### PR TITLE
Fix compile warnings in mirb

### DIFF
--- a/tools/mirb/mirb.c
+++ b/tools/mirb/mirb.c
@@ -5,7 +5,7 @@
 ** an interactive way and executes it
 ** immediately. It's a REPL...
 */
- 
+
 #include <string.h>
 
 #include <mruby.h>
@@ -143,7 +143,7 @@ print_cmdline(int code_block_open)
 int
 main(void)
 {
-  char last_char;
+  int last_char;
   char ruby_code[1024] = { 0 };
   char last_code_line[1024] = { 0 };
   int char_index;
@@ -156,7 +156,7 @@ main(void)
 
   print_hint();
 
-  /* new interpreter instance */ 
+  /* new interpreter instance */
   mrb = mrb_open();
   if (mrb == NULL) {
     fprintf(stderr, "Invalid mrb interpreter, exiting mirb");
@@ -207,7 +207,7 @@ main(void)
     parser->send = ruby_code + strlen(ruby_code);
     parser->lineno = 1;
     mrb_parser_parse(parser, cxt);
-    code_block_open = is_code_block_open(parser); 
+    code_block_open = is_code_block_open(parser);
 
     if (code_block_open) {
       /* no evaluation of code */


### PR DESCRIPTION
Change last_char type to int
Warnings
mirb.c:174:7: warning: comparison is always false due to limited range of data type [-Wtype-limits]
warning: comparison is always false due to limited range of data type [-Wtype-limits]
