### PR TITLE
fixed. cygwin-gcc(ver4.8.3) warning in conv_digit()

### DIFF
--- a/src/string.c
+++ b/src/string.c
@@ -1854,13 +1854,10 @@ mrb_cstr_to_inum(mrb_state *mrb, const char *str, int base, int badcheck)
   unsigned long n = 0;
   mrb_int val;
 
-#undef ISDIGIT
-#define ISDIGIT(c) ('0' <= (c) && (c) <= '9')
 #define conv_digit(c) \
-    (!ISASCII(c) ? -1 : \
-     isdigit(c) ? ((c) - '0') : \
-     islower(c) ? ((c) - 'a' + 10) : \
-     isupper(c) ? ((c) - 'A' + 10) : \
+    (ISDIGIT(c) ? ((c) - '0') : \
+     ISLOWER(c) ? ((c) - 'a' + 10) : \
+     ISUPPER(c) ? ((c) - 'A' + 10) : \
      -1)
 
   if (!str) {


### PR DESCRIPTION
Changed standard API to the macro in conv_digit().
