### PR TITLE
Revert part of "Refine `tasks/toolchains/(gcc|clang).rake`" (07c6b7f0)

### DIFF
--- a/tasks/toolchains/clang.rake
+++ b/tasks/toolchains/clang.rake
@@ -1,7 +1,8 @@
 MRuby::Toolchain.new(:clang) do |conf, _params|
   toolchain :gcc, default_command: 'clang'
 
-  [conf.cc, conf.objc, conf.asm, conf.cxx].each do |compiler|
-    compiler.flags.unshift('-Wzero-length-array')
+  [conf.cc, conf.objc, conf.asm].each do |cc|
+    cc.flags << '-Wzero-length-array' unless ENV['CFLAGS']
   end
+  conf.cxx.flags << '-Wzero-length-array' unless ENV['CXXFLAGS'] || ENV['CFLAGS']
 end


### PR DESCRIPTION
`-Wzero-length-array` is not a mandatory option, so the original is better.