### PR TITLE
Update android build script.

### DIFF
--- a/examples/targets/build_config_android_arm64-v8a.rb
+++ b/examples/targets/build_config_android_arm64-v8a.rb
@@ -1,0 +1,26 @@
+MRuby::Build.new do |conf|
+
+  # Gets set by the VS command prompts.
+  if ENV['VisualStudioVersion'] || ENV['VSINSTALLDIR']
+    toolchain :visualcpp
+  else
+    toolchain :gcc
+  end
+
+  enable_debug
+
+  # include the default GEMs
+  conf.gembox 'default'
+end
+
+# Requires Android NDK r13 or later.
+MRuby::CrossBuild.new('android-arm64-v8a') do |conf|
+  params = { 
+    :arch => 'arm64-v8a', 
+    :platform => 'android-24',
+    :toolchain => :clang,
+  }
+  toolchain :android, params
+
+  conf.gembox 'default'
+end

--- a/examples/targets/build_config_android_armeabi.rb
+++ b/examples/targets/build_config_android_armeabi.rb
@@ -1,0 +1,26 @@
+MRuby::Build.new do |conf|
+
+  # Gets set by the VS command prompts.
+  if ENV['VisualStudioVersion'] || ENV['VSINSTALLDIR']
+    toolchain :visualcpp
+  else
+    toolchain :gcc
+  end
+
+  enable_debug
+
+  # include the default GEMs
+  conf.gembox 'default'
+end
+
+# Requires Android NDK r13 or later.
+MRuby::CrossBuild.new('android-armeabi') do |conf|
+  params = { 
+    :arch => 'armeabi', 
+    :platform => 'android-24',
+    :toolchain => :clang,
+  }
+  toolchain :android, params
+
+  conf.gembox 'default'
+end

--- a/tasks/toolchains/android.rake
+++ b/tasks/toolchains/android.rake
@@ -203,31 +203,33 @@ Set ANDROID_PLATFORM environment variable or set :platform parameter
   def cflags
     flags = []
 
-    flags += %W(-D__android__ --sysroot="#{sysroot}")
+    flags += %W(-MMD -MP)
+    flags += %W(-D__android__ -DANDROID --sysroot="#{sysroot}")
     case toolchain
     when :gcc
-      flags += %W(-mandroid)
       case arch
-      when /armeabi-v7a/  then flags += %W(-march=armv7-a)
-      when /armeabi/      then flags += %W(-march=armv5te)
-      when /arm64-v8a/    then flags += %W(-march=armv8-a)
+      when /armeabi-v7a/  then flags += %W(-march=armv7-a -mfpu=vfpv3-d16 -mfloat-abi=softfp -fpic)
+      when /armeabi/      then flags += %W(-march=armv5te -mtune=xscale -msoft-float -fpic)
+      when /arm64-v8a/    then flags += %W(-march=armv8-a -fpic)
       when /x86_64/       then flags += %W(-march=x86-64)
       when /x86/          then flags += %W(-march=i686)
-      when /mips64/       then flags += %W(-march=mips64)
-      when /mips/         then flags += %W(-march=mips32)
+      when /mips64/       then flags += %W(-march=mips64r6 -fmessage-length=0 -fpic)
+      when /mips/         then flags += %W(-march=mips32 -fmessage-length=0 -fpic)
       end
     when :clang
       flags += %W(-gcc-toolchain "#{gcc_toolchain_path.to_s}")
       case arch
