### PR TITLE
Mark all the built-in classes during GC sweep

### DIFF
--- a/mrbgems/mruby-bin-mruby/bintest/mruby.rb
+++ b/mrbgems/mruby-bin-mruby/bintest/mruby.rb
@@ -44,3 +44,17 @@ EOS
   script.flush
   assert_equal "\"test\"\n\"fin\"\n", `#{cmd('mruby')} #{script.path}`
 end
+
+assert('garbage collecting built-in classes') do
+  script = Tempfile.new('test.rb')
+
+  script.write <<RUBY
+NilClass = nil
+GC.start
+Array.dup
+print nil.class.name
+RUBY
+  script.flush
+  assert_equal "NilClass", `#{cmd('mruby')} #{script.path}`
+  assert_equal 0, $?.exitstatus
+end

--- a/src/gc.c
+++ b/src/gc.c
@@ -832,6 +832,26 @@ root_scan_phase(mrb_state *mrb, mrb_gc *gc)
   }
   /* mark class hierarchy */
   mrb_gc_mark(mrb, (struct RBasic*)mrb->object_class);
+
+  /* mark built-in classes */
+  mrb_gc_mark(mrb, (struct RBasic*)mrb->class_class);
+  mrb_gc_mark(mrb, (struct RBasic*)mrb->module_class);
+  mrb_gc_mark(mrb, (struct RBasic*)mrb->proc_class);
+  mrb_gc_mark(mrb, (struct RBasic*)mrb->string_class);
+  mrb_gc_mark(mrb, (struct RBasic*)mrb->array_class);
+  mrb_gc_mark(mrb, (struct RBasic*)mrb->hash_class);
+
+  mrb_gc_mark(mrb, (struct RBasic*)mrb->float_class);
+  mrb_gc_mark(mrb, (struct RBasic*)mrb->fixnum_class);
+  mrb_gc_mark(mrb, (struct RBasic*)mrb->true_class);
+  mrb_gc_mark(mrb, (struct RBasic*)mrb->false_class);
+  mrb_gc_mark(mrb, (struct RBasic*)mrb->nil_class);
+  mrb_gc_mark(mrb, (struct RBasic*)mrb->symbol_class);
+  mrb_gc_mark(mrb, (struct RBasic*)mrb->kernel_module);
+
+  mrb_gc_mark(mrb, (struct RBasic*)mrb->eException_class);
+  mrb_gc_mark(mrb, (struct RBasic*)mrb->eStandardError_class);
+
   /* mark top_self */
   mrb_gc_mark(mrb, (struct RBasic*)mrb->top_self);
   /* mark exception */


### PR DESCRIPTION
This fixes an issue where a built-in class can get garbage collected, put onto the freelist, and reused. This can lead to instantiating an object with an MRB_TT that doesn't match its class.