### PR TITLE
String#index shouldn't return nil when "".index ""

### DIFF
--- a/src/string.c
+++ b/src/string.c
@@ -1608,7 +1608,7 @@ mrb_str_index(mrb_state *mrb, mrb_value str)
       return mrb_nil_value();
     }
   }
-  if (pos >= clen) return mrb_nil_value();
+  if (pos > clen) return mrb_nil_value();
   pos = chars2bytes(str, 0, pos);
 
   switch (mrb_type(sub)) {

--- a/test/t/string.rb
+++ b/test/t/string.rb
@@ -402,6 +402,8 @@ assert('String#index', '15.2.10.5.22') do
   assert_equal 0, 'abc'.index('a')
   assert_nil 'abc'.index('d')
   assert_equal 3, 'abcabc'.index('a', 1)
+  assert_equal 5, "hello".index("", 5)
+  assert_equal nil, "hello".index("", 6)
 end
 
 assert('String#initialize', '15.2.10.5.23') do


### PR DESCRIPTION
```
$ cat t.rb
p "".index ""
p "hello".index("", 5)
```

```
$ mruby t.rb
nil
nil
```

```
$ ruby -v t.rb
ruby 2.5.0dev (2017-01-12 trunk 57313) [x86_64-darwin16]
0
5
```

```