### PR TITLE
Fix typo; Replace extensional with extended

### DIFF
--- a/mrbgems/default.gembox
+++ b/mrbgems/default.gembox
@@ -14,34 +14,34 @@ MRuby::GemBox.new do |conf|
   # Use standard Struct class
   conf.gem :core => "mruby-struct"
 
-  # Use extensional Enumerable module
+  # Use extended Enumerable module
   conf.gem :core => "mruby-enum-ext"
 
-  # Use extensional String class
+  # Use extended String class
   conf.gem :core => "mruby-string-ext"
 
-  # Use extensional Numeric class
+  # Use extended Numeric class
   conf.gem :core => "mruby-numeric-ext"
 
-  # Use extensional Array class
+  # Use extended Array class
   conf.gem :core => "mruby-array-ext"
 
-  # Use extensional Hash class
+  # Use extended Hash class
   conf.gem :core => "mruby-hash-ext"
 
-  # Use extensional Range class
+  # Use extended Range class
   conf.gem :core => "mruby-range-ext"
 
-  # Use extensional Proc class
+  # Use extended Proc class
   conf.gem :core => "mruby-proc-ext"
 
-  # Use extensional Symbol class
+  # Use extended Symbol class
   conf.gem :core => "mruby-symbol-ext"
 
   # Use Random class
   conf.gem :core => "mruby-random"
 
-  # Use extensional Object class
+  # Use extended Object class
   conf.gem :core => "mruby-object-ext"
 
   # Use ObjectSpace class
@@ -68,7 +68,7 @@ MRuby::GemBox.new do |conf|
   # Generate mruby-strip command
   conf.gem :core => "mruby-bin-strip"
 
-  # Use extensional Kernel module
+  # Use extended Kernel module
   conf.gem :core => "mruby-kernel-ext"
 
   # Use mruby-compiler to build other mrbgems

--- a/mrbgems/default.gembox
+++ b/mrbgems/default.gembox
@@ -14,34 +14,34 @@ MRuby::GemBox.new do |conf|
   # Use standard Struct class
   conf.gem :core => "mruby-struct"
 
-  # Use extended Enumerable module
+  # Use Enumerable module extension
   conf.gem :core => "mruby-enum-ext"
 
-  # Use extended String class
+  # Use String class extension
   conf.gem :core => "mruby-string-ext"
 
-  # Use extended Numeric class
+  # Use Numeric class extension
   conf.gem :core => "mruby-numeric-ext"
 
-  # Use extended Array class
+  # Use Array class extension
   conf.gem :core => "mruby-array-ext"
 
-  # Use extended Hash class
+  # Use Hash class extension
   conf.gem :core => "mruby-hash-ext"
 
-  # Use extended Range class
+  # Use Range class extension
   conf.gem :core => "mruby-range-ext"
 
-  # Use extended Proc class
+  # Use Proc class extension
   conf.gem :core => "mruby-proc-ext"
 
-  # Use extended Symbol class
+  # Use Symbol class extension
   conf.gem :core => "mruby-symbol-ext"
 
   # Use Random class
   conf.gem :core => "mruby-random"
 
-  # Use extended Object class
+  # Use Object class extension
   conf.gem :core => "mruby-object-ext"
 
   # Use ObjectSpace class
@@ -56,7 +56,7 @@ MRuby::GemBox.new do |conf|
   # Use Enumerable::Lazy class (require mruby-enumerator)
   conf.gem :core => "mruby-enum-lazy"
 
-  # Use extended toplevel object (main) methods
+  # Use toplevel object (main) methods extension
   conf.gem :core => "mruby-toplevel-ext"
 
   # Generate mirb command
@@ -68,7 +68,7 @@ MRuby::GemBox.new do |conf|
   # Generate mruby-strip command
   conf.gem :core => "mruby-bin-strip"
 
-  # Use extended Kernel module
+  # Use Kernel module extension
   conf.gem :core => "mruby-kernel-ext"
 
   # Use mruby-compiler to build other mrbgems

--- a/mrbgems/mruby-array-ext/mrbgem.rake
+++ b/mrbgems/mruby-array-ext/mrbgem.rake
@@ -1,5 +1,5 @@
 MRuby::Gem::Specification.new('mruby-array-ext') do |spec|
   spec.license = 'MIT'
   spec.author  = 'mruby developers'
-  spec.summary = 'extended Array class'
+  spec.summary = 'Array class extension'
 end

--- a/mrbgems/mruby-array-ext/mrbgem.rake
+++ b/mrbgems/mruby-array-ext/mrbgem.rake
@@ -1,5 +1,5 @@
 MRuby::Gem::Specification.new('mruby-array-ext') do |spec|
   spec.license = 'MIT'
   spec.author  = 'mruby developers'
