### PR TITLE
Use mrb_get_args instead of direct stack access

### DIFF
--- a/src/proc.c
+++ b/src/proc.c
@@ -53,8 +53,9 @@ mrb_proc_new_cfunc(mrb_state *mrb, mrb_func_t func)
 static mrb_value
 mrb_proc_initialize(mrb_state *mrb, mrb_value self)
 {
-  mrb_value blk = mrb->stack[mrb->ci->argc+1];
+  mrb_value blk;
 
+  mrb_get_args(mrb, "&", &blk);
   if (!mrb_nil_p(blk)) {
     *mrb_proc_ptr(self) = *mrb_proc_ptr(blk);
   }


### PR DESCRIPTION
Improve a patch for #37.
