### PR TITLE
Use `RBasic` padding for embedded string on 64-bit CPU

### DIFF
--- a/include/mruby/object.h
+++ b/include/mruby/object.h
@@ -8,11 +8,11 @@
 #define MRUBY_OBJECT_H
 
 #define MRB_OBJECT_HEADER \
+  struct RClass *c;       \
+  struct RBasic *gcnext;  \
   enum mrb_vtype tt:8;    \
   uint32_t color:3;       \
-  uint32_t flags:21;      \
-  struct RClass *c;       \
-  struct RBasic *gcnext
+  uint32_t flags:21
 
 #define MRB_FLAG_TEST(obj, flag) ((obj)->flags & (flag))
 

--- a/src/gc.c
+++ b/src/gc.c
@@ -521,7 +521,7 @@ MRB_API struct RBasic*
 mrb_obj_alloc(mrb_state *mrb, enum mrb_vtype ttype, struct RClass *cls)
 {
   struct RBasic *p;
-  static const RVALUE RVALUE_zero = { { { MRB_TT_FALSE } } };
+  static const RVALUE RVALUE_zero = { { { NULL, NULL, MRB_TT_FALSE } } };
   mrb_gc *gc = &mrb->gc;
 
   if (cls) {

--- a/src/string.c
+++ b/src/string.c
@@ -54,8 +54,8 @@ str_init_normal(mrb_state *mrb, struct RString *s, const char *p, size_t len)
 static void
 str_init_embed(struct RString *s, const char *p, size_t len)
 {
-  if (p) memcpy(s->as.ary, p, len);
-  s->as.ary[len] = '\0';
+  if (p) memcpy(RSTR_EMBED_PTR(s), p, len);
+  RSTR_EMBED_PTR(s)[len] = '\0';
   RSTR_SET_TYPE_FLAG(s, EMBED);
   RSTR_SET_EMBED_LEN(s, len);
 }
@@ -188,7 +188,7 @@ resize_capa(mrb_state *mrb, struct RString *s, size_t capacity)
 #endif
   if (RSTR_EMBED_P(s)) {
     if (!RSTR_EMBEDDABLE_P(capacity)) {
-      str_init_normal_capa(mrb, s, s->as.ary, RSTR_EMBED_LEN(s), capacity);
+      str_init_normal_capa(mrb, s, RSTR_EMBED_PTR(s), RSTR_EMBED_LEN(s), capacity);
     }
   }
   else {


### PR DESCRIPTION
On 64-bit CPU, there is padding in `RBasic`, so reorder the fields and use
it as buffer of embedded string. This change allows 4 more bytes to be
embedded on 64-bit CPU.

However, an incompatibility will occur if `RString::as::ary` is accessed
directly because `RString` structure has changed.