### PR TITLE
clean up the warnings when GC_PROFILE is set

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -147,9 +147,9 @@ gettimeofday_time(void)
   gc_time = gettimeofday_time() - gc_time;\
   gc_total_time += gc_time;\
   fprintf(stderr, "gc_state: %d\n", mrb->gc_state);\
-  fprintf(stderr, "live: %d\n", mrb->live);\
-  fprintf(stderr, "majorgc_old_threshold: %d\n", mrb->majorgc_old_threshold);\
-  fprintf(stderr, "gc_threshold: %d\n", mrb->gc_threshold);\
+  fprintf(stderr, "live: %zu\n", mrb->live);\
+  fprintf(stderr, "majorgc_old_threshold: %zu\n", mrb->majorgc_old_threshold);\
+  fprintf(stderr, "gc_threshold: %zu\n", mrb->gc_threshold);\
   fprintf(stderr, "gc_time: %30.20f\n", gc_time);\
   fprintf(stderr, "gc_total_time: %30.20f\n\n", gc_total_time);\
 } while(0)


### PR DESCRIPTION
it would be a good practice to printf `size_t` with `%zu`

```
CC    src/gc.c -> build/host/src/gc.o
/home/liyazhou/code/mruby/src/gc.c: In function ‘mrb_incremental_gc’:
/home/liyazhou/code/mruby/src/gc.c:999:3: warning: format ‘%d’ expects argument of type ‘int’, but argument 3 has type ‘size_t’ [-Wformat]
/home/liyazhou/code/mruby/src/gc.c:999:3: warning: format ‘%d’ expects argument of type ‘int’, but argument 3 has type ‘size_t’ [-Wformat]
/home/liyazhou/code/mruby/src/gc.c:999:3: warning: format ‘%d’ expects argument of type ‘int’, but argument 3 has type ‘size_t’ [-Wformat]
/home/liyazhou/code/mruby/src/gc.c: In function ‘mrb_full_gc’:
/home/liyazhou/code/mruby/src/gc.c:1028:3: warning: format ‘%d’ expects argument of type ‘int’, but argument 3 has type ‘size_t’ [-Wformat]
/home/liyazhou/code/mruby/src/gc.c:1028:3: warning: format ‘%d’ expects argument of type ‘int’, but argument 3 has type ‘size_t’ [-Wformat]
/home/liyazhou/code/mruby/src/gc.c:1028:3: warning: format ‘%d’ expects argument of type ‘int’, but argument 3 has type ‘size_t’ [-Wformat]
```
