### PR TITLE
Doesn't clear black of all marked objects in the major collector.

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -780,7 +780,7 @@ incremental_sweep_phase(mrb_state *mrb, size_t limit)
         }
       }
       else {
-        if (!is_minor_gc(mrb))
+        if (!is_generational(mrb))
           paint_partial_white(mrb, &p->as.basic); /* next gc target */
         dead_slot = 0;
       }
@@ -863,11 +863,10 @@ clear_all_old(mrb_state *mrb)
   if (is_major_gc(mrb)) {
     advance_phase(mrb, GC_STATE_NONE);
   }
-  else {
-    mrb->is_generational_gc_mode = FALSE;
-    prepare_incremental_sweep(mrb);
-    advance_phase(mrb, GC_STATE_NONE);
-  }
+
+  mrb->is_generational_gc_mode = FALSE;
+  prepare_incremental_sweep(mrb);
+  advance_phase(mrb, GC_STATE_NONE);
   mrb->variable_gray_list = mrb->gray_list = NULL;
   mrb->is_generational_gc_mode = origin_mode;
 }


### PR DESCRIPTION
Since the minor collector doesn't need to mark these objects, the worst-case pause time is reduced.
