### PR TITLE
Reimplement Enumerable#cycle 

### DIFF
--- a/mrbgems/mruby-enum-ext/mrblib/enum.rb
+++ b/mrbgems/mruby-enum-ext/mrblib/enum.rb
@@ -573,35 +573,38 @@ module Enumerable
   #     a.cycle(2) { |x| puts x }  # print, a, b, c, a, b, c.
   #
 
-  def cycle(n=nil, &block)
-    return to_enum(:cycle, n) if !block && n.nil?
+  def cycle(nv = nil, &block)
+    return to_enum(:cycle, nv) unless block
+
+    n = nil
+
+    if nv.nil?
+      n = -1
+    else
+      unless nv.respond_to?(:to_int)
+        raise TypeError, "no implicit conversion of #{nv.class} into Integer"
+      end
+      n = nv.to_int
+      unless n.kind_of?(Integer)
+        raise TypeError, "no implicit conversion of #{nv.class} into Integer"
+      end
+      return nil if n <= 0
+    end
 
     ary = []
-    if n.nil?
-      self.each do|*val|
-        ary.push val
-        block.call(*val)
-      end
-      loop do
-        ary.each do|e|
-          block.call(*e)
-        end
-      end
-    else
-      raise TypeError, "no implicit conversion of #{n.class} into Integer" unless n.respond_to?(:to_int)
+    each do |*i|
+      ary.push(i)
+      yield(*i)
+    end
+    return nil if ary.empty?
 
-      n = n.to_int
-      self.each do|*val|
-        ary.push val
-      end
-      count = 0
-      while count < n
-        ary.each do|e|
-          block.call(*e)
-        end
-        count += 1
+    while n < 0 || 0 < (n -= 1)
+      ary.each do |i|
+        yield(*i)
       end
     end
+
+    nil
   end
 
   ##

--- a/mrbgems/mruby-enum-ext/test/enum.rb
+++ b/mrbgems/mruby-enum-ext/test/enum.rb
@@ -128,6 +128,13 @@ assert("Enumerable#cycle") do
   ["a", "b", "c"].cycle(2) { |v| a << v }
   assert_equal ["a", "b", "c", "a", "b", "c"], a
   assert_raise(TypeError) { ["a", "b", "c"].cycle("a") { |v| a << v } }
+
+  empty = Class.new do
+    include Enumerable
+    def each
+    end
+  end
+  assert_nil empty.new.cycle { break :nope }
 end
 
 assert("Enumerable#find_index") do


### PR DESCRIPTION
I tryed [mruby-spec](https://github.com/ksss/mruby-spec) with enumerable and encountered infinite loop

Because this code run inifinity

```rb
class Empty
  include Enumerable
  def each
  end
end
Empty.new.cycle { break :nope }
```

So, I supported all specs in https://github.com/ruby/spec/blob/27960d06e0ce92c37f074450f0eab4b0519b118c/core/enumerable/cycle_spec.rb without Enumerable#size