### PR TITLE
Fix build mruby for NetBSD

### DIFF
--- a/mrbgems/mruby-bin-mirb/mrbgem.rake
+++ b/mrbgems/mruby-bin-mirb/mrbgem.rake
@@ -12,7 +12,11 @@ MRuby::Gem::Specification.new('mruby-bin-mirb') do |spec|
         spec.linker.libraries << 'termcap'
       end
     end
-    spec.linker.libraries << 'readline'
+    if RUBY_PLATFORM.include?('netbsd')
+      spec.linker.libraries << 'edit'
+    else
+      spec.linker.libraries << 'readline'
+    end
   elsif spec.build.cc.search_header_path 'linenoise.h'
     spec.cc.defines << "ENABLE_LINENOISE"
   end

--- a/src/fmt_fp.c
+++ b/src/fmt_fp.c
@@ -90,7 +90,7 @@ fmt_u(uint32_t x, char *s)
 typedef char compiler_defines_long_double_incorrectly[9-(int)sizeof(long double)];
 #endif
 
-#if defined(__CYGWIN32__) || defined(mips)
+#if defined(__CYGWIN32__) || defined(__NetBSD__) || defined(mips)
 static long double
 frexpl (long double x, int *eptr)
 {


### PR DESCRIPTION
There are 2 compilation issues on NetBSD.

1. NetBSD 6.1.5 (latest release) does not have fexpl(3).
2. NetBSD does not have libreadline but readline(3) is in libedit.

The patch attached fixes them.