### PR TITLE
Support Enumerable methods

### DIFF
--- a/mrbgems/mruby-enumerator/mrblib/enumerator.rb
+++ b/mrbgems/mruby-enumerator/mrblib/enumerator.rb
@@ -516,6 +516,7 @@ class Enumerator
 
   # just for internal
   class Generator
+    include Enumerable
     def initialize(&block)
       raise TypeError, "wrong argument type #{self.class} (expected Proc)" unless block.kind_of? Proc
 


### PR DESCRIPTION
Expect behavior.

```sh
$ ruby -e 'p Enumerator::Generator.new{|y| y << 1 << 2 << 3}.map{|i| i * i }'
[1, 4, 9]
```