### PR TITLE
Make type casts safer

### DIFF
--- a/include/mruby/dump.h
+++ b/include/mruby/dump.h
@@ -92,14 +92,14 @@ struct rite_binary_footer {
   RITE_SECTION_HEADER;
 };
 
-static inline int
+static inline size_t
 uint8_to_bin(uint8_t s, uint8_t *bin)
 {
   *bin = s;
   return sizeof(uint8_t);
 }
 
-static inline int
+static inline size_t
 uint16_to_bin(uint16_t s, uint8_t *bin)
 {
   *bin++ = (s >> 8) & 0xff;
@@ -107,7 +107,7 @@ uint16_to_bin(uint16_t s, uint8_t *bin)
   return sizeof(uint16_t);
 }
 
-static inline int
+static inline size_t
 uint32_to_bin(uint32_t l, uint8_t *bin)
 {
   *bin++ = (l >> 24) & 0xff;

--- a/include/mruby/string.h
+++ b/include/mruby/string.h
@@ -15,7 +15,7 @@ extern "C" {
 
 extern const char mrb_digitmap[];
 
-#define RSTRING_EMBED_LEN_MAX (sizeof(void*) * 3 - 1)
+#define RSTRING_EMBED_LEN_MAX ((mrb_int)(sizeof(void*) * 3 - 1))
 
 struct RString {
   MRB_OBJECT_HEADER;

--- a/mrbgems/mruby-proc-ext/src/proc.c
+++ b/mrbgems/mruby-proc-ext/src/proc.c
@@ -21,7 +21,7 @@ mrb_proc_source_location(mrb_state *mrb, mrb_value self)
   }
   else {
     mrb_irep *irep = p->body.irep;
-    uint32_t line;
+    int32_t line;
     const char *filename;
 
     filename = mrb_debug_get_filename(irep, 0);

--- a/src/class.c
+++ b/src/class.c
@@ -533,9 +533,12 @@ mrb_get_args(mrb_state *mrb, const char *format, ...)
 
         ps = va_arg(ap, char**);
         if (i < argc) {
+          size_t size_t_len;
           ss = to_str(mrb, *sp++);
           s = mrb_str_ptr(ss);
-          len = (mrb_int)strlen(RSTRING_PTR(ss));
+          size_t_len = strlen(RSTRING_PTR(ss));
+          mrb_assert(size_t_len <= MRB_INT_MAX);
+          len = (mrb_int)size_t_len;
           if (len < RSTRING_LEN(ss)) {
             mrb_raise(mrb, E_ARGUMENT_ERROR, "string contains null byte");
           }

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -5,6 +5,7 @@
 */
 
 #include <ctype.h>
+#include <limits.h>
 #include <stdlib.h>
 #include <string.h>
 #include "mruby.h"
@@ -2582,14 +2583,16 @@ static void
 codedump(mrb_state *mrb, mrb_irep *irep)
 {
 #ifdef ENABLE_STDIO
-  uint32_t i;
+  int i;
   int ai;
   mrb_code c;
 
   if (!irep) return;
   printf("irep %p nregs=%d nlocals=%d pools=%d syms=%d reps=%d\n", irep,
          irep->nregs, irep->nlocals, (int)irep->plen, (int)irep->slen, (int)irep->rlen);
-  for (i=0; i<irep->ilen; i++) {
+
+  mrb_assert(irep->ilen <= INT_MAX);
+  for (i = 0; i < (int)(irep->ilen); i++) {
     ai = mrb_gc_arena_save(mrb);
     printf("%03d ", i);
     c = irep->iseq[i];

--- a/src/string.c
+++ b/src/string.c
@@ -2067,8 +2067,12 @@ mrb_string_value_cstr(mrb_state *mrb, mrb_value *ptr)
 {
   struct RString *ps = mrb_str_ptr(*ptr);
   char *s = STR_PTR(ps);
+  mrb_int len;
 
-  if (!s || STR_LEN(ps) != strlen(s)) {
+  len = STR_LEN(ps);
+  mrb_assert(len >= 0);
+  mrb_assert((size_t)len <= SIZE_MAX);
+  if (!s || (size_t)len != strlen(s)) {
     mrb_raise(mrb, E_ARGUMENT_ERROR, "string contains null byte");
   }
   return s;


### PR DESCRIPTION
There have many type mismatched, legacy code in src/dump.c. This will fix them.
And this PR includes a patch for more strict warning checks.
