### PR TITLE
change gemdir from "#{gem_clone_dir}/#{repo_name}" to "#{gem_clone_dir}/#{repo_owner}/#{repo_name}"

### DIFF
--- a/tasks/mruby_build_gem.rake
+++ b/tasks/mruby_build_gem.rake
@@ -56,6 +56,11 @@ module MRuby
         url = params[:git]
         gemdir = "#{gem_clone_dir}/#{url.match(/([-\w]+)(\.[-\w]+|)$/).to_a[1]}"
 
+        if File.exists?(gemdir)
+          old_url = %x[GIT_DIR=#{gemdir}/.git git ls-remote --get-url origin].strip
+          FileUtils.rm_r gemdir unless old_url == url
+        end
+
         if File.exist?(gemdir)
           if $pull_gems
             git.run_pull gemdir, url


### PR DESCRIPTION
When building with external mrbgems, for example using these lines in build_config.rb:

``` ruby
conf.gem :github => 'iij/mruby-digest'
```

The repo will be clone into _build/mrbgems/mruby-digest_. Each time I build, that path will be checked, created and pulled from remote if not exists.

Assume someday for some reason I want to use my own fork of that gem, and I updated build_config.rb to:

``` ruby
conf.gem :github => 'dorentus/mruby-digest'
```

But when I run `./minirake all`, since the repo name is not changed and _build/mrbgems/mruby-digest_ already exists, it does not got changed as expected. I have to remove _build/mrbgems/mruby-digest_ manually to got it  updated.

---

This patch changes gemdir to "#{gem_clone_dir}/#{repo_owner}/#{repo_name}" and fixes problems above.
