### PR TITLE
Refactor kernel.c

### DIFF
--- a/src/kernel.c
+++ b/src/kernel.c
@@ -597,12 +597,10 @@ static mrb_value
 mrb_obj_is_kind_of_m(mrb_state *mrb, mrb_value self)
 {
   mrb_value arg;
-  mrb_bool kind_of_p;
 
   mrb_get_args(mrb, "C", &arg);
-  kind_of_p = mrb_obj_is_kind_of(mrb, self, mrb_class_ptr(arg));
 
-  return mrb_bool_value(kind_of_p);
+  return mrb_bool_value(mrb_obj_is_kind_of(mrb, self, mrb_class_ptr(arg)));
 }
 
 KHASH_DECLARE(st, mrb_sym, char, FALSE)


### PR DESCRIPTION
It is unnecessary to assgin values to temporary variables.
