### PR TITLE
be able to source with :path for mrbgems

### DIFF
--- a/tasks/mruby_build_gem.rake
+++ b/tasks/mruby_build_gem.rake
@@ -76,6 +76,9 @@ module MRuby
 
       if params[:core]
         gemdir = "#{root}/mrbgems/#{params[:core]}"
+      elsif params[:path]
+        require 'pathname'
+        gemdir = Pathname.new(params[:path]).absolute? ? params[:path] : "#{root}/#{params[:path]}"
       elsif params[:git]
         url = params[:git]
         gemdir = "#{gem_clone_dir}/#{url.match(/([-\w]+)(\.[-\w]+|)$/).to_a[1]}"


### PR DESCRIPTION
Allow people in `build_config.rb` to override a github repo or mgem with a local working copy, so you don't need to push to github to see the changes. This would like this:

```ruby
conf.gem :path => '/path/to/gem_fork`
```