### PR TITLE
don't always generate gem functions

### DIFF
--- a/tasks/mrbgem_spec.rake
+++ b/tasks/mrbgem_spec.rake
@@ -36,6 +36,8 @@ module MRuby
 
       attr_accessor :export_include_paths
 
+      attr_reader :generate_functions
+
       attr_block MRuby::Build::COMMANDS
 
       def initialize(name, &block)
@@ -56,7 +58,9 @@ module MRuby
         @objs = Dir.glob("#{dir}/src/*.{c,cpp,cxx,cc,m,asm,s,S}").map do |f|
           objfile(f.relative_path_from(@dir).to_s.pathmap("#{build_dir}/%X"))
         end
-        @objs << objfile("#{build_dir}/gem_init")
+
+        @generate_functions = !(@rbfiles.empty? && @objs.empty?)
+        @objs << objfile("#{build_dir}/gem_init") if @generate_functions
 
         @test_rbfiles = Dir.glob("#{dir}/test/*.rb")
         @test_objs = Dir.glob("#{dir}/test/*.{c,cpp,cxx,cc,m,asm,s,S}").map do |f|
@@ -89,7 +93,7 @@ module MRuby
           compiler.include_paths << "#{dir}/include" if File.directory? "#{dir}/include"
         end
 
-        define_gem_init_builder
+        define_gem_init_builder if @generate_functions
       end
 
       def add_dependency(name, *requirements)

--- a/tasks/ruby_ext.rake
+++ b/tasks/ruby_ext.rake
@@ -42,6 +42,15 @@ class Symbol
   end
 end
 
+module Enumerable
+  # Compatible with 1.9 on 1.8
+  def each_with_object(memo)
+    return to_enum :each_with_object, memo unless block_given?
+    each { |obj| yield obj, memo }
+    memo
+  end
+end
+
 $pp_show = true
 
 if $verbose.nil?


### PR DESCRIPTION
If the src and mrblib directories of a mrbgem don't exist or don't include "usable" files (for tools like mirb), then functions for gem initialization and finalization don't have to be generated.

I did some tests, but if I missed anything, please tell me as I'm not really familiar with the internals of the build system yet.
