### PR TITLE
Prevent signed integer overflow.

### DIFF
--- a/mrbgems/mruby-sprintf/src/sprintf.c
+++ b/mrbgems/mruby-sprintf/src/sprintf.c
@@ -200,7 +200,7 @@ check_name_arg(mrb_state *mrb, int posarg, const char *name, mrb_int len)
 
 #define GETNUM(n, val) \
   for (; p < end && ISDIGIT(*p); p++) {\
-    if (n > MRB_INT_MAX/10) {\
+    if (n > (MRB_INT_MAX - (*p - '0'))/10) {\
       mrb_raise(mrb, E_ARGUMENT_ERROR, #val " too big"); \
     } \
     n = 10 * n + (*p - '0'); \
@@ -1056,18 +1056,18 @@ retry:
           if (i > 0)
             need = BIT_DIGITS(i);
         }
-        need += (flags&FPREC) ? prec : 6;
-        if (need < 0) {
+        if (need > MRB_INT_MAX - ((flags&FPREC) ? prec : 6)) {
         too_big_width:
           mrb_raise(mrb, E_ARGUMENT_ERROR,
                     (width > prec ? "width too big" : "prec too big"));
         }
+        need += (flags&FPREC) ? prec : 6;
         if ((flags&FWIDTH) && need < width)
           need = width;
-        need += 20;
-        if (need <= 0) {
+        if (need > MRB_INT_MAX - 20) {
           goto too_big_width;
         }
+        need += 20;
 
         CHECK(need);
         n = snprintf(&buf[blen], need, fbuf, fval);


### PR DESCRIPTION
https://github.com/mruby/mruby/issues/4108 was addressed in 625976d7931006bae7e960e561ecdaccb0cb6a28, but signed integer overflows can still occur. I'm concerned that compilers might decide to optimize away the overflow checks, so I've rewritten the code in a way that should avoid signed integer overflows.

I also noticed that the overflow check in `GETNUM` was incorrect, so I fixed that as well.