### PR TITLE
Refactor enumerable.rb

### DIFF
--- a/mrblib/enum.rb
+++ b/mrblib/enum.rb
@@ -176,14 +176,12 @@ module Enumerable
   #
   # ISO 15.3.2.2.10
   def include?(obj)
-    st = false
     self.each{|val|
       if val == obj
-        st = true
-        break
+        return true
       end
     }
-    st
+    false
   end
 
   ##


### PR DESCRIPTION
st variable is not necessary.
Return values should return immediately in the following method:
- Enumerable#all?
- Enumerable#any?
- Enumerable#include?
