### PR TITLE
Sprintf NotImplementedError

### DIFF
--- a/mrblib/print.rb
+++ b/mrblib/print.rb
@@ -50,11 +50,21 @@ module Kernel
 
   ##
   # Invoke method +sprintf+ and pass +*args+ to it.
-  # Pass return value to *print* of STDOUT.
+  # Pass return value to +print+ of STDOUT.
   def printf(*args)
     if Kernel.respond_to?(:sprintf)
       __printstr__(sprintf(*args))
     else
+      raise NotImplementedError.new('sprintf not available')
+    end
+  end
+
+  ##
+  # +sprintf+ is defined in +src/sprintf.c+
+  # This stub method is only to inform the user
+  # that +sprintf+ isn't implemented.
+  unless Kernel.respond_to?(:sprintf)
+    def sprintf(*args)
       raise NotImplementedError.new('sprintf not available')
     end
   end


### PR DESCRIPTION
This patch raises NotImplementedError for sprintf and printf in case sprintf wasn't compiled into the mruby-core.
