### PR TITLE
fix #1459

### DIFF
--- a/src/codegen.c
+++ b/src/codegen.c
@@ -959,6 +959,9 @@ gen_vmassignment(codegen_scope *s, node *tree, int rhs, int val)
       }
     }
   }
+  else {
+    pop();
+  }
 }
 
 static void


### PR DESCRIPTION
gen_vmassignment() missed a pop() in a conditional branch, but we have
to keep each conditional branch 's stack depth the same all the time
when it left execution.
