### PR TITLE
Don't reset ridx,eidx. And fix for #1949

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -2251,10 +2251,10 @@ RETRY_TRY_BLOCK:
       /*        stop VM */
     L_STOP:
       {
-        int n = mrb->c->ci->eidx;
-
-        while (n--) {
-          ecall(mrb, n);
+        int eidx_stop = mrb->c->ci == mrb->c->cibase ? 0 : mrb->c->ci[-1].eidx;
+        int eidx = mrb->c->ci->eidx;
+        while (eidx > eidx_stop) {
+          ecall(mrb, --eidx);
         }
       }
       ERR_PC_CLR(mrb);
@@ -2307,8 +2307,6 @@ mrb_toplevel_run(mrb_state *mrb, struct RProc *proc)
   }
   ci = cipush(mrb);
   ci->acc = CI_ACC_SKIP;
-  ci->eidx = 0;
-  ci->ridx = 0;
   ci->target_class = mrb->object_class;
   v = mrb_context_run(mrb, proc, mrb_top_self(mrb), 0);
   cipop(mrb);


### PR DESCRIPTION
To call mrb_toplevel_run recursive is breaks rescue/ensure stack.
It is from change https://github.com/mruby/mruby/issues/1949

Re-enter to mrb_toplevel_run example is:
load(https://github.com/mruby/mruby/pull/2169)
or Kernel.eval.

Code to see problem:

```
begin
ensure
  puts "A"
end

begin
  Kernel.eval "begin; ensure; puts 'B'; end"
ensure
  puts 'C'
end

if true
  # https://github.com/mruby/mruby/issues/1949
  a = []
  begin
      a.push 0
      Kernel.eval 'p "test"'
      p a
  ensure
      a = nil
  end
end

if true
  begin
    Kernel.eval "begin; rescue; end"
    raise "zzzz"
  rescue => e
    puts "!!!!! should come here !!!!! e=#{e.inspect}"
  end
end
```

Output(master)

```
% ../mruby/bin/mruby a.rb
A
B
"test"
[0]
TypeError: expected String
```

Output(fixed)

```
% ../mruby/bin/mruby a.rb
A
B
C
"test"
[0]
!!!!! should come here !!!!! e=a.rb:27: zzzz (RuntimeError)
```
