### PR TITLE
Update example build_config to include host build setting

### DIFF
--- a/examples/targets/build_config_ArduinoDue.rb
+++ b/examples/targets/build_config_ArduinoDue.rb
@@ -1,8 +1,24 @@
+MRuby::Build.new do |conf|
+
+  # Gets set by the VS command prompts.
+  if ENV['VisualStudioVersion'] || ENV['VSINSTALLDIR']
+    toolchain :visualcpp
+  else
+    toolchain :gcc
+  end
+
+  enable_debug
+
+  # include the default GEMs
+  conf.gembox 'default'
+
+end
+
 # Cross Compiling configuration for Arduino Due
 # http://arduino.cc/en/Main/ArduinoBoardDue
 #
 # Requires Arduino IDE >= 1.5
-MRuby::CrossBuild.new("Arduino Due") do |conf|
+MRuby::CrossBuild.new("ArduinoDue") do |conf|
   toolchain :gcc
 
   # Mac OS X

--- a/examples/targets/build_config_IntelGalileo.rb
+++ b/examples/targets/build_config_IntelGalileo.rb
@@ -1,8 +1,24 @@
+MRuby::Build.new do |conf|
+
+  # Gets set by the VS command prompts.
+  if ENV['VisualStudioVersion'] || ENV['VSINSTALLDIR']
+    toolchain :visualcpp
+  else
+    toolchain :gcc
+  end
+
+  enable_debug
+
+  # include the default GEMs
+  conf.gembox 'default'
+
+end
+
+
 # Cross Compiling configuration for Intel Galileo on Arduino environment
 # http://arduino.cc/en/ArduinoCertified/IntelGalileo
 #
 # Requires Arduino IDE for Intel Galileo
-
 MRuby::CrossBuild.new("Galileo") do |conf|
   toolchain :gcc
 

--- a/examples/targets/build_config_chipKITMax32.rb
+++ b/examples/targets/build_config_chipKITMax32.rb
@@ -1,3 +1,19 @@
+MRuby::Build.new do |conf|
+
+  # Gets set by the VS command prompts.
+  if ENV['VisualStudioVersion'] || ENV['VSINSTALLDIR']
+    toolchain :visualcpp
+  else
+    toolchain :gcc
+  end
+
+  enable_debug
+
+  # include the default GEMs
+  conf.gembox 'default'
+
+end
+
 # Cross Compiling configuration for Digilent chipKIT Max32
 # http://www.digilentinc.com/Products/Detail.cfm?Prod=CHIPKIT-MAX32
 #
@@ -5,7 +21,7 @@
 #
 # This configuration is based on @kyab's version
 # http://d.hatena.ne.jp/kyab/20130201
-MRuby::CrossBuild.new("chipKitMax32") do |conf|
+MRuby::CrossBuild.new("chipKITMax32") do |conf|
   toolchain :gcc
 
   # Mac OS X


### PR DESCRIPTION
By this changes,
- File name indicate it is build_config file more clearly.
- Include host build setting, to make trying easy( I saw some people confused and missed host build setting on cross build environment. Of course developer should consult documents, but I think it would be better to make examples more practical).

Also, I made below small changes.
- Change cross build name from "Arduino Due" to "ArduinoDue" for avoid build dir including space. 
- Fix cross build name from "chipKitMax32" to "chipKITMax32".
