### PR TITLE
Remove byteorder processing from irep load/dump

### DIFF
--- a/include/mruby/dump.h
+++ b/include/mruby/dump.h
@@ -17,10 +17,6 @@
 MRB_BEGIN_DECL
 
 #define DUMP_DEBUG_INFO 1
-#define DUMP_ENDIAN_BIG 2
-#define DUMP_ENDIAN_LIL 4
-#define DUMP_ENDIAN_NAT 6
-#define DUMP_ENDIAN_MASK 6
 
 int mrb_dump_irep(mrb_state *mrb, mrb_irep *irep, uint8_t flags, uint8_t **bin, size_t *bin_size);
 #ifndef MRB_DISABLE_STDIO
@@ -51,7 +47,6 @@ MRB_API mrb_irep *mrb_read_irep(mrb_state*, const uint8_t*);
 
 /* Rite Binary File header */
 #define RITE_BINARY_IDENT              "RITE"
-#define RITE_BINARY_IDENT_LIL          "ETIR"
 #define RITE_BINARY_FORMAT_VER         "0006"
 #define RITE_COMPILER_NAME             "MATZ"
 #define RITE_COMPILER_VERSION          "0000"

--- a/mrbgems/mruby-bin-mrbc/tools/mrbc/mrbc.c
+++ b/mrbgems/mruby-bin-mrbc/tools/mrbc/mrbc.c
@@ -32,8 +32,6 @@ usage(const char *name)
   "-v           print version number, then turn on verbose mode",
   "-g           produce debugging information",
   "-B<symbol>   binary <symbol> output in C language format",
-  "-e           generate little endian iseq data",
-  "-E           generate big endian iseq data",
   "--remove-lv  remove local variables",
   "--verbose    run at verbose mode",
   "--version    print the version",
@@ -121,10 +119,10 @@ parse_args(mrb_state *mrb, int argc, char **argv, struct mrbc_args *args)
         args->flags |= DUMP_DEBUG_INFO;
         break;
       case 'E':
-        args->flags = DUMP_ENDIAN_BIG | (args->flags & ~DUMP_ENDIAN_MASK);
+        /* do nothing, but this switch remains for backward compatibility */
         break;
       case 'e':
-        args->flags = DUMP_ENDIAN_LIL | (args->flags & ~DUMP_ENDIAN_MASK);
+        /* do nothing, but this switch remains for backward compatibility */
         break;
       case 'h':
         return -1;
@@ -156,10 +154,6 @@ parse_args(mrb_state *mrb, int argc, char **argv, struct mrbc_args *args)
     else {
       break;
     }
-  }
-  if (args->verbose && args->initname && (args->flags & DUMP_ENDIAN_MASK) == 0) {
-    fprintf(stderr, "%s: generating %s endian C file. specify -e/-E for cross compiling.\n",
-            args->prog, bigendian_p() ? "big" : "little");
   }
   return i;
 }

--- a/src/dump.c
+++ b/src/dump.c
@@ -13,9 +13,6 @@
 #include <mruby/numeric.h>
 #include <mruby/debug.h>
 
-#define FLAG_BYTEORDER_NATIVE 2
-#define FLAG_BYTEORDER_NONATIVE 0
-
 #ifndef MRB_WITHOUT_FLOAT
 #ifdef MRB_USE_FLOAT
 #define MRB_FLOAT_FMT "%.9g"
@@ -709,22 +706,7 @@ write_rite_binary_header(mrb_state *mrb, size_t binary_size, uint8_t *bin, uint8
   uint16_t crc;
   uint32_t offset;
 
-  switch (flags & DUMP_ENDIAN_NAT) {
-  endian_big:
-  case DUMP_ENDIAN_BIG:
-    memcpy(header->binary_ident, RITE_BINARY_IDENT, sizeof(header->binary_ident));
-    break;
-  endian_little:
-  case DUMP_ENDIAN_LIL:
-    memcpy(header->binary_ident, RITE_BINARY_IDENT_LIL, sizeof(header->binary_ident));
-    break;
-
-  case DUMP_ENDIAN_NAT:
-    if (bigendian_p()) goto endian_big;
-    goto endian_little;
-    break;
-  }
-
+  memcpy(header->binary_ident, RITE_BINARY_IDENT, sizeof(header->binary_ident));
   memcpy(header->binary_version, RITE_BINARY_FORMAT_VER, sizeof(header->binary_version));
   memcpy(header->compiler_name, RITE_COMPILER_NAME, sizeof(header->compiler_name));
   memcpy(header->compiler_version, RITE_COMPILER_VERSION, sizeof(header->compiler_version));
@@ -762,21 +744,6 @@ lv_defined_p(mrb_irep *irep)
   }
 
   return FALSE;
-}
-
-static uint8_t
-dump_flags(uint8_t flags, uint8_t native)
-{
-  if (native == FLAG_BYTEORDER_NATIVE) {
-    if ((flags & DUMP_ENDIAN_NAT) == 0) {
-      return (flags & DUMP_DEBUG_INFO) | DUMP_ENDIAN_NAT;
-    }
-    return flags;
-  }
-  if ((flags & DUMP_ENDIAN_NAT) == 0) {
-    return (flags & DUMP_DEBUG_INFO) | DUMP_ENDIAN_BIG;
-  }
-  return flags;
 }
 
 static int
