### PR TITLE
make clean error workaround

### DIFF
--- a/Makefile.doc
+++ b/Makefile.doc
@@ -11,5 +11,5 @@ docserver : docs
 	firefox doxygen/html/index.html 
 
 docsclean :
-	rm -r doxygen
+	rm -rf doxygen
 .PHONY : docserver docsclean


### PR DESCRIPTION
I have error at make clean at no doxygen environment. 

% make clean
rm -r doxygen
rm: doxygen: No such file or directory
*** Error code 1

Stop.

This is work around for this error.