### PR TITLE
Pass when assert returns a false value

### DIFF
--- a/test/assert.rb
+++ b/test/assert.rb
@@ -44,7 +44,8 @@ def assert(str = 'Assertion failed', iso = '')
   begin
     $mrbtest_assert = []
     $mrbtest_assert_idx = 0
-    if(!yield || $mrbtest_assert.size > 0)
+    yield
+    if($mrbtest_assert.size > 0)
       $asserts.push(assertion_string('Fail: ', str, iso, nil))
       $ko_test += 1
       t_print('F')


### PR DESCRIPTION
I'd like to pass when `assert` block returns a false value because the block may be tested sufficiently by `assert_*`.

If doesn't pass the value, test code will be failed unexpectedly. For example, my mrbgem's test:
```ruby
assert 'K2Hash#open' do
  ...
  db = K2Hash.new(...
  assert_true db.empty?
  db.close #=> nil
end
```
It fails and the reason isn't told.
```
$ ./minirake test
...
Fail: K2Hash#open (mrbgems: mruby-k2hash)
Skip: Module#prepend super in alias  super does not currently work in aliased methods
Total: 964
   OK: 963
   KO: 1
Crash: 0
 Time: 0.52 seconds
rake aborted!
Command Failed: ["build/host/bin/mrbtest"]
Rakefile:119:in `block (2 levels) in <top (required)>'
```