### PR TITLE
Raise SEGV by using String literal

### DIFF
--- a/test/t/literals.rb
+++ b/test/t/literals.rb
@@ -22,10 +22,9 @@ assert('Literals Numerical', '8.7.6.2') do
     1.0e1 == 10.0 and 1.0e-1 == 0.1 and 1.0e+1 == 10.0
 end
 
-#assert('Literals Strings Single Quoted', '8.7.6.3.2') do
-# creates segmentation fault for now
-#  'abc' == 'abc' and '\'' == '\'' and '\\' == '\\'
-#end
+assert('Literals Strings Single Quoted', '8.7.6.3.2') do
+  'abc' == 'abc' and '\'' == '\'' and '\\' == '\\'
+end
 
 assert('Literals Strings Double Quoted', '8.7.6.3.3') do
   a = "abc"


### PR DESCRIPTION
This patch raises a SEGV while using a string literal. Actually I planned to improve the Literal test cases but it seems more and more SEGV appearing the more I use them. So lets take one by one (-:

Short remark: This SEGV doesn't appear due to the use of single-quoated strings. I played a little bit around and it seems that it might be again connected to the amount of strings initialized before the use of this literal.
