### PR TITLE
printf precision parameter must be 'int' type

### DIFF
--- a/src/backtrace.c
+++ b/src/backtrace.c
@@ -216,7 +216,7 @@ print_backtrace(mrb_state *mrb, mrb_value backtrace)
   for (i = 0; i < n; i++) {
     mrb_value entry = RARRAY_PTR(backtrace)[i];
 
-    fprintf(stream, "\t[%d] %.*s\n", i, RSTRING_LEN(entry), RSTRING_PTR(entry));
+    fprintf(stream, "\t[%d] %.*s\n", i, (int)RSTRING_LEN(entry), RSTRING_PTR(entry));
   }
 }
 


### PR DESCRIPTION
There is a problem when MRB_INT64 is enabled.

Linux printf manpage(http://linux.die.net/man/3/printf) says about this.

> The precision
>
> An optional precision, in the form of a period ('.') followed by an optional decimal digit string. Instead of a decimal digit string one may write "*" or "*m$" (for some decimal integer m) to specify that the precision is given in the next argument, or in the m-th argument, respectively, which must be of type int. 
