### PR TITLE
Use mrb_calloc if you want zero cleard buffers.

### DIFF
--- a/src/array.c
+++ b/src/array.c
@@ -46,8 +46,7 @@ ary_new_capa(mrb_state *mrb, int capa)
   }
 
   a = (struct RArray*)mrb_obj_alloc(mrb, MRB_TT_ARRAY, mrb->array_class);
-  a->ptr = mrb_malloc(mrb, blen);
-  memset(a->ptr, 0, blen);
+  a->ptr = mrb_calloc(mrb, blen, 1);
   a->aux.capa = capa;
   a->len = 0;
 

--- a/src/dump.c
+++ b/src/dump.c
@@ -460,11 +460,10 @@ calc_crc_section(mrb_state *mrb, mrb_irep *irep, uint16_t *crc, int section)
   default: return MRB_DUMP_GENERAL_FAILURE;
   }
 
-  if ((buf = mrb_malloc(mrb, buf_size)) == 0)
+  if ((buf = mrb_calloc(mrb, 1, buf_size)) == 0)
     return MRB_DUMP_GENERAL_FAILURE;
 
   buf_top = buf;
-  memset(buf, 0, buf_size);
 
   switch (section) {
   case DUMP_IREP_HEADER: buf += write_irep_header(mrb, irep, buf, type); break;
@@ -598,10 +597,8 @@ dump_irep_record(mrb_state *mrb, int irep_no, FILE* fp, uint32_t *rlen)
   if (irep_record_size == 0)
     return MRB_DUMP_GENERAL_FAILURE;
 
-  if ((buf = mrb_malloc(mrb, irep_record_size)) == 0)
+  if ((buf = mrb_calloc(mrb, 1, irep_record_size)) == 0)
     return MRB_DUMP_GENERAL_FAILURE;
-
-  memset( buf, 0, irep_record_size);
 
   if ((rc = write_irep_record(mrb, irep_no, buf, rlen, DUMP_TYPE_HEX)) != MRB_DUMP_OK) {
     rc = MRB_DUMP_GENERAL_FAILURE;

--- a/src/gc.c
+++ b/src/gc.c
@@ -246,11 +246,9 @@ unlink_free_heap_page(mrb_state *mrb, struct heap_page *page)
 static void
 add_heap(mrb_state *mrb)
 {
-  struct heap_page *page = mrb_malloc(mrb, sizeof(struct heap_page));
+  struct heap_page *page = mrb_calloc(mrb, 1, sizeof(struct heap_page));
   RVALUE *p, *e;
   struct RBasic *prev = NULL;
-
-  memset(page, 0, sizeof(struct heap_page));
 
   for (p = page->objects, e=p+HEAP_PAGE_SIZE; p<e; p++) {
     p->as.free.tt = MRB_TT_FREE;

--- a/src/parse.y
+++ b/src/parse.y
@@ -4792,8 +4792,7 @@ mrbc_context_new(mrb_state *mrb)
 {
   mrbc_context *c;
 
-  c = mrb_malloc(mrb, sizeof(mrbc_context));
-  memset(c, 0, sizeof(mrbc_context));
+  c = mrb_calloc(mrb, 1, sizeof(mrbc_context));
   return c;
 }
 

--- a/src/state.c
+++ b/src/state.c
@@ -76,8 +76,7 @@ mrb_add_irep(mrb_state *mrb, int idx)
     int max = 256;
 
     if (idx > max) max = idx+1;
-    mrb->irep = mrb_malloc(mrb, sizeof(mrb_irep*)*max);
-    memset(mrb->irep, 0, sizeof(mrb_irep*)*max);
+    mrb->irep = mrb_calloc(mrb, max, sizeof(mrb_irep*));
     mrb->irep_capa = max;
   }
   else if (mrb->irep_capa <= idx) {

--- a/src/vm.c
+++ b/src/vm.c
@@ -28,16 +28,14 @@ static void
 stack_init(mrb_state *mrb)
 {
   /* assert(mrb->stack == NULL); */
-  mrb->stbase = mrb_malloc(mrb, sizeof(mrb_value) * STACK_INIT_SIZE);
-  memset(mrb->stbase, 0, sizeof(mrb_value) * STACK_INIT_SIZE);
+  mrb->stbase = mrb_calloc(mrb, STACK_INIT_SIZE, sizeof(mrb_value));
   mrb->stend = mrb->stbase + STACK_INIT_SIZE;
   mrb->stack = mrb->stbase;
 
   /* assert(mrb->ci == NULL); */
-  mrb->cibase = mrb_malloc(mrb, sizeof(mrb_callinfo)*CALLINFO_INIT_SIZE);
+  mrb->cibase = mrb_calloc(mrb, CALLINFO_INIT_SIZE, sizeof(mrb_callinfo));
   mrb->ciend = mrb->cibase + CALLINFO_INIT_SIZE;
   mrb->ci = mrb->cibase;
-  memset(mrb->ci, 0, sizeof(mrb_callinfo));
   mrb->ci->target_class = mrb->object_class;
 }
 


### PR DESCRIPTION
mrb_calloc() is safer than mrb_malloc() & memset().
