### PR TITLE
Support override of + - * / for Fixnum and Float.

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -184,6 +184,8 @@ typedef struct mrb_state {
   mrb_atexit_func *atexit_stack;
 #endif
   mrb_int atexit_stack_len;
+
+  unsigned numeric_methods;
 } mrb_state;
 
 #if __STDC_VERSION__ >= 201112L

--- a/src/class.c
+++ b/src/class.c
@@ -15,6 +15,7 @@
 #include "mruby/variable.h"
 #include "mruby/error.h"
 #include "mruby/data.h"
+#include "methods.h"
 
 KHASH_DEFINE(mt, mrb_sym, struct RProc*, TRUE, kh_int_hash_func, kh_int_hash_equal)
 
@@ -326,6 +327,36 @@ mrb_define_method_raw(mrb_state *mrb, struct RClass *c, mrb_sym mid, struct RPro
   kh_value(h, k) = p;
   if (p) {
     mrb_field_write_barrier(mrb, (struct RBasic *)c, (struct RBasic *)p);
+  }
+
+  /* Clear flag for optimized numeric method */
+  if (c == mrb->fixnum_class) {
+    if (mid == mrb_intern_lit(mrb, "+")) {
+        mrb->numeric_methods &= ~MRB_METHOD_FIXNUM_PLUS;
+    }
+    else if (mid == mrb_intern_lit(mrb, "-")) {
+        mrb->numeric_methods &= ~MRB_METHOD_FIXNUM_MINUS;
+    }
+    else if (mid == mrb_intern_lit(mrb, "*")) {
+        mrb->numeric_methods &= ~MRB_METHOD_FIXNUM_TIMES;
+    }
+    else if (mid == mrb_intern_lit(mrb, "/")) {
+        mrb->numeric_methods &= ~MRB_METHOD_FIXNUM_DIV;
+    }
+  }
+  else if (c == mrb->float_class) {
+    if (mid == mrb_intern_lit(mrb, "+")) {
+        mrb->numeric_methods &= ~MRB_METHOD_FLOAT_PLUS;
+    }
+    else if (mid == mrb_intern_lit(mrb, "-")) {
+        mrb->numeric_methods &= ~MRB_METHOD_FLOAT_MINUS;
+    }
+    else if (mid == mrb_intern_lit(mrb, "*")) {
+        mrb->numeric_methods &= ~MRB_METHOD_FLOAT_TIMES;
+    }
+    else if (mid == mrb_intern_lit(mrb, "/")) {
+        mrb->numeric_methods &= ~MRB_METHOD_FLOAT_DIV;
+    }
   }
 }
 

--- a/src/methods.h
+++ b/src/methods.h
@@ -1,0 +1,19 @@
+/*
+** methods.h - defines for method override flags
+**
+** See Copyright Notice in mruby.h
+*/
+
+#ifndef METHODS_H
+#define METHODS_H
+
+#define MRB_METHOD_FIXNUM_PLUS  0x01
+#define MRB_METHOD_FIXNUM_MINUS 0x02
+#define MRB_METHOD_FIXNUM_TIMES 0x04
+#define MRB_METHOD_FIXNUM_DIV   0x08
+#define MRB_METHOD_FLOAT_PLUS   0x10
+#define MRB_METHOD_FLOAT_MINUS  0x20
+#define MRB_METHOD_FLOAT_TIMES  0x40
+#define MRB_METHOD_FLOAT_DIV    0x80
+
+#endif /* METHODS_H */

--- a/src/numeric.c
+++ b/src/numeric.c
@@ -1341,12 +1341,12 @@ mrb_init_numeric(mrb_state *mrb)
 
   /* Use the optimizations until and unless the methods are overridden */
   mrb->numeric_methods |=
-          MRB_METHOD_FIXNUM_PLUS  ||
-          MRB_METHOD_FIXNUM_MINUS ||
-          MRB_METHOD_FIXNUM_TIMES ||
-          MRB_METHOD_FIXNUM_DIV   ||
-          MRB_METHOD_FLOAT_PLUS   ||
-          MRB_METHOD_FLOAT_MINUS  ||
-          MRB_METHOD_FLOAT_TIMES  ||
+          MRB_METHOD_FIXNUM_PLUS  |
+          MRB_METHOD_FIXNUM_MINUS |
+          MRB_METHOD_FIXNUM_TIMES |
+          MRB_METHOD_FIXNUM_DIV   |
+          MRB_METHOD_FLOAT_PLUS   |
+          MRB_METHOD_FLOAT_MINUS  |
+          MRB_METHOD_FLOAT_TIMES  |
           MRB_METHOD_FLOAT_DIV    ;
 }

