### PR TITLE
Add mrb_class_defined_under

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -567,6 +567,37 @@ MRB_API mrb_bool mrb_class_defined(mrb_state *mrb, const char *name);
 MRB_API struct RClass * mrb_class_get(mrb_state *mrb, const char *name);
 
 /**
+ * Returns an mrb_bool. True if inner class was defined, and false if the inner class was not defined.
+ *
+ * Example:
+ *     void
+ *     mrb_example_gem_init(mrb_state* mrb) {
+ *       struct RClass *example_outer, *example_inner;
+ *       mrb_bool cd;
+ *
+ *       example_outer = mrb_define_module(mrb, "ExampleOuter");
+ *
+ *       example_inner = mrb_define_class_under(mrb, example_outer, "ExampleInner", mrb->object_class);
+ *       cd = mrb_class_defined_under(mrb, example_outer, "ExampleInner");
+ *
+ *       // If mrb_class_defined_under returns 1 then puts "True"
+ *       // If mrb_class_defined_under returns 0 then puts "False"
+ *       if (cd == 1){
+ *         puts("True");
+ *       }
+ *       else {
+ *         puts("False");
+ *       }
+ *      }
+ *
+ * @param [mrb_state*] mrb The current mruby state.
+ * @param [struct RClass *] outer The name of the outer class.
+ * @param [const char *] name A string representing the name of the inner class.
+ * @return [mrb_bool] A boolean value.
+ */
+MRB_API mrb_bool mrb_class_defined_under(mrb_state *mrb, struct RClass *outer, const char *name);
+
+/**
  * Gets a child class.
  * @param [mrb_state*] mrb The current mruby state.
  * @param [struct RClass *] outer The name of the parent class.

--- a/mrbgems/mruby-compiler/core/codegen.c
+++ b/mrbgems/mruby-compiler/core/codegen.c
@@ -1655,11 +1655,21 @@ codegen(codegen_scope *s, node *tree, int val)
         }
         tree = tree->car;
         if (tree->car) {                /* pre */
+          int first = TRUE;
           t = tree->car;
           n = 0;
           while (t) {
-            gen_assignment(s, t->car, rhs+n, NOVAL);
-            n++;
+            if (n < len) {
+              gen_assignment(s, t->car, rhs+n, NOVAL);
+              n++;
+            }
+            else {
+              if (first) {
+                genop(s, MKOP_A(OP_LOADNIL, rhs+n));
+                first = FALSE;
+              }
+              gen_assignment(s, t->car, rhs+n, NOVAL);
+            }
             t = t->cdr;
           }
         }

--- a/mrbgems/mruby-compiler/core/codegen.c
+++ b/mrbgems/mruby-compiler/core/codegen.c
@@ -1645,7 +1645,7 @@ codegen(codegen_scope *s, node *tree, int val)
       node *t = tree->cdr, *p;
       int rhs = cursp();
 
-      if ((intptr_t)t->car == NODE_ARRAY && nosplat(t->cdr)) {
+      if ((intptr_t)t->car == NODE_ARRAY && t->cdr && nosplat(t->cdr)) {
         /* fixed rhs */
         t = t->cdr;
         while (t) {

--- a/src/class.c
+++ b/src/class.c
@@ -271,6 +271,16 @@ mrb_class_defined(mrb_state *mrb, const char *name)
   return mrb_const_defined(mrb, mrb_obj_value(mrb->object_class), mrb_symbol(sym));
 }
 
+MRB_API mrb_bool
+mrb_class_defined_under(mrb_state *mrb, struct RClass *outer, const char *name)
+{
+  mrb_value sym = mrb_check_intern_cstr(mrb, name);
+  if (mrb_nil_p(sym)) {
+    return FALSE;
+  }
+  return mrb_const_defined_at(mrb, mrb_obj_value(outer), mrb_symbol(sym));
+}
+
 MRB_API struct RClass *
 mrb_class_get_under(mrb_state *mrb, struct RClass *outer, const char *name)
 {

--- a/src/variable.c
+++ b/src/variable.c
@@ -760,13 +760,15 @@ mrb_mod_cv_get(mrb_state *mrb, struct RClass * c, mrb_sym sym)
 {
   struct RClass * cls = c;
   mrb_value v;
+  int given = FALSE;
 
   while (c) {
     if (c->iv && iv_get(mrb, c->iv, sym, &v)) {
-      return v;
+      given = TRUE;
     }
     c = c->super;
   }
+  if (given) return v;
   if (cls && cls->tt == MRB_TT_SCLASS) {
     mrb_value klass;
 
@@ -774,12 +776,14 @@ mrb_mod_cv_get(mrb_state *mrb, struct RClass * c, mrb_sym sym)
                            mrb_intern_lit(mrb, "__attached__"));
     c = mrb_class_ptr(klass);
     if (c->tt == MRB_TT_CLASS || c->tt == MRB_TT_MODULE) {
+      given = FALSE;
       while (c) {
         if (c->iv && iv_get(mrb, c->iv, sym, &v)) {
-          return v;
+          given = TRUE;
         }
         c = c->super;
       }
+      if (given) return v;
     }
   }
   mrb_name_error(mrb, sym, "uninitialized class variable %S in %S",

--- a/src/vm.c
+++ b/src/vm.c
@@ -1513,6 +1513,7 @@ RETRY_TRY_BLOCK:
       /* A B     return R(A) (B=normal,in-block return/break) */
       if (mrb->exc) {
         mrb_callinfo *ci;
+        mrb_value *stk;
         int eidx;
 
       L_RAISE:
@@ -1524,6 +1525,7 @@ RETRY_TRY_BLOCK:
           if (ci->ridx == 0) goto L_STOP;
           goto L_RESCUE;
         }
+        stk = mrb->c->stack;
         while (ci[0].ridx == ci[-1].ridx) {
           cipop(mrb);
           ci = mrb->c->ci;
@@ -1533,6 +1535,7 @@ RETRY_TRY_BLOCK:
             MRB_THROW(prev_jmp);
           }
           if (ci == mrb->c->cibase) {
+            mrb->c->stack = stk;
             while (eidx > 0) {
               ecall(mrb, --eidx);
             }

--- a/test/t/exception.rb
+++ b/test/t/exception.rb
@@ -338,10 +338,13 @@ assert('Exception 19') do
       begin
         1 * "b"
       ensure
-        @e = self.z
+        @e = self.zz
       end
     end
 
+    def zz
+      true
+    end
     def z
       true
     end


### PR DESCRIPTION
Works the same way as mrb_class_defined but uses mrb_const_defined_at with a given outer class to test if an inner class is defined.

Example code for checking if an inner class of a module is defined:
```c
void
mrb_example_gem_init(mrb_state* mrb) {
  struct RClass *example_outer, *example_inner;
  mrb_bool cd;

  example_outer = mrb_define_module(mrb, "ExampleOuter");

  example_inner = mrb_define_class_under(mrb, example_outer, "ExampleInner", mrb->object_class);
  cd = mrb_class_under_defined(mrb, example_outer, "ExampleInner");

  // If mrb_class_under_defined returns 1 then puts "True"
  // If mrb_class_under_defined returns 0 then puts "False"
  if (cd == 1){
    puts("True");
  }
  else {
    puts("False");
  }
}
```