### PR TITLE
raises an ArgumentError when calling #call on the Proc without receiver

### DIFF
--- a/mrbgems/mruby-symbol-ext/mrblib/symbol.rb
+++ b/mrbgems/mruby-symbol-ext/mrblib/symbol.rb
@@ -1,7 +1,9 @@
 class Symbol
 
   def to_proc
-    Proc.new do |obj, *args|
+    Proc.new do |*args|
+      raise ArgumentError, "no receiver given" if args.length == 0
+      obj = args.shift
       obj.send(self, *args)
     end
   end

--- a/mrbgems/mruby-symbol-ext/test/symbol.rb
+++ b/mrbgems/mruby-symbol-ext/test/symbol.rb
@@ -3,6 +3,8 @@
 
 assert('Symbol#to_proc') do
   assert_equal 5, :abs.to_proc[-5]
+
+  assert_raise(ArgumentError) { :object_id.to_proc.call }
 end
 
 assert('Symbol.all_symbols') do


### PR DESCRIPTION
This fix is compatibility with other Ruby.
