### PR TITLE
Cleanup mrb_str_resize().

### DIFF
--- a/src/string.c
+++ b/src/string.c
@@ -104,10 +104,9 @@ mrb_str_resize(mrb_state *mrb, mrb_value str, mrb_int len)
   mrb_str_modify(mrb, s);
   slen = s->len;
   if (len != slen) {
-    if (slen < len || slen -len > 1024) {
-      s->ptr = (char *)mrb_realloc(mrb, s->ptr, len+1);
+    if (slen < len || slen - len > 256) {
+      RESIZE_CAPA(s, len);
     }
-    s->aux.capa = len;
     s->len = len;
     s->ptr[len] = '\0';   /* sentinel */
   }


### PR DESCRIPTION
There has minor issue in mrb_str_resize(). It may substitute an inefficient value to aux.capa.
