### PR TITLE
Plattform Status Documentation

### DIFF
--- a/doc/plattform_status.md
+++ b/doc/plattform_status.md
@@ -1,0 +1,32 @@
+# Plattform Status
+
+What is the status of mruby on specific plattforms
+
+## Linux
+
+### Ubuntu 12.04
+
+*Works!* This plattform is used by @matz
+
++ Linux 3.2.0-23-generic #36-Ubuntu x86_64 GNU/Linux
++ gcc (Ubuntu/Linaro 4.6.3-1ubuntu5) 4.6.3
+
+## Mac OS X
+
+### 10.7
+
+*Works!* This plattform is most of the time working.
+
++ Darwin 11.3.0 Darwin Kernel Version 11.3.0: 
+  root:xnu-1699.24.23~1/RELEASE_X86_64 x86_64
++ i686-apple-darwin11-llvm-gcc-4.2 (GCC) 4.2.1 
+  (Based on Apple Inc. build 5658) (LLVM build 2336.9.00)
+
+### 10.8
+
+*Works!*
+
+## Windows
+
+### Windows 7
+


### PR DESCRIPTION
As discussed here (https://github.com/mruby/mruby/issues/162) I created a first file which contains some platforms on which mruby is supposed to work. Next step should be a documentation platforms are supported by the mruby development team.
