### PR TITLE
Removed tests that look outdated. 

### DIFF
--- a/src/codegen.c
+++ b/src/codegen.c
@@ -4,7 +4,6 @@
 ** See Copyright Notice in mruby.h
 */
 
-#undef CODEGEN_TEST
 #define CODEGEN_DUMP
 
 #include "mruby.h"
@@ -2577,35 +2576,3 @@ mrb_generate_code(mrb_state *mrb, parser_state *p)
 
   return start;
 }
-
-#ifdef CODEGEN_TEST
-int
-main()
-{
-  mrb_state *mrb = mrb_open();
-  int n;
-
-#if 1
-  n = mrb_compile_string(mrb, "p(__FILE__)\np(__LINE__)");
-#else
-  n = mrb_compile_string(mrb, "\
-def fib(n)\n\
-  if n<2\n\
-    n\n\
-  else\n\
-    fib(n-2)+fib(n-1)\n\
-  end\n\
-end\n\
-p(fib(30), \"\\n\")\n\
-");
-#endif
-  printf("ret: %d\n", n);
-#ifdef CODEGEN_DUMP
-  codedump_all(mrb, n);
-#endif
-  mrb_run(mrb, mrb_proc_new(mrb, mrb->irep[0]), mrb_nil_value());
-  mrb_close(mrb);
-
-  return 0;
-}
-#endif

--- a/src/parse.y
+++ b/src/parse.y
@@ -5,7 +5,6 @@
 */
 
 %{
-#undef PARSER_TEST
 #undef PARSER_DEBUG
 
 #define YYDEBUG 1
@@ -5648,26 +5647,3 @@ parser_dump(mrb_state *mrb, node *tree, int offset)
   }
 #endif
 }
-
-#ifdef PARSER_TEST
-int
-main()
-{
-  mrb_state *mrb = mrb_open();
-  int n;
-
-  n = mrb_compile_string(mrb, "\
-def fib(n)\n\
-  if n<2\n\
-    n\n\
-  else\n\
-    fib(n-2)+fib(n-1)\n\
-  end\n\
-end\n\
-print(fib(20), \"\\n\")\n\
-");
-  printf("ret: %d\n", n);
-
-  return 0;
-}
-#endif


### PR DESCRIPTION
Both of these look like they are outdated because mrb_compile_string is gone. Maybe if they need to stick around there could be another tool program created that rolls them up in one place. There seem to be a couple other main()s in the src directory that could go as well potentially.
