### PR TITLE
Update documentation of fetch

### DIFF
--- a/mrbgems/mruby-array-ext/mrblib/array.rb
+++ b/mrbgems/mruby-array-ext/mrblib/array.rb
@@ -275,8 +275,9 @@ class Array
   #  +default+ value.
   #
   #  Alternatively, if a block is given it will only be executed when an
-  #  invalid +index+ is referenced.  Negative values of +index+ count from the
-  #  end of the array.
+  #  invalid +index+ is referenced.
+  #
+  #  Negative values of +index+ count from the end of the array.
   #
   #     a = [ 11, 22, 33, 44 ]
   #     a.fetch(1)               #=> 22


### PR DESCRIPTION
The sentence `Negative values of +index+ count from the end of the array.` can be interpreted that it only holds if a block is given. Clarify it.