### PR TITLE
Modify stack position of NODE_DEF and NODE_SDEF.

### DIFF
--- a/src/codegen.c
+++ b/src/codegen.c
@@ -2125,6 +2125,7 @@ codegen(codegen_scope *s, node *tree, int val)
       genop(s, MKOP_AB(OP_METHOD, cursp(), sym));
       if (val) {
         genop(s, MKOP_A(OP_LOADNIL, cursp()));
+        push();
       }
     }
     break;
@@ -2144,6 +2145,7 @@ codegen(codegen_scope *s, node *tree, int val)
       genop(s, MKOP_AB(OP_METHOD, cursp(), sym));
       if (val) {
         genop(s, MKOP_A(OP_LOADNIL, cursp()));
+        push();
       }
     }
     break;


### PR DESCRIPTION
Here is the error case.

``` ruby
def test(a)
  b = 2
  b = if (a == 1)
        def test2
          return 1
        end
        1
      else
        def test2
          return 2
        end
      end
  b
end

p test(1)
  #2 (not 1)
```

This sample may be too artificial, but I think that this patch improves mruby's behavior.
