### PR TITLE
two pool fixes

### DIFF
--- a/src/pool.c
+++ b/src/pool.c
@@ -37,7 +37,7 @@ struct mrb_pool {
 #undef TEST_POOL
 #ifdef TEST_POOL
 
-#define mrb_malloc(m,s) malloc(s)
+#define mrb_malloc_simple(m,s) malloc(s)
 #define mrb_free(m,p) free(p)
 #endif
 
@@ -50,7 +50,7 @@ struct mrb_pool {
 mrb_pool*
 mrb_pool_open(mrb_state *mrb)
 {
-  mrb_pool *pool = (mrb_pool *)mrb_malloc(mrb, sizeof(mrb_pool));
+  mrb_pool *pool = (mrb_pool *)mrb_malloc_simple(mrb, sizeof(mrb_pool));
 
   if (pool) {
     pool->mrb = mrb;
@@ -82,7 +82,7 @@ page_alloc(mrb_pool *pool, size_t len)
 
   if (len < POOL_PAGE_SIZE)
     len = POOL_PAGE_SIZE;
-  page = (struct mrb_pool_page *)mrb_malloc(pool->mrb, sizeof(struct mrb_pool_page)+len);
+  page = (struct mrb_pool_page *)mrb_malloc_simple(pool->mrb, sizeof(struct mrb_pool_page)+len);
   if (page) {
     page->offset = 0;
     page->len = len;


### PR DESCRIPTION
I'm not 100% sure about 307c356 but looking at codegen.c and pool.c, I think `mrb_malloc_simple` should be used here.
