### PR TITLE
Need mruby-compiler to build mruby-bin-mruby and mruby-bin-mirb for

### DIFF
--- a/mrbgems/default.gembox
+++ b/mrbgems/default.gembox
@@ -70,4 +70,7 @@ MRuby::GemBox.new do |conf|
 
   # Use extensional Kernel module
   conf.gem :core => "mruby-kernel-ext"
+
+  # Use mruby-compiler to build other mrbgems
+  conf.gem :core => "mruby-compiler"
 end

--- a/mrbgems/mruby-bin-mirb/mrbgem.rake
+++ b/mrbgems/mruby-bin-mirb/mrbgem.rake
@@ -26,4 +26,5 @@ MRuby::Gem::Specification.new('mruby-bin-mirb') do |spec|
   end
 
   spec.bins = %w(mirb)
+  spec.add_dependency('mruby-compiler', :core => 'mruby-compiler')
 end

--- a/mrbgems/mruby-bin-mruby/mrbgem.rake
+++ b/mrbgems/mruby-bin-mruby/mrbgem.rake
@@ -3,4 +3,5 @@ MRuby::Gem::Specification.new('mruby-bin-mruby') do |spec|
   spec.author  = 'mruby developers'
   spec.summary = 'mruby command'
   spec.bins = %w(mruby)
+  spec.add_dependency('mruby-compiler', :core => 'mruby-compiler')
 end


### PR DESCRIPTION
cross compilesWhen trying to build `mruby-bin-mruby` or `mruby-bin-mirb` for cross compilation from Linux to OSX, I ran into the following error:

```
clang: error: linker command failed with exit code 1 (use -v to see invocation)
Undefined symbols for architecture x86_64:
  "_mrb_load_file_cxt", referenced from:
      _main in mruby.o
  "_mrb_load_string_cxt", referenced from:
      _main in mruby.o
  "_mrbc_context_free", referenced from:
      _main in mruby.o
  "_mrbc_context_new", referenced from:
      _main in mruby.o
  "_mrbc_filename", referenced from:
      _main in mruby.o
ld: symbol(s) not found for architecture x86_64
```

Adding `mruby-compiler` fixes it. If this is needed for cross compiles, we should just add it as a build dependency.

/cc @zzak