### PR TITLE
Skip "Syntax OK" if syntax isn't ok

### DIFF
--- a/tools/mruby/mruby.c
+++ b/tools/mruby/mruby.c
@@ -196,7 +196,7 @@ main(int argc, char **argv)
       v = mrb_load_file_cxt(mrb, args.rfp, c);
     }
     mrbc_context_free(mrb, c);
-    if (args.check_syntax) {
+    if (args.check_syntax && !mrb->exc) {
       printf("Syntax OK\n");
     }
     else if (!mrb_undef_p(v) && mrb->exc) {


### PR DESCRIPTION
This patch includes an additional check if there was an exception raised during the Syntax check. If yes then the "Syntax OK" print out is skipped.

Before

```
$ ./bin/mruby -c test.rb 
-c:2:0: syntax error, unexpected $end, expecting '}'
Syntax OK
```

After

```
$ ./bin/mruby -c test.rb 
-c:2:0: syntax error, unexpected $end, expecting '}'
```

Content

```
$ cat test.rb 
{
```
