### PR TITLE
Undef Class#extend_object.

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -1444,4 +1444,5 @@ mrb_init_class(mrb_state *mrb)
 
   mrb_define_method(mrb, mod, "===", mrb_mod_eqq, ARGS_REQ(1));
   mrb_undef_method(mrb, cls, "append_features");
+  mrb_undef_method(mrb, cls, "extend_object");
 }


### PR DESCRIPTION
Undefine Class#extend_object, as well as append_features.
