### PR TITLE
Fix interpolation escaping in String.inspect

### DIFF
--- a/src/string.c
+++ b/src/string.c
@@ -2644,7 +2644,7 @@ mrb_str_inspect(mrb_state *mrb, mrb_value str)
     }
 #endif
     c = *p;
-    if (c == '"'|| c == '\\' || (c == '#' && IS_EVSTR(p, pend))) {
+    if (c == '"'|| c == '\\' || (c == '#' && IS_EVSTR(p+1, pend))) {
       buf[0] = '\\'; buf[1] = c;
       mrb_str_cat(mrb, result, buf, 2);
       continue;


### PR DESCRIPTION
The following example produces an incorrect output:

```ruby
$s = "Test \#{x}"
puts $s.inspect
```
This outputs `"Test #{x}"`, whereas the correct output would be `"Test \#{x}"`.

The problem is that the parameter for `IS_EVSTR` is off by one, since `*p` is the current character (i.e. `c`), not the next one.
