### PR TITLE
Refine the default values of `flunk`

### DIFF
--- a/test/assert.rb
+++ b/test/assert.rb
@@ -247,7 +247,7 @@ def pass
   assert_true(true)
 end
 
-def flunk(msg = nil, diff = "Epic Fail!")
+def flunk(msg = "Epic Fail!", diff = "")
   assert_true(false, msg, diff)
 end
 


### PR DESCRIPTION
The default message for the second argument should be set to the first
argument because only one argument is normally specified.