### PR TITLE
Mention mrbgems in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ To run the tests, execute the following from the project's root directory.
 
     $ make test
 
+## Customization
+
+mruby contains a package manager called *mrbgems*. To create extensions
+in C and/or Ruby you should create a *GEM*. You will find a complete
+documentation with examples under *doc/mrbgems*.
+
 ## License
 
 Copyright (c) 2012 mruby developers


### PR DESCRIPTION
I point to the doc/mrbgems folder from the README,
