### PR TITLE
Fix behavior of Comparable methods when <=> return nil

### DIFF
--- a/mrblib/compar.rb
+++ b/mrblib/compar.rb
@@ -13,7 +13,7 @@ module Comparable
   def < other
     cmp = self <=> other
     if cmp.nil?
-      false
+      raise ArgumentError, "comparison of #{self.class} with #{other.class} failed"
     elsif cmp < 0
       true
     else
@@ -30,7 +30,7 @@ module Comparable
   def <= other
     cmp = self <=> other
     if cmp.nil?
-      false
+      raise ArgumentError, "comparison of #{self.class} with #{other.class} failed"
     elsif cmp <= 0
       true
     else
@@ -62,7 +62,7 @@ module Comparable
   def > other
     cmp = self <=> other
     if cmp.nil?
-      false
+      raise ArgumentError, "comparison of #{self.class} with #{other.class} failed"
     elsif cmp > 0
       true
     else
@@ -79,7 +79,7 @@ module Comparable
   def >= other
     cmp = self <=> other
     if cmp.nil?
-      false
+      raise ArgumentError, "comparison of #{self.class} with #{other.class} failed"
     elsif cmp >= 0
       true
     else

--- a/test/t/comparable.rb
+++ b/test/t/comparable.rb
@@ -3,22 +3,26 @@ assert('Comparable#<', '15.3.3.2.1') do
   class Foo
     include Comparable
     def <=>(x)
-      0
+      x
     end
   end
-
-  assert_false(Foo.new < Foo.new)
+  assert_false(Foo.new < 0)
+  assert_false(Foo.new < 1)
+  assert_true(Foo.new < -1)
+  assert_raise(ArgumentError){ Foo.new < nil }
 end
 
 assert('Comparable#<=', '15.3.3.2.2') do
   class Foo
     include Comparable
     def <=>(x)
-      0
+      x
     end
   end
-
-  assert_true(Foo.new <= Foo.new)
+  assert_true(Foo.new <= 0)
+  assert_false(Foo.new <= 1)
+  assert_true(Foo.new <= -1)
+  assert_raise(ArgumentError){ Foo.new <= nil }
 end
 
 assert('Comparable#==', '15.3.3.2.3') do
@@ -36,22 +40,26 @@ assert('Comparable#>', '15.3.3.2.4') do
   class Foo
     include Comparable
     def <=>(x)
-      0
+      x
     end
   end
-
-  assert_false(Foo.new > Foo.new)
+  assert_false(Foo.new > 0)
+  assert_true(Foo.new > 1)
+  assert_false(Foo.new > -1)
+  assert_raise(ArgumentError){ Foo.new > nil }
 end
 
 assert('Comparable#>=', '15.3.3.2.5') do
   class Foo
     include Comparable
     def <=>(x)
-      0
+      x
     end
   end
-
-  assert_true(Foo.new >= Foo.new)
+  assert_true(Foo.new >= 0)
+  assert_true(Foo.new >= 1)
+  assert_false(Foo.new >= -1)
+  assert_raise(ArgumentError){ Foo.new >= nil }
 end
 
 assert('Comparable#between?', '15.3.3.2.6') do


### PR DESCRIPTION
If `<=>` method return not Integer value,
The ISO spec of some Comparable methods(`<`,`>`,`<=`,`>=`) defined that "the behavior is unspecified".
And _master_, return `false` that time.

But, I think it's should be raise ArgumentError like that.

before

``` ruby
> 0.0 <=> nil
 => nil
> 0.0 < nil
 => false
> 0.0 > nil
 => false
> 0.0 == nil
 => false
```

after

``` ruby
> 0.0 <=> nil
 => nil
> 0.0 < nil
 => ArgumentError
> 0.0 > nil
 => ArgumentError
> 0.0 == nil
 => false
```
