### PR TITLE
Clang and ICC/ICL: define DIRECT_THREADED

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -527,7 +527,7 @@ argnum_error(mrb_state *mrb, int num)
 #define CODE_FETCH_HOOK(mrb, irep, pc, regs)
 #endif
 
-#ifdef __GNUC__
+#if defined __GNUC__ || defined __clang__ || defined __INTEL_COMPILER
 #define DIRECT_THREADED
 #endif
 


### PR DESCRIPTION
This is most likely only needed on Windows be-
cause **GNUC** is not defined by both compilers.

It might fail with some unusual configurations.
If that is the case, feel free to open an issue.
