### PR TITLE
Fix weird behavior of the NODE_NEGATE

### DIFF
--- a/mrbgems/mruby-compiler/core/codegen.c
+++ b/mrbgems/mruby-compiler/core/codegen.c
@@ -2339,9 +2339,8 @@ codegen(codegen_scope *s, node *tree, int val)
 
       case NODE_INT:
         if (val) {
-          tree = tree->cdr;
-          char *p = (char*)tree->car;
-          int base = nint(tree->cdr->car);
+          char *p = (char*)tree->cdr->car;
+          int base = nint(tree->cdr->cdr->car);
           mrb_int i;
           mrb_code co;
           mrb_bool overflow;

--- a/mrbgems/mruby-compiler/core/codegen.c
+++ b/mrbgems/mruby-compiler/core/codegen.c
@@ -2376,6 +2376,7 @@ codegen(codegen_scope *s, node *tree, int val)
           codegen(s, tree, VAL);
           pop();
           genop(s, MKOP_ABC(OP_SEND, cursp(), sym, 0));
+          push();
         }
         else {
           codegen(s, tree, NOVAL);

--- a/mrbgems/mruby-compiler/core/codegen.c
+++ b/mrbgems/mruby-compiler/core/codegen.c
@@ -2323,12 +2323,11 @@ codegen(codegen_scope *s, node *tree, int val)
   case NODE_NEGATE:
     {
       nt = nint(tree->car);
-      tree = tree->cdr;
       switch (nt) {
 #ifndef MRB_WITHOUT_FLOAT
       case NODE_FLOAT:
         if (val) {
-          char *p = (char*)tree;
+          char *p = (char*)tree->cdr;
           mrb_float f = mrb_float_read(p, NULL);
           int off = new_lit(s, mrb_float_value(s->mrb, -f));
 
@@ -2340,6 +2339,7 @@ codegen(codegen_scope *s, node *tree, int val)
 
       case NODE_INT:
         if (val) {
+          tree = tree->cdr;
           char *p = (char*)tree->car;
           int base = nint(tree->cdr->car);
           mrb_int i;
@@ -2373,13 +2373,10 @@ codegen(codegen_scope *s, node *tree, int val)
 
       default:
         if (val) {
-          int sym = new_msym(s, mrb_intern_lit(s->mrb, "-"));
-
-          genop(s, MKOP_ABx(OP_LOADI, cursp(), 0));
-          push();
+          int sym = new_msym(s, mrb_intern_lit(s->mrb, "-@"));
           codegen(s, tree, VAL);
-          pop(); pop();
-          genop(s, MKOP_ABC(OP_SUB, cursp(), sym, 2));
+          pop();
+          genop(s, MKOP_ABC(OP_SEND, cursp(), sym, 0));
         }
         else {
           codegen(s, tree, NOVAL);


### PR DESCRIPTION
I'm trying to change the parser a bit to suit my needs.
When I tried to use the NODE_NEGATE, I got very weird behavior.
With this AST:
```
00001 NODE_SCOPE:
00001   NODE_BEGIN:
00001     NODE_NEGATE
00001       NODE_CALL(.):
00001         NODE_CONST MyClass
00001         method='func' (15)
00001         args:
00001           NODE_INT 0 base 10
00001           NODE_INT 1 base 10
```

I got this bytecode:
```
irep 0x7ffcd1c0fc40 nregs=2 nlocals=1 pools=0 syms=1 reps=0
    1 000 OP_LOADI      R1      -32767
    1 001 OP_SUB        R0      :-      2
    1 002 OP_STOP
```

So I changed the bytecode generator to get:
```
irep 0x7fb29ec0fc40 nregs=5 nlocals=1 pools=0 syms=3 reps=0
    1 000 OP_GETCONST   R1      :MyClass
    1 001 OP_LOADI      R2      0
    1 002 OP_LOADI      R3      1
    1 003 OP_SEND       R1      :func   2
    1 004 OP_SEND       R1      :-@     0
    1 005 OP_STOP
```