### PR TITLE
Fix splat and multiple assignments

### DIFF
--- a/src/codegen.c
+++ b/src/codegen.c
@@ -1001,7 +1001,9 @@ gen_vmassignment(codegen_scope *s, node *tree, int rhs, int val)
     }
     if (val) {
       genop(s, MKOP_AB(OP_MOVE, cursp(), rhs));
-      push();
+    }
+    else {
+      pop();
     }
     genop(s, MKOP_ABC(OP_APOST, cursp(), n, post));
     n = 1;
@@ -1016,6 +1018,7 @@ gen_vmassignment(codegen_scope *s, node *tree, int rhs, int val)
         n++;
       }
     }
+    push();
   }
 }
 

--- a/test/t/syntax.rb
+++ b/test/t/syntax.rb
@@ -181,6 +181,38 @@ assert('Splat and multiple assignment') do
   assert_equal [1,nil,2], [a,b,c]
 end
 
+assert('Splat and multiple assignment from variable') do
+  a = [1, 2, 3]
+  b, *c = a
+
+  assert_equal 1, b
+  assert_equal [2, 3], c
+end
+
+assert('Splat and multiple assignment from variables') do
+  a = [1, 2, 3]
+  b = [4, 5, 6, 7]
+  c, d, *e, f, g = *a, *b
+
+  assert_equal 1, c
+  assert_equal 2, d
+  assert_equal [3, 4, 5], e
+  assert_equal 6, f
+  assert_equal 7, g
+end
+
+assert('Splat and multiple assignment in for') do
+  a = [1, 2, 3, 4, 5, 6, 7]
+  for b, c, *d, e, f in [a] do
+  end
+
+  assert_equal 1, b
+  assert_equal 2, c
+  assert_equal [3, 4, 5], d
+  assert_equal 6, e
+  assert_equal 7, f
+end
+
 assert('Return values of case statements') do
   a = [] << case 1
   when 3 then 2


### PR DESCRIPTION
Case1: From variable

Code:

```
a = [1, 2, 3, 4, 5]
b, c, *d = a

p [a, b, c, d]
```

Before:

```
[[1, 2, 3, 4, 5], 1, 2, []]
```

After:

```
[[1, 2, 3, 4, 5], 1, 2, [3, 4, 5]]
```

Ruby:

```
[[1, 2, 3, 4, 5], 1, 2, [3, 4, 5]]
```

Case2: From variables

Code:

```
a = [1, 2, 3]
b = [4, 5, 6, 7]
c, d, *e, f, g = *a, *b

p [a, b, c, d, e, f, g]
```

Before:

```
[[1, 2, 3], [4, 5, 6, 7], 1, 2, [], 6, 7]
```

After:

```
[[1, 2, 3], [4, 5, 6, 7], 1, 2, [3, 4, 5], 6, 7]
```

Ruby:

```
[[1, 2, 3], [4, 5, 6, 7], 1, 2, [3, 4, 5], 6, 7]
```

Case 3: "for"

Code:

```
a = [1, 2, 3, 4, 5, 6, 7]
for b, c, *d, e, f in [a] do
  p [a, b, c, d, e, f]
end
```

Before:

```
[[1, 2, 3, 4, 5, 6, 7], 1, 2, [], nil, nil]
```

After:

```
[[1, 2, 3, 4, 5, 6, 7], 1, 2, [3, 4, 5], 6, 7]
```

Ruby:

```
[[1, 2, 3, 4, 5, 6, 7], 1, 2, [3, 4, 5], 6, 7]
```
