### PR TITLE
Implement `Kernel#at_exit` and `Kernel.at_exit`.

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -173,7 +173,7 @@ typedef struct mrb_state {
 
   void *ud; /* auxiliary data */
 
-  mrb_atexit_func *atexit_stack;
+  mrb_value *atexit_stack;
   mrb_int atexit_stack_len;
 } mrb_state;
 
@@ -420,6 +420,7 @@ mrb_bool mrb_pool_can_realloc(struct mrb_pool*, void*, size_t);
 void* mrb_alloca(mrb_state *mrb, size_t);
 
 void mrb_atexit(mrb_state *mrb, mrb_atexit_func func);
+void mrb_atexit_proc(mrb_state *mrb, mrb_value proc);
 
 #ifdef MRB_DEBUG
 #include <assert.h>

--- a/mrbgems/mruby-kernel-ext/src/kernel.c
+++ b/mrbgems/mruby-kernel-ext/src/kernel.c
@@ -21,12 +21,42 @@ mrb_f_method(mrb_state *mrb, mrb_value self)
     return mrb_nil_value();
 }
 
+/*
+ *  call-seq:
+ *     at_exit { block } -> proc
+ *
+ *  Converts _block_ to a +Proc+ object (and therefore
+ *  binds it at the point of call) and registers it for execution when
+ *  the program exits. If multiple handlers are registered, they are
+ *  executed in reverse order of registration.
+ *
+ *     def do_at_exit(str1)
+ *       at_exit { print str1 }
+ *     end
+ *     at_exit { puts "cruel world" }
+ *     do_at_exit("goodbye ")
+ *     exit
+ *
+ *  <em>produces:</em>
+ *
+ *     goodbye cruel world
+ */
+static mrb_value
+mrb_f_at_exit(mrb_state *mrb, mrb_value self)
+{
+  mrb_value b;
+  mrb_get_args(mrb, "&", &b);
+  mrb_atexit_proc(mrb, b);
+  return b;
+}
+
 void
 mrb_mruby_kernel_ext_gem_init(mrb_state *mrb)
 {
   struct RClass *krn = mrb->kernel_module;
 
   mrb_define_module_function(mrb, krn, "fail", mrb_f_raise, MRB_ARGS_OPT(2));
+  mrb_define_module_function(mrb, krn, "at_exit", mrb_f_at_exit, MRB_ARGS_NONE() | MRB_ARGS_BLOCK());
   mrb_define_method(mrb, krn, "__method__", mrb_f_method, MRB_ARGS_NONE());
 }
 

--- a/mrbgems/mruby-kernel-ext/test/kernel.rb
+++ b/mrbgems/mruby-kernel-ext/test/kernel.rb
@@ -16,3 +16,10 @@ assert('Kernel#__method__') do
   assert_equal(:m1, c.new.m1)
   assert_equal(:m2, c.new.m2)
 end
+
+assert('Kernel#at_exit, Kernel.at_exit') do
+  assert_raise(ArgumentError) { at_exit(0) }
+  assert_raise(ArgumentError) { Kernel.at_exit(0) }
+  at_exit {}
+  Kernel.at_exit {}
+end

--- a/src/gc.c
+++ b/src/gc.c
@@ -715,6 +715,10 @@ root_scan_phase(mrb_state *mrb)
   if (mrb->root_c != mrb->c) {
     mark_context(mrb, mrb->c);
   }
+
+  for (i = 0, e = mrb->atexit_stack_len; i < e; ++i) {
+    mrb_gc_mark_value(mrb, mrb->atexit_stack[i]);
+  }
 }
 
 static size_t


### PR DESCRIPTION
`atexit_stack`'s type will be `mrb_value*` and it will be marked on `root_scan_phase()`.
