### PR TITLE
add check_const_name for Module#const_defined?/const_get/const_set

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -1483,6 +1483,8 @@ mrb_mod_const_set(mrb_state *mrb, mrb_value mod)
 {
   mrb_value sym, value;
   mrb_get_args(mrb, "oo", &sym, &value);
+
+  check_const_name(mrb, mrb_sym_value(mrb,sym));
   mrb_const_set(mrb, mod, mrb_sym_value(mrb, sym), value);
   return value;
 }


### PR DESCRIPTION
_Module#const_defined?_, _Module#const_get_ and _Module#const_set_ these methods didn't check name for constant variable, so, it'll cause some problem. 
Example:

``` ruby
class A
  CONST1 = 10 
  @iv = 1
  @@cv= 2
end
```

Test in ruby 1.9.x's irb:

``` ruby
A.const_defined? :CONST1 # => ture
A.const_defined? :@iv  # => NameError: wrong constant name @iv
A.const_defined? :@@cv # => NameError: wrong constant name @@cv
A.const_get :@iv       # => NameError: wrong constant name @iv
A.const_get :@@cv      # => NameError: wrong constant name @@cv
A.const_set :@iv, 100  # => NameError: wrong constant name @iv
```

Test in mruby's mirb:

``` ruby
A.const_defined? :CONST1 # => ture
A.const_defined? :@iv  # => true
A.const_defined? :@@cv # => true
A.const_get :@iv       # => 1
A.const_get :@@cv      # => 2
A.const_set :@iv, 100  # => 100
```
