### PR TITLE
correctly handle *splat arguments in mrb_get_argc

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -858,11 +858,21 @@ mrb_get_mid(mrb_state *mrb) /* get method symbol */
   return mrb->c->ci->mid;
 }
 
+/* returns -1 for *splat arguments */
 static inline mrb_int
-mrb_get_argc(mrb_state *mrb) /* get argc */
+mrb_vm_get_argc(mrb_state *mrb) /* get argc */
 {
   return mrb->c->ci->argc;
 }
+
+/**
+ * Retrieve number of arguments from mrb_state.
+ *
+ * Correctly handles *splat arguments.
+ */
+MRB_API mrb_int mrb_get_argc(mrb_state *mrb);
+
+MRB_API mrb_value* mrb_get_argv(mrb_state *mrb);
 
 /* `strlen` for character string literals (use with caution or `strlen` instead)
     Adjacent string literals are concatenated in C/C++ in translation phase 6.

--- a/src/class.c
+++ b/src/class.c
@@ -532,6 +532,34 @@ to_sym(mrb_state *mrb, mrb_value ss)
   }
 }
 
+MRB_API mrb_int
+mrb_get_argc(mrb_state *mrb)
+{
+  mrb_int argc = mrb_vm_get_argc(mrb);
+  if (argc < 0) {
+    struct RArray *a = mrb_ary_ptr(mrb->c->stack[1]);
+
+    argc = ARY_LEN(a);
+  }
+  return argc;
+}
+
+MRB_API mrb_value*
+mrb_get_argv(mrb_state *mrb)
+{
+  mrb_int argc = mrb_vm_get_argc(mrb);
+  mrb_value *array_argv;
+  if (argc < 0) {
+    struct RArray *a = mrb_ary_ptr(mrb->c->stack[1]);
+
+    array_argv = ARY_PTR(a);
+  }
+  else {
+    array_argv = NULL;
+  }
+  return array_argv;
+}
+
 /*
   retrieve arguments from mrb_state.
 
@@ -569,23 +597,14 @@ mrb_get_args(mrb_state *mrb, const char *format, ...)
   char c;
   mrb_int i = 0;
   va_list ap;
-  mrb_int argc = mrb->c->ci->argc;
+  mrb_int argc = mrb_get_argc(mrb);
   mrb_int arg_i = 0;
-  mrb_value *array_argv;
+  mrb_value *array_argv = mrb_get_argv(mrb);
   mrb_bool opt = FALSE;
   mrb_bool opt_skip = TRUE;
   mrb_bool given = TRUE;
 
   va_start(ap, format);
-  if (argc < 0) {
-    struct RArray *a = mrb_ary_ptr(mrb->c->stack[1]);
-
-    argc = ARY_LEN(a);
-    array_argv = ARY_PTR(a);
-  }
-  else {
-    array_argv = NULL;
-  }
 
 #define ARGV \
   (array_argv ? array_argv : (mrb->c->stack + 1))


### PR DESCRIPTION
also add `mrb_vm_get_argc` and `mrb_get_argv`

Fixes #3825

It doesn't look like the original version of `mrb_get_argc` was used anywhere in mruby.