### PR TITLE
Dump more node types in `mrb_parser_dump`

### DIFF
--- a/mrbgems/mruby-compiler/core/parse.y
+++ b/mrbgems/mruby-compiler/core/parse.y
@@ -6950,6 +6950,10 @@ mrb_parser_dump(mrb_state *mrb, node *tree, int offset)
     dump_recur(mrb, tree, offset+1);
     break;
 
+  case NODE_LITERAL_DELIM:
+    printf("NODE_LITERAL_DELIM\n");
+    break;
+
   case NODE_SELF:
     printf("NODE_SELF\n");
     break;

--- a/mrbgems/mruby-compiler/core/parse.y
+++ b/mrbgems/mruby-compiler/core/parse.y
@@ -6935,6 +6935,11 @@ mrb_parser_dump(mrb_state *mrb, node *tree, int offset)
            intn(tree));
     break;
 
+  case NODE_DSYM:
+    printf("NODE_DSYM:\n");
+    mrb_parser_dump(mrb, tree, offset+1);
+    break;
+
   case NODE_SELF:
     printf("NODE_SELF\n");
     break;

--- a/mrbgems/mruby-compiler/core/parse.y
+++ b/mrbgems/mruby-compiler/core/parse.y
@@ -6945,6 +6945,11 @@ mrb_parser_dump(mrb_state *mrb, node *tree, int offset)
     dump_recur(mrb, tree, offset+1);
     break;
 
+  case NODE_SYMBOLS:
+    printf("NODE_SYMBOLS:\n");
+    dump_recur(mrb, tree, offset+1);
+    break;
+
   case NODE_SELF:
     printf("NODE_SELF\n");
     break;

--- a/mrbgems/mruby-compiler/core/parse.y
+++ b/mrbgems/mruby-compiler/core/parse.y
@@ -6940,6 +6940,11 @@ mrb_parser_dump(mrb_state *mrb, node *tree, int offset)
     mrb_parser_dump(mrb, tree, offset+1);
     break;
 
+  case NODE_WORDS:
+    printf("NODE_WORDS:\n");
+    dump_recur(mrb, tree, offset+1);
+    break;
+
   case NODE_SELF:
     printf("NODE_SELF\n");
     break;


### PR DESCRIPTION
Add support for the following node types:

- NODE_DSYM
- NODE_WORDS
- NODE_SYMBOLS
- NODE_LITERAL_DELIM