### PR TITLE
Fix wrong the number of marked objects of MRB_TT_ENV in gray mark phase

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -938,7 +938,7 @@ gc_gray_mark(mrb_state *mrb, mrb_gc *gc, struct RBasic *obj)
     break;
 
   case MRB_TT_ENV:
-    children += (int)obj->flags;
+    children += MRB_ENV_STACK_LEN(obj);
     break;
 
   case MRB_TT_FIBER:


### PR DESCRIPTION
If MRB_TT_ENV has stack shared flag or bidx flag, flags is too large
than the real stack size.