### PR TITLE
fix bug Enmerable#entries when yield multi values

### DIFF
--- a/mrblib/enum.rb
+++ b/mrblib/enum.rb
@@ -129,8 +129,15 @@ module Enumerable
   # ISO 15.3.2.2.6
   def entries
     ary = []
-    self.each{|val|
-      ary.push val
+    self.each{|*args|
+      ary.push case args.length
+               when 0
+                 nil
+               when 1
+                 args[0]
+               else
+                 args
+               end
     }
     ary
   end

--- a/test/t/enumerable.rb
+++ b/test/t/enumerable.rb
@@ -105,4 +105,15 @@ end
 
 assert('Enumerable#to_a', '15.3.2.2.20') do
   assert_equal [1], [1].to_a
+
+  obj = Object.new
+  class << obj
+    include Enumerable
+    def each
+      yield
+      yield 1
+      yield 1,2,3
+    end
+  end
+  assert_equal [nil,1,[1,2,3]], obj.to_a
 end


### PR DESCRIPTION
I think that It's should be same behavior with CRuby.
