### PR TITLE
Add super in aliased methods.

### DIFF
--- a/include/mruby/proc.h
+++ b/include/mruby/proc.h
@@ -39,6 +39,8 @@ struct RProc {
 #define MRB_ASPEC_KDICT(a)        ((a) & (1<<1))
 #define MRB_ASPEC_BLOCK(a)        ((a) & 1)
 
+#define MRB_PROC_ALIAS_METHOD 64
+#define MRB_PROC_ALIAS_METHOD_P(p) (((p)->flags & MRB_PROC_ALIAS_METHOD) != 0)
 #define MRB_PROC_CFUNC 128
 #define MRB_PROC_CFUNC_P(p) (((p)->flags & MRB_PROC_CFUNC) != 0)
 #define MRB_PROC_STRICT 256


### PR DESCRIPTION
Related #1457

@matz reviews:
///////////
Two problems:
- you have added org_mid member to RProc, but adding member enlarges RVALUE thus mruby would consumes more memory.
- you changes mrb->c->ci->target_class in vm.c:1034 that might cause problem.

I wil work on it. I have to figure out how to save original mid first though.
///////////

I fix two problems.
- Saves memory. An original mid is saved as hash in 'alias' intance variable instead of struct RProc.
- mrb_method_search_vm func changes a given class. mrb->c->ci->target_class pointer copy struct RClass *target_class. target_class is give mrb_method_search_vm func.

Test code:

``` ruby
This test code super-in-aliased-method.rb:

class Name

  def name
    return "super-name"
  end

end

class Human < Name

  def name
    return "James-#{super}"
  end

  alias get_name name
  # Or
  #alias_method :get_name, :name
end

human = Human.new
puts "name:#{human.name}\n"
puts "get_name:#{human.get_name}\n"
```

Result :

``` ruby
mruby super-in-aliased-method.rb 
name:James-super-name
get_name:James-super-name
```
