### PR TITLE
The class of a module should not be Class

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -851,7 +851,6 @@ mrb_module_new(mrb_state *mrb)
 {
   struct RClass *m = mrb_obj_alloc(mrb, MRB_TT_MODULE, mrb->module_class);
   m->mt = kh_init(mt, mrb);
-  make_metaclass(mrb, m);
 
   return m;
 }


### PR DESCRIPTION
I've found that the following code causes SEGV:

  module X
  end
  X.new

It's because mrb_module_new() calls make_metaclass(), and thus the class of a module is Class, not Module, in mruby:

  module X
  end
  p X.class #=> Class

I think modules should not have metaclasses because there is no need to inherit singleton methods of superclasses.
