### PR TITLE
Fix Kernel#global_variables for $1-$9

### DIFF
--- a/src/variable.c
+++ b/src/variable.c
@@ -1052,7 +1052,7 @@ mrb_f_global_variables(mrb_state *mrb, mrb_value self)
   buf[2] = 0;
   for (i = 1; i <= 9; ++i) {
     buf[1] = (char)(i + '0');
-    mrb_ary_push(mrb, ary, mrb_symbol_value(mrb_intern_lit(mrb, buf)));
+    mrb_ary_push(mrb, ary, mrb_symbol_value(mrb_intern(mrb, buf, 2)));
   }
   return ary;
 }

--- a/test/t/kernel.rb
+++ b/test/t/kernel.rb
@@ -479,7 +479,7 @@ assert('Kernel#!=') do
   assert_false (str2 != str1)
 end
 
-# operator "!~" is defined in ISO Ruby 11.4.4. 
+# operator "!~" is defined in ISO Ruby 11.4.4.
 assert('Kernel#!~') do
   x = "x"
   def x.=~(other)
@@ -509,6 +509,13 @@ assert('Kernel#respond_to_missing?') do
 
   assert_true Test4RespondToMissing.new.respond_to?(:a_method)
   assert_false Test4RespondToMissing.new.respond_to?(:no_method)
+end
+
+assert('Kernel#global_variables') do
+  variables = global_variables
+  1.upto(9) do |i|
+    assert_equal variables.include?(:"$#{i}"), true
+  end
 end
 
 assert('stack extend') do


### PR DESCRIPTION
This patch fix wrong symbols for global variables $1-$9.

Before:

``` ruby
> global_variables
 => [:"\000\000", :"\000\000", :"\000\000", :"\000\000", :"\000\000", :"\000\000", :"\000\000", :"\000\000", :"\000\000"]
```

After:

``` ruby
> global_variables
 => [:$1, :$2, :$3, :$4, :$5, :$6, :$7, :$8, :$9]
```

ps. I'm new with mruby, may be this variables should be assigned in a different place. This global variables assign when we call `global_variables`

``` ruby
list1 = Symbol.all_symbols.dup
global_variables
p Symbol.all_symbols - list1
```

Without patch: 

```
[:"\177\000", :"\177\000", :"\177\000", :"\177\000", :"\177\000", :"\177\000"]
```

With patch:

```
[:$6, :$3, :$1, :$2, :$5, :$7, :$8, :$9, :$4]
```
