### PR TITLE
Change return back to break in the default case.

### DIFF
--- a/mrbgems/mruby-compiler/core/codegen.c
+++ b/mrbgems/mruby-compiler/core/codegen.c
@@ -1026,7 +1026,7 @@ gen_assignment(codegen_scope *s, node *tree, int sp, int val)
 #ifndef MRB_DISABLE_STDIO
     fprintf(stderr, "unknown lhs %d\n", type);
 #endif
-    return;
+    break;
   }
   if (val) push();
 }


### PR DESCRIPTION
@matz 

Fixes #3642 as suggested by https://hackerone.com/avisaven in https://github.com/mruby/mruby/issues/3642#issuecomment-300277550