### PR TITLE
Add String#dump method.

### DIFF
--- a/mrbgems/mruby-string-ext/src/string.c
+++ b/mrbgems/mruby-string-ext/src/string.c
@@ -21,7 +21,8 @@ mrb_mruby_string_ext_gem_init(mrb_state* mrb)
 {
   struct RClass * s = mrb->string_class;
 
-  mrb_define_method(mrb, s, "getbyte", mrb_str_getbyte, ARGS_REQ(1));
+  mrb_define_method(mrb, s, "dump",            mrb_str_dump,            ARGS_NONE());
+  mrb_define_method(mrb, s, "getbyte",         mrb_str_getbyte,         ARGS_REQ(1));
 }
 
 void

--- a/mrbgems/mruby-string-ext/test/string.rb
+++ b/mrbgems/mruby-string-ext/test/string.rb
@@ -13,3 +13,6 @@ assert('String#getbyte') do
   assert_equal bytes2[0], str2.getbyte(0)
 end
 
+assert('String#dump') do
+  "foo".dump == "\"foo\""
+end


### PR DESCRIPTION
Related on #877. String#dump is famous but not specified ISO Ruby, as you know.
