### PR TITLE
Remove extra edges structure for RRange

### DIFF
--- a/include/mruby/range.h
+++ b/include/mruby/range.h
@@ -14,14 +14,11 @@
  */
 MRB_BEGIN_DECL
 
-typedef struct mrb_range_edges {
-  mrb_value beg;
-  mrb_value end;
-} mrb_range_edges;
 
 struct RRange {
   MRB_OBJECT_HEADER;
-  mrb_range_edges *edges;
+  mrb_value beg;
+  mrb_value end;
   mrb_bool excl : 1;
 };
 

--- a/mrbgems/mruby-range-ext/src/range.c
+++ b/mrbgems/mruby-range-ext/src/range.c
@@ -49,8 +49,8 @@ mrb_range_cover(mrb_state *mrb, mrb_value range)
 
   mrb_get_args(mrb, "o", &val);
 
-  beg = r->edges->beg;
-  end = r->edges->end;
+  beg = r->beg;
+  end = r->end;
 
   if (r_le(mrb, beg, val)) {
     if (r->excl) {
@@ -90,7 +90,7 @@ mrb_range_last(mrb_state *mrb, mrb_value range)
   struct RRange *r = mrb_range_ptr(range);
 
   if (mrb_get_args(mrb, "|o", &num) == 0) {
-    return r->edges->end;
+    return r->end;
   }
 
   array = mrb_funcall(mrb, range, "to_a", 0);
@@ -117,8 +117,8 @@ mrb_range_size(mrb_state *mrb, mrb_value range)
   mrb_bool num_p = TRUE;
   mrb_bool excl;
 
-  beg = r->edges->beg;
-  end = r->edges->end;
+  beg = r->beg;
+  end = r->end;
   excl = r->excl;
   if (mrb_fixnum_p(beg)) {
     beg_f = (mrb_float)mrb_fixnum(beg);

--- a/src/gc.c
+++ b/src/gc.c
@@ -655,11 +655,8 @@ gc_mark_children(mrb_state *mrb, mrb_gc *gc, struct RBasic *obj)
   case MRB_TT_RANGE:
     {
       struct RRange *r = (struct RRange*)obj;
-
-      if (r->edges) {
-        mrb_gc_mark_value(mrb, r->edges->beg);
-        mrb_gc_mark_value(mrb, r->edges->end);
-      }
+      mrb_gc_mark_value(mrb, r->beg);
+      mrb_gc_mark_value(mrb, r->end);
     }
     break;
 
@@ -771,10 +768,6 @@ obj_free(mrb_state *mrb, struct RBasic *obj)
         mrb_irep_decref(mrb, p->body.irep);
       }
     }
-    break;
-
-  case MRB_TT_RANGE:
-    mrb_free(mrb, ((struct RRange*)obj)->edges);
     break;
 
   case MRB_TT_DATA:

--- a/test/t/range.rb
+++ b/test/t/range.rb
@@ -93,3 +93,14 @@ assert('Range#eql?', '15.2.14.4.14') do
   assert_false (1..10).eql? (Range.new(1.0, 10.0))
   assert_false (1..10).eql? "1..10"
 end
+
+assert('Range without initialize_copy does not fail') do
+  begin
+    Range.alias_method(:old_initialize_copy, :initialize_copy)
+    Range.remove_method(:initialize_copy)
+    assert_equal "nil..nil", (1..2).dup.inspect
+  ensure
+    Range.alias_method(:initialize_copy, :old_initialize_copy)
+    Range.remove_method(:old_initialize_copy)
+  end
+end


### PR DESCRIPTION
Fixes initialize issue reported by @charliesome

I'm guessing the reason struct has an extra struct is to make `RVALUE` smaller? If so, might it be a better alternative to implement RRange using RData, so we can have data structure checks everywhere? Currently there's a lot of unchecked access to `r->edges` which can always be null if the range wasn't initialized