### PR TITLE
Support lock file for git.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -8,12 +8,19 @@ MRUBY_BUILD_HOST_IS_OPENBSD = RUBY_PLATFORM.include?('openbsd')
 $LOAD_PATH << File.join(MRUBY_ROOT, "lib")
 
 # load build systems
+require 'yaml'
 require "mruby-core-ext"
 require "mruby/build"
 require "mruby/gem"
 
 # load configuration file
 MRUBY_CONFIG = (ENV['MRUBY_CONFIG'] && ENV['MRUBY_CONFIG'] != '') ? ENV['MRUBY_CONFIG'] : "#{MRUBY_ROOT}/build_config.rb"
+MRUBY_CONFIG_LOCK_FILE = "#{MRUBY_CONFIG}.lock"
+MRUBY_CONFIG_LOCK = if File.exist? MRUBY_CONFIG_LOCK_FILE
+                      YAML.load File.read MRUBY_CONFIG_LOCK_FILE
+                    else
+                      {}
+                    end
 load MRUBY_CONFIG
 
 # load basic rules
@@ -115,6 +122,13 @@ task :all => depfiles do
   MRuby.each_target do
     print_build_summary
   end
+
+  locks_result = { 'builds' => {} }
+  MRuby.each_target do
+    locks_result['builds'][name] = locks
+  end
+
+  File.write MRUBY_CONFIG_LOCK_FILE, YAML.dump(locks_result)
 end
 
 desc "run all mruby tests"

--- a/lib/mruby/build.rb
+++ b/lib/mruby/build.rb
@@ -45,7 +45,7 @@ module MRuby
     include Rake::DSL
     include LoadGems
     attr_accessor :name, :bins, :exts, :file_separator, :build_dir, :gem_clone_dir
-    attr_reader :libmruby_objs, :gems, :toolchains
+    attr_reader :libmruby_objs, :gems, :toolchains, :locks
     attr_writer :enable_bintest, :enable_test
 
     alias libmruby libmruby_objs
@@ -70,7 +70,7 @@ module MRuby
 
         @file_separator = '/'
         @build_dir = "#{build_dir}/#{@name}"
-        @gem_clone_dir = "#{build_dir}/mrbgems"
+        @gem_clone_dir = "#{@build_dir}/repos"
         @cc = Command::Compiler.new(self, %w(.c))
         @cxx = Command::Compiler.new(self, %w(.cc .cxx .cpp))
         @objc = Command::Compiler.new(self, %w(.m))
@@ -91,6 +91,10 @@ module MRuby
         @enable_bintest = false
         @enable_test = false
         @toolchains = []
+
+        @locks = MRUBY_CONFIG_LOCK['builds'][@name] if MRUBY_CONFIG_LOCK['builds']
+        @locks ||= {}
+        @enable_lock = true
 
         MRuby.targets[@name] = self
       end
@@ -116,6 +120,10 @@ module MRuby
       @mrbc.compile_options += ' -g'
 
       @enable_debug = true
+    end
+
+    def disable_lock
+      @enable_lock = false
     end
 
     def disable_cxx_exception

--- a/lib/mruby/build/command.rb
+++ b/lib/mruby/build/command.rb
@@ -243,15 +243,16 @@ module MRuby
 
   class Command::Git < Command
     attr_accessor :flags
-    attr_accessor :clone_options, :pull_options, :checkout_options
+    attr_accessor :clone_options, :pull_options, :checkout_options, :reset_options
 
     def initialize(build)
       super
       @command = 'git'
       @flags = %w[]
       @clone_options = "clone %{flags} %{url} %{dir}"
-      @pull_options = "pull"
-      @checkout_options = "checkout %{checksum_hash}"
+      @pull_options = "--git-dir '%{repo_dir}/.git' --work-tree '%{repo_dir}' pull"
+      @checkout_options = "--git-dir '%{repo_dir}/.git' --work-tree '%{repo_dir}' checkout %{checksum_hash}"
+      @reset_options = "--git-dir '%{repo_dir}/.git' --work-tree '%{repo_dir}' reset %{checksum_hash}"
     end
 
     def run_clone(dir, url, _flags = [])
