### PR TITLE
mruby should be throw a NameError, if class variable is not exist.

### DIFF
--- a/src/variable.c
+++ b/src/variable.c
@@ -676,6 +676,8 @@ mrb_mod_class_variables(mrb_state *mrb, mrb_value mod)
 mrb_value
 mrb_mod_cv_get(mrb_state *mrb, struct RClass * c, mrb_sym sym)
 {
+  struct RClass * cls = c;
+
   while (c) {
     if (c->iv) {
       iv_tbl *t = c->iv;
@@ -686,6 +688,9 @@ mrb_mod_cv_get(mrb_state *mrb, struct RClass * c, mrb_sym sym)
     }
     c = c->super;
   }
+  mrb_raisef(mrb, E_NAME_ERROR, "uninitialized class variable %s in %s",
+             mrb_sym2name(mrb, sym), mrb_class_name(mrb, cls));
+  /* not reached */
   return mrb_nil_value();
 }
 


### PR DESCRIPTION
MRuby should be throw a NameError, if class variable is not exist.
