### PR TITLE
Refactor hardcoded PARSER_DUMP macro

### DIFF
--- a/include/mrbconf.h
+++ b/include/mrbconf.h
@@ -21,6 +21,9 @@ typedef int mrb_int;
 typedef intptr_t mrb_sym;
 #define readint(p,base) strtol((p),NULL,(base))
 
+#undef  PARSER_DUMP        /* do not print out parser state */
+//#define PARSER_DUMP        /* print out parser state */
+
 #undef  INCLUDE_ENCODING   /* not use encoding classes (ascii only) */
 //#define INCLUDE_ENCODING   /* use UTF-8 encoding classes */
 
@@ -29,6 +32,10 @@ typedef intptr_t mrb_sym;
 
 #ifdef  INCLUDE_REGEXP
 # define INCLUDE_ENCODING  /* Regexp depends Encoding */
+#endif
+
+#ifdef  MRUBY_DEBUG_BUILD
+# define PARSER_DUMP
 #endif
 
 #undef  HAVE_UNISTD_H /* WINDOWS */

--- a/src/parse.y
+++ b/src/parse.y
@@ -4761,8 +4761,6 @@ mrb_parse_string(mrb_state *mrb, const char *s)
   return mrb_parse_nstring(mrb, s, strlen(s));
 }
 
-#define PARSER_DUMP
-
 void parser_dump(mrb_state *mrb, node *tree, int offset);
 
 int


### PR DESCRIPTION
Utility function `mrb_compile_string` is currently not very useful except for debugging purposes, and client code can be more complex than needed.

For example, one needs to use the commented out code in `mrb_run_string` of [this gist](https://gist.github.com/2865384) as a workaround to `mrb_compile_string` so as to avoid getting a print out of the parser internals.
