### PR TITLE
tasks/ruby_ext.rake: Fix build error when file path includes \1 or \2.  ...

### DIFF
--- a/tasks/ruby_ext.rake
+++ b/tasks/ruby_ext.rake
@@ -22,7 +22,7 @@ class String
     if params.is_a?(Hash)
       str = self.clone
       params.each do |k, v|
-        str.gsub!("%{#{k}}", v)
+        str.gsub!("%{#{k}}") { v }
       end
       str
     else


### PR DESCRIPTION
Fix for #2709