### PR TITLE
parser_dump supports NODE_REGEX.

### DIFF
--- a/src/parse.y
+++ b/src/parse.y
@@ -5500,7 +5500,7 @@ parser_dump(mrb_state *mrb, node *tree, int offset)
     break;
 
   case NODE_REGX:
-    printf("NODE_REGX /%s/\n", (char*)tree->car->cdr->car);
+    printf("NODE_REGX /%s/%s\n", (char*)tree->car, (char*)tree->cdr);
     break;
 
   case NODE_SYM:


### PR DESCRIPTION
Prevent segmentation fault when Regexp literal is used and "-v" option is specified.
