### PR TITLE
Improve performance `String#index` with UTF-8

### DIFF
--- a/test/t/string.rb
+++ b/test/t/string.rb
@@ -468,6 +468,17 @@ assert('String#index', '15.2.10.5.22') do
   assert_equal nil, "hello".index("", 6)
 end
 
+assert('String#index(UTF-8)', '15.2.10.5.22') do
+  assert_equal 0, '⓿➊➋➌➍➎'.index('⓿')
+  assert_nil '⓿➊➋➌➍➎'.index('➓')
+  assert_equal 6, '⓿➊➋➌➍➎⓿➊➋➌➍➎'.index('⓿', 1)
+  assert_equal 6, "⓿➊➋➌➍➎".index("", 6)
+  assert_equal nil, "⓿➊➋➌➍➎".index("", 7)
+  assert_equal 0, '⓿➊➋➌➍➎'.index("\xe2")
+  assert_equal nil, '⓿➊➋➌➍➎'.index("\xe3")
+  assert_equal 6, "\xd1\xd1\xd1\xd1\xd1\xd1⓿➊➋➌➍➎".index('⓿')
+end if UTF8STRING
+
 assert('String#initialize', '15.2.10.5.23') do
   a = ''
   a.initialize('abc')


### PR DESCRIPTION
It minimizes the number of `utf8len ()` calls per character.

  - `RSTRING_CHAR_LEN()` is only used when `pos` is given a negative value.
  - `pos` is kept in character units, and is not converted between bytes.

The string search algorithm is Boyer-Moore-Horspool algorithm (Quick Search algorithm).

As a side effect, the correct position is returned even if an invalid UTF-8 string is given.

```console
% ./mruby@master -e 'p ("\xd1" * 100 + "#").index("#")'
50
% ./mruby@improve-index -e 'p ("\xd1" * 100 + "#").index("#")'
100
% ruby26 -e 'p ("\xd1" * 100 + "#").index("#")'
100
```

The other behavior should be the same as the current implementation.
