### PR TITLE
fix capture group index bug

### DIFF
--- a/src/parse.y
+++ b/src/parse.y
@@ -5118,7 +5118,14 @@ parser_yylex(parser_state *p)
       pushback(p, c);
       if (last_state == EXPR_FNAME) goto gvar;
       tokfix(p);
-      yylval.nd = new_nth_ref(p, atoi(tok(p)));
+      {
+        unsigned long n = strtoul(tok(p), NULL, 10);
+        if (n > INT_MAX) {
+          yyerror_i(p, "capture group index must be <= %d", INT_MAX);
+          return 0;
+        }
+        yylval.nd = new_nth_ref(p, (int)n);
+      }
       return tNTH_REF;
 
     default:


### PR DESCRIPTION
`atoi()` is used to convert the index to an int but the behavior is undefined if the value can't be represented.

```
> $9999999999
00007 NODE_SCOPE:
00007   NODE_BEGIN:
00007     NODE_NTH_REF: $2147483647
irep 00630580 nregs=2 nlocals=1 pools=0 syms=1 reps=0
file: (mirb)
7 000 OP_GETGLOBAL  R1      :$2147483647
7 001 OP_STOP
```
Call `strtoul()` instead as its behavior in such cases is defined and add a simple range check.

Alternatively `NODE_NTH_REF`'s cdr could be changed from `int` to `mrb_sym` (like `NODE_GVAR`). Then there would be no limitation but who needs that many capture groups anyway?