### PR TITLE
Add fixed state atexit stack feature.

### DIFF
--- a/include/mrbconf.h
+++ b/include/mrbconf.h
@@ -59,6 +59,12 @@
 /* fixed size GC arena */
 //#define MRB_GC_FIXED_ARENA
 
+/* state atexit stack size */
+//#define MRB_FIXED_STATE_ATEXIT_STACK_SIZE 5
+
+/* fixed size state atexit stack */
+//#define MRB_FIXED_STATE_ATEXIT_STACK
+
 /* -DDISABLE_XXXX to drop following features */
 //#define DISABLE_STDIO		/* use of stdio */
 

--- a/include/mruby.h
+++ b/include/mruby.h
@@ -52,6 +52,10 @@ typedef void* (*mrb_allocf) (struct mrb_state *mrb, void*, size_t, void *ud);
 #define MRB_GC_ARENA_SIZE 100
 #endif
 
+#ifndef MRB_FIXED_STATE_ATEXIT_STACK_SIZE
+#define MRB_FIXED_STATE_ATEXIT_STACK_SIZE 5
+#endif
+
 typedef struct {
   mrb_sym mid;
   struct RProc *proc;
@@ -173,7 +177,11 @@ typedef struct mrb_state {
 
   void *ud; /* auxiliary data */
 
+#ifdef MRB_FIXED_STATE_ATEXIT_STACK
+  mrb_atexit_func atexit_stack[MRB_FIXED_STATE_ATEXIT_STACK_SIZE];
+#else
   mrb_atexit_func *atexit_stack;
+#endif
   mrb_int atexit_stack_len;
 } mrb_state;
 


### PR DESCRIPTION
Adds following macros:
- MRB_FIXED_STATE_ATEXIT_STACK (not defined by default)
  - When defined enables fixed state atexit stack.
- MRB_FIXED_STATE_ATEXIT_STACK_SIZE (default value: 5)
  - This macro will be ignored when `MRB_FIXED_STATE_ATEXIT_STACK` isn't defined.
  - When `mrb_state_atexit` is called more than this value it will raise runtime error.
