### PR TITLE
Refine top-self as an instance of Object.

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -106,6 +106,8 @@ typedef struct mrb_state {
   struct RClass *symbol_class;
   struct RClass *kernel_module;
 
+  struct RObject *top_self;
+
   struct heap_page *heaps;
   struct heap_page *sweeps;
   struct heap_page *free_heaps;

--- a/include/mruby/class.h
+++ b/include/mruby/class.h
@@ -39,8 +39,6 @@ mrb_class(mrb_state *mrb, mrb_value v)
     return mrb->fixnum_class;
   case MRB_TT_FLOAT:
     return mrb->float_class;
-  case MRB_TT_MAIN:
-    return mrb->object_class;
 
 #ifdef ENABLE_REGEXP
   case MRB_TT_REGEX:

--- a/include/mruby/value.h
+++ b/include/mruby/value.h
@@ -18,25 +18,24 @@ enum mrb_vtype {
   MRB_TT_UNDEF,       /*   5 */
   MRB_TT_FLOAT,       /*   6 */
   MRB_TT_VOIDP,       /*   7 */
-  MRB_TT_MAIN,        /*   8 */
-  MRB_TT_OBJECT,      /*   9 */
-  MRB_TT_CLASS,       /*  10 */
-  MRB_TT_MODULE,      /*  11 */
-  MRB_TT_ICLASS,      /*  12 */
-  MRB_TT_SCLASS,      /*  13 */
-  MRB_TT_PROC,        /*  14 */
-  MRB_TT_ARRAY,       /*  15 */
-  MRB_TT_HASH,        /*  16 */
-  MRB_TT_STRING,      /*  17 */
-  MRB_TT_RANGE,       /*  18 */
-  MRB_TT_REGEX,       /*  19 */
-  MRB_TT_STRUCT,      /*  20 */
-  MRB_TT_EXCEPTION,   /*  21 */
-  MRB_TT_MATCH,       /*  22 */
-  MRB_TT_FILE,        /*  23 */
-  MRB_TT_ENV,         /*  24 */
-  MRB_TT_DATA,        /*  25 */
-  MRB_TT_MAXDEFINE    /*  26 */
+  MRB_TT_OBJECT,      /*   8 */
+  MRB_TT_CLASS,       /*   9 */
+  MRB_TT_MODULE,      /*  10 */
+  MRB_TT_ICLASS,      /*  11 */
+  MRB_TT_SCLASS,      /*  12 */
+  MRB_TT_PROC,        /*  13 */
+  MRB_TT_ARRAY,       /*  14 */
+  MRB_TT_HASH,        /*  15 */
+  MRB_TT_STRING,      /*  16 */
+  MRB_TT_RANGE,       /*  17 */
+  MRB_TT_REGEX,       /*  18 */
+  MRB_TT_STRUCT,      /*  19 */
+  MRB_TT_EXCEPTION,   /*  20 */
+  MRB_TT_MATCH,       /*  21 */
+  MRB_TT_FILE,        /*  22 */
+  MRB_TT_ENV,         /*  23 */
+  MRB_TT_DATA,        /*  24 */
+  MRB_TT_MAXDEFINE    /*  25 */
 };
 
 typedef struct mrb_value {
@@ -80,25 +79,24 @@ enum mrb_vtype {
   MRB_TT_UNDEF,       /*   6 */
   MRB_TT_FLOAT,       /*   7 */
   MRB_TT_VOIDP,       /*   8 */
-  MRB_TT_MAIN,        /*   9 */
-  MRB_TT_OBJECT,      /*  10 */
-  MRB_TT_CLASS,       /*  11 */
-  MRB_TT_MODULE,      /*  12 */
-  MRB_TT_ICLASS,      /*  13 */
-  MRB_TT_SCLASS,      /*  14 */
-  MRB_TT_PROC,        /*  15 */
-  MRB_TT_ARRAY,       /*  16 */
-  MRB_TT_HASH,        /*  17 */
-  MRB_TT_STRING,      /*  18 */
-  MRB_TT_RANGE,       /*  19 */
-  MRB_TT_REGEX,       /*  20 */
-  MRB_TT_STRUCT,      /*  21 */
-  MRB_TT_EXCEPTION,   /*  22 */
-  MRB_TT_MATCH,       /*  23 */
-  MRB_TT_FILE,        /*  24 */
-  MRB_TT_ENV,         /*  25 */
-  MRB_TT_DATA,        /*  26 */
-  MRB_TT_MAXDEFINE    /*  27 */
+  MRB_TT_OBJECT,      /*   9 */
+  MRB_TT_CLASS,       /*  10 */
+  MRB_TT_MODULE,      /*  11 */
+  MRB_TT_ICLASS,      /*  12 */
+  MRB_TT_SCLASS,      /*  13 */
+  MRB_TT_PROC,        /*  14 */
+  MRB_TT_ARRAY,       /*  15 */
+  MRB_TT_HASH,        /*  16 */
+  MRB_TT_STRING,      /*  17 */
+  MRB_TT_RANGE,       /*  18 */
+  MRB_TT_REGEX,       /*  19 */
+  MRB_TT_STRUCT,      /*  20 */
+  MRB_TT_EXCEPTION,   /*  21 */
+  MRB_TT_MATCH,       /*  22 */
+  MRB_TT_FILE,        /*  23 */
+  MRB_TT_ENV,         /*  24 */
+  MRB_TT_DATA,        /*  25 */
+  MRB_TT_MAXDEFINE    /*  26 */
 };
 
 #ifdef MRB_ENDIAN_BIG
@@ -201,7 +199,7 @@ struct RObject {
 };
 
 #define mrb_obj_ptr(v)   ((struct RObject*)((v).value.p))
-#define mrb_immediate_p(x) (mrb_type(x) <= MRB_TT_MAIN)
+#define mrb_immediate_p(x) (mrb_type(x) <= MRB_TT_VOIDP)
 #define mrb_special_const_p(x) mrb_immediate_p(x)
 
 static inline mrb_value

--- a/src/class.c
+++ b/src/class.c
@@ -887,7 +887,6 @@ mrb_singleton_class(mrb_state *mrb, mrb_value v)
     return mrb_obj_value(mrb->false_class);
   case MRB_TT_TRUE:
     return mrb_obj_value(mrb->true_class);
-  case MRB_TT_MAIN:
   case MRB_TT_VOIDP:
     return mrb_obj_value(mrb->object_class);
   case MRB_TT_SYMBOL:
@@ -1737,6 +1736,12 @@ mrb_mod_eqq(mrb_state *mrb, mrb_value mod)
   return mrb_true_value();
 }
 
+static mrb_value
+mrb_top_self_to_s(mrb_state *mrb, mrb_value top_self)
+{
+  return mrb_str_new(mrb, "main", 4);
+}
+
 void
 mrb_init_class(mrb_state *mrb)
 {
@@ -1811,4 +1816,8 @@ mrb_init_class(mrb_state *mrb)
   mrb_define_method(mrb, mod, "===", mrb_mod_eqq, ARGS_REQ(1));
   mrb_undef_method(mrb, cls, "append_features");
   mrb_undef_method(mrb, cls, "extend_object");
+
+  mrb->top_self = (struct RObject*)mrb_obj_alloc(mrb, MRB_TT_OBJECT, obj);
+  mrb_define_singleton_method(mrb, mrb->top_self, "to_s", mrb_top_self_to_s, ARGS_NONE());
+  mrb_define_singleton_method(mrb, mrb->top_self, "inspect", mrb_top_self_to_s, ARGS_NONE());
 }

--- a/src/gc.c
+++ b/src/gc.c
@@ -585,6 +585,8 @@ root_scan_phase(mrb_state *mrb)
   }
   /* mark class hierarchy */
   mrb_gc_mark(mrb, (struct RBasic*)mrb->object_class);
