### PR TITLE
Fix modifiable class name

### DIFF
--- a/src/variable.c
+++ b/src/variable.c
@@ -1106,6 +1106,7 @@ mrb_class_find_path(mrb_state *mrb, struct RClass *c)
     iv_del(mrb, c->iv, mrb_intern_lit(mrb, "__outer__"), NULL);
     iv_put(mrb, c->iv, mrb_intern_lit(mrb, "__classname__"), path);
     mrb_field_write_barrier_value(mrb, (struct RBasic*)c, path);
+    path = mrb_str_dup(mrb, path);
   }
   return path;
 }


### PR DESCRIPTION
#### Fix the following example:

    ```ruby 
    Object.const_set :A, Module.new{const_set :B, Class.new}
    ab = A::B.to_s
    p ab         #=> "A::B" # Good
    ab[0] = "x"
    p A::B.to_s  #=> "x::B" # Bad
    ```