### PR TITLE
Always include build_config.rb to compile dependency.

### DIFF
--- a/tasks/mruby_build_commands.rake
+++ b/tasks/mruby_build_commands.rake
@@ -110,7 +110,7 @@ module MRuby
         File.read(file).gsub("\\\n ", "").scan(/^\S+:\s+(.+)$/).flatten.map {|s| s.split(' ') }.flatten
       else
         []
-      end
+      end + [ MRUBY_CONFIG ]
     end
   end
 


### PR DESCRIPTION
build_config.rb modifies `cc.defines` (eg. `DISABLE_GEMS`) so files depending on such flags should be rebuilt.
1. rake without any gems
2. edit build_config.rb to add gem
3. rake (without rake clean)

rake output `Build summary` with `Included Gems` but actually `DISABLE_GEMS` flag lives.

Ref. (Failing scenario script): https://gist.github.com/cho45/9181191
