### PR TITLE
Define DISABLE_GEMS flag based on the value of ENABLE_GEMS in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,11 @@ else ifeq ($(COMPILE_MODE),small)
   CFLAGS = -Os
 endif
 
-ALL_CFLAGS = -Wall -Werror-implicit-function-declaration $(CFLAGS)
+ifeq ($(ENABLE_GEMS),false)
+	GEMS_FLAG = -DDISABLE_GEMS
+endif
+
+ALL_CFLAGS = -Wall -Werror-implicit-function-declaration $(CFLAGS) $(GEMS_FLAG)
 ifeq ($(OS),Windows_NT)
   MAKE_FLAGS = --no-print-directory CC=$(CC) LL=$(LL) ALL_CFLAGS='$(ALL_CFLAGS)' LDFLAGS='$(LDFLAGS)' ENABLE_GEMS='$(ENABLE_GEMS)' ACTIVE_GEMS='$(ACTIVE_GEMS)' MRUBY_ROOT='$(MRUBY_ROOT)'
 else

--- a/doc/mrbgems/README.md
+++ b/doc/mrbgems/README.md
@@ -10,8 +10,11 @@ there is no overhead inside of the mruby interpreter.
 
 To activate you have to make the following changes:
 * set ```ENABLE_GEMS``` to ```true``` in *$(MRUBY_ROOT)/Makefile*
-* comment out ```DISABLE_GEMS``` in *$(MRUBY_ROOT)/include/mrbconf.h*
 * activate GEMs in *$(MRUBY_ROOT)/mrbgems/GEMS.active*
+
+Notice that we do not need to comment out ```DISABLE_GEMS```
+in *$(MRUBY_ROOT)/include/mrbconf.h*, since this flag will now be included as
+a command line flag in *$(MRUBY_ROOT)/Makefile*.
 
 Every activated GEM has to be listed in *GEMS.active*. You have to point to
 the GEM directory absolute or relative (based on *mrbgems/g*). It is possible

--- a/include/mrbconf.h
+++ b/include/mrbconf.h
@@ -50,7 +50,9 @@
 //#define DISABLE_TIME		/* Time class */
 //#define DISABLE_STRUCT	/* Struct class */
 //#define DISABLE_STDIO		/* use of stdio */
-#define DISABLE_GEMS		/* Package Manager mrbgems */
+
+/* Now DISABLE_GEMS is added as a command line flag in Makefile, */
+/* we do not need to set it here. */
 
 #undef  HAVE_UNISTD_H /* WINDOWS */
 #define HAVE_UNISTD_H /* LINUX */


### PR DESCRIPTION
Currently, to enable mrbgems, we have to change two values:
- set `ENABLE_GEMS` to `true` in _$(MRUBY_ROOT)/Makefile_
- comment out `DISABLE_GEMS` in _$(MRUBY_ROOT)/include/mrbconf.h_

And of course, we also need to modify the _GEMS.active_ file.

This may bring some inconsistency: if we set `ENABLE_GEMS` to `true` but forgot to comment out `DISABLE_GEMS`, we still cannot use mrbgems.

This commit add `DISABLE_GEMS` as a command line flag to the compiler, so we only need to set the value of `ENABLE_GEMS` here.
