### PR TITLE
Fix typo in parser around tLEQ

### DIFF
--- a/src/parse.y
+++ b/src/parse.y
@@ -1512,7 +1512,7 @@ op		: '|'		{ $$ = intern("|"); }
 		| '>'		{ $$ = intern(">"); }
 		| tGEQ		{ $$ = intern(">="); }
 		| '<'		{ $$ = intern("<"); }
-		| tLEQ		{ $$ = intern(">="); }
+		| tLEQ		{ $$ = intern("<="); }
 		| tNEQ		{ $$ = intern("!="); }
 		| tLSHFT	{ $$ = intern("<<"); }
 		| tRSHFT	{ $$ = intern(">>"); }


### PR DESCRIPTION
This fix is obvios. See also #277
