### PR TITLE
test/assert.rb should not use puts

### DIFF
--- a/test/assert.rb
+++ b/test/assert.rb
@@ -213,7 +213,7 @@ def report()
   t_print("\n")
 
   $asserts.each do |msg|
-    puts msg
+    t_print "#{msg}\n"
   end
 
   $total_test = $ok_test+$ko_test+$kill_test


### PR DESCRIPTION
Is there a reason for `test/assert.rb` to use `puts`? This requires `mruby-print` gem to be always included in tests. We should be able to use `t_print` (which calls `__t_printstr__` from test driver) instead.