### PR TITLE
[mruby-test] Fix task name is not necessarily a valid path

### DIFF
--- a/mrbgems/mruby-test/mrbgem.rake
+++ b/mrbgems/mruby-test/mrbgem.rake
@@ -164,9 +164,9 @@ MRuby::Gem::Specification.new('mruby-test') do |spec|
                       nil
                     end
   current_gem_list = build.gems.map(&:name).join("\n")
-  task active_gems_path do |t|
-    FileUtils.mkdir_p File.dirname t.name
-    File.write t.name, current_gem_list
+  task active_gems_path do |_t|
+    FileUtils.mkdir_p File.dirname(active_gems_path)
+    File.write active_gems_path, current_gem_list
   end
   file clib => active_gems_path if active_gem_list != current_gem_list
 


### PR DESCRIPTION
## About

I guess since 1d7c69a windows builds seem to be broken when `enable_test` is activated.

```sh
Errno::ENOENT: No such file or directory @ dir_s_mkdir - mruby:Z:/Documents
```

The fix makes sure that we pass a valid file path and not the name of the rake file task.