### PR TITLE
Add test for Random::srand

### DIFF
--- a/mrbgems/mruby-random/test/random.rb
+++ b/mrbgems/mruby-random/test/random.rb
@@ -15,6 +15,14 @@ assert("Kernel::srand") do
   r1 == r2
 end
 
+assert("Random::srand") do
+  Random.srand(345)
+  r1 = rand
+  srand(345)
+  r2 = Random.rand
+  r1 == r2
+end
+
 assert("fixnum") do
   rand(3).class == Fixnum
 end


### PR DESCRIPTION
Kernel.srand and Random.srand use a same pseudo-random number generator like CRuby.
