### PR TITLE
Remove unnecessary out of memory check in `ary_expand_capa`.

### DIFF
--- a/src/array.c
+++ b/src/array.c
@@ -200,10 +200,6 @@ ary_expand_capa(mrb_state *mrb, struct RArray *a, mrb_int len)
   if (capa > a->aux.capa) {
     mrb_value *expanded_ptr = (mrb_value *)mrb_realloc(mrb, a->ptr, sizeof(mrb_value)*capa);
 
-    if (!expanded_ptr) {
-      mrb_raise(mrb, E_RUNTIME_ERROR, "out of memory");
-    }
-
     a->aux.capa = capa;
     a->ptr = expanded_ptr;
   }


### PR DESCRIPTION
Since `mrb_realloc` raises `mrb->nomem_err` when it failed to allocate memory.
