### PR TITLE
Improve `Struct#[]=`.

### DIFF
--- a/mrbgems/mruby-struct/src/struct.c
+++ b/mrbgems/mruby-struct/src/struct.c
@@ -672,7 +672,7 @@ mrb_struct_aset(mrb_state *mrb, mrb_value s)
     return mrb_struct_aset_sym(mrb, s, mrb_symbol(idx), val);
   }
 
-  i = mrb_fixnum(idx);
+  i = mrb_int(mrb, idx);
   if (i < 0) i = RSTRUCT_LEN(s) + i;
   if (i < 0) {
     mrb_raisef(mrb, E_INDEX_ERROR,

--- a/mrbgems/mruby-struct/test/struct.rb
+++ b/mrbgems/mruby-struct/test/struct.rb
@@ -41,6 +41,7 @@ assert('Struct#[]=', '15.2.18.4.3') do
   cc[:m1] == 3
   cc["m2"] = 3
   assert_equal 3, cc["m2"]
+  assert_raise(TypeError) { cc[[]] = 3 }
 end
 
 assert('Struct#each', '15.2.18.4.4') do


### PR DESCRIPTION
- Support string key.
- Check invalid key type.
