### PR TITLE
Refactor mrb_utf8_strlen() in mruby-string-utf8

### DIFF
--- a/mrbgems/mruby-string-utf8/src/string.c
+++ b/mrbgems/mruby-string-utf8/src/string.c
@@ -127,9 +127,7 @@ mrb_utf8_strlen(mrb_value str, mrb_int len)
 static mrb_value
 mrb_str_size(mrb_state *mrb, mrb_value str)
 {
-  mrb_int size = mrb_utf8_strlen(str, -1);
-
-  return mrb_fixnum_value(size);
+  return mrb_fixnum_value(mrb_utf8_strlen(str, -1));
 }
 
 #define RSTRING_LEN_UTF8(s) mrb_utf8_strlen(s, -1)


### PR DESCRIPTION
It is unnecessary to assign value.
