### PR TITLE
Fix embedded document with unterminated terminator

### DIFF
--- a/mrbgems/mruby-compiler/bintest/mrbc.rb
+++ b/mrbgems/mruby-compiler/bintest/mrbc.rb
@@ -19,3 +19,12 @@ assert('parsing function with void argument') do
   assert_equal "#{cmd('mrbc')}:#{a.path}:Syntax OK", result.chomp
   assert_equal 0, $?.exitstatus
 end
+
+assert('embedded document with invalid terminator') do
+  a, out = Tempfile.new('a.rb'), Tempfile.new('out.mrb')
+  a.write("=begin\n=endx\n")
+  a.flush
+  result = `#{cmd('mrbc')} -c -o #{out.path} #{a.path} 2>&1`
+  assert_equal "#{a.path}:3:0: embedded document meets end of file", result.chomp
+  assert_equal 1, $?.exitstatus
+end

--- a/mrbgems/mruby-compiler/core/parse.y
+++ b/mrbgems/mruby-compiler/core/parse.y
@@ -3580,7 +3580,7 @@ skips(parser_state *p, const char *s)
     /* skip until first char */
     for (;;) {
       c = nextc(p);
-      if (c < 0) return c;
+      if (c < 0) return FALSE;
       if (c == '\n') {
         p->lineno++;
         p->column = 0;


### PR DESCRIPTION
`skips()` is `mrb_bool` function, should return `FALSE` at EOF, not `EOF`.