### PR TITLE
Fix rational new on 32 bits mode

### DIFF
--- a/mrbgems/mruby-rational/src/rational.c
+++ b/mrbgems/mruby-rational/src/rational.c
@@ -1,30 +1,71 @@
 #include <mruby.h>
 #include <mruby/class.h>
 #include <mruby/string.h>
-#include <mruby/istruct.h>
 
 struct mrb_rational {
   mrb_int numerator;
   mrb_int denominator;
 };
 
-static struct mrb_rational*
-rational_ptr(mrb_value v)
+#if MRB_INT_MAX <= INTPTR_MAX
+
+#define RATIONAL_USE_ISTRUCT
+/* use TT_ISTRUCT */
+#include <mruby/istruct.h>
+
+#define rational_ptr(mrb, v) (struct mrb_rational*)mrb_istruct_ptr(v)
+
+static struct RBasic*
+rational_alloc(mrb_state *mrb, struct RClass *c, struct mrb_rational **p)
 {
-  return (struct mrb_rational*)mrb_istruct_ptr(v);
+  struct RIStruct *s;
+
+  s = (struct RIStruct*)mrb_obj_alloc(mrb, MRB_TT_ISTRUCT, c);
+  *p = (struct mrb_rational*)s->inline_data;
+
+  return (struct RBasic*)s;
 }
+
+#else
+/* use TT_DATA */
+#include <mruby/data.h>
+
+static const struct mrb_data_type mrb_rational_type = {"Rational", mrb_free};
+
+static struct RBasic*
+rational_alloc(mrb_state *mrb, struct RClass *c, struct mrb_rational **p)
+{
+  struct RData *d;
+
+  Data_Make_Struct(mrb, c, struct mrb_rational, &mrb_rational_type, *p, d);
+
+  return (struct RBasic*)d;
+}
+
+static struct mrb_rational*
+rational_ptr(mrb_state *mrb, mrb_value v)
+{
+  struct mrb_rational *p;
+
+  p = DATA_GET_PTR(mrb, v, &mrb_rational_type, struct mrb_rational);
+  if (!p) {
+    mrb_raise(mrb, E_ARGUMENT_ERROR, "uninitialized rational");
+  }
+  return p;
+}
+#endif
 
 static mrb_value
 rational_numerator(mrb_state *mrb, mrb_value self)
 {
-  struct mrb_rational *p = rational_ptr(self);
+  struct mrb_rational *p = rational_ptr(mrb, self);
   return mrb_fixnum_value(p->numerator);
 }
 
 static mrb_value
 rational_denominator(mrb_state *mrb, mrb_value self)
 {
-  struct mrb_rational *p = rational_ptr(self);
+  struct mrb_rational *p = rational_ptr(mrb, self);
   return mrb_fixnum_value(p->denominator);
 }
 
@@ -32,13 +73,12 @@ static mrb_value
 rational_new(mrb_state *mrb, mrb_int numerator, mrb_int denominator)
 {
   struct RClass *c = mrb_class_get(mrb, "Rational");
-  struct RIStruct *s = (struct RIStruct*)mrb_obj_alloc(mrb, MRB_TT_ISTRUCT, c);
-  mrb_value rat = mrb_obj_value(s);
-  struct mrb_rational *p = rational_ptr(rat);
+  struct mrb_rational *p;
+  struct RBasic *rat = rational_alloc(mrb, c, &p);
   p->numerator = numerator;
   p->denominator = denominator;
-  MRB_SET_FROZEN_FLAG(s);
-  return rat;
+  MRB_SET_FROZEN_FLAG(rat);
+  return mrb_obj_value(rat);
 }
 
 static mrb_value
@@ -54,7 +94,7 @@ rational_s_new(mrb_state *mrb, mrb_value self)
 static mrb_value
 rational_to_f(mrb_state *mrb, mrb_value self)
 {
-  struct mrb_rational *p = rational_ptr(self);
+  struct mrb_rational *p = rational_ptr(mrb, self);
   mrb_float f = (mrb_float)p->numerator / (mrb_float)p->denominator;
 
   return mrb_float_value(mrb, f);
@@ -64,7 +104,7 @@ rational_to_f(mrb_state *mrb, mrb_value self)
 static mrb_value
 rational_to_i(mrb_state *mrb, mrb_value self)
 {
-  struct mrb_rational *p = rational_ptr(self);
+  struct mrb_rational *p = rational_ptr(mrb, self);
   return mrb_fixnum_value(p->numerator / p->denominator);
 }
 
@@ -77,7 +117,7 @@ rational_to_r(mrb_state *mrb, mrb_value self)
 static mrb_value
 rational_negative_p(mrb_state *mrb, mrb_value self)
 {
-  struct mrb_rational *p = rational_ptr(self);
+  struct mrb_rational *p = rational_ptr(mrb, self);
   if (p->numerator < 0) {
     return mrb_true_value();
   }
@@ -94,9 +134,10 @@ void mrb_mruby_rational_gem_init(mrb_state *mrb)
 {
   struct RClass *rat;
 
+#ifdef COMPLEX_USE_RATIONAL
   mrb_assert(sizeof(struct mrb_rational) < ISTRUCT_DATA_SIZE);
+#endif
   rat = mrb_define_class(mrb, "Rational", mrb_class_get(mrb, "Numeric"));
-  MRB_SET_INSTANCE_TT(rat, MRB_TT_ISTRUCT);
   mrb_undef_class_method(mrb, rat, "new");
   mrb_define_class_method(mrb, rat, "_new", rational_s_new, MRB_ARGS_REQ(2));
   mrb_define_method(mrb, rat, "numerator", rational_numerator, MRB_ARGS_NONE());


### PR DESCRIPTION
This PR contains the patch of simply halving the numerator and denominator if they do not fit into `mrb_int`.
If this is a problem, please point out.
