### PR TITLE
proto fuzzer: Add source files necessary to compile proto fuzzer

### DIFF
--- a/oss-fuzz/mruby_proto_fuzzer.cpp
+++ b/oss-fuzz/mruby_proto_fuzzer.cpp
@@ -1,0 +1,44 @@
+#include <string>
+#include <iostream>
+#include <fstream>
+
+#include <mruby.h>
+#include <mruby/compile.h>
+
+#include "libprotobuf-mutator/src/libfuzzer/libfuzzer_macro.h"
+#include "ruby.pb.h"
+#include "proto_to_ruby.h"
+
+using namespace ruby_fuzzer;
+using namespace std;
+
+int FuzzRB(const uint8_t *Data, size_t size) {
+	mrb_value v;
+	mrb_state *mrb = mrb_open();
+	if (!mrb)
+		return 0;
+
+	char *code = (char *)malloc(size+1);
+	if (!code)
+		return 0;
+	memcpy(code, Data, size);
+	code[size] = '\0';
+
+	if (const char *dump_path = getenv("PROTO_FUZZER_DUMP_PATH")) {
+		// With libFuzzer binary run this to generate an RB file x.rb:
+		// PROTO_FUZZER_DUMP_PATH=x.rb ./a.out proto-input
+		std::ofstream of(dump_path);
+		of.write(code, size);
+	}
+	v = mrb_load_string(mrb, code);
+	mrb_close(mrb);
+
+	free(code);
+	return 0;
+}
+
+DEFINE_PROTO_FUZZER(const Function &function) {
+	protoConverter converter;
+	auto s = converter.FunctionToString(function);
+	(void)FuzzRB((const uint8_t*)s.data(), s.size());
+}

