### PR TITLE
Add MRB_PRIMITIVE_BOXING mode

### DIFF
--- a/include/mrbconf.h
+++ b/include/mrbconf.h
@@ -26,6 +26,9 @@
 /* represent mrb_value as a word (natural unit of data for the processor) */
 // #define MRB_WORD_BOXING
 
+/* represent mrb_value in primitive type; use together with MRB_NAN_BOXING or MRB_WORD_BOXING */
+// #define MRB_PRIMITIVE_BOXING
+
 /* argv max size in mrb_funcall */
 //#define MRB_FUNCALL_ARGC_MAX 16
 

--- a/include/mruby/class.h
+++ b/include/mruby/class.h
@@ -28,7 +28,7 @@ mrb_class(mrb_state *mrb, mrb_value v)
 {
   switch (mrb_type(v)) {
   case MRB_TT_FALSE:
-    if (v.value.i)
+    if (mrb_get_attr_i(v))
       return mrb->false_class;
     return mrb->nil_class;
   case MRB_TT_TRUE:

--- a/src/class.c
+++ b/src/class.c
@@ -1446,7 +1446,7 @@ undef_method(mrb_state *mrb, struct RClass *c, mrb_sym a)
     mrb_name_error(mrb, a, "undefined method '%S' for class '%S'", mrb_sym2str(mrb, a), mrb_obj_value(c));
   }
   else {
-    MRB_SET_VALUE(m, MRB_TT_PROC, value.p, 0);
+    MRB_SET_VALUE(m, MRB_TT_PROC, p, 0);
     mrb_define_method_vm(mrb, c, a, m);
   }
 }

--- a/src/etc.c
+++ b/src/etc.c
@@ -191,8 +191,8 @@ mrb_float_value(mrb_state *mrb, mrb_float f)
 {
   mrb_value v;
 
-  v.value.p = mrb_obj_alloc(mrb, MRB_TT_FLOAT, mrb->float_class);
-  v.value.fp->f = f;
+  mrb_set_word_ptr(v, mrb_obj_alloc(mrb, MRB_TT_FLOAT, mrb->float_class));
+  mrb_set_word_float(v, f);
   return v;
 }
 
@@ -211,8 +211,8 @@ mrb_cptr_value(mrb_state *mrb, void *p)
 {
   mrb_value v;
 
-  v.value.p = mrb_obj_alloc(mrb, MRB_TT_CPTR, mrb->object_class);
-  v.value.vp->p = p;
+  mrb_set_word_ptr(v, mrb_obj_alloc(mrb, MRB_TT_CPTR, mrb->object_class));
+  mrb_set_word_cptr(v, p);
   return v;
 }
 #endif  /* MRB_WORD_BOXING */

--- a/src/hash.c
+++ b/src/hash.c
@@ -19,7 +19,7 @@ mrb_hash_ht_hash_func(mrb_state *mrb, mrb_value key)
   mrb_value h2;
 
   h2 = mrb_funcall(mrb, key, "hash", 0, 0);
-  h ^= h2.value.i;
+  h ^= mrb_get_attr_i(h2);
   return h;
 }
 

--- a/src/object.c
+++ b/src/object.c
@@ -19,9 +19,9 @@ mrb_obj_eq(mrb_state *mrb, mrb_value v1, mrb_value v2)
 
   case MRB_TT_FALSE:
   case MRB_TT_FIXNUM:
-    return (v1.value.i == v2.value.i);
+    return (mrb_get_attr_i(v1) == mrb_get_attr_i(v2));
   case MRB_TT_SYMBOL:
-    return (v1.value.sym == v2.value.sym);
+    return (mrb_get_attr_sym(v1) == mrb_get_attr_sym(v2));
 
   case MRB_TT_FLOAT:
     return (mrb_float(v1) == mrb_float(v2));

--- a/src/vm.c
+++ b/src/vm.c
@@ -30,18 +30,22 @@ void abort(void);
 #endif
 #endif
 
