### PR TITLE
Use typedef names as possible

### DIFF
--- a/include/mruby/array.h
+++ b/include/mruby/array.h
@@ -11,18 +11,18 @@
 extern "C" {
 #endif
 
-struct mrb_shared_array {
+typedef struct mrb_shared_array {
   int refcnt;
   mrb_value *ptr;
   int len;
-};
+} mrb_shared_array;
 
 struct RArray {
   MRB_OBJECT_HEADER;
   int len;
   union {
     int capa;
-    struct mrb_shared_array *shared;
+    mrb_shared_array *shared;
   } aux;
   mrb_value *ptr;
 };
@@ -35,7 +35,7 @@ struct RArray {
 #define RARRAY_PTR(a) (RARRAY(a)->ptr)
 #define MRB_ARY_SHARED      256
 
-void mrb_ary_decref(mrb_state*, struct mrb_shared_array*);
+void mrb_ary_decref(mrb_state*, mrb_shared_array*);
 mrb_value mrb_ary_new_capa(mrb_state*, int);
 mrb_value mrb_ary_new(mrb_state *mrb);
 mrb_value mrb_ary_new_elts(mrb_state *mrb, int n, const mrb_value *elts);

--- a/include/mruby/data.h
+++ b/include/mruby/data.h
@@ -11,19 +11,19 @@
 extern "C" {
 #endif
 
-struct mrb_data_type {
+typedef struct mrb_data_type {
   const char *struct_name;
   void (*dfree)(mrb_state *mrb, void*);
-};
+} mrb_data_type;
 
 struct RData {
   MRB_OBJECT_HEADER;
   struct iv_tbl *iv;
-  struct mrb_data_type *type;
+  mrb_data_type *type;
   void *data;
 };
 
-struct RData *mrb_data_object_alloc(mrb_state *mrb, struct RClass* klass, void *datap, const struct mrb_data_type *type);
+struct RData *mrb_data_object_alloc(mrb_state *mrb, struct RClass* klass, void *datap, const mrb_data_type *type);
 
 #define Data_Wrap_Struct(mrb,klass,type,ptr)\
   mrb_data_object_alloc(mrb,klass,ptr,type)
@@ -37,8 +37,8 @@ struct RData *mrb_data_object_alloc(mrb_state *mrb, struct RClass* klass, void *
 #define RDATA(obj)         ((struct RData *)((obj).value.p))
 #define DATA_PTR(d)        (RDATA(d)->data)
 #define DATA_TYPE(d)       (RDATA(d)->type)
-void *mrb_get_datatype(mrb_state *mrb, mrb_value, const struct mrb_data_type*);
-void *mrb_check_datatype(mrb_state *mrb, mrb_value, const struct mrb_data_type*);
+void *mrb_get_datatype(mrb_state *mrb, mrb_value, const mrb_data_type*);
+void *mrb_check_datatype(mrb_state *mrb, mrb_value, const mrb_data_type*);
 #define Data_Get_Struct(mrb,obj,type,sval) do {\
   *(void**)&sval = mrb_check_datatype(mrb, obj, type); \
 } while (0)

--- a/include/mruby/dump.h
+++ b/include/mruby/dump.h
@@ -82,7 +82,7 @@ mrb_value mrb_load_irep_file(mrb_state*,FILE*);
 #define MRB_DUMP_DEFAULT_STR_LEN       128
 
 //Rite Binary file_header
-typedef struct _rite_binary_header {
+typedef struct {
   unsigned char    rbfi[4];        //Rite Binary File Identify
   unsigned char    rbfv[8];        //Rite Binary File Format Version
   unsigned char    risv[8];        //Rite Instruction Specification Version
@@ -95,7 +95,7 @@ typedef struct _rite_binary_header {
 } rite_binary_header;
 
 // Rite File file_header
-typedef struct _rite_file_header {
+typedef struct {
   unsigned char    rbfi[4];        //Rite Binary File Identify
   unsigned char    rbfv[8];        //Rite Binary File Format Version
   unsigned char    risv[8];        //Rite Instruction Specification Version

--- a/include/mruby/range.h
+++ b/include/mruby/range.h
@@ -11,14 +11,14 @@
 extern "C" {
 #endif
 
-struct mrb_range_edges {
+typedef struct mrb_range_edges {
   mrb_value beg;
   mrb_value end;
-};
+} mrb_range_edges;
 
 struct RRange {
   MRB_OBJECT_HEADER;
-  struct mrb_range_edges *edges;
+  mrb_range_edges *edges;
   int excl;
 };
 

--- a/include/mruby/string.h
+++ b/include/mruby/string.h
@@ -21,18 +21,18 @@ extern "C" {
 
 extern const char mrb_digitmap[];
 
-struct mrb_shared_string {
+typedef struct mrb_shared_string {
   int refcnt;
   char *ptr;
   int len;
-};
+} mrb_shared_string;
 
 struct RString {
   MRB_OBJECT_HEADER;
   int len;
   union {
     int capa;
-    struct mrb_shared_string *shared;
+    mrb_shared_string *shared;
   } aux;
   char *ptr;
 };
@@ -45,7 +45,7 @@ struct RString {
 #define RSTRING_END(s)    (RSTRING(s)->ptr + RSTRING(s)->len)
 #define MRB_STR_SHARED      256
 
-void mrb_str_decref(mrb_state*, struct mrb_shared_string*);
+void mrb_str_decref(mrb_state*, mrb_shared_string*);
 mrb_value mrb_str_literal(mrb_state*, mrb_value);
 void mrb_str_concat(mrb_state*, mrb_value, mrb_value);
 mrb_value mrb_str_plus(mrb_state*, mrb_value, mrb_value);

--- a/src/array.c
+++ b/src/array.c
@@ -125,7 +125,7 @@ static void
 ary_modify(mrb_state *mrb, struct RArray *a)
 {
   if (a->flags & MRB_ARY_SHARED) {
-    struct mrb_shared_array *shared = a->aux.shared;
+    mrb_shared_array *shared = a->aux.shared;
 
     if (shared->refcnt == 1 && a->ptr == shared->ptr) {
       a->ptr = shared->ptr;
@@ -154,7 +154,7 @@ static void
 ary_make_shared(mrb_state *mrb, struct RArray *a)
 {
   if (!(a->flags & MRB_ARY_SHARED)) {
-    struct mrb_shared_array *shared = (struct mrb_shared_array *)mrb_malloc(mrb, sizeof(struct mrb_shared_array));
+    mrb_shared_array *shared = (mrb_shared_array *)mrb_malloc(mrb, sizeof(mrb_shared_array));
 
     shared->refcnt = 1;
     if (a->aux.capa > a->len) {
@@ -667,7 +667,7 @@ mrb_ary_len(mrb_state *mrb, mrb_value ary)
 }
 
 void
-mrb_ary_decref(mrb_state *mrb, struct mrb_shared_array *shared)
+mrb_ary_decref(mrb_state *mrb, mrb_shared_array *shared)
 {
   shared->refcnt--;
   if (shared->refcnt == 0) {

--- a/src/etc.c
+++ b/src/etc.c
@@ -11,19 +11,19 @@
 #include "mruby/data.h"
 
 struct RData*
-mrb_data_object_alloc(mrb_state *mrb, struct RClass *klass, void *ptr, const struct mrb_data_type *type)
+mrb_data_object_alloc(mrb_state *mrb, struct RClass *klass, void *ptr, const mrb_data_type *type)
 {
   struct RData *data;
 
   data = (struct RData*)mrb_obj_alloc(mrb, MRB_TT_DATA, klass);
   data->data = ptr;
-  data->type = (struct mrb_data_type*) type;
+  data->type = (mrb_data_type*) type;
 
   return data;
 }
 
 void *
-mrb_get_datatype(mrb_state *mrb, mrb_value obj, const struct mrb_data_type *type)
+mrb_get_datatype(mrb_state *mrb, mrb_value obj, const mrb_data_type *type)
 {
   if (mrb_special_const_p(obj) || (mrb_type(obj) != MRB_TT_DATA)) {
     return NULL;
@@ -35,7 +35,7 @@ mrb_get_datatype(mrb_state *mrb, mrb_value obj, const struct mrb_data_type *type
 }
 
 void *
-mrb_check_datatype(mrb_state *mrb, mrb_value obj, const struct mrb_data_type *type)
+mrb_check_datatype(mrb_state *mrb, mrb_value obj, const mrb_data_type *type)
 {
   static const char mesg[] = "wrong argument type %s (expected %s)";
 

--- a/src/range.c
+++ b/src/range.c
@@ -40,7 +40,7 @@ mrb_range_new(mrb_state *mrb, mrb_value beg, mrb_value end, int excl)
 
   r = (struct RRange*)mrb_obj_alloc(mrb, MRB_TT_RANGE, RANGE_CLASS);
   range_check(mrb, beg, end);
-  r->edges = (struct mrb_range_edges *)mrb_malloc(mrb, sizeof(struct mrb_range_edges));
+  r->edges = (mrb_range_edges *)mrb_malloc(mrb, sizeof(mrb_range_edges));
   r->edges->beg = beg;
   r->edges->end = end;
   r->excl = excl;
@@ -103,7 +103,7 @@ range_init(mrb_state *mrb, mrb_value range, mrb_value beg, mrb_value end, int ex
   range_check(mrb, beg, end);
   r->excl = exclude_end;
   if (!r->edges) {
-    r->edges = (struct mrb_range_edges *)mrb_malloc(mrb, sizeof(struct mrb_range_edges));
+    r->edges = (mrb_range_edges *)mrb_malloc(mrb, sizeof(mrb_range_edges));
   }
   r->edges->beg = beg;
   r->edges->end = end;

--- a/src/string.c
+++ b/src/string.c
@@ -35,7 +35,7 @@ _obj_classname(mrb_state *mrb, mrb_value obj)
 }
 
 void
-mrb_str_decref(mrb_state *mrb, struct mrb_shared_string *shared)
+mrb_str_decref(mrb_state *mrb, mrb_shared_string *shared)
 {
   shared->refcnt--;
   if (shared->refcnt == 0) {
@@ -48,7 +48,7 @@ static void
 str_modify(mrb_state *mrb, struct RString *s)
 {
   if (s->flags & MRB_STR_SHARED) {
-    struct mrb_shared_string *shared = s->aux.shared;
+    mrb_shared_string *shared = s->aux.shared;
 
     if (shared->refcnt == 1 && s->ptr == shared->ptr) {
       s->ptr = shared->ptr;
@@ -275,7 +275,7 @@ static void
 str_make_shared(mrb_state *mrb, struct RString *s)
 {
   if (!(s->flags & MRB_STR_SHARED)) {
-    struct mrb_shared_string *shared = (struct mrb_shared_string *)mrb_malloc(mrb, sizeof(struct mrb_shared_string));
+    mrb_shared_string *shared = (mrb_shared_string *)mrb_malloc(mrb, sizeof(mrb_shared_string));
 
     shared->refcnt = 1;
     if (s->aux.capa > s->len) {
@@ -301,7 +301,7 @@ mrb_value
 mrb_str_literal(mrb_state *mrb, mrb_value str)
 {
   struct RString *s, *orig;
-  struct mrb_shared_string *shared;
+  mrb_shared_string *shared;
 
   s = str_alloc(mrb, mrb->string_class);
   orig = mrb_str_ptr(str);
@@ -1161,7 +1161,7 @@ static mrb_value
 mrb_str_subseq(mrb_state *mrb, mrb_value str, int beg, int len)
 {
   struct RString *orig, *s;
-  struct mrb_shared_string *shared;
+  mrb_shared_string *shared;
 
   orig = mrb_str_ptr(str);
   str_make_shared(mrb, orig);


### PR DESCRIPTION
In the current API set, there are both of typedef-ed structures and and un-typedef-ed.
They don't consistent.
Some un-typedef-ed are not alternative but others can use typedef-ed type.

I suggest to use only typedef-ed types.
But in this version, they have "typedef struct A { } A;" format. This is for the backward compatibility.
