### PR TITLE
Remove duplicated mrb_print_backtrace() declaration

### DIFF
--- a/include/mruby/error.h
+++ b/include/mruby/error.h
@@ -23,7 +23,6 @@ MRB_API mrb_value mrb_exc_new_str(mrb_state *mrb, struct RClass* c, mrb_value st
 #define mrb_exc_new_str_lit(mrb, c, lit) mrb_exc_new_str(mrb, c, mrb_str_new_lit(mrb, lit))
 MRB_API mrb_value mrb_make_exception(mrb_state *mrb, int argc, const mrb_value *argv);
 MRB_API void mrb_exc_print(mrb_state *mrb, struct RObject *exc);
-MRB_API void mrb_print_backtrace(mrb_state *mrb);
 MRB_API mrb_value mrb_exc_backtrace(mrb_state *mrb, mrb_value exc);
 MRB_API mrb_value mrb_get_backtrace(mrb_state *mrb);
 MRB_API mrb_noreturn void mrb_no_method_error(mrb_state *mrb, mrb_sym id, mrb_int argc, const mrb_value *argv, const char *fmt, ...);


### PR DESCRIPTION
It is declared in mruby.h.
