### PR TITLE
modify mrb_to_str() in order to display big float number

### DIFF
--- a/src/numeric.c
+++ b/src/numeric.c
@@ -187,7 +187,8 @@ mrb_flo_to_str(mrb_state *mrb, mrb_value flo, int max_digit)
       }
 
       if (exp >= 100) {
-        mrb_raise(mrb, E_RANGE_ERROR, "Too large exponent.");
+        *(c++) = '0' + exp / 100;
+        exp -= exp / 100 * 100;
       }
 
       *(c++) = '0' + exp / 10;


### PR DESCRIPTION
before:

```
(mirb)> 10.0**100
RangeError: Too large exponent.
```

after:

```
(mirb)> 10.0**100   
 => 1.0e+100
```
