### PR TITLE
Fixed setting custom rbfiles in gemspec

### DIFF
--- a/tasks/mrbgem_spec.rake
+++ b/tasks/mrbgem_spec.rake
@@ -63,9 +63,6 @@ module MRuby
           objfile(f.relative_path_from(@dir).to_s.pathmap("#{build_dir}/%X"))
         end
 
-        @generate_functions = !(@rbfiles.empty? && @objs.empty?)
-        @objs << objfile("#{build_dir}/gem_init") if @generate_functions
-
         @test_rbfiles = Dir.glob("#{dir}/test/**/*.rb")
         @test_objs = Dir.glob("#{dir}/test/*.{c,cpp,cxx,cc,m,asm,s,S}").map do |f|
           objfile(f.relative_path_from(dir).to_s.pathmap("#{build_dir}/%X"))
@@ -82,6 +79,9 @@ module MRuby
         @export_include_paths << "#{dir}/include" if File.directory? "#{dir}/include"
 
         instance_eval(&@initializer)
+
+        @generate_functions = !(@rbfiles.empty? && @objs.empty?)
+        @objs << objfile("#{build_dir}/gem_init") if @generate_functions
 
         if !name || !licenses || !authors
           fail "#{name || dir} required to set name, license(s) and author(s)"


### PR DESCRIPTION
Currently, the root folder containing the ruby files of a gem to compile (mrblib/) cannot be customized. The gemspec offers methods like `mrblib_dir=` and `rbfiles=`, but that's of little value: The gemspec is evaluated in [mrbgem_spec.rake#L84](https://github.com/mruby/mruby/blob/aa3cb0466e39d8a0f548f569461efec1ca07bb6b/tasks/mrbgem_spec.rake#L84) but the file list using `mrblib_dir` is already compiled in [mrbgem_spec.rake#L61](https://github.com/mruby/mruby/blob/aa3cb0466e39d8a0f548f569461efec1ca07bb6b/tasks/mrbgem_spec.rake#L61). Also, the file list is already used in [mrbgem_spec.rake#L66](https://github.com/mruby/mruby/blob/aa3cb0466e39d8a0f548f569461efec1ca07bb6b/tasks/mrbgem_spec.rake#L66).

To be able to at least set the files with `rbfiles=`, lines 66 and 67 have to happen after evaluation of the gemspec. And that's what this patch does.