### PR TITLE
Deletes unused variable 'struct RArray *sv' in struct.c .

### DIFF
--- a/mrbgems/mruby-struct/src/struct.c
+++ b/mrbgems/mruby-struct/src/struct.c
@@ -506,7 +506,6 @@ mrb_value
 mrb_struct_init_copy(mrb_state *mrb, mrb_value copy)
 {
   mrb_value s;
-  struct RArray *sv;
   int i, len;
 
   mrb_get_args(mrb, "o", &s);


### PR DESCRIPTION
Enviroment
OS : Mac OS X 10.8.2
Changes toolchain from gcc to clang.

<pre>build_config.rb
  toolchain :clang</pre>

Causes a warning when mruby is built.
<pre>
$ make
  ...
  CC    mrbgems/mruby-struct/src/struct.c -> build/host/mrbgems/mruby-struct/src/struct.o
  mrbgems/mruby-struct//src/struct.c:509:18: warning: unused variable 'sv' [-Wunused-variable]
  struct RArray *sv;
</pre>


Deletes unused variable 'struct RArray *sv'.

<pre>mrbgems/mruby-struct/src/struct.c
  struct RArray *sv
</pre>


Causes no warning when mruby is built.
