### PR TITLE
delete obsolete macros (mrb_basic + mrb_object)

### DIFF
--- a/include/mruby/object.h
+++ b/include/mruby/object.h
@@ -37,16 +37,13 @@ struct RBasic {
   MRB_OBJECT_HEADER;
 };
 #define mrb_basic_ptr(v) ((struct RBasic*)(mrb_ptr(v)))
-/* obsolete macro mrb_basic; will be removed soon */
-#define mrb_basic(v)     mrb_basic_ptr(v)
 
 struct RObject {
   MRB_OBJECT_HEADER;
   struct iv_tbl *iv;
 };
 #define mrb_obj_ptr(v)   ((struct RObject*)(mrb_ptr(v)))
-/* obsolete macro mrb_object; will be removed soon */
-#define mrb_object(o) mrb_obj_ptr(o)
+
 #define mrb_immediate_p(x) (mrb_type(x) < MRB_TT_HAS_BASIC)
 #define mrb_special_const_p(x) mrb_immediate_p(x)
 


### PR DESCRIPTION
Over a year ago is not "soon" anymore. See:
88483fad0036e5cb023940f7c6d18006517fa731
243669308dfd10c8444c2992a883e165b9209941
