### PR TITLE
Fix segfault when undef is called with more than 126 arguments

### DIFF
--- a/mrbgems/mruby-compiler/core/codegen.c
+++ b/mrbgems/mruby-compiler/core/codegen.c
@@ -2560,13 +2560,31 @@ codegen(codegen_scope *s, node *tree, int val)
       genop(s, MKOP_A(OP_TCLASS, cursp()));
       push();
       while (t) {
-        int symbol = new_msym(s, sym(t->car));
+        int symbol;
+        if (num >= CALL_MAXARGS - 1) {
+          pop_n(num);
+          genop(s, MKOP_ABC(OP_ARRAY, cursp(), cursp(), num));
+          while (t) {
+            symbol = new_msym(s, sym(t->car));
+            push();
+            genop(s, MKOP_ABx(OP_LOADSYM, cursp(), symbol));
+            pop();
+            genop(s, MKOP_AB(OP_ARYPUSH, cursp(), cursp()+1));
+            t = t->cdr;
+          }
+          num = CALL_MAXARGS;
+          break;
+        }
+        symbol = new_msym(s, sym(t->car));
         genop(s, MKOP_ABx(OP_LOADSYM, cursp(), symbol));
         push();
         t = t->cdr;
         num++;
       }
-      pop_n(num + 1);
+      pop();
+      if (num < CALL_MAXARGS) {
+        pop_n(num);
+      }
       genop(s, MKOP_ABC(OP_SEND, cursp(), undef, num));
       if (val) {
         push();

--- a/test/t/codegen.rb
+++ b/test/t/codegen.rb
@@ -63,3 +63,13 @@ assert('splat in case splat') do
 
   assert_equal [1], a
 end
+
+assert('undef with 127 or more arguments') do
+  assert_raise NameError do
+    undef
+      a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a,
+      a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a,
+      a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a,
+      a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a
+  end
+end


### PR DESCRIPTION
The issue is that when there are more than 126 arguments an array needs
to be created to pass the arguments on with.

Reported by https://hackerone.com/revskills