### PR TITLE
Add Rake command 'deep_clean' which cleans everything including the mrbg...

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -113,5 +113,13 @@ task :clean do
     FileUtils.rm_rf t.build_dir, { :verbose => $verbose }
   end
   FileUtils.rm_f depfiles, { :verbose => $verbose }
-  puts "Cleaned up build folder"
+  puts "Cleaned up target build folder"
+end
+
+desc "clean everything!"
+task :deep_clean => ["clean"] do
+  MRuby.each_target do |t|
+    FileUtils.rm_rf t.gem_clone_dir, { :verbose => $verbose }
+  end
+  puts "Cleaned up mrbgems build folder"
 end


### PR DESCRIPTION
Add Rake command 'deep_clean' which cleans everything including the mrbgems clone directories. This became necessary for another pull request I'm preparing which expects a clean mrbgem clone folder.

This might also relate to #1972 
