### PR TITLE
Fix Enumerator#each_with_index with block

### DIFF
--- a/mrbgems/mruby-enumerator/mrblib/enumerator.rb
+++ b/mrbgems/mruby-enumerator/mrblib/enumerator.rb
@@ -177,8 +177,8 @@ class Enumerator
   #
   # If no block is given, a new Enumerator is returned that includes the index.
   #
-  def each_with_index
-    with_index
+  def each_with_index(&block)
+    with_index(0, &block)
   end
 
   ##

--- a/mrbgems/mruby-enumerator/test/enumerator.rb
+++ b/mrbgems/mruby-enumerator/test/enumerator.rb
@@ -65,6 +65,13 @@ assert 'Enumerator#with_index string offset' do
   assert_raise(TypeError){ @obj.to_enum(:foo, 1, 2, 3).with_index('1').to_a }
 end
 
+assert 'Enumerator#each_with_index' do
+  assert_equal([[1,0],[2,1],[3,2]], @obj.to_enum(:foo, 1, 2, 3).each_with_index.to_a)
+  a = []
+  @obj.to_enum(:foo, 1, 2, 3).each_with_index {|*i| a << i}
+  assert_equal([[1, 0], [2, 1], [3, 2]], a)
+end
+
 assert 'Enumerator#with_object' do
   obj = [0, 1]
   ret = (1..10).each.with_object(obj) {|i, memo|


### PR DESCRIPTION
In previous version,

```
a = [3, 2, 1]
e = a.each
e.sort_by(&:to_i) # => []
```

In this version,

```
a = [3, 2, 1]
e = a.each
e.sort_by(&:to_i) # => [1, 2, 3]
```