### PR TITLE
Detect if ncurses' backend is terminfo or termcap.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,7 @@
 # basic build file for mruby
 MRUBY_ROOT = File.dirname(File.expand_path(__FILE__))
 MRUBY_BUILD_HOST_IS_CYGWIN = RUBY_PLATFORM.include?('cygwin')
+MRUBY_BUILD_HOST_IS_OPENBSD = RUBY_PLATFORM.include?('openbsd')
 
 # load build systems
 load "#{MRUBY_ROOT}/tasks/ruby_ext.rake"

--- a/mrbgems/mruby-bin-mirb/mrbgem.rake
+++ b/mrbgems/mruby-bin-mirb/mrbgem.rake
@@ -6,10 +6,16 @@ MRuby::Gem::Specification.new('mruby-bin-mirb') do |spec|
   if spec.build.cc.search_header_path 'readline/readline.h'
     spec.cc.defines << "ENABLE_READLINE"
     if spec.build.cc.search_header_path 'termcap.h'
-      if MRUBY_BUILD_HOST_IS_CYGWIN then
-        spec.linker.libraries << 'ncurses'
-      else
-        spec.linker.libraries << 'termcap'
+      if MRUBY_BUILD_HOST_IS_CYGWIN || MRUBY_BUILD_HOST_IS_OPENBSD
+        if spec.build.cc.search_header_path 'termcap.h'
+          if MRUBY_BUILD_HOST_IS_CYGWIN then
+            spec.linker.libraries << 'ncurses'
+          elsif spec.linker.has_library('libterminfo') then
+            spec.linker.libraries << 'terminfo'
+          else
+            spec.linker.libraries << 'termcap'
+          end
+        end
       end
     end
     if RUBY_PLATFORM.include?('netbsd')


### PR DESCRIPTION
Detect if ncurses' backend is terminfo or termcap. fixes #2662

Borrowed from @mattn's code at:
https://github.com/mruby/mruby/issues/2662#issuecomment-65535705

Signed-off-by: Huei-Horng Yo <hiroshi@ghostsinthelab.org>