### PR TITLE
Simple Method Cache

### DIFF
--- a/benchmark/ao-render.rb
+++ b/benchmark/ao-render.rb
@@ -5,8 +5,8 @@
 # mruby version by Hideki Miura
 #
 
-IMAGE_WIDTH = 256
-IMAGE_HEIGHT = 256
+IMAGE_WIDTH = 128
+IMAGE_HEIGHT = 128
 NSUBSAMPLES = 2
 NAO_SAMPLES = 8
 

--- a/build_config.rb
+++ b/build_config.rb
@@ -8,7 +8,7 @@ MRuby::Build.new do |conf|
     toolchain :gcc
   end
 
-  enable_debug
+  #enable_debug
 
   # Use mrbgems
   # conf.gem 'examples/mrbgems/ruby_extension_example'

--- a/include/mrbconf.h
+++ b/include/mrbconf.h
@@ -72,6 +72,9 @@
 /* fixed size state atexit stack */
 //#define MRB_FIXED_STATE_ATEXIT_STACK
 
+/* enable method cache */
+#define MRB_ENABLE_METHOD_CACHE
+
 /* -DDISABLE_XXXX to drop following features */
 //#define DISABLE_STDIO		/* use of stdio */
 

--- a/include/mruby.h
+++ b/include/mruby.h
@@ -69,6 +69,10 @@ typedef struct {
   int argc;
   int acc;
   struct RClass *target_class;
+#ifdef MRB_ENABLE_JIT
+  uint32_t send_idx;
+  uint32_t rescue_idx;
+#endif
 } mrb_callinfo;
 
 enum mrb_fiber_state {
@@ -186,6 +190,8 @@ typedef struct mrb_state {
   mrb_atexit_func *atexit_stack;
 #endif
   mrb_int atexit_stack_len;
+
+  struct RProc *proc_list;
 } mrb_state;
 
 #if __STDC_VERSION__ >= 201112L
@@ -381,6 +387,7 @@ MRB_API void mrb_print_error(mrb_state *mrb);
    + those E_* macros requires mrb_state* variable named mrb.
    + exception objects obtained from those macros are local to mrb
 */
+
 #define E_RUNTIME_ERROR             (mrb_class_get(mrb, "RuntimeError"))
 #define E_TYPE_ERROR                (mrb_class_get(mrb, "TypeError"))
 #define E_ARGUMENT_ERROR            (mrb_class_get(mrb, "ArgumentError"))
@@ -398,6 +405,10 @@ MRB_API void mrb_print_error(mrb_state *mrb);
 #define E_FLOATDOMAIN_ERROR         (mrb_class_get(mrb, "FloatDomainError"))
 
 #define E_KEY_ERROR                 (mrb_class_get(mrb, "KeyError"))
+
+#define E_FIBER_ERROR (mrb_class_get(mrb, "FiberError"))
+
+
 
 MRB_API mrb_value mrb_yield(mrb_state *mrb, mrb_value b, mrb_value arg);
 MRB_API mrb_value mrb_yield_argv(mrb_state *mrb, mrb_value b, mrb_int argc, const mrb_value *argv);
@@ -427,7 +438,6 @@ MRB_API mrb_bool mrb_obj_is_instance_of(mrb_state *mrb, mrb_value obj, struct RC
 /* fiber functions (you need to link mruby-fiber mrbgem to use) */
 MRB_API mrb_value mrb_fiber_resume(mrb_state *mrb, mrb_value fib, mrb_int argc, const mrb_value *argv);
 MRB_API mrb_value mrb_fiber_yield(mrb_state *mrb, mrb_int argc, const mrb_value *argv);
-#define E_FIBER_ERROR (mrb_class_get(mrb, "FiberError"))
 
 /* memory pool implementation */
 typedef struct mrb_pool mrb_pool;

--- a/include/mruby.h
+++ b/include/mruby.h
@@ -69,10 +69,6 @@ typedef struct {
   int argc;
   int acc;
   struct RClass *target_class;
-#ifdef MRB_ENABLE_JIT
-  uint32_t send_idx;
-  uint32_t rescue_idx;
-#endif
 } mrb_callinfo;
 
 enum mrb_fiber_state {

--- a/include/mruby.h
+++ b/include/mruby.h
@@ -191,7 +191,9 @@ typedef struct mrb_state {
 #endif
   mrb_int atexit_stack_len;
 
+#ifdef MRB_ENABLE_METHOD_CACHE
   struct RProc *proc_list;
+#endif
 } mrb_state;
 
 #if __STDC_VERSION__ >= 201112L

--- a/include/mruby/class.h
+++ b/include/mruby/class.h
@@ -21,15 +21,15 @@ struct RClass {
 struct mrb_mcache_entry {
   mrb_sym mid;
   struct RClass *c;
-  struct RClass *sc;
-  struct RProc* p;
 };
 
 #define MRB_METHOD_CACHE_SIZE 4
 struct mrb_mcache {
+  struct mrb_mcache_entry entries[MRB_METHOD_CACHE_SIZE];
+  struct RClass *classes[MRB_METHOD_CACHE_SIZE];
+  struct RProc* procs[MRB_METHOD_CACHE_SIZE];
   int16_t head;
   int16_t tail;
-  struct mrb_mcache_entry entries[MRB_METHOD_CACHE_SIZE];
 };
 
 
@@ -77,6 +77,7 @@ MRB_API void mrb_alias_method(mrb_state *mrb, struct RClass *c, mrb_sym a, mrb_s
 
 MRB_API struct RClass *mrb_class_outer_module(mrb_state*, struct RClass *);
 MRB_API struct RProc *mrb_method_search_vm(mrb_state*, struct RClass**, mrb_sym);
+MRB_API struct RProc *mrb_method_search_vm_proc(mrb_state*, struct RProc *p, struct RClass**, mrb_sym);
 MRB_API struct RProc *mrb_method_search(mrb_state*, struct RClass*, mrb_sym);
 
 MRB_API struct RClass* mrb_class_real(struct RClass* cl);

--- a/include/mruby/class.h
+++ b/include/mruby/class.h
@@ -18,6 +18,21 @@ struct RClass {
   struct RClass *super;
 };
 
+struct mrb_mcache_entry {
+  mrb_sym mid;
+  struct RClass *c;
+  struct RClass *sc;
+  struct RProc* p;
+};
+
+#define MRB_METHOD_CACHE_SIZE 4
+struct mrb_mcache {
+  int16_t head;
+  int16_t tail;
+  struct mrb_mcache_entry entries[MRB_METHOD_CACHE_SIZE];
+};
+
+
 #define mrb_class_ptr(v)    ((struct RClass*)(mrb_ptr(v)))
 #define RCLASS_SUPER(v)     (((struct RClass*)(mrb_ptr(v)))->super)
 #define RCLASS_IV_TBL(v)    (((struct RClass*)(mrb_ptr(v)))->iv)
@@ -65,6 +80,8 @@ MRB_API struct RProc *mrb_method_search_vm(mrb_state*, struct RClass**, mrb_sym)
 MRB_API struct RProc *mrb_method_search(mrb_state*, struct RClass*, mrb_sym);
 
 MRB_API struct RClass* mrb_class_real(struct RClass* cl);
+
+void mrb_mcache_init(mrb_state *, struct mrb_mcache *);
 
 void mrb_gc_mark_mt(mrb_state*, struct RClass*);
 size_t mrb_gc_mark_mt_size(mrb_state*, struct RClass*);

--- a/include/mruby/class.h
+++ b/include/mruby/class.h
@@ -63,6 +63,8 @@ mrb_class(mrb_state *mrb, mrb_value v)
   }
 }
 
+struct RProc *_mrb_method_search_vm(mrb_state*, struct RClass**, mrb_sym);
+
 #define MRB_SET_INSTANCE_TT(c, tt) c->flags = ((c->flags & ~0xff) | (char)tt)
 #define MRB_INSTANCE_TT(c) (enum mrb_vtype)(c->flags & 0xff)
 
@@ -77,7 +79,6 @@ MRB_API void mrb_alias_method(mrb_state *mrb, struct RClass *c, mrb_sym a, mrb_s
 
 MRB_API struct RClass *mrb_class_outer_module(mrb_state*, struct RClass *);
 MRB_API struct RProc *mrb_method_search_vm(mrb_state*, struct RClass**, mrb_sym);
-MRB_API struct RProc *mrb_method_search_vm_proc(mrb_state*, struct RProc *p, struct RClass**, mrb_sym);
 MRB_API struct RProc *mrb_method_search(mrb_state*, struct RClass*, mrb_sym);
 
 MRB_API struct RClass* mrb_class_real(struct RClass* cl);

--- a/include/mruby/proc.h
+++ b/include/mruby/proc.h
@@ -8,6 +8,7 @@
 #define MRUBY_PROC_H
 
 #include "mruby/irep.h"
+#include "mruby/class.h"
 
 #if defined(__cplusplus)
 extern "C" {
@@ -33,6 +34,10 @@ struct RProc {
   } body;
   struct RClass *target_class;
   struct REnv *env;
+  struct mrb_mcache mcache;
+
+  struct RProc *next;
+  struct RProc *prev;
 };
 
 /* aspec access */
@@ -53,9 +58,12 @@ struct RProc {
 
 struct RProc *mrb_proc_new(mrb_state*, mrb_irep*);
 struct RProc *mrb_closure_new(mrb_state*, mrb_irep*);
+void mrb_proc_destroy(mrb_state *, struct RProc *p);
+
 MRB_API struct RProc *mrb_proc_new_cfunc(mrb_state*, mrb_func_t);
 MRB_API struct RProc *mrb_closure_new_cfunc(mrb_state *mrb, mrb_func_t func, int nlocals);
 void mrb_proc_copy(struct RProc *a, struct RProc *b);
+void mrb_proc_register(mrb_state *mrb, struct RProc *p);
 
 /* implementation of #send method */
 MRB_API mrb_value mrb_f_send(mrb_state *mrb, mrb_value self);
@@ -65,6 +73,7 @@ MRB_API struct RProc *mrb_proc_new_cfunc_with_env(mrb_state*, mrb_func_t, mrb_in
 MRB_API mrb_value mrb_proc_cfunc_env_get(mrb_state*, mrb_int);
 /* old name */
 #define mrb_cfunc_env_get(mrb, idx) mrb_proc_cfunc_env_get(mrb, idx)
+
 
 #include "mruby/khash.h"
 KHASH_DECLARE(mt, mrb_sym, struct RProc*, TRUE)

--- a/include/mruby/proc.h
+++ b/include/mruby/proc.h
@@ -34,10 +34,12 @@ struct RProc {
   } body;
   struct RClass *target_class;
   struct REnv *env;
-  struct mrb_mcache mcache;
 
+#ifdef MRB_ENABLE_METHOD_CACHE
+  struct mrb_mcache mcache;
   struct RProc *next;
   struct RProc *prev;
+#endif
 };
 
 /* aspec access */

--- a/src/class.c
+++ b/src/class.c
@@ -391,20 +391,6 @@ mcache_search_proc(mrb_state *mrb, struct RProc *p, struct RClass *c, mrb_sym mi
   *found = FALSE;
   return NULL;
 }
-
-static inline struct RProc *
-mcache_search(mrb_state *mrb, struct RClass *c, mrb_sym mid, mrb_bool *found)
-{
-  mrb_callinfo *ci = mrb->c->ci;
-
-  if(ci && ci->proc) {
-    return mcache_search_proc(mrb, ci->proc, c, mid, found);
-  }
-  else {
-    *found = FALSE;
-    return NULL;
-  }
-}
 #endif
 
 

--- a/src/class.c
+++ b/src/class.c
@@ -1163,10 +1163,11 @@ search_class(mrb_state *mrb, struct RClass **cp, mrb_sym mid)
     c = c->super;
   }
 
+#ifdef MRB_ENABLE_METHOD_CACHE
   {
     struct mrb_mcache_entry e;
     mrb_callinfo *ci;
-    
+
     e.c = *cp;
     e.mid = mid;
     ci = mrb->c->ci;
@@ -1174,6 +1175,7 @@ search_class(mrb_state *mrb, struct RClass **cp, mrb_sym mid)
       mcache_enqueue(mrb, &ci->proc->mcache, e, c, NULL);
     }
   }
+#endif
 
   return NULL;                  /* no method */
 
@@ -1207,8 +1209,8 @@ mrb_method_search_vm_proc(mrb_state *mrb, struct RProc *p, struct RClass **cp, m
     //fprintf(stderr, "lookup for (%p %s) was a hit (%p)\n", *cp, mrb_sym2name(mrb, mid), m);
     return m;
   }
-#endif
   else
+#endif
   {
     //fprintf(stderr, "lookup for (%p %s) was no hit\n", *cp, mrb_sym2name(mrb, mid));
     return search_class(mrb, cp, mid);

--- a/src/class_inline.h
+++ b/src/class_inline.h
@@ -1,0 +1,19 @@
+static inline struct RProc *
+mrb_method_search_vm_proc(mrb_state *mrb, struct RProc *p, struct RClass **cp, mrb_sym mid)
+{
+#ifdef MRB_ENABLE_METHOD_CACHE
+  struct RClass *c = *cp;
+  struct mrb_mcache_entry *es = p->mcache.entries;
+  int i;
+
+  for(i = 0; i < MRB_METHOD_CACHE_SIZE; i++) {
+    struct mrb_mcache_entry *e = &es[i];
+
+    if (e->c == c && e->mid == mid) {
+      return p->mcache.procs[i];
+    }
+  }
+#endif
+
+  return _mrb_method_search_vm(mrb, cp, mid);
+}

--- a/src/gc.c
+++ b/src/gc.c
@@ -665,6 +665,8 @@ obj_free(mrb_state *mrb, struct RBasic *obj)
     {
       struct RProc *p = (struct RProc*)obj;
 
+      mrb_proc_destroy(mrb, p);
+
       if (!MRB_PROC_CFUNC_P(p) && p->body.irep) {
         mrb_irep_decref(mrb, p->body.irep);
       }

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -1000,6 +1000,8 @@ mod_define_singleton_method(mrb_state *mrb, mrb_value self)
   }
   p = (struct RProc*)mrb_obj_alloc(mrb, MRB_TT_PROC, mrb->proc_class);
   mrb_proc_copy(p, mrb_proc_ptr(blk));
+  mrb_proc_register(mrb, p);
+
   p->flags |= MRB_PROC_STRICT;
   mrb_define_method_raw(mrb, mrb_class_ptr(mrb_singleton_class(mrb, self)), mid, p);
   return mrb_symbol_value(mid);

--- a/src/proc.c
+++ b/src/proc.c
@@ -16,16 +16,19 @@ static mrb_code call_iseq[] = {
 void
 mrb_proc_register(mrb_state *mrb, struct RProc *p)
 {
+#ifdef MRB_ENABLE_METHOD_CACHE
   p->next = mrb->proc_list;
   if (p->next) {
     p->next->prev = p;
   }
   mrb->proc_list = p;
+#endif
 }
 
 void
 mrb_proc_destroy(mrb_state *mrb, struct RProc *p)
 {
+#ifdef MRB_ENABLE_METHOD_CACHE
   if (p->next) {
     p->next->prev = p->prev;
   }
@@ -36,6 +39,7 @@ mrb_proc_destroy(mrb_state *mrb, struct RProc *p)
   if(p == mrb->proc_list) {
     mrb->proc_list = p->next;
   }
+#endif
 }
 
 struct RProc *
@@ -56,8 +60,10 @@ mrb_proc_new(mrb_state *mrb, mrb_irep *irep)
   p->env = 0;
   mrb_irep_incref(mrb, irep);
 
+#ifdef MRB_ENABLE_METHOD_CACHE
   mrb_mcache_init(mrb, &p->mcache);
   mrb_proc_register(mrb, p);
+#endif
 
   return p;
 }
@@ -110,8 +116,10 @@ mrb_proc_new_cfunc(mrb_state *mrb, mrb_func_t func)
   p->flags |= MRB_PROC_CFUNC;
   p->env = 0;
 
+#ifdef MRB_ENABLE_METHOD_CACHE
   mrb_mcache_init(mrb, &p->mcache);
   mrb_proc_register(mrb, p);
+#endif
 
   return p;
 }
@@ -175,7 +183,10 @@ mrb_proc_copy(struct RProc *a, struct RProc *b)
   }
   a->target_class = b->target_class;
   a->env = b->env;
+
+#ifdef MRB_ENABLE_METHOD_CACHE
   a->mcache = b->mcache;
+#endif
 }
 
 static mrb_value

--- a/src/vm.c
+++ b/src/vm.c
@@ -1071,7 +1071,8 @@ RETRY_TRY_BLOCK:
         }
       }
       c = mrb_class(mrb, recv);
