### PR TITLE
MSVC: include float header for _isnan and _finite

### DIFF
--- a/src/sprintf.c
+++ b/src/sprintf.c
@@ -17,6 +17,10 @@
 #include <math.h>
 #include <ctype.h>
 
+#ifdef _MSC_VER
+#include <float.h>
+#endif
+
 #ifdef HAVE_IEEEFP_H
 #include <ieeefp.h>
 #endif


### PR DESCRIPTION
Because of default int compiling is possible but it's better if the header with the prototypes (float.h) is included.

http://msdn.microsoft.com/en-us/library/tzthab44.aspx
http://msdn.microsoft.com/en-us/library/sb8es7a8.aspx
