### PR TITLE
`class`/`module` expression  with empty body should return `nil`

### DIFF
--- a/mrbgems/mruby-compiler/core/codegen.c
+++ b/mrbgems/mruby-compiler/core/codegen.c
@@ -2806,7 +2806,10 @@ codegen(codegen_scope *s, node *tree, int val)
       idx = new_sym(s, nsym(tree->car->cdr));
       genop_2(s, OP_CLASS, cursp(), idx);
       body = tree->cdr->cdr->car;
-      if (!(nint(body->cdr->car) == NODE_BEGIN && body->cdr->cdr == NULL)) {
+      if (nint(body->cdr->car) == NODE_BEGIN && body->cdr->cdr == NULL) {
+        genop_1(s, OP_LOADNIL, cursp());
+      }
+      else {
         idx = scope_body(s, body, val);
         genop_2(s, OP_EXEC, cursp(), idx);
       }
@@ -2834,8 +2837,11 @@ codegen(codegen_scope *s, node *tree, int val)
       pop();
       idx = new_sym(s, nsym(tree->car->cdr));
       genop_2(s, OP_MODULE, cursp(), idx);
-      if (!(nint(tree->cdr->car->cdr->car) == NODE_BEGIN &&
-            tree->cdr->car->cdr->cdr == NULL)) {
+      if (nint(tree->cdr->car->cdr->car) == NODE_BEGIN &&
+          tree->cdr->car->cdr->cdr == NULL) {
+        genop_1(s, OP_LOADNIL, cursp());
+      }
+      else {
         idx = scope_body(s, tree->cdr->car, val);
         genop_2(s, OP_EXEC, cursp(), idx);
       }
@@ -2852,8 +2858,11 @@ codegen(codegen_scope *s, node *tree, int val)
       codegen(s, tree->car, VAL);
       pop();
       genop_1(s, OP_SCLASS, cursp());
-      if (!(nint(tree->cdr->car->cdr->car) == NODE_BEGIN &&
-            tree->cdr->car->cdr->cdr == NULL)) {
+      if (nint(tree->cdr->car->cdr->car) == NODE_BEGIN &&
+          tree->cdr->car->cdr->cdr == NULL) {
+        genop_1(s, OP_LOADNIL, cursp());
+      }
+      else {
         idx = scope_body(s, tree->cdr->car, val);
         genop_2(s, OP_EXEC, cursp(), idx);
       }

--- a/test/t/class.rb
+++ b/test/t/class.rb
@@ -236,6 +236,11 @@ assert('class to return the last value') do
   assert_equal(m, :m)
 end
 
+assert('class to return nil if body is empty') do
+  assert_nil(class C end)
+  assert_nil(class << self; end)
+end
+
 assert('raise when superclass is not a class') do
   module FirstModule; end
   assert_raise(TypeError, 'should raise TypeError') do

--- a/test/t/module.rb
+++ b/test/t/module.rb
@@ -708,6 +708,15 @@ assert('module with non-class/module outer raises TypeError') do
   assert_raise(TypeError) { module []::M2 end }
 end
 
+assert('module to return the last value') do
+  m = module M; :m end
+  assert_equal(m, :m)
+end
+
+assert('module to return nil if body is empty') do
+  assert_nil(module M end)
+end
+
 assert('get constant of parent module in singleton class; issue #3568') do
   actual = module GetConstantInSingletonTest
     EXPECTED = "value"


### PR DESCRIPTION
### Before

  ~~~ruby
  p(class A end)          #=> A
  p(class << self; end)   #=> #<Class:#<Object:0x7fdc3880e420>>
  p(module B end)         #=> B
  ~~~

### After/Ruby:

  ~~~ruby
  p(class A end)          #=> nil
  p(class << self; end)   #=> nil
  p(module B end)         #=> nil
  ~~~