### PR TITLE
C API documentation

### DIFF
--- a/include/mrbconf.h
+++ b/include/mrbconf.h
@@ -100,15 +100,4 @@
 # define TRUE 1
 #endif
 
-#if defined(MRB_BUILD_AS_DLL)
-
-#if defined(MRB_CORE) || defined(MRB_LIB)
-#define MRB_API __declspec(dllexport)
-#else
-#define MRB_API __declspec(dllimport)
-#endif
-#else
-#define MRB_API extern
-#endif
-
 #endif  /* MRUBYCONF_H */

--- a/include/mruby.h
+++ b/include/mruby.h
@@ -1,28 +1,30 @@
 /*
-** mruby - An embeddable Ruby implementation
-**
-** Copyright (c) mruby developers 2010-2015
-**
-** Permission is hereby granted, free of charge, to any person obtaining
-** a copy of this software and associated documentation files (the
-** "Software"), to deal in the Software without restriction, including
-** without limitation the rights to use, copy, modify, merge, publish,
-** distribute, sublicense, and/or sell copies of the Software, and to
-** permit persons to whom the Software is furnished to do so, subject to
-** the following conditions:
-**
-** The above copyright notice and this permission notice shall be
-** included in all copies or substantial portions of the Software.
-**
-** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-** SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-**
-** [ MIT license: http://www.opensource.org/licenses/mit-license.php ]
+ * mruby - An embeddable Ruby implementation
+ *
+ * Copyright (c) mruby developers 2010-2015
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * [ MIT license: http://www.opensource.org/licenses/mit-license.php ]
+ *
+ * @header mruby.h
 */
 
 #ifndef MRUBY_H
