### PR TITLE
Improve `utf8len()` performance with UTF-8

### DIFF
--- a/src/string.c
+++ b/src/string.c
@@ -233,7 +233,9 @@ utf8len(const char* p, const char* e)
   mrb_int len;
   mrb_int i;
 
+  if ((unsigned char)*p < 0x80) return 1;
   len = utf8len_codepage[(unsigned char)*p];
+  if (len == 1) return 1;
   if (len > e - p) return 1;
   for (i = 1; i < len; ++i)
     if ((p[i] & 0xc0) != 0x80)


### PR DESCRIPTION
I revenge #4529 (without permission).

----

I compared with the file that actually exists.

Acquisition and processing of sample file:

  - ASCII only HTML - `2000-2FFF` (530,693 bytes)
    ```console
    % fetch https://en.wikibooks.org/wiki/Unicode/Character_reference/2000-2FFF
    ```
  - Mixed Japanese UTF-8 HTML - `book.utf-8.html` (3,100,523 bytes)
    ```console
    % fetch -o- https://www.freebsd.org/doc/ja_JP.eucJP/books/handbook/book.html | nkf -Eu > book.utf-8.html
    ```
  - Almost Japanese UTF-8 TEXT - `uchuno_hajimari.utf-8.txt` (517,378 bytes)
    from https\://www.aozora.gr.jp/cards/000226/card1150.html
    ```console
    % fetch -o- https://www.aozora.gr.jp/cards/000226/files/1150_ruby_38564.zip | tar xf - -O uchuno_hajimari.txt | nkf -Su > uchuno_hajimari.utf-8.txt
    ```
  - Japanese UTF-8 HTML - `ゲゲゲの鬼太郎の登場キャラクター` (1,363,429 bytes)
    ```console
    % fetch https://ja.wikipedia.org/wiki/ゲゲゲの鬼太郎の登場キャラクター
    ```
  - Binary - `/boot/kernel/zfs.ko` (3,224,408 bytes)
    From FreeBSD 12.0-RELEASE-p6 GENERIC amd64

### Comparison script

```shell
for file in 2000-2FFF book.utf-8.html uchuno_hajimari.utf-8.txt ゲゲゲの鬼太郎の登場キャラクター zfs.ko
do
	echo "\e[7m[[$file]]\e[m"
	for ruby in ./mruby@master ./mruby@improve-utf8len ruby25
	do
		printf "%-24s" $ruby
		/usr/bin/time $ruby -e 'mode = RUBY_ENGINE == "mruby" ? "rb" : "rb:utf-8"; src = File.read(ARGV[0], mode: mode); 1000.times { src.size }' "$file"
	done
done
```

### Run on FreeBSD 12.0-RELEASE-p6 GENERIC amd64

```
[[2000-2FFF]]
./mruby@master                  2.35 real         2.35 user         0.00 sys
./mruby@improve-utf8len         0.54 real         0.54 user         0.00 sys
ruby25                          0.16 real         0.14 user         0.01 sys
[[book.utf-8.html]]
./mruby@master                 10.60 real        10.56 user         0.00 sys
./mruby@improve-utf8len         4.68 real         4.67 user         0.00 sys
ruby25                          0.59 real         0.57 user         0.01 sys
[[uchuno_hajimari.utf-8.txt]]
./mruby@master                  0.85 real         0.85 user         0.00 sys
./mruby@improve-utf8len         0.81 real         0.80 user         0.00 sys
ruby25                          0.16 real         0.15 user         0.00 sys
[[ゲゲゲの鬼太郎の登場キャラクター]]
./mruby@master                  3.23 real         3.22 user         0.00 sys
./mruby@improve-utf8len         2.18 real         2.17 user         0.00 sys
ruby25                          0.30 real         0.29 user         0.00 sys
[[zfs.ko]]
./mruby@master                 16.99 real        16.91 user         0.01 sys
./mruby@improve-utf8len        12.73 real        12.65 user         0.01 sys
ruby25                         13.62 real        13.55 user         0.01 sys
```

### Run on FreeBSD 12.0-RELEASE r341666 GENERIC arm64

```
[[2000-2FFF]]
./mruby@master                  5.43 real         5.41 user         0.01 sys
./mruby@improve-utf8len         1.83 real         1.82 user         0.00 sys
ruby25                          0.63 real         0.58 user         0.04 sys
[[book.utf-8.html]]
./mruby@master                 27.06 real        27.03 user         0.03 sys
./mruby@improve-utf8len        15.89 real        15.86 user         0.03 sys
ruby25                          2.70 real         2.66 user         0.03 sys
[[uchuno_hajimari.utf-8.txt]]
./mruby@master                  3.51 real         3.51 user         0.00 sys
./mruby@improve-utf8len         3.36 real         3.34 user         0.01 sys
ruby25                          0.62 real         0.60 user         0.02 sys
[[ゲゲゲの鬼太郎の登場キャラクター]]
./mruby@master                 10.17 real        10.16 user         0.00 sys
./mruby@improve-utf8len         8.43 real         8.42 user         0.00 sys
ruby25                          1.38 real         1.34 user         0.03 sys
[[zfs.ko]]
./mruby@master                 35.55 real        35.52 user         0.03 sys
./mruby@improve-utf8len        23.00 real        22.97 user         0.03 sys
ruby25                         52.15 real        52.10 user         0.05 sys
```
