### PR TITLE
Modify eval for access outer local variable

### DIFF
--- a/mrbgems/mruby-eval/src/eval.c
+++ b/mrbgems/mruby-eval/src/eval.c
@@ -1,5 +1,95 @@
 #include "mruby.h"
 #include "mruby/compile.h"
+#include "mruby/irep.h"
+#include "mruby/proc.h"
+#include "opcode.h"
+
+static struct mrb_irep *
+get_closure_irep(mrb_state *mrb, int level)
+{
+  struct REnv *e = mrb->c->ci[-1].proc->env;
+  struct RProc *proc;
+
+  if (level == 0) {
+    return mrb->c->ci[-1].proc->body.irep;
+  }
+    
+  while (--level) {
+    e = (struct REnv*)e->c;
+    if (!e) return NULL;
+  }
+
+  if (!e) return NULL;
+  proc = mrb->c->cibase[e->cioff].proc;
+
+  return proc->body.irep;
+}
+
+static inline mrb_code
+search_variable(mrb_state *mrb, mrb_sym vsym)
+{
+  mrb_irep *virep;
+  int level;
+  int pos;
+
+  for (level = 0; (virep = get_closure_irep(mrb, level)); level++) {
+    if (virep->lv == NULL) {
+      continue;
+    }
+    for (pos = 0; pos < virep->nlocals - 1; pos++) {
+      if (vsym == virep->lv[pos].name) {
+	return (MKARG_B(pos + 1) | MKARG_C(level));
+      }
+    }
+  }
+
+  return 0;
+}
+
+
+static void
+patch_irep(mrb_state *mrb, mrb_irep *irep)
+{
+  int i;
+  mrb_code c;
+
+  for (i = 0; i < irep->ilen; i++) {
+    c = irep->iseq[i];
+    switch(GET_OPCODE(c)){
+    case OP_SEND:
+      if (GETARG_C(c) != 0) {
+	break;
+      }
+      {
+	mrb_code arg = search_variable(mrb, irep->syms[GETARG_B(c)]);
+	if (arg != 0) {
+	  /* must replace */
+	  irep->iseq[i] = MKOPCODE(OP_GETUPVAR) | MKARG_A(GETARG_A(c)) | arg;
+	}
+      }
+      break;
+
+    case OP_MOVE:
+      /* src part */
+      if (GETARG_B(c) < irep->nlocals) {
+	mrb_code arg = search_variable(mrb, irep->lv[GETARG_B(c) - 1].name);
+	if (arg != 0) {
+	  /* must replace */
+	  irep->iseq[i] = MKOPCODE(OP_GETUPVAR) | MKARG_A(GETARG_A(c)) | arg;
+	}
+      }
+      /* dst part */
+      if (GETARG_A(c) < irep->nlocals) {
+	mrb_code arg = search_variable(mrb, irep->lv[GETARG_A(c) - 1].name);
+	if (arg != 0) {
+	  /* must replace */
+	  irep->iseq[i] = MKOPCODE(OP_SETUPVAR) | MKARG_A(GETARG_B(c)) | arg;
+	}
+      }
+      break;
+    }
+  }
+}
 
 static struct RProc*
 create_proc_from_string(mrb_state *mrb, char *s, int len, mrb_value binding, char *file, mrb_int line)
