### PR TITLE
Interpret argument in 'f ()' as nil instead of nothing

### DIFF
--- a/mrbgems/mruby-compiler/bintest/mrbc.rb
+++ b/mrbgems/mruby-compiler/bintest/mrbc.rb
@@ -10,3 +10,12 @@ assert('Compiling multiple files without new line in last line. #2361') do
   assert_equal "#{cmd('mrbc')}:#{a.path}:Syntax OK", result.chomp
   assert_equal 0, $?.exitstatus
 end
+
+assert('parsing function with void argument') do
+  a, out = Tempfile.new('a.rb'), Tempfile.new('out.mrb')
+  a.write('f ()')
+  a.flush
+  result = `#{cmd('mrbc')} -c -o #{out.path} #{a.path} 2>&1`
+  assert_equal "#{cmd('mrbc')}:#{a.path}:Syntax OK", result.chomp
+  assert_equal 0, $?.exitstatus
+end

--- a/mrbgems/mruby-compiler/core/parse.y
+++ b/mrbgems/mruby-compiler/core/parse.y
@@ -2109,7 +2109,7 @@ primary         : literal
                     }
                 | tLPAREN_ARG {p->lstate = EXPR_ENDARG;} rparen
                     {
-                      $$ = 0;
+                      $$ = new_nil(p);
                     }
                 | tLPAREN compstmt ')'
                     {


### PR DESCRIPTION
Otherwise there will be a segfault when it's used in `void_expr_error`