### PR TITLE
Patch for inheritance of built-in class

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -1050,6 +1050,9 @@ mrb_class_new(mrb_state *mrb, struct RClass *super)
     mrb_check_inheritable(mrb, super);
   }
   c = boot_defclass(mrb, super);
+  if (super){
+    MRB_SET_INSTANCE_TT(c, MRB_INSTANCE_TT(super));
+  }
   make_metaclass(mrb, c);
 
   return c;


### PR DESCRIPTION
As I mentioned in issue #315, current implementation does not allow some built-in classes to be inherited.

Please refer to #315 for more detail.
