### PR TITLE
Fix stack move segfaulting in OP_ARYCAT

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -2134,8 +2134,8 @@ RETRY_TRY_BLOCK:
 
     CASE(OP_ARYCAT) {
       /* A B            mrb_ary_concat(R(A),R(B)) */
-      mrb_ary_concat(mrb, regs[GETARG_A(i)],
-                     mrb_ary_splat(mrb, regs[GETARG_B(i)]));
+      mrb_value splat = mrb_ary_splat(mrb, regs[GETARG_B(i)]);
+      mrb_ary_concat(mrb, regs[GETARG_A(i)], splat);
       ARENA_RESTORE(mrb, ai);
       NEXT;
     }


### PR DESCRIPTION
Testcase (couldn't get it to work as a test):

```
def nil.b
  b *nil
end
nil.b
```