### PR TITLE
Fix build error on Windows with MRB_BUILD_AS_DLL

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -1095,9 +1095,6 @@ mrb_gc_arena_restore(mrb_state *mrb, int idx)
   mrb->gc.arena_idx = idx;
 }
 
-MRB_API int mrb_gc_arena_save(mrb_state*);
-MRB_API void mrb_gc_arena_restore(mrb_state*,int);
-
 MRB_API void mrb_garbage_collect(mrb_state*);
 MRB_API void mrb_full_gc(mrb_state*);
 MRB_API void mrb_incremental_gc(mrb_state *);


### PR DESCRIPTION
Error message:

    C:\projects\groonga\vendor\mruby-source\include\mruby.h(1098): error C2375: 'mrb_gc_arena_save' : redefinition; different linkage [C:\projects\groonga\vendor\mruby\mruby.vcxproj]
              C:\projects\groonga\vendor\mruby-source\include\mruby.h(1083) : see declaration of 'mrb_gc_arena_save'
    C:\projects\groonga\vendor\mruby-source\include\mruby.h(1099): error C2375: 'mrb_gc_arena_restore' : redefinition; different linkage [C:\projects\groonga\vendor\mruby\mruby.vcxproj]
              C:\projects\groonga\vendor\mruby-source\include\mruby.h(1084) : see declaration of 'mrb_gc_arena_restore'

We may be able to fix this by just removing `MRB_API` but I didn't try it yet. Because  we already have static declarations of them.