### PR TITLE
Ensure RVALUE is large enough for word boxing types.

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -107,6 +107,10 @@ typedef struct {
     struct RRange range;
     struct RData data;
     struct RProc proc;
+#ifdef MRB_WORD_BOXING
+    struct RFloat floatv;
+    struct RCptr cptr;
+#endif
   } as;
 } RVALUE;
 


### PR DESCRIPTION
It's possible a future change would make RVALUE shorter than the word boxing objects.
