### PR TITLE
Suppress a warning

### DIFF
--- a/mrbgems/mruby-eval/src/eval.c
+++ b/mrbgems/mruby-eval/src/eval.c
@@ -133,7 +133,7 @@ patch_irep(mrb_state *mrb, mrb_irep *irep, int bnest)
 void mrb_codedump_all(mrb_state*, struct RProc*);
 
 static struct RProc*
-create_proc_from_string(mrb_state *mrb, char *s, int len, mrb_value binding, char *file, mrb_int line)
+create_proc_from_string(mrb_state *mrb, char *s, int len, mrb_value binding, const char *file, mrb_int line)
 {
   mrbc_context *cxt;
   struct mrb_parser_state *p;


### PR DESCRIPTION
    mrbgems/mruby-eval/src/eval.c: In function ‘create_proc_from_string’:
    mrbgems/mruby-eval/src/eval.c:152:10: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
         file = "(eval)";
              ^