### PR TITLE
irep dump: fix format string for MRB_USE_FLOAT

### DIFF
--- a/src/dump.c
+++ b/src/dump.c
@@ -16,7 +16,7 @@
 #define FLAG_BYTEORDER_NONATIVE 0
 
 #ifdef MRB_USE_FLOAT
-#define MRB_FLOAT_FMT "%.9e"
+#define MRB_FLOAT_FMT "%.8e"
 #else
 #define MRB_FLOAT_FMT "%.16e"
 #endif


### PR DESCRIPTION
IEC 60559 single format has 6 to 9 significant decimal digits precision.

However the printf conversion specifier e (and E, of course) already writes 1 digit - the one before the decimal point - and precision specifies the number of digits to write after the decimal point.