### PR TITLE
Fix outer module name

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -1701,7 +1701,8 @@ mrb_class_name(mrb_state *mrb, struct RClass* c)
 {
   mrb_value path = mrb_class_path(mrb, c);
   if (mrb_nil_p(path)) {
-    path = mrb_str_new_lit(mrb, "#<Class:");
+    path = c->tt == MRB_TT_MODULE ? mrb_str_new_lit(mrb, "#<Module:") :
+                                    mrb_str_new_lit(mrb, "#<Class:");
     mrb_str_concat(mrb, path, mrb_ptr_to_str(mrb, c));
     mrb_str_cat_lit(mrb, path, ">");
   }


### PR DESCRIPTION
# Fix outer module name

When not defined a outer module name, class type is "Class".

  - Currently:

    ```ruby
    a = Module.new
    a::B = Module.new
    p [a, a::B] # => [#<Module:0x801825890>, #<Class:0x801825890>::B]
    ```

  - After patched:

    ```ruby
    a = Module.new
    a::B = Module.new
    p [a, a::B] # => [#<Module:0x801825890>, #<Module:0x801825890>::B]
    ```
