### PR TITLE
Fix wrong name of Hash#select!

### DIFF
--- a/mrblib/hash.rb
+++ b/mrblib/hash.rb
@@ -110,7 +110,7 @@ class Hash
   end
 
   # 1.9 Hash#select! returns Hash; ISO says nothing.
-  def reject!(&b)
+  def select!(&b)
     keys = []
     self.each_key{|k|
       v = self[k]


### PR DESCRIPTION
During refactoring of the Hash methods select (!) and reject (!) in commit d060c8a713cbfd356fd3814339bf6248d76f3507 select! wasn't correctly written.

This patch just renames the method to the right.
