### PR TITLE
`bin=` should be an instance method in `MRuby::Gem::Specification`

### DIFF
--- a/lib/mruby/gem.rb
+++ b/lib/mruby/gem.rb
@@ -119,8 +119,8 @@ module MRuby
         @conflicts << {:gem => name, :requirements => req.empty? ? nil : req}
       end
 
-      def self.bin=(bin)
-        @bins = [bin].flatten
+      def bin=(bin)
+        @bins = [bin]
       end
 
       def build_dir


### PR DESCRIPTION
`Array#flatten` is unneeded because we should use `bins=` for passing an
array, I think.