### PR TITLE
renamed mrb_exc_new3 to mrb_exc_new_str

### DIFF
--- a/src/error.c
+++ b/src/error.c
@@ -25,7 +25,7 @@ mrb_exc_new(mrb_state *mrb, struct RClass *c, const char *ptr, long len)
 }
 
 mrb_value
-mrb_exc_new3(mrb_state *mrb, struct RClass* c, mrb_value str)
+mrb_exc_new_str(mrb_state *mrb, struct RClass* c, mrb_value str)
 {
   str = mrb_str_to_str(mrb, str);
   return mrb_funcall(mrb, mrb_obj_value(c), "new", 1, str);
@@ -231,7 +231,7 @@ mrb_raise(mrb_state *mrb, struct RClass *c, const char *msg)
 {
   mrb_value mesg;
   mesg = mrb_str_new_cstr(mrb, msg);
-  mrb_exc_raise(mrb, mrb_exc_new3(mrb, c, mesg));
+  mrb_exc_raise(mrb, mrb_exc_new_str(mrb, c, mesg));
 }
 
 mrb_value
@@ -297,7 +297,7 @@ mrb_raisef(mrb_state *mrb, struct RClass *c, const char *fmt, ...)
   va_start(args, fmt);
   mesg = mrb_vformat(mrb, fmt, args);
   va_end(args);
-  mrb_exc_raise(mrb, mrb_exc_new3(mrb, c, mesg));
+  mrb_exc_raise(mrb, mrb_exc_new_str(mrb, c, mesg));
 }
 
 void
@@ -376,7 +376,7 @@ make_exception(mrb_state *mrb, int argc, mrb_value *argv, int isstr)
       if (isstr) {
         mesg = mrb_check_string_type(mrb, argv[0]);
         if (!mrb_nil_p(mesg)) {
-          mesg = mrb_exc_new3(mrb, E_RUNTIME_ERROR, mesg);
+          mesg = mrb_exc_new_str(mrb, E_RUNTIME_ERROR, mesg);
           break;
         }
       }

--- a/src/error.h
+++ b/src/error.h
@@ -9,7 +9,7 @@
 
 void mrb_sys_fail(mrb_state *mrb, const char *mesg);
 int sysexit_status(mrb_state *mrb, mrb_value err);
-mrb_value mrb_exc_new3(mrb_state *mrb, struct RClass* c, mrb_value str);
+mrb_value mrb_exc_new_str(mrb_state *mrb, struct RClass* c, mrb_value str);
 mrb_value make_exception(mrb_state *mrb, int argc, mrb_value *argv, int isstr);
 mrb_value mrb_make_exception(mrb_state *mrb, int argc, mrb_value *argv);
 mrb_value mrb_format(mrb_state *mrb, const char *format, ...);

--- a/src/vm.c
+++ b/src/vm.c
@@ -490,7 +490,7 @@ localjump_error(mrb_state *mrb, localjump_error_kind kind)
   msg = mrb_str_buf_new(mrb, sizeof(lead) + 7);
   mrb_str_buf_cat(mrb, msg, lead, sizeof(lead) - 1);
   mrb_str_buf_cat(mrb, msg, kind_str[kind], kind_str_len[kind]);
-  exc = mrb_exc_new3(mrb, E_LOCALJUMP_ERROR, msg);
+  exc = mrb_exc_new_str(mrb, E_LOCALJUMP_ERROR, msg);
   mrb->exc = mrb_obj_ptr(exc);
 }
 
@@ -509,7 +509,7 @@ argnum_error(mrb_state *mrb, int num)
     str = mrb_format(mrb, "wrong number of arguments (%S for %S)",
                   mrb_fixnum_value(mrb->c->ci->argc), mrb_fixnum_value(num));
   }
-  exc = mrb_exc_new3(mrb, E_ARGUMENT_ERROR, str);
+  exc = mrb_exc_new_str(mrb, E_ARGUMENT_ERROR, str);
   mrb->exc = mrb_obj_ptr(exc);
 }
 
@@ -1332,7 +1332,7 @@ mrb_context_run(mrb_state *mrb, struct RProc *proc, mrb_value self, unsigned int
               goto L_RAISE;
             }
             if (mrb->c->prev->ci == mrb->c->prev->cibase) {
-              mrb_value exc = mrb_exc_new3(mrb, E_RUNTIME_ERROR, mrb_str_new(mrb, "double resume", 13));
+              mrb_value exc = mrb_exc_new_str(mrb, E_RUNTIME_ERROR, mrb_str_new(mrb, "double resume", 13));
               mrb->exc = mrb_obj_ptr(exc);
               goto L_RAISE;
             }
@@ -2138,10 +2138,10 @@ mrb_context_run(mrb_state *mrb, struct RProc *proc, mrb_value self, unsigned int
       mrb_value exc;
 
       if (GETARG_A(i) == 0) {
-        exc = mrb_exc_new3(mrb, E_RUNTIME_ERROR, msg);
+        exc = mrb_exc_new_str(mrb, E_RUNTIME_ERROR, msg);
       }
       else {
-        exc = mrb_exc_new3(mrb, E_LOCALJUMP_ERROR, msg);
+        exc = mrb_exc_new_str(mrb, E_LOCALJUMP_ERROR, msg);
       }
       mrb->exc = mrb_obj_ptr(exc);
       goto L_RAISE;


### PR DESCRIPTION
- more descriptive name (also, there isn't a function called mrb_exc_new2!)
- no wrapper (macro/static inline function) for
  backwards compatibility because nothing besides
  mruby itself seems to be calling this function:
  http://mruby-code-search.ongaeshi.me/home?query=mrb_exc_new3
