### PR TITLE
Update doc/compile/README.md about mruby and mirb

### DIFF
--- a/doc/compile/README.md
+++ b/doc/compile/README.md
@@ -77,13 +77,14 @@ in ```ANDROID_STANDALONE_TOOLCHAIN```.
 
 It is possible to select which tools should be compiled during the compilation
 process. The following tools can be selected:
-* mrbc (mruby compiler)
 * mruby (mruby interpreter)
 * mirb (mruby interactive shell)
 
-To select all define an array in ```conf.bins```:
+To select them declare conf.gem as follows:
 
-	conf.bins = %(mrbc mruby mirb)
+	conf.gem "#{root}/mrbgems/mruby-bin-mruby"
+
+	conf.gem "#{root}/mrbgems/mruby-bin-mirb"
 
 ### File Separator
 
@@ -237,9 +238,9 @@ linking with *build/host/lib/libmruby_core.a*
 under *mrblib* with ```build/host/bin/mrbc```
 * compile *build/host/mrblib/mrblib.c* to *build/host/mrblib/mrblib.o* 
 * create *build/host/lib/libmruby.a* out of all object files (C and Ruby)
-* create ```build/host/bin/mruby``` by compiling *tools/mruby/mruby.c* and
+* create ```build/host/bin/mruby``` by compiling *mrbgems/mruby-bin-mruby/tools/mruby/mruby.c* and
 linking with *build/host/lib/libmruby.a*
-* create ```build/host/bin/mirb``` by compiling *tools/mirb/mirb.c* and
+* create ```build/host/bin/mirb``` by compiling *mrbgems/mruby-bin-mirb/tools/mirb/mirb.c* and
 linking with *build/host/lib/libmruby.a*
 
 ```
@@ -311,9 +312,9 @@ result will be stored in *build/i386/src/y.tab.c*)
 under *mrblib* with the native ```build/host/bin/mrbc```
 * cross-compile *build/host/mrblib/mrblib.c* to *build/host/mrblib/mrblib.o*
 * create *build/i386/lib/libmruby.a* out of all object files (C and Ruby)
-* create ```build/i386/bin/mruby``` by cross-compiling *tools/mruby/mruby.c* and
+* create ```build/i386/bin/mruby``` by cross-compiling *mrbgems/mruby-bin-mruby/tools/mruby/mruby.c* and
 linking with *build/i386/lib/libmruby.a*
-* create ```build/i386/bin/mirb``` by cross-compiling *tools/mirb/mirb.c* and
+* create ```build/i386/bin/mirb``` by cross-compiling *mrbgems/mruby-bin-mirb/tools/mirb/mirb.c* and
 linking with *build/i386/lib/libmruby.a*
 * create *build/i386/lib/libmruby_core.a* out of all object files (C only)
 * create ```build/i386/bin/mrbc``` by cross-compiling *tools/mrbc/mrbc.c* and


### PR DESCRIPTION
The README.md does not describe actual situation after commit 9d8143f9302f86348df5d0a75ebbb433c8330354 (i.e. moving tools/{mruby,mirb} to mrbgems/mruby-tool-{mruby,mirb})
