### PR TITLE
Kernel.loop should not catch StandardError.

### DIFF
--- a/mrblib/kernel.rb
+++ b/mrblib/kernel.rb
@@ -45,7 +45,7 @@ module Kernel
     while(true)
       yield
     end
-  rescue => StopIteration
+  rescue StopIteration
     nil
   end
 


### PR DESCRIPTION
Current implementation of Kernel.loop prevents us to catch a StandardError exception raised in the loop block because Kernel.loop itself catches it then throws it away.

```
begin
  loop do
    hoge
  end
rescue => e
  p e
end
```

``` sh
% ruby a.rb
#<NameError: undefined local variable or method `hoge' for main:Object>

% bin/mruby a.rb
%
```
