### PR TITLE
Module#prepend

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -206,6 +206,7 @@ MRB_API struct RClass *mrb_define_class(mrb_state *, const char*, struct RClass*
 MRB_API struct RClass *mrb_define_module(mrb_state *, const char*);
 MRB_API mrb_value mrb_singleton_class(mrb_state*, mrb_value);
 MRB_API void mrb_include_module(mrb_state*, struct RClass*, struct RClass*);
+MRB_API void mrb_prepend_module(mrb_state*, struct RClass*, struct RClass*);
 
 MRB_API void mrb_define_method(mrb_state*, struct RClass*, const char*, mrb_func_t, mrb_aspec);
 MRB_API void mrb_define_class_method(mrb_state *, struct RClass *, const char *, mrb_func_t, mrb_aspec);

--- a/include/mruby/class.h
+++ b/include/mruby/class.h
@@ -16,6 +16,7 @@ struct RClass {
   struct iv_tbl *iv;
   struct kh_mt *mt;
   struct RClass *super;
+  struct RClass *origin;
 };
 
 #define mrb_class_ptr(v)    ((struct RClass*)(mrb_ptr(v)))

--- a/include/mruby/class.h
+++ b/include/mruby/class.h
@@ -49,8 +49,11 @@ mrb_class(mrb_state *mrb, mrb_value v)
   }
 }
 
-#define MRB_SET_INSTANCE_TT(c, tt) c->flags = ((c->flags & ~0xff) | (char)tt)
-#define MRB_INSTANCE_TT(c) (enum mrb_vtype)(c->flags & 0xff)
+// TODO: figure out where to put user flags
+#define MRB_FLAG_IS_ORIGIN (1 << 20)
+#define MRB_FLAG_IS_INSTANCE (0xFF)
+#define MRB_SET_INSTANCE_TT(c, tt) c->flags = ((c->flags & ~MRB_FLAG_IS_INSTANCE) | (char)tt)
+#define MRB_INSTANCE_TT(c) (enum mrb_vtype)(c->flags & MRB_FLAG_IS_INSTANCE)
 
 MRB_API struct RClass* mrb_define_class_id(mrb_state*, mrb_sym, struct RClass*);
 MRB_API struct RClass* mrb_define_module_id(mrb_state*, mrb_sym);

--- a/include/mruby/class.h
+++ b/include/mruby/class.h
@@ -51,9 +51,9 @@ mrb_class(mrb_state *mrb, mrb_value v)
 
 // TODO: figure out where to put user flags
 #define MRB_FLAG_IS_ORIGIN (1 << 20)
-#define MRB_FLAG_IS_INSTANCE (0xFF)
-#define MRB_SET_INSTANCE_TT(c, tt) c->flags = ((c->flags & ~MRB_FLAG_IS_INSTANCE) | (char)tt)
-#define MRB_INSTANCE_TT(c) (enum mrb_vtype)(c->flags & MRB_FLAG_IS_INSTANCE)
+#define MRB_INSTANCE_TT_MASK (0xFF)
+#define MRB_SET_INSTANCE_TT(c, tt) c->flags = ((c->flags & ~MRB_INSTANCE_TT_MASK) | (char)tt)
+#define MRB_INSTANCE_TT(c) (enum mrb_vtype)(c->flags & MRB_INSTANCE_TT_MASK)
 
 MRB_API struct RClass* mrb_define_class_id(mrb_state*, mrb_sym, struct RClass*);
 MRB_API struct RClass* mrb_define_module_id(mrb_state*, mrb_sym);

--- a/include/mruby/object.h
+++ b/include/mruby/object.h
@@ -14,6 +14,8 @@
   struct RClass *c;\
   struct RBasic *gcnext
 
+#define MRB_FLAG_TEST(obj, flag) ((obj)->flags & flag)
+
 /* white: 011, black: 100, gray: 000 */
 #define MRB_GC_GRAY 0
 #define MRB_GC_WHITE_A 1

--- a/src/class.c
+++ b/src/class.c
@@ -1945,6 +1945,7 @@ remove_method(mrb_state *mrb, mrb_value mod, mrb_sym mid)
     k = kh_get(mt, mrb, h, mid);
     if (k != kh_end(h)) {
       kh_del(mt, mrb, h, k);
+      mrb_funcall(mrb, mod, "method_removed", 1, mrb_symbol_value(mid));
       return;
     }
   }
