### PR TITLE
fix String#inspect with MRB_UTF8_STRING

### DIFF
--- a/src/string.c
+++ b/src/string.c
@@ -2586,7 +2586,7 @@ mrb_str_inspect(mrb_state *mrb, mrb_value str)
         buf[i] = p[i];
       }
       mrb_str_cat(mrb, result, buf, clen);
-      p += clen;
+      p += clen-1;
       continue;
     }
 #endif


### PR DESCRIPTION
cf. #2963 

```
$ ./bin/mirb 
mirb - Embeddable Interactive Ruby Shell

> a = "あ"
 => "あ"
> a.inspect
 => "\"あ\""
> b = "あい"
 => "あい"
> b.inspect
 => "\"あい\""
```
