### PR TITLE
remove the minor GC introduced in clear_all_old(), and introduce prepare_major_gc()

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -1215,6 +1215,7 @@ change_gen_gc_mode(mrb_state *mrb, mrb_int enable)
   if (is_generational(mrb) && !enable) {
     clear_all_old(mrb);
     mrb_assert(mrb->gc_state == GC_STATE_NONE);
+    incremental_gc_until(mrb, GC_STATE_NONE);
     mrb->gc_full = FALSE;
   }
   else if (!is_generational(mrb) && enable) {


### PR DESCRIPTION
1)

```
  if (is_major_gc(mrb)) {
    incremental_gc_until(mrb, GC_STATE_NONE);
  }
```

this snippet from `clear_all_old()` is in fact triggering a MINOR gc if it's `is_major_gc()`. is there any reason on this? 

2)  `clear_all_old()` is pretty precise on what it does, but `prepare_major_gc()` is more descriptive on what its role is.
