### PR TITLE
Refactor fix_rev

### DIFF
--- a/src/numeric.c
+++ b/src/numeric.c
@@ -889,10 +889,9 @@ fix_equal(mrb_state *mrb, mrb_value x)
 static mrb_value
 fix_rev(mrb_state *mrb, mrb_value num)
 {
-    mrb_int val = mrb_fixnum(num);
+  mrb_int val = mrb_fixnum(num);
 
-    val = ~val;
-    return mrb_fixnum_value(val);
+  return mrb_fixnum_value(~val);
 }
 
 static mrb_value


### PR DESCRIPTION
It is not necessary to assign ~val to val.
