### PR TITLE
The output of Kernel#instance_variables contains instance variables and ...

### DIFF
--- a/src/variable.c
+++ b/src/variable.c
@@ -580,7 +580,7 @@ iv_i(mrb_state *mrb, mrb_sym sym, mrb_value v, void *p)
 
   ary = *(mrb_value*)p;
   s = mrb_sym2name_len(mrb, sym, &len);
-  if (len > 1 && s[0] == '@') {
+  if (len > 1 && s[0] == '@' && s[1] != '@') {
     mrb_ary_push(mrb, ary, mrb_symbol_value(sym));
   }
   return 0;


### PR DESCRIPTION
Example:

``` ruby
class One
  @ivar  = 1
  @@var1 = 1
end

p One.instance_variables 
```

ruby 1.9.x output:

``` ruby
[:@ivar]
```

mruby output:

``` ruby
[:@@var1, :@ivar]
```
