### PR TITLE
Fixed irep index overflows, when defining new closure.

### DIFF
--- a/include/mruby/irep.h
+++ b/include/mruby/irep.h
@@ -12,7 +12,7 @@ extern "C" {
 #endif
 
 typedef struct mrb_irep {
-  uint16_t idx;
+  uint32_t idx;
   uint16_t nlocals;
   uint16_t nregs;
   uint8_t flags;


### PR DESCRIPTION
Issue #1137.
In the present implementation, when calling mrb_load_string continuously, irep is not released.
Therefore, a 16-bit index was overflowing.
