### PR TITLE
fix SEGV bug for mrb_str_new_static

### DIFF
--- a/src/string.c
+++ b/src/string.c
@@ -256,6 +256,9 @@ mrb_value
 mrb_str_new_static(mrb_state *mrb, const char *p, size_t len)
 {
   struct RString *s;
+  if ((mrb_int)len < 0) {
+    mrb_raise(mrb, E_ARGUMENT_ERROR, "negative string size (or size too big)");
+  }
 
   s = mrb_obj_alloc_string(mrb);
   s->len = len;


### PR DESCRIPTION
`mrb_str_new_static` has the potential to cause seg-fault when 3rd argument is negative.

``` c
/* example for reproducing */
mrb_value s = mrb_str_new_static(mrb, "string", -1);
mrb_str_cat_lit(mrb, s, "hoge");
```
