### PR TITLE
Canonicalize NaN value in NaN boxing environment

### DIFF
--- a/include/mruby/value.h
+++ b/include/mruby/value.h
@@ -134,7 +134,12 @@ mrb_float_value(mrb_float f)
 {
   mrb_value v;
 
-  v.f = f;
+  if (f != f) {
+    v.ttt = 0x7ff80000;
+    v.value.i = 0;
+  } else {
+    v.f = f;
+  }
   return v;
 }
 #endif	/* MRB_NAN_BOXING */


### PR DESCRIPTION
Currently NaN is not canonicalized in NaN boxing environment.
So if NaN value that can be recognized as other mrb value is accidentally generated, mrb_float_value fails to generate float NaN value.

Example code is following.

``` c++
// compiled in Fedora 32bit
//
// MRB_NAN_BOXING is enabled.
//
#include <iostream>
#include <cassert>
#include <cmath>
#include "mruby.h"

int main(int argc, char** argv) {
        union {
                mrb_value bytes;
                double value;
        } v;
        assert(sizeof(mrb_value) == sizeof(double));

        // Assign fixnum pattern intensionally, but this is valid float NaN.
        v.bytes = mrb_fixnum_value(0);

        // Ensure v.value is valid NaN.
        assert(v.value != v.value);

        // This is result of mrb_float_value, but type tag is fixnum.
        mrb_value value = mrb_float_value(v.value);
        std::cout << mrb_type(value) << std::endl;  // 4
        return 0;
}
```

So we should canonizalize NaN value bit pattern.
