### PR TITLE
sort mrbgem's mrblib/*.rb files

### DIFF
--- a/tasks/mrbgem_spec.rake
+++ b/tasks/mrbgem_spec.rake
@@ -51,7 +51,7 @@ module MRuby
         end
         @linker = LinkerConfig.new([], [], [], [])
 
-        @rbfiles = Dir.glob("#{dir}/mrblib/*.rb")
+        @rbfiles = Dir.glob("#{dir}/mrblib/*.rb").sort
         @objs = Dir.glob("#{dir}/src/*.{c,cpp,m,asm,S}").map do |f|
           objfile(f.relative_path_from(@dir).to_s.pathmap("#{build_dir}/%X"))
         end


### PR DESCRIPTION
In some environment, the results of `Dir.glob` will not be sorted
- like:  https://github.com/mruby/mruby/commit/5de9a8cc50052db105ea8ba06d64b95cb1b57db1
