### PR TITLE
Fix segfault when removing ivars on immediates (fixes #4519)

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -1133,7 +1133,7 @@ MRB_API mrb_noreturn void mrb_exc_raise(mrb_state *mrb, mrb_value exc);
 MRB_API mrb_noreturn void mrb_raise(mrb_state *mrb, struct RClass *c, const char *msg);
 MRB_API mrb_noreturn void mrb_raisef(mrb_state *mrb, struct RClass *c, const char *fmt, ...);
 MRB_API mrb_noreturn void mrb_name_error(mrb_state *mrb, mrb_sym id, const char *fmt, ...);
-MRB_API mrb_noreturn void mrb_frozen_error(mrb_state *mrb, void *frozen_obj);
+MRB_API mrb_noreturn void mrb_frozen_error(mrb_state *mrb, mrb_value frozen_obj);
 MRB_API void mrb_warn(mrb_state *mrb, const char *fmt, ...);
 MRB_API mrb_noreturn void mrb_bug(mrb_state *mrb, const char *fmt, ...);
 MRB_API void mrb_print_backtrace(mrb_state *mrb);
@@ -1189,7 +1189,7 @@ MRB_API void mrb_check_type(mrb_state *mrb, mrb_value x, enum mrb_vtype t);
 
 MRB_INLINE void mrb_check_frozen(mrb_state *mrb, void *o)
 {
-  if (MRB_FROZEN_P((struct RBasic*)o)) mrb_frozen_error(mrb, o);
+  if (MRB_FROZEN_P((struct RBasic*)o)) mrb_frozen_error(mrb, mrb_obj_value(o));
 }
 
 typedef enum call_type {

--- a/src/error.c
+++ b/src/error.c
@@ -485,10 +485,10 @@ mrb_no_method_error(mrb_state *mrb, mrb_sym id, mrb_value args, char const* fmt,
 }
 
 MRB_API mrb_noreturn void
-mrb_frozen_error(mrb_state *mrb, void *frozen_obj)
+mrb_frozen_error(mrb_state *mrb, mrb_value frozen_obj)
 {
   mrb_raisef(mrb, E_FROZEN_ERROR, "can't modify frozen %S",
-             mrb_obj_value(mrb_class(mrb, mrb_obj_value(frozen_obj))));
+             mrb_obj_value(mrb_class(mrb, frozen_obj)));
 }
 
 void

--- a/src/variable.c
+++ b/src/variable.c
@@ -521,7 +521,9 @@ mrb_obj_iv_inspect(mrb_state *mrb, struct RObject *obj)
 MRB_API mrb_value
 mrb_iv_remove(mrb_state *mrb, mrb_value obj, mrb_sym sym)
 {
-  mrb_check_frozen(mrb, mrb_obj_ptr(obj));
+  if (mrb_immediate_p(obj) || MRB_FROZEN_P(mrb_obj_ptr(obj)))
+    mrb_frozen_error(mrb, obj);
+
   if (obj_iv_p(obj)) {
     iv_tbl *t = mrb_obj_ptr(obj)->iv;
     mrb_value val;

--- a/test/t/kernel.rb
+++ b/test/t/kernel.rb
@@ -405,6 +405,12 @@ assert('Kernel#remove_instance_variable', '15.3.1.3.41') do
   assert_raise(NameError) { tri.remove }
   assert_raise(NameError) { tri.remove_instance_variable(:var) }
   assert_raise(FrozenError) { tri.freeze.remove }
+
+  assert_raise(FrozenError) { 1.remove_instance_variable '@a' }
+  assert_raise(FrozenError) { nil.remove_instance_variable '@a' }
+  assert_raise(FrozenError) { 1.0.remove_instance_variable '@a' }
+  assert_raise(FrozenError) { true.remove_instance_variable '@a' }
+  assert_raise(FrozenError) { :a.remove_instance_variable '@a' }
 end
 
 # Kernel#require is defined in mruby-require. '15.3.1.3.42'


### PR DESCRIPTION
The problem is that `mrb_iv_frozen` treats the `mrb_value` as a pointer,
but it can also be an immediate (`nil`, a fixnum, etc). This leads to
a segfault since the immediate's value is not a valid pointer.

Looking at `mrb_obj_frozen` and comparing with CRuby behaviour,
immediates should always be treated as frozen. This commit checks
whether the value involved is an immediate and raises `FrozenError` if
so.