### PR TITLE
Fix mrbc_filename leak

### DIFF
--- a/mrbgems/mruby-compiler/core/parse.y
+++ b/mrbgems/mruby-compiler/core/parse.y
@@ -5540,6 +5540,7 @@ mrbc_context_new(mrb_state *mrb)
 MRB_API void
 mrbc_context_free(mrb_state *mrb, mrbc_context *cxt)
 {
+  mrb_free(mrb, cxt->filename);
   mrb_free(mrb, cxt->syms);
   mrb_free(mrb, cxt);
 }
@@ -5549,9 +5550,12 @@ mrbc_filename(mrb_state *mrb, mrbc_context *c, const char *s)
 {
   if (s) {
     int len = strlen(s);
-    char *p = (char *)mrb_alloca(mrb, len + 1);
+    char *p = (char *)mrb_malloc(mrb, len + 1);
 
     memcpy(p, s, len + 1);
+    if (c->filename) {
+      mrb_free(mrb, c->filename);
+    }
     c->filename = p;
   }
   return c->filename;


### PR DESCRIPTION
Hi there,
I'm very new to mruby.

I encountered a small memory leak when using mruby-eval,
it was small(maybe 8bytes for once for glibc)
but ate all physical memory on my system after one day of stress test.

I've dug it and found mrbc_context.filename is not freed when
the context is freed. I know this conversion has been closed at #1878 and
I understand this behavior never cause problem if application creates
only one mrb_context for one mrb_state. 
However, mruby-eval allows to create many contexts in one mrb_state.

This pull request tries to fix the memory leak, I'm not sure it's correct or not
but it works for me.