### PR TITLE
Integrate mrblib/float.rb into src/numeric.c

### DIFF
--- a/mrblib/float.rb
+++ b/mrblib/float.rb
@@ -1,9 +1,0 @@
-##
-# Float
-#
-# ISO 15.2.9
-class Float
-  # mruby special - since mruby integers may be upgraded to floats,
-  # floats should be compatible to integers.
-  include Integral
-end if Object.const_defined?(:Float)

--- a/mrblib/mrblib.rake
+++ b/mrblib/mrblib.rake
@@ -8,9 +8,6 @@ MRuby.each_target do
   file objfile("#{current_build_dir}/mrblib") => "#{current_build_dir}/mrblib.c"
   file "#{current_build_dir}/mrblib.c" => [mrbcfile, __FILE__] + Dir.glob("#{current_dir}/*.rb").sort do |t|
     _, _, *rbfiles = t.prerequisites
-    if self.cc.defines.flatten.include?("MRB_WITHOUT_FLOAT")
-      rbfiles.delete("#{current_dir}/float.rb")
-    end
     FileUtils.mkdir_p File.dirname(t.name)
     open(t.name, 'w') do |f|
       _pp "GEN", "*.rb", "#{t.name.relative_path}"

--- a/src/numeric.c
+++ b/src/numeric.c
@@ -1487,10 +1487,12 @@ flo_plus(mrb_state *mrb, mrb_value x)
 void
 mrb_init_numeric(mrb_state *mrb)
 {
-  struct RClass *numeric, *integer, *fixnum;
+  struct RClass *numeric, *integer, *fixnum, *integral;
 #ifndef MRB_WITHOUT_FLOAT
   struct RClass *fl;
 #endif
+
+  integral = mrb_define_module(mrb, "Integral");
 
   /* Numeric Class */
   numeric = mrb_define_class(mrb, "Numeric",  mrb->object_class);                /* 15.2.7 */
@@ -1578,6 +1580,7 @@ mrb_init_numeric(mrb_state *mrb)
 #ifdef NAN
   mrb_define_const(mrb, fl, "NAN", mrb_float_value(mrb, NAN));
 #endif
+
+  mrb_include_module(mrb, fl, integral);
 #endif
-  mrb_define_module(mrb, "Integral");
 }


### PR DESCRIPTION
- Avoid hack for `MRB_WITHOUT_FLOAT` in build scripts
- Avoid runtime dispatch for `MRB_WITHOUT_FLOAT`