### PR TITLE
fix broken lexical variables

### DIFF
--- a/mrbgems/mruby-eval/test/eval.rb
+++ b/mrbgems/mruby-eval/test/eval.rb
@@ -99,3 +99,19 @@ assert('Object#instance_eval with begin-rescue-ensure execution order') do
   hell_raiser = HellRaiser.new
   assert_equal([:enter_raise_hell, :begin, :rescue, :ensure], hell_raiser.raise_hell)
 end
+
+assert('Kernel.#eval(strinng) Issue #4021') do
+  assert_equal('FOO') { (eval <<'EOS').call }
+foo = "FOO"
+Proc.new { foo }
+EOS
+  assert_equal('FOO') {
+    def do_eval(code)
+      eval(code)
+    end
+    do_eval(<<'EOS').call
+foo = "FOO"
+Proc.new { foo }
+EOS
+  }
+end

--- a/src/vm.c
+++ b/src/vm.c
@@ -528,8 +528,6 @@ mrb_exec_irep(mrb_state *mrb, mrb_value self, struct RProc *p)
     return MRB_PROC_CFUNC(p)(mrb, self);
   }
   ci->nregs = p->body.irep->nregs;
-  ci->env = MRB_PROC_ENV(p);
-  if (ci->env) ci->env->stack[0] = self;
   if (ci->argc < 0) keep = 3;
   else keep = ci->argc + 2;
   if (ci->nregs < keep) {


### PR DESCRIPTION
As discussed in https://github.com/mruby/mruby/issues/4021, the commit 26e436e24797f0c3228bc9900615afe7d2e29ddf caused problems around `ci->env`. If I understand correctly, there're no reasons to set it in there.