### PR TITLE
Align pool allocator with 8 byte in 64-bit environment.

### DIFF
--- a/src/pool.c
+++ b/src/pool.c
@@ -13,7 +13,11 @@
 /* allocated memory address should be multiple of POOL_ALIGNMENT */
 /* or undef it if alignment does not matter */
 #ifndef POOL_ALIGNMENT
+#if INTPTR_MAX == INT64_MAX
+#define POOL_ALIGNMENT 8
+#else
 #define POOL_ALIGNMENT 4
+#endif
 #endif
 /* page size of memory pool */
 #ifndef POOL_PAGE_SIZE


### PR DESCRIPTION
To avoid warnings from undefined behavior sanitizer.
( https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html )