### PR TITLE
Fix a bug that class variable can't be referenced from class method

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -2175,6 +2175,15 @@ RETRY_TRY_BLOCK:
       }
       else {
         p = mrb_proc_new(mrb, irep->reps[GETARG_b(i)]);
+        if (c & OP_L_METHOD) {
+          if (p->target_class->tt == MRB_TT_SCLASS) {
+            mrb_value klass;
+            klass = mrb_obj_iv_get(mrb,
+                                   (struct RObject *)p->target_class,
+                                   mrb_intern_lit(mrb, "__attached__"));
+            p->target_class = mrb_class_ptr(klass);
+          }
+        }
       }
       if (c & OP_L_STRICT) p->flags |= MRB_PROC_STRICT;
       regs[GETARG_A(i)] = mrb_obj_value(p);

--- a/test/t/class.rb
+++ b/test/t/class.rb
@@ -370,3 +370,16 @@ assert('clone Class') do
 
   Foo.clone.new.func
 end
+
+assert('class variable and class << self style class method') do
+  class ClassVariableTest
+    @@class_variable = "value"
+    class << self
+      def class_variable
+        @@class_variable
+      end
+    end
+  end
+
+  assert_equal("value", ClassVariableTest.class_variable)
+end


### PR DESCRIPTION
Class method defined in singleton class should be evaluated in class
context not singleton class context.

fix #2515
