### PR TITLE
timer on windows bug fixed.

### DIFF
--- a/mrbgems/mruby-time/src/time.c
+++ b/mrbgems/mruby-time/src/time.c
@@ -80,7 +80,7 @@ gettimeofday(struct timeval *tv, void *tz)
     t.u64 -= UI64(116444736000000000);  /* Unix epoch bias */
     t.u64 /= 10;                      /* to microseconds */
     tv->tv_sec = (time_t)(t.u64 / (1000 * 1000));
-    tv->tv_usec = t.u64 % 1000 * 1000;
+    tv->tv_usec = t.u64 % (1000 * 1000);
   }
   return 0;
 }


### PR DESCRIPTION
timer implementation on windows(mingw and vc) is not correct. 

time_travel.rb

``` ruby
old_tm = Time.new

succeeded = true

10000.times do

  1000.times do
    Hash.new
  end

  tm = Time.new
  if tm < old_tm
    puts "time travel happened! now #{tm.to_f}, past #{old_tm.to_f}. failed!"
    succeeded = false
    break
  end

  old_tm = tm

end

if succeeded
  puts "no time travel. succeeded!."
end
```

this code outputs follows.

```
time travel happened! now 1407588844.0, past 1407588844.9990. failed!
```

mruby was builded like follows.

``` ruby
VCVAR_PATH = 'C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat'
MINIRAKE = '.\minirake'

puts `git clone https://github.com/mruby/mruby.git build_tmp/mruby`
Dir.chdir 'build_tmp/mruby'
puts `ruby #{MINIRAKE}`
#puts `cmd /c "call \"#{VCVAR_PATH.gsub("\\", "\\\\")}\" x86 & ruby #{MINIRAKE.gsub("\\", "\\\\")} -v"`
Dir.chdir '../..'

puts "time travel"
puts `build_tmp/mruby/build/host/bin/mruby time_travel.rb`

```
