### PR TITLE
define and use print format macros for mrb_int

### DIFF
--- a/include/mrbconf.h
+++ b/include/mrbconf.h
@@ -71,12 +71,22 @@
    typedef int64_t mrb_int;
 #  define MRB_INT_MIN INT64_MIN
 #  define MRB_INT_MAX INT64_MAX
+#  define PRIdMRB_INT PRId64
+#  define PRIiMRB_INT PRIi64
+#  define PRIoMRB_INT PRIo64
+#  define PRIxMRB_INT PRIx64
+#  define PRIXMRB_INT PRIX64
 #  define str_to_mrb_int(buf) strtoll(buf, NULL, 10)
 # endif
 #else
   typedef int32_t mrb_int;
 # define MRB_INT_MIN INT32_MIN
 # define MRB_INT_MAX INT32_MAX
+# define PRIdMRB_INT PRId32
+# define PRIiMRB_INT PRIi32
+# define PRIoMRB_INT PRIo32
+# define PRIxMRB_INT PRIx32
+# define PRIXMRB_INT PRIX32
 # define str_to_mrb_int(buf) strtol(buf, NULL, 10)
 #endif
 typedef short mrb_sym;
@@ -105,7 +115,15 @@ typedef short mrb_sym;
 # define isinf(n) (!_finite(n) && !_isnan(n))
 # define strtoll _strtoi64
 # define PRId32 "I32d"
+# define PRIi32 "I32i"
+# define PRIo32 "I32o"
+# define PRIx32 "I32x"
+# define PRIX32 "I32X"
 # define PRId64 "I64d"
+# define PRIi64 "I64i"
+# define PRIo64 "I64o"
+# define PRIx64 "I64x"
+# define PRIX64 "I64X"
 #else
 # include <inttypes.h>
 #endif

--- a/mrbgems/mruby-numeric-ext/src/numeric_ext.c
+++ b/mrbgems/mruby-numeric-ext/src/numeric_ext.c
@@ -9,7 +9,7 @@ mrb_int_chr(mrb_state *mrb, mrb_value x)
 
   chr = mrb_fixnum(x);
   if (chr >= (1 << CHAR_BIT)) {
-    mrb_raisef(mrb, E_RANGE_ERROR, "%ld out of char range", chr);
+    mrb_raisef(mrb, E_RANGE_ERROR, "%" PRIdMRB_INT " out of char range", chr);
   }
   c = (char)chr;
 

--- a/mrbgems/mruby-struct/src/struct.c
+++ b/mrbgems/mruby-struct/src/struct.c
@@ -66,7 +66,8 @@ mrb_struct_members(mrb_state *mrb, mrb_value s)
   mrb_value members = mrb_struct_s_members(mrb, mrb_obj_value(mrb_obj_class(mrb, s)));
   if (!strcmp(mrb_class_name(mrb, mrb_obj_class(mrb, s)), "Struct")) {
     if (RSTRUCT_LEN(s) != RARRAY_LEN(members)) {
-      mrb_raisef(mrb, E_TYPE_ERROR, "struct size differs (%ld required %ld given)",
+      mrb_raisef(mrb, E_TYPE_ERROR,
+                 "struct size differs (%" PRIdMRB_INT " required %" PRIdMRB_INT " given)",
                  RARRAY_LEN(members), RSTRUCT_LEN(s));
     }
   }
@@ -577,10 +578,12 @@ mrb_struct_aref_n(mrb_state *mrb, mrb_value s, mrb_value idx)
   i = mrb_fixnum(idx);
   if (i < 0) i = RSTRUCT_LEN(s) + i;
   if (i < 0)
-      mrb_raisef(mrb, E_INDEX_ERROR, "offset %ld too small for struct(size:%ld)",
+      mrb_raisef(mrb, E_INDEX_ERROR,
+                 "offset %" PRIdMRB_INT " too small for struct(size:%" PRIdMRB_INT ")",
                  i, RSTRUCT_LEN(s));
   if (RSTRUCT_LEN(s) <= i)
-    mrb_raisef(mrb, E_INDEX_ERROR, "offset %ld too large for struct(size:%ld)",
+    mrb_raisef(mrb, E_INDEX_ERROR,
+               "offset %" PRIdMRB_INT " too large for struct(size:%" PRIdMRB_INT ")",
                i, RSTRUCT_LEN(s));
   return RSTRUCT_PTR(s)[i];
 }
@@ -603,7 +606,8 @@ mrb_struct_aset_id(mrb_state *mrb, mrb_value s, mrb_sym id, mrb_value val)
   members = mrb_struct_members(mrb, s);
   len = RARRAY_LEN(members);
   if (RSTRUCT_LEN(s) != len) {
-    mrb_raisef(mrb, E_TYPE_ERROR, "struct size differs (%ld required %ld given)",
+    mrb_raisef(mrb, E_TYPE_ERROR,
+               "struct size differs (%" PRIdMRB_INT " required %" PRIdMRB_INT " given)",
                len, RSTRUCT_LEN(s));
   }
   ptr = RSTRUCT_PTR(s);
@@ -656,11 +660,13 @@ mrb_struct_aset(mrb_state *mrb, mrb_value s)
   i = mrb_fixnum(idx);
   if (i < 0) i = RSTRUCT_LEN(s) + i;
   if (i < 0) {
-    mrb_raisef(mrb, E_INDEX_ERROR, "offset %ld too small for struct(size:%ld)",
+    mrb_raisef(mrb, E_INDEX_ERROR,
+               "offset %" PRIdMRB_INT " too small for struct(size:%" PRIdMRB_INT ")",
                i, RSTRUCT_LEN(s));
   }
   if (RSTRUCT_LEN(s) <= i) {
-    mrb_raisef(mrb, E_INDEX_ERROR, "offset %ld too large for struct(size:%ld)",
+    mrb_raisef(mrb, E_INDEX_ERROR,
+               "offset %" PRIdMRB_INT " too large for struct(size:%" PRIdMRB_INT ")",
                i, RSTRUCT_LEN(s));
   }
   return RSTRUCT_PTR(s)[i] = val;

--- a/src/array.c
+++ b/src/array.c
@@ -577,7 +577,7 @@ mrb_ary_set(mrb_state *mrb, mrb_value ary, mrb_int n, mrb_value val) /* rb_ary_s
   if (n < 0) {
     n += a->len;
     if (n < 0) {
-      mrb_raisef(mrb, E_INDEX_ERROR, "index %ld out of array", n - a->len);
+      mrb_raisef(mrb, E_INDEX_ERROR, "index %" PRIdMRB_INT " out of array", n - a->len);
     }
   }
   if (a->len <= (int)n) {


### PR DESCRIPTION
This is mainly for portability. For example: %ld can't be used to print a 64-bit mrb_int on WIN(32|64) because long is 32-bit wide.

We had MRB_INT_FORMAT but it's gone and I think it's better if such macros follow a naming convention (see [1]). Additionally I defined some macros for other formats (oct, hex). They're not used in mruby but they might be helpful for someone else.

[1] But there's an exception: I decided to suffix them with MRB_INT (PRIdMRB_INT) for clarity but only MRB would be fine too for me and it's also shorter. If you think MRB is clear enough, I'll change it.
