### PR TITLE
Bug/paren arg

### DIFF
--- a/mrbgems/mruby-compiler/core/parse.y
+++ b/mrbgems/mruby-compiler/core/parse.y
@@ -5078,6 +5078,9 @@ parser_yylex(parser_state *p)
     else if (IS_SPCARG(-1)) {
       c = tLPAREN_ARG;
     }
+    else if (p->lstate == EXPR_END && space_seen) {
+      c = tLPAREN_ARG;
+    }
     p->paren_nest++;
     COND_PUSH(0);
     CMDARG_PUSH(0);
@@ -5497,11 +5500,9 @@ parser_yylex(parser_state *p)
       mrb_sym ident = intern_cstr(tok(p));
 
       pylval.id = ident;
-#if 0
       if (last_state != EXPR_DOT && islower(tok(p)[0]) && local_var_p(p, ident)) {
         p->lstate = EXPR_END;
       }
-#endif
     }
     return result;
   }

--- a/mrbgems/mruby-compiler/core/parse.y
+++ b/mrbgems/mruby-compiler/core/parse.y
@@ -5498,7 +5498,7 @@ parser_yylex(parser_state *p)
 
       pylval.id = ident;
 #if 0
-      if (last_state != EXPR_DOT && islower(tok(p)[0]) && lvar_defined(ident)) {
+      if (last_state != EXPR_DOT && islower(tok(p)[0]) && local_var_p(p, ident)) {
         p->lstate = EXPR_END;
       }
 #endif


### PR DESCRIPTION
trick2013/yhara/entry.rb has a conditional operator `?` just followed by a local variable,`String===x ?x.upcase:`.
mruby parses it as a string literal.

```
$ ~-/bin/mruby -v -c sample/trick2013/yhara/entry.rb 
mruby 1.3.0 (2017-7-4) 
sample/trick2013/yhara/entry.rb:1:37: syntax error, unexpected tCHAR, expecting keyword_do or '{' or '('
sample/trick2013/yhara/entry.rb:1:45: syntax error, unexpected ':', expecting ')'
SyntaxError: syntax error
```