### PR TITLE
Avoid unnecessary stores and reloads

### DIFF
--- a/include/mruby/boxing_nan.h
+++ b/include/mruby/boxing_nan.h
@@ -61,7 +61,6 @@ typedef struct mrb_value {
 #define mrb_symbol(o)   (o).value.sym
 
 #define BOXNAN_SET_VALUE(o, tt, attr, v) do {\
-  (o).value.ttt = (0xfff00000|(((tt)+1)<<14));\
   switch (tt) {\
   case MRB_TT_FALSE:\
   case MRB_TT_TRUE:\
@@ -70,6 +69,7 @@ typedef struct mrb_value {
   case MRB_TT_SYMBOL: (o).attr = (v); break;\
   default: (o).value.i = 0; (o).value.p = (void*)((uintptr_t)(o).value.p | (((uintptr_t)(v))>>2)); break;\
   }\
+  (o).value.ttt = (0xfff00000|(((tt)+1)<<14));\
 } while (0)
 
 #define SET_FLOAT_VALUE(mrb,r,v) do { \

--- a/include/mruby/boxing_word.h
+++ b/include/mruby/boxing_word.h
@@ -92,15 +92,13 @@ mrb_type(mrb_value o)
 #define mrb_nil_p(o)  ((o).w == MRB_Qnil)
 
 #define BOXWORD_SET_VALUE(o, ttt, attr, v) do {\
-  (o).w = 0;\
-  (o).attr = (v);\
   switch (ttt) {\
   case MRB_TT_FALSE:  (o).w = (v) ? MRB_Qfalse : MRB_Qnil; break;\
   case MRB_TT_TRUE:   (o).w = MRB_Qtrue; break;\
   case MRB_TT_UNDEF:  (o).w = MRB_Qundef; break;\
-  case MRB_TT_FIXNUM: (o).value.i_flag = MRB_FIXNUM_FLAG; break;\
-  case MRB_TT_SYMBOL: (o).value.sym_flag = MRB_SYMBOL_FLAG; break;\
-  default:            if ((o).value.bp) (o).value.bp->tt = ttt; break;\
+  case MRB_TT_FIXNUM: (o).value.i_flag = MRB_FIXNUM_FLAG; (o).attr = (v); break;\
+  case MRB_TT_SYMBOL: (o).value.sym_flag = MRB_SYMBOL_FLAG; (o).attr = (v); break;\
+  default:            (o).w = 0; (o).attr = (v); if ((o).value.bp) (o).value.bp->tt = ttt; break;\
   }\
 } while (0)
 


### PR DESCRIPTION
Looking at the assembly output, I found that the compiler produces an unnecessary store and, in consequence, an unneeded reload. Since this code gets executed quite frequently I changed things
so that the compiler (only tested with Clang) generates a single load.

The NaN-boxing case is rather obvious. For word-boxing, integers and symbols always occupy all bits
of the word (right?), so  clearing to zero beforehand is useless.

It did a quick `make test` with the appropriate boxing macros set and things should be fine.