### PR TITLE
Remove bit fields.

### DIFF
--- a/include/mruby/compile.h
+++ b/include/mruby/compile.h
@@ -67,8 +67,8 @@ enum heredoc_type {
 /* heredoc structure */
 struct mrb_parser_heredoc_info {
   enum heredoc_type type;
-  int allow_indent:1;
-  int line_head:1;
+  int allow_indent;
+  int line_head;
   const char *term;
   int term_len;
   mrb_ast_node *doc;

--- a/tools/mruby/mruby.c
+++ b/tools/mruby/mruby.c
@@ -26,10 +26,10 @@ void mrb_show_copyright(mrb_state *);
 struct _args {
   FILE *rfp;
   char* cmdline;
-  int fname        : 1;
-  int mrbfile      : 1;
-  int check_syntax : 1;
-  int verbose      : 1;
+  int fname;
+  int mrbfile;
+  int check_syntax;
+  int verbose;
   int argc;
   char** argv;
 };


### PR DESCRIPTION
I can catch the intention in the code a little bit. But there are less merits using bit-files.
And more, It will cause undefined behavior to use bi-fields.

The targets using compile.h and/or mruby.c have probably rich RAMs.
I think there is no reason to save some bytes there.
