### PR TITLE
Fix incompatibility for Enumerable#first

### DIFF
--- a/mrbgems/mruby-enum-ext/mrblib/enum.rb
+++ b/mrbgems/mruby-enum-ext/mrblib/enum.rb
@@ -215,13 +215,15 @@ module Enumerable
   # Returns the first element, or the first +n+ elements, of the enumerable.
   # If the enumerable is empty, the first form returns <code>nil</code>, and the
   # second form returns an empty array.
-  def first(n=NONE)
-    if n == NONE
+  def first(*args)
+    case args.length
+    when 0
       self.each do |*val|
         return val.__svalue
       end
       return nil
-    else
+    when 1
+      n = args[0]
       raise TypeError, "no implicit conversion of #{n.class} into Integer" unless n.respond_to?(:to_int)
       i = n.to_int
       raise ArgumentError, "attempt to take negative size" if i < 0
@@ -233,6 +235,8 @@ module Enumerable
         break if i == 0
       end
       ary
+    else
+      raise ArgumentError, "wrong number of arguments (given #{args.length}, expected 0..1)"
     end
   end
 

--- a/mrbgems/mruby-enum-ext/mrblib/enum.rb
+++ b/mrbgems/mruby-enum-ext/mrblib/enum.rb
@@ -222,14 +222,17 @@ module Enumerable
       end
       return nil
     else
-      a = []
-      i = 0
+      raise TypeError, "no implicit conversion of #{n.class} into Integer" unless n.respond_to?(:to_int)
+      i = n.to_int
+      raise ArgumentError, "attempt to take negative size" if i < 0
+      ary = []
+      return ary if i == 0
       self.each do |*val|
-        break if n<=i
-        a.push val.__svalue
-        i += 1
+        ary << val.__svalue
+        i -= 1
+        break if i == 0
       end
-      a
+      ary
     end
   end
 


### PR DESCRIPTION
### Like a Enumerable#take

`Enumerable#first` with argument should be same as `Enumerable#take`

See also https://github.com/mruby/mruby/pull/3271

### 	Argument more strictly

```rb
class A
  include Enumerable
  def each
    yield 1
  end
end
class B
  def ==(*)
    true
  end
end
A.new.first(B.new)
# CRuby(expect) => no implicit conversion of B into Integer (TypeError)
# mruby(actual) => 1
```

This fix passed all specs of that https://github.com/ruby/spec/blob/913edd49cd02424dcb3f2ead76e549d8bb4d92bd/core/enumerable/first_spec.rb