### PR TITLE
fix masgn nosplat array rhs bug

### DIFF
--- a/src/codegen.c
+++ b/src/codegen.c
@@ -1615,8 +1615,14 @@ codegen(codegen_scope *s, node *tree, int val)
             }
           }
           if (t->car) {         /* rest (len - pre - post) */
-            int rn = len - post - n;
+            int rn;
 
+            if (len < post + n) {
+              rn = 0;
+            }
+            else {
+              rn = len - post - n;
+            }
             genop(s, MKOP_ABC(OP_ARRAY, cursp(), rhs+n, rn));
             gen_assignment(s, t->car, cursp(), NOVAL);
             n += rn;

--- a/test/t/syntax.rb
+++ b/test/t/syntax.rb
@@ -234,6 +234,20 @@ assert('multiple assignment (rest+post)') do
   assert_equal 3, d
 end
 
+assert('multiple assignment (nosplat array rhs)') do
+  a, *b = []
+  *c, d = [0]
+  e, *f, g = [1, 2]
+
+  assert_nil a
+  assert_equal [], b
+  assert_equal [], c
+  assert_equal 0, d
+  assert_equal 1, e
+  assert_equal [], f
+  assert_equal 2, g
+end
+
 assert('Return values of case statements') do
   a = [] << case 1
   when 3 then 2


### PR DESCRIPTION
The rest lhs variable has to be an empty array if rhs is an array with less elements than pre + post lhs variables. The codegen generated OP_ARRAY with an invalid length (such as 127 for `*a, b = []`) because rn was negative.