### PR TITLE
Rename `Kernel#__method__` to `Kernel#__callee__`

### DIFF
--- a/mrbgems/mruby-enumerator/mrblib/enumerator.rb
+++ b/mrbgems/mruby-enumerator/mrblib/enumerator.rb
@@ -596,7 +596,7 @@ module Kernel
   #       def repeat(n)
   #         raise ArgumentError, "#{n} is negative!" if n < 0
   #         unless block_given?
-  #           return to_enum(__method__, n) do # __method__ is :repeat here
+  #           return to_enum(__callee__, n) do # __callee__ is :repeat here
   #             sz = size     # Call size and multiply by n...
   #             sz * n if sz  # but return nil if size itself is nil
   #           end

--- a/mrbgems/mruby-kernel-ext/src/kernel.c
+++ b/mrbgems/mruby-kernel-ext/src/kernel.c
@@ -63,15 +63,14 @@ mrb_f_caller(mrb_state *mrb, mrb_value self)
 
 /*
  *  call-seq:
- *     __method__         -> symbol
+ *     __callee__         -> symbol
  *
- *  Returns the name at the definition of the current method as a
- *  Symbol.
+ *  Returns the called name of the current method as a Symbol.
  *  If called outside of a method, it returns <code>nil</code>.
  *
  */
 static mrb_value
-mrb_f_method(mrb_state *mrb, mrb_value self)
+mrb_f_callee(mrb_state *mrb, mrb_value self)
 {
   mrb_callinfo *ci = mrb->c->ci;
   ci--;
@@ -213,7 +212,7 @@ mrb_mruby_kernel_ext_gem_init(mrb_state *mrb)
 
   mrb_define_module_function(mrb, krn, "fail", mrb_f_raise, MRB_ARGS_OPT(2));
   mrb_define_module_function(mrb, krn, "caller", mrb_f_caller, MRB_ARGS_OPT(2));
-  mrb_define_method(mrb, krn, "__method__", mrb_f_method, MRB_ARGS_NONE());
+  mrb_define_method(mrb, krn, "__callee__", mrb_f_callee, MRB_ARGS_NONE());
   mrb_define_module_function(mrb, krn, "Integer", mrb_f_integer, MRB_ARGS_ANY());
 #ifndef MRB_WITHOUT_FLOAT
   mrb_define_module_function(mrb, krn, "Float", mrb_f_float, MRB_ARGS_REQ(1));

--- a/mrbgems/mruby-kernel-ext/test/kernel.rb
+++ b/mrbgems/mruby-kernel-ext/test/kernel.rb
@@ -34,13 +34,22 @@ assert('Kernel.caller, Kernel#caller') do
   assert_raise(TypeError) { c.new.baz(nil) }
 end
 
-assert('Kernel#__method__') do
-  assert_equal(:m, Class.new {def m; __method__; end}.new.m)
-  assert_equal(:m, Class.new {define_method(:m) {__method__}}.new.m)
+assert('Kernel#__callee__') do
+  c = Class.new do
+    def m1; __callee__ end
+    define_method(:m2) {__callee__}
+    alias m3 m1
+    alias_method :m4, :m2
+  end
+  assert_equal(:m1, c.new.m1)
+  assert_equal(:m2, c.new.m2)
+  assert_equal(:m3, c.new.m3)
+  assert_equal(:m4, c.new.m4)
+
   c = Class.new do
     [:m1, :m2].each do |m|
       define_method(m) do
-        __method__
+        __callee__
       end
     end
   end


### PR DESCRIPTION
Because the current behavior of `__method__` is equivalent to `__callee__`.

### Example

  ```ruby
  # example.rb
  def src
    __send__(ARGV[0])
  end
  alias dst src
  %w[src dst].each {|n| puts "call #{n} => #{__send__(n).inspect}"}
  ```

#### Ruby:

    $ ruby example.rb __method__
    call src => :src
    call dst => :src

    $ ruby example.rb __callee__
    call src => :src
    call dst => :dst

#### mruby:

    $ bin/mruby example.rb __method__
    call src => :src
    call dst => :dst