### PR TITLE
Add new specifiers/modifiers to format string of `mrb_vfromat()`

### DIFF
--- a/mrbgems/mruby-test/driver.c
+++ b/mrbgems/mruby-test/driver.c
@@ -21,6 +21,7 @@
 extern const uint8_t mrbtest_assert_irep[];
 
 void mrbgemtest_init(mrb_state* mrb);
+void mrb_init_test_vformat(mrb_state* mrb);
 
 /* Print a short remark for the user */
 static void
@@ -230,6 +231,8 @@ mrb_init_test_driver(mrb_state *mrb, mrb_bool verbose)
   mrb_define_const(mrb, mrbtest, "FLOAT_TOLERANCE", mrb_float_value(mrb, 1e-12));
 #endif
 #endif
+
+  mrb_init_test_vformat(mrb);
 
   if (verbose) {
     mrb_gv_set(mrb, mrb_intern_lit(mrb, "$mrbtest_verbose"), mrb_true_value());

--- a/mrbgems/mruby-test/mrbgem.rake
+++ b/mrbgems/mruby-test/mrbgem.rake
@@ -15,8 +15,9 @@ MRuby::Gem::Specification.new('mruby-test') do |spec|
   mrbtest_lib = libfile("#{build_dir}/mrbtest")
   mrbtest_objs = []
 
-  driver_obj = objfile("#{build_dir}/driver")
-  # driver = "#{spec.dir}/driver.c"
+  driver_objs = Dir.glob("#{dir}/*.{c,cpp,cxx,cc,m,asm,s,S}").map do |f|
+    objfile(f.relative_path_from(dir).to_s.pathmap("#{build_dir}/%X"))
+  end
 
   assert_c = "#{build_dir}/assert.c"
   assert_rb = "#{MRUBY_ROOT}/test/assert.rb"
@@ -133,7 +134,7 @@ MRuby::Gem::Specification.new('mruby-test') do |spec|
   end
 
   unless build.build_mrbtest_lib_only?
-    file exec => [driver_obj, mlib, mrbtest_lib, build.libmruby_static] do |t|
+    file exec => [*driver_objs, mlib, mrbtest_lib, build.libmruby_static] do |t|
       gem_flags = build.gems.map { |g| g.linker.flags }
       gem_flags_before_libraries = build.gems.map { |g| g.linker.flags_before_libraries }
       gem_flags_after_libraries = build.gems.map { |g| g.linker.flags_after_libraries }

--- a/mrbgems/mruby-test/vformat.c
+++ b/mrbgems/mruby-test/vformat.c
@@ -1,0 +1,186 @@
+#include <string.h>
+#include <mruby.h>
+#include <mruby/class.h>
+#include <mruby/data.h>
+#include <mruby/string.h>
+
+#define NATIVE_TYPES                                                        \
+  char c;                                                                   \
+  mrb_float f;                                                              \
+  mrb_int i;                                                                \
+  mrb_sym n;                                                                \
+  char *s;                                                                  \
+  struct RClass *C
+
+typedef enum {
+  ARG_c,
+  ARG_f,
+  ARG_i,
+  ARG_n,
+  ARG_s,
+  ARG_C,
+  ARG_v,
+} VFArgumentType;
+
+typedef struct {
+  VFArgumentType type;
+  union { NATIVE_TYPES; };
+} VFNative;
+
+typedef struct {
+  VFArgumentType type;
+  union {
+    NATIVE_TYPES;
+    mrb_value v;
+  };
+} VFArgument;
+
+static void
+native_free(mrb_state *mrb, void *data)
+{
+  VFNative *native = (VFNative*)data;
+  if (native->type == ARG_s) mrb_free(mrb, native->s);
+  mrb_free(mrb, native);
+}
+
+static const struct mrb_data_type native_data_type = {
+  "TestVFormat::Native", native_free
+};
+
+static mrb_value
+native_initialize(mrb_state *mrb, mrb_value self)
+{
+  VFNative data, *datap;
+  mrb_value obj;
+
+  mrb_get_args(mrb, "o", &obj);
+  switch (mrb_type(obj)) {
+    case MRB_TT_FLOAT:
+      data.f = mrb_float(obj);
+      data.type = ARG_f;
+      break;
+    case MRB_TT_FIXNUM:
+      data.i = mrb_fixnum(obj);
+      data.type = ARG_i;
+      break;
+    case MRB_TT_SYMBOL:
+      data.n = mrb_symbol(obj);
+      data.type = ARG_n;
+      break;
+    case MRB_TT_CLASS: case MRB_TT_SCLASS: case MRB_TT_MODULE:
+      data.C = mrb_class_ptr(obj);
+      data.type = ARG_C;
+      break;
+    case MRB_TT_STRING: {
+      mrb_int len = RSTRING_LEN(obj);
+      const char *s = RSTRING_PTR(obj);
+      if (len == 1) {
+        /* one byte string is considered char */
+        data.c = s[0];
+        data.type = ARG_c;
+      }
+      else {
+        data.s = (char*)mrb_malloc(mrb, len + 1);
+        memcpy(data.s, s, len);
+        data.s[len] = '\0';
+        data.type = ARG_s;
+      }
+      break;
+    }
+    default: {
+      mrb_value msg = mrb_str_new_cstr(mrb, "native type for ");
+      mrb_str_cat_cstr(mrb, msg, mrb_class_name(mrb, mrb_class(mrb, obj)));
+      mrb_str_cat_cstr(mrb, msg, " is unknown");
+      mrb_raise(mrb, E_ARGUMENT_ERROR, RSTRING_PTR(msg));
+    }
+  }
+
+  datap = (VFNative*)mrb_malloc(mrb, sizeof(VFNative));
+  *datap = data;
+  mrb_data_init(self, datap, &native_data_type);
+  return self;
+}
+
+static VFArgument*
+arg_from_obj(mrb_state *mrb, mrb_value obj, struct RClass *native_class,
+             VFArgument *vf_arg)
+{
+  if (mrb_obj_is_instance_of(mrb, obj, native_class)) {
+    const VFNative *native = (VFNative*)DATA_PTR(obj);
+    *(VFNative*)vf_arg = *native;
+  }
+  else {
+    vf_arg->v = obj;
+    vf_arg->type = ARG_v;
+  }
+  return vf_arg;
+}
+
+#define VF_FORMAT_INIT(klass)                                               \
+  struct RClass *vf_native_class =                                          \
+    mrb_class_get_under(mrb, mrb_class_ptr(klass), "Native");               \
+  VFArgument vf_args[2];
+
+#define VF_ARG(args, idx) \
+  arg_from_obj(mrb, args[idx], vf_native_class, &vf_args[idx])
+
+#define VF_FORMAT0(fmt) mrb_format(mrb, fmt);
+#define VF_FORMAT1(fmt, args) \
+  (VF_ARG(args, 0), VF_FORMAT_TYPED(fmt, 1, vf_args, NULL))
+#define VF_FORMAT2(fmt, args) (                                             \
+  VF_ARG(args, 0), VF_ARG(args, 1),                                         \
+  VF_FORMAT2_COND_EXPR(fmt, vf_args, vf_args+1, c) :                        \
+  VF_FORMAT2_COND_EXPR(fmt, vf_args, vf_args+1, f) :                        \
+  VF_FORMAT2_COND_EXPR(fmt, vf_args, vf_args+1, i) :                        \
+  VF_FORMAT2_COND_EXPR(fmt, vf_args, vf_args+1, n) :                        \
+  VF_FORMAT2_COND_EXPR(fmt, vf_args, vf_args+1, s) :                        \
+  VF_FORMAT2_COND_EXPR(fmt, vf_args, vf_args+1, C) :                        \
+  VF_FORMAT2_COND_EXPR(fmt, vf_args, vf_args+1, v) :                        \
+  mrb_nil_value()  /* not reached */                                        \
+)
+#define VF_FORMAT2_COND_EXPR(fmt, a1, a2, t) \
+  a1->type == ARG_##t ? VF_FORMAT_TYPED(fmt, 2, a2, (a1)->t)
+#define VF_FORMAT_TYPED(fmt, n_arg, type_a, v1)                             \
+  VF_FORMAT_TYPED_COND_EXPR(fmt, n_arg, type_a, v1, c) :                    \
+  VF_FORMAT_TYPED_COND_EXPR(fmt, n_arg, type_a, v1, f) :                    \
+  VF_FORMAT_TYPED_COND_EXPR(fmt, n_arg, type_a, v1, i) :                    \
+  VF_FORMAT_TYPED_COND_EXPR(fmt, n_arg, type_a, v1, n) :                    \
+  VF_FORMAT_TYPED_COND_EXPR(fmt, n_arg, type_a, v1, s) :                    \
+  VF_FORMAT_TYPED_COND_EXPR(fmt, n_arg, type_a, v1, C) :                    \
+  VF_FORMAT_TYPED_COND_EXPR(fmt, n_arg, type_a, v1, v) :                    \
+  mrb_nil_value()  /* not reached */
+#define VF_FORMAT_TYPED_COND_EXPR(fmt, n_arg, type_a, v1, t)                \
+  (type_a)->type == ARG_##t ? n_arg == 1 ?                                  \
+    mrb_format(mrb, fmt, (type_a)->t) : mrb_format(mrb, fmt, v1, (type_a)->t)
+
+static mrb_value
+vf_s_format(mrb_state *mrb, mrb_value klass)
+{
+  mrb_value fmt_str, args[2];
+  mrb_int argc = mrb_get_args(mrb, "S|oo", &fmt_str, args, args+1);
+  const char *fmt = mrb_string_value_cstr(mrb, &fmt_str);
+
+  VF_FORMAT_INIT(klass);
+
+  switch (argc) {
+    case 1: return VF_FORMAT0(fmt);
+    case 2: return VF_FORMAT1(fmt, args);
+    case 3: return VF_FORMAT2(fmt, args);
+    default: return mrb_nil_value();  /* not reached */
+  }
+}
+
+void
+mrb_init_test_vformat(mrb_state *mrb)
+{
+  struct RClass *vf, *n;
+
+  vf = mrb_define_module(mrb, "TestVFormat");
+  mrb_define_class_method(mrb, vf, "format", vf_s_format, MRB_ARGS_ARG(1,2));
+
+  n = mrb_define_class_under(mrb, vf, "Native", mrb->object_class);
+  MRB_SET_INSTANCE_TT(n, MRB_TT_DATA);
+  mrb_define_method(mrb, n, "initialize", native_initialize, MRB_ARGS_REQ(1));
+  mrb_singleton_class(mrb, mrb_obj_value(n));
+  mrb_define_alias(mrb, n->c, "[]", "new");
+}

