### PR TITLE
Added dump_irep in header.

### DIFF
--- a/include/mruby/dump.h
+++ b/include/mruby/dump.h
@@ -14,6 +14,7 @@ extern "C" {
 #include "mruby.h"
 #include "mruby/irep.h"
 
+int dump_irep(mrb_state *mrb, mrb_irep *irep, int debug_info, uint8_t **bin, size_t *bin_size);
 #ifdef ENABLE_STDIO
 int mrb_dump_irep_binary(mrb_state*, mrb_irep*, int, FILE*);
 int mrb_dump_irep_cfunc(mrb_state *mrb, mrb_irep*, int, FILE *f, const char *initname);

--- a/src/dump.c
+++ b/src/dump.c
@@ -725,7 +725,7 @@ is_debug_info_defined(mrb_irep *irep)
   return TRUE;
 }
 
-static int
+int
 dump_irep(mrb_state *mrb, mrb_irep *irep, int debug_info, uint8_t **bin, size_t *bin_size)
 {
   int result = MRB_DUMP_GENERAL_FAILURE;


### PR DESCRIPTION
Hello,
Added dump_irep on header so We're able to get compiled bytecode in a buffer.
I couldn't understand how do that without STDIO(returning a buffer).

Sorry if I missed something.
