### PR TITLE
Removed unnecessary const macro - const keyword is already a dependency

### DIFF
--- a/src/string.c
+++ b/src/string.c
@@ -2770,14 +2770,6 @@ mrb_init_string(mrb_state *mrb)
 #include <ctype.h>
 #include <errno.h>
 
-#ifndef __STDC__
-# ifdef __GNUC__
-#  define const __const__
-# elif !defined(_MSC_VER)
-#  define const
-# endif
-#endif
-
 static const int maxExponent = 511; /* Largest possible base 10 exponent.  Any
                                      * exponent larger than this will already
                                      * produce underflow or overflow, so there's


### PR DESCRIPTION
const is already used at the top of string.c, so we can guarantee that the compiler supports the const keyword at this position of the code.

This macro also does not work for circumstances where \_\_STDC__ is not defined and your compiler has not definition (the default is to disable the const keyword, this does not sound like intentional behaviour).