### PR TITLE
Allow programmers to specify build path manually

### DIFF
--- a/tasks/mruby_build.rake
+++ b/tasks/mruby_build.rake
@@ -43,7 +43,7 @@ module MRuby
     end
     include Rake::DSL
     include LoadGems
-    attr_accessor :name, :bins, :exts, :file_separator
+    attr_accessor :name, :bins, :exts, :file_separator, :build_dir
     attr_reader :libmruby, :gems
 
     COMPILERS = %w(cc cxx objc asm)
@@ -63,6 +63,7 @@ module MRuby
         end
 
         @file_separator = '/'
+        @build_dir = "#{MRUBY_ROOT}/build/#{@name}"
         @cc = Command::Compiler.new(self, %w(.c))
         @cxx = Command::Compiler.new(self, %w(.cc .cxx .cpp))
         @objc = Command::Compiler.new(self, %w(.m))
@@ -93,10 +94,6 @@ module MRuby
 
     def root
       MRUBY_ROOT
-    end
-
-    def build_dir
-      "#{MRUBY_ROOT}/build/#{self.name}"
     end
 
     def mrbcfile

--- a/tasks/mruby_build_gem.rake
+++ b/tasks/mruby_build_gem.rake
@@ -39,18 +39,18 @@ module MRuby
         gemdir = "#{root}/mrbgems/#{params[:core]}"
       elsif params[:git]
         url = params[:git]
-        gemdir = "build/mrbgems/#{url.match(/([-\w]+)(\.[-\w]+|)$/).to_a[1]}"
+        gemdir = "#{build_dir}/mrbgems/#{url.match(/([-\w]+)(\.[-\w]+|)$/).to_a[1]}"
 
         if File.exists?(gemdir)
           if $pull_gems
             git.run_pull gemdir, url
           else
             gemdir
-          end 
+          end
         else
           options = [params[:options]] || []
           options << "--branch \"#{params[:branch]}\"" if params[:branch]
-          FileUtils.mkdir_p "build/mrbgems"
+          FileUtils.mkdir_p "#{build_dir}/mrbgems"
           git.run_clone gemdir, url, options
         end
       else


### PR DESCRIPTION
Currently the build dir for mruby is always `#{MRUBY_ROOT}/build/#{@name}`, this commit allows users to customize build dir using the following syntax in `bulid_config.rb`:

``` Ruby
conf.build_dir = "/tmp/mruby-build"
```

The mrbgems checked out using `git` and the generated files will all be redirected to this folder.
