### PR TITLE
Reimplement `Enumerable#zip` with Enumerator

### DIFF
--- a/mrbgems/mruby-enumerator/test/enumerator.rb
+++ b/mrbgems/mruby-enumerator/test/enumerator.rb
@@ -544,3 +544,13 @@ assert 'Range#each' do
   end
   assert_equal [1,2,3,4,5], c
 end
+
+assert 'Enumerable#zip' do
+  assert_equal [[1, 10], [2, 11], [3, 12]], [1,2,3].zip(10..Float::INFINITY)
+
+  ret = []
+  assert_equal nil, [1,2,3].zip(10..Float::INFINITY) { |i| ret << i }
+  assert_equal [[1, 10], [2, 11], [3, 12]], ret
+
+  assert_raise(TypeError) { [1].zip(1) }
+end


### PR DESCRIPTION
for fix some specs
- [passes each element of the result array to a block and return nil if a block is given](https://github.com/ruby/spec/blob/a585ec35d185435e5c11f371ba4ed2a29d8817bd/core/enumerable/zip_spec.rb#L11-L17)
- [converts arguments to arrays using #to_ary](https://github.com/ruby/spec/blob/a585ec35d185435e5c11f371ba4ed2a29d8817bd/core/enumerable/zip_spec.rb#L23-L27)
- [converts arguments to enums using #to_enum](https://github.com/ruby/spec/blob/a585ec35d185435e5c11f371ba4ed2a29d8817bd/core/enumerable/zip_spec.rb#L29-L34)
- [gathers whole arrays as elements when each yields multiple](https://github.com/ruby/spec/blob/a585ec35d185435e5c11f371ba4ed2a29d8817bd/core/enumerable/zip_spec.rb#L36-L39)