### PR TITLE
Regularized #include under include/mruby/*.h

### DIFF
--- a/include/mruby/array.h
+++ b/include/mruby/array.h
@@ -7,7 +7,7 @@
 #ifndef MRUBY_ARRAY_H
 #define MRUBY_ARRAY_H
 
-#include "mruby/common.h"
+#include "common.h"
 
 /*
  * Array class

--- a/include/mruby/class.h
+++ b/include/mruby/class.h
@@ -7,7 +7,7 @@
 #ifndef MRUBY_CLASS_H
 #define MRUBY_CLASS_H
 
-#include "mruby/common.h"
+#include "common.h"
 
 /**
  * Class class

--- a/include/mruby/compile.h
+++ b/include/mruby/compile.h
@@ -7,7 +7,7 @@
 #ifndef MRUBY_COMPILE_H
 #define MRUBY_COMPILE_H
 
-#include "mruby/common.h"
+#include "common.h"
 
 /**
  * MRuby Compiler

--- a/include/mruby/data.h
+++ b/include/mruby/data.h
@@ -7,7 +7,7 @@
 #ifndef MRUBY_DATA_H
 #define MRUBY_DATA_H
 
-#include "mruby/common.h"
+#include "common.h"
 
 /**
  * Custom C wrapped data.

--- a/include/mruby/debug.h
+++ b/include/mruby/debug.h
@@ -7,7 +7,7 @@
 #ifndef MRUBY_DEBUG_H
 #define MRUBY_DEBUG_H
 
-#include "mruby/common.h"
+#include "common.h"
 
 /**
  * MRuby Debugging.

--- a/include/mruby/dump.h
+++ b/include/mruby/dump.h
@@ -8,8 +8,8 @@
 #define MRUBY_DUMP_H
 
 #include "mruby.h"
-#include "mruby/irep.h"
-#include "mruby/common.h"
+#include "irep.h"
+#include "common.h"
 
 /**
  * Dumping compiled mruby script.

--- a/include/mruby/error.h
+++ b/include/mruby/error.h
@@ -7,7 +7,7 @@
 #ifndef MRUBY_ERROR_H
 #define MRUBY_ERROR_H
 
-#include "mruby/common.h"
+#include "common.h"
 
 /**
  * MRuby error handling.

--- a/include/mruby/gc.h
+++ b/include/mruby/gc.h
@@ -7,7 +7,7 @@
 #ifndef MRUBY_GC_H
 #define MRUBY_GC_H
 
-#include "mruby/common.h"
+#include "common.h"
 
 /**
  * Uncommon memory management stuffs.

--- a/include/mruby/hash.h
+++ b/include/mruby/hash.h
@@ -7,7 +7,7 @@
 #ifndef MRUBY_HASH_H
 #define MRUBY_HASH_H
 
-#include "mruby/common.h"
+#include "common.h"
 
 /**
  * Hash class

--- a/include/mruby/irep.h
+++ b/include/mruby/irep.h
@@ -7,8 +7,8 @@
 #ifndef MRUBY_IREP_H
 #define MRUBY_IREP_H
 
-#include "mruby/common.h"
-#include "mruby/compile.h"
+#include "common.h"
+#include "compile.h"
 
 /**
  * Compiled mruby scripts.

--- a/include/mruby/khash.h
+++ b/include/mruby/khash.h
@@ -10,7 +10,7 @@
 #include <string.h>
 
 #include "mruby.h"
-#include "mruby/common.h"
+#include "common.h"
 
 /**
  * khash definitions used in mruby's hash table.

--- a/include/mruby/numeric.h
+++ b/include/mruby/numeric.h
@@ -7,7 +7,7 @@
 #ifndef MRUBY_NUMERIC_H
 #define MRUBY_NUMERIC_H
 
-#include "mruby/common.h"
+#include "common.h"
 
 /**
  * Numeric class and it's sub-classes.

--- a/include/mruby/proc.h
+++ b/include/mruby/proc.h
@@ -7,8 +7,8 @@
 #ifndef MRUBY_PROC_H
 #define MRUBY_PROC_H
 
-#include "mruby/common.h"
-#include "mruby/irep.h"
+#include "common.h"
+#include "irep.h"
 
 /**
  * Proc class
@@ -68,7 +68,7 @@ MRB_API mrb_value mrb_proc_cfunc_env_get(mrb_state*, mrb_int);
 /* old name */
 #define mrb_cfunc_env_get(mrb, idx) mrb_proc_cfunc_env_get(mrb, idx)
 
-#include "mruby/khash.h"
+#include "khash.h"
 KHASH_DECLARE(mt, mrb_sym, struct RProc*, TRUE)
 
 MRB_END_DECL

--- a/include/mruby/range.h
+++ b/include/mruby/range.h
@@ -7,7 +7,7 @@
 #ifndef MRUBY_RANGE_H
 #define MRUBY_RANGE_H
 
-#include "mruby/common.h"
+#include "common.h"
 
 /**
  * Range class

--- a/include/mruby/string.h
+++ b/include/mruby/string.h
@@ -7,7 +7,7 @@
 #ifndef MRUBY_STRING_H
 #define MRUBY_STRING_H
 
-#include "mruby/common.h"
+#include "common.h"
 
 /**
  * String class

--- a/include/mruby/value.h
+++ b/include/mruby/value.h
@@ -7,7 +7,7 @@
 #ifndef MRUBY_VALUE_H
 #define MRUBY_VALUE_H
 
-#include "mruby/common.h"
+#include "common.h"
 
 /**
  * MRuby Value definition functions and macros.
@@ -96,7 +96,7 @@ enum mrb_vtype {
   MRB_TT_MAXDEFINE    /*  23 */
 };
 
-#include "mruby/object.h"
+#include "object.h"
 
 #ifdef MRB_DOCUMENTATION_BLOCK
 

--- a/include/mruby/variable.h
+++ b/include/mruby/variable.h
@@ -7,7 +7,7 @@
 #ifndef MRUBY_VARIABLE_H
 #define MRUBY_VARIABLE_H
 
-#include "mruby/common.h"
+#include "common.h"
 
 /**
  * Functions to access mruby variables.

--- a/include/mruby/version.h
+++ b/include/mruby/version.h
@@ -7,7 +7,7 @@
 #ifndef MRUBY_VERSION_H
 #define MRUBY_VERSION_H
 
-#include "mruby/common.h"
+#include "common.h"
 
 /**
  * mruby version definition macros


### PR DESCRIPTION
According to C Preprocessor syntax (see [the manual]( https://gcc.gnu.org/onlinedocs/cpp/Include-Syntax.html)), the `#include "file"` syntax 
> searches for a file named `file` first in the directory containing the current file, then in the quote directories and then the same directories used for `<file>`.

The original call, e.g. `#include "mruby/common.h"` from within the mruby folder, requires to have `-Ipath/to/mruby/include/mruby` in compilation (which is not always the case).

Conversely, the current PR is always working  (i.e. regardless compilation switches), because `mruby/array.h` is always able to find `#include "common.h"` since it is in its same directory.