### PR TITLE
mirb dies if #inspect returns a non-string value

### DIFF
--- a/mrbgems/mruby-bin-mirb/tools/mirb/mirb.c
+++ b/mrbgems/mruby-bin-mirb/tools/mirb/mirb.c
@@ -83,7 +83,9 @@ p(mrb_state *mrb, mrb_value obj, int prompt)
       obj = mrb_funcall(mrb, mrb_obj_value(mrb->exc), "inspect", 0);
     }
   }
-  fwrite(RSTRING_PTR(obj), RSTRING_LEN(obj), 1, stdout);
+  if (mrb_string_p(obj)) {
+    fwrite(RSTRING_PTR(obj), RSTRING_LEN(obj), 1, stdout);
+  }
   putc('\n', stdout);
 }
 


### PR DESCRIPTION
``` sh
% echo 'class A; def inspect; 1; end; end; A.new' | bin/mirb
mirb - Embeddable Interactive Ruby Shell

> 
zsh: segmentation fault (core dumped)  bin/mirb
```

`Kernel#p` shows nothing if `Object#inspect` returns a non-string value.  mirb should do that too.
