### PR TITLE
Remove needless MRB_API

### DIFF
--- a/src/load.c
+++ b/src/load.c
@@ -646,7 +646,7 @@ mrb_load_irep(mrb_state *mrb, const uint8_t *bin)
 
 #ifndef MRB_DISABLE_STDIO
 
-MRB_API mrb_irep*
+mrb_irep*
 mrb_read_irep_file(mrb_state *mrb, FILE* fp)
 {
   mrb_irep *irep = NULL;

--- a/src/proc.c
+++ b/src/proc.c
@@ -135,7 +135,7 @@ mrb_proc_cfunc_env_get(mrb_state *mrb, mrb_int idx)
   return e->stack[idx];
 }
 
-MRB_API void
+void
 mrb_proc_copy(struct RProc *a, struct RProc *b)
 {
   a->flags = b->flags;

--- a/src/string.c
+++ b/src/string.c
@@ -576,7 +576,7 @@ str_rindex(mrb_state *mrb, mrb_value str, mrb_value sub, mrb_int pos)
   }
 }
 
-MRB_API mrb_int
+mrb_int
 mrb_str_strlen(mrb_state *mrb, struct RString *s)
 {
   mrb_int i, max = RSTR_LEN(s);


### PR DESCRIPTION
ref #3215

If a function (such as mrb_read_irep_file()) is declared without MRB_API
in header file (such as include/mruby/dump.h), implementation of the
function in source file (such as src/load.c) should also defined without
MRB_API.

If MRB_API is mismatch, Visual C++ reports link error with C2375 error
code: https://msdn.microsoft.com/en-us/library/5k6kw95a.aspx