### PR TITLE
mrb_funcall_with_block: raised exception corrupts ci and stack

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -316,8 +316,13 @@ mrb_funcall_with_block(mrb_state *mrb, mrb_value self, mrb_sym mid, int argc, mr
 
   if (!mrb->jmp) {
     jmp_buf c_jmp;
+    mrb_callinfo *old_ci = mrb->ci;
 
     if (setjmp(c_jmp) != 0) {	/* error */
+      while (old_ci != mrb->ci) {
+        mrb->stack = mrb->stbase + mrb->ci->stackidx;
+        cipop(mrb);
+      }
       mrb->jmp = 0;
       return mrb_nil_value();
     }


### PR DESCRIPTION
For the original bug report see [[ruby-talk:404969]](http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/404969).
