### PR TITLE
Fix wrong storage of data when hex-style string is loaded

### DIFF
--- a/src/parse.y
+++ b/src/parse.y
@@ -3329,7 +3329,7 @@ read_escape(parser_state *p)
 	  break;
 	}
       }
-      c = scan_hex(buf, i+1, &i);
+      c = scan_hex(buf, i, &i);
       if (i == 0) {
 	yyerror(p, "Invalid escape character syntax");
 	return 0;


### PR DESCRIPTION
This patch fixes corruption of data when hex-style string is
loaded.

I saw following phenomenon in an ubuntu/amd64 environment.

Test code:
str = "\x0\x1\x2\x03\x04\x05\x06\a\b\t\n\v\f\r\x0E\x0F\x10"
p str[-1] == "\0x10"

Output(binary program with mrbc -B):
false

Output(script with mruby):
true
