### PR TITLE
irep is released when Fiber is terminated

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -965,9 +965,11 @@ gc_gray_mark(mrb_state *mrb, mrb_gc *gc, struct RBasic *obj)
       size_t i;
       mrb_callinfo *ci;
 
-      if (!c) break;
+      if (!c || c->status == MRB_FIBER_TERMINATED) break;
+
       /* mark stack */
       i = c->stack - c->stbase;
+
       if (c->ci) {
         i += ci_nregs(c->ci);
       }


### PR DESCRIPTION
refs:  https://github.com/matsumotory/ngx_mruby/pull/384

Proc of fiber will be GC when it is finished.
In that case, there was a case where SEGV occurred, so we fixed it.

```
Program received signal SIGSEGV, Segmentation fault.                                               
0x000000000057ebab in ci_nregs (ci=0xa45720) at /home/pyama/src/github.com/matsumotory/ngx_mruby/mruby/src/gc.c:562
562         n = p->body.irep->nregs;                                                                      
(gdb) bt                                                                                                 
#0  0x000000000057ebab in ci_nregs (ci=0xa45720) at /home/pyama/src/github.com/matsumotory/ngx_mruby/mruby/src/gc.c:562              
#1  0x000000000057fa3c in gc_gray_mark (mrb=0xa47950, gc=0xa47a18, obj=0xadcdc0) at /home/pyama/src/github.com/matsumotory/ngx_mruby/mruby/src/gc.c:973
#2  0x000000000057fbf6 in incremental_marking_phase (mrb=0xa47950, gc=0xa47a18, limit=18446744073709551615)
    at /home/pyama/src/github.com/matsumotory/ngx_mruby/mruby/src/gc.c:1031
(gdb) p p->body
$1 = {irep = 0x2, func = 0x2}
```