### PR TITLE
remove return

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -1425,7 +1425,7 @@ gc_each_objects(mrb_state *mrb, mrb_gc *gc, mrb_each_object_callback *callback, 
 void
 mrb_objspace_each_objects(mrb_state *mrb, mrb_each_object_callback *callback, void *data)
 {
-  return gc_each_objects(mrb, &mrb->gc, callback, data);
+  gc_each_objects(mrb, &mrb->gc, callback, data);
 }
 
 #ifdef GC_TEST


### PR DESCRIPTION
The return type of the `mrb_objspace_each_objects` function is `void`. So this return statement with an expression is unnecessary and also violates a constraint. From C99 §6.8.6.4:
>A return statement with an expression shall not appear in a function whose return type is void.