### PR TITLE
Implement `mrb_immediate_p` macro for `MRB_WORD_BOXING`

### DIFF
--- a/include/mruby/boxing_word.h
+++ b/include/mruby/boxing_word.h
@@ -28,11 +28,6 @@ struct RCptr {
 };
 
 #define MRB_FIXNUM_SHIFT 1
-#ifdef MRB_WITHOUT_FLOAT
-#define MRB_TT_HAS_BASIC MRB_TT_CPTR
-#else
-#define MRB_TT_HAS_BASIC MRB_TT_FLOAT
-#endif
 
 enum mrb_special_consts {
   MRB_Qnil    = 0,
@@ -41,9 +36,10 @@ enum mrb_special_consts {
   MRB_Qundef  = 6,
 };
 
-#define MRB_FIXNUM_FLAG   0x01
-#define MRB_SYMBOL_FLAG   0x0e
-#define MRB_SPECIAL_SHIFT 8
+#define MRB_IMMEDIATE_MASK  0x07
+#define MRB_FIXNUM_FLAG     0x01
+#define MRB_SYMBOL_FLAG     0x0e
+#define MRB_SPECIAL_SHIFT   8
 
 #if defined(MRB_64BIT)
 #define MRB_SYMBOL_BITSIZE  (sizeof(mrb_sym) * CHAR_BIT)
@@ -113,6 +109,7 @@ mrb_type(mrb_value o)
 }
 
 #define mrb_bool(o)    ((o).w != MRB_Qnil && (o).w != MRB_Qfalse)
+#define mrb_immediate_p(o) ((o).w & MRB_IMMEDIATE_MASK || (o).w == MRB_Qnil)
 #define mrb_fixnum_p(o) ((o).value.i_flag == MRB_FIXNUM_FLAG)
 #define mrb_undef_p(o) ((o).w == MRB_Qundef)
 #define mrb_nil_p(o)  ((o).w == MRB_Qnil)

--- a/include/mruby/object.h
+++ b/include/mruby/object.h
@@ -32,7 +32,6 @@ struct RObject {
 };
 #define mrb_obj_ptr(v)   ((struct RObject*)(mrb_ptr(v)))
 
-#define mrb_immediate_p(x) (mrb_type(x) < MRB_TT_HAS_BASIC)
 #define mrb_special_const_p(x) mrb_immediate_p(x)
 
 struct RFiber {

--- a/include/mruby/value.h
+++ b/include/mruby/value.h
@@ -161,6 +161,9 @@ typedef void mrb_value;
 #include "boxing_no.h"
 #endif
 
+#ifndef mrb_immediate_p
+#define mrb_immediate_p(o) (mrb_type(o) < MRB_TT_HAS_BASIC)
+#endif
 #ifndef mrb_fixnum_p
 #define mrb_fixnum_p(o) (mrb_type(o) == MRB_TT_FIXNUM)
 #endif


### PR DESCRIPTION
The default implementation of `mrb_immediate_p` uses `mrb_type`. However,
in `MRB_WORD_BOXING`, `mrb_type` has many branches and is inefficient, so
provide an implementation that does not use `mrb_type`.