### PR TITLE
Fix "ambiguous first argument" warning

### DIFF
--- a/test/t/integer.rb
+++ b/test/t/integer.rb
@@ -152,7 +152,7 @@ assert('Integer#<<', '15.2.8.3.12') do
   assert_equal 2147483648, 1 << 31
 
   # -3 Left Shift by 30 is bitShift overflow to SignedInt
-  assert_equal -3221225472, -3 << 30
+  assert_equal(-3221225472, -3 << 30)
 end
 
 assert('Integer#>>', '15.2.8.3.13') do


### PR DESCRIPTION
Similar to #3005 

Maybe there's something we can fix in the parser?

/cc @cremno 