### PR TITLE
Method visibility implementation

### DIFF
--- a/doc/guides/mrbconf.md
+++ b/doc/guides/mrbconf.md
@@ -154,6 +154,11 @@ largest value of required alignment.
 * Return `TRUE` if `ptr` is in read-only section, otherwise return `FALSE`.
 
 ## Other configuration.
+
+`MRB_ENABLE_METHOD_VISIBILITY`
+* Adds method visibility support.
+* Cannot be used with `MRB_METHOD_TABLE_INLINE`.
+
 `MRB_UTF8_STRING`
 * Adds UTF-8 encoding support to character-oriented String instance methods.
 * If it isn't defined, they only support the US-ASCII encoding.

--- a/include/mrbconf.h
+++ b/include/mrbconf.h
@@ -74,6 +74,9 @@
 # endif
 #endif
 
+/* enable support for method visibility */
+#define MRB_ENABLE_METHOD_VISIBILITY
+
 /* represent mrb_value in boxed double; conflict with MRB_USE_FLOAT and MRB_WITHOUT_FLOAT */
 //#define MRB_NAN_BOXING
 

--- a/include/mruby/class.h
+++ b/include/mruby/class.h
@@ -78,6 +78,7 @@ MRB_API struct RClass* mrb_define_module_id(mrb_state*, mrb_sym);
 MRB_API struct RClass *mrb_vm_define_class(mrb_state*, mrb_value, mrb_value, mrb_sym);
 MRB_API struct RClass *mrb_vm_define_module(mrb_state*, mrb_value, mrb_sym);
 MRB_API void mrb_define_method_raw(mrb_state*, struct RClass*, mrb_sym, mrb_method_t);
+MRB_API void mrb_define_method_id_with_visibility(mrb_state *mrb, struct RClass *c, mrb_sym mid, mrb_func_t func, mrb_aspec aspec, enum mrb_method_visibility method_visibility);
 MRB_API void mrb_define_method_id(mrb_state *mrb, struct RClass *c, mrb_sym mid, mrb_func_t func, mrb_aspec aspec);
 MRB_API void mrb_alias_method(mrb_state*, struct RClass *c, mrb_sym a, mrb_sym b);
 

--- a/mrbgems/mruby-metaprog/src/metaprog.c
+++ b/mrbgems/mruby-metaprog/src/metaprog.c
@@ -165,7 +165,7 @@ mrb_local_variables(mrb_state *mrb, mrb_value self)
 KHASH_DECLARE(st, mrb_sym, char, FALSE)
 
 static void
