### PR TITLE
fix miscalculation of column number in `peekc_n`

### DIFF
--- a/mrbgems/mruby-compiler/core/parse.y
+++ b/mrbgems/mruby-compiler/core/parse.y
@@ -3473,6 +3473,7 @@ peekc_n(parser_state *p, int n)
   do {
     c0 = nextc(p);
     if (c0 == -1) return c0;    /* do not skip partial EOF */
+    if (c0 >= 0) --p->column;
     list = push(list, (node*)(intptr_t)c0);
   } while(n--);
   if (p->pb) {


### PR DESCRIPTION
My understanding is that the peek functions of parser.y are expected to just _peek_ into what characters are coming, without changing the state of the parser.

However, `peekc_n` is not resetting the change to `p->column` made by `nextc`.
Therefore, when the peek functions are called under certain conditions, the column number becomes incorrect, as reported in #3053.

This PR fixes the issue by decrementing `p->column` in `peekc_n` after a successful to `nextc`.