### PR TITLE
Fix 36fc1f14 not checking in the right location

### DIFF
--- a/src/error.c
+++ b/src/error.c
@@ -278,8 +278,6 @@ mrb_exc_set(mrb_state *mrb, mrb_value exc)
     mrb->exc = 0;
   }
   else {
-    if (!mrb_obj_is_kind_of(mrb, exc, mrb->eException_class))
-      mrb_raise(mrb, E_TYPE_ERROR, "exception object expected");
     mrb->exc = mrb_obj_ptr(exc);
   }
 }
@@ -287,6 +285,9 @@ mrb_exc_set(mrb_state *mrb, mrb_value exc)
 MRB_API mrb_noreturn void
 mrb_exc_raise(mrb_state *mrb, mrb_value exc)
 {
+  if (!mrb_obj_is_kind_of(mrb, exc, mrb->eException_class)) {
+    mrb_raise(mrb, E_TYPE_ERROR, "exception object expected");
+  }
   mrb_exc_set(mrb, exc);
   if (!mrb->gc.out_of_memory) {
     exc_debug_info(mrb, mrb->exc);

--- a/test/t/nomethoderror.rb
+++ b/test/t/nomethoderror.rb
@@ -51,3 +51,21 @@ assert('Can still call super when BasicObject#method_missing is removed') do
     end
   end
 end
+
+assert("NoMethodError#new does not return an exception") do
+  begin
+    class << NoMethodError
+      def new(*)
+        nil
+      end
+    end
+
+    assert_raise(TypeError) do
+      Object.q
+    end
+  ensure
+    class << NoMethodError
+      remove_method :new
+    end
+  end
+end


### PR DESCRIPTION
36fc1f14 should've added the exception class check in the mrb_exc_raise function, as the check in mrb_exc_set doesn't work if the value is nil. I also added the test that was originally in https://github.com/mruby/mruby/pull/3292 (which was failing on master)