### PR TITLE
suppress warning

### DIFF
--- a/src/dump.c
+++ b/src/dump.c
@@ -477,7 +477,7 @@ calc_crc_section(mrb_state *mrb, mrb_irep *irep, uint16_t *crc, int section)
   char *buf, *buf_top;
   uint32_t buf_size;
   int type = DUMP_TYPE_BIN;
-  int result;
+  int result = 0;
 
   switch (section) {
   case DUMP_IREP_HEADER: buf_size = get_irep_header_size(mrb, irep, type); break;


### PR DESCRIPTION
```
src/dump.c:509:3: warning: variable 'result' is used uninitialized whenever switch default is taken [-Wsometimes-uninitialized]
  default:
  ^~~~~~~
src/dump.c:512:7: note: uninitialized use occurs here
  if (result < 0) {
      ^~~~~~
src/dump.c:480:13: note: initialize the variable 'result' to silence this warning
  int result;
            ^
             = 0
```
