### PR TITLE
fix infinite loop in String#match(arg) when arg is String

### DIFF
--- a/mrblib/string.rb
+++ b/mrblib/string.rb
@@ -146,7 +146,16 @@ class String
   ##
   # ISO 15.2.10.5.27
   def match(re, &block)
-    re.match(self, &block)
+    if re.respond_to? :to_str
+      if Object.const_defined?(:Regexp)
+        r = Regexp.new(re)
+        r.match(self, &block)
+      else
+        raise NotImplementedError, "String#match needs Regexp class"
+      end
+    else
+      re.match(self, &block)
+    end
   end
 end
 


### PR DESCRIPTION
Before:

```
$ ./bin/mirb 
mirb - Embeddable Interactive Ruby Shell

> "abc".match("b")
/Users/maki/tmp/mruby/mrblib/string.rb:149: stack level too deep. (limit=(0x40000 - 128)) (SystemStackError)
```

After (with `conf.gem github: 'iij/mruby-regexp-pcre'`):

```
$ ./bin/mirb 
mirb - Embeddable Interactive Ruby Shell

> "abc".match("b")
 => #<MatchData "b">
```

After (without any regexp gems):

```
$ ./bin/mirb 
mirb - Embeddable Interactive Ruby Shell

> "abc".match("b")
/Users/maki/tmp/mruby/mrblib/string.rb:154: String#match needs Regexp class (NotImplementedError)
```

cf. ISO (draft) 15.2.10.5.27 (and JIS X 03071:2011):
 
> if *regexp* (argument of `String#match`) is an instance of the class `String`, create a direct instance of
> the class `Regexp` by invoking the method `new` on the class `Regexp` with *regexp* as the
> argument.
