### PR TITLE
mruby-sprintf: follow CRuby changes

### DIFF
--- a/mrbgems/mruby-sprintf/src/sprintf.c
+++ b/mrbgems/mruby-sprintf/src/sprintf.c
@@ -155,10 +155,7 @@ mrb_fix2binstr(mrb_state *mrb, mrb_value x, int base)
   ((nth >= argc) ? (mrb_raise(mrb, E_ARGUMENT_ERROR, "too few arguments"), mrb_undef_value()) : argv[nth])
 
 #define GETNAMEARG(id, name, len) ( \
-  posarg > 0 ? \
-  (mrb_raisef(mrb, E_ARGUMENT_ERROR, "named%S after unnumbered(%S)", mrb_str_new(mrb, (name), (len)), mrb_fixnum_value(posarg)), mrb_undef_value()) : \
-  posarg == -1 ? \
-  (mrb_raisef(mrb, E_ARGUMENT_ERROR, "named%S after numbered", mrb_str_new(mrb, (name), (len))), mrb_undef_value()) :    \
+  check_name_arg(mrb, posarg, name, len), \
   (posarg = -2, mrb_hash_fetch(mrb, get_hash(mrb, &hash, argc, argv), id, mrb_undef_value())))
 
 #define GETNUM(n, val) \
@@ -252,6 +249,17 @@ check_pos_arg(mrb_state *mrb, int posarg, int n)
   }
   if (n < 1) {
     mrb_raisef(mrb, E_ARGUMENT_ERROR, "invalid index - %S$", mrb_fixnum_value(n));
+  }
+}
+
+static void
+check_name_arg(mrb_state *mrb, int posarg, const char *name, mrb_int len)
+{
+  if (posarg > 0) {
+    mrb_raisef(mrb, E_ARGUMENT_ERROR, "named%S after unnumbered(%S)", mrb_str_new(mrb, name, len), mrb_fixnum_value(posarg));
+  }
+  if (posarg == -1) {
+    mrb_raisef(mrb, E_ARGUMENT_ERROR, "named%S after numbered", mrb_str_new(mrb, name, len));
   }
 }
 
@@ -675,7 +683,7 @@ retry:
         }
         symname = mrb_str_new(mrb, start + 1, p - start - 1);
         id = mrb_intern_str(mrb, symname);
-        nextvalue = GETNAMEARG(mrb_symbol_value(id), start, (int)(p - start + 1));
+        nextvalue = GETNAMEARG(mrb_symbol_value(id), start, p - start + 1);
         if (mrb_undef_p(nextvalue)) {
           mrb_raisef(mrb, E_KEY_ERROR, "key%S not found", mrb_str_new(mrb, start, p - start + 1));
         }

--- a/mrbgems/mruby-sprintf/src/sprintf.c
+++ b/mrbgems/mruby-sprintf/src/sprintf.c
@@ -147,13 +147,9 @@ mrb_fix2binstr(mrb_state *mrb, mrb_value x, int base)
   check_next_arg(mrb, posarg, nextarg), \
   (posarg = nextarg++, GETNTHARG(posarg)))
 
-#define GETPOSARG(n) (posarg > 0 ? \
-  (mrb_raisef(mrb, E_ARGUMENT_ERROR, "numbered(%S) after unnumbered(%S)", mrb_fixnum_value(n), mrb_fixnum_value(posarg)), mrb_undef_value()) : \
-  posarg == -2 ? \
-  (mrb_raisef(mrb, E_ARGUMENT_ERROR, "numbered(%S) after named", mrb_fixnum_value(n)), mrb_undef_value()) : \
-  ((n < 1) ? \
-  (mrb_raisef(mrb, E_ARGUMENT_ERROR, "invalid index - %S$", mrb_fixnum_value(n)), mrb_undef_value()) : \
-  (posarg = -1, GETNTHARG(n))))
+#define GETPOSARG(n) ( \
+  check_pos_arg(mrb, posarg, (n)), \
+  (posarg = -1, GETNTHARG(n)))
 
 #define GETNTHARG(nth) \
   ((nth >= argc) ? (mrb_raise(mrb, E_ARGUMENT_ERROR, "too few arguments"), mrb_undef_value()) : argv[nth])
@@ -242,6 +238,20 @@ check_next_arg(mrb_state *mrb, int posarg, int nextarg)
     mrb_raisef(mrb, E_ARGUMENT_ERROR, "unnumbered(%S) mixed with numbered", mrb_fixnum_value(nextarg));
   case -2:
     mrb_raisef(mrb, E_ARGUMENT_ERROR, "unnumbered(%S) mixed with named", mrb_fixnum_value(nextarg));