--- a/oss-fuzz/proto_to_ruby.cpp
+++ b/oss-fuzz/proto_to_ruby.cpp
@@ -1,0 +1,455 @@
+#include "proto_to_ruby.h"
+
+using namespace ruby_fuzzer;
+
+std::string protoConverter::removeSpecial(const std::string &x)
+{
+	std::string tmp(x);
+	if (!tmp.empty())
+		tmp.erase(std::remove_if(tmp.begin(), tmp.end(),
+		                         [](char c) { return !(std::isalpha(c) || std::isdigit(c)); } ), tmp.end());
+	return tmp;
+}
+
+void protoConverter::visit(ArrType const& x)
+{
+	if (x.elements_size() > 0) {
+		int i = x.elements_size();
+		m_output << "[";
+		for (auto &e : x.elements()) {
+			i--;
+			if (i == 0) {
+				visit(e);
+			} else {
+				visit(e);
+				m_output << ", ";
+			}
+		}
+		m_output << "]";
+	} else {
+		m_output << "[1]";
+	}
+}
+
+void protoConverter::visit(Array const& x)
+{
+	switch (x.arr_func()) {
+		case Array::FLATTEN:
+			visit(x.arr_arg());
+			m_output << ".flatten";
+			break;
+		case Array::COMPACT:
+			visit(x.arr_arg());
+			m_output << ".compact";
+			break;
+		case Array::FETCH:
+			visit(x.arr_arg());
+			m_output << ".fetch";
+			break;
+		case Array::FILL:
+			visit(x.arr_arg());
+			m_output << ".fill";
+			break;
+		case Array::ROTATE:
+			visit(x.arr_arg());
+			m_output << ".rotate";
+			break;
+		case Array::ROTATE_E:
+			visit(x.arr_arg());
+			m_output << ".rotate!";
+			break;
+		case Array::DELETEIF:
+			visit(x.arr_arg());
+			m_output << ".delete_if";
+			break;
+		case Array::INSERT:
+			visit(x.arr_arg());
+			m_output << ".insert";
+			break;
+		case Array::BSEARCH:
+			visit(x.arr_arg());
+			m_output << ".bsearch";
+			break;
+		case Array::KEEPIF:
+			visit(x.arr_arg());
+			m_output << ".keep_if";
+			break;
+		case Array::SELECT:
+			visit(x.arr_arg());
+			m_output << ".select";
+			break;
+		case Array::VALUES_AT:
+			visit(x.arr_arg());
+			m_output << ".values_at";
+			break;
+		case Array::BLOCK:
+			visit(x.arr_arg());
+			m_output << ".index";
+			break;
+		case Array::DIG:
+			visit(x.arr_arg());
+			m_output << ".dig";
+			break;
+		case Array::SLICE:
+			visit(x.arr_arg());
+			m_output << ".slice";
+			break;
+		case Array::PERM:
+			visit(x.arr_arg());
+			m_output << ".permutation";
+			break;
+		case Array::COMB:
+			visit(x.arr_arg());
+			m_output << ".combination";
+			break;
+		case Array::ASSOC:
+			visit(x.arr_arg());
+			m_output << ".assoc";
+			break;
+		case Array::RASSOC:
+			visit(x.arr_arg());
+			m_output << ".rassoc";
+			break;
+	}
+	m_output << "(";
+	visit(x.val_arg());
+	m_output << ")";
+}
+
+void protoConverter::visit(AssignmentStatement const& x)
+{
+	m_output << "var_" << m_numLiveVars << " = ";
+	visit(x.rvalue());
+	m_numVarsPerScope.top()++;
+	m_numLiveVars++;
+	m_output << "\n";
+}
+
+void protoConverter::visit(BinaryOp const& x)
+{
+	m_output << "(";
+	visit(x.left());
+	switch (x.op()) {
+		case BinaryOp::ADD: m_output << " + "; break;
+		case BinaryOp::SUB: m_output << " - "; break;
+		case BinaryOp::MUL: m_output << " * "; break;
+		case BinaryOp::DIV: m_output << " / "; break;
+		case BinaryOp::MOD: m_output << " % "; break;
+		case BinaryOp::XOR: m_output << " ^ "; break;
+		case BinaryOp::AND: m_output << " and "; break;
+		case BinaryOp::OR: m_output << " or "; break;
+		case BinaryOp::EQ: m_output << " == "; break;
+		case BinaryOp::NE: m_output << " != "; break;
+		case BinaryOp::LE: m_output << " <= "; break;
+		case BinaryOp::GE: m_output << " >= "; break;
+		case BinaryOp::LT: m_output << " < "; break;
+		case BinaryOp::GT: m_output << " > "; break;
+		case BinaryOp::RS: m_output << " >> "; break;
+	}
+	visit(x.right());
+	m_output << ")";
+}
+
+void protoConverter::visit(BuiltinFuncs const& x)
+{
+	switch (x.bifunc_oneof_case()) {
+		case BuiltinFuncs::kOs:
+			visit(x.os());
+			break;
+		case BuiltinFuncs::kTime:
+			visit(x.time());
+			break;
+		case BuiltinFuncs::kArr:
+			visit(x.arr());
+			break;
+		case BuiltinFuncs::kMops:
+			visit(x.mops());
+			break;
+		case BuiltinFuncs::BIFUNC_ONEOF_NOT_SET:
+			m_output << "1";
+			break;
+	}
+	m_output << "\n";
+}
+
+void protoConverter::visit(Const const& x)
+{
+	switch (x.const_oneof_case()) {
+		case Const::kIntLit:
+			m_output << "(" << (x.int_lit() % 13) << ")";
+			break;
+		case Const::kBoolVal:
+			m_output << "(" << x.bool_val() << ")";
+			break;
+		case Const::CONST_ONEOF_NOT_SET:
+			m_output << "1";
+			break;
+	}
+}
+
+void protoConverter::visit(Function const& x)
+{
+	m_output << "def foo()\nvar_0 = 1\n";
+	visit(x.statements());
+	m_output << "end\n";
+	m_output << "foo\n";
+}
+
+void protoConverter::visit(HashType const& x)
+{
+	if (x.keyval_size() > 0) {
+		int i = x.keyval_size();
+		m_output << "{";
+		for (auto &e : x.keyval()) {
+			i--;
+			if (i == 0) {
+				visit(e);
+			}
+			else {
+				visit(e);
+				m_output << ", ";
+			}
+		}
+		m_output << "}";
+	}
+}
+
+void protoConverter::visit(IfElse const& x)
+{
+	m_output << "if ";
+	visit(x.cond());
+	m_output << "\n";
+	visit(x.if_body());
+	m_output << "\nelse\n";
+	visit(x.else_body());
+	m_output << "\nend\n";
+}
+
+void protoConverter::visit(KVPair const& x)
+{
+	m_output << "\"" << removeSpecial(x.key()) << "\"";
+	m_output << " => ";
+	m_output << "\"" << removeSpecial(x.val()) << "\"";
+}
+
+void protoConverter::visit(MathConst const& x)
+{
+	switch (x.math_const()) {
+		case MathConst::PI:
+			m_output << "Math::PI";
+			break;
+		case MathConst::E:
+			m_output << "Math::E";
+			break;
+	}
+}
+
+void protoConverter::visit(MathOps const& x)
+{
+	switch (x.math_op()) {
+		case MathOps::CBRT:
+			m_output << "Math.cbrt(";
+			visit(x.math_arg());
+			m_output << ")";
+			break;
+		case MathOps::COS:
+			m_output << "Math.cos(";
+			visit(x.math_arg());
+			m_output << ")";
+			break;
+		case MathOps::ERF:
+			m_output << "Math.erf(";
+			visit(x.math_arg());
+			m_output << ")";
+			break;
+		case MathOps::ERFC:
+			m_output << "Math.erfc(";
+			visit(x.math_arg());
+			m_output << ")";
+			break;
+		case MathOps::LOG:
+			m_output << "Math.log(";
+			visit(x.math_arg());
+			m_output << ")";
+			break;
+		case MathOps::LOG10:
+			m_output << "Math.log10(";
+			visit(x.math_arg());
+			m_output << ")";
+			break;
+		case MathOps::LOG2:
+			m_output << "Math.log2(";
+			visit(x.math_arg());
+			m_output << ")";
+			break;
+		case MathOps::SIN:
+			m_output << "Math.sin(";
+			visit(x.math_arg());
+			m_output << ")";
+			break;
+		case MathOps::SQRT:
+			m_output << "Math.sqrt(";
+			visit(x.math_arg());
+			m_output << ")";
+			break;
+		case MathOps::TAN:
+			m_output << "Math.tan(";
+			visit(x.math_arg());
+			m_output << ")";
+			break;
+	}
+}
+
+void protoConverter::visit(MathType const& x)
+{
+	switch (x.math_arg_oneof_case()) {
+		case MathType::kMathRval:
+			visit(x.math_rval());
+			break;
+		case MathType::kMathConst:
+			visit(x.math_const());
+			break;
+		case MathType::MATH_ARG_ONEOF_NOT_SET:
+			m_output << "1";
+			break;
+	}
+}
+
+void protoConverter::visit(ObjectSpace const& x)
+{
+	switch (x.os_func()) {
+		case ObjectSpace::COUNT:
+			m_output << "ObjectSpace.count_objects";
+			break;
+	}
+	m_output << "(";
+	visit(x.os_arg());
+	m_output << ")" << "\n";
+}
+
+void protoConverter::visit(Rvalue const& x)
+{
+	switch (x.rvalue_oneof_case()) {
+		case Rvalue::kVarref:
+			visit(x.varref());
+			break;
+		case Rvalue::kCons:
+			visit(x.cons());
+			break;
+		case Rvalue::kBinop:
+			visit(x.binop());
+			break;
+		case Rvalue::RVALUE_ONEOF_NOT_SET:
+			m_output << "1";
+			break;
+	}
+}
+
+void protoConverter::visit(Statement const& x)
+{
+	switch (x.stmt_oneof_case()) {
+		case Statement::kAssignment:
+			visit(x.assignment());
+			break;
+		case Statement::kIfelse:
+			visit(x.ifelse());
+			break;
+		case Statement::kTernaryStmt:
+			visit(x.ternary_stmt());
+			break;
+		case Statement::kBuiltins:
+			visit(x.builtins());
+			break;
+		case Statement::kBlockstmt:
+			visit(x.blockstmt());
+			break;
+		case Statement::STMT_ONEOF_NOT_SET:
+			break;
+	}
+	m_output << "\n";
+}
+
+void protoConverter::visit(StatementSeq const& x)
+{
+	if (x.statements_size() > 0) {
+		m_numVarsPerScope.push(0);
+		m_output << "@scope ||= begin\n";
+		for (auto &st : x.statements())
+			visit(st);
+		m_output << "end\n";
+		m_numLiveVars -= m_numVarsPerScope.top();
+		m_numVarsPerScope.pop();
+	}
+}
+
+void protoConverter::visit(StringExtNoArg const& x)
+{
+	m_output << "\"" << removeSpecial(x.str_arg()) << "\"";
+	switch (x.str_op()) {
+		case StringExtNoArg::DUMP:
+			m_output << ".dump";
+			break;
+		case StringExtNoArg::STRIP:
+			m_output << ".strip";
+			break;
+		case StringExtNoArg::LSTRIP:
+			m_output << ".lstrip";
+			break;
+		case StringExtNoArg::RSTRIP:
+			m_output << ".rstrip";
+			break;
+		case StringExtNoArg::STRIPE:
+			m_output << ".strip!";
+			break;
+		case StringExtNoArg::LSTRIPE:
+			m_output << ".lstrip!";
+			break;
+		case StringExtNoArg::RSTRIPE:
+			m_output << ".rstrip!";
+			break;
+		case StringExtNoArg::SWAPCASE:
+			m_output << ".swapcase";
+			break;
+		case StringExtNoArg::SWAPCASEE:
+			m_output << ".swapcase!";
+			break;
+		case StringExtNoArg::SQUEEZE:
+			m_output << ".squeeze";
+			break;
+	}
+}
+
+void protoConverter::visit(Ternary const& x)
+{
+	m_output << "(";
+	visit(x.tern_cond());
+	m_output << " ? ";
+	visit(x.t_branch());
+	m_output << " : ";
+	visit(x.f_branch());
+	m_output << ")\n";
+}
+
+void protoConverter::visit(Time const& x)
+{
+	switch (x.t_func()) {
+		case Time::AT:
+			m_output << "Time.at";
+			break;
+		case Time::GM:
+			m_output << "Time.gm";
+			break;
+	}
+	m_output << "(" << (x.t_arg()% 13) << ")" << "\n";
+}
+
+void protoConverter::visit(VarRef const& x)
+{
+	m_output << "var_" << (static_cast<uint32_t>(x.varnum()) % m_numLiveVars);
+}
+
+std::string protoConverter::FunctionToString(Function const& input)
+{
+	visit(input);
+	return m_output.str();
+}

