### PR TITLE
Prohibit `MRB_INT64` on 32-bit architecture

### DIFF
--- a/include/mrbconf.h
+++ b/include/mrbconf.h
@@ -63,6 +63,10 @@
 # endif
 #endif
 
+#if defined(MRB_32BIT) && defined(MRB_INT64)
+#error MRB_INT64 cannot be used on 32-bit architecture
+#endif
+
 #define MRB_COMPLEX_NUMBERS
 #define MRB_RATIONAL_NUMBERS
 

--- a/include/mruby/boxing_word.h
+++ b/include/mruby/boxing_word.h
@@ -11,10 +11,6 @@
 # error MRB_INT16 is too small for MRB_WORD_BOXING.
 #endif
 
-#if defined(MRB_INT64) && !defined(MRB_64BIT)
-#error MRB_INT64 cannot be used with MRB_WORD_BOXING in 32-bit mode.
-#endif
-
 #ifndef MRB_WITHOUT_FLOAT
 struct RFloat {
   MRB_OBJECT_HEADER;


### PR DESCRIPTION
I think `mrb_int` size should be less than or equal to pointer size. In the
case of `MRB_INT64` on 32-bit architecture, `struct RString` etc sizes
exceed 6 words at least for now.