### PR TITLE
Core support for complex numbers

### DIFF
--- a/include/mrbconf.h
+++ b/include/mrbconf.h
@@ -17,10 +17,13 @@
 /* add -DMRB_INT64 to use 64bit integer for mrb_int; conflict with MRB_INT16 */
 //#define MRB_INT64
 
+/* add support for complex numbers */
+//#define MRB_COMPLEX
+
 /* represent mrb_value in boxed double; conflict with MRB_USE_FLOAT */
 //#define MRB_NAN_BOXING
 
-/* define on big endian machines; used by MRB_NAN_BOXING */
+/* define on big endian machines; used by MRB_NAN_BOXING and MRB_COMPLEX */
 //#define MRB_ENDIAN_BIG
 
 /* represent mrb_value as a word (natural unit of data for the processor) */

--- a/include/mruby.h
+++ b/include/mruby.h
@@ -130,6 +130,9 @@ typedef struct mrb_state {
 
   struct RClass *float_class;
   struct RClass *fixnum_class;
+#ifdef MRB_COMPLEX
+  struct RClass *complex_class;
+#endif
   struct RClass *true_class;
   struct RClass *false_class;
   struct RClass *nil_class;

--- a/include/mruby/boxing_cpx.h
+++ b/include/mruby/boxing_cpx.h
@@ -1,0 +1,135 @@
+/*
+** mruby/complex.h - mrb_value for complex numbers
+**
+** See Copyright Notice in mruby.h
+*/
+
+#ifndef MRUBY_BOXING_CPX_H
+#define MRUBY_BOXING_CPX_H
+
+#ifdef MRB_NAN_BOXING
+# error MRB_COMPLEX not compatible with MRB_NAN_BOXING
+#endif
+
+#if defined(MRB_USE_FLOAT) && defined(MRB_INT64)
+# error MRB_COMPLEX boxing not usable with both MRB_USE_FLOAT and MRB_INT64
+#endif
+
+#define MRB_FIXNUM_SHIFT 0
+#define MRB_TT_HAS_BASIC  MRB_TT_OBJECT
+#define MRB_VALUE_NIL_NONZERO
+
+/* When not word boxing, Complex() numbers are represented by boxing
+ * the imaginary number so it can also represent the value type.
+ * For example, the float version:
+ *   imaginary : FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF
+ *   mrb_vtype : 11111111 11111111 TTTTTTTT TTTTTTTT
+ * The double version:
+ *   imaginary : FFFFFFFFFFFFFFFF FFFFFFFFFFFFFFFF FFFFFFFFFFFFFFFF FFFFFFFFFFFFFFFF
+ *   mrb_vtype : 1111111111111111 1111111111111111 TTTTTTTTTTTTTTTT TTTTTTTTTTTTTTTT
+ * The real part is a union of all types.
+ */
+
+#ifdef MRB_USE_FLOAT
+
+typedef struct mrb_value {
+  union {
+    mrb_float f;
+    void *p;
+    mrb_int i;
+    mrb_sym sym;
+  } value;
+  union {
+    mrb_float fi;
+    struct {
+      MRB_ENDIAN_LOHI (
+        uint16_t tt_nan;,
+        uint16_t tt;
+        )
+    };
+  };
+} mrb_value;
+
+#define mrb_complex_p(o) (0xFFFF != (o).tt_nan)
+#define mrb_type(o)     (0xFFFF == (o).tt_nan ? (o).tt : MRB_TT_COMPLEX)
+
+#define BOXCPX_SET_VALUE(o, ttt, attr, v) do {\
+  (o).tt_nan = 0xFFFF;\
+  (o).tt = ttt;\
+  (o).attr = v;\
+} while (0)
+
+#define SET_COMPLEX_VALUE(mrb, o, real, imag) do {\
+  if (imag != imag) {\
+    (o).tt_nan = 0x7FC0;\
+    (o).tt = 0;\
+  } else {\
+    (o).fi = imag;\
+  }\
+  (o).value.f = real;\
+} while(0)
+
+#else
+
+typedef struct mrb_value {
+  union {
+    mrb_float f;
+    void *p;
+    mrb_int i;
+    mrb_sym sym;
+  } value;
+  union {
+    mrb_float fi;
+    struct {
+      MRB_ENDIAN_LOHI (
+        uint32_t tt_nan;,
+        uint32_t tt;
+        )
+    };
+  };
+} mrb_value;
+
+#define mrb_complex_p(o) (0xFFFFFFFF != (o).tt_nan)
+#define mrb_type(o)     (0xFFFFFFFF == (o).tt_nan ? (o).tt : MRB_TT_COMPLEX)
+
+#define BOXCPX_SET_VALUE(o, ttt, attr, v) do {\
+  (o).tt_nan = 0xFFFFFFFF;\
+  (o).tt = ttt;\
+  (o).attr = v;\
+} while (0)
+
+#define SET_COMPLEX_VALUE(mrb, o, real, imag) do {\
+  if (imag != imag) {\
+    (o).tt_nan = 0x7FF80000;\
+    (o).tt = 0;\
+  } else {\
+    (o).fi = imag;\
+  }\
+  (o).value.f = real;\
+} while(0)
+
+#endif
+
+#define mrb_float_pool(mrb,f) mrb_float_value(mrb,f)
+
+#define mrb_ptr(o)      (o).value.p
+#define mrb_cptr(o)     mrb_ptr(o)
+#define mrb_float(o)    (o).value.f
+#define mrb_fixnum(o)   (o).value.i
+#define mrb_symbol(o)   (o).value.sym
+#define mrb_real(o)     (o).value.f
+#define mrb_imag(o)     (o).fi
+
+#define SET_NIL_VALUE(r) BOXCPX_SET_VALUE(r, MRB_TT_FALSE, value.i, 0)
+#define SET_FALSE_VALUE(r) BOXCPX_SET_VALUE(r, MRB_TT_FALSE, value.i, 1)
+#define SET_TRUE_VALUE(r) BOXCPX_SET_VALUE(r, MRB_TT_TRUE, value.i, 1)
+#define SET_BOOL_VALUE(r,b) BOXCPX_SET_VALUE(r, b ? MRB_TT_TRUE : MRB_TT_FALSE, value.i, 1)
+#define SET_INT_VALUE(r,n) BOXCPX_SET_VALUE(r, MRB_TT_FIXNUM, value.i, (n))
+#define SET_FLOAT_VALUE(mrb,r,v) BOXCPX_SET_VALUE(r, MRB_TT_FLOAT, value.f, (v))
+#define SET_SYM_VALUE(r,v) BOXCPX_SET_VALUE(r, MRB_TT_SYMBOL, value.sym, (v))
+#define SET_OBJ_VALUE(r,v) BOXCPX_SET_VALUE(r, (((struct RObject*)(v))->tt), value.p, (v))
+#define SET_PROC_VALUE(r,v) BOXCPX_SET_VALUE(r, MRB_TT_PROC, value.p, v)
+#define SET_CPTR_VALUE(mrb,r,v) BOXCPX_SET_VALUE(r, MRB_TT_CPTR, value.p, v)
+#define SET_UNDEF_VALUE(r) BOXCPX_SET_VALUE(r, MRB_TT_UNDEF, value.i, 0)
+
+#endif /* MRUBY_BOXING_CPX_H */

