### PR TITLE
Remove the unused libterminfo detection code.

### DIFF
--- a/mrbgems/mruby-bin-mirb/mrbgem.rake
+++ b/mrbgems/mruby-bin-mirb/mrbgem.rake
@@ -10,8 +10,6 @@ MRuby::Gem::Specification.new('mruby-bin-mirb') do |spec|
         if spec.build.cc.search_header_path 'termcap.h'
           if MRUBY_BUILD_HOST_IS_CYGWIN then
             spec.linker.libraries << 'ncurses'
-          elsif spec.linker.has_library('libterminfo') then
-            spec.linker.libraries << 'terminfo'
           else
             spec.linker.libraries << 'termcap'
           end


### PR DESCRIPTION
The detection code is unused even on OpenBSD 5.7,
because of the standard installation is libtermcap be installed, not libterminfo.

This fixes #2829

Tested on Arch Linux (x86_64) & OpenBSD 5.7 (amd64).

Signed-off-by: Huei-Horng Yo <hiroshi@ghostsinthelab.org>