### PR TITLE
mrb_hash_ht_hash_func use mrb_obj_id() instead of mrb_sym2name_len()

### DIFF
--- a/src/hash.c
+++ b/src/hash.c
@@ -31,8 +31,7 @@ mrb_hash_ht_hash_func(mrb_state *mrb, mrb_value key)
     break;
 
   case MRB_TT_SYMBOL:
-    p = mrb_sym2name_len(mrb, mrb_symbol(key), &len);
-    break;
+    return mrb_obj_id(key);
 
   case MRB_TT_FIXNUM:
     return (khint_t)mrb_float_id((mrb_float)mrb_fixnum(key));


### PR DESCRIPTION
`hash[:symbol]` is usecase of commonly-used.

But mrb_sym2name_len have cost that search symbol from n2s table.
And `Symbol.object_id` is never change.

I propose to use mrb_obj_id() when hash search symbol key.

Simplicity benchmark https://gist.github.com/ksss/10088148
