### PR TITLE
.PHONY should be placed after `all'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,15 +4,14 @@
 
 RAKE = ruby ./minirake
 
-.PHONY : all
 all :
 	$(RAKE)
+.PHONY : all
 
-.PHONY : test
 test : all
 	$(RAKE) test
+.PHONY : test
 
-.PHONY : clean
 clean :
 	$(RAKE) clean
-
+.PHONY : clean


### PR DESCRIPTION
Because some make (e.g. nmake) recognize it as a normal rule definition and if it's the first rule, make runs it as a default rule.
Consequently `all',`test' and `clean' are all ran (because they are depended by .PHONY), and builded files are cleaned.
