### PR TITLE
Clean up value.h and mrb_value boxing

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -325,11 +325,11 @@ int mrb_gc_arena_save(mrb_state*);
 void mrb_gc_arena_restore(mrb_state*,int);
 void mrb_gc_mark(mrb_state*,struct RBasic*);
 #define mrb_gc_mark_value(mrb,val) do {\
-  if (MRB_TT_HAS_BASIC_P(mrb_type(val))) mrb_gc_mark((mrb), mrb_basic_ptr(val)); \
+  if (!mrb_immediate_p(val)) mrb_gc_mark((mrb), mrb_basic_ptr(val)); \
 } while (0)
 void mrb_field_write_barrier(mrb_state *, struct RBasic*, struct RBasic*);
 #define mrb_field_write_barrier_value(mrb, obj, val) do{\
-  if (MRB_TT_HAS_BASIC_P(mrb_type(val))) mrb_field_write_barrier((mrb), (obj), mrb_basic_ptr(val)); \
+  if (!mrb_immediate_p(val)) mrb_field_write_barrier((mrb), (obj), mrb_basic_ptr(val)); \
 } while (0)
 void mrb_write_barrier(mrb_state *, struct RBasic*);
 

--- a/include/mruby/boxing_nan.h
+++ b/include/mruby/boxing_nan.h
@@ -1,0 +1,94 @@
+/*
+** mruby/boxing_nan.h - nan boxing mrb_value definition
+**
+** See Copyright Notice in mruby.h
+*/
+
+#ifndef MRUBY_BOXING_NAN_H
+#define MRUBY_BOXING_NAN_H
+
+#ifdef MRB_USE_FLOAT
+# error ---->> MRB_NAN_BOXING and MRB_USE_FLOAT conflict <<----
+#endif
+
+#ifdef MRB_INT64
+# error ---->> MRB_NAN_BOXING and MRB_INT64 conflict <<----
+#endif
+
+#define MRB_FIXNUM_SHIFT 0
+#define MRB_TT_HAS_BASIC MRB_TT_OBJECT
+
+#ifdef MRB_ENDIAN_BIG
+#define MRB_ENDIAN_LOHI(a,b) a b
+#else
+#define MRB_ENDIAN_LOHI(a,b) b a
+#endif
+
+/* value representation by nan-boxing:
+ *   float : FFFFFFFFFFFFFFFF FFFFFFFFFFFFFFFF FFFFFFFFFFFFFFFF FFFFFFFFFFFFFFFF
+ *   object: 111111111111TTTT TTPPPPPPPPPPPPPP PPPPPPPPPPPPPPPP PPPPPPPPPPPPPPPP
+ *   int   : 1111111111110001 0000000000000000 IIIIIIIIIIIIIIII IIIIIIIIIIIIIIII
+ *   sym   : 1111111111110001 0100000000000000 SSSSSSSSSSSSSSSS SSSSSSSSSSSSSSSS
+ * In order to get enough bit size to save TT, all pointers are shifted 2 bits
+ * in the right direction. Also, TTTTTT is the mrb_vtype + 1;
+ */
+typedef struct mrb_value {
+  union {
+    mrb_float f;
+    union {
+      void *p;
+      struct {
+        MRB_ENDIAN_LOHI(
+          uint32_t ttt;
+          ,union {
+            mrb_int i;
+            mrb_sym sym;
+          };
+        )
+      };
+    } value;
+  };
+} mrb_value;
+
+#define mrb_float_pool(mrb,f) mrb_float_value(mrb,f)
+
+#define mrb_tt(o)       ((enum mrb_vtype)(((o).value.ttt & 0xfc000)>>14)-1)
+#define mrb_type(o)     ((uint32_t)0xfff00000 < (o).value.ttt ? mrb_tt(o) : MRB_TT_FLOAT)
+#define mrb_ptr(o)      ((void*)((((uintptr_t)0x3fffffffffff)&((uintptr_t)((o).value.p)))<<2))
+#define mrb_float(o)    (o).f
+#define mrb_cptr(o)     mrb_ptr(o)
+#define mrb_fixnum(o)   (o).value.i
+#define mrb_symbol(o)   (o).value.sym
+
+#define BOXNAN_SET_VALUE(o, tt, attr, v) do {\
+  (o).value.ttt = (0xfff00000|(((tt)+1)<<14));\
+  switch (tt) {\
+  case MRB_TT_FALSE:\
+  case MRB_TT_TRUE:\
+  case MRB_TT_UNDEF:\
+  case MRB_TT_FIXNUM:\
+  case MRB_TT_SYMBOL: (o).attr = (v); break;\
+  default: (o).value.i = 0; (o).value.p = (void*)((uintptr_t)(o).value.p | (((uintptr_t)(v))>>2)); break;\
+  }\
+} while (0)
+
+#define SET_FLOAT_VALUE(mrb,r,v) do { \
+  if (v != v) { \
+    (r).value.ttt = 0x7ff80000; \
+    (r).value.i = 0; \
+  } else { \
+    (r).f = v; \
+  }} while(0)
+
+#define SET_NIL_VALUE(r) BOXNAN_SET_VALUE(r, MRB_TT_FALSE, value.i, 0)
+#define SET_FALSE_VALUE(r) BOXNAN_SET_VALUE(r, MRB_TT_FALSE, value.i, 1)
+#define SET_TRUE_VALUE(r) BOXNAN_SET_VALUE(r, MRB_TT_TRUE, value.i, 1)
+#define SET_BOOL_VALUE(r,b) BOXNAN_SET_VALUE(r, b ? MRB_TT_TRUE : MRB_TT_FALSE, value.i, 1)
+#define SET_FIXNUM_VALUE(r,n) BOXNAN_SET_VALUE(r, MRB_TT_FIXNUM, value.i, (n))
+#define SET_SYM_VALUE(r,v) BOXNAN_SET_VALUE(r, MRB_TT_SYMBOL, value.sym, (v))
+#define SET_OBJ_VALUE(r,v) BOXNAN_SET_VALUE(r, (((struct RObject*)(v))->tt), value.p, (v))
+#define SET_PROC_VALUE(r,v) BOXNAN_SET_VALUE(r, MRB_TT_PROC, value.p, v)
+#define SET_CPTR_VALUE(mrb,r,v) BOXNAN_SET_VALUE(r, MRB_TT_CPTR, value.p, v)
+#define SET_UNDEF_VALUE(r) BOXNAN_SET_VALUE(r, MRB_TT_UNDEF, value.i, 0)
+
+#endif  /* MRUBY_BOXING_NAN_H */

