### PR TITLE
Fix MRB_DISABLE_STDIO typo.

### DIFF
--- a/mrbgems/mruby-compiler/core/parse.y
+++ b/mrbgems/mruby-compiler/core/parse.y
@@ -5442,7 +5442,7 @@ mrb_parser_new(mrb_state *mrb)
   p->pool = pool;
 
   p->s = p->send = NULL;
-#ifndef MRB_DISBLE_STDIO
+#ifndef MRB_DISABLE_STDIO
   p->f = NULL;
 #endif
 


### PR DESCRIPTION
Following https://github.com/mruby/mruby/commit/4440566b9522ae5ff6b2bce7b3d8ecd232304eea, I found another little typo, this time in the compiler.