### PR TITLE
io: Skip TTY test for environments that TTY device is unavailable.

### DIFF
--- a/mrbgems/mruby-io/test/io.rb
+++ b/mrbgems/mruby-io/test/io.rb
@@ -344,15 +344,21 @@ end
 
 assert('IO#isatty') do
   skip "isatty is not supported on this platform" if MRubyIOTestUtil.win?
-  f1 = File.open("/dev/tty")
-  f2 = File.open($mrbtest_io_rfname)
-
-  assert_true  f1.isatty
-  assert_false f2.isatty
-
-  f1.close
-  f2.close
-  true
+  begin
+    f = File.open("/dev/tty")
+  rescue RuntimeError => e
+    skip e.message
+  else
+    assert_true f.isatty
+  ensure
+    f&.close
+  end
+  begin
+    f = File.open($mrbtest_io_rfname)
+    assert_false f.isatty
+  ensure
+    f&.close
+  end
 end
 
 assert('IO#pos=, IO#seek') do


### PR DESCRIPTION
e.g. GitLab CI