### PR TITLE
Append cflags for undefined macro

### DIFF
--- a/tasks/toolchains/gcc.rake
+++ b/tasks/toolchains/gcc.rake
@@ -1,7 +1,7 @@
 MRuby::Toolchain.new(:gcc) do |conf, _params|
   [conf.cc, conf.objc, conf.asm].each do |cc|
     cc.command = ENV['CC'] || 'gcc'
-    cc.flags = [ENV['CFLAGS'] || %w(-g -std=gnu99 -O3 -Wall -Werror-implicit-function-declaration -Wdeclaration-after-statement -Wwrite-strings)]
+    cc.flags = [ENV['CFLAGS'] || %w(-g -std=gnu99 -O3 -Wall -Werror-implicit-function-declaration -Wdeclaration-after-statement -Wwrite-strings -Wundef)]
     cc.defines = %w(DISABLE_GEMS)
     cc.option_include_path = '-I%s'
     cc.option_define = '-D%s'
@@ -12,7 +12,7 @@ MRuby::Toolchain.new(:gcc) do |conf, _params|
 
   [conf.cxx].each do |cxx|
     cxx.command = ENV['CXX'] || 'g++'
-    cxx.flags = [ENV['CXXFLAGS'] || ENV['CFLAGS'] || %w(-g -O3 -Wall -Werror-implicit-function-declaration)]
+    cxx.flags = [ENV['CXXFLAGS'] || ENV['CFLAGS'] || %w(-g -O3 -Wall -Werror-implicit-function-declaration -Wundef)]
     cxx.defines = %w(DISABLE_GEMS)
     cxx.option_include_path = '-I%s'
     cxx.option_define = '-D%s'


### PR DESCRIPTION
The gcc and clang have `-Wundef` which warns undefined macros.
Since it is not included in `-Wall`, how about considering adding intentionally?

- - - -

In MSVC, `/w34668` will be similarly warned.
https://github.com/dearblue/mruby/commit/82327b9e4fc8f9b529874ea84df8e92d3916aa8d

Since `__STDC_VERSION__` is warned as undefined, it was not included in the patch.
https://ci.appveyor.com/project/dearblue/mruby/build/job/f3bjosftdol73vjj