### PR TITLE
Fix potential overflow in `utf8len()`

### DIFF
--- a/src/string.c
+++ b/src/string.c
@@ -234,7 +234,7 @@ utf8len(const char* p, const char* e)
   mrb_int i;
 
   len = utf8len_codepage[(unsigned char)*p];
-  if (p + len > e) return 1;
+  if (len > e - p) return 1;
   for (i = 1; i < len; ++i)
     if ((p[i] & 0xc0) != 0x80)
       return 1;


### PR DESCRIPTION
For example on 32 bit mode, when `p = 0xfffffffd`, `e = 0xfffffffe` and `len = 4`, the sum of `p` and `len` can be to `1`, and comparison with `e` will to be false.

As a result, a segmentation fault occurs by referring to address 0.

----

I think that it is not realistic unless the address space is 16 bits, but just in case.
