### PR TITLE
Use substitution instead of memset in structure initializations.

### DIFF
--- a/include/mruby/data.h
+++ b/include/mruby/data.h
@@ -30,7 +30,7 @@ struct RData *mrb_data_object_alloc(mrb_state *mrb, struct RClass* klass, void *
 
 #define Data_Make_Struct(mrb,klass,strct,type,sval) (\
   sval = mrb_malloc(mrb, sizeof(strct)),\
-  memset(sval, 0, sizeof(strct)),\
+  { static const strct zero = { 0 }; *sval = zero},\
   Data_Wrap_Struct(mrb,klass,type,sval)\
 )
 

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -453,7 +453,10 @@ new_sym(codegen_scope *s, mrb_sym sym)
   }
   if (s->slen > 125 && s->slen < 256) {
     s->syms = (mrb_sym *)codegen_realloc(s, s->syms, sizeof(mrb_sym)*65536);
-    memset(s->syms+s->slen, 0, sizeof(mrb_sym)*(256-s->slen));
+    for (i = 0; i < 256 - s->slen; i++) {
+      static const mrb_sym mrb_sym_zero = { 0 };
+      s->syms[i + s->slen] = mrb_sym_zero;
+    }
     s->slen = 256;
   }
   s->syms[s->slen] = sym;
