### PR TITLE
Fix possible heap use after free in `mrb_exec_irep` and stack expanding.

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -156,6 +156,18 @@ envadjust(mrb_state *mrb, mrb_value *oldbase, mrb_value *newbase, size_t size)
 
       e->stack = newbase + off;
     }
+
+    if (ci->proc && MRB_PROC_ENV_P(ci->proc) && ci->env != MRB_PROC_ENV(ci->proc)) {
+      e = MRB_PROC_ENV(ci->proc);
+
+      if (e && MRB_ENV_STACK_SHARED_P(e) &&
+          (st = e->stack) && oldbase <= st && st < oldbase+size) {
+        ptrdiff_t off = e->stack - oldbase;
+
+        e->stack = newbase + off;
+      }
+    }
+
     ci->stackent = newbase + (ci->stackent - oldbase);
     ci++;
   }


### PR DESCRIPTION
Since `mrb_exec_irep` doesn't overwrite `ci->env` it may causes use after free error with `MRB_GC_STRESS`, address sanitizer, [iij/mruby-require](http://github.com/iij/mruby-require).
To fix this `REnv` of `RProc` associated to callinfo needs to be adjusted too.

```
require loop check : .                                                                                                                                                                                                                                                                  
require nest : =================================================================                                                                                                                                                                                                        
==14524==ERROR: AddressSanitizer: heap-use-after-free on address 0x61d000047948 at pc 0x000000490a16 bp 0x7fff491a7440 sp 0x7fff491a7430                                                                                                                                                
READ of size 4 at 0x61d000047948 thread T0                                                                                                                                                                                                                                              
    #0 0x490a15 in gc_mark_children /home/takeshi/dev/mruby/src/gc.c:666                                                                                                                                                                                                                
    #1 0x492bbc in gc_gray_mark /home/takeshi/dev/mruby/src/gc.c:914                                                                                                                                                                                                                    
    #2 0x49359e in incremental_marking_phase /home/takeshi/dev/mruby/src/gc.c:1009                                                                                                                                                                                                      
    #3 0x4948af in incremental_gc /home/takeshi/dev/mruby/src/gc.c:1122                                                                                                                                                                                                                 
    #4 0x4949c7 in incremental_gc_until /home/takeshi/dev/mruby/src/gc.c:1147                                                                                                                                                                                                           
    #5 0x495986 in mrb_full_gc /home/takeshi/dev/mruby/src/gc.c:1247                                                                                                                                                                                                                    
    #6 0x48ed47 in mrb_obj_alloc /home/takeshi/dev/mruby/src/gc.c:513                                                                                                                                                                                                                   
    #7 0x4b423b in str_new /home/takeshi/dev/mruby/src/string.c:61                                                                                                                                                                                                                      
    #8 0x4b71e6 in byte_subseq /home/takeshi/dev/mruby/src/string.c:408                                                                                                                                                                                                                 
    #9 0x4b75ee in str_substr /home/takeshi/dev/mruby/src/string.c:453                                                                                                                                                                                                                  
    #10 0x4be49c in mrb_str_aref /home/takeshi/dev/mruby/src/string.c:1053                                                                                                                                                                                                              
    #11 0x4bec9c in mrb_str_aref_m /home/takeshi/dev/mruby/src/string.c:1147                                                                                                                                                                                                            
    #12 0x430d95 in mrb_vm_exec /home/takeshi/dev/mruby/src/vm.c:1462                                                                                                                                                                                                                   
    #13 0x425da1 in mrb_vm_run /home/takeshi/dev/mruby/src/vm.c:935                                                                                                                                                                                                                     
    #14 0x45215f in mrb_top_run /home/takeshi/dev/mruby/src/vm.c:3000                                                                                                                                                                                                                   
    #15 0x419397 in load_irep /home/takeshi/dev/mruby/src/load.c:644                                                                                                                                                                                                                    
    #16 0x4193d6 in mrb_load_irep_cxt /home/takeshi/dev/mruby/src/load.c:650                                                                                                                                                                                                            
    #17 0x419400 in mrb_load_irep /home/takeshi/dev/mruby/src/load.c:656                                                                                                                                                                                                                
    #18 0x40514c in GENERATED_TMP_mrb_mruby_require_gem_test /home/takeshi/dev/mruby/build/host/mrbgems/mruby-require/gem_test.c:976                                                                                                                                                    
    #19 0x404a49 in mrbgemtest_init /home/takeshi/dev/mruby/build/host/mrbgems/mruby-test/mrbtest.c:79                                                                                                                                                                                  
    #20 0x40490a in mrb_init_mrbtest /home/takeshi/dev/mruby/build/host/mrbgems/mruby-test/mrbtest.c:38                                                                                                                                                                                 
    #21 0x4047c2 in main /home/takeshi/dev/mruby/mrbgems/mruby-test/driver.c:170                                                                                                                                                                                                        
    #22 0x7f375646882f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2082f)                                                                                                                                                                                                   
    #23 0x402ff8 in _start (/home/takeshi/dev/mruby/build/host/bin/mrbtest+0x402ff8)                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                        
0x61d000047948 is located 1224 bytes inside of 2048-byte region [0x61d000047480,0x61d000047c80)                                                                                                                                                                                         
freed by thread T0 here:                                                                                                                                                                                                                                                                
    #0 0x7f37578d2961 in realloc (/usr/lib/x86_64-linux-gnu/libasan.so.2+0x98961)                                                                                                                                                                                                       
    #1 0x452ad8 in mrb_default_allocf /home/takeshi/dev/mruby/src/state.c:55                                                                                                                                                                                                            
    #2 0x48c41a in mrb_realloc_simple /home/takeshi/dev/mruby/src/gc.c:206                                                                                                                                                                                                              
    #3 0x48c58e in mrb_realloc /home/takeshi/dev/mruby/src/gc.c:220                                                                                                                                                                                                                     
    #4 0x41b5bd in stack_extend_alloc /home/takeshi/dev/mruby/src/vm.c:191                                                                                                                                                                                                              
    #5 0x41bad9 in stack_extend /home/takeshi/dev/mruby/src/vm.c:212                                                                                                                                                                                                                    
    #6 0x43308e in mrb_vm_exec /home/takeshi/dev/mruby/src/vm.c:1564                                                                                                                                                                                                                    
    #7 0x425da1 in mrb_vm_run /home/takeshi/dev/mruby/src/vm.c:935                                                                                                                                                                                                                      
    #8 0x45215f in mrb_top_run /home/takeshi/dev/mruby/src/vm.c:3000                                                                                                                                                                                                                    
    #9 0x419397 in load_irep /home/takeshi/dev/mruby/src/load.c:644                                                                                                                                                                                                                     
    #10 0x4193d6 in mrb_load_irep_cxt /home/takeshi/dev/mruby/src/load.c:650                                                                                                                                                                                                            
    #11 0x419400 in mrb_load_irep /home/takeshi/dev/mruby/src/load.c:656                                                                                                                                                                                                                
    #12 0x40514c in GENERATED_TMP_mrb_mruby_require_gem_test /home/takeshi/dev/mruby/build/host/mrbgems/mruby-require/gem_test.c:976                                                                                                                                                    
    #13 0x404a49 in mrbgemtest_init /home/takeshi/dev/mruby/build/host/mrbgems/mruby-test/mrbtest.c:79                                                                                                                                                                                  
    #14 0x40490a in mrb_init_mrbtest /home/takeshi/dev/mruby/build/host/mrbgems/mruby-test/mrbtest.c:38                                                                                                                                                                                 
    #15 0x4047c2 in main /home/takeshi/dev/mruby/mrbgems/mruby-test/driver.c:170                                                                                                                                                                                                        
    #16 0x7f375646882f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2082f)                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                        
previously allocated by thread T0 here:                                                                                                                                                                                                                                                 
    #0 0x7f37578d2961 in realloc (/usr/lib/x86_64-linux-gnu/libasan.so.2+0x98961)                                                                                                                                                                                                       
    #1 0x452ad8 in mrb_default_allocf /home/takeshi/dev/mruby/src/state.c:55                                                                                                                                                                                                            
    #2 0x48c41a in mrb_realloc_simple /home/takeshi/dev/mruby/src/gc.c:206                                                                                                                                                                                                              
    #3 0x48c58e in mrb_realloc /home/takeshi/dev/mruby/src/gc.c:220                                                                                                                                                                                                                     
    #4 0x48c82d in mrb_malloc /home/takeshi/dev/mruby/src/gc.c:242                                                                                                                                                                                                                      
    #5 0x48c8cf in mrb_calloc /home/takeshi/dev/mruby/src/gc.c:260                                                                                                                                                                                                                      
    #6 0x41a9e1 in stack_init /home/takeshi/dev/mruby/src/vm.c:131                                                                                                                                                                                                                      
    #7 0x41eaf7 in mrb_funcall_with_block /home/takeshi/dev/mruby/src/vm.c:420                                                                                                                                                                                                          
    #8 0x41e5c2 in mrb_funcall_with_block /home/takeshi/dev/mruby/src/vm.c:398                                                                                                                                                                                                          
    #9 0x4206a4 in mrb_funcall_argv /home/takeshi/dev/mruby/src/vm.c:503                                                                                                                                                                                                                
    #10 0x4a972e in mrb_obj_new /home/takeshi/dev/mruby/src/class.c:1610                                                                                                                                                                                                                
    #11 0x487113 in mrb_exc_new_str /home/takeshi/dev/mruby/src/error.c:32                                                                                                                                                                                                              
    #12 0x48b20c in mrb_init_exception /home/takeshi/dev/mruby/src/error.c:507                                                                                                                                                                                                          
    #13 0x45f1ed in mrb_init_core /home/takeshi/dev/mruby/src/init.c:42                                                                                                                                                                                                                 
    #14 0x452a88 in mrb_open_core /home/takeshi/dev/mruby/src/state.c:42                                                                                                                                                                                                                
    #15 0x404df2 in GENERATED_TMP_mrb_mruby_require_gem_test /home/takeshi/dev/mruby/build/host/mrbgems/mruby-require/gem_test.c:937                                                                                                                                                    
    #16 0x404a49 in mrbgemtest_init /home/takeshi/dev/mruby/build/host/mrbgems/mruby-test/mrbtest.c:79                                                                                                                                                                                  
    #17 0x40490a in mrb_init_mrbtest /home/takeshi/dev/mruby/build/host/mrbgems/mruby-test/mrbtest.c:38                                                                                                                                                                                 
    #18 0x4047c2 in main /home/takeshi/dev/mruby/mrbgems/mruby-test/driver.c:170                                                                                                                                                                                                        
    #19 0x7f375646882f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2082f)                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                        
SUMMARY: AddressSanitizer: heap-use-after-free /home/takeshi/dev/mruby/src/gc.c:666 gc_mark_children                                                                                                                                                                                    
Shadow bytes around the buggy address:                                                                                                                                                                                                                                                  
  0x0c3a80000ed0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd                                                                                                                                                                                                                       
  0x0c3a80000ee0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd                                                                                                                                                                                                                       
  0x0c3a80000ef0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd                                                                                                                                                                                                                       
  0x0c3a80000f00: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd                                                                                                                                                                                                                       
  0x0c3a80000f10: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd                                                                                                                                                                                                                       
=>0x0c3a80000f20: fd fd fd fd fd fd fd fd fd[fd]fd fd fd fd fd fd                                                                                                                                                                                                                       
  0x0c3a80000f30: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd                                                                                                                                                                                                                       
  0x0c3a80000f40: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd                                                                                                                                                                                                                       
  0x0c3a80000f50: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c3a80000f60: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c3a80000f70: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Heap right redzone:      fb
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack partial redzone:   f4
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
==14524==ABORTING
rake aborted!
Command Failed: ["build/host/bin/mrbtest" -v]
```