### PR TITLE
Fix Hash#shift return value from Hash to Array

### DIFF
--- a/src/hash.c
+++ b/src/hash.c
@@ -613,9 +613,9 @@ mrb_hash_shift(mrb_state *mrb, mrb_value hash)
         delKey = kh_key(h,k);
         delVal = mrb_hash_delete_key(mrb, hash, delKey);
 
-        result = mrb_hash_new(mrb, 1);
-        k = kh_put(ht, RHASH_TBL(result), KEY(delKey));
-        kh_value(RHASH_TBL(result), k) = delVal;
+        result = mrb_ary_new(mrb);
+        mrb_ary_push(mrb, result, delKey);
+        mrb_ary_push(mrb, result, delVal);
         return result;
       }
     }

--- a/test/t/hash.rb
+++ b/test/t/hash.rb
@@ -192,10 +192,10 @@ end
 
 assert('Hash#shift', '15.2.13.4.24') do
   a = { 'abc_key' => 'abc_value', 'cba_key' => 'cba_value' }
-  # TODO Broken ATM (Hash instead of Array
   b = a.shift
 
-  a == { 'abc_key' => 'abc_value' }
+  a == { 'abc_key' => 'abc_value' } and
+    b == [ 'cba_key', 'cba_value' ]
 end
 
 assert('Hash#size', '15.2.13.4.25') do


### PR DESCRIPTION
This patch fixes the return Value of Hash#shift from a Hash to an Array according to ISO 15.2.13.4.24. Test case included.