-  spec.summary = 'extensional Array class'
+  spec.summary = 'extended Array class'
 end

--- a/mrbgems/mruby-enum-ext/mrbgem.rake
+++ b/mrbgems/mruby-enum-ext/mrbgem.rake
@@ -1,5 +1,5 @@
 MRuby::Gem::Specification.new('mruby-enum-ext') do |spec|
   spec.license = 'MIT'
   spec.author  = 'mruby developers'
-  spec.summary = 'extended Enumerable module'
+  spec.summary = 'Enumerable module extension'
 end

--- a/mrbgems/mruby-enum-ext/mrbgem.rake
+++ b/mrbgems/mruby-enum-ext/mrbgem.rake
@@ -1,5 +1,5 @@
 MRuby::Gem::Specification.new('mruby-enum-ext') do |spec|
   spec.license = 'MIT'
   spec.author  = 'mruby developers'
-  spec.summary = 'extensional Enumerable module'
+  spec.summary = 'extended Enumerable module'
 end

--- a/mrbgems/mruby-hash-ext/mrbgem.rake
+++ b/mrbgems/mruby-hash-ext/mrbgem.rake
@@ -1,7 +1,7 @@
 MRuby::Gem::Specification.new('mruby-hash-ext') do |spec|
   spec.license = 'MIT'
   spec.author  = 'mruby developers'
-  spec.summary = 'extensional Hash class'
+  spec.summary = 'extended Hash class'
   spec.add_dependency 'mruby-enum-ext', :core => 'mruby-enum-ext'
   spec.add_dependency 'mruby-array-ext', :core => 'mruby-array-ext'
 end

--- a/mrbgems/mruby-hash-ext/mrbgem.rake
+++ b/mrbgems/mruby-hash-ext/mrbgem.rake
@@ -1,7 +1,7 @@
 MRuby::Gem::Specification.new('mruby-hash-ext') do |spec|
   spec.license = 'MIT'
   spec.author  = 'mruby developers'
-  spec.summary = 'extended Hash class'
+  spec.summary = 'Hash class extension'
   spec.add_dependency 'mruby-enum-ext', :core => 'mruby-enum-ext'
   spec.add_dependency 'mruby-array-ext', :core => 'mruby-array-ext'
 end

--- a/mrbgems/mruby-kernel-ext/mrbgem.rake
+++ b/mrbgems/mruby-kernel-ext/mrbgem.rake
@@ -1,5 +1,5 @@
 MRuby::Gem::Specification.new('mruby-kernel-ext') do |spec|
   spec.license = 'MIT'
   spec.author  = 'mruby developers'
-  spec.summary = 'extended Kernel module'
+  spec.summary = 'Kernel module extension'
 end

--- a/mrbgems/mruby-kernel-ext/mrbgem.rake
+++ b/mrbgems/mruby-kernel-ext/mrbgem.rake
@@ -1,5 +1,5 @@
 MRuby::Gem::Specification.new('mruby-kernel-ext') do |spec|
   spec.license = 'MIT'
   spec.author  = 'mruby developers'
-  spec.summary = 'extensional Kernel module'
+  spec.summary = 'extended Kernel module'
 end

--- a/mrbgems/mruby-numeric-ext/mrbgem.rake
+++ b/mrbgems/mruby-numeric-ext/mrbgem.rake
@@ -1,5 +1,5 @@
 MRuby::Gem::Specification.new('mruby-numeric-ext') do |spec|
   spec.license = 'MIT'
   spec.author  = 'mruby developers'
-  spec.summary = 'extended Numeric class'
+  spec.summary = 'Numeric class extension'
 end

--- a/mrbgems/mruby-numeric-ext/mrbgem.rake
+++ b/mrbgems/mruby-numeric-ext/mrbgem.rake
@@ -1,5 +1,5 @@
 MRuby::Gem::Specification.new('mruby-numeric-ext') do |spec|
   spec.license = 'MIT'
   spec.author  = 'mruby developers'
-  spec.summary = 'extensional Numeric class'
+  spec.summary = 'extended Numeric class'
 end

--- a/mrbgems/mruby-object-ext/mrbgem.rake
+++ b/mrbgems/mruby-object-ext/mrbgem.rake
@@ -1,5 +1,5 @@
 MRuby::Gem::Specification.new('mruby-object-ext') do |spec|
   spec.license = 'MIT'
   spec.author  = 'mruby developers'
-  spec.summary = 'extended Object class'
+  spec.summary = 'Object class extension'
 end

