### PR TITLE
Change C API for raise.

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -282,8 +282,8 @@ mrb_value mrb_exc_new(mrb_state *mrb, struct RClass *c, const char *ptr, long le
 void mrb_exc_raise(mrb_state *mrb, mrb_value exc);
 
 int mrb_block_given_p(void);
-void mrb_raise(mrb_state *mrb, struct RClass *c, const char *fmt, ...);
-void rb_raise(struct RClass *c, const char *fmt, ...);
+void mrb_raise(mrb_state *mrb, struct RClass *c, const char *msg);
+void mrb_raisef(mrb_state *mrb, struct RClass *c, const char *fmt, ...);
 void mrb_warn(const char *fmt, ...);
 void mrb_bug(const char *fmt, ...);
 

--- a/src/array.c
+++ b/src/array.c
@@ -580,7 +580,7 @@ mrb_ary_set(mrb_state *mrb, mrb_value ary, mrb_int n, mrb_value val) /* rb_ary_s
   if (n < 0) {
     n += a->len;
     if (n < 0) {
-      mrb_raise(mrb, E_INDEX_ERROR, "index %ld out of array", n - a->len);
+      mrb_raisef(mrb, E_INDEX_ERROR, "index %ld out of array", n - a->len);
     }
   }
   if (a->len <= (int)n) {

--- a/src/class.c
+++ b/src/class.c
@@ -171,11 +171,11 @@ mrb_vm_define_class(mrb_state *mrb, mrb_value outer, mrb_value super, mrb_sym id
     c = mrb_class_ptr(v);
     if (!mrb_nil_p(super)) {
       if (mrb_type(super) != MRB_TT_CLASS) {
-        mrb_raise(mrb, E_TYPE_ERROR, "superclass must be a Class (%s given)", mrb_obj_classname(mrb, super));
+        mrb_raisef(mrb, E_TYPE_ERROR, "superclass must be a Class (%s given)", mrb_obj_classname(mrb, super));
       }
 
       if (!c->super || mrb_class_ptr(super) != mrb_class_real(c->super)) {
-        mrb_raise(mrb, E_TYPE_ERROR, "superclass mismatch for class %s", mrb_sym2name(mrb, id));
+        mrb_raisef(mrb, E_TYPE_ERROR, "superclass mismatch for class %s", mrb_sym2name(mrb, id));
       }
     }
 
@@ -184,7 +184,7 @@ mrb_vm_define_class(mrb_state *mrb, mrb_value outer, mrb_value super, mrb_sym id
 
   if (!mrb_nil_p(super)) {
     if (mrb_type(super) != MRB_TT_CLASS) {
-      mrb_raise(mrb, E_TYPE_ERROR, "superclass must be a Class (%s given)", mrb_obj_classname(mrb, super));
+      mrb_raisef(mrb, E_TYPE_ERROR, "superclass must be a Class (%s given)", mrb_obj_classname(mrb, super));
     }
     s = mrb_class_ptr(super);
   }
@@ -205,7 +205,7 @@ class_from_sym(mrb_state *mrb, struct RClass *klass, mrb_sym id)
   mrb_value c = mrb_const_get(mrb, mrb_obj_value(klass), id);
 
   if (mrb_type(c) != MRB_TT_MODULE && mrb_type(c) != MRB_TT_CLASS) {
-    mrb_raise(mrb, E_TYPE_ERROR, "%s is not a class/module", mrb_sym2name(mrb, id));
+    mrb_raisef(mrb, E_TYPE_ERROR, "%s is not a class/module", mrb_sym2name(mrb, id));
   }
   return mrb_class_ptr(c);
 }
@@ -318,7 +318,7 @@ check_type(mrb_state *mrb, mrb_value val, enum mrb_vtype t, const char *c, const
 
   tmp = mrb_check_convert_type(mrb, val, t, c, m);
   if (mrb_nil_p(tmp)) {
-    mrb_raise(mrb, E_TYPE_ERROR, "expected %s", c);
+    mrb_raisef(mrb, E_TYPE_ERROR, "expected %s", c);
   }
   return tmp;
 }
@@ -618,7 +618,7 @@ mrb_get_args(mrb_state *mrb, const char *format, ...)
       }
       break;
     default:
-      mrb_raise(mrb, E_ARGUMENT_ERROR, "invalide argument specifier %c", c);
+      mrb_raisef(mrb, E_ARGUMENT_ERROR, "invalide argument specifier %c", c);
       break;
     }
   }
@@ -852,7 +852,7 @@ mrb_method_search(mrb_state *mrb, struct RClass* c, mrb_sym mid)
 
   m = mrb_method_search_vm(mrb, &c, mid);
   if (!m) {
-    mrb_raise(mrb, E_NOMETHOD_ERROR, "no method named %s\n", mrb_sym2name(mrb, mid));
+    mrb_raisef(mrb, E_NOMETHOD_ERROR, "no method named %s\n", mrb_sym2name(mrb, mid));
   }
   return m;
 }
@@ -1008,7 +1008,7 @@ mrb_bob_missing(mrb_state *mrb, mrb_value mod)
   if (!SYMBOL_P(name)) {
     mrb_raise(mrb, E_TYPE_ERROR, "name should be a symbol");
   }
-  mrb_raise(mrb, E_NOMETHOD_ERROR, "no method named %s", mrb_sym2name(mrb, mrb_symbol(name)));
+  mrb_raisef(mrb, E_NOMETHOD_ERROR, "no method named %s", mrb_sym2name(mrb, mrb_symbol(name)));
   /* not reached */
   return mrb_nil_value();
 }
