### PR TITLE
cmake updates to support older versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@
 #  4c. Build, test, and install: `make all test install`
 #  4d. Build, test, and package: `make all test package`
 
-cmake_minimum_required(VERSION 2.8.8 FATAL_ERROR)
+cmake_minimum_required(VERSION 2.4 FATAL_ERROR)
 
 # Default build mode is Release With Debug Info unless specified
 if(NOT CMAKE_BUILD_TYPE)
@@ -26,7 +26,7 @@ if(NOT CMAKE_BUILD_TYPE)
       "Choose build type: empty Debug Release RelWithDebInfo MinSizeRel"
       FORCE)
   message(STATUS "Build type not set, defaulting to 'RelWithDebInfo'")
-endif()
+endif(NOT CMAKE_BUILD_TYPE)
 
 project(mruby C)
 
@@ -39,7 +39,26 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR AND NOT MSVC_IDE)
           "\nIn-source builds are not allowed as CMake would overwrite the "
           "Makefiles distributed with mruby. Please change to the 'build' "
           "subdirectory and run CMake from there.")
-endif()
+endif(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR AND NOT MSVC_IDE)
+
+# Build a CMAKE_VER variable out of CMAKE_{MAJOR,MINOR,PATCH}_VERSION, each
+# zeropassed to three digits (i.e. "002008008") for easy comparison.
+# Newer versions of cmake have the VERSION_{LESS,EQUAL,GREATER} comparison
+# predicates, but we don't want to rely on them being there
+set(CMAKE_VER "${CMAKE_PATCH_VERSION}")
+string(REGEX REPLACE "^([0-9])\$" "0\\1" CMAKE_VER "${CMAKE_VER}")
+string(REGEX REPLACE "^([0-9][0-9])\$" "0\\1" CMAKE_VER "${CMAKE_VER}")
+set(CMAKE_VER "${CMAKE_MINOR_VERSION}${CMAKE_VER}")
+string(REGEX REPLACE "^([0-9][0-9][0-9][0-9])\$" "0\\1" CMAKE_VER "${CMAKE_VER}")
+string(REGEX REPLACE "^([0-9][0-9][0-9][0-9][0-9])\$" "0\\1" CMAKE_VER "${CMAKE_VER}")
+set(CMAKE_VER "${CMAKE_MAJOR_VERSION}${CMAKE_VER}")
+string(REGEX REPLACE "^([0-9][0-9][0-9][0-9][0-9][0-9][0-9])\$" "0\\1" CMAKE_VER "${CMAKE_VER}")
+string(REGEX REPLACE "^([0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9])\$" "0\\1" CMAKE_VER "${CMAKE_VER}")
+
+if("${CMAKEVER}" STRLESS "002006000")
+  # Versions of cmake prior to 2.6 didn't support cross-compiling
+  set(CMAKE_CROSSCOMPILING 0 )
+endif("${CMAKEVER}" STRLESS "002006000")
 
 if(COMMAND cmake_policy)
   cmake_policy(SET CMP0003 NEW)  # don't split absolute link paths
@@ -53,7 +72,7 @@ if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
     "Install path prefix prepended to install directories."
     FORCE
     )
