### PR TITLE
Replace in safe `mrb_get_argv()`

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -899,7 +899,16 @@ mrb_get_mid(mrb_state *mrb) /* get method symbol */
  */
 MRB_API mrb_int mrb_get_argc(mrb_state *mrb);
 
-MRB_API mrb_value* mrb_get_argv(mrb_state *mrb);
+/**
+ * Retrieve the arguments from mrb_state.
+ *
+ * Correctly handles *splat arguments.
+ *
+ * If you need `mrb_gc_arena_save()`, do it after `mrb_get_argv()`.
+ *
+ * @return the arguments. If there is no arguments, it will be `NULL`.
+ */
+MRB_API mrb_value *mrb_get_argv(mrb_state *mrb);
 
 /* `strlen` for character string literals (use with caution or `strlen` instead)
     Adjacent string literals are concatenated in C/C++ in translation phase 6.


### PR DESCRIPTION
The `mrb_get_argv()` function now returns a copy of the argument on the stack or a splat argument.

With this change, `bin/mruby` built with `CFLAGS=-Os` will increase by 200 bytes.

```console
% ls -l mruby@*
-rwxr-xr-x  1 dearblue  dearblue  615448 10月  6 14:06 mruby@master
-rwxr-xr-x  1 dearblue  dearblue  615648 10月  6 14:05 mruby@patched
```

----

Since the `mrb_get_argv ()` function is `MRB_API`, it is expected that the arguments can be obtained correctly.
Or I think better to should delete `MRB_API` as an internal function.
