### PR TITLE
Added rewrite of Array#[] to mruby-array-ext gem

### DIFF
--- a/mrbgems/mruby-array-ext/mrblib/array.rb
+++ b/mrbgems/mruby-array-ext/mrblib/array.rb
@@ -201,4 +201,36 @@ class Array
       self.replace(result)
     end
   end
+  
+  ##
+  # call-seq:
+  #    ary[rng]    -> ary slice
+  #
+  # Remeturns a slice of +ary+ according to the Range instance +rng+.
+  #
+  #    a = [ "a", "b", "c", "d", "e" ]
+  #    a[1]     => "b"
+  #    a[1,2]   => ["b", "c"]
+  #    a[1..-2] => ["b", "c", "d"]
+  #
+  def [](idx, len=nil)
+    case idx
+    when Range
+      if idx.last < 0 then
+        len = self.length - idx.first + idx.last + 1
+      else
+        len = idx.last - idx.first + 1
+      end
+      return self.slice(idx.first, len)
+    when Numeric
+      if len then
+        return self.slice(idx.to_i, len.to_i)
+      else
+        return self.slice(idx.to_i)
+      end
+    else
+      self.slice(idx)
+    end
+  end
+  
 end

--- a/mrbgems/mruby-array-ext/test/array.rb
+++ b/mrbgems/mruby-array-ext/test/array.rb
@@ -107,3 +107,10 @@ assert("Array#compact!") do
   a.compact!
   a == [1, "2", :t, false]
 end
+
+assert("Array#[]") do
+  a = [ "a", "b", "c", "d", "e" ]
+  a[1.1]   == "b" and
+  a[1,2]   == ["b", "c"] and
+  a[1..-2] == ["b", "c", "d"]
+end


### PR DESCRIPTION
So that arrays can be ...sliced with ranges (as in `a[1..-2]`)
