### PR TITLE
Delete `!!Notice!!` intro paragraph from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,3 @@
-# !!Notice!!
-    This is a preliminary release for internal team review.
-    The URLs and addresses described below are not available yet.
-    The official release will be announced later.
-    Any suggestions for modification are welcome.
-    Delays in replies are to be expected. Sorry in advance.
-
 [![Build Status](https://travis-ci.org/mruby/mruby.png?branch=master)](https://travis-ci.org/mruby/mruby)
 
 ## What's mruby


### PR DESCRIPTION
It's become misleading since the release of 1.0.0 and the launch of mruby.org.
