### PR TITLE
Only remove quotes when on windows.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,11 @@ else
 CFLAGS = -O3
 endif
 ALL_CFLAGS = -Wall -Werror-implicit-function-declaration $(CFLAGS)
-MAKE_FLAGS = --no-print-directory CC=$(CC) LL=$(LL)
+ifeq ($(OS),Windows_NT)
+	MAKE_FLAGS = --no-print-directory CC=$(CC) LL=$(LL)
+else
+	MAKE_FLAGS = --no-print-directory CC='$(CC)' LL='$(LL)'
+endif
 
 ##############################
 # generic build targets, rules

--- a/mrblib/Makefile
+++ b/mrblib/Makefile
@@ -24,7 +24,11 @@ CFLAGS = -O3
 endif
 INCLUDES = -I../src -I../include
 ALL_CFLAGS = -Wall -Werror-implicit-function-declaration $(CFLAGS)
-MAKE_FLAGS = --no-print-directory CC=$(CC) LL=$(LL)
+ifeq ($(OS),Windows_NT)
+	MAKE_FLAGS = --no-print-directory CC=$(CC) LL=$(LL)
+else
+	MAKE_FLAGS = --no-print-directory CC='$(CC)' LL='$(LL)'
+endif
 
 # mruby compiler
 ifeq ($(OS),Windows_NT)

--- a/src/Makefile
+++ b/src/Makefile
@@ -45,7 +45,11 @@ else
 CFLAGS = -O3
 endif
 ALL_CFLAGS = -Wall -Werror-implicit-function-declaration $(CFLAGS)
-MAKE_FLAGS = --no-print-directory CC=$(CC) LL=$(LL)
+ifeq ($(OS),Windows_NT)
+	MAKE_FLAGS = --no-print-directory CC=$(CC) LL=$(LL)
+else
+	MAKE_FLAGS = --no-print-directory CC='$(CC)' LL='$(LL)'
+endif
 
 ##############################
 # generic build targets, rules

--- a/tools/mrbc/Makefile
+++ b/tools/mrbc/Makefile
@@ -37,7 +37,11 @@ else
 CFLAGS = -O3
 endif
 ALL_CFLAGS = -Wall -Werror-implicit-function-declaration $(CFLAGS)
-MAKE_FLAGS = --no-print-directory CC=$(CC) LL=$(LL)
+ifeq ($(OS),Windows_NT)
+	MAKE_FLAGS = --no-print-directory CC=$(CC) LL=$(LL)
+else
+	MAKE_FLAGS = --no-print-directory CC='$(CC)' LL='$(LL)'
+endif
 
 ##############################
 # generic build targets, rules

--- a/tools/mruby/Makefile
+++ b/tools/mruby/Makefile
@@ -45,7 +45,11 @@ else
 CFLAGS = -O3
 endif
 ALL_CFLAGS = -Wall -Werror-implicit-function-declaration $(CFLAGS)
-MAKE_FLAGS = --no-print-directory CC=$(CC) LL=$(LL)
+ifeq ($(OS),Windows_NT)
+	MAKE_FLAGS = --no-print-directory CC=$(CC) LL=$(LL)
+else
+	MAKE_FLAGS = --no-print-directory CC='$(CC)' LL='$(LL)'
+endif
 
 ##############################
 # generic build targets, rules


### PR DESCRIPTION
I tried to repeat the original issue found here: https://gist.github.com/2425219

Installing MinGW with the GUI and using make didn't fail for me. I'm assuming the real issue has something to do with Windows because the quoted variables work fine on other platforms. I've added a flag to remove them only when running under Windows. This is step 1 of getting the iOS build working again.
