### PR TITLE
Implement Enumerable::Lazy#to_enum and enum_for

### DIFF
--- a/mrbgems/mruby-enum-lazy/mrblib/lazy.rb
+++ b/mrbgems/mruby-enum-lazy/mrblib/lazy.rb
@@ -40,6 +40,15 @@ module Enumerable
       }
     end
 
+    def to_enum(meth=:each, *args, &block)
+      lz = Lazy.new(self, &block)
+      lz.obj = self
+      lz.meth = meth
+      lz.args = args
+      lz
+    end
+    alias enum_for to_enum
+
     def map(&block)
       Lazy.new(self){|yielder, val|
         yielder << block.call(val)

--- a/mrbgems/mruby-enum-lazy/test/lazy.rb
+++ b/mrbgems/mruby-enum-lazy/test/lazy.rb
@@ -40,6 +40,12 @@ assert("Enumerable::Lazy laziness") do
   assert_equal [10,20], a.b
 end
 
+assert("Enumrable::Lazy#to_enum") do
+  lazy_enum = (0..Float::INFINITY).lazy.to_enum(:each_slice, 2)
+  assert_kind_of Enumerable::Lazy, lazy_enum
+  assert_equal [0*1, 2*3, 4*5, 6*7], lazy_enum.map { |a| a.first * a.last }.first(4)
+end
+
 assert("Enumerable::Lazy#zip with cycle") do
   e1 = [1, 2, 3].cycle
   e2 = [:a, :b].cycle


### PR DESCRIPTION
When `to_enum` method called by `Enumerable::Lazy` object, It lost information for lazy.
I think It should keep.

# Reproduction code

```rb
p (0..Float::INFINITY).lazy.to_enum(:each_slice, 2).map { |a| a.first * a.last }.first(4)
```

# Actual
```sh
$ mruby t.rb
...inifinite loop...
```

# Expect

```sh
$ ruby t.rb
[0, 6, 20, 42]
```