### PR TITLE
Fix unused function warning when readline enabled (mirb)

### DIFF
--- a/mrbgems/mruby-bin-mirb/tools/mirb/mirb.c
+++ b/mrbgems/mruby-bin-mirb/tools/mirb/mirb.c
@@ -218,6 +218,7 @@ print_hint(void)
   printf("mirb - Embeddable Interactive Ruby Shell\n\n");
 }
 
+#ifndef ENABLE_READLINE
 /* Print the command line prompt of the REPL */
 static void
 print_cmdline(int code_block_open)
@@ -229,6 +230,7 @@ print_cmdline(int code_block_open)
     printf("> ");
   }
 }
+#endif 
 
 void mrb_codedump_all(mrb_state*, struct RProc*);
 


### PR DESCRIPTION
Fix below warning occured when READLINE enabled.

``` sh
CC    mrbgems/mruby-bin-mirb/tools/mirb/mirb.c -> build/host/mrbgems/mruby-bin-mirb/tools/mirb/mirb.o
/Users/koji/work/mruby/mruby/mrbgems/mruby-bin-mirb/tools/mirb/mirb.c:223:1: warning: unused function 'print_cmdline'
      [-Wunused-function]
print_cmdline(int code_block_open)
^
1 warning generated.
```
