### PR TITLE
Null check for irep & initialize loc.lineno

### DIFF
--- a/src/backtrace.c
+++ b/src/backtrace.c
@@ -108,6 +108,8 @@ each_backtrace(mrb_state *mrb, mrb_int ciidx, mrb_code *pc0, each_backtrace_func
 
   for (i = ciidx; i >= 0; i--) {
     struct backtrace_location_raw loc;
+    loc.lineno = -1;
+    
     mrb_callinfo *ci;
     mrb_irep *irep;
     mrb_code *pc;
@@ -128,8 +130,11 @@ each_backtrace(mrb_state *mrb, mrb_int ciidx, mrb_code *pc0, each_backtrace_func
     else {
       pc = pc0;
     }
-    loc.filename = mrb_debug_get_filename(irep, (uint32_t)(pc - irep->iseq));
-    loc.lineno = mrb_debug_get_line(irep, (uint32_t)(pc - irep->iseq));
+    
+    if (irep) {
+      loc.filename = mrb_debug_get_filename(irep, (uint32_t)(pc - irep->iseq));
+      loc.lineno = mrb_debug_get_line(irep, (uint32_t)(pc - irep->iseq));
+    }
 
     if (loc.lineno == -1) continue;
 

--- a/src/backtrace.c
+++ b/src/backtrace.c
@@ -108,11 +108,11 @@ each_backtrace(mrb_state *mrb, mrb_int ciidx, mrb_code *pc0, each_backtrace_func
 
   for (i = ciidx; i >= 0; i--) {
     struct backtrace_location_raw loc;
-    loc.lineno = -1;
-    
     mrb_callinfo *ci;
     mrb_irep *irep;
     mrb_code *pc;
+    
+    loc.lineno = -1;
 
     ci = &mrb->c->cibase[i];
 


### PR DESCRIPTION
Was really hoping to solve #3118 (& therefor jbreeden/mruby-apr#9), but no such luck.

Still, this fixes the segfault in #3122 for me.

```sh
[jared:~/projects/mruby-spec] cat test.rb 
def gen
  e0 = nil
  begin
    1.times {
      raise 'foobar'
    }
  rescue => e
    e0 = e
  end
  e0
end

e = gen
GC.start
gen
GC.start

p e.backtrace
[jared:~/projects/mruby-spec] mruby ./test.rb 
["./test.rb:18"]
```

(Of course, the backtrace is still losing information about where the exception was actually raised)