### PR TITLE
Proc shouldn't have `initialize` method

### DIFF
--- a/mrbgems/mruby-proc-ext/test/proc.rb
+++ b/mrbgems/mruby-proc-ext/test/proc.rb
@@ -58,17 +58,6 @@ assert('Proc#parameters') do
   assert_equal([[:req, :a], [:req, :b], [:opt, :c], [:opt, :d], [:rest, :e], [:req, :f], [:req, :g], [:block, :h]], lambda {|a,b,c=:c,d=:d,*e,f,g,&h|}.parameters)
 end
 
-assert('Proc#parameters with uninitialized Proc') do
-  begin
-    Proc.alias_method(:original_initialize, :initialize)
-    Proc.remove_method(:initialize)
-    assert_equal [], Proc.new{|a, b, c| 1}.parameters
-  ensure
-    Proc.alias_method(:initialize, :original_initialize)
-    Proc.remove_method(:original_initialize)
-  end
-end
-
 assert('Proc#to_proc') do
   proc = Proc.new {}
   assert_equal proc, proc.to_proc

--- a/src/proc.c
+++ b/src/proc.c
@@ -148,19 +148,19 @@ mrb_proc_copy(struct RProc *a, struct RProc *b)
 }
 
 static mrb_value
-mrb_proc_initialize(mrb_state *mrb, mrb_value self)
+mrb_proc_s_new(mrb_state *mrb, mrb_value proc_class)
 {
   mrb_value blk;
+  struct RProc *p;
 
   mrb_get_args(mrb, "&", &blk);
   if (mrb_nil_p(blk)) {
     /* Calling Proc.new without a block is not implemented yet */
     mrb_raise(mrb, E_ARGUMENT_ERROR, "tried to create Proc object without a block");
   }
-  else {
-    mrb_proc_copy(mrb_proc_ptr(self), mrb_proc_ptr(blk));
-  }
-  return self;
+  p = (struct RProc *)mrb_obj_alloc(mrb, MRB_TT_PROC, mrb_class_ptr(proc_class));
+  mrb_proc_copy(p, mrb_proc_ptr(blk));
+  return mrb_obj_value(p);
 }
 
 static mrb_value
@@ -268,7 +268,7 @@ mrb_init_proc(mrb_state *mrb)
   call_irep->iseq = call_iseq;
   call_irep->ilen = 1;
 
-  mrb_define_method(mrb, mrb->proc_class, "initialize", mrb_proc_initialize, MRB_ARGS_NONE());
+  mrb_define_class_method(mrb, mrb->proc_class, "new", mrb_proc_s_new, MRB_ARGS_ANY());
   mrb_define_method(mrb, mrb->proc_class, "initialize_copy", mrb_proc_init_copy, MRB_ARGS_REQ(1));
   mrb_define_method(mrb, mrb->proc_class, "arity", mrb_proc_arity, MRB_ARGS_NONE());
 

--- a/src/proc.c
+++ b/src/proc.c
@@ -151,6 +151,7 @@ static mrb_value
 mrb_proc_s_new(mrb_state *mrb, mrb_value proc_class)
 {
   mrb_value blk;
+  mrb_value proc;
   struct RProc *p;
 
   mrb_get_args(mrb, "&", &blk);
@@ -160,7 +161,9 @@ mrb_proc_s_new(mrb_state *mrb, mrb_value proc_class)
   }
   p = (struct RProc *)mrb_obj_alloc(mrb, MRB_TT_PROC, mrb_class_ptr(proc_class));
   mrb_proc_copy(p, mrb_proc_ptr(blk));
-  return mrb_obj_value(p);
+  proc = mrb_obj_value(p);
+  mrb_funcall_with_block(mrb, proc, mrb_intern_lit(mrb, "initialize"), 0, NULL, blk);
+  return proc;
 }
 
 static mrb_value

--- a/test/t/proc.rb
+++ b/test/t/proc.rb
@@ -136,6 +136,18 @@ assert('Proc#return_does_not_break_self') do
   assert_equal c, c.block.call
 end
 
+assert('call Proc#initialize if defined') do
+  a = []
+  c = Class.new(Proc) do
+    define_method(:initialize) do
+      a << :ok
+    end
+  end
+
+  assert_kind_of c, c.new{}
+  assert_equal [:ok], a
+end
+
 assert('&obj call to_proc if defined') do
   pr = Proc.new{}
   def mock(&b)

--- a/test/t/proc.rb
+++ b/test/t/proc.rb
@@ -46,17 +46,6 @@ assert('Proc#arity', '15.2.17.4.2') do
   assert_equal(-1, g)
 end
 
-assert('Proc#arity with unitialized Proc') do
-  begin
-    Proc.alias_method(:original_initialize, :initialize)
-    Proc.remove_method(:initialize)
-    assert_equal 0, Proc.new{|a, b, c| 1}.arity
-  ensure
-    Proc.alias_method(:initialize, :original_initialize)
-    Proc.remove_method(:original_initialize)
-  end
-end
-
 assert('Proc#call', '15.2.17.4.3') do
   a = 0
   b = Proc.new { a += 1 }
@@ -162,20 +151,4 @@ assert('&obj call to_proc if defined') do
   assert_equal :from_to_proc, mock(&obj).call
 
   assert_raise(TypeError){ mock(&(Object.new)) }
-end
-
-assert('initialize_copy works when initialize is removed') do
-  begin
-    Proc.alias_method(:old_initialize, :initialize)
-    Proc.remove_method(:initialize)
-
-    a = Proc.new {}
-    b = Proc.new {}
-    assert_nothing_raised do
-      a.initialize_copy(b)
-    end
-  ensure
-    Proc.alias_method(:initialize, :old_initialize)
-    Proc.remove_method(:old_initialize)
-  end
 end


### PR DESCRIPTION
CRuby's `Proc` class does't have `initialize` method.
And It raises some issues when it called `Proc.remove_method(:initialize)`

I think, `Proc` class shouldn't have `initialize` method in mruby too.

ref: #3356