### PR TITLE
Avoid "may be used uninitialized in this function" warning.

### DIFF
--- a/src/load.c
+++ b/src/load.c
@@ -251,7 +251,7 @@ int
 mrb_load_irep(mrb_state *mrb, FILE* fp)
 {
   int ret, i;
-  uint32_t  len, rlen;
+  uint32_t  len, rlen = 0;
   unsigned char hex8[8], hcrc[4];
   unsigned char *dst, *rite_dst = NULL;
   rite_binary_header  bin_header;
@@ -498,7 +498,7 @@ int
 mrb_read_irep(mrb_state *mrb, const char *bin)
 {
   int ret = MRB_DUMP_OK, i, n, nirep, sirep;
-  uint32_t len;
+  uint32_t len = 0;
   unsigned char *src;
   rite_binary_header  bin_header;
 

--- a/src/vm.c
+++ b/src/vm.c
@@ -372,11 +372,11 @@ mrb_run(mrb_state *mrb, struct RProc *proc, mrb_value self)
   mrb_code *pc = irep->iseq;
   mrb_value *pool = irep->pool;
   mrb_sym *syms = irep->syms;
-  mrb_value *regs;
+  mrb_value *regs = NULL;
   mrb_code i;
   int ai = mrb->arena_idx;
   jmp_buf c_jmp;
-  jmp_buf *prev_jmp;
+  jmp_buf *prev_jmp = NULL;
 
 #ifdef DIRECT_THREADED
   static void *optable[] = {
@@ -878,7 +878,7 @@ mrb_run(mrb_state *mrb, struct RProc *proc, mrb_value self)
         regs[a] = mrb_ary_new_elts(mrb, m1+m2, stack);
       }
       else {
-        mrb_value *pp;
+        mrb_value *pp = NULL;
         struct RArray *rest;
         int len = 0;
 


### PR DESCRIPTION
Though I reviewed code and I think these uninitialized variables are harmless, it's not a bad manner to initialize auto variables / to reduce warnings.
