### PR TITLE
String literal concatenation

### DIFF
--- a/mrbgems/mruby-compiler/core/parse.y
+++ b/mrbgems/mruby-compiler/core/parse.y
@@ -852,11 +852,17 @@ new_dstr(parser_state *p, node *a)
   return cons((node*)NODE_DSTR, a);
 }
 
+static int
+string_node_p(node *n)
+{
+  return (int)((enum node_type)(intptr_t)n->car == NODE_STR);
+}
+
 static node*
 concat_string(parser_state *p, node *a, node *b)
 {
-  if ((enum node_type)(intptr_t)a->car == NODE_STR) {
-    if ((enum node_type)(intptr_t)b->car == NODE_STR) {
+  if (string_node_p(a)) {
+    if (string_node_p(b)) {
       /* a == NODE_STR && b == NODE_STR */
       size_t newlen = (size_t)a->cdr->cdr + (size_t)b->cdr->cdr;
       char *str = (char*)mrb_pool_realloc(p->pool, a->cdr->car, (size_t)a->cdr->cdr + 1, newlen + 1);

--- a/mrbgems/mruby-compiler/core/parse.y
+++ b/mrbgems/mruby-compiler/core/parse.y
@@ -893,6 +893,21 @@ concat_string(parser_state *p, node *a, node *b)
       }
     }
   }
+  else if (string_node_p(b)) {
+    /* a == NODE_DSTR && b == NODE_STR */
+
+    node *c;
+    for (c = a; c->cdr != NULL; c = c->cdr) ;
+    if (string_node_p(c->car)) {
+      /* a->[..., NODE_STR] && b == NODE_STR */
+      composite_string_node(p, c->car->cdr, b->cdr);
+      cons_free(b);
+      return a;
+    }
+
+    push(a, b);
+    return a;
+  }
 
   return new_dstr(p, list2(a, b));
 }

--- a/mrbgems/mruby-compiler/core/parse.y
+++ b/mrbgems/mruby-compiler/core/parse.y
@@ -855,6 +855,21 @@ new_dstr(parser_state *p, node *a)
 static node*
 concat_string(parser_state *p, node *a, node *b)
 {
+  if ((enum node_type)(intptr_t)a->car == NODE_STR) {
+    if ((enum node_type)(intptr_t)b->car == NODE_STR) {
+      /* a == NODE_STR && b == NODE_STR */
+      size_t newlen = (size_t)a->cdr->cdr + (size_t)b->cdr->cdr;
+      char *str = (char*)mrb_pool_realloc(p->pool, a->cdr->car, (size_t)a->cdr->cdr + 1, newlen + 1);
+      memcpy(str + (size_t)a->cdr->cdr, b->cdr->car, (size_t)b->cdr->cdr);
+      str[newlen] = '\0';
+      a->cdr->car = (node*)str;
+      a->cdr->cdr = (node*)newlen;
+      cons_free(b->cdr);
+      cons_free(b);
+      return a;
+    }
+  }
+
   return new_dstr(p, list2(a, b));
 }
 

--- a/mrbgems/mruby-compiler/core/parse.y
+++ b/mrbgems/mruby-compiler/core/parse.y
@@ -881,6 +881,17 @@ concat_string(parser_state *p, node *a, node *b)
       cons_free(b);
       return a;
     }
+    else {
+      /* a == NODE_STR && b == NODE_DSTR */
+
+      if (string_node_p(b->cdr->car)) {
+        /* a == NODE_STR && b->[NODE_STR, ...] */
+        composite_string_node(p, a->cdr, b->cdr->car->cdr);
+        cons_free(b->cdr->car);
+        b->cdr->car = a;
+        return b;
+      }
+    }
   }
 
   return new_dstr(p, list2(a, b));

--- a/mrbgems/mruby-compiler/core/parse.y
+++ b/mrbgems/mruby-compiler/core/parse.y
@@ -908,6 +908,27 @@ concat_string(parser_state *p, node *a, node *b)
     push(a, b);
     return a;
   }
