### PR TITLE
Fix Enumeable#take some incompatibility

### DIFF
--- a/mrbgems/mruby-enum-ext/mrblib/enum.rb
+++ b/mrbgems/mruby-enum-ext/mrblib/enum.rb
@@ -61,9 +61,11 @@ module Enumerable
     i = n.to_int
     raise ArgumentError, "attempt to take negative size" if i < 0
     ary = []
+    return ary if i == 0
     self.each do |*val|
-      break if ary.size >= n
       ary << val.__svalue
+      i -= 1
+      break if i == 0
     end
     ary
   end

--- a/mrbgems/mruby-enum-ext/mrblib/enum.rb
+++ b/mrbgems/mruby-enum-ext/mrblib/enum.rb
@@ -58,9 +58,8 @@ module Enumerable
 
   def take(n)
     raise TypeError, "no implicit conversion of #{n.class} into Integer" unless n.respond_to?(:to_int)
-    raise ArgumentError, "attempt to take negative size" if n < 0
-
-    n = n.to_int
+    i = n.to_int
+    raise ArgumentError, "attempt to take negative size" if i < 0
     ary = []
     self.each do |*val|
       break if ary.size >= n


### PR DESCRIPTION
### 	Support object does'n have `<` method

```rb
class A
  def to_int
    3
  end
end
(0..10).take(A.new)
# CRuby(expect) => [0, 1, 2]
# mruby(actual) => undefined method '<' for #<A:0x7ffa390055a0> (NoMethodError)
```

### 	Shouldn't call `each` method if size is 0

```rb
class B
  include Enumerable
  def each
    raise "wow"
  end
end
B.new.take(0)
# CRuby(expect) => []
# mruby(actual) => wow (RuntimeError)
```

This fix passed all specs of that https://github.com/ruby/spec/blob/66daf290cb49707190481b4cf24e700010cd53bf/core/enumerable/shared/take.rb