### PR TITLE
Remove "Check the usage of a NUL character" test

### DIFF
--- a/test/t/string.rb
+++ b/test/t/string.rb
@@ -694,10 +694,6 @@ assert('String interpolation (mrb_str_concat for shared strings)') do
   assert_equal "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA:", "#{a}:"
 end
 
-assert('Check the usage of a NUL character') do
-  "qqq\0ppp"
-end
-
 assert('String#bytes') do
   str1 = "hello"
   bytes1 = [104, 101, 108, 108, 111]


### PR DESCRIPTION
Because there is not assertion in this test and NUL character literal is
used in other tests.