### PR TITLE
Warn if assertion is missing inside `assert` (like #4309 etc)

### DIFF
--- a/mrbgems/mruby-test/driver.c
+++ b/mrbgems/mruby-test/driver.c
@@ -131,6 +131,7 @@ mrb_t_pass_result(mrb_state *mrb_dst, mrb_state *mrb_src)
   TEST_COUNT_PASS(ok_test);
   TEST_COUNT_PASS(ko_test);
   TEST_COUNT_PASS(kill_test);
+  TEST_COUNT_PASS(warning_test);
   TEST_COUNT_PASS(skip_test);
 
 #undef TEST_COUNT_PASS

--- a/test/assert.rb
+++ b/test/assert.rb
@@ -1,6 +1,7 @@
 $ok_test = 0
 $ko_test = 0
 $kill_test = 0
+$warning_test = 0
 $skip_test = 0
 $asserts  = []
 $test_start = Time.now if Object.const_defined?(:Time)
@@ -46,10 +47,14 @@ def assert(str = 'Assertion failed', iso = '')
     $mrbtest_assert = []
     $mrbtest_assert_idx = 0
     yield
-    if($mrbtest_assert.size > 0)
+    if $mrbtest_assert.size > 0
       $asserts.push(assertion_string('Fail: ', str, iso))
       $ko_test += 1
       t_print('F')
+    elsif $mrbtest_assert_idx == 0
+      $asserts.push(assertion_string('Warn: ', str, iso, 'no assertion'))
+      $warning_test += 1
+      t_print('W')
     else
       $ok_test += 1
       t_print('.')
@@ -220,17 +225,18 @@ def report()
     t_print("#{msg}\n")
   end
 
-  $total_test = $ok_test + $ko_test + $kill_test + $skip_test
-  t_print("Total: #{$total_test}\n")
+  $total_test = $ok_test + $ko_test + $kill_test + $warning_test + $skip_test
+  t_print("  Total: #{$total_test}\n")
 
-  t_print("   OK: #{$ok_test}\n")
-  t_print("   KO: #{$ko_test}\n")
-  t_print("Crash: #{$kill_test}\n")
-  t_print(" Skip: #{$skip_test}\n")
+  t_print("     OK: #{$ok_test}\n")
+  t_print("     KO: #{$ko_test}\n")
+  t_print("  Crash: #{$kill_test}\n")
+  t_print("Warning: #{$warning_test}\n")
+  t_print("   Skip: #{$skip_test}\n")
 
   if Object.const_defined?(:Time)
     t_time = Time.now - $test_start
-    t_print(" Time: #{t_time.round(2)} seconds\n")
+    t_print("   Time: #{t_time.round(2)} seconds\n")
   end
 end
 


### PR DESCRIPTION
Currently many warnings appear (草生える in progress).

~~~
>>> Test host <<<
mrbtest - Embeddable Ruby Test

................W.............................................................
..............................................W...............................
.............................................WW.WWWWW..WWWWWWWWWWWWWWWWWWWWWWW
WWWWWW.W.W..............?....W..........W...................WW................
............WWWWWWWWWWWWWWWWWWWWWWWWWWW.......................................
...........................................WWWWWWWWWWWWWWW.....WWWWWWW........
.....................................WWWWWWW..................................
..........................?...................................................
..............................................................................
..............................................................................
..............................................................................
..............................................................................
........................................................WW....................
..............................................................................
.......W................................................................W.....
.........
Warn: Fiber with splat in the block argument list => no assertion (mrbgems: mruby-fiber)
Warn: Array#bsearch_index => no assertion (mrbgems: mruby-array-ext)
Warn: Time.new [15.2.3.3.3] => no assertion (mrbgems: mruby-time)
Warn: Time [15.2.19] => no assertion (mrbgems: mruby-time)
Warn: Time.gm [15.2.19.6.2] => no assertion (mrbgems: mruby-time)
Warn: Time.local [15.2.19.6.3] => no assertion (mrbgems: mruby-time)
Warn: Time.mktime [15.2.19.6.4] => no assertion (mrbgems: mruby-time)
Warn: Time.now [15.2.19.6.5] => no assertion (mrbgems: mruby-time)
Warn: Time.utc [15.2.19.6.6] => no assertion (mrbgems: mruby-time)
Warn: Time#<=> [15.2.19.7.3] => no assertion (mrbgems: mruby-time)
Warn: Time#asctime [15.2.19.7.4] => no assertion (mrbgems: mruby-time)
Warn: Time#ctime [15.2.19.7.5] => no assertion (mrbgems: mruby-time)
Warn: Time#day [15.2.19.7.6] => no assertion (mrbgems: mruby-time)
Warn: Time#dst? [15.2.19.7.7] => no assertion (mrbgems: mruby-time)
Warn: Time#getgm [15.2.19.7.8] => no assertion (mrbgems: mruby-time)
Warn: Time#getlocal [15.2.19.7.9] => no assertion (mrbgems: mruby-time)
Warn: Time#getutc [15.2.19.7.10] => no assertion (mrbgems: mruby-time)
Warn: Time#gmt? [15.2.19.7.11] => no assertion (mrbgems: mruby-time)
Warn: Time#gmtime [15.2.19.7.13] => no assertion (mrbgems: mruby-time)
Warn: Time#hour [15.2.19.7.15] => no assertion (mrbgems: mruby-time)
Warn: Time#initialize_copy [15.2.19.7.17] => no assertion (mrbgems: mruby-time)
Warn: Time#localtime [15.2.19.7.18] => no assertion (mrbgems: mruby-time)
Warn: Time#mday [15.2.19.7.19] => no assertion (mrbgems: mruby-time)
Warn: Time#min [15.2.19.7.20] => no assertion (mrbgems: mruby-time)
Warn: Time#mon [15.2.19.7.21] => no assertion (mrbgems: mruby-time)
Warn: Time#month [15.2.19.7.22] => no assertion (mrbgems: mruby-time)
Warn: Times#sec [15.2.19.7.23] => no assertion (mrbgems: mruby-time)
Warn: Time#to_f [15.2.19.7.24] => no assertion (mrbgems: mruby-time)
Warn: Time#to_i [15.2.19.7.25] => no assertion (mrbgems: mruby-time)
Warn: Time#usec [15.2.19.7.26] => no assertion (mrbgems: mruby-time)
Warn: Time#utc [15.2.19.7.27] => no assertion (mrbgems: mruby-time)
Warn: Time#utc? [15.2.19.7.28] => no assertion (mrbgems: mruby-time)
Warn: Time#wday [15.2.19.7.30] => no assertion (mrbgems: mruby-time)
Warn: Time#yday [15.2.19.7.31] => no assertion (mrbgems: mruby-time)
Warn: Time#year [15.2.19.7.32] => no assertion (mrbgems: mruby-time)
Warn: Time#zone [15.2.19.7.33] => no assertion (mrbgems: mruby-time)
Warn: Time#to_s => no assertion (mrbgems: mruby-time)
Warn: Time#inspect => no assertion (mrbgems: mruby-time)
Warn: 2000 times 500us make a second => no assertion (mrbgems: mruby-time)
Warn: File TEST SETUP => no assertion (mrbgems: mruby-io)
Skip: File.expand_path (with ENV) (mrbgems: mruby-io)
Warn: FileTest TEST SETUP => no assertion (mrbgems: mruby-io)
Warn: IO TEST SETUP => no assertion (mrbgems: mruby-io)
Warn: IO.new => no assertion (mrbgems: mruby-io)
Warn: IO gc check => no assertion (mrbgems: mruby-io)
Warn: Math.sin 0 => no assertion (mrbgems: mruby-math)
Warn: Math.sin PI/2 => no assertion (mrbgems: mruby-math)
Warn: Math.cos 0 => no assertion (mrbgems: mruby-math)
Warn: Math.cos PI/2 => no assertion (mrbgems: mruby-math)
Warn: Math.tan 0 => no assertion (mrbgems: mruby-math)
Warn: Math.tan PI/4 => no assertion (mrbgems: mruby-math)
Warn: Fundamental trig identities => no assertion (mrbgems: mruby-math)
Warn: Math.erf 0 => no assertion (mrbgems: mruby-math)
Warn: Math.exp 0 => no assertion (mrbgems: mruby-math)
Warn: Math.exp 1 => no assertion (mrbgems: mruby-math)
Warn: Math.exp 1.5 => no assertion (mrbgems: mruby-math)
Warn: Math.log 1 => no assertion (mrbgems: mruby-math)
Warn: Math.log E => no assertion (mrbgems: mruby-math)
Warn: Math.log E**3 => no assertion (mrbgems: mruby-math)
Warn: Math.log2 1 => no assertion (mrbgems: mruby-math)
Warn: Math.log2 2 => no assertion (mrbgems: mruby-math)
Warn: Math.log10 1 => no assertion (mrbgems: mruby-math)
Warn: Math.log10 10 => no assertion (mrbgems: mruby-math)
Warn: Math.log10 10**100 => no assertion (mrbgems: mruby-math)
Warn: Math.sqrt => no assertion (mrbgems: mruby-math)
Warn: Math.cbrt => no assertion (mrbgems: mruby-math)
Warn: Math.hypot => no assertion (mrbgems: mruby-math)
Warn: Math.frexp 1234 => no assertion (mrbgems: mruby-math)
Warn: Math.erf 1 => no assertion (mrbgems: mruby-math)
Warn: Math.erfc 1 => no assertion (mrbgems: mruby-math)
Warn: Math.erf -1 => no assertion (mrbgems: mruby-math)
Warn: Math.erfc -1 => no assertion (mrbgems: mruby-math)
Warn: Check class pointer of ObjectSpace.each_object. => no assertion (mrbgems: mruby-objectspace)
Warn: [""].pack("m") => no assertion (mrbgems: mruby-pack)
Warn: ["\0"].pack("m") => no assertion (mrbgems: mruby-pack)
Warn: ["\0\0"].pack("m") => no assertion (mrbgems: mruby-pack)
Warn: ["\0\0\0"].pack("m") => no assertion (mrbgems: mruby-pack)
Warn: ["abc..xyzABC..XYZ"].pack("m") => no assertion (mrbgems: mruby-pack)
Warn: "YWJ...".unpack("m") should "abc..xyzABC..XYZ" => no assertion (mrbgems: mruby-pack)
Warn: ["3031"].pack("H*") => no assertion (mrbgems: mruby-pack)
Warn: ["10"].pack("H*") => no assertion (mrbgems: mruby-pack)
Warn: [0,1,127,128,255].pack("C*") => no assertion (mrbgems: mruby-pack)
Warn: ["abc"].pack("a") => no assertion (mrbgems: mruby-pack)
Warn: ["abc"].pack("a") => no assertion (mrbgems: mruby-pack)
Warn: ["abc"].pack("A") => no assertion (mrbgems: mruby-pack)
Warn: ["abc"].pack("A") => no assertion (mrbgems: mruby-pack)
Warn: issue #1 => no assertion (mrbgems: mruby-pack)
Warn: Random#srand => no assertion (mrbgems: mruby-random)
Warn: Kernel::srand => no assertion (mrbgems: mruby-random)
Warn: Random::srand => no assertion (mrbgems: mruby-random)
Warn: fixnum => no assertion (mrbgems: mruby-random)
Warn: float => no assertion (mrbgems: mruby-random)
Warn: Array#shuffle => no assertion (mrbgems: mruby-random)
Warn: Array#shuffle! => no assertion (mrbgems: mruby-random)
Warn: String#dump => no assertion (mrbgems: mruby-string-ext)
Warn: String#strip => no assertion (mrbgems: mruby-string-ext)
Warn: String#lstrip => no assertion (mrbgems: mruby-string-ext)
Warn: String#rstrip => no assertion (mrbgems: mruby-string-ext)
Warn: String#strip! => no assertion (mrbgems: mruby-string-ext)
Warn: String#lstrip! => no assertion (mrbgems: mruby-string-ext)
Warn: String#rstrip! => no assertion (mrbgems: mruby-string-ext)
Skip: Struct.new removes existing constant => redefining Struct with same name cause warnings (mrbgems: mruby-struct)
Warn: Issue 1467 => no assertion (core)
Warn: clone Module => no assertion (core)
Warn: Check the usage of a NUL character => no assertion (core)
Warn: method definition in cmdarg => no assertion (core)
  Total: 1179
     OK: 1073
     KO: 0
  Crash: 0
Warning: 104
   Skip: 2
   Time: 1.68 seconds
~~~