### PR TITLE
Refine `Time#(to_s|inspect)`

### DIFF
--- a/mrbgems/mruby-time/src/time.c
+++ b/mrbgems/mruby-time/src/time.c
@@ -18,6 +18,7 @@
 #endif
 
 #define NDIV(x,y) (-(-((x)+1)/(y))-1)
+#define TO_S_FMT "%Y-%m-%d %H:%M:%S "
 
 #if defined(_MSC_VER) && _MSC_VER < 1800
 double round(double x) {
@@ -760,7 +761,6 @@ mrb_time_sec(mrb_state *mrb, mrb_value self)
   return mrb_fixnum_value(tm->datetime.tm_sec);
 }
 
-
 /* 15.2.19.7.24 */
 /* Returns a Float with the time since the epoch in seconds. */
 static mrb_value
@@ -824,6 +824,15 @@ mrb_time_utc_p(mrb_state *mrb, mrb_value self)
   return mrb_bool_value(tm->timezone == MRB_TIMEZONE_UTC);
 }
 
+static mrb_value
+mrb_time_to_s(mrb_state *mrb, mrb_value self)
+{
+  char buf[64];
+  struct mrb_time *tm = time_get_ptr(mrb, self);
+  const char *fmt = tm->timezone == MRB_TIMEZONE_UTC ? TO_S_FMT "UTC" : TO_S_FMT "%z";
+  size_t len = strftime(buf, sizeof(buf), fmt, &tm->datetime);
+  return mrb_str_new(mrb, buf, len);
+}
 
 void
 mrb_mruby_time_gem_init(mrb_state* mrb)
@@ -844,8 +853,8 @@ mrb_mruby_time_gem_init(mrb_state* mrb)
   mrb_define_method(mrb, tc, "<=>"    , mrb_time_cmp    , MRB_ARGS_REQ(1)); /* 15.2.19.7.1 */
   mrb_define_method(mrb, tc, "+"      , mrb_time_plus   , MRB_ARGS_REQ(1)); /* 15.2.19.7.2 */
   mrb_define_method(mrb, tc, "-"      , mrb_time_minus  , MRB_ARGS_REQ(1)); /* 15.2.19.7.3 */
-  mrb_define_method(mrb, tc, "to_s"   , mrb_time_asctime, MRB_ARGS_NONE());
-  mrb_define_method(mrb, tc, "inspect", mrb_time_asctime, MRB_ARGS_NONE());
+  mrb_define_method(mrb, tc, "to_s"   , mrb_time_to_s   , MRB_ARGS_NONE());
+  mrb_define_method(mrb, tc, "inspect", mrb_time_to_s   , MRB_ARGS_NONE());
   mrb_define_method(mrb, tc, "asctime", mrb_time_asctime, MRB_ARGS_NONE()); /* 15.2.19.7.4 */
   mrb_define_method(mrb, tc, "ctime"  , mrb_time_asctime, MRB_ARGS_NONE()); /* 15.2.19.7.5 */
   mrb_define_method(mrb, tc, "day"    , mrb_time_day    , MRB_ARGS_NONE()); /* 15.2.19.7.6 */

--- a/mrbgems/mruby-time/test/time.rb
+++ b/mrbgems/mruby-time/test/time.rb
@@ -235,11 +235,11 @@ end
 # Not ISO specified
 
 assert('Time#to_s') do
-  assert_equal("Sun Mar 13 07:06:40 2011", Time.at(1300000000.0).utc.to_s)
+  assert_equal("2003-04-05 06:07:08 UTC", Time.gm(2003,4,5,6,7,8,9).to_s)
 end
 
 assert('Time#inspect') do
-  assert_equal("Sun Mar 13 07:06:40 2011", Time.at(1300000000.0).utc.inspect)
+  assert_match("2013-10-28 16:27:48 [^U]*", Time.local(2013,10,28,16,27,48).inspect)
 end
 
 assert('day of week methods') do


### PR DESCRIPTION
### For the following reasons:

- Ruby compatibility.
- Add UTC offset (time zone informations was not included by #4433).
- More readable.

### Example:

#### Before this patch:

```ruby
p Time.gm(2003,4,5,6,7,8,9)        #=> Sat Apr  5 06:07:08 2003
p Time.local(2013,10,28,16,27,48)  #=> Mon Oct 28 16:27:48 2013
```

#### After this patch:

```ruby
p Time.gm(2003,4,5,6,7,8,9)        #=> 2003-04-05 06:07:08 UTC
p Time.local(2013,10,28,16,27,48)  #=> 2013-10-28 16:27:48 +0900
```

### Implementation:

I use `strftime(3)` because UTC offset can be added and program size become
smaller than the other implementations (using `sprintf(3)`, self conversion
etc) in my environment.