### PR TITLE
Makefile mods

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,12 @@
 # makefile discription.
 # basic build file for mruby
 
-# compiler, linker (gcc)
-CC = gcc
-LL = gcc
+# compiler, linker (gcc), archiver, parser generator
+export CC = gcc
+export LL = gcc
+export AR = ar
+export YACC = bison
+
 DEBUG_MODE = 1
 ifeq ($(DEBUG_MODE),1)
 CFLAGS = -g -O3
@@ -22,6 +25,10 @@ endif
 
 export MSG_BEGIN = @for line in
 export MSG_END = ; do echo "$$line"; done
+
+export CP := cp
+export RM_F := rm -f
+export CAT := cat
 
 ##############################
 # generic build targets, rules

--- a/mrblib/Makefile
+++ b/mrblib/Makefile
@@ -15,17 +15,15 @@ MRBS := $(MRB1)
 LIBR0 := ../lib/libmruby_core.a
 LIBR := ../lib/libmruby.a
 
-# C compiler (gcc)
-CC = gcc
-LL = gcc
-AR = ar
+# libraries, includes
+INCLUDES = -I../src -I../include
+
 DEBUG_MODE = 1
 ifeq ($(DEBUG_MODE),1)
 CFLAGS = -g
 else
 CFLAGS = -O3
 endif
-INCLUDES = -I../src -I../include
 ALL_CFLAGS = -Wall -Werror-implicit-function-declaration $(CFLAGS)
 ifeq ($(OS),Windows_NT)
   MAKE_FLAGS = CC=$(CC) LL=$(LL) ALL_CFLAGS="$(ALL_CFLAGS)"
@@ -40,6 +38,7 @@ else
 MRBC = ../bin/mrbc
 endif
 
+
 ##############################
 # generic build targets, rules
 
@@ -48,7 +47,7 @@ all : $(LIBR)
 
 # update libmruby.a
 $(LIBR) : $(MLIB) $(LIBR0)
-	cp $(LIBR0) $(LIBR)
+	$(CP) $(LIBR0) $(LIBR)
 	$(AR) r $(LIBR) $(MLIB)
 
 # Compile mrblib source
@@ -57,17 +56,17 @@ $(MLIB) : $(CLIB)
 
 # Compile C source from merged mruby source
 $(CLIB) : $(RLIB) $(MRBC)
-	$(MRBC) -Bmrblib_irep -o$(DLIB) $(RLIB); cat init_$(TARGET).c $(DLIB) > $@
+	$(MRBC) -Bmrblib_irep -o$(DLIB) $(RLIB); $(CAT) init_$(TARGET).c $(DLIB) > $@
 
 $(MRBC) : ../src/opcode.h ../src/codegen.c ../src/parse.y
 	$(MAKE) -C ../tools/mrbc $(MAKE_FLAGS)
 
 # merge mruby sources
 $(RLIB) : $(MRBS)
-	cat $? > $@
+	$(CAT) $? > $@
 
 # clean up
 .PHONY : clean
 clean :
 	@echo "make: removing targets, objects and depend files of `pwd`"
-	-rm -f $(MRBC) $(MLIB) $(CLIB) $(RLIB) $(DLIB) $(DEPLIB) $(LIBR)
+	-$(RM_F) $(MRBC) $(MLIB) $(CLIB) $(RLIB) $(DLIB) $(DEPLIB) $(LIBR)

--- a/src/Makefile
+++ b/src/Makefile
@@ -19,12 +19,6 @@ OBJS := $(OBJ1) $(OBJ2) $(OBJ3)
 # libraries, includes
 INCLUDES = -I$(BASEDIR) -I$(BASEDIR)/../include
 
-# compiler, linker (gcc)
-CC = gcc
-LL = gcc
-AR = ar
-YACC = bison
-
 DEBUG_MODE = 1
 ifeq ($(DEBUG_MODE),1)
 CFLAGS = -g -O3
@@ -32,6 +26,7 @@ else
 CFLAGS = -O3
 endif
 ALL_CFLAGS = -Wall -Werror-implicit-function-declaration $(CFLAGS)
+
 
 ##############################
 # generic build targets, rules
@@ -64,6 +59,6 @@ $(LDEF) : $(KWD)
 .PHONY : clean #cleandep
 clean :
 	@echo "make: removing targets, objects and depend files of `pwd`"
-	-rm -f $(TARGET) $(OBJS) $(OBJY) $(YC)
-	-rm -f $(OBJS:.o=.d) $(OBJY:.o=.d)
-	-rm -f $(patsubst %.c,%.o,$(EXCEPT1)) $(patsubst %.c,%.d,$(EXCEPT1))
+	-$(RM_F) $(TARGET) $(OBJS) $(OBJY) $(YC)
+	-$(RM_F) $(OBJS:.o=.d) $(OBJY:.o=.d)
+	-$(RM_F) $(patsubst %.c,%.o,$(EXCEPT1)) $(patsubst %.c,%.d,$(EXCEPT1))

