### PR TITLE
Create a symbolic link in the temporary directory; fix #4642

### DIFF
--- a/mrbgems/mruby-io/test/file.rb
+++ b/mrbgems/mruby-io/test/file.rb
@@ -179,20 +179,25 @@ end
 
 assert('File.symlink') do
   target_name = "/usr/bin"
-  symlink_name = MRubyIOTestUtil.mktemp("test-bin-dummy-XXXXXXXX")
   if !File.exist?(target_name)
     skip("target directory of File.symlink is not found")
-  else
-    begin
-      assert_equal 0, File.symlink(target_name, symlink_name)
-      begin
-        assert_equal true, File.symlink?(symlink_name)
-      ensure
-        File.delete symlink_name
-      end
-    rescue NotImplementedError => e
-      skip e.message
-    end
+  end
+
+  begin
+    tmpdir = MRubyIOTestUtil.mkdtemp("mruby-io-test.XXXXXX")
+  rescue => e
+    skip e.message
+  end
+
+  symlink_name = "#{tmpdir}/test-bin-dummy"
+  begin
+    assert_equal 0, File.symlink(target_name, symlink_name)
+    assert_equal true, File.symlink?(symlink_name)
+  rescue NotImplementedError => e
+    skip e.message
+  ensure
+    File.delete symlink_name rescue nil
+    MRubyIOTestUtil.rmdir tmpdir rescue nil
   end
 end
 

--- a/mrbgems/mruby-io/test/mruby_io_test.c
+++ b/mrbgems/mruby-io/test/mruby_io_test.c
@@ -44,7 +44,6 @@ mkdtemp(char *temp)
   return path;
 }
 
-#define mktemp(path) _mktemp(path)
 #define umask(mode) _umask(mode)
 #define rmdir(path) _rmdir(path)
 #else
@@ -200,20 +199,6 @@ mrb_io_test_file_cleanup(mrb_state *mrb, mrb_value self)
 }
 
 static mrb_value
-mrb_io_test_mktemp(mrb_state *mrb, mrb_value klass)
-{
-  mrb_value str;
-  char *cp;
-
-  mrb_get_args(mrb, "S", &str);
-  cp = mrb_str_to_cstr(mrb, str);
-  if (mktemp(cp) == NULL) {
-    mrb_sys_fail(mrb, "mktemp");
-  }
-  return mrb_str_new_cstr(mrb, cp);
-}
-
-static mrb_value
 mrb_io_test_mkdtemp(mrb_state *mrb, mrb_value klass)
 {
   mrb_value str;
@@ -263,7 +248,6 @@ mrb_mruby_io_gem_test(mrb_state* mrb)
   mrb_define_class_method(mrb, io_test, "file_test_setup", mrb_io_test_file_setup, MRB_ARGS_NONE());
   mrb_define_class_method(mrb, io_test, "file_test_cleanup", mrb_io_test_file_cleanup, MRB_ARGS_NONE());
 
-  mrb_define_class_method(mrb, io_test, "mktemp", mrb_io_test_mktemp, MRB_ARGS_REQ(1));
   mrb_define_class_method(mrb, io_test, "mkdtemp", mrb_io_test_mkdtemp, MRB_ARGS_REQ(1));
   mrb_define_class_method(mrb, io_test, "rmdir", mrb_io_test_rmdir, MRB_ARGS_REQ(1));
   mrb_define_class_method(mrb, io_test, "win?", mrb_io_win_p, MRB_ARGS_NONE());


### PR DESCRIPTION
Because the linker gives a warning on FreeBSD 12.0.

```
warning: mktemp() possibly used unsafely; consider using mkstemp()
```

Even with travis-ci, there was a warning:
https://travis-ci.org/mruby/mruby/jobs/573416883#L1335-L1338

```
warning: the use of `mktemp' is dangerous, better use `mkstemp' or `mkdtemp'
```