--- a/include/mruby/boxing_nix.h
+++ b/include/mruby/boxing_nix.h
@@ -1,0 +1,49 @@
+/*
+** mruby/boxing_nix.h - unboxed mrb_value definition
+**
+** See Copyright Notice in mruby.h
+*/
+
+#ifndef MRUBY_BOXING_NIX_H
+#define MRUBY_BOXING_NIX_H
+
+#define MRB_FIXNUM_SHIFT 0
+#define MRB_TT_HAS_BASIC MRB_TT_OBJECT
+
+typedef struct mrb_value {
+  union {
+    mrb_float f;
+    void *p;
+    mrb_int i;
+    mrb_sym sym;
+  } value;
+  enum mrb_vtype tt;
+} mrb_value;
+
+#define mrb_float_pool(mrb,f) mrb_float_value(mrb,f)
+
+#define mrb_ptr(o)      (o).value.p
+#define mrb_cptr(o)     mrb_ptr(o)
+#define mrb_float(o)    (o).value.f
+#define mrb_fixnum(o)   (o).value.i
+#define mrb_symbol(o)   (o).value.sym
+#define mrb_type(o)     (o).tt
+
+#define BOXNIX_SET_VALUE(o, ttt, attr, v) do {\
+  (o).tt = ttt;\
+  (o).attr = v;\
+} while (0)
+
+#define SET_NIL_VALUE(r) BOXNIX_SET_VALUE(r, MRB_TT_FALSE, value.i, 0)
+#define SET_FALSE_VALUE(r) BOXNIX_SET_VALUE(r, MRB_TT_FALSE, value.i, 1)
+#define SET_TRUE_VALUE(r) BOXNIX_SET_VALUE(r, MRB_TT_TRUE, value.i, 1)
+#define SET_BOOL_VALUE(r,b) BOXNIX_SET_VALUE(r, b ? MRB_TT_TRUE : MRB_TT_FALSE, value.i, 1)
+#define SET_FIXNUM_VALUE(r,n) BOXNIX_SET_VALUE(r, MRB_TT_FIXNUM, value.i, (n))
+#define SET_FLOAT_VALUE(mrb,r,v) BOXNIX_SET_VALUE(r, MRB_TT_FLOAT, value.f, (v))
+#define SET_SYM_VALUE(r,v) BOXNIX_SET_VALUE(r, MRB_TT_SYMBOL, value.sym, (v))
+#define SET_OBJ_VALUE(r,v) BOXNIX_SET_VALUE(r, (((struct RObject*)(v))->tt), value.p, (v))
+#define SET_PROC_VALUE(r,v) BOXNIX_SET_VALUE(r, MRB_TT_PROC, value.p, v)
+#define SET_CPTR_VALUE(mrb,r,v) BOXNIX_SET_VALUE(r, MRB_TT_CPTR, value.p, v)
+#define SET_UNDEF_VALUE(r) BOXNIX_SET_VALUE(r, MRB_TT_UNDEF, value.i, 0)
+
+#endif  /* MRUBY_BOXING_NIX_H */

--- a/include/mruby/boxing_word.h
+++ b/include/mruby/boxing_word.h
@@ -1,0 +1,109 @@
+/*
+** mruby/boxing_word.h - word boxing mrb_value definition
+**
+** See Copyright Notice in mruby.h
+*/
+
+#ifndef MRUBY_BOXING_WORD_H
+#define MRUBY_BOXING_WORD_H
+
+#if defined(MRB_INT16)
+# error MRB_INT16 is too small for MRB_WORD_BOXING.
+#endif
+
+#define MRB_FIXNUM_SHIFT 1
+#define MRB_TT_HAS_BASIC MRB_TT_FLOAT
+
+enum mrb_special_consts {
+  MRB_Qnil    = 0,
+  MRB_Qfalse  = 2,
+  MRB_Qtrue   = 4,
+  MRB_Qundef  = 6,
+};
+
+#define MRB_FIXNUM_FLAG   0x01
+#define MRB_SYMBOL_FLAG   0x0e
+#define MRB_SPECIAL_SHIFT 8
+
+typedef union mrb_value {
+  union {
+    void *p;
+    struct {
+      unsigned int i_flag : MRB_FIXNUM_SHIFT;
+      mrb_int i : (MRB_INT_BIT - MRB_FIXNUM_SHIFT);
+    };
+    struct {
+      unsigned int sym_flag : MRB_SPECIAL_SHIFT;
+      int sym : (sizeof(mrb_sym) * CHAR_BIT);
+    };
+    struct RBasic *bp;
+    struct RFloat *fp;
+    struct RCptr *vp;
+  } value;
+  unsigned long w;
+} mrb_value;
+
+mrb_value word_boxing_mrb_cptr_value(struct mrb_state*, void*);
+mrb_value word_boxing_mrb_float_value(struct mrb_state*, mrb_float);
+mrb_value word_boxing_mrb_float_pool(struct mrb_state*, mrb_float);
+
+#define mrb_float_pool(mrb,f) word_boxing_mrb_float_pool(mrb,f)
+
+#define mrb_ptr(o)     (o).value.p
+#define mrb_cptr(o)    (o).value.vp->p
+#define mrb_float(o)   (o).value.fp->f
+#define mrb_fixnum(o)  (o).value.i
+#define mrb_symbol(o)  (o).value.sym
+
+static inline enum mrb_vtype
+mrb_type(mrb_value o)
+{
+  switch (o.w) {
+  case MRB_Qfalse:
+  case MRB_Qnil:
+    return MRB_TT_FALSE;
+  case MRB_Qtrue:
+    return MRB_TT_TRUE;
+  case MRB_Qundef:
+    return MRB_TT_UNDEF;
+  }
+  if (o.value.i_flag == MRB_FIXNUM_FLAG) {
+    return MRB_TT_FIXNUM;
+  }
+  if (o.value.sym_flag == MRB_SYMBOL_FLAG) {
+    return MRB_TT_SYMBOL;
+  }
+  return o.value.bp->tt;
+}
+
+#define mrb_bool(o)    ((o).w != MRB_Qnil && (o).w != MRB_Qfalse)
+#define mrb_fixnum_p(o) ((o).value.i_flag == MRB_FIXNUM_FLAG)
+#define mrb_undef_p(o) ((o).w == MRB_Qundef)
+#define mrb_nil_p(o)  ((o).w == MRB_Qnil)
+
+#define BOXWORD_SET_VALUE(o, ttt, attr, v) do {\
+  (o).w = 0;\
+  (o).attr = (v);\
+  switch (ttt) {\
+  case MRB_TT_FALSE:  (o).w = (v) ? MRB_Qfalse : MRB_Qnil; break;\
+  case MRB_TT_TRUE:   (o).w = MRB_Qtrue; break;\
+  case MRB_TT_UNDEF:  (o).w = MRB_Qundef; break;\
+  case MRB_TT_FIXNUM: (o).value.i_flag = MRB_FIXNUM_FLAG; break;\
+  case MRB_TT_SYMBOL: (o).value.sym_flag = MRB_SYMBOL_FLAG; break;\
+  default:            if ((o).value.bp) (o).value.bp->tt = ttt; break;\
+  }\
+} while (0)
+
+#define SET_FLOAT_VALUE(mrb,r,v) r = word_boxing_mrb_float_value(mrb, v)
+#define SET_CPTR_VALUE(mrb,r,v) r = word_boxing_mrb_cptr_value(mrb, v)
+#define SET_NIL_VALUE(r) BOXWORD_SET_VALUE(r, MRB_TT_FALSE, value.i, 0)
+#define SET_FALSE_VALUE(r) BOXWORD_SET_VALUE(r, MRB_TT_FALSE, value.i, 1)
+#define SET_TRUE_VALUE(r) BOXWORD_SET_VALUE(r, MRB_TT_TRUE, value.i, 1)
+#define SET_BOOL_VALUE(r,b) BOXWORD_SET_VALUE(r, b ? MRB_TT_TRUE : MRB_TT_FALSE, value.i, 1)
+#define SET_FIXNUM_VALUE(r,n) BOXWORD_SET_VALUE(r, MRB_TT_FIXNUM, value.i, (n))
+#define SET_SYM_VALUE(r,v) BOXWORD_SET_VALUE(r, MRB_TT_SYMBOL, value.sym, (v))
+#define SET_OBJ_VALUE(r,v) BOXWORD_SET_VALUE(r, (((struct RObject*)(v))->tt), value.p, (v))
+#define SET_PROC_VALUE(r,v) BOXWORD_SET_VALUE(r, MRB_TT_PROC, value.p, v)
+#define SET_UNDEF_VALUE(r) BOXWORD_SET_VALUE(r, MRB_TT_UNDEF, value.i, 0)
+
+#endif  /* MRUBY_BOXING_WORD_H */