-method_entry_loop(mrb_state *mrb, struct RClass* klass, khash_t(st)* set, mrb_method_flag_t flag)
+method_entry_loop(mrb_state *mrb, struct RClass* klass, khash_t(st)* set, int flag)
 {
   khint_t i;
 
@@ -187,7 +187,7 @@ method_entry_loop(mrb_state *mrb, struct RClass* klass, khash_t(st)* set, mrb_me
 }
 
 static mrb_value
-mrb_class_instance_method_list(mrb_state *mrb, mrb_bool recur, struct RClass* klass, mrb_method_flag_t flag)
+mrb_class_instance_method_list(mrb_state *mrb, mrb_bool recur, struct RClass* klass, int flag)
 {
   khint_t i;
   mrb_value ary;
@@ -225,7 +225,7 @@ mrb_class_instance_method_list(mrb_state *mrb, mrb_bool recur, struct RClass* kl
 }
 
 static mrb_value
-mrb_obj_methods(mrb_state *mrb, mrb_bool recur, mrb_value obj, mrb_method_flag_t flag)
+mrb_obj_methods(mrb_state *mrb, mrb_bool recur, mrb_value obj, int flag)
 {
   return mrb_class_instance_method_list(mrb, recur, mrb_class(mrb, obj), flag);
 }

--- a/mrbgems/mruby-metaprog/test/metaprog.rb
+++ b/mrbgems/mruby-metaprog/test/metaprog.rb
@@ -75,21 +75,110 @@ assert('Kernel#instance_variables', '15.3.1.3.23') do
 end
 
 assert('Kernel#methods', '15.3.1.3.31') do
-  assert_equal Array, methods.class
+  if Mrbtest::METHOD_VISIBILITY
+    class A1
+      def f; true; end
+      protected
+      def g; true; end
+      private 
+      def h; true; end
+    end
+    class B1 < A1
+      def a; true; end
+      protected
+      def b; true; end
+      private
+      def c; true; end
+    end
+    b = B1.new
+    class << b
+      def i; true; end
+      protected
+      def j; true; end
+      private
+      def k; true; end
+    end
+    pmethods = b.methods
+    assert_equal Array, pmethods.class
+    assert_true  pmethods.include?(:f)
+    assert_true  pmethods.include?(:g)
+    assert_false pmethods.include?(:h)
+    assert_true  pmethods.include?(:a)
+    assert_true  pmethods.include?(:b)
+    assert_false pmethods.include?(:c)
+    assert_true  pmethods.include?(:i)
+    assert_true  pmethods.include?(:j)
+    assert_false pmethods.include?(:k)
+    pmethods = b.methods(false)
+    assert_equal Array, pmethods.class
+    assert_equal 2, pmethods.size
+    assert_true  pmethods.include?(:i)
+    assert_true  pmethods.include?(:j)
+  else
+    assert_equal Array, public_methods.class
+  end
 end
 
 assert('Kernel#private_methods', '15.3.1.3.36') do
-  assert_equal Array, private_methods.class
+  if Mrbtest::METHOD_VISIBILITY
+    class A2
+      def f; true; end
+      private
+      def g; true; end
+    end
+    class B2 < A2
+      private
+      def h; true; end
+    end
+    b = B2.new
+    pmethods = b.private_methods
+    assert_equal Array, pmethods.class
+    assert_true  pmethods.include?(:g)
+    assert_true  pmethods.include?(:h)
+    assert_false pmethods.include?(:f)
+    pmethods = b.private_methods(false)
+    assert_equal Array, pmethods.class
+    assert_equal [:h], pmethods
+  else
+    assert_equal Array, public_methods.class
+  end
 end
 
 assert('Kernel#protected_methods', '15.3.1.3.37') do
-  assert_equal Array, protected_methods.class
+  if Mrbtest::METHOD_VISIBILITY
+    class A3
+      def f; true; end
+      protected
+      def g; true; end
+    end
+    class B3 < A3
+      protected
+      def h; true; end
+    end
+    b = B3.new
+    pmethods = b.protected_methods
+    assert_equal Array, pmethods.class
+    assert_equal 2, pmethods.size
+    assert_true  pmethods.include?(:g)
+    assert_true  pmethods.include?(:h)
+    pmethods = b.protected_methods(false)
+    assert_equal Array, pmethods.class
+    assert_equal [:h], pmethods
+  else
+    assert_equal Array, public_methods.class
+  end
 end
 
 assert('Kernel#public_methods', '15.3.1.3.38') do
   assert_equal Array, public_methods.class
   class Foo
     def foo
+    end
+    if Mrbtest::METHOD_VISIBILITY
+      private
+      def f; end
+      protected
+      def g; end
     end
   end
   assert_equal [:foo], Foo.new.public_methods(false)

--- a/mrbgems/mruby-proc-ext/test/proc.c
+++ b/mrbgems/mruby-proc-ext/test/proc.c
@@ -19,6 +19,7 @@ proc_new_cfunc_with_env(mrb_state *mrb, mrb_value self)
   n_val = mrb_symbol_value(n);
   p = mrb_proc_new_cfunc_with_env(mrb, return_func_name, 1, &n_val);
   MRB_METHOD_FROM_PROC(m, p);
+  MRB_METHOD_SET_VISIBILITY(m, MRB_METHOD_PUBLIC);
   mrb_define_method_raw(mrb, mrb_class_ptr(self), n, m);
   return self;
 }
@@ -41,6 +42,7 @@ cfunc_env_get(mrb_state *mrb, mrb_value self)
   mrb_get_args(mrb, "na", &n, &argv, &argc);
   p = mrb_proc_new_cfunc_with_env(mrb, return_env, argc, argv);
   MRB_METHOD_FROM_PROC(m, p);
+  MRB_METHOD_SET_VISIBILITY(m, MRB_METHOD_PUBLIC);
   mrb_define_method_raw(mrb, mrb_class_ptr(self), n, m);
   return self;
 }

