### PR TITLE
Fix `Rational#==(Complex)`

### DIFF
--- a/mrbgems/mruby-rational/mrblib/rational.rb
+++ b/mrbgems/mruby-rational/mrblib/rational.rb
@@ -62,6 +62,19 @@ class Rational < Numeric
       nil
     end
   end
+
+  def ==(rhs)
+    if rhs.is_a?(Integral)
+      return numerator == rhs if denominator == 1
+      rhs = Rational(rhs)
+    end
+
+    if rhs.is_a?(Rational)
+      numerator * rhs.denominator == denominator * rhs.numerator
+    else
+      rhs == self
+    end
+  end
 end
 
 class Numeric


### PR DESCRIPTION
Consider a Numreic class like `Complex` that does not have `<=>` but `==`
works (`0i == 0r` is `true`).