### PR TITLE
Suppress warnings generated by -Wwrite-strings

### DIFF
--- a/mrbgems/mruby-bin-debugger/tools/mrdb/cmdbreak.c
+++ b/mrbgems/mruby-bin-debugger/tools/mrdb/cmdbreak.c
@@ -156,7 +156,7 @@ check_bptype(char* args)
 static void
 print_breakpoint(mrb_debug_breakpoint *bp)
 {
-  char* enable_letter[] = {BREAK_INFO_MSG_DISABLE, BREAK_INFO_MSG_ENABLE};
+  const char* enable_letter[] = {BREAK_INFO_MSG_DISABLE, BREAK_INFO_MSG_ENABLE};
 
   if(bp->type == MRB_DEBUG_BPTYPE_LINE) {
     printf(BREAK_INFO_MSG_LINEBREAK,

--- a/mrbgems/mruby-bin-mruby/tools/mruby/mruby.c
+++ b/mrbgems/mruby-bin-mruby/tools/mruby/mruby.c
@@ -209,7 +209,7 @@ main(int argc, char **argv)
   /* Set $0 */
   zero_sym = mrb_intern_lit(mrb, "$0");
   if (args.rfp) {
-    char *cmdline;
+    const char *cmdline;
     cmdline = args.cmdline ? args.cmdline : "-";
     mrbc_filename(mrb, c, cmdline);
     mrb_gv_set(mrb, zero_sym, mrb_str_new_cstr(mrb, cmdline));

--- a/mrbgems/mruby-string-ext/src/string.c
+++ b/mrbgems/mruby-string-ext/src/string.c
@@ -253,7 +253,7 @@ mrb_str_succ_bang(mrb_state *mrb, mrb_value self)
 {
   mrb_value result;
   unsigned char *p, *e, *b, *t;
-  char *prepend;
+  const char *prepend;
   struct RString *s = mrb_str_ptr(self);
   size_t l;
 

--- a/src/fmt_fp.c
+++ b/src/fmt_fp.c
@@ -121,7 +121,7 @@ fmt_fp(struct fmt_args *f, long double y, int w, int p, int fl, int t)
   } else prefix++, pl=0;
 
   if (!isfinite(y)) {
-    char *ss = (t&32)?"inf":"INF";
+    const char *ss = (t&32)?"inf":"INF";
     if (y!=y) ss=(t&32)?"nan":"NAN";
     pad(f, ' ', w, 3+pl, fl&~ZERO_PAD);
     out(f, prefix, pl);

--- a/tasks/toolchains/gcc.rake
+++ b/tasks/toolchains/gcc.rake
@@ -1,7 +1,7 @@
 MRuby::Toolchain.new(:gcc) do |conf|
   [conf.cc, conf.objc, conf.asm].each do |cc|
     cc.command = ENV['CC'] || 'gcc'
-    cc.flags = [ENV['CFLAGS'] || %w(-g -std=gnu99 -O3 -Wall -Werror-implicit-function-declaration -Wdeclaration-after-statement)]
+    cc.flags = [ENV['CFLAGS'] || %w(-g -std=gnu99 -O3 -Wall -Werror-implicit-function-declaration -Wdeclaration-after-statement -Wwrite-strings)]
     cc.defines = %w(DISABLE_GEMS)
     cc.option_include_path = '-I%s'
     cc.option_define = '-D%s'


### PR DESCRIPTION
Here are suppressed warnings:

    src/fmt_fp.c: In function 'fmt_fp':
    src/fmt_fp.c:124:16: warning: initialization discards 'const' qualifier from pointer target type
         char *ss = (t&32)?"inf":"INF";
                    ^
    src/fmt_fp.c:125:17: warning: assignment discards 'const' qualifier from pointer target type
         if (y!=y) ss=(t&32)?"nan":"NAN";
                     ^
    mrbgems/mruby-string-ext/src/string.c: In function 'mrb_str_succ_bang':
    mrbgems/mruby-string-ext/src/string.c:302:27: warning: assignment discards 'const' qualifier from pointer target type
           if (e == b) prepend = "1";
                               ^
    mrbgems/mruby-string-ext/src/string.c:305:27: warning: assignment discards 'const' qualifier from pointer target type
           if (e == b) prepend = "a";
                               ^
    mrbgems/mruby-string-ext/src/string.c:308:27: warning: assignment discards 'const' qualifier from pointer target type
           if (e == b) prepend = "A";
                               ^
    mrbgems/mruby-bin-mruby/tools/mruby/mruby.c: In function 'main':
    mrbgems/mruby-bin-mruby/tools/mruby/mruby.c:213:13: warning: assignment discards 'const' qualifier from pointer target type
         cmdline = args.cmdline ? args.cmdline : "-";
                 ^
    mrbgems/mruby-bin-debugger/tools/mrdb/cmdbreak.c: In function 'print_breakpoint':
    mrbgems/mruby-bin-debugger/tools/mrdb/cmdbreak.c:159:3: warning: initialization discards 'const' qualifier from pointer target type
       char* enable_letter[] = {BREAK_INFO_MSG_DISABLE, BREAK_INFO_MSG_ENABLE};
       ^
    mrbgems/mruby-bin-debugger/tools/mrdb/cmdbreak.c:159:3: warning: initialization discards 'const' qualifier from pointer target type