@@ -260,19 +261,26 @@ module MRuby
     end
 
     def run_pull(dir, url)
-      root = Dir.pwd
-      Dir.chdir dir
       _pp "GIT PULL", url, dir.relative_path
-      _run pull_options
-      Dir.chdir root
+      _run pull_options, { :repo_dir => dir }
     end
 
     def run_checkout(dir, checksum_hash)
-      root = Dir.pwd
-      Dir.chdir dir
       _pp "GIT CHECKOUT", checksum_hash
-      _run checkout_options, { :checksum_hash => checksum_hash }
-      Dir.chdir root
+      _run checkout_options, { :checksum_hash => checksum_hash, :repo_dir => dir }
+    end
+
+    def run_reset_hard(dir, checksum_hash)
+      _pp "GIT RESET", checksum_hash
+      _run reset_options, { :checksum_hash => checksum_hash, :repo_dir => dir }
+    end
+
+    def commit_hash(dir)
+      `#{@command} --git-dir '#{dir}/.git' --work-tree '#{dir}' rev-parse --verify HEAD`.strip
+    end
+
+    def current_branch(dir)
+      `#{@command} --git-dir '#{dir}/.git' --work-tree '#{dir}' rev-parse --abbrev-ref HEAD`.strip
     end
   end
 

--- a/lib/mruby/build/load_gems.rb
+++ b/lib/mruby/build/load_gems.rb
@@ -83,11 +83,18 @@ module MRuby
         # by default the 'master' branch is used
         branch = params[:branch] ? params[:branch] : 'master'
 
+        lock = @locks[url] if @enable_lock
+
         if File.exist?(gemdir)
           if $pull_gems
             git.run_pull gemdir, url
-          else
-            gemdir
+            # Jump to the top of the branch
+            git.run_checkout(gemdir, branch)
+            git.run_reset_hard gemdir, "origin/#{branch}"
+          elsif params[:checksum_hash]
+            git.run_reset_hard(gemdir, params[:checksum_hash])
+          elsif lock
+            git.run_reset_hard(gemdir, lock['commit'])
           end
         else
           options = [params[:options]] || []
@@ -96,14 +103,21 @@ module MRuby
           options << "--depth 1" unless params[:checksum_hash]
           FileUtils.mkdir_p "#{gem_clone_dir}"
           git.run_clone gemdir, url, options
+
+          # Jump to the specified commit
+          if params[:checksum_hash]
+            git.run_reset_hard gemdir, params[:checksum_hash]
+          elsif lock
+            git.run_reset_hard gemdir, lock['commit']
+          end
         end
 
-        if params[:checksum_hash]
-          # Jump to the specified commit
-          git.run_checkout gemdir, params[:checksum_hash]
-        else
-          # Jump to the top of the branch
-          git.run_checkout gemdir, branch if $pull_gems
+        if @enable_lock
+          @locks[url] = {
+            'url' => url,
+            'branch' => git.current_branch(gemdir),
+            'commit' => git.commit_hash(gemdir),
+          }
         end
 
         gemdir << "/#{params[:path]}" if params[:path]


### PR DESCRIPTION
Inspired by https://udzura.hatenablog.jp/entry/2018/12/05/143801
Creates lock file to `"#{MRUBY_CONFIG}.lock`.
When pulled or `checksum_hash` is set should be updated with it.
Lock file looks like:
```yaml
---
builds:
  host:
    https://github.com/mattn/mruby-onig-regexp.git:
      url: https://github.com/mattn/mruby-onig-regexp.git
      branch: master
      commit: 354c0df670fe6822528d5a508fb7722233f4b920
```
