### PR TITLE
Add support for CC="gcc --option ..." again

### DIFF
--- a/lib/mruby/build/command.rb
+++ b/lib/mruby/build/command.rb
@@ -30,10 +30,13 @@ module MRuby
     def _run(options, params={})
       return sh command + ' ' + ( options % params ) if NotFoundCommands.key? @command
       begin
+        fiber, $rake_root_fiber = $rake_root_fiber, nil
         sh build.filename(command) + ' ' + ( options % params )
       rescue RuntimeError
         NotFoundCommands[@command] = true
         _run options, params
+      ensure
+        $rake_root_fiber = fiber
       end
     end
   end


### PR DESCRIPTION
If $rake_root_fiber is used, sh runs command in another Fiber. If
command is ran in another Fiber, "rescue RuntimEerror" can't rescue
exception for system(...) failure.

How to reproduce:

    $ CC="gcc -std=gnu99" ./minirake
    (in /home/kou/work/ruby/mruby.kou)
    CC    mrbgems/mruby-compiler/core/codegen.c -> build/test/mrbgems/mruby-compiler/core/codegen.o
    sh: 1: gcc -std=gnu99: not found
    rake aborted!
    Command Failed: ["gcc -std=gnu99" -g -std=gnu99 ...]