### PR TITLE
Additional Integer Documentation

### DIFF
--- a/mrblib/numeric.rb
+++ b/mrblib/numeric.rb
@@ -1,8 +1,14 @@
-#
-#  Integer
-#
+##
+# Integer
+#  
+# ISO 15.2.8
 class Integer
-  # 15.2.8.3.15
+
+  ##
+  # Calls the given block once for each Integer
+  # from +self+ downto +num+.
+  #
+  # ISO 15.2.8.3.15
   def downto(num, &block)
     raise TypeError, "expected Integer" unless num.kind_of? Integer
     i = self
@@ -13,7 +19,10 @@ class Integer
     self
   end
 
-  # 15.2.8.3.22
+  ##
+  # Calls the given block +self+ times.
+  #
+  # ISO 15.2.8.3.22
   def times(&block)
     i = 0
     while(i < self)
@@ -23,7 +32,11 @@ class Integer
     self
   end
 
-  # 15.2.8.3.27
+  ##
+  # Calls the given block once for each Integer
+  # from +self+ upto +num+.
+  #
+  # ISO 15.2.8.3.27
   def upto(num, &block)
     raise TypeError, "expected Integer" unless num.kind_of? Integer
     i = self


### PR DESCRIPTION
I've added some more documentation to the Integer class. Due to the reason that I only saw the ISO Reference Number on top of many methods I'm wondering if this might be on purpose and you want to keep the ISO Reference Document as the only documentation. If you are ok with additional comments around the Reference Number I'm happy to add some more documentation around the other classes too. 
