### PR TITLE
Close `mrb_state` before error exit.

### DIFF
--- a/mrbgems/mruby-test/init_mrbtest.c
+++ b/mrbgems/mruby-test/init_mrbtest.c
@@ -31,6 +31,7 @@ mrb_init_mrbtest(mrb_state *mrb)
 
   if (mrb->exc) {
     mrb_print_error(mrb);
+    mrb_close(mrb);
     exit(EXIT_FAILURE);
   }
   mrb_close(core_test);

--- a/mrbgems/mruby-test/mrbgem.rake
+++ b/mrbgems/mruby-test/mrbgem.rake
@@ -101,6 +101,7 @@ MRuby::Gem::Specification.new('mruby-test') do |spec|
             end
             f.puts %Q[  if (mrb2->exc) {]
             f.puts %Q[    mrb_print_error(mrb2);]
+            f.puts %Q[    mrb_close(mrb2);]
             f.puts %Q[    exit(EXIT_FAILURE);]
             f.puts %Q[  }]
             f.puts %Q[  mrb_const_set(mrb2, mrb_obj_value(mrb2->object_class), mrb_intern_lit(mrb2, "GEMNAME"), mrb_str_new(mrb2, "#{g.name}", #{g.name.length}));]


### PR DESCRIPTION
Since in leak sanitizer all the memories allocated by `mrb_state` gets reported as leaked memories.