### PR TITLE
Remove definition of `Kernel#sprintf` in `mruby-print`

### DIFF
--- a/mrbgems/mruby-print/mrblib/print.rb
+++ b/mrbgems/mruby-print/mrblib/print.rb
@@ -52,9 +52,6 @@ module Kernel
     def printf(*args)
       raise NotImplementedError.new('printf not available')
     end
-    def sprintf(*args)
-      raise NotImplementedError.new('sprintf not available')
-    end
   else
     def printf(*args)
       __printstr__(sprintf(*args))


### PR DESCRIPTION
`Kernel#sprintf` is defined in `mruby-sprintf`