### PR TITLE
Remove `LINENO` section.

### DIFF
--- a/include/mruby/debug.h
+++ b/include/mruby/debug.h
@@ -54,6 +54,7 @@ int32_t mrb_debug_get_line(mrb_irep *irep, uint32_t pc);
 
 mrb_irep_debug_info_file *mrb_debug_info_append_file(
     mrb_state *mrb, mrb_irep *irep,
+    const char *filename, const uint16_t *lines,
     uint32_t start_pos, uint32_t end_pos);
 mrb_irep_debug_info *mrb_debug_info_alloc(mrb_state *mrb, mrb_irep *irep);
 void mrb_debug_info_free(mrb_state *mrb, mrb_irep_debug_info *d);

--- a/include/mruby/dump.h
+++ b/include/mruby/dump.h
@@ -51,7 +51,6 @@ mrb_irep *mrb_read_irep(mrb_state*, const uint8_t*);
 
 #define RITE_BINARY_EOF                "END\0"
 #define RITE_SECTION_IREP_IDENTIFIER   "IREP"
-#define RITE_SECTION_LINENO_IDENTIFIER "LINE"
 #define RITE_SECTION_DEBUG_IDENTIFIER  "DBG\0"
 #define RITE_SECTION_LV_IDENTIFIER     "LVAR"
 
@@ -80,10 +79,6 @@ struct rite_section_irep_header {
   RITE_SECTION_HEADER;
 
   uint8_t rite_version[4];    /* Rite Instruction Specification Version */
-};
-
-struct rite_section_lineno_header {
-  RITE_SECTION_HEADER;
 };
 
 struct rite_section_debug_header {

--- a/include/mruby/irep.h
+++ b/include/mruby/irep.h
@@ -36,9 +36,6 @@ typedef struct mrb_irep {
   struct mrb_irep **reps;
 
   struct mrb_locals *lv;
-  /* debug info */
-  const char *filename;
-  uint16_t *lines;
   struct mrb_irep_debug_info* debug_info;
 
   size_t ilen, plen, slen, rlen, refcnt;

--- a/src/debug.c
+++ b/src/debug.c
@@ -9,6 +9,8 @@ get_file(mrb_irep_debug_info *info, uint32_t pc)
   mrb_irep_debug_info_file **ret;
   int32_t count;
 
+  if (!info) { return NULL; }
+
   if (pc >= info->pc_count) { return NULL; }
   /* get upper bound */
   ret = info->files;

--- a/src/debug.c
+++ b/src/debug.c
@@ -52,12 +52,9 @@ select_line_type(const uint16_t *lines, size_t lines_len)
 char const*
 mrb_debug_get_filename(mrb_irep *irep, uint32_t pc)
 {
-  if (irep && pc < irep->ilen) {
     mrb_irep_debug_info_file* f = NULL;
-    if (!irep->debug_info) { return irep->filename; }
-    else if ((f = get_file(irep->debug_info, pc))) {
-      return f->filename;
-    }
+  if (irep && pc < irep->ilen && (f = get_file(irep->debug_info, pc))) {
+    return f->filename;
   }
   return NULL;
 }
@@ -65,41 +62,37 @@ mrb_debug_get_filename(mrb_irep *irep, uint32_t pc)
 int32_t
 mrb_debug_get_line(mrb_irep *irep, uint32_t pc)
 {
-  if (irep && pc < irep->ilen) {
-    mrb_irep_debug_info_file* f = NULL;
-    if (!irep->debug_info) {
-      return irep->lines? irep->lines[pc] : -1;
-    }
-    else if ((f = get_file(irep->debug_info, pc))) {
-      switch (f->line_type) {
-        case mrb_debug_line_ary:
-          mrb_assert(f->start_pos <= pc && pc < (f->start_pos + f->line_entry_count));
-          return f->lines.ary[pc - f->start_pos];
+  mrb_irep_debug_info_file* f = NULL;
+  if (irep && pc < irep->ilen && (f = get_file(irep->debug_info, pc))) {
+    switch (f->line_type) {
+    case mrb_debug_line_ary:
+      mrb_assert(f->start_pos <= pc && pc < (f->start_pos + f->line_entry_count));
+      return f->lines.ary[pc - f->start_pos];
 
-        case mrb_debug_line_flat_map: {
-          /* get upper bound */
-          mrb_irep_debug_info_line *ret = f->lines.flat_map;
-          uint32_t count = f->line_entry_count;
-          while (count > 0) {
-            int32_t step = count / 2;
-            mrb_irep_debug_info_line *it = ret + step;
-            if (!(pc < it->start_pos)) {
-              ret = it + 1;
-              count -= step + 1;
-            } else { count = step; }
-          }
-
-          --ret;
-
-          /* check line entry pointer range */
-          mrb_assert(f->lines.flat_map <= ret && ret < (f->lines.flat_map + f->line_entry_count));
-          /* check pc range */
-          mrb_assert(ret->start_pos <= pc &&
-                     pc < (((uint32_t)(ret + 1 - f->lines.flat_map) < f->line_entry_count)
-                           ? (ret+1)->start_pos : irep->debug_info->pc_count));
-
-          return ret->line;
+    case mrb_debug_line_flat_map:
+      {
+        /* get upper bound */
+        mrb_irep_debug_info_line *ret = f->lines.flat_map;
+        uint32_t count = f->line_entry_count;
+        while (count > 0) {
+          int32_t step = count / 2;
+          mrb_irep_debug_info_line *it = ret + step;
+          if (!(pc < it->start_pos)) {
+            ret = it + 1;
+            count -= step + 1;
+          } else { count = step; }
         }
+
+        --ret;
+
+        /* check line entry pointer range */
+        mrb_assert(f->lines.flat_map <= ret && ret < (f->lines.flat_map + f->line_entry_count));
+        /* check pc range */
+        mrb_assert(ret->start_pos <= pc &&
+                   pc < (((uint32_t)(ret + 1 - f->lines.flat_map) < f->line_entry_count)
+                         ? (ret+1)->start_pos : irep->debug_info->pc_count));
+
+        return ret->line;
       }
     }
   }
@@ -121,6 +114,7 @@ mrb_debug_info_alloc(mrb_state *mrb, mrb_irep *irep)
 
 mrb_irep_debug_info_file *
 mrb_debug_info_append_file(mrb_state *mrb, mrb_irep *irep,
+                           const char *filename, const uint16_t *lines,
                            uint32_t start_pos, uint32_t end_pos)
 {
   mrb_irep_debug_info *info;
@@ -132,12 +126,9 @@ mrb_debug_info_append_file(mrb_state *mrb, mrb_irep *irep,
 
   if (!irep->debug_info) { return NULL; }
 
-  mrb_assert(irep->filename);
-  mrb_assert(irep->lines);
-
   info = irep->debug_info;
 
-  if (info->flen > 0 && strcmp(irep->filename, info->files[info->flen - 1]->filename) == 0) {
+  if (info->flen > 0 && strcmp(filename, info->files[info->flen - 1]->filename) == 0) {
     return NULL;
   }
 
@@ -154,12 +145,12 @@ mrb_debug_info_append_file(mrb_state *mrb, mrb_irep *irep,
   ret->start_pos = start_pos;
   info->pc_count = end_pos;
 
-  fn_len = strlen(irep->filename);
-  ret->filename_sym = mrb_intern(mrb, irep->filename, fn_len);
+  fn_len = strlen(filename);
+  ret->filename_sym = mrb_intern(mrb, filename, fn_len);
   len = 0;
   ret->filename = mrb_sym2name_len(mrb, ret->filename_sym, &len);
 
-  ret->line_type = select_line_type(irep->lines + start_pos, end_pos - start_pos);
+  ret->line_type = select_line_type(lines + start_pos, end_pos - start_pos);
   ret->lines.ptr = NULL;
 
   switch (ret->line_type) {
@@ -167,7 +158,7 @@ mrb_debug_info_append_file(mrb_state *mrb, mrb_irep *irep,
       ret->line_entry_count = file_pc_count;
       ret->lines.ary = (uint16_t*)mrb_malloc(mrb, sizeof(uint16_t) * file_pc_count);
       for (i = 0; i < file_pc_count; ++i) {
-        ret->lines.ary[i] = irep->lines[start_pos + i];
+        ret->lines.ary[i] = lines[start_pos + i];
       }
       break;
 
@@ -177,18 +168,18 @@ mrb_debug_info_append_file(mrb_state *mrb, mrb_irep *irep,
       ret->lines.flat_map = (mrb_irep_debug_info_line*)mrb_malloc(mrb, sizeof(mrb_irep_debug_info_line) * 1);
       ret->line_entry_count = 0;
       for (i = 0; i < file_pc_count; ++i) {
-        if (irep->lines[start_pos + i] == prev_line) { continue; }
+        if (lines[start_pos + i] == prev_line) { continue; }
 
         ret->lines.flat_map = (mrb_irep_debug_info_line*)mrb_realloc(
             mrb, ret->lines.flat_map,
             sizeof(mrb_irep_debug_info_line) * (ret->line_entry_count + 1));
         m.start_pos = start_pos + i;
-        m.line = irep->lines[start_pos + i];
+        m.line = lines[start_pos + i];
         ret->lines.flat_map[ret->line_entry_count] = m;
 
         /* update */
         ++ret->line_entry_count;
-        prev_line = irep->lines[start_pos + i];
+        prev_line = lines[start_pos + i];
       }
     } break;
 

--- a/src/state.c
+++ b/src/state.c
@@ -150,8 +150,6 @@ mrb_irep_free(mrb_state *mrb, mrb_irep *irep)
   }
   mrb_free(mrb, irep->reps);
   mrb_free(mrb, irep->lv);
-  mrb_free(mrb, (void *)irep->filename);
-  mrb_free(mrb, irep->lines);
   mrb_debug_info_free(mrb, irep->debug_info);
   mrb_free(mrb, irep);
 }


### PR DESCRIPTION
Since it isn't used anymore.
It shouldn't break compatibility with 1.0.0. Though may cause problem with mruby older than 1.0.0.
