### PR TITLE
Improved speed of enumeration methods

### DIFF
--- a/mrbgems/mruby-array-ext/mrblib/array.rb
+++ b/mrbgems/mruby-array-ext/mrblib/array.rb
@@ -252,7 +252,7 @@ class Array
 
   # for efficiency
   def reverse_each(&block)
-    return to_enum :reverse_each unless block_given?
+    return to_enum :reverse_each unless block
 
     i = self.size - 1
     while i>=0
@@ -474,7 +474,7 @@ class Array
   #     scores.delete_if {|score| score < 80 }   #=> [97]
 
   def delete_if(&block)
-    return to_enum :delete_if unless block_given?
+    return to_enum :delete_if unless block
 
     idx = 0
     while idx < self.size do
@@ -503,7 +503,7 @@ class Array
   #  If no block is given, an Enumerator is returned instead.
 
   def reject!(&block)
-    return to_enum :reject! unless block_given?
+    return to_enum :reject! unless block
 
     len = self.size
     idx = 0
@@ -593,7 +593,7 @@ class Array
   #  undefined which value is actually picked up at each iteration.
 
   def bsearch(&block)
-    return to_enum :bsearch unless block_given?
+    return to_enum :bsearch unless block
 
     if idx = bsearch_index(&block)
       self[idx]
@@ -615,7 +615,7 @@ class Array
   #  element itself. For more details consult the documentation for #bsearch.
 
   def bsearch_index(&block)
-    return to_enum :bsearch_index unless block_given?
+    return to_enum :bsearch_index unless block
 
     low = 0
     high = size
@@ -667,7 +667,7 @@ class Array
   #     scores.delete_if {|score| score < 80 }   #=> [97]
 
   def delete_if(&block)
-    return to_enum :delete_if unless block_given?
+    return to_enum :delete_if unless block
 
     idx = 0
     while idx < self.size do
@@ -696,7 +696,7 @@ class Array
   #     a.keep_if { |val| val > 3 } #=> [4, 5]
 
   def keep_if(&block)
-    return to_enum :keep_if unless block_given?
+    return to_enum :keep_if unless block
 
     idx = 0
     len = self.size
@@ -725,7 +725,7 @@ class Array
   #  If no block is given, an Enumerator is returned instead.
 
   def select!(&block)
-    return to_enum :select! unless block_given?
+    return to_enum :select! unless block
 
     result = []
     self.each do |x|

--- a/mrbgems/mruby-enumerator/mrblib/enumerator.rb
+++ b/mrbgems/mruby-enumerator/mrblib/enumerator.rb
@@ -110,7 +110,7 @@ class Enumerator
   #     p fib.take(10) # => [1, 1, 2, 3, 5, 8, 13, 21, 34, 55]
   #
   def initialize(obj=nil, meth=:each, *args, &block)
-    if block_given?
+    if block
       obj = Generator.new(&block)
     else
       raise ArgumentError unless obj
@@ -151,8 +151,9 @@ class Enumerator
   #
   # +offset+:: the starting index to use
   #
-  def with_index(offset=0)
-    return to_enum :with_index, offset unless block_given?
+  def with_index(offset=0, &block)
+    return to_enum :with_index, offset unless block
+
     offset = if offset.nil?
       0
     elsif offset.respond_to?(:to_int)
@@ -164,7 +165,7 @@ class Enumerator
     n = offset - 1
     enumerator_block_call do |*i|
       n += 1
-      yield i.__svalue, n
+      block.call i.__svalue, n
     end
   end
 
@@ -209,11 +210,11 @@ class Enumerator
   #   # => foo:1
   #   # => foo:2
   #
-  def with_object(object)
-    return to_enum(:with_object, object) unless block_given?
+  def with_object(object, &block)
+    return to_enum(:with_object, object) unless block
 
     enumerator_block_call do |i|
-      yield [i,object]
+      block.call [i,object]
     end
     object
   end
@@ -277,7 +278,7 @@ class Enumerator
       end
       obj.args = args
     end
-    return obj unless block_given?
+    return obj unless block
     enumerator_block_call(&block)
   end
 
@@ -538,7 +539,7 @@ class Enumerator
   # just for internal
   class Yielder
     def initialize(&block)
-      raise LocalJumpError, "no block given" unless block_given?
+      raise LocalJumpError, "no block given" unless block
 
       @proc = block
     end

--- a/mrbgems/mruby-hash-ext/mrblib/hash.rb
+++ b/mrbgems/mruby-hash-ext/mrblib/hash.rb
@@ -171,7 +171,7 @@ class Hash
   #
 
   def delete_if(&block)
-    return to_enum :delete_if unless block_given?
+    return to_enum :delete_if unless block
 
     self.each do |k, v|
       self.delete(k) if block.call(k, v)
@@ -228,7 +228,7 @@ class Hash
   #
 
   def keep_if(&block)
-    return to_enum :keep_if unless block_given?
+    return to_enum :keep_if unless block
 
     keys = []
     self.each do |k, v|
@@ -393,11 +393,11 @@ class Hash
   #
   # If no block is given, an enumerator is returned instead.
   #
-  def transform_keys(&b)
-    return to_enum :transform_keys unless block_given?
+  def transform_keys(&block)
+    return to_enum :transform_keys unless block
     hash = {}
     self.keys.each do |k|
-      new_key = yield(k)
+      new_key = block.call(k)
       hash[new_key] = self[k]
     end
     hash
@@ -412,11 +412,11 @@ class Hash
   #
   # If no block is given, an enumerator is returned instead.
   #
-  def transform_keys!(&b)
-    return to_enum :transform_keys! unless block_given?
+  def transform_keys!(&block)
+    return to_enum :transform_keys! unless block
     self.keys.each do |k|
       value = self[k]
