### PR TITLE
Make source compilable with C++17

### DIFF
--- a/mrbgems/mruby-bin-debugger/tools/mrdb/apibreak.c
+++ b/mrbgems/mruby-bin-debugger/tools/mrdb/apibreak.c
@@ -193,7 +193,7 @@ mrb_debug_set_break_line(mrb_state *mrb, mrb_debug_context *dbg, const char *fil
     return MRB_DEBUG_BREAK_INVALID_LINENO;
   }
 
-  set_file = mrb_malloc(mrb, strlen(file) + 1);
+  set_file = (char*)mrb_malloc(mrb, strlen(file) + 1);
 
   index = dbg->bpnum;
   dbg->bp[index].bpno = dbg->next_bpno;
@@ -230,14 +230,14 @@ mrb_debug_set_break_method(mrb_state *mrb, mrb_debug_context *dbg, const char *c
   }
 
   if (class_name != NULL) {
-    set_class = mrb_malloc(mrb, strlen(class_name) + 1);
+    set_class = (char*)mrb_malloc(mrb, strlen(class_name) + 1);
     strncpy(set_class, class_name, strlen(class_name) + 1);
   }
   else {
     set_class = NULL;
   }
 
-  set_method = mrb_malloc(mrb, strlen(method_name) + 1);
+  set_method = (char*)mrb_malloc(mrb, strlen(method_name) + 1);
 
   strncpy(set_method, method_name, strlen(method_name) + 1);
 
@@ -503,5 +503,3 @@ mrb_debug_check_breakpoint_method(mrb_state *mrb, mrb_debug_context *dbg, struct
 
   return 0;
 }
-
-

--- a/mrbgems/mruby-bin-debugger/tools/mrdb/apilist.c
+++ b/mrbgems/mruby-bin-debugger/tools/mrdb/apilist.c
@@ -48,7 +48,7 @@ build_path(mrb_state *mrb, const char *dir, const char *base)
     len += strlen(dir) + sizeof("/") - 1;
   }
 
