### PR TITLE
Custom build path pulls git gems for every build target

### DIFF
--- a/tasks/mruby_build.rake
+++ b/tasks/mruby_build.rake
@@ -43,7 +43,7 @@ module MRuby
     end
     include Rake::DSL
     include LoadGems
-    attr_accessor :name, :bins, :exts, :file_separator, :build_dir
+    attr_accessor :name, :bins, :exts, :file_separator, :build_dir, :gem_clone_dir
     attr_reader :libmruby, :gems
 
     COMPILERS = %w(cc cxx objc asm)
@@ -64,6 +64,7 @@ module MRuby
 
         @file_separator = '/'
         @build_dir = "#{MRUBY_ROOT}/build/#{@name}"
+        @gem_clone_dir = "#{MRUBY_ROOT}/build/mrbgems"
         @cc = Command::Compiler.new(self, %w(.c))
         @cxx = Command::Compiler.new(self, %w(.cc .cxx .cpp))
         @objc = Command::Compiler.new(self, %w(.m))
@@ -194,8 +195,8 @@ module MRuby
     attr_block %w(test_runner)
 
     def initialize(name, &block)
-	@test_runner = Command::CrossTestRunner.new(self)
-	super
+  @test_runner = Command::CrossTestRunner.new(self)
+  super
     end
 
     def run_test

--- a/tasks/mruby_build_gem.rake
+++ b/tasks/mruby_build_gem.rake
@@ -39,7 +39,7 @@ module MRuby
         gemdir = "#{root}/mrbgems/#{params[:core]}"
       elsif params[:git]
         url = params[:git]
-        gemdir = "#{build_dir}/mrbgems/#{url.match(/([-\w]+)(\.[-\w]+|)$/).to_a[1]}"
+        gemdir = "#{gem_clone_dir}/#{url.match(/([-\w]+)(\.[-\w]+|)$/).to_a[1]}"
 
         if File.exists?(gemdir)
           if $pull_gems
@@ -50,7 +50,7 @@ module MRuby
         else
           options = [params[:options]] || []
           options << "--branch \"#{params[:branch]}\"" if params[:branch]
-          FileUtils.mkdir_p "#{build_dir}/mrbgems"
+          FileUtils.mkdir_p "#{gem_clone_dir}"
           git.run_clone gemdir, url, options
         end
       else


### PR DESCRIPTION
Introduced in #1384, a git based gem will be cloned to the current build target's build directory. 

This works fine but the gem is cloned for every build target, adding a massive overhead when running clean/make regularly.

Is it acceptable to add `gem_clone_dir` as an option to `build_config.rb`, or is it an unnecessary overhead to programmers with a custom build path? (@xxuejie)
