### PR TITLE
SEGV by adding a new assert

### DIFF
--- a/test/t/literals.rb
+++ b/test/t/literals.rb
@@ -33,16 +33,20 @@ assert('Literals Strings Double Quoted', '8.7.6.3.3') do
     "#{a}" == "abc"
 end
 
-#creates segmentation fault for now
-#assert('Literals Strings Quoted Non-Expanded', '8.7.6.3.4') do
-#  a = %q{abc}
-#  b = %q(abc)
-#  c = %q[abc]
-#  d = %q<abc>
-#  e = %/abc/
-#  f = %/ab\/c/
+assert('Literals Strings Quoted Non-Expanded', '8.7.6.3.4') do
+  a = %q{abc}
+  b = %q(abc)
+  c = %q[abc]
+  d = %q<abc>
+  e = %q/abc/
+  f = %q/ab\/c/
 
-#  a == 'abc' and b == 'abc' and c == 'abc' and d == 'abc' and
-#    e == 'abc' and f 'ab/c'
-#end
+  a == 'abc' and b == 'abc' and c == 'abc' and d == 'abc' and
+    e == 'abc' and f == 'ab/c'
+end
+
+assert('Literals Strings Quoted Expanded', '8.7.6.3.5') do
+  # segv atm
+  true
+end
 


### PR DESCRIPTION
This patch just adds an empty assert but raises a segv too. This one I'm very confused. There is really no change to the code but as soon as I add the assert it segv. Hopefully this one is only due to my creepy build environment. I could reproduce on Mac OS X 10.7.
