### PR TITLE
silence clang warning

### DIFF
--- a/src/dump.c
+++ b/src/dump.c
@@ -507,6 +507,7 @@ calc_crc_section(mrb_state *mrb, mrb_irep *irep, uint16_t *crc, int section)
     result = write_syms_block(mrb, irep, buf, type);
     break;
   default:
+    result = MRB_DUMP_GENERAL_FAILURE;
     break; /* Already checked above. */
   }
   if (result < 0) {


### PR DESCRIPTION
src/dump.c:509:3: warning: variable 'result' is used uninitialized whenever switch
      default is taken [-Wsometimes-uninitialized]
  default:
  ^~~~~~~
src/dump.c:512:7: note: uninitialized use occurs here
  if (result < 0) {
      ^~~~~~
src/dump.c:480:13: note: initialize the variable 'result' to silence this warning
  int result;
            ^
             = 0
