### PR TITLE
Improved Kernel#raise

### DIFF
--- a/mrbgems/mruby-kernel-ext/test/kernel.rb
+++ b/mrbgems/mruby-kernel-ext/test/kernel.rb
@@ -1,6 +1,15 @@
-assert('Kernel.fail, Kernel#fail') do
-  assert_raise(RuntimeError) { fail }
-  assert_raise(RuntimeError) { Kernel.fail }
+assert('Kernel#fail') do
+  # identical to Kernel#raise, test availability only
+  assert_raise_with_message NameError, "error message" do
+    fail NameError, "error message"
+  end
+end
+
+assert('Kernel.fail') do
+  # identical to Kernel.raise, test availability only
+  assert_raise_with_message NameError, "error message" do
+    Kernel.fail NameError, "error message"
+  end
 end
 
 assert('Kernel.caller, Kernel#caller') do

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -833,7 +833,7 @@ mrb_obj_public_methods(mrb_state *mrb, mrb_value self)
  *  call-seq:
  *     raise
  *     raise(string)
- *     raise(exception [, string])
+ *     raise(exception [, string [, array]])
  *
  *  With no arguments, raises a <code>RuntimeError</code>
  *  With a single +String+ argument, raises a
@@ -851,11 +851,11 @@ mrb_obj_public_methods(mrb_state *mrb, mrb_value self)
 MRB_API mrb_value
 mrb_f_raise(mrb_state *mrb, mrb_value self)
 {
-  mrb_value a[2], exc;
+  mrb_value a[3], exc;
   mrb_int argc;
 
 
-  argc = mrb_get_args(mrb, "|oo", &a[0], &a[1]);
+  argc = mrb_get_args(mrb, "|ooo", &a[0], &a[1], &a[2]);
   switch (argc) {
   case 0:
     mrb_raise(mrb, E_RUNTIME_ERROR, "");

--- a/test/assert.rb
+++ b/test/assert.rb
@@ -166,6 +166,35 @@ def assert_raise(*exc)
   end
 end
 
+def assert_raise_with_message(exc_cls, exc_msg, msg = nil)
+  return true unless $mrbtest_assert
+  $mrbtest_assert_idx += 1
+
+  begin
+    yield
+    msg ||= "Expected to raise #{exc_cls} but nothing was raised."
+    diff = nil
+    $mrbtest_assert.push [$mrbtest_assert_idx, msg, diff]
+    false
+  rescue exc_cls => e
+    if exc_msg == e.message
+      true
+    else
+      msg ||= "Expected to raise #{exc_cls} with message #{exc_msg.inspect}, not"
+      diff = "      Class: <#{e.class}>\n" +
+             "    Message: #{e.message}"
+      $mrbtest_assert.push [$mrbtest_assert_idx, msg, diff]
+      false
+    end
+  rescue Exception => e
+    msg ||= "Expected to raise #{exc_cls}, not"
+    diff = "      Class: <#{e.class}>\n" +
+           "    Message: #{e.message}"
+    $mrbtest_assert.push [$mrbtest_assert_idx, msg, diff]
+    false
+  end
+end
+
 def assert_nothing_raised(msg = nil)
   return true unless $mrbtest_assert
   $mrbtest_assert_idx += 1

--- a/test/t/exception.rb
+++ b/test/t/exception.rb
@@ -364,6 +364,39 @@ assert('Exception#backtrace') do
       e.backtrace
     end
   end
+
+  # Don't continue unless backtraces are actually available
+  begin
+    raise "get backtrace"
+  rescue => e
+    next if e.backtrace.empty?
+  end
+
+  def raiser
+    raise "error"
+  end
+  raise_loc = "#{__FILE__}:#{__LINE__-2}:in raiser"
+
+  def reraiser
+    raiser
+  rescue => e
+    raise e
+  end
+  reraise_loc = "#{__FILE__}:#{__LINE__-4}:in reraiser"
+
+  backtrace = begin
+    raiser
+  rescue => e
+    e.backtrace
+  end
+  assert_equal raise_loc, backtrace.first
+
+  backtrace = begin
+    reraiser
+  rescue => e
+    e.backtrace
+  end
+  assert_equal [raise_loc, reraise_loc], backtrace.first(2)
 end
 
 assert('Raise in ensure') do

--- a/test/t/kernel.rb
+++ b/test/t/kernel.rb
@@ -79,12 +79,20 @@ assert('Kernel.puts', '15.3.1.2.11') do
 end
 
 assert('Kernel.raise', '15.3.1.2.12') do
-  assert_raise RuntimeError do
+  assert_raise_with_message RuntimeError, "" do
     Kernel.raise
   end
 
-  assert_raise RuntimeError do
-    Kernel.raise RuntimeError.new
+  assert_raise_with_message RuntimeError, "error message" do
+    Kernel.raise "error message"
+  end
+
+  assert_raise_with_message NameError, "error message" do
+    Kernel.raise NameError.new("error message")
+  end
+
+  assert_raise_with_message NameError, "error message" do
+    Kernel.raise NameError, "error message"
   end
 end
 
@@ -458,12 +466,20 @@ end
 # Kernel#puts is defined in mruby-print mrbgem. '15.3.1.3.39'
 
 assert('Kernel#raise', '15.3.1.3.40') do
-  assert_raise RuntimeError do
+  assert_raise_with_message RuntimeError, "" do
     raise
   end
 
-  assert_raise RuntimeError do
-    raise RuntimeError.new
+  assert_raise_with_message RuntimeError, "error message" do
+    raise "error message"
+  end
+
+  assert_raise_with_message NameError, "error message" do
+    raise NameError.new("error message")
+  end
+
+  assert_raise_with_message NameError, "error message" do
+    raise NameError, "error message"
   end
 end
 

--- a/test/t/kernel.rb
+++ b/test/t/kernel.rb
@@ -94,6 +94,31 @@ assert('Kernel.raise', '15.3.1.2.12') do
   assert_raise_with_message NameError, "error message" do
     Kernel.raise NameError, "error message"
   end
+
+  assert_raise_with_message TypeError, "backtrace must be Array of String" do
+    Kernel.raise RuntimeError, "error message", "no array"
+  end
+
+  backtrace = begin
+    Kernel.raise RuntimeError, "error message", ['loc0', 'loc1']
+  rescue => e
+    e.backtrace
+  end
+  assert_equal ['loc0', 'loc1'], backtrace
+
+  # Don't continue unless actual backtraces are available
+  begin
+    raise "get backtrace"
+  rescue => e
+    next if e.backtrace.empty?
+  end
+
+  backtrace = begin
+    Kernel.raise RuntimeError, "error message"
+  rescue => e
+    e.backtrace
+  end
+  assert_equal "#{__FILE__}:#{__LINE__-4}:in call", backtrace.first
 end
 
 assert('Kernel#__id__', '15.3.1.3.3') do
@@ -481,6 +506,31 @@ assert('Kernel#raise', '15.3.1.3.40') do
   assert_raise_with_message NameError, "error message" do
     raise NameError, "error message"
   end
+
+  assert_raise_with_message TypeError, "backtrace must be Array of String" do
+    raise RuntimeError, "error message", "no array"
+  end
+
+  backtrace = begin
+    raise RuntimeError, "error message", ['loc0', 'loc1']
+  rescue => e
+    e.backtrace
+  end
+  assert_equal ['loc0', 'loc1'], backtrace
+
+  # Don't continue unless actual backtraces are available
+  begin
+    raise "get backtrace"
+  rescue => e
+    next if e.backtrace.empty?
+  end
+
+  backtrace = begin
+    raise RuntimeError, "error message"
+  rescue => e
+    e.backtrace
+  end
+  assert_equal "#{__FILE__}:#{__LINE__-4}:in call", backtrace.first
 end
 
 assert('Kernel#remove_instance_variable', '15.3.1.3.41') do


### PR DESCRIPTION
1) ~~`raise` with no arguments now raises a NotImplementedError with a proper message.~~ (removed, see below)
2) ~~Re-raised errors now keep their backtrace like in CRuby.~~ (already added by #3840 in the meantime)
3) `raise exc, msg, backtrace` with a backtrace as third argument is now supported.