### PR TITLE
OP_ENTER fix variable assignment

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -1325,16 +1325,18 @@ RETRY_TRY_BLOCK:
           pc += argc - m1 - m2 + 1;
       }
       else {
+        int rnum = 0;
         if (argv0 != argv) {
           regs[len+1] = *blk; /* move block */
           value_move(&regs[1], argv, m1+o);
         }
         if (r) {
-          regs[m1+o+1] = mrb_ary_new_from_values(mrb, argc-m1-o-m2, argv+m1+o);
+          rnum = argc-m1-o-m2;
+          regs[m1+o+1] = mrb_ary_new_from_values(mrb, rnum, argv+m1+o);
         }
         if (m2) {
           if (argc-m2 > m1) {
-            value_move(&regs[m1+o+r+1], &argv[argc-m2], m2);
+            value_move(&regs[m1+o+r+1], &argv[m1+o+rnum], m2);
           }
         }
         if (argv0 == argv) {

--- a/test/t/bs_block.rb
+++ b/test/t/bs_block.rb
@@ -512,3 +512,10 @@ assert('BS Block 37') do
   end
 end
 
+assert('BS Block 38') do
+  def iter
+    yield 1,2,3,4,5,6
+  end
+
+  assert_equal [1,2,3,4,5], iter{|a,b,c=:c,d,e| [a,b,c,d,e]}
+end


### PR DESCRIPTION
I think, `m2`(post argument num) index in `argv` should depends on whether there exists `r`(rest argument).
