### PR TITLE
make %(foo) work

### DIFF
--- a/src/parse.y
+++ b/src/parse.y
@@ -4228,6 +4228,7 @@ parser_yylex(parser_state *p)
       else if (term == '[') term = ']';
       else if (term == '{') term = '}';
       else if (term == '<') term = '>';
+      p->sterm = term;
 #if 0
       else paren = 0;
 #endif


### PR DESCRIPTION
%(foo) does not work currently.

> $ cat t.rb
> %(foo)
> $ bin/mruby t.rb
> syntax error, unexpected tIDENTIFIER, expecting tSTRING or tSTRING_PART
## 

Yusuke Endoh mame@tsg.ne.jp