@@ -2049,11 +2052,12 @@ codegen(codegen_scope *s, node *tree, int val)
 static codegen_scope*
 scope_new(mrb_state *mrb, codegen_scope *prev, node *lv)
 {
+  static const codegen_scope codegen_scope_zero = { 0 };
   mrb_pool *pool = mrb_pool_open(mrb);
   codegen_scope *p = (codegen_scope *)mrb_pool_alloc(pool, sizeof(codegen_scope));
   if (!p) return 0;
 
-  memset(p, 0, sizeof(codegen_scope));
+  *p = codegen_scope_zero;
   p->mrb = mrb;
   p->mpool = pool;
   if (!prev) return p;

--- a/src/gc.c
+++ b/src/gc.c
@@ -326,6 +326,7 @@ struct RBasic*
 mrb_obj_alloc(mrb_state *mrb, enum mrb_vtype ttype, struct RClass *cls)
 {
   struct RBasic *p;
+  static const RVALUE RVALUE_zero = { 0 };
 
 #ifdef MRB_GC_STRESS
   mrb_garbage_collect(mrb);
@@ -345,7 +346,7 @@ mrb_obj_alloc(mrb_state *mrb, enum mrb_vtype ttype, struct RClass *cls)
 
   mrb->live++;
   gc_protect(mrb, p);
-  memset(p, 0, sizeof(RVALUE));
+  *(RVALUE *)p = RVALUE_zero;
   p->tt = ttype;
   p->c = cls;
   paint_partial_white(mrb, p);

--- a/src/load.c
+++ b/src/load.c
@@ -448,7 +448,10 @@ read_rite_irep_record(mrb_state *mrb, unsigned char *src, mrb_irep *irep, uint32
       goto error_exit;
     }
 
-    memset(irep->syms, 0, sizeof(mrb_sym)*(irep->slen));
+    for (i = 0; i < irep->slen; i++) {
+      static const mrb_sym mrb_sym_zero = { 0 };
+      *irep->syms = mrb_sym_zero;
+    }
     for (i=0; i<irep->slen; i++) {
       snl = bin_to_uint16(src);               //symbol name length
       src += MRB_DUMP_SIZE_OF_SHORT;
@@ -509,11 +512,12 @@ mrb_read_irep(mrb_state *mrb, const char *bin)
   mrb_add_irep(mrb, sirep + nirep);
 
   for (n=0,i=sirep; n<nirep; n++,i++) {
+    static const mrb_irep mrb_irep_zero = { 0 };
     if ((mrb->irep[i] = (mrb_irep *)mrb_malloc(mrb, sizeof(mrb_irep))) == NULL) {
       ret = MRB_DUMP_GENERAL_FAILURE;
       goto error_exit;
     }
-    memset(mrb->irep[i], 0, sizeof(mrb_irep));
+    *mrb->irep[i] = mrb_irep_zero;
   }
   src += sizeof(bin_header) + MRB_DUMP_SIZE_OF_SHORT;  //header + crc
 

--- a/src/parse.y
+++ b/src/parse.y
@@ -4747,13 +4747,14 @@ mrb_parser_new(mrb_state *mrb)
 {
   mrb_pool *pool;
   parser_state *p;
+  static const parser_state parser_state_zero = { 0 };
 
   pool = mrb_pool_open(mrb);
   if (!pool) return 0;
   p = (parser_state *)mrb_pool_alloc(pool, sizeof(parser_state));
   if (!p) return 0;
 
-  memset(p, 0, sizeof(parser_state));
+  *p = parser_state_zero;
   p->mrb = mrb;
   p->pool = pool;
   p->in_def = p->in_single = 0;

--- a/src/proc.c
+++ b/src/proc.c
@@ -149,11 +149,12 @@ mrb_init_proc(mrb_state *mrb)
 {
   struct RProc *m;
   mrb_irep *call_irep = (mrb_irep *)mrb_alloca(mrb, sizeof(mrb_irep));
+  static const mrb_irep mrb_irep_zero = { 0 };
 
   if ( call_iseq == NULL || call_irep == NULL )
     return;
 
-  memset(call_irep, 0, sizeof(mrb_irep));
+  *call_irep = mrb_irep_zero;
   call_irep->flags = MRB_ISEQ_NO_FREE;
   call_irep->idx = -1;
   call_irep->iseq = call_iseq;

--- a/src/state.c
+++ b/src/state.c
@@ -16,10 +16,11 @@ void mrb_init_ext(mrb_state*);
 mrb_state*
 mrb_open_allocf(mrb_allocf f, void *ud)
 {
+  static const mrb_state mrb_state_zero = { 0 };
   mrb_state *mrb = (mrb_state *)(f)(NULL, NULL, sizeof(mrb_state), ud);
   if (mrb == NULL) return NULL;
 
-  memset(mrb, 0, sizeof(mrb_state));
+  *mrb = mrb_state_zero;
   mrb->ud = ud;
   mrb->allocf = f;
   mrb->current_white_part = MRB_GC_WHITE_A;
@@ -119,12 +120,15 @@ mrb_add_irep(mrb_state *mrb, int idx)
     mrb->irep_capa = max;
   }
   else if (mrb->irep_capa <= idx) {
+    int i;
     size_t old_capa = mrb->irep_capa;
     while (mrb->irep_capa <= idx) {
       mrb->irep_capa *= 2;
     }
     mrb->irep = (mrb_irep **)mrb_realloc(mrb, mrb->irep, sizeof(mrb_irep*)*mrb->irep_capa);
-    memset(mrb->irep + old_capa, 0, sizeof(mrb_irep*) * (mrb->irep_capa - old_capa));
+    for (i = old_capa; i < mrb->irep_capa - old_capa; i++) {
+      mrb->irep[i] = NULL;
+    }
   }
 }
 

--- a/src/vm.c
+++ b/src/vm.c
@@ -100,15 +100,16 @@ stack_extend(mrb_state *mrb, int room, int keep)
     envadjust(mrb, oldbase, mrb->stbase);
   }
   if (room > keep) {
-#ifndef MRB_NAN_BOXING
-    memset(mrb->stack+keep, 0, sizeof(mrb_value) * (room-keep));
-#else
     int i;
 
     for (i=keep; i<room; i++) {
+#ifndef MRB_NAN_BOXING
+      static const mrb_value mrb_value_zero = { { 0 } };
+      mrb->stack[i] = mrb_value_zero;
+#else
       SET_NIL_VALUE(mrb->stack[i]);
-    }
 #endif
+    }
   }
 }
 


### PR DESCRIPTION
This fix is same as memcpy workaround. It is not a bug fix but a prevention of complier's bugs.

It is required more .rodata section by this fix.  But it may be 100bytes or less.
It will be less impact to code size and CPU load as compiler will optimize loops same as memcpy's.