--- a/include/mruby/class.h
+++ b/include/mruby/class.h
@@ -28,7 +28,7 @@ mrb_class(mrb_state *mrb, mrb_value v)
 {
   switch (mrb_type(v)) {
   case MRB_TT_FALSE:
-    if (v.value.i)
+    if (mrb_fixnum(v))
       return mrb->false_class;
     return mrb->nil_class;
   case MRB_TT_TRUE:

--- a/include/mruby/object.h
+++ b/include/mruby/object.h
@@ -1,0 +1,68 @@
+/*
+** mruby/object.h - mruby object definition
+**
+** See Copyright Notice in mruby.h
+*/
+
+#ifndef MRUBY_OBJECT_H
+#define MRUBY_OBJECT_H
+
+#define MRB_OBJECT_HEADER \
+  enum mrb_vtype tt:8;\
+  uint32_t color:3;\
+  uint32_t flags:21;\
+  struct RClass *c;\
+  struct RBasic *gcnext
+
+/* white: 011, black: 100, gray: 000 */
+#define MRB_GC_GRAY 0
+#define MRB_GC_WHITE_A 1
+#define MRB_GC_WHITE_B (1 << 1)
+#define MRB_GC_BLACK (1 << 2)
+#define MRB_GC_WHITES (MRB_GC_WHITE_A | MRB_GC_WHITE_B)
+#define MRB_GC_COLOR_MASK 7
+
+#define paint_gray(o) ((o)->color = MRB_GC_GRAY)
+#define paint_black(o) ((o)->color = MRB_GC_BLACK)
+#define paint_white(o) ((o)->color = MRB_GC_WHITES)
+#define paint_partial_white(s, o) ((o)->color = (s)->current_white_part)
+#define is_gray(o) ((o)->color == MRB_GC_GRAY)
+#define is_white(o) ((o)->color & MRB_GC_WHITES)
+#define is_black(o) ((o)->color & MRB_GC_BLACK)
+#define is_dead(s, o) (((o)->color & other_white_part(s) & MRB_GC_WHITES) || (o)->tt == MRB_TT_FREE)
+#define flip_white_part(s) ((s)->current_white_part = other_white_part(s))
+#define other_white_part(s) ((s)->current_white_part ^ MRB_GC_WHITES)
+
+struct RBasic {
+  MRB_OBJECT_HEADER;
+};
+#define mrb_basic_ptr(v) ((struct RBasic*)(mrb_ptr(v)))
+/* obsolete macro mrb_basic; will be removed soon */
+#define mrb_basic(v)     mrb_basic_ptr(v)
+
+struct RObject {
+  MRB_OBJECT_HEADER;
+  struct iv_tbl *iv;
+};
+#define mrb_obj_ptr(v)   ((struct RObject*)(mrb_ptr(v)))
+/* obsolete macro mrb_object; will be removed soon */
+#define mrb_object(o) mrb_obj_ptr(o)
+#define mrb_immediate_p(x) (mrb_type(x) < MRB_TT_HAS_BASIC)
+#define mrb_special_const_p(x) mrb_immediate_p(x)
+
+struct RFiber {
+  MRB_OBJECT_HEADER;
+  struct mrb_context *cxt;
+};
+
+struct RFloat {
+  MRB_OBJECT_HEADER;
+  mrb_float f;
+};
+
+struct RCptr {
+  MRB_OBJECT_HEADER;
+  void *p;
+};
+
+#endif  /* MRUBY_OBJECT_H */

--- a/include/mruby/value.h
+++ b/include/mruby/value.h
@@ -1,5 +1,5 @@
 /*
-** mruby/value.h - mrb_value definition
+** mruby/value.h - mruby value definitions
 **
 ** See Copyright Notice in mruby.h
 */
@@ -7,6 +7,31 @@
 #ifndef MRUBY_VALUE_H
 #define MRUBY_VALUE_H
 
+typedef short mrb_sym;
+typedef uint8_t mrb_bool;
+struct mrb_state;
+
+#if defined(MRB_INT16) && defined(MRB_INT64)
+# error "You can't define MRB_INT16 and MRB_INT64 at the same time."
+#endif
+
+#if defined(MRB_INT64)
+  typedef int64_t mrb_int;
+# define MRB_INT_BIT 64
+# define MRB_INT_MIN (INT64_MIN>>MRB_FIXNUM_SHIFT)
+# define MRB_INT_MAX (INT64_MAX>>MRB_FIXNUM_SHIFT)
+#elif defined(MRB_INT16)
+  typedef int16_t mrb_int;
+# define MRB_INT_BIT 16
+# define MRB_INT_MIN (INT16_MIN>>MRB_FIXNUM_SHIFT)
+# define MRB_INT_MAX )INT16_MAX>>MRB_FIXNUM_SHIFT)
+#else
+  typedef int32_t mrb_int;
+# define MRB_INT_BIT 32
+# define MRB_INT_MIN (INT32_MIN>>MRB_FIXNUM_SHIFT)
+# define MRB_INT_MAX (INT32_MAX>>MRB_FIXNUM_SHIFT)
+#endif
+  
 #ifdef MRB_USE_FLOAT
   typedef float mrb_float;
 # define mrb_float_to_str(buf, i) sprintf(buf, "%.7e", i)
@@ -16,55 +41,6 @@
 # define mrb_float_to_str(buf, i) sprintf(buf, "%.16e", i)
 # define str_to_mrb_float(buf) strtod(buf, NULL)
 #endif
-
-#if defined(MRB_INT16) && defined(MRB_INT64)
-# error "You can't define MRB_INT16 and MRB_INT64 at the same time."
-#endif
-
-#if defined(MRB_INT64)
-# ifdef MRB_NAN_BOXING
-#  error Cannot use NaN boxing when mrb_int is 64bit
-# else
-   typedef int64_t mrb_int;
-#  define MRB_INT_BIT 64
-#  ifdef MRB_WORD_BOXING
-#   define MRB_INT_MIN (INT64_MIN>>MRB_FIXNUM_SHIFT)
-#   define MRB_INT_MAX (INT64_MAX>>MRB_FIXNUM_SHIFT)
-#  else
-#   define MRB_INT_MIN INT64_MIN
-#   define MRB_INT_MAX INT64_MAX
-#  endif
-#  define PRIdMRB_INT PRId64
-#  define PRIiMRB_INT PRIi64
-#  define PRIoMRB_INT PRIo64
-#  define PRIxMRB_INT PRIx64
-#  define PRIXMRB_INT PRIX64
-# endif
-#elif defined(MRB_INT16)
-# ifdef MRB_WORD_BOXING
-# error "MRB_INT16 is too small for MRB_WORD_BOXING."
-# endif
-  typedef int16_t mrb_int;
-# define MRB_INT_BIT 16
-# define MRB_INT_MIN INT16_MIN
-# define MRB_INT_MAX INT16_MAX
-#else
-  typedef int32_t mrb_int;
-# define MRB_INT_BIT 32
-# ifdef MRB_WORD_BOXING
-#  define MRB_INT_MIN (INT32_MIN>>MRB_FIXNUM_SHIFT)
-#  define MRB_INT_MAX (INT32_MAX>>MRB_FIXNUM_SHIFT)
-# else
-#  define MRB_INT_MIN INT32_MIN
-#  define MRB_INT_MAX INT32_MAX
-# endif
-# define PRIdMRB_INT PRId32
-# define PRIiMRB_INT PRIi32
-# define PRIoMRB_INT PRIo32
-# define PRIxMRB_INT PRIx32
-# define PRIXMRB_INT PRIX32
-#endif
-typedef short mrb_sym;
 
 #ifdef _MSC_VER
 # ifndef __cplusplus
@@ -81,16 +57,6 @@ typedef short mrb_sym;
 #  define signbit(n) (_copysign(1.0, (n)) < 0.0)
 #  define strtoll _strtoi64
 #  define strtof (float)strtod
-#  define PRId32 "I32d"
-#  define PRIi32 "I32i"
-#  define PRIo32 "I32o"
-#  define PRIx32 "I32x"
-#  define PRIX32 "I32X"
-#  define PRId64 "I64d"
-#  define PRIi64 "I64i"
-#  define PRIo64 "I64o"
-#  define PRIx64 "I64x"
-#  define PRIX64 "I64X"
 static const unsigned int IEEE754_INFINITY_BITS_SINGLE = 0x7F800000;
 #  define INFINITY (*(float *)&IEEE754_INFINITY_BITS_SINGLE)
 #  define NAN ((float)(INFINITY - INFINITY))
@@ -100,115 +66,6 @@ static const unsigned int IEEE754_INFINITY_BITS_SINGLE = 0x7F800000;
 #else
 # include <inttypes.h>
 #endif
-
-typedef uint8_t mrb_bool;
-struct mrb_state;
-
-#if defined(MRB_NAN_BOXING)
-
-#ifdef MRB_USE_FLOAT
-# error ---->> MRB_NAN_BOXING and MRB_USE_FLOAT conflict <<----
-#endif
-
-#ifdef MRB_INT64
-# error ---->> MRB_NAN_BOXING and MRB_INT64 conflict <<----
-#endif
-
-enum mrb_vtype {
-  MRB_TT_FALSE = 1,   /*   1 */
-  MRB_TT_FREE,        /*   2 */
-  MRB_TT_TRUE,        /*   3 */
-  MRB_TT_FIXNUM,      /*   4 */
-  MRB_TT_SYMBOL,      /*   5 */
-  MRB_TT_UNDEF,       /*   6 */
-  MRB_TT_FLOAT,       /*   7 */
-  MRB_TT_CPTR,        /*   8 */
-  MRB_TT_OBJECT,      /*   9 */
-  MRB_TT_CLASS,       /*  10 */
-  MRB_TT_MODULE,      /*  11 */
-  MRB_TT_ICLASS,      /*  12 */
-  MRB_TT_SCLASS,      /*  13 */
-  MRB_TT_PROC,        /*  14 */
-  MRB_TT_ARRAY,       /*  15 */
-  MRB_TT_HASH,        /*  16 */
-  MRB_TT_STRING,      /*  17 */
-  MRB_TT_RANGE,       /*  18 */
-  MRB_TT_EXCEPTION,   /*  19 */
-  MRB_TT_FILE,        /*  20 */
-  MRB_TT_ENV,         /*  21 */
-  MRB_TT_DATA,        /*  22 */
-  MRB_TT_FIBER,       /*  23 */
-  MRB_TT_MAXDEFINE    /*  24 */
-};
-
-#define MRB_TT_HAS_BASIC  MRB_TT_OBJECT
-
-#ifdef MRB_ENDIAN_BIG
-#define MRB_ENDIAN_LOHI(a,b) a b
-#else
-#define MRB_ENDIAN_LOHI(a,b) b a
-#endif
-
-typedef struct mrb_value {
-  union {
-    mrb_float f;
-    union {
-      void *p;
-      struct {
-        MRB_ENDIAN_LOHI(
-          uint32_t ttt;
-          ,union {
-            mrb_int i;
-            mrb_sym sym;
-          };
-        )
-      };
-    } value;
-  };
-} mrb_value;
-
-/* value representation by nan-boxing:
- *   float : FFFFFFFFFFFFFFFF FFFFFFFFFFFFFFFF FFFFFFFFFFFFFFFF FFFFFFFFFFFFFFFF
- *   object: 111111111111TTTT TTPPPPPPPPPPPPPP PPPPPPPPPPPPPPPP PPPPPPPPPPPPPPPP
- *   int   : 1111111111110001 0000000000000000 IIIIIIIIIIIIIIII IIIIIIIIIIIIIIII
- *   sym   : 1111111111110001 0100000000000000 SSSSSSSSSSSSSSSS SSSSSSSSSSSSSSSS
- * In order to get enough bit size to save TT, all pointers are shifted 2 bits
- * in the right direction.
- */
-#define mrb_tt(o)       ((enum mrb_vtype)(((o).value.ttt & 0xfc000)>>14))
-#define mrb_mktt(tt)    (0xfff00000|((tt)<<14))
-#define mrb_type(o)     ((uint32_t)0xfff00000 < (o).value.ttt ? mrb_tt(o) : MRB_TT_FLOAT)
-#define mrb_ptr(o)      ((void*)((((uintptr_t)0x3fffffffffff)&((uintptr_t)((o).value.p)))<<2))
-#define mrb_float(o)    (o).f
-
-#define MRB_SET_VALUE(o, tt, attr, v) do {\
-  (o).value.ttt = mrb_mktt(tt);\
-  switch (tt) {\
-  case MRB_TT_FALSE:\
-  case MRB_TT_TRUE:\
-  case MRB_TT_UNDEF:\
-  case MRB_TT_FIXNUM:\
-  case MRB_TT_SYMBOL: (o).attr = (v); break;\
-  default: (o).value.i = 0; (o).value.p = (void*)((uintptr_t)(o).value.p | (((uintptr_t)(v))>>2)); break;\
-  }\
-} while (0)
-
-static inline mrb_value
-mrb_float_value(struct mrb_state *mrb, mrb_float f)
-{
-  mrb_value v;
-
-  if (f != f) {
-    v.value.ttt = 0x7ff80000;
-    v.value.i = 0;
-  } else {
-    v.f = f;
-  }
-  return v;
-}
-#define mrb_float_pool(mrb,f) mrb_float_value(mrb,f)
-
-#else
 
 enum mrb_vtype {
   MRB_TT_FALSE = 0,   /*   0 */
@@ -237,118 +94,28 @@ enum mrb_vtype {
   MRB_TT_MAXDEFINE    /*  23 */
 };
 
-#if defined(MRB_WORD_BOXING)
+#include "mruby/object.h"
 
-#include <limits.h>
-#define MRB_TT_HAS_BASIC  MRB_TT_FLOAT
-
-enum mrb_special_consts {
-  MRB_Qnil    = 0,
-  MRB_Qfalse  = 2,
-  MRB_Qtrue   = 4,
-  MRB_Qundef  = 6,
-};
-
-#define MRB_FIXNUM_FLAG   0x01
-#define MRB_FIXNUM_SHIFT  1
-#define MRB_SYMBOL_FLAG   0x0e
-#define MRB_SPECIAL_SHIFT 8
-
-typedef union mrb_value {
-  union {
-    void *p;
-    struct {
-      unsigned int i_flag : MRB_FIXNUM_SHIFT;
-      mrb_int i : (MRB_INT_BIT - MRB_FIXNUM_SHIFT);
-    };
-    struct {
-      unsigned int sym_flag : MRB_SPECIAL_SHIFT;
-      int sym : (sizeof(mrb_sym) * CHAR_BIT);
-    };
-    struct RBasic *bp;
-    struct RFloat *fp;
-    struct RCptr *vp;
-  } value;
-  unsigned long w;
-} mrb_value;
-
-#define mrb_ptr(o)      (o).value.p
-#define mrb_float(o)    (o).value.fp->f
-
-#define MRB_SET_VALUE(o, ttt, attr, v) do {\
-  (o).w = 0;\
-  (o).attr = (v);\
-  switch (ttt) {\
-  case MRB_TT_FALSE:  (o).w = (v) ? MRB_Qfalse : MRB_Qnil; break;\
-  case MRB_TT_TRUE:   (o).w = MRB_Qtrue; break;\
-  case MRB_TT_UNDEF:  (o).w = MRB_Qundef; break;\
-  case MRB_TT_FIXNUM: (o).value.i_flag = MRB_FIXNUM_FLAG; break;\
-  case MRB_TT_SYMBOL: (o).value.sym_flag = MRB_SYMBOL_FLAG; break;\
-  default:            if ((o).value.bp) (o).value.bp->tt = ttt; break;\
-  }\
-} while (0)
-
-mrb_value mrb_float_value(struct mrb_state *mrb, mrb_float f);
-mrb_value mrb_float_pool(struct mrb_state *mrb, mrb_float f);
-
-#else /* No MRB_xxx_BOXING */
-
-#define MRB_TT_HAS_BASIC  MRB_TT_OBJECT
-
-typedef struct mrb_value {
-  union {
-    mrb_float f;
-    void *p;
-    mrb_int i;
-    mrb_sym sym;
-  } value;
-  enum mrb_vtype tt;
-} mrb_value;
-
-#define mrb_type(o)     (o).tt
-#define mrb_ptr(o)      (o).value.p
-#define mrb_float(o)    (o).value.f
-
-#define MRB_SET_VALUE(o, ttt, attr, v) do {\
-  (o).tt = ttt;\
-  (o).attr = v;\
-} while (0)
-
-static inline mrb_value
-mrb_float_value(struct mrb_state *mrb, mrb_float f)
-{
-  mrb_value v;
-  (void) mrb;
-
-  MRB_SET_VALUE(v, MRB_TT_FLOAT, value.f, f);
-  return v;
-}
-#define mrb_float_pool(mrb,f) mrb_float_value(mrb,f)
-
-#endif  /* no boxing */
-
+#if defined(MRB_NAN_BOXING)
+#include "boxing_nan.h"
+#elif defined(MRB_WORD_BOXING)
+#include "boxing_word.h"
+#else
+#include "boxing_nix.h"
 #endif
 
