### PR TITLE
Remove redundant NULL checks for mrb_malloc().

### DIFF
--- a/mrbgems/mruby-bin-debugger/tools/mrdb/apibreak.c
+++ b/mrbgems/mruby-bin-debugger/tools/mrdb/apibreak.c
@@ -203,9 +203,6 @@ mrb_debug_set_break_line( mrb_state *mrb, mrb_debug_context *dbg, const char *fi
   } 
 
   set_file = mrb_malloc(mrb, strlen(file) + 1);
-  if(set_file == NULL) {
-    return MRB_DEBUG_NOBUF;
-  }
 
   index = dbg->bpnum;
   dbg->bp[index].bpno = dbg->next_bpno;
@@ -243,10 +240,6 @@ mrb_debug_set_break_method( mrb_state *mrb, mrb_debug_context *dbg, const char *
 
   if(class_name != NULL) {
     set_class = mrb_malloc(mrb, strlen(class_name) + 1);
-    if(set_class == NULL) {
-      return MRB_DEBUG_NOBUF;
-    }
-    
     strncpy(set_class, class_name, strlen(class_name) + 1);
   }
   else {
@@ -254,12 +247,6 @@ mrb_debug_set_break_method( mrb_state *mrb, mrb_debug_context *dbg, const char *
   }
 
   set_method = mrb_malloc(mrb, strlen(method_name) + 1);
-  if(set_method == NULL) {
-    if(set_class != NULL) {
-      mrb_free(mrb, (void*)set_class);
-    }
-    return MRB_DEBUG_NOBUF;
-  }
 
   strncpy(set_method, method_name, strlen(method_name) + 1);
 

--- a/mrbgems/mruby-bin-debugger/tools/mrdb/apilist.c
+++ b/mrbgems/mruby-bin-debugger/tools/mrdb/apilist.c
@@ -48,15 +48,15 @@ build_path(mrb_state *mrb, const char *dir, const char *base)
     len += strlen(dir) + strlen("/");
   }
 
-  if ((path = mrb_malloc(mrb, len)) != NULL) {
-    memset(path, 0, len);
+  path = mrb_malloc(mrb, len);
+  memset(path, 0, len);
 
-    if (strcmp(dir, ".")) {
-      strcat(path, dir);
-      strcat(path, "/");
-    }
-    strcat(path, base);
+  if (strcmp(dir, ".")) {
+    strcat(path, dir);
+    strcat(path, "/");
   }
+  strcat(path, base);
+
   return path;
 }
 
@@ -73,10 +73,10 @@ dirname(mrb_state *mrb, const char *path)
   p = strrchr(path, '/');
   len = p != NULL ? p - path : strlen(path);
 
-  if ((dir = mrb_malloc(mrb, len + 1)) != NULL) {
-    strncpy(dir, path, len);
-    dir[len] = '\0';
-  }
+  dir = mrb_malloc(mrb, len + 1);
+  strncpy(dir, path, len);
+  dir[len] = '\0';
+
   return dir;
 }
 
@@ -85,9 +85,7 @@ source_file_new(mrb_state *mrb, mrb_debug_context *dbg, char *filename)
 {
   source_file *file = NULL;
 
-  if ((file = mrb_malloc(mrb, sizeof(source_file))) == NULL) {
-    return NULL;
-  }
+  file = mrb_malloc(mrb, sizeof(source_file));
 
   memset(file, '\0', sizeof(source_file));
   file->fp = fopen(filename, "rb");

--- a/mrbgems/mruby-bin-debugger/tools/mrdb/cmdmisc.c
+++ b/mrbgems/mruby-bin-debugger/tools/mrdb/cmdmisc.c
@@ -255,11 +255,11 @@ replace_ext(mrb_state *mrb, const char *filename, const char *ext)
     len = strlen(filename);
   }
 
-  if ((s = mrb_malloc(mrb, len + strlen(ext) + 1)) != NULL) {
-    memset(s, '\0', len + strlen(ext) + 1);
-    strncpy(s, filename, len);
-    strcat(s, ext);
-  }
+  s = mrb_malloc(mrb, len + strlen(ext) + 1);
+  memset(s, '\0', len + strlen(ext) + 1);
+  strncpy(s, filename, len);
+  strcat(s, ext);
+
   return s;
 }
 


### PR DESCRIPTION
`mrb_malloc()` causes an exception when memory was empty.
