### PR TITLE
Fix clang warnings

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -2308,10 +2308,9 @@ RETRY_TRY_BLOCK:
         {
           mrb_int x = mrb_fixnum(regs[a]);
           mrb_int y = mrb_fixnum(regs[a+1]);
-          double f;
+          double f = NAN;
           if (y == 0) {
-            if (x == 0) f = NAN;
-            else if (x > 0) f = INFINITY;
+            if (x > 0) f = INFINITY;
             else if (x < 0) f = -INFINITY;
           }
           else {


### PR DESCRIPTION
Warning fix.

Before:
```
CC    src/vm.c -> build/host-debug/src/vm.o
@mruby/src/vm.c:2315:22: warning: variable 'f' is used uninitialized whenever 'if' condition is false [-Wsometimes-uninitialized]
            else if (x < 0) f = -INFINITY;
                     ^~~~~
@mruby/src/vm.c:2320:41: note: uninitialized use occurs here
          SET_FLOAT_VALUE(mrb, regs[a], f);
                                        ^
@mruby/include/mruby/boxing_no.h:42:78: note: expanded from macro 'SET_FLOAT_VALUE'
#define SET_FLOAT_VALUE(mrb,r,v) BOXNIX_SET_VALUE(r, MRB_TT_FLOAT, value.f, (v))
                                                                             ^
@mruby/include/mruby/boxing_no.h:34:14: note: expanded from macro 'BOXNIX_SET_VALUE'
  (o).attr = v;\
             ^
@mruby/src/vm.c:2315:18: note: remove the 'if' if its condition is always true
            else if (x < 0) f = -INFINITY;
                 ^~~~~~~~~~~
@mruby/src/vm.c:2311:19: note: initialize the variable 'f' to silence this warning
          double f;
                  ^
                   = 0.0
1 warning generated.
```