### PR TITLE
Fix C++ files detection for automatic C++ ABI enabling.

### DIFF
--- a/tasks/mrbgem_spec.rake
+++ b/tasks/mrbgem_spec.rake
@@ -40,16 +40,11 @@ module MRuby
         @name = name
         @initializer = block
         @version = "0.0.0"
-        @cxx_abi_enabled = false
         MRuby::Gem.current = self
       end
 
       def run_test_in_other_mrb_state?
         not test_preload.nil? or not test_objs.empty?
-      end
-
-      def cxx_abi_enabled?
-        @cxx_abi_enabled
       end
 
       def setup
@@ -64,14 +59,12 @@ module MRuby
 
         @rbfiles = Dir.glob("#{dir}/mrblib/*.rb").sort
         @objs = Dir.glob("#{dir}/src/*.{c,cpp,cxx,m,asm,S}").map do |f|
-          @cxx_abi_enabled = true if f =~ /(cxx|cpp)$/
           objfile(f.relative_path_from(@dir).to_s.pathmap("#{build_dir}/%X"))
         end
         @objs << objfile("#{build_dir}/gem_init")
 
         @test_rbfiles = Dir.glob("#{dir}/test/*.rb")
         @test_objs = Dir.glob("#{dir}/test/*.{c,cpp,cxx,m,asm,S}").map do |f|
-          @cxx_abi_enabled = true if f =~ /(cxx|cpp)$/
           objfile(f.relative_path_from(dir).to_s.pathmap("#{build_dir}/%X"))
         end
         @test_preload = nil # 'test/assert.rb'

--- a/tasks/mruby_build_gem.rake
+++ b/tasks/mruby_build_gem.rake
@@ -30,12 +30,15 @@ module MRuby
       load gemrake
       return nil unless Gem.current
 
-      enable_cxx_abi if Gem.current.cxx_abi_enabled?
-
       Gem.current.dir = gemdir
       Gem.current.build = MRuby::Build.current
       Gem.current.build_config_initializer = block
       gems << Gem.current
+
+      cxx_srcs = Dir.glob("#{Gem.current.dir}/src/*.{cpp,cxx}")
+      cxx_srcs += Dir.glob("#{Gem.current.dir}/test/*.{cpp,cxx}")
+      enable_cxx_abi unless cxx_srcs.empty?
+
       Gem.current
     end
 


### PR DESCRIPTION
Since `MRuby::Gem::Specification#setup`'s call is late as I expected, doing C++ files detection in it is too late.
So it should be done in `MRuby::LoadGems#gem`.
