### PR TITLE
Build fails when set `conf.build_dir=<rel path>` and `conf.enable_cxx_exception`

### DIFF
--- a/lib/mruby/build.rb
+++ b/lib/mruby/build.rb
@@ -162,8 +162,6 @@ module MRuby
     end
 
     def compile_as_cxx src, cxx_src, obj = nil, includes = []
-      src = File.absolute_path src
-      cxx_src = File.absolute_path cxx_src
       obj = objfile(cxx_src) if obj.nil?
 
       file cxx_src => [src, __FILE__] do |t|
@@ -175,7 +173,7 @@ module MRuby
 #ifndef MRB_ENABLE_CXX_ABI
 extern "C" {
 #endif
-#include "#{src}"
+#include "#{File.absolute_path src}"
 #ifndef MRB_ENABLE_CXX_ABI
 }
 #endif


### PR DESCRIPTION
Build fails with the setting where `conf.build_dir=<rel path>` and `conf.enable_cxx_exception` are described in `build_config.rb`.

  - `test_build_config.rb`:

    ```ruby
    MRuby::Build.new do |conf|
      toolchain :gcc
      conf.build_dir = "build/host"
      enable_cxx_exception
    end
    ```

  - before patched:

    ```
    $ MRUBY_CONFIG=test_build_config.rb ./minirake
    (in /usr/home/dearblue/works/ruby/mruby.git)
    rake aborted!
    Don't know how to rake /usr/home/dearblue/works/ruby/mruby.git/build/host/mrbgems/mruby-compiler/core/y.tab.c
    ```

The `MRuby::Build#compile_as_cxx` method converts the path given as a rule to an absolute path, but this patch does not convert but gives it as it is.
