### PR TITLE
Implement Kernel#__method__

### DIFF
--- a/src/kernel.c
+++ b/src/kernel.c
@@ -210,6 +210,26 @@ mrb_f_block_given_p_m(mrb_state *mrb, mrb_value self)
   return mrb_bool_value(given_p);
 }
 
+/*
+ *  call-seq:
+ *     __method__         -> symbol
+ *
+ *  Returns the name at the definition of the current method as a
+ *  Symbol.
+ *  If called outside of a method, it returns <code>nil</code>.
+ *
+ */
+static mrb_value
+mrb_f_method(mrb_state *mrb, mrb_value self)
+{
+  mrb_callinfo *ci = mrb->c->ci;
+  ci--;
+  if (ci->mid)
+    return mrb_symbol_value(ci->mid);
+  else
+    return mrb_nil_value();
+}
+
 /* 15.3.1.3.7  */
 /*
  *  call-seq:
@@ -1113,6 +1133,7 @@ mrb_init_kernel(mrb_state *mrb)
   mrb_define_method(mrb, krn, "===",                        mrb_equal_m,                     MRB_ARGS_REQ(1));    /* 15.3.1.3.2  */
   mrb_define_method(mrb, krn, "__id__",                     mrb_obj_id_m,                    MRB_ARGS_NONE());    /* 15.3.1.3.3  */
   mrb_define_method(mrb, krn, "__send__",                   mrb_f_send,                      MRB_ARGS_ANY());     /* 15.3.1.3.4  */
+  mrb_define_method(mrb, krn, "__method__",                 mrb_f_method,                    MRB_ARGS_NONE());
   mrb_define_method(mrb, krn, "block_given?",               mrb_f_block_given_p_m,           MRB_ARGS_NONE());    /* 15.3.1.3.6  */
   mrb_define_method(mrb, krn, "class",                      mrb_obj_class_m,                 MRB_ARGS_NONE());    /* 15.3.1.3.7  */
   mrb_define_method(mrb, krn, "clone",                      mrb_obj_clone,                   MRB_ARGS_NONE());    /* 15.3.1.3.8  */

--- a/test/t/kernel.rb
+++ b/test/t/kernel.rb
@@ -528,6 +528,20 @@ assert('Kernel#global_variables') do
   end
 end
 
+assert('Kernel#__method__') do
+  assert_equal(:m, Class.new {def m; __method__; end}.new.m)
+  assert_equal(:m, Class.new {define_method(:m) {__method__}}.new.m)
+  c = Class.new do
+    [:m1, :m2].each do |m|
+      define_method(m) do
+        __method__
+      end
+    end
+  end
+  assert_equal(:m1, c.new.m1)
+  assert_equal(:m2, c.new.m2)
+end
+
 assert('stack extend') do
   def recurse(count, stop)
     return count if count > stop
@@ -539,3 +553,4 @@ assert('stack extend') do
     recurse(0, 100000)
   end
 end
+


### PR DESCRIPTION
- not support origin alias name.
- not ISO defined method.
