### PR TITLE
mruby-sprintf should precede mruby-print

### DIFF
--- a/build_config.rb
+++ b/build_config.rb
@@ -11,6 +11,9 @@ MRuby::Build.new do |conf|
   # conf.gem :github => 'masuidrive/mrbgems-example', :branch => 'master'
   # conf.gem :git => 'git@github.com:masuidrive/mrbgems-example.git', :branch => 'master', :options => '-v'
 
+  # Use standard Kernel#sprintf method
+  conf.gem "#{root}/mrbgems/mruby-sprintf"
+
   # Use standard print/puts/p
   conf.gem "#{root}/mrbgems/mruby-print"
 
@@ -22,9 +25,6 @@ MRuby::Build.new do |conf|
 
   # Use standard Struct class
   conf.gem "#{root}/mrbgems/mruby-struct"
-
-  # Use standard Kernel#sprintf method
-  conf.gem "#{root}/mrbgems/mruby-sprintf"
 
   # Use extensional Enumerable module
   conf.gem "#{root}/mrbgems/mruby-enum-ext"


### PR DESCRIPTION
sprintf need to be defined before printf
