### PR TITLE
provide targets for building native extensions during CrossBuild

### DIFF
--- a/tasks/mruby_build.rake
+++ b/tasks/mruby_build.rake
@@ -283,6 +283,10 @@ EOS
 
   class CrossBuild < Build
     attr_block %w(test_runner)
+    # cross compiling targets for building native extensions.
+    # host  - arch of where the built binary will run
+    # build - arch of the machine building the binary
+    attr_accessor :host_target, :build_target
 
     def initialize(name, build_dir=nil, &block)
       @test_runner = Command::CrossTestRunner.new(self)


### PR DESCRIPTION
Sometimes a mrbgem pulls in a native extension that needs to be built. There's currently no way to provide information to autoconf or build scripts how to build the native extension for the `MRuby::CrossBuild` target. Instead gems are forced to [skip building them](https://github.com/mattn/mruby-onig-regexp/commit/c2a82f6bcd8698b86bcffa0e79ba42dcebd5fe81) when detecting a `MRuby::CrossBuild`. This is a proposal for a `MRuby::CrossBuild` to provide this information so a [mrbgem can take advantage of it](https://github.com/hone/mruby-onig-regexp/commit/d3c8875713e938840a2dd8fcff6adefc9cdad580). The naming is based off the [flags for autoconf](https://www.gnu.org/software/autoconf/manual/autoconf-2.65/html_node/Specifying-Target-Triplets.html).

Would love your throughts @take-cheeze.

/cc @zzak