### PR TITLE
Modify return value of mrbtest.

### DIFF
--- a/test/driver.c
+++ b/test/driver.c
@@ -11,6 +11,7 @@
 #include <mruby/proc.h>
 #include <mruby/data.h>
 #include <mruby/compile.h>
+#include <mruby/variable.h>
 
 void
 mrb_init_mrbtest(mrb_state *);
@@ -23,12 +24,24 @@ void print_hint(void)
   printf("Thanks :)\n\n");
 }
 
+static int
+check_error(mrb_state *mrb)
+{
+  /* Error check */
+  /* $ko_test and $kill_test should be 0 */
+  mrb_value ko_test = mrb_gv_get(mrb, mrb_intern(mrb, "$ko_test"));
+  mrb_value kill_test = mrb_gv_get(mrb, mrb_intern(mrb, "$kill_test"));
+
+  return FIXNUM_P(ko_test) && mrb_fixnum(ko_test) == 0 && FIXNUM_P(kill_test) && mrb_fixnum(kill_test) == 0;
+}
+
 int
 main(void)
 {
   mrb_state *mrb;
   mrb_value return_value;
   const char *prog = "report()";
+  int ret = EXIT_SUCCESS;
 
   print_hint();
 
@@ -46,11 +59,12 @@ main(void)
   if (mrb->exc) {
     mrb_p(mrb, return_value);
     mrb->exc = 0;
+    ret = EXIT_FAILURE;
   }
-  else {
-    /* no */
+  else if (!check_error(mrb)) {
+    ret = EXIT_FAILURE;
   }
   mrb_close(mrb);
 
-  return EXIT_SUCCESS;
+  return ret;
 }


### PR DESCRIPTION
This is an improvement for CI, such as Travis.

If this patch is applied, mrbtest returns EXIT_SUCCESS only when $ko_test and $kill_test are 0.
