### PR TITLE
Remove unused variable.

### DIFF
--- a/src/kernel.c
+++ b/src/kernel.c
@@ -1134,7 +1134,6 @@ get_errinfo(mrb_state *mrb)
 mrb_value
 mrb_f_raise(mrb_state *mrb, mrb_value self)
 {
-  mrb_value err;
   mrb_value *argv;
   int argc;
 


### PR DESCRIPTION
Remove err as it is already unused since applied 54bc7e0721ffc
