### PR TITLE
Add shuffle and shuffle! methods to Array extension

### DIFF
--- a/mrbgems/mruby-random/test/random.rb
+++ b/mrbgems/mruby-random/test/random.rb
@@ -30,3 +30,17 @@ end
 assert("float") do
   rand.class == Float
 end
+
+assert("Array#shuffle") do 
+  ary = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+  shuffled = ary.shuffle
+  
+  ary == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] and shuffled != ary and 10.times { |x| ary.include? x }
+end
+
+assert('Array#shuffle!') do
+  ary = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+  ary.shuffle!
+  
+  ary != [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] and 10.times { |x| ary.include? x }
+end


### PR DESCRIPTION
This pull request adds shuffle and shuffle bang.

Notice that I'm initializing the rand() on the initialization of the GEM. Ideally I would like to depend on the Random class but I don't think it makes sense to have the Array extension depend on the Random extension.

Thoughts on this would be appreciated.

Perhaps shuffle and shuffle! should be moved to the Random GEM.
