### PR TITLE
Fix segmentation fault ref: #3648

### DIFF
--- a/mrbgems/mruby-sprintf/src/sprintf.c
+++ b/mrbgems/mruby-sprintf/src/sprintf.c
@@ -982,15 +982,17 @@ retry:
         }
         if (dots) PUSH("..", 2);
 
-        if (v < 0) {
-          char c = sign_bits(base, p);
-          FILL(c, prec - len);
+        if (prec > len) {
+          CHECK(prec - len);
+          if (v < 0) {
+            char c = sign_bits(base, p);
+            FILL(c, prec - len);
+          }
+          else if ((flags & (FMINUS|FPREC)) != FMINUS) {
+            char c = '0';
+            FILL(c, prec - len);
+          }
         }
-        else if ((flags & (FMINUS|FPREC)) != FMINUS) {
-          char c = '0';
-          FILL(c, prec - len);
-        }
-
         PUSH(s, len);
         if (width > 0) {
           FILL(' ', width);

--- a/mrbgems/mruby-sprintf/test/sprintf.rb
+++ b/mrbgems/mruby-sprintf/test/sprintf.rb
@@ -87,6 +87,10 @@ assert("String#% with invalid chr") do
   end
 end
 
+assert("String#% %b") do
+  assert_equal("..10115", "%0b5" % -5)
+end
+
 assert("String#% invalid format") do
   assert_raise ArgumentError do
     "%?" % ""


### PR DESCRIPTION
Fix #3648

ruby/spec results
[spec/core/string/modulo_spec.rb](https://github.com/ruby/spec/blob/562cc9a0a8b9d2782474a5bd75c619d6cd285a32/core/string/modulo_spec.rb)

before:
Clash on https://github.com/ruby/spec/blob/562cc9a0a8b9d2782474a5bd75c619d6cd285a32/core/string/modulo_spec.rb#L306

after:
1 file, 111 examples, 466 expectations, 37 failures, 16 errors, 0 tagged (It was able to run to the end!)

ref: https://github.com/ruby/ruby/blob/15196f4c6df6859f825cd16c90d8c27fdcf2400b/sprintf.c#L1018-L1027