### PR TITLE
Use new specifiers/modifiers of `mrb_vfromat()`

### DIFF
--- a/mrbgems/mruby-compiler/core/codegen.c
+++ b/mrbgems/mruby-compiler/core/codegen.c
@@ -2373,7 +2373,7 @@ codegen(codegen_scope *s, node *tree, int val)
       mrb_value str;
       int sym;
 
-      str = mrb_format(mrb, "$%S", mrb_fixnum_value(nint(tree)));
+      str = mrb_format(mrb, "$%d", nint(tree));
       sym = new_sym(s, mrb_intern_str(mrb, str));
       genop_2(s, OP_GETGV, cursp(), sym);
       push();

--- a/mrbgems/mruby-compiler/core/parse.y
+++ b/mrbgems/mruby-compiler/core/parse.y
@@ -3831,7 +3831,7 @@ backref_error(parser_state *p, node *n)
     yyerror_c(p, "can't set variable $", (char)intn(n->cdr));
   }
   else {
-    mrb_bug(p->mrb, "Internal error in backref_error() : n=>car == %S", mrb_fixnum_value(c));
+    mrb_bug(p->mrb, "Internal error in backref_error() : n=>car == %d", c);
   }
 }
 

--- a/mrbgems/mruby-complex/src/complex.c
+++ b/mrbgems/mruby-complex/src/complex.c
@@ -101,7 +101,7 @@ complex_to_f(mrb_state *mrb, mrb_value self)
   struct mrb_complex *p = complex_ptr(mrb, self);
 
   if (p->imaginary != 0) {
-    mrb_raisef(mrb, E_RANGE_ERROR, "can't convert %S into Float", self);
+    mrb_raisef(mrb, E_RANGE_ERROR, "can't convert %v into Float", self);
   }
 
   return mrb_float_value(mrb, p->real);
@@ -113,7 +113,7 @@ complex_to_i(mrb_state *mrb, mrb_value self)
   struct mrb_complex *p = complex_ptr(mrb, self);
 
   if (p->imaginary != 0) {
-    mrb_raisef(mrb, E_RANGE_ERROR, "can't convert %S into Float", self);
+    mrb_raisef(mrb, E_RANGE_ERROR, "can't convert %v into Float", self);
   }
   return mrb_int_value(mrb, p->real);
 }

--- a/mrbgems/mruby-eval/src/eval.c
+++ b/mrbgems/mruby-eval/src/eval.c
@@ -254,15 +254,15 @@ create_proc_from_string(mrb_state *mrb, char *s, mrb_int len, mrb_value binding,
     mrb_value str;
 
     if (file) {
-      str = mrb_format(mrb, " file %S line %S: %S",
-                       mrb_str_new_cstr(mrb, file),
-                       mrb_fixnum_value(p->error_buffer[0].lineno),
-                       mrb_str_new_cstr(mrb, p->error_buffer[0].message));
+      str = mrb_format(mrb, "file %s line %d: %s",
+                       file,
+                       p->error_buffer[0].lineno,
+                       p->error_buffer[0].message);
     }
     else {
-      str = mrb_format(mrb, " line %S: %S",
-                       mrb_fixnum_value(p->error_buffer[0].lineno),
-                       mrb_str_new_cstr(mrb, p->error_buffer[0].message));
+      str = mrb_format(mrb, "line %d: %s",
+                       p->error_buffer[0].lineno,
+                       p->error_buffer[0].message);
     }
     mrb_parser_free(p);
     mrbc_context_free(mrb, cxt);

--- a/mrbgems/mruby-io/src/file.c
+++ b/mrbgems/mruby-io/src/file.c
@@ -146,7 +146,7 @@ mrb_file_s_rename(mrb_state *mrb, mrb_value obj)
 #endif
     mrb_locale_free(src);
     mrb_locale_free(dst);
-    mrb_sys_fail(mrb, RSTRING_PTR(mrb_format(mrb, "(%S, %S)", from, to)));
+    mrb_sys_fail(mrb, RSTRING_PTR(mrb_format(mrb, "(%v, %v)", from, to)));
   }
   mrb_locale_free(src);
   mrb_locale_free(dst);
@@ -307,7 +307,7 @@ mrb_file__gethome(mrb_state *mrb, mrb_value klass)
     }
     home = pwd->pw_dir;
     if (!mrb_file_is_absolute_path(home)) {
-      mrb_raisef(mrb, E_ARGUMENT_ERROR, "non-absolute home of ~%S", username);
+      mrb_raisef(mrb, E_ARGUMENT_ERROR, "non-absolute home of ~%v", username);
     }
   }
   home = mrb_locale_from_utf8(home, -1);
@@ -398,7 +398,7 @@ mrb_file_s_symlink(mrb_state *mrb, mrb_value klass)
   if (symlink(src, dst) == -1) {
     mrb_locale_free(src);
     mrb_locale_free(dst);
-    mrb_sys_fail(mrb, mrb_str_to_cstr(mrb, mrb_format(mrb, "(%S, %S)", from, to)));
+    mrb_sys_fail(mrb, RSTRING_PTR(mrb_format(mrb, "(%v, %v)", from, to)));
   }
   mrb_locale_free(src);
   mrb_locale_free(dst);

--- a/mrbgems/mruby-io/src/io.c
+++ b/mrbgems/mruby-io/src/io.c
@@ -127,7 +127,7 @@ mrb_io_modestr_to_flags(mrb_state *mrb, const char *mode)
       flags |= FMODE_WRITABLE | FMODE_APPEND | FMODE_CREATE;
       break;
     default:
-      mrb_raisef(mrb, E_ARGUMENT_ERROR, "illegal access mode %S", mrb_str_new_cstr(mrb, mode));
+      mrb_raisef(mrb, E_ARGUMENT_ERROR, "illegal access mode %s", mode);
   }
 
   while (*m) {
@@ -141,7 +141,7 @@ mrb_io_modestr_to_flags(mrb_state *mrb, const char *mode)
       case ':':
         /* XXX: PASSTHROUGH*/
       default:
-        mrb_raisef(mrb, E_ARGUMENT_ERROR, "illegal access mode %S", mrb_str_new_cstr(mrb, mode));
+        mrb_raisef(mrb, E_ARGUMENT_ERROR, "illegal access mode %s", mode);
     }
   }
 
@@ -191,8 +191,7 @@ mrb_fd_cloexec(mrb_state *mrb, int fd)
 
   flags = fcntl(fd, F_GETFD);
   if (flags == -1) {
-    mrb_bug(mrb, "mrb_fd_cloexec: fcntl(%S, F_GETFD) failed: %S",
-      mrb_fixnum_value(fd), mrb_fixnum_value(errno));
+    mrb_bug(mrb, "mrb_fd_cloexec: fcntl(%d, F_GETFD) failed: %d", fd, errno);
   }
   if (fd <= 2) {
     flags2 = flags & ~FD_CLOEXEC; /* Clear CLOEXEC for standard file descriptors: 0, 1, 2. */
@@ -202,8 +201,7 @@ mrb_fd_cloexec(mrb_state *mrb, int fd)
   }
   if (flags != flags2) {
     if (fcntl(fd, F_SETFD, flags2) == -1) {
-      mrb_bug(mrb, "mrb_fd_cloexec: fcntl(%S, F_SETFD, %S) failed: %S",
-        mrb_fixnum_value(fd), mrb_fixnum_value(flags2), mrb_fixnum_value(errno));
+      mrb_bug(mrb, "mrb_fd_cloexec: fcntl(%d, F_SETFD, %d) failed: %d", fd, flags2, errno);
     }
   }
 #endif
@@ -381,7 +379,7 @@ mrb_io_s_popen(mrb_state *mrb, mrb_value klass)
       CloseHandle(ifd[1]);
       CloseHandle(ofd[0]);
       CloseHandle(ofd[1]);
-      mrb_raisef(mrb, E_IO_ERROR, "command not found: %S", cmd);
+      mrb_raisef(mrb, E_IO_ERROR, "command not found: %v", cmd);
     }
     CloseHandle(pi.hThread);
     CloseHandle(ifd[0]);
@@ -494,7 +492,7 @@ mrb_io_s_popen(mrb_state *mrb, mrb_value klass)
           close(fd);
         }
         mrb_proc_exec(pname);
-        mrb_raisef(mrb, E_IO_ERROR, "command not found: %S", cmd);
+        mrb_raisef(mrb, E_IO_ERROR, "command not found: %v", cmd);
         _exit(127);
       }
       result = mrb_nil_value();
@@ -783,9 +781,7 @@ reopen:
       }
     }
 
-    emsg = mrb_format(mrb, "open %S", mrb_str_new_cstr(mrb, pathname));
-    mrb_str_modify(mrb, mrb_str_ptr(emsg));
-    mrb_sys_fail(mrb, RSTRING_PTR(emsg));
+    mrb_sys_fail(mrb, RSTRING_PTR(mrb_format(mrb, "open %s", pathname)));
   }
   mrb_locale_free(fname);
 
@@ -1068,7 +1064,7 @@ mrb_io_s_select(mrb_state *mrb, mrb_value klass)
   mrb_get_args(mrb, "*", &argv, &argc);
 
   if (argc < 1 || argc > 4) {
-    mrb_raisef(mrb, E_ARGUMENT_ERROR, "wrong number of arguments (%S for 1..4)", mrb_fixnum_value(argc));
+    mrb_raisef(mrb, E_ARGUMENT_ERROR, "wrong number of arguments (%i for 1..4)", argc);
   }
 
   timeout = mrb_nil_value();

