### PR TITLE
exc_inspect: dup file and check mesg only once

### DIFF
--- a/src/error.c
+++ b/src/error.c
@@ -122,28 +122,30 @@ static mrb_value
 exc_inspect(mrb_state *mrb, mrb_value exc)
 {
   mrb_value str, mesg, file, line;
+  mrb_bool append_mesg;
 
   mesg = mrb_attr_get(mrb, exc, mrb_intern_lit(mrb, "mesg"));
   file = mrb_attr_get(mrb, exc, mrb_intern_lit(mrb, "file"));
   line = mrb_attr_get(mrb, exc, mrb_intern_lit(mrb, "line"));
+  append_mesg = !mrb_nil_p(mesg) && RSTRING_LEN(mesg) > 0;
 
   if (!mrb_nil_p(file) && !mrb_nil_p(line)) {
-    str = file;
+    str = mrb_str_dup(mrb, file);
     mrb_str_cat_lit(mrb, str, ":");
     mrb_str_append(mrb, str, line);
     mrb_str_cat_lit(mrb, str, ": ");
-    if (!mrb_nil_p(mesg) && RSTRING_LEN(mesg) > 0) {
+    if (append_mesg) {
       mrb_str_append(mrb, str, mesg);
       mrb_str_cat_lit(mrb, str, " (");
     }
     mrb_str_cat_cstr(mrb, str, mrb_obj_classname(mrb, exc));
-    if (!mrb_nil_p(mesg) && RSTRING_LEN(mesg) > 0) {
+    if (append_mesg) {
       mrb_str_cat_lit(mrb, str, ")");
     }
   }
   else {
     str = mrb_str_new_cstr(mrb, mrb_obj_classname(mrb, exc));
-    if (!mrb_nil_p(mesg) && RSTRING_LEN(mesg) > 0) {
+    if (append_mesg) {
       mrb_str_cat_lit(mrb, str, ": ");
       mrb_str_append(mrb, str, mesg);
     }


### PR DESCRIPTION
``` ruby
begin
  fail ArgumentError, 'wrong number of arguments'
rescue => e
  p e, e
end
```

``` bash
test.rb:2: undefined method 'fail' for main (NoMethodError)
test.rb:2: undefined method 'fail' for main (NoMethodError):2: undefined method
'fail' for main (NoMethodError)
```
