### PR TITLE
Fix a bug that if and no return value case can't return true clause value

### DIFF
--- a/src/codegen.c
+++ b/src/codegen.c
@@ -1462,8 +1462,13 @@ codegen(codegen_scope *s, node *tree, int val)
         genop(s, MKOP_AB(OP_MOVE, cursp(), pos));
         push();
       }
-      else if (pos3) {
-        dispatch_linked(s, pos3);
+      else {
+        if (pos3) {
+          dispatch_linked(s, pos3);
+        }
+        if (head) {
+          pop();
+        }
       }
     }
     break;

--- a/test/t/syntax.rb
+++ b/test/t/syntax.rb
@@ -241,6 +241,20 @@ assert('Return values of case statements') do
   assert_equal 1, fb.call
 end
 
+assert('Return values of if and case statements') do
+  true_clause_value =
+    if true
+      1
+    else
+      case 2
+      when 3
+      end
+      4
+    end
+
+  assert_equal 1, true_clause_value
+end
+
 assert('splat in case statement') do
   values = [3,5,1,7,8]
   testa = [1,2,7]


### PR DESCRIPTION
Here is a script that reproduce this problem:

     x = if true
           1
         else
           case 2
           when 3
           end
           4
         end
     p x # => nil # 1 is expected