### PR TITLE
Remove constant export declaration for MRBC output compiled as C

### DIFF
--- a/src/dump.c
+++ b/src/dump.c
@@ -943,7 +943,9 @@ mrb_dump_irep_cfunc(mrb_state *mrb, mrb_irep *irep, uint8_t flags, FILE *fp, con
       return MRB_DUMP_WRITE_FAULT;
     }
     if (fprintf(fp,
+          "#ifdef __cplusplus\n"
           "extern const uint8_t %s[];\n"
+          "#endif\n"
           "const uint8_t\n"
           "#if defined __GNUC__\n"
           "__attribute__((aligned(%u)))\n"


### PR DESCRIPTION
In commit 401ad4586ffe8bc26740f49f9049132ad2c50539, add `extern` like this:

https://github.com/mruby/mruby/commit/401ad4586ffe8bc26740f49f9049132ad2c50539#diff-669d4cc5c9c8f4573c5f8d57f5dcab20

When including byte code in C function,

```
mrbc -g -Bwatchcode -owatch_ruby.h watch.rb
```

the `extern` cause compile error.

```
watch_ruby.h:11:1: error: declaration of 'watchcode' with no linkage follows extern declaration
 watchcode[] = {
 ^~~~~~~~~
watch_ruby.h:4:22: note: previous declaration of 'watchcode' was here
 extern const uint8_t watchcode[];
```

This patch fixes the problem.