### PR TITLE
Add field `allocf_ud` to replace current `ud`.

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -112,6 +112,7 @@ typedef struct mrb_state {
   struct mrb_jmpbuf *jmp;
 
   mrb_allocf allocf;                      /* memory allocation function */
+  void *allocf_ud;                        /* auxiliary data of allocf */
 
   struct mrb_context *c;
   struct mrb_context *root_c;

--- a/src/gc.c
+++ b/src/gc.c
@@ -171,10 +171,10 @@ mrb_realloc_simple(mrb_state *mrb, void *p,  size_t len)
 {
   void *p2;
 
-  p2 = (mrb->allocf)(mrb, p, len, mrb->ud);
+  p2 = (mrb->allocf)(mrb, p, len, mrb->allocf_ud);
   if (!p2 && len > 0 && mrb->heaps) {
     mrb_full_gc(mrb);
-    p2 = (mrb->allocf)(mrb, p, len, mrb->ud);
+    p2 = (mrb->allocf)(mrb, p, len, mrb->allocf_ud);
   }
 
   return p2;
@@ -240,7 +240,7 @@ mrb_calloc(mrb_state *mrb, size_t nelem, size_t len)
 void
 mrb_free(mrb_state *mrb, void *p)
 {
-  (mrb->allocf)(mrb, p, 0, mrb->ud);
+  (mrb->allocf)(mrb, p, 0, mrb->allocf_ud);
 }
 
 #ifndef MRB_HEAP_PAGE_SIZE

--- a/src/state.c
+++ b/src/state.c
@@ -37,7 +37,7 @@ mrb_open_core(mrb_allocf f, void *ud)
   if (mrb == NULL) return NULL;
 
   *mrb = mrb_state_zero;
-  mrb->ud = ud;
+  mrb->allocf_ud = ud;
   mrb->allocf = f;
   mrb->current_white_part = MRB_GC_WHITE_A;
   mrb->atexit_stack_len = 0;


### PR DESCRIPTION
Since some use it as `mrb_state` associated user data.
