### PR TITLE
Set correct build dir for bins

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -52,7 +52,11 @@ MRuby.each_target do |target|
   gems.map do |gem|
     current_dir = gem.dir.relative_path_from(Dir.pwd)
     relative_from_root = gem.dir.relative_path_from(MRUBY_ROOT)
-    current_build_dir = "#{build_dir}/#{relative_from_root}"
+    current_build_dir = File.expand_path "#{build_dir}/#{relative_from_root}"
+
+    if current_build_dir !~ /^#{build_dir}/
+      current_build_dir = "#{build_dir}/mrbgems/#{gem.name}"
+    end
 
     gem.bins.each do |bin|
       exec = exefile("#{build_dir}/bin/#{bin}")


### PR DESCRIPTION
When cross-compiling a custom gem containing a binary I ran into a bug: the resulting executable
was placed into the host's output directory, rather than the one for the cross-build target. This bug does not appear for gems that come with mruby itself but only for gems outside `MRUBY_ROOT`, in which case `relative_from_root`  will give a double period path ('../') that points to the wrong directory.

I don't know if this is a decent fix, but it seems to work.