### PR TITLE
Optimize `str_subseq` with `MRB_UTF8_STRING` to ASCII only string

### DIFF
--- a/src/string.c
+++ b/src/string.c
@@ -603,7 +603,7 @@ str_range_to_bytes(mrb_value str, mrb_int *pos, mrb_int *len)
 static inline mrb_value
 str_subseq(mrb_state *mrb, mrb_value str, mrb_int beg, mrb_int len)
 {
-  str_range_to_bytes(str, &beg, &len);
+  if (!RSTR_ASCII_P(mrb_str_ptr(str))) str_range_to_bytes(str, &beg, &len);
   return mrb_str_byte_subseq(mrb, str, beg, len);
 }
 #else


### PR DESCRIPTION
### Benchmark (with `MRB_UTF8_STRING`)

  ```ruby
  # benchmark.rb
  COUNT = 300000
  SIZE = 10000
  s = "a" * SIZE
  s.size  # set `MRB_STR_ASCII` flag
  i = 0
  while i < COUNT
    s[-1]
    i += 1
  end
  ```

#### Before this patch:

  ```
  $ time mruby benchmark.rb
          2.06 real         2.05 user         0.00 sys
  ```

#### After this patch:

  ```
  $ time mruby benchmark.rb
          0.05 real         0.04 user         0.00 sys
  ```