### PR TITLE
Feature/fix misaligned access

### DIFF
--- a/include/mruby/dump.h
+++ b/include/mruby/dump.h
@@ -43,7 +43,7 @@ MRB_API mrb_irep *mrb_read_irep(mrb_state*, const uint8_t*);
 
 /* Rite Binary File header */
 #define RITE_BINARY_IDENTIFIER         "RITE"
-#define RITE_BINARY_FORMAT_VER         "0002"
+#define RITE_BINARY_FORMAT_VER         "0003"
 #define RITE_COMPILER_NAME             "MATZ"
 #define RITE_COMPILER_VERSION          "0000"
 
@@ -56,6 +56,7 @@ MRB_API mrb_irep *mrb_read_irep(mrb_state*, const uint8_t*);
 #define RITE_SECTION_LV_IDENTIFIER     "LVAR"
 
 #define MRB_DUMP_DEFAULT_STR_LEN      128
+#define MRB_DUMP_ALIGNMENT            sizeof(uint32_t)
 
 /* binary header */
 struct rite_binary_header {
@@ -65,6 +66,7 @@ struct rite_binary_header {
   uint8_t binary_size[4];     /* Binary Size */
   uint8_t compiler_name[4];   /* Compiler name */
   uint8_t compiler_version[4];
+  uint8_t padding[2];
 };
 
 /* section header */

--- a/src/load.c
+++ b/src/load.c
@@ -32,6 +32,12 @@
 #endif
 
 static size_t
+skip_padding(ptrdiff_t len, size_t align)
+{
+  return (-len) & (align - 1);
+}
+
+static size_t
 offset_crc_body(void)
 {
   struct rite_binary_header header;
@@ -64,6 +70,9 @@ read_irep_record_1(mrb_state *mrb, const uint8_t *bin, size_t *len, uint8_t flag
   irep->rlen = (size_t)bin_to_uint16(src);
   src += sizeof(uint16_t);
 
+  /* skip padding in irep header */
+  src += skip_padding(src - bin, MRB_DUMP_ALIGNMENT);
+
   /* Binary Data Section */
   /* ISEQ BLOCK */
   irep->ilen = (size_t)bin_to_uint32(src);
@@ -92,6 +101,7 @@ read_irep_record_1(mrb_state *mrb, const uint8_t *bin, size_t *len, uint8_t flag
       }
     }
   }
+  src += skip_padding(src - bin, MRB_DUMP_ALIGNMENT);
 
   /* POOL BLOCK */
   plen = (size_t)bin_to_uint32(src); /* number of pool */
@@ -137,6 +147,7 @@ read_irep_record_1(mrb_state *mrb, const uint8_t *bin, size_t *len, uint8_t flag
       mrb_gc_arena_restore(mrb, ai);
     }
   }
+  src += skip_padding(src - bin, MRB_DUMP_ALIGNMENT);
 
   /* SYMS BLOCK */
   irep->slen = (size_t)bin_to_uint32(src);  /* syms length */
@@ -167,6 +178,7 @@ read_irep_record_1(mrb_state *mrb, const uint8_t *bin, size_t *len, uint8_t flag
       mrb_gc_arena_restore(mrb, ai);
     }
   }
+  src += skip_padding(src - bin, MRB_DUMP_ALIGNMENT);
 
   irep->reps = (mrb_irep**)mrb_malloc(mrb, sizeof(mrb_irep*)*irep->rlen);
 


### PR DESCRIPTION
Using static irep binary (3492be4) fails on alignment-strict processors.
This patch adds padding bytes after and each header and block (iseq/pool/syms) to align to 4-byte boundary.
Note that dumped mrb format has changed.
(RITE_BINARY_FORMAT_VER "0002" => "0003")

I have tested on following machines:
- Intel x86_64 (gcc 4.8.3)
- Altera Nios II -- alignment-strict processor (nios2-elf-gcc 4.7.3)
