### PR TITLE
Refactored #assert_raise and #assert_nothing_raised

### DIFF
--- a/test/assert.rb
+++ b/test/assert.rb
@@ -143,52 +143,41 @@ def assert_not_include(collection, obj, msg = nil)
   assert_false(collection.include?(obj), msg, diff)
 end
 
-def assert_raise(*exp)
-  ret = true
-  if $mrbtest_assert
-    $mrbtest_assert_idx += 1
-    msg = exp.last.class == String ? exp.pop : nil
-    msg = msg.to_s + " : " if msg
-    should_raise = false
-    begin
-      yield
-      should_raise = true
-    rescue Exception => e
-      msg = "#{msg}#{exp.inspect} exception expected, not"
-      diff = "      Class: <#{e.class}>\n" +
-             "    Message: #{e.message}"
-      unless exp.any?{|ex| ex.instance_of?(Module) ? e.kind_of?(ex) : ex == e.class }
-        $mrbtest_assert.push([$mrbtest_assert_idx, msg, diff])
-        ret = false
-      end
-    end
+def assert_raise(exc, msg = nil)
+  return true unless $mrbtest_assert
+  $mrbtest_assert_idx += 1
 
-    exp = exp.first if exp.first
-    if should_raise
-      msg = "#{msg}#{exp.inspect} expected but nothing was raised."
-      $mrbtest_assert.push([$mrbtest_assert_idx, msg, nil])
-      ret = false
-    end
+  begin
+    yield
+    msg ||= "Expected to raise #{exc} but nothing was raised."
+    diff = nil
+    $mrbtest_assert.push [$mrbtest_assert_idx, msg, diff]
+    false
+  rescue exc
+    true
+  rescue Exception => e
+    msg ||= "Expected to raise #{exc}, not"
+    diff = "      Class: <#{e.class}>\n" +
+           "    Message: #{e.message}"
+    $mrbtest_assert.push [$mrbtest_assert_idx, msg, diff]
+    false
   end
-  ret
 end
 
-def assert_nothing_raised(*exp)
-  ret = true
-  if $mrbtest_assert
-    $mrbtest_assert_idx += 1
-    msg = exp.last.class == String ? exp.pop : ""
-    begin
-      yield
-    rescue Exception => e
-      msg = "#{msg} exception raised."
-      diff = "      Class: <#{e.class}>\n" +
-             "    Message: #{e.message}"
-      $mrbtest_assert.push([$mrbtest_assert_idx, msg, diff])
-      ret = false
-    end
+def assert_nothing_raised(msg = nil)
+  return true unless $mrbtest_assert
+  $mrbtest_assert_idx += 1
+
+  begin
+    yield
+    true
+  rescue Exception => e
+    msg ||= "Expected not to raise #{exc.join(', ')} but it raised"
+    diff =  "      Class: <#{e.class}>\n" +
+            "    Message: #{e.message}"
+    $mrbtest_assert.push [$mrbtest_assert_idx, msg, diff]
+    false
   end
-  ret
 end
 
 ##

--- a/test/t/module.rb
+++ b/test/t/module.rb
@@ -635,7 +635,7 @@ end
     c.singleton_class.class_eval do
       define_method(:method_removed) {|id| removed = id}
     end
-    assert_nothing_raised(NoMethodError, NameError, '[Bug #7843]') do
+    assert_nothing_raised('[Bug #7843]') do
       c.class_eval do
         remove_method(:foo)
       end
@@ -724,7 +724,7 @@ end
     end
     a = c.new
     assert_true a.respond_to?(:foo), bug8005
-    assert_nothing_raised(NoMethodError, bug8005) {a.send :foo}
+    assert_nothing_raised(bug8005) {a.send :foo}
   end
 
   # mruby has no visibility control


### PR DESCRIPTION
`assert_nothing_raised` didn't check the given exceptions anyway.