### PR TITLE
Add include for toplevel self(main)

### DIFF
--- a/mrbgems/mruby-toplevel-ext/mrbgem.rake
+++ b/mrbgems/mruby-toplevel-ext/mrbgem.rake
@@ -1,0 +1,4 @@
+MRuby::Gem::Specification.new('mruby-toplevel-ext') do |spec|
+  spec.license = 'MIT'
+  spec.authors = 'mruby developers'
+end

--- a/mrbgems/mruby-toplevel-ext/mrblib/toplevel.rb
+++ b/mrbgems/mruby-toplevel-ext/mrblib/toplevel.rb
@@ -1,0 +1,4 @@
+
+def self.include (*modules)
+  self.class.include *modules
+end

--- a/mrbgems/mruby-toplevel-ext/test/toplevel.rb
+++ b/mrbgems/mruby-toplevel-ext/test/toplevel.rb
@@ -1,0 +1,24 @@
+##
+# Toplevel Self(Ext) Test
+
+module ToplevelTestModule1
+  def method_foo
+    :foo
+  end
+
+  CONST_BAR = :bar
+end
+
+module ToplevelTestModule2
+  CONST_BAR = :bar2
+end
+
+assert('Toplevel#include') do
+  self.include ToplevelTestModule2, ToplevelTestModule1
+  
+  assert_true self.class.included_modules.include?( ToplevelTestModule1 )
+  assert_true self.class.included_modules.include?( ToplevelTestModule2 )
+  assert_equal :foo, method_foo
+  assert_equal :bar2, CONST_BAR
+end
+


### PR DESCRIPTION
I heard in somewhere `include` for main is not in ISO, but sometimes `include` is convenience for small programs.
How about to add `include` as mrbgem? 
