### PR TITLE
Remove duplicates header files in `src/pool.c`

### DIFF
--- a/src/pool.c
+++ b/src/pool.c
@@ -4,8 +4,6 @@
 ** See Copyright Notice in mruby.h
 */
 
-#include <stddef.h>
-#include <stdint.h>
 #include <string.h>
 #include <mruby.h>
 


### PR DESCRIPTION
These are included in `mruby.h`.

As a background, if `enable_cxx_abi` is specified, the macro that defines the maximum value in `stdint.h` is undefined depending on the environment.

- Confirmed with gcc on FreeBSD 12.0 and mingw32-gcc available on FreeBSD.
- `INTPTR_MAX`, `INT64_MAX` and `UINT64_MAX` are defined by `cstdint` added in C++11. But `toolchains :gcc` adds `-std=c++03`, so the macros are not defined.
- To have these defined in `C++03`, `__STDC_CONSTANT_MACROS` must be defined in advance. This is already done by `mruby.h`.