### PR TITLE
Simplify mrb_range_beg_len(). Don't use OTHER macro.

### DIFF
--- a/include/mruby/range.h
+++ b/include/mruby/range.h
@@ -26,7 +26,7 @@ struct RRange {
 #define mrb_range_value(p)  mrb_obj_value((void*)(p))
 
 mrb_value mrb_range_new(mrb_state*, mrb_value, mrb_value, int);
-mrb_int mrb_range_beg_len(mrb_state *mrb, mrb_value range, mrb_int *begp, mrb_int *lenp, mrb_int len, mrb_int err);
+mrb_int mrb_range_beg_len(mrb_state *mrb, mrb_value range, mrb_int *begp, mrb_int *lenp, mrb_int len);
 
 #if defined(__cplusplus)
 }  /* extern "C" { */

--- a/src/string.c
+++ b/src/string.c
@@ -759,23 +759,22 @@ num_index:
         return mrb_str_dup(mrb, indx);
       return mrb_nil_value();
 
-    default:
+    case MRB_TT_RANGE:
       /* check if indx is Range */
       {
         mrb_int beg, len;
         mrb_value tmp;
 
         len = RSTRING_LEN(str);
-        switch (mrb_range_beg_len(mrb, indx, &beg, &len, len, 0)) {
-          case FALSE:
-            break;
-          case 2/*OTHER*/:
-            return mrb_nil_value();
-          default:
-            tmp = mrb_str_subseq(mrb, str, beg, len);
-            return tmp;
+        if (mrb_range_beg_len(mrb, indx, &beg, &len, len)) {
+          tmp = mrb_str_subseq(mrb, str, beg, len);
+          return tmp;
+        }
+        else {
+          return mrb_nil_value();
         }
       }
+    default:
       idx = mrb_fixnum(indx);
       goto num_index;
     }


### PR DESCRIPTION
mrb_range_beg_len() in range.c is too rich to use in mruby core.

We'll get a good side effect after applying this patch, we can stop using OTHER macro.
