### PR TITLE
Refactor mrb_hash_has_keyWithKey() func in hash.c

### DIFF
--- a/src/hash.c
+++ b/src/hash.c
@@ -921,17 +921,12 @@ mrb_hash_has_keyWithKey(mrb_state *mrb, mrb_value hash, mrb_value key)
 {
   khash_t(ht) *h = RHASH_TBL(hash);
   khiter_t k;
-  mrb_bool result;
 
   if (h) {
     k = kh_get(ht, h, key);
-    result = (k != kh_end(h));
+    return mrb_bool_value(k != kh_end(h));
   }
-  else {
-    result = 0;
-  }
-
-  return mrb_bool_value(result);
+  return mrb_false_value();
 }
 
 /* 15.2.13.4.13 */


### PR DESCRIPTION
If a return value is decided, a program should return value Immediately.

<pre>
if (h) {
  k = kh_get(ht, h, key);
  return mrb_bool_value(k != kh_end(h));
}
</pre>


'result = 0' is ambiguous.
A program returns mrb_false_value().