+  else {
+    /* a == NODE_DSTR && b == NODE_DSTR */
+
+    node *c, *d;
+    for (c = a; c->cdr != NULL; c = c->cdr) ;
+    if (string_node_p(c->car) && string_node_p(b->cdr->car)) {
+      /* a->[..., NODE_STR] && b->[NODE_STR, ...] */
+      d = b->cdr;
+      cons_free(b);
+      composite_string_node(p, c->car->cdr, d->car->cdr);
+      cons_free(d->car);
+      c->cdr = d->cdr;
+      cons_free(d);
+      return a;
+    }
+    else {
+      c->cdr = b->cdr;
+      cons_free(b);
+      return a;
+    }
+  }
 
   return new_dstr(p, list2(a, b));
 }

--- a/test/t/string.rb
+++ b/test/t/string.rb
@@ -713,3 +713,10 @@ assert('String#freeze') do
 
   assert_raise(RuntimeError) { str.upcase! }
 end
+
+assert('String literal concatenation') do
+  assert_equal 2, ("A" "B").size
+  assert_equal 3, ('A' "B" 'C').size
+  assert_equal 3, (?A "#{?B}C").size
+  assert_equal 4, (%(A) "B#{?C}" "D").size
+end


### PR DESCRIPTION
This is a patch that concatenate consecutive string literals at the syntax parse stage.

When long strings are divided into multiple lines and described, it is possible to suppress the concatenation process at run time.  
Unlike CRuby, expressions with only strings included in expression expansion are not concatenated.

  - mruby HEAD:

    ```
    $ ./build/host/bin/mruby -v -e 'p "A" "B" "C#{?D}E" "F" "G#{1; ?H}I" "J"'
    mruby 2.0.0 (2018-12-11)
    -e:1:6: syntax error, unexpected tSTRING_BEG, expecting $end
    SyntaxError: syntax error
    ```

  - After patched:

    ```
    $ ./build/host/bin/mruby -v -e 'p "A" "B" "C#{?D}E" "F" "G#{1; ?H}I" "J"'
    mruby 2.0.0 (2018-12-11)
    00001 NODE_SCOPE:
    00001   NODE_BEGIN:
    00001     NODE_FCALL:
    00001       NODE_SELF
    00001       method='p' (71)
    00001       args:
    00001         NODE_DSTR
    00001           NODE_STR "ABC" len 3
    00001           NODE_BEGIN:
    00001             NODE_STR "D" len 1
    00001           NODE_STR "EFG" len 3
    00001           NODE_BEGIN:
    00001             NODE_INT 1 base 10
    00001             NODE_STR "H" len 1
    00001           NODE_STR "IJ" len 2
    irep 0x801904ff0 nregs=4 nlocals=1 pools=5 syms=1 reps=0
    file: -e
        1 000 OP_LOADSELF   R1
        1 002 OP_STRING     R2      L(0)    ; "ABC"
        1 005 OP_STRING     R3      L(1)    ; "D"
        1 008 OP_STRCAT     R2
        1 010 OP_STRING     R3      L(2)    ; "EFG"
        1 013 OP_STRCAT     R2
        1 015 OP_STRING     R3      L(3)    ; "H"
        1 018 OP_STRCAT     R2
        1 020 OP_STRING     R3      L(4)    ; "IJ"
        1 023 OP_STRCAT     R2
        1 025 OP_SEND       R1      :p      1
        1 029 OP_RETURN     R1
        1 031 OP_STOP

    "ABCDEFGHIJ"
    ```

  - ruby-2.6

    ```
    % ruby26 --dump insns -v -e 'p ?A "B" "C#{?D}E" "F" "G#{1; ?H}I" "J"'
    ruby 2.6.1p33 (2019-01-30 revision 66950) [amd64-freebsd12]
    -e:1: warning: unused literal ignored
    == disasm: #<ISeq:<main>@-e:1 (1,0)-(1,39)> (catch: FALSE)
    0000 putself                                                          (   1)[Li]
    0001 putstring                    "ABCDEFGHIJ"
    0003 opt_send_without_block       <callinfo!mid:p, argc:1, FCALL|ARGS_SIMPLE>, <callcache>
    0006 leave
    ```
