### PR TITLE
mrbc: use binary mode on outfile

### DIFF
--- a/tools/mrbc/mrbc.c
+++ b/tools/mrbc/mrbc.c
@@ -282,7 +282,7 @@ main(int argc, char **argv)
     if (strcmp("-", args.outfile) == 0) {
       wfp = stdout;
     }
-    else if ((wfp = fopen(args.outfile, "w")) == NULL) {
+    else if ((wfp = fopen(args.outfile, "wb")) == NULL) {
       fprintf(stderr, "%s: cannot open output file:(%s)\n", args.prog, args.outfile);
       return EXIT_FAILURE;
     }


### PR DESCRIPTION
This solves the problem of incorrect bytecode generated by mrbc
for single files on Windows platform (which is by default text-mode)

This fixes #1256

Thanks @matz for pointing out an overlook on my part.
