### PR TITLE
Reduce warning for enumeration

### DIFF
--- a/mrbgems/mruby-objectspace/src/mruby_objectspace.c
+++ b/mrbgems/mruby-objectspace/src/mruby_objectspace.c
@@ -124,6 +124,8 @@ os_each_object_cb(mrb_state *mrb, struct RBasic *obj, void *ud)
   case MRB_TT_ENV:
   case MRB_TT_ICLASS:
     return;
+  default:
+    break;
   }
 
   /* filter half baked (or internal) objects */


### PR DESCRIPTION
22 enumeration values not handled in switch: 'MRB_TT_FALSE',
'MRB_TT_FREE', 'MRB_TT_TRUE'... [-Wswitch]
