### PR TITLE
Fix mruby-io

### DIFF
--- a/mrbgems/mruby-io/mrblib/io.rb
+++ b/mrbgems/mruby-io/mrblib/io.rb
@@ -253,12 +253,14 @@ class IO
         break
       end
 
-      if limit && limit <= @buf.bytesize
-        array.push IO._bufread(@buf, limit)
+      if limit && limit <= @buf.size
+        array.push @buf[0, limit]
+        @buf = @buf[limit, @buf.size - limit]
         break
       elsif idx = @buf.index(rs)
-        len = idx + rs.bytesize
-        array.push IO._bufread(@buf, len)
+        len = idx + rs.size
+        array.push @buf[0, len]
+        @buf = @buf[len, @buf.size - len]
         break
       else
         array.push @buf
@@ -281,7 +283,9 @@ class IO
 
   def readchar
     _read_buf
-    IO._bufread(@buf, 1)
+    c = @buf[0]
+    @buf = @buf[1, @buf.size]
+    c
   end
 
   def getc

--- a/mrbgems/mruby-io/mrblib/io.rb
+++ b/mrbgems/mruby-io/mrblib/io.rb
@@ -170,8 +170,14 @@ class IO
   end
 
   def _read_buf
-    return @buf if @buf && @buf.bytesize > 0
-    @buf = sysread(BUF_SIZE)
+    return @buf if @buf && @buf.bytesize >= 4 # maximum UTF-8 character is 4 bytes
+    @buf ||= ""
+    begin
+      @buf += sysread(BUF_SIZE)
+    rescue EOFError => e
+      raise e if @buf.empty?
+    end
+    @buf
   end
 
   def ungetc(substr)

--- a/mrbgems/mruby-io/mrblib/io.rb
+++ b/mrbgems/mruby-io/mrblib/io.rb
@@ -150,7 +150,7 @@ class IO
 
   def pos
     raise IOError if closed?
-    sysseek(0, SEEK_CUR) - @buf.length
+    sysseek(0, SEEK_CUR) - @buf.bytesize
   end
   alias_method :tell, :pos
 

--- a/mrbgems/mruby-io/mrblib/io.rb
+++ b/mrbgems/mruby-io/mrblib/io.rb
@@ -123,8 +123,8 @@ class IO
 
   def write(string)
     str = string.is_a?(String) ? string : string.to_s
-    return str.size unless str.size > 0
-    if 0 < @buf.length
+    return 0 if str.empty?
+    unless @buf.empty?
       # reset real pos ignore buf
       seek(pos, SEEK_SET)
     end
@@ -141,7 +141,7 @@ class IO
     _check_readable
     begin
       buf = _read_buf
-      return buf.size == 0
+      return buf.empty?
     rescue EOFError
       return true
     end
@@ -170,7 +170,7 @@ class IO
   end
 
   def _read_buf
-    return @buf if @buf && @buf.size > 0
+    return @buf if @buf && @buf.bytesize > 0
     @buf = sysread(BUF_SIZE)
   end
 
@@ -255,12 +255,12 @@ class IO
 
       if limit && limit <= @buf.size
         array.push @buf[0, limit]
-        @buf = @buf[limit, @buf.size - limit]
+        @buf[0, limit] = ""
         break
       elsif idx = @buf.index(rs)
         len = idx + rs.size
         array.push @buf[0, len]
-        @buf = @buf[len, @buf.size - len]
+        @buf[0, len] = ""
         break
       else
         array.push @buf
@@ -284,7 +284,7 @@ class IO
   def readchar
     _read_buf
     c = @buf[0]
-    @buf = @buf[1, @buf.size]
+    @buf[0] = ""
     c
   end
 


### PR DESCRIPTION
"Fix broken UTF-8 characters by `IO#getc`" (https://github.com/mruby/mruby/commit/992ba476a95136eaad5b9b208d4ca5a1ca31324d) increases the object code size without `MRB_UTF8_STRING` too, so I would like to improve if there is a better solution (but no idea).