@@ -870,7 +837,7 @@ error_exit:
 int
 mrb_dump_irep(mrb_state *mrb, mrb_irep *irep, uint8_t flags, uint8_t **bin, size_t *bin_size)
 {
-  return dump_irep(mrb, irep, dump_flags(flags, FLAG_BYTEORDER_NONATIVE), bin, bin_size);
+  return dump_irep(mrb, irep, flags, bin, bin_size);
 }
 
 #ifndef MRB_DISABLE_STDIO
@@ -886,7 +853,7 @@ mrb_dump_irep_binary(mrb_state *mrb, mrb_irep *irep, uint8_t flags, FILE* fp)
     return MRB_DUMP_INVALID_ARGUMENT;
   }
 
-  result = dump_irep(mrb, irep, dump_flags(flags, FLAG_BYTEORDER_NONATIVE), &bin, &bin_size);
+  result = dump_irep(mrb, irep, flags, &bin, &bin_size);
   if (result == MRB_DUMP_OK) {
     if (fwrite(bin, sizeof(bin[0]), bin_size, fp) != bin_size) {
       result = MRB_DUMP_WRITE_FAULT;
@@ -895,20 +862,6 @@ mrb_dump_irep_binary(mrb_state *mrb, mrb_irep *irep, uint8_t flags, FILE* fp)
 
   mrb_free(mrb, bin);
   return result;
-}
-
-static mrb_bool
-dump_bigendian_p(uint8_t flags)
-{
-  switch (flags & DUMP_ENDIAN_NAT) {
-  case DUMP_ENDIAN_BIG:
-    return TRUE;
-  case DUMP_ENDIAN_LIL:
-    return FALSE;
-  default:
-  case DUMP_ENDIAN_NAT:
-    return bigendian_p();
-  }
 }
 
 int
@@ -921,23 +874,8 @@ mrb_dump_irep_cfunc(mrb_state *mrb, mrb_irep *irep, uint8_t flags, FILE *fp, con
   if (fp == NULL || initname == NULL || initname[0] == '\0') {
     return MRB_DUMP_INVALID_ARGUMENT;
   }
-  flags = dump_flags(flags, FLAG_BYTEORDER_NATIVE);
   result = dump_irep(mrb, irep, flags, &bin, &bin_size);
   if (result == MRB_DUMP_OK) {
-    if (!dump_bigendian_p(flags)) {
-      if (fprintf(fp, "/* dumped in little endian order.\n"
-                  "   use `mrbc -E` option for big endian CPU. */\n") < 0) {
-        mrb_free(mrb, bin);
-        return MRB_DUMP_WRITE_FAULT;
-      }
-    }
-    else {
-      if (fprintf(fp, "/* dumped in big endian order.\n"
-                  "   use `mrbc -e` option for better performance on little endian CPU. */\n") < 0) {
-        mrb_free(mrb, bin);
-        return MRB_DUMP_WRITE_FAULT;
-      }
-    }
     if (fprintf(fp, "#include <stdint.h>\n") < 0) { /* for uint8_t under at least Darwin */
       mrb_free(mrb, bin);
       return MRB_DUMP_WRITE_FAULT;

--- a/src/load.c
+++ b/src/load.c
@@ -19,9 +19,6 @@
 # error size_t must be at least 32 bits wide
 #endif
 
-#define FLAG_BYTEORDER_BIG 2
-#define FLAG_BYTEORDER_LIL 4
-#define FLAG_BYTEORDER_NATIVE 8
 #define FLAG_SRC_MALLOC 1
 #define FLAG_SRC_STATIC 0
 
@@ -94,8 +91,7 @@ read_irep_record_1(mrb_state *mrb, const uint8_t *bin, size_t *len, uint8_t flag
     if (SIZE_ERROR_MUL(irep->ilen, sizeof(mrb_code))) {
       return NULL;
     }
-    if ((flags & FLAG_SRC_MALLOC) == 0 &&
-        (flags & FLAG_BYTEORDER_NATIVE)) {
+    if ((flags & FLAG_SRC_MALLOC) == 0) {
       irep->iseq = (mrb_code*)src;
       src += sizeof(mrb_code) * irep->ilen;
       irep->flags |= MRB_ISEQ_NO_FREE;
@@ -523,19 +519,7 @@ read_binary_header(const uint8_t *bin, size_t *bin_size, uint16_t *crc, uint8_t 
 {
   const struct rite_binary_header *header = (const struct rite_binary_header *)bin;
 
-  if (memcmp(header->binary_ident, RITE_BINARY_IDENT, sizeof(header->binary_ident)) == 0) {
-    if (bigendian_p())
-      *flags |= FLAG_BYTEORDER_NATIVE;
-    else
-      *flags |= FLAG_BYTEORDER_BIG;
-  }
-  else if (memcmp(header->binary_ident, RITE_BINARY_IDENT_LIL, sizeof(header->binary_ident)) == 0) {
-    if (bigendian_p())
-      *flags |= FLAG_BYTEORDER_LIL;
-    else
-      *flags |= FLAG_BYTEORDER_NATIVE;
-  }
-  else {
+  if (memcmp(header->binary_ident, RITE_BINARY_IDENT, sizeof(header->binary_ident)) != 0) {
     return MRB_DUMP_INVALID_FILE_HEADER;
   }
 


### PR DESCRIPTION
The `-E` and `-e` switches of the `mrbc` command are remains.
Because for backward compatibility.

To be on the safe side, I confirmed that `.mrb` files generated by `mrbc` are the same on little-endian machine (FreeBSD 12.0 AMD64) and big-endian machine (NetBSD 8.0 SPARC64 on QEmu).