### PR TITLE
fix inspect method

### DIFF
--- a/src/variable.c
+++ b/src/variable.c
@@ -548,6 +548,7 @@ mrb_obj_iv_inspect(mrb_state *mrb, struct RObject *obj)
     mrb_value str = mrb_sprintf(mrb, "-<%s:%p", cn, (void*)obj);
 
     iv_foreach(mrb, t, inspect_i, &str);
+    mrb_str_cat(mrb, str, ">", 1);
     return str;
   }
   return mrb_any_to_s(mrb, mrb_obj_value(obj));


### PR DESCRIPTION
test code

``` ruby
class Hoge
  def initialize
    @hoge = "hoge"
  end
end

puts Hoge.new.inspect
```
- before

```
$ bin/mruby test.rb
#<Hoge:0x8ef0808 @hoge="hoge"
```
- after

```
$ bin/mruby test.rb
#<Hoge:0x82973c8 @hoge="hoge">
```
