### PR TITLE
MiniRake::Task#timestamp should use Time.now only

### DIFF
--- a/minirake
+++ b/minirake
@@ -113,8 +113,7 @@ module MiniRake
     # Timestamp for this task.  Basic tasks return the current time for
     # their time stamp.  Other tasks can be more sophisticated.
     def timestamp
-      prerequisites = @prerequisites.collect{ |n| n.is_a?(Proc) ? n.call(name) : n }.flatten
-      prerequisites.collect { |n| Task[n].timestamp }.max || Time.now
+      Time.now
     end
 
     # Class Methods ----------------------------------------------------


### PR DESCRIPTION
```rb
$ cat t.rake
require 'fileutils'

file "a.txt" do |t|
  p t.name
  FileUtils.touch(t.name)
end

task "b.txt" => "a.txt" do |t|
  p t.name
  FileUtils.touch(t.name)
end

file "c.txt" => "b.txt" do |t|
  p t.name
  FileUtils.touch(t.name)
end
```

```
$ rm -f {a,b,c}.txt

$ rake c.txt -f t.rake
"a.txt"
"b.txt"
"c.txt"

$ rake c.txt -f t.rake
"b.txt"
"c.txt"

$ rake c.txt -f t.rake
"b.txt"
"c.txt"

$ ./minirake c.txt -f t.rake
(in /Users/ksss/src/github.com/ksss/mruby)
"b.txt"

$ touch b.txt

$ ./minirake c.txt -f t.rake
(in /Users/ksss/src/github.com/ksss/mruby)
"b.txt"

$ rake c.txt -f t.rake
"b.txt"
"c.txt"
```

I think, minirake should call "c.txt" file task block
