### PR TITLE
Implemented round(double) function when _MSC_VER < 1800

### DIFF
--- a/mrbgems/mruby-time/src/time.c
+++ b/mrbgems/mruby-time/src/time.c
@@ -11,6 +11,16 @@
 #include <mruby/class.h>
 #include <mruby/data.h>
 
+#if _MSC_VER < 1800
+double round(double x) {
+  if (x >= 0.0) {
+    return (double)((int)(x + 0.5));
+  } else {
+    return (double)((int)(x - 0.5));
+  }
+}
+#endif
+
 #if !defined(__MINGW64__) && defined(_WIN32)
 # define llround(x) round(x)
 #endif


### PR DESCRIPTION
Implemented round(double) function  within mruby-time gem, for it is missing on VisualStudio compilers where _MSC_ver < 1800