### PR TITLE
Hash object_id to prevent programs from knowing pointers

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -184,6 +184,8 @@ typedef struct mrb_state {
   struct RClass *eStandardError_class;
   struct RObject *nomem_err;              /* pre-allocated NoMemoryError */
 
+  unsigned char key[16]; /* siphash key */
+
   void *ud; /* auxiliary data */
 
 #ifdef MRB_FIXED_STATE_ATEXIT_STACK
@@ -981,7 +983,7 @@ MRB_API mrb_value mrb_vm_exec(mrb_state*, struct RProc*, mrb_code*);
 #define mrb_context_run(m,p,s,k) mrb_vm_run((m),(p),(s),(k))
 
 MRB_API void mrb_p(mrb_state*, mrb_value);
-MRB_API mrb_int mrb_obj_id(mrb_value obj);
+MRB_API mrb_int mrb_obj_id(mrb_state *mrb, mrb_value obj);
 MRB_API mrb_sym mrb_obj_to_sym(mrb_state *mrb, mrb_value name);
 
 MRB_API mrb_bool mrb_obj_eq(mrb_state*, mrb_value, mrb_value);

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -146,7 +146,7 @@ mrb_equal_m(mrb_state *mrb, mrb_value self)
 static mrb_value
 mrb_obj_id_m(mrb_state *mrb, mrb_value self)
 {
-  return mrb_fixnum_value(mrb_obj_id(self));
+  return mrb_fixnum_value(mrb_obj_id(mrb, self));
 }
 
 /* 15.3.1.2.2  */
@@ -463,7 +463,7 @@ mrb_obj_extend_m(mrb_state *mrb, mrb_value self)
 MRB_API mrb_value
 mrb_obj_hash(mrb_state *mrb, mrb_value self)
 {
-  return mrb_fixnum_value(mrb_obj_id(self));
+  return mrb_fixnum_value(mrb_obj_id(mrb, self));
 }
 
 /* 15.3.1.3.16 */

--- a/src/randombytes.c
+++ b/src/randombytes.c
@@ -1,0 +1,313 @@
+/*
+ * Adopted from libsodium
+ *
+ * ISC License
+ *
+ * Copyright (c) 2013-2016
+ * Frank Denis <j at pureftpd dot org>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include <sys/types.h>
+#ifndef _WIN32
+# include <sys/stat.h>
+# include <sys/time.h>
+#endif
+#ifdef __linux__
+# include <sys/syscall.h>
+# include <poll.h>
+#endif
+
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdint.h>
+#include <string.h>
+#ifndef _WIN32
+# include <unistd.h>
+#endif
+
+#ifdef _WIN32
+/* `RtlGenRandom` is used over `CryptGenRandom` on Microsoft Windows based systems:
+ *  - `CryptGenRandom` requires pulling in `CryptoAPI` which causes unnecessary
+ *     memory overhead if this API is not being used for other purposes
+ *  - `RtlGenRandom` is thus called directly instead. A detailed explanation
+ *     can be found here: https://blogs.msdn.microsoft.com/michael_howard/2005/01/14/cryptographically-secure-random-number-on-windows-without-using-cryptoapi/
+ */
+# include <windows.h>
+# define RtlGenRandom SystemFunction036
+# if defined(__cplusplus)
+extern "C"
+# endif
+BOOLEAN NTAPI RtlGenRandom(PVOID RandomBuffer, ULONG RandomBufferLength);
+# pragma comment(lib, "advapi32.lib")
+#endif
+
+#if defined(__OpenBSD__) || defined(__CloudABI__)
+# define HAVE_SAFE_ARC4RANDOM 1
+#endif
+
+#ifndef SSIZE_MAX
+# define SSIZE_MAX (SIZE_MAX / 2 - 1)
+#endif
+
+#ifdef HAVE_SAFE_ARC4RANDOM
+
+static void
+randombytes_sysrandom_stir(void)
+{
+}
+
+void
+randombytes_sysrandom_buf(void * const buf, const size_t size)
+{
+    return arc4random_buf(buf, size);
+}
+
+#else /* __OpenBSD__ */
+
+typedef struct SysRandom_ {
+    int random_data_source_fd;
+    int initialized;
+    int getrandom_available;
+} SysRandom;
+
+static SysRandom stream = {
+    .random_data_source_fd = -1,
+    .initialized = 0,
+    .getrandom_available = 0
+};
+
+#ifndef _WIN32
+static ssize_t
+safe_read(const int fd, void * const buf_, size_t size)
+{
+    unsigned char *buf = (unsigned char *) buf_;
+    ssize_t        readnb;
+
+    assert(size > (size_t) 0U);
+    assert(size <= SSIZE_MAX);
+    do {
+        while ((readnb = read(fd, buf, size)) < (ssize_t) 0 &&
+               (errno == EINTR || errno == EAGAIN)); /* LCOV_EXCL_LINE */
+        if (readnb < (ssize_t) 0) {
+            return readnb; /* LCOV_EXCL_LINE */
+        }
+        if (readnb == (ssize_t) 0) {
+            break; /* LCOV_EXCL_LINE */
+        }
+        size -= (size_t) readnb;
+        buf += readnb;
+    } while (size > (ssize_t) 0);
+
+    return (ssize_t) (buf - (unsigned char *) buf_);
+}
+#endif
+
+#ifndef _WIN32
+# if defined(__linux__) && !defined(USE_BLOCKING_RANDOM) && !defined(NO_BLOCKING_RANDOM_POLL)
+static int
+randombytes_block_on_dev_random(void)
+{
+    struct pollfd pfd;
+    int           fd;
+    int           pret;
+
+    fd = open("/dev/random", O_RDONLY);
+    if (fd == -1) {
+        return 0;
+    }
+    pfd.fd = fd;
+    pfd.events = POLLIN;
+    pfd.revents = 0;
+    do {
+        pret = poll(&pfd, 1, -1);
+    } while (pret < 0 && (errno == EINTR || errno == EAGAIN));
+    if (pret != 1) {
+        (void) close(fd);
+        errno = EIO;
+        return -1;
+    }
+    return close(fd);
+}
+# endif
+
+static int
+randombytes_sysrandom_random_dev_open(void)
+{
+/* LCOV_EXCL_START */
+    struct stat        st;
+    static const char *devices[] = {
+# ifndef USE_BLOCKING_RANDOM
+        "/dev/urandom",
+# endif
+        "/dev/random", NULL
+    };
+    const char **      device = devices;
+    int                fd;
+
+# if defined(__linux__) && !defined(USE_BLOCKING_RANDOM) && !defined(NO_BLOCKING_RANDOM_POLL)
+    if (randombytes_block_on_dev_random() != 0) {
+        return -1;
+    }
+# endif
+    do {
+        fd = open(*device, O_RDONLY);
+        if (fd != -1) {
+            if (fstat(fd, &st) == 0 &&
+# ifdef __COMPCERT__
+                1
+# elif defined(S_ISNAM)
+                (S_ISNAM(st.st_mode) || S_ISCHR(st.st_mode))
+# else
+                S_ISCHR(st.st_mode)
+# endif
+               ) {
+# if defined(F_SETFD) && defined(FD_CLOEXEC)
+                (void) fcntl(fd, F_SETFD, fcntl(fd, F_GETFD) | FD_CLOEXEC);
+# endif
+                return fd;
+            }
+            (void) close(fd);
+        } else if (errno == EINTR) {
+            continue;
+        }
+        device++;
+    } while (*device != NULL);
+
+    errno = EIO;
+    return -1;
+/* LCOV_EXCL_STOP */
+}
+
+# if defined(SYS_getrandom) && defined(__NR_getrandom)
+static int
+_randombytes_linux_getrandom(void * const buf, const size_t size)
+{
+    int readnb;
+
+    assert(size <= 256U);
+    do {
+        readnb = syscall(SYS_getrandom, buf, (int) size, 0);
+    } while (readnb < 0 && (errno == EINTR || errno == EAGAIN));
+
+    return (readnb == (int) size) - 1;
+}
+
+static int
+randombytes_linux_getrandom(void * const buf_, size_t size)
+{
+    unsigned char *buf = (unsigned char *) buf_;
+    size_t         chunk_size = 256U;
+
+    do {
+        if (size < chunk_size) {
+            chunk_size = size;
+            assert(chunk_size > (size_t) 0U);
+        }
+        if (_randombytes_linux_getrandom(buf, chunk_size) != 0) {
+            return -1;
+        }
+        size -= chunk_size;
+        buf += chunk_size;
+    } while (size > (size_t) 0U);
+
+    return 0;
+}
+# endif
+
+static void
+randombytes_sysrandom_init(void)
+{
+    const int     errno_save = errno;
+
+# if defined(SYS_getrandom) && defined(__NR_getrandom)
+    {
+        unsigned char fodder[16];
+
+        if (randombytes_linux_getrandom(fodder, sizeof fodder) == 0) {
+            stream.getrandom_available = 1;
+            errno = errno_save;
+            return;
+        }
+        stream.getrandom_available = 0;
+    }
+# endif
+
+    if ((stream.random_data_source_fd =
+         randombytes_sysrandom_random_dev_open()) == -1) {
+        abort(); /* LCOV_EXCL_LINE */
+    }
+    errno = errno_save;
+}
+
+#else /* _WIN32 */
+
+static void
+randombytes_sysrandom_init(void)
+{
+}
+#endif
+
+static void
+randombytes_sysrandom_stir(void)
+{
+    if (stream.initialized == 0) {
+        randombytes_sysrandom_init();
+        stream.initialized = 1;
+    }
+}
+
+static void
+randombytes_sysrandom_stir_if_needed(void)
+{
+    if (stream.initialized == 0) {
+        randombytes_sysrandom_stir();
+    }
+}
+
+void
+randombytes_sysrandom_buf(void * const buf, const size_t size)
+{
+    randombytes_sysrandom_stir_if_needed();
+#ifdef ULONG_LONG_MAX
+    /* coverity[result_independent_of_operands] */
+    assert(size <= ULONG_LONG_MAX);
+#endif
+#ifndef _WIN32
+# if defined(SYS_getrandom) && defined(__NR_getrandom)
+    if (stream.getrandom_available != 0) {
+        if (randombytes_linux_getrandom(buf, size) != 0) {
+            abort();
+        }
+        return;
+    }
+# endif
+    if (stream.random_data_source_fd == -1 ||
+        safe_read(stream.random_data_source_fd, buf, size) != (ssize_t) size) {
+        abort(); /* LCOV_EXCL_LINE */
+    }
+#else
+    if (size > (size_t) 0xffffffff) {
+        abort(); /* LCOV_EXCL_LINE */
+    }
+    if (! RtlGenRandom((PVOID) buf, (ULONG) size)) {
+        abort(); /* LCOV_EXCL_LINE */
+    }
+#endif
+}
+
+#endif /* __OpenBSD__ */

--- a/src/shorthash_siphash24.c
+++ b/src/shorthash_siphash24.c
@@ -1,0 +1,112 @@
+/*
+ * Adopted from libsodium
+ *
+ * ISC License
+ *
+ * Copyright (c) 2013-2016
+ * Frank Denis <j at pureftpd dot org>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <stdint.h>
+
+#define LOAD64_LE(SRC) load64_le(SRC)
+
+static inline uint64_t
+load64_le(const uint8_t src[8])
+{
+#ifdef NATIVE_LITTLE_ENDIAN
+    uint64_t w;
+    memcpy(&w, src, sizeof w);
+    return w;
+#else
+    uint64_t w = (uint64_t) src[0];
+    w |= (uint64_t) src[1] <<  8;
+    w |= (uint64_t) src[2] << 16;
+    w |= (uint64_t) src[3] << 24;
+    w |= (uint64_t) src[4] << 32;
+    w |= (uint64_t) src[5] << 40;
+    w |= (uint64_t) src[6] << 48;
+    w |= (uint64_t) src[7] << 56;
+    return w;
+#endif
+}
+
+typedef uint64_t u64;
+typedef uint32_t u32;
+typedef uint8_t   u8;
+
+#define ROTL(x,b) (u64)( ((x) << (b)) | ( (x) >> (64 - (b))) )
+
+#define SIPROUND            \
+  do {              \
+    v0 += v1; v1=ROTL(v1,13); v1 ^= v0; v0=ROTL(v0,32); \
+    v2 += v3; v3=ROTL(v3,16); v3 ^= v2;     \
+    v0 += v3; v3=ROTL(v3,21); v3 ^= v0;     \
+    v2 += v1; v1=ROTL(v1,17); v1 ^= v2; v2=ROTL(v2,32); \
+  } while(0)
+
+u64 crypto_shorthash_siphash24(const unsigned char *in,
+                               unsigned long long inlen, const unsigned char *k)
+{
+  /* "somepseudorandomlygeneratedbytes" */
+  u64 v0 = 0x736f6d6570736575ULL;
+  u64 v1 = 0x646f72616e646f6dULL;
+  u64 v2 = 0x6c7967656e657261ULL;
+  u64 v3 = 0x7465646279746573ULL;
+  u64 b;
+  u64 k0 = LOAD64_LE( k );
+  u64 k1 = LOAD64_LE( k + 8 );
+  u64 m;
+  const u8 *end = in + inlen - ( inlen % sizeof( u64 ) );
+  const int left = inlen & 7;
+  b = ( ( u64 )inlen ) << 56;
+  v3 ^= k1;
+  v2 ^= k0;
+  v1 ^= k1;
+  v0 ^= k0;
+
+  for ( ; in != end; in += 8 )
+  {
+    m = LOAD64_LE( in );
+    v3 ^= m;
+    SIPROUND;
+    SIPROUND;
+    v0 ^= m;
+  }
+
+  switch( left )
+  {
+  case 7: b |= ( ( u64 )in[ 6] )  << 48;
+  case 6: b |= ( ( u64 )in[ 5] )  << 40;
+  case 5: b |= ( ( u64 )in[ 4] )  << 32;
+  case 4: b |= ( ( u64 )in[ 3] )  << 24;
+  case 3: b |= ( ( u64 )in[ 2] )  << 16;
+  case 2: b |= ( ( u64 )in[ 1] )  <<  8;
+  case 1: b |= ( ( u64 )in[ 0] ); break;
+  case 0: break;
+  }
+
+  v3 ^= b;
+  SIPROUND;
+  SIPROUND;
+  v0 ^= b;
+  v2 ^= 0xff;
+  SIPROUND;
+  SIPROUND;
+  SIPROUND;
+  SIPROUND;
+  b = v0 ^ v1 ^ v2  ^ v3;
+  return b;
+}

