### PR TITLE
Fix undefined error of pointer dereference.

### DIFF
--- a/src/backtrace.c
+++ b/src/backtrace.c
@@ -51,6 +51,7 @@ each_backtrace(mrb_state *mrb, ptrdiff_t ciidx, mrb_code *pc0, each_backtrace_fu
       pc = mrb->c->cibase[i].err;
     }
     else if (i+1 <= ciidx) {
+      if (!mrb->c->cibase[i + 1].pc) continue;
       pc = &mrb->c->cibase[i+1].pc[-1];
     }
     else {


### PR DESCRIPTION
Since it's noisy and may cause an error in specific environment.
```
/home/takeshi/dev/mruby/src/backtrace.c:55:13: runtime error: pointer index expression with base 0x000000000000 overflowed to 0xfffffffffffffffc
    #0 0x801b29 in each_backtrace /home/takeshi/dev/mruby/src/backtrace.c:55:13
    #1 0x7fd347 in packed_backtrace /home/takeshi/dev/mruby/src/backtrace.c:206:3
    #2 0x7fc831 in mrb_keep_backtrace /home/takeshi/dev/mruby/src/backtrace.c:225:15
    #3 0x6bcbbc in mrb_exc_set /home/takeshi/dev/mruby/src/error.c:238:7
    #4 0x6be277 in mrb_exc_raise /home/takeshi/dev/mruby/src/error.c:249:3
    #5 0x7b1e74 in mrb_f_raise /home/takeshi/dev/mruby/src/kernel.c:903:5
    #6 0x5a8df9 in mrb_vm_exec /home/takeshi/dev/mruby/src/vm.c:1469:18
    #7 0x58aa70 in mrb_vm_run /home/takeshi/dev/mruby/src/vm.c:947:12
    #8 0x57bbfc in mrb_run /home/takeshi/dev/mruby/src/vm.c:2988:12
    #9 0x613d59 in ecall /home/takeshi/dev/mruby/src/vm.c:367:3
    #10 0x5c665d in mrb_vm_exec /home/takeshi/dev/mruby/src/vm.c:1954:15
    #11 0x58aa70 in mrb_vm_run /home/takeshi/dev/mruby/src/vm.c:947:12
    #12 0x615f38 in mrb_top_run /home/takeshi/dev/mruby/src/vm.c:3002:12
    #13 0x560b33 in load_irep /home/takeshi/dev/mruby/src/load.c:645:10
    #14 0x560345 in mrb_load_irep_cxt /home/takeshi/dev/mruby/src/load.c:651:10
    #15 0x560d6b in mrb_load_irep /home/takeshi/dev/mruby/src/load.c:657:10
    #16 0x557de5 in GENERATED_TMP_mrb_mruby_test_gem_test /home/takeshi/dev/mruby/build/host/mrbgems/mruby-test/gem_test.c:18107:3
    #17 0x52f853 in mrbgemtest_init /home/takeshi/dev/mruby/build/host/mrbgems/mruby-test/mrbtest.c:65:5
    #18 0x52f680 in mrb_init_mrbtest /home/takeshi/dev/mruby/build/host/mrbgems/mruby-test/mrbtest.c:38:3
    #19 0x52e6ed in main /home/takeshi/dev/mruby/mrbgems/mruby-test/driver.c:170:3
    #20 0x7f429a5de82f in __libc_start_main /build/glibc-Cl5G7W/glibc-2.23/csu/../csu/libc-start.c:291
    #21 0x4232d8 in _start (/home/takeshi/dev/mruby/build/host/bin/mrbtest+0x4232d8)

SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /home/takeshi/dev/mruby/src/backtrace.c:55:13 in 
```