### PR TITLE
change the error message (NoMethodError, NameError)

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -852,7 +852,9 @@ mrb_method_search(mrb_state *mrb, struct RClass* c, mrb_sym mid)
 
   m = mrb_method_search_vm(mrb, &c, mid);
   if (!m) {
-    mrb_raisef(mrb, E_NOMETHOD_ERROR, "no method named %s\n", mrb_sym2name(mrb, mid));
+    mrb_raisef(mrb, E_NAME_ERROR, "undefined method '%s' for class %s",
+        mrb_sym2name(mrb, mid),
+        RSTRING_PTR(mrb_funcall(mrb, mrb_obj_value(c), "inspect", 0)));
   }
   return m;
 }
@@ -1008,7 +1010,9 @@ mrb_bob_missing(mrb_state *mrb, mrb_value mod)
   if (!SYMBOL_P(name)) {
     mrb_raise(mrb, E_TYPE_ERROR, "name should be a symbol");
   }
-  mrb_raisef(mrb, E_NOMETHOD_ERROR, "no method named %s", mrb_sym2name(mrb, mrb_symbol(name)));
+  mrb_raisef(mrb, E_NOMETHOD_ERROR, "undefined method '%s' for %s",
+      mrb_sym2name(mrb, mrb_symbol(name)),
+      RSTRING_PTR(mrb_funcall(mrb, mod, "inspect", 0)));
   /* not reached */
   return mrb_nil_value();
 }


### PR DESCRIPTION
change error message for..

```
# ruby 1.9.3
$ ruby -e 'class A; end; A.new.foo'
-e:1:in `<main>': undefined method `foo' for #<A:0x007f9322051358> (NoMethodError)

# mruby (before)
$ ./bin/mruby -e 'class A; end; A.new.foo'
-e:1: no method named foo (NoMethodError)

# mruby (after)
$ ./bin/mruby -e 'class A; end; A.new.foo'
-e:1: undefined method 'foo' for #<A:0x7f8dcc00ad88> (NoMethodError)
```

```
# ruby 1.9.3
$ ruby -e 'class A; alias foo bar; end' 
-e:1:in `<class:A>': undefined method `bar' for class `A' (NameError)
        from -e:1:in `<main>'

# mruby (before)
$ ./bin/mruby -e 'class A; alias foo bar; end'
-e:1: no method named bar
 (NoMethodError)

# mruby (after)
$ ./bin/mruby -e 'class A; alias foo bar; end'
-e:1: undefined method 'bar' for class A (NameError)
```
