### PR TITLE
Fix mrb_iv_check function decleration

### DIFF
--- a/include/mruby/variable.h
+++ b/include/mruby/variable.h
@@ -40,7 +40,7 @@ MRB_API mrb_bool mrb_const_defined(mrb_state*, mrb_value, mrb_sym);
 MRB_API void mrb_const_remove(mrb_state*, mrb_value, mrb_sym);
 
 MRB_API mrb_bool mrb_iv_p(mrb_state *mrb, mrb_sym sym);
-MRB_API mrb_bool mrb_iv_check(mrb_state *mrb, mrb_sym sym);
+MRB_API void mrb_iv_check(mrb_state *mrb, mrb_sym sym);
 MRB_API mrb_value mrb_obj_iv_get(mrb_state *mrb, struct RObject *obj, mrb_sym sym);
 MRB_API void mrb_obj_iv_set(mrb_state *mrb, struct RObject *obj, mrb_sym sym, mrb_value v);
 MRB_API mrb_bool mrb_obj_iv_defined(mrb_state *mrb, struct RObject *obj, mrb_sym sym);


### PR DESCRIPTION
In the header file, the returned type for `mrb_iv_check` is `mrb_bool`.

However, at [here](https://github.com/mruby/mruby/blob/master/src/variable.c#L564) we can find the real returned type is `void`.
