### PR TITLE
Hash#{select,select!} support return Enumerator

### DIFF
--- a/mrbgems/mruby-enumerator/test/enumerator.rb
+++ b/mrbgems/mruby-enumerator/test/enumerator.rb
@@ -494,6 +494,20 @@ assert 'Hash#each_value' do
   assert_equal [1,2], {a:1,b:2}.each_value.to_a.sort
 end
 
+assert 'Hash#select' do
+  h = {1=>2,3=>4,5=>6}
+  hret = h.select.with_index {|a,b| a[1] == 4}
+  assert_equal({3=>4}, hret)
+  assert_equal({1=>2,3=>4,5=>6}, h)
+end
+
+assert 'Hash#select!' do
+  h = {1=>2,3=>4,5=>6}
+  hret = h.select!.with_index {|a,b| a[1] == 4}
+  assert_equal h, hret
+  assert_equal({3=>4}, h)
+end
+
 assert 'Range#each' do
   a = (1..5)
   b = a.each

--- a/mrblib/hash.rb
+++ b/mrblib/hash.rb
@@ -167,7 +167,7 @@ class Hash
     keys = []
     self.each_key{|k|
       v = self[k]
-      unless b.call(k, v)
+      unless b.call([k, v])
         keys.push(k)
       end
     }
@@ -185,7 +185,7 @@ class Hash
     h = {}
     self.each_key{|k|
       v = self[k]
-      if b.call(k, v)
+      if b.call([k, v])
         h[k] = v
       end
     }


### PR DESCRIPTION
This PR have two points.
- Support return Enumerator
- Fix yield value when called by Enumerator method (e.g. `with_index`)
