### PR TITLE
Add Makefile for backward compatibility of shell build processes.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+# mruby is using Rake (http://rake.rubyforge.org) as a build tool.
+# We provide a minimalistic version called minirake inside of our 
+# codebase.
+
+RAKE = ./minirake
+
+.PHONY : all
+all :
+	$(RAKE)
+
+.PHONY : test
+test :
+	$(RAKE) test
+
+.PHONY : clean
+clean :
+	$(RAKE) clean
+
+.PHONY : showconfig
+showconfig :
+	$(RAKE) showconfig


### PR DESCRIPTION
I just created a makefile so that mruby can still be build by the "normal unix method" `make`, `make test`, `make clean`. I of course only call minirake.
