### PR TITLE
fix memory leak in function: make_cdump_irep

### DIFF
--- a/src/cdump.c
+++ b/src/cdump.c
@@ -166,6 +166,10 @@ make_cdump_irep(mrb_state *mrb, int irep_no, FILE *f)
   }
   else
   SOURCE_CODE0("");
+
+  if (buf)
+    mrb_free(mrb, buf);
+
   return MRB_CDUMP_OK;
 }
 


### PR DESCRIPTION
_buf_ in _make_cdump_irep_  need to be released.
