### PR TITLE
delete duplicate definition of Exception.exception

### DIFF
--- a/mrblib/error.rb
+++ b/mrblib/error.rb
@@ -1,18 +1,3 @@
-##
-# Exception
-#
-# ISO 15.2.22
-class Exception
-
-  ##
-  # Raise an exception.
-  #
-  # ISO 15.2.22.4.1
-  def self.exception(*args, &block)
-    self.new(*args, &block)
-  end
-end
-
 # ISO 15.2.24
 class ArgumentError < StandardError
 end


### PR DESCRIPTION
It overwrote the original definition in [src/error.c, line 446](https://github.com/mruby/mruby/blob/a1731254bee12c831ea1d509bf43520db1d0d9af/src/error.c#L446).