### PR TITLE
Kernel#respond_to? should return true|false only

### DIFF
--- a/src/kernel.c
+++ b/src/kernel.c
@@ -963,7 +963,7 @@ obj_respond_to(mrb_state *mrb, mrb_value self)
       mrb_value args[2];
       args[0] = mid;
       args[1] = mrb_bool_value(priv);
-      return mrb_funcall_argv(mrb, self, rtm_id, 2, args);
+      return mrb_bool_value(mrb_bool(mrb_funcall_argv(mrb, self, rtm_id, 2, args)));
     }
   }
   return mrb_bool_value(respond_to_p);


### PR DESCRIPTION
t.rb

```rb
class A
  def respond_to_missing? method, bool
    p [method, bool]
  end
end
p A.new.respond_to?(:foo)
```

Actual

```
$ mruby t.rb
[:foo, false]
[:foo, false]
```

Expect

```
$ ruby t.rb
[:foo, false]
true
```