-#ifdef MRB_WORD_BOXING
-
-#define mrb_cptr(o) (o).value.vp->p
-#define mrb_fixnum_p(o) ((o).value.i_flag == MRB_FIXNUM_FLAG)
-#define mrb_undef_p(o) ((o).w == MRB_Qundef)
-#define mrb_nil_p(o)  ((o).w == MRB_Qnil)
-#define mrb_bool(o)   ((o).w != MRB_Qnil && (o).w != MRB_Qfalse)
-
-#else
-
-#define mrb_cptr(o) mrb_ptr(o)
+#ifndef mrb_fixnum_p
 #define mrb_fixnum_p(o) (mrb_type(o) == MRB_TT_FIXNUM)
+#endif
+#ifndef mrb_undef_p
 #define mrb_undef_p(o) (mrb_type(o) == MRB_TT_UNDEF)
-#define mrb_nil_p(o)  (mrb_type(o) == MRB_TT_FALSE && !(o).value.i)
+#endif
+#ifndef mrb_nil_p
+#define mrb_nil_p(o)  (mrb_type(o) == MRB_TT_FALSE && !mrb_fixnum(o))
+#endif
+#ifndef mrb_bool
 #define mrb_bool(o)   (mrb_type(o) != MRB_TT_FALSE)
-
-#endif  /* no boxing */
-
-#define mrb_fixnum(o) (o).value.i
-#define mrb_symbol(o) (o).value.sym
+#endif
 #define mrb_float_p(o) (mrb_type(o) == MRB_TT_FLOAT)
 #define mrb_symbol_p(o) (mrb_type(o) == MRB_TT_SYMBOL)
 #define mrb_array_p(o) (mrb_type(o) == MRB_TT_ARRAY)
