### PR TITLE
Fix `(fixnum_value ... float_value).min` with `mruby-range-ext`

### DIFF
--- a/mrbgems/mruby-range-ext/mrblib/range.rb
+++ b/mrbgems/mruby-range-ext/mrblib/range.rb
@@ -53,7 +53,6 @@ class Range
 
     # fast path for numerics
     if (val.kind_of?(Fixnum) || val.kind_of?(Float)) && (last.kind_of?(Fixnum) || last.kind_of?(Float))
-      raise TypeError if exclude_end? && !last.kind_of?(Fixnum)
       return nil if val > last
       return nil if val == last && exclude_end?
 


### PR DESCRIPTION
#### Before this patch:

    $ bin/mruby -e 'p (2...4.0).min'  #=> TypeError

#### After this patch (same as CRuby and without `mruby-range-ext`):

    $ bin/mruby -e 'p (2...4.0).min'  #=> 2