### PR TITLE
Fix name assignment to frozen anonymous class/module

### DIFF
--- a/include/mruby/variable.h
+++ b/include/mruby/variable.h
@@ -117,6 +117,7 @@ MRB_API void mrb_mod_cv_set(mrb_state *mrb, struct RClass * c, mrb_sym sym, mrb_
 MRB_API void mrb_cv_set(mrb_state *mrb, mrb_value mod, mrb_sym sym, mrb_value v);
 MRB_API mrb_bool mrb_cv_defined(mrb_state *mrb, mrb_value mod, mrb_sym sym);
 mrb_value mrb_obj_iv_inspect(mrb_state*, struct RObject*);
+void mrb_obj_iv_set_force(mrb_state *mrb, struct RObject *obj, mrb_sym sym, mrb_value v);
 mrb_value mrb_mod_constants(mrb_state *mrb, mrb_value mod);
 mrb_value mrb_f_global_variables(mrb_state *mrb, mrb_value self);
 mrb_value mrb_obj_instance_variables(mrb_state*, mrb_value);

--- a/src/class.c
+++ b/src/class.c
@@ -66,15 +66,15 @@ mrb_class_name_class(mrb_state *mrb, struct RClass *outer, struct RClass *c, mrb
     name = mrb_class_path(mrb, outer);
     if (mrb_nil_p(name)) {      /* unnamed outer class */
       if (outer != mrb->object_class && outer != c) {
-        mrb_obj_iv_set(mrb, (struct RObject*)c, mrb_intern_lit(mrb, "__outer__"),
-                       mrb_obj_value(outer));
+        mrb_obj_iv_set_force(mrb, (struct RObject*)c, mrb_intern_lit(mrb, "__outer__"),
+                             mrb_obj_value(outer));
       }
       return;
     }
     mrb_str_cat_cstr(mrb, name, "::");
     mrb_str_cat_cstr(mrb, name, mrb_sym2name(mrb, id));
   }
-  mrb_obj_iv_set(mrb, (struct RObject*)c, nsym, name);
+  mrb_obj_iv_set_force(mrb, (struct RObject*)c, nsym, name);
 }
 
 static void

--- a/test/t/module.rb
+++ b/test/t/module.rb
@@ -653,6 +653,10 @@ assert('Module#to_s') do
 
   assert_match "#<Module:0x*>", Module.new.to_s
   assert_match "#<Class:0x*>", Class.new.to_s
+
+  assert_equal "FrozenClassToS", (FrozenClassToS = Class.new.freeze).to_s
+  assert_equal "Outer::A", (Outer::A = Module.new.freeze).to_s
+  assert_match "#<Module:0x*>::A", (Module.new::A = Class.new.freeze).to_s
 end
 
 assert('Module#inspect') do


### PR DESCRIPTION
Fix the following issues:

```ruby
A = Class.new.freeze              #=> FrozenError
Module.new::B = Class.new.freeze  #=> FrozenError
String::B = Module.new.freeze     #=> FrozenError
```