### PR TITLE
mrbgem compile should be depend on mrbgem.rake

### DIFF
--- a/tasks/mrbgem_spec.rake
+++ b/tasks/mrbgem_spec.rake
@@ -130,7 +130,7 @@ module MRuby
       end
 
       def define_gem_init_builder
-        file objfile("#{build_dir}/gem_init") => "#{build_dir}/gem_init.c"
+        file objfile("#{build_dir}/gem_init") => [ "#{build_dir}/gem_init.c", File.join(dir, "mrbgem.rake") ]
         file "#{build_dir}/gem_init.c" => [build.mrbcfile, __FILE__] + [rbfiles].flatten do |t|
           FileUtils.mkdir_p build_dir
           generate_gem_init("#{build_dir}/gem_init.c")

--- a/tasks/mruby_build_commands.rake
+++ b/tasks/mruby_build_commands.rake
@@ -92,6 +92,8 @@ module MRuby
 
     def define_rules(build_dir, source_dir='')
       @out_ext = build.exts.object
+      gemrake = File.join(source_dir, "mrbgem.rake")
+      rakedep = File.exist?(gemrake) ? [ gemrake ] : []
 
       if build_dir.include? "mrbgems/"
         generated_file_matcher = Regexp.new("^#{Regexp.escape build_dir}/(.*)#{Regexp.escape out_ext}$")
@@ -104,7 +106,7 @@ module MRuby
             file.sub(generated_file_matcher, "#{source_dir}/\\1#{ext}")
           },
           proc { |file|
-            get_dependencies(file)
+            get_dependencies(file) + rakedep
           }
         ] do |t|
           run t.name, t.prerequisites.first
@@ -115,7 +117,7 @@ module MRuby
             file.sub(generated_file_matcher, "#{build_dir}/\\1#{ext}")
           },
           proc { |file|
-            get_dependencies(file)
+            get_dependencies(file) + rakedep
           }
         ] do |t|
           run t.name, t.prerequisites.first


### PR DESCRIPTION
I think it should be recompile mrbgem when its *mrbgem.rake* has been modified !
the reason list below :

* compiler and linker options maybe change
* the mrbgem information maybe change, such as version.
