### PR TITLE
Copy default_proc by Hash#dup.

### DIFF
--- a/src/hash.c
+++ b/src/hash.c
@@ -225,6 +225,7 @@ mrb_hash_dup(mrb_state *mrb, mrb_value hash)
   struct RHash* ret;
   khash_t(ht) *h, *ret_h;
   khiter_t k, ret_k;
+  mrb_value ifnone, vret;
 
   h = RHASH_TBL(hash);
   ret = (struct RHash*)mrb_obj_alloc(mrb, MRB_TT_HASH, mrb->hash_class);
@@ -243,7 +244,18 @@ mrb_hash_dup(mrb_state *mrb, mrb_value hash)
     }
   }
 
-  return mrb_obj_value(ret);
+  if (MRB_RHASH_DEFAULT_P(hash)) {
+    ret->flags |= MRB_HASH_DEFAULT;
+  }
+  if (MRB_RHASH_PROCDEFAULT_P(hash)) {
+    ret->flags |= MRB_HASH_PROC_DEFAULT;
+  }
+  vret = mrb_obj_value(ret);
+  ifnone = RHASH_IFNONE(hash);
+  if (!mrb_nil_p(ifnone)) {
+      mrb_iv_set(mrb, vret, mrb_intern_lit(mrb, "ifnone"), ifnone);
+  }
+  return vret;
 }
 
 MRB_API mrb_value

--- a/test/t/hash.rb
+++ b/test/t/hash.rb
@@ -44,6 +44,10 @@ assert('Hash#dup') do
   b = a.dup
   a['a'] = 2
   assert_equal({'a' => 1}, b)
+
+  c = Hash.new { |h, k| h[k] = k.upcase }
+  d = c.dup
+  assert_equal("FOO", d["foo"])
 end
 
 assert('Hash#default', '15.2.13.4.5') do


### PR DESCRIPTION
Hash#dup copies default_proc in CRuby:

```
$ ruby -e 'h = Hash.new {|h,k| 123}; p h.dup[0]'       
123
```

So default_proc should also be copied in mruby.