### PR TITLE
Fix build error on VS2012 toolchain.

### DIFF
--- a/include/mruby/dump.h
+++ b/include/mruby/dump.h
@@ -67,7 +67,7 @@ struct rite_binary_header {
 // section header
 #define RITE_SECTION_HEADER \
   uint8_t section_identify[4]; \
-  uint8_t section_size[4];
+  uint8_t section_size[4]
 
 struct rite_section_header {
   RITE_SECTION_HEADER;

--- a/mrbgems/mruby-random/src/random.c
+++ b/mrbgems/mruby-random/src/random.c
@@ -183,10 +183,11 @@ static mrb_value mrb_random_init(mrb_state *mrb, mrb_value self)
 static mrb_value mrb_random_rand(mrb_state *mrb, mrb_value self)
 {
   mrb_value max;
+  mrb_value seed;
   mt_state *t = mrb_mt_get_context(mrb, self);
 
   max = get_opt(mrb);
-  mrb_value seed = mrb_iv_get(mrb, self, mrb_intern(mrb, INSTANCE_RAND_SEED_KEY));
+  seed = mrb_iv_get(mrb, self, mrb_intern(mrb, INSTANCE_RAND_SEED_KEY));
   if (mrb_nil_p(seed)) {
     mrb_random_mt_srand(mrb, t, mrb_nil_value());
   }
@@ -198,11 +199,12 @@ static mrb_value mrb_random_rand(mrb_state *mrb, mrb_value self)
 static mrb_value mrb_random_srand(mrb_state *mrb, mrb_value self)
 {
   mrb_value seed;
+  mrb_value old_seed;
   mt_state *t = mrb_mt_get_context(mrb, self);
 
   seed = get_opt(mrb);
   seed = mrb_random_mt_srand(mrb, t, seed);
-  mrb_value old_seed = mrb_iv_get(mrb, self, mrb_intern(mrb, INSTANCE_RAND_SEED_KEY));
+  old_seed = mrb_iv_get(mrb, self, mrb_intern(mrb, INSTANCE_RAND_SEED_KEY));
   mrb_iv_set(mrb, self, mrb_intern(mrb, INSTANCE_RAND_SEED_KEY), seed);
   mrb_iv_set(mrb, self, mrb_intern(mrb, MT_STATE_KEY),
     mrb_obj_value(Data_Wrap_Struct(mrb, mrb->object_class, &mt_state_type, (void*) t)));


### PR DESCRIPTION
A local variables define beginning of a scope block.
VS2012 unacceptable ";;" in struct definition.
