### PR TITLE
Fix crash when exponent is -2147483648

### DIFF
--- a/src/string.c
+++ b/src/string.c
@@ -2868,7 +2868,11 @@ mrb_float_read(const char *string, char **endPtr)
 	mantSize -= 1;			/* One of the digits was the point. */
     }
     if (mantSize > 18) {
-	fracExp = decPt - 18;
+	if (decPt - 18 > 29999) {
+	    fracExp = 29999;
+	} else {
+	    fracExp = decPt - 18;
+	}
 	mantSize = 18;
     } else {
 	fracExp = decPt - mantSize;
@@ -2922,6 +2926,9 @@ mrb_float_read(const char *string, char **endPtr)
 	}
 	while (isdigit(*p)) {
 	    exp = exp * 10 + (*p - '0');
+	    if (exp > 19999) {
+		exp = 19999;
+	    }
 	    p += 1;
 	}
     }

--- a/test/t/string.rb
+++ b/test/t/string.rb
@@ -596,10 +596,14 @@ assert('String#to_f', '15.2.10.5.38') do
   a = ''.to_f
   b = '123456789'.to_f
   c = '12345.6789'.to_f
+  d = '1e-2147483648'.to_f
+  e = '1e2147483648'.to_f
 
   assert_float(0.0, a)
   assert_float(123456789.0, b)
   assert_float(12345.6789, c)
+  assert_float(0, d)
+  assert_float(Float::INFINITY, e)
 end
 
 assert('String#to_i', '15.2.10.5.39') do


### PR DESCRIPTION
@matz

Currently, the following inputs (and others) crash MRuby:
```ruby
'1e-2147483648'.to_f
'1e2147483648'.to_f
```
This happens because `exp` is equal to -2147483648 here:

https://github.com/mruby/mruby/blob/73cc08772f1a11140b238525698bce0664326a50/src/string.c#L2943

Negating `exp` there leaves it as -2147483648 (since 2147483648 = -2147483648 for 32-bit signed integers). This then results in an out-of-bounds read from `powersOf10` a few lines later.

I've tried to solve the problem by limiting `fracExp` and `exp` to reasonable values. (MRI also limits the exponent to 19999.)

This issue was reported by https://hackerone.com/revskills.