### PR TITLE
Add encoding argument to `Integral#chr`

### DIFF
--- a/mrbgems/mruby-string-ext/mrblib/string.rb
+++ b/mrbgems/mruby-string-ext/mrblib/string.rb
@@ -414,7 +414,7 @@ class String
       e = max.ord
       while c <= e
         break if exclusive and c == e
-        yield c.chr
+        yield c.chr(__ENCODING__)
         c += 1
       end
       return self

--- a/mrbgems/mruby-string-ext/test/numeric.rb
+++ b/mrbgems/mruby-string-ext/test/numeric.rb
@@ -1,5 +1,29 @@
+# coding: utf-8
+
 assert('Integer#chr') do
   assert_equal("A", 65.chr)
   assert_equal("B", 0x42.chr)
+  assert_equal("\xab", 171.chr)
   assert_raise(RangeError) { -1.chr }
+  assert_raise(RangeError) { 256.chr }
+
+  assert_equal("A", 65.chr("ASCII-8BIT"))
+  assert_equal("B", 0x42.chr("BINARY"))
+  assert_equal("\xab", 171.chr("ascii-8bit"))
+  assert_raise(RangeError) { -1.chr("binary") }
+  assert_raise(RangeError) { 256.chr("Ascii-8bit") }
+  assert_raise(ArgumentError) { 65.chr("ASCII") }
+  assert_raise(ArgumentError) { 65.chr("ASCII-8BIT", 2) }
+  assert_raise(TypeError) { 65.chr(:BINARY) }
+
+  if __ENCODING__ == "ASCII-8BIT"
+    assert_raise(ArgumentError) { 65.chr("UTF-8") }
+  else
+    assert_equal("A", 65.chr("UTF-8"))
+    assert_equal("B", 0x42.chr("UTF-8"))
+    assert_equal("«", 171.chr("utf-8"))
+    assert_equal("あ", 12354.chr("Utf-8"))
+    assert_raise(RangeError) { -1.chr("utf-8") }
+    assert_raise(RangeError) { 0x110000.chr.chr("UTF-8") }
+  end
 end

--- a/mrbgems/mruby-string-ext/test/string.rb
+++ b/mrbgems/mruby-string-ext/test/string.rb
@@ -167,8 +167,15 @@ end
 assert('String#concat') do
   assert_equal "Hello World!", "Hello " << "World" << 33
   assert_equal "Hello World!", "Hello ".concat("World").concat(33)
-
   assert_raise(TypeError) { "".concat(Object.new) }
+
+  if UTF8STRING
+    assert_equal "H«", "H" << 0xab
+    assert_equal "Hは", "H" << 12399
+  else
+    assert_equal "H\xab", "H" << 0xab
+    assert_raise(RangeError) { "H" << 12399 }
+  end
 end
 
 assert('String#casecmp') do


### PR DESCRIPTION
Currently, `Integral#chr` in mruby changes behavior by `MRB_UTF8_STRING`
setting.

before this patch:

    $ bin/mruby -e 'p 171.chr'  #=> "\xab"  (`MRB_UTF8_STRING` is disabled)
    $ bin/mruby -e 'p 171.chr'  #=> "«"     (`MRB_UTF8_STRING` is enabled)

This behavior is incompatible with Ruby, and a little inconvenient because
it can't be interpreted as ASCII-8BIT with `MRB_UTF8_STRING`, I think.

So add encoding argument according to Ruby.

after this patch:

    $ bin/mruby -e 'p 171.chr'                #=> "\xab"
    $ bin/mruby -e 'p 171.chr("ASCII-8BIT")'  #=> "\xab"
    $ bin/mruby -e 'p 171.chr("UTF-8")'       #=> "«"

Allow only `String` for encoding because mruby doesn't have `Encoding`
class, and `"ASCII-8BIT"` (`"BINARY"`) and `"UTF-8"` (only with
`MRB_UTF8_STRING`) are valid values (default is `"ASCII-8BIT"`).