@@ -1105,7 +1105,7 @@ void
 mrb_check_inheritable(mrb_state *mrb, struct RClass *super)
 {
   if (super->tt != MRB_TT_CLASS) {
-    mrb_raise(mrb, E_TYPE_ERROR, "superclass must be a Class (%s given)",
+    mrb_raisef(mrb, E_TYPE_ERROR, "superclass must be a Class (%s given)",
            mrb_obj_classname(mrb, mrb_obj_value(super)));
   }
   if (super->tt == MRB_TT_SCLASS) {
@@ -1323,7 +1323,7 @@ mrb_sym_value(mrb_state *mrb, mrb_value val)
   }
   else if(mrb_type(val) != MRB_TT_SYMBOL) {
     mrb_value obj = mrb_funcall(mrb, val, "inspect", 0);
-    mrb_raise(mrb, E_TYPE_ERROR, "%s is not a symbol",
+    mrb_raisef(mrb, E_TYPE_ERROR, "%s is not a symbol",
          mrb_string_value_ptr(mrb, obj));
   }
   return mrb_symbol(val);

--- a/src/error.c
+++ b/src/error.c
@@ -217,7 +217,15 @@ mrb_exc_raise(mrb_state *mrb, mrb_value exc)
 }
 
 void
-mrb_raise(mrb_state *mrb, struct RClass *c, const char *fmt, ...)
+mrb_raise(mrb_state *mrb, struct RClass *c, const char *msg)
+{
+  mrb_value mesg;
+  mesg = mrb_str_new2(mrb, msg);
+  mrb_exc_raise(mrb, mrb_exc_new3(mrb, c, mesg));
+}
+
+void
+mrb_raisef(mrb_state *mrb, struct RClass *c, const char *fmt, ...)
 {
   va_list args;
   char buf[256];
@@ -369,7 +377,7 @@ exception_call:
 
       break;
     default:
-      mrb_raise(mrb, E_ARGUMENT_ERROR, "wrong number of arguments (%d for 0..3)", argc);
+      mrb_raisef(mrb, E_ARGUMENT_ERROR, "wrong number of arguments (%d for 0..3)", argc);
       break;
   }
   if (argc > 0) {
@@ -391,7 +399,7 @@ mrb_make_exception(mrb_state *mrb, int argc, mrb_value *argv)
 void
 mrb_sys_fail(mrb_state *mrb, const char *mesg)
 {
-  mrb_raise(mrb, E_RUNTIME_ERROR, "%s", mesg);
+  mrb_raise(mrb, E_RUNTIME_ERROR, mesg);
 }
 
 void

--- a/src/etc.c
+++ b/src/etc.c
@@ -44,7 +44,7 @@ mrb_check_datatype(mrb_state *mrb, mrb_value obj, const struct mrb_data_type *ty
   }
   if (DATA_TYPE(obj) != type) {
     const char *etype = DATA_TYPE(obj)->struct_name;
-    mrb_raise(mrb, E_TYPE_ERROR, mesg, etype, type->struct_name);
+    mrb_raisef(mrb, E_TYPE_ERROR, mesg, etype, type->struct_name);
   }
   return DATA_PTR(obj);
 }
@@ -94,7 +94,7 @@ mrb_to_id(mrb_state *mrb, mrb_value name)
       tmp = mrb_check_string_type(mrb, name);
       if (mrb_nil_p(tmp)) {
         tmp = mrb_inspect(mrb, name);
-        mrb_raise(mrb, E_TYPE_ERROR, "%s is not a symbol",
+        mrb_raisef(mrb, E_TYPE_ERROR, "%s is not a symbol",
              RSTRING_PTR(tmp));
       }
       name = tmp;

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -348,7 +348,7 @@ mrb_obj_clone(mrb_state *mrb, mrb_value self)
   struct RObject *clone;
 
   if (mrb_special_const_p(self)) {
-      mrb_raise(mrb, E_TYPE_ERROR, "can't clone %s", mrb_obj_classname(mrb, self));
+      mrb_raisef(mrb, E_TYPE_ERROR, "can't clone %s", mrb_obj_classname(mrb, self));
   }
   clone = (struct RObject*)mrb_obj_alloc(mrb, mrb_type(self), mrb_obj_class(mrb, self));
   clone->c = mrb_singleton_class_clone(mrb, self);
@@ -383,7 +383,7 @@ mrb_obj_dup(mrb_state *mrb, mrb_value obj)
     mrb_value dup;
 
     if (mrb_special_const_p(obj)) {
-        mrb_raise(mrb, E_TYPE_ERROR, "can't dup %s", mrb_obj_classname(mrb, obj));
+        mrb_raisef(mrb, E_TYPE_ERROR, "can't dup %s", mrb_obj_classname(mrb, obj));
     }
     p = mrb_obj_alloc(mrb, mrb_type(obj), mrb_obj_class(mrb, obj));
     dup = mrb_obj_value(p);

--- a/src/numeric.c
+++ b/src/numeric.c
@@ -950,7 +950,7 @@ static mrb_value
 lshift(mrb_state *mrb, mrb_int val, unsigned long width)
 {
   if (width > (sizeof(mrb_int)*CHAR_BIT-1)) {
-      mrb_raise(mrb, E_RANGE_ERROR, "width(%d) > (%d:sizeof(mrb_int)*CHAR_BIT-1)", width,
+      mrb_raisef(mrb, E_RANGE_ERROR, "width(%d) > (%d:sizeof(mrb_int)*CHAR_BIT-1)", width,
 		sizeof(mrb_int)*CHAR_BIT-1);
   }
   val = val << width;
@@ -1164,7 +1164,7 @@ mrb_fix2str(mrb_state *mrb, mrb_value x, int base)
   int neg = 0;
 
   if (base < 2 || 36 < base) {
-    mrb_raise(mrb, E_ARGUMENT_ERROR, "invalid radix %d", base);
+    mrb_raisef(mrb, E_ARGUMENT_ERROR, "invalid radix %d", base);
   }
   if (val == 0) {
     return mrb_str_new(mrb, "0", 1);

--- a/src/object.c
+++ b/src/object.c
@@ -305,7 +305,7 @@ convert_type(mrb_state *mrb, mrb_value val, const char *tname, const char *metho
   m = mrb_intern(mrb, method);
   if (!mrb_respond_to(mrb, val, m)) {
     if (raise) {
-      mrb_raise(mrb, E_TYPE_ERROR, "can't convert %s into %s",
+      mrb_raisef(mrb, E_TYPE_ERROR, "can't convert %s into %s",
          mrb_nil_p(val) ? "nil" :
          (mrb_type(val) == MRB_TT_TRUE) ? "true" :
          (mrb_type(val) == MRB_TT_FALSE) ? "false" :
@@ -341,7 +341,7 @@ mrb_convert_type(mrb_state *mrb, mrb_value val, mrb_int type, const char *tname,
   if (mrb_type(val) == type) return val;
   v = convert_type(mrb, val, tname, method, 1/*Qtrue*/);
   if (mrb_type(v) != type) {
-    mrb_raise(mrb, E_TYPE_ERROR, "%s cannot be converted to %s by #%s",
+    mrb_raisef(mrb, E_TYPE_ERROR, "%s cannot be converted to %s by #%s",
 	      mrb_obj_classname(mrb, val), tname, method);
   }
   return v;
@@ -419,12 +419,12 @@ mrb_check_type(mrb_state *mrb, mrb_value x, enum mrb_vtype t)
         else {
           etype = mrb_obj_classname(mrb, x);
         }
-        mrb_raise(mrb, E_TYPE_ERROR, "wrong argument type %s (expected %s)",
+        mrb_raisef(mrb, E_TYPE_ERROR, "wrong argument type %s (expected %s)",
 		  etype, type->name);
       }
       type++;
     }
-    mrb_raise(mrb, E_TYPE_ERROR, "unknown type 0x%x (0x%x given)", t, mrb_type(x));
+    mrb_raisef(mrb, E_TYPE_ERROR, "unknown type 0x%x (0x%x given)", t, mrb_type(x));
   }
 }
 
@@ -513,7 +513,7 @@ mrb_to_integer(mrb_state *mrb, mrb_value val, const char *method)
     v = convert_type(mrb, val, "Integer", method, TRUE);
     if (!mrb_obj_is_kind_of(mrb, v, mrb->fixnum_class)) {
       const char *cname = mrb_obj_classname(mrb, val);
-      mrb_raise(mrb, E_TYPE_ERROR, "can't convert %s to Integer (%s#%s gives %s)",
+      mrb_raisef(mrb, E_TYPE_ERROR, "can't convert %s to Integer (%s#%s gives %s)",
                cname, cname, method, mrb_obj_classname(mrb, v));
     }
     return v;

--- a/src/range.c
+++ b/src/range.c
@@ -296,7 +296,7 @@ mrb_range_beg_len(mrb_state *mrb, mrb_value range, mrb_int *begp, mrb_int *lenp,
 
 out_of_range:
   if (err) {
-    mrb_raise(mrb, E_RANGE_ERROR, "%ld..%s%ld out of range",
+    mrb_raisef(mrb, E_RANGE_ERROR, "%ld..%s%ld out of range",
       b, r->excl? "." : "", e);
   }
   return OTHER;

--- a/src/sprintf.c
+++ b/src/sprintf.c
@@ -81,7 +81,7 @@ mrb_fix2binstr(mrb_state *mrb, mrb_value x, int base)
   char d;
 
   if (base != 2) {
-    mrb_raise(mrb, E_ARGUMENT_ERROR, "invalid radix %d", base);
+    mrb_raisef(mrb, E_ARGUMENT_ERROR, "invalid radix %d", base);
   }
 
   if (val >= (1 << 10))
@@ -146,17 +146,17 @@ mrb_fix2binstr(mrb_state *mrb, mrb_value x, int base)
 
 #define GETARG() (!mrb_undef_p(nextvalue) ? nextvalue : \
   posarg == -1 ? \
-  (mrb_raise(mrb, E_ARGUMENT_ERROR, "unnumbered(%d) mixed with numbered", nextarg), mrb_undef_value()) : \
+  (mrb_raisef(mrb, E_ARGUMENT_ERROR, "unnumbered(%d) mixed with numbered", nextarg), mrb_undef_value()) : \
   posarg == -2 ? \
-  (mrb_raise(mrb, E_ARGUMENT_ERROR, "unnumbered(%d) mixed with named", nextarg), mrb_undef_value()) : \
+  (mrb_raisef(mrb, E_ARGUMENT_ERROR, "unnumbered(%d) mixed with named", nextarg), mrb_undef_value()) : \
   (posarg = nextarg++, GETNTHARG(posarg)))
 
 #define GETPOSARG(n) (posarg > 0 ? \
-  (mrb_raise(mrb, E_ARGUMENT_ERROR, "numbered(%d) after unnumbered(%d)", n, posarg), mrb_undef_value()) : \
+  (mrb_raisef(mrb, E_ARGUMENT_ERROR, "numbered(%d) after unnumbered(%d)", n, posarg), mrb_undef_value()) : \
   posarg == -2 ? \
-  (mrb_raise(mrb, E_ARGUMENT_ERROR, "numbered(%d) after named", n), mrb_undef_value()) : \
+  (mrb_raisef(mrb, E_ARGUMENT_ERROR, "numbered(%d) after named", n), mrb_undef_value()) : \
   ((n < 1) ? \
-  (mrb_raise(mrb, E_ARGUMENT_ERROR, "invalid index - %d$", n), mrb_undef_value()) : \
+  (mrb_raisef(mrb, E_ARGUMENT_ERROR, "invalid index - %d$", n), mrb_undef_value()) : \
   (posarg = -1, GETNTHARG(n))))
 
 #define GETNTHARG(nth) \
@@ -164,9 +164,9 @@ mrb_fix2binstr(mrb_state *mrb, mrb_value x, int base)
 
 #define GETNAMEARG(id, name, len) ( \
   posarg > 0 ? \
-  (mrb_raise(mrb, E_ARGUMENT_ERROR, "named%.*s after unnumbered(%d)", (len), (name), posarg), mrb_undef_value()) : \
+  (mrb_raisef(mrb, E_ARGUMENT_ERROR, "named%.*s after unnumbered(%d)", (len), (name), posarg), mrb_undef_value()) : \
   posarg == -1 ? \
-  (mrb_raise(mrb, E_ARGUMENT_ERROR, "named%.*s after numbered", (len), (name)), mrb_undef_value()) :    \
+  (mrb_raisef(mrb, E_ARGUMENT_ERROR, "named%.*s after numbered", (len), (name)), mrb_undef_value()) :    \
   (posarg = -2, mrb_hash_fetch(mrb, get_hash(mrb, &hash, argc, argv), id, mrb_undef_value())))
 
 #define GETNUM(n, val) \
@@ -178,7 +178,7 @@ mrb_fix2binstr(mrb_state *mrb, mrb_value x, int base)
     n = next_n; \
   } \
   if (p >= end) { \
-    mrb_raise(mrb, E_ARGUMENT_ERROR, "malformed format string - %%*[0-9]"); \
+    mrb_raise(mrb, E_ARGUMENT_ERROR, "malformed format string - %*[0-9]"); \
   }
 
 #define GETASTER(num) do { \
@@ -548,7 +548,7 @@ mrb_str_format(mrb_state *mrb, int argc, const mrb_value *argv, mrb_value fmt)
 retry:
     switch (*p) {
       default:
-        mrb_raise(mrb, E_ARGUMENT_ERROR, "malformed format string - %%%c", *p);
+        mrb_raisef(mrb, E_ARGUMENT_ERROR, "malformed format string - %%%c", *p);
         break;
 
       case ' ':
@@ -587,7 +587,7 @@ retry:
         GETNUM(n, width);
         if (*p == '$') {
           if (!mrb_undef_p(nextvalue)) {
-            mrb_raise(mrb, E_ARGUMENT_ERROR, "value given twice - %d$", n);
+            mrb_raisef(mrb, E_ARGUMENT_ERROR, "value given twice - %d$", n);
           }
           nextvalue = GETPOSARG(n);
           p++;
@@ -607,14 +607,14 @@ retry:
         for (; p < end && *p != term; )
           p++;
         if (id) {
-          mrb_raise(mrb, E_ARGUMENT_ERROR, "name%.*s after <%s>",
+          mrb_raisef(mrb, E_ARGUMENT_ERROR, "name%.*s after <%s>",
                     (int)(p - start + 1), start, mrb_sym2name(mrb, id));
         }
         symname = mrb_str_new(mrb, start + 1, p - start - 1);
         id = mrb_intern_str(mrb, symname);
         nextvalue = GETNAMEARG(mrb_symbol_value(id), start, (int)(p - start + 1));
         if (mrb_undef_p(nextvalue)) {
-          mrb_raise(mrb, E_KEY_ERROR, "key%.*s not found", (int)(p - start + 1), start);
+          mrb_raisef(mrb, E_KEY_ERROR, "key%.*s not found", (int)(p - start + 1), start);
         }
         if (term == '}') goto format_s;
         p++;
@@ -658,7 +658,7 @@ retry:
         
       case '%':
         if (flags != FNONE) {
-          mrb_raise(mrb, E_ARGUMENT_ERROR, "invalid format character - %%");
+          mrb_raise(mrb, E_ARGUMENT_ERROR, "invalid format character - %");
         }
         PUSH("%", 1);
         break;
@@ -1052,7 +1052,7 @@ retry:
    */
   if (posarg >= 0 && nextarg < argc) {
     const char *mesg = "too many arguments for format string";
-    if (RTEST(ruby_debug)) mrb_raise(mrb, E_ARGUMENT_ERROR, "%s", mesg);
+    if (RTEST(ruby_debug)) mrb_raise(mrb, E_ARGUMENT_ERROR, mesg);
     if (RTEST(ruby_verbose)) mrb_warn("%s", mesg);
   }
   mrb_str_resize(mrb, result, blen);

--- a/src/string.c
+++ b/src/string.c
@@ -840,7 +840,7 @@ mrb_str_aref_m(mrb_state *mrb, mrb_value str)
     return mrb_str_substr(mrb, str, mrb_fixnum(a1), mrb_fixnum(a2));
   }
   if (argc != 1) {
-    mrb_raise(mrb, E_ARGUMENT_ERROR, "wrong number of arguments (%d for 1)", argc);
+    mrb_raisef(mrb, E_ARGUMENT_ERROR, "wrong number of arguments (%d for 1)", argc);
   }
   return mrb_str_aref(mrb, str, a1);
 }
@@ -1525,7 +1525,7 @@ mrb_str_index_m(mrb_state *mrb, mrb_value str)
 
       tmp = mrb_check_string_type(mrb, sub);
       if (mrb_nil_p(tmp)) {
-        mrb_raise(mrb, E_TYPE_ERROR, "type mismatch: %s given",
+        mrb_raisef(mrb, E_TYPE_ERROR, "type mismatch: %s given",
            mrb_obj_classname(mrb, sub));
       }
       sub = tmp;
@@ -1931,7 +1931,7 @@ mrb_str_rindex_m(mrb_state *mrb, mrb_value str)
 
       tmp = mrb_check_string_type(mrb, sub);
       if (mrb_nil_p(tmp)) {
-        mrb_raise(mrb, E_TYPE_ERROR, "type mismatch: %s given",
+        mrb_raisef(mrb, E_TYPE_ERROR, "type mismatch: %s given",
                  mrb_obj_classname(mrb, sub));
       }
       sub = tmp;
@@ -2466,7 +2466,7 @@ mrb_cstr_to_inum(mrb_state *mrb, const char *str, int base, int badcheck)
       break;
     default:
       if (base < 2 || 36 < base) {
-        mrb_raise(mrb, E_ARGUMENT_ERROR, "illegal radix %d", base);
+        mrb_raisef(mrb, E_ARGUMENT_ERROR, "illegal radix %d", base);
       }
       if (base <= 32) {
         len = 5;
@@ -2510,7 +2510,7 @@ mrb_cstr_to_inum(mrb_state *mrb, const char *str, int base, int badcheck)
     return mrb_fixnum_value(result);
   }
 bad:
-  mrb_raise(mrb, E_ARGUMENT_ERROR, "invalide string for number(%s)", str);
+  mrb_raisef(mrb, E_ARGUMENT_ERROR, "invalide string for number(%s)", str);
   /* not reached */
   return mrb_fixnum_value(0);
 }
@@ -2589,7 +2589,7 @@ mrb_str_to_i(mrb_state *mrb, mrb_value self)
     base = mrb_fixnum(argv[0]);
 
   if (base < 0) {
-    mrb_raise(mrb, E_ARGUMENT_ERROR, "illegal radix %d", base);
+    mrb_raisef(mrb, E_ARGUMENT_ERROR, "illegal radix %d", base);
   }
   return mrb_str_to_inum(mrb, self, base, 0/*Qfalse*/);
 }
@@ -2620,7 +2620,7 @@ mrb_cstr_to_dbl(mrb_state *mrb, const char * p, int badcheck)
   if (p == end) {
     if (badcheck) {
 bad:
-      mrb_raise(mrb, E_ARGUMENT_ERROR, "invalide string for float(%s)", p);
+      mrb_raisef(mrb, E_ARGUMENT_ERROR, "invalide string for float(%s)", p);
       /* not reached */
     }
     return d;

--- a/src/struct.c
+++ b/src/struct.c
@@ -70,7 +70,7 @@ mrb_struct_members(mrb_state *mrb, mrb_value s)
   mrb_value members = mrb_struct_s_members(mrb, mrb_obj_value(mrb_obj_class(mrb, s)));
   if (mrb_type(s) == MRB_TT_STRUCT) {
     if (RSTRUCT_LEN(s) != RARRAY_LEN(members)) {
-      mrb_raise(mrb, E_TYPE_ERROR, "struct size differs (%ld required %ld given)",
+      mrb_raisef(mrb, E_TYPE_ERROR, "struct size differs (%ld required %ld given)",
              RARRAY_LEN(members), RSTRUCT_LEN(s));
     }
   }
@@ -595,10 +595,10 @@ mrb_struct_aref_n(mrb_state *mrb, mrb_value s, mrb_value idx)
   i = mrb_fixnum(idx);
   if (i < 0) i = RSTRUCT_LEN(s) + i;
   if (i < 0)
-      mrb_raise(mrb, E_INDEX_ERROR, "offset %ld too small for struct(size:%ld)",
+      mrb_raisef(mrb, E_INDEX_ERROR, "offset %ld too small for struct(size:%ld)",
            i, RSTRUCT_LEN(s));
   if (RSTRUCT_LEN(s) <= i)
-      mrb_raise(mrb, E_INDEX_ERROR, "offset %ld too large for struct(size:%ld)",
+      mrb_raisef(mrb, E_INDEX_ERROR, "offset %ld too large for struct(size:%ld)",
            i, RSTRUCT_LEN(s));
   return RSTRUCT_PTR(s)[i];
 }
@@ -622,7 +622,7 @@ mrb_struct_aset_id(mrb_state *mrb, mrb_value s, mrb_sym id, mrb_value val)
     len = RARRAY_LEN(members);
     mrb_struct_modify(s);
     if (RSTRUCT_LEN(s) != len) {
-      mrb_raise(mrb, E_TYPE_ERROR, "struct size differs (%ld required %ld given)",
+      mrb_raisef(mrb, E_TYPE_ERROR, "struct size differs (%ld required %ld given)",
              len, RSTRUCT_LEN(s));
     }
     ptr = RSTRUCT_PTR(s);
@@ -675,11 +675,11 @@ mrb_struct_aset(mrb_state *mrb, mrb_value s)
   i = mrb_fixnum(idx);
   if (i < 0) i = RSTRUCT_LEN(s) + i;
   if (i < 0) {
-    mrb_raise(mrb, E_INDEX_ERROR, "offset %ld too small for struct(size:%ld)",
+    mrb_raisef(mrb, E_INDEX_ERROR, "offset %ld too small for struct(size:%ld)",
 	      i, RSTRUCT_LEN(s));
   }
   if (RSTRUCT_LEN(s) <= i) {
-    mrb_raise(mrb, E_INDEX_ERROR, "offset %ld too large for struct(size:%ld)",
+    mrb_raisef(mrb, E_INDEX_ERROR, "offset %ld too large for struct(size:%ld)",
 	      i, RSTRUCT_LEN(s));
   }
   mrb_struct_modify(s);

--- a/src/variable.c
+++ b/src/variable.c
@@ -712,7 +712,7 @@ const_get(mrb_state *mrb, struct RClass *base, mrb_sym sym)
     }
     c = c->super;
   }
-  mrb_raise(mrb, E_NAME_ERROR, "uninitialized constant %s",
+  mrb_raisef(mrb, E_NAME_ERROR, "uninitialized constant %s",
             mrb_sym2name(mrb, sym));
   /* not reached */
   return mrb_nil_value();

--- a/src/vm.c
+++ b/src/vm.c
@@ -236,7 +236,7 @@ mrb_funcall(mrb_state *mrb, mrb_value self, const char *name, int argc, ...)
     mrb_value argv[MRB_FUNCALL_ARGC_MAX];
 
     if (argc > MRB_FUNCALL_ARGC_MAX) {
-      mrb_raise(mrb, E_ARGUMENT_ERROR, "Too long arguments. (limit=%d)", MRB_FUNCALL_ARGC_MAX);
+      mrb_raisef(mrb, E_ARGUMENT_ERROR, "Too long arguments. (limit=%d)", MRB_FUNCALL_ARGC_MAX);
     }
 
     va_start(ap, argc);
@@ -277,7 +277,7 @@ mrb_funcall_with_block(mrb_state *mrb, mrb_value self, mrb_sym mid, int argc, mr
   }
   n = mrb->ci->nregs;
   if (argc < 0) {
-    mrb_raise(mrb, E_ARGUMENT_ERROR, "negative argc for funcall (%d)", argc);
+    mrb_raisef(mrb, E_ARGUMENT_ERROR, "negative argc for funcall (%d)", argc);
   }
   c = mrb_class(mrb, self);
   p = mrb_method_search_vm(mrb, &c, mid);


### PR DESCRIPTION
It calls snprintf() in the current version of mrb_raise(). "raise" is called frequently and snprintf() causes a heavy CPU load (especially tiny embedded systems).
About 60% of mrb_raise call doesn't need formatting.
So we should prepare unformatted version of mrb_raise variant.

API changes in this patch is like this.  
mrb_raisef(): new function. Same as previou version of mrb_raise().
mrb_raise(): API modified. It cannot treat variable arguments.
