### PR TITLE
Use value.i for nil/false check.

### DIFF
--- a/include/mruby/class.h
+++ b/include/mruby/class.h
@@ -28,7 +28,7 @@ mrb_class(mrb_state *mrb, mrb_value v)
 {
   switch (mrb_type(v)) {
   case MRB_TT_FALSE:
-    if (v.value.p)
+    if (v.value.i)
       return mrb->false_class;
     return mrb->nil_class;
   case MRB_TT_TRUE:


### PR DESCRIPTION
On some architectures like (sizeof(void *) > sizeof(int)), value.p will not be 0 even if value.i == 0
