### PR TITLE
Correct a small error in parse.y

### DIFF
--- a/mrbgems/mruby-compiler/core/parse.y
+++ b/mrbgems/mruby-compiler/core/parse.y
@@ -5723,7 +5723,7 @@ mrb_parser_set_filename(struct mrb_parser_state *p, const char *f)
 
   new_table = (mrb_sym*)parser_palloc(p, sizeof(mrb_sym) * p->filename_table_length);
   if (p->filename_table) {
-    memmove(new_table, p->filename_table, sizeof(mrb_sym) * p->filename_table_length);
+    memmove(new_table, p->filename_table, sizeof(mrb_sym) * p->current_filename_index);
   }
   p->filename_table = new_table;
   p->filename_table[p->filename_table_length - 1] = sym;


### PR DESCRIPTION
While running mruby with address sanitizer, it detected a small error in parse.y where some bytes are copied from an unallocated area. This practically causes no harm because the location is immediately rewritten with correct data, but I had to correct it in order to continue with my debugging.

You may want to fix it in the official repo.