--- a/test/t/vformat.rb
+++ b/test/t/vformat.rb
@@ -1,0 +1,88 @@
+def assert_format(exp, args)
+  assert_equal(exp, TestVFormat.format(*args))
+end
+
+def assert_format_pattern(exp_pattern, args)
+  assert_match(exp_pattern, TestVFormat.format(*args))
+end
+
+# Pass if ArgumentError is raised or return value is +exp+.
+def assert_implementation_dependent(exp, args)
+  begin
+    ret = TestVFormat.format(*args)
+  rescue ArgumentError
+    return pass
+  end
+  if ret == exp
+    pass
+  else
+    flunk "", "Expected ArgumentError is raised or #{ret.inspect} to be #{exp}."
+  end
+end
+
+def sclass(v)
+  class << v
+    self
+  end
+end
+
+assert('mrb_vformat') do
+  n = TestVFormat::Native
+  assert_format '', ['']
+  assert_format 'No specifier!', ['No specifier!']
+  assert_format '`c`: C', ['`c`: %c', n[?C]]
+  assert_format '`d`: 123', ['`d`: %d', n[123]]
+  assert_format '`i`: -83', ['`i`: %i', n[-83]]
+  assert_format '`f`: 0.0125', ['`f`: %f', n[0.0125]]
+  assert_format '`t`: NilClass', ['`t`: %t', nil]
+  assert_format '`t`: FalseClass', ['`t`: %t', false]
+  assert_format '`t`: TrueClass', ['`t`: %t', true]
+  assert_format '`t`: Fixnum', ['`t`: %t', 0]
+  assert_format '`t`: Hash', ['`t`: %t', k: "value"]
+  assert_format_pattern '#<Class:#<Class:#<Hash:0x*>>>', ['%t', sclass({})]
+  assert_format '-Infinity', ['%f', n[-Float::INFINITY]]
+  assert_format 'NaN: Not a Number', ['%f: Not a Number', n[Float::NAN]]
+  assert_format 'string and length', ['string %l length', n['andante'], n[3]]
+  assert_format '`n`: sym', ['`n`: %n', n[:sym]]
+  assert_format '%C文字列%', ['%s', n['%C文字列%']]
+  assert_format '`C`: Kernel module', ['`C`: %C module', n[Kernel]]
+  assert_format '`C`: NilClass', ['`C`: %C', n[nil.class]]
+  assert_format_pattern '#<Class:#<String:0x*>>', ['%C', n[sclass("")]]
+  assert_format '`T`: NilClass', ['`T`: %T', nil]
+  assert_format '`T`: FalseClass', ['`T`: %T', false]
+  assert_format '`T`: TrueClass', ['`T`: %T', true]
+  assert_format '`T`: Fixnum', ['`T`: %T', 0]
+  assert_format '`T`: Hash', ['`T`: %T', k: "value"]
+  assert_format_pattern 'Class', ['%T', sclass({})]
+  assert_format '`Y`: nil', ['`Y`: %Y', nil]
+  assert_format '`Y`: false', ['`Y`: %Y', false]
+  assert_format '`Y`: true', ['`Y`: %Y', true]
+  assert_format '`Y`: Fixnum', ['`Y`: %Y', 0]
+  assert_format '`Y`: Hash', ['`Y`: %Y', k: "value"]
+  assert_format 'Class', ['%Y', sclass({})]
+  assert_format_pattern '#<Class:#<String:0x*>>', ['%v', sclass("")]
+  assert_format '`v`: 1...3', ['`v`: %v', 1...3]
+  assert_format '`S`: {:a=>1, "b"=>"c"}', ['`S`: %S', a: 1, "b" => ?c]
+  assert_format 'percent: %', ['percent: %%']
+  assert_format '"I": inspect char', ['%!c: inspect char', n[?I]]
+  assert_format '709: inspect mrb_int', ['%!d: inspect mrb_int', n[709]]
+  assert_format '"a\x00b\xff"', ['%!l', n["a\000b\xFFc\000d"], n[4]]
+  assert_format ':"&.": inspect symbol', ['%!n: inspect symbol', n['&.'.to_sym]]
+  assert_format 'inspect "String"', ['inspect %!v', 'String']
+  assert_format 'inspect Array: [1, :x, {}]', ['inspect Array: %!v', [1,:x,{}]]
+  assert_format_pattern '`!C`: #<Class:0x*>', ['`!C`: %!C', n[Class.new]]
+  assert_format 'to_s -> to_s: ab,cd', ['to_s -> to_s: %n,%v', n[:ab], 'cd']
+  assert_format 'to_s -> inspect: x:y', ['to_s -> inspect: %v%!v', 'x', :y]
+  assert_format 'inspect -> to_s: "a"b', ['inspect -> to_s: %!v%n', 'a', n[:b]]
+  assert_format 'Y -> to_s: nile', ['Y -> to_s: %Y%v', nil, "e"]
+  assert_format '"abc":Z', ['%!s%!n', n['abc'], n[:Z]]
+  assert_format 'escape: \\%a,b,c,d', ['escape: \\\\\%a,b,\c%v', ',d']
+
+  assert_implementation_dependent 'unknown specifier: %^',
+                                  ['unknown specifier: %^']
+  assert_implementation_dependent 'unknown specifier with modifier: %!^',
+                                  ['unknown specifier with modifier: %!^']
+  assert_implementation_dependent 'termination is \\', ['termination is \\']
+  assert_implementation_dependent 'termination is %', ['termination is %']
+  assert_implementation_dependent 'termination is %!', ['termination is %!']
+end


