### PR TITLE
Fix socket closing

### DIFF
--- a/mrbgems/mruby-io/include/mruby/ext/io.h
+++ b/mrbgems/mruby-io/include/mruby/ext/io.h
@@ -15,7 +15,8 @@ struct mrb_io {
   int pid;  /* child's pid (for pipes)  */
   unsigned int readable:1,
                writable:1,
-               sync:1;
+               sync:1,
+               is_socket:1;
 };
 
 #define FMODE_READABLE             0x00000001

--- a/mrbgems/mruby-io/src/io.c
+++ b/mrbgems/mruby-io/src/io.c
@@ -471,8 +471,18 @@ fptr_finalize(mrb_state *mrb, struct mrb_io *fptr, int quiet)
   }
 
   if (fptr->fd > 2) {
-    if (close(fptr->fd) == -1) {
-      saved_errno = errno;
+#ifdef _WIN32
+    if (fptr->is_socket) {
+      if (closesocket(fptr->fd) != 0) {
+        saved_errno = WSAGetLastError();
+      }
+      fptr->fd = -1;
+    }
+#endif
+    if (fptr->fd != -1) {
+      if (close(fptr->fd) == -1) {
+        saved_errno = errno;
+      }
     }
     fptr->fd = -1;
   }

--- a/mrbgems/mruby-socket/mrblib/socket.rb
+++ b/mrbgems/mruby-socket/mrblib/socket.rb
@@ -165,7 +165,7 @@ class Addrinfo
   end
 end
 
-class BasicSocket
+class BasicSocket < IO
   @@do_not_reverse_lookup = true
 
   def self.do_not_reverse_lookup
@@ -208,7 +208,7 @@ class BasicSocket
   attr_accessor :do_not_reverse_lookup
 end
 
-class IPSocket
+class IPSocket < BasicSocket
   def self.getaddress(host)
     Addrinfo.ip(host).ip_address
   end
@@ -227,7 +227,7 @@ class IPSocket
   end
 end
 
-class TCPSocket
+class TCPSocket < IPSocket
   def initialize(host, service, local_host=nil, local_service=nil)
     if @init_with_fd
       super(host, service)
@@ -264,7 +264,7 @@ class TCPSocket
   #def self.gethostbyname(host)
 end
 
-class TCPServer
+class TCPServer < TCPSocket
   def initialize(host=nil, service)
     ai = Addrinfo.getaddrinfo(host, service, nil, nil, nil, Socket::AI_PASSIVE)[0]
     @init_with_fd = true
@@ -306,7 +306,7 @@ class TCPServer
   end
 end
 
-class UDPSocket
+class UDPSocket < IPSocket
   def initialize(af=Socket::AF_INET)
     super(Socket._socket(af, Socket::SOCK_DGRAM, 0), "r+")
     @af = af
@@ -350,7 +350,7 @@ class UDPSocket
   end
 end
 
-class Socket
+class Socket < BasicSocket
   def initialize(domain, type, protocol=0)
     super(Socket._socket(domain, type, protocol), "r+")
   end

--- a/mrbgems/mruby-socket/mrblib/socket.rb
+++ b/mrbgems/mruby-socket/mrblib/socket.rb
@@ -178,6 +178,7 @@ class BasicSocket
 
   def initialize(*args)
     super(*args)
+    self.is_socket = true
     @do_not_reverse_lookup = @@do_not_reverse_lookup
   end
 

--- a/mrbgems/mruby-socket/src/socket.c
+++ b/mrbgems/mruby-socket/src/socket.c
@@ -35,6 +35,8 @@
 #include "mruby/variable.h"
 #include "error.h"
 
+#include "mruby/ext/io.h"
+
 #define E_SOCKET_ERROR             (mrb_class_get(mrb, "SocketError"))
 
 #if !defined(mrb_cptr)
@@ -471,6 +473,21 @@ mrb_basicsocket_shutdown(mrb_state *mrb, mrb_value self)
 }
 
 static mrb_value
+mrb_basicsocket_set_is_socket(mrb_state *mrb, mrb_value self)
+{
+  mrb_bool b;
+  struct mrb_io *io_p;
+  mrb_get_args(mrb, "b", &b);
+
+  io_p = (struct mrb_io*)DATA_PTR(self);
+  if (io_p) {
+    io_p->is_socket = b;
+  }
+
+  return mrb_bool_value(b);
+}
+
+static mrb_value
 mrb_ipsocket_ntop(mrb_state *mrb, mrb_value klass)
 {
   mrb_int af, n;
@@ -829,6 +846,7 @@ mrb_mruby_socket_gem_init(mrb_state* mrb)
   // #sendmsg_nonblock
   mrb_define_method(mrb, bsock, "setsockopt", mrb_basicsocket_setsockopt, MRB_ARGS_REQ(1)|MRB_ARGS_OPT(2));
   mrb_define_method(mrb, bsock, "shutdown", mrb_basicsocket_shutdown, MRB_ARGS_OPT(1));
+  mrb_define_method(mrb, bsock, "is_socket=", mrb_basicsocket_set_is_socket, MRB_ARGS_REQ(1));
 
   ipsock = mrb_define_class(mrb, "IPSocket", bsock);
   mrb_define_class_method(mrb, ipsock, "ntop", mrb_ipsocket_ntop, MRB_ARGS_REQ(1));

--- a/mrbgems/mruby-socket/test/unix.rb
+++ b/mrbgems/mruby-socket/test/unix.rb
@@ -1,5 +1,3 @@
-unless SocketTest.win?
-
 def unixserver_test_block
   path = SocketTest.tmppath
   File.unlink path rescue nil
@@ -126,5 +124,3 @@ assert('UNIXSocket#recvfrom') do
     # a[1][1] would be "" or something
   end
 end
-
-end  # win?


### PR DESCRIPTION
Seems like it needs to call `closesocket` instead of `close` in Windows.
https://msdn.microsoft.com/en-us/library/windows/desktop/ms737582(v=vs.85).aspx

[`BasicSocket#close`](https://github.com/iij/mruby-socket/blob/ab54185005ec87fe4f5b10df95ad29659884141b/src/socket.c#L721) does support it but in mruby-io it isn't.