### PR TITLE
Fix that `print` command raises `FrozenError` in `mrdb`; ref 1f5a7f2f

### DIFF
--- a/mrbgems/mruby-bin-debugger/tools/mrdb/apiprint.c
+++ b/mrbgems/mruby-bin-debugger/tools/mrdb/apiprint.c
@@ -74,7 +74,7 @@ mrb_debug_eval(mrb_state *mrb, mrb_debug_context *dbg, const char *expr, size_t 
     *exc = mrb_obj_is_kind_of(mrb, v, mrb->eException_class);
   }
 
-  s = mrb_funcall(mrb, v, "inspect", 0);
+  s = mrb_inspect(mrb, v);
 
   /* enable code_fetch_hook */
   mrb->code_fetch_hook = tmp;

--- a/mrbgems/mruby-bin-debugger/tools/mrdb/cmdprint.c
+++ b/mrbgems/mruby-bin-debugger/tools/mrdb/cmdprint.c
@@ -18,7 +18,6 @@ dbgcmd_print(mrb_state *mrb, mrdb_state *mrdb)
 {
   mrb_value expr;
   mrb_value result;
-  mrb_value s;
   uint8_t wcnt;
   int ai;
 
@@ -39,8 +38,9 @@ dbgcmd_print(mrb_state *mrb, mrdb_state *mrdb)
   result = mrb_debug_eval(mrb, mrdb->dbg, RSTRING_PTR(expr), RSTRING_LEN(expr), NULL, 0);
 
   /* $print_no = result */
-  s = mrb_str_cat_lit(mrb, result, "\0");
-  printf("$%lu = %s\n", (unsigned long)mrdb->print_no++, RSTRING_PTR(s));
+  printf("$%lu = ", (unsigned long)mrdb->print_no++);
+  fwrite(RSTRING_PTR(result), RSTRING_LEN(result), 1, stdout);
+  putc('\n', stdout);
 
   if (mrdb->print_no == 0) {
     mrdb->print_no = 1;


### PR DESCRIPTION
#### Before this patch:

  ```
  $ echo 'p true' | bin/mrdb /dev/null
  (/dev/null:1) mruby application exited.
  FrozenError: can't modify frozen String
  (-:0)
  ```

#### After this patch:

  ```
  $ echo 'p true' | bin/mrdb /dev/null
  (/dev/null:1) $1 = true
  (/dev/null:1)
  ```