### PR TITLE
Fix SEGV when including an object other than Module

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -502,6 +502,7 @@ mrb_mod_include(mrb_state *mrb, mrb_value klass)
   mrb_value mod;
 
   mrb_get_args(mrb, "o", &mod);
+  mrb_check_type(mrb, mod, MRB_TT_MODULE);
   mrb_include_module(mrb, mrb_class_ptr(klass), mrb_class_ptr(mod));
   return mod;
 }


### PR DESCRIPTION
```
$ bin/mruby -e 'class C; include 0; end'
[1]    24670 segmentation fault (core dumped)  bin/mruby -e 'class C; include 0; end'
```