@@ -358,93 +125,27 @@ mrb_float_value(struct mrb_state *mrb, mrb_float f)
 #define mrb_test(o)   mrb_bool(o)
 mrb_bool mrb_regexp_p(struct mrb_state*, mrb_value);
 
-#define MRB_OBJECT_HEADER \
-  enum mrb_vtype tt:8;\
-  uint32_t color:3;\
-  uint32_t flags:21;\
-  struct RClass *c;\
-  struct RBasic *gcnext
-
-/* white: 011, black: 100, gray: 000 */
-#define MRB_GC_GRAY 0
-#define MRB_GC_WHITE_A 1
-#define MRB_GC_WHITE_B (1 << 1)
-#define MRB_GC_BLACK (1 << 2)
-#define MRB_GC_WHITES (MRB_GC_WHITE_A | MRB_GC_WHITE_B)
-#define MRB_GC_COLOR_MASK 7
-
-#define paint_gray(o) ((o)->color = MRB_GC_GRAY)
-#define paint_black(o) ((o)->color = MRB_GC_BLACK)
-#define paint_white(o) ((o)->color = MRB_GC_WHITES)
-#define paint_partial_white(s, o) ((o)->color = (s)->current_white_part)
-#define is_gray(o) ((o)->color == MRB_GC_GRAY)
-#define is_white(o) ((o)->color & MRB_GC_WHITES)
-#define is_black(o) ((o)->color & MRB_GC_BLACK)
-#define is_dead(s, o) (((o)->color & other_white_part(s) & MRB_GC_WHITES) || (o)->tt == MRB_TT_FREE)
-#define flip_white_part(s) ((s)->current_white_part = other_white_part(s))
-#define other_white_part(s) ((s)->current_white_part ^ MRB_GC_WHITES)
-
-struct RBasic {
-  MRB_OBJECT_HEADER;
-};
-#define mrb_basic_ptr(v) ((struct RBasic*)(mrb_ptr(v)))
-/* obsolete macro mrb_basic; will be removed soon */
-#define mrb_basic(v)     mrb_basic_ptr(v)
-
-struct RObject {
-  MRB_OBJECT_HEADER;
-  struct iv_tbl *iv;
-};
-#define mrb_obj_ptr(v)   ((struct RObject*)(mrb_ptr(v)))
-/* obsolete macro mrb_object; will be removed soon */
-#define mrb_object(o) mrb_obj_ptr(o)
-#define mrb_immediate_p(x) (mrb_type(x) < MRB_TT_HAS_BASIC)
-#define mrb_special_const_p(x) mrb_immediate_p(x)
-
-struct RFiber {
-  MRB_OBJECT_HEADER;
-  struct mrb_context *cxt;
-};
-
-#ifdef MRB_WORD_BOXING
-struct RFloat {
-  MRB_OBJECT_HEADER;
-  mrb_float f;
-};
-
-struct RCptr {
-  MRB_OBJECT_HEADER;
-  void *p;
-};
-
-static inline enum mrb_vtype
-mrb_type(mrb_value o)
+static inline mrb_value
+mrb_float_value(struct mrb_state *mrb, mrb_float f)
 {
-  switch (o.w) {
-  case MRB_Qfalse:
-  case MRB_Qnil:
-    return MRB_TT_FALSE;
-  case MRB_Qtrue:
-    return MRB_TT_TRUE;
-  case MRB_Qundef:
-    return MRB_TT_UNDEF;
-  }
-  if (o.value.i_flag == MRB_FIXNUM_FLAG) {
-    return MRB_TT_FIXNUM;
-  }
-  if (o.value.sym_flag == MRB_SYMBOL_FLAG) {
-    return MRB_TT_SYMBOL;
-  }
-  return o.value.bp->tt;
+  mrb_value v;
+  SET_FLOAT_VALUE(mrb, v, f);
+  return v;
 }
-#endif  /* MRB_WORD_BOXING */
+
+static inline mrb_value
+mrb_cptr_value(struct mrb_state *mrb, void *p)
+{
+  mrb_value v;
+  SET_CPTR_VALUE(mrb,v,p);
+  return v;
+}
 
 static inline mrb_value
 mrb_fixnum_value(mrb_int i)
 {
   mrb_value v;
-
-  MRB_SET_VALUE(v, MRB_TT_FIXNUM, value.i, i);
+  SET_FIXNUM_VALUE(v, i);
   return v;
 }
 
@@ -452,8 +153,7 @@ static inline mrb_value
 mrb_symbol_value(mrb_sym i)
 {
   mrb_value v;
-
-  MRB_SET_VALUE(v, MRB_TT_SYMBOL, value.sym, i);
+  SET_SYM_VALUE(v, i);
   return v;
 }
 
