### PR TITLE
Fix a bug that no expression case doesn't return valid value

### DIFF
--- a/src/codegen.c
+++ b/src/codegen.c
@@ -1458,7 +1458,7 @@ codegen(codegen_scope *s, node *tree, int val)
         int pos = cursp();
         genop(s, MKOP_A(OP_LOADNIL, cursp()));
         if (pos3) dispatch_linked(s, pos3);
-        pop();
+        if (head) pop();
         genop(s, MKOP_AB(OP_MOVE, cursp(), pos));
         push();
       }

--- a/test/t/syntax.rb
+++ b/test/t/syntax.rb
@@ -255,6 +255,16 @@ assert('Return values of if and case statements') do
   assert_equal 1, true_clause_value
 end
 
+assert('Return values of no expression case statement') do
+  when_value =
+    case
+    when true
+      1
+    end
+
+  assert_equal 1, when_value
+end
+
 assert('splat in case statement') do
   values = [3,5,1,7,8]
   testa = [1,2,7]


### PR DESCRIPTION
Here is a script that reproduces this problem:

     x = case
         when true; 1
         end
     p x # => main # 1 is expected