### PR TITLE
Remove unnecessary backticks

### DIFF
--- a/include/mruby/compile.h
+++ b/include/mruby/compile.h
@@ -55,8 +55,8 @@ enum mrb_lex_state_enum {
   EXPR_CMDARG,                /* newline significant, +/- is an operator. */
   EXPR_MID,                   /* newline significant, +/- is an operator. */
   EXPR_FNAME,                 /* ignore newline, no reserved words. */
-  EXPR_DOT,                   /* right after `.' or `::', no reserved words. */
-  EXPR_CLASS,                 /* immediate after `class', no here document. */
+  EXPR_DOT,                   /* right after '.' or '::', no reserved words. */
+  EXPR_CLASS,                 /* immediate after 'class', no here document. */
   EXPR_VALUE,                 /* alike EXPR_BEG but label is disallowed. */
   EXPR_MAX_STATE
 };

--- a/include/mruby/opcode.h
+++ b/include/mruby/opcode.h
@@ -8,7 +8,7 @@
 #define MRUBY_OPCODE_H
 
 #define MAXARG_Bx        (0xffff)
-#define MAXARG_sBx       (MAXARG_Bx>>1)         /* `sBx' is signed */
+#define MAXARG_sBx       (MAXARG_Bx>>1)         /* 'sBx' is signed */
 
 /* instructions: packed 32 bit      */
 /* -------------------------------  */

