### PR TITLE
Travis tests for multiple configurations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,47 @@
+---
 language: c
-
-sudo: false
-
-matrix:
-  include:
-    - os: linux
-      sudo: 9000
-    - os: osx
-      osx_image: xcode7.1
-
+sudo: required
+compiler:
+- gcc
+- clang
+os:
+- linux
+- osx
 addons:
   apt:
     packages:
-      - gperf
-
-env: MRUBY_CONFIG=travis_config.rb
+    - gperf
+    - gcc-multilib
+    - g++-4.6-multilib
+    - lib32bz2-dev
+    - libc6-dev-i386
+    - lib32z1-dev
+    - lib32readline6-dev
+    - lib32ncurses5-dev
+env:
+  global:
+  - MRUBY_CONFIG=travis_config.rb
+  matrix:
+  - CFLAGS='-m32 ' LDFLAGS='-m32'
+  - CFLAGS='-m32 -DMRB_NAN_BOXING=1' LDFLAGS='-m32'
+  - CFLAGS='-m32 -DMRB_WORD_BOXING=1' LDFLAGS='-m32'
+  - CFLAGS='-m32 -DMRB_INT16=1' LDFLAGS='-m32'
+  - CFLAGS='-m32 -DMRB_INT16=1 -DMRB_NAN_BOXING=1' LDFLAGS='-m32'
+  - CFLAGS='-m32 -DMRB_INT64=1' LDFLAGS='-m32'
+  - CFLAGS='-m32 -DMRB_USE_FLOAT=1' LDFLAGS='-m32'
+  - CFLAGS='-m32 -DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1' LDFLAGS='-m32'
+  - CFLAGS='-m32 -DMRB_USE_FLOAT=1 -DMRB_INT16=1' LDFLAGS='-m32'
+  - CFLAGS='-m32 -DMRB_USE_FLOAT=1 -DMRB_INT64=1' LDFLAGS='-m32'
+  - CFLAGS='' LDFLAGS=''
+  - CFLAGS='-DMRB_NAN_BOXING=1' LDFLAGS=''
+  - CFLAGS='-DMRB_WORD_BOXING=1' LDFLAGS=''
+  - CFLAGS='-DMRB_INT16=1' LDFLAGS=''
+  - CFLAGS='-DMRB_INT16=1 -DMRB_NAN_BOXING=1' LDFLAGS=''
+  - CFLAGS='-DMRB_INT64=1' LDFLAGS=''
+  - CFLAGS='-DMRB_INT64=1 -DMRB_WORD_BOXING=1' LDFLAGS=''
+  - CFLAGS='-DMRB_USE_FLOAT=1' LDFLAGS=''
+  - CFLAGS='-DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1' LDFLAGS=''
+  - CFLAGS='-DMRB_USE_FLOAT=1 -DMRB_INT16=1' LDFLAGS=''
+  - CFLAGS='-DMRB_USE_FLOAT=1 -DMRB_INT64=1' LDFLAGS=''
+  - CFLAGS='-DMRB_USE_FLOAT=1 -DMRB_INT64=1 -DMRB_WORD_BOXING=1' LDFLAGS=''
 script: "./minirake all test"

--- a/Rakefile
+++ b/Rakefile
@@ -146,3 +146,31 @@ task :doc do
     puts "  $ gem install yard-mruby"
   end
 end
+
+desc 'create build configurations and update .travis.yml'
+task :build_configurations do
+  require 'yaml'
+
+  configs = []
+  [true, false].each do |mode_32|
+    ['', 'MRB_USE_FLOAT'].each do |float_conf|
+      ['', 'MRB_INT16', 'MRB_INT64'].each do |int_conf|
+        ['', 'MRB_NAN_BOXING', 'MRB_WORD_BOXING'].each do |boxing_conf|
+          next if float_conf == 'MRB_USE_FLOAT' and boxing_conf == 'MRB_NAN_BOXING'
+          next if int_conf == 'MRB_INT64' and boxing_conf == 'MRB_NAN_BOXING'
+          next if int_conf == 'MRB_INT16' and boxing_conf == 'MRB_WORD_BOXING'
+          next if int_conf == 'MRB_INT64' and boxing_conf == 'MRB_WORD_BOXING' and mode_32
+          env = [float_conf, int_conf, boxing_conf].map do |conf|
+            conf == '' ? nil : "-D#{conf}=1"
+          end.compact.join(' ')
+          bit = mode_32 ? '-m32 ' : ''
+          configs << "CFLAGS='#{bit}#{env}' LDFLAGS='#{bit.strip}'"
+        end
+      end
+    end
+  end
+  path = './.travis.yml'
+  data = YAML.load_file(path)
+  data["env"]["matrix"] = configs
+  File.open(path, 'w') { |f| YAML.dump(data, f) }
+end


### PR DESCRIPTION
mruby has many configuration options and I wanted to check how these configurations behave. So I've added support for multiple configurations in Travis testing, including:
- 32/64 bit architecture
- float/double
- 16/32/64 bit int size
- none/NaN/word boxing
- GCC/clang
- Linux/OSX

with unsupported configurations like `float` + NaN boxing removed from the pool.

The results are not so good. Most non-standard configurations crash or fail tests. Of all 96 possible configurations, only 13 build and test correctly.

I'll try to submit patches where possible, and create issues for more complex problems.