### PR TITLE
Fix out of boundary scan in case of octal formatted string

### DIFF
--- a/src/parse.y
+++ b/src/parse.y
@@ -3316,7 +3316,7 @@ read_escape(parser_state *p)
 	   break;
 	 }
        }
-       c = scan_oct(buf, i+1, &i);
+       c = scan_oct(buf, i, &i);
     }
     return c;
 


### PR DESCRIPTION
This patch fixes a side effect of #2e7953536e