-  path = mrb_malloc(mrb, len);
+  path = (char*)mrb_malloc(mrb, len);
   memset(path, 0, len);
 
   if (strcmp(dir, ".")) {
@@ -64,7 +64,8 @@ static char*
 dirname(mrb_state *mrb, const char *path)
 {
   size_t len;
-  char *p, *dir;
+  const char *p;
+  char *dir;
 
   if (path == NULL) {
     return NULL;
@@ -73,7 +74,7 @@ dirname(mrb_state *mrb, const char *path)
   p = strrchr(path, '/');
   len = p != NULL ? (size_t)(p - path) : strlen(path);
 
-  dir = mrb_malloc(mrb, len + 1);
+  dir = (char*)mrb_malloc(mrb, len + 1);
   strncpy(dir, path, len);
   dir[len] = '\0';
 
@@ -85,7 +86,7 @@ source_file_new(mrb_state *mrb, mrb_debug_context *dbg, char *filename)
 {
   source_file *file = NULL;
 
-  file = mrb_malloc(mrb, sizeof(source_file));
+  file = (source_file*)mrb_malloc(mrb, sizeof(source_file));
 
   memset(file, '\0', sizeof(source_file));
   file->fp = fopen(filename, "rb");
@@ -96,7 +97,7 @@ source_file_new(mrb_state *mrb, mrb_debug_context *dbg, char *filename)
   }
 
   file->lineno = 1;
-  file->path = mrb_malloc(mrb, strlen(filename) + 1);
+  file->path = (char*)mrb_malloc(mrb, strlen(filename) + 1);
   strcpy(file->path, filename);
   return file;
 }

--- a/mrbgems/mruby-bin-debugger/tools/mrdb/cmdmisc.c
+++ b/mrbgems/mruby-bin-debugger/tools/mrdb/cmdmisc.c
@@ -133,7 +133,7 @@ typedef struct listcmd_parser_state {
 static listcmd_parser_state*
 listcmd_parser_state_new(mrb_state *mrb)
 {
-  listcmd_parser_state *st = mrb_malloc(mrb, sizeof(listcmd_parser_state));
+  listcmd_parser_state *st = (listcmd_parser_state*)mrb_malloc(mrb, sizeof(listcmd_parser_state));
   memset(st, 0, sizeof(listcmd_parser_state));
   return st;
 }
@@ -227,7 +227,7 @@ parse_filename(mrb_state *mrb, char **sp, listcmd_parser_state *st)
   }
 
   if (len > 0) {
-    st->filename = mrb_malloc(mrb, len + 1);
+    st->filename = (char*)mrb_malloc(mrb, len + 1);
     strncpy(st->filename, *sp, len);
     st->filename[len] = '\0';
     *sp += len;
@@ -242,7 +242,8 @@ char*
 replace_ext(mrb_state *mrb, const char *filename, const char *ext)
 {
   size_t len;
-  char *p, *s;
+  const char *p;
+  char *s;
 
   if (filename == NULL) {
     return NULL;
@@ -255,7 +256,7 @@ replace_ext(mrb_state *mrb, const char *filename, const char *ext)
     len = strlen(filename);
   }
 
-  s = mrb_malloc(mrb, len + strlen(ext) + 1);
+  s = (char*)mrb_malloc(mrb, len + strlen(ext) + 1);
   memset(s, '\0', len + strlen(ext) + 1);
   strncpy(s, filename, len);
   strcat(s, ext);
@@ -325,7 +326,7 @@ parse_listcmd_args(mrb_state *mrb, mrdb_state *mrdb, listcmd_parser_state *st)
 static mrb_bool
 check_cmd_pattern(const char *pattern, const char *cmd)
 {
-  char *lbracket, *rbracket, *p, *q;
+  const char *lbracket, *rbracket, *p, *q;
 
   if (pattern == NULL && cmd == NULL) {
     return TRUE;

--- a/mrbgems/mruby-bin-debugger/tools/mrdb/mrdb.c
+++ b/mrbgems/mruby-bin-debugger/tools/mrdb/mrdb.c
@@ -184,7 +184,7 @@ cleanup(mrb_state *mrb, struct _args *args)
 static mrb_debug_context*
 mrb_debug_context_new(mrb_state *mrb)
 {
-  mrb_debug_context *dbg = mrb_malloc(mrb, sizeof(mrb_debug_context));
+  mrb_debug_context *dbg = (mrb_debug_context*)mrb_malloc(mrb, sizeof(mrb_debug_context));
 
   memset(dbg, 0, sizeof(mrb_debug_context));
 
@@ -223,12 +223,12 @@ mrb_debug_context_free(mrb_state *mrb)
 static mrdb_state*
 mrdb_state_new(mrb_state *mrb)
 {
-  mrdb_state *mrdb = mrb_malloc(mrb, sizeof(mrdb_state));
+  mrdb_state *mrdb = (mrdb_state*)mrb_malloc(mrb, sizeof(mrdb_state));
 
   memset(mrdb, 0, sizeof(mrdb_state));
 
   mrdb->dbg = mrb_debug_context_get(mrb);
-  mrdb->command = mrb_malloc(mrb, MAX_COMMAND_LINE+1);
+  mrdb->command = (char*)mrb_malloc(mrb, MAX_COMMAND_LINE+1);
   mrdb->print_no = 1;
 
   return mrdb;

--- a/mrbgems/mruby-compiler/core/lex.def
+++ b/mrbgems/mruby-compiler/core/lex.def
@@ -52,7 +52,7 @@ inline
 #endif
 #endif
 static unsigned int
-hash (register const char *str, register unsigned int len)
+hash (const char *str, unsigned int len)
 {
   static const unsigned char asso_values[] =
     {
@@ -83,7 +83,7 @@ hash (register const char *str, register unsigned int len)
       51, 51, 51, 51, 51, 51, 51, 51, 51, 51,
       51, 51, 51, 51, 51, 51
     };
-  register int hval = len;
+  int hval = len;
 
   switch (hval)
     {
@@ -105,7 +105,7 @@ __attribute__ ((__gnu_inline__))
 #endif
 #endif
 const struct kwtable *
-mrb_reserved_word (register const char *str, register unsigned int len)
+mrb_reserved_word (const char *str, unsigned int len)
 {
   static const struct kwtable wordlist[] =
     {
@@ -196,11 +196,11 @@ mrb_reserved_word (register const char *str, register unsigned int len)
 
   if (len <= MAX_WORD_LENGTH && len >= MIN_WORD_LENGTH)
     {
-      register int key = hash (str, len);
+      int key = hash (str, len);
 
       if (key <= MAX_HASH_VALUE && key >= 0)
         {
-          register const char *s = wordlist[key].name;
+          const char *s = wordlist[key].name;
 
           if (*str == *s && !strcmp (str + 1, s + 1))
             return &wordlist[key];
@@ -209,4 +209,3 @@ mrb_reserved_word (register const char *str, register unsigned int len)
   return 0;
 }
 #line 50 "/home/matz/work/mruby/mrbgems/mruby-compiler/core/keywords"
-

--- a/src/string.c
+++ b/src/string.c
@@ -2835,8 +2835,8 @@ mrb_float_read(const char *string, char **endPtr)
     int sign, expSign = FALSE;
     double fraction, dblExp;
     const double *d;
-    register const char *p;
-    register int c;
+    const char *p;
+    int c;
     int exp = 0;                /* Exponent read from "EX" field. */
     int fracExp = 0;            /* Exponent that derives from the fractional
                                  * part.  Under normal circumstatnces, it is


### PR DESCRIPTION
Changes applied:

- Removing "register" keyword
- Fixing const pointer to pointer assignments
- Adding type casts to rb_malloc calls