### PR TITLE
Fix for sprintf test exceeding bounds with MRB_INT16

### DIFF
--- a/mrbgems/mruby-sprintf/test/sprintf.rb
+++ b/mrbgems/mruby-sprintf/test/sprintf.rb
@@ -5,5 +5,5 @@ assert('String#%') do
   assert_equal "one=1", "one=%d" % 1
   assert_equal "1 one 1.0", "%d %s %3.1f" % [ 1, "one", 1.01 ]
   assert_equal "123 < 456", "%{num} < %<str>s" % { num: 123, str: "456" }
-  assert_equal 16, ("%b" % (1<<15)).size
+  assert_equal 15, ("%b" % (1<<14)).size
 end


### PR DESCRIPTION
This is an artifact discovered during #3258. `1 << 15` is too big to fit a 16-bit int.