### PR TITLE
Added hooks for debugging feature.

### DIFF
--- a/examples/mrbgems/hooks/README.md
+++ b/examples/mrbgems/hooks/README.md
@@ -1,0 +1,4 @@
+Hooks Example
+=========
+
+This is an example gem what uses hooks

--- a/examples/mrbgems/hooks/mrbgem.rake
+++ b/examples/mrbgems/hooks/mrbgem.rake
@@ -1,0 +1,20 @@
+MRuby::Gem::Specification.new('debug') do |spec|
+  spec.license = 'MIT'
+  spec.authors = 'mruby developers'
+ 
+  # Add compile flags
+  # spec.cc.flags << ''
+
+  # Add cflags to all
+  # spec.mruby.cc.flags << ''
+
+  # Add libraries
+  # spec.linker.libraries << 'external_lib'
+
+  # Default building fules
+  # spec.rbfiles = Dir.glob("#{dir}/mrblib/*.rb")
+  # spec.objs = Dir.glob("#{dir}/src/*.{c,cpp,m,asm,S}").map { |f| objfile(f.relative_path_from(dir).pathmap("#{build_dir}/%X")) }
+  # spec.test_rbfiles = Dir.glob("#{dir}/test/*.rb")
+  # spec.test_objs = Dir.glob("#{dir}/test/*.{c,cpp,m,asm,S}").map { |f| objfile(f.relative_path_from(dir).pathmap("#{build_dir}/%X")) }
+  # spec.test_preload = 'test/assert.rb'
+end

--- a/examples/mrbgems/hooks/src/hooks.c
+++ b/examples/mrbgems/hooks/src/hooks.c
@@ -1,0 +1,84 @@
+#include <mruby.h>
+#include <stdio.h>
+
+static 
+void hook_vm_step(struct mrb_state* mrb, mrb_code *pc) {
+  printf("pc[%p] = %p\n", mrb, pc);
+}
+
+static 
+void hook_mrb_open(struct mrb_state* mrb) {
+  printf("mrb_open(%p)\n", mrb);
+}
+
+static 
+void hook_mrb_close(struct mrb_state* mrb) {
+  printf("mrb_close(%p)\n", mrb);
+}
+
+static 
+void hook_mrb_realloc(struct mrb_state* mrb, void *resultp, void* srcp, size_t size) {
+  printf("realloc(%p, %ld, %p)\n", mrb, size, resultp);
+}
+
+static 
+void hook_mrb_free(struct mrb_state* mrb, void *p) {
+  printf("free(%p, %p)\n", mrb, p);
+}
+
+static
+void hook_mrb_read_irep(struct mrb_state* mrb, int ret, const char *bin) {
+  printf("mrb_read_irep(%p, %d, %p)\n", mrb, ret, bin);
+}
+
+static
+void hook_mrb_run_enter(struct mrb_state* mrb, struct RProc *proc, mrb_value self) {
+  printf(">> mrb_run(%p)\n", mrb);
+}
+
+static
+void hook_mrb_run_exit(struct mrb_state* mrb, mrb_value result, struct RProc *proc, mrb_value self) {
+  printf("<< mrb_run(%p)\n", mrb);
+}
+
+static
+void hook_gc_start(struct mrb_state* mrb) {
+  printf("gc_start(%p)\n", mrb);
+}
+
+static
+void hook_gc_stop(struct mrb_state* mrb) {
+  printf("gc_stop(%p)\n", mrb);
+}
+
+void
+mrb_debug_gem_init(mrb_state* mrb) {
+#ifdef ENABLE_HOOKS
+  mrb->hook_mrb_open = hook_mrb_open;
+  mrb->hook_mrb_close = hook_mrb_close;
+  mrb->hook_mrb_realloc = hook_mrb_realloc;
+  mrb->hook_mrb_free = hook_mrb_free;
+  mrb->hook_mrb_read_irep = hook_mrb_read_irep;
+  mrb->hook_mrb_run_enter = hook_mrb_run_enter;
+  mrb->hook_mrb_run_exit = hook_mrb_run_exit;
+  mrb->hook_vm_step = hook_vm_step;
+  mrb->hook_gc_start = hook_gc_start;
+  mrb->hook_gc_stop = hook_gc_stop;
+#endif
+}
+
+void
+mrb_debug_gem_final(mrb_state* mrb) {
+#ifdef ENABLE_HOOKS
+  mrb->hook_mrb_open = NULL;
+  mrb->hook_mrb_close = NULL;
+  mrb->hook_mrb_realloc = NULL;
+  mrb->hook_mrb_free = NULL;
+  mrb->hook_mrb_read_irep = NULL;
+  mrb->hook_mrb_run_enter = NULL;
+  mrb->hook_mrb_run_exit = NULL;
+  mrb->hook_vm_step = NULL;
+  mrb->hook_gc_start = NULL;
+  mrb->hook_gc_stop = NULL;
+#endif
+}

