### PR TITLE
Add "Visual Studio 2010" subsection to "Toolchains" section of doc/compile/README.md

### DIFF
--- a/doc/compile/README.md
+++ b/doc/compile/README.md
@@ -58,6 +58,12 @@ GCC toolchain.
 
 	toolchain :clang
 
+#### Visual Studio 2010
+
+Toolchain configuration for Visual Studio 2010 on Windows.
+
+	toolchain :vs2010
+
 #### Visual Studio 2012
 
 Toolchain configuration for Visual Studio 2012 on Windows.


### PR DESCRIPTION
To follow h2so5/add-vs2010-toolchain
