### PR TITLE
Modify ci->nregs.

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -718,7 +718,12 @@ mrb_run(mrb_state *mrb, struct RProc *proc, mrb_value self)
       mrb->stack += a;
 
       if (MRB_PROC_CFUNC_P(m)) {
-	ci->nregs = n + 1;
+        if (n == CALL_MAXARGS) {
+          ci->nregs = 3;
+        }
+        else {
+          ci->nregs = n + 2;
+        }
         mrb->stack[0] = m->body.func(mrb, recv);
         mrb->arena_idx = ai;
         if (mrb->exc) goto L_RAISE;


### PR DESCRIPTION
I think that nregs should be `n+2` to include block.
If `n` is `CALL_MAXARGS`, nregs should be 3 (self, array and block).

Please review this patch because I don't have confidence.