--- a/include/mrbconf.h
+++ b/include/mrbconf.h
@@ -49,7 +49,8 @@
 //#define DISABLE_MATH		/* Math functions */
 //#define DISABLE_TIME		/* Time class */
 //#define DISABLE_STRUCT	/* Struct class */
-//#define DISABLE_STDIO		/* use of stdio */
+//#define DISABLE_STDIO   /* use of stdio */
+//#define DISABLE_HOOKS   /* hooks for debugger */
 
 /* Now DISABLE_GEMS is added as a command line flag in Rakefile, */
 /* we do not need to set it here. */
@@ -114,6 +115,9 @@ typedef short mrb_sym;
 #endif
 #ifndef DISABLE_STDIO
 #define ENABLE_STDIO
+#endif
+#ifndef DISABLE_HOOKS
+#define ENABLE_HOOKS
 #endif
 
 #ifndef FALSE

--- a/include/mruby.h
+++ b/include/mruby.h
@@ -137,6 +137,22 @@ typedef struct mrb_state {
   struct RClass *eStandardError_class;
 
   void *ud; /* auxiliary data */
+
+#ifdef ENABLE_HOOKS
+  void (*hook_mrb_open)(struct mrb_state* mrb);
+  void (*hook_mrb_close)(struct mrb_state* mrb);
+
+  void (*hook_mrb_realloc)(struct mrb_state* mrb, void *resultp, void* srcp, size_t size);
+  void (*hook_mrb_free)(struct mrb_state* mrb, void* p);
+
+  void (*hook_mrb_read_irep)(struct mrb_state* mrb, int ret, const char *bin);
+  void (*hook_mrb_run_enter)(struct mrb_state* mrb, struct RProc *proc, mrb_value self);
+  void (*hook_mrb_run_exit)(struct mrb_state* mrb, mrb_value result, struct RProc *proc, mrb_value self);
+
+  void (*hook_vm_step)(struct mrb_state* mrb, mrb_code *pc);
+  void (*hook_gc_start)(struct mrb_state* mrb);
+  void (*hook_gc_stop)(struct mrb_state* mrb);
+#endif
 } mrb_state;
 
 typedef mrb_value (*mrb_func_t)(mrb_state *mrb, mrb_value);

--- a/src/gc.c
+++ b/src/gc.c
@@ -15,6 +15,7 @@
 #include "mruby/proc.h"
 #include "mruby/data.h"
 #include "mruby/variable.h"
+#include "monitor.h"
 
 #ifndef SIZE_MAX
 #include <limits.h> // for SIZE_MAX
@@ -166,6 +167,9 @@ mrb_realloc(mrb_state *mrb, void *p, size_t len)
     mrb_garbage_collect(mrb);
     p2 = (mrb->allocf)(mrb, p, len, mrb->ud);
   }
+
+  HOOK_MRB_REALLOC(mrb, p2, p, len);
+
   return p2;
 }
 
@@ -195,6 +199,7 @@ mrb_calloc(mrb_state *mrb, size_t nelem, size_t len)
 void*
 mrb_free(mrb_state *mrb, void *p)
 {
+  HOOK_MRB_FREE(mrb, p);
   return (mrb->allocf)(mrb, p, 0, mrb->ud);
 }
 
@@ -928,6 +933,7 @@ mrb_garbage_collect(mrb_state *mrb)
 
   if (mrb->gc_disabled) return;
   GC_INVOKE_TIME_REPORT("mrb_garbage_collect()");