@@ -461,40 +161,7 @@ static inline mrb_value
 mrb_obj_value(void *p)
 {
   mrb_value v;
-  struct RBasic *b = (struct RBasic*)p;
-
-  MRB_SET_VALUE(v, b->tt, value.p, p);
-  return v;
-}
-
-#ifdef MRB_WORD_BOXING
-mrb_value
-mrb_cptr_value(struct mrb_state *mrb, void *p);
-#else
-static inline mrb_value
-mrb_cptr_value(struct mrb_state *mrb, void *p)
-{
-  mrb_value v;
-  (void) mrb;
-
-  MRB_SET_VALUE(v, MRB_TT_CPTR, value.p, p);
-  return v;
-}
-#endif
-/* obsolete macros; will be removed */
-#define MRB_TT_VOIDP MRB_TT_CPTR
-#define mrb_voidp_value(m,p) mrb_cptr_value((m),(p))
-#define mrb_voidp(o) mrb_cptr(o)
-#define mrb_voidp_p(o) mrb_cptr_p(o)
-
-#define MRB_TT_HAS_BASIC_P(tt) ((tt) >= MRB_TT_HAS_BASIC)
-
-static inline mrb_value
-mrb_false_value(void)
-{
-  mrb_value v;
-
-  MRB_SET_VALUE(v, MRB_TT_FALSE, value.i, 1);
+  SET_OBJ_VALUE(v, (struct RBasic*)p);
   return v;
 }
 
@@ -502,8 +169,15 @@ static inline mrb_value
 mrb_nil_value(void)
 {
   mrb_value v;
+  SET_NIL_VALUE(v);
+  return v;
+}
 
-  MRB_SET_VALUE(v, MRB_TT_FALSE, value.i, 0);
+static inline mrb_value
+mrb_false_value(void)
+{
+  mrb_value v;
+  SET_FALSE_VALUE(v);
   return v;
 }
 
@@ -511,17 +185,7 @@ static inline mrb_value
 mrb_true_value(void)
 {
   mrb_value v;
-
-  MRB_SET_VALUE(v, MRB_TT_TRUE, value.i, 1);
-  return v;
-}
-
-static inline mrb_value
-mrb_undef_value(void)
-{
-  mrb_value v;
-
-  MRB_SET_VALUE(v, MRB_TT_UNDEF, value.i, 0);
+  SET_TRUE_VALUE(v);
   return v;
 }
 
@@ -529,8 +193,15 @@ static inline mrb_value
 mrb_bool_value(mrb_bool boolean)
 {
   mrb_value v;
+  SET_BOOL_VALUE(v, boolean);
+  return v;
+}
 
-  MRB_SET_VALUE(v, boolean ? MRB_TT_TRUE : MRB_TT_FALSE, value.i, 1);
+static inline mrb_value
+mrb_undef_value(void)
+{
+  mrb_value v;
+  SET_UNDEF_VALUE(v);
   return v;
 }
 

--- a/mrbgems/mruby-fiber/src/fiber.c
+++ b/mrbgems/mruby-fiber/src/fiber.c
@@ -8,8 +8,6 @@
 #define FIBER_STACK_INIT_SIZE 64
 #define FIBER_CI_INIT_SIZE 8
 
-#define SET_NIL_VALUE(r) MRB_SET_VALUE(r, MRB_TT_FALSE, value.i, 0)
-
 /*
  *  call-seq:
  *     Fiber.new{...} -> obj

--- a/src/class.c
+++ b/src/class.c
@@ -1500,7 +1500,7 @@ undef_method(mrb_state *mrb, struct RClass *c, mrb_sym a)
     mrb_name_error(mrb, a, "undefined method '%S' for class '%S'", mrb_sym2str(mrb, a), mrb_obj_value(c));
   }
   else {
-    MRB_SET_VALUE(m, MRB_TT_PROC, value.p, 0);
+    SET_PROC_VALUE(m, 0);
     mrb_define_method_vm(mrb, c, a, m);
   }
 }

--- a/src/etc.c
+++ b/src/etc.c
@@ -148,7 +148,7 @@ mrb_obj_id(mrb_value obj)
 
 #ifdef MRB_WORD_BOXING
 mrb_value
-mrb_float_value(mrb_state *mrb, mrb_float f)
+word_boxing_mrb_float_value(mrb_state *mrb, mrb_float f)
 {
   mrb_value v;
 
@@ -158,7 +158,7 @@ mrb_float_value(mrb_state *mrb, mrb_float f)
 }
 
 mrb_value
-mrb_float_pool(mrb_state *mrb, mrb_float f)
+word_boxing_mrb_float_pool(mrb_state *mrb, mrb_float f)
 {
   struct RFloat *nf = (struct RFloat *)mrb_malloc(mrb, sizeof(struct RFloat));
   nf->tt = MRB_TT_FLOAT;
@@ -168,7 +168,7 @@ mrb_float_pool(mrb_state *mrb, mrb_float f)
 }
 
 mrb_value
-mrb_cptr_value(mrb_state *mrb, void *p)
+word_boxing_mrb_cptr_value(mrb_state *mrb, void *p)
 {
   mrb_value v;
 

--- a/src/numeric.c
+++ b/src/numeric.c
@@ -687,12 +687,8 @@ int_to_i(mrb_state *mrb, mrb_value num)
   return num;
 }
 
-#ifdef MRB_FIXNUM_SHIFT
-#define SQRT_INT_MAX ((mrb_int)1<<((MRB_INT_BIT-1-MRB_FIXNUM_SHIFT)/2))
-#else
-#define SQRT_INT_MAX ((mrb_int)1<<((MRB_INT_BIT-1)/2))
-#endif
 /*tests if N*N would overflow*/
+#define SQRT_INT_MAX ((mrb_int)1<<((MRB_INT_BIT-1-MRB_FIXNUM_SHIFT)/2))
 #define FIT_SQRT_INT(n) (((n)<SQRT_INT_MAX)&&((n)>=-SQRT_INT_MAX))
 
 mrb_value

--- a/src/object.c
+++ b/src/object.c
@@ -19,9 +19,9 @@ mrb_obj_eq(mrb_state *mrb, mrb_value v1, mrb_value v2)
 
   case MRB_TT_FALSE:
   case MRB_TT_FIXNUM:
-    return (v1.value.i == v2.value.i);
+    return (mrb_fixnum(v1) == mrb_fixnum(v2));
   case MRB_TT_SYMBOL:
-    return (v1.value.sym == v2.value.sym);
+    return (mrb_symbol(v1) == mrb_symbol(v2));
 
   case MRB_TT_FLOAT:
     return (mrb_float(v1) == mrb_float(v2));

--- a/src/vm.c
+++ b/src/vm.c
@@ -32,20 +32,6 @@ void abort(void);
 #endif
 #endif
 
-#define SET_TRUE_VALUE(r) MRB_SET_VALUE(r, MRB_TT_TRUE, value.i, 1)
-#define SET_FALSE_VALUE(r) MRB_SET_VALUE(r, MRB_TT_FALSE, value.i, 1)
-#define SET_NIL_VALUE(r) MRB_SET_VALUE(r, MRB_TT_FALSE, value.i, 0)
-#define SET_INT_VALUE(r,n) MRB_SET_VALUE(r, MRB_TT_FIXNUM, value.i, (n))
-#define SET_SYM_VALUE(r,v) MRB_SET_VALUE(r, MRB_TT_SYMBOL, value.sym, (v))
-#define SET_OBJ_VALUE(r,v) MRB_SET_VALUE(r, (((struct RObject*)(v))->tt), value.p, (v))
-#ifdef MRB_NAN_BOXING
-#define SET_FLT_VALUE(mrb,r,v) r.f = (v)
-#elif defined(MRB_WORD_BOXING)
-#define SET_FLT_VALUE(mrb,r,v) r = mrb_float_value(mrb, (v))
-#else
-#define SET_FLT_VALUE(mrb,r,v) MRB_SET_VALUE(r, MRB_TT_FLOAT, value.f, (v))
-#endif
-
 #define STACK_INIT_SIZE 128
 #define CALLINFO_INIT_SIZE 32
 
