### PR TITLE
Fix build on a c++ compiler

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -325,7 +325,7 @@ struct RBasic*
 mrb_obj_alloc(mrb_state *mrb, enum mrb_vtype ttype, struct RClass *cls)
 {
   struct RBasic *p;
-  static const RVALUE RVALUE_zero = { { { 0 } } };
+  static const RVALUE RVALUE_zero = { { { MRB_TT_FALSE } } };
 
 #ifdef MRB_GC_STRESS
   mrb_garbage_collect(mrb);

--- a/src/state.c
+++ b/src/state.c
@@ -53,7 +53,7 @@ mrb_alloca(mrb_state *mrb, size_t size)
 {
   struct alloca_header *p;
 
-  p = mrb_malloc(mrb, sizeof(struct alloca_header)+size);
+  p = (struct alloca_header*) mrb_malloc(mrb, sizeof(struct alloca_header)+size);
   p->next = mrb->mems;
   mrb->mems = p;
   return (void*)p->buf;


### PR DESCRIPTION
Hi there,

This commits fix the build on a c++ compiler. It is tested on clang++ and g++. I understand that you want to follow the C99 standard. But why not make it compatible on more compilers?

But still feel free to ignore this commits if you do not care about c++ compilers:) Thanks for your help.
