### PR TITLE
build_mrbconf.h

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -29,6 +29,9 @@ load "#{MRUBY_ROOT}/tasks/libmruby.rake"
 load "#{MRUBY_ROOT}/tasks/mrbgems_test.rake"
 load "#{MRUBY_ROOT}/test/mrbtest.rake"
 
+# generate build specific mrbconf.h (build_mrbconf.h)
+load "#{MRUBY_ROOT}/tasks/build_mrbconf.rake"
+
 ##############################
 # generic build targets, rules
 task :default => :all

--- a/Rakefile
+++ b/Rakefile
@@ -13,6 +13,9 @@ load "#{MRUBY_ROOT}/tasks/mrbgem_spec.rake"
 MRUBY_CONFIG = (ENV['MRUBY_CONFIG'] && ENV['MRUBY_CONFIG'] != '') ? ENV['MRUBY_CONFIG'] : "#{MRUBY_ROOT}/build_config.rb"
 load MRUBY_CONFIG
 
+# generate build specific mrbconf.h (build_mrbconf.h)
+load "#{MRUBY_ROOT}/tasks/build_mrbconf.rake"
+
 # load basic rules
 MRuby.each_target do |build|
   build.define_rules
@@ -28,9 +31,6 @@ load "#{MRUBY_ROOT}/tasks/libmruby.rake"
 
 load "#{MRUBY_ROOT}/tasks/mrbgems_test.rake"
 load "#{MRUBY_ROOT}/test/mrbtest.rake"
-
-# generate build specific mrbconf.h (build_mrbconf.h)
-load "#{MRUBY_ROOT}/tasks/build_mrbconf.rake"
 
 ##############################
 # generic build targets, rules

--- a/include/mrbconf.h
+++ b/include/mrbconf.h
@@ -7,6 +7,10 @@
 #ifndef MRUBYCONF_H
 #define MRUBYCONF_H
 
+#ifdef MRB_HAVE_BUILD_MRBCONF_H
+#include "build_mrbconf.h"
+#endif
+
 /* configuration options: */
 /* add -DMRB_USE_FLOAT to use float instead of double for floating point numbers */
 //#define MRB_USE_FLOAT

--- a/tasks/build_mrbconf.rake
+++ b/tasks/build_mrbconf.rake
@@ -1,4 +1,6 @@
 MRuby.each_target do |target|
+  next if mrbconf.empty?
+
   mrbconf_h = "#{build_dir}/include/build_mrbconf.h"
 
   source = <<EOS

--- a/tasks/build_mrbconf.rake
+++ b/tasks/build_mrbconf.rake
@@ -1,0 +1,24 @@
+MRuby.each_target do |target|
+  mrbconf_h = "#{build_dir}/include/build_mrbconf.h"
+
+  source = <<EOS
+#ifndef MRB_BUILD_MRBCONF_H
+#define MRB_BUILD_MRBCONF_H
+
+#{mrbconf.map { |v| "#define MRB_#{v.to_s.upcase}" }.join("\n")}
+
+#endif
+EOS
+
+  if not File.exists? mrbconf_h or File.read(mrbconf_h) != source
+    FileUtils.mkdir_p File.dirname mrbconf_h
+    File.write mrbconf_h, source
+  end
+
+  file "#{MRUBY_ROOT}/include/mrbconf.h" => mrbconf_h
+
+  compilers.each do |v|
+    v.include_paths << File.dirname(mrbconf_h)
+    v.defines << 'MRB_HAVE_BUILD_MRBCONF_H'
+  end
+end

--- a/tasks/mruby_build.rake
+++ b/tasks/mruby_build.rake
@@ -44,7 +44,7 @@ module MRuby
     include Rake::DSL
     include LoadGems
     attr_accessor :name, :bins, :exts, :file_separator, :build_dir, :gem_clone_dir, :enable_bintest
-    attr_reader :libmruby, :gems
+    attr_reader :libmruby, :gems, :mrbconf
 
     COMPILERS = %w(cc cxx objc asm)
     COMMANDS = COMPILERS + %w(linker archiver yacc gperf git exts mrbc)
@@ -77,6 +77,7 @@ module MRuby
         @gperf = Command::Gperf.new(self)
         @git = Command::Git.new(self)
         @mrbc = Command::Mrbc.new(self)
+        @mrbconf = []
 
         @bins = %w(mrbc)
         @gems, @libmruby = MRuby::Gem::List.new, []
@@ -90,8 +91,13 @@ module MRuby
     end
 
     def enable_debug
-      compilers.each { |c| c.defines += %w(MRB_DEBUG) }
       @mrbc.compile_options += ' -g'
+      enable_mrbconf :debug
+    end
+
+    def enable_mrbconf(*args)
+      @mrbconf += args
+      @mrbconf.uniq
     end
 
     def toolchain(name)

--- a/travis_config.rb
+++ b/travis_config.rb
@@ -5,7 +5,7 @@ MRuby::Build.new('debug') do |conf|
   # include all core GEMs
   conf.gembox 'full-core'
   conf.cc.flags += %w(-Werror=declaration-after-statement)
-  conf.cc.defines += %w(MRB_GC_FIXED_ARENA)
+  conf.enable_mrbconf :gc_fixed_arena
 end
 
 MRuby::Build.new do |conf|
@@ -14,6 +14,6 @@ MRuby::Build.new do |conf|
   # include all core GEMs
   conf.gembox 'full-core'
   conf.cc.flags += %w(-Werror=declaration-after-statement)
-  conf.cc.defines = %w(MRB_DEBUG MRB_GC_FIXED_ARENA)
+  conf.enable_mrbconf :debug, :gc_fixed_arena
   conf.enable_bintest = true
 end


### PR DESCRIPTION
With this patch mruby build system can separate `mrbconf.h` macro and compiler flag macro.
To use `mrbconf.h` macro use `MRuby::Build#enable_mrbconf` method to enable specific macro easily instead of appending to `defines` property.
(if you need to enable `MRB_GC_FIXED_ARENA` call `enable_mrbconf :gc_fixed_arena`)

Additionally when you change **mrbconf** in **build_config.rb** the whole code would be recompiled with new **mrbconf** so that it's safer.

Though it has some limitation:
- it can't specify macro with value
- it can't disable mrbconf
- it can't detect conflict of mrbconfs
