### PR TITLE
Name the return value of `mrb_range_beg_len()`

### DIFF
--- a/include/mruby/range.h
+++ b/include/mruby/range.h
@@ -64,7 +64,13 @@ MRB_API struct RRange* mrb_range_ptr(mrb_state *mrb, mrb_value range);
  */
 MRB_API mrb_value mrb_range_new(mrb_state *mrb, mrb_value start, mrb_value end, mrb_bool exclude);
 
-MRB_API mrb_int mrb_range_beg_len(mrb_state *mrb, mrb_value range, mrb_int *begp, mrb_int *lenp, mrb_int len, mrb_bool trunc);
+enum mrb_range_beg_len {
+  MRB_RANGE_TYPE_MISMATCH = 0,  /* (failure) not range */
+  MRB_RANGE_OK = 1,             /* (success) range */
+  MRB_RANGE_OUT = 2             /* (failure) out of range */
+};
+
+MRB_API enum mrb_range_beg_len mrb_range_beg_len(mrb_state *mrb, mrb_value range, mrb_int *begp, mrb_int *lenp, mrb_int len, mrb_bool trunc);
 mrb_value mrb_get_values_at(mrb_state *mrb, mrb_value obj, mrb_int olen, mrb_int argc, const mrb_value *argv, mrb_value (*func)(mrb_state*, mrb_value, mrb_int));
 void mrb_gc_mark_range(mrb_state *mrb, struct RRange *r);
 

