### PR TITLE
Update androidndk.rake to add support 64bit architectures.

### DIFF
--- a/tasks/toolchains/androidndk.rake
+++ b/tasks/toolchains/androidndk.rake
@@ -62,6 +62,8 @@ Set ANDROID_NDK_HOME environment variable or set :ndk_home parameter
           'mips64el-linux-android-*'
         when /mips/
           'mipsel-linux-android-*'
+        when /x86_64/
+          'x86_64-*'
         when /x86/
           'x86-*'
         end
@@ -80,6 +82,7 @@ Set ANDROID_NDK_HOME environment variable or set :ndk_home parameter
                case arch
                when /armeabi/ then 'arm-linux-androideabi-'
                when /arm64/   then 'aarch64-linux-android-'
+               when /x86_64/  then 'x86_64-'
                when /x86/     then 'x86-'
                when /mips64/  then 'mips64el-linux-android-'
                when /mips/    then 'mipsel-linux-android-'
@@ -92,6 +95,7 @@ Set ANDROID_NDK_HOME environment variable or set :ndk_home parameter
     path = case arch
            when /armeabi/ then 'arch-arm'
            when /arm64/   then 'arch-arm64'
+           when /x86_64/  then 'arch-x86_64'
            when /x86/     then 'arch-x86'
            when /mips64/  then 'arch-mips64'
            when /mips/    then 'arch-mips'
@@ -107,6 +111,7 @@ Set ANDROID_NDK_HOME environment variable or set :ndk_home parameter
       command = case arch
                 when /armeabi/ then 'arm-linux-androideabi-'
                 when /arm64/   then 'aarch64-linux-android-'
+                when /x86_64/  then 'x86_64-linux-android-'
                 when /x86/     then 'i686-linux-android-'
                 when /mips64/  then 'mips64el-linux-android-'
                 when /mips/    then 'mipsel-linux-android-'
@@ -143,6 +148,8 @@ Set ANDROID_NDK_HOME environment variable or set :ndk_home parameter
         flags += %W(-fpic -fno-strict-aliasing -finline-functions -fmessage-length=0 -fno-inline-functions-called-once -fgcse-after-reload -frerun-cse-after-loop -frename-registers -no-canonical-prefixes)
       when /mips/
         flags += %W(-fpic -fno-strict-aliasing -finline-functions -fmessage-length=0 -fno-inline-functions-called-once -fgcse-after-reload -frerun-cse-after-loop -frename-registers)
+      when /x86_64/
+        flags += %W(-fstack-protector-strong -no-canonical-prefixes)
       when /x86/
         flags += %W(-no-canonical-prefixes)
       end

--- a/tasks/toolchains/androidndk.rake
+++ b/tasks/toolchains/androidndk.rake
@@ -172,7 +172,7 @@ Set ANDROID_NDK_HOME environment variable or set :ndk_home parameter
       when /arm64/
         flags += %W(-no-canonical-prefixes)
       when /armeabi/
-        flags += %W() #add required flags
+        flags += %W(-no-canonical-prefixes)
       when /mips64/
         flags += %W() #add required flags
       when /mips/

--- a/tasks/toolchains/androidndk.rake
+++ b/tasks/toolchains/androidndk.rake
@@ -178,7 +178,7 @@ Set ANDROID_NDK_HOME environment variable or set :ndk_home parameter
       when /armeabi/
         flags += %W(-no-canonical-prefixes)
       when /mips64/
-        flags += %W() #add required flags
+        flags += %W(-no-canonical-prefixes)
       when /mips/
         flags += %W() #add required flags
       when /x86_64/

--- a/tasks/toolchains/androidndk.rake
+++ b/tasks/toolchains/androidndk.rake
@@ -133,6 +133,8 @@ Set ANDROID_NDK_HOME environment variable or set :ndk_home parameter
       case arch
       when /arm64/
         flags += %W(-fpic -ffunction-sections -funwind-tables -fstack-protector-strong -no-canonical-prefixes)
