### PR TITLE
Don't crash if NULL is passed to mrb_close

### DIFF
--- a/src/state.c
+++ b/src/state.c
@@ -234,6 +234,7 @@ mrb_free_context(mrb_state *mrb, struct mrb_context *c)
 MRB_API void
 mrb_close(mrb_state *mrb)
 {
+  if (!mrb) return;
   if (mrb->atexit_stack_len > 0) {
     mrb_int i;
     for (i = mrb->atexit_stack_len; i > 0; --i) {


### PR DESCRIPTION
Sometimes it is very useful just return from mrb_close if NULL is
passed as mrb.  This is the same spirit of free(3), which just does
nothing if NULL is passed.