### PR TITLE
Change to return the exception object when an exception occurred in mrb_funcall

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -302,7 +302,7 @@ mrb_funcall_with_block(mrb_state *mrb, mrb_value self, mrb_sym mid, int argc, mr
         cipop(mrb);
       }
       mrb->jmp = 0;
-      val = mrb_nil_value();
+      val = mrb_obj_value(mrb->exc);
     }
     else {
       mrb->jmp = &c_jmp;


### PR DESCRIPTION
When a Exception occurred, mrb_run returned the exception object, but mrb_funcall returned nil object.
I think that mrb_funcall shold return the exception object.
