### PR TITLE
Remove unused function parametes.

### DIFF
--- a/src/dump.c
+++ b/src/dump.c
@@ -59,7 +59,7 @@ static inline int uint16_dump(uint16_t,char*,int);
 static inline int uint32_dump(uint32_t,char*,int);
 static char* str_dump(char*,char*,uint16_t,int);
 static uint16_t str_dump_len(char*,uint16_t, int);
-static uint32_t get_irep_header_size(mrb_state*,mrb_irep*,int);
+static uint32_t get_irep_header_size(mrb_state*,int);
 static uint32_t get_iseq_block_size(mrb_state*,mrb_irep*,int);
 static uint32_t get_pool_block_size(mrb_state*,mrb_irep*,int);
 static uint32_t get_syms_block_size(mrb_state*,mrb_irep*,int);
@@ -202,7 +202,7 @@ str_dump_len(char *str, uint16_t len, int type)
 }
 
 static uint32_t
-get_irep_header_size(mrb_state *mrb, mrb_irep *irep, int type)
+get_irep_header_size(mrb_state *mrb, int type)
 {
   uint32_t size = 0;
 
@@ -305,7 +305,7 @@ get_irep_record_size(mrb_state *mrb, int irep_no, int type)
   mrb_irep *irep = mrb->irep[irep_no];
 
   size += DUMP_SIZE(MRB_DUMP_SIZE_OF_LONG, type); /* rlen */
-  size += get_irep_header_size(mrb, irep, type);
+  size += get_irep_header_size(mrb, type);
   size += get_iseq_block_size(mrb, irep, type);
   size += get_pool_block_size(mrb, irep, type);
   size += get_syms_block_size(mrb, irep, type);
@@ -480,7 +480,7 @@ calc_crc_section(mrb_state *mrb, mrb_irep *irep, uint16_t *crc, int section)
   int result;
 
   switch (section) {
-  case DUMP_IREP_HEADER: buf_size = get_irep_header_size(mrb, irep, type); break;
+  case DUMP_IREP_HEADER: buf_size = get_irep_header_size(mrb, type); break;
   case DUMP_ISEQ_BLOCK:  buf_size = get_iseq_block_size(mrb, irep, type); break;
   case DUMP_POOL_BLOCK:  buf_size = get_pool_block_size(mrb, irep, type); break;
   case DUMP_SYMS_BLOCK:  buf_size = get_syms_block_size(mrb, irep, type); break;

--- a/src/range.c
+++ b/src/range.c
@@ -333,7 +333,7 @@ range_to_s(mrb_state *mrb, mrb_value range)
 }
 
 static mrb_value
-inspect_range(mrb_state *mrb, mrb_value range, mrb_value dummy, int recur)
+inspect_range(mrb_state *mrb, mrb_value range, int recur)
 {
   mrb_value str, str2;
   struct RRange *r = mrb_range_ptr(range);
@@ -368,7 +368,7 @@ inspect_range(mrb_state *mrb, mrb_value range, mrb_value dummy, int recur)
 static mrb_value
 range_inspect(mrb_state *mrb, mrb_value range)
 {
-    return inspect_range(mrb, range, range, 0);
+    return inspect_range(mrb, range, 0);
 }
 
 /* 15.2.14.4.14(x) */

--- a/src/struct.c
+++ b/src/struct.c
@@ -463,7 +463,7 @@ mrb_struct_initialize(mrb_state *mrb, mrb_value self, mrb_value values)
 }
 
 static mrb_value
-inspect_struct(mrb_state *mrb, mrb_value s, mrb_value dummy, int recur)
+inspect_struct(mrb_state *mrb, mrb_value s, int recur)
 {
     const char *cn = mrb_class_name(mrb, mrb_obj_class(mrb, s));
     mrb_value members, str = mrb_str_new(mrb, "#<struct ", 9);
@@ -521,7 +521,7 @@ inspect_struct(mrb_state *mrb, mrb_value s, mrb_value dummy, int recur)
 static mrb_value
 mrb_struct_inspect(mrb_state *mrb, mrb_value s)
 {
-    return inspect_struct(mrb, s, s, 0);
+    return inspect_struct(mrb, s, 0);
 }
 
 /* 15.2.18.4.9  */


### PR DESCRIPTION
Some functions have unused and unnecessary parameters. They should be removed if there is no special reason.
