### PR TITLE
Lazily cache UTF-8 character length on RString

### DIFF
--- a/include/mruby/string.h
+++ b/include/mruby/string.h
@@ -23,6 +23,9 @@ struct RString {
   union {
     struct {
       mrb_int len;
+#ifdef MRB_UTF8_STRING
+      mrb_int char_len;
+#endif
       union {
         mrb_int capa;
         struct mrb_shared_string *shared;


### PR DESCRIPTION
Store the UTF-8 length as computed by `utf8_strlen` on `RString` when `MRB_UTF8_STRING` is defined. This significantly (3200x) speeds up `String` operations at the cost of one `mrb_int` of memory per `RString`.

The UTF-8 `char_len` is computed on first call to `utf8_strlen` and is cached until `mrb_str_modify` is called, when it is zeroed out. `utf8_strlen` gets a new fastpath for when the character length is cached and retains the fast path for ASCII strings which is used as a fallback.

## Benchmark

```sh
/usr/bin/time -l ./bin/mruby -e 'def str(len); ("💪" * len); end; s = str(100000); puts s.length; 1000000.times { s.length }'
```

## This PR @ `ca692e6`

Completes in 0.30 seconds.

```console
$ /usr/bin/time -l ./bin/mruby -e 'def str(len); ("💪" * len); end; s = str(100000); puts s.length; 1000000.times { s.length }'
100000
        0.30 real         0.30 user         0.00 sys
   2306048  maximum resident set size
         0  average shared memory size
         0  average unshared data size
         0  average unshared stack size
       572  page reclaims
         0  page faults
         0  swaps
         0  block input operations
         0  block output operations
         0  messages sent
         0  messages received
         0  signals received
         0  voluntary context switches
        48  involuntary context switches
```

### master

Completes in 963 seconds. The caching implementation is 3210x faster than master.

```console
$ /usr/bin/time -l ./bin/mruby -e 'def str(len); ("💪" * len); end; s = str(100000); puts s.length; 1000000.times { s.length }'
100000
      963.41 real       961.82 user         0.74 sys
   2252800  maximum resident set size
         0  average shared memory size
         0  average unshared data size
         0  average unshared stack size
       559  page reclaims
         0  page faults
         0  swaps
         0  block input operations
         0  block output operations
         0  messages sent
         0  messages received
         0  signals received
         0  voluntary context switches
    139399  involuntary context switches
```