### PR TITLE
use _setjmp/_longjmp on OS X

### DIFF
--- a/include/mruby/throw.h
+++ b/include/mruby/throw.h
@@ -20,11 +20,19 @@ typedef mrb_int mrb_jmpbuf_impl;
 
 #include <setjmp.h>
 
-#define MRB_TRY(buf) do { if (setjmp((buf)->impl) == 0) {
+#if defined(__APPLE__)
+#define MRB_SETJMP _setjmp
+#define MRB_LONGJMP _longjmp
+#else
+#define MRB_SETJMP setjmp
+#define MRB_LONGJMP longjmp
+#endif
+
+#define MRB_TRY(buf) do { if (MRB_SETJMP((buf)->impl) == 0) {
 #define MRB_CATCH(buf) } else {
 #define MRB_END_EXC(buf) } } while(0)
 
-#define MRB_THROW(buf) longjmp((buf)->impl, 1);
+#define MRB_THROW(buf) MRB_LONGJMP((buf)->impl, 1);
 #define mrb_jmpbuf_impl jmp_buf
 
 #endif

--- a/include/mruby/throw.h
+++ b/include/mruby/throw.h
@@ -20,7 +20,7 @@ typedef mrb_int mrb_jmpbuf_impl;
 
 #include <setjmp.h>
 
-#if defined(__APPLE__)
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
 #define MRB_SETJMP _setjmp
 #define MRB_LONGJMP _longjmp
 #else


### PR DESCRIPTION
setjmp/longjmp are very slow on OS X; _setjmp/_longjmp should be used for implementing TRY-CATCH.

The reason is as stated in the man pages of OSX, quoting:
> ```
> The setjmp()/longjmp() pairs save and restore the signal mask while _setjmp()/_longjmp() pairs save and restore only
> the register set and the stack.  (See sigprocmask(2).)
> ```

With the change, benchmark/bm_ao_render.rb became 20% faster (11.791 seconds => 9.668 seconds) on my MacBook Pro.

Shown below is the profile result of the master branch running mb_ao_render.rb on OS X.
![Profile result of master running bm_ao_render.rb](https://i.gyazo.com/589cd8c05b0a20706b99f039dcdbd1bd.png)