### PR TITLE
Uncommented the Visual Studio version check 

### DIFF
--- a/tasks/toolchains/visualcpp.rake
+++ b/tasks/toolchains/visualcpp.rake
@@ -55,14 +55,15 @@ MRuby::Toolchain.new(:visualcpp) do |conf, _params|
 
   conf.file_separator = '\\'
 
-  if require 'open3'
-    Open3.popen3 conf.cc.command do |_, _, e, _|
-      if /Version (\d{2})\.\d{2}\.\d{5}/ =~ e.gets && $1.to_i <= 17
-        m = "# VS2010/2012 support will be dropped after the next release! #"
-        h = "#" * m.length
-        puts h, m, h
-      end
-    end
-  end
+  # Unreliable detection and will result in invalid encoding errors for localized versions of Visual C++
+  # if require 'open3'
+  #   Open3.popen3 conf.cc.command do |_, _, e, _|
+  #     if /Version (\d{2})\.\d{2}\.\d{5}/ =~ e.gets && $1.to_i <= 17
+  #       m = "# VS2010/2012 support will be dropped after the next release! #"
+  #       h = "#" * m.length
+  #       puts h, m, h
+  #     end
+  #   end
+  # end
 
 end


### PR DESCRIPTION
The code does not work with internationalized versions of Visual Studio. 
It will capture the returned string in the local codepage encoding and make ruby exit
with an invalid UTF8 error message.

Also the word "Version" might be translated and not appear in the output.