### PR TITLE
fix off-by-one error in String#rindex(fixnum)

### DIFF
--- a/src/string.c
+++ b/src/string.c
@@ -1660,7 +1660,7 @@ mrb_str_rindex_m(mrb_state *mrb, mrb_value str)
       mrb_int len = RSTRING_LEN(str);
       unsigned char *p = (unsigned char*)RSTRING_PTR(str);
 
-      for (pos=len;pos>=0;pos--) {
+      for (pos=len-1;pos>=0;pos--) {
         if (p[pos] == c) return mrb_fixnum_value(pos);
       }
       return mrb_nil_value();

--- a/test/t/string.rb
+++ b/test/t/string.rb
@@ -330,6 +330,9 @@ assert('String#rindex', '15.2.10.5.31') do
   assert_nil 'abc'.rindex('d')
   assert_equal 0, 'abcabc'.rindex('a', 1)
   assert_equal 3, 'abcabc'.rindex('a', 4)
+
+  assert_equal 3,   'abcabc'.rindex(97)
+  assert_equal nil, 'abcabc'.rindex(0)
 end
 
 # 'String#scan', '15.2.10.5.32' will be tested in mrbgems.


### PR DESCRIPTION
I think null-terminated string should not be included in search targets.
