### PR TITLE
Reduce needless Array generation in some String methods

### DIFF
--- a/mrbgems/mruby-string-ext/mrblib/string.rb
+++ b/mrbgems/mruby-string-ext/mrblib/string.rb
@@ -354,7 +354,7 @@ class String
 
   def chars(&block)
     if block_given?
-      self.split('').map do |i|
+      self.split('').each do |i|
         block.call(i)
       end
       self
@@ -366,7 +366,7 @@ class String
   def each_char(&block)
     return to_enum :each_char unless block
 
-    split('').map do |i|
+    split('').each do |i|
       block.call(i)
     end
     self
@@ -376,7 +376,7 @@ class String
     len = self.size
 
     if block_given?
-      self.split('').map do|x|
+      self.split('').each do|x|
         block.call(x.ord)
       end
       self


### PR DESCRIPTION
Here are some benchmarks:

each_char:

    # /tmp/each_char.rb
    a = "a" * 1000000
    a.each_char do |x|
    end

Without this change:

    % time bin/mruby /tmp/each_char.rb
    bin/mruby /tmp/each_char.rb  1.07s user 0.02s system 99% cpu 1.088 total

With this change:

    % time bin/mruby /tmp/each_char.rb
    bin/mruby /tmp/each_char.rb  0.52s user 0.01s system 99% cpu 0.530 total

2 times faster with this change.

codepoints:

    # /tmp/codepoints.rb
    a = "a" * 1000000
    a.codepoints do |x|
    end

Without this change:

    % time bin/mruby /tmp/codepoints.rb
    bin/mruby /tmp/codepoints.rb  1.16s user 0.05s system 99% cpu 1.216 total

With this change:

    % time bin/mruby /tmp/codepoints.rb
    bin/mruby /tmp/codepoints.rb  0.56s user 0.02s system 99% cpu 0.589 total