### PR TITLE
Change Lazy class outer

### DIFF
--- a/mrbgems/default.gembox
+++ b/mrbgems/default.gembox
@@ -53,7 +53,7 @@ MRuby::GemBox.new do |conf|
   # Use Enumerator class (require mruby-fiber)
   conf.gem :core => "mruby-enumerator"
 
-  # Use Enumerable::Lazy class (require mruby-enumerator)
+  # Use Enumerator::Lazy class (require mruby-enumerator)
   conf.gem :core => "mruby-enum-lazy"
 
   # Use toplevel object (main) methods extension

--- a/mrbgems/mruby-enum-lazy/mrbgem.rake
+++ b/mrbgems/mruby-enum-lazy/mrbgem.rake
@@ -1,7 +1,7 @@
 MRuby::Gem::Specification.new('mruby-enum-lazy') do |spec|
   spec.license = 'MIT'
   spec.author  = 'mruby developers'
-  spec.summary = 'Enumerable::Lazy class'
+  spec.summary = 'Enumerator::Lazy class'
   spec.add_dependency('mruby-enumerator', :core => 'mruby-enumerator')
   spec.add_dependency('mruby-enum-ext', :core => 'mruby-enum-ext')
 end

--- a/mrbgems/mruby-enum-lazy/mrblib/lazy.rb
+++ b/mrbgems/mruby-enum-lazy/mrblib/lazy.rb
@@ -2,7 +2,7 @@ module Enumerable
 
   # = Enumerable#lazy implementation
   #
-  # Enumerable#lazy returns an instance of Enumerable::Lazy.
+  # Enumerable#lazy returns an instance of Enumerator::Lazy.
   # You can use it just like as normal Enumerable object,
   # except these methods act as 'lazy':
   #
@@ -16,9 +16,11 @@ module Enumerable
   #   - flat_map  collect_concat
   #   - zip
   def lazy
-    Lazy.new(self)
+    Enumerator::Lazy.new(self)
   end
+end
 
+class Enumerator
   # == Acknowledgements
   #
   #   Based on https://github.com/yhara/enumerable-lazy

--- a/mrbgems/mruby-enum-lazy/test/lazy.rb
+++ b/mrbgems/mruby-enum-lazy/test/lazy.rb
@@ -1,9 +1,9 @@
-assert("Enumerable::Lazy") do
+assert("Enumerator::Lazy") do
   a = [1, 2]
-  assert_equal Enumerable::Lazy, a.lazy.class
+  assert_equal Enumerator::Lazy, a.lazy.class
 end
 
-assert("Enumerable::Lazy laziness") do
+assert("Enumerator::Lazy laziness") do
   a = Object.new
   def a.each
     return to_enum :each unless block_given?
@@ -40,7 +40,7 @@ assert("Enumerable::Lazy laziness") do
   assert_equal [10,20], a.b
 end
 
-assert("Enumerable::Lazy#zip with cycle") do
+assert("Enumerator::Lazy#zip with cycle") do
   e1 = [1, 2, 3].cycle
   e2 = [:a, :b].cycle
   assert_equal [[1,:a],[2,:b],[3,:a]], e1.lazy.zip(e2).first(3)


### PR DESCRIPTION
I think that Lazy class should be under Enumerator class instead of Enumerable module.

```rb
$ ruby -e 'p [].lazy.class'
Enumerator::Lazy
```