### PR TITLE
Add locals null checks

### DIFF
--- a/src/parse.y
+++ b/src/parse.y
@@ -239,7 +239,9 @@ local_nest(parser_state *p)
 static void
 local_unnest(parser_state *p)
 {
-  p->locals = p->locals->cdr;
+  if (p->locals) {
+    p->locals = p->locals->cdr;
+  }
 }
 
 static mrb_bool
@@ -261,7 +263,9 @@ local_var_p(parser_state *p, mrb_sym sym)
 static void
 local_add_f(parser_state *p, mrb_sym sym)
 {
-  p->locals->car = push(p->locals->car, nsym(sym));
+  if (p->locals) {
+    p->locals->car = push(p->locals->car, nsym(sym));
+  }
 }
 
 static void


### PR DESCRIPTION
I believe this will fix #2779 and also the following that causes a crash:

```
j do
  def !a.test
  end
  c = 1
end
```