--- a/mrbgems/mruby-compiler/core/parse.y
+++ b/mrbgems/mruby-compiler/core/parse.y
@@ -4204,7 +4204,7 @@ parser_yylex(parser_state *p)
       }
       pushback(p, c);
       if (IS_SPCARG(c)) {
-        yywarning(p, "`*' interpreted as argument prefix");
+        yywarning(p, "'*' interpreted as argument prefix");
         c = tSTAR;
       }
       else if (IS_BEG()) {
@@ -4455,7 +4455,7 @@ parser_yylex(parser_state *p)
     }
     pushback(p, c);
     if (IS_SPCARG(c)) {
-      yywarning(p, "`&' interpreted as argument prefix");
+      yywarning(p, "'&' interpreted as argument prefix");
       c = tAMPER;
     }
     else if (IS_BEG()) {
@@ -4761,7 +4761,7 @@ parser_yylex(parser_state *p)
         nondigit = c;
         break;
 
-      case '_':       /* `_' in number just ignored */
+      case '_':       /* '_' in number just ignored */
         if (nondigit) goto decode_num;
         nondigit = c;
         break;
@@ -4776,7 +4776,7 @@ parser_yylex(parser_state *p)
     pushback(p, c);
     if (nondigit) {
       trailing_uc:
-      yyerror_i(p, "trailing `%c' in number", nondigit);
+      yyerror_i(p, "trailing '%c' in number", nondigit);
     }
     tokfix(p);
     if (is_float) {
@@ -5157,10 +5157,10 @@ parser_yylex(parser_state *p)
       }
       else if (isdigit(c)) {
         if (p->bidx == 1) {
-          yyerror_i(p, "`@%c' is not allowed as an instance variable name", c);
+          yyerror_i(p, "'@%c' is not allowed as an instance variable name", c);
         }
         else {
-          yyerror_i(p, "`@@%c' is not allowed as a class variable name", c);
+          yyerror_i(p, "'@@%c' is not allowed as a class variable name", c);
         }
         return 0;
       }
@@ -5176,7 +5176,7 @@ parser_yylex(parser_state *p)
 
     default:
       if (!identchar(c)) {
-        yyerror_i(p,  "Invalid char `\\x%02X' in expression", c);
+        yyerror_i(p,  "Invalid char '\\x%02X' in expression", c);
         goto retry;
       }
 

--- a/mrbgems/mruby-hash-ext/mrblib/hash.rb
+++ b/mrbgems/mruby-hash-ext/mrblib/hash.rb
@@ -119,7 +119,7 @@ class Hash
   #
   #  <em>produces:</em>
   #
-  #     prog.rb:2:in `fetch': key not found (KeyError)
+  #     prog.rb:2:in 'fetch': key not found (KeyError)
   #      from prog.rb:2
   #
 

--- a/mrbgems/mruby-sprintf/src/sprintf.c
+++ b/mrbgems/mruby-sprintf/src/sprintf.c
@@ -234,20 +234,20 @@ get_hash(mrb_state *mrb, mrb_value *hash, int argc, const mrb_value *argv)
  *      ------+--------------------------------------------------------------
  *        b   | Convert argument as a binary number.
  *            | Negative numbers will be displayed as a two's complement
- *            | prefixed with `..1'.
- *        B   | Equivalent to `b', but uses an uppercase 0B for prefix
+ *            | prefixed with '..1'.
+ *        B   | Equivalent to 'b', but uses an uppercase 0B for prefix
  *            | in the alternative format by #.
  *        d   | Convert argument as a decimal number.
- *        i   | Identical to `d'.
+ *        i   | Identical to 'd'.
  *        o   | Convert argument as an octal number.
  *            | Negative numbers will be displayed as a two's complement
- *            | prefixed with `..7'.
- *        u   | Identical to `d'.
+ *            | prefixed with '..7'.
+ *        u   | Identical to 'd'.
  *        x   | Convert argument as a hexadecimal number.
  *            | Negative numbers will be displayed as a two's complement
- *            | prefixed with `..f' (representing an infinite string of
+ *            | prefixed with '..f' (representing an infinite string of
  *            | leading 'ff's).
- *        X   | Equivalent to `x', but uses uppercase letters.
+ *        X   | Equivalent to 'x', but uses uppercase letters.
  *
  *      Field |  Float Format
  *      ------+--------------------------------------------------------------
@@ -255,7 +255,7 @@ get_hash(mrb_state *mrb, mrb_value *hash, int argc, const mrb_value *argv)
  *            | with one digit before the decimal point as [-]d.dddddde[+-]dd.
  *            | The precision specifies the number of digits after the decimal
  *            | point (defaulting to six).
- *        E   | Equivalent to `e', but uses an uppercase E to indicate
+ *        E   | Equivalent to 'e', but uses an uppercase E to indicate
  *            | the exponent.
  *        f   | Convert floating point argument as [-]ddd.dddddd,
  *            | where the precision specifies the number of digits after
@@ -264,11 +264,11 @@ get_hash(mrb_state *mrb, mrb_value *hash, int argc, const mrb_value *argv)
  *            | if the exponent is less than -4 or greater than or
  *            | equal to the precision, or in dd.dddd form otherwise.
  *            | The precision specifies the number of significant digits.
- *        G   | Equivalent to `g', but use an uppercase `E' in exponent form.
+ *        G   | Equivalent to 'g', but use an uppercase 'E' in exponent form.
  *        a   | Convert floating point argument as [-]0xh.hhhhp[+-]dd,
  *            | which is consisted from optional sign, "0x", fraction part
  *            | as hexadecimal, "p", and exponential part as decimal.
- *        A   | Equivalent to `a', but use uppercase `X' and `P'.
+ *        A   | Equivalent to 'a', but use uppercase 'X' and 'P'.
  *
  *      Field |  Other Format
  *      ------+--------------------------------------------------------------
@@ -287,7 +287,7 @@ get_hash(mrb_state *mrb, mrb_value *hash, int argc, const mrb_value *argv)
  *    ---------+---------------+-----------------------------------------
  *    space    | bBdiouxX      | Leave a space at the start of
  *             | aAeEfgG       | non-negative numbers.
- *             | (numeric fmt) | For `o', `x', `X', `b' and `B', use
+ *             | (numeric fmt) | For 'o', 'x', 'X', 'b' and 'B', use
  *             |               | a minus sign with absolute value for
  *             |               | negative values.
  *    ---------+---------------+-----------------------------------------
@@ -297,27 +297,27 @@ get_hash(mrb_state *mrb, mrb_value *hash, int argc, const mrb_value *argv)
  *             |               | sprintf string.
  *    ---------+---------------+-----------------------------------------
  *     #       | bBoxX         | Use an alternative format.
- *             | aAeEfgG       | For the conversions `o', increase the precision
- *             |               | until the first digit will be `0' if
+ *             | aAeEfgG       | For the conversions 'o', increase the precision
+ *             |               | until the first digit will be '0' if
  *             |               | it is not formatted as complements.
- *             |               | For the conversions `x', `X', `b' and `B'
- *             |               | on non-zero, prefix the result with ``0x'',
- *             |               | ``0X'', ``0b'' and ``0B'', respectively.
- *             |               | For `a', `A', `e', `E', `f', `g', and 'G',
+ *             |               | For the conversions 'x', 'X', 'b' and 'B'
+ *             |               | on non-zero, prefix the result with "0x",
+ *             |               | "0X", "0b" and "0B", respectively.
+ *             |               | For 'a', 'A', 'e', 'E', 'f', 'g', and 'G',
  *             |               | force a decimal point to be added,
  *             |               | even if no digits follow.
- *             |               | For `g' and 'G', do not remove trailing zeros.
+ *             |               | For 'g' and 'G', do not remove trailing zeros.
  *    ---------+---------------+-----------------------------------------
  *    +        | bBdiouxX      | Add a leading plus sign to non-negative
  *             | aAeEfgG       | numbers.
- *             | (numeric fmt) | For `o', `x', `X', `b' and `B', use
+ *             | (numeric fmt) | For 'o', 'x', 'X', 'b' and 'B', use
  *             |               | a minus sign with absolute value for
  *             |               | negative values.
  *    ---------+---------------+-----------------------------------------
  *    -        | all           | Left-justify the result of this conversion.
  *    ---------+---------------+-----------------------------------------
  *    0 (zero) | bBdiouxX      | Pad with zeros, not spaces.
- *             | aAeEfgG       | For `o', `x', `X', `b' and `B', radix-1
+ *             | aAeEfgG       | For 'o', 'x', 'X', 'b' and 'B', radix-1
  *             | (numeric fmt) | is used for negative numbers formatted as
  *             |               | complements.
  *    ---------+---------------+-----------------------------------------
@@ -328,21 +328,21 @@ get_hash(mrb_state *mrb, mrb_value *hash, int argc, const mrb_value *argv)
  *
  *  Examples of flags:
  *
- *   # `+' and space flag specifies the sign of non-negative numbers.
+ *   # '+' and space flag specifies the sign of non-negative numbers.
  *   sprintf("%d", 123)  #=> "123"
  *   sprintf("%+d", 123) #=> "+123"
  *   sprintf("% d", 123) #=> " 123"
  *
- *   # `#' flag for `o' increases number of digits to show `0'.
- *   # `+' and space flag changes format of negative numbers.
+ *   # '#' flag for 'o' increases number of digits to show '0'.
+ *   # '+' and space flag changes format of negative numbers.
  *   sprintf("%o", 123)   #=> "173"
  *   sprintf("%#o", 123)  #=> "0173"
  *   sprintf("%+o", -123) #=> "-173"
  *   sprintf("%o", -123)  #=> "..7605"
  *   sprintf("%#o", -123) #=> "..7605"
  *
- *   # `#' flag for `x' add a prefix `0x' for non-zero numbers.
- *   # `+' and space flag disables complements for negative numbers.
+ *   # '#' flag for 'x' add a prefix '0x' for non-zero numbers.
+ *   # '+' and space flag disables complements for negative numbers.
  *   sprintf("%x", 123)   #=> "7b"
  *   sprintf("%#x", 123)  #=> "0x7b"
  *   sprintf("%+x", -123) #=> "-7b"
@@ -350,12 +350,12 @@ get_hash(mrb_state *mrb, mrb_value *hash, int argc, const mrb_value *argv)
  *   sprintf("%#x", -123) #=> "0x..f85"
  *   sprintf("%#x", 0)    #=> "0"
  *
- *   # `#' for `X' uses the prefix `0X'.
+ *   # '#' for 'X' uses the prefix '0X'.
  *   sprintf("%X", 123)  #=> "7B"
  *   sprintf("%#X", 123) #=> "0X7B"
  *
- *   # `#' flag for `b' add a prefix `0b' for non-zero numbers.
- *   # `+' and space flag disables complements for negative numbers.
+ *   # '#' flag for 'b' add a prefix '0b' for non-zero numbers.
+ *   # '+' and space flag disables complements for negative numbers.
  *   sprintf("%b", 123)   #=> "1111011"
  *   sprintf("%#b", 123)  #=> "0b1111011"
  *   sprintf("%+b", -123) #=> "-1111011"
@@ -363,19 +363,19 @@ get_hash(mrb_state *mrb, mrb_value *hash, int argc, const mrb_value *argv)
  *   sprintf("%#b", -123) #=> "0b..10000101"
  *   sprintf("%#b", 0)    #=> "0"
  *
- *   # `#' for `B' uses the prefix `0B'.
+ *   # '#' for 'B' uses the prefix '0B'.
  *   sprintf("%B", 123)  #=> "1111011"
  *   sprintf("%#B", 123) #=> "0B1111011"
  *
- *   # `#' for `e' forces to show the decimal point.
+ *   # '#' for 'e' forces to show the decimal point.
  *   sprintf("%.0e", 1)  #=> "1e+00"
  *   sprintf("%#.0e", 1) #=> "1.e+00"
  *
- *   # `#' for `f' forces to show the decimal point.
+ *   # '#' for 'f' forces to show the decimal point.
  *   sprintf("%.0f", 1234)  #=> "1234"
  *   sprintf("%#.0f", 1234) #=> "1234."
  *
- *   # `#' for `g' forces to show the decimal point.
+ *   # '#' for 'g' forces to show the decimal point.
  *   # It also disables stripping lowest zeros.
  *   sprintf("%g", 123.4)   #=> "123.4"
  *   sprintf("%#g", 123.4)  #=> "123.400"
@@ -409,7 +409,7 @@ get_hash(mrb_state *mrb, mrb_value *hash, int argc, const mrb_value *argv)
  *
  *  Examples of precisions:
  *
- *   # precision for `d', 'o', 'x' and 'b' is
+ *   # precision for 'd', 'o', 'x' and 'b' is
  *   # minimum number of digits               <------>
  *   sprintf("%20.8d", 123)  #=> "            00000123"
  *   sprintf("%20.8o", 123)  #=> "            00000173"
@@ -420,8 +420,8 @@ get_hash(mrb_state *mrb, mrb_value *hash, int argc, const mrb_value *argv)
  *   sprintf("%20.8x", -123) #=> "            ..ffff85"
  *   sprintf("%20.8b", -11)  #=> "            ..110101"
  *
- *   # "0x" and "0b" for `#x' and `#b' is not counted for
- *   # precision but "0" for `#o' is counted.  <------>
+ *   # "0x" and "0b" for '#x' and '#b' is not counted for
+ *   # precision but "0" for '#o' is counted.  <------>
  *   sprintf("%#20.8d", 123)  #=> "            00000123"
  *   sprintf("%#20.8o", 123)  #=> "            00000173"
  *   sprintf("%#20.8x", 123)  #=> "          0x0000007b"
@@ -431,22 +431,22 @@ get_hash(mrb_state *mrb, mrb_value *hash, int argc, const mrb_value *argv)
  *   sprintf("%#20.8x", -123) #=> "          0x..ffff85"
  *   sprintf("%#20.8b", -11)  #=> "          0b..110101"
  *
- *   # precision for `e' is number of
+ *   # precision for 'e' is number of
  *   # digits after the decimal point           <------>
  *   sprintf("%20.8e", 1234.56789) #=> "      1.23456789e+03"
  *
- *   # precision for `f' is number of
+ *   # precision for 'f' is number of
  *   # digits after the decimal point               <------>
  *   sprintf("%20.8f", 1234.56789) #=> "       1234.56789000"
  *
- *   # precision for `g' is number of
+ *   # precision for 'g' is number of
  *   # significant digits                          <------->
  *   sprintf("%20.8g", 1234.56789) #=> "           1234.5679"
  *
  *   #                                         <------->
  *   sprintf("%20.8g", 123456789)  #=> "       1.2345679e+08"
  *
- *   # precision for `s' is
+ *   # precision for 's' is
  *   # maximum number of characters                    <------>
  *   sprintf("%20.8s", "string test") #=> "            string t"
  *
@@ -539,7 +539,7 @@ mrb_str_format(mrb_state *mrb, int argc, const mrb_value *argv, mrb_value fmt)
     if (t >= end)
       goto sprint_exit; /* end of fmt string */
 
-    p = t + 1;    /* skip `%' */
+    p = t + 1;    /* skip '%' */
 
     width = prec = -1;
     nextvalue = mrb_undef_value();

--- a/mrbgems/mruby-struct/src/struct.c
+++ b/mrbgems/mruby-struct/src/struct.c
@@ -114,7 +114,7 @@ mrb_struct_getmember(mrb_state *mrb, mrb_value obj, mrb_sym id)
       return ptr[i];
     }
   }
