### PR TITLE
Stop warning in compiling proc.c

### DIFF
--- a/src/proc.c
+++ b/src/proc.c
@@ -43,7 +43,7 @@ closure_setup(mrb_state *mrb, struct RProc *p, int nlocals)
     e = mrb->ci->env;
   }
   p->env = e;
-  return p;
+  return;
 }
 
 struct RProc *


### PR DESCRIPTION
```
proc.c:46: warning: ‘return’ with a value, in function returning void
```

introduced in f312af11.
