### PR TITLE
Add --libmruby-path support to mruby-bin-mruby-config.

### DIFF
--- a/mrbgems/mruby-bin-mruby-config/mrbgem.rake
+++ b/mrbgems/mruby-bin-mruby-config/mrbgem.rake
@@ -23,7 +23,7 @@ MRuby.each_target do
     FileUtils.copy "#{File.dirname(__FILE__)}/#{mruby_config}", t.name
     config = Hash[open("#{build_dir}/lib/libmruby.flags.mak").read.split("\n").map {|x| a = x.split(/\s*=\s*/, 2); [a[0], a[1].gsub('\\"', '"') ]}]
     IO.write(t.name, File.open(t.name) {|f|
-      f.read.gsub (/echo (MRUBY_CFLAGS|MRUBY_LIBS|MRUBY_LDFLAGS_BEFORE_LIBS|MRUBY_LDFLAGS)/) {|x| config[$1].empty? ? '' : "echo #{config[$1]}"}
+      f.read.gsub (/echo (MRUBY_CFLAGS|MRUBY_LIBS|MRUBY_LDFLAGS_BEFORE_LIBS|MRUBY_LDFLAGS|MRUBY_LIBMRUBY_PATH)/) {|x| config[$1].empty? ? '' : "echo #{config[$1]}"}
     })
     FileUtils.chmod(0755, t.name)
   end

--- a/mrbgems/mruby-bin-mruby-config/mruby-config
+++ b/mrbgems/mruby-bin-mruby-config/mruby-config
@@ -6,12 +6,14 @@ while [ $# -gt 0 ]; do
     --ldflags) echo MRUBY_LDFLAGS;;
     --ldflags-before-libs) echo MRUBY_LDFLAGS_BEFORE_LIBS;;
     --libs) echo MRUBY_LIBS;;
+    --libmruby-path) echo MRUBY_LIBMRUBY_PATH;;
     --help) echo "Usage: mruby-config [switches]"
             echo "  switches:"
             echo "  --cflags                    print flags passed to compiler"
             echo "  --ldflags                   print flags passed to linker"
             echo "  --ldflags-before-libs       print flags passed to linker before linked libraries"
             echo "  --libs                      print linked libraries"
+            echo "  --libmruby-path             print libmruby path"
             exit 0;;
   esac
   shift

--- a/mrbgems/mruby-bin-mruby-config/mruby-config.bat
+++ b/mrbgems/mruby-bin-mruby-config/mruby-config.bat
@@ -7,6 +7,7 @@ if "%0" equ "--cflags" goto cflags
 if "%0" equ "--ldflags" goto ldflags
 if "%0" equ "--ldflags-before-libs" goto ldflagsbeforelibs
 if "%0" equ "--libs" goto libs
+if "%0" equ "--libmruby-path" goto libmrubypath
 if "%0" equ "--help" goto showhelp
 echo Invalid Option
 goto :eof
@@ -27,6 +28,10 @@ goto top
 echo MRUBY_LDFLAGS_BEFORE_LIBS
 goto top
 
+:libmrubypath
+echo MRUBY_LIBMRUBY_PATH
+goto top
+
 :showhelp
 echo Usage: mruby-config [switches]
 echo   switches:
@@ -34,3 +39,4 @@ echo   --cflags                   print flags passed to compiler
 echo   --ldflags                  print flags passed to linker
 echo   --ldflags-before-libs      print flags passed to linker before linked libraries
 echo   --libs                     print linked libraries
+echo   --libmruby-path            print libmruby path

--- a/tasks/libmruby.rake
+++ b/tasks/libmruby.rake
@@ -16,6 +16,8 @@ MRuby.each_target do
 
       gem_libraries = gems.map { |g| g.linker.libraries }
       f.puts "MRUBY_LIBS = #{linker.option_library % 'mruby'} #{linker.library_flags(gem_libraries)}"
+
+      f.puts "MRUBY_LIBMRUBY_PATH = #{libfile("#{build_dir}/lib/libmruby")}"
     end
   end
   task :all => "#{build_dir}/lib/libmruby.flags.mak"


### PR DESCRIPTION
It makes possible to add dependency to libmruby	to my app's Makefile as	below:

```
LIBMRUBY_PATH=`mruby-config --libmruby-path`

myapp : $(OBJS) $(LIBMRUBY_PATH)
	# link stuff
```