### PR TITLE
Use PRId32 in c99 environment.

### DIFF
--- a/src/cdump.c
+++ b/src/cdump.c
@@ -6,6 +6,12 @@
 
 #include "mruby/cdump.h"
 
+#if defined(__STDC__) && defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
+#include <inttypes.h>
+#else
+#define PRId32 "x"
+#endif
+
 #include <string.h>
 
 #include "mruby/irep.h"
@@ -29,7 +35,7 @@ make_cdump_isec(mrb_state *mrb, int irep_no, FILE *f)
   if (irep->ilen > 0) {
     SOURCE_CODE  ("static mrb_code iseq_%d[] = {", irep_no);
     for (i=0; i<irep->ilen; i++)
-      SOURCE_CODE("  0x%08x,"                    , irep->iseq[i]);
+      SOURCE_CODE("  0x%08"PRId32","                    , irep->iseq[i]);
     SOURCE_CODE0 ("};");
     SOURCE_CODE0 ("");
   }


### PR DESCRIPTION
This issue is discussed before. It is the second try.
In case sizeof(uint32_t) != sizeof(unsigned int), we got warnings at cdump.c.
Using PRId32 macro is the best way to avoid it.
But terrible VC++ doesn't have PRId32 that is supported since C99.

This patch is to define PRId32 as "x" if the complier doesn't support C99.
