### PR TITLE
Add first sample for MIPS cross compile

### DIFF
--- a/cmake/Toolchain-Linux-openwrt-mips.cmake.sample
+++ b/cmake/Toolchain-Linux-openwrt-mips.cmake.sample
@@ -1,0 +1,10 @@
+# Toolchain file for building with OpenWRT Toolchain for MIPS.
+# This is a preliminary version for mips outside of the buildroot-ng.
+# The next version should be target independent.
+# Further improvements:
+#   - use ENV variables in OpenWRT toolchain (like HOSTCC, TARGET_CC)
+#   - set flags properly for host and target
+
+set(CMAKE_SYSTEM_NAME Linux)
+set(TOOLCHAIN_PREFIX mips-openwrt-linux)
+set(CMAKE_C_COMPILER ${TOOLCHAIN_PREFIX}-gcc)


### PR DESCRIPTION
This patch is a small sample to compile mruby to MIPS architecture. Test against AR9331 (MIPS24k). We need to modify the flags to make it smaller and more efficient. The current result with cmake is approx. 1.4M. Using some mips related tunings I've striped it down to less than 400k. Afterwards I want to integrate the ENV variables from OpenWRT. With this it should be possible to target mruby to nearly all Linux architectures.
