### PR TITLE
Revert "Fallback to `mrb_assert` instead of dirty trick."

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -432,7 +432,7 @@ void mrb_atexit(mrb_state *mrb, mrb_atexit_func func);
 #if __STDC_VERSION__ >= 201112L
 #define mrb_static_assert(exp, str) _Static_assert(exp, str)
 #else
-#define mrb_static_assert(exp, str) mrb_assert(exp)
+#define mrb_static_assert(exp, str) typedef char mrb_static_assert ## __LINE__[exp]
 #endif
 
 mrb_value mrb_format(mrb_state *mrb, const char *format, ...);


### PR DESCRIPTION
This reverts commit 4de468e75414eb1adb3bafba19b72caba3a17044.

mrb_assert() may not compatible with mrb_static_assert().

You can use mrb_static_assert() (strictly _Static_assert())
in out of functions.
mrb_assert() (possibly assert()) can use only in functions.
