### PR TITLE
Refine error message for time interval

### DIFF
--- a/mrbgems/mruby-sleep/src/mrb_sleep.c
+++ b/mrbgems/mruby-sleep/src/mrb_sleep.c
@@ -51,7 +51,7 @@ mrb_f_sleep(mrb_state *mrb, mrb_value self)
         usleep(sec * 1000000);
     }
     else {
-        mrb_raise(mrb, E_ARGUMENT_ERROR, "time interval must be positive integer");
+        mrb_raise(mrb, E_ARGUMENT_ERROR, "time interval must not be negative");
     }
 #else
     mrb_int sec;
@@ -60,7 +60,7 @@ mrb_f_sleep(mrb_state *mrb, mrb_value self)
     if (sec >= 0) {
         sleep(sec);
     } else {
-        mrb_raise(mrb, E_ARGUMENT_ERROR, "time interval must be positive integer");
+        mrb_raise(mrb, E_ARGUMENT_ERROR, "time interval must not be negative");
     }
 #endif
     end = time(0) - beg;
@@ -94,7 +94,7 @@ mrb_f_usleep(mrb_state *mrb, mrb_value self)
     if (usec >= 0) {
         usleep(usec);
     } else {
-        mrb_raise(mrb, E_ARGUMENT_ERROR, "time interval must be positive integer");
+        mrb_raise(mrb, E_ARGUMENT_ERROR, "time interval must not be negative integer");
     }
 
 #ifdef _WIN32

--- a/mrbgems/mruby-sleep/test/sleep_test.rb
+++ b/mrbgems/mruby-sleep/test/sleep_test.rb
@@ -1,13 +1,27 @@
 assert("sleep works") do
   assert_nothing_raised { sleep(1) }
+  assert_nothing_raised { sleep(0) }
 end
 
-assert("sleep would not accept negative value") do
+assert("sleep would accept non-negative float value") do
+  skip unless Object.const_defined?(:Float)
+  assert_nothing_raised { sleep(0.01) }
+  assert_nothing_raised { sleep(0.0) }
+  assert_nothing_raised { sleep(-0.0) }
+end
+
+assert("sleep would not accept negative integer value") do
   assert_raise(ArgumentError) { sleep(-1) }
+end
+
+assert("sleep would not accept negative float value") do
+  skip unless Object.const_defined?(:Float)
+  assert_raise(ArgumentError) { sleep(-0.1) }
 end
 
 assert("usleep works") do
   assert_nothing_raised { usleep(100) }
+  assert_nothing_raised { usleep(0) }
 end
 
 assert("usleep would not accept negative value") do


### PR DESCRIPTION
Time interval value can be zero, and float (in `Kernel#sleep`)