### PR TITLE
Use mrb_ptr instead of mrb_cptr in Kernel#to_s

### DIFF
--- a/src/object.c
+++ b/src/object.c
@@ -444,7 +444,7 @@ mrb_any_to_s(mrb_state *mrb, mrb_value obj)
   mrb_str_cat_lit(mrb, str, "#<");
   mrb_str_cat_cstr(mrb, str, cname);
   mrb_str_cat_lit(mrb, str, ":");
-  mrb_str_concat(mrb, str, mrb_ptr_to_str(mrb, mrb_cptr(obj)));
+  mrb_str_concat(mrb, str, mrb_ptr_to_str(mrb, mrb_ptr(obj)));
   mrb_str_cat_lit(mrb, str, ">");
 
   return str;

--- a/test/t/kernel.rb
+++ b/test/t/kernel.rb
@@ -520,6 +520,21 @@ assert('Kernel#to_s', '15.3.1.3.46') do
   assert_equal to_s.class, String
 end
 
+assert('Kernel#to_s on primitives') do
+  begin
+    Fixnum.alias_method :to_s_, :to_s
+    Fixnum.remove_method :to_s
+
+    assert_nothing_raised do
+      # segfaults if mrb_cptr is used
+      1.to_s
+    end
+  ensure
+    Fixnum.alias_method :to_s, :to_s_
+    Fixnum.remove_method :to_s_
+  end
+end
+
 assert('Kernel.local_variables', '15.3.1.2.7') do
   a, b = 0, 1
   a += b


### PR DESCRIPTION
This is to avoid segfault when WORD_BOXING is enabled