### PR TITLE
Avoid using `mrb_str_to_cstr` if possible

### DIFF
--- a/mrbgems/mruby-io/src/file.c
+++ b/mrbgems/mruby-io/src/file.c
@@ -146,7 +146,7 @@ mrb_file_s_rename(mrb_state *mrb, mrb_value obj)
 #endif
     mrb_locale_free(src);
     mrb_locale_free(dst);
-    mrb_sys_fail(mrb, mrb_str_to_cstr(mrb, mrb_format(mrb, "(%S, %S)", from, to)));
+    mrb_sys_fail(mrb, RSTRING_PTR(mrb_format(mrb, "(%S, %S)", from, to)));
   }
   mrb_locale_free(src);
   mrb_locale_free(dst);
@@ -159,12 +159,12 @@ mrb_file_dirname(mrb_state *mrb, mrb_value klass)
 #if defined(_WIN32) || defined(_WIN64)
   char dname[_MAX_DIR], vname[_MAX_DRIVE];
   char buffer[_MAX_DRIVE + _MAX_DIR];
+  const char *utf8_path;
   char *path;
   size_t ridx;
-  mrb_value s;
-  mrb_get_args(mrb, "S", &s);
-  path = mrb_locale_from_utf8(mrb_str_to_cstr(mrb, s), -1);
-  _splitpath((const char*)path, vname, dname, NULL, NULL);
+  mrb_get_args(mrb, "z", &utf8_path);
+  path = mrb_locale_from_utf8(utf8_path, -1);
+  _splitpath(path, vname, dname, NULL, NULL);
   snprintf(buffer, _MAX_DRIVE + _MAX_DIR, "%s%s", vname, dname);
   mrb_locale_free(path);
   ridx = strlen(buffer);
@@ -248,7 +248,7 @@ mrb_file_realpath(mrb_state *mrb, mrb_value klass)
     s = mrb_str_append(mrb, s, pathname);
     pathname = s;
   }
-  cpath = mrb_locale_from_utf8(mrb_str_to_cstr(mrb, pathname), -1);
+  cpath = mrb_locale_from_utf8(mrb_string_value_cstr(mrb, &pathname), -1);
   result = mrb_str_buf_new(mrb, PATH_MAX);
   if (realpath(cpath, RSTRING_PTR(result)) == NULL) {
     mrb_locale_free(cpath);
@@ -300,7 +300,7 @@ mrb_file__gethome(mrb_state *mrb, mrb_value klass)
       mrb_raise(mrb, E_ARGUMENT_ERROR, "non-absolute home");
     }
   } else {
-    const char *cuser = mrb_str_to_cstr(mrb, username);
+    const char *cuser = mrb_string_value_cstr(mrb, &username);
     struct passwd *pwd = getpwnam(cuser);
     if (pwd == NULL) {
       return mrb_nil_value();
@@ -393,9 +393,8 @@ mrb_file_s_symlink(mrb_state *mrb, mrb_value klass)
   int ai = mrb_gc_arena_save(mrb);
 
   mrb_get_args(mrb, "SS", &from, &to);
-  src = mrb_locale_from_utf8(mrb_str_to_cstr(mrb, from), -1);
-  dst = mrb_locale_from_utf8(mrb_str_to_cstr(mrb, to), -1);
-
+  src = mrb_locale_from_utf8(mrb_string_value_cstr(mrb, &from), -1);
+  dst = mrb_locale_from_utf8(mrb_string_value_cstr(mrb, &to), -1);
   if (symlink(src, dst) == -1) {
     mrb_locale_free(src);
     mrb_locale_free(dst);
@@ -417,7 +416,7 @@ mrb_file_s_chmod(mrb_state *mrb, mrb_value klass) {
 
   mrb_get_args(mrb, "i*", &mode, &filenames, &argc);
   for (i = 0; i < argc; i++) {
-    const char *utf8_path = mrb_str_to_cstr(mrb, filenames[i]);
+    const char *utf8_path = mrb_string_value_cstr(mrb, &filenames[i]);
     char *path = mrb_locale_from_utf8(utf8_path, -1);
     if (CHMOD(path, mode) == -1) {
       mrb_locale_free(path);

--- a/mrbgems/mruby-io/src/file_test.c
+++ b/mrbgems/mruby-io/src/file_test.c
@@ -63,7 +63,7 @@ mrb_stat0(mrb_state *mrb, mrb_value obj, struct stat *st, int do_lstat)
 
   tmp = mrb_funcall(mrb, obj, "is_a?", 1, str_klass);
   if (mrb_test(tmp)) {
-    char *path = mrb_locale_from_utf8(mrb_str_to_cstr(mrb, obj), -1);
+    char *path = mrb_locale_from_utf8(mrb_string_value_cstr(mrb, &obj), -1);
     int ret;
     if (do_lstat) {
       ret = LSTAT(path, st);

--- a/mrbgems/mruby-io/test/mruby_io_test.c
+++ b/mrbgems/mruby-io/test/mruby_io_test.c
@@ -215,11 +215,9 @@ mrb_io_test_mkdtemp(mrb_state *mrb, mrb_value klass)
 static mrb_value
 mrb_io_test_rmdir(mrb_state *mrb, mrb_value klass)
 {
-  mrb_value str;
-  char *cp;
+  const char *cp;
 
-  mrb_get_args(mrb, "S", &str);
-  cp = mrb_str_to_cstr(mrb, str);
+  mrb_get_args(mrb, "z", &cp);
   if (rmdir(cp) == -1) {
     mrb_sys_fail(mrb, "rmdir");
   }

--- a/mrbgems/mruby-socket/src/socket.c
+++ b/mrbgems/mruby-socket/src/socket.c
@@ -131,7 +131,7 @@ mrb_addrinfo_getaddrinfo(mrb_state *mrb, mrb_value klass)
   mrb_get_args(mrb, "oo|oooi", &nodename, &service, &family, &socktype, &protocol, &flags);
 
   if (mrb_string_p(nodename)) {
-    hostname = mrb_str_to_cstr(mrb, nodename);
+    hostname = mrb_string_value_cstr(mrb, &nodename);
   } else if (mrb_nil_p(nodename)) {
     hostname = NULL;
   } else {
@@ -139,7 +139,7 @@ mrb_addrinfo_getaddrinfo(mrb_state *mrb, mrb_value klass)
   }
 
   if (mrb_string_p(service)) {
-    servname = mrb_str_to_cstr(mrb, service);
+    servname = mrb_string_value_cstr(mrb, &service);
   } else if (mrb_fixnum_p(service)) {
     servname = RSTRING_PTR(mrb_fixnum_to_str(mrb, service, 10));
   } else if (mrb_nil_p(service)) {


### PR DESCRIPTION
Because it always allocate new string. Replace with the followings:

- Use `RSRING_PTR` if string is guaranteed to be null-terminated.
- Use `mrb_string_value_cstr` or `mrb_get_args("z")` if return value isn't
  modified.