### PR TITLE
Fix `mrb_vformat("%f")` with `MRB_USE_FLOAT`

### DIFF
--- a/mrbgems/mruby-test/vformat.c
+++ b/mrbgems/mruby-test/vformat.c
@@ -4,6 +4,11 @@
 #include <mruby/data.h>
 #include <mruby/string.h>
 
+#ifdef MRB_WITHOUT_FLOAT
+typedef mrb_int mrb_float;
+#define mrb_float(o) mrb_fixnum(o)
+#endif
+
 #define NATIVE_TYPES                                                        \
   char c;                                                                   \
   int d;                                                                    \

--- a/src/error.c
+++ b/src/error.c
@@ -328,9 +328,11 @@ mrb_vformat(mrb_state *mrb, const char *format, va_list ap)
           i = *p == 'd' ? (mrb_int)va_arg(ap, int) : va_arg(ap, mrb_int);
           obj = mrb_fixnum_value(i);
           goto L_cat_obj;
+#ifndef MRB_WITHOUT_FLOAT
         case 'f':
-          obj = mrb_float_value(mrb, va_arg(ap, mrb_float));
+          obj = mrb_float_value(mrb, (mrb_float)va_arg(ap, double));
           goto L_cat_obj;
+#endif
         case 'l':
           chars = va_arg(ap, char*);
           len = va_arg(ap, mrb_int);

--- a/test/t/vformat.rb
+++ b/test/t/vformat.rb
@@ -35,15 +35,12 @@ assert('mrb_vformat') do
   assert_format '`d`: -79', ['`d`: %d', n.d(-79)]
   assert_format '`i`: 514', ['`i`: %i', n.i(514)]
   assert_format '`i`: -83', ['`i`: %i', n.i(-83)]
-  assert_format '`f`: 0.0125', ['`f`: %f', n.f(0.0125)]
   assert_format '`t`: NilClass', ['`t`: %t', nil]
   assert_format '`t`: FalseClass', ['`t`: %t', false]
   assert_format '`t`: TrueClass', ['`t`: %t', true]
   assert_format '`t`: Fixnum', ['`t`: %t', 0]
   assert_format '`t`: Hash', ['`t`: %t', k: "value"]
   assert_format_pattern '#<Class:#<Class:#<Hash:0x*>>>', ['%t', sclass({})]
-  assert_format '-Infinity', ['%f', n.f(-Float::INFINITY)]
-  assert_format 'NaN: Not a Number', ['%f: Not a Number', n.f(Float::NAN)]
   assert_format 'string and length', ['string %l length', n.s('andante'), n.i(3)]
   assert_format '`n`: sym', ['`n`: %n', n.n(:sym)]
   assert_format '%C文字列%', ['%s', n.s('%C文字列%')]
@@ -87,4 +84,9 @@ assert('mrb_vformat') do
   assert_implementation_dependent 'termination is \\', ['termination is \\']
   assert_implementation_dependent 'termination is %', ['termination is %']
   assert_implementation_dependent 'termination is %!', ['termination is %!']
+
+  skip unless Object.const_defined?(:Float)
+  assert_format '`f`: 0.0125', ['`f`: %f', n.f(0.0125)]
+  assert_format '-Infinity', ['%f', n.f(-Float::INFINITY)]
+  assert_format 'NaN: Not a Number', ['%f: Not a Number', n.f(Float::NAN)]
 end


### PR DESCRIPTION
It potentially not work when `mrb_float` is `float` because `float` variable
in variable length arguments is promoted to `double`.

Also I fixed build with `MRB_WITHOUT_FLOAT`.