### PR TITLE
Float#round fix bug for infinity and nan cases

### DIFF
--- a/src/numeric.c
+++ b/src/numeric.c
@@ -594,6 +594,16 @@ flo_round(mrb_state *mrb, mrb_value num)
 
   mrb_get_args(mrb, "|i", &ndigits);
   number = mrb_float(num);
+
+  if (isinf(number)) {
+    if (0 < ndigits) return num;
+    else mrb_raise(mrb, E_FLOATDOMAIN_ERROR, number < 0 ? "-Infinity" : "Infinity");
+  }
+  if (isnan(number)) {
+    if (0 < ndigits) return num;
+    else mrb_raise(mrb, E_FLOATDOMAIN_ERROR, "NaN");
+  }
+
   f = 1.0;
   i = abs(ndigits);
   while  (--i >= 0)
@@ -621,7 +631,11 @@ flo_round(mrb_state *mrb, mrb_value num)
     if (ndigits < 0) number *= f;
     else number /= f;
   }
-  if (ndigits > 0) return mrb_float_value(mrb, number);
+
+  if (ndigits > 0) {
+    if (isinf(number) || isnan(number)) return num;
+    return mrb_float_value(mrb, number);
+  }
   return mrb_fixnum_value((mrb_int)number);
 }
 

--- a/test/t/float.rb
+++ b/test/t/float.rb
@@ -130,6 +130,18 @@ assert('Float#round', '15.2.9.3.12') do
   assert_equal(    3, g)
   assert_float(  3.4, h)
   assert_float(3.423, i)
+
+  assert_equal(42.0, 42.0.round(307))
+  assert_equal(1.0e307, 1.0e307.round(2))
+
+  inf = 1.0/0.0
+  assert_raise(FloatDomainError){ inf.round }
+  assert_raise(FloatDomainError){ inf.round(-1) }
+  assert_equal(inf, inf.round(1))
+  nan = 0.0/0.0
+  assert_raise(FloatDomainError){ nan.round }
+  assert_raise(FloatDomainError){ nan.round(-1) }
+  assert_true(nan.round(1).nan?)
 end
 
 assert('Float#to_f', '15.2.9.3.13') do


### PR DESCRIPTION
Current is like that.

``` ruby
> inf = 1.0/0.0
 => inf
> inf.round
 => -2147483648
> inf.round(-1)
 => -2147483648
> inf.round(1)
 => inf
> nan = 0.0/0.0
 => NaN
> nan.round
 => -2147483648
> nan.round(-1)
 => -2147483648
> nan.round(1)
 => NaN
> 42.0.round(306)
 => 42.0
> 42.0.round(307)
 => inf
> 1.0e307.round(1)
 => 1.0e+307
> 1.0e307.round(2)
 => inf
```

I think it's should be like that.

``` ruby
> inf = 1.0/0.0
 => inf
> inf.round
(mirb):1: Infinity (FloatDomainError)
> inf.round(-1)
(mirb):1: Infinity (FloatDomainError)
> inf.round(1)
 => inf
> nan = 0.0/0.0
 => NaN
> nan.round
(mirb):1: NaN (FloatDomainError)
> nan.round(-1)
(mirb):1: NaN (FloatDomainError)
> nan.round(1)
 => NaN
> 42.0.round(306)
 => 42.0
> 42.0.round(307)
 => 42.0
> 1.0e307.round(1)
 => 1.0e+307
> 1.0e307.round(2)
 => 1.0e+307
```
