### PR TITLE
sprintf may throw a exception with wrong message when argument is a too long shared string.

### DIFF
--- a/src/string.c
+++ b/src/string.c
@@ -2163,7 +2163,7 @@ mrb_str_len_to_inum(mrb_state *mrb, const char *str, size_t len, int base, int b
     n *= base;
     n += c;
     if (n > MRB_INT_MAX) {
-      mrb_raisef(mrb, E_ARGUMENT_ERROR, "string (%S) too big for integer", mrb_str_new_cstr(mrb, str));
+      mrb_raisef(mrb, E_ARGUMENT_ERROR, "string (%S) too big for integer", mrb_str_new(mrb, str, len));
     }
   }
   val = n;
@@ -2179,7 +2179,7 @@ mrb_str_len_to_inum(mrb_state *mrb, const char *str, size_t len, int base, int b
   /* not reached */
  bad:
   mrb_raisef(mrb, E_ARGUMENT_ERROR, "invalid string for number(%S)",
-             mrb_inspect(mrb, mrb_str_new_cstr(mrb, str)));
+             mrb_inspect(mrb, mrb_str_new(mrb, str, len)));
   /* not reached */
   return mrb_fixnum_value(0);
 }


### PR DESCRIPTION
```
% bin/mruby -e 'a="1"*100; t=a[0,30]; sprintf("%u", t)'
trace:
	[0] -e:1
-e:1: string (1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111) too big for integer (ArgumentError)
```

The number of "1" characters should be only 30, not 100.  Another case is:

```
% bin/mruby -e 'a="a"*100; t=a[0,30]; sprintf("%u", t)'
trace:
	[0] -e:1
-e:1: invalid string for number("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa") (ArgumentError)
```
