### PR TITLE
Improve replacement math functions for Visual C++.

### DIFF
--- a/mrbgems/mruby-math/src/math.c
+++ b/mrbgems/mruby-math/src/math.c
@@ -23,10 +23,74 @@ domain_error(mrb_state *mrb, const char *func)
 
 #define MATH_TOLERANCE 1E-12
 
-#define asinh(x) log(x + sqrt(pow(x,2.0) + 1))
-#define acosh(x) log(x + sqrt(pow(x,2.0) - 1))
-#define atanh(x) (log(1+x) - log(1-x))/2.0
-#define cbrt(x)  pow(x,1.0/3.0)
+double
+asinh(double x)
+{
+  double xa, ya, y;
+
+  /* Basic formula loses precision for x < 0, but asinh is an odd function */
+  xa = fabs(x);
+  if (xa > 3.16227E+18) {
+    /* Prevent x*x from overflowing; basic formula reduces to log(2*x) */
+    ya = log(xa) + 0.69314718055994530942;
+  }
+  else {
+    /* Basic formula for asinh */
+    ya = log(xa + sqrt(xa*xa + 1.0));
+  }
+
+  y = copysign(ya, x);
+  return y;
+}
+
+double
+acosh(double x)
+{
+  double y;
+
+  if (x > 3.16227E+18) {
+    /* Prevent x*x from overflowing; basic formula reduces to log(2*x) */
+    y = log(x) + 0.69314718055994530942;
+  }
+  else {
+    /* Basic formula for acosh */
+    y = log(x + sqrt(x*x - 1.0));
+  }
+
+  return y;
+}
+
+double
+atanh(double x)
+{
+  double y;
+
+  if (fabs(x) < 1E-2) {
+    /* The sums 1+x and 1-x lose precision for small x.  Use the polynomial
+       instead. */
+    double x2 = x * x;
+    y = x*(1.0 + x2*(1.0/3.0 + x2*(1.0/5.0 + x2*(1.0/7.0))));
+  }
+  else {
+    /* Basic formula for atanh */
+    y = 0.5 * (log(1.0+x) - log(1.0-x));
+  }
+
+  return y;
+}
+
+double
+cbrt(double x)
+{
+  double xa, ya, y;
+
+  /* pow(x, y) is undefined for x < 0 and y not an integer, but cbrt is an
+     odd function */
+  xa = fabs(x);
+  ya = pow(xa, 1.0/3.0);
+  y = copysign(ya, x);
+  return y;
+}
 
 /* Declaration of complementary Error function */
 double


### PR DESCRIPTION
This change provides improved versions of asinh, acosh, atanh and cbrt for versions of Visual C++ that lack these functions:
- For asinh and acosh, the term pow(x, 2.0) overflows for |x| greater than sqrt(DBL_MAX).  For large positive x, sqrt(x_x+1) is indistinguishable from x, and so the basic formulas both reduce to log(2_x), coded as log(x) + log(2).
- For asinh, the term x - sqrt(x*x-1) approaches x - x and loses significance as x becomes more negative; but asinh is an odd function.  Coding asinh explicitly as an odd function also simplifies the overflow check.
- cbrt also needs to be explicitly coded as an odd function, because pow(x, y) returns NaN for x < 0 and y not an integer.
- For atanh, the sums 1+x and 1-x lose precision for small x.  Measurable error appears for |x| less than about 1E-2.  A polynomial approximation of four terms gives an accurate result for such small x.
