### PR TITLE
Set regs to stack on return of const_get calls before use

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -702,7 +702,9 @@ mrb_run(mrb_state *mrb, struct RProc *proc, mrb_value self)
     CASE(OP_GETCONST) {
       /* A B    R(A) := constget(Sym(B)) */
       ERR_PC_HOOK(mrb, pc);
-      regs[GETARG_A(i)] = mrb_vm_const_get(mrb, syms[GETARG_Bx(i)]);
+      mrb_value val = mrb_vm_const_get(mrb, syms[GETARG_Bx(i)]);
+      regs = mrb->c->stack;
+      regs[GETARG_A(i)] = val;
       NEXT;
     }
 
@@ -717,7 +719,9 @@ mrb_run(mrb_state *mrb, struct RProc *proc, mrb_value self)
       int a = GETARG_A(i);
 
       ERR_PC_HOOK(mrb, pc);
-      regs[a] = mrb_const_get(mrb, regs[a], syms[GETARG_Bx(i)]);
+      mrb_value val = mrb_const_get(mrb, regs[a], syms[GETARG_Bx(i)]);
+      regs = mrb->c->stack;
+      regs[a] = val;
       NEXT;
     }
 


### PR DESCRIPTION
I believe this fixes issue #1537. The problem looks like it happens when the stack grows leaving the local variable regs pointing to the old stack instead of the new one once the call to the underlying const_get unwinds. 
