### PR TITLE
Silence "unused parameter" warnings in C++

### DIFF
--- a/include/mruby/value.h
+++ b/include/mruby/value.h
@@ -130,6 +130,7 @@ static inline mrb_value
 mrb_float_value(struct mrb_state *mrb, mrb_float f)
 {
   mrb_value v;
+  (void) mrb;
   SET_FLOAT_VALUE(mrb, v, f);
   return v;
 }
@@ -138,6 +139,7 @@ static inline mrb_value
 mrb_cptr_value(struct mrb_state *mrb, void *p)
 {
   mrb_value v;
+  (void) mrb;
   SET_CPTR_VALUE(mrb,v,p);
   return v;
 }


### PR DESCRIPTION
This has been done already, but the fixes were accidentally
removed in 249f05e7d70761823ef07a990276f9200e8b3302.
