### PR TITLE
Modify allocation size of mrb->irep.

### DIFF
--- a/src/state.c
+++ b/src/state.c
@@ -83,7 +83,7 @@ mrb_add_irep(mrb_state *mrb, int idx)
     while (mrb->irep_capa <= idx) {
       mrb->irep_capa *= 2;
     }
-    mrb->irep = mrb_realloc(mrb, mrb->irep, sizeof(mrb_irep)*mrb->irep_capa);
+    mrb->irep = mrb_realloc(mrb, mrb->irep, sizeof(mrb_irep*)*mrb->irep_capa);
   }
 }
 


### PR DESCRIPTION
The type of mrb->irep is 'mrb_irep **', so allocation size should not be 'sizeof(mrb_irep)*mrb->irep_capa' but 'sizeof(mrb_irep*)*mrb->irep_capa'.
