### PR TITLE
Modified build dependency to exclude 'LEGAL' from libmruby archive.

### DIFF
--- a/tasks/mrbgems.rake
+++ b/tasks/mrbgems.rake
@@ -8,7 +8,7 @@ MRuby.each_target do
     
     # loader all gems
     self.libmruby << objfile("#{build_dir}/mrbgems/gem_init")
-    file objfile("#{build_dir}/mrbgems/gem_init") => "#{build_dir}/mrbgems/gem_init.c"
+    file objfile("#{build_dir}/mrbgems/gem_init") => ["#{build_dir}/mrbgems/gem_init.c", "#{build_dir}/LEGAL"]
     file "#{build_dir}/mrbgems/gem_init.c" => [MRUBY_CONFIG] do |t|
       FileUtils.mkdir_p "#{build_dir}/mrbgems"
       open(t.name, 'w') do |f|
@@ -42,7 +42,6 @@ MRuby.each_target do
   end
 
   # legal documents
-  self.libmruby << "#{build_dir}/LEGAL"
   file "#{build_dir}/LEGAL" => [MRUBY_CONFIG] do |t|
     open(t.name, 'w+') do |f|
      f.puts <<LEGAL


### PR DESCRIPTION
On #1089 'LEGAL File Generator for Builds', 
An auto generated file 'LEGAL' was contained in the archive.
Since modified build dependency to exclude 'LEGAL' from libmruby archive.
