### PR TITLE
Fix misspelling words in comments, docs

### DIFF
--- a/doc/guides/mrbgems.md
+++ b/doc/guides/mrbgems.md
@@ -179,11 +179,11 @@ Version requirement supports following operators:
 
 When more than one version requirements is passed, the dependency must satisfy all of it.
 
-You can have default gem to use as depedency when it's not defined in *build_config.rb*.
+You can have default gem to use as dependency when it's not defined in *build_config.rb*.
 When the last argument of `add_dependency` call is `Hash`, it will be treated as default gem information.
 Its format is same as argument of method `MRuby::Build#gem`, expect that it can't be treated as path gem location.
 
-When a special version of depedency is required,
+When a special version of dependency is required,
 use `MRuby::Build#gem` in *build_config.rb* to override default gem.
 
 If you have conflicting GEMs use the following method:

--- a/include/mruby.h
+++ b/include/mruby.h
@@ -782,7 +782,7 @@ MRB_API struct RClass * mrb_define_module_under(mrb_state *mrb, struct RClass *o
 #define MRB_ARGS_REQ(n)     ((mrb_aspec)((n)&0x1f) << 18)
 
 /**
- * Funtion takes n optional arguments
+ * Function takes n optional arguments
  *
  * @param n
  *      The number of optional arguments.
@@ -790,7 +790,7 @@ MRB_API struct RClass * mrb_define_module_under(mrb_state *mrb, struct RClass *o
 #define MRB_ARGS_OPT(n)     ((mrb_aspec)((n)&0x1f) << 13)
 
 /**
- * Funtion takes n1 mandatory arguments and n2 optional arguments
+ * Function takes n1 mandatory arguments and n2 optional arguments
  *
  * @param n1
  *      The number of required arguments.

--- a/minirake
+++ b/minirake
@@ -95,7 +95,7 @@ module MiniRake
     def done?; @done end
     def running?; @running end
 
-    # Invoke the task if it is needed.  Prerequites are invoked first.
+    # Invoke the task if it is needed. Prerequisites are invoked first.
     def invoke
       puts "Invoke #{name} (already=[#{@already_invoked}], needed=[#{needed?}])" if $trace
       return if @already_invoked

--- a/mrbgems/mruby-bin-debugger/bintest/print.rb
+++ b/mrbgems/mruby-bin-debugger/bintest/print.rb
@@ -317,7 +317,7 @@ TestConstNameSubClass.new.m()
 bp = nil
 SRC
 
-  # todo: wait for 'break' to be implimented
+  # todo: wait for 'break' to be implemented
   tc = []
   9.times { tc << {:cmd=>"s"} }
   tc << {:cmd=>"p CONST", :exp=>"super class"}

--- a/mrbgems/mruby-compiler/core/codegen.c
+++ b/mrbgems/mruby-compiler/core/codegen.c
@@ -200,7 +200,7 @@ genop_peep(codegen_scope *s, mrb_code i, int val)
       switch (c0) {
       case OP_MOVE:
         if (GETARG_A(i) == GETARG_A(i0)) {
-          /* skip overriden OP_MOVE */
+          /* skip overridden OP_MOVE */
           s->pc--;
           s->iseq[s->pc] = i;
         }

--- a/mrbgems/mruby-socket/src/socket.c
+++ b/mrbgems/mruby-socket/src/socket.c
@@ -300,7 +300,7 @@ mrb_basicsocket_getpeereid(mrb_state *mrb, mrb_value self)
   mrb_ary_push(mrb, ary, mrb_fixnum_value((mrb_int)egid));
   return ary;
 #else
-  mrb_raise(mrb, E_RUNTIME_ERROR, "getpeereid is not avaialble on this system");
+  mrb_raise(mrb, E_RUNTIME_ERROR, "getpeereid is not available on this system");
   return mrb_nil_value();
 #endif
 }

--- a/test/t/literals.rb
+++ b/test/t/literals.rb
@@ -22,7 +22,7 @@ assert('Literals Numerical', '8.7.6.2') do
   # decimal
   assert_equal 999, 0d999
   assert_equal 999, 0D999
-  # decimal seperator
+  # decimal separator
   assert_equal 10000000, 10_000_000
   assert_equal       10, 1_0
   # integer with exponent

--- a/test/t/module.rb
+++ b/test/t/module.rb
@@ -699,7 +699,7 @@ end
     end
   end
 
-  # these assertions will not run without a #assert_seperately method
+  # these assertions will not run without a #assert_separately method
   #assert 'test_prepend_optmethod' do
   #  bug7983 = '[ruby-dev:47124] [Bug #7983]'
   #  assert_separately [], %{
@@ -807,7 +807,7 @@ end
     assert_equal([m, c2, m, c1], c2.ancestors[0, 4], "should accesisble prepended module in superclass")
   end
 
-  # requires #assert_seperately
+  # requires #assert_separately
   #assert 'Module#prepend call super' do
   #  assert_separately([], <<-'end;') #do
   #    bug10847 = '[ruby-core:68093] [Bug #10847]'


### PR DESCRIPTION
This pull request fixes minor typos in comments, docs, and error messages.