### PR TITLE
introduce mrb_define_module_lit for C string literals

### DIFF
--- a/examples/mrbgems/c_and_ruby_extension_example/src/example.c
+++ b/examples/mrbgems/c_and_ruby_extension_example/src/example.c
@@ -10,7 +10,7 @@ mrb_c_method(mrb_state *mrb, mrb_value self)
 
 void
 mrb_c_and_ruby_extension_example_gem_init(mrb_state* mrb) {
-  struct RClass *class_cextension = mrb_define_module(mrb, "CRubyExtension");
+  struct RClass *class_cextension = mrb_define_module_lit(mrb, "CRubyExtension");
   mrb_define_class_method(mrb, class_cextension, "c_method", mrb_c_method, MRB_ARGS_NONE());
 }
 

--- a/examples/mrbgems/c_extension_example/src/example.c
+++ b/examples/mrbgems/c_extension_example/src/example.c
@@ -10,7 +10,7 @@ mrb_c_method(mrb_state *mrb, mrb_value self)
 
 void
 mrb_c_extension_example_gem_init(mrb_state* mrb) {
-  struct RClass *class_cextension = mrb_define_module(mrb, "CExtension");
+  struct RClass *class_cextension = mrb_define_module_lit(mrb, "CExtension");
   mrb_define_class_method(mrb, class_cextension, "c_method", mrb_c_method, MRB_ARGS_NONE());
 }
 

--- a/include/mruby.h
+++ b/include/mruby.h
@@ -174,6 +174,8 @@ typedef struct mrb_state {
 typedef mrb_value (*mrb_func_t)(mrb_state *mrb, mrb_value);
 struct RClass *mrb_define_class(mrb_state *, const char*, struct RClass*);
 struct RClass *mrb_define_module(mrb_state *, const char*);
+struct RClass *mrb_define_module_static(mrb_state *mrb, const char *name, size_t len);
+#define mrb_define_module_lit(mrb, lit) mrb_define_module_static(mrb, lit, mrb_strlen_lit(lit))
 mrb_value mrb_singleton_class(mrb_state*, mrb_value);
 void mrb_include_module(mrb_state*, struct RClass*, struct RClass*);
 

--- a/mrbgems/mruby-math/src/math.c
+++ b/mrbgems/mruby-math/src/math.c
@@ -622,7 +622,7 @@ void
 mrb_mruby_math_gem_init(mrb_state* mrb)
 {
   struct RClass *mrb_math;
-  mrb_math = mrb_define_module(mrb, "Math");
+  mrb_math = mrb_define_module_lit(mrb, "Math");
 
 #ifdef M_PI
   mrb_define_const(mrb, mrb_math, "PI", mrb_float_value(mrb, M_PI));

--- a/mrbgems/mruby-objectspace/src/mruby_objectspace.c
+++ b/mrbgems/mruby-objectspace/src/mruby_objectspace.c
@@ -103,7 +103,7 @@ os_count_objects(mrb_state *mrb, mrb_value self)
 void
 mrb_mruby_objectspace_gem_init(mrb_state *mrb)
 {
-  struct RClass *os = mrb_define_module(mrb, "ObjectSpace");
+  struct RClass *os = mrb_define_module_lit(mrb, "ObjectSpace");
   mrb_define_class_method(mrb, os, "count_objects", os_count_objects, MRB_ARGS_OPT(1));
 }
 

--- a/mrbgems/mruby-sprintf/src/kernel.c
+++ b/mrbgems/mruby-sprintf/src/kernel.c
@@ -14,7 +14,7 @@ mrb_mruby_sprintf_gem_init(mrb_state* mrb)
   struct RClass *krn;
 
   if (mrb->kernel_module == NULL) {
-    mrb->kernel_module = mrb_define_module(mrb, "Kernel"); /* Might be PARANOID. */
+    mrb->kernel_module = mrb_define_module_lit(mrb, "Kernel"); /* Might be PARANOID. */
   }
   krn = mrb->kernel_module;
 

--- a/src/class.c
+++ b/src/class.c
@@ -159,6 +159,12 @@ mrb_define_module(mrb_state *mrb, const char *name)
 }
 
 struct RClass*
+mrb_define_module_static(mrb_state *mrb, const char *name, size_t len)
+{
+  return define_module(mrb, mrb_intern_static(mrb, name, len), mrb->object_class);
+}
+
+struct RClass*
 mrb_vm_define_module(mrb_state *mrb, mrb_value outer, mrb_sym id)
 {
   return define_module(mrb, id, mrb_class_ptr(outer));

--- a/src/compar.c
+++ b/src/compar.c
@@ -9,5 +9,5 @@
 void
 mrb_init_comparable(mrb_state *mrb)
 {
-  mrb_define_module(mrb, "Comparable");
+  mrb_define_module_lit(mrb, "Comparable");
 }

--- a/src/enum.c
+++ b/src/enum.c
@@ -9,6 +9,6 @@
 void
 mrb_init_enumerable(mrb_state *mrb)
 {
-  mrb_define_module(mrb, "Enumerable");
+  mrb_define_module_lit(mrb, "Enumerable");
 }
 

--- a/src/gc.c
+++ b/src/gc.c
@@ -1314,7 +1314,7 @@ mrb_init_gc(mrb_state *mrb)
 {
   struct RClass *gc;
 
-  gc = mrb_define_module(mrb, "GC");
+  gc = mrb_define_module_lit(mrb, "GC");
 
   mrb_define_class_method(mrb, gc, "start", gc_start, MRB_ARGS_NONE());
   mrb_define_class_method(mrb, gc, "enable", gc_enable, MRB_ARGS_NONE());

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -1099,7 +1099,7 @@ mrb_init_kernel(mrb_state *mrb)
 {
   struct RClass *krn;
 
-  krn = mrb->kernel_module = mrb_define_module(mrb, "Kernel");
+  krn = mrb->kernel_module = mrb_define_module_lit(mrb, "Kernel");
   mrb_define_class_method(mrb, krn, "block_given?",         mrb_f_block_given_p_m,           MRB_ARGS_NONE());    /* 15.3.1.2.2  */
   mrb_define_class_method(mrb, krn, "global_variables",     mrb_f_global_variables,          MRB_ARGS_NONE());    /* 15.3.1.2.4  */
   mrb_define_class_method(mrb, krn, "iterator?",            mrb_f_block_given_p_m,           MRB_ARGS_NONE());    /* 15.3.1.2.5  */


### PR DESCRIPTION
Introduce `mrb_define_module_lit` and `mrb_define_module_static`.
