### PR TITLE
fix signature of mrb_class_new_instance()

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -285,7 +285,7 @@ MRB_API void mrb_undef_class_method(mrb_state*, struct RClass*, const char*);
 MRB_API mrb_value mrb_obj_new(mrb_state *mrb, struct RClass *c, mrb_int argc, const mrb_value *argv);
 
 /** See @ref mrb_obj_new */
-MRB_INLINE mrb_value mrb_class_new_instance(mrb_state *mrb, struct RClass *c, mrb_int argc, const mrb_value *argv) 
+MRB_INLINE mrb_value mrb_class_new_instance(mrb_state *mrb, mrb_int argc, const mrb_value *argv, struct RClass *c)
 {
   return mrb_obj_new(mrb,c,argc,argv);
 }


### PR DESCRIPTION
dd925578c604a608f83172f85d8e5bfc3bb99c6a changed the order of arguments,
but it doesn't seem intentional.

Some mrbgems are broken by this change.
https://github.com/search?l=c&q=mrb_class_new_instance&type=Code&utf8=%E2%9C%93