### PR TITLE
New Emscriptem WebAssembly target + examples

### DIFF
--- a/examples/emcc-wasm/compile_to_wasm.sh
+++ b/examples/emcc-wasm/compile_to_wasm.sh
@@ -1,0 +1,27 @@
+#/usr/bin/env bash
+port=8000
+build_dir=../../build
+
+which emcc
+ret=$?
+if [ $ret -ne 0  ]; then
+  echo "emcc compiler could not be found.\nInstall Emscripten or source emsdk_set_env.sh file. Exiting."
+  exit $ret
+fi
+
+for f in hello_world fib; do
+  echo -n "Compiling $f.rb to $f.wasm..."
+  ../../bin/mrbc -Btest_symbol $f.rb
+  emcc -D CFILE="<$f.c>" -I../../include -I. -o $f.bc stub.c
+  emcc -o $f.html $f.bc ../../build/emcc-wasm/lib/libmruby.bc
+  echo "done"
+done
+
+echo ""
+echo "Launch a minimal Web server:"
+echo "ruby -run -e httpd . -p $port"
+echo ""
+echo "and navigate to:"
+for f in hello_world fib; do
+ echo "http://localhost:8000/$f.html"
+done

--- a/examples/emcc-wasm/fib.rb
+++ b/examples/emcc-wasm/fib.rb
@@ -1,0 +1,7 @@
+
+def fib n
+  return n if n < 2
+  fib(n-2) + fib(n-1)
+end
+
+puts 1.upto(15).collect {|i| fib(i)}.join(',')

--- a/examples/emcc-wasm/hello_world.rb
+++ b/examples/emcc-wasm/hello_world.rb
@@ -1,0 +1,1 @@
+puts "Hello World!"

--- a/examples/emcc-wasm/stub.c
+++ b/examples/emcc-wasm/stub.c
@@ -1,0 +1,13 @@
+#include <mruby.h>
+#include <mruby/irep.h>
+#include CFILE
+
+int
+main(void)
+{
+  mrb_state *mrb = mrb_open();
+  if (!mrb) { /* handle error */ }
+  mrb_load_irep(mrb, test_symbol);
+  mrb_close(mrb);
+  return 0;
+}

--- a/examples/targets/build_config_emcc_wasm.rb
+++ b/examples/targets/build_config_emcc_wasm.rb
@@ -1,0 +1,37 @@
+MRuby::Build.new do |conf|
+  # load specific toolchain settings
+
+  # Gets set by the VS command prompts.
+  if ENV['VisualStudioVersion'] || ENV['VSINSTALLDIR']
+    toolchain :visualcpp
+  else
+    toolchain :gcc
+  end
+
+  # include the default GEMs
+  conf.gembox 'default'
+end
+
+
+# Define cross build settings
+MRuby::CrossBuild.new('emcc-wasm') do |conf|
+  toolchain :gcc
+
+  conf.cc.command = 'emcc'
+  #conf.cc.flags << "-m32"
+  conf.linker.command = 'emcc'
+  #conf.linker.flags << "-m32"
+  conf.archiver.command = 'emcc'
+  conf.archiver.archive_options = '-o %{outfile} %{objs}'
+
+  conf.exts do |exts|
+    exts.object = '.o'
+    exts.executable = ''
+    exts.library = '.bc' # It's LLVM bit code
+  end
+
+  conf.build_mrbtest_lib_only
+
+  conf.gembox 'default'
+end
+


### PR DESCRIPTION
This is a follow-up to the email I sent Matz last week asking if there was any plan to running Ruby on WebAssembly. I decided to give it a shot. In this pull request you'll find:

- A new crossbuild file to target Emscripten WebAssembly. For this MRUBY_CONFIG to work you need to install Emscripten on your machine first (emcc compiler)

- Once you have build the emcc-wasm target go to examples/emcc-wasm and run the compile script to generate the two Web Assembly examples

This proves that we can run mruby in the Emscripten WebAssembly runtime.  This is however "just" a demonstrator as what we are showing here is the RiteVM mruby VM running within the Wasm VM. So from a performance standpoint we could do much better if mruby could generate WebAssembly bitcode. I don't know what's the best way of doing this though. Generate WebAssembly directly or "transpile" RiteVM instructions to WebAssembly bitcode ?

Comments, feedback welcome