-      m = mrb_method_search_vm(mrb, &c, mid);
+      //m = mrb_method_search_vm(mrb, &c, mid);
+      m = mrb_method_search_vm_proc(mrb, proc, &c, mid);
       if (!m) {
         mrb_value sym = mrb_symbol_value(mid);
 
@@ -1224,7 +1225,7 @@ RETRY_TRY_BLOCK:
 
       recv = regs[0];
       c = mrb->c->ci->target_class->super;
-      m = mrb_method_search_vm(mrb, &c, mid);
+      m = mrb_method_search_vm_proc(mrb, proc, &c, mid);
       if (!m) {
         mid = mrb_intern_lit(mrb, "method_missing");
         m = mrb_method_search_vm(mrb, &c, mid);
@@ -1609,7 +1610,7 @@ RETRY_TRY_BLOCK:
 
       recv = regs[a];
       c = mrb_class(mrb, recv);
-      m = mrb_method_search_vm(mrb, &c, mid);
+      m = mrb_method_search_vm_proc(mrb, proc, &c, mid);
       if (!m) {
         mrb_value sym = mrb_symbol_value(mid);
 

--- a/src/vm.c
+++ b/src/vm.c
@@ -21,6 +21,7 @@
 #include "mruby/opcode.h"
 #include "value_array.h"
 #include "mrb_throw.h"
+#include "class_inline.h"
 
 #ifndef ENABLE_STDIO
 #if defined(__cplusplus)

--- a/test/t/methods.rb
+++ b/test/t/methods.rb
@@ -107,3 +107,56 @@ assert('The undef statement (method undefined)', '13.3.7 a) 5)') do
     undef :non_existing_method
   end
 end
+
+assert('Method lookup after #include') do
+  module IncludeLookup
+    module A
+      def m
+        "a"
+      end
+    end
+
+    module B
+      def m
+        "b"
+      end
+    end
+
+    module C
+      def m
+        "c"
+      end
+    end
+
+    module D
+      def m
+        "d"
+      end
+    end
+
+
+    class X
+      include A
+    end
+
+    class Y < X
+    end
+  end
+
+  y = IncludeLookup::Y.new
+
+  assert_equal "a", y.m
+
+  IncludeLookup::X.send :include, IncludeLookup::B
+
+  assert_equal "b", y.m
+
+  IncludeLookup::X.send :include, IncludeLookup::C
+
+  assert_equal "c", y.m
+
+  IncludeLookup::Y.send :include, IncludeLookup::D
+
+  assert_equal "d", y.m
+
+end


### PR DESCRIPTION
This is an implementation of a simple method cache. The cache is inherently local. Every proc gets a small cache (default is 4 entries). 
At the same time, the cache is precise, in the sense that it is always up-to-date and doesn't require any complicated invalidation logic. Instead, upon definition (or undefinition) of a method we walk through all procs and their caches and update them (a bit like a garbage collector walks the heap).
Thus, the cost of defining and undefining a method increases, whilst lookup becomes faster.

Now some numbers: the `fib(39)` benchmark yields an improvement of about 6-8% on my machine.
Of course, the cache shines if there are deep inheritance chains or tight loops with lookups and is essentially a waste of memory for simple scripts.

If you consider merging this, I'd vote for not enabling by default.