### PR TITLE
ROM-able ISEQ revisited

### DIFF
--- a/tasks/mruby_build.rake
+++ b/tasks/mruby_build.rake
@@ -44,7 +44,7 @@ module MRuby
     include Rake::DSL
     include LoadGems
     attr_accessor :name, :bins, :exts, :file_separator
-    attr_reader :libmruby, :gems
+    attr_reader :libmruby, :gems, :endian
 
     COMPILERS = %w(cc cxx objc asm)
     COMMANDS = COMPILERS + %w(linker archiver yacc gperf git exts mrbc)
@@ -89,6 +89,10 @@ module MRuby
       tc = Toolchain.toolchains[name.to_s]
       fail "Unknown #{name} toolchain" unless tc
       tc.setup(self)
+    end
+
+    def endian(name)
+      @mrbc.endian = name.to_s
     end
 
     def root

--- a/tasks/mruby_build_commands.rake
+++ b/tasks/mruby_build_commands.rake
@@ -236,12 +236,13 @@ module MRuby
   end
 
   class Command::Mrbc < Command
-    attr_accessor :compile_options
+    attr_accessor :compile_options, :endian
 
     def initialize(build)
       super
       @command = nil
-      @compile_options = "-B%{funcname} -o-"
+      @compile_options = "-B%{funcname} -E%{endian} -o-"
+      @endian = "neutral"
     end
 
     def run(out, infiles, funcname)
@@ -250,7 +251,7 @@ module MRuby
       infiles.each do |f|
         _pp "MRBC", f.relative_path, nil, :indent => 2
       end
-      IO.popen("#{filename @command} #{@compile_options % {:funcname => funcname}} #{infiles.join(' ')}", 'r+') do |io|
+      IO.popen("#{filename @command} #{@compile_options % {:funcname => funcname, :endian => @endian}} #{infiles.join(' ')}", 'r+') do |io|
         out.puts io.read
       end
     end

--- a/tools/mrbc/mrbc.c
+++ b/tools/mrbc/mrbc.c
@@ -21,6 +21,7 @@ struct mrbc_args {
   const char *prog;
   const char *outfile;
   const char *initname;
+  int endian;
   mrb_bool check_syntax : 1;
   mrb_bool verbose      : 1;
   mrb_bool debug_info   : 1;
@@ -36,6 +37,7 @@ usage(const char *name)
   "-v           print version number, then turn on verbose mode",
   "-g           produce debugging information",
   "-B<symbol>   binary <symbol> output in C language format",
+  "-E<endian>   endian for C language format. neutral|little|big",
   "--verbose    run at verbose mode",
   "--version    print the version",
   "--copyright  print the copyright",
@@ -104,6 +106,21 @@ parse_args(mrb_state *mrb, int argc, char **argv, struct mrbc_args *args)
         }
         if (*args->initname == '\0') {
           fprintf(stderr, "%s: function name is not specified.\n", args->prog);
+          return -1;
+        }
+        break;
+      case 'E':
+        if (strcmp(argv[i]+2, "neutral") == 0) {
+          args->endian = RITE_ISEQ_ENDIAN_NEUTRAL;
+        }
+        else if (strcmp(argv[i]+2, "little") == 0) {
+          args->endian = RITE_ISEQ_ENDIAN_LITTLE;
+        }
+        else if (strcmp(argv[i]+2, "big") == 0) {
+          args->endian = RITE_ISEQ_ENDIAN_BIG;
+        }
+        else{
+          fprintf(stderr,"%s: endian should be neutral,little,or big\n", args->prog);
           return -1;
         }
         break;
@@ -217,7 +234,7 @@ dump_file(mrb_state *mrb, FILE *wfp, const char *outfile, struct mrbc_args *args
   int n = MRB_DUMP_OK;
 
   if (args->initname) {
-    n = mrb_dump_irep_cfunc(mrb, 0, args->debug_info, wfp, args->initname);
+    n = mrb_dump_irep_cfunc(mrb, 0, args->debug_info, args->endian, wfp, args->initname);
     if (n == MRB_DUMP_INVALID_ARGUMENT) {
       fprintf(stderr, "%s: invalid C language symbol name\n", args->initname);
     }


### PR DESCRIPTION
This is second version of #880. Related issues are #944, #964.

In my environment(using default gembox, clang, x64),
total heap allocation till end of mrb_open() was reduced around 13kb (183514bytes to 170654bytes).
- Bytecode format now has endian field.
- mrbc has new option `-E<endian>`. Only effective with -B(C-func).
- Default for `-E` is "neutral", which means copy all iseq(same as current). 
- In build_config, you can specify  `endian :little`, or `endian :big` in each target. This value is used for `-E` option on running mrbc.
- Currently CRC are checked even for C-func. I would update to skip CRC check if it is OK.
- I do not have Big-endian device. Only little endian was tested.

test code.

``` c
#include <stdio.h>
#include <stdlib.h>

#include "mruby.h"

size_t total = 0;

void *myallocf(mrb_state *mrb, void *p, size_t size, void *ud){
    if (size == 0){
        free(p);
        return NULL;
    }else{
        //printf("alloc size=%ld, p=%p\n",size,p);
        total += size;
        void *ret = realloc(p, size);
        return ret;
    }
}

int main(int argc, const char * argv[])
{
    mrb_state *mrb = mrb_open_allocf(myallocf, NULL);
    printf("total : %zu bytes\n", total);
    mrb_close(mrb);

    return 0;
}

```
