### PR TITLE
Removed unnecessary #undef ISPRINT in include/mruby.h

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -302,7 +302,6 @@ mrb_value mrb_obj_clone(mrb_state *mrb, mrb_value self);
 #ifndef ISPRINT
 //#define ISASCII(c) isascii((int)(unsigned char)(c))
 #define ISASCII(c) 1
-#undef ISPRINT
 #define ISPRINT(c) (ISASCII(c) && isprint((int)(unsigned char)(c)))
 #define ISSPACE(c) (ISASCII(c) && isspace((int)(unsigned char)(c)))
 #define ISUPPER(c) (ISASCII(c) && isupper((int)(unsigned char)(c)))


### PR DESCRIPTION
At line 302 in include/mruby.h we check if `ISPRINT` is not defined, then at line 305 we `#undef ISPRINT`

```
/* need to include <ctype.h> to use these macros */
#ifndef ISPRINT
//#define ISASCII(c) isascii((int)(unsigned char)(c))
#define ISASCII(c) 1
#undef ISPRINT
#define ISPRINT(c) (ISASCII(c) && isprint((int)(unsigned char)(c)))
#define ISSPACE(c) (ISASCII(c) && isspace((int)(unsigned char)(c)))
#define ISUPPER(c) (ISASCII(c) && isupper((int)(unsigned char)(c)))
#define ISLOWER(c) (ISASCII(c) && islower((int)(unsigned char)(c)))
#define ISALNUM(c) (ISASCII(c) && isalnum((int)(unsigned char)(c)))
#define ISALPHA(c) (ISASCII(c) && isalpha((int)(unsigned char)(c)))
#define ISDIGIT(c) (ISASCII(c) && isdigit((int)(unsigned char)(c)))
#define ISXDIGIT(c) (ISASCII(c) && isxdigit((int)(unsigned char)(c)))
#define TOUPPER(c) (ISASCII(c) ? toupper((int)(unsigned char)(c)) : (c))
#define TOLOWER(c) (ISASCII(c) ? tolower((int)(unsigned char)(c)) : (c))
#endif
```

Maybe I'm missing something but it sounds suspect to me: perhaps line 305 should be removed?
