### PR TITLE
Fix GC of struct

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -626,6 +626,15 @@ gc_gray_mark(mrb_state *mrb, struct RBasic *obj)
     break;
 #endif
 
+#ifdef ENABLE_STRUCT
+  case MRB_TT_STRUCT:
+    {
+      struct RStruct *s = (struct RStruct*)obj;
+      children += s->len;
+    }
+    break;
+#endif
+
   default:
     break;
   }


### PR DESCRIPTION
I forgot to add code for struct in gc_gray_mark and obj_free at issue #313.
Please refer to #313 for more detail.

Sorry for inconvenience.
