### PR TITLE
fix cannot get/set const variable form singleton class

### DIFF
--- a/src/variable.c
+++ b/src/variable.c
@@ -674,6 +674,7 @@ mod_const_check(mrb_state *mrb, mrb_value mod)
   switch (mrb_type(mod)) {
   case MRB_TT_CLASS:
   case MRB_TT_MODULE:
+  case MRB_TT_SCLASS:
     break;
   default:
     mrb_raise(mrb, E_TYPE_ERROR, "constant look-up for non class/module");


### PR DESCRIPTION
Example:

``` ruby
class T
  class << self
    VERSION = "1.0.0"
  end
end

p T.singleton_class::VERSION
```

Ruby 1.9.2 ouput:

``` ruby
"1.0.0"
```

MRuby ouput:

``` ruby
TypeError: constant look-up for non class/module
```
