### PR TITLE
Fix Struct#dup issue

### DIFF
--- a/mrbgems/mruby-struct/src/struct.c
+++ b/mrbgems/mruby-struct/src/struct.c
@@ -429,10 +429,7 @@ mrb_struct_init_copy(mrb_state *mrb, mrb_value copy)
   if (!mrb_array_p(s)) {
     mrb_raise(mrb, E_TYPE_ERROR, "corrupted struct");
   }
-  if (RSTRUCT_LEN(copy) != RSTRUCT_LEN(s)) {
-    mrb_raise(mrb, E_TYPE_ERROR, "struct size mismatch");
-  }
-  len = RSTRUCT_LEN(copy);
+  len = RSTRUCT_LEN(s);
   for (i = 0; i < len; i++) {
     mrb_ary_set(mrb, copy, i, RSTRUCT_PTR(s)[i]);
   }

--- a/mrbgems/mruby-struct/test/struct.rb
+++ b/mrbgems/mruby-struct/test/struct.rb
@@ -140,3 +140,8 @@ assert('Struct#values_at') do
   assert_equal ['io', 'aki'], a.values_at(1, 0)
   assert_raise(IndexError) { a.values_at 2 }
 end
+
+assert('Struct#dup') do
+  A = Struct.new(:a, :b)
+  assert_nothing_raised(TypeError) { A.new(1, 2).dup }
+end


### PR DESCRIPTION
Remove needless assertion. The argument 'copy' is always empty array so this assertion is failed with 'struct' which has more than one 'members'.

This is related to #3114.
CC: @sgnr, @mattn