### PR TITLE
Fix behavior Hash#eql?

### DIFF
--- a/src/hash.c
+++ b/src/hash.c
@@ -901,7 +901,7 @@ hash_equal(mrb_state *mrb, mrb_value hash1, mrb_value hash2, mrb_bool eql)
       key = kh_key(h1,k1);
       k2 = kh_get(ht, mrb, h2, key);
       if (k2 != kh_end(h2)) {
-        if (mrb_equal(mrb, kh_value(h1,k1), kh_value(h2,k2))) {
+        if (mrb_eql(mrb, kh_value(h1,k1), kh_value(h2,k2))) {
           continue; /* next key */
         }
       }

--- a/test/t/hash.rb
+++ b/test/t/hash.rb
@@ -269,6 +269,14 @@ end
 
 # Not ISO specified
 
+assert('Hash#eql?') do
+  a = { 'a' => 1, 'b' => 2, 'c' => 3 }
+  b = { 'a' => 1, 'b' => 2, 'c' => 3 }
+  c = { 'a' => 1.0, 'b' => 2, 'c' => 3 }
+  assert_true(a.eql?(b))
+  assert_false(a.eql?(c))
+end
+
 assert('Hash#reject') do
   h = {:one => 1, :two => 2, :three => 3, :four => 4}
   ret = h.reject do |k,v|


### PR DESCRIPTION
This behavior specification of mruby?

```
> 1.eql?(1.0)
 => false
> [1].eql?([1.0])
 => false
> {a:1}.eql?({a:1.0})
 => true
```

I think it's should be that.

```
> 1.eql?(1.0)
 => false
> [1].eql?([1.0])
 => false
> {a:1}.eql?({a:1.0})
 => false
```
