### PR TITLE
Add optional params to toolchain configuration

### DIFF
--- a/tasks/mruby_build.rake
+++ b/tasks/mruby_build.rake
@@ -26,8 +26,8 @@ module MRuby
       MRuby::Toolchain.toolchains[@name] = self
     end
 
-    def setup(conf)
-      conf.instance_eval(&@initializer)
+    def setup(conf,params={})
+      conf.instance_exec(conf, params, &@initializer)
     end
 
     def self.load
@@ -158,10 +158,10 @@ EOS
       @enable_bintest
     end
 
-    def toolchain(name)
+    def toolchain(name, params={})
       tc = Toolchain.toolchains[name.to_s]
       fail "Unknown #{name} toolchain" unless tc
-      tc.setup(self)
+      tc.setup(self, params)
       @toolchains.unshift name.to_s
     end
 


### PR DESCRIPTION
Here's a proposed implementation of part of the mechanism I explained in #2972.

I't basically adds an optional params argument to the `toolchain` method on `Build` objects.
That additional param is then passed to the Toolchain to be handled at will.

For example:

```ruby
# On build_config.rb I could do something like:
MRuby::CrossBuild.new('device') do |conf|
  toolchain :xcode, platform: 'iPhoneOS'
end
MRuby::CrossBuild.new('simulator') do |conf|
  toolchain :xcode, platform: 'iPhoneSimulator'
end

# And the toolchain might be defined as:
MRuby::Toolchain.new(:xcode) do |conf,params|
  toolchain :clang
  platform = params.fetch(:platform)
  # do something
end
```

I'm actually working on a couple toolchains using these structure, but I wanted to leave this here first.
