### PR TITLE
Assignment of anonymous class/module name

### DIFF
--- a/include/mrbconf.h
+++ b/include/mrbconf.h
@@ -110,6 +110,9 @@
 /* fixed size state atexit stack */
 //#define MRB_FIXED_STATE_ATEXIT_STACK
 
+/* improve meta programming support */
+//#define MRB_IMPROVE_META_PROGRAMMING
+
 /* -DMRB_DISABLE_XXXX to drop following features */
 //#define MRB_DISABLE_STDIO /* use of stdio */
 

--- a/src/class.c
+++ b/src/class.c
@@ -65,7 +65,7 @@ mrb_class_name_class(mrb_state *mrb, struct RClass *outer, struct RClass *c, mrb
   else {
     name = mrb_class_path(mrb, outer);
     if (mrb_nil_p(name)) {      /* unnamed outer class */
-      if (outer != mrb->object_class) {
+      if (outer != mrb->object_class && outer != c) {
         mrb_obj_iv_set(mrb, (struct RObject*)c, mrb_intern_lit(mrb, "__outer__"),
                        mrb_obj_value(outer));
       }

--- a/src/variable.c
+++ b/src/variable.c
@@ -1069,8 +1069,10 @@ mrb_class_find_path(mrb_state *mrb, struct RClass *c)
 
   str = mrb_sym2name_len(mrb, name, &len);
   mrb_str_cat(mrb, path, str, len);
-  iv_del(mrb, c->iv, mrb_intern_lit(mrb, "__outer__"), NULL);
-  iv_put(mrb, c->iv, mrb_intern_lit(mrb, "__classname__"), path);
-  mrb_field_write_barrier_value(mrb, (struct RBasic*)c, path);
+  if (RSTRING_PTR(path)[0] != '#') {
+    iv_del(mrb, c->iv, mrb_intern_lit(mrb, "__outer__"), NULL);
+    iv_put(mrb, c->iv, mrb_intern_lit(mrb, "__classname__"), path);
+    mrb_field_write_barrier_value(mrb, (struct RBasic*)c, path);
+  }
   return path;
 }

--- a/src/variable.c
+++ b/src/variable.c
@@ -377,21 +377,23 @@ is_namespace(enum mrb_vtype tt)
 static inline void
 assign_class_name(mrb_state *mrb, struct RObject *obj, mrb_sym sym, mrb_value v)
 {
-  if (is_namespace(obj->tt) && is_namespace(mrb_type(v)) && ISUPPER(mrb_sym2name(mrb, sym)[0])) {
+  if (is_namespace(obj->tt) && is_namespace(mrb_type(v))) {
     struct RObject *c = mrb_obj_ptr(v);
-    mrb_sym id_classname = mrb_intern_lit(mrb, "__classname__");
-    mrb_value o = mrb_obj_iv_get(mrb, c, id_classname);
-
-    if (mrb_nil_p(o)) {
-      mrb_sym id_outer = mrb_intern_lit(mrb, "__outer__");
-      o = mrb_obj_iv_get(mrb, c, id_outer);
+    if (obj != c && ISUPPER(mrb_sym2name(mrb, sym)[0])) {
+      mrb_sym id_classname = mrb_intern_lit(mrb, "__classname__");
+      mrb_value o = mrb_obj_iv_get(mrb, c, id_classname);
 
       if (mrb_nil_p(o)) {
-        if ((struct RClass *)obj == mrb->object_class) {
-          mrb_obj_iv_set(mrb, c, id_classname, mrb_symbol_value(sym));
-        }
-        else {
-          mrb_obj_iv_set(mrb, c, id_outer, mrb_obj_value(obj));
+        mrb_sym id_outer = mrb_intern_lit(mrb, "__outer__");
+        o = mrb_obj_iv_get(mrb, c, id_outer);
+
+        if (mrb_nil_p(o)) {
+          if ((struct RClass *)obj == mrb->object_class) {
+            mrb_obj_iv_set(mrb, c, id_classname, mrb_symbol_value(sym));
+          }
+          else {
+            mrb_obj_iv_set(mrb, c, id_outer, mrb_obj_value(obj));
+          }
         }
       }
     }

--- a/src/variable.c
+++ b/src/variable.c
@@ -344,7 +344,9 @@ mrb_iv_get(mrb_state *mrb, mrb_value obj, mrb_sym sym)
   return mrb_nil_value();
 }
 
+#ifdef MRB_IMPROVE_META_PROGRAMMING
 static inline void assign_class_name(mrb_state *mrb, struct RObject *obj, mrb_sym sym, mrb_value v);
+#endif
 
 MRB_API void
 mrb_obj_iv_set(mrb_state *mrb, struct RObject *obj, mrb_sym sym, mrb_value v)
@@ -354,7 +356,9 @@ mrb_obj_iv_set(mrb_state *mrb, struct RObject *obj, mrb_sym sym, mrb_value v)
   if (MRB_FROZEN_P(obj)) {
     mrb_raisef(mrb, E_FROZEN_ERROR, "can't modify frozen %S", mrb_obj_value(obj));
   }
+#ifdef MRB_IMPROVE_META_PROGRAMMING
   assign_class_name(mrb, obj, sym, v);
+#endif
   if (!obj->iv) {
     obj->iv = iv_new(mrb);
   }
@@ -363,6 +367,7 @@ mrb_obj_iv_set(mrb_state *mrb, struct RObject *obj, mrb_sym sym, mrb_value v)
   mrb_write_barrier(mrb, (struct RBasic*)obj);
 }
 
+#ifdef MRB_IMPROVE_META_PROGRAMMING
 static inline mrb_bool
 is_namespace(enum mrb_vtype tt)
 {
@@ -392,6 +397,7 @@ assign_class_name(mrb_state *mrb, struct RObject *obj, mrb_sym sym, mrb_value v)
     }
   }
 }
+#endif
 
 MRB_API void
 mrb_iv_set(mrb_state *mrb, mrb_value obj, mrb_sym sym, mrb_value v)
@@ -1102,10 +1108,14 @@ mrb_class_find_path(mrb_state *mrb, struct RClass *c)
 
   str = mrb_sym2name_len(mrb, name, &len);
   mrb_str_cat(mrb, path, str, len);
+#ifdef MRB_IMPROVE_META_PROGRAMMING
   if (RSTRING_PTR(path)[0] != '#') {
+#endif
     iv_del(mrb, c->iv, mrb_intern_lit(mrb, "__outer__"), NULL);
     iv_put(mrb, c->iv, mrb_intern_lit(mrb, "__classname__"), path);
     mrb_field_write_barrier_value(mrb, (struct RBasic*)c, path);
+#ifdef MRB_IMPROVE_META_PROGRAMMING
   }
+#endif
   return path;
 }


### PR DESCRIPTION
I tried it possible to assign an anonymous class/module name.
This is useful for meta-programming.

It is enabled by setting `conf.cc.defines << "MRB_IMPROVE_META_PROGRAMMING"` to `build_config.rb`.

  - sample script (`sample.rb`):

    ```ruby
    p a = Class.new
    A = a
    p A

    B = A
    Object.instance_exec { remove_const :A }
    p B

    class C
      d = Class.new
      p d
      D = d
    end

    p C::D

    e = Class.new {
      f = Class.new
      const_set(:F, f)
    }

    p e::F
    E = e
    p E::F
    ```

  - Result by default (same as master and 1.4.1):

    ```
    $ ./build/host/bin/mruby sample.rb
    #<Class:0x801825890>
    #<Class:0x801825890>
    #<Class:0x801825890>
    #<Class:0x8018254a0>
    #<Class:0x8018254a0>
    #<Class:0x801825290>::F
    #<Class:0x801825290>::F
    ```

  - Result with `MRB_IMPROVE_META_PROGRAMMING` configuration:

    ```
    $ ./build/host2/bin/mruby sample.rb
    #<Class:0x801825890>
    A
    A
    #<Class:0x8018254a0>
    C::D
    #<Class:0x801825260>::F
    E::F
    ```

  - `build_config.rb` at test:

    ```ruby
    MRuby::Build.new("host") do
      toolchain "gcc"
      gembox "default"
      enable_test
      enable_bintest
    end

    MRuby::Build.new("host2") do
      toolchain "gcc"
      cc.defines << "MRB_IMPROVE_META_PROGRAMMING"
      gembox "default"
      enable_test
      enable_bintest
    end
    ```

### Object code size

When I built it with GCC-8.2.0 for FreeBSD AMD64, it was strangely reduced by 432 bytes.

When I built it with GCC-4.8.1 for mingw32, it was 5120 bytes increase.
