### PR TITLE
Use `$undefined.equal?(obj2)` instead of `obj2 == $undefined` in `ass…

### DIFF
--- a/test/assert.rb
+++ b/test/assert.rb
@@ -149,7 +149,7 @@ end
 def assert_operator(*args); _assert_operator(true, *args) end
 def assert_not_operator(*args); _assert_operator(false, *args) end
 def _assert_operator(affirmed, obj1, op, obj2 = $undefined, msg = nil)
-  return _assert_predicate(affirmed, obj1, op, msg) if obj2 == $undefined
+  return _assert_predicate(affirmed, obj1, op, msg) if $undefined.equal?(obj2)
   unless ret = obj1.__send__(op, obj2) == affirmed
     diff = "    Expected #{obj1.inspect} to #{'not ' unless affirmed}be #{op} #{obj2.inspect}."
   end


### PR DESCRIPTION
…ert.rb`

In case `obj2.==` is broken.