### PR TITLE
I replace 'Pre-Conditions' with 'Preconditions' because the former is a ...

### DIFF
--- a/doc/mrbgems/README.md
+++ b/doc/mrbgems/README.md
@@ -156,7 +156,7 @@ the following options additionally inside of your GEM specification:
 mruby can be extended with C. This is possible by using the C API to
 integrate C libraries into mruby.
 
-### Pre-Conditions
+### Preconditions
 
 mrbgems expects that you have implemented a C method called
 `mrb_YOURGEMNAME_gem_init(mrb_state)`. `YOURGEMNAME` will be replaced


### PR DESCRIPTION
...wrong word.

'pre-condition' was not found in:
http://www.ldoceonline.com/spellcheck/?q=pre-condition

'precondition' was found in:
http://www.ldoceonline.com/dictionary/precondition
