### PR TITLE
Remove redundant null checks.

### DIFF
--- a/src/cdump.c
+++ b/src/cdump.c
@@ -167,8 +167,7 @@ make_cdump_irep(mrb_state *mrb, int irep_no, FILE *f)
   else
   SOURCE_CODE0("");
 
-  if (buf)
-    mrb_free(mrb, buf);
+  mrb_free(mrb, buf);
 
   return MRB_CDUMP_OK;
 }

--- a/src/dump.c
+++ b/src/dump.c
@@ -409,8 +409,7 @@ write_pool_block(mrb_state *mrb, mrb_irep *irep, char *buf, int type)
   }
 
 error_exit:
-  if (char_buf)
-    mrb_free(mrb, char_buf);
+  mrb_free(mrb, char_buf);
   return (int)(buf - buf_top);
 }
 
@@ -455,8 +454,7 @@ write_syms_block(mrb_state *mrb, mrb_irep *irep, char *buf, int type)
   }
 
 error_exit:
-  if (char_buf)
-    mrb_free(mrb, char_buf);
+  mrb_free(mrb, char_buf);
   return (int)(buf - buf_top);
 }
 

--- a/src/load.c
+++ b/src/load.c
@@ -235,8 +235,7 @@ load_rite_irep_record(mrb_state *mrb, RiteFILE* rfp, unsigned char* dst, uint32_
   *len = dst - pStart;
 
 error_exit:
-  if (char_buf)
-    mrb_free(mrb, char_buf);
+  mrb_free(mrb, char_buf);
 
   return MRB_DUMP_OK;
 }
@@ -292,8 +291,7 @@ mrb_read_irep_file(mrb_state *mrb, FILE* fp)
     ret = mrb_read_irep(mrb, (char*)rite_dst);
 
 error_exit:
-  if (rite_dst)
-    mrb_free(mrb, rite_dst);
+  mrb_free(mrb, rite_dst);
 
   return ret;
 }
@@ -489,8 +487,7 @@ read_rite_irep_record(mrb_state *mrb, unsigned char *src, uint32_t* len)
 
   *len = src - recordStart;
 error_exit:
-  if (buf)
-    mrb_free(mrb, buf);
+  mrb_free(mrb, buf);
 
   return ret;
 }


### PR DESCRIPTION
It's guaranteed by the C specification that calling free() with NULL is safe.
