### PR TITLE
Make string embad from shared

### DIFF
--- a/src/string.c
+++ b/src/string.c
@@ -685,13 +685,20 @@ mrb_str_modify(mrb_state *mrb, struct RString *s)
 
       p = RSTR_PTR(s);
       len = s->as.heap.len;
-      ptr = (char *)mrb_malloc(mrb, (size_t)len + 1);
+      if (len < RSTRING_EMBED_LEN_MAX) {
+        RSTR_SET_EMBED_FLAG(s);
+        RSTR_SET_EMBED_LEN(s, len);
+        ptr = RSTR_PTR(s);
+      }
+      else {
+        ptr = (char *)mrb_malloc(mrb, (size_t)len + 1);
+        s->as.heap.ptr = ptr;
+        s->as.heap.aux.capa = len;
+      }
       if (p) {
         memcpy(ptr, p, len);
       }
       ptr[len] = '\0';
-      s->as.heap.ptr = ptr;
-      s->as.heap.aux.capa = len;
       str_decref(mrb, shared);
     }
     RSTR_UNSET_SHARED_FLAG(s);


### PR DESCRIPTION
# Problem

I found heap-buffer-overflow pattern. (mruby: 011e0bb0 )

```
$ mruby -e '(["a"].join[0].."").to_s'
=================================================================
==24826==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x60200001f192 at pc 0x00010ad174ca bp 0x7fff552f3a20 sp 0x7fff552f31d0
WRITE of size 2 at 0x60200001f192 thread T0
    #0 0x10ad174c9 in __asan_memcpy (libclang_rt.asan_osx_dynamic.dylib:x86_64h+0x4d4c9)
    #1 0x10aa182ea in str_buf_cat string.c:184
    #2 0x10aa176cc in mrb_str_cat string.c:2591
    #3 0x10a9f9e00 in range_to_s range.c:301
    #4 0x10aa741bf in mrb_vm_exec vm.c:1314
    #5 0x10aa6907f in mrb_vm_run vm.c:860
    #6 0x10aa9ccf9 in mrb_top_run vm.c:2733
    #7 0x10ab101c5 in mrb_load_exec parse.y:5780
    #8 0x10ab11037 in mrb_load_nstring_cxt parse.y:5802
    #9 0x10ab11556 in mrb_load_string_cxt parse.y:5814
    #10 0x10a903e81 in main mruby.c:232
    #11 0x7fff92fbb234 in start (libdyld.dylib:x86_64+0x5234)

0x60200001f192 is located 0 bytes to the right of 2-byte region [0x60200001f190,0x60200001f192)
allocated by thread T0 here:
    #0 0x10ad20520 in wrap_realloc (libclang_rt.asan_osx_dynamic.dylib:x86_64h+0x56520)
    #1 0x10a9fce95 in mrb_default_allocf state.c:60
    #2 0x10a97d6a8 in mrb_realloc_simple gc.c:203
    #3 0x10a97ddfe in mrb_realloc gc.c:217
    #4 0x10a97e883 in mrb_malloc gc.c:238
    #5 0x10aa024ef in mrb_str_modify string.c:688
    #6 0x10aa177ff in str_buf_cat string.c:153
    #7 0x10aa176cc in mrb_str_cat string.c:2591
    #8 0x10a9f9e00 in range_to_s range.c:301
    #9 0x10aa741bf in mrb_vm_exec vm.c:1314
    #10 0x10aa6907f in mrb_vm_run vm.c:860
    #11 0x10aa9ccf9 in mrb_top_run vm.c:2733
    #12 0x10ab101c5 in mrb_load_exec parse.y:5780
    #13 0x10ab11037 in mrb_load_nstring_cxt parse.y:5802
    #14 0x10ab11556 in mrb_load_string_cxt parse.y:5814
    #15 0x10a903e81 in main mruby.c:232
    #16 0x7fff92fbb234 in start (libdyld.dylib:x86_64+0x5234)

SUMMARY: AddressSanitizer: heap-buffer-overflow (libclang_rt.asan_osx_dynamic.dylib:x86_64h+0x4d4c9) in __asan_memcpy
Shadow bytes around the buggy address:
  0x1c0400003de0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x1c0400003df0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x1c0400003e00: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x1c0400003e10: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x1c0400003e20: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
=>0x1c0400003e30: fa fa[02]fa fa fa 02 fa fa fa 00 00 fa fa 03 fa
  0x1c0400003e40: fa fa 00 fa fa fa 00 04 fa fa 00 00 fa fa fd fd
  0x1c0400003e50: fa fa fd fd fa fa 03 fa fa fa fd fd fa fa 03 fa
  0x1c0400003e60: fa fa 05 fa fa fa 00 fa fa fa 00 fa fa fa 00 00
  0x1c0400003e70: fa fa 00 00 fa fa 00 00 fa fa 00 00 fa fa fd fa
  0x1c0400003e80: fa fa 06 fa fa fa 00 fa fa fa 00 00 fa fa 06 fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==24826==ABORTING
[2]    24826 abort      mruby -e '(["a"].join[0].."").to_s'
```

lldb

```
frame #5: 0x00000001001162eb mruby`str_buf_cat(mrb=0x000061400000a440, s=0x000062f000003130, ptr="...", len=2) at string.c:184
   181 	  if (off != -1) {
   182 	      ptr = RSTR_PTR(s) + off;
   183 	  }
-> 184 	  memcpy(RSTR_PTR(s) + RSTR_LEN(s), ptr, len);
   185 	  mrb_assert_int_fit(size_t, total, mrb_int, MRB_INT_MAX);
   186 	  RSTR_SET_LEN(s, total);
   187 	  RSTR_PTR(s)[total] = '\0';   /* sentinel */
(lldb) p *s
(RString) $1 = {
  tt = MRB_TT_STRING
  color = 1
  flags = 0
  c = 0x000062f00000a3f0
  gcnext = 0x0000000000000000
  as = {
    heap = {
      len = 1
      aux = {
        capa = 1
        shared = 0x0000603000000001
      }
      ptr = 0x000060200001f170 "a"
    }
    ary = {
      [0] = '\x01'
      [1] = '\0'
      [2] = '\0'
      [3] = '\0'
      [4] = '\0'
      [5] = '\0'
      [6] = '\0'
      [7] = '\0'
      [8] = '\x01'
      [9] = '\0'
      [10] = '\0'
      [11] = '\0'
      [12] = '0'
      [13] = '`'
      [14] = '\0'
      [15] = '\0'
      [16] = 'p'
      [17] = '�'
      [18] = '\x01'
      [19] = '\0'
      [20] = ' '
      [21] = '`'
      [22] = '\0'
      [23] = '\0'
    }
  }
}
```

The capacity of `s` is 1.
But it will copy memory more than it's capacity.

# Proposal

Make string embed if small and shared.
This technique not only fixes the problem but also reduces malloc/free at certain conditions.

# Concern

- I think, it should remove maybe  https://github.com/mruby/mruby/blob/171e732dc7a73a046b2a56f2750cd81ea50bc5cb/src/string.c#L159-L160
- I can't reproduce this block https://github.com/mruby/mruby/blob/171e732dc7a73a046b2a56f2750cd81ea50bc5cb/src/string.c#L677-L680

ref: https://github.com/mruby/mruby/issues/3651