### PR TITLE
NaN boxing: use uintptr_t for bit manipulations

### DIFF
--- a/include/mruby/value.h
+++ b/include/mruby/value.h
@@ -155,7 +155,7 @@ typedef struct mrb_value {
 #define mrb_tt(o)       (((o).value.ttt & 0xfc000)>>14)
 #define mrb_mktt(tt)    (0xfff00000|((tt)<<14))
 #define mrb_type(o)     ((uint32_t)0xfff00000 < (o).value.ttt ? mrb_tt(o) : MRB_TT_FLOAT)
-#define mrb_ptr(o)      ((void*)((((intptr_t)0x3fffffffffff)&((intptr_t)((o).value.p)))<<2))
+#define mrb_ptr(o)      ((void*)((((uintptr_t)0x3fffffffffff)&((uintptr_t)((o).value.p)))<<2))
 #define mrb_float(o)    (o).f
 
 #define MRB_SET_VALUE(o, tt, attr, v) do {\
@@ -166,7 +166,7 @@ typedef struct mrb_value {
   case MRB_TT_UNDEF:\
   case MRB_TT_FIXNUM:\
   case MRB_TT_SYMBOL: (o).attr = (v); break;\
-  default: (o).value.i = 0; (o).value.p = (void*)((intptr_t)(o).value.p | (((intptr_t)(v))>>2)); break;\
+  default: (o).value.i = 0; (o).value.p = (void*)((uintptr_t)(o).value.p | (((uintptr_t)(v))>>2)); break;\
   }\
 } while (0)
 


### PR DESCRIPTION
This probably hasn't any effect on the code in this case (maybe on/with some less common system/compiler) but it's always good to avoid bitwise operations on signed types. It was actually unsigned once (changed by 1f5c91d68dfca9a7000f2b194efceed9b96ffdf6).
