### PR TITLE
Fix building with MRB_USE_FLOAT=1

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -65,6 +65,9 @@
 
 #include "mrbconf.h"
 
+#ifndef FLT_EPSILON
+#define FLT_EPSILON (1.19209290e-07f)
+#endif
 #ifndef DBL_EPSILON
 #define DBL_EPSILON ((double)2.22044604925031308085e-16L)
 #endif


### PR DESCRIPTION
Fixes:

```
/builds/dabroz/mruby/mrbgems/mruby-range-ext/src/range.c:142:71: error: use of undeclared identifier 'FLT_EPSILON'
    mrb_float err = (fabs(beg_f) + fabs(end_f) + fabs(end_f-beg_f)) * MRB_FLOAT_EPSILON;
                                                                      ^
/builds/dabroz/mruby/include/mruby.h:76:27: note: expanded from macro 'MRB_FLOAT_EPSILON'
#define MRB_FLOAT_EPSILON FLT_EPSILON
                          ^
1 error generated.
```