### PR TITLE
stdint header seems required on osx for uint8_t

### DIFF
--- a/src/dump.c
+++ b/src/dump.c
@@ -512,6 +512,7 @@ mrb_dump_irep_cfunc(mrb_state *mrb, size_t start_index, int debug_info, FILE *fp
 
   result = mrb_dump_irep(mrb, start_index, debug_info, &bin, &bin_size);
   if (result == MRB_DUMP_OK) {
+    fprintf(fp, "#include <stdint.h>\n"); // for uint8_t under at least Darwin
     fprintf(fp, "const uint8_t %s[] = {", initname);
     while (bin_idx < bin_size) {
       if (bin_idx % 16 == 0 ) fputs("\n", fp);


### PR DESCRIPTION
stdint.h header is required at least on OS X to use uint8_t, the error I got was when running rake test with an external "gem" included (in this case it was mruby-cfunc).

With this patch everything works fine.
