### PR TITLE
Define mrb_bool_t.

### DIFF
--- a/include/mrbconf.h
+++ b/include/mrbconf.h
@@ -110,8 +110,10 @@ typedef short mrb_sym;
 # define strtoll _strtoi64
 # define PRId32 "I32d"
 # define PRId64 "I64d"
+typedef unsigned int mrb_bool;
 #else
 # include <inttypes.h>
+typedef _Bool mrb_bool;
 #endif
 
 #ifdef ENABLE_STDIO

--- a/include/mruby.h
+++ b/include/mruby.h
@@ -121,9 +121,9 @@ typedef struct mrb_state {
   size_t gc_threshold;
   int gc_interval_ratio;
   int gc_step_ratio;
-  unsigned int gc_disabled:1;
-  unsigned int gc_full:1;
-  unsigned int is_generational_gc_mode:1;
+  mrb_bool gc_disabled:1;
+  mrb_bool gc_full:1;
+  mrb_bool is_generational_gc_mode:1;
   size_t majorgc_old_threshold;
   struct alloca_header *mems;
 

--- a/include/mruby/compile.h
+++ b/include/mruby/compile.h
@@ -21,9 +21,9 @@ typedef struct mrbc_context {
   int slen;
   char *filename;
   short lineno;
-  int capture_errors:1;
-  int dump_result:1;
-  int no_exec:1;
+  mrb_bool capture_errors:1;
+  mrb_bool dump_result:1;
+  mrb_bool no_exec:1;
 } mrbc_context;
 
 mrbc_context* mrbc_context_new(mrb_state *mrb);
@@ -67,8 +67,8 @@ enum heredoc_type {
 /* heredoc structure */
 struct mrb_parser_heredoc_info {
   enum heredoc_type type;
-  int allow_indent:1;
-  int line_head:1;
+  mrb_bool allow_indent:1;
+  mrb_bool line_head:1;
   const char *term;
   int term_len;
   mrb_ast_node *doc;
@@ -102,8 +102,8 @@ struct mrb_parser_state {
 
   mrb_ast_node *heredocs;	/* list of mrb_parser_heredoc_info* */
   mrb_ast_node *parsing_heredoc;
-  int heredoc_starts_nextline:1;
-  int heredoc_end_now:1;	/* for mirb */
+  mrb_bool heredoc_starts_nextline:1;
+  mrb_bool heredoc_end_now:1; /* for mirb */
 
   void *ylval;
 

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -49,7 +49,7 @@ typedef struct scope {
   int pc;
   int lastlabel;
   int ainfo:15;
-  int mscope:1;
+  mrb_bool mscope:1;
 
   struct loopinfo *loop;
   int ensure_level;

--- a/src/gc.c
+++ b/src/gc.c
@@ -197,7 +197,7 @@ struct heap_page {
   struct heap_page *next;
   struct heap_page *free_next;
   struct heap_page *free_prev;
-  unsigned int old:1;
+  mrb_bool old:1;
   RVALUE objects[MRB_HEAP_PAGE_SIZE];
 };
 

--- a/tools/mrbc/mrbc.c
+++ b/tools/mrbc/mrbc.c
@@ -19,8 +19,8 @@ struct _args {
   char *filename;
   char *initname;
   char *ext;
-  int check_syntax : 1;
-  int verbose      : 1;
+  mrb_bool check_syntax : 1;
+  mrb_bool verbose      : 1;
 };
 
 static void

--- a/tools/mruby/mruby.c
+++ b/tools/mruby/mruby.c
@@ -26,10 +26,10 @@ void mrb_show_copyright(mrb_state *);
 struct _args {
   FILE *rfp;
   char* cmdline;
-  int fname        : 1;
-  int mrbfile      : 1;
-  int check_syntax : 1;
-  int verbose      : 1;
+  mrb_bool fname        : 1;
+  mrb_bool mrbfile      : 1;
+  mrb_bool check_syntax : 1;
+  mrb_bool verbose      : 1;
   int argc;
   char** argv;
 };


### PR DESCRIPTION
It's for compatibility improvements.

It's hard to predict what value is stored on "signed int" members with 1bit bit-field. Their behaviors are completely runtime dependent.
And there are some unstable code like this in the mruby core.

I suggest to use new type mrb_boot_t.
It is typedef-ed to _Bool on C99. _Bool is well defined in C99 spec.
So low risks. And it except some optimization by compilers.

Meanwhile, as always, there is no _Bool on MSVC (sigh). So it is typedef-ed to "unsigned int".
You might think it is small fix. But it is safer than current code. And it may affords intensions of the author.
