### PR TITLE
LEGAL File Generator for Builds

### DIFF
--- a/tasks/mrbgems.rake
+++ b/tasks/mrbgems.rake
@@ -40,4 +40,49 @@ MRuby.each_target do
       end
     end
   end
+
+  # legal documents
+  self.libmruby << "#{build_dir}/LEGAL"
+  file "#{build_dir}/LEGAL" => [MRUBY_CONFIG] do |t|
+    open(t.name, 'w+') do |f|
+     f.puts <<LEGAL
+Copyright (c) #{Time.now.year} mruby developers
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+LEGAL
+
+      if enable_gems?
+        f.puts <<GEMS_LEGAL
+
+Additional Licenses
+
+Due to the reason that you choosed additional mruby packages (GEMS),
+please check the following additional licenses too:
+GEMS_LEGAL
+ 
+        gems.map do |g|
+          f.puts
+          f.puts "GEM: #{g.name}"
+          f.puts "Copyright (c) #{Time.now.year} #{g.authors}"
+          f.puts "License: #{g.licenses}"
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Due to the reason that a mruby user will probably separate the build directory from the source I propose with this change to generate an additional LEGAL with every build for every target, which is specifying which packages are used and under which license they are. A mruby user can then deploy the binary or library directly together with this LEGAL file. Due to the reason that I'm not a lawyer this is of course only my non-professional understanding of the legal responsibilities of a user but I guess it is much better as the current state which generates a binary without a clear information what is contained inside of it. 
