### PR TITLE
corrected printf formats in parse.y and codegen.c 

### DIFF
--- a/src/codegen.c
+++ b/src/codegen.c
@@ -1481,7 +1481,7 @@ codegen(codegen_scope *s, node *tree, int val)
       char buf[4];
       int sym;
 
-      snprintf(buf, 3, "$%c", (intptr_t)tree);
+      snprintf(buf, 3, "$%ld", (intptr_t)tree);
       sym = new_sym(s, mrb_intern(s->mrb, buf));
       genop(s, MKOP_ABx(OP_GETGLOBAL, cursp(), sym));
       push();
@@ -1493,7 +1493,7 @@ codegen(codegen_scope *s, node *tree, int val)
       char buf[4];
       int sym;
 
-      snprintf(buf, 3, "$%d", (intptr_t)tree);
+      snprintf(buf, 3, "$%ld", (intptr_t)tree);
       sym = new_sym(s, mrb_intern(s->mrb, buf));
       genop(s, MKOP_ABx(OP_GETGLOBAL, cursp(), sym));
       push();

--- a/src/parse.y
+++ b/src/parse.y
@@ -5238,11 +5238,11 @@ parser_dump(mrb_state *mrb, node *tree, int offset)
     break;
 
   case NODE_BACK_REF:
-    printf("NODE_BACK_REF: $%c\n", (int)tree);
+    printf("NODE_BACK_REF: $%ld\n", (long int)tree);
     break;
 
   case NODE_NTH_REF:
-    printf("NODE_NTH_REF: $%d\n", (int)tree);
+    printf("NODE_NTH_REF: $%ld\n", (long int)tree);
     break;
 
   case NODE_ARG:


### PR DESCRIPTION
@matz: I made two very minor correction to get rid of the warnings in codeine.c and parse.y introduced in 103ef78e. I am not really sure that I got what you meant to do, though, so probably I'm just messing around.
