### PR TITLE
Fix message lengths.

### DIFF
--- a/src/parse.y
+++ b/src/parse.y
@@ -4875,7 +4875,8 @@ load_exec(mrb_state *mrb, parser_state *p, mrbc_context *c)
       return mrb_undef_value();
     }
     else {
-      mrb->exc = (struct RObject*)mrb_object(mrb_exc_new(mrb, E_SYNTAX_ERROR, "syntax error", 0));
+      static const char msg[] = "syntax error";
+      mrb->exc = (struct RObject*)mrb_object(mrb_exc_new(mrb, E_SYNTAX_ERROR, msg, sizeof(msg) - 1));
       mrb_parser_free(p);
       return mrb_nil_value();
     }
@@ -4883,7 +4884,8 @@ load_exec(mrb_state *mrb, parser_state *p, mrbc_context *c)
   n = mrb_generate_code(mrb, p->tree);
   mrb_parser_free(p);
   if (n < 0) {
-    mrb->exc = (struct RObject*)mrb_object(mrb_exc_new(mrb, E_SCRIPT_ERROR, "codegen error", 0));
+    static const char msg[] = "codegen error";
+    mrb->exc = (struct RObject*)mrb_object(mrb_exc_new(mrb, E_SCRIPT_ERROR, msg, sizeof(msg) - 1));
     return mrb_nil_value();
   }
   if (c) {

--- a/src/vm.c
+++ b/src/vm.c
@@ -905,13 +905,13 @@ mrb_run(mrb_state *mrb, struct RProc *proc, mrb_value self)
       if (lv == 0) stack = regs + 1;
       else {
         struct REnv *e = uvenv(mrb, lv-1);
-	if (!e) {
-	  mrb_value exc;
-	  static const char m[] = "super called outside of method";
-	  exc = mrb_exc_new(mrb, E_NOMETHOD_ERROR, m, sizeof(m) - 1);
-	  mrb->exc = (struct RObject*)mrb_object(exc);
-	  goto L_RAISE;
-	}
+        if (!e) {
+          mrb_value exc;
+          static const char m[] = "super called outside of method";
+          exc = mrb_exc_new(mrb, E_NOMETHOD_ERROR, m, sizeof(m) - 1);
+          mrb->exc = (struct RObject*)mrb_object(exc);
+          goto L_RAISE;
+        }
         stack = e->stack + 1;
       }
       if (r == 0) {
@@ -1598,9 +1598,10 @@ mrb_run(mrb_state *mrb, struct RProc *proc, mrb_value self)
     CASE(OP_TCLASS) {
       /* A B    R(A) := target_class */
       if (!mrb->ci->target_class) {
-	mrb_value exc = mrb_exc_new(mrb, E_TYPE_ERROR, "no target class or module", 25);
-	mrb->exc = (struct RObject*)mrb_object(exc);
-	goto L_RAISE;
+        static const char msg[] = "no target class or module";
+        mrb_value exc = mrb_exc_new(mrb, E_TYPE_ERROR, msg, sizeof(msg) - 1);
+        mrb->exc = (struct RObject*)mrb_object(exc);
+        goto L_RAISE;
       }
       regs[GETARG_A(i)] = mrb_obj_value(mrb->ci->target_class);
       NEXT;


### PR DESCRIPTION
load_exec(): Fix message lenghtes in mrb_exc_new().
mrb_run(): Fix not to use a magic number but sizeof.
