### PR TITLE
check by MRB_PROC_CFUNC_P

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -460,7 +460,13 @@ mrb_f_send(mrb_state *mrb, mrb_value self)
   ci->mid = name;
   ci->target_class = c;
   ci->proc = p;
-  ci->nregs = p->body.irep->nregs;
+  if (MRB_PROC_CFUNC_P(p)) {
+    ci->nregs = argc + 2;
+  }
+  else{
+    ci->nregs = p->body.irep->nregs;
+  }
+
   regs = mrb->c->stack+1;
   /* remove first symbol from arguments */
   if (ci->argc >= 0) {


### PR DESCRIPTION
https://github.com/carsonmcdonald/ios-ruby-embedded/issues/5

MRB_PROC_CFUNC_P(p)がtrueのときはp->body.irep->nregsが2000を超える値となりおかしい、
irepとfuncがunionだ。ということまではわかったのですが、
    ci->nregs = argc + 2;
のところは+2で良いのかよくわかりません。
が、MRB_PROC_CFUNC_Pでチェックする必要がありそうな気がします。
