### PR TITLE
Module#remove_method support duck-type

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -1804,7 +1804,7 @@ mrb_mod_remove_method(mrb_state *mrb, mrb_value mod)
 
   mrb_get_args(mrb, "*", &argv, &argc);
   while (argc--) {
-    remove_method(mrb, mod, mrb_symbol(*argv));
+    remove_method(mrb, mod, mrb_to_sym(mrb, *argv));
     argv++;
   }
   return mod;


### PR DESCRIPTION
I make two C function(`to_sym` and `mrb_to_sym`) that reason.
- Module#remove_method should support duck-type
- mrb_get_args('n') also
