### PR TITLE
Fix destroyed "inline packed symbols" on 32 bit mode with `MRB_WORD_BOXING`

### DIFF
--- a/include/mruby/value.h
+++ b/include/mruby/value.h
@@ -160,6 +160,10 @@ typedef void mrb_value;
 #ifndef mrb_bool
 #define mrb_bool(o)   (mrb_type(o) != MRB_TT_FALSE)
 #endif
+#if !defined(MRB_SYMBOL_BITSIZE)
+#define MRB_SYMBOL_BITSIZE (sizeof(mrb_sym) * CHAR_BIT)
+#define MRB_SYMBOL_MAX      UINT32_MAX
+#endif
 #ifndef MRB_WITHOUT_FLOAT
 #define mrb_float_p(o) (mrb_type(o) == MRB_TT_FLOAT)
 #endif

--- a/src/symbol.c
+++ b/src/symbol.c
@@ -34,13 +34,18 @@ static const char pack_table[] = "_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRS
 static mrb_sym
 sym_inline_pack(const char *name, uint16_t len)
 {
+  enum {
+    lower_length_max  = (MRB_SYMBOL_BITSIZE - 2) / 5,
+    mix_length_max    = (MRB_SYMBOL_BITSIZE - 2) / 6
+  };
+
   char c;
   const char *p;
   int i;
   mrb_sym sym = 0;
   int lower = 1;
 
-  if (len > 6) return 0;        /* too long */
+  if (len > lower_length_max) return 0; /* too long */
   for (i=0; i<len; i++) {
     uint32_t bits;
 
@@ -64,7 +69,7 @@ sym_inline_pack(const char *name, uint16_t len)
     }
     return sym | 3;
   }
-  if (len == 6) return 0;
+  if (len > mix_length_max) return 0;
   return sym | 1;
 }
 

--- a/src/symbol.c
+++ b/src/symbol.c
@@ -34,10 +34,8 @@ static const char pack_table[] = "_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRS
 static mrb_sym
 sym_inline_pack(const char *name, uint16_t len)
 {
-  enum {
-    lower_length_max  = (MRB_SYMBOL_BITSIZE - 2) / 5,
-    mix_length_max    = (MRB_SYMBOL_BITSIZE - 2) / 6
-  };
+  const int lower_length_max = (MRB_SYMBOL_BITSIZE - 2) / 5;
+  const int mix_length_max   = (MRB_SYMBOL_BITSIZE - 2) / 6;
 
   char c;
   const char *p;


### PR DESCRIPTION
When building with `MRB_WORD_BOXING` in 32 bit mode, symbols are destroyed depending on the character string length.

```
$ build/host32-word/bin/mruby -e 'p [:zzzzzz, :ZZZZZ]'
[:zzzzb, :ZZZd]
```

In 32-bit mode with `MRB_WORD_BOXING`, only the value of` mrb_sym` is guaranteed 24 bits, there are only 4 spaces for lower case letters and 3 letters for numeral alphabet mixture.

For this reason, I restricted the length of the character string that can be inline packed symbols with this combination of configurations.

The "inline packed symbols" is nice idea :thumbsup:
