### PR TITLE
I fix ISO no in String class in comparison with ISO_IEC_30170_2012(E)

### DIFF
--- a/src/string.c
+++ b/src/string.c
@@ -2347,47 +2347,47 @@ mrb_str_dump(mrb_state *mrb, mrb_value str)
         *q++ = '\\';
         *q++ = 'n';
         break;
-    
+
       case '\r':
         *q++ = '\\';
         *q++ = 'r';
         break;
-    
+
       case '\t':
         *q++ = '\\';
         *q++ = 't';
         break;
-    
+
       case '\f':
         *q++ = '\\';
         *q++ = 'f';
         break;
-    
+
       case '\013':
         *q++ = '\\';
         *q++ = 'v';
         break;
-    
+
       case '\010':
         *q++ = '\\';
         *q++ = 'b';
         break;
-    
+
       case '\007':
         *q++ = '\\';
         *q++ = 'a';
         break;
-    
+
       case '\033':
         *q++ = '\\';
         *q++ = 'e';
         break;
-    
+
       case '#':
         if (IS_EVSTR(p, pend)) *q++ = '\\';
         *q++ = '#';
         break;
-  
+
       default:
         if (ISPRINT(c)) {
           *q++ = c;
@@ -2527,13 +2527,13 @@ mrb_init_string(mrb_state *mrb)
   MRB_SET_INSTANCE_TT(s, MRB_TT_STRING);
   mrb_include_module(mrb, s, mrb_class_get(mrb, "Comparable"));
 
-  mrb_define_method(mrb, s, "+",               mrb_str_plus_m,          MRB_ARGS_REQ(1)); /* 15.2.10.5.2  */
+
   mrb_define_method(mrb, s, "bytesize",        mrb_str_bytesize,        MRB_ARGS_NONE());
-  mrb_define_method(mrb, s, "size",            mrb_str_size,            MRB_ARGS_NONE()); /* 15.2.10.5.33 */
-  mrb_define_method(mrb, s, "length",          mrb_str_size,            MRB_ARGS_NONE()); /* 15.2.10.5.26 */
-  mrb_define_method(mrb, s, "*",               mrb_str_times,           MRB_ARGS_REQ(1)); /* 15.2.10.5.1  */
-  mrb_define_method(mrb, s, "<=>",             mrb_str_cmp_m,           MRB_ARGS_REQ(1)); /* 15.2.10.5.3  */
-  mrb_define_method(mrb, s, "==",              mrb_str_equal_m,         MRB_ARGS_REQ(1)); /* 15.2.10.5.4  */
+
+  mrb_define_method(mrb, s, "<=>",             mrb_str_cmp_m,           MRB_ARGS_REQ(1)); /* 15.2.10.5.1  */
+  mrb_define_method(mrb, s, "==",              mrb_str_equal_m,         MRB_ARGS_REQ(1)); /* 15.2.10.5.2  */
+  mrb_define_method(mrb, s, "+",               mrb_str_plus_m,          MRB_ARGS_REQ(1)); /* 15.2.10.5.4  */
+  mrb_define_method(mrb, s, "*",               mrb_str_times,           MRB_ARGS_REQ(1)); /* 15.2.10.5.5  */
   mrb_define_method(mrb, s, "[]",              mrb_str_aref_m,          MRB_ARGS_ANY());  /* 15.2.10.5.6  */
   mrb_define_method(mrb, s, "capitalize",      mrb_str_capitalize,      MRB_ARGS_NONE()); /* 15.2.10.5.7  */
   mrb_define_method(mrb, s, "capitalize!",     mrb_str_capitalize_bang, MRB_ARGS_REQ(1)); /* 15.2.10.5.8  */
@@ -2552,17 +2552,19 @@ mrb_init_string(mrb_state *mrb)
   mrb_define_method(mrb, s, "initialize",      mrb_str_init,            MRB_ARGS_REQ(1)); /* 15.2.10.5.23 */
   mrb_define_method(mrb, s, "initialize_copy", mrb_str_replace,         MRB_ARGS_REQ(1)); /* 15.2.10.5.24 */
   mrb_define_method(mrb, s, "intern",          mrb_str_intern,          MRB_ARGS_NONE()); /* 15.2.10.5.25 */
+  mrb_define_method(mrb, s, "length",          mrb_str_size,            MRB_ARGS_NONE()); /* 15.2.10.5.26 */
   mrb_define_method(mrb, s, "replace",         mrb_str_replace,         MRB_ARGS_REQ(1)); /* 15.2.10.5.28 */
   mrb_define_method(mrb, s, "reverse",         mrb_str_reverse,         MRB_ARGS_NONE()); /* 15.2.10.5.29 */
   mrb_define_method(mrb, s, "reverse!",        mrb_str_reverse_bang,    MRB_ARGS_NONE()); /* 15.2.10.5.30 */
   mrb_define_method(mrb, s, "rindex",          mrb_str_rindex_m,        MRB_ARGS_ANY());  /* 15.2.10.5.31 */
+  mrb_define_method(mrb, s, "size",            mrb_str_size,            MRB_ARGS_NONE()); /* 15.2.10.5.33 */
   mrb_define_method(mrb, s, "slice",           mrb_str_aref_m,          MRB_ARGS_ANY());  /* 15.2.10.5.34 */
   mrb_define_method(mrb, s, "split",           mrb_str_split_m,         MRB_ARGS_ANY());  /* 15.2.10.5.35 */
 
-  mrb_define_method(mrb, s, "to_i",            mrb_str_to_i,            MRB_ARGS_ANY());  /* 15.2.10.5.38 */
-  mrb_define_method(mrb, s, "to_f",            mrb_str_to_f,            MRB_ARGS_NONE()); /* 15.2.10.5.39 */
+  mrb_define_method(mrb, s, "to_f",            mrb_str_to_f,            MRB_ARGS_NONE()); /* 15.2.10.5.38 */
+  mrb_define_method(mrb, s, "to_i",            mrb_str_to_i,            MRB_ARGS_ANY());  /* 15.2.10.5.39 */
   mrb_define_method(mrb, s, "to_s",            mrb_str_to_s,            MRB_ARGS_NONE()); /* 15.2.10.5.40 */
-  mrb_define_method(mrb, s, "to_str",          mrb_str_to_s,            MRB_ARGS_NONE()); /* 15.2.10.5.40 */
+  mrb_define_method(mrb, s, "to_str",          mrb_str_to_s,            MRB_ARGS_NONE());
   mrb_define_method(mrb, s, "to_sym",          mrb_str_intern,          MRB_ARGS_NONE()); /* 15.2.10.5.41 */
   mrb_define_method(mrb, s, "upcase",          mrb_str_upcase,          MRB_ARGS_REQ(1)); /* 15.2.10.5.42 */
   mrb_define_method(mrb, s, "upcase!",         mrb_str_upcase_bang,     MRB_ARGS_REQ(1)); /* 15.2.10.5.43 */

--- a/test/t/string.rb
+++ b/test/t/string.rb
@@ -9,15 +9,7 @@ assert('String superclass', '15.2.10.2') do
   assert_equal Object, String.superclass
 end
 
-assert('String#*', '15.2.10.5.1') do
-  assert_equal 'aaaaa', 'a' * 5
-end
-
-assert('String#+', '15.2.10.5.2') do
-  assert_equal 'ab', 'a' + 'b'
-end
-
-assert('String#<=>', '15.2.10.5.3') do
+assert('String#<=>', '15.2.10.5.1') do
   a = '' <=> ''
   b = '' <=> 'not empty'
   c = 'not empty' <=> ''
@@ -31,9 +23,17 @@ assert('String#<=>', '15.2.10.5.3') do
   assert_equal  1, e
 end
 
-assert('String#==', '15.2.10.5.4') do
+assert('String#==', '15.2.10.5.2') do
   assert_equal 'abc', 'abc'
   assert_not_equal 'abc', 'cba'
+end
+
+assert('String#+', '15.2.10.5.4') do
+  assert_equal 'ab', 'a' + 'b'
+end
+
+assert('String#*', '15.2.10.5.5') do
+  assert_equal 'aaaaa', 'a' * 5
 end
 
 # 'String#=~', '15.2.10.5.5' will be tested in mrbgems.
@@ -396,8 +396,17 @@ assert('String#sub!', '15.2.10.5.37') do
   assert_equal 'aBcabc', b
 end
 
+assert('String#to_f', '15.2.10.5.38') do
+  a = ''.to_f
+  b = '123456789'.to_f
+  c = '12345.6789'.to_f
 
-assert('String#to_i', '15.2.10.5.38') do
+  assert_float(0.0, a)
+  assert_float(123456789.0, b)
+  assert_float(12345.6789, c)
+end
+
+assert('String#to_i', '15.2.10.5.39') do
   a = ''.to_i
   b = '32143'.to_i
   c = 'a'.to_i(16)
@@ -407,16 +416,6 @@ assert('String#to_i', '15.2.10.5.38') do
   assert_equal 32143, b
   assert_equal 10, c
   assert_equal 4, d
-end
-
-assert('String#to_f', '15.2.10.5.39') do
-  a = ''.to_f
-  b = '123456789'.to_f
-  c = '12345.6789'.to_f
-
-  assert_float(0.0, a)
-  assert_float(123456789.0, b)
-  assert_float(12345.6789, c)
 end
 
 assert('String#to_s', '15.2.10.5.40') do


### PR DESCRIPTION
I fix ISO no in String class in comparison with ISO_IEC_30170_2012(E)-Charactor_PDF_document.pdf

ISO no:

``` ruby
15.2.10.5.1 String#<=>
15.2.10.5.2 String#==
15.2.10.5.4 String#+
15.2.10.5.5 String#*
15.2.10.5.38 String#to_f
15.2.10.5.39 String#to_i
```

Not ISO:

``` ruby
String#to_str
```

String#to_s is ISO spec but String#to_str is not ISO.
