### PR TITLE
Add Fiber#resumable? and Fiber#transferable? .

### DIFF
--- a/mrbgems/mruby-fiber/src/fiber.c
+++ b/mrbgems/mruby-fiber/src/fiber.c
@@ -235,6 +235,33 @@ fiber_eq(mrb_state *mrb, mrb_value self)
 }
 
 static mrb_value
+fiber_resumable_p(mrb_state *mrb, mrb_value self)
+{
+  struct mrb_context *c = fiber_check(mrb, self);
+  switch (c->status) {
+  case MRB_FIBER_CREATED:
+  case MRB_FIBER_SUSPENDED:
+    return mrb_true_value();
+  default:
+    return mrb_false_value();
+  }
+}
+
+static mrb_value
+fiber_transferable_p(mrb_state *mrb, mrb_value self)
+{
+  struct mrb_context *c = fiber_check(mrb, self);
+  switch (c->status) {
+  case MRB_FIBER_CREATED:
+  case MRB_FIBER_SUSPENDED:
+  case MRB_FIBER_TRANSFERRED:
+    return mrb_true_value();
+  default:
+    return mrb_false_value();
+  }
+}
+
+static mrb_value
 fiber_transfer(mrb_state *mrb, mrb_value self)
 {
   struct mrb_context *c = fiber_check(mrb, self);
@@ -333,6 +360,8 @@ mrb_mruby_fiber_gem_init(mrb_state* mrb)
   mrb_define_method(mrb, c, "resume",     fiber_resume,  MRB_ARGS_ANY());
   mrb_define_method(mrb, c, "transfer",   fiber_transfer, MRB_ARGS_ANY());
   mrb_define_method(mrb, c, "alive?",     fiber_alive_p, MRB_ARGS_NONE());
+  mrb_define_method(mrb, c, "resumable?", fiber_resumable_p, MRB_ARGS_NONE());
+  mrb_define_method(mrb, c, "transferable?", fiber_transferable_p, MRB_ARGS_NONE());
   mrb_define_method(mrb, c, "==",         fiber_eq,      MRB_ARGS_REQ(1));
 
   mrb_define_class_method(mrb, c, "yield", fiber_yield, MRB_ARGS_ANY());

--- a/mrbgems/mruby-fiber/test/fiber.rb
+++ b/mrbgems/mruby-fiber/test/fiber.rb
@@ -38,6 +38,52 @@ assert('Fiber#alive?') {
   r1 == true and r2 == false
 }
 
+assert('Fiber#resumable?') do
+  f2 = nil
+  f1 = Fiber.new {
+    assert_false f1.resumable? # running
+    f2.resume
+    assert_false f2.alive?
+    Fiber.yield
+  }
+  f2 = Fiber.new {
+    assert_false f1.resumable? # resuming
+  }
+  assert_true f1.resumable? # created
+  f1.resume
+  assert_true f1.resumable? # suspended
+  f1.resume
+  assert_false f1.resumable? # terminated
+
+  root = Fiber.current
+  f = Fiber.new { root.transfer }
+  f.resume
+  assert_false f.resumable? # transferred
+end
+
+assert('Fiber#transferable?') do
+  f2 = nil
+  f1 = Fiber.new {
+    assert_false f1.transferable? # running
+    f2.resume
+    assert_false f2.alive?
+    Fiber.yield
+  }
+  f2 = Fiber.new {
+    assert_false f1.transferable? # resuming
+  }
+  assert_true f1.transferable? # created
+  f1.resume
+  assert_true f1.transferable? # suspended
+  f1.resume
+  assert_false f1.transferable? # terminated
+
+  root = Fiber.current
+  f = Fiber.new { root.transfer }
+  f.resume
+  assert_true f.transferable? # transferred
+end
+
 assert('Fiber#==') do
   root = Fiber.current
   assert_equal root, root


### PR DESCRIPTION
`Fiber#resumable?` returns `true` when the fiber can be resumed.
`Fiber#transferable?` returns `true` when the fiber can be transferred.
The difference between `Fiber#alive?` is that these return `false` when the fiber is running or in resume stack.
