### PR TITLE
Make sure that mrb_string_value_ptr() returns a null-terminated string.

### DIFF
--- a/src/string.c
+++ b/src/string.c
@@ -646,7 +646,10 @@ MRB_API const char*
 mrb_string_value_ptr(mrb_state *mrb, mrb_value ptr)
 {
   mrb_value str = mrb_str_to_str(mrb, ptr);
-  return RSTRING_PTR(str);
+  const char *p = RSTRING_PTR(str);
+  if (p[RSTRING_LEN(str)] == '\0')
+    return p;
+  return mrb_string_value_cstr(mrb, &str);
 }
 
 void


### PR DESCRIPTION
This fixes the following unexpected behavior.

```
$ mirb
> ENV["PATH"]
 => "C:\Program Files ....
> ENV["PATH************************"[0..3]]
 => nil
```