@@ -2197,6 +2198,7 @@ mrb_init_class(mrb_state *mrb)
   mrb_define_method(mrb, mod, "public",                  mrb_mod_dummy_visibility, MRB_ARGS_ANY());  /* 15.2.2.4.38 */
   mrb_define_method(mrb, mod, "remove_class_variable",   mrb_mod_remove_cvar,      MRB_ARGS_REQ(1)); /* 15.2.2.4.39 */
   mrb_define_method(mrb, mod, "remove_method",           mrb_mod_remove_method,    MRB_ARGS_ANY());  /* 15.2.2.4.41 */
+  mrb_define_method(mrb, mod, "method_removed",          mrb_bob_init,             MRB_ARGS_REQ(1));  /* 15.2.2.4.41 */
   mrb_define_method(mrb, mod, "attr_reader",             mrb_mod_attr_reader,      MRB_ARGS_ANY());  /* 15.2.2.4.13 */
   mrb_define_method(mrb, mod, "attr_writer",             mrb_mod_attr_writer,      MRB_ARGS_ANY());  /* 15.2.2.4.14 */
   mrb_define_method(mrb, mod, "to_s",                    mrb_mod_to_s,             MRB_ARGS_NONE());

--- a/src/class.c
+++ b/src/class.c
@@ -76,6 +76,7 @@ prepare_singleton_class(mrb_state *mrb, struct RBasic *o)
 
   if (o->c->tt == MRB_TT_SCLASS) return;
   sc = (struct RClass*)mrb_obj_alloc(mrb, MRB_TT_SCLASS, mrb->class_class);
