### PR TITLE
Add CMake support authorship miss

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -5,3 +5,4 @@ Original Authors "mruby developers" are:
    Network Applied Communication Laboratory, Inc.
    Daniel Bovensiepen
    Jon Maken
+   Bjorn De Meyer


### PR DESCRIPTION
I missed adding one of the authors of the CMake support.

Please correct my unfortunate oversight.