@@ -202,7 +204,14 @@ typedef struct mrb_state {
 #endif
 
 typedef mrb_value (*mrb_func_t)(mrb_state *mrb, mrb_value);
-MRB_API struct RClass *mrb_define_class(mrb_state *, const char*, struct RClass*);
+
+/**
+ * Define a new Class
+ *
+ * @param name The name of the defined class
+ * @param super The new class parent
+ */
+MRB_API struct RClass *mrb_define_class(mrb_state *mrb, const char *name, struct RClass *super);
 MRB_API struct RClass *mrb_define_module(mrb_state *, const char*);
 MRB_API mrb_value mrb_singleton_class(mrb_state*, mrb_value);
 MRB_API void mrb_include_module(mrb_state*, struct RClass*, struct RClass*);

--- a/include/mruby.h
+++ b/include/mruby.h
@@ -25,26 +25,26 @@
 ** [ MIT license: http://www.opensource.org/licenses/mit-license.php ]
 */
 
-/**
- * @header mruby.h
- *
- * Basic mruby header.
- */
-
 #ifndef MRUBY_H
 #define MRUBY_H
-
-#if defined(__cplusplus)
-extern "C" {
-#endif
 
 #include <stdint.h>
 #include <stddef.h>
 #include <limits.h>
 
 #include "mrbconf.h"
+#include "mruby/common.h"
 #include "mruby/value.h"
 #include "mruby/version.h"
+
+/**
+ * @file mruby.h
+ * @brief Main header of mruby C API. Include this first.
+ * @defgroup mrb_core MRuby core
+ * @ingroup MRuby
+ * @{
+ */
+MRB_BEGIN_DECL
 
 typedef uint32_t mrb_code;
 typedef uint32_t mrb_aspec;
@@ -244,20 +244,31 @@ MRB_API void mrb_prepend_module(mrb_state*, struct RClass*, struct RClass*);
  * Defines a global function in ruby.
  *
  * If you're creating a gem it may look something like this:
- *    mrb_value example_method(mrb_state* mrb, mrb_value self){
- *        puts("Executing example command!");
- *        return self;
- *    }
  *
- *    void mrb_example_gem_init(mrb_state* mrb) {
- *      mrb_define_method(mrb, mrb->kernel_module, "example_method", example_method, MRB_ARGS_NONE());  
- *    }
+ *     mrb_value example_method(mrb_state* mrb, mrb_value self){
+ *          puts("Executing example command!");
+ *          return self;
+ *     }
  *
- *    void mrb_example_gem_final(mrb_state* mrb) {
- *      //free(TheAnimals);
- *    }
+ *     void mrb_example_gem_init(mrb_state* mrb) {
+ *           mrb_define_method(mrb, mrb->kernel_module, "example_method", example_method, MRB_ARGS_NONE());
+ *     }
+ *
+ *     void mrb_example_gem_final(mrb_state* mrb) {
+ *         //free(TheAnimals);
+ *     }
+ *
+ * @param mrb
+ *      The MRuby state reference.
+ * @param cla
+ *      The class pointer where the method will be defined.
+ * @param func
+ *      The function pointer to the method definition.
+ * @param aspec
+ *      The method required parameters definition.
  */
-MRB_API void mrb_define_method(mrb_state*, struct RClass*, const char*, mrb_func_t, mrb_aspec);
+MRB_API void mrb_define_method(mrb_state *mrb, struct RClass *cla, const char *name, mrb_func_t func, mrb_aspec aspec);
+
 MRB_API void mrb_define_class_method(mrb_state *, struct RClass *, const char *, mrb_func_t, mrb_aspec);
 MRB_API void mrb_define_singleton_method(mrb_state*, struct RObject*, const char*, mrb_func_t, mrb_aspec);
 MRB_API void mrb_define_module_function(mrb_state*, struct RClass*, const char*, mrb_func_t, mrb_aspec);
@@ -303,11 +314,15 @@ MRB_API struct RClass * mrb_define_module_under(mrb_state *mrb, struct RClass *o
 /* accept no arguments */
 #define MRB_ARGS_NONE()     ((mrb_aspec)0)
 
-/**
- * Retrieve arguments from mrb_state.
+/** Retrieve arguments from mrb_state.
+ *
  * When applicable, implicit conversions (such as to_str, to_ary, to_hash) are
  * applied to received arguments.
  * Use it inside a function pointed by mrb_func_t.
+ *
+ * @param mrb
+ *      The current MRuby state.
+ *
  * @param format
  *      is a list of following format specifiers:
  *      <pre>
@@ -395,6 +410,9 @@ char* mrb_locale_from_utf8(const char *p, size_t len);
 
 /**
  * Creates new mrb_state.
+ *
+ * @returns
+ *      Pointer to the newly created mrb_state.
  */
 MRB_API mrb_state* mrb_open(void);
 
@@ -405,14 +423,20 @@ MRB_API mrb_state* mrb_open(void);
  * @param ud
  *      will be passed to custom allocator f. If user data isn't required just
  *      pass NULL. Function pointer f must satisfy requirements of its type.
+ *
+ * @returns
+ *      Pointer to the newly created mrb_state.
  */
 MRB_API mrb_state* mrb_open_allocf(mrb_allocf, void *ud);
 MRB_API mrb_state* mrb_open_core(mrb_allocf, void *ud);
 
 /**
- * Deletes mrb_state.
+ * Closes and frees a mrb_state.
+ *
+ * @param mrb
+ *      Pointer to the mrb_state to be closed.
  */
-MRB_API void mrb_close(mrb_state*);
+MRB_API void mrb_close(mrb_state *mrb);
 
 MRB_API void* mrb_default_allocf(mrb_state*, void*, size_t, void*);
 
@@ -570,8 +594,7 @@ MRB_API void mrb_show_copyright(mrb_state *mrb);
 
 MRB_API mrb_value mrb_format(mrb_state *mrb, const char *format, ...);
 
-#if defined(__cplusplus)
-}  /* extern "C" { */
-#endif
+/** @} */
+MRB_END_DECL
 
 #endif  /* MRUBY_H */

--- a/include/mruby/array.h
+++ b/include/mruby/array.h
@@ -17,6 +17,7 @@
  */
 MRB_BEGIN_DECL
 
+
 typedef struct mrb_shared_array {
   int refcnt;
   mrb_int len;
@@ -47,15 +48,93 @@ struct RArray {
 void mrb_ary_decref(mrb_state*, mrb_shared_array*);
 MRB_API void mrb_ary_modify(mrb_state*, struct RArray*);
 MRB_API mrb_value mrb_ary_new_capa(mrb_state*, mrb_int);
+
+/**
+ * Initializes a new array.
+ *
+ * Equivalent to:
+ *
+ *      Array.new
+ *
+ * @param mrb
+ *      The MRuby state reference.
+ * @returns
+ *      The initialized array
+ */
 MRB_API mrb_value mrb_ary_new(mrb_state *mrb);
 MRB_API mrb_value mrb_ary_new_from_values(mrb_state *mrb, mrb_int size, const mrb_value *vals);
 MRB_API mrb_value mrb_assoc_new(mrb_state *mrb, mrb_value car, mrb_value cdr);
 MRB_API void mrb_ary_concat(mrb_state*, mrb_value, mrb_value);
 MRB_API mrb_value mrb_ary_splat(mrb_state*, mrb_value);
-MRB_API void mrb_ary_push(mrb_state*, mrb_value, mrb_value);
+
+/**
+ * Pushes value into array.
+ *
+ * Equivalent to:
+ *
+ *      ary << value
+ *
+ * @param mrb
+ *      The MRuby state reference.
+ * @param ary
+ *      The array in which the value will be pushed
+ * @param value
+ *      The value to be pushed into array
+ */
+MRB_API void mrb_ary_push(mrb_state *mrb, mrb_value array, mrb_value value);
+
+/**
+ * Pops the last element from the array.
+ *
+ * Equivalent to:
+ *
+ *      ary.pop
+ *
+ * @param mrb
+ *      The MRuby state reference.
+ * @param ary
+ *      The array from which the value will be poped.
+ * @returns
+ *      The poped value.
+ */
 MRB_API mrb_value mrb_ary_pop(mrb_state *mrb, mrb_value ary);
+
+/**
+ * Returns a reference to an element of the array on the given index.
+ *
+ * Equivalent to:
+ *
+ *      ary[n]
+ *
+ * @param mrb
+ *      The MRuby state reference.
+ * @param ary
+ *      The target array.
+ * @param n
+ *      The array index being referenced
+ * @returns
+ *      The referenced value.
+ */
 MRB_API mrb_value mrb_ary_ref(mrb_state *mrb, mrb_value ary, mrb_int n);
+
+/**
+ * Sets a value on an array at the given index
+ *
+ * Equivalent to:
+ *
+ *      ary[n] = val
+ *
+ * @param mrb
+ *      The MRuby state reference.
+ * @param ary
+ *      The target array.
+ * @param n
+ *      The array index being referenced.
+ * @param val
+ *      The value being setted.
+ */
 MRB_API void mrb_ary_set(mrb_state *mrb, mrb_value ary, mrb_int n, mrb_value val);
+
 MRB_API void mrb_ary_replace(mrb_state *mrb, mrb_value a, mrb_value b);
 MRB_API mrb_value mrb_check_array_type(mrb_state *mrb, mrb_value self);
 MRB_API mrb_value mrb_ary_unshift(mrb_state *mrb, mrb_value self, mrb_value item);

--- a/include/mruby/array.h
+++ b/include/mruby/array.h
@@ -7,9 +7,16 @@
 #ifndef MRUBY_ARRAY_H
 #define MRUBY_ARRAY_H
 
-#if defined(__cplusplus)
-extern "C" {
-#endif
+#include "mruby/common.h"
+
+/**
+ * @file mruby/array.h
+ * @brief Array class
+ * @defgroup mrb_array MRuby Array class
+ * @ingroup MRuby
+ * @{
+ */
+MRB_BEGIN_DECL
 
 typedef struct mrb_shared_array {
   int refcnt;
@@ -67,8 +74,7 @@ mrb_ary_len(mrb_state *mrb, mrb_value ary)
   return RARRAY_LEN(ary);
 }
 
-#if defined(__cplusplus)
-}  /* extern "C" { */
-#endif
+/** @} */
+MRB_END_DECL
 
 #endif  /* MRUBY_ARRAY_H */

--- a/include/mruby/array.h
+++ b/include/mruby/array.h
@@ -11,9 +11,8 @@
 
 /**
  * @file mruby/array.h
- * @brief Array class
- * @defgroup mrb_array MRuby Array class
- * @ingroup MRuby
+ * @defgroup mruby_array Array class
+ * @ingroup mruby
  * @{
  */
 MRB_BEGIN_DECL

--- a/include/mruby/class.h
+++ b/include/mruby/class.h
@@ -11,9 +11,8 @@
 
 /**
  * @file mruby/class.h
- * @brief Class class
- * @defgroup mrb_class MRuby Class class
- * @ingroup MRuby
+ * @defgroup mruby_class Class class
+ * @ingroup mruby
  * @{
  */
 MRB_BEGIN_DECL

--- a/include/mruby/class.h
+++ b/include/mruby/class.h
@@ -7,9 +7,16 @@
 #ifndef MRUBY_CLASS_H
 #define MRUBY_CLASS_H
 
-#if defined(__cplusplus)
-extern "C" {
-#endif
+#include "mruby/common.h"
+
+/**
+ * @file mruby/class.h
+ * @brief Class class
+ * @defgroup mrb_class MRuby Class class
+ * @ingroup MRuby
+ * @{
+ */
+MRB_BEGIN_DECL
 
 struct RClass {
   MRB_OBJECT_HEADER;
@@ -81,8 +88,7 @@ void mrb_gc_mark_mt(mrb_state*, struct RClass*);
 size_t mrb_gc_mark_mt_size(mrb_state*, struct RClass*);
 void mrb_gc_free_mt(mrb_state*, struct RClass*);
 
-#if defined(__cplusplus)
-}  /* extern "C" { */
-#endif
+/** @} */
+MRB_END_DECL
 
 #endif  /* MRUBY_CLASS_H */

--- a/include/mruby/common.h
+++ b/include/mruby/common.h
@@ -1,0 +1,35 @@
+/*
+** mruby/common.h - mruby common platform definitions
+**
+** See Copyright Notice in mruby.h
+*/
+
+#ifndef MRUBY_COMMON_H
+#define MRUBY_COMMON_H
+
+#ifdef __cplusplus
+/** Start declarations in C++ mode */
+#define MRB_BEGIN_DECL extern "C" {
+/** End declarations in C++ mode */
+#define MRB_END_DECL	}
+#else
+/** Start declarations in C mode */
+#define MRB_BEGIN_DECL /* empty */
+/** End declarations in C mode */
+#define MRB_END_DECL	/* empty */
+#endif
+
+
+#if defined(MRB_BUILD_AS_DLL)
+#if defined(MRB_CORE) || defined(MRB_LIB)
+#define MRB_API __declspec(dllexport)
+#else
+#define MRB_API __declspec(dllimport)
+#endif
+#else
+#define MRB_API extern
+#endif
+
+MRB_END_DECL
+
+#endif  /* MRUBY_COMMON_H */

--- a/include/mruby/common.h
+++ b/include/mruby/common.h
@@ -7,29 +7,62 @@
 #ifndef MRUBY_COMMON_H
 #define MRUBY_COMMON_H
 
+/**
+ * @file mruby/common.h
+ * @defgroup mruby_common Shared compiler macros
+ * @ingroup mruby
+ * @{
+ */
+
 #ifdef __cplusplus
-/** Start declarations in C++ mode */
-#define MRB_BEGIN_DECL extern "C" {
-/** End declarations in C++ mode */
-#define MRB_END_DECL	}
+# define MRB_BEGIN_DECL extern "C" {
+# define MRB_END_DECL	}
 #else
 /** Start declarations in C mode */
-#define MRB_BEGIN_DECL /* empty */
+# define MRB_BEGIN_DECL
 /** End declarations in C mode */
-#define MRB_END_DECL	/* empty */
+# define MRB_END_DECL
+#endif
+
+/** Declare a function that never returns. */
+#if __STDC_VERSION__ >= 201112L
+# define mrb_noreturn _Noreturn
+#elif defined __GNUC__ && !defined __STRICT_ANSI__
+# define mrb_noreturn __attribute__((noreturn))
+#elif defined _MSC_VER
+# define mrb_noreturn __declspec(noreturn)
+#else
+# define mrb_noreturn
+#endif
+
+/** Mark a function as deprecated. */
+#if defined __GNUC__ && !defined __STRICT_ANSI__
+# define mrb_deprecated __attribute__((deprecated))
+#elif defined _MSC_VER
+# define mrb_deprecated __declspec(deprecated)
+#else
+# define mrb_deprecated
+#endif
+
+/** Declare a function as always inlined. */
+#if defined(_MSC_VER)
+# define MRB_INLINE static __inline
+#else
+# define MRB_INLINE static inline
 #endif
 
 
+/** Declare a public MRuby API function. */
 #if defined(MRB_BUILD_AS_DLL)
 #if defined(MRB_CORE) || defined(MRB_LIB)
-#define MRB_API __declspec(dllexport)
+# define MRB_API __declspec(dllexport)
 #else
-#define MRB_API __declspec(dllimport)
+# define MRB_API __declspec(dllimport)
 #endif
 #else
-#define MRB_API extern
+# define MRB_API extern
 #endif
 
-MRB_END_DECL
+/** @} */
 
 #endif  /* MRUBY_COMMON_H */

--- a/include/mruby/compile.h
+++ b/include/mruby/compile.h
@@ -7,9 +7,16 @@
 #ifndef MRUBY_COMPILE_H
 #define MRUBY_COMPILE_H
 
-#if defined(__cplusplus)
-extern "C" {
-#endif
+#include "mruby/common.h"
+
+/**
+ * @file mruby/compile.h
+ * @brief MRuby compiler
+ * @defgroup mrb_compile MRuby compiler
+ * @ingroup MRuby
+ * @{
+ */
+MRB_BEGIN_DECL
 
 #include "mruby.h"
 
@@ -183,8 +190,7 @@ MRB_API mrb_value mrb_load_file_cxt(mrb_state*,FILE*, mrbc_context *cxt);
 MRB_API mrb_value mrb_load_string_cxt(mrb_state *mrb, const char *s, mrbc_context *cxt);
 MRB_API mrb_value mrb_load_nstring_cxt(mrb_state *mrb, const char *s, int len, mrbc_context *cxt);
 
-#if defined(__cplusplus)
-}  /* extern "C" { */
-#endif
+/** @} */
+MRB_END_DECL
 
 #endif /* MRUBY_COMPILE_H */

--- a/include/mruby/compile.h
+++ b/include/mruby/compile.h
@@ -11,9 +11,8 @@
 
 /**
  * @file mruby/compile.h
- * @brief MRuby compiler
- * @defgroup mrb_compile MRuby compiler
- * @ingroup MRuby
+ * @defgroup mruby_compile Compiler
+ * @ingroup mruby
  * @{
  */
 MRB_BEGIN_DECL

--- a/include/mruby/data.h
+++ b/include/mruby/data.h
@@ -7,9 +7,16 @@
 #ifndef MRUBY_DATA_H
 #define MRUBY_DATA_H
 
-#if defined(__cplusplus)
-extern "C" {
-#endif
+#include "mruby/common.h"
+
+/**
+ * @file mruby/data.h
+ * @brief User defined objects.
+ * @defgroup mrb_string MRuby User defined objects.
+ * @ingroup MRuby
+ * @{
+ */
+MRB_BEGIN_DECL
 
 typedef struct mrb_data_type {
   const char *struct_name;
@@ -59,8 +66,7 @@ mrb_data_init(mrb_value v, void *ptr, const mrb_data_type *type)
   DATA_TYPE(v) = type;
 }
 
-#if defined(__cplusplus)
-}  /* extern "C" { */
-#endif
+/** @} */
+MRB_END_DECL
 
 #endif /* MRUBY_DATA_H */

--- a/include/mruby/data.h
+++ b/include/mruby/data.h
@@ -11,9 +11,8 @@
 
 /**
  * @file mruby/data.h
- * @brief User defined objects.
- * @defgroup mrb_string MRuby User defined objects.
- * @ingroup MRuby
+ * @defgroup mruby_data User defined objects.
+ * @ingroup mruby
  * @{
  */
 MRB_BEGIN_DECL

--- a/include/mruby/data.h
+++ b/include/mruby/data.h
@@ -11,14 +11,23 @@
 
 /**
  * @file mruby/data.h
- * @defgroup mruby_data User defined objects.
+ * @defgroup mruby_data Custom C wrapped data.
+ *
+ * Defining Ruby wrappers around native objects.
+ *
  * @ingroup mruby
  * @{
  */
 MRB_BEGIN_DECL
 
+/**
+ * Custom data type description.
+ */
 typedef struct mrb_data_type {
+  /** data type name */
   const char *struct_name;
+
+  /** data type release function pointer */
   void (*dfree)(mrb_state *mrb, void*);
 } mrb_data_type;
 

--- a/include/mruby/debug.h
+++ b/include/mruby/debug.h
@@ -11,9 +11,8 @@
 
 /**
  * @file mruby/debug.h
- * @brief Debugging.
- * @defgroup mrb_string MRuby Debugging.
- * @ingroup MRuby
+ * @defgroup mruby_debug Debugging.
+ * @ingroup mruby
  * @{
  */
 MRB_BEGIN_DECL

--- a/include/mruby/debug.h
+++ b/include/mruby/debug.h
@@ -7,9 +7,16 @@
 #ifndef MRUBY_DEBUG_H
 #define MRUBY_DEBUG_H
 
-#if defined(__cplusplus)
-extern "C" {
-#endif
+#include "mruby/common.h"
+
+/**
+ * @file mruby/debug.h
+ * @brief Debugging.
+ * @defgroup mrb_string MRuby Debugging.
+ * @ingroup MRuby
+ * @{
+ */
+MRB_BEGIN_DECL
 
 typedef enum mrb_debug_line_type {
   mrb_debug_line_ary = 0,
@@ -58,8 +65,7 @@ MRB_API mrb_irep_debug_info_file *mrb_debug_info_append_file(
 MRB_API mrb_irep_debug_info *mrb_debug_info_alloc(mrb_state *mrb, mrb_irep *irep);
 MRB_API void mrb_debug_info_free(mrb_state *mrb, mrb_irep_debug_info *d);
 
-#if defined(__cplusplus)
-}  /* extern "C" { */
-#endif
+/** @} */
+MRB_END_DECL
 
 #endif /* MRUBY_DEBUG_H */

--- a/include/mruby/dump.h
+++ b/include/mruby/dump.h
@@ -7,12 +7,18 @@
 #ifndef MRUBY_DUMP_H
 #define MRUBY_DUMP_H
 
-#if defined(__cplusplus)
-extern "C" {
-#endif
-
 #include "mruby.h"
 #include "mruby/irep.h"
+#include "mruby/common.h"
+
+/**
+ * @file mruby/dump.h
+ * @brief Dumping compiled mruby script.
+ * @defgroup mrb_dump Dumping compiled mruby script.
+ * @ingroup MRuby
+ * @{
+ */
+MRB_BEGIN_DECL
 
 #define DUMP_DEBUG_INFO 1
 #define DUMP_ENDIAN_BIG 2
@@ -185,11 +191,10 @@ bin_to_uint8(const uint8_t *bin)
   return (uint8_t)bin[0];
 }
 
-#if defined(__cplusplus)
-}  /* extern "C" { */
-#endif
+/** @} */
+MRB_END_DECL
 
-/* crc.c */
+/** @internal crc.c */
 uint16_t
 calc_crc_16_ccitt(const uint8_t *src, size_t nbytes, uint16_t crc);
 

--- a/include/mruby/dump.h
+++ b/include/mruby/dump.h
@@ -13,9 +13,8 @@
 
 /**
  * @file mruby/dump.h
- * @brief Dumping compiled mruby script.
- * @defgroup mrb_dump Dumping compiled mruby script.
- * @ingroup MRuby
+ * @defgroup mruby_dump Dumping compiled mruby script.
+ * @ingroup mruby
  * @{
  */
 MRB_BEGIN_DECL

--- a/include/mruby/error.h
+++ b/include/mruby/error.h
@@ -11,9 +11,8 @@
 
 /**
  * @file mruby/error.h
- * @brief Error handling.
- * @defgroup mrb_error MRuby Error handling.
- * @ingroup MRuby
+ * @defgroup mruby_error Error handling.
+ * @ingroup mruby
  * @{
  */
 MRB_BEGIN_DECL

--- a/include/mruby/error.h
+++ b/include/mruby/error.h
@@ -7,9 +7,16 @@
 #ifndef MRUBY_ERROR_H
 #define MRUBY_ERROR_H
 
-#if defined(__cplusplus)
-extern "C" {
-#endif
+#include "mruby/common.h"
+
+/**
+ * @file mruby/error.h
+ * @brief Error handling.
+ * @defgroup mrb_error MRuby Error handling.
+ * @ingroup MRuby
+ * @{
+ */
+MRB_BEGIN_DECL
 
 struct RException {
   MRB_OBJECT_HEADER;
@@ -39,8 +46,7 @@ MRB_API mrb_value mrb_rescue_exceptions(mrb_state *mrb, mrb_func_t body, mrb_val
                                         mrb_func_t rescue, mrb_value r_data,
                                         mrb_int len, struct RClass **classes);
 
-#if defined(__cplusplus)
-}  /* extern "C" { */
-#endif
+/** @} */
+MRB_END_DECL
 
 #endif  /* MRUBY_ERROR_H */

--- a/include/mruby/gc.h
+++ b/include/mruby/gc.h
@@ -11,9 +11,8 @@
 
 /**
  * @file mruby/gc.h
- * @brief Uncommon memory management stuffs.
- * @defgroup mrb_gc MRuby garbage collection.
- * @ingroup MRuby
+ * @defgroup mruby_gc Uncommon memory management stuffs.
+ * @ingroup mruby
  * @{
  */
 MRB_BEGIN_DECL

--- a/include/mruby/gc.h
+++ b/include/mruby/gc.h
@@ -7,16 +7,22 @@
 #ifndef MRUBY_GC_H
 #define MRUBY_GC_H
 
-#if defined(__cplusplus)
-extern "C" {
-#endif
+#include "mruby/common.h"
+
+/**
+ * @file mruby/gc.h
+ * @brief Uncommon memory management stuffs.
+ * @defgroup mrb_gc MRuby garbage collection.
+ * @ingroup MRuby
+ * @{
+ */
+MRB_BEGIN_DECL
 
 typedef void (mrb_each_object_callback)(mrb_state *mrb, struct RBasic *obj, void *data);
 void mrb_objspace_each_objects(mrb_state *mrb, mrb_each_object_callback *callback, void *data);
 MRB_API void mrb_free_context(mrb_state *mrb, struct mrb_context *c);
 
-#if defined(__cplusplus)
-}  /* extern "C" { */
-#endif
+/** @} */
+MRB_END_DECL
 
 #endif  /* MRUBY_GC_H */

--- a/include/mruby/hash.h
+++ b/include/mruby/hash.h
@@ -7,9 +7,16 @@
 #ifndef MRUBY_HASH_H
 #define MRUBY_HASH_H
 
-#if defined(__cplusplus)
-extern "C" {
-#endif
+#include "mruby/common.h"
+
+/**
+ * @file mruby/hash.h
+ * @brief Hash class
+ * @defgroup mrb_hash MRuby Hash class
+ * @ingroup MRuby
+ * @{
+ */
+MRB_BEGIN_DECL
 
 struct RHash {
   MRB_OBJECT_HEADER;
@@ -47,8 +54,7 @@ void mrb_gc_mark_hash(mrb_state*, struct RHash*);
 size_t mrb_gc_mark_hash_size(mrb_state*, struct RHash*);
 void mrb_gc_free_hash(mrb_state*, struct RHash*);
 
-#if defined(__cplusplus)
-}  /* extern "C" { */
-#endif
+/** @} */
+MRB_END_DECL
 
 #endif  /* MRUBY_HASH_H */

--- a/include/mruby/hash.h
+++ b/include/mruby/hash.h
@@ -11,9 +11,8 @@
 
 /**
  * @file mruby/hash.h
- * @brief Hash class
- * @defgroup mrb_hash MRuby Hash class
- * @ingroup MRuby
+ * @defgroup mruby_hash Hash class
+ * @ingroup mruby
  * @{
  */
 MRB_BEGIN_DECL

--- a/include/mruby/irep.h
+++ b/include/mruby/irep.h
@@ -12,9 +12,8 @@
 
 /**
  * @file mruby/irep.h
- * @brief Compiled mruby script.
- * @defgroup mrb_irep Compiled mruby script.
- * @ingroup MRuby
+ * @defgroup mruby_irep Compiled mruby scripts.
+ * @ingroup mruby
  * @{
  */
 MRB_BEGIN_DECL

--- a/include/mruby/irep.h
+++ b/include/mruby/irep.h
@@ -7,11 +7,17 @@
 #ifndef MRUBY_IREP_H
 #define MRUBY_IREP_H
 
-#if defined(__cplusplus)
-extern "C" {
-#endif
-
+#include "mruby/common.h"
 #include "mruby/compile.h"
+
+/**
+ * @file mruby/irep.h
+ * @brief Compiled mruby script.
+ * @defgroup mrb_irep Compiled mruby script.
+ * @ingroup MRuby
+ * @{
+ */
+MRB_BEGIN_DECL
 
 enum irep_pool_type {
   IREP_TT_STRING,
@@ -53,8 +59,7 @@ void mrb_irep_free(mrb_state*, struct mrb_irep*);
 void mrb_irep_incref(mrb_state*, struct mrb_irep*);
 void mrb_irep_decref(mrb_state*, struct mrb_irep*);
 
-#if defined(__cplusplus)
-}  /* extern "C" { */
-#endif
+/** @} */
+MRB_END_DECL
 
 #endif  /* MRUBY_IREP_H */

--- a/include/mruby/khash.h
+++ b/include/mruby/khash.h
@@ -7,12 +7,19 @@
 #ifndef MRUBY_KHASH_H
 #define MRUBY_KHASH_H
 
-#if defined(__cplusplus)
-extern "C" {
-#endif
+#include <string.h>
 
 #include "mruby.h"
-#include <string.h>
+#include "mruby/common.h"
+
+/**
+ * @file mruby/khash.h
+ * @brief Defines of khash which is used in hash table of mruby.
+ * @defgroup mrb_khash Defines of khash which is used in hash table of mruby.
+ * @ingroup MRuby
+ * @{
+ */
+MRB_BEGIN_DECL
 
 typedef uint32_t khint_t;
 typedef khint_t khiter_t;
@@ -266,8 +273,7 @@ static inline khint_t __ac_X31_hash_string(const char *s)
 
 typedef const char *kh_cstr_t;
 
-#if defined(__cplusplus)
-}  /* extern "C" { */
-#endif
+/** @} */
+MRB_END_DECL
 
 #endif  /* MRUBY_KHASH_H */

--- a/include/mruby/khash.h
+++ b/include/mruby/khash.h
@@ -14,9 +14,8 @@
 
 /**
  * @file mruby/khash.h
- * @brief Defines of khash which is used in hash table of mruby.
- * @defgroup mrb_khash Defines of khash which is used in hash table of mruby.
- * @ingroup MRuby
+ * @defgroup mruby_khash khash definitions used in mruby's hash table.
+ * @ingroup mruby
  * @{
  */
 MRB_BEGIN_DECL

--- a/include/mruby/numeric.h
+++ b/include/mruby/numeric.h
@@ -7,9 +7,16 @@
 #ifndef MRUBY_NUMERIC_H
 #define MRUBY_NUMERIC_H
 
-#if defined(__cplusplus)
-extern "C" {
-#endif
+#include "mruby/common.h"
+
+/**
+ * @file mruby/numeric.h
+ * @brief Numeric class and sub-classes of it.
+ * @defgroup mrb_string Numeric class and sub-classes of it.
+ * @ingroup MRuby
+ * @{
+ */
+MRB_BEGIN_DECL
 
 #define POSFIXABLE(f) ((f) <= MRB_INT_MAX)
 #define NEGFIXABLE(f) ((f) >= MRB_INT_MIN)
@@ -104,8 +111,7 @@ mrb_int_sub_overflow(mrb_int minuend, mrb_int subtrahend, mrb_int *difference)
 #undef MRB_UINT_MAKE
 #undef MRB_UINT_MAKE2
 
-#if defined(__cplusplus)
-}  /* extern "C" { */
-#endif
+/** @} */
+MRB_END_DECL
 
 #endif  /* MRUBY_NUMERIC_H */

--- a/include/mruby/numeric.h
+++ b/include/mruby/numeric.h
@@ -11,9 +11,11 @@
 
 /**
  * @file mruby/numeric.h
- * @brief Numeric class and sub-classes of it.
- * @defgroup mrb_string Numeric class and sub-classes of it.
- * @ingroup MRuby
+ * @defgroup mruby_numeric Numeric class and it's sub-classes.
+ *
+ * Numeric, Integer, Float, Fixnum classes
+ *
+ * @ingroup mruby
  * @{
  */
 MRB_BEGIN_DECL

--- a/include/mruby/proc.h
+++ b/include/mruby/proc.h
@@ -7,11 +7,17 @@
 #ifndef MRUBY_PROC_H
 #define MRUBY_PROC_H
 
+#include "mruby/common.h"
 #include "mruby/irep.h"
 
-#if defined(__cplusplus)
-extern "C" {
-#endif
+/**
+ * @file mruby/proc.h
+ * @brief Proc class
+ * @defgroup mrb_proc MRuby Proc class
+ * @ingroup MRuby
+ * @{
+ */
+MRB_BEGIN_DECL
 
 struct REnv {
   MRB_OBJECT_HEADER;
@@ -69,8 +75,7 @@ MRB_API mrb_value mrb_proc_cfunc_env_get(mrb_state*, mrb_int);
 #include "mruby/khash.h"
 KHASH_DECLARE(mt, mrb_sym, struct RProc*, TRUE)
 
-#if defined(__cplusplus)
-}  /* extern "C" { */
-#endif
+/** @} */
+MRB_END_DECL
 
 #endif  /* MRUBY_PROC_H */

--- a/include/mruby/proc.h
+++ b/include/mruby/proc.h
@@ -12,9 +12,8 @@
 
 /**
  * @file mruby/proc.h
- * @brief Proc class
- * @defgroup mrb_proc MRuby Proc class
- * @ingroup MRuby
+ * @defgroup mruby_proc Proc class
+ * @ingroup mruby
  * @{
  */
 MRB_BEGIN_DECL

--- a/include/mruby/range.h
+++ b/include/mruby/range.h
@@ -11,9 +11,8 @@
 
 /**
  * @file mruby/range.h
- * @brief Range class
- * @defgroup mrb_range MRuby Range class
- * @ingroup MRuby
+ * @defgroup mruby_range Range class
+ * @ingroup mruby
  * @{
  */
 MRB_BEGIN_DECL

--- a/include/mruby/range.h
+++ b/include/mruby/range.h
@@ -7,9 +7,16 @@
 #ifndef MRUBY_RANGE_H
 #define MRUBY_RANGE_H
 
-#if defined(__cplusplus)
-extern "C" {
-#endif
+#include "mruby/common.h"
+
+/**
+ * @file mruby/range.h
+ * @brief Range class
+ * @defgroup mrb_range MRuby Range class
+ * @ingroup MRuby
+ * @{
+ */
+MRB_BEGIN_DECL
 
 typedef struct mrb_range_edges {
   mrb_value beg;
@@ -29,8 +36,7 @@ MRB_API mrb_value mrb_range_new(mrb_state*, mrb_value, mrb_value, mrb_bool);
 MRB_API mrb_bool mrb_range_beg_len(mrb_state *mrb, mrb_value range, mrb_int *begp, mrb_int *lenp, mrb_int len);
 mrb_value mrb_get_values_at(mrb_state *mrb, mrb_value obj, mrb_int olen, mrb_int argc, const mrb_value *argv, mrb_value (*func)(mrb_state*, mrb_value, mrb_int));
 
-#if defined(__cplusplus)
-}  /* extern "C" { */
-#endif
+/** @} */
+MRB_END_DECL
 
 #endif  /* MRUBY_RANGE_H */

--- a/include/mruby/string.h
+++ b/include/mruby/string.h
@@ -1,16 +1,22 @@
-/**
- * @header mruby/string.h
- * @copyright See Copyright Notice in mruby.h
- *
- * String class
- */
+/*
+** mruby/string.h - String class
+**
+** See Copyright Notice in mruby.h
+*/
 
 #ifndef MRUBY_STRING_H
 #define MRUBY_STRING_H
 
-#if defined(__cplusplus)
-extern "C" {
-#endif
+#include "mruby/common.h"
+
+/**
+ * @file mruby/string.h
+ * @brief String class
+ * @defgroup mrb_string MRuby String class
+ * @ingroup MRuby
+ * @{
+ */
+MRB_BEGIN_DECL
 
 extern const char mrb_digitmap[];
 
@@ -121,8 +127,7 @@ void mrb_regexp_check(mrb_state *mrb, mrb_value obj);
 #define mrb_str_buf_cat(mrb, str, ptr, len) mrb_str_cat(mrb, str, ptr, len)
 #define mrb_str_buf_append(mrb, str, str2) mrb_str_cat_str(mrb, str, str2)
 
-#if defined(__cplusplus)
-}  /* extern "C" { */
-#endif
+/** @} */
+MRB_END_DECL
 
 #endif  /* MRUBY_STRING_H */

--- a/include/mruby/string.h
+++ b/include/mruby/string.h
@@ -11,9 +11,8 @@
 
 /**
  * @file mruby/string.h
- * @brief String class
- * @defgroup mrb_string MRuby String class
- * @ingroup MRuby
+ * @defgroup mrb_string String class
+ * @ingroup mruby
  * @{
  */
 MRB_BEGIN_DECL

--- a/include/mruby/string.h
+++ b/include/mruby/string.h
@@ -1,8 +1,9 @@
-/*
-** mruby/string.h - String class
-**
-** See Copyright Notice in mruby.h
-*/
+/**
+ * @header mruby/string.h
+ * @copyright See Copyright Notice in mruby.h
+ *
+ * String class
+ */
 
 #ifndef MRUBY_STRING_H
 #define MRUBY_STRING_H
@@ -67,7 +68,7 @@ struct RString {
 #define RSTRING(s)           mrb_str_ptr(s)
 #define RSTRING_PTR(s)       RSTR_PTR(RSTRING(s))
 #define RSTRING_EMBED_LEN(s) RSTR_ENBED_LEN(RSTRING(s))
-#define RSTRING_LEN(s)       RSTR_LEN(RSTRING(s))  
+#define RSTRING_LEN(s)       RSTR_LEN(RSTRING(s))
 #define RSTRING_CAPA(s)      RSTR_CAPA(RSTRING(s))
 #define RSTRING_END(s)       (RSTRING_PTR(s) + RSTRING_LEN(s))
 mrb_int mrb_str_strlen(mrb_state*, struct RString*);

--- a/include/mruby/value.h
+++ b/include/mruby/value.h
@@ -7,6 +7,17 @@
 #ifndef MRUBY_VALUE_H
 #define MRUBY_VALUE_H
 
+#include "mruby/common.h"
+
+/**
+ * @file mruby/value.h
+ * @brief mrb_value functions and macros.
+ * @defgroup mrb_value mrb_value functions and macros.
+ * @ingroup MRuby
+ * @{
+ */
+MRB_BEGIN_DECL
+
 typedef uint32_t mrb_sym;
 typedef uint8_t mrb_bool;
 struct mrb_state;
@@ -225,5 +236,8 @@ mrb_ro_data_p(const char *p)
 #else
 # define mrb_ro_data_p(p) FALSE
 #endif
+
+/** @} */
+MRB_END_DECL
 
 #endif  /* MRUBY_VALUE_H */

--- a/include/mruby/value.h
+++ b/include/mruby/value.h
@@ -176,8 +176,14 @@ mrb_obj_value(void *p)
   return v;
 }
 
-static inline mrb_value
-mrb_nil_value(void)
+
+/**
+ * Get a nil mrb_value object.
+ *
+ * @return
+ *      nil mrb_value object reference.
+ */
+MRB_INLINE mrb_value mrb_nil_value(void)
 {
   mrb_value v;
   SET_NIL_VALUE(v);

--- a/include/mruby/value.h
+++ b/include/mruby/value.h
@@ -11,9 +11,11 @@
 
 /**
  * @file mruby/value.h
- * @brief mrb_value functions and macros.
- * @defgroup mrb_value mrb_value functions and macros.
- * @ingroup MRuby
+ * @defgroup mruby_value Value definitions
+ *
+ * @ref mrb_value functions and macros.
+ *
+ * @ingroup mruby
  * @{
  */
 MRB_BEGIN_DECL

--- a/include/mruby/variable.h
+++ b/include/mruby/variable.h
@@ -7,9 +7,16 @@
 #ifndef MRUBY_VARIABLE_H
 #define MRUBY_VARIABLE_H
 
-#if defined(__cplusplus)
-extern "C" {
-#endif
+#include "mruby/common.h"
+
+/**
+ * @file mruby/variable.h
+ * @brief Functions to access mruby variables.
+ * @defgroup mrb_variable Functions to access to mruby variables.
+ * @ingroup MRuby
+ * @{
+ */
+MRB_BEGIN_DECL
 
 typedef struct global_variable {
   int   counter;
@@ -74,8 +81,7 @@ void mrb_gc_mark_iv(mrb_state*, struct RObject*);
 size_t mrb_gc_mark_iv_size(mrb_state*, struct RObject*);
 void mrb_gc_free_iv(mrb_state*, struct RObject*);
 
-#if defined(__cplusplus)
-}  /* extern "C" { */
-#endif
+/** @} */
+MRB_END_DECL
 
 #endif  /* MRUBY_VARIABLE_H */

--- a/include/mruby/variable.h
+++ b/include/mruby/variable.h
@@ -11,9 +11,8 @@
 
 /**
  * @file mruby/variable.h
- * @brief Functions to access mruby variables.
- * @defgroup mrb_variable Functions to access to mruby variables.
- * @ingroup MRuby
+ * @defgroup mruby_variable Functions to access to mruby variables.
+ * @ingroup mruby
  * @{
  */
 MRB_BEGIN_DECL

--- a/include/mruby/version.h
+++ b/include/mruby/version.h
@@ -7,6 +7,17 @@
 #ifndef MRUBY_VERSION_H
 #define MRUBY_VERSION_H
 
+#include "mruby/common.h"
+
+/**
+ * @file mruby/version.h
+ * @brief MRuby version macros
+ * @defgroup mrb_string MRuby version macros
+ * @ingroup MRuby
+ * @{
+ */
+MRB_BEGIN_DECL
+
 #define MRB_STRINGIZE0(expr) #expr
 #define MRB_STRINGIZE(expr) MRB_STRINGIZE0(expr)
 
@@ -38,5 +49,8 @@
   MRB_STRINGIZE(MRUBY_BIRTH_YEAR)"-"   \
   MRB_STRINGIZE(MRUBY_RELEASE_YEAR)" " \
   MRUBY_AUTHOR                         \
+
+/** @} */
+MRB_END_DECL
 
 #endif  /* MRUBY_VERSION_H */


### PR DESCRIPTION
I started to work on documenting MRuby's C API.

While working on a gem project, I started to get locked quite often on "whats the function that does x?" moments so I started to document the methods I found on the process.

I noticed there are some methods already documented at [doc/api](https://github.com/mruby/mruby/tree/master/doc/api) but I believe it's better to have the API documented on the headers, so I've been taking those docs, and merging them into the headers as well.

I'm leaving this pull request to get some feedback before putting more effort into it.

Some of the things I've experimented with related with documenting MRuby's C API are:

* Generate a simple API website: the generated site is available right now at http://sagmor.com/mruby-c-api/ and its source at https://github.com/sagmor/mruby-c-api. eventually with a "c-api" repo it could be automated and live in `mruby.org/c-api` for example.
* Grabbed some macros like `MRB_API`, `mrb_deprecated` and moved them to `mruby/common.h`
* Add a couple macros `MRB_BEGIN_DECL` and `MRB_END_DECL` to get rid of those ugly `extern "C"` all over the headers.
* Replacing some `#define` aliases with inline function, this is just an experiment/proposal, they look more consistent while documenting (see [mrb_class_new_instance](http://sagmor.com/mruby-c-api/group__mruby.html#ga05117cc9d150df3921cdade39a74d59e))
* typedeffed [mrb_get_args](http://sagmor.com/mruby-c-api/group__mruby.html#ga6659ff35e634812fff48bb6a7f66730e) format string to document it separately (See [mrb_args_format](http://sagmor.com/mruby-c-api/group__mruby.html#gad46e8c7921f4ad0181f527670eeb1e27)

As I said, I'm leaving this here to see what you think of these approaches before putting more effort into them.