### PR TITLE
Move macros for aspec access to include/mrbgem/proc.h

### DIFF
--- a/include/mrbgem/proc.h
+++ b/include/mrbgem/proc.h
@@ -1,0 +1,14 @@
+
+#ifndef MRUBYGEM_PROC_H_
+#define MRUBYGEM_PROC_H_
+
+/* aspec access */
+#define ARGS_GETREQ(a)          (((a) >> 19) & 0x1f)
+#define ARGS_GETOPT(a)          (((a) >> 14) & 0x1f)
+#define ARGS_GETREST(a)         ((a) & (1<<13))
+#define ARGS_GETPOST(a)         (((a) >> 8) & 0x1f)
+#define ARGS_GETKEY(a)          (((a) >> 3) & 0x1f))
+#define ARGS_GETKDICT(a)        ((a) & (1<<2))
+#define ARGS_GETBLOCK(a)        ((a) & (1<<1))
+
+#endif

--- a/include/mruby/proc.h
+++ b/include/mruby/proc.h
@@ -30,15 +30,6 @@ struct RProc {
   struct REnv *env;
 };
 
-/* aspec access */
-#define ARGS_GETREQ(a)          (((a) >> 19) & 0x1f)
-#define ARGS_GETOPT(a)          (((a) >> 14) & 0x1f)
-#define ARGS_GETREST(a)         ((a) & (1<<13))
-#define ARGS_GETPOST(a)         (((a) >> 8) & 0x1f)
-#define ARGS_GETKEY(a)          (((a) >> 3) & 0x1f))
-#define ARGS_GETKDICT(a)        ((a) & (1<<2))
-#define ARGS_GETBLOCK(a)        ((a) & (1<<1))
-
 #define MRB_PROC_CFUNC 128
 #define MRB_PROC_CFUNC_P(p) ((p)->flags & MRB_PROC_CFUNC)
 #define MRB_PROC_STRICT 256

--- a/src/proc.c
+++ b/src/proc.c
@@ -7,6 +7,7 @@
 #include "mruby.h"
 #include "mruby/class.h"
 #include "mruby/proc.h"
+#include "mrbgem/proc.h"
 #include "opcode.h"
 
 static mrb_code call_iseq[] = {


### PR DESCRIPTION
This is a counter offer to #1193.

I agree some mrbgems want macros that are used in the core.
But mruby is "eMbeddable". It means we should care about applications that bind libmruby.a.
Especially include files. It may be caused serious bugs by macros.

My suggestion is separate include directories like below.
- Don't export (use locally).
  - src/, mrbgems/*/src/
- Can be used by the core and mrbgems.
  - include/mrbgem/
- May be used by applications. Of course, the core and mrbgems can use them.
  - include/, include/mruby/