### PR DESCRIPTION
### Format sequence syntax:

```text
%[modifier]specifier
```

### Modifiers:

```text
----------+------------------------------------------------------------
Modifier  | Meaning
----------+------------------------------------------------------------
    !     | Convert to string by corresponding `inspect` instead of
          | corresponding `to_s`.
----------+------------------------------------------------------------
```

### Specifiers:

```text
----------+----------------+--------------------------------------------
Specifier | Argument Type  | Note
----------+----------------+--------------------------------------------
    c     | char           |
   d,i    | mrb_int        |
    f     | mrb_float      |
    l     | char*, mrb_int | Arguments are string and length.
    n     | mrb_sym        |
    s     | char*          | Argument is NUL terminated string.
    t     | mrb_value      | Convert to type (class) of object.
   v,S    | mrb_value      |
    C     | struct RClass* |
    T     | mrb_value      | Convert to real type (class) of object.
    Y     | mrb_value      | Same as `!v` if argument is `true`, `false`
          |                | or `nil`, otherwise same as `T`.
    %     | -              | Convert to percent sign itself (no argument
          |                | taken).
----------+----------------+--------------------------------------------
```

This change will increase the binary size, but replacing all format strings
with new specifiers/modifiers will decrease the size because it reduces
inline expansion of `mrb_obj_value()`, etc. at the caller.

---

I will replace all format strings if this PR is accepted.