### PR TITLE
Move `Object#dig` to `Struct#dig`

### DIFF
--- a/mrbgems/mruby-struct/mrblib/struct.rb
+++ b/mrbgems/mruby-struct/mrblib/struct.rb
@@ -81,23 +81,22 @@ if Object.const_defined?(:Struct)
     # 15.2.18.4.11(x)
     #
     alias to_s inspect
-  end
 
-  ##
-  # call-seq:
-  #   hsh.dig(key,...)                 -> object
-  #
-  # Extracts the nested value specified by the sequence of <i>key</i>
-  # objects by calling +dig+ at each step, returning +nil+ if any
-  # intermediate step is +nil+.
-  #
-  def dig(idx,*args)
-    n = self[idx]
-    if args.size > 0
-      n&.dig(*args)
-    else
-      n
+    ##
+    # call-seq:
+    #   hsh.dig(key,...)                 -> object
+    #
+    # Extracts the nested value specified by the sequence of <i>key</i>
+    # objects by calling +dig+ at each step, returning +nil+ if any
+    # intermediate step is +nil+.
+    #
+    def dig(idx,*args)
+      n = self[idx]
+      if args.size > 0
+        n&.dig(*args)
+      else
+        n
+      end
     end
   end
 end
-


### PR DESCRIPTION
This method seems to be mistakenly put into `Object` instead of `Struct`
since it's in `struct.rb` and daf83946b says:

> add #dig to Array,Hash and Struct
