### PR TITLE
sort method should not consume system stack.

### DIFF
--- a/mrblib/array.rb
+++ b/mrblib/array.rb
@@ -197,24 +197,28 @@ class Array
   # left  : the beginning of sort region
   # right : the end of sort region
   def __sort_sub__(left, right, &block)
-    if left < right
-      i = left
-      j = right
-      pivot = self[i + (j - i) / 2]
-      while true
-        while ((block)? block.call(self[i], pivot): (self[i] <=> pivot)) < 0
+    stack = [ [left, right] ]
+    until stack.empty?
+      left, right = stack.pop
+      if left < right
+        i = left
+        j = right
+        pivot = self[i + (j - i) / 2]
+        while true
+          while ((block)? block.call(self[i], pivot): (self[i] <=> pivot)) < 0
+            i += 1
+          end
+          while ((block)? block.call(pivot, self[j]): (pivot <=> self[j])) < 0
+            j -= 1
+          end
+          break if (i >= j)
+          tmp = self[i]; self[i] = self[j]; self[j] = tmp;
           i += 1
-        end
-        while ((block)? block.call(pivot, self[j]): (pivot <=> self[j])) < 0
           j -= 1
         end
-        break if (i >= j)
-        tmp = self[i]; self[i] = self[j]; self[j] = tmp;
-        i += 1
-        j -= 1
+        stack.push [left, i-1]
+        stack.push [j+1, right]
       end
-      __sort_sub__(left, i-1, &block)
-      __sort_sub__(j+1, right, &block)
     end
   end
   #  private :__sort_sub__


### PR DESCRIPTION
Current implementation of `Enumerable#sort` is vulnerable to malicious input.  It should not consume system stack.

```
% bin/mruby -e 'a = 1.upto(600).to_a + 600.downto(1).to_a; a.map{ |i| [i] }.sort'

trace (most recent call last):
        [0] -e:1
        [1] /d/home/tsahara/src/mruby-master/mrblib/array.rb:234:in sort
        [2] /d/home/tsahara/src/mruby-master/mrblib/array.rb:228:in sort!
        [3] /d/home/tsahara/src/mruby-master/mrblib/array.rb:216:in __sort_sub__
        [4] /d/home/tsahara/src/mruby-master/mrblib/array.rb:216:in __sort_sub__
        [5] /d/home/tsahara/src/mruby-master/mrblib/array.rb:216:in __sort_sub__
        [6] /d/home/tsahara/src/mruby-master/mrblib/array.rb:216:in __sort_sub__
        [7] /d/home/tsahara/src/mruby-master/mrblib/array.rb:216:in __sort_sub__
        [8] /d/home/tsahara/src/mruby-master/mrblib/array.rb:216:in __sort_sub__
(snip)
        [511] /d/home/tsahara/src/mruby-master/mrblib/array.rb:205:in __sort_sub__
        [512] /d/home/tsahara/src/mruby-master/mrblib/array.rb:164:in <=>
/d/home/tsahara/src/mruby-master/mrblib/array.rb:164: stack level too deep (Syst
emStackError)
```

With attached patch, mruby uses a dynamically allocated array as a stack.