### PR TITLE
Support parsing a Regexp literal with 'o' option

### DIFF
--- a/mrbgems/mruby-compiler/core/parse.y
+++ b/mrbgems/mruby-compiler/core/parse.y
@@ -4526,6 +4526,7 @@ parse_string(parser_state *p)
       case 'm': f |= 4; break;
       case 'u': f |= 16; break;
       case 'n': f |= 32; break;
+      case 'o': break;
       default: tokadd(p, re_opt); break;
       }
     }


### PR DESCRIPTION
CRuby supports a 'o' `Regexp` option for `Regexp` literals, e.g. `/foo/o` that disables multiple interpolation passes.

This commit adds support for parsing such literals. Nothing is done with the option, it is consumed and ignored by the parser.