### PR TITLE
\1 sequences as empty strings

### DIFF
--- a/mrblib/string.rb
+++ b/mrblib/string.rb
@@ -34,6 +34,8 @@ class String
             m
           when "'"
             post
+          when "1", "2", "3", "4", "5", "6", "7", "8", "9"
+            ""
           else
             self[j, 2]
           end

--- a/test/t/string.rb
+++ b/test/t/string.rb
@@ -365,6 +365,7 @@ assert('String#gsub', '15.2.10.5.18') do
   assert_equal('$$a$$',  '##a##'.gsub('##'){|w| '$$' }, 'mruby/mruby#847 another case with block')
   assert_equal('A',      'a'.gsub('a', 'A'))
   assert_equal('A',      'a'.gsub('a'){|w| w.capitalize })
+  assert_equal("<a><><>", 'a'.gsub('a', '<\0><\1><\2>'))
 end
 
 assert('String#gsub with backslash') do


### PR DESCRIPTION
`String#gsub` supports only string pattern argument.
Corresponding captures never used in this case.