### PR TITLE
`assert_true`/`assert_false` should pass when actual is only `true`/`false`

### DIFF
--- a/test/assert.rb
+++ b/test/assert.rb
@@ -78,7 +78,7 @@ end
 def assert_true(ret, msg = nil, diff = nil)
   if $mrbtest_assert
     $mrbtest_assert_idx += 1
-    unless ret
+    unless ret == true
       msg ||= "Expected #{ret.inspect} to be true"
       diff ||= assertion_diff(true, ret)
       $mrbtest_assert.push([$mrbtest_assert_idx, msg, diff])
@@ -88,7 +88,7 @@ def assert_true(ret, msg = nil, diff = nil)
 end
 
 def assert_false(ret, msg = nil, diff = nil)
-  if ret
+  unless ret == false
     msg ||= "Expected #{ret.inspect} to be false"
     diff ||= assertion_diff(false, ret)
   end


### PR DESCRIPTION
For the following reasons:

- Previous behavior is confusable because it's different from test/unit rubygem's `assert_true`
- Tests may pass unintentionally in an inappropriate way; ref #4285 #4287