### PR TITLE
Silence 'unused parameter' warnings in value.h

### DIFF
--- a/include/mruby/value.h
+++ b/include/mruby/value.h
@@ -292,8 +292,8 @@ typedef struct mrb_value {
 static inline mrb_value
 mrb_float_value(struct mrb_state *mrb, mrb_float f)
 {
-  (void) mrb;
   mrb_value v;
+  (void) mrb;
 
   MRB_SET_VALUE(v, MRB_TT_FLOAT, value.f, f);
   return v;
@@ -446,8 +446,8 @@ mrb_voidp_value(struct mrb_state *mrb, void *p);
 static inline mrb_value
 mrb_voidp_value(struct mrb_state *mrb, void *p)
 {
-  (void) mrb;
   mrb_value v;
+  (void) mrb;
 
   MRB_SET_VALUE(v, MRB_TT_VOIDP, value.p, p);
   return v;


### PR DESCRIPTION
These warnings come up for me when compiling with g++.
