### PR TITLE
Make CFLAG choices in Makefiles more flexible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,12 +7,19 @@ export LL = gcc
 export AR = ar
 export YACC = bison
 
-DEBUG_MODE = 1
-ifeq ($(DEBUG_MODE),1)
-CFLAGS = -g -O3
-else
-CFLAGS = -O3
+ifeq ($(strip $(COMPILE_MODE)),)
+  # default compile option
+  COMPILE_MODE = debug
 endif
+
+ifeq ($(COMPILE_MODE),debug)
+  CFLAGS = -g -O3
+else ifeq ($(COMPILE_MODE),release)
+  CFLAGS = -O3
+else ifeq ($(COMPILE_MODE),small)
+  CFLAGS = -Os
+endif
+
 ALL_CFLAGS = -Wall -Werror-implicit-function-declaration $(CFLAGS)
 ifeq ($(OS),Windows_NT)
   MAKE_FLAGS = --no-print-directory CC=$(CC) LL=$(LL) ALL_CFLAGS='$(ALL_CFLAGS)'

--- a/mrblib/Makefile
+++ b/mrblib/Makefile
@@ -18,12 +18,19 @@ LIBR := ../lib/libmruby.a
 # libraries, includes
 INCLUDES = -I../src -I../include
 
-DEBUG_MODE = 1
-ifeq ($(DEBUG_MODE),1)
-CFLAGS = -g
-else
-CFLAGS = -O3
+ifeq ($(strip $(COMPILE_MODE)),)
+  # default compile option
+  COMPILE_MODE = debug
 endif
+
+ifeq ($(COMPILE_MODE),debug)
+  CFLAGS = -g -O3
+else ifeq ($(COMPILE_MODE),release)
+  CFLAGS = -O3
+else ifeq ($(COMPILE_MODE),small)
+  CFLAGS = -Os
+endif
+
 ALL_CFLAGS = -Wall -Werror-implicit-function-declaration $(CFLAGS)
 ifeq ($(OS),Windows_NT)
   MAKE_FLAGS = CC=$(CC) LL=$(LL) ALL_CFLAGS="$(ALL_CFLAGS)"

--- a/src/Makefile
+++ b/src/Makefile
@@ -19,12 +19,19 @@ OBJS := $(OBJ1) $(OBJ2) $(OBJ3)
 # libraries, includes
 INCLUDES = -I$(BASEDIR) -I$(BASEDIR)/../include
 
-DEBUG_MODE = 1
-ifeq ($(DEBUG_MODE),1)
-CFLAGS = -g -O3
-else
-CFLAGS = -O3
+ifeq ($(strip $(COMPILE_MODE)),)
+  # default compile option
+  COMPILE_MODE = debug
 endif
+
+ifeq ($(COMPILE_MODE),debug)
+  CFLAGS = -g -O3
+else ifeq ($(COMPILE_MODE),release)
+  CFLAGS = -O3
+else ifeq ($(COMPILE_MODE),small)
+  CFLAGS = -Os
+endif
+
 ALL_CFLAGS = -Wall -Werror-implicit-function-declaration $(CFLAGS)
 
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -20,12 +20,19 @@ OBJS := driver.o $(MLIB)
 LIBS = -lm
 INCLUDES = -I$(BASEDIR)/../src -I$(BASEDIR)/../include
 
-DEBUG_MODE = 1
-ifeq ($(DEBUG_MODE),1)
-CFLAGS = -g
-else
-CFLAGS = -O3
+ifeq ($(strip $(COMPILE_MODE)),)
+  # default compile option
+  COMPILE_MODE = debug
 endif
+
+ifeq ($(COMPILE_MODE),debug)
+  CFLAGS = -g -O3
+else ifeq ($(COMPILE_MODE),release)
+  CFLAGS = -O3
+else ifeq ($(COMPILE_MODE),small)
+  CFLAGS = -Os
+endif
+
 ALL_CFLAGS = -Wall -Werror-implicit-function-declaration $(CFLAGS)
 ifeq ($(OS),Windows_NT)
   MAKE_FLAGS = CC=$(CC) LL=$(LL) ALL_CFLAGS="$(ALL_CFLAGS)"

