### PR TITLE
msvc breaks with current mirb c99 impl

### DIFF
--- a/include/mrbconf.h
+++ b/include/mrbconf.h
@@ -43,6 +43,12 @@ typedef intptr_t mrb_sym;
 #endif
 
 #ifdef _MSC_VER
+/* C99 stdbool.h emulation */
+typedef unsigned int _Bool;
+# define bool _Bool
+# define true 1
+# define false 0
+
 # define inline __inline
 # define snprintf _snprintf
 # define isnan _isnan

--- a/tools/mirb/mirb.c
+++ b/tools/mirb/mirb.c
@@ -7,8 +7,12 @@
 */
  
 #include <string.h>
-#include <stdbool.h>
-#include <unistd.h>
+
+#ifndef _MSC_VER
+# include <stdbool.h>
+# include <unistd.h>
+#endif
+
 #include <fcntl.h>
 
 #include <mruby.h>


### PR DESCRIPTION
emulate C99's stdbool.h for msvc
