### PR TITLE
Avoid setup duplication

### DIFF
--- a/tasks/mrbgem_spec.rake
+++ b/tasks/mrbgem_spec.rake
@@ -48,10 +48,12 @@ module MRuby
         @version = "0.0.0"
         @mrblib_dir = "mrblib"
         @objs_dir = "src"
+        @after_setup = false
         MRuby::Gem.current = self
       end
 
       def setup
+        return nil if @after_setup
         MRuby::Gem.current = self
         MRuby::Build::COMMANDS.each do |command|
           instance_variable_set("@#{command}", @build.send(command).clone)
@@ -90,6 +92,7 @@ module MRuby
         build.libmruby << @objs
 
         instance_eval(&@build_config_initializer) if @build_config_initializer
+        @after_setup = true
       end
 
       def setup_compilers


### PR DESCRIPTION
I encountered build issue.

https://github.com/zzak/mruby-uri/pull/6
https://travis-ci.org/zzak/mruby-uri/jobs/207632178

Strangely, It built twice mruby-onig-regexp.
But, It built once when wrote `conf.gem 'mruby-onig-regexp'` at `build_config.rb`.

Because **mruby-test** called `MRuby::Gem::Specification#setup` to resolve this dependency from here https://github.com/mruby/mruby/blob/63dbed00946afda34178a479cfa38fa78d620a00/mrbgems/mruby-test/mrbgem.rake#L36

But when wrote `conf.gem`, it was skipped.

I think, it doesn't expected behavior.
So, I proposed to avoid setup duplication.

How do you think?

ref https://github.com/mattn/mruby-onig-regexp/pull/53