--- a/src/numeric.c
+++ b/src/numeric.c
@@ -13,6 +13,7 @@
 #include "mruby/array.h"
 #include "mruby/numeric.h"
 #include "mruby/string.h"
+#include "methods.h"
 
 #ifdef MRB_USE_FLOAT
 #define floor(f) floorf(f)
@@ -1337,4 +1338,15 @@ mrb_init_numeric(mrb_state *mrb)
   mrb_define_method(mrb, fl,      "to_s",      flo_to_s,         MRB_ARGS_NONE()); /* 15.2.9.3.16(x) */
   mrb_define_method(mrb, fl,      "inspect",   flo_to_s,         MRB_ARGS_NONE());
   mrb_define_method(mrb, fl,      "nan?",      flo_nan_p,        MRB_ARGS_NONE());
+
+  /* Use the optimizations until and unless the methods are overridden */
+  mrb->numeric_methods |=
+          MRB_METHOD_FIXNUM_PLUS  ||
+          MRB_METHOD_FIXNUM_MINUS ||
+          MRB_METHOD_FIXNUM_TIMES ||
+          MRB_METHOD_FIXNUM_DIV   ||
+          MRB_METHOD_FLOAT_PLUS   ||
+          MRB_METHOD_FLOAT_MINUS  ||
+          MRB_METHOD_FLOAT_TIMES  ||
+          MRB_METHOD_FLOAT_DIV    ;
 }

--- a/src/vm.c
+++ b/src/vm.c
@@ -21,6 +21,7 @@
 #include "mruby/opcode.h"
 #include "value_array.h"
 #include "mrb_throw.h"
+#include "methods.h"
 
 #ifndef ENABLE_STDIO
 #if defined(__cplusplus)
@@ -1677,6 +1678,14 @@ RETRY_TRY_BLOCK:
       int a = GETARG_A(i);
 
       /* need to check if op is overridden */
