### PR TITLE
Rename from mrb_notimplement to mrb_f_notimplement

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -221,7 +221,7 @@ MRB_API struct RClass * mrb_class_get(mrb_state *mrb, const char *name);
 MRB_API struct RClass * mrb_class_get_under(mrb_state *mrb, struct RClass *outer, const char *name);
 MRB_API struct RClass * mrb_module_get(mrb_state *mrb, const char *name);
 MRB_API struct RClass * mrb_module_get_under(mrb_state *mrb, struct RClass *outer, const char *name);
-MRB_API mrb_value mrb_notimplement(mrb_state*, mrb_value);
+MRB_API mrb_value mrb_f_notimplement(mrb_state*, mrb_value);
 
 MRB_API mrb_value mrb_obj_dup(mrb_state *mrb, mrb_value obj);
 MRB_API mrb_value mrb_check_to_integer(mrb_state *mrb, mrb_value val, const char *method);

--- a/src/class.c
+++ b/src/class.c
@@ -364,7 +364,7 @@ mrb_define_method_vm(mrb_state *mrb, struct RClass *c, mrb_sym name, mrb_value b
 }
 
 MRB_API mrb_value
-mrb_notimplement(mrb_state *mrb, mrb_value self)
+mrb_f_notimplement(mrb_state *mrb, mrb_value self)
 {
   const char *str;
   mrb_int len;


### PR DESCRIPTION
I was re-thinking, The name of not implement C API is `mrb_f_notimplement` more good.
This is just like CRuby's `rb_f_notimplement`,
and we also would be able to have `mrb_notimplement` like CRuby's `rb_notimplement` in the future.
