### PR TITLE
pop cmdarg in lambda body; fix [ruby-bug#11380]

### DIFF
--- a/mrbgems/mruby-compiler/core/parse.y
+++ b/mrbgems/mruby-compiler/core/parse.y
@@ -2154,6 +2154,7 @@ primary         : literal
                       $$ = new_lambda(p, $3, $5);
                       local_unnest(p);
                       p->cmdarg_stack = $<stack>4;
+                      CMDARG_LEXPOP();
                     }
                 | keyword_if expr_value then
                   compstmt


### PR DESCRIPTION
See ruby/ruby@dfec9d978804fbd53df9e6b93e5801985b2b3130. It fixes a regression which affects mruby too because of 2fe556d9c039839c20965a2c90dff703f04e40ec.