### PR TITLE
Add null char terminate to each symbol name.

### DIFF
--- a/src/dump.c
+++ b/src/dump.c
@@ -166,7 +166,7 @@ get_syms_block_size(mrb_state *mrb, mrb_irep *irep)
     size += sizeof(uint16_t); /* snl(n) */
     if (irep->syms[sym_no] != 0) {
       mrb_sym2name_len(mrb, irep->syms[sym_no], &len);
-      size += len; /* sn(n) */
+      size += len + 1; /* sn(n) + null char */
     }
   }
 
@@ -194,6 +194,7 @@ write_syms_block(mrb_state *mrb, mrb_irep *irep, uint8_t *buf)
       cur += uint16_to_bin((uint16_t)len, cur); /* length of symbol name */
       memcpy(cur, name, len); /* symbol name */
       cur += (uint16_t)len;
+      *cur++ = '\0';
     }
     else {
       cur += uint16_to_bin(MRB_DUMP_NULL_SYM_LEN, cur); /* length of symbol name */

--- a/src/load.c
+++ b/src/load.c
@@ -131,7 +131,7 @@ read_rite_irep_record(mrb_state *mrb, const uint8_t *bin, uint32_t *len)
       }
 
       irep->syms[i] = mrb_intern2(mrb, (char *)src, snl);
-      src += snl;
+      src += snl + 1;
 
       mrb_gc_arena_restore(mrb, ai);
     }


### PR DESCRIPTION
I want to hear @masuidrive's comments whether it is acceptable or not.

In case IREP array is on .rodata (typically on ROM), we may reduce malloc/free on symbol hashes.
In such case, it is required each symbol name in the table is null terminated.

This patch is not only  for ROMed targets but some targets that have tiny RAM. Like uCLinux based.
