### PR TITLE
Move Kernel#sprintf to mrbgem

### DIFF
--- a/build_config.rb
+++ b/build_config.rb
@@ -20,6 +20,9 @@ MRuby::Build.new do |conf|
   # Use standard Struct class
   conf.gem 'mrbgems/mruby-struct'
 
+  # Use standard Kernel#sprintf method
+  conf.gem 'mrbgems/mruby-sprintf'
+
   # Generate binaries
   # conf.bins = %w(mrbc mruby mirb)
   

--- a/include/mrbconf.h
+++ b/include/mrbconf.h
@@ -47,7 +47,6 @@
 //#define POOL_PAGE_SIZE 16000
 
 /* -DDISABLE_XXXX to drop following features */
-//#define DISABLE_SPRINTF	/* Kernel.sprintf method */
 //#define DISABLE_STDIO		/* use of stdio */
 
 /* -DENABLE_XXXX to enable following features */
@@ -83,9 +82,6 @@
 typedef short mrb_sym;
 
 /* define ENABLE_XXXX from DISABLE_XXX */
-#ifndef DISABLE_SPRINTF
-#define ENABLE_SPRINTF
-#endif
 #ifndef DISABLE_STDIO
 #define ENABLE_STDIO
 #endif

--- a/mrbgems/mruby-sprintf/mrbgem.rake
+++ b/mrbgems/mruby-sprintf/mrbgem.rake
@@ -1,0 +1,4 @@
+MRuby::Gem::Specification.new('mruby-sprintf') do |spec|
+  spec.license = 'MIT'
+  spec.authors = 'mruby developers'
+end

--- a/mrbgems/mruby-sprintf/src/kernel.c
+++ b/mrbgems/mruby-sprintf/src/kernel.c
@@ -1,0 +1,30 @@
+/*
+** kernel.c - Kernel module suppliment
+**
+** See Copyright Notice in mruby.h
+*/
+
+#include "mruby.h"
+
+mrb_value mrb_f_sprintf(mrb_state *mrb, mrb_value obj); /* in sprintf.c */
+
+void
+mrb_mruby_sprintf_gem_init(mrb_state* mrb)
+{
+  struct RClass *krn;
+
+  if (mrb->kernel_module == NULL) {
+    mrb->kernel_module = mrb_define_module(mrb, "Kernel"); /* Might be PARANOID. */
+  }
+  krn = mrb->kernel_module;
+
+  mrb_define_method(mrb, krn, "sprintf", mrb_f_sprintf, ARGS_ANY());
+  mrb_define_method(mrb, krn, "format",  mrb_f_sprintf, ARGS_ANY());
+}
+
+void
+mrb_mruby_sprintf_gem_final(mrb_state* mrb)
+{
+  /* nothing to do. */
+}
+

--- a/mrbgems/mruby-sprintf/src/sprintf.c
+++ b/mrbgems/mruby-sprintf/src/sprintf.c
@@ -6,8 +6,6 @@
 
 #include "mruby.h"
 
-#ifdef ENABLE_SPRINTF
-
 #include <stdio.h>
 #include <string.h>
 #include "mruby/string.h"
@@ -1091,5 +1089,3 @@ fmt_setup(char *buf, size_t size, int c, int flags, int width, int prec)
   *buf++ = c;
   *buf = '\0';
 }
-
-#endif	/* ENABLE_SPRINTF */

--- a/mrbgems/mruby-sprintf/test/sprintf.rb
+++ b/mrbgems/mruby-sprintf/test/sprintf.rb
@@ -1,0 +1,3 @@
+##
+# Kernel#sprintf Kernel#format Test
+

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -1108,11 +1108,6 @@ mrb_init_kernel(mrb_state *mrb)
   mrb_define_method(mrb, krn, "singleton_methods",          mrb_obj_singleton_methods_m,     ARGS_ANY());     /* 15.3.1.3.45 */
   mrb_define_method(mrb, krn, "to_s",                       mrb_any_to_s,                    ARGS_NONE());    /* 15.3.1.3.46 */
 
-#ifdef ENABLE_SPRINTF
-  mrb_define_method(mrb, krn, "sprintf",                    mrb_f_sprintf,                   ARGS_ANY());     /* in sprintf.c */
-  mrb_define_method(mrb, krn, "format",                     mrb_f_sprintf,                   ARGS_ANY());     /* in sprintf.c */
-#endif
-
   mrb_include_module(mrb, mrb->object_class, mrb->kernel_module);
   mrb_alias_method(mrb, mrb->module_class, mrb_intern(mrb, "dup"), mrb_intern(mrb, "clone"));
 }


### PR DESCRIPTION
It should be moved Kernel#sprintf and Kernel#format into mrbgem.
They are not used in mruby core itself.
And possibly they are too large to use on small bare-metals, as you know.
