### PR TITLE
Describe GemBox files can be located anywhere

### DIFF
--- a/doc/mrbgems/README.md
+++ b/doc/mrbgems/README.md
@@ -57,6 +57,11 @@ the build block:
 This will cause the *custom* GemBox to be read in during the build process,
 adding *mruby-time* and *mrbgems-example* to the build.
 
+If you want, you can put GemBox outside of mruby directory. In that case you must 
+specify absolute path like below.
+
+	conf.gembox "#{ENV["HOME"]}/mygemboxes/custom"
+
 There are two GemBoxes that ship with mruby: [default](../../mrbgems/default.gembox)
 and [full-core](../../mrbgems/full-core.gembox). The [default](../../mrbgems/default.gembox) GemBox
 contains several core components of mruby, and [full-core](../../mrbgems/full-core.gembox)


### PR DESCRIPTION
I've just found GemBox can be located any path. 

It is nice feature  for me because I want manage my gems and GemBox (and build_config.rb) outside of mruby dir.

I thought  it might be better to be described in README.
