### PR TITLE
Rename MRB_USE_ETEXT_EDATA to MRB_USE_LINK_TIME_RO_DATA_P and support lld linked programs

### DIFF
--- a/doc/guides/mrbconf.md
+++ b/doc/guides/mrbconf.md
@@ -134,21 +134,16 @@ largest value of required alignment.
 
 ## Reduce heap memory configuration.
 
-`MRB_USE_ETEXT_EDATA`
+`MRB_USE_LINK_TIME_RO_DATA_P`
+* Only available on ELF platforms.
 * If you specify the address of a read-only section when creating a symbol or string, that string will be used as it is.
 * Heap memory can be saved.
-* Uses `_etext` and `__init_array_start`.
-* It must be `_etext < data_addr < &__init_array_start`.
-
-`MRB_NO_INIT_ARRAY_START`
-* Ignored if `MRB_USE_ETEXT_EDATA` is not defined.
-* Please try if `__init_array_start` is not available.
-* Uses `_etext` and `_edata`.
-* It must be `_etext < data_addr < _edata`.
+* Uses `__ehdr_start` and `__init_array_start`.
+* It must be `__ehdr_start < data_addr < __init_array_start`.
 
 `MRB_USE_CUSTOM_RO_DATA_P`
-* Takes precedence over `MRB_USE_ETEXT_EDATA`.
-* Please try if both `MRB_USE_ETEXT_EDATA` and `MRB_NO_INIT_ARRAY_START` are not available.
+* Takes precedence over `MRB_USE_LINK_TIME_RO_DATA_P`.
+* Please try if `MRB_USE_LINK_TIME_RO_DATA_P` is not available.
 * The `mrb_ro_data_p()` function is implemented by the user in an arbitrary file.
 * The prototype declaration is `mrb_bool mrb_ro_data_p(const char *ptr)`.
 * Return `TRUE` if `ptr` is in read-only section, otherwise return `FALSE`.

--- a/include/mrbconf.h
+++ b/include/mrbconf.h
@@ -88,14 +88,10 @@
 /* number of object per heap page */
 //#define MRB_HEAP_PAGE_SIZE 1024
 
-/* if _etext and _edata available, mruby can reduce memory used by symbols */
-//#define MRB_USE_ETEXT_EDATA
+/* if __ehdr_start is available, mruby can reduce memory used by symbols */
+//#define MRB_USE_LINK_TIME_RO_DATA_P
 
-/* do not use __init_array_start to determine readonly data section;
-   effective only when MRB_USE_ETEXT_EDATA is defined */
-//#define MRB_NO_INIT_ARRAY_START
-
-/* if do not works both MRB_USE_ETEXT_EDATA and MRB_NO_INIT_ARRAY_START,
+/* if MRB_USE_LINK_TIME_RO_DATA_P does not work,
    you can try mrb_ro_data_p() that you have implemented yourself in any file;
    prototype is `mrb_bool mrb_ro_data_p(const char *ptr)` */
 //#define MRB_USE_CUSTOM_RO_DATA_P

--- a/include/mruby/value.h
+++ b/include/mruby/value.h
@@ -309,37 +309,25 @@ mrb_undef_value(void)
   return v;
 }
 
+#if defined(MRB_USE_ETEXT_EDATA) && !defined(MRB_USE_LINK_TIME_RO_DATA_P)
+# ifdef __GNUC__
+#  warning MRB_USE_ETEXT_EDATA is deprecated. Define MRB_USE_LINK_TIME_RO_DATA_P instead.
+# endif
+# define MRB_USE_LINK_TIME_RO_DATA_P
+#endif
+
 #if defined(MRB_USE_CUSTOM_RO_DATA_P)
 /* If you define `MRB_USE_CUSTOM_RO_DATA_P`, you must implement `mrb_ro_data_p()`. */
 mrb_bool mrb_ro_data_p(const char *p);
