### PR TITLE
modify Module#class_variables test

### DIFF
--- a/test/t/module.rb
+++ b/test/t/module.rb
@@ -34,14 +34,13 @@ end
 assert('Module#class_variables', '15.2.2.4.19') do
   class Test4ClassVariables1
     @@var1 = 1
-    @@var2 = 2
   end
   class Test4ClassVariables2 < Test4ClassVariables1
-    @@var3 = 2
+    @@var2 = 2
   end
 
-  Test4ClassVariables1.class_variables == [:@@var1, :@@var2] &&
-  Test4ClassVariables2.class_variables == [:@@var3]
+  Test4ClassVariables1.class_variables == [:@@var1] &&
+  Test4ClassVariables2.class_variables == [:@@var2]
 end
 
 assert('Module#const_defined?', '15.2.2.4.20') do


### PR DESCRIPTION
``` ruby
assert('Module#class_variables', '15.2.2.4.19') do
  class Test4ClassVariables1
    @@var1 = 1
    @@var2 = 2
  end
  class Test4ClassVariables2 < Test4ClassVariables1
    @@var3 = 2
  end

  Test4ClassVariables1.class_variables == [:@@var1, :@@var2] &&
  Test4ClassVariables2.class_variables == [:@@var3]
end
```

Because **iv_tbl**  do not guarantee the order of it's value, so the result of _Test4ClassVariables1.class_variables_ is _[:@@var1, :@@var2]_ or _[:@@var2, :@@var1]_. 
In _[:@@var2, :@@var1]_ case, _Test4ClassVariables1.class_variables == [:@@var1, :@@var2]_ is **false** .