--- a/mrbgems/mruby-io/test/mruby_io_test.c
+++ b/mrbgems/mruby-io/test/mruby_io_test.c
@@ -136,9 +136,9 @@ mrb_io_test_io_setup(mrb_state *mrb, mrb_value self)
   sun0.sun_family = AF_UNIX;
   snprintf(sun0.sun_path, sizeof(sun0.sun_path), "%s", socketname);
   if (bind(fd3, (struct sockaddr *)&sun0, sizeof(sun0)) == -1) {
-    mrb_raisef(mrb, E_RUNTIME_ERROR, "can't bind AF_UNIX socket to %S: %S",
-               mrb_str_new_cstr(mrb, sun0.sun_path),
-               mrb_fixnum_value(errno));
+    mrb_raisef(mrb, E_RUNTIME_ERROR, "can't bind AF_UNIX socket to %s: %d",
+               sun0.sun_path,
+               errno);
   }
   close(fd3);
 #endif

--- a/mrbgems/mruby-kernel-ext/src/kernel.c
+++ b/mrbgems/mruby-kernel-ext/src/kernel.c
@@ -31,22 +31,21 @@ mrb_f_caller(mrb_state *mrb, mrb_value self)
         }
       }
       else {
-        v = mrb_to_int(mrb, v);
-        lev = mrb_fixnum(v);
+        lev = mrb_int(mrb, v);
         if (lev < 0) {
-          mrb_raisef(mrb, E_ARGUMENT_ERROR, "negative level (%S)", v);
+          mrb_raisef(mrb, E_ARGUMENT_ERROR, "negative level (%v)", v);
         }
         n = bt_len - lev;
       }
       break;
     case 2:
-      lev = mrb_fixnum(mrb_to_int(mrb, v));
-      n = mrb_fixnum(mrb_to_int(mrb, length));
+      lev = mrb_int(mrb, v);
+      n = mrb_int(mrb, length);
       if (lev < 0) {
-        mrb_raisef(mrb, E_ARGUMENT_ERROR, "negative level (%S)", v);
+        mrb_raisef(mrb, E_ARGUMENT_ERROR, "negative level (%v)", v);
       }
       if (n < 0) {
-        mrb_raisef(mrb, E_ARGUMENT_ERROR, "negative size (%S)", length);
+        mrb_raisef(mrb, E_ARGUMENT_ERROR, "negative size (%v)", length);
       }
       break;
     default:

--- a/mrbgems/mruby-math/src/math.c
+++ b/mrbgems/mruby-math/src/math.c
@@ -18,8 +18,7 @@ domain_error(mrb_state *mrb, const char *func)
 {
   struct RClass *math = mrb_module_get(mrb, "Math");
   struct RClass *domainerror = mrb_class_get_under(mrb, math, "DomainError");
-  mrb_value str = mrb_str_new_cstr(mrb, func);
-  mrb_raisef(mrb, domainerror, "Numerical argument is out of domain - %S", str);
+  mrb_raisef(mrb, domainerror, "Numerical argument is out of domain - %s", func);
 }
 
 /* math functions not provided by Microsoft Visual C++ 2012 or older */

--- a/mrbgems/mruby-metaprog/src/metaprog.c
+++ b/mrbgems/mruby-metaprog/src/metaprog.c
@@ -414,7 +414,7 @@ check_cv_name_sym(mrb_state *mrb, mrb_sym id)
   mrb_int len;
   const char *name = mrb_sym2name_len(mrb, id, &len);
   if (!cv_name_p(mrb, name, len)) {
-    mrb_name_error(mrb, id, "'%S' is not allowed as a class variable name", mrb_sym2str(mrb, id));
+    mrb_name_error(mrb, id, "'%n' is not allowed as a class variable name", id);
   }
 }
 
@@ -454,12 +454,10 @@ mrb_mod_remove_cvar(mrb_state *mrb, mrb_value mod)
   if (!mrb_undef_p(val)) return val;
 
   if (mrb_cv_defined(mrb, mod, id)) {
-    mrb_name_error(mrb, id, "cannot remove %S for %S",
-                   mrb_sym2str(mrb, id), mod);
+    mrb_name_error(mrb, id, "cannot remove %n for %v", id, mod);
   }
 
-  mrb_name_error(mrb, id, "class variable %S not defined for %S",
-                 mrb_sym2str(mrb, id), mod);
+  mrb_name_error(mrb, id, "class variable %n not defined for %v", id, mod);
 
  /* not reached */
  return mrb_nil_value();
@@ -622,8 +620,7 @@ remove_method(mrb_state *mrb, mrb_value mod, mrb_sym mid)
     }
   }
 
-  mrb_name_error(mrb, mid, "method '%S' not defined in %S",
-                 mrb_sym2str(mrb, mid), mod);
+  mrb_name_error(mrb, mid, "method '%n' not defined in %v", mid, mod);
 }
 
 /* 15.2.2.4.41 */

--- a/mrbgems/mruby-method/src/method.c
+++ b/mrbgems/mruby-method/src/method.c
@@ -29,8 +29,7 @@ unbound_method_bind(mrb_state *mrb, mrb_value self)
         if (mrb_type(owner) == MRB_TT_SCLASS) {
           mrb_raise(mrb, E_TYPE_ERROR, "singleton method called for a different object");
         } else {
-          const char *s = mrb_class_name(mrb, mrb_class_ptr(owner));
-          mrb_raisef(mrb, E_TYPE_ERROR, "bind argument must be an instance of %S", mrb_str_new_static(mrb, s, strlen(s)));
+          mrb_raisef(mrb, E_TYPE_ERROR, "bind argument must be an instance of %v", owner);
         }
   }
   me = method_object_alloc(mrb, mrb_class_get(mrb, "Method"));
@@ -289,7 +288,6 @@ static void
 mrb_search_method_owner(mrb_state *mrb, struct RClass *c, mrb_value obj, mrb_sym name, struct RClass **owner, struct RProc **proc, mrb_bool unbound)
 {
   mrb_value ret;
-  const char *s;
 
   *owner = c;
   *proc = method_search_vm(mrb, owner, name);
@@ -313,13 +311,7 @@ mrb_search_method_owner(mrb_state *mrb, struct RClass *c, mrb_value obj, mrb_sym
   return;
 
 name_error:
-  s = mrb_class_name(mrb, c);
-  mrb_raisef(
-    mrb, E_NAME_ERROR,
-    "undefined method '%S' for class '%S'",
-    mrb_sym2str(mrb, name),
-    mrb_str_new_static(mrb, s, strlen(s))
-  );
+  mrb_raisef(mrb, E_NAME_ERROR, "undefined method '%n' for class '%C'", name, c);
 }
 
 static mrb_value

--- a/mrbgems/mruby-pack/src/pack.c
+++ b/mrbgems/mruby-pack/src/pack.c
@@ -529,8 +529,8 @@ utf8_to_uv(mrb_state *mrb, const char *p, long *lenp)
     mrb_raise(mrb, E_ARGUMENT_ERROR, "malformed UTF-8 character");
   }
   if (n > *lenp) {
-    mrb_raisef(mrb, E_ARGUMENT_ERROR, "malformed UTF-8 character (expected %S bytes, given %S bytes)",
-               mrb_fixnum_value(n), mrb_fixnum_value(*lenp));
+    mrb_raisef(mrb, E_ARGUMENT_ERROR, "malformed UTF-8 character (expected %d bytes, given %d bytes)",
+               n, *lenp);
   }
   *lenp = n--;
   if (n != 0) {
@@ -976,7 +976,7 @@ alias:
       case 4: t = 'L'; goto alias;
       case 8: t = 'Q'; goto alias;
       default:
-        mrb_raisef(mrb, E_RUNTIME_ERROR, "mruby-pack does not support sizeof(int) == %S", mrb_fixnum_value(sizeof(int)));
+        mrb_raisef(mrb, E_RUNTIME_ERROR, "mruby-pack does not support sizeof(int) == %d", (int)sizeof(int));
     }
     break;
   case 'i':
@@ -985,7 +985,7 @@ alias:
       case 4: t = 'l'; goto alias;
       case 8: t = 'q'; goto alias;
       default:
-        mrb_raisef(mrb, E_RUNTIME_ERROR, "mruby-pack does not support sizeof(int) == %S", mrb_fixnum_value(sizeof(int)));
+        mrb_raisef(mrb, E_RUNTIME_ERROR, "mruby-pack does not support sizeof(int) == %d", (int)sizeof(int));
     }
     break;
   case 'L':
