### PR TITLE
MSVC 2015 implements inline keyword

### DIFF
--- a/include/mruby/value.h
+++ b/include/mruby/value.h
@@ -40,17 +40,15 @@ struct mrb_state;
 # define str_to_mrb_float(buf) strtod(buf, NULL)
 #endif
 
-#ifdef _MSC_VER
+#if defined _MSC_VER && _MSC_VER < 1900
 # ifndef __cplusplus
 #  define inline __inline
 # endif
-# if _MSC_VER < 1900
-#  include <stdarg.h>
+# include <stdarg.h>
 MRB_API int mrb_msvc_vsnprintf(char *s, size_t n, const char *format, va_list arg);
 MRB_API int mrb_msvc_snprintf(char *s, size_t n, const char *format, ...);
-#  define vsnprintf(s, n, format, arg) mrb_msvc_vsnprintf(s, n, format, arg)
-#  define snprintf(s, n, format, ...) mrb_msvc_snprintf(s, n, format, __VA_ARGS__)
-# endif
+# define vsnprintf(s, n, format, arg) mrb_msvc_vsnprintf(s, n, format, arg)
+# define snprintf(s, n, format, ...) mrb_msvc_snprintf(s, n, format, __VA_ARGS__)
 # if _MSC_VER < 1800
 #  include <float.h>
 #  define isfinite(n) _finite(n)


### PR DESCRIPTION
Apparently the C compiler of Visual Studio 2015 CTP6 finally implements inline as `inline` and not only as `_inline` and `__inline`.