### PR TITLE
Support to call without block to String#each_char

### DIFF
--- a/mrbgems/mruby-string-ext/mrblib/string.rb
+++ b/mrbgems/mruby-string-ext/mrblib/string.rb
@@ -362,7 +362,15 @@ class String
       self.split('')
     end
   end
-  alias each_char chars
+
+  def each_char(&block)
+    return to_enum :each_char unless block
+
+    split('').map do |i|
+      block.call(i)
+    end
+    self
+  end
 
   def codepoints(&block)
     len = self.size


### PR DESCRIPTION
`String#char` and `String#each_char` aren't same methods.

This patch support like this (same as CRuby).

```rb
"foo".each_char.with_index do |ch, index|
  # ...
end
```