### PR TITLE
Use an ENV variable for mrbc to help cross-compiling mruby

### DIFF
--- a/tasks/mruby_build.rake
+++ b/tasks/mruby_build.rake
@@ -101,7 +101,7 @@ module MRuby
     end
 
     def mrbcfile
-      @mrbcfile ||= exefile("build/host/bin/mrbc")
+      @mrbcfile ||= (ENV['MRBC_BIN'] || exefile("build/host/bin/mrbc"))
     end
 
     def compile_c(outfile, infile, flags=[], includes=[])


### PR DESCRIPTION
mruby build system uses mrbc apparently during the build process.
Cross-compiling mruby for ARM using the Android NDK fails because
it tries to use the mrbc ARM binary in x86.

Build output snippet:

```
build/host/bin/mrbc: 1: build/host/bin/mrbc: Syntax error: word
unexpected (expecting ")")
...
...
/home/rubiojr/android/toolchain-p14/bin/../lib/gcc/arm-linux-androideabi/4.6/../../../../arm-linux-androideabi/bin/ld:
build/host/lib/libmruby.a(mrblib.o): in function
mrb_init_mrblib:mrblib.c(.text+0x40): error: undefined reference to
'mrblib_irep'
```

Not sure if adding an ENV var is the right approach though.

I've detailed the whole build process (with the patch) at:

http://rubiojr.rbel.co/hack/2013/01/15/cross-compiling-mruby-for-android-in-debianubuntu-amd64-using-the-android-ndk/
