### PR TITLE
Fallback to float when compiled binary with 64bit compiler.

### DIFF
--- a/src/load.c
+++ b/src/load.c
@@ -126,9 +126,10 @@ read_irep_record_1(mrb_state *mrb, const uint8_t *bin, size_t *len, uint8_t flag
       }
       src += pool_data_len;
       switch (tt) { /* pool data */
-      case IREP_TT_FIXNUM:
-        irep->pool[i] = mrb_str_to_inum(mrb, s, 10, FALSE);
-        break;
+      case IREP_TT_FIXNUM: {
+        mrb_value num = mrb_str_to_inum(mrb, s, 10, FALSE);
+        irep->pool[i] = mrb_float_p(num)? mrb_float_pool(mrb, mrb_float(num)) : num;
+      } break;
 
 #ifndef MRB_WITHOUT_FLOAT
       case IREP_TT_FLOAT:

--- a/src/string.c
+++ b/src/string.c
@@ -2167,8 +2167,13 @@ mrb_str_len_to_inum(mrb_state *mrb, const char *str, mrb_int len, mrb_int base, 
     n *= base;
     n += c;
     if (n > (uint64_t)MRB_INT_MAX + (sign ? 0 : 1)) {
-      mrb_raisef(mrb, E_ARGUMENT_ERROR, "string (%S) too big for integer",
-                 mrb_str_new(mrb, str, pend-str));
+      if (base == 10) {
+        return mrb_float_value(mrb, mrb_str_to_dbl(mrb, mrb_str_new(mrb, str, len), badcheck));
+      }
+      else {
+        mrb_raisef(mrb, E_ARGUMENT_ERROR, "string (%S) too big for integer",
+                   mrb_str_new(mrb, str, pend-str));
+      }
     }
   }
   val = (mrb_int)n;


### PR DESCRIPTION
closes #3997.
In compiler built with `MRB_INT64`, it treats integer as `Fixnum` that doesn't fit to `int32_t`.