### PR TITLE
The original code crashed when mrb->backtrace.n grew to 16.

### DIFF
--- a/src/backtrace.c
+++ b/src/backtrace.c
@@ -330,7 +330,7 @@ save_backtrace_i(mrb_state *mrb,
 {
   mrb_backtrace_entry *entry;
 
-  if (loc_raw->i >= mrb->backtrace.n_allocated) {
+  if (mrb->backtrace.n >= mrb->backtrace.n_allocated) {
     int new_n_allocated;
     if (mrb->backtrace.n_allocated == 0) {
       new_n_allocated = 8;


### PR DESCRIPTION
It looks like the logic to reallocate the backtrace was flawed,
based on the wrong variable (loc_raw->i, which, as I have verified,
decreases from 16 to 0 instead of increasing)

I am not sure if this is the correct fix