### PR TITLE
Should only check frozen fix #3737

### DIFF
--- a/src/array.c
+++ b/src/array.c
@@ -106,11 +106,17 @@ ary_fill_with_nil(mrb_value *ptr, mrb_int size)
 }
 
 static void
-ary_modify(mrb_state *mrb, struct RArray *a)
+ary_modify_check(mrb_state *mrb, struct RArray *a)
 {
   if (MRB_FROZEN_P(a)) {
     mrb_raise(mrb, E_RUNTIME_ERROR, "can't modify frozen array");
   }
+}
+
+static void
+ary_modify(mrb_state *mrb, struct RArray *a)
+{
+  ary_modify_check(mrb, a);
 
   if (ARY_SHARED_P(a)) {
     mrb_shared_array *shared = a->aux.shared;
@@ -458,7 +464,7 @@ mrb_ary_shift(mrb_state *mrb, mrb_value self)
   struct RArray *a = mrb_ary_ptr(self);
   mrb_value val;
 
-  ary_modify(mrb, a);
+  ary_modify_check(mrb, a);
   if (a->len == 0) return mrb_nil_value();
   if (ARY_SHARED_P(a)) {
   L_SHIFT:

--- a/src/array.c
+++ b/src/array.c
@@ -451,7 +451,7 @@ mrb_ary_pop(mrb_state *mrb, mrb_value ary)
 {
   struct RArray *a = mrb_ary_ptr(ary);
 
-  ary_modify(mrb, a);
+  ary_modify_check(mrb, a);
   if (a->len == 0) return mrb_nil_value();
   return a->ptr[--a->len];
 }

--- a/test/t/array.rb
+++ b/test/t/array.rb
@@ -284,6 +284,8 @@ assert('Array#shift', '15.2.12.5.27') do
   assert_nil([].shift)
   assert_equal([2,3], a)
   assert_equal(1, b)
+
+  assert_raise(RuntimeError) { [].freeze.shift }
 end
 
 assert('Array#size', '15.2.12.5.28') do

--- a/test/t/array.rb
+++ b/test/t/array.rb
@@ -237,6 +237,8 @@ assert('Array#pop', '15.2.12.5.21') do
   assert_nil([].pop)
   assert_equal([1,2], a)
   assert_equal(3, b)
+
+  assert_raise(RuntimeError) { [].freeze.pop }
 end
 
 assert('Array#push', '15.2.12.5.22') do


### PR DESCRIPTION
before ( ce6c05600af11f540302145ff4b6988a5a37518a )

```
$ time ./build/host/bin/mruby benchmark/bm_so_lists.rb
./build/host/bin/mruby benchmark/bm_so_lists.rb  52.75s user 0.75s system 97% cpu 54.662 total
```

after

```
$ time ./build/host/bin/mruby benchmark/bm_so_lists.rb
./build/host/bin/mruby benchmark/bm_so_lists.rb  8.52s user 0.18s system 99% cpu 8.733 total
```