### PR TITLE
Remove `Kernel#global_variables` from core

### DIFF
--- a/mrbgems/mruby-metaprog/src/metaprog.c
+++ b/mrbgems/mruby-metaprog/src/metaprog.c
@@ -686,7 +686,7 @@ mrb_mruby_metaprog_gem_init(mrb_state* mrb)
   struct RClass *krn = mrb->kernel_module;
   struct RClass *mod = mrb->module_class;
 
-  mrb_define_method(mrb, krn, "global_variables", mrb_f_global_variables, MRB_ARGS_NONE()); /* 15.3.1.2.4 */
+  mrb_define_method(mrb, krn, "global_variables", mrb_f_global_variables, MRB_ARGS_NONE()); /* 15.3.1.3.14 (15.3.1.2.4) */
   mrb_define_method(mrb, krn, "local_variables", mrb_local_variables, MRB_ARGS_NONE()); /* 15.3.1.3.28 */
 
   mrb_define_method(mrb, krn, "singleton_class", mrb_singleton_class, MRB_ARGS_NONE());

--- a/mrbgems/mruby-metaprog/test/metaprog.rb
+++ b/mrbgems/mruby-metaprog/test/metaprog.rb
@@ -99,6 +99,18 @@ assert('Kernel#singleton_methods', '15.3.1.3.45') do
   assert_equal singleton_methods.class, Array
 end
 
+assert('Kernel.global_variables', '15.3.1.2.4') do
+  assert_equal Array, Kernel.global_variables.class
+end
+
+assert('Kernel#global_variables', '15.3.1.3.14') do
+  variables = global_variables
+  assert_equal Array, variables.class
+  1.upto(9) do |i|
+    assert_equal variables.include?(:"$#{i}"), true
+  end
+end
+
 assert('Kernel.local_variables', '15.3.1.2.7') do
   a, b = 0, 1
   a += b

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -783,7 +783,6 @@ mrb_init_kernel(mrb_state *mrb)
   mrb_define_method(mrb, krn, "extend",                     mrb_obj_extend_m,                MRB_ARGS_ANY());     /* 15.3.1.3.13 */
   mrb_define_method(mrb, krn, "freeze",                     mrb_obj_freeze,                  MRB_ARGS_NONE());
   mrb_define_method(mrb, krn, "frozen?",                    mrb_obj_frozen,                  MRB_ARGS_NONE());
-  mrb_define_method(mrb, krn, "global_variables",           mrb_f_global_variables,          MRB_ARGS_NONE());    /* 15.3.1.3.14 */
   mrb_define_method(mrb, krn, "hash",                       mrb_obj_hash,                    MRB_ARGS_NONE());    /* 15.3.1.3.15 */
   mrb_define_method(mrb, krn, "initialize_copy",            mrb_obj_init_copy,               MRB_ARGS_REQ(1));    /* 15.3.1.3.16 */
   mrb_define_method(mrb, krn, "inspect",                    mrb_obj_inspect,                 MRB_ARGS_NONE());    /* 15.3.1.3.17 */

--- a/test/t/kernel.rb
+++ b/test/t/kernel.rb
@@ -31,10 +31,6 @@ end
 
 # Kernel.eval is provided by the mruby-gem mrbgem. '15.3.1.2.3'
 
-assert('Kernel.global_variables', '15.3.1.2.4') do
-  assert_equal Array, Kernel.global_variables.class
-end
-
 assert('Kernel.iterator?', '15.3.1.2.5') do
   assert_false Kernel.iterator?
 end
@@ -266,10 +262,6 @@ assert('Kernel#frozen?') do
   assert_true 0.0.frozen?
 end
 
-assert('Kernel#global_variables', '15.3.1.3.14') do
-  assert_equal Array, global_variables.class
-end
-
 assert('Kernel#hash', '15.3.1.3.15') do
   assert_equal hash, hash
 end
@@ -486,13 +478,6 @@ assert('Kernel#respond_to_missing?') do
 
   assert_true Test4RespondToMissing.new.respond_to?(:a_method)
   assert_false Test4RespondToMissing.new.respond_to?(:no_method)
-end
-
-assert('Kernel#global_variables') do
-  variables = global_variables
-  1.upto(9) do |i|
-    assert_equal variables.include?(:"$#{i}"), true
-  end
 end
 
 assert('stack extend') do


### PR DESCRIPTION
This method is defined in `mruby-metaprog` gem.