### PR TITLE
Test all bundled gems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 # no installation...
 
-before-script: ruby -pi -e 'gsub(/\s*#\s*conf.gem\s*"#\{root\}/, "conf.gem \"\#{root}")' build_config.rb
+before_script: ruby -pi -e 'gsub(/\s*#\s*conf.gem\s*"#\{root\}/, "conf.gem \"\#{root}")' build_config.rb
 script: "./minirake all test"


### PR DESCRIPTION
This is really quick hack. But required for keeping code quality.
This enables commented out gems on build_config.rb.

I hope it's added test build support to Rake system.
