### PR TITLE
Implement block pass

### DIFF
--- a/src/codegen.c
+++ b/src/codegen.c
@@ -1942,6 +1942,9 @@ codegen(codegen_scope *s, node *tree, int val)
 
   case NODE_BLOCK_ARG:
     codegen(s, tree, VAL);
+    pop();
+    genop(s, MKOP_A(OP_BLOCK_PASS, cursp()));
+    push();
     break;
 
   case NODE_INT:
@@ -2885,6 +2888,10 @@ codedump(mrb_state *mrb, mrb_irep *irep)
              (GETARG_Bx(c)>>9)&0x1,
              (GETARG_Bx(c)>>4)&0x1f,
              (GETARG_Bx(c)>>0)&0xf);
+      print_lv(mrb, irep, c, RA);
+      break;
+    case OP_BLOCK_PASS:
+      printf("OP_BLOCK_PASS\tR%d", GETARG_A(c));
       print_lv(mrb, irep, c, RA);
       break;
 

--- a/src/opcode.h
+++ b/src/opcode.h
@@ -101,6 +101,7 @@ enum {
   OP_RETURN,/*    A B     return R(A) (B=normal,in-block return/break)    */
   OP_TAILCALL,/*  A B C   return call(R(A),mSym(B),*R(C))                 */
   OP_BLKPUSH,/*   A Bx    R(A) := block (16=6:1:5:4)                      */
+  OP_BLOCK_PASS,/*A       R(A) := &R(A)                                   */
 
   OP_ADD,/*       A B C   R(A) := R(A)+R(A+1) (mSyms[B]=:+,C=1)           */
   OP_ADDI,/*      A B C   R(A) := R(A)+C (mSyms[B]=:+)                    */

--- a/src/vm.c
+++ b/src/vm.c
@@ -674,7 +674,7 @@ mrb_context_run(mrb_state *mrb, struct RProc *proc, mrb_value self, unsigned int
     &&L_OP_ONERR, &&L_OP_RESCUE, &&L_OP_POPERR, &&L_OP_RAISE, &&L_OP_EPUSH, &&L_OP_EPOP,
     &&L_OP_SEND, &&L_OP_SENDB, &&L_OP_FSEND,
     &&L_OP_CALL, &&L_OP_SUPER, &&L_OP_ARGARY, &&L_OP_ENTER,
-    &&L_OP_KARG, &&L_OP_KDICT, &&L_OP_RETURN, &&L_OP_TAILCALL, &&L_OP_BLKPUSH,
+    &&L_OP_KARG, &&L_OP_KDICT, &&L_OP_RETURN, &&L_OP_TAILCALL, &&L_OP_BLKPUSH, &&L_OP_BLOCK_PASS,
     &&L_OP_ADD, &&L_OP_ADDI, &&L_OP_SUB, &&L_OP_SUBI, &&L_OP_MUL, &&L_OP_DIV,
     &&L_OP_EQ, &&L_OP_LT, &&L_OP_LE, &&L_OP_GT, &&L_OP_GE,
     &&L_OP_ARRAY, &&L_OP_ARYCAT, &&L_OP_ARYPUSH, &&L_OP_AREF, &&L_OP_ASET, &&L_OP_APOST,
@@ -1587,6 +1587,19 @@ RETRY_TRY_BLOCK:
         stack = e->stack + 1;
       }
       regs[a] = stack[m1+r+m2];
+      NEXT;
+    }
+
+    CASE(OP_BLOCK_PASS) {
+      /* A    R(A) := &R(A) */
+      int a = GETARG_A(i);
+      if (!mrb_nil_p(regs[a])) {
+        mrb_value converted = mrb_check_convert_type(mrb, regs[a], MRB_TT_PROC, "Proc", "to_proc");
+        if (mrb_nil_p(converted)) {
+          mrb_raisef(mrb, E_TYPE_ERROR, "wrong argument type %S (expected Proc)", mrb_obj_class(mrb, regs[a]));
+        }
+        regs[a] = converted;
+      }
       NEXT;
     }
 

--- a/test/t/proc.rb
+++ b/test/t/proc.rb
@@ -131,3 +131,20 @@ assert('Proc#return_does_not_break_self') do
   assert_equal nil, c.return_nil
   assert_equal c, c.block.call
 end
+
+assert('&obj call to_proc if defined') do
+  pr = Proc.new{}
+  def mock(&b)
+    b
+  end
+  assert_equal pr.object_id, mock(&pr).object_id
+  assert_equal pr, mock(&pr)
+
+  obj = Object.new
+  def obj.to_proc
+    Proc.new{ :from_to_proc }
+  end
+  assert_equal :from_to_proc, mock(&obj).call
+
+  assert_raise(TypeError){ mock(&(Object.new)) }
+end


### PR DESCRIPTION
Object try call `to_proc` method when called with `&`
- define new operation `OP_BLOCK_PASS`
- check and call `to_proc` method if not `nil`
- raise TypeError if not defined `to_proc` or `to_proc` return not Proc object

see also https://github.com/mruby/mruby/issues/1471
