### PR TITLE
'mrb_sym' used as 'uint32_t'. it's broken portability.

### DIFF
--- a/include/mruby/khash.h
+++ b/include/mruby/khash.h
@@ -202,7 +202,22 @@ static inline khint_t __ac_X31_hash_string(const char *s)
 }
 #define kh_str_hash_func(mrb,key) __ac_X31_hash_string(key)
 #define kh_str_hash_equal(mrb,a, b) (strcmp(a, b) == 0)
-
+static inline khint_t kh_mrbsym_hash_func(struct mrb_state *mrb, mrb_sym key)
+{
+#if defined(__STDINT_LIMITS)
+#if INTPTR_MAX == INT32_MAX
+	return kh_int_hash_func(mrb, key);
+#else
+	return kh_int64_hash_func(mrb, key);
+#endif
+#else
+	return kh_int_hash_func(mrb, key);
+#endif
+}
+static inline int kh_mrbsym_hash_equal(struct mrb_state *mrb, mrb_sym a, mrb_sym b)
+{
+	return a == b ? 1 : 0;
+}
 #define KHASH_MAP_INIT_INT(name, khval_t)                               \
     KHASH_INIT(name, uint32_t, khval_t, 1, kh_int_hash_func, kh_int_hash_equal)
 typedef const char *kh_cstr_t;

--- a/src/class.c
+++ b/src/class.c
@@ -17,8 +17,8 @@
 
 #include "mruby/khash.h"
 
-KHASH_MAP_INIT_INT(mt, struct RProc*);
-KHASH_MAP_INIT_INT(iv, mrb_value);
+KHASH_INIT(mt, mrb_sym, struct RProc*, 1, kh_mrbsym_hash_func, kh_mrbsym_hash_equal);
+KHASH_INIT(iv, mrb_sym, mrb_value,     1, kh_mrbsym_hash_func, kh_mrbsym_hash_equal);
 
 typedef struct fc_result {
     mrb_sym name;

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -39,8 +39,8 @@ typedef enum {
 #include "regint.h"
 #endif
 
-KHASH_MAP_INIT_INT(mt, struct RProc*);
-KHASH_MAP_INIT_INT(iv, mrb_value);
+KHASH_INIT(mt, mrb_sym, struct PRoc*, 1, kh_mrbsym_hash_func, kh_mrbsym_hash_equal);
+KHASH_INIT(iv, mrb_sym, mrb_value,    1, kh_mrbsym_hash_func, kh_mrbsym_hash_equal);
 
 #ifndef FALSE
 #define FALSE   0

--- a/src/variable.c
+++ b/src/variable.c
@@ -19,7 +19,7 @@
 #include "st.h"
 #endif
 
-KHASH_MAP_INIT_INT(iv, mrb_value);
+KHASH_INIT(iv, mrb_sym, mrb_value, 1, kh_mrbsym_hash_func, kh_mrbsym_hash_equal);
 
 #ifndef FALSE
 #define FALSE   0


### PR DESCRIPTION
modify 'kh_xxx'.
"mrb_sym" is used as "uint32_t", it breaks portability.
it is minimum modification for keeping the portability.
