### PR TITLE
Fix out-of-bound access

### DIFF
--- a/mrbgems/mruby-sprintf/src/sprintf.c
+++ b/mrbgems/mruby-sprintf/src/sprintf.c
@@ -567,6 +567,7 @@ mrb_str_format(mrb_state *mrb, int argc, const mrb_value *argv, mrb_value fmt)
     mrb_sym id = 0;
 
     for (t = p; t < end && *t != '%'; t++) ;
+    if (t + 1 == end) ++t;
     PUSH(p, t - p);
     if (t >= end)
       goto sprint_exit; /* end of fmt string */

--- a/mrbgems/mruby-sprintf/test/sprintf.rb
+++ b/mrbgems/mruby-sprintf/test/sprintf.rb
@@ -30,3 +30,14 @@ assert("String#% with invalid chr") do
     end
   end
 end
+
+assert("String#% invalid format") do
+  assert_raise ArgumentError do
+    "%?" % ""
+  end
+end
+
+assert("String#% invalid format shared substring") do
+  fmt = ("x"*30+"%!")[0...-1]
+  assert_equal fmt, sprintf(fmt, "")
+end


### PR DESCRIPTION
Get rid of out-of-bound access when single % at the end.

The latter test case doesn't fail with cruby, because shared sub-strings are not allowed in the middle, right now.