### PR TITLE
Fix heap buffer overflow; fix #4569

### DIFF
--- a/src/string.c
+++ b/src/string.c
@@ -324,22 +324,20 @@ str_index_str_by_char_search(mrb_state *mrb, const char *p, const char *pend, co
   }
 
   /* Searching */
-  if (p < pend && pend - p >= slen) {
-    for (;;) {
-      const char *pivot;
+  while (p < pend && pend - p >= slen) {
+    const char *pivot;
 
-      if (memcmp(p, s, slen) == 0) {
-        return off;
-      }
-
-      pivot = p + qstable[(unsigned char)p[slen - 1]];
-      if (pivot > pend || pivot < p /* overflowed */) { return -1; }
-
-      do {
-        p += utf8len(p, pend);
-        off ++;
-      } while (p < pivot);
+    if (memcmp(p, s, slen) == 0) {
+      return off;
     }
+
+    pivot = p + qstable[(unsigned char)p[slen - 1]];
+    if (pivot > pend || pivot < p /* overflowed */) { return -1; }
+
+    do {
+      p += utf8len(p, pend);
+      off ++;
+    } while (p < pivot);
   }
 
   return -1;


### PR DESCRIPTION
This patch fixes the heap buffer overflow shown at https://github.com/mruby/mruby/pull/4569#issuecomment-510850076.

The performance loss is a few percent.
