### PR TITLE
fix memcpy-param-overlap

### DIFF
--- a/src/parse.y
+++ b/src/parse.y
@@ -5466,7 +5466,7 @@ mrb_parser_set_filename(struct mrb_parser_state *p, const char *f)
 
   new_table = (mrb_sym*)parser_palloc(p, sizeof(mrb_sym) * p->filename_table_length);
   if (p->filename_table) {
-    memcpy(new_table, p->filename_table, sizeof(mrb_sym) * p->filename_table_length);
+    memmove(new_table, p->filename_table, sizeof(mrb_sym) * p->filename_table_length);
   }
   p->filename_table = new_table;
   p->filename_table[p->filename_table_length - 1] = sym;


### PR DESCRIPTION
See #2189. I still don't know why the parameters overlap. I can't reproduce this error locally.