@@ -1086,8 +1086,7 @@ alias:
       count = -1;
     } else if (ch == '_' || ch == '!' || ch == '<' || ch == '>') {
       if (strchr("sSiIlLqQ", (int)t) == NULL) {
-        char ch_str = (char)ch;
-        mrb_raisef(mrb, E_ARGUMENT_ERROR, "'%S' allowed only after types sSiIlLqQ", mrb_str_new(mrb, &ch_str, 1));
+        mrb_raisef(mrb, E_ARGUMENT_ERROR, "'%c' allowed only after types sSiIlLqQ", ch);
       }
       if (ch == '_' || ch == '!') {
         flags |= PACK_FLAG_s;
@@ -1156,7 +1155,7 @@ mrb_pack_pack(mrb_state *mrb, mrb_value ary)
 #endif
       else if (type == PACK_TYPE_STRING) {
         if (!mrb_string_p(o)) {
-          mrb_raisef(mrb, E_TYPE_ERROR, "can't convert %S into String", mrb_class_path(mrb, mrb_obj_class(mrb, o)));
+          mrb_raisef(mrb, E_TYPE_ERROR, "can't convert %T into String", o);
         }
       }
 

--- a/mrbgems/mruby-socket/src/socket.c
+++ b/mrbgems/mruby-socket/src/socket.c
@@ -171,7 +171,7 @@ mrb_addrinfo_getaddrinfo(mrb_state *mrb, mrb_value klass)
 
   error = getaddrinfo(hostname, servname, &hints, &res0);
   if (error) {
-    mrb_raisef(mrb, E_SOCKET_ERROR, "getaddrinfo: %S", mrb_str_new_cstr(mrb, gai_strerror(error)));
+    mrb_raisef(mrb, E_SOCKET_ERROR, "getaddrinfo: %s", gai_strerror(error));
   }
   mrb_cv_set(mrb, klass, mrb_intern_lit(mrb, "_lastai"), mrb_cptr_value(mrb, res0));
 
@@ -206,7 +206,7 @@ mrb_addrinfo_getnameinfo(mrb_state *mrb, mrb_value self)
   }
   error = getnameinfo((struct sockaddr *)RSTRING_PTR(sastr), (socklen_t)RSTRING_LEN(sastr), RSTRING_PTR(host), NI_MAXHOST, RSTRING_PTR(serv), NI_MAXSERV, (int)flags);
   if (error) {
-    mrb_raisef(mrb, E_SOCKET_ERROR, "getnameinfo: %S", mrb_str_new_cstr(mrb, gai_strerror(error)));
+    mrb_raisef(mrb, E_SOCKET_ERROR, "getnameinfo: %s", gai_strerror(error));
   }
   ary = mrb_ary_new_capa(mrb, 2);
   mrb_str_resize(mrb, host, strlen(RSTRING_PTR(host)));
@@ -476,7 +476,7 @@ mrb_basicsocket_setsockopt(mrb_state *mrb, mrb_value self)
     optname = mrb_fixnum(mrb_funcall(mrb, so, "optname", 0));
     optval = mrb_funcall(mrb, so, "data", 0);
   } else {
-    mrb_raisef(mrb, E_ARGUMENT_ERROR, "wrong number of arguments (%S for 3)", mrb_fixnum_value(argc));
+    mrb_raisef(mrb, E_ARGUMENT_ERROR, "wrong number of arguments (%i for 3)", argc);
   }
 
   s = socket_fd(mrb, self);
@@ -702,7 +702,7 @@ mrb_socket_sockaddr_un(mrb_state *mrb, mrb_value klass)
 
   mrb_get_args(mrb, "S", &path);
   if ((size_t)RSTRING_LEN(path) > sizeof(sunp->sun_path) - 1) {
-    mrb_raisef(mrb, E_ARGUMENT_ERROR, "too long unix socket path (max: %S bytes)", mrb_fixnum_value(sizeof(sunp->sun_path) - 1));
+    mrb_raisef(mrb, E_ARGUMENT_ERROR, "too long unix socket path (max: %d bytes)", (int)sizeof(sunp->sun_path) - 1);
   }
   s = mrb_str_buf_new(mrb, sizeof(struct sockaddr_un));
   sunp = (struct sockaddr_un *)RSTRING_PTR(s);

--- a/mrbgems/mruby-sprintf/src/sprintf.c
+++ b/mrbgems/mruby-sprintf/src/sprintf.c
@@ -81,7 +81,7 @@ mrb_fix2binstr(mrb_state *mrb, mrb_value x, int base)
   char d;
 
   if (base != 2) {
-    mrb_raisef(mrb, E_ARGUMENT_ERROR, "invalid radix %S", mrb_fixnum_value(base));
+    mrb_raisef(mrb, E_ARGUMENT_ERROR, "invalid radix %d", base);
   }
   if (val == 0) {
     return mrb_str_new_lit(mrb, "0");
@@ -144,10 +144,10 @@ check_next_arg(mrb_state *mrb, int posarg, int nextarg)
 {
   switch (posarg) {
   case -1:
-    mrb_raisef(mrb, E_ARGUMENT_ERROR, "unnumbered(%S) mixed with numbered", mrb_fixnum_value(nextarg));
+    mrb_raisef(mrb, E_ARGUMENT_ERROR, "unnumbered(%d) mixed with numbered", nextarg);
     break;
   case -2:
-    mrb_raisef(mrb, E_ARGUMENT_ERROR, "unnumbered(%S) mixed with named", mrb_fixnum_value(nextarg));
+    mrb_raisef(mrb, E_ARGUMENT_ERROR, "unnumbered(%d) mixed with named", nextarg);
     break;
   default:
     break;
@@ -158,26 +158,26 @@ static void
 check_pos_arg(mrb_state *mrb, mrb_int posarg, mrb_int n)
 {
   if (posarg > 0) {
-    mrb_raisef(mrb, E_ARGUMENT_ERROR, "numbered(%S) after unnumbered(%S)",
-               mrb_fixnum_value(n), mrb_fixnum_value(posarg));
+    mrb_raisef(mrb, E_ARGUMENT_ERROR, "numbered(%i) after unnumbered(%i)",
+               n, posarg);
   }
   if (posarg == -2) {
-    mrb_raisef(mrb, E_ARGUMENT_ERROR, "numbered(%S) after named", mrb_fixnum_value(n));
+    mrb_raisef(mrb, E_ARGUMENT_ERROR, "numbered(%i) after named", n);
   }
   if (n < 1) {
-    mrb_raisef(mrb, E_ARGUMENT_ERROR, "invalid index - %S$", mrb_fixnum_value(n));
+    mrb_raisef(mrb, E_ARGUMENT_ERROR, "invalid index - %i$", n);
   }
 }
 
 static void
-check_name_arg(mrb_state *mrb, int posarg, const char *name, mrb_int len)
+check_name_arg(mrb_state *mrb, int posarg, const char *name, size_t len)
 {
   if (posarg > 0) {
-    mrb_raisef(mrb, E_ARGUMENT_ERROR, "named%S after unnumbered(%S)",
-               mrb_str_new(mrb, (name), (len)), mrb_fixnum_value(posarg));
+    mrb_raisef(mrb, E_ARGUMENT_ERROR, "named%l after unnumbered(%d)",
+               name, len, posarg);
   }
   if (posarg == -1) {
-    mrb_raisef(mrb, E_ARGUMENT_ERROR, "named%S after numbered", mrb_str_new(mrb, (name), (len)));
+    mrb_raisef(mrb, E_ARGUMENT_ERROR, "named%l after numbered", name, len);
   }
 }
 
@@ -580,7 +580,7 @@ mrb_str_format(mrb_state *mrb, mrb_int argc, const mrb_value *argv, mrb_value fm
 retry:
     switch (*p) {
       default:
-        mrb_raisef(mrb, E_ARGUMENT_ERROR, "malformed format string - \\%%S", mrb_str_new(mrb, p, 1));
+        mrb_raisef(mrb, E_ARGUMENT_ERROR, "malformed format string - %%%c", *p);
         break;
 
       case ' ':
@@ -619,7 +619,7 @@ retry:
         GETNUM(n, width);
         if (*p == '$') {
           if (!mrb_undef_p(nextvalue)) {
-            mrb_raisef(mrb, E_ARGUMENT_ERROR, "value given twice - %S$", mrb_fixnum_value(n));
+            mrb_raisef(mrb, E_ARGUMENT_ERROR, "value given twice - %i$", n);
           }
           nextvalue = GETPOSARG(n);
           p++;
@@ -639,14 +639,14 @@ retry:
         for (; p < end && *p != term; )
           p++;
         if (id) {
-          mrb_raisef(mrb, E_ARGUMENT_ERROR, "name%S after <%S>",
-                     mrb_str_new(mrb, start, p - start + 1), mrb_sym2str(mrb, id));
+          mrb_raisef(mrb, E_ARGUMENT_ERROR, "name%l after <%n>",
+                     start, p - start + 1, id);
         }
         symname = mrb_str_new(mrb, start + 1, p - start - 1);
         id = mrb_intern_str(mrb, symname);
-        nextvalue = GETNAMEARG(mrb_symbol_value(id), start, (mrb_int)(p - start + 1));
+        nextvalue = GETNAMEARG(mrb_symbol_value(id), start, p - start + 1);
         if (mrb_undef_p(nextvalue)) {
-          mrb_raisef(mrb, E_KEY_ERROR, "key%S not found", mrb_str_new(mrb, start, p - start + 1));
+          mrb_raisef(mrb, E_KEY_ERROR, "key%l not found", start, p - start + 1);
         }
         if (term == '}') goto format_s;
         p++;
@@ -1089,7 +1089,7 @@ retry:
   if (posarg >= 0 && nextarg < argc) {
     const char *mesg = "too many arguments for format string";
     if (mrb_test(ruby_debug)) mrb_raise(mrb, E_ARGUMENT_ERROR, mesg);
-    if (mrb_test(ruby_verbose)) mrb_warn(mrb, "%S", mrb_str_new_cstr(mrb, mesg));
+    if (mrb_test(ruby_verbose)) mrb_warn(mrb, "%s", mesg);
   }
 #endif
   mrb_str_resize(mrb, result, blen);

--- a/mrbgems/mruby-string-ext/src/string.c
+++ b/mrbgems/mruby-string-ext/src/string.c
@@ -40,7 +40,7 @@ int_chr_binary(mrb_state *mrb, mrb_value num)
   mrb_value str;
 
   if (cp < 0 || 0xff < cp) {
-    mrb_raisef(mrb, E_RANGE_ERROR, "%S out of char range", num);
+    mrb_raisef(mrb, E_RANGE_ERROR, "%v out of char range", num);
   }
   c = (char)cp;
   str = mrb_str_new(mrb, &c, 1);
@@ -59,7 +59,7 @@ int_chr_utf8(mrb_state *mrb, mrb_value num)
   uint32_t ascii_flag = 0;
 
   if (cp < 0 || 0x10FFFF < cp) {
-    mrb_raisef(mrb, E_RANGE_ERROR, "%S out of char range", num);
+    mrb_raisef(mrb, E_RANGE_ERROR, "%v out of char range", num);
   }
   if (cp < 0x80) {
     utf8[0] = (char)cp;
@@ -114,7 +114,7 @@ mrb_str_setbyte(mrb_state *mrb, mrb_value str)
 
   len = RSTRING_LEN(str);
   if (pos < -len || len <= pos)
-    mrb_raisef(mrb, E_INDEX_ERROR, "index %S out of string", mrb_fixnum_value(pos));
+    mrb_raisef(mrb, E_INDEX_ERROR, "index %i out of string", pos);
   if (pos < 0)
     pos += len;
 
@@ -583,8 +583,7 @@ str_tr(mrb_state *mrb, mrb_value str, mrb_value p1, mrb_value p2, mrb_bool squee
           continue;
         }
         if (c > 0x80) {
-          mrb_raisef(mrb, E_ARGUMENT_ERROR, "character (%S) out of range",
-                     mrb_fixnum_value((mrb_int)c));
+          mrb_raisef(mrb, E_ARGUMENT_ERROR, "character (%i) out of range", c);
         }
 	lastch = c;
 	s[i] = (char)c;
@@ -956,7 +955,7 @@ mrb_int_chr(mrb_state *mrb, mrb_value num)
   }
 #endif
   else {
-    mrb_raisef(mrb, E_ARGUMENT_ERROR, "unknown encoding name - %S", enc);
+    mrb_raisef(mrb, E_ARGUMENT_ERROR, "unknown encoding name - %v", enc);
   }
   /* not reached */
   return mrb_nil_value();

--- a/mrbgems/mruby-struct/src/struct.c
+++ b/mrbgems/mruby-struct/src/struct.c
@@ -66,8 +66,8 @@ struct_members(mrb_state *mrb, mrb_value s)
     }
     else {
       mrb_raisef(mrb, E_TYPE_ERROR,
-                 "struct size differs (%S required %S given)",
-                 mrb_fixnum_value(RARRAY_LEN(members)), mrb_fixnum_value(RSTRUCT_LEN(s)));
+                 "struct size differs (%i required %i given)",
+                 RARRAY_LEN(members), RSTRUCT_LEN(s));
     }
   }
   return members;
@@ -205,10 +205,10 @@ make_struct(mrb_state *mrb, mrb_value name, mrb_value members, struct RClass *kl
     mrb_to_str(mrb, name);
     id = mrb_obj_to_sym(mrb, name);
     if (!mrb_const_name_p(mrb, RSTRING_PTR(name), RSTRING_LEN(name))) {
-      mrb_name_error(mrb, id, "identifier %S needs to be constant", name);
+      mrb_name_error(mrb, id, "identifier %v needs to be constant", name);
     }
     if (mrb_const_defined_at(mrb, mrb_obj_value(klass), id)) {
-      mrb_warn(mrb, "redefining constant Struct::%S", name);
+      mrb_warn(mrb, "redefining constant Struct::%v", name);
       mrb_const_remove(mrb, mrb_obj_value(klass), id);
     }
     c = mrb_define_class_under(mrb, klass, RSTRING_PTR(name), klass);
@@ -388,7 +388,7 @@ struct_aref_sym(mrb_state *mrb, mrb_value obj, mrb_sym id)
       return ptr[i];
     }
   }
-  mrb_name_error(mrb, id, "no member '%S' in struct", mrb_sym2str(mrb, id));
+  mrb_name_error(mrb, id, "no member '%n' in struct", id);
   return mrb_nil_value();       /* not reached */
 }
 
@@ -399,12 +399,10 @@ struct_aref_int(mrb_state *mrb, mrb_value s, mrb_int i)
 
   if (idx < 0)
     mrb_raisef(mrb, E_INDEX_ERROR,
-               "offset %S too small for struct(size:%S)",
-               mrb_fixnum_value(i), mrb_fixnum_value(RSTRUCT_LEN(s)));
+               "offset %i too small for struct(size:%i)", i, RSTRUCT_LEN(s));
   if (RSTRUCT_LEN(s) <= idx)
     mrb_raisef(mrb, E_INDEX_ERROR,
-               "offset %S too large for struct(size:%S)",
-               mrb_fixnum_value(i), mrb_fixnum_value(RSTRUCT_LEN(s)));
+               "offset %i too large for struct(size:%i)", i, RSTRUCT_LEN(s));
   return RSTRUCT_PTR(s)[idx];
 }
 
