### PR TITLE
String#casecmp should be call `to_str`

### DIFF
--- a/mrbgems/mruby-string-ext/mrblib/string.rb
+++ b/mrbgems/mruby-string-ext/mrblib/string.rb
@@ -47,7 +47,9 @@ class String
 #    "abcdef".casecmp("ABCDEF")    #=> 0
 #
   def casecmp(str)
-    self.downcase <=> str.downcase
+    self.downcase <=> str.to_str.downcase
+  rescue NoMethodError
+    raise TypeError, "no implicit conversion of #{str.class} into String"
   end
 
   def partition(sep)

--- a/mrbgems/mruby-string-ext/test/string.rb
+++ b/mrbgems/mruby-string-ext/test/string.rb
@@ -98,6 +98,11 @@ assert('String#casecmp') do
   assert_equal 0, "aBcDeF".casecmp("abcdef")
   assert_equal(-1, "abcdef".casecmp("abcdefg"))
   assert_equal 0, "abcdef".casecmp("ABCDEF")
+  o = Object.new
+  def o.to_str
+    "ABCDEF"
+  end
+  assert_equal 0, "abcdef".casecmp(o)
 end
 
 assert('String#start_with?') do


### PR DESCRIPTION
This fix is compatibility for rubyspec.
