### PR TITLE
Modify build script for gcc.

### DIFF
--- a/tasks/toolchains/gcc.rake
+++ b/tasks/toolchains/gcc.rake
@@ -10,8 +10,8 @@ MRuby::Toolchain.new(:gcc) do |conf|
   end
 
   [conf.cxx].each do |cxx|
-    cxx.command = ENV['CC'] || 'g++'
-    cxx.flags = [ENV['CFLAGS'] || %w(-g -O3 -Wall -Werror-implicit-function-declaration)]
+    cxx.command = ENV['CXX'] || 'g++'
+    cxx.flags = [ENV['CXXFLAGS'] || %w(-g -O3 -Wall -Werror-implicit-function-declaration)]
     cxx.include_paths = ["#{MRUBY_ROOT}/include"]
     cxx.defines = %w(DISABLE_GEMS)
     cxx.option_include_path = '-I%s'


### PR DESCRIPTION
Newly added compile option '-std=gnu99' is not necessary for C++.
And 'g++' should be used to compile for C++ source codes, I think.
