### PR TITLE
Extend MiniRake::DSL module to prevent inheritance pollution

### DIFF
--- a/minirake
+++ b/minirake
@@ -287,7 +287,7 @@ module MiniRake
 end
 
 Rake = MiniRake
-include MiniRake::DSL
+extend MiniRake::DSL
 
 
 ######################################################################


### PR DESCRIPTION
`include MiniRake::DSL` on toplevel will pollute ancestor tree of every object.

`extend MiniRake::DSL` will add those methods only to `main` object.

Rake does the same: https://github.com/jimweirich/rake/blob/master/lib/rake/dsl_definition.rb#L153
