### PR TITLE
revise the Two White Parts comments in gc.c

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -38,18 +38,23 @@
     * Gray - Marked, But the child objects are unmarked.
     * Black - Marked, the child objects are also marked.
 
-  == Two white part
+  == Two White Types
 
-  The white has a different part of A and B.
-  In sweep phase, the sweep target white is either A or B.
-  The sweep target white is switched just before sweep phase.
-  e.g. A -> B -> A -> B ...
+  There're two white color types in a flip-flop fassion: White-A and White-B,
+  which respectively represent the Current White color (the newly allocated
+  objects in the current round of GC) and the Sweep Target White color (the
+  dead objects to be swept).
 
-  All objects are painted white when allocated.
-  This white is another the sweep target white.
-  For example, if the sweep target white is A, it's B.
-  So objects when allocated in sweep phase will be next sweep phase target.
-  Therefore, these objects will not be released accidentally in sweep phase.
+  A and B will be switched just at the beginning of the next round of GC. At
+  that time, all the dead objects have been swept, while the newly created
+  objects in the current round of GC which finally remains White are now
+  regarded as dead objects. Instead of traversing all the White-A objects and
+  paint them as White-B, just switch the meaning of White-A and White-B would
+  be much cheaper.
+
+  As a result, the objects we sweep in the current round of GC are always
+  left from the previous round of GC. This allows us to sweep objects
+  incrementally, without the disturbance of the newly created objects.
 
   == Execution Timing
 


### PR DESCRIPTION
> The sweep target white is switched just before sweep phase.

In fact the two white colors are switched at the beginning of a round of GC. This PR fixed this description in a full revise of comments.
