### PR TITLE
Fix bug in mruby-test gem (fix #3094)

### DIFF
--- a/mrbgems/mruby-test/mrbgem.rake
+++ b/mrbgems/mruby-test/mrbgem.rake
@@ -146,6 +146,19 @@ MRuby::Gem::Specification.new('mruby-test') do |spec|
   end
 
   init = "#{spec.dir}/init_mrbtest.c"
+
+  # store the last gem selection and make the re-build
+  # of the test gem depending on a change to the gem
+  # selection
+  active_gems = "#{build_dir}/active_gems.lst"
+  FileUtils.mkdir_p File.dirname(active_gems)
+  open(active_gems, 'w+') do |f|
+    build.gems.each do |g|
+      f.puts g.name
+    end
+  end
+  file clib => active_gems
+
   file mlib => clib
   file clib => init do |t|
     _pp "GEN", "*.rb", "#{clib.relative_path}"


### PR DESCRIPTION
In an used build path mruby-test wasn't updating mrbtest.c in the
case that the mgem selection was changed. This lead to:
  - a missing reference in case a GEM was removed
  - ignoring all new GEMs added to the build configuration

This fix keeps track of the active gems and demands a rebuild of
mrbtest.c in case that the gem selection changed.

fix #3094