### PR TITLE
Support MRB_WITHOUT_FLOAT to mruby-io

### DIFF
--- a/mrbgems/mruby-io/src/file.c
+++ b/mrbgems/mruby-io/src/file.c
@@ -345,7 +345,11 @@ mrb_file_mtime(mrb_state *mrb, mrb_value self)
   fd = (int)mrb_fixnum(mrb_io_fileno(mrb, self));
   if (fstat(fd, &st) == -1)
     return mrb_false_value();
+#ifndef MRB_WITHOUT_FLOAT
   return mrb_funcall(mrb, obj, "at", 1, mrb_float_value(mrb, st.st_mtime));
+#else
+  return mrb_funcall(mrb, obj, "at", 1, mrb_fixnum_value(st.st_mtime));
+#endif
 }
 
 mrb_value


### PR DESCRIPTION
The current master does not build with MRB_WITHOUT_FLOAT.
This change allows to built it successfully.