### PR TITLE
Improve Android NDK toolchain support.

### DIFF
--- a/tasks/toolchains/androideabi.rake
+++ b/tasks/toolchains/androideabi.rake
@@ -46,6 +46,8 @@ MRuby::Toolchain.new(:androideabi) do |conf|
       HOST_PLATFORM = 'windows'
     when /darwin/i
       HOST_PLATFORM = 'darwin-x86'
+    when /x86_64-linux/i
+      HOST_PLATFORM = 'linux-x86_64'
     when /linux/i
       HOST_PLATFORM = 'linux-x86'
     else


### PR DESCRIPTION
Linux-x86_64 has not been supported now.
This commit add Linux-x86_64 platform support.
