### PR TITLE
refactor write_pool_block()

### DIFF
--- a/src/dump.c
+++ b/src/dump.c
@@ -178,43 +178,27 @@ write_pool_block(mrb_state *mrb, mrb_irep *irep, uint8_t *buf)
     case MRB_TT_FIXNUM:
       cur += uint8_to_bin(IREP_TT_FIXNUM, cur); /* data type */
       str = mrb_fixnum_to_str(mrb, irep->pool[pool_no], 10);
-      char_ptr = RSTRING_PTR(str);
-      {
-        mrb_int tlen;
-
-        tlen = RSTRING_LEN(str);
-        mrb_assert_int_fit(mrb_int, tlen, uint16_t, UINT16_MAX);
-        len = (uint16_t)tlen;
-      }
       break;
 
     case MRB_TT_FLOAT:
       cur += uint8_to_bin(IREP_TT_FLOAT, cur); /* data type */
       str = mrb_float_to_str(mrb, irep->pool[pool_no], MRB_FLOAT_FMT);
-      char_ptr = RSTRING_PTR(str);
-      {
-        mrb_int tlen;
-
-        tlen = RSTRING_LEN(str);
-        mrb_assert_int_fit(mrb_int, tlen, uint16_t, UINT16_MAX);
-        len = (uint16_t)tlen;
-      }
       break;
 
     case MRB_TT_STRING:
       cur += uint8_to_bin(IREP_TT_STRING, cur); /* data type */
-      char_ptr = RSTRING_PTR(irep->pool[pool_no]);
-      {
-        mrb_int tlen;
-
-        tlen = RSTRING_LEN(irep->pool[pool_no]);
-        mrb_assert_int_fit(mrb_int, tlen, uint16_t, UINT16_MAX);
-        len = (uint16_t)tlen;
-      }
+      str = irep->pool[pool_no];
       break;
 
     default:
       continue;
+    }
+
+    char_ptr = RSTRING_PTR(str);
+    {
+      mrb_int tlen = RSTRING_LEN(str);
+      mrb_assert_int_fit(mrb_int, tlen, uint16_t, UINT16_MAX);
+      len = (uint16_t)tlen;
     }
 
     cur += uint16_to_bin(len, cur); /* data length */


### PR DESCRIPTION
No need to write the same assertion in each case (except the default one). Instead we can assert after the switch statement.