### PR TITLE
Fix loss of MSB in conditions of octal formatted string

### DIFF
--- a/src/parse.y
+++ b/src/parse.y
@@ -3307,7 +3307,8 @@ read_escape(parser_state *p)
        int buf[3];
        int i;
 
-       for (i=0; i<3; i++) {
+       buf[0] = c;
+       for (i=1; i<3; i++) {
 	 buf[i] = nextc(p);
 	 if (buf[i] == -1) goto eof;
 	 if (buf[i] < '0' || '7' < buf[i]) {


### PR DESCRIPTION
This patch fixes following bug:

> p "\377"
> "?"
>  => "?"
> 
> p "\377"
> "\377"
>  => "\377"
