### PR TITLE
Reduce compiler include_paths

### DIFF
--- a/tasks/mrbgem_spec.rake
+++ b/tasks/mrbgem_spec.rake
@@ -413,9 +413,12 @@ module MRuby
           # as circular dependency has already detected in the caller.
           import_include_paths(dep_g)
 
+          dep_g.export_include_paths.uniq!
           g.compilers.each do |compiler|
             compiler.include_paths += dep_g.export_include_paths
             g.export_include_paths += dep_g.export_include_paths
+            compiler.include_paths.uniq!
+            g.export_include_paths.uniq!
           end
         end
       end


### PR DESCRIPTION
When I tried to build [mruby-gtk3](https://github.com/ppibburr/mruby-gtk3), sometimes faild by inflation of include_paths. It contains many -I"/some/path/mruby-cfunc/include".
I guess it should be a 'set', without duplication.