### PR TITLE
Fix build error when trace mode

### DIFF
--- a/minirake
+++ b/minirake
@@ -237,6 +237,7 @@ module MiniRake
 
     # Time stamp for file task.
     def timestamp
+      return Time.at(0) unless File.exist?(name)
       stat = File::stat(name.to_s)
       stat.directory? ? Time.at(0) : stat.mtime
     end


### PR DESCRIPTION
Referenced https://github.com/ruby/rake/blob/af15762f972a3f8322a9b5904d56fe2ff3dd8352/lib/rake/file_task.rb#L21

# Reproduction

Rakefile

```
file "a.txt" do
  system "echo hello > a.txt"
end

file "b.txt" => "a.txt" do
  system "cp a.txt b.txt"
end

task :default => "b.txt"
```

```
$ touch b.txt
$ ruby minirake --trace
Invoke default (already=[], needed=[true])
rake aborted!
No such file or directory @ rb_file_s_stat - a.txt
minirake:241:in `stat'
minirake:241:in `timestamp'
minirake:233:in `block in needed?'
minirake:233:in `collect'
minirake:233:in `needed?'
minirake:91:in `invoke'
minirake:95:in `block in invoke'
minirake:95:in `each'
minirake:95:in `invoke'
minirake:467:in `block in run'
minirake:466:in `each'
minirake:466:in `run'
minirake:484:in `<main>'
```

# Expect

```
$ rake --trace
** Invoke default (first_time)
** Invoke b.txt (first_time)
** Invoke a.txt (first_time)
** Execute a.txt
** Execute b.txt
** Execute default
```