### PR TITLE
fix #1519

### DIFF
--- a/src/codegen.c
+++ b/src/codegen.c
@@ -684,16 +684,23 @@ static int
 gen_values(codegen_scope *s, node *t, int val)
 {
   int n = 0;
+  int is_splat;
 
   while (t) {
-    if (n >= 127 || (intptr_t)t->car->car == NODE_SPLAT) { // splat mode
+    is_splat = (intptr_t)t->car->car == NODE_SPLAT; // splat mode
+    if (n >= 127 || is_splat) {
       if (val) {
         pop_n(n);
         genop(s, MKOP_ABC(OP_ARRAY, cursp(), cursp(), n));
         push();
         codegen(s, t->car, VAL);
         pop(); pop();
-        genop(s, MKOP_AB(OP_ARYCAT, cursp(), cursp()+1));
+        if (is_splat) {
+            genop(s, MKOP_AB(OP_ARYCAT, cursp(), cursp()+1));
+        }
+        else {
+            genop(s, MKOP_AB(OP_ARYPUSH, cursp(), cursp()+1));
+        }
         t = t->cdr;
         while (t) {
           push();


### PR DESCRIPTION
the 128th element in an array literal would trigger a corner case on
splat mode checking, in which mruby will splat an that value into its
parent array. the issue was masked by the fact of ary_concat() also
accept non-array value:

1.9.3p286 :002> a = 1
1.9.3p286 :003> [*a]
 => [1]

the expected behaviour should be OP_ARYPUSH the 128th element
unless it's in splat mode, instead of splatting it by OP_ARYCAT.
#1519
