### PR TITLE
Always increment `total` field of `os_count_struct` in callback.

### DIFF
--- a/mrbgems/mruby-objectspace/src/mruby_objectspace.c
+++ b/mrbgems/mruby-objectspace/src/mruby_objectspace.c
@@ -15,12 +15,13 @@ os_count_object_type(mrb_state *mrb, struct RBasic *obj, void *data)
   struct os_count_struct *obj_count;
   obj_count = (struct os_count_struct*)data;
 
+  obj_count->total++;
+
   if (is_dead(mrb, obj)) {
     obj_count->freed++;
   }
   else {
     obj_count->counts[obj->tt]++;
-    obj_count->total++;
   }
 }
 

--- a/mrbgems/mruby-objectspace/test/objectspace.rb
+++ b/mrbgems/mruby-objectspace/test/objectspace.rb
@@ -10,6 +10,8 @@ assert('ObjectSpace.count_objects') do
   assert_true(h.has_key?(:FREE))
   assert_true(h.has_key?(:T_FIBER)) if Object.const_defined? :Fiber
 
+  assert_equal(h[:TOTAL] * 2, h.values.reduce(:+))
+
   h = ObjectSpace.count_objects
   assert_kind_of(Hash, h)
   assert_true(h.keys.all? {|x| x.is_a?(Symbol) || x.is_a?(Integer) })


### PR DESCRIPTION
Check sum of `ObjectSpace.count_objects` values is twice of total objects count.
(Which is CRuby's behavior.)
