### PR TITLE
Fix calculation of new string capacity.

### DIFF
--- a/src/string.c
+++ b/src/string.c
@@ -162,11 +162,11 @@ str_buf_cat(mrb_state *mrb, struct RString *s, const char *ptr, size_t len)
   total = RSTR_LEN(s)+len;
   if (capa <= total) {
     while (total > capa) {
-      if (capa + 1 >= MRB_INT_MAX / 2) {
-        capa = (total + 4095) / 4096;
-        break;
+      if (capa <= MRB_INT_MAX / 2) {
+        capa *= 2;
+      } else {
+        capa = MRB_INT_MAX;
       }
-      capa = (capa + 1) * 2;
     }
     resize_capa(mrb, s, capa);
   }


### PR DESCRIPTION
@matz 

If MRuby is compiled with `MRB_INT16`, then the following code causes a crash:
```ruby
loop { ([0]*10000).to_s }
```
This happens because `str_buf_cat` incorrectly computes the new string capacity, choosing a capacity which is 1/4096 of the needed value: https://github.com/mruby/mruby/blob/9cef2654025e6646b1d0ff259086fc9eb02fff84/src/string.c#L166

To fix this I'm proposing to change the capacity calculation to match what's done for arrays: https://github.com/mruby/mruby/blob/647ad29a7a1147e2c3ed93329cabbb974482697f/src/array.c#L180-L184