### PR TITLE
Fix build on mingw32/64: struct timeval isn't defined in default. See: 6...

### DIFF
--- a/mrbgems/mruby-time/src/time.c
+++ b/mrbgems/mruby-time/src/time.c
@@ -10,6 +10,10 @@
 #include "mruby/class.h"
 #include "mruby/data.h"
 
+#if defined(__MINGW64__) || defined(__MINGW32__)
+# include <sys/time.h>
+#endif
+
 /** Time class configuration */
 
 /* gettimeofday(2) */


### PR DESCRIPTION
See: 642477ef6a92c553d7abb00051674f4b518046c3
