### PR TITLE
Refactor mrb_hash_empty_p() func in hash.c

### DIFF
--- a/src/hash.c
+++ b/src/hash.c
@@ -776,16 +776,9 @@ mrb_value
 mrb_hash_empty_p(mrb_state *mrb, mrb_value self)
 {
   khash_t(ht) *h = RHASH_TBL(self);
-  mrb_bool empty_p;
 
-  if (h) {
-    empty_p = (kh_size(h) == 0);
-  }
-  else {
-    empty_p = 1;
-  }
-
-  return mrb_bool_value(empty_p);
+  if (h) return mrb_bool_value(kh_size(h) == 0);
+  return mrb_true_value();
 }
 
 static mrb_value


### PR DESCRIPTION
If a return value is decided, a program should return value Immediately.

<pre>
if (h) return mrb_bool_value(kh_size(h) == 0);
</pre>

'empty_p = 1' is ambiguous.
A program returns mrb_true_value().
