### PR TITLE
detect cyclic-include in Module#include

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -690,6 +690,9 @@ mrb_include_module(mrb_state *mrb, struct RClass *c, struct RClass *m)
     struct RClass *p = c, *ic;
     int superclass_seen = 0;
 
+    if (c->mt == m->mt) {
+      mrb_raise(mrb, E_ARGUMENT_ERROR, "cyclic include detected");
+    }
     while (p) {
       if (c != p && p->tt == MRB_TT_CLASS) {
         superclass_seen = 1;


### PR DESCRIPTION
detect cyclic-include in _Module#include_.

Example:

``` Ruby
module M end
module N end

module M
  include N
end

module N
  include M
end
```

CRuby throw a ArgumentError and message: ‘cyclic include detected’ . So mruby should do the same.