-#elif defined(MRB_USE_ETEXT_EDATA)
-#if (defined(__APPLE__) && defined(__MACH__))
-#include <mach-o/getsect.h>
-static inline mrb_bool
-mrb_ro_data_p(const char *p)
-{
-  return (const char*)get_etext() < p && p < (const char*)get_edata();
-}
-#else
-extern char _etext[];
-#ifdef MRB_NO_INIT_ARRAY_START
-extern char _edata[];
-
-static inline mrb_bool
-mrb_ro_data_p(const char *p)
-{
-  return _etext < p && p < _edata;
-}
-#else
+#elif defined(MRB_USE_LINK_TIME_RO_DATA_P)
+extern char __ehdr_start[];
 extern char __init_array_start[];
 
 static inline mrb_bool
 mrb_ro_data_p(const char *p)
 {
-  return _etext < p && p < (char*)&__init_array_start;
+  return __ehdr_start < p && p < __init_array_start;
 }
-#endif
-#endif
 #else
 # define mrb_ro_data_p(p) FALSE
 #endif

--- a/src/load.c
+++ b/src/load.c
@@ -554,7 +554,7 @@ read_irep(mrb_state *mrb, const uint8_t *bin, size_t bufsize, uint8_t flags)
 mrb_irep*
 mrb_read_irep(mrb_state *mrb, const uint8_t *bin)
 {
-#if defined(MRB_USE_ETEXT_EDATA) || defined(MRB_USE_CUSTOM_RO_DATA_P)
+#if defined(MRB_USE_LINK_TIME_RO_DATA_P) || defined(MRB_USE_CUSTOM_RO_DATA_P)
   uint8_t flags = mrb_ro_data_p((char*)bin) ? FLAG_SRC_STATIC : FLAG_SRC_MALLOC;
 #else
   uint8_t flags = FLAG_SRC_STATIC;


### PR DESCRIPTION
In lld linked programs, .rodata comes before .text, thus mrb_ro_data_p
will return false for strings in .rodata. Change the lower bound from
_etext to __ehdr_start to catch these cases. This works for ld.bfd, gold
and lld, and it does not have false positives even if .init_array does
not exist.

Remove the branch that uses _edata: strings in .data can be modified so
this is semantically incorrect. Delete the `__APPLE__` branch (its
manpages say get_etext() and get_edata() are strongly discouraged).
.init_array has been adopted by most ELF platforms to supersede .ctors.

Neither _etext nor _edata is used, so rename MRB_USE_ETEXT_EDATA to
MRB_USE_EHDR_START.

-------------------------------

This removes code added by #3639 @Asmod4n You can use `MRB_USE_CUSTOM_RO_DATA_P` instead. The `_edata` approach can be wrong if the user modifies `.data`, so I don't think it makes lots of sense to support it by default.

Most ELF platforms support .init_array. For example, glibc has supported .init_array since 1999.

To use lld (LLVM linker), you can add `-fuse-ld=lld` to `conf.linker.flags`.
This option is supported by clang newer than Nov 9, 2013, and GCC 9 and newer.
Some Debian derivatives back port a patch to GCC 7 and 8.

Here is the readelf -S dump of my mruby executable:

```
...
  [11] .rodata           PROGBITS        0000000000004da0 004da0 03fdf3 00  AM  0   0 32
  [12] .eh_frame_hdr     PROGBITS        0000000000044b94 044b94 0039d4 00   A  0   0  4
  [13] .eh_frame         PROGBITS        0000000000048568 048568 00ee4c 00   A  0   0  8
  [14] .text             PROGBITS        0000000000058000 058000 08cf00 00  AX  0   0 16
  [15] .init             PROGBITS        00000000000e4f00 0e4f00 000017 00  AX  0   0  4
  [16] .fini             PROGBITS        00000000000e4f18 0e4f18 000009 00  AX  0   0  4
  [17] .plt              PROGBITS        00000000000e4f30 0e4f30 000690 00  AX  0   0 16
  [18] .fini_array       FINI_ARRAY      00000000000e6000 0e6000 000008 08  WA  0   0  8
  [19] .init_array       INIT_ARRAY      00000000000e6008 0e6008 000008 08  WA  0   0  8
```