### PR TITLE
Modify handling of `bodystmt`.

### DIFF
--- a/src/parse.y
+++ b/src/parse.y
@@ -1050,7 +1050,7 @@ bodystmt	: compstmt
 		      }
 		      else if ($3) {
 			yywarn(p, "else without rescue is useless");
-			$$ = append($$, $3);
+			$$ = push($1, $3);
 		      }
 		      else {
 			$$ = $1;


### PR DESCRIPTION
In the current implementation, segmentation fault occurs
if `bodystmt` has `opt_else` without `opt_rescue`.

For example, the following code causes segmentation fault.

``` ruby
begin
  p 1
else
  p 2
end
```

I think that `opt_else` without `opt_rescue` is useless, but segmentation fault should not be caused.
