### PR TITLE
Fix to sizeof(mrb_value) is 4 bytes with MRB_WORD_BOXING on 32-bit mode

### DIFF
--- a/include/mruby/boxing_word.h
+++ b/include/mruby/boxing_word.h
@@ -45,6 +45,14 @@ enum mrb_special_consts {
 #define MRB_SYMBOL_FLAG   0x0e
 #define MRB_SPECIAL_SHIFT 8
 
+#if defined(MRB_64BIT)
+#define MRB_SYMBOL_BITSIZE  (sizeof(mrb_sym) * CHAR_BIT)
+#define MRB_SYMBOL_MAX      UINT32_MAX
+#else
+#define MRB_SYMBOL_BITSIZE  (sizeof(mrb_sym) * CHAR_BIT - MRB_SPECIAL_SHIFT)
+#define MRB_SYMBOL_MAX      (UINT32_MAX >> MRB_SPECIAL_SHIFT)
+#endif
+
 typedef union mrb_value {
   union {
     void *p;
@@ -54,7 +62,7 @@ typedef union mrb_value {
     };
     struct {
       unsigned int sym_flag : MRB_SPECIAL_SHIFT;
-      mrb_sym sym : (sizeof(mrb_sym) * CHAR_BIT);
+      mrb_sym sym : MRB_SYMBOL_BITSIZE;
     };
     struct RBasic *bp;
 #ifndef MRB_WITHOUT_FLOAT


### PR DESCRIPTION
When use `MRB_WORD_BOXING` on 32-bit mode, currently `sizeof(mrb_value)` is 8 bytes.

  - `$ cat sample1.c`

    ```c
    #define MRB_WORD_BOXING
    #include <mruby.h>
    #include <stdio.h>

    int
    main(int argc, char *argv[])
    {
        printf("sizeof(mrb_value): %d bytes\n", sizeof(mrb_value));
        return 0;
    }
    ```

  - `$ mingw32-gcc -Iinclude -o sample1.exe sample1.c && wine sample1.exe`

    ```
    sizeof(mrb_value): 8 bytes
    ```

  - After patched, `$ mingw32-gcc -Iinclude -o sample1.exe sample1.c && wine sample1.exe`

    ```
    sizeof(mrb_value): 4 bytes
    ```

I doing not use it, I do not strongly want to be fixed, but in a 32 bit environment it seems better to be 4 bytes.

The build_config.rb for testing is in <https://gist.github.com/dearblue/f02dceb7143729689755e6557f43f913>.

This fix can not be combined with `MRB_ENABLE_BUILTIN_SYMBOLS` of builtin-symbols (#4076).
If this fix is merged, we will also fix builtin-symbols (#4076).
