### PR TITLE
Use ptrdiff_t to suppress signedness warning

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -220,7 +220,7 @@ cipush(mrb_state *mrb)
   int ridx = ci->ridx;
 
   if (ci + 1 == c->ciend) {
-    size_t size = ci - c->cibase;
+    ptrdiff_t size = ci - c->cibase;
 
     c->cibase = (mrb_callinfo *)mrb_realloc(mrb, c->cibase, sizeof(mrb_callinfo)*size*2);
     c->ci = c->cibase + size;


### PR DESCRIPTION
3df32161797aa9c6e9df259e8d8571b454cb2333 says so but there is no warning
with GCC 4.9 on my Debian GNU/Linux environment.