### PR TITLE
Stop warning: extra ';' outside of a function

### DIFF
--- a/include/mruby/proc.h
+++ b/include/mruby/proc.h
@@ -52,7 +52,7 @@ struct RProc *mrb_closure_new(mrb_state*, mrb_irep*);
 void mrb_proc_copy(struct RProc *a, struct RProc *b);
 
 #include "mruby/khash.h"
-KHASH_DECLARE(mt, mrb_sym, struct RProc*, 1);
+KHASH_DECLARE(mt, mrb_sym, struct RProc*, 1)
 
 #if defined(__cplusplus)
 }  /* extern "C" { */

--- a/src/class.c
+++ b/src/class.c
@@ -15,7 +15,7 @@
 #include "mruby/array.h"
 #include "error.h"
 
-KHASH_DEFINE(mt, mrb_sym, struct RProc*, 1, kh_int_hash_func, kh_int_hash_equal);
+KHASH_DEFINE(mt, mrb_sym, struct RProc*, 1, kh_int_hash_func, kh_int_hash_equal)
 
 typedef struct fc_result {
     mrb_sym name;

--- a/src/hash.c
+++ b/src/hash.c
@@ -29,8 +29,8 @@ mrb_hash_ht_hash_equal(mrb_state *mrb, mrb_value a, mrb_value b)
   return mrb_eql(mrb, a, b);
 }
 
-KHASH_DECLARE(ht, mrb_value, mrb_value, 1);
-KHASH_DEFINE (ht, mrb_value, mrb_value, 1, mrb_hash_ht_hash_func, mrb_hash_ht_hash_equal);
+KHASH_DECLARE(ht, mrb_value, mrb_value, 1)
+KHASH_DEFINE (ht, mrb_value, mrb_value, 1, mrb_hash_ht_hash_func, mrb_hash_ht_hash_equal)
 
 static void mrb_hash_modify(mrb_state *mrb, mrb_value hash);
 

--- a/src/variable.c
+++ b/src/variable.c
@@ -256,7 +256,7 @@ iv_free(mrb_state *mrb, iv_tbl *t)
 #endif
 
 KHASH_DECLARE(iv, mrb_sym, mrb_value, 1)
-KHASH_DEFINE(iv, mrb_sym, mrb_value, 1, kh_int_hash_func, kh_int_hash_equal);
+KHASH_DEFINE(iv, mrb_sym, mrb_value, 1, kh_int_hash_func, kh_int_hash_equal)
 
 typedef struct iv_tbl {
   khash_t(iv) h;


### PR DESCRIPTION
``` sh
$ make clean all CFLAGS="-pedantic" CC=clang
```

Stop the following warning:

```
warning: extra ';' outside of a function [-Wpedantic]
```
