### PR TITLE
mirb: Don't exit on Ctrl-C

### DIFF
--- a/mrbgems/mruby-bin-mirb/tools/mirb/mirb.c
+++ b/mrbgems/mruby-bin-mirb/tools/mirb/mirb.c
@@ -327,6 +327,7 @@ main(int argc, char **argv)
   int char_index;
 #else
   char *history_path;
+  char* line;
 #endif
   mrbc_context *cxt;
   struct mrb_parser_state *parser;
@@ -411,7 +412,7 @@ main(int argc, char **argv)
     last_code_line[char_index++] = '\n';
     last_code_line[char_index] = '\0';
 #else
-    char* line = MIRB_READLINE(code_block_open ? "* " : "> ");
+    line = MIRB_READLINE(code_block_open ? "* " : "> ");
     if (line == NULL) {
       printf("\n");
       break;

--- a/mrbgems/mruby-bin-mirb/tools/mirb/mirb.c
+++ b/mrbgems/mruby-bin-mirb/tools/mirb/mirb.c
@@ -32,6 +32,16 @@
 #define MIRB_USING_HISTORY()
 #endif
 
+#ifndef _WIN32
+#define MIRB_SIGSETJMP(env) sigsetjmp(env, 1)
+#define MIRB_SIGLONGJMP(env, val) siglongjmp(env, val)
+#define SIGJMP_BUF sigjmp_buf
+#else
+#define MIRB_SIGSETJMP(env) setjmp(env)
+#define MIRB_SIGLONGJMP(env, val) longjmp(env, val)
+#define SIGJMP_BUF jmp_buf
+#endif
+
 #include "mruby.h"
 #include "mruby/array.h"
 #include "mruby/proc.h"
@@ -307,15 +317,22 @@ check_keyword(const char *buf, const char *word)
   return 1;
 }
 
-sigjmp_buf ctrl_c_buf;
 
-void 
-signal_handler(int signo)
+#ifndef ENABLE_READLINE
+volatile sig_atomic_t input_canceled = 0;
+void
+ctrl_c_handler(int signo)
 {
-  if (signo == SIGINT) {
-    longjmp(ctrl_c_buf, 1);
-  }
+  input_canceled = 1;
 }
+#else
+SIGJMP_BUF ctrl_c_buf;
+void
+ctrl_c_handler(int signo)
+{
+  MIRB_SIGLONGJMP(ctrl_c_buf, 1);
+}
+#endif
 
 int
 main(int argc, char **argv)
@@ -376,25 +393,11 @@ main(int argc, char **argv)
 
   ai = mrb_gc_arena_save(mrb);
 
-  if (signal(SIGINT, signal_handler) == SIG_ERR){
-    printf("failed to set signal handler\n");
-  }
-
   while (TRUE) {
-
-    if (setjmp(ctrl_c_buf) == 0) {
-      ; 
-    }
-    else {
-      ruby_code[0] = '\0';
-      last_code_line[0] = '\0';
-      code_block_open = FALSE;
-      puts("^C");
-    }
-
 #ifndef ENABLE_READLINE
     print_cmdline(code_block_open);
 
+    signal(SIGINT, ctrl_c_handler);
     char_index = 0;
     while ((last_char = getchar()) != '\n') {
       if (last_char == EOF) break;
@@ -404,6 +407,15 @@ main(int argc, char **argv)
       }
       last_code_line[char_index++] = last_char;
     }
+    signal(SIGINT, SIG_DFL);
+    if (input_canceled) {
+      ruby_code[0] = '\0';
+      last_code_line[0] = '\0';
+      code_block_open = FALSE;
+      puts("^C");
+      input_canceled = 0;
+      continue;
+    }
     if (last_char == EOF) {
       fputs("\n", stdout);
       break;
@@ -412,7 +424,19 @@ main(int argc, char **argv)
     last_code_line[char_index++] = '\n';
     last_code_line[char_index] = '\0';
 #else
+    if (MIRB_SIGSETJMP(ctrl_c_buf) == 0) {
+      ; 
+    }
+    else {
+      ruby_code[0] = '\0';
+      last_code_line[0] = '\0';
+      code_block_open = FALSE;
+      puts("^C");
+    }
+    signal(SIGINT, ctrl_c_handler);
     line = MIRB_READLINE(code_block_open ? "* " : "> ");
+    signal(SIGINT, SIG_DFL);
+
     if (line == NULL) {
       printf("\n");
       break;


### PR DESCRIPTION
mirb exits when I press Ctrl-C(SIGINT) during input.
I think it should go back prompt again, like irb.

 