### PR TITLE
Fix lost lineno

### DIFF
--- a/mrbgems/mruby-kernel-ext/test/kernel.rb
+++ b/mrbgems/mruby-kernel-ext/test/kernel.rb
@@ -6,6 +6,7 @@ end
 assert('Kernel.caller, Kernel#caller') do
   skip "backtrace isn't available" if caller(0).empty?
 
+  caller_lineno = __LINE__ + 3
   c = Class.new do
     def foo(*args)
       caller(*args)
@@ -19,6 +20,7 @@ assert('Kernel.caller, Kernel#caller') do
       bar(*args)
     end
   end
+  assert_equal "kernel.rb:#{caller_lineno}:in Object#foo", c.new.baz(0)[0][-26..-1]
   assert_equal "#bar", c.new.baz[0][-4..-1]
   assert_equal "#foo", c.new.baz(0)[0][-4..-1]
   assert_equal "#bar", c.new.baz(1)[0][-4..-1]

--- a/src/backtrace.c
+++ b/src/backtrace.c
@@ -81,6 +81,7 @@ get_backtrace_i(mrb_state *mrb, struct backtrace_location *loc, void *data)
 
   str = mrb_str_new_cstr(mrb, loc->filename);
   snprintf(buf, sizeof(buf), ":%d", loc->lineno);
+  mrb_str_cat_cstr(mrb, str, buf);
 
   if (loc->method) {
     mrb_str_cat_lit(mrb, str, ":in ");


### PR DESCRIPTION
`Kernel#caller` result lost lineno from https://github.com/mruby/mruby/commit/dcf6a413cab097e39d2d883d7c8c297d29ea43b8 .
Maybe, @matz forgot to fix it.