### PR TITLE
Make OP_ASGN faster.

### DIFF
--- a/src/codegen.c
+++ b/src/codegen.c
@@ -1488,6 +1488,12 @@ codegen(codegen_scope *s, node *tree, int val)
       else if (len == 1 && name[0] == '-')  {
         genop_peep(s, MKOP_ABC(OP_SUB, cursp(), idx, 1), val);
       }
+      else if (len == 1 && name[0] == '*')  {
+        genop(s, MKOP_ABC(OP_MUL, cursp(), idx, 1));
+      }
+      else if (len == 1 && name[0] == '/')  {
+        genop(s, MKOP_ABC(OP_DIV, cursp(), idx, 1));
+      }
       else if (len == 1 && name[0] == '<')  {
         genop(s, MKOP_ABC(OP_LT, cursp(), idx, 1));
       }


### PR DESCRIPTION
I think that `*=` and `/=` can be compiled to `OP_MUL` and `OP_DIV`.

Sample `test.rb`:

``` ruby
a = 10.0
10000000.times do
  a *= 1
end
```

Without this patch:

```
% time ./bin/mruby test.rb
2.028u 0.003s 0:02.03 99.5% 0+0k 0+0io 0pf+0w
```

With this patch:

```
% time ./bin/mruby test.rb
1.476u 0.003s 0:01.48 99.3% 0+0k 0+0io 0pf+0w
```
