### PR TITLE
implement llround. some platform (ex: mingw32) doesn't have llround.

### DIFF
--- a/mrbgems/mruby-time/src/time.c
+++ b/mrbgems/mruby-time/src/time.c
@@ -11,6 +11,10 @@
 #include "mruby/class.h"
 #include "mruby/data.h"
 
+#if !defined(__MINGW64__) && defined(_WIN32)
+# define llround(x) round(x)
+#endif
+
 #if defined(__MINGW64__) || defined(__MINGW32__)
 # include <sys/time.h>
 #endif


### PR DESCRIPTION
if you want, I'll make block this part with `#ifdef _WIN32`.