### PR TITLE
Fix crash if #inspect does not return a string value

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -1072,7 +1072,7 @@ mrb_method_search(mrb_state *mrb, struct RClass* c, mrb_sym mid)
   m = mrb_method_search_vm(mrb, &c, mid);
   if (!m) {
     mrb_value inspect = mrb_funcall(mrb, mrb_obj_value(c), "inspect", 0);
-    if (RSTRING_LEN(inspect) > 64) {
+    if (mrb_string_p(inspect) && RSTRING_LEN(inspect) > 64) {
       inspect = mrb_any_to_s(mrb, mrb_obj_value(c));
     }
     mrb_name_error(mrb, mid, "undefined method '%S' for class %S",
@@ -1324,7 +1324,7 @@ mrb_bob_missing(mrb_state *mrb, mrb_value mod)
   }
   else if (mrb_respond_to(mrb, mod, inspect) && mrb->c->ci - mrb->c->cibase < 64) {
     repr = mrb_funcall_argv(mrb, mod, inspect, 0, 0);
-    if (RSTRING_LEN(repr) > 64) {
+    if (mrb_string_p(repr) && RSTRING_LEN(repr) > 64) {
       repr = mrb_any_to_s(mrb, mod);
     }
   }


### PR DESCRIPTION
case 1

```
class A; def inspect; 1; end; end
A.new.a
```

case 2

```
class A
  def self.inspect
    1
  end
  alias_method :a, :b
end
```
