### PR TITLE
fixed showing no 'Usage'.

### DIFF
--- a/tools/mruby/mruby.c
+++ b/tools/mruby/mruby.c
@@ -60,6 +60,8 @@ parse_args(mrb_state *mrb, int argc, char **argv, struct _args *args)
 
   memset(args, 0, sizeof(*args));
 
+  if (argc == 1) return -2;
+
   for (argc--,argv++; argc > 0; argc--,argv++) {
     char *item;
     if (argv[0][0] != '-') break;
@@ -121,7 +123,7 @@ append_cmdline:
       else return -3;
       return 0;
     default:
-      break;
+      return -4;
     }
   }
 


### PR DESCRIPTION
mruby command not shows 'Usage: [swiches] programfile' with no switches or wrong switches.

Not Fixed
$ mruby                /\* no switches _/
$ mruby -h             /_ wrong switches */

Fixed
$ mruby
or
$ mruby -h
Usage: mruby [switches] programfile
  switches:
  -b           load and execute RiteBinary (mrb) file
  -c           check syntax only
  -e 'command' one line of script
  -v           print version number, then run in verbose mode
  --verbose    run in verbose mode
  --version    print the version
  --copyright  print the copyright
