### PR TITLE
Fix unexpected behavior with break

### DIFF
--- a/mrbgems/mruby-compiler/core/codegen.c
+++ b/mrbgems/mruby-compiler/core/codegen.c
@@ -2852,6 +2852,9 @@ loop_break(codegen_scope *s, node *tree)
       loop->pc3 = tmp;
     }
     else {
+      if (!tree) {
+        genop(s, MKOP_A(OP_LOADNIL, cursp()));
+      }
       genop(s, MKOP_AB(OP_RETURN, cursp(), OP_R_BREAK));
     }
   }


### PR DESCRIPTION
I found unexpected behavior.

```rb
def yie
  yield
end

def bre
  yie {
    1+1
    break
  }
end

p bre #=> display 2, but should be nil
```

You can check this behavior on [ruby/spec/language/break_spec.rb](https://github.com/ruby/spec/blob/d05fabfe0ba3774710d912d2802d6d235c1ed8ae/language/break_spec.rb)

This patch fix 2 cases of specs

before:
F..FFF..F.FFF.FFEEE..FE.F.FEE.E

after:
...FFF....FFF.FFEEE..FE.F.FEE.E

Fixed specs:
https://github.com/ruby/spec/blob/d05fabfe0ba3774710d912d2802d6d235c1ed8ae/language/break_spec.rb#L10-L13
https://github.com/ruby/spec/blob/d05fabfe0ba3774710d912d2802d6d235c1ed8ae/language/break_spec.rb#L91-L94