### PR TITLE
Reword mention of mrbtest in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ the [ISO standard](http://www.iso.org/iso/iso_catalogue/catalogue_tc/catalogue_d
 mruby can be linked and embedded within your application.  We provide the interpreter program "mruby" and
 the interactive mruby shell "mirb" as examples.  You can also compile Ruby programs into compiled byte code
 using the mruby compiler "mrbc".  All those tools reside in the "bin" directory.  "mrbc" is also able to
-generate compiled byte code in a C source file.  You can check the "mrbtest" program under the "test" directory.
+generate compiled byte code in a C source file, see the "mrbtest" program under the "test" directory
+for an example.
 
 This achievement was sponsored by the Regional Innovation Creation R&D Programs of
 the Ministry of Economy, Trade and Industry of Japan.


### PR DESCRIPTION
I'm not really sure I correctly understood the meaning of `"mrbc" is also able to generate compiled byte code in a C source file.
You can check the "mrbtest" program under the "test" directory.`

I guess mrbtest is meant as an example for using byte code in a C source file and tried to clarify that meaning.

If I'm wrong, just ignore this. :)
