### PR TITLE
mrb_sym2name_len become faster.

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -167,6 +167,7 @@ typedef struct mrb_state {
 
   mrb_sym symidx;
   struct kh_n2s *name2sym;      /* symbol table */
+  struct kh_s2n *sym2name;
 
 #ifdef ENABLE_DEBUG
   void (*code_fetch_hook)(struct mrb_state* mrb, struct mrb_irep *irep, mrb_code *pc, mrb_value *regs);


### PR DESCRIPTION
mrb_sym2name_len used linear search.

this image is profiling result of my software.

![profile_mruby](https://cloud.githubusercontent.com/assets/553189/4263042/67d9df74-3bc6-11e4-8158-1eda69e0a1c4.png)

I change linear search to searching by hash.
