### PR TITLE
Give the type 'void' to functions have no argument.

### DIFF
--- a/mrbgems/mruby-random/src/random.c
+++ b/mrbgems/mruby-random/src/random.c
@@ -30,12 +30,12 @@ static void mt_g_srand(unsigned long seed)
   init_genrand(seed);
 }
 
-static unsigned long mt_g_rand()
+static unsigned long mt_g_rand(void)
 {
   return genrand_int32();
 }
 
-static double mt_g_rand_real()
+static double mt_g_rand_real(void)
 {
   return genrand_real1();
 }


### PR DESCRIPTION
According to the C standard, it is desirable to give the type 'void' to a function has no argument.
