### PR TITLE
Remove extra separator in compile command

### DIFF
--- a/tasks/mrbgem_spec.rake
+++ b/tasks/mrbgem_spec.rake
@@ -81,7 +81,7 @@ module MRuby
         instance_eval(&@build_config_initializer) if @build_config_initializer
 
         compilers.each do |compiler|
-          compiler.define_rules build_dir, "#{dir}/"
+          compiler.define_rules build_dir, "#{dir}"
         end
 
         define_gem_init_builder


### PR DESCRIPTION
I noticed extra separator for path to *.c are passed to compiler.

Here is example (here I intentionally cause compile error to show full command line)

```
build/mrbgems/mruby-cfunc//src/cfunc.c:22:1: error: expected external declaration
-
^
1 error generated.
rake aborted!
Command Failed: ["clang" -arch x86_64 -DENABLE_READLINE --verbose -pthread -I"/Users/koji/work/mruby/mruby/include" -I"/Users/koji/work/mruby/mruby/mrbgems/mruby-sprintf/include" -I"/Users/koji/work/mruby/mruby/mrbgems/mruby-print/include" -I"/Users/koji/work/mruby/mruby/mrbgems/mruby-math/include" -I"/Users/koji/work/mruby/mruby/mrbgems/mruby-time/include" -I"/Users/koji/work/mruby/mruby/mrbgems/mruby-struct/include" -I"/Users/koji/work/mruby/mruby/mrbgems/mruby-enum-ext/include" -I"/Users/koji/work/mruby/mruby/mrbgems/mruby-string-ext/include" -I"/Users/koji/work/mruby/mruby/mrbgems/mruby-numeric-ext/include" -I"/Users/koji/work/mruby/mruby/mrbgems/mruby-array-ext/include" -I"/Users/koji/work/mruby/mruby/mrbgems/mruby-hash-ext/include" -I"/Users/koji/work/mruby/mruby/mrbgems/mruby-range-ext/include" -I"/Users/koji/work/mruby/mruby/mrbgems/mruby-proc-ext/include" -I"/Users/koji/work/mruby/mruby/mrbgems/mruby-symbol-ext/include" -I"/Users/koji/work/mruby/mruby/mrbgems/mruby-random/include" -I"/Users/koji/work/mruby/mruby/mrbgems/mruby-objectspace/include" -I"/Users/koji/work/mruby/mruby/mrbgems/mruby-fiber/include" -I"/Users/koji/work/mruby/mruby/mrbgems/mruby-bin-mirb/include" -I"/Users/koji/work/mruby/mruby/mrbgems/mruby-bin-mruby/include" -I"build/mrbgems/mruby-cfunc/include" -I"build/libffi/host/libffi-3.0.11/lib/libffi-3.0.11/include" -o "/Users/koji/work/mruby/mruby/build/host/mrbgems/mruby-cfunc/src/cfunc.o" -c "build/mrbgems/mruby-cfunc//src/cfunc.c"]

make: *** [all] Error 1
```

see the last -> -c "build/mrbgems/mruby-cfunc//src/cfunc.c".

At least In my environment extra separator(/) is not problem. 
But It would be better to be fixed.