+      when 'armeabi-v7a-hard'
+        flags += %W(-fpic -ffunction-sections -funwind-tables -fstack-protector-strong -no-canonical-prefixes -march=armv7-a -mhard-float -D_NDK_MATH_NO_SOFTFP=1 -mfpu=vfpv3-d16)
       when 'armeabi-v7a'
         flags += %W(-fpic -ffunction-sections -funwind-tables -fstack-protector-strong -no-canonical-prefixes -march=armv7-a -mfloat-abi=softfp -mfpu=vfpv3-d16)
       when /arm/

--- a/tasks/toolchains/androidndk.rake
+++ b/tasks/toolchains/androidndk.rake
@@ -60,6 +60,8 @@ Set ANDROID_NDK_HOME environment variable or set :ndk_home parameter
           'aarch64-linux-android-*'
         when /mips/
           'mipsel-linux-android-*'
+        when /x86/
+          'x86-*'
         end
       when :clang
         'llvm-*'

--- a/tasks/toolchains/androidndk.rake
+++ b/tasks/toolchains/androidndk.rake
@@ -134,9 +134,9 @@ Set ANDROID_NDK_HOME environment variable or set :ndk_home parameter
       when /arm64/
         flags += %W(-fpic -ffunction-sections -funwind-tables -fstack-protector-strong -no-canonical-prefixes)
       when 'armeabi-v7a'
-        flags += %W(-march=armv7-a -mfloat-abi=softfp -mfpu=vfpv3-d16)
+        flags += %W(-fpic -ffunction-sections -funwind-tables -fstack-protector-strong -no-canonical-prefixes -march=armv7-a -mfloat-abi=softfp -mfpu=vfpv3-d16)
       when /arm/
-        flags += %W(-march=armv5te -mtune=xscale -msoft-float)
+        flags += %W(-fpic -ffunction-sections -funwind-tables -fstack-protector-strong -no-canonical-prefixes -march=armv5te -mtune=xscale -msoft-float)
       when /mips64/
         flags += %W(-fpic -fno-strict-aliasing -finline-functions -ffunction-sections -funwind-tables -fmessage-length=0 -fno-inline-functions-called-once -fgcse-after-reload -frerun-cse-after-loop -frename-registers -no-canonical-prefixes)
       when /mips/

--- a/tasks/toolchains/androidndk.rake
+++ b/tasks/toolchains/androidndk.rake
@@ -131,8 +131,8 @@ Set ANDROID_NDK_HOME environment variable or set :ndk_home parameter
       flags += %W(-ffunction-sections -funwind-tables -fstack-protector)
       flags += %W(-D__android__ -mandroid --sysroot="#{sysroot}")
       case arch
-	  when /arm64/
-	    flags += %W()
+      when /arm64/
+        flags += %W()
       when 'armeabi-v7a'
         flags += %W(-march=armv7-a -mfloat-abi=softfp -mfpu=vfpv3-d16)
       when /arm/

--- a/tasks/toolchains/androidndk.rake
+++ b/tasks/toolchains/androidndk.rake
@@ -144,12 +144,8 @@ Set ANDROID_NDK_HOME environment variable or set :ndk_home parameter
         flags += %W(-fpic -fstack-protector-strong -march=armv7-a -mfloat-abi=softfp -mfpu=vfpv3-d16)
       when /arm/
         flags += %W(-fpic -fstack-protector-strong -march=armv5te -mtune=xscale -msoft-float)
-      when /mips64/
-        flags += %W(-fpic -fno-strict-aliasing -finline-functions -fmessage-length=0 -fno-inline-functions-called-once -fgcse-after-reload -frerun-cse-after-loop -frename-registers)
       when /mips/
         flags += %W(-fpic -fno-strict-aliasing -finline-functions -fmessage-length=0 -fno-inline-functions-called-once -fgcse-after-reload -frerun-cse-after-loop -frename-registers)
-      when /x86_64/
-        flags += %W(-fstack-protector-strong)
       when /x86/
         flags += %W(-fstack-protector-strong)
       end

