### PR TITLE
Fix error handling for mrb_open_allocf().

### DIFF
--- a/src/state.c
+++ b/src/state.c
@@ -110,6 +110,10 @@ mrb_open_allocf(mrb_allocf f, void *ud)
 {
   mrb_state *mrb = mrb_open_core(f, ud);
 
+  if (mrb == NULL) {
+    return NULL;
+  }
+
 #ifndef DISABLE_GEMS
   mrb_init_mrbgems(mrb);
   mrb_gc_arena_restore(mrb, 0);


### PR DESCRIPTION
When `DISABLE_GEMS` is not defined and a return value of `mrb_open_core()` is `NULL`, `mrb_open_allocf()` may cause SEGV.
