### PR TITLE
Use mrb_str_new_lit instead of mrb_str_new for C string literal

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -1342,7 +1342,7 @@ mrb_context_run(mrb_state *mrb, struct RProc *proc, mrb_value self, unsigned int
               goto L_RAISE;
             }
             if (mrb->c->prev->ci == mrb->c->prev->cibase) {
-              mrb_value exc = mrb_exc_new_str(mrb, E_RUNTIME_ERROR, mrb_str_new(mrb, "double resume", 13));
+              mrb_value exc = mrb_exc_new_str(mrb, E_RUNTIME_ERROR, mrb_str_new_lit(mrb, "double resume"));
               mrb->exc = mrb_obj_ptr(exc);
               goto L_RAISE;
             }


### PR DESCRIPTION
Continued from #1742.
