### PR TITLE
Trying to make the code more readable

### DIFF
--- a/src/numeric.c
+++ b/src/numeric.c
@@ -380,7 +380,11 @@ flo_shift(mrb_state *mrb, mrb_value x, mrb_int width)
 #if defined(_ISOC99_SOURCE)
     val = trunc(val);
 #else
-    val = val > 0 ? floor(val) : ceil(val);
+    if (val > 0){
+        val = floor(val);    
+    } else {
+        val = ceil(val);
+    }
 #endif
     if (val == 0 && mrb_float(x) < 0) {
       return mrb_fixnum_value(-1);


### PR DESCRIPTION
Hi all,

I'm running some C code analysis tool that pointed me to this small code fragment. I'm suggesting this patch to try to make the source code more understandable by removing mixing of ternary if statements with attributions.

Would you guys agree with this type of changes? The tools pointed me to almost 20 cases like this one in the source code of mruby.