### PR TITLE
Support string argument in Array#*

### DIFF
--- a/src/array.c
+++ b/src/array.c
@@ -370,6 +370,23 @@ mrb_ary_replace_m(mrb_state *mrb, mrb_value self)
   return self;
 }
 
+/*
+ *  call-seq:
+ *     ary * int     -> new_ary
+ *     ary * str     -> new_string
+ *
+ *  Repetition --- With a String argument, equivalent to
+ *  <code>ary.join(str)</code>.
+ *
+ *  Otherwise, returns a new array built by concatenating the +int+ copies of
+ *  +self+.
+ *
+ *
+ *     [ 1, 2, 3 ] * 3    #=> [ 1, 2, 3, 1, 2, 3, 1, 2, 3 ]
+ *     [ 1, 2, 3 ] * ","  #=> "1,2,3"
+ *
+ */
+
 static mrb_value
 mrb_ary_times(mrb_state *mrb, mrb_value self)
 {
@@ -378,7 +395,12 @@ mrb_ary_times(mrb_state *mrb, mrb_value self)
   mrb_value ary;
   mrb_value *ptr;
   mrb_int times;
+  mrb_value obj;
 
+  mrb_get_args(mrb, "o", &obj);
+  if (mrb_type(obj) == MRB_TT_STRING) {
+    return mrb_ary_join(mrb, self, obj);
+  }
   mrb_get_args(mrb, "i", &times);
   if (times < 0) {
     mrb_raise(mrb, E_ARGUMENT_ERROR, "negative argument");

--- a/test/t/array.rb
+++ b/test/t/array.rb
@@ -28,6 +28,7 @@ assert('Array#*', '15.2.12.5.2') do
   end
   assert_equal([1, 1, 1], [1].*(3))
   assert_equal([], [1].*(0))
+  assert_equal("1,2,3", [1, 2, 3] * ",")
 end
 
 assert('Array#<<', '15.2.12.5.3') do


### PR DESCRIPTION
Support this following statemet:

``` ruby
[ 1, 2, 3 ] * ","  #=> "1,2,3"
```
