### PR TITLE
Under cygwin host, ncurses.a is only available instead of termcap.a.

### DIFF
--- a/mrbgems/mruby-bin-mirb/mrbgem.rake
+++ b/mrbgems/mruby-bin-mirb/mrbgem.rake
@@ -6,7 +6,11 @@ MRuby::Gem::Specification.new('mruby-bin-mirb') do |spec|
   if spec.build.cc.search_header_path 'readline/readline.h'
     spec.cc.defines << "ENABLE_READLINE"
     if spec.build.cc.search_header_path 'termcap.h'
-      spec.linker.libraries << 'termcap'
+      if MRUBY_BUILD_HOST_IS_CYGWIN then
+        spec.linker.libraries << 'ncurses'
+      else
+        spec.linker.libraries << 'termcap'
+      end
     end
     spec.linker.libraries << 'readline'
   elsif spec.build.cc.search_header_path 'linenoise.h'


### PR DESCRIPTION
Please also see https://cygwin.com/ml/cygwin/2010-10/msg00018.html .