-  mrb_raisef(mrb, E_INDEX_ERROR, "`%S' is not a struct member", mrb_sym2str(mrb, id));
+  mrb_raisef(mrb, E_INDEX_ERROR, "'%S' is not a struct member", mrb_sym2str(mrb, id));
   return mrb_nil_value();       /* not reached */
 }
 
@@ -193,7 +193,7 @@ mrb_struct_set(mrb_state *mrb, mrb_value obj, mrb_value val)
       return ptr[i] = val;
     }
   }
-  mrb_raisef(mrb, E_INDEX_ERROR, "`%S' is not a struct member", mrb_sym2str(mrb, mid));
+  mrb_raisef(mrb, E_INDEX_ERROR, "'%S' is not a struct member", mrb_sym2str(mrb, mid));
   return mrb_nil_value();       /* not reached */
 }
 
@@ -749,8 +749,8 @@ mrb_struct_values_at(mrb_state *mrb, mrb_value self)
  *  The <code>Struct</code> class is a generator of specific classes,
  *  each one of which is defined to hold a set of variables and their
  *  accessors. In these examples, we'll call the generated class
- *  ``<i>Customer</i>Class,'' and we'll show an example instance of that
- *  class as ``<i>Customer</i>Inst.''
+ *  "<i>Customer</i>Class," and we'll show an example instance of that
+ *  class as "<i>Customer</i>Inst."
  *
  *  In the descriptions that follow, the parameter <i>symbol</i> refers
  *  to a symbol, which is either a quoted string or a

