### PR TITLE
remove unnecessary <inttypes.h> inclusion

### DIFF
--- a/include/mruby/value.h
+++ b/include/mruby/value.h
@@ -61,11 +61,7 @@ MRB_API int mrb_msvc_snprintf(char *s, size_t n, const char *format, ...);
 static const unsigned int IEEE754_INFINITY_BITS_SINGLE = 0x7F800000;
 #  define INFINITY (*(float *)&IEEE754_INFINITY_BITS_SINGLE)
 #  define NAN ((float)(INFINITY - INFINITY))
-# else
-#  include <inttypes.h>
 # endif
-#else
-# include <inttypes.h>
 #endif
 
 enum mrb_vtype {


### PR DESCRIPTION
The format specifier macros were needed to portably print a `mrb_int`, because `mrb_raisef()` originally called `vsnprintf()`. It doesn't anymore since 18b2683b97ae54d4f2f15c19076f33aa29eaf2b7 and the `mrb_int` format specifier macros are already gone (couldn't find the commit).