### PR TITLE
Don't generate code for NODE_NEGATE if the result isn't used

### DIFF
--- a/mrbgems/mruby-compiler/core/codegen.c
+++ b/mrbgems/mruby-compiler/core/codegen.c
@@ -2223,6 +2223,10 @@ codegen(codegen_scope *s, node *tree, int val)
     {
       nt = (intptr_t)tree->car;
       tree = tree->cdr;
+      if (!val) {
+        codegen(s, tree, NOVAL);
+        break;
+      }
       switch (nt) {
       case NODE_FLOAT:
         {

--- a/test/t/codegen.rb
+++ b/test/t/codegen.rb
@@ -63,3 +63,13 @@ assert('splat in case splat') do
 
   assert_equal [1], a
 end
+
+assert('negate literal register alignment') do
+  a = *case
+  when 0
+    -0.0
+    2
+  end
+
+  assert_equal [2], a
+end


### PR DESCRIPTION
As reported by https://hackerone.com/haquaman

The current code for NODE_NEGATE can cause a register misalignment, as it pushes values onto the stack even when its return value isn't used. This PR fixes it with a short circuit if the result isn't used (which leads to the code being optimized away entirely if the tree is NODE_FLOAT or NODE_INT)