+      if (mrb_type(regs[a]) == MRB_TT_FIXNUM
+      &&  (mrb->numeric_methods & MRB_METHOD_FIXNUM_PLUS) == 0) {
+        goto L_SEND;
+      }
+      if (mrb_type(regs[a]) == MRB_TT_FLOAT
+      &&  (mrb->numeric_methods & MRB_METHOD_FLOAT_PLUS) == 0) {
+        goto L_SEND;
+      }
       switch (TYPES2(mrb_type(regs[a]),mrb_type(regs[a+1]))) {
       case TYPES2(MRB_TT_FIXNUM,MRB_TT_FIXNUM):
         {
@@ -1736,6 +1745,14 @@ RETRY_TRY_BLOCK:
       int a = GETARG_A(i);
 
       /* need to check if op is overridden */
+      if (mrb_type(regs[a]) == MRB_TT_FIXNUM
+      &&  (mrb->numeric_methods & MRB_METHOD_FIXNUM_MINUS) == 0) {
+        goto L_SEND;
+      }
+      if (mrb_type(regs[a]) == MRB_TT_FLOAT
+      &&  (mrb->numeric_methods & MRB_METHOD_FLOAT_MINUS) == 0) {
+        goto L_SEND;
+      }
       switch (TYPES2(mrb_type(regs[a]),mrb_type(regs[a+1]))) {
       case TYPES2(MRB_TT_FIXNUM,MRB_TT_FIXNUM):
         {
@@ -1790,6 +1807,14 @@ RETRY_TRY_BLOCK:
       int a = GETARG_A(i);
 
       /* need to check if op is overridden */
+      if (mrb_type(regs[a]) == MRB_TT_FIXNUM
+      &&  (mrb->numeric_methods & MRB_METHOD_FIXNUM_TIMES) == 0) {
+        goto L_SEND;
+      }
+      if (mrb_type(regs[a]) == MRB_TT_FLOAT
+      &&  (mrb->numeric_methods & MRB_METHOD_FLOAT_TIMES) == 0) {
+        goto L_SEND;
+      }
       switch (TYPES2(mrb_type(regs[a]),mrb_type(regs[a+1]))) {
       case TYPES2(MRB_TT_FIXNUM,MRB_TT_FIXNUM):
         {
@@ -1854,6 +1879,14 @@ RETRY_TRY_BLOCK:
       int a = GETARG_A(i);
 
       /* need to check if op is overridden */
+      if (mrb_type(regs[a]) == MRB_TT_FIXNUM
+      &&  (mrb->numeric_methods & MRB_METHOD_FIXNUM_DIV) == 0) {
+        goto L_SEND;
+      }
+      if (mrb_type(regs[a]) == MRB_TT_FLOAT
+      &&  (mrb->numeric_methods & MRB_METHOD_FLOAT_DIV) == 0) {
+        goto L_SEND;
+      }
       switch (TYPES2(mrb_type(regs[a]),mrb_type(regs[a+1]))) {
       case TYPES2(MRB_TT_FIXNUM,MRB_TT_FIXNUM):
         {
@@ -1909,6 +1942,9 @@ RETRY_TRY_BLOCK:
       /* need to check if + is overridden */
       switch (mrb_type(regs[a])) {
       case MRB_TT_FIXNUM:
+        if ((mrb->numeric_methods & MRB_METHOD_FIXNUM_PLUS) == 0) {
+          goto L_SEND_ADDI;
+        }
         {
           mrb_int x = mrb_fixnum(regs[a]);
           mrb_int y = GETARG_C(i);
@@ -1922,6 +1958,9 @@ RETRY_TRY_BLOCK:
         }
         break;
       case MRB_TT_FLOAT:
+        if ((mrb->numeric_methods & MRB_METHOD_FLOAT_PLUS) == 0) {
+          goto L_SEND_ADDI;
+        }
 #ifdef MRB_WORD_BOXING
         {
           mrb_float x = mrb_float(regs[a]);
@@ -1931,8 +1970,14 @@ RETRY_TRY_BLOCK:
         mrb_float(regs[a]) += GETARG_C(i);
 #endif
         break;
+      L_SEND_ADDI:
       default:
-        SET_INT_VALUE(regs[a+1], GETARG_C(i));
+        if (syms[GETARG_B(i)] == mrb_intern_lit(mrb, "-")) {
+          SET_INT_VALUE(regs[a+1], -GETARG_C(i));
+        }
+        else {
+          SET_INT_VALUE(regs[a+1], GETARG_C(i));
+        }
         i = MKOP_ABC(OP_SEND, a, GETARG_B(i), 1);
         goto L_SEND;
       }
@@ -1947,6 +1992,9 @@ RETRY_TRY_BLOCK:
       /* need to check if + is overridden */
       switch (mrb_type(regs_a[0])) {
       case MRB_TT_FIXNUM:
+        if ((mrb->numeric_methods & MRB_METHOD_FIXNUM_MINUS) == 0) {
+          goto L_SEND_SUBI;
+        }
         {
           mrb_int x = mrb_fixnum(regs_a[0]);
           mrb_int y = GETARG_C(i);
@@ -1961,6 +2009,9 @@ RETRY_TRY_BLOCK:
         }
         break;
       case MRB_TT_FLOAT:
+        if ((mrb->numeric_methods & MRB_METHOD_FLOAT_MINUS) == 0) {
+          goto L_SEND_SUBI;
+        }
 #ifdef MRB_WORD_BOXING
         {
           mrb_float x = mrb_float(regs[a]);
@@ -1970,8 +2021,14 @@ RETRY_TRY_BLOCK:
         mrb_float(regs_a[0]) -= GETARG_C(i);
 #endif
         break;
+      L_SEND_SUBI:
       default:
-        SET_INT_VALUE(regs_a[1], GETARG_C(i));
+        if (syms[GETARG_B(i)] == mrb_intern_lit(mrb, "+")) {
+          SET_INT_VALUE(regs[a+1], -GETARG_C(i));
+        }
+        else {
+          SET_INT_VALUE(regs[a+1], GETARG_C(i));
+        }
         i = MKOP_ABC(OP_SEND, a, GETARG_B(i), 1);
         goto L_SEND;
       }

--- a/test/t/op_override.rb
+++ b/test/t/op_override.rb
@@ -1,0 +1,20 @@
+assert('operator override', 'issue #2557') do
+  class Optest
+    def +(x)
+      "add #{x}"
+    end
+    def -(x)
+      "sub #{x}"
+    end
+  end
+
+  q = Optest.new
+  assert_equal('add 5',  q + +5)
+  assert_equal('add -5', q + -5)
+  assert_equal('sub 5',  q - +5)
+  assert_equal('sub -5', q - -5)
+  assert_equal('add 500',  q + +500)
+  assert_equal('add -500', q + -500)
+  assert_equal('sub 500',  q - +500)
+  assert_equal('sub -500', q - -500)
+end


### PR DESCRIPTION
For support of mruby-bignum (https://github.com/chasonr/mruby-bignum/).

A set of flags is added to mrb_state, corresponding to each of eight numeric
methods with existing optimizations:  + - \* / for Fixnum and for Float.
If the flag is set, the method has not been overriden and the optimization
remains in effect.  If clear, the use of the operator produces a method call.
Thus these methods can be overriden, just like any other.

This pull request supersedes #2558, and addresses issue #2557.
