### PR TITLE
Add customized `mrb_ro_data_p()`

### DIFF
--- a/include/mruby/value.h
+++ b/include/mruby/value.h
@@ -278,7 +278,10 @@ mrb_undef_value(void)
   return v;
 }
 
-#ifdef MRB_USE_ETEXT_EDATA
+#if defined(MRB_USE_CUSTOM_RO_DATA_P)
+/* If you define `MRB_USE_CUSTOM_RO_DATA_P`, you must implement `mrb_ro_data_p()`. */
+mrb_bool mrb_ro_data_p(const char *p);
+#elif defined(MRB_USE_ETEXT_EDATA)
 #if (defined(__APPLE__) && defined(__MACH__))
 #include <mach-o/getsect.h>
 static inline mrb_bool


### PR DESCRIPTION
This is a patch that allows the user to define the `mrb_ro_data_p()` function.

It becomes effective by adding `MRB_USE_CUSTOM_RO_DATA_P` to `conf.cc.defines` in `build_config.rb`.

(Limitation) It can not be defined as an inline function.


## Background

Defining `MRB_USE_ETEXT_EDATA` in ESP32 will increase RAM usage (the cause will be described later).

So, if we could use the user-definable `mrb_ro_data_p ()` function, we could reduce it by 3.6 KiB.

  - without `MRB_USE_ETEXT_EDATA`:

    ```
    free heap size (in bytes):
         before `mrb_open()`:   298728
          after `mrb_open()`:   117836 (delta  -180892)
    ```

  - with `MRB_USE_ETEXT_EDATAP`:

    ```
    free heap size (in bytes):
         before `mrb_open()`:   298728
          after `mrb_open()`:    76636 (delta  -222092)
    ```

  - Patched with `MRB_USE_CUSTOM_RO_DATA_P`:

    ```
    free heap size (in bytes):
         before `mrb_open()`:   298728
          after `mrb_open()`:   121516 (delta  -177212)
    ```

### Why define `MRB_USE_ETEXT_EDATA` causes more RAM usage on ESP32

Addresses indicated by `_etext` and `__init_array_start` on ESP32 are not in the expected layout of the `mrb_ro_data_p()` function.

Therefore, `mrb_ro_data_p()` is always `FALSE`, and it seems that irep is now allocated in the heap.

  - Address:

    ```
    _etext: 0x4000d66c
    _edata: (undefined)
    &__init_array_start: 0x3f42bd04

    Instruction ROM region:
            virtual address: 0x40800000 - 0x40c00000, size: 4194304 bytes
    Instruction RAM region:
            virtual address: 0x40000000 - 0x40400000, size: 4194304 bytes
            virtual address: 0x40400000 - 0x40800000, size: 4194304 bytes
    Data ROM region:
            virtual address: 0x3f400000 - 0x3f800000, size: 4194304 bytes
    Data RAM region:
            virtual address: 0x3ff80000 - 0x40000000, size:  524288 bytes
            virtual address: 0x3f800000 - 0x3fc00000, size: 4194304 bytes
    ```

### *Custom* `mrb_ro_data_p()` for ESP32 with gcc-5.2.0 used this time

```c
mrb_bool
mrb_ro_data_p(const char *p)
{
  for (int i = 0; i < Xthal_num_datarom; i ++) {
    uint32_t range = (uint32_t)p - Xthal_datarom_vaddr[i];
    if (range < Xthal_datarom_size[i]) { return TRUE; }
  }

  return FALSE;
}
```
