### PR TITLE
Round execution time

### DIFF
--- a/test/assert.rb
+++ b/test/assert.rb
@@ -228,7 +228,8 @@ def report()
   t_print("Crash: #{$kill_test}\n")
 
   if Object.const_defined?(:Time)
-    t_print(" Time: #{Time.now - $test_start} seconds\n")
+    t_time = Time.now - $test_start
+    t_print(" Time: #{t_time.round(2)} seconds\n")
   end
 end
 


### PR DESCRIPTION
Currently the test report looks like this:
```
Total: 835
   OK: 835
   KO: 0
Crash: 0
 Time: 0.07538899999999 seconds
```
This change rounds just the test time to a more readable point:
```
Total: 835
   OK: 835
   KO: 0
Crash: 0
 Time: 0.08 seconds
```