### PR TITLE
Fix default GEMs are deactived

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -12,7 +12,7 @@ MAKE = ENV['MAKE'] || 'make'
 MRUBY_ROOT = ENV['MRUBY_ROOT'] || File.expand_path(File.dirname(__FILE__))
 
 # by default GEMs are deactivated
-ENABLE_GEMS = ENV['ENABLE_GEMS'] == 'true'
+ENABLE_GEMS = ENV['ENABLE_GEMS'] || 'false'
 
 # the default file which contains the active GEMs
 ACTIVE_GEMS = File.join(File.dirname(__FILE__), 'mrbgems', 'GEMS.active')


### PR DESCRIPTION
「 == 'true'」 of 「ENABLE_GEMS = ENV['ENABLE_GEMS'] == 'true'」means nothing. default GEMs are deactived. It means「ENABLE_GEMS = ENV['ENABLE_GEMS'] || 'false'」
