### PR TITLE
LinkerConfig is a struct with five params

### DIFF
--- a/tasks/mrbgem_spec.rake
+++ b/tasks/mrbgem_spec.rake
@@ -52,7 +52,7 @@ module MRuby
         MRuby::Build::COMMANDS.each do |command|
           instance_variable_set("@#{command}", @build.send(command).clone)
         end
-        @linker = LinkerConfig.new([], [], [], [])
+        @linker = LinkerConfig.new([], [], [], [], [])
 
         @rbfiles = Dir.glob("#{dir}/mrblib/**/*.rb").sort
         @objs = Dir.glob("#{dir}/src/*.{c,cpp,cxx,cc,m,asm,s,S}").map do |f|


### PR DESCRIPTION
Since `LinkerConfig` does not set the fifth param to `[]`, `spec.linker.flags_after_libraries` will be `nil` inside `mrbgem.rake` where as all the other attributes are set to `[]`.