### PR TITLE
fix env->stack misadjusting: fix #4029

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -141,7 +141,7 @@ stack_init(mrb_state *mrb)
 }
 
 static inline void
-envadjust(mrb_state *mrb, mrb_value *oldbase, mrb_value *newbase, size_t size)
+envadjust(mrb_state *mrb, mrb_value *oldbase, mrb_value *newbase, size_t oldsize)
 {
   mrb_callinfo *ci = mrb->c->cibase;
 
@@ -151,7 +151,7 @@ envadjust(mrb_state *mrb, mrb_value *oldbase, mrb_value *newbase, size_t size)
     mrb_value *st;
 
     if (e && MRB_ENV_STACK_SHARED_P(e) &&
-        (st = e->stack) && oldbase <= st && st < oldbase+size) {
+        (st = e->stack) && oldbase <= st && st < oldbase+oldsize) {
       ptrdiff_t off = e->stack - oldbase;
 
       e->stack = newbase + off;
@@ -161,7 +161,7 @@ envadjust(mrb_state *mrb, mrb_value *oldbase, mrb_value *newbase, size_t size)
       e = MRB_PROC_ENV(ci->proc);
 
       if (e && MRB_ENV_STACK_SHARED_P(e) &&
-          (st = e->stack) && oldbase <= st && st < oldbase+size) {
+          (st = e->stack) && oldbase <= st && st < oldbase+oldsize) {
         ptrdiff_t off = e->stack - oldbase;
 
         e->stack = newbase + off;
@@ -205,7 +205,7 @@ stack_extend_alloc(mrb_state *mrb, int room)
     mrb_exc_raise(mrb, mrb_obj_value(mrb->stack_err));
   }
   stack_clear(&(newstack[oldsize]), size - oldsize);
-  envadjust(mrb, oldbase, newstack, size);
+  envadjust(mrb, oldbase, newstack, oldsize);
   mrb->c->stbase = newstack;
   mrb->c->stack = mrb->c->stbase + off;
   mrb->c->stend = mrb->c->stbase + size;


### PR DESCRIPTION
Currently `envadjust` checks `oldbase <= env->stack < oldbase + newsize`, but it's wrong - we should use oldbase + **oldsize** as the upper bound.
After https://github.com/mruby/mruby/pull/3991, in one `envadjust` call, an `env `can be checked 2 times (when `ci[0]->env` and `ci[1]->proc->e.env` are identical). If newbase is allocated immediately after oldbase, `env->stack` pointer accidentally gets adjusted 2 times and refers out of range of the new stack area.

To reproduce, consume large amount of stack and then refer some lexical variable (`x`) in a closure.
```ruby
def doit(depth)
  return if depth == 0
  v0, v1, v2, v3, v4, v5, v6, v7, v8, v9 = (1..10).map { 'BROKEN' }
  doit(depth - 1)
end

x = 'OK'
proc {
  doit(100)
  puts x
}.call
```

$ seq 10 | xargs  -n 1 build/host/bin/mruby repro.rb
```
OK
OK
OK
OK
OK
OK
BROKEN
OK
BROKEN
OK
```

As far as I checked, OSX seems to often reallocate a new buffer immediately after old buffer, but in Linux it's not so often.