### PR TITLE
Fix mirb to use readline

### DIFF
--- a/tools/mirb/mirb.c
+++ b/tools/mirb/mirb.c
@@ -273,7 +273,7 @@ main(int argc, char **argv)
       printf("\n");
       break;
     }
-    strncat(last_code_line, line, sizeof(last_code_line)-1);
+    strncpy(last_code_line, line, sizeof(last_code_line)-1);
     add_history(line);
     free(line);
 #endif


### PR DESCRIPTION
Current mirb can't interpret a code block across multiple lines if ENABLE_READLINE macro was defined.

current 

```
> def foo
*   "foo"
line 2: syntax error, unexpected tSTRING_BEG, expecting ';' or '\n'
>
```

fixed

```
> def foo
*   "foo"
* end
 => nil
> foo
 => "foo"
>
```
