### PR TITLE
Refine `tasks/toolchains/(gcc|clang).rake`

### DIFF
--- a/tasks/toolchains/clang.rake
+++ b/tasks/toolchains/clang.rake
@@ -1,11 +1,7 @@
 MRuby::Toolchain.new(:clang) do |conf, _params|
-  toolchain :gcc
+  toolchain :gcc, default_command: 'clang'
 
-  [conf.cc, conf.objc, conf.asm].each do |cc|
-    cc.command = ENV['CC'] || 'clang'
-    cc.flags << '-Wzero-length-array' unless ENV['CFLAGS']
+  [conf.cc, conf.objc, conf.asm, conf.cxx].each do |compiler|
+    compiler.flags.unshift('-Wzero-length-array')
   end
-  conf.cxx.command = ENV['CXX'] || 'clang++'
-  conf.cxx.flags << '-Wzero-length-array' unless ENV['CXXFLAGS'] || ENV['CFLAGS']
-  conf.linker.command = ENV['LD'] || ENV['CXX'] || ENV['CC'] || 'clang'
 end

--- a/tasks/toolchains/gcc.rake
+++ b/tasks/toolchains/gcc.rake
@@ -1,26 +1,24 @@
-MRuby::Toolchain.new(:gcc) do |conf, _params|
-  [conf.cc, conf.objc, conf.asm].each do |cc|
-    cc.command = ENV['CC'] || 'gcc'
-    cc.flags = [ENV['CFLAGS'] || %w(-g -std=gnu99 -O3 -Wall -Werror-implicit-function-declaration -Wdeclaration-after-statement -Wwrite-strings -Wundef)]
-    cc.option_include_path = '-I%s'
-    cc.option_define = '-D%s'
-    cc.compile_options = '%{flags} -MMD -o %{outfile} -c %{infile}'
-    cc.cxx_compile_flag = '-x c++ -std=c++03'
-    cc.cxx_exception_flag = '-fexceptions'
-  end
+MRuby::Toolchain.new(:gcc) do |conf, params|
+  default_command = params[:default_command] || 'gcc'
+  compile_flags = %w(-g -O3 -Wall -Wundef -Werror-implicit-function-declaration)
 
-  [conf.cxx].each do |cxx|
-    cxx.command = ENV['CXX'] || 'g++'
-    cxx.flags = [ENV['CXXFLAGS'] || ENV['CFLAGS'] || %w(-g -O3 -Wall -Werror-implicit-function-declaration -Wundef)]
-    cxx.option_include_path = '-I%s'
-    cxx.option_define = '-D%s'
-    cxx.compile_options = '%{flags} -MMD -o %{outfile} -c %{infile}'
-    cxx.cxx_compile_flag = '-x c++ -std=c++03'
-    cxx.cxx_exception_flag = '-fexceptions'
+  [conf.cc, conf.objc, conf.asm, conf.cxx].each do |compiler|
+    if compiler == conf.cxx
+      compiler.command = ENV['CXX'] || default_command.sub(/cc|$/, '++')
+      compiler.flags = [ENV['CXXFLAGS'] || ENV['CFLAGS'] || compile_flags]
+    else
+      compiler.command = ENV['CC'] || default_command
+      compiler.flags = ['-std=gnu99', ENV['CFLAGS'] || [compile_flags, %w(-Wdeclaration-after-statement -Wwrite-strings)]]
+    end
+    compiler.option_include_path = '-I%s'
+    compiler.option_define = '-D%s'
+    compiler.compile_options = '%{flags} -MMD -o %{outfile} -c %{infile}'
+    compiler.cxx_compile_flag = '-x c++ -std=c++03'
+    compiler.cxx_exception_flag = '-fexceptions'
   end
 
   conf.linker do |linker|
-    linker.command = ENV['LD'] || ENV['CXX'] || ENV['CC'] || 'gcc'
+    linker.command = ENV['LD'] || ENV['CXX'] || ENV['CC'] || default_command
     linker.flags = [ENV['LDFLAGS'] || %w()]
     linker.libraries = %w(m)
     linker.library_paths = []


### PR DESCRIPTION
- Make sure to specify `-std=gnu99` for C compiler flag.
- Make sure to specify `-Wzero-length-array` for C/C++ compiler flag (Clang).
- Extract similar codes.