@@ -437,7 +435,7 @@ mrb_struct_aref(mrb_state *mrb, mrb_value s)
     mrb_value sym = mrb_check_intern_str(mrb, idx);
 
     if (mrb_nil_p(sym)) {
-      mrb_name_error(mrb, mrb_intern_str(mrb, idx), "no member '%S' in struct", idx);
+      mrb_name_error(mrb, mrb_intern_str(mrb, idx), "no member '%v' in struct", idx);
     }
     idx = sym;
   }
@@ -465,7 +463,7 @@ mrb_struct_aset_sym(mrb_state *mrb, mrb_value s, mrb_sym id, mrb_value val)
       return val;
     }
   }
-  mrb_name_error(mrb, id, "no member '%S' in struct", mrb_sym2str(mrb, id));
+  mrb_name_error(mrb, id, "no member '%n' in struct", id);
   return val;                   /* not reach */
 }
 
@@ -504,7 +502,7 @@ mrb_struct_aset(mrb_state *mrb, mrb_value s)
     mrb_value sym = mrb_check_intern_str(mrb, idx);
 
     if (mrb_nil_p(sym)) {
-      mrb_name_error(mrb, mrb_intern_str(mrb, idx), "no member '%S' in struct", idx);
+      mrb_name_error(mrb, mrb_intern_str(mrb, idx), "no member '%v' in struct", idx);
     }
     idx = sym;
   }
@@ -516,13 +514,11 @@ mrb_struct_aset(mrb_state *mrb, mrb_value s)
   if (i < 0) i = RSTRUCT_LEN(s) + i;
   if (i < 0) {
     mrb_raisef(mrb, E_INDEX_ERROR,
-               "offset %S too small for struct(size:%S)",
-               mrb_fixnum_value(i), mrb_fixnum_value(RSTRUCT_LEN(s)));
+               "offset %i too small for struct(size:%i)", i, RSTRUCT_LEN(s));
   }
   if (RSTRUCT_LEN(s) <= i) {
     mrb_raisef(mrb, E_INDEX_ERROR,
-               "offset %S too large for struct(size:%S)",
-               mrb_fixnum_value(i), mrb_fixnum_value(RSTRUCT_LEN(s)));
+               "offset %i too large for struct(size:%i)", i, RSTRUCT_LEN(s));
   }
   mrb_struct_modify(mrb, s);
   return RSTRUCT_PTR(s)[i] = val;

--- a/mrbgems/mruby-time/src/time.c
+++ b/mrbgems/mruby-time/src/time.c
@@ -267,7 +267,7 @@ mrb_to_time_t(mrb_state *mrb, mrb_value obj, time_t *usec)
   return t;
 
 out_of_range:
-  mrb_raisef(mrb, E_ARGUMENT_ERROR, "%S out of Time range", obj);
+  mrb_raisef(mrb, E_ARGUMENT_ERROR, "%v out of Time range", obj);
 
   /* not reached */
   if (usec) { *usec = 0; }
@@ -293,7 +293,7 @@ time_update_datetime(mrb_state *mrb, struct mrb_time *self, int dealloc)
     mrb_sec sec = (mrb_sec)t;
 
     if (dealloc) mrb_free(mrb, self);
-    mrb_raisef(mrb, E_ARGUMENT_ERROR, "%S out of Time range", mrb_sec_value(mrb, sec));
+    mrb_raisef(mrb, E_ARGUMENT_ERROR, "%v out of Time range", mrb_sec_value(mrb, sec));
     /* not reached */
     return NULL;
   }

