### PR TITLE
fixed printing failed assertions

### DIFF
--- a/test/assert.rb
+++ b/test/assert.rb
@@ -23,8 +23,8 @@ def assertion_string(err, str, iso=nil, e=nil, bt=nil)
   msg += " => #{e.message}" if e
   msg += " (mrbgems: #{GEMNAME})" if Object.const_defined?(:GEMNAME)
   if $mrbtest_assert && $mrbtest_assert.size > 0
-    $mrbtest_assert.each do |idx, msg, diff|
-      msg += "\n - Assertion[#{idx}] Failed: #{msg}\n#{diff}"
+    $mrbtest_assert.each do |idx, assert_msg, diff|
+      msg += "\n - Assertion[#{idx}] Failed: #{assert_msg}\n#{diff}"
     end
   end
   msg += "\nbacktrace:\n\t#{bt.join("\n\t")}" if bt


### PR DESCRIPTION
The `msg` outside the block was not modified since it was shadowed by `msg` inside the block.