### PR TITLE
rename `mrb_str_buf_append` to `mrb_str_cat_str`

### DIFF
--- a/include/mruby/string.h
+++ b/include/mruby/string.h
@@ -76,12 +76,12 @@ mrb_value mrb_str_to_inum(mrb_state *mrb, mrb_value str, mrb_int base, mrb_bool 
 double mrb_str_to_dbl(mrb_state *mrb, mrb_value str, mrb_bool badcheck);
 mrb_value mrb_str_to_str(mrb_state *mrb, mrb_value str);
 mrb_int mrb_str_hash(mrb_state *mrb, mrb_value str);
-mrb_value mrb_str_buf_append(mrb_state *mrb, mrb_value str, mrb_value str2);
 mrb_value mrb_str_inspect(mrb_state *mrb, mrb_value str);
 mrb_bool mrb_str_equal(mrb_state *mrb, mrb_value str1, mrb_value str2);
 mrb_value mrb_str_dump(mrb_state *mrb, mrb_value str);
 mrb_value mrb_str_cat(mrb_state *mrb, mrb_value str, const char *ptr, size_t len);
 mrb_value mrb_str_cat_cstr(mrb_state *mrb, mrb_value str, const char *ptr);
+mrb_value mrb_str_cat_str(mrb_state *mrb, mrb_value str, mrb_value str2);
 #define mrb_str_cat_lit(mrb, str, lit) mrb_str_cat(mrb, str, lit, mrb_strlen_lit(lit))
 mrb_value mrb_str_append(mrb_state *mrb, mrb_value str, mrb_value str2);
 
@@ -99,6 +99,12 @@ static inline mrb_value
 mrb_str_buf_cat(mrb_state *mrb, mrb_value str, const char *ptr, size_t len)
 {
   return mrb_str_cat(mrb, str, ptr, len);
+}
+
+static inline mrb_value
+mrb_str_buf_append(mrb_state *mrb, mrb_value str, mrb_value str2)
+{
+  return mrb_str_cat_str(mrb, str, str2);
 }
 
 #if defined(__cplusplus)

--- a/src/array.c
+++ b/src/array.c
@@ -946,7 +946,7 @@ join_ary(mrb_state *mrb, mrb_value ary, mrb_value sep, mrb_value list)
 
   for (i=0; i<RARRAY_LEN(ary); i++) {
     if (i > 0 && !mrb_nil_p(sep)) {
-      mrb_str_buf_append(mrb, result, sep);
+      mrb_str_cat_str(mrb, result, sep);
     }
 
     val = RARRAY_PTR(ary)[i];
@@ -958,7 +958,7 @@ join_ary(mrb_state *mrb, mrb_value ary, mrb_value sep, mrb_value list)
 
     case MRB_TT_STRING:
     str_join:
-      mrb_str_buf_append(mrb, result, val);
+      mrb_str_cat_str(mrb, result, val);
       break;
 
     default:

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -1929,7 +1929,7 @@ codegen(codegen_scope *s, node *tree, int val)
       mrb_value str = mrb_str_buf_new(mrb, 4);
 
       mrb_str_cat_lit(mrb, str, "$");
-      mrb_str_buf_append(mrb, str, mrb_fixnum_to_str(mrb, fix, 10));
+      mrb_str_cat_str(mrb, str, mrb_fixnum_to_str(mrb, fix, 10));
       sym = new_sym(s, mrb_intern_str(mrb, str));
       genop(s, MKOP_ABx(OP_GETGLOBAL, cursp(), sym));
       push();

--- a/src/string.c
+++ b/src/string.c
@@ -1254,13 +1254,6 @@ mrb_str_substr(mrb_state *mrb, mrb_value str, mrb_int beg, mrb_int len)
   return str2;
 }
 
-mrb_value
-mrb_str_buf_append(mrb_state *mrb, mrb_value str, mrb_value str2)
-{
-  mrb_str_cat(mrb, str, RSTRING_PTR(str2), RSTRING_LEN(str2));
-  return str;
-}
-
 mrb_int
 mrb_str_hash(mrb_state *mrb, mrb_value str)
 {
@@ -2469,10 +2462,16 @@ mrb_str_cat_cstr(mrb_state *mrb, mrb_value str, const char *ptr)
 }
 
 mrb_value
+mrb_str_cat_str(mrb_state *mrb, mrb_value str, mrb_value str2)
+{
+  return mrb_str_cat(mrb, str, RSTRING_PTR(str2), RSTRING_LEN(str2));
+}
+
+mrb_value
 mrb_str_append(mrb_state *mrb, mrb_value str, mrb_value str2)
 {
   str2 = mrb_str_to_str(mrb, str2);
-  return mrb_str_buf_append(mrb, str, str2);
+  return mrb_str_cat_str(mrb, str, str2);
 }
 
 #define CHAR_ESC_LEN 13 /* sizeof(\x{ hex of 32bit unsigned int } \0) */


### PR DESCRIPTION
I think the new name is better and less confusing, because:
- `mrb_str_append` calls `mrb_str_to_str` and this function doesn't
- `mrb_str_buf_append` **is** `mrb_str_cat` for `mrb_value` strings
