### PR TITLE
Changed the RData type field to 'const'

### DIFF
--- a/include/mruby/data.h
+++ b/include/mruby/data.h
@@ -19,7 +19,7 @@ typedef struct mrb_data_type {
 struct RData {
   MRB_OBJECT_HEADER;
   struct iv_tbl *iv;
-  mrb_data_type *type;
+  const mrb_data_type *type;
   void *data;
 };
 


### PR DESCRIPTION
Within the mruby source code the RData's 'type' field is either initialized, or used in const manner.
IMHO changing the 'type' after it has been created might cause hard to track errors.

This change allows the following compact C++11 code (based on https://github.com/gaffo/mruby/) to work:

``` c
struct wrap_ClassName {
  ClassName * m_p = nullptr;
  static void free_wrap(mrb_state * mrb, void * ptr) {
    wrap_ClassName * p = (wrap_ClassName *)ptr;
    if (p && p->m_p) {
      delete p->m_p;
      p->m_p = nullptr;
    }
    mrb_free(mrb, ptr);
  }
  // The initalize method binding mrb -> c++ ctor
  static mrb_value initialize(mrb_state * mrb, mrb_value self) {
    // search the incomming value for a new binding struct
    wrap_ClassName * p = (wrap_ClassName *)mrb_get_datatype(mrb, self, &wrap_binding);
    // if it already has one, get rid of it
    if (p)
      free_wrap(mrb, p);
    // grab a new struct from the mrb managed memory pool
    p = (wrap_ClassName *)mrb_malloc(mrb, sizeof(wrap_ClassName));
    // new up our c++ class on this struct
    p->m_p = new ClassName;
    // set the outgoing value with the correct data pointers
    DATA_PTR(self) = p;        
    DATA_TYPE(self) = &wrap_binding;
    return self;
    }
    static constexpr mrb_data_type wrap_binding = { "ClassName", free_wrap };
};
```
