### PR TITLE
Modify NODE_IF handling.

### DIFF
--- a/src/codegen.c
+++ b/src/codegen.c
@@ -1099,8 +1099,12 @@ codegen(codegen_scope *s, node *tree, int val)
       genop(s, MKOP_AsBx(OP_JMPNOT, cursp(), 0));
 
       codegen(s, tree->cdr->car, val);
+      if (val && !(tree->cdr->car)) {
+        genop(s, MKOP_A(OP_LOADNIL, cursp()));
+        push();
+      }
       if (e) {
-        if (val && tree->cdr->car) pop();
+        if (val) pop();
         pos2 = new_label(s);
         genop(s, MKOP_sBx(OP_JMP, 0));
         dispatch(s, pos1);


### PR DESCRIPTION
`unless` without `else` sometimes causes strange result.

When `unless` is used without `else`, `tree->cdr->car` of `NODE_IF` is `NULL` in codegen function.
In this case, `pop()` should not be called because `codegen` generates no code.

This is a sample to reproduce this issue.

``` ruby
def test(&block)
  buf = nil
  block.call(buf) unless (false)
end

test do |i|
  p i  # nil is expected.
end
```

Without this patch, the above code outputs as follows:

```
#<Proc:0xXXXXXXX>
```
