### PR TITLE
MSVC doesn't define strtoll

### DIFF
--- a/include/mrbconf.h
+++ b/include/mrbconf.h
@@ -127,6 +127,7 @@ typedef short mrb_sym;
 # define snprintf _snprintf
 # define isnan _isnan
 # define isinf(n) (!_finite(n) && !_isnan(n))
+# define strtoll _strtoi64
 #endif
 
 #endif  /* MRUBYCONF_H */


### PR DESCRIPTION
When MRB_INT64 is defined, strtoll is used. Microsoft's compiler doesn't define this function but _stroi64 should do the job just as well.
