### PR TITLE
mrdb: add and use mrb_debug_{str,strn}dup()

### DIFF
--- a/mrbgems/mruby-bin-debugger/tools/mrdb/apibreak.c
+++ b/mrbgems/mruby-bin-debugger/tools/mrdb/apibreak.c
@@ -14,6 +14,7 @@
 #include "mruby/variable.h"
 #include "mrdberror.h"
 #include "apibreak.h"
+#include "apistring.h"
 
 #define MAX_BREAKPOINTNO (MAX_BREAKPOINT * 1024)
 #define MRB_DEBUG_BP_FILE_OK   (0x0001)
@@ -202,7 +203,7 @@ mrb_debug_set_break_line( mrb_state *mrb, mrb_debug_context *dbg, const char *fi
     return MRB_DEBUG_BREAK_INVALID_LINENO;
   } 
 
-  set_file = mrb_malloc(mrb, strlen(file) + 1);
+  set_file = mrb_debug_strdup(mrb, file);
   if(set_file == NULL) {
     return MRB_DEBUG_NOBUF;
   }
@@ -214,8 +215,6 @@ mrb_debug_set_break_line( mrb_state *mrb, mrb_debug_context *dbg, const char *fi
   dbg->bp[index].type = MRB_DEBUG_BPTYPE_LINE;
   dbg->bp[index].point.linepoint.lineno = lineno;
   dbg->bpnum++;
-
-  strncpy(set_file, file, strlen(file) + 1);
 
   dbg->bp[index].point.linepoint.file = set_file;
 
@@ -242,26 +241,22 @@ mrb_debug_set_break_method( mrb_state *mrb, mrb_debug_context *dbg, const char *
   }
 
   if(class_name != NULL) {
-    set_class = mrb_malloc(mrb, strlen(class_name) + 1);
+    set_class = mrb_debug_strdup(mrb, class_name);
     if(set_class == NULL) {
       return MRB_DEBUG_NOBUF;
     }
-    
-    strncpy(set_class, class_name, strlen(class_name) + 1);
   }
   else {
     set_class = NULL;
   }
 
-  set_method = mrb_malloc(mrb, strlen(method_name) + 1);
+  set_method = mrb_debug_strdup(mrb, method_name);
   if(set_method == NULL) {
     if(set_class != NULL) {
       mrb_free(mrb, (void*)set_class);
     }
     return MRB_DEBUG_NOBUF;
   }
-
-  strncpy(set_method, method_name, strlen(method_name) + 1);
 
   index = dbg->bpnum;
   dbg->bp[index].bpno = dbg->next_bpno;

--- a/mrbgems/mruby-bin-debugger/tools/mrdb/apilist.c
+++ b/mrbgems/mruby-bin-debugger/tools/mrdb/apilist.c
@@ -9,6 +9,7 @@
 #include "mrdb.h"
 #include "mrdberror.h"
 #include "apilist.h"
+#include "apistring.h"
 #include "mruby/compile.h"
 #include "mruby/irep.h"
 #include "mruby/debug.h"
@@ -64,7 +65,7 @@ static char*
 dirname(mrb_state *mrb, const char *path)
 {
   size_t len;
-  char *p, *dir;
+  char *p;
 
   if (path == NULL) {
     return NULL;
@@ -73,11 +74,7 @@ dirname(mrb_state *mrb, const char *path)
   p = strrchr(path, '/');
   len = p != NULL ? p - path : strlen(path);
 
-  if ((dir = mrb_malloc(mrb, len + 1)) != NULL) {
-    strncpy(dir, path, len);
-    dir[len] = '\0';
-  }
-  return dir;
+  return mrb_debug_strndup(mrb, path, len);
 }
 
 static source_file*
@@ -98,8 +95,10 @@ source_file_new(mrb_state *mrb, mrb_debug_context *dbg, char *filename)
   }
 
   file->lineno = 1;
-  file->path = mrb_malloc(mrb, strlen(filename) + 1);
-  strcpy(file->path, filename);
+  if ((file->path = mrb_debug_strdup(mrb, filename)) == NULL) {
+    source_file_free(mrb, file);
+    return NULL;
+  }
   return file;
 }
 

--- a/mrbgems/mruby-bin-debugger/tools/mrdb/apistring.c
+++ b/mrbgems/mruby-bin-debugger/tools/mrdb/apistring.c
@@ -1,0 +1,34 @@
+/*
+** apistring.c
+**
+*/
+
+#include <string.h>
+#include "apistring.h"
+
+static size_t
+mrb_debug_strnlen(const char *s, size_t maxlen)
+{
+  const char *p = memchr(s, '\0', maxlen);
+  return p != NULL ? (size_t)(p - s) : maxlen;
+}
+
+char*
+mrb_debug_strndup(mrb_state *mrb, const char *s, size_t size)
+{
+  size_t l = mrb_debug_strnlen(s, size);
+  char *d = mrb_malloc_simple(mrb, l + 1);
+  if (d != NULL) {
+    memcpy(d, s, l);
+    d[l] = '\0';
+  }
+  return d;
+}
+
+char*
+mrb_debug_strdup(mrb_state *mrb, const char *s)
+{
+  size_t z = strlen(s) + 1;
+  char *d = mrb_malloc_simple(mrb, z);
+  return d != NULL ? memcpy(d, s, z) : NULL;
+}

--- a/mrbgems/mruby-bin-debugger/tools/mrdb/apistring.h
+++ b/mrbgems/mruby-bin-debugger/tools/mrdb/apistring.h
@@ -1,0 +1,14 @@
+/*
+ * apistring.h
+ */
+
+#ifndef APISTRING_H_
+#define APISTRING_H_
+
+#include "mruby.h"
+
+/* both functions return a null pointer on failure */
+char *mrb_debug_strndup(mrb_state *mrb, const char *s, size_t size);
+char *mrb_debug_strdup(mrb_state *mrb, const char *s);
+
+#endif /* APISTRING_H_ */

--- a/mrbgems/mruby-bin-debugger/tools/mrdb/cmdmisc.c
+++ b/mrbgems/mruby-bin-debugger/tools/mrdb/cmdmisc.c
@@ -8,6 +8,7 @@
 #include <string.h>
 
 #include "apilist.h"
+#include "apistring.h"
 #include "mruby/compile.h"
 
 typedef struct help_msg {
@@ -226,10 +227,7 @@ parse_filename(mrb_state *mrb, char **sp, listcmd_parser_state *st)
     len = strlen(*sp);
   }
 
-  if (len > 0) {
-    st->filename = mrb_malloc(mrb, len + 1);
-    strncpy(st->filename, *sp, len);
-    st->filename[len] = '\0';
+  if (len > 0 && (st->filename = mrb_debug_strndup(mrb, *sp, len)) != NULL) {
     *sp += len;
     return TRUE;
   }


### PR DESCRIPTION
(cc: @mimaki)

I think it's a good idea to add and use these functions, because they're easier and safer (see #2652) to use than the previous (varying) combination of functions calls (`mrb_malloc()`+`strlen()`+`strncpy()` or `strcpy()`). They also simplify reading and maintaining the code a bit.

I'm unsure about the two new files, but I was also unsure about adding the functions to libmruby itself (`src/gc.c`).
