### PR TITLE
Implement C API mrb_notimplement

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -221,6 +221,7 @@ MRB_API struct RClass * mrb_class_get(mrb_state *mrb, const char *name);
 MRB_API struct RClass * mrb_class_get_under(mrb_state *mrb, struct RClass *outer, const char *name);
 MRB_API struct RClass * mrb_module_get(mrb_state *mrb, const char *name);
 MRB_API struct RClass * mrb_module_get_under(mrb_state *mrb, struct RClass *outer, const char *name);
+MRB_API mrb_value mrb_notimplement(mrb_state*, mrb_value);
 
 MRB_API mrb_value mrb_obj_dup(mrb_state *mrb, mrb_value obj);
 MRB_API mrb_value mrb_check_to_integer(mrb_state *mrb, mrb_value val, const char *method);

--- a/src/class.c
+++ b/src/class.c
@@ -363,6 +363,22 @@ mrb_define_method_vm(mrb_state *mrb, struct RClass *c, mrb_sym name, mrb_value b
   }
 }
 
+MRB_API mrb_value
+mrb_notimplement(mrb_state *mrb, mrb_value self)
+{
+  const char *str;
+  mrb_int len;
+  mrb_callinfo *ci = mrb->c->ci;
+
+  if (ci->mid) {
+    str = mrb_sym2name_len(mrb, ci->mid, &len);
+    mrb_raisef(mrb, E_NOTIMP_ERROR,
+      "%S() function is unimplemented on this machine not implemented",
+      mrb_str_new_static(mrb, str, (size_t)len));
+  }
+  return mrb_nil_value();
+}
+
 static mrb_value
 check_type(mrb_state *mrb, mrb_value val, enum mrb_vtype t, const char *c, const char *m)
 {


### PR DESCRIPTION
I propose new C api `mrb_notimplement`.

This function offer a versatile method just like CRuby's `rb_notimplement` function.
