### PR TITLE
Should be true for close_on_exec flag

### DIFF
--- a/mrbgems/mruby-io/src/io.c
+++ b/mrbgems/mruby-io/src/io.c
@@ -684,7 +684,7 @@ fptr_finalize(mrb_state *mrb, struct mrb_io *fptr, int quiet)
       io_set_process_status(mrb, pid, status);
     }
 #else
-    HANDLE h = OpenProcess(PROCESS_QUERY_INFORMATION, FALSE, fptr->pid); 
+    HANDLE h = OpenProcess(PROCESS_QUERY_INFORMATION, FALSE, fptr->pid);
     DWORD status;
     if (WaitForSingleObject(h, INFINITE) && GetExitCodeProcess(h, &status))
       if (!quiet)

--- a/mrbgems/mruby-io/test/io.rb
+++ b/mrbgems/mruby-io/test/io.rb
@@ -216,7 +216,10 @@ assert('IO#dup for readable') do
   dup = io.dup
   assert_true io != dup
   assert_true io.fileno != dup.fileno
-  assert_true dup.close_on_exec?
+  begin
+    assert_true dup.close_on_exec?
+  rescue NotImplementedError
+  end
   assert_equal 'm', dup.sysread(1)
   assert_equal 'r', io.sysread(1)
   assert_equal 'u', dup.sysread(1)

--- a/mrbgems/mruby-io/test/io.rb
+++ b/mrbgems/mruby-io/test/io.rb
@@ -216,6 +216,7 @@ assert('IO#dup for readable') do
   dup = io.dup
   assert_true io != dup
   assert_true io.fileno != dup.fileno
+  assert_true dup.close_on_exec?
   assert_equal 'm', dup.sysread(1)
   assert_equal 'r', io.sysread(1)
   assert_equal 'u', dup.sysread(1)


### PR DESCRIPTION
`close_on_exec` flag of duplicated object should be true.

And I think, It is not need that close fd when failed.
Because `fd` and `fd2` will close by GC on `fptr_finalize`.