### PR TITLE
Fix SEGV caused by using the splat operator for non arrays

### DIFF
--- a/src/array.c
+++ b/src/array.c
@@ -725,7 +725,12 @@ mrb_ary_rindex_m(mrb_state *mrb, mrb_value self)
 mrb_value
 mrb_ary_splat(mrb_state *mrb, mrb_value v)
 {
-  return v;
+  if (mrb_type(v) == MRB_TT_ARRAY) {
+    return v;
+  }
+  else {
+    return mrb_ary_new_from_values(mrb, &v, 1);
+  }
 }
 
 static mrb_value


### PR DESCRIPTION
The following code causes SEGV.

```
$ bin/mruby -e 'm(*0)'
```

Note that ISO/IEC 30170 does not specify the case.
In CRuby, it converts an object to an array by calling #to_a if possible.
My patch simply returns an array containing an object.

```
$ cat t.rb
def m(*args)
  p args
end

m(*0)
m(*{a: 0})

$ ruby -v t.rb
ruby 2.0.0dev (2012-05-02 trunk 35518) [x86_64-linux]
[0]
[[:a, 0]]

$ bin/mruby t.rb
[0]
[{:a=>0}]
```
