### PR TITLE
vm: fix 'keep' usage in stack_extend_alloc().

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -139,7 +139,7 @@ stack_extend_alloc(mrb_state *mrb, int room, int keep)
   int off = mrb->c->stack - mrb->c->stbase;
 
   /* do not leave uninitialized malloc region */
-  if (keep > size) keep = size;
+  if (keep > size) size = keep;
 
   /* Use linear stack growth.
      It is slightly slower than doubling thestack space,


### PR DESCRIPTION
The parameter 'keep' was being set to 'size' (depending on the value
of size) and never used. I think it should be the other way around,
'size' should be set to 'keep' if 'keep' is larger than 'size'.
