### PR TITLE
Fix rake failure since `mrbtest_objs` isn't flattened.

### DIFF
--- a/tasks/mrbgem_spec.rake
+++ b/tasks/mrbgem_spec.rake
@@ -62,6 +62,7 @@ module MRuby
         @test_objs = Dir.glob("#{dir}/test/*.{c,cpp,cxx,cc,m,asm,s,S}").map do |f|
           objfile(f.relative_path_from(dir).to_s.pathmap("#{build_dir}/%X"))
         end
+        @custom_test_init = !@test_objs.empty?
         @test_preload = nil # 'test/assert.rb'
         @test_args = {}
 
@@ -187,6 +188,10 @@ module MRuby
 
       def test_dependencies
         [@name]
+      end
+
+      def custom_test_init?
+        @custom_test_init
       end
 
       def version_ok?(req_versions)

--- a/tasks/mrbgems_test.rake
+++ b/tasks/mrbgems_test.rake
@@ -3,6 +3,7 @@ MRuby.each_target do
 
   gems.each do |g|
     test_rbobj = g.test_rbireps.ext(exts.object)
+    g.test_objs << test_rbobj
     dep_list = gems.tsort_dependencies g.test_dependencies, gem_table
 
     file test_rbobj => g.test_rbireps
@@ -77,7 +78,7 @@ MRuby.each_target do
               f.puts %Q[  mrb_const_set(mrb2, mrb_obj_value(mrb2->object_class), mrb_intern_lit(mrb2, "TEST_ARGS"), test_args_hash); ]
             end
 
-            f.puts %Q[  mrb_#{g.funcname}_gem_test(mrb2);] unless g.test_objs.empty?
+            f.puts %Q[  mrb_#{g.funcname}_gem_test(mrb2);] if g.custom_test_init?
 
             f.puts %Q[  mrb_load_irep(mrb2, gem_test_irep_#{g.funcname}_#{i});]
             f.puts %Q[  ]

--- a/test/mrbtest.rake
+++ b/test/mrbtest.rake
@@ -12,10 +12,11 @@ MRuby.each_target do
   ass_lib = ass_c.ext(exts.object)
 
   mrbtest_lib = libfile("#{current_build_dir}/mrbtest")
-  mrbtest_objs = gems.map do |v|
-    v.test_objs + [v.test_rbireps.ext(exts.object)]
+  mrbtest_objs = [mlib, ass_lib]
+  gems.each do |v|
+    mrbtest_objs.concat v.test_objs
   end
-  file mrbtest_lib => [mlib, ass_lib] + mrbtest_objs do |t|
+  file mrbtest_lib => mrbtest_objs do |t|
     archiver.run t.name, t.prerequisites
   end
 


### PR DESCRIPTION
- Append generated test object to `@test_objs` of mrbgem spec.
- Add method `custom_test_init?` to check whether mrbgem has custom test initialization function.
