### PR TITLE
Fix ISO no in Array#* and Array#+

### DIFF
--- a/src/array.c
+++ b/src/array.c
@@ -1124,8 +1124,8 @@ mrb_init_array(mrb_state *mrb)
 
   mrb_define_class_method(mrb, a, "[]",        mrb_ary_s_create,     MRB_ARGS_ANY());  /* 15.2.12.4.1 */
 
-  mrb_define_method(mrb, a, "*",               mrb_ary_times,        MRB_ARGS_REQ(1)); /* 15.2.12.5.1  */
-  mrb_define_method(mrb, a, "+",               mrb_ary_plus,         MRB_ARGS_REQ(1)); /* 15.2.12.5.2  */
+  mrb_define_method(mrb, a, "+",               mrb_ary_plus,         MRB_ARGS_REQ(1)); /* 15.2.12.5.1  */
+  mrb_define_method(mrb, a, "*",               mrb_ary_times,        MRB_ARGS_REQ(1)); /* 15.2.12.5.2  */
   mrb_define_method(mrb, a, "<<",              mrb_ary_push_m,       MRB_ARGS_REQ(1)); /* 15.2.12.5.3  */
   mrb_define_method(mrb, a, "[]",              mrb_ary_aget,         MRB_ARGS_ANY());  /* 15.2.12.5.4  */
   mrb_define_method(mrb, a, "[]=",             mrb_ary_aset,         MRB_ARGS_ANY());  /* 15.2.12.5.5  */

--- a/test/t/array.rb
+++ b/test/t/array.rb
@@ -17,17 +17,17 @@ assert('Array.[]', '15.2.12.4.1') do
   assert_equal([1, 2, 3], Array.[](1,2,3))
 end
 
-assert('Array#*', '15.2.12.5.1') do
+assert('Array#+', '15.2.12.5.1') do
+  assert_equal([1, 1], [1].+([1]))
+end
+
+assert('Array#*', '15.2.12.5.2') do
   assert_raise(ArgumentError) do
     # this will cause an exception due to the wrong argument
     [1].*(-1)
   end
   assert_equal([1, 1, 1], [1].*(3))
   assert_equal([], [1].*(0))
-end
-
-assert('Array#+', '15.2.12.5.2') do
-  assert_equal([1, 1], [1].+([1]))
 end
 
 assert('Array#<<', '15.2.12.5.3') do


### PR DESCRIPTION
The following ISO numbers are incorrect:

``` ruby
Array#*      # 15.2.12.5.1
Array#-      # 15.2.12.5.2
```

The following ISO numbers are correct:

``` ruby
Array#+      # 15.2.12.5.1
Array#*      # 15.2.12.5.2
```

I made sure above in ISO_IEC_30170_2012(E)_Character_PDF_document.pdf.
