### PR TITLE
Fix segfault in gen_values with NOVAL and more than 127 args

### DIFF
--- a/mrbgems/mruby-compiler/core/codegen.c
+++ b/mrbgems/mruby-compiler/core/codegen.c
@@ -818,8 +818,6 @@ gen_values(codegen_scope *s, node *t, int val)
         }
       }
       else {
-        codegen(s, t->car->cdr, NOVAL);
-        t = t->cdr;
         while (t) {
           codegen(s, t->car, NOVAL);
           t = t->cdr;

--- a/test/t/codegen.rb
+++ b/test/t/codegen.rb
@@ -73,3 +73,11 @@ assert('undef with 127 or more arguments') do
       a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a
   end
 end
+
+assert('next in normal loop with 127 arguments') do
+  assert_raise NameError do
+    while true
+      next A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A
+    end
+  end
+end


### PR DESCRIPTION
There seemed to be some unused code leftover in `gen_values` that can cause a segmentation fault if gen_values is used with more than 127 arguments in a NOVAL context.

This fixes that issue by removing the unused code