### PR TITLE
Initial implementation of `RubyVM`.

### DIFF
--- a/include/mrbconf.h
+++ b/include/mrbconf.h
@@ -116,6 +116,9 @@
 /* -DMRB_ENABLE_XXXX to enable following features */
 //#define MRB_ENABLE_DEBUG_HOOK /* hooks for debugger */
 
+/* takes VN statistics */
+//#define MRB_ENABLE_VM_STAT
+
 /* end of configuration */
 
 /* define MRB_DISABLE_XXXX from DISABLE_XXX (for compatibility) */

--- a/include/mruby.h
+++ b/include/mruby.h
@@ -263,6 +263,12 @@ typedef struct mrb_state {
 
   void *ud; /* auxiliary data */
 
+#ifdef MRB_ENABLE_VM_STAT
+  mrb_int global_method_state;
+  mrb_int global_constant_state;
+  mrb_int class_serial;
+#endif
+
 #ifdef MRB_FIXED_STATE_ATEXIT_STACK
   mrb_atexit_func atexit_stack[MRB_FIXED_STATE_ATEXIT_STACK_SIZE];
 #else

--- a/include/mruby/dump.h
+++ b/include/mruby/dump.h
@@ -22,6 +22,9 @@ MRB_BEGIN_DECL
 #define DUMP_ENDIAN_NAT 6
 #define DUMP_ENDIAN_MASK 6
 
+#define MRB_READ_FLAG_SRC_MALLOC 1
+#define MRB_READ_FLAG_SRC_STATIC 0
+
 int mrb_dump_irep(mrb_state *mrb, mrb_irep *irep, uint8_t flags, uint8_t **bin, size_t *bin_size);
 #ifndef MRB_DISABLE_STDIO
 int mrb_dump_irep_binary(mrb_state*, mrb_irep*, uint8_t, FILE*);
@@ -31,6 +34,7 @@ MRB_API mrb_value mrb_load_irep_file(mrb_state*,FILE*);
 MRB_API mrb_value mrb_load_irep_file_cxt(mrb_state*, FILE*, mrbc_context*);
 #endif
 MRB_API mrb_irep *mrb_read_irep(mrb_state*, const uint8_t*);
+MRB_API mrb_irep *mrb_read_irep_flags(mrb_state*, const uint8_t*, uint8_t flags);
 
 /* dump/load error code
  *

--- a/mrbgems/mruby-mrubyvm/mrbgem.rake
+++ b/mrbgems/mruby-mrubyvm/mrbgem.rake
@@ -1,0 +1,8 @@
+MRuby::Gem::Specification.new 'mruby-mrubyvm' do |spec|
+  spec.license = 'MIT'
+  spec.author  = 'mruby developers'
+  spec.summary = 'mruby implementation of `RubyVM`'
+
+  add_dependency 'mruby-compiler'
+end
+

--- a/mrbgems/mruby-mrubyvm/src/mruby_vm.c
+++ b/mrbgems/mruby-mrubyvm/src/mruby_vm.c
@@ -1,0 +1,195 @@
+#include <mruby.h>
+#include <mruby/class.h>
+#include <mruby/compile.h>
+#include <mruby/data.h>
+#include <mruby/dump.h>
+#include <mruby/hash.h>
+#include <mruby/irep.h>
+
+#ifdef MRB_ENABLE_VM_STAT
+
+static mrb_value
+vm_stat(mrb_state *mrb, mrb_value cls)
+{
+  mrb_value res = mrb_nil_value();
+  mrb_get_args(mrb, "|o", &res);
+
+  if (mrb_nil_p(res)) {
+    res = mrb_hash_new_capa(mrb, 3);
+  }
+
+  switch(mrb_type(res)) {
+  case MRB_TT_SYMBOL: {
+    mrb_sym const sym = mrb_symbol(res);
+    if (sym == mrb_intern_lit(mrb, "global_method_state")) {
+      return mrb_fixnum_value(mrb->global_method_state);
+    } else if (sym == mrb_intern_lit(mrb, "global_constant_state")) {
+      return mrb_fixnum_value(mrb->global_constant_state);
+    } else if (sym == mrb_intern_lit(mrb, "class_serial")) {
+      return mrb_fixnum_value(mrb->class_serial);
+    }
+  } break;
+
+  case MRB_TT_HASH:
+#define set_val(v) \
+    mrb_hash_set(mrb, res, mrb_symbol_value(mrb_intern_lit(mrb, #v)), mrb_fixnum_value(mrb->v))
+
+    set_val(global_method_state);
+    set_val(global_constant_state);
+    set_val(class_serial);
+#undef set_val
+    return res;
+
+  default: break;
+  }
+
+  mrb_raisef(mrb, E_ARGUMENT_ERROR, "invalid argument: %S", mrb_inspect(mrb, res));
+}
+
+#endif /* MRB_ENABLE_VM_STAT */
+
+/*
+static void
+mrbc_free(mrb_state *mrb, void *p)
+{
+  mrbc_context *cxt = (mrbc_context*)p;
+  mrbc_context_free(mrb, cxt);
+}
+
+static mrb_data_type mrbc_type = { "MRubyVM::CompilerContext", mrbc_free };
+*/
+
+static void
+iseq_free(mrb_state *mrb, void *p)
+{
+  mrb_irep *irep = (mrb_irep*)p;
+  mrb_irep_decref(mrb, irep);
+}
+
+static mrb_data_type iseq_type = { "MRubyVM::InstructionSequence", iseq_free };
+
+static mrb_value
+iseq_load_from_binary(mrb_state *mrb, mrb_value self)
+{
+  char const *bin;
+  mrb_int bin_len;
+  mrb_irep *irep;
+  struct RClass *cls = mrb_class_get_under(mrb, mrb_class_get(mrb, "MRubyVM"), "InstructionSequence");
+
+  mrb_get_args(mrb, "s", &bin, &bin_len);
+
+  irep = mrb_read_irep_flags(mrb, (uint8_t const*)bin, MRB_READ_FLAG_SRC_MALLOC);
+
+  if (!irep) {
+    mrb_raisef(mrb, E_SCRIPT_ERROR, "can't read irep");
+  }
+
+  return mrb_obj_value(mrb_data_object_alloc(mrb, cls, irep, &iseq_type));
+}
+
+static mrb_value
+iseq_to_binary(mrb_state *mrb, mrb_value self)
+{
+  mrb_irep *irep = (mrb_irep*)DATA_PTR(self);
+  mrb_value opts = mrb_hash_new(mrb);
+  uint8_t flags = 0;
+  uint8_t *res = NULL;
+  size_t res_size;
+  int res_code;
+  mrb_value ret;
+
+  mrb_get_args(mrb, "|H", &opts);
+
+  if (mrb_bool(mrb_hash_get(mrb, opts, mrb_symbol_value(mrb_intern_lit(mrb, "mrb_debug_info"))))) {
+    flags |= DUMP_DEBUG_INFO;
+  }
+
+  res_code = mrb_dump_irep(mrb, irep, flags, &res, &res_size);
+  if (res_code != MRB_DUMP_OK) {
+    mrb_free(mrb, res);
+    mrb_raisef(mrb, E_RUNTIME_ERROR, "failed dumping irep");
+  }
+
+  ret = mrb_str_new(mrb, (char const*)res, res_size);
+  mrb_free(mrb, res);
+  return ret;
+}
+
+static void
+irep_remove_lvar(mrb_state *mrb, mrb_irep *irep)
+{
+  int i;
+
+  if (irep->lv) {
+    mrb_free(mrb, irep->lv);
+    irep->lv = NULL;
+  }
+
+  for (i = 0; i < irep->rlen; ++i) {
+    irep_remove_lvar(mrb, irep->reps[i]);
+  }
+}
+
+static mrb_value
+iseq_remove_lvar(mrb_state *mrb, mrb_value self)
+{
+  mrb_irep *irep = (mrb_irep*)DATA_PTR(self);
+  irep_remove_lvar(mrb, irep);
+  return self;
+}
+
+void
+mrb_mruby_mrubyvm_gem_init(mrb_state *mrb)
+{
+  struct RClass *vm, *iseq, *cxt;
+
+  vm = mrb_define_class(mrb, "MRubyVM", mrb->object_class);
+  /* define alias `RubyVM` */
+  mrb_define_global_const(mrb, "RubyVM", mrb_obj_value(vm));
+
+#ifdef MRB_ENABLE_VM_STAT
+  mrb_define_module_function(mrb, vm, "stat", vm_stat, MRB_ARGS_OPT(1));
+#endif
+
+  cxt = mrb_define_class_under(mrb, vm, "CompilerContext", mrb->object_class);
+  MRB_SET_INSTANCE_TT(cxt, MRB_TT_DATA);
+
+  iseq = mrb_define_class_under(mrb, vm, "InstructionSequence", mrb->object_class);
+  MRB_SET_INSTANCE_TT(iseq, MRB_TT_DATA);
+
+  /*
+  mrb_define_module_function(mrb, iseq, "compile", iseq_compile, MRB_ARGS_ARG(1, 4));
+  mrb_define_module_function(mrb, iseq, "compile_file", iseq_compile_file, MRB_ARGS_ARG(1, 1));
+  mrb_define_module_function(mrb, iseq, "compile_option", iseq_compile_option, MRB_ARGS_NONE());
+  mrb_define_module_function(mrb, iseq, "compile_option=", iseq_set_compile_option, MRB_ARGS_REQ(1));
+  mrb_define_module_function(mrb, iseq, "disasm", iseq_cls_disasm, MRB_ARGS_REQ(1));
+  mrb_define_module_function(mrb, iseq, "disassemble", iseq_cls_disasm, MRB_ARGS_REQ(1));
+  */
+  mrb_define_module_function(mrb, iseq, "load_from_binary", iseq_load_from_binary, MRB_ARGS_REQ(1));
+  /*
+  mrb_define_module_function(mrb, iseq, "load_from_binary_extra_data", iseq_load_from_binary_extra_data, MRB_ARGS_REQ(1));
+  mrb_define_module_function(mrb, iseq, "of", iseq_of, MRB_ARGS_REQ(1));
+  */
+
+  /*
+  mrb_define_method(mrb, iseq, "initialize", iseq_init, MRB_ARGS_ARG(1, 4));
+  mrb_define_method(mrb, iseq, "absolute_path", iseq_abs_path, MRB_ARGS_NONE());
+  mrb_define_method(mrb, iseq, "base_label", iseq_base_label, MRB_ARGS_NONE());
+  mrb_define_method(mrb, iseq, "disasm", iseq_disasm, MRB_ARGS_NONE());
+  mrb_define_method(mrb, iseq, "disassemble", iseq_disasm, MRB_ARGS_NONE());
+  mrb_define_method(mrb, iseq, "each_child", iseq_disasm, MRB_ARGS_BLOCK());
+  mrb_define_method(mrb, iseq, "eval", iseq_eval, MRB_ARGS_NONE());
+  mrb_define_method(mrb, iseq, "first_lineno", iseq_first_lineno, MRB_ARGS_NONE());
+  mrb_define_method(mrb, iseq, "inspect", iseq_inspect, MRB_ARGS_NONE());
+  mrb_define_method(mrb, iseq, "label", iseq_label, MRB_ARGS_NONE());
+  mrb_define_method(mrb, iseq, "path", iseq_path, MRB_ARGS_NONE());
+  mrb_define_method(mrb, iseq, "to_a", iseq_to_a, MRB_ARGS_NONE());
+  */
+  mrb_define_method(mrb, iseq, "to_binary", iseq_to_binary, MRB_ARGS_NONE());
+  mrb_define_method(mrb, iseq, "remove_lvar", iseq_remove_lvar, MRB_ARGS_OPT(1));
+}
+
+void
+mrb_mruby_mrubyvm_gem_final(mrb_state *mrb)
+{
+}

--- a/mrbgems/mruby-mrubyvm/test/mruby_vm.rb
+++ b/mrbgems/mruby-mrubyvm/test/mruby_vm.rb
@@ -1,0 +1,14 @@
+assert 'MRubyVM' do
+  assert_true Object.const_defined? :RubyVM
+  assert_true Object.const_defined? :MRubyVM
+end
+
+assert 'MRubyVM.stat' do
+  skip unless MRubyVM.respond_to? :stat
+
+  assert_raise(ArgumentError) { MRubyVM.stat(:__test) }
+  assert_kind_of Hash, MRubyVM.stat
+  assert_true 1 <= MRubyVM.stat(:global_method_state)
+  assert_equal 1, MRubyVM.stat(:global_constant_state)
+  assert_equal 1, MRubyVM.stat(:class_serial)
+end

--- a/src/class.c
+++ b/src/class.c
@@ -1357,6 +1357,10 @@ mc_clear_all(mrb_state *mrb)
   for (i=0; i<MRB_METHOD_CACHE_SIZE; i++) {
     mc[i].c = 0;
   }
+
+#ifdef MRB_ENABLE_VM_STAT
+  mrb->global_method_state += 1;
+#endif
 }
 
 static void

