### PR TITLE
Remove unnecessary type `mrb_hash_value`

### DIFF
--- a/include/mruby/hash.h
+++ b/include/mruby/hash.h
@@ -197,13 +197,6 @@ MRB_API mrb_value mrb_hash_dup(mrb_state *mrb, mrb_value hash);
  */
 MRB_API void mrb_hash_merge(mrb_state *mrb, mrb_value hash1, mrb_value hash2);
 
-/* declaration of struct mrb_hash_value */
-/* be careful when you touch the internal */
-typedef struct {
-  mrb_value v;
-  mrb_int n;
-} mrb_hash_value;
-
 /* RHASH_TBL allocates st_table if not available. */
 #define RHASH(obj)   ((struct RHash*)(mrb_ptr(obj)))
 #define RHASH_TBL(h)          (RHASH(h)->ht)


### PR DESCRIPTION
The type `mrb_hash_value` is no longer used by the segmented list implementation (ref e8dcfe1 and e65d426).