### PR TITLE
Refine processing for gem lock file

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -8,10 +8,10 @@ MRUBY_BUILD_HOST_IS_OPENBSD = RUBY_PLATFORM.include?('openbsd')
 $LOAD_PATH << File.join(MRUBY_ROOT, "lib")
 
 # load build systems
-require 'yaml'
 require "mruby-core-ext"
 require "mruby/build"
 require "mruby/gem"
+require "mruby/lockfile"
 
 # load configuration file
 MRUBY_CONFIG = (ENV['MRUBY_CONFIG'] && ENV['MRUBY_CONFIG'] != '') ? ENV['MRUBY_CONFIG'] : "#{MRUBY_ROOT}/build_config.rb"
@@ -125,25 +125,7 @@ task :all => depfiles do
   MRuby.each_target do
     print_build_summary
   end
-
-  require 'mruby/source'
-
-  locks_result = {
-    'mruby_version' => {
-      'version' => MRuby::Source::MRUBY_VERSION,
-      'release_no' => MRuby::Source::MRUBY_RELEASE_NO
-    },
-    'builds' => {}
-  }
-  if File.exist? "#{MRUBY_ROOT}/.git"
-    locks_result['mruby_version']['git_commit'] = `git --git-dir '#{MRUBY_ROOT}/.git' --work-tree '#{MRUBY_ROOT}' rev-parse --verify HEAD`.strip
-  end
-
-  MRuby.each_target do
-    locks_result['builds'][name] = locks
-  end
-
-  File.write MRUBY_CONFIG_LOCK_FILE, YAML.dump(locks_result)
+  MRuby::Lockfile.write
 end
 
 desc "run all mruby tests"

--- a/lib/mruby/build.rb
+++ b/lib/mruby/build.rb
@@ -39,7 +39,7 @@ module MRuby
     include Rake::DSL
     include LoadGems
     attr_accessor :name, :bins, :exts, :file_separator, :build_dir, :gem_clone_dir
-    attr_reader :libmruby_objs, :gems, :toolchains, :locks
+    attr_reader :libmruby_objs, :gems, :toolchains
     attr_writer :enable_bintest, :enable_test
 
     alias libmruby libmruby_objs
@@ -84,11 +84,8 @@ module MRuby
         @cxx_abi_enabled = false
         @enable_bintest = false
         @enable_test = false
-        @toolchains = []
-
-        @locks = MRUBY_CONFIG_LOCK['builds'][@name] if MRUBY_CONFIG_LOCK['builds']
-        @locks ||= {}
         @enable_lock = true
+        @toolchains = []
 
         MRuby.targets[@name] = self
       end
@@ -118,6 +115,10 @@ module MRuby
 
     def disable_lock
       @enable_lock = false
+    end
+
+    def lock_enabled?
+      Lockfile.enabled? && @enable_lock
     end
 
     def disable_cxx_exception
@@ -231,6 +232,10 @@ EOS
 
     def build_mrbc_exec
       gem :core => 'mruby-bin-mrbc'
+    end
+
+    def locks
+      Lockfile.build(@name)
     end
 
     def mrbcfile

--- a/lib/mruby/build/load_gems.rb
+++ b/lib/mruby/build/load_gems.rb
@@ -83,7 +83,7 @@ module MRuby
         # by default the 'master' branch is used
         branch = params[:branch] ? params[:branch] : 'master'
 
-        lock = @locks[url] if @enable_lock
+        lock = locks[url] if lock_enabled?
 
         if File.exist?(gemdir)
           if $pull_gems
@@ -112,8 +112,8 @@ module MRuby
           end
         end
 
-        if @enable_lock
-          @locks[url] = {
+        if lock_enabled?
+          locks[url] = {
             'url' => url,
             'branch' => git.current_branch(gemdir),
             'commit' => git.commit_hash(gemdir),

--- a/lib/mruby/lockfile.rb
+++ b/lib/mruby/lockfile.rb
@@ -1,0 +1,73 @@
+autoload :YAML, 'yaml'
+
+module MRuby
+  autoload :Source, 'mruby/source'
+
+  class Lockfile
+    class << self
+      def enable
+        @enabled = true
+      end
+
+      def disable
+        @enabled = false
+      end
+
+      def enabled?
+        @enabled
+      end
+
+      def build(target_name)
+        instance.build(target_name)
+      end
+
+      def write
+        instance.write if enabled?
+      end
+
+      def instance
+        @instance ||= new("#{MRUBY_CONFIG}.lock")
+      end
+    end
+
+    def initialize(filename)
+      @filename = filename
+    end
+
+    def build(target_name)
+      read[target_name] ||= {}
+    end
+
+    def write
+      locks = {"mruby_version" => mruby}
+      locks["builds"] = @builds if @builds
+      File.write(@filename, YAML.dump(locks))
+    end
+
+    private
+
+    def read
+      @builds ||= if File.exist?(@filename)
+                    YAML.load_file(@filename)["builds"] || {}
+                  else
+                    {}
+                  end
+    end
+
+    def mruby
+      mruby = {
+        'version' => MRuby::Source::MRUBY_VERSION,
+        'release_no' => MRuby::Source::MRUBY_RELEASE_NO,
+      }
+
+      git_dir = "#{MRUBY_ROOT}/.git"
+      if File.directory?(git_dir)
+        mruby['git_commit'] = `git --git-dir '#{git_dir}' --work-tree '#{MRUBY_ROOT}' rev-parse --verify HEAD`.strip
+      end
+
+      mruby
+    end
+
+    enable
+  end
+end


### PR DESCRIPTION
- Defer YAML library and lock file loading until needed.
- Don't write empty parts into lock file.
- Extract code to read/write lock file to `MRuby::Lockfile`.
- `MRuby::Lockfile.disable` disables the use of lock file.

---

The use of lock file is enabled by default (without external gem) and only the `mruby_version` part is written. However, since `mruby_version` part is unused and lock file doesn't make sense, I think it is better to disable the use of lock file by default.