### PR TITLE
add comments for major GC

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -88,6 +88,9 @@
 
     * Major GC - same as a full regular GC cycle.
 
+  the difference between "tranditional" generational GC is that, the major GC
+  in mruby is triggered incrementally in a tri-color manner.
+
 
   For details, see the comments for each function.
 
@@ -944,6 +947,7 @@ clear_all_old(mrb_state *mrb)
 
   mrb_assert(is_generational(mrb));
   if (is_major_gc(mrb)) {
+    /* finish the half baked GC */
     incremental_gc_until(mrb, GC_STATE_NONE);
   }
 


### PR DESCRIPTION
it seems that the designed behavior of mruby's major GC in generational mode is triggered incrementally like a regular tri-color GC cycle.

so we can conclude that it's necessary to finish the half baked GC in advance in `clear_all_old()` if it's a major GC.
