### PR TITLE
Fix `RBreak` exceeding 6 words on 32-bit mode w/o boxing and `MRB_USE_FLOAT`

### DIFF
--- a/include/mruby/boxing_no.h
+++ b/include/mruby/boxing_no.h
@@ -10,15 +10,17 @@
 #define MRB_FIXNUM_SHIFT 0
 #define MRB_TT_HAS_BASIC MRB_TT_OBJECT
 
-typedef struct mrb_value {
-  union {
+union mrb_value_value {
 #ifndef MRB_WITHOUT_FLOAT
-    mrb_float f;
+  mrb_float f;
 #endif
-    void *p;
-    mrb_int i;
-    mrb_sym sym;
-  } value;
+  void *p;
+  mrb_int i;
+  mrb_sym sym;
+};
+
+typedef struct mrb_value {
+  union mrb_value_value value;
   enum mrb_vtype tt;
 } mrb_value;
 

--- a/src/vm.c
+++ b/src/vm.c
@@ -836,8 +836,8 @@ break_new(mrb_state *mrb, struct RProc *p, mrb_value val)
   struct RBreak *brk;
 
   brk = (struct RBreak*)mrb_obj_alloc(mrb, MRB_TT_BREAK, NULL);
-  brk->proc = p;
-  brk->val = val;
+  mrb_break_proc_set(brk, p);
+  mrb_break_value_set(brk, val);
 
   return brk;
 }
@@ -2100,8 +2100,8 @@ RETRY_TRY_BLOCK:
           }
           if (FALSE) {
           L_BREAK:
-            v = ((struct RBreak*)mrb->exc)->val;
-            proc = ((struct RBreak*)mrb->exc)->proc;
+            v = mrb_break_value_get((struct RBreak*)mrb->exc);
+            proc = mrb_break_proc_get((struct RBreak*)mrb->exc);
             mrb->exc = NULL;
             ci = mrb->c->ci;
           }


### PR DESCRIPTION
ref: https://github.com/mruby/mruby/pull/4483#issuecomment-498001736

In this configuration, `tt` of `RBreak::val` is set into `RBreak::flags`.