### PR TITLE
use mrb_malloc instead of malloc

### DIFF
--- a/src/struct.c
+++ b/src/struct.c
@@ -416,7 +416,7 @@ mrb_struct_initialize_withArg(mrb_state *mrb, int argc, mrb_value *argv, mrb_val
     mrb_raise(mrb, E_ARGUMENT_ERROR, "struct size differs");
   }
   st = RSTRUCT(self);
-  st->ptr = malloc(sizeof(mrb_value)*argc);
+  st->ptr = mrb_malloc(mrb, sizeof(mrb_value)*argc);
   st->len = n;
   memcpy(st->ptr, argv, sizeof(mrb_value)*argc);
   //if (n > argc) {


### PR DESCRIPTION
I think this is the only one use case using (system) malloc in src/*.c

(There is another malloc in tool/mrbc/mrbc.c. It should be fixed, too?)
