### PR TITLE
get rid of shadowing variables

### DIFF
--- a/src/codegen.c
+++ b/src/codegen.c
@@ -81,7 +81,7 @@ static struct loopinfo *loop_push(codegen_scope *s, enum looptype t);
 static void loop_break(codegen_scope *s, node *tree);
 static void loop_pop(codegen_scope *s, int val);
 
-static void gen_assignment(codegen_scope *s, node *node, int sp, int val);
+static void gen_assignment(codegen_scope *s, node *tree, int sp, int val);
 static void gen_vmassignment(codegen_scope *s, node *tree, int rhs, int val);
 
 static void codegen(codegen_scope *s, node *tree, int val);
@@ -327,10 +327,9 @@ genop_peep(codegen_scope *s, mrb_code i, int val)
       }
     case OP_STRCAT:
       if (c0 == OP_STRING) {
-        int i = GETARG_Bx(i0);
+        mrb_value v = s->irep->pool[GETARG_Bx(i0)];
 
-        if (mrb_type(s->irep->pool[i]) == MRB_TT_STRING &&
-            RSTRING_LEN(s->irep->pool[i]) == 0) {
+        if (mrb_string_p(v) && RSTRING_LEN(v) == 0) {
           s->pc--;
           return 0;
         }
@@ -845,34 +844,34 @@ gen_call(codegen_scope *s, node *tree, mrb_sym name, int sp, int val)
   push();pop();
   pop_n(n+1);
   {
-    mrb_int len;
-    const char *name = mrb_sym2name_len(s->mrb, sym, &len);
+    mrb_int symlen;
+    const char *symname = mrb_sym2name_len(s->mrb, sym, &symlen);
 
-    if (!noop && len == 1 && name[0] == '+')  {
+    if (!noop && symlen == 1 && symname[0] == '+')  {
       genop_peep(s, MKOP_ABC(OP_ADD, cursp(), idx, n), val);
     }
-    else if (!noop && len == 1 && name[0] == '-')  {
+    else if (!noop && symlen == 1 && symname[0] == '-')  {
       genop_peep(s, MKOP_ABC(OP_SUB, cursp(), idx, n), val);
     }
-    else if (!noop && len == 1 && name[0] == '*')  {
+    else if (!noop && symlen == 1 && symname[0] == '*')  {
       genop(s, MKOP_ABC(OP_MUL, cursp(), idx, n));
     }
-    else if (!noop && len == 1 && name[0] == '/')  {
+    else if (!noop && symlen == 1 && symname[0] == '/')  {
       genop(s, MKOP_ABC(OP_DIV, cursp(), idx, n));
     }
-    else if (!noop && len == 1 && name[0] == '<')  {
+    else if (!noop && symlen == 1 && symname[0] == '<')  {
       genop(s, MKOP_ABC(OP_LT, cursp(), idx, n));
     }
-    else if (!noop && len == 2 && name[0] == '<' && name[1] == '=')  {
+    else if (!noop && symlen == 2 && symname[0] == '<' && symname[1] == '=')  {
       genop(s, MKOP_ABC(OP_LE, cursp(), idx, n));
     }
-    else if (!noop && len == 1 && name[0] == '>')  {
+    else if (!noop && symlen == 1 && symname[0] == '>')  {
       genop(s, MKOP_ABC(OP_GT, cursp(), idx, n));
     }
-    else if (!noop && len == 2 && name[0] == '>' && name[1] == '=')  {
+    else if (!noop && symlen == 2 && symname[0] == '>' && symname[1] == '=')  {
       genop(s, MKOP_ABC(OP_GE, cursp(), idx, n));
     }
-    else if (!noop && len == 2 && name[0] == '=' && name[1] == '=')  {
+    else if (!noop && symlen == 2 && symname[0] == '=' && symname[1] == '=')  {
       genop(s, MKOP_ABC(OP_EQ, cursp(), idx, n));
     }
     else {
@@ -891,19 +890,19 @@ gen_call(codegen_scope *s, node *tree, mrb_sym name, int sp, int val)
 }
 
 static void
-gen_assignment(codegen_scope *s, node *node, int sp, int val)
+gen_assignment(codegen_scope *s, node *tree, int sp, int val)
 {
   int idx;
-  int type = (intptr_t)node->car;
+  int type = (intptr_t)tree->car;
 
-  node = node->cdr;
+  tree = tree->cdr;
   switch ((intptr_t)type) {
   case NODE_GVAR:
-    idx = new_sym(s, sym(node));
+    idx = new_sym(s, sym(tree));
     genop_peep(s, MKOP_ABx(OP_SETGLOBAL, sp, idx), val);
     break;
   case NODE_LVAR:
-    idx = lv_idx(s, sym(node));
+    idx = lv_idx(s, sym(tree));
     if (idx > 0) {
       if (idx != sp) {
         genop_peep(s, MKOP_AB(OP_MOVE, idx, sp), val);
@@ -915,7 +914,7 @@ gen_assignment(codegen_scope *s, node *node, int sp, int val)
       codegen_scope *up = s->prev;
 
       while (up) {
-        idx = lv_idx(up, sym(node));
+        idx = lv_idx(up, sym(tree));
         if (idx > 0) {
           genop_peep(s, MKOP_ABC(OP_SETUPVAR, sp, idx, lv), val);
           break;
@@ -926,29 +925,29 @@ gen_assignment(codegen_scope *s, node *node, int sp, int val)
     }
     break;
   case NODE_IVAR:
-    idx = new_sym(s, sym(node));
+    idx = new_sym(s, sym(tree));
     genop_peep(s, MKOP_ABx(OP_SETIV, sp, idx), val);
     break;
   case NODE_CVAR:
-    idx = new_sym(s, sym(node));
+    idx = new_sym(s, sym(tree));
     genop_peep(s, MKOP_ABx(OP_SETCV, sp, idx), val);
     break;
   case NODE_CONST:
-    idx = new_sym(s, sym(node));
+    idx = new_sym(s, sym(tree));
     genop_peep(s, MKOP_ABx(OP_SETCONST, sp, idx), val);
     break;
   case NODE_COLON2:
-    idx = new_sym(s, sym(node->cdr));
+    idx = new_sym(s, sym(tree->cdr));
     genop_peep(s, MKOP_AB(OP_MOVE, cursp(), sp), NOVAL);
     push();
-    codegen(s, node->car, VAL);
+    codegen(s, tree->car, VAL);
     pop_n(2);
     genop_peep(s, MKOP_ABx(OP_SETMCNST, cursp(), idx), val);
     break;
 
   case NODE_CALL:
     push();
-    gen_call(s, node, attrsym(s, sym(node->cdr->car)), sp, NOVAL);
+    gen_call(s, tree, attrsym(s, sym(tree->cdr->car)), sp, NOVAL);
     pop();
     if (val) {
       genop_peep(s, MKOP_AB(OP_MOVE, cursp(), sp), val);
@@ -2233,7 +2232,6 @@ codegen(codegen_scope *s, node *tree, int val)
       }
       if (n->cdr) {
         char *p2 = (char*)n->cdr;
-        int off;
 
         push();
         off = new_lit(s, mrb_str_new_cstr(s->mrb, p2));

--- a/src/parse.y
+++ b/src/parse.y
@@ -3967,22 +3967,22 @@ parse_string(parser_state *p)
 
   if (type & STR_FUNC_REGEXP) {
     int f = 0;
-    int c;
+    int re_opt;
     char *s = strndup(tok(p), toklen(p));
     char flags[3];
     char *flag = flags;
     char *dup;
 
     newtok(p);
-    while (c = nextc(p), c >= 0 && ISALPHA(c)) {
-      switch (c) {
+    while (re_opt = nextc(p), re_opt >= 0 && ISALPHA(re_opt)) {
+      switch (re_opt) {
       case 'i': f |= 1; break;
       case 'x': f |= 2; break;
       case 'm': f |= 4; break;
-      default: tokadd(p, c); break;
+      default: tokadd(p, re_opt); break;
       }
     }
-    pushback(p, c);
+    pushback(p, re_opt);
     if (toklen(p)) {
       char msg[128];
       tokfix(p);
@@ -5668,14 +5668,14 @@ void
 mrb_parser_dump(mrb_state *mrb, node *tree, int offset)
 {
 #ifdef ENABLE_STDIO
-  int n;
+  int current_node;
 
   if (!tree) return;
   again:
   dump_prefix(tree, offset);
-  n = (int)(intptr_t)tree->car;
+  current_node = (int)(intptr_t)tree->car;
   tree = tree->cdr;
-  switch (n) {
+  switch (current_node) {
   case NODE_BEGIN:
     printf("NODE_BEGIN:\n");
     dump_recur(mrb, tree, offset+1);
@@ -6402,7 +6402,7 @@ mrb_parser_dump(mrb_state *mrb, node *tree, int offset)
     break;
 
   default:
-    printf("node type: %d (0x%x)\n", n, (unsigned)n);
+    printf("node type: %d (0x%x)\n", current_node, (unsigned)current_node);
     break;
   }
 #endif

--- a/src/string.c
+++ b/src/string.c
@@ -1640,7 +1640,6 @@ mrb_str_rindex_m(mrb_state *mrb, mrb_value str)
   switch (mrb_type(sub)) {
     case MRB_TT_FIXNUM: {
       int c = mrb_fixnum(sub);
-      mrb_int len = RSTRING_LEN(str);
       unsigned char *p = (unsigned char*)RSTRING_PTR(str);
 
       for (pos=len-1;pos>=0;pos--) {

--- a/src/vm.c
+++ b/src/vm.c
@@ -2113,7 +2113,7 @@ RETRY_TRY_BLOCK:
       else {
         struct RArray *ary = mrb_ary_ptr(v);
         int len = ary->len;
-        int i;
+        int idx;
 
         if (len > pre + post) {
           regs[a++] = mrb_ary_new_from_values(mrb, len - pre - post, ary->ptr+pre);
@@ -2123,11 +2123,11 @@ RETRY_TRY_BLOCK:
         }
         else {
           regs[a++] = mrb_ary_new_capa(mrb, 0);
-          for (i=0; i+pre<len; i++) {
-            regs[a+i] = ary->ptr[pre+i];
+          for (idx=0; idx+pre<len; i++) {
+            regs[a+i] = ary->ptr[pre+idx];
           }
-          while (i < post) {
-            SET_NIL_VALUE(regs[a+i]);
+          while (idx < post) {
+            SET_NIL_VALUE(regs[a+idx]);
             i++;
           }
         }


### PR DESCRIPTION
Mostly by renaming the shadowing variable.
If a shadowing variable was deleted, the shadowed one can be used instead.

---

This is only for `src/*`. I'll create another PR for mrbgems.
