### PR TITLE
Hash#__update fix typo

### DIFF
--- a/mrblib/hash.rb
+++ b/mrblib/hash.rb
@@ -197,7 +197,7 @@ class Hash
   end
 
   def __update(h)
-    h.each_key{|k| self[k] = h[v]}
+    h.each_key{|k| self[k] = h[k]}
     self
   end
 end


### PR DESCRIPTION
It's called by create Hash of over 126 keys.
But test not call this now.

See also https://github.com/mruby/mruby/pull/1896
