### PR TITLE
Improve `Struct` test.

### DIFF
--- a/mrbgems/mruby-struct/src/struct.c
+++ b/mrbgems/mruby-struct/src/struct.c
@@ -512,7 +512,7 @@ struct_aref_sym(mrb_state *mrb, mrb_value s, mrb_sym id)
       return ptr[i];
     }
   }
-  mrb_raisef(mrb, E_INDEX_ERROR, "no member '%S' in struct", mrb_sym2str(mrb, id));
+  mrb_name_error(mrb, id, "no member '%S' in struct", mrb_sym2str(mrb, id));
   return mrb_nil_value();       /* not reached */
 }
 
@@ -560,7 +560,7 @@ mrb_struct_aref(mrb_state *mrb, mrb_value s)
     mrb_value sym = mrb_check_intern_str(mrb, idx);
 
     if (mrb_nil_p(sym)) {
-      mrb_raisef(mrb, E_INDEX_ERROR, "no member '%S' in struct", idx);
+      mrb_name_error(mrb, mrb_intern_str(mrb, idx), "no member '%S' in struct", idx);
     }
     idx = sym;
   }
@@ -591,7 +591,7 @@ mrb_struct_aset_sym(mrb_state *mrb, mrb_value s, mrb_sym id, mrb_value val)
       return val;
     }
   }
-  mrb_raisef(mrb, E_INDEX_ERROR, "no member '%S' in struct", mrb_sym2str(mrb, id));
+  mrb_name_error(mrb, id, "no member '%S' in struct", mrb_sym2str(mrb, id));
   return val;                   /* not reach */
 }
 
@@ -630,7 +630,7 @@ mrb_struct_aset(mrb_state *mrb, mrb_value s)
     mrb_value sym = mrb_check_intern_str(mrb, idx);
 
     if (mrb_nil_p(sym)) {
-      mrb_raisef(mrb, E_INDEX_ERROR, "no member '%S' in struct", idx);
+      mrb_name_error(mrb, mrb_intern_str(mrb, idx), "no member '%S' in struct", idx);
     }
     idx = sym;
   }

--- a/mrbgems/mruby-struct/test/struct.rb
+++ b/mrbgems/mruby-struct/test/struct.rb
@@ -34,6 +34,7 @@ assert('Struct#[]', '15.2.18.4.2') do
   assert_equal 2, cc[-1]
   assert_raise(TypeError) { cc[[]] }
   assert_raise(IndexError) { cc[2] }
+  assert_raise(NameError) { cc['tama'] }
 end
 
 assert('Struct#[]=', '15.2.18.4.3') do
@@ -49,6 +50,7 @@ assert('Struct#[]=', '15.2.18.4.3') do
   assert_equal 5, cc[-1]
   assert_raise(TypeError) { cc[[]] = 3 }
   assert_raise(IndexError) { cc[2] = 7 }
+  assert_raise(NameError) { cc['pochi'] = 8 }
 end
 
 assert('Struct#each', '15.2.18.4.4') do

--- a/mrbgems/mruby-struct/test/struct.rb
+++ b/mrbgems/mruby-struct/test/struct.rb
@@ -2,39 +2,41 @@
 # Struct ISO Test
 
 assert('Struct', '15.2.18') do
-  Struct.class == Class
+  assert_equal Class, Struct.class
 end
 
 assert('Struct.new', '15.2.18.3.1') do
   c = Struct.new(:m1, :m2)
-  c.superclass == Struct and
-    c.members == [:m1,:m2]
+  assert_equal Struct, c.superclass
+  assert_equal [:m1, :m2], c.members
 end
 
 # Check crash bug with Struc.new and no params.
 assert('Struct.new', '15.2.18.3.1') do
   c = Struct.new()
-  c.superclass == Struct and c.members == []
+  assert_equal Struct, c.superclass
+  assert_equal [], c.members
 end
 
 assert('Struct#==', '15.2.18.4.1') do
   c = Struct.new(:m1, :m2)
   cc1 = c.new(1,2)
   cc2 = c.new(1,2)
-  cc1 == cc2
+  assert_true cc1 == cc2
 end
 
 assert('Struct#[]', '15.2.18.4.2') do
   c = Struct.new(:m1, :m2)
   cc = c.new(1,2)
-  cc[:m1] == 1 and cc["m2"] == 2
+  assert_equal 1, cc[:m1]
+  assert_equal 2, cc["m2"]
 end
 
 assert('Struct#[]=', '15.2.18.4.3') do
   c = Struct.new(:m1, :m2)
   cc = c.new(1,2)
   cc[:m1] = 3
-  cc[:m1] == 3
+  assert_equal 3, cc[:m1]
   cc["m2"] = 3
   assert_equal 3, cc["m2"]
   assert_raise(TypeError) { cc[[]] = 3 }
@@ -47,7 +49,7 @@ assert('Struct#each', '15.2.18.4.4') do
   cc.each{|x|
     a << x
   }
-  a[0] == 1 and a[1] == 2
+  assert_equal [1, 2], a
 end
 
 assert('Struct#each_pair', '15.2.18.4.5') do
@@ -57,19 +59,17 @@ assert('Struct#each_pair', '15.2.18.4.5') do
   cc.each_pair{|k,v|
     a << [k,v]
   }
-  a[0] == [:m1, 1] and a[1] == [:m2, 2]
+  assert_equal [[:m1, 1], [:m2, 2]], a
 end
 
 assert('Struct#members', '15.2.18.4.6') do
   c = Struct.new(:m1, :m2)
-  cc = c.new(1,2)
-  cc.members == [:m1,:m2]
+  assert_equal [:m1, :m2], c.new(1,2).members
 end
 
 assert('Struct#select', '15.2.18.4.7') do
   c = Struct.new(:m1, :m2)
-  cc = c.new(1,2)
-  cc.select{|v| v % 2 == 0} == [2]
+  assert_equal([2]) { c.new(1,2).select{|v| v % 2 == 0} }
 end
 
 assert('large struct') do

--- a/mrbgems/mruby-struct/test/struct.rb
+++ b/mrbgems/mruby-struct/test/struct.rb
@@ -30,6 +30,10 @@ assert('Struct#[]', '15.2.18.4.2') do
   cc = c.new(1,2)
   assert_equal 1, cc[:m1]
   assert_equal 2, cc["m2"]
+  assert_equal 1, cc[0]
+  assert_equal 2, cc[-1]
+  assert_raise(TypeError) { cc[[]] }
+  assert_raise(IndexError) { cc[2] }
 end
 
 assert('Struct#[]=', '15.2.18.4.3') do
@@ -39,7 +43,12 @@ assert('Struct#[]=', '15.2.18.4.3') do
   assert_equal 3, cc[:m1]
   cc["m2"] = 3
   assert_equal 3, cc["m2"]
+  cc[0] = 4
+  assert_equal 4, cc[0]
+  cc[-1] = 5
+  assert_equal 5, cc[-1]
   assert_raise(TypeError) { cc[[]] = 3 }
+  assert_raise(IndexError) { cc[2] = 7 }
 end
 
 assert('Struct#each', '15.2.18.4.4') do


### PR DESCRIPTION
* Use `assert_*` method in `Struct` test.
* Improve `Struct#[]` and `Struct#[]=` tests. Checks raised exceptions and negative value index.
* Optimization using `mrb_check_intern_str()` seems to conflict with `NameError` raising when it is implemented as how it's defined in specification.