### PR TITLE
Remove redundant substitutions.

### DIFF
--- a/tasks/toolchains/gcc.rake
+++ b/tasks/toolchains/gcc.rake
@@ -2,7 +2,6 @@ MRuby::Toolchain.new(:gcc) do |conf|
   [conf.cc, conf.objc, conf.asm].each do |cc|
     cc.command = ENV['CC'] || 'gcc'
     cc.flags = [ENV['CFLAGS'] || %w(-g -std=gnu99 -O3 -Wall -Werror-implicit-function-declaration -Wdeclaration-after-statement)]
-    cc.include_paths = ["#{MRUBY_ROOT}/include"]
     cc.defines = %w(DISABLE_GEMS)
     cc.option_include_path = '-I%s'
     cc.option_define = '-D%s'
@@ -12,7 +11,6 @@ MRuby::Toolchain.new(:gcc) do |conf|
   [conf.cxx].each do |cxx|
     cxx.command = ENV['CXX'] || 'g++'
     cxx.flags = [ENV['CXXFLAGS'] || ENV['CFLAGS'] || %w(-g -O3 -Wall -Werror-implicit-function-declaration)]
-    cxx.include_paths = ["#{MRUBY_ROOT}/include"]
     cxx.defines = %w(DISABLE_GEMS)
     cxx.option_include_path = '-I%s'
     cxx.option_define = '-D%s'

--- a/tasks/toolchains/visualcpp.rake
+++ b/tasks/toolchains/visualcpp.rake
@@ -3,7 +3,6 @@ MRuby::Toolchain.new(:visualcpp) do |conf|
     cc.command = ENV['CC'] || 'cl.exe'
     # C4013: implicit function declaration
     cc.flags = [ENV['CFLAGS'] || %w(/c /nologo /W3 /we4013 /Zi /MD /O2 /D_CRT_SECURE_NO_WARNINGS)]
-    cc.include_paths = ["#{MRUBY_ROOT}/include"]
     cc.defines = %w(DISABLE_GEMS MRB_STACK_EXTEND_DOUBLING)
     cc.option_include_path = '/I%s'
     cc.option_define = '/D%s'
@@ -13,7 +12,6 @@ MRuby::Toolchain.new(:visualcpp) do |conf|
   [conf.cxx].each do |cxx|
     cxx.command = ENV['CXX'] || 'cl.exe'
     cxx.flags = [ENV['CXXFLAGS'] || ENV['CFLAGS'] || %w(/c /nologo /W3 /Zi /MD /O2 /EHsc /D_CRT_SECURE_NO_WARNINGS)]
-    cxx.include_paths = ["#{MRUBY_ROOT}/include"]
     cxx.defines = %w(DISABLE_GEMS MRB_STACK_EXTEND_DOUBLING)
     cxx.option_include_path = '/I%s'
     cxx.option_define = '/D%s'


### PR DESCRIPTION
"#{MRUBY_ROOT}/include" is set in Command::Compiler#initialize .
