### PR TITLE
Add a program `sizeof' to measure sizeof(...) before preprocessing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@
 cscope.out
 mruby.exe
 y.tab.c
+src/sizeof.h
+src/sizeof

--- a/Makefile
+++ b/Makefile
@@ -12,15 +12,17 @@ ifeq ($(OS),Windows_NT)
 EXE := $(TARGET).exe
 LIB := $(RITEVM).lib
 MRB := $(MRUBY).exe
+SIZEOF := src/sizeof.exe
 else
 EXE := $(TARGET)
 LIB := $(RITEVM).a
 MRB := $(MRUBY)
+SIZEOF := src/sizeof
 endif
 MSRC := src/minimain.c
 YSRC := src/parse.y
 YC := src/y.tab.c
-EXCEPT1 := $(YC) $(MSRC)
+EXCEPT1 := $(YC) $(MSRC) src/sizeof.c
 OBJM := $(patsubst %.c,%.o,$(MSRC))
 OBJY := $(patsubst %.c,%.o,$(YC))
 OBJ1 := $(patsubst %.c,%.o,$(filter-out $(EXCEPT1),$(wildcard src/*.c)))
@@ -117,4 +119,10 @@ clean :
 	-rm -f $(EXE) $(OBJM)
 	-rm -f $(OBJM:.o=.d)
 	-rm -f $(IOSLIB) $(IOSSIMLIB) $(IOSDEVLIB)
+	-rm -f $(SIZEOF) src/sizeof.h
 	@echo "make: removing targets, objects and depend files of `pwd`"
+
+# measurement of sizeof()
+src/sizeof.h : $(SIZEOF)
+	$(SIZEOF) > $@
+$(OBJ1) : src/sizeof.h

--- a/src/Makefile
+++ b/src/Makefile
@@ -9,12 +9,14 @@ BASEDIR = .
 TARGET := ../lib/ritevm
 ifeq ($(OS),Windows_NT)
 LIB := $(TARGET).lib
+SIZEOF := $(BASEDIR)/sizeof.exe
 else
 LIB := $(TARGET).a
+SIZEOF := $(BASEDIR)/sizeof
 endif
 YSRC := $(BASEDIR)/parse.y
 YC := $(BASEDIR)/y.tab.c
-EXCEPT1 := $(YC) $(BASEDIR)/minimain.c $(BASEDIR)/compile.c $(BASEDIR)/dump.c $(BASEDIR)/cdump.c
+EXCEPT1 := $(YC) $(BASEDIR)/minimain.c $(BASEDIR)/compile.c $(BASEDIR)/dump.c $(BASEDIR)/cdump.c $(BASEDIR)/sizeof.c
 OBJY := $(patsubst %.c,%.o,$(YC))
 OBJ1 := $(patsubst %.c,%.o,$(filter-out $(EXCEPT1),$(wildcard $(BASEDIR)/*.c)))
 #OBJ2 := $(patsubst %.c,%.o,$(wildcard $(BASEDIR)/ext/regex/*.c))
@@ -86,5 +88,10 @@ clean :
 	$(MAKE) clean -C ../mrblib $(MAKE_FLAGS)
 	-rm -f $(LIB) $(OBJS) $(OBJY) $(YC)
 	-rm -f $(OBJS:.o=.d) $(OBJY:.o=.d)
+	-rm -f $(SIZEOF) sizeof.h
 	@echo "make: removing targets, objects and depend files of `pwd`"
 
+# measurement of sizeof()
+sizeof.h : $(SIZEOF)
+	$(SIZEOF) > $@
+$(OBJ1) : $(BASEDIR)/sizeof.h

--- a/src/sizeof.c
+++ b/src/sizeof.c
@@ -1,0 +1,10 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+
+int
+main(void)
+{
+	printf("#define SIZEOF_UINTPTR_T %lu\n", sizeof(uintptr_t));
+	exit(EXIT_SUCCESS);
+}

--- a/src/st.h
+++ b/src/st.h
@@ -35,6 +35,8 @@ extern "C" {
 # endif
 #endif
 
+#include "sizeof.h"
+
 #ifndef _
 # define _(args) args
 #endif
@@ -69,7 +71,8 @@ struct st_hash_type {
     st_index_t (*hash)(ANYARGS /*st_data_t*/);        /* st_hash_func* */
 };
 
-#define ST_INDEX_BITS (sizeof(st_index_t) * CHAR_BIT)
+#define SIZEOF_ST_INDEX_T SIZEOF_UINTPTR_T
+#define ST_INDEX_BITS (SIZEOF_ST_INDEX_T * CHAR_BIT)
 
 struct st_table {
     const struct st_hash_type *type;

--- a/tools/mrbc/Makefile
+++ b/tools/mrbc/Makefile
@@ -9,12 +9,14 @@ BASEDIR := ../../src
 TARGET := ../../bin/mrbc
 ifeq ($(OS),Windows_NT)
 EXE := $(TARGET).exe
+SIZEOF := $(BASEDIR)/sizeof.exe
 else
 EXE := $(TARGET)
+SIZEOF := $(BASEDIR)/sizeof
 endif
 YSRC := $(BASEDIR)/parse.y
 YC := $(BASEDIR)/y.tab.c
-EXCEPT1 := $(YC) $(BASEDIR)/minimain.c $(BASEDIR)/load.c $(BASEDIR)/init_ext.c
+EXCEPT1 := $(YC) $(BASEDIR)/minimain.c $(BASEDIR)/load.c $(BASEDIR)/init_ext.c $(BASEDIR)/sizeof.c
 OBJY := $(patsubst %.c,%.o,$(YC))
 OBJ0 := $(patsubst %.c,%.o,$(wildcard $(BASEDIR)/../tools/mrbc/*.c))
 OBJ1 := $(patsubst %.c,%.o,$(filter-out $(EXCEPT1),$(wildcard $(BASEDIR)/*.c)))
@@ -69,5 +71,10 @@ $(YC) : $(YSRC)
 clean :
 	-rm -f $(EXE) $(OBJS) $(OBJY) $(YC)
 	-rm -f $(OBJS:.o=.d) $(OBJY:.o=.d)
+	-rm -f $(SIZEOF) $(BASEDIR)/sizeof.h
 	@echo "make: removing targets, objects and depend files of `pwd`"
 
+# measurement of sizeof()
+$(BASEDIR)/sizeof.h : $(SIZEOF)
+	$(SIZEOF) > $@
+$(OBJ1) : $(BASEDIR)/sizeof.h

--- a/tools/mruby/Makefile
+++ b/tools/mruby/Makefile
@@ -9,12 +9,14 @@ BASEDIR = ../../src
 TARGET := ../../bin/mruby
 ifeq ($(OS),Windows_NT)
 EXE := $(TARGET).exe
+SIZEOF := $(BASEDIR)/sizeof.exe
 else
 EXE := $(TARGET)
+SIZEOF := $(BASEDIR)/sizeof
 endif
 YSRC := $(BASEDIR)/parse.y
 YC := $(BASEDIR)/y.tab.c
-EXCEPT1 := $(YC) $(BASEDIR)/minimain.c $(BASEDIR)/dump.c $(BASEDIR)/cdump.c
+EXCEPT1 := $(YC) $(BASEDIR)/minimain.c $(BASEDIR)/dump.c $(BASEDIR)/cdump.c $(BASEDIR)/sizeof.c
 OBJY := $(patsubst %.c,%.o,$(YC))
 OBJ0 := $(patsubst %.c,%.o,$(wildcard $(BASEDIR)/../tools/mruby/*.c))
 OBJ1 := $(patsubst %.c,%.o,$(filter-out $(EXCEPT1),$(wildcard $(BASEDIR)/*.c)))
@@ -86,4 +88,11 @@ clean :
 	$(MAKE) clean -C ../../mrblib $(MAKE_FLAGS)
 	-rm -f $(EXE) $(OBJS) $(OBJY) $(YC) $(EXTS)
 	-rm -f $(OBJS:.o=.d) $(OBJY:.o=.d) $(EXTS:.o=.d)
+	-rm -f $(SIZEOF) $(BASEDIR)/sizeof.h
 	@echo "make: removing targets, objects and depend files of `pwd`"
+
+# measurement of sizeof()
+$(BASEDIR)/sizeof.h : $(SIZEOF)
+	$(SIZEOF) > $@
+$(OBJ1) : $(BASEDIR)/sizeof.h
+


### PR DESCRIPTION
SIZEOF_ST_INDEX_T seems to be missing its definition but is difficult to define dynamically as it will be used in #if. At least on NetBSD 4.0.1_PATCH amd64, gmake fails with the error like:
../../src/st.c:969:5 error: missing binary operator before token "("

This patch tries to run a small program sizeof before pre-processing the mruby source codes to define needed sizeof()'s into an additional header file, sizeof.h
