### PR TITLE
fix bison 3.0 warning

### DIFF
--- a/src/parse.y
+++ b/src/parse.y
@@ -933,7 +933,7 @@ heredoc_end(parser_state *p)
 
 %}
 
-%pure_parser
+%pure-parser
 %parse-param {parser_state *p}
 %lex-param {parser_state *p}
 


### PR DESCRIPTION
```
YACC  src/parse.y -> build/host/src/y.tab.c
src/parse.y:936.1-12: warning: deprecated directive, use ‘%pure-parser’ [-Wdeprecated]
 %pure_parser
 ^^^^^^^^^^^^
```

This change is compatible with older versions like 2.4.2.
