### PR TITLE
Always return non-NULL in `mrb_hash_tbl`.

### DIFF
--- a/src/hash.c
+++ b/src/hash.c
@@ -265,7 +265,7 @@ mrb_hash_tbl(mrb_state *mrb, mrb_value hash)
   khash_t(ht) *h = RHASH_TBL(hash);
 
   if (!h) {
-    RHASH_TBL(hash) = kh_init(ht, mrb);
+    return RHASH_TBL(hash) = kh_init(ht, mrb);
   }
   return h;
 }


### PR DESCRIPTION
Currently when `RHASH_TBL(hash)` isn't initialized `mrb_hash_tbl` returns `NULL`.
