### PR TITLE
Additional options for Android build script.

### DIFF
--- a/examples/targets/build_config_android_armeabi_v7a_neon_hard.rb
+++ b/examples/targets/build_config_android_armeabi_v7a_neon_hard.rb
@@ -1,0 +1,28 @@
+MRuby::Build.new do |conf|
+
+  # Gets set by the VS command prompts.
+  if ENV['VisualStudioVersion'] || ENV['VSINSTALLDIR']
+    toolchain :visualcpp
+  else
+    toolchain :gcc
+  end
+
+  enable_debug
+
+  # include the default GEMs
+  conf.gembox 'default'
+end
+
+# Requires Android NDK r13 or later.
+MRuby::CrossBuild.new('android-armeabi-v7a-neon-hard') do |conf|
+  params = {
+    :arch => 'armeabi-v7a',
+    :mfpu => 'neon',
+    :mfloat_abi => 'hard',
+    :platform => 'android-24',
+    :toolchain => :clang,
+  }
+  toolchain :android, params
+
+  conf.gembox 'default'
+end

--- a/tasks/toolchains/android.rake
+++ b/tasks/toolchains/android.rake
@@ -186,6 +186,22 @@ Set ANDROID_PLATFORM environment variable or set :platform parameter
     @platform
   end
 
+  def armeabi_v7a_mfpu
+    @armeabi_v7a_mfpu ||= (params[:mfpu] || 'vfpv3-d16').to_s
+  end
+
+  def armeabi_v7a_mfloat_abi
+    @armeabi_v7a_mfloat_abi ||= (params[:mfloat_abi] || 'softfp').to_s
+  end
+
+  def no_warn_mismatch
+    if %W(soft softfp).include? armeabi_v7a_mfloat_abi
+      ''
+    else
+      ',--no-warn-mismatch'
+    end
+  end
+
   def cc
     case toolchain
     when :gcc then bin_gcc('gcc')
@@ -200,36 +216,56 @@ Set ANDROID_PLATFORM environment variable or set :platform parameter
     end
   end
 
-  def cflags
+  def ctarget
     flags = []
 
-    flags += %W(-MMD -MP)
-    flags += %W(-D__android__ -DANDROID --sysroot="#{sysroot}")
     case toolchain
     when :gcc
       case arch
-      when /armeabi-v7a/  then flags += %W(-march=armv7-a -mfpu=vfpv3-d16 -mfloat-abi=softfp -fpic)
-      when /armeabi/      then flags += %W(-march=armv5te -mtune=xscale -msoft-float -fpic)
-      when /arm64-v8a/    then flags += %W(-march=armv8-a -fpic)
+      when /armeabi-v7a/  then flags += %W(-march=armv7-a)
+      when /armeabi/      then flags += %W(-march=armv5te)
+      when /arm64-v8a/    then flags += %W(-march=armv8-a)
       when /x86_64/       then flags += %W(-march=x86-64)
       when /x86/          then flags += %W(-march=i686)
-      when /mips64/       then flags += %W(-march=mips64r6 -fmessage-length=0 -fpic)
-      when /mips/         then flags += %W(-march=mips32 -fmessage-length=0 -fpic)
+      when /mips64/       then flags += %W(-march=mips64r6)
+      when /mips/         then flags += %W(-march=mips32)
       end
     when :clang
-      flags += %W(-gcc-toolchain "#{gcc_toolchain_path.to_s}")
       case arch
-      when /armeabi-v7a/  then flags += %W(-target armv7-none-linux-androideabi -fpic)
-      when /armeabi/      then flags += %W(-target armv5te-none-linux-androideabi -fpic)
-      when /arm64-v8a/    then flags += %W(-target aarch64-none-linux-android -fpic)
-      when /x86_64/       then flags += %W(-target x86_64-none-linux-android -fPIC)
-      when /x86/          then flags += %W(-target i686-none-linux-android -fPIC)
-      when /mips64/       then flags += %W(-target mips64el-none-linux-android -fmessage-length=0 -fpic)
-      when /mips/         then flags += %W(-target mipsel-none-linux-android -fmessage-length=0 -fpic)
+      when /armeabi-v7a/  then flags += %W(-target armv7-none-linux-androideabi)
+      when /armeabi/      then flags += %W(-target armv5te-none-linux-androideabi)
+      when /arm64-v8a/    then flags += %W(-target aarch64-none-linux-android)
+      when /x86_64/       then flags += %W(-target x86_64-none-linux-android)
+      when /x86/          then flags += %W(-target i686-none-linux-android)
+      when /mips64/       then flags += %W(-target mips64el-none-linux-android)
+      when /mips/         then flags += %W(-target mipsel-none-linux-android)
       end
-      flags += %W(-Wno-invalid-command-line-argument -Wno-unused-command-line-argument)
     end
-    flags += %W(-ffunction-sections -funwind-tables -fstack-protector-strong -no-canonical-prefixes)
+
+    case arch
+    when /armeabi-v7a/  then flags += %W(-mfpu=#{armeabi_v7a_mfpu} -mfloat-abi=#{armeabi_v7a_mfloat_abi})
+    when /armeabi/      then flags += %W(-mtune=xscale -msoft-float)
+    when /arm64-v8a/    then flags += %W()
+    when /x86_64/       then flags += %W()
+    when /x86/          then flags += %W()
+    when /mips64/       then flags += %W(-fmessage-length=0)
+    when /mips/         then flags += %W(-fmessage-length=0)
+    end
+
+    flags
+  end
+
+  def cflags
+    flags = []
+
+    flags += %W(-MMD -MP -D__android__ -DANDROID --sysroot="#{sysroot}")
+    flags += ctarget
+    case toolchain
+    when :gcc
+    when :clang
+      flags += %W(-gcc-toolchain "#{gcc_toolchain_path.to_s}" -Wno-invalid-command-line-argument -Wno-unused-command-line-argument)
+    end
+    flags += %W(-fpic -ffunction-sections -funwind-tables -fstack-protector-strong -no-canonical-prefixes)
 
     flags
   end
@@ -246,10 +282,14 @@ Set ANDROID_PLATFORM environment variable or set :platform parameter
     flags = []
 
     case toolchain
+    when :gcc
+      case arch
+      when /armeabi-v7a/  then flags += %W(-Wl#{no_warn_mismatch})
+      end
     when :clang
       flags += %W(-gcc-toolchain "#{gcc_toolchain_path.to_s}")
       case arch
-      when /armeabi-v7a/  then flags += %W(-target armv7-none-linux-androideabi -Wl,--fix-cortex-a8)
+      when /armeabi-v7a/  then flags += %W(-target armv7-none-linux-androideabi -Wl,--fix-cortex-a8#{no_warn_mismatch})
       when /armeabi/      then flags += %W(-target armv5te-none-linux-androideabi)
       when /arm64-v8a/    then flags += %W(-target aarch64-none-linux-android)
       when /x86_64/       then flags += %W(-target x86_64-none-linux-android)


### PR DESCRIPTION
As discussed in the comments for PR https://github.com/mruby/mruby/pull/3455#issuecomment-280048567

This adds support for the supplied Android build script to configure the hardware floating point for armeabi-v7a.

````ruby
MRuby::CrossBuild.new('android-armeabi-v7a-neon-hard') do |conf|
  params = { 
    :arch => 'armeabi-v7a', 
    :mfpu => 'neon',
    :mfloat_abi => 'hard',
  }
  toolchain :android, params

  conf.gembox 'default'
end
````

This also adds a new example build script demonstrating this usage.