### PR TITLE
Should raise RuntimeError when object frozen

### DIFF
--- a/src/array.c
+++ b/src/array.c
@@ -796,6 +796,7 @@ mrb_ary_aset(mrb_state *mrb, mrb_value self)
   mrb_value v1, v2, v3;
   mrb_int i, len;
 
+  mrb_ary_modify(mrb, mrb_ary_ptr(self));
   if (mrb_get_args(mrb, "oo|o", &v1, &v2, &v3) == 2) {
     switch (mrb_type(v1)) {
     /* a[n..m] = v */


### PR DESCRIPTION
It's a small change.

before

```rb
a = [].freeze
a[0] = 1 #=> can't modify frozen array (RuntimeError)
a[:b] = 1 #=> can't convert Symbol into Integer (TypeError)
```

after

```rb
a = [].freeze
a[0] = 1 #=> can't modify frozen array (RuntimeError)
a[:b] = 1 #=> can't modify frozen array (RuntimeError)
```
