### PR TITLE
Range#each fixnums are special

### DIFF
--- a/mrblib/range.rb
+++ b/mrblib/range.rb
@@ -13,11 +13,23 @@ class Range
     return to_enum :each unless block_given?
 
     val = self.first
+    last = self.last
+
+    if val.kind_of?(Fixnum) && last.kind_of?(Fixnum) # fixnums are special
+      lim = last
+      lim += 1 unless exclude_end?
+      i = val
+      while i < lim
+        block.call(i)
+        i += 1
+      end
+      return self
+    end
+
     unless val.respond_to? :succ
       raise TypeError, "can't iterate"
     end
 
-    last = self.last
     return self if (val <=> last) > 0
 
     while((val <=> last) < 0)


### PR DESCRIPTION
Range#each is commonly-used.
And Integer#succ behavior is ensured by ISO.

So, I propose that avoid check `respond_to?(:succ)` and call `Fixnum#+` method if Range#each both arguments are `Fixnum`

---

for reference

```
$ uname -a
Linux localhost.localdomain 2.6.32-279.el6.x86_64 #1 SMP Fri Jun 22 12:19:21 UTC 2012 x86_64 x86_64 x86_64 GNU/Linux
```

```
t = Time.now

(0..1000000).each do
end

puts Time.now - t
```

before

```
0.34153699999999
```

after

```
0.16073899999999
```
