### PR TITLE
Bugfix nagative-number lshift() bit overflow

### DIFF
--- a/src/numeric.c
+++ b/src/numeric.c
@@ -821,15 +821,28 @@ static mrb_value
 lshift(mrb_state *mrb, mrb_int val, mrb_int width)
 {
   mrb_assert(width > 0);
-  if ((width > NUMERIC_SHIFT_WIDTH_MAX) ||
-      (val   > (MRB_INT_MAX >> width))) {
+  if (val > 0) {
+    if ((width > NUMERIC_SHIFT_WIDTH_MAX) ||
+        (val   > (MRB_INT_MAX >> width))) {
+      goto bit_overflow;
+    }
+  } else {
+    if ((width > NUMERIC_SHIFT_WIDTH_MAX) ||
+        (val   < (MRB_INT_MIN >> width))) {
+      goto bit_overflow;
+    }
+  }
+
+  return mrb_fixnum_value(val << width);
+
+bit_overflow:
+  {
     mrb_float f = (mrb_float)val;
     while (width--) {
       f *= 2;
     }
     return mrb_float_value(mrb, f);
   }
-  return mrb_fixnum_value(val << width);
 }
 
 static mrb_value

--- a/test/t/integer.rb
+++ b/test/t/integer.rb
@@ -150,6 +150,9 @@ assert('Integer#<<', '15.2.8.3.12') do
 
   # Left Shift by 31 is bitShift overflow to SignedInt
   assert_equal 2147483648, 1 << 31
+
+  # -3 Left Shift by 30 is bitShift overflow to SignedInt
+  assert_equal -3221225472, -3 << 30
 end
 
 assert('Integer#>>', '15.2.8.3.13') do


### PR DESCRIPTION
related #3023 

sorry negative number don't care.

```ruby
$ ./bin/mirb --version
mruby 1.2.0 (2015-11-17) 
$ ./bin/mirb
mirb - Embeddable Interactive Ruby Shell

> -3<<29
 => -1610612736
> -3<<30
 => 1073741824
> -3<<31
 => -2147483648
```
this PR fix it.

```ruby
$ ./bin/mirb 
mirb - Embeddable Interactive Ruby Shell

> -3<<29
 => -1610612736
> -3<<30
 => -3221225472
> -3<<31
 => -6442450944
```