### PR TITLE
Add mrb_utf8_from_locale, mrb_utf8_free, mrb_locale_from_utf8, mrb_locale_free

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -292,6 +292,18 @@ MRB_API mrb_value mrb_str_new_cstr(mrb_state*, const char*);
 MRB_API mrb_value mrb_str_new_static(mrb_state *mrb, const char *p, size_t len);
 #define mrb_str_new_lit(mrb, lit) mrb_str_new_static(mrb, (lit), mrb_strlen_lit(lit))
 
+#ifdef _WIN32
+char* mrb_utf8_from_locale(const char *p, size_t len);
+char* mrb_locale_from_utf8(const char *p, size_t len);
+#define mrb_locale_free(p) free(p)
+#define mrb_utf8_free(p) free(p)
+#else
+#define mrb_utf8_from_locale(p, l) (p)
+#define mrb_locale_from_utf8(p, l) (p)
+#define mrb_locale_free(p)
+#define mrb_utf8_free(p)
+#endif
+
 MRB_API mrb_state* mrb_open(void);
 MRB_API mrb_state* mrb_open_allocf(mrb_allocf, void *ud);
 MRB_API mrb_state* mrb_open_core(mrb_allocf, void *ud);

--- a/mrbgems/mruby-bin-mirb/tools/mirb/mirb.c
+++ b/mrbgems/mruby-bin-mirb/tools/mirb/mirb.c
@@ -366,6 +366,8 @@ main(int argc, char **argv)
   ai = mrb_gc_arena_save(mrb);
 
   while (TRUE) {
+    char *utf8;
+
 #ifndef ENABLE_READLINE
     print_cmdline(code_block_open);
 
@@ -415,17 +417,21 @@ main(int argc, char **argv)
       strcpy(ruby_code, last_code_line);
     }
 
+    utf8 = mrb_utf8_from_locale(ruby_code, -1);
+    if (!utf8) abort();
+
     /* parse code */
     parser = mrb_parser_new(mrb);
     if (parser == NULL) {
       fputs("create parser state error\n", stderr);
       break;
     }
-    parser->s = ruby_code;
-    parser->send = ruby_code + strlen(ruby_code);
+    parser->s = utf8;
+    parser->send = utf8 + strlen(utf8);
     parser->lineno = cxt->lineno;
     mrb_parser_parse(parser, cxt);
     code_block_open = is_code_block_open(parser);
+    mrb_utf8_free(utf8);
 
     if (code_block_open) {
       /* no evaluation of code */

--- a/mrbgems/mruby-bin-mruby/tools/mruby/mruby.c
+++ b/mrbgems/mruby-bin-mruby/tools/mruby/mruby.c
@@ -191,7 +191,11 @@ main(int argc, char **argv)
 
   ARGV = mrb_ary_new_capa(mrb, args.argc);
   for (i = 0; i < args.argc; i++) {
-    mrb_ary_push(mrb, ARGV, mrb_str_new_cstr(mrb, args.argv[i]));
+    char* utf8 = mrb_utf8_from_locale(args.argv[i], -1);
+    if (utf8) {
+      mrb_ary_push(mrb, ARGV, mrb_str_new_cstr(mrb, utf8));
+      mrb_utf8_free(utf8);
+    }
   }
   mrb_define_global_const(mrb, "ARGV", ARGV);
 
@@ -222,7 +226,10 @@ main(int argc, char **argv)
     v = mrb_load_file_cxt(mrb, args.rfp, c);
   }
   else {
-    v = mrb_load_string_cxt(mrb, args.cmdline, c);
+    char* utf8 = mrb_utf8_from_locale(args.cmdline, -1);
+    if (!utf8) abort();
+    v = mrb_load_string_cxt(mrb, utf8, c);
+    mrb_utf8_free(utf8);
   }
 
   mrbc_context_free(mrb, c);

--- a/mrbgems/mruby-print/src/print.c
+++ b/mrbgems/mruby-print/src/print.c
@@ -1,17 +1,18 @@
 #include "mruby.h"
 #include "mruby/string.h"
 #include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
 
 static void
 printstr(mrb_state *mrb, mrb_value obj)
 {
-  char *s;
-  mrb_int len;
-
   if (mrb_string_p(obj)) {
-    s = RSTRING_PTR(obj);
-    len = RSTRING_LEN(obj);
-    fwrite(s, len, 1, stdout);
+    char* ptr = mrb_locale_from_utf8(RSTRING_PTR(obj), RSTRING_LEN(obj));
+    if (ptr) {
+      fwrite(ptr, strlen(ptr), 1, stdout);
+      mrb_locale_free(ptr);
+    }
   }
 }
 


### PR DESCRIPTION
Add mrb_cstr_from_locale/mrb_cstr_to_locale. ARGV should be utf8 strings converted from locale strings. And __printstr__ should print locale strings.

![](http://go-gyazo.appspot.com/20620da21d03fb3c.png)