### PR TITLE
StopIteration is defined in mruby-enumerator, not in core.

### DIFF
--- a/mrbgems/mruby-enumerator/mrblib/enumerator.rb
+++ b/mrbgems/mruby-enumerator/mrblib/enumerator.rb
@@ -612,6 +612,16 @@ module Kernel
     Enumerator.new self, meth, *args
   end
   alias :enum_for :to_enum
+
+  def loop
+    return to_enum :loop unless block_given?
+
+    while(true)
+      yield
+    end
+  rescue StopIteration
+    nil
+  end
 end
 
 module Enumerable

--- a/mrblib/kernel.rb
+++ b/mrblib/kernel.rb
@@ -30,8 +30,6 @@ module Kernel
     while(true)
       yield
     end
-  rescue StopIteration
-    nil
   end
 
   # 11.4.4 Step c)


### PR DESCRIPTION
If you build mruby without mruby-enumerator, Kernel.loop fails because StopIteration is not defined.