-endif()
+endif(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 
 # TODO refactor to use an option when adding shared lib support
 set(BUILD_SHARED_LIBS OFF)
@@ -76,16 +95,21 @@ include_directories("${CMAKE_SOURCE_DIR}/include" "${CMAKE_SOURCE_DIR}/src")
 # instead of `lib'.  Set this to 64 to do that.
 #set(LIB_SUFFIX "" CACHE STRING "Suffix for 'lib' directories, e.g. '64'")
 
+file(GLOB MRUBY_SRC_C "${CMAKE_SOURCE_DIR}/src/*.c")
+list(APPEND MRUBY_SRC_C "${CMAKE_BINARY_DIR}/src/parse.c")
+
 # build the components
 add_subdirectory(src)
-add_subdirectory(mrblib)
 add_subdirectory(tools)
+add_subdirectory(mrblib)
 add_subdirectory(test)
 
 # install the header files
 install(FILES include/mruby.h DESTINATION include)
 install(FILES include/mrbconf.h DESTINATION include)
-install(DIRECTORY include/mruby DESTINATION include FILES_MATCHING PATTERN "*.h")
+install(DIRECTORY DESTINATION include/mruby )
+file(GLOB INCLUDE_SLASH_MRUBY_FILES "include/mruby/*.h" )
+install(FILES ${INCLUDE_SLASH_MRUBY_FILES} DESTINATION include/mruby)
 
 # TODO refactor once proper versioning scheme implemented
 # archive packaging
@@ -93,14 +117,16 @@ set(CPACK_GENERATOR "TGZ;ZIP")
 string(TOLOWER ${CMAKE_SYSTEM_NAME} MRUBY_HOST)
 if(CMAKE_C_COMPILER_VERSION)
   string(REPLACE "." "" MRUBY_GCC_VERSION ${CMAKE_C_COMPILER_VERSION})
-endif()
+endif(CMAKE_C_COMPILER_VERSION)
 
 # TODO add build info suffix for non-Windows builds?
 if(MINGW)
   set(MRUBY_BUILD "-mingw${MRUBY_GCC_VERSION}")
-elseif(MSVC)
-  set(MRUBY_BUILD "-msvc${MSVC_VERSION}")
-endif()
+else(MINGW)
+  if(MSVC)
+    set(MRUBY_BUILD "-msvc${MSVC_VERSION}")
+  endif(MSVC)
+endif(MINGW)
 set(CPACK_PACKAGE_FILE_NAME
   "${CMAKE_PROJECT_NAME}-${MRUBY_VERSION}-${MRUBY_HOST}${MRUBY_BUILD}"
   )

--- a/cmake/modules/IntrospectSystem.cmake
+++ b/cmake/modules/IntrospectSystem.cmake
@@ -10,21 +10,21 @@ if(CMAKE_COMPILER_IS_GNUCC)
   set(CMAKE_C_FLAGS_RELEASE "-O3 -DNDEBUG")
 
   set(MRUBY_LIBS m)
-else()
+else(CMAKE_COMPILER_IS_GNUCC)
   if(MSVC)
     # TODO default MSVC flags
     add_definitions(
       -D_CRT_SECURE_NO_WARNINGS
       -wd4018  # suppress 'signed/unsigned mismatch'
       )
-  endif()
-endif()
+  endif(MSVC)
+endif(CMAKE_COMPILER_IS_GNUCC)
 
 if(MSVC)
   add_definitions(
     -DRUBY_EXPORT   # required by oniguruma.h
     )
-endif()
+endif(MSVC)
 
 
 # include helpers
@@ -35,18 +35,18 @@ include(CheckSymbolExists)
 CHECK_INCLUDE_FILE(string.h HAVE_STRING_H)
 if(HAVE_STRING_H)
   add_definitions(-DHAVE_STRING_H)
-endif()
+endif(HAVE_STRING_H)
 
 CHECK_INCLUDE_FILE(float.h HAVE_FLOAT_H)
 if(HAVE_FLOAT_H)
   add_definitions(-DHAVE_FLOAT_H)
-endif()
+endif(HAVE_FLOAT_H)
 
 
 # symbol checks
 CHECK_SYMBOL_EXISTS(gettimeofday sys/time.h HAVE_GETTIMEOFDAY)
 if(NOT HAVE_GETTIMEOFDAY)
   add_definitions(-DNO_GETTIMEOFDAY)
-endif()
+endif(NOT HAVE_GETTIMEOFDAY)
 
 # vim: ts=2 sts=2 sw=2 et

--- a/mrblib/CMakeLists.txt
+++ b/mrblib/CMakeLists.txt
@@ -21,37 +21,53 @@ if(CMAKE_CROSSCOMPILING)
             "${CMAKE_CURRENT_SOURCE_DIR}/init_mrblib.c"
             "${CMAKE_BINARY_DIR}/native/mrblib/mrblib.ctmp"
     )
-else()
+else(CMAKE_CROSSCOMPILING)
+  set(XPCAT_COMMAND xpcat)
+  set(MRBC_COMMAND mrbc)
+  if("${CMAKE_VER}" STRLESS "002006000")
+    # Prior to cmake 2.6, add_custom_command couldn't automatically find the
+    # location of a target binary
+    get_target_property(XPCAT_COMMAND xpcat LOCATION)
+    get_target_property(MRBC_COMMAND mrbc LOCATION)
+  endif("${CMAKE_VER}" STRLESS "002006000")
+
   # generate a single rb file from all existing ones
   add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/mrblib.rbtmp"
     DEPENDS xpcat
-    COMMAND xpcat -o "${CMAKE_CURRENT_BINARY_DIR}/mrblib.rbtmp" ${MRBLIB_SRC_RB}
+    COMMAND ${XPCAT_COMMAND} -o "${CMAKE_CURRENT_BINARY_DIR}/mrblib.rbtmp" ${MRBLIB_SRC_RB}
     )
 
   # mruby compile and generate C byte array representation
   add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/mrblib.ctmp"
     DEPENDS mrbc "${CMAKE_CURRENT_BINARY_DIR}/mrblib.rbtmp"
