### PR TITLE
Fix compile error check of Mrbc command.

### DIFF
--- a/tasks/mruby_build_commands.rake
+++ b/tasks/mruby_build_commands.rake
@@ -271,7 +271,7 @@ module MRuby
         out.puts io.read
       end
       # if mrbc execution fail, drop the file
-      unless $?.exitstatus
+      if $?.exitstatus != 0
         File.delete(out.path)
         exit(-1)
       end


### PR DESCRIPTION
Since `$?.exitstatus` returns int it's alway true so the output file deletion and rake abort won't happen in **mrbc** compile error.
