### PR TITLE
Remove RB_GC_GUARD(x) macro.

### DIFF
--- a/include/mruby/string.h
+++ b/include/mruby/string.h
@@ -11,10 +11,6 @@
 extern "C" {
 #endif
 
-#ifndef RB_GC_GUARD
-#define RB_GC_GUARD(v) v
-#endif
-
 #define IS_EVSTR(p,e) ((p) < (e) && (*(p) == '$' || *(p) == '@' || *(p) == '{'))
 
 #define STR_BUF_MIN_SIZE 128

--- a/src/string.c
+++ b/src/string.c
@@ -1511,9 +1511,8 @@ mrb_value
 mrb_str_intern(mrb_state *mrb, mrb_value self)
 {
   mrb_sym id;
-  mrb_value str = RB_GC_GUARD(self);
 
-  id = mrb_intern_str(mrb, str);
+  id = mrb_intern_str(mrb, self);
   return mrb_symbol_value(id);
 
 }


### PR DESCRIPTION
See also mruby/mruby#948.
