### PR TITLE
Some update for `String#each_line`

### DIFF
--- a/mrblib/string.rb
+++ b/mrblib/string.rb
@@ -9,12 +9,15 @@ class String
   # and pass the respective line.
   #
   # ISO 15.2.10.5.15
-  def each_line(&block)
+  def each_line(rs = "\n", &block)
+    return block.call(self) if rs.nil?
+    rs = rs.to_str
     offset = 0
+    rs_len = rs.length
     this = dup
-    while pos = this.index("\n", offset)
-      block.call(this[offset, pos + 1 - offset])
-      offset = pos + 1
+    while pos = this.index(rs, offset)
+      block.call(this[offset, pos + rs_len - offset])
+      offset = pos + rs_len
     end
     block.call(this[offset, this.size - offset]) if this.size > offset
     self

--- a/mrblib/string.rb
+++ b/mrblib/string.rb
@@ -11,11 +11,12 @@ class String
   # ISO 15.2.10.5.15
   def each_line(&block)
     offset = 0
-    while pos = self.index("\n", offset)
-      block.call(self[offset, pos + 1 - offset])
+    this = dup
+    while pos = this.index("\n", offset)
+      block.call(this[offset, pos + 1 - offset])
       offset = pos + 1
     end
-    block.call(self[offset, self.size - offset]) if self.size > offset
+    block.call(this[offset, this.size - offset]) if this.size > offset
     self
   end
 

--- a/mrblib/string.rb
+++ b/mrblib/string.rb
@@ -10,6 +10,7 @@ class String
   #
   # ISO 15.2.10.5.15
   def each_line(rs = "\n", &block)
+    return to_enum(:each_line, rs, &block) unless block
     return block.call(self) if rs.nil?
     rs = rs.to_str
     offset = 0

--- a/test/t/string.rb
+++ b/test/t/string.rb
@@ -341,6 +341,12 @@ assert('String#each_line', '15.2.10.5.15') do
   end
 
   assert_equal list, n_list
+
+  n_list.clear
+  a.each_line("li") do |line|
+    n_list << line
+  end
+  assert_equal ["first li", "ne\nsecond li", "ne\nthird li", "ne"], n_list
 end
 
 assert('String#empty?', '15.2.10.5.16') do


### PR DESCRIPTION
- Use duplicated object for block args
- Suuport custom separator
- Support to return enumerator when no block given