### PR TITLE
Add more debug flags for GCC based compilers

### DIFF
--- a/tasks/mruby_build.rake
+++ b/tasks/mruby_build.rake
@@ -94,7 +94,12 @@ module MRuby
     end
 
     def enable_debug
-      compilers.each { |c| c.defines += %w(MRB_DEBUG) }
+      compilers.each do |c|
+        c.defines += %w(MRB_DEBUG)
+        if toolchains.any? { |toolchain| toolchain == "gcc" }
+          c.flags += %w(-g3 -O0)
+        end
+      end
       @mrbc.compile_options += ' -g'
     end
 


### PR DESCRIPTION
We can use `#define`-ed macros in GDB with `-g3` flag.

We can run code step by step in GDB with `-O0` flag.

See also about `-g3`: http://www.clear-code.com/blog/2013/5/8.html (in Japanese)