### PR TITLE
Use MRB_IREP_ARRAY_INIT_SIZE macro. 

### DIFF
--- a/include/mrbconf.h
+++ b/include/mrbconf.h
@@ -34,6 +34,9 @@
 /* initial size for IV khash; ignored when MRB_USE_IV_SEGLIST is set */
 //#define MRB_IVHASH_INIT_SIZE 8
 
+/* initial size for IREP array */
+//#define MRB_IREP_ARRAY_INIT_SIZE (256u)
+
 /* default size of khash table bucket */
 //#define KHASH_DEFAULT_SIZE 32
 

--- a/src/state.c
+++ b/src/state.c
@@ -110,6 +110,10 @@ mrb_close(mrb_state *mrb)
   mrb_free(mrb, mrb);
 }
 
+#ifndef MRB_IREP_ARRAY_INIT_SIZE
+# define MRB_IREP_ARRAY_INIT_SIZE (256u)
+#endif
+
 mrb_irep*
 mrb_add_irep(mrb_state *mrb)
 {
@@ -117,7 +121,7 @@ mrb_add_irep(mrb_state *mrb)
   mrb_irep *irep;
 
   if (!mrb->irep) {
-    int max = 256;
+    size_t max = MRB_IREP_ARRAY_INIT_SIZE;
 
     if (mrb->irep_len > max) max = mrb->irep_len+1;
     mrb->irep = (mrb_irep **)mrb_calloc(mrb, max, sizeof(mrb_irep*));


### PR DESCRIPTION
It should be configurable since it's possible to reduce (a few) RAM size.
