### PR TITLE
Add constants for floating point number

### DIFF
--- a/include/mruby/numeric.h
+++ b/include/mruby/numeric.h
@@ -160,6 +160,36 @@ mrb_int_mul_overflow(mrb_int multiplier, mrb_int multiplicand, mrb_int *product)
 
 #endif
 
+#ifndef MRB_WITHOUT_FLOAT
+# include <stdint.h>
+# include <float.h>
+
+# define MRB_FLT_RADIX          FLT_RADIX
+
+# ifdef MRB_USE_FLOAT
+#  define MRB_FLT_MANT_DIG      FLT_MANT_DIG
+#  define MRB_FLT_EPSILON       FLT_EPSILON
+#  define MRB_FLT_DIG           FLT_DIG
+#  define MRB_FLT_MIN_EXP       FLT_MIN_EXP
+#  define MRB_FLT_MIN           FLT_MIN
+#  define MRB_FLT_MIN_10_EXP    FLT_MIN_10_EXP
+#  define MRB_FLT_MAX_EXP       FLT_MAX_EXP
+#  define MRB_FLT_MAX           FLT_MAX
+#  define MRB_FLT_MAX_10_EXP    FLT_MAX_10_EXP
+
+# else /* not MRB_USE_FLOAT */
+#  define MRB_FLT_MANT_DIG      DBL_MANT_DIG
+#  define MRB_FLT_EPSILON       DBL_EPSILON
+#  define MRB_FLT_DIG           DBL_DIG
+#  define MRB_FLT_MIN_EXP       DBL_MIN_EXP
+#  define MRB_FLT_MIN           DBL_MIN
+#  define MRB_FLT_MIN_10_EXP    DBL_MIN_10_EXP
+#  define MRB_FLT_MAX_EXP       DBL_MAX_EXP
+#  define MRB_FLT_MAX           DBL_MAX
+#  define MRB_FLT_MAX_10_EXP    DBL_MAX_10_EXP
+# endif /* MRB_USE_FLOAT */
+#endif /* MRB_WITHOUT_FLOAT */
+
 MRB_END_DECL
 
 #endif  /* MRUBY_NUMERIC_H */

--- a/mrbgems/mruby-numeric-ext/src/numeric_ext.c
+++ b/mrbgems/mruby-numeric-ext/src/numeric_ext.c
@@ -1,5 +1,6 @@
 #include <limits.h>
 #include <mruby.h>
+#include <mruby/numeric.h>
 
 static inline mrb_int
 to_int(mrb_state *mrb, mrb_value x)
@@ -64,6 +65,19 @@ mrb_mruby_numeric_ext_gem_init(mrb_state* mrb)
   mrb_define_method(mrb, i, "allbits?", mrb_int_allbits, MRB_ARGS_REQ(1));
   mrb_define_method(mrb, i, "anybits?", mrb_int_anybits, MRB_ARGS_REQ(1));
   mrb_define_method(mrb, i, "nobits?", mrb_int_nobits, MRB_ARGS_REQ(1));
+
+#ifndef MRB_WITHOUT_FLOAT
+  mrb_define_const(mrb, mrb->float_class, "RADIX",        mrb_fixnum_value(MRB_FLT_RADIX));
+  mrb_define_const(mrb, mrb->float_class, "MANT_DIG",     mrb_fixnum_value(MRB_FLT_MANT_DIG));
+  mrb_define_const(mrb, mrb->float_class, "EPSILON",      mrb_float_value(mrb, MRB_FLT_EPSILON));
+  mrb_define_const(mrb, mrb->float_class, "DIG",          mrb_fixnum_value(MRB_FLT_DIG));
+  mrb_define_const(mrb, mrb->float_class, "MIN_EXP",      mrb_fixnum_value(MRB_FLT_MIN_EXP));
+  mrb_define_const(mrb, mrb->float_class, "MIN",          mrb_float_value(mrb, MRB_FLT_MIN));
+  mrb_define_const(mrb, mrb->float_class, "MIN_10_EXP",   mrb_fixnum_value(MRB_FLT_MIN_10_EXP));
+  mrb_define_const(mrb, mrb->float_class, "MAX_EXP",      mrb_fixnum_value(MRB_FLT_MAX_EXP));
+  mrb_define_const(mrb, mrb->float_class, "MAX",          mrb_float_value(mrb, MRB_FLT_MAX));
+  mrb_define_const(mrb, mrb->float_class, "MAX_10_EXP",   mrb_fixnum_value(MRB_FLT_MAX_10_EXP));
+#endif /* MRB_WITHOUT_FLOAT */
 }
 
 void


### PR DESCRIPTION
- Added macros available from C to `include/mruby/numeric.h`.
- Added the constants available from Ruby space to `mruby-numeric-ext`.
   Since `MRB_FLT_ROUNDS` can change its behavior, it is defined as a class method.