### PR TITLE
MRUBY_VERSION should be only numbers separated by dot, like JRUBY_VERSION or Rubinius::VERSION

### DIFF
--- a/include/mruby/version.h
+++ b/include/mruby/version.h
@@ -4,7 +4,7 @@
 #define MRUBY_RUBY_VERSION "1.9"
 #define MRUBY_RUBY_ENGINE  "mruby"
 
-#define MRUBY_VERSION "v1.0.0"
+#define MRUBY_VERSION "1.0.0"
 #define MRUBY_RELEASE_MAJOR 1
 #define MRUBY_RELEASE_MINOR 0
 #define MRUBY_RELEASE_TEENY 1


### PR DESCRIPTION
JRUBY_VERSION and Rubinius::VERSION are as follows:

``` sh
$ jruby -e 'p JRUBY_VERSION'
"1.7.4"
$ rbx -e 'p Rubinius::VERSION'
"2.2.3"
```

They are same fomrat as RUBY_VERSION:

``` sh
$ ruby -e 'p RUBY_VERSION'
"2.1.0"
```

So IMHO, it's better to use same format for MRUBY_VERSION, like "1.0.0", not "v1.0.0".
