### PR TITLE
define convert method mrb_int/mrb_float with C string

### DIFF
--- a/include/mrbconf.h
+++ b/include/mrbconf.h
@@ -55,19 +55,26 @@
 
 #ifdef MRB_USE_FLOAT
 typedef float mrb_float;
+#define mrb_float_to_str(buf, i) sprintf((buf), "%.7e", (i))
+#define str_to_mrb_float(buf) (mrb_float)strtof((buf),NULL)
 #else
 typedef double mrb_float;
+#define mrb_float_to_str(buf, i) sprintf((buf), "%.16e", (i))
+#define str_to_mrb_float(buf) (mrb_float)strtod((buf),NULL)
 #endif
-#define readfloat(p) (mrb_float)strtod((p),NULL)
 
 #ifdef MRB_NAN_BOXING
 typedef int32_t mrb_int;
 #define MRB_INT_MIN INT32_MIN
 #define MRB_INT_MAX INT32_MAX
+#define mrb_int_to_str(buf, i) sprintf((buf), "%d", (i))
+#define str_to_mrb_int(buf) (mrb_int)strtol((buf), NULL, 10);
 #else
 typedef int mrb_int;
 #define MRB_INT_MIN INT_MIN
 #define MRB_INT_MAX INT_MAX
+#define mrb_int_to_str(buf, i) sprintf((buf), "%d", (i))
+#define str_to_mrb_int(buf) (mrb_int)strtol((buf), NULL, 10);
 #endif
 typedef short mrb_sym;
 

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -1738,7 +1738,7 @@ codegen(codegen_scope *s, node *tree, int val)
   case NODE_FLOAT:
     if (val) {
       char *p = (char*)tree;
-      mrb_float f = readfloat(p);
+      mrb_float f = str_to_mrb_float(p);
       int off = new_lit(s, mrb_float_value(f));
 
       genop(s, MKOP_ABx(OP_LOADL, cursp(), off));
@@ -1754,7 +1754,7 @@ codegen(codegen_scope *s, node *tree, int val)
       case NODE_FLOAT:
         {
           char *p = (char*)tree;
-          mrb_float f = readfloat(p);
+          mrb_float f = str_to_mrb_float(p);
           int off = new_lit(s, mrb_float_value(-f));
 
           genop(s, MKOP_ABx(OP_LOADL, cursp(), off));

--- a/src/dump.c
+++ b/src/dump.c
@@ -226,11 +226,11 @@ get_pool_block_size(mrb_state *mrb, mrb_irep *irep, int type)
 
     switch (mrb_type(irep->pool[pool_no])) {
     case MRB_TT_FIXNUM:
-      len = sprintf( buf, "%d", mrb_fixnum(irep->pool[pool_no]));
+      len = mrb_int_to_str( buf, mrb_fixnum(irep->pool[pool_no]));
       size += (uint32_t)len;
       break;
     case MRB_TT_FLOAT:
-      len = sprintf( buf, "%.16e", mrb_float(irep->pool[pool_no]));
+      len = mrb_float_to_str( buf, mrb_float(irep->pool[pool_no]));
       size += (uint32_t)len;
       break;
     case MRB_TT_STRING:
@@ -346,11 +346,11 @@ write_pool_block(mrb_state *mrb, mrb_irep *irep, char *buf, int type)
 
     switch (mrb_type(irep->pool[pool_no])) {
     case MRB_TT_FIXNUM:
-      len = sprintf(char_buf, "%d", mrb_fixnum(irep->pool[pool_no]));
+      len = mrb_int_to_str(char_buf, mrb_fixnum(irep->pool[pool_no]));
       break;
 
     case MRB_TT_FLOAT:
-      len = sprintf(char_buf, "%.16e", mrb_float(irep->pool[pool_no]));
+      len = mrb_float_to_str(char_buf, mrb_float(irep->pool[pool_no]));
       break;
 
     case MRB_TT_STRING:

--- a/src/load.c
+++ b/src/load.c
@@ -405,12 +405,12 @@ read_rite_irep_record(mrb_state *mrb, unsigned char *src, mrb_irep *irep, uint32
 
       switch (tt) {                           //pool data
       case MRB_TT_FIXNUM:
-        fix_num = strtol(buf, NULL, 10);
+        fix_num = str_to_mrb_int(buf);
         irep->pool[i] = mrb_fixnum_value(fix_num);
         break;
 
       case MRB_TT_FLOAT:
-        f = readfloat(buf);
+        f = str_to_mrb_float(buf);
         irep->pool[i] = mrb_float_value(f);
         break;
 

--- a/src/numeric.c
+++ b/src/numeric.c
@@ -246,8 +246,8 @@ flodivmod(mrb_state *mrb, mrb_float x, mrb_float y, mrb_float *divp, mrb_float *
   mrb_float div, mod;
 
   if (y == 0.0) {
-    *divp = strtod("inf", NULL);
-    *modp = strtod("nan", NULL);
+    *divp = str_to_mrb_float("inf");
+    *modp = str_to_mrb_float("nan");
     return;
   }
   mod = fmod(x, y);
@@ -778,7 +778,7 @@ fix_mod(mrb_state *mrb, mrb_value x)
     mrb_int mod;
 
     if (mrb_fixnum(y) == 0) {
-      return mrb_float_value(strtod("nan", NULL));
+      return mrb_float_value(str_to_mrb_float("nan"));
     }
     fixdivmod(mrb, a, mrb_fixnum(y), 0, &mod);
     return mrb_fixnum_value(mod);
@@ -807,8 +807,8 @@ fix_divmod(mrb_state *mrb, mrb_value x)
     mrb_int div, mod;
 
     if (mrb_fixnum(y) == 0) {
-      return mrb_assoc_new(mrb, mrb_float_value(strtod("inf", NULL)),
-			        mrb_float_value(strtod("nan", NULL)));
+      return mrb_assoc_new(mrb, mrb_float_value(str_to_mrb_float("inf")),
+			        mrb_float_value(str_to_mrb_float("nan")));
     }
     fixdivmod(mrb, mrb_fixnum(x), mrb_fixnum(y), &div, &mod);
     return mrb_assoc_new(mrb, mrb_fixnum_value(div), mrb_fixnum_value(mod));


### PR DESCRIPTION
define convert method mrb_int/mrb_float with C string in mrbconf.h.

It's for changing mrb_int/mrb_float size.

ex) typedef int64_t mrb_int;
