### PR TITLE
Fix memory leak in String#to_i and String#to_f.

### DIFF
--- a/src/string.c
+++ b/src/string.c
@@ -2544,12 +2544,8 @@ mrb_str_to_inum(mrb_state *mrb, mrb_value str, int base, int badcheck)
   if (s) {
     len = RSTRING_LEN(str);
     if (s[len]) {    /* no sentinel somehow */
-      char *p = (char *)mrb_malloc(mrb, len+1);
-
-      //MEMCPY(p, s, char, len);
-      memcpy(p, s, len);
-      p[len] = '\0';
-      s = p;
+      struct RString *temp_str = str_new(mrb, s, len);
+      s = temp_str->ptr;
     }
   }
   return mrb_cstr_to_inum(mrb, s, base, badcheck);
@@ -2681,11 +2677,8 @@ mrb_str_to_dbl(mrb_state *mrb, mrb_value str, int badcheck)
       mrb_raise(mrb, E_ARGUMENT_ERROR, "string for Float contains null byte");
     }
     if (s[len]) {    /* no sentinel somehow */
-      char *p = (char *)mrb_malloc(mrb, len+1);
-
-      memcpy(p, s, len);
-      p[len] = '\0';
-      s = p;
+      struct RString *temp_str = str_new(mrb, s, len);
+      s = temp_str->ptr;
     }
   }
   return mrb_cstr_to_dbl(mrb, s, badcheck);


### PR DESCRIPTION
String#to_i causes memory leak if the receiver is a shared string.

Use str_new instead of mrb_malloc so that GC can manage the buffer.

Error case:

``` ruby
a = "0x10000 aaaaaaaaaaaaaaaaaaaaa".slice(0 .. 3)
100000000.times do
  a.to_f
end
```
