### PR TITLE
Do not raise an exception when bintest fail

### DIFF
--- a/mrbgems/mruby-test/driver.c
+++ b/mrbgems/mruby-test/driver.c
@@ -30,31 +30,19 @@ print_hint(void)
 }
 
 static int
-check_error(mrb_state *mrb)
-{
-  /* Error check */
-  /* $ko_test and $kill_test should be 0 */
-  mrb_value ko_test = mrb_gv_get(mrb, mrb_intern_lit(mrb, "$ko_test"));
-  mrb_value kill_test = mrb_gv_get(mrb, mrb_intern_lit(mrb, "$kill_test"));
-
-  return mrb_fixnum_p(ko_test) && mrb_fixnum(ko_test) == 0 && mrb_fixnum_p(kill_test) && mrb_fixnum(kill_test) == 0;
-}
-
-static int
 eval_test(mrb_state *mrb)
 {
   /* evaluate the test */
-  mrb_funcall(mrb, mrb_top_self(mrb), "report", 0);
+  mrb_value result = mrb_funcall(mrb, mrb_top_self(mrb), "report", 0);
   /* did an exception occur? */
   if (mrb->exc) {
     mrb_print_error(mrb);
     mrb->exc = 0;
     return EXIT_FAILURE;
   }
-  else if (!check_error(mrb)) {
-    return EXIT_FAILURE;
+  else {
+    return mrb_bool(result) ? EXIT_SUCCESS : EXIT_FAILURE;
   }
-  return EXIT_SUCCESS;
 }
 
 static void

--- a/test/assert.rb
+++ b/test/assert.rb
@@ -213,7 +213,7 @@ end
 ##
 # Report the test result and print all assertions
 # which were reported broken.
-def report()
+def report
   t_print("\n")
 
   $asserts.each do |msg|
@@ -232,6 +232,8 @@ def report()
     t_time = Time.now - $test_start
     t_print(" Time: #{t_time.round(2)} seconds\n")
   end
+
+  $ko_test == 0 && $kill_test == 0
 end
 
 ##

--- a/test/bintest.rb
+++ b/test/bintest.rb
@@ -39,4 +39,4 @@ ARGV.each do |gem|
   end
 end
 
-load 'test/report.rb'
+exit report

--- a/test/report.rb
+++ b/test/report.rb
@@ -1,4 +1,0 @@
-report
-if $ko_test > 0 or $kill_test > 0
-  raise "mrbtest failed (KO:#{$ko_test}, Crash:#{$kill_test})"
-end


### PR DESCRIPTION
- An exception do not raise when mrbtest fail.
- There are no useful informations in exception message and backtrace.