### PR TITLE
Use inptr_t as the type of ud. Instead of void*.

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -41,7 +41,7 @@ typedef int32_t mrb_code;
 
 struct mrb_state;
 
-typedef void* (*mrb_allocf) (struct mrb_state *mrb, void*, size_t, intptr_t ud);
+typedef void* (*mrb_allocf) (struct mrb_state *mrb, void*, size_t, uintptr_t ud);
 
 #ifndef MRB_ARENA_SIZE
 #define MRB_ARENA_SIZE 100
@@ -140,7 +140,7 @@ typedef struct mrb_state {
   struct RClass *eException_class;
   struct RClass *eStandardError_class;
 
-  intptr_t ud; /* auxiliary data */
+  uintptr_t ud; /* auxiliary data */
 } mrb_state;
 
 typedef mrb_value (*mrb_func_t)(mrb_state *mrb, mrb_value);
@@ -209,7 +209,7 @@ mrb_value mrb_str_new_cstr(mrb_state*, const char*);
 mrb_value mrb_str_new2(mrb_state *mrb, const char *p);
 
 mrb_state* mrb_open(void);
-mrb_state* mrb_open_allocf(mrb_allocf, intptr_t ud);
+mrb_state* mrb_open_allocf(mrb_allocf, uintptr_t ud);
 void mrb_close(mrb_state*);
 int mrb_checkstack(mrb_state*,int);
 

--- a/src/state.c
+++ b/src/state.c
@@ -14,7 +14,7 @@ void mrb_init_core(mrb_state*);
 void mrb_final_core(mrb_state*);
 
 mrb_state*
-mrb_open_allocf(mrb_allocf f, intptr_t ud)
+mrb_open_allocf(mrb_allocf f, uintptr_t ud)
 {
   static const mrb_state mrb_state_zero = { 0 };
   mrb_state *mrb = (mrb_state *)(f)(NULL, NULL, sizeof(mrb_state), ud);
@@ -31,7 +31,7 @@ mrb_open_allocf(mrb_allocf f, intptr_t ud)
 }
 
 static void*
-allocf(mrb_state *mrb, void *p, size_t size, intptr_t ud)
+allocf(mrb_state *mrb, void *p, size_t size, uintptr_t ud)
 {
   if (size == 0) {
     free(p);
@@ -74,7 +74,7 @@ mrb_alloca_free(mrb_state *mrb)
 mrb_state*
 mrb_open()
 {
-  mrb_state *mrb = mrb_open_allocf(allocf, (intptr_t)NULL);
+  mrb_state *mrb = mrb_open_allocf(allocf, (uintptr_t)NULL);
 
   return mrb;
 }


### PR DESCRIPTION
This is not a bug fix but a deviation proposal.

mrb_state.ud is prepared for the application dependent data.
And some applications may require just  a integer. For example, ID number, array index.
So it's more useful to declare as intptr_t instead of void*, I think.
