### PR TITLE
sprintf: Should use mrb_int for any object

### DIFF
--- a/mrbgems/mruby-sprintf/src/sprintf.c
+++ b/mrbgems/mruby-sprintf/src/sprintf.c
@@ -221,7 +221,7 @@ check_name_arg(mrb_state *mrb, int posarg, const char *name, int len)
     tmp_v = GETNEXTARG(); \
     p = t; \
   } \
-  num = mrb_fixnum(tmp_v); \
+  num = mrb_int(mrb, tmp_v); \
 } while (0)
 
 static mrb_value


### PR DESCRIPTION
```
$ cat t.rb
o=Object.new
def o.to_int
  1
end
p "%*d" % [o, 1]
```

```
$ ruby t.rb
"1"

$ mruby t.rb
# prints very long white space....
```

The cause is that `mrb_fixnum` calls with any object(e.g. MRB_TT_OBJECT).