### PR TITLE
fix test so that it can be ran multiple times instead of just once

### DIFF
--- a/test/t/kernel.rb
+++ b/test/t/kernel.rb
@@ -376,7 +376,7 @@ assert('Kernel#method_missing', '15.3.1.3.30') do
   end
 
   class NoInspectClass
-    undef inspect
+    undef inspect if instance_methods(true).include?(:inspect)
   end
   d = NoInspectClass.new
   begin


### PR DESCRIPTION
This is the only test in the whole suite that cannot be ran multiple times, because undef will fail the second time.
It is nice to be able to do this e.g. for benchmarking reasons.
