### PR TITLE
remove unused functions 'mrb_strerrno' and 'mrb_bug_errno'.

### DIFF
--- a/src/error.c
+++ b/src/error.c
@@ -291,31 +291,6 @@ mrb_bug(const char *fmt, ...)
   exit(EXIT_FAILURE);
 }
 
-static const char *
-mrb_strerrno(int err)
-{
-#define defined_error(name, num) if (err == num) return name;
-#define undefined_error(name)
-//#include "known_errors.inc"
-#undef defined_error
-#undef undefined_error
-    return NULL;
-}
-
-void
-mrb_bug_errno(const char *mesg, int errno_arg)
-{
-  if (errno_arg == 0)
-    mrb_bug("%s: errno == 0 (NOERROR)", mesg);
-  else {
-    const char *errno_str = mrb_strerrno(errno_arg);
-    if (errno_str)
-      mrb_bug("%s: %s (%s)", mesg, strerror(errno_arg), errno_str);
-    else
-      mrb_bug("%s: %s (%d)", mesg, strerror(errno_arg), errno_arg);
-  }
-}
-
 int
 sysexit_status(mrb_state *mrb, mrb_value err)
 {

--- a/src/error.h
+++ b/src/error.h
@@ -8,7 +8,6 @@
 #define MRUBY_ERROR_H
 
 void mrb_sys_fail(mrb_state *mrb, const char *mesg);
-void mrb_bug_errno(const char*, int);
 int sysexit_status(mrb_state *mrb, mrb_value err);
 mrb_value mrb_exc_new3(mrb_state *mrb, struct RClass* c, mrb_value str);
 mrb_value make_exception(mrb_state *mrb, int argc, mrb_value *argv, int isstr);


### PR DESCRIPTION
'strerror' is not supported on the freestanding environment ('strerror' is declared in 'string.h'. And 'string.h' is not provided for freestanding environment).
And 'mrb_bug_errno' is not called by any other code.
So 'mrb_strerrno' is called just only by 'mrb_bug_errno'.
