### PR TITLE
Modify reference to ci.

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -287,7 +287,7 @@ mrb_funcall_with_block(mrb_state *mrb, mrb_value self, mrb_sym mid, int argc, mr
     val = p->body.func(mrb, self);
     mrb->arena_idx = ai;
     mrb_gc_protect(mrb, val);
-    mrb->stack = mrb->stbase + ci->stackidx;
+    mrb->stack = mrb->stbase + mrb->ci->stackidx;
     cipop(mrb);
   }
   else {
@@ -331,7 +331,7 @@ mrb_yield_internal(mrb_state *mrb, mrb_value b, int argc, mrb_value *argv, mrb_v
 
   if (MRB_PROC_CFUNC_P(p)) {
     val = p->body.func(mrb, self);
-    mrb->stack = mrb->stbase + ci->stackidx;
+    mrb->stack = mrb->stbase + mrb->ci->stackidx;
     cipop(mrb);
   }
   else {
@@ -772,7 +772,7 @@ mrb_run(mrb_state *mrb, struct RProc *proc, mrb_value self)
         mrb->arena_idx = ai;
         if (mrb->exc) goto L_RAISE;
         /* pop stackpos */
-        regs = mrb->stack = mrb->stbase + ci->stackidx;
+        regs = mrb->stack = mrb->stbase + mrb->ci->stackidx;
         cipop(mrb);
         NEXT;
       }
@@ -830,7 +830,7 @@ mrb_run(mrb_state *mrb, struct RProc *proc, mrb_value self)
         mrb->arena_idx = ai;
         if (mrb->exc) goto L_RAISE;
         /* pop stackpos */
-        regs = mrb->stack = mrb->stbase + ci->stackidx;
+        regs = mrb->stack = mrb->stbase + mrb->ci->stackidx;
         cipop(mrb);
         NEXT;
       }
@@ -903,7 +903,7 @@ mrb_run(mrb_state *mrb, struct RProc *proc, mrb_value self)
         mrb->arena_idx = ai;
         if (mrb->exc) goto L_RAISE;
         /* pop stackpos */
-        regs = mrb->stack = mrb->stbase + ci->stackidx;
+        regs = mrb->stack = mrb->stbase + mrb->ci->stackidx;
         cipop(mrb);
         NEXT;
       }
@@ -1619,7 +1619,7 @@ mrb_run(mrb_state *mrb, struct RProc *proc, mrb_value self)
         mrb->arena_idx = ai;
         if (mrb->exc) goto L_RAISE;
         /* pop stackpos */
-        regs = mrb->stack = mrb->stbase + ci->stackidx;
+        regs = mrb->stack = mrb->stbase + mrb->ci->stackidx;
         cipop(mrb);
         NEXT;
       }


### PR DESCRIPTION
Refer to mrb->ci instead of local variable `ci` after m->body.func is called,
because mrb->ci may be changed in m->body.func.
