### PR TITLE
Integer("1_0") raises an exception

### DIFF
--- a/src/string.c
+++ b/src/string.c
@@ -2162,7 +2162,7 @@ mrb_str_len_to_inum(mrb_state *mrb, const char *str, size_t len, int base, int b
         continue;
       }
       p++;
-      if (badcheck && p<pend)
+      if (badcheck && p>=pend)
         goto bad;
     }
     if (badcheck && *p == '\0') {


### PR DESCRIPTION
`"1_0"` is a string to be converted to a number but `Integer("1_0")` raises an exception.

```
% bin/mruby -e 'p Integer("1_0")'
trace:
        [0] -e:1
-e:1: invalid string for number("1_0") (ArgumentError)

% ruby -e 'p Integer("1_0")'
10
```
