### PR TITLE
string.c: remove str_mod_check

### DIFF
--- a/src/string.c
+++ b/src/string.c
@@ -107,16 +107,6 @@ mrb_str_resize(mrb_state *mrb, mrb_value str, mrb_int len)
   return str;
 }
 
-static inline void
-str_mod_check(mrb_state *mrb, mrb_value str, char *p, mrb_int len)
-{
-  struct RString *s = mrb_str_ptr(str);
-
-  if (s->ptr != p || s->len != len) {
-    mrb_raise(mrb, E_RUNTIME_ERROR, "string modified");
-  }
-}
-
 #define mrb_obj_alloc_string(mrb) ((struct RString*)mrb_obj_alloc((mrb), MRB_TT_STRING, (mrb)->string_class))
 
 /* char offset to byte offset */


### PR DESCRIPTION
Clang 3.4 emits '-Wunused-function' - and it's really unused!
But according to the description this seems to be a bug:

> Warn whenever a static function is declared but not defined or
> a **non-inline static** function is unused. This warning is enabled by
> -Wall.

Source: http://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html
## 

So should it be removed?
