### PR TITLE
Bugfix for crash if main was extended with a module.

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -786,6 +786,8 @@ mrb_singleton_class(mrb_state *mrb, mrb_value v)
     return mrb_obj_value(mrb->false_class);
   case MRB_TT_TRUE:
     return mrb_obj_value(mrb->true_class);
+  case MRB_TT_MAIN:
+    return mrb_obj_value(mrb->object_class);
   case MRB_TT_SYMBOL:
   case MRB_TT_FIXNUM:
   case MRB_TT_FLOAT:

--- a/test/t/kernel.rb
+++ b/test/t/kernel.rb
@@ -204,6 +204,16 @@ assert('Kernel#extend', '15.3.1.3.13') do
   a.respond_to?(:test_method) == true && b.respond_to?(:test_method) == false
 end
 
+assert('Kernel#extend works on toplevel', '15.3.1.3.13') do
+  module Test4ExtendModule
+    def test_method; end
+  end
+  # This would crash... 
+  extend(Test4ExtendModule)
+
+  respond_to?(:test_method) == true
+end
+
 assert('Kernel#global_variables', '15.3.1.3.14') do
   global_variables.class == Array
 end


### PR DESCRIPTION
The following code would crash with an segmentation violation: 

module Foo ; end ; extend Foo

This was because the top-level main case wasn't handled correctly. This pull request contains the bugfix and a test case in test/t/kernel.rb.

Kind Regards,

B. 
