### PR TITLE
add extern funcs declaration and casts for cimpiling C++ compiler

### DIFF
--- a/include/mruby/dump.h
+++ b/include/mruby/dump.h
@@ -140,11 +140,12 @@ bin_to_uint8(const uint8_t *bin)
   return (uint8_t)bin[0];
 }
 
-/* crc.c */
-uint16_t
-calc_crc_16_ccitt(const uint8_t *src, size_t nbytes, uint16_t crc);
 #if defined(__cplusplus)
 }  /* extern "C" { */
 #endif
+
+/* crc.c */
+uint16_t
+calc_crc_16_ccitt(const uint8_t *src, size_t nbytes, uint16_t crc);
 
 #endif  /* MRUBY_DUMP_H */

--- a/src/class.c
+++ b/src/class.c
@@ -837,7 +837,7 @@ mrb_mod_included_modules(mrb_state *mrb, mrb_value self)
   return result;
 }
 
-mrb_value class_instance_method_list(mrb_state*, int, struct RClass*, int);
+mrb_value class_instance_method_list(mrb_state*, mrb_bool, struct RClass*, int);
 
 /* 15.2.2.4.33 */
 /*

--- a/src/dump.c
+++ b/src/dump.c
@@ -12,6 +12,8 @@
 #include "mruby/irep.h"
 #include "mruby/numeric.h"
 
+int sprintf(char*, const char*, ...);
+
 static size_t
 get_irep_record_size(mrb_state *mrb, mrb_irep *irep);
 

--- a/src/parse.y
+++ b/src/parse.y
@@ -763,7 +763,7 @@ new_nth_ref(parser_state *p, int n)
 static node*
 new_heredoc(parser_state *p)
 {
-  parser_heredoc_info *inf = parser_palloc(p, sizeof(parser_heredoc_info));
+  parser_heredoc_info *inf = (parser_heredoc_info *)parser_palloc(p, sizeof(parser_heredoc_info));
   return cons((node*)NODE_HEREDOC, (node*)inf);
 }
 
@@ -3415,7 +3415,7 @@ scan_hex(const int *start, int len, int *retlen)
   char *tmp;
 
   /* assert(len <= 2) */
-  while (len-- && *s && (tmp = strchr(hexdigit, *s))) {
+  while (len-- && *s && (tmp = (char*)strchr(hexdigit, *s))) {
     retval <<= 4;
     retval |= (tmp - hexdigit) & 15;
     s++;
@@ -3773,7 +3773,7 @@ heredoc_identifier(parser_state *p)
   info->term_len = toklen(p);
   if (! quote)
     type |= STR_FUNC_EXPAND;
-  info->type = type;
+  info->type = (string_type)type;
   info->allow_indent = indent;
   info->line_head = TRUE;
   info->doc = NULL;

--- a/src/vm.c
+++ b/src/vm.c
@@ -22,6 +22,15 @@
 #include "opcode.h"
 #include "value_array.h"
 
+#ifndef ENABLE_STDIO
+#if defined(__cplusplus)
+extern "C" {
+#endif
+void abort(void);
+#if defined(__cplusplus)
+}  /* extern "C" { */
+#endif
+#endif
 
 #define SET_TRUE_VALUE(r) MRB_SET_VALUE(r, MRB_TT_TRUE, value.i, 1)
 #define SET_FALSE_VALUE(r) MRB_SET_VALUE(r, MRB_TT_FALSE, value.i, 1)


### PR DESCRIPTION
There are some function prototype conflictions and missing type casts.
