### PR TITLE
Make symbolic link names unique for test

### DIFF
--- a/mrbgems/mruby-io/test/file.rb
+++ b/mrbgems/mruby-io/test/file.rb
@@ -179,7 +179,7 @@ end
 
 assert('File.symlink') do
   target_name = "/usr/bin"
-  symlink_name = "test-bin-dummy"
+  symlink_name = MRubyIOTestUtil.mktemp("test-bin-dummy-XXXXXXXX")
   if !File.exist?(target_name)
     skip("target directory of File.symlink is not found")
   else

--- a/mrbgems/mruby-io/test/mruby_io_test.c
+++ b/mrbgems/mruby-io/test/mruby_io_test.c
@@ -44,6 +44,7 @@ mkdtemp(char *temp)
   return path;
 }
 
+#define mktemp(path) _mktemp(path)
 #define umask(mode) _umask(mode)
 #define rmdir(path) _rmdir(path)
 #else
@@ -199,6 +200,20 @@ mrb_io_test_file_cleanup(mrb_state *mrb, mrb_value self)
 }
 
 static mrb_value
+mrb_io_test_mktemp(mrb_state *mrb, mrb_value klass)
+{
+  mrb_value str;
+  char *cp;
+
+  mrb_get_args(mrb, "S", &str);
+  cp = mrb_str_to_cstr(mrb, str);
+  if (mktemp(cp) == NULL) {
+    mrb_sys_fail(mrb, "mktemp");
+  }
+  return mrb_str_new_cstr(mrb, cp);
+}
+
+static mrb_value
 mrb_io_test_mkdtemp(mrb_state *mrb, mrb_value klass)
 {
   mrb_value str;
@@ -248,6 +263,7 @@ mrb_mruby_io_gem_test(mrb_state* mrb)
   mrb_define_class_method(mrb, io_test, "file_test_setup", mrb_io_test_file_setup, MRB_ARGS_NONE());
   mrb_define_class_method(mrb, io_test, "file_test_cleanup", mrb_io_test_file_cleanup, MRB_ARGS_NONE());
 
+  mrb_define_class_method(mrb, io_test, "mktemp", mrb_io_test_mktemp, MRB_ARGS_REQ(1));
   mrb_define_class_method(mrb, io_test, "mkdtemp", mrb_io_test_mkdtemp, MRB_ARGS_REQ(1));
   mrb_define_class_method(mrb, io_test, "rmdir", mrb_io_test_rmdir, MRB_ARGS_REQ(1));
   mrb_define_class_method(mrb, io_test, "win?", mrb_io_win_p, MRB_ARGS_NONE());


### PR DESCRIPTION
If tests containing mruby-io are run in parallel, problems may occur due to the same symbolic link names.

https://github.com/mruby/mruby/blob/83dab1ee0d0d3aa76e44f7fbf14360ee501be151/mrbgems/mruby-io/test/file.rb#L180-L187

Perhaps you can solve the problem described at https://github.com/mruby/mruby/pull/4636#issuecomment-522312628.
