### PR TITLE
End loop if nextc is -1

### DIFF
--- a/src/parse.y
+++ b/src/parse.y
@@ -3704,7 +3704,7 @@ parse_string(parser_state *p)
     char flag[4] = { '\0' };
 
     newtok(p);
-    while (c = nextc(p), ISALPHA(c)) {
+    while (c = nextc(p), c != -1 && ISALPHA(c)) {
       switch (c) {
       case 'i': f |= 1; break;
       case 'x': f |= 2; break;


### PR DESCRIPTION
Found that the following went into a never ending loop when using mirb when compiled with readline support on OSX:

```
"testing" =~ /testing/
```

ISALPHA contains isalpha and that may return true if LOCAL_ALL is not set to C.
