### PR TITLE
SIZEOF_ST_INDEX_T undeclared

### DIFF
--- a/src/st.h
+++ b/src/st.h
@@ -64,6 +64,8 @@ struct st_table_entry {
     st_table_entry *fore, *back;
 };
 
+#define SIZEOF_ST_INDEX_T 4
+
 struct st_hash_type {
     int (*compare)(ANYARGS /*st_data_t, st_data_t*/); /* st_compare_func* */
     st_index_t (*hash)(ANYARGS /*st_data_t*/);        /* st_hash_func* */


### PR DESCRIPTION
has been removed in this commit https://github.com/mruby/mruby/commit/5622c977f441a91a7482d5956df96e60d71d90f9#L4R66
