### PR TITLE
Fix segfault caused by empty condition in ternary

### DIFF
--- a/mrbgems/mruby-compiler/core/codegen.c
+++ b/mrbgems/mruby-compiler/core/codegen.c
@@ -1362,6 +1362,10 @@ codegen(codegen_scope *s, node *tree, int val)
       int pos1, pos2;
       node *e = tree->cdr->cdr->car;
 
+      if (!tree->car) {
+        codegen(s, e, val);
+        return;
+      }
       switch ((intptr_t)tree->car->car) {
       case NODE_TRUE:
       case NODE_INT:

--- a/test/t/codegen.rb
+++ b/test/t/codegen.rb
@@ -1,0 +1,6 @@
+##
+# Codegen tests
+
+assert('empty condition in ternary expression parses correctly') do
+  assert_equal () ? 1 : 2, 2
+end


### PR DESCRIPTION
Reported by https://hackerone.com/jpenalbae