### PR TITLE
Publish mrb_hash_delete_key.

### DIFF
--- a/include/mruby/hash.h
+++ b/include/mruby/hash.h
@@ -26,6 +26,7 @@ mrb_value mrb_hash_new(mrb_state *mrb);
 void mrb_hash_set(mrb_state *mrb, mrb_value hash, mrb_value key, mrb_value val);
 mrb_value mrb_hash_get(mrb_state *mrb, mrb_value hash, mrb_value key);
 mrb_value mrb_hash_fetch(mrb_state *mrb, mrb_value hash, mrb_value key, mrb_value def);
+mrb_value mrb_hash_delete_key(mrb_state *mrb, mrb_value hash, mrb_value key);
 mrb_value mrb_hash(mrb_state *mrb, mrb_value obj);
 
 /* RHASH_TBL allocates st_table if not available. */

--- a/src/hash.c
+++ b/src/hash.c
@@ -488,7 +488,7 @@ mrb_hash_set_default_proc(mrb_state *mrb, mrb_value hash)
   return ifnone;
 }
 
-static mrb_value
+mrb_value
 mrb_hash_delete_key(mrb_state *mrb, mrb_value hash, mrb_value key)
 {
   khash_t(ht) *h = RHASH_TBL(hash);


### PR DESCRIPTION
This is not a bug fix but a request.

I want hash.c to publish `mrb_hash_delete_key` as well as `mrb_hash_set`, `mrb_hash_get` and `mrb_hash_fetch`, because "delete" is also a primitive operation of hash.
