### PR TITLE
Support pkg-config in mrbgem.rake

### DIFF
--- a/tasks/mrbgem_spec.rake
+++ b/tasks/mrbgem_spec.rake
@@ -1,6 +1,7 @@
 require 'pathname'
 require 'forwardable'
 require 'tsort'
+require 'shellwords'
 
 module MRuby
   module Gem
@@ -124,6 +125,21 @@ module MRuby
 
       def test_rbireps
         "#{build_dir}/gem_test.c"
+      end
+
+      def search_package(name, version_query=nil)
+        package_query = name
+        package_query += " #{version_query}" if version_query
+        _pp "PKG-CONFIG", package_query
+        escaped_package_query = Shellwords.escape(package_query)
+        if system("pkg-config --exists #{escaped_package_query}")
+          cc.flags += [`pkg-config --cflags #{escaped_package_query}`.strip]
+          cxx.flags += [`pkg-config --cflags #{escaped_package_query}`.strip]
+          linker.flags += [`pkg-config --libs #{escaped_package_query}`.strip]
+          true
+        else
+          false
+        end
       end
 
       def funcname


### PR DESCRIPTION
Example usage:

    MRuby::Gem::Specification.new('mruby-onig-regexp') do |spec|
      # ...
      if spec.search_package('onigmo')
        # Use onigmo.h when onigmo.pc exist.
        spec.cc.defines += ["HAVE_ONIGMO_H"]
      elsif spec.search_package('oniguruma')
        # Use oniguruma.h when oniguruma.pc exist.
        spec.cc.defines += ["HAVE_ONIGURUMA_H"]
      else
        # Use bundled Onigmo otherwise.
        # ...
      end
    end