### PR TITLE
Correctly handle large negative usec value.

### DIFF
--- a/mrbgems/mruby-time/src/time.c
+++ b/mrbgems/mruby-time/src/time.c
@@ -245,7 +245,7 @@ time_alloc(mrb_state *mrb, double sec, double usec, enum mrb_timezone timezone)
     tm->usec -= sec2 * 1000000;
     tm->sec += sec2;
   }
-  if (tm->usec >= 1000000) {
+  else if (tm->usec >= 1000000) {
     long sec2 = usec / 1000000;
     tm->usec -= sec2 * 1000000;
     tm->sec += sec2;


### PR DESCRIPTION
@matz The fix for https://github.com/mruby/mruby/issues/3561 produces incorrect results when `usec` is a large negative value:
```
> Time.at(0, -1e16)
 => Fri Mar 23 07:26:39 1336
```
The correct value (as reported by CRuby) is:
```
irb(main):001:0> Time.at(0, -1e16)
=> 1653-02-10 01:13:20 -0500
```

The reason for this is that floating point inaccuracy can leave `tm->usec` with a value that is larger than 1000000 after the first `if` statement, which causes the second `if` statement to execute as well. To solve this problem, I've added an `else` so that only one of the cases can execute. This produces the correct result:
```
> Time.at(0, -1e16)
 => Mon Feb 10 01:13:19 1653
```