### PR TITLE
Remove constant when a struct is redefined.

### DIFF
--- a/mrbgems/mruby-struct/src/struct.c
+++ b/mrbgems/mruby-struct/src/struct.c
@@ -203,7 +203,7 @@ make_struct(mrb_state *mrb, mrb_value name, mrb_value members, struct RClass * k
     }
     if (mrb_const_defined_at(mrb, mrb_obj_value(klass), id)) {
       mrb_warn(mrb, "redefining constant Struct::%S", name);
-      /* ?rb_mod_remove_const(klass, mrb_sym2name(mrb, id)); */
+      mrb_const_remove(mrb, mrb_obj_value(klass), id);
     }
     c = mrb_define_class_under(mrb, klass, RSTRING_PTR(name), klass);
   }

--- a/mrbgems/mruby-struct/test/struct.rb
+++ b/mrbgems/mruby-struct/test/struct.rb
@@ -158,3 +158,24 @@ assert("Struct#dig") do
   assert_equal 1, a.dig(:purple, :red)
   assert_equal 1, a.dig(1, 0)
 end
+
+assert("Struct.new removes existing constant") do
+  begin
+    assert_not_equal Struct.new("Test", :a), Struct.new("Test", :a, :b)
+  ensure
+    Struct.remove_const :Test
+  end
+end
+
+assert("Struct#initialize_copy requires struct to be the same type") do
+  begin
+    Struct.new("Test", :a)
+    a = Struct::Test.new("a")
+    Struct.new("Test", :a, :b)
+    assert_raise(TypeError) do
+      a.initialize_copy(Struct::Test.new("a", "b"))
+    end
+  ensure
+    Struct.remove_const :Test
+  end
+end


### PR DESCRIPTION
Otherwise this can cause a segfault