### PR TITLE
Read irep from buffers

### DIFF
--- a/include/mruby/dump.h
+++ b/include/mruby/dump.h
@@ -31,6 +31,7 @@ MRB_API mrb_value mrb_load_irep_file(mrb_state*,FILE*);
 MRB_API mrb_value mrb_load_irep_file_cxt(mrb_state*, FILE*, mrbc_context*);
 #endif
 MRB_API mrb_irep *mrb_read_irep(mrb_state*, const uint8_t*);
+MRB_API mrb_irep *mrb_read_irep_buf(mrb_state*, const void*, size_t);
 
 /* dump/load error code
  *

--- a/include/mruby/irep.h
+++ b/include/mruby/irep.h
@@ -52,8 +52,20 @@ MRB_API mrb_irep *mrb_add_irep(mrb_state *mrb);
 /* @param [const uint8_t*] irep code, expected as a literal */
 MRB_API mrb_value mrb_load_irep(mrb_state*, const uint8_t*);
 
+/*
+ * @param [const void*] irep code
+ * @param [size_t] size of irep buffer. If -1 is given, it is considered unrestricted.
+ */
+MRB_API mrb_value mrb_load_irep_buf(mrb_state*, const void*, size_t);
+
 /* @param [const uint8_t*] irep code, expected as a literal */
 MRB_API mrb_value mrb_load_irep_cxt(mrb_state*, const uint8_t*, mrbc_context*);
+
+/*
+ * @param [const void*] irep code
+ * @param [size_t] size of irep buffer. If -1 is given, it is considered unrestricted.
+ */
+MRB_API mrb_value mrb_load_irep_buf_cxt(mrb_state*, const void*, size_t, mrbc_context*);
 
 void mrb_irep_free(mrb_state*, struct mrb_irep*);
 void mrb_irep_incref(mrb_state*, struct mrb_irep*);

--- a/src/load.c
+++ b/src/load.c
@@ -539,6 +539,10 @@ read_binary_header(const uint8_t *bin, size_t *bin_size, uint16_t *crc, uint8_t 
     return MRB_DUMP_INVALID_FILE_HEADER;
   }
 
+  if (memcmp(header->binary_version, RITE_BINARY_FORMAT_VER, sizeof(header->binary_version)) != 0) {
+    return MRB_DUMP_INVALID_FILE_HEADER;
+  }
+
   if (crc) {
     *crc = bin_to_uint16(header->binary_crc);
   }

--- a/src/load.c
+++ b/src/load.c
@@ -629,6 +629,12 @@ mrb_read_irep(mrb_state *mrb, const uint8_t *bin)
   return read_irep(mrb, bin, (size_t)-1, flags);
 }
 
+MRB_API mrb_irep*
+mrb_read_irep_buf(mrb_state *mrb, const void *buf, size_t bufsize)
+{
+  return read_irep(mrb, (const uint8_t *)buf, bufsize, FLAG_SRC_MALLOC);
+}
+
 void mrb_exc_set(mrb_state *mrb, mrb_value exc);
 
 static void
@@ -663,9 +669,21 @@ mrb_load_irep_cxt(mrb_state *mrb, const uint8_t *bin, mrbc_context *c)
 }
 
 MRB_API mrb_value
+mrb_load_irep_buf_cxt(mrb_state *mrb, const void *buf, size_t bufsize, mrbc_context *c)
+{
+  return load_irep(mrb, mrb_read_irep_buf(mrb, buf, bufsize), c);
+}
+
+MRB_API mrb_value
 mrb_load_irep(mrb_state *mrb, const uint8_t *bin)
 {
   return mrb_load_irep_cxt(mrb, bin, NULL);
+}
+
+MRB_API mrb_value
+mrb_load_irep_buf(mrb_state *mrb, const void *buf, size_t bufsize)
+{
+  return mrb_load_irep_buf_cxt(mrb, buf, bufsize, NULL);
 }
 
 #ifndef MRB_DISABLE_STDIO


### PR DESCRIPTION

This patch appends `_buf` to some functions that read irep, and adds a function to check the buffer size as an argument.
Also, confirmation of the binary version is done by the internal `read_binary_header()` function which is called indirectly.

  - `MRB_API mrb_irep *mrb_read_irep_buf(mrb_state *mrb, const void *buf, size_t bufsize)`
  - `MRB_API mrb_value mrb_load_irep_buf(mrb_state *mrb, const void *buf, size_t bufsize)`
  - `MRB_API mrb_value mrb_load_irep_buf_cxt(mrb_state *mrb, const void *buf, size_t bufsize, mrbc_context *c)`

If you give `bufsize = -1`, the buffer size is virtually not checked.
The `read_binary_header ()` function has been changed to return `MRB_DUMP_READ_FAULT` if the size of irep itself is larger than the buffer size.

----

The `mrb_read_irep ()` function, etc. assumes that literal data is given.

For example, given irep data received by inter-process communication etc., it will occur problems if there is a conflict between the buffer size and `struct rite_binary_header.binary_size`.

So I need to check the size and version of the binary data before passing it to the `mrb_read_irep()` function.

I wanted a function to take care of this and made it a pull request.

----

This PR competes with #3977.
