### PR TITLE
mrdb: add "info locals" command

### DIFF
--- a/mrbgems/mruby-bin-debugger/tools/mrdb/apiprint.c
+++ b/mrbgems/mruby-bin-debugger/tools/mrdb/apiprint.c
@@ -31,7 +31,7 @@ mrdb_check_syntax(mrb_state *mrb, mrb_debug_context *dbg, const char *expr, size
 }
 
 mrb_value
-mrb_debug_eval(mrb_state *mrb, mrb_debug_context *dbg, const char *expr, size_t len, mrb_bool *exc)
+mrb_debug_eval(mrb_state *mrb, mrb_debug_context *dbg, const char *expr, size_t len, mrb_bool *exc, int direct_eval)
 {
   void (*tmp)(struct mrb_state *, struct mrb_irep *, mrb_code *, mrb_value *);
   mrb_value ruby_code;
@@ -47,6 +47,11 @@ mrb_debug_eval(mrb_state *mrb, mrb_debug_context *dbg, const char *expr, size_t 
   if (mrb->exc) {
     v = mrb_obj_value(mrb->exc);
     mrb->exc = 0;
+  }
+  else if (direct_eval) {
+    recv = dbg->regs[0];
+
+    v = mrb_funcall(mrb, recv, expr, 0);
   }
   else {
     /*

--- a/mrbgems/mruby-bin-debugger/tools/mrdb/apiprint.h
+++ b/mrbgems/mruby-bin-debugger/tools/mrdb/apiprint.h
@@ -8,6 +8,6 @@
 #include <mruby.h>
 #include "mrdb.h"
 
-mrb_value mrb_debug_eval(mrb_state*, mrb_debug_context*, const char*, size_t, mrb_bool*);
+mrb_value mrb_debug_eval(mrb_state*, mrb_debug_context*, const char*, size_t, mrb_bool*, int);
 
 #endif /* APIPRINT_H_ */

--- a/mrbgems/mruby-bin-debugger/tools/mrdb/cmdmisc.c
+++ b/mrbgems/mruby-bin-debugger/tools/mrdb/cmdmisc.c
@@ -82,6 +82,12 @@ static help_msg help_msg_list[] = {
     "Arguments are breakpoint numbers with spaces in between.\n"
   },
   {
+    "i[nfo]", "l[ocals]", "Print name of local variables",
+    "Usage: info locals\n"
+    "\n"
+    "Print name of local variables.\n"
+  },
+  {
     "l[ist]", NULL, "List specified line",
     "Usage: list\n"
     "       list first[,last]\n"

--- a/mrbgems/mruby-bin-debugger/tools/mrdb/cmdprint.c
+++ b/mrbgems/mruby-bin-debugger/tools/mrdb/cmdprint.c
@@ -36,7 +36,7 @@ dbgcmd_print(mrb_state *mrb, mrdb_state *mrdb)
     expr = mrb_str_cat_cstr(mrb, expr, mrdb->words[wcnt]);
   }
 
-  result = mrb_debug_eval(mrb, mrdb->dbg, RSTRING_PTR(expr), RSTRING_LEN(expr), NULL);
+  result = mrb_debug_eval(mrb, mrdb->dbg, RSTRING_PTR(expr), RSTRING_LEN(expr), NULL, 0);
 
   /* $print_no = result */
   s = mrb_str_cat_lit(mrb, result, "\0");
@@ -55,4 +55,27 @@ dbgcmd_state
 dbgcmd_eval(mrb_state *mrb, mrdb_state *mrdb)
 {
   return dbgcmd_print(mrb, mrdb);
+}
+
+dbgcmd_state
+dbgcmd_info_local(mrb_state *mrb, mrdb_state *mrdb)
+{
+  mrb_value result;
+  mrb_value s;
+  int ai;
+
+  ai = mrb_gc_arena_save(mrb);
+
+  result = mrb_debug_eval(mrb, mrdb->dbg, "local_variables", 0, NULL, 1);
+
+  s = mrb_str_cat_lit(mrb, result, "\0");
+  printf("$%lu = %s\n", (unsigned long)mrdb->print_no++, RSTRING_PTR(s));
+
+  if (mrdb->print_no == 0) {
+    mrdb->print_no = 1;
+  }
+
+  mrb_gc_arena_restore(mrb, ai);
+
+  return DBGST_PROMPT;
 }

--- a/mrbgems/mruby-bin-debugger/tools/mrdb/mrdb.c
+++ b/mrbgems/mruby-bin-debugger/tools/mrdb/mrdb.c
@@ -52,6 +52,7 @@ static const debug_command debug_command_list[] = {
   {"eval",      NULL,           2, 0, 0, DBGCMD_EVAL,           dbgcmd_eval},            /* ev[al] */
   {"help",      NULL,           1, 0, 1, DBGCMD_HELP,           dbgcmd_help},            /* h[elp] */
   {"info",      "breakpoints",  1, 1, 1, DBGCMD_INFO_BREAK,     dbgcmd_info_break},      /* i[nfo] b[reakpoints] */
+  {"info",      "locals",       1, 1, 0, DBGCMD_INFO_LOCAL,     dbgcmd_info_local},      /* i[nfo] l[ocals] */
   {"list",      NULL,           1, 0, 1, DBGCMD_LIST,           dbgcmd_list},            /* l[ist] */
   {"print",     NULL,           1, 0, 0, DBGCMD_PRINT,          dbgcmd_print},           /* p[rint] */
   {"quit",      NULL,           1, 0, 0, DBGCMD_QUIT,           dbgcmd_quit},            /* q[uit] */

--- a/mrbgems/mruby-bin-debugger/tools/mrdb/mrdb.h
+++ b/mrbgems/mruby-bin-debugger/tools/mrdb/mrdb.h
@@ -23,6 +23,7 @@ typedef enum debug_command_id {
   DBGCMD_STEP,
   DBGCMD_BREAK,
   DBGCMD_INFO_BREAK,
+  DBGCMD_INFO_LOCAL,
   DBGCMD_WATCH,
   DBGCMD_INFO_WATCH,
   DBGCMD_ENABLE,
@@ -151,6 +152,7 @@ dbgcmd_state dbgcmd_next(mrb_state*, mrdb_state*);
 /* cmdbreak.c */
 dbgcmd_state dbgcmd_break(mrb_state*, mrdb_state*);
 dbgcmd_state dbgcmd_info_break(mrb_state*, mrdb_state*);
+dbgcmd_state dbgcmd_info_local(mrb_state*, mrdb_state*);
 dbgcmd_state dbgcmd_delete(mrb_state*, mrdb_state*);
 dbgcmd_state dbgcmd_enable(mrb_state*, mrdb_state*);
 dbgcmd_state dbgcmd_disable(mrb_state*, mrdb_state*);


### PR DESCRIPTION
Currently, we cannot get a list of local variables in mrdb because mrdb's `eval` command uses `instance_eval` to evaluate expressions.

To be more precise, `eval local_variables` always prints `[:e]` because evaluation is implemented as `instance_eval("begin\n#{expr}\nrescue => e\ne\nend")` in `mrb_debug_eval()` 

```
$ cat test.rb
foo = :bar
$ ./bin/mrdb test.rb
(test.rb:1) eval local_variables
$1 = [:e]   #### This is NOT what we want...
(test.rb:1)
```

This PR adds `info locals` command, which can print expected names of local variables by evaluating `local_variables` directly.
```
$ cat test.rb
foo = :bar
$ ./bin/mrdb test.rb
(test.rb:1) info locals
$1 = [:foo]
(test.rb:1)
```