### PR TITLE
symname_p support `!~`

### DIFF
--- a/src/symbol.c
+++ b/src/symbol.c
@@ -354,7 +354,9 @@ symname_p(const char *name)
       if (*++m == '*') ++m;
       break;
     case '!':
-      if (*++m == '=') ++m;
+      switch (*++m) {
+        case '=': case '~': ++m;
+      }
       break;
     case '+': case '-':
       if (*++m == '@') ++m;


### PR DESCRIPTION
**before**

```ruby
p :== #=> :==
p :!= #=> :!=
p :=~ #=> :=~
p :!~ #=> :"!~"
```

**after**

```ruby
p :== #=> :==
p :!= #=> :!=
p :=~ #=> :=~
p :!~ #=> :!~
```

I think **after** behavior is more better than **before** because same as CRuby.