### PR TITLE
Avoid Syntax Error on CRuby v1.8

### DIFF
--- a/tasks/toolchains/visualcpp.rake
+++ b/tasks/toolchains/visualcpp.rake
@@ -53,7 +53,7 @@ MRuby::Toolchain.new(:visualcpp) do |conf, _params|
 
   if require 'open3'
     Open3.popen3 conf.cc.command do |_, _, e, _|
-      if /Version (?<v>\d{2}\.\d{2}\.\d{5})/ =~ e.gets && v.to_i <= 17
+      if /Version (\d{2})\.\d{2}\.\d{5}/ =~ e.gets && $1.to_i <= 17
         m = "# VS2010/2012 support will be dropped after the next release! #"
         h = "#" * m.length
         puts h, m, h


### PR DESCRIPTION
CRuby v1.8 dose not support named capture.

```
$ ruby -v
ruby 1.8.7 (2013-06-27 patchlevel 374) [i686-darwin13.4.0]

$ rake
rake aborted!
SyntaxError: src/github.com/ksss/mruby/tasks/toolchains/visualcpp.rake:56: undefined (?...) sequence: /Version (?<v>\d{2}\.\d{2}\.\d{5})/

$ ./minirake
(in src/github.com/ksss/mruby)
rake aborted!
src/github.com/ksss/mruby/tasks/toolchains/visualcpp.rake:56: undefined (?...) sequence: /Version (?<v>\d{2}\.\d{2}\.\d{5})/
./rakefile:10:in `load'
```

Since this fix https://github.com/mruby/mruby/pull/3139

@cremno Could you review this? (I don't have visual studio)