### PR TITLE
Fetch arguments earlier in mrb_random_init to avoid a crash.

### DIFF
--- a/mrbgems/mruby-random/src/random.c
+++ b/mrbgems/mruby-random/src/random.c
@@ -124,6 +124,8 @@ mrb_random_init(mrb_state *mrb, mrb_value self)
   mrb_value seed;
   mt_state *t;
 
+  seed = get_opt(mrb);
+
   /* avoid memory leaks */
   t = (mt_state*)DATA_PTR(self);
   if (t) {
@@ -134,7 +136,6 @@ mrb_random_init(mrb_state *mrb, mrb_value self)
   t = (mt_state *)mrb_malloc(mrb, sizeof(mt_state));
   t->mti = N + 1;
 
-  seed = get_opt(mrb);
   seed = mrb_random_mt_srand(mrb, t, seed);
   if (mrb_nil_p(seed)) {
     t->has_seed = FALSE;


### PR DESCRIPTION
The following input demonstrates a crash due to a null pointer dereference:
```ruby
$r = Random.new
a = Object.new
def a.to_int
    $r.rand
end

$r.initialize a
```
This happens because this line calls `mrb_get_args`, which can execute Ruby code: https://github.com/mruby/mruby/blob/6420951463ec9ace9eecb50923dc6a1925a45d31/mrbgems/mruby-random/src/random.c#L137

This allows `mrb_random_rand` to be called at a time when the object's data pointer is still NULL.

I've fixed that by moving the `get_opt` call to the top of `mrb_random_init`.

This issue was reported by https://hackerone.com/eboda