### PR TITLE
Modify irep initialization and GC.

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -587,8 +587,10 @@ root_scan_phase(mrb_state *mrb)
     mrb_gc_mark(mrb, (struct RBasic*)ci->target_class);
   }
   /* mark irep pool */
-  for (i=0; i<mrb->irep_len; i++) {
-    if (mrb->irep) {
+  if (mrb->irep) {
+    size_t len = mrb->irep_len;
+    if (len > mrb->irep_capa) len = mrb->irep_capa;
+    for (i=0; i<len; i++) {
       mrb_irep *irep = mrb->irep[i];
       if (!irep) continue;
       for (j=0; j<irep->plen; j++) {

--- a/src/state.c
+++ b/src/state.c
@@ -83,10 +83,12 @@ mrb_add_irep(mrb_state *mrb, int idx)
     mrb->irep_capa = max;
   }
   else if (mrb->irep_capa <= idx) {
+    size_t old_capa = mrb->irep_capa;
     while (mrb->irep_capa <= idx) {
       mrb->irep_capa *= 2;
     }
     mrb->irep = (mrb_irep **)mrb_realloc(mrb, mrb->irep, sizeof(mrb_irep*)*mrb->irep_capa);
+    memset(mrb->irep + old_capa, 0, sizeof(mrb_irep*) * (mrb->irep_capa - old_capa));
   }
 }
 


### PR DESCRIPTION
Initialize mrb->irep array with 0 when realloc is called.
`root_scan_phase` expect that mrb->irep array should be initialized with 0.

Refer to irep_len and irep_capa when irep is marked by GC.
mrb->irep_len sometimes exceeds mrb->irep_capa in gc.c,
because irep_len is incremented in scope_new and then irep_capa is set in scope_finish via mrb_add_irep.
So irep_len can be larger than irep_capa if GC occurs just after scape_new is called.
