### PR TITLE
display BasicObject information in mirb

### DIFF
--- a/tools/mirb/mirb.c
+++ b/tools/mirb/mirb.c
@@ -261,6 +261,9 @@ main(void)
 	else {
 	  /* no */
 	  printf(" => ");
+	  if (!mrb_respond_to(mrb,result,mrb_intern(mrb,"inspect"))){
+	    result = mrb_any_to_s(mrb,result);
+	  }
 	  p(mrb, result);
 	}
       }


### PR DESCRIPTION
I want to see BasicObject information in mirb like below.

> bo = BasicObject.new
>  => "#BasicObject:0x100806190"
