### PR TITLE
mrb_get_mid and mrb_get_argc

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -255,6 +255,18 @@ MRB_API struct RClass * mrb_define_module_under(mrb_state *mrb, struct RClass *o
 
 MRB_API mrb_int mrb_get_args(mrb_state *mrb, const char *format, ...);
 
+static inline mrb_sym
+mrb_get_mid(mrb_state *mrb) /* get method symbol */
+{
+  return mrb->c->ci->mid;
+}
+
+static inline int
+mrb_get_argc(mrb_state *mrb) /* get argc */
+{
+  return mrb->c->ci->argc;
+}
+
 /* `strlen` for character string literals (use with caution or `strlen` instead)
     Adjacent string literals are concatenated in C/C++ in translation phase 6.
     If `lit` is not one, the compiler will report a syntax error:


### PR DESCRIPTION
mrb_get_mid Returns the name Symbol of the current method
mrb_get_argc Returns the number of arguments sent to the current method

These are struct member accessors; makes the ability to query the current method more obvious.