### PR TITLE
Put package's libs flag after %{objs}

### DIFF
--- a/tasks/mrbgem_spec.rake
+++ b/tasks/mrbgem_spec.rake
@@ -135,7 +135,7 @@ module MRuby
         if system("pkg-config --exists #{escaped_package_query}")
           cc.flags += [`pkg-config --cflags #{escaped_package_query}`.strip]
           cxx.flags += [`pkg-config --cflags #{escaped_package_query}`.strip]
-          linker.flags += [`pkg-config --libs #{escaped_package_query}`.strip]
+          linker.flags_before_libraries += [`pkg-config --libs #{escaped_package_query}`.strip]
           true
         else
           false


### PR DESCRIPTION
In case `LDFLAG` contains `-Wl,--as-needed` or `--as-needed` is enabled by default, `-l` flags should appear after objs specifiction.

----

For instance, try building mruby tool includes mattn/mruby-onig-regexp with `LDFLAG="-Wl,--as-needed"`.