### PR TITLE
Refactor true_or() and false_and() in object.c.

### DIFF
--- a/src/object.c
+++ b/src/object.c
@@ -172,9 +172,6 @@ true_to_s(mrb_state *mrb, mrb_value obj)
 static mrb_value
 true_or(mrb_state *mrb, mrb_value obj)
 {
-  mrb_bool obj2;
-
-  mrb_get_args(mrb, "b", &obj2);
   return mrb_true_value();
 }
 
@@ -203,9 +200,6 @@ true_or(mrb_state *mrb, mrb_value obj)
 static mrb_value
 false_and(mrb_state *mrb, mrb_value obj)
 {
-  mrb_bool obj2;
-
-  mrb_get_args(mrb, "b", &obj2);
   return mrb_false_value();
 }
 


### PR DESCRIPTION
Because return values is constant values, no need to use 'mrb_get_args(mrb, "b", &obj2)'.
