### PR TITLE
Use %d instead of %ld in case the type of parameter is int.

### DIFF
--- a/src/cdump.c
+++ b/src/cdump.c
@@ -146,7 +146,7 @@ make_cdump_irep(mrb_state *mrb, int irep_no, FILE *f)
           }
         }
         memset(buf, 0, buf_len);
-        SOURCE_CODE("  irep->pool[%d] = mrb_str_new(mrb, \"%s\", %ld);",               n, str_to_format(irep->pool[n], buf), RSTRING_LEN(irep->pool[n])); break;
+        SOURCE_CODE("  irep->pool[%d] = mrb_str_new(mrb, \"%s\", %d);",               n, str_to_format(irep->pool[n], buf), RSTRING_LEN(irep->pool[n])); break;
       /* TODO MRB_TT_REGEX */
       default: break;
       }


### PR DESCRIPTION
The type of RString.len (defined in mruby/string.h) is int. So there should be used %d as the format.
