### PR TITLE
Remove bit-fields. They doesn't reduce memory on major environments.

### DIFF
--- a/include/mruby/irep.h
+++ b/include/mruby/irep.h
@@ -12,10 +12,10 @@ extern "C" {
 #endif
 
 typedef struct mrb_irep {
-  int idx:16;
-  int nlocals:16;
-  int nregs:16;
-  int flags:8;
+  uint16_t idx;
+  uint16_t nlocals;
+  uint16_t nregs;
+  uint8_t flags;
 
   mrb_code *iseq;
   mrb_value *pool;


### PR DESCRIPTION
I tested code below on {arm-eabi,mips-elf,x86_64-darwin10}-gcc.
I got always (sizeof(struct mrb_irep) == sizeof(struct_irep2) == 8) on all environments.

I survey assemble code generated by gcc.
Generated substiture_mrb_irep() and substiture_mrb_irep2() are same.

The result is reasonable.
There have 16bit/8bit word register access operand on almost all 32bit CPUs.
So the compiler will generate packed structure if there is no alignment issue.
It can be regardless whether you use bit-fields or not.

In case the CPU required more than 4bytes as an alignment, smart compiler will
put members with paddings. This can be even if you use bit-fields.
Also it's possible you may get packed structures on such architectures.
As Your compiler have force-data-size-optimization options, possibly.
Then, you know, you will get more code size, low speed.

I think it is no proportionate merit to use bit-filelds there.
It's always better: keeping it simple.
Bit-fields is too complex. At least here.

```
#include <stdio.h>
#include <stdint.h>

  struct mrb_irep {
    int idx:16;
    int nlocals:16;
    int nregs:16;
    int flags:8;
  };


  struct mrb_irep2 {
    uint16_t idx;
    uint16_t nlocals;
    uint16_t nregs;
    uint8_t flags;
  };

int
main(void)
{
  printf("%d %d\n", sizeof(struct mrb_irep), sizeof(struct mrb_irep2));
}

void
substiture_mrb_irep(void)
{
  volatile struct mrb_irep a;

  a.idx = 10;
  a.nlocals = 20;
  a.nregs = 30;
  a.flags = 40;
}

void
substiture_mrb_irep2(void)
{
  volatile struct mrb_irep2 a;

  a.idx = 10;
  a.nlocals = 20;
  a.nregs = 30;
  a.flags = 40;
}
```
