### PR TITLE
Should not define to `Struct` class

### DIFF
--- a/mrbgems/mruby-struct/src/struct.c
+++ b/mrbgems/mruby-struct/src/struct.c
@@ -361,7 +361,7 @@ mrb_struct_s_def(mrb_state *mrb, mrb_value klass)
   }
   st = make_struct(mrb, name, rest, struct_class(mrb));
   if (!mrb_nil_p(b)) {
-    mrb_yield_with_class(mrb, b, 1, &st, st, mrb_class_ptr(klass));
+    mrb_yield_with_class(mrb, b, 1, &st, st, mrb_class_ptr(st));
   }
 
   return st;

--- a/mrbgems/mruby-struct/test/struct.rb
+++ b/mrbgems/mruby-struct/test/struct.rb
@@ -23,6 +23,9 @@ assert('Struct#==', '15.2.18.4.1') do
   cc1 = c.new(1,2)
   cc2 = c.new(1,2)
   assert_true cc1 == cc2
+
+  Struct.new(:m1, :m2) { def foo; end }
+  assert_raise(NoMethodError) { Struct.new(:m1).new.foo }
 end
 
 assert('Struct#[]', '15.2.18.4.2') do


### PR DESCRIPTION
```rb
Struct.new(:foo) do
  def bar
  end
end
Struct.new(:baz).new.bar
```

This case should raise NoMethodError, But nothing.