### PR TITLE
Refine message to `skip` in nested `assert`

### DIFF
--- a/mrbgems/mruby-bin-mruby/bintest/mruby.rb
+++ b/mrbgems/mruby-bin-mruby/bintest/mruby.rb
@@ -3,7 +3,7 @@ require 'open3'
 
 def assert_mruby(exp_out, exp_err, exp_success, args)
   out, err, stat = Open3.capture3(cmd("mruby"), *args)
-  assert do
+  assert "assert_mruby" do
     assert_operator(exp_out, :===, out, "standard output")
     assert_operator(exp_err, :===, err, "standard error")
     assert_equal(exp_success, stat.success?, "exit success?")

--- a/mrbgems/mruby-complex/test/complex.rb
+++ b/mrbgems/mruby-complex/test/complex.rb
@@ -1,5 +1,5 @@
 def assert_complex(real, exp)
-  assert do
+  assert "assert_complex" do
     assert_float real.real,      exp.real
     assert_float real.imaginary, exp.imaginary
   end

--- a/mrbgems/mruby-io/test/io.rb
+++ b/mrbgems/mruby-io/test/io.rb
@@ -5,7 +5,7 @@ MRubyIOTestUtil.io_test_setup
 $cr, $crlf, $cmd = MRubyIOTestUtil.win? ? [1, "\r\n", "cmd /c "] : [0, "\n", ""]
 
 def assert_io_open(meth)
-  assert do
+  assert "assert_io_open" do
     fd = IO.sysopen($mrbtest_io_rfname)
     assert_equal Fixnum, fd.class
     io1 = IO.__send__(meth, fd)

--- a/mrbgems/mruby-pack/test/pack.rb
+++ b/mrbgems/mruby-pack/test/pack.rb
@@ -2,7 +2,7 @@ PACK_IS_LITTLE_ENDIAN = "\x01\00".unpack('S')[0] == 0x01
 
 def assert_pack tmpl, packed, unpacked
   t = tmpl.inspect
-  assert do
+  assert "assert_pack" do
     assert_equal packed, unpacked.pack(tmpl), "#{unpacked.inspect}.pack(#{t})"
     assert_equal unpacked, packed.unpack(tmpl), "#{packed.inspect}.unpack(#{t})"
   end

--- a/mrbgems/mruby-rational/test/rational.rb
+++ b/mrbgems/mruby-rational/test/rational.rb
@@ -23,14 +23,14 @@ class ComplexLikeNumeric < UserDefinedNumeric
 end
 
 def assert_rational(exp, real)
-  assert do
+  assert "assert_rational" do
     assert_float exp.numerator,   real.numerator
     assert_float exp.denominator, real.denominator
   end
 end
 
 def assert_equal_rational(exp, o1, o2)
-  assert do
+  assert "assert_equal_rational" do
     if exp
       assert_operator(o1, :==, o2)
       assert_not_operator(o1, :!=, o2)

--- a/test/assert.rb
+++ b/test/assert.rb
@@ -76,7 +76,7 @@ end
 # iso : The ISO reference code of the feature
 #       which will be tested by this
 #       assertion
-def assert(str = 'Assertion failed', iso = '')
+def assert(str = 'assert', iso = '')
   t_print(str, (iso != '' ? " [#{iso}]" : ''), ' : ') if $mrbtest_verbose
   begin
     $mrbtest_child_noassert ||= [0]
@@ -99,10 +99,10 @@ def assert(str = 'Assertion failed', iso = '')
     yield
     if $mrbtest_assert.size > 0
       if $mrbtest_assert.size == $mrbtest_child_noassert[-1]
-        $asserts.push(assertion_string('Info: ', str, iso))
+        $asserts.push(assertion_string('Skip: ', str, iso))
         $mrbtest_child_noassert[-2] += 1
-        $ok_test += 1
-        t_print('.')
+        $skip_test += 1
+        t_print('?')
       else
         $asserts.push(assertion_string('Fail: ', str, iso))
         $ko_test += 1

--- a/test/t/numeric.rb
+++ b/test/t/numeric.rb
@@ -8,7 +8,7 @@ def  assert_step(exp, receiver, args, inf: false)
     break if inf && exp.size == act.size
   end
   expr = "#{receiver.inspect}.step(#{args.map(&:inspect).join(', ')})"
-  assert do
+  assert "assert_step" do
     assert_true(exp.eql?(act), "#{expr}: counters", assertion_diff(exp, act))
     assert_same(receiver, ret, "#{expr}: return value") unless inf
   end


### PR DESCRIPTION
- I think "Info" is used only to `skip` (@dearblue right?), so change to "Skip".
- Changed the default value of `assert` and specify the argument explicitly at the caller of `assert` because it is unnatural "Assertion failed" is output even though the assertion doesn't fail.

### Example:

```ruby
def assert_foo(exp, act)
  assert do
    assert_equal exp[0], act[0]
    assert_equal exp[1], act[1]
  end
end

def assert_bar(exp, act)
  assert do
    skip
  end
end

def assert_baz(exp, act)
  assert do
    assert_equal exp, act
    assert_bar exp, act
  end
end

assert 'test#skip_in_nested_assert' do
  assert_baz 1, 1
end
```

#### Before this patch:

```text
?..
Info: test#skip_in_nested_assert (core)
 - Assertion[1]
    Info: Assertion failed (core)
     - Assertion[1-2]
        Skip: Assertion failed (core)
  Total: 3
     OK: 2
     KO: 0
  Crash: 0
Warning: 0
   Skip: 1
```

#### After this patch:

```text
???
Skip: test#skip_in_nested_assert (core)
 - Assertion[1]
    Skip: assert (core)
     - Assertion[1-2]
        Skip: assert (core)
  Total: 3
     OK: 0
     KO: 0
  Crash: 0
Warning: 0
   Skip: 3
```