### PR TITLE
Fix build_config.rb for ArduinoDue

### DIFF
--- a/examples/targets/ArduinoDue.rb
+++ b/examples/targets/ArduinoDue.rb
@@ -53,6 +53,9 @@ MRuby::CrossBuild.new("Arduino Due") do |conf|
   #do not build executable test
   conf.build_mrbtest_lib_only
 
+  #disable C++ exception
+  conf.disable_cxx_exception
+
   #gems from core
   conf.gem :core => "mruby-print" 
   conf.gem :core => "mruby-math"


### PR DESCRIPTION
Default IDE for Arduino Due disables C++ exception (-fno-exceptions), so I added `disable_cxx_exception`.
