### PR TITLE
Refactor mrb_define_class() method in class.c.c

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -159,9 +159,7 @@ mrb_define_class_id(mrb_state *mrb, mrb_sym name, struct RClass *super)
 struct RClass*
 mrb_define_class(mrb_state *mrb, const char *name, struct RClass *super)
 {
-  struct RClass *c;
-  c = mrb_define_class_id(mrb, mrb_intern(mrb, name), super);
-  return c;
+  return mrb_define_class_id(mrb, mrb_intern(mrb, name), super);
 }
 
 struct RClass*


### PR DESCRIPTION
A temporary c variable is redundancy.

<pre>
c = mrb_define_class_id(mrb, mrb_intern(mrb, name), super);
return c;
</pre>


Set a value in return statement.

<pre>
return mrb_define_class_id(mrb, mrb_intern(mrb, name), super);
</pre>