+  sc->origin = sc;
   sc->mt = 0;
   sc->iv = 0;
   if (o->tt == MRB_TT_CLASS) {
@@ -799,6 +800,7 @@ include_module_at(mrb_state *mrb, struct RClass *c, struct RClass *ins_pos, stru
     else {
       ic->c = m;
     }
+    ic->origin = ic;
     ic->mt = m->mt;
     ic->iv = m->iv;
     ic->super = ins_pos->super;
@@ -825,6 +827,7 @@ mrb_prepend_module(mrb_state *mrb, struct RClass *c, struct RClass *m)
   origin = c->origin;
   if (origin == c) {
     origin = (struct RClass*)mrb_obj_alloc(mrb, MRB_TT_ICLASS, c);
+    origin->origin = origin;
     //OBJ_WB_UNPROTECT(origin); /* TODO: conservative shading. Need more survey. */
     origin->super = c->super;
     c->super = origin;
@@ -1547,6 +1550,7 @@ MRB_API struct RClass*
 mrb_module_new(mrb_state *mrb)
 {
   struct RClass *m = (struct RClass*)mrb_obj_alloc(mrb, MRB_TT_MODULE, mrb->module_class);
+  m->origin = m;
   m->mt = kh_init(mt, mrb);
 
   return m;

--- a/src/class.c
+++ b/src/class.c
@@ -2198,7 +2198,7 @@ mrb_init_class(mrb_state *mrb)
   mrb_define_method(mrb, mod, "public",                  mrb_mod_dummy_visibility, MRB_ARGS_ANY());  /* 15.2.2.4.38 */
   mrb_define_method(mrb, mod, "remove_class_variable",   mrb_mod_remove_cvar,      MRB_ARGS_REQ(1)); /* 15.2.2.4.39 */
   mrb_define_method(mrb, mod, "remove_method",           mrb_mod_remove_method,    MRB_ARGS_ANY());  /* 15.2.2.4.41 */
-  mrb_define_method(mrb, mod, "method_removed",          mrb_bob_init,             MRB_ARGS_REQ(1));  /* 15.2.2.4.41 */
+  mrb_define_method(mrb, mod, "method_removed",          mrb_bob_init,             MRB_ARGS_REQ(1));
   mrb_define_method(mrb, mod, "attr_reader",             mrb_mod_attr_reader,      MRB_ARGS_ANY());  /* 15.2.2.4.13 */
   mrb_define_method(mrb, mod, "attr_writer",             mrb_mod_attr_writer,      MRB_ARGS_ANY());  /* 15.2.2.4.14 */
   mrb_define_method(mrb, mod, "to_s",                    mrb_mod_to_s,             MRB_ARGS_NONE());

--- a/src/class.c
+++ b/src/class.c
@@ -1000,10 +1000,11 @@ mrb_mod_included_modules(mrb_state *mrb, mrb_value self)
 {
   mrb_value result;
   struct RClass *c = mrb_class_ptr(self);
+  struct RClass *origin = c->origin;
 
   result = mrb_ary_new(mrb);
   while (c) {
-    if (c->tt == MRB_TT_ICLASS) {
+    if (c != origin && c->tt == MRB_TT_ICLASS) {
       if (c->c->tt == MRB_TT_MODULE) {
         mrb_ary_push(mrb, result, mrb_obj_value(c->c));
       }

--- a/src/class.c
+++ b/src/class.c
@@ -834,7 +834,10 @@ include_module_at(mrb_state *mrb, struct RClass *klass, struct RClass *c, struct
 MRB_API void
 mrb_include_module(mrb_state *mrb, struct RClass *c, struct RClass *m)
 {
-  include_module_at(mrb, c, c->origin, m, 1);
+  int changed = include_module_at(mrb, c, c->origin, m, 1);
+  if (changed < 0) {
+    mrb_raise(mrb, E_ARGUMENT_ERROR, "cyclic include detected");
+  }
 }
 
 MRB_API void

--- a/src/class.c
+++ b/src/class.c
@@ -327,12 +327,6 @@ mrb_define_method_raw(mrb_state *mrb, struct RClass *c, mrb_sym mid, struct RPro
 {
   khash_t(mt) *h;
   khiter_t k;
-
-  if (!c->origin) {
-    printf("Warning, class %s does not have valid origin\n", mrb_class_name(mrb, c));
-    mrb_raisef(mrb, E_RUNTIME_ERROR, "Invalid origin");
-    c->origin = c;
-  }
   h = c->origin->mt;
 
   if (!h) h = c->mt = kh_init(mt, mrb);

--- a/src/class.c
+++ b/src/class.c
@@ -797,7 +797,7 @@ include_class_new(mrb_state *mrb, struct RClass *m, struct RClass *super)
   return ic;
 }
 
-MRB_API int
+static int
 include_module_at(mrb_state *mrb, struct RClass *c, struct RClass *ins_pos, struct RClass *m, int search_super)
 {
   struct RClass *p, *ic;

--- a/src/class.c
+++ b/src/class.c
@@ -856,6 +856,7 @@ mrb_prepend_module(mrb_state *mrb, struct RClass *c, struct RClass *m)
   origin = c->origin;
   if (origin == c) {
     origin = (struct RClass*)mrb_obj_alloc(mrb, MRB_TT_ICLASS, c);
+    origin->flags |= MRB_FLAG_IS_ORIGIN;
     origin->origin = origin;
     origin->super = c->super;
     c->super = origin;

--- a/src/class.c
+++ b/src/class.c
@@ -770,11 +770,8 @@ boot_defclass(mrb_state *mrb, struct RClass *super)
 }
 
 MRB_API inline void
-include_module_at(mrb_state *mrb, struct RClass *c, struct RClass *m, int search_super)
+include_module_at(mrb_state *mrb, struct RClass *c, struct RClass *ins_pos, struct RClass *m, int search_super)
 {
-  struct RClass *ins_pos;
-
-  ins_pos = c;
   while (m) {
     struct RClass *p = c, *ic;
     int superclass_seen = 0;
@@ -816,7 +813,7 @@ include_module_at(mrb_state *mrb, struct RClass *c, struct RClass *m, int search
 MRB_API void
 mrb_include_module(mrb_state *mrb, struct RClass *c, struct RClass *m)
 {
-  include_module_at(mrb, c, m, FALSE);
+  include_module_at(mrb, c, c->origin, m, FALSE);
 }
 
 MRB_API void
@@ -835,7 +832,7 @@ mrb_prepend_module(mrb_state *mrb, struct RClass *c, struct RClass *m)
     origin->mt = c->mt;
     c->mt = kh_init(mt, mrb);
   }
-  include_module_at(mrb, c, m, FALSE); // changed =
+  include_module_at(mrb, c, c, m, FALSE); // changed =
   if (changed) {
     //rb_vm_check_redefinition_by_prepend(klass);
   }

--- a/src/class.c
+++ b/src/class.c
@@ -776,11 +776,25 @@ include_module_at(mrb_state *mrb, struct RClass *c, struct RClass *ins_pos, stru
   while (m) {
     struct RClass *p = c, *ic;
     int superclass_seen = 0;
-
+ 
+    //if (m->origin != m)
+    //  goto skip;
     if (c->mt && c->mt == m->mt) {
       mrb_raise(mrb, E_ARGUMENT_ERROR, "cyclic include detected");
     }
     while (p) {
+      /*if (p->tt == MRB_TT_ICLASS) {
+        if (!superclass_seen) {
+          ins_pos = p; // move insert point
+        }
+        goto skip;
+      } else if (p->tt == MRB_TT_CLASS) {
+        if (p->mt == m->mt) {
+          if (!search_super) break;
+          superclass_seen = 1;
+        }
+      }*/
+      //
       if (c != p && p->tt == MRB_TT_CLASS) {
         if (!search_super) break;
         superclass_seen = 1;

--- a/src/class.c
+++ b/src/class.c
@@ -1004,7 +1004,9 @@ mrb_mod_included_modules(mrb_state *mrb, mrb_value self)
   result = mrb_ary_new(mrb);
   while (c) {
     if (c->tt == MRB_TT_ICLASS) {
-      mrb_ary_push(mrb, result, mrb_obj_value(c->c));
+      if (c->c->tt == MRB_TT_MODULE) {
+        mrb_ary_push(mrb, result, mrb_obj_value(c->c));
+      }
     }
     c = c->super;
   }

--- a/src/class.c
+++ b/src/class.c
@@ -798,26 +798,26 @@ include_class_new(mrb_state *mrb, struct RClass *m, struct RClass *super)
 }
 
 MRB_API int
-include_module_at(mrb_state *mrb, struct RClass *klass, struct RClass *c, struct RClass *module, int search_super)
+include_module_at(mrb_state *mrb, struct RClass *c, struct RClass *ins_pos, struct RClass *m, int search_super)
 {
-  struct RClass *p, *iclass;
-  void *klass_mt = klass->origin->mt;
+  struct RClass *p, *ic;
+  void *klass_mt = c->origin->mt;
 
-  while (module) {
+  while (m) {
     int superclass_seen = 0;
 
-    if (module->origin != module)
+    if (m->origin != m)
       goto skip;
 
-    if (klass_mt && klass_mt == module->mt)
+    if (klass_mt && klass_mt == m->mt)
       return -1;
 
-    p = klass->super;
+    p = c->super;
     while(p) {
       if (p->tt == MRB_TT_ICLASS) {
-        if (p->mt == module->mt) {
+        if (p->mt == m->mt) {
           if (!superclass_seen) {
-            c = p; // move insert point
+            ins_pos = p; // move insert point
           }
           goto skip;
         }
@@ -828,12 +828,12 @@ include_module_at(mrb_state *mrb, struct RClass *klass, struct RClass *c, struct
       p = p->super;
     }
 
-    iclass = include_class_new(mrb, module, c->super);
-    c->super = iclass;
-    mrb_field_write_barrier(mrb, (struct RBasic*)c, (struct RBasic*)c->super);
-    c = iclass;
+    ic = include_class_new(mrb, m, ins_pos->super);
+    ins_pos->super = ic;
+    mrb_field_write_barrier(mrb, (struct RBasic*)ins_pos, (struct RBasic*)ins_pos->super);
+    ins_pos = ic;
   skip:
-    module = module->super;
+    m = m->super;
   }
   return 0;
 }

--- a/src/class.c
+++ b/src/class.c
@@ -1020,8 +1020,6 @@ static mrb_value
 mrb_mod_initialize(mrb_state *mrb, mrb_value mod)
 {
   mrb_value b;
-
-  /* hack, fix missing module->origin */
   struct RClass *m = mrb_class_ptr(mod);
   boot_initmod(mrb, m); // bootstrap a newly initialized module
   mrb_get_args(mrb, "|&", &b);

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -248,6 +248,11 @@ mrb_singleton_class_clone(mrb_state *mrb, mrb_value obj)
       clone->c = mrb_singleton_class_clone(mrb, mrb_obj_value(klass));
     }
 
+    if (klass->origin != klass)
+      clone->origin = klass->origin;
+    else
+      clone->origin = clone;
+
     clone->super = klass->super;
     if (klass->iv) {
       mrb_iv_copy(mrb, mrb_obj_value(clone), mrb_obj_value(klass));
@@ -269,6 +274,13 @@ copy_class(mrb_state *mrb, mrb_value dst, mrb_value src)
 {
   struct RClass *dc = mrb_class_ptr(dst);
   struct RClass *sc = mrb_class_ptr(src);
+  /* if the origin is not the same as the class, then the origin and
+     the current class need to be copied */
+  if (sc->origin != sc) {
+    dc->origin = mrb_class_ptr(mrb_obj_dup(mrb, mrb_obj_value(sc->origin)));
+  } else {
+    dc->origin = dc;
+  }
   dc->mt = kh_copy(mt, mrb, sc->mt);
   dc->super = sc->super;
 }

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -653,13 +653,19 @@ mrb_class_instance_method_list(mrb_state *mrb, mrb_bool recur, struct RClass* kl
 {
   khint_t i;
   mrb_value ary;
+  mrb_bool prepended;
   struct RClass* oldklass;
   khash_t(st)* set = kh_init(st, mrb);
+
+  if (!recur && klass->origin != klass) {
+    klass = klass->origin;
+    prepended = 1;
+  }
 
   oldklass = 0;
   while (klass && (klass != oldklass)) {
     method_entry_loop(mrb, klass, set);
-    if ((klass->tt == MRB_TT_ICLASS) ||
+    if ((klass->tt == MRB_TT_ICLASS && !prepended) ||
         (klass->tt == MRB_TT_SCLASS)) {
     }
     else {

--- a/src/object.c
+++ b/src/object.c
@@ -487,6 +487,7 @@ mrb_obj_is_kind_of(mrb_state *mrb, mrb_value obj, struct RClass *c)
       mrb_raise(mrb, E_TYPE_ERROR, "class or module required");
   }
 
+  c = c->origin;
   while (cl) {
     if (cl == c || cl->mt == c->mt)
       return TRUE;

--- a/test/t/module.rb
+++ b/test/t/module.rb
@@ -491,18 +491,18 @@ assert('Module#prepend') do
     def m1; [:M4, super, :M4] end
   end
 
-  class C0
+  class P0
     include M0
     prepend M1
     def m1; [:C0, super, :C0] end
   end
-  class C1 < C0
+  class P1 < P0
     prepend M2, M3
     include M4
     def m1; [:C1, super, :C1] end
   end
 
-  obj = C1.new
+  obj = P1.new
   expected = [:M2,[:M3,[:C1,[:M4,[:M1,[:C0,[:M0],:C0],:M1],:M4],:C1],:M3],:M2]
   assert_equal(expected, obj.m1)
 end

--- a/test/t/module.rb
+++ b/test/t/module.rb
@@ -495,7 +495,7 @@ end
 # Not ISO specified
 
 # @!group prepend
-  assert('test_prepend') do
+  assert('Module#prepend') do
     module M0
       def m1; [:M0] end
     end
@@ -530,13 +530,13 @@ end
 
   # mruby shouldn't be affected by this since there is
   # no visibility control (yet)
-  assert('test_public_prepend') do
+  assert('Module#prepend public') do
     assert_nothing_raised('ruby/ruby #8846') do
       Class.new.prepend(Module.new)
     end
   end
 
-  assert('test_prepend_inheritance') do
+  assert('Module#prepend inheritance') do
     bug6654 = '[ruby-core:45914]'
     a = labeled_module('a')
     b = labeled_module('b') { include a }
@@ -562,18 +562,18 @@ end
     assert_kind_of(b, c.new, bug8357)
   end
 
-  assert('test_prepend_instance_methods') do
+  assert('Moduler#prepend + #instance_methods') do
     bug6655 = '[ruby-core:45915]'
     assert_equal(Object.instance_methods, Class.new {prepend Module.new}.instance_methods, bug6655)
   end
 
-  assert 'test_prepend_singleton_methods' do
+  assert 'Module#prepend + #singleton_methods' do
     o = Object.new
     o.singleton_class.class_eval {prepend Module.new}
     assert_equal([], o.singleton_methods)
   end
 
-  assert 'test_prepend_remove_method' do
+  assert 'Module#prepend + #remove_method' do
     c = Class.new do
       prepend Module.new { def foo; end }
     end
@@ -597,7 +597,7 @@ end
     assert_equal(:foo, removed)
   end
 
-  assert 'test_prepend_class_ancestors' do
+  assert 'Module#prepend + Class#ancestors' do
     bug6658 = '[ruby-core:45919]'
     m = labeled_module("m")
     c = labeled_class("c") {prepend m}
@@ -609,8 +609,7 @@ end
     assert_equal([c2, m, c, Object], anc[0..anc.index(Object)], bug6662)
   end
 
-  # this assertion causes the mrbtest to segfault
-  assert 'test_prepend_module_ancestors' do
+  assert 'Module#prepend + Module#ancestors' do
     bug6659 = '[ruby-dev:45861]'
     m0 = labeled_module("m0") { def x; [:m0, *super] end }
     m1 = labeled_module("m1") { def x; [:m1, *super] end; prepend m0 }
@@ -638,13 +637,13 @@ end
     assert_equal([m3, m0, m1], m3.ancestors)
   end
 
-  assert 'test_prepend_instance_methods_false' do
+  assert 'Module#prepend #instance_methods(false)' do
     bug6660 = '[ruby-dev:45863]'
     assert_equal([:m1], Class.new{ prepend Module.new; def m1; end }.instance_methods(false), bug6660)
     assert_equal([:m1], Class.new(Class.new{def m2;end}){ prepend Module.new; def m1; end }.instance_methods(false), bug6660)
   end
 
-  assert 'test_cyclic_prepend' do
+  assert 'cyclic Module#prepend' do
     bug7841 = '[ruby-core:52205] [Bug #7841]'
     m1 = Module.new
     m2 = Module.new
@@ -670,7 +669,7 @@ end
   #end
 
   # mruby has no visibility control
-  assert 'test_prepend_visibility' do
+  assert 'Module#prepend visibility' do
     bug8005 = '[ruby-core:53106] [Bug #8005]'
     c = Class.new do
       prepend Module.new {}
@@ -683,7 +682,7 @@ end
   end
 
   # mruby has no visibility control
-  assert 'test_prepend_visibility_inherited' do
+  assert 'Module#prepend inherited visibility' do
     bug8238 = '[ruby-core:54105] [Bug #8238]'
     module Test4PrependVisibilityInherited
       class A
@@ -698,7 +697,7 @@ end
     assert_equal(Test4PrependVisibilityInherited::A, Test4PrependVisibilityInherited::B.new.foo, "#{bug8238}")
   end
 
-  assert 'test_prepend_included_modules' do
+  assert 'Module#prepend + #included_modules' do
     bug8025 = '[ruby-core:53158] [Bug #8025]'
     mixin = labeled_module("mixin")
     c = labeled_module("c") {prepend mixin}
@@ -713,7 +712,8 @@ end
     assert_include(im, mixin, bug8025)
   end
 
-  assert 'test_prepend_super_in_alias' do
+  assert 'Module#prepend super in alias' do
+    skip "super does not currently work in aliased methods"
     bug7842 = '[Bug #7842]'
 
     p = labeled_module("P") do
@@ -740,20 +740,20 @@ end
     end
   end
 
-  assert 'test_prepend_each_classes' do
+  assert 'Module#prepend each class' do
     m = labeled_module("M")
     c1 = labeled_class("C1") {prepend m}
     c2 = labeled_class("C2", c1) {prepend m}
-    assert_equal([m, c2, m, c1], c2.ancestors[0, 4], "should be able to prepend each classes")
+    assert_equal([m, c2, m, c1], c2.ancestors[0, 4], "should be able to prepend each class")
   end
 
-  assert 'test_prepend_no_duplication' do
+  assert 'Module#prepend no duplication' do
     m = labeled_module("M")
     c = labeled_class("C") {prepend m; prepend m}
     assert_equal([m, c], c.ancestors[0, 2], "should never duplicate")
   end
 
-  assert 'test_prepend_in_superclass' do
+  assert 'Module#prepend in superclass' do
     m = labeled_module("M")
     c1 = labeled_class("C1")
     c2 = labeled_class("C2", c1) {prepend m}
@@ -762,7 +762,7 @@ end
   end
 
   # requires #assert_seperately
-  #assert 'test_prepend_call_super' do
+  #assert 'Module#prepend call super' do
   #  assert_separately([], <<-'end;') #do
   #    bug10847 = '[ruby-core:68093] [Bug #10847]'
   #    module M; end

--- a/test/t/module.rb
+++ b/test/t/module.rb
@@ -540,10 +540,6 @@ assert('Module#prepend') do
     end
 
     bug8357 = '[ruby-core:54742] [Bug #8357]'
-    t_print c.new.kind_of?(b)
-    t_print "\n"
-    t_print [b, b.ancestors, c, c.ancestors].inspect
-    t_print "\n"
     assert_kind_of(b, c.new, bug8357)
   end
 end

--- a/test/t/module.rb
+++ b/test/t/module.rb
@@ -474,6 +474,39 @@ end
 
 # Not ISO specified
 
+assert('Module#prepend') do
+  module M0
+    def m1; [:M0] end
+  end
+  module M1
+    def m1; [:M1, super, :M1] end
+  end
+  module M2
+    def m1; [:M2, super, :M2] end
+  end
+  M3 = Module.new do
+    def m1; [:M3, super, :M3] end
+  end
+  module M4
+    def m1; [:M4, super, :M4] end
+  end
+
+  class C0
+    include M0
+    prepend M1
+    def m1; [:C0, super, :C0] end
+  end
+  class C1 < C0
+    prepend M2, M3
+    include M4
+    def m1; [:C1, super, :C1] end
+  end
+
+  obj = C1.new
+  expected = [:M2,[:M3,[:C1,[:M4,[:M1,[:C0,[:M0],:C0],:M1],:M4],:C1],:M3],:M2]
+  assert_equal(expected, obj.m1)
+end
+
 assert('Module#to_s') do
   module Test4to_sModules
   end

--- a/test/t/module.rb
+++ b/test/t/module.rb
@@ -670,32 +670,34 @@ assert('Module#prepend') do
   #  assert_equal(0, 1 / 2)
   #end
 
-  #assert 'test_prepend_visibility' do
-  #  bug8005 = '[ruby-core:53106] [Bug #8005]'
-  #  c = Class.new do
-  #    prepend Module.new {}
-  #    def foo() end
-  #    protected :foo
-  #  end
-  #  a = c.new
-  #  assert_respond_to a, [:foo, true], bug8005
-  #  assert_nothing_raised(NoMethodError, bug8005) {a.send :foo}
-  #end
+  # mruby has no visibility control
+  assert 'test_prepend_visibility' do
+    bug8005 = '[ruby-core:53106] [Bug #8005]'
+    c = Class.new do
+      prepend Module.new {}
+      def foo() end
+      protected :foo
+    end
+    a = c.new
+    assert_true a.respond_to?(:foo), bug8005
+    assert_nothing_raised(NoMethodError, bug8005) {a.send :foo}
+  end
 
-  #assert 'test_prepend_visibility_inherited' do
-  #  bug8238 = '[ruby-core:54105] [Bug #8238]'
-  #  assert_separately [], <<-"end;", timeout: 20
-  #    class A
-  #      def foo() A; end
-  #      private :foo
-  #    end
-  #    class B < A
-  #      public :foo
-  #      prepend Module.new
-  #    end
-  #    assert_equal(A, B.new.foo, "#{bug8238}")
-  #  end;
-  #end
+  # mruby has no visibility control
+  assert 'test_prepend_visibility_inherited' do
+    bug8238 = '[ruby-core:54105] [Bug #8238]'
+    module Test4PrependVisibilityInherited
+      class A
+        def foo() A; end
+        private :foo
+      end
+      class B < A
+        public :foo
+        prepend Module.new
+      end
+    end
+    assert_equal(Test4PrependVisibilityInherited::A, Test4PrependVisibilityInherited::B.new.foo, "#{bug8238}")
+  end
 
   assert 'test_prepend_included_modules' do
     bug8025 = '[ruby-core:53158] [Bug #8025]'

--- a/test/t/module.rb
+++ b/test/t/module.rb
@@ -611,33 +611,33 @@ assert('Module#prepend') do
   end
 
   # this assertion causes the mrbtest to segfault
-  #assert 'test_prepend_module_ancestors' do
-  #  bug6659 = '[ruby-dev:45861]'
-  #  m0 = labeled_module("m0") { def x; [:m0, *super] end }
-  #  m1 = labeled_module("m1") { def x; [:m1, *super] end; prepend m0 }
-  #  m2 = labeled_module("m2") { def x; [:m2, *super] end; prepend m1 }
-  #  c0 = labeled_class("c0") { def x; [:c0] end }
-  #  c1 = labeled_class("c1") { def x; [:c1] end; prepend m2 }
-  #  c2 = labeled_class("c2", c0) { def x; [:c2, *super] end; include m2 }
-  #  #
-  #  assert_equal([m0, m1], m1.ancestors, bug6659)
-  #  #
-  #  bug6662 = '[ruby-dev:45868]'
-  #  assert_equal([m0, m1, m2], m2.ancestors, bug6662)
-  #  assert_equal([m0, m1, m2, c1], c1.ancestors[0, 4], bug6662)
-  #  assert_equal([:m0, :m1, :m2, :c1], c1.new.x)
-  #  assert_equal([c2, m0, m1, m2, c0], c2.ancestors[0, 5], bug6662)
-  #  assert_equal([:c2, :m0, :m1, :m2, :c0], c2.new.x)
-  #  #
-  #  m3 = labeled_module("m3") { include m1; prepend m1 }
-  #  assert_equal([m3, m0, m1], m3.ancestors)
-  #  m3 = labeled_module("m3") { prepend m1; include m1 }
-  #  assert_equal([m0, m1, m3], m3.ancestors)
-  #  m3 = labeled_module("m3") { prepend m1; prepend m1 }
-  #  assert_equal([m0, m1, m3], m3.ancestors)
-  #  m3 = labeled_module("m3") { include m1; include m1 }
-  #  assert_equal([m3, m0, m1], m3.ancestors)
-  #end
+  assert 'test_prepend_module_ancestors' do
+    bug6659 = '[ruby-dev:45861]'
+    m0 = labeled_module("m0") { def x; [:m0, *super] end }
+    m1 = labeled_module("m1") { def x; [:m1, *super] end; prepend m0 }
+    m2 = labeled_module("m2") { def x; [:m2, *super] end; prepend m1 }
+    c0 = labeled_class("c0") { def x; [:c0] end }
+    c1 = labeled_class("c1") { def x; [:c1] end; prepend m2 }
+    c2 = labeled_class("c2", c0) { def x; [:c2, *super] end; include m2 }
+    #
+    assert_equal([m0, m1], m1.ancestors, bug6659)
+    #
+    bug6662 = '[ruby-dev:45868]'
+    assert_equal([m0, m1, m2], m2.ancestors, bug6662)
+    assert_equal([m0, m1, m2, c1], c1.ancestors[0, 4], bug6662)
+    assert_equal([:m0, :m1, :m2, :c1], c1.new.x)
+    assert_equal([c2, m0, m1, m2, c0], c2.ancestors[0, 5], bug6662)
+    assert_equal([:c2, :m0, :m1, :m2, :c0], c2.new.x)
+    #
+    m3 = labeled_module("m3") { include m1; prepend m1 }
+    assert_equal([m3, m0, m1], m3.ancestors)
+    m3 = labeled_module("m3") { prepend m1; include m1 }
+    assert_equal([m0, m1, m3], m3.ancestors)
+    m3 = labeled_module("m3") { prepend m1; prepend m1 }
+    assert_equal([m0, m1, m3], m3.ancestors)
+    m3 = labeled_module("m3") { include m1; include m1 }
+    assert_equal([m3, m0, m1], m3.ancestors)
+  end
 
   assert 'test_prepend_instance_methods_false' do
     bug6660 = '[ruby-dev:45863]'

--- a/test/t/module.rb
+++ b/test/t/module.rb
@@ -495,7 +495,6 @@ end
 # Not ISO specified
 
 # @!group prepend
-assert('Module#prepend') do
   assert('test_prepend') do
     module M0
       def m1; [:M0] end
@@ -773,7 +772,6 @@ assert('Module#prepend') do
   #    end
   #  end;
   #end
-end
 # @!endgroup prepend
 
 assert('Module#to_s') do

--- a/test/t/module.rb
+++ b/test/t/module.rb
@@ -720,17 +720,25 @@ assert('Module#prepend') do
     p = labeled_module("P") do
       def m; "P"+super; end
     end
+
     a = labeled_class("A") do
       def m; "A"; end
     end
+
     b = labeled_class("B", a) do
       def m; "B"+super; end
       alias m2 m
       prepend p
       alias m3 m
     end
-    assert_equal("BA", b.new.m2, bug7842)
-    assert_equal("PBA", b.new.m3, bug7842)
+
+    assert_nothing_raised do
+      assert_equal("BA", b.new.m2, bug7842)
+    end
+
+    assert_nothing_raised do
+      assert_equal("PBA", b.new.m3, bug7842)
+    end
   end
 
   assert 'test_prepend_each_classes' do

--- a/test/t/module.rb
+++ b/test/t/module.rb
@@ -543,21 +543,21 @@ assert('Module#prepend') do
     b = labeled_module('b') { include a }
     c = labeled_module('c') { prepend b }
 
-    assert bug6654 do
+    #assert bug6654 do
       # the Module#< operator should be used here instead, but we don't have it
       assert_include(c.ancestors, a)
       assert_include(c.ancestors, b)
-    end
+    #end
 
     bug8357 = '[ruby-core:54736] [Bug #8357]'
     b = labeled_module('b') { prepend a }
     c = labeled_class('c') { include b }
 
-    assert bug8357 do
+    #assert bug8357 do
       # the Module#< operator should be used here instead, but we don't have it
       assert_include(c.ancestors, a)
       assert_include(c.ancestors, b)
-    end
+    #end
 
     bug8357 = '[ruby-core:54742] [Bug #8357]'
     assert_kind_of(b, c.new, bug8357)


### PR DESCRIPTION
Hi, we requested Module#prepend, so about a year later we figured what the heck and went ahead and implemented it.

We've gone and ported over the original ruby commits by ko1 and nobu over to mruby, all tests currently pass. RClass struct size is now bigger, because we needed to add `origin`, but that seems unavoidable.

/cc @matz @cremno @zzak

Closes #2082.
