### PR TITLE
Fix `Fixnum#(to_s|inspect)` argument specs

### DIFF
--- a/src/numeric.c
+++ b/src/numeric.c
@@ -1663,8 +1663,8 @@ mrb_init_numeric(mrb_state *mrb)
 #ifndef MRB_WITHOUT_FLOAT
   mrb_define_method(mrb, fixnum,  "to_f",     fix_to_f,        MRB_ARGS_NONE()); /* 15.2.8.3.23 */
 #endif
-  mrb_define_method(mrb, fixnum,  "to_s",     fix_to_s,        MRB_ARGS_NONE()); /* 15.2.8.3.25 */
-  mrb_define_method(mrb, fixnum,  "inspect",  fix_to_s,        MRB_ARGS_NONE());
+  mrb_define_method(mrb, fixnum,  "to_s",     fix_to_s,        MRB_ARGS_OPT(1)); /* 15.2.8.3.25 */
+  mrb_define_method(mrb, fixnum,  "inspect",  fix_to_s,        MRB_ARGS_OPT(1));
   mrb_define_method(mrb, fixnum,  "divmod",   fix_divmod,      MRB_ARGS_REQ(1)); /* 15.2.8.3.30 (x) */
 
 #ifndef MRB_WITHOUT_FLOAT

--- a/test/t/integer.rb
+++ b/test/t/integer.rb
@@ -232,8 +232,16 @@ assert('Integer#to_i', '15.2.8.3.24') do
 end
 
 assert('Integer#to_s', '15.2.8.3.25') do
-  assert_equal '1', 1.to_s
-  assert_equal("-1", -1.to_s)
+  assert_equal "1", 1.to_s
+  assert_equal "-1", -1.to_s
+  assert_equal "1010", 10.to_s(2)
+  assert_equal "a", 10.to_s(36)
+  assert_equal "-a", -10.to_s(36)
+  assert_equal "30071", 12345.to_s(8)
+  assert_raise(ArgumentError) { 10.to_s(-1) }
+  assert_raise(ArgumentError) { 10.to_s(0) }
+  assert_raise(ArgumentError) { 10.to_s(1) }
+  assert_raise(ArgumentError) { 10.to_s(37) }
 end
 
 assert('Integer#truncate', '15.2.8.3.26') do


### PR DESCRIPTION
#### Before this patch:

  ```terminal
  $ bin/mruby -e 'p 3.to_s(2)'
  trace (most recent call last):
    [0] -e:1
  -e:1: 'to_s': wrong number of arguments (1 for 0) (ArgumentError) 
  ```

#### After this patch:

  ```terminal
  $ bin/mruby -e 'p 3.to_s(2)'
  "11"
  ```