--- a/mrbgems/mruby-struct/src/struct.c
+++ b/mrbgems/mruby-struct/src/struct.c
@@ -190,8 +190,10 @@ make_struct_define_accessors(mrb_state *mrb, mrb_value members, struct RClass *c
       struct RProc *aref = mrb_proc_new_cfunc_with_env(mrb, mrb_struct_ref, 1, &at);
       struct RProc *aset = mrb_proc_new_cfunc_with_env(mrb, mrb_struct_set_m, 1, &at);
       MRB_METHOD_FROM_PROC(m, aref);
+      MRB_METHOD_SET_VISIBILITY(m, MRB_METHOD_PUBLIC);
       mrb_define_method_raw(mrb, c, id, m);
       MRB_METHOD_FROM_PROC(m, aset);
+      MRB_METHOD_SET_VISIBILITY(m, MRB_METHOD_PUBLIC);
       mrb_define_method_raw(mrb, c, mrb_id_attrset(mrb, id), m);
       mrb_gc_arena_restore(mrb, ai);
     }

--- a/mrbgems/mruby-test/driver.c
+++ b/mrbgems/mruby-test/driver.c
@@ -231,6 +231,12 @@ mrb_init_test_driver(mrb_state *mrb, mrb_bool verbose)
 #endif
 #endif
 
+#ifdef MRB_ENABLE_METHOD_VISIBILITY
+  mrb_define_const(mrb, mrbtest, "METHOD_VISIBILITY", mrb_true_value());
+#else
+  mrb_define_const(mrb, mrbtest, "METHOD_VISIBILITY", mrb_false_value());
+#endif
+
   if (verbose) {
     mrb_gv_set(mrb, mrb_intern_lit(mrb, "$mrbtest_verbose"), mrb_true_value());
   }

--- a/src/class.c
+++ b/src/class.c
@@ -1723,7 +1723,7 @@ mrb_obj_respond_to_with_private(mrb_state *mrb, struct RClass* c, mrb_sym mid, m
     return FALSE;
   }
 #ifdef MRB_ENABLE_METHOD_VISIBILITY
-  if (!priv && !MRB_IS_METHOD_PUBLIC(m)) {
+  if (priv == FALSE && !MRB_IS_METHOD_PUBLIC(m)) {
     return FALSE;
   }
 #endif

--- a/src/class.c
+++ b/src/class.c
@@ -1431,6 +1431,7 @@ mrb_method_search_vm(mrb_state *mrb, struct RClass **cp, mrb_sym mid)
     c = c->super;
   }
   MRB_METHOD_FROM_PROC(m, NULL);
+  MRB_METHOD_SET_VISIBILITY(m, MRB_METHOD_PUBLIC);
   return m;                  /* no method */
 }
 

--- a/src/class.c
+++ b/src/class.c
@@ -1723,7 +1723,7 @@ mrb_obj_respond_to_with_private(mrb_state *mrb, struct RClass* c, mrb_sym mid, m
     return FALSE;
   }
 #ifdef MRB_ENABLE_METHOD_VISIBILITY
