### PR TITLE
Improve compatibility to CRuby for `Float#to_s`

### DIFF
--- a/src/state.c
+++ b/src/state.c
@@ -41,6 +41,10 @@ mrb_open_core(mrb_allocf f, void *ud)
 
   mrb_init_core(mrb);
 
+#if !defined(MRB_DISABLE_STDIO) && defined(_MSC_VER) && _MSC_VER < 1900
+  _set_output_format(_TWO_DIGIT_EXPONENT);
+#endif
+
   return mrb;
 }
 

--- a/test/t/float.rb
+++ b/test/t/float.rb
@@ -206,4 +206,37 @@ assert('Float#>>') do
   assert_equal(-1, -23.0 >> 128)
 end
 
+assert('Float#to_s') do
+  uses_float = 4e38.infinite?  # enable MRB_USE_FLOAT?
+
+  assert_equal("Infinity", Float::INFINITY.to_s)
+  assert_equal("-Infinity", (-Float::INFINITY).to_s)
+  assert_equal("NaN", Float::NAN.to_s)
+  assert_equal("0.0", 0.0.to_s)
+  assert_equal("-0.0", -0.0.to_s)
+  assert_equal("-3.21", -3.21.to_s)
+  assert_equal("50.0", 50.0.to_s)
+  assert_equal("0.00021", 0.00021.to_s)
+  assert_equal("-0.00021", -0.00021.to_s)
+  assert_equal("2.1e-05", 0.000021.to_s)
+  assert_equal("-2.1e-05", -0.000021.to_s)
+  assert_equal("1.0e+20", 1e20.to_s)
+  assert_equal("-1.0e+20", -1e20.to_s)
+  assert_equal("1.0e+16", 10000000000000000.0.to_s)
+  assert_equal("-1.0e+16", -10000000000000000.0.to_s)
+  assert_equal("100000.0", 100000.0.to_s)
+  assert_equal("-100000.0", -100000.0.to_s)
+  if uses_float
+    assert_equal("1.0e+08", 100000000.0.to_s)
+    assert_equal("-1.0e+08", -100000000.0.to_s)
+    assert_equal("1.0e+07", 10000000.0.to_s)
+    assert_equal("-1.0e+07", -10000000.0.to_s)
+  else
+    assert_equal("1.0e+15", 1000000000000000.0.to_s)
+    assert_equal("-1.0e+15", -1000000000000000.0.to_s)
+    assert_equal("100000000000000.0", 100000000000000.0.to_s)
+    assert_equal("-100000000000000.0", -100000000000000.0.to_s)
+  end
+end
+
 end # const_defined?(:Float)


### PR DESCRIPTION
### Bfore:

  ~~~ruby
  p Float::INFINITY.to_s  #=> "inf"
  p 50.0.to_s             #=> "50"
  p 1e20.to_s             #=> "1e+20"
  ~~~

### After / CRuby:

  ~~~ruby
  p Float::INFINITY.to_s  #=> "Infinity"
  p 50.0.to_s             #=> "50.0"
  p 1e20.to_s             #=> "1.0e+20"
   ~~~