### PR TITLE
Avoid premature overflow in Complex#abs and Complex#/

### DIFF
--- a/mrbgems/mruby-complex/mrblib/complex.rb
+++ b/mrbgems/mruby-complex/mrblib/complex.rb
@@ -45,8 +45,7 @@ class Complex < Numeric
 
   def /(rhs)
     if rhs.is_a? Complex
-      div = rhs.real * rhs.real + rhs.imaginary * rhs.imaginary
-      Complex((real * rhs.real + imaginary * rhs.imaginary) / div, (rhs.real * imaginary - real * rhs.imaginary) / div)
+      __div__(rhs)
     elsif rhs.is_a? Numeric
       Complex(real / rhs, imaginary / rhs)
     end

--- a/mrbgems/mruby-complex/mrblib/complex.rb
+++ b/mrbgems/mruby-complex/mrblib/complex.rb
@@ -62,7 +62,7 @@ class Complex < Numeric
   end
 
   def abs
-    Math.sqrt(abs2)
+    Math.hypot imaginary, real
   end
   alias_method :magnitude, :abs
 

--- a/mrbgems/mruby-complex/test/complex.rb
+++ b/mrbgems/mruby-complex/test/complex.rb
@@ -70,6 +70,14 @@ end
 assert 'Complex#abs' do
   assert_float Complex(-1).abs,        1
   assert_float Complex(3.0, -4.0).abs, 5.0
+  if 1e39.infinite? then
+    # MRB_USE_FLOAT in effect
+    exp = 125
+  else
+    exp = 1021
+  end
+  assert_true Complex(3.0*2**exp, 4.0*2**exp).abs.finite?
+  assert_float Complex(3.0*2**exp, 4.0*2**exp).abs, 5.0*2**exp
 end
 
 assert 'Complex#abs2' do

--- a/mrbgems/mruby-complex/test/complex.rb
+++ b/mrbgems/mruby-complex/test/complex.rb
@@ -59,6 +59,15 @@ assert 'Complex#/' do
   assert_complex Complex(-2, 9) / Complex(-9, 2), ((36 / 85)          - (77i / 85))
   assert_complex Complex(9, 8)  / 4             , ((9 / 4)            + 2i)
   assert_complex Complex(20, 9) / 9.8           , (2.0408163265306123 + 0.9183673469387754i)
+  if 1e39.infinite? then
+    # MRB_USE_FLOAT in effect
+    ten = 1e21
+    one = 1e20
+  else
+    ten = 1e201
+    one = 1e200
+  end
+  assert_complex Complex(ten, ten) / Complex(one, one), Complex(10.0, 0.0)
 end
 
 assert 'Complex#==' do
@@ -76,8 +85,8 @@ assert 'Complex#abs' do
   else
     exp = 1021
   end
-  assert_true Complex(3.0*2**exp, 4.0*2**exp).abs.finite?
-  assert_float Complex(3.0*2**exp, 4.0*2**exp).abs, 5.0*2**exp
+  assert_true Complex(3.0*2.0**exp, 4.0*2.0**exp).abs.finite?
+  assert_float Complex(3.0*2.0**exp, 4.0*2.0**exp).abs, 5.0*2.0**exp
 end
 
 assert 'Complex#abs2' do


### PR DESCRIPTION
Complex#abs is reimplemented in terms of Math.hypot. This function is defined in terms of the C99 hypot() function, which overflows only if the final result is not representable.

Example: without this modification, Complex(3e200, 4e200).abs returns infinity. The correct answer is 5e200.

The case of Complex divided by Complex is reimplemented in C, to maintain its performance. The implementation uses the textbook formula for complex division, but performs the arithmetic on (significand, exponent) pairs. This change avoids a great many needles overflows.

Example: without this modification, (1e201+1e201i) / (1e200+1e200i) returns (NaN+NaNi). The correct answer is (10.0+0.0i).

I have not attempted to reimplement multiplication this way. Complex multiplication can needlessly overflow in a few rare cases, but it is probably not worth the effort to cover them. Neither CRuby nor glibc covers these cases.