--- a/mrblib/array.rb
+++ b/mrblib/array.rb
@@ -146,7 +146,7 @@ class Array
   #  equal, then that inequality is the return value. If all the
   #  values found are equal, then the return is based on a
   #  comparison of the array lengths.  Thus, two arrays are
-  #  ``equal'' according to <code>Array#<=></code> if and only if they have
+  #  "equal" according to <code>Array#<=></code> if and only if they have
   #  the same length and the value of each element is equal to the
   #  value of the corresponding element in the other array.
   #

--- a/src/class.c
+++ b/src/class.c
@@ -212,7 +212,7 @@ MRB_API struct RClass*
 mrb_define_class_id(mrb_state *mrb, mrb_sym name, struct RClass *super)
 {
   if (!super) {
-    mrb_warn(mrb, "no super class for `%S', Object assumed", mrb_sym2str(mrb, name));
+    mrb_warn(mrb, "no super class for '%S', Object assumed", mrb_sym2str(mrb, name));
   }
   return define_class(mrb, name, super, mrb->object_class);
 }
@@ -311,7 +311,7 @@ mrb_define_class_under(mrb_state *mrb, struct RClass *outer, const char *name, s
 
 #if 0
   if (!super) {
-    mrb_warn(mrb, "no super class for `%S::%S', Object assumed",
+    mrb_warn(mrb, "no super class for '%S::%S', Object assumed",
              mrb_obj_value(outer), mrb_sym2str(mrb, id));
   }
 #endif
@@ -1658,7 +1658,7 @@ check_cv_name_str(mrb_state *mrb, mrb_value str)
   mrb_int len = RSTRING_LEN(str);
 
   if (len < 3 || !(s[0] == '@' && s[1] == '@')) {
-    mrb_name_error(mrb, mrb_intern_str(mrb, str), "`%S' is not allowed as a class variable name", str);
+    mrb_name_error(mrb, mrb_intern_str(mrb, str), "'%S' is not allowed as a class variable name", str);
   }
 }
 
@@ -1846,7 +1846,7 @@ remove_method(mrb_state *mrb, mrb_value mod, mrb_sym mid)
     }
   }
 
