### PR TITLE
mruby-enumerator: Refine accessors (obj/meth/args/fib).

### DIFF
--- a/mrbgems/mruby-enumerator/mrblib/enumerator.rb
+++ b/mrbgems/mruby-enumerator/mrblib/enumerator.rb
@@ -128,8 +128,8 @@ class Enumerator
     @feedvalue = nil
     @stop_exc = false
   end
-  attr_accessor :obj, :meth, :args, :fib
-  private :obj, :meth, :args, :fib
+  attr_accessor :args
+  attr_reader :obj, :meth, :fib
 
   def initialize_copy(obj)
     raise TypeError, "can't copy type #{obj.class}" unless obj.kind_of? Enumerator


### PR DESCRIPTION
- Writers are not used except `args`.
- All accessors are used as public (e.g. in `initialized_copy`).