### PR TITLE
C doesn't have try-catch

### DIFF
--- a/include/mruby/throw.h
+++ b/include/mruby/throw.h
@@ -7,7 +7,7 @@
 #ifndef MRB_THROW_H
 #define MRB_THROW_H
 
-#ifdef MRB_ENABLE_CXX_EXCEPTION
+#if defined(MRB_ENABLE_CXX_EXCEPTION) && defined(__cplusplus)
 
 #define MRB_TRY(buf) do { try {
 #define MRB_CATCH(buf) } catch(mrb_jmpbuf_impl e) { if (e != (buf)->impl) { throw e; }
@@ -40,7 +40,7 @@ typedef mrb_int mrb_jmpbuf_impl;
 struct mrb_jmpbuf {
   mrb_jmpbuf_impl impl;
 
-#ifdef MRB_ENABLE_CXX_EXCEPTION
+#if defined(MRB_ENABLE_CXX_EXCEPTION) && defined(__cplusplus)
   static mrb_int jmpbuf_id;
   mrb_jmpbuf() : impl(jmpbuf_id++) {}
 #endif


### PR DESCRIPTION
It seems that there is a problem in case of using C and C++ gems at same time.
for example:

you write in build_config.rb like this.

```rb
conf.gem :github => 'kjunichi/mruby-mrmagick'
conf.gem :github => 'matsumoto-r/mruby-redis'
```

compile errors occur.

```txt
CC    build/mrbgems/mruby-redis/src/mrb_redis.c -> build/host/mrbgems/mruby-redis/src/mrb_redis.o
In file included from /Users/kjunichi/work/mruby/mrmagick/mruby/build/mrbgems/mruby-redis/src/mrb_redis.c:45:
/Users/kjunichi/work/mruby/mrmagick/mruby/include/mruby/throw.h:44:3: error: type name does not allow storage class
      to be specified
  static mrb_int jmpbuf_id;
  ^
/Users/kjunichi/work/mruby/mrmagick/mruby/include/mruby/throw.h:45:3: error: type name requires a specifier or
      qualifier
  mrb_jmpbuf() : impl(jmpbuf_id++) {}
  ^
/Users/kjunichi/work/mruby/mrmagick/mruby/include/mruby/throw.h:45:18: error: implicit declaration of function 'impl'
      is invalid in C99 [-Werror,-Wimplicit-function-declaration]
  mrb_jmpbuf() : impl(jmpbuf_id++) {}
                 ^
/Users/kjunichi/work/mruby/mrmagick/mruby/include/mruby/throw.h:45:23: error: use of undeclared identifier
      'jmpbuf_id'
  mrb_jmpbuf() : impl(jmpbuf_id++) {}
```
