### PR TITLE
Fix MSVC warnings for numeric.c

### DIFF
--- a/include/mruby/value.h
+++ b/include/mruby/value.h
@@ -75,7 +75,8 @@ typedef short mrb_sym;
 #  define PRIo64 "I64o"
 #  define PRIx64 "I64x"
 #  define PRIX64 "I64X"
-#  define INFINITY ((float)(DBL_MAX * DBL_MAX))
+static unsigned int IEEE754_INFINITY_BITS_SINGLE = 0x7F800000;
+#  define INFINITY (*(float *)&IEEE754_INFINITY_BITS_SINGLE)
 #  define NAN ((float)(INFINITY - INFINITY))
 # else
 #  include <inttypes.h>


### PR DESCRIPTION
This fix suppress warning C4756 below in MSVC(<VC++2013)

```
e:\work\mruby\mruby\src\numeric.c(307) : warning C4756: 定数演算でオーバーフローを起こしました。
e:\work\mruby\mruby\src\numeric.c(816) : warning C4756: 定数演算でオーバーフローを起こしました。
```

Other method to suppress this warning is to disable this warning only in numeric.c( MSVC has such ability : `#pragma warning (disable:C4765)`).
But It would introduce  #ifdef _MSC_VER,,, lines in numeric.c. I think it is better to avoid such annoying compiler specific #ifdef in *.c.
