### PR TITLE
Nested `assert` for mrbtest

### DIFF
--- a/mrbgems/mruby-bin-mruby/bintest/mruby.rb
+++ b/mrbgems/mruby-bin-mruby/bintest/mruby.rb
@@ -3,9 +3,11 @@ require 'open3'
 
 def assert_mruby(exp_out, exp_err, exp_success, args)
   out, err, stat = Open3.capture3(cmd("mruby"), *args)
-  assert_operator(exp_out, :===, out, "standard output")
-  assert_operator(exp_err, :===, err, "standard error")
-  assert_equal(exp_success, stat.success?, "exit success?")
+  assert do
+    assert_operator(exp_out, :===, out, "standard output")
+    assert_operator(exp_err, :===, err, "standard error")
+    assert_equal(exp_success, stat.success?, "exit success?")
+  end
 end
 
 assert('regression for #1564') do

--- a/mrbgems/mruby-complex/test/complex.rb
+++ b/mrbgems/mruby-complex/test/complex.rb
@@ -1,6 +1,8 @@
 def assert_complex(real, exp)
-  assert_float real.real,      exp.real
-  assert_float real.imaginary, exp.imaginary
+  assert do
+    assert_float real.real,      exp.real
+    assert_float real.imaginary, exp.imaginary
+  end
 end
 
 assert 'Complex' do

--- a/mrbgems/mruby-io/test/io.rb
+++ b/mrbgems/mruby-io/test/io.rb
@@ -5,24 +5,26 @@ MRubyIOTestUtil.io_test_setup
 $cr, $crlf, $cmd = MRubyIOTestUtil.win? ? [1, "\r\n", "cmd /c "] : [0, "\n", ""]
 
 def assert_io_open(meth)
-  fd = IO.sysopen($mrbtest_io_rfname)
-  assert_equal Fixnum, fd.class
-  io1 = IO.__send__(meth, fd)
-  begin
-    assert_equal IO, io1.class
-    assert_equal $mrbtest_io_msg, io1.read
-  ensure
-    io1.close
-  end
-
-  io2 = IO.__send__(meth, IO.sysopen($mrbtest_io_rfname))do |io|
-    if meth == :open
-      assert_equal $mrbtest_io_msg, io.read
-    else
-      flunk "IO.#{meth} does not take block"
+  assert do
+    fd = IO.sysopen($mrbtest_io_rfname)
+    assert_equal Fixnum, fd.class
+    io1 = IO.__send__(meth, fd)
+    begin
+      assert_equal IO, io1.class
+      assert_equal $mrbtest_io_msg, io1.read
+    ensure
+      io1.close
     end
+
+    io2 = IO.__send__(meth, IO.sysopen($mrbtest_io_rfname))do |io|
+      if meth == :open
+        assert_equal $mrbtest_io_msg, io.read
+      else
+        flunk "IO.#{meth} does not take block"
+      end
+    end
+    io2.close unless meth == :open
   end
-  io2.close unless meth == :open
 end
 
 assert('IO.class', '15.2.20') do

--- a/mrbgems/mruby-io/test/io.rb
+++ b/mrbgems/mruby-io/test/io.rb
@@ -4,7 +4,7 @@
 MRubyIOTestUtil.io_test_setup
 $cr, $crlf, $cmd = MRubyIOTestUtil.win? ? [1, "\r\n", "cmd /c "] : [0, "\n", ""]
 
-assert_io_open = ->(meth) do
+def assert_io_open(meth)
   fd = IO.sysopen($mrbtest_io_rfname)
   assert_equal Fixnum, fd.class
   io1 = IO.__send__(meth, fd)
@@ -38,7 +38,7 @@ assert('IO.ancestors', '15.2.20.3') do
 end
 
 assert('IO.open', '15.2.20.4.1') do
-  assert_io_open.(:open)
+  assert_io_open(:open)
 end
 
 assert('IO#close', '15.2.20.5.1') do
@@ -224,11 +224,11 @@ assert('IO#dup for writable') do
 end
 
 assert('IO.for_fd') do
-  assert_io_open.(:for_fd)
+  assert_io_open(:for_fd)
 end
 
 assert('IO.new') do
-  assert_io_open.(:new)
+  assert_io_open(:new)
 end
 
 assert('IO gc check') do

--- a/mrbgems/mruby-pack/test/pack.rb
+++ b/mrbgems/mruby-pack/test/pack.rb
@@ -2,8 +2,10 @@ PACK_IS_LITTLE_ENDIAN = "\x01\00".unpack('S')[0] == 0x01
 
 def assert_pack tmpl, packed, unpacked
   t = tmpl.inspect
-  assert_equal packed, unpacked.pack(tmpl), "#{unpacked.inspect}.pack(#{t})"
-  assert_equal unpacked, packed.unpack(tmpl), "#{packed.inspect}.unpack(#{t})"
+  assert do
+    assert_equal packed, unpacked.pack(tmpl), "#{unpacked.inspect}.pack(#{t})"
+    assert_equal unpacked, packed.unpack(tmpl), "#{packed.inspect}.unpack(#{t})"
+  end
 end
 
 # pack & unpack 'm' (base64)

--- a/mrbgems/mruby-rational/test/rational.rb
+++ b/mrbgems/mruby-rational/test/rational.rb
@@ -23,17 +23,21 @@ class ComplexLikeNumeric < UserDefinedNumeric
 end
 
 def assert_rational(exp, real)
-  assert_float exp.numerator,   real.numerator
-  assert_float exp.denominator, real.denominator
+  assert do
+    assert_float exp.numerator,   real.numerator
+    assert_float exp.denominator, real.denominator
+  end
 end
 
 def assert_equal_rational(exp, o1, o2)
-  if exp
-    assert_operator(o1, :==, o2)
-    assert_not_operator(o1, :!=, o2)
-  else
-    assert_not_operator(o1, :==, o2)
-    assert_operator(o1, :!=, o2)
+  assert do
+    if exp
+      assert_operator(o1, :==, o2)
+      assert_not_operator(o1, :!=, o2)
+    else
+      assert_not_operator(o1, :==, o2)
+      assert_operator(o1, :!=, o2)
+    end
   end
 end
 


### PR DESCRIPTION
When nesting `assert` used in test, it is indented and displayed.  
Assertion numbers are concatenated by `"-"` at this time.

The purpose is to match the apparent numbers when failing with `assert_mruby` which is defined by `mrbgems/mruby-bin-mruby/bintest/mruby.rb` for example.

Child assertions "skip" and "info" are reported as parent assertions "info" and `$ok_test += 1`.
The child assertions "ko" and "crash" are reported as the parent assertion "ko" and `$ko_test += 1`.

When child assertions are mixed, "ko" takes precedence.

If you use `"."` As a concatenation character, I think it is easy to confuse it with the ISO Ruby section number when it is displayed.  
So we chose `"-"` as the concatenation character.

Note that this patch conflicts with #4320.

### Incompatibility

- `$mrbtest_assert_idx` takes `nil` or an integer array object.  
  So far it was `nil` or an integer.
- `$asserts` points to the top of the internal stack in the `assert`.
- `$mrbtest_assert` points to the top of the internal stack in `assert`.
