### PR TITLE
Rename androidndk tolchain to just android

### DIFF
--- a/tasks/toolchains/android.rake
+++ b/tasks/toolchains/android.rake
@@ -1,5 +1,4 @@
-
-class MRuby::Toolchain::AndroidNDK
+class MRuby::Toolchain::Android
   DEFAULT_ARCH = 'armeabi'
   DEFAULT_PLATFORM = 'android-14'
   DEFAULT_TOOLCHAIN = :gcc
@@ -199,8 +198,8 @@ Set ANDROID_NDK_HOME environment variable or set :ndk_home parameter
   end
 end
 
-MRuby::Toolchain.new(:androidndk) do |conf, params|
-  ndk = MRuby::Toolchain::AndroidNDK.new(params)
+MRuby::Toolchain.new(:android) do |conf, params|
+  ndk = MRuby::Toolchain::Android.new(params)
 
   toolchain ndk.toolchain
 


### PR DESCRIPTION
As discussed in #2983 I renamed the `AndroidNDK` class to just `Android` and the  toolchain from `:androidndk` to just `:android` too.