-  if (priv == FALSE && !MRB_IS_METHOD_PUBLIC(m)) {
+  if (!priv && !MRB_IS_METHOD_PUBLIC(m)) {
     return FALSE;
   }
 #endif

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -701,9 +701,9 @@ mrb_obj_missing(mrb_state *mrb, mrb_value mod)
 #endif
 
 static inline mrb_bool
-basic_obj_respond_to(mrb_state *mrb, mrb_value obj, mrb_sym id, int pub)
+basic_obj_respond_to(mrb_state *mrb, mrb_value obj, mrb_sym id, mrb_bool priv)
 {
-  return mrb_respond_to(mrb, obj, id);
+  return mrb_respond_to_with_private(mrb, obj, id, priv);
 }
 
 /* 15.3.1.3.43 */
@@ -729,7 +729,7 @@ obj_respond_to(mrb_state *mrb, mrb_value self)
   mrb_bool priv = FALSE, respond_to_p;
 
   mrb_get_args(mrb, "n|b", &id, &priv);
-  respond_to_p = basic_obj_respond_to(mrb, self, id, !priv);
+  respond_to_p = basic_obj_respond_to(mrb, self, id, priv);
   if (!respond_to_p) {
     rtm_id = mrb_intern_lit(mrb, "respond_to_missing?");
     if (basic_obj_respond_to(mrb, self, rtm_id, !priv)) {

--- a/src/proc.c
+++ b/src/proc.c
@@ -306,6 +306,7 @@ mrb_init_proc(mrb_state *mrb)
 
   p = mrb_proc_new(mrb, call_irep);
   MRB_METHOD_FROM_PROC(m, p);
+  MRB_METHOD_SET_VISIBILITY(m, MRB_METHOD_PUBLIC);
   mrb_define_method_raw(mrb, mrb->proc_class, mrb_intern_lit(mrb, "call"), m);
   mrb_define_method_raw(mrb, mrb->proc_class, mrb_intern_lit(mrb, "[]"), m);
 

--- a/src/vm.c
+++ b/src/vm.c
@@ -1416,11 +1416,11 @@ RETRY_TRY_BLOCK:
         if (MRB_METHOD_UNDEF_P(m) || (missing == mrb->c->ci->mid && mrb_obj_eq(mrb, regs[0], recv))) {
           mrb_value args = (argc < 0) ? regs[a+1] : mrb_ary_new_from_values(mrb, c, regs+a+1);
           ERR_PC_SET(mrb);
-          if (is_method_unreachable == FALSE) {
+          if (!is_method_unreachable) {
             mrb_method_missing(mrb, mid, recv, args);
           } else {
 #ifdef MRB_ENABLE_METHOD_VISIBILITY
-            if (is_method_private == TRUE) {
+            if (is_method_private) {
               mrb_no_method_error(mrb, mid, args, "private method '%S' called", mrb_sym2str(mrb, mid));
             } else {
               mrb_no_method_error(mrb, mid, args, "protected method '%S' called", mrb_sym2str(mrb, mid));

--- a/src/vm.c
+++ b/src/vm.c
@@ -1416,11 +1416,11 @@ RETRY_TRY_BLOCK:
         if (MRB_METHOD_UNDEF_P(m) || (missing == mrb->c->ci->mid && mrb_obj_eq(mrb, regs[0], recv))) {
           mrb_value args = (argc < 0) ? regs[a+1] : mrb_ary_new_from_values(mrb, c, regs+a+1);
           ERR_PC_SET(mrb);
-          if (!is_method_unreachable) {
+          if (is_method_unreachable == FALSE) {
             mrb_method_missing(mrb, mid, recv, args);
           } else {
 #ifdef MRB_ENABLE_METHOD_VISIBILITY
-            if (is_method_private) {
+            if (is_method_private == TRUE) {
               mrb_no_method_error(mrb, mid, args, "private method '%S' called", mrb_sym2str(mrb, mid));
             } else {
               mrb_no_method_error(mrb, mid, args, "protected method '%S' called", mrb_sym2str(mrb, mid));

--- a/test/t/kernel.rb
+++ b/test/t/kernel.rb
@@ -422,6 +422,9 @@ assert('Kernel#respond_to?', '15.3.1.3.43') do
 
     def test_method; end
     undef test_method
+
+    private
+    def private_method; end
   end
 
   assert_raise TypeError do
@@ -440,6 +443,11 @@ assert('Kernel#respond_to?', '15.3.1.3.43') do
   assert_true Test4RespondTo.new.respond_to?(:valid_method)
   assert_true Test4RespondTo.new.respond_to?('valid_method')
   assert_false Test4RespondTo.new.respond_to?(:test_method)
+
+  if Mrbtest::METHOD_VISIBILITY
+    assert_false Test4RespondTo.new.respond_to?(:private_method)
+    assert_true  Test4RespondTo.new.respond_to?(:private_method, true)
+  end
 end
 
 assert('Kernel#to_s', '15.3.1.3.46') do

--- a/test/t/methods.rb
+++ b/test/t/methods.rb
@@ -107,3 +107,221 @@ assert('The undef statement (method undefined)', '13.3.7 a) 5)') do
     undef :non_existing_method
   end
 end
+
+assert('Visibility') do
+  class A
+    private
+    def private_method
+      true
+    end
+    public
+    def public_method
+      true
+    end
+    protected
+    def protected_method
+      true
+    end
+
+    private
+    def call_private_and_protected_from_public
+      private_method && protected_method
+    end
+    public :call_private_and_protected_from_public
+  end
+  a = A.new
+  assert_raise(NoMethodError, 'Call private method') do
+    a.private_method
+  end
+  assert_raise(NoMethodError, 'Call protected method') do
+    a.protected_method
+  end
+  assert_true(a.__send__(:private_method), 'Call private method (send)')
+  assert_true(a.__send__(:protected_method), 'Call protected method (send)')
+  assert_true(a.public_method, 'Call public method')
+  assert_true(a.call_private_and_protected_from_public, 'Call private and protected methods from public method')
+
+  class B < A
+    def super_private_from_public
+      private_method
+    end
+    def super_protected_from_public
+      protected_method
+    end
+  end
+  b = B.new 
+  assert_true(b.super_private_from_public, 'Call private method from child class')
+  assert_true(b.super_protected_from_public, 'Call protected method from child class')
+  
+  class C < A
+    def private_method
+      super
+    end
+    def protected_method
+      super
+    end
+  end
+  c = C.new
+  assert_true(c.private_method, 'Call private super method')
+  assert_true(c.protected_method, 'Call protected super method')
+
+  class D < A
+    public :private_method
+  end
+  d = D.new
+  assert_true(d.private_method, 'Redefine visibility in child class')
+
+  class A
+    public
+    def private_method
+      false
+    end
+  end
+  assert_false(d.private_method, 'Redefine implementation of private method')
+
+  class A1
+    private
+    def f(a)
+      a
+    end
+    
+    def g(&b)
+      b.call
+    end
+  end
+
+  class A2 < A1
+    public :f, :g
+  end
+
+  a2 = A2.new
+  assert_true(a2.f(true), 'Redefine visibility (with parameters)')
+  # assert_true(a2.g { true })
+  
+  module M
+    private
+    def private_method
+      true
+    end
+    protected
+    def protected_method
+      true
+    end
+  end
+  
+  class AM
+    include M
+  end
+
+  class BM < AM
+    def test_private
+      private_method
+    end
+
+    def test_protected
+      protected_method
+    end
+  end
+
+  bm = BM.new
+  assert_true(bm.test_private)
+  assert_true(bm.test_protected)
+
+  def bm.singleton_m 
+    test_private
+  end
+
+  assert_true(bm.singleton_m)
+
+  class << bm
+    private :singleton_m
+  end
+
+  assert_raise(NoMethodError) do
+    bm.singleton_m
+  end
+
+  class CM
+  end
+
+  cm = CM.new
+
+  class << cm
+    include M
+    def test_private
+        private_method
+    end
+  end
+
+  assert_true(cm.test_private) 
+
+  class DM
+    def f
+      g
+    end
+  end
+
+  dm = DM.new
+
+  class << dm
+    private
+    def g
+      true
+    end
+  end
+
+  assert_raise(NoMethodError) do
+    dm.g
+  end
+
+  assert_true(dm.f)
+
+  class E
+    private
+    define_method(:f) { true }
+  end
+
+  e = E.new
+
+  assert_raise(NoMethodError) do
+    e.f
+  end
+
+  class F
+    private
+    -> () { F.define_method(:f) { true } }.call
+  end
+
+  f = F.new
+
+  assert_raise(NoMethodError) do
+    f.f
+  end
+
+  class G1
+  end
+
+  class G2
+    private
+     -> () { G1.define_method(:f) { true } }.call
+  end
+
+  g1 = G1.new
+  assert_true(g1.f)
+
+  class H
+    private
+    def self.f; true; end
+  end
+
+  assert_true(H.f)
+
+  class << H
+    private :f
+  end
+
+  assert_raise(NoMethodError) do
+    H.f
+  end
+
+end if Mrbtest::METHOD_VISIBILITY


### PR DESCRIPTION
I implemented method visibility (public/private/protected) support for mruby. I think this function is quite an important part of the language.
There may still be errors in it, because I implemented it mostly intuitively.

Features of the implementation:
- It is optional (can be turned off). In the off state, it has a (nearly) zero impact on performance.
- Cannot be used with `MRB_METHOD_TABLE_INLINE`.
- It has slight differences with cruby (for example, it is possible to call private methods through `self` (although, in humble my opinion, this is quite a correct behavior)).

I would be happy if my humble efforts help someone.