+  HOOK_GC_START(mrb);
   GC_TIME_START;
 
   if (mrb->gc_state == GC_STATE_SWEEP) {
@@ -955,6 +961,7 @@ mrb_garbage_collect(mrb_state *mrb)
   }
 
   GC_TIME_STOP_AND_REPORT;
+  HOOK_GC_STOP(mrb);
 }
 
 int

--- a/src/monitor.h
+++ b/src/monitor.h
@@ -1,0 +1,33 @@
+#ifdef ENABLE_HOOKS
+
+# define HOOK_MRB_OPEN(mrb) ((mrb)->hook_mrb_open ? (mrb)->hook_mrb_open(mrb) : NULL)
+# define HOOK_MRB_CLOSE(mrb) ((mrb)->hook_mrb_close ? (mrb)->hook_mrb_close(mrb) : NULL)
+
+# define HOOK_MRB_REALLOC(mrb, resultp, srcp, size) ((mrb)->hook_mrb_realloc ? (mrb)->hook_mrb_realloc((mrb), (resultp), (srcp), (size)) : NULL) 
+# define HOOK_MRB_FREE(mrb, p) ((mrb)->hook_mrb_free ? (mrb)->hook_mrb_free((mrb), (p)) : NULL)
+
+# define HOOK_MRB_READ_IREP(mrb, ret, bin) ((mrb)->hook_mrb_read_irep ? (mrb)->hook_mrb_read_irep((mrb), (ret), (bin)) : NULL)
+# define HOOK_MRB_RUN_ENTER(mrb, proc, self) ((mrb)->hook_mrb_run_enter ? (mrb)->hook_mrb_run_enter((mrb), (proc), (self)) : NULL)
+# define HOOK_MRB_RUN_EXIT(mrb, result, proc, self) ((mrb)->hook_mrb_run_exit ? (mrb)->hook_mrb_run_exit((mrb), (result), (proc), (self)) : NULL)
+
+# define HOOK_VM_STEP(mrb, pc) ((mrb)->hook_vm_step ? (mrb)->hook_vm_step((mrb), (pc)) : NULL)
+# define HOOK_GC_START(mrb) ((mrb)->hook_gc_start ? (mrb)->hook_gc_start(mrb) : NULL)
+# define HOOK_GC_STOP(mrb) ((mrb)->hook_gc_stop ? (mrb)->hook_gc_stop(mrb) : NULL)
+
+#else
+
+# define HOOK_MRB_OPEN(mrb)
+# define HOOK_MRB_CLOSE(mrb)
+
+# define HOOK_MRB_REALLOC(mrb, resultp, srcp, size)
+# define HOOK_MRB_FREE(mrb, p)
+
+# define HOOK_MRB_READ_IREP(mrb, ret, bin)
+# define HOOK_MRB_RUN_ENTER(mrb, proc, self)
+# define HOOK_MRB_RUN_EXIT(mrb, proc, self)
+
+# define HOOK_MRB_VM_STEP(mrb)
+# define HOOK_MRB_GC_START(mrb)
+# define HOOK_MRB_GC_STOP(mrb)
+
+#endif

--- a/src/state.c
+++ b/src/state.c
@@ -7,6 +7,7 @@
 #include "mruby.h"
 #include "mruby/irep.h"
 #include "mruby/variable.h"
+#include "monitor.h"
 #include <string.h>
 
 void mrb_init_heap(mrb_state*);
@@ -76,6 +77,8 @@ mrb_open()
 {
   mrb_state *mrb = mrb_open_allocf(allocf, NULL);
 
+  HOOK_MRB_OPEN(mrb);
+
   return mrb;
 }
 
@@ -86,6 +89,8 @@ void
 mrb_close(mrb_state *mrb)
 {
   int i;
+
+  HOOK_MRB_CLOSE(mrb);
 
   mrb_final_core(mrb);
 


### PR DESCRIPTION
- mrb_open
- mrb_close
- mrb_realloc (included mrb_malloc/mrb_calloc)
- mrb_free
- mrb_read_irep
- mrb_run ( enter | exit )
- mrb_vm_step - hook each step in RiteVM
- mrb_gc ( start | stop )

I think we need below features for creating debugger.
- Get irep information
- Get runtime information
- Get GC information
