### PR TITLE
Pass gem's version information to compilers.

### DIFF
--- a/tasks/mrbgem_spec.rake
+++ b/tasks/mrbgem_spec.rake
@@ -82,6 +82,7 @@ module MRuby
 
         compilers.each do |compiler|
           compiler.define_rules build_dir, "#{dir}"
+          compiler.defines << %Q[MRBGEM_#{funcname.upcase}_VERSION=#{version}]
         end
 
         define_gem_init_builder


### PR DESCRIPTION
Some gems want to set version as a constant value in mruby (like Ruby-serialport.)
