### PR TITLE
Fix: A GEM with a Dash inside of the name doesn't work.

### DIFF
--- a/mrbgems/Makefile4gem
+++ b/mrbgems/Makefile4gem
@@ -49,14 +49,14 @@ gem_mixlib.c : gem_mrblib_header.ctmp gem_mrblib_irep.ctmp gem_mixlib_init.ctmp
 	cat $^ > $@
 
 gem_mixlib_init.ctmp :
-	$(MRUBY_ROOT)/mrbgems/generator gem_mixlib $(GEM) "$(ACTIVE_GEMS)" > $@
+	$(MRUBY_ROOT)/mrbgems/generator gem_mixlib $(GEM) > $@
 
 # Building target for C files
 gem-c-files : gem_srclib.o
 	$(AR) rs $(GEM_PACKAGE) $(GEM_OBJECTS) $<
 
 gem_srclib.c :
-	$(MRUBY_ROOT)/mrbgems/generator gem_srclib $(GEM) "$(ACTIVE_GEMS)" > $@
+	$(MRUBY_ROOT)/mrbgems/generator gem_srclib $(GEM) > $@
 
 # Building target for Ruby Files
 gem-rb-files : gem_mrblib.o
@@ -66,10 +66,10 @@ gem_mrblib.c : gem_mrblib_header.ctmp gem_mrblib_irep.ctmp gem_mrblib_init.ctmp
 	cat $^ > $@
 
 gem_mrblib_header.ctmp :
-	$(MRUBY_ROOT)/mrbgems/generator gem_mrblib "$(ACTIVE_GEMS)" > $@
+	$(MRUBY_ROOT)/mrbgems/generator gem_mrblib > $@
 
 gem_mrblib_init.ctmp :
-	$(MRUBY_ROOT)/mrbgems/generator gem_mrblib $(GEM) "$(ACTIVE_GEMS)" > $@
+	$(MRUBY_ROOT)/mrbgems/generator gem_mrblib $(GEM) > $@
 
 gem_mrblib_irep.ctmp : gem_mrblib.rbtmp
 	$(MRUBY_ROOT)/bin/mrbc -Bgem_mrblib_irep_$(GEM) -o$@ $<


### PR DESCRIPTION
While porting @mattn 's mruby-md5 binding to mrbgems (https://github.com/mattn/mruby-md5/pull/1) we figured out that the current mrbgems implementation has a flaw with a dash inside of the name. A dash can be used in a directory but not in a C function. Due to the reason that the current implementation used the same name for the "init" C function and the folder this wasn't working. I integrated this special case. I will have a closer look afterwards if it is even possible to overcome this issue from a design point of view.
