### PR TITLE
Use sizeof(void*) instead of mrb_int size and extend embed string size.

### DIFF
--- a/include/mruby/string.h
+++ b/include/mruby/string.h
@@ -15,14 +15,7 @@ extern "C" {
 
 extern const char mrb_digitmap[];
 
-/* (sizeof(mrb_int)*2+sizeof(char*))/sizeof(char)-1 */
-#if defined(MRB_INT16)
-# define RSTRING_EMBED_LEN_MAX 9
-#elif defined(MRB_INT64)
-# define RSTRING_EMBED_LEN_MAX 15
-#else
-# define RSTRING_EMBED_LEN_MAX 11
-#endif
+#define RSTRING_EMBED_LEN_MAX (sizeof(void*) * 3 - 1)
 
 struct RString {
   MRB_OBJECT_HEADER;
@@ -58,7 +51,7 @@ struct RString {
 #define MRB_STR_SHARED    1
 #define MRB_STR_NOFREE    2
 #define MRB_STR_EMBED     4
-#define MRB_STR_EMBED_LEN_MASK 120
+#define MRB_STR_EMBED_LEN_MASK 0xf8
 #define MRB_STR_EMBED_LEN_SHIFT 3
 
 void mrb_gc_free_str(mrb_state*, struct RString*);


### PR DESCRIPTION
Since `mrb_int` is `uint32_t` by default independently of pointer size, embed string size should use pointer size. Object in RVALUE's max use is 3 pointers so I used `sizeof(void*) * 3`.
In additional doing compile time thing in C is troublesome, extending embed string size to 5bit will make `RSTRING_EMBED_LEN_MAX` more easier.
