### PR TITLE
mrb_flo_to_str: treat subnormals as zero

### DIFF
--- a/src/numeric.c
+++ b/src/numeric.c
@@ -109,138 +109,131 @@ num_div(mrb_state *mrb, mrb_value x)
  */
 
 static mrb_value
-mrb_flo_to_str(mrb_state *mrb, mrb_float flo)
+mrb_flo_to_str_normal(mrb_state *mrb, double n)
 {
-  double n = (double)flo;
   int max_digits = FLO_MAX_DIGITS;
+  int digit;
+  int m = 0;
+  int exp;
+  mrb_bool e = FALSE;
+  char s[48];
+  char *c = &s[0];
+  int length = 0;
 
-  if (isnan(n)) {
-    return mrb_str_new_lit(mrb, "NaN");
+  if (signbit(n)) {
+    n = -n;
+    *(c++) = '-';
   }
-  else if (isinf(n)) {
-    if (n < 0) {
-      return mrb_str_new_lit(mrb, "-inf");
-    }
-    else {
-      return mrb_str_new_lit(mrb, "inf");
-    }
+
+  if (n > 1.0) {
+    exp = (int)floor(log10(n));
   }
   else {
-    int digit;
-    int m = 0;
-    int exp;
-    mrb_bool e = FALSE;
-    char s[48];
-    char *c = &s[0];
-    int length = 0;
+    exp = (int)-ceil(-log10(n));
+  }
 
-    if (signbit(n)) {
-      n = -n;
+  /* preserve significands */
+  if (exp < 0) {
+    int i, beg = -1, end = 0;
+    double f = n;
+    double fd = 0;
+    for (i = 0; i < FLO_MAX_DIGITS; ++i) {
+      f = (f - fd) * 10.0;
+      fd = floor(f + FLO_EPSILON);
+      if (fd != 0) {
+        if (beg < 0) beg = i;
+        end = i + 1;
+      }
+    }
+    if (beg >= 0) length = end - beg;
+    if (length > FLO_MAX_SIGN_LENGTH) length = FLO_MAX_SIGN_LENGTH;
+  }
+
+  if (abs(exp) + length >= FLO_MAX_DIGITS) {
+    /* exponent representation */
+    e = TRUE;
+    n = n / pow(10.0, exp);
+  }
+  else {
+    /* un-exponent (normal) representation */
+    if (exp > 0) {
+      m = exp;
+    }
+  }
+
+  /* puts digits */
+  while (max_digits >= 0) {
+    double weight = pow(10.0, m);
+    double fdigit = n / weight;
+
+    if (fdigit < 0) fdigit = n = 0;
+    if (m < -1 && fdigit < FLO_EPSILON) {
+      if (e || exp > 0 || m <= -abs(exp)) {
+        break;
+      }
+    }
+    digit = (int)floor(fdigit + FLO_EPSILON);
+    if (m == 0 && digit > 9) {
+      n /= 10.0;
+      exp++;
+      continue;
+    }
+    *(c++) = '0' + digit;
+    n -= (digit * weight);
+    max_digits--;
+    if (m-- == 0) {
+      *(c++) = '.';
+    }
+  }
+  if (c[-1] == '0') {
+    while (&s[0] < c && c[-1] == '0') {
+      c--;
+    }
+    c++;
+  }
+
+  if (e) {
+    *(c++) = 'e';
+    if (exp > 0) {
+      *(c++) = '+';
+    }
+    else {
       *(c++) = '-';
+      exp = -exp;
     }
 
-    if (n != 0.0) {
-      if (n > 1.0) {
-        exp = (int)floor(log10(n));
-      }
-      else {
-        exp = (int)-ceil(-log10(n));
-      }
-    }
-    else {
-      exp = 0;
-    }
-    
-    /* preserve significands */
-    if (exp < 0) {
-      int i, beg = -1, end = 0;
-      double f = n;
-      double fd = 0;
-      for (i = 0; i < FLO_MAX_DIGITS; ++i) {
-        f = (f - fd) * 10.0;
-        fd = floor(f + FLO_EPSILON);
-        if (fd != 0) {
-          if (beg < 0) beg = i;
-          end = i + 1;
-        }
-      }
-      if (beg >= 0) length = end - beg;
-      if (length > FLO_MAX_SIGN_LENGTH) length = FLO_MAX_SIGN_LENGTH;
+    if (exp >= 100) {
+      *(c++) = '0' + exp / 100;
+      exp -= exp / 100 * 100;
     }
 
-    if (abs(exp) + length >= FLO_MAX_DIGITS) {
-      /* exponent representation */
-      e = TRUE;
-      n = n / pow(10.0, exp);
-      if (isinf(n)) {
-        if (s < c) {            /* s[0] == '-' */
-          return mrb_str_new_lit(mrb, "-0.0");
-        }
-        else {
-          return mrb_str_new_lit(mrb, "0.0");
-        }
-      }
-    }
-    else {
-      /* un-exponent (normal) representation */
-      if (exp > 0) {
-        m = exp;
-      }
-    }
+    *(c++) = '0' + exp / 10;
+    *(c++) = '0' + exp % 10;
+  }
 
-    /* puts digits */
-    while (max_digits >= 0) {
-      double weight = pow(10.0, m);
-      double fdigit = n / weight;
+  *c = '\0';
 
-      if (fdigit < 0) fdigit = n = 0;
-      if (m < -1 && fdigit < FLO_EPSILON) {
-        if (e || exp > 0 || m <= -abs(exp)) {
-          break;
-        }
-      }
-      digit = (int)floor(fdigit + FLO_EPSILON);
-      if (m == 0 && digit > 9) {
-        n /= 10.0;
-        exp++;
-        continue;
-      }
-      *(c++) = '0' + digit;
-      n -= (digit * weight);
-      max_digits--;
-      if (m-- == 0) {
-        *(c++) = '.';
-      }
-    }
-    if (c[-1] == '0') {
-      while (&s[0] < c && c[-1] == '0') {
-        c--;
-      }
-      c++;
-    }
+  return mrb_str_new(mrb, &s[0], c - &s[0]);
+}
 
-    if (e) {
-      *(c++) = 'e';
-      if (exp > 0) {
-        *(c++) = '+';
-      }
-      else {
-        *(c++) = '-';
-        exp = -exp;
-      }
-
-      if (exp >= 100) {
-        *(c++) = '0' + exp / 100;
-        exp -= exp / 100 * 100;
-      }
-
-      *(c++) = '0' + exp / 10;
-      *(c++) = '0' + exp % 10;
-    }
-
-    *c = '\0';
-
-    return mrb_str_new(mrb, &s[0], c - &s[0]);
+static mrb_value
+mrb_flo_to_str(mrb_state *mrb, mrb_float flo)
+{
+  switch (fpclassify(flo)) {
+  case FP_INFINITE:
+    return signbit(flo) ? mrb_str_new_lit(mrb, "-inf") : mrb_str_new_lit(mrb, "inf");
+  case FP_NAN:
+    return mrb_str_new_lit(mrb, "NaN");
+  case FP_NORMAL:
+    return mrb_flo_to_str_normal(mrb, (double)flo);
+  case FP_SUBNORMAL:
+    /* fall through */
+  case FP_ZERO:
+    return signbit(flo) ? mrb_str_new_lit(mrb, "-0.0") : mrb_str_new_lit(mrb, "0.0");
+  default:
+    /* unreachable */
+    mrb_assert(0);
+    return mrb_nil_value();
   }
 }
 


### PR DESCRIPTION
I hope `mrb_flo_to_str_normal` is okay (besides naming issues). I just thought `mrb_flo_to_str` was getting too long and hard to read (many conditionals and indentation).
