### PR TITLE
`Kernel#global_variables` should not include undefined `$1`-`$9`

### DIFF
--- a/mrbgems/mruby-metaprog/test/metaprog.rb
+++ b/mrbgems/mruby-metaprog/test/metaprog.rb
@@ -104,11 +104,14 @@ assert('Kernel.global_variables', '15.3.1.2.4') do
 end
 
 assert('Kernel#global_variables', '15.3.1.3.14') do
-  variables = global_variables
-  assert_equal Array, variables.class
-  1.upto(9) do |i|
-    assert_equal variables.include?(:"$#{i}"), true
-  end
+  variables1 = global_variables
+  assert_equal Array, variables1.class
+  assert_not_include(variables1, :$kernel_global_variables_test)
+
+  $kernel_global_variables_test = nil
+  variables2 = global_variables
+  assert_include(variables2, :$kernel_global_variables_test)
+  assert_equal(1, variables2.size - variables1.size)
 end
 
 assert('Kernel.local_variables', '15.3.1.2.7') do

--- a/src/variable.c
+++ b/src/variable.c
@@ -965,16 +965,8 @@ mrb_f_global_variables(mrb_state *mrb, mrb_value self)
 {
   iv_tbl *t = mrb->globals;
   mrb_value ary = mrb_ary_new(mrb);
-  size_t i;
-  char buf[3];
 
   iv_foreach(mrb, t, gv_i, &ary);
-  buf[0] = '$';
-  buf[2] = 0;
-  for (i = 1; i <= 9; ++i) {
-    buf[1] = (char)(i + '0');
-    mrb_ary_push(mrb, ary, mrb_symbol_value(mrb_intern(mrb, buf, 2)));
-  }
   return ary;
 }
 


### PR DESCRIPTION
- They are not include in Ruby.
- Appear in duplicate when `$1`-`$9` are defined.