### PR TITLE
Remove `Kernel#getc`

### DIFF
--- a/mrbgems/mruby-io/mrblib/kernel.rb
+++ b/mrbgems/mruby-io/mrblib/kernel.rb
@@ -28,8 +28,4 @@ module Kernel
   def gets(*args)
     $stdin.gets(*args)
   end
-
-  def getc(*args)
-    $stdin.getc(*args)
-  end
 end


### PR DESCRIPTION
`Kernel#getc` has been removed since Ruby 1.9 and is not defined in ISO.