### PR TITLE
This patch changes git gem behavior to never pull gems unless specified.

### DIFF
--- a/tasks/mruby_build_gem.rake
+++ b/tasks/mruby_build_gem.rake
@@ -106,7 +106,7 @@ module MRuby
           git.run_checkout gemdir, params[:checksum_hash]
         else
           # Jump to the top of the branch
-          git.run_checkout gemdir, branch
+          git.run_checkout gemdir, branch if $pull_gems
         end
       else
         fail "unknown gem option #{params}"


### PR DESCRIPTION
Since mgem's function almost the same as git gems, but you can see they already
avoid pulling from source after the gem has already been cloned.

 You can see from the `load_special_path_gem` method found in the file
`mruby_build_gem.rake`, or extracted here:

```ruby
if File.exist? mgem_list_dir
  git.run_pull mgem_list_dir, mgem_list_url if $pull_gems
else
  FileUtils.mkdir_p mgem_list_dir
  git.run_clone mgem_list_dir, mgem_list_url, "--depth 1"
end
```

Also, later in this same method; mgem will set the `git` params.
Doing this will trigger the following block:

```ruby
if File.exist?(gemdir)
  if $pull_gems
    git.run_pull gemdir, url
  else
    gemdir
  end
else
  # ... clone
end
```

You can see here, this checks if `$pull_gems` is enabled before pulling.

Lastly, the final condition for this method is here:

```ruby
if params[:checksum_hash]
  # Jump to the specified commit
  git.run_checkout gemdir, params[:checksum_hash]
else
  # Jump to the top of the branch
  git.run_checkout gemdir, branch if $pull_gems
end
```

What we changed was the `else` condition of this block to follow the same
behavior as the aforementioned code. In doing so, we can avoid two things:

* Excess `clone` calls can slow down builds (times number of gems used)
* We _don't_ want our code to _update_ during build

To explain, if during build time there are some changes in the gem we are
depending upon: updating during compile time could actually break our
application.

This is what we're trying to avoid.