### PR TITLE
Fix redundant declraration warnings by gcc.

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -481,7 +481,6 @@ mrb_value mrb_class_new_instance_m(mrb_state *mrb, mrb_value klass);
 #define xfree       free
 #endif
 
-void mrb_garbage_collect(mrb_state *mrb);
 void mrb_gc_protect(mrb_state *mrb, mrb_value obj);
 mrb_value mrb_to_int(mrb_state *mrb, mrb_value val);
 void mrb_check_type(mrb_state *mrb, mrb_value x, enum mrb_vtype t);

--- a/src/cdump.c
+++ b/src/cdump.c
@@ -195,7 +195,6 @@ mrb_cdump_irep(mrb_state *mrb, int n, FILE *f,const char *initname)
 
   SOURCE_CODE0("  mrb->irep_len = idx;");
   SOURCE_CODE0("");
-  SOURCE_CODE0("  extern mrb_value mrb_top_self(mrb_state *mrb);");
   SOURCE_CODE0("  mrb_run(mrb, mrb_proc_new(mrb, mrb->irep[n]), mrb_top_self(mrb));");
   SOURCE_CODE0("}");
 

--- a/src/error.h
+++ b/src/error.h
@@ -12,13 +12,11 @@ struct RException {
 };
 
 void mrb_sys_fail(mrb_state *mrb, const char *mesg);
-void mrb_exc_raise(mrb_state *mrb, mrb_value mesg);
 void mrb_bug_errno(const char*, int);
 int sysexit_status(mrb_state *mrb, mrb_value err);
 void error_pos(void);
 mrb_value mrb_exc_new3(mrb_state *mrb, struct RClass* c, mrb_value str);
 mrb_value make_exception(mrb_state *mrb, int argc, mrb_value *argv, int isstr);
-mrb_value mrb_exc_new(mrb_state *mrb, struct RClass *c, const char *ptr, long len);
 mrb_value mrb_make_exception(mrb_state *mrb, int argc, mrb_value *argv);
 mrb_value mrb_sprintf(mrb_state *mrb, const char *fmt, ...);
 void mrb_name_error(mrb_state *mrb, mrb_sym id, const char *fmt, ...);


### PR DESCRIPTION
These declarations are declared in other places.
