### PR TITLE
Use mrb_intern2 instead of mrb_intern as possible. 

### DIFF
--- a/src/array.c
+++ b/src/array.c
@@ -1042,7 +1042,7 @@ mrb_ary_equal(mrb_state *mrb, mrb_value ary1)
   mrb_get_args(mrb, "o", &ary2);
   if (mrb_obj_equal(mrb, ary1,ary2)) return mrb_true_value();
   if (mrb_type(ary2) != MRB_TT_ARRAY) {
-    if (!mrb_respond_to(mrb, ary2, mrb_intern(mrb, "to_ary"))) {
+    if (!mrb_respond_to(mrb, ary2, mrb_intern2(mrb, "to_ary", 6))) {
         return mrb_false_value();
     }
     if (mrb_equal(mrb, ary2, ary1)){

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -425,7 +425,7 @@ for_body(codegen_scope *s, node *tree)
   s = prev;
   genop(s, MKOP_Abc(OP_LAMBDA, cursp(), idx - base, OP_L_BLOCK));
   pop();
-  idx = new_msym(s, mrb_intern(s->mrb, "each"));
+  idx = new_msym(s, mrb_intern2(s->mrb, "each", 4));
   genop(s, MKOP_ABC(OP_SEND, cursp(), idx, 0));
 }
 
@@ -868,14 +868,14 @@ codegen(codegen_scope *s, node *tree, int val)
               codegen(s, n4->car, VAL);
             }
             else {
-              genop(s, MKOP_ABx(OP_GETCONST, cursp(), new_msym(s, mrb_intern(s->mrb, "StandardError"))));
+              genop(s, MKOP_ABx(OP_GETCONST, cursp(), new_msym(s, mrb_intern2(s->mrb, "StandardError", 13))));
               push();
             }
             genop(s, MKOP_AB(OP_MOVE, cursp(), exc));
             push();
             genop(s, MKOP_A(OP_LOADNIL, cursp()));
             pop(); pop();
-            genop(s, MKOP_ABC(OP_SEND, cursp(), new_msym(s, mrb_intern(s->mrb, "===")), 1));
+            genop(s, MKOP_ABC(OP_SEND, cursp(), new_msym(s, mrb_intern2(s->mrb, "===", 3)), 1));
             tmp = new_label(s);
             genop(s, MKOP_AsBx(OP_JMPIF, cursp(), pos2));
             pos2 = tmp;
@@ -1065,7 +1065,7 @@ codegen(codegen_scope *s, node *tree, int val)
             push();
             genop(s, MKOP_A(OP_LOADNIL, cursp()));
             pop(); pop();
-            genop(s, MKOP_ABC(OP_SEND, cursp(), new_msym(s, mrb_intern(s->mrb, "===")), 1));
+            genop(s, MKOP_ABC(OP_SEND, cursp(), new_msym(s, mrb_intern2(s->mrb, "===", 3)), 1));
           }
           tmp = new_label(s);
           genop(s, MKOP_AsBx(OP_JMPIF, cursp(), pos2));
@@ -1390,7 +1390,7 @@ codegen(codegen_scope *s, node *tree, int val)
       genop(s, MKOP_A(OP_LOADNIL, cursp()));
       pop_n(n+1);
       if (sendv) n = CALL_MAXARGS;
-      genop(s, MKOP_ABC(OP_SEND, cursp(), new_msym(s, mrb_intern(s->mrb, "call")), n));
+      genop(s, MKOP_ABC(OP_SEND, cursp(), new_msym(s, mrb_intern2(s->mrb, "call", 4)), n));
       if (val) push();
     }
     break;
