### PR TITLE
Add "test runner" support for cross builds.

### DIFF
--- a/build_config.rb
+++ b/build_config.rb
@@ -114,4 +114,7 @@ end
 #   conf.build_mrbtest_lib_only
 #   
 #   conf.gem 'examples/mrbgems/c_and_ruby_extension_example'
+#
+#   conf.test_runner.command = 'env'
+#
 # end

--- a/tasks/mruby_build.rake
+++ b/tasks/mruby_build.rake
@@ -194,10 +194,21 @@ module MRuby
   end # Build
 
   class CrossBuild < Build
+    attr_block %w(test_runner)
+
+    def initialize(name, &block)
+	@test_runner = Command::CrossTestRunner.new(self)
+	super
+    end
+
     def run_test
       mrbtest = exefile("#{build_dir}/test/mrbtest")
-      puts "You should run #{mrbtest} on target device."
-      puts 
+      if (@test_runner.command == nil)
+        puts "You should run #{mrbtest} on target device."
+        puts
+      else
+        @test_runner.run(mrbtest)
+      end
     end
   end # CrossBuild
 end # MRuby

--- a/tasks/mruby_build_commands.rake
+++ b/tasks/mruby_build_commands.rake
@@ -259,4 +259,24 @@ module MRuby
       end
     end
   end
+
+  class Command::CrossTestRunner < Command
+    attr_accessor :runner_options
+    attr_accessor :verbose_flag
+    attr_accessor :flags
+
+    def initialize(build)
+      super
+      @command = nil
+      @runner_options = '%{flags} %{infile}'
+      @verbose_flag = ''
+      @flags = []
+    end
+
+    def run(testbinfile)
+      puts "TEST for " + @build.name
+      _run runner_options, { :flags => [flags, verbose_flag].flatten.join(' '), :infile => testbinfile }
+    end
+  end
+
 end


### PR DESCRIPTION
In some cases, we can automated test on build time by execute a kind of "test runner" tools.
"test runner" means target simulator like QEmu, GDB sim, and so on.
Also "test runner" might be debug agents for real targets.

If you do not setup test_runner, Rake will work same as before.
