### PR TITLE
Reduce sprintf() calls. Remove mrb_int_to_str() and MRB_INT_FORMAT.

### DIFF
--- a/include/mrbconf.h
+++ b/include/mrbconf.h
@@ -72,16 +72,12 @@
    typedef int64_t mrb_int;
 #  define MRB_INT_MIN INT64_MIN
 #  define MRB_INT_MAX INT64_MAX
-#  define MRB_INT_FORMAT PRId64
-#  define mrb_int_to_str(buf, i) sprintf(buf, "%" MRB_INT_FORMAT, i)
 #  define str_to_mrb_int(buf) strtoll(buf, NULL, 10)
 # endif
 #else
   typedef int32_t mrb_int;
 # define MRB_INT_MIN INT32_MIN
 # define MRB_INT_MAX INT32_MAX
-# define MRB_INT_FORMAT PRId32
-# define mrb_int_to_str(buf, i) sprintf(buf, "%" MRB_INT_FORMAT, i)
 # define str_to_mrb_int(buf) strtol(buf, NULL, 10)
 #endif
 typedef short mrb_sym;

--- a/src/dump.c
+++ b/src/dump.c
@@ -10,6 +10,7 @@
 
 #include "mruby/string.h"
 #include "mruby/irep.h"
+#include "mruby/numeric.h"
 
 static const unsigned char def_rite_binary_header[] =
   RITE_FILE_IDENFIFIER
@@ -241,8 +242,8 @@ get_pool_block_size(mrb_state *mrb, mrb_irep *irep, int type)
 
     switch (mrb_type(irep->pool[pool_no])) {
     case MRB_TT_FIXNUM:
-      len = mrb_int_to_str( buf, mrb_fixnum(irep->pool[pool_no]));
-      size += (uint32_t)len;
+      str = mrb_fix2str(mrb, irep->pool[pool_no], 10);
+      size += (uint32_t)RSTRING_LEN(str);
       break;
     case MRB_TT_FLOAT:
       len = mrb_float_to_str( buf, mrb_float(irep->pool[pool_no]));
@@ -358,7 +359,9 @@ write_pool_block(mrb_state *mrb, mrb_irep *irep, char *buf, int type)
 
     switch (mrb_type(irep->pool[pool_no])) {
     case MRB_TT_FIXNUM:
-      len = mrb_int_to_str(char_buf, mrb_fixnum(irep->pool[pool_no]));
+      str = mrb_fix2str(mrb, irep->pool[pool_no], 10);
+      memcpy(char_buf, RSTRING_PTR(str), RSTRING_LEN(str));
+      len = RSTRING_LEN(str);
       break;
 
     case MRB_TT_FLOAT:

--- a/src/string.c
+++ b/src/string.c
@@ -14,6 +14,7 @@
 #include "mruby/range.h"
 #include "mruby/array.h"
 #include "mruby/class.h"
+#include "mruby/numeric.h"
 #include <stdio.h>
 #include "re.h"
 
@@ -2552,9 +2553,16 @@ mrb_str_dump(mrb_state *mrb, mrb_value str)
           *q++ = c;
       }
       else {
-          *q++ = '\\';
-          sprintf(q, "%03o", c&0xff);
-          q += 3;
+        mrb_value octstr;
+        mrb_value chr;
+        const char *ptr;
+        int len;
+        chr = mrb_fixnum_value(c & 0xff);
+        octstr = mrb_fix2str(mrb, chr, 8);
+        ptr = mrb_str_body(octstr, &len);
+        memcpy(q, "\\000", 4);
+        memcpy(q + 4 - len, ptr, len);
+        q += 4;
       }
     }
     *q++ = '"';
@@ -2637,9 +2645,17 @@ mrb_str_inspect(mrb_state *mrb, mrb_value str)
           continue;
       }
       else {
-	int n = sprintf(buf, "\\%03o", c & 0377);
-	mrb_str_buf_cat(mrb, result, buf, n);
-          continue;
+        mrb_value octstr;
+        mrb_value chr;
+        const char *ptr;
+        int len;
+        chr = mrb_fixnum_value(c & 0xff);
+        octstr = mrb_fix2str(mrb, chr, 8);
+        ptr = mrb_str_body(octstr, &len);
+        memcpy(buf, "\\000", 4);
+        memcpy(buf + 4 - len, ptr, len);
+        mrb_str_buf_cat(mrb, result, buf, 4);
+        continue;
       }
     }
     mrb_str_buf_cat(mrb, result, "\"", 1);


### PR DESCRIPTION
sprintf() is defined in stdio.h. So it can't use if there is no stdio.h on target environments.
This fix doesn't remove all sprintf() in the repository. Just reduces.

This patch provides a happy side effect. We can remove MRB_INT_FORMAT macro.
