### PR TITLE
Fix Range#size results

### DIFF
--- a/mrbgems/mruby-range-ext/src/range.c
+++ b/mrbgems/mruby-range-ext/src/range.c
@@ -139,7 +139,7 @@ mrb_range_size(mrb_state *mrb, mrb_value range)
 {
   struct RRange *r = mrb_range_ptr(range);
   mrb_value beg, end;
-  double beg_f, end_f;
+  mrb_float beg_f, end_f;
   mrb_bool num_p = TRUE;
   mrb_bool excl;
 
@@ -147,7 +147,7 @@ mrb_range_size(mrb_state *mrb, mrb_value range)
   end = r->edges->end;
   excl = r->excl;
   if (mrb_fixnum_p(beg)) {
-    beg_f = (double)mrb_fixnum(beg);
+    beg_f = (mrb_float)mrb_fixnum(beg);
   }
   else if (mrb_float_p(beg)) {
     beg_f = mrb_float(beg);
@@ -156,7 +156,7 @@ mrb_range_size(mrb_state *mrb, mrb_value range)
     num_p = FALSE;
   }
   if (mrb_fixnum_p(end)) {
-    end_f = (double)mrb_fixnum(end);
+    end_f = (mrb_float)mrb_fixnum(end);
   }
   else if (mrb_float_p(end)) {
     end_f = mrb_float(end);
@@ -165,8 +165,8 @@ mrb_range_size(mrb_state *mrb, mrb_value range)
     num_p = FALSE;
   }
   if (num_p) {
-    double n = end_f - beg_f;
-    double err = (fabs(beg_f) + fabs(end_f) + fabs(end_f-beg_f)) * DBL_EPSILON;
+    mrb_float n = end_f - beg_f;
+    mrb_float err = (fabs(beg_f) + fabs(end_f) + fabs(end_f-beg_f)) * DBL_EPSILON;
 
     if (err>0.5) err=0.5;
     if (excl) {

--- a/mrbgems/mruby-range-ext/test/range.rb
+++ b/mrbgems/mruby-range-ext/test/range.rb
@@ -25,5 +25,7 @@ assert('Range#size') do
   assert_equal 6, (1...6.3).size
   assert_equal 5, (1...6.0).size
   assert_equal 5, (1.1...6).size
+  assert_equal 15, (1.0..15.9).size
+  assert_equal Float::INFINITY, (0..Float::INFINITY).size
   assert_nil ('a'..'z').size
 end


### PR DESCRIPTION
# Actual

```rb
$ mirb
mirb - Embeddable Interactive Ruby Shell

> (1.0..15.9).size
 => 16
> (0..Float::INFINITY).size
 => -2147483648
```

# Expect

```rb
$ irb
irb(main):001:0> (1.0..15.9).size
=> 15
irb(main):002:0> (0..Float::INFINITY).size
=> Infinity
```

This fix passed all specs of that https://github.com/ruby/spec/blob/66daf290cb49707190481b4cf24e700010cd53bf/core/range/size_spec.rb