### PR TITLE
printf: cast variables to the expected type

### DIFF
--- a/src/codegen.c
+++ b/src/codegen.c
@@ -2715,7 +2715,7 @@ codedump(mrb_state *mrb, mrb_irep *irep)
   int32_t line;
 
   if (!irep) return;
-  printf("irep %p nregs=%d nlocals=%d pools=%d syms=%d reps=%d\n", irep,
+  printf("irep %p nregs=%d nlocals=%d pools=%d syms=%d reps=%d\n", (void*)irep,
          irep->nregs, irep->nlocals, (int)irep->plen, (int)irep->slen, (int)irep->rlen);
 
   for (i = 0; i < (int)irep->ilen; i++) {

--- a/src/parse.y
+++ b/src/parse.y
@@ -6366,7 +6366,7 @@ mrb_parser_dump(mrb_state *mrb, node *tree, int offset)
     break;
 
   default:
-    printf("node type: %d (0x%x)\n", (int)n, (int)n);
+    printf("node type: %d (0x%x)\n", n, (unsigned)n);
     break;
   }
 #endif


### PR DESCRIPTION
%x expects unsigned int and %p expects void *

GCC emits a diagnostic about %p/void\* in pedantic mode:
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=26542
