### PR TITLE
GEMS.active support relative path

### DIFF
--- a/mrbgems/build_tasks.rb
+++ b/mrbgems/build_tasks.rb
@@ -64,6 +64,10 @@ end
 def for_each_gem(&block)
   IO.readlines(ACTIVE_GEMS).map { |line|
     path = line.chomp
+    if not File.exist?(path)
+      path2 = File.join MRUBY_ROOT, 'mrbgems', 'g', path
+      path = path2 if File.exist? path2
+    end
     gemname = File.basename(path)
     escaped_gemname = gemname.gsub(/-/, '_')
     block.call(path, gemname, escaped_gemname)


### PR DESCRIPTION
https://github.com/mruby/mruby/tree/master/doc/mrbgems says:

```
Every activated GEM has to be listed in GEMS.active. 
You have to point to the GEM directory absolute or relative (based on mrbgems/g). 
```

but, not working...
