### PR TITLE
RStruct.ptr must allocate members size

### DIFF
--- a/src/struct.c
+++ b/src/struct.c
@@ -412,7 +412,7 @@ mrb_struct_initialize_withArg(mrb_state *mrb, int argc, mrb_value *argv, mrb_val
     mrb_raise(mrb, E_ARGUMENT_ERROR, "struct size differs");
   }
   st = RSTRUCT(self);
-  st->ptr = mrb_malloc(mrb, sizeof(mrb_value)*argc);
+  st->ptr = mrb_calloc(mrb, sizeof(mrb_value), n);
   st->len = n;
   memcpy(st->ptr, argv, sizeof(mrb_value)*argc);
 


### PR DESCRIPTION
Currently, RStruct.ptr is allocated only arguments size. So, SEGV occurs when called inspect.
