### PR TITLE
Fix check for VisualStudio Version in mruby-math gem

### DIFF
--- a/mrbgems/mruby-math/src/math.c
+++ b/mrbgems/mruby-math/src/math.c
@@ -19,7 +19,7 @@ domain_error(mrb_state *mrb, const char *func)
 }
 
 /* math functions not provided by Microsoft Visual C++ 2012 or older */
-#if defined _MSC_VER && _MSC_VER < 1800
+#if defined _MSC_VER && _MSC_VER < 1700
 
 #include <float.h>
 


### PR DESCRIPTION
erf() and other similar mathematical functions are available in MSVC starting from VS2012 (_MSC_VER == 1700).