### PR TITLE
I modified the undefined frexpl in cygwin of make

### DIFF
--- a/src/fmt_fp.c
+++ b/src/fmt_fp.c
@@ -90,11 +90,13 @@ fmt_u(uint32_t x, char *s)
 typedef char compiler_defines_long_double_incorrectly[9-(int)sizeof(long double)];
 #endif
 
+#ifdef __CYGWIN32__
 static long double
 frexpl (long double x, int *eptr)
 {
 	return frexp(x, eptr);
 }
+#endif
 
 static int
 fmt_fp(struct fmt_args *f, long double y, int w, int p, int fl, int t)

--- a/src/fmt_fp.c
+++ b/src/fmt_fp.c
@@ -90,6 +90,12 @@ fmt_u(uint32_t x, char *s)
 typedef char compiler_defines_long_double_incorrectly[9-(int)sizeof(long double)];
 #endif
 
+static long double
+frexpl (long double x, int *eptr)
+{
+	return frexp(x, eptr);
+}
+
 static int
 fmt_fp(struct fmt_args *f, long double y, int w, int p, int fl, int t)
 {


### PR DESCRIPTION
cygwinでmakeすると、下記のようなエラーがでるので、
  ----------------------------------------------------------------------------------------------
C:\git\github\mruby\src\fmt_fp.c: 関数 ‘fmt_fp’ 内:
C:\git\github\mruby\src\fmt_fp.c:125:3: エラー: 関数 ‘frexpl’ の暗黙的な宣言です [-Werror=implicit-function-declaration]
   y = frexpl(y, &e2) * 2;
   ^
C:\git\github\mruby\src\fmt_fp.c:125:7: 警告: 組み込み関数 ‘frexpl’ の互換性がない暗黙的な宣言です
   y = frexpl(y, &e2) * 2;
...
  ----------------------------------------------------------------------------------------------
fmt_fp.cに、frexp()をラップしたfrexpl()を追加しました。
