### PR TITLE
Improve handling of "exit" and "quit" in mirb. 

### DIFF
--- a/tools/mirb/mirb.c
+++ b/tools/mirb/mirb.c
@@ -182,12 +182,19 @@ main(void)
     last_code_line[char_index] = '\0';
 
     if ((strcmp(last_code_line, "quit") == 0) || (strcmp(last_code_line, "exit") == 0)) {
-      /*:quit the program */
-      break;
+      if (!code_block_open || !parser->sterm){
+        break;
+      }
+      else{
+        /* count the quit/exit commands as strings if in a quote block */
+        strcat(ruby_code, "\n");
+        strcat(ruby_code, last_code_line);
+      }
     }
+
     else {
       if (code_block_open) {
-	strcat(ruby_code, "\n");
+        strcat(ruby_code, "\n");
         strcat(ruby_code, last_code_line);
       }
       else {


### PR DESCRIPTION
Two things: `exit` / `quit` only "resetting the block" seems non-obvious to users. In my opinion, it should just terminate. Additionally, this pull request handles the case of "exit" and "quit" as strings between a quotation block. 

Previously, 

```
> "
* exit
> "
* 
* 
```

Now

```

> "
* exit
* "
 => "\nexit\n"
> 
```
