### PR TITLE
Add build_mrbtest after config block is evaluated

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -116,9 +116,7 @@ end
 desc "run all mruby tests"
 task :test => ["all"] do
   MRuby.each_target do
-    if gems.find { |v| v.name == 'mruby-test' }
-      run_test unless build_mrbtest_lib_only?
-    end
+    run_test if test_enabled?
   end
 end
 

--- a/build_config.rb
+++ b/build_config.rb
@@ -114,9 +114,9 @@ MRuby::Build.new('test') do |conf|
 
   enable_debug
   conf.enable_bintest
+  conf.enable_test
 
   conf.gembox 'default'
-  conf.gem :core => "mruby-test"
 end
 
 # Define cross build settings

--- a/mrbgems/mruby-test/mrbgem.rake
+++ b/mrbgems/mruby-test/mrbgem.rake
@@ -32,7 +32,7 @@ MRuby::Gem::Specification.new('mruby-test') do |spec|
     end
   end
 
-  gem_table = build.gems.generate_gem_table self
+  gem_table = build.gems.generate_gem_table build
 
   build.gems.each do |g|
     test_rbobj = g.test_rbireps.ext(exts.object)

--- a/tasks/mruby_build.rake
+++ b/tasks/mruby_build.rake
@@ -46,7 +46,7 @@ module MRuby
     include LoadGems
     attr_accessor :name, :bins, :exts, :file_separator, :build_dir, :gem_clone_dir
     attr_reader :libmruby, :gems, :toolchains
-    attr_writer :enable_bintest
+    attr_writer :enable_bintest, :enable_test
 
     COMPILERS = %w(cc cxx objc asm)
     COMMANDS = COMPILERS + %w(linker archiver yacc gperf git exts mrbc)
@@ -85,6 +85,8 @@ module MRuby
         @build_mrbtest_lib_only = false
         @cxx_abi_enabled = false
         @cxx_exception_disabled = false
+        @enable_bintest = false
+        @enable_test = false
         @toolchains = []
 
         MRuby.targets[@name] = self
@@ -94,6 +96,7 @@ module MRuby
       MRuby.targets[@name].instance_eval(&block)
 
       build_mrbc_exec if name == 'host'
+      build_mrbtest if test_enabled?
     end
 
     def enable_debug
@@ -168,6 +171,18 @@ EOS
 
     def root
       MRUBY_ROOT
+    end
+
+    def enable_test
+      @enable_test = true
+    end
+
+    def test_enabled?
+      @enable_test
+    end
+
+    def build_mrbtest
+      gem :core => 'mruby-test'
     end
 
     def build_mrbc_exec
@@ -252,7 +267,7 @@ EOS
       mrbtest = exefile("#{build_dir}/bin/mrbtest")
       sh "#{filename mrbtest.relative_path}#{$verbose ? ' -v' : ''}"
       puts
-      run_bintest if @enable_bintest
+      run_bintest if bintest_enabled?
     end
 
     def run_bintest
@@ -297,7 +312,7 @@ EOS
     end
 
     def run_test
-      mrbtest = exefile("#{build_dir}/test/mrbtest")
+      mrbtest = exefile("#{build_dir}/bin/mrbtest")
       if (@test_runner.command == nil)
         puts "You should run #{mrbtest} on target device."
         puts

--- a/travis_config.rb
+++ b/travis_config.rb
@@ -22,6 +22,7 @@ MRuby::Build.new do |conf|
     c.defines += %w(MRB_GC_FIXED_ARENA)
   end
   conf.enable_bintest
+  conf.enable_test
 end
 
 MRuby::Build.new('cxx_abi') do |conf|
@@ -33,18 +34,9 @@ MRuby::Build.new('cxx_abi') do |conf|
     c.defines += %w(MRB_GC_FIXED_ARENA)
   end
   conf.enable_bintest
+  conf.enable_test
 
   enable_cxx_abi
 
   build_mrbc_exec
-end
-
-MRuby::Build.new('test') do |conf|
-  toolchain :gcc
-
-  enable_debug
-  conf.enable_bintest
-
-  conf.gembox 'full-core'
-  conf.gem :core => "mruby-test"
 end


### PR DESCRIPTION
Add build_mrbtest after config block is evaluated

This allows us to add `enable_test` anywhere in a build target,
without having to worry about the order in which they are included.

Previously, there was a bug that occured when adding 'mruby-test' gem
to dependencies before additional gems.

Instead of adding the 'mruby-test' gem dependency manually to a test build,
we now only need to call `enable_test` in the target. This also allows us to
call `test_enabled?` downstream when compiling mruby ourselves.