+  /* mark top self */
+  mrb_gc_mark(mrb, (struct RBasic*)mrb->top_self);
   /* mark exception */
   mrb_gc_mark(mrb, (struct RBasic*)mrb->exc);
   /* mark stack */

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -61,9 +61,6 @@ mrb_obj_inspect(mrb_state *mrb, mrb_value obj)
   if ((mrb_type(obj) == MRB_TT_OBJECT) && mrb_obj_basic_to_s_p(mrb, obj)) {
     return mrb_obj_iv_inspect(mrb, mrb_obj_ptr(obj));
   }
-  else if (mrb_type(obj) == MRB_TT_MAIN) {
-    return mrb_str_new(mrb, "main", 4);
-  }
   return mrb_any_to_s(mrb, obj);
 }
 

--- a/src/state.c
+++ b/src/state.c
@@ -144,8 +144,5 @@ mrb_add_irep(mrb_state *mrb)
 mrb_value
 mrb_top_self(mrb_state *mrb)
 {
-  mrb_value v;
-
-  MRB_SET_VALUE(v, MRB_TT_MAIN, value.i, 0);
-  return v;
+  return mrb_obj_value(mrb->top_self);
 }


### PR DESCRIPTION
I tried to refine top level self as an instance of Object.
I think that this implementation makes `mrb_state` larger but the behavior is similar to CRuby.

It is also a preparation to define singleton methods of top-self, such as `include`.
If @matz accepts this patch, I will send another pull request about top-self's `include`.
(Please refer to [283f8f1](https://github.com/masamitsu-murase/mruby_efi_shell/commit/283f8f19840682c250820ab74418d16a7db6d3e2).)
