### PR TITLE
tiny word boxing optimization

### DIFF
--- a/include/mruby/value.h
+++ b/include/mruby/value.h
@@ -315,6 +315,7 @@ mrb_float_value(struct mrb_state *mrb, mrb_float f)
 #define mrb_bool(o)   ((o).w != MRB_Qnil && (o).w != MRB_Qfalse)
 
 #else
+
 #define mrb_cptr(o) mrb_ptr(o)
 #define mrb_fixnum_p(o) (mrb_type(o) == MRB_TT_FIXNUM)
 #define mrb_undef_p(o) (mrb_type(o) == MRB_TT_UNDEF)

--- a/mrbgems/mruby-range-ext/src/range.c
+++ b/mrbgems/mruby-range-ext/src/range.c
@@ -7,7 +7,7 @@ r_le(mrb_state *mrb, mrb_value a, mrb_value b)
   mrb_value r = mrb_funcall(mrb, a, "<=>", 1, b); /* compare result */
   /* output :a < b => -1, a = b =>  0, a > b => +1 */
 
-  if (mrb_type(r) == MRB_TT_FIXNUM) {
+  if (mrb_fixnum_p(r)) {
     mrb_int c = mrb_fixnum(r);
     if (c == 0 || c == -1) return TRUE;
   }
@@ -21,11 +21,7 @@ r_lt(mrb_state *mrb, mrb_value a, mrb_value b)
   mrb_value r = mrb_funcall(mrb, a, "<=>", 1, b);
   /* output :a < b => -1, a = b =>  0, a > b => +1 */
 
-  if (mrb_type(r) == MRB_TT_FIXNUM) {
-    if (mrb_fixnum(r) == -1) return TRUE;
-  }
-
-  return FALSE;
+  return mrb_fixnum_p(r) && mrb_fixnum(r) == -1;
 }
 
 /*

--- a/src/array.c
+++ b/src/array.c
@@ -318,7 +318,7 @@ mrb_ary_cmp(mrb_state *mrb, mrb_value ary1)
     for (i=0; i<len; i++) {
       mrb_value v = ary_elt(ary2, i);
       r = mrb_funcall_argv(mrb, ary_elt(ary1, i), cmp, 1, &v);
-      if (mrb_type(r) != MRB_TT_FIXNUM || mrb_fixnum(r) != 0) return r;
+      if (!mrb_fixnum_p(r) || mrb_fixnum(r) != 0) return r;
     }
   }
   len = a1->len - a2->len;
@@ -697,7 +697,7 @@ mrb_ary_aget(mrb_state *mrb, mrb_value self)
     return mrb_ary_ref(mrb, self, index);
 
   case 1:
-    if (mrb_type(argv[0]) != MRB_TT_FIXNUM) {
+    if (!mrb_fixnum_p(argv[0])) {
       mrb_raise(mrb, E_TYPE_ERROR, "expected Fixnum");
     }
     if (index < 0) index += a->len;

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -421,7 +421,7 @@ new_lit(codegen_scope *s, mrb_value val)
   case MRB_TT_FIXNUM:
     for (i=0; i<s->irep->plen; i++) {
       pv = &s->irep->pool[i];
-      if (mrb_type(*pv) != MRB_TT_FIXNUM) continue;
+      if (!mrb_fixnum_p(*pv)) continue;
       if (mrb_fixnum(*pv) == mrb_fixnum(val)) return i;
     }
     break;

--- a/src/object.c
+++ b/src/object.c
@@ -326,9 +326,9 @@ mrb_check_to_integer(mrb_state *mrb, mrb_value val, const char *method)
 {
   mrb_value v;
 
-  if (mrb_type(val) == MRB_TT_FIXNUM) return val;
+  if (mrb_fixnum_p(val)) return val;
   v = convert_type(mrb, val, "Integer", method, FALSE);
-  if (mrb_nil_p(v) || mrb_type(v) != MRB_TT_FIXNUM) {
+  if (mrb_nil_p(v) || !mrb_fixnum_p(v)) {
     return mrb_nil_value();
   }
   return v;
@@ -404,7 +404,7 @@ mrb_check_type(mrb_state *mrb, mrb_value x, enum mrb_vtype t)
         if (mrb_nil_p(x)) {
           etype = "nil";
         }
-        else if (mrb_type(x) == MRB_TT_FIXNUM) {
+        else if (mrb_fixnum_p(x)) {
           etype = "Fixnum";
         }
         else if (mrb_type(x) == MRB_TT_SYMBOL) {

--- a/src/range.c
+++ b/src/range.c
@@ -176,7 +176,7 @@ r_le(mrb_state *mrb, mrb_value a, mrb_value b)
   mrb_value r = mrb_funcall(mrb, a, "<=>", 1, b); /* compare result */
   /* output :a < b => -1, a = b =>  0, a > b => +1 */
 
-  if (mrb_type(r) == MRB_TT_FIXNUM) {
+  if (mrb_fixnum_p(r)) {
     mrb_int c = mrb_fixnum(r);
     if (c == 0 || c == -1) return TRUE;
   }
@@ -190,11 +190,7 @@ r_gt(mrb_state *mrb, mrb_value a, mrb_value b)
   mrb_value r = mrb_funcall(mrb, a, "<=>", 1, b);
   /* output :a < b => -1, a = b =>  0, a > b => +1 */
 
-  if (mrb_type(r) == MRB_TT_FIXNUM) {
-    if (mrb_fixnum(r) == 1) return TRUE;
-  }
-
-  return FALSE;
+  return mrb_fixnum_p(r) && mrb_fixnum(r) == 1;
 }
 
 static mrb_bool
@@ -203,7 +199,7 @@ r_ge(mrb_state *mrb, mrb_value a, mrb_value b)
   mrb_value r = mrb_funcall(mrb, a, "<=>", 1, b); /* compare result */
   /* output :a < b => -1, a = b =>  0, a > b => +1 */
 
-  if (mrb_type(r) == MRB_TT_FIXNUM) {
+  if (mrb_fixnum_p(r)) {
     mrb_int c = mrb_fixnum(r);
     if (c == 0 || c == 1) return TRUE;
   }

--- a/src/string.c
+++ b/src/string.c
@@ -1248,7 +1248,7 @@ mrb_str_include(mrb_state *mrb, mrb_value self)
   mrb_bool include_p;
 
   mrb_get_args(mrb, "o", &str2);
-  if (mrb_type(str2) == MRB_TT_FIXNUM) {
+  if (mrb_fixnum_p(str2)) {
     include_p = (memchr(RSTRING_PTR(self), mrb_fixnum(str2), RSTRING_LEN(self)) != NULL);
   }
   else {


### PR DESCRIPTION
Using mrb_fixnum_p when word boxing is enabled is better than calling mrb_type.
