### PR TITLE
Fix segfault in mrb_proc_copy.

### DIFF
--- a/src/proc.c
+++ b/src/proc.c
@@ -140,7 +140,7 @@ mrb_proc_copy(struct RProc *a, struct RProc *b)
 {
   a->flags = b->flags;
   a->body = b->body;
-  if (!MRB_PROC_CFUNC_P(a)) {
+  if (!MRB_PROC_CFUNC_P(a) && a->body.irep) {
     a->body.irep->refcnt++;
   }
   a->target_class = b->target_class;

--- a/test/t/proc.rb
+++ b/test/t/proc.rb
@@ -163,3 +163,19 @@ assert('&obj call to_proc if defined') do
 
   assert_raise(TypeError){ mock(&(Object.new)) }
 end
+
+assert('initialize_copy works when initialize is removed') do
+  begin
+    Proc.alias_method(:old_initialize, :initialize)
+    Proc.remove_method(:initialize)
+
+    a = Proc.new {}
+    b = Proc.new {}
+    assert_nothing_raised do
+      a.initialize_copy(b)
+    end
+  ensure
+    Proc.alias_method(:initialize, :old_initialize)
+    Proc.remove_method(:old_initialize)
+  end
+end


### PR DESCRIPTION
@matz 

The following code results in a crash:
```ruby
Proc.remove_method(:initialize)
a = Proc.new {}
b = Proc.new {}
a.initialize_copy(b)
```
This patch corrects the problem by checking `a->body.irep` before dereferencing it.

This issue was reported by https://hackerone.com/brakhane.