### PR TITLE
Raise LocalJumpError when returning from top-level

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -1002,6 +1002,10 @@ mrb_run(mrb_state *mrb, struct RProc *proc, mrb_value self)
 
         switch (GETARG_B(i)) {
         case OP_R_NORMAL:
+          if (ci == mrb->cibase) {
+            localjump_error(mrb, "return");
+            goto L_RAISE;
+          }
           ci = mrb->ci;
           break;
         case OP_R_BREAK:


### PR DESCRIPTION
```
$ bin/mruby -e return
[1]    14393 segmentation fault (core dumped)  bin/mruby -e return

$ ruby -ve return
ruby 2.0.0dev (2012-05-12 trunk 35629) [x86_64-linux]
-e:1:in `<main>': unexpected return (LocalJumpError)
```
