### PR TITLE
Coverity: fix dangling pointer

### DIFF
--- a/src/string.c
+++ b/src/string.c
@@ -2057,6 +2057,7 @@ MRB_API double
 mrb_cstr_to_dbl(mrb_state *mrb, const char * p, mrb_bool badcheck)
 {
   char *end;
+  char buf[DBL_DIG * 4 + 10];
   double d;
 
   enum {max_width = 20};
@@ -2077,7 +2078,6 @@ bad:
     return d;
   }
   if (*end) {
-    char buf[DBL_DIG * 4 + 10];
     char *n = buf;
     char *e = buf + sizeof(buf) - 1;
     char prev = 0;


### PR DESCRIPTION
CID 75872 (#3-2 of 3): Pointer to local outside scope (RETURN_LOCAL)
38. use_invalid: Using p, which points to an out-of-scope variable buf.

It could be fixed in a different way but that seems to be the simplest one.