### PR TITLE
Fix unexpected free of root fiber object and add correct Fiber#== due to it.

### DIFF
--- a/mrbgems/mruby-fiber/src/fiber.c
+++ b/mrbgems/mruby-fiber/src/fiber.c
@@ -213,6 +213,19 @@ fiber_alive_p(mrb_state *mrb, mrb_value self)
   return mrb_bool_value(c->status != MRB_FIBER_TERMINATED);
 }
 
+static mrb_value
+fiber_eq(mrb_state *mrb, mrb_value self)
+{
+  mrb_value other;
+  mrb_get_args(mrb, "o", &other);
+
+  if(mrb_type(other) != MRB_TT_FIBER) {
+    return mrb_false_value();
+  }
+
+  return mrb_bool_value(fiber_check(mrb, self) == fiber_check(mrb, other));
+}
+
 mrb_value
 mrb_fiber_yield(mrb_state *mrb, int len, mrb_value *a)
 {
@@ -289,6 +302,7 @@ mrb_mruby_fiber_gem_init(mrb_state* mrb)
   mrb_define_method(mrb, c, "initialize", fiber_init,    MRB_ARGS_NONE());
   mrb_define_method(mrb, c, "resume",     fiber_resume,  MRB_ARGS_ANY());
   mrb_define_method(mrb, c, "alive?",     fiber_alive_p, MRB_ARGS_NONE());
+  mrb_define_method(mrb, c, "==",         fiber_eq,      MRB_ARGS_REQ(1));
 
   mrb_define_class_method(mrb, c, "yield", fiber_yield, MRB_ARGS_ANY());
   mrb_define_class_method(mrb, c, "current", fiber_current, MRB_ARGS_NONE());

--- a/mrbgems/mruby-fiber/test/fiber.rb
+++ b/mrbgems/mruby-fiber/test/fiber.rb
@@ -17,6 +17,19 @@ assert('Fiber#alive?') {
   r1 == true and r2 == false
 }
 
+assert('Fiber#==') do
+  root = Fiber.current
+  assert_equal root, root
+  assert_equal root, Fiber.current
+  assert_false root != Fiber.current
+  f = Fiber.new {
+    assert_false root == Fiber.current
+  }
+  f.resume
+  assert_false f == root
+  assert_true f != root
+end
+
 assert('Fiber.yield') {
   f = Fiber.new{|x| Fiber.yield(x == 3)}
   f.resume(3)


### PR DESCRIPTION
Marking `fib` field of `mrb_context` is an alternative of this fix.