-  mrb_name_error(mrb, mid, "method `%S' not defined in %S",
+  mrb_name_error(mrb, mid, "method '%S' not defined in %S",
     mrb_sym2str(mrb, mid), mod);
 }
 

--- a/src/numeric.c
+++ b/src/numeric.c
@@ -110,8 +110,8 @@ num_div(mrb_state *mrb, mrb_value x)
  *
  *  Returns a string containing a representation of self. As well as a
  *  fixed or exponential form of the number, the call may return
- *  ``<code>NaN</code>'', ``<code>Infinity</code>'', and
- *  ``<code>-Infinity</code>''.
+ *  "<code>NaN</code>", "<code>Infinity</code>", and
+ *  "<code>-Infinity</code>".
  */
 
 static mrb_value

--- a/src/object.c
+++ b/src/object.c
@@ -428,7 +428,7 @@ mrb_check_type(mrb_state *mrb, mrb_value x, enum mrb_vtype t)
  *  Returns a string representing <i>obj</i>. The default
  *  <code>to_s</code> prints the object's class and an encoding of the
  *  object id. As a special case, the top-level object that is the
- *  initial execution context of Ruby programs returns ``main.''
+ *  initial execution context of Ruby programs returns "main."
  */
 
 MRB_API mrb_value

--- a/src/string.c
+++ b/src/string.c
@@ -1100,7 +1100,7 @@ mrb_str_downcase_bang(mrb_state *mrb, mrb_value str)
  *
  *  Returns a copy of <i>str</i> with all uppercase letters replaced with their
  *  lowercase counterparts. The operation is locale insensitive---only
