### PR TITLE
Change to always use locals->car->car.

### DIFF
--- a/src/parse.y
+++ b/src/parse.y
@@ -257,7 +257,11 @@ local_var_p(parser_state *p, mrb_sym sym)
 static void
 local_add_f(parser_state *p, mrb_sym sym)
 {
-  p->locals->car = push(p->locals->car, nsym(sym));
+  if (p->locals->car && !p->locals->car->car) {
+    p->locals->car->car = nsym(sym);
+  } else {
+    p->locals->car = push(p->locals->car, nsym(sym));
+  }
 }
 
 static void


### PR DESCRIPTION
When p->locals->car is not NULL and p->locals->car->car is NULL,
local_add_f dose not append sym to p->locals->car->car.
This commit change to append sym to p->locals->car->car.
This will close #2333.
