### PR TITLE
Fix crash in method call in `ObjectSpace.each_object` block.

### DIFF
--- a/mrbgems/mruby-objectspace/src/mruby_objectspace.c
+++ b/mrbgems/mruby-objectspace/src/mruby_objectspace.c
@@ -119,6 +119,13 @@ os_each_object_cb(mrb_state *mrb, struct RBasic *obj, void *ud)
     return;
   }
 
+  /* filter internal objects */
+  switch (obj->tt) {
+  case MRB_TT_ENV:
+  case MRB_TT_ICLASS:
+    return;
+  }
+
   /* filter class kind if target module defined */
   if (d->target_module && !mrb_obj_is_kind_of(mrb, mrb_obj_value(obj), d->target_module)) {
     return;

--- a/mrbgems/mruby-objectspace/test/objectspace.rb
+++ b/mrbgems/mruby-objectspace/test/objectspace.rb
@@ -54,3 +54,7 @@ assert('ObjectSpace.each_object') do
   assert_equal arys.length, arys_count
   assert_true arys.length < objs.length
 end
+
+assert 'Check class pointer of ObjectSpace.each_object.' do
+  ObjectSpace.each_object { |obj| !obj }
+end

--- a/src/error.c
+++ b/src/error.c
@@ -91,14 +91,9 @@ static mrb_value
 exc_to_s(mrb_state *mrb, mrb_value exc)
 {
   mrb_value mesg = mrb_attr_get(mrb, exc, mrb_intern_lit(mrb, "mesg"));
-  struct RObject *p;
 
   if (!mrb_string_p(mesg)) {
     return mrb_str_new_cstr(mrb, mrb_obj_classname(mrb, exc));
-  }
-  p = mrb_obj_ptr(mesg);
-  if (!p->c) {
-    p->c = mrb->string_class;
   }
   return mesg;
 }
@@ -440,6 +435,9 @@ void
 mrb_init_exception(mrb_state *mrb)
 {
   struct RClass *exception, *runtime_error, *script_error;
+
+  /* initialize mrb->string_class before creating RString object for nomem_err */
+  mrb->string_class = mrb_define_class(mrb, "String", mrb->object_class);
 
   mrb->eException_class = exception = mrb_define_class(mrb, "Exception", mrb->object_class); /* 15.2.22 */
   mrb_define_class_method(mrb, exception, "exception", mrb_instance_new,  MRB_ARGS_ANY());


### PR DESCRIPTION
- Filter `MRB_TT_ENV` and `MRB_TT_ICLASS` since it's internal object.
- Set `mrb->string_class` in `mrb_init_exception` instead.
  - Since https://github.com/mruby/mruby/commit/919af61766b1d06cd0e747c1d6257ada14c09eff isn't enough in this case.
