### PR TITLE
converting string representation of MRB_INT_MIN raises an exception

### DIFF
--- a/src/string.c
+++ b/src/string.c
@@ -2178,7 +2178,8 @@ mrb_str_len_to_inum(mrb_state *mrb, const char *str, size_t len, int base, int b
     if (sign && n > MRB_INT_MAX) {
       mrb_raisef(mrb, E_ARGUMENT_ERROR, "string (%S) too big for integer",
                  mrb_str_new(mrb, str, pend-str));
-    } else if (!sign && n > -(int64_t)MRB_INT_MIN) {
+    }
+    else if (!sign && n > -(int64_t)MRB_INT_MIN) {
       mrb_raisef(mrb, E_ARGUMENT_ERROR, "string (%S) too small for integer",
                  mrb_str_new(mrb, str, pend-str));
     }

--- a/src/string.c
+++ b/src/string.c
@@ -2175,8 +2175,11 @@ mrb_str_len_to_inum(mrb_state *mrb, const char *str, size_t len, int base, int b
     }
     n *= base;
     n += c;
-    if (n > MRB_INT_MAX) {
+    if (sign && n > MRB_INT_MAX) {
       mrb_raisef(mrb, E_ARGUMENT_ERROR, "string (%S) too big for integer",
+                 mrb_str_new(mrb, str, pend-str));
+    } else if (!sign && n > -(int64_t)MRB_INT_MIN) {
+      mrb_raisef(mrb, E_ARGUMENT_ERROR, "string (%S) too small for integer",
                  mrb_str_new(mrb, str, pend-str));
     }
   }


### PR DESCRIPTION
Without this patch, `Integer("-2147483648")` raises an exception.  But it can be conveted to a Fixnum.

Before:
```
% bin/mruby -e 'Integer("-2147483648")'
trace:
        [0] -e:1
-e:1: string (-2147483648) too big for integer (ArgumentError)
```

After:
```
% bin/mruby -e 'p Integer("-2147483648")'
-2147483648
```