### PR TITLE
Remove webhook notification for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,3 @@ addons:
 
 env: MRUBY_CONFIG=travis_config.rb
 script: "./minirake all test"
-
-notifications:
-  # Update mruby-head installed on Travis CI so other projects can test against it.
-  webhooks:
-    urls:
-      - "https://rubies.travis-ci.org/rebuild/mruby-head"
-    on_success: always
-    on_failure: never


### PR DESCRIPTION
`travis-rubies` now uses 3 Mac jobs to create archives for various OS
releases.

This is a bit wasteful if multiple builds pass in a short period.

Instead, Travis CI is now running a nightly build of mruby-head
(around 22:30 UTC). This will happen regardless of the state of the
master branch.