### PR TITLE
[WIP] fix for Windows builds in C++ mode

### DIFF
--- a/src/mruby_core.rake
+++ b/src/mruby_core.rake
@@ -9,7 +9,7 @@ MRuby.each_target do
   }.compact
 
   if cxx_abi_enabled?
-    objs += %w(vm error).map { |v| compile_as_cxx "#{current_dir}/#{v}.c", "#{current_build_dir}/#{v}.cxx" }
+    objs += %w(vm error string).map { |v| compile_as_cxx "#{current_dir}/#{v}.c", "#{current_build_dir}/#{v}.cxx" }
   end
   self.libmruby << objs
 


### PR DESCRIPTION
This is caused by the latest change in `mrb_float_read`