### PR TITLE
Add API to define cfunc Proc with userdata.

### DIFF
--- a/include/mruby/proc.h
+++ b/include/mruby/proc.h
@@ -55,6 +55,10 @@ void mrb_proc_copy(struct RProc *a, struct RProc *b);
 /* implementation of #send method */
 mrb_value mrb_f_send(mrb_state *mrb, mrb_value self);
 
+/* following functions are defined in mruby-proc-ext so please include it when using */
+struct RProc *mrb_proc_new_cfunc_with_env(mrb_state*, mrb_func_t, mrb_int, const mrb_value*);
+mrb_value mrb_cfunc_env_get(mrb_state*, mrb_int);
+
 #include "mruby/khash.h"
 KHASH_DECLARE(mt, mrb_sym, struct RProc*, 1)
 

--- a/mrbgems/mruby-proc-ext/test/proc.c
+++ b/mrbgems/mruby-proc-ext/test/proc.c
@@ -1,0 +1,56 @@
+#include "mruby.h"
+#include "mruby/proc.h"
+#include "mruby/class.h"
+
+static mrb_value
+return_func_name(mrb_state *mrb, mrb_value self)
+{
+  return mrb_cfunc_env_get(mrb, 0);
+}
+
+static mrb_value
+proc_new_cfunc_with_env(mrb_state *mrb, mrb_value self)
+{
+  mrb_sym n;
+  mrb_value n_val;
+  mrb_get_args(mrb, "n", &n);
+  n_val = mrb_symbol_value(n);
+  mrb_define_method_raw(mrb, mrb_class_ptr(self), n,
+                        mrb_proc_new_cfunc_with_env(mrb, return_func_name, 1, &n_val));
+  return self;
+}
+
+static mrb_value
+return_env(mrb_state *mrb, mrb_value self)
+{
+  mrb_int idx;
+  mrb_get_args(mrb, "i", &idx);
+  return mrb_cfunc_env_get(mrb, idx);
+}
+
+static mrb_value
+cfunc_env_get(mrb_state *mrb, mrb_value self)
+{
+  mrb_sym n;
+  mrb_value *argv; mrb_int argc;
+  mrb_get_args(mrb, "na", &n, &argv, &argc);
+  mrb_define_method_raw(mrb, mrb_class_ptr(self), n,
+                        mrb_proc_new_cfunc_with_env(mrb, return_env, argc, argv));
+  return self;
+}
+
+static mrb_value
+cfunc_without_env(mrb_state *mrb, mrb_value self)
+{
+  return mrb_cfunc_env_get(mrb, 0);
+}
+
+void mrb_mruby_proc_ext_gem_test(mrb_state *mrb)
+{
+  struct RClass *cls;
+
+  cls = mrb_define_class(mrb, "ProcExtTest", mrb->object_class);
+  mrb_define_module_function(mrb, cls, "mrb_proc_new_cfunc_with_env", proc_new_cfunc_with_env, MRB_ARGS_REQ(1));
+  mrb_define_module_function(mrb, cls, "mrb_cfunc_env_get", cfunc_env_get, MRB_ARGS_REQ(2));
+  mrb_define_module_function(mrb, cls, "cfunc_without_env", cfunc_without_env, MRB_ARGS_NONE());
+}

--- a/mrbgems/mruby-proc-ext/test/proc.rb
+++ b/mrbgems/mruby-proc-ext/test/proc.rb
@@ -46,3 +46,26 @@ end
 assert('Kernel#proc') do
   assert_true !proc{|a|}.lambda?
 end
+
+assert('mrb_proc_new_cfunc_with_env') do
+  ProcExtTest.mrb_proc_new_cfunc_with_env(:test)
+  ProcExtTest.mrb_proc_new_cfunc_with_env(:mruby)
+
+  t = ProcExtTest.new
+
+  assert_equal :test, t.test
+  assert_equal :mruby, t.mruby
+end
+
+assert('mrb_cfunc_env_get') do
+  ProcExtTest.mrb_cfunc_env_get :get_int, [0, 1, 2]
+
+  t = ProcExtTest.new
+
+  assert_raise(TypeError) { t.cfunc_without_env }
+
+  assert_raise(IndexError) { t.get_int(-1) }
+  assert_raise(IndexError) { t.get_int(3) }
+
+  assert_equal 1, t.get_int(1)
+end


### PR DESCRIPTION
The APIs are defined in mruby-proc-ext so include it before using this API.
This should resolve #1794 .

`mrb_proc_new_cfunc_with_env` creates cfunc Proc with _env_(=userdata).
To define a method with it use `mrb_define_method_raw` instead of function like `mrb_define_method`.

`mrb_cfunc_env_get(mrb_state*, mrb_int)` retrieves env variable associated to current cfunc Proc.
It may raise `TypeError` if the current Proc isn't cfunc Proc or it doesn't have _env_ associated.
And it may raise `IndexError` if 2nd argument is out of range of _env_.

(Please read test code added for more detail usage.)
