### PR TITLE
Reorder members in `struct backtrace_location`

### DIFF
--- a/src/backtrace.c
+++ b/src/backtrace.c
@@ -17,8 +17,8 @@
 
 struct backtrace_location {
   int lineno;
-  const char *filename;
   mrb_sym method_id;
+  const char *filename;
 };
 
 typedef void (*each_backtrace_func)(mrb_state*, struct backtrace_location*, void*);


### PR DESCRIPTION
`sizeof(struct backtrace_location)` is 24 bytes -> 16 bytes in LP64
data model etc.