### PR TITLE
Remove one of the lines that did the same thing

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -2736,7 +2736,6 @@ RETRY_TRY_BLOCK:
       p = mrb_proc_new(mrb, nirep);
       p->c = NULL;
       mrb_field_write_barrier(mrb, (struct RBasic*)p, (struct RBasic*)proc);
-      MRB_PROC_SET_TARGET_CLASS(p, mrb_class_ptr(recv));
       p->flags |= MRB_PROC_SCOPE;
 
       /* prepare stack */


### PR DESCRIPTION
This line is apparently useless, because a bit lower there is almost the same line.