### PR TITLE
Make `class` & `module` return a symbol

### DIFF
--- a/mrbgems/mruby-compiler/core/codegen.c
+++ b/mrbgems/mruby-compiler/core/codegen.c
@@ -2545,7 +2545,7 @@ codegen(codegen_scope *s, node *tree, int val)
 
   case NODE_CLASS:
     {
-      int idx;
+      int idx, sclass_idx;
 
       if (tree->car->car == (node*)0) {
         genop(s, MKOP_A(OP_LOADNIL, cursp()));
@@ -2567,9 +2567,14 @@ codegen(codegen_scope *s, node *tree, int val)
       }
       pop(); pop();
       idx = new_msym(s, sym(tree->car->cdr));
+      sclass_idx = idx;
+
       genop(s, MKOP_AB(OP_CLASS, cursp(), idx));
       idx = scope_body(s, tree->cdr->cdr->car, val);
       genop(s, MKOP_ABx(OP_EXEC, cursp(), idx));
+
+      genop(s, MKOP_ABx(OP_LOADSYM, cursp(), sclass_idx ? sclass_idx : idx));
+
       if (val) {
         push();
       }
@@ -2596,6 +2601,7 @@ codegen(codegen_scope *s, node *tree, int val)
       genop(s, MKOP_AB(OP_MODULE, cursp(), idx));
       idx = scope_body(s, tree->cdr->car, val);
       genop(s, MKOP_ABx(OP_EXEC, cursp(), idx));
+      genop(s, MKOP_ABx(OP_LOADSYM, cursp(), idx));
       if (val) {
         push();
       }

--- a/test/t/class.rb
+++ b/test/t/class.rb
@@ -231,9 +231,12 @@ assert('Class.new') do
   assert_equal([klass], a)
 end
 
-assert('class to return the last value') do
-  m = class C; :m end
-  assert_equal(m, :m)
+assert('class to return a symbol representing the defined class') do
+  c = class C; :m end
+  assert_equal(:C, c)
+
+  d = class D < C; :m end
+  assert_equal(:D, d)
 end
 
 assert('raise when superclass is not a class') do

--- a/test/t/module.rb
+++ b/test/t/module.rb
@@ -837,3 +837,8 @@ assert('module with non-class/module outer raises TypeError') do
   assert_raise(TypeError) { module 0::M1 end }
   assert_raise(TypeError) { module []::M2 end }
 end
+
+assert('module to return a symbol representing the defined module') do
+  m = module M; :s end
+  assert_equal(:M, m)
+end


### PR DESCRIPTION
This commit makes the behavior of `class` and `module` consistent with how `def`
is currently working:

    class A end      # => :A
    class B < A; end # => :B
    module M end     # => :M