### PR TITLE
Adjust ci->nregs to prevent heap corruption

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -346,7 +346,7 @@ mrb_funcall_with_block(mrb_state *mrb, mrb_value self, mrb_sym mid, int argc, mr
       ci->nregs = argc + 2;
     }
     else {
-      ci->nregs = p->body.irep->nregs + 2;
+      ci->nregs = p->body.irep->nregs + n;
     }
     ci->acc = -1;
     mrb->stack = mrb->stack + n;


### PR DESCRIPTION
``` bash
bin/mruby -e "fib = Hash.new{ |h,k| h[k] = k < 2 ? k : h[k-1] + h[k-2] }; \
puts fib[18]" 
*** glibc detected *** bin/mruby: realloc(): invalid next size: 0x081a3b28 ***
```

p->body.irep->nregs is 0 (not sure why) so stack is not extended. But argc is 2, so stack should have been extended by 4. 

If this fix is OK, there is another issue of a stack overflow caused by running this code with n > 6000.
