### PR TITLE
Fix checking return value of fread()

### DIFF
--- a/src/load.c
+++ b/src/load.c
@@ -734,7 +734,7 @@ mrb_read_irep_file(mrb_state *mrb, FILE* fp)
     else if (memcmp(section_header.section_identify, RITE_SECTION_DEBUG_IDENTIFIER, sizeof(section_header.section_identify)) == 0) {
       uint8_t* const bin = mrb_malloc(mrb, section_size);
       fseek(fp, fpos, SEEK_SET);
-      if(fread((char*)bin, section_size, 1, fp) != section_size) {
+      if(fread((char*)bin, section_size, 1, fp) != 1) {
         mrb_free(mrb, bin);
         return MRB_DUMP_READ_FAULT;
       }


### PR DESCRIPTION
The latest code cannot execute a *.mrb including debug information. (compiled with "-g" option)
- test.rb

```
undefined_method
```
- current

```
$ bin/mrbc test.rb
$ bin/mruby -b test.mrb
trace:
NoMethodError: undefined method 'undefined_method' for main
```

```
$ bin/mrbc -g test.rb
$ bin/mruby -b test.mrb
failed to load mrb file: test.mrb
```
- fixed

```
$ bin/mrbc test.rb
$ bin/mruby -b test.mrb
trace:
NoMethodError: undefined method 'undefined_method' for main
```

```
$ bin/mrbc -g test.rb
$ bin/mruby -b test.mrb
trace:
        [0] test.rb:1
test.rb:1: undefined method 'undefined_method' for main (NoMethodError)
```
