### PR TITLE
Remove unneeded `/src/y.tab.c` in `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,5 +32,3 @@ tags
 
 /doc/api
 /doc/capi
-
-/src/y.tab.c


### PR DESCRIPTION
Currently, `y.tab.c` is generated to under the `build/` directory.