-      when /armeabi-v7a/  then flags += %W(-target armv7-none-linux-androideabi)
-      when /armeabi/      then flags += %W(-target armv5te-none-linux-androideabi)
-      when /arm64-v8a/    then flags += %W(-target aarch64-none-linux-android)
-      when /x86_64/       then flags += %W(-target x86_64-none-linux-android)
-      when /x86/          then flags += %W(-target i686-none-linux-android)
-      when /mips64/       then flags += %W(-target mips64el-none-linux-android)
-      when /mips/         then flags += %W(-target mipsel-none-linux-android)
+      when /armeabi-v7a/  then flags += %W(-target armv7-none-linux-androideabi -fpic)
+      when /armeabi/      then flags += %W(-target armv5te-none-linux-androideabi -fpic)
+      when /arm64-v8a/    then flags += %W(-target aarch64-none-linux-android -fpic)
+      when /x86_64/       then flags += %W(-target x86_64-none-linux-android -fPIC)
+      when /x86/          then flags += %W(-target i686-none-linux-android -fPIC)
+      when /mips64/       then flags += %W(-target mips64el-none-linux-android -fmessage-length=0 -fpic)
+      when /mips/         then flags += %W(-target mipsel-none-linux-android -fmessage-length=0 -fpic)
       end
+      flags += %W(-Wno-invalid-command-line-argument -Wno-unused-command-line-argument)
     end
+    flags += %W(-ffunction-sections -funwind-tables -fstack-protector-strong -no-canonical-prefixes)
 
     flags
   end

--- a/tasks/toolchains/android.rake
+++ b/tasks/toolchains/android.rake
@@ -232,6 +232,34 @@ Set ANDROID_PLATFORM environment variable or set :platform parameter
     flags
   end
 
+  def ldflags
+    flags = []
+
+    flags += %W(--sysroot="#{sysroot}")
+
+    flags
+  end
+
+  def ldflags_before_libraries
+    flags = []
+
+    case toolchain
+    when :clang
+      flags += %W(-gcc-toolchain "#{gcc_toolchain_path.to_s}")
+      case arch
+      when /armeabi-v7a/  then flags += %W(-target armv7-none-linux-androideabi)
+      when /armeabi/      then flags += %W(-target armv5te-none-linux-androideabi)
+      when /arm64-v8a/    then flags += %W(-target aarch64-none-linux-android)
+      when /x86_64/       then flags += %W(-target x86_64-none-linux-android)
+      when /x86/          then flags += %W(-target i686-none-linux-android)
+      when /mips64/       then flags += %W(-target mips64el-none-linux-android)
+      when /mips/         then flags += %W(-target mipsel-none-linux-android)
+      end
+    end
+    flags += %W(-no-canonical-prefixes)
+
+    flags
+  end
 end
 
 MRuby::Toolchain.new(:android) do |conf, params|
@@ -246,5 +274,6 @@ MRuby::Toolchain.new(:android) do |conf, params|
 
   conf.archiver.command = android.ar
   conf.linker.command = android.cc
-  conf.linker.flags = []
+  conf.linker.flags = android.ldflags
+  conf.linker.flags_before_libraries = android.ldflags_before_libraries
 end

--- a/tasks/toolchains/android.rake
+++ b/tasks/toolchains/android.rake
@@ -247,7 +247,7 @@ Set ANDROID_PLATFORM environment variable or set :platform parameter
     when :clang
       flags += %W(-gcc-toolchain "#{gcc_toolchain_path.to_s}")
       case arch
-      when /armeabi-v7a/  then flags += %W(-target armv7-none-linux-androideabi)
+      when /armeabi-v7a/  then flags += %W(-target armv7-none-linux-androideabi -Wl,--fix-cortex-a8)
       when /armeabi/      then flags += %W(-target armv5te-none-linux-androideabi)
       when /arm64-v8a/    then flags += %W(-target aarch64-none-linux-android)
       when /x86_64/       then flags += %W(-target x86_64-none-linux-android)


### PR DESCRIPTION
This PR updates build script for Android.

In usual case, required LDFLAGS and CFLAGS should be set by default.
If anyone need overwriting these flags, it can be done in `build_config.rb`.
I think, for many mruby users/developers, no requiring many flags to build mruby is good.

NOTE:
- Please use Android NDK `r12b` or later (recommended is latest `r13b`)
- When use Android NDK `r11c`, cannot build mruby by gcc for mips64 (by clang is okay)
- Security flags (e.g. `-Wa,--noexecstack`) is omitted (please set in your `build_config.rb` if needed).