### PR TITLE
Try Binding class

### DIFF
--- a/mrbgems/mruby-binding/mrbgem.rake
+++ b/mrbgems/mruby-binding/mrbgem.rake
@@ -1,0 +1,7 @@
+MRuby::Gem::Specification.new('mruby-binding') do |spec|
+  spec.license = 'MIT'
+  spec.author  = 'mruby developers'
+  spec.summary = 'Binding class'
+
+  spec.add_dependency('mruby-eval', :core => 'mruby-eval')
+end

--- a/mrbgems/mruby-binding/mrblib/binding.rb
+++ b/mrbgems/mruby-binding/mrblib/binding.rb
@@ -1,0 +1,5 @@
+class Binding
+  def eval(expr, *args)
+    Kernel.eval(expr, self, *args)
+  end
+end

--- a/mrbgems/mruby-binding/src/binding.c
+++ b/mrbgems/mruby-binding/src/binding.c
@@ -1,0 +1,46 @@
+#include "mruby.h"
+#include "mruby/array.h"
+#include "mruby/hash.h"
+#include "mruby/proc.h"
+#include "mruby/variable.h"
+
+mrb_value proc_local_variables(mrb_state *mrb, struct RProc *proc);
+
+static mrb_value
+binding_local_variables(mrb_state *mrb, mrb_value self)
+{
+  struct RProc *proc = mrb_proc_ptr(mrb_iv_get(mrb, self, mrb_intern_lit(mrb, "proc")));
+  return proc_local_variables(mrb, proc);
+}
+
+static mrb_value
+mrb_f_binding(mrb_state *mrb, mrb_value self)
+{
+  struct RObject *obj;
+  mrb_value binding;
+  struct RProc *proc;
+  mrb_int i;
+
+  obj = (struct RObject*)mrb_obj_alloc(mrb, MRB_TT_OBJECT, mrb_class_get(mrb, "Binding"));
+  binding = mrb_obj_value(obj);
+  proc = mrb->c->ci[-1].proc;
+  mrb_iv_set(mrb, binding, mrb_intern_lit(mrb, "proc"), mrb_obj_value(proc));
+  mrb_iv_set(mrb, binding, mrb_intern_lit(mrb, "recv"), self);
+  return binding;
+}
+
+void
+mrb_mruby_binding_gem_init(mrb_state *mrb)
+{
+  struct RClass *binding = mrb_define_class(mrb, "Binding", mrb->object_class);
+  mrb_undef_class_method(mrb, binding, "new");
+
+  mrb_define_method(mrb, mrb->kernel_module, "binding", mrb_f_binding, MRB_ARGS_NONE());
+
+  mrb_define_method(mrb, binding, "local_variables", binding_local_variables, MRB_ARGS_NONE());
+}
+
+void
+mrb_mruby_binding_gem_final(mrb_state *mrb)
+{
+}

--- a/mrbgems/mruby-binding/test/binding.rb
+++ b/mrbgems/mruby-binding/test/binding.rb
@@ -1,0 +1,17 @@
+assert("Kernel.#binding") do
+  assert_kind_of Binding, binding
+end
+
+assert("Binding#local_variables") do
+  block = Proc.new do |a|
+    b = 1
+    binding
+  end
+  assert_equal [:a, :b, :block], block.call(0).local_variables
+end
+
+assert("Binding#eval") do
+  b = nil
+  1.times { x, y, z = 1, 2, 3; [x,y,z]; b = binding }
+  assert_equal([1, 2, 3], b.eval("[x, y, z]"))
+end

--- a/mrbgems/mruby-eval/test/eval.rb
+++ b/mrbgems/mruby-eval/test/eval.rb
@@ -44,7 +44,7 @@ assert('Kernel#eval', '15.3.1.3.12') do
 end
 
 assert('rest arguments of eval') do
-  assert_raise(ArgumentError) { Kernel.eval('0', 0, 'test', 0) }
+  assert_raise(TypeError) { Kernel.eval('0', 0, 'test', 0) }
   assert_equal ['test', 'test.rb', 10] do
     Kernel.eval('[\'test\', __FILE__, __LINE__]', nil, 'test.rb', 10)
   end

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -1129,15 +1129,12 @@ mrb_obj_ceqq(mrb_state *mrb, mrb_value self)
   return mrb_false_value();
 }
 
-static mrb_value
-mrb_local_variables(mrb_state *mrb, mrb_value self)
+mrb_value
+proc_local_variables(mrb_state *mrb, struct RProc *proc)
 {
-  struct RProc *proc;
   mrb_value vars;
   struct mrb_irep *irep;
   size_t i;
-
-  proc = mrb->c->ci[-1].proc;
 
   if (MRB_PROC_CFUNC_P(proc)) {
     return mrb_ary_new(mrb);
@@ -1176,6 +1173,13 @@ mrb_local_variables(mrb_state *mrb, mrb_value self)
 }
 
 mrb_value mrb_obj_equal_m(mrb_state *mrb, mrb_value);
+
+static mrb_value
+mrb_local_variables(mrb_state *mrb, mrb_value self)
+{
+  return proc_local_variables(mrb, mrb->c->ci[-1].proc);
+}
+
 void
 mrb_init_kernel(mrb_state *mrb)
 {


### PR DESCRIPTION
I'm trying to implement CRuby's `Binding` class. 
`Binding#local_variables` is easy.
But I couldn't implement `Binding#eval` because it's too difficult.
It failed in this case.

```rb
class A
  class << self
    def b
      @a = 42
      b = 'local_variable'
      binding
    end
  end
end
p A.b.eval("[@a, b]")
# Expect: [42, "local_variable"]
# Actual(This branch): [42, []]
```

Does anyone have a good idea?