### PR TITLE
Only use log if it exists

### DIFF
--- a/tasks/mruby_build_commands.rake
+++ b/tasks/mruby_build_commands.rake
@@ -253,7 +253,7 @@ module MRuby
       IO.popen(commandline, 'r+') do |io|
         [infiles].flatten.each do |f|
           _pp "MRBC", f.relative_path, nil, :indent => 2
-          log "#{commandline} ## #{f}"
+          log "#{commandline} ## #{f}" if respond_to? :log
           io.write IO.read(f)
         end
         io.close_write


### PR DESCRIPTION
minirake has log but rake doesn't. This should fix the issue introduced in #1105. 
