### PR TITLE
adding mruby-string-utf8 breaks String#[float]

### DIFF
--- a/mrbgems/mruby-string-utf8/src/string.c
+++ b/mrbgems/mruby-string-utf8/src/string.c
@@ -3,6 +3,7 @@
 #include "mruby/class.h"
 #include "mruby/string.h"
 #include "mruby/range.h"
+#include "mruby/numeric.h"
 #include "mruby/re.h"
 #include <ctype.h>
 #include <string.h>
@@ -257,6 +258,8 @@ mrb_str_aref(mrb_state *mrb, mrb_value str, mrb_value indx)
 
   mrb_regexp_check(mrb, indx);
   switch (mrb_type(indx)) {
+    case MRB_TT_FLOAT:
+      indx = mrb_flo_to_fixnum(mrb, indx);
     case MRB_TT_FIXNUM:
       idx = mrb_fixnum(indx);
 

--- a/mrbgems/mruby-string-utf8/test/string.rb
+++ b/mrbgems/mruby-string-utf8/test/string.rb
@@ -9,6 +9,7 @@ assert('String#[]') do
   assert_equal "世界", "こんにちは世界"[-2..-1]
   assert_equal "んに", "こんにちは世界"[1,2]
   assert_equal "世", "こんにちは世界"["世"]
+  assert_equal 'b', 'abc'[1.1]
 end
 
 assert('String#reverse', '15.2.10.5.29') do


### PR DESCRIPTION
#2651 is not perfect because same code exists in mruby-string-utf8 too.  When we build mruby with mruby-string-utf8:

```
% bin/mruby -e 'p "abc"[1.1]'
nil
```

Without mruby-string-utf8, it returns "b" as expected.
