### PR TITLE
Changed use of MRB_INT_MAX to MRB_INT_MAX-1

### DIFF
--- a/src/array.c
+++ b/src/array.c
@@ -19,7 +19,7 @@
 #define ARY_DEFAULT_LEN   4
 #define ARY_SHRINK_RATIO  5 /* must be larger than 2 */
 #define ARY_C_MAX_SIZE (SIZE_MAX / sizeof(mrb_value))
-#define ARY_MAX_SIZE ((ARY_C_MAX_SIZE < (size_t)MRB_INT_MAX) ? (mrb_int)ARY_C_MAX_SIZE : MRB_INT_MAX)
+#define ARY_MAX_SIZE ((ARY_C_MAX_SIZE < (size_t)MRB_INT_MAX) ? (mrb_int)ARY_C_MAX_SIZE : MRB_INT_MAX-1)
 
 static inline mrb_value
 ary_elt(mrb_value ary, mrb_int offset)
@@ -40,7 +40,7 @@ ary_new_capa(mrb_state *mrb, mrb_int capa)
   if (capa > ARY_MAX_SIZE) {
     mrb_raise(mrb, E_ARGUMENT_ERROR, "array size too big");
   }
-  blen = capa * sizeof(mrb_value) ;
+  blen = capa * sizeof(mrb_value);
   if (blen < capa) {
     mrb_raise(mrb, E_ARGUMENT_ERROR, "array size too big");
   }


### PR DESCRIPTION
Comparisons using capa > ARY_MAX_SIZE will always be false if ARY_MAX_SIZE is MRB_INT_MAX. This change reduces ARY_MAX_SIZE by one when it uses MRB_INT_MAX.