@@ -802,7 +788,7 @@ RETRY_TRY_BLOCK:
 
     CASE(OP_LOADI) {
       /* A sBx  R(A) := sBx */
-      SET_INT_VALUE(regs[GETARG_A(i)], GETARG_sBx(i));
+      SET_FIXNUM_VALUE(regs[GETARG_A(i)], GETARG_sBx(i));
       NEXT;
     }
 
@@ -1680,18 +1666,9 @@ RETRY_TRY_BLOCK:
       NEXT;
     }
 
-#define attr_i value.i
-#ifdef MRB_NAN_BOXING
-#define attr_f f
-#elif defined(MRB_WORD_BOXING)
-#define attr_f value.fp->f
-#else
-#define attr_f value.f
-#endif
-
 #define TYPES2(a,b) ((((uint16_t)(a))<<8)|(((uint16_t)(b))&0xff))
 #define OP_MATH_BODY(op,v1,v2) do {\
-  regs[a].v1 = regs[a].v1 op regs[a+1].v2;\
+  v1(regs[a]) = v1(regs[a]) op v2(regs[a+1]);\
 } while(0)
 
     CASE(OP_ADD) {
@@ -1708,17 +1685,17 @@ RETRY_TRY_BLOCK:
           x = mrb_fixnum(regs_a[0]);
           y = mrb_fixnum(regs_a[1]);
           if (mrb_int_add_overflow(x, y, &z)) {
-            SET_FLT_VALUE(mrb, regs_a[0], (mrb_float)x + (mrb_float)y);
+            SET_FLOAT_VALUE(mrb, regs_a[0], (mrb_float)x + (mrb_float)y);
             break;
           }
-          SET_INT_VALUE(regs[a], z);
+          SET_FIXNUM_VALUE(regs[a], z);
         }
         break;
       case TYPES2(MRB_TT_FIXNUM,MRB_TT_FLOAT):
         {
           mrb_int x = mrb_fixnum(regs[a]);
           mrb_float y = mrb_float(regs[a+1]);
-          SET_FLT_VALUE(mrb, regs[a], (mrb_float)x + y);
+          SET_FLOAT_VALUE(mrb, regs[a], (mrb_float)x + y);
         }
         break;
       case TYPES2(MRB_TT_FLOAT,MRB_TT_FIXNUM):
@@ -1726,10 +1703,10 @@ RETRY_TRY_BLOCK:
         {
           mrb_float x = mrb_float(regs[a]);
           mrb_int y = mrb_fixnum(regs[a+1]);
-          SET_FLT_VALUE(mrb, regs[a], x + y);
+          SET_FLOAT_VALUE(mrb, regs[a], x + y);
         }
 #else
-        OP_MATH_BODY(+,attr_f,attr_i);
+        OP_MATH_BODY(+,mrb_float,mrb_fixnum);
 #endif
         break;
       case TYPES2(MRB_TT_FLOAT,MRB_TT_FLOAT):
@@ -1737,10 +1714,10 @@ RETRY_TRY_BLOCK:
         {
           mrb_float x = mrb_float(regs[a]);
           mrb_float y = mrb_float(regs[a+1]);
-          SET_FLT_VALUE(mrb, regs[a], x + y);
+          SET_FLOAT_VALUE(mrb, regs[a], x + y);
         }
 #else
-        OP_MATH_BODY(+,attr_f,attr_f);
+        OP_MATH_BODY(+,mrb_float,mrb_float);
 #endif
         break;
       case TYPES2(MRB_TT_STRING,MRB_TT_STRING):
@@ -1766,17 +1743,17 @@ RETRY_TRY_BLOCK:
           x = mrb_fixnum(regs[a]);
           y = mrb_fixnum(regs[a+1]);
           if (mrb_int_sub_overflow(x, y, &z)) {
-            SET_FLT_VALUE(mrb, regs[a], (mrb_float)x - (mrb_float)y);
+            SET_FLOAT_VALUE(mrb, regs[a], (mrb_float)x - (mrb_float)y);
             break;
           }
-          SET_INT_VALUE(regs[a], z);
+          SET_FIXNUM_VALUE(regs[a], z);
         }
         break;
       case TYPES2(MRB_TT_FIXNUM,MRB_TT_FLOAT):
         {
           mrb_int x = mrb_fixnum(regs[a]);
           mrb_float y = mrb_float(regs[a+1]);
-          SET_FLT_VALUE(mrb, regs[a], (mrb_float)x - y);
+          SET_FLOAT_VALUE(mrb, regs[a], (mrb_float)x - y);
         }
         break;
       case TYPES2(MRB_TT_FLOAT,MRB_TT_FIXNUM):
@@ -1784,10 +1761,10 @@ RETRY_TRY_BLOCK:
         {
           mrb_float x = mrb_float(regs[a]);
           mrb_int y = mrb_fixnum(regs[a+1]);
-          SET_FLT_VALUE(mrb, regs[a], x - y);
+          SET_FLOAT_VALUE(mrb, regs[a], x - y);
         }
 #else
-        OP_MATH_BODY(-,attr_f,attr_i);
+        OP_MATH_BODY(-,mrb_float,mrb_fixnum);
 #endif
         break;
       case TYPES2(MRB_TT_FLOAT,MRB_TT_FLOAT):
@@ -1795,10 +1772,10 @@ RETRY_TRY_BLOCK:
         {
           mrb_float x = mrb_float(regs[a]);
           mrb_float y = mrb_float(regs[a+1]);
-          SET_FLT_VALUE(mrb, regs[a], x - y);
+          SET_FLOAT_VALUE(mrb, regs[a], x - y);
         }
 #else
-        OP_MATH_BODY(-,attr_f,attr_f);
+        OP_MATH_BODY(-,mrb_float,mrb_float);
 #endif
         break;
       default:
