### PR TITLE
Fix public methods

### DIFF
--- a/src/kernel.c
+++ b/src/kernel.c
@@ -722,9 +722,7 @@ mrb_obj_singleton_methods(mrb_state *mrb, mrb_bool recur, mrb_value obj)
 static mrb_value
 mrb_obj_methods(mrb_state *mrb, mrb_bool recur, mrb_value obj, mrb_method_flag_t flag)
 {
-  if (recur)
-    return mrb_class_instance_method_list(mrb, recur, mrb_class(mrb, obj), 0);
-  return mrb_obj_singleton_methods(mrb, recur, obj);
+  return mrb_class_instance_method_list(mrb, recur, mrb_class(mrb, obj), 0);
 }
 /* 15.3.1.3.31 */
 /*

--- a/test/t/kernel.rb
+++ b/test/t/kernel.rb
@@ -423,6 +423,11 @@ end
 
 assert('Kernel#public_methods', '15.3.1.3.38') do
   assert_equal Array, public_methods.class
+  class Foo
+    def foo
+    end
+  end
+  assert_equal [:foo], Foo.new.public_methods(false)
 end
 
 # Kernel#puts is defined in mruby-print mrbgem. '15.3.1.3.39'


### PR DESCRIPTION
```ruby
class Foo
  def foo
  end
end

class Bar < Foo
  def bar
  end
end

p Foo.new.public_methods(false)
p Bar.new.public_methods(false)
p Bar.new.public_methods.include?(:foo)
```

CRuby works as below:
```
[:foo]
[:bar]
true
```

But mruby does:
```
[:foo]
[:bar]
false
```

