### PR TITLE
Support private and protected visibility.

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -360,12 +360,12 @@ void mrb_gc_protect(mrb_state *mrb, mrb_value obj);
 mrb_value mrb_to_int(mrb_state *mrb, mrb_value val);
 void mrb_check_type(mrb_state *mrb, mrb_value x, enum mrb_vtype t);
 
-typedef enum call_type {
-    CALL_PUBLIC,
-    CALL_FCALL,
-    CALL_VCALL,
-    CALL_TYPE_MAX
-} call_type;
+typedef enum mrb_call_type {
+    MRB_CALL_PUBLIC,
+    MRB_CALL_PRIVATE, MRB_CALL_FCALL = MRB_CALL_PRIVATE,
+    MRB_CALL_PROTECTED, MRB_CALL_VCALL = MRB_CALL_PROTECTED,
+    MRB_CALL_TYPE_MAX
+} mrb_call_type;
 
 void mrb_define_alias(mrb_state *mrb, struct RClass *klass, const char *name1, const char *name2);
 const char *mrb_class_name(mrb_state *mrb, struct RClass* klass);

--- a/include/mruby/class.h
+++ b/include/mruby/class.h
@@ -49,6 +49,9 @@ mrb_class(mrb_state *mrb, mrb_value v)
 #define MRB_SET_INSTANCE_TT(c, tt) c->flags = ((c->flags & ~0xff) | (char)tt)
 #define MRB_INSTANCE_TT(c) (enum mrb_vtype)(c->flags & 0xff)
 
+#define MRB_SET_CALL_TYPE(c, t) c->flags = ((c->flags & ~0x600) | ((t & 0x3) << 9))
+#define MRB_CALL_TYPE(c) ((enum mrb_call_type)((c->flags >> 9) & 0x3))
+
 struct RClass* mrb_define_class_id(mrb_state*, mrb_sym, struct RClass*);
 struct RClass* mrb_define_module_id(mrb_state*, mrb_sym);
 struct RClass *mrb_vm_define_class(mrb_state*, mrb_value, mrb_value, mrb_sym);

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -773,7 +773,7 @@ gen_values(codegen_scope *s, node *t, int val)
 #define CALL_MAXARGS 127
 
 static void
-gen_call(codegen_scope *s, node *tree, mrb_sym name, int sp, int val, node_type nt)
+gen_call(codegen_scope *s, node *tree, mrb_sym name, int sp, int val, enum node_type nt)
 {
   mrb_sym sym = name ? name : sym(tree->cdr->car);
   int idx;
@@ -1445,7 +1445,7 @@ codegen(codegen_scope *s, node *tree, int val)
 
   case NODE_FCALL:
   case NODE_CALL:
-    gen_call(s, tree, 0, 0, val, (node_type)nt);
+    gen_call(s, tree, 0, 0, val, (enum node_type)nt);
     break;
 
   case NODE_DOT2:

--- a/src/opcode.h
+++ b/src/opcode.h
@@ -145,6 +145,8 @@ enum {
   OP_RSVD3,/*             reserved instruction #3                         */
   OP_RSVD4,/*             reserved instruction #4                         */
   OP_RSVD5,/*             reserved instruction #5                         */
+
+  OP_FSENDB,/*     A B C   R(A) := fcall(R(A),mSym(B),R(A+1),...,R(A+C),&R(A+C+1))*/
 };
 
 #define OP_L_STRICT  1

--- a/src/vm.c
+++ b/src/vm.c
@@ -1004,6 +1004,9 @@ RETRY_TRY_BLOCK:
             goto L_RAISE;
           }
           break;
+
+        default:
+          break;
       }
 
       /* push callinfo */

--- a/test/t/module.rb
+++ b/test/t/module.rb
@@ -517,3 +517,45 @@ assert('clone Module') do
 
   B.new.foo
 end
+
+assert('method call type') do
+  class CallTypeTest
+    def test_private(&block)
+      func(&block)
+    end
+    def test_protected(&block)
+      self.func(&block)
+    end
+    private
+    def func
+      yield
+    end
+  end
+
+  v = CallTypeTest.new
+
+  assert_raise(NoMethodError) { v.func { :test } }
+  assert_raise(NoMethodError) { v.test_protected { :test } }
+  assert_equal :test, v.test_private { :test }
+
+  class CallTypeTest
+    protected :func
+  end
+
+  assert_raise(NoMethodError) { v.func { :test } }
+  assert_equal :test, v.test_protected { :test }
+  assert_equal :test, v.test_private { :test }
+
+  class CallTypeTest
+    def public_func
+      :test
+    end
+
+    public :func
+  end
+
+  assert_equal :test, v.public_func
+  assert_equal :test, v.func { :test }
+  assert_equal :test, v.test_protected { :test }
+  assert_equal :test, v.test_private { :test }
+end


### PR DESCRIPTION
- This will break compatibility with old mruby irep since opcode `OP_FSEND` and `OP_FSENDB` that won't be supported by old VM would be used to check private call.
- `mrb_call_type` would be stored to `struct RClass` and `struct RProc` in 10th and 11th bit of `flags` using `0x600` bit mask. `RClass`'s `mrb_call_type` flags would be cleared if class scope is opened.
- Method such as `private_instance_methods` and `protected_instance_methods` isn't implemented yet.
