### PR TITLE
add clang to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,15 @@
+language: c
+
+compiler:
+  - gcc
+  - clang
+
 # no installation...
 
 install:
  - sudo apt-get -q install gperf
 
-env: MRUBY_CONFIG=travis_config.rb
+env: MRUBY_CONFIG=travis_config.rb ASAN_SYMBOLIZER_PATH=/usr/local/clang-3.4/bin/llvm-symbolizer
 script: "./minirake all test"
 
 notifications:

--- a/travis_config.rb
+++ b/travis_config.rb
@@ -1,5 +1,19 @@
+class MRuby::Build
+  def travis_toolchain_selection
+    if ENV['CC'] == 'clang'
+      toolchain :clang
+      sanitizers = %w(-fsanitize=address,undefined -fno-sanitize=alignment,float-divide-by-zero)
+      cc.flags += sanitizers
+      linker.flags += sanitizers
+    else
+      toolchain :gcc
+    end
+  end
+end
+
 MRuby::Build.new('debug') do |conf|
-  toolchain :gcc
+  travis_toolchain_selection
+
   enable_debug
 
   # include all core GEMs
@@ -11,7 +25,7 @@ MRuby::Build.new('debug') do |conf|
 end
 
 MRuby::Build.new do |conf|
-  toolchain :gcc
+  travis_toolchain_selection
 
   # include all core GEMs
   conf.gembox 'full-core'
@@ -23,7 +37,7 @@ MRuby::Build.new do |conf|
 end
 
 MRuby::Build.new('cxx_abi') do |conf|
-  toolchain :gcc
+  travis_toolchain_selection
 
   conf.gembox 'full-core'
   conf.cc.flags += %w(-Werror=declaration-after-statement)


### PR DESCRIPTION
I think testing mruby with another compiler (the builds are parallel) and also using its undefined behavior sanitizer can be helpful to find programming mistakes. I've disabled the alignment one for now, because of errors in `src/codegen.c`. And since `mrbc` is used a lot during building mruby, the log would contain too much errors (in my opinion). Of course, the alignment issues should be fixed someday.

Example: https://travis-ci.org/cremno/mruby/jobs/24410033#L747-L748