--- a/test/Makefile
+++ b/test/Makefile
@@ -16,17 +16,16 @@ ASSLIB := $(BASEDIR)/assert.rb
 MRBS := $(BASEDIR)/t/*.rb
 OBJS := driver.o $(MLIB)
 
-# C compiler (gcc)
-CC = gcc
-LL = gcc
-AR = ar
+# libraries, includes
+LIBS = -lm
+INCLUDES = -I$(BASEDIR)/../src -I$(BASEDIR)/../include
+
 DEBUG_MODE = 1
 ifeq ($(DEBUG_MODE),1)
 CFLAGS = -g
 else
 CFLAGS = -O3
 endif
-INCLUDES = -I../src -I../include
 ALL_CFLAGS = -Wall -Werror-implicit-function-declaration $(CFLAGS)
 ifeq ($(OS),Windows_NT)
   MAKE_FLAGS = CC=$(CC) LL=$(LL) ALL_CFLAGS="$(ALL_CFLAGS)"
@@ -43,20 +42,6 @@ MRBC = ../bin/mrbc
 EXE := $(TARGET)
 endif
 
-# libraries, includes
-LIBS = -lm
-
-# compiler, linker (gcc)
-CC = gcc
-LL = gcc
-YACC = bison
-DEBUG_MODE = 1
-ifeq ($(DEBUG_MODE),1)
-CFLAGS = -g -O3
-else
-CFLAGS = -O3
-endif
-ALL_CFLAGS = -Wall -Werror-implicit-function-declaration $(CFLAGS)
 
 ##############################
 # generic build targets, rules
@@ -77,14 +62,14 @@ $(OBJS) : %.o : %.c
 
 # Compile C source from merged mruby source
 $(CLIB) : $(RLIB) $(MRBC) $(INIT)
-	$(MRBC) -Bmrbtest_irep -o$(DLIB) $(RLIB); cat $(INIT) $(DLIB) > $@
+	$(MRBC) -Bmrbtest_irep -o$(DLIB) $(RLIB); $(CAT) $(INIT) $(DLIB) > $@
 
 # merge mruby sources
 $(RLIB) : $(ASSLIB) $(MRBS)
-	cat $(ASSLIB) $(MRBS) > $@
+	$(CAT) $(ASSLIB) $(MRBS) > $@
 
 # clean up
 .PHONY : clean
 clean :
 	@echo "make: removing targets, objects and depend files of `pwd`"
-	-rm -f $(MLIB) $(CLIB) $(RLIB) $(DLIB) $(DEPLIB) $(OBJS) $(EXE)
+	-$(RM_F) $(MLIB) $(CLIB) $(RLIB) $(DLIB) $(DEPLIB) $(OBJS) $(EXE)

--- a/tools/mirb/Makefile
+++ b/tools/mirb/Makefile
@@ -21,10 +21,6 @@ EXTS := $(EXT1)
 LIBS = -lm
 INCLUDES = -I$(BASEDIR) -I$(BASEDIR)/../include
 
-# compiler, linker (gcc)
-CC = gcc
-LL = gcc
-YACC = bison
 DEBUG_MODE = 1
 ifeq ($(DEBUG_MODE),1)
   CFLAGS = -g -O3
@@ -69,5 +65,5 @@ clean :
 	$(MAKE) clean -C ../../mrblib $(MAKE_FLAGS)
 	$(MAKE) clean -C ../mrbc $(MAKE_FLAGS)
 	@echo "make: removing targets, objects and depend files of `pwd`"
-	-rm -f $(EXE) $(OBJS)
-	-rm -f $(OBJS:.o=.d)
+	-$(RM_F) $(EXE) $(OBJS)
+	-$(RM_F) $(OBJS:.o=.d)

--- a/tools/mrbc/Makefile
+++ b/tools/mrbc/Makefile
@@ -23,9 +23,6 @@ LIBS = -lm
 INCLUDES = -I$(BASEDIR) -I$(BASEDIR)/../include
 
 # compiler, linker (gcc)
-CC = gcc
-LL = gcc
-YACC = bison
 DEBUG_MODE = 1
 ifeq ($(DEBUG_MODE),1)
 CFLAGS = -g -O3
@@ -38,6 +35,7 @@ ifeq ($(OS),Windows_NT)
 else
   MAKE_FLAGS = CC='$(CC)' LL='$(LL)' ALL_CFLAGS='$(ALL_CFLAGS)'
 endif
+
 
 ##############################
 # generic build targets, rules
@@ -63,5 +61,5 @@ $(LIBR) :
 .PHONY : clean
 clean :
 	@echo "make: removing targets, objects and depend files of `pwd`"
-	-rm -f $(EXE) $(OBJS)
-	-rm -f $(OBJS:.o=.d)
+	-$(RM_F) $(EXE) $(OBJS)
+	-$(RM_F) $(OBJS:.o=.d)

--- a/tools/mruby/Makefile
+++ b/tools/mruby/Makefile
@@ -26,9 +26,6 @@ LIBS = -lm
 INCLUDES = -I$(BASEDIR) -I$(BASEDIR)/../include
 
 # compiler, linker (gcc)
-CC = gcc
-LL = gcc
-YACC = bison
 DEBUG_MODE = 1
 ifeq ($(DEBUG_MODE),1)
 CFLAGS = -g -O3
@@ -73,5 +70,5 @@ clean :
 	$(MAKE) clean -C ../../mrblib $(MAKE_FLAGS)
 	$(MAKE) clean -C ../mrbc $(MAKE_FLAGS)
 	@echo "make: removing targets, objects and depend files of `pwd`"
-	-rm -f $(EXE) $(OBJS)
-	-rm -f $(OBJS:.o=.d)
+	-$(RM_F) $(EXE) $(OBJS)
+	-$(RM_F) $(OBJS:.o=.d)


### PR DESCRIPTION
Two commits to make the basic Makefile a bit nicer. First adds simple `help` and `showconfig` targets, and the second does a bit of DRY cleaning.

Tested on:
- Win7 32bit with msys/mingw-w64: `make clean && make test`
- Win7 32bit with msys/mingw-w64 + clang 3.1: `make clean && make test CC=C:/clang/bin/clang.exe`
- Arch 3.3.6 , Ubuntu Server 12.04 both 32bit: `make clean && make test`
