### PR TITLE
fix 3a4c8e2

### DIFF
--- a/src/parse.y
+++ b/src/parse.y
@@ -3338,9 +3338,8 @@ nextc(parser_state *p)
     mrbc_context *cxt = p->cxt;
 
     if (cxt->partial_hook(p) < 0) return -1;
-    p->cxt = NULL;
-    tokadd(p, '\n');
-    c = nextc(p);
+    c = '\n';
+    p->lineno = 1;
     p->cxt = cxt;
     return c;
   }


### PR DESCRIPTION
unfortunately the previouse commit for #1550 is incorrect, which still concatenate the
keywords, but like this:

```
  method='"end\nb"' (201)
```

this pr fix the previous problem, I'm testing whether this modification will affect the lineno
of the second file, and I'll update the status after test compete. sorry for the previous untest
code.
