### PR TITLE
clean -Wunused-function when defined DISABLE_STDIO

### DIFF
--- a/src/parse.y
+++ b/src/parse.y
@@ -4934,6 +4934,8 @@ mrb_load_string(mrb_state *mrb, const char *s)
   return mrb_load_string_cxt(mrb, s, NULL);
 }
 
+#ifdef ENABLE_STDIO
+
 static void
 dump_prefix(int offset)
 {
@@ -4951,6 +4953,8 @@ dump_recur(mrb_state *mrb, node *tree, int offset)
     tree = tree->cdr;
   }
 }
+
+#endif
 
 void
 parser_dump(mrb_state *mrb, node *tree, int offset)


### PR DESCRIPTION
cleans these warnings;

```
./parse.y:4938:1: warning: ‘dump_prefix’ defined but not used [-Wunused-function]
./parse.y:4947:1: warning: ‘dump_recur’ defined but not used [-Wunused-function]
```
