### PR TITLE
Build sources in {GEM}/tools/{BIN_NAME}/ with the configuration for {GEM}.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -56,9 +56,8 @@ MRuby.each_target do |target|
 
     gem.bins.each do |bin|
       exec = exefile("#{build_dir}/bin/#{bin}")
-      objs = Dir.glob("#{current_dir}/tools/#{bin}/*.{c,cpp,cxx,cc}").map { |f| objfile(f.pathmap("#{current_build_dir}/tools/#{bin}/%n")) }
 
-      file exec => objs + [libfile("#{build_dir}/lib/libmruby")] do |t|
+      file exec => gem.bin_objs[bin] + [libfile("#{build_dir}/lib/libmruby")] do |t|
         gem_flags = gems.map { |g| g.linker.flags }
         gem_flags_before_libraries = gems.map { |g| g.linker.flags_before_libraries }
         gem_flags_after_libraries = gems.map { |g| g.linker.flags_after_libraries }

--- a/tasks/mrbgem_spec.rake
+++ b/tasks/mrbgem_spec.rake
@@ -28,6 +28,7 @@ module MRuby
       attr_accessor :rbfiles, :objs
       attr_accessor :test_objs, :test_rbfiles, :test_args
       attr_accessor :test_preload
+      attr_reader :bin_objs
 
       attr_accessor :bins
 
@@ -90,6 +91,14 @@ module MRuby
           compiler.define_rules build_dir, "#{dir}"
           compiler.defines << %Q[MRBGEM_#{funcname.upcase}_VERSION=#{version}]
           compiler.include_paths << "#{dir}/include" if File.directory? "#{dir}/include"
+        end
+
+	# This need to be evaluted after initializers.
+	@bin_objs = {}
+        @bins.each do |bin|
+          @bin_objs[bin] = Dir.glob("#{dir}/tools/#{bin}/*.{c,cpp,cxx,cc,m,asm,s,S}").map do |f|
+            objfile(f.relative_path_from(dir).to_s.pathmap("#{build_dir}/%X"))
+          end
         end
 
         define_gem_init_builder


### PR DESCRIPTION
After applied this fix, build options defined gems are passed to sources in tools/.
This will make binaries more configurable.
