### PR TITLE
Add type check (conversion) in `String#[]=`

### DIFF
--- a/mrblib/string.rb
+++ b/mrblib/string.rb
@@ -197,12 +197,12 @@ class String
   def []=(*args)
     anum = args.size
     if anum == 2
-      pos, value = args
+      pos, value = args[0], args[1].__to_str
       case pos
       when String
         posnum = self.index(pos)
         if posnum
-          b = self[0, posnum.to_i]
+          b = self[0, posnum]
           a = self[(posnum + pos.length)..-1]
           self.replace([b, value, a].join(''))
         else
@@ -217,17 +217,18 @@ class String
         end
         return self[head, tail-head]=value
       else
+        pos = pos.__to_int
         pos += self.length if pos < 0
         if pos < 0 || pos > self.length
           raise IndexError, "index #{args[0]} out of string"
         end
-        b = self[0, pos.to_i]
+        b = self[0, pos]
         a = self[pos + 1..-1]
         self.replace([b, value, a].join(''))
       end
       return value
     elsif anum == 3
-      pos, len, value = args
+      pos, len, value = args[0].__to_int, args[1].__to_int, args[2].__to_str
       pos += self.length if pos < 0
       if pos < 0 || pos > self.length
         raise IndexError, "index #{args[0]} out of string"
@@ -235,7 +236,7 @@ class String
       if len < 0
         raise IndexError, "negative length #{len}"
       end
-      b = self[0, pos.to_i]
+      b = self[0, pos]
       a = self[pos + len..-1]
       self.replace([b, value, a].join(''))
       return value

--- a/test/t/string.rb
+++ b/test/t/string.rb
@@ -161,6 +161,9 @@ assert('String#[]=') do
    assert_equal 'aXc', e
   end
 
+  assert_raise(TypeError) { 'a'[0] = 1 }
+  assert_raise(TypeError) { 'a'[:a] = '1' }
+
   # length of args is 2
   a1 = 'abc'
   assert_raise(IndexError) do
@@ -197,6 +200,10 @@ assert('String#[]=') do
   assert_raise(IndexError) do
     b3['XX'] = 'Y'
   end
+
+  assert_raise(TypeError) { 'a'[:a, 0] = '1' }
+  assert_raise(TypeError) { 'a'[0, :a] = '1' }
+  assert_raise(TypeError) { 'a'[0, 1] = 1 }
 end
 
 assert('String#capitalize', '15.2.10.5.7') do


### PR DESCRIPTION
#### Before this patch:

```ruby
'a'[0] = 1        #=> 1
'a'[:a] = '1'     #=> ArgumentError
'a'[:a, 0] = '1'  #=> ArgumentError
'a'[0, :a] = '1'  #=> ArgumentError
'a'[0, 1] = 1     #=> 1
```

#### After this patch / Ruby:

```ruby
'a'[0] = 1        #=> TypeError
'a'[:a] = '1'     #=> TypeError
'a'[:a, 0] = '1'  #=> TypeError
'a'[0, :a] = '1'  #=> TypeError
'a'[0, 1] = 1     #=> TypeError
```