### PR TITLE
Decrease size a bit (_Noreturn)

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -160,6 +160,16 @@ typedef struct mrb_state {
   void *ud; /* auxiliary data */
 } mrb_state;
 
+#if __STDC_VERSION__ >= 201112L
+# define mrb_noreturn _Noreturn
+#elif defined __GNUC__ && !defined __STRICT_ANSI__
+# define mrb_noreturn __attribute__((noreturn))
+#elif defined _MSC_VER
+# define mrb_noreturn __declspec(noreturn)
+#else
+# define mrb_noreturn
+#endif
+
 typedef mrb_value (*mrb_func_t)(mrb_state *mrb, mrb_value);
 struct RClass *mrb_define_class(mrb_state *, const char*, struct RClass*);
 struct RClass *mrb_define_module(mrb_state *, const char*);
@@ -315,13 +325,13 @@ mrb_value mrb_obj_clone(mrb_state *mrb, mrb_value self);
 #endif
 
 mrb_value mrb_exc_new(mrb_state *mrb, struct RClass *c, const char *ptr, long len);
-void mrb_exc_raise(mrb_state *mrb, mrb_value exc);
+mrb_noreturn void mrb_exc_raise(mrb_state *mrb, mrb_value exc);
 
-void mrb_raise(mrb_state *mrb, struct RClass *c, const char *msg);
-void mrb_raisef(mrb_state *mrb, struct RClass *c, const char *fmt, ...);
-void mrb_name_error(mrb_state *mrb, mrb_sym id, const char *fmt, ...);
+mrb_noreturn void mrb_raise(mrb_state *mrb, struct RClass *c, const char *msg);
+mrb_noreturn void mrb_raisef(mrb_state *mrb, struct RClass *c, const char *fmt, ...);
+mrb_noreturn void mrb_name_error(mrb_state *mrb, mrb_sym id, const char *fmt, ...);
 void mrb_warn(mrb_state *mrb, const char *fmt, ...);
-void mrb_bug(mrb_state *mrb, const char *fmt, ...);
+mrb_noreturn void mrb_bug(mrb_state *mrb, const char *fmt, ...);
 void mrb_print_backtrace(mrb_state *mrb);
 void mrb_print_error(mrb_state *mrb);
 

--- a/src/error.c
+++ b/src/error.c
@@ -209,7 +209,7 @@ exc_debug_info(mrb_state *mrb, struct RObject *exc)
   }
 }
 
-void
+mrb_noreturn void
 mrb_exc_raise(mrb_state *mrb, mrb_value exc)
 {
   mrb->exc = mrb_obj_ptr(exc);
@@ -221,7 +221,7 @@ mrb_exc_raise(mrb_state *mrb, mrb_value exc)
   mrb_longjmp(mrb);
 }
 
-void
+mrb_noreturn void
 mrb_raise(mrb_state *mrb, struct RClass *c, const char *msg)
 {
   mrb_value mesg;
@@ -283,7 +283,7 @@ mrb_format(mrb_state *mrb, const char *format, ...)
   return str;
 }
 
-void
+mrb_noreturn void
 mrb_raisef(mrb_state *mrb, struct RClass *c, const char *fmt, ...)
 {
   va_list args;
@@ -295,7 +295,7 @@ mrb_raisef(mrb_state *mrb, struct RClass *c, const char *fmt, ...)
   mrb_exc_raise(mrb, mrb_exc_new3(mrb, c, mesg));
 }
 
-void
+mrb_noreturn void
 mrb_name_error(mrb_state *mrb, mrb_sym id, const char *fmt, ...)
 {
   mrb_value exc;
@@ -326,7 +326,7 @@ mrb_warn(mrb_state *mrb, const char *fmt, ...)
 #endif
 }
 
-void
+mrb_noreturn void
 mrb_bug(mrb_state *mrb, const char *fmt, ...)
 {
 #ifdef ENABLE_STDIO

--- a/src/error.h
+++ b/src/error.h
@@ -14,6 +14,6 @@ mrb_value make_exception(mrb_state *mrb, int argc, mrb_value *argv, int isstr);
 mrb_value mrb_make_exception(mrb_state *mrb, int argc, mrb_value *argv);
 mrb_value mrb_format(mrb_state *mrb, const char *format, ...);
 void mrb_exc_print(mrb_state *mrb, struct RObject *exc);
-void mrb_longjmp(mrb_state *mrb);
+mrb_noreturn void mrb_longjmp(mrb_state *mrb);
 
 #endif  /* MRUBY_ERROR_H */

--- a/src/vm.c
+++ b/src/vm.c
@@ -2128,7 +2128,7 @@ mrb_run(mrb_state *mrb, struct RProc *proc, mrb_value self)
   END_DISPATCH;
 }
 
-void
+mrb_noreturn void
 mrb_longjmp(mrb_state *mrb)
 {
   longjmp(*(jmp_buf*)mrb->jmp, 1);


### PR DESCRIPTION
(I'm aware that mruby targets C99 and Microsoft's compiler but I also know it makes use of extensions like label as values/computed goto or enum bit-fields.)

I think `_Noreturn` should be used too because it decreases the size of mruby (although not much) and you don't need to edit mruby's source code to have this desirable advantage. The required changes are small.

Sadly C11 isn't widespread but extensions can be used.

I  suggest a macro called `mrb_noreturn` should be defined under …
C11 as `_Noreturn`
GCC/Clang (w/o `-pedantic`) as `__attribute__ ((noreturn))`
MS as `__declspec(noreturn)`
otherwise it's empty.

For demonstration purposes I only added `_Noreturn` to the declaration of `mrb_longjmp`, `mrb_bug` and `mrb_exc_raise`:

``` bash
$ clang -v
clang version 3.3 (tags/RELEASE_33/final)
Target: x86_64-unknown-linux-gnu
Thread model: posix
$ cat build_config_clang.rb 
MRuby::Build.new { |c|
  toolchain :clang
  c.gembox 'default'
  c.cc.flags = %w(-Os -std=gnu11 -flto)
  c.linker.flags = %w(-flto)
}
```

After `strip -s` each executable's size in bytes was:

| executable | mirb | mrbc | mruby |
| --- | --- | --- | --- |
| default | 363.808 | 296.472 | 372.032 |
| noreturn | 361.280 | 294.760 | 369.456 |
| difference | 2.528 | 1.712 | 2.576 |

I'll open a pull request as soon as this suggestion is accepted.
