### PR TITLE
Add define controlled config.h include

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -31,6 +31,10 @@
 #include <stdlib.h>
 #include "mrbconf.h"
 
+#ifdef HAVE_CONFIG_H
+# include "config.h"
+#endif
+
 enum mrb_vtype {
   MRB_TT_FALSE = 0,   /*   0 */
   MRB_TT_FREE,        /*   1 */


### PR DESCRIPTION
This enables cleaner builds for those choosing to dynamically create `config.h`. I've got an initial implementation working in the CMake prototype.

I set the location at the top of `include` as a peer to `mruby.h` because I don't believe Ruby's arch specific location is desirable with mruby's expected use cases. That said, it's an easy change in CMake to match whatever location you want.
