### PR TITLE
Add Kernel#String

### DIFF
--- a/mrbgems/mruby-kernel-ext/src/kernel.c
+++ b/mrbgems/mruby-kernel-ext/src/kernel.c
@@ -24,6 +24,31 @@ mrb_f_method(mrb_state *mrb, mrb_value self)
 
 /*
  *  call-seq:
+ *     String(arg)   -> string
+ *
+ *  Returns <i>arg</i> as an <code>String</code>.
+ *
+ *  First tries to call its <code>to_str</code> method, then its to_s method.
+ *
+ *     String(self)        #=> "main"
+ *     String(self.class)  #=> "Object"
+ *     String(123456)      #=> "123456"
+ */
+static mrb_value
+mrb_f_string(mrb_state *mrb, mrb_value self)
+{
+  mrb_value arg, tmp;
+
+  mrb_get_args(mrb, "o", &arg);
+  tmp = mrb_check_convert_type(mrb, arg, MRB_TT_STRING, "String", "to_str");
+  if (mrb_nil_p(tmp)) {
+    tmp = mrb_check_convert_type(mrb, arg, MRB_TT_STRING, "String", "to_s");
+  }
+  return tmp;
+}
+
+/*
+ *  call-seq:
  *     Array(arg)    -> array
  *
  *  Returns +arg+ as an Array.
@@ -57,6 +82,7 @@ mrb_mruby_kernel_ext_gem_init(mrb_state *mrb)
 
   mrb_define_module_function(mrb, krn, "fail", mrb_f_raise, MRB_ARGS_OPT(2));
   mrb_define_method(mrb, krn, "__method__", mrb_f_method, MRB_ARGS_NONE());
+  mrb_define_module_function(mrb, krn, "String", mrb_f_string, MRB_ARGS_REQ(1));
   mrb_define_module_function(mrb, krn, "Array", mrb_f_array, MRB_ARGS_REQ(1));
 }
 

--- a/mrbgems/mruby-kernel-ext/test/kernel.rb
+++ b/mrbgems/mruby-kernel-ext/test/kernel.rb
@@ -17,6 +17,12 @@ assert('Kernel#__method__') do
   assert_equal(:m2, c.new.m2)
 end
 
+assert('Kernel#String') do
+  assert_equal("main", String(self))
+  assert_equal("Object", String(self.class))
+  assert_equal("123456", String(123456))
+end
+
 assert('Kernel#Array') do
   assert_equal([1], Kernel.Array(1))
   assert_equal([1, 2, 3, 4, 5], Kernel.Array([1, 2, 3, 4, 5]))


### PR DESCRIPTION
I ported to mruby from ruby:
rb_String(VALUE val)
https://github.com/ruby/ruby/blob/trunk/object.c#L3010

rb_check_string_type
https://github.com/ruby/ruby/blob/trunk/string.c#L1745

I fixed doc.

ruby

```
 *  Converts <i>arg</i> to a <code>String</code> by calling its
 *  <code>to_s</code> method.
```

mruby

```
 *  Returns <i>arg</i> as an <code>String</code>.
 *
 *  First tries to call its <code>to_str</code> method, then its to_s method.
```
