### PR TITLE
Change the way that the DISABLE_GEMS flag is set.

### DIFF
--- a/tasks/mrbgem_spec.rake
+++ b/tasks/mrbgem_spec.rake
@@ -37,7 +37,6 @@ module MRuby
         MRuby::Gem.current = self
 
         @build.compilers.each do |compiler|
-          compiler.defines -= %w(DISABLE_GEMS)
           compiler.include_paths << "#{dir}/include"
         end
         MRuby::Build::COMMANDS.each do |command|

--- a/tasks/mruby_build.rake
+++ b/tasks/mruby_build.rake
@@ -83,7 +83,11 @@ module MRuby
       instance_eval(&block)
 
       compilers.each do |compiler|
-        compiler.defines -= %w(DISABLE_GEMS) if respond_to?(:enable_gems?) && enable_gems?
+        if respond_to?(:enable_gems?) && enable_gems?
+          compiler.defines -= %w(DISABLE_GEMS) 
+        else
+          compiler.defines += %w(DISABLE_GEMS) 
+        end
         compiler.define_rules build_dir
       end
     end

--- a/tasks/mruby_build_commands.rake
+++ b/tasks/mruby_build_commands.rake
@@ -40,7 +40,7 @@ module MRuby
       @flags = [ENV['CFLAGS'] || []]
       @source_exts = source_exts
       @include_paths = ["#{build.root}/include"]
-      @defines = %w(DISABLE_GEMS)
+      @defines = %w()
       @option_include_path = '-I%s'
       @option_define = '-D%s'
       @compile_options = "%{flags} -MMD -o %{outfile} -c %{infile}"


### PR DESCRIPTION
I ran into an issue where setting the defines in the build configuration clobbers the DISABLE_GEMS define. I believe this change should correct that. The DISABLE_GEMS define seems like a system define that shouldn't be changed via the configuration file defines, if you want to change it then change the gems settings in the configuration instead.
