### PR TITLE
Should raise FloatDomainError

### DIFF
--- a/mrbgems/mruby-time/src/time.c
+++ b/mrbgems/mruby-time/src/time.c
@@ -211,16 +211,7 @@ mrb_time_wrap(mrb_state *mrb, struct RClass *tc, struct mrb_time *tm)
   return mrb_obj_value(Data_Wrap_Struct(mrb, tc, &mrb_time_type, tm));
 }
 
-static void
-check_num_exact(mrb_state *mrb, double num)
-{
-  if (isinf(num)) {
-    mrb_raise(mrb, E_FLOATDOMAIN_ERROR, num < 0 ? "-Infinity" : "Infinity");
-  }
-  if (isnan(num)) {
-    mrb_raise(mrb, E_FLOATDOMAIN_ERROR, "NaN");
-  }
-}
+void mrb_check_num_exact(mrb_state *mrb, mrb_float num);
 
 /* Allocates a mrb_time object and initializes it. */
 static struct mrb_time*
@@ -229,8 +220,8 @@ time_alloc(mrb_state *mrb, double sec, double usec, enum mrb_timezone timezone)
   struct mrb_time *tm;
   time_t tsec = 0;
 
-  check_num_exact(mrb, sec);
-  check_num_exact(mrb, usec);
+  mrb_check_num_exact(mrb, (mrb_float)sec);
+  mrb_check_num_exact(mrb, (mrb_float)usec);
 
   if (sizeof(time_t) == 4 && (sec > (double)INT32_MAX || (double)INT32_MIN > sec)) {
     goto out_of_range;

--- a/src/numeric.c
+++ b/src/numeric.c
@@ -610,6 +610,17 @@ flo_round(mrb_state *mrb, mrb_value num)
   return mrb_fixnum_value((mrb_int)number);
 }
 
+void
+mrb_check_num_exact(mrb_state *mrb, mrb_float num)
+{
+  if (isinf(num)) {
+    mrb_raise(mrb, E_FLOATDOMAIN_ERROR, num < 0 ? "-Infinity" : "Infinity");
+  }
+  if (isnan(num)) {
+    mrb_raise(mrb, E_FLOATDOMAIN_ERROR, "NaN");
+  }
+}
+
 /* 15.2.9.3.14 */
 /* 15.2.9.3.15 */
 /*
@@ -630,6 +641,7 @@ flo_truncate(mrb_state *mrb, mrb_value num)
   if (f < 0.0) f = ceil(f);
 
   if (!FIXABLE(f)) {
+    mrb_check_num_exact(mrb, f);
     return mrb_float_value(mrb, f);
   }
   return mrb_fixnum_value((mrb_int)f);

--- a/test/t/float.rb
+++ b/test/t/float.rb
@@ -148,6 +148,9 @@ end
 
 assert('Float#to_i', '15.2.9.3.14') do
   assert_equal(3, 3.123456789.to_i)
+  assert_raise(FloatDomainError) { Float::INFINITY.to_i }
+  assert_raise(FloatDomainError) { (-Float::INFINITY).to_i }
+  assert_raise(FloatDomainError) { Float::NAN.to_i }
 end
 
 assert('Float#truncate', '15.2.9.3.15') do


### PR DESCRIPTION
I'm concerned about this use case.

```c
mrb_value v = mrb_funcall(mrb, num, "to_i", 0)
mrb_int i = mrb_fixnum(v);

if (i == 0) {
  // ...
```

example: https://github.com/iij/mruby-pack/blob/88a7fedea413568a1ff0410e109ff55a03b63a5f/src/pack.c#L1022

If `num` is `Float::INFINITY`, then `i` is `0`.
But I think, It's not expected value.

This behavior is compatible with CRuby.

```
$ ruby -e 'Float::INFINITY.to_i'
	from -e:1:in `<main>'
-e:1:in `to_i': Infinity (FloatDomainError)
```