### PR TITLE
Fix leaked function symbols

### DIFF
--- a/mrbgems/mruby-compiler/core/codegen.c
+++ b/mrbgems/mruby-compiler/core/codegen.c
@@ -273,8 +273,7 @@ genop_W(codegen_scope *s, mrb_code i, uint32_t a)
 #define NOVAL  0
 #define VAL    1
 
-//static
-mrb_bool
+static mrb_bool
 no_optimize(codegen_scope *s)
 {
   if (s && s->parser && s->parser->no_optimize)

--- a/src/gc.c
+++ b/src/gc.c
@@ -396,7 +396,7 @@ mrb_gc_init(mrb_state *mrb, mrb_gc *gc)
 
 static void obj_free(mrb_state *mrb, struct RBasic *obj, int end);
 
-void
+static void
 free_heap(mrb_state *mrb, mrb_gc *gc)
 {
   mrb_heap_page *page = gc->heaps;

--- a/src/symbol.c
+++ b/src/symbol.c
@@ -91,7 +91,7 @@ sym_inline_unpack(mrb_sym sym, char *buf, mrb_int *lenp)
 }
 #endif
 
-uint8_t
+static uint8_t
 symhash(const char *key, size_t len)
 {
     uint32_t hash, i;


### PR DESCRIPTION
- `free_heap()` in src/gc.c
- `symhash()` in src/symbol.c
- `no_optimize()` in mrbgems/mruby-compiler/core/codegen.c

```
% nm --defined-only --extern-only build/host/lib/libmruby_core.a | egrep -v ' mrbc?_| kh_|^[a-z_\.]+:' | uniq
                                                                                                              
0000000000000dd0 T symhash
                                                                                                              
0000000000001760 T free_heap
                                                                                                              
0000000000000000 T calc_crc_16_ccitt
                                                                                                              
0000000000002070 T no_optimize
```
