### PR TITLE
Singleton class of frozen object should be frozen

### DIFF
--- a/mrbgems/mruby-metaprog/test/metaprog.rb
+++ b/mrbgems/mruby-metaprog/test/metaprog.rb
@@ -122,6 +122,22 @@ assert('Kernel#define_singleton_method') do
   assert_equal :singleton_method_ok, o.test_method
 end
 
+assert('Kernel#singleton_class') do
+  o1 = Object.new
+  assert_same(o1.singleton_class, class << o1; self end)
+
+  o2 = Object.new
+  sc2 = class << o2; self end
+  assert_same(o2.singleton_class, sc2)
+
+  o3 = Object.new
+  sc3 = o3.singleton_class
+  o3.freeze
+  assert_predicate(sc3, :frozen?)
+
+  assert_predicate(Object.new.freeze.singleton_class, :frozen?)
+end
+
 def labeled_module(name, &block)
   Module.new do
     (class <<self; self end).class_eval do

--- a/src/class.c
+++ b/src/class.c
@@ -120,6 +120,7 @@ prepare_singleton_class(mrb_state *mrb, struct RBasic *o)
   mrb_field_write_barrier(mrb, (struct RBasic*)o, (struct RBasic*)sc);
   mrb_field_write_barrier(mrb, (struct RBasic*)sc, (struct RBasic*)o);
   mrb_obj_iv_set(mrb, (struct RObject*)sc, mrb_intern_lit(mrb, "__attached__"), mrb_obj_value(o));
+  sc->flags |= o->flags & MRB_FL_OBJ_IS_FROZEN;
 }
 
 static mrb_value

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -438,6 +438,7 @@ mrb_obj_freeze(mrb_state *mrb, mrb_value self)
     struct RBasic *b = mrb_basic_ptr(self);
     if (!MRB_FROZEN_P(b)) {
       MRB_SET_FROZEN_FLAG(b);
+      if (b->c->tt == MRB_TT_SCLASS) MRB_SET_FROZEN_FLAG(b->c);
     }
   }
   return self;

--- a/test/t/class.rb
+++ b/test/t/class.rb
@@ -356,6 +356,13 @@ assert('singleton tests') do
       end
     end
   end if Object.const_defined?(:Float)
+
+  o = Object.new
+  sc = class << o; self end
+  o.freeze
+  assert_predicate(sc, :frozen?)
+
+  assert_predicate(class << Object.new.freeze; self end, :frozen?)
 end
 
 assert('clone Class') do


### PR DESCRIPTION
Singleton class of frozen object should be frozen

#### Before this patch:

```ruby
p (class << Object.new.freeze; self end).frozen?                #=> false
sc = class << (o=Object.new); self end; o.freeze; p sc.frozen?  #=> false
```

#### After this patch / Ruby:

```ruby
p (class << Object.new.freeze; self end).frozen?                #=> true
sc = class << (o=Object.new); self end; o.freeze; p sc.frozen?  #=> true
```