### PR TITLE
GitLab.com tests for multiple configurations

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,3214 @@
+---
+stages:
+- pretest
+- test
+pretest:
+  stage: pretest
+  image: registry.gitlab.com/dabroz/mruby:gcc47_0.1
+  tags:
+  - linux
+  variables:
+    CC: gcc-4.7
+    CXX: g++-4.7
+    LD: gcc-4.7
+  script: "./minirake all test"
+Test gcc-4.7 32bit:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
+  variables:
+    CC: gcc-4.7
+    CXX: g++-4.7
+    LD: gcc-4.7
+    CFLAGS: "-m32 -DMRB_WORD_BOXING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-4.7 32bit_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
+  variables:
+    CC: gcc-4.7
+    CXX: g++-4.7
+    LD: gcc-4.7
+    CFLAGS: "-m32 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-4.7 32bit_nan:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
+  variables:
+    CC: gcc-4.7
+    CXX: g++-4.7
+    LD: gcc-4.7
+    CFLAGS: "-m32 -DMRB_NAN_BOXING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-4.7 32bit_nan_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
+  variables:
+    CC: gcc-4.7
+    CXX: g++-4.7
+    LD: gcc-4.7
+    CFLAGS: "-m32 -DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-4.7 32bit_int16:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
+  variables:
+    CC: gcc-4.7
+    CXX: g++-4.7
+    LD: gcc-4.7
+    CFLAGS: "-m32 -DMRB_INT16=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-4.7 32bit_int16_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
+  variables:
+    CC: gcc-4.7
+    CXX: g++-4.7
+    LD: gcc-4.7
+    CFLAGS: "-m32 -DMRB_INT16=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-4.7 32bit_int16_nan:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
+  variables:
+    CC: gcc-4.7
+    CXX: g++-4.7
+    LD: gcc-4.7
+    CFLAGS: "-m32 -DMRB_INT16=1 -DMRB_NAN_BOXING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-4.7 32bit_int16_nan_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
+  variables:
+    CC: gcc-4.7
+    CXX: g++-4.7
+    LD: gcc-4.7
+    CFLAGS: "-m32 -DMRB_INT16=1 -DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-4.7 32bit_int64:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
+  variables:
+    CC: gcc-4.7
+    CXX: g++-4.7
+    LD: gcc-4.7
+    CFLAGS: "-m32 -DMRB_INT64=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-4.7 32bit_int64_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
+  variables:
+    CC: gcc-4.7
+    CXX: g++-4.7
+    LD: gcc-4.7
+    CFLAGS: "-m32 -DMRB_INT64=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-4.7 32bit_float:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
+  variables:
+    CC: gcc-4.7
+    CXX: g++-4.7
+    LD: gcc-4.7
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-4.7 32bit_float_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
+  variables:
+    CC: gcc-4.7
+    CXX: g++-4.7
+    LD: gcc-4.7
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-4.7 32bit_float_int16:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
+  variables:
+    CC: gcc-4.7
+    CXX: g++-4.7
+    LD: gcc-4.7
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT16=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-4.7 32bit_float_int16_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
+  variables:
+    CC: gcc-4.7
+    CXX: g++-4.7
+    LD: gcc-4.7
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT16=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-4.7 32bit_float_int64:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
+  variables:
+    CC: gcc-4.7
+    CXX: g++-4.7
+    LD: gcc-4.7
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT64=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-4.7 32bit_float_int64_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
+  variables:
+    CC: gcc-4.7
+    CXX: g++-4.7
+    LD: gcc-4.7
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT64=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-4.7 64bit:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
+  variables:
+    CC: gcc-4.7
+    CXX: g++-4.7
+    LD: gcc-4.7
+    CFLAGS: "-DMRB_WORD_BOXING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-4.7 64bit_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
+  variables:
+    CC: gcc-4.7
+    CXX: g++-4.7
+    LD: gcc-4.7
+    CFLAGS: "-DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-4.7 64bit_nan:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
+  variables:
+    CC: gcc-4.7
+    CXX: g++-4.7
+    LD: gcc-4.7
+    CFLAGS: "-DMRB_NAN_BOXING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-4.7 64bit_nan_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
+  variables:
+    CC: gcc-4.7
+    CXX: g++-4.7
+    LD: gcc-4.7
+    CFLAGS: "-DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-4.7 64bit_int16:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
+  variables:
+    CC: gcc-4.7
+    CXX: g++-4.7
+    LD: gcc-4.7
+    CFLAGS: "-DMRB_INT16=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-4.7 64bit_int16_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
+  variables:
+    CC: gcc-4.7
+    CXX: g++-4.7
+    LD: gcc-4.7
+    CFLAGS: "-DMRB_INT16=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-4.7 64bit_int16_nan:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
+  variables:
+    CC: gcc-4.7
+    CXX: g++-4.7
+    LD: gcc-4.7
+    CFLAGS: "-DMRB_INT16=1 -DMRB_NAN_BOXING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-4.7 64bit_int16_nan_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
+  variables:
+    CC: gcc-4.7
+    CXX: g++-4.7
+    LD: gcc-4.7
+    CFLAGS: "-DMRB_INT16=1 -DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-4.7 64bit_int64:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
+  variables:
+    CC: gcc-4.7
+    CXX: g++-4.7
+    LD: gcc-4.7
+    CFLAGS: "-DMRB_INT64=1 -DMRB_WORD_BOXING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-4.7 64bit_int64_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
+  variables:
+    CC: gcc-4.7
+    CXX: g++-4.7
+    LD: gcc-4.7
+    CFLAGS: "-DMRB_INT64=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-4.7 64bit_float:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
+  variables:
+    CC: gcc-4.7
+    CXX: g++-4.7
+    LD: gcc-4.7
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-4.7 64bit_float_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
+  variables:
+    CC: gcc-4.7
+    CXX: g++-4.7
+    LD: gcc-4.7
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-4.7 64bit_float_int16:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
+  variables:
+    CC: gcc-4.7
+    CXX: g++-4.7
+    LD: gcc-4.7
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT16=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-4.7 64bit_float_int16_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
+  variables:
+    CC: gcc-4.7
+    CXX: g++-4.7
+    LD: gcc-4.7
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT16=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-4.7 64bit_float_int64:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
+  variables:
+    CC: gcc-4.7
+    CXX: g++-4.7
+    LD: gcc-4.7
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT64=1 -DMRB_WORD_BOXING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-4.7 64bit_float_int64_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
+  variables:
+    CC: gcc-4.7
+    CXX: g++-4.7
+    LD: gcc-4.7
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT64=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-4.8 32bit:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
+  variables:
+    CC: gcc-4.8
+    CXX: g++-4.8
+    LD: gcc-4.8
+    CFLAGS: "-m32 -DMRB_WORD_BOXING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-4.8 32bit_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
+  variables:
+    CC: gcc-4.8
+    CXX: g++-4.8
+    LD: gcc-4.8
+    CFLAGS: "-m32 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-4.8 32bit_nan:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
+  variables:
+    CC: gcc-4.8
+    CXX: g++-4.8
+    LD: gcc-4.8
+    CFLAGS: "-m32 -DMRB_NAN_BOXING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-4.8 32bit_nan_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
+  variables:
+    CC: gcc-4.8
+    CXX: g++-4.8
+    LD: gcc-4.8
+    CFLAGS: "-m32 -DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-4.8 32bit_int16:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
+  variables:
+    CC: gcc-4.8
+    CXX: g++-4.8
+    LD: gcc-4.8
+    CFLAGS: "-m32 -DMRB_INT16=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-4.8 32bit_int16_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
+  variables:
+    CC: gcc-4.8
+    CXX: g++-4.8
+    LD: gcc-4.8
+    CFLAGS: "-m32 -DMRB_INT16=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-4.8 32bit_int16_nan:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
+  variables:
+    CC: gcc-4.8
+    CXX: g++-4.8
+    LD: gcc-4.8
+    CFLAGS: "-m32 -DMRB_INT16=1 -DMRB_NAN_BOXING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-4.8 32bit_int16_nan_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
+  variables:
+    CC: gcc-4.8
+    CXX: g++-4.8
+    LD: gcc-4.8
+    CFLAGS: "-m32 -DMRB_INT16=1 -DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-4.8 32bit_int64:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
+  variables:
+    CC: gcc-4.8
+    CXX: g++-4.8
+    LD: gcc-4.8
+    CFLAGS: "-m32 -DMRB_INT64=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-4.8 32bit_int64_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
+  variables:
+    CC: gcc-4.8
+    CXX: g++-4.8
+    LD: gcc-4.8
+    CFLAGS: "-m32 -DMRB_INT64=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-4.8 32bit_float:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
+  variables:
+    CC: gcc-4.8
+    CXX: g++-4.8
+    LD: gcc-4.8
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-4.8 32bit_float_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
+  variables:
+    CC: gcc-4.8
+    CXX: g++-4.8
+    LD: gcc-4.8
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-4.8 32bit_float_int16:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
+  variables:
+    CC: gcc-4.8
+    CXX: g++-4.8
+    LD: gcc-4.8
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT16=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-4.8 32bit_float_int16_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
+  variables:
+    CC: gcc-4.8
+    CXX: g++-4.8
+    LD: gcc-4.8
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT16=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-4.8 32bit_float_int64:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
+  variables:
+    CC: gcc-4.8
+    CXX: g++-4.8
+    LD: gcc-4.8
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT64=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-4.8 32bit_float_int64_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
+  variables:
+    CC: gcc-4.8
+    CXX: g++-4.8
+    LD: gcc-4.8
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT64=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-4.8 64bit:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
+  variables:
+    CC: gcc-4.8
+    CXX: g++-4.8
+    LD: gcc-4.8
+    CFLAGS: "-DMRB_WORD_BOXING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-4.8 64bit_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
+  variables:
+    CC: gcc-4.8
+    CXX: g++-4.8
+    LD: gcc-4.8
+    CFLAGS: "-DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-4.8 64bit_nan:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
+  variables:
+    CC: gcc-4.8
+    CXX: g++-4.8
+    LD: gcc-4.8
+    CFLAGS: "-DMRB_NAN_BOXING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-4.8 64bit_nan_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
+  variables:
+    CC: gcc-4.8
+    CXX: g++-4.8
+    LD: gcc-4.8
+    CFLAGS: "-DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-4.8 64bit_int16:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
+  variables:
+    CC: gcc-4.8
+    CXX: g++-4.8
+    LD: gcc-4.8
+    CFLAGS: "-DMRB_INT16=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-4.8 64bit_int16_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
+  variables:
+    CC: gcc-4.8
+    CXX: g++-4.8
+    LD: gcc-4.8
+    CFLAGS: "-DMRB_INT16=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-4.8 64bit_int16_nan:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
+  variables:
+    CC: gcc-4.8
+    CXX: g++-4.8
+    LD: gcc-4.8
+    CFLAGS: "-DMRB_INT16=1 -DMRB_NAN_BOXING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-4.8 64bit_int16_nan_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
+  variables:
+    CC: gcc-4.8
+    CXX: g++-4.8
+    LD: gcc-4.8
+    CFLAGS: "-DMRB_INT16=1 -DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-4.8 64bit_int64:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
+  variables:
+    CC: gcc-4.8
+    CXX: g++-4.8
+    LD: gcc-4.8
+    CFLAGS: "-DMRB_INT64=1 -DMRB_WORD_BOXING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-4.8 64bit_int64_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
+  variables:
+    CC: gcc-4.8
+    CXX: g++-4.8
+    LD: gcc-4.8
+    CFLAGS: "-DMRB_INT64=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-4.8 64bit_float:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
+  variables:
+    CC: gcc-4.8
+    CXX: g++-4.8
+    LD: gcc-4.8
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-4.8 64bit_float_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
+  variables:
+    CC: gcc-4.8
+    CXX: g++-4.8
+    LD: gcc-4.8
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-4.8 64bit_float_int16:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
+  variables:
+    CC: gcc-4.8
+    CXX: g++-4.8
+    LD: gcc-4.8
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT16=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-4.8 64bit_float_int16_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
+  variables:
+    CC: gcc-4.8
+    CXX: g++-4.8
+    LD: gcc-4.8
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT16=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-4.8 64bit_float_int64:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
+  variables:
+    CC: gcc-4.8
+    CXX: g++-4.8
+    LD: gcc-4.8
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT64=1 -DMRB_WORD_BOXING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-4.8 64bit_float_int64_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
+  variables:
+    CC: gcc-4.8
+    CXX: g++-4.8
+    LD: gcc-4.8
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT64=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-4.9 32bit:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
+  variables:
+    CC: gcc-4.9
+    CXX: g++-4.9
+    LD: gcc-4.9
+    CFLAGS: "-m32 -DMRB_WORD_BOXING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-4.9 32bit_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
+  variables:
+    CC: gcc-4.9
+    CXX: g++-4.9
+    LD: gcc-4.9
+    CFLAGS: "-m32 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-4.9 32bit_nan:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
+  variables:
+    CC: gcc-4.9
+    CXX: g++-4.9
+    LD: gcc-4.9
+    CFLAGS: "-m32 -DMRB_NAN_BOXING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-4.9 32bit_nan_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
+  variables:
+    CC: gcc-4.9
+    CXX: g++-4.9
+    LD: gcc-4.9
+    CFLAGS: "-m32 -DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-4.9 32bit_int16:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
+  variables:
+    CC: gcc-4.9
+    CXX: g++-4.9
+    LD: gcc-4.9
+    CFLAGS: "-m32 -DMRB_INT16=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-4.9 32bit_int16_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
+  variables:
+    CC: gcc-4.9
+    CXX: g++-4.9
+    LD: gcc-4.9
+    CFLAGS: "-m32 -DMRB_INT16=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-4.9 32bit_int16_nan:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
+  variables:
+    CC: gcc-4.9
+    CXX: g++-4.9
+    LD: gcc-4.9
+    CFLAGS: "-m32 -DMRB_INT16=1 -DMRB_NAN_BOXING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-4.9 32bit_int16_nan_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
+  variables:
+    CC: gcc-4.9
+    CXX: g++-4.9
+    LD: gcc-4.9
+    CFLAGS: "-m32 -DMRB_INT16=1 -DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-4.9 32bit_int64:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
+  variables:
+    CC: gcc-4.9
+    CXX: g++-4.9
+    LD: gcc-4.9
+    CFLAGS: "-m32 -DMRB_INT64=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-4.9 32bit_int64_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
+  variables:
+    CC: gcc-4.9
+    CXX: g++-4.9
+    LD: gcc-4.9
+    CFLAGS: "-m32 -DMRB_INT64=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-4.9 32bit_float:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
+  variables:
+    CC: gcc-4.9
+    CXX: g++-4.9
+    LD: gcc-4.9
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-4.9 32bit_float_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
+  variables:
+    CC: gcc-4.9
+    CXX: g++-4.9
+    LD: gcc-4.9
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-4.9 32bit_float_int16:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
+  variables:
+    CC: gcc-4.9
+    CXX: g++-4.9
+    LD: gcc-4.9
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT16=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-4.9 32bit_float_int16_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
+  variables:
+    CC: gcc-4.9
+    CXX: g++-4.9
+    LD: gcc-4.9
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT16=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-4.9 32bit_float_int64:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
+  variables:
+    CC: gcc-4.9
+    CXX: g++-4.9
+    LD: gcc-4.9
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT64=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-4.9 32bit_float_int64_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
+  variables:
+    CC: gcc-4.9
+    CXX: g++-4.9
+    LD: gcc-4.9
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT64=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-4.9 64bit:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
+  variables:
+    CC: gcc-4.9
+    CXX: g++-4.9
+    LD: gcc-4.9
+    CFLAGS: "-DMRB_WORD_BOXING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-4.9 64bit_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
+  variables:
+    CC: gcc-4.9
+    CXX: g++-4.9
+    LD: gcc-4.9
+    CFLAGS: "-DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-4.9 64bit_nan:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
+  variables:
+    CC: gcc-4.9
+    CXX: g++-4.9
+    LD: gcc-4.9
+    CFLAGS: "-DMRB_NAN_BOXING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-4.9 64bit_nan_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
+  variables:
+    CC: gcc-4.9
+    CXX: g++-4.9
+    LD: gcc-4.9
+    CFLAGS: "-DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-4.9 64bit_int16:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
+  variables:
+    CC: gcc-4.9
+    CXX: g++-4.9
+    LD: gcc-4.9
+    CFLAGS: "-DMRB_INT16=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-4.9 64bit_int16_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
+  variables:
+    CC: gcc-4.9
+    CXX: g++-4.9
+    LD: gcc-4.9
+    CFLAGS: "-DMRB_INT16=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-4.9 64bit_int16_nan:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
+  variables:
+    CC: gcc-4.9
+    CXX: g++-4.9
+    LD: gcc-4.9
+    CFLAGS: "-DMRB_INT16=1 -DMRB_NAN_BOXING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-4.9 64bit_int16_nan_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
+  variables:
+    CC: gcc-4.9
+    CXX: g++-4.9
+    LD: gcc-4.9
+    CFLAGS: "-DMRB_INT16=1 -DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-4.9 64bit_int64:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
+  variables:
+    CC: gcc-4.9
+    CXX: g++-4.9
+    LD: gcc-4.9
+    CFLAGS: "-DMRB_INT64=1 -DMRB_WORD_BOXING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-4.9 64bit_int64_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
+  variables:
+    CC: gcc-4.9
+    CXX: g++-4.9
+    LD: gcc-4.9
+    CFLAGS: "-DMRB_INT64=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-4.9 64bit_float:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
+  variables:
+    CC: gcc-4.9
+    CXX: g++-4.9
+    LD: gcc-4.9
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-4.9 64bit_float_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
+  variables:
+    CC: gcc-4.9
+    CXX: g++-4.9
+    LD: gcc-4.9
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-4.9 64bit_float_int16:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
+  variables:
+    CC: gcc-4.9
+    CXX: g++-4.9
+    LD: gcc-4.9
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT16=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-4.9 64bit_float_int16_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
+  variables:
+    CC: gcc-4.9
+    CXX: g++-4.9
+    LD: gcc-4.9
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT16=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-4.9 64bit_float_int64:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
+  variables:
+    CC: gcc-4.9
+    CXX: g++-4.9
+    LD: gcc-4.9
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT64=1 -DMRB_WORD_BOXING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-4.9 64bit_float_int64_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
+  variables:
+    CC: gcc-4.9
+    CXX: g++-4.9
+    LD: gcc-4.9
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT64=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-5 32bit:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
+  variables:
+    CC: gcc-5
+    CXX: g++-5
+    LD: gcc-5
+    CFLAGS: "-m32 -DMRB_WORD_BOXING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-5 32bit_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
+  variables:
+    CC: gcc-5
+    CXX: g++-5
+    LD: gcc-5
+    CFLAGS: "-m32 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-5 32bit_nan:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
+  variables:
+    CC: gcc-5
+    CXX: g++-5
+    LD: gcc-5
+    CFLAGS: "-m32 -DMRB_NAN_BOXING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-5 32bit_nan_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
+  variables:
+    CC: gcc-5
+    CXX: g++-5
+    LD: gcc-5
+    CFLAGS: "-m32 -DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-5 32bit_int16:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
+  variables:
+    CC: gcc-5
+    CXX: g++-5
+    LD: gcc-5
+    CFLAGS: "-m32 -DMRB_INT16=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-5 32bit_int16_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
+  variables:
+    CC: gcc-5
+    CXX: g++-5
+    LD: gcc-5
+    CFLAGS: "-m32 -DMRB_INT16=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-5 32bit_int16_nan:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
+  variables:
+    CC: gcc-5
+    CXX: g++-5
+    LD: gcc-5
+    CFLAGS: "-m32 -DMRB_INT16=1 -DMRB_NAN_BOXING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-5 32bit_int16_nan_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
+  variables:
+    CC: gcc-5
+    CXX: g++-5
+    LD: gcc-5
+    CFLAGS: "-m32 -DMRB_INT16=1 -DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-5 32bit_int64:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
+  variables:
+    CC: gcc-5
+    CXX: g++-5
+    LD: gcc-5
+    CFLAGS: "-m32 -DMRB_INT64=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-5 32bit_int64_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
+  variables:
+    CC: gcc-5
+    CXX: g++-5
+    LD: gcc-5
+    CFLAGS: "-m32 -DMRB_INT64=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-5 32bit_float:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
+  variables:
+    CC: gcc-5
+    CXX: g++-5
+    LD: gcc-5
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-5 32bit_float_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
+  variables:
+    CC: gcc-5
+    CXX: g++-5
+    LD: gcc-5
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-5 32bit_float_int16:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
+  variables:
+    CC: gcc-5
+    CXX: g++-5
+    LD: gcc-5
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT16=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-5 32bit_float_int16_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
+  variables:
+    CC: gcc-5
+    CXX: g++-5
+    LD: gcc-5
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT16=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-5 32bit_float_int64:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
+  variables:
+    CC: gcc-5
+    CXX: g++-5
+    LD: gcc-5
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT64=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-5 32bit_float_int64_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
+  variables:
+    CC: gcc-5
+    CXX: g++-5
+    LD: gcc-5
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT64=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-5 64bit:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
+  variables:
+    CC: gcc-5
+    CXX: g++-5
+    LD: gcc-5
+    CFLAGS: "-DMRB_WORD_BOXING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-5 64bit_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
+  variables:
+    CC: gcc-5
+    CXX: g++-5
+    LD: gcc-5
+    CFLAGS: "-DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-5 64bit_nan:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
+  variables:
+    CC: gcc-5
+    CXX: g++-5
+    LD: gcc-5
+    CFLAGS: "-DMRB_NAN_BOXING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-5 64bit_nan_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
+  variables:
+    CC: gcc-5
+    CXX: g++-5
+    LD: gcc-5
+    CFLAGS: "-DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-5 64bit_int16:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
+  variables:
+    CC: gcc-5
+    CXX: g++-5
+    LD: gcc-5
+    CFLAGS: "-DMRB_INT16=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-5 64bit_int16_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
+  variables:
+    CC: gcc-5
+    CXX: g++-5
+    LD: gcc-5
+    CFLAGS: "-DMRB_INT16=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-5 64bit_int16_nan:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
+  variables:
+    CC: gcc-5
+    CXX: g++-5
+    LD: gcc-5
+    CFLAGS: "-DMRB_INT16=1 -DMRB_NAN_BOXING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-5 64bit_int16_nan_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
+  variables:
+    CC: gcc-5
+    CXX: g++-5
+    LD: gcc-5
+    CFLAGS: "-DMRB_INT16=1 -DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-5 64bit_int64:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
+  variables:
+    CC: gcc-5
+    CXX: g++-5
+    LD: gcc-5
+    CFLAGS: "-DMRB_INT64=1 -DMRB_WORD_BOXING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-5 64bit_int64_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
+  variables:
+    CC: gcc-5
+    CXX: g++-5
+    LD: gcc-5
+    CFLAGS: "-DMRB_INT64=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-5 64bit_float:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
+  variables:
+    CC: gcc-5
+    CXX: g++-5
+    LD: gcc-5
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-5 64bit_float_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
+  variables:
+    CC: gcc-5
+    CXX: g++-5
+    LD: gcc-5
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-5 64bit_float_int16:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
+  variables:
+    CC: gcc-5
+    CXX: g++-5
+    LD: gcc-5
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT16=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-5 64bit_float_int16_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
+  variables:
+    CC: gcc-5
+    CXX: g++-5
+    LD: gcc-5
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT16=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-5 64bit_float_int64:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
+  variables:
+    CC: gcc-5
+    CXX: g++-5
+    LD: gcc-5
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT64=1 -DMRB_WORD_BOXING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-5 64bit_float_int64_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
+  variables:
+    CC: gcc-5
+    CXX: g++-5
+    LD: gcc-5
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT64=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-6 32bit:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
+  variables:
+    CC: gcc-6
+    CXX: g++-6
+    LD: gcc-6
+    CFLAGS: "-m32 -DMRB_WORD_BOXING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-6 32bit_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
+  variables:
+    CC: gcc-6
+    CXX: g++-6
+    LD: gcc-6
+    CFLAGS: "-m32 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-6 32bit_nan:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
+  variables:
+    CC: gcc-6
+    CXX: g++-6
+    LD: gcc-6
+    CFLAGS: "-m32 -DMRB_NAN_BOXING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-6 32bit_nan_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
+  variables:
+    CC: gcc-6
+    CXX: g++-6
+    LD: gcc-6
+    CFLAGS: "-m32 -DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-6 32bit_int16:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
+  variables:
+    CC: gcc-6
+    CXX: g++-6
+    LD: gcc-6
+    CFLAGS: "-m32 -DMRB_INT16=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-6 32bit_int16_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
+  variables:
+    CC: gcc-6
+    CXX: g++-6
+    LD: gcc-6
+    CFLAGS: "-m32 -DMRB_INT16=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-6 32bit_int16_nan:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
+  variables:
+    CC: gcc-6
+    CXX: g++-6
+    LD: gcc-6
+    CFLAGS: "-m32 -DMRB_INT16=1 -DMRB_NAN_BOXING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-6 32bit_int16_nan_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
+  variables:
+    CC: gcc-6
+    CXX: g++-6
+    LD: gcc-6
+    CFLAGS: "-m32 -DMRB_INT16=1 -DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-6 32bit_int64:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
+  variables:
+    CC: gcc-6
+    CXX: g++-6
+    LD: gcc-6
+    CFLAGS: "-m32 -DMRB_INT64=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-6 32bit_int64_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
+  variables:
+    CC: gcc-6
+    CXX: g++-6
+    LD: gcc-6
+    CFLAGS: "-m32 -DMRB_INT64=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-6 32bit_float:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
+  variables:
+    CC: gcc-6
+    CXX: g++-6
+    LD: gcc-6
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-6 32bit_float_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
+  variables:
+    CC: gcc-6
+    CXX: g++-6
+    LD: gcc-6
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-6 32bit_float_int16:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
+  variables:
+    CC: gcc-6
+    CXX: g++-6
+    LD: gcc-6
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT16=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-6 32bit_float_int16_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
+  variables:
+    CC: gcc-6
+    CXX: g++-6
+    LD: gcc-6
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT16=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-6 32bit_float_int64:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
+  variables:
+    CC: gcc-6
+    CXX: g++-6
+    LD: gcc-6
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT64=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-6 32bit_float_int64_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
+  variables:
+    CC: gcc-6
+    CXX: g++-6
+    LD: gcc-6
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT64=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test gcc-6 64bit:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
+  variables:
+    CC: gcc-6
+    CXX: g++-6
+    LD: gcc-6
+    CFLAGS: "-DMRB_WORD_BOXING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-6 64bit_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
+  variables:
+    CC: gcc-6
+    CXX: g++-6
+    LD: gcc-6
+    CFLAGS: "-DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-6 64bit_nan:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
+  variables:
+    CC: gcc-6
+    CXX: g++-6
+    LD: gcc-6
+    CFLAGS: "-DMRB_NAN_BOXING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-6 64bit_nan_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
+  variables:
+    CC: gcc-6
+    CXX: g++-6
+    LD: gcc-6
+    CFLAGS: "-DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-6 64bit_int16:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
+  variables:
+    CC: gcc-6
+    CXX: g++-6
+    LD: gcc-6
+    CFLAGS: "-DMRB_INT16=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-6 64bit_int16_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
+  variables:
+    CC: gcc-6
+    CXX: g++-6
+    LD: gcc-6
+    CFLAGS: "-DMRB_INT16=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-6 64bit_int16_nan:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
+  variables:
+    CC: gcc-6
+    CXX: g++-6
+    LD: gcc-6
+    CFLAGS: "-DMRB_INT16=1 -DMRB_NAN_BOXING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-6 64bit_int16_nan_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
+  variables:
+    CC: gcc-6
+    CXX: g++-6
+    LD: gcc-6
+    CFLAGS: "-DMRB_INT16=1 -DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-6 64bit_int64:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
+  variables:
+    CC: gcc-6
+    CXX: g++-6
+    LD: gcc-6
+    CFLAGS: "-DMRB_INT64=1 -DMRB_WORD_BOXING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-6 64bit_int64_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
+  variables:
+    CC: gcc-6
+    CXX: g++-6
+    LD: gcc-6
+    CFLAGS: "-DMRB_INT64=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-6 64bit_float:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
+  variables:
+    CC: gcc-6
+    CXX: g++-6
+    LD: gcc-6
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-6 64bit_float_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
+  variables:
+    CC: gcc-6
+    CXX: g++-6
+    LD: gcc-6
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-6 64bit_float_int16:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
+  variables:
+    CC: gcc-6
+    CXX: g++-6
+    LD: gcc-6
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT16=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-6 64bit_float_int16_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
+  variables:
+    CC: gcc-6
+    CXX: g++-6
+    LD: gcc-6
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT16=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-6 64bit_float_int64:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
+  variables:
+    CC: gcc-6
+    CXX: g++-6
+    LD: gcc-6
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT64=1 -DMRB_WORD_BOXING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test gcc-6 64bit_float_int64_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
+  variables:
+    CC: gcc-6
+    CXX: g++-6
+    LD: gcc-6
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT64=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.5 32bit:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang35_0.7
+  variables:
+    CC: clang-3.5
+    CXX: clang++-3.5
+    LD: clang-3.5
+    CFLAGS: "-m32 -DMRB_WORD_BOXING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.5 32bit_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang35_0.7
+  variables:
+    CC: clang-3.5
+    CXX: clang++-3.5
+    LD: clang-3.5
+    CFLAGS: "-m32 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.5 32bit_nan:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang35_0.7
+  variables:
+    CC: clang-3.5
+    CXX: clang++-3.5
+    LD: clang-3.5
+    CFLAGS: "-m32 -DMRB_NAN_BOXING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.5 32bit_nan_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang35_0.7
+  variables:
+    CC: clang-3.5
+    CXX: clang++-3.5
+    LD: clang-3.5
+    CFLAGS: "-m32 -DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.5 32bit_int16:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang35_0.7
+  variables:
+    CC: clang-3.5
+    CXX: clang++-3.5
+    LD: clang-3.5
+    CFLAGS: "-m32 -DMRB_INT16=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.5 32bit_int16_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang35_0.7
+  variables:
+    CC: clang-3.5
+    CXX: clang++-3.5
+    LD: clang-3.5
+    CFLAGS: "-m32 -DMRB_INT16=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.5 32bit_int16_nan:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang35_0.7
+  variables:
+    CC: clang-3.5
+    CXX: clang++-3.5
+    LD: clang-3.5
+    CFLAGS: "-m32 -DMRB_INT16=1 -DMRB_NAN_BOXING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.5 32bit_int16_nan_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang35_0.7
+  variables:
+    CC: clang-3.5
+    CXX: clang++-3.5
+    LD: clang-3.5
+    CFLAGS: "-m32 -DMRB_INT16=1 -DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.5 32bit_int64:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang35_0.7
+  variables:
+    CC: clang-3.5
+    CXX: clang++-3.5
+    LD: clang-3.5
+    CFLAGS: "-m32 -DMRB_INT64=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.5 32bit_int64_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang35_0.7
+  variables:
+    CC: clang-3.5
+    CXX: clang++-3.5
+    LD: clang-3.5
+    CFLAGS: "-m32 -DMRB_INT64=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.5 32bit_float:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang35_0.7
+  variables:
+    CC: clang-3.5
+    CXX: clang++-3.5
+    LD: clang-3.5
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.5 32bit_float_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang35_0.7
+  variables:
+    CC: clang-3.5
+    CXX: clang++-3.5
+    LD: clang-3.5
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.5 32bit_float_int16:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang35_0.7
+  variables:
+    CC: clang-3.5
+    CXX: clang++-3.5
+    LD: clang-3.5
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT16=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.5 32bit_float_int16_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang35_0.7
+  variables:
+    CC: clang-3.5
+    CXX: clang++-3.5
+    LD: clang-3.5
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT16=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.5 32bit_float_int64:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang35_0.7
+  variables:
+    CC: clang-3.5
+    CXX: clang++-3.5
+    LD: clang-3.5
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT64=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.5 32bit_float_int64_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang35_0.7
+  variables:
+    CC: clang-3.5
+    CXX: clang++-3.5
+    LD: clang-3.5
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT64=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.5 64bit:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang35_0.7
+  variables:
+    CC: clang-3.5
+    CXX: clang++-3.5
+    LD: clang-3.5
+    CFLAGS: "-DMRB_WORD_BOXING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.5 64bit_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang35_0.7
+  variables:
+    CC: clang-3.5
+    CXX: clang++-3.5
+    LD: clang-3.5
+    CFLAGS: "-DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.5 64bit_nan:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang35_0.7
+  variables:
+    CC: clang-3.5
+    CXX: clang++-3.5
+    LD: clang-3.5
+    CFLAGS: "-DMRB_NAN_BOXING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.5 64bit_nan_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang35_0.7
+  variables:
+    CC: clang-3.5
+    CXX: clang++-3.5
+    LD: clang-3.5
+    CFLAGS: "-DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.5 64bit_int16:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang35_0.7
+  variables:
+    CC: clang-3.5
+    CXX: clang++-3.5
+    LD: clang-3.5
+    CFLAGS: "-DMRB_INT16=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.5 64bit_int16_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang35_0.7
+  variables:
+    CC: clang-3.5
+    CXX: clang++-3.5
+    LD: clang-3.5
+    CFLAGS: "-DMRB_INT16=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.5 64bit_int16_nan:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang35_0.7
+  variables:
+    CC: clang-3.5
+    CXX: clang++-3.5
+    LD: clang-3.5
+    CFLAGS: "-DMRB_INT16=1 -DMRB_NAN_BOXING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.5 64bit_int16_nan_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang35_0.7
+  variables:
+    CC: clang-3.5
+    CXX: clang++-3.5
+    LD: clang-3.5
+    CFLAGS: "-DMRB_INT16=1 -DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.5 64bit_int64:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang35_0.7
+  variables:
+    CC: clang-3.5
+    CXX: clang++-3.5
+    LD: clang-3.5
+    CFLAGS: "-DMRB_INT64=1 -DMRB_WORD_BOXING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.5 64bit_int64_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang35_0.7
+  variables:
+    CC: clang-3.5
+    CXX: clang++-3.5
+    LD: clang-3.5
+    CFLAGS: "-DMRB_INT64=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.5 64bit_float:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang35_0.7
+  variables:
+    CC: clang-3.5
+    CXX: clang++-3.5
+    LD: clang-3.5
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.5 64bit_float_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang35_0.7
+  variables:
+    CC: clang-3.5
+    CXX: clang++-3.5
+    LD: clang-3.5
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.5 64bit_float_int16:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang35_0.7
+  variables:
+    CC: clang-3.5
+    CXX: clang++-3.5
+    LD: clang-3.5
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT16=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.5 64bit_float_int16_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang35_0.7
+  variables:
+    CC: clang-3.5
+    CXX: clang++-3.5
+    LD: clang-3.5
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT16=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.5 64bit_float_int64:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang35_0.7
+  variables:
+    CC: clang-3.5
+    CXX: clang++-3.5
+    LD: clang-3.5
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT64=1 -DMRB_WORD_BOXING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.5 64bit_float_int64_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang35_0.7
+  variables:
+    CC: clang-3.5
+    CXX: clang++-3.5
+    LD: clang-3.5
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT64=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.6 32bit:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang36_0.7
+  variables:
+    CC: clang-3.6
+    CXX: clang++-3.6
+    LD: clang-3.6
+    CFLAGS: "-m32 -DMRB_WORD_BOXING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.6 32bit_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang36_0.7
+  variables:
+    CC: clang-3.6
+    CXX: clang++-3.6
+    LD: clang-3.6
+    CFLAGS: "-m32 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.6 32bit_nan:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang36_0.7
+  variables:
+    CC: clang-3.6
+    CXX: clang++-3.6
+    LD: clang-3.6
+    CFLAGS: "-m32 -DMRB_NAN_BOXING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.6 32bit_nan_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang36_0.7
+  variables:
+    CC: clang-3.6
+    CXX: clang++-3.6
+    LD: clang-3.6
+    CFLAGS: "-m32 -DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.6 32bit_int16:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang36_0.7
+  variables:
+    CC: clang-3.6
+    CXX: clang++-3.6
+    LD: clang-3.6
+    CFLAGS: "-m32 -DMRB_INT16=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.6 32bit_int16_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang36_0.7
+  variables:
+    CC: clang-3.6
+    CXX: clang++-3.6
+    LD: clang-3.6
+    CFLAGS: "-m32 -DMRB_INT16=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.6 32bit_int16_nan:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang36_0.7
+  variables:
+    CC: clang-3.6
+    CXX: clang++-3.6
+    LD: clang-3.6
+    CFLAGS: "-m32 -DMRB_INT16=1 -DMRB_NAN_BOXING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.6 32bit_int16_nan_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang36_0.7
+  variables:
+    CC: clang-3.6
+    CXX: clang++-3.6
+    LD: clang-3.6
+    CFLAGS: "-m32 -DMRB_INT16=1 -DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.6 32bit_int64:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang36_0.7
+  variables:
+    CC: clang-3.6
+    CXX: clang++-3.6
+    LD: clang-3.6
+    CFLAGS: "-m32 -DMRB_INT64=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.6 32bit_int64_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang36_0.7
+  variables:
+    CC: clang-3.6
+    CXX: clang++-3.6
+    LD: clang-3.6
+    CFLAGS: "-m32 -DMRB_INT64=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.6 32bit_float:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang36_0.7
+  variables:
+    CC: clang-3.6
+    CXX: clang++-3.6
+    LD: clang-3.6
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.6 32bit_float_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang36_0.7
+  variables:
+    CC: clang-3.6
+    CXX: clang++-3.6
+    LD: clang-3.6
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.6 32bit_float_int16:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang36_0.7
+  variables:
+    CC: clang-3.6
+    CXX: clang++-3.6
+    LD: clang-3.6
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT16=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.6 32bit_float_int16_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang36_0.7
+  variables:
+    CC: clang-3.6
+    CXX: clang++-3.6
+    LD: clang-3.6
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT16=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.6 32bit_float_int64:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang36_0.7
+  variables:
+    CC: clang-3.6
+    CXX: clang++-3.6
+    LD: clang-3.6
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT64=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.6 32bit_float_int64_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang36_0.7
+  variables:
+    CC: clang-3.6
+    CXX: clang++-3.6
+    LD: clang-3.6
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT64=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.6 64bit:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang36_0.7
+  variables:
+    CC: clang-3.6
+    CXX: clang++-3.6
+    LD: clang-3.6
+    CFLAGS: "-DMRB_WORD_BOXING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.6 64bit_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang36_0.7
+  variables:
+    CC: clang-3.6
+    CXX: clang++-3.6
+    LD: clang-3.6
+    CFLAGS: "-DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.6 64bit_nan:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang36_0.7
+  variables:
+    CC: clang-3.6
+    CXX: clang++-3.6
+    LD: clang-3.6
+    CFLAGS: "-DMRB_NAN_BOXING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.6 64bit_nan_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang36_0.7
+  variables:
+    CC: clang-3.6
+    CXX: clang++-3.6
+    LD: clang-3.6
+    CFLAGS: "-DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.6 64bit_int16:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang36_0.7
+  variables:
+    CC: clang-3.6
+    CXX: clang++-3.6
+    LD: clang-3.6
+    CFLAGS: "-DMRB_INT16=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.6 64bit_int16_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang36_0.7
+  variables:
+    CC: clang-3.6
+    CXX: clang++-3.6
+    LD: clang-3.6
+    CFLAGS: "-DMRB_INT16=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.6 64bit_int16_nan:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang36_0.7
+  variables:
+    CC: clang-3.6
+    CXX: clang++-3.6
+    LD: clang-3.6
+    CFLAGS: "-DMRB_INT16=1 -DMRB_NAN_BOXING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.6 64bit_int16_nan_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang36_0.7
+  variables:
+    CC: clang-3.6
+    CXX: clang++-3.6
+    LD: clang-3.6
+    CFLAGS: "-DMRB_INT16=1 -DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.6 64bit_int64:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang36_0.7
+  variables:
+    CC: clang-3.6
+    CXX: clang++-3.6
+    LD: clang-3.6
+    CFLAGS: "-DMRB_INT64=1 -DMRB_WORD_BOXING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.6 64bit_int64_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang36_0.7
+  variables:
+    CC: clang-3.6
+    CXX: clang++-3.6
+    LD: clang-3.6
+    CFLAGS: "-DMRB_INT64=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.6 64bit_float:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang36_0.7
+  variables:
+    CC: clang-3.6
+    CXX: clang++-3.6
+    LD: clang-3.6
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.6 64bit_float_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang36_0.7
+  variables:
+    CC: clang-3.6
+    CXX: clang++-3.6
+    LD: clang-3.6
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.6 64bit_float_int16:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang36_0.7
+  variables:
+    CC: clang-3.6
+    CXX: clang++-3.6
+    LD: clang-3.6
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT16=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.6 64bit_float_int16_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang36_0.7
+  variables:
+    CC: clang-3.6
+    CXX: clang++-3.6
+    LD: clang-3.6
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT16=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.6 64bit_float_int64:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang36_0.7
+  variables:
+    CC: clang-3.6
+    CXX: clang++-3.6
+    LD: clang-3.6
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT64=1 -DMRB_WORD_BOXING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.6 64bit_float_int64_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang36_0.7
+  variables:
+    CC: clang-3.6
+    CXX: clang++-3.6
+    LD: clang-3.6
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT64=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.7 32bit:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang37_0.7
+  variables:
+    CC: clang-3.7
+    CXX: clang++-3.7
+    LD: clang-3.7
+    CFLAGS: "-m32 -DMRB_WORD_BOXING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.7 32bit_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang37_0.7
+  variables:
+    CC: clang-3.7
+    CXX: clang++-3.7
+    LD: clang-3.7
+    CFLAGS: "-m32 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.7 32bit_nan:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang37_0.7
+  variables:
+    CC: clang-3.7
+    CXX: clang++-3.7
+    LD: clang-3.7
+    CFLAGS: "-m32 -DMRB_NAN_BOXING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.7 32bit_nan_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang37_0.7
+  variables:
+    CC: clang-3.7
+    CXX: clang++-3.7
+    LD: clang-3.7
+    CFLAGS: "-m32 -DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.7 32bit_int16:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang37_0.7
+  variables:
+    CC: clang-3.7
+    CXX: clang++-3.7
+    LD: clang-3.7
+    CFLAGS: "-m32 -DMRB_INT16=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.7 32bit_int16_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang37_0.7
+  variables:
+    CC: clang-3.7
+    CXX: clang++-3.7
+    LD: clang-3.7
+    CFLAGS: "-m32 -DMRB_INT16=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.7 32bit_int16_nan:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang37_0.7
+  variables:
+    CC: clang-3.7
+    CXX: clang++-3.7
+    LD: clang-3.7
+    CFLAGS: "-m32 -DMRB_INT16=1 -DMRB_NAN_BOXING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.7 32bit_int16_nan_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang37_0.7
+  variables:
+    CC: clang-3.7
+    CXX: clang++-3.7
+    LD: clang-3.7
+    CFLAGS: "-m32 -DMRB_INT16=1 -DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.7 32bit_int64:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang37_0.7
+  variables:
+    CC: clang-3.7
+    CXX: clang++-3.7
+    LD: clang-3.7
+    CFLAGS: "-m32 -DMRB_INT64=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.7 32bit_int64_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang37_0.7
+  variables:
+    CC: clang-3.7
+    CXX: clang++-3.7
+    LD: clang-3.7
+    CFLAGS: "-m32 -DMRB_INT64=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.7 32bit_float:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang37_0.7
+  variables:
+    CC: clang-3.7
+    CXX: clang++-3.7
+    LD: clang-3.7
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.7 32bit_float_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang37_0.7
+  variables:
+    CC: clang-3.7
+    CXX: clang++-3.7
+    LD: clang-3.7
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.7 32bit_float_int16:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang37_0.7
+  variables:
+    CC: clang-3.7
+    CXX: clang++-3.7
+    LD: clang-3.7
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT16=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.7 32bit_float_int16_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang37_0.7
+  variables:
+    CC: clang-3.7
+    CXX: clang++-3.7
+    LD: clang-3.7
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT16=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.7 32bit_float_int64:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang37_0.7
+  variables:
+    CC: clang-3.7
+    CXX: clang++-3.7
+    LD: clang-3.7
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT64=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.7 32bit_float_int64_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang37_0.7
+  variables:
+    CC: clang-3.7
+    CXX: clang++-3.7
+    LD: clang-3.7
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT64=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.7 64bit:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang37_0.7
+  variables:
+    CC: clang-3.7
+    CXX: clang++-3.7
+    LD: clang-3.7
+    CFLAGS: "-DMRB_WORD_BOXING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.7 64bit_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang37_0.7
+  variables:
+    CC: clang-3.7
+    CXX: clang++-3.7
+    LD: clang-3.7
+    CFLAGS: "-DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.7 64bit_nan:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang37_0.7
+  variables:
+    CC: clang-3.7
+    CXX: clang++-3.7
+    LD: clang-3.7
+    CFLAGS: "-DMRB_NAN_BOXING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.7 64bit_nan_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang37_0.7
+  variables:
+    CC: clang-3.7
+    CXX: clang++-3.7
+    LD: clang-3.7
+    CFLAGS: "-DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.7 64bit_int16:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang37_0.7
+  variables:
+    CC: clang-3.7
+    CXX: clang++-3.7
+    LD: clang-3.7
+    CFLAGS: "-DMRB_INT16=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.7 64bit_int16_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang37_0.7
+  variables:
+    CC: clang-3.7
+    CXX: clang++-3.7
+    LD: clang-3.7
+    CFLAGS: "-DMRB_INT16=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.7 64bit_int16_nan:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang37_0.7
+  variables:
+    CC: clang-3.7
+    CXX: clang++-3.7
+    LD: clang-3.7
+    CFLAGS: "-DMRB_INT16=1 -DMRB_NAN_BOXING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.7 64bit_int16_nan_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang37_0.7
+  variables:
+    CC: clang-3.7
+    CXX: clang++-3.7
+    LD: clang-3.7
+    CFLAGS: "-DMRB_INT16=1 -DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.7 64bit_int64:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang37_0.7
+  variables:
+    CC: clang-3.7
+    CXX: clang++-3.7
+    LD: clang-3.7
+    CFLAGS: "-DMRB_INT64=1 -DMRB_WORD_BOXING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.7 64bit_int64_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang37_0.7
+  variables:
+    CC: clang-3.7
+    CXX: clang++-3.7
+    LD: clang-3.7
+    CFLAGS: "-DMRB_INT64=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.7 64bit_float:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang37_0.7
+  variables:
+    CC: clang-3.7
+    CXX: clang++-3.7
+    LD: clang-3.7
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.7 64bit_float_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang37_0.7
+  variables:
+    CC: clang-3.7
+    CXX: clang++-3.7
+    LD: clang-3.7
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.7 64bit_float_int16:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang37_0.7
+  variables:
+    CC: clang-3.7
+    CXX: clang++-3.7
+    LD: clang-3.7
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT16=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.7 64bit_float_int16_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang37_0.7
+  variables:
+    CC: clang-3.7
+    CXX: clang++-3.7
+    LD: clang-3.7
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT16=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.7 64bit_float_int64:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang37_0.7
+  variables:
+    CC: clang-3.7
+    CXX: clang++-3.7
+    LD: clang-3.7
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT64=1 -DMRB_WORD_BOXING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.7 64bit_float_int64_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang37_0.7
+  variables:
+    CC: clang-3.7
+    CXX: clang++-3.7
+    LD: clang-3.7
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT64=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.8 32bit:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang38_0.7
+  variables:
+    CC: clang-3.8
+    CXX: clang++-3.8
+    LD: clang-3.8
+    CFLAGS: "-m32 -DMRB_WORD_BOXING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.8 32bit_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang38_0.7
+  variables:
+    CC: clang-3.8
+    CXX: clang++-3.8
+    LD: clang-3.8
+    CFLAGS: "-m32 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.8 32bit_nan:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang38_0.7
+  variables:
+    CC: clang-3.8
+    CXX: clang++-3.8
+    LD: clang-3.8
+    CFLAGS: "-m32 -DMRB_NAN_BOXING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.8 32bit_nan_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang38_0.7
+  variables:
+    CC: clang-3.8
+    CXX: clang++-3.8
+    LD: clang-3.8
+    CFLAGS: "-m32 -DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.8 32bit_int16:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang38_0.7
+  variables:
+    CC: clang-3.8
+    CXX: clang++-3.8
+    LD: clang-3.8
+    CFLAGS: "-m32 -DMRB_INT16=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.8 32bit_int16_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang38_0.7
+  variables:
+    CC: clang-3.8
+    CXX: clang++-3.8
+    LD: clang-3.8
+    CFLAGS: "-m32 -DMRB_INT16=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.8 32bit_int16_nan:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang38_0.7
+  variables:
+    CC: clang-3.8
+    CXX: clang++-3.8
+    LD: clang-3.8
+    CFLAGS: "-m32 -DMRB_INT16=1 -DMRB_NAN_BOXING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.8 32bit_int16_nan_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang38_0.7
+  variables:
+    CC: clang-3.8
+    CXX: clang++-3.8
+    LD: clang-3.8
+    CFLAGS: "-m32 -DMRB_INT16=1 -DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.8 32bit_int64:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang38_0.7
+  variables:
+    CC: clang-3.8
+    CXX: clang++-3.8
+    LD: clang-3.8
+    CFLAGS: "-m32 -DMRB_INT64=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.8 32bit_int64_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang38_0.7
+  variables:
+    CC: clang-3.8
+    CXX: clang++-3.8
+    LD: clang-3.8
+    CFLAGS: "-m32 -DMRB_INT64=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.8 32bit_float:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang38_0.7
+  variables:
+    CC: clang-3.8
+    CXX: clang++-3.8
+    LD: clang-3.8
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.8 32bit_float_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang38_0.7
+  variables:
+    CC: clang-3.8
+    CXX: clang++-3.8
+    LD: clang-3.8
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.8 32bit_float_int16:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang38_0.7
+  variables:
+    CC: clang-3.8
+    CXX: clang++-3.8
+    LD: clang-3.8
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT16=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.8 32bit_float_int16_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang38_0.7
+  variables:
+    CC: clang-3.8
+    CXX: clang++-3.8
+    LD: clang-3.8
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT16=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.8 32bit_float_int64:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang38_0.7
+  variables:
+    CC: clang-3.8
+    CXX: clang++-3.8
+    LD: clang-3.8
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT64=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.8 32bit_float_int64_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang38_0.7
+  variables:
+    CC: clang-3.8
+    CXX: clang++-3.8
+    LD: clang-3.8
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT64=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.8 64bit:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang38_0.7
+  variables:
+    CC: clang-3.8
+    CXX: clang++-3.8
+    LD: clang-3.8
+    CFLAGS: "-DMRB_WORD_BOXING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.8 64bit_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang38_0.7
+  variables:
+    CC: clang-3.8
+    CXX: clang++-3.8
+    LD: clang-3.8
+    CFLAGS: "-DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.8 64bit_nan:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang38_0.7
+  variables:
+    CC: clang-3.8
+    CXX: clang++-3.8
+    LD: clang-3.8
+    CFLAGS: "-DMRB_NAN_BOXING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.8 64bit_nan_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang38_0.7
+  variables:
+    CC: clang-3.8
+    CXX: clang++-3.8
+    LD: clang-3.8
+    CFLAGS: "-DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.8 64bit_int16:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang38_0.7
+  variables:
+    CC: clang-3.8
+    CXX: clang++-3.8
+    LD: clang-3.8
+    CFLAGS: "-DMRB_INT16=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.8 64bit_int16_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang38_0.7
+  variables:
+    CC: clang-3.8
+    CXX: clang++-3.8
+    LD: clang-3.8
+    CFLAGS: "-DMRB_INT16=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.8 64bit_int16_nan:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang38_0.7
+  variables:
+    CC: clang-3.8
+    CXX: clang++-3.8
+    LD: clang-3.8
+    CFLAGS: "-DMRB_INT16=1 -DMRB_NAN_BOXING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.8 64bit_int16_nan_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang38_0.7
+  variables:
+    CC: clang-3.8
+    CXX: clang++-3.8
+    LD: clang-3.8
+    CFLAGS: "-DMRB_INT16=1 -DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.8 64bit_int64:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang38_0.7
+  variables:
+    CC: clang-3.8
+    CXX: clang++-3.8
+    LD: clang-3.8
+    CFLAGS: "-DMRB_INT64=1 -DMRB_WORD_BOXING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.8 64bit_int64_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang38_0.7
+  variables:
+    CC: clang-3.8
+    CXX: clang++-3.8
+    LD: clang-3.8
+    CFLAGS: "-DMRB_INT64=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.8 64bit_float:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang38_0.7
+  variables:
+    CC: clang-3.8
+    CXX: clang++-3.8
+    LD: clang-3.8
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.8 64bit_float_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang38_0.7
+  variables:
+    CC: clang-3.8
+    CXX: clang++-3.8
+    LD: clang-3.8
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.8 64bit_float_int16:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang38_0.7
+  variables:
+    CC: clang-3.8
+    CXX: clang++-3.8
+    LD: clang-3.8
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT16=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.8 64bit_float_int16_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang38_0.7
+  variables:
+    CC: clang-3.8
+    CXX: clang++-3.8
+    LD: clang-3.8
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT16=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.8 64bit_float_int64:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang38_0.7
+  variables:
+    CC: clang-3.8
+    CXX: clang++-3.8
+    LD: clang-3.8
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT64=1 -DMRB_WORD_BOXING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.8 64bit_float_int64_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang38_0.7
+  variables:
+    CC: clang-3.8
+    CXX: clang++-3.8
+    LD: clang-3.8
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT64=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.9 32bit:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang39_0.7
+  variables:
+    CC: clang-3.9
+    CXX: clang++-3.9
+    LD: clang-3.9
+    CFLAGS: "-m32 -DMRB_WORD_BOXING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.9 32bit_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang39_0.7
+  variables:
+    CC: clang-3.9
+    CXX: clang++-3.9
+    LD: clang-3.9
+    CFLAGS: "-m32 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.9 32bit_nan:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang39_0.7
+  variables:
+    CC: clang-3.9
+    CXX: clang++-3.9
+    LD: clang-3.9
+    CFLAGS: "-m32 -DMRB_NAN_BOXING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.9 32bit_nan_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang39_0.7
+  variables:
+    CC: clang-3.9
+    CXX: clang++-3.9
+    LD: clang-3.9
+    CFLAGS: "-m32 -DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.9 32bit_int16:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang39_0.7
+  variables:
+    CC: clang-3.9
+    CXX: clang++-3.9
+    LD: clang-3.9
+    CFLAGS: "-m32 -DMRB_INT16=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.9 32bit_int16_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang39_0.7
+  variables:
+    CC: clang-3.9
+    CXX: clang++-3.9
+    LD: clang-3.9
+    CFLAGS: "-m32 -DMRB_INT16=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.9 32bit_int16_nan:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang39_0.7
+  variables:
+    CC: clang-3.9
+    CXX: clang++-3.9
+    LD: clang-3.9
+    CFLAGS: "-m32 -DMRB_INT16=1 -DMRB_NAN_BOXING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.9 32bit_int16_nan_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang39_0.7
+  variables:
+    CC: clang-3.9
+    CXX: clang++-3.9
+    LD: clang-3.9
+    CFLAGS: "-m32 -DMRB_INT16=1 -DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.9 32bit_int64:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang39_0.7
+  variables:
+    CC: clang-3.9
+    CXX: clang++-3.9
+    LD: clang-3.9
+    CFLAGS: "-m32 -DMRB_INT64=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.9 32bit_int64_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang39_0.7
+  variables:
+    CC: clang-3.9
+    CXX: clang++-3.9
+    LD: clang-3.9
+    CFLAGS: "-m32 -DMRB_INT64=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.9 32bit_float:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang39_0.7
+  variables:
+    CC: clang-3.9
+    CXX: clang++-3.9
+    LD: clang-3.9
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.9 32bit_float_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang39_0.7
+  variables:
+    CC: clang-3.9
+    CXX: clang++-3.9
+    LD: clang-3.9
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.9 32bit_float_int16:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang39_0.7
+  variables:
+    CC: clang-3.9
+    CXX: clang++-3.9
+    LD: clang-3.9
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT16=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.9 32bit_float_int16_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang39_0.7
+  variables:
+    CC: clang-3.9
+    CXX: clang++-3.9
+    LD: clang-3.9
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT16=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.9 32bit_float_int64:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang39_0.7
+  variables:
+    CC: clang-3.9
+    CXX: clang++-3.9
+    LD: clang-3.9
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT64=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.9 32bit_float_int64_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang39_0.7
+  variables:
+    CC: clang-3.9
+    CXX: clang++-3.9
+    LD: clang-3.9
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT64=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; ./minirake --verbose all test
+Test clang-3.9 64bit:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang39_0.7
+  variables:
+    CC: clang-3.9
+    CXX: clang++-3.9
+    LD: clang-3.9
+    CFLAGS: "-DMRB_WORD_BOXING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.9 64bit_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang39_0.7
+  variables:
+    CC: clang-3.9
+    CXX: clang++-3.9
+    LD: clang-3.9
+    CFLAGS: "-DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.9 64bit_nan:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang39_0.7
+  variables:
+    CC: clang-3.9
+    CXX: clang++-3.9
+    LD: clang-3.9
+    CFLAGS: "-DMRB_NAN_BOXING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.9 64bit_nan_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang39_0.7
+  variables:
+    CC: clang-3.9
+    CXX: clang++-3.9
+    LD: clang-3.9
+    CFLAGS: "-DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.9 64bit_int16:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang39_0.7
+  variables:
+    CC: clang-3.9
+    CXX: clang++-3.9
+    LD: clang-3.9
+    CFLAGS: "-DMRB_INT16=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.9 64bit_int16_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang39_0.7
+  variables:
+    CC: clang-3.9
+    CXX: clang++-3.9
+    LD: clang-3.9
+    CFLAGS: "-DMRB_INT16=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.9 64bit_int16_nan:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang39_0.7
+  variables:
+    CC: clang-3.9
+    CXX: clang++-3.9
+    LD: clang-3.9
+    CFLAGS: "-DMRB_INT16=1 -DMRB_NAN_BOXING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.9 64bit_int16_nan_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang39_0.7
+  variables:
+    CC: clang-3.9
+    CXX: clang++-3.9
+    LD: clang-3.9
+    CFLAGS: "-DMRB_INT16=1 -DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.9 64bit_int64:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang39_0.7
+  variables:
+    CC: clang-3.9
+    CXX: clang++-3.9
+    LD: clang-3.9
+    CFLAGS: "-DMRB_INT64=1 -DMRB_WORD_BOXING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.9 64bit_int64_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang39_0.7
+  variables:
+    CC: clang-3.9
+    CXX: clang++-3.9
+    LD: clang-3.9
+    CFLAGS: "-DMRB_INT64=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.9 64bit_float:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang39_0.7
+  variables:
+    CC: clang-3.9
+    CXX: clang++-3.9
+    LD: clang-3.9
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.9 64bit_float_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang39_0.7
+  variables:
+    CC: clang-3.9
+    CXX: clang++-3.9
+    LD: clang-3.9
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.9 64bit_float_int16:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang39_0.7
+  variables:
+    CC: clang-3.9
+    CXX: clang++-3.9
+    LD: clang-3.9
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT16=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.9 64bit_float_int16_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang39_0.7
+  variables:
+    CC: clang-3.9
+    CXX: clang++-3.9
+    LD: clang-3.9
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT16=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.9 64bit_float_int64:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang39_0.7
+  variables:
+    CC: clang-3.9
+    CXX: clang++-3.9
+    LD: clang-3.9
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT64=1 -DMRB_WORD_BOXING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test
+Test clang-3.9 64bit_float_int64_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang39_0.7
+  variables:
+    CC: clang-3.9
+    CXX: clang++-3.9
+    LD: clang-3.9
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT64=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; ./minirake --verbose all test

