### PR TITLE
Fix SEGV when returning from terminated method

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -992,6 +992,7 @@ mrb_run(mrb_state *mrb, struct RProc *proc, mrb_value self)
         case OP_R_RETURN:
           if (proc->env->cioff < 0) {
             localjump_error(mrb, "return");
+            goto L_RAISE;
           }
           ci = mrb->ci = mrb->cibase + proc->env->cioff;
           break;


### PR DESCRIPTION
```
$ bin/mruby -e 'def m; Proc.new{ return }; end; m.call'
[1]    23268 segmentation fault (core dumped)  bin/mruby -e 'def m; Proc.new{ return }; end; m.call'
```
