### PR TITLE
Remove mrb_str_new2().

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -203,7 +203,6 @@ void *mrb_free(mrb_state*, void*);
 
 mrb_value mrb_str_new(mrb_state *mrb, const char *p, int len); /* mrb_str_new */
 mrb_value mrb_str_new_cstr(mrb_state*, const char*);
-mrb_value mrb_str_new2(mrb_state *mrb, const char *p);
 
 mrb_state* mrb_open(void);
 mrb_state* mrb_open_allocf(mrb_allocf, void *ud);

--- a/mrbgems/mruby-sprintf/src/sprintf.c
+++ b/mrbgems/mruby-sprintf/src/sprintf.c
@@ -110,7 +110,7 @@ mrb_fix2binstr(mrb_state *mrb, mrb_value x, int base)
     }
   }
 
-  return mrb_str_new2(mrb, b);
+  return mrb_str_new_cstr(mrb, b);
 }
 
 #define FNONE  0

--- a/mrbgems/mruby-struct/src/struct.c
+++ b/mrbgems/mruby-struct/src/struct.c
@@ -288,7 +288,7 @@ mrb_struct_define(mrb_state *mrb, const char *name, ...)
   char *mem;
 
   if (!name) nm = mrb_nil_value();
-  else nm = mrb_str_new2(mrb, name);
+  else nm = mrb_str_new_cstr(mrb, name);
   ary = mrb_ary_new(mrb);
 
   va_start(ar, name);

--- a/src/error.c
+++ b/src/error.c
@@ -89,7 +89,7 @@ exc_to_s(mrb_state *mrb, mrb_value exc)
 {
   mrb_value mesg = mrb_attr_get(mrb, exc, mrb_intern(mrb, "mesg"));
 
-  if (mrb_nil_p(mesg)) return mrb_str_new2(mrb, mrb_obj_classname(mrb, exc));
+  if (mrb_nil_p(mesg)) return mrb_str_new_cstr(mrb, mrb_obj_classname(mrb, exc));
   return mesg;
 }
 
@@ -140,7 +140,7 @@ exc_inspect(mrb_state *mrb, mrb_value exc)
     }
   }
   else {
-    str = mrb_str_new2(mrb, mrb_obj_classname(mrb, exc));
+    str = mrb_str_new_cstr(mrb, mrb_obj_classname(mrb, exc));
     if (!mrb_nil_p(mesg) && RSTRING_LEN(mesg) > 0) {
       mrb_str_cat2(mrb, str, ": ");
       mrb_str_append(mrb, str, mesg);
@@ -218,7 +218,7 @@ void
 mrb_raise(mrb_state *mrb, struct RClass *c, const char *msg)
 {
   mrb_value mesg;
-  mesg = mrb_str_new2(mrb, msg);
+  mesg = mrb_str_new_cstr(mrb, msg);
   mrb_exc_raise(mrb, mrb_exc_new3(mrb, c, mesg));
 }
 

--- a/src/string.c
+++ b/src/string.c
@@ -224,17 +224,6 @@ mrb_str_new(mrb_state *mrb, const char *p, int len)
   return mrb_obj_value(s);
 }
 
-mrb_value
-mrb_str_new2(mrb_state *mrb, const char *ptr)
-{
-  struct RString *s;
-  if (!ptr) {
-    mrb_raise(mrb, E_ARGUMENT_ERROR, "NULL pointer given");
-  }
-  s = str_new(mrb, ptr, strlen(ptr));
-  return mrb_obj_value(s);
-}
-
 /*
  *  call-seq: (Caution! NULL string)
  *     String.new(str="")   => new_str
@@ -246,11 +235,23 @@ mrb_value
 mrb_str_new_cstr(mrb_state *mrb, const char *p)
 {
   struct RString *s;
-  int len = strlen(p);
+  size_t len;
+
+  if (p) {
+    len = strlen(p);
+    if (len > MRB_INT_MAX) {
+      len = MRB_INT_MAX;
+    }
+  }
+  else {
+    len = 0;
+  }
 
   s = mrb_obj_alloc_string(mrb);
   s->ptr = (char *)mrb_malloc(mrb, len+1);
-  memcpy(s->ptr, p, len);
+  if (p) {
+    memcpy(s->ptr, p, len);
+  }
   s->ptr[len] = 0;
   s->len = len;
   s->aux.capa = len;


### PR DESCRIPTION
This patch will modify API set.

mrb_str_new2() is slightly rough as it throws an exception.
And it is similar to mrb_str_new_str().
And ... "new2" is not a good name... ,right? ;-)

So I suggest to use mrb_str_new_cstr() instead.
I applied some modification to mrb_str_new_cstr(). If it is given NULL pointer, it generates mrb_str that have zero length string.
