### PR TITLE
irep->pool struct pool -> mrb_value

### DIFF
--- a/include/mruby/irep.h
+++ b/include/mruby/irep.h
@@ -26,17 +26,7 @@ typedef struct mrb_irep {
   uint8_t flags;
 
   mrb_code *iseq;
-  struct irep_pool {
-    union {
-      mrb_float f;
-      struct irep_pool_string {
-        mrb_int len;
-        char buf[1];
-      } *s;
-      mrb_int i;
-    } value;
-    enum irep_pool_type type;
-  } *pool;
+  mrb_value *pool;
   mrb_sym *syms;
   struct mrb_irep **reps;
 

--- a/include/mruby/string.h
+++ b/include/mruby/string.h
@@ -50,6 +50,7 @@ char *mrb_string_value_cstr(mrb_state *mrb, mrb_value *ptr);
 char *mrb_string_value_ptr(mrb_state *mrb, mrb_value ptr);
 int mrb_str_offset(mrb_state *mrb, mrb_value str, int pos);
 mrb_value mrb_str_dup(mrb_state *mrb, mrb_value str);
+mrb_value mrb_str_dup_static(mrb_state *mrb, mrb_value str);
 mrb_value mrb_str_intern(mrb_state *mrb, mrb_value self);
 mrb_value mrb_str_cat_cstr(mrb_state *, mrb_value, const char *);
 mrb_value mrb_str_to_inum(mrb_state *mrb, mrb_value str, int base, int badcheck);

--- a/src/dump.c
+++ b/src/dump.c
@@ -79,19 +79,19 @@ get_pool_block_size(mrb_state *mrb, mrb_irep *irep)
   for (pool_no = 0; pool_no < irep->plen; pool_no++) {
     int ai = mrb_gc_arena_save(mrb);
 
-    switch (irep->pool[pool_no].type) {
-    case IREP_TT_FIXNUM:
-      str = mrb_fixnum_to_str(mrb, mrb_fixnum_value(irep->pool[pool_no].value.i), 10);
+    switch (mrb_type(irep->pool[pool_no])) {
+    case MRB_TT_FIXNUM:
+      str = mrb_fixnum_to_str(mrb, irep->pool[pool_no], 10);
       size += RSTRING_LEN(str);
       break;
 
-    case IREP_TT_FLOAT:
-      len = mrb_float_to_str(buf, irep->pool[pool_no].value.f);
+    case MRB_TT_FLOAT:
+      len = mrb_float_to_str(buf, mrb_float(irep->pool[pool_no]));
       size += len;
       break;
 
-    case IREP_TT_STRING:
-      size += irep->pool[pool_no].value.s->len;
+    case MRB_TT_STRING:
+      size += RSTRING_LEN(irep->pool[pool_no]);
       break;
 
     default:
@@ -118,23 +118,23 @@ write_pool_block(mrb_state *mrb, mrb_irep *irep, uint8_t *buf)
   for (pool_no = 0; pool_no < irep->plen; pool_no++) {
     int ai = mrb_gc_arena_save(mrb);
 
-    cur += uint8_to_bin(irep->pool[pool_no].type, cur); /* data type */
+    cur += uint8_to_bin(mrb_type(irep->pool[pool_no]), cur); /* data type */
 
-    switch (irep->pool[pool_no].type) {
-    case IREP_TT_FIXNUM:
-      str = mrb_fixnum_to_str(mrb, mrb_fixnum_value(irep->pool[pool_no].value.i), 10);
+    switch (mrb_type(irep->pool[pool_no])) {
+    case MRB_TT_FIXNUM:
+      str = mrb_fixnum_to_str(mrb, irep->pool[pool_no], 10);
       char_ptr = RSTRING_PTR(str);
       len = RSTRING_LEN(str);
       break;
 
-    case IREP_TT_FLOAT:
-      len = mrb_float_to_str(char_buf, irep->pool[pool_no].value.f);
+    case MRB_TT_FLOAT:
+      len = mrb_float_to_str(char_buf, mrb_float(irep->pool[pool_no]));
       char_ptr = &char_buf[0];
       break;
 
-    case IREP_TT_STRING:
-      char_ptr = irep->pool[pool_no].value.s->buf;
-      len = irep->pool[pool_no].value.s->len;
+    case MRB_TT_STRING:
+      char_ptr = RSTRING_PTR(irep->pool[pool_no]);
+      len = RSTRING_LEN(irep->pool[pool_no]);
       break;
 
     default:

--- a/src/load.c
+++ b/src/load.c
@@ -87,7 +87,7 @@ read_irep_record_1(mrb_state *mrb, const uint8_t *bin, uint32_t *len)
     if (SIZE_ERROR_MUL(sizeof(mrb_value), plen)) {
       return NULL;
     }
-    irep->pool = (struct irep_pool*)mrb_malloc(mrb, sizeof(struct irep_pool) * plen);
+    irep->pool = (struct mrb_value*)mrb_malloc(mrb, sizeof(mrb_value) * plen);
     if (irep->pool == NULL) {
       return NULL;
     }
@@ -100,38 +100,22 @@ read_irep_record_1(mrb_state *mrb, const uint8_t *bin, uint32_t *len)
       src += sizeof(uint16_t);
       s = mrb_str_new(mrb, (char *)src, pool_data_len);
       src += pool_data_len;
-      irep->pool[i].type = tt;
       switch (tt) { //pool data
-      case IREP_TT_FIXNUM:
-        {
-          mrb_value v = mrb_str_to_inum(mrb, s, 10, FALSE);
-
-          switch (mrb_type(v)) {
-          case MRB_TT_FIXNUM:
-            irep->pool[i].value.i = mrb_fixnum(v);
-            break;
-          case MRB_TT_FLOAT:
-            irep->pool[i].type = MRB_TT_FLOAT;
-            irep->pool[i].value.f = mrb_float(v);
-          default:
-             /* broken data; should not happen */
-            irep->pool[i].value.i = 0;
-          }
-        }
+      case MRB_TT_FIXNUM:
+        irep->pool[i] = mrb_str_to_inum(mrb, s, 10, FALSE);
         break;
 
-      case IREP_TT_FLOAT:
-        irep->pool[i].value.f = mrb_str_to_dbl(mrb, s, FALSE);
+      case MRB_TT_FLOAT:
+        irep->pool[i] = mrb_float_value(mrb, mrb_str_to_dbl(mrb, s, FALSE));
         break;
 
-      case IREP_TT_STRING:
-        irep->pool[i].value.s = (struct irep_pool_string*)mrb_malloc(mrb, sizeof(struct irep_pool_string) + pool_data_len);
-        irep->pool[i].value.s->len = pool_data_len;
-        memcpy(irep->pool[i].value.s->buf, src-pool_data_len, pool_data_len);
+      case MRB_TT_STRING:
+        irep->pool[i] = mrb_str_dup_static(mrb, s);
         break;
 
       default:
         /* should not happen */
+        irep->pool[i] = mrb_nil_value();
         break;
       }
       irep->plen++;

--- a/src/state.c
+++ b/src/state.c
@@ -11,6 +11,7 @@
 #include "mruby/irep.h"
 #include "mruby/variable.h"
 #include "mruby/debug.h"
+#include "mruby/string.h"
 
 void mrb_init_heap(mrb_state*);
 void mrb_init_core(mrb_state*);
@@ -129,8 +130,8 @@ mrb_irep_free(mrb_state *mrb, mrb_irep *irep)
   if (!(irep->flags & MRB_ISEQ_NO_FREE))
     mrb_free(mrb, irep->iseq);
   for (i=0; i<irep->plen; i++) {
-    if (irep->pool[i].type == IREP_TT_STRING)
-      mrb_free(mrb, irep->pool[i].value.s);
+    if (mrb_type(irep->pool[i]) == MRB_TT_STRING)
+      mrb_free(mrb, mrb_obj_ptr(irep->pool[i]));
   }
   mrb_free(mrb, irep->pool);
   mrb_free(mrb, irep->syms);

--- a/src/string.c
+++ b/src/string.c
@@ -734,6 +734,28 @@ mrb_str_dup(mrb_state *mrb, mrb_value str)
   return mrb_str_new(mrb, s->ptr, s->len);
 }
 
+mrb_value
+mrb_str_dup_static(mrb_state *mrb, mrb_value str)
+{
+  struct RString *s = mrb_str_ptr(str);
+  struct RString *ns;
+  mrb_int len;
+
+  ns = (struct RString *)mrb_malloc(mrb, sizeof(struct RString));
+  ns->tt = MRB_TT_STRING;
+  ns->c = mrb->string_class;
+
+  len = s->len;
+  ns->len = len;
+  ns->ptr = (char *)mrb_malloc(mrb, (size_t)len+1);
+  if (s->ptr) {
+    memcpy(ns->ptr, s->ptr, len);
+  }
+  ns->ptr[len] = '\0';
+
+  return mrb_obj_value(ns);
+}
+
 static mrb_value
 mrb_str_aref(mrb_state *mrb, mrb_value str, mrb_value indx)
 {

--- a/src/vm.c
+++ b/src/vm.c
@@ -554,7 +554,7 @@ mrb_context_run(mrb_state *mrb, struct RProc *proc, mrb_value self, unsigned int
   /* mrb_assert(mrb_proc_cfunc_p(proc)) */
   mrb_irep *irep = proc->body.irep;
   mrb_code *pc = irep->iseq;
-  struct irep_pool *pool = irep->pool;
+  mrb_value *pool = irep->pool;
   mrb_sym *syms = irep->syms;
   mrb_value *regs = NULL;
   mrb_code i;
@@ -618,10 +618,7 @@ mrb_context_run(mrb_state *mrb, struct RProc *proc, mrb_value self, unsigned int
 
     CASE(OP_LOADL) {
       /* A Bx   R(A) := Pool(Bx) */
-      if (pool[GETARG_Bx(i)].type == IREP_TT_FLOAT)
-        SET_FLT_VALUE(mrb, regs[GETARG_A(i)], pool[GETARG_Bx(i)].value.f);
-      else
-        SET_INT_VALUE(regs[GETARG_A(i)], pool[GETARG_Bx(i)].value.i);
+      regs[GETARG_A(i)] =  pool[GETARG_Bx(i)];
       NEXT;
     }
 
@@ -1939,7 +1936,7 @@ mrb_context_run(mrb_state *mrb, struct RProc *proc, mrb_value self, unsigned int
 
     CASE(OP_STRING) {
       /* A Bx           R(A) := str_new(Lit(Bx)) */
-      regs[GETARG_A(i)] = mrb_str_new(mrb, pool[GETARG_Bx(i)].value.s->buf, pool[GETARG_Bx(i)].value.s->len);
+      regs[GETARG_A(i)] = mrb_str_dup(mrb, pool[GETARG_Bx(i)]);
       mrb_gc_arena_restore(mrb, ai);
       NEXT;
     }
@@ -2134,7 +2131,7 @@ mrb_context_run(mrb_state *mrb, struct RProc *proc, mrb_value self, unsigned int
 
     CASE(OP_ERR) {
       /* Bx     raise RuntimeError with message Lit(Bx) */
-      mrb_value msg = mrb_str_new(mrb, pool[GETARG_Bx(i)].value.s->buf, pool[GETARG_Bx(i)].value.s->len);
+      mrb_value msg = mrb_str_dup(mrb, pool[GETARG_Bx(i)]);
       mrb_value exc;
 
       if (GETARG_A(i) == 0) {


### PR DESCRIPTION
The current type of irep->pool is struct struct irep_pool. But　implementation using this type needs conditional branch in OP_LOADL  instruction. So I propose changing the type of irep->pool to mrb_value.　Ｉ got speed ​​improvement of about 1.5% in the ao-bench.
