### PR TITLE
delete mrb_free()-related non-NULL checks

### DIFF
--- a/mrbgems/mruby-bin-mrbc/tools/mrbc/mrbc.c
+++ b/mrbgems/mruby-bin-mrbc/tools/mrbc/mrbc.c
@@ -161,8 +161,7 @@ parse_args(mrb_state *mrb, int argc, char **argv, struct mrbc_args *args)
 static void
 cleanup(mrb_state *mrb, struct mrbc_args *args)
 {
-  if (args->outfile)
-    mrb_free(mrb, (void*)args->outfile);
+  mrb_free(mrb, (void*)args->outfile);
   mrb_close(mrb);
 }
 

--- a/mrbgems/mruby-bin-mruby/tools/mruby/mruby.c
+++ b/mrbgems/mruby-bin-mruby/tools/mruby/mruby.c
@@ -159,10 +159,9 @@ cleanup(mrb_state *mrb, struct _args *args)
 {
   if (args->rfp && args->rfp != stdin)
     fclose(args->rfp);
-  if (args->cmdline && !args->fname)
+  if (!args->fname)
     mrb_free(mrb, args->cmdline);
-  if (args->argv)
-    mrb_free(mrb, args->argv);
+  mrb_free(mrb, args->argv);
   mrb_close(mrb);
 }
 

--- a/src/dump.c
+++ b/src/dump.c
@@ -978,12 +978,8 @@ error_exit:
     mrb_free(mrb, *bin);
     *bin = NULL;
   }
-  if (lv_syms) {
-    mrb_free(mrb, lv_syms);
-  }
-  if (filenames) {
-    mrb_free(mrb, filenames);
-  }
+  mrb_free(mrb, lv_syms);
+  mrb_free(mrb, filenames);
   return result;
 }
 


### PR DESCRIPTION
Passing a null pointer to `free()` is fine. So there's no need to optimize for speed in these cases since a program only exits once and errors are rare. Also the mruby source code doesn't have these kind of checks elsewhere.

The ones in `{Time,Random}#initialize` are kept because there it actually might matter. I didn't measure it though.