### PR TITLE
Adapt a behavior of String#slice! to other Ruby implementations

### DIFF
--- a/mrbgems/mruby-string-ext/mrblib/string.rb
+++ b/mrbgems/mruby-string-ext/mrblib/string.rb
@@ -169,7 +169,7 @@ class String
     if arg1 != nil && arg2 != nil
       idx = arg1
       idx += self.size if arg1 < 0
-      if idx >= 0 && idx < self.size && arg2 > 0
+      if idx >= 0 && idx <= self.size && arg2 > 0
         str = self[idx, arg2]
       else
         return nil

--- a/mrbgems/mruby-string-ext/test/string.rb
+++ b/mrbgems/mruby-string-ext/test/string.rb
@@ -218,7 +218,7 @@ assert('String#slice!') do
   assert_equal "Foo", a
 
   a = "FooBar"
-  assert_nil a.slice!(6, 2)
+  assert_equal "", a.slice!(6, 2)
   assert_equal "FooBar", a
 
   a = "FooBar"


### PR DESCRIPTION
Currently,  `String#slice!` returns `nil` value  when index (1st arg) equals self.size.

```
$ bin/mruby -e "p 'foo'.slice!(3,1)"
nil
```

But other Ruby implementations (such as CRuby, JRuby) return "" (null character).

```
$ ruby -e "p 'foo'.slice!(3,1)"
""
```
