### PR TITLE
run bintests within subfolders of bintest/

### DIFF
--- a/test/bintest.rb
+++ b/test/bintest.rb
@@ -2,7 +2,7 @@ $:.unshift File.dirname(File.dirname(File.expand_path(__FILE__)))
 require 'test/assert.rb'
 
 ARGV.each do |gem|
-  Dir["#{gem}/bintest/*.rb"].each do |file|
+  Dir["#{gem}/bintest/**/*.rb"].each do |file|
     load file
   end
 end


### PR DESCRIPTION
Currently, when running bintests mruby only checks for tests 1 level deep of the `bintest/` dir. So `bintest/foo.rb` will run, but `bintest/bar/baz.rb` will not. This allows the latter to be detected and run so people can organize their bintests however they want as long as they're in the `bintest/` dir.