### PR TITLE
Make mruby build directory customizable.

### DIFF
--- a/tasks/mruby_build.rake
+++ b/tasks/mruby_build.rake
@@ -206,7 +206,7 @@ module MRuby
   class CrossBuild < Build
     attr_block %w(test_runner)
 
-    def initialize(name, &block)
+    def initialize(name, build_dir=nil, &block)
   @test_runner = Command::CrossTestRunner.new(self)
   super
     end


### PR DESCRIPTION
With this pull request will make files generated by mruby to be created to any one of directory from the following
- directory specified in `MRuby::Build` construction
- environment variable _MRUBY_BUILD_DIR_ (which overwrites default output directory)
- "#{MRUBY_ROOT}/build" (former and default output directory)
