### PR TITLE
Fix to not print unnecessary comma.

### DIFF
--- a/src/parse.y
+++ b/src/parse.y
@@ -5855,6 +5855,7 @@ mrb_parser_dump(mrb_state *mrb, node *tree, int offset)
     printf("NODE_SCOPE:\n");
     {
       node *n2 = tree->car;
+      mrb_bool first_lval = TRUE;
 
       if (n2  && (n2->car || n2->cdr)) {
         dump_prefix(offset+1);
@@ -5862,8 +5863,9 @@ mrb_parser_dump(mrb_state *mrb, node *tree, int offset)
         dump_prefix(offset+2);
         while (n2) {
           if (n2->car) {
-            if (n2 != tree->car) printf(", ");
+            if (!first_lval) printf(", ");
             printf("%s", mrb_sym2name(mrb, sym(n2->car)));
+            first_lval = FALSE;
           }
           n2 = n2->cdr;
         }
@@ -6240,6 +6242,7 @@ mrb_parser_dump(mrb_state *mrb, node *tree, int offset)
     tree = tree->cdr;
     {
       node *n2 = tree->car;
+      mrb_bool first_lval = TRUE;
 
       if (n2 && (n2->car || n2->cdr)) {
         dump_prefix(offset+1);
@@ -6247,8 +6250,9 @@ mrb_parser_dump(mrb_state *mrb, node *tree, int offset)
         dump_prefix(offset+2);
         while (n2) {
           if (n2->car) {
-            if (n2 != tree->car) printf(", ");
+            if (!first_lval) printf(", ");
             printf("%s", mrb_sym2name(mrb, sym(n2->car)));
+            first_lval = FALSE;
           }
           n2 = n2->cdr;
         }


### PR DESCRIPTION
When `n2->car` is 0 and `n2->cdd` is not 0,
unnecessary comma was printed before first local variables.
