### PR TITLE
Remove *very early version* notice

### DIFF
--- a/mrbgems/mruby-bin-mirb/tools/mirb/mirb.c
+++ b/mrbgems/mruby-bin-mirb/tools/mirb/mirb.c
@@ -215,9 +215,7 @@ cleanup(mrb_state *mrb, struct _args *args)
 static void
 print_hint(void)
 {
-  printf("mirb - Embeddable Interactive Ruby Shell\n");
-  printf("\nThis is a very early version, please test and report errors.\n");
-  printf("Thanks :)\n\n");
+  printf("mirb - Embeddable Interactive Ruby Shell\n\n");
 }
 
 /* Print the command line prompt of the REPL */

--- a/test/driver.c
+++ b/test/driver.c
@@ -24,9 +24,7 @@ mrb_init_mrbtest(mrb_state *);
 static void
 print_hint(void)
 {
-  printf("mrbtest - Embeddable Ruby Test\n");
-  printf("\nThis is a very early version, please test and report errors.\n");
-  printf("Thanks :)\n\n");
+  printf("mrbtest - Embeddable Ruby Test\n\n");
 }
 
 static int


### PR DESCRIPTION
Due to the reason that we have reached version 1 and  I didn't notice so many critical bugs in `mirb` or `mrbtest` lately, I suggest to remove the _very early version_ notice from `mirb` and `mrbtest`.