--- a/tools/mirb/Makefile
+++ b/tools/mirb/Makefile
@@ -21,12 +21,19 @@ EXTS := $(EXT1)
 LIBS = -lm
 INCLUDES = -I$(BASEDIR) -I$(BASEDIR)/../include
 
-DEBUG_MODE = 1
-ifeq ($(DEBUG_MODE),1)
-  CFLAGS = -g -O3
-else
-  CFLAGS = -O3
+ifeq ($(strip $(COMPILE_MODE)),)
+  # default compile option
+  COMPILE_MODE = debug
 endif
+
+ifeq ($(COMPILE_MODE),debug)
+  CFLAGS = -g -O3
+else ifeq ($(COMPILE_MODE),release)
+  CFLAGS = -O3
+else ifeq ($(COMPILE_MODE),small)
+  CFLAGS = -Os
+endif
+
 ALL_CFLAGS = -Wall -Werror-implicit-function-declaration $(CFLAGS)
 ifeq ($(OS),Windows_NT)
   MAKE_FLAGS = CC=$(CC) LL=$(LL) ALL_CFLAGS="$(ALL_CFLAGS)"

--- a/tools/mrbc/Makefile
+++ b/tools/mrbc/Makefile
@@ -23,12 +23,19 @@ LIBS = -lm
 INCLUDES = -I$(BASEDIR) -I$(BASEDIR)/../include
 
 # compiler, linker (gcc)
-DEBUG_MODE = 1
-ifeq ($(DEBUG_MODE),1)
-CFLAGS = -g -O3
-else
-CFLAGS = -O3
+ifeq ($(strip $(COMPILE_MODE)),)
+  # default compile option
+  COMPILE_MODE = debug
 endif
+
+ifeq ($(COMPILE_MODE),debug)
+  CFLAGS = -g -O3
+else ifeq ($(COMPILE_MODE),release)
+  CFLAGS = -O3
+else ifeq ($(COMPILE_MODE),small)
+  CFLAGS = -Os
+endif
+
 ALL_CFLAGS = -Wall -Werror-implicit-function-declaration $(CFLAGS)
 ifeq ($(OS),Windows_NT)
   MAKE_FLAGS = CC=$(CC) LL=$(LL) ALL_CFLAGS="$(ALL_CFLAGS)"

--- a/tools/mruby/Makefile
+++ b/tools/mruby/Makefile
@@ -26,12 +26,19 @@ LIBS = -lm
 INCLUDES = -I$(BASEDIR) -I$(BASEDIR)/../include
 
 # compiler, linker (gcc)
-DEBUG_MODE = 1
-ifeq ($(DEBUG_MODE),1)
-CFLAGS = -g -O3
-else
-CFLAGS = -O3
+ifeq ($(strip $(COMPILE_MODE)),)
+  # default compile option
+  COMPILE_MODE = debug
 endif
+
+ifeq ($(COMPILE_MODE),debug)
+  CFLAGS = -g -O3
+else ifeq ($(COMPILE_MODE),release)
+  CFLAGS = -O3
+else ifeq ($(COMPILE_MODE),small)
+  CFLAGS = -Os
+endif
+
 ALL_CFLAGS = -Wall -Werror-implicit-function-declaration $(CFLAGS)
 ifeq ($(OS),Windows_NT)
   MAKE_FLAGS = CC=$(CC) LL=$(LL) ALL_CFLAGS="$(ALL_CFLAGS)"


### PR DESCRIPTION
This patch contains a change to the CFLAGS. Till now it was hard coded that always the debug options "-g -O3" are used. I changed this to let the user decide by introducing the COMPILE_MODE variable. The user can choose between debug (-g -O3), release (-O3) and small (-Os).
