### PR TITLE
Refactor mrb_obj_eq() func in object.c.

### DIFF
--- a/src/object.c
+++ b/src/object.c
@@ -17,7 +17,7 @@ mrb_obj_eq(mrb_state *mrb, mrb_value v1, mrb_value v2)
   if (mrb_type(v1) != mrb_type(v2)) return FALSE;
   switch (mrb_type(v1)) {
   case MRB_TT_TRUE:
-    return 1;
+    return TRUE;
 
   case MRB_TT_FALSE:
   case MRB_TT_FIXNUM:


### PR DESCRIPTION
It is ambiguous that return value is 1.
Return value should be 'TRUE'.
