### PR TITLE
Define isascii for C99

### DIFF
--- a/src/parse.y
+++ b/src/parse.y
@@ -38,6 +38,10 @@ static void yywarn(parser_state *p, const char *s);
 static void yywarning(parser_state *p, const char *s);
 static void backref_error(parser_state *p, node *n);
 
+#ifndef isascii
+#define isascii(c) (((c) & ~0x7f) == 0)
+#endif
+
 #define identchar(c) (isalnum(c) || (c) == '_' || !isascii(c))
 
 typedef unsigned int stack_type;


### PR DESCRIPTION
isascii() is a BSD extension and is also an SVr4 extension.
