### PR TITLE
Use mrb_int in mrbgem rest arguments getting.

### DIFF
--- a/mrbgems/mruby-hash-ext/src/hash-ext.c
+++ b/mrbgems/mruby-hash-ext/src/hash-ext.c
@@ -23,7 +23,8 @@ static mrb_value
 hash_values_at(mrb_state *mrb, mrb_value hash)
 {
   mrb_value *argv, result;
-  int argc, i, ai;
+  mrb_int argc, i;
+  int ai;
 
   mrb_get_args(mrb, "*", &argv, &argc);
   result = mrb_ary_new_capa(mrb, argc);

--- a/mrbgems/mruby-object-ext/src/object.c
+++ b/mrbgems/mruby-object-ext/src/object.c
@@ -63,7 +63,7 @@ static mrb_value
 mrb_obj_instance_exec(mrb_state *mrb, mrb_value self)
 {
   mrb_value *argv;
-  int argc;
+  mrb_int argc;
   mrb_value blk;
   struct RClass *c;
 

--- a/mrbgems/mruby-sprintf/src/sprintf.c
+++ b/mrbgems/mruby-sprintf/src/sprintf.c
@@ -471,7 +471,7 @@ get_hash(mrb_state *mrb, mrb_value *hash, int argc, const mrb_value *argv)
 mrb_value
 mrb_f_sprintf(mrb_state *mrb, mrb_value obj)
 {
-  int argc;
+  mrb_int argc;
   mrb_value *argv;
 
   mrb_get_args(mrb, "*", &argv, &argc);

--- a/mrbgems/mruby-string-ext/src/string.c
+++ b/mrbgems/mruby-string-ext/src/string.c
@@ -113,7 +113,7 @@ static mrb_value
 mrb_str_start_with(mrb_state *mrb, mrb_value self)
 {
   mrb_value *argv, sub;
-  int argc, i;
+  mrb_int argc, i;
   mrb_get_args(mrb, "*", &argv, &argc);
 
   for (i = 0; i < argc; i++) {
@@ -142,7 +142,7 @@ static mrb_value
 mrb_str_end_with(mrb_state *mrb, mrb_value self)
 {
   mrb_value *argv, sub;
-  int argc, i;
+  mrb_int argc, i;
   mrb_get_args(mrb, "*", &argv, &argc);
 
   for (i = 0; i < argc; i++) {

--- a/mrbgems/mruby-string-utf8/src/string.c
+++ b/mrbgems/mruby-string-utf8/src/string.c
@@ -356,7 +356,7 @@ static mrb_value
 mrb_str_index_m(mrb_state *mrb, mrb_value str)
 {
   mrb_value *argv;
-  int argc;
+  mrb_int argc;
 
   mrb_value sub;
   mrb_int pos;
@@ -440,7 +440,7 @@ static mrb_value
 mrb_str_rindex_m(mrb_state *mrb, mrb_value str)
 {
   mrb_value *argv;
-  int argc;
+  mrb_int argc;
   mrb_value sub;
   mrb_value vpos;
   mrb_int pos, len = RSTRING_LEN(str);

--- a/mrbgems/mruby-struct/src/struct.c
+++ b/mrbgems/mruby-struct/src/struct.c
@@ -347,7 +347,7 @@ mrb_struct_s_def(mrb_state *mrb, mrb_value klass)
   mrb_value b, st;
   mrb_sym id;
   mrb_value *argv;
-  int argc;
+  mrb_int argc;
 
   name = mrb_nil_value();
   rest = mrb_nil_value();
@@ -428,7 +428,7 @@ static mrb_value
 mrb_struct_initialize_m(mrb_state *mrb, /*int argc, mrb_value *argv,*/ mrb_value self)
 {
   mrb_value *argv;
-  int argc;
+  mrb_int argc;
 
   mrb_get_args(mrb, "*", &argv, &argc);
   return mrb_struct_initialize_withArg(mrb, argc, argv, self);


### PR DESCRIPTION
Released [mruby-clang-plugin](https://github.com/take-cheeze/mruby-clang-plugin) 1.0.0 and supported latest mruby master branch.
