### PR TITLE
Fix errors caused by stdio.h dependent code.

### DIFF
--- a/include/mruby/dump.h
+++ b/include/mruby/dump.h
@@ -12,16 +12,22 @@ extern "C" {
 #endif
 
 #include "mruby.h"
+#ifdef ENABLE_STDIO
 #include <stdio.h>
+#endif
 #include <stdint.h>
 
+#ifdef ENABLE_STDIO
 int mrb_dump_irep(mrb_state*,int,FILE*);
-int mrb_read_irep(mrb_state*,const char*);
-int mrb_read_irep_file(mrb_state*,FILE*);
-/* mrb_value mrb_load_irep(mrb_state*,const char*); */ /* declared in <irep.h> */
-mrb_value mrb_load_irep_file(mrb_state*,FILE*);
-
 int mrb_bdump_irep(mrb_state *mrb, int n, FILE *f,const char *initname);
+
+int mrb_read_irep_file(mrb_state*,FILE*);
+#endif
+int mrb_read_irep(mrb_state*,const char*);
+
+#ifdef ENABLE_STDIO
+mrb_value mrb_load_irep_file(mrb_state*,FILE*);
+#endif
 
 /* dump type */
 #define DUMP_TYPE_CODE 0

--- a/src/dump.c
+++ b/src/dump.c
@@ -50,6 +50,8 @@ enum {
   DUMP_SECTION_NUM,
 };
 
+#ifdef ENABLE_STDIO
+
 uint16_t calc_crc_16_ccitt(unsigned char*,int);
 static inline int uint8_dump(uint8_t,char*,int);
 static inline int uint16_dump(uint16_t,char*,int);
@@ -742,3 +744,5 @@ mrb_bdump_irep(mrb_state *mrb, int n, FILE *f,const char *initname)
 
   return rc;
 }
+
+#endif /* ENABLE_STDIO */


### PR DESCRIPTION
dump.c / load.c has dependency to stdio.h.
So they can't compile if he build with C99  freestanding environment.

This patch is just for now.
I think we should separate dump.c / load.c with stdio, someday.
