### PR TITLE
Add Tests for all Exception classes, for false, true, Proc, Module, nil ...

### DIFF
--- a/test/t/argumenterror.rb
+++ b/test/t/argumenterror.rb
@@ -1,0 +1,7 @@
+##
+# ArgumentError ISO Test
+
+assert('ArgumentError', '15.2.24') do
+  ArgumentError.class == Class
+end
+

--- a/test/t/class.rb
+++ b/test/t/class.rb
@@ -1,121 +1,126 @@
 ##
-# Bootstrap tests for Class
+# Class ISO Test
 
-assert('BS Class 1') do
+assert('Class', '15.2.3') do
+  Class.class == Class
+end
+
+# Not ISO specified
+
+assert('Class 1') do
   class C; end
   C.class == Class
 end
 
-assert('BS Class 2') do
+assert('Class 2') do
   class C; end
   C.new.class == C
 end
 
-assert('BS Class 3') do
+assert('Class 3') do
   class C; end
   C.new.class.class == Class
 end
 
-assert('BS Class 4') do
+assert('Class 4') do
   class A; end
   class C < A; end
   C.class == Class
 end
 
-assert('BS Class 5') do
+assert('Class 5') do
   class A; end
   class C < A; end
   C.new.class == C
 end
 
-assert('BS Class 6') do
+assert('Class 6') do
   class A; end
   class C < A; end
   C.new.class.class == Class
 end
 
-assert('BS Class Module 1') do
+assert('Class Module 1') do
   module M; end
   M.class == Module
 end
 
-assert('BS Class Module 2') do
+assert('Class Module 2') do
   module M; end
   class C; include M; end
   C.new.class == C
 end
 
 # nested class
-assert('BS Class Nested 1') do
+assert('Class Nested 1') do
   class A; end
   class A::B; end
   A::B == A::B
 end
 
-assert('BS Class Nested 2') do
+assert('Class Nested 2') do
   class A; end
   class A::B; end
   A::B.new.class == A::B
 end
 
-assert('BS Class Nested 3') do
+assert('Class Nested 3') do
   class A; end
   class A::B; end
   A::B.new.class.class == Class
 end
 
-assert('BS Class Nested 4') do
+assert('Class Nested 4') do
   class A; end
   class A::B; end
   class A::B::C; end
   A::B::C == A::B::C
 end
 
-assert('BS Class Nested 5') do
+assert('Class Nested 5') do
   class A; end
   class A::B; end
   class A::B::C; end
   A::B::C.class == Class
 end
 
-assert('BS Class Nested 6') do
+assert('Class Nested 6') do
   class A; end
   class A::B; end
   class A::B::C; end
   A::B::C.new.class == A::B::C
 end
 
-assert('BS Class Nested 7') do
+assert('Class Nested 7') do
   class A; end
   class A::B; end
   class A::B2 < A::B; end
   A::B2 == A::B2
 end
 
-assert('BS Class Nested 8') do
+assert('Class Nested 8') do
   class A; end
   class A::B; end
   class A::B2 < A::B; end
   A::B2.class == Class
 end
 
-assert('BS Class Colon 1') do
+assert('Class Colon 1') do
   class A; end; A::C = 1; A::C == 1
 end
 
-assert('BS Class Colon 2') do
+assert('Class Colon 2') do
   class A; class ::C; end end; C == C
 end
 
-assert('BS Class Colon 3') do
+assert('Class Colon 3') do
   class A; class ::C; end end; C.class == Class
 end
 
-assert('BS Class Dup 1') do
+assert('Class Dup 1') do
   class C; end;  C.dup.class == Class
 end
 
-assert('BS Class Dup 2') do
+assert('Class Dup 2') do
   module M; end;  M.dup.class == Module
 end
-

--- a/test/t/exception.rb
+++ b/test/t/exception.rb
@@ -1,7 +1,45 @@
 ##
-# Bootstrap tests for Exceptions
+# Exception ISO Test
 
-assert('BS Exception 1') do
+assert('Exception', '15.2.22') do
+  Exception.class == Class
+end
+
+assert('Exception.exception', '15.2.22.4.1') do
+  e = Exception.exception('a')
+
+  e.class == Exception
+end
+
+assert('Exception#exception', '15.2.22.5.1') do
+  e1 = Exception.exception()
+  e2 = Exception.exception('b')
+
+  e1.class == Exception and e2.class == Exception
+end
+
+assert('Exception#message', '15.2.22.5.2') do
+  e = Exception.exception('a')
+  
+  e.message == 'a'
+end
+
+assert('Exception#to_s', '15.2.22.5.3') do
+  e = Exception.exception('a')
+  
+  e.to_s == 'a'
+end
+
+assert('Exception.exception', '15.2.22.4.1') do
+  e = Exception.exception()
+  e.initialize('a')
+
+  e.message == 'a'
+end
+
+# Not ISO specified
+
+assert('Exception 1') do
   begin
     1+1
   ensure
