### PR TITLE
Return nil if type differ in `String#<=>`.

### DIFF
--- a/src/string.c
+++ b/src/string.c
@@ -926,7 +926,7 @@ mrb_str_cmp_m(mrb_state *mrb, mrb_value str1)
     else {
       mrb_value tmp = mrb_funcall(mrb, str2, "<=>", 1, str1);
 
-      if (!mrb_nil_p(tmp)) return mrb_nil_value();
+      if (mrb_nil_p(tmp)) return mrb_nil_value();
       if (!mrb_fixnum_p(tmp)) {
         return mrb_funcall(mrb, mrb_fixnum_value(0), "-", 1, tmp);
       }

--- a/test/t/string.rb
+++ b/test/t/string.rb
@@ -20,6 +20,7 @@ assert('String#<=>', '15.2.10.5.1') do
   assert_equal  1, c
   assert_equal(-1, d)
   assert_equal  1, e
+  assert_nil 'a' <=> 1024
 end
 
 assert('String#==', '15.2.10.5.2') do


### PR DESCRIPTION
Since it raised `TypeError` from 1.3: https://wandbox.org/permlink/mQ6E4k3GNATbBZ31