### PR TITLE
Android mips/mips64 support

### DIFF
--- a/tasks/toolchains/android.rake
+++ b/tasks/toolchains/android.rake
@@ -5,9 +5,12 @@ class MRuby::Toolchain::Android
   DEFAULT_TOOLCHAIN = :clang
 
   DEFAULT_NDK_HOMES = %w{
-    /usr/local/opt/android-ndk
     /usr/local/opt/android-sdk/ndk-bundle
+    /usr/local/opt/android-ndk
     %LOCALAPPDATA%/Android/android-sdk/ndk-bundle
+    %LOCALAPPDATA%/Android/android-ndk
+    ~/Library/Android/sdk/ndk-bundle
+    ~/Library/Android/ndk
   }
 
   TOOLCHAINS = [:clang] # TODO : Add gcc support
@@ -92,6 +95,7 @@ Set ANDROID_PLATFORM environment variable or set :platform parameter
       DEFAULT_NDK_HOMES.find { |path|
         path.gsub! '%LOCALAPPDATA%', ENV['LOCALAPPDATA'] || '%LOCALAPPDATA%'
         path.gsub! '\\', '/'
+        path.gsub! '~', Dir.home || '~'
         File.directory?(path)
       } || raise(AndroidNDKHomeNotFound)
     )
@@ -195,7 +199,7 @@ Set ANDROID_PLATFORM environment variable or set :platform parameter
     flags += %W(-D__android__ --sysroot="#{sysroot}")
     case toolchain
     when :clang
-      flags += %W(-gcc-toolchain #{toolchain_path.to_s})
+      flags += %W(-gcc-toolchain "#{toolchain_path.to_s}")
       case arch
       when /armeabi-v7a/  then flags += %W(-target armv7-none-linux-androideabi)
       when /armeabi/      then flags += %W(-target armv5te-none-linux-androideabi)


### PR DESCRIPTION
Added macOS NDK search paths.

The Android SDK now has NDK installation built in, so the task will now favour that if no ndk_home is set.
~/Library/Android is the default for macOS.

The gcc toolchain path has quotes now, this is a minor change but it fixes the possibility of spaces in that path - keeps it consistent with the use of quotes for other paths in the task.