### PR TITLE
Deduplicate constant names

### DIFF
--- a/include/mruby/array.h
+++ b/include/mruby/array.h
@@ -291,6 +291,16 @@ MRB_API mrb_value mrb_ary_join(mrb_state *mrb, mrb_value ary, mrb_value sep);
  */
 MRB_API mrb_value mrb_ary_resize(mrb_state *mrb, mrb_value ary, mrb_int new_len);
 
+/*
+ * Get index of obj in the array
+ *
+ * @param mrb The mruby state reference.
+ * @param ary The target array.
+ * @param obj The object you want to find from the array.
+ * @return Returns the index of matching elements. If it does not exist, returns -1.
+ */
+MRB_API mrb_int mrb_ary_index(mrb_state *mrb, mrb_value ary, mrb_value obj);
+
 MRB_END_DECL
 
 #endif  /* MRUBY_ARRAY_H */

--- a/src/array.c
+++ b/src/array.c
@@ -1022,6 +1022,19 @@ mrb_ary_last(mrb_state *mrb, mrb_value self)
   return mrb_ary_new_from_values(mrb, size, ARY_PTR(a) + alen - size);
 }
 
+MRB_API mrb_int
+mrb_ary_index(mrb_state *mrb, mrb_value ary, mrb_value obj)
+{
+  mrb_int i;
+
+  for (i = 0; i < RARRAY_LEN(ary); i++) {
+    if (mrb_equal(mrb, RARRAY_PTR(ary)[i], obj)) {
+      return i;
+    }
+  }
+  return -1;
+}
+
 static mrb_value
 mrb_ary_index_m(mrb_state *mrb, mrb_value self)
 {
@@ -1029,12 +1042,10 @@ mrb_ary_index_m(mrb_state *mrb, mrb_value self)
   mrb_int i;
 
   mrb_get_args(mrb, "o", &obj);
-  for (i = 0; i < RARRAY_LEN(self); i++) {
-    if (mrb_equal(mrb, RARRAY_PTR(self)[i], obj)) {
-      return mrb_fixnum_value(i);
-    }
-  }
-  return mrb_nil_value();
+
+  i = mrb_ary_index(mrb, self, obj);
+  if (i < 0) return mrb_nil_value();
+  return mrb_fixnum_value(i);
 }
 
 static mrb_value

--- a/src/variable.c
+++ b/src/variable.c
@@ -882,7 +882,10 @@ const_i(mrb_state *mrb, mrb_sym sym, mrb_value v, void *p)
   ary = *(mrb_value*)p;
   s = mrb_sym2name_len(mrb, sym, &len);
   if (len >= 1 && ISUPPER(s[0])) {
-    mrb_ary_push(mrb, ary, mrb_symbol_value(sym));
+    mrb_value o = mrb_symbol_value(sym);
+    if (mrb_ary_index(mrb, ary, o) < 0) {
+      mrb_ary_push(mrb, ary, o);
+    }
   }
   return 0;
 }


### PR DESCRIPTION
If the module/class do `include`, `mod.constants` returned duplicate constant names.

Before patched:

```ruby
p Object.constants.grep(:BasicObject)
# => [:BasicObject, :BasicObject]
# BasicObject::BasicObject and Kernel::BasicObject
```

**NOTE**:

  - The patch includes the `mrb_ary_index()` function as an API.
  - Since the situation continues from before mruby-1.0.0, I think that it is also one hand to make the specification.
    At least I'm not in trouble.
