### PR TITLE
rework mruby-objectspace and gc.[ch]

### DIFF
--- a/include/mruby/gc.h
+++ b/include/mruby/gc.h
@@ -7,11 +7,16 @@
 #ifndef MRUBY_GC_H
 #define MRUBY_GC_H
 
-#include "mruby.h"
-#include "mruby/value.h"
+#if defined(__cplusplus)
+extern "C" {
+#endif
 
-typedef void (each_object_callback)(mrb_state *mrb, struct RBasic* obj, void *data);
-void mrb_objspace_each_objects(mrb_state *mrb, each_object_callback* callback, void *data);
+typedef void (mrb_each_object_callback)(mrb_state *mrb, struct RBasic *obj, void *data);
+void mrb_objspace_each_objects(mrb_state *mrb, mrb_each_object_callback *callback, void *data);
 void mrb_free_context(mrb_state *mrb, struct mrb_context *c);
+
+#if defined(__cplusplus)
+}  /* extern "C" { */
+#endif
 
 #endif  /* MRUBY_GC_H */

--- a/src/gc.c
+++ b/src/gc.c
@@ -1281,21 +1281,21 @@ gc_generational_mode_set(mrb_state *mrb, mrb_value self)
 }
 
 void
-mrb_objspace_each_objects(mrb_state *mrb, each_object_callback* callback, void *data)
+mrb_objspace_each_objects(mrb_state *mrb, mrb_each_object_callback *callback, void *data)
 {
-    struct heap_page* page = mrb->heaps;
+  struct heap_page* page = mrb->heaps;
 
-    while (page != NULL) {
-        RVALUE *p, *pend;
+  while (page != NULL) {
+    RVALUE *p, *pend;
 
-        p = page->objects;
-        pend = p + MRB_HEAP_PAGE_SIZE;
-        for (;p < pend; p++) {
-           (*callback)(mrb, &p->as.basic, data);
-        }
-
-        page = page->next;
+    p = page->objects;
+    pend = p + MRB_HEAP_PAGE_SIZE;
+    for (;p < pend; p++) {
+      (*callback)(mrb, &p->as.basic, data);
     }
+
+    page = page->next;
+  }
 }
 
 #ifdef GC_TEST


### PR DESCRIPTION
- functions should have C linkage (for C++ code)
- add prefix to each_object_callback
- use more appropriate variable types / initialization
- ObjectSpace::count_objects has 1 opt. arg.
- prefer mrb_intern_lit to mrb_intern_cstr for str. lit.
- mruby/value.h is included by mruby.h
- adjust coding style
