### PR TITLE
Add case statement of MRB_TT_SCLASS in mrb_obj_is_kind_of()

### DIFF
--- a/src/object.c
+++ b/src/object.c
@@ -481,6 +481,7 @@ mrb_obj_is_kind_of(mrb_state *mrb, mrb_value obj, struct RClass *c)
     case MRB_TT_MODULE:
     case MRB_TT_CLASS:
     case MRB_TT_ICLASS:
+    case MRB_TT_SCLASS:
       break;
 
     default:


### PR DESCRIPTION
Wondering why they are different. I used `ruby 2.0.0p645` and `mruby 1.2.0 (2015-11-17)` to get following result.

```
$ cat foobar.rb
class A; end
puts ObjectSpace.each_object(A) {|k| puts k}
puts ObjectSpace.each_object(singleton_class) {|k| puts k}

$ ruby foobar.rb
0
main
1

$ mruby foobar.rb
0
trace:
	[0] foobar.rb:3
foobar.rb:3: class or module required (TypeError)
```

If this is a bug, then my best guess to fix this is adding case statement for `MRB_TT_SCLASS` in mrb_obj_is_kind_of() in src/object.c. From my quick check it looks fixed but totally no idea if this is the right way.
