### PR TITLE
Fix build error in ruby 1.8.

### DIFF
--- a/tasks/toolchains/clang.rake
+++ b/tasks/toolchains/clang.rake
@@ -1,4 +1,4 @@
-MRuby::Toolchain.new(:clang) do |conf|
+MRuby::Toolchain.new(:clang) do |conf, _params|
   toolchain :gcc
 
   [conf.cc, conf.objc, conf.asm].each do |cc|

--- a/tasks/toolchains/gcc.rake
+++ b/tasks/toolchains/gcc.rake
@@ -1,4 +1,4 @@
-MRuby::Toolchain.new(:gcc) do |conf|
+MRuby::Toolchain.new(:gcc) do |conf, _params|
   [conf.cc, conf.objc, conf.asm].each do |cc|
     cc.command = ENV['CC'] || 'gcc'
     cc.flags = [ENV['CFLAGS'] || %w(-g -std=gnu99 -O3 -Wall -Werror-implicit-function-declaration -Wdeclaration-after-statement -Wwrite-strings)]

--- a/tasks/toolchains/visualcpp.rake
+++ b/tasks/toolchains/visualcpp.rake
@@ -1,4 +1,4 @@
-MRuby::Toolchain.new(:visualcpp) do |conf|
+MRuby::Toolchain.new(:visualcpp) do |conf, _params|
   [conf.cc].each do |cc|
     cc.command = ENV['CC'] || 'cl.exe'
     # C4013: implicit function declaration


### PR DESCRIPTION
The following error and warning occurs when run `ruby ./minirake` in `ruby 1.8.7`.

```
/*****/mruby/tasks/toolchains/gcc.rake:1: warning: multiple values for a block parameter (2 for 1)
	from /*****/mruby/tasks/mruby_build.rake:30
rake aborted!
undefined method `cc' for #<Array:0x100715970>
./rakefile:15:in `load'
```

This error has occurred from #2978.
I applied the changes of #2978 to `:clang`, `:gcc` and `:visualcpp` toolchains.
