### PR TITLE
add mrbc -h option

### DIFF
--- a/tools/mrbc/mrbc.c
+++ b/tools/mrbc/mrbc.c
@@ -117,6 +117,8 @@ parse_args(mrb_state *mrb, int argc, char **argv, struct mrbc_args *args)
       case 'g':
         args->debug_info = 1;
         break;
+      case 'h':
+        return -1;
       case '-':
         if (argv[i][1] == '\n') {
           return i;


### PR DESCRIPTION
I expected, 

``` bash
$ ./bin/mrbc -h
Usage: ./bin/mrbc [switches] programfile
  switches:
  -c           check syntax only
  -o<outfile>  place the output into <outfile>
  -v           print version number, then turn on verbose mode
  -g           produce debugging information
  -B<symbol>   binary <symbol> output in C language format
  --verbose    run at verbose mode
  --version    print the version
  --copyright  print the copyright
```

but cause this show.

``` bash
$ ./bin/mrbc -h
./bin/mrbc: cannot open program file. (-h)
```
