### PR TITLE
Suppress "warning: array subscript has type ‘char’ [-Wchar-subscripts]".

### DIFF
--- a/src/codegen.c
+++ b/src/codegen.c
@@ -803,7 +803,7 @@ readint_float(codegen_scope *s, const char *p, int base)
   int n;
 
   while (p <= e) {
-    char c = tolower(*p);
+    char c = tolower((unsigned char)*p);
     for (n=0; n<base; n++) {
       if (mrb_digitmap[n] == c) {
 	f *= base;

--- a/src/string.c
+++ b/src/string.c
@@ -868,12 +868,12 @@ mrb_str_capitalize_bang(mrb_state *mrb, mrb_value str)
   if (s->len == 0 || !s->ptr) return mrb_nil_value();
   p = s->ptr; pend = s->ptr + s->len;
   if (ISLOWER(*p)) {
-    *p = toupper(*p);
+    *p = toupper((unsigned char)*p);
     modify = 1;
   }
   while (++p < pend) {
     if (ISUPPER(*p)) {
-      *p = tolower(*p);
+      *p = tolower((unsigned char)*p);
       modify = 1;
     }
   }
@@ -1081,7 +1081,7 @@ mrb_str_downcase_bang(mrb_state *mrb, mrb_value str)
   pend = s->ptr + s->len;
   while (p < pend) {
     if (ISUPPER(*p)) {
-      *p = tolower(*p);
+      *p = tolower((unsigned char)*p);
       modify = 1;
     }
     p++;
@@ -2759,7 +2759,7 @@ mrb_str_upcase_bang(mrb_state *mrb, mrb_value str)
   pend = RSTRING_END(str);
   while (p < pend) {
     if (ISLOWER(*p)) {
-      *p = toupper(*p);
+      *p = toupper((unsigned char)*p);
       modify = 1;
     }
     p++;


### PR DESCRIPTION
They're possible to crash the runtime.

(I just did type cast easily. But I think the best fix is to  add asserts if the value is positive. But I didn't add asserts.)
