### PR TITLE
Fix heap use after free on mruby-aws-sigv4.

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -527,6 +527,8 @@ mrb_exec_irep(mrb_state *mrb, mrb_value self, struct RProc *p)
     return MRB_PROC_CFUNC(p)(mrb, self);
   }
   ci->nregs = p->body.irep->nregs;
+  ci->env = MRB_PROC_ENV(p);
+  if (ci->env) ci->env->stack[0] = self;
   if (ci->argc < 0) keep = 3;
   else keep = ci->argc + 2;
   if (ci->nregs < keep) {


### PR DESCRIPTION
https://103.128.221.202.static.iijgio.jp/jenkins/view/0-master-mrbgem/job/master-mruby-aws-sigv4/37/consoleFull
BTW is modifying `self` value of env OK?