### PR TITLE
don't strip away backtrace info when an exception is re-thrown

### DIFF
--- a/src/backtrace.c
+++ b/src/backtrace.c
@@ -215,11 +215,14 @@ packed_backtrace(mrb_state *mrb)
 void
 mrb_keep_backtrace(mrb_state *mrb, mrb_value exc)
 {
+  mrb_sym sym = mrb_intern_lit(mrb, "backtrace");
   mrb_value backtrace;
-  int ai = mrb_gc_arena_save(mrb);
+  int ai;
 
+  if (mrb_iv_defined(mrb, exc, sym)) return;
+  ai = mrb_gc_arena_save(mrb);
   backtrace = packed_backtrace(mrb);
-  mrb_iv_set(mrb, exc, mrb_intern_lit(mrb, "backtrace"), backtrace);
+  mrb_iv_set(mrb, exc, sym, backtrace);
   mrb_gc_arena_restore(mrb, ai);
 }
 

--- a/src/error.c
+++ b/src/error.c
@@ -200,6 +200,7 @@ exc_debug_info(mrb_state *mrb, struct RObject *exc)
   mrb_callinfo *ci = mrb->c->ci;
   mrb_code *pc = ci->pc;
 
+  if (mrb_obj_iv_defined(mrb, exc, mrb_intern_lit(mrb, "file"))) return;
   while (ci >= mrb->c->cibase) {
     mrb_code *err = ci->err;
 


### PR DESCRIPTION
When an exception is not caught by rescue cluases of the current block, mruby re-throw it using `OP_RAISE`.  But`OP_RAISE` overwrites backtrace information of the exception unconditionally so a part of backtrace information is stripped away.

```rb
% cat a.rb
def fun
  begin
    xyzzy
  rescue NoMemoryError
  end
end

fun
```

```
% bin/mruby a.rb
trace:
        [0] a.rb:8
a.rb:8: undefined method 'xyzzy' for main (NoMethodError)
```

The backtrace output above does not point to the location where an exception was originally thrown, but _the caller_ of the procedure.  With this patch, mruby points to the correct location.

```
% bin/mruby a.rb
trace:
        [0] a.rb:8
        [1] a.rb:3:in fun
a.rb:3: undefined method 'xyzzy' for main (NoMethodError)
```
