### PR TITLE
Check whether internal khash is initialized in Hash#compact!

### DIFF
--- a/mrbgems/mruby-hash-ext/src/hash-ext.c
+++ b/mrbgems/mruby-hash-ext/src/hash-ext.c
@@ -52,6 +52,7 @@ hash_compact_bang(mrb_state *mrb, mrb_value hash)
   khash_t(ht) *h = RHASH_TBL(hash);
   mrb_int n = -1;
 
+  if (!h) return mrb_nil_value();
   for (k = kh_begin(h); k != kh_end(h); k++) {
     if (kh_exist(h, k)) {
       mrb_value val = kh_value(h, k).v;


### PR DESCRIPTION
The new C version of `Hash#compact!` (introduced in 6c61a60609e973f3dec00e86ca6f1519ae83e1e3) does not check whether the internal khash is initialized before operating on it. As a result, code such as the following causes a null pointer dereference:
```ruby
class X < Hash
    def initialize
    end 
end
X.new.compact!
```
I've fixed the issue by adding a null check.

This issue was reported by Dinko Galetic & Denis Kasak (https://hackerone.com/dgaletic).