### PR TITLE
add mrb_retrieve_values (like mrb_get_args, but recieve argc/argv)

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -218,6 +218,8 @@ struct RClass * mrb_define_module_under(mrb_state *mrb, struct RClass *outer, co
 #define ARGS_NONE()         MRB_ARGS_NONE()
 
 int mrb_get_args(mrb_state *mrb, const char *format, ...);
+int mrb_retrieve_values(mrb_state *mrb, int argc, mrb_value *sp, const char *format, ...);
+
 
 mrb_value mrb_funcall(mrb_state*, mrb_value, const char*, int,...);
 mrb_value mrb_funcall_argv(mrb_state*, mrb_value, mrb_sym, int, mrb_value*);

--- a/src/class.c
+++ b/src/class.c
@@ -366,6 +366,8 @@ to_hash(mrb_state *mrb, mrb_value val)
   return check_type(mrb, val, MRB_TT_HASH, "Hash", "to_hash");
 }
 
+static int mrb_retrieve_values_v(mrb_state *, int, mrb_value *, const char *, va_list);
+
 /*
   retrieve arguments from mrb_state.
 
@@ -393,12 +395,9 @@ to_hash(mrb_state *mrb, mrb_value val)
 int
 mrb_get_args(mrb_state *mrb, const char *format, ...)
 {
-  char c;
-  int i = 0;
   mrb_value *sp = mrb->c->stack + 1;
   va_list ap;
   int argc = mrb->c->ci->argc;
-  int opt = 0;
 
   va_start(ap, format);
   if (argc < 0) {
@@ -407,6 +406,25 @@ mrb_get_args(mrb_state *mrb, const char *format, ...)
     argc = a->len;
     sp = a->ptr;
   }
+  return mrb_retrieve_values_v(mrb, argc, sp, format, ap);
+}
+
+int
+mrb_retrive_values(mrb_state *mrb, int argc, mrb_value *sp, const char *format, ...)
+{
+  va_list ap;
+
+  va_start(ap, format);
+  return mrb_retrieve_values_v(mrb, argc, sp, format, ap);
+}
+
+static int
+mrb_retrieve_values_v(mrb_state *mrb, int argc, mrb_value *sp, const char *format, va_list ap)
+{
+  char c;
+  int i = 0;
+  int opt = 0;
+
   while ((c = *format++)) {
     switch (c) {
     case '|': case '*': case '&':


### PR DESCRIPTION
Sometimes I want check types of mrb_value[] and get C level value.
(checking rest argument, array, and so on.)

mrb_get_args() is good for me, but it is only for stack.
So I would like to suggest to add mrb_retrieve_values().