--- a/mrbgems/mruby-array-ext/src/array.c
+++ b/mrbgems/mruby-array-ext/src/array.c
@@ -145,7 +145,7 @@ mrb_ary_slice_bang(mrb_state *mrb, mrb_value self)
     mrb_get_args(mrb, "o|i", &index, &len);
     switch (mrb_type(index)) {
     case MRB_TT_RANGE:
-      if (mrb_range_beg_len(mrb, index, &i, &len, ARY_LEN(a), TRUE) == 1) {
+      if (mrb_range_beg_len(mrb, index, &i, &len, ARY_LEN(a), TRUE) == MRB_RANGE_OK) {
         goto delete_pos_len;
       }
       else {

--- a/mrbgems/mruby-kernel-ext/src/kernel.c
+++ b/mrbgems/mruby-kernel-ext/src/kernel.c
@@ -22,7 +22,7 @@ mrb_f_caller(mrb_state *mrb, mrb_value self)
     case 1:
       if (mrb_type(v) == MRB_TT_RANGE) {
         mrb_int beg, len;
-        if (mrb_range_beg_len(mrb, v, &beg, &len, bt_len, TRUE) == 1) {
+        if (mrb_range_beg_len(mrb, v, &beg, &len, bt_len, TRUE) == MRB_RANGE_OK) {
           lev = beg;
           n = len;
         }

--- a/mrbgems/mruby-string-ext/src/string.c
+++ b/mrbgems/mruby-string-ext/src/string.c
@@ -58,11 +58,11 @@ mrb_str_byteslice(mrb_state *mrb, mrb_value str)
 
       len = RSTRING_LEN(str);
       switch (mrb_range_beg_len(mrb, a1, &beg, &len, len, TRUE)) {
-      case 0:                   /* not range */
+      case MRB_RANGE_TYPE_MISMATCH:
         break;
-      case 1:                   /* range */
+      case MRB_RANGE_OK:
         return mrb_str_substr(mrb, str, beg, len);
-      case 2:                   /* out of range */
+      case MRB_RANGE_OUT:
         mrb_raisef(mrb, E_RANGE_ERROR, "%S out of range", a1);
         break;
       }

--- a/src/array.c
+++ b/src/array.c
@@ -858,7 +858,7 @@ mrb_ary_aget(mrb_state *mrb, mrb_value self)
     switch (mrb_type(index)) {
       /* a[n..m] */
     case MRB_TT_RANGE:
-      if (mrb_range_beg_len(mrb, index, &i, &len, ARY_LEN(a), TRUE) == 1) {
+      if (mrb_range_beg_len(mrb, index, &i, &len, ARY_LEN(a), TRUE) == MRB_RANGE_OK) {
         return ary_subseq(mrb, a, i, len);
       }
       else {
@@ -927,13 +927,13 @@ mrb_ary_aset(mrb_state *mrb, mrb_value self)
   if (mrb_get_args(mrb, "oo|o", &v1, &v2, &v3) == 2) {
     /* a[n..m] = v */
     switch (mrb_range_beg_len(mrb, v1, &i, &len, RARRAY_LEN(self), FALSE)) {
-    case 0:                   /* not range */
+    case MRB_RANGE_TYPE_MISMATCH:
       mrb_ary_set(mrb, self, aget_index(mrb, v1), v2);
       break;
-    case 1:                   /* range */
+    case MRB_RANGE_OK:
       mrb_ary_splice(mrb, self, i, len, v2);
       break;
-    case 2:                   /* out of range */
+    case MRB_RANGE_OUT:
       mrb_raisef(mrb, E_RANGE_ERROR, "%S out of range", v1);
       break;
     }

--- a/src/range.c
+++ b/src/range.c
@@ -352,7 +352,7 @@ mrb_get_values_at(mrb_state *mrb, mrb_value obj, mrb_int olen, mrb_int argc, con
     if (mrb_fixnum_p(argv[i])) {
       mrb_ary_push(mrb, result, func(mrb, obj, mrb_fixnum(argv[i])));
     }
-    else if (mrb_range_beg_len(mrb, argv[i], &beg, &len, olen, FALSE) == 1) {
+    else if (mrb_range_beg_len(mrb, argv[i], &beg, &len, olen, FALSE) == MRB_RANGE_OK) {
       mrb_int const end = olen < beg + len ? olen : beg + len;
       for (j = beg; j < end; ++j) {
         mrb_ary_push(mrb, result, func(mrb, obj, j));
@@ -398,13 +398,13 @@ mrb_range_new(mrb_state *mrb, mrb_value beg, mrb_value end, mrb_bool excl)
   return mrb_range_value(r);
 }
 
-MRB_API mrb_int
+MRB_API enum mrb_range_beg_len
 mrb_range_beg_len(mrb_state *mrb, mrb_value range, mrb_int *begp, mrb_int *lenp, mrb_int len, mrb_bool trunc)
 {
   mrb_int beg, end;
   struct RRange *r;
 
-  if (mrb_type(range) != MRB_TT_RANGE) return 0;
+  if (mrb_type(range) != MRB_TT_RANGE) return MRB_RANGE_TYPE_MISMATCH;
   r = mrb_range_ptr(mrb, range);
 
   beg = mrb_int(mrb, RANGE_BEG(r));
@@ -412,11 +412,11 @@ mrb_range_beg_len(mrb_state *mrb, mrb_value range, mrb_int *begp, mrb_int *lenp,
 
   if (beg < 0) {
     beg += len;
-    if (beg < 0) return 2;
+    if (beg < 0) return MRB_RANGE_OUT;
   }
 
   if (trunc) {
-    if (beg > len) return 2;
+    if (beg > len) return MRB_RANGE_OUT;
     if (end > len) end = len;
   }
 
@@ -427,7 +427,7 @@ mrb_range_beg_len(mrb_state *mrb, mrb_value range, mrb_int *begp, mrb_int *lenp,
 
   *begp = beg;
   *lenp = len;
-  return 1;
+  return MRB_RANGE_OK;
 }
 
 void

--- a/src/string.c
+++ b/src/string.c
@@ -1041,9 +1041,9 @@ num_index:
 
           len = RSTRING_CHAR_LEN(str);
           switch (mrb_range_beg_len(mrb, indx, &beg, &len, len, TRUE)) {
-          case 1:
+          case MRB_RANGE_OK:
             return str_subseq(mrb, str, beg, len);
-          case 2:
+          case MRB_RANGE_OUT:
             return mrb_nil_value();
           default:
             break;


### PR DESCRIPTION
Since the `mrb_range_beg_len()` function is `MRB_API`, I think it is better to return an enumeration value rather than returning a magic number.

The name written in this patch may be used in the future, so I think it is better to add one more word.
But I didn't think of a good name.
