### PR TITLE
Cut off mrb_irep_free from mrb_close

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -207,6 +207,7 @@ mrb_value mrb_str_new2(mrb_state *mrb, const char *p);
 
 mrb_state* mrb_open(void);
 mrb_state* mrb_open_allocf(mrb_allocf, void *ud);
+void mrb_irep_free(mrb_state*, int);
 void mrb_close(mrb_state*);
 int mrb_checkstack(mrb_state*,int);
 

--- a/src/state.c
+++ b/src/state.c
@@ -79,6 +79,18 @@ mrb_open(void)
   return mrb;
 }
 
+void
+mrb_irep_free(mrb_state *mrb, int n)
+{
+  if (!(mrb->irep[n]->flags & MRB_ISEQ_NO_FREE))
+    mrb_free(mrb, mrb->irep[n]->iseq);
+
+  mrb_free(mrb, mrb->irep[n]->pool);
+  mrb_free(mrb, mrb->irep[n]->syms);
+  mrb_free(mrb, mrb->irep[n]->lines);
+  mrb_free(mrb, mrb->irep[n]);
+}
+
 void mrb_free_symtbl(mrb_state *mrb);
 void mrb_free_heap(mrb_state *mrb);
 
@@ -94,12 +106,7 @@ mrb_close(mrb_state *mrb)
   mrb_free(mrb, mrb->stbase);
   mrb_free(mrb, mrb->cibase);
   for (i=0; i<mrb->irep_len; i++) {
-    if (!(mrb->irep[i]->flags & MRB_ISEQ_NO_FREE))
-      mrb_free(mrb, mrb->irep[i]->iseq);
-    mrb_free(mrb, mrb->irep[i]->pool);
-    mrb_free(mrb, mrb->irep[i]->syms);
-    mrb_free(mrb, mrb->irep[i]->lines);
-    mrb_free(mrb, mrb->irep[i]);
+    mrb_irep_free(mrb, i);
   }
   mrb_free(mrb, mrb->irep);
   mrb_free(mrb, mrb->rescue);


### PR DESCRIPTION
When using same mrb_state several times on a process, I need irep-clean-function like mrb_irep_free for now, for example mod_mruby. 
