### PR TITLE
Drop initialization dependency from `mruby-print` to `mruby-sprintf`

### DIFF
--- a/mrbgems/mruby-print/mrblib/print.rb
+++ b/mrbgems/mruby-print/mrblib/print.rb
@@ -48,14 +48,8 @@ module Kernel
     args.__svalue
   end
 
-  unless Kernel.respond_to?(:sprintf)
-    def printf(*args)
-      raise NotImplementedError.new('printf not available')
-    end
-  else
-    def printf(*args)
-      __printstr__(sprintf(*args))
-      nil
-    end
+  def printf(*args)
+    __printstr__(sprintf(*args))
+    nil
   end
 end


### PR DESCRIPTION
In the old implementation, `Kernel#printf` raise error if `mruby-sprintf`
gem isn't specified before `mruby-print` gem. The new implementation
eliminates this ordering issue. This way is the same as `Kernel#printf` and
`IO#printf` in `mruby-io` gem.