### PR TITLE
Add doubling stack extend, as fix for #2016

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -140,6 +140,12 @@ stack_extend_alloc(mrb_state *mrb, int room)
   int size = mrb->c->stend - mrb->c->stbase;
   int off = mrb->c->stack - mrb->c->stbase;
 
+#ifdef MRB_STACK_EXTEND_DOUBLING
+  if (room <= size)
+    size *= 2;
+  else
+    size += room;
+#else
   /* Use linear stack growth.
      It is slightly slower than doubling the stack space,
      but it saves memory on small devices. */
@@ -147,6 +153,7 @@ stack_extend_alloc(mrb_state *mrb, int room)
     size += MRB_STACK_GROWTH;
   else
     size += room;
+#endif
 
   mrb->c->stbase = (mrb_value *)mrb_realloc(mrb, mrb->c->stbase, sizeof(mrb_value) * size);
   mrb->c->stack = mrb->c->stbase + off;

--- a/tasks/toolchains/visualcpp.rake
+++ b/tasks/toolchains/visualcpp.rake
@@ -3,7 +3,7 @@ MRuby::Toolchain.new(:visualcpp) do |conf|
     cc.command = ENV['CC'] || 'cl.exe'
     cc.flags = [ENV['CFLAGS'] || %w(/c /nologo /W3 /Zi /MD /O2 /D_CRT_SECURE_NO_WARNINGS)]
     cc.include_paths = ["#{MRUBY_ROOT}/include"]
-    cc.defines = %w(DISABLE_GEMS)
+    cc.defines = %w(DISABLE_GEMS MRB_STACK_EXTEND_DOUBLING)
     cc.option_include_path = '/I%s'
     cc.option_define = '/D%s'
     cc.compile_options = "%{flags} /Fo%{outfile} %{infile}"
@@ -13,7 +13,7 @@ MRuby::Toolchain.new(:visualcpp) do |conf|
     cxx.command = ENV['CXX'] || 'cl.exe'
     cxx.flags = [ENV['CXXFLAGS'] || ENV['CFLAGS'] || %w(/c /nologo /W3 /Zi /MD /O2 /EHsc /D_CRT_SECURE_NO_WARNINGS)]
     cxx.include_paths = ["#{MRUBY_ROOT}/include"]
-    cxx.defines = %w(DISABLE_GEMS)
+    cxx.defines = %w(DISABLE_GEMS MRB_STACK_EXTEND_DOUBLING)
     cxx.option_include_path = '/I%s'
     cxx.option_define = '/D%s'
     cxx.compile_options = "%{flags} /Fo%{outfile} %{infile}"


### PR DESCRIPTION
`make test` for Windows7 on Virtualbox now takes less than 2sec.
