### PR TITLE
mruby-time: Fix mruby specific timegm() cannot return minus

### DIFF
--- a/mrbgems/mruby-time/src/time.c
+++ b/mrbgems/mruby-time/src/time.c
@@ -138,8 +138,14 @@ timegm(struct tm *tm)
   int i;
   unsigned int *nday = (unsigned int*) ndays[is_leapyear(tm->tm_year+1900)];
 
-  for (i = 70; i < tm->tm_year; ++i)
-    r += is_leapyear(i+1900) ? 366*24*60*60 : 365*24*60*60;
+  static const int epoch_year = 70;
+  if(tm->tm_year >= epoch_year) {
+    for (i = epoch_year; i < tm->tm_year; ++i)
+      r += is_leapyear(i+1900) ? 366*24*60*60 : 365*24*60*60;
+  } else {
+    for (i = tm->tm_year; i < epoch_year; ++i)
+      r -= is_leapyear(i+1900) ? 366*24*60*60 : 365*24*60*60;
+  }
   for (i = 0; i < tm->tm_mon; ++i)
     r += nday[i] * 24 * 60 * 60;
   r += (tm->tm_mday - 1) * 24 * 60 * 60;

--- a/mrbgems/mruby-time/test/time.rb
+++ b/mrbgems/mruby-time/test/time.rb
@@ -234,11 +234,3 @@ end
 assert('Time.gm with Dec 31 23:59:59 1969 raise ArgumentError') do
   assert_raise(ArgumentError) {Time.gm(1969, 12, 31, 23, 59, 59)}
 end
-
-assert('Time.new can make less than Dec 31 23:59:58 1969') do
-  Time.new(1969, 12, 31, 23, 59, 58).year == 1969
-end
-
-assert('Time.gm can make less than Dec 31 23:59:58 1969') do
-  Time.gm(1969, 12, 31, 23, 59, 58).year == 1969
-end

--- a/mrbgems/mruby-time/test/time.rb
+++ b/mrbgems/mruby-time/test/time.rb
@@ -226,3 +226,19 @@ assert('2000 times 500us make a second') do
   end
   t.usec == 0
 end
+
+assert('Time.new with Dec 31 23:59:59 1969 raise ArgumentError') do
+  assert_raise(ArgumentError) {Time.new(1969, 12, 31, 23, 59, 59)}
+end
+
+assert('Time.gm with Dec 31 23:59:59 1969 raise ArgumentError') do
+  assert_raise(ArgumentError) {Time.gm(1969, 12, 31, 23, 59, 59)}
+end
+
+assert('Time.new can make less than Dec 31 23:59:58 1969') do
+  Time.new(1969, 12, 31, 23, 59, 58).year == 1969
+end
+
+assert('Time.gm can make less than Dec 31 23:59:58 1969') do
+  Time.gm(1969, 12, 31, 23, 59, 58).year == 1969
+end


### PR DESCRIPTION
Test env: gcc 4.8.5 (Linux)
Current mruby specific timegm() at mrbgems/mruby-time/src/time.c cannot returns minus value.
I tested with following Ruby code and result is following:
```
assert('Time.new with Dec 31 23:59:59 1969 raise ArgumentError') do
  assert_raise(ArgumentError) {Time.new(1969, 12, 31, 23, 59, 59)} # Passed
end
 
assert('Time.gm with Dec 31 23:59:59 1969 raise ArgumentError') do
  assert_raise(ArgumentError) {Time.gm(1969, 12, 31, 23, 59, 59)} # Failed
end
```

I still cannot understand why ArgumentError is raised at Dec 31 23:59:59 1969,
but if Time.gm is called with older than 1970, returns unix time "31535999" internally
and behave differently with Time.new.

I changed timegm() can returns minus value when older than 1970 is input with TIme.new and TIme.gm.
Test code details is following (I checked also leepyear):
```
#include <stdio.h>
#include <time.h>
#include <assert.h>

static unsigned int
is_leapyear(unsigned int y)
{
  return (y % 4) == 0 && ((y % 100) != 0 || (y % 400) == 0);
}

static time_t
timegm(struct tm *tm)
{
  static const unsigned int ndays[2][12] = {
    {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31},
    {31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31}
  };
  time_t r = 0;
  int i;
  unsigned int *nday = (unsigned int*) ndays[is_leapyear(tm->tm_year+1900)];

  static const int epoch_year = 70;
  if(tm->tm_year >= epoch_year) {
    for (i = epoch_year; i < tm->tm_year; ++i)
      r += is_leapyear(i+1900) ? 366*24*60*60 : 365*24*60*60;
  } else {
    for (i = tm->tm_year; i < epoch_year; ++i)
      r -= is_leapyear(i+1900) ? 366*24*60*60 : 365*24*60*60;
  }
  for (i = 0; i < tm->tm_mon; ++i)
    r += nday[i] * 24 * 60 * 60;
  r += (tm->tm_mday - 1) * 24 * 60 * 60;
  r += tm->tm_hour * 60 * 60;
  r += tm->tm_min * 60;
  r += tm->tm_sec;
  return r;
}

int main()
{
    struct tm tt = {0};
    tt.tm_year = 1969 - 1900;
    tt.tm_mon = 12 - 1;
    tt.tm_mday = 31;
    tt.tm_hour = 23;
    tt.tm_min = 59;
    tt.tm_sec = 59;
    tt.tm_isdst = -1;
    
    printf("%d\n", timegm(&tt));
    printf("%d\n", mktime(&tt));
    assert(timegm(&tt) == -1);
    
    tt.tm_sec = 58;
    assert(timegm(&tt) == -2);
    
    tt.tm_year = 1968 - 1900;
    tt.tm_mon = 2 - 1;
    tt.tm_mday = 29;
    tt.tm_hour = 0;
    tt.tm_min = 0;
    tt.tm_sec = 0;
    assert(timegm(&tt) == -58060800);
    
    return 0;
}
```

I have 2 questions:
1. mruby specific timegm() don't need to return minus? If it's no, this change is needed.
1. ArgumentError below is correct behavior? I think if you want to limit minus input, you also need to limit less than Dec 31 23:59:58 1969. If it's no, I'll confirm correct spec and change code again.

FInally,
This pull request is first for me, 
so if something is wrong, could you tell me that?