### PR TITLE
Fix incorrect memory allocation of mrdb_state_new.

### DIFF
--- a/mrbgems/mruby-bin-debugger/tools/mrdb/mrdb.c
+++ b/mrbgems/mruby-bin-debugger/tools/mrdb/mrdb.c
@@ -222,9 +222,9 @@ mrb_debug_context_free(mrb_state *mrb)
 static mrdb_state*
 mrdb_state_new(mrb_state *mrb)
 {
-  mrdb_state *mrdb = mrb_malloc(mrb, sizeof(mrb_state));
+  mrdb_state *mrdb = mrb_malloc(mrb, sizeof(mrdb_state));
 
-  memset(mrdb, 0, sizeof(mrb_state));
+  memset(mrdb, 0, sizeof(mrdb_state));
 
   mrdb->dbg = mrb_debug_context_get(mrb);
   mrdb->command = mrb_malloc(mrb, MAX_COMMAND_LINE+1);


### PR DESCRIPTION
As detected in a Coverity scan. https://scan8.coverity.com/reports.htm#v26153/p11375/fileInstanceId=6844472&defectInstanceId=2516000&mergedDefectId=75866