### PR TITLE
Fix build failed on VS2012

### DIFF
--- a/mrbgems/mruby-math/src/math.c
+++ b/mrbgems/mruby-math/src/math.c
@@ -21,6 +21,8 @@ domain_error(mrb_state *mrb, const char *func)
 /* math functions not provided by Microsoft Visual C++ 2012 or older */
 #if defined _MSC_VER && _MSC_VER < 1800
 
+#include <float.h>
+
 #define MATH_TOLERANCE 1E-12
 
 double
@@ -39,7 +41,7 @@ asinh(double x)
     ya = log(xa + sqrt(xa*xa + 1.0));
   }
 
-  y = copysign(ya, x);
+  y = _copysign(ya, x);
   return y;
 }
 
@@ -88,7 +90,7 @@ cbrt(double x)
      odd function */
   xa = fabs(x);
   ya = pow(xa, 1.0/3.0);
-  y = copysign(ya, x);
+  y = _copysign(ya, x);
   return y;
 }
 


### PR DESCRIPTION
use `_copysign` instead of `copysign`.
VS2012 or older is only have `_copysign` and `_copysignl`. (http://msdn.microsoft.com/en-us/library/0yafk1hc%28v=vs.110%29.aspx)
