### PR TITLE
Fix coercing for first step counter in `Numeric#step`

### DIFF
--- a/mrblib/numeric.rb
+++ b/mrblib/numeric.rb
@@ -104,11 +104,18 @@ module Integral
     raise ArgumentError, "step can't be 0" if step == 0
     return to_enum(:step, num, step) unless block
 
-    i = if Object.const_defined?(:Float) && num.kind_of?(Float) then self.to_f else self end
+    i = self
+    if Object.const_defined?(:Float) &&
+      (kind_of?(Float) || num.kind_of?(Float) || step.kind_of?(Float))
+      i = i.to_f
+      num = num.to_f unless num == nil
+      step = step.to_f
+    end
+
     if num == nil
       while true
         block.call(i)
-        i+=step
+        i += step
       end
       return self
     end

--- a/test/t/integer.rb
+++ b/test/t/integer.rb
@@ -257,19 +257,3 @@ assert('Integer#divmod', '15.2.8.3.30') do
   assert_equal [-2, -1],  25.divmod(-13)
   assert_equal [ 1, -6], -13.divmod(-7)
 end
-
-# Not ISO specified
-
-assert('Integer#step') do
-  a = []
-  b = []
-  1.step(3) do |i|
-    a << i
-  end
-  1.step(6, 2) do |i|
-    b << i
-  end
-
-  assert_equal [1, 2, 3], a
-  assert_equal [1, 3, 5], b
-end

--- a/test/t/numeric.rb
+++ b/test/t/numeric.rb
@@ -42,3 +42,35 @@ end
 assert('Numeric#**') do
   assert_equal 8.0, 2.0**3
 end
+
+assert('Numeric#step') do
+  assert_step = ->(exp, receiver, args) do
+    inf = !args[0]
+    act = []
+    ret = receiver.step(*args) do |i|
+      act << i
+      break if inf && exp.size == act.size
+    end
+    expr = "#{receiver.inspect}.step(#{args.map(&:inspect).join(', ')})"
+    msg = "#{expr}: counters"
+    diff = assertion_diff(exp, act)
+    assert_true exp.map{|v|[v,v.class]} == act.map{|v|[v,v.class]}, msg, diff
+    assert_same receiver, ret, "#{expr}: return value" unless inf
+  end
+
+  assert_raise(ArgumentError) { 1.step(2, 0) { break } }
+  assert_step.([2, 3, 4], 2, [4])
+  assert_step.([10, 8, 6, 4, 2], 10, [1, -2])
+  assert_step.([], 2, [1, 3])
+  assert_step.([], -2, [-1, -3])
+  assert_step.([10, 11, 12, 13], 10, [])
+  assert_step.([10, 7, 4], 10, [nil, -3])
+
+  skip unless Object.const_defined?(:Float)
+  assert_raise(ArgumentError) { 1.step(2, 0.0) { break } }
+  assert_step.([2.0, 3.0, 4.0], 2, [4.0])
+  assert_step.([7.0, 4.0, 1.0, -2.0], 7, [-4, -3.0])
+  assert_step.([2.0, 3.0, 4.0], 2.0, [4])
+  assert_step.([10.0, 11.0, 12.0, 13.0], 10.0, [])
+  assert_step.([10.0, 7.0, 4.0], 10, [nil, -3.0])
+end


### PR DESCRIPTION
### Before:

~~~ruby
a=[]; 7.step(4, -3.0) { |c| a << c }; p a  #=> [7, 4.0]
~~~

### After / Ruby:

~~~ruby
a=[]; 7.step(4, -3.0) { |c| a << c }; p a  #=> [7.0, 4.0]
~~~