### PR TITLE
Initialize mt of module with khash.

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -1065,6 +1065,7 @@ struct RClass *
 mrb_module_new(mrb_state *mrb)
 {
   struct RClass *m = (struct RClass*)mrb_obj_alloc(mrb, MRB_TT_MODULE, mrb->module_class);
+  m->mt = kh_init(mt, mrb);
 
   return m;
 }


### PR DESCRIPTION
This patch initializes 'mt' member of module with khash.

This solves the following issues:

1:  Methods of a module cannot be called if the methods are defined after the module is included.

``` ruby
module M; end
class A
  include M
end
module M
  def m; end  # define method 'm' after M is included by A.
end
A.new.m
```

In this case, 'm' cannot be called and NoMethodError is raised.

'mt' member of module is shared with Mixed-in module holder, MRB_TT_ICLASS instance, when the module is included.
(Please refer to mrb_include_module function in class.c.)
So I think that 'mt' should be initialized before mrb_include_module is called.

2:  'kind_of?' does not return correct result.

``` ruby
module M; end
module N; end
class A
  include M
end
A.new.kind_of?(M)  # => true (correct)
A.new.kind_of?(N)  # => true (wrong)
```

In the current implementation, 'kind_of?' is checked in mrb_obj_is_kind_of in object.c.
mrb_obj_is_kind_of compares classes as follows:

``` c
  while (cl) {
    if (cl == c || cl->mt == c->mt)
      return 1/* TRUE */;
    cl = cl->super;
  }
  return 0/* FALSE */;
```

It seems that this function expects 'mt' has been already initialized.
