### PR TITLE
Simplify error.c

### DIFF
--- a/mrblib/error.rb
+++ b/mrblib/error.rb
@@ -17,5 +17,13 @@ end
 class ScriptError < Exception
 end
 
+# ISO 15.2.38
+class SyntaxError < ScriptError
+end
+
+# ISO 15.2.39
+class LoadError < ScriptError
+end
+
 class NotImplementedError < ScriptError
 end

--- a/src/error.c
+++ b/src/error.c
@@ -385,9 +385,6 @@ mrb_init_exception(mrb_state *mrb)
   eNameError              = mrb_define_class(mrb, "NameError",           mrb->eStandardError_class); /* 15.2.31 */
 
   mrb_define_class(mrb, "NoMethodError",       eNameError);          /* 15.2.32 */
-  //  eScriptError            = mrb_define_class(mrb, "ScriptError",         mrb->eException_class);     /* 15.2.37 */
-  //  mrb_define_class(mrb, "SyntaxError",         eScriptError);        /* 15.2.38 */
-  //  mrb_define_class(mrb, "LoadError",           eScriptError);        /* 15.2.39 */
   //  mrb_define_class(mrb, "SystemCallError",     mrb->eStandardError_class); /* 15.2.36 */
   mrb_define_class(mrb, "LocalJumpError",      mrb->eStandardError_class); /* 15.2.25 */
 

--- a/test/t/exception.rb
+++ b/test/t/exception.rb
@@ -41,6 +41,36 @@ assert('Exception.exception', '15.2.22.4.1') do
   e.message == 'a'
 end
 
+assert('ScriptError', '15.2.37') do
+  begin
+    raise ScriptError.new
+  rescue ScriptError
+    true
+  else
+    false
+  end
+end
+
+assert('SyntaxError', '15.2.38') do
+  begin
+    raise SyntaxError.new
+  rescue SyntaxError
+    true
+  else
+    false
+  end
+end
+
+assert('LoadError', '15.2.39') do
+  begin
+    raise LoadError.new
+  rescue LoadError
+    true
+  else
+    false
+  end
+end
+
 # Not ISO specified
 
 assert('Exception 1') do


### PR DESCRIPTION
There are two patches.

One is two unused functions.
Other is not to use strlen().

There are related issues in mrb_warn/mrb_bug. But I left them. (I'll post later.)
