### PR TITLE
LocalJumpError message contained garbage characters

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -268,7 +268,7 @@ localjump_error(mrb_state *mrb, const char *kind)
   mrb_value exc;
 
   snprintf(buf, 256, "unexpected %s", kind);
-  exc = mrb_exc_new(mrb, E_LOCALJUMP_ERROR, buf, sizeof(buf));
+  exc = mrb_exc_new(mrb, E_LOCALJUMP_ERROR, buf, strlen(buf));
   mrb->exc = mrb_object(exc);
 }
 


### PR DESCRIPTION
```
$ bin/mruby -e 'def m; Proc.new{ break }; end; m.call'
#<LocalJumpError: unexpected break�x�o�`x�ox�o0����@^�������0`�I0�lr�5���x�oxFp`lr����`lrM`�p��o`�I
0������@M������tr>
```
