### PR TITLE
Fix `mrb_vformat()` crashes with `MRB_INT16`

### DIFF
--- a/src/error.c
+++ b/src/error.c
@@ -326,7 +326,11 @@ mrb_vformat(mrb_state *mrb, const char *format, va_list ap)
           len = 1;
           goto L_cat;
         case 'd': case 'i':
+#if MRB_INT_MAX < INT_MAX
+          i = (mrb_int)va_arg(ap, int);
+#else
           i = *p == 'd' ? (mrb_int)va_arg(ap, int) : va_arg(ap, mrb_int);
+#endif
           obj = mrb_fixnum_value(i);
           goto L_cat_obj;
 #ifndef MRB_WITHOUT_FLOAT


### PR DESCRIPTION
If `MRB_INT16` is specified, the variable length argument `mrb_int` is converted to `int`.

----

When building with GCC (gcc-9.2.0), a warning is displayed.

```
src/error.c: In function 'mrb_vformat':
src/error.c:329:65: warning: 'mrb_int' {aka 'short int'} is promoted to 'int' when passed through '...'
  329 |           i = *p == 'd' ? (mrb_int)va_arg(ap, int) : va_arg(ap, mrb_int);
      |                                                                 ^
src/error.c:329:65: note: (so you should pass 'int' not 'mrb_int' {aka 'short int'} to 'va_arg')
src/error.c:329:65: note: if this code is reached, the program will abort
```

If I run it on FreeBSD as it is, it crashed by `SIGILL`.

----

**NOTE**: This patch may be undesirable because the value given as `int` will be converted to 16-bit `mrb_int`.
