### PR TITLE
Appveyor Improvements

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,6 +22,9 @@ environment:
 
 init:
   - call "%visualcpp%" %machine%
+  # For using Rubyinstaller's Ruby 2.4 64bit
+  - set PATH=C:\Ruby24-x64\bin;%PATH%
+  - ruby --version
 
 
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,10 @@ os: Visual Studio 2015
 clone_depth: 50
 
 
+cache:
+  - win_flex_bison-2.5.10.zip
+
+
 environment:
   matrix:
     # Visual Studio 2015 64bit
@@ -18,10 +22,14 @@ environment:
 
 init:
   - call "%visualcpp%" %machine%
-  # For using bison.exe
-  - set PATH=%PATH%;C:\cygwin\bin;
+
+
+install:
+  - if not exist win_flex_bison-2.5.10.zip appveyor DownloadFile "https://github.com/lexxmark/winflexbison/releases/download/v.2.5.10/win_flex_bison-2.5.10.zip"
+  - 7z x -y -owin_flex_bison win_flex_bison-2.5.10.zip > nul
 
 
 build_script:
+  - set YACC=.\win_flex_bison\win_bison.exe
   - set MRUBY_CONFIG=appveyor_config.rb
-  - ruby .\minirake test
+  - ruby .\minirake test all

--- a/appveyor_config.rb
+++ b/appveyor_config.rb
@@ -5,7 +5,7 @@ MRuby::Build.new('debug') do |conf|
   # include all core GEMs
   conf.gembox 'full-core'
   conf.compilers.each do |c|
-    c.defines += %w(MRB_GC_STRESS MRB_GC_FIXED_ARENA)
+    c.defines += %w(MRB_GC_STRESS MRB_GC_FIXED_ARENA MRB_METHOD_CACHE)
   end
 
   build_mrbc_exec


### PR DESCRIPTION
Current appveyor.yml uses PATH to add Cygwin's bin directory for using bison. If Cygwin's ruby overrides AppVeyor's default Ruby, It might be bad for bintest of mruby.