### PR TITLE
Refactor mrb_ary_equal() func and mrb_ary_eql() func in array.c.

### DIFF
--- a/src/array.c
+++ b/src/array.c
@@ -1091,30 +1091,18 @@ static mrb_value
 mrb_ary_eql(mrb_state *mrb, mrb_value ary1)
 {
   mrb_value ary2;
-  mrb_bool eql_p;
+  mrb_int i;
 
   mrb_get_args(mrb, "o", &ary2);
-  if (mrb_obj_equal(mrb, ary1, ary2)) {
-    eql_p = 1;
-  }
-  else if (!mrb_array_p(ary2)) {
-    eql_p = 0;
-  }
-  else if (RARRAY_LEN(ary1) != RARRAY_LEN(ary2)) {
-    eql_p = 0;
-  }
-  else {
-    mrb_int i;
-    eql_p = 1;
-    for (i=0; i<RARRAY_LEN(ary1); i++) {
-      if (!mrb_eql(mrb, ary_elt(ary1, i), ary_elt(ary2, i))) {
-        eql_p = 0;
-        break;
-      }
+  if (mrb_obj_equal(mrb, ary1, ary2)) return mrb_true_value();
+  if (!mrb_array_p(ary2)) return mrb_false_value();
+  if (RARRAY_LEN(ary1) != RARRAY_LEN(ary2)) return mrb_false_value();
+  for (i=0; i<RARRAY_LEN(ary1); i++) {
+    if (!mrb_eql(mrb, ary_elt(ary1, i), ary_elt(ary2, i))) {
+      return mrb_false_value();
     }
   }
-
-  return mrb_bool_value(eql_p);
+  return mrb_true_value();
 }
 
 void


### PR DESCRIPTION
It is ambiguous that return value is 0 or 1.
Return value is mrb_true_value() or mrb_false_value().
A program should return a value immediately.
