### PR TITLE
mrdb: Added 'next' command.

### DIFF
--- a/mrbgems/mruby-bin-debugger/tools/mrdb/cmdrun.c
+++ b/mrbgems/mruby-bin-debugger/tools/mrdb/cmdrun.c
@@ -57,5 +57,6 @@ dbgcmd_state
 dbgcmd_next(mrb_state *mrb, mrdb_state *mrdb)
 {
   mrdb->dbg->xm = DBG_NEXT;
+  mrdb->dbg->prvci = mrb->c->ci;
   return DBGST_CONTINUE;
 }

--- a/mrbgems/mruby-bin-debugger/tools/mrdb/cmdrun.c
+++ b/mrbgems/mruby-bin-debugger/tools/mrdb/cmdrun.c
@@ -52,3 +52,10 @@ dbgcmd_step(mrb_state *mrb, mrdb_state *mrdb)
   mrdb->dbg->xm = DBG_STEP;
   return DBGST_CONTINUE;
 }
+
+dbgcmd_state
+dbgcmd_next(mrb_state *mrb, mrdb_state *mrdb)
+{
+  mrdb->dbg->xm = DBG_NEXT;
+  return DBGST_CONTINUE;
+}

--- a/mrbgems/mruby-bin-debugger/tools/mrdb/mrdb.c
+++ b/mrbgems/mruby-bin-debugger/tools/mrdb/mrdb.c
@@ -57,6 +57,7 @@ static const debug_command debug_command_list[] = {
   {"quit",      NULL,           1, 0, 0, DBGCMD_QUIT,           dbgcmd_quit},            /* q[uit] */
   {"run",       NULL,           1, 0, 0, DBGCMD_RUN,            dbgcmd_run},             /* r[un] */
   {"step",      NULL,           1, 0, 1, DBGCMD_STEP,           dbgcmd_step},            /* s[tep] */
+  {"next",      NULL,           1, 0, 1, DBGCMD_NEXT,           dbgcmd_next},            /* s[tep] */
   {NULL}
 };
 
@@ -560,6 +561,7 @@ mrb_code_fetch_hook(mrb_state *mrb, mrb_irep *irep, mrb_code *pc, mrb_value *reg
     dbg->root_irep = irep;
     dbg->prvfile = NULL;
     dbg->prvline = 0;
+    dbg->prvci = NULL;
     dbg->xm = DBG_RUN;
     dbg->xphase = DBG_PHASE_RUNNING;
   }
@@ -569,12 +571,22 @@ mrb_code_fetch_hook(mrb_state *mrb, mrb_irep *irep, mrb_code *pc, mrb_value *reg
 
   switch (dbg->xm) {
   case DBG_STEP:
-  case DBG_NEXT:  // temporary
     if (!file || (dbg->prvfile == file && dbg->prvline == line)) {
       return;
     }
     dbg->method_bpno = 0;
     dbg->bm = BRK_STEP;
+    break;
+
+  case DBG_NEXT:
+    if (!file || (dbg->prvfile == file && dbg->prvline == line)) {
+      return;
+    }
+    if((uint32_t)(dbg->prvci) < (uint32_t)(mrb->c->ci)) {
+      return;
+    }
+    dbg->method_bpno = 0;
+    dbg->bm = BRK_NEXT;
     break;
 
   case DBG_RUN:
@@ -594,6 +606,7 @@ mrb_code_fetch_hook(mrb_state *mrb, mrb_irep *irep, mrb_code *pc, mrb_value *reg
     }
     dbg->prvfile = file;
     dbg->prvline = line;
+    dbg->prvci = mrb->c->ci;
     return;
   case DBG_INIT:
     dbg->root_irep = irep;

--- a/mrbgems/mruby-bin-debugger/tools/mrdb/mrdb.c
+++ b/mrbgems/mruby-bin-debugger/tools/mrdb/mrdb.c
@@ -585,6 +585,7 @@ mrb_code_fetch_hook(mrb_state *mrb, mrb_irep *irep, mrb_code *pc, mrb_value *reg
     if((uint32_t)(dbg->prvci) < (uint32_t)(mrb->c->ci)) {
       return;
     }
+    dbg->prvci = NULL;
     dbg->method_bpno = 0;
     dbg->bm = BRK_NEXT;
     break;
@@ -606,7 +607,6 @@ mrb_code_fetch_hook(mrb_state *mrb, mrb_irep *irep, mrb_code *pc, mrb_value *reg
     }
     dbg->prvfile = file;
     dbg->prvline = line;
-    dbg->prvci = mrb->c->ci;
     return;
   case DBG_INIT:
     dbg->root_irep = irep;

--- a/mrbgems/mruby-bin-debugger/tools/mrdb/mrdb.c
+++ b/mrbgems/mruby-bin-debugger/tools/mrdb/mrdb.c
@@ -57,7 +57,7 @@ static const debug_command debug_command_list[] = {
   {"quit",      NULL,           1, 0, 0, DBGCMD_QUIT,           dbgcmd_quit},            /* q[uit] */
   {"run",       NULL,           1, 0, 0, DBGCMD_RUN,            dbgcmd_run},             /* r[un] */
   {"step",      NULL,           1, 0, 1, DBGCMD_STEP,           dbgcmd_step},            /* s[tep] */
-  {"next",      NULL,           1, 0, 1, DBGCMD_NEXT,           dbgcmd_next},            /* s[tep] */
+  {"next",      NULL,           1, 0, 1, DBGCMD_NEXT,           dbgcmd_next},            /* n[ext] */
   {NULL}
 };
 

--- a/mrbgems/mruby-bin-debugger/tools/mrdb/mrdb.h
+++ b/mrbgems/mruby-bin-debugger/tools/mrdb/mrdb.h
@@ -109,6 +109,7 @@ typedef struct mrb_debug_context {
 
   const char *prvfile;
   int32_t prvline;
+  mrb_callinfo *prvci;
 
   mrdb_exemode xm;
   mrdb_exephase xphase;
@@ -146,6 +147,7 @@ typedef dbgcmd_state (*debug_command_func)(mrb_state*, mrdb_state*);
 dbgcmd_state dbgcmd_run(mrb_state*, mrdb_state*);
 dbgcmd_state dbgcmd_continue(mrb_state*, mrdb_state*);
 dbgcmd_state dbgcmd_step(mrb_state*, mrdb_state*);
+dbgcmd_state dbgcmd_next(mrb_state*, mrdb_state*);
 /* cmdbreak.c */
 dbgcmd_state dbgcmd_break(mrb_state*, mrdb_state*);
 dbgcmd_state dbgcmd_info_break(mrb_state*, mrdb_state*);


### PR DESCRIPTION
So far I have added a 'next' was not supported by mrdb.
This enables step-over during debugging.
'next' is available by entering the 'next' or 'n' at the prompt.

reference:http://qiita.com/Y_uuu/items/f71cf8c94f36d54d2d1e
