### PR TITLE
simple fix for underflow / capture errors and warnings

### DIFF
--- a/src/compile.h
+++ b/src/compile.h
@@ -25,6 +25,12 @@ enum mrb_lex_state_enum {
     EXPR_MAX_STATE
 };
 
+struct mrb_parser_message {
+  int lineno;
+  int column;
+  char* message;
+};
+
 struct mrb_parser_state {
   mrb_state *mrb;
   struct mrb_pool *pool;
@@ -55,7 +61,12 @@ struct mrb_parser_state {
   void *ylval;
 
   int nerr;
+  int nwarn;
   mrb_ast_node *tree, *begin_tree;
+
+  int capture_errors;
+  struct mrb_parser_message error_buffer[10];
+  struct mrb_parser_message warn_buffer[10];
 
   jmp_buf jmp;
 };
@@ -63,6 +74,7 @@ struct mrb_parser_state {
 struct mrb_parser_state* mrb_parse_file(mrb_state*,FILE*);
 struct mrb_parser_state* mrb_parse_string(mrb_state*,char*);
 struct mrb_parser_state* mrb_parse_nstring(mrb_state*,char*,size_t);
+struct mrb_parser_state* mrb_parse_nstring_ext(mrb_state*,char*,size_t);
 int mrb_generate_code(mrb_state*, mrb_ast_node*);
 
 int mrb_compile_file(mrb_state*,FILE*);

--- a/src/parse.y
+++ b/src/parse.y
@@ -2898,8 +2898,21 @@ none		: /* none */
 static void
 yyerror(parser_state *p, const char *s)
 {
-  fputs(s, stderr);
-  fputs("\n", stderr);
+  char* c;
+  size_t n;
+
+  if (! p->capture_errors) {
+    fputs(s, stderr);
+    fputs("\n", stderr);
+  }
+  else if (p->nerr < sizeof(p->error_buffer) / sizeof(p->error_buffer[0])) {
+    n = strlen(s);
+    c = parser_palloc(p, n + 1);
+    memcpy(c, s, n + 1);
+    p->error_buffer[p->nerr].message = c;
+    p->error_buffer[p->nerr].lineno = p->lineno;
+    p->error_buffer[p->nerr].column = p->column;
+  }
   p->nerr++;
 }
 
@@ -2915,8 +2928,22 @@ yyerror_i(parser_state *p, const char *fmt, int i)
 static void
 yywarn(parser_state *p, const char *s)
 {
-  fputs(s, stderr);
-  fputs("\n", stderr);
+  char* c;
+  size_t n;
+
+  if (! p->capture_errors) {
+    fputs(s, stderr);
+    fputs("\n", stderr);
+  }
+  else if (p->nerr < sizeof(p->warn_buffer) / sizeof(p->warn_buffer[0])) {
+    n = strlen(s);
+    c = parser_palloc(p, n + 1);
+    memcpy(c, s, n + 1);
+    p->error_buffer[p->nwarn].message = c;
+    p->error_buffer[p->nwarn].lineno = p->lineno;
+    p->error_buffer[p->nwarn].column = p->column;
+  }
+  p->nwarn++;
 }
 
 static void
@@ -4609,6 +4636,8 @@ parser_new(mrb_state *mrb)
   p->cmd_start = TRUE;
   p->in_def = p->in_single = FALSE;
 
+  p->capture_errors = NULL;
+
   p->lineno = 1;
 #if defined(PARSER_TEST) || defined(PARSER_DEBUG)
   yydebug = 1;
@@ -4641,6 +4670,22 @@ mrb_parse_nstring(mrb_state *mrb, char *s, size_t len)
   p->s = s;
   p->send = s + len;
   p->f = NULL;
+
+  start_parser(p);
+  return p;
+}
+
+parser_state*
+mrb_parse_nstring_ext(mrb_state *mrb, char *s, size_t len)
+{
+  parser_state *p;
+
+  p = parser_new(mrb);
+  if (!p) return 0;
+  p->s = s;
+  p->send = s + len;
+  p->f = NULL;
+  p->capture_errors = 1;
 
   start_parser(p);
   return p;


### PR DESCRIPTION
This is a (simple) fix for underflow. It is not perfect. It would be better to check in pushback and "repair" lineno and column there. But this requires a more complicated structure to keep track of the columns in the previous line(s). Which is completed if more than one pushback is allowed.
