### PR TITLE
Add weak dependency feature for mrbgems

### DIFF
--- a/lib/mruby/gem.rb
+++ b/lib/mruby/gem.rb
@@ -333,13 +333,17 @@ module MRuby
         end
       end
 
+      def weak_dependency? dep
+        dep[:default] && dep[:default][:weak]
+      end
+
       def generate_gem_table build
         gem_table = @ary.reduce({}) { |res,v| res[v.name] = v; res }
 
         default_gems = []
         each do |g|
           g.dependencies.each do |dep|
-            default_gems << default_gem_params(dep) unless gem_table.key?(dep[:gem]) || dep[:default][:weak]
+            default_gems << default_gem_params(dep) unless gem_table.key?(dep[:gem]) || weak_dependency?(dep)
           end
         end
 
@@ -351,14 +355,14 @@ module MRuby
           spec.setup
 
           spec.dependencies.each do |dep|
-            default_gems << default_gem_params(dep) unless gem_table.key?(dep[:gem]) || dep[:default][:weak]
+            default_gems << default_gem_params(dep) unless gem_table.key?(dep[:gem]) || weak_dependency?(dep)
           end
           gem_table[spec.name] = spec
         end
 
         each do |g|
           g.dependencies.delete_if do |dep|
-            gem_table[dep[:gem]].nil? && dep[:default][:weak]
+            gem_table[dep[:gem]].nil? && weak_dependency?(dep)
           end
 
           g.dependencies.each do |dep|

--- a/lib/mruby/gem.rb
+++ b/lib/mruby/gem.rb
@@ -339,7 +339,7 @@ module MRuby
         default_gems = []
         each do |g|
           g.dependencies.each do |dep|
-            default_gems << default_gem_params(dep) unless gem_table.key? dep[:gem]
+            default_gems << default_gem_params(dep) unless gem_table.key?(dep[:gem]) || dep[:default][:weak]
           end
         end
 
@@ -351,12 +351,16 @@ module MRuby
           spec.setup
 
           spec.dependencies.each do |dep|
-            default_gems << default_gem_params(dep) unless gem_table.key? dep[:gem]
+            default_gems << default_gem_params(dep) unless gem_table.key?(dep[:gem]) || dep[:default][:weak]
           end
           gem_table[spec.name] = spec
         end
 
         each do |g|
+          g.dependencies.delete_if do |dep|
+            gem_table[dep[:gem]].nil? && dep[:default][:weak]
+          end
+
           g.dependencies.each do |dep|
             name = dep[:gem]
             req_versions = dep[:requirements]

--- a/mrbgems/full-core.gembox
+++ b/mrbgems/full-core.gembox
@@ -1,9 +1,6 @@
 MRuby::GemBox.new do |conf|
-  conf.gem :core => "mruby-sprintf"
-  conf.gem :core => "mruby-print"
-
   Dir.glob("#{root}/mrbgems/mruby-*/mrbgem.rake") do |x|
     g = File.basename File.dirname x
-    conf.gem :core => g unless g =~ /^mruby-(print|sprintf|bin-debugger|test)$/
+    conf.gem :core => g unless g =~ /^mruby-(bin-debugger|test)$/
   end
 end

--- a/mrbgems/mruby-print/mrbgem.rake
+++ b/mrbgems/mruby-print/mrbgem.rake
@@ -2,4 +2,5 @@ MRuby::Gem::Specification.new('mruby-print') do |spec|
   spec.license = 'MIT'
   spec.author  = 'mruby developers'
   spec.summary = 'standard print/puts/p'
+  spec.add_dependency 'mruby-sprintf', :weak => true
 end


### PR DESCRIPTION
This feature is a hint to change the mrbgem inclusion order when specified by `spec.add_dependency` of `mrbgem.rake`.
It does not mean that it is depends directly, so it will not include mrbgem by itself.

To use this feature, give the `weak: true` argument to the `MRuby::Gem::Specification#add_dependency` method in `mruby-XXX/mrbgem.rake`.

```ruby
spec.add_dependency "mruby-sprintf", :weak => true
```

Example with `mruby-print` and `mruby-sprintf`:

  - `my_build_config.rb`

    ```ruby
    configurations = {
      build: {
        host: {
          gems: [
            { core: "mruby-sprintf" },
            { core: "mruby-print" },
          ]
        },

        ### So far in the wrong mrbgems order
        host2: {
          gems: [
            { core: "mruby-print" },
            { core: "mruby-sprintf" }
          ]
        },

        ### Not including mruby-sprintf
        host3: {
          gems: [
            { core: "mruby-print" }
          ]
        },

        host4: {
          gems: [
            { core: "mruby-sprintf" }
          ]
        }
      }
    }

    configurations[:build].each do |name, conf|
      MRuby::Build.new(name.to_s) do |c|
        toolchain :gcc
        conf[:gems].each { |*g| gem *g }
      end
    end
    ```

  - Build summary of `MRUBY_CONFIG=my_build_config.rb ./minirake clean all`

    ```
    ================================================
          Config Name: host
     Output Directory: build/host
             Binaries: mrbc
        Included Gems:
                 mruby-sprintf - standard Kernel#sprintf method
                 mruby-print - standard print/puts/p
                 mruby-compiler - mruby compiler library
                 mruby-bin-mrbc - mruby compiler executable
    ================================================

    ### mruby-sprintf is weak dependency, so included mruby-sprintf before mruby-print
    ================================================
          Config Name: host2
     Output Directory: build/host2
        Included Gems:
                 mruby-sprintf - standard Kernel#sprintf method
                 mruby-print - standard print/puts/p
    ================================================

    ### mruby-sprintf is weak dependency, but it is not specified directly, so included mruby-print only
    ================================================
          Config Name: host3
     Output Directory: build/host3
        Included Gems:
                 mruby-print - standard print/puts/p
    ================================================

    ================================================
          Config Name: host4
     Output Directory: build/host4
        Included Gems:
                 mruby-sprintf - standard Kernel#sprintf method
    ================================================
    ```


## Compatible problems for users

**It is *not* backwards compatible.** Also it will always be treated as dependent for previous mruby versions.

Therefore, it is necessary to decide by `require "mruby/source"` and `MRuby::Source::MRUBY_RELEASE_NO`.

e.g.:  
```ruby
# A part of mruby-XXX/mrbgem.rake

require "mruby/source"

spec.add_dependency "mruby-YYY", weak: true if MRuby::Source::MRUBY_RELEASE_NO >= 20000
```
