### PR TITLE
revert accidental constify.

### DIFF
--- a/include/mruby/string.h
+++ b/include/mruby/string.h
@@ -101,7 +101,7 @@ MRB_API mrb_value mrb_str_cat_str(mrb_state *mrb, mrb_value str, mrb_value str2)
 MRB_API mrb_value mrb_str_append(mrb_state *mrb, mrb_value str, mrb_value str2);
 
 MRB_API int mrb_str_cmp(mrb_state *mrb, mrb_value str1, mrb_value str2);
-MRB_API const char *mrb_str_to_cstr(mrb_state *mrb, mrb_value str);
+MRB_API char *mrb_str_to_cstr(mrb_state *mrb, mrb_value str);
 mrb_value mrb_str_pool(mrb_state *mrb, mrb_value str);
 mrb_int mrb_str_hash(mrb_state *mrb, mrb_value str);
 mrb_value mrb_str_dump(mrb_state *mrb, mrb_value str);

--- a/src/string.c
+++ b/src/string.c
@@ -306,7 +306,7 @@ mrb_gc_free_str(mrb_state *mrb, struct RString *str)
     mrb_free(mrb, str->as.heap.ptr);
 }
 
-MRB_API const char*
+MRB_API char*
 mrb_str_to_cstr(mrb_state *mrb, mrb_value str0)
 {
   struct RString *s;


### PR DESCRIPTION
String returned by `mrb_str_to_cstr` can be changed by caller.
