### PR TITLE
Fix sleep example

### DIFF
--- a/mrbgems/mruby-sleep/README.md
+++ b/mrbgems/mruby-sleep/README.md
@@ -15,8 +15,8 @@ end
 ## example
 
 ```ruby
-Sleep::sleep(10)
-Sleep::usleep(10000)
+sleep(10)
+usleep(10000)
 ```
 
 # License

--- a/mrbgems/mruby-sleep/README.md
+++ b/mrbgems/mruby-sleep/README.md
@@ -8,7 +8,7 @@ MRuby::Build.new do |conf|
 
     # ... (snip) ...
 
-    conf.gem :git => 'https://github.com/matsumoto-r/mruby-sleep.git'
+    conf.gem :core => 'mruby-sleep'
 end
 ```
 

--- a/mrbgems/mruby-sleep/example/sleep.rb
+++ b/mrbgems/mruby-sleep/example/sleep.rb
@@ -1,3 +1,3 @@
-Sleep::sleep(10)
-Sleep::usleep(10000)
+sleep(10)
+usleep(10000)
 


### PR DESCRIPTION
I fixed the example code of mruby-sleep so that it works.

*   Sleep module is undefined. So, delete the module name.
*   Specify the core library instead of the external library.