--- a/src/array.c
+++ b/src/array.c
@@ -668,7 +668,7 @@ mrb_ary_set(mrb_state *mrb, mrb_value ary, mrb_int n, mrb_value val)
   if (n < 0) {
     n += len;
     if (n < 0) {
-      mrb_raisef(mrb, E_INDEX_ERROR, "index %S out of array", mrb_fixnum_value(n - len));
+      mrb_raisef(mrb, E_INDEX_ERROR, "index %i out of array", n - len);
     }
   }
   if (len <= n) {
@@ -700,7 +700,7 @@ mrb_ary_splice(mrb_state *mrb, mrb_value ary, mrb_int head, mrb_int len, mrb_val
   ary_modify(mrb, a);
 
   /* len check */
-  if (len < 0) mrb_raisef(mrb, E_INDEX_ERROR, "negative length (%S)", mrb_fixnum_value(len));
+  if (len < 0) mrb_raisef(mrb, E_INDEX_ERROR, "negative length (%i)", len);
 
   /* range check */
   if (head < 0) {
@@ -734,7 +734,7 @@ mrb_ary_splice(mrb_state *mrb, mrb_value ary, mrb_int head, mrb_int len, mrb_val
   }
   if (head >= alen) {
     if (head > ARY_MAX_SIZE - argc) {
-      mrb_raisef(mrb, E_INDEX_ERROR, "index %S too big", mrb_fixnum_value(head));
+      mrb_raisef(mrb, E_INDEX_ERROR, "index %i too big", head);
     }
     len = head + argc;
     if (len > ARY_CAPA(a)) {
@@ -750,7 +750,7 @@ mrb_ary_splice(mrb_state *mrb, mrb_value ary, mrb_int head, mrb_int len, mrb_val
     mrb_int newlen;
 
     if (alen - len > ARY_MAX_SIZE - argc) {
-      mrb_raisef(mrb, E_INDEX_ERROR, "index %S too big", mrb_fixnum_value(alen + argc - len));
+      mrb_raisef(mrb, E_INDEX_ERROR, "index %i too big", alen + argc - len);
     }
     newlen = alen + argc - len;
     if (newlen > ARY_CAPA(a)) {
@@ -934,7 +934,7 @@ mrb_ary_aset(mrb_state *mrb, mrb_value self)
       mrb_ary_splice(mrb, self, i, len, v2);
       break;
     case MRB_RANGE_OUT:
-      mrb_raisef(mrb, E_RANGE_ERROR, "%S out of range", v1);
+      mrb_raisef(mrb, E_RANGE_ERROR, "%v out of range", v1);
       break;
     }
     return v2;

--- a/src/backtrace.c
+++ b/src/backtrace.c
@@ -246,9 +246,7 @@ mrb_unpack_backtrace(mrb_state *mrb, mrb_value backtrace)
     mrb_value btline;
 
     if (entry->filename == NULL) continue;
-    btline = mrb_format(mrb, "%S:%S",
-                              mrb_str_new_cstr(mrb, entry->filename),
-                              mrb_fixnum_value(entry->lineno));
+    btline = mrb_format(mrb, "%s:%d", entry->filename, entry->lineno);
     if (entry->method_id != 0) {
       mrb_str_cat_lit(mrb, btline, ":in ");
       mrb_str_cat_cstr(mrb, btline, mrb_sym2name(mrb, entry->method_id));

--- a/src/class.c
+++ b/src/class.c
@@ -177,7 +177,7 @@ static void
 check_if_class_or_module(mrb_state *mrb, mrb_value obj)
 {
   if (!class_ptr_p(obj)) {
-    mrb_raisef(mrb, E_TYPE_ERROR, "%S is not a class/module", mrb_inspect(mrb, obj));
+    mrb_raisef(mrb, E_TYPE_ERROR, "%!v is not a class/module", obj);
   }
 }
 
@@ -215,7 +215,7 @@ mrb_vm_define_module(mrb_state *mrb, mrb_value outer, mrb_sym id)
     mrb_value old = mrb_const_get(mrb, outer, id);
 
     if (mrb_type(old) != MRB_TT_MODULE) {
-      mrb_raisef(mrb, E_TYPE_ERROR, "%S is not a module", mrb_inspect(mrb, old));
+      mrb_raisef(mrb, E_TYPE_ERROR, "%!v is not a module", old);
     }
     return mrb_class_ptr(old);
   }
@@ -248,9 +248,8 @@ define_class(mrb_state *mrb, mrb_sym name, struct RClass *super, struct RClass *
     c = class_from_sym(mrb, outer, name);
     MRB_CLASS_ORIGIN(c);
     if (super && mrb_class_real(c->super) != super) {
-      mrb_raisef(mrb, E_TYPE_ERROR, "superclass mismatch for Class %S (%S not %S)",
-                 mrb_sym2str(mrb, name),
-                 mrb_obj_value(c->super), mrb_obj_value(super));
+      mrb_raisef(mrb, E_TYPE_ERROR, "superclass mismatch for Class %n (%C not %C)",
+                 name, c->super, super);
     }
     return c;
   }
@@ -265,7 +264,7 @@ MRB_API struct RClass*
 mrb_define_class_id(mrb_state *mrb, mrb_sym name, struct RClass *super)
 {
   if (!super) {
-    mrb_warn(mrb, "no super class for '%S', Object assumed", mrb_sym2str(mrb, name));
+    mrb_warn(mrb, "no super class for '%n', Object assumed", name);
   }
   return define_class(mrb, name, super, mrb->object_class);
 }
@@ -313,8 +312,7 @@ mrb_vm_define_class(mrb_state *mrb, mrb_value outer, mrb_value super, mrb_sym id
 
   if (!mrb_nil_p(super)) {
     if (mrb_type(super) != MRB_TT_CLASS) {
-      mrb_raisef(mrb, E_TYPE_ERROR, "superclass must be a Class (%S given)",
-                 mrb_inspect(mrb, super));
+      mrb_raisef(mrb, E_TYPE_ERROR, "superclass must be a Class (%!v given)", super);
     }
     s = mrb_class_ptr(super);
   }
@@ -326,13 +324,13 @@ mrb_vm_define_class(mrb_state *mrb, mrb_value outer, mrb_value super, mrb_sym id
     mrb_value old = mrb_const_get(mrb, outer, id);
 
     if (mrb_type(old) != MRB_TT_CLASS) {
-      mrb_raisef(mrb, E_TYPE_ERROR, "%S is not a class", mrb_inspect(mrb, old));
+      mrb_raisef(mrb, E_TYPE_ERROR, "%!v is not a class", old);
     }
     c = mrb_class_ptr(old);
     if (s) {
       /* check super class */
       if (mrb_class_real(c->super) != s) {
-        mrb_raisef(mrb, E_TYPE_ERROR, "superclass mismatch for class %S", old);
+        mrb_raisef(mrb, E_TYPE_ERROR, "superclass mismatch for class %v", old);
       }
     }
     return c;
@@ -431,8 +429,7 @@ mrb_define_class_under(mrb_state *mrb, struct RClass *outer, const char *name, s
 
 #if 0
   if (!super) {
-    mrb_warn(mrb, "no super class for '%S::%S', Object assumed",
-             mrb_obj_value(outer), mrb_sym2str(mrb, id));
+    mrb_warn(mrb, "no super class for '%C::%n', Object assumed", outer, id);
   }
 #endif
   c = define_class(mrb, id, super, outer);
@@ -489,8 +486,7 @@ mrb_notimplement(mrb_state *mrb)
   mrb_callinfo *ci = mrb->c->ci;
 
   if (ci->mid) {
-    mrb_value str = mrb_sym2str(mrb, ci->mid);
-    mrb_raisef(mrb, E_NOTIMP_ERROR, "%S() function is unimplemented on this machine", str);
+    mrb_raisef(mrb, E_NOTIMP_ERROR, "%n() function is unimplemented on this machine", ci->mid);
   }
 }
 
@@ -505,7 +501,7 @@ mrb_notimplement_m(mrb_state *mrb, mrb_value self)
 
 #define CHECK_TYPE(mrb, val, t, c) do { \
   if (mrb_type(val) != (t)) {\
-    mrb_raisef(mrb, E_TYPE_ERROR, "expected %S", mrb_str_new_lit(mrb, c));\
+    mrb_raisef(mrb, E_TYPE_ERROR, "expected %l", c, sizeof(c "")-1);\
   }\
 } while (0)
 
@@ -669,7 +665,7 @@ mrb_get_args(mrb_state *mrb, const char *format, ...)
 
           ss = ARGV[arg_i++];
           if (!class_ptr_p(ss)) {
-            mrb_raisef(mrb, E_TYPE_ERROR, "%S is not class/module", ss);
+            mrb_raisef(mrb, E_TYPE_ERROR, "%v is not class/module", ss);
           }
           *p = ss;
           i++;
@@ -816,7 +812,7 @@ mrb_get_args(mrb_state *mrb, const char *format, ...)
           ss = ARGV[arg_i];
           if (mrb_type(ss) != MRB_TT_ISTRUCT)
           {
-            mrb_raisef(mrb, E_TYPE_ERROR, "%S is not inline struct", ss);
+            mrb_raisef(mrb, E_TYPE_ERROR, "%v is not inline struct", ss);
           }
           *p = mrb_istruct_ptr(ss);
           arg_i++;
@@ -964,7 +960,7 @@ mrb_get_args(mrb_state *mrb, const char *format, ...)
       }
       break;
     default:
-      mrb_raisef(mrb, E_ARGUMENT_ERROR, "invalid argument specifier %S", mrb_str_new(mrb, &c, 1));
+      mrb_raisef(mrb, E_ARGUMENT_ERROR, "invalid argument specifier %c", c);
       break;
     }
   }
@@ -1357,8 +1353,7 @@ mrb_method_search(mrb_state *mrb, struct RClass* c, mrb_sym mid)
     if (mrb_string_p(inspect) && RSTRING_LEN(inspect) > 64) {
       inspect = mrb_any_to_s(mrb, mrb_obj_value(c));
     }
-    mrb_name_error(mrb, mid, "undefined method '%S' for class %S",
-               mrb_sym2str(mrb, mid), inspect);
+    mrb_name_error(mrb, mid, "undefined method '%n' for class %v", mid, inspect);
   }
   return m;
 }
@@ -1479,7 +1474,7 @@ mrb_instance_alloc(mrb_state *mrb, mrb_value cv)
 
   if (ttype == 0) ttype = MRB_TT_OBJECT;
   if (ttype <= MRB_TT_CPTR) {
-    mrb_raisef(mrb, E_TYPE_ERROR, "can't create instance of %S", cv);
+    mrb_raisef(mrb, E_TYPE_ERROR, "can't create instance of %v", cv);
   }
   o = (struct RObject*)mrb_obj_alloc(mrb, ttype, c);
   return mrb_obj_value(o);
@@ -1706,7 +1701,7 @@ static void
 mrb_check_inheritable(mrb_state *mrb, struct RClass *super)
 {
   if (super->tt != MRB_TT_CLASS) {
-    mrb_raisef(mrb, E_TYPE_ERROR, "superclass must be a Class (%S given)", mrb_obj_value(super));
+    mrb_raisef(mrb, E_TYPE_ERROR, "superclass must be a Class (%C given)", super);
   }
   if (super->tt == MRB_TT_SCLASS) {
     mrb_raise(mrb, E_TYPE_ERROR, "can't make subclass of singleton class");
@@ -1835,7 +1830,7 @@ void
 mrb_undef_method_id(mrb_state *mrb, struct RClass *c, mrb_sym a)
 {
   if (!mrb_obj_respond_to(mrb, c, a)) {
-    mrb_name_error(mrb, a, "undefined method '%S' for class '%S'", mrb_sym2str(mrb, a), mrb_obj_value(c));
+    mrb_name_error(mrb, a, "undefined method '%n' for class '%C'", a, c);
   }
   else {
     mrb_method_t m;
@@ -1878,7 +1873,7 @@ check_const_name_sym(mrb_state *mrb, mrb_sym id)
   mrb_int len;
   const char *name = mrb_sym2name_len(mrb, id, &len);
   if (!mrb_const_name_p(mrb, name, len)) {
-    mrb_name_error(mrb, id, "wrong constant name %S", mrb_sym2str(mrb, id));
+    mrb_name_error(mrb, id, "wrong constant name %n", id);
   }
 }
 
@@ -1935,7 +1930,7 @@ mrb_mod_const_get(mrb_state *mrb, mrb_value mod)
     else {
       off = end + 2;
       if (off == len) {         /* trailing "::" */
-        mrb_name_error(mrb, id, "wrong constant name '%S'", path);
+        mrb_name_error(mrb, id, "wrong constant name '%v'", path);
       }
     }
   }
@@ -1965,7 +1960,7 @@ mrb_mod_remove_const(mrb_state *mrb, mrb_value mod)
   check_const_name_sym(mrb, id);
   val = mrb_iv_remove(mrb, mod, id);
   if (mrb_undef_p(val)) {
-    mrb_name_error(mrb, id, "constant %S not defined", mrb_sym2str(mrb, id));
+    mrb_name_error(mrb, id, "constant %n not defined", id);
   }
   return val;
 }
@@ -1978,13 +1973,10 @@ mrb_mod_const_missing(mrb_state *mrb, mrb_value mod)
   mrb_get_args(mrb, "n", &sym);
 
   if (mrb_class_real(mrb_class_ptr(mod)) != mrb->object_class) {
-    mrb_name_error(mrb, sym, "uninitialized constant %S::%S",
-                   mod,
-                   mrb_sym2str(mrb, sym));
+    mrb_name_error(mrb, sym, "uninitialized constant %v::%n", mod, sym);
   }
   else {
-    mrb_name_error(mrb, sym, "uninitialized constant %S",
-                   mrb_sym2str(mrb, sym));
+    mrb_name_error(mrb, sym, "uninitialized constant %n", sym);
   }
   /* not reached */
   return mrb_nil_value();
@@ -2045,7 +2037,7 @@ mod_define_method(mrb_state *mrb, mrb_value self)
       /* ignored */
       break;
     default:
-      mrb_raisef(mrb, E_TYPE_ERROR, "wrong argument type %S (expected Proc)", mrb_obj_value(mrb_obj_class(mrb, proc)));
+      mrb_raisef(mrb, E_TYPE_ERROR, "wrong argument type %T (expected Proc)", proc);
       break;
   }
   if (mrb_nil_p(blk)) {

--- a/src/error.c
+++ b/src/error.c
@@ -151,14 +151,14 @@ exc_inspect(mrb_state *mrb, mrb_value exc)
   str = mrb_str_new_cstr(mrb, cname);
   if (mrb_string_p(file) && mrb_fixnum_p(line)) {
     if (append_mesg) {
-      str = mrb_format(mrb, "%S:%S: %S (%S)", file, line, mesg, str);
+      str = mrb_format(mrb, "%v:%v: %v (%v)", file, line, mesg, str);
     }
     else {
-      str = mrb_format(mrb, "%S:%S: %S", file, line, str);
+      str = mrb_format(mrb, "%v:%v: %v", file, line, str);
     }
   }
   else if (append_mesg) {
-    str = mrb_format(mrb, "%S: %S", str, mesg);
+    str = mrb_format(mrb, "%v: %v", str, mesg);
   }
   return str;
 }
@@ -523,7 +523,7 @@ exception_call:
 
       break;
     default:
-      mrb_raisef(mrb, E_ARGUMENT_ERROR, "wrong number of arguments (%S for 0..3)", mrb_fixnum_value(argc));
+      mrb_raisef(mrb, E_ARGUMENT_ERROR, "wrong number of arguments (%i for 0..3)", argc);
       break;
   }
   if (argc > 0) {
@@ -576,8 +576,7 @@ mrb_no_method_error(mrb_state *mrb, mrb_sym id, mrb_value args, char const* fmt,
 MRB_API mrb_noreturn void
 mrb_frozen_error(mrb_state *mrb, void *frozen_obj)
 {
-  mrb_raisef(mrb, E_FROZEN_ERROR, "can't modify frozen %S",
-             mrb_obj_value(mrb_class(mrb, mrb_obj_value(frozen_obj))));
+  mrb_raisef(mrb, E_FROZEN_ERROR, "can't modify frozen %t", mrb_obj_value(frozen_obj));
 }
 
 void

--- a/src/etc.c
+++ b/src/etc.c
@@ -31,14 +31,12 @@ mrb_data_check_type(mrb_state *mrb, mrb_value obj, const mrb_data_type *type)
     const mrb_data_type *t2 = DATA_TYPE(obj);
 
     if (t2) {
-      mrb_raisef(mrb, E_TYPE_ERROR, "wrong argument type %S (expected %S)",
-                 mrb_str_new_cstr(mrb, t2->struct_name), mrb_str_new_cstr(mrb, type->struct_name));
+      mrb_raisef(mrb, E_TYPE_ERROR, "wrong argument type %s (expected %s)",
+                 t2->struct_name, type->struct_name);
     }
     else {
-      struct RClass *c = mrb_class(mrb, obj);
-
-      mrb_raisef(mrb, E_TYPE_ERROR, "uninitialized %S (expected %S)",
-                 mrb_obj_value(c), mrb_str_new_cstr(mrb, type->struct_name));
+      mrb_raisef(mrb, E_TYPE_ERROR, "uninitialized %t (expected %s)",
+                 obj, type->struct_name);
     }
   }
 }
@@ -67,7 +65,7 @@ mrb_obj_to_sym(mrb_state *mrb, mrb_value name)
 {
   if (mrb_symbol_p(name)) return mrb_symbol(name);
   if (mrb_string_p(name)) return mrb_intern_str(mrb, name);
-  mrb_raisef(mrb, E_TYPE_ERROR, "%S is not a symbol nor a string", mrb_inspect(mrb, name));
+  mrb_raisef(mrb, E_TYPE_ERROR, "%!v is not a symbol nor a string", name);
   return 0;  /* not reached */
 }
 

--- a/src/gc.c
+++ b/src/gc.c
@@ -542,7 +542,7 @@ mrb_obj_alloc(mrb_state *mrb, enum mrb_vtype ttype, struct RClass *cls)
         ttype != MRB_TT_ICLASS &&
         ttype != MRB_TT_ENV &&
         ttype != tt) {
-      mrb_raisef(mrb, E_TYPE_ERROR, "allocation failure of %S", mrb_obj_value(cls));
+      mrb_raisef(mrb, E_TYPE_ERROR, "allocation failure of %C", cls);
     }
   }
 

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -325,7 +325,7 @@ mrb_obj_clone(mrb_state *mrb, mrb_value self)
   mrb_value clone;
 
   if (mrb_immediate_p(self)) {
-    mrb_raisef(mrb, E_TYPE_ERROR, "can't clone %S", self);
+    mrb_raisef(mrb, E_TYPE_ERROR, "can't clone %v", self);
   }
   if (mrb_type(self) == MRB_TT_SCLASS) {
     mrb_raise(mrb, E_TYPE_ERROR, "can't clone singleton class");
@@ -366,7 +366,7 @@ mrb_obj_dup(mrb_state *mrb, mrb_value obj)
   mrb_value dup;
 
   if (mrb_immediate_p(obj)) {
-    mrb_raisef(mrb, E_TYPE_ERROR, "can't dup %S", obj);
+    mrb_raisef(mrb, E_TYPE_ERROR, "can't dup %v", obj);
   }
   if (mrb_type(obj) == MRB_TT_SCLASS) {
     mrb_raise(mrb, E_TYPE_ERROR, "can't dup singleton class");
@@ -641,7 +641,7 @@ mrb_obj_remove_instance_variable(mrb_state *mrb, mrb_value self)
   mrb_iv_name_sym_check(mrb, sym);
   val = mrb_iv_remove(mrb, self, sym);
   if (mrb_undef_p(val)) {
-    mrb_name_error(mrb, sym, "instance variable %S not defined", mrb_sym2str(mrb, sym));
+    mrb_name_error(mrb, sym, "instance variable %n not defined", sym);
   }
   return val;
 }
@@ -649,7 +649,7 @@ mrb_obj_remove_instance_variable(mrb_state *mrb, mrb_value self)
 void
 mrb_method_missing(mrb_state *mrb, mrb_sym name, mrb_value self, mrb_value args)
 {
-  mrb_no_method_error(mrb, name, args, "undefined method '%S'", mrb_sym2str(mrb, name));
+  mrb_no_method_error(mrb, name, args, "undefined method '%n'", name);
 }
 
 /* 15.3.1.3.30 */

--- a/src/numeric.c
+++ b/src/numeric.c
@@ -1257,7 +1257,7 @@ mrb_flo_to_fixnum(mrb_state *mrb, mrb_value x)
       z = (mrb_int)d;
     }
     else {
-      mrb_raisef(mrb, E_RANGE_ERROR, "number (%S) too big for integer", x);
+      mrb_raisef(mrb, E_RANGE_ERROR, "number (%v) too big for integer", x);
     }
   }
   return mrb_fixnum_value(z);
