### PR TITLE
fix arity of lambdas with optional arguments

### DIFF
--- a/src/proc.c
+++ b/src/proc.c
@@ -216,7 +216,7 @@ mrb_proc_arity(mrb_state *mrb, mrb_value self)
   ma = MRB_ASPEC_REQ(aspec);
   ra = MRB_ASPEC_REST(aspec);
   pa = MRB_ASPEC_POST(aspec);
-  arity = ra ? -(ma + pa + 1) : ma + pa;
+  arity = ra || MRB_PROC_STRICT_P(p) ? -(ma + pa + 1) : ma + pa;
 
   return mrb_fixnum_value(arity);
 }

--- a/test/t/proc.rb
+++ b/test/t/proc.rb
@@ -36,6 +36,14 @@ assert('Proc#arity', '15.2.17.4.2') do
   assert_equal(-3, b)
   assert_equal  1, c
   assert_equal  1, d
+
+  e = ->(x=0, y){}.arity
+  f = ->((x, y), z=0){}.arity
+  g = ->(x=0){}.arity
+
+  assert_equal(-2, e)
+  assert_equal(-2, f)
+  assert_equal(-1, g)
 end
 
 assert('Proc#call', '15.2.17.4.3') do


### PR DESCRIPTION
From [the CRuby 2.2.2 Proc#arity documentation](https://github.com/ruby/ruby/blob/v2_2_2/proc.c#L790-L793):

>If the block has optional arguments, returns -n-1, where n is the number of mandatory arguments, with the exception for blocks that are not lambdas and have only a finite number of optional arguments; in this latter case, returns n.