### PR TITLE
Allow rethrowing `MRB_TT_BREAK`

### DIFF
--- a/src/error.c
+++ b/src/error.c
@@ -241,10 +241,15 @@ mrb_exc_set(mrb_state *mrb, mrb_value exc)
 MRB_API mrb_noreturn void
 mrb_exc_raise(mrb_state *mrb, mrb_value exc)
 {
-  if (!mrb_obj_is_kind_of(mrb, exc, mrb->eException_class)) {
-    mrb_raise(mrb, E_TYPE_ERROR, "exception object expected");
+  if (mrb_break_p(exc)) {
+    mrb->exc = mrb_obj_ptr(exc);
   }
-  mrb_exc_set(mrb, exc);
+  else {
+    if (!mrb_obj_is_kind_of(mrb, exc, mrb->eException_class)) {
+      mrb_raise(mrb, E_TYPE_ERROR, "exception object expected");
+    }
+    mrb_exc_set(mrb, exc);
+  }
   if (!mrb->jmp) {
     mrb_p(mrb, exc);
     abort();


### PR DESCRIPTION
If a `break` global jump occurs from mruby space via `mrb_protect()`, `mrb_exc_raise()` will raise a `TypeError` exception if you use `mrb_exc_raise()` to resend.
As a countermeasure, this patch makes `mrb_exc_raise ()` also accept `MRB_TT_BREAK` objects.

Example (C code is in last because it is a few large):

  - Before patched:

    ```console
    % gcc -Wall -g3 -Og -Iinclude rbreak.c build/host/lib/libmruby.a -lm
    % ./a.out
    rbreak.c:19:trial_yield
    rbreak.c:33:test_enter: type=MRB_TT_BREAK
    TypeError: exception object expected
    ```

  - After patched:

    ```console
    % gcc -Wall -g3 -Og -Iinclude rbreak.c build/host/lib/libmruby.a -lm
    % ./a.out
    rbreak.c:19:trial_yield
    rbreak.c:33:test_enter: type=MRB_TT_BREAK
    :broken
    ```

  - Sample C code (`rbreak.c`):

    ```c
    #include <mruby.h>
    #include <mruby/error.h>
    #include <mruby/compile.h>
    #include <stdio.h>

    static const char *
    vtype_name(enum mrb_vtype vt)
    {
      switch (vt) {
      case MRB_TT_EXCEPTION:  return "MRB_TT_EXCEPTION";
      case MRB_TT_BREAK:      return "MRB_TT_BREAK";
      default:                return NULL;
      }
    }

    static mrb_value
    trial_yield(mrb_state *mrb, mrb_value block)
    {
      fprintf(stderr, "%s:%d:%s\n", __FILE__, __LINE__, __func__);
      mrb_value ret = mrb_yield(mrb, block, mrb_nil_value());
      fprintf(stderr, "%s:%d:%s\n", __FILE__, __LINE__, __func__);
      return ret;
    }

    static mrb_value
    test_enter(mrb_state *mrb, mrb_value self)
    {
      mrb_value block;
      mrb_get_args(mrb, "&!", &block);

      mrb_bool has_err;
      mrb_value ret = mrb_protect(mrb, trial_yield, block, &has_err);
      fprintf(stderr, "%s:%d:%s: type=%s\n", __FILE__, __LINE__, __func__, vtype_name(mrb_type(ret)));

      if (has_err) {
        mrb_exc_raise(mrb, ret);
      }
      return ret;
    }

    int
    main(int argc, char *argv[])
    {
      mrb_state *mrb = mrb_open();
      mrb_define_method(mrb, mrb->object_class, "test_enter", test_enter, MRB_ARGS_ANY());

      mrb_load_string(mrb,
                      "begin\n"
                      "  p test_enter { break :broken }\n"
                      "rescue => e\n"
                      "  p e\n"
                      "end");
      mrb_close(mrb);

      return 0;
    }
    ```
