### PR TITLE
Implement String#clear

### DIFF
--- a/src/string.c
+++ b/src/string.c
@@ -2542,6 +2542,37 @@ mrb_str_bytes(mrb_state *mrb, mrb_value str)
   return a;
 }
 
+static inline void
+str_discard(mrb_value str) {
+  struct RString *s = mrb_str_ptr(str);
+
+  if (!STR_SHARED_P(s) && !STR_EMBED_P(s)) {
+    RSTRING(str)->as.heap.ptr = 0;
+    RSTRING(str)->as.heap.len = 0;
+  }
+}
+
+/*
+ *  call-seq:
+ *     string.clear    ->  string
+ *
+ *  Makes string empty.
+ *
+ *     a = "abcde"
+ *     a.clear    #=> ""
+ */
+static mrb_value
+mrb_str_clear(mrb_state *mrb, mrb_value str)
+{
+  struct RString *s = mrb_str_ptr(str);
+
+  str_discard(str);
+  STR_SET_EMBED_FLAG(s);
+  STR_SET_EMBED_LEN(s, 0);
+  RSTRING_PTR(str)[0] = 0;
+  return str;
+}
+
 /* ---------------------------*/
 void
 mrb_init_string(mrb_state *mrb)
@@ -2593,4 +2624,5 @@ mrb_init_string(mrb_state *mrb)
   mrb_define_method(mrb, s, "upcase!",         mrb_str_upcase_bang,     MRB_ARGS_REQ(1)); /* 15.2.10.5.43 */
   mrb_define_method(mrb, s, "inspect",         mrb_str_inspect,         MRB_ARGS_NONE()); /* 15.2.10.5.46(x) */
   mrb_define_method(mrb, s, "bytes",           mrb_str_bytes,           MRB_ARGS_NONE());
+  mrb_define_method(mrb, s, "clear",           mrb_str_clear,           MRB_ARGS_NONE());
 }

--- a/test/t/string.rb
+++ b/test/t/string.rb
@@ -515,3 +515,9 @@ assert('String#each_byte') do
 
   assert_equal bytes1, bytes2
 end
+
+assert('String#clear') do
+  s = "foo" * 100
+  assert_equal("", s.clear)
+  assert_equal("", s)
+end


### PR DESCRIPTION
It is not ISO method but STR_SET_EMBED_FLAG and STR_SET_EMBED_LEN macros is defined in src/string.c.
I implement String#clear in src/string.c.