--- a/include/mruby/boxing_nan.h
+++ b/include/mruby/boxing_nan.h
@@ -17,12 +17,7 @@
 
 #define MRB_FIXNUM_SHIFT 0
 #define MRB_TT_HAS_BASIC MRB_TT_OBJECT
-
-#ifdef MRB_ENDIAN_BIG
-#define MRB_ENDIAN_LOHI(a,b) a b
-#else
-#define MRB_ENDIAN_LOHI(a,b) b a
-#endif
+#define MRB_VALUE_NIL_NONZERO
 
 /* value representation by nan-boxing:
  *   float : FFFFFFFFFFFFFFFF FFFFFFFFFFFFFFFF FFFFFFFFFFFFFFFF FFFFFFFFFFFFFFFF

--- a/include/mruby/boxing_word.h
+++ b/include/mruby/boxing_word.h
@@ -38,12 +38,14 @@ typedef union mrb_value {
     };
     struct RBasic *bp;
     struct RFloat *fp;
+    struct RComplex *cp;
     struct RCptr *vp;
   } value;
   unsigned long w;
 } mrb_value;
 
 mrb_value mrb_word_boxing_cptr_value(struct mrb_state*, void*);
+mrb_value mrb_word_boxing_complex_value(struct mrb_state*, mrb_float, mrb_float);
 mrb_value mrb_word_boxing_float_value(struct mrb_state*, mrb_float);
 mrb_value mrb_word_boxing_float_pool(struct mrb_state*, mrb_float);
 
@@ -105,5 +107,11 @@ mrb_type(mrb_value o)
 #define SET_OBJ_VALUE(r,v) BOXWORD_SET_VALUE(r, (((struct RObject*)(v))->tt), value.p, (v))
 #define SET_PROC_VALUE(r,v) BOXWORD_SET_VALUE(r, MRB_TT_PROC, value.p, v)
 #define SET_UNDEF_VALUE(r) BOXWORD_SET_VALUE(r, MRB_TT_UNDEF, value.i, 0)
+
+#ifdef MRB_COMPLEX
+#define mrb_real(o)     (o).value.cp->real
+#define mrb_imag(o)     (o).value.cp->imag
+#define SET_COMPLEX_VALUE(mrb,r,vr,vi) r = mrb_word_boxing_complex_value(mrb, vr, vi)
+#endif
 
 #endif  /* MRUBY_BOXING_WORD_H */

--- a/include/mruby/class.h
+++ b/include/mruby/class.h
@@ -39,6 +39,10 @@ mrb_class(mrb_state *mrb, mrb_value v)
     return mrb->fixnum_class;
   case MRB_TT_FLOAT:
     return mrb->float_class;
+#ifdef MRB_COMPLEX
+  case MRB_TT_COMPLEX:
+    return mrb->complex_class;
+#endif
   case MRB_TT_CPTR:
     return mrb->object_class;
   case MRB_TT_ENV:

--- a/include/mruby/object.h
+++ b/include/mruby/object.h
@@ -60,6 +60,12 @@ struct RFloat {
   mrb_float f;
 };
 
