### PR TITLE
Fix byte order

### DIFF
--- a/include/mrbconf.h
+++ b/include/mrbconf.h
@@ -60,7 +60,8 @@
 
 /* define on big endian machines; used by MRB_NAN_BOXING, etc. */
 #ifndef MRB_ENDIAN_BIG
-# if BYTE_ORDER == BIG_ENDIAN
+# if (defined(BYTE_ORDER) && defined(BIG_ENDIAN) && BYTE_ORDER == BIG_ENDIAN) || \
+     (defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
 #  define MRB_ENDIAN_BIG
 # endif
 #endif

--- a/mrbgems/mruby-pack/src/pack.c
+++ b/mrbgems/mruby-pack/src/pack.c
@@ -64,6 +64,16 @@ const static unsigned char base64chars[] =
     "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 static unsigned char base64_dec_tab[128];
 
+#if !defined(BYTE_ORDER) && defined(__BYTE_ORDER__)
+# define BYTE_ORDER __BYTE_ORDER__
+#endif
+#if !defined(BIG_ENDIAN) && defined(__ORDER_BIG_ENDIAN__)
+# define BIG_ENDIAN __ORDER_BIG_ENDIAN__
+#endif
+#if !defined(LITTLE_ENDIAN) && defined(__ORDER_LITTLE_ENDIAN__)
+# define LITTLE_ENDIAN __ORDER_LITTLE_ENDIAN__
+#endif
+
 #ifdef BYTE_ORDER
 # if BYTE_ORDER == BIG_ENDIAN
 #  define littleendian 0


### PR DESCRIPTION
`BYTE_ORDER` and `BIG_ENDIAN` macros are not defined by clang and gcc on FreeBSD amd64, so defined `MRB_ENDIAN_BIG` always.

  - by GCC-8.2

    ```
    $ gcc8 -dM -E -xc -o - /dev/null | egrep 'BYTE_ORDER|_ENDIAN' | sort
    #define __BYTE_ORDER__ __ORDER_LITTLE_ENDIAN__
    #define __FLOAT_WORD_ORDER__ __ORDER_LITTLE_ENDIAN__
    #define __ORDER_BIG_ENDIAN__ 4321
    #define __ORDER_LITTLE_ENDIAN__ 1234
    #define __ORDER_PDP_ENDIAN__ 3412
    ```

  - by clang-7.0

    ```
    $ clang70 -dM -E -xc -o - /dev/null | egrep 'BYTE_ORDER|_ENDIAN' | sort
    #define __BYTE_ORDER__ __ORDER_LITTLE_ENDIAN__
    #define __LITTLE_ENDIAN__ 1
    #define __ORDER_BIG_ENDIAN__ 4321
    #define __ORDER_LITTLE_ENDIAN__ 1234
    #define __ORDER_PDP_ENDIAN__ 3412
    ```

I noticed it when building with `MRB_NAN_BOXING`.

- - - -

Macros such as BYTE_ORDER are not defined by the standard.

I looked at FreeBSD / NetBSD / OpenBSD and it seems that you need `#include <sys/endian.h>` to use it.

Also, since it is `#include <sys/endian.h>` in `<sys/types.h>`, it can be used with `# include <sys/types.h>`.

OpenBSD also provides `#include <endian.h>`.