--- a/oss-fuzz/proto_to_ruby.h
+++ b/oss-fuzz/proto_to_ruby.h
@@ -1,0 +1,55 @@
+#include <cstdint>
+#include <cstddef>
+#include <string>
+#include <ostream>
+#include <sstream>
+#include <stack>
+#include "ruby.pb.h"
+
+namespace ruby_fuzzer {
+	class protoConverter
+	{
+	public:
+		protoConverter() {
+			m_numLiveVars = 1;
+			m_numVarsPerScope.push(m_numLiveVars);
+		}
+		protoConverter(protoConverter const& x) {
+			m_numLiveVars = x.m_numLiveVars;
+			m_numVarsPerScope = x.m_numVarsPerScope;
+		}
+		~protoConverter() {}
+		std::string FunctionToString(Function const& _input);
+
+	private:
+		void visit(ArrType const&);
+		void visit(Array const&);
+		void visit(AssignmentStatement const&);
+		void visit(BinaryOp const&);
+		void visit(BuiltinFuncs const&);
+		void visit(Const const&);
+		void visit(Function const&);
+		void visit(HashType const&);
+		void visit(IfElse const&);
+		void visit(KVPair const&);
+		void visit(MathConst const&);
+		void visit(MathOps const&);
+		void visit(MathType const&);
+		void visit(ObjectSpace const&);
+		void visit(Rvalue const&);
+		void visit(Statement const&);
+		void visit(StatementSeq const&);
+		void visit(StringExtNoArg const&);
+		void visit(Ternary const&);
+		void visit(Time const&);
+		void visit(VarRef const&);
+		template <class T>
+		void visit(google::protobuf::RepeatedPtrField<T> const& _repeated_field);
+
+		std::string removeSpecial(const std::string &x);
+
+		std::ostringstream m_output;
+		std::stack<uint8_t> m_numVarsPerScope;
+		int32_t m_numLiveVars;
+	};
+}