-    COMMAND mrbc -Bmrblib_irep -o"${CMAKE_CURRENT_BINARY_DIR}/mrblib.ctmp"
+    COMMAND ${MRBC_COMMAND} -Bmrblib_irep -o"${CMAKE_CURRENT_BINARY_DIR}/mrblib.ctmp"
                  "${CMAKE_CURRENT_BINARY_DIR}/mrblib.rbtmp"
     )
 
   # aggregate mruby's standard library as a single C file
   add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/mrblib.c"
     DEPENDS xpcat init_mrblib.c "${CMAKE_CURRENT_BINARY_DIR}/mrblib.ctmp"
-    COMMAND xpcat -o "${CMAKE_CURRENT_BINARY_DIR}/mrblib.c"
+    COMMAND ${XPCAT_COMMAND} -o "${CMAKE_CURRENT_BINARY_DIR}/mrblib.c"
                      "${CMAKE_CURRENT_SOURCE_DIR}/init_mrblib.c"
                      "${CMAKE_CURRENT_BINARY_DIR}/mrblib.ctmp"
     )
-endif()
+endif(CMAKE_CROSSCOMPILING)
 
+if("${CMAKE_VER}" STRLESS "002008008" )
+  # prior to cmake 2.8.8, the "OBJECT" library wasn't available, so simulate
+  # it by adding the same sources to this object.  Unfortunately this will
+  # force it to recompile them
+  add_library(libmruby_static STATIC ${MRUBY_SRC_C} mrblib.c)
+else("${CMAKE_VER}" STRLESS "002008008" )
+  add_library(mrblib_object OBJECT mrblib.c)
 
-add_library(mrblib_object OBJECT mrblib.c)
+  # generate final static libmruby archive library
+  add_library(libmruby_static STATIC
+    $<TARGET_OBJECTS:mruby_object>
+    $<TARGET_OBJECTS:mrblib_object>
+    )
+endif("${CMAKE_VER}" STRLESS "002008008" )
 
-# generate final static libmruby archive library
-add_library(libmruby_static STATIC
-  $<TARGET_OBJECTS:mruby_object>
-  $<TARGET_OBJECTS:mrblib_object>
-  )
 set_target_properties(libmruby_static PROPERTIES OUTPUT_NAME mruby)
 
 install(TARGETS libmruby_static

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,12 +1,28 @@
 # build the core mruby C files
 
-find_package(BISON)
-bison_target(mruby parse.y "${CMAKE_CURRENT_BINARY_DIR}/parse.c")
+find_program(BISON_EXECUTABLE NAMES bison DOC "Bison executable")
+if(NOT BISON_EXECUTABLE)
+  message(FATAL_ERROR "Could not find \"bison\" executable")
+endif(NOT BISON_EXECUTABLE)
+add_custom_command(
+    OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/parse.c"
+    DEPENDS parse.y
+    COMMAND ${BISON_EXECUTABLE}
+    ARGS -o "${CMAKE_CURRENT_BINARY_DIR}/parse.c" "${CMAKE_CURRENT_SOURCE_DIR}/parse.y"
+)
 
-file(GLOB MRUBY_SRC_C "*.c")
-list(APPEND MRUBY_SRC_C "${CMAKE_CURRENT_BINARY_DIR}/parse.c")
-
-add_library(mruby_object OBJECT ${MRUBY_SRC_C} ${BISON_mruby_OUTPUTS})
-add_library(mruby_static STATIC EXCLUDE_FROM_ALL $<TARGET_OBJECTS:mruby_object>)
+if("${CMAKE_VER}" STRLESS "002008008" )
+  # "add_library(OBJECT)" was added in cmake 2.8.8.  If it isn't there, just
+  # build a normal library out of these sources
+  if("${CMAKE_VER}" STRGREATER "002004006" )
+    add_library(mruby_static STATIC EXCLUDE_FROM_ALL ${MRUBY_SRC_C})
+  else("${CMAKE_VER}" STRGREATER "002004006" )
+    # before cmake 2.4.7, EXCLUDE_FROM_ALL didn't work on libraries
+    add_library(mruby_static STATIC ${MRUBY_SRC_C})
+  endif("${CMAKE_VER}" STRGREATER "002004006" )
+else("${CMAKE_VER}" STRLESS "002008008" )
+  add_library(mruby_object OBJECT ${MRUBY_SRC_C})
+  add_library(mruby_static STATIC EXCLUDE_FROM_ALL $<TARGET_OBJECTS:mruby_object>)
+endif("${CMAKE_VER}" STRLESS "002008008" )
 
 # vim: ts=2 sts=2 sw=2 et

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,26 +1,34 @@
 # build standalone mrbtest runner containing all *.rb tests
 
 if(NOT CMAKE_CROSSCOMPILING)
+  set(XPCAT_COMMAND xpcat)
+  set(MRBC_COMMAND mrbc)
+  if("${CMAKE_VER}" STRLESS "002006000")
+    # Prior to cmake 2.6, add_custom_command couldn't automatically find the
+    # location of a target binary
+    get_target_property(XPCAT_COMMAND xpcat LOCATION)
+    get_target_property(MRBC_COMMAND mrbc LOCATION)
+  endif("${CMAKE_VER}" STRLESS "002006000")
 
   file(GLOB MRBTEST_SRC_RB "assert.rb" "t/*.rb")
 
   # generate a single rb file from all existing test *.rb
   add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/mrbtest.rbtmp"
     DEPENDS xpcat
-    COMMAND xpcat -o "${CMAKE_CURRENT_BINARY_DIR}/mrbtest.rbtmp" ${MRBTEST_SRC_RB}
+    COMMAND ${XPCAT_COMMAND} -o "${CMAKE_CURRENT_BINARY_DIR}/mrbtest.rbtmp" ${MRBTEST_SRC_RB}
     )
 
   # mruby compile and generate C byte array representation
   add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/mrbtest.ctmp"
     DEPENDS mrbc "${CMAKE_CURRENT_BINARY_DIR}/mrbtest.rbtmp"
