### PR TITLE
add RUBY_ENGINE_VERSION

### DIFF
--- a/src/version.c
+++ b/src/version.c
@@ -4,8 +4,11 @@
 void
 mrb_init_version(mrb_state* mrb)
 {
+  mrb_value mruby_version = mrb_str_new_lit(mrb, MRUBY_VERSION);
+
   mrb_define_global_const(mrb, "RUBY_VERSION", mrb_str_new_lit(mrb, MRUBY_RUBY_VERSION));
   mrb_define_global_const(mrb, "RUBY_ENGINE", mrb_str_new_lit(mrb, MRUBY_RUBY_ENGINE));
+  mrb_define_global_const(mrb, "RUBY_ENGINE_VERSION", mruby_version);
   mrb_define_global_const(mrb, "MRUBY_VERSION", mrb_str_new_lit(mrb, MRUBY_VERSION));
   mrb_define_global_const(mrb, "MRUBY_RELEASE_NO", mrb_fixnum_value(MRUBY_RELEASE_NO));
   mrb_define_global_const(mrb, "MRUBY_RELEASE_DATE", mrb_str_new_lit(mrb, MRUBY_RELEASE_DATE));


### PR DESCRIPTION
`RUBY_ENGINE_VERSION` is equivalent to `MRUBY_VERSION`. It would be a
standard way to get the interpreter version (without a case expression).

[Opal](https://github.com/opal/opal/commit/c537e69868be4d60e5b0f2e61fa3b938eb515376), [Rubinius](https://github.com/rubinius/rubinius/commit/8212c460b97a6f277db35de5295f046a868eb8ac), and [JRuby](https://github.com/jruby/jruby/issues/2751) already implement it, but [CRuby doesn't (yet)](https://github.com/ruby/ruby/pull/858).