### PR TITLE
Fix disappearance of a local variable when return statement is called

### DIFF
--- a/src/codegen.c
+++ b/src/codegen.c
@@ -1490,6 +1490,7 @@ codegen(codegen_scope *s, node *tree, int val)
     else {
       genop_peep(s, MKOP_AB(OP_RETURN, cursp(), OP_R_NORMAL), NOVAL);
     }
+    push();
     break;
 
   case NODE_YIELD:


### PR DESCRIPTION
Commit of #18dd60c causes disappearance of a local variable
if return statement is called without arguments.

This patch fixes incorrect value of stack pointer.

test program:
def test_return_cond
  return if nil
  obj = 123
  p obj
  p obj.class
end
test_return_cond

output(commit #18dd60c):
main
Object

output(includes this patch):
123
Fixnum
