### PR TITLE
Add missing regs update

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -2271,6 +2271,7 @@ RETRY_TRY_BLOCK:
         base = mrb_obj_value(mrb->c->ci->target_class);
       }
       c = mrb_vm_define_class(mrb, base, super, id);
+      regs = mrb->c->stack;
       regs[a] = mrb_obj_value(c);
       ARENA_RESTORE(mrb, ai);
       NEXT;


### PR DESCRIPTION
mrb_vm_define_class() may realloc() mrb->c->stack because it calls
mrb_funcall() for inherited hook. If mrb->c->stack is realloc()-ed, regs
refers orphan address.