--- a/tasks/toolchains/androidndk.rake
+++ b/tasks/toolchains/androidndk.rake
@@ -53,7 +53,12 @@ Set ANDROID_NDK_HOME environment variable or set :ndk_home parameter
     params.fetch(:toolchain_version) do
       test = case toolchain
       when :gcc
-        'arm-linux-androideabi-*'
+        case arch
+        when /armeabi/
+          'arm-linux-androideabi-*'
+        when /arm64/
+          'aarch64-linux-android-*'
+        end
       when :clang
         'llvm-*'
       end
@@ -67,9 +72,10 @@ Set ANDROID_NDK_HOME environment variable or set :ndk_home parameter
              when :clang then 'llvm-'
              when :gcc
                case arch
-               when /arm/  then 'arm-linux-androideabi-'
-               when /x86/  then 'x86-'
-               when /mips/ then 'mipsel-linux-android-'
+               when /armeabi/ then 'arm-linux-androideabi-'
+               when /arm64/   then 'aarch64-linux-android-'
+               when /x86/     then 'x86-'
+               when /mips/    then 'mipsel-linux-android-'
                end
              end
     home_path.join('toolchains', prefix + toolchain_version.to_s, 'prebuilt', host_platform)
@@ -77,9 +83,10 @@ Set ANDROID_NDK_HOME environment variable or set :ndk_home parameter
 
   def sysroot
     path = case arch
-           when /arm/  then 'arch-arm'
-           when /x86/  then 'arch-x86'
-           when /mips/ then 'arch-mips'
+           when /armeabi/ then 'arch-arm'
+           when /arm64/   then 'arch-arm64'
+           when /x86/     then 'arch-x86'
+           when /mips/    then 'arch-mips'
            end
 
     home_path.join('platforms', platform, path).to_s
@@ -90,9 +97,10 @@ Set ANDROID_NDK_HOME environment variable or set :ndk_home parameter
 
     if toolchain == :gcc
       command = case arch
-                when /arm/  then 'arm-linux-androideabi-'
-                when /x86/  then 'i686-linux-android-'
-                when /mips/ then 'mipsel-linux-android-'
+                when /armeabi/ then 'arm-linux-androideabi-'
+                when /arm64/   then 'aarch64-linux-android-'
+                when /x86/     then 'i686-linux-android-'
+                when /mips/    then 'mipsel-linux-android-'
                 end + command
     end
 
@@ -114,6 +122,8 @@ Set ANDROID_NDK_HOME environment variable or set :ndk_home parameter
       flags += %W(-ffunction-sections -funwind-tables -fstack-protector)
       flags += %W(-D__android__ -mandroid --sysroot="#{sysroot}")
       case arch
+	  when /arm64/
+	    flags += %W()
       when 'armeabi-v7a'
         flags += %W(-march=armv7-a -mfloat-abi=softfp -mfpu=vfpv3-d16)
       when /arm/

--- a/tasks/toolchains/androidndk.rake
+++ b/tasks/toolchains/androidndk.rake
@@ -58,6 +58,8 @@ Set ANDROID_NDK_HOME environment variable or set :ndk_home parameter
           'arm-linux-androideabi-*'
         when /arm64/
           'aarch64-linux-android-*'
+        when /mips64/
+          'mips64el-linux-android-*'
         when /mips/
           'mipsel-linux-android-*'
         when /x86/
@@ -79,6 +81,7 @@ Set ANDROID_NDK_HOME environment variable or set :ndk_home parameter
                when /armeabi/ then 'arm-linux-androideabi-'
                when /arm64/   then 'aarch64-linux-android-'
                when /x86/     then 'x86-'
+               when /mips64/  then 'mips64el-linux-android-'
                when /mips/    then 'mipsel-linux-android-'
                end
              end
@@ -90,6 +93,7 @@ Set ANDROID_NDK_HOME environment variable or set :ndk_home parameter
            when /armeabi/ then 'arch-arm'
            when /arm64/   then 'arch-arm64'
            when /x86/     then 'arch-x86'
