### PR TITLE
remove various preprocessor conditionals

### DIFF
--- a/mrbgems/mruby-sprintf/src/sprintf.c
+++ b/mrbgems/mruby-sprintf/src/sprintf.c
@@ -15,10 +15,6 @@
 #include <math.h>
 #include <ctype.h>
 
-#ifdef HAVE_IEEEFP_H
-#include <ieeefp.h>
-#endif
-
 #define BIT_DIGITS(N)   (((N)*146)/485 + 1)  /* log2(10) =~ 146/485 */
 #define BITSPERDIG (sizeof(mrb_int)*CHAR_BIT)
 #define EXTENDSIGN(n, l) (((~0 << (n)) >> (((n)*(l)) % BITSPERDIG)) & ~(~0 << (n)))

--- a/src/array.c
+++ b/src/array.c
@@ -4,12 +4,7 @@
 ** See Copyright Notice in mruby.h
 */
 
-#ifndef SIZE_MAX
- /* Some versions of VC++
-  * has SIZE_MAX in stdint.h
-  */
-# include <limits.h>
-#endif
+#include <limits.h>
 #include "mruby.h"
 #include "mruby/array.h"
 #include "mruby/class.h"

--- a/src/gc.c
+++ b/src/gc.c
@@ -4,12 +4,7 @@
 ** See Copyright Notice in mruby.h
 */
 
-#ifndef SIZE_MAX
- /* Some versions of VC++
-  * has SIZE_MAX in stdint.h
-  */
-# include <limits.h>
-#endif
+#include <limits.h>
 #include <string.h>
 #include <stdlib.h>
 #include "mruby.h"

--- a/src/load.c
+++ b/src/load.c
@@ -4,12 +4,7 @@
 ** See Copyright Notice in mruby.h
 */
 
-#ifndef SIZE_MAX
- /* Some versions of VC++
-  * has SIZE_MAX in stdint.h
-  */
-# include <limits.h>
-#endif
+#include <limits.h>
 #include <stdlib.h>
 #include <string.h>
 #include "mruby/dump.h"

--- a/src/numeric.c
+++ b/src/numeric.c
@@ -5,12 +5,6 @@
 */
 
 #include <float.h>
-#if defined(__FreeBSD__) && __FreeBSD__ < 4
-# include <floatingpoint.h>
-#endif
-#ifdef HAVE_IEEEFP_H
-# include <ieeefp.h>
-#endif
 #include <limits.h>
 #include <math.h>
 #include <stdlib.h>

--- a/src/string.c
+++ b/src/string.c
@@ -5,12 +5,7 @@
 */
 
 #include <ctype.h>
-#ifndef SIZE_MAX
- /* Some versions of VC++
-  * has SIZE_MAX in stdint.h
-  */
-# include <limits.h>
-#endif
+#include <limits.h>
 #include <stddef.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
- HAVE_IEEEFP_H is nowhere defined or needed at all
- FreeBSD < 4 is unsupported since years
- MSVC workaround (around what exactly?)
