### PR TITLE
Unused func prototype and typedef

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -247,7 +247,6 @@ mrb_value mrb_convert_type(mrb_state *mrb, mrb_value val, mrb_int type, const ch
 int mrb_obj_is_kind_of(mrb_state *mrb, mrb_value obj, struct RClass *c);
 mrb_value mrb_obj_inspect(mrb_state *mrb, mrb_value self);
 mrb_value mrb_obj_clone(mrb_state *mrb, mrb_value self);
-mrb_value mrb_check_funcall(mrb_state *mrb, mrb_value recv, mrb_sym mid, int argc, mrb_value *argv);
 
 /* need to include <ctype.h> to use these macros */
 #ifndef ISPRINT


### PR DESCRIPTION
I don't think mrb_funcargv_t is needed, even in the future. I'm not sure about mrb_check_funcall.
