### PR TITLE
ArgumentError raised when mrb_get_args(mrb, "z", ...) receives substring.

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -487,7 +487,7 @@ mrb_get_args(mrb_state *mrb, const char *format, ...)
         if (i < argc) {
           ss = to_str(mrb, *sp++);
           s = mrb_str_ptr(ss);
-          if (strlen(s->ptr) != s->len) {
+          if (strlen(s->ptr) < s->len) {
             mrb_raise(mrb, E_ARGUMENT_ERROR, "String contains NUL");
           }
           *ps = s->ptr;


### PR DESCRIPTION
Applying the patch, fixes unnecessary exception in mrb_get_args() with "z" format.

```
static mrb_value
foo(mrb_state *mrb, mrb_value self)
{
  char *p;
  mrb_get_args(mrb, "z", &p);

}

void
mrb_init_foo(mrb_state *mrb)
{
  mrb_define_method(mrb, mrb->object_class, "foo", foo, MRB_ARGS_REQ(1));
}
```

```
str = "ABCDE"
foo str[2] # => "xxx.rb:2: String contains NUL (ArgumentError)"
```
