### PR TITLE
fixed error-handling for mrb_open().

### DIFF
--- a/mrbgems/mruby-bin-debugger/tools/mrdb/mrdb.c
+++ b/mrbgems/mruby-bin-debugger/tools/mrdb/mrdb.c
@@ -651,12 +651,12 @@ main(int argc, char **argv)
   mrb_debug_context* dbg_backup;
   debug_command *cmd;
 
+ l_restart:
+
   if (mrb == NULL) {
     fputs("Invalid mrb_state, exiting mruby\n", stderr);
     return EXIT_FAILURE;
   }
-
- l_restart:
 
   /* parse command parameters */
   n = parse_args(mrb, argc, argv, &args);


### PR DESCRIPTION
When [`mrb_open()` is called again](https://github.com/cubicdaiya/mruby/blob/error-handling-mrb-open/mrbgems/mruby-bin-debugger/tools/mrdb/mrdb.c#L710), it is not checked.