### PR TITLE
Add —-recursive option to automatically update submodules from git mgems

### DIFF
--- a/tasks/mruby_build_gem.rake
+++ b/tasks/mruby_build_gem.rake
@@ -91,6 +91,7 @@ module MRuby
           end
         else
           options = [params[:options]] || []
+          options << "--recursive"
           options << "--branch \"#{branch}\""
           options << "--depth 1" unless params[:checksum_hash]
           FileUtils.mkdir_p "#{gem_clone_dir}"


### PR DESCRIPTION
In some mrbgems is usual to add some dependencies libraries as dependencies, like:
https://github.com/luisbebop/mruby-polarssl
https://github.com/sadasant/mruby-qrcode

Is interesting that mrbgem, configured as git, have all submodules automatic initialized and updated:
```
MRuby::Build.new do |conf|

    # ... (snip) ...

    conf.gem :git => 'git@github.com:luisbebop/mruby-polarssl.git'
end
```