### PR TITLE
Add `assert_not_nil` method

### DIFF
--- a/test/assert.rb
+++ b/test/assert.rb
@@ -208,6 +208,13 @@ def assert_nil(obj, msg = nil)
   assert_true(ret, msg, diff)
 end
 
+def assert_not_nil(obj, msg = nil)
+  if ret = obj.nil?
+    diff = "    Expected #{obj.inspect} to not be nil."
+  end
+  assert_false(ret, msg, diff)
+end
+
 def assert_include(*args); _assert_include(true, *args) end
 def assert_not_include(*args); _assert_include(false, *args) end
 def _assert_include(affirmed, collection, obj, msg = nil)


### PR DESCRIPTION
I added `assert_not_nil` method.
Of course there are other ways.

```ruby
assert_true target != nil
assert_false target.nil?
#etc...
```

However, I thought it was superior in terms of readability.

```ruby
assert_not_nil target
```

I did the following check.

```ruby
assert('assert_not_nil pass') do
  assert_not_nil 'hoge'
end

assert('assert_not_nil fail') do
  assert_not_nil nil
end
```

```
Fail: assert_not_nil fail (core)
 - Assertion[1]
    Expected nil to not be nil.
```

Please check.