### PR TITLE
provide macro to ease using printf mrb_int

### DIFF
--- a/include/mruby/value.h
+++ b/include/mruby/value.h
@@ -27,16 +27,25 @@ struct mrb_state;
 # define MRB_INT_BIT 64
 # define MRB_INT_MIN (INT64_MIN>>MRB_FIXNUM_SHIFT)
 # define MRB_INT_MAX (INT64_MAX>>MRB_FIXNUM_SHIFT)
+# define MRB_PRIo PRIo64
+# define MRB_PRId PRId64
+# define MRB_PRIx PRIx64
 #elif defined(MRB_INT16)
   typedef int16_t mrb_int;
 # define MRB_INT_BIT 16
 # define MRB_INT_MIN (INT16_MIN>>MRB_FIXNUM_SHIFT)
 # define MRB_INT_MAX (INT16_MAX>>MRB_FIXNUM_SHIFT)
+# define MRB_PRIo PRIo16
+# define MRB_PRId PRId16
+# define MRB_PRIx PRIx16
 #else
   typedef int32_t mrb_int;
 # define MRB_INT_BIT 32
 # define MRB_INT_MIN (INT32_MIN>>MRB_FIXNUM_SHIFT)
 # define MRB_INT_MAX (INT32_MAX>>MRB_FIXNUM_SHIFT)
+# define MRB_PRIo PRIo32
+# define MRB_PRId PRId32
+# define MRB_PRIx PRIx32
 #endif
 
 #ifdef MRB_USE_FLOAT


### PR DESCRIPTION
This PR adds macros that map `MRB_PRI?` to `PRI?NN` depending on the size of `mrb_int`.

Such macro makes us easy to use printf (and its variant) to stringify the values of `mrb_int`.