+           when /mips64/  then 'arch-mips64'
            when /mips/    then 'arch-mips'
            end
 
@@ -104,6 +108,7 @@ Set ANDROID_NDK_HOME environment variable or set :ndk_home parameter
                 when /armeabi/ then 'arm-linux-androideabi-'
                 when /arm64/   then 'aarch64-linux-android-'
                 when /x86/     then 'i686-linux-android-'
+                when /mips64/  then 'mips64el-linux-android-'
                 when /mips/    then 'mipsel-linux-android-'
                 end + command
     end
@@ -132,6 +137,8 @@ Set ANDROID_NDK_HOME environment variable or set :ndk_home parameter
         flags += %W(-march=armv7-a -mfloat-abi=softfp -mfpu=vfpv3-d16)
       when /arm/
         flags += %W(-march=armv5te -mtune=xscale -msoft-float)
+      when /mips64/
+        flags += %W(-fpic -fno-strict-aliasing -finline-functions -ffunction-sections -funwind-tables -fmessage-length=0 -fno-inline-functions-called-once -fgcse-after-reload -frerun-cse-after-loop -frename-registers -no-canonical-prefixes)
       when /mips/
         flags += %W(-fpic -fno-strict-aliasing -finline-functions -fmessage-length=0 -fno-inline-functions-called-once -fgcse-after-reload -frerun-cse-after-loop -frename-registers)
       end

--- a/tasks/toolchains/androidndk.rake
+++ b/tasks/toolchains/androidndk.rake
@@ -170,7 +170,7 @@ Set ANDROID_NDK_HOME environment variable or set :ndk_home parameter
       flags = %W(-D__android__ -mandroid --sysroot="#{sysroot}")
       case arch
       when /arm64/
-        flags += %W() #add required flags
+        flags += %W(-no-canonical-prefixes)
       when /armeabi/
         flags += %W() #add required flags
       when /mips64/

--- a/tasks/toolchains/androidndk.rake
+++ b/tasks/toolchains/androidndk.rake
@@ -164,7 +164,25 @@ Set ANDROID_NDK_HOME environment variable or set :ndk_home parameter
   end
 
   def ldflags
-    %W(-D__android__ -mandroid --sysroot="#{sysroot}")
+    flags = []
+    case toolchain
+    when :gcc
+      flags = %W(-D__android__ -mandroid --sysroot="#{sysroot}")
+      case arch
+      when /arm64/
+        flags += %W() #add required flags
+      when /armeabi/
+        flags += %W() #add required flags
+      when /mips64/
+        flags += %W() #add required flags
+      when /mips/
+        flags += %W() #add required flags
+      when /x86_64/
+        flags += %W() #add required flags
+      when /x86/
+        flags += %W() #add required flags
+      end
+    end
   end
 
   def ar

--- a/tasks/toolchains/androidndk.rake
+++ b/tasks/toolchains/androidndk.rake
@@ -143,6 +143,8 @@ Set ANDROID_NDK_HOME environment variable or set :ndk_home parameter
         flags += %W(-fpic -fno-strict-aliasing -finline-functions -ffunction-sections -funwind-tables -fmessage-length=0 -fno-inline-functions-called-once -fgcse-after-reload -frerun-cse-after-loop -frename-registers -no-canonical-prefixes)
       when /mips/
         flags += %W(-fpic -fno-strict-aliasing -finline-functions -fmessage-length=0 -fno-inline-functions-called-once -fgcse-after-reload -frerun-cse-after-loop -frename-registers)
+      when /x86/
+        flags += %W(-ffunction-sections -funwind-tables -no-canonical-prefixes)
       end
     when :clang
     end

--- a/tasks/toolchains/androidndk.rake
+++ b/tasks/toolchains/androidndk.rake
@@ -184,7 +184,7 @@ Set ANDROID_NDK_HOME environment variable or set :ndk_home parameter
       when /x86_64/
         flags += %W(-no-canonical-prefixes)
       when /x86/
