### PR TITLE
Store raw stack address in callinfo instead of offset from stbas

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -53,7 +53,7 @@ typedef void* (*mrb_allocf) (struct mrb_state *mrb, void*, size_t, void *ud);
 typedef struct {
   mrb_sym mid;
   struct RProc *proc;
-  int stackidx;
+  mrb_value *stackent;
   int nregs;
   int argc;
   mrb_code *pc;                 /* return address */

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -218,7 +218,7 @@ mrb_f_block_given_p_m(mrb_state *mrb, mrb_value self)
   mrb_value *bp;
   mrb_bool given_p;
 
-  bp = mrb->c->stbase + ci->stackidx + 1;
+  bp = ci->stackent + 1;
   ci--;
   if (ci <= mrb->c->cibase) {
     given_p = 0;


### PR DESCRIPTION
Currentry, RIRE VM saves stack pointer as offset from stbase(bottom of stack) at method invocation. I modify to save stack pointer as raw address of stack. As a result of this change, I except getting better efficiency method call.
