### PR TITLE
Add gem test dependencies

### DIFF
--- a/tasks/mrbgem_spec.rake
+++ b/tasks/mrbgem_spec.rake
@@ -103,6 +103,10 @@ module MRuby
         @dependencies << {:gem => name, :requirements => requirements, :default => default_gem}
       end
 
+      def add_test_dependency(*args)
+        add_dependency(*args) if build.test_enabled?
+      end
+
       def add_conflict(name, *req)
         @conflicts << {:gem => name, :requirements => req.empty? ? nil : req}
       end


### PR DESCRIPTION
Added a `add_test_dependency` method to gems specs.

All it does is call `add_dependency` if `test_enabled?` is true.

Not sure if it's the best approach but seems to be working :smile: 