### PR TITLE
Expose htable header

### DIFF
--- a/include/mruby/hash.h
+++ b/include/mruby/hash.h
@@ -9,6 +9,7 @@
 
 #include "common.h"
 #include <mruby/khash.h>
+#include <mruby/htable.h>
 
 /**
  * Hash class

--- a/include/mruby/htable.h
+++ b/include/mruby/htable.h
@@ -1,0 +1,27 @@
+#include "common.h"
+
+struct segkv {
+  mrb_value key;
+  mrb_value val;
+};
+
+typedef struct segment {
+  uint16_t size;
+  struct segment *next;
+  struct segkv e[];
+} segment;
+
+typedef struct segindex {
+  size_t size;
+  size_t capa;
+  struct segkv *table[];
+} segindex;
+
+/* Instance variable table structure */
+typedef struct htable {
+  segment *rootseg;
+  segment *lastseg;
+  mrb_int size;
+  uint16_t last_len;
+  segindex *index;
+} htable;

--- a/src/hash.c
+++ b/src/hash.c
@@ -21,32 +21,6 @@ mrb_int mrb_float_id(mrb_float f);
 #endif
 #define HT_SEG_INCREASE_RATIO 6 / 5
 
-struct segkv {
-  mrb_value key;
-  mrb_value val;
-};
-
-typedef struct segment {
-  uint16_t size;
-  struct segment *next;
-  struct segkv e[];
-} segment;
-
-typedef struct segindex {
-  size_t size;
-  size_t capa;
-  struct segkv *table[];
-} segindex;
-
-/* hash table structure */
-typedef struct htable {
-  segment *rootseg;
-  segment *lastseg;
-  mrb_int size;
-  uint16_t last_len;
-  segindex *index;
-} htable;
-
 static /* inline */ size_t
 ht_hash_func(mrb_state *mrb, htable *t, mrb_value key)
 {


### PR DESCRIPTION
As #4186 mentioned, the breaking changes of the removal `khash` structure have made some libraries not working. [Shopify ESS](https://github.com/Shopify/ess) uses the `khash` feature to serialize/deserialize mruby binaries by `msgpack`. The removal of the `khash` makes it impossible to work.

I here suggest that we could expose the `htable` header from the `hash.c` to `htable.h`, which makes it possible to call it from the C program directly. An example usage is shown below.

```c
case MRB_TT_HASH: {
  auto *kh = RHASH_TBL(ruby_value);
  segment *seg;
  mrb_int i;

  if (kh) {
    auto size = size_t{};
    if (size > UINT32_MAX) {
      throw fatal_error(status_code::structure_too_deep);
    }
    packer.pack_map((uint32_t) size);

    seg = kh->rootseg;
    while (seg) {
      for (i=0; i<seg->size; i++) {
        if (!seg->next && i >= kh->last_len) {
          return;
        }
        if (mrb_undef_p(seg->e[i].key)) continue;

        emit_ruby_as_msgpack_rec(engine, seg->e[i].key, packer, depth + 1);
        emit_ruby_as_msgpack_rec(engine, seg->e[i].val, packer, depth + 1);
      }
      seg = seg->next;
    }
  } else {
    packer.pack_map(0);
  }
  return;
}
```