### PR TITLE
Silence unused label warnings from gcc; ref #4524

### DIFF
--- a/src/string.c
+++ b/src/string.c
@@ -1719,11 +1719,14 @@ mrb_str_reverse_bang(mrb_state *mrb, mrb_value str)
 
   if (RSTR_LEN(s) > 1) {
     mrb_str_modify(mrb, s);
-   bytes:
-    p = RSTR_PTR(s);
-    e = p + RSTR_LEN(s) - 1;
-    str_reverse(p, e);
+    goto bytes;
   }
+  return str;
+
+ bytes:
+  p = RSTR_PTR(s);
+  e = p + RSTR_LEN(s) - 1;
+  str_reverse(p, e);
   return str;
 }
 


### PR DESCRIPTION
```shell
mruby/mruby/src/string.c:1722:4: warning: label 'bytes' defined but not used [-Wunused-label]
    bytes:
    ^~~~~
```