### PR TITLE
fix incorrect checkups in check_iv_name

### DIFF
--- a/src/kernel.c
+++ b/src/kernel.c
@@ -564,7 +564,7 @@ check_iv_name(mrb_state *mrb, mrb_sym id)
   int len;
 
   s = mrb_sym2name_len(mrb, id, &len);
-  if (len < 2 || s[0] != '@') {
+  if (len < 2 || !(s[0] == '@' && s[1] != '@')) {
     mrb_name_error(mrb, id, "`%s' is not allowed as an instance variable name", s);
   }
 }


### PR DESCRIPTION
The checkups in check_iv_name should be more strict.

Example:

``` ruby
class Test4CheckIVName
  @iv = 1
  @@cv = 2 
end

p Test4CheckIVName.instance_variable_get(:@iv)
p Test4CheckIVName.instance_variable_get(:@@cv) # should be throw a error，beacase @@cv is a class variable, not a instance variable.
```

Ruby 1.9.x output:

``` ruby
1
`@@cv' is not allowed as an instance variable name (NameError)
```

But in mruby:

``` ruby
1
2
```
