### PR TITLE
parse.y: lparen_arg statement

### DIFF
--- a/mrbgems/mruby-compiler/core/parse.y
+++ b/mrbgems/mruby-compiler/core/parse.y
@@ -2090,7 +2090,7 @@ primary         : literal
                       $<stack>$ = p->cmdarg_stack;
                       p->cmdarg_stack = 0;
                     }
-                  expr {p->lstate = EXPR_ENDARG;} rparen
+                  stmt {p->lstate = EXPR_ENDARG;} rparen
                     {
                       p->cmdarg_stack = $<stack>2;
                       $$ = $3;


### PR DESCRIPTION
allow parenthesised statement as a method argument.
reported [Feature:12686] in bugs.ruby-lang.org fixed in CRuby 2.4.