### PR TITLE
MSVC: treat implicit function decl. as error

### DIFF
--- a/tasks/toolchains/visualcpp.rake
+++ b/tasks/toolchains/visualcpp.rake
@@ -1,7 +1,8 @@
 MRuby::Toolchain.new(:visualcpp) do |conf|
   [conf.cc].each do |cc|
     cc.command = ENV['CC'] || 'cl.exe'
-    cc.flags = [ENV['CFLAGS'] || %w(/c /nologo /W3 /Zi /MD /O2 /D_CRT_SECURE_NO_WARNINGS)]
+    # C4013: implicit function declaration
+    cc.flags = [ENV['CFLAGS'] || %w(/c /nologo /W3 /we4013 /Zi /MD /O2 /D_CRT_SECURE_NO_WARNINGS)]
     cc.include_paths = ["#{MRUBY_ROOT}/include"]
     cc.defines = %w(DISABLE_GEMS MRB_STACK_EXTEND_DOUBLING)
     cc.option_include_path = '/I%s'


### PR DESCRIPTION
As equivalent to GCC's [-Werror-implicit-function-declaration](https://github.com/mruby/mruby/blob/6ff1b63b0d8a8e3fc755bfc0a5256a0c52703075/tasks/toolchains/gcc.rake#L4).
