### PR TITLE
Fix segfault when Fixnum#chr doesn't return a string

### DIFF
--- a/mrbgems/mruby-sprintf/src/sprintf.c
+++ b/mrbgems/mruby-sprintf/src/sprintf.c
@@ -675,6 +675,7 @@ retry:
         else {
           mrb_raise(mrb, E_ARGUMENT_ERROR, "invalid character");
         }
+        mrb_check_type(mrb, tmp, MRB_TT_STRING);
         c = RSTRING_PTR(tmp);
         n = RSTRING_LEN(tmp);
         if (!(flags & FWIDTH)) {

--- a/mrbgems/mruby-sprintf/test/sprintf.rb
+++ b/mrbgems/mruby-sprintf/test/sprintf.rb
@@ -7,3 +7,26 @@ assert('String#%') do
   assert_equal "123 < 456", "%{num} < %<str>s" % { num: 123, str: "456" }
   assert_equal 15, ("%b" % (1<<14)).size
 end
+
+assert("String#% with invalid chr") do
+  begin
+    class Fixnum
+      alias_method :chr_, :chr if method_defined?(:chr)
+
+      def chr
+        nil
+      end
+    end
+
+    assert_raise TypeError do
+      "%c" % 0
+    end
+  ensure
+    class Fixnum
+      if method_defined?(:chr_)
+        alias_method :chr, :chr_
+        remove_method :chr_
+      end
+    end
+  end
+end


### PR DESCRIPTION
This code can cause a segfault currently:

```ruby
class Fixnum
  def chr
    nil
  end
end

"%c" % 0
```

@matz