### PR TITLE
Remove unnecessary mrb_init_ext definition

### DIFF
--- a/tools/mrbc/mrbc.c
+++ b/tools/mrbc/mrbc.c
@@ -205,11 +205,6 @@ main(int argc, char **argv)
 }
 
 void
-mrb_init_ext(mrb_state *mrb)
-{
-}
-
-void
 mrb_init_mrblib(mrb_state *mrb)
 {
 }


### PR DESCRIPTION
While cleaning up a section of the CMake build impl, I got a multiple definition link error. This code appears unnecessary and removing it fixes the issue.

Tested on 32bit Win7 and Ubuntu 12.04 using the basic Makefiles and the CMake generated Makefiles.
