### PR TITLE
No need to specify empty bin list anymore(example)

### DIFF
--- a/examples/targets/ArduinoDue.rb
+++ b/examples/targets/ArduinoDue.rb
@@ -27,6 +27,4 @@ MRuby::CrossBuild.new("Arduino Due") do |conf|
     archiver.archive_options = 'rcs %{outfile} %{objs}'
   end
 
-  # No binaries necessary
-  conf.bins = []
 end

--- a/examples/targets/chipKitMax32.rb
+++ b/examples/targets/chipKitMax32.rb
@@ -31,6 +31,4 @@ MRuby::CrossBuild.new("chipKitMax32") do |conf|
     archiver.archive_options = 'rcs %{outfile} %{objs}'
   end
 
-  # No binaries necessary
-  conf.bins = []
 end


### PR DESCRIPTION
Specifying empty bin list in example build config for Arduino boards is not required any more.
