### PR TITLE
add MRB_WITHOUT_METHOD_TABLE_INLINE option

### DIFF
--- a/include/mrbconf.h
+++ b/include/mrbconf.h
@@ -38,9 +38,13 @@
 
 /* add -DMRB_METHOD_TABLE_INLINE unless platform uses MSB of pointers */
 //#define MRB_METHOD_TABLE_INLINE
+/* add -DMRB_WITHOUT_METHOD_TABLE_INLINE to don't use method table inline */
+//#define MRB_WITHOUT_METHOD_TABLE_INLINE
 /* turn MRB_METHOD_TABLE_INLINE on for linux by default */
+#if !defined(MRB_WITHOUT_METHOD_TABLE_INLINE) 
 #if !defined(MRB_METHOD_TABLE_INLINE) && defined(__linux__)
 # define MRB_METHOD_TABLE_INLINE
+#endif
 #endif
 
 /* add -DMRB_INT16 to use 16bit integer for mrb_int; conflict with MRB_INT64 */


### PR DESCRIPTION
RTL8196 (mips big endian soc) platform don't work method table inline at cross compile by linux gcc. This option is force don't use  MRB_METHOD_TABLE_INLINE on linux gcc. 

my gcc is this.

% mips-cc -v
Using built-in specs.
Target: mips-linux
Configured with: RSDK Builder release 1.5
Thread model: posix
gcc version 4.4.5-1.5.5p4 (GCC) 

日本語ですみません。

このオプションを指定する事で動くようにはなるのですが、今ひとつ釈然としないところがあります。MRB_METHOD_TABLE_INLINEはMSBすなわちBig endianのプラットフォームで利用するとコメントにありますが、Big endianのRTL8196で指定すると動かなくなるのはコメントが間違っているような気もします。またLinuxの場合のLittle endianでもこのオプションは指定される事になり、そもそもendianに起因した設定では無いような気もします。

Embededな環境でこの件のデバッグはかなり手間がかかったので、可能であれば自動的に設定できた方が良いかとも思います。