### PR TITLE
Comment out Math module and Time class for user friendly

### DIFF
--- a/build_config.rb
+++ b/build_config.rb
@@ -12,10 +12,10 @@ MRuby::Build.new do |conf|
   # conf.gem :git => 'git@github.com:masuidrive/mrbgems-example.git', :branch => 'master', :options => '-v'
 
   # Use standard Math module
-  conf.gem 'mrbgems/mruby-math'
+  # conf.gem 'mrbgems/mruby-math'
 
   # Use standard Time class
-  conf.gem 'mrbgems/mruby-time'
+  # conf.gem 'mrbgems/mruby-time'
 
   # Generate binaries
   # conf.bins = %w(mrbc mruby mirb)


### PR DESCRIPTION
build_config.rb is generated by mgem as much as possible. If "Math module" and "Time class" were written in default build_config.rb, mgem will delete these config lines in ordinary below usage.

mgem config > build_config.rb

I'ts not user-friendly.
so, I think we shuould prepare minimal build_config.rb, and add setting of recommended standard module or class to mgem interactive settings like ToolChain. Cc: @bovi

How do you think?
