### PR TITLE
Add compiler flag to disable direct threading

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -927,10 +927,11 @@ argnum_error(mrb_state *mrb, mrb_int num)
 #define BYTECODE_DECODER(x) (x)
 #endif
 
-
+#ifndef DISABLE_DIRECT_THREADING
 #if defined __GNUC__ || defined __clang__ || defined __INTEL_COMPILER
 #define DIRECT_THREADED
 #endif
+#endif /* ifndef DISABLE_DIRECT_THREADING */
 
 #ifndef DIRECT_THREADED
 

--- a/src/vm.c
+++ b/src/vm.c
@@ -927,11 +927,11 @@ argnum_error(mrb_state *mrb, mrb_int num)
 #define BYTECODE_DECODER(x) (x)
 #endif
 
-#ifndef DISABLE_DIRECT_THREADING
+#ifndef MRB_DISABLE_DIRECT_THREADING
 #if defined __GNUC__ || defined __clang__ || defined __INTEL_COMPILER
 #define DIRECT_THREADED
 #endif
-#endif /* ifndef DISABLE_DIRECT_THREADING */
+#endif /* ifndef MRB_DISABLE_DIRECT_THREADING */
 
 #ifndef DIRECT_THREADED
 


### PR DESCRIPTION
This is helpful for compilation targets that don't support computed gotos like, in my case, WebAssembly (which at least doesn't support it **yet**).
I am not sure if it is possible to test this automatically. I confirmed that the change is working on my local machine and `./minirake test` works fine (which isn't suprising as I only added a new option which is not tested).

Please let me know if I missed something.