### PR TITLE
Fix string test with 16-bit integers

### DIFF
--- a/mrbgems/mruby-sprintf/test/sprintf.rb
+++ b/mrbgems/mruby-sprintf/test/sprintf.rb
@@ -94,7 +94,7 @@ end
 assert("String#% %d") do
   assert_equal("  10",   "%4d" % 10)
   assert_equal("1000",   "%4d" % 1000)
-  assert_equal("100000", "%4d" % 100000)
+  assert_equal("10000",  "%4d" % 10000)
 end
 
 assert("String#% invalid format") do


### PR DESCRIPTION
Fixed test:

```
$ CFLAGS='-DMRB_INT16=1' rake test
[...]
ArgumentError: String#% %d => number (100000) too big for integer (mrbgems: mruby-sprintf)
Skip: Struct.new removes existing constant  redefining Struct with same name cause warnings
Skip: Module#prepend super in alias  super does not currently work in aliased methods
Total: 970
   OK: 969
   KO: 0
Crash: 1
 Time: 0.27 seconds
rake aborted!
Command failed with status (1): ["build/test/bin/mrbtest"...]
[...]
```