### PR TITLE
remove unnecessary mrb_immediate_p()

### DIFF
--- a/src/array.c
+++ b/src/array.c
@@ -1052,7 +1052,6 @@ mrb_ary_eq(mrb_state *mrb, mrb_value ary1)
 
   mrb_get_args(mrb, "o", &ary2);
   if (mrb_obj_equal(mrb, ary1, ary2)) return mrb_true_value();
-  if (mrb_immediate_p(ary2)) return mrb_false_value();
   if (!mrb_array_p(ary2)) {
     return mrb_false_value();
   }
@@ -1068,7 +1067,6 @@ mrb_ary_cmp(mrb_state *mrb, mrb_value ary1)
 
   mrb_get_args(mrb, "o", &ary2);
   if (mrb_obj_equal(mrb, ary1, ary2)) return mrb_fixnum_value(0);
-  if (mrb_immediate_p(ary2)) return mrb_nil_value();
   if (!mrb_array_p(ary2)) {
     return mrb_nil_value();
   }

--- a/src/etc.c
+++ b/src/etc.c
@@ -26,7 +26,7 @@ mrb_data_object_alloc(mrb_state *mrb, struct RClass *klass, void *ptr, const mrb
 MRB_API void
 mrb_data_check_type(mrb_state *mrb, mrb_value obj, const mrb_data_type *type)
 {
-  if (mrb_immediate_p(obj) || (mrb_type(obj) != MRB_TT_DATA)) {
+  if (mrb_type(obj) != MRB_TT_DATA) {
     mrb_check_type(mrb, obj, MRB_TT_DATA);
   }
   if (DATA_TYPE(obj) != type) {
@@ -48,7 +48,7 @@ mrb_data_check_type(mrb_state *mrb, mrb_value obj, const mrb_data_type *type)
 MRB_API void*
 mrb_data_check_get_ptr(mrb_state *mrb, mrb_value obj, const mrb_data_type *type)
 {
-  if (mrb_immediate_p(obj) || (mrb_type(obj) != MRB_TT_DATA)) {
+  if (mrb_type(obj) != MRB_TT_DATA) {
     return NULL;
   }
   if (DATA_TYPE(obj) != type) {


### PR DESCRIPTION
I think `!mrb_array_p(ary2)` and `mrb_type(obj) != MRB_TT_DATA` are sufficient or am I missing something?