### PR TITLE
Fixed NaN boxing for 64-bit configrations

### DIFF
--- a/include/mrbconf.h
+++ b/include/mrbconf.h
@@ -7,6 +7,20 @@
 #ifndef MRUBYCONF_H
 #define MRUBYCONF_H
 
+/* architecture selection: */
+/* specify -DMRB_32BIT or -DMRB_64BIT to override */
+#if !defined(MRB_32BIT) && !defined(MRB_64BIT)
+#if defined(__amd64__) || defined(__amd64) || defined(__x86_64__) || defined(__x86_64) || defined(_M_X64) || defined(_M_AMD64) || defined(__aarch64__)
+#define MRB_64BIT
+#else
+#define MRB_32BIT
+#endif
+#endif
+
+#if defined(MRB_32BIT) && defined(MRB_64BIT)
+#error Cannot build for 32 and 64 bit architecture at the same time
+#endif
+
 /* configuration options: */
 /* add -DMRB_USE_FLOAT to use float instead of double for floating point numbers */
 //#define MRB_USE_FLOAT

--- a/include/mruby.h
+++ b/include/mruby.h
@@ -32,6 +32,21 @@
 #include <stddef.h>
 #include <limits.h>
 
+#ifdef MRB_DEBUG
+#include <assert.h>
+#define mrb_assert(p) assert(p)
+#define mrb_assert_int_fit(t1,n,t2,max) assert((n)>=0 && ((sizeof(n)<=sizeof(t2))||(n<=(t1)(max))))
+#else
+#define mrb_assert(p) ((void)0)
+#define mrb_assert_int_fit(t1,n,t2,max) ((void)0)
+#endif
+
+#if __STDC_VERSION__ >= 201112L
+#define mrb_static_assert(exp, str) _Static_assert(exp, str)
+#else
+#define mrb_static_assert(exp, str) mrb_assert(exp)
+#endif
+
 #include "mrbconf.h"
 #include "mruby/common.h"
 #include <mruby/value.h>
@@ -1134,21 +1149,6 @@ MRB_API void mrb_state_atexit(mrb_state *mrb, mrb_atexit_func func);
 
 MRB_API void mrb_show_version(mrb_state *mrb);
 MRB_API void mrb_show_copyright(mrb_state *mrb);
-
-#ifdef MRB_DEBUG
-#include <assert.h>
-#define mrb_assert(p) assert(p)
-#define mrb_assert_int_fit(t1,n,t2,max) assert((n)>=0 && ((sizeof(n)<=sizeof(t2))||(n<=(t1)(max))))
-#else
-#define mrb_assert(p) ((void)0)
-#define mrb_assert_int_fit(t1,n,t2,max) ((void)0)
-#endif
-
-#if __STDC_VERSION__ >= 201112L
-#define mrb_static_assert(exp, str) _Static_assert(exp, str)
-#else
-#define mrb_static_assert(exp, str) mrb_assert(exp)
-#endif
 
 MRB_API mrb_value mrb_format(mrb_state *mrb, const char *format, ...);
 

--- a/include/mruby/boxing_nan.h
+++ b/include/mruby/boxing_nan.h
@@ -60,6 +60,12 @@ typedef struct mrb_value {
 #define mrb_fixnum(o)   (o).value.i
 #define mrb_symbol(o)   (o).value.sym
 
+#ifdef MRB_64BIT
+#define BOXNAN_SHIFT_LONG_POINTER(v) (((uintptr_t)(v)>>34)&0x3fff)
+#else
+#define BOXNAN_SHIFT_LONG_POINTER(v) 0
+#endif
+
 #define BOXNAN_SET_VALUE(o, tt, attr, v) do {\
   switch (tt) {\
   case MRB_TT_FALSE:\
@@ -69,7 +75,7 @@ typedef struct mrb_value {
   case MRB_TT_SYMBOL: (o).attr = (v); break;\
   default: (o).value.i = 0; (o).value.p = (void*)((uintptr_t)(o).value.p | (((uintptr_t)(v))>>2)); break;\
   }\
-  (o).value.ttt = (0xfff00000|(((tt)+1)<<14));\
+  (o).value.ttt = (0xfff00000|(((tt)+1)<<14)|BOXNAN_SHIFT_LONG_POINTER(v));\
 } while (0)
 
 #define SET_FLOAT_VALUE(mrb,r,v) do { \

--- a/include/mruby/value.h
+++ b/include/mruby/value.h
@@ -211,6 +211,8 @@ mrb_obj_value(void *p)
 {
   mrb_value v;
   SET_OBJ_VALUE(v, (struct RBasic*)p);
+  mrb_assert(p == mrb_ptr(v));
+  mrb_assert(((struct RBasic*)p)->tt == mrb_type(v));
   return v;
 }
 


### PR DESCRIPTION
This is an artifact discovered during #3258. 

Fixed NaN boxing for 64-bit configrations on platforms that use full 48-bit usermode pointers

Definition of boxed pointer is following:
`111111111111TTTT TTPPPPPPPPPPPPPP PPPPPPPPPPPPPPPP PPPPPPPPPPPPPPPP`

Previously, only the last 32-bit were set, and remaining 14 bits were zeroed when setting `ttt`:
```c
(o).value.ttt = (0xfff00000|(((tt)+1)<<14));
```

Currently, remaining 14 bits are preserved. Have also added architecture detection code and an assertion on pointer and type in `mrb_obj_value`.