### PR TITLE
Fix error handling for mrb_pool_realloc().

### DIFF
--- a/src/pool.c
+++ b/src/pool.c
@@ -166,6 +166,9 @@ mrb_pool_realloc(mrb_pool *pool, void *p, size_t oldlen, size_t newlen)
     page = page->next;
   }
   np = mrb_pool_alloc(pool, newlen);
+  if (np == NULL) {
+      return NULL;
+  }
   memcpy(np, p, oldlen);
   return np;
 }


### PR DESCRIPTION
`mrb_pool_alloc()` may return `NULL`.
