### PR TITLE
Fix an off-by-one causing a buffer overflow in mirb.

### DIFF
--- a/mrbgems/mruby-bin-mirb/tools/mirb/mirb.c
+++ b/mrbgems/mruby-bin-mirb/tools/mirb/mirb.c
@@ -442,7 +442,7 @@ main(int argc, char **argv)
     char_index = 0;
     while ((last_char = getchar()) != '\n') {
       if (last_char == EOF) break;
-      if (char_index > sizeof(last_code_line)-2) {
+      if (char_index >= sizeof(last_code_line)-2) {
         fputs("input string too long\n", stderr);
         continue;
       }


### PR DESCRIPTION
If MRuby is built without libreadline, then a buffer overflow occurs in mirb when a line 1023 characters or longer is read:
```
$ ruby -e 'puts "0"*1023' | bin/mirb
mirb - Embeddable Interactive Ruby Shell

> Segmentation fault (core dumped)
```
This happens because mirb reads into a 1024-byte buffer, but doesn't leave enough space for the `\n` and `\0` that will be appended to the input. This PR fixes the off-by one.

This issue was reported by https://hackerone.com/geeknik