### PR TITLE
Exclude pipe and exec on iOS/tvOS

### DIFF
--- a/mrbgems/mruby-io/src/io.c
+++ b/mrbgems/mruby-io/src/io.c
@@ -209,7 +209,7 @@ mrb_fd_cloexec(mrb_state *mrb, int fd)
 #endif
 }
 
-#ifndef _WIN32
+#if !defined(_WIN32) && !TARGET_OS_IPHONE
 static int
 mrb_cloexec_pipe(mrb_state *mrb, int fildes[2])
 {


### PR DESCRIPTION
Use of `execl()` is prohibited on these platforms