### PR TITLE
Change AppVeyor's clone_depth

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ version: "{build}"
 
 os: Visual Studio 2015
 
-clone_depth: 1
+clone_depth: 50
 
 
 environment:


### PR DESCRIPTION
A too small depth size will fail ```git checkout``` in the old AppVeyor's CI Queue.
This commit change the depth size from 1 to 50(Travis CI's default).