### PR TITLE
Fix passing all zero string to Kernel#Integer

### DIFF
--- a/mrbgems/mruby-kernel-ext/test/kernel.rb
+++ b/mrbgems/mruby-kernel-ext/test/kernel.rb
@@ -22,6 +22,8 @@ assert('Kernel#Integer') do
   assert_equal(26, Integer("0x1a"))
   assert_equal(930, Integer("0930", 10))
   assert_equal(7, Integer("111", 2))
+  assert_equal(0, Integer("0"))
+  assert_equal(0, Integer("00000"))
   assert_raise(TypeError) { Integer(nil) }
 end
 

--- a/src/string.c
+++ b/src/string.c
@@ -2153,6 +2153,8 @@ mrb_str_len_to_inum(mrb_state *mrb, const char *str, size_t len, int base, int b
         break;
       }
     }
+    if (*(p - 1) == '0')
+      p--;
   }
   if (p == pend) {
     if (badcheck) goto bad;


### PR DESCRIPTION
This is related to #3083.