### PR TITLE
Fix parenthesis for macros

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -995,8 +995,8 @@ MRB_API char* mrb_locale_from_utf8(const char *p, int len);
 #define mrb_locale_free(p) free(p)
 #define mrb_utf8_free(p) free(p)
 #else
-#define mrb_utf8_from_locale(p, l) ((char*)p)
-#define mrb_locale_from_utf8(p, l) ((char*)p)
+#define mrb_utf8_from_locale(p, l) ((char*)(p))
+#define mrb_locale_from_utf8(p, l) ((char*)(p))
 #define mrb_locale_free(p)
 #define mrb_utf8_free(p)
 #endif

--- a/include/mruby/boxing_nan.h
+++ b/include/mruby/boxing_nan.h
@@ -81,7 +81,7 @@ typedef struct mrb_value {
 } while (0)
 
 #define SET_FLOAT_VALUE(mrb,r,v) do { \
-  if (v != v) { \
+  if ((v) != (v)) { \
     (r).value.ttt = 0x7ff80000; \
     (r).value.i = 0; \
   } \

--- a/include/mruby/boxing_word.h
+++ b/include/mruby/boxing_word.h
@@ -129,9 +129,9 @@ mrb_type(mrb_value o)
 } while (0)
 
 #ifndef MRB_WITHOUT_FLOAT
-#define SET_FLOAT_VALUE(mrb,r,v) (r) = mrb_word_boxing_float_value(mrb, v)
+#define SET_FLOAT_VALUE(mrb,r,v) ((r) = mrb_word_boxing_float_value(mrb, v))
 #endif
-#define SET_CPTR_VALUE(mrb,r,v) (r) = mrb_word_boxing_cptr_value(mrb, v)
+#define SET_CPTR_VALUE(mrb,r,v) ((r) = mrb_word_boxing_cptr_value(mrb, v))
 #define SET_NIL_VALUE(r) BOXWORD_SET_VALUE(r, MRB_TT_FALSE, value.i, 0)
 #define SET_FALSE_VALUE(r) BOXWORD_SET_VALUE(r, MRB_TT_FALSE, value.i, 1)
 #define SET_TRUE_VALUE(r) BOXWORD_SET_VALUE(r, MRB_TT_TRUE, value.i, 1)

--- a/include/mruby/boxing_word.h
+++ b/include/mruby/boxing_word.h
@@ -129,13 +129,13 @@ mrb_type(mrb_value o)
 } while (0)
 
 #ifndef MRB_WITHOUT_FLOAT
-#define SET_FLOAT_VALUE(mrb,r,v) r = mrb_word_boxing_float_value(mrb, v)
+#define SET_FLOAT_VALUE(mrb,r,v) (r) = mrb_word_boxing_float_value(mrb, v)
 #endif
-#define SET_CPTR_VALUE(mrb,r,v) r = mrb_word_boxing_cptr_value(mrb, v)
+#define SET_CPTR_VALUE(mrb,r,v) (r) = mrb_word_boxing_cptr_value(mrb, v)
 #define SET_NIL_VALUE(r) BOXWORD_SET_VALUE(r, MRB_TT_FALSE, value.i, 0)
 #define SET_FALSE_VALUE(r) BOXWORD_SET_VALUE(r, MRB_TT_FALSE, value.i, 1)
 #define SET_TRUE_VALUE(r) BOXWORD_SET_VALUE(r, MRB_TT_TRUE, value.i, 1)
-#define SET_BOOL_VALUE(r,b) BOXWORD_SET_VALUE(r, b ? MRB_TT_TRUE : MRB_TT_FALSE, value.i, 1)
+#define SET_BOOL_VALUE(r,b) BOXWORD_SET_VALUE(r, (b) ? MRB_TT_TRUE : MRB_TT_FALSE, value.i, 1)
 #define SET_INT_VALUE(r,n) BOXWORD_SET_VALUE(r, MRB_TT_FIXNUM, value.i, (n))
 #define SET_SYM_VALUE(r,v) BOXWORD_SET_VALUE(r, MRB_TT_SYMBOL, value.sym, (v))
 #define SET_OBJ_VALUE(r,v) BOXWORD_SET_VALUE(r, (((struct RObject*)(v))->tt), value.p, (v))

--- a/include/mruby/class.h
+++ b/include/mruby/class.h
@@ -70,7 +70,7 @@ mrb_class(mrb_state *mrb, mrb_value v)
 } while (0)
 #define MRB_FL_CLASS_IS_INHERITED (1 << 17)
 #define MRB_INSTANCE_TT_MASK (0xFF)
-#define MRB_SET_INSTANCE_TT(c, tt) (c)->flags = (((c)->flags & ~MRB_INSTANCE_TT_MASK) | (char)(tt))
+#define MRB_SET_INSTANCE_TT(c, tt) ((c)->flags = (((c)->flags & ~MRB_INSTANCE_TT_MASK) | (char)(tt)))
 #define MRB_INSTANCE_TT(c) (enum mrb_vtype)((c)->flags & MRB_INSTANCE_TT_MASK)
 
 MRB_API struct RClass* mrb_define_class_id(mrb_state*, mrb_sym, struct RClass*);

