### PR TITLE
fixed segv. initialize array by over 127 items

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -554,6 +554,10 @@ mrb_run(mrb_state *mrb, struct RProc *proc, mrb_value self)
   if (!mrb->stack) {
     stack_init(mrb);
   }
+  int stack_shortfall = proc->body.irep->nregs - (mrb->stend - mrb->stack);
+  if( 0 < stack_shortfall ) {
+    stack_extend(mrb, proc->body.irep->nregs, 0);
+  }
   mrb->ci->proc = proc;
   mrb->ci->nregs = irep->nregs + 2;
   regs = mrb->stack;


### PR DESCRIPTION
Segv occurred when running the code below.

```
a = [
       1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,
       1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,2,
       1,1,3,3,3,3,3,3,3,3,3,3,3,3,2,2,
       1,1,3,3,3,3,3,3,3,3,3,3,3,3,2,2,
       1,1,3,3,3,3,3,3,3,3,3,3,3,3,2,2,
       1,1,3,3,3,3,3,3,3,3,3,3,3,3,2,2,
       1,1,3,3,3,3,3,3,3,3,3,3,3,3,2,2,
       1,1,3,3,3,3,3,3,1,1,1,1,1,1,1,
]
```

'mrbc --verbose' by this code.

```
000 OP_LOADI    R2      1
001 OP_LOADI    R3      1
002 OP_LOADI    R4      1
003 OP_LOADI    R5      1
...
126 OP_LOADI    R128    1
127 OP_ARRAY    R2      R2      127
128 OP_MOVE     R1      R2
129 OP_STOP
```

stack init size = STACK_INIT_SIZE 128.
when R128 is outside the array access occurs.
