### PR TITLE
[mrbgems] Identify GEM duplications

### DIFF
--- a/tasks/mrbgem_spec.rake
+++ b/tasks/mrbgem_spec.rake
@@ -169,6 +169,22 @@ module MRuby
       end
 
     end # Specification
+
+    class List < Array
+      def <<(gem)
+        fail ArgumentError.new("Don't find directory for this GEM") unless gem.respond_to? :dir
+        unless include?(gem)
+          super(gem)
+        else
+          # GEM was already added to this list
+        end
+      end
+
+      # we assume that a gem with the same directory is equal
+      def include?(gem)
+        detect {|g| g.dir == gem.dir }
+      end
+    end # List
   end # Gem
 
   GemBox = Object.new

--- a/tasks/mruby_build.rake
+++ b/tasks/mruby_build.rake
@@ -75,7 +75,7 @@ module MRuby
         @mrbc = Command::Mrbc.new(self)
 
         @bins = %w(mrbc)
-        @gems, @libmruby = GemList.new, []
+        @gems, @libmruby = MRuby::Gem::List.new, []
         @build_mrbtest_lib_only = false
 
         MRuby.targets[@name] = self

--- a/tasks/mruby_build_gem.rake
+++ b/tasks/mruby_build_gem.rake
@@ -1,20 +1,4 @@
 module MRuby
-  class GemList < Array
-    def <<(gem)
-      fail ArgumentError.new("Don't find directory for this GEM") unless gem.respond_to? :dir
-      unless include?(gem)
-        super(gem)
-      else
-        # GEM was already added to this list
-      end
-    end
-
-    # we assume that a gem with the same directory is equal
-    def include?(gem)
-      detect {|g| g.dir == gem.dir }
-    end
-  end
-
   module LoadGems
     def gembox(gemboxfile)
       gembox = File.expand_path("#{gemboxfile}.gembox", "#{MRUBY_ROOT}/mrbgems")


### PR DESCRIPTION
We have to expect that in the future, when mruby contains a gem dependency system, it is likely that the same gem might be added via such a dependency. This pull request can identify these kind of duplicates and avoids to add them to the build process.
