### PR TITLE
Fix MSVC 14.0 warnings

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -858,7 +858,7 @@ mrb_get_mid(mrb_state *mrb) /* get method symbol */
   return mrb->c->ci->mid;
 }
 
-static inline int
+static inline mrb_int
 mrb_get_argc(mrb_state *mrb) /* get argc */
 {
   return mrb->c->ci->argc;

--- a/include/mruby.h
+++ b/include/mruby.h
@@ -1054,7 +1054,7 @@ MRB_API mrb_sym mrb_obj_to_sym(mrb_state *mrb, mrb_value name);
 MRB_API mrb_bool mrb_obj_eq(mrb_state*, mrb_value, mrb_value);
 MRB_API mrb_bool mrb_obj_equal(mrb_state*, mrb_value, mrb_value);
 MRB_API mrb_bool mrb_equal(mrb_state *mrb, mrb_value obj1, mrb_value obj2);
-MRB_API mrb_value mrb_convert_to_integer(mrb_state *mrb, mrb_value val, int base);
+MRB_API mrb_value mrb_convert_to_integer(mrb_state *mrb, mrb_value val, mrb_int base);
 MRB_API mrb_value mrb_Integer(mrb_state *mrb, mrb_value val);
 MRB_API mrb_value mrb_Float(mrb_state *mrb, mrb_value val);
 MRB_API mrb_value mrb_inspect(mrb_state *mrb, mrb_value obj);

--- a/include/mruby/array.h
+++ b/include/mruby/array.h
@@ -45,7 +45,7 @@ struct RArray {
 #define ARY_EMBED_P(a) ((a)->flags & MRB_ARY_EMBED_MASK)
 #define ARY_UNSET_EMBED_FLAG(a) ((a)->flags &= ~(MRB_ARY_EMBED_MASK))
 #define ARY_EMBED_LEN(a) ((mrb_int)(((a)->flags & MRB_ARY_EMBED_MASK) - 1))
-#define ARY_SET_EMBED_LEN(a,len) ((a)->flags = ((a)->flags&~MRB_ARY_EMBED_MASK) | (len + 1))
+#define ARY_SET_EMBED_LEN(a,len) ((a)->flags = ((a)->flags&~MRB_ARY_EMBED_MASK) | ((uint32_t)(len) + 1))
 #define ARY_EMBED_PTR(a) (&((a)->as.embed[0]))
 
 #define ARY_LEN(a) (ARY_EMBED_P(a)?ARY_EMBED_LEN(a):(a)->as.heap.len)

--- a/include/mruby/error.h
+++ b/include/mruby/error.h
@@ -24,7 +24,7 @@ struct RException {
 MRB_API void mrb_sys_fail(mrb_state *mrb, const char *mesg);
 MRB_API mrb_value mrb_exc_new_str(mrb_state *mrb, struct RClass* c, mrb_value str);
 #define mrb_exc_new_str_lit(mrb, c, lit) mrb_exc_new_str(mrb, c, mrb_str_new_lit(mrb, lit))
-MRB_API mrb_value mrb_make_exception(mrb_state *mrb, int argc, const mrb_value *argv);
+MRB_API mrb_value mrb_make_exception(mrb_state *mrb, mrb_int argc, const mrb_value *argv);
 MRB_API mrb_value mrb_exc_backtrace(mrb_state *mrb, mrb_value exc);
 MRB_API mrb_value mrb_get_backtrace(mrb_state *mrb);
 MRB_API mrb_noreturn void mrb_no_method_error(mrb_state *mrb, mrb_sym id, mrb_value args, const char *fmt, ...);

--- a/include/mruby/gc.h
+++ b/include/mruby/gc.h
@@ -33,6 +33,13 @@ typedef enum {
   MRB_GC_STATE_SWEEP
 } mrb_gc_state;
 
+/* Disable MSVC warning "C4200: nonstandard extension used: zero-sized array
+ * in struct/union" when in C++ mode */
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4200)
+#endif
+
 typedef struct mrb_heap_page {
   struct RBasic *freelist;
   struct mrb_heap_page *prev;
@@ -42,6 +49,10 @@ typedef struct mrb_heap_page {
   mrb_bool old:1;
   void *objects[];
 } mrb_heap_page;
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 typedef struct mrb_gc {
   mrb_heap_page *heaps;                /* heaps for GC */

--- a/include/mruby/numeric.h
+++ b/include/mruby/numeric.h
@@ -25,7 +25,7 @@ MRB_BEGIN_DECL
 #define FIXABLE_FLOAT(f) TYPED_FIXABLE(f,double)
 
 MRB_API mrb_value mrb_flo_to_fixnum(mrb_state *mrb, mrb_value val);
-MRB_API mrb_value mrb_fixnum_to_str(mrb_state *mrb, mrb_value x, int base);
+MRB_API mrb_value mrb_fixnum_to_str(mrb_state *mrb, mrb_value x, mrb_int base);
 /* ArgumentError if format string doesn't match /%(\.[0-9]+)?[aAeEfFgG]/ */
 MRB_API mrb_value mrb_float_to_str(mrb_state *mrb, mrb_value x, const char *fmt);
 MRB_API mrb_float mrb_to_flo(mrb_state *mrb, mrb_value x);

--- a/include/mruby/string.h
+++ b/include/mruby/string.h
@@ -409,7 +409,7 @@ MRB_API int mrb_str_cmp(mrb_state *mrb, mrb_value str1, mrb_value str2);
 MRB_API char *mrb_str_to_cstr(mrb_state *mrb, mrb_value str);
 
 mrb_value mrb_str_pool(mrb_state *mrb, mrb_value str);
-mrb_int mrb_str_hash(mrb_state *mrb, mrb_value str);
+uint32_t mrb_str_hash(mrb_state *mrb, mrb_value str);
 mrb_value mrb_str_dump(mrb_state *mrb, mrb_value str);
 
 /*

--- a/mrbgems/mruby-compiler/core/parse.y
+++ b/mrbgems/mruby-compiler/core/parse.y
@@ -3452,7 +3452,7 @@ backref_error(parser_state *p, node *n)
   c = (int)(intptr_t)n->car;
 
   if (c == NODE_NTH_REF) {
-    yyerror_i(p, "can't set variable $%" MRB_PRId, (mrb_int)(intptr_t)n->cdr);
+    yyerror_i(p, "can't set variable $%" MRB_PRId, (int)(intptr_t)n->cdr);
   }
   else if (c == NODE_BACK_REF) {
     yyerror_i(p, "can't set variable $%c", (int)(intptr_t)n->cdr);

--- a/mrbgems/mruby-eval/src/eval.c
+++ b/mrbgems/mruby-eval/src/eval.c
@@ -198,7 +198,7 @@ patch_irep(mrb_state *mrb, mrb_irep *irep, int bnest, mrb_irep *top)
 void mrb_codedump_all(mrb_state*, struct RProc*);
 
 static struct RProc*
-create_proc_from_string(mrb_state *mrb, char *s, int len, mrb_value binding, const char *file, mrb_int line)
+create_proc_from_string(mrb_state *mrb, char *s, mrb_int len, mrb_value binding, const char *file, mrb_int line)
 {
   mrbc_context *cxt;
   struct mrb_parser_state *p;

--- a/mrbgems/mruby-eval/src/eval.c
+++ b/mrbgems/mruby-eval/src/eval.c
@@ -211,7 +211,7 @@ create_proc_from_string(mrb_state *mrb, char *s, int len, mrb_value binding, con
   }
 
   cxt = mrbc_context_new(mrb);
-  cxt->lineno = line;
+  cxt->lineno = (short)line;
 
   mrbc_filename(mrb, cxt, file ? file : "(eval)");
   cxt->capture_errors = TRUE;

--- a/mrbgems/mruby-exit/src/mruby-exit.c
+++ b/mrbgems/mruby-exit/src/mruby-exit.c
@@ -7,7 +7,7 @@ f_exit(mrb_state *mrb, mrb_value self)
   mrb_int i = EXIT_SUCCESS;
 
   mrb_get_args(mrb, "|i", &i);
-  exit(i);
+  exit((int)i);
   /* not reached */
   return mrb_nil_value();
 }

--- a/mrbgems/mruby-fiber/src/fiber.c
+++ b/mrbgems/mruby-fiber/src/fiber.c
@@ -212,7 +212,7 @@ fiber_switch(mrb_state *mrb, mrb_value self, mrb_int len, const mrb_value *a, mr
     while (b<e) {
       *b++ = *a++;
     }
-    c->cibase->argc = len;
+    c->cibase->argc = (int)len;
     value = c->stack[0] = c->ci->proc->env->stack[0];
   }
   else {

--- a/mrbgems/mruby-math/src/math.c
+++ b/mrbgems/mruby-math/src/math.c
@@ -486,7 +486,7 @@ static mrb_value
 math_log(mrb_state *mrb, mrb_value obj)
 {
   mrb_float x, base;
-  int argc;
+  mrb_int argc;
 
   argc = mrb_get_args(mrb, "f|f", &x, &base);
   if (x < 0.0) {

--- a/mrbgems/mruby-math/src/math.c
+++ b/mrbgems/mruby-math/src/math.c
@@ -657,7 +657,7 @@ math_ldexp(mrb_state *mrb, mrb_value obj)
   mrb_int   i;
 
   mrb_get_args(mrb, "fi", &x, &i);
-  x = ldexp(x, i);
+  x = ldexp(x, (int)i);
 
   return mrb_float_value(mrb, x);
 }

--- a/mrbgems/mruby-print/src/print.c
+++ b/mrbgems/mruby-print/src/print.c
@@ -19,7 +19,7 @@ printstr(mrb_state *mrb, mrb_value obj)
 #if defined(_WIN32)
     if (isatty(fileno(stdout))) {
       DWORD written;
-      int mlen = RSTRING_LEN(obj);
+      int mlen = (int)RSTRING_LEN(obj);
       char* utf8 = RSTRING_PTR(obj);
       int wlen = MultiByteToWideChar(CP_UTF8, 0, utf8, mlen, NULL, 0);
       wchar_t* utf16 = (wchar_t*)mrb_malloc(mrb, (wlen+1) * sizeof(wchar_t));

--- a/mrbgems/mruby-sprintf/src/sprintf.c
+++ b/mrbgems/mruby-sprintf/src/sprintf.c
@@ -153,7 +153,7 @@ check_next_arg(mrb_state *mrb, int posarg, int nextarg)
 }
 
 static void
-check_pos_arg(mrb_state *mrb, int posarg, int n)
+check_pos_arg(mrb_state *mrb, mrb_int posarg, mrb_int n)
 {
   if (posarg > 0) {
     mrb_raisef(mrb, E_ARGUMENT_ERROR, "numbered(%S) after unnumbered(%S)",

--- a/mrbgems/mruby-sprintf/src/sprintf.c
+++ b/mrbgems/mruby-sprintf/src/sprintf.c
@@ -19,7 +19,7 @@
 #define BITSPERDIG MRB_INT_BIT
 #define EXTENDSIGN(n, l) (((~0U << (n)) >> (((n)*(l)) % BITSPERDIG)) & ~(~0U << (n)))
 
-mrb_value mrb_str_format(mrb_state *, int, const mrb_value *, mrb_value);
+mrb_value mrb_str_format(mrb_state *, mrb_int, const mrb_value *, mrb_value);
 static void fmt_setup(char*,size_t,int,int,mrb_int,mrb_int);
 
 static char*
@@ -518,7 +518,7 @@ mrb_f_sprintf(mrb_state *mrb, mrb_value obj)
 }
 
 mrb_value
-mrb_str_format(mrb_state *mrb, int argc, const mrb_value *argv, mrb_value fmt)
+mrb_str_format(mrb_state *mrb, mrb_int argc, const mrb_value *argv, mrb_value fmt)
 {
   const char *p, *end;
   char *buf;

--- a/mrbgems/mruby-sprintf/src/sprintf.c
+++ b/mrbgems/mruby-sprintf/src/sprintf.c
@@ -168,7 +168,7 @@ check_pos_arg(mrb_state *mrb, int posarg, int n)
 }
 
 static void
-check_name_arg(mrb_state *mrb, int posarg, const char *name, int len)
+check_name_arg(mrb_state *mrb, int posarg, const char *name, mrb_int len)
 {
   if (posarg > 0) {
     mrb_raisef(mrb, E_ARGUMENT_ERROR, "named%S after unnumbered(%S)",
@@ -224,7 +224,7 @@ check_name_arg(mrb_state *mrb, int posarg, const char *name, int len)
 } while (0)
 
 static mrb_value
-get_hash(mrb_state *mrb, mrb_value *hash, int argc, const mrb_value *argv)
+get_hash(mrb_state *mrb, mrb_value *hash, mrb_int argc, const mrb_value *argv)
 {
   mrb_value tmp;
 
@@ -643,7 +643,7 @@ retry:
         }
         symname = mrb_str_new(mrb, start + 1, p - start - 1);
         id = mrb_intern_str(mrb, symname);
-        nextvalue = GETNAMEARG(mrb_symbol_value(id), start, (int)(p - start + 1));
+        nextvalue = GETNAMEARG(mrb_symbol_value(id), start, (mrb_int)(p - start + 1));
         if (mrb_undef_p(nextvalue)) {
           mrb_raisef(mrb, E_KEY_ERROR, "key%S not found", mrb_str_new(mrb, start, p - start + 1));
         }

--- a/mrbgems/mruby-sprintf/src/sprintf.c
+++ b/mrbgems/mruby-sprintf/src/sprintf.c
@@ -999,13 +999,15 @@ retry:
       case 'A': {
         mrb_value val = GETARG();
         double fval;
-        int i, need = 6;
+        mrb_int i;
+        mrb_int need = 6;
         char fbuf[32];
+        int frexp_result;
 
         fval = mrb_float(mrb_Float(mrb, val));
         if (!isfinite(fval)) {
           const char *expr;
-          const int elen = 3;
+          const mrb_int elen = 3;
           char sign = '\0';
 
           if (isnan(fval)) {
@@ -1045,7 +1047,8 @@ retry:
         need = 0;
         if (*p != 'e' && *p != 'E') {
           i = INT_MIN;
-          frexp(fval, &i);
+          frexp(fval, &frexp_result);
+          i = (mrb_int)frexp_result;
           if (i > 0)
             need = BIT_DIGITS(i);
         }

--- a/mrbgems/mruby-sprintf/src/sprintf.c
+++ b/mrbgems/mruby-sprintf/src/sprintf.c
@@ -198,7 +198,7 @@ check_name_arg(mrb_state *mrb, int posarg, const char *name, int len)
 
 #define GETNUM(n, val) \
   for (; p < end && ISDIGIT(*p); p++) {\
-    int next_n = 10 * n + (*p - '0'); \
+    mrb_int next_n = 10 * n + (*p - '0'); \
     if (next_n / 10 != n) {\
       mrb_raise(mrb, E_ARGUMENT_ERROR, #val " too big"); \
     } \

--- a/mrbgems/mruby-string-ext/src/string.c
+++ b/mrbgems/mruby-string-ext/src/string.c
@@ -23,7 +23,7 @@ static mrb_value
 mrb_str_setbyte(mrb_state *mrb, mrb_value str)
 {
   mrb_int pos, byte;
-  long len;
+  mrb_int len;
 
   mrb_get_args(mrb, "ii", &pos, &byte);
 

--- a/mrbgems/mruby-string-ext/src/string.c
+++ b/mrbgems/mruby-string-ext/src/string.c
@@ -44,7 +44,7 @@ mrb_str_byteslice(mrb_state *mrb, mrb_value str)
 {
   mrb_value a1;
   mrb_int len;
-  int argc;
+  mrb_int argc;
 
   argc = mrb_get_args(mrb, "o|i", &a1, &len);
   if (argc == 2) {

--- a/mrbgems/mruby-string-ext/src/string.c
+++ b/mrbgems/mruby-string-ext/src/string.c
@@ -35,7 +35,7 @@ mrb_str_setbyte(mrb_state *mrb, mrb_value str)
 
   mrb_str_modify(mrb, mrb_str_ptr(str));
   byte &= 0xff;
-  RSTRING_PTR(str)[pos] = byte;
+  RSTRING_PTR(str)[pos] = (unsigned char)byte;
   return mrb_fixnum_value((unsigned char)byte);
 }
 

--- a/mrbgems/mruby-test/driver.c
+++ b/mrbgems/mruby-test/driver.c
@@ -60,7 +60,7 @@ static void
 t_printstr(mrb_state *mrb, mrb_value obj)
 {
   char *s;
-  int len;
+  mrb_int len;
 
   if (mrb_string_p(obj)) {
     s = RSTRING_PTR(obj);

--- a/mrbgems/mruby-time/src/time.c
+++ b/mrbgems/mruby-time/src/time.c
@@ -634,7 +634,7 @@ mrb_time_initialize(mrb_state *mrb, mrb_value self)
 {
   mrb_int ayear = 0, amonth = 1, aday = 1, ahour = 0,
   amin = 0, asec = 0, ausec = 0;
-  int n;
+  mrb_int n;
   struct mrb_time *tm;
 
   n = mrb_get_args(mrb, "|iiiiiii",

--- a/mrbgems/mruby-time/src/time.c
+++ b/mrbgems/mruby-time/src/time.c
@@ -369,7 +369,7 @@ time_mktime(mrb_state *mrb, mrb_int ayear, mrb_int amonth, mrb_int aday,
     mrb_raise(mrb, E_ARGUMENT_ERROR, "Not a valid time.");
   }
 
-  return time_alloc(mrb, (double)nowsecs, ausec, timezone);
+  return time_alloc(mrb, (double)nowsecs, (double)ausec, timezone);
 }
 
 /* 15.2.19.6.2 */

--- a/src/backtrace.c
+++ b/src/backtrace.c
@@ -75,7 +75,8 @@ each_backtrace(mrb_state *mrb, ptrdiff_t ciidx, mrb_code *pc0, each_backtrace_fu
 static void
 print_backtrace(mrb_state *mrb, mrb_value backtrace)
 {
-  int i, n;
+  int i;
+  mrb_int n;
   FILE *stream = stderr;
 
   if (!mrb_array_p(backtrace)) return;

--- a/src/class.c
+++ b/src/class.c
@@ -569,7 +569,7 @@ mrb_get_args(mrb_state *mrb, const char *format, ...)
   char c;
   int i = 0;
   va_list ap;
-  int argc = mrb->c->ci->argc;
+  mrb_int argc = mrb->c->ci->argc;
   int arg_i = 0;
   mrb_value *array_argv;
   mrb_bool opt = FALSE;

--- a/src/class.c
+++ b/src/class.c
@@ -567,7 +567,7 @@ mrb_get_args(mrb_state *mrb, const char *format, ...)
 {
   const char *fmt = format;
   char c;
-  int i = 0;
+  mrb_int i = 0;
   va_list ap;
   mrb_int argc = mrb->c->ci->argc;
   int arg_i = 0;

--- a/src/class.c
+++ b/src/class.c
@@ -570,7 +570,7 @@ mrb_get_args(mrb_state *mrb, const char *format, ...)
   mrb_int i = 0;
   va_list ap;
   mrb_int argc = mrb->c->ci->argc;
-  int arg_i = 0;
+  mrb_int arg_i = 0;
   mrb_value *array_argv;
   mrb_bool opt = FALSE;
   mrb_bool opt_skip = TRUE;

--- a/src/dump.c
+++ b/src/dump.c
@@ -707,7 +707,7 @@ write_lv_sym_table(mrb_state *mrb, uint8_t **start, mrb_sym const *syms, uint32_
 
   for (i = 0; i < syms_len; ++i) {
     str = mrb_sym2name_len(mrb, syms[i], &str_len);
-    cur += uint16_to_bin(str_len, cur);
+    cur += uint16_to_bin((uint16_t)str_len, cur);
     memcpy(cur, str, str_len);
     cur += str_len;
   }

--- a/src/dump.c
+++ b/src/dump.c
@@ -654,7 +654,7 @@ write_section_debug(mrb_state *mrb, mrb_irep *irep, uint8_t *cur, mrb_sym const 
   for (i = 0; i < filenames_len; ++i) {
     sym = mrb_sym2name_len(mrb, filenames[i], &sym_len);
     mrb_assert(sym);
-    cur += uint16_to_bin(sym_len, cur);
+    cur += uint16_to_bin((uint16_t)sym_len, cur);
     memcpy(cur, sym, sym_len);
     cur += sym_len;
     section_size += sizeof(uint16_t) + sym_len;

--- a/src/error.c
+++ b/src/error.c
@@ -386,7 +386,7 @@ mrb_bug(mrb_state *mrb, const char *fmt, ...)
 }
 
 MRB_API mrb_value
-mrb_make_exception(mrb_state *mrb, int argc, const mrb_value *argv)
+mrb_make_exception(mrb_state *mrb, mrb_int argc, const mrb_value *argv)
 {
   mrb_value mesg;
   int n;

--- a/src/error.c
+++ b/src/error.c
@@ -71,7 +71,7 @@ exc_exception(mrb_state *mrb, mrb_value self)
 {
   mrb_value exc;
   mrb_value a;
-  int argc;
+  mrb_int argc;
 
   argc = mrb_get_args(mrb, "|o", &a);
   if (argc == 0) return self;

--- a/src/gc.c
+++ b/src/gc.c
@@ -551,7 +551,7 @@ mark_context_stack(mrb_state *mrb, struct mrb_context *c)
   size_t i;
   size_t e;
   mrb_value nil;
-  int nregs;
+  mrb_int nregs;
 
   if (c->stack == NULL) return;
   e = c->stack - c->stbase;

--- a/src/gc.c
+++ b/src/gc.c
@@ -1389,7 +1389,7 @@ gc_interval_ratio_set(mrb_state *mrb, mrb_value obj)
   mrb_int ratio;
 
   mrb_get_args(mrb, "i", &ratio);
-  mrb->gc.interval_ratio = ratio;
+  mrb->gc.interval_ratio = (int)ratio;
   return mrb_nil_value();
 }
 

--- a/src/gc.c
+++ b/src/gc.c
@@ -1422,7 +1422,7 @@ gc_step_ratio_set(mrb_state *mrb, mrb_value obj)
   mrb_int ratio;
 
   mrb_get_args(mrb, "i", &ratio);
-  mrb->gc.step_ratio = ratio;
+  mrb->gc.step_ratio = (int)ratio;
   return mrb_nil_value();
 }
 

--- a/src/hash.c
+++ b/src/hash.c
@@ -37,7 +37,7 @@ mrb_hash_ht_hash_func(mrb_state *mrb, mrb_value key)
 
   default:
     hv = mrb_funcall(mrb, key, "hash", 0);
-    h = (khint_t)t ^ mrb_fixnum(hv);
+    h = (khint_t)t ^ (khint_t)mrb_fixnum(hv);
     break;
   }
   return kh_int_hash_func(mrb, h);

--- a/src/hash.c
+++ b/src/hash.c
@@ -136,7 +136,7 @@ mrb_hash_new_capa(mrb_state *mrb, mrb_int capa)
 
   h = (struct RHash*)mrb_obj_alloc(mrb, MRB_TT_HASH, mrb->hash_class);
   /* khash needs 1/4 empty space so it is not resized immediately */
-  h->ht = kh_init_size(ht, mrb, capa*4/3);
+  h->ht = kh_init_size(ht, mrb, (khint_t)(capa*4/3));
   h->iv = 0;
   return mrb_obj_value(h);
 }

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -855,7 +855,7 @@ MRB_API mrb_value
 mrb_f_raise(mrb_state *mrb, mrb_value self)
 {
   mrb_value a[2], exc;
-  int argc;
+  mrb_int argc;
 
 
   argc = mrb_get_args(mrb, "|oo", &a[0], &a[1]);

--- a/src/numeric.c
+++ b/src/numeric.c
@@ -877,7 +877,7 @@ static mrb_value flo_or(mrb_state *mrb, mrb_value x);
 static mrb_value flo_xor(mrb_state *mrb, mrb_value x);
 #define bit_op(x,y,op1,op2) do {\
   if (mrb_fixnum_p(y)) return mrb_fixnum_value(mrb_fixnum(x) op2 mrb_fixnum(y));\
-  return flo_ ## op1(mrb, mrb_float_value(mrb, mrb_fixnum(x)));\
+  return flo_ ## op1(mrb, mrb_float_value(mrb, (mrb_float)mrb_fixnum(x)));\
 } while(0)
 
 /* 15.2.8.3.9  */

--- a/src/numeric.c
+++ b/src/numeric.c
@@ -951,7 +951,7 @@ lshift(mrb_state *mrb, mrb_int val, mrb_int width)
         (val   < (MRB_INT_MIN >> width))) {
       goto bit_overflow;
     }
-    return mrb_fixnum_value(val * (1u << width));
+    return mrb_fixnum_value(val * ((mrb_int)1 << width));
   }
 
 bit_overflow:

--- a/src/numeric.c
+++ b/src/numeric.c
@@ -1162,7 +1162,7 @@ fix_minus(mrb_state *mrb, mrb_value self)
 
 
 MRB_API mrb_value
-mrb_fixnum_to_str(mrb_state *mrb, mrb_value x, int base)
+mrb_fixnum_to_str(mrb_state *mrb, mrb_value x, mrb_int base)
 {
   char buf[MRB_INT_BIT+1];
   char *b = buf + sizeof buf;

--- a/src/object.c
+++ b/src/object.c
@@ -523,7 +523,7 @@ mrb_to_int(mrb_state *mrb, mrb_value val)
 }
 
 MRB_API mrb_value
-mrb_convert_to_integer(mrb_state *mrb, mrb_value val, int base)
+mrb_convert_to_integer(mrb_state *mrb, mrb_value val, mrb_int base)
 {
   mrb_value tmp;
 

--- a/src/pool.c
+++ b/src/pool.c
@@ -25,6 +25,13 @@
 #endif
 /* end of configuration section */
 
+/* Disable MSVC warning "C4200: nonstandard extension used: zero-sized array
+ * in struct/union" when in C++ mode */
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4200)
+#endif
+
 struct mrb_pool_page {
   struct mrb_pool_page *next;
   size_t offset;
@@ -32,6 +39,10 @@ struct mrb_pool_page {
   void *last;
   char page[];
 };
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 struct mrb_pool {
   mrb_state *mrb;

--- a/src/proc.c
+++ b/src/proc.c
@@ -35,7 +35,7 @@ mrb_proc_new(mrb_state *mrb, mrb_irep *irep)
 }
 
 static struct REnv*
-env_new(mrb_state *mrb, int nlocals)
+env_new(mrb_state *mrb, mrb_int nlocals)
 {
   struct REnv *e;
 

--- a/src/range.c
+++ b/src/range.c
@@ -131,7 +131,7 @@ mrb_range_initialize(mrb_state *mrb, mrb_value range)
 {
   mrb_value beg, end;
   mrb_bool exclusive;
-  int n;
+  mrb_int n;
 
   n = mrb_get_args(mrb, "oo|b", &beg, &end, &exclusive);
   if (n != 3) {

--- a/src/state.c
+++ b/src/state.c
@@ -63,7 +63,7 @@ mrb_default_allocf(mrb_state *mrb, void *p, size_t size, void *ud)
 
 struct alloca_header {
   struct alloca_header *next;
-  char buf[];
+  char buf[1];
 };
 
 MRB_API void*

--- a/src/string.c
+++ b/src/string.c
@@ -488,7 +488,7 @@ check_frozen(mrb_state *mrb, struct RString *s)
 static mrb_value
 str_replace(mrb_state *mrb, struct RString *s1, struct RString *s2)
 {
-  long len;
+  mrb_int len;
 
   check_frozen(mrb, s1);
   if (s1 == s2) return mrb_obj_value(s1);

--- a/src/string.c
+++ b/src/string.c
@@ -1467,7 +1467,7 @@ mrb_str_substr(mrb_state *mrb, mrb_value str, mrb_int beg, mrb_int len)
   return str_substr(mrb, str, beg, len);
 }
 
-mrb_int
+uint32_t
 mrb_str_hash(mrb_state *mrb, mrb_value str)
 {
   /* 1-8-7 */
@@ -1480,7 +1480,7 @@ mrb_str_hash(mrb_state *mrb, mrb_value str)
     key = key*65599 + *p;
     p++;
   }
-  return (mrb_int)(key + (key>>5));
+  return (uint32_t)(key + (key>>5));
 }
 
 /* 15.2.10.5.20 */

--- a/src/string.c
+++ b/src/string.c
@@ -1911,7 +1911,7 @@ mrb_str_rindex(mrb_state *mrb, mrb_value str)
 static mrb_value
 mrb_str_split_m(mrb_state *mrb, mrb_value str)
 {
-  int argc;
+  mrb_int argc;
   mrb_value spat = mrb_nil_value();
   enum {awk, string, regexp} split_type = string;
   mrb_int i = 0;

--- a/src/string.c
+++ b/src/string.c
@@ -1125,7 +1125,7 @@ static mrb_value
 mrb_str_aref_m(mrb_state *mrb, mrb_value str)
 {
   mrb_value a1, a2;
-  int argc;
+  mrb_int argc;
 
   argc = mrb_get_args(mrb, "o|o", &a1, &a2);
   if (argc == 2) {

--- a/src/string.c
+++ b/src/string.c
@@ -2025,7 +2025,7 @@ mrb_str_split_m(mrb_state *mrb, mrb_value str)
 }
 
 MRB_API mrb_value
-mrb_str_len_to_inum(mrb_state *mrb, const char *str, size_t len, int base, int badcheck)
+mrb_str_len_to_inum(mrb_state *mrb, const char *str, mrb_int len, mrb_int base, int badcheck)
 {
   const char *p = str;
   const char *pend = str + len;

--- a/src/vm.c
+++ b/src/vm.c
@@ -1754,7 +1754,7 @@ RETRY_TRY_BLOCK:
       }
       else if (len > 1 && argc == 1 && mrb_array_p(argv[0])) {
         mrb_gc_protect(mrb, argv[0]);
-        argc = RARRAY_LEN(argv[0]);
+        argc = (int)RARRAY_LEN(argv[0]);
         argv = RARRAY_PTR(argv[0]);
       }
       if (argc < len) {

--- a/src/vm.c
+++ b/src/vm.c
@@ -454,7 +454,7 @@ mrb_funcall_with_block(mrb_state *mrb, mrb_value self, mrb_sym mid, mrb_int argc
     }
     else {
       if (argc < 0) argc = 1;
-      ci->nregs = p->body.irep->nregs + argc;
+      ci->nregs = (int)(p->body.irep->nregs + argc);
       stack_extend(mrb, ci->nregs);
     }
     if (voff >= 0) {

--- a/src/vm.c
+++ b/src/vm.c
@@ -701,7 +701,7 @@ mrb_yield_with_class(mrb_state *mrb, mrb_value b, mrb_int argc, const mrb_value 
   ci->mid = mid;
   ci->proc = p;
   ci->stackent = mrb->c->stack;
-  ci->argc = argc;
+  ci->argc = (int)argc;
   ci->target_class = c;
   ci->acc = CI_ACC_SKIP;
   mrb->c->stack = mrb->c->stack + n;

--- a/src/vm.c
+++ b/src/vm.c
@@ -435,7 +435,7 @@ mrb_funcall_with_block(mrb_state *mrb, mrb_value self, mrb_sym mid, mrb_int argc
     ci->mid = mid;
     ci->proc = p;
     ci->stackent = mrb->c->stack;
-    ci->argc = argc;
+    ci->argc = (int)argc;
     ci->target_class = c;
     mrb->c->stack = mrb->c->stack + n;
     if (mrb->c->stbase <= argv && argv < mrb->c->stend) {

--- a/src/vm.c
+++ b/src/vm.c
@@ -2628,7 +2628,7 @@ RETRY_TRY_BLOCK:
         v = mrb_ary_new_from_values(mrb, 1, &regs[a]);
       }
       ary = mrb_ary_ptr(v);
-      len = ARY_LEN(ary);
+      len = (int)ARY_LEN(ary);
       if (len > pre + post) {
         v = mrb_ary_new_from_values(mrb, len - pre - post, ARY_PTR(ary)+pre);
         regs[a++] = v;

--- a/src/vm.c
+++ b/src/vm.c
@@ -705,7 +705,7 @@ mrb_yield_with_class(mrb_state *mrb, mrb_value b, mrb_int argc, const mrb_value 
   ci->target_class = c;
   ci->acc = CI_ACC_SKIP;
   mrb->c->stack = mrb->c->stack + n;
-  ci->nregs = MRB_PROC_CFUNC_P(p) ? argc+2 : p->body.irep->nregs;
+  ci->nregs = MRB_PROC_CFUNC_P(p) ? (int)(argc+2) : p->body.irep->nregs;
   stack_extend(mrb, ci->nregs);
 
   mrb->c->stack[0] = self;

--- a/src/vm.c
+++ b/src/vm.c
@@ -442,7 +442,7 @@ mrb_funcall_with_block(mrb_state *mrb, mrb_value self, mrb_sym mid, mrb_int argc
       voff = argv - mrb->c->stbase;
     }
     if (MRB_PROC_CFUNC_P(p)) {
-      ci->nregs = argc + 2;
+      ci->nregs = (int)(argc + 2);
       stack_extend(mrb, ci->nregs);
     }
     else if (argc >= CALL_MAXARGS) {

--- a/src/vm.c
+++ b/src/vm.c
@@ -1699,7 +1699,7 @@ RETRY_TRY_BLOCK:
           struct RArray *ary = mrb_ary_ptr(stack[m1]);
 
           pp = ARY_PTR(ary);
-          len = ARY_LEN(ary);
+          len = (int)ARY_LEN(ary);
         }
         regs[a] = mrb_ary_new_capa(mrb, m1+len+m2);
         rest = mrb_ary_ptr(regs[a]);

--- a/src/vm.c
+++ b/src/vm.c
@@ -1741,7 +1741,7 @@ RETRY_TRY_BLOCK:
       if (argc < 0) {
         struct RArray *ary = mrb_ary_ptr(regs[1]);
         argv = ARY_PTR(ary);
-        argc = ARY_LEN(ary);
+        argc = (int)ARY_LEN(ary);
         mrb_gc_protect(mrb, regs[1]);
       }
       if (mrb->c->ci->proc && MRB_PROC_STRICT_P(mrb->c->ci->proc)) {


### PR DESCRIPTION
I fixed all warnings exposed by Appveyor MSVC 14.0, except one related to exception handling. Mostly fixing `int` vs `mrb_int` casts.