### PR TITLE
Make sprintf/format optional.

### DIFF
--- a/include/mrbconf.h
+++ b/include/mrbconf.h
@@ -34,6 +34,9 @@ typedef intptr_t mrb_sym;
 # define INCLUDE_ENCODING  /* Regexp depends Encoding */
 #endif
 
+//#undef INCLUDE_KERNEL_SPRINTF     /* not use Kernel.sprintf method. */
+#define INCLUDE_KERNEL_SPRINTF     /* not use Kernel.sprintf method. */
+
 #ifdef  MRUBY_DEBUG_BUILD
 # define PARSER_DUMP
 #endif

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -1425,8 +1425,10 @@ mrb_init_kernel(mrb_state *mrb)
   mrb_define_method(mrb, krn, "singleton_methods",          mrb_obj_singleton_methods_m,     ARGS_ANY());     /* 15.3.1.3.45 */
   mrb_define_method(mrb, krn, "to_s",                       mrb_any_to_s,                    ARGS_NONE());    /* 15.3.1.3.46 */
 
+#ifdef INCLUDE_KERNEL_SPRINTF
   mrb_define_method(mrb, krn, "sprintf",                    mrb_f_sprintf,                   ARGS_ANY());     /* in sprintf.c */
   mrb_define_method(mrb, krn, "format",                     mrb_f_sprintf,                   ARGS_ANY());     /* in sprintf.c */
+#endif
 
   mrb_include_module(mrb, mrb->object_class, mrb->kernel_module);
 }

--- a/src/sprintf.c
+++ b/src/sprintf.c
@@ -5,6 +5,9 @@
 */
 
 #include "mruby.h"
+
+#ifdef INCLUDE_KERNEL_SPRINTF
+
 #include <stdio.h>
 #include <string.h>
 #include "encoding.h"
@@ -1078,3 +1081,5 @@ fmt_setup(char *buf, size_t size, int c, int flags, int width, int prec)
     *buf++ = c;
     *buf = '\0';
 }
+
+#endif //INCLUDE_KERNEL_SPRINTF


### PR DESCRIPTION
sprintf/format method are useful.
But there seems not be in ISO standard. And they are too rich for tiny embedded systems.
I think they should be optional similar to RegExp.
