### PR TITLE
Fix broken MRB_INT64

### DIFF
--- a/src/error.c
+++ b/src/error.c
@@ -44,7 +44,7 @@ static mrb_value
 exc_initialize(mrb_state *mrb, mrb_value exc)
 {
   mrb_value mesg;
-  int argc;
+  mrb_int argc;
   mrb_value *argv;
 
   if (mrb_get_args(mrb, "|o*", &mesg, &argv, &argc) >= 1) {


### PR DESCRIPTION
@matz 

Fixes this: https://github.com/mruby/mruby/commit/7523cdf3404230213cb858f38bd91135d478a7f3#commitcomment-20436148