+struct RComplex {
+  MRB_OBJECT_HEADER;
+  mrb_float real;
+  mrb_float imag;
+};
+
 struct RCptr {
   MRB_OBJECT_HEADER;
   void *p;

--- a/include/mruby/value.h
+++ b/include/mruby/value.h
@@ -75,31 +75,40 @@ enum mrb_vtype {
   MRB_TT_SYMBOL,      /*   4 */
   MRB_TT_UNDEF,       /*   5 */
   MRB_TT_FLOAT,       /*   6 */
-  MRB_TT_CPTR,        /*   7 */
-  MRB_TT_OBJECT,      /*   8 */
-  MRB_TT_CLASS,       /*   9 */
-  MRB_TT_MODULE,      /*  10 */
-  MRB_TT_ICLASS,      /*  11 */
-  MRB_TT_SCLASS,      /*  12 */
-  MRB_TT_PROC,        /*  13 */
-  MRB_TT_ARRAY,       /*  14 */
-  MRB_TT_HASH,        /*  15 */
-  MRB_TT_STRING,      /*  16 */
-  MRB_TT_RANGE,       /*  17 */
-  MRB_TT_EXCEPTION,   /*  18 */
-  MRB_TT_FILE,        /*  19 */
-  MRB_TT_ENV,         /*  20 */
-  MRB_TT_DATA,        /*  21 */
-  MRB_TT_FIBER,       /*  22 */
-  MRB_TT_MAXDEFINE    /*  23 */
+  MRB_TT_COMPLEX,     /*   7 */
+  MRB_TT_CPTR,        /*   8 */
+  MRB_TT_OBJECT,      /*   9 */
+  MRB_TT_CLASS,       /*  10 */
+  MRB_TT_MODULE,      /*  11 */
+  MRB_TT_ICLASS,      /*  12 */
+  MRB_TT_SCLASS,      /*  13 */
+  MRB_TT_PROC,        /*  14 */
+  MRB_TT_ARRAY,       /*  15 */
+  MRB_TT_HASH,        /*  16 */
+  MRB_TT_STRING,      /*  17 */
+  MRB_TT_RANGE,       /*  18 */
+  MRB_TT_EXCEPTION,   /*  19 */
+  MRB_TT_FILE,        /*  20 */
+  MRB_TT_ENV,         /*  21 */
+  MRB_TT_DATA,        /*  22 */
+  MRB_TT_FIBER,       /*  23 */
+  MRB_TT_MAXDEFINE    /*  24 */
 };
+
+#ifdef MRB_ENDIAN_BIG
+#define MRB_ENDIAN_LOHI(a,b) a b
+#else
+#define MRB_ENDIAN_LOHI(a,b) b a
+#endif
 
 #include "mruby/object.h"
 
-#if defined(MRB_NAN_BOXING)
-#include "boxing_nan.h"
-#elif defined(MRB_WORD_BOXING)
+#if defined(MRB_WORD_BOXING)
 #include "boxing_word.h"
+#elif defined(MRB_COMPLEX)
+#include "boxing_cpx.h"
+#elif defined(MRB_NAN_BOXING)
+#include "boxing_nan.h"
 #else
 #include "boxing_no.h"
 #endif
@@ -111,19 +120,32 @@ enum mrb_vtype {
 #define mrb_undef_p(o) (mrb_type(o) == MRB_TT_UNDEF)
 #endif
 #ifndef mrb_nil_p
-#define mrb_nil_p(o)  (mrb_type(o) == MRB_TT_FALSE && !mrb_fixnum(o))
+#define mrb_nil_p(o) (mrb_type(o) == MRB_TT_FALSE && !mrb_fixnum(o))
 #endif
 #ifndef mrb_bool
-#define mrb_bool(o)   (mrb_type(o) != MRB_TT_FALSE)
+#define mrb_bool(o) (mrb_type(o) != MRB_TT_FALSE)
 #endif
-#define mrb_float_p(o) (mrb_type(o) == MRB_TT_FLOAT)
+#ifndef mrb_complex_p
+#define mrb_complex_p(o) (mrb_type(o) == MRB_TT_COMPLEX)
+#endif
+#define mrb_float_p(o)  (mrb_type(o) == MRB_TT_FLOAT)
 #define mrb_symbol_p(o) (mrb_type(o) == MRB_TT_SYMBOL)
-#define mrb_array_p(o) (mrb_type(o) == MRB_TT_ARRAY)
+#define mrb_array_p(o)  (mrb_type(o) == MRB_TT_ARRAY)
 #define mrb_string_p(o) (mrb_type(o) == MRB_TT_STRING)
-#define mrb_hash_p(o) (mrb_type(o) == MRB_TT_HASH)
-#define mrb_cptr_p(o) (mrb_type(o) == MRB_TT_CPTR)
-#define mrb_test(o)   mrb_bool(o)
+#define mrb_hash_p(o)   (mrb_type(o) == MRB_TT_HASH)
+#define mrb_cptr_p(o)   (mrb_type(o) == MRB_TT_CPTR)
+#define mrb_test(o)     mrb_bool(o)
 mrb_bool mrb_regexp_p(struct mrb_state*, mrb_value);
+
+#ifdef MRB_COMPLEX
+static inline mrb_value
+mrb_complex_value(struct mrb_state *mrb, mrb_float real, mrb_float imag)
+{
+  mrb_value v;
+  SET_COMPLEX_VALUE(mrb, v, real, imag);
+  return v;
+}
+#endif
 
 static inline mrb_value
 mrb_float_value(struct mrb_state *mrb, mrb_float f)

--- a/mrbgems/mruby-fiber/src/fiber.c
+++ b/mrbgems/mruby-fiber/src/fiber.c
@@ -89,7 +89,7 @@ fiber_init(mrb_state *mrb, mrb_value self)
   c->stend = c->stbase + FIBER_STACK_INIT_SIZE;
   c->stack = c->stbase;
 
-#ifdef MRB_NAN_BOXING
+#ifdef MRB_VALUE_NIL_NONZERO
   {
     mrb_value *p = c->stbase;
     mrb_value *pend = p + FIBER_STACK_INIT_SIZE;

--- a/mrbgems/mruby-object-ext/src/object.c
+++ b/mrbgems/mruby-object-ext/src/object.c
@@ -74,6 +74,9 @@ mrb_obj_instance_exec(mrb_state *mrb, mrb_value self)
   }
 
   switch (mrb_type(self)) {
+#ifdef MRB_COMPLEX
+    case MRB_TT_COMPLEX:
+#endif
   case MRB_TT_SYMBOL:
   case MRB_TT_FIXNUM:
   case MRB_TT_FLOAT:

--- a/src/class.c
+++ b/src/class.c
@@ -972,6 +972,9 @@ mrb_singleton_class(mrb_state *mrb, mrb_value v)
     return mrb_obj_value(mrb->true_class);
   case MRB_TT_CPTR:
     return mrb_obj_value(mrb->object_class);
+#ifdef MRB_COMPLEX
+  case MRB_TT_COMPLEX:
+#endif
   case MRB_TT_SYMBOL:
   case MRB_TT_FIXNUM:
   case MRB_TT_FLOAT:

--- a/src/complex.c
+++ b/src/complex.c
@@ -1,0 +1,281 @@
+/*
+** complex.c - Complex class
+**
+** See Copyright Notice in mruby.h
+*/
+
+
+#include <float.h>
+#include <math.h>
+#include <stdlib.h>
+
+#include "mruby.h"
+#include "mruby/string.h"
+#include "mruby/numeric.h"
+
+#ifdef MRB_COMPLEX
+
+mrb_noreturn static void
+cpx_raise_not_numeric_error(mrb_state *mrb)
+{
+  mrb_raise(mrb, E_TYPE_ERROR, "non complex value");
+}
+
+static void
+cpx_print_to_string(mrb_state *mrb, mrb_value str, mrb_value self)
+{
+  mrb_str_concat(mrb, str, mrb_float_value(mrb, mrb_real(self)));
+  if (mrb_imag(self) >= 0 || isnan(mrb_imag(self)))
+    mrb_str_cat_lit(mrb, str, "+");
+  mrb_str_concat(mrb, str, mrb_float_value(mrb, mrb_imag(self)));
+  if (!isfinite(mrb_imag(self)))
+    mrb_str_cat_lit(mrb, str, "*");
+  mrb_str_cat_lit(mrb, str, "i");
+}
+
+static mrb_value
+cpx_to_s(mrb_state *mrb, mrb_value self)
+{
+  mrb_value str = mrb_str_buf_new(mrb, 48);
+
+  cpx_print_to_string(mrb, str, self);
+  return str;
+}
+
+static mrb_value
+cpx_inspect(mrb_state *mrb, mrb_value self)
+{
+  mrb_value str = mrb_str_buf_new(mrb, 48);
+
+  mrb_str_cat_lit(mrb, str, "(");
+  cpx_print_to_string(mrb, str, self);
+  mrb_str_cat_lit(mrb, str, ")");
+  return str;
+}
+
+static mrb_value
+cpx_new(mrb_state *mrb, mrb_value self)
+{
+  mrb_float real, imag;
+  int argc = mrb_get_args(mrb, "f|f", &real, &imag);
+  if (argc == 1) imag = 0.0;
+  return mrb_complex_value(mrb, real, imag);
+}
+
+static mrb_value
+cpx_real(mrb_state *mrb, mrb_value self)
+{
+  return mrb_float_value(mrb, mrb_real(self));
+}
+
+static mrb_value
+cpx_imag(mrb_state *mrb, mrb_value self)
+{
+  return mrb_float_value(mrb, mrb_imag(self));
+}
+
+static mrb_value
+cpx_equal(mrb_state *mrb, mrb_value self)
+{
+  mrb_value other;
+  mrb_float oreal, oimag;
+
+  mrb_get_args(mrb, "o", &other);
+  switch (mrb_type(other)) {
+  case MRB_TT_COMPLEX:
+    oreal = mrb_real(other);
+    oimag = mrb_imag(other);
+    break;
+  case MRB_TT_FIXNUM:
+    oreal = (mrb_float)mrb_fixnum(other);
+    oimag = 0;
+    break;
+  case MRB_TT_FLOAT:
+    oreal = mrb_float(other);
+    oimag = 0;
+    break;
+  default:
+    return mrb_false_value();
+  }
+  return mrb_bool_value(mrb_imag(self) == oimag && mrb_real(self) == oreal);
+}
+
+static mrb_value
+cpx_eql(mrb_state *mrb, mrb_value self)
+{
+  mrb_value other;
+
+  mrb_get_args(mrb, "o", &other);
+  if (!mrb_complex_p(other)) return mrb_false_value();
+  return mrb_bool_value(mrb_imag(self) == mrb_imag(other) && mrb_real(self) == mrb_real(other));
+}
+
+static mrb_value
+cpx_plus(mrb_state *mrb, mrb_value self)
+{
+  mrb_value other;
+  mrb_float oreal;
+
+  mrb_get_args(mrb, "o", &other);
+  switch (mrb_type(other)) {
+  case MRB_TT_COMPLEX:
+    return mrb_complex_value(mrb,
+      mrb_real(self) + mrb_real(other),
+      mrb_imag(self) + mrb_imag(other)
+    );
+    break;
+  case MRB_TT_FIXNUM:
+    oreal = (mrb_float)mrb_fixnum(other);
+    break;
+  case MRB_TT_FLOAT:
+    oreal = mrb_float(other);
+    break;
+  default:
+    cpx_raise_not_numeric_error(mrb);
+  }
+  return mrb_complex_value(mrb,
+    mrb_real(self) + oreal,
+    mrb_imag(self)
+  );
+}
+
+static mrb_value
+cpx_minus(mrb_state *mrb, mrb_value self)
+{
+  mrb_value other;
+  mrb_float oreal;
+
+  mrb_get_args(mrb, "o", &other);
+  switch (mrb_type(other)) {
+  case MRB_TT_COMPLEX:
+    return mrb_complex_value(mrb,
+      mrb_real(self) - mrb_real(other),
+      mrb_imag(self) - mrb_imag(other)
+    );
+    break;
+  case MRB_TT_FIXNUM:
+    oreal = (mrb_float)mrb_fixnum(other);
+    break;
+  case MRB_TT_FLOAT:
+    oreal = mrb_float(other);
+    break;
+  default:
+    cpx_raise_not_numeric_error(mrb);
+  }
+  return mrb_complex_value(mrb,
+    mrb_real(self) - oreal,
+    mrb_imag(self)
+  );
+}
+
+static mrb_value
+cpx_mul(mrb_state *mrb, mrb_value self)
+{
+  mrb_value other;
+  mrb_float oreal;
+
+  mrb_get_args(mrb, "o", &other);
+  switch (mrb_type(other)) {
+  case MRB_TT_COMPLEX:
+    return mrb_complex_value(mrb,
+      mrb_real(self) * mrb_real(other) - mrb_imag(self) * mrb_imag(other),
+      mrb_imag(self) * mrb_real(other) + mrb_real(self) * mrb_imag(other)
+      );
+    break;
+  case MRB_TT_FIXNUM:
+    oreal = (mrb_float)mrb_fixnum(other);
+    break;
+  case MRB_TT_FLOAT:
+    oreal = mrb_float(other);
+    break;
+  default:
+    cpx_raise_not_numeric_error(mrb);
+  }
+  return mrb_complex_value(mrb,
+    mrb_real(self) * oreal,
+    mrb_imag(self) * oreal
+  );
+}
+
+static mrb_value
+cpx_div(mrb_state *mrb, mrb_value self)
+{
+  mrb_value other;
+  mrb_float oreal;
+
+  mrb_get_args(mrb, "o", &other);
+  switch (mrb_type(other)) {
+  case MRB_TT_COMPLEX:
+    if (fabs(mrb_real(other)) > fabs(mrb_imag(other))) {
+      mrb_float r, n;
+      r = mrb_imag(other) / mrb_real(other);
+      n = mrb_real(other) * (r*r+1);
+      return mrb_complex_value(mrb,
+        (mrb_real(self) + (mrb_imag(self) * r)) / n,
+        (mrb_imag(self) - (mrb_real(self) * r)) / n
+      );
+    } else {
+      mrb_float r, n;
+      r = mrb_real(other) / mrb_imag(other);
+      n = mrb_imag(other) * (r*r+1);
+      return mrb_complex_value(mrb,
+        ((mrb_real(self) * r) + mrb_imag(self)) / n,
+        ((mrb_imag(self) * r) - mrb_real(self)) / n
+      );
+    }
+  case MRB_TT_FIXNUM:
+    oreal = (mrb_float)mrb_fixnum(other);
+    break;
+  case MRB_TT_FLOAT:
+    oreal = mrb_float(other);
+    break;
+  default:
+    cpx_raise_not_numeric_error(mrb);
+  }
+  return mrb_complex_value(mrb,
+    mrb_real(self) / oreal,
+    mrb_imag(self) / oreal
+  );
+}
+#endif
+
+/* ------------------------------------------------------------------------*/
+void
+mrb_init_complex(mrb_state *mrb)
+{
+#ifdef MRB_COMPLEX
+  struct RClass *complex, *numeric;
+  
+#ifndef MRB_WORD_BOXING
+  /* When not word boxing, make sure the binary representation of
+   * mrb_value is identical to C99 and C++ complex numbers.
+   */
+#ifdef MRB_USE_FLOAT
+  mrb_static_assert(sizeof(void*) == 4, "when using MRB_FLOAT and MRB_COMPLEX, sizeof pointer must be 4 bytes");
+  mrb_static_assert(sizeof(mrb_value) == 8, "sizeof mrb_value is not 8");
+#else
+  mrb_static_assert(sizeof(mrb_value) == 16, "sizeof mrb_value is not 16");
+#endif
+#endif
+  
+  /* Complex() initializer */
+  mrb_define_module_function(mrb, mrb->kernel_module, "Complex", cpx_new, MRB_ARGS_ARG(1,1));
+  /* Complex Class */
+  numeric = mrb_class_get(mrb, "Numeric");
+  complex = mrb->complex_class = mrb_define_class(mrb, "Complex", numeric);
+  mrb_undef_class_method(mrb,  complex, "new");
+  mrb_undef_method(mrb, complex, "<=>");
+  mrb_undef_method(mrb, complex, "**");
+  mrb_define_method(mrb, complex, "to_s", cpx_to_s, MRB_ARGS_REQ(1));
+  mrb_define_method(mrb, complex, "inspect", cpx_inspect, MRB_ARGS_REQ(1));
+  mrb_define_method(mrb, complex, "==", cpx_equal, MRB_ARGS_REQ(1));
+  mrb_define_method(mrb, complex, "eql?", cpx_eql, MRB_ARGS_REQ(1));
+  mrb_define_method(mrb, complex, "real", cpx_real, MRB_ARGS_NONE());
+  mrb_define_method(mrb, complex, "imag", cpx_imag, MRB_ARGS_NONE());
+  mrb_define_method(mrb, complex, "+", cpx_plus, MRB_ARGS_REQ(1));
+  mrb_define_method(mrb, complex, "-", cpx_minus, MRB_ARGS_REQ(1));
+  mrb_define_method(mrb, complex, "*", cpx_mul, MRB_ARGS_REQ(1));
+  mrb_define_method(mrb, complex, "/", cpx_div, MRB_ARGS_REQ(1));
+  mrb_define_method(mrb, complex, "quo", cpx_div, MRB_ARGS_REQ(1));
+#endif
+}

--- a/src/etc.c
+++ b/src/etc.c
@@ -104,6 +104,30 @@ mrb_float_id(mrb_float f)
   return id;
 }
 
+#ifdef MRB_COMPLEX
+static mrb_int
+mrb_complex_id(mrb_float real, mrb_float imag)
+{
+  const char *p = (const char*)&real;
+  int len = sizeof(real);
+  mrb_int id = 0;
+
+  while (len--) {
+    id = id*65599 + *p;
+    p++;
+  }
+  p = (const char*)&imag;
+  len = sizeof(imag);
+  while (len--) {
+    id = id*65599 + *p;
+    p++;
+  }
+  id = id + (id>>5);
+
+  return id;
+}
+#endif
+
 mrb_int
 mrb_obj_id(mrb_value obj)
 {
@@ -128,6 +152,10 @@ mrb_obj_id(mrb_value obj)
     return MakeID2(mrb_float_id((mrb_float)mrb_fixnum(obj)), MRB_TT_FLOAT);
   case  MRB_TT_FLOAT:
     return MakeID(mrb_float_id(mrb_float(obj)));
+#ifdef MRB_COMPLEX
+  case  MRB_TT_COMPLEX:
+    return MakeID(mrb_complex_id(mrb_real(obj), mrb_imag(obj)));
+#endif
   case  MRB_TT_STRING:
   case  MRB_TT_OBJECT:
   case  MRB_TT_CLASS:
@@ -147,6 +175,19 @@ mrb_obj_id(mrb_value obj)
 }
 
 #ifdef MRB_WORD_BOXING
+#ifdef MRB_COMPLEX
+mrb_value
+mrb_word_boxing_complex_value(mrb_state *mrb, mrb_float real, mrb_float imag)
+{
+  mrb_value v;
+
+  v.value.p = mrb_obj_alloc(mrb, MRB_TT_COMPLEX, mrb->complex_class);
+  v.value.cp->real = real;
+  v.value.cp->imag = imag;
+  return v;
+}
+#endif
+
 mrb_value
 mrb_word_boxing_float_value(mrb_state *mrb, mrb_float f)
 {

--- a/src/gc.c
+++ b/src/gc.c
@@ -108,6 +108,9 @@ typedef struct {
     struct RData data;
     struct RProc proc;
 #ifdef MRB_WORD_BOXING
+#ifdef MRB_COMPLEX
+    struct RComplex complexv;
+#endif
     struct RFloat floatv;
     struct RCptr cptr;
 #endif
@@ -604,6 +607,9 @@ obj_free(mrb_state *mrb, struct RBasic *obj)
     /* cannot happen */
     return;
 
+#ifdef MRB_COMPLEX
+  case MRB_TT_COMPLEX:
+#endif
   case MRB_TT_FLOAT:
 #ifdef MRB_WORD_BOXING
     break;

--- a/src/init.c
+++ b/src/init.c
@@ -19,6 +19,7 @@ void mrb_init_string(mrb_state*);
 void mrb_init_array(mrb_state*);
 void mrb_init_hash(mrb_state*);
 void mrb_init_numeric(mrb_state*);
+void mrb_init_complex(mrb_state*);
 void mrb_init_range(mrb_state*);
 void mrb_init_gc(mrb_state*);
 void mrb_init_math(mrb_state*);
@@ -44,6 +45,9 @@ mrb_init_core(mrb_state *mrb)
   mrb_init_array(mrb); DONE;
   mrb_init_hash(mrb); DONE;
   mrb_init_numeric(mrb); DONE;
+#ifdef MRB_COMPLEX
+  mrb_init_complex(mrb); DONE;
+#endif
   mrb_init_range(mrb); DONE;
   mrb_init_gc(mrb); DONE;
   mrb_init_version(mrb); DONE;

--- a/src/numeric.c
+++ b/src/numeric.c
@@ -93,10 +93,27 @@ mrb_num_div(mrb_state *mrb, mrb_value x, mrb_value y)
 static mrb_value
 num_div(mrb_state *mrb, mrb_value x)
 {
-  mrb_float y;
+  mrb_value y;
+  mrb_float f;
 
-  mrb_get_args(mrb, "f", &y);
-  return mrb_float_value(mrb, mrb_to_flo(mrb, x) / y);
+  f = mrb_to_flo(mrb, x);
+  mrb_get_args(mrb, "o", &y);
+#ifdef MRB_COMPLEX
+  if (mrb_complex_p(y)) {
+    if (fabs(mrb_real(y)) > fabs(mrb_imag(y))) {
+      mrb_float r, n;
+      r = mrb_imag(y) / mrb_real(y);
+      n = mrb_real(y) * (r*r+1);
+      return mrb_complex_value(mrb, f/n, -f*r/n);
+    } else {
+      mrb_float r, n;
+      r = mrb_real(y) / mrb_imag(y);
+      n = mrb_imag(y) * (r*r+1);
+      return mrb_complex_value(mrb, f*r/n, -f/n);
+    }
+  }
+#endif
+  return mrb_float_value(mrb, f / mrb_to_flo(mrb, y));
 }
 
 /********************************************************************
@@ -276,6 +293,11 @@ flo_minus(mrb_state *mrb, mrb_value x)
   mrb_value y;
 
   mrb_get_args(mrb, "o", &y);
+#ifdef MRB_COMPLEX
+  if (mrb_complex_p(y)) {
+    return mrb_complex_value(mrb,  mrb_float(x) - mrb_real(y), mrb_imag(y));
+  }
+#endif
   return mrb_float_value(mrb, mrb_float(x) - mrb_to_flo(mrb, y));
 }
 
@@ -294,6 +316,14 @@ flo_mul(mrb_state *mrb, mrb_value x)
   mrb_value y;
 
   mrb_get_args(mrb, "o", &y);
+#ifdef MRB_COMPLEX
+  if (mrb_complex_p(y)) {
+    return mrb_complex_value( mrb,
+      mrb_real(y) * mrb_float(x),
+      mrb_imag(y) * mrb_float(x)
+    );
+  }
+#endif
   return mrb_float_value(mrb, mrb_float(x) * mrb_to_flo(mrb, y));
 }
 
@@ -402,6 +432,10 @@ flo_eq(mrb_state *mrb, mrb_value x)
   mrb_get_args(mrb, "o", &y);
 
   switch (mrb_type(y)) {
+#ifdef MRB_COMPLEX
+    case MRB_TT_COMPLEX:
+    return mrb_bool_value(mrb_imag(y) == 0 && mrb_real(y) == mrb_float(x));
+#endif
   case MRB_TT_FIXNUM:
     b = (mrb_float)mrb_fixnum(y);
     break;
@@ -730,6 +764,14 @@ fix_mul(mrb_state *mrb, mrb_value x)
   mrb_value y;
 
   mrb_get_args(mrb, "o", &y);
+#ifdef MRB_COMPLEX
+  if (mrb_complex_p(y)) {
+    return mrb_complex_value( mrb,
+      mrb_real(y) * (mrb_float)mrb_fixnum(x),
+      mrb_imag(y) * (mrb_float)mrb_fixnum(x)
+    );
+  }
+#endif
   return mrb_fixnum_mul(mrb, x, y);
 }
 
@@ -864,6 +906,10 @@ fix_equal(mrb_state *mrb, mrb_value x)
 
   mrb_get_args(mrb, "o", &y);
   switch (mrb_type(y)) {
+#ifdef MRB_COMPLEX
+  case MRB_TT_COMPLEX:
+    return mrb_bool_value(mrb_imag(y) == 0 && mrb_real(y) == (mrb_float)mrb_fixnum(x));
+#endif
   case MRB_TT_FIXNUM:
     return mrb_bool_value(mrb_fixnum(x) == mrb_fixnum(y));
   case MRB_TT_FLOAT:
@@ -1133,6 +1179,11 @@ fix_plus(mrb_state *mrb, mrb_value self)
   mrb_value other;
 
   mrb_get_args(mrb, "o", &other);
+#ifdef MRB_COMPLEX
+  if (mrb_complex_p(other)) {
+    return mrb_complex_value(mrb, mrb_real(other) + (mrb_float)mrb_fixnum(self), mrb_imag(other));
+  }
+#endif
   return mrb_fixnum_plus(mrb, self, other);
 }
 
@@ -1170,6 +1221,11 @@ fix_minus(mrb_state *mrb, mrb_value self)
   mrb_value other;
 
   mrb_get_args(mrb, "o", &other);
+#ifdef MRB_COMPLEX
+  if (mrb_complex_p(other)) {
+    return mrb_complex_value(mrb, (mrb_float)mrb_fixnum(self) - mrb_real(other), mrb_imag(other));
+  }
+#endif
   return mrb_fixnum_minus(mrb, self, other);
 }
 
@@ -1281,6 +1337,11 @@ flo_plus(mrb_state *mrb, mrb_value x)
   mrb_value y;
 
   mrb_get_args(mrb, "o", &y);
+#ifdef MRB_COMPLEX
+  if (mrb_complex_p(y)) {
+    return mrb_complex_value(mrb, mrb_real(y) + mrb_float(x), mrb_imag(y));
+  }
+#endif
   return mrb_float_value(mrb, mrb_float(x) + mrb_to_flo(mrb, y));
 }
 

--- a/src/object.c
+++ b/src/object.c
@@ -26,6 +26,10 @@ mrb_obj_eq(mrb_state *mrb, mrb_value v1, mrb_value v2)
   case MRB_TT_FLOAT:
     return (mrb_float(v1) == mrb_float(v2));
 
+#ifdef MRB_COMPLEX
+  case MRB_TT_COMPLEX:
+    return (mrb_real(v1) == mrb_real(v2) && mrb_imag(v1) == mrb_imag(v2));
+#endif
   default:
     return (mrb_ptr(v1) == mrb_ptr(v2));
   }
@@ -373,6 +377,9 @@ static const struct types {
   {MRB_TT_SCLASS, "SClass"},
   {MRB_TT_PROC,   "Proc"},
   {MRB_TT_FLOAT,  "Float"},
+#ifdef MRB_COMPLEX
+  {MRB_TT_COMPLEX,"Complex"},
+#endif
   {MRB_TT_ARRAY,  "Array"},
   {MRB_TT_HASH,   "Hash"},
   {MRB_TT_STRING, "String"},

--- a/src/vm.c
+++ b/src/vm.c
@@ -60,7 +60,7 @@ The value below allows about 60000 recursive calls in the simplest case. */
 static inline void
 stack_clear(mrb_value *from, size_t count)
 {
-#ifndef MRB_NAN_BOXING
+#ifndef MRB_VALUE_NIL_NONZERO
   const mrb_value mrb_value_zero = { { 0 } };
 
   while (count-- > 0) {

--- a/test/assert.rb
+++ b/test/assert.rb
@@ -209,6 +209,15 @@ def assert_float(exp, act, msg = nil)
 end
 
 ##
+# Fails unless +exp+ is almost equal to +act+ in terms of a Complex number
+def assert_complex(exp, act, msg = nil)
+  msg = "Complex #{exp} expected to be equal to #{act}" unless msg
+  diff = assertion_diff(exp, act)
+  result = check_float(exp.real, act.real) and check_float(exp.imag, act.imag)
+  assert_true result, msg, diff
+end
+
+##
 # Report the test result and print all assertions
 # which were reported broken.
 def report()

--- a/test/t/complex.rb
+++ b/test/t/complex.rb
@@ -1,0 +1,58 @@
+if (Complex rescue nil) # Only run when built with MRB_COMPLEX
+
+assert("Complex() varargs") do
+  assert_equal 12.34, Complex(12.34).real
+  assert_equal 0, Complex(12.34).imag
+  assert_equal 12.34, Complex(12.34, 56.78).real
+  assert_equal 56.78, Complex(12.34, 56.78).imag
+end
+
+assert("Complex() equality") do
+  assert_not_equal Complex(0/0, 0/0), Complex(0/0, 0/0)
+  assert_not_equal Complex(12.34, 0), Complex(12.34, 56.78)
+  assert_not_equal Complex(12.34, 56.78), Complex(0, 56.78)
+  assert_equal Complex(12.34, 56.78), Complex(12.34, 56.78)
+  assert_equal 12.34, Complex(12.34)
+  assert_equal 42, Complex(42)
+  assert_equal Complex(12.34), 12.34
+  assert_equal Complex(42), 42
+end
+
+assert("Complex() addition") do
+  assert_complex Complex(8,10), Complex(3,4) + Complex(5,6)
+  assert_complex Complex(3.6,4), Complex(3.1,4) + 0.5
+  assert_complex Complex(8.1,4), Complex(3.1,4) + 5
+  assert_complex Complex(3.6,4), 0.5 + Complex(3.1,4)
+  assert_complex Complex(8.1,4), 5 + Complex(3.1,4)
+end
+
+assert("Complex() subtraction") do
+  assert_complex Complex(1,3), Complex(5,6) - Complex(4,3)
+  assert_complex Complex(2.6,4), Complex(3.1,4) - 0.5
+  assert_complex Complex(-1.9,4), Complex(3.1,4) - 5
+  assert_complex Complex(-2.6,4), 0.5 - Complex(3.1,4)
+  assert_complex Complex(1.9,4), 5 - Complex(3.1,4)
+end
+
+assert("Complex() multiplication") do
+  assert_complex Complex(2,39), Complex(5,6) * Complex(4,3)
+  assert_complex Complex(1.55,2), Complex(3.1,4) * 0.5
+  assert_complex Complex(15.5,20), Complex(3.1,4) * 5
+  assert_complex Complex(1.55,2), 0.5 * Complex(3.1,4)
+  assert_complex Complex(15.5,20), 5 * Complex(3.1,4)
+end
+
+assert("Complex() division") do
+  nans = Complex(-3,37) / Complex(0,0)
+  assert_true nans.real.nan?
+  assert_true nans.imag.nan?
+  assert_complex Complex(3,2), Complex(-3,37) / Complex(5,9)
+  assert_complex Complex(5,9), Complex(-3,37) / Complex(3,2)
+  assert_complex Complex(-2,-3), Complex(6,9) / -3
+  assert_complex Complex(0.4,-0.8), 2 / Complex(1,2)
+  assert_complex Complex(0.8,-0.4), 2 / Complex(2,1)
+  assert_complex Complex(0.2,-0.1), 0.5 / Complex(2,1)
+  assert_complex Complex(0.1,-0.2), 0.5 / Complex(1,2)
+end
+
+end


### PR DESCRIPTION
This is support for "fast" complex numbers in the core. Enable MRB_COMPLEX to turn it on. Normally, MRB_COMPLEX will use its own mrb_value boxing but you can also use it with MRB_WORD_BOXING.

Methods like **, abs, conj, phase, arg, and polar should probably be an mrbgem. Let me know if you agree. I will do this work after I review any changes made to this pull request.

Also, vm.c can speed up complex math in the same way as regular math. I will submit this as a separate pull request so you can decide if it should be in the core.
