### PR TITLE
Use size_t to calculate bytes needed for array.

### DIFF
--- a/src/array.c
+++ b/src/array.c
@@ -20,15 +20,12 @@ static struct RArray*
 ary_new_capa(mrb_state *mrb, mrb_int capa)
 {
   struct RArray *a;
-  mrb_int blen;
+  size_t blen;
 
   if (capa > ARY_MAX_SIZE) {
     mrb_raise(mrb, E_ARGUMENT_ERROR, "array size too big");
   }
   blen = capa * sizeof(mrb_value);
-  if (blen < capa) {
-    mrb_raise(mrb, E_ARGUMENT_ERROR, "array size too big");
-  }
 
   a = (struct RArray*)mrb_obj_alloc(mrb, MRB_TT_ARRAY, mrb->array_class);
   a->ptr = (mrb_value *)mrb_malloc(mrb, blen);


### PR DESCRIPTION
@matz 

The following code crashes MRuby when built in the default configuration:
```ruby
[0]*300_000_000
```
This happens because the maximum array length is `MRB_INT_MAX-1`, and so an array could require up to `(MRB_INT_MAX-1) * sizeof(mrb_value)` bytes to store. This value can be larger than 32 bits, which overflows `blen`. To fix this problem, I've changed `blen` to a `size_t`. Since `ARY_MAX_SIZE` is no larger than `SIZE_MAX / sizeof(mrb_value)` no overflow can occur after this change.

The second overflow check is unnecessary, so I've removed it.

The bug was reported by Hugh Davenport (https://hackerone.com/haquaman).