### PR TITLE
area of implicit nil is not enough to nregs

### DIFF
--- a/src/codegen.c
+++ b/src/codegen.c
@@ -819,6 +819,7 @@ gen_call(codegen_scope *s, node *tree, mrb_sym name, int sp, int val)
   else {
     blk = cursp();
   }
+  push();pop();
   pop_n(n+1);
   {
     mrb_int len;
@@ -1631,6 +1632,7 @@ codegen(codegen_scope *s, node *tree, int val)
         break;
       }
       codegen(s, tree->cdr->cdr->car, VAL);
+      push();pop();
       pop(); pop();
 
       idx = new_msym(s, sym);


### PR DESCRIPTION
There is a possibility that protrude from the stack.

def foo
  "a" < 2
end

irep 00C3A1A8 nregs=4 nlocals=2 pools=1 syms=1 reps=0
000 OP_ENTER    0:0:0:0:0:0:0
001 OP_STRING   R2      "a"
002 OP_LOADI    R3      2
003 OP_LT       R2      :<      1
004 OP_RETURN   R2

R2 ...receiver
R3 ...Argument
R4 ...Block(nil)

nregs 5 need.
