### PR TITLE
Suppress a struct initializer warning

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -101,7 +101,7 @@ static inline void
 stack_clear(mrb_value *from, size_t count)
 {
 #ifndef MRB_NAN_BOXING
-  const mrb_value mrb_value_zero = { 0 };
+  const mrb_value mrb_value_zero = { { 0 } };
 
   while (count-- > 0) {
     *from++ = mrb_value_zero;


### PR DESCRIPTION
Suppress a compiler (clang) warning bellow:

    src/vm.c:104:38: warning: suggest braces around initialization of
        subobject [-Wmissing-braces]
      const mrb_value mrb_value_zero = { 0 };
                                         ^
                                         {}