### PR TITLE
fix: SIZE_MAX is not defined in "stdint.h"

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -17,6 +17,10 @@
 #include "mruby/data.h"
 #include "mruby/variable.h"
 
+#ifndef SIZE_MAX
+#include <limits.h> // for SIZE_MAX
+#endif
+
 /*
   = Tri-color Incremental Garbage Collection
 


### PR DESCRIPTION
On some platforms, "SIZE_MAX" is defined in "limits.h" instead of "stdint.h".
