### PR TITLE
lineno and column

### DIFF
--- a/src/parse.y
+++ b/src/parse.y
@@ -2976,12 +2976,16 @@ nextc(parser_state *p)
     c = *p->s++;
   }
   if (c == '\n') {
-    p->lineno++;
-    p->column = 0;
+    if (p->nerr < 1) {
+      p->lineno++;
+      p->column = 0;
+    }
     // must understand heredoc
   }
   else {
-    p->column++;
+    if (p->nerr < 1) {
+      p->column++;
+    }
   }
   return c;
 }


### PR DESCRIPTION
It would be helpful if "lineno" and "column" point to the position of the first error. But I'm not sure if this change is possible. I assume it should, because in cause of an error **FILE** and **LINE** are irrelevant. Alternatively, it would be nice to add a error marker to the structure.
