### PR TITLE
rename ENABLE_DEBUG to MRB_DEFINE_HOOKS

### DIFF
--- a/doc/guides/mrbconf.md
+++ b/doc/guides/mrbconf.md
@@ -23,14 +23,15 @@ You can use mrbconfs with following ways:
   * Printing features in **src/print.c**.
 
 ## Debug macros.
-`ENABLE_DEBUG`
+`MRB_DEFINE_HOOKS`
 * When defined code fetch hook and debug OP hook will be enabled.
 * When using any of the hook set function pointer `code_fetch_hook` and/or `debug_op_hook` of `mrb_state`.
 * Fetch hook will be called before any OP.
 * Debug OP hook will be called when dispatching `OP_DEBUG`.
+* Defines `ENABLE_DEBUG` and vice versa (backward compatibility).
 
 `DISABLE_DEBUG`
-* Will be define automatically if `ENABLE_DEBUG` isn't defined.
+* Defined when `MRB_DEFINE_HOOKS` isn't (backward compatibility).
 
 `MRB_DEBUG`
 * When defined `mrb_assert*` macro will be defined with macros from `<assert.h>`.

--- a/include/mrbconf.h
+++ b/include/mrbconf.h
@@ -75,11 +75,11 @@
 /* fixed size state atexit stack */
 //#define MRB_FIXED_STATE_ATEXIT_STACK
 
+/* defines mrb_state::{code_fetch_hook,debug_op_hook} */
+//#define MRB_DEFINE_HOOKS
+
 /* -DDISABLE_XXXX to drop following features */
 //#define DISABLE_STDIO		/* use of stdio */
-
-/* -DENABLE_XXXX to enable following features */
-//#define ENABLE_DEBUG		/* hooks for debugger */
 
 /* end of configuration */
 
@@ -87,12 +87,19 @@
 #ifndef DISABLE_STDIO
 #define ENABLE_STDIO
 #endif
-#ifndef ENABLE_DEBUG
-#define DISABLE_DEBUG
-#endif
 
 #ifdef ENABLE_STDIO
 # include <stdio.h>
+#endif
+
+/* backward compatibility */
+#ifdef ENABLE_DEBUG
+#define MRB_DEFINE_HOOKS
+#endif
+#ifdef MRB_DEFINE_HOOKS
+#define ENABLE_DEBUG
+#else
+#define DISABLE_DEBUG
 #endif
 
 #ifndef FALSE

--- a/include/mruby.h
+++ b/include/mruby.h
@@ -152,7 +152,7 @@ typedef struct mrb_state {
   struct symbol_name *symtbl;   /* symbol table */
   size_t symcapa;
 
-#ifdef ENABLE_DEBUG
+#ifdef MRB_DEFINE_HOOKS
   void (*code_fetch_hook)(struct mrb_state* mrb, struct mrb_irep *irep, mrb_code *pc, mrb_value *regs);
   void (*debug_op_hook)(struct mrb_state* mrb, struct mrb_irep *irep, mrb_code *pc, mrb_value *regs);
 #endif

--- a/src/vm.c
+++ b/src/vm.c
@@ -693,7 +693,7 @@ argnum_error(mrb_state *mrb, mrb_int num)
 
 #define ERR_PC_SET(mrb, pc) mrb->c->ci->err = pc;
 #define ERR_PC_CLR(mrb)     mrb->c->ci->err = 0;
-#ifdef ENABLE_DEBUG
+#ifdef MRB_DEFINE_HOOKS
 #define CODE_FETCH_HOOK(mrb, irep, pc, regs) if ((mrb)->code_fetch_hook) (mrb)->code_fetch_hook((mrb), (irep), (pc), (regs));
 #else
 #define CODE_FETCH_HOOK(mrb, irep, pc, regs)
@@ -2340,7 +2340,7 @@ RETRY_TRY_BLOCK:
 
     CASE(OP_DEBUG) {
       /* A B C    debug print R(A),R(B),R(C) */
-#ifdef ENABLE_DEBUG
+#ifdef MRB_DEFINE_HOOKS
       mrb->debug_op_hook(mrb, irep, pc, regs);
 #else
 #ifdef ENABLE_STDIO


### PR DESCRIPTION
Here are some reasons why it should be renamed:
- `ENABLE_DEBUG` isn't prefixed (possible name clash with other libs)
- the `enable_debug` build config method is totally unrelated to this
- the new name MRB_DEFINE_HOOKS is more precise

`ENABLE_DEBUG` and `DISABLE_DEBUG` will still work for backward compatibility but mruby users should update their code. E.g. to `#if defined MRB_DEFINE_HOOKS || defined ENABLE_DEBUG`.