### PR TITLE
clean up external symbols

### DIFF
--- a/mrbgems/mruby-bin-mirb/tools/mirb/mirb.c
+++ b/mrbgems/mruby-bin-mirb/tools/mirb/mirb.c
@@ -42,7 +42,7 @@ p(mrb_state *mrb, mrb_value obj, int prompt)
 
 /* Guess if the user might want to enter more
  * or if he wants an evaluation of his code now */
-mrb_bool
+static mrb_bool
 is_code_block_open(struct mrb_parser_state *parser)
 {
   int code_block_open = FALSE;
@@ -221,7 +221,7 @@ print_hint(void)
 }
 
 /* Print the command line prompt of the REPL */
-void
+static void
 print_cmdline(int code_block_open)
 {
   if (code_block_open) {
@@ -232,7 +232,7 @@ print_cmdline(int code_block_open)
   }
 }
 
-void codedump_all(mrb_state*, struct RProc*);
+void mrb_codedump_all(mrb_state*, struct RProc*);
 
 int
 main(int argc, char **argv)
@@ -364,7 +364,7 @@ main(int argc, char **argv)
         struct RProc *proc = mrb_generate_code(mrb, parser);
 
         if (args.verbose) {
-          codedump_all(mrb, proc);
+          mrb_codedump_all(mrb, proc);
         }
         /* pass a proc for evaulation */
         nregs = first_command ? 0: proc->body.irep->nregs;

--- a/src/class.c
+++ b/src/class.c
@@ -866,7 +866,7 @@ mrb_mod_included_modules(mrb_state *mrb, mrb_value self)
   return result;
 }
 
-mrb_value class_instance_method_list(mrb_state*, mrb_bool, struct RClass*, int);
+mrb_value mrb_class_instance_method_list(mrb_state*, mrb_bool, struct RClass*, int);
 
 /* 15.2.2.4.33 */
 /*
@@ -902,7 +902,7 @@ mrb_mod_instance_methods(mrb_state *mrb, mrb_value mod)
   struct RClass *c = mrb_class_ptr(mod);
   mrb_bool recur = TRUE;
   mrb_get_args(mrb, "|b", &recur);
-  return class_instance_method_list(mrb, recur, c, 0);
+  return mrb_class_instance_method_list(mrb, recur, c, 0);
 }
 
 mrb_value mrb_yield_internal(mrb_state *mrb, mrb_value b, int argc, mrb_value *argv, mrb_value self, struct RClass *c);

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -26,7 +26,7 @@ enum looptype {
   LOOP_FOR,
   LOOP_BEGIN,
   LOOP_RESCUE,
-} type;
+};
 
 struct loopinfo {
   enum looptype type;
@@ -2905,7 +2905,7 @@ codedump_recur(mrb_state *mrb, mrb_irep *irep)
 }
 
 void
-codedump_all(mrb_state *mrb, struct RProc *proc)
+mrb_codedump_all(mrb_state *mrb, struct RProc *proc)
 {
   codedump_recur(mrb, proc->body.irep);
 }

--- a/src/error.c
+++ b/src/error.c
@@ -345,20 +345,13 @@ mrb_bug(mrb_state *mrb, const char *fmt, ...)
   exit(EXIT_FAILURE);
 }
 
-int
-sysexit_status(mrb_state *mrb, mrb_value err)
-{
-  mrb_value st = mrb_iv_get(mrb, err, mrb_intern_lit(mrb, "status"));
-  return mrb_fixnum(st);
-}
-
 static void
 set_backtrace(mrb_state *mrb, mrb_value info, mrb_value bt)
 {
   mrb_funcall(mrb, info, "set_backtrace", 1, bt);
 }
 
-mrb_value
+static mrb_value
 make_exception(mrb_state *mrb, int argc, mrb_value *argv, int isstr)
 {
   mrb_value mesg;

--- a/src/error.h
+++ b/src/error.h
@@ -8,9 +8,7 @@
 #define MRUBY_ERROR_H
 
 void mrb_sys_fail(mrb_state *mrb, const char *mesg);
-int sysexit_status(mrb_state *mrb, mrb_value err);
 mrb_value mrb_exc_new_str(mrb_state *mrb, struct RClass* c, mrb_value str);
-mrb_value make_exception(mrb_state *mrb, int argc, mrb_value *argv, int isstr);
 mrb_value mrb_make_exception(mrb_state *mrb, int argc, mrb_value *argv);
 mrb_value mrb_format(mrb_state *mrb, const char *format, ...);
 void mrb_exc_print(mrb_state *mrb, struct RObject *exc);

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -749,7 +749,7 @@ method_entry_loop(mrb_state *mrb, struct RClass* klass, khash_t(st)* set)
 }
 
 mrb_value
-class_instance_method_list(mrb_state *mrb, mrb_bool recur, struct RClass* klass, int obj)
+mrb_class_instance_method_list(mrb_state *mrb, mrb_bool recur, struct RClass* klass, int obj)
 {
   khint_t i;
   mrb_value ary;
@@ -816,7 +816,7 @@ mrb_value
 mrb_obj_methods(mrb_state *mrb, mrb_bool recur, mrb_value obj, mrb_method_flag_t flag)
 {
   if (recur)
-      return class_instance_method_list(mrb, recur, mrb_class(mrb, obj), 0);
+      return mrb_class_instance_method_list(mrb, recur, mrb_class(mrb, obj), 0);
   else
       return mrb_obj_singleton_methods(mrb, recur, obj);
 }
@@ -1019,7 +1019,7 @@ basic_obj_respond_to(mrb_state *mrb, mrb_value obj, mrb_sym id, int pub)
  *  If the method is not defined, <code>respond_to_missing?</code>
  *  method is called and the result is returned.
  */
-mrb_value
+static mrb_value
 obj_respond_to(mrb_state *mrb, mrb_value self)
 {
   mrb_value *argv;

--- a/src/range.c
+++ b/src/range.c
@@ -376,7 +376,7 @@ range_eql(mrb_state *mrb, mrb_value range)
 }
 
 /* 15.2.14.4.15(x) */
-mrb_value
+static mrb_value
 range_initialize_copy(mrb_state *mrb, mrb_value copy)
 {
   mrb_value src;

--- a/src/string.c
+++ b/src/string.c
@@ -132,7 +132,7 @@ str_new(mrb_state *mrb, const char *p, mrb_int len)
   return s;
 }
 
-void
+static void
 str_with_class(mrb_state *mrb, struct RString *s, mrb_value obj)
 {
   s->c = mrb_str_ptr(obj)->c;


### PR DESCRIPTION
remove unused and unneeded:
- sysexit_status
- type (a global variable)

add mrb_ prefix to:
- codedump_all
- class_instance_method_list
- parser_dump

make various functions static, incl.:
- yyparse
- make_exception