@@ -9,7 +47,7 @@ assert('BS Exception 1') do
   end == 2
 end
 
-assert('BS Exception 2') do
+assert('Exception 2') do
   begin
     1+1
     begin
@@ -22,7 +60,7 @@ assert('BS Exception 2') do
   end == 4
 end
 
-assert('BS Exception 3') do
+assert('Exception 3') do
   begin
     1+1
     begin
@@ -40,7 +78,7 @@ assert('BS Exception 3') do
   end == 4
 end
 
-assert('BS Exception 4') do
+assert('Exception 4') do
   a = nil
   1.times{|e|
     begin
@@ -51,7 +89,7 @@ assert('BS Exception 4') do
   a == NilClass
 end
 
-assert('BS Exception 5') do
+assert('Exception 5') do
   $ans = []
   def m
     $!
@@ -69,7 +107,7 @@ assert('BS Exception 5') do
   $ans == [nil]
 end
 
-assert('BS Exception 6') do
+assert('Exception 6') do
   $i = 0
   def m
     iter{
@@ -95,7 +133,7 @@ assert('BS Exception 6') do
   $i == 7
 end
 
-assert('BS Exception 7') do
+assert('Exception 7') do
   $i = 0
   def m
     begin
@@ -115,7 +153,7 @@ assert('BS Exception 7') do
   $i == 10
 end
 
-assert('BS Exception 8') do
+assert('Exception 8') do
   begin
     1
   rescue
@@ -125,7 +163,7 @@ assert('BS Exception 8') do
   end == 3
 end
 
-assert('BS Exception 9') do
+assert('Exception 9') do
   begin
     1+1
   rescue
@@ -137,7 +175,7 @@ assert('BS Exception 9') do
   end == 6
 end
 
-assert('BS Exception 10') do
+assert('Exception 10') do
   begin
     1+1
     begin
@@ -155,4 +193,3 @@ assert('BS Exception 10') do
     7+7
   end == 12
 end
-

--- a/test/t/false.rb
+++ b/test/t/false.rb
@@ -1,0 +1,27 @@
+##
+# FalseClass ISO Test
+
+assert('FalseClass', '15.2.6') do
+  FalseClass.class == Class
+end
+
+assert('FalseClass false', '15.2.6.1') do
+  not false
+end
+
+assert('FalseClass#&', '15.2.6.3.1') do
+  not FalseClass.new.&(true) and not FalseClass.new.&(false)
+end
+
+assert('FalseClass#^', '15.2.6.3.2') do
+  FalseClass.new.^(true) and not FalseClass.new.^(false)
+end
+
+assert('FalseClass#to_s', '15.2.6.3.3') do
+  FalseClass.new.to_s == 'false'
+end
+
+assert('FalseClass#|', '15.2.6.3.4') do
+  FalseClass.new.|(true) and not FalseClass.new.|(false)
+end
+

--- a/test/t/indexerror.rb
+++ b/test/t/indexerror.rb
@@ -1,0 +1,7 @@
+##
+# IndexError ISO Test
+
+assert('IndexError', '15.2.33') do
+  IndexError.class == Class
+end
+

--- a/test/t/localjumperror.rb
+++ b/test/t/localjumperror.rb
@@ -1,0 +1,10 @@
+##
+# LocalJumpError ISO Test
+
+assert('LocalJumoError', '15.2.25') do
+  LocalJumpError.class == Class
+end
+
+# TODO 15.2.25.2.1 LocalJumpError#exit_value
+# TODO 15.2.25.2.2 LocalJumpError#reason
+

--- a/test/t/module.rb
+++ b/test/t/module.rb
@@ -1,0 +1,11 @@
+##
+# Module ISO Test
+
+assert('Module', '15.2.2') do
+  Module.class == Class
+end
+
+# TODO not implemented ATM assert('Module.constants', '15.2.2') do
+
+# TODO not implemented ATM assert('Module.nesting', '15.2.2') do
+

--- a/test/t/nameerror.rb
+++ b/test/t/nameerror.rb
@@ -1,0 +1,15 @@
+##
+# NameError ISO Test
+
+assert('NameError', '15.2.31') do
+  NameError.class == Class
+end
+
+# TODO 15.2.31.2.1 NameError#name
+
+assert('NameError#initialize', '15.2.31.2.2') do
+   e = NameError.new.initialize('a')
+
+   e.class == NameError and e.message == 'a'
+end
+

--- a/test/t/nil.rb
+++ b/test/t/nil.rb
@@ -1,0 +1,27 @@
+##
+# NilClass ISO Test
+
+assert('NilClass', '15.2.4') do
+  NilClass.class == Class
+end
+
+assert('NilClass#&', '15.2.4.3.1') do
+  not NilClass.new.& and not NilClass.new.&(nil)
+end
+
+assert('NilClass#^', '15.2.4.3.2') do
+  NilClass.new.^(true) and not NilClass.new.^(false)
+end
+
+assert('NilClass#|', '15.2.4.3.3') do
+  NilClass.new.|(true) and not NilClass.new.|(false)
+end
+
+assert('NilClass#nil?', '15.2.4.3.4') do
+  NilClass.new.nil?
+end
+
+assert('NilClass#to_s', '15.2.4.3.5') do
+  NilClass.new.to_s == ''
+end
+

--- a/test/t/nomethoderror.rb
+++ b/test/t/nomethoderror.rb
@@ -1,0 +1,14 @@
+##
+# NoMethodError ISO Test
+
+assert('NoMethodError', '15.2.32') do
+  e2 = nil
+  begin
+    doesNotExistAsAMethodNameForVerySure("")
+  rescue => e1
+    e2 = e1
+  end
+
+  NoMethodError.class == Class and e2.class == NoMethodError
+end
+

--- a/test/t/object.rb
+++ b/test/t/object.rb
@@ -1,0 +1,7 @@
+##
+# Object ISO Test
+
+assert('Object', '15.2.1') do
+  Object.class == Class
+end
+

--- a/test/t/proc.rb
+++ b/test/t/proc.rb
@@ -1,0 +1,45 @@
+##
+# Proc ISO Test
+
+assert('Proc', '15.2.17') do
+  Proc.class == Class
+end
+
+assert('Proc.new', '15.2.17.3.1') do
+  a = nil
+
+  begin
+    Proc.new
+  rescue => e
+    a = e
+  end
+
+  b = Proc.new {}
+
+  a.class == ArgumentError and b.class == Proc
+end
+
+assert('Proc#[]', '15.2.17.4.1') do
+  a = 0
+  b = Proc.new { a += 1 }
+  b.[]
+
+  a2 = 0
+  b2 = Proc.new { |i| a2 += i }
+  b2.[](5)
+
+  a == 1 and a2 == 5
+end
+
+assert('Proc#call', '15.2.17.4.3') do
+  a = 0
+  b = Proc.new { a += 1 }
+  b.call
+
+  a2 = 0
+  b2 = Proc.new { |i| a2 += i }
+  b2.call(5)
+
+  a == 1 and a2 == 5 
+end
+

--- a/test/t/rangeerror.rb
+++ b/test/t/rangeerror.rb
@@ -1,0 +1,7 @@
+##
+# RangeError ISO Test
+
+assert('RangeError', '15.2.26') do
+  RangeError.class == Class
+end
+

--- a/test/t/regexperror.rb
+++ b/test/t/regexperror.rb
@@ -1,0 +1,5 @@
+##
+# RegexpError ISO Test
+
+# TODO broken ATM assert('RegexpError', '15.2.27') do
+

--- a/test/t/runtimeerror.rb
+++ b/test/t/runtimeerror.rb
@@ -1,0 +1,15 @@
+##
+# RuntimeError ISO Test
+
+assert('RuntimeError', '15.2.28') do
+  e2 = nil
+  begin
+    # this will cause an exception due to the wrong location
+    retry
+  rescue => e1
+    e2 = e1
+  end
+
+  RuntimeError.class == Class and e2.class == RuntimeError
+end
+

--- a/test/t/standarderror.rb
+++ b/test/t/standarderror.rb
@@ -1,0 +1,7 @@
+##
+# StandardError ISO Test
+
+assert('StandardError', '15.2.23') do
+  StandardError.class == Class
+end
+

--- a/test/t/struct.rb
+++ b/test/t/struct.rb
@@ -1,0 +1,7 @@
+##
+# Struct ISO Test
+
+assert('Struct', '15.2.18') do
+  Struct.class == Class
+end
+

--- a/test/t/true.rb
+++ b/test/t/true.rb
@@ -1,0 +1,27 @@
+##
+# TrueClass ISO Test
+
+assert('TrueClass', '15.2.5') do
+  TrueClass.class == Class
+end
+
+assert('TrueClass true', '15.2.5.1') do
+  true
+end
+
+assert('TrueClass#&', '15.2.5.3.1') do
+  TrueClass.new.&(true) and not TrueClass.new.&(false)
+end
+
+assert('TrueClass#^', '15.2.5.3.2') do
+  not TrueClass.new.^(true) and TrueClass.new.^(false)
+end
+
+assert('TrueClass#to_s', '15.2.5.3.3') do
+  TrueClass.new.to_s == 'true'
+end
+
+assert('TrueClass#|', '15.2.5.3.4') do
+  TrueClass.new.|(true) and TrueClass.new.|(false)
+end
+

--- a/test/t/typeerror.rb
+++ b/test/t/typeerror.rb
@@ -1,0 +1,7 @@
+##
+# TypeError ISO Test
+
+assert('TypeError', '15.2.29') do
+  TypeError.class == Class
+end
+


### PR DESCRIPTION
This patch contains new test cases for:
- all available exception class which I found (-;
- for the boolean types (false, true, TrueClass, FalseClass)
- nil
- Module
- Object
- Struct (which fails massive at the moment and so doesn't have sufficient tests)
- Proc
