### PR TITLE
Use `__ENCODING__` in tests

### DIFF
--- a/mrbgems/mruby-string-ext/test/string.rb
+++ b/mrbgems/mruby-string-ext/test/string.rb
@@ -2,7 +2,7 @@
 ##
 # String(Ext) Test
 
-UTF8STRING = ("\343\201\202".size == 1)
+UTF8STRING = __ENCODING__ == "UTF-8"
 
 assert('String#getbyte') do
   str1 = "hello"

--- a/mrbgems/mruby-symbol-ext/test/symbol.rb
+++ b/mrbgems/mruby-symbol-ext/test/symbol.rb
@@ -14,7 +14,7 @@ end
   assert("Symbol##{n}") do
     assert_equal 5, :hello.__send__(n)
     assert_equal 4, :"aA\0b".__send__(n)
-    if "あ".size == 1  # enable MRB_UTF8_STRING?
+    if __ENCODING__ == "UTF-8"
       assert_equal 8, :"こんにちは世界!".__send__(n)
       assert_equal 4, :"aあ\0b".__send__(n)
     else

--- a/test/t/string.rb
+++ b/test/t/string.rb
@@ -2,7 +2,7 @@
 ##
 # String ISO Test
 
-UTF8STRING = ("\343\201\202".size == 1)
+UTF8STRING = __ENCODING__ == "UTF-8"
 
 assert('String', '15.2.10') do
   assert_equal Class, String.class


### PR DESCRIPTION
It cannot be used for `String#size` test if judging whether or not `MRB_UTF8_STRING` is defined by result of `String#size`.