### PR TITLE
Ranges should not rewrite

### DIFF
--- a/src/range.c
+++ b/src/range.c
@@ -129,6 +129,9 @@ mrb_range_initialize(mrb_state *mrb, mrb_value range)
     exclusive = FALSE;
   }
   /* Ranges are immutable, so that they should be initialized only once. */
+  if (mrb_range_ptr(range)->edges) {
+    mrb_name_error(mrb, mrb_intern_lit(mrb, "initialize"), "`initialize' called twice");
+  }
   range_init(mrb, range, beg, end, exclusive);
   return range;
 }

--- a/test/t/range.rb
+++ b/test/t/range.rb
@@ -57,6 +57,8 @@ assert('Range#initialize', '15.2.14.4.9') do
   assert_true a.exclude_end?
   assert_equal (1..10), b
   assert_false b.exclude_end?
+
+  assert_raise(NameError) { (0..1).send(:initialize, 1, 3) }
 end
 
 assert('Range#last', '15.2.14.4.10') do


### PR DESCRIPTION
In comments say *"Ranges are immutable, so that they should be initialized only once."*
But Range object can rewrite by `Range#initialize`.

```rb
$ mirb
mirb - Embeddable Interactive Ruby Shell

> range = (0..1)
 => 0..1
> range.send(:initialize, 1, 3)
 => 1..3
> range
 => 1..3
```

CRuby raise NameError in this case.

```rb
$ irb
irb(main):001:0> (0..1).send(:initialize, 1, 3)
NameError: `initialize' called twice
```