### PR TITLE
fix broken error message

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -853,7 +853,7 @@ mrb_method_search(mrb_state *mrb, struct RClass* c, mrb_sym mid)
   m = mrb_method_search_vm(mrb, &c, mid);
   if (!m) {
     mrb_value inspect = mrb_funcall(mrb, mrb_obj_value(c), "inspect", 0);
-    if (RSTRING_LEN(inspect) > 150) {
+    if (RSTRING_LEN(inspect) > 64) {
       inspect = mrb_any_to_s(mrb, mrb_obj_value(c));
     }
     mrb_raisef(mrb, E_NAME_ERROR, "undefined method '%s' for class %s",
@@ -1015,7 +1015,7 @@ mrb_bob_missing(mrb_state *mrb, mrb_value mod)
   }
 
   mrb_value inspect = mrb_funcall(mrb, mod, "inspect", 0);
-  if (RSTRING_LEN(inspect) > 150) {
+  if (RSTRING_LEN(inspect) > 64) {
     inspect = mrb_any_to_s(mrb, mod);
   }
 


### PR DESCRIPTION
A long inspect string, the output will be corrupted.

```
### before
% ./bin/mruby -e '("a"*230).notfoundmethod'
trace:
    [0] -e:1
-e:1: undefined method 'notfoundmethod' for "aaaaa (--snip--) aaaaaf?0?Cz?c?&??? (NoMethodError)

### after
% ./bin/mruby -e '("a"*62).notfoundmethod'
trace:
    [0] -e:1
-e:1: undefined method 'notfoundmethod' for "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" (NoMethodError)
% ./bin/mruby -e '("a"*63).notfoundmethod'
trace:
    [0] -e:1
-e:1: undefined method 'notfoundmethod' for #<String:0x7fee94024d18> (NoMethodError)
```
