### PR TITLE
MSVC: fix warnings

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -494,7 +494,7 @@ mrb_get_args(mrb_state *mrb, const char *format, ...)
         if (i < argc) {
           ss = to_str(mrb, *sp++);
           s = mrb_str_ptr(ss);
-          if (strlen(s->ptr) < s->len) {
+          if ((mrb_int)strlen(s->ptr) < s->len) {
             mrb_raise(mrb, E_ARGUMENT_ERROR, "String contains NUL");
           }
           *ps = s->ptr;

--- a/src/numeric.c
+++ b/src/numeric.c
@@ -200,7 +200,7 @@ mrb_flo_to_str(mrb_state *mrb, mrb_value flo, int max_digit)
       *(c++) = '-';
     }
 
-    exp = log10(n);
+    exp = (int)log10(n);
 
     if ((exp < 0 ? -exp : exp) > max_digit) {
       /* exponent representation */
@@ -223,7 +223,7 @@ mrb_flo_to_str(mrb_state *mrb, mrb_value flo, int max_digit)
     /* puts digits */
     while (max_digit >= 0) {
       mrb_float weight = pow(10.0, m);
-      digit = floor(n / weight + FLT_EPSILON);
+      digit = (int)floor(n / weight + FLT_EPSILON);
       *(c++) = '0' + digit;
       n -= (digit * weight);
       max_digit--;


### PR DESCRIPTION
```
class.c(497) : warning C4018: '<' : signed/unsigned mismatch
numeric.c(203) : warning C4244: '=' : conversion from 'double' to 'int', possible loss of data
numeric.c(226) : warning C4244: '=' : conversion from 'double' to 'int', possible loss of data
```
