### PR TITLE
Update Travis CI build to install gperf

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
 # no installation...
 
+install:
+ - sudo apt-get -q install gperf
+
 script: "./minirake all test"


### PR DESCRIPTION
I noticed that a build failed to validate because gperf wasn't found on the Travis box.
