### PR TITLE
SHARED/FSHARED string is not required when sharing NOFREE string

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -748,7 +748,7 @@ gc_mark_children(mrb_state *mrb, mrb_gc *gc, struct RBasic *obj)
     break;
 
   case MRB_TT_STRING:
-    if (RSTR_FSHARED_P(obj) && !RSTR_NOFREE_P(obj)) {
+    if (RSTR_FSHARED_P(obj)) {
       struct RString *s = (struct RString*)obj;
       mrb_gc_mark(mrb, (struct RBasic*)s->as.heap.aux.fshared);
     }


### PR DESCRIPTION
I think the string buffer of NOFREE string always exists and does not need
to be released, so it can be shared as another NOFREE string.

Also changed the `mrb_shared_string` field order so that eliminate padding if
`int` and `mrb_int` sizes are less than pointer size.