### PR TITLE
Fix assignment of block as actual value and not expected

### DIFF
--- a/test/assert.rb
+++ b/test/assert.rb
@@ -101,7 +101,7 @@ end
 
 def assert_equal(arg1, arg2 = nil, arg3 = nil)
   if block_given?
-    exp, act, msg = yield, arg1, arg2
+    exp, act, msg = arg1, yield, arg2
   else
     exp, act, msg = arg1, arg2, arg3
   end
@@ -113,7 +113,7 @@ end
 
 def assert_not_equal(arg1, arg2 = nil, arg3 = nil)
   if block_given?
-    exp, act, msg = yield, arg1, arg2
+    exp, act, msg = arg1, yield, arg2
   else
     exp, act, msg = arg1, arg2, arg3
   end


### PR DESCRIPTION
As mentioned in #1420 the assignment of the block should be the actual value which has to be compared to the expected value in the argument list.
