### PR TITLE
Shrink `mrb_get_args()`

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -619,6 +619,8 @@ mrb_get_args(mrb_state *mrb, const char *format, ...)
   opt = FALSE;
   i = 0;
   while ((c = *format++)) {
+    mrb_value *argv = ARGV;
+
     switch (c) {
     case '|': case '*': case '&': case '?':
       break;
@@ -641,7 +643,7 @@ mrb_get_args(mrb_state *mrb, const char *format, ...)
 
         p = va_arg(ap, mrb_value*);
         if (i < argc) {
-          *p = ARGV[arg_i++];
+          *p = argv[arg_i++];
           i++;
         }
       }
@@ -654,7 +656,7 @@ mrb_get_args(mrb_state *mrb, const char *format, ...)
         if (i < argc) {
           mrb_value ss;
 
-          ss = ARGV[arg_i++];
+          ss = argv[arg_i++];
           if (!class_ptr_p(ss)) {
             mrb_raisef(mrb, E_TYPE_ERROR, "%v is not class/module", ss);
           }
@@ -670,14 +672,14 @@ mrb_get_args(mrb_state *mrb, const char *format, ...)
         p = va_arg(ap, mrb_value*);
         if (*format == '!') {
           format++;
-          if (i < argc && mrb_nil_p(ARGV[arg_i])) {
-            *p = ARGV[arg_i++];
+          if (i < argc && mrb_nil_p(argv[arg_i])) {
+            *p = argv[arg_i++];
             i++;
             break;
           }
         }
         if (i < argc) {
-          *p = ARGV[arg_i++];
+          *p = argv[arg_i++];
           mrb_to_str(mrb, *p);
           i++;
         }
@@ -690,14 +692,14 @@ mrb_get_args(mrb_state *mrb, const char *format, ...)
         p = va_arg(ap, mrb_value*);
         if (*format == '!') {
           format++;
-          if (i < argc && mrb_nil_p(ARGV[arg_i])) {
-            *p = ARGV[arg_i++];
+          if (i < argc && mrb_nil_p(argv[arg_i])) {
+            *p = argv[arg_i++];
             i++;
             break;
           }
         }
         if (i < argc) {
-          *p = to_ary(mrb, ARGV[arg_i++]);
+          *p = to_ary(mrb, argv[arg_i++]);
           i++;
         }
       }
@@ -709,14 +711,14 @@ mrb_get_args(mrb_state *mrb, const char *format, ...)
         p = va_arg(ap, mrb_value*);
         if (*format == '!') {
           format++;
-          if (i < argc && mrb_nil_p(ARGV[arg_i])) {
-            *p = ARGV[arg_i++];
+          if (i < argc && mrb_nil_p(argv[arg_i])) {
+            *p = argv[arg_i++];
             i++;
             break;
           }
         }
         if (i < argc) {
-          *p = to_hash(mrb, ARGV[arg_i++]);
+          *p = to_hash(mrb, argv[arg_i++]);
           i++;
         }
       }
@@ -731,7 +733,7 @@ mrb_get_args(mrb_state *mrb, const char *format, ...)
         pl = va_arg(ap, mrb_int*);
         if (*format == '!') {
           format++;
-          if (i < argc && mrb_nil_p(ARGV[arg_i])) {
+          if (i < argc && mrb_nil_p(argv[arg_i])) {
             *ps = NULL;
             *pl = 0;
             i++; arg_i++;
@@ -739,7 +741,7 @@ mrb_get_args(mrb_state *mrb, const char *format, ...)
           }
         }
         if (i < argc) {
-          ss = ARGV[arg_i++];
+          ss = argv[arg_i++];
           mrb_to_str(mrb, ss);
           *ps = RSTRING_PTR(ss);
           *pl = RSTRING_LEN(ss);
@@ -755,14 +757,14 @@ mrb_get_args(mrb_state *mrb, const char *format, ...)
         ps = va_arg(ap, const char**);
         if (*format == '!') {
           format++;
-          if (i < argc && mrb_nil_p(ARGV[arg_i])) {
+          if (i < argc && mrb_nil_p(argv[arg_i])) {
             *ps = NULL;
             i++; arg_i++;
             break;
           }
         }
         if (i < argc) {
-          ss = ARGV[arg_i++];
+          ss = argv[arg_i++];
           mrb_to_str(mrb, ss);
           *ps = RSTRING_CSTR(mrb, ss);
           i++;
@@ -780,7 +782,7 @@ mrb_get_args(mrb_state *mrb, const char *format, ...)
         pl = va_arg(ap, mrb_int*);
         if (*format == '!') {
           format++;
-          if (i < argc && mrb_nil_p(ARGV[arg_i])) {
+          if (i < argc && mrb_nil_p(argv[arg_i])) {
             *pb = 0;
             *pl = 0;
             i++; arg_i++;
@@ -788,7 +790,7 @@ mrb_get_args(mrb_state *mrb, const char *format, ...)
           }
         }
         if (i < argc) {
-          aa = to_ary(mrb, ARGV[arg_i++]);
+          aa = to_ary(mrb, argv[arg_i++]);
           a = mrb_ary_ptr(aa);
           *pb = ARY_PTR(a);
           *pl = ARY_LEN(a);
@@ -803,7 +805,7 @@ mrb_get_args(mrb_state *mrb, const char *format, ...)
 
         p = va_arg(ap, void**);
         if (i < argc) {
-          ss = ARGV[arg_i];
+          ss = argv[arg_i];
           if (mrb_type(ss) != MRB_TT_ISTRUCT)
           {
             mrb_raisef(mrb, E_TYPE_ERROR, "%v is not inline struct", ss);
@@ -821,7 +823,7 @@ mrb_get_args(mrb_state *mrb, const char *format, ...)
 
         p = va_arg(ap, mrb_float*);
         if (i < argc) {
-          *p = mrb_to_flo(mrb, ARGV[arg_i]);
+          *p = mrb_to_flo(mrb, argv[arg_i]);
           arg_i++;
           i++;
         }
@@ -834,7 +836,7 @@ mrb_get_args(mrb_state *mrb, const char *format, ...)
 
         p = va_arg(ap, mrb_int*);
         if (i < argc) {
-          *p = mrb_fixnum(mrb_to_int(mrb, ARGV[arg_i]));
+          *p = mrb_fixnum(mrb_to_int(mrb, argv[arg_i]));
           arg_i++;
           i++;
         }
@@ -845,7 +847,7 @@ mrb_get_args(mrb_state *mrb, const char *format, ...)
         mrb_bool *boolp = va_arg(ap, mrb_bool*);
 
         if (i < argc) {
-          mrb_value b = ARGV[arg_i++];
+          mrb_value b = argv[arg_i++];
           *boolp = mrb_test(b);
           i++;
         }
@@ -859,7 +861,7 @@ mrb_get_args(mrb_state *mrb, const char *format, ...)
         if (i < argc) {
           mrb_value ss;
 
-          ss = ARGV[arg_i++];
+          ss = argv[arg_i++];
           *symp = to_sym(mrb, ss);
           i++;
         }
@@ -874,14 +876,14 @@ mrb_get_args(mrb_state *mrb, const char *format, ...)
         type = va_arg(ap, struct mrb_data_type const*);
         if (*format == '!') {
           format++;
-          if (i < argc && mrb_nil_p(ARGV[arg_i])) {
+          if (i < argc && mrb_nil_p(argv[arg_i])) {
             *datap = 0;
             i++; arg_i++;
             break;
           }
         }
         if (i < argc) {
-          *datap = mrb_data_get_ptr(mrb, ARGV[arg_i++], type);
+          *datap = mrb_data_get_ptr(mrb, argv[arg_i++], type);
           ++i;
         }
       }
@@ -936,10 +938,10 @@ mrb_get_args(mrb_state *mrb, const char *format, ...)
           *pl = argc-i;
           if (*pl > 0) {
             if (nocopy) {
-              *var = ARGV+arg_i;
+              *var = argv+arg_i;
             }
             else {
-              mrb_value args = mrb_ary_new_from_values(mrb, *pl, ARGV+arg_i);
+              mrb_value args = mrb_ary_new_from_values(mrb, *pl, argv+arg_i);
               RARRAY(args)->c = NULL;
               *var = RARRAY_PTR(args);
             }


### PR DESCRIPTION
 1. Cache argv first in each specifiers for `mrb_get_args()`; ref #3090
 
    In terms of specifiers, argv is never referenced after a method call as shown in #3090.

    Reduction of object code can be expected.

    If you need to refer to argv after a method call in the same loop, update argv after the method call.

 2. Integrated the `!` modifier part.
 
    As a side effect, all specifiers now accept the `!` modifier.

----

The object file size comparison uses cross-compileable GCC available in FreeBSD 12.0.
Only `src/class.c` is compiled with `-Os` switch.

The compared branches are:

0.[2f9b1fdb0](https://github.com/mruby/mruby/commit/2f9b1fdb0c6ec4835b66b26db52ef7b98b9554b8) : Currently master
1.[f312638ec](https://github.com/mruby/mruby/commit/f312638ecd0d9d884d0600c5ad44f4c00a6c313b) : Cache argv first in each specifiers for `mrb_get_args()`
2.[62499c625](https://github.com/mruby/mruby/commit/62499c62507033d37222e0492e2062a2ea781d56) : Shrink `mrb_get_args()`
3.[a7f339319](https://github.com/dearblue/mruby/commit/a7f33931936f4c270127b897adb311d449df8b6f) : Integrate processing of `A`, `H`, `S` and `C` specifiers (**Not included in this patch**)

```
File size  File name

    45968  2.62499c625/class.o@aarch64-unknown-freebsd12.0-gcc
    46216  1.f312638ec/class.o@aarch64-unknown-freebsd12.0-gcc
    46552  3.a7f339319/class.o@aarch64-unknown-freebsd12.0-gcc
    46656  0.2f9b1fdb0/class.o@aarch64-unknown-freebsd12.0-gcc
          
    34908  3.a7f339319/class.o@i386-unknown-freebsd12.0-gcc
    35056  2.62499c625/class.o@i386-unknown-freebsd12.0-gcc
    35184  1.f312638ec/class.o@i386-unknown-freebsd12.0-gcc
    35708  0.2f9b1fdb0/class.o@i386-unknown-freebsd12.0-gcc
          
    56620  1.f312638ec/class.o@mips-unknown-freebsd12.0-gcc
    56852  2.62499c625/class.o@mips-unknown-freebsd12.0-gcc
    57044  0.2f9b1fdb0/class.o@mips-unknown-freebsd12.0-gcc
    57416  3.a7f339319/class.o@mips-unknown-freebsd12.0-gcc
          
    62872  1.f312638ec/class.o@powerpc64-unknown-freebsd12.0-gcc
    62984  2.62499c625/class.o@powerpc64-unknown-freebsd12.0-gcc
    63328  0.2f9b1fdb0/class.o@powerpc64-unknown-freebsd12.0-gcc
    64392  3.a7f339319/class.o@powerpc64-unknown-freebsd12.0-gcc
          
    40184  2.62499c625/class.o@psp-gcc
    40388  1.f312638ec/class.o@psp-gcc
    40680  3.a7f339319/class.o@psp-gcc
    41052  0.2f9b1fdb0/class.o@psp-gcc
          
    85792  3.a7f339319/class.o@riscv64-unknown-freebsd12.0-gcc
    85856  1.f312638ec/class.o@riscv64-unknown-freebsd12.0-gcc
    86568  2.62499c625/class.o@riscv64-unknown-freebsd12.0-gcc
    87456  0.2f9b1fdb0/class.o@riscv64-unknown-freebsd12.0-gcc
          
    46640  2.62499c625/class.o@sparc64-unknown-freebsd12.0-gcc
    46816  1.f312638ec/class.o@sparc64-unknown-freebsd12.0-gcc
    47256  0.2f9b1fdb0/class.o@sparc64-unknown-freebsd12.0-gcc
    47344  3.a7f339319/class.o@sparc64-unknown-freebsd12.0-gcc
          
    46984  2.62499c625/class.o@x86_64-unknown-freebsd12.0-gcc
    47288  1.f312638ec/class.o@x86_64-unknown-freebsd12.0-gcc
    47720  0.2f9b1fdb0/class.o@x86_64-unknown-freebsd12.0-gcc
    47752  3.a7f339319/class.o@x86_64-unknown-freebsd12.0-gcc
          
    52776  3.a7f339319/class.o@xtensa-esp32-elf-gcc
    52996  2.62499c625/class.o@xtensa-esp32-elf-gcc
    53548  1.f312638ec/class.o@xtensa-esp32-elf-gcc
    54900  0.2f9b1fdb0/class.o@xtensa-esp32-elf-gcc
```
