### PR TITLE
fix MRUBY_VERSION value

### DIFF
--- a/src/version.c
+++ b/src/version.c
@@ -9,7 +9,7 @@ mrb_init_version(mrb_state* mrb)
   mrb_define_global_const(mrb, "RUBY_VERSION", mrb_str_new_lit(mrb, MRUBY_RUBY_VERSION));
   mrb_define_global_const(mrb, "RUBY_ENGINE", mrb_str_new_lit(mrb, MRUBY_RUBY_ENGINE));
   mrb_define_global_const(mrb, "RUBY_ENGINE_VERSION", mruby_version);
-  mrb_define_global_const(mrb, "MRUBY_VERSION", mrb_str_new_lit(mrb, MRUBY_VERSION));
+  mrb_define_global_const(mrb, "MRUBY_VERSION", mruby_version);
   mrb_define_global_const(mrb, "MRUBY_RELEASE_NO", mrb_fixnum_value(MRUBY_RELEASE_NO));
   mrb_define_global_const(mrb, "MRUBY_RELEASE_DATE", mrb_str_new_lit(mrb, MRUBY_RELEASE_DATE));
   mrb_define_global_const(mrb, "MRUBY_DESCRIPTION", mrb_str_new_lit(mrb, MRUBY_DESCRIPTION));


### PR DESCRIPTION
`RUBY_ENGINE_VERSION` and `MRUBY_VERSION` should refer to the same string.

Rationale: One less object is created and [JRuby does it too](https://github.com/jruby/jruby/blob/915993886ae6663586d893b7d237f750068aceb5/core/src/main/java/org/jruby/RubyGlobal.java#L133-L141).