### PR TITLE
Reversing gems final

### DIFF
--- a/tasks/mrbgems.rake
+++ b/tasks/mrbgems.rake
@@ -18,7 +18,7 @@ MRuby.each_target do
         gem_init_calls = gem_func_gems.each_with_object('') do |g, s|
           s << "  GENERATED_TMP_mrb_#{g.funcname}_gem_init(mrb);\n"
         end
-        gem_final_calls = gem_func_gems.each_with_object('') do |g, s|
+        gem_final_calls = gem_func_gems.reverse_each.with_object('') do |g, s|
           s << "  GENERATED_TMP_mrb_#{g.funcname}_gem_final(mrb);\n"
         end
         f.puts %Q[/*]


### PR DESCRIPTION
Currently `XXX_gem_final()` is called in the same order as `XXX_gem_init()`.
I seems that it would be better to reverse this, but how is it?

  - Currently sample `host/mrbgems/gem_init.c`:

    ```c
    static void
    mrb_final_mrbgems(mrb_state *mrb) {
      GENERATED_TMP_mrb_mruby_sprintf_gem_final(mrb);     /* 1 */
      GENERATED_TMP_mrb_mruby_print_gem_final(mrb);       /* 2 */
      GENERATED_TMP_mrb_mruby_error_gem_final(mrb);       /* 3 */
      GENERATED_TMP_mrb_mruby_fiber_gem_final(mrb);       /* 4 */
      GENERATED_TMP_mrb_mruby_enum_ext_gem_final(mrb);    /* 5 */
      GENERATED_TMP_mrb_mruby_enumerator_gem_final(mrb);  /* 6 */
      GENERATED_TMP_mrb_mruby_string_ext_gem_final(mrb);  /* 7 */
    }

    void
    mrb_init_mrbgems(mrb_state *mrb) {
      GENERATED_TMP_mrb_mruby_sprintf_gem_init(mrb);      /* 1 */
      GENERATED_TMP_mrb_mruby_print_gem_init(mrb);        /* 2 */
      GENERATED_TMP_mrb_mruby_error_gem_init(mrb);        /* 3 */
      GENERATED_TMP_mrb_mruby_fiber_gem_init(mrb);        /* 4 */
      GENERATED_TMP_mrb_mruby_enum_ext_gem_init(mrb);     /* 5 */
      GENERATED_TMP_mrb_mruby_enumerator_gem_init(mrb);   /* 6 */
      GENERATED_TMP_mrb_mruby_string_ext_gem_init(mrb);   /* 7 */
      mrb_state_atexit(mrb, mrb_final_mrbgems);
    }
    ```

  - After patched `host/mrbgems/gem_init.c`:

    ```c
    static void
    mrb_final_mrbgems(mrb_state *mrb) {
      GENERATED_TMP_mrb_mruby_string_ext_gem_final(mrb);  /* 7 */
      GENERATED_TMP_mrb_mruby_enumerator_gem_final(mrb);  /* 6 */
      GENERATED_TMP_mrb_mruby_enum_ext_gem_final(mrb);    /* 5 */
      GENERATED_TMP_mrb_mruby_fiber_gem_final(mrb);       /* 4 */
      GENERATED_TMP_mrb_mruby_error_gem_final(mrb);       /* 3 */
      GENERATED_TMP_mrb_mruby_print_gem_final(mrb);       /* 2 */
      GENERATED_TMP_mrb_mruby_sprintf_gem_final(mrb);     /* 1 */
    }

    void
    mrb_init_mrbgems(mrb_state *mrb) {
      ... snipped ...
    }
    ```
