### PR TITLE
More C++ compilability work: mrb_obj_alloc void* conversions

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -81,7 +81,7 @@ typedef struct mrb_value {
 #define mrb_fixnum(o) (o).value.i
 #define mrb_float(o)  (o).value.f
 #define mrb_symbol(o) (o).value.sym
-#define mrb_object(o) ((struct RObject *) (o).value.p)
+#define mrb_object(o) ((struct RBasic *) (o).value.p)
 #define FIXNUM_P(o)   ((o).tt == MRB_TT_FIXNUM)
 #define UNDEF_P(o)    ((o).tt == MRB_TT_UNDEF)
 
@@ -337,7 +337,7 @@ mrb_value mrb_str_format(mrb_state *, int, const mrb_value *, mrb_value);
 void *mrb_malloc(mrb_state*, size_t);
 void *mrb_calloc(mrb_state*, size_t, size_t);
 void *mrb_realloc(mrb_state*, void*, size_t);
-void *mrb_obj_alloc(mrb_state*, enum mrb_vtype, struct RClass*);
+struct RBasic *mrb_obj_alloc(mrb_state*, enum mrb_vtype, struct RClass*);
 void *mrb_free(mrb_state*, void*);
 
 mrb_value mrb_str_new(mrb_state *mrb, const char *p, size_t len); /* mrb_str_new */
@@ -368,11 +368,11 @@ int mrb_gc_arena_save(mrb_state*);
 void mrb_gc_arena_restore(mrb_state*,int);
 void mrb_gc_mark(mrb_state*,struct RBasic*);
 #define mrb_gc_mark_value(mrb,val) do {\
-  if ((val).tt >= MRB_TT_OBJECT) mrb_gc_mark((mrb), (struct RBasic *) mrb_object(val));\
+  if ((val).tt >= MRB_TT_OBJECT) mrb_gc_mark((mrb), mrb_object(val));\
 } while (0);
 void mrb_field_write_barrier(mrb_state *, struct RBasic*, struct RBasic*);
 #define mrb_field_write_barrier_value(mrb, obj, val) do{\
-  if ((val.tt >= MRB_TT_OBJECT)) mrb_field_write_barrier((mrb), (obj), (struct RBasic *) mrb_object(val));\
+  if ((val.tt >= MRB_TT_OBJECT)) mrb_field_write_barrier((mrb), (obj), mrb_object(val));\
 } while (0);
 void mrb_write_barrier(mrb_state *, struct RBasic*);
 

--- a/include/mruby/class.h
+++ b/include/mruby/class.h
@@ -55,7 +55,7 @@ mrb_class(mrb_state *mrb, mrb_value v)
     return mrb->nil_class; /* not reach */
 #endif
   default:
-    return ((struct RBasic*)mrb_object(v))->c;
+    return mrb_object(v)->c;
   }
 }
 

--- a/src/array.c
+++ b/src/array.c
@@ -49,7 +49,7 @@ mrb_ary_new_capa(mrb_state *mrb, size_t capa)
     mrb_raise(mrb, E_ARGUMENT_ERROR, "ary size too big");
   }
 
-  a = mrb_obj_alloc(mrb, MRB_TT_ARRAY, mrb->array_class);
+  a = (struct RArray *) mrb_obj_alloc(mrb, MRB_TT_ARRAY, mrb->array_class);
   a->buf = mrb_malloc(mrb, blen);
   memset(a->buf, 0, blen);
   a->capa = capa;

--- a/src/class.c
+++ b/src/class.c
@@ -108,7 +108,7 @@ make_metaclass(mrb_state *mrb, struct RClass *c)
   if (c->c->tt == MRB_TT_SCLASS) {
     return;
   }
