### PR TITLE
I implement super in aliased methods.

### DIFF
--- a/include/mruby/proc.h
+++ b/include/mruby/proc.h
@@ -40,8 +40,8 @@ struct RProc {
 #define MRB_ASPEC_KDICT(a)        ((a) & (1<<1))
 #define MRB_ASPEC_BLOCK(a)        ((a) & 1)
 
-#define MRB_PROC_METHOD_ALIAS 64
-#define MRB_PROC_METHOD_ALIAS_P(p) (((p)->flags & MRB_PROC_METHOD_ALIAS) != 0)
+#define MRB_PROC_ALIAS_METHOD 64
+#define MRB_PROC_ALIAS_METHOD_P(p) (((p)->flags & MRB_PROC_ALIAS_METHOD) != 0)
 #define MRB_PROC_CFUNC 128
 #define MRB_PROC_CFUNC_P(p) (((p)->flags & MRB_PROC_CFUNC) != 0)
 #define MRB_PROC_STRICT 256

--- a/include/mruby/proc.h
+++ b/include/mruby/proc.h
@@ -28,6 +28,7 @@ struct RProc {
   } body;
   struct RClass *target_class;
   struct REnv *env;
+  mrb_sym org_mid;              /* Original method */
 };
 
 /* aspec access */
@@ -39,6 +40,8 @@ struct RProc {
 #define MRB_ASPEC_KDICT(a)        ((a) & (1<<1))
 #define MRB_ASPEC_BLOCK(a)        ((a) & 1)
 
+#define MRB_PROC_METHOD_ALIAS 64
+#define MRB_PROC_METHOD_ALIAS_P(p) (((p)->flags & MRB_PROC_METHOD_ALIAS) != 0)
 #define MRB_PROC_CFUNC 128
 #define MRB_PROC_CFUNC_P(p) (((p)->flags & MRB_PROC_CFUNC) != 0)
 #define MRB_PROC_STRICT 256

--- a/src/class.c
+++ b/src/class.c
@@ -1339,7 +1339,7 @@ mrb_alias_method(mrb_state *mrb, struct RClass *c, mrb_sym new, mrb_sym org)
   struct RProc *m = mrb_method_search(mrb, c, org);
 
   m->org_mid = org;
-  m->flags |= MRB_PROC_METHOD_ALIAS;
+  m->flags |= MRB_PROC_ALIAS_METHOD;
   mrb_define_method_vm(mrb, c, new, mrb_obj_value(m));
 }
 

--- a/src/class.c
+++ b/src/class.c
@@ -55,7 +55,7 @@ mrb_name_class(mrb_state *mrb, struct RClass *c, mrb_sym name)
   mrb_obj_iv_set(mrb, (struct RObject*)c,
                  mrb_intern2(mrb, "__classid__", 11), mrb_symbol_value(name));
 }
-                                
+
 #define make_metaclass(mrb, c) prepare_singleton_class((mrb), (struct RBasic*)(c))
 
 static void
@@ -1334,11 +1334,13 @@ mrb_obj_class(mrb_state *mrb, mrb_value obj)
 }
 
 void
-mrb_alias_method(mrb_state *mrb, struct RClass *c, mrb_sym a, mrb_sym b)
+mrb_alias_method(mrb_state *mrb, struct RClass *c, mrb_sym new, mrb_sym org)
 {
-  struct RProc *m = mrb_method_search(mrb, c, b);
+  struct RProc *m = mrb_method_search(mrb, c, org);
 
-  mrb_define_method_vm(mrb, c, a, mrb_obj_value(m));
+  m->org_mid = org;
+  m->flags |= MRB_PROC_METHOD_ALIAS;
+  mrb_define_method_vm(mrb, c, new, mrb_obj_value(m));
 }
 
 /*!

--- a/src/vm.c
+++ b/src/vm.c
@@ -1032,7 +1032,7 @@ mrb_run(mrb_state *mrb, struct RProc *proc, mrb_value self)
       recv = regs[0];
       c = mrb->c->ci->target_class->super;
       method = mrb_method_search_vm(mrb, &mrb->c->ci->target_class, mid);
-      if (MRB_PROC_METHOD_ALIAS_P(method)) {
+      if (MRB_PROC_ALIAS_METHOD_P(method)) {
         /* Change an original method name from an aliased method name */
         mid = method->org_mid;
       }

--- a/src/vm.c
+++ b/src/vm.c
@@ -1024,12 +1024,18 @@ mrb_run(mrb_state *mrb, struct RProc *proc, mrb_value self)
       mrb_callinfo *ci = mrb->c->ci;
       struct RProc *m;
       struct RClass *c;
+      struct RProc *method;
       mrb_sym mid = ci->mid;
       int a = GETARG_A(i);
       int n = GETARG_C(i);
 
       recv = regs[0];
       c = mrb->c->ci->target_class->super;
+      method = mrb_method_search_vm(mrb, &mrb->c->ci->target_class, mid);
+      if (MRB_PROC_METHOD_ALIAS_P(method)) {
+        /* Change an original method name from an aliased method name */
+        mid = method->org_mid;
+      }
       m = mrb_method_search_vm(mrb, &c, mid);
       if (!m) {
         mid = mrb_intern2(mrb, "method_missing", 14);


### PR DESCRIPTION
This test code super-in-aliased-method.rb:

``` ruby
class Name

  def name
    return "super-name"
  end

end

class Human < Name

  def name
    return "James-#{super}"
  end

  alias get_name name
  # Or
  #alias_method :get_name, :name
end

human = Human.new
puts "name:#{human.name}\n"
puts "get_name:#{human.get_name}\n"
```

Don't impelment super in aliased methods:

```
$ mruby super-in-aliased-method.rb 
name:James-super-name
trace:
    [1] super-in-aliased-method.rb:12:in Human.get_name
    [0] super-in-aliased-method.rb:22
super-in-aliased-method.rb:12: undefined method 'get_name' for #<Human:0x7fdfc4006470> (NoMethodError)
```

This issue is that super call get_name method of super class in aliased method.
Correctly super should call name method.

Impelment super in aliased methods:

```
$ mruby super-in-aliased-method.rb 
name:James-super-name
get_name:James-super-name
```

super calls name method.
