### PR TITLE
Cleanup marcos for arg

### DIFF
--- a/include/mruby/proc.h
+++ b/include/mruby/proc.h
@@ -31,13 +31,13 @@ struct RProc {
 };
 
 /* aspec access */
-#define MRB_ARGS_REQ(a)          (((a) >> 19) & 0x1f)
-#define MRB_ARGS_OPT(a)          (((a) >> 14) & 0x1f)
-#define MRB_ARGS_REST(a)         ((a) & (1<<13))
-#define MRB_ARGS_POST(a)         (((a) >> 8) & 0x1f)
-#define MRB_ARGS_KEY(a)          (((a) >> 3) & 0x1f)
-#define MRB_ARGS_KDICT(a)        ((a) & (1<<2))
-#define MRB_ARGS_BLOCK(a)        ((a) & (1<<1))
+#define MRB_ARGS_REQ(a)          (((a) >> 18) & 0x1f)
+#define MRB_ARGS_OPT(a)          (((a) >> 13) & 0x1f)
+#define MRB_ARGS_REST(a)         ((a) & (1<<12))
+#define MRB_ARGS_POST(a)         (((a) >> 7) & 0x1f)
+#define MRB_ARGS_KEY(a)          (((a) >> 2) & 0x1f)
+#define MRB_ARGS_KDICT(a)        ((a) & (1<<1))
+#define MRB_ARGS_BLOCK(a)        ((a) & 1)
 
 #define MRB_PROC_CFUNC 128
 #define MRB_PROC_CFUNC_P(p) ((p)->flags & MRB_PROC_CFUNC)

--- a/src/proc.c
+++ b/src/proc.c
@@ -137,7 +137,7 @@ mrb_proc_arity(mrb_state *mrb, mrb_value self)
 {
   struct RProc *p = mrb_proc_ptr(self);
   mrb_code *iseq = mrb_proc_iseq(mrb, p);
-  mrb_aspec aspec = *iseq >> 6;
+  mrb_aspec aspec = GETARG_Ax(*iseq);
   int ma, ra, pa, arity;
   
   ma = MRB_ARGS_REQ(aspec);


### PR DESCRIPTION
There are two patches. The one is obvious.
The another is not a bug fix but for symmetry and/or readability.