@@ -1389,7 +1389,7 @@ mrb_fixnum_to_str(mrb_state *mrb, mrb_value x, mrb_int base)
   mrb_int val = mrb_fixnum(x);
 
   if (base < 2 || 36 < base) {
-    mrb_raisef(mrb, E_ARGUMENT_ERROR, "invalid radix %S", mrb_fixnum_value(base));
+    mrb_raisef(mrb, E_ARGUMENT_ERROR, "invalid radix %i", base);
   }
 
   if (val == 0) {
@@ -1501,9 +1501,7 @@ integral_cmp(mrb_state *mrb, mrb_value self)
 static void
 cmperr(mrb_state *mrb, mrb_value v1, mrb_value v2)
 {
-  mrb_raisef(mrb, E_ARGUMENT_ERROR, "comparison of %S with %S failed",
-             mrb_obj_value(mrb_class(mrb, v1)),
-             mrb_obj_value(mrb_class(mrb, v2)));
+  mrb_raisef(mrb, E_ARGUMENT_ERROR, "comparison of %t with %t failed", v1, v2);
 }
 
 static mrb_value

--- a/src/object.c
+++ b/src/object.c
@@ -297,17 +297,6 @@ mrb_init_object(mrb_state *mrb)
 }
 
 static mrb_value