-#define SET_TRUE_VALUE(r) MRB_SET_VALUE(r, MRB_TT_TRUE, value.i, 1)
-#define SET_FALSE_VALUE(r) MRB_SET_VALUE(r, MRB_TT_FALSE, value.i, 1)
-#define SET_NIL_VALUE(r) MRB_SET_VALUE(r, MRB_TT_FALSE, value.i, 0)
-#define SET_INT_VALUE(r,n) MRB_SET_VALUE(r, MRB_TT_FIXNUM, value.i, (n))
-#define SET_SYM_VALUE(r,v) MRB_SET_VALUE(r, MRB_TT_SYMBOL, value.sym, (v))
-#define SET_OBJ_VALUE(r,v) MRB_SET_VALUE(r, (((struct RObject*)(v))->tt), value.p, (v))
+#define SET_TRUE_VALUE(r) MRB_SET_VALUE(r, MRB_TT_TRUE, i, 1)
+#define SET_FALSE_VALUE(r) MRB_SET_VALUE(r, MRB_TT_FALSE, i, 1)
+#define SET_NIL_VALUE(r) MRB_SET_VALUE(r, MRB_TT_FALSE, i, 0)
+#define SET_INT_VALUE(r,n) MRB_SET_VALUE(r, MRB_TT_FIXNUM, i, (n))
+#define SET_SYM_VALUE(r,v) MRB_SET_VALUE(r, MRB_TT_SYMBOL, sym, (v))
+#define SET_OBJ_VALUE(r,v) MRB_SET_VALUE(r, (((struct RObject*)(v))->tt), p, (v))
 #ifdef MRB_NAN_BOXING
+# ifdef MRB_PRIMITIVE_BOXING
+#define SET_FLT_VALUE(mrb,r,v) r = mrb_float_value(mrb, (v))
+# else
 #define SET_FLT_VALUE(mrb,r,v) r.f = (v)
+# endif
 #elif defined(MRB_WORD_BOXING)
 #define SET_FLT_VALUE(mrb,r,v) r = mrb_float_value(mrb, (v))
 #else
-#define SET_FLT_VALUE(mrb,r,v) MRB_SET_VALUE(r, MRB_TT_FLOAT, value.f, (v))
+#define SET_FLT_VALUE(mrb,r,v) MRB_SET_VALUE(r, MRB_TT_FLOAT, f, (v))
 #endif
 
 #define STACK_INIT_SIZE 128
