### PR TITLE
Fix for 'inline' macro redefinition error in VS2012 C++

### DIFF
--- a/include/mrbconf.h
+++ b/include/mrbconf.h
@@ -116,6 +116,7 @@ typedef short mrb_sym;
 #endif
 
 #ifdef _MSC_VER
+# define _ALLOW_KEYWORD_MACROS
 # include <float.h>
 # define inline __inline
 # define snprintf _snprintf


### PR DESCRIPTION
Currently when compiling C++ code, VS2012 errors on the keyword 'inline' being redefined.

This can be easily suppressed by adding `# define _ALLOW_KEYWORD_MACROS` within mrbconf.h.

Unfortunately this will also suppress the error for everything else being compiled, and **could** cause issues to someone unintentionally redefining other keywords.
