### PR TITLE
fix when mruby parse embedded rd document, mruby throw a syntax error.

### DIFF
--- a/src/parse.y
+++ b/src/parse.y
@@ -3162,9 +3162,12 @@ skips(parser_state *p, const char *s)
       int len = strlen(s);
 
       while (len--) {
-	nextc(p);
+        nextc(p);
       }
       return TRUE;
+    }
+	else{
+      s--;
     }
   }
   return FALSE;


### PR DESCRIPTION
Example：

``` ruby
=begin
 =end
=end

=begin
 = end
=end

=begin
 = eeeeeend
=end

=begin
g_game = RavenGame.new

1000.times do |i|
  g_game.update
end
=end

p "Test"

```

These embedded rd documents could make mruby throw syntax error.
