### PR TITLE
Avoid a narrowing cast in flo_round under MRB_INT64.

### DIFF
--- a/src/numeric.c
+++ b/src/numeric.c
@@ -436,7 +436,7 @@ flo_round(mrb_state *mrb, mrb_value num)
 {
   double number, f;
   mrb_int ndigits = 0;
-  int i;
+  mrb_int i;
 
   mrb_get_args(mrb, "|i", &ndigits);
   number = mrb_float(num);
@@ -451,7 +451,7 @@ flo_round(mrb_state *mrb, mrb_value num)
   }
 
   f = 1.0;
-  i = abs(ndigits);
+  i = ndigits >= 0 ? ndigits : -ndigits;
   while  (--i >= 0)
     f = f*10.0;
 


### PR DESCRIPTION
`flo_round` is producing the following warning under both Darwin and Linux x86_64

```
mruby/src/numeric.c:454:7: warning: absolute value function 'abs' given an argument of type 'mrb_int' (aka 'long long') but has parameter of type 'int' which may
      cause truncation of value [-Wabsolute-value]
  i = abs(ndigits);
```

An alternative would be to not rely on `MRB_INT64` and have a check such as
```c
if (sizeof(num) == sizeof(long long)) {
  return llabs(num);
} else {
  return abs(num);
}
```