### PR TITLE
fix #1442

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -677,6 +677,10 @@ root_scan_phase(mrb_state *mrb)
   mrb_gc_mark(mrb, (struct RBasic*)mrb->exc);
 
   mark_context(mrb, mrb->root_c);
+  if (mrb->root_c != mrb->c) {
+    mark_context(mrb, mrb->c);
+  }
+
   /* mark irep pool */
   if (mrb->irep) {
     size_t len = mrb->irep_len;


### PR DESCRIPTION
in the marking root phase, we only marked the root context, but leaving
the current context unmarked. when we execute a fiber, the current
context would be changed and trigger this issue.
