### PR TITLE
Change modifier to `MRB_INLINE` from `static inline`

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -868,7 +868,7 @@ typedef const char *mrb_args_format;
  */
 MRB_API mrb_int mrb_get_args(mrb_state *mrb, mrb_args_format format, ...);
 
-static inline mrb_sym
+MRB_INLINE mrb_sym
 mrb_get_mid(mrb_state *mrb) /* get method symbol */
 {
   return mrb->c->ci->mid;
@@ -1081,13 +1081,13 @@ MRB_API mrb_value mrb_Float(mrb_state *mrb, mrb_value val);
 MRB_API mrb_value mrb_inspect(mrb_state *mrb, mrb_value obj);
 MRB_API mrb_bool mrb_eql(mrb_state *mrb, mrb_value obj1, mrb_value obj2);
 
-static inline int
+MRB_INLINE int
 mrb_gc_arena_save(mrb_state *mrb)
 {
   return mrb->gc.arena_idx;
 }
 
-static inline void
+MRB_INLINE void
 mrb_gc_arena_restore(mrb_state *mrb, int idx)
 {
   mrb->gc.arena_idx = idx;
@@ -1192,7 +1192,7 @@ MRB_API mrb_value mrb_to_int(mrb_state *mrb, mrb_value val);
 MRB_API mrb_value mrb_to_str(mrb_state *mrb, mrb_value val);
 MRB_API void mrb_check_type(mrb_state *mrb, mrb_value x, enum mrb_vtype t);
 
-static inline void mrb_check_frozen(mrb_state *mrb, void *o)
+MRB_INLINE void mrb_check_frozen(mrb_state *mrb, void *o)
 {
   if (MRB_FROZEN_P((struct RBasic*)o)) mrb_frozen_error(mrb, o);
 }

--- a/include/mruby/boxing_word.h
+++ b/include/mruby/boxing_word.h
@@ -91,7 +91,7 @@ MRB_API mrb_value mrb_word_boxing_float_pool(struct mrb_state*, mrb_float);
 #define mrb_fixnum(o)  ((mrb_int)(o).value.i)
 #define mrb_symbol(o)  (o).value.sym
 
-static inline enum mrb_vtype
+MRB_INLINE enum mrb_vtype
 mrb_type(mrb_value o)
 {
   switch (o.w) {

--- a/include/mruby/class.h
+++ b/include/mruby/class.h
@@ -23,7 +23,7 @@ struct RClass {
 
 #define mrb_class_ptr(v)    ((struct RClass*)(mrb_ptr(v)))
 
-static inline struct RClass*
+MRB_INLINE struct RClass*
 mrb_class(mrb_state *mrb, mrb_value v)
 {
   switch (mrb_type(v)) {

--- a/include/mruby/data.h
+++ b/include/mruby/data.h
@@ -63,7 +63,7 @@ MRB_API void *mrb_data_check_get_ptr(mrb_state *mrb, mrb_value, const mrb_data_t
   *(void**)&sval = mrb_data_get_ptr(mrb, obj, type); \
 } while (0)
 
-static inline void
+MRB_INLINE void
 mrb_data_init(mrb_value v, void *ptr, const mrb_data_type *type)
 {
   mrb_assert(mrb_type(v) == MRB_TT_DATA);

--- a/include/mruby/value.h
+++ b/include/mruby/value.h
@@ -189,7 +189,7 @@ MRB_INLINE mrb_value mrb_float_value(struct mrb_state *mrb, mrb_float f)
 }
 #endif
 
-static inline mrb_value
+MRB_INLINE mrb_value
 mrb_cptr_value(struct mrb_state *mrb, void *p)
 {
   mrb_value v;
@@ -208,7 +208,7 @@ MRB_INLINE mrb_value mrb_fixnum_value(mrb_int i)
   return v;
 }
 
-static inline mrb_value
+MRB_INLINE mrb_value
 mrb_symbol_value(mrb_sym i)
 {
   mrb_value v;
@@ -216,7 +216,7 @@ mrb_symbol_value(mrb_sym i)
   return v;
 }
 
-static inline mrb_value
+MRB_INLINE mrb_value
 mrb_obj_value(void *p)
 {
   mrb_value v;
@@ -260,7 +260,7 @@ MRB_INLINE mrb_value mrb_true_value(void)
   return v;
 }
 
-static inline mrb_value
+MRB_INLINE mrb_value
 mrb_bool_value(mrb_bool boolean)
 {
   mrb_value v;
@@ -268,7 +268,7 @@ mrb_bool_value(mrb_bool boolean)
   return v;
 }
 
-static inline mrb_value
+MRB_INLINE mrb_value
 mrb_undef_value(void)
 {
   mrb_value v;


### PR DESCRIPTION
Changed some functions defined under the `include/` directory from `static inline` to `MRB_INLINE`.
The purpose is to make it easy to understand as part of the exposed C API.

However, I may have changed the extra functions to `MRB_INLINE`.