@@ -7,6 +97,7 @@ create_proc_from_string(mrb_state *mrb, char *s, int len, mrb_value binding, cha
   mrbc_context *cxt;
   struct mrb_parser_state *p;
   struct RProc *proc;
+  struct REnv *e;
 
   if (!mrb_nil_p(binding)) {
     mrb_raise(mrb, E_ARGUMENT_ERROR, "Binding of eval must be nil.");
@@ -34,6 +125,13 @@ create_proc_from_string(mrb_state *mrb, char *s, int len, mrb_value binding, cha
   }
 
   proc = mrb_generate_code(mrb, p);
+  e = (struct REnv*)mrb_obj_alloc(mrb, MRB_TT_ENV, (struct RClass*)mrb->c->ci[-1].proc->env);
+  e->mid = mrb->c->ci[-1].mid;
+  e->cioff = mrb->c->ci - mrb->c->cibase - 1;
+  e->stack = mrb->c->ci->stackent;
+  mrb->c->ci->env = e;
+  proc->env = e;
+  patch_irep(mrb, proc->body.irep);
 
   mrb_parser_free(p);
   mrbc_context_free(mrb, cxt);
@@ -55,10 +153,12 @@ f_eval(mrb_state *mrb, mrb_value self)
   char *file = NULL;
   mrb_int line = 1;
   mrb_value ret;
+  struct RProc *proc;
 
   mrb_get_args(mrb, "s|ozi", &s, &len, &binding, &file, &line);
 
-  ret = mrb_toplevel_run(mrb, create_proc_from_string(mrb, s, len, binding, file, line));
+  proc = create_proc_from_string(mrb, s, len, binding, file, line);
+  ret = mrb_toplevel_run(mrb, proc);
   if (mrb->exc) {
     mrb_exc_raise(mrb, mrb_obj_value(mrb->exc));
   }
@@ -76,3 +176,4 @@ void
 mrb_mruby_eval_gem_final(mrb_state* mrb)
 {
 }
+

--- a/mrbgems/mruby-eval/src/opcode.h
+++ b/mrbgems/mruby-eval/src/opcode.h
@@ -1,0 +1,160 @@
+/*
+** opcode.h - RiteVM operation codes
+**
+** See Copyright Notice in mruby.h
+*/
+
+#ifndef OPCODE_H
+#define OPCODE_H
+
+#define MAXARG_Bx        (0xffff)
+#define MAXARG_sBx       (MAXARG_Bx>>1)         /* `sBx' is signed */
+
+/* instructions: packed 32 bit      */
+/* -------------------------------  */
+/*     A:B:C:OP = 9: 9: 7: 7        */
+/*      A:Bx:OP =    9:16: 7        */
+/*        Ax:OP =      25: 7        */
+/*   A:Bz:Cz:OP = 9:14: 2: 7        */
+
+#define GET_OPCODE(i)            ((int)(((mrb_code)(i)) & 0x7f))
+#define GETARG_A(i)              ((int)((((mrb_code)(i)) >> 23) & 0x1ff))
+#define GETARG_B(i)              ((int)((((mrb_code)(i)) >> 14) & 0x1ff))
+#define GETARG_C(i)              ((int)((((mrb_code)(i)) >>  7) & 0x7f))
+#define GETARG_Bx(i)             ((int)((((mrb_code)(i)) >>  7) & 0xffff))
+#define GETARG_sBx(i)            ((int)(GETARG_Bx(i)-MAXARG_sBx))
+#define GETARG_Ax(i)             ((int32_t)((((mrb_code)(i)) >>  7) & 0x1ffffff))
+#define GETARG_UNPACK_b(i,n1,n2) ((int)((((mrb_code)(i)) >> (7+(n2))) & (((1<<(n1))-1))))
+#define GETARG_UNPACK_c(i,n1,n2) ((int)((((mrb_code)(i)) >> 7) & (((1<<(n2))-1))))
+#define GETARG_b(i)              GETARG_UNPACK_b(i,14,2)
+#define GETARG_c(i)              GETARG_UNPACK_c(i,14,2)
+
+#define MKOPCODE(op)          ((op) & 0x7f)
+#define MKARG_A(c)            ((mrb_code)((c) & 0x1ff) << 23)
+#define MKARG_B(c)            ((mrb_code)((c) & 0x1ff) << 14)
+#define MKARG_C(c)            (((c) & 0x7f) <<  7)
+#define MKARG_Bx(v)           ((mrb_code)((v) & 0xffff) << 7)
+#define MKARG_sBx(v)          MKARG_Bx((v)+MAXARG_sBx)
+#define MKARG_Ax(v)           ((mrb_code)((v) & 0x1ffffff) << 7)
+#define MKARG_PACK(b,n1,c,n2) ((((b) & ((1<<n1)-1)) << (7+n2))|(((c) & ((1<<n2)-1)) << 7))
+#define MKARG_bc(b,c)         MKARG_PACK(b,14,c,2)
+
+#define MKOP_A(op,a)        (MKOPCODE(op)|MKARG_A(a))
+#define MKOP_AB(op,a,b)     (MKOP_A(op,a)|MKARG_B(b))
+#define MKOP_ABC(op,a,b,c)  (MKOP_AB(op,a,b)|MKARG_C(c))
+#define MKOP_ABx(op,a,bx)   (MKOP_A(op,a)|MKARG_Bx(bx))
+#define MKOP_Bx(op,bx)      (MKOPCODE(op)|MKARG_Bx(bx))
+#define MKOP_sBx(op,sbx)    (MKOPCODE(op)|MKARG_sBx(sbx))
+#define MKOP_AsBx(op,a,sbx) (MKOP_A(op,a)|MKARG_sBx(sbx))
+#define MKOP_Ax(op,ax)      (MKOPCODE(op)|MKARG_Ax(ax))
+#define MKOP_Abc(op,a,b,c)  (MKOP_A(op,a)|MKARG_bc(b,c))
+
+enum {
+  /*-----------------------------------------------------------------------
+  operation code  operand description
+  ------------------------------------------------------------------------*/
+  OP_NOP=0,/*                                                             */
+  OP_MOVE,/*      A B     R(A) := R(B)                                    */
+  OP_LOADL,/*     A Bx    R(A) := Lit(Bx)                                 */
+  OP_LOADI,/*     A sBx   R(A) := sBx                                     */
+  OP_LOADSYM,/*   A Bx    R(A) := Sym(Bx)                                 */
+  OP_LOADNIL,/*   A       R(A) := nil                                     */
+  OP_LOADSELF,/*  A       R(A) := self                                    */
+  OP_LOADT,/*     A       R(A) := true                                    */
+  OP_LOADF,/*     A       R(A) := false                                   */
+
+  OP_GETGLOBAL,/* A Bx    R(A) := getglobal(Sym(Bx))                      */
+  OP_SETGLOBAL,/* A Bx    setglobal(Sym(Bx), R(A))                        */
+  OP_GETSPECIAL,/*A Bx    R(A) := Special[Bx]                             */
+  OP_SETSPECIAL,/*A Bx    Special[Bx] := R(A)                             */
+  OP_GETIV,/*     A Bx    R(A) := ivget(Sym(Bx))                          */
+  OP_SETIV,/*     A Bx    ivset(Sym(Bx),R(A))                             */
+  OP_GETCV,/*     A Bx    R(A) := cvget(Sym(Bx))                          */
+  OP_SETCV,/*     A Bx    cvset(Sym(Bx),R(A))                             */
+  OP_GETCONST,/*  A Bx    R(A) := constget(Sym(Bx))                       */
+  OP_SETCONST,/*  A Bx    constset(Sym(Bx),R(A))                          */
+  OP_GETMCNST,/*  A Bx    R(A) := R(A)::Sym(Bx)                           */
+  OP_SETMCNST,/*  A Bx    R(A+1)::Sym(Bx) := R(A)                         */
+  OP_GETUPVAR,/*  A B C   R(A) := uvget(B,C)                              */
+  OP_SETUPVAR,/*  A B C   uvset(B,C,R(A))                                 */
+
+  OP_JMP,/*       sBx     pc+=sBx                                         */
+  OP_JMPIF,/*     A sBx   if R(A) pc+=sBx                                 */
+  OP_JMPNOT,/*    A sBx   if !R(A) pc+=sBx                                */
+  OP_ONERR,/*     sBx     rescue_push(pc+sBx)                             */
+  OP_RESCUE,/*    A       clear(exc); R(A) := exception (ignore when A=0) */
+  OP_POPERR,/*    A       A.times{rescue_pop()}                           */
+  OP_RAISE,/*     A       raise(R(A))                                     */
+  OP_EPUSH,/*     Bx      ensure_push(SEQ[Bx])                            */
+  OP_EPOP,/*      A       A.times{ensure_pop().call}                      */
+
+  OP_SEND,/*      A B C   R(A) := call(R(A),mSym(B),R(A+1),...,R(A+C))    */
+  OP_SENDB,/*     A B C   R(A) := call(R(A),mSym(B),R(A+1),...,R(A+C),&R(A+C+1))*/
+  OP_FSEND,/*     A B C   R(A) := fcall(R(A),mSym(B),R(A+1),...,R(A+C-1)) */
+  OP_CALL,/*      A B C   R(A) := self.call(R(A),.., R(A+C))              */
+  OP_SUPER,/*     A B C   R(A) := super(R(A+1),... ,R(A+C-1))             */
+  OP_ARGARY,/*    A Bx    R(A) := argument array (16=6:1:5:4)             */
+  OP_ENTER,/*     Ax      arg setup according to flags (23=5:5:1:5:5:1:1) */
+  OP_KARG,/*      A B C   R(A) := kdict[mSym(B)]; if C kdict.rm(mSym(B))  */
+  OP_KDICT,/*     A C     R(A) := kdict                                   */
+
+  OP_RETURN,/*    A B     return R(A) (B=normal,in-block return/break)    */
+  OP_TAILCALL,/*  A B C   return call(R(A),mSym(B),*R(C))                 */
+  OP_BLKPUSH,/*   A Bx    R(A) := block (16=6:1:5:4)                      */
+
+  OP_ADD,/*       A B C   R(A) := R(A)+R(A+1) (mSyms[B]=:+,C=1)           */
+  OP_ADDI,/*      A B C   R(A) := R(A)+C (mSyms[B]=:+)                    */
+  OP_SUB,/*       A B C   R(A) := R(A)-R(A+1) (mSyms[B]=:-,C=1)           */
+  OP_SUBI,/*      A B C   R(A) := R(A)-C (mSyms[B]=:-)                    */
+  OP_MUL,/*       A B C   R(A) := R(A)*R(A+1) (mSyms[B]=:*,C=1)           */
+  OP_DIV,/*       A B C   R(A) := R(A)/R(A+1) (mSyms[B]=:/,C=1)           */
+  OP_EQ,/*        A B C   R(A) := R(A)==R(A+1) (mSyms[B]=:==,C=1)         */
+  OP_LT,/*        A B C   R(A) := R(A)<R(A+1)  (mSyms[B]=:<,C=1)          */
+  OP_LE,/*        A B C   R(A) := R(A)<=R(A+1) (mSyms[B]=:<=,C=1)         */
+  OP_GT,/*        A B C   R(A) := R(A)>R(A+1)  (mSyms[B]=:>,C=1)          */
+  OP_GE,/*        A B C   R(A) := R(A)>=R(A+1) (mSyms[B]=:>=,C=1)         */
+
+  OP_ARRAY,/*     A B C   R(A) := ary_new(R(B),R(B+1)..R(B+C))            */
+  OP_ARYCAT,/*    A B     ary_cat(R(A),R(B))                              */
+  OP_ARYPUSH,/*   A B     ary_push(R(A),R(B))                             */
+  OP_AREF,/*      A B C   R(A) := R(B)[C]                                 */
+  OP_ASET,/*      A B C   R(B)[C] := R(A)                                 */
+  OP_APOST,/*     A B C   *R(A),R(A+1)..R(A+C) := R(A)                    */
+
+  OP_STRING,/*    A Bx    R(A) := str_dup(Lit(Bx))                        */
+  OP_STRCAT,/*    A B     str_cat(R(A),R(B))                              */
+
+  OP_HASH,/*      A B C   R(A) := hash_new(R(B),R(B+1)..R(B+C))           */
+  OP_LAMBDA,/*    A Bz Cz R(A) := lambda(SEQ[Bz],Cz)                      */
+  OP_RANGE,/*     A B C   R(A) := range_new(R(B),R(B+1),C)                */
+
+  OP_OCLASS,/*    A       R(A) := ::Object                                */
+  OP_CLASS,/*     A B     R(A) := newclass(R(A),mSym(B),R(A+1))           */
+  OP_MODULE,/*    A B     R(A) := newmodule(R(A),mSym(B))                 */
+  OP_EXEC,/*      A Bx    R(A) := blockexec(R(A),SEQ[Bx])                 */
+  OP_METHOD,/*    A B     R(A).newmethod(mSym(B),R(A+1))                  */
+  OP_SCLASS,/*    A B     R(A) := R(B).singleton_class                    */
+  OP_TCLASS,/*    A       R(A) := target_class                            */
+
+  OP_DEBUG,/*     A       print R(A)                                      */
+  OP_STOP,/*              stop VM                                         */
+  OP_ERR,/*       Bx      raise RuntimeError with message Lit(Bx)         */
+
+  OP_RSVD1,/*             reserved instruction #1                         */
+  OP_RSVD2,/*             reserved instruction #2                         */
+  OP_RSVD3,/*             reserved instruction #3                         */
+  OP_RSVD4,/*             reserved instruction #4                         */
+  OP_RSVD5,/*             reserved instruction #5                         */
+};
+
+#define OP_L_STRICT  1
+#define OP_L_CAPTURE 2
+#define OP_L_METHOD  OP_L_STRICT
+#define OP_L_LAMBDA  (OP_L_STRICT|OP_L_CAPTURE)
+#define OP_L_BLOCK   OP_L_CAPTURE
+
+#define OP_R_NORMAL 0
+#define OP_R_BREAK  1
+#define OP_R_RETURN 2
+
+#endif  /* OPCODE_H */

--- a/mrbgems/mruby-eval/test/eval.rb
+++ b/mrbgems/mruby-eval/test/eval.rb
@@ -1,6 +1,23 @@
 assert('Kernel.eval') do
   assert_equal(10) { Kernel.eval '1 * 10' }
   assert_equal('aaa') { Kernel.eval "'a' * 3" }
+  assert_equal(10) {
+    a = 10
+    Kernel.eval "a"
+  }
+  assert_equal(20) {
+    a = 10
+    Kernel.eval "a = 20"
+    a
+  }
+  assert_equal(15) {
+    c = 5
+    lambda {
+      a = 10
+      Kernel.eval "c = a + c"
+    }.call
+    c
+  }
 end
 
 assert('eval') do


### PR DESCRIPTION
This patch enable to access outer local variables by "Kernel.eval" method. For example 
a = 10
p eval "a"                   # 10
eval "a = 20" 
p a                             # 20

My path not support using closure in eval method. But I will support this in the near future.
