### PR TITLE
Add type check in Hash#merge!

### DIFF
--- a/mrbgems/mruby-hash-ext/mrblib/hash.rb
+++ b/mrbgems/mruby-hash-ext/mrblib/hash.rb
@@ -1,5 +1,6 @@
 class Hash
   def merge!(other, &block)
+    raise "can't convert argument into Hash" unless other.respond_to?(:to_hash)
     if block
       other.each_key{|k|
         self[k] = (self.has_key?(k))? block.call(k, self[k], other[k]): other[k]


### PR DESCRIPTION
Hash.merge! doesn't nil check.

```
bin/mruby -e "{}.merge!(nil)"
trace:
    [0] -e:1
-e:1: undefined method 'each_key' for nil (NoMethodError)
```

After fix:

```
bin/mruby -e "{}.merge!(nil)"                               
trace:
    [0] -e:1
-e:1: can't convert argument into Hash (RuntimeError)
```
