### PR TITLE
Data_Make_Struct: invalid syntax

### DIFF
--- a/include/mruby/data.h
+++ b/include/mruby/data.h
@@ -30,7 +30,7 @@ struct RData *mrb_data_object_alloc(mrb_state *mrb, struct RClass* klass, void *
 
 #define Data_Make_Struct(mrb,klass,strct,type,sval) (\
   sval = mrb_malloc(mrb, sizeof(strct)),\
-  { static const strct zero = { 0 }; *sval = zero},\
+  memset(sval, 0, sizeof(strct)),\
   Data_Wrap_Struct(mrb,klass,type,sval)\
 )
 


### PR DESCRIPTION
Struct assignment can't be used here. I replaced it with memset.

Also it's possible mrb_malloc is returning NULL. Either a check should be added to the macro (mruby doesn't have NoMemoryError - what should be used instead?) or it should be removed (that can be done without any impact on current code because nobody is using it).
