### PR TITLE
Don't redefine timeval in MinGW environments

### DIFF
--- a/mrbgems/mruby-time/src/time.c
+++ b/mrbgems/mruby-time/src/time.c
@@ -53,10 +53,14 @@
 #  endif
 
 typedef long suseconds_t;
+
+# ifndef __MINGW64__
 struct timeval {
   time_t tv_sec;
   suseconds_t tv_usec;
 };
+# endif
+
 static int
 gettimeofday(struct timeval *tv, void *tz)
 {


### PR DESCRIPTION
In MinGW, time.h defines timeval, so we do this to avoid redefinition errors.

Fixes #1856
