### PR TITLE
Remove `Enumerator::Chain#initialize_copy`

### DIFF
--- a/mrbgems/mruby-enum-chain/mrblib/chain.rb
+++ b/mrbgems/mruby-enum-chain/mrblib/chain.rb
@@ -20,10 +20,6 @@ class Enumerator
       @enums = args
     end
 
-    def initialize_copy(orig)
-      @enums = orig.__copy_enums
-    end
-
     def each(&block)
       return to_enum unless block_given?
 
@@ -52,12 +48,6 @@ class Enumerator
 
     def inspect
       "#<#{self.class}: #{@enums.inspect}>"
-    end
-
-    def __copy_enums
-      @enums.each_with_object([]) do |e, a|
-        a << e.clone
-      end
     end
   end
 end


### PR DESCRIPTION
I think `Enumerator::Chain#initialize_copy` is unnecessary because CRuby
doesn't clone elements.

FYI, the remaining `each_with_object` in `Enumerator::Chain#initialize_copy`
was correction omission in #4599.