### PR TITLE
Fix warning shift-negative-value

### DIFF
--- a/mrbgems/mruby-sprintf/src/sprintf.c
+++ b/mrbgems/mruby-sprintf/src/sprintf.c
@@ -17,7 +17,7 @@
 
 #define BIT_DIGITS(N)   (((N)*146)/485 + 1)  /* log2(10) =~ 146/485 */
 #define BITSPERDIG MRB_INT_BIT
-#define EXTENDSIGN(n, l) (((~0 << (n)) >> (((n)*(l)) % BITSPERDIG)) & ~(~0 << (n)))
+#define EXTENDSIGN(n, l) (((~0U << (n)) >> (((n)*(l)) % BITSPERDIG)) & ~(~0U << (n)))
 
 mrb_value mrb_str_format(mrb_state *, int, const mrb_value *, mrb_value);
 static void fmt_setup(char*,size_t,int,int,mrb_int,mrb_int);


### PR DESCRIPTION
On OSX & clang v7.3.0 appear these warning.

```
/Users/yuki/src/github.com/ksss/mruby/mrbgems/mruby-sprintf/src/sprintf.c:37:11: warning: shifting a negative signed value is undefined
      [-Wshift-negative-value]
    *t |= EXTENDSIGN(3, strlen(t));
          ^~~~~~~~~~~~~~~~~~~~~~~~
/Users/yuki/src/github.com/ksss/mruby/mrbgems/mruby-sprintf/src/sprintf.c:20:32: note: expanded from macro 'EXTENDSIGN'
#define EXTENDSIGN(n, l) (((~0 << (n)) >> (((n)*(l)) % BITSPERDIG)) & ~(~0 << (n)))
                            ~~ ^
/Users/yuki/src/github.com/ksss/mruby/mrbgems/mruby-sprintf/src/sprintf.c:37:11: warning: shifting a negative signed value is undefined
      [-Wshift-negative-value]
    *t |= EXTENDSIGN(3, strlen(t));
          ^~~~~~~~~~~~~~~~~~~~~~~~
/Users/yuki/src/github.com/ksss/mruby/mrbgems/mruby-sprintf/src/sprintf.c:20:76: note: expanded from macro 'EXTENDSIGN'
#define EXTENDSIGN(n, l) (((~0 << (n)) >> (((n)*(l)) % BITSPERDIG)) & ~(~0 << (n)))
```

So, I use unsigned suffix.

http://stackoverflow.com/questions/22883790/left-shift-of-negative-values-by-0-positions

This fix seems to be silent.
But I don't know best way to fix...