### PR TITLE
feature: add mrb_fatal

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -46,6 +46,7 @@ struct mrb_irep;
 struct mrb_state;
 
 typedef void* (*mrb_allocf) (struct mrb_state *mrb, void*, size_t, void *ud);
+typedef void (*mrb_fatalf)(struct mrb_state *, const char *);
 
 #ifndef MRB_GC_ARENA_SIZE
 #define MRB_GC_ARENA_SIZE 100
@@ -101,6 +102,7 @@ typedef struct mrb_state {
   void *jmp;
 
   mrb_allocf allocf;                      /* memory allocation function */
+  mrb_fatalf fatalf;
 
   struct mrb_context *c;
   struct mrb_context *root_c;
@@ -317,6 +319,8 @@ mrb_value mrb_obj_clone(mrb_state *mrb, mrb_value self);
 #define TOUPPER(c) (ISASCII(c) ? toupper((int)(unsigned char)(c)) : (c))
 #define TOLOWER(c) (ISASCII(c) ? tolower((int)(unsigned char)(c)) : (c))
 #endif
+
+void mrb_fatal(mrb_state *, const char *);
 
 mrb_value mrb_exc_new(mrb_state *mrb, struct RClass *c, const char *ptr, long len);
 void mrb_exc_raise(mrb_state *mrb, mrb_value exc);

--- a/src/error.c
+++ b/src/error.c
@@ -219,7 +219,7 @@ mrb_exc_raise(mrb_state *mrb, mrb_value exc)
   exc_debug_info(mrb, mrb->exc);
   if (!mrb->jmp) {
     mrb_p(mrb, exc);
-    abort();
+    mrb_fatal(mrb, NULL);
   }
   mrb_longjmp(mrb);
 }

--- a/src/gc.c
+++ b/src/gc.c
@@ -5,7 +5,6 @@
 */
 
 #include <string.h>
-#include <stdlib.h>
 #include "mruby.h"
 #include "mruby/array.h"
 #include "mruby/class.h"
@@ -185,11 +184,11 @@ mrb_realloc(mrb_state *mrb, void *p, size_t len)
   p2 = mrb_realloc_simple(mrb, p, len);
   if (!p2 && len) {
     if (mrb->out_of_memory) {
-      /* mrb_panic(mrb); */
+      mrb_fatal(mrb, "out of memory");
     }
     else {
       mrb->out_of_memory = TRUE;
-      mrb_raise(mrb, E_RUNTIME_ERROR, "Out of memory");
+      mrb_raise(mrb, E_RUNTIME_ERROR, "out of memory");
     }
   }
   else {
@@ -422,9 +421,7 @@ static inline void
 add_gray_list(mrb_state *mrb, struct RBasic *obj)
 {
 #ifdef MRB_GC_STRESS
-  if (obj->tt > MRB_TT_MAXDEFINE) {
-    abort();
-  }
+  mrb_assert(obj->tt < MRB_TT_MAXDEFINE);
 #endif
   paint_gray(obj);
   obj->gcnext = mrb->gray_list;

--- a/src/vm.c
+++ b/src/vm.c
@@ -21,16 +21,6 @@
 #include "opcode.h"
 #include "value_array.h"
 
-#ifndef ENABLE_STDIO
-#if defined(__cplusplus)
-extern "C" {
-#endif
-void abort(void);
-#if defined(__cplusplus)
-}  /* extern "C" { */
-#endif
-#endif
-
 #define SET_TRUE_VALUE(r) MRB_SET_VALUE(r, MRB_TT_TRUE, value.i, 1)
 #define SET_FALSE_VALUE(r) MRB_SET_VALUE(r, MRB_TT_FALSE, value.i, 1)
 #define SET_NIL_VALUE(r) MRB_SET_VALUE(r, MRB_TT_FALSE, value.i, 0)
@@ -2128,7 +2118,7 @@ mrb_context_run(mrb_state *mrb, struct RProc *proc, mrb_value self, unsigned int
 #ifdef ENABLE_STDIO
       printf("OP_DEBUG %d %d %d\n", GETARG_A(i), GETARG_B(i), GETARG_C(i));
 #else
-      abort();
+      mrb_fatal(mrb, NULL);
 #endif
 #endif
       NEXT;


### PR DESCRIPTION
**mrb_state.fatalf**
- synopsis: `typedef void (*mrb_fatalf)(struct mrb_state *, const char *);`
- an error message is optional (2nd argument == NULL)
- may be used to “rescue” a fatal error if an abort(3) call is undesirable
- by default a nonnull error message and '\n' will be written to stderr(3)

**mrb_fatal**
-  calls `(*mrb_state.fatalf)()` if it is not NULL
-  calls abort(3) if `(*mrb_state.fatalf)()` is NULL or returns

And a somewhat related fix:
add_gray_list: prefer an assertation and MRB_TT_MAXDEFINE is invalid, too

This (or at least a very similar) feature was already discussed in the past but the proposed name was `mrb_panic`. I don't have a strong opinion on the name. I just renamed it because I think **fatal** feels more “natural” to Ruby programmers - even though here it isn't an exception like in CRuby.

See #1064 for a previous discussion and #1700: maybe this feature could have been helpful here but that question wasn't answered yet.
And http://www.lua.org/manual/5.2/manual.html#4.6 for a description of Lua's panic function.