-      new_key = yield(k)
+      new_key = block.call(k)
       self.__delete(k)
       self[new_key] = value
     end

--- a/mrblib/array.rb
+++ b/mrblib/array.rb
@@ -11,7 +11,7 @@ class Array
   #
   # ISO 15.2.12.5.10
   def each(&block)
-    return to_enum :each unless block_given?
+    return to_enum :each unless block
 
     idx = 0
     while idx < length
@@ -27,7 +27,7 @@ class Array
   #
   # ISO 15.2.12.5.11
   def each_index(&block)
-    return to_enum :each_index unless block_given?
+    return to_enum :each_index unless block
 
     idx = 0
     while idx < length
@@ -44,7 +44,7 @@ class Array
   #
   # ISO 15.2.12.5.7
   def collect!(&block)
-    return to_enum :collect! unless block_given?
+    return to_enum :collect! unless block
 
     self.each_index { |idx| self[idx] = block.call(self[idx]) }
     self

--- a/mrblib/hash.rb
+++ b/mrblib/hash.rb
@@ -84,7 +84,7 @@ class Hash
   #
   # ISO 15.2.13.4.9
   def each(&block)
-    return to_enum :each unless block_given?
+    return to_enum :each unless block
 
     keys = self.keys
     vals = self.values
@@ -117,7 +117,7 @@ class Hash
   #
   # ISO 15.2.13.4.10
   def each_key(&block)
-    return to_enum :each_key unless block_given?
+    return to_enum :each_key unless block
 
     self.keys.each{|k| block.call(k)}
     self
@@ -143,7 +143,7 @@ class Hash
   #
   # ISO 15.2.13.4.11
   def each_value(&block)
-    return to_enum :each_value unless block_given?
+    return to_enum :each_value unless block
 
     self.keys.each{|k| block.call(self[k])}
     self
@@ -224,12 +224,12 @@ class Hash
   #
   #  1.8/1.9 Hash#reject! returns Hash; ISO says nothing.
   #
-  def reject!(&b)
-    return to_enum :reject! unless block_given?
+  def reject!(&block)
+    return to_enum :reject! unless block
 
     keys = []
     self.each{|k,v|
-      if b.call([k, v])
+      if block.call([k, v])
         keys.push(k)
       end
     }
@@ -255,12 +255,12 @@ class Hash
   #
   #  1.8/1.9 Hash#reject returns Hash; ISO says nothing.
   #
-  def reject(&b)
-    return to_enum :reject unless block_given?
+  def reject(&block)
+    return to_enum :reject unless block
 
     h = {}
     self.each{|k,v|
-      unless b.call([k, v])
+      unless block.call([k, v])
         h[k] = v
       end
     }
@@ -277,12 +277,12 @@ class Hash
   #
   #  1.9 Hash#select! returns Hash; ISO says nothing.
   #
-  def select!(&b)
-    return to_enum :select! unless block_given?
+  def select!(&block)
+    return to_enum :select! unless block
 
     keys = []
     self.each{|k,v|
-      unless b.call([k, v])
+      unless block.call([k, v])
         keys.push(k)
       end
     }
@@ -308,12 +308,12 @@ class Hash
   #
   #  1.9 Hash#select returns Hash; ISO says nothing
   #
-  def select(&b)
-    return to_enum :select unless block_given?
+  def select(&block)
+    return to_enum :select unless block
 
     h = {}
     self.each{|k,v|
-      if b.call([k, v])
+      if block.call([k, v])
         h[k] = v
       end
     }

--- a/mrblib/numeric.rb
+++ b/mrblib/numeric.rb
@@ -45,7 +45,7 @@ module Integral
   #
   # ISO 15.2.8.3.15
   def downto(num, &block)
-    return to_enum(:downto, num) unless block_given?
+    return to_enum(:downto, num) unless block
 
     i = self.to_i
     while i >= num
@@ -70,7 +70,7 @@ module Integral
   #
   # ISO 15.2.8.3.22
   def times &block
-    return to_enum :times unless block_given?
+    return to_enum :times unless block
 
     i = 0
     while i < self
@@ -86,7 +86,7 @@ module Integral
   #
   # ISO 15.2.8.3.27
   def upto(num, &block)
-    return to_enum(:upto, num) unless block_given?
+    return to_enum(:upto, num) unless block
 
     i = self.to_i
     while i <= num
@@ -102,7 +102,7 @@ module Integral
   #
   def step(num=nil, step=1, &block)
     raise ArgumentError, "step can't be 0" if step == 0
-    return to_enum(:step, num, step) unless block_given?
+    return to_enum(:step, num, step) unless block
 
     i = if num.kind_of? Float then self.to_f else self end
     if num == nil

--- a/mrblib/range.rb
+++ b/mrblib/range.rb
@@ -10,7 +10,7 @@ class Range
   #
   # ISO 15.2.14.4.4
   def each(&block)
-    return to_enum :each unless block_given?
+    return to_enum :each unless block
 
     val = self.first
     last = self.last


### PR DESCRIPTION
Replaced `yield if block_given?` with `block.call if block` because the latter is ~20% faster than the former:

```
$ time build/bench/bin/mruby -e '
  def m
    yield if block_given?
  end

  i = 10_000_000
  while i > 0; m{}; i -= 1 end'

real    0m1.899s
user    0m1.899s
sys     0m0.000s
```

```
$ time build/bench/bin/mruby -e '
  def m(&b)
    b.call if b
  end

  i = 10_000_000
  while i > 0; m{}; i -= 1 end'

real    0m1.511s
user    0m1.510s
sys     0m0.001s