### PR TITLE
Revert "Optimization for String#* for 1-byte strings"

### DIFF
--- a/src/string.c
+++ b/src/string.c
@@ -872,9 +872,7 @@ mrb_str_times(mrb_state *mrb, mrb_value self)
   str2 = str_new(mrb, 0, len);
   str_with_class(mrb, str2, self);
   p = RSTR_PTR(str2);
-  if (len == 1) {
-    memset(p, RSTRING_PTR(self)[0], len);
-  } else if (len > 0) {
+  if (len > 0) {
     n = RSTRING_LEN(self);
     memcpy(p, RSTRING_PTR(self), n);
     while (n <= len/2) {


### PR DESCRIPTION
This reverts commit d1bc7caecaf337976351934d5910726106601bd9.

I've compared both versions and it seems that this optimization is unnecessary, so I'm reverting it to simplify the code. It was also mistakenly checking for `len`, where in fact it should check `n` (and later repeat the same char `len` times). 