### PR TITLE
Set array length after expanding capacity.

### DIFF
--- a/src/array.c
+++ b/src/array.c
@@ -256,7 +256,6 @@ mrb_ary_resize(mrb_state *mrb, mrb_value ary, mrb_int new_len)
   ary_modify(mrb, a);
   old_len = RARRAY_LEN(ary);
   if (old_len != new_len) {
-    ARY_SET_LEN(a, new_len);
     if (new_len < old_len) {
       ary_shrink_capa(mrb, a);
     }
@@ -264,6 +263,7 @@ mrb_ary_resize(mrb_state *mrb, mrb_value ary, mrb_int new_len)
       ary_expand_capa(mrb, a, new_len);
       ary_fill_with_nil(ARY_PTR(a) + old_len, new_len - old_len);
     }
+    ARY_SET_LEN(a, new_len);
   }
 
   return ary;


### PR DESCRIPTION
Since it causes assertion failure in mruby-capacity.
In embedded array it checks the embedded array capacity and cause assertion failure before expanding capacity.
https://103.128.221.202.static.iijgio.jp/jenkins/view/0-master-mrbgem/job/master-mruby-capacity/1/console