### PR TITLE
Make topenv() static inlined to avoid compiling error when using clang and -O0 mode

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -175,7 +175,7 @@ is_strict(mrb_state *mrb, struct REnv *e)
   return 0;
 }
 
-inline struct REnv*
+static inline struct REnv*
 top_env(mrb_state *mrb, struct RProc *proc)
 {
   struct REnv *e = proc->env;


### PR DESCRIPTION
Current code only marks top_env as inlined(not static).

If we compile mruby using clang with -O0 mode, the following error would occur:

```
Undefined symbols for architecture x86_64:
  "_top_env", referenced from:
      _mrb_run in libmruby_core.a(vm.o)
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
rake aborted!
```

Marking top_env as static inlined solves this problem.
