### PR TITLE
Rename GC_STATE_NONE GC_STATE_ROOT

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -99,7 +99,7 @@ struct mrb_context {
 };
 
 enum gc_state {
-  GC_STATE_NONE = 0,
+  GC_STATE_ROOT = 0,
   GC_STATE_MARK,
   GC_STATE_SWEEP
 };


### PR DESCRIPTION
GC_STATE_NONE is inappropriate name. This state is to do nothing but to search reference objects from root , to mark it and  to insert them into queue recursively.

GC_STATE_ROOT is appropriate name.
