### PR TITLE
Fix SEGV when unshared env

### DIFF
--- a/mrbgems/mruby-eval/src/eval.c
+++ b/mrbgems/mruby-eval/src/eval.c
@@ -26,6 +26,8 @@ get_closure_irep(mrb_state *mrb, int level)
   }
 
   if (!e) return NULL;
+  if (!MRB_ENV_STACK_SHARED_P(e)) return NULL;
+
   proc = c->cibase[e->cioff].proc;
 
   if (!proc || MRB_PROC_CFUNC_P(proc)) {


### PR DESCRIPTION
I'm trying project what run [ruby/spec](https://github.com/ruby/spec) by mruby. (https://github.com/ksss/mruby-spec)

I encountered SEGV on spec for /language.

On `get_closure_irep` in eval.c, It is a possibility that unshare stack env (cioff=-1) comes.
And It will read `mrb->c->cibase[-1]`.

https://github.com/mruby/mruby/blob/9040086e927781018dc9b89d0d160dbba4e76297/mrbgems/mruby-eval/src/eval.c#L29

### How to reproduce

```rb
def m
  Proc.new { eval('raise') }
end

1.times{1.times{1.times{1.times{1.times{1.times{1.times{1.times{
1.times{1.times{1.times{1.times{1.times{1.times{1.times{1.times{
  m.call
}}}}}}}}
}}}}}}}}
```