### PR TITLE
mruby-time: call ISO C11's timespec_get() if available

### DIFF
--- a/mrbgems/mruby-time/src/time.c
+++ b/mrbgems/mruby-time/src/time.c
@@ -235,7 +235,17 @@ current_mrb_time(mrb_state *mrb)
   struct mrb_time *tm;
 
   tm = (struct mrb_time *)mrb_malloc(mrb, sizeof(*tm));
-#ifdef NO_GETTIMEOFDAY
+#if defined(TIME_UTC)
+  {
+    struct timespec ts;
+    if (timespec_get(&ts, TIME_UTC) == 0) {
+      mrb_free(mrb, tm);
+      mrb_raise(mrb, E_RUNTIME_ERROR, "timespec_get() failed for unknown reasons");
+    }
+    tm->sec = ts.tv_sec;
+    tm->usec = ts.tv_nsec / 1000;
+  }
+#elif defined(NO_GETTIMEOFDAY)
   {
     static time_t last_sec = 0, last_usec = 0;
 


### PR DESCRIPTION
`gettimeofday()` is an obsolescent POSIX function which may be removed in a future version. POSIX recommends using `clock_gettime()` (also POSIX) instead, but it isn't available on OS X or Windows (at least with MSVC and older MinGW versions).

Whereas `timespec_get()` is part of ISO C11 and mruby uses some small other C11 features too. It isn't universally available yet either, but it might be in the future. And Visual C++ 2015 implements it! I think it's a reasonable choice, since mruby strives for plain ISO C compatibility, .

`TIME_UTC` is used instead of `__STDC_VERSION__`, because if `TIME_UTC` is defined, then most likely `timespec_get()` is too. This isn't true in case of ` __STDC_VERSION__` (see MSVC).