--- a/oss-fuzz/ruby.proto
+++ b/oss-fuzz/ruby.proto
@@ -1,0 +1,201 @@
+syntax = "proto2";
+
+message VarRef {
+  required int32 varnum = 1;
+}
+
+message ArrType {
+    repeated Const elements = 1;
+}
+
+message KVPair {
+    required string key = 1;
+    required string val = 2;
+}
+
+message HashType {
+    repeated KVPair keyval = 1;
+}
+
+message StringExtNoArg {
+  enum StrExtOp {
+    DUMP = 0;
+    STRIP = 1;
+    LSTRIP = 2;
+    RSTRIP = 3;
+    STRIPE = 4;
+    LSTRIPE = 5;
+    RSTRIPE = 6;
+    SWAPCASE = 7;
+    SWAPCASEE = 8;
+    SQUEEZE = 9;
+  }
+  required StrExtOp str_op = 1;
+  required string str_arg = 2;
+}
+
+message MathConst {
+    enum MathConstLit {
+        PI = 0;
+        E = 1;
+    }
+    required MathConstLit math_const = 1;
+}
+
+message Const {
+    oneof const_oneof {
+        uint32 int_lit = 1;
+        bool bool_val = 4;
+    }
+}
+
+message BinaryOp {
+  enum Op {
+    ADD = 0;
+    SUB = 1;
+    MUL = 2;
+    DIV = 3;
+    MOD = 4;
+    XOR = 5;
+    AND = 6;
+    OR = 7;
+    EQ = 8;
+    NE = 9;
+    LE = 10;
+    GE = 11;
+    LT = 12;
+    GT = 13;
+    RS = 14;
+  };
+  required Op op = 1;
+  required Rvalue left = 2;
+  required Rvalue right = 3;
+}
+
+message Rvalue {
+  oneof rvalue_oneof {
+    VarRef varref = 1;
+    Const cons = 2;
+    BinaryOp binop = 3;
+  }
+}
+
+message AssignmentStatement {
+  required Rvalue rvalue = 2;
+}
+
+
+message IfElse {
+  required Rvalue cond = 1;
+  required StatementSeq if_body = 2;
+  required StatementSeq else_body = 3;
+}
+
+//TODO: Add Switch statement
+//message Switch {
+//    required Rvalue switch_var = 1;
+//    repeated Rvalue cond = 2;
+//}
+
+message Ternary {
+    required Rvalue tern_cond = 1;
+    required Rvalue t_branch = 2;
+    required Rvalue f_branch = 3;
+}
+
+message ObjectSpace {
+    enum OS_methods {
+        COUNT = 1;
+    }
+    required OS_methods os_func = 1;
+    required HashType os_arg = 2;
+}
+
+message Time {
+    enum T_methods {
+        AT = 1;
+        GM = 2;
+    }
+    required T_methods t_func = 1;
+    required uint32 t_arg = 2;
+}
+
+message Array {
+    enum Arr_methods {
+        FLATTEN = 1;
+        COMPACT = 2;
+        FETCH = 3;
+        FILL = 4;
+        ROTATE = 5;
+        ROTATE_E = 6;
+        DELETEIF = 7;
+        INSERT = 8;
+        BSEARCH = 9;
+        KEEPIF = 10;
+        SELECT = 11;
+        VALUES_AT = 12;
+        BLOCK = 13;
+        DIG = 14;
+        SLICE = 15;
+        PERM = 16;
+        COMB = 17;
+        ASSOC = 18;
+        RASSOC = 19;
+    }
+    required Arr_methods arr_func = 1;
+    required ArrType  arr_arg = 2;
+    required Rvalue   val_arg = 3;
+}
+
+message MathType {
+    oneof math_arg_oneof {
+        Rvalue math_rval = 2;
+        MathConst math_const = 3;
+    }
+}
+
+message MathOps {
+    enum Mops {
+      CBRT = 1;
+      COS = 2;
+      ERF = 3;
+      ERFC = 4;
+      LOG = 5;
+      LOG10 = 6;
+      LOG2 = 7;
+      SIN = 8;
+      SQRT = 9;
+      TAN = 10;
+    }
+    required Mops math_op = 1;
+    required MathType math_arg = 2;
+}
+
+message BuiltinFuncs {
+    oneof bifunc_oneof {
+        ObjectSpace os = 1;
+        Time time = 2;
+        Array arr = 3;
+        MathOps mops = 4;
+    }
+}
+
+message Statement {
+  oneof stmt_oneof {
+    AssignmentStatement assignment = 1;
+    IfElse              ifelse     = 2;
+    Ternary             ternary_stmt = 3;
+    BuiltinFuncs        builtins = 4;
+    StatementSeq        blockstmt = 5;
+  }
+}
+
+message StatementSeq {
+  repeated Statement statements = 1;
+}
+
+message Function {
+  required StatementSeq statements = 1;
+}
+
+package ruby_fuzzer;


### PR DESCRIPTION
This PR
  - adds source and header files necessary to build and run [proto fuzzer](https://github.com/google/fuzzer-test-suite/blob/master/tutorial/structure-aware-fuzzing.md) on oss-fuzz
  - adds a simple proto specification for the ruby language

Once this PR is merged, I will push changes necessary to build the proto fuzzer to oss-fuzz.