### PR TITLE
Remove `MRB_TT_HAS_BASIC` macro

### DIFF
--- a/include/mruby/value.h
+++ b/include/mruby/value.h
@@ -166,10 +166,8 @@ typedef void mrb_value;
 #include "boxing_no.h"
 #endif
 
-#define MRB_TT_HAS_BASIC MRB_TT_FREE
-
 #ifndef mrb_immediate_p
-#define mrb_immediate_p(o) (mrb_type(o) < MRB_TT_HAS_BASIC)
+#define mrb_immediate_p(o) (mrb_type(o) < MRB_TT_FREE)
 #endif
 #ifndef mrb_fixnum_p
 #define mrb_fixnum_p(o) (mrb_type(o) == MRB_TT_FIXNUM)


### PR DESCRIPTION
The value of `MRB_TT_HAS_BASIC` is meaningless because `MRB_TT_HAS_BASIC` is
no longer used with `MRB_WORD_BOXING` at b2c3d88f.