### PR TITLE
Fix UTC offset representation in `Time#to_s` on some environments; ref #4604

### DIFF
--- a/mrbgems/mruby-time/test/time.rb
+++ b/mrbgems/mruby-time/test/time.rb
@@ -239,7 +239,8 @@ assert('Time#to_s') do
 end
 
 assert('Time#inspect') do
-  assert_match("2013-10-28 16:27:48 [^U]*", Time.local(2013,10,28,16,27,48).inspect)
+  assert_match("2013-10-28 16:27:48 [+-][0-9][0-9][0-9][0-9]",
+               Time.local(2013,10,28,16,27,48).inspect)
 end
 
 assert('day of week methods') do


### PR DESCRIPTION
Use own implementation to calculate UTC offset on Visual Studio 2015 or
earlier or MinGW because `strftime("%z")` on these environments does not
conform C99.