@@ -1822,12 +1799,12 @@ RETRY_TRY_BLOCK:
           switch (mrb_type(z)) {
           case MRB_TT_FIXNUM:
             {
-              SET_INT_VALUE(regs[a], mrb_fixnum(z));
+              SET_FIXNUM_VALUE(regs[a], mrb_fixnum(z));
             }
             break;
           case MRB_TT_FLOAT:
             {
-              SET_FLT_VALUE(mrb, regs[a], mrb_float(z));
+              SET_FLOAT_VALUE(mrb, regs[a], mrb_float(z));
             }
             break;
           default:
@@ -1840,7 +1817,7 @@ RETRY_TRY_BLOCK:
         {
           mrb_int x = mrb_fixnum(regs[a]);
           mrb_float y = mrb_float(regs[a+1]);
-          SET_FLT_VALUE(mrb, regs[a], (mrb_float)x * y);
+          SET_FLOAT_VALUE(mrb, regs[a], (mrb_float)x * y);
         }
         break;
       case TYPES2(MRB_TT_FLOAT,MRB_TT_FIXNUM):
@@ -1848,10 +1825,10 @@ RETRY_TRY_BLOCK:
         {
           mrb_float x = mrb_float(regs[a]);
           mrb_int y = mrb_fixnum(regs[a+1]);
-          SET_FLT_VALUE(mrb, regs[a], x * y);
+          SET_FLOAT_VALUE(mrb, regs[a], x * y);
         }
 #else
-        OP_MATH_BODY(*,attr_f,attr_i);
+        OP_MATH_BODY(*,mrb_float,mrb_fixnum);
 #endif
         break;
       case TYPES2(MRB_TT_FLOAT,MRB_TT_FLOAT):
@@ -1859,10 +1836,10 @@ RETRY_TRY_BLOCK:
         {
           mrb_float x = mrb_float(regs[a]);
           mrb_float y = mrb_float(regs[a+1]);
-          SET_FLT_VALUE(mrb, regs[a], x * y);
+          SET_FLOAT_VALUE(mrb, regs[a], x * y);
         }
 #else
-        OP_MATH_BODY(*,attr_f,attr_f);
+        OP_MATH_BODY(*,mrb_float,mrb_float);
 #endif
         break;
       default:
@@ -1881,14 +1858,14 @@ RETRY_TRY_BLOCK:
         {
           mrb_int x = mrb_fixnum(regs[a]);
           mrb_int y = mrb_fixnum(regs[a+1]);
-          SET_FLT_VALUE(mrb, regs[a], (mrb_float)x / (mrb_float)y);
+          SET_FLOAT_VALUE(mrb, regs[a], (mrb_float)x / (mrb_float)y);
         }
         break;
       case TYPES2(MRB_TT_FIXNUM,MRB_TT_FLOAT):
         {
           mrb_int x = mrb_fixnum(regs[a]);
           mrb_float y = mrb_float(regs[a+1]);
-          SET_FLT_VALUE(mrb, regs[a], (mrb_float)x / y);
+          SET_FLOAT_VALUE(mrb, regs[a], (mrb_float)x / y);
         }
         break;
       case TYPES2(MRB_TT_FLOAT,MRB_TT_FIXNUM):
@@ -1896,10 +1873,10 @@ RETRY_TRY_BLOCK:
         {
           mrb_float x = mrb_float(regs[a]);
           mrb_int y = mrb_fixnum(regs[a+1]);
-          SET_FLT_VALUE(mrb, regs[a], x / y);
+          SET_FLOAT_VALUE(mrb, regs[a], x / y);
         }
 #else
-        OP_MATH_BODY(/,attr_f,attr_i);
+        OP_MATH_BODY(/,mrb_float,mrb_fixnum);
 #endif
         break;
       case TYPES2(MRB_TT_FLOAT,MRB_TT_FLOAT):
@@ -1907,18 +1884,18 @@ RETRY_TRY_BLOCK:
         {
           mrb_float x = mrb_float(regs[a]);
           mrb_float y = mrb_float(regs[a+1]);
-          SET_FLT_VALUE(mrb, regs[a], x / y);
+          SET_FLOAT_VALUE(mrb, regs[a], x / y);
         }
 #else
-        OP_MATH_BODY(/,attr_f,attr_f);
+        OP_MATH_BODY(/,mrb_float,mrb_float);
 #endif
         break;
       default:
         goto L_SEND;
       }
 #ifdef MRB_NAN_BOXING
-      if (isnan(regs[a].attr_f)) {
-        regs[a] = mrb_float_value(mrb, regs[a].attr_f);
+      if (isnan(mrb_float(regs[a]))) {
+        regs[a] = mrb_float_value(mrb, mrb_float(regs[a]));
       }
 #endif
       NEXT;
@@ -1932,29 +1909,29 @@ RETRY_TRY_BLOCK:
       switch (mrb_type(regs[a])) {
       case MRB_TT_FIXNUM:
         {
-          mrb_int x = regs[a].attr_i;
+          mrb_int x = mrb_fixnum(regs[a]);
           mrb_int y = GETARG_C(i);
           mrb_int z;
 
           if (mrb_int_add_overflow(x, y, &z)) {
-            SET_FLT_VALUE(mrb, regs[a], (mrb_float)x + (mrb_float)y);
+            SET_FLOAT_VALUE(mrb, regs[a], (mrb_float)x + (mrb_float)y);
             break;
           }
-          regs[a].attr_i = z;
+          mrb_fixnum(regs[a]) = z;
         }
         break;
       case MRB_TT_FLOAT:
 #ifdef MRB_WORD_BOXING
         {
           mrb_float x = mrb_float(regs[a]);
-          SET_FLT_VALUE(mrb, regs[a], x + GETARG_C(i));
+          SET_FLOAT_VALUE(mrb, regs[a], x + GETARG_C(i));
         }
 #else
-        regs[a].attr_f += GETARG_C(i);
+        mrb_float(regs[a]) += GETARG_C(i);
 #endif
         break;
       default:
-        SET_INT_VALUE(regs[a+1], GETARG_C(i));
+        SET_FIXNUM_VALUE(regs[a+1], GETARG_C(i));
         i = MKOP_ABC(OP_SEND, a, GETARG_B(i), 1);
         goto L_SEND;
       }
@@ -1970,15 +1947,15 @@ RETRY_TRY_BLOCK:
       switch (mrb_type(regs_a[0])) {
       case MRB_TT_FIXNUM:
         {
-          mrb_int x = regs_a[0].attr_i;
+          mrb_int x = mrb_fixnum(regs_a[0]);
           mrb_int y = GETARG_C(i);
           mrb_int z;
 
           if (mrb_int_sub_overflow(x, y, &z)) {
-            SET_FLT_VALUE(mrb, regs_a[0], (mrb_float)x - (mrb_float)y);
+            SET_FLOAT_VALUE(mrb, regs_a[0], (mrb_float)x - (mrb_float)y);
           }
           else {
-            regs_a[0].attr_i = z;
+            mrb_fixnum(regs_a[0]) = z;
           }
         }
         break;
@@ -1986,37 +1963,37 @@ RETRY_TRY_BLOCK:
 #ifdef MRB_WORD_BOXING
         {
           mrb_float x = mrb_float(regs[a]);
-          SET_FLT_VALUE(mrb, regs[a], x - GETARG_C(i));
+          SET_FLOAT_VALUE(mrb, regs[a], x - GETARG_C(i));
         }
 #else
-        regs_a[0].attr_f -= GETARG_C(i);
+        mrb_float(regs_a[0]) -= GETARG_C(i);
 #endif
         break;
       default:
-        SET_INT_VALUE(regs_a[1], GETARG_C(i));
+        SET_FIXNUM_VALUE(regs_a[1], GETARG_C(i));
         i = MKOP_ABC(OP_SEND, a, GETARG_B(i), 1);
         goto L_SEND;
       }
       NEXT;
     }
 
-#define OP_CMP_BODY(op,v1,v2) (regs[a].v1 op regs[a+1].v2)
+#define OP_CMP_BODY(op,v1,v2) (v1(regs[a]) op v2(regs[a+1]))
 
 #define OP_CMP(op) do {\
   int result;\
   /* need to check if - is overridden */\
   switch (TYPES2(mrb_type(regs[a]),mrb_type(regs[a+1]))) {\
   case TYPES2(MRB_TT_FIXNUM,MRB_TT_FIXNUM):\
-    result = OP_CMP_BODY(op,attr_i,attr_i);\
+    result = OP_CMP_BODY(op,mrb_fixnum,mrb_fixnum);\
     break;\
   case TYPES2(MRB_TT_FIXNUM,MRB_TT_FLOAT):\
-    result = OP_CMP_BODY(op,attr_i,attr_f);\
+    result = OP_CMP_BODY(op,mrb_fixnum,mrb_float);\
     break;\
   case TYPES2(MRB_TT_FLOAT,MRB_TT_FIXNUM):\
-    result = OP_CMP_BODY(op,attr_f,attr_i);\
+    result = OP_CMP_BODY(op,mrb_float,mrb_fixnum);\
     break;\
   case TYPES2(MRB_TT_FLOAT,MRB_TT_FLOAT):\
-    result = OP_CMP_BODY(op,attr_f,attr_f);\
+    result = OP_CMP_BODY(op,mrb_float,mrb_float);\
     break;\
   default:\
     goto L_SEND;\


### PR DESCRIPTION
The mrb_value boxing types make value.h very complicated. There are many nested ifdefs and the struct implementation has made its way into other parts of the code causing more ifdefs there.

I split value.h into an interface and implementation. Knowledge of mrb_value structure is no longer needed outside of implementation header file. There are no longer any large ifdef blocks for boxing and less ifdefs overall. I think this will make things easier for gem and core developers alike.
