### PR TITLE
test fails when we don't have Enumerator.

### DIFF
--- a/mrbgems/mruby-array-ext/test/array.rb
+++ b/mrbgems/mruby-array-ext/test/array.rb
@@ -139,5 +139,10 @@ assert("Array#reverse_each") do
     b << i
   end
   assert_equal [ "d", "c", "b", "a" ], b
-  assert_equal [ "d", "c", "b", "a" ], a.reverse_each.to_a
+
+  if Object.const_defined?(:Enumerator)
+    assert_equal [ "d", "c", "b", "a" ], a.reverse_each.to_a
+  else
+    true
+  end
 end


### PR DESCRIPTION
a test in mruby-array-ext depends on mruby-enumerator.
