### PR TITLE
add mrb_proc2closure

### DIFF
--- a/include/mruby/proc.h
+++ b/include/mruby/proc.h
@@ -49,6 +49,7 @@ struct RProc {
 struct RProc *mrb_proc_new(mrb_state*, mrb_irep*);
 struct RProc *mrb_proc_new_cfunc(mrb_state*, mrb_func_t);
 struct RProc *mrb_closure_new(mrb_state*, mrb_irep*);
+struct RProc *mrb_proc2closure(mrb_state *mrb, struct RProc *p, unsigned int nlocals);
 void mrb_proc_copy(struct RProc *a, struct RProc *b);
 
 #include "mruby/khash.h"

--- a/src/proc.c
+++ b/src/proc.c
@@ -27,14 +27,13 @@ mrb_proc_new(mrb_state *mrb, mrb_irep *irep)
 }
 
 struct RProc *
-mrb_closure_new(mrb_state *mrb, mrb_irep *irep)
+mrb_proc2closure(mrb_state *mrb, struct RProc *p, unsigned int nlocals)
 {
-  struct RProc *p = mrb_proc_new(mrb, irep);
   struct REnv *e;
 
   if (!mrb->ci->env) {
     e = (struct REnv*)mrb_obj_alloc(mrb, MRB_TT_ENV, (struct RClass*)mrb->ci->proc->env);
-    e->flags= (unsigned int)mrb->ci->proc->body.irep->nlocals;
+    e->flags= nlocals;
     e->mid = mrb->ci->mid;
     e->cioff = mrb->ci - mrb->cibase;
     e->stack = mrb->stack;
@@ -45,6 +44,14 @@ mrb_closure_new(mrb_state *mrb, mrb_irep *irep)
   }
   p->env = e;
   return p;
+}
+
+struct RProc *
+mrb_closure_new(mrb_state *mrb, mrb_irep *irep)
+{
+  struct RProc *p = mrb_proc_new(mrb, irep);
+  return mrb_proc2closure(mrb, p,
+    (unsigned int)mrb->ci->proc->body.irep->nlocals);
 }
 
 struct RProc *


### PR DESCRIPTION
Would be nice to have a way to make a cfunc proc or existing irep proc into a closure. Right now it's not possible since mrb_closure_new can only take an irep. I suggest something like this, feel free to change details.

I provide nlocals as an argument so it can be used for cfunc also, since normally nlocals is read from irep, which is not there for cfunc.
Perhaps it would be better to define an extra internal _inline_ function that does this, and call it from both mrb_proc2closure and mrb_capture_new (just for performance reasons). It depends how much you care for the extra asm jmp.
