### PR TITLE
Add/Edit ossfuzz config options

### DIFF
--- a/oss-fuzz/config/mruby_proto_fuzzer.options
+++ b/oss-fuzz/config/mruby_proto_fuzzer.options
@@ -2,4 +2,3 @@
 close_fd_mask = 3
 dict = mruby.dict
 fork = 1
-only_ascii = 1


### PR DESCRIPTION
This PR
  - Modifies the `fork` config parameter inside `mruby_fuzzer.options` to `1` as suggested [here]()
  - Adds a libfuzzer options file for the yet-to-be-enabled proto fuzzer.