### PR TITLE
Avoid Error when Compiling with -std=c99 flag

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -429,6 +429,8 @@ to_sym(mrb_state *mrb, mrb_value ss)
   else {
     mrb_value obj = mrb_funcall(mrb, ss, "inspect", 0);
     mrb_raisef(mrb, E_TYPE_ERROR, "%S is not a symbol", obj);
+    /* not reached */
+    return 0;
   }
 }
 


### PR DESCRIPTION
The else block doesn't return a value, so the compiler gives a warning when compiling with -std=c99 flag