### PR TITLE
Added a check for 64 bit time_t overflow

### DIFF
--- a/mrbgems/mruby-time/src/time.c
+++ b/mrbgems/mruby-time/src/time.c
@@ -193,7 +193,6 @@ mrb_time_wrap(mrb_state *mrb, struct RClass *tc, struct mrb_time *tm)
   return mrb_obj_value(Data_Wrap_Struct(mrb, tc, &mrb_time_type, tm));
 }
 
-
 /* Allocates a mrb_time object and initializes it. */
 static struct mrb_time*
 time_alloc(mrb_state *mrb, double sec, double usec, enum mrb_timezone timezone)
@@ -201,12 +200,15 @@ time_alloc(mrb_state *mrb, double sec, double usec, enum mrb_timezone timezone)
   struct mrb_time *tm;
 
   tm = (struct mrb_time *)mrb_malloc(mrb, sizeof(struct mrb_time));
-  tm->sec  = (time_t)sec;
-  if (sizeof(time_t) == 4 && (sec > (double)INT32_MAX || (double)INT32_MIN > sec)) {
-    goto out_of_range;
-  }
-  else if ((sec > 0 && tm->sec < 0) || (sec < 0 && (double)tm->sec > sec)) {
-  out_of_range:
+  tm->sec = (time_t)sec;
+  if (
+    /* Check for overflow of 32 bit time_t */
+    (sizeof(time_t) == 4 && (sec > (double)INT32_MAX || (double)INT32_MIN > sec)) ||
+    /* Check for overflow of 64 bit time_t */
+    (sizeof(time_t) == 8 && (sec > (double)INT64_MAX || (double)INT64_MIN > sec)) ||
+    /* Check for wrapping of tm->sec */
+    ((sec > 0 && tm->sec < 0) || (sec < 0 && (double)tm->sec > sec))
+  ) {
     mrb_raisef(mrb, E_ARGUMENT_ERROR, "%S out of Time range", mrb_float_value(mrb, sec));
   }
   tm->usec = (time_t)llround((sec - tm->sec) * 1.0e6 + usec);


### PR DESCRIPTION
This should check for overflow on platforms where time_t is 64 bit.