### PR TITLE
add assert before write khash del flags

### DIFF
--- a/include/mruby/khash.h
+++ b/include/mruby/khash.h
@@ -193,6 +193,7 @@ kh_fill_flags(uint8_t *p, uint8_t c, size_t len)
   void kh_del_##name(mrb_state *mrb, kh_##name##_t *h, khint_t x)       \
   {                                                                     \
     (void)mrb;                                                          \
+    mrb_assert(x != h->n_buckets && !__ac_iseither(h->ed_flags, x));    \
     h->ed_flags[x/4] |= __m_del[x%4];                                   \
     h->size--;                                                          \
   }                                                                     \


### PR DESCRIPTION
I want to ensure that both bit flags empty and del have never on.
just like https://github.com/attractivechaos/klib/blob/master/khash.h
