### PR TITLE
Use default case in switch statement.

### DIFF
--- a/src/sprintf.c
+++ b/src/sprintf.c
@@ -54,7 +54,7 @@ remove_sign_bits(char *str, int base)
 static char
 sign_bits(int base, const char *p)
 {
-  char c = '.';
+  char c;
 
   switch (base) {
   case 16:
@@ -65,6 +65,8 @@ sign_bits(int base, const char *p)
     c = '7'; break;
   case 2:
     c = '1'; break;
+  default:
+    c = '.'; break;
   }
   return c;
 }
@@ -74,7 +76,7 @@ mrb_fix2binstr(mrb_state *mrb, mrb_value x, int base)
 {
   char buf[64], *b = buf + sizeof buf;
   unsigned long val = mrb_fixnum(x);
-  char d = 0;
+  char d;
 
   if (base != 2) {
     mrb_raise(mrb, E_ARGUMENT_ERROR, "invalid radix %d", base);
@@ -97,6 +99,7 @@ mrb_fix2binstr(mrb_state *mrb, mrb_value x, int base)
     case 16: d = 'f'; break;
     case 8:  d = '7'; break;
     case 2:  d = '1'; break;
+    default: d = 0;   break;
     }
 
     if (d && *b != d) {
@@ -793,6 +796,8 @@ format_s:
         case 'B':
           if (flags&(FPLUS|FSPACE)) sign = 1;
           break;
+	default:
+	  break;
         }
         if (flags & FSHARP) {
           switch (*p) {
@@ -801,6 +806,7 @@ format_s:
           case 'X': prefix = "0X"; break;
           case 'b': prefix = "0b"; break;
           case 'B': prefix = "0B"; break;
+	  default: break;
           }
         }
 
@@ -884,13 +890,14 @@ bin_retry:
           snprintf(fbuf, sizeof(fbuf), "%%l%c", c);
           snprintf(++s, sizeof(nbuf) - 1, fbuf, v);
           if (v < 0) {
-            char d = 0;
+            char d;
 
             s = remove_sign_bits(s, base);
             switch (base) {
             case 16: d = 'f'; break;
             case 8:  d = '7'; break;
             case 2:  d = '1'; break;
+	    default: d = 0; break;
             }
 
             if (d && *s != d) {

--- a/src/string.c
+++ b/src/string.c
@@ -4400,9 +4400,17 @@ mrb_str_conv_enc_opts(mrb_state *mrb, mrb_value str, mrb_encoding *from, mrb_enc
         mrb_enc_associate(mrb, newstr, to);
         return newstr;
 
-      default:
+      case econv_invalid_byte_sequence:
+      case econv_undefined_conversion:
+      case econv_source_buffer_empty:
+      case econv_after_output:
+      case econv_incomplete_input:
         /* some error, return original */
         return str;
+
+      default:
+	mrb_bug("Internal Error: Invalid return value mrb_econv_convert.");
+	return str;
     }
 }
 

--- a/src/transcode.c
+++ b/src/transcode.c
@@ -543,6 +543,7 @@ transcode_restartable0(mrb_state *mrb,
       case 32: goto resume_label32;
       case 33: goto resume_label33;
       case 34: goto resume_label34;
+      default: break;
     }
 
     while (1) {
@@ -1197,6 +1198,10 @@ trans_sweep(mrb_state *mrb, mrb_econv_t *ec,
               case econv_finished:
                 ec->num_finished = i+1;
                 break;
+
+	      default:
+		mrb_bug("Internal Error: invalid return value from mrb_transcoding_convert().");
+		break;
             }
         }
     }
@@ -1507,8 +1512,12 @@ mrb_econv_convert(mrb_state *mrb, mrb_econv_t *ec,
       /* todo: add more alternative behaviors */
         switch (ec->flags & ECONV_INVALID_MASK) {
           case ECONV_INVALID_REPLACE:
-          if (output_replacement_character(mrb, ec) == 0)
+            if (output_replacement_character(mrb, ec) == 0)
                 goto resume;
+
+	  default:
+	    mrb_bug("Internal error: Unhandled ECONV_INVALID_xxx.");
+	    break;
       }
     }
 
@@ -1526,6 +1535,10 @@ mrb_econv_convert(mrb_state *mrb, mrb_econv_t *ec,
             if (output_hex_charref(mrb, ec) == 0)
                 goto resume;
             break;
+
+	  default:
+	    mrb_bug("Internal error: Unhandled ECONV_UNDEF_xxx.");
+	    break;
         }
     }
 


### PR DESCRIPTION
This not bug fixes.
It is required to use 'default:' case by some coding guide lines.
I think it is a good practice for bug free.
