### PR TITLE
parser_dump and codedump_all are not used in mrbc

### DIFF
--- a/tools/mrbc/mrbc.c
+++ b/tools/mrbc/mrbc.c
@@ -11,8 +11,6 @@
 
 void mrb_show_version(mrb_state *);
 void mrb_show_copyright(mrb_state *);
-void parser_dump(mrb_state*, struct mrb_ast_node*, int);
-void codedump_all(mrb_state*, int);
 
 struct mrbc_args {
   int argc;


### PR DESCRIPTION
so declarations can be removed
