### PR TITLE
fix the behavior of Module#ancestors

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -793,7 +793,7 @@ mrb_mod_ancestors(mrb_state *mrb, mrb_value self)
     if (c->tt == MRB_TT_ICLASS) {
       mrb_ary_push(mrb, result, mrb_obj_value(c->c));
     }
-    else {
+    else if (c->tt != MRB_TT_SCLASS) {
       mrb_ary_push(mrb, result, mrb_obj_value(c));
     }
     c = c->super;

--- a/test/t/module.rb
+++ b/test/t/module.rb
@@ -14,8 +14,12 @@ end
 # TODO not implemented ATM assert('Module.nesting', '15.2.2.3.2') do
 
 assert('Module#ancestors', '15.2.2.4.9') do
+  class Test4ModuleAncestors
+  end
+  sc = Test4ModuleAncestors.singleton_class
   r = String.ancestors
-  r.class == Array and r.include?(String) and r.include?(Object)
+  r.class == Array and r.include?(String) and r.include?(Object) and
+  ! sc.ancestors.include?(sc)
 end
 
 assert('Module#append_features', '15.2.2.4.10') do


### PR DESCRIPTION
The behavior of _Module#ancestors_ is different than CRuby:
Example:

``` ruby
class Demo 
end
p Demo.ancestors
p Demo.singleton_class.ancestors
```

CRuby 1.9.x~ 2.0.0 output:

``` ruby
[Demo, Object, Kernel, BasicObject]
[Class, Module, Object, Kernel, BasicObject]
```

mruby output:

``` ruby
[Demo, Object, Kernel, BasicObject]
[#<Class:Demo>, #<Class:Object>, #<Class:BasicObject>, Class, Module, Object, Kernel, BasicObject]
```

---

Although ISO Ruby says that if _receiver_ of _ancestors_ is a singleton class, the behavior is implementation-defined. I think that the behavior of _Moudle#ancestors_ should be consistent in mruby and CRuby.
