### PR TITLE
Update ossfuzz options

### DIFF
--- a/oss-fuzz/config/mruby_fuzzer.options
+++ b/oss-fuzz/config/mruby_fuzzer.options
@@ -1,3 +1,5 @@
 [libfuzzer]
-close_fd_mask=3
-dict=mruby.dict
+close_fd_mask = 3
+dict = mruby.dict
+fork = 8
+only_ascii = 1


### PR DESCRIPTION
This PR
  - Adds a space between earlier ossfuzz options
  - Adds two new options
    - `only_ascii` ensures that the fuzzer generates only ASCII input
    - `fork=8` ensures that the fuzzer does not halt on the first timeout/out-of-memory issue, while parallelizing fuzzing across 8 independent processes.
