### PR TITLE
Fix a crash bug on raising after realloc

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -316,7 +316,7 @@ mrb_funcall_with_block(mrb_state *mrb, mrb_value self, mrb_sym mid, mrb_int argc
 
   if (!mrb->jmp) {
     struct mrb_jmpbuf c_jmp;
-    mrb_callinfo *old_ci = mrb->c->ci;
+    size_t nth_ci = mrb->c->ci - mrb->c->cibase;
 
     MRB_TRY(&c_jmp) {
       mrb->jmp = &c_jmp;
@@ -325,7 +325,7 @@ mrb_funcall_with_block(mrb_state *mrb, mrb_value self, mrb_sym mid, mrb_int argc
       mrb->jmp = 0;
     }
     MRB_CATCH(&c_jmp) { /* error */
-      while (old_ci != mrb->c->ci) {
+      while (nth_ci < (mrb->c->ci - mrb->c->cibase)) {
         mrb->c->stack = mrb->c->ci->stackent;
         cipop(mrb);
       }


### PR DESCRIPTION
The following program reproduces this problem:

    #include <mruby.h>

    static mrb_value
    recursive(mrb_state *mrb, mrb_value self)
    {
      mrb_int n;

      mrb_get_args(mrb, "i", &n);

      if (n == 0) {
        mrb_raise(mrb, E_RUNTIME_ERROR, "XXX");
      } else {
        mrb_funcall(mrb, self, "recursive", 1, mrb_fixnum_value(n - 1));
      }

      return self;
    }

    int
    main(void)
    {
      mrb_state *mrb;

      mrb = mrb_open();

      mrb_define_method(mrb, mrb->kernel_module, "recursive", recursive,
                        MRB_ARGS_REQ(1));
      mrb_funcall(mrb, mrb_top_self(mrb), "recursive", 1, mrb_fixnum_value(30));

      mrb_close(mrb);
    }

Recursive method call isn't required. It's just for expanding call info
stack.

If mrb_realloc() is called in cipush(), cibase address is changed. So,
we shouldn't compare ci before mrb_realloc() and cibase after
mrb_realloc(). It accesses unknown address and causes crash.