### PR TITLE
Integrate `Integral#chr` (`Fixnum#chr`) to `mruby-string-ext`

### DIFF
--- a/mrbgems/mruby-numeric-ext/src/numeric_ext.c
+++ b/mrbgems/mruby-numeric-ext/src/numeric_ext.c
@@ -9,32 +9,6 @@ to_int(mrb_state *mrb, mrb_value x)
 }
 
 /*
- *  Document-method: Integer#chr
- *  call-seq:
- *     int.chr  ->  string
- *
- *  Returns a string containing the character represented by the +int+'s value
- *  according to +encoding+.
- *
- *     65.chr    #=> "A"
- *     230.chr   #=> "\xE6"
- */
-static mrb_value
-mrb_int_chr(mrb_state *mrb, mrb_value x)
-{
-  mrb_int chr;
-  char c;
-
-  chr = to_int(mrb, x);
-  if (chr >= (1 << CHAR_BIT)) {
-    mrb_raisef(mrb, E_RANGE_ERROR, "%S out of char range", x);
-  }
-  c = (char)chr;
-
-  return mrb_str_new(mrb, &c, 1);
-}
-
-/*
  *  call-seq:
  *     int.allbits?(mask)  ->  true or false
  *
@@ -87,7 +61,6 @@ mrb_mruby_numeric_ext_gem_init(mrb_state* mrb)
 {
   struct RClass *i = mrb_module_get(mrb, "Integral");
 
-  mrb_define_method(mrb, i, "chr", mrb_int_chr, MRB_ARGS_NONE());
   mrb_define_method(mrb, i, "allbits?", mrb_int_allbits, MRB_ARGS_REQ(1));
   mrb_define_method(mrb, i, "anybits?", mrb_int_anybits, MRB_ARGS_REQ(1));
   mrb_define_method(mrb, i, "nobits?", mrb_int_nobits, MRB_ARGS_REQ(1));

--- a/mrbgems/mruby-numeric-ext/test/numeric.rb
+++ b/mrbgems/mruby-numeric-ext/test/numeric.rb
@@ -1,14 +1,6 @@
 ##
 # Numeric(Ext) Test
 
-assert('Integer#chr') do
-  assert_equal("A", 65.chr)
-  assert_equal("B", 0x42.chr)
-
-  # multibyte encoding (not support yet)
-  assert_raise(RangeError) { 256.chr }
-end
-
 assert('Integer#div') do
   assert_equal 52, 365.div(7)
 end

--- a/mrbgems/mruby-string-ext/src/string.c
+++ b/mrbgems/mruby-string-ext/src/string.c
@@ -125,7 +125,7 @@ mrb_str_swapcase(mrb_state *mrb, mrb_value self)
   return str;
 }
 
-static mrb_value mrb_fixnum_chr(mrb_state *mrb, mrb_value num);
+static mrb_value mrb_int_chr(mrb_state *mrb, mrb_value num);
 
 /*
  *  call-seq:
@@ -149,7 +149,7 @@ mrb_str_concat_m(mrb_state *mrb, mrb_value self)
 
   mrb_get_args(mrb, "o", &str);
   if (mrb_fixnum_p(str))
-    str = mrb_fixnum_chr(mrb, str);
+    str = mrb_int_chr(mrb, str);
   else
     str = mrb_ensure_string_type(mrb, str);
   mrb_str_concat(mrb, self, str);
@@ -837,7 +837,7 @@ mrb_str_chr(mrb_state *mrb, mrb_value self)
 }
 
 static mrb_value
-mrb_fixnum_chr(mrb_state *mrb, mrb_value num)
+mrb_int_chr(mrb_state *mrb, mrb_value num)
 {
   mrb_int cp = mrb_fixnum(num);
 #ifdef MRB_UTF8_STRING
@@ -1219,7 +1219,7 @@ mrb_mruby_string_ext_gem_init(mrb_state* mrb)
   mrb_define_method(mrb, s, "delete_suffix",   mrb_str_del_suffix,      MRB_ARGS_REQ(1));
 
   mrb_define_method(mrb, s, "__lines",         mrb_str_lines,           MRB_ARGS_NONE());
-  mrb_define_method(mrb, mrb->fixnum_class, "chr", mrb_fixnum_chr, MRB_ARGS_NONE());
+  mrb_define_method(mrb, mrb_module_get(mrb, "Integral"), "chr", mrb_int_chr, MRB_ARGS_NONE());
 }
 
 void

--- a/mrbgems/mruby-string-ext/test/fixnum.rb
+++ b/mrbgems/mruby-string-ext/test/fixnum.rb
@@ -1,3 +1,0 @@
-assert('Fixnum#chr') do
-  assert_equal "a", 97.chr
-end

--- a/mrbgems/mruby-string-ext/test/numeric.rb
+++ b/mrbgems/mruby-string-ext/test/numeric.rb
@@ -1,0 +1,5 @@
+assert('Integer#chr') do
+  assert_equal("A", 65.chr)
+  assert_equal("B", 0x42.chr)
+  assert_raise(RangeError) { -1.chr }
+end


### PR DESCRIPTION
Because they're defined in both `mruby-string-ext` and `mruby-numeric-ext`
(they seem more natural to define in N, but `mruby-string-ext` depends on
`Integral#chr`).