### PR TITLE
invalid base shouldn't silently fail

### DIFF
--- a/src/codegen.c
+++ b/src/codegen.c
@@ -1095,6 +1095,7 @@ readint_mrb_int(codegen_scope *s, const char *p, int base, mrb_bool neg, mrb_boo
   mrb_int result = 0;
   int n;
 
+  mrb_assert(base >= 2 && base <= 36);
   if (*p == '+') p++;
   while (p < e) {
     char c = *p;
@@ -1108,23 +1109,21 @@ readint_mrb_int(codegen_scope *s, const char *p, int base, mrb_bool neg, mrb_boo
       codegen_error(s, "malformed readint input");
     }
 
-    if(base > 0) {
-      if (neg) {
-        if ((MRB_INT_MIN + n)/base > result) {
-          *overflow = TRUE;
-          return 0;
-        }
-        result *= base;
-        result -= n;
+    if (neg) {
+      if ((MRB_INT_MIN + n)/base > result) {
+        *overflow = TRUE;
+        return 0;
       }
-      else {
-        if ((MRB_INT_MAX - n)/base < result) {
-          *overflow = TRUE;
-          return 0;
-        }
-        result *= base;
-        result += n;
+      result *= base;
+      result -= n;
+    }
+    else {
+      if ((MRB_INT_MAX - n)/base < result) {
+        *overflow = TRUE;
+        return 0;
       }
+      result *= base;
+      result += n;
     }
     p++;
   }


### PR DESCRIPTION
Revert 44a5809224e819bf8bcca4ae9a8c5ea5bf4cefd7 and check range of `base` with `mrb_assert`.
It actually can only be either 2, 8, 10 or 16 (and never 0), unless mruby sources are modified. But I don't see a reason to impose further limits.
