### PR TITLE
[cmake] Add -DDISABLE_GEMS to compile options.

### DIFF
--- a/cmake/modules/IntrospectSystem.cmake
+++ b/cmake/modules/IntrospectSystem.cmake
@@ -20,6 +20,8 @@ else()
   endif()
 endif()
 
+add_definitions(-DDISABLE_GEMS)
+
 if(MSVC)
   add_definitions(
     -DRUBY_EXPORT   # required by oniguruma.h


### PR DESCRIPTION
After added mruby-gems, cmake build was failed.
This is a quick hack fix.
We need to discuss about build systems for mruby later.
