### PR TITLE
Add mrbgem license checker.

### DIFF
--- a/tasks/mrbgem_spec.rake
+++ b/tasks/mrbgem_spec.rake
@@ -289,6 +289,9 @@ module MRuby
 
       def check
         each do |g|
+          unless g.build.mrbgem_license_checker.nil?
+            fail "License checking failed: #{g.licenses}" unless g.build.mrbgem_license_checker.call g.licenses
+          end
           g.dependencies.each do |dep|
             name = dep[:gem]
             req_versions = dep[:requirements]

--- a/tasks/mruby_build.rake
+++ b/tasks/mruby_build.rake
@@ -44,7 +44,7 @@ module MRuby
     include Rake::DSL
     include LoadGems
     attr_accessor :name, :bins, :exts, :file_separator, :build_dir, :gem_clone_dir, :enable_bintest
-    attr_reader :libmruby, :gems
+    attr_reader :libmruby, :gems, :mrbgem_license_checker
 
     COMPILERS = %w(cc cxx objc asm)
     COMMANDS = COMPILERS + %w(linker archiver yacc gperf git exts mrbc)
@@ -88,6 +88,10 @@ module MRuby
 
       MRuby::Build.current = MRuby.targets[@name]
       MRuby.targets[@name].instance_eval(&block)
+    end
+
+    def set_mrbgem_license_checker(&b)
+      @mrbgem_license_checker = b
     end
 
     def enable_debug

--- a/travis_config.rb
+++ b/travis_config.rb
@@ -2,6 +2,8 @@ MRuby::Build.new('debug') do |conf|
   toolchain :gcc
   enable_debug
 
+  set_mrbgem_license_checker { |l| l == 'MIT' }
+
   # include all core GEMs
   conf.gembox 'full-core'
   conf.cc.flags += %w(-Werror=declaration-after-statement)


### PR DESCRIPTION
Block passed to `MRuby::Build#set_mrbgem_license_checker(&blk)` will be called per each mrbgems in mrbgems setup with license string argument.
When any of the call returns false the build will fail before it starts.
