### PR TITLE
Refactoring: Use array_copy instead of for loop

### DIFF
--- a/src/array.c
+++ b/src/array.c
@@ -590,7 +590,7 @@ mrb_ary_splice(mrb_state *mrb, mrb_value ary, mrb_int head, mrb_int len, mrb_val
 {
   struct RArray *a = mrb_ary_ptr(ary);
   const mrb_value *argv;
-  mrb_int i, argc;
+  mrb_int argc;
 
   ary_modify(mrb, a);
 
@@ -631,9 +631,7 @@ mrb_ary_splice(mrb_state *mrb, mrb_value ary, mrb_int head, mrb_int len, mrb_val
     }
     ary_fill_with_nil(a->ptr + a->len, head - a->len);
     if (argc > 0) {
-      for (i = 0; i < argc; i++) {
-        a->ptr[head + i] = argv[i];
-      }
+      array_copy(a->ptr + head, argv, argc);
     }
     a->len = len;
   }


### PR DESCRIPTION
Fix for https://github.com/mruby/mruby/commit/fdec607cd06bc12c844fd71bdb75db74f909ff74