### PR TITLE
Derive DISABLE_GEMS macro according to build configuration

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -36,6 +36,10 @@ end
 LDFLAGS = [ENV['LDFLAGS']]
 LIBS = [ENV['LIBS'] || '-lm']
 
+if !ENABLE_GEMS
+  CFLAGS << "-DDISABLE_GEMS"
+end
+
 CFLAGS << "-Wall" << "-Werror-implicit-function-declaration" << "-I#{MRUBY_ROOT}/include"
 if ENV['OS'] == 'Windows_NT'
   MAKE_FLAGS = "--no-print-directory CC=#{CC} LL=#{LL} AR=#{AR} YACC=#{YACC} CFLAGS=\"#{CFLAGS.join(' ')}\" LDFLAGS=\"#{LDFLAGS.join(' ')}\" LIBS=\"#{LIBS.join(' ')}\" ENABLE_GEMS=\"#{ENABLE_GEMS}\" MRUBY_ROOT=\"#{MRUBY_ROOT}\""

--- a/doc/mrbgems/README.md
+++ b/doc/mrbgems/README.md
@@ -10,8 +10,11 @@ there is no overhead inside of the mruby interpreter.
 
 To activate you have to make the following changes:
 * set ```ENABLE_GEMS``` to ```true``` in *$(MRUBY_ROOT)/Makefile*
-* comment out ```DISABLE_GEMS``` in *$(MRUBY_ROOT)/include/mrbconf.h*
 * activate GEMs in *$(MRUBY_ROOT)/mrbgems/GEMS.active*
+
+Notice that we do not need to comment out ```DISABLE_GEMS```
+in *$(MRUBY_ROOT)/include/mrbconf.h*, since this flag will now be included as
+a command line flag in *$(MRUBY_ROOT)/Rakefile*.
 
 Every activated GEM has to be listed in *GEMS.active*. You have to point to
 the GEM directory absolute or relative (based on *mrbgems/g*). It is possible

--- a/include/mrbconf.h
+++ b/include/mrbconf.h
@@ -50,7 +50,9 @@
 //#define DISABLE_TIME		/* Time class */
 //#define DISABLE_STRUCT	/* Struct class */
 //#define DISABLE_STDIO		/* use of stdio */
-#define DISABLE_GEMS		/* Package Manager mrbgems */
+
+/* Now DISABLE_GEMS is added as a command line flag in Rakefile, */
+/* we do not need to set it here. */
 
 #undef  HAVE_UNISTD_H /* WINDOWS */
 #define HAVE_UNISTD_H /* LINUX */


### PR DESCRIPTION
This is a newer version of Pull Request #633.

To enable mrbgems, we have to change two values now:
1. set ENABLE_GEMS to true in Rakefile
2. comment out DISABLE_GEMS in include/mrbconf.h

And of course, we also need to modify the _GEMS.active_ file.

This two flags here are doing the same thing, so why not derive one from the other? This commit uses the value of ENABLE_GEMS to determine if we need to define DISABLE_GEMS macro.
