### PR TITLE
Check if sc->mt is initialized before copying it.

### DIFF
--- a/src/kernel.c
+++ b/src/kernel.c
@@ -241,7 +241,12 @@ copy_class(mrb_state *mrb, mrb_value dst, mrb_value src)
     c1->super = mrb_class_ptr(mrb_obj_dup(mrb, mrb_obj_value(c0)));
     c1->super->flags |= MRB_FLAG_IS_ORIGIN;
   }
-  dc->mt = kh_copy(mt, mrb, sc->mt);
+  if (sc->mt) {
+    dc->mt = kh_copy(mt, mrb, sc->mt);
+  }
+  else {
+    dc->mt = kh_init(mt, mrb);
+  }
   dc->super = sc->super;
   MRB_SET_INSTANCE_TT(dc, MRB_INSTANCE_TT(sc));
 }


### PR DESCRIPTION
The following input demonstrates a null pointer dereference:
```ruby
class X < Module
  def initialize
  end
end

X.new.clone
```
ASAN report:
```
==27567==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000000 (pc 0x000105e43143 bp 0x7fff59ddab50 sp 0x7fff59ddaa80 T0)
==27567==The signal is caused by a READ memory access.
==27567==Hint: address points to the zero page.
    #0 0x105e43142 in kh_copy_mt class.c:19
    #1 0x105ed2315 in copy_class kernel.c:244
    #2 0x105ebf207 in init_copy kernel.c:255
    #3 0x105ebd840 in mrb_obj_clone kernel.c:315
    #4 0x105f8c618 in mrb_vm_exec vm.c:1279
    #5 0x105f8179f in mrb_vm_run vm.c:829
    #6 0x105fb48b9 in mrb_top_run vm.c:2674
    #7 0x106085ba5 in mrb_load_exec parse.y:5780
    #8 0x1060864f5 in mrb_load_file_cxt parse.y:5789
    #9 0x105e1d9e6 in main mruby.c:227
    #10 0x7fffbbbba234 in start (libdyld.dylib:x86_64+0x5234)

==27567==Register values:
rax = 0x0000000000000000  rbx = 0x00007fff59ddac40  rcx = 0x0000000000000000  rdx = 0x0000100000000000
rdi = 0x000061400001b100  rsi = 0x0000100000000000  rbp = 0x00007fff59ddab50  rsp = 0x00007fff59ddaa80
 r8 = 0x00001c0800003d3c   r9 = 0x0000100000000000  r10 = 0x0000000000000080  r11 = 0x0000000000000000
r12 = 0xf2f20000f1f1f1f1  r13 = 0x00001fffeb3bc470  r14 = 0x00007fff59ddac00  r15 = 0x00007fff59ddac20
AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: SEGV class.c:19 in kh_copy_mt
==27567==ABORTING
Abort trap: 6
```
This occurs because `copy_class` does not check whether `sc->mt` is initialized before copying it. I've fixed this by adding a check similar to the one already present in `mrb_singleton_class_clone`: https://github.com/mruby/mruby/blob/79e0314337f64bf48b280197f112070011a3619a/src/kernel.c#L213-L218

This issue was reported by https://hackerone.com/ssarong