### PR TITLE
I add ISO Upper-case and lower-case characters '15.2.10.4' test.

### DIFF
--- a/test/t/string.rb
+++ b/test/t/string.rb
@@ -14,16 +14,12 @@ assert('Upper-case and lower-case characters', '15.2.10.4') do
   lower_case = "abcdefghijklmnopqrstuvwxyz"
   up_case =    "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
-  i = 0
-  ALPHABET_NUM.times do
+  ALPHABET_NUM.times do |i|
     assert_equal lower_case[i], up_case[i].downcase
-    i += 1
   end
 
-  i = 0
-  ALPHABET_NUM.times do
+  ALPHABET_NUM.times do |i|
     assert_equal up_case[i], lower_case[i].upcase
-    i += 1
   end
 
   true  # If not, it causes KO


### PR DESCRIPTION
ISO 15.2.10.4 Upper-case and lower-case characters

The correspondence between upper-case and lower-case characters is given in Table A.

Table A.

| upper-case characters | lower-case characters |
| :-: | :-: |
| A | a |
| B | b |
| C | c |
| D | d |
| E | e |
| F | f |
| G | g |
| H | h |
| I | i |
| J | j |
| K | k |
| L | l |
| M | m |
| N | n |
| O | o |
| P | p |
| Q | q |
| R | r |
| S | s |
| T | t |
| U | u |
| V | v |
| W | w |
| X | x |
| Y | y |
| Z | z |
