### PR TITLE
Fix build error for MRB_WORD_BOXING

### DIFF
--- a/include/mruby/value.h
+++ b/include/mruby/value.h
@@ -215,6 +215,7 @@ enum mrb_vtype {
 
 #if defined(MRB_WORD_BOXING)
 
+#include <limits.h>
 #define MRB_TT_HAS_BASIC  MRB_TT_FLOAT
 
 enum mrb_special_consts {

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -2409,7 +2409,7 @@ scope_new(mrb_state *mrb, codegen_scope *prev, node *lv)
   p->iseq = (mrb_code*)mrb_malloc(mrb, sizeof(mrb_code)*p->icapa);
 
   p->pcapa = 32;
-  p->irep->pool = (struct mrb_value*)mrb_malloc(mrb, sizeof(struct mrb_value)*p->pcapa);
+  p->irep->pool = (mrb_value*)mrb_malloc(mrb, sizeof(mrb_value)*p->pcapa);
   p->irep->plen = 0;
 
   p->scapa = 256;

--- a/src/load.c
+++ b/src/load.c
@@ -87,7 +87,7 @@ read_irep_record_1(mrb_state *mrb, const uint8_t *bin, uint32_t *len)
     if (SIZE_ERROR_MUL(sizeof(mrb_value), plen)) {
       return NULL;
     }
-    irep->pool = (struct mrb_value*)mrb_malloc(mrb, sizeof(mrb_value) * plen);
+    irep->pool = (mrb_value*)mrb_malloc(mrb, sizeof(mrb_value) * plen);
     if (irep->pool == NULL) {
       return NULL;
     }


### PR DESCRIPTION
I've noticed MRB_WORD_BOXING does not work, so I fixed compile errors.
But this pull-request is incomplete because test fails (only with -DMRB_WORD_BOXING).

```
[koji@macbookpro:~/work/mruby/mruby]$ make test
ruby ./minirake
(in /Users/koji/work/mruby/mruby)
loading build config from : /Users/koji/work/mruby/kyab_build_config.rb

Build summary:

================================================
      Config Name: host
 Output Directory: build/host
         Binaries: mrbc
    Included Gems:
             mruby-sprintf - 0.0.0
             mruby-print - 0.0.0
             mruby-math - 0.0.0
             mruby-time - 0.0.0
             mruby-struct - 0.0.0
             mruby-enum-ext - 0.0.0
             mruby-string-ext - 0.0.0
             mruby-numeric-ext - 0.0.0
             mruby-array-ext - 0.0.0
             mruby-hash-ext - 0.0.0
             mruby-range-ext - 0.0.0
             mruby-proc-ext - 0.0.0
             mruby-symbol-ext - 0.0.0
             mruby-random - 0.0.0
             mruby-object-ext - 0.0.0
             mruby-objectspace - 0.0.0
             mruby-fiber - 0.0.0
             mruby-toplevel-ext - 0.0.0
             mruby-bin-mirb - 0.0.0
               - Binaries: mirb
             mruby-bin-mruby - 0.0.0
               - Binaries: mruby
             mruby-hs-regexp - 0.0.0
================================================

ruby ./minirake test
(in /Users/koji/work/mruby/mruby)
loading build config from : /Users/koji/work/mruby/kyab_build_config.rb
GEN   *.rb -> build/host/test/mrbtest.c
      MRBC test/assert.rb 
      MRBC test/t/argumenterror.rb 
      MRBC test/t/array.rb 
      MRBC test/t/basicobject.rb 
      MRBC test/t/bs_block.rb 
      MRBC test/t/bs_literal.rb 
      MRBC test/t/class.rb 
      MRBC test/t/comparable.rb 
      MRBC test/t/enumerable.rb 
      MRBC test/t/exception.rb 
      MRBC test/t/false.rb 
      MRBC test/t/float.rb 
      MRBC test/t/gc.rb 
      MRBC test/t/hash.rb 
      MRBC test/t/indexerror.rb 
      MRBC test/t/integer.rb 
      MRBC test/t/kernel.rb 
      MRBC test/t/literals.rb 
      MRBC test/t/localjumperror.rb 
      MRBC test/t/methods.rb 
      MRBC test/t/module.rb 
      MRBC test/t/nameerror.rb 
      MRBC test/t/nil.rb 
      MRBC test/t/nomethoderror.rb 
      MRBC test/t/numeric.rb 
      MRBC test/t/object.rb 
      MRBC test/t/proc.rb 
      MRBC test/t/range.rb 
      MRBC test/t/rangeerror.rb 
      MRBC test/t/regexperror.rb 
      MRBC test/t/runtimeerror.rb 
      MRBC test/t/standarderror.rb 
      MRBC test/t/string.rb 
      MRBC test/t/symbol.rb 
      MRBC test/t/syntax.rb 
      MRBC test/t/true.rb 
      MRBC test/t/typeerror.rb 
mrbc(52896,0xa16491a8) malloc: *** error for object 0x7c1a7858: pointer being freed was not allocated
*** set a breakpoint in malloc_error_break to debug
rake aborted!
exit

make: *** [test] Error 1
```

I'm using lldb to debug mrbc and find it dead on mrb_close() but could not proceed.
Any suggestions?
