### PR TITLE
Simplify get arguments

### DIFF
--- a/mrbgems/mruby-string-ext/src/string.c
+++ b/mrbgems/mruby-string-ext/src/string.c
@@ -134,19 +134,18 @@ mrb_str_byteslice(mrb_state *mrb, mrb_value str)
   if (mrb_get_args(mrb, "o|o", &a1, &a2) == 2) {
     beg = mrb_fixnum(mrb_to_int(mrb, a1));
     len = mrb_fixnum(mrb_to_int(mrb, a2));
-    goto subseq;
   }
-  if (mrb_type(a1) == MRB_TT_RANGE) {
-    if (mrb_range_beg_len(mrb, a1, &beg, &len, str_len, TRUE) == MRB_RANGE_OK) {
-      goto subseq;
+  else if (mrb_type(a1) == MRB_TT_RANGE) {
+    if (mrb_range_beg_len(mrb, a1, &beg, &len, str_len, TRUE) != MRB_RANGE_OK) {
+      return mrb_nil_value();
     }
-    return mrb_nil_value();
+  }
+  else {
+    beg = mrb_fixnum(mrb_to_int(mrb, a1));
+    len = 1;
+    empty = FALSE;
   }
 
-  beg = mrb_fixnum(mrb_to_int(mrb, a1));
-  len = 1;
-  empty = FALSE;
-subseq:
   if (mrb_str_beg_len(str_len, &beg, &len) && (empty || len != 0)) {
     return mrb_str_byte_subseq(mrb, str, beg, len);
   }

--- a/src/string.c
+++ b/src/string.c
@@ -1759,28 +1759,25 @@ mrb_str_include(mrb_state *mrb, mrb_value self)
 static mrb_value
 mrb_str_index_m(mrb_state *mrb, mrb_value str)
 {
-  mrb_value *argv;
-  mrb_int argc;
   mrb_value sub;
-  mrb_int pos, clen;
+  mrb_int pos;
 
-  mrb_get_args(mrb, "*!", &argv, &argc);
-  if (argc == 2) {
-    mrb_get_args(mrb, "oi", &sub, &pos);
-  }
-  else {
-    pos = 0;
-    if (argc > 0)
-      sub = argv[0];
-    else
+  switch (mrb_get_args(mrb, "|oi", &sub, &pos)) {
+    case 0:
       sub = mrb_nil_value();
-  }
-  if (pos < 0) {
-    clen = RSTRING_CHAR_LEN(str);
-    pos += clen;
-    if (pos < 0) {
-      return mrb_nil_value();
-    }
+      /* fall through */
+    case 1:
+      pos = 0;
+      break;
+    case 2:
+      if (pos < 0) {
+        mrb_int clen = RSTRING_CHAR_LEN(str);
+        pos += clen;
+        if (pos < 0) {
+          return mrb_nil_value();
+        }
+      }
+      break;
   }
 
   switch (mrb_type(sub)) {
@@ -2009,28 +2006,25 @@ mrb_str_reverse(mrb_state *mrb, mrb_value str)
 static mrb_value
 mrb_str_rindex(mrb_state *mrb, mrb_value str)
 {
-  mrb_value *argv;
-  mrb_int argc;
   mrb_value sub;
   mrb_int pos, len = RSTRING_CHAR_LEN(str);
 
-  mrb_get_args(mrb, "*!", &argv, &argc);
-  if (argc == 2) {
-    mrb_get_args(mrb, "oi", &sub, &pos);
-    if (pos < 0) {
-      pos += len;
-      if (pos < 0) {
-        return mrb_nil_value();
-      }
-    }
-    if (pos > len) pos = len;
-  }
-  else {
-    pos = len;
-    if (argc > 0)
-      sub = argv[0];
-    else
+  switch (mrb_get_args(mrb, "|oi", &sub, &pos)) {
+    case 0:
       sub = mrb_nil_value();
+      /* fall through */
+    case 1:
+      pos = len;
+      break;
+    case 2:
+      if (pos < 0) {
+        pos += len;
+        if (pos < 0) {
+          return mrb_nil_value();
+        }
+      }
+      if (pos > len) pos = len;
+      break;
   }
   pos = chars2bytes(str, 0, pos);
 


### PR DESCRIPTION
- `mrb_str_index_m()` and `mrb_str_rindex()`
  Make `mrb_get_args()` called only once from called twice.
- `mrb_str_byteslice()`
  Replace `goto` with `if ~ else`.