### PR TITLE
Move `Integral#(zero|nonzero|positive|negative)?` to `Numeric`

### DIFF
--- a/mrbgems/mruby-numeric-ext/mrblib/numeric_ext.rb
+++ b/mrbgems/mruby-numeric-ext/mrblib/numeric_ext.rb
@@ -1,4 +1,4 @@
-module Integral
+class Numeric
   def zero?
     self == 0
   end


### PR DESCRIPTION
Because these methods work if object is `Comparable`, and `Numeric` is
`Comparable`.