### PR TITLE
Regexp compile

### DIFF
--- a/src/codegen.c
+++ b/src/codegen.c
@@ -1932,7 +1932,7 @@ codegen(codegen_scope *s, node *tree, int val)
         pop();
       }
       pop();
-      sym = new_sym(s, mrb_intern(s->mrb, "new"));
+      sym = new_sym(s, mrb_intern(s->mrb, "compile"));
       genop(s, MKOP_ABC(OP_SEND, cursp(), sym, n));
       mrb_gc_arena_restore(s->mrb, ai); 
       push();


### PR DESCRIPTION
Currently regexp literals are parsed as:

``` ruby
Object.send(:new, :Regexp)
```

But it is not possible to cache the instances. So how about to use `compile` method?

https://github.com/mattn/mruby-pcre-regexp/blob/master/mrblib/pcre_regexp.rb#L2-L10

If literals are parsed as following, Regexp make memolize instances.

``` ruby
Object.send(:compile, :Regexp)
```

I'm not master of ruby. So If i'm missing something wrong, please close this.
