### PR TITLE
Use C style comments instead of C++ style comments

### DIFF
--- a/examples/mrbgems/c_and_ruby_extension_example/src/example.c
+++ b/examples/mrbgems/c_and_ruby_extension_example/src/example.c
@@ -16,5 +16,5 @@ mrb_c_and_ruby_extension_example_gem_init(mrb_state* mrb) {
 
 void
 mrb_c_and_ruby_extension_example_gem_final(mrb_state* mrb) {
-  // finalizer
+  /* finalizer */
 }

--- a/examples/mrbgems/c_extension_example/src/example.c
+++ b/examples/mrbgems/c_extension_example/src/example.c
@@ -16,5 +16,5 @@ mrb_c_extension_example_gem_init(mrb_state* mrb) {
 
 void
 mrb_c_extension_example_gem_final(mrb_state* mrb) {
-  // finalizer
+  /* finalizer */
 }

--- a/include/mrbconf.h
+++ b/include/mrbconf.h
@@ -9,61 +9,61 @@
 
 /* configuration options: */
 /* add -DMRB_USE_FLOAT to use float instead of double for floating point numbers */
-//#define MRB_USE_FLOAT
+/* #define MRB_USE_FLOAT */
 
 /* add -DMRB_INT16 to use 16bit integer for mrb_int; conflict with MRB_INT64 */
-//#define MRB_INT16
+/* #define MRB_INT16 */
 
 /* add -DMRB_INT64 to use 64bit integer for mrb_int; conflict with MRB_INT16 */
-//#define MRB_INT64
+/* #define MRB_INT64 */
 
 /* represent mrb_value in boxed double; conflict with MRB_USE_FLOAT */
-//#define MRB_NAN_BOXING
+/* #define MRB_NAN_BOXING */
 
 /* define on big endian machines; used by MRB_NAN_BOXING */
-//#define MRB_ENDIAN_BIG
+/* #define MRB_ENDIAN_BIG */
 
 /* represent mrb_value as a word (natural unit of data for the processor) */
-// #define MRB_WORD_BOXING
+/* #define MRB_WORD_BOXING */
 
 /* argv max size in mrb_funcall */
-//#define MRB_FUNCALL_ARGC_MAX 16
+/* #define MRB_FUNCALL_ARGC_MAX 16 */
 
 /* number of object per heap page */
-//#define MRB_HEAP_PAGE_SIZE 1024
+/* #define MRB_HEAP_PAGE_SIZE 1024 */
 
 /* use segmented list for IV table */
-//#define MRB_USE_IV_SEGLIST
+/* #define MRB_USE_IV_SEGLIST */
 
 /* initial size for IV khash; ignored when MRB_USE_IV_SEGLIST is set */
-//#define MRB_IVHASH_INIT_SIZE 8
+/* #define MRB_IVHASH_INIT_SIZE 8 */
 
 /* turn off generational GC by default */
-//#define MRB_GC_TURN_OFF_GENERATIONAL
+/* #define MRB_GC_TURN_OFF_GENERATIONAL */
 
 /* default size of khash table bucket */
-//#define KHASH_DEFAULT_SIZE 32
+/* #define KHASH_DEFAULT_SIZE 32 */
 
 /* allocated memory address alignment */
-//#define POOL_ALIGNMENT 4
+/* #define POOL_ALIGNMENT 4 */
 
 /* page size of memory pool */
-//#define POOL_PAGE_SIZE 16000
+/* #define POOL_PAGE_SIZE 16000 */
 
 /* initial minimum size for string buffer */
-//#define MRB_STR_BUF_MIN_SIZE 128
+/* #define MRB_STR_BUF_MIN_SIZE 128 */
 
 /* arena size */
-//#define MRB_GC_ARENA_SIZE 100
+/* #define MRB_GC_ARENA_SIZE 100 */
 
 /* fixed size GC arena */
-//#define MRB_GC_FIXED_ARENA
+/* #define MRB_GC_FIXED_ARENA */
 
 /* -DDISABLE_XXXX to drop following features */
-//#define DISABLE_STDIO		/* use of stdio */
+/* #define DISABLE_STDIO */ /* use of stdio */
 
 /* -DENABLE_XXXX to enable following features */
-//#define ENABLE_DEBUG		/* hooks for debugger */
+/* #define ENABLE_DEBUG */ /* hooks for debugger */
 
 /* end of configuration */
 

--- a/include/mruby.h
+++ b/include/mruby.h
@@ -304,7 +304,7 @@ mrb_value mrb_obj_clone(mrb_state *mrb, mrb_value self);
 
 /* need to include <ctype.h> to use these macros */
 #ifndef ISPRINT
-//#define ISASCII(c) isascii((int)(unsigned char)(c))
+/* #define ISASCII(c) isascii((int)(unsigned char)(c)) */
 #define ISASCII(c) 1
 #define ISPRINT(c) (ISASCII(c) && isprint((int)(unsigned char)(c)))
 #define ISSPACE(c) (ISASCII(c) && isspace((int)(unsigned char)(c)))

--- a/include/mruby/dump.h
+++ b/include/mruby/dump.h
@@ -55,17 +55,17 @@ mrb_irep *mrb_read_irep(mrb_state*, const uint8_t*);
 
 #define MRB_DUMP_DEFAULT_STR_LEN      128
 
-// binary header
+/* binary header */
 struct rite_binary_header {
-  uint8_t binary_identify[4]; // Binary Identifier
-  uint8_t binary_version[4];  // Binary Format Version
-  uint8_t binary_crc[2];      // Binary CRC
-  uint8_t binary_size[4];     // Binary Size
-  uint8_t compiler_name[4];   // Compiler name
+  uint8_t binary_identify[4]; /* Binary Identifier */
+  uint8_t binary_version[4];  /* Binary Format Version */
+  uint8_t binary_crc[2];      /* Binary CRC */
+  uint8_t binary_size[4];     /* Binary Size */
+  uint8_t compiler_name[4];   /* Compiler name */
   uint8_t compiler_version[4];
 };
 
-// section header
+/* section header */
 #define RITE_SECTION_HEADER \
   uint8_t section_identify[4]; \
   uint8_t section_size[4]
@@ -77,7 +77,7 @@ struct rite_section_header {
 struct rite_section_irep_header {
   RITE_SECTION_HEADER;
 
-  uint8_t rite_version[4];    // Rite Instruction Specification Version
+  uint8_t rite_version[4];    /* Rite Instruction Specification Version */
 };
 
 struct rite_section_lineno_header {

--- a/include/mruby/khash.h
+++ b/include/mruby/khash.h
@@ -24,7 +24,7 @@ typedef khint_t khiter_t;
 
 #define UPPER_BOUND(x) ((x)>>2|(x)>>1)
 
-//extern uint8_t __m[];
+/* extern uint8_t __m[]; */
 
 /* mask for flags */
 static const uint8_t __m_empty[8]  = {0x02, 0x08, 0x20, 0x80};

--- a/include/mruby/variable.h
+++ b/include/mruby/variable.h
@@ -16,9 +16,9 @@ typedef struct global_variable {
     mrb_value *data;
     mrb_value (*getter)(void);
     void  (*setter)(void);
-    //void  (*marker)();
-    //int block_trace;
-    //struct trace_var *trace;
+    /* void  (*marker)(); */
+    /* int block_trace; */
+    /* struct trace_var *trace; */
 } global_variable;
 
 struct global_entry {

--- a/mrbgems/mruby-random/src/mt19937ar.c
+++ b/mrbgems/mruby-random/src/mt19937ar.c
@@ -8,7 +8,7 @@
 #include "mt19937ar.h"
 
 /* Period parameters */  
-//#define N 624
+/* #define N 624 */  
 #define M 397
 #define MATRIX_A 0x9908b0dfUL   /* constant vector a */
 #define UPPER_MASK 0x80000000UL /* most significant w-r bits */

--- a/mrbgems/mruby-random/src/random.h
+++ b/mrbgems/mruby-random/src/random.h
@@ -1,7 +1,7 @@
 /*
-// random.h - Random module
-//
-// See Copyright Notice in mruby.h
+** random.h - Random module
+**
+** See Copyright Notice in mruby.h
 */
 
 #ifndef RANDOM_H

--- a/mrbgems/mruby-struct/src/struct.c
+++ b/mrbgems/mruby-struct/src/struct.c
@@ -216,15 +216,15 @@ mrb_struct_set_m(mrb_state *mrb, mrb_value obj)
   return mrb_struct_set(mrb, obj, val);
 }
 
-#define is_notop_id(id) (id)//((id)>tLAST_TOKEN)
-#define is_local_id(id) (is_notop_id(id))//&&((id)&ID_SCOPE_MASK)==ID_LOCAL)
+#define is_notop_id(id) (id) /* ((id)>tLAST_TOKEN) */
+#define is_local_id(id) (is_notop_id(id)) /* &&((id)&ID_SCOPE_MASK)==ID_LOCAL) */
 int
 mrb_is_local_id(mrb_sym id)
 {
   return is_local_id(id);
 }
 
-#define is_const_id(id) (is_notop_id(id))//&&((id)&ID_SCOPE_MASK)==ID_CONST)
+#define is_const_id(id) (is_notop_id(id)) /* &&((id)&ID_SCOPE_MASK)==ID_CONST) */
 int
 mrb_is_const_id(mrb_sym id)
 {
@@ -251,7 +251,7 @@ make_struct(mrb_state *mrb, mrb_value name, mrb_value members, struct RClass * k
     }
     if (mrb_const_defined_at(mrb, klass, id)) {
       mrb_warn(mrb, "redefining constant Struct::%S", name);
-      //?rb_mod_remove_const(klass, mrb_sym2name(mrb, id));
+      /* ?rb_mod_remove_const(klass, mrb_sym2name(mrb, id)); */
     }
     c = mrb_define_class_under(mrb, klass, RSTRING_PTR(name), klass);
   }
@@ -262,7 +262,7 @@ make_struct(mrb_state *mrb, mrb_value name, mrb_value members, struct RClass * k
   mrb_define_class_method(mrb, c, "new", mrb_instance_new, MRB_ARGS_ANY());
   mrb_define_class_method(mrb, c, "[]", mrb_instance_new, MRB_ARGS_ANY());
   mrb_define_class_method(mrb, c, "members", mrb_struct_s_members_m, MRB_ARGS_NONE());
-  //RSTRUCT(nstr)->basic.c->super = c->c;
+  /* RSTRUCT(nstr)->basic.c->super = c->c; */
   ptr_members = RARRAY_PTR(members);
   len = RARRAY_LEN(members);
   for (i=0; i< len; i++) {

--- a/mrbgems/mruby-time/src/time.c
+++ b/mrbgems/mruby-time/src/time.c
@@ -137,7 +137,7 @@ mrb_time_update_datetime(struct mrb_time *self)
   }
   if (!aid) return NULL;
 #ifdef NO_GMTIME_R
-  self->datetime = *aid; // copy data
+  self->datetime = *aid; /* copy data */
 #endif
 
   return self;

--- a/src/class.c
+++ b/src/class.c
@@ -1931,7 +1931,6 @@ mrb_init_class(mrb_state *mrb)
   struct RClass *obj;           /* Object */
   struct RClass *mod;           /* Module */
   struct RClass *cls;           /* Class */
-  //struct RClass *krn;    /* Kernel */
 
   /* boot class hierarchy */
   bob = boot_defclass(mrb, 0);

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -535,15 +535,15 @@ for_body(codegen_scope *s, node *tree)
   node *n2;
   mrb_code c;
 
-  // generate receiver
+  /* generate receiver */
   codegen(s, tree->cdr->car, VAL);
-  // generate loop-block
+  /* generate loop-block */
   s = scope_new(s->mrb, s, tree->car);
 
   lp = loop_push(s, LOOP_FOR);
   lp->pc1 = new_label(s);
 
-  // generate loop variable
+  /* generate loop variable */
   n2 = tree->car;
   if (n2->car && !n2->car->cdr && !n2->cdr) {
     genop(s, MKOP_Ax(OP_ENTER, 0x40000));
@@ -718,7 +718,7 @@ gen_values(codegen_scope *s, node *t, int val)
   int is_splat;
 
   while (t) {
-    is_splat = (intptr_t)t->car->car == NODE_SPLAT; // splat mode
+    is_splat = (intptr_t)t->car->car == NODE_SPLAT; /* splat mode */
     if (n >= 127 || is_splat) {
       if (val) {
         pop_n(n);
@@ -756,7 +756,7 @@ gen_values(codegen_scope *s, node *t, int val)
       }
       return -1;
     }
-    // normal (no splat) mode
+    /* normal (no splat) mode */
     codegen(s, t->car, val);
     n++;
     t = t->cdr;
@@ -1531,7 +1531,7 @@ codegen(codegen_scope *s, node *tree, int val)
       int rhs = cursp();
 
       if ((intptr_t)t->car == NODE_ARRAY && nosplat(t->cdr)) {
-        // fixed rhs
+        /* fixed rhs */
         t = t->cdr;
         while (t) {
           codegen(s, t->car, VAL);
@@ -1580,7 +1580,7 @@ codegen(codegen_scope *s, node *tree, int val)
         }
       }
       else {
-        // variable rhs
+        /* variable rhs */
         codegen(s, t, VAL);
         gen_vmassignment(s, tree->car, rhs, val);
       }
@@ -1913,7 +1913,7 @@ codegen(codegen_scope *s, node *tree, int val)
     break;
 
   case NODE_ARG:
-    // should not happen
+    /* should not happen */
     break;
 
   case NODE_BLOCK_ARG:
@@ -2444,7 +2444,7 @@ scope_new(mrb_state *mrb, codegen_scope *prev, node *lv)
   }
   p->lineno = prev->lineno;
 
-  // debug setting
+  /* debug setting */
   p->debug_start_pos = 0;
   if(p->filename) {
     mrb_debug_info_alloc(mrb, p->irep);
@@ -2921,7 +2921,7 @@ mrb_generate_code(mrb_state *mrb, parser_state *p)
   scope->filename = p->filename;
   scope->filename_index = p->current_filename_index;
   if (setjmp(scope->jmp) == 0) {
-    // prepare irep
+    /* prepare irep */
     codegen(scope, p->tree, NOVAL);
     proc = mrb_proc_new(mrb, scope->irep);
     mrb_irep_decref(mrb, scope->irep);

--- a/src/crc.c
+++ b/src/crc.c
@@ -8,12 +8,13 @@
 #include <stdint.h>
 #include <stddef.h>
 
-// Calculate CRC (CRC-16-CCITT)
-//
-//  0000_0000_0000_0000_0000_0000_0000_0000
-//          ^|------- CRC -------|- work --|
-//        carry
-#define  CRC_16_CCITT       0x11021ul        //x^16+x^12+x^5+1
+/* Calculate CRC (CRC-16-CCITT)
+**
+**  0000_0000_0000_0000_0000_0000_0000_0000
+**          ^|------- CRC -------|- work --|
+**        carry
+*/
+#define  CRC_16_CCITT       0x11021ul        /* x^16+x^12+x^5+1 */
 #define  CRC_XOR_PATTERN    (CRC_16_CCITT << 8)
 #define  CRC_CARRY_BIT      (0x01000000)
 

--- a/src/debug.c
+++ b/src/debug.c
@@ -10,7 +10,7 @@ get_file(mrb_irep_debug_info *info, uint32_t pc)
   int32_t count;
 
   if(pc >= info->pc_count) { return NULL; }
-  // get upper bound
+  /* get upper bound */
   ret = info->files;
   count =  info->flen;
   while (count > 0) {
@@ -24,9 +24,9 @@ get_file(mrb_irep_debug_info *info, uint32_t pc)
 
   --ret;
 
-  // check returning file exists inside debug info
+  /* check returning file exists inside debug info */
   mrb_assert(info->files <= ret && ret < (info->files + info->flen));
-  // check pc is within the range of returning file
+  /* check pc is within the range of returning file */
   mrb_assert((*ret)->start_pos <= pc &&
              pc < (((ret + 1 - info->files) < info->flen)
                    ? (*(ret+1))->start_pos : info->pc_count));
@@ -77,7 +77,7 @@ mrb_debug_get_line(mrb_irep *irep, uint32_t pc)
           return f->line_ary[pc - f->start_pos];
 
         case mrb_debug_line_flat_map: {
-          // get upper bound
+          /* get upper bound */
           mrb_irep_debug_info_line *ret = f->line_flat_map;
           uint32_t count = f->line_entry_count;
           while (count > 0) {
@@ -91,9 +91,9 @@ mrb_debug_get_line(mrb_irep *irep, uint32_t pc)
 
           --ret;
 
-          // check line entry pointer range
+          /* check line entry pointer range */
           mrb_assert(f->line_flat_map <= ret && ret < (f->line_flat_map + f->line_entry_count));
-          // check pc range
+          /* check pc range */
           mrb_assert(ret->start_pos <= pc &&
                      pc < (((ret + 1 - f->line_flat_map) < f->line_entry_count)
                            ? (ret+1)->start_pos : irep->debug_info->pc_count));
@@ -185,7 +185,7 @@ mrb_debug_info_append_file(mrb_state *mrb, mrb_irep *irep,
         m.line = irep->lines[start_pos + i];
         ret->line_flat_map[ret->line_entry_count] = m;
 
-        // update
+        /* update */
         ++ret->line_entry_count;
         prev_line = irep->lines[start_pos + i];
       }

--- a/src/dump.c
+++ b/src/dump.c
@@ -317,7 +317,7 @@ write_section_lineno_header(mrb_state *mrb, uint32_t section_size, uint8_t *bin)
 {
   struct rite_section_lineno_header *header = (struct rite_section_lineno_header*)bin;
 
-  // TODO
+  /* TODO */
   memcpy(header->section_identify, RITE_SECTION_LINENO_IDENTIFIER, sizeof(header->section_identify));
   uint32_to_bin(section_size, header->section_size);
 
@@ -329,14 +329,14 @@ get_lineno_record_size(mrb_state *mrb, mrb_irep *irep)
 {
   size_t size = 0;
 
-  size += sizeof(uint32_t); // record size
-  size += sizeof(uint16_t); // filename size
+  size += sizeof(uint32_t); /* record size */
+  size += sizeof(uint16_t); /* filename size */
   if (irep->filename) {
-    size += strlen(irep->filename); // filename
+    size += strlen(irep->filename); /* filename */
   }
-  size += sizeof(uint32_t); // niseq
+  size += sizeof(uint32_t); /* niseq */
   if (irep->lines) {
-    size += sizeof(uint16_t) * irep->ilen; // lineno
+    size += sizeof(uint16_t) * irep->ilen; /* lineno */
   }
   return size;
 }
@@ -419,18 +419,18 @@ get_debug_record_size(mrb_state *mrb, mrb_irep *irep)
   uint32_t f_idx;
   size_t i;
 
-  ret += sizeof(uint32_t); // record size
-  ret += sizeof(uint16_t); // file count
+  ret += sizeof(uint32_t); /* record size */
+  ret += sizeof(uint16_t); /* file count */
 
   for (f_idx = 0; f_idx < irep->debug_info->flen; ++f_idx) {
     mrb_irep_debug_info_file const* file = irep->debug_info->files[f_idx];
 
-    ret += sizeof(uint32_t); // position
-    ret += sizeof(uint16_t); // filename index
+    ret += sizeof(uint32_t); /* position */
+    ret += sizeof(uint16_t); /* filename index */
 
-    // lines
-    ret += sizeof(uint32_t); // entry count
-    ret += sizeof(uint8_t); // line type
+    /* lines */
+    ret += sizeof(uint32_t); /* entry count */
+    ret += sizeof(uint8_t); /* line type */
     switch(file->line_type) {
       case mrb_debug_line_ary:
         ret += sizeof(uint16_t) * file->line_entry_count;
@@ -480,12 +480,12 @@ get_filename_table_size(mrb_state *mrb, mrb_irep *irep, mrb_sym **fp, size_t *lp
 
     file = di->files[file_i];
     if (find_filename_index(filenames, *lp, file->filename_sym) == -1) {
-      // register filename
+      /* register filename */
       *lp += 1;
       *fp = filenames = (mrb_sym *)mrb_realloc(mrb, filenames, sizeof(mrb_sym) * (*lp));
       filenames[*lp - 1] = file->filename_sym;
 
-      // filename
+      /* filename */
       mrb_sym2name_len(mrb, file->filename_sym, &filename_len);
       size += sizeof(uint16_t) + filename_len;
     }
@@ -504,23 +504,23 @@ write_debug_record_1(mrb_state *mrb, mrb_irep *irep, uint8_t *bin, mrb_sym const
   uint32_t f_idx;
   size_t ret;
 
-  cur = bin + sizeof(uint32_t); // skip record size
-  cur += uint16_to_bin(irep->debug_info->flen, cur); // file count
+  cur = bin + sizeof(uint32_t); /* skip record size */
+  cur += uint16_to_bin(irep->debug_info->flen, cur); /* file count */
 
   for (f_idx = 0; f_idx < irep->debug_info->flen; ++f_idx) {
     int filename_idx;
     const mrb_irep_debug_info_file *file = irep->debug_info->files[f_idx];
 
-    // position
+    /* position */
     cur += uint32_to_bin(file->start_pos, cur);
 
-    // filename index
+    /* filename index */
     filename_idx = find_filename_index(filenames, filenames_len,
                                                   file->filename_sym);
     mrb_assert(filename_idx != -1);
     cur += uint16_to_bin(filename_idx, cur);
 
-    // lines
+    /* lines */
     cur += uint32_to_bin(file->line_entry_count, cur);
     cur += uint8_to_bin(file->line_type, cur);
     switch(file->line_type) {
@@ -581,12 +581,12 @@ write_filename_table(mrb_state *mrb, mrb_irep *irep, uint8_t **cp, mrb_sym **fp,
     mrb_irep_debug_info_file *file = debug_info->files[file_i];
     if (find_filename_index(filenames, *lp, file->filename_sym) != -1) continue;
 
-    // register filename
+    /* register filename */
     *lp += 1;
     *fp = filenames = (mrb_sym*)mrb_realloc(mrb, filenames, sizeof(mrb_sym) * (*lp));
     filenames[*lp - 1] = file->filename_sym;
 
-    // filename
+    /* filename */
     fn_len = (uint16_t)strlen(file->filename);
     cur += uint16_to_bin(fn_len, cur);
     memcpy(cur, file->filename, fn_len);
@@ -620,7 +620,7 @@ write_section_debug(mrb_state *mrb, mrb_irep *irep, uint8_t *cur)
   cur += sizeof(struct rite_section_debug_header);
   section_size += sizeof(struct rite_section_debug_header);
 
-  // filename table
+  /* filename table */
   filenames = (mrb_sym *)mrb_malloc(mrb, sizeof(mrb_sym) * 1);
   filenames_len_out = cur;
   cur += sizeof(uint16_t);
@@ -628,7 +628,7 @@ write_section_debug(mrb_state *mrb, mrb_irep *irep, uint8_t *cur)
   section_size += write_filename_table(mrb, irep, &cur, &filenames, &filenames_len);
   uint16_to_bin(filenames_len, filenames_len_out);
 
-  // debug records
+  /* debug records */
   dlen = write_debug_record(mrb, irep, cur, filenames, filenames_len);
   section_size += dlen;
 
@@ -695,10 +695,10 @@ dump_irep(mrb_state *mrb, mrb_irep *irep, int debug_info, uint8_t **bin, size_t 
       mrb_sym *filenames;
 
       section_lineno_size += sizeof(struct rite_section_debug_header);
-      // filename table
+      /* filename table */
       filenames = (mrb_sym*)mrb_malloc(mrb, sizeof(mrb_sym) + 1);
 
-      // filename table size
+      /* filename table size */
       section_lineno_size += sizeof(uint16_t);
       section_lineno_size += get_filename_table_size(mrb, irep, &filenames, NULL);
       mrb_free(mrb, filenames);
@@ -803,7 +803,7 @@ mrb_dump_irep_cfunc(mrb_state *mrb, mrb_irep *irep, int debug_info, FILE *fp, co
 
   result = dump_irep(mrb, irep, debug_info, &bin, &bin_size);
   if (result == MRB_DUMP_OK) {
-    fprintf(fp, "#include <stdint.h>\n"); // for uint8_t under at least Darwin
+    fprintf(fp, "#include <stdint.h>\n"); /* for uint8_t under at least Darwin */
     fprintf(fp, "const uint8_t %s[] = {", initname);
     while (bin_idx < bin_size) {
       if (bin_idx % 16 == 0) fputs("\n", fp);

--- a/src/load.c
+++ b/src/load.c
@@ -42,23 +42,23 @@ read_irep_record_1(mrb_state *mrb, const uint8_t *bin, uint32_t *len, mrb_bool a
   int ai = mrb_gc_arena_save(mrb);
   mrb_irep *irep = mrb_add_irep(mrb);
 
-  // skip record size
+  /* skip record size */
   src += sizeof(uint32_t);
 
-  // number of local variable
+  /* number of local variable */
   irep->nlocals = bin_to_uint16(src);
   src += sizeof(uint16_t);
 
-  // number of register variable
+  /* number of register variable */
   irep->nregs = bin_to_uint16(src);
   src += sizeof(uint16_t);
 
-  // number of child irep
+  /* number of child irep */
   irep->rlen = bin_to_uint16(src);
   src += sizeof(uint16_t);
 
-  // Binary Data Section
-  // ISEQ BLOCK
+  /* Binary Data Section */
+  /* ISEQ BLOCK */
   irep->ilen = bin_to_uint32(src);
   src += sizeof(uint32_t);
   if (irep->ilen > 0) {
@@ -70,12 +70,12 @@ read_irep_record_1(mrb_state *mrb, const uint8_t *bin, uint32_t *len, mrb_bool a
       return NULL;
     }
     for (i = 0; i < irep->ilen; i++) {
-      irep->iseq[i] = bin_to_uint32(src);     //iseq
+      irep->iseq[i] = bin_to_uint32(src);     /* iseq */
       src += sizeof(uint32_t);
     }
   }
 
-  //POOL BLOCK
+  /* POOL BLOCK */
   plen = bin_to_uint32(src); /* number of pool */
   src += sizeof(uint32_t);
   if (plen > 0) {
@@ -90,8 +90,8 @@ read_irep_record_1(mrb_state *mrb, const uint8_t *bin, uint32_t *len, mrb_bool a
     for (i = 0; i < plen; i++) {
       mrb_value s;
 
-      tt = *src++; //pool TT
-      pool_data_len = bin_to_uint16(src); //pool data length
+      tt = *src++; /* pool TT */
+      pool_data_len = bin_to_uint16(src); /* pool data length */
       src += sizeof(uint16_t);
       if (alloc) {
         s = mrb_str_new(mrb, (char *)src, pool_data_len);
@@ -100,7 +100,7 @@ read_irep_record_1(mrb_state *mrb, const uint8_t *bin, uint32_t *len, mrb_bool a
         s = mrb_str_new_static(mrb, (char *)src, pool_data_len);
       }
       src += pool_data_len;
-      switch (tt) { //pool data
+      switch (tt) { /* pool data */
       case IREP_TT_FIXNUM:
         irep->pool[i] = mrb_str_to_inum(mrb, s, 10, FALSE);
         break;
@@ -123,8 +123,8 @@ read_irep_record_1(mrb_state *mrb, const uint8_t *bin, uint32_t *len, mrb_bool a
     }
   }
 
-  //SYMS BLOCK
-  irep->slen = bin_to_uint32(src);  //syms length
+  /* SYMS BLOCK */
+  irep->slen = bin_to_uint32(src);  /* syms length */
   src += sizeof(uint32_t);
   if (irep->slen > 0) {
     if (SIZE_ERROR_MUL(sizeof(mrb_sym), irep->slen)) {
@@ -136,7 +136,7 @@ read_irep_record_1(mrb_state *mrb, const uint8_t *bin, uint32_t *len, mrb_bool a
     }
 
     for (i = 0; i < irep->slen; i++) {
-      snl = bin_to_uint16(src);               //symbol name length
+      snl = bin_to_uint16(src);               /* symbol name length */
       src += sizeof(uint16_t);
 
       if (snl == MRB_DUMP_NULL_SYM_LEN) {
@@ -198,7 +198,7 @@ read_lineno_record_1(mrb_state *mrb, const uint8_t *bin, mrb_irep *irep, uint32_
 
   ret = MRB_DUMP_OK;
   *len = 0;
-  bin += sizeof(uint32_t); // record size
+  bin += sizeof(uint32_t); /* record size */
   *len += sizeof(uint32_t);
   fname_len = bin_to_uint16(bin);
   bin += sizeof(uint16_t);
@@ -216,7 +216,7 @@ read_lineno_record_1(mrb_state *mrb, const uint8_t *bin, mrb_irep *irep, uint32_
   *len += fname_len;
 
   niseq = bin_to_uint32(bin);
-  bin += sizeof(uint32_t); // niseq
+  bin += sizeof(uint32_t); /* niseq */
   *len += sizeof(uint32_t);
 
   if (SIZE_ERROR_MUL(niseq, sizeof(uint16_t))) {
@@ -228,7 +228,7 @@ read_lineno_record_1(mrb_state *mrb, const uint8_t *bin, mrb_irep *irep, uint32_
   }
   for (i = 0; i < niseq; i++) {
     lines[i] = bin_to_uint16(bin);
-    bin += sizeof(uint16_t); // niseq
+    bin += sizeof(uint16_t); /* niseq */
     *len += sizeof(uint16_t);
   }
 
@@ -263,7 +263,7 @@ read_section_lineno(mrb_state *mrb, const uint8_t *bin, mrb_irep *irep)
   len = 0;
   bin += sizeof(struct rite_section_lineno_header);
 
-  //Read Binary Data Section
+  /* Read Binary Data Section */
   return read_lineno_record(mrb, bin, irep, &len);
 }
 
@@ -296,7 +296,7 @@ read_debug_record(mrb_state *mrb, const uint8_t *start, mrb_irep* irep, uint32_t
 
     file->start_pos = bin_to_uint32(bin); bin += sizeof(uint32_t);
 
-    // filename
+    /* filename */
     filename_idx = bin_to_uint16(bin);
     bin += sizeof(uint16_t);
     mrb_assert(filename_idx < filenames_len);
@@ -542,7 +542,7 @@ read_section_lineno_file(mrb_state *mrb, FILE *fp, mrb_irep *irep)
     return MRB_DUMP_READ_FAULT;
   }
 
-  //Read Binary Data Section
+  /* Read Binary Data Section */
   return read_lineno_record_file(mrb, fp, irep);
 }
 
@@ -650,7 +650,7 @@ mrb_read_irep_file(mrb_state *mrb, FILE* fp)
   }
   fseek(fp, fpos + section_size, SEEK_SET);
 
-  // read sections
+  /* read sections */
   do {
     fpos = ftell(fp);
     if (fread(&section_header, sizeof(struct rite_section_header), 1, fp) == 0) {

--- a/src/object.c
+++ b/src/object.c
@@ -361,7 +361,7 @@ static const struct types {
   unsigned char type;
   const char *name;
 } builtin_types[] = {
-//    {MRB_TT_NIL,  "nil"},
+/*    {MRB_TT_NIL,  "nil"}, */
   {MRB_TT_FALSE,  "false"},
   {MRB_TT_TRUE,   "true"},
   {MRB_TT_FIXNUM, "Fixnum"},
@@ -377,12 +377,12 @@ static const struct types {
   {MRB_TT_HASH,   "Hash"},
   {MRB_TT_STRING, "String"},
   {MRB_TT_RANGE,  "Range"},
-//    {MRB_TT_BIGNUM,  "Bignum"},
+/*    {MRB_TT_BIGNUM,  "Bignum"}, */
   {MRB_TT_FILE,   "File"},
   {MRB_TT_DATA,   "Data"},  /* internal use: wrapped C pointers */
-//    {MRB_TT_VARMAP,  "Varmap"},  /* internal use: dynamic variables */
-//    {MRB_TT_NODE,  "Node"},  /* internal use: syntax tree node */
-//    {MRB_TT_UNDEF,  "undef"},  /* internal use: #undef; should not happen */
+/*    {MRB_TT_VARMAP,  "Varmap"}, */ /* internal use: dynamic variables */
+/*    {MRB_TT_NODE,  "Node"}, */ /* internal use: syntax tree node */
+/*    {MRB_TT_UNDEF,  "undef"}, */ /* internal use: #undef; should not happen */
     {-1,  0}
 };
 

--- a/src/parse.y
+++ b/src/parse.y
@@ -207,7 +207,7 @@ parser_strdup(parser_state *p, const char *s)
 #undef strdup
 #define strdup(s) parser_strdup(p, s)
 
-// xxx -----------------------------
+/* xxx ----------------------------- */
 
 static node*
 local_switch(parser_state *p)
@@ -266,14 +266,14 @@ local_add(parser_state *p, mrb_sym sym)
   }
 }
 
-// (:scope (vars..) (prog...))
+/* (:scope (vars..) (prog...)) */
 static node*
 new_scope(parser_state *p, node *body)
 {
   return cons((node*)NODE_SCOPE, cons(p->locals->car, body));
 }
 
-// (:begin prog...)
+/* (:begin prog...) */
 static node*
 new_begin(parser_state *p, node *body)
 {
@@ -284,84 +284,84 @@ new_begin(parser_state *p, node *body)
 
 #define newline_node(n) (n)
 
-// (:rescue body rescue else)
+/* (:rescue body rescue else) */
 static node*
 new_rescue(parser_state *p, node *body, node *resq, node *els)
 {
   return list4((node*)NODE_RESCUE, body, resq, els);
 }
 
-// (:ensure body ensure)
+/* (:ensure body ensure) */
 static node*
 new_ensure(parser_state *p, node *a, node *b)
 {
   return cons((node*)NODE_ENSURE, cons(a, cons(0, b)));
 }
 
-// (:nil)
+/* (:nil) */
 static node*
 new_nil(parser_state *p)
 {
   return list1((node*)NODE_NIL);
 }
 
-// (:true)
+/* (:true) */
 static node*
 new_true(parser_state *p)
 {
   return list1((node*)NODE_TRUE);
 }
 
-// (:false)
+/* (:false) */
 static node*
 new_false(parser_state *p)
 {
   return list1((node*)NODE_FALSE);
 }
 
-// (:alias new old)
+/* (:alias new old) */
 static node*
 new_alias(parser_state *p, mrb_sym a, mrb_sym b)
 {
   return cons((node*)NODE_ALIAS, cons(nsym(a), nsym(b)));
 }
 
-// (:if cond then else)
+/* (:if cond then else) */
 static node*
 new_if(parser_state *p, node *a, node *b, node *c)
 {
   return list4((node*)NODE_IF, a, b, c);
 }
 
-// (:unless cond then else)
+/* (:unless cond then else) */
 static node*
 new_unless(parser_state *p, node *a, node *b, node *c)
 {
   return list4((node*)NODE_IF, a, c, b);
 }
 
-// (:while cond body)
+/* (:while cond body) */
 static node*
 new_while(parser_state *p, node *a, node *b)
 {
   return cons((node*)NODE_WHILE, cons(a, b));
 }
 
-// (:until cond body)
+/* (:until cond body) */
 static node*
 new_until(parser_state *p, node *a, node *b)
 {
   return cons((node*)NODE_UNTIL, cons(a, b));
 }
 
-// (:for var obj body)
+/* (:for var obj body) */
 static node*
 new_for(parser_state *p, node *v, node *o, node *b)
 {
   return list4((node*)NODE_FOR, v, o, b);
 }
 
-// (:case a ((when ...) body) ((when...) body))
+/* (:case a ((when ...) body) ((when...) body)) */
 static node*
 new_case(parser_state *p, node *a, node *b)
 {
@@ -375,49 +375,49 @@ new_case(parser_state *p, node *a, node *b)
   return n;
 }
 
-// (:postexe a)
+/* (:postexe a) */
 static node*
 new_postexe(parser_state *p, node *a)
 {
   return cons((node*)NODE_POSTEXE, a);
 }
 
-// (:self)
+/* (:self) */
 static node*
 new_self(parser_state *p)
 {
   return list1((node*)NODE_SELF);
 }
 
-// (:call a b c)
+/* (:call a b c) */
 static node*
 new_call(parser_state *p, node *a, mrb_sym b, node *c)
 {
   return list4((node*)NODE_CALL, a, nsym(b), c);
 }
 
-// (:fcall self mid args)
+/* (:fcall self mid args) */
 static node*
 new_fcall(parser_state *p, mrb_sym b, node *c)
 {
   return list4((node*)NODE_FCALL, new_self(p), nsym(b), c);
 }
 
-// (:super . c)
+/* (:super . c) */
 static node*
 new_super(parser_state *p, node *c)
 {
   return cons((node*)NODE_SUPER, c);
 }
 
-// (:zsuper)
+/* (:zsuper) */
 static node*
 new_zsuper(parser_state *p)
 {
   return list1((node*)NODE_ZSUPER);
 }
 
-// (:yield . c)
+/* (:yield . c) */
 static node*
 new_yield(parser_state *p, node *c)
 {
@@ -430,105 +430,105 @@ new_yield(parser_state *p, node *c)
   return cons((node*)NODE_YIELD, 0);
 }
 
-// (:return . c)
+/* (:return . c) */
 static node*
 new_return(parser_state *p, node *c)
 {
   return cons((node*)NODE_RETURN, c);
 }
 
-// (:break . c)
+/* (:break . c) */
 static node*
 new_break(parser_state *p, node *c)
 {
   return cons((node*)NODE_BREAK, c);
 }
 
-// (:next . c)
+/* (:next . c) */
 static node*
 new_next(parser_state *p, node *c)
 {
   return cons((node*)NODE_NEXT, c);
 }
 
-// (:redo)
+/* (:redo) */
 static node*
 new_redo(parser_state *p)
 {
   return list1((node*)NODE_REDO);
 }
 
-// (:retry)
+/* (:retry) */
 static node*
 new_retry(parser_state *p)
 {
   return list1((node*)NODE_RETRY);
 }
 
-// (:dot2 a b)
+/* (:dot2 a b) */
 static node*
 new_dot2(parser_state *p, node *a, node *b)
 {
   return cons((node*)NODE_DOT2, cons(a, b));
 }
 
-// (:dot3 a b)
+/* (:dot3 a b) */
 static node*
 new_dot3(parser_state *p, node *a, node *b)
 {
   return cons((node*)NODE_DOT3, cons(a, b));
 }
 
-// (:colon2 b c)
+/* (:colon2 b c) */
 static node*
 new_colon2(parser_state *p, node *b, mrb_sym c)
 {
   return cons((node*)NODE_COLON2, cons(b, nsym(c)));
 }
 
-// (:colon3 . c)
+/* (:colon3 . c) */
 static node*
 new_colon3(parser_state *p, mrb_sym c)
 {
   return cons((node*)NODE_COLON3, nsym(c));
 }
 
-// (:and a b)
+/* (:and a b) */
 static node*
 new_and(parser_state *p, node *a, node *b)
 {
   return cons((node*)NODE_AND, cons(a, b));
 }
 
-// (:or a b)
+/* (:or a b) */
 static node*
 new_or(parser_state *p, node *a, node *b)
 {
   return cons((node*)NODE_OR, cons(a, b));
 }
 
-// (:array a...)
+/* (:array a...) */
 static node*
 new_array(parser_state *p, node *a)
 {
   return cons((node*)NODE_ARRAY, a);
 }
 
-// (:splat . a)
+/* (:splat . a) */
 static node*
 new_splat(parser_state *p, node *a)
 {
   return cons((node*)NODE_SPLAT, a);
 }
 
-// (:hash (k . v) (k . v)...)
+/* (:hash (k . v) (k . v)...) */
 static node*
 new_hash(parser_state *p, node *a)
 {
   return cons((node*)NODE_HASH, a);
 }
 
-// (:sym . a)
+/* (:sym . a) */
 static node*
 new_sym(parser_state *p, mrb_sym sym)
 {
@@ -544,96 +544,96 @@ new_strsym(parser_state *p, node* str)
   return mrb_intern(p->mrb, s, len);
 }
 
-// (:lvar . a)
+/* (:lvar . a) */
 static node*
 new_lvar(parser_state *p, mrb_sym sym)
 {
   return cons((node*)NODE_LVAR, nsym(sym));
 }
 
-// (:gvar . a)
+/* (:gvar . a) */
 static node*
 new_gvar(parser_state *p, mrb_sym sym)
 {
   return cons((node*)NODE_GVAR, nsym(sym));
 }
 
-// (:ivar . a)
+/* (:ivar . a) */
 static node*
 new_ivar(parser_state *p, mrb_sym sym)
 {
   return cons((node*)NODE_IVAR, nsym(sym));
 }
 
-// (:cvar . a)
+/* (:cvar . a) */
 static node*
 new_cvar(parser_state *p, mrb_sym sym)
 {
   return cons((node*)NODE_CVAR, nsym(sym));
 }
 
-// (:const . a)
+/* (:const . a) */
 static node*
 new_const(parser_state *p, mrb_sym sym)
 {
   return cons((node*)NODE_CONST, nsym(sym));
 }
 
-// (:undef a...)
+/* (:undef a...) */
 static node*
 new_undef(parser_state *p, mrb_sym sym)
 {
   return list2((node*)NODE_UNDEF, nsym(sym));
 }
 
-// (:class class super body)
+/* (:class class super body) */
 static node*
 new_class(parser_state *p, node *c, node *s, node *b)
 {
   return list4((node*)NODE_CLASS, c, s, cons(p->locals->car, b));
 }
 
-// (:sclass obj body)
+/* (:sclass obj body) */
 static node*
 new_sclass(parser_state *p, node *o, node *b)
 {
   return list3((node*)NODE_SCLASS, o, cons(p->locals->car, b));
 }
 
-// (:module module body)
+/* (:module module body) */
 static node*
 new_module(parser_state *p, node *m, node *b)
 {
   return list3((node*)NODE_MODULE, m, cons(p->locals->car, b));
 }
 
-// (:def m lv (arg . body))
+/* (:def m lv (arg . body)) */
 static node*
 new_def(parser_state *p, mrb_sym m, node *a, node *b)
 {
   return list5((node*)NODE_DEF, nsym(m), p->locals->car, a, b);
 }
 
-// (:sdef obj m lv (arg . body))
+/* (:sdef obj m lv (arg . body)) */
 static node*
 new_sdef(parser_state *p, node *o, mrb_sym m, node *a, node *b)
 {
   return list6((node*)NODE_SDEF, o, nsym(m), p->locals->car, a, b);
 }
 
-// (:arg . sym)
+/* (:arg . sym) */
 static node*
 new_arg(parser_state *p, mrb_sym sym)
 {
   return cons((node*)NODE_ARG, nsym(sym));
 }
 
-// (m o r m2 b)
-// m: (a b c)
-// o: ((a . e1) (b . e2))
-// r: a
-// m2: (a b c)
-// b: a
+/* (m o r m2 b) */
+/* m: (a b c) */
+/* o: ((a . e1) (b . e2)) */
+/* r: a */
+/* m2: (a b c) */
+/* b: a */
 static node*
 new_args(parser_state *p, node *m, node *opt, mrb_sym rest, node *m2, mrb_sym blk)
 {
@@ -645,126 +645,126 @@ new_args(parser_state *p, node *m, node *opt, mrb_sym rest, node *m2, mrb_sym bl
   return cons(m, n);
 }
 
-// (:block_arg . a)
+/* (:block_arg . a) */
 static node*
 new_block_arg(parser_state *p, node *a)
 {
   return cons((node*)NODE_BLOCK_ARG, a);
 }
 
-// (:block arg body)
+/* (:block arg body) */
 static node*
 new_block(parser_state *p, node *a, node *b)
 {
   return list4((node*)NODE_BLOCK, p->locals->car, a, b);
 }
 
-// (:lambda arg body)
+/* (:lambda arg body) */
 static node*
 new_lambda(parser_state *p, node *a, node *b)
 {
   return list4((node*)NODE_LAMBDA, p->locals->car, a, b);
 }
 
-// (:asgn lhs rhs)
+/* (:asgn lhs rhs) */
 static node*
 new_asgn(parser_state *p, node *a, node *b)
 {
   return cons((node*)NODE_ASGN, cons(a, b));
 }
 
-// (:masgn mlhs=(pre rest post)  mrhs)
+/* (:masgn mlhs=(pre rest post)  mrhs) */
 static node*
 new_masgn(parser_state *p, node *a, node *b)
 {
   return cons((node*)NODE_MASGN, cons(a, b));
 }
 
-// (:asgn lhs rhs)
+/* (:asgn lhs rhs) */
 static node*
 new_op_asgn(parser_state *p, node *a, mrb_sym op, node *b)
 {
   return list4((node*)NODE_OP_ASGN, a, nsym(op), b);
 }
 
-// (:int . i)
+/* (:int . i) */
 static node*
 new_int(parser_state *p, const char *s, int base)
 {
   return list3((node*)NODE_INT, (node*)strdup(s), (node*)(intptr_t)base);
 }
 
-// (:float . i)
+/* (:float . i) */
 static node*
 new_float(parser_state *p, const char *s)
 {
   return cons((node*)NODE_FLOAT, (node*)strdup(s));
 }
 
-// (:str . (s . len))
+/* (:str . (s . len)) */
 static node*
 new_str(parser_state *p, const char *s, int len)
 {
   return cons((node*)NODE_STR, cons((node*)strndup(s, len), (node*)(intptr_t)len));
 }
 
-// (:dstr . a)
+/* (:dstr . a) */
 static node*
 new_dstr(parser_state *p, node *a)
 {
   return cons((node*)NODE_DSTR, a);
 }
 
-// (:str . (s . len))
+/* (:str . (s . len)) */
 static node*
 new_xstr(parser_state *p, const char *s, int len)
 {
   return cons((node*)NODE_XSTR, cons((node*)strndup(s, len), (node*)(intptr_t)len));
 }
 
-// (:xstr . a)
+/* (:xstr . a) */
 static node*
 new_dxstr(parser_state *p, node *a)
 {
   return cons((node*)NODE_DXSTR, a);
 }
 
-// (:dsym . a)
+/* (:dsym . a) */
 static node*
 new_dsym(parser_state *p, node *a)
 {
   return cons((node*)NODE_DSYM, new_dstr(p, a));
 }
 
-// (:str . (a . a))
+/* (:str . (a . a)) */
 static node*
 new_regx(parser_state *p, const char *p1, const char* p2)
 {
   return cons((node*)NODE_REGX, cons((node*)p1, (node*)p2));
 }
 
-// (:dregx . a)
+/* (:dregx . a) */
 static node*
 new_dregx(parser_state *p, node *a, node *b)
 {
   return cons((node*)NODE_DREGX, cons(a, b));
 }
 
-// (:backref . n)
+/* (:backref . n) */
 static node*
 new_back_ref(parser_state *p, int n)
 {
   return cons((node*)NODE_BACK_REF, (node*)(intptr_t)n);
 }
 
-// (:nthref . n)
+/* (:nthref . n) */
 static node*
 new_nth_ref(parser_state *p, int n)
 {
   return cons((node*)NODE_NTH_REF, (node*)(intptr_t)n);
 }
 
-// (:heredoc . a)
+/* (:heredoc . a) */
 static node*
 new_heredoc(parser_state *p)
 {
@@ -783,30 +783,30 @@ new_literal_delim(parser_state *p)
   return cons((node*)NODE_LITERAL_DELIM, 0);
 }
 
-// (:words . a)
+/* (:words . a) */
 static node*
 new_words(parser_state *p, node *a)
 {
   return cons((node*)NODE_WORDS, a);
 }
 
-// (:symbols . a)
+/* (:symbols . a) */
 static node*
 new_symbols(parser_state *p, node *a)
 {
   return cons((node*)NODE_SYMBOLS, a);
 }
 
-// xxx -----------------------------
+/* xxx ----------------------------- */
 
-// (:call a op)
+/* (:call a op) */
 static node*
 call_uni_op(parser_state *p, node *recv, char *m)
 {
   return new_call(p, recv, intern_cstr(m), 0);
 }
 
-// (:call a op b)
+/* (:call a op b) */
 static node*
 call_bin_op(parser_state *p, node *recv, char *m, node *arg1)
 {
@@ -979,7 +979,7 @@ heredoc_end(parser_state *p)
 }
 #define is_strterm_type(p,str_func) ((int)(intptr_t)((p)->lex_strterm->car) & (str_func))
 
-// xxx -----------------------------
+/* xxx ----------------------------- */
 
 %}
 
@@ -3432,7 +3432,7 @@ skips(parser_state *p, const char *s)
   int c;
 
   for (;;) {
-    // skip until first char
+    /* skip until first char */
     for (;;) {
       c = nextc(p);
       if (c < 0) return c;
@@ -4228,7 +4228,7 @@ parser_yylex(parser_state *p)
       return '?';
     }
     token_column = newtok(p);
-    // need support UTF-8 if configured
+    /* need support UTF-8 if configured */
     if ((isalnum(c) || c == '_')) {
       int c2 = nextc(p);
       pushback(p, c2);

--- a/src/vm.c
+++ b/src/vm.c
@@ -1320,7 +1320,7 @@ mrb_context_run(mrb_state *mrb, struct RProc *proc, mrb_value self, unsigned int
 
         switch (GETARG_B(i)) {
         case OP_R_RETURN:
-          // Fall through to OP_R_NORMAL otherwise
+          /* Fall through to OP_R_NORMAL otherwise */
           if (proc->env && !MRB_PROC_STRICT_P(proc)) {
             struct REnv *e = top_env(mrb, proc);
 


### PR DESCRIPTION
According to CONTRIBUTING.md,

```
#### Don't use C++ style comments

    /* This is the prefered comment style */

Use C++ style comments only for temporary comment e.g. commenting out some code lines.
```
