### PR TITLE
MRB_HEAP_PAGE_SIZE: new definition.

### DIFF
--- a/include/mrbconf.h
+++ b/include/mrbconf.h
@@ -23,6 +23,8 @@
 
 //#define MRB_FUNCALL_ARGC_MAX 16 /* argv size in mrb_funcall */
 
+#define MRB_HEAP_PAGE_SIZE 256
+
 #undef  HAVE_UNISTD_H /* WINDOWS */
 #define HAVE_UNISTD_H /* LINUX */
 

--- a/src/gc.c
+++ b/src/gc.c
@@ -189,7 +189,11 @@ mrb_free(mrb_state *mrb, void *p)
   return (mrb->allocf)(mrb, p, 0);
 }
 
-#define HEAP_PAGE_SIZE 1024
+#if defined(MRB_HEAP_PAGE_SIZE)
+# define HEAP_PAGE_SIZE MRB_HEAP_PAGE_SIZE
+#else
+# define HEAP_PAGE_SIZE 1024
+#endif
 
 struct heap_page {
   struct RBasic *freelist;


### PR DESCRIPTION
This is for HEAP_PAGE_SIZE customization support.

And I modified the value of current HEAP_PAGE_SIZE. It was too large to run tiny scripts like mrbtest.exe .
