### PR TITLE
define YYDEBUG macro conditionally

### DIFF
--- a/src/parse.y
+++ b/src/parse.y
@@ -6,8 +6,9 @@
 
 %{
 #undef PARSER_DEBUG
-
-#define YYDEBUG 1
+#ifdef PARSER_DEBUG
+# define YYDEBUG 1
+#endif
 #define YYERROR_VERBOSE 1
 /*
  * Force yacc to use our memory management.  This is a little evil because


### PR DESCRIPTION
The `YYDEBUG` macro enables parser debugging which unnecessarily increases the executable size (9 to 10 KB). Now it only will be defined when `PARSER_DEBUG` is too.