### PR TITLE
adhoc fix for pass build

### DIFF
--- a/mrbgems/mruby-bin-debugger/tools/mrdb/cmdbreak.c
+++ b/mrbgems/mruby-bin-debugger/tools/mrdb/cmdbreak.c
@@ -58,10 +58,11 @@ print_api_common_error(int32_t error)
 }
 
 #undef STRTOUL
-#define STRTOUL(ul,s) \
+#define STRTOUL(ul,s) { \
+    int i; \
     ul = 0; \
-    int i = 0; \
-    for(i=0; ISDIGIT(s[i]); i++) ul = 10*ul + (s[i] -'0');
+    for(i=0; ISDIGIT(s[i]); i++) ul = 10*ul + (s[i] -'0'); \
+}
 
 static int32_t
 parse_breakpoint_no(char* args)


### PR DESCRIPTION
mruby-bin-debugger enforce the std=gnu99 compile option.
if CFLAGS without std=gnu99, mruby debugger make build error as follows:.

> "gcc" -g -O3 -Wall -Werror-implicit-function-declaration -Wdeclaration-after-statement -DENABLE_DEBUG -DMRBGEM_MRUBY_BIN_DEBUGGER_VERSION=0.0.0 -I"/home/murase/git/mruby/include" -MMD -o "/home/murase/git/mruby/build/host-debug/mrbgems/mruby-bin-debugger/tools/mrdb/cmdbreak.o" -c "/home/murase/git/mruby/mrbgems/mruby-bin-debugger/tools/mrdb/cmdbreak.c"
> /home/murase/git/mruby/mrbgems/mruby-bin-debugger/tools/mrdb/cmdbreak.c: In function ‘parse_breakpoint_no’:
> /home/murase/git/mruby/mrbgems/mruby-bin-debugger/tools/mrdb/cmdbreak.c:63:5: error: ‘for’ loop initial declarations are only allowed in C99 or C11 mode
>      for(int i=0; ISDIGIT(s[i]); i++) ul = 10*ul + (s[i] -'0');
>      ^
> ...
