### PR TITLE
Get constant of parent class even if child class is defined in signle…

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -127,10 +127,19 @@ MRB_API struct RClass*
 mrb_class_outer_module(mrb_state *mrb, struct RClass *c)
 {
   mrb_value outer;
+  struct RClass *cls;
 
   outer = mrb_obj_iv_get(mrb, (struct RObject*)c, mrb_intern_lit(mrb, "__outer__"));
   if (mrb_nil_p(outer)) return NULL;
-  return mrb_class_ptr(outer);
+  cls = mrb_class_ptr(outer);
+  if (cls->tt == MRB_TT_SCLASS)
+  {
+    mrb_value klass;
+    klass = mrb_obj_iv_get(mrb, (struct RObject *)cls,
+                           mrb_intern_lit(mrb, "__attached__"));
+    cls = mrb_class_ptr(klass);
+  }
+  return cls;
 }
 
 static void

--- a/test/t/class.rb
+++ b/test/t/class.rb
@@ -410,6 +410,20 @@ assert('class variable in module and class << self style class method') do
   assert_equal("value", ClassVariableInModuleTest.class_variable)
 end
 
+assert('child class/module defined in singleton class get parent constant') do
+  actual = module GetParentConstantTest
+            EXPECT = "value"
+            class << self
+              class CHILD
+                class << self
+                    EXPECT
+                end
+              end
+            end
+          end
+  assert_equal("value", actual)
+end
+
 assert('overriding class variable with a module (#3235)') do
   module ModuleWithCVar
     @@class_variable = 1


### PR DESCRIPTION
…ton class; fix #3575