--- a/src/load.c
+++ b/src/load.c
@@ -21,8 +21,6 @@
 #define FLAG_BYTEORDER_BIG 2
 #define FLAG_BYTEORDER_LIL 4
 #define FLAG_BYTEORDER_NATIVE 8
-#define FLAG_SRC_MALLOC 1
-#define FLAG_SRC_STATIC 0
 
 #define SIZE_ERROR_MUL(nmemb, size) ((size_t)(nmemb) > SIZE_MAX / (size))
 
@@ -76,7 +74,7 @@ read_irep_record_1(mrb_state *mrb, const uint8_t *bin, size_t *len, uint8_t flag
     if (SIZE_ERROR_MUL(irep->ilen, sizeof(mrb_code))) {
       return NULL;
     }
-    if ((flags & FLAG_SRC_MALLOC) == 0 &&
+    if ((flags & MRB_READ_FLAG_SRC_MALLOC) == 0 &&
         (flags & FLAG_BYTEORDER_NATIVE)) {
       irep->iseq = (mrb_code*)src;
       src += sizeof(uint32_t) * irep->ilen;
@@ -118,7 +116,7 @@ read_irep_record_1(mrb_state *mrb, const uint8_t *bin, size_t *len, uint8_t flag
       tt = *src++; /* pool TT */
       pool_data_len = bin_to_uint16(src); /* pool data length */
       src += sizeof(uint16_t);
-      if (flags & FLAG_SRC_MALLOC) {
+      if (flags & MRB_READ_FLAG_SRC_MALLOC) {
         s = mrb_str_new(mrb, (char *)src, pool_data_len);
       }
       else {
@@ -168,7 +166,7 @@ read_irep_record_1(mrb_state *mrb, const uint8_t *bin, size_t *len, uint8_t flag
         continue;
       }
 
-      if (flags & FLAG_SRC_MALLOC) {
+      if (flags & MRB_READ_FLAG_SRC_MALLOC) {
         irep->syms[i] = mrb_intern(mrb, (char *)src, snl);
       }
       else {
@@ -407,7 +405,7 @@ read_section_debug(mrb_state *mrb, const uint8_t *start, mrb_irep *irep, uint8_t
   for (i = 0; i < filenames_len; ++i) {
     uint16_t f_len = bin_to_uint16(bin);
     bin += sizeof(uint16_t);
-    if (flags & FLAG_SRC_MALLOC) {
+    if (flags & MRB_READ_FLAG_SRC_MALLOC) {
       filenames[i] = mrb_intern(mrb, (const char *)bin, (size_t)f_len);
     }
     else {
@@ -486,7 +484,7 @@ read_section_lv(mrb_state *mrb, const uint8_t *start, mrb_irep *irep, uint8_t fl
   uint32_t syms_len;
   mrb_sym *syms;
   mrb_sym (*intern_func)(mrb_state*, const char*, size_t) =
-    (flags & FLAG_SRC_MALLOC)? mrb_intern : mrb_intern_static;
+    (flags & MRB_READ_FLAG_SRC_MALLOC)? mrb_intern : mrb_intern_static;
 
   bin = start;
   header = (struct rite_section_lv_header const*)bin;
@@ -609,11 +607,17 @@ mrb_irep*
 mrb_read_irep(mrb_state *mrb, const uint8_t *bin)
 {
 #ifdef MRB_USE_ETEXT_EDATA
-  uint8_t flags = mrb_ro_data_p((char*)bin) ? FLAG_SRC_STATIC : FLAG_SRC_MALLOC;
+  uint8_t flags = mrb_ro_data_p((char*)bin) ? MRB_READ_FLAG_SRC_STATIC : MRB_READ_FLAG_SRC_MALLOC;
 #else
-  uint8_t flags = FLAG_SRC_STATIC;
+  uint8_t flags = MRB_READ_FLAG_SRC_STATIC;
 #endif
 
+  return read_irep(mrb, bin, flags);
+}
+
+mrb_irep*
+mrb_read_irep_flags(mrb_state *mrb, const uint8_t *bin, uint8_t flags)
+{
   return read_irep(mrb, bin, flags);
 }
 
@@ -685,7 +689,7 @@ mrb_read_irep_file(mrb_state *mrb, FILE* fp)
   if (fread(buf+header_size, buf_size-header_size, 1, fp) == 0) {
     goto irep_exit;
   }
-  irep = read_irep(mrb, buf, FLAG_SRC_MALLOC);
+  irep = read_irep(mrb, buf, MRB_READ_FLAG_SRC_MALLOC);
 
 irep_exit:
   mrb_free(mrb, buf);

--- a/src/state.c
+++ b/src/state.c
@@ -34,6 +34,12 @@ mrb_open_core(mrb_allocf f, void *ud)
   mrb->allocf = f;
   mrb->atexit_stack_len = 0;
 
+#ifdef MRB_ENABLE_VM_STAT
+  mrb->global_method_state = 1;
+  mrb->global_constant_state = 1;
+  mrb->class_serial = 1;
+#endif
+
   mrb_gc_init(mrb, &mrb->gc);
   mrb->c = (struct mrb_context*)mrb_malloc(mrb, sizeof(struct mrb_context));
   *mrb->c = mrb_context_zero;


### PR DESCRIPTION
(Related to: https://github.com/mruby/mruby/pull/3956 )
Merge https://github.com/mruby/mruby/pull/3977 first.
VM stats are now optional with mrbconf.