### PR TITLE
Add `mruby-method` gem to `default.gembox` [ci skip]

### DIFF
--- a/mrbgems/default.gembox
+++ b/mrbgems/default.gembox
@@ -86,6 +86,9 @@ MRuby::GemBox.new do |conf|
   # Use class/module extension
   conf.gem :core => "mruby-class-ext"
 
+  # Use Method/UnboundMethod class
+  conf.gem :core => "mruby-method"
+
   # Use mruby-compiler to build other mrbgems
   conf.gem :core => "mruby-compiler"
 end


### PR DESCRIPTION
I think `mruby-method` gem is used more than `mruby-objectspace` gem.