### PR TITLE
modify method flag in method:mrb_obj_methods_m

### DIFF
--- a/src/kernel.c
+++ b/src/kernel.c
@@ -822,7 +822,7 @@ mrb_obj_methods_m(mrb_state *mrb, mrb_value self)
   int argc;
 
   mrb_get_args(mrb, "*", &argv, &argc);
-  return mrb_obj_methods(mrb, argc, argv, self, (mrb_method_flag_t)0); /* everything but private */
+  return mrb_obj_methods(mrb, argc, argv, self, (mrb_method_flag_t)-1); /* everything but private */
 }
 
 /* 15.3.1.3.32 */


### PR DESCRIPTION
``` C
mrb_value
mrb_obj_methods_m(mrb_state *mrb, mrb_value self)
{
  ......
  return mrb_obj_methods(mrb, argc, argv, self, (mrb_method_flag_t)0); /* everything but private */
}
```

Because _NOEX_PUBLIC_ is also equal to 0, so "0" at _mrb_obj_methods_m_  potentially confusing.

And the code of ruby 1.9.x, the flag is -1.

``` C
static int
ins_methods_i(st_data_t name, st_data_t type, st_data_t ary)
{
    return ins_methods_push((ID)name, (long)type, (VALUE)ary, -1); /* everything but private */
}
```
