### PR TITLE
Refine `mrbgems/mruby-bin-config/mrbgem.rake`

### DIFF
--- a/mrbgems/mruby-bin-config/mrbgem.rake
+++ b/mrbgems/mruby-bin-config/mrbgem.rake
@@ -1,17 +1,22 @@
-MRuby.each_target do
-  next if kind_of? MRuby::CrossBuild
+unless MRuby::Build.current.kind_of?(MRuby::CrossBuild)
+  MRuby::Gem::Specification.new('mruby-bin-config') do |spec|
+    name = 'mruby-config'
+    spec.license = 'MIT'
+    spec.author  = 'mruby developers'
+    spec.summary = "#{name} command"
 
-  mruby_config = 'mruby-config' + (ENV['OS'] == 'Windows_NT' ? '.bat' : '')
-  mruby_config_path = "#{build_dir}/bin/#{mruby_config}"
-  @bins << mruby_config
+    mruby_config = name + (ENV['OS'] == 'Windows_NT' ? '.bat' : '')
+    mruby_config_path = "#{build.build_dir}/bin/#{mruby_config}"
+    make_cfg = "#{build.build_dir}/lib/libmruby.flags.mak"
+    build.bins << mruby_config
 
-  make_cfg = "#{build_dir}/lib/libmruby.flags.mak"
-  file mruby_config_path => [libmruby_static, make_cfg] do |t|
-    FileUtils.copy "#{File.dirname(__FILE__)}/#{mruby_config}", t.name
-    config = Hash[open(make_cfg).read.split("\n").map {|x| a = x.split(/\s*=\s*/, 2); [a[0], a[1].gsub('\\"', '"') ]}]
-    IO.write(t.name, File.open(t.name) {|f|
-      f.read.gsub (/echo (MRUBY_CFLAGS|MRUBY_LIBS|MRUBY_LDFLAGS_BEFORE_LIBS|MRUBY_LDFLAGS|MRUBY_LIBMRUBY_PATH)/) {|x| config[$1].empty? ? '' : "echo #{config[$1]}"}
-    })
-    FileUtils.chmod(0755, t.name)
+    file mruby_config_path => [build.libmruby_static, make_cfg] do |t|
+      config = Hash[File.readlines(make_cfg).map(&:chomp).map {|l|
+        l.gsub('\\"', '"').split(' = ', 2).map! {|s| s.sub(/^(?=.)/, 'echo ')}
+      }]
+      tmplt = File.read("#{__dir__}/#{mruby_config}")
+      File.write(t.name, tmplt.gsub(/(#{Regexp.union(*config.keys)})\b/, config))
+      FileUtils.chmod(0755, t.name)
+    end
   end
 end


### PR DESCRIPTION
- Use `MRuby::Gem::Specification`
- Fix a binary name is added to `MRuby::Build#bins` multiple times
- Close file immediately (avoid using `open(...).read`)
- Simplify