### PR TITLE
Replace obsolete macros

### DIFF
--- a/mrbgems/mruby-io/src/file_test.c
+++ b/mrbgems/mruby-io/src/file_test.c
@@ -44,7 +44,7 @@ mrb_stat0(mrb_state *mrb, mrb_value obj, struct stat *st, int do_lstat)
 {
   if (mrb_obj_is_kind_of(mrb, obj, mrb_class_get(mrb, "IO"))) {
     struct mrb_io *fptr;
-    fptr = (struct mrb_io *)mrb_get_datatype(mrb, obj, &mrb_io_type);
+    fptr = (struct mrb_io *)mrb_data_get_ptr(mrb, obj, &mrb_io_type);
 
     if (fptr && fptr->fd >= 0) {
       return fstat(fptr->fd, st);

--- a/mrbgems/mruby-io/src/io.c
+++ b/mrbgems/mruby-io/src/io.c
@@ -79,7 +79,7 @@ io_get_open_fptr(mrb_state *mrb, mrb_value self)
 {
   struct mrb_io *fptr;
 
-  fptr = (struct mrb_io *)mrb_get_datatype(mrb, self, &mrb_io_type);
+  fptr = (struct mrb_io *)mrb_data_get_ptr(mrb, self, &mrb_io_type);
   if (fptr == NULL) {
     mrb_raise(mrb, E_IO_ERROR, "uninitialized stream.");
   }
@@ -955,7 +955,7 @@ mrb_value
 mrb_io_closed(mrb_state *mrb, mrb_value io)
 {
   struct mrb_io *fptr;
-  fptr = (struct mrb_io *)mrb_get_datatype(mrb, io, &mrb_io_type);
+  fptr = (struct mrb_io *)mrb_data_get_ptr(mrb, io, &mrb_io_type);
   if (fptr == NULL || fptr->fd >= 0) {
     return mrb_false_value();
   }


### PR DESCRIPTION
`mrb_get_datatype()` used in `mruby-io` is obsoleted by `include/mruby/data.h`.

https://github.com/mruby/mruby/blob/2847692d5900745630e1db484884a0bb5fffba7e/include/mruby/data.h#L58-L60