### PR TITLE
[WIP] Add sanitizer support in gcc like toolchain.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,27 @@
 language: c
 
-sudo: false
-
 matrix:
   include:
     - os: linux
-      sudo: 9000
+      sudo: false
+      dist: trusty
     - os: osx
-      osx_image: xcode7.1
 
 addons:
   apt:
+    sources:
+      - ubuntu-toolchain-r-test
     packages:
       - gperf
+      - gcc-6
+      - g++-6
 
-env: MRUBY_CONFIG=travis_config.rb
+env:
+  - MRUBY_CONFIG=travis_config.rb
+before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; brew install gcc@6 ; fi
+  - export CC=gcc-6
+  - export CXX=g++-6
+  - export LD=gcc-6
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export LDFLAGS="-fuse-ld=gold" ; fi
 script: "./minirake all test"

--- a/mrbgems/mruby-socket/test/sockettest.c
+++ b/mrbgems/mruby-socket/test/sockettest.c
@@ -1,11 +1,15 @@
 #include <stdio.h>
+#include <stdlib.h>
 
 #include "mruby.h"
 
 mrb_value
 mrb_sockettest_tmppath(mrb_state *mrb, mrb_value klass)
 {
-  return mrb_str_new_cstr(mrb, tempnam(NULL, "mruby-socket"));
+  char *tmp = tempnam(NULL, "mruby-socket");
+  mrb_value str = mrb_str_new_cstr(mrb, tmp);
+  free(tmp);
+  return str;
 }
 
 void

--- a/tasks/toolchains/gcc.rake
+++ b/tasks/toolchains/gcc.rake
@@ -55,4 +55,12 @@ MRuby::Toolchain.new(:gcc) do |conf, _params|
       @header_search_paths
     end
   end
+
+  def conf.enable_sanitizer(*opts)
+    fail 'sanitizer already set' if @sanitizer_list
+
+    @sanitizer_list = opts
+    flg = "-fsanitize=#{opts.join ','}"
+    [self.cc, self.cxx, self.linker].each{|cmd| cmd.flags << flg }
+  end
 end

--- a/travis_config.rb
+++ b/travis_config.rb
@@ -1,6 +1,7 @@
 MRuby::Build.new('debug') do |conf|
   toolchain :gcc
   enable_debug
+  enable_sanitizer :address, :undefined, :leak
 
   # include all core GEMs
   conf.gembox 'full-core'
@@ -15,6 +16,7 @@ end
 MRuby::Build.new('full-debug') do |conf|
   toolchain :gcc
   enable_debug
+  enable_sanitizer :address, :undefined, :leak
 
   # include all core GEMs
   conf.gembox 'full-core'
@@ -25,6 +27,7 @@ end
 
 MRuby::Build.new do |conf|
   toolchain :gcc
+  enable_sanitizer :address, :undefined, :leak
 
   # include all core GEMs
   conf.gembox 'full-core'
@@ -38,6 +41,7 @@ end
 
 MRuby::Build.new('cxx_abi') do |conf|
   toolchain :gcc
+  enable_sanitizer :address, :undefined, :leak
 
   conf.gembox 'full-core'
   conf.cc.flags += %w(-Werror=declaration-after-statement)


### PR DESCRIPTION
Travis build of macos takes too much time to fix...
Is there any fast starting macos CI service?

- [x] Define `enable_sanitizer` method in gcc like toolchain(including clang).
- [x] Fix leak of mruby-socket test caused by `tempnam`.
- [ ] Need to fix travis osx build error.