### PR TITLE
Slightly faster Array#each method.

### DIFF
--- a/mrblib/array.rb
+++ b/mrblib/array.rb
@@ -10,11 +10,9 @@ class Array
   #
   # ISO 15.2.12.5.10
   def each(&block)
-    idx = 0
-    while(idx < length)
-      block.call(self[idx])
-      idx += 1
-    end
+    idx, length = -1, self.length-1
+    block.call(self[idx += 1]) while(idx < length)
+    
     self
   end
 


### PR DESCRIPTION
A small change to update Array#each to be slightly faster (and a bit more readable).
##### Benchmark

``` rb
100.times { (1..1_000_000).to_a.each { |i| i } }
```
##### Before

``` sh
~/Code/mruby/tmp $ time ../bin/mruby -b benchmark.mrb

real    1m13.050s
user    1m8.591s
sys     0m1.698s
```
##### After

``` sh
~/Code/mruby/tmp $ time ../bin/mruby -b benchmark.mrb

real    1m2.577s
user    1m0.353s
sys     0m1.594s
```
