### PR TITLE
fix build when neither src nor mrblib directory exists.

### DIFF
--- a/tasks/mrbgems_test.rake
+++ b/tasks/mrbgems_test.rake
@@ -4,10 +4,11 @@ MRuby.each_target do
   gems.each do |g|
     test_rbobj = g.test_rbireps.ext(exts.object)
     g.test_objs << test_rbobj
-    dep_list = gems.tsort_dependencies g.test_dependencies, gem_table
+    dep_list = gems.tsort_dependencies(g.test_dependencies, gem_table).select(&:generate_functions)
 
     file test_rbobj => g.test_rbireps
     file g.test_rbireps => [g.test_rbfiles].flatten + [File.join(g.dir, 'mrbgem.rake'), g.build.mrbcfile, __FILE__, "#{MRUBY_ROOT}/tasks/mrbgem_spec.rake"] do |t|
+      FileUtils.mkdir_p File.dirname(t.name)
       open(t.name, 'w') do |f|
         g.print_gem_test_header(f)
         test_preload = g.test_preload and [g.dir, MRUBY_ROOT].map {|dir|


### PR DESCRIPTION
One more step from #2503, we can have test-only mrbgem.
