### PR TITLE
libreadline requires libtermcap on OpenBSD.

### DIFF
--- a/mrbgems/mruby-bin-mirb/mrbgem.rake
+++ b/mrbgems/mruby-bin-mirb/mrbgem.rake
@@ -5,6 +5,9 @@ MRuby::Gem::Specification.new('mruby-bin-mirb') do |spec|
 
   if spec.build.cc.search_header_path 'readline/readline.h'
     spec.cc.defines << "ENABLE_READLINE"
+    if spec.build.cc.search_header_path 'termcap.h'
+      spec.linker.libraries << 'termcap'
+    end
     spec.linker.libraries << 'readline'
   elsif spec.build.cc.search_header_path 'linenoise.h'
     spec.cc.defines << "ENABLE_LINENOISE"


### PR DESCRIPTION
"rake all" fails on OpenBSD without the patch:

```
...
LD    build/host/bin/mirb 
...
/usr/lib/libreadline.so.3.0: undefined reference to `tgetnum'
/usr/lib/libreadline.so.3.0: undefined reference to `tgoto'
/usr/lib/libreadline.so.3.0: undefined reference to `tgetflag'
/usr/lib/libreadline.so.3.0: undefined reference to `tputs'
/usr/lib/libreadline.so.3.0: undefined reference to `tgetent'
/usr/lib/libreadline.so.3.0: undefined reference to `tgetstr'
collect2: ld returned 1 exit status
```
