### PR TITLE
Not create local variables in scope_new

### DIFF
--- a/src/parse.y
+++ b/src/parse.y
@@ -2438,12 +2438,10 @@ opt_block_param : none
 
 block_param_def : '|' opt_bv_decl '|'
                     {
-                      local_add_f(p, 0);
                       $$ = 0;
                     }
                 | tOROP
                     {
-                      local_add_f(p, 0);
                       $$ = 0;
                     }
                 | '|' block_param opt_bv_decl '|'


### PR DESCRIPTION
Reduce malloc for lv like that syntax.

``` ruby
# '|' opt_bv_decl '|'
3.times do|
|end
# tOROP
Proc.new{||}
```

And it can help to notice which OP_ENTER was run or not because irep->lv == 0.
