### PR TITLE
Add outer class for fix inner singleton class

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -102,6 +102,7 @@ prepare_singleton_class(mrb_state *mrb, struct RBasic *o)
   mrb_field_write_barrier(mrb, (struct RBasic*)o, (struct RBasic*)sc);
   mrb_field_write_barrier(mrb, (struct RBasic*)sc, (struct RBasic*)o);
   mrb_obj_iv_set(mrb, (struct RObject*)sc, mrb_intern_lit(mrb, "__attached__"), mrb_obj_value(o));
+  mrb_obj_iv_set(mrb, (struct RObject*)sc, mrb_intern_lit(mrb, "__outer__"), mrb_obj_value(o));
 }
 
 static struct RClass *

--- a/test/t/class.rb
+++ b/test/t/class.rb
@@ -358,6 +358,19 @@ assert('singleton tests') do
       end
     end
   end
+
+  assert_nothing_raised do
+    module FooMod
+      class FooModInner
+      end
+      class << self
+        FooModInner
+        class << self
+          FooModInner
+        end
+      end
+    end
+  end
 end
 
 assert('clone Class') do


### PR DESCRIPTION
That code raise NameError.

``` ruby
module Mod
  module InnerModule
  end
  class InnerClass
  end
  class << self
    InnerModule #=> uninitialized constant InnerModule (NameError)
    InnerClass #=> uninitialized constant InnerClass (NameError)
  end
end
```

This reason was that singleton class object can't find outer class for iv `__outer__` was nothing.
