### PR TITLE
Implement default gem info to use when there is no depending gem loaded.

### DIFF
--- a/tasks/mrbgems.rake
+++ b/tasks/mrbgems.rake
@@ -2,7 +2,7 @@ MRuby.each_target do
   if enable_gems?
     # set up all gems
     gems.each(&:setup)
-    gems.check
+    gems.check self
 
     # loader all gems
     self.libmruby << objfile("#{build_dir}/mrbgems/gem_init")


### PR DESCRIPTION
- With this feature the last `Hash` argument of `MRuby::Gem::Specification#add_dependency` will be treated as default gem info.
  - It will be loaded when `MRuby::Gem::List#check` is called.
  - `String` argument won't be supported since it's not portable and makes arguments matching difficult.
  - Maybe the second argument is more suitable. I'll change to second argument if there is :+1:s to it.
- You can overwrite the default gem info by loading depending gem with `gem` method in **build_config.rb**.
  - The default gem info will be ignored when there is mrbgem with same name that is already loaded with `gem` method in **build_config.rb**.
  - It won't fallback to default gem info when version error occur.(Though fallback maybe a future work.)
- The dependency and loaded default gem's name must be same.(Will cause `fail` if it's not same)
- Default gem info will be defined to `:default` key of dependency info.
- Method `MRuby::Gem::List#check` will require instance of `MRuby::Build` as argument.(The change to **tasks/mrbgems.rake**)
- This feature can't be used in **mruby-1.0.0**(maybe redefining `MRuby::Gem::Specification#version_ok?` that ignores `Hash` can make it compatible).

Following is the example applied to **[mruby-sinatic](https://github.com/mattn/mruby-sinatic)**:

``` ruby
MRuby::Gem::Specification.new('mruby-sinatic') do |spec|
  spec.license = 'MIT'
  spec.authors = 'mattn'
  spec.add_dependency('mruby-uv', '>= 0.0.0', :github => 'mattn/mruby-uv')
  spec.add_dependency('mruby-http', :github => 'mattn/mruby-http')
end
```
