### PR TITLE
Android Task GCC support re-added

### DIFF
--- a/tasks/toolchains/android.rake
+++ b/tasks/toolchains/android.rake
@@ -13,7 +13,7 @@ class MRuby::Toolchain::Android
     ~/Library/Android/ndk
   }
 
-  TOOLCHAINS = [:clang, :gcc] # TODO : Add gcc support
+  TOOLCHAINS = [:clang, :gcc]
 
   ARCHITECTURES = %w{
     armeabi armeabi-v7a arm64-v8a


### PR DESCRIPTION
This adds GCC compiler support back into the Android build rule. It is there for support, as the default for Android is now Clang (with GCC deprecated).

There are a few things omitted that were in the old Android task; namely hard/soft floating point support and the cortex a8 fix. These should probably be handled as cflags outside of the rule itself.