### PR TITLE
Fix some incompatibility for Enumerator#with_index

### DIFF
--- a/mrbgems/mruby-enumerator/mrblib/enumerator.rb
+++ b/mrbgems/mruby-enumerator/mrblib/enumerator.rb
@@ -162,9 +162,9 @@ class Enumerator
     end
 
     n = offset - 1
-    enumerator_block_call do |i|
+    enumerator_block_call do |*i|
       n += 1
-      yield [i,n]
+      yield i.__svalue, n
     end
   end
 

--- a/mrbgems/mruby-enumerator/mrblib/enumerator.rb
+++ b/mrbgems/mruby-enumerator/mrblib/enumerator.rb
@@ -153,9 +153,15 @@ class Enumerator
   #
   def with_index(offset=0)
     return to_enum :with_index, offset unless block_given?
-    raise TypeError, "no implicit conversion of #{offset.class} into Integer" unless offset.respond_to?(:to_int)
+    offset = if offset.nil?
+      0
+    elsif offset.respond_to?(:to_int)
+      offset.to_int
+    else
+      raise TypeError, "no implicit conversion of #{offset.class} into Integer"
+    end
 
-    n = offset.to_int - 1
+    n = offset - 1
     enumerator_block_call do |i|
       n += 1
       yield [i,n]

--- a/mrbgems/mruby-enumerator/test/enumerator.rb
+++ b/mrbgems/mruby-enumerator/test/enumerator.rb
@@ -50,6 +50,9 @@ end
 assert 'Enumerator#with_index' do
   assert_equal([[1,0],[2,1],[3,2]], @obj.to_enum(:foo, 1, 2, 3).with_index.to_a)
   assert_equal([[1,5],[2,6],[3,7]], @obj.to_enum(:foo, 1, 2, 3).with_index(5).to_a)
+  a = []
+  @obj.to_enum(:foo, 1, 2, 3).with_index(10).with_index(20) { |*i| a << i }
+  assert_equal [[[1, 10], 20], [[2, 11], 21], [[3, 12], 22]], a
 end
 
 assert 'Enumerator#with_index nonnum offset' do


### PR DESCRIPTION
# Support nil argument as no argument

```rb
p [1,2,3].each.with_index(nil).to_a
# CRuby(expect) => [[1, 0], [2, 1], [3, 2]]
# mruby(actual) => no implicit conversion of NilClass into Integer (TypeError)
```

# Support svalue

```rb
a = []
[1,2,3].each.with_index(10).with_index(20) { |*i| a << i }
p a
# CRuby(expect) => [[[1, 10], 20], [[2, 11], 21], [[3, 12], 22]]
# mruby(actual) => [[[[1, 10], 20]], [[[2, 11], 21]], [[[3, 12], 22]]]
```