### PR TITLE
Use memchr for performance

### DIFF
--- a/src/string.c
+++ b/src/string.c
@@ -352,12 +352,12 @@ mrb_memsearch(const void *x0, mrb_int m, const void *y0, mrb_int n)
     return 0;
   }
   else if (m == 1) {
-    const unsigned char *ys = y, *ye = ys + n;
-    for (; y < ye; ++y) {
-      if (*x == *y)
-        return y - ys;
-    }
-    return -1;
+    const unsigned char *ys = memchr(y, *x, n);
+
+    if (ys)
+      return ys - y;
+    else
+      return -1;
   }
   return mrb_memsearch_qs((const unsigned char *)x0, m, (const unsigned char *)y0, n);
 }


### PR DESCRIPTION
Use `memchr` for performance.

This code was copy from https://github.com/ruby/ruby/blob/2f2a5c3ae9f9e7a4d09b1500de8d864f48d69cad/re.c#L264-L269

### benchmark

```shell
$ uname -v
Darwin Kernel Version 15.2.0: Fri Nov 13 19:56:56 PST 2015; root:xnu-3248.20.55~2/RELEASE_X86_64
```

```ruby
s = "b"
str = ("a" * 100 + s)

t = Time.now
str.index(s)
puts Time.now - t
```

before => 0.000788
after  => 0.000508

---

```ruby
s = "b"
str = ("a" * 100 * 1024 * 1024 + s)

t = Time.now
str.index(s)
puts Time.now - t
```

before => 0.225474
after  => 0.008658