### PR TITLE
Reimplements Range#first

### DIFF
--- a/mrbgems/mruby-range-ext/mrblib/range.rb
+++ b/mrbgems/mruby-range-ext/mrblib/range.rb
@@ -1,0 +1,31 @@
+class Range
+  ##
+  # call-seq:
+  #    rng.first    -> obj
+  #    rng.first(n) -> an_array
+  #
+  # Returns the first object in the range, or an array of the first +n+
+  # elements.
+  #
+  #   (10..20).first     #=> 10
+  #   (10..20).first(3)  #=> [10, 11, 12]
+  #
+  def first(*args)
+    return self.begin if args.empty?
+
+    raise ArgumentError, "wrong number of arguments (given #{args.length}, expected 1)" unless args.length == 1
+    nv = args[0]
+    raise TypeError, "no implicit conversion from nil to integer" unless nv.nil?.!
+    raise TypeError, "no implicit conversion of #{nv.class} into Integer" unless nv.respond_to?(:to_int)
+    n = nv.to_int
+    raise TypeError, "no implicit conversion of #{nv.class} into Integer" unless n.kind_of?(Integer)
+    raise ArgumentError, "negative array size (or size too big)" unless 0 <= n
+    ary = []
+    each do |i|
+      break if n <= 0
+      ary.push(i)
+      n -= 1
+    end
+    ary
+  end
+end

--- a/mrbgems/mruby-range-ext/src/range.c
+++ b/mrbgems/mruby-range-ext/src/range.c
@@ -68,32 +68,6 @@ mrb_range_cover(mrb_state *mrb, mrb_value range)
 
 /*
  *  call-seq:
- *     rng.first    -> obj
- *     rng.first(n) -> an_array
- *
- *  Returns the first object in the range, or an array of the first +n+
- *  elements.
- *
- *    (10..20).first     #=> 10
- *    (10..20).first(3)  #=> [10, 11, 12]
- */
-static mrb_value
-mrb_range_first(mrb_state *mrb, mrb_value range)
-{
-  mrb_int num;
-  mrb_value array;
-  struct RRange *r = mrb_range_ptr(range);
-
-  if (mrb_get_args(mrb, "|i", &num) == 0) {
-    return r->edges->beg;
-  }
-
-  array = mrb_funcall(mrb, range, "to_a", 0);
-  return mrb_funcall(mrb, array, "first", 1, mrb_fixnum_value(num));
-}
-
-/*
- *  call-seq:
  *     rng.last    -> obj
  *     rng.last(n) -> an_array
  *
@@ -193,7 +167,6 @@ mrb_mruby_range_ext_gem_init(mrb_state* mrb)
   struct RClass * s = mrb_class_get(mrb, "Range");
 
   mrb_define_method(mrb, s, "cover?", mrb_range_cover, MRB_ARGS_REQ(1));
-  mrb_define_method(mrb, s, "first",  mrb_range_first, MRB_ARGS_OPT(1));
   mrb_define_method(mrb, s, "last",   mrb_range_last,  MRB_ARGS_OPT(1));
   mrb_define_method(mrb, s, "size",   mrb_range_size,  MRB_ARGS_NONE());
 }

--- a/mrbgems/mruby-range-ext/test/range.rb
+++ b/mrbgems/mruby-range-ext/test/range.rb
@@ -10,6 +10,7 @@ end
 assert('Range#first') do
   assert_equal 10, (10..20).first
   assert_equal [10, 11, 12], (10..20).first(3)
+  assert_equal [0, 1, 2], (0..Float::INFINITY).first(3)
 end
 
 assert('Range#last') do


### PR DESCRIPTION
`Range#first` with argument works like `Enumerable#take`.
`Range#first` shouldn't call `Range#to_a` on infinity range.

```rb
$ mirb
mirb - Embeddable Interactive Ruby Shell

> (0..Float::INFINITY).first(3)
# ...infinite loop...
```

So, I reimplemented `Range#first` with Ruby code.
Because it hard to write `break` in iterator on C functions.
And this implementation passed specs of that https://github.com/ruby/spec/blob/66daf290cb49707190481b4cf24e700010cd53bf/core/range/first_spec.rb
(I know that it's a bit too strictly)