### PR TITLE
fix access denied error at incremental build

### DIFF
--- a/minirake
+++ b/minirake
@@ -237,7 +237,7 @@ module MiniRake
 
     # Time stamp for file task.
     def timestamp
-      File.new(name.to_s).mtime
+      File::stat(name.to_s).mtime
     end
   end
 


### PR DESCRIPTION
On windows (both MSVC and mingw), incremental build was failed like this.

```
mruby\src\array.c : fatal error C1083: コンパイラの生成した ファイルを開けません。'build\host\src\array.obj': Permission denied
rake aborted!
```

I think the output file is locked by File object.
This change works for me.Is this correct?
