### PR TITLE
add Module#module_function

### DIFF
--- a/test/t/module.rb
+++ b/test/t/module.rb
@@ -522,3 +522,13 @@ assert('clone Module') do
 
   B.new.foo
 end
+
+assert('Module#module_function') do
+  module M
+    def modfunc; end
+    module_function :modfunc
+  end
+  
+  assert_true M.respond_to?(:modfunc)
+end
+


### PR DESCRIPTION
- Solves #1958 
- This patch adds the Module#module_function method.
- mruby does not support private and protected visibility. Thus, this patch does not support the usage with no argument.
