### PR TITLE
Fix parameters when noname rest

### DIFF
--- a/mrbgems/mruby-proc-ext/src/proc.c
+++ b/mrbgems/mruby-proc-ext/src/proc.c
@@ -140,14 +140,16 @@ mrb_proc_parameters(mrb_state *mrb, mrb_value self)
   parameters_list[4].size = MRB_ASPEC_BLOCK(aspec);
 
   parameters = mrb_ary_new_capa(mrb, irep->nlocals-1);
+
   for (i = 0, p = parameters_list; p->name; p++) {
     mrb_value sname = mrb_symbol_value(mrb_intern_cstr(mrb, p->name));
     for (j = 0; j < p->size; i++, j++) {
-      mrb_assert(i < (irep->nlocals-1));
-      mrb_ary_push(mrb, parameters, mrb_assoc_new(mrb,
-        sname,
-        mrb_symbol_value(irep->lv[i].name)
-      ));
+      mrb_value a = mrb_ary_new(mrb);
+      mrb_ary_push(mrb, a, sname);
+      if (irep->lv[i].name) {
+        mrb_ary_push(mrb, a, mrb_symbol_value(irep->lv[i].name));
+      }
+      mrb_ary_push(mrb, parameters, a);
     }
   }
   return parameters;

--- a/mrbgems/mruby-proc-ext/src/proc.c
+++ b/mrbgems/mruby-proc-ext/src/proc.c
@@ -110,7 +110,7 @@ mrb_proc_parameters(mrb_state *mrb, mrb_value self)
   const struct RProc *proc = mrb_proc_ptr(self);
   const struct mrb_irep *irep = proc->body.irep;
   mrb_aspec aspec;
-  mrb_value parameters;
+  mrb_value sname, parameters;
   int i, j;
 
   if (MRB_PROC_CFUNC_P(proc)) {
@@ -142,7 +142,8 @@ mrb_proc_parameters(mrb_state *mrb, mrb_value self)
   parameters = mrb_ary_new_capa(mrb, irep->nlocals-1);
 
   for (i = 0, p = parameters_list; p->name; p++) {
-    mrb_value sname = mrb_symbol_value(mrb_intern_cstr(mrb, p->name));
+    if (p->size <= 0) continue;
+    sname = mrb_symbol_value(mrb_intern_cstr(mrb, p->name));
     for (j = 0; j < p->size; i++, j++) {
       mrb_value a = mrb_ary_new(mrb);
       mrb_ary_push(mrb, a, sname);

--- a/mrbgems/mruby-proc-ext/test/proc.rb
+++ b/mrbgems/mruby-proc-ext/test/proc.rb
@@ -53,6 +53,7 @@ assert('Proc#parameters') do
   assert_equal([[:req, :a]], lambda {|a|}.parameters)
   assert_equal([[:opt, :a]], lambda {|a=nil|}.parameters)
   assert_equal([[:req, :a]], ->(a){}.parameters)
+  assert_equal([[:rest]], lambda { |*| }.parameters)
   assert_equal([[:rest, :a]], Proc.new {|*a|}.parameters)
   assert_equal([[:opt, :a], [:opt, :b], [:opt, :c], [:opt, :d], [:rest, :e], [:opt, :f], [:opt, :g], [:block, :h]], Proc.new {|a,b,c=:c,d=:d,*e,f,g,&h|}.parameters)
   assert_equal([[:req, :a], [:req, :b], [:opt, :c], [:opt, :d], [:rest, :e], [:req, :f], [:req, :g], [:block, :h]], lambda {|a,b,c=:c,d=:d,*e,f,g,&h|}.parameters)


### PR DESCRIPTION
```rb
p lambda { |*| }.parameters
# Actual => [[:rest, :""]]
# Expect => [[:rest]]
```