### PR TITLE
Don't use Build.current if possible

### DIFF
--- a/tasks/mruby_build_gem.rake
+++ b/tasks/mruby_build_gem.rake
@@ -31,7 +31,7 @@ module MRuby
       return nil unless Gem.current
 
       Gem.current.dir = gemdir
-      Gem.current.build = MRuby::Build.current
+      Gem.current.build = self.is_a?(MRuby::Build) ? self : MRuby::Build.current
       Gem.current.build_config_initializer = block
       gems << Gem.current
 


### PR DESCRIPTION
Some of my *mrbgems* have pretty complicated build logic.
I usually use a singleton method on the spec objects and call it in the block one can pass to the
`gem` method. I ran into a bug, however: in one of these blocks I dynamically add other gems to the build, i.e. I call `gem` from within a block passed to another `gem` call. Now, because of the way these blocks are evaluated, `Build.current` is not set to the right build object and the spec is possibly assigned a different, wrong build object (e.g. a cross build object created later).

This seems to fix that.
