### PR TITLE
float + nil should be raise TypeError

### DIFF
--- a/src/numeric.c
+++ b/src/numeric.c
@@ -1306,15 +1306,14 @@ num_cmp(mrb_state *mrb, mrb_value self)
  * and <code>other</code>.
  */
 static mrb_value
-flo_plus(mrb_state *mrb, mrb_value self)
+flo_plus(mrb_state *mrb, mrb_value x)
 {
-  mrb_float x,  y;
+  mrb_value y;
 
-  x = mrb_float(self);
-  mrb_get_args(mrb, "f", &y);
-
-  return mrb_float_value(mrb, x + y);
+  mrb_get_args(mrb, "o", &y);
+  return mrb_float_value(mrb, mrb_float(x) + mrb_to_flo(mrb, y));
 }
+
 /* ------------------------------------------------------------------------*/
 void
 mrb_init_numeric(mrb_state *mrb)

--- a/test/t/float.rb
+++ b/test/t/float.rb
@@ -15,6 +15,9 @@ assert('Float#+', '15.2.9.3.1') do
 
   assert_float(3.123456789, a)
   assert_float(4.123456789, b)
+
+  assert_raise(TypeError){ 0.0+nil }
+  assert_raise(TypeError){ 1.0+nil }
 end
 
 assert('Float#-', '15.2.9.3.2') do


### PR DESCRIPTION
before

``` ruby
1.0+nil #=> 1.0
1.0-nil #=> non float value (TypeError)
```

after

``` ruby
1.0+nil #=> non float value (TypeError)
1.0-nil #=> non float value (TypeError)
```
