### PR TITLE
target_class should not be TT_ICLASS in instance_eval(string); ref #1152

### DIFF
--- a/mrbgems/mruby-eval/src/eval.c
+++ b/mrbgems/mruby-eval/src/eval.c
@@ -1,4 +1,5 @@
 #include "mruby.h"
+#include "mruby/class.h"
 #include "mruby/compile.h"
 #include "mruby/irep.h"
 #include "mruby/proc.h"
@@ -197,6 +198,9 @@ f_instance_eval(mrb_state *mrb, mrb_value self)
 
     mrb_get_args(mrb, "s|zi", &s, &len, &file, &line);
     mrb->c->ci->acc = CI_ACC_SKIP;
+    if (mrb->c->ci->target_class->tt == MRB_TT_ICLASS) {
+      mrb->c->ci->target_class = mrb->c->ci->target_class->c;
+    }
     return mrb_run(mrb, create_proc_from_string(mrb, s, len, mrb_nil_value(), file, line), self);
   }
   else {


### PR DESCRIPTION
when mrb_funcall called instance_eval(string), mrb->c->ci->target_class doesn't modified.

``` c
mrb_funcall(mrb, mrb_obj_value(mrb->kernel_module), "instance_eval", 1, "class Foo; end");
// ==> TypeError: #<Kernel:0x8a256a0> is not a class/module
```

target_class should not be TT_ICLASS. ref #1152
