### PR TITLE
Fixed C declaration in re.h

### DIFF
--- a/include/mruby/re.h
+++ b/include/mruby/re.h
@@ -7,14 +7,10 @@
 #ifndef MRUBY_RE_H
 #define MRUBY_RE_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+MRB_BEGIN_DECL
 
 #define REGEXP_CLASS          "Regexp"
 
-#ifdef __cplusplus
-}
-#endif
+MRB_END_DECL
 
 #endif  /* RE_H */


### PR DESCRIPTION
Fixed `extern "C"` to use `MRB_BEGIN/END_DECL` in `re.h`

(although we could also drop it entirely since all the files has is a single `#define`)