### PR TITLE
fix build on VS2012

### DIFF
--- a/mrbgems/mruby-bin-debugger/tools/mrdb/apibreak.c
+++ b/mrbgems/mruby-bin-debugger/tools/mrdb/apibreak.c
@@ -450,7 +450,7 @@ mrb_debug_check_breakpoint_line( mrb_state *mrb, mrb_debug_context *dbg, const c
 {
   mrb_debug_breakpoint *bp;
   mrb_debug_linepoint *line_p;
-  int i;
+  uint32_t i;
 
   if((mrb == NULL) || (dbg == NULL) || (file == NULL) || (line <= 0)) {
     return MRB_DEBUG_INVALID_ARGUMENT;
@@ -488,7 +488,7 @@ mrb_debug_check_breakpoint_method( mrb_state *mrb, mrb_debug_context *dbg, struc
 {
   mrb_debug_breakpoint *bp;
   int32_t bpno;
-  int i;
+  uint32_t i;
 
   if((mrb == NULL) || (dbg == NULL) || (class_obj == NULL)) {
     return MRB_DEBUG_INVALID_ARGUMENT;

--- a/mrbgems/mruby-math/src/math.c
+++ b/mrbgems/mruby-math/src/math.c
@@ -19,7 +19,7 @@ domain_error(mrb_state *mrb, const char *func)
 }
 
 /* math functions not provided by Microsoft Visual C++ 2012 or older */
-#if defined _MSC_VER && _MSC_VER < 1700
+#if defined _MSC_VER && _MSC_VER <= 1700
 
 #include <float.h>
 

--- a/src/dump.c
+++ b/src/dump.c
@@ -54,7 +54,7 @@ write_irep_header(mrb_state *mrb, mrb_irep *irep, uint8_t *buf)
 {
   uint8_t *cur = buf;
 
-  cur += uint32_to_bin(get_irep_record_size_1(mrb, irep), cur);  /* record size */
+  cur += uint32_to_bin((uint32_t)get_irep_record_size_1(mrb, irep), cur);  /* record size */
   cur += uint16_to_bin((uint16_t)irep->nlocals, cur);  /* number of local variable */
   cur += uint16_to_bin((uint16_t)irep->nregs, cur);  /* number of register variable */
   cur += uint16_to_bin((uint16_t)irep->rlen, cur);  /* number of child irep */

--- a/src/fmt_fp.c
+++ b/src/fmt_fp.c
@@ -156,7 +156,7 @@ fmt_fp(struct fmt_args *f, long double y, int w, int p, int fl, int t)
 
     s=buf;
     do {
-      int x=y;
+      int x=(int)y;
       *s++=xdigits[x]|(t&32);
       y=16*(y-x);
       if (s-buf==1 && (y||p>0||(fl&ALT_FORM))) *s++='.';
@@ -184,7 +184,7 @@ fmt_fp(struct fmt_args *f, long double y, int w, int p, int fl, int t)
   else a=r=z=big+sizeof(big)/sizeof(*big) - LDBL_MANT_DIG - 1;
 
   do {
-    *z = y;
+    *z = (uint32_t)y;
     y = 1000000000*(y-*z++);
   } while (y);
 
@@ -194,7 +194,7 @@ fmt_fp(struct fmt_args *f, long double y, int w, int p, int fl, int t)
     for (d=z-1; d>=a; d--) {
       uint64_t x = ((uint64_t)*d<<sh)+carry;
       *d = x % 1000000000;
-      carry = x / 1000000000;
+      carry = (uint32_t)(x / 1000000000);
     }
     if (carry) *--a = carry;
     while (z>a && !z[-1]) z--;

--- a/src/string.c
+++ b/src/string.c
@@ -4,6 +4,10 @@
 ** See Copyright Notice in mruby.h
 */
 
+#ifdef _MSC_VER
+# define _CRT_NONSTDC_NO_DEPRECATE
+#endif
+
 #include <float.h>
 #include <limits.h>
 #include <stddef.h>
@@ -2170,12 +2174,12 @@ mrb_str_len_to_inum(mrb_state *mrb, const char *str, size_t len, int base, int b
     }
     n *= base;
     n += c;
-    if (n > (int64_t)MRB_INT_MAX + (sign ? 0 : 1)) {
+    if (n > (uint64_t)MRB_INT_MAX + (sign ? 0 : 1)) {
       mrb_raisef(mrb, E_ARGUMENT_ERROR, "string (%S) too big for integer",
                  mrb_str_new(mrb, str, pend-str));
     }
   }
-  val = n;
+  val = (mrb_int)n;
   if (badcheck) {
     if (p == str) goto bad; /* no number */
     while (p<pend && ISSPACE(*p)) p++;


### PR DESCRIPTION
build error on VS2012 because ignoring _MSC_VER=1700 in mrbgems/mruby-math/src/math.c
```
#if defined _MSC_VER && _MSC_VER < 1700
```

I fixed some other compilation warnings.

http://denx.jp/mruby-on-unity

![](http://denx.jp/wp-content/uploads/2015/12/ruby_minirake.png)