### PR TITLE
regexp parsing bug if unknown option is used

### DIFF
--- a/src/parse.y
+++ b/src/parse.y
@@ -3461,9 +3461,8 @@ parse_string(parser_state *p, int term)
     pushback(p, c);
     if (toklen(p)) {
       char msg[128];
-      free(s);
       tokfix(p);
-      snprintf(msg, sizeof(msg), "unknown regexp option %s - %s",
+      snprintf(msg, sizeof(msg), "unknown regexp option%s - %s",
           toklen(p) > 1 ? "s" : "", tok(p));
       yyerror(p, msg);
     }


### PR DESCRIPTION
free must not be called - this isn't POSIX strndup. I also removed a redundant space in the message string.
