### PR TITLE
Adding line numbers to the output of mirb.

### DIFF
--- a/mrbgems/mruby-bin-mirb/tools/mirb/mirb.c
+++ b/mrbgems/mruby-bin-mirb/tools/mirb/mirb.c
@@ -275,6 +275,7 @@ main(int argc, char **argv)
 
   cxt = mrbc_context_new(mrb);
   cxt->capture_errors = 1;
+  cxt->lineno = 1;
   mrbc_filename(mrb, cxt, "(mirb)");
   if (args.verbose) cxt->dump_result = 1;
 
@@ -346,7 +347,7 @@ main(int argc, char **argv)
     parser = mrb_parser_new(mrb);
     parser->s = ruby_code;
     parser->send = ruby_code + strlen(ruby_code);
-    parser->lineno = 1;
+    parser->lineno = cxt->lineno;
     mrb_parser_parse(parser, cxt);
     code_block_open = is_code_block_open(parser);
 
@@ -385,6 +386,7 @@ main(int argc, char **argv)
       mrb_gc_arena_restore(mrb, ai);
     }
     mrb_parser_free(parser);
+    cxt->lineno++;
   }
   mrbc_context_free(mrb, cxt);
   mrb_close(mrb);

--- a/src/parse.y
+++ b/src/parse.y
@@ -5167,7 +5167,6 @@ mrbc_filename(mrb_state *mrb, mrbc_context *c, const char *s)
 
     memcpy(p, s, len + 1);
     c->filename = p;
-    c->lineno = 1;
   }
   return c->filename;
 }


### PR DESCRIPTION
Before:

```
> "hi"
hi
> d
(mirb):1: undefined method 'd' for main (NoMethodError)
> d
(mirb):1: undefined method 'd' for main (NoMethodError)
> "hi"
hi
> "#{'}"
line 1: unterminated string meets end of file
```

After

```
> "hi"
hi
> d
(mirb):2: undefined method 'd' for main (NoMethodError)
> d
(mirb):3: undefined method 'd' for main (NoMethodError)
> "hi"
hi
> "#{'}"
line 5: unterminated string meets end of file
```
