### PR TITLE
Remove API mrb_str_catf().

### DIFF
--- a/include/mruby/string.h
+++ b/include/mruby/string.h
@@ -68,7 +68,6 @@ int mrb_str_offset(mrb_state *mrb, mrb_value str, int pos);
 mrb_value mrb_str_dup(mrb_state *mrb, mrb_value str); /* mrb_str_dup */
 mrb_value mrb_str_intern(mrb_state *mrb, mrb_value self);
 mrb_value mrb_str_cat2(mrb_state *mrb, mrb_value str, const char *ptr);
-mrb_value mrb_str_catf(mrb_state *mrb, mrb_value str, const char *format, ...);
 mrb_value mrb_str_to_inum(mrb_state *mrb, mrb_value str, int base, int badcheck);
 double mrb_str_to_dbl(mrb_state *mrb, mrb_value str, int badcheck);
 mrb_value mrb_str_to_str(mrb_state *mrb, mrb_value str);

--- a/src/string.c
+++ b/src/string.c
@@ -6,7 +6,6 @@
 
 #include "mruby.h"
 
-#include <stdarg.h>
 #include <string.h>
 #include "mruby/string.h"
 #include <ctype.h>
@@ -2852,27 +2851,6 @@ mrb_value
 mrb_str_cat2(mrb_state *mrb, mrb_value str, const char *ptr)
 {
   return mrb_str_cat(mrb, str, ptr, strlen(ptr));
-}
-
-static mrb_value
-mrb_str_vcatf(mrb_state *mrb, mrb_value str, const char *fmt, va_list ap)
-{
-    mrb_string_value(mrb, &str);
-    mrb_str_resize(mrb, str, (char*)RSTRING_END(str) - RSTRING_PTR(str));
-
-    return str;
-}
-
-mrb_value
-mrb_str_catf(mrb_state *mrb, mrb_value str, const char *format, ...)
-{
-    va_list ap;
-
-    va_start(ap, format);
-    str = mrb_str_vcatf(mrb, str, format, ap);
-    va_end(ap);
-
-    return str;
 }
 
 mrb_value


### PR DESCRIPTION
I guess mrb_str_catf() will not work as expected by API designer.
And it is not called by anyone in core libraries.
I think this can be removed.
