### PR TITLE
Remove the bit-field by mrb_value.tt

### DIFF
--- a/include/mruby/value.h
+++ b/include/mruby/value.h
@@ -43,7 +43,7 @@ typedef struct mrb_value {
     mrb_int i;
     mrb_sym sym;
   } value;
-  enum mrb_vtype tt:8;
+  enum mrb_vtype tt;
 } mrb_value;
 
 #define mrb_type(o)   (o).tt


### PR DESCRIPTION
This patch is based on discussion with @miura1729.

I think the bit-field by mrb_value.tt is redundant.
It make increase CPU cost. And less memory merit. Maybe (as it depends on ABI). 
