### PR TITLE
Refine `Array#(permutation|combination) test`

### DIFF
--- a/mrbgems/mruby-array-ext/test/array.rb
+++ b/mrbgems/mruby-array-ext/test/array.rb
@@ -1,6 +1,20 @@
 ##
 # Array(Ext) Test
 
+def assert_permutation_combination(exp, receiver, meth, *args)
+  act = []
+  receiver.__send__(meth, *args) { |v| act << v }
+  assert_equal(exp, act.sort)
+end
+
+def assert_permutation(exp, receiver, *args)
+  assert_permutation_combination(exp, receiver, :permutation, *args)
+end
+
+def assert_combination(exp, receiver, *args)
+  assert_permutation_combination(exp, receiver, :combination, *args)
+end
+
 assert("Array#assoc") do
   s1 = [ "colors", "red", "blue", "green" ]
   s2 = [ "letters", "a", "b", "c" ]
@@ -369,30 +383,22 @@ end
 
 assert("Array#permutation") do
   a = [1, 2, 3]
-  assert_equal([[1,2,3],[1,3,2],[2,1,3],[2,3,1],[3,1,2],[3,2,1]],
-               a.permutation.to_a)
-  assert_equal([[1],[2],[3]],
-               a.permutation(1).to_a)
-  assert_equal([[1,2],[1,3],[2,1],[2,3],[3,1],[3,2]],
-               a.permutation(2).to_a)
-  assert_equal([[1,2,3],[1,3,2],[2,1,3],[2,3,1],[3,1,2],[3,2,1]],
-               a.permutation(3).to_a)
-  assert_equal([[]], a.permutation(0).to_a)
-  assert_equal([], a.permutation(4).to_a)
+  assert_permutation([[1,2,3],[1,3,2],[2,1,3],[2,3,1],[3,1,2],[3,2,1]], a)
+  assert_permutation([[1],[2],[3]], a, 1)
+  assert_permutation([[1,2],[1,3],[2,1],[2,3],[3,1],[3,2]], a, 2)
+  assert_permutation([[1,2,3],[1,3,2],[2,1,3],[2,3,1],[3,1,2],[3,2,1]], a, 3)
+  assert_permutation([[]], a, 0)
+  assert_permutation([], a, 4)
 end
 
 assert("Array#combination") do
   a = [1, 2, 3, 4]
-  assert_equal([[1],[2],[3],[4]],
-               a.combination(1).to_a)
-  assert_equal([[1,2],[1,3],[1,4],[2,3],[2,4],[3,4]],
-               a.combination(2).to_a)
-  assert_equal([[1,2,3],[1,2,4],[1,3,4],[2,3,4]],
-               a.combination(3).to_a)
-  assert_equal([[1,2,3,4]],
-               a.combination(4).to_a)
-  assert_equal([[]], a.combination(0).to_a)
-  assert_equal([], a.combination(5).to_a)
+  assert_combination([[1],[2],[3],[4]], a, 1)
+  assert_combination([[1,2],[1,3],[1,4],[2,3],[2,4],[3,4]], a, 2)
+  assert_combination([[1,2,3],[1,2,4],[1,3,4],[2,3,4]], a, 3)
+  assert_combination([[1,2,3,4]], a, 4)
+  assert_combination([[]], a, 0)
+  assert_combination([], a, 5)
 end
 
 assert('Array#transpose') do


### PR DESCRIPTION
- No guarantees about the order in which the permutations/combinations
  are yielded.

- Drop dependency on `Enumerator`.