### PR TITLE
Safeguard against using MRB_INT64 with MRB_WORD_BOXING in 32-bit mode

### DIFF
--- a/include/mruby/boxing_word.h
+++ b/include/mruby/boxing_word.h
@@ -11,6 +11,10 @@
 # error MRB_INT16 is too small for MRB_WORD_BOXING.
 #endif
 
+#if defined(MRB_INT64) && !defined(MRB_64BIT)
+#error MRB_INT64 cannot be used with MRB_WORD_BOXING in 32-bit mode.
+#endif
+
 struct RFloat {
   MRB_OBJECT_HEADER;
   mrb_float f;


### PR DESCRIPTION
This is an artifact discovered during #3258.

32-bit `void*` conflicts with 64-bit `mrb_int`.