### PR TITLE
Add "-std=c99" to gcc. It is for portability.

### DIFF
--- a/tasks/toolchains/gcc.rake
+++ b/tasks/toolchains/gcc.rake
@@ -1,7 +1,7 @@
 MRuby::Toolchain.new(:gcc) do |conf|
   [conf.cc, conf.cxx, conf.objc, conf.asm].each do |cc|
     cc.command = ENV['CC'] || 'gcc'
-    cc.flags = [ENV['CFLAGS'] || %w(-g -O3 -Wall -Werror-implicit-function-declaration)]
+    cc.flags = [ENV['CFLAGS'] || %w(-std=c99 -g -O3 -Wall -Werror-implicit-function-declaration)]
     cc.include_paths = ["#{MRUBY_ROOT}/include"]
     cc.defines = %w(DISABLE_GEMS)
     cc.option_include_path = '-I%s'


### PR DESCRIPTION
I didn't add -W and/or -pedantic. They are too severe for the current mruby.
