### PR TITLE
Fix comparisons in str_squeeze.

### DIFF
--- a/mrbgems/mruby-string-ext/src/string.c
+++ b/mrbgems/mruby-string-ext/src/string.c
@@ -543,7 +543,7 @@ str_squeeze(mrb_state *mrb, mrb_value str, mrb_value v_pat)
 {
   struct tr_pattern *pat = NULL;
   mrb_int i;
-  char *s;
+  unsigned char *s;
   mrb_int len;
   mrb_bool flag_changed = FALSE;
   mrb_int lastch = -1;
@@ -552,7 +552,7 @@ str_squeeze(mrb_state *mrb, mrb_value str, mrb_value v_pat)
   if (!mrb_nil_p(v_pat)) {
     pat = tr_parse_pattern(mrb, pat, v_pat, TRUE);
   }
-  s = RSTRING_PTR(str);
+  s = (unsigned char *)RSTRING_PTR(str);
   len = RSTRING_LEN(str);
 
   if (pat) {


### PR DESCRIPTION
Dinko Galetic & Denis Kasak noticed that strings beginning with `\xff` can cause a crash in `str_squeeze` because `s[0]` is treated as a signed value, causing it to be equal to `lastch`, which is -1. After this occurs, `i` is decremented and `s[-1]` is accessed.

The following inputs demonstrate crashes:
```ruby
"\xff00000000000000000000000".squeeze("\xff")
```
```ruby
"\xff00000000000000000000000".squeeze!("\xff")
```
```ruby
"\xff00000000000000000000000".squeeze
```
```ruby
"\xff00000000000000000000000".squeeze!
```
Changing `s` to an `unsigned char *` fixes the problem.