@@ -73,7 +77,11 @@ static inline void
 stack_clear(mrb_value *from, size_t count)
 {
 #ifndef MRB_NAN_BOXING
+#ifndef MRB_PRIMITIVE_BOXING
   const mrb_value mrb_value_zero = { { 0 } };
+#else
+  const mrb_value mrb_value_zero = 0;
+#endif
 
   while (count-- > 0) {
     *from++ = mrb_value_zero;
@@ -1468,18 +1476,9 @@ mrb_context_run(mrb_state *mrb, struct RProc *proc, mrb_value self, unsigned int
       NEXT;
     }
 
-#define attr_i value.i
-#ifdef MRB_NAN_BOXING
-#define attr_f f
-#elif defined(MRB_WORD_BOXING)
-#define attr_f value.fp->f
-#else
-#define attr_f value.f
-#endif
-
 #define TYPES2(a,b) ((((uint16_t)(a))<<8)|(((uint16_t)(b))&0xff))
 #define OP_MATH_BODY(op,v1,v2) do {\
-  regs[a].v1 = regs[a].v1 op regs[a+1].v2;\
+  mrb_set_##v1(regs[a], mrb_get_##v1(regs[a]) op mrb_get_##v2(regs[a+1])); \
 } while(0)
 
     CASE(OP_ADD) {
@@ -1720,7 +1719,7 @@ mrb_context_run(mrb_state *mrb, struct RProc *proc, mrb_value self, unsigned int
       switch (mrb_type(regs[a])) {
       case MRB_TT_FIXNUM:
         {
-          mrb_int x = regs[a].attr_i;
+          mrb_int x = mrb_get_attr_i(regs[a]);
           mrb_int y = GETARG_C(i);
           mrb_int z = x + y;
 
@@ -1729,7 +1728,7 @@ mrb_context_run(mrb_state *mrb, struct RProc *proc, mrb_value self, unsigned int
             SET_FLT_VALUE(mrb, regs[a], (mrb_float)x + (mrb_float)y);
             break;
           }
-          regs[a].attr_i = z;
+          mrb_set_attr_i(regs[a], z);
         }
         break;
       case MRB_TT_FLOAT:
@@ -1739,7 +1738,7 @@ mrb_context_run(mrb_state *mrb, struct RProc *proc, mrb_value self, unsigned int
           SET_FLT_VALUE(mrb, regs[a], x + GETARG_C(i));
         }
 #else
-        regs[a].attr_f += GETARG_C(i);
+        mrb_set_attr_f(regs[a], mrb_get_attr_f(regs[a]) + GETARG_C(i));
 #endif
         break;
       default:
@@ -1759,7 +1758,7 @@ mrb_context_run(mrb_state *mrb, struct RProc *proc, mrb_value self, unsigned int
       switch (mrb_type(regs_a[0])) {
       case MRB_TT_FIXNUM:
         {
-          mrb_int x = regs_a[0].attr_i;
+          mrb_int x = mrb_get_attr_i(regs_a[0]);
           mrb_int y = GETARG_C(i);
           mrb_int z = x - y;
 
@@ -1768,7 +1767,7 @@ mrb_context_run(mrb_state *mrb, struct RProc *proc, mrb_value self, unsigned int
             SET_FLT_VALUE(mrb, regs_a[0], (mrb_float)x - (mrb_float)y);
           }
           else {
-            regs_a[0].attr_i = z;
+            mrb_set_attr_i(regs_a[0], z);
           }
         }
         break;
@@ -1779,7 +1778,7 @@ mrb_context_run(mrb_state *mrb, struct RProc *proc, mrb_value self, unsigned int
           SET_FLT_VALUE(mrb, regs[a], x - GETARG_C(i));
         }
 #else
-        regs_a[0].attr_f -= GETARG_C(i);
+        mrb_set_attr_f(regs_a[0], mrb_get_attr_f(regs_a[0]) - GETARG_C(i));
 #endif
         break;
       default:
@@ -1791,7 +1790,7 @@ mrb_context_run(mrb_state *mrb, struct RProc *proc, mrb_value self, unsigned int
     }
 
 #define OP_CMP_BODY(op,v1,v2) do {\
-  if (regs[a].v1 op regs[a+1].v2) {\
+  if (mrb_get_##v1(regs[a]) op mrb_get_##v2(regs[a+1])) {\
     SET_TRUE_VALUE(regs[a]);\
   }\
   else {\


### PR DESCRIPTION
**WARNING**:  This is a crazy idea for a pretty stupid problem. So please read this description before jumping into code reviewing(we may need to think about if we want to include this feature indeed).

In some C compilers(clang with le32-unknown-nacl target, used by [emscripten](https://github.com/kripken/emscripten) and [pnacl-clang](https://chromium.googlesource.com/native_client/pnacl-clang/)), `va_arg` cannot be used on aggregate types(e.g. unions or structs). In fact, the LLVM bitcode [does not support](http://llvm.org/docs/LangRef.html#i-va-arg) aggregate types. While some [progress](https://code.google.com/p/nativeclient/issues/detail?id=2381) in pnacl-clang has been made, we are still not having a proper solution for this. Although not confirmed, I wonder there might be more compilers (like those for embedded devices) with this problem.

On the other hand, mruby is [using](https://github.com/mruby/mruby/blob/master/src/vm.c#L299) `va_arg` on `mrb_value`, which is implemented as a struct. Since this is exposed in the mruby public API, it is very unlikely(or it might be possible?) to remove the `va_arg` here so as to solve the problem.

We can encapulate mrb_value using primitive values like `uintptr_t`, this way the problem will be gone. Luckily, we already have NaN-boxing and word boxing mode, which pack `mrb_value` either using `double` or `unsigned long`. However, those 2 boxing modes still represent `mrb_value` using union, which is still counted as aggregated types.

This PR provides a new mode called `MRB_PRIMITIVE_BOXING`. When used together with `MRB_NAN_BOXING` or `MRB_WORD_BOXING` modes, it will pack `mrb_value` using `uint64_t` (for NaN-boxing mode) or `uintptr_t` (for word boxing mode). Bit manipulations will be used to extract values from the primitive types. This way we can have mruby works despite of the restrictions on va_arg.
# Benefits
- mruby is working even though the compiler does not support aggregate types in `va_arg`.
- We will have C99-compatible NaN-boxing mode and word-boxing mode(solves #1299).
# Overheads
- Sophisticated bit manipulations are needed for new modes, which adds burden for maintenance.
- We cannot access fields in `mrb_value` using `value.i`, `value.sym`, etc. We have to use newly defined macros like `mrb_get_attr_i`, `mrb_get_attr_sym` or `mrb_get_word_iflag`, `mrb_get_word_bp_struct` for word boxing mode.

This PR is tested on following OS+compiler combinations. In each combination, all 5 modes (normal mode, `MRB_NAN_BOXING`, `MRB_NAN_BOXING`+`MRB_PRIMITIVE_BOXING`,`MRB_WORD_BOXING`, `MRB_WORD_BOXING`+`MRB_PRIMITIVE_BOXING`) are tested and working correctly.
- Mac OS X 10.9 + Apple LLVM version 5.0 (clang-500.2.79)
- CentOS 6.4(64bit) + gcc (GCC) 4.4.7 20120313 (Red Hat 4.4.7-4)
- Ubuntu 12.04.3 LTS(64bit) + gcc (Ubuntu/Linaro 4.6.3-1ubuntu5) 4.6.3
- Debian GNU/Linux 7(32bit) + gcc (Debian 4.7.2-5) 4.7.2

So what do you guys think? Should we merge and include this new mode? Thanks for reading!