-    COMMAND mrbc -Bmrbtest_irep -o"${CMAKE_CURRENT_BINARY_DIR}/mrbtest.ctmp"
+    COMMAND ${MRBC_COMMAND} -Bmrbtest_irep -o"${CMAKE_CURRENT_BINARY_DIR}/mrbtest.ctmp"
                  "${CMAKE_CURRENT_BINARY_DIR}/mrbtest.rbtmp"
     )
 
   # aggregate mruby's *.rb test files as a single C file
   add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/mrbtest.c"
     DEPENDS xpcat init_mrbtest.c "${CMAKE_CURRENT_BINARY_DIR}/mrbtest.ctmp"
-    COMMAND xpcat -o "${CMAKE_CURRENT_BINARY_DIR}/mrbtest.c"
+    COMMAND ${XPCAT_COMMAND} -o "${CMAKE_CURRENT_BINARY_DIR}/mrbtest.c"
                      "${CMAKE_CURRENT_SOURCE_DIR}/init_mrbtest.c"
                      "${CMAKE_CURRENT_BINARY_DIR}/mrbtest.ctmp"
     )
@@ -37,6 +45,6 @@ if(NOT CMAKE_CROSSCOMPILING)
     COMMAND "${CMAKE_CURRENT_BINARY_DIR}/mrbtest"
     )
 
-endif()
+endif(NOT CMAKE_CROSSCOMPILING)
 
 # vim: ts=2 sts=2 sw=2 et


### PR DESCRIPTION
The original version of the CMakeLists.txt files only worked with the very
latest version of cmake (2.8.8)  On the systems I work on there is a mix
of cmake 2.4.6 and cmake 2.6.4, and for various reasons it's not easy for
me to update.  Therefore I thought I'd make them a little more portable
- Compute a ${CMAKE_VER} string which is in the form "002006004" for 2.6.4,
  so we can easily use STRLESS/STRGREATER to compare them.  Newer cmake has
  a VERSION_LESS comparison predicate but that isn't portable to these older
  versions
- Use the horrid if()/else()/endif() syntax where you repeat the stanza
  in each item.  For example, instead of:
    if(foo)
      ...
    else()
      ...
    endif()
  You have to say:
    if(foo)
      ...
    else(foo)
      ...
    endif(foo)
  
  It's ugly, but only a minor annoyance.
- add_library(...OBJECT...) is only available in the very newest cmake (2.8.8)
  It's very handy though since it avoids having to recompile all of the .c
  files to put them into two separate libraries.  If we're using an older
  cmake just work around this by making two separate STATIC libraries which
  is a little slower but works fine.
- Avoid add_library(...STATIC EXCLUDE_FROM_ALL...) on 2.4.6 to workaround
  a bug
- cmake older than 2.6 doesn't support cross-compiling, so make sure
  it's off
- don't use INSTALL(DIRECTORY ... FILES_MATCHING PATTERN ...)
- For add_custom_command(), cmake prior to 2.6 needed you to specify
  the exact path to the binary (which you can get from get_target_property)
  Starting in 2.6, this pattern was deprecated so when using the
  newer tools still have cmake figure it out for itself
