### PR TITLE
Remove 'mrb_state' field from 'kh_xxx_t' structure.

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -188,7 +188,7 @@ struct RClass * mrb_class_get_under(mrb_state *mrb, struct RClass *outer, const 
 
 mrb_value mrb_obj_dup(mrb_state *mrb, mrb_value obj);
 mrb_value mrb_check_to_integer(mrb_state *mrb, mrb_value val, const char *method);
-mrb_bool mrb_obj_respond_to(struct RClass* c, mrb_sym mid);
+mrb_bool mrb_obj_respond_to(mrb_state *mrb, struct RClass* c, mrb_sym mid);
 struct RClass * mrb_define_class_under(mrb_state *mrb, struct RClass *outer, const char *name, struct RClass *super);
 struct RClass * mrb_define_module_under(mrb_state *mrb, struct RClass *outer, const char *name);
 

--- a/src/class.c
+++ b/src/class.c
@@ -46,7 +46,7 @@ mrb_gc_mark_mt_size(mrb_state *mrb, struct RClass *c)
 void
 mrb_gc_free_mt(mrb_state *mrb, struct RClass *c)
 {
-  kh_destroy(mt, c->mt);
+  kh_destroy(mt, mrb, c->mt);
 }
 
 void
@@ -297,7 +297,7 @@ mrb_define_method_raw(mrb_state *mrb, struct RClass *c, mrb_sym mid, struct RPro
   khiter_t k;
 
   if (!h) h = c->mt = kh_init(mt, mrb);
-  k = kh_put(mt, h, mid);
+  k = kh_put(mt, mrb, h, mid);
   kh_value(h, k) = p;
   if (p) {
     mrb_field_write_barrier(mrb, (struct RBasic *)c, (struct RBasic *)p);
@@ -330,7 +330,7 @@ mrb_define_method_vm(mrb_state *mrb, struct RClass *c, mrb_sym name, mrb_value b
   struct RProc *p;
 
   if (!h) h = c->mt = kh_init(mt, mrb);
-  k = kh_put(mt, h, name);
+  k = kh_put(mt, mrb, h, name);
   p = mrb_proc_ptr(body);
   kh_value(h, k) = p;
   if (p) {
@@ -995,7 +995,7 @@ mrb_method_search_vm(mrb_state *mrb, struct RClass **cp, mrb_sym mid)
     khash_t(mt) *h = c->mt;
 
     if (h) {
-      k = kh_get(mt, h, mid);
+      k = kh_get(mt, mrb, h, mid);
       if (k != kh_end(h)) {
         m = kh_value(h, k);
         if (!m) break;
@@ -1180,7 +1180,7 @@ mrb_bob_missing(mrb_state *mrb, mrb_value mod)
 }
 
 mrb_bool
-mrb_obj_respond_to(struct RClass* c, mrb_sym mid)
+mrb_obj_respond_to(mrb_state *mrb, struct RClass* c, mrb_sym mid)
 {
   khiter_t k;
 
@@ -1188,7 +1188,7 @@ mrb_obj_respond_to(struct RClass* c, mrb_sym mid)
     khash_t(mt) *h = c->mt;
 
     if (h) {
-      k = kh_get(mt, h, mid);
+      k = kh_get(mt, mrb, h, mid);
       if (k != kh_end(h)) {
         if (kh_value(h, k)) {
           return TRUE;  /* method exists */
@@ -1206,7 +1206,7 @@ mrb_obj_respond_to(struct RClass* c, mrb_sym mid)
 mrb_bool
 mrb_respond_to(mrb_state *mrb, mrb_value obj, mrb_sym mid)
 {
-  return mrb_obj_respond_to(mrb_class(mrb, obj), mid);
+  return mrb_obj_respond_to(mrb, mrb_class(mrb, obj), mid);
 }
 
 mrb_value
@@ -1442,7 +1442,7 @@ undef_method(mrb_state *mrb, struct RClass *c, mrb_sym a)
 {
   mrb_value m;
 
-  if (!mrb_obj_respond_to(c, a)) {
+  if (!mrb_obj_respond_to(mrb, c, a)) {
     mrb_name_error(mrb, a, "undefined method '%S' for class '%S'", mrb_sym2str(mrb, a), mrb_obj_value(c));
   }
   else {
@@ -1713,7 +1713,7 @@ mrb_mod_method_defined(mrb_state *mrb, mrb_value mod)
 
   id = get_sym_or_str_arg(mrb);
   if (mrb_symbol_p(id)) {
-    method_defined_p = mrb_obj_respond_to(mrb_class_ptr(mod), mrb_symbol(id));
+    method_defined_p = mrb_obj_respond_to(mrb, mrb_class_ptr(mod), mrb_symbol(id));
   }
   else {
     mrb_value sym = mrb_check_intern_str(mrb, id);
@@ -1721,7 +1721,7 @@ mrb_mod_method_defined(mrb_state *mrb, mrb_value mod)
       method_defined_p = FALSE;
     }
     else {
-      method_defined_p = mrb_obj_respond_to(mrb_class_ptr(mod), mrb_symbol(sym));
+      method_defined_p = mrb_obj_respond_to(mrb, mrb_class_ptr(mod), mrb_symbol(sym));
     }
   }
   return mrb_bool_value(method_defined_p);
@@ -1735,9 +1735,9 @@ remove_method(mrb_state *mrb, mrb_value mod, mrb_sym mid)
   khiter_t k;
 
   if (h) {
-    k = kh_get(mt, h, mid);
+    k = kh_get(mt, mrb, h, mid);
     if (k != kh_end(h)) {
-      kh_del(mt, h, k);
+      kh_del(mt, mrb, h, k);
       return;
     }
   }

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -733,7 +733,7 @@ method_entry_loop(mrb_state *mrb, struct RClass* klass, khash_t(st)* set)
   if (!h) return;
   for (i=0;i<kh_end(h);i++) {
     if (kh_exist(h, i)) {
-      kh_put(st, set, kh_key(h,i));
+      kh_put(st, mrb, set, kh_key(h,i));
     }
   }
 }
@@ -765,7 +765,7 @@ class_instance_method_list(mrb_state *mrb, mrb_bool recur, struct RClass* klass,
       mrb_ary_push(mrb, ary, mrb_symbol_value(kh_key(set,i)));
     }
   }
-  kh_destroy(st, set);
+  kh_destroy(st, mrb, set);
 
   return ary;
 }
@@ -797,7 +797,7 @@ mrb_obj_singleton_methods(mrb_state *mrb, mrb_bool recur, mrb_value obj)
       mrb_ary_push(mrb, ary, mrb_symbol_value(kh_key(set,i)));
     }
   }
-  kh_destroy(st, set);
+  kh_destroy(st, mrb, set);
 
   return ary;
 }

--- a/src/symbol.c
+++ b/src/symbol.c
@@ -45,7 +45,7 @@ mrb_intern(mrb_state *mrb, const char *name, size_t len)
 
   sname.len = len;
   sname.name = name;
-  k = kh_get(n2s, h, sname);
+  k = kh_get(n2s, mrb, h, sname);
   if (k != kh_end(h))
     return kh_value(h, k);
 
@@ -54,7 +54,7 @@ mrb_intern(mrb_state *mrb, const char *name, size_t len)
   memcpy(p, name, len);
   p[len] = 0;
   sname.name = (const char*)p;
-  k = kh_put(n2s, h, sname);
+  k = kh_put(n2s, mrb, h, sname);
   kh_value(h, k) = sym;
 
   return sym;
@@ -82,7 +82,7 @@ mrb_check_intern(mrb_state *mrb, const char *name, size_t len)
   sname.len = len;
   sname.name = name;
 
-  k = kh_get(n2s, h, sname);
+  k = kh_get(n2s, mrb, h, sname);
   if (k != kh_end(h)) {
     return mrb_symbol_value(kh_value(h, k));
   }
@@ -130,7 +130,7 @@ mrb_free_symtbl(mrb_state *mrb)
 
   for (k = kh_begin(h); k != kh_end(h); k++)
     if (kh_exist(h, k)) mrb_free(mrb, (char*)kh_key(h, k).name);
-  kh_destroy(n2s,mrb->name2sym);
+  kh_destroy(n2s, mrb, mrb->name2sym);
 }
 
 void

--- a/src/variable.c
+++ b/src/variable.c
@@ -311,7 +311,7 @@ iv_put(mrb_state *mrb, iv_tbl *t, mrb_sym sym, mrb_value val)
   khash_t(iv) *h = &t->h;
   khiter_t k;
 
-  k = kh_put(iv, h, sym);
+  k = kh_put(iv, mrb, h, sym);
   kh_value(h, k) = val;
 }
 
@@ -321,7 +321,7 @@ iv_get(mrb_state *mrb, iv_tbl *t, mrb_sym sym, mrb_value *vp)
   khash_t(iv) *h = &t->h;
   khiter_t k;
 
-  k = kh_get(iv, h, sym);
+  k = kh_get(iv, mrb, h, sym);
   if (k != kh_end(h)) {
     if (vp) *vp = kh_value(h, k);
     return TRUE;
@@ -336,10 +336,10 @@ iv_del(mrb_state *mrb, iv_tbl *t, mrb_sym sym, mrb_value *vp)
   khiter_t k;
 
   if (h) {
-    k = kh_get(iv, h, sym);
+    k = kh_get(iv, mrb, h, sym);
     if (k != kh_end(h)) {
       mrb_value val = kh_value(h, k);
-      kh_del(iv, h, k);
+      kh_del(iv, mrb, h, k);
       if (vp) *vp = val;
       return TRUE;
     }
@@ -360,7 +360,7 @@ iv_foreach(mrb_state *mrb, iv_tbl *t, iv_foreach_func *func, void *p)
         n = (*func)(mrb, kh_key(h, k), kh_value(h, k), p);
         if (n > 0) return FALSE;
         if (n < 0) {
-          kh_del(iv, h, k);
+          kh_del(iv, mrb, h, k);
         }
       }
     }
@@ -386,7 +386,7 @@ iv_copy(mrb_state *mrb, iv_tbl *t)
 static void
 iv_free(mrb_state *mrb, iv_tbl *t)
 {
-  kh_destroy(iv, &t->h);
+  kh_destroy(iv, mrb, &t->h);
 }
 
 #endif


### PR DESCRIPTION
'kh_xxx_t' requires 'mrb_state' to allocate, free, and compute hash value.
But 'mrb_state' should not be held by 'kh_xxx_t' and 'mrb_state' should be
supplied from outside.
