### PR TITLE
Add documentation to mrb_load_irep

### DIFF
--- a/include/mruby/irep.h
+++ b/include/mruby/irep.h
@@ -48,8 +48,13 @@ typedef struct mrb_irep {
 #define MRB_ISEQ_NO_FREE 1
 
 MRB_API mrb_irep *mrb_add_irep(mrb_state *mrb);
+
+/* @param [const uint8_t*] irep code, expected as a literal */
 MRB_API mrb_value mrb_load_irep(mrb_state*, const uint8_t*);
+
+/* @param [const uint8_t*] irep code, expected as a literal */
 MRB_API mrb_value mrb_load_irep_cxt(mrb_state*, const uint8_t*, mrbc_context*);
+
 void mrb_irep_free(mrb_state*, struct mrb_irep*);
 void mrb_irep_incref(mrb_state*, struct mrb_irep*);
 void mrb_irep_decref(mrb_state*, struct mrb_irep*);


### PR DESCRIPTION
I spent a while trying to figure out why memory appeared to get corrupted when calling `mrb_load_irep`, but not when calling `mrb_load_string_cxt`. Problems with names having hex characters, when calling `methods` as such. I figured out that `mrb_load_irep` expected it's irep as a literal, were as I was supplying it temporally from the stack. This implementation makes sense for most applications.

Im not sure how obvious this problem would have been to everyone working with _mruby_, I might suggest adding some documentation to `mrb_load_irep` such as this PR.
Ill leave it to your discretion.