### PR TITLE
Fix index in error message of `Struct#[]`

### DIFF
--- a/mrbgems/mruby-struct/src/struct.c
+++ b/mrbgems/mruby-struct/src/struct.c
@@ -385,16 +385,17 @@ struct_aref_sym(mrb_state *mrb, mrb_value obj, mrb_sym id)
 static mrb_value
 struct_aref_int(mrb_state *mrb, mrb_value s, mrb_int i)
 {
-  if (i < 0) i = RSTRUCT_LEN(s) + i;
-  if (i < 0)
-      mrb_raisef(mrb, E_INDEX_ERROR,
-                 "offset %S too small for struct(size:%S)",
-                 mrb_fixnum_value(i), mrb_fixnum_value(RSTRUCT_LEN(s)));
-  if (RSTRUCT_LEN(s) <= i)
+  mrb_int idx = i < 0 ? RSTRUCT_LEN(s) + i : i;
+
+  if (idx < 0)
+    mrb_raisef(mrb, E_INDEX_ERROR,
+               "offset %S too small for struct(size:%S)",
+               mrb_fixnum_value(i), mrb_fixnum_value(RSTRUCT_LEN(s)));
+  if (RSTRUCT_LEN(s) <= idx)
     mrb_raisef(mrb, E_INDEX_ERROR,
                "offset %S too large for struct(size:%S)",
                mrb_fixnum_value(i), mrb_fixnum_value(RSTRUCT_LEN(s)));
-  return RSTRUCT_PTR(s)[i];
+  return RSTRUCT_PTR(s)[idx];
 }
 
 /* 15.2.18.4.2  */


### PR DESCRIPTION
#### Before this patch:

    $ bin/mruby -e 'Struct.new(:a,:b).new[-3]'
    #=> offset -1 too small for struct(size:2) (IndexError)

#### After this patch (same as Ruby):

    $ bin/mruby -e 'Struct.new(:a,:b).new[-3]'
    #=> offset -3 too small for struct(size:2) (IndexError)