### PR TITLE
Fix condition of Range#include?

### DIFF
--- a/src/range.c
+++ b/src/range.c
@@ -229,7 +229,7 @@ mrb_range_include(mrb_state *mrb, mrb_value range)
   end = r->edges->end;
   include_p = r_le(mrb, beg, val) && /* beg <= val */
               ((r->excl && r_gt(mrb, end, val)) || /* end >  val */
-              (r_ge(mrb, end, val))); /* end >= val */
+              (!r->excl && r_ge(mrb, end, val))); /* end >= val */
 
   return mrb_bool_value(include_p);
 }

--- a/test/t/range.rb
+++ b/test/t/range.rb
@@ -43,10 +43,11 @@ assert('Range#first', '15.2.14.4.7') do
 end
 
 assert('Range#include?', '15.2.14.4.8') do
-  a = (1..10)
+  assert_true (1..10).include?(10)
+  assert_false (1..10).include?(11)
 
-  assert_true a.include?(5)
-  assert_false a.include?(20)
+  assert_true (1...10).include?(9)
+  assert_false (1...10).include?(10)
 end
 
 assert('Range#initialize', '15.2.14.4.9') do


### PR DESCRIPTION
# Expect

```rb
p (1...10).include?(9) #=> true
p (1...10).include?(10) #=> false
```

# Actual

```rb
p (1...10).include?(9) #=> true
p (1...10).include?(10) #=> true
```

Maybe missed in https://github.com/mruby/mruby/commit/be5986b2b4fc1534d753d53ac26081c98ce8883d