### PR TITLE
Bugfix lshift() bit overflow

### DIFF
--- a/src/numeric.c
+++ b/src/numeric.c
@@ -821,7 +821,9 @@ static mrb_value
 lshift(mrb_state *mrb, mrb_int val, mrb_int width)
 {
   mrb_assert(width > 0);
-  if (width > NUMERIC_SHIFT_WIDTH_MAX) {
+  if ((width > NUMERIC_SHIFT_WIDTH_MAX) ||
+      (val   > (MRB_INT_MAX >> width))
+       ) {
     mrb_float f = (mrb_float)val;
     while (width--) {
       f *= 2;

--- a/test/t/integer.rb
+++ b/test/t/integer.rb
@@ -147,6 +147,9 @@ assert('Integer#<<', '15.2.8.3.12') do
 
   # Left Shift by a negative is Right Shift
   assert_equal 23, 46 << -1
+
+  # Left Shift by 31 is bitShift overflow to SignedInt
+  assert_equal 2147483648, 1 << 31
 end
 
 assert('Integer#>>', '15.2.8.3.13') do


### PR DESCRIPTION
1<<31 return -2147483648.

```shell
$ ./bin/mirb --version
mruby 1.2.0 (2015-11-17) 
$ ./bin/mirb
mirb - Embeddable Interactive Ruby Shell

> 1<<30
 => 1073741824
> 1<<31
 => -2147483648
> 1<<32
 => 4294967296
> 
```

I expect.

```shell
$ ./bin/mirb
mirb - Embeddable Interactive Ruby Shell

> 1<<30
 => 1073741824
> 1<<31
 => 2147483648
> 1<<32
 => 4294967296
> 
```