### PR TITLE
GCC: add -std=gnu99 to CFLAGS

### DIFF
--- a/tasks/toolchains/gcc.rake
+++ b/tasks/toolchains/gcc.rake
@@ -1,7 +1,7 @@
 MRuby::Toolchain.new(:gcc) do |conf|
   [conf.cc, conf.cxx, conf.objc, conf.asm].each do |cc|
     cc.command = ENV['CC'] || 'gcc'
-    cc.flags = [ENV['CFLAGS'] || %w(-g -O3 -Wall -Werror-implicit-function-declaration)]
+    cc.flags = [ENV['CFLAGS'] || %w(-g -std=gnu99 -O3 -Wall -Werror-implicit-function-declaration)]
     cc.include_paths = ["#{MRUBY_ROOT}/include"]
     cc.defines = %w(DISABLE_GEMS)
     cc.option_include_path = '-I%s'


### PR DESCRIPTION
- this change prevents issues like #1539 in the future
- Clang's default is already gnu99 but GCC's is gnu89
- mruby is C99 (+ GNU exts), not C89 (+ GNU exts)
