### PR TITLE
Use NULL instead of 0.

### DIFF
--- a/src/cdump.c
+++ b/src/cdump.c
@@ -22,7 +22,7 @@ make_cdump_isec(mrb_state *mrb, int irep_no, FILE *f)
   int i;
   mrb_irep *irep = mrb->irep[irep_no];
 
-  if (irep == 0)
+  if (irep == NULL)
     return -1;
 
   /* dump isec struct*/
@@ -103,11 +103,11 @@ make_cdump_irep(mrb_state *mrb, int irep_no, FILE *f)
   char *buf = 0;
   size_t buf_len, str_len;
 
-  if (irep == 0)
+  if (irep == NULL)
     return -1;
 
   buf_len = MRB_CDUMP_LINE_LEN;
-  if ((buf = (char *)mrb_malloc(mrb, buf_len)) == 0 ) {
+  if ((buf = (char *)mrb_malloc(mrb, buf_len)) == NULL) {
     return MRB_CDUMP_GENERAL_FAILURE;
   }
 
@@ -150,7 +150,7 @@ make_cdump_irep(mrb_state *mrb, int irep_no, FILE *f)
         str_len = str_format_len(irep->pool[n]) + 1;
         if ( str_len > buf_len ) {
           buf_len = str_len;
-          if ((buf = (char *)mrb_realloc(mrb, buf, buf_len)) == 0 ) {
+          if ((buf = (char *)mrb_realloc(mrb, buf, buf_len)) == NULL) {
             return MRB_CDUMP_GENERAL_FAILURE;
           }
         }
@@ -174,7 +174,7 @@ mrb_cdump_irep(mrb_state *mrb, int n, FILE *f,const char *initname)
 {
   int irep_no, irep_num;
 
-  if (mrb == 0 || n < 0 || n >= mrb->irep_len || f == 0 || initname == 0)
+  if (mrb == NULL || n < 0 || n >= mrb->irep_len || f == NULL || initname == NULL)
     return -1;
 
   irep_num = mrb->irep_len - n;

--- a/src/dump.c
+++ b/src/dump.c
@@ -335,7 +335,7 @@ write_pool_block(mrb_state *mrb, mrb_irep *irep, char *buf, int type)
   uint16_t len =0;
 
   buf_size = MRB_DUMP_DEFAULT_STR_LEN;
-  if ((char_buf = (char *)mrb_malloc(mrb, buf_size)) == 0)
+  if ((char_buf = (char *)mrb_malloc(mrb, buf_size)) == NULL)
     goto error_exit;
 
   buf += uint32_dump((uint32_t)irep->plen, buf, type); /* number of pool */
@@ -358,7 +358,7 @@ write_pool_block(mrb_state *mrb, mrb_irep *irep, char *buf, int type)
       len = str_dump_len(RSTRING_PTR(str), RSTRING_LEN(str), type);
       if (len > buf_size - 1) {
         buf_size = len + 1;
-        if ((char_buf = (char *)mrb_realloc(mrb, char_buf, buf_size)) == 0)
+        if ((char_buf = (char *)mrb_realloc(mrb, char_buf, buf_size)) == NULL)
           goto error_exit;
         memset(char_buf, 0, buf_size);
       }
@@ -371,7 +371,7 @@ write_pool_block(mrb_state *mrb, mrb_irep *irep, char *buf, int type)
       len = str_dump_len(RSTRING_PTR(str), RSTRING_LEN(str), type);
       if ( len > buf_size - 1) {
         buf_size = len + 1;
-        if ((char_buf = mrb_realloc(mrb, char_buf, buf_size)) == 0)
+        if ((char_buf = mrb_realloc(mrb, char_buf, buf_size)) == NULL)
           goto error_exit;
         memset(char_buf, 0, buf_size);
       }
@@ -405,7 +405,7 @@ write_syms_block(mrb_state *mrb, mrb_irep *irep, char *buf, int type)
   uint16_t buf_size =0;
 
   buf_size = MRB_DUMP_DEFAULT_STR_LEN;
-  if ((char_buf = (char *)mrb_malloc(mrb, buf_size)) == 0)
+  if ((char_buf = (char *)mrb_malloc(mrb, buf_size)) == NULL)
     goto error_exit;
 
   buf += uint32_dump((uint32_t)irep->slen, buf, type); /* number of symbol */
@@ -421,7 +421,7 @@ write_syms_block(mrb_state *mrb, mrb_irep *irep, char *buf, int type)
       nlen = str_dump_len((char*)name, len, type);
       if ( nlen > buf_size - 1) {
         buf_size = nlen + 1;
-        if ((char_buf = (char *)mrb_realloc(mrb, char_buf, buf_size)) == 0)
+        if ((char_buf = (char *)mrb_realloc(mrb, char_buf, buf_size)) == NULL)
           goto error_exit;
       }
       memset(char_buf, 0, buf_size);
@@ -457,7 +457,7 @@ calc_crc_section(mrb_state *mrb, mrb_irep *irep, uint16_t *crc, int section)
   default: return MRB_DUMP_GENERAL_FAILURE;
   }
 
-  if ((buf = (char *)mrb_calloc(mrb, 1, buf_size)) == 0)
+  if ((buf = (char *)mrb_calloc(mrb, 1, buf_size)) == NULL)
     return MRB_DUMP_GENERAL_FAILURE;
 
   buf_top = buf;
@@ -542,7 +542,7 @@ write_irep_record(mrb_state *mrb, int irep_no, char* bin, uint32_t *rlen, int ty
   mrb_irep *irep = mrb->irep[irep_no];
   int section;
 
-  if (irep == 0)
+  if (irep == NULL)
     return MRB_DUMP_INVALID_IREP;
 
   /* buf alloc */
@@ -586,7 +586,7 @@ dump_irep_record(mrb_state *mrb, int irep_no, FILE* fp, uint32_t *rlen)
   char *buf;
   mrb_irep *irep = mrb->irep[irep_no];
 
-  if (irep == 0)
+  if (irep == NULL)
     return MRB_DUMP_INVALID_IREP;
 
   /* buf alloc */
@@ -594,7 +594,7 @@ dump_irep_record(mrb_state *mrb, int irep_no, FILE* fp, uint32_t *rlen)
   if (irep_record_size == 0)
     return MRB_DUMP_GENERAL_FAILURE;
 
-  if ((buf = (char *)mrb_calloc(mrb, 1, irep_record_size)) == 0)
+  if ((buf = (char *)mrb_calloc(mrb, 1, irep_record_size)) == NULL)
     return MRB_DUMP_GENERAL_FAILURE;
 
   if ((rc = write_irep_record(mrb, irep_no, buf, rlen, DUMP_TYPE_HEX)) != MRB_DUMP_OK) {
@@ -620,7 +620,7 @@ mrb_write_irep(mrb_state *mrb, int top, char *bin)
   int irep_no;
   char *bin_top;
 
-  if (mrb == 0 || top < 0 || top >= mrb->irep_len || bin == 0)
+  if (mrb == NULL || top < 0 || top >= mrb->irep_len || bin == NULL)
     return MRB_DUMP_INVALID_ARGUMENT;
 
   bin_top = bin;
@@ -648,7 +648,7 @@ mrb_dump_irep(mrb_state *mrb, int top, FILE* fp)
   uint32_t rlen=0; /* size of irep record */
   int irep_no;
 
-  if (mrb == 0 || top < 0 || top >= mrb->irep_len || fp == 0)
+  if (mrb == NULL || top < 0 || top >= mrb->irep_len || fp == NULL)
     return MRB_DUMP_INVALID_ARGUMENT;
 
   if (fwrite(&def_rite_file_header, sizeof(rite_file_header), 1, fp) != 1) /* dummy write */
@@ -678,7 +678,7 @@ mrb_bdump_irep(mrb_state *mrb, int n, FILE *f,const char *initname)
   int buf_size = 0;
   int buf_idx = 0;
 
-  if (mrb == 0 || n < 0 || n >= mrb->irep_len || f == 0 || initname == 0)
+  if (mrb == NULL || n < 0 || n >= mrb->irep_len || f == NULL || initname == NULL)
     return -1;
 
   buf_size = sizeof(rite_binary_header) + MRB_DUMP_SIZE_OF_SHORT/* crc */;
@@ -686,7 +686,7 @@ mrb_bdump_irep(mrb_state *mrb, int n, FILE *f,const char *initname)
     buf_size += get_irep_record_size(mrb, irep_no, DUMP_TYPE_BIN);
   buf_size += MRB_DUMP_SIZE_OF_LONG; /* end of file */
 
-  if ((buf = (char *)mrb_malloc(mrb, buf_size)) == 0)
+  if ((buf = (char *)mrb_malloc(mrb, buf_size)) == NULL)
     return MRB_DUMP_GENERAL_FAILURE;
 
   rc = mrb_write_irep(mrb, n, buf);

--- a/src/load.c
+++ b/src/load.c
@@ -143,7 +143,7 @@ load_rite_irep_record(mrb_state *mrb, RiteFILE* rfp, unsigned char* dst, uint32_
   uint16_t buf_size =0;
 
   buf_size = MRB_DUMP_DEFAULT_STR_LEN;
-  if ((char_buf = (char *)mrb_malloc(mrb, buf_size)) == 0)
+  if ((char_buf = (char *)mrb_malloc(mrb, buf_size)) == NULL)
     goto error_exit;
 
   pStart = dst;
@@ -192,7 +192,7 @@ load_rite_irep_record(mrb_state *mrb, RiteFILE* rfp, unsigned char* dst, uint32_
 
     if ( pdl > buf_size - 1) {
       buf_size = pdl + 1;
-      if ((char_buf = (char *)mrb_realloc(mrb, char_buf, buf_size)) == 0)
+      if ((char_buf = (char *)mrb_realloc(mrb, char_buf, buf_size)) == NULL)
         goto error_exit;
     }
     memset(char_buf, '\0', buf_size);
@@ -219,7 +219,7 @@ load_rite_irep_record(mrb_state *mrb, RiteFILE* rfp, unsigned char* dst, uint32_
 
     if ( snl > buf_size - 1) {
       buf_size = snl + 1;
-      if ((char_buf = (char *)mrb_realloc(mrb, char_buf, buf_size)) == 0)
+      if ((char_buf = (char *)mrb_realloc(mrb, char_buf, buf_size)) == NULL)
         goto error_exit;
     }
     memset(char_buf, '\0', buf_size);


### PR DESCRIPTION
0 in pointer calculation will be cast to (void *)0 since C99 guarantees.
So they are not bug fixes.

But it decrease the readability for human to jumble NULL and 0, I think.
