### PR TITLE
add_dependency doesn't work

### DIFF
--- a/tasks/mrbgem_spec.rake
+++ b/tasks/mrbgem_spec.rake
@@ -306,7 +306,7 @@ module MRuby
           g.dependencies.each do |dep|
             unless gem_table.key? dep[:gem]
               if dep[:default]; default_gems << dep
-              elsif File.exist? "#{root}/mrbgems/#{dep[:gem]}" # check core
+              elsif File.exist? "#{MRUBY_ROOT}/mrbgems/#{dep[:gem]}" # check core
                 default_gems << { :gem => dep[:gem], :default => { :core => dep[:gem] } }
               else # fallback to mgem-list
                 default_gems << { :gem => dep[:gem], :default => { :mgem => dep[:gem] } }


### PR DESCRIPTION
```
rake aborted!
undefined local variable or method `root' for #<MRuby::Gem::List:0x002b4f6123c3b0>
```
