### PR TITLE
String#gsub fix with last character

### DIFF
--- a/mrblib/string.rb
+++ b/mrblib/string.rb
@@ -28,8 +28,10 @@ class String
   #
   # ISO 15.2.10.5.18
   def gsub(*args, &block)
+    lc = ''
     if args.size == 2
-      split(args[0]).join(args[1])
+      lc = args[1] if self[-1] == args[0]
+      split(args[0]).join(args[1]) + lc
     elsif args.size == 1 && block
       split(args[0]).join(block.call(args[0]))
     else

--- a/test/t/string.rb
+++ b/test/t/string.rb
@@ -193,7 +193,9 @@ assert('String#eql?', '15.2.10.5.17') do
 end
 
 assert('String#gsub', '15.2.10.5.18') do
-  'abcabc'.gsub('b', 'B') == 'aBcaBc' && 'abcabc'.gsub('b') { |w| w.capitalize } == 'aBcaBc' 
+  'abcabc'.gsub('b', 'B') == 'aBcaBc' and
+    'abcabc'.gsub('b') { |w| w.capitalize } == 'aBcaBc' and
+    '#a#a#'.gsub('#', '$') == '$a$a$'
 end
 
 assert('String#gsub!', '15.2.10.5.19') do
@@ -318,7 +320,9 @@ assert('String#split', '15.2.10.5.35') do
 end
 
 assert('String#sub', '15.2.10.5.36') do
-  'abcabc'.sub('b', 'B') == 'aBcabc' && 'abcabc'.sub('b') { |w| w.capitalize } == 'aBcabc' 
+  'abcabc'.sub('b', 'B') == 'aBcabc' and
+    'abcabc'.sub('b') { |w| w.capitalize } == 'aBcabc' and
+    'aa#'.sub('#', '$') == 'aa$'
 end
 
 assert('String#sub!', '15.2.10.5.37') do


### PR DESCRIPTION
Due to the reason that the current String#gsub implementation uses String#split it will forget to replace the last character in case it is a hit.
