### PR TITLE
mrdb: fix heap-use-after-free

### DIFF
--- a/mrbgems/mruby-bin-debugger/tools/mrdb/cmdmisc.c
+++ b/mrbgems/mruby-bin-debugger/tools/mrdb/cmdmisc.c
@@ -411,11 +411,11 @@ dbgcmd_list(mrb_state *mrb, mrdb_state *mrdb)
       filename = st->filename;
     }
     mrb_debug_list(mrb, mrdb->dbg, filename, st->line_min, st->line_max);
-    listcmd_parser_state_free(mrb, st);
 
     if (filename != NULL && filename != st->filename) {
       mrb_free(mrb, filename);
     }
+    listcmd_parser_state_free(mrb, st);
   }
 
   return DBGST_PROMPT;


### PR DESCRIPTION
```
=================================================================
==12327==ERROR: AddressSanitizer: heap-use-after-free on address 0x60300000d338 at pc 0x0000004c3bd2 bp 0x7fff137c22e0 sp 0x7fff137c22d8
READ of size 8 at 0x60300000d338 thread T0
    #0 0x4c3bd1 in dbgcmd_list /[REDACTED]/mruby-git/mrbgems/mruby-bin-debugger/tools/mrdb/cmdmisc.c:417:9
    #1 0x4c1ceb in mrb_debug_break_hook /[REDACTED]/mruby-git/mrbgems/mruby-bin-debugger/tools/mrdb/mrdb.c:634:10
    #2 0x4c1b36 in mrb_code_fetch_hook /[REDACTED]/mruby-git/mrbgems/mruby-bin-debugger/tools/mrdb/mrdb.c:616:3
    #3 0x4d960e in mrb_context_run /[REDACTED]/mruby-git/src/vm.c:1588:7
    #4 0x4dcbf1 in mrb_toplevel_run_keep /[REDACTED]/mruby-git/src/vm.c:2391:12
    #5 0x542730 in load_exec /[REDACTED]/mruby-git/src/parse.y:5599:7
    #6 0x4c0ab5 in main /[REDACTED]/mruby-git/mrbgems/mruby-bin-debugger/tools/mrdb/mrdb.c:692:9
    #7 0x7f455ad2b03f in __libc_start_main (/usr/lib/libc.so.6+0x2003f)
    #8 0x4bd3ec in _start (/[REDACTED]/mruby-git/bin/mrdb+0x4bd3ec)

0x60300000d338 is located 8 bytes inside of 24-byte region [0x60300000d330,0x60300000d348)
freed by thread T0 here:
    #0 0x49faeb in __interceptor_free (/[REDACTED]/mruby-git/bin/mrdb+0x49faeb)
    #1 0x4e91b9 in mrb_default_allocf /[REDACTED]/mruby-git/src/state.c:60:5
    #2 0x4c3b72 in dbgcmd_list /[REDACTED]/mruby-git/mrbgems/mruby-bin-debugger/tools/mrdb/cmdmisc.c:415:5
    #3 0x4c1ceb in mrb_debug_break_hook /[REDACTED]/mruby-git/mrbgems/mruby-bin-debugger/tools/mrdb/mrdb.c:634:10
    #4 0x4c1b36 in mrb_code_fetch_hook /[REDACTED]/mruby-git/mrbgems/mruby-bin-debugger/tools/mrdb/mrdb.c:616:3
    #5 0x4d960e in mrb_context_run /[REDACTED]/mruby-git/src/vm.c:1588:7
    #6 0x4dcbf1 in mrb_toplevel_run_keep /[REDACTED]/mruby-git/src/vm.c:2391:12
    #7 0x542730 in load_exec /[REDACTED]/mruby-git/src/parse.y:5599:7
    #8 0x4c0ab5 in main /[REDACTED]/mruby-git/mrbgems/mruby-bin-debugger/tools/mrdb/mrdb.c:692:9
    #9 0x7f455ad2b03f in __libc_start_main (/usr/lib/libc.so.6+0x2003f)

previously allocated by thread T0 here:
    #0 0x4a005e in realloc (/[REDACTED]/mruby-git/bin/mrdb+0x4a005e)
    #1 0x4c6dcd in mrb_realloc_simple /[REDACTED]/mruby-git/src/gc.c:177:8
    #2 0x4c7094 in mrb_realloc /[REDACTED]/mruby-git/src/gc.c:192:8
    #3 0x4c3bef in listcmd_parser_state_new /[REDACTED]/mruby-git/mrbgems/mruby-bin-debugger/tools/mrdb/cmdmisc.c:136:30
    #4 0x4c3a68 in dbgcmd_list /[REDACTED]/mruby-git/mrbgems/mruby-bin-debugger/tools/mrdb/cmdmisc.c:407:30
    #5 0x4c1ceb in mrb_debug_break_hook /[REDACTED]/mruby-git/mrbgems/mruby-bin-debugger/tools/mrdb/mrdb.c:634:10
    #6 0x4c1b36 in mrb_code_fetch_hook /[REDACTED]/mruby-git/mrbgems/mruby-bin-debugger/tools/mrdb/mrdb.c:616:3
    #7 0x4d960e in mrb_context_run /[REDACTED]/mruby-git/src/vm.c:1588:7
    #8 0x4dcbf1 in mrb_toplevel_run_keep /[REDACTED]/mruby-git/src/vm.c:2391:12
    #9 0x542730 in load_exec /[REDACTED]/mruby-git/src/parse.y:5599:7
    #10 0x4c0ab5 in main /[REDACTED]/mruby-git/mrbgems/mruby-bin-debugger/tools/mrdb/mrdb.c:692:9
    #11 0x7f455ad2b03f in __libc_start_main (/usr/lib/libc.so.6+0x2003f)

SUMMARY: AddressSanitizer: heap-use-after-free /[REDACTED]/mruby-git/mrbgems/mruby-bin-debugger/tools/mrdb/cmdmisc.c:417 dbgcmd_list
Shadow bytes around the buggy address:
  0x0c067fff9a10: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c067fff9a20: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c067fff9a30: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c067fff9a40: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c067fff9a50: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
=>0x0c067fff9a60: fd fd fd fa fa fa fd[fd]fd fa fa fa 00 00 00 00
  0x0c067fff9a70: fa fa 00 00 00 00 fa fa 00 00 04 fa fa fa 00 00
  0x0c067fff9a80: 00 fa fa fa 00 00 00 00 fa fa 00 00 00 fa fa fa
  0x0c067fff9a90: 00 00 00 04 fa fa 00 00 00 fa fa fa 00 00 00 fa
  0x0c067fff9aa0: fa fa 00 00 00 fa fa fa 00 00 00 fa fa fa 00 00
  0x0c067fff9ab0: 00 fa fa fa 00 00 00 fa fa fa 00 00 00 00 fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Heap right redzone:      fb
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack partial redzone:   f4
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  ASan internal:           fe
==12327==ABORTING
=================================================================
```