-  sc = mrb_obj_alloc(mrb, MRB_TT_SCLASS, mrb->class_class);
+  sc = (struct RClass *) mrb_obj_alloc(mrb, MRB_TT_SCLASS, mrb->class_class);
   sc->mt = 0;
   if (!c->super) {
     sc->super = mrb->class_class;
@@ -500,7 +500,7 @@ boot_defclass(mrb_state *mrb, struct RClass *super)
 {
   struct RClass *c;
 
-  c = mrb_obj_alloc(mrb, MRB_TT_CLASS, mrb->class_class);
+  c = (struct RClass *) mrb_obj_alloc(mrb, MRB_TT_CLASS, mrb->class_class);
   c->super = super ? super : mrb->object_class;
   mrb_field_write_barrier(mrb, (struct RBasic*)c, (struct RBasic*)super);
   c->mt = kh_init(mt, mrb);
@@ -512,7 +512,7 @@ mrb_include_module(mrb_state *mrb, struct RClass *c, struct RClass *m)
 {
   struct RClass *ic;
 
-  ic = mrb_obj_alloc(mrb, MRB_TT_ICLASS, mrb->class_class);
+  ic = (struct RClass *) mrb_obj_alloc(mrb, MRB_TT_ICLASS, mrb->class_class);
   ic->c = m;
   ic->mt = m->mt;
   ic->iv = m->iv;
@@ -540,7 +540,7 @@ mrb_singleton_class_ptr(mrb_state *mrb, struct RClass *c)
   if (c->tt == MRB_TT_SCLASS) {
     return c;
   }
-  sc = mrb_obj_alloc(mrb, MRB_TT_SCLASS, mrb->class_class);
+  sc = (struct RClass *) mrb_obj_alloc(mrb, MRB_TT_SCLASS, mrb->class_class);
   sc->mt = 0;
   sc->super = c;
   mrb_field_write_barrier(mrb, (struct RBasic*)sc, (struct RBasic*)c);
@@ -563,7 +563,7 @@ mrb_singleton_class(mrb_state *mrb, mrb_value v)
   default:
     break;
   }
-  obj = (struct RBasic*)mrb_object(v);
+  obj = mrb_object(v);
   obj->c = mrb_singleton_class_ptr(mrb, obj->c);
   return mrb_obj_value(obj->c);
 }
@@ -668,7 +668,7 @@ mrb_value
 mrb_class_new_instance(mrb_state *mrb, int argc, mrb_value *argv, struct RClass * klass)
 {
   mrb_value obj;
-  struct RClass * c = mrb_obj_alloc(mrb, klass->tt, klass);
+  struct RClass * c = (struct RClass *) mrb_obj_alloc(mrb, klass->tt, klass);
   c->super = klass;
   obj = mrb_obj_value(c);
   mrb_obj_call_init(mrb, obj, argc, argv);
@@ -686,7 +686,7 @@ mrb_class_new_instance_m(mrb_state *mrb, mrb_value klass)
   mrb_value obj;
 
   mrb_get_args(mrb, "b*", &b, &argv, &argc);
-  c = mrb_obj_alloc(mrb, k->tt, k);
+  c = (struct RClass *) mrb_obj_alloc(mrb, k->tt, k);
   c->super = k;
   obj = mrb_obj_value(c);
   mrb_funcall_with_block(mrb, obj, "initialize", argc, argv, b);
@@ -706,7 +706,7 @@ mrb_instance_new(mrb_state *mrb, mrb_value cv)
   int argc;
 
   if (ttype == 0) ttype = MRB_TT_OBJECT;
-  o = mrb_obj_alloc(mrb, ttype, c);
+  o = (struct RObject *) mrb_obj_alloc(mrb, ttype, c);
   obj = mrb_obj_value(o);
   mrb_get_args(mrb, "b*", &b, &argv, &argc);
   mrb_funcall_with_block(mrb, obj, "initialize", argc, argv, b);
@@ -895,7 +895,7 @@ mrb_class_new(mrb_state *mrb, struct RClass *super)
 struct RClass *
 mrb_module_new(mrb_state *mrb)
 {
-  struct RClass *m = mrb_obj_alloc(mrb, MRB_TT_MODULE, mrb->module_class);
+  struct RClass *m = (struct RClass *) mrb_obj_alloc(mrb, MRB_TT_MODULE, mrb->module_class);
 
   return m;
 }

--- a/src/error.c
+++ b/src/error.c
@@ -183,7 +183,7 @@ exc_equal(mrb_state *mrb, mrb_value exc)
 void
 mrb_exc_raise(mrb_state *mrb, mrb_value exc)
 {
-    mrb->exc = mrb_object(exc);
+    mrb->exc = (struct RObject *) mrb_object(exc);
     longjmp(*(jmp_buf*)mrb->jmp, 1);
 }
 

--- a/src/etc.c
+++ b/src/etc.c
@@ -23,7 +23,7 @@ mrb_data_object_alloc(mrb_state *mrb, struct RClass *klass, void *ptr, const str
 {
   struct RData *data;
 
-  data = mrb_obj_alloc(mrb, MRB_TT_DATA, klass);
+  data = (struct RData *) mrb_obj_alloc(mrb, MRB_TT_DATA, klass);
   data->data = ptr;
   data->type = (struct mrb_data_type *) type;
 

--- a/src/gc.c
+++ b/src/gc.c
@@ -242,7 +242,7 @@ mrb_init_heap(mrb_state *mrb)
 #endif
 }
 
-void*
+struct RBasic*
 mrb_obj_alloc(mrb_state *mrb, enum mrb_vtype ttype, struct RClass *cls)
 {
   struct RBasic *p;
@@ -270,7 +270,7 @@ mrb_obj_alloc(mrb_state *mrb, enum mrb_vtype ttype, struct RClass *cls)
   p->tt = ttype;
   p->c = cls;
   paint_partial_white(mrb, p);
-  return (void*)p;
+  return p;
 }
 
 static inline void

--- a/src/hash.c
+++ b/src/hash.c
@@ -100,7 +100,7 @@ mrb_hash_new_capa(mrb_state *mrb, size_t capa)
 {
   struct RHash *h;
 
-  h = mrb_obj_alloc(mrb, MRB_TT_HASH, mrb->hash_class);
+  h = (struct RHash *) mrb_obj_alloc(mrb, MRB_TT_HASH, mrb->hash_class);
   h->ht = kh_init(ht, mrb);
   kh_resize(ht, h->ht, capa);
   h->iv = 0;
@@ -197,7 +197,7 @@ mrb_hash_dup(mrb_state *mrb, mrb_value hash)
   khash_t(ht) *h, *ret_h;
   khiter_t k, ret_k;
 
-  ret = mrb_obj_alloc(mrb, MRB_TT_HASH, mrb->hash_class);
+  ret = (struct RHash *) mrb_obj_alloc(mrb, MRB_TT_HASH, mrb->hash_class);
   ret->ht = kh_init(ht, mrb);
 
   if (!RHASH_EMPTY_P(hash)) {

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -367,7 +367,7 @@ mrb_singleton_class_clone(mrb_state *mrb, mrb_value obj)
       //struct clone_method_data data;
       /* copy singleton(unnamed) class */
       //VALUE clone = class_alloc(RBASIC(klass)->flags, 0);
-    struct RClass *clone = mrb_obj_alloc(mrb, klass->tt, mrb->class_class);
+    struct RClass *clone = (struct RClass *) mrb_obj_alloc(mrb, klass->tt, mrb->class_class);
     //clone->super = objklass->super;
 
       if ((mrb_type(obj) == MRB_TT_CLASS) ||
@@ -452,7 +452,7 @@ mrb_obj_clone(mrb_state *mrb, mrb_value self)
   if (mrb_special_const_p(self)) {
       mrb_raise(mrb, E_TYPE_ERROR, "can't clone %s", mrb_obj_classname(mrb, self));
   }
-  clone = mrb_obj_alloc(mrb, self.tt, mrb_obj_class(mrb, self));
+  clone = (struct RObject *) mrb_obj_alloc(mrb, self.tt, mrb_obj_class(mrb, self));
   clone->c = mrb_singleton_class_clone(mrb, self);
   init_copy(mrb, mrb_obj_value(clone), self);
   //1-9-2 no bug mrb_funcall(mrb, clone, "initialize_clone", 1, self);

--- a/src/proc.c
+++ b/src/proc.c
@@ -15,7 +15,7 @@ mrb_proc_new(mrb_state *mrb, mrb_irep *irep)
 {
   struct RProc *p;
 
-  p = mrb_obj_alloc(mrb, MRB_TT_PROC, mrb->proc_class);
+  p = (struct RProc *) mrb_obj_alloc(mrb, MRB_TT_PROC, mrb->proc_class);
   p->body.irep = irep;
   p->target_class = (mrb->ci) ? mrb->ci->target_class : 0;
   p->env = 0;
@@ -30,7 +30,7 @@ mrb_closure_new(mrb_state *mrb, mrb_irep *irep)
   struct REnv *e;
 
   if (!mrb->ci->env) {
-    e = mrb_obj_alloc(mrb, MRB_TT_ENV, (struct RClass *) mrb->ci->proc->env);
+    e = (struct REnv *) mrb_obj_alloc(mrb, MRB_TT_ENV, (struct RClass *) mrb->ci->proc->env);
     e->flags= (unsigned int)mrb->ci->proc->body.irep->nlocals;
     e->mid = mrb->ci->mid;
     e->cioff = mrb->ci - mrb->cibase;
@@ -49,7 +49,7 @@ mrb_proc_new_cfunc(mrb_state *mrb, mrb_func_t func)
 {
   struct RProc *p;
 
-  p = mrb_obj_alloc(mrb, MRB_TT_PROC, mrb->proc_class);
+  p = (struct RProc *) mrb_obj_alloc(mrb, MRB_TT_PROC, mrb->proc_class);
   p->body.func = func;
   p->flags |= MRB_PROC_CFUNC;
 

--- a/src/range.c
+++ b/src/range.c
@@ -37,7 +37,7 @@ mrb_range_new(mrb_state *mrb, mrb_value beg, mrb_value end, int excl)
 {
   struct RRange *r;
 
-  r = mrb_obj_alloc(mrb, MRB_TT_RANGE, RANGE_CLASS);
+  r = (struct RRange *) mrb_obj_alloc(mrb, MRB_TT_RANGE, RANGE_CLASS);
   r->edges = mrb_malloc(mrb, sizeof(struct mrb_range_edges));
   r->edges->beg = beg;
   r->edges->end = end;

--- a/src/re.c
+++ b/src/re.c
@@ -88,7 +88,7 @@ mrb_reg_s_new_instance(mrb_state *mrb, /*int argc, mrb_value *argv, */mrb_value 
   struct RRegexp *re;
 
   mrb_get_args(mrb, "*", &argv, &argc);
-  re = mrb_obj_alloc(mrb, MRB_TT_REGEX, REGEX_CLASS);
+  re = (struct RRegexp *) mrb_obj_alloc(mrb, MRB_TT_REGEX, REGEX_CLASS);
   re->ptr = 0;
   re->src = 0;
   re->usecnt = 0;
@@ -1665,7 +1665,7 @@ match_alloc(mrb_state *mrb)
 {
   struct RMatch* m;
 
-  m = mrb_obj_alloc(mrb, MRB_TT_MATCH, MATCH_CLASS);
+  m = (struct RMatch *) mrb_obj_alloc(mrb, MRB_TT_MATCH, MATCH_CLASS);
 
   m->str    = 0;
   m->rmatch = 0;
@@ -2453,7 +2453,7 @@ mrb_reg_s_alloc(mrb_state *mrb, mrb_value dummy)
 
   //NEWOBJ(re, struct RRegexp);
   //OBJSETUP(re, klass, T_REGEXP);
-  re = mrb_obj_alloc(mrb, MRB_TT_REGEX, REGEX_CLASS);
+  re = (struct RRegexp *) mrb_obj_alloc(mrb, MRB_TT_REGEX, REGEX_CLASS);
 
   re->ptr = 0;
   re->src = 0;

--- a/src/string.c
+++ b/src/string.c
@@ -291,12 +291,14 @@ mrb_str_capacity(mrb_value str)
 }
 #endif //INCLUDE_ENCODING
 
+#define mrb_obj_alloc_string(mrb) ((struct RString *) mrb_obj_alloc((mrb), MRB_TT_STRING, (mrb)->string_class))
+
 static inline mrb_value
 str_alloc(mrb_state *mrb)
 {
   struct RString* s;
 
-  s = mrb_obj_alloc(mrb, MRB_TT_STRING, mrb->string_class);
+  s = mrb_obj_alloc_string(mrb);
   //NEWOBJ(str, struct RString);
   //OBJSETUP(str, klass, T_STRING);
 
@@ -480,7 +482,7 @@ str_new4(mrb_state *mrb, mrb_value str)
 {
   mrb_value str2;
 
-  str2 = mrb_obj_value(mrb_obj_alloc(mrb, MRB_TT_STRING, mrb->string_class));
+  str2 = mrb_obj_value(mrb_obj_alloc_string(mrb));
   RSTRING(str2)->len = RSTRING_LEN(str);
   RSTRING(str2)->buf = RSTRING_PTR(str);
 
@@ -537,7 +539,7 @@ mrb_str_buf_new(mrb_state *mrb, size_t capa)
 {
   struct RString *s;
 
-  s = mrb_obj_alloc(mrb, MRB_TT_STRING, mrb->string_class);
+  s = mrb_obj_alloc_string(mrb);
 
   if (capa < STR_BUF_MIN_SIZE) {
     capa = STR_BUF_MIN_SIZE;
@@ -607,7 +609,7 @@ mrb_str_new(mrb_state *mrb, const char *p, size_t len)
   if (len == 0) {
     return mrb_str_buf_new(mrb, len);
   }
-  s = mrb_obj_alloc(mrb, MRB_TT_STRING, mrb->string_class);
+  s = mrb_obj_alloc_string(mrb);
   s->buf = mrb_malloc(mrb, len+1);
   if (p) {
     memcpy(s->buf, p, len);
@@ -655,7 +657,7 @@ mrb_str_new_cstr(mrb_state *mrb, const char *p)
   struct RString *s;
   size_t len = strlen(p);
 
-  s = mrb_obj_alloc(mrb, MRB_TT_STRING, mrb->string_class);
+  s = mrb_obj_alloc_string(mrb);
   s->buf = mrb_malloc(mrb, len+1);
   memcpy(s->buf, p, len);
   s->buf[len] = 0;
@@ -1420,7 +1422,7 @@ mrb_str_dup(mrb_state *mrb, mrb_value str)
   struct RString *s = mrb_str_ptr(str);
   struct RString *dup;
 
-  dup = mrb_obj_alloc(mrb, MRB_TT_STRING, mrb->string_class);
+  dup = mrb_obj_alloc_string(mrb);
   dup->buf = mrb_malloc(mrb, s->len+1);
   if (s->buf) {
     memcpy(dup->buf, s->buf, s->len);

--- a/src/vm.c
+++ b/src/vm.c
@@ -279,7 +279,7 @@ localjump_error(mrb_state *mrb, const char *kind)
 
   snprintf(buf, 256, "unexpected %s", kind);
   exc = mrb_exc_new(mrb, E_LOCALJUMP_ERROR, buf, strlen(buf));
-  mrb->exc = mrb_object(exc);
+  mrb->exc = (struct RObject *) mrb_object(exc);
 }
 
 static void
@@ -298,7 +298,7 @@ argnum_error(mrb_state *mrb, int num)
 	     mrb->ci->argc, num);
   }
   exc = mrb_exc_new(mrb, E_ARGUMENT_ERROR, buf, strlen(buf));
-  mrb->exc = mrb_object(exc);
+  mrb->exc = (struct RObject *) mrb_object(exc);
 }
 
 #define SET_TRUE_VALUE(r) {\
@@ -625,7 +625,7 @@ mrb_run(mrb_state *mrb, struct RProc *proc, mrb_value self)
 
     CASE(OP_RAISE) {
       /* A      raise(R(A)) */
-      mrb->exc = mrb_object(regs[GETARG_A(i)]);
+      mrb->exc = (struct RObject *) mrb_object(regs[GETARG_A(i)]);
       goto L_RAISE;
     }
 
@@ -1573,7 +1573,7 @@ mrb_run(mrb_state *mrb, struct RProc *proc, mrb_value self)
       mrb_value msg = pool[GETARG_Bx(i)];
       mrb_value exc = mrb_exc_new3(mrb, mrb->eRuntimeError_class, msg);
 
-      mrb->exc = mrb_object(exc);
+      mrb->exc = (struct RObject *) mrb_object(exc);
       goto L_RAISE;
     }
   }


### PR DESCRIPTION
One of the biggest set of changes needed to make C++ compile, is that you
can't autoconvert "void*" to a different pointer type without a cast (you
can of course, convert pointers _to_ "void*"!)

For the first part, convert the users of "mrb_obj_alloc".  Since it has
to return something, make it RBasic\* (that's what mrb_obj_alloc() is
operating on anyway).  This way, even in C you'll get a warning if you
don't cast it.

For places where there are a lot of similar calls to mrb_obj_alloc(),
this can be easily hidden through a macro.  I did this in string.c:
    #define mrb_obj_alloc_string(mrb) ((struct RString *) mrb_obj_alloc((mrb), MRB_TT_STRING, (mrb)->string_class))

I also updated the mrb_object() macro to also return a RBasic\* -- my
previous commit changed that from "void*" -> "RObject*", but I figure
it should be consistent with mrb_obj_alloc()
