### PR TITLE
add including limits.h.

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -34,6 +34,7 @@ extern "C" {
 
 #include <stdint.h>
 #include <stddef.h>
+#include <limits.h>
 
 #include "mrbconf.h"
 #include "mruby/value.h"

--- a/src/dump.c
+++ b/src/dump.c
@@ -6,6 +6,7 @@
 
 #include <ctype.h>
 #include <string.h>
+#include <limits.h>
 #include "mruby/dump.h"
 #include "mruby/string.h"
 #include "mruby/irep.h"


### PR DESCRIPTION
Because Android's libc(bionic) defines SIZE_MAX at limits.h(it is usually defined at stdint.h).
