### PR TITLE
Compiling mruby as C++ code

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -28,9 +28,25 @@
 #ifndef MRUBY_H
 #define MRUBY_H
 
+#ifdef __cplusplus
+#define __STDC_LIMIT_MACROS
+#define __STDC_CONSTANT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+
 #include <stdint.h>
 #include <stddef.h>
 #include <limits.h>
+
+#ifdef __cplusplus
+#ifndef SIZE_MAX
+#ifdef __SIZE_MAX__
+#define SIZE_MAX __SIZE_MAX__
+#else
+#define SIZE_MAX std::numeric_limits<size_t>::max()
+#endif
+#endif
+#endif
 
 #ifdef MRB_DEBUG
 #include <assert.h>

--- a/include/mruby/boxing_nan.h
+++ b/include/mruby/boxing_nan.h
@@ -53,7 +53,7 @@ typedef struct mrb_value {
 #define mrb_float_pool(mrb,f) mrb_float_value(mrb,f)
 
 #define mrb_tt(o)       ((enum mrb_vtype)(((o).value.ttt & 0xfc000)>>14)-1)
-#define mrb_type(o)     ((uint32_t)0xfff00000 < (o).value.ttt ? mrb_tt(o) : MRB_TT_FLOAT)
+#define mrb_type(o)     (enum mrb_vtype)((uint32_t)0xfff00000 < (o).value.ttt ? mrb_tt(o) : MRB_TT_FLOAT)
 #define mrb_ptr(o)      ((void*)((((uintptr_t)0x3fffffffffff)&((uintptr_t)((o).value.p)))<<2))
 #define mrb_float(o)    (o).f
 #define mrb_cptr(o)     mrb_ptr(o)

--- a/include/mruby/common.h
+++ b/include/mruby/common.h
@@ -9,8 +9,13 @@
 
 
 #ifdef __cplusplus
+#ifdef MRB_ENABLE_CXX_EXCEPTION
+#define MRB_BEGIN_DECL
+#define MRB_END_DECL
+#else
 # define MRB_BEGIN_DECL extern "C" {
 # define MRB_END_DECL	}
+#endif
 #else
 /** Start declarations in C mode */
 # define MRB_BEGIN_DECL

--- a/include/mruby/throw.h
+++ b/include/mruby/throw.h
@@ -7,6 +7,10 @@
 #ifndef MRB_THROW_H
 #define MRB_THROW_H
 
+#if defined(MRB_ENABLE_CXX_EXCEPTION) && !defined(__cplusplus)
+#error Trying to use C++ exception handling in C code
+#endif
+
 #if defined(MRB_ENABLE_CXX_EXCEPTION) && defined(__cplusplus)
 
 #define MRB_TRY(buf) do { try {

--- a/mrbgems/mruby-inline-struct/test/inline.c
+++ b/mrbgems/mruby-inline-struct/test/inline.c
@@ -6,7 +6,7 @@
 static mrb_value
 istruct_test_initialize(mrb_state *mrb, mrb_value self)
 {
-  char *string = mrb_istruct_ptr(self);
+  char *string = (char*)mrb_istruct_ptr(self);
   mrb_int size = mrb_istruct_size();
   mrb_value object;
   mrb_get_args(mrb, "o", &object);
@@ -31,7 +31,7 @@ istruct_test_initialize(mrb_state *mrb, mrb_value self)
 static mrb_value
 istruct_test_to_s(mrb_state *mrb, mrb_value self)
 {
-  return mrb_str_new_cstr(mrb, mrb_istruct_ptr(self));
+  return mrb_str_new_cstr(mrb, (const char*)mrb_istruct_ptr(self));
 }
 
 static mrb_value
@@ -63,7 +63,7 @@ istruct_test_test_receive_direct(mrb_state *mrb, mrb_value self)
 static mrb_value
 istruct_test_mutate(mrb_state *mrb, mrb_value self)
 {
-  char *ptr = mrb_istruct_ptr(self);
+  char *ptr = (char*)mrb_istruct_ptr(self);
   memcpy(ptr, "mutate", 6);
   return mrb_nil_value();
 }

--- a/mrbgems/mruby-objectspace/src/mruby_objectspace.c
+++ b/mrbgems/mruby-objectspace/src/mruby_objectspace.c
@@ -49,7 +49,7 @@ static mrb_value
 os_count_objects(mrb_state *mrb, mrb_value self)
 {
   struct os_count_struct obj_count = { 0 };
-  enum mrb_vtype i;
+  mrb_int i;
   mrb_value hash;
 
   if (mrb_get_args(mrb, "|H", &hash) == 0) {

--- a/mrbgems/mruby-print/src/print.c
+++ b/mrbgems/mruby-print/src/print.c
@@ -22,7 +22,7 @@ printstr(mrb_state *mrb, mrb_value obj)
       int mlen = RSTRING_LEN(obj);
       char* utf8 = RSTRING_PTR(obj);
       int wlen = MultiByteToWideChar(CP_UTF8, 0, utf8, mlen, NULL, 0);
-      wchar_t* utf16 = mrb_malloc(mrb, (wlen+1) * sizeof(wchar_t));
+      wchar_t* utf16 = (wchar_t*)mrb_malloc(mrb, (wlen+1) * sizeof(wchar_t));
       if (utf16 == NULL) return;
       if (MultiByteToWideChar(CP_UTF8, 0, utf8, mlen, utf16, wlen) > 0) {
         utf16[wlen] = 0;

--- a/mrbgems/mruby-sprintf/src/sprintf.c
+++ b/mrbgems/mruby-sprintf/src/sprintf.c
@@ -843,13 +843,13 @@ retry:
             strncpy(nbuf, RSTRING_PTR(val), sizeof(nbuf));
             break;
           case 8:
-            snprintf(nbuf, sizeof(nbuf), "%"MRB_PRIo, v);
+            snprintf(nbuf, sizeof(nbuf), "%" MRB_PRIo, v);
             break;
           case 10:
-            snprintf(nbuf, sizeof(nbuf), "%"MRB_PRId, v);
+            snprintf(nbuf, sizeof(nbuf), "%" MRB_PRId, v);
             break;
           case 16:
-            snprintf(nbuf, sizeof(nbuf), "%"MRB_PRIx, v);
+            snprintf(nbuf, sizeof(nbuf), "%" MRB_PRIx, v);
             break;
           }
           s = nbuf;
@@ -864,13 +864,13 @@ retry:
             strncpy(++s, RSTRING_PTR(val), sizeof(nbuf)-1);
             break;
           case 8:
-            snprintf(++s, sizeof(nbuf)-1, "%"MRB_PRIo, v);
+            snprintf(++s, sizeof(nbuf)-1, "%" MRB_PRIo, v);
             break;
           case 10:
-            snprintf(++s, sizeof(nbuf)-1, "%"MRB_PRId, v);
+            snprintf(++s, sizeof(nbuf)-1, "%" MRB_PRId, v);
             break;
           case 16:
-            snprintf(++s, sizeof(nbuf)-1, "%"MRB_PRIx, v);
+            snprintf(++s, sizeof(nbuf)-1, "%" MRB_PRIx, v);
             break;
           }
           if (v < 0) {

--- a/src/backtrace.c
+++ b/src/backtrace.c
@@ -160,7 +160,7 @@ static void
 output_backtrace_i(mrb_state *mrb, struct backtrace_location_raw *loc_raw, void *data)
 {
   struct backtrace_location loc;
-  struct output_backtrace_args *args = data;
+  struct output_backtrace_args *args = (struct output_backtrace_args *)data;
 
   loc.i          = loc_raw->i;
   loc.lineno     = loc_raw->lineno;
@@ -338,7 +338,7 @@ save_backtrace_i(mrb_state *mrb,
     else {
       new_n_allocated = mrb->backtrace.n_allocated * 2;
     }
-    mrb->backtrace.entries =
+    mrb->backtrace.entries = (mrb_backtrace_entry *)
       mrb_realloc(mrb,
                   mrb->backtrace.entries,
                   sizeof(mrb_backtrace_entry) * new_n_allocated);

--- a/src/dump.c
+++ b/src/dump.c
@@ -1059,6 +1059,7 @@ mrb_dump_irep_cfunc(mrb_state *mrb, mrb_irep *irep, uint8_t flags, FILE *fp, con
       return MRB_DUMP_WRITE_FAULT;
     }
     if (fprintf(fp,
+          "extern const uint8_t %s[];\n"
           "const uint8_t\n"
           "#if defined __GNUC__\n"
           "__attribute__((aligned(%u)))\n"
@@ -1066,6 +1067,7 @@ mrb_dump_irep_cfunc(mrb_state *mrb, mrb_irep *irep, uint8_t flags, FILE *fp, con
           "__declspec(align(%u))\n"
           "#endif\n"
           "%s[] = {",
+          initname,
           (uint16_t)MRB_DUMP_ALIGNMENT, (uint16_t)MRB_DUMP_ALIGNMENT, initname) < 0) {
       mrb_free(mrb, bin);
       return MRB_DUMP_WRITE_FAULT;

--- a/src/string.c
+++ b/src/string.c
@@ -361,7 +361,7 @@ mrb_memsearch(const void *x0, mrb_int m, const void *y0, mrb_int n)
     return 0;
   }
   else if (m == 1) {
-    const unsigned char *ys = memchr(y, *x, n);
+    const unsigned char *ys = (const unsigned char *)memchr(y, *x, n);
 
     if (ys)
       return ys - y;

--- a/tasks/mruby_build.rake
+++ b/tasks/mruby_build.rake
@@ -120,7 +120,7 @@ module MRuby
     def enable_cxx_abi
       return if @cxx_exception_disabled or @cxx_abi_enabled
       compilers.each { |c| c.defines += %w(MRB_ENABLE_CXX_EXCEPTION) }
-      compilers.each { |c| c.flags << '-x c++'}
+      compilers.each { |c| c.flags << c.cxx_compile_flag }
       linker.command = cxx.command if toolchains.find { |v| v == 'gcc' }
       @cxx_abi_enabled = true
     end

--- a/tasks/mruby_build.rake
+++ b/tasks/mruby_build.rake
@@ -120,6 +120,7 @@ module MRuby
     def enable_cxx_abi
       return if @cxx_exception_disabled or @cxx_abi_enabled
       compilers.each { |c| c.defines += %w(MRB_ENABLE_CXX_EXCEPTION) }
+      compilers.each { |c| c.flags << '-x c++'}
       linker.command = cxx.command if toolchains.find { |v| v == 'gcc' }
       @cxx_abi_enabled = true
     end
@@ -135,9 +136,13 @@ module MRuby
 #define __STDC_CONSTANT_MACROS
 #define __STDC_LIMIT_MACROS
 
+#ifndef MRB_ENABLE_CXX_EXCEPTION
 extern "C" {
+#endif
 #include "#{src}"
+#ifndef MRB_ENABLE_CXX_EXCEPTION
 }
+#endif
 
 #{src == "#{MRUBY_ROOT}/src/error.c"? 'mrb_int mrb_jmpbuf::jmpbuf_id = 0;' : ''}
 EOS

--- a/tasks/mruby_build_commands.rake
+++ b/tasks/mruby_build_commands.rake
@@ -41,6 +41,7 @@ module MRuby
   class Command::Compiler < Command
     attr_accessor :flags, :include_paths, :defines, :source_exts
     attr_accessor :compile_options, :option_define, :option_include_path, :out_ext
+    attr_accessor :cxx_compile_flag
 
     def initialize(build, source_exts=[])
       super(build)

--- a/tasks/toolchains/gcc.rake
+++ b/tasks/toolchains/gcc.rake
@@ -6,7 +6,7 @@ MRuby::Toolchain.new(:gcc) do |conf, _params|
     cc.option_include_path = '-I%s'
     cc.option_define = '-D%s'
     cc.compile_options = '%{flags} -MMD -o %{outfile} -c %{infile}'
-    cc.cxx_compile_flag = '-x c++'
+    cc.cxx_compile_flag = '-x c++ -std=c++03'
   end
 
   [conf.cxx].each do |cxx|
@@ -16,7 +16,7 @@ MRuby::Toolchain.new(:gcc) do |conf, _params|
     cxx.option_include_path = '-I%s'
     cxx.option_define = '-D%s'
     cxx.compile_options = '%{flags} -MMD -o %{outfile} -c %{infile}'
-    cxx.cxx_compile_flag = '-x c++'
+    cxx.cxx_compile_flag = '-x c++ -std=c++03'
   end
 
   conf.linker do |linker|

--- a/tasks/toolchains/gcc.rake
+++ b/tasks/toolchains/gcc.rake
@@ -6,6 +6,7 @@ MRuby::Toolchain.new(:gcc) do |conf, _params|
     cc.option_include_path = '-I%s'
     cc.option_define = '-D%s'
     cc.compile_options = '%{flags} -MMD -o %{outfile} -c %{infile}'
+    cc.cxx_compile_flag = '-x c++'
   end
 
   [conf.cxx].each do |cxx|
@@ -15,6 +16,7 @@ MRuby::Toolchain.new(:gcc) do |conf, _params|
     cxx.option_include_path = '-I%s'
     cxx.option_define = '-D%s'
     cxx.compile_options = '%{flags} -MMD -o %{outfile} -c %{infile}'
+    cxx.cxx_compile_flag = '-x c++'
   end
 
   conf.linker do |linker|

--- a/tasks/toolchains/visualcpp.rake
+++ b/tasks/toolchains/visualcpp.rake
@@ -7,6 +7,7 @@ MRuby::Toolchain.new(:visualcpp) do |conf, _params|
     cc.option_include_path = '/I%s'
     cc.option_define = '/D%s'
     cc.compile_options = "%{flags} /Fo%{outfile} %{infile}"
+    cc.cxx_compile_flag = '/TP'
   end
 
   conf.cxx do |cxx|
@@ -16,6 +17,7 @@ MRuby::Toolchain.new(:visualcpp) do |conf, _params|
     cxx.option_include_path = '/I%s'
     cxx.option_define = '/D%s'
     cxx.compile_options = "%{flags} /Fo%{outfile} %{infile}"
+    cxx.cxx_compile_flag = '/TP'
   end
 
   conf.linker do |linker|


### PR DESCRIPTION
This is an artifact discovered during #3258. 

mruby offers a way to use C++ exceptions instead of C jumps. This is a great idea, especially given that C++ exceptions cost nothing on modern compilers.

However, this is made in such a way that most of mruby code is compiled as C, and only some special files (`vm.c`, `error.c`, etc.) are complied as C++, while still being defined as "`extern C`".

This is unfortunately an undefined behavior, and many compilers won't generate proper exception propagation code in functions defined as such. That includes both GCC and Clang on different platforms.

The proper solution is to compile all of mruby code as C++. This pull request deals with this issue in a following manner:
- fixed few issues with code that was proper C but not C++ (ie. implicit `void*` casts)
- added macros for C-style definitions like `INT32_MAX`, `SIZE_MAX`, etc.
- added export declarations to MRBC outputs
- changed the method of compiling mruby with C++ ABI to use `-x c++`

The last point should be reworked in the future (hacks for marking some files as C++ would no longer be needed), but it serves well for now, and increases the compatibility of mruby significantly. 