@@ -1652,7 +1652,7 @@ codegen(codegen_scope *s, node *tree, int val)
 
       default:
         {
-          int sym = new_msym(s, mrb_intern(s->mrb, "-"));
+          int sym = new_msym(s, mrb_intern2(s->mrb, "-", 1));
 
           genop(s, MKOP_ABx(OP_LOADI, cursp(), 0));
           push();
@@ -1743,7 +1743,7 @@ codegen(codegen_scope *s, node *tree, int val)
     {
       int a = new_msym(s, (mrb_sym)tree->car);
       int b = new_msym(s, (mrb_sym)tree->cdr);
-      int c = new_msym(s, mrb_intern(s->mrb, "alias_method"));
+      int c = new_msym(s, mrb_intern2(s->mrb, "alias_method", 12));
 
       genop(s, MKOP_A(OP_TCLASS, cursp()));
       push();
@@ -1763,7 +1763,7 @@ codegen(codegen_scope *s, node *tree, int val)
   case NODE_UNDEF:
     {
       int sym = new_msym(s, (mrb_sym)tree);
-      int undef = new_msym(s, mrb_intern(s->mrb, "undef_method"));
+      int undef = new_msym(s, mrb_intern2(s->mrb, "undef_method", 12));
 
       genop(s, MKOP_A(OP_TCLASS, cursp()));
       push();

--- a/src/error.c
+++ b/src/error.c
@@ -49,7 +49,7 @@ exc_initialize(mrb_state *mrb, mrb_value exc)
   mrb_value mesg;
 
   if (mrb_get_args(mrb, "|o", &mesg) == 1) {
-    mrb_iv_set(mrb, exc, mrb_intern(mrb, "mesg"), mesg);
+    mrb_iv_set(mrb, exc, mrb_intern2(mrb, "mesg", 4), mesg);
   }
   return exc;
 }
@@ -78,7 +78,7 @@ exc_exception(mrb_state *mrb, mrb_value self)
   if (argc == 0) return self;
   if (mrb_obj_equal(mrb, self, a)) return self;
   exc = mrb_obj_clone(mrb, self);
-  mrb_iv_set(mrb, exc, mrb_intern(mrb, "mesg"), a);
+  mrb_iv_set(mrb, exc, mrb_intern2(mrb, "mesg", 4), a);
 
   return exc;
 }
@@ -94,7 +94,7 @@ exc_exception(mrb_state *mrb, mrb_value self)
 static mrb_value
 exc_to_s(mrb_state *mrb, mrb_value exc)
 {
-  mrb_value mesg = mrb_attr_get(mrb, exc, mrb_intern(mrb, "mesg"));
+  mrb_value mesg = mrb_attr_get(mrb, exc, mrb_intern2(mrb, "mesg", 4));
 
   if (mrb_nil_p(mesg)) return mrb_str_new2(mrb, mrb_obj_classname(mrb, exc));
   return mesg;
@@ -144,13 +144,13 @@ exc_equal(mrb_state *mrb, mrb_value exc)
 {
   mrb_value obj;
   mrb_value mesg;
-  mrb_sym id_mesg = mrb_intern(mrb, "mesg");
+  mrb_sym id_mesg = mrb_intern2(mrb, "mesg", 4);
 
   mrb_get_args(mrb, "o", &obj);
   if (mrb_obj_equal(mrb, exc, obj)) return mrb_true_value();
 
   if (mrb_obj_class(mrb, exc) != mrb_obj_class(mrb, obj)) {
-    if ( mrb_respond_to(mrb, obj, mrb_intern(mrb, "message")) ) {
+    if ( mrb_respond_to(mrb, obj, mrb_intern2(mrb, "message", 7)) ) {
       mesg = mrb_funcall(mrb, obj, "message", 0);
     }
     else
@@ -275,7 +275,7 @@ mrb_bug_errno(const char *mesg, int errno_arg)
 int
 sysexit_status(mrb_state *mrb, mrb_value err)
 {
-  mrb_value st = mrb_iv_get(mrb, err, mrb_intern(mrb, "status"));
+  mrb_value st = mrb_iv_get(mrb, err, mrb_intern2(mrb, "status", 6));
   return mrb_fixnum(st);
 }
 
@@ -320,7 +320,7 @@ exception_call:
       //  /* undef */
       //  mrb_raise(mrb, E_TYPE_ERROR, "exception class/object expected");
       //}
-      if (mrb_respond_to(mrb, argv[0], mrb_intern(mrb, "exception"))) {
+      if (mrb_respond_to(mrb, argv[0], mrb_intern2(mrb, "exception", 9))) {
         mesg = mrb_funcall_argv(mrb, argv[0], "exception", n, argv+1);
       }
       else {

--- a/src/hash.c
+++ b/src/hash.c
@@ -268,7 +268,7 @@ mrb_hash_init_core(mrb_state *mrb, mrb_value hash)
     RHASH(hash)->flags |= MRB_HASH_PROC_DEFAULT;
     ifnone = block;
   }
-  mrb_iv_set(mrb, hash, mrb_intern(mrb, "ifnone"), ifnone);
+  mrb_iv_set(mrb, hash, mrb_intern2(mrb, "ifnone", 6), ifnone);
   return hash;
 }
 
@@ -433,7 +433,7 @@ mrb_hash_set_default(mrb_state *mrb, mrb_value hash)
 
   mrb_get_args(mrb, "o", &ifnone);
   mrb_hash_modify(mrb, hash);
-  mrb_iv_set(mrb, hash, mrb_intern(mrb, "ifnone"), ifnone);
+  mrb_iv_set(mrb, hash, mrb_intern2(mrb, "ifnone", 6), ifnone);
   RHASH(hash)->flags &= ~(MRB_HASH_PROC_DEFAULT);
 
   return ifnone;
@@ -484,7 +484,7 @@ mrb_hash_set_default_proc(mrb_state *mrb, mrb_value hash)
 
   mrb_get_args(mrb, "o", &ifnone);
   mrb_hash_modify(mrb, hash);
-  mrb_iv_set(mrb, hash, mrb_intern(mrb, "ifnone"), ifnone);
+  mrb_iv_set(mrb, hash, mrb_intern2(mrb, "ifnone", 6), ifnone);
   RHASH(hash)->flags |= MRB_HASH_PROC_DEFAULT;
 
   return ifnone;
@@ -769,7 +769,7 @@ mrb_hash_replace(mrb_state *mrb, mrb_value hash)
   else {
     ifnone = RHASH_IFNONE(hash2);
   }
-  mrb_iv_set(mrb, hash, mrb_intern(mrb, "ifnone"), ifnone);
+  mrb_iv_set(mrb, hash, mrb_intern2(mrb, "ifnone", 6), ifnone);
 
   return hash;
 }
@@ -1105,7 +1105,7 @@ hash_equal(mrb_state *mrb, mrb_value hash1, mrb_value hash2, int eql)
 
   if (mrb_obj_equal(mrb, hash1, hash2)) return mrb_true_value();
   if (mrb_type(hash2) != MRB_TT_HASH) {
-      if (!mrb_respond_to(mrb, hash2, mrb_intern(mrb, "to_hash"))) {
+      if (!mrb_respond_to(mrb, hash2, mrb_intern2(mrb, "to_hash", 7))) {
           return mrb_false_value();
       }
       if (eql)

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -78,10 +78,7 @@ inspect_obj(mrb_state *mrb, mrb_value obj, mrb_value str, int recur)
 int
 mrb_obj_basic_to_s_p(mrb_state *mrb, mrb_value obj)
 {
-    //const mrb_method_entry_t *me = mrb_method_entry(CLASS_OF(obj), mrb_intern("to_s"));
-    //if (me && me->def && me->def->type == VM_METHOD_TYPE_CFUNC &&
-    //me->def->body.cfunc.func == mrb_any_to_s)
-    struct RProc *me = mrb_method_search(mrb, mrb_class(mrb, obj), mrb_intern(mrb, "to_s"));
+    struct RProc *me = mrb_method_search(mrb, mrb_class(mrb, obj), mrb_intern2(mrb, "to_s", 4));
     if (me && MRB_PROC_CFUNC_P(me) && (me->body.func == mrb_any_to_s))
       return 1;
     return 0;

--- a/src/proc.c
+++ b/src/proc.c
@@ -164,8 +164,8 @@ mrb_init_proc(mrb_state *mrb)
   mrb_define_method(mrb, mrb->proc_class, "initialize_copy", mrb_proc_init_copy, ARGS_REQ(1));
 
   m = mrb_proc_new(mrb, call_irep);
-  mrb_define_method_raw(mrb, mrb->proc_class, mrb_intern(mrb, "call"), m);
-  mrb_define_method_raw(mrb, mrb->proc_class, mrb_intern(mrb, "[]"), m);
+  mrb_define_method_raw(mrb, mrb->proc_class, mrb_intern2(mrb, "call", 4), m);
+  mrb_define_method_raw(mrb, mrb->proc_class, mrb_intern2(mrb, "[]", 2), m);
 
   mrb_define_class_method(mrb, mrb->kernel_module, "lambda", proc_lambda, ARGS_NONE());    /* 15.3.1.2.6  */
   mrb_define_method(mrb, mrb->kernel_module,       "lambda", proc_lambda, ARGS_NONE());    /* 15.3.1.3.27 */

--- a/src/string.c
+++ b/src/string.c
@@ -519,10 +519,10 @@ mrb_str_cmp_m(mrb_state *mrb, mrb_value str1)
 
   mrb_get_args(mrb, "o", &str2);
   if (mrb_type(str2) != MRB_TT_STRING) {
-    if (!mrb_respond_to(mrb, str2, mrb_intern(mrb, "to_s"))) {
+    if (!mrb_respond_to(mrb, str2, mrb_intern2(mrb, "to_s", 4))) {
       return mrb_nil_value();
     }
-    else if (!mrb_respond_to(mrb, str2, mrb_intern(mrb, "<=>"))) {
+    else if (!mrb_respond_to(mrb, str2, mrb_intern2(mrb, "<=>", 3))) {
       return mrb_nil_value();
     }
     else {
@@ -558,7 +558,7 @@ mrb_str_equal(mrb_state *mrb, mrb_value str1, mrb_value str2)
   if (mrb_obj_equal(mrb, str1, str2)) return TRUE;
   if (mrb_type(str2) != MRB_TT_STRING) {
     if (mrb_nil_p(str2)) return FALSE;
-    if (!mrb_respond_to(mrb, str2, mrb_intern(mrb, "to_str"))) {
+    if (!mrb_respond_to(mrb, str2, mrb_intern2(mrb, "to_str", 6))) {
       return FALSE;
     }
     str2 = mrb_funcall(mrb, str2, "to_str", 0);
@@ -1718,7 +1718,6 @@ mrb_str_match_m(mrb_state *mrb, mrb_value self)
     mrb_raise(mrb, E_ARGUMENT_ERROR, "wrong number of arguments (%d for 1..2)", argc);
   re = argv[0];
   argv[0] = self;
-  //  result = mrb_funcall2(get_pat(re, 0), mrb_intern("match"), argc, argv);
   result = mrb_funcall(mrb, get_pat(mrb, re, 0), "match", 1, self);
   if (!mrb_nil_p(result) && mrb_block_given_p()) {
     return mrb_yield(mrb, b, result);

--- a/src/struct.c
+++ b/src/struct.c
@@ -27,6 +27,10 @@
 //#include "defines.h"
 #define mrb_long2int(n) ((int)(n))
 
+static const char c__members__str[] = "__members__";
+static const int  c__members__len = sizeof(c__members__str) - 1;
+
+#define MRB_INTERN(mrb, name) mrb_intern2(mrb, c##name##str, c##name##len)
 
 static struct RClass *
 struct_class(mrb_state *mrb)
@@ -62,7 +66,7 @@ mrb_struct_iv_get(mrb_state *mrb, mrb_value c, const char *name)
 mrb_value
 mrb_struct_s_members(mrb_state *mrb, mrb_value klass)
 {
-    mrb_value members = struct_ivar_get(mrb, klass, mrb_intern(mrb, "__members__"));
+    mrb_value members = struct_ivar_get(mrb, klass, MRB_INTERN(mrb, __members__));
 
     if (mrb_nil_p(members)) {
       mrb_raise(mrb, E_TYPE_ERROR, "uninitialized struct");
@@ -284,7 +288,7 @@ make_struct(mrb_state *mrb, mrb_value name, mrb_value members, struct RClass * k
     }
     MRB_SET_INSTANCE_TT(c, MRB_TT_STRUCT);
     nstr = mrb_obj_value(c);
-    mrb_iv_set(mrb, nstr, mrb_intern(mrb, "__members__"), members);
+    mrb_iv_set(mrb, nstr, MRB_INTERN(mrb, __members__), members);
 
     mrb_define_class_method(mrb, c, "new", mrb_instance_new, ARGS_ANY());
     mrb_define_class_method(mrb, c, "[]", mrb_instance_new, ARGS_ANY());
@@ -416,7 +420,7 @@ static long
 num_members(mrb_state *mrb, struct RClass *klass)
 {
     mrb_value members;
-    members = struct_ivar_get(mrb, mrb_obj_value(klass), mrb_intern(mrb, "__members__"));
+    members = struct_ivar_get(mrb, mrb_obj_value(klass), MRB_INTERN(mrb, __members__));
     if (mrb_type(members) != MRB_TT_ARRAY) {
       mrb_raise(mrb, E_TYPE_ERROR, "broken members");
     }

--- a/src/variable.c
+++ b/src/variable.c
@@ -308,7 +308,7 @@ const_get(mrb_state *mrb, struct RClass *base, mrb_sym sym)
   struct RClass *c = base;
   khash_t(iv) *h;
   khiter_t k;
-  mrb_sym cm = mrb_intern(mrb, "const_missing");
+  mrb_sym cm = mrb_intern2(mrb, "const_missing", 13);
 
  L_RETRY:
   while (c) {

--- a/src/vm.c
+++ b/src/vm.c
@@ -24,6 +24,11 @@
 #define STACK_INIT_SIZE 128
 #define CALLINFO_INIT_SIZE 32
 
+static const char cmethod_missingstr[] = "method_missing";
+static const int  cmethod_missinglen = sizeof(cmethod_missingstr) - 1;
+
+#define MRB_INTERN(mrb, name) (mrb_intern2(mrb, c##name##str, c##name##len))
+
 static void
 stack_init(mrb_state *mrb)
 {
@@ -196,7 +201,7 @@ mrb_funcall_with_block(mrb_state *mrb, mrb_value self, const char *name, int arg
   p = mrb_method_search_vm(mrb, &c, mid);
   if (!p) {
     undef = mid;
-    mid = mrb_intern(mrb, "method_missing");
+    mid = MRB_INTERN(mrb, method_missing);
     p = mrb_method_search_vm(mrb, &c, mid);
     n++; argc++;
   }
@@ -690,7 +695,7 @@ mrb_run(mrb_state *mrb, struct RProc *proc, mrb_value self)
       if (!m) {
         mrb_value sym = mrb_symbol_value(mid);
 
-        mid = mrb_intern(mrb, "method_missing");
+        mid = MRB_INTERN(mrb, method_missing);
         m = mrb_method_search_vm(mrb, &c, mid);
         if (n == CALL_MAXARGS) {
           mrb_ary_unshift(mrb, regs[a+1], sym);
@@ -822,7 +827,7 @@ mrb_run(mrb_state *mrb, struct RProc *proc, mrb_value self)
       m = mrb_method_search_vm(mrb, &c, mid);
       if (!m) {
         c = mrb->ci->proc->target_class;
-        mid = mrb_intern(mrb, "method_missing");
+        mid = MRB_INTERN(mrb, method_missing);
         m = mrb_method_search_vm(mrb, &c, mid);
         if (n == CALL_MAXARGS) {
           mrb_ary_unshift(mrb, regs[a+1], mrb_symbol_value(ci->mid));
@@ -1106,7 +1111,7 @@ mrb_run(mrb_state *mrb, struct RProc *proc, mrb_value self)
       if (!m) {
         mrb_value sym = mrb_symbol_value(mid);
 
-        mid = mrb_intern(mrb, "method_missing");
+        mid = MRB_INTERN(mrb, method_missing);
         m = mrb_method_search_vm(mrb, &c, mid);
         if (n == CALL_MAXARGS) {
           mrb_ary_unshift(mrb, regs[a+1], sym);


### PR DESCRIPTION
This is related on #301.  Similar to Matz's patch 19638ded7367520.
mrb_intern_str is sophisticated. But mrb_intern2 is more lightweight.
Anyway, places I changed by this fix should be fixed.
