### PR TITLE
fix #1550

### DIFF
--- a/src/parse.y
+++ b/src/parse.y
@@ -37,6 +37,7 @@ static void yyerror(parser_state *p, const char *s);
 static void yywarn(parser_state *p, const char *s);
 static void yywarning(parser_state *p, const char *s);
 static void backref_error(parser_state *p, node *n);
+static void tokadd(parser_state *p, int c);
 
 #ifndef isascii
 #define isascii(c) (((c) & ~0x7f) == 0)
@@ -3338,6 +3339,7 @@ nextc(parser_state *p)
 
     if (cxt->partial_hook(p) < 0) return -1;
     p->cxt = NULL;
+    tokadd(p, '\n');
     c = nextc(p);
     p->cxt = cxt;
     return c;


### PR DESCRIPTION
emit a "\n" as the first token for parser instead of taking the
first character from the next file for lexer, to prevent mruby
"concatenate" two keywords between files

it should be regarded as a work around, for it breaks abstraction
layers, and can not resolve this case:

```
$ cat a.rb
"
$ cat b.rb
b"

$ bin/mrbc -o- -v a.rb b.rb
mruby - Embeddable Ruby  Copyright (c) 2010-2013 mruby
developers
NODE_SCOPE:
        NODE_BEGIN:
                NODE_STR "

b " len 4
irep 0 nregs=2 nlocals=1 pools=1 syms=0
000 OP_STRING   R1      "\n\nb "
001 OP_STOP
```

thanks @bovi 's idea
