### PR TITLE
Make mrb_top_self return a real instance.

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -74,6 +74,7 @@ typedef struct mrb_state {
 
   mrb_value *stack;
   mrb_value *stbase, *stend;
+  mrb_value *top_self;
 
   mrb_callinfo *ci;
   mrb_callinfo *cibase, *ciend;
@@ -138,6 +139,7 @@ typedef struct mrb_state {
   struct RClass *eStandardError_class;
 
   void *ud; /* auxiliary data */
+
 } mrb_state;
 
 typedef mrb_value (*mrb_func_t)(mrb_state *mrb, mrb_value);
@@ -238,11 +240,11 @@ int mrb_gc_arena_save(mrb_state*);
 void mrb_gc_arena_restore(mrb_state*,int);
 void mrb_gc_mark(mrb_state*,struct RBasic*);
 #define mrb_gc_mark_value(mrb,val) do {\
-  if (mrb_type(val) >= MRB_TT_OBJECT) mrb_gc_mark((mrb), mrb_basic_ptr(val));\
+  if (mrb_type(val) >= MRB_TT_MAIN) mrb_gc_mark((mrb), mrb_basic_ptr(val));\
 } while (0)
 void mrb_field_write_barrier(mrb_state *, struct RBasic*, struct RBasic*);
 #define mrb_field_write_barrier_value(mrb, obj, val) do{\
-  if ((val.tt >= MRB_TT_OBJECT)) mrb_field_write_barrier((mrb), (obj), mrb_basic_ptr(val));\
+  if ((val.tt >= MRB_TT_MAIN)) mrb_field_write_barrier((mrb), (obj), mrb_basic_ptr(val));\
 } while (0)
 void mrb_write_barrier(mrb_state *, struct RBasic*);
 

--- a/src/gc.c
+++ b/src/gc.c
@@ -392,6 +392,7 @@ gc_mark_children(mrb_state *mrb, struct RBasic *obj)
     }
     /* fall through */
 
+  case MRB_TT_MAIN:
   case MRB_TT_OBJECT:
   case MRB_TT_DATA:
     mrb_gc_mark_iv(mrb, (struct RObject*)obj);
@@ -478,6 +479,7 @@ obj_free(mrb_state *mrb, struct RBasic *obj)
     /* cannot happen */
     return;
 
+  case MRB_TT_MAIN:
   case MRB_TT_OBJECT:
     mrb_gc_free_iv(mrb, (struct RObject*)obj);
     break;
@@ -618,6 +620,7 @@ gc_gray_mark(mrb_state *mrb, struct RBasic *obj)
     }
     break;
 
+  case MRB_TT_MAIN:
   case MRB_TT_OBJECT:
   case MRB_TT_DATA:
     children += mrb_gc_mark_iv_size(mrb, (struct RObject*)obj);

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -306,6 +306,7 @@ init_copy(mrb_state *mrb, mrb_value dest, mrb_value obj)
       case MRB_TT_SCLASS:
       case MRB_TT_HASH:
       case MRB_TT_DATA:
+      case MRB_TT_MAIN:
         mrb_iv_copy(mrb, dest, obj);
         break;
 

--- a/src/state.c
+++ b/src/state.c
@@ -7,6 +7,7 @@
 #include "mruby.h"
 #include "mruby/irep.h"
 #include "mruby/variable.h"
+#include "mruby/class.h"
 #include <stdlib.h>
 #include <string.h>
 
@@ -160,8 +161,11 @@ mrb_add_irep(mrb_state *mrb)
 mrb_value
 mrb_top_self(mrb_state *mrb)
 {
-  mrb_value v;
-
-  MRB_SET_VALUE(v, MRB_TT_MAIN, value.i, 0);
-  return v;
+  if(mrb->top_self == NULL)
+  {
+    mrb->top_self = (mrb_value *)mrb_calloc(mrb, 1, sizeof(mrb_value));
+    *(mrb->top_self) = mrb_class_new_instance(mrb, 0, NULL, mrb->object_class);
+    mrb->top_self->tt = MRB_TT_MAIN;
+  }
+  return *(mrb->top_self);
 }

--- a/src/variable.c
+++ b/src/variable.c
@@ -419,6 +419,7 @@ obj_iv_p(mrb_value obj)
     case MRB_TT_SCLASS:
     case MRB_TT_HASH:
     case MRB_TT_DATA:
+    case MRB_TT_MAIN:
       return TRUE;
     default:
       return FALSE;


### PR DESCRIPTION
This makes top self an instance variable. Calls to mrb_top_self return the same value for a given mrb_state. Adds the ability to add instance variables to top self. 
