### PR TITLE
Add `mrb_true_p()` and `mrb_false_p()` macro functions

### DIFF
--- a/include/mruby/boxing_word.h
+++ b/include/mruby/boxing_word.h
@@ -116,6 +116,8 @@ mrb_type(mrb_value o)
 #define mrb_fixnum_p(o) ((o).value.i_flag == MRB_FIXNUM_FLAG)
 #define mrb_undef_p(o) ((o).w == MRB_Qundef)
 #define mrb_nil_p(o)  ((o).w == MRB_Qnil)
+#define mrb_false_p(o) ((o).w == MRB_Qfalse)
+#define mrb_true_p(o)  ((o).w == MRB_Qtrue)
 
 #define BOXWORD_SET_VALUE(o, ttt, attr, v) do { \
   switch (ttt) {\

--- a/include/mruby/value.h
+++ b/include/mruby/value.h
@@ -157,6 +157,12 @@ typedef void mrb_value;
 #ifndef mrb_nil_p
 #define mrb_nil_p(o)  (mrb_type(o) == MRB_TT_FALSE && !mrb_fixnum(o))
 #endif
+#ifndef mrb_false_p
+#define mrb_false_p(o) (mrb_type(o) == MRB_TT_FALSE && !!mrb_fixnum(o))
+#endif
+#ifndef mrb_true_p
+#define mrb_true_p(o)  (mrb_type(o) == MRB_TT_TRUE)
+#endif
 #ifndef mrb_bool
 #define mrb_bool(o)   (mrb_type(o) != MRB_TT_FALSE)
 #endif


### PR DESCRIPTION
CRuby can use `obj == Qtrue` and `obj == Qfalse` if a strict comparison is required.
But mruby has no alternate it.
