### PR TITLE
fix bug for get_valid_iv_sym

### DIFF
--- a/src/kernel.c
+++ b/src/kernel.c
@@ -585,7 +585,7 @@ get_valid_iv_sym(mrb_state *mrb, mrb_value iv_name)
   mrb_assert(mrb_symbol_p(iv_name) || mrb_string_p(iv_name));
 
   if (mrb_string_p(iv_name)) {
-    iv_name_id = mrb_intern_cstr(mrb, RSTRING_PTR(iv_name));
+    iv_name_id = mrb_intern(mrb, RSTRING_PTR(iv_name), RSTRING_LEN(iv_name));
     valid_iv_name(mrb, iv_name_id, RSTRING_PTR(iv_name), RSTRING_LEN(iv_name));
   }
   else {


### PR DESCRIPTION
When sub-string is used in the following way, it does not work well.

``` ruby
o = Object.new
o.instance_variable_set(:@a, 1)
o.instance_variable_defined?("@abc"[0,2]) #=> false (this should be true)
```

Thanks @tsahara for providing an  example.
