### PR TITLE
visualcpp toolchain: change compiler/linker flags

### DIFF
--- a/tasks/toolchains/visualcpp.rake
+++ b/tasks/toolchains/visualcpp.rake
@@ -1,7 +1,7 @@
 MRuby::Toolchain.new(:visualcpp) do |conf|
-  [conf.cc, conf.cxx].each do |cc|
+  [conf.cc].each do |cc|
     cc.command = ENV['CC'] || 'cl.exe'
-    cc.flags = [ENV['CFLAGS'] || %w(/c /nologo /W3 /D_DEBUG /MDd /Zi /Od /RTC1 /DHAVE_STRING_H /DNO_GETTIMEOFDAY /D_CRT_SECURE_NO_WARNINGS)]
+    cc.flags = [ENV['CFLAGS'] || %w(/c /nologo /W3 /Zi /MD /O2 /D_CRT_SECURE_NO_WARNINGS)]
     cc.include_paths = ["#{MRUBY_ROOT}/include"]
     cc.defines = %w(DISABLE_GEMS)
     cc.option_include_path = '/I%s'
@@ -9,26 +9,36 @@ MRuby::Toolchain.new(:visualcpp) do |conf|
     cc.compile_options = "%{flags} /Fo%{outfile} %{infile}"
   end
 
+  [conf.cxx].each do |cxx|
+    cxx.command = ENV['CXX'] || 'cl.exe'
+    cxx.flags = [ENV['CXXFLAGS'] || ENV['CFLAGS'] || %w(/c /nologo /W3 /Zi /MD /O2 /EHsc /D_CRT_SECURE_NO_WARNINGS)]
+    cxx.include_paths = ["#{MRUBY_ROOT}/include"]
+    cxx.defines = %w(DISABLE_GEMS)
+    cxx.option_include_path = '/I%s'
+    cxx.option_define = '/D%s'
+    cxx.compile_options = "%{flags} /Fo%{outfile} %{infile}"
+  end
+
   conf.linker do |linker|
     linker.command = ENV['LD'] || 'link.exe'
-    linker.flags = [ENV['LDFLAGS'] || %w(/nologo)]
+    linker.flags = [ENV['LDFLAGS'] || %w(/NOLOGO /DEBUG /INCREMENTAL:NO /OPT:ICF /OPT:REF)]
     linker.libraries = %w()
     linker.library_paths = %w()
     linker.option_library = '%s.lib'
     linker.option_library_path = '/LIBPATH:%s'
     linker.link_options = "%{flags} /OUT:%{outfile} %{objs} %{flags_before_libraries} %{libs} %{flags_after_libraries}"
   end
- 
+
   conf.archiver do |archiver|
     archiver.command = ENV['AR'] || 'lib.exe'
     archiver.archive_options = '/nologo /OUT:%{outfile} %{objs}'
   end
- 
+
   conf.yacc do |yacc|
     yacc.command = ENV['YACC'] || 'bison.exe'
     yacc.compile_options = '-o %{outfile} %{infile}'
   end
- 
+
   conf.gperf do |gperf|
     gperf.command = 'gperf.exe'
     gperf.compile_options = '-L ANSI-C -C -p -j1 -i 1 -g -o -t -N mrb_reserved_word -k"1,3,$" %{infile} > %{outfile}'


### PR DESCRIPTION
with these flags visualcpp should behave more like the gcc toolchain

c:
- produce debug information
- optimize for speed instead of disabling optimization
- use non-debug version of Microsoft's C library
- remove unused and unnecessary macro definitions

cxx:
- separate C and C++ (#1594)
- specify kind of exception handling (see warning C4530)

linker:
- produce debug information
- disable incremental linking and re-enable optimizations
