### PR TITLE
64bit Cygwin also doesn't have frexpl(3)

### DIFF
--- a/src/fmt_fp.c
+++ b/src/fmt_fp.c
@@ -90,7 +90,7 @@ fmt_u(uint32_t x, char *s)
 typedef char compiler_defines_long_double_incorrectly[9-(int)sizeof(long double)];
 #endif
 
-#if ((defined(__CYGWIN32__) || defined(__NetBSD__) || defined(mips)) && !defined(__linux__)) || defined(__android__)
+#if ((defined(__CYGWIN__) || defined(__NetBSD__) || defined(mips)) && !defined(__linux__)) || defined(__android__)
 #undef frexpl
 #define frexpl frexp
 #endif


### PR DESCRIPTION
64bit Cygwin doesn't have frexpl(3) as well as 32bit Cygwin, so I couldn't build mruby on 64bit Cygwin.
I tested this on 64bit Cygwin, 32bit Cygwin and Mac OS X.