### PR TITLE
Update Coopyright Information to year 2015

### DIFF
--- a/MITL
+++ b/MITL
@@ -1,4 +1,4 @@
-Copyright (c) 2014 mruby developers
+Copyright (c) 2015 mruby developers
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ how to use mrbgems look into the folder *examples/mrbgems/*.
 
 ## License
 
-Copyright (c) 2014 mruby developers
+Copyright (c) 2015 mruby developers
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/include/mruby.h
+++ b/include/mruby.h
@@ -1,7 +1,7 @@
 /*
 ** mruby - An embeddable Ruby implementation
 **
-** Copyright (c) mruby developers 2010-2014
+** Copyright (c) mruby developers 2010-2015
 **
 ** Permission is hereby granted, free of charge, to any person obtaining
 ** a copy of this software and associated documentation files (the


### PR DESCRIPTION
Not sure what todo with ``doc/debugger/README.md`` as it claims the copyright belongs to the "mruby-forum" instead of "mruby developers"