### PR TITLE
Define DBL_DIG only if it wasn't previously defined

### DIFF
--- a/src/string.c
+++ b/src/string.c
@@ -2598,7 +2598,10 @@ mrb_cstr_to_dbl(mrb_state *mrb, const char * p, int badcheck)
   double d;
 //  const char *ellipsis = "";
 //  int w;
-#define DBL_DIG 16
+#if !defined(DBL_DIG)
+  #define DBL_DIG 16
+#endif
+
   enum {max_width = 20};
 #define OutOfRange() (((w = end - p) > max_width) ? \
       (w = max_width, ellipsis = "...") : \


### PR DESCRIPTION
DBL_DIG may already be defined on the target system, defining it without checking first may overwrite system values.
