### PR TITLE
Use `__send__` instead of `send` in a Range test.

### DIFF
--- a/test/t/range.rb
+++ b/test/t/range.rb
@@ -59,7 +59,7 @@ assert('Range#initialize', '15.2.14.4.9') do
   assert_equal (1..10), b
   assert_false b.exclude_end?
 
-  assert_raise(NameError) { (0..1).send(:initialize, 1, 3) }
+  assert_raise(NameError) { (0..1).__send__(:initialize, 1, 3) }
 end
 
 assert('Range#last', '15.2.14.4.10') do


### PR DESCRIPTION
This assertion is accidentaly passed because `send` was removed from mruby
core so `NoMethodError` is raised and `NoMethodError` is subclass of
`NameError`.