### PR TITLE
Implement `add_conflicts`. Solve #2383.

### DIFF
--- a/tasks/mrbgem_spec.rake
+++ b/tasks/mrbgem_spec.rake
@@ -103,7 +103,11 @@ module MRuby
       end
 
       def add_conflicts(*names)
-        @conflicts += names
+        @conflicts += names.map { |n| {:gem => n} }
+      end
+
+      def add_conflict(name, *req)
+        @conflicts << {:gem => name, :requirements => req.empty? ? nil : req}
       end
 
       def self.bin=(bin)
@@ -328,7 +332,10 @@ module MRuby
             end
           end
 
-          cfls = g.conflicts.select { |c| gem_table.key? c }
+          cfls = g.conflicts.select { |c|
+            cfl_g = gem_table[c[:gem]]
+            cfl_g and cfl_g.version_ok?(c[:requirements] || ['>= 0.0.0'])
+          }.map { |c| "#{c[:gem]}(#{gem_table[c[:gem]].version})" }
           fail "Conflicts of gem `#{g.name}` found: #{cfls.join ', '}" unless cfls.empty?
         end
 


### PR DESCRIPTION
Usage:

``` ruby
spec.add_conflicts 'mruby-gem-x', 'mruby-gem-y'
```

Format of `@conflicts` instance variable is array of conflicting mrbgem name.
I've tried `add_conflict` method that could take version requirements as rest arguments.
Though it was same as `add_dependency` so I didn't included it to this patch.