--- a/mrbgems/mruby-object-ext/mrbgem.rake
+++ b/mrbgems/mruby-object-ext/mrbgem.rake
@@ -1,5 +1,5 @@
 MRuby::Gem::Specification.new('mruby-object-ext') do |spec|
   spec.license = 'MIT'
   spec.author  = 'mruby developers'
-  spec.summary = 'extensional Object class'
+  spec.summary = 'extended Object class'
 end

--- a/mrbgems/mruby-proc-ext/mrbgem.rake
+++ b/mrbgems/mruby-proc-ext/mrbgem.rake
@@ -1,5 +1,5 @@
 MRuby::Gem::Specification.new('mruby-proc-ext') do |spec|
   spec.license = 'MIT'
   spec.author  = 'mruby developers'
-  spec.summary = 'extended Proc class'
+  spec.summary = 'Proc class extension'
 end

--- a/mrbgems/mruby-proc-ext/mrbgem.rake
+++ b/mrbgems/mruby-proc-ext/mrbgem.rake
@@ -1,5 +1,5 @@
 MRuby::Gem::Specification.new('mruby-proc-ext') do |spec|
   spec.license = 'MIT'
   spec.author  = 'mruby developers'
-  spec.summary = 'extensional Proc class'
+  spec.summary = 'extended Proc class'
 end

--- a/mrbgems/mruby-range-ext/mrbgem.rake
+++ b/mrbgems/mruby-range-ext/mrbgem.rake
@@ -1,5 +1,5 @@
 MRuby::Gem::Specification.new('mruby-range-ext') do |spec|
   spec.license = 'MIT'
   spec.author  = 'mruby developers'
-  spec.summary = 'extended Range class'
+  spec.summary = 'Range class extension'
 end

--- a/mrbgems/mruby-range-ext/mrbgem.rake
+++ b/mrbgems/mruby-range-ext/mrbgem.rake
@@ -1,5 +1,5 @@
 MRuby::Gem::Specification.new('mruby-range-ext') do |spec|
   spec.license = 'MIT'
   spec.author  = 'mruby developers'
-  spec.summary = 'extensional Range class'
+  spec.summary = 'extended Range class'
 end

--- a/mrbgems/mruby-string-ext/mrbgem.rake
+++ b/mrbgems/mruby-string-ext/mrbgem.rake
@@ -1,5 +1,5 @@
 MRuby::Gem::Specification.new('mruby-string-ext') do |spec|
   spec.license = 'MIT'
   spec.author  = 'mruby developers'
-  spec.summary = 'extensional String class'
+  spec.summary = 'extended String class'
 end

--- a/mrbgems/mruby-string-ext/mrbgem.rake
+++ b/mrbgems/mruby-string-ext/mrbgem.rake
@@ -1,5 +1,5 @@
 MRuby::Gem::Specification.new('mruby-string-ext') do |spec|
   spec.license = 'MIT'
   spec.author  = 'mruby developers'
-  spec.summary = 'extended String class'
+  spec.summary = 'String class extension'
 end

--- a/mrbgems/mruby-symbol-ext/mrbgem.rake
+++ b/mrbgems/mruby-symbol-ext/mrbgem.rake
@@ -1,5 +1,5 @@
 MRuby::Gem::Specification.new('mruby-symbol-ext') do |spec|
   spec.license = 'MIT'
   spec.author  = 'mruby developers'
-  spec.summary = 'extended Symbol class'
+  spec.summary = 'Symbol class extension'
 end

--- a/mrbgems/mruby-symbol-ext/mrbgem.rake
+++ b/mrbgems/mruby-symbol-ext/mrbgem.rake
@@ -1,5 +1,5 @@
 MRuby::Gem::Specification.new('mruby-symbol-ext') do |spec|
   spec.license = 'MIT'
   spec.author  = 'mruby developers'
-  spec.summary = 'extensional Symbol class'
+  spec.summary = 'extended Symbol class'
 end

--- a/mrbgems/mruby-toplevel-ext/mrbgem.rake
+++ b/mrbgems/mruby-toplevel-ext/mrbgem.rake
@@ -1,5 +1,5 @@
 MRuby::Gem::Specification.new('mruby-toplevel-ext') do |spec|
   spec.license = 'MIT'
   spec.author  = 'mruby developers'
-  spec.summary = 'extended toplevel object (main) methods'
+  spec.summary = 'toplevel object (main) methods extension'
 end


### PR DESCRIPTION
Adjective of `extension`(noun) is not `extensional` but `extended`

extenstional means 外延的 in Japanese.

refer:
http://ejje.weblio.jp/content/extensional