### PR TITLE
Typedef some object structures: mrb_obj, mrb_str, mrb_proc, mrb_env.

### DIFF
--- a/include/mruby/proc.h
+++ b/include/mruby/proc.h
@@ -13,14 +13,14 @@
 extern "C" {
 #endif
 
-struct REnv {
+typedef struct REnv {
   MRB_OBJECT_HEADER;
   mrb_value *stack;
   mrb_sym mid;
   int cioff;
-};
+} mrb_env;
 
-struct RProc {
+typedef struct RProc {
   MRB_OBJECT_HEADER;
   union {
     mrb_irep *irep;
@@ -28,7 +28,7 @@ struct RProc {
   } body;
   struct RClass *target_class;
   struct REnv *env;
-};
+} mrb_proc;
 
 /* aspec access */
 #define ARGS_GETREQ(a)          (((a) >> 19) & 0x1f)

--- a/include/mruby/string.h
+++ b/include/mruby/string.h
@@ -27,7 +27,7 @@ typedef struct mrb_shared_string {
   int len;
 } mrb_shared_string;
 
-struct RString {
+typedef struct RString {
   MRB_OBJECT_HEADER;
   int len;
   union {
@@ -35,7 +35,7 @@ struct RString {
     mrb_shared_string *shared;
   } aux;
   char *ptr;
-};
+} mrb_str;
 
 #define mrb_str_ptr(s)    ((struct RString*)((s).value.p))
 #define RSTRING(s)        ((struct RString*)((s).value.p))

--- a/include/mruby/value.h
+++ b/include/mruby/value.h
@@ -189,10 +189,10 @@ struct RBasic {
 
 #define mrb_basic(v)     ((struct RBasic*)((v).value.p))
 
-struct RObject {
+typedef struct RObject {
   MRB_OBJECT_HEADER;
   struct iv_tbl *iv;
-};
+} mrb_obj;
 
 #define mrb_obj_ptr(v)   ((struct RObject*)((v).value.p))
 #define mrb_immediate_p(x) (mrb_type(x) <= MRB_TT_MAIN)


### PR DESCRIPTION
It's for naming consistency and to avoid name conflits with parent applications.
Still struct RObject, struct RString, struct RProc, struct REnv for now to keep backward compatibility. They should treat as obsolete.

I kept struct RClass as is for now.
Modifying mrb_class causes errors since mrb_class is declared as a function. This is the reason why.
