### PR TITLE
add method(compact, compact!) and test of Hash to mruby-hash-ext

### DIFF
--- a/mrbgems/mruby-hash-ext/mrblib/hash.rb
+++ b/mrbgems/mruby-hash-ext/mrblib/hash.rb
@@ -115,6 +115,40 @@ class Hash
   alias update merge!
 
   ##
+  # call-seq:
+  #    hsh.compact     -> new_hsh
+  #
+  # Returns a new hash with the nil values/key pairs removed
+  #
+  #    h = { a: 1, b: false, c: nil }
+  #    h.compact     #=> { a: 1, b: false }
+  #    h             #=> { a: 1, b: false, c: nil }
+  #
+  def compact
+    result = self.dup
+    result.compact!
+    result
+  end
+
+  ##
+  # call-seq:
+  #    hsh.compact!    -> hsh
+  #
+  # Removes all nil values from the hash. Returns the hash.
+  #
+  #    h = { a: 1, b: false, c: nil }
+  #    h.compact!     #=> { a: 1, b: false }
+  #
+  def compact!
+    result = self.select { |k, v| !v.nil? }
+    if result.size == self.size
+      nil
+    else
+      self.replace(result)
+    end
+  end
+
+  ##
   #  call-seq:
   #     hsh.fetch(key [, default] )       -> obj
   #     hsh.fetch(key) {| key | block }   -> obj

--- a/mrbgems/mruby-hash-ext/test/hash.rb
+++ b/mrbgems/mruby-hash-ext/test/hash.rb
@@ -82,6 +82,20 @@ assert('Hash#values_at') do
   assert_equal keys, h.values_at(*keys)
 end
 
+assert('Hash#compact') do
+  h = { "cat" => "feline", "dog" => nil, "cow" => false }
+
+  assert_equal({ "cat" => "feline", "cow" => false }, h.compact)
+  assert_equal({ "cat" => "feline", "dog" => nil, "cow" => false }, h)
+end
+
+assert('Hash#compact!') do
+  h = { "cat" => "feline", "dog" => nil, "cow" => false }
+
+  h.compact!
+  assert_equal({ "cat" => "feline", "cow" => false }, h)
+end
+
 assert('Hash#fetch') do
   h = { "cat" => "feline", "dog" => "canine", "cow" => "bovine" }
   assert_equal "feline", h.fetch("cat")


### PR DESCRIPTION
I was implement `Hash#compact` and `Hash#compact!` to mruby-hash-ext.

I saw this document and code.
* http://ruby-doc.org/core-2.4.1/Hash.html#method-i-compact
* https://github.com/mruby/mruby/blob/f9c3ebd29d7410be209b3f22b9923f0f81f0141d/mrbgems/mruby-array-ext/mrblib/array.rb#L218-L251

and exec below code.
```
$ irb -v
irb 0.9.6(09/06/30)
$ ruby -v
ruby 2.4.1p111 (2017-03-22 revision 58053) [x86_64-darwin16]
$ irb
irb(main):001:0> {:a => true, :b => nil}.compact!
=> {:a=>true}
irb(main):002:0> {:a => true}.compact!
=> nil
```

CRuby document says.

Array http://ruby-doc.org/core-2.4.1/Array.html#method-i-compact

> compact! → ary or nil
> Removes nil elements from the array.
> 
> Returns nil if no changes were made, otherwise returns the array.

Hash http://ruby-doc.org/core-2.4.1/Hash.html#method-i-compact

> compact! → hsh
> Removes all nil values from the hash. Returns the hash.

Hash document is not pointing to something like `Returns nil if no changes were made, otherwise returns the hash.`...
Is my implementation right?