### PR TITLE
Fix mirb crash 

### DIFF
--- a/tools/mirb/mirb.c
+++ b/tools/mirb/mirb.c
@@ -191,6 +191,10 @@ main(void)
     last_code_line[char_index] = '\0';
 #else
     char* line = readline(code_block_open ? "* " : "> ");
+    if(line == NULL) {
+      printf("\n");
+      break;
+    }
     strncat(last_code_line, line, sizeof(last_code_line)-1);
     add_history(line);
     free(line);


### PR DESCRIPTION
This fixes an mirb crash when it is compiled with readline. Hitting ctrl-d wouldn't exit early enough.
