### PR TITLE
Add null check on lex_strterm in heredoc block

### DIFF
--- a/src/parse.y
+++ b/src/parse.y
@@ -4150,7 +4150,9 @@ parser_yylex(parser_state *p)
     p->lineno++;
     p->column = 0;
     if (p->parsing_heredoc != NULL) {
-      return parse_string(p);
+      if (p->lex_strterm) {
+        return parse_string(p);
+      }
     }
     goto retry;
   default:


### PR DESCRIPTION
This should fix another class of issues from the test cases in #2769, specifically certain special characters in heredocs combined with unterminated blocks. Here is an example, the ^@ here is actually a special character:

```
begin
<<o
^@
do
end
```