### PR TITLE
Remove mrbtest irep

### DIFF
--- a/mrbgems/mruby-test/init_mrbtest.c
+++ b/mrbgems/mruby-test/init_mrbtest.c
@@ -4,7 +4,6 @@
 #include "mruby/variable.h"
 
 extern const uint8_t mrbtest_assert_irep[];
-extern const uint8_t mrbtest_irep[];
 
 void mrbgemtest_init(mrb_state* mrb);
 void mrb_init_test_driver(mrb_state* mrb, mrb_bool verbose);
@@ -24,7 +23,6 @@ mrb_init_mrbtest(mrb_state *mrb)
   }
   mrb_init_test_driver(core_test, mrb_test(mrb_gv_get(mrb, mrb_intern_lit(mrb, "$mrbtest_verbose"))));
   mrb_load_irep(core_test, mrbtest_assert_irep);
-  mrb_load_irep(core_test, mrbtest_irep);
   mrb_t_pass_result(mrb, core_test);
 
 #ifndef DISABLE_GEMS

--- a/mrbgems/mruby-test/mrbgem.rake
+++ b/mrbgems/mruby-test/mrbgem.rake
@@ -6,9 +6,10 @@ MRuby::Gem::Specification.new('mruby-test') do |spec|
   build.bins << 'mrbtest'
   spec.add_dependency('mruby-compiler', :core => 'mruby-compiler')
 
+  spec.test_rbfiles = Dir.glob("#{MRUBY_ROOT}/test/t/*.rb")
+
   clib = "#{build_dir}/mrbtest.c"
   mlib = clib.ext(exts.object)
-  mrbs = Dir.glob("#{MRUBY_ROOT}/test/t/*.rb")
   exec = exefile("#{build.build_dir}/bin/mrbtest")
 
   libmruby = libfile("#{build.build_dir}/lib/libmruby")
@@ -146,7 +147,7 @@ MRuby::Gem::Specification.new('mruby-test') do |spec|
 
   init = "#{spec.dir}/init_mrbtest.c"
   file mlib => clib
-  file clib => [build.mrbcfile, init] + mrbs do |t|
+  file clib => init do |t|
     _pp "GEN", "*.rb", "#{clib.relative_path}"
     FileUtils.mkdir_p File.dirname(clib)
     open(clib, 'w') do |f|
@@ -160,7 +161,6 @@ MRuby::Gem::Specification.new('mruby-test') do |spec|
       f.puts %Q[ */]
       f.puts %Q[]
       f.puts IO.read(init)
-      mrbc.run f, mrbs, 'mrbtest_irep'
       build.gems.each do |g|
         f.puts %Q[void GENERATED_TMP_mrb_#{g.funcname}_gem_test(mrb_state *mrb);]
       end

--- a/mrbgems/mruby-test/mrbgem.rake
+++ b/mrbgems/mruby-test/mrbgem.rake
@@ -27,7 +27,7 @@ MRuby::Gem::Specification.new('mruby-test') do |spec|
   mrbtest_objs << assert_lib
 
   file assert_lib => assert_c
-  file assert_c => [build.mrbcfile, assert_rb] do |t|
+  file assert_c => assert_rb do |t|
     open(t.name, 'w') do |f|
       mrbc.run f, assert_rb, 'mrbtest_assert_irep'
     end
@@ -41,7 +41,7 @@ MRuby::Gem::Specification.new('mruby-test') do |spec|
     dep_list = build.gems.tsort_dependencies(g.test_dependencies, gem_table).select(&:generate_functions)
 
     file test_rbobj => g.test_rbireps
-    file g.test_rbireps => [g.test_rbfiles].flatten + [File.join(g.dir, 'mrbgem.rake'), g.build.mrbcfile, "#{MRUBY_ROOT}/tasks/mrbgem_spec.rake"] do |t|
+    file g.test_rbireps => [g.test_rbfiles].flatten do |t|
       FileUtils.mkdir_p File.dirname(t.name)
       open(t.name, 'w') do |f|
         g.print_gem_test_header(f)


### PR DESCRIPTION
If we make the core tests a dependency on the mruby-test gem,
we don't need to worry about maintaining the core test irep alone.

This patch also removes unnecessary dependencies for assert_rb codegen and test_rbireps.