### PR TITLE
[255, 255, 255, 255, 255].hash raises "can't convert Float into Integer"

### DIFF
--- a/mrblib/enum.rb
+++ b/mrblib/enum.rb
@@ -383,7 +383,7 @@ module Enumerable
     h = 12347
     i = 0
     self.each do |e|
-      n = e.hash << (i % 16)
+      n = (e.hash & (0x7fffffff >> (i % 16))) << (i % 16)
       h ^= n
       i += 1
     end


### PR DESCRIPTION
Hello,

~~~~
$ ./bin/mruby -e '[255, 255, 255, 255, 255].hash'
trace:
        [0] /tmp/mruby/mrblib/enum.rb:387:in Enumerable.hash
        [1] /tmp/mruby/mrblib/array.rb:17:in Array.each
        [2] /tmp/mruby/mrblib/enum.rb:385:in Enumerable#hash
        [3] -e:1
/tmp/mruby/mrblib/enum.rb:387: can't convert Float into Integer (TypeError)
~~~~

This is caused by `0 ^ 0x8000_0000 #=> TypeError`.  I'm unsure if this is an intended limit, but if so, `Enumerable#hash` should be fixed.

Thank you,