--- a/Rakefile
+++ b/Rakefile
@@ -28,6 +28,8 @@ load "#{MRUBY_ROOT}/tasks/libmruby.rake"
 
 load "#{MRUBY_ROOT}/tasks/benchmark.rake"
 
+load "#{MRUBY_ROOT}/tasks/gitlab.rake"
+
 ##############################
 # generic build targets, rules
 task :default => :all

--- a/tasks/gitlab.rake
+++ b/tasks/gitlab.rake
@@ -1,0 +1,118 @@
+CI_VERSION = '0.7'.freeze
+CI_BASE = 'ubuntu:16.10'.freeze
+CI_COMPILERS = ['gcc-4.7',
+                'gcc-4.8',
+                'gcc-4.9',
+                'gcc-5',
+                'gcc-6',
+                'clang-3.5',
+                'clang-3.6',
+                'clang-3.7',
+                'clang-3.8',
+                'clang-3.9'].freeze
+
+def ci_image_tag(compiler)
+  compiler.tr('+', 'c').delete('-').delete('.')
+end
+
+def ci_docker_tag(compiler)
+  tag = ci_image_tag(compiler)
+  "registry.gitlab.com/dabroz/mruby:#{tag}_#{CI_VERSION}"
+end
+
+def run_cmd(cmd)
+  puts cmd
+  raise 'error' unless system cmd
+end
+
+desc 'recreate docker images for GitLab builds'
+task :gitlab_dockers do
+  CI_COMPILERS.each do |compiler|
+    tag = ci_image_tag(compiler)
+    filename = "Dockerfile.#{tag}"
+    File.open(filename, 'wb') do |f|
+      f << "# #{compiler} - #{tag}\n"
+      f << "FROM #{CI_BASE}\n"
+      f << "RUN apt-get update && apt-get install -y git ruby2.3 ruby2.3-dev bison\n"
+      f << "RUN apt-get update && apt-get install -y binutils manpages\n"
+      f << "RUN apt-get update && apt-get install -y #{compiler}\n"
+      if compiler['gcc']
+        f << "RUN apt-get update && apt-get install -y libx32#{compiler}-dev\n"
+        f << "RUN apt-get update && apt-get install --no-install-recommends -y #{compiler}-multilib\n"
+      end
+      f << "RUN dpkg --add-architecture i386\n"
+      f << "RUN apt-get update && apt-get install -y linux-libc-dev:i386\n"
+      if compiler['clang']
+        f << "RUN apt-get update && apt-get install --no-install-recommends -y libc6-dev-i386\n"
+        f << "RUN apt-get update && apt-get install -y gcc gcc-multilib\n"
+      end
+    end
+    docker_tag = ci_docker_tag(compiler)
+    cmd1 = "docker build -t #{docker_tag} -f #{filename} ."
+    cmd2 = "docker push #{docker_tag}"
+    run_cmd cmd1
+    run_cmd cmd2
+    File.delete(filename)
+  end
+end
+
+desc 'create build configurations and update .gitlab-ci.yml'
+task :gitlab_config do
+  require 'yaml'
+
+  configs = []
+  [true, false].each do |mode_32|
+    ['', 'MRB_USE_FLOAT'].each do |float_conf|
+      ['', 'MRB_INT16', 'MRB_INT64'].each do |int_conf|
+        ['', 'MRB_NAN_BOXING', 'MRB_WORD_BOXING'].each do |boxing_conf|
+          ['', 'MRB_UTF8_STRING'].each do |utf8_conf|
+            next if (float_conf == 'MRB_USE_FLOAT') && (boxing_conf == 'MRB_NAN_BOXING')
+            next if (int_conf == 'MRB_INT64') && (boxing_conf == 'MRB_NAN_BOXING')
+            next if (int_conf == 'MRB_INT16') && (boxing_conf == 'MRB_WORD_BOXING')
+            next if (int_conf == 'MRB_INT64') && (boxing_conf == 'MRB_WORD_BOXING') && mode_32
+            env = [float_conf, int_conf, boxing_conf, utf8_conf].map do |conf|
+              conf == '' ? nil : "-D#{conf}=1"
+            end.compact.join(' ')
+            bit = mode_32 ? '-m32 ' : ''
+            _info = ''
+            _info += mode_32 ? '32bit ' : '64bit '
+            _info += float_conf['USE'] ? 'float ' : ''
+            _info += int_conf['16'] ? 'int16 ' : ''
+            _info += int_conf['64'] ? 'int64 ' : ''
+            _info += boxing_conf['NAN'] ? 'nan ' : ''
+            _info += boxing_conf['word'] ? 'word ' : ''
+            _info += utf8_conf['UTF8'] ? 'utf8 ' : ''
+            _info = _info.gsub(/ +/, ' ').strip.tr(' ', '_')
+            configs << { '_info' => _info, 'CFLAGS' => "#{bit}#{env}", 'LDFLAGS' => bit.strip.to_s }
+          end
+        end
+      end
+    end
+  end
+  path = './.gitlab-ci.yml'
+  data = YAML.load_file(path)
+  data.keys.select do |key|
+    key.start_with? 'Test'
+  end.each do |key|
+    data.delete(key)
+  end
+  CI_COMPILERS.each do |compiler|
+    configs.each do |config|
+      name = "Test #{compiler} #{config['_info']}"
+      hash = {
+        'CC' => compiler,
+        'CXX' => compiler.gsub('gcc', 'g++').gsub('clang', 'clang++'),
+        'LD' => compiler
+      }
+      hash = hash.merge(config)
+      hash.delete('_info')
+      data[name] = {
+        'stage' => 'test',
+        'image' => ci_docker_tag(compiler),
+        'variables' => hash,
+        'script' => 'env; ./minirake --verbose all test'
+      }
+    end
+  end
+  File.open(path, 'w') { |f| YAML.dump(data, f) }
+end


### PR DESCRIPTION
Previously I've proposed #3258 as a method to test mruby on different build configurations (and found many bugs with rarely used combinations). However that method vastly increased Travis build times which is unfortunate. I was thinking about a way to enforce compatibility without such side-effect. Lately I was experimenting with GitLab CI and found it to be an excellent candidate for such testing.

I've created a mirror of the official mruby repository, which is automatically updated every 24h:
https://gitlab.com/dabroz/mruby

This patch introduces Gitlab testing, using GitLab CI, to test many different configurations:
 - 32/64 bit architecture
 - float/double
 - 16/32/64 bit int size
 - none/NaN/word boxing
 - ASCII/UTF8

using various compilers:
 - gcc-4.7
 - gcc-4.8
 - gcc-4.9
 - gcc-5
 - gcc-6
 - clang-3.5
 - clang-3.6
 - clang-3.7
 - clang-3.8
 - clang-3.9

#3457 is required for this to pass all tests on GitLab.

This has no impact on GitHub/Travis builds/testing/pull requests etc.

What is currently missing in GitLab testing is Windows/OSX platforms, since GitLab.com shared runners only support Docker (Linux) builds. I will try to devise a way to add different platforms to this testing procedure in the future.