-inspect_type(mrb_state *mrb, mrb_value val)
-{
-  if (mrb_type(val) == MRB_TT_FALSE || mrb_type(val) == MRB_TT_TRUE) {
-    return mrb_inspect(mrb, val);
-  }
-  else {
-    return mrb_str_new_cstr(mrb, mrb_obj_classname(mrb, val));
-  }
-}
-
-static mrb_value
 convert_type(mrb_state *mrb, mrb_value val, const char *tname, const char *method, mrb_bool raise)
 {
   mrb_sym m = 0;
@@ -315,7 +304,7 @@ convert_type(mrb_state *mrb, mrb_value val, const char *tname, const char *metho
   m = mrb_intern_cstr(mrb, method);
   if (!mrb_respond_to(mrb, val, m)) {
     if (raise) {
-      mrb_raisef(mrb, E_TYPE_ERROR, "can't convert %S into %S", inspect_type(mrb, val), mrb_str_new_cstr(mrb, tname));
+      mrb_raisef(mrb, E_TYPE_ERROR, "can't convert %Y into %s", val, tname);
     }
     return mrb_nil_value();
   }
@@ -330,8 +319,7 @@ mrb_convert_type(mrb_state *mrb, mrb_value val, enum mrb_vtype type, const char 
   if (mrb_type(val) == type) return val;
   v = convert_type(mrb, val, tname, method, TRUE);
   if (mrb_type(v) != type) {
-    mrb_raisef(mrb, E_TYPE_ERROR, "%S cannot be converted to %S by #%S", val,
-               mrb_str_new_cstr(mrb, tname), mrb_str_new_cstr(mrb, method));
+    mrb_raisef(mrb, E_TYPE_ERROR, "%v cannot be converted to %s by #%s", val, tname, method);
   }
   return v;
 }
@@ -405,13 +393,12 @@ mrb_check_type(mrb_state *mrb, mrb_value x, enum mrb_vtype t)
         else {
           etype = mrb_obj_classname(mrb, x);
         }
-        mrb_raisef(mrb, E_TYPE_ERROR, "wrong argument type %S (expected %S)",
-                   mrb_str_new_cstr(mrb, etype), mrb_str_new_cstr(mrb, type->name));
+        mrb_raisef(mrb, E_TYPE_ERROR, "wrong argument type %s (expected %s)",
+                   etype, type->name);
       }
       type++;
     }
-    mrb_raisef(mrb, E_TYPE_ERROR, "unknown type %S (%S given)",
-               mrb_fixnum_value(t), mrb_fixnum_value(mrb_type(x)));
+    mrb_raisef(mrb, E_TYPE_ERROR, "unknown type %d (%d given)", t, mrb_type(x));
   }
 }
 
@@ -499,15 +486,12 @@ mrb_to_int(mrb_state *mrb, mrb_value val)
 {
 
   if (!mrb_fixnum_p(val)) {
-    mrb_value type;
-
 #ifndef MRB_WITHOUT_FLOAT
     if (mrb_float_p(val)) {
       return mrb_flo_to_fixnum(mrb, val);
     }
 #endif
-    type = inspect_type(mrb, val);
-    mrb_raisef(mrb, E_TYPE_ERROR, "can't convert %S to Integer", type);
+    mrb_raisef(mrb, E_TYPE_ERROR, "can't convert %Y to Integer", val);
   }
   return val;
 }
@@ -598,8 +582,7 @@ MRB_API mrb_value
 mrb_ensure_string_type(mrb_state *mrb, mrb_value str)
 {
   if (!mrb_string_p(str)) {
-    mrb_raisef(mrb, E_TYPE_ERROR, "%S cannot be converted to String",
-               inspect_type(mrb, str));
+    mrb_raisef(mrb, E_TYPE_ERROR, "%Y cannot be converted to String", str);
   }
   return str;
 }
@@ -615,8 +598,7 @@ MRB_API mrb_value
 mrb_ensure_array_type(mrb_state *mrb, mrb_value ary)
 {
   if (!mrb_array_p(ary)) {
-    mrb_raisef(mrb, E_TYPE_ERROR, "%S cannot be converted to Array",
-               inspect_type(mrb, ary));
+    mrb_raisef(mrb, E_TYPE_ERROR, "%Y cannot be converted to Array", ary);
   }
   return ary;
 }
@@ -632,8 +614,7 @@ MRB_API mrb_value
 mrb_ensure_hash_type(mrb_state *mrb, mrb_value hash)
 {
   if (!mrb_hash_p(hash)) {
-    mrb_raisef(mrb, E_TYPE_ERROR, "%S cannot be converted to Hash",
-               inspect_type(mrb, hash));
+    mrb_raisef(mrb, E_TYPE_ERROR, "%Y cannot be converted to Hash", hash);
   }
   return hash;
 }

--- a/src/proc.c
+++ b/src/proc.c
@@ -153,8 +153,8 @@ mrb_proc_cfunc_env_get(mrb_state *mrb, mrb_int idx)
     mrb_raise(mrb, E_TYPE_ERROR, "Can't get cfunc env from cfunc Proc without REnv.");
   }
   if (idx < 0 || MRB_ENV_STACK_LEN(e) <= idx) {
-    mrb_raisef(mrb, E_INDEX_ERROR, "Env index out of range: %S (expected: 0 <= index < %S)",
-               mrb_fixnum_value(idx), mrb_fixnum_value(MRB_ENV_STACK_LEN(e)));
+    mrb_raisef(mrb, E_INDEX_ERROR, "Env index out of range: %i (expected: 0 <= index < %i)",
+               idx, MRB_ENV_STACK_LEN(e));
   }
 
   return e->stack[idx];

--- a/src/range.c
+++ b/src/range.c
@@ -363,7 +363,7 @@ mrb_get_values_at(mrb_state *mrb, mrb_value obj, mrb_int olen, mrb_int argc, con
       }
     }
     else {
-      mrb_raisef(mrb, E_TYPE_ERROR, "invalid values selector: %S", argv[i]);
+      mrb_raisef(mrb, E_TYPE_ERROR, "invalid values selector: %v", argv[i]);
     }
   }
 

--- a/src/string.c
+++ b/src/string.c
@@ -1226,7 +1226,7 @@ mrb_str_aref_m(mrb_state *mrb, mrb_value str)
 static mrb_noreturn void
 str_out_of_index(mrb_state *mrb, mrb_value index)
 {
-  mrb_raisef(mrb, E_INDEX_ERROR, "index %S out of string", index);
+  mrb_raisef(mrb, E_INDEX_ERROR, "index %v out of string", index);
 }
 
 static mrb_value
