### PR TITLE
OP_ENTER fix segmentation fault

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -1306,16 +1306,19 @@ RETRY_TRY_BLOCK:
       }
       mrb->c->ci->argc = len;
       if (argc < len) {
+        int mlen = m2;
+        if (argc < m1+m2) {
+          if (m1 < argc)
+            mlen = argc - m1;
+          else
+            mlen = 0;
+        }
         regs[len+1] = *blk; /* move block */
         SET_NIL_VALUE(regs[argc+1]);
         if (argv0 != argv) {
-          value_move(&regs[1], argv, argc-m2); /* m1 + o */
+          value_move(&regs[1], argv, argc-mlen); /* m1 + o */
         }
-        if (m2) {
-          int mlen = m2;
-          if (argc-m2 <= m1) {
-            mlen = argc - m1;
-          }
+        if (mlen) {
           value_move(&regs[len-m2+1], &argv[argc-mlen], mlen);
         }
         if (r) {

--- a/test/t/proc.rb
+++ b/test/t/proc.rb
@@ -72,6 +72,29 @@ assert('Proc#call proc args pos block') do
   assert_equal [1, 2, Proc, :x], (pr.call(1, 2, 3, 4){|x| x})
 end
 
+assert('Proc#call proc args pos rest post') do
+  pr = Proc.new {|a,b,*c,d,e|
+    [a,b,c,d,e]
+  }
+  assert_equal [nil, nil, [], nil, nil], pr.call()
+  assert_equal [1, nil, [], nil, nil], pr.call(1)
+  assert_equal [1, 2, [], nil, nil], pr.call(1,2)
+  assert_equal [1, 2, [], 3, nil], pr.call(1,2,3)
+  assert_equal [1, 2, [], 3, 4], pr.call(1,2,3,4)
+  assert_equal [1, 2, [3], 4, 5], pr.call(1,2,3,4,5)
+  assert_equal [1, 2, [3, 4], 5, 6], pr.call(1,2,3,4,5,6)
+  assert_equal [1, 2, [3, 4, 5], 6,7], pr.call(1,2,3,4,5,6,7)
+
+  assert_equal [nil, nil, [], nil, nil], pr.call([])
+  assert_equal [1, nil, [], nil, nil], pr.call([1])
+  assert_equal [1, 2, [], nil, nil], pr.call([1,2])
+  assert_equal [1, 2, [], 3, nil], pr.call([1,2,3])
+  assert_equal [1, 2, [], 3, 4], pr.call([1,2,3,4])
+  assert_equal [1, 2, [3], 4, 5], pr.call([1,2,3,4,5])
+  assert_equal [1, 2, [3, 4], 5, 6], pr.call([1,2,3,4,5,6])
+  assert_equal [1, 2, [3, 4, 5], 6,7], pr.call([1,2,3,4,5,6,7])
+end
+
 assert('Proc#return_does_not_break_self') do
   class TestClass
     attr_accessor :block


### PR DESCRIPTION
`mlen` should in `0`~ `m2`.

```
Proc.new{|a,*b,c|}.call #=> segmentation fault
```
