### PR TITLE
"string"[true] is treated like "string"[1]

### DIFF
--- a/src/string.c
+++ b/src/string.c
@@ -797,8 +797,11 @@ num_index:
         }
       }
     default:
-      idx = mrb_fixnum(indx);
-      goto num_index;
+      if (mrb_fixnum_p(indx)) {
+        idx = mrb_fixnum(indx);
+        goto num_index;
+      }
+      else break;
     }
     return mrb_nil_value();    /* not reached */
 }


### PR DESCRIPTION
```
./bin/mruby -e "p 'bar'[nil]" 
"b"
```

```
./bin/mruby -e "p 'bar'[true]"
"a"
```

After fix:

```
./bin/mruby -e "p 'bar'[true]" 
nil
```
