### PR TITLE
turn off generational gc mode by default.

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -334,8 +334,6 @@ mrb_init_heap(mrb_state *mrb)
   add_heap(mrb);
   mrb->gc_interval_ratio = DEFAULT_GC_INTERVAL_RATIO;
   mrb->gc_step_ratio = DEFAULT_GC_STEP_RATIO;
-  mrb->is_generational_gc_mode = TRUE;
-  mrb->gc_full = TRUE;
 
 #ifdef GC_PROFILE
   program_invoke_time = gettimeofday_time();


### PR DESCRIPTION
in the current implementation, `bin/mruby -e "puts GC.generational_mode"` would result `true`.

currently the Generational Mode is based on Tri-color infrastructure and experimental, it's promising, but it's might not our current default choice.

in theory, the Tri-color GC offers controllable latency, but longer the GC cycle, so more memory would be consumed overally; Generational GC shortens the GC cycle, so less memory consumption, offers longer latency but better overall performance.

but in the current implementation, GC will traverse all the heap slots in the sweep phase, which downgrade the performance of Generational GC. we might have to make more optimization on this before making it default.
