### PR TITLE
Separate compilers setup from config setup

### DIFF
--- a/tasks/mrbgem_spec.rake
+++ b/tasks/mrbgem_spec.rake
@@ -90,7 +90,9 @@ module MRuby
         build.libmruby << @objs
 
         instance_eval(&@build_config_initializer) if @build_config_initializer
+      end
 
+      def setup_compilers
         compilers.each do |compiler|
           compiler.define_rules build_dir, "#{dir}"
           compiler.defines << %Q[MRBGEM_#{funcname.upcase}_VERSION=#{version}]
@@ -418,6 +420,8 @@ module MRuby
         gem_table = generate_gem_table build
 
         @ary = tsort_dependencies gem_table.keys, gem_table, true
+
+        each(&:setup_compilers)
 
         each do |g|
           import_include_paths(g)


### PR DESCRIPTION
Fixes #3418.

I've tried to make the fix as small as possible.

Previously we had 2 places where compilers were configured (`Specification#setup` –  config options – and `List#check` – include paths).
That caused a problem when someone tries to use gem table only to build the dependencies (as in #3418) and does not want to define compilers rules.

From the other hand, we already configure compilers in `List#check` method, so, I think, it make sense to define rules there too.
