### PR TITLE
[mrbgems] mruby_ldflags were ignored 

### DIFF
--- a/tasks/mruby_build.rake
+++ b/tasks/mruby_build.rake
@@ -139,7 +139,7 @@ module MRuby
     
     def link(outfile, objfiles, flags=[], libs=[])
       FileUtils.mkdir_p File.dirname(outfile)
-      flags = [ldflags, flags]
+      flags = [ldflags, gems.map { |g| g.mruby_ldflags }, flags]
       libs = [libs, self.libs]
       sh "#{filename ld} -o #{filename outfile} #{flags.join(' ')} #{filenames objfiles} #{libs.flatten.join(' ')}"
     end


### PR DESCRIPTION
It seemed till now the variable mruby_ldflags was ignored in the GEM specification.
