### PR TITLE
Change mrblib's source path to absolute path

### DIFF
--- a/mrblib/mrblib.rake
+++ b/mrblib/mrblib.rake
@@ -1,5 +1,5 @@
 MRuby.each_target do
-  current_dir = File.dirname(__FILE__).relative_path_from(Dir.pwd)
+  current_dir = File.dirname(__FILE__)
   relative_from_root = File.dirname(__FILE__).relative_path_from(MRUBY_ROOT)
   current_build_dir = "#{build_dir}/#{relative_from_root}"
 


### PR DESCRIPTION
A file name that is included in debug information of mrbgems libraries (written by Ruby) is stored as an absolute path.
But, a file name that is included in debug information of mrblib libraris (written by Ruby) is stored as a relative path.

I think absolute path is preferred when referring to the source file in the debugger.

Please accept PR that was changed to specify an absolute path name of the source file when compiling mrblib.
