### PR TITLE
Avoid root fiber initialization for CRuby.

### DIFF
--- a/minirake
+++ b/minirake
@@ -6,12 +6,10 @@
 
 require 'getoptlong'
 require 'fileutils'
-require 'fiber'
 
 $rake_fiber_table = {}
 $rake_jobs = 1
 $rake_failed = []
-$rake_root_fiber = Fiber.current
 
 class String
   def ext(newext='')
@@ -111,9 +109,13 @@ module MiniRake
 
       if needed?
         @running = true
-        return Fiber.new do
+        if $rake_root_fiber
+          return Fiber.new do
+            self.execute
+            $rake_root_fiber.transfer
+          end
+        else
           self.execute
-          $rake_root_fiber.transfer
         end
       end
 
@@ -308,7 +310,7 @@ module MiniRake
     def sh(cmd)
       puts cmd if $verbose
 
-      if $rake_jobs == 1 || Fiber.current == $rake_root_fiber
+      if !$rake_root_fiber || Fiber.current == $rake_root_fiber
         system(cmd) or fail "Command Failed: [#{cmd}]"
         return
       end
@@ -480,6 +482,12 @@ class RakeApp
   # Run the +rake+ application.
   def run
     handle_options
+
+    if $rake_root_fiber
+      require 'fiber'
+      $rake_root_fiber = Fiber.current
+    end
+
     begin
       here = Dir.pwd
       while ! have_rakefile


### PR DESCRIPTION
Should fix #4085 without `-j` option.