### PR TITLE
Assert should handle all exceptions.

### DIFF
--- a/test/assert.rb
+++ b/test/assert.rb
@@ -32,7 +32,7 @@ def assert(str = 'Assertion failed', iso = '')
       $ok_test += 1
       print('.')
     end
-  rescue => e
+  rescue Exception => e
     $asserts.push(['Error: ', str, iso, e])
     $kill_test += 1
     print('X')


### PR DESCRIPTION
mruby supports NotImplementedError. It's not subclass of StandardError. So assert should catch all exceptions.
