### PR TITLE
delete needless output in String#[]=

### DIFF
--- a/mrblib/string.rb
+++ b/mrblib/string.rb
@@ -133,7 +133,6 @@ class String
   def []=(pos, value)
     b = self[0, pos]
     a = self[pos+1..-1]
-    p [b, value, a].join('')
     self.replace([b, value, a].join(''))
   end
 end


### PR DESCRIPTION
There is needless output in String#[]= .

Example:

``` ruby
s = "abcd"
s[0]= "X"

p s
```

mruby output:

``` ruby
"Xbcd"
"Xbcd"
```
