### PR TITLE
fail to debuild

### DIFF
--- a/test/bintest.rb
+++ b/test/bintest.rb
@@ -2,11 +2,21 @@ $:.unshift File.dirname(File.dirname(File.expand_path(__FILE__)))
 require 'test/assert.rb'
 
 def cmd(s)
-  ENV['SHELL'] ? "bin/#{s}" : "bin\\#{s}.exe"
+  case RbConfig::CONFIG['host_os']
+  when /mswin(?!ce)|mingw|cygwin|bccwin/
+    "bin\\#{s}.exe"
+  else
+    "bin/#{s}"
+  end
 end
 
 def shellquote(s)
-  ENV['SHELL'] ? "'#{s}'" : "\"#{s}\""
+  case RbConfig::CONFIG['host_os']
+  when /mswin(?!ce)|mingw|cygwin|bccwin/
+    "\"#{s}\""
+  else
+    "'#{s}'"
+  end
 end
 
 ARGV.each do |gem|


### PR DESCRIPTION
Fail to debian package build.
Because not define $SHELL environment variable at debian build tool.

More Info : https://github.com/mruby-debian/mruby/issues/1