### PR TITLE
nextc(): always return an '\n' at end of input

### DIFF
--- a/include/mruby/compile.h
+++ b/include/mruby/compile.h
@@ -113,6 +113,7 @@ struct mrb_parser_state {
   char const *filename;
   int lineno;
   int column;
+  int eof;
 
   enum mrb_lex_state_enum lstate;
   mrb_ast_node *lex_strterm; /* (type nest_level beg . end) */


### PR DESCRIPTION
fix #1564
