### PR TITLE
closure_setup shouldn't return something

### DIFF
--- a/src/proc.c
+++ b/src/proc.c
@@ -43,7 +43,7 @@ closure_setup(mrb_state *mrb, struct RProc *p, int nlocals)
     e = mrb->ci->env;
   }
   p->env = e;
-  return p;
+  return;
 }
 
 struct RProc *


### PR DESCRIPTION
closure_setup is defined as static void. I removed the rproc which was returned due to the reason that nobody is receiving it nevertheless. I hope that wasn't some kind of hack I overlooked :)
