### PR TITLE
freeze the hash keys (fixes #2945)

### DIFF
--- a/src/hash.c
+++ b/src/hash.c
@@ -104,12 +104,11 @@ static void mrb_hash_modify(mrb_state *mrb, mrb_value hash);
 static inline mrb_value
 mrb_hash_ht_key(mrb_state *mrb, mrb_value key)
 {
-  if (mrb_string_p(key)) {
+  if (mrb_string_p(key) && !RSTR_FROZEN_P(mrb_str_ptr(key))) {
     key = mrb_str_dup(mrb, key);
     RSTR_SET_FROZEN_FLAG(mrb_str_ptr(key));
-    return key;
-  } else
-    return key;
+  }
+  return key;
 }
 
 #define KEY(key) mrb_hash_ht_key(mrb, key)

--- a/src/hash.c
+++ b/src/hash.c
@@ -104,9 +104,11 @@ static void mrb_hash_modify(mrb_state *mrb, mrb_value hash);
 static inline mrb_value
 mrb_hash_ht_key(mrb_state *mrb, mrb_value key)
 {
-  if (mrb_string_p(key))
-    return mrb_str_dup(mrb, key);
-  else
+  if (mrb_string_p(key)) {
+    key = mrb_str_dup(mrb, key);
+    RSTR_SET_FROZEN_FLAG(mrb_str_ptr(key));
+    return key;
+  } else
     return key;
 }
 


### PR DESCRIPTION
As discussed in #2945, `Hash#keys` returns unfrozen key objects that are actually being used by the underlying hash table.  And unexpected behaviors happen if they get modified by the caller.

Thank to 1a45447, we can fix the issue as is done by MRI by freezing the key string when they are registered to the hash table.

Disclaimer: I am totally new to mruby and there might be issues overlooked within this PR.