### PR TITLE
Fix a warning happens on MRB_INT64 enabled.

### DIFF
--- a/src/string.c
+++ b/src/string.c
@@ -2050,7 +2050,7 @@ mrb_cstr_to_inum(mrb_state *mrb, const char *str, int base, int badcheck)
   char *end;
   char sign = 1;
   int c;
-  unsigned int n;
+  unsigned long n;
   mrb_int val;
 
 #undef ISDIGIT


### PR DESCRIPTION
I tested on OSX 10.6.8 / gcc4.2.
The type of n should be unsigned long.
As it have the return value of strtoul().
