### PR TITLE
goto STOP if ridx==0

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -1408,6 +1408,7 @@ RETRY_TRY_BLOCK:
           }
         }
       L_RESCUE:
+        if (ci->ridx == 0) goto L_STOP;
         proc = ci->proc;
         irep = proc->body.irep;
         pool = irep->pool;


### PR DESCRIPTION
I met segmentation fault.
I think bug is around L_RAISE, or inc/dec ridx.

Code to reproduce the problem:

```
// mruby_load_crash.c
// gcc -I../mruby/include -I../mruby/src mruby_load_crash.c ../mruby/build/host/lib/libmruby.a -lm && ./a.out
#include "mruby.h"
#include "mruby/compile.h"
#include "mruby/string.h"

mrb_value _load_file(mrb_state* mrb, char* filename)
{
    FILE* f = fopen(filename, "rb");
    mrb_value ret = mrb_load_file(mrb, f);
    fclose(f);
    return ret;
}

mrb_value _mrb_load(mrb_state *mrb, mrb_value self) {
    mrb_value* args;
    int n;
    mrb_get_args(mrb, "*", &args, &n);
    return _load_file(mrb, RSTRING_PTR(args[0]));
}

int main()
{
    mrb_state* mrb = mrb_open();
    struct RClass* mod = mrb->kernel_module;
    mrb_define_module_function(mrb, mod, "load", _mrb_load, MRB_ARGS_ANY());

    mrb_value ret = _load_file(mrb, "a.rb");
    printf("exc=%p\n", mrb->exc);
    printf("ret=[%s]\n", RSTRING_PTR(mrb_inspect(mrb,ret)));

    return 0;
}
```

```
# a.rb
begin
  load("b.rb")
rescue => e
  puts "e=#{e.inspect}"
end
```

```
# b.rb
raise "error in b.rb"
```
