### PR TITLE
Fix build on MIPS of linux

### DIFF
--- a/src/fmt_fp.c
+++ b/src/fmt_fp.c
@@ -90,7 +90,7 @@ fmt_u(uint32_t x, char *s)
 typedef char compiler_defines_long_double_incorrectly[9-(int)sizeof(long double)];
 #endif
 
-#if defined(__CYGWIN32__) || defined(__NetBSD__) || defined(mips)
+#if (defined(__CYGWIN32__) || defined(__NetBSD__) || defined(mips)) && !defined(__linux__)
 static long double
 frexpl (long double x, int *eptr)
 {


### PR DESCRIPTION
MIPS of Linux platform is supported frexpl(3).
This fixes to use the frexpl that are provided with gcc if user wants to build
on MIPS of Linux platform.

Signe-doff-by: Nobuhiro Iwamatsu <iwamatsu@nigauri.org>