### PR TITLE
use Kernel#__send__ insteard of Kernel#send

### DIFF
--- a/mrbgems/mruby-symbol-ext/mrblib/symbol.rb
+++ b/mrbgems/mruby-symbol-ext/mrblib/symbol.rb
@@ -3,7 +3,7 @@ class Symbol
 
   def to_proc
     ->(obj,*args,&block) do
-      obj.send(self, *args, &block)
+      obj.__send__(self, *args, &block)
     end
   end
 

--- a/mrblib/enum.rb
+++ b/mrblib/enum.rb
@@ -202,7 +202,7 @@ module Enumerable
     raise ArgumentError, "too many arguments" if args.size > 2
     if Symbol === args[-1]
       sym = args[-1]
-      block = ->(x,y){x.send(sym,y)}
+      block = ->(x,y){x.__send__(sym,y)}
       args.pop
     end
     if args.empty?


### PR DESCRIPTION
Avoid method name conflict.
