### PR TITLE
remove bit-shift operation.

### DIFF
--- a/src/codegen.c
+++ b/src/codegen.c
@@ -541,11 +541,11 @@ for_body(codegen_scope *s, node *tree)
   // generate loop variable
   n2 = tree->car;
   if (n2->car && !n2->car->cdr && !n2->cdr) {
-    genop(s, MKOP_Ax(OP_ENTER, 1<<18));
+    genop(s, MKOP_Ax(OP_ENTER, 0x40000));
     gen_assignment(s, n2->car->car, 1, NOVAL);
   }
   else {
-    genop(s, MKOP_Ax(OP_ENTER, 1<<18));
+    genop(s, MKOP_Ax(OP_ENTER, 0x40000));
     gen_vmassignment(s, n2, 1, VAL);
   }
   codegen(s, tree->cdr->cdr->car, VAL);

--- a/src/crc.c
+++ b/src/crc.c
@@ -13,7 +13,7 @@
 //        carry
 #define  CRC_16_CCITT       0x11021ul        //x^16+x^12+x^5+1
 #define  CRC_XOR_PATTERN    (CRC_16_CCITT << 8)
-#define  CRC_CARRY_BIT      (1 << 24)
+#define  CRC_CARRY_BIT      (0x01000000)
 
 uint16_t
 calc_crc_16_ccitt(unsigned char *src, int nbytes)

--- a/src/opcode.h
+++ b/src/opcode.h
@@ -7,7 +7,7 @@
 #ifndef OPCODE_H
 #define OPCODE_H
 
-#define MAXARG_Bx        ((1<<16)-1)
+#define MAXARG_Bx        (0xffff)
 #define MAXARG_sBx       (MAXARG_Bx>>1)         /* `sBx' is signed */
 
 /* instructions OP:A:B:C = 7:9:9:7 (32 bits) */

--- a/src/vm.c
+++ b/src/vm.c
@@ -45,7 +45,7 @@
 /* Maximum stack depth. Should be set lower on memory constrained systems.
 The value below allows about 60000 recursive calls in the simplest case. */
 #ifndef MRB_STACK_MAX
-#define MRB_STACK_MAX ((1<<18) - MRB_STACK_GROWTH)
+#define MRB_STACK_MAX (0x40000 - MRB_STACK_GROWTH)
 #endif
 
 #ifdef VM_DEBUG


### PR DESCRIPTION
on some environment such as avr-elf, 'sizeof(int)' returns 2.
in that case, this expression is ill-formed:

```
lval = (1 << 16) - 1;
```

because shifted value is larger than 16bit.
