### PR TITLE
Disable C++ exception for chipKIT Max32 example build_config

### DIFF
--- a/examples/targets/build_config_chipKITMax32.rb
+++ b/examples/targets/build_config_chipKITMax32.rb
@@ -70,6 +70,9 @@ MRuby::CrossBuild.new("chipKITMax32") do |conf|
   #do not build test executable
   conf.build_mrbtest_lib_only
 
+  #disable C++ exception
+  conf.disable_cxx_exception
+
   #gems from core
   conf.gem :core => "mruby-print"
   conf.gem :core => "mruby-math"


### PR DESCRIPTION
I noticed on gcc provided in IDE for chipKIT Max32, C++ exception is disabled by default. This change prevents build error when someone add mrbgems which includes .cpp files.  