--- a/src/state.c
+++ b/src/state.c
@@ -11,6 +11,7 @@
 #include <mruby/variable.h>
 #include <mruby/debug.h>
 #include <mruby/string.h>
+#include "randombytes.c"
 
 void mrb_init_core(mrb_state*);
 void mrb_init_mrbgems(mrb_state*);
@@ -38,6 +39,8 @@ mrb_open_core(mrb_allocf f, void *ud)
   mrb->allocf_ud = ud;
   mrb->allocf = f;
   mrb->atexit_stack_len = 0;
+
+  randombytes_sysrandom_buf((void*)mrb->key, sizeof(mrb->key));
 
   mrb_gc_init(mrb, &mrb->gc);
   mrb->c = (struct mrb_context*)mrb_malloc(mrb, sizeof(struct mrb_context));

--- a/test/t/kernel.rb
+++ b/test/t/kernel.rb
@@ -398,6 +398,7 @@ assert('Kernel#object_id', '15.3.1.3.33') do
   a = ""
   b = ""
   assert_not_equal a.object_id, b.object_id
+  assert_equal a.object_id, a.object_id
 
   assert_kind_of Numeric, object_id
   assert_kind_of Numeric, "".object_id


### PR DESCRIPTION
While running the [Shopify bug bounty for mruby](https://hackerone.com/shopify-scripts) we noticed that a lot of exploits utilize the fact that `object_id` is directly related to the memory address of an object, which makes it very easy to construct arbitrary objects in memory.

This PR fixes the issue by applying a randomly seeded hash to object_id, resulting in object_ids being nondeterministic.

## Results

Running this file after compiling with `MRB_INT64` and `MRB_WORD_BOXING`

```
# id.rb
puts Object.new.object_id
puts Object.new.object_id
puts Object.new.object_id
```

### Before this PR

```
~/src/github.com/mruby/mruby (master) bin/mruby ./id.rb
140338777833864
140338777833576
140338777833000
~/src/github.com/mruby/mruby (master) bin/mruby ./id.rb
140526011564424
140526011564136
140526011563560
~/src/github.com/mruby/mruby (master) bin/mruby ./id.rb
140254254219656
140254254219368
140254254218792
```

### After this PR

```
~/src/github.com/mruby/mruby (hash-object-id) bin/mruby ./id.rb
-4501018806046184518
-2341758151096772472
-785186630034095801
~/src/github.com/mruby/mruby (hash-object-id) bin/mruby ./id.rb
552799609413634798
3966797781753601314
4531261121971834197
~/src/github.com/mruby/mruby (hash-object-id) bin/mruby ./id.rb
-962803763787832197
2853411265111984547
2087943745143658397
```

## Choice of hash code

I decided to go with the [libsodium](https://github.com/jedisct1/libsodium) implementations of siphash and cryptographically secure bytes, because `libsodium` is very widely used, and the code is released under [ISC](https://opensource.org/licenses/ISC), which is compatible with MIT.

For review @fbogsany @matz