### PR TITLE
let the C compiler validate the identifier

### DIFF
--- a/src/dump.c
+++ b/src/dump.c
@@ -1020,22 +1020,6 @@ mrb_dump_irep_binary(mrb_state *mrb, mrb_irep *irep, uint8_t flags, FILE* fp)
 }
 
 static mrb_bool
-is_valid_c_symbol_name(const char *name)
-{
-   const char *c = NULL;
-
-   if (name == NULL || name[0] == '\0') return FALSE;
-   if (!ISALPHA(name[0]) && name[0] != '_') return FALSE;
-
-   c = &name[1];
-   for (; *c != '\0'; ++c) {
-     if (!ISALNUM(*c) && *c != '_') return FALSE;
-   }
-
-   return TRUE;
-}
-
-static mrb_bool
 dump_bigendian_p(uint8_t flags)
 {
   switch (flags & DUMP_ENDIAN_NAT) {
@@ -1056,7 +1040,7 @@ mrb_dump_irep_cfunc(mrb_state *mrb, mrb_irep *irep, uint8_t flags, FILE *fp, con
   size_t bin_size = 0, bin_idx = 0;
   int result;
 
-  if (fp == NULL || initname == NULL || !is_valid_c_symbol_name(initname)) {
+  if (fp == NULL || initname == NULL || initname[0] == '\0') {
     return MRB_DUMP_INVALID_ARGUMENT;
   }
   flags = dump_flags(flags, FLAG_BYTEORDER_NATIVE);


### PR DESCRIPTION
Some C compilers may allow other characters in identifiers such as `$`. They may also implement C99's extended identifiers (`\u30EB\u30D3\u30FC`, `ルビー`).

https://gcc.gnu.org/onlinedocs/gcc/Dollar-Signs.html
https://gcc.gnu.org/wiki/FAQ#What_is_the_status_of_adding_the_UTF-8_support_for_identifier_names_in_GCC.3F
http://llvm.org/releases/3.3/tools/clang/docs/ReleaseNotes.html#extended-identifiers-unicode-support-and-universal-character-names