### PR TITLE
use the same error msg as mrb_str_to_cstr/CRuby

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -522,7 +522,7 @@ mrb_get_args(mrb_state *mrb, const char *format, ...)
           s = mrb_str_ptr(ss);
           len = (mrb_int)strlen(s->ptr);
           if (len < s->len) {
-            mrb_raise(mrb, E_ARGUMENT_ERROR, "String contains NUL");
+            mrb_raise(mrb, E_ARGUMENT_ERROR, "string contains null byte");
           }
           else if (len > s->len) {
             mrb_str_modify(mrb, s);


### PR DESCRIPTION
It's better to have one message for the same error
than two different (although similar worded) ones.
