### PR TITLE
Give me block by mrb_get_args() (forced block arguments)

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -843,7 +843,7 @@ MRB_API struct RClass * mrb_define_module_under(mrb_state *mrb, struct RClass *o
  * | `i`  | {Integer}      | {mrb_int}         |                                                    |
  * | `b`  | boolean        | {mrb_bool}        |                                                    |
  * | `n`  | {Symbol}       | {mrb_sym}         |                                                    |
- * | `&`  | block          | {mrb_value}       |                                                    |
+ * | `&`  | block          | {mrb_value}       | when && gives raised exception if no block given.  |
  * | `*`  | rest arguments | {mrb_value} *, {mrb_int} | Receive the rest of arguments as an array.  |
  * | &vert; | optional     |                   | After this spec following specs would be optional. |
  * | `?`  | optional given | {mrb_bool}        | `TRUE` if preceding argument is given. Used to check optional argument is given. |

--- a/include/mruby.h
+++ b/include/mruby.h
@@ -843,7 +843,7 @@ MRB_API struct RClass * mrb_define_module_under(mrb_state *mrb, struct RClass *o
  * | `i`  | {Integer}      | {mrb_int}         |                                                    |
  * | `b`  | boolean        | {mrb_bool}        |                                                    |
  * | `n`  | {Symbol}       | {mrb_sym}         |                                                    |
- * | `&`  | block          | {mrb_value}       | when && gives raised exception if no block given.  |
+ * | `&`  | block          | {mrb_value}       | when &! gives raised exception if no block given.  |
  * | `*`  | rest arguments | {mrb_value} *, {mrb_int} | Receive the rest of arguments as an array.  |
  * | &vert; | optional     |                   | After this spec following specs would be optional. |
  * | `?`  | optional given | {mrb_bool}        | `TRUE` if preceding argument is given. Used to check optional argument is given. |

--- a/src/class.c
+++ b/src/class.c
@@ -593,7 +593,7 @@ mrb_get_argv(mrb_state *mrb)
     n:      Symbol         [mrb_sym]
     d:      Data           [void*,mrb_data_type const] 2nd argument will be used to check data type so it won't be modified
     I:      Inline struct  [void*]
-    &:      Block          [mrb_value]
+    &:      Block          [mrb_value]            when && gives raised exception if no block given
     *:      rest argument  [mrb_value*,mrb_int]   The rest of the arguments as an array; *! avoid copy of the stack
     |:      optional                              Following arguments are optional
     ?:      optional given [mrb_bool]             true if preceding argument (optional) is given
@@ -936,6 +936,12 @@ mrb_get_args(mrb_state *mrb, const char *format, ...)
         }
         else {
           bp = mrb->c->stack + mrb->c->ci->argc + 1;
+        }
+        if (*format == '&') {
+          format ++;
+          if (mrb_nil_p(*bp)) {
+            mrb_raise(mrb, E_ARGUMENT_ERROR, "no block given");
+          }
         }
         *p = *bp;
       }

--- a/src/class.c
+++ b/src/class.c
@@ -593,7 +593,7 @@ mrb_get_argv(mrb_state *mrb)
     n:      Symbol         [mrb_sym]
     d:      Data           [void*,mrb_data_type const] 2nd argument will be used to check data type so it won't be modified
     I:      Inline struct  [void*]
-    &:      Block          [mrb_value]            when && gives raised exception if no block given
+    &:      Block          [mrb_value]            when &! gives raised exception if no block given
     *:      rest argument  [mrb_value*,mrb_int]   The rest of the arguments as an array; *! avoid copy of the stack
     |:      optional                              Following arguments are optional
     ?:      optional given [mrb_bool]             true if preceding argument (optional) is given
@@ -937,7 +937,7 @@ mrb_get_args(mrb_state *mrb, const char *format, ...)
         else {
           bp = mrb->c->stack + mrb->c->ci->argc + 1;
         }
-        if (*format == '&') {
+        if (*format == '!') {
           format ++;
           if (mrb_nil_p(*bp)) {
             mrb_raise(mrb, E_ARGUMENT_ERROR, "no block given");


### PR DESCRIPTION
I added feature to ``mrb_get_args()`` function for forced block argument.

By giving two consecutive ``&``, exception is raised if block is not given.

```c
/* raise exception if no block given */
mrb_get_args(mrb, "&&", &block);
```

I tried to labor saving in the processing that required block. How is it?
