### PR TITLE
Remove magic numbers in mrb_funcall()

### DIFF
--- a/include/mrbconf.h
+++ b/include/mrbconf.h
@@ -23,6 +23,10 @@
 
 #undef  HAVE_UNISTD_H /* WINDOWS */
 #define HAVE_UNISTD_H /* LINUX */
+
+#define MRB_FUNCALL_ARGC_MAX 16U /* Allocate arrays using auto variable. */
+//#undef MRB_FUNCALL_ARGC_MAX /* Allocate arrays using mrb_malloc if undefned. */
+
 /* end of configuration */
 
 #ifdef MRB_USE_FLOAT


### PR DESCRIPTION
There is two magic numbers 5, 16 in mrb_funcall().

I traced function call flow and I think there is no need to prepare 5 of nil. It should be removed.

16 is not too bad this source tree. But it's possible to use by user applications.
And it is not recommended to use magic numbers in general.
(In case we keep magic number, it's better to insert assert() for avoiding stack overflow.)
