### PR TITLE
add function 'mrb_str_new_cstrl'

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -247,6 +247,7 @@ void mrb_free(mrb_state*, void*);
 
 mrb_value mrb_str_new(mrb_state *mrb, const char *p, size_t len);
 mrb_value mrb_str_new_cstr(mrb_state*, const char*);
+mrb_value mrb_str_new_cstrl(mrb_state*, const char*p, size_t len);
 mrb_value mrb_str_new_static(mrb_state *mrb, const char *p, size_t len);
 
 mrb_state* mrb_open(void);

--- a/src/string.c
+++ b/src/string.c
@@ -274,6 +274,20 @@ mrb_str_new_cstr(mrb_state *mrb, const char *p)
 }
 
 mrb_value
+mrb_str_new_cstrl(mrb_state *mrb, const char *p, size_t len)
+{
+  struct RString *s;
+
+  if ((mrb_int)len < 0) {
+    mrb_raise(mrb, E_ARGUMENT_ERROR, "argument too big");
+  }
+
+  s = str_new(mrb, p, len);
+
+  return mrb_obj_value(s);
+}
+
+mrb_value
 mrb_str_new_static(mrb_state *mrb, const char *p, size_t len)
 {
   struct RString *s;


### PR DESCRIPTION
This is length-limited 'mrb_str_new_cstr' and comparable to 'lua_pushlstirng' of Lua.(In this case, 'mrb_str_new_cstr' is comparable to 'lua_pushstring' of Lua)
## use case

As I'm in trouble using 'mrb_str_new_cstr' to the length-attached string of Nginx(ngx_str_t), I want to add this function to mruby for developing ngx_mruby.

For, ngx_str_t is defined as following.

``` c
typedef struct {
    size_t      len;
    u_char     *data;
} ngx_str_t;
```

As the data is not ensured zero-terminated in Nginx, the following code does not works as I had expected.

``` c
/* This is the value when URI is "/mruby".
/* r->method_name.data -> GET /mruby/ HTTP/1.1  */
/* r->method_name.len -> 3 */
mrb_value val;
ngx_http_request_t *r;
r = ngx_mrb_get_request();
val = mrb_str_new_cstr(mrb, (const char *)r->method_name.data); /* "GET /mruby/ HTTP/1.1" is copied */
```

As r->method_name.data is not null-terminated, 
the actual method_name becomes not "GET" but "GET /mruby/ HTTP/1.1".

mrb_str_new_cstrl resolves this problem.

``` c
/* This is the value when URI is "/mruby".
/* r->method_name.data -> GET /mruby/ HTTP/1.1  */
/* r->method_name.len -> 3 */
mrb_value val;
ngx_http_request_t *r;
r = ngx_mrb_get_request();
val = mrb_str_new_cstrl(mrb, (const char *)r->method_name.data, r->method_name.len); /* "GET" is copied */
```
