### PR TITLE
fix block variable in Hash#fetch

### DIFF
--- a/mrbgems/mruby-hash-ext/mrblib/hash.rb
+++ b/mrbgems/mruby-hash-ext/mrblib/hash.rb
@@ -126,7 +126,7 @@ class Hash
   def fetch(key, none=NONE, &block)
     unless self.key?(key)
       if block
-        block.call
+        block.call(key)
       elsif none != NONE
         none
       else

--- a/mrbgems/mruby-hash-ext/test/hash.rb
+++ b/mrbgems/mruby-hash-ext/test/hash.rb
@@ -75,6 +75,7 @@ assert('Hash#fetch') do
   assert_equal "feline", h.fetch("cat")
   assert_equal "mickey", h.fetch("mouse", "mickey")
   assert_equal "minny", h.fetch("mouse"){"minny"}
+  assert_equal "mouse", h.fetch("mouse"){|k| k}
   begin
     h.fetch("gnu")
   rescue => e


### PR DESCRIPTION
A block of Hash#fetch should have block variable, which is the same value of `key`.