### PR TITLE
Add Fiber's double resume test and fix it.

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -70,7 +70,7 @@ typedef struct {
 enum mrb_fiber_state {
   MRB_FIBER_CREATED = 0,
   MRB_FIBER_RUNNING,
-  MRB_FIBER_RESUMED,
+  MRB_FIBER_SUSPENDED,
   MRB_FIBER_TERMINATED,
 };
 

--- a/mrbgems/mruby-fiber/test/fiber.rb
+++ b/mrbgems/mruby-fiber/test/fiber.rb
@@ -62,3 +62,16 @@ assert('Yield raises when called on root fiber') {
     true
   end
 }
+
+assert('Double resume of Fiber') do
+  f1 = Fiber.new {}
+  f2 = Fiber.new {
+    f1.resume
+    assert_raise(RuntimeError) { f2.resume }
+    Fiber.yield 0
+  }
+  assert_equal 0, f2.resume
+  f2.resume
+  assert_false f1.alive?
+  assert_false f2.alive?
+end


### PR DESCRIPTION
This PR is a cherry pick of PR #1860.
`MRB_FIBER_RESUMED` would be replaced with `MRB_FIBER_SUSPENDED`.
Since `MRB_FIBER_RESUMED` seems not effective to check fiber's double resume.
