### PR TITLE
fix type; it's different with mruby.h

### DIFF
--- a/src/object.c
+++ b/src/object.c
@@ -508,7 +508,7 @@ mrb_any_to_s(mrb_state *mrb, mrb_value obj)
  *     b.kind_of? M       #=> true
  */
 
-int
+mrb_int
 mrb_obj_is_kind_of(mrb_state *mrb, mrb_value obj, struct RClass *c)
 {
   struct RClass *cl = mrb_class(mrb, obj);


### PR DESCRIPTION
the type of mrb_obj_is_kind_of is mrb_int in mruby.h, but int in object.c.
Is it right?  or mruby.h should be fixed?
