### PR TITLE
Should clear method name

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -2434,6 +2434,7 @@ mrb_top_run(mrb_state *mrb, struct RProc *proc, mrb_value self, unsigned int sta
     return mrb_vm_run(mrb, proc, self, stack_keep);
   }
   ci = cipush(mrb);
+  ci->mid = 0;
   ci->nregs = 1;   /* protect the receiver */
   ci->acc = CI_ACC_SKIP;
   ci->target_class = mrb->object_class;


### PR DESCRIPTION
This patch fix two issue if callinfo over CALLINFO_INIT_SIZE(32)

- Fix method name in top-level
- Fix SEGV when call Exception#backtrace

```rb
1.times{1.times{1.times{1.times{1.times{1.times{1.times{1.times{
1.times{1.times{1.times{1.times{1.times{1.times{1.times{1.times{
  begin
    eval('raise')
  rescue => e
    print e.backtrace
  end
}}}}}}}}
}}}}}}}}
```

This code have rundom results.

```
$ mruby t.rb
["(eval):1:in Object.rand", "t.rb:6:in Object.call", "mruby/mrblib/numeric.rb:77:in Integral#times", ... , "t.rb:3"]
```

`Object.rand` never call in script and this string sometimes chenge `Object.__attached__`, `Object.INFINITY` or SEGV.

```rb
$ mruby t.rb
[1]    41204 segmentation fault  mruby t.rb
```

This issue's reasone is here.

https://github.com/ksss/mruby/blob/501e1ef2605541b98b6f0d2ba2fec69ff068f1cf/src/vm.c#L226

`mrb_calloc` clean up memory by 0. But `mrb_realloc` is nothing.

This line was called if callinfo over CALLINFO_INIT_SIZE(32).

`Kernel#eval` call `mrb_top_run` and push none cleared `mid` to callinfo.

I think it should clear by 0.

---

```
$ uname -v
Darwin Kernel Version 15.6.0: Mon Aug 29 20:21:34 PDT 2016; root:xnu-3248.60.11~1/RELEASE_X86_64

$ clang -v
Apple LLVM version 7.3.0 (clang-703.0.31)
Target: x86_64-apple-darwin15.6.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```