+  }
+}
+
+static void
+check_pos_arg(mrb_state *mrb, int posarg, int n)
+{
+  if (posarg > 0) {
+    mrb_raisef(mrb, E_ARGUMENT_ERROR, "numbered(%S) after unnumbered(%S)", mrb_fixnum_value(n), mrb_fixnum_value(posarg));
+  }
+  if (posarg == -2) {
+    mrb_raisef(mrb, E_ARGUMENT_ERROR, "numbered(%S) after named", mrb_fixnum_value(n));
+  }
+  if (n < 1) {
+    mrb_raisef(mrb, E_ARGUMENT_ERROR, "invalid index - %S$", mrb_fixnum_value(n));
   }
 }
 

--- a/mrbgems/mruby-sprintf/src/sprintf.c
+++ b/mrbgems/mruby-sprintf/src/sprintf.c
@@ -144,10 +144,7 @@ mrb_fix2binstr(mrb_state *mrb, mrb_value x, int base)
   GETNEXTARG())
 
 #define GETNEXTARG() ( \
-  posarg == -1 ? \
-  (mrb_raisef(mrb, E_ARGUMENT_ERROR, "unnumbered(%S) mixed with numbered", mrb_fixnum_value(nextarg)), mrb_undef_value()) : \
-  posarg == -2 ? \
-  (mrb_raisef(mrb, E_ARGUMENT_ERROR, "unnumbered(%S) mixed with named", mrb_fixnum_value(nextarg)), mrb_undef_value()) : \
+  check_next_arg(mrb, posarg, nextarg), \
   (posarg = nextarg++, GETNTHARG(posarg)))
 
 #define GETPOSARG(n) (posarg > 0 ? \
@@ -235,6 +232,17 @@ get_num(mrb_state *mrb, const char *p, const char *end, int *valp)
   }
   *valp = next_n;
   return p;
+}
+
+static void
+check_next_arg(mrb_state *mrb, int posarg, int nextarg)
+{
+  switch (posarg) {
+  case -1:
+    mrb_raisef(mrb, E_ARGUMENT_ERROR, "unnumbered(%S) mixed with numbered", mrb_fixnum_value(nextarg));
+  case -2:
+    mrb_raisef(mrb, E_ARGUMENT_ERROR, "unnumbered(%S) mixed with named", mrb_fixnum_value(nextarg));
+  }
 }
 
 static mrb_value

--- a/mrbgems/mruby-sprintf/src/sprintf.c
+++ b/mrbgems/mruby-sprintf/src/sprintf.c
@@ -141,6 +141,9 @@ mrb_fix2binstr(mrb_state *mrb, mrb_value x, int base)
 } while (0)
 
 #define GETARG() (!mrb_undef_p(nextvalue) ? nextvalue : \
+  GETNEXTARG())
+
+#define GETNEXTARG() ( \
   posarg == -1 ? \
   (mrb_raisef(mrb, E_ARGUMENT_ERROR, "unnumbered(%S) mixed with numbered", mrb_fixnum_value(nextarg)), mrb_undef_value()) : \
   posarg == -2 ? \
@@ -185,7 +188,7 @@ mrb_fix2binstr(mrb_state *mrb, mrb_value x, int base)
     tmp = GETPOSARG(n); \
   } \
   else { \
-    tmp = GETARG(); \
+    tmp = GETNEXTARG(); \
     p = t; \
   } \
   num = mrb_fixnum(tmp); \

--- a/mrbgems/mruby-sprintf/test/sprintf.rb
+++ b/mrbgems/mruby-sprintf/test/sprintf.rb
@@ -1,5 +1,7 @@
-#assert('Kernel.sprintf') do
-#end
+assert('sprintf invalid') do
+  assert_raise(ArgumentError) { sprintf('%1$*d', 3) }
+  assert_raise(ArgumentError) { sprintf('%1$.*d', 3) }
+end
 
 assert('String#%') do
   assert_equal "one=1", "one=%d" % 1


### PR DESCRIPTION
See [r46656](https://github.com/ruby/ruby/commit/3659c10b9d156cf8e12602996aa4719efc437ecd), [r46657](https://github.com/ruby/ruby/commit/420523389ec582f13924608ceb7640c95d7dd7a4), [r46658](https://github.com/ruby/ruby/commit/3f48c1fdf785f0d5a9939fc6163d9015d40e2b79), [r46659](https://github.com/ruby/ruby/commit/18a9926ad992f166cd1287ded00e9b7929c897c3) and [r46756](https://github.com/ruby/ruby/commit/8b427e357b707131614a45a3746dd06f9ac9a14b).
