### PR TITLE
Fix `Fixnum` overflow test in `Integer#<<` test

### DIFF
--- a/test/t/integer.rb
+++ b/test/t/integer.rb
@@ -154,11 +154,11 @@ assert('Integer#<<', '15.2.8.3.12') do
   # Left Shift by a negative is Right Shift
   assert_equal 23, 46 << -1
 
-  # Left Shift by 31 is bitShift overflow to SignedInt
-  assert_equal 2147483648, 1 << 31
+  skip unless Object.const_defined?(:Float)
 
-  # -3 Left Shift by 30 is bitShift overflow to SignedInt
-  assert_equal(-3221225472, -3 << 30)
+  # Overflow to Fixnum
+  assert_float 9223372036854775808.0, 1 << 63
+  assert_float(-13835058055282163712.0, -3 << 62)
 end
 
 assert('Integer#>>', '15.2.8.3.13') do


### PR DESCRIPTION
- Skip when `MRB_WITHOUT_FLOAT` is defined.
- Make `Fixnum` overflow even when `MRB_INT64` is defined.