### PR TITLE
Hash#{reject,reject!} support return Enumerator

### DIFF
--- a/mrbgems/mruby-enumerator/test/enumerator.rb
+++ b/mrbgems/mruby-enumerator/test/enumerator.rb
@@ -508,6 +508,20 @@ assert 'Hash#select!' do
   assert_equal({3=>4}, h)
 end
 
+assert 'Hash#reject' do
+  h = {1=>2,3=>4,5=>6}
+  hret = h.reject.with_index {|a,b| a[1] == 4}
+  assert_equal({1=>2,5=>6}, hret)
+  assert_equal({1=>2,3=>4,5=>6}, h)
+end
+
+assert 'Hash#reject!' do
+  h = {1=>2,3=>4,5=>6}
+  hret = h.reject!.with_index {|a,b| a[1] == 4}
+  assert_equal h, hret
+  assert_equal({1=>2,5=>6}, h)
+end
+
 assert 'Range#each' do
   a = (1..5)
   b = a.each

--- a/mrblib/hash.rb
+++ b/mrblib/hash.rb
@@ -139,7 +139,7 @@ class Hash
     keys = []
     self.each_key{|k|
       v = self[k]
-      if b.call(k, v)
+      if b.call([k, v])
         keys.push(k)
       end
     }
@@ -157,7 +157,7 @@ class Hash
     h = {}
     self.each_key{|k|
       v = self[k]
-      unless b.call(k, v)
+      unless b.call([k, v])
         h[k] = v
       end
     }


### PR DESCRIPTION
This is a fix for the Hash#reject{,!} similar to https://github.com/mruby/mruby/pull/1923
