### PR TITLE
Add semi-colon after the statement.

### DIFF
--- a/include/mruby/data.h
+++ b/include/mruby/data.h
@@ -30,7 +30,7 @@ struct RData *mrb_data_object_alloc(mrb_state *mrb, struct RClass* klass, void *
 
 #define Data_Make_Struct(mrb,klass,strct,type,sval) (\
   sval = mrb_malloc(mrb, sizeof(strct)),\
-  { static const strct zero = { 0 }; *sval = zero},\
+  { static const strct zero = { 0 }; *sval = zero; },\
   Data_Wrap_Struct(mrb,klass,type,sval)\
 )
 


### PR DESCRIPTION
This fix is related #821. It may be gcc extension omitting semi-colon.
(I'm not sure this fixes #821. But the fix will be required anyway.)
