### PR TITLE
add MRB_INT_BIT

### DIFF
--- a/include/mruby/value.h
+++ b/include/mruby/value.h
@@ -26,6 +26,7 @@
 #  error Cannot use NaN boxing when mrb_int is 64bit
 # else
    typedef int64_t mrb_int;
+#  define MRB_INT_BIT 64
 #  define MRB_INT_MIN INT64_MIN
 #  define MRB_INT_MAX INT64_MAX
 #  define PRIdMRB_INT PRId64
@@ -36,10 +37,12 @@
 # endif
 #elif defined(MRB_INT16)
   typedef int16_t mrb_int;
+# define MRB_INT_BIT 16
 # define MRB_INT_MIN INT16_MIN
 # define MRB_INT_MAX INT16_MAX
 #else
   typedef int32_t mrb_int;
+# define MRB_INT_BIT 32
 # define MRB_INT_MIN INT32_MIN
 # define MRB_INT_MAX INT32_MAX
 # define PRIdMRB_INT PRId32
@@ -239,7 +242,7 @@ typedef union mrb_value {
     void *p;
     struct {
       unsigned int i_flag : MRB_FIXNUM_SHIFT;
-      mrb_int i : (sizeof(mrb_int) * CHAR_BIT - MRB_FIXNUM_SHIFT);
+      mrb_int i : (MRB_INT_BIT - MRB_FIXNUM_SHIFT);
     };
     struct {
       unsigned int sym_flag : MRB_SPECIAL_SHIFT;

--- a/mrbgems/mruby-sprintf/src/sprintf.c
+++ b/mrbgems/mruby-sprintf/src/sprintf.c
@@ -16,7 +16,7 @@
 #include <ctype.h>
 
 #define BIT_DIGITS(N)   (((N)*146)/485 + 1)  /* log2(10) =~ 146/485 */
-#define BITSPERDIG (sizeof(mrb_int)*CHAR_BIT)
+#define BITSPERDIG MRB_INT_BIT
 #define EXTENDSIGN(n, l) (((~0 << (n)) >> (((n)*(l)) % BITSPERDIG)) & ~(~0 << (n)))
 
 mrb_value mrb_str_format(mrb_state *, int, const mrb_value *, mrb_value);

--- a/src/numeric.c
+++ b/src/numeric.c
@@ -680,7 +680,7 @@ int_to_i(mrb_state *mrb, mrb_value num)
   return num;
 }
 
-#define SQRT_INT_MAX ((mrb_int)1<<((sizeof(mrb_int)*CHAR_BIT-1)/2))
+#define SQRT_INT_MAX ((mrb_int)1<<((MRB_INT_BIT-1)/2))
 /*tests if N*N would overflow*/
 #define FIT_SQRT_INT(n) (((n)<SQRT_INT_MAX)&&((n)>=-SQRT_INT_MAX))
 
@@ -959,13 +959,13 @@ fix_xor(mrb_state *mrb, mrb_value x)
   return mrb_fixnum_value(val);
 }
 
-#define NUMERIC_SHIFT_WIDTH_MAX (sizeof(mrb_int)*CHAR_BIT-1)
+#define NUMERIC_SHIFT_WIDTH_MAX (MRB_INT_BIT-1)
 
 static mrb_value
 lshift(mrb_state *mrb, mrb_int val, size_t width)
 {
   if (width > NUMERIC_SHIFT_WIDTH_MAX) {
-    mrb_raisef(mrb, E_RANGE_ERROR, "width(%S) > (%S:sizeof(mrb_int)*CHAR_BIT-1)",
+    mrb_raisef(mrb, E_RANGE_ERROR, "width(%S) > (%S:MRB_INT_BIT-1)",
                mrb_fixnum_value(width),
                mrb_fixnum_value(NUMERIC_SHIFT_WIDTH_MAX));
   }
@@ -1207,7 +1207,7 @@ fix_minus(mrb_state *mrb, mrb_value self)
 mrb_value
 mrb_fixnum_to_str(mrb_state *mrb, mrb_value x, int base)
 {
-  char buf[sizeof(mrb_int)*CHAR_BIT+1];
+  char buf[MRB_INT_BIT+1];
   char *b = buf + sizeof buf;
   mrb_int val = mrb_fixnum(x);
 


### PR DESCRIPTION
I initially assumed `sizeof(mrb_int)*CHAR_BIT` is more often used, but that wasn't the case.

But I still think `MRB_INT_BIT` could be an useful addition:
- `<limits.h>` for `CHAR_BIT` is not needed anymore
- easier and faster to read than `sizeof(mrb_int)*CHAR_BIT`
- simplifies preprocessor conditionals: `defined MRB_INT16 || defined MRB_INT64` → `MRB_INT_BIT != 32`
