### PR TITLE
Customize installation directory using INSTALL_DIR environment variable

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -32,7 +32,7 @@ load "#{MRUBY_ROOT}/tasks/benchmark.rake"
 # generic build targets, rules
 task :default => :all
 
-bin_path = "#{MRUBY_ROOT}/bin"
+bin_path = ENV['INSTALL_DIR'] || "#{MRUBY_ROOT}/bin"
 FileUtils.mkdir_p bin_path, { :verbose => $verbose }
 
 depfiles = MRuby.targets['host'].bins.map do |bin|
@@ -71,7 +71,7 @@ MRuby.each_target do |target|
       end
 
       if target == MRuby.targets['host']
-        install_path = MRuby.targets['host'].exefile("#{MRUBY_ROOT}/bin/#{bin}")
+        install_path = MRuby.targets['host'].exefile("#{bin_path}/#{bin}")
 
         file install_path => exec do |t|
           FileUtils.rm_f t.name, { :verbose => $verbose }
@@ -80,7 +80,7 @@ MRuby.each_target do |target|
         depfiles += [ install_path ]
       elsif target == MRuby.targets['host-debug']
         unless MRuby.targets['host'].gems.map {|g| g.bins}.include?([bin])
-          install_path = MRuby.targets['host-debug'].exefile("#{MRUBY_ROOT}/bin/#{bin}")
+          install_path = MRuby.targets['host-debug'].exefile("#{bin_path}/#{bin}")
 
           file install_path => exec do |t|
             FileUtils.rm_f t.name, { :verbose => $verbose }


### PR DESCRIPTION
Previously, minirake installed several commands (e.g., mrbc) in
repository locally under bin directory.  But there was no knob for
users to change this directory.  It effectively made `make distcheck`
fail if mruby was embedded into project managed by autotools.

This change adds a way for the user to change installation directory
by setting INSTALL_DIR environment variable.