### PR TITLE
Don't crash if pattern not found for sub

### DIFF
--- a/mrblib/string.rb
+++ b/mrblib/string.rb
@@ -111,6 +111,7 @@ class String
   def sub(*args, &block)
     if args.size == 2
       pre, post = split(args[0], 2)
+      return self unless post # The sub target wasn't found in the string
       pre + args[1].__sub_replace(pre, args[0], post) + post
     elsif args.size == 1 && block
       split(args[0], 2).join(block.call(args[0]))


### PR DESCRIPTION
`String#sub` throws if the pattern to substitute is not in the string. The issue being that `pre, post = split(args[0], 2)` returns `[ORIGINAL_STRING, nil]`, that nil goes on to cause problems.

Before
```
C:\projects\mruby-bindings\mruby>bin\mirb.exe
mirb - Embeddable Interactive Ruby Shell

> 'a'.sub 'b', 'c'
(mirb):1: expected String (TypeError)
```

After
```
C:\projects\mruby-bindings\mruby>bin\mirb.exe
mirb - Embeddable Interactive Ruby Shell

> 'a'.sub 'b', 'c'
 => "a"
> 'a'.sub 'a', 'b'
 => "b"
> 'a'.sub 'a' do |c| 'b' end
 => "b"
> 'a'.sub 'b' do |c| 'd' end
 => "a"
```