### PR TITLE
call mrb_close() in tools and test programs

### DIFF
--- a/src/codegen.c
+++ b/src/codegen.c
@@ -2291,6 +2291,7 @@ p(fib(30), \"\\n\")\n\
   codedump_all(mrb, n);
 #endif
   mrb_run(mrb, mrb_proc_new(mrb, mrb->irep[0]), mrb_nil_value());
+  mrb_close(mrb);
 
   return 0;
 }

--- a/test/driver.c
+++ b/test/driver.c
@@ -55,6 +55,7 @@ main(void)
   else {
     /* no */
   }
+  mrb_close(mrb);
 
   return 0;
 }

--- a/tools/mirb/mirb.c
+++ b/tools/mirb/mirb.c
@@ -227,6 +227,7 @@ main(void)
       }
     }
   }
+  mrb_close(mrb_interpreter);
 
   return 0;
 }

--- a/tools/mrbc/mrbc.c
+++ b/tools/mrbc/mrbc.c
@@ -163,12 +163,14 @@ main(int argc, char **argv)
   if (n < 0 || args.rfp == NULL) {
     cleanup(&args);
     usage(argv[0]);
+    mrb_close(mrb);
     return n;
   }
 
   p = mrb_parse_file(mrb, args.rfp);
   if (!p || !p->tree || p->nerr) {
     cleanup(&args);
+    mrb_close(mrb);
     return -1;
   }
 
@@ -183,6 +185,7 @@ main(int argc, char **argv)
 
   if (n < 0 || args.check_syntax) {
     cleanup(&args);
+    mrb_close(mrb);
     return n;
   }
   if (args.initname) {
@@ -196,6 +199,7 @@ main(int argc, char **argv)
   }
 
   cleanup(&args);
+  mrb_close(mrb);
 
   return n;
 }

--- a/tools/mruby/mruby.c
+++ b/tools/mruby/mruby.c
@@ -130,6 +130,7 @@ cleanup(mrb_state *mrb, struct _args *args)
     mrb_free(mrb, args->cmdline);
   if (args->argv)
     mrb_free(mrb, args->argv);
+  mrb_close(mrb);
 }
 
 int


### PR DESCRIPTION
Trying to set a good example for people reading the code: if you call mrb_open() you should call mrb_close() when you're done.

At some point I hope that this will mean "make test" valgrind clean, but it seems we're some distance away from that at the moment
