### PR TITLE
Remove a meaningless branch condition in `mruby-struct`

### DIFF
--- a/mrbgems/mruby-struct/src/struct.c
+++ b/mrbgems/mruby-struct/src/struct.c
@@ -158,20 +158,6 @@ mrb_struct_set_m(mrb_state *mrb, mrb_value obj)
   return val;
 }
 
-static mrb_bool
-is_local_id(mrb_state *mrb, const char *name)
-{
-  if (!name) return FALSE;
-  return !ISUPPER(name[0]);
-}
-
-static mrb_bool
-is_const_id(mrb_state *mrb, const char *name)
-{
-  if (!name) return FALSE;
-  return ISUPPER(name[0]);
-}
-
 static void
 make_struct_define_accessors(mrb_state *mrb, mrb_value members, struct RClass *c)
 {
@@ -182,19 +168,15 @@ make_struct_define_accessors(mrb_state *mrb, mrb_value members, struct RClass *c
 
   for (i=0; i<len; i++) {
     mrb_sym id = mrb_symbol(ptr_members[i]);
-    const char *name = mrb_sym2name_len(mrb, id, NULL);
-
-    if (is_local_id(mrb, name) || is_const_id(mrb, name)) {
-      mrb_method_t m;
-      mrb_value at = mrb_fixnum_value(i);
-      struct RProc *aref = mrb_proc_new_cfunc_with_env(mrb, mrb_struct_ref, 1, &at);
-      struct RProc *aset = mrb_proc_new_cfunc_with_env(mrb, mrb_struct_set_m, 1, &at);
-      MRB_METHOD_FROM_PROC(m, aref);
-      mrb_define_method_raw(mrb, c, id, m);
-      MRB_METHOD_FROM_PROC(m, aset);
-      mrb_define_method_raw(mrb, c, mrb_id_attrset(mrb, id), m);
-      mrb_gc_arena_restore(mrb, ai);
-    }
+    mrb_method_t m;
+    mrb_value at = mrb_fixnum_value(i);
+    struct RProc *aref = mrb_proc_new_cfunc_with_env(mrb, mrb_struct_ref, 1, &at);
+    struct RProc *aset = mrb_proc_new_cfunc_with_env(mrb, mrb_struct_set_m, 1, &at);
+    MRB_METHOD_FROM_PROC(m, aref);
+    mrb_define_method_raw(mrb, c, id, m);
+    MRB_METHOD_FROM_PROC(m, aset);
+    mrb_define_method_raw(mrb, c, mrb_id_attrset(mrb, id), m);
+    mrb_gc_arena_restore(mrb, ai);
   }
 }
 


### PR DESCRIPTION
The following branch condition is always true:

```c
  // mrbgems/mruby-struct/src/struct.c:187 in make_struct_define_accessors()
  if (is_local_id(mrb, name) || is_const_id(mrb, name)) {
```