### PR TITLE
Do not link bins with flags and libraries defined in other gems.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -59,12 +59,9 @@ MRuby.each_target do |target|
       objs = Dir.glob("#{current_dir}/tools/#{bin}/*.{c,cpp,cxx,cc}").map { |f| objfile(f.pathmap("#{current_build_dir}/tools/#{bin}/%n")) }
 
       file exec => objs + [libfile("#{build_dir}/lib/libmruby")] do |t|
-        gem_flags = gems.map { |g| g.linker.flags }
-        gem_flags_before_libraries = gems.map { |g| g.linker.flags_before_libraries }
-        gem_flags_after_libraries = gems.map { |g| g.linker.flags_after_libraries }
-        gem_libraries = gems.map { |g| g.linker.libraries }
-        gem_library_paths = gems.map { |g| g.linker.library_paths }
-        linker.run t.name, t.prerequisites, gem_libraries, gem_library_paths, gem_flags, gem_flags_before_libraries, gem_flags_after_libraries
+        l = gem.linker
+        linker.run t.name, t.prerequisites, l.libraries, l.library_paths,
+          l.flags, l.flags_before_libraries, l.flags_after_libraries
       end
 
       if target == MRuby.targets['host']


### PR DESCRIPTION
It may cause unexpected build failures without this patch.
Because other bin gems may set flags/libraries which are unsuitable to your bins.
