### PR TITLE
Add default benchmark build config

### DIFF
--- a/build_config.rb
+++ b/build_config.rb
@@ -122,6 +122,14 @@ MRuby::Build.new('test') do |conf|
   conf.gembox 'default'
 end
 
+MRuby::Build.new('bench') do |conf|
+  toolchain :gcc
+
+  conf.cc.flags << '-O3'
+
+  conf.gembox 'default'
+end
+
 # Define cross build settings
 # MRuby::CrossBuild.new('32bit') do |conf|
 #   toolchain :gcc


### PR DESCRIPTION
Since the default `host` build enables debug mode, I think we should add an another build just for benchmarking mruby.