### PR TITLE
allow to override default printing function

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -113,6 +113,12 @@ struct mrb_state;
  */
 typedef void* (*mrb_allocf) (struct mrb_state *mrb, void*, size_t, void *ud);
 
+/**
+ * Function pointer type of custom printing function. It will be used instead of
+ * fprintf(stdout/stderr) if provided.
+ */
+typedef void (*mrb_print_func) (struct mrb_state *mrb, const char *string_ptr, size_t string_length, mrb_bool error_stream);
+
 #ifndef MRB_FIXED_STATE_ATEXIT_STACK_SIZE
 #define MRB_FIXED_STATE_ATEXIT_STACK_SIZE 5
 #endif
@@ -251,6 +257,8 @@ typedef struct mrb_state {
   mrb_atexit_func *atexit_stack;
 #endif
   mrb_int atexit_stack_len;
+
+  mrb_print_func print_func;
 } mrb_state;
 
 

--- a/mrbgems/mruby-print/src/print.c
+++ b/mrbgems/mruby-print/src/print.c
@@ -1,6 +1,10 @@
 #include <mruby.h>
 #include <mruby/string.h>
+
+#ifndef MRB_DISABLE_STDIO
 #include <stdio.h>
+#endif
+
 #include <string.h>
 #include <stdlib.h>
 #if defined(_WIN32)
@@ -15,7 +19,16 @@
 static void
 printstr(mrb_state *mrb, mrb_value obj)
 {
-  if (mrb_string_p(obj)) {
+  if (!mrb_string_p(obj))
+    return;
+
+  if (mrb->print_func)
+  {
+    mrb->print_func(mrb, RSTRING_PTR(obj), RSTRING_LEN(obj), FALSE);
+    return;
+  }
+  
+#ifndef MRB_DISABLE_STDIO
 #if defined(_WIN32)
     if (isatty(fileno(stdout))) {
       DWORD written;
@@ -34,7 +47,7 @@ printstr(mrb_state *mrb, mrb_value obj)
 #endif
       fwrite(RSTRING_PTR(obj), RSTRING_LEN(obj), 1, stdout);
     fflush(stdout);
-  }
+#endif
 }
 
 /* 15.3.1.2.9  */


### PR DESCRIPTION
`mrb_state` now features a `mrb_print_func` callback, that allows to use custom printing function to be used instead of the default fprintf implementation, like `__android_log_print` (Android) or `OutputDebugString` (Win32).

Fixes #3734