### PR TITLE
Fixed mrbc file ext on host

### DIFF
--- a/tasks/mruby_build.rake
+++ b/tasks/mruby_build.rake
@@ -99,7 +99,7 @@ module MRuby
     end
 
     def mrbcfile
-      exefile("build/host/bin/mrbc")
+      MRuby.targets['host'].exefile("build/host/bin/mrbc")
     end
 
     def compilers


### PR DESCRIPTION
Fixed mrbc file ext on host
This bug produce when you do cross compile for other file ext. system.
