### PR TITLE
Some more vm refactorings

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -1345,7 +1345,10 @@ RETRY_TRY_BLOCK:
       else {
         blk = regs[bidx];
         if (!mrb_nil_p(blk) && mrb_type(blk) != MRB_TT_PROC) {
-          blk = regs[bidx] = mrb_convert_type(mrb, blk, MRB_TT_PROC, "Proc", "to_proc");
+          /* store the converted proc not directly in the stack because the stack
+             might have been reallocated during mrb_convert_type(), see #3622 */
+          blk = mrb_convert_type(mrb, blk, MRB_TT_PROC, "Proc", "to_proc");
+          regs[bidx] = blk;
         }
       }
       c = mrb_class(mrb, recv);
@@ -1528,7 +1531,10 @@ RETRY_TRY_BLOCK:
       recv = regs[0];
       blk = regs[bidx];
       if (!mrb_nil_p(blk) && mrb_type(blk) != MRB_TT_PROC) {
-        blk = regs[bidx] = mrb_convert_type(mrb, blk, MRB_TT_PROC, "Proc", "to_proc");
+        /* store the converted proc not directly in the stack because the stack
+           might have been reallocated during mrb_convert_type(), see #3622 */
+        blk = mrb_convert_type(mrb, blk, MRB_TT_PROC, "Proc", "to_proc");
+        regs[bidx] = blk;
       }
       c = ci->target_class->super;
       m = mrb_method_search_vm(mrb, &c, mid);

--- a/src/vm.c
+++ b/src/vm.c
@@ -1339,20 +1339,12 @@ RETRY_TRY_BLOCK:
 
       recv = regs[a];
       if (GET_OPCODE(i) != OP_SENDB) {
-        if (bidx >= ci->nregs) {
-          ci->nregs = bidx+1;
-          stack_extend(mrb, ci->nregs);
-        }
         SET_NIL_VALUE(regs[bidx]);
         blk = regs[bidx];
       }
       else {
         blk = regs[bidx];
         if (!mrb_nil_p(blk) && mrb_type(blk) != MRB_TT_PROC) {
-          if (bidx >= ci->nregs) {
-            ci->nregs = bidx+1;
-            stack_extend(mrb, ci->nregs);
-          }
           blk = regs[bidx] = mrb_convert_type(mrb, blk, MRB_TT_PROC, "Proc", "to_proc");
         }
       }
@@ -1536,10 +1528,6 @@ RETRY_TRY_BLOCK:
       recv = regs[0];
       blk = regs[bidx];
       if (!mrb_nil_p(blk) && mrb_type(blk) != MRB_TT_PROC) {
-        if (bidx >= ci->nregs) {
-          ci->nregs = bidx+1;
-          stack_extend(mrb, ci->nregs);
-        }
         blk = regs[bidx] = mrb_convert_type(mrb, blk, MRB_TT_PROC, "Proc", "to_proc");
       }
       c = ci->target_class->super;


### PR DESCRIPTION
One additional thing: While going through the code I was wondering if sections:

https://github.com/mruby/mruby/blob/8bf492f12707777c321dcf40494f757947649f62/src/vm.c#L1366-L1369

and 

https://github.com/mruby/mruby/blob/8bf492f12707777c321dcf40494f757947649f62/src/vm.c#L1560-L1563

are needed or could be removed.

In both cases the stack should have room for the block. Actually, the stack was just accessed at the block's offset a few lines earlier. Removing those lines does not break any tests.