### PR TITLE
Catch exceptions while initializing.

### DIFF
--- a/src/state.c
+++ b/src/state.c
@@ -32,7 +32,9 @@ mrb_open_allocf(mrb_allocf f, void *ud)
 
   if (setjmp(c_jmp) != 0) {
     if (mrb->exc) {
+#ifdef ENABLE_STDIO
       mrb_p(mrb, mrb_obj_value(mrb->exc));
+#endif
       mrb->jmp = NULL;
     }
     return NULL;


### PR DESCRIPTION
If exception occur while initializing mrbgems, mruby call `abort()`.
I think it should be bits gracefull.

How about show errors and return NULL for `mrb_open()` ?
