### PR TITLE
Remove API mrb_string_value(). 

### DIFF
--- a/include/mruby/string.h
+++ b/include/mruby/string.h
@@ -46,7 +46,6 @@ mrb_value mrb_str_plus(mrb_state*, mrb_value, mrb_value);
 mrb_value mrb_ptr_to_str(mrb_state *, void *);
 mrb_value mrb_obj_as_string(mrb_state *mrb, mrb_value obj);
 mrb_value mrb_str_resize(mrb_state *mrb, mrb_value str, int len); /* mrb_str_resize */
-mrb_value mrb_string_value(mrb_state *mrb, mrb_value *ptr); /* StringValue */
 mrb_value mrb_str_substr(mrb_state *mrb, mrb_value str, mrb_int beg, mrb_int len);
 mrb_value mrb_check_string_type(mrb_state *mrb, mrb_value str);
 mrb_value mrb_str_buf_new(mrb_state *mrb, int capa);

--- a/mrbgems/mruby-sprintf/src/sprintf.c
+++ b/mrbgems/mruby-sprintf/src/sprintf.c
@@ -528,7 +528,7 @@ mrb_str_format(mrb_state *mrb, int argc, const mrb_value *argv, mrb_value fmt)
 
   ++argc;
   --argv;
-  mrb_string_value(mrb, &fmt);
+  fmt = mrb_str_to_str(mrb, fmt);
   p = RSTRING_PTR(fmt);
   end = p + RSTRING_LEN(fmt);
   blen = 0;

--- a/src/dump.c
+++ b/src/dump.c
@@ -90,7 +90,7 @@ get_pool_block_size(mrb_state *mrb, mrb_irep *irep)
       break;
 
     case MRB_TT_STRING:
-      str = mrb_string_value(mrb, &irep->pool[pool_no]);
+      str = mrb_str_to_str(mrb, irep->pool[pool_no]);
       size += RSTRING_LEN(str);
       break;
 

--- a/src/error.c
+++ b/src/error.c
@@ -27,7 +27,7 @@ mrb_exc_new(mrb_state *mrb, struct RClass *c, const char *ptr, long len)
 mrb_value
 mrb_exc_new3(mrb_state *mrb, struct RClass* c, mrb_value str)
 {
-  mrb_string_value(mrb, &str);
+  str = mrb_str_to_str(mrb, str);
   return mrb_funcall(mrb, mrb_obj_value(c), "new", 1, str);
 }
 

--- a/src/string.c
+++ b/src/string.c
@@ -616,21 +616,10 @@ mrb_str_to_str(mrb_state *mrb, mrb_value str)
   return str;
 }
 
-mrb_value
-mrb_string_value(mrb_state *mrb, mrb_value *ptr)
-{
-  mrb_value s = *ptr;
-  if (!mrb_string_p(s)) {
-    s = mrb_str_to_str(mrb, s);
-    *ptr = s;
-  }
-  return s;
-}
-
 char *
 mrb_string_value_ptr(mrb_state *mrb, mrb_value ptr)
 {
-    mrb_value str = mrb_string_value(mrb, &ptr);
+    mrb_value str = mrb_str_to_str(mrb, ptr);
     return RSTRING_PTR(str);
 }
 /* 15.2.10.5.5  */
@@ -1316,7 +1305,7 @@ mrb_str_include(mrb_state *mrb, mrb_value self)
     include_p = memchr(RSTRING_PTR(self), mrb_fixnum(str2), RSTRING_LEN(self));
   }
   else {
-    mrb_string_value(mrb, &str2);
+    str2 = mrb_str_to_str(mrb, str2);
     i = mrb_str_index(mrb, self, str2, 0);
 
     include_p = (i != -1);
@@ -2213,7 +2202,7 @@ mrb_str_to_inum(mrb_state *mrb, mrb_value str, int base, int badcheck)
   char *s;
   int len;
 
-  mrb_string_value(mrb, &str);
+  str = mrb_str_to_str(mrb, str);
   if (badcheck) {
     s = mrb_string_value_cstr(mrb, &str);
   }
@@ -2345,7 +2334,7 @@ mrb_str_to_dbl(mrb_state *mrb, mrb_value str, int badcheck)
   char *s;
   int len;
 
-  mrb_string_value(mrb, &str);
+  str = mrb_str_to_str(mrb, str);
   s = RSTRING_PTR(str);
   len = RSTRING_LEN(str);
   if (s) {
@@ -2578,7 +2567,7 @@ mrb_str_cat_cstr(mrb_state *mrb, mrb_value str, const char *ptr)
 mrb_value
 mrb_str_append(mrb_state *mrb, mrb_value str, mrb_value str2)
 {
-  mrb_string_value(mrb, &str2);
+  str2 = mrb_str_to_str(mrb, str2);
   return mrb_str_buf_append(mrb, str, str2);
 }
 


### PR DESCRIPTION
There have mrb_str_to_str() in the core. And mrb_string_value() is no merit to keep using.
