### PR TITLE
use %ld instead of %zd for windows.

### DIFF
--- a/src/cdump.c
+++ b/src/cdump.c
@@ -146,7 +146,7 @@ make_cdump_irep(mrb_state *mrb, int irep_no, FILE *f)
           }
         }
         memset(buf, 0, buf_len);
-        SOURCE_CODE("  irep->pool[%d] = mrb_str_new(mrb, \"%s\", %zd);",               n, str_to_format(irep->pool[n], buf), RSTRING_LEN(irep->pool[n])); break;
+        SOURCE_CODE("  irep->pool[%d] = mrb_str_new(mrb, \"%s\", %ld);",               n, str_to_format(irep->pool[n], buf), RSTRING_LEN(irep->pool[n])); break;
       /* TODO MRB_TT_REGEX */
       default: break;
       }


### PR DESCRIPTION
use %ld instead.

ref: https://github.com/mruby/mruby/commit/c138d7ef0a2365fd7da6a6374f9fa607633f07d5
