### PR TITLE
NULL safed `mrb_open_core()`

### DIFF
--- a/src/state.c
+++ b/src/state.c
@@ -26,6 +26,7 @@ mrb_open_core(mrb_allocf f, void *ud)
   static const struct mrb_context mrb_context_zero = { 0 };
   mrb_state *mrb;
 
+  if (f == NULL) f = mrb_default_allocf;
   mrb = (mrb_state *)(f)(NULL, NULL, sizeof(mrb_state), ud);
   if (mrb == NULL) return NULL;
 


### PR DESCRIPTION
I am lazy, so I'm happy if I can pass `NULL` to `mrb_open_core()`.
