### PR TITLE
Add missing `arg_i++` to fix bug of `s!` in mrb_get_args.

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -696,7 +696,7 @@ mrb_get_args(mrb_state *mrb, const char *format, ...)
           if (i < argc && mrb_nil_p(ARGV[arg_i])) {
             *ps = NULL;
             *pl = 0;
-            i++;
+            i++; arg_i++;
             break;
           }
         }


### PR DESCRIPTION
BTW, isn't `arg_i` and `i` always same in `mrb_get_args`?
I don't want two same variables if those are always same.