### PR TITLE
Mrbgems Dash Issue and better cleanup

### DIFF
--- a/mrbgems/Makefile4gem
+++ b/mrbgems/Makefile4gem
@@ -69,7 +69,7 @@ gem_mrblib_init.ctmp :
 	$(MRUBY_ROOT)/mrbgems/generator gem_mrblib $(GEM) > $@
 
 gem_mrblib_irep.ctmp : gem_mrblib.rbtmp
-	$(MRUBY_ROOT)/bin/mrbc -Bgem_mrblib_irep_$(GEM) -o$@ $<
+	$(MRUBY_ROOT)/bin/mrbc -Bgem_mrblib_irep_$(subst -,_,$(GEM)) -o$@ $<
 
 gem_mrblib.rbtmp :
 	cat $(GEM_RB_FILES) > $@


### PR DESCRIPTION
As mentioned by @mattn there was another dash issue (https://github.com/mattn/mruby/commit/e42a11339c4a9093e71d931c9d45abb67ebe9b70#commitcomment-2285892). This time with Ruby based GEMs. In the attachment is a fix for that and also I found that the cleanup target for GEMs wasn't complete.
