### PR TITLE
Remove `mrb_alloca()` function

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -228,7 +228,6 @@ typedef struct mrb_state {
   struct RClass *symbol_class;
   struct RClass *kernel_module;
 
-  struct alloca_header *mems;
   mrb_gc gc;
 
 #ifdef MRB_METHOD_CACHE
@@ -1247,7 +1246,6 @@ MRB_API void mrb_pool_close(struct mrb_pool*);
 MRB_API void* mrb_pool_alloc(struct mrb_pool*, size_t);
 MRB_API void* mrb_pool_realloc(struct mrb_pool*, void*, size_t oldlen, size_t newlen);
 MRB_API mrb_bool mrb_pool_can_realloc(struct mrb_pool*, void*, size_t);
-MRB_API void* mrb_alloca(mrb_state *mrb, size_t);
 
 MRB_API void mrb_state_atexit(mrb_state *mrb, mrb_atexit_func func);
 

--- a/src/state.c
+++ b/src/state.c
@@ -57,38 +57,6 @@ mrb_default_allocf(mrb_state *mrb, void *p, size_t size, void *ud)
   }
 }
 
-struct alloca_header {
-  struct alloca_header *next;
-  char buf[1];
-};
-
-MRB_API void*
-mrb_alloca(mrb_state *mrb, size_t size)
-{
-  struct alloca_header *p;
-
-  p = (struct alloca_header*) mrb_malloc(mrb, sizeof(struct alloca_header)+size);
-  p->next = mrb->mems;
-  mrb->mems = p;
-  return (void*)p->buf;
-}
-
-static void
-mrb_alloca_free(mrb_state *mrb)
-{
-  struct alloca_header *p;
-  struct alloca_header *tmp;
-
-  if (mrb == NULL) return;
-  p = mrb->mems;
-
-  while (p) {
-    tmp = p;
-    p = p->next;
-    mrb_free(mrb, tmp);
-  }
-}
-
 MRB_API mrb_state*
 mrb_open(void)
 {
@@ -256,7 +224,6 @@ mrb_close(mrb_state *mrb)
   mrb_gc_free_gv(mrb);
   mrb_free_context(mrb, mrb->root_c);
   mrb_free_symtbl(mrb);
-  mrb_alloca_free(mrb);
   mrb_gc_destroy(mrb, &mrb->gc);
   mrb_free(mrb, mrb);
 }


### PR DESCRIPTION
When I found this function, I expected it to behave the same as the `alloca(3)` function, but it is accually the `mrb_alloca()` function does not free the heap until the `mrb_close()` function is called.

Also, even if it is deleted, it can be replaced with the combination of the `MRB_TT_DATA` object and the `mrb_gv_set()` function if it is sure necessary.

----

I suggest removing function or changing the function name (This patch is removing function).

As far as I inspected it lightly, it is not used in mruby core and core gems.
In mgem-list's mruby gems, only `mruby-dll` has referenced `mrb_alloca()` symbol from `mruby.def`.
