### PR TITLE
use mrb_str_cat_str() instead of mrb_str_append()

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -1608,10 +1608,10 @@ mrb_mod_to_s(mrb_state *mrb, mrb_value klass)
       case MRB_TT_CLASS:
       case MRB_TT_MODULE:
       case MRB_TT_SCLASS:
-        mrb_str_append(mrb, str, mrb_inspect(mrb, v));
+        mrb_str_cat_str(mrb, str, mrb_inspect(mrb, v));
         break;
       default:
-        mrb_str_append(mrb, str, mrb_any_to_s(mrb, v));
+        mrb_str_cat_str(mrb, str, mrb_any_to_s(mrb, v));
         break;
     }
     return mrb_str_cat_lit(mrb, str, ">");

--- a/src/error.c
+++ b/src/error.c
@@ -152,7 +152,7 @@ exc_inspect(mrb_state *mrb, mrb_value exc)
     mrb_str_append(mrb, str, line);
     mrb_str_cat_lit(mrb, str, ": ");
     if (append_mesg) {
-      mrb_str_append(mrb, str, mesg);
+      mrb_str_cat_str(mrb, str, mesg);
       mrb_str_cat_lit(mrb, str, " (");
     }
     mrb_str_cat_cstr(mrb, str, mrb_obj_classname(mrb, exc));
@@ -165,7 +165,7 @@ exc_inspect(mrb_state *mrb, mrb_value exc)
     str = mrb_str_new_cstr(mrb, cname);
     mrb_str_cat_lit(mrb, str, ": ");
     if (append_mesg) {
-      mrb_str_append(mrb, str, mesg);
+      mrb_str_cat_str(mrb, str, mesg);
     }
     else {
       mrb_str_cat_cstr(mrb, str, cname);

--- a/src/range.c
+++ b/src/range.c
@@ -290,7 +290,7 @@ range_to_s(mrb_state *mrb, mrb_value range)
   str2 = mrb_obj_as_string(mrb, r->edges->end);
   str  = mrb_str_dup(mrb, str);
   mrb_str_cat(mrb, str, "...", r->excl ? 3 : 2);
-  mrb_str_append(mrb, str, str2);
+  mrb_str_cat_str(mrb, str, str2);
 
   return str;
 }
@@ -315,7 +315,7 @@ range_inspect(mrb_state *mrb, mrb_value range)
   str2 = mrb_inspect(mrb, r->edges->end);
   str  = mrb_str_dup(mrb, str);
   mrb_str_cat(mrb, str, "...", r->excl ? 3 : 2);
-  mrb_str_append(mrb, str, str2);
+  mrb_str_cat_str(mrb, str, str2);
 
   return str;
 }

--- a/src/variable.c
+++ b/src/variable.c
@@ -609,7 +609,7 @@ inspect_i(mrb_state *mrb, mrb_sym sym, mrb_value v, void *p)
   else {
     ins = mrb_inspect(mrb, v);
   }
-  mrb_str_append(mrb, str, ins);
+  mrb_str_cat_str(mrb, str, ins);
   return 0;
 }
 


### PR DESCRIPTION
`mrb_any_to_s()`, `mrb_obj_as_string()` and `mrb_inspect()` always return a string which means `mrb_str_cat_str()` can be directly called instead of indirectly by `mrb_str_append()`.