### PR TITLE
Update print.c

### DIFF
--- a/mrbgems/mruby-print/src/print.c
+++ b/mrbgems/mruby-print/src/print.c
@@ -33,6 +33,7 @@ printstr(mrb_state *mrb, mrb_value obj)
     } else
 #endif
       fwrite(RSTRING_PTR(obj), RSTRING_LEN(obj), 1, stdout);
+    fflush(stdout);
   }
 }
 


### PR DESCRIPTION
Strings not containing a newline are not printed synchronously
ex. `bin/mruby -e '["a", "b", "c", "\n", "d", "e", "f", "\n"].each {|e| print e ; usleep 200000}'`