### PR TITLE
return-value of mrb_run is invalid in top-level-scope

### DIFF
--- a/src/codegen.c
+++ b/src/codegen.c
@@ -661,7 +661,7 @@ scope_body(codegen_scope *s, node *tree, int val)
 {
   codegen_scope *scope = scope_new(s->mrb, s, tree->car);
 
-  codegen(scope, tree->cdr, val);
+  codegen(scope, tree->cdr, VAL);
   if (!s->iseq) {
     genop(scope, MKOP_A(OP_STOP, 0));
   }


### PR DESCRIPTION
The return-value of mrb_run in top-level-scope is not the evaluated value at last from c209fa9514ea6296a798168481a769bd2225243d.

For example, the following mruby script by mrb_run does not return the value of `sum`.

``` ruby
sum = 0
(1..10).each { |i| sum += i }
sum
```

In detail, when the above script is called by C, the return-value is not the value of `sum`.

``` c
mrb_value result;
// execute above mruby script
result = mrb_run(mrb, proc, mrb_top_self(mrb));

result = mrb_obj_as_string(mrb, result);
char *s = RSTRING_PTR(result);
printf("s:%s\n", s); // expected: 55, actual: 1..10
```

I don't know whether this is expected behavior. 
But I think better that the return-value of mrb_run in top-level-scope is the evaluated value at last.
