### PR TITLE
Remove ";" suffix from function-type macros.

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -231,11 +231,11 @@ void mrb_gc_arena_restore(mrb_state*,int);
 void mrb_gc_mark(mrb_state*,struct RBasic*);
 #define mrb_gc_mark_value(mrb,val) do {\
   if (mrb_type(val) >= MRB_TT_OBJECT) mrb_gc_mark((mrb), mrb_object(val));\
-} while (0);
+} while (0)
 void mrb_field_write_barrier(mrb_state *, struct RBasic*, struct RBasic*);
 #define mrb_field_write_barrier_value(mrb, obj, val) do{\
   if ((val.tt >= MRB_TT_OBJECT)) mrb_field_write_barrier((mrb), (obj), mrb_object(val));\
-} while (0);
+} while (0)
 void mrb_write_barrier(mrb_state *, struct RBasic*);
 
 mrb_value mrb_check_convert_type(mrb_state *mrb, mrb_value val, mrb_int type, const char *tname, const char *method);

--- a/include/mruby/khash.h
+++ b/include/mruby/khash.h
@@ -41,7 +41,7 @@ static const uint8_t __m[8] = {0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80};
   v |= v >> 8;\
   v |= v >> 16;\
   v++;\
-} while (0);
+} while (0)
 
 /* declare struct kh_xxx and kh_xxx_funcs
 

--- a/include/mruby/value.h
+++ b/include/mruby/value.h
@@ -55,7 +55,7 @@ typedef struct mrb_value {
 #define MRB_SET_VALUE(o, ttt, attr, v) do {\
   (o).tt = ttt;\
   (o).attr = v;\
-} while (0);
+} while (0)
 
 static inline mrb_value
 mrb_float_value(mrb_float f)
@@ -131,7 +131,7 @@ typedef struct mrb_value {
 #define MRB_SET_VALUE(o, tt, attr, v) do {\
   (o).ttt = mrb_mktt(tt);\
   (o).attr = v;\
-} while (0);
+} while (0)
 
 static inline mrb_value
 mrb_float_value(mrb_float f)

--- a/src/math.c
+++ b/src/math.c
@@ -11,7 +11,7 @@
 #include <math.h>
 
 #define domain_error(msg) \
-    mrb_raise(mrb, E_RANGE_ERROR, "Numerical argument is out of domain - " #msg);
+    mrb_raise(mrb, E_RANGE_ERROR, "Numerical argument is out of domain - " #msg)
 
 /* math functions not provided under Microsoft Visual C++ */
 #ifdef _MSC_VER


### PR DESCRIPTION
Function-type macro should not end with ";".

In the current implementation, the following source code occurs compilation error,
because the definition of `mrb_gc_mark_value` ends with ";".

``` c
if (a)
  mrb_gc_mark_value(mrb,val1);
else
  mrb_gc_mark_value(mrb,val2);
```
