### PR TITLE
Added support for Random as an argument to shuffle and shuffle!

### DIFF
--- a/mrbgems/mruby-random/test/random.rb
+++ b/mrbgems/mruby-random/test/random.rb
@@ -44,3 +44,33 @@ assert('Array#shuffle!') do
   
   ary != [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] and 10.times { |x| ary.include? x }
 end
+
+assert("Array#shuffle(random)") do 
+  assert_raise(TypeError) do
+    # this will cause an exception due to the wrong argument
+    [1, 2].shuffle "Not a Random instance"
+  end
+  
+  # verify that the same seed causes the same results
+  ary1 = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+  shuffle1 = ary1.shuffle Random.new 345
+  ary2 = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+  shuffle2 = ary2.shuffle Random.new 345
+  
+  ary1 != shuffle1 and 10.times { |x| shuffle1.include? x } and shuffle1 == shuffle2
+end
+
+assert('Array#shuffle!(random)') do
+  assert_raise(TypeError) do
+    # this will cause an exception due to the wrong argument
+    [1, 2].shuffle! "Not a Random instance"
+  end
+    
+  # verify that the same seed causes the same results
+  ary1 = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+  ary1.shuffle! Random.new 345
+  ary2 = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+  ary2.shuffle! Random.new 345
+  
+  ary1 != [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] and 10.times { |x| ary1.include? x } and ary1 == ary2
+end


### PR DESCRIPTION
Added support for Random as an argument to shuffle and shuffle!

Refactored random gem to use DATA instance type and hold mt_state inside the DATA_PTR instead of in an instance variable. Not sure why this design was different from the Time gem, maybe it was old?
