### PR TITLE
Fix possible segfault when accessing backtrace with MRB_WORD_BOXING.

### DIFF
--- a/src/backtrace.c
+++ b/src/backtrace.c
@@ -132,9 +132,18 @@ output_backtrace(mrb_state *mrb, mrb_int ciidx, mrb_code *pc0, output_stream_fun
 static void
 exc_output_backtrace(mrb_state *mrb, struct RObject *exc, output_stream_func func, void *stream)
 {
+  mrb_value lastpc;
+  mrb_code *code;
+  
+  lastpc = mrb_obj_iv_get(mrb, exc, mrb_intern_lit(mrb, "lastpc"));
+  if (mrb_nil_p(lastpc)) {
+    code = NULL;
+  } else {
+    code = (mrb_code*)mrb_cptr(lastpc);
+  }
+
   output_backtrace(mrb, mrb_fixnum(mrb_obj_iv_get(mrb, exc, mrb_intern_lit(mrb, "ciidx"))),
-                   (mrb_code*)mrb_cptr(mrb_obj_iv_get(mrb, exc, mrb_intern_lit(mrb, "lastpc"))),
-                   func, stream);
+                   code, func, stream);
 }
 
 /* mrb_print_backtrace/mrb_get_backtrace:


### PR DESCRIPTION
When invoking a method implemented as a `CFUNC` directly from C thought `mrb_funcall_argv`, `@lastpc` on the exception is not set. This is fine without boxing but, with `MRB_WORD_BOXING`, `mrb_exc_backtrace` causes a segfault. This is because of the [`mrb_cptr` with a `nil` value](https://github.com/mruby/mruby/blob/4957c852696c9559bfbea988325fd9bf94fc34bc/src/backtrace.c#L136).

---

I used the following program to test it
```c
#include "mruby.h"
#include "mruby/error.h"

int main(int argc, char *argv[]) {
  mrb_state *mrb = mrb_open();
  mrb_value s = mrb_str_new_cstr(mrb, "this will not end well");
  mrb_value count = mrb_fixnum_value(-4);
  mrb_funcall_argv(mrb, s, mrb_intern_lit(mrb, "*"), 1, &count);
  mrb_p(mrb, mrb_inspect(mrb, mrb_exc_backtrace(mrb, mrb_obj_value(mrb->exc))));
  return 0;
}
```