### PR TITLE
Refere ISEQ BLOCK of binary bytecode to ROM directly(rebased).

### DIFF
--- a/include/mrbconf.h
+++ b/include/mrbconf.h
@@ -19,7 +19,7 @@
 /* represent mrb_value in boxed double; conflict with MRB_USE_FLOAT */
 //#define MRB_NAN_BOXING
 
-/* define on big endian machines; used by MRB_NAN_BOXING */
+/* define on big endian machines; used by MRB_NAN_BOXING and when dump C bytecode for cross-compile*/
 //#define MRB_ENDIAN_BIG
 
 /* argv max size in mrb_funcall */

--- a/include/mruby/dump.h
+++ b/include/mruby/dump.h
@@ -16,7 +16,7 @@ extern "C" {
 #include <stdint.h>
 
 int mrb_dump_irep(mrb_state*,int,FILE*);
-int mrb_read_irep(mrb_state*,const char*);
+int mrb_read_irep(mrb_state*,const char*,int);
 int mrb_read_irep_file(mrb_state*,FILE*);
 /* mrb_value mrb_load_irep(mrb_state*,const char*); */ /* declared in <irep.h> */
 mrb_value mrb_load_irep_file(mrb_state*,FILE*);
@@ -42,9 +42,12 @@ int mrb_bdump_irep(mrb_state *mrb, int n, FILE *f,const char *initname, int endi
 #define MRB_DUMP_INVALID_IREP           -6
 #define MRB_DUMP_INVALID_ARGUMENT       -7
 
- /* endian for binary output */
- #define MRB_DUMP_ENDIAN_LITTLE        0
- #define MRB_DUMP_ENDIAN_BIG           1
+/* endian for binary output */
+#define MRB_DUMP_ENDIAN_LITTLE        0
+#define MRB_DUMP_ENDIAN_BIG           1
+
+#define MRB_COPY_ISEQ_BLOCK           0
+#define MRB_NOCOPY_ISEQ_BLOCK         1
 
 /* size of long/int/short value on dump/load */
 #define MRB_DUMP_SIZE_OF_LONG          4

--- a/include/mruby/dump.h
+++ b/include/mruby/dump.h
@@ -21,7 +21,7 @@ int mrb_read_irep_file(mrb_state*,FILE*);
 /* mrb_value mrb_load_irep(mrb_state*,const char*); */ /* declared in <irep.h> */
 mrb_value mrb_load_irep_file(mrb_state*,FILE*);
 
-int mrb_bdump_irep(mrb_state *mrb, int n, FILE *f,const char *initname);
+int mrb_bdump_irep(mrb_state *mrb, int n, FILE *f,const char *initname, int endian);
 
 /* dump type */
 #define DUMP_TYPE_CODE 0
@@ -41,6 +41,10 @@ int mrb_bdump_irep(mrb_state *mrb, int n, FILE *f,const char *initname);
 #define MRB_DUMP_INVALID_FILE_HEADER    -5
 #define MRB_DUMP_INVALID_IREP           -6
 #define MRB_DUMP_INVALID_ARGUMENT       -7
+
+ /* endian for binary output */
+ #define MRB_DUMP_ENDIAN_LITTLE        0
+ #define MRB_DUMP_ENDIAN_BIG           1
 
 /* size of long/int/short value on dump/load */
 #define MRB_DUMP_SIZE_OF_LONG          4
@@ -117,6 +121,17 @@ uint32_to_bin(uint32_t l, char *bin)
   *bin++ = (l >> 16) & 0xff;
   *bin++ = (l >> 8) & 0xff;
   *bin   = l & 0xff;
+  return (MRB_DUMP_SIZE_OF_LONG);
+}
+
+static inline int
+uint32_to_bin_flip(uint32_t l, char *bin)
+{
+  char *p = (char *)&l;
+  *bin++ = p[3];
+  *bin++ = p[2];
+  *bin++ = p[1];
+  *bin   = p[0];
   return (MRB_DUMP_SIZE_OF_LONG);
 }
 

--- a/src/dump.c
+++ b/src/dump.c
@@ -54,9 +54,9 @@ enum {
 };
 
 #ifdef MRB_ENDIAN_BIG
-# define MRB_CHECK_ENDIAN(x) ((x) == MRB_DUMP_ENDIAN_BIG)
+# define MRB_SAME_ENDIAN(x) ((x) == MRB_DUMP_ENDIAN_BIG)
 #else
-# define MRB_CHECK_ENDIAN(x) ((x) == MRB_DUMP_ENDIAN_LITTLE)
+# define MRB_SAME_ENDIAN(x) ((x) == MRB_DUMP_ENDIAN_LITTLE)
 #endif
 
 uint16_t calc_crc_16_ccitt(unsigned char*,int);
@@ -345,7 +345,7 @@ write_iseq_block(mrb_state *mrb, mrb_irep *irep, char *buf, int type, int endian
   for (iseq_no = 0; iseq_no < irep->ilen; iseq_no++){
 
     if (type == DUMP_TYPE_BIN){
-      if ( MRB_CHECK_ENDIAN(endian) ) {
+      if ( MRB_SAME_ENDIAN(endian) ) {
         *(uint32_t *)buf = (uint32_t)irep->iseq[iseq_no];
         buf += MRB_DUMP_SIZE_OF_LONG;
       }else{

--- a/src/load.c
+++ b/src/load.c
@@ -374,13 +374,9 @@ read_rite_irep_record(mrb_state *mrb, unsigned char *src, uint32_t* len)
   irep->ilen = bin_to_uint32(src);          //iseq length
   src += MRB_DUMP_SIZE_OF_LONG;
   if (irep->ilen > 0) {
-    irep->iseq = (mrb_code *)mrb_malloc(mrb, sizeof(mrb_code) * irep->ilen);
-    if (irep->iseq == NULL) {
-      ret = MRB_DUMP_GENERAL_FAILURE;
-      goto error_exit;
-    }
+    irep->iseq = (mrb_code *)src;               //iseq
+    irep->flags = MRB_ISEQ_NO_FREE;
     for (i=0; i<irep->ilen; i++) {
-      irep->iseq[i] = bin_to_uint32(src);     //iseq
       src += MRB_DUMP_SIZE_OF_LONG;
     }
   }

--- a/tools/mrbc/mrbc.c
+++ b/tools/mrbc/mrbc.c
@@ -19,6 +19,7 @@ struct _args {
   char *filename;
   char *initname;
   char *ext;
+  int endian;
   int check_syntax : 1;
   int verbose      : 1;
 };
@@ -32,6 +33,7 @@ usage(const char *name)
   "-o<outfile>  place the output into <outfile>",
   "-v           print version number, then trun on verbose mode",
   "-B<symbol>   binary <symbol> output in C language format",
+  "-E[little|big] specify endian for binary output(default is little)",
   "--verbose    run at verbose mode",
   "--version    print the version",
   "--copyright  print the copyright",
@@ -72,6 +74,7 @@ parse_args(mrb_state *mrb, int argc, char **argv, struct _args *args)
 
   *args = args_zero;
   args->ext = RITEBIN_EXT;
+  args->endian = MRB_DUMP_ENDIAN_LITTLE;
 
   for (argc--,argv++; argc > 0; argc--,argv++) {
     if (**argv == '-') {
@@ -91,6 +94,18 @@ parse_args(mrb_state *mrb, int argc, char **argv, struct _args *args)
         if (*args->initname == '\0') {
           printf("%s: Function name is not specified.\n", *origargv);
           result = -2;
+          goto exit;
+        }
+        break;
+      case 'E':
+        if (strcmp((*argv) + 2, "little") == 0) {
+          args->endian = MRB_DUMP_ENDIAN_LITTLE;
+        }
+        else if (strcmp((*argv) + 2, "big") == 0) {
+          args->endian = MRB_DUMP_ENDIAN_BIG;
+        }else{
+          result = -2;
+          printf("%s: Endian should be little or big.\n", *origargv);
           goto exit;
         }
         break;
@@ -203,7 +218,7 @@ main(int argc, char **argv)
     return EXIT_SUCCESS;
   }
   if (args.initname) {
-    n = mrb_bdump_irep(mrb, n, args.wfp, args.initname);
+    n = mrb_bdump_irep(mrb, n, args.wfp, args.initname, args.endian);
   }
   else {
     n = mrb_dump_irep(mrb, n, args.wfp);


### PR DESCRIPTION
I've implemented idea of referring ISEQ BLOCK of binary bytecode to ROM directly. Based on (6) of http://www.csk.com/fukuoka/services/mruby/nxt02.html.

I'm not sure this kind of hack is wellcome, but in my environment, around 8kb of heap can be saved by this change.
