### PR TITLE
Remove redundant colon in `Proc#inspect` (`mruby-proc-ext`)

### DIFF
--- a/mrbgems/mruby-proc-ext/src/proc.c
+++ b/mrbgems/mruby-proc-ext/src/proc.c
@@ -38,7 +38,7 @@ mrb_proc_inspect(mrb_state *mrb, mrb_value self)
 {
   struct RProc *p = mrb_proc_ptr(self);
   mrb_value str = mrb_str_new_lit(mrb, "#<Proc:");
-  mrb_str_concat(mrb, str, mrb_ptr_to_str(mrb, mrb_cptr(self)));
+  mrb_str_cat_str(mrb, str, mrb_ptr_to_str(mrb, mrb_cptr(self)));
 
   if (!MRB_PROC_CFUNC_P(p)) {
     mrb_irep *irep = p->body.irep;
@@ -52,7 +52,7 @@ mrb_proc_inspect(mrb_state *mrb, mrb_value self)
 
     line = mrb_debug_get_line(mrb, irep, 0);
     if (line != -1) {
-      str = mrb_format(mrb, "%S:%S", str, mrb_fixnum_value(line));
+      mrb_str_concat(mrb, str, mrb_fixnum_value(line));
     }
     else {
       mrb_str_cat_lit(mrb, str, "-");

--- a/mrbgems/mruby-proc-ext/test/proc.rb
+++ b/mrbgems/mruby-proc-ext/test/proc.rb
@@ -1,16 +1,32 @@
 ##
 # Proc(Ext) Test
 
+def enable_debug_info?
+  return @enable_debug_info unless @enable_debug_info == nil
+  begin
+    raise
+  rescue => e
+    @enable_debug_info = !e.backtrace.empty?
+  end
+end
+
 assert('Proc#source_location') do
-  loc = Proc.new {}.source_location
-  next true if loc.nil?
-  assert_equal loc[0][-7, 7], 'proc.rb'
-  assert_equal loc[1], 5
+  skip unless enable_debug_info?
+  file, line = Proc.new{}.source_location
+  assert_equal __FILE__, file
+  assert_equal __LINE__ - 2, line
 end
 
 assert('Proc#inspect') do
   ins = Proc.new{}.inspect
-  assert_kind_of String, ins
+  if enable_debug_info?
+    metas = %w(\\ * ? [ ] { })
+    file = __FILE__.split("").map{|c| metas.include?(c) ? "\\#{c}" : c}.join
+    line = __LINE__ - 4
+  else
+    file = line = "-"
+  end
+  assert_match "#<Proc:0x*@#{file}:#{line}>", ins
 end
 
 assert('Proc#parameters') do


### PR DESCRIPTION
#### Before this patch:

    $ bin/mruby -e 'p proc{}'  #=> #<Proc:0x7fd5eb8206d0@-e::1>

#### After this patch:

    $ bin/mruby -e 'p proc{}'  #=> #<Proc:0x7fd5eb8206d0@-e:1>