### PR TITLE
Implement :checksum_hash mrbgem option

### DIFF
--- a/build_config.rb
+++ b/build_config.rb
@@ -16,7 +16,7 @@ MRuby::Build.new do |conf|
   #   g.cc.flags << '-g' # append cflags in this gem
   # end
   # conf.gem 'examples/mrbgems/c_and_ruby_extension_example'
-  # conf.gem :github => 'masuidrive/mrbgems-example', :branch => 'master'
+  # conf.gem :github => 'masuidrive/mrbgems-example', :checksum_hash => '76518e8aecd131d047378448ac8055fa29d974a9'
   # conf.gem :git => 'git@github.com:masuidrive/mrbgems-example.git', :branch => 'master', :options => '-v'
 
   # include the default GEMs

--- a/tasks/mruby_build_commands.rake
+++ b/tasks/mruby_build_commands.rake
@@ -228,14 +228,15 @@ module MRuby
 
   class Command::Git < Command
     attr_accessor :flags
-    attr_accessor :clone_options, :pull_options
+    attr_accessor :clone_options, :pull_options, :checkout_options
 
     def initialize(build)
       super
       @command = 'git'
-      @flags = %w[--depth 1]
+      @flags = %w[]
       @clone_options = "clone %{flags} %{url} %{dir}"
       @pull_options = "pull"
+      @checkout_options = "checkout %{checksum_hash}"
     end
 
     def run_clone(dir, url, _flags = [])
@@ -248,6 +249,14 @@ module MRuby
       Dir.chdir dir
       _pp "GIT PULL", url, dir.relative_path
       _run pull_options
+      Dir.chdir root
+    end
+
+    def run_checkout(dir, checksum_hash)
+      root = Dir.pwd
+      Dir.chdir dir
+      _pp "GIT CHECKOUT", checksum_hash
+      _run checkout_options, { :checksum_hash => checksum_hash }
       Dir.chdir root
     end
   end


### PR DESCRIPTION
This allows to use a mgem with a specific checksum hash.
The following modification were necessary to implement this
function:
- add run_checkout build command to use 'git checkout'
- skip shallow copy in case checksum_hash is used
- make 'master' the default branch if branch isn't defined
