### PR TITLE
Keep signs of small Fixnums to right of + and -

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -1934,7 +1934,12 @@ RETRY_TRY_BLOCK:
 #endif
         break;
       default:
-        SET_INT_VALUE(regs[a+1], GETARG_C(i));
+        if (syms[GETARG_B(i)] == mrb_intern_lit(mrb, "-")) {
+          SET_INT_VALUE(regs[a+1], -GETARG_C(i));
+        }
+        else {
+          SET_INT_VALUE(regs[a+1], GETARG_C(i));
+        }
         i = MKOP_ABC(OP_SEND, a, GETARG_B(i), 1);
         goto L_SEND;
       }
@@ -1973,7 +1978,12 @@ RETRY_TRY_BLOCK:
 #endif
         break;
       default:
-        SET_INT_VALUE(regs_a[1], GETARG_C(i));
+        if (syms[GETARG_B(i)] == mrb_intern_lit(mrb, "+")) {
+          SET_INT_VALUE(regs_a[1], -GETARG_C(i));
+        }
+        else {
+          SET_INT_VALUE(regs_a[1], GETARG_C(i));
+        }
         i = MKOP_ABC(OP_SEND, a, GETARG_B(i), 1);
         goto L_SEND;
       }

--- a/test/t/op_override.rb
+++ b/test/t/op_override.rb
@@ -1,0 +1,20 @@
+assert('operator override', 'issue #2557') do
+  class Optest
+    def +(x)
+      "add #{x}"
+    end
+    def -(x)
+      "sub #{x}"
+    end
+  end
+
+  q = Optest.new
+  assert_equal('add 5',  q + +5)
+  assert_equal('add -5', q + -5)
+  assert_equal('sub 5',  q - +5)
+  assert_equal('sub -5', q - -5)
+  assert_equal('add 500',  q + +500)
+  assert_equal('add -500', q + -500)
+  assert_equal('sub 500',  q - +500)
+  assert_equal('sub -500', q - -500)
+end


### PR DESCRIPTION
Resolve issue #2557:  When an OP_ADDI or OP_SUBI instruction must convert to a method call, check syms[GETARG_B(i)] for the method being called.  If the method does not match the instruction, the RHS is negative.
