### PR TITLE
OP_ENTER clean block object in register

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -1307,6 +1307,7 @@ RETRY_TRY_BLOCK:
       mrb->c->ci->argc = len;
       if (argc < len) {
         regs[len+1] = *blk; /* move block */
+        SET_NIL_VALUE(regs[argc+1]);
         if (argv0 != argv) {
           value_move(&regs[1], argv, argc-m2); /* m1 + o */
         }

--- a/test/t/proc.rb
+++ b/test/t/proc.rb
@@ -55,6 +55,23 @@ assert('Proc#call', '15.2.17.4.3') do
   assert_equal 5, a2
 end
 
+assert('Proc#call proc args pos block') do
+  pr = proc {|a,b,&c|
+    [a, b, c.class, c&&c.call(:x)]
+  }
+  assert_equal [nil, nil, Proc, :proc], (pr.call(){ :proc })
+  assert_equal [1, nil, Proc, :proc], (pr.call(1){ :proc })
+  assert_equal [1, 2, Proc, :proc], (pr.call(1, 2){ :proc })
+  assert_equal [1, 2, Proc, :proc], (pr.call(1, 2, 3){ :proc })
+  assert_equal [1, 2, Proc, :proc], (pr.call(1, 2, 3, 4){ :proc })
+
+  assert_equal [nil, nil, Proc, :x], (pr.call(){|x| x})
+  assert_equal [1, nil, Proc, :x], (pr.call(1){|x| x})
+  assert_equal [1, 2, Proc, :x], (pr.call(1, 2){|x| x})
+  assert_equal [1, 2, Proc, :x], (pr.call(1, 2, 3){|x| x})
+  assert_equal [1, 2, Proc, :x], (pr.call(1, 2, 3, 4){|x| x})
+end
+
 assert('Proc#return_does_not_break_self') do
   class TestClass
     attr_accessor :block


### PR DESCRIPTION
Rest block object in register would be assigned to normal variable by wrong.
