### PR TITLE
mruby-math: remove Cygwin compatibility macros

### DIFF
--- a/mrbgems/mruby-math/src/math.c
+++ b/mrbgems/mruby-math/src/math.c
@@ -359,14 +359,6 @@ math_atanh(mrb_state *mrb, mrb_value obj)
 /*
   EXPONENTIALS AND LOGARITHMS
 */
-#if defined __CYGWIN__
-# include <cygwin/version.h>
-# if CYGWIN_VERSION_DLL_MAJOR < 1005
-#  define nan(x) nan()
-# endif
-# define log(x) ((x) < 0.0 ? nan("") : log(x))
-# define log10(x) ((x) < 0.0 ? nan("") : log10(x))
-#endif
 
 /*
  *  call-seq:


### PR DESCRIPTION
nan:
 The first non-test release of Cygwin 1.5.x was over a decade ago:
 http://cygwin.com/ml/cygwin-announce/2003-09/msg00001.html

log/log10:
 This workaround is not needed anymore (1.2.6.1, 1.3 - both over 6 years ago):
 https://sourceware.org/cgi-bin/cvsweb.cgi/src/newlib/libm/math/w_log.c?cvsroot=src
