### PR TITLE
convert exception message to string

### DIFF
--- a/src/error.c
+++ b/src/error.c
@@ -149,14 +149,14 @@ exc_inspect(mrb_state *mrb, mrb_value exc)
     }
   }
   else {
-    str = mrb_str_new_cstr(mrb, mrb_obj_classname(mrb, exc));
+    const char *cname = mrb_obj_classname(mrb, exc);
+    str = mrb_str_new_cstr(mrb, cname);
+    mrb_str_cat_lit(mrb, str, ": ");
     if (append_mesg) {
-      mrb_str_cat_lit(mrb, str, ": ");
       mrb_str_append(mrb, str, mesg);
     }
     else {
-      mrb_str_cat_lit(mrb, str, ": ");
-      mrb_str_cat_cstr(mrb, str, mrb_obj_classname(mrb, exc));
+      mrb_str_cat_cstr(mrb, str, cname);
     }
   }
   return str;


### PR DESCRIPTION
b4bb2a7 fixes a crash caused by:

``` ruby
ArgumentError.new(1).inspect
```

36d3909 is just some refactoring.
