### PR TITLE
string contains null byte check utility function (mrb_str_to_cstr)

### DIFF
--- a/include/mruby/string.h
+++ b/include/mruby/string.h
@@ -80,6 +80,7 @@ mrb_value mrb_str_cat(mrb_state *mrb, mrb_value str, const char *ptr, long len);
 mrb_value mrb_str_append(mrb_state *mrb, mrb_value str, mrb_value str2);
 
 int mrb_str_cmp(mrb_state *mrb, mrb_value str1, mrb_value str2);
+char *mrb_str_to_cstr(mrb_state *mrb, mrb_value str);
 
 #if defined(__cplusplus)
 }  /* extern "C" { */

--- a/src/string.c
+++ b/src/string.c
@@ -257,6 +257,18 @@ mrb_str_new_cstr(mrb_state *mrb, const char *p)
   return mrb_obj_value(s);
 }
 
+char *
+mrb_str_to_cstr(mrb_state *mrb, mrb_value str0)
+{
+  mrb_value str;
+
+  str = mrb_str_new(mrb, RSTRING_PTR(str0), RSTRING_LEN(str0));
+  if (strlen(RSTRING_PTR(str)) != RSTRING_LEN(str)) {
+    mrb_raise(mrb, E_ARGUMENT_ERROR, "string contains null byte");
+  }
+  return RSTRING_PTR(str);
+}
+
 static void
 str_make_shared(mrb_state *mrb, struct RString *s)
 {


### PR DESCRIPTION
see also
- http://www.ruby-lang.org/en/news/2012/10/12/poisoned-NUL-byte-vulnerability/
- iij/mruby's issue https://github.com/iij/mruby/issues/38
