### PR TITLE
Modified behaviour of Hash.delete

### DIFF
--- a/src/hash.c
+++ b/src/hash.c
@@ -982,10 +982,10 @@ MRB_API mrb_value
 mrb_hash_delete_key(mrb_state *mrb, mrb_value hash, mrb_value key)
 {
   seglist *sg = RHASH_TBL(hash);
-  mrb_value del_val;
+  mrb_value del_val,orig_val=mrb_hash_get(mrb,hash,key);
 
   if (sg_del(mrb, sg, key, &del_val)) {
-    return del_val;
+    return orig_val;
   }
 
   /* not found */


### PR DESCRIPTION
Originally, Hash.delete, after deleting an element of the hash, returned the original **value** associated with the deleted key. 

After commit e8dcfe17 (6 august), this was changed, so that the removed **key** was returned. 

With this small patch I try to restore the previous behaviour, in the hope the change was not intentional (I use Hash.delete return values a lot in my code). I modified `mrb_hash_delete_key` because this was more immediate than modifying `mrb_hash_delete`, and I saw that `mrb_hash_delete_key`  is currently used only a couple of times:

* once inside `mrb_hash_delete`
* once in `vm.c` at line 1891, and the return value is not used.

If the change was intentional, please let me know, so I modify my code. Otherwise, you may want to implement a better patch instead of adopting mine.