### PR TITLE
Use Rake instead of MiniRake on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,4 +39,4 @@ install:
 build_script:
   - set YACC=.\win_flex_bison\win_bison.exe
   - set MRUBY_CONFIG=appveyor_config.rb
-  - ruby .\minirake test
+  - rake -E $stdout.sync=true test


### PR DESCRIPTION
### 1. Parallel build

Build time becomes less than half. FYI, `minirake -j4` is the following failure:

    C:\projects\mruby\mrbgems\mruby-inline-struct\test\inline.c: fatal error C1041: cannot open program database 'C:\projects\mruby\vc140.pdb'; if multiple CL.EXE write to the same .PDB file, please use /FS

### 2. Synchronize standard output

#### No synchronized:

    mrbtest - Embeddable Ruby Test
    ...........................
    Total: 1165
    (snip)
     Time: 1.19 seconds
    bintest - Command Binary Test

    .....................
    Total: 21
    (snip)
     Time: 0.39 seconds
    mrbtest - Embeddable Ruby Test

    ...........................
    Total: 1165
    (snip)
     Skip: 23
     Time: 1.15 seconds
    (snip)

    >>> Test cxx_abi <<<

    >>> Bintest host <<<
    >>> Test host <<<

    >>> Test full-debug <<<

    >>> Bintest cxx_abi <<<

#### Synchronized:

    >>> Test full-debug <<<
    mrbtest - Embeddable Ruby Test
    ...........................
    Total: 1165
    (snip)
     Time: 1.25 seconds

    >>> Test host <<<
    mrbtest - Embeddable Ruby Test
    ...........................
    Total: 1165
    (snip)
     Time: 1.16 seconds

    >>> Bintest host <<<
    bintest - Command Binary Test
    .....................
    Total: 21
    (snip)
     Time: 0.41 seconds

    >>> Test cxx_abi <<<
    mrbtest - Embeddable Ruby Test
    (snip)