### PR TITLE
Assign will break when used in a C++ environment

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -134,7 +134,7 @@ static inline mrb_value
 mrb_obj_value(void *p)
 {
   mrb_value v;
-  struct RBasic *b = p;
+  struct RBasic *b = (struct RBasic*) p;
 
   v.tt = b->tt;
   v.value.p = p;


### PR DESCRIPTION
Even when using extern "C" the uncast assignment will be rejected by the g++ compiler.
