### PR TITLE
idx should be less than the cap, if it is equal irep needs to grow.

### DIFF
--- a/src/state.c
+++ b/src/state.c
@@ -78,8 +78,8 @@ mrb_add_irep(mrb_state *mrb, int idx)
     mrb->irep = mrb_malloc(mrb, sizeof(mrb_irep*)*max);
     mrb->irep_capa = max;
   }
-  else if (mrb->irep_capa < idx) {
-    while (mrb->irep_capa < idx) {
+  else if (mrb->irep_capa <= idx) {
+    while (mrb->irep_capa <= idx) {
       mrb->irep_capa *= 2;
     }
     mrb->irep = mrb_realloc(mrb, mrb->irep, sizeof(mrb_irep)*mrb->irep_capa);


### PR DESCRIPTION
The check for growing the irep array was off by one. Should fix issue 149.
