### PR TITLE
Removed the errno declaration from string.c

### DIFF
--- a/src/string.c
+++ b/src/string.c
@@ -2769,9 +2769,6 @@ mrb_init_string(mrb_state *mrb)
 
 #include <ctype.h>
 #include <errno.h>
-#ifndef errno
-extern  int     errno;
-#endif
 
 #ifndef __STDC__
 # ifdef __GNUC__

--- a/src/string.c
+++ b/src/string.c
@@ -2750,7 +2750,7 @@ mrb_init_string(mrb_state *mrb)
   mrb_define_method(mrb, s, "freeze",          mrb_str_freeze,          MRB_ARGS_NONE());
 }
 
-/* 
+/*
  *	Source code for the "strtod" library procedure.
  *
  * Copyright (c) 1988-1993 The Regents of the University of California.
@@ -2769,7 +2769,9 @@ mrb_init_string(mrb_state *mrb)
 
 #include <ctype.h>
 #include <errno.h>
+#ifndef errno
 extern  int     errno;
+#endif
 
 #ifndef __STDC__
 # ifdef __GNUC__
@@ -2876,7 +2878,7 @@ mrb_float_read(const char *string, char **endPtr)
      * If the mantissa has more than 18 digits, ignore the extras, since
      * they can't affect the value anyway.
      */
-    
+
     pExp  = p;
     p -= mantSize;
     if (decPt < 0) {
@@ -2954,7 +2956,7 @@ mrb_float_read(const char *string, char **endPtr)
      * many powers of 2 of 10. Then combine the exponent with the
      * fraction.
      */
-    
+
     if (exp < 0) {
 	expSign = TRUE;
 	exp = -exp;


### PR DESCRIPTION
…lt errno macro

Addresses issue https://github.com/mruby/mruby/issues/3326 specifically for platforms that define errno as a macro.