### PR TITLE
Fixed float tolerance in tests when MRB_USE_FLOAT is set

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -64,6 +64,13 @@
 #endif
 
 #include "mrbconf.h"
+
+#ifdef MRB_USE_FLOAT
+#define MRB_FLOAT_EPSILON FLT_EPSILON
+#else
+#define MRB_FLOAT_EPSILON DBL_EPSILON
+#endif
+
 #include "mruby/common.h"
 #include <mruby/value.h>
 #include <mruby/gc.h>

--- a/mrbgems/mruby-range-ext/src/range.c
+++ b/mrbgems/mruby-range-ext/src/range.c
@@ -140,7 +140,7 @@ mrb_range_size(mrb_state *mrb, mrb_value range)
   }
   if (num_p) {
     mrb_float n = end_f - beg_f;
-    mrb_float err = (fabs(beg_f) + fabs(end_f) + fabs(end_f-beg_f)) * DBL_EPSILON;
+    mrb_float err = (fabs(beg_f) + fabs(end_f) + fabs(end_f-beg_f)) * MRB_FLOAT_EPSILON;
 
     if (err>0.5) err=0.5;
     if (excl) {

--- a/mrbgems/mruby-test/driver.c
+++ b/mrbgems/mruby-test/driver.c
@@ -94,6 +94,12 @@ mrb_init_test_driver(mrb_state *mrb, mrb_bool verbose)
   mrb_define_const(mrb, mrbtest, "FIXNUM_MIN", mrb_fixnum_value(MRB_INT_MIN));
   mrb_define_const(mrb, mrbtest, "FIXNUM_BIT", mrb_fixnum_value(MRB_INT_BIT));
 
+#ifdef MRB_USE_FLOAT
+  mrb_define_const(mrb, mrbtest, "FLOAT_TOLERANCE", mrb_float_value(mrb, 1e-6));
+#else
+  mrb_define_const(mrb, mrbtest, "FLOAT_TOLERANCE", mrb_float_value(mrb, 1e-12));
+#endif
+
   if (verbose) {
     mrb_gv_set(mrb, mrb_intern_lit(mrb, "$mrbtest_verbose"), mrb_true_value());
   }

--- a/test/assert.rb
+++ b/test/assert.rb
@@ -232,7 +232,7 @@ end
 ##
 # Performs fuzzy check for equality on methods returning floats
 def check_float(a, b)
-  tolerance = 1e-12
+  tolerance = Mrbtest::FLOAT_TOLERANCE
   a = a.to_f
   b = b.to_f
   if a.finite? and b.finite?


### PR DESCRIPTION
This is an artifact discovered during #3258.

When single-precision float is used, `1e-12` cannot be used as *epsilon*. New constant for the test driver is introduced. 