### PR TITLE
rename include blocker

### DIFF
--- a/mrbgems/mruby-compiler/core/node.h
+++ b/mrbgems/mruby-compiler/core/node.h
@@ -4,8 +4,8 @@
 ** See Copyright Notice in mruby.h
 */
 
-#ifndef NODE_H
-#define NODE_H
+#ifndef MRUBY_COMPILER_NODE_H
+#define MRUBY_COMPILER_NODE_H
 
 enum node_type {
   NODE_METHOD,
@@ -114,4 +114,4 @@ enum node_type {
   NODE_LAST
 };
 
-#endif  /* NODE_H */
+#endif  /* MRUBY_COMPILER_NODE_H */

--- a/mrbgems/mruby-random/src/random.h
+++ b/mrbgems/mruby-random/src/random.h
@@ -4,8 +4,8 @@
 ** See Copyright Notice in mruby.h
 */
 
-#ifndef RANDOM_H
-#define RANDOM_H
+#ifndef MRUBY_RANDOM_H
+#define MRUBY_RANDOM_H
 
 void mrb_mruby_random_gem_init(mrb_state *mrb);
 


### PR DESCRIPTION
RANDOM_H / NODE_H is easy name to be duplicate.