### PR TITLE
first argument to `%.*s` must be int

### DIFF
--- a/src/backtrace.c
+++ b/src/backtrace.c
@@ -216,7 +216,7 @@ print_backtrace(mrb_state *mrb, mrb_value backtrace)
   for (i = 0; i < n; i++) {
     mrb_value entry = RARRAY_PTR(backtrace)[i];
 
-    fprintf(stream, "\t[%d] %.*s\n", i, RSTRING_LEN(entry), RSTRING_PTR(entry));
+    fprintf(stream, "\t[%d] %.*s\n", i, (int)RSTRING_LEN(entry), RSTRING_PTR(entry));
   }
 }
 


### PR DESCRIPTION
Result type of `RSTRING_LEN` is `mrb_int`; it needs to be casted to `int` before passed to sprintf as the length argument of `%.*s` in case `sizeof(mrb_int)` is not equal to `sizeof(int)`.