### PR TITLE
Refactor mrb_range_beg_len() func in range.c

### DIFF
--- a/src/range.c
+++ b/src/range.c
@@ -276,10 +276,10 @@ mrb_range_beg_len(mrb_state *mrb, mrb_value range, mrb_int *begp, mrb_int *lenp,
 
   if (beg < 0) {
     beg += len;
-    if (beg < 0) goto out_of_range;
+    if (beg < 0) return FALSE;
   }
 
-  if (beg > len) goto out_of_range;
+  if (beg > len) return FALSE;
   if (end > len) end = len;
 
   if (end < 0) end += len;
@@ -290,9 +290,6 @@ mrb_range_beg_len(mrb_state *mrb, mrb_value range, mrb_int *begp, mrb_int *lenp,
   *begp = beg;
   *lenp = len;
   return TRUE;
-
-out_of_range:
-  return FALSE;
 }
 
 /* 15.2.14.4.12(x) */


### PR DESCRIPTION
Even if you do not use the goto statement, it is sufficient to use return statement.
