### PR TITLE
Protect proc of ensure.

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -1236,6 +1236,12 @@ mrb_run(mrb_state *mrb, struct RProc *proc, mrb_value self)
         acc = ci->acc;
         pc = ci->pc;
         regs = mrb->stack = mrb->stbase + ci->stackidx;
+        {
+          int idx = eidx;
+          while (idx > mrb->ci->eidx) {
+            mrb_gc_protect(mrb, mrb_obj_value(mrb->ensure[--idx]));
+          }
+        }
         while (eidx > mrb->ci->eidx) {
           ecall(mrb, --eidx);
         }


### PR DESCRIPTION
Protect proc of ensure from GC until `ecall` is called.

The following code causes segmentation fault in the current implementation.

``` ruby
def test
  begin
    begin
      return
    ensure
      puts "."
    end
  ensure
    puts "."
  end
end

while true
  test
end
```

This issue was found by iij's test case.
