### PR TITLE
MSVC: compilation works again (+minor style fixes)

### DIFF
--- a/include/mruby/debug.h
+++ b/include/mruby/debug.h
@@ -1,12 +1,15 @@
+/*
+** mruby/debug.h - mruby debug info
+**
+** See Copyright Notice in mruby.h
+*/
+
 #ifndef MRUBY_DEBUG_H
 #define MRUBY_DEBUG_H
 
 #if defined(__cplusplus)
 extern "C" {
 #endif
-
-#include <stdint.h>
-#include "mruby/value.h"
 
 typedef enum mrb_debug_line_type {
   mrb_debug_line_ary = 0,
@@ -20,43 +23,40 @@ typedef struct mrb_irep_debug_info_line {
 
 typedef struct mrb_irep_debug_info_file {
   uint32_t start_pos;
-  char const* filename;
+  const char *filename;
   mrb_sym filename_sym;
   uint32_t line_entry_count;
   mrb_debug_line_type line_type;
   union {
-    void* line_ptr;
-    mrb_irep_debug_info_line* line_flat_map;
-    uint16_t* line_ary;
+    void *line_ptr;
+    mrb_irep_debug_info_line *line_flat_map;
+    uint16_t *line_ary;
   };
 } mrb_irep_debug_info_file;
 
 typedef struct mrb_irep_debug_info {
   uint32_t pc_count;
   uint16_t flen;
-  mrb_irep_debug_info_file** files;
+  mrb_irep_debug_info_file **files;
 } mrb_irep_debug_info;
-
-struct mrb_irep;
-struct mrb_state;
 
 /*
  * get line from irep's debug info and program counter
  * @return returns NULL if not found
  */
-char const* mrb_debug_get_filename(struct mrb_irep* irep, uint32_t pc);
+const char *mrb_debug_get_filename(mrb_irep *irep, uint32_t pc);
 
 /*
  * get line from irep's debug info and program counter
  * @return returns -1 if not found
  */
-int32_t mrb_debug_get_line(struct mrb_irep* irep, uint32_t pc);
+int32_t mrb_debug_get_line(mrb_irep *irep, uint32_t pc);
 
-mrb_irep_debug_info_file* mrb_debug_info_append_file(
-    struct mrb_state* mrb, struct mrb_irep* irep,
+mrb_irep_debug_info_file *mrb_debug_info_append_file(
+    mrb_state *mrb, mrb_irep *irep,
     uint32_t start_pos, uint32_t end_pos);
-mrb_irep_debug_info* mrb_debug_info_alloc(struct mrb_state* mrb, struct mrb_irep* irep);
-void mrb_debug_info_free(struct mrb_state* mrb, mrb_irep_debug_info* d);
+mrb_irep_debug_info *mrb_debug_info_alloc(mrb_state *mrb, mrb_irep *irep);
+void mrb_debug_info_free(mrb_state *mrb, mrb_irep_debug_info *d);
 
 #if defined(__cplusplus)
 }  /* extern "C" { */

--- a/src/load.c
+++ b/src/load.c
@@ -300,51 +300,60 @@ error_exit:
   return result;
 }
 
-static int read_rite_debug_record(mrb_state* mrb, uint8_t const *start, size_t irepno, uint32_t *len, mrb_sym const* filenames, size_t filenames_len) {
-  uint8_t const* bin = start;
-
-  mrb_irep* const irep = mrb->irep[irepno];
+static int
+read_rite_debug_record(mrb_state *mrb, const uint8_t *start, size_t irepno, uint32_t *len, const mrb_sym *filenames, size_t filenames_len)
+{
+  const uint8_t *bin = start;
+  mrb_irep *irep = mrb->irep[irepno];
+  size_t record_size;
+  uint16_t f_idx;
 
   if(irep->debug_info) { return MRB_DUMP_INVALID_IREP; }
 
   irep->debug_info = (mrb_irep_debug_info*)mrb_malloc(mrb, sizeof(mrb_irep_debug_info));
   irep->debug_info->pc_count = irep->ilen;
 
-  size_t const record_size = bin_to_uint32(bin); bin += sizeof(uint32_t);
+  record_size = bin_to_uint32(bin);
+  bin += sizeof(uint32_t);
 
   irep->debug_info->flen = bin_to_uint16(bin);
   irep->debug_info->files = (mrb_irep_debug_info_file**)mrb_malloc(mrb, sizeof(mrb_irep_debug_info*) * irep->debug_info->flen);
   bin += sizeof(uint16_t);
 
-  uint16_t f_idx;
   for (f_idx = 0; f_idx < irep->debug_info->flen; ++f_idx) {
-    mrb_irep_debug_info_file* const file = (mrb_irep_debug_info_file*)mrb_malloc(mrb, sizeof(mrb_irep_debug_info_file));
+    mrb_irep_debug_info_file *file;
+    uint16_t filename_idx;
+    size_t len;
+
+    file = (mrb_irep_debug_info_file *)mrb_malloc(mrb, sizeof(*file));
     irep->debug_info->files[f_idx] = file;
 
     file->start_pos = bin_to_uint32(bin); bin += sizeof(uint32_t);
 
     // filename
-    uint16_t const filename_idx = bin_to_uint16(bin);
+    filename_idx = bin_to_uint16(bin);
     bin += sizeof(uint16_t);
     mrb_assert(filename_idx < filenames_len);
     file->filename_sym = filenames[filename_idx];
-    size_t len = 0;
+    len = 0;
     file->filename = mrb_sym2name_len(mrb, file->filename_sym, &len);
 
     file->line_entry_count = bin_to_uint32(bin); bin += sizeof(uint32_t);
     file->line_type = bin_to_uint8(bin); bin += sizeof(uint8_t);
     switch(file->line_type) {
       case mrb_debug_line_ary: {
-        file->line_ary = mrb_malloc(mrb, sizeof(uint16_t) * file->line_entry_count);
         size_t l;
+
+        file->line_ary = (uint16_t *)mrb_malloc(mrb, sizeof(uint16_t) * file->line_entry_count);
         for(l = 0; l < file->line_entry_count; ++l) {
           file->line_ary[l] = bin_to_uint16(bin); bin += sizeof(uint16_t);
         }
       } break;
 
       case mrb_debug_line_flat_map: {
-        file->line_flat_map = mrb_malloc(mrb, sizeof(mrb_irep_debug_info_line) * file->line_entry_count);
         size_t l;
+
+        file->line_flat_map = mrb_malloc(mrb, sizeof(mrb_irep_debug_info_line) * file->line_entry_count);
         for(l = 0; l < file->line_entry_count; ++l) {
           file->line_flat_map[l].start_pos = bin_to_uint32(bin); bin += sizeof(uint32_t);
           file->line_flat_map[l].line = bin_to_uint16(bin); bin += sizeof(uint16_t);
@@ -365,24 +374,29 @@ static int read_rite_debug_record(mrb_state* mrb, uint8_t const *start, size_t i
 }
 
 static int
-read_rite_section_debug(mrb_state* mrb, const uint8_t* start, size_t sirep)
+read_rite_section_debug(mrb_state *mrb, const uint8_t *start, size_t sirep)
 {
-  uint8_t const* bin = start;
-  struct rite_section_debug_header const* header = (struct rite_section_debug_header const*)bin;
-  bin += sizeof(struct rite_section_debug_header);
+  const uint8_t *bin;
+  struct rite_section_debug_header *header;
   uint16_t i;
-
   int result;
+  uint16_t nirep;
+  size_t filenames_len;
+  mrb_sym *filenames;
 
-  uint16_t const nirep = bin_to_uint16(header->nirep);
+  bin = start;
+  header = (struct rite_section_debug_header *)bin;
+  bin += sizeof(struct rite_section_debug_header);
 
-  size_t const filenames_len = bin_to_uint16(bin);
+  nirep = bin_to_uint16(header->nirep);
+
+  filenames_len = bin_to_uint16(bin);
   bin += sizeof(uint16_t);
-  mrb_sym* filenames = (mrb_sym*)mrb_malloc(mrb, sizeof(mrb_sym*) * filenames_len);
+  filenames = (mrb_sym*)mrb_malloc(mrb, sizeof(mrb_sym*) * filenames_len);
   for(i = 0; i < filenames_len; ++i) {
-    uint16_t const f_len = bin_to_uint16(bin);
+    uint16_t f_len = bin_to_uint16(bin);
     bin += sizeof(uint16_t);
-    filenames[i] = mrb_intern2(mrb, (char const*)bin, f_len);
+    filenames[i] = mrb_intern2(mrb, (const char *)bin, f_len);
     bin += f_len;
   }
 

--- a/src/parse.y
+++ b/src/parse.y
@@ -5185,14 +5185,17 @@ mrbc_partial_hook(mrb_state *mrb, mrbc_context *c, int (*func)(struct mrb_parser
 }
 
 void
-mrb_parser_set_filename(struct mrb_parser_state* p, char const* f)
+mrb_parser_set_filename(struct mrb_parser_state *p, const char *f)
 {
-  mrb_sym const sym = mrb_intern(p->mrb, f);
+  mrb_sym sym;
   size_t len;
+  size_t i;
+  mrb_sym* new_table;
+
+  sym = mrb_intern_cstr(p->mrb, f);
   p->filename = mrb_sym2name_len(p->mrb, sym, &len);
   p->lineno = (p->filename_table_length > 0)? 0 : 1;
-
-  size_t i;
+  
   for(i = 0; i < p->filename_table_length; ++i) {
     if(p->filename_table[i] == sym) {
       p->current_filename_index = i;
@@ -5202,7 +5205,7 @@ mrb_parser_set_filename(struct mrb_parser_state* p, char const* f)
 
   p->current_filename_index = p->filename_table_length++;
 
-  mrb_sym* const new_table = parser_palloc(p, sizeof(mrb_sym) * p->filename_table_length);
+  new_table = parser_palloc(p, sizeof(mrb_sym) * p->filename_table_length);
   if (p->filename_table) {
     memcpy(new_table, p->filename_table, sizeof(mrb_sym) * p->filename_table_length);
   }


### PR DESCRIPTION
It's mainly moving variable declarations at the beginning of a block. I also took the liberty to:
- add the missing short description and reference to the copyright notice to the new header
- remove `const` from integer variables like `uint32_t`

(The upside is very minimal and even then the declaration and definition should match (see the function `mrb_debug_get_line` in `src/debug.c` and `include/mruby/debug.h`))
- adjust the style (casting void pointers, const placement), although not fully
