### PR TITLE
fix incorrect mrb->irep initialization

### DIFF
--- a/src/state.c
+++ b/src/state.c
@@ -126,7 +126,7 @@ mrb_add_irep(mrb_state *mrb, int idx)
       mrb->irep_capa *= 2;
     }
     mrb->irep = (mrb_irep **)mrb_realloc(mrb, mrb->irep, sizeof(mrb_irep*)*mrb->irep_capa);
-    for (i = old_capa; i < mrb->irep_capa - old_capa; i++) {
+    for (i = old_capa; i < mrb->irep_capa; i++) {
       mrb->irep[i] = NULL;
     }
   }


### PR DESCRIPTION
I found a error in function _mrb_add_irep_

``` C
void
mrb_add_irep(mrb_state *mrb, int idx)
{
  if (!mrb->irep) {
    int max = 256;

    if (idx > max) max = idx+1;
    mrb->irep = (mrb_irep **)mrb_calloc(mrb, max, sizeof(mrb_irep*));
    mrb->irep_capa = max;
  }
  else if (mrb->irep_capa <= idx) {
    int i;
    size_t old_capa = mrb->irep_capa;
    while (mrb->irep_capa <= idx) {
      mrb->irep_capa *= 2;
    }
    mrb->irep = (mrb_irep **)mrb_realloc(mrb, mrb->irep, sizeof(mrb_irep*)*mrb->irep_capa);
    for (i = old_capa; i < mrb->irep_capa - old_capa; i++) {   // ------> here 
      mrb->irep[i] = NULL;
    }
  }
}
```

Let's  assume:
**old_capa** = 512
**mrb->irep_capa** = 1024
So,  **mrb->irep_capa** - **old_capa**  = 512

``` c
for (i = old_capa; i < mrb->irep_capa - old_capa; i++)
```

described  as

``` c
for (i = 512 ; i < 512 ; i++)  //  This is an invalid "for(...)"
```

And,sometimes, the error can cause mruby crash (Mac OS 10.7.3, WinXP sp2).
