### PR TITLE
Fixes a number of "comparison between signed and unsigned" warnings.

### DIFF
--- a/src/array.c
+++ b/src/array.c
@@ -66,7 +66,7 @@ mrb_ary_new(mrb_state *mrb)
 static inline void
 array_copy(mrb_value *dst, const mrb_value *src, size_t size)
 {
-  int i;
+  size_t i;
 
   for (i = 0; i < size; i++) {
     dst[i] = src[i];

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -2538,7 +2538,7 @@ codedump(mrb_state *mrb, int n)
 void
 codedump_all(mrb_state *mrb, int start)
 {
-  int i;
+  size_t i;
 
   for (i=start; i<mrb->irep_len; i++) {
     codedump(mrb, i);

--- a/src/object.c
+++ b/src/object.c
@@ -395,7 +395,7 @@ mrb_check_type(mrb_state *mrb, mrb_value x, enum mrb_vtype t)
 {
   const struct types *type = builtin_types;
   struct RString *s;
-  int xt;
+  enum mrb_vtype xt;
 
   xt = mrb_type(x);
   if ((xt != t) || (xt == MRB_TT_DATA)) {

--- a/src/state.c
+++ b/src/state.c
@@ -85,7 +85,7 @@ void mrb_free_heap(mrb_state *mrb);
 void
 mrb_close(mrb_state *mrb)
 {
-  int i;
+  size_t i;
 
   mrb_final_core(mrb);
 

--- a/src/vm.c
+++ b/src/vm.c
@@ -58,7 +58,7 @@ The value below allows about 60000 recursive calls in the simplest case. */
 static inline void
 stack_copy(mrb_value *dst, const mrb_value *src, size_t size)
 {
-  int i;
+  size_t i;
 
   for (i = 0; i < size; i++) {
     dst[i] = src[i];


### PR DESCRIPTION
This is a start fixing a few of the easiest to fix warnings with regards to issue #735.

There are a good bit more to be fixed. I found a few that changed behavior of the tests so I started over with the easiest set first.
