### PR TITLE
fix mruby exit status with mrb file.

### DIFF
--- a/tools/mruby/mruby.c
+++ b/tools/mruby/mruby.c
@@ -113,7 +113,7 @@ append_cmdline:
     case '-':
       if (strcmp((*argv) + 2, "version") == 0) {
         mrb_show_version(mrb);
-	exit(0);
+        exit(0);
       }
       else if (strcmp((*argv) + 2, "verbose") == 0) {
         args->verbose = 1;
@@ -121,7 +121,7 @@ append_cmdline:
       }
       else if (strcmp((*argv) + 2, "copyright") == 0) {
         mrb_show_copyright(mrb);
-	exit(0);
+        exit(0);
       }
       else return -3;
       return 0;
@@ -135,8 +135,8 @@ append_cmdline:
     else {
       args->rfp = fopen(argv[0], args->mrbfile ? "rb" : "r");
       if (args->rfp == NULL) {
-	printf("%s: Cannot open program file. (%s)\n", *origargv, *argv);
-	return 0;
+        printf("%s: Cannot open program file. (%s)\n", *origargv, *argv);
+        return 0;
       }
       args->fname = 1;
       args->cmdline = argv[0];
@@ -196,8 +196,10 @@ main(int argc, char **argv)
     }
     else if (!args.check_syntax) {
       mrb_run(mrb, mrb_proc_new(mrb, mrb->irep[n]), mrb_top_self(mrb));
+      n = 0;
       if (mrb->exc) {
-	p(mrb, mrb_obj_value(mrb->exc));
+        p(mrb, mrb_obj_value(mrb->exc));
+        n = -1;
       }
     }
   }
@@ -221,7 +223,7 @@ main(int argc, char **argv)
     mrbc_context_free(mrb, c);
     if (mrb->exc) {
       if (!mrb_undef_p(v)) {
-	p(mrb, mrb_obj_value(mrb->exc));
+        p(mrb, mrb_obj_value(mrb->exc));
       }
       n = -1;
     }


### PR DESCRIPTION
```
$ cat a.rb
puts "hello"

$ ./bin/mruby a.rb; echo $?
hello
0

$ ./bin/mrbc a.rb
$ ./bin/mruby -b a.mrb; echo $?
hello
1  # not success (this patch fixes)
```

and,  some correct indents.
