### PR TITLE
Fix incorrect debug filename for bytecode from multiple *.rb

### DIFF
--- a/include/mruby/irep.h
+++ b/include/mruby/irep.h
@@ -32,6 +32,7 @@ typedef struct mrb_irep {
 
 mrb_irep *mrb_add_irep(mrb_state *mrb);
 mrb_value mrb_load_irep(mrb_state*, const uint8_t*);
+int mrb_irep_stop_p(mrb_state *mrb, mrb_irep *irep);
 
 #if defined(__cplusplus)
 }  /* extern "C" { */

--- a/src/state.c
+++ b/src/state.c
@@ -10,6 +10,7 @@
 #include "mruby/class.h"
 #include "mruby/irep.h"
 #include "mruby/variable.h"
+#include "opcode.h"
 
 void mrb_init_heap(mrb_state*);
 void mrb_init_core(mrb_state*);
@@ -186,6 +187,14 @@ mrb_add_irep(mrb_state *mrb)
   irep->idx = mrb->irep_len++;
 
   return irep;
+}
+
+int
+mrb_irep_stop_p(mrb_state *mrb, mrb_irep *irep)
+{
+
+  return (GET_OPCODE( irep->iseq[irep->ilen - 1] ) == OP_STOP);
+
 }
 
 mrb_value


### PR DESCRIPTION
Fix #1243

With this fix bytecode from multiple *.rb with `mrbc -g` shows correct filename.
I hope someone to review.

``` sh
[koji@macbookpro:~/work/mruby]$ cat one.rb
puts "hi from one.rb"

non_defined_func

[koji@macbookpro:~/work/mruby]$ cat two.rb
puts "hi from two.rb"

[koji@macbookpro:~/work/mruby]$ mrbc -g -o prog.mrb one.rb two.rb
[koji@macbookpro:~/work/mruby]$ mruby -b prog.mrb
hi from one.rb
trace:
    [0] one.rb:3
one.rb:3: undefined method 'non_defined_func' for main (NoMethodError)
```
