### PR TITLE
Avoid call to_s during backtrace traversal

### DIFF
--- a/src/backtrace.c
+++ b/src/backtrace.c
@@ -79,7 +79,7 @@ get_backtrace_i(mrb_state *mrb, struct backtrace_location *loc, void *data)
   ary = mrb_obj_value((struct RArray*)data);
 
   str = mrb_str_new_cstr(mrb, loc->filename);
-  str = mrb_format(mrb, "%S:%S", str, mrb_fixnum_value(loc->lineno));
+  str = mrb_format(mrb, "%S:%S", str, mrb_fixnum_to_str(mrb, mrb_fixnum_value(loc->lineno), 10));
 
   if (loc->method) {
     mrb_str_cat_lit(mrb, str, ":in ");


### PR DESCRIPTION
Calling `mrb_format(mrb, "%S:%S", str, mrb_fixnum_value(loc->lineno))` with a fixnum results in the vm calling `to_s` to convert the fixnum to a string. This produces a bug where [mrb_callinfo](https://github.com/mruby/mruby/blob/master/src/backtrace.c#L113) changes during retrieval of backtrace.

To fix this, the fixnum can be converted to a string before being passed to `mrb_format`.