### PR TITLE
crc.c - replace POSIX with C99 header

### DIFF
--- a/src/crc.c
+++ b/src/crc.c
@@ -6,7 +6,7 @@
 
 #include <limits.h>
 #include <stdint.h>
-#include <sys/types.h>
+#include <stddef.h>
 
 // Calculate CRC (CRC-16-CCITT)
 //


### PR DESCRIPTION
There's no need to include an unportable header like sys/types.h for `size_t`. Including a standard C header like stddef.h is better.
