### PR TITLE
Fix usage of Class#name in mruby-bin-mruby's bintest

### DIFF
--- a/mrbgems/mruby-bin-mruby/bintest/mruby.rb
+++ b/mrbgems/mruby-bin-mruby/bintest/mruby.rb
@@ -52,7 +52,7 @@ assert('garbage collecting built-in classes') do
 NilClass = nil
 GC.start
 Array.dup
-print nil.class.name
+print nil.class.to_s
 RUBY
   script.flush
   assert_equal "NilClass", `#{cmd('mruby')} #{script.path}`


### PR DESCRIPTION
I found that the mruby-bin's bintest case added at [this commit](https://github.com/mruby/mruby/commit/f7a891fa8979bdb82410e1adc98765013cc29a79) requires `Class(Module)#name`, which is defined at [mruby-class-ext mgem](https://github.com/mruby/mruby/blob/master/mrbgems/mruby-class-ext/src/class.c#L17), not *at core*.

This would not break mruby's upstream test, but breaks bintests of binary tools(such as mruby-cli ones) which create a `mruby` binary additionally.

ref: https://github.com/mruby/mruby/commit/f7a891fa8979bdb82410e1adc98765013cc29a79#diff-1d3b69d05e6068fdd48537dda6e5cb62R55