### PR TITLE
fix usage message

### DIFF
--- a/mrbgems/mruby-bin-strip/tools/mruby-strip/mruby-strip.c
+++ b/mrbgems/mruby-bin-strip/tools/mruby-strip/mruby-strip.c
@@ -31,8 +31,8 @@ irep_remove_lv(mrb_state *mrb, mrb_irep *irep)
 static void
 print_usage(const char *f)
 {
-  printf("Usage: %s [options] irepfiles\n", f);
-  printf("options:\n");
+  printf("Usage: %s [switches] irepfiles\n", f);
+  printf("switches:\n");
   printf("  -l, --lvar   remove LVAR section too.\n");
 }
 


### PR DESCRIPTION
make a Usage message in common.

mruby-bin-[mirb/mruby/mrcbc/...] is used a "switches" word. only mruby-strip is used "options".
