### PR TITLE
Size limitation to mrb_str

### DIFF
--- a/include/mruby/string.h
+++ b/include/mruby/string.h
@@ -44,11 +44,11 @@ mrb_value mrb_str_literal(mrb_state*, mrb_value);
 void mrb_str_concat(mrb_state*, mrb_value, mrb_value);
 mrb_value mrb_str_plus(mrb_state*, mrb_value, mrb_value);
 mrb_value mrb_obj_as_string(mrb_state *mrb, mrb_value obj);
-mrb_value mrb_str_resize(mrb_state *mrb, mrb_value str, int len); /* mrb_str_resize */
+mrb_value mrb_str_resize(mrb_state *mrb, mrb_value str, mrb_int len); /* mrb_str_resize */
 mrb_value mrb_string_value(mrb_state *mrb, mrb_value *ptr); /* StringValue */
 mrb_value mrb_str_substr(mrb_state *mrb, mrb_value str, mrb_int beg, mrb_int len);
 mrb_value mrb_check_string_type(mrb_state *mrb, mrb_value str);
-mrb_value mrb_str_buf_new(mrb_state *mrb, int capa);
+mrb_value mrb_str_buf_new(mrb_state *mrb, mrb_int capa);
 mrb_value mrb_str_buf_cat(mrb_state *mrb, mrb_value str, const char *ptr, size_t len);
 
 char *mrb_string_value_cstr(mrb_state *mrb, mrb_value *ptr);
@@ -65,7 +65,7 @@ mrb_value mrb_str_buf_append(mrb_state *mrb, mrb_value str, mrb_value str2);
 mrb_value mrb_str_inspect(mrb_state *mrb, mrb_value str);
 int mrb_str_equal(mrb_state *mrb, mrb_value str1, mrb_value str2);
 mrb_value mrb_str_dump(mrb_state *mrb, mrb_value str);
-mrb_value mrb_str_cat(mrb_state *mrb, mrb_value str, const char *ptr, mrb_int len);
+mrb_value mrb_str_cat(mrb_state *mrb, mrb_value str, const char *ptr, size_t len);
 mrb_value mrb_str_append(mrb_state *mrb, mrb_value str, mrb_value str2);
 
 int mrb_str_cmp(mrb_state *mrb, mrb_value str1, mrb_value str2);


### PR DESCRIPTION
On some target architectures, the length of mrb_str should be limited.
This limitation is caused by SIZE_MAX and MRB_INT_MAX.
