### PR TITLE
mrbgems - remove static RClass

### DIFF
--- a/doc/mrbgems/c_extension_example/src/example.c
+++ b/doc/mrbgems/c_extension_example/src/example.c
@@ -1,8 +1,6 @@
 #include <mruby.h>
 #include <stdio.h>
 
-static struct RClass *_class_cextension;
-
 static mrb_value
 mrb_c_method(mrb_state *mrb, mrb_value self)
 {
@@ -12,6 +10,6 @@ mrb_c_method(mrb_state *mrb, mrb_value self)
 
 void
 mrb_c_extension_example_gem_init(mrb_state* mrb) {
-  _class_cextension = mrb_define_module(mrb, "CExtension");
-  mrb_define_class_method(mrb, _class_cextension, "c_method", mrb_c_method, ARGS_NONE());
+  struct RClass *class_cextension = mrb_define_module(mrb, "CExtension");
+  mrb_define_class_method(mrb, class_cextension, "c_method", mrb_c_method, ARGS_NONE());
 }


### PR DESCRIPTION
As suggested by @masuidrive remove static RClass in mrbgems examples as already done here by @matz: ce56f19b02a0c9ddd5715750b34cf7f9554f19f4
