### PR TITLE
check if outer is a class or module

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -131,6 +131,19 @@ mrb_class_outer_module(mrb_state *mrb, struct RClass *c)
   return mrb_class_ptr(outer);
 }
 
+static void
+check_if_class_or_module(mrb_state *mrb, mrb_value obj)
+{
+  switch (mrb_type(obj)) {
+  case MRB_TT_CLASS:
+  case MRB_TT_SCLASS:
+  case MRB_TT_MODULE:
+    return;
+  default:
+    mrb_raisef(mrb, E_TYPE_ERROR, "%S is not a class/module", mrb_inspect(mrb, obj));
+  }
+}
+
 static struct RClass*
 define_module(mrb_state *mrb, mrb_sym name, struct RClass *outer)
 {
@@ -160,6 +173,7 @@ mrb_define_module(mrb_state *mrb, const char *name)
 MRB_API struct RClass*
 mrb_vm_define_module(mrb_state *mrb, mrb_value outer, mrb_sym id)
 {
+  check_if_class_or_module(mrb, outer);
   return define_module(mrb, id, mrb_class_ptr(outer));
 }
 
@@ -232,15 +246,7 @@ mrb_vm_define_class(mrb_state *mrb, mrb_value outer, mrb_value super, mrb_sym id
   else {
     s = 0;
   }
-  switch (mrb_type(outer)) {
-  case MRB_TT_CLASS:
-  case MRB_TT_SCLASS:
-  case MRB_TT_MODULE:
-    break;
-  default:
-    mrb_raisef(mrb, E_TYPE_ERROR, "%S is not a class/module", outer);
-    break;
-  }
+  check_if_class_or_module(mrb, outer);
   c = define_class(mrb, id, s, mrb_class_ptr(outer));
   mrb_class_inherited(mrb, mrb_class_real(c->super), c);
 

--- a/test/t/class.rb
+++ b/test/t/class.rb
@@ -383,3 +383,8 @@ assert('class variable and class << self style class method') do
 
   assert_equal("value", ClassVariableTest.class_variable)
 end
+
+assert('class with non-class/module outer raises TypeError') do
+  assert_raise(TypeError) { class 0::C1; end }
+  assert_raise(TypeError) { class []::C2; end }
+end

--- a/test/t/module.rb
+++ b/test/t/module.rb
@@ -533,3 +533,7 @@ assert('Module#module_function') do
   assert_true M.respond_to?(:modfunc)
 end
 
+assert('module with non-class/module outer raises TypeError') do
+  assert_raise(TypeError) { module 0::M1 end }
+  assert_raise(TypeError) { module []::M2 end }
+end


### PR DESCRIPTION
For modules this check didn't exist yet. Also call `#inspect`.

This fixes [id:000379,sig:11,src:014265,op:arith8,pos:8,val:+26](https://github.com/tongson/afl-fuzz-findings/blob/1e8a1fb7210d756174ecd0f7e171534a805cbbb5/mruby-1.1.0/crashes/id:000379%2Csig:11%2Csrc:014265%2Cop:arith8%2Cpos:8%2Cval:%2B26) (ref #2769).