### PR TITLE
fix bug when `0 + other object`

### DIFF
--- a/src/numeric.c
+++ b/src/numeric.c
@@ -1131,10 +1131,10 @@ mrb_fixnum_plus(mrb_state *mrb, mrb_value x, mrb_value y)
   mrb_int a;
 
   a = mrb_fixnum(x);
-  if (a == 0) return y;
   if (mrb_fixnum_p(y)) {
     mrb_int b, c;
 
+    if (a == 0) return y;
     b = mrb_fixnum(y);
     c = a + b;
     if (((a < 0) ^ (b < 0)) == 0 && (a < 0) != (c < 0)) {

--- a/test/t/integer.rb
+++ b/test/t/integer.rb
@@ -15,6 +15,9 @@ assert('Integer#+', '15.2.8.3.1') do
 
   assert_equal 2, a
   assert_equal 2.0, b
+
+  assert_raise(TypeError){ 0+nil }
+  assert_raise(TypeError){ 1+nil }
 end
 
 assert('Integer#-', '15.2.8.3.2') do


### PR DESCRIPTION
`0+nil` should be raise TypeError.

before

```
0+nil #=> nil
1+nil #=> TypeError
```

after

```
0+nil #=> TypeError
1+nil #=> TypeError
```

(But `if (mrb_fixnum_p(y)) {` block is never called in current situation...)