- *  characters ``A'' to ``Z'' are affected.
+ *  characters 'A' to 'Z' are affected.
  *
  *     "hEllO".downcase   #=> "hello"
  */
@@ -1703,7 +1703,7 @@ mrb_str_rindex_m(mrb_state *mrb, mrb_value str)
  *
  *  If <i>pattern</i> is omitted, the value of <code>$;</code> is used.  If
  *  <code>$;</code> is <code>nil</code> (which is the default), <i>str</i> is
- *  split on whitespace as if ` ' were specified.
+ *  split on whitespace as if ' ' were specified.
  *
  *  If the <i>limit</i> parameter is omitted, trailing null fields are
  *  suppressed. If <i>limit</i> is a positive number, at most that number of
@@ -2211,7 +2211,7 @@ mrb_str_upcase_bang(mrb_state *mrb, mrb_value str)
  *
  *  Returns a copy of <i>str</i> with all lowercase letters replaced with their
  *  uppercase counterparts. The operation is locale insensitive---only
- *  characters ``a'' to ``z'' are affected.
+ *  characters 'a' to 'z' are affected.
  *
  *     "hEllO".upcase   #=> "HELLO"
  */

--- a/src/variable.c
+++ b/src/variable.c
@@ -563,7 +563,7 @@ MRB_API void
 mrb_iv_check(mrb_state *mrb, mrb_sym iv_name)
 {
   if (!mrb_iv_p(mrb, iv_name)) {
-    mrb_name_error(mrb, iv_name, "`%S' is not allowed as an instance variable name", mrb_sym2str(mrb, iv_name));
+    mrb_name_error(mrb, iv_name, "'%S' is not allowed as an instance variable name", mrb_sym2str(mrb, iv_name));
   }
 }
 


### PR DESCRIPTION
Dr Markus Kuhn published in 1999 an article [1] explaining in details
why we shouldn't use the ASCII grave accent (0x60) as a left quotation.

Backticks have been used most notably to produce nice-looking LaTeX
documents but it doesn't seem to be an issue on modern platforms and
for the oldest ones, there are workarounds as mentioned by Dr Kuhn.

[1]: https://www.cl.cam.ac.uk/~mgk25/ucs/quotes.html