### PR TITLE
split declaration and definition of "khash_xxx".

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -23,9 +23,6 @@
   #define mrb_usascii_str_new2 mrb_str_new_cstr
 #endif
 
-KHASH_MAP_INIT_INT(mt, struct RProc*);
-KHASH_MAP_INIT_INT(iv, mrb_value);
-
 typedef struct fc_result {
     mrb_sym name;
     struct RClass * klass;

--- a/src/hash.c
+++ b/src/hash.c
@@ -34,7 +34,7 @@ mrb_hash_ht_hash_equal(mrb_state *mrb, mrb_value a, mrb_value b)
   return mrb_equal(mrb, a, b);
 }
 
-KHASH_INIT(ht, mrb_value, mrb_value, 1, mrb_hash_ht_hash_func, mrb_hash_ht_hash_equal);
+KHASH_DEF(ht, mrb_value, mrb_value, 1, mrb_hash_ht_hash_func, mrb_hash_ht_hash_equal);
 
 mrb_value mrb_exec_recursive_paired(mrb_state *mrb, mrb_value (*func) (mrb_state *, mrb_value, mrb_value, int),
                                   mrb_value obj, mrb_value paired_obj, void* arg);

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -39,9 +39,6 @@ typedef enum {
 #include "regint.h"
 #endif
 
-KHASH_MAP_INIT_INT(mt, struct RProc*);
-KHASH_MAP_INIT_INT(iv, mrb_value);
-
 #ifndef FALSE
 #define FALSE   0
 #endif

--- a/src/khash.c
+++ b/src/khash.c
@@ -1,0 +1,8 @@
+#include "mruby/khash.h"
+#include "stdio.h"
+
+KHASH_DEF(mt,  mrb_sym,   struct RProc*, 1, kh_mrbsym_hash_func, kh_mrbsym_hash_equal);
+KHASH_DEF(iv,  mrb_sym,       mrb_value, 1, kh_mrbsym_hash_func, kh_mrbsym_hash_equal);
+KHASH_DEF(s2n, mrb_sym,       kh_cstr_t, 1, kh_mrbsym_hash_func, kh_mrbsym_hash_equal);
+KHASH_DEF(n2s, kh_cstr_t,       mrb_sym, 1, kh_str_hash_func,    kh_str_hash_equal);
+

--- a/src/symbol.c
+++ b/src/symbol.c
@@ -17,9 +17,6 @@
 #include <stdio.h>
 
 /* ------------------------------------------------------ */
-KHASH_MAP_INIT_INT(s2n, const char*);
-KHASH_MAP_INIT_STR(n2s, mrb_sym);
-/* ------------------------------------------------------ */
 mrb_sym
 mrb_intern(mrb_state *mrb, const char *name)
 {

--- a/src/variable.c
+++ b/src/variable.c
@@ -19,8 +19,6 @@
 #include "st.h"
 #endif
 
-KHASH_MAP_INIT_INT(iv, mrb_value);
-
 #ifndef FALSE
 #define FALSE   0
 #endif


### PR DESCRIPTION
I split declaration and definition of "khash_xxx".
Because some implementation used non-portable code and code is messy.
And some implementations of "kh_xx_yy" functions are instantiated many times.
This means that executable binary size is increased.

non-portable code is:
- 'mrb_sym' (defined as 'intptr_t') is used as 'uint32_t'.
