### PR TITLE
Make strucdata optional if ENABLE_STRUCT is activated

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -90,7 +90,9 @@ typedef struct {
     struct RArray array;
     struct RHash hash;
     struct RRange range;
+#ifdef ENABLE_STRUCT
     struct RStruct structdata;
+#endif
     struct RProc procdata;
 #ifdef ENABLE_REGEXP
     struct RMatch match;


### PR DESCRIPTION
This patch removes the structdata out of the GC union in case there is no Struct activated inside of the mruby-core.
