### PR TITLE
fix SEGV bug for mrb_str_new

### DIFF
--- a/src/string.c
+++ b/src/string.c
@@ -216,6 +216,9 @@ mrb_value
 mrb_str_new(mrb_state *mrb, const char *p, size_t len)
 {
   struct RString *s;
+  if ((mrb_int)len < 0) {
+    mrb_raise(mrb, E_ARGUMENT_ERROR, "negative string size (or size too big)");
+  }
 
   s = str_new(mrb, p, len);
   return mrb_obj_value(s);


### PR DESCRIPTION
`mrb_str_new` causes seg-fault when 3rd argument is negative.

``` c
/* example for reproducing */
mrb_value s = mrb_str_new(mrb, "string", -1);
```
