### PR TITLE
fix bug when `0 * other object`

### DIFF
--- a/src/numeric.c
+++ b/src/numeric.c
@@ -690,10 +690,10 @@ mrb_fixnum_mul(mrb_state *mrb, mrb_value x, mrb_value y)
   mrb_int a;
 
   a = mrb_fixnum(x);
-  if (a == 0) return x;
   if (mrb_fixnum_p(y)) {
     mrb_int b, c;
 
+    if (a == 0) return x;
     b = mrb_fixnum(y);
     if (FIT_SQRT_INT(a) && FIT_SQRT_INT(b))
       return mrb_fixnum_value(a*b);

--- a/test/t/integer.rb
+++ b/test/t/integer.rb
@@ -31,6 +31,9 @@ assert('Integer#*', '15.2.8.3.3') do
 
   assert_equal 1, a
   assert_equal 1.0, b
+
+  assert_raise(TypeError){ 0*nil }
+  assert_raise(TypeError){ 1*nil }
 end
 
 assert('Integer#/', '15.2.8.3.4') do


### PR DESCRIPTION
`0*nil` should be raise TypeError.
