### PR TITLE
fix ambiguous first argument warning

### DIFF
--- a/test/t/float.rb
+++ b/test/t/float.rb
@@ -198,5 +198,5 @@ assert('Float#>>') do
   assert_equal 0, 23.0 >> 128
 
   # Don't raise on large Right Shift
-  assert_equal -1, -23.0 >> 128
+  assert_equal(-1, -23.0 >> 128)
 end


### PR DESCRIPTION
>/home/travis/build/mruby/mruby/test/t/float.rb:201:17: ambiguous first argument; put parentheses or even spaces