### PR TITLE
Modify Arduino build config for IDE >= 1.5.7

### DIFF
--- a/examples/targets/build_config_ArduinoDue.rb
+++ b/examples/targets/build_config_ArduinoDue.rb
@@ -27,7 +27,10 @@ MRuby::CrossBuild.new("ArduinoDue") do |conf|
   # ARDUINO_PATH = '/Applications/Arduino.app/Contents/Java'
   # GNU Linux
   ARDUINO_PATH = '/opt/arduino'
+   # Arduino IDE <= 1.5.6
   BIN_PATH = "#{ARDUINO_PATH}/hardware/tools/g++_arm_none_eabi/bin"
+  # Arduino IDE >= 1.5.7
+  # BIN_PATH = "#{ARDUINO_PATH}/hardware/tools/gcc-arm-none-eabi-4.8.3-2014q1/bin"
   SAM_PATH = "#{ARDUINO_PATH}/hardware/arduino/sam"
   TARGET_PATH = "#{SAM_PATH}/variants/arduino_due_x"
 


### PR DESCRIPTION
Arduino IDE >= 1.5.7 changes ARDUINO_PATH from `Contents/Resources/Java` to `Contents/Java`, and uses new gcc bundle, mentioned in #2632
