### PR TITLE
remove unnecessary _WIN32 preprocessor check

### DIFF
--- a/src/load.c
+++ b/src/load.c
@@ -19,7 +19,7 @@
 #define FLAG_SRC_MALLOC 1
 #define FLAG_SRC_STATIC 0
 
-#if !defined(_WIN32) && SIZE_MAX < UINT32_MAX
+#if SIZE_MAX < UINT32_MAX
 # define SIZE_ERROR_MUL(x, y) ((x) > SIZE_MAX / (y))
 # define SIZE_ERROR(x) ((x) > SIZE_MAX)
 #else


### PR DESCRIPTION
I could be missing something, but `!defined(_WIN32)` seems unnecessary to me, as `SIZE_MAX < UINT32_MAX` is always false on Win32 / Win64.
