### PR TITLE
Replaced PRId64 with PRIdPTR for intptr_t snprintf

### DIFF
--- a/mrbgems/mruby-compiler/core/codegen.c
+++ b/mrbgems/mruby-compiler/core/codegen.c
@@ -2199,7 +2199,7 @@ codegen(codegen_scope *s, node *tree, int val)
       char buf[32];
       int sym;
 
-      snprintf(buf, sizeof(buf), "$%" PRId64, (intptr_t)tree);
+      snprintf(buf, sizeof(buf), "$%" PRIdPTR, (intptr_t)tree);
       sym = new_sym(s, mrb_intern_cstr(mrb, buf));
       genop(s, MKOP_ABx(OP_GETGLOBAL, cursp(), sym));
       push();

--- a/mrbgems/mruby-compiler/core/codegen.c
+++ b/mrbgems/mruby-compiler/core/codegen.c
@@ -2199,7 +2199,7 @@ codegen(codegen_scope *s, node *tree, int val)
       char buf[32];
       int sym;
 
-      snprintf(buf, sizeof(buf), "$%" PRIdPTR, (intptr_t)tree);
+      snprintf(buf, sizeof(buf), "$%d", (int)tree);
       sym = new_sym(s, mrb_intern_cstr(mrb, buf));
       genop(s, MKOP_ABx(OP_GETGLOBAL, cursp(), sym));
       push();

--- a/mrbgems/mruby-compiler/core/codegen.c
+++ b/mrbgems/mruby-compiler/core/codegen.c
@@ -2199,7 +2199,7 @@ codegen(codegen_scope *s, node *tree, int val)
       char buf[32];
       int sym;
 
-      snprintf(buf, sizeof(buf), "$%d", (int)tree);
+      snprintf(buf, sizeof(buf), "$%d", (int)(intptr_t)tree);
       sym = new_sym(s, mrb_intern_cstr(mrb, buf));
       genop(s, MKOP_ABx(OP_GETGLOBAL, cursp(), sym));
       push();


### PR DESCRIPTION
https://github.com/mruby/mruby/commit/3703aed7ab7c056ef7a58fd8d25b84b59f715dad introduced the warning https://github.com/mruby/mruby/issues/3492#issuecomment-287977542

> mruby/mrbgems/mruby-compiler/core/codegen.c:2202:47:
> warning: format specifies type 'long long' but the argument has type 'intptr_t' (aka 'long') [-Wformat]
> snprintf(buf, sizeof(buf), "$%" PRId64, (intptr_t)tree);

PRIdPTR fixes this  (expands to the correct format for intptr_t)