### PR TITLE
Refactor eval.

### DIFF
--- a/mrbgems/mruby-eval/src/eval.c
+++ b/mrbgems/mruby-eval/src/eval.c
@@ -112,6 +112,7 @@ create_proc_from_string(mrb_state *mrb, char *s, int len, mrb_value binding, cha
   if (file) {
     mrbc_filename(mrb, cxt, file);
   }
+  cxt->capture_errors = TRUE;
 
   p = mrb_parse_nstring(mrb, s, len, cxt);
 

--- a/mrbgems/mruby-eval/test/eval.rb
+++ b/mrbgems/mruby-eval/test/eval.rb
@@ -44,3 +44,9 @@ assert('rest arguments of eval') do
     Kernel.eval('[\'test\', __FILE__, __LINE__]', nil, 'test.rb', 10)
   end
 end
+
+assert 'eval syntax error' do
+  assert_raise(SyntaxError) do
+    eval 'p "test'
+  end
+end


### PR DESCRIPTION
- Set `capture_errors` true in compiler context.
  - Add test for it.
- Use `mrb_parse_nstring` instead.
