### PR TITLE
Fix crash on load *mrb

### DIFF
--- a/src/load.c
+++ b/src/load.c
@@ -187,7 +187,6 @@ read_rite_section_irep(mrb_state *mrb, const uint8_t *bin)
 {
   int result;
   size_t sirep;
-  size_t i;
   uint32_t len;
   uint16_t nirep;
   uint16_t n;
@@ -200,14 +199,14 @@ read_rite_section_irep(mrb_state *mrb, const uint8_t *bin)
   nirep = bin_to_uint16(header->nirep);
 
   //Read Binary Data Section
-  for (n = 0, i = sirep; n < nirep; n++, i++) {
+  for (n = 0; n < nirep; n++) {
     result = read_rite_irep_record(mrb, bin, &len);
     if (result != MRB_DUMP_OK)
       goto error_exit;
     bin += len;
   }
 
-  result = sirep + bin_to_uint16(header->sirep);
+  result = nirep;
 error_exit:
   if (result < MRB_DUMP_OK) {
     irep_free(sirep, mrb);
@@ -368,7 +367,7 @@ mrb_read_irep(mrb_state *mrb, const uint8_t *bin)
     bin += bin_to_uint32(section_header->section_size);
   } while (memcmp(section_header->section_identify, RITE_BINARY_EOF, sizeof(section_header->section_identify)) != 0);
 
-  return total_nirep;
+  return sirep;
 }
 
 static void
@@ -464,7 +463,6 @@ read_rite_section_irep_file(mrb_state *mrb, FILE *fp)
 {
   int32_t result;
   size_t sirep;
-  size_t i;
   uint16_t nirep;
   uint16_t n;
   uint32_t len, buf_size;
@@ -488,7 +486,7 @@ read_rite_section_irep_file(mrb_state *mrb, FILE *fp)
   }
 
   //Read Binary Data Section
-  for (n = 0, i = sirep; n < nirep; n++, i++) {
+  for (n = 0; n < nirep; n++) {
     void *ptr;
 
     if (fread(buf, record_header_size, 1, fp) == 0) {
@@ -516,7 +514,7 @@ read_rite_section_irep_file(mrb_state *mrb, FILE *fp)
       goto error_exit;
   }
 
-  result = sirep + bin_to_uint16(header.sirep);
+  result = nirep;
 error_exit:
   if (buf) {
     mrb_free(mrb, buf);
@@ -614,7 +612,7 @@ mrb_read_irep_file(mrb_state *mrb, FILE* fp)
     fseek(fp, fpos + section_size, SEEK_SET);
   } while (memcmp(section_header.section_identify, RITE_BINARY_EOF, sizeof(section_header.section_identify)) != 0);
 
-  return total_nirep;
+  return sirep;
 }
 
 mrb_value


### PR DESCRIPTION
If call mrb_dump_irep_binary() with start irep with non-zero , load/run crashes.

test code:

``` c
#include <stdio.h>
#include <string.h>

#include "mruby.h"
#include "mruby/dump.h"
#include "mruby/compile.h"
#include "mruby/proc.h"

void dumpMRB(mrb_state *mrb, const char *filename, const char *code){
    mrbc_context *cxt;

    cxt = mrbc_context_new(mrb);
    cxt->capture_errors = 1;
    //cxt->no_exec = 1;
    cxt->filename = (char *)filename;

    struct mrb_parser_state *parser = mrb_parser_new(mrb);
    parser->s = code;
    parser->send = code + strlen(code);
    //parser->lineno = 1;
    mrb_parser_parse(parser, cxt);

    int n = mrb_generate_code(mrb,parser);
    if (n < 0) {
        printf("failed to generate code. err=%d\n",n);
        return;
    }

    FILE *f = fopen(filename,"w+b");
    int ret = mrb_dump_irep_binary(mrb, n, 0, f);
    if (ret != MRB_DUMP_OK){
        printf("failed to create %s\n",filename);
        fclose(f);
        return;
    }
    fclose(f);
    mrb_parser_free(parser);
    mrbc_context_free(mrb,cxt);

}

void runMRB(mrb_state *mrb, const char *filename){
    FILE *f = fopen(filename, "rb");
    int n = mrb_read_irep_file(mrb, f);

    if (n < 0){
        printf("failed to load mrb:%s\n", filename);
        return;
    }
    mrb_run(mrb, mrb_proc_new(mrb, mrb->irep[n]), mrb_top_self(mrb));
    fclose(f);
}

int main(int argc, const char * argv[])
{
    mrb_state *mrb1,*mrb2;
    mrb1 = mrb_open();
    mrb2 = mrb_open();
    dumpMRB(mrb1,"one.mrb","puts :one; def func1;puts :func1;end");
    dumpMRB(mrb1,"two.mrb","puts :two; func1 ");
    runMRB(mrb2, "one.mrb");
    runMRB(mrb2, "two.mrb");

    mrb_close(mrb1);
    mrb_close(mrb2);
    return 0;
}


```
