### PR TITLE
Add build on Trusty and OS X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ matrix:
     - os: linux
       sudo: 9000
     - os: osx
+      osx_image: xcod6.4
 
 install:
   - if [ $TRAVIS_OS_NAME = 'linux' ]; then sudo apt-get update -qq; sudo apt-get -q install gperf; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
-# no installation...
+language: c
+
+sudo: 9000
 
 install:
  - sudo apt-get -q install gperf

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: c
 
-sudo: 9000
+matrix:
+  include:
+    - sudo: 9000
 
 install:
   - sudo apt-get update -qq

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,12 @@ language: c
 
 matrix:
   include:
-    - sudo: 9000
+    - os: linux
+      sudo: 9000
+    - os: osx
 
 install:
-  - sudo apt-get update -qq
-  - sudo apt-get -q install gperf
+  - if [ $TRAVIS_OS_NAME = 'linux' ]; then sudo apt-get update -qq; sudo apt-get -q install gperf; fi
 
 env: MRUBY_CONFIG=travis_config.rb
 script: "./minirake all test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ language: c
 sudo: 9000
 
 install:
- - sudo apt-get -q install gperf
+  - sudo apt-get update -qq
+  - sudo apt-get -q install gperf
 
 env: MRUBY_CONFIG=travis_config.rb
 script: "./minirake all test"


### PR DESCRIPTION
This PR adds a second job in a build matrix running on Trusty (Ubuntu 14.04 LTS), and a third, running on OS X.

For Trusty, `apt-get update` is necessary; without it, the current image cannot find `gperf`.

`language: c` has been added for tracking metrics correctly.

The multi-os feature has been turned on for `mruby/mruby`, so this PR should on the Mac image as well.

You can see an example build at https://travis-ci.org/BanzaiMan/mruby/builds/73983119.