--- a/include/mruby/class.h
+++ b/include/mruby/class.h
@@ -61,17 +61,17 @@ mrb_class(mrb_state *mrb, mrb_value v)
 #define MRB_FL_CLASS_IS_PREPENDED (1 << 19)
 #define MRB_FL_CLASS_IS_ORIGIN (1 << 18)
 #define MRB_CLASS_ORIGIN(c) do {\
-  if (c->flags & MRB_FL_CLASS_IS_PREPENDED) {\
-    c = c->super;\
-    while (!(c->flags & MRB_FL_CLASS_IS_ORIGIN)) {\
-      c = c->super;\
+  if ((c)->flags & MRB_FL_CLASS_IS_PREPENDED) {\
+    (c) = (c)->super;\
+    while (!((c)->flags & MRB_FL_CLASS_IS_ORIGIN)) {\
+      (c) = (c)->super;\
     }\
   }\
 } while (0)
 #define MRB_FL_CLASS_IS_INHERITED (1 << 17)
 #define MRB_INSTANCE_TT_MASK (0xFF)
-#define MRB_SET_INSTANCE_TT(c, tt) c->flags = ((c->flags & ~MRB_INSTANCE_TT_MASK) | (char)tt)
-#define MRB_INSTANCE_TT(c) (enum mrb_vtype)(c->flags & MRB_INSTANCE_TT_MASK)
+#define MRB_SET_INSTANCE_TT(c, tt) (c)->flags = (((c)->flags & ~MRB_INSTANCE_TT_MASK) | (char)(tt))
+#define MRB_INSTANCE_TT(c) (enum mrb_vtype)((c)->flags & MRB_INSTANCE_TT_MASK)
 
 MRB_API struct RClass* mrb_define_class_id(mrb_state*, mrb_sym, struct RClass*);
 MRB_API struct RClass* mrb_define_module_id(mrb_state*, mrb_sym);

--- a/include/mruby/data.h
+++ b/include/mruby/data.h
@@ -40,9 +40,9 @@ MRB_API struct RData *mrb_data_object_alloc(mrb_state *mrb, struct RClass* klass
   mrb_data_object_alloc(mrb,klass,ptr,type)
 
 #define Data_Make_Struct(mrb,klass,strct,type,sval,data) do { \
-  sval = mrb_malloc(mrb, sizeof(strct));                     \
-  { static const strct zero = { 0 }; *sval = zero; };\
-  data = Data_Wrap_Struct(mrb,klass,type,sval);\
+  (sval) = mrb_malloc(mrb, sizeof(strct));                     \
+  { static const strct zero = { 0 }; *(sval) = zero; };\
+  (data) = Data_Wrap_Struct(mrb,klass,type,sval);\
 } while (0)
 
 #define RDATA(obj)         ((struct RData *)(mrb_ptr(obj)))

--- a/include/mruby/object.h
+++ b/include/mruby/object.h
@@ -14,7 +14,7 @@
   struct RClass *c;\
   struct RBasic *gcnext
 
-#define MRB_FLAG_TEST(obj, flag) ((obj)->flags & flag)
+#define MRB_FLAG_TEST(obj, flag) ((obj)->flags & (flag))
 
 
 struct RBasic {

--- a/include/mruby/proc.h
+++ b/include/mruby/proc.h
@@ -69,11 +69,11 @@ struct RProc {
 #define MRB_PROC_SET_TARGET_CLASS(p,tc) do {\
   if (MRB_PROC_ENV_P(p)) {\
     (p)->e.env->c = (tc);\
-    mrb_field_write_barrier(mrb, (struct RBasic*)(p)->e.env, (struct RBasic*)tc);\
+    mrb_field_write_barrier(mrb, (struct RBasic*)(p)->e.env, (struct RBasic*)(tc));\
   }\
   else {\
     (p)->e.target_class = (tc);\
-    mrb_field_write_barrier(mrb, (struct RBasic*)p, (struct RBasic*)tc);\
+    mrb_field_write_barrier(mrb, (struct RBasic*)p, (struct RBasic*)(tc));\
   }\
 } while (0)
 #define MRB_PROC_SCOPE 2048
@@ -101,8 +101,8 @@ MRB_API mrb_value mrb_proc_cfunc_env_get(mrb_state*, mrb_int);
 #define MRB_METHOD_FUNC_FL ((uintptr_t)1)
 #define MRB_METHOD_FUNC_P(m) (((uintptr_t)(m))&MRB_METHOD_FUNC_FL)
 #define MRB_METHOD_FUNC(m) ((mrb_func_t)((uintptr_t)(m)&(~MRB_METHOD_FUNC_FL)))
-#define MRB_METHOD_FROM_FUNC(m,fn) m=(mrb_method_t)((struct RProc*)((uintptr_t)(fn)|MRB_METHOD_FUNC_FL))
-#define MRB_METHOD_FROM_PROC(m,pr) m=(mrb_method_t)(struct RProc*)(pr)
+#define MRB_METHOD_FROM_FUNC(m,fn) (m)=(mrb_method_t)((struct RProc*)((uintptr_t)(fn)|MRB_METHOD_FUNC_FL))
+#define MRB_METHOD_FROM_PROC(m,pr) (m)=(mrb_method_t)(struct RProc*)(pr)
 #define MRB_METHOD_PROC_P(m) (!MRB_METHOD_FUNC_P(m))
 #define MRB_METHOD_PROC(m) ((struct RProc*)(m))
 #define MRB_METHOD_UNDEF_P(m) ((m)==0)

--- a/include/mruby/proc.h
+++ b/include/mruby/proc.h
@@ -23,13 +23,13 @@ struct REnv {
 };
 
 /* flags (21bits): 1(shared flag):10(cioff/bidx):10(stack_len) */
-#define MRB_ENV_SET_STACK_LEN(e,len) (e)->flags = (((e)->flags & ~0x3ff)|((unsigned int)(len) & 0x3ff))
+#define MRB_ENV_SET_STACK_LEN(e,len) ((e)->flags = (((e)->flags & ~0x3ff)|((unsigned int)(len) & 0x3ff)))
 #define MRB_ENV_STACK_LEN(e) ((mrb_int)((e)->flags & 0x3ff))
 #define MRB_ENV_STACK_UNSHARED (1<<20)
-#define MRB_ENV_UNSHARE_STACK(e) (e)->flags |= MRB_ENV_STACK_UNSHARED
+#define MRB_ENV_UNSHARE_STACK(e) ((e)->flags |= MRB_ENV_STACK_UNSHARED)
 #define MRB_ENV_STACK_SHARED_P(e) (((e)->flags & MRB_ENV_STACK_UNSHARED) == 0)
 #define MRB_ENV_BIDX(e) (((e)->flags >> 10) & 0x3ff)
-#define MRB_ENV_SET_BIDX(e,idx) (e)->flags = (((e)->flags & ~(0x3ff<<10))|((unsigned int)(idx) & 0x3ff)<<10)
+#define MRB_ENV_SET_BIDX(e,idx) ((e)->flags = (((e)->flags & ~(0x3ff<<10))|((unsigned int)(idx) & 0x3ff)<<10))
 
 void mrb_env_unshare(mrb_state*, struct REnv*);
 
@@ -101,8 +101,8 @@ MRB_API mrb_value mrb_proc_cfunc_env_get(mrb_state*, mrb_int);
 #define MRB_METHOD_FUNC_FL ((uintptr_t)1)
 #define MRB_METHOD_FUNC_P(m) (((uintptr_t)(m))&MRB_METHOD_FUNC_FL)
 #define MRB_METHOD_FUNC(m) ((mrb_func_t)((uintptr_t)(m)&(~MRB_METHOD_FUNC_FL)))
-#define MRB_METHOD_FROM_FUNC(m,fn) (m)=(mrb_method_t)((struct RProc*)((uintptr_t)(fn)|MRB_METHOD_FUNC_FL))
-#define MRB_METHOD_FROM_PROC(m,pr) (m)=(mrb_method_t)(struct RProc*)(pr)
+#define MRB_METHOD_FROM_FUNC(m,fn) ((m)=(mrb_method_t)((struct RProc*)((uintptr_t)(fn)|MRB_METHOD_FUNC_FL)))
+#define MRB_METHOD_FROM_PROC(m,pr) ((m)=(mrb_method_t)(struct RProc*)(pr))
 #define MRB_METHOD_PROC_P(m) (!MRB_METHOD_FUNC_P(m))
 #define MRB_METHOD_PROC(m) ((struct RProc*)(m))
 #define MRB_METHOD_UNDEF_P(m) ((m)==0)

--- a/include/mruby/string.h
+++ b/include/mruby/string.h
@@ -39,15 +39,15 @@ struct RString {
 #define RSTR_UNSET_EMBED_FLAG(s) ((s)->flags &= ~(MRB_STR_EMBED|MRB_STR_EMBED_LEN_MASK))
 #define RSTR_SET_EMBED_LEN(s, n) do {\
   size_t tmp_n = (n);\
-  s->flags &= ~MRB_STR_EMBED_LEN_MASK;\
-  s->flags |= (tmp_n) << MRB_STR_EMBED_LEN_SHIFT;\
+  (s)->flags &= ~MRB_STR_EMBED_LEN_MASK;\
+  (s)->flags |= (tmp_n) << MRB_STR_EMBED_LEN_SHIFT;\
 } while (0)
 #define RSTR_SET_LEN(s, n) do {\
   if (RSTR_EMBED_P(s)) {\
     RSTR_SET_EMBED_LEN((s),(n));\
   }\
   else {\
-    s->as.heap.len = (mrb_int)(n);\
+    (s)->as.heap.len = (mrb_int)(n);\
   }\
 } while (0)
 #define RSTR_EMBED_LEN(s)\


### PR DESCRIPTION
I think that some macros and arguments are better to enclose in parenthesis.