### PR TITLE
Inherit `$mrbtest_verbose` flag in core tests.

### DIFF
--- a/tasks/mrbgems_test.rake
+++ b/tasks/mrbgems_test.rake
@@ -34,15 +34,13 @@ MRuby.each_target do
           f.puts %Q[void GENERATED_TMP_mrb_#{d.funcname}_gem_init(mrb_state *mrb);]
           f.puts %Q[void GENERATED_TMP_mrb_#{d.funcname}_gem_final(mrb_state *mrb);]
         end
-        f.puts %Q[void mrb_init_test_driver(mrb_state *mrb);]
+        f.puts %Q[void mrb_init_test_driver(mrb_state *mrb, mrb_bool verbose);]
         f.puts %Q[void mrb_t_pass_result(mrb_state *dst, mrb_state *src);]
         f.puts %Q[void GENERATED_TMP_mrb_#{g.funcname}_gem_test(mrb_state *mrb) {]
         unless g.test_rbfiles.empty?
           f.puts %Q[  mrb_state *mrb2;]
-          if g.test_args.empty?
-            f.puts %Q[  mrb_value verbose;]
-          else
-            f.puts %Q[  mrb_value verbose, test_args_hash;]
+          unless g.test_args.empty?
+            f.puts %Q[  mrb_value test_args_hash;]
           end
           f.puts %Q[  int ai;]
           g.test_rbfiles.count.times do |i|
@@ -52,11 +50,7 @@ MRuby.each_target do
               f.puts %Q[  GENERATED_TMP_mrb_#{d.funcname}_gem_init(mrb2);]
               f.puts %Q[  mrb_state_atexit(mrb2, GENERATED_TMP_mrb_#{d.funcname}_gem_final);]
             end
-            f.puts %Q[  mrb_init_test_driver(mrb2);]
-            f.puts %Q[  verbose = mrb_gv_get(mrb, mrb_intern_lit(mrb, "$mrbtest_verbose"));]
-            f.puts %Q[  if (mrb_test(verbose)) {]
-            f.puts %Q[    mrb_gv_set(mrb2, mrb_intern_lit(mrb2, "$mrbtest_verbose"), verbose);]
-            f.puts %Q[  }]
+            f.puts %Q[  mrb_init_test_driver(mrb2, mrb_test(mrb_gv_get(mrb, mrb_intern_lit(mrb, "$mrbtest_verbose"))));]
             if test_preload.nil?
               f.puts %Q[  mrb_load_irep(mrb2, mrbtest_assert_irep);]
             else

--- a/test/driver.c
+++ b/test/driver.c
@@ -83,7 +83,7 @@ mrb_t_printstr(mrb_state *mrb, mrb_value self)
 }
 
 void
-mrb_init_test_driver(mrb_state *mrb)
+mrb_init_test_driver(mrb_state *mrb, mrb_bool verbose)
 {
   struct RClass *krn, *mrbtest;
 
@@ -95,6 +95,10 @@ mrb_init_test_driver(mrb_state *mrb)
   mrb_define_const(mrb, mrbtest, "FIXNUM_MAX", mrb_fixnum_value(MRB_INT_MAX));
   mrb_define_const(mrb, mrbtest, "FIXNUM_MIN", mrb_fixnum_value(MRB_INT_MIN));
   mrb_define_const(mrb, mrbtest, "FIXNUM_BIT", mrb_fixnum_value(MRB_INT_BIT));
+
+  if (verbose) {
+    mrb_gv_set(mrb, mrb_intern_lit(mrb, "$mrbtest_verbose"), mrb_true_value());
+  }
 }
 
 void
@@ -139,6 +143,7 @@ main(int argc, char **argv)
 {
   mrb_state *mrb;
   int ret;
+  mrb_bool verbose = FALSE;
 
   print_hint();
 
@@ -151,10 +156,10 @@ main(int argc, char **argv)
 
   if (argc == 2 && argv[1][0] == '-' && argv[1][1] == 'v') {
     printf("verbose mode: enable\n\n");
-    mrb_gv_set(mrb, mrb_intern_lit(mrb, "$mrbtest_verbose"), mrb_true_value());
+    verbose = TRUE;
   }
 
-  mrb_init_test_driver(mrb);
+  mrb_init_test_driver(mrb, verbose);
   mrb_init_mrbtest(mrb);
   ret = eval_test(mrb);
   mrb_close(mrb);

--- a/test/init_mrbtest.c
+++ b/test/init_mrbtest.c
@@ -1,12 +1,13 @@
 #include <stdlib.h>
 #include "mruby.h"
 #include "mruby/irep.h"
+#include "mruby/variable.h"
 
 extern const uint8_t mrbtest_assert_irep[];
 extern const uint8_t mrbtest_irep[];
 
 void mrbgemtest_init(mrb_state* mrb);
-void mrb_init_test_driver(mrb_state* mrb);
+void mrb_init_test_driver(mrb_state* mrb, mrb_bool verbose);
 void mrb_t_pass_result(mrb_state *mrb_dst, mrb_state *mrb_src);
 
 void
@@ -17,7 +18,7 @@ mrb_init_mrbtest(mrb_state *mrb)
   mrb_load_irep(mrb, mrbtest_assert_irep);
 
   core_test = mrb_open_core(mrb_default_allocf, NULL);
-  mrb_init_test_driver(core_test);
+  mrb_init_test_driver(core_test, mrb_test(mrb_gv_get(mrb, mrb_intern_lit(mrb, "$mrbtest_verbose"))));
   mrb_load_irep(core_test, mrbtest_assert_irep);
   mrb_load_irep(core_test, mrbtest_irep);
   mrb_t_pass_result(mrb, core_test);


### PR DESCRIPTION
Do flag inheriting in test driver initialization too.
