### PR TITLE
Fix test of mruby-pack with big-endian CPUs

### DIFF
--- a/mrbgems/mruby-pack/test/pack.rb
+++ b/mrbgems/mruby-pack/test/pack.rb
@@ -129,7 +129,7 @@ assert 'pack/unpack "i"' do
   if PACK_IS_LITTLE_ENDIAN
     str = "\xC7\xCF" + "\xFF" * (int_size-2)
   else
-    str = "\xFF" * (int_size-2) + "\xC7\xCF"
+    str = "\xFF" * (int_size-2) + "\xCF\xC7"
   end
   assert_pack 'i', str, [-12345]
 end
@@ -141,7 +141,7 @@ assert 'pack/unpack "I"' do
   if PACK_IS_LITTLE_ENDIAN
     str = "\x39\x30" + "\0" * (uint_size-2)
   else
-    str = "\0" * (uint_size-2) + "\x39\x30"
+    str = "\0" * (uint_size-2) + "\x30\x39"
   end
   assert_pack 'I', str, [12345]
 end


### PR DESCRIPTION
When running the mruby-pack test with big endian, test data is incorrect,
so it will fail with "i" and "I".

------
Fail: pack/unpack "i" (mrbgems: mruby-pack)
 - Assertion[1] Failed: Expected to be equal
    Expected: "\xff\xff\xc7\xcf"
      Actual: "\xff\xff\xcf\xc7"
 - Assertion[2] Failed: Expected to be equal
    Expected: [-12345]
      Actual: [-14385]
Fail: pack/unpack "I" (mrbgems: mruby-pack)
 - Assertion[1] Failed: Expected to be equal
    Expected: "\x00\x0090"
      Actual: "\x00\x0009"
 - Assertion[2] Failed: Expected to be equal
    Expected: [12345]
      Actual: [14640]
------

This will fix the test data at big-endian.

Signed-off-by: Nobuhiro Iwamatsu <iwamatsu@nigauri.org>