-        flags += %W() #add required flags
+        flags += %W(-no-canonical-prefixes)
       end
     end
   end

--- a/tasks/toolchains/androidndk.rake
+++ b/tasks/toolchains/androidndk.rake
@@ -133,25 +133,25 @@ Set ANDROID_NDK_HOME environment variable or set :ndk_home parameter
 
     case toolchain
     when :gcc
-      flags += %W(-ffunction-sections -funwind-tables)
+      flags += %W(-ffunction-sections -funwind-tables -no-canonical-prefixes)
       flags += %W(-D__android__ -mandroid --sysroot="#{sysroot}")
       case arch
       when /arm64/
-        flags += %W(-fpic -fstack-protector-strong -no-canonical-prefixes)
+        flags += %W(-fpic -fstack-protector-strong)
       when 'armeabi-v7a-hard'
-        flags += %W(-fpic -fstack-protector-strong -no-canonical-prefixes -march=armv7-a -mhard-float -D_NDK_MATH_NO_SOFTFP=1 -mfpu=vfpv3-d16)
+        flags += %W(-fpic -fstack-protector-strong -march=armv7-a -mhard-float -D_NDK_MATH_NO_SOFTFP=1 -mfpu=vfpv3-d16)
       when 'armeabi-v7a'
-        flags += %W(-fpic -fstack-protector-strong -no-canonical-prefixes -march=armv7-a -mfloat-abi=softfp -mfpu=vfpv3-d16)
+        flags += %W(-fpic -fstack-protector-strong -march=armv7-a -mfloat-abi=softfp -mfpu=vfpv3-d16)
       when /arm/
-        flags += %W(-fpic -fstack-protector-strong -no-canonical-prefixes -march=armv5te -mtune=xscale -msoft-float)
+        flags += %W(-fpic -fstack-protector-strong -march=armv5te -mtune=xscale -msoft-float)
       when /mips64/
-        flags += %W(-fpic -fno-strict-aliasing -finline-functions -fmessage-length=0 -fno-inline-functions-called-once -fgcse-after-reload -frerun-cse-after-loop -frename-registers -no-canonical-prefixes)
+        flags += %W(-fpic -fno-strict-aliasing -finline-functions -fmessage-length=0 -fno-inline-functions-called-once -fgcse-after-reload -frerun-cse-after-loop -frename-registers)
       when /mips/
         flags += %W(-fpic -fno-strict-aliasing -finline-functions -fmessage-length=0 -fno-inline-functions-called-once -fgcse-after-reload -frerun-cse-after-loop -frename-registers)
       when /x86_64/
-        flags += %W(-fstack-protector-strong -no-canonical-prefixes)
+        flags += %W(-fstack-protector-strong)
       when /x86/
-        flags += %W(-fstack-protector-strong -no-canonical-prefixes)
+        flags += %W(-fstack-protector-strong)
       end
     when :clang
     end

--- a/tasks/toolchains/androidndk.rake
+++ b/tasks/toolchains/androidndk.rake
@@ -180,7 +180,7 @@ Set ANDROID_NDK_HOME environment variable or set :ndk_home parameter
       when /mips64/
         flags += %W(-no-canonical-prefixes)
       when /mips/
-        flags += %W() #add required flags
+        flags += %W(-no-canonical-prefixes)
       when /x86_64/
         flags += %W() #add required flags
       when /x86/

--- a/tasks/toolchains/androidndk.rake
+++ b/tasks/toolchains/androidndk.rake
@@ -167,24 +167,12 @@ Set ANDROID_NDK_HOME environment variable or set :ndk_home parameter
     flags = []
     case toolchain
     when :gcc
-      flags = %W(-D__android__ -mandroid --sysroot="#{sysroot}")
+      flags = %W(-D__android__ -mandroid --sysroot="#{sysroot}" -no-canonical-prefixes)
       case arch
