### PR TITLE
Rakefile: make bin directory

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -33,8 +33,11 @@ load "#{MRUBY_ROOT}/test/mrbtest.rake"
 # generic build targets, rules
 task :default => :all
 
+bin_path = "#{MRUBY_ROOT}/bin"
+FileUtils.mkdir_p bin_path, { :verbose => $verbose }
+
 depfiles = MRuby.targets['host'].bins.map do |bin|
-  install_path = MRuby.targets['host'].exefile("#{MRUBY_ROOT}/bin/#{bin}")
+  install_path = MRuby.targets['host'].exefile("#{bin_path}/#{bin}")
   source_path = MRuby.targets['host'].exefile("#{MRuby.targets['host'].build_dir}/bin/#{bin}")
 
   file install_path => source_path do |t|


### PR DESCRIPTION
Sometimes `./bin/` doesn't exist because I removed or didn't copy/move it.
I think making sure it does, shouldn't be a big problem.
And the error message, if it doesn't, might be confusing for some people:

```
AR    build/host/lib/libmruby_core.lib
LD    build/host/bin/mrbc.exe
rake aborted!
No such file or directory - c:/libs/build/mruby-llvm/bin/mrbc.exe
c:/libs/build/mruby-llvm/Rakefile:42:in `block (2 levels) in <top (required)>
Tasks: TOP => default => all => c:/libs/build/mruby-llvm/bin/mrbc.exe
(See full trace by running task with --trace)
```
