### PR TITLE
Fix an error when calling a method implemented in C by super() with argu...

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -1250,7 +1250,12 @@ RETRY_TRY_BLOCK:
       mrb->c->stack[0] = recv;
 
       if (MRB_PROC_CFUNC_P(m)) {
-        ci->nregs = 0;
+        if (n == CALL_MAXARGS) {
+          ci->nregs = 3;
+        }
+        else {
+          ci->nregs = n + 2;
+        }
         mrb->c->stack[0] = m->body.func(mrb, recv);
         mrb_gc_arena_restore(mrb, ai);
         if (mrb->exc) goto L_RAISE;


### PR DESCRIPTION
This PR fixes an error when calling a method implemented in C by super() with some arguments .
It makes the following code workable:

Expected:

```
class MRBTime < Time; def self.new; super(2012, 4, 21); end; end
MRBTime.new # => Sat Apr 21 00:00:00 2012
```

Actual:

```
class MRBTime < Time; def self.new; super(2012, 4, 21); end; end
MRBTime.new # => can't convert nil into Integer (TypeError)
```
