### PR TITLE
Clean up mrbconf.h

### DIFF
--- a/include/mrbconf.h
+++ b/include/mrbconf.h
@@ -54,48 +54,39 @@
 /* Now DISABLE_GEMS is added as a command line flag in Rakefile, */
 /* we do not need to set it here. */
 
-#undef  HAVE_UNISTD_H /* WINDOWS */
+//#undef  HAVE_UNISTD_H /* WINDOWS */
 #define HAVE_UNISTD_H /* LINUX */
 
 /* end of configuration */
 
 #ifdef MRB_USE_FLOAT
   typedef float mrb_float;
-# define mrb_float_to_str(buf, i) sprintf((buf), "%.7e", (i))
-# define str_to_mrb_float(buf) (mrb_float)strtof((buf),NULL)
+# define mrb_float_to_str(buf, i) sprintf(buf, "%.7e", i)
+# define str_to_mrb_float(buf) strtof(buf, NULL)
 #else
   typedef double mrb_float;
-# define mrb_float_to_str(buf, i) sprintf((buf), "%.16e", (i))
-# define str_to_mrb_float(buf) (mrb_float)strtod((buf),NULL)
+# define mrb_float_to_str(buf, i) sprintf(buf, "%.16e", i)
+# define str_to_mrb_float(buf) strtod(buf, NULL)
 #endif
 
-#ifdef MRB_NAN_BOXING
-# ifdef MRB_INT64
+#ifdef MRB_INT64
+# ifdef MRB_NAN_BOXING
 #  error Cannot use NaN boxing when mrb_int is 64bit
 # else
-   typedef int32_t mrb_int;
-#  define MRB_INT_MIN INT32_MIN
-#  define MRB_INT_MAX INT32_MAX
-#  define MRB_INT_FORMAT PRId32
-#  define mrb_int_to_str(buf, i) sprintf((buf), "%" MRB_INT_FORMAT, (i))
-#  define str_to_mrb_int(buf) (mrb_int)strtol((buf), NULL, 10)
-# endif
-#else
-# ifdef MRB_INT64
    typedef int64_t mrb_int;
 #  define MRB_INT_MIN INT64_MIN
 #  define MRB_INT_MAX INT64_MAX
 #  define MRB_INT_FORMAT PRId64
-#  define mrb_int_to_str(buf, i) sprintf((buf), "%" MRB_INT_FORMAT, (i))
-#  define str_to_mrb_int(buf) (mrb_int)strtoll((buf), NULL, 10)
-# else
-   typedef int32_t mrb_int;
-#  define MRB_INT_MIN INT32_MIN
-#  define MRB_INT_MAX INT32_MAX
-#  define MRB_INT_FORMAT PRId32
-#  define mrb_int_to_str(buf, i) sprintf((buf), "%" MRB_INT_FORMAT, (i))
-#  define str_to_mrb_int(buf) (mrb_int)strtol((buf), NULL, 10)
+#  define mrb_int_to_str(buf, i) sprintf(buf, "%" MRB_INT_FORMAT, i)
+#  define str_to_mrb_int(buf) strtoll(buf, NULL, 10)
 # endif
+#else
+  typedef int32_t mrb_int;
+# define MRB_INT_MIN INT32_MIN
+# define MRB_INT_MAX INT32_MAX
+# define MRB_INT_FORMAT PRId32
+# define mrb_int_to_str(buf, i) sprintf(buf, "%" MRB_INT_FORMAT, i)
+# define str_to_mrb_int(buf) strtol(buf, NULL, 10)
 #endif
 typedef short mrb_sym;
 


### PR DESCRIPTION
- undef for windows is not used by default so comment it
- casting to the same type is not needed
- parenthesis are not needed for macro attributes separated by commas
- change order of MRB_NAN_BOXING and MRB_INT64 to simplify logic
