### PR TITLE
Restore 32-bit OSX builds

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -118,16 +118,16 @@ static inline void
 envadjust(mrb_state *mrb, mrb_value *oldbase, mrb_value *newbase)
 {
   mrb_callinfo *ci = mrb->c->cibase;
-  ptrdiff_t off;
 
   if (newbase == oldbase) return;
-  off = newbase - oldbase;
   while (ci <= mrb->c->ci) {
     struct REnv *e = ci->env;
     if (e && MRB_ENV_STACK_SHARED_P(e)) {
-      e->stack += off;
+      ptrdiff_t off = e->stack - oldbase;
+
+      e->stack = newbase + off;
     }
-    ci->stackent += off;
+    ci->stackent = newbase + (ci->stackent - oldbase);
     ci++;
   }
 }


### PR DESCRIPTION
This reverts commit a1d32af91692c2b624e9c04fcd94aa958dbba626.

I am unsure about specifics of this change, but it seems to break building 32-bit version of mruby on my OSX setup:

```
Process 46763 launched: './mruby/build/test-32bit/bin/mrbtest' (i386)
mrbtest - Embeddable Ruby Test

Process 46763 stopped
* thread #1: tid = 0xeb10d8, 0x00056500 mrbtest`mrb_class(mrb=0x01900000, v=mrb_value @ 0xbfffe9d4) + 192 at class.h:50, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=1, address=0x4)
    frame #0: 0x00056500 mrbtest`mrb_class(mrb=0x01900000, v=mrb_value @ 0xbfffe9d4) + 192 at class.h:50
   47  	  case MRB_TT_ENV:
   48  	    return NULL;
   49  	  default:
-> 50  	    return mrb_obj_ptr(v)->c;
   51  	  }
   52  	}
   53  	
(lldb) bt
* thread #1: tid = 0xeb10d8, 0x00056500 mrbtest`mrb_class(mrb=0x01900000, v=mrb_value @ 0xbfffe9d4) + 192 at class.h:50, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=1, address=0x4)
  * frame #0: 0x00056500 mrbtest`mrb_class(mrb=0x01900000, v=mrb_value @ 0xbfffe9d4) + 192 at class.h:50
    frame #1: 0x00059176 mrbtest`mrb_vm_exec(mrb=0x01900000, proc=0x028069b8, pc=0x0021fed8) + 6198 at vm.c:1257
    frame #2: 0x000578fc mrbtest`mrb_vm_run(mrb=0x01900000, proc=0x02803940, self=mrb_value @ 0xbffff53c, stack_keep=4) + 188 at vm.c:857
    frame #3: 0x0006074b mrbtest`mrb_top_run(mrb=0x01900000, proc=0x02803940, self=mrb_value @ 0xbffff5ac, stack_keep=0) + 139 at vm.c:2730
    frame #4: 0x00036593 mrbtest`mrb_load_irep_cxt(mrb=0x01900000, bin="ETIR0003\x17?, c=0x00000000) + 291 at load.c:638
    frame #5: 0x00036805 mrbtest`mrb_load_irep(mrb=0x01900000, bin="ETIR0003\x17?) + 53 at load.c:644
    frame #6: 0x00004905 mrbtest`GENERATED_TMP_mrb_mruby_sprintf_gem_test(mrb=0x00500190) + 7349 at gem_test.c:309
    frame #7: 0x00002b6f mrbtest`mrbgemtest_init(mrb=0x00500190) + 111 at mrbtest.c:86
    frame #8: 0x00002abc mrbtest`mrb_init_mrbtest(mrb=0x00500190) + 332 at mrbtest.c:38
    frame #9: 0x0000273e mrbtest`main(argc=1, argv=0xbffff7f4) + 206 at driver.c:167
    frame #10: 0x994ba6ad libdyld.dylib`start + 1
```

You can test the config by trying to build `mruby-float4` on OSX (https://github.com/dabroz/mruby-float4.git -> `rake test`).