### PR TITLE
enhance CMake support for Xcode native builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,8 +37,9 @@ project(mruby C)
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR AND NOT (MSVC_IDE OR XCODE))
   message(FATAL_ERROR
           "\nIn-source builds are not allowed as CMake would overwrite the "
-          "Makefiles distributed with mruby. Please change to the 'build' "
-          "subdirectory and run CMake from there.")
+          "Makefiles distributed with mruby. Delete any created 'CMakeFiles' "
+          "subdirectory and 'CMakeCache.txt' file from the current directory, "
+          "change to the 'build' subdirectory, and re-run CMake from there.")
 endif()
 
 if(COMMAND cmake_policy)


### PR DESCRIPTION
Tested in the following 32bit environments:
- Arch 3.3.7, gcc 4.7.0, Unix Makefiles
- Arch 3.3.7, cross build for Windows using mingw/gcc 4.6.2, Unix Makefiles
- Ubuntu Server 12.04, gcc 4.6.3, Unix Makefiles
- Ubuntu Server 12.04, cross build for Windows using mingw-w64/gcc 4.6.3, Unix Makefiles
- Win7, mingw, gcc 4.6.2, MSYS Makefiles
- Win7, WinSDK 7.1, NMake Makefiles
- Win7, WinSDK 7.1, Visual Studio 10 using MSBuild

@nkshigeru still builds OK with Visual Studio 10 IDE?
