### PR TITLE
fix build faild on Cygwin Environment

### DIFF
--- a/tasks/mruby_build.rake
+++ b/tasks/mruby_build.rake
@@ -63,12 +63,11 @@ module MRuby
 
       if ENV['OS'] == 'Windows_NT'
         @exts = Exts.new('.o', '.exe', '.a')
-        @file_separator = '\\'
       else
         @exts = Exts.new('.o', '', '.a')
-        @file_separator = '/'
       end
 
+      @file_separator = '/'
       @cc = Command::Compiler.new(self, %w(.c))
       @cxx = Command::Compiler.new(self, %w(.cc .cxx .cpp))
       @objc = Command::Compiler.new(self, %w(.m))


### PR DESCRIPTION
Fix build faild on Cygwin Environment.

A path on Cygwin like this: _/cygdrive/k/work/mruby/include_, but ENV['OS'] is 'Windows_NT'.
So, the path will be replaced by _\cygdrive\k\work\mruby\include_ in building process, GCC on Gygwin cannot find this path.

`@file_separator = '\\'` is unnecessary for Windows_NT case. 
Because `@file_separator = '/'` work well on Windows.
