### PR TITLE
Use specified macro(NULL) instead of magic-number.

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -128,7 +128,7 @@ mrb_class_outer_module(mrb_state *mrb, struct RClass *c)
   mrb_value outer;
 
   outer = mrb_obj_iv_get(mrb, (struct RObject*)c, mrb_intern_lit(mrb, "__outer__"));
-  if (mrb_nil_p(outer)) return 0;
+  if (mrb_nil_p(outer)) return NULL;
   return mrb_class_ptr(outer);
 }
 
@@ -1030,7 +1030,7 @@ mrb_method_search_vm(mrb_state *mrb, struct RClass **cp, mrb_sym mid)
     }
     c = c->super;
   }
-  return 0;                  /* no method */
+  return NULL;                  /* no method */
 }
 
 MRB_API struct RProc*
@@ -1295,7 +1295,7 @@ MRB_API struct RClass *
 mrb_class_real(struct RClass* cl)
 {
   if (cl == 0)
-    return 0;
+    return NULL;
   while ((cl->tt == MRB_TT_SCLASS) || (cl->tt == MRB_TT_ICLASS)) {
     cl = cl->super;
   }

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -2470,7 +2470,7 @@ scope_new(mrb_state *mrb, codegen_scope *prev, node *lv)
   mrb_pool *pool = mrb_pool_open(mrb);
   codegen_scope *p = (codegen_scope *)mrb_pool_alloc(pool, sizeof(codegen_scope));
 
-  if (!p) return 0;
+  if (!p) return NULL;
   *p = codegen_scope_zero;
   p->mrb = mrb;
   p->mpool = pool;

--- a/src/parse.y
+++ b/src/parse.y
@@ -5365,9 +5365,9 @@ mrb_parser_new(mrb_state *mrb)
   static const parser_state parser_state_zero = { 0 };
 
   pool = mrb_pool_open(mrb);
-  if (!pool) return 0;
+  if (!pool) return NULL;
   p = (parser_state *)mrb_pool_alloc(pool, sizeof(parser_state));
-  if (!p) return 0;
+  if (!p) return NULL;
 
   *p = parser_state_zero;
   p->mrb = mrb;
@@ -5483,7 +5483,7 @@ mrb_parse_file(mrb_state *mrb, FILE *f, mrbc_context *c)
   parser_state *p;
 
   p = mrb_parser_new(mrb);
-  if (!p) return 0;
+  if (!p) return NULL;
   p->s = p->send = NULL;
   p->f = f;
 
@@ -5498,7 +5498,7 @@ mrb_parse_nstring(mrb_state *mrb, const char *s, int len, mrbc_context *c)
   parser_state *p;
 
   p = mrb_parser_new(mrb);
-  if (!p) return 0;
+  if (!p) return NULL;
   p->s = s;
   p->send = s + len;
 


### PR DESCRIPTION
These might be trivial changes. But I think specified-macro(`NULL`) should be returned instead of magic-number(`0`) when a return value of pointer-type is nil.
