### PR TITLE
Add missing MRB_API

### DIFF
--- a/include/mruby/dump.h
+++ b/include/mruby/dump.h
@@ -26,7 +26,7 @@ int mrb_dump_irep(mrb_state *mrb, mrb_irep *irep, uint8_t flags, uint8_t **bin, 
 #ifndef MRB_DISABLE_STDIO
 int mrb_dump_irep_binary(mrb_state*, mrb_irep*, uint8_t, FILE*);
 int mrb_dump_irep_cfunc(mrb_state *mrb, mrb_irep*, uint8_t flags, FILE *f, const char *initname);
-mrb_irep *mrb_read_irep_file(mrb_state*, FILE*);
+MRB_API mrb_irep *mrb_read_irep_file(mrb_state*, FILE*);
 MRB_API mrb_value mrb_load_irep_file(mrb_state*,FILE*);
 MRB_API mrb_value mrb_load_irep_file_cxt(mrb_state*, FILE*, mrbc_context*);
 #endif


### PR DESCRIPTION
MRB_API is used implementation in load.c:

    MRB_API mrb_irep*
    mrb_read_irep_file(mrb_state *mrb, FILE* fp)