### PR TITLE
Fix exceptions for visualcpp

### DIFF
--- a/tasks/toolchains/visualcpp.rake
+++ b/tasks/toolchains/visualcpp.rake
@@ -11,7 +11,7 @@ MRuby::Toolchain.new(:visualcpp) do |conf|
 
   [conf.cxx].each do |cxx|
     cxx.command = ENV['CXX'] || 'cl.exe'
-    cxx.flags = [ENV['CXXFLAGS'] || ENV['CFLAGS'] || %w(/c /nologo /W3 /Zi /MD /O2 /EHsc /D_CRT_SECURE_NO_WARNINGS)]
+    cxx.flags = [ENV['CXXFLAGS'] || ENV['CFLAGS'] || %w(/c /nologo /W3 /Zi /MD /O2 /EHs /D_CRT_SECURE_NO_WARNINGS)]
     cxx.defines = %w(DISABLE_GEMS MRB_STACK_EXTEND_DOUBLING)
     cxx.option_include_path = '/I%s'
     cxx.option_define = '/D%s'


### PR DESCRIPTION
Exception handling is broken for visualcpp toolchain, if using C++ source files.

The issue is the the `/EHsc` cxx flag. From [MSDN /EH docs](https://msdn.microsoft.com/en-us/library/1deeycx5.aspx), this <i>'tells the compiler to assume that functions declared as extern "C" never throw a C++ exception.'</i>

The problem with that is that all of the functions in vm.c *are* extern "C". See this block from `mrb_funcall_with_block`

```C
   MRB_TRY(&c_jmp) {
      mrb->jmp = &c_jmp;
      /* recursive call */
      val = mrb_funcall_with_block(mrb, self, mid, argc, argv, blk);
      mrb->jmp = 0;
    }
    MRB_CATCH(&c_jmp) { /* error */
      while (old_ci != mrb->c->ci) {
        mrb->c->stack = mrb->c->ci->stackent;
        cipop(mrb);
      }
      mrb->jmp = 0;
      val = mrb_obj_value(mrb->exc);
    }
    MRB_END_EXC(&c_jmp);
```

`cl.exe` (Microsoft C/C++ Version 18.00.31101 for x86) looks at this block, sees that `mrb_funcall_with_block` is `extern "C"` and assumes - like it's been told - that this function cannot throw a C++ exception. The exception handler is then removed from the generated code.

However, MRB_THROW is defined to throw an exception with the cxx_abi is enabled. The effect is that at runtime an exception is thrown out of this block. The stack is not processed, and mrb->jmp is not cleared.

Changing the flag to `/EHs` allows the exception handling to work as intended.

I have run `ruby ./minirake test` with both GCC & VisualCPP, and all tests pass with this change.
I don't have a test written for this change, but you can see my usage here:
 - [lamina](https://github.com/jbreeden/lamina) commit  [e9dec24](https://github.com/jbreeden/lamina/commit/e9dec2431241019612be3339a4f3837a8277de4b) changes the toolchain flag
- [mruby-cef](https://github.com/jbreeden/mruby-cef) (used by lamina) commit [d25e436](https://github.com/jbreeden/mruby-cef/commit/d25e4369ea2c1c30711d470fd4e3dd4efbeeb098) shows how I am able to handle exceptions with the change
  + In this commit, you can see I was catching the exceptions before, that should never have been making it out to my code.
  + Now, I'm able to check the return value (or mrb->exc) as expected.