### PR TITLE
fix issues of mrb_gc_unregister introduced in 09b1185

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -453,7 +453,7 @@ mrb_gc_unregister(mrb_state *mrb, mrb_value obj)
   mrb_sym root = mrb_intern_lit(mrb, GC_ROOT_NAME);
   mrb_value table = mrb_gv_get(mrb, root);
   struct RArray *a;
-  mrb_int i, len;
+  mrb_int i;
 
   if (mrb_nil_p(table)) return;
   if (mrb_type(table) != MRB_TT_ARRAY) {
@@ -462,14 +462,13 @@ mrb_gc_unregister(mrb_state *mrb, mrb_value obj)
   }
   a = mrb_ary_ptr(table);
   mrb_ary_modify(mrb, a);
-  len = a->len-1;
-  for (i=0; i<len; i++) {
+  for (i = 0; i < a->len; i++) {
     if (mrb_obj_eq(mrb, a->ptr[i], obj)) {
-      memmove(&a->ptr[i], &a->ptr[i+1], len-i);
+      a->len--;
+      memmove(&a->ptr[i], &a->ptr[i + 1], (a->len - i) * sizeof(a->ptr[i]));
       break;
     }
   }
-  a->len--;
 }
 
 MRB_API struct RBasic*


### PR DESCRIPTION
* fixes partial copy of objects in GC root array (due to missing `* sizeof(mrb_value)`)
* restores the behavior that permitted an unregistered object to be used as an argument

The issues were detected while trying to update the mruby used by H2O in https://github.com/h2o/h2o/pull/1135.