### PR TITLE
fix build error when ENABLE_DEBUG is defined

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -513,7 +513,7 @@ argnum_error(mrb_state *mrb, int num)
 }
 
 #ifdef ENABLE_DEBUG
-#define CODE_FETCH_HOOK(mrb, irep, pc, regs) ((mrb)->code_fetch_hook ? (mrb)->code_fetch_hook((mrb), (irep), (pc), (regs)) : NULL)
+#define CODE_FETCH_HOOK(mrb, irep, pc, regs) if ((mrb)->code_fetch_hook) (mrb)->code_fetch_hook((mrb), (irep), (pc), (regs)); 
 #else
 #define CODE_FETCH_HOOK(mrb, irep, pc, regs)
 #endif


### PR DESCRIPTION
fix a compile error when ENABLE_DEBUG macro is defined.
