### PR TITLE
Remove some roundoff from mrb_flo_to_str

### DIFF
--- a/src/numeric.c
+++ b/src/numeric.c
@@ -188,8 +188,8 @@ mrb_flo_to_str(mrb_state *mrb, mrb_float flo)
 
     /* puts digits */
     while (max_digits >= 0) {
-      double weight = pow(10.0, m);
-      double fdigit = n / weight;
+      double weight = (m < 0) ? 0.0 : pow(10.0, m);
+      double fdigit = (m < 0) ? n * 10.0 : n / weight;
 
       if (fdigit < 0) fdigit = n = 0;
       if (m < -1 && fdigit < FLO_EPSILON) {
@@ -204,7 +204,7 @@ mrb_flo_to_str(mrb_state *mrb, mrb_float flo)
         continue;
       }
       *(c++) = '0' + digit;
-      n -= (digit * weight);
+      n = (m < 0) ? n * 10.0 - digit : n - (digit * weight);
       max_digits--;
       if (m-- == 0) {
         *(c++) = '.';


### PR DESCRIPTION
The floating point number 3.125 converts to string as "3.12499999999999", even though it can be exactly represented in binary.

This change removes a source of roundoff error from mrb_flo_to_str.  Once the decimal point has been generated, instead of using pow(10.0, m) to extract the next digit, it multiplies n by 10 with each pass.  3.125 now converts as "3.125".
