### PR TITLE
Fix for issue introduced in #1132

### DIFF
--- a/mrblib/error.rb
+++ b/mrblib/error.rb
@@ -38,8 +38,6 @@ end
 
 # ISO 15.2.31
 class NameError < StandardError
-  attr_accessor :name
-
   def new(message="NameError", name=nil)
     initialize(message, name)
   end
@@ -47,6 +45,14 @@ class NameError < StandardError
   def initialize(message=nil, name=nil)
     @name = name
     super(message)
+  end
+
+  def name
+    @name
+  end
+
+  def name=(str)
+    @name = str
   end
 end
 


### PR DESCRIPTION
This removes the use of attr_accessor, it may not be available. It looks like the ordering of the prerequisites can be different between systems and that sometimes causes class.rb to be introduced into the irep after attr_accessor is needed.
