### PR TITLE
Fix double rounded by negative index for `String#[]`

### DIFF
--- a/src/string.c
+++ b/src/string.c
@@ -449,9 +449,6 @@ str_substr(mrb_state *mrb, mrb_value str, mrb_int beg, mrb_int len)
   if (clen == 0) {
     len = 0;
   }
-  else if (beg < 0) {
-    beg = clen + beg;
-  }
   if (beg > clen) return mrb_nil_value();
   if (beg < 0) {
     beg += clen;


### PR DESCRIPTION
- Before patched:
  ```
  $ mruby -e 'p (-12..-1).map { |i| "Hello"[i] }.join'
  "HelloHello"
  ```
- After patched:
  ```
  $ mruby -e 'p (-12..-1).map { |i| "Hello"[i] }.join'
  "Hello"
  ```