### PR TITLE
ctype function can not take `signed char`

### DIFF
--- a/mrbgems/mruby-compiler/core/parse.y
+++ b/mrbgems/mruby-compiler/core/parse.y
@@ -5802,7 +5802,7 @@ parser_yylex(parser_state *p)
       mrb_sym ident = intern_cstr(tok(p));
 
       pylval.id = ident;
-      if (last_state != EXPR_DOT && islower(tok(p)[0]) && local_var_p(p, ident)) {
+      if (last_state != EXPR_DOT && islower((unsigned char)tok(p)[0]) && local_var_p(p, ident)) {
         p->lstate = EXPR_END;
       }
     }

--- a/mrbgems/mruby-pack/src/pack.c
+++ b/mrbgems/mruby-pack/src/pack.c
@@ -627,7 +627,7 @@ unpack_a(mrb_state *mrb, const void *src, int slen, mrb_value ary, long count, u
     }
   }
   else if (!(flags & PACK_FLAG_a)) {  /* "A" */
-    while (copylen > 0 && (sptr[copylen - 1] == '\0' || isspace(sptr[copylen - 1]))) {
+    while (copylen > 0 && (sptr[copylen - 1] == '\0' || isspace((unsigned char)sptr[copylen - 1]))) {
       copylen--;
     }
   }
@@ -895,9 +895,9 @@ read_tmpl(mrb_state *mrb, struct tmpl *tmpl, int *dirp, int *typep, int *sizep, 
   int ch, dir, type, size = 0;
   int count = 1;
   unsigned int flags = 0;
-  const char *tptr;
+  const unsigned char *tptr;
 
-  tptr = RSTRING_PTR(tmpl->str);
+  tptr = (const unsigned char *)RSTRING_PTR(tmpl->str);
   tlen = RSTRING_LEN(tmpl->str);
 
   t = tptr[tmpl->idx++];

--- a/src/string.c
+++ b/src/string.c
@@ -2821,7 +2821,7 @@ mrb_float_read(const char *string, char **endPtr)
     int sign, expSign = FALSE;
     double fraction, dblExp;
     const double *d;
-    const char *p;
+    const unsigned char *p;
     int c;
     int exp = 0;                /* Exponent read from "EX" field. */
     int fracExp = 0;            /* Exponent that derives from the fractional
@@ -2836,14 +2836,14 @@ mrb_float_read(const char *string, char **endPtr)
     int mantSize;               /* Number of digits in mantissa. */
     int decPt;                  /* Number of mantissa digits BEFORE decimal
                                  * point. */
-    const char *pExp;           /* Temporarily holds location of exponent
+    const unsigned char *pExp;  /* Temporarily holds location of exponent
                                  * in string. */
 
     /*
      * Strip off leading blanks and check for a sign.
      */
 
-    p = string;
+    p = (const unsigned char *)string;
     while (isspace(*p)) {
       p += 1;
     }
@@ -2905,7 +2905,7 @@ mrb_float_read(const char *string, char **endPtr)
     }
     if (mantSize == 0) {
       fraction = 0.0;
-      p = string;
+      p = (const unsigned char *)string;
       goto done;
     }
     else {


### PR DESCRIPTION
The ctype function takes a value of `unsigned char` and `EOF` (probably `-1`).

This patch is solved for problems a compile error on ESP32 with ESP-IDF.
