### PR TITLE
Fix disappearance of command_call in case of statement without parentheses

### DIFF
--- a/src/parse.y
+++ b/src/parse.y
@@ -1126,7 +1126,7 @@ stmt		: keyword_alias fsym {p->lstate = EXPR_FNAME;} fsym
 		| command_asgn
 		| mlhs '=' command_call
 		    {
-		      $$ = new_masgn(p, $1, list1($3));
+		      $$ = new_masgn(p, $1, $3);
 		    }
 		| var_lhs tOP_ASGN command_call
 		    {


### PR DESCRIPTION
This patch fixes following bug.

```
def foo(a, b)
  return a, b
end

a, b = foo 1,2
a, b = foo(1,2)
p a, b
```

before the fix:
    Object
    nil
    1
    main

after the fix:
    1
    2
    1
    2
