### PR TITLE
add mrbtest verbose mode ('-v' option)

### DIFF
--- a/test/assert.rb
+++ b/test/assert.rb
@@ -23,6 +23,7 @@ end
 #       which will be tested by this
 #       assertion
 def assert(str = 'Assertion failed', iso = '')
+  print(str, (iso != '' ? " [#{iso}]" : ''), ' : ') if $mrbtest_verbose
   begin
     if(!yield)
       $asserts.push(assertion_string('Fail: ', str, iso))
@@ -37,6 +38,7 @@ def assert(str = 'Assertion failed', iso = '')
     $kill_test += 1
     print('X')
   end
+  print("\n") if $mrbtest_verbose
 end
 
 ##

--- a/test/driver.c
+++ b/test/driver.c
@@ -36,7 +36,7 @@ check_error(mrb_state *mrb)
 }
 
 int
-main(void)
+main(int argc, char **argv)
 {
   mrb_state *mrb;
   mrb_value return_value;
@@ -50,6 +50,11 @@ main(void)
   if (mrb == NULL) {
     fprintf(stderr, "Invalid mrb_state, exiting test driver");
     return EXIT_FAILURE;
+  }
+
+  if (argc == 2 && strncmp(argv[1], "-v", 2) == 0) {
+    printf("verbose mode: enable\n\n");
+    mrb_gv_set(mrb, mrb_intern(mrb, "$mrbtest_verbose"), mrb_true_value());
   }
 
   mrb_init_mrbtest(mrb);


### PR DESCRIPTION
```
$ ./build/host/test/mrbtest -v
mrbtest - Embeddable Ruby Test

This is a very early version, please test and report errors.
Thanks :)

verbose mode: enable

ArgumentError [15.2.24] : .
ArgumentError superclass [15.2.24.2] : .
Array [15.2.12] : .
 ... (snip)
```
