### PR TITLE
Fix #2236 .

### DIFF
--- a/mrbgems/mruby-enumerator/mrbgem.rake
+++ b/mrbgems/mruby-enumerator/mrbgem.rake
@@ -2,5 +2,6 @@ MRuby::Gem::Specification.new('mruby-enumerator') do |spec|
   spec.license = 'MIT'
   spec.author  = 'mruby developers'
   spec.add_dependency('mruby-fiber')
+  spec.add_dependency('mruby-enum-ext', :core => 'mruby-enum-ext')
   spec.summary = 'Enumerator class'
 end

--- a/mrbgems/mruby-enumerator/mrblib/enumerator.rb
+++ b/mrbgems/mruby-enumerator/mrblib/enumerator.rb
@@ -220,9 +220,9 @@ class Enumerator
     args = ""
     if @args && @args.size > 0
       args = "("
-      @args.each {|arg| args << "#{arg}, " }
+      @args.each {|arg| args += "#{arg}, " }
       args = args[0, args.size-2]
-      args << ")"
+      args += ")"
     end
     "#<#{self.class}: #{@obj}:#{@meth}#{args}>"
   end


### PR DESCRIPTION
- Use `+=` operator instead of `<<`.
- Add dependency 'mruby-enum-ext' in 'mruby-enumerator'.
