### PR TITLE
`Array#permutation` with a negative argument should not yield

### DIFF
--- a/mrbgems/mruby-array-ext/mrblib/array.rb
+++ b/mrbgems/mruby-array-ext/mrblib/array.rb
@@ -819,7 +819,7 @@ class Array
     size = self.size
     if n == 0
       yield []
-    elsif n <= size
+    elsif 0 < n && n <= size
       i = 0
       while i<size
         result = [self[i]]

--- a/mrbgems/mruby-array-ext/test/array.rb
+++ b/mrbgems/mruby-array-ext/test/array.rb
@@ -392,6 +392,7 @@ assert("Array#permutation") do
   assert_permutation([[1,2,3],[1,3,2],[2,1,3],[2,3,1],[3,1,2],[3,2,1]], a, 3)
   assert_permutation([[]], a, 0)
   assert_permutation([], a, 4)
+  assert_permutation([], a, -1)
 end
 
 assert("Array#combination") do
@@ -402,6 +403,7 @@ assert("Array#combination") do
   assert_combination([[1,2,3,4]], a, 4)
   assert_combination([[]], a, 0)
   assert_combination([], a, 5)
+  assert_combination([], a, -1)
 end
 
 assert('Array#transpose') do


### PR DESCRIPTION
#### Before this patch:

  ```terminal
  $ bin/mruby -e '[1].permutation(-1){|v| p v}'  #=> [1]
  ```

#### After this patch (same as Ruby):

  ```terminal
  $ bin/mruby -e '[1].permutation(-1){|v| p v}'  #=> no output
  ```