-      when /arm64/
-        flags += %W(-no-canonical-prefixes)
       when 'armeabi-v7a-hard'
-        flags += %W(-no-canonical-prefixes -march=armv7-a -Wl,--fix-cortex-a8 -Wl,--no-warn-mismatch -lm_hard)
+        flags += %W(-march=armv7-a -Wl,--fix-cortex-a8 -Wl,--no-warn-mismatch -lm_hard)
       when 'armeabi-v7a'
-        flags += %W(-no-canonical-prefixes -march=armv7-a -Wl,--fix-cortex-a8)
-      when /armeabi/
-        flags += %W(-no-canonical-prefixes)
-      when /mips64/
-        flags += %W(-no-canonical-prefixes)
-      when /mips/
-        flags += %W(-no-canonical-prefixes)
-      when /x86_64/
-        flags += %W(-no-canonical-prefixes)
-      when /x86/
-        flags += %W(-no-canonical-prefixes)
+        flags += %W(-march=armv7-a -Wl,--fix-cortex-a8)
       end
     end
   end

--- a/tasks/toolchains/androidndk.rake
+++ b/tasks/toolchains/androidndk.rake
@@ -132,7 +132,7 @@ Set ANDROID_NDK_HOME environment variable or set :ndk_home parameter
       flags += %W(-D__android__ -mandroid --sysroot="#{sysroot}")
       case arch
       when /arm64/
-        flags += %W()
+        flags += %W(-fpic -ffunction-sections -funwind-tables -fstack-protector-strong -no-canonical-prefixes)
       when 'armeabi-v7a'
         flags += %W(-march=armv7-a -mfloat-abi=softfp -mfpu=vfpv3-d16)
       when /arm/

--- a/tasks/toolchains/androidndk.rake
+++ b/tasks/toolchains/androidndk.rake
@@ -171,6 +171,10 @@ Set ANDROID_NDK_HOME environment variable or set :ndk_home parameter
       case arch
       when /arm64/
         flags += %W(-no-canonical-prefixes)
+      when 'armeabi-v7a-hard'
+        flags += %W(-no-canonical-prefixes -march=armv7-a -Wl,--fix-cortex-a8 -Wl,--no-warn-mismatch -lm_hard)
+      when 'armeabi-v7a'
+        flags += %W(-no-canonical-prefixes -march=armv7-a -Wl,--fix-cortex-a8)
       when /armeabi/
         flags += %W(-no-canonical-prefixes)
       when /mips64/

--- a/tasks/toolchains/androidndk.rake
+++ b/tasks/toolchains/androidndk.rake
@@ -58,6 +58,8 @@ Set ANDROID_NDK_HOME environment variable or set :ndk_home parameter
           'arm-linux-androideabi-*'
         when /arm64/
           'aarch64-linux-android-*'
+        when /mips/
+          'mipsel-linux-android-*'
         end
       when :clang
         'llvm-*'

--- a/tasks/toolchains/androidndk.rake
+++ b/tasks/toolchains/androidndk.rake
@@ -182,7 +182,7 @@ Set ANDROID_NDK_HOME environment variable or set :ndk_home parameter
       when /mips/
         flags += %W(-no-canonical-prefixes)
       when /x86_64/
-        flags += %W() #add required flags
+        flags += %W(-no-canonical-prefixes)
       when /x86/
         flags += %W() #add required flags
       end

--- a/tasks/toolchains/androidndk.rake
+++ b/tasks/toolchains/androidndk.rake
@@ -128,23 +128,23 @@ Set ANDROID_NDK_HOME environment variable or set :ndk_home parameter
 
     case toolchain
     when :gcc
-      flags += %W(-ffunction-sections -funwind-tables -fstack-protector)
+      flags += %W(-ffunction-sections -funwind-tables)
       flags += %W(-D__android__ -mandroid --sysroot="#{sysroot}")
       case arch
       when /arm64/
