### PR TITLE
closure At initialization time upper is not necessarily initialized

### DIFF
--- a/src/proc.c
+++ b/src/proc.c
@@ -71,7 +71,11 @@ closure_setup(mrb_state *mrb, struct RProc *p)
   else {
     struct RClass *tc = MRB_PROC_TARGET_CLASS(p);
 
-    e = env_new(mrb, up->body.irep->nlocals);
+    if(up == NULL) {
+      e = env_new(mrb, 0);
+    } else {
+      e = env_new(mrb, up->body.irep->nlocals);
+    }
     ci->env = e;
     if (tc) {
       e->c = tc;


### PR DESCRIPTION
Hi!
When using `mrb_closure_new`, I encountered a case where` p -> upper `is not necessarily initialized.
When it is not initialized, I ignore that value, but I can not understand well whether this patch is correct. Please tell me the role of `upper` if possible.

Japanese:
`mrb_closure_new` 利用時に、トップレベルでの呼び出しなど、必ずしも引数のprocオブジェクトの `upper` に値が入らないケースがあります。その場合には `e = env_new(mrb, 0);`　のように処理するようにしたのですが、このパッチが正しいのかはよくわかっていません。この場合、 `env_new` の第2引数に他にふさわしい値があれば教えてください。