### PR TITLE
Add string test for string interpolation

### DIFF
--- a/test/t/string.rb
+++ b/test/t/string.rb
@@ -319,3 +319,11 @@ assert('String#upcase!', '15.2.10.5.43') do
 
   a == 'ABC'
 end
+
+# Not ISO specified
+
+assert('String interpolation (mrb_str_concat for shared strings)') do
+  a = "A" * 32
+  "#{a}:" == "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA:"
+end
+


### PR DESCRIPTION
This patch is (as requested) an exchange for issue #219. It contains a test case to proof that issue #214 is now fixed.