@@ -1286,7 +1286,7 @@ mrb_str_aset(mrb_state *mrb, mrb_value str, mrb_value indx, mrb_value alen, mrb_
       mrb_raise(mrb, E_INDEX_ERROR, "string not matched");
     case STR_CHAR_RANGE:
       if (len < 0) {
-        mrb_raisef(mrb, E_INDEX_ERROR, "negative length %S", alen);
+        mrb_raisef(mrb, E_INDEX_ERROR, "negative length %v", alen);
       }
       charlen = RSTRING_CHAR_LEN(str);
       if (beg < 0) { beg += charlen; }
@@ -1763,7 +1763,7 @@ mrb_str_index_m(mrb_state *mrb, mrb_value str)
 
       tmp = mrb_check_string_type(mrb, sub);
       if (mrb_nil_p(tmp)) {
-        mrb_raisef(mrb, E_TYPE_ERROR, "type mismatch: %S given", sub);
+        mrb_raisef(mrb, E_TYPE_ERROR, "type mismatch: %v given", sub);
       }
       sub = tmp;
     }
@@ -2014,7 +2014,7 @@ mrb_str_rindex(mrb_state *mrb, mrb_value str)
 
       tmp = mrb_check_string_type(mrb, sub);
       if (mrb_nil_p(tmp)) {
-        mrb_raisef(mrb, E_TYPE_ERROR, "type mismatch: %S given", sub);
+        mrb_raisef(mrb, E_TYPE_ERROR, "type mismatch: %v given", sub);
       }
       sub = tmp;
     }
@@ -2265,7 +2265,7 @@ mrb_str_len_to_inum(mrb_state *mrb, const char *str, mrb_int len, mrb_int base, 
       break;
     default:
       if (base < 2 || 36 < base) {
-        mrb_raisef(mrb, E_ARGUMENT_ERROR, "illegal radix %S", mrb_fixnum_value(base));
+        mrb_raisef(mrb, E_ARGUMENT_ERROR, "illegal radix %i", base);
       }
       break;
   } /* end of switch (base) { */
@@ -2325,8 +2325,7 @@ mrb_str_len_to_inum(mrb_state *mrb, const char *str, mrb_int len, mrb_int base, 
       else
 #endif
       {
-        mrb_raisef(mrb, E_RANGE_ERROR, "string (%S) too big for integer",
-                   mrb_str_new(mrb, str, pend-str));
+        mrb_raisef(mrb, E_RANGE_ERROR, "string (%l) too big for integer", str, pend-str);
       }
     }
   }
@@ -2342,8 +2341,7 @@ mrb_str_len_to_inum(mrb_state *mrb, const char *str, mrb_int len, mrb_int base, 
   mrb_raise(mrb, E_ARGUMENT_ERROR, "string contains null byte");
   /* not reached */
  bad:
-  mrb_raisef(mrb, E_ARGUMENT_ERROR, "invalid string for number(%S)",
-             mrb_inspect(mrb, mrb_str_new(mrb, str, pend-str)));
+  mrb_raisef(mrb, E_ARGUMENT_ERROR, "invalid string for number(%!l)", str, pend-str);
   /* not reached */
   return mrb_fixnum_value(0);
 }
@@ -2419,7 +2417,7 @@ mrb_str_to_i(mrb_state *mrb, mrb_value self)
 
   mrb_get_args(mrb, "|i", &base);
   if (base < 0) {
-    mrb_raisef(mrb, E_ARGUMENT_ERROR, "illegal radix %S", mrb_fixnum_value(base));
+    mrb_raisef(mrb, E_ARGUMENT_ERROR, "illegal radix %i", base);
   }
   return mrb_str_to_inum(mrb, self, base, FALSE);
 }
@@ -2444,7 +2442,7 @@ mrb_cstr_to_dbl(mrb_state *mrb, const char * p, mrb_bool badcheck)
   if (p == end) {
     if (badcheck) {
 bad:
-      mrb_raisef(mrb, E_ARGUMENT_ERROR, "invalid string for float(%S)", mrb_str_new_cstr(mrb, p));
+      mrb_raisef(mrb, E_ARGUMENT_ERROR, "invalid string for float(%s)", p);
       /* not reached */
     }
     return d;

--- a/src/variable.c
+++ b/src/variable.c
@@ -446,7 +446,7 @@ MRB_API void
 mrb_iv_name_sym_check(mrb_state *mrb, mrb_sym iv_name)
 {
   if (!mrb_iv_name_sym_p(mrb, iv_name)) {
-    mrb_name_error(mrb, iv_name, "'%S' is not allowed as an instance variable name", mrb_sym2str(mrb, iv_name));
+    mrb_name_error(mrb, iv_name, "'%n' is not allowed as an instance variable name", iv_name);
   }
 }
 
@@ -654,8 +654,7 @@ mrb_mod_cv_get(mrb_state *mrb, struct RClass *c, mrb_sym sym)
       if (given) return v;
     }
   }
-  mrb_name_error(mrb, sym, "uninitialized class variable %S in %S",
-                 mrb_sym2str(mrb, sym), mrb_obj_value(cls));
+  mrb_name_error(mrb, sym, "uninitialized class variable %n in %C", sym, cls);
   /* not reached */
   return mrb_nil_value();
 }

--- a/src/vm.c
+++ b/src/vm.c
@@ -461,7 +461,7 @@ mrb_funcall_with_block(mrb_state *mrb, mrb_value self, mrb_sym mid, mrb_int argc
       stack_init(mrb);
     }
     if (argc < 0) {
-      mrb_raisef(mrb, E_ARGUMENT_ERROR, "negative argc for funcall (%S)", mrb_fixnum_value(argc));
+      mrb_raisef(mrb, E_ARGUMENT_ERROR, "negative argc for funcall (%i)", argc);
     }
     c = mrb_class(mrb, self);
     m = mrb_method_search_vm(mrb, &c, mid);
@@ -878,13 +878,11 @@ argnum_error(mrb_state *mrb, mrb_int num)
     }
   }
   if (mrb->c->ci->mid) {
-    str = mrb_format(mrb, "'%S': wrong number of arguments (%S for %S)",
-                  mrb_sym2str(mrb, mrb->c->ci->mid),
-                  mrb_fixnum_value(argc), mrb_fixnum_value(num));
+    str = mrb_format(mrb, "'%n': wrong number of arguments (%i for %i)",
+                     mrb->c->ci->mid, argc, num);
   }
   else {
-    str = mrb_format(mrb, "wrong number of arguments (%S for %S)",
-                     mrb_fixnum_value(argc), mrb_fixnum_value(num));
+    str = mrb_format(mrb, "wrong number of arguments (%i for %i)", argc, num);
   }
   exc = mrb_exc_new_str(mrb, E_ARGUMENT_ERROR, str);
   mrb_exc_set(mrb, exc);
@@ -1868,7 +1866,7 @@ RETRY_TRY_BLOCK:
       mrb_value kdict = regs[mrb->c->ci->argc];
 
       if (!mrb_hash_p(kdict) || !mrb_hash_key_p(mrb, kdict, k)) {
-        mrb_value str = mrb_format(mrb, "missing keyword: %S", k);
+        mrb_value str = mrb_format(mrb, "missing keyword: %v", k);
         mrb_exc_set(mrb, mrb_exc_new_str(mrb, E_ARGUMENT_ERROR, str));
         goto L_RAISE;
       }
@@ -1895,7 +1893,7 @@ RETRY_TRY_BLOCK:
       if (mrb_hash_p(kdict) && !mrb_hash_empty_p(mrb, kdict)) {
         mrb_value keys = mrb_hash_keys(mrb, kdict);
         mrb_value key1 = RARRAY_PTR(keys)[0];
-        mrb_value str = mrb_format(mrb, "unknown keyword: %S", key1);
+        mrb_value str = mrb_format(mrb, "unknown keyword: %v", key1);
         mrb_exc_set(mrb, mrb_exc_new_str(mrb, E_ARGUMENT_ERROR, str));
         goto L_RAISE;
       }

--- a/tasks/toolchains/visualcpp.rake
+++ b/tasks/toolchains/visualcpp.rake
@@ -2,7 +2,7 @@ MRuby::Toolchain.new(:visualcpp) do |conf, _params|
   conf.cc do |cc|
     cc.command = ENV['CC'] || 'cl.exe'
     # C4013: implicit function declaration
-    cc.flags = [ENV['CFLAGS'] || %w(/c /nologo /W3 /we4013 /Zi /Zm2000 /MD /O2 /D_CRT_SECURE_NO_WARNINGS)]
+    cc.flags = [ENV['CFLAGS'] || %w(/c /nologo /W3 /we4013 /Zi /MD /O2 /D_CRT_SECURE_NO_WARNINGS)]
     cc.defines = %w(MRB_STACK_EXTEND_DOUBLING)
     cc.option_include_path = '/I%s'
     cc.option_define = '/D%s'


### PR DESCRIPTION
Use new specifiers/modifiers of `mrb_vfromat()`

The binary sizes (gems are only `mruby-bin-mruby`) are reduced slightly in
my environment than before the introduction of new specifiers/modifiers
(5116789a) with this change.

```text
------------+------------------+------------------+--------
 BINARY     | BEFORE (5116789) |  AFTER (This PR) |  RATIO
------------+------------------+------------------+--------
 mruby      |     593416 bytes |     593208 bytes | -0.04%
 libmruby.a |     769048 bytes |     767264 bytes | -0.23%
------------+------------------+------------------+--------
```

BTW, I accidentally changed `tasks/toolchains/visualcpp.rake` at #4613,
so I put it back.