### PR TITLE
Fix doesn't work bintest on :visualcpp toolchain

### DIFF
--- a/test/bintest.rb
+++ b/test/bintest.rb
@@ -20,6 +20,11 @@ def shellquote(s)
 end
 
 ARGV.each do |gem|
+  case RbConfig::CONFIG['host_os']
+  when /mswin(?!ce)|mingw|cygwin|bccwin/
+    gem = gem.gsub('\\', '/')
+  end
+
   Dir["#{gem}/bintest/**/*.rb"].each do |file|
     load file
   end


### PR DESCRIPTION
```:visualcpp``` toolchain set ```conf.file_separator = '\\'``` by default.
Dir.glob return empty array by backslash separator.
