### PR TITLE
refactor code to call mrb_inspect() instead

### DIFF
--- a/mrbgems/mruby-bin-mruby/tools/mruby/mruby.c
+++ b/mrbgems/mruby-bin-mruby/tools/mruby/mruby.c
@@ -11,12 +11,8 @@
 static void
 p(mrb_state *mrb, mrb_value obj)
 {
-  mrb_value val;
+  mrb_value val = mrb_inspect(mrb, obj);
 
-  val = mrb_funcall(mrb, obj, "inspect", 0);
-  if (!mrb_string_p(val)) {
-    val = mrb_obj_as_string(mrb, obj);
-  }
   fwrite(RSTRING_PTR(val), RSTRING_LEN(val), 1, stdout);
   putc('\n', stdout);
 }

--- a/src/print.c
+++ b/src/print.c
@@ -27,12 +27,8 @@ MRB_API void
 mrb_p(mrb_state *mrb, mrb_value obj)
 {
 #ifdef ENABLE_STDIO
-  mrb_value val;
+  mrb_value val = mrb_inspect(mrb, obj);
 
-  val = mrb_funcall(mrb, obj, "inspect", 0);
-  if (!mrb_string_p(val)) {
-    val = mrb_obj_as_string(mrb, obj);
-  }
   printstr(mrb, val);
   putc('\n', stdout);
 #endif


### PR DESCRIPTION
`mrb_inspect()` also calls `mrb_obj_as_string()` after `#inspect` to ensure the `mrb_value` is a string.