### PR TITLE
Removed ununnecessary escape character '\' in libmruby.flags.mak

### DIFF
--- a/tasks/libmruby.rake
+++ b/tasks/libmruby.rake
@@ -5,17 +5,17 @@ MRuby.each_target do
 
   file "#{build_dir}/lib/libmruby.flags.mak" => [__FILE__, libfile("#{build_dir}/lib/libmruby")] do |t|
     open(t.name, 'w') do |f|
-      f.puts "MRUBY_CFLAGS = #{cc.all_flags.gsub('"', '\\"')}"
+      f.puts "MRUBY_CFLAGS = #{cc.all_flags}"
 
       gem_flags = gems.map { |g| g.linker.flags }
       gem_library_paths = gems.map { |g| g.linker.library_paths }
-      f.puts "MRUBY_LDFLAGS = #{linker.all_flags(gem_library_paths, gem_flags).gsub('"', '\\"')} #{linker.option_library_path % "#{build_dir}/lib"}"
+      f.puts "MRUBY_LDFLAGS = #{linker.all_flags(gem_library_paths, gem_flags)} #{linker.option_library_path % "#{build_dir}/lib"}"
 
       gem_flags_before_libraries = gems.map { |g| g.linker.flags_before_libraries }
-      f.puts "MRUBY_LDFLAGS_BEFORE_LIBS = #{[linker.flags_before_libraries, gem_flags_before_libraries].flatten.join(' ').gsub('"', '\\"')}"
+      f.puts "MRUBY_LDFLAGS_BEFORE_LIBS = #{[linker.flags_before_libraries, gem_flags_before_libraries].flatten.join(' ')}"
 
       gem_libraries = gems.map { |g| g.linker.libraries }
-      f.puts "MRUBY_LIBS = #{linker.option_library % 'mruby'} #{linker.library_flags(gem_libraries).gsub('"', '\\"')}"
+      f.puts "MRUBY_LIBS = #{linker.option_library % 'mruby'} #{linker.library_flags(gem_libraries)}"
     end
   end
   task :all => "#{build_dir}/lib/libmruby.flags.mak"


### PR DESCRIPTION
There seems to be an unnecessary escape character '\' in libmruby.flags.mak.
I think #800 is the cause. 