### PR TITLE
Fix compilation on gcc 4.9.x

### DIFF
--- a/mrbgems/mruby-test/driver.c
+++ b/mrbgems/mruby-test/driver.c
@@ -50,10 +50,10 @@ static mrb_value
 t_print(mrb_state *mrb, mrb_value self)
 {
   mrb_value *argv;
-  mrb_int argc;
+  mrb_int argc, i;
 
   mrb_get_args(mrb, "*!", &argv, &argc);
-  for (mrb_int i = 0; i < argc; ++i) {
+  for (i = 0; i < argc; ++i) {
     mrb_value s = mrb_obj_as_string(mrb, argv[i]);
     fwrite(RSTRING_PTR(s), RSTRING_LEN(s), 1, stdout);
   }

--- a/src/numeric.c
+++ b/src/numeric.c
@@ -212,7 +212,8 @@ flo_to_s(mrb_state *mrb, mrb_value flt)
     insert_dot_zero:
     begp = RSTRING_PTR(str);
     len = RSTRING_LEN(str);
-    for (char *p = begp, *endp = p + len; p < endp; ++p) {
+    char *p, *endp;
+    for (p = begp, endp = p + len; p < endp; ++p) {
       if (*p == '.') {
         return str;
       }

--- a/src/numeric.c
+++ b/src/numeric.c
@@ -207,12 +207,13 @@ flo_to_s(mrb_state *mrb, mrb_value flt)
     char fmt[] = "%." MRB_STRINGIZE(FLO_TO_STR_PREC) "g";
     mrb_value str = mrb_float_to_str(mrb, flt, fmt);
     mrb_int len;
+    char *p;
     char *begp;
+    char *endp;
 
     insert_dot_zero:
     begp = RSTRING_PTR(str);
     len = RSTRING_LEN(str);
-    char *p, *endp;
     for (p = begp, endp = p + len; p < endp; ++p) {
       if (*p == '.') {
         return str;

--- a/src/variable.c
+++ b/src/variable.c
@@ -1115,7 +1115,8 @@ mrb_class_find_path(mrb_state *mrb, struct RClass *c)
 mrb_bool
 mrb_ident_p(const char *s, mrb_int len)
 {
-  for (mrb_int i = 0; i < len; i++) {
+  mrb_int i;
+  for (i = 0; i < len; i++) {
     if (!identchar(s[i])) return FALSE;
   }
   return TRUE;


### PR DESCRIPTION
Older gcc's don't permit these variables to be declared within `for` loops.