### PR TITLE
Improved speed of creating new hash tables

### DIFF
--- a/src/hash.c
+++ b/src/hash.c
@@ -145,10 +145,7 @@ mrb_hash_new_capa(mrb_state *mrb, mrb_int capa)
   struct RHash *h;
 
   h = (struct RHash*)mrb_obj_alloc(mrb, MRB_TT_HASH, mrb->hash_class);
-  h->ht = kh_init(ht, mrb);
-  if (capa > 0) {
-    kh_resize(ht, mrb, h->ht, capa);
-  }
+  h->ht = kh_init_size(ht, mrb, capa);
   h->iv = 0;
   return mrb_obj_value(h);
 }

--- a/src/hash.c
+++ b/src/hash.c
@@ -145,7 +145,8 @@ mrb_hash_new_capa(mrb_state *mrb, mrb_int capa)
   struct RHash *h;
 
   h = (struct RHash*)mrb_obj_alloc(mrb, MRB_TT_HASH, mrb->hash_class);
-  h->ht = kh_init_size(ht, mrb, capa);
+  /* khash needs 1/4 empty space so it is not resized immediately */
+  h->ht = kh_init_size(ht, mrb, capa*4/3);
   h->iv = 0;
   return mrb_obj_value(h);
 }


### PR DESCRIPTION
This patch cuts the time to create new hashes almost in half:

Before:
```
$ time build/bench/bin/mruby -e "
i = 10_000_000
while i > 0
  h = {}
  i -= 1
end"
real    0m2.136s
user    0m2.123s
sys     0m0.007s

$ time build/bench/bin/mruby -e "
i = 10_000_000
while i > 0
  h = {a:1, b:2, c:3, d:4}
  i -= 1
end"
real    0m4.248s
user    0m4.248s
sys     0m0.000s
```

After:
```
$ time build/bench/bin/mruby -e "
i = 10_000_000
while i > 0
  h = {}
  i -= 1
end"
real    0m1.377s
user    0m1.374s
sys     0m0.003s

$ time build/bench/bin/mruby -e "
i = 10_000_000
while i > 0
  h = {a:1, b:2, c:3, d:4}
  i -= 1
end"
real    0m2.272s
user    0m2.261s
sys     0m0.003s
```