### PR TITLE
Allow parenthesed do-block in cmdarg

### DIFF
--- a/src/parse.y
+++ b/src/parse.y
@@ -2039,9 +2039,15 @@ primary         : literal
                       p->cmdarg_stack = $<stack>1;
                       $$ = $3;
                     }
-                | tLPAREN_ARG expr {p->lstate = EXPR_ENDARG;} rparen
+                | tLPAREN_ARG
                     {
-                      $$ = $2;
+                      $<stack>1 = p->cmdarg_stack;
+                      p->cmdarg_stack = 0;
+                    }
+                  expr {p->lstate = EXPR_ENDARG;} rparen
+                    {
+                      p->cmdarg_stack = $<stack>1;
+                      $$ = $3;
                     }
                 | tLPAREN_ARG {p->lstate = EXPR_ENDARG;} rparen
                     {

--- a/test/t/syntax.rb
+++ b/test/t/syntax.rb
@@ -254,3 +254,14 @@ assert('External command execution.') do
   end
   true
 end
+
+assert('parenthesed do-block in cmdarg') do
+  class ParenDoBlockCmdArg
+    def test(block)
+      block.call
+    end
+  end
+  x = ParenDoBlockCmdArg.new
+  result = x.test (proc do :ok; end)
+  assert_equal :ok, result
+end


### PR DESCRIPTION
Flush cmdarg flags inside left-paren in a command argument, to allow
parenthesed `do-block` as an argument without arguments parentheses.
`CMDARG_PUSH(0)` for tLPAREN_ARG is before `CMDARG_PUSH(1)` in
`command_args` due to look-ahead.
Import from ruby/ruby@c501345218dc5fb0fae90d56a0c6fd19d38df5bb