-        flags += %W(-fpic -ffunction-sections -funwind-tables -fstack-protector-strong -no-canonical-prefixes)
+        flags += %W(-fpic -fstack-protector-strong -no-canonical-prefixes)
       when 'armeabi-v7a-hard'
-        flags += %W(-fpic -ffunction-sections -funwind-tables -fstack-protector-strong -no-canonical-prefixes -march=armv7-a -mhard-float -D_NDK_MATH_NO_SOFTFP=1 -mfpu=vfpv3-d16)
+        flags += %W(-fpic -fstack-protector-strong -no-canonical-prefixes -march=armv7-a -mhard-float -D_NDK_MATH_NO_SOFTFP=1 -mfpu=vfpv3-d16)
       when 'armeabi-v7a'
-        flags += %W(-fpic -ffunction-sections -funwind-tables -fstack-protector-strong -no-canonical-prefixes -march=armv7-a -mfloat-abi=softfp -mfpu=vfpv3-d16)
+        flags += %W(-fpic -fstack-protector-strong -no-canonical-prefixes -march=armv7-a -mfloat-abi=softfp -mfpu=vfpv3-d16)
       when /arm/
-        flags += %W(-fpic -ffunction-sections -funwind-tables -fstack-protector-strong -no-canonical-prefixes -march=armv5te -mtune=xscale -msoft-float)
+        flags += %W(-fpic -fstack-protector-strong -no-canonical-prefixes -march=armv5te -mtune=xscale -msoft-float)
       when /mips64/
-        flags += %W(-fpic -fno-strict-aliasing -finline-functions -ffunction-sections -funwind-tables -fmessage-length=0 -fno-inline-functions-called-once -fgcse-after-reload -frerun-cse-after-loop -frename-registers -no-canonical-prefixes)
+        flags += %W(-fpic -fno-strict-aliasing -finline-functions -fmessage-length=0 -fno-inline-functions-called-once -fgcse-after-reload -frerun-cse-after-loop -frename-registers -no-canonical-prefixes)
       when /mips/
         flags += %W(-fpic -fno-strict-aliasing -finline-functions -fmessage-length=0 -fno-inline-functions-called-once -fgcse-after-reload -frerun-cse-after-loop -frename-registers)
       when /x86/
-        flags += %W(-ffunction-sections -funwind-tables -no-canonical-prefixes)
+        flags += %W(-no-canonical-prefixes)
       end
     when :clang
     end

--- a/tasks/toolchains/androidndk.rake
+++ b/tasks/toolchains/androidndk.rake
@@ -163,7 +163,8 @@ Set ANDROID_NDK_HOME environment variable or set :ndk_home parameter
     flags = []
     case toolchain
     when :gcc
-      flags = %W(-D__android__ -mandroid --sysroot="#{sysroot}" -no-canonical-prefixes)
+      flags += %W(-no-canonical-prefixes)
+      flags += %W(-D__android__ -mandroid --sysroot="#{sysroot}")
       case arch
       when 'armeabi-v7a-hard'
         flags += %W(-march=armv7-a -Wl,--fix-cortex-a8 -Wl,--no-warn-mismatch -lm_hard)

--- a/tasks/toolchains/androidndk.rake
+++ b/tasks/toolchains/androidndk.rake
@@ -151,7 +151,7 @@ Set ANDROID_NDK_HOME environment variable or set :ndk_home parameter
       when /x86_64/
         flags += %W(-fstack-protector-strong -no-canonical-prefixes)
       when /x86/
-        flags += %W(-no-canonical-prefixes)
+        flags += %W(-fstack-protector-strong -no-canonical-prefixes)
       end
     when :clang
     end


### PR DESCRIPTION
To support 64bit architectures (arm64, mips64 and x86_64), androidndk.rake have to be modified.
We can build libmruby.a for 64bit architecture like below:

```Ruby
# add codes below into your build_config.rb
MRuby::CrossBuild.new('android-arm64') do |conf|
  toolchain :androidndk, arch: 'arm64', platform: 'android-21' # 'android-19' or before cannot be used to build for 64bit architecture
end
```