### PR TITLE
Add build_lib_only mode.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -79,14 +79,14 @@ MRuby.each_target do |target|
         depfiles += [ exec ]
       end
     end
-  end
+  end if target.build_lib_only? == false
 end
 
 depfiles += MRuby.targets.map { |n, t|
   [t.libfile("#{t.build_dir}/lib/libmruby")]
 }.flatten
 
-depfiles += MRuby.targets.reject { |n, t| n == 'host' }.map { |n, t|
+depfiles += MRuby.targets.reject { |n, t| n == 'host' or t.build_lib_only? }.map { |n, t|
   t.bins.map { |bin| t.exefile("#{t.build_dir}/bin/#{bin}") }
 }.flatten
 

--- a/doc/compile/README.md
+++ b/doc/compile/README.md
@@ -256,6 +256,19 @@ When debugging mode is enabled
 	* Because ```-g``` flag would be added to ```mrbc``` runner.
     * You can have better backtrace of mruby scripts with this.
 
+### Library only build
+
+To suppress executable binary builds add the following:
+
+	conf.build_lib_only
+
+When library only build mode is enabled, building binaries
+specified by {conf,gem}.bins are cancelled.
+Note that binaries in targets['host'].bins are always built even if
+build_lib_only is set. At least mrbc is required to build libmruby.a.
+This will be useful if you want to link libmruby.a into another
+applications.
+
 ## Cross-Compilation
 
 mruby can also be cross-compiled from one platform to another. To

--- a/tasks/mruby_build.rake
+++ b/tasks/mruby_build.rake
@@ -81,6 +81,7 @@ module MRuby
 
         @bins = %w(mrbc)
         @gems, @libmruby = MRuby::Gem::List.new, []
+        @build_lib_only = false
         @build_mrbtest_lib_only = false
         @cxx_abi_enabled = false
         @cxx_exception_disabled = false
@@ -191,6 +192,14 @@ module MRuby
       end
     end
 
+    def build_lib_only
+      @build_lib_only = true
+    end
+
+    def build_lib_only?
+      @build_lib_only
+    end
+
     def build_mrbtest_lib_only
       @build_mrbtest_lib_only = true
     end
@@ -216,14 +225,18 @@ module MRuby
       puts "================================================"
       puts "      Config Name: #{@name}"
       puts " Output Directory: #{self.build_dir.relative_path}"
-      puts "         Binaries: #{@bins.join(', ')}" unless @bins.empty?
+      if @build_lib_only
+        puts "         Binaries are not generated as build_lib_only was set."
+      else
+        puts "         Binaries: #{@bins.join(', ')}" unless @bins.empty?
+      end
       unless @gems.empty?
         puts "    Included Gems:"
         @gems.map do |gem|
           gem_version = " - #{gem.version}" if gem.version != '0.0.0'
           gem_summary = " - #{gem.summary}" if gem.summary
           puts "             #{gem.name}#{gem_version}#{gem_summary}"
-          puts "               - Binaries: #{gem.bins.join(', ')}" unless gem.bins.empty?
+          puts "               - Binaries: #{gem.bins.join(', ')}" unless (gem.bins.empty? or @build_lib_only)
         end
       end
       puts "================================================"


### PR DESCRIPTION
This patch aims for cross environments. Some can be build libmruby.a but cannot build executables in mruby world.

An example is to use mruby-bin-mocloudos-shell in embedded systems.
https://github.com/monami-ya-mrb/mruby-bin-mocloudos-shell
It has src/ and tools/ .
Some freestanding C targets can't be built tools/ (as freestanding C doesn't provide main() ).
But it can build src/ .
So he want to get just libmruby.a (with src/, without tools/) and link it on the another environment.
In this case, he want to ignore `spec.bins = %w(mocloudos-shell)` in mrbgem.spec.
But there is no way to ignore it.
