### PR TITLE
Fixed Module#to_s and #name for #const_set modules

### DIFF
--- a/mrbgems/mruby-class-ext/test/module.rb
+++ b/mrbgems/mruby-class-ext/test/module.rb
@@ -1,10 +1,24 @@
 assert 'Module#name' do
-  module A
-    class B
-    end
+  module Outer
+    class Inner; end
+    const_set :SetInner, Class.new
   end
 
-  assert_nil A::B.singleton_class.name
-  assert_equal 'Fixnum', Fixnum.name
-  assert_equal 'A::B', A::B.name
+  assert_equal 'Outer', Outer.name
+  assert_equal 'Outer::Inner', Outer::Inner.name
+  assert_equal 'Outer::SetInner', Outer::SetInner.name
+
+  outer = Module.new do
+    const_set :SetInner, Class.new
+  end
+  Object.const_set :SetOuter, outer
+
+  assert_equal 'SetOuter', SetOuter.name
+  assert_equal 'SetOuter::SetInner', SetOuter::SetInner.name
+
+  mod = Module.new
+  cls = Class.new
+
+  assert_nil mod.name
+  assert_nil cls.name
 end

--- a/src/class.c
+++ b/src/class.c
@@ -2178,6 +2178,9 @@ mrb_mod_const_set(mrb_state *mrb, mrb_value mod)
 
   mrb_get_args(mrb, "no", &id, &value);
   check_const_name_sym(mrb, id);
+  if (mrb_type(value) == MRB_TT_CLASS || mrb_type(value) == MRB_TT_MODULE) {
+    setup_class(mrb, mrb_class_ptr(mod), mrb_class_ptr(value), id);
+  }
   mrb_const_set(mrb, mod, id, value);
   return value;
 }

--- a/test/t/module.rb
+++ b/test/t/module.rb
@@ -787,10 +787,28 @@ end
 # @!endgroup prepend
 
 assert('Module#to_s') do
-  module Test4to_sModules
+  module Outer
+    class Inner; end
+    const_set :SetInner, Class.new
   end
 
-  assert_equal 'Test4to_sModules', Test4to_sModules.to_s
+  assert_equal 'Outer', Outer.to_s
+  assert_equal 'Outer::Inner', Outer::Inner.to_s
+  assert_equal 'Outer::SetInner', Outer::SetInner.to_s
+
+  outer = Module.new do
+    const_set :SetInner, Class.new
+  end
+  Object.const_set :SetOuter, outer
+
+  assert_equal 'SetOuter', SetOuter.to_s
+  assert_equal 'SetOuter::SetInner', SetOuter::SetInner.to_s
+
+  mod = Module.new
+  cls = Class.new
+
+  assert_equal "#<Module:0x", mod.to_s[0,11]
+  assert_equal "#<Class:0x", cls.to_s[0,10]
 end
 
 assert('Module#inspect') do


### PR DESCRIPTION
Placing a module inside a namespace with `Module#const_set` was not factored in when calling `Module#to_s`:

```ruby
module Namespace
  const_set :Mod, Module.new
end
Namespace::Mod.to_s # => "#<Module:0x155cdf0>
```

This patch fixes it, so that:

```ruby
Namespace::Mod.to_s # => "Namespace::Mod"
```