### PR TITLE
fix outputs of Kernel.#puts and IO#puts when args include Array class or subclass

### DIFF
--- a/mrbgems/mruby-io/mrblib/io.rb
+++ b/mrbgems/mruby-io/mrblib/io.rb
@@ -338,9 +338,15 @@ class IO
     i = 0
     len = args.size
     while i < len
-      s = args[i].to_s
-      write s
-      write "\n" if (s[-1] != "\n")
+      if args[i].kind_of?(Array)
+        args[i].each do |arg|
+          self.puts(arg)
+        end
+      else
+        s = args[i].to_s
+        write s
+        write "\n" if (s[-1] != "\n")
+      end
       i += 1
     end
     write "\n" if len == 0

--- a/mrbgems/mruby-print/mrblib/print.rb
+++ b/mrbgems/mruby-print/mrblib/print.rb
@@ -24,9 +24,15 @@ module Kernel
     i = 0
     len = args.size
     while i < len
-      s = args[i].to_s
-      __printstr__ s
-      __printstr__ "\n" if (s[-1] != "\n")
+      if args[i].kind_of?(Array)
+        args[i].each do |arg|
+          self.puts(arg)
+        end
+      else
+        s = args[i].to_s
+        __printstr__ s
+        __printstr__ "\n" if (s[-1] != "\n")
+      end
       i += 1
     end
     __printstr__ "\n" if len == 0


### PR DESCRIPTION
According to ISO/IEC 30170 15.2.20.5.13, if args of Kernel.#puts and IO#puts include Array instance each element should output indivisually.
But mruby seems to output a result of to_s method similarly other Object.

example: 

* Ruby 2.6.5 on Ubuntu 18.04.3 LTS

```
$ ruby -e 'puts "foo", "bar", "baz"'
foo
bar
baz
```
 
```
$ ruby -e 'puts ["foo", "bar", "baz"]'
foo
bar
baz
```

```
$ ruby -e 'puts "foo", ["bar", "baz"]'
foo
bar
baz
```

* mruby (master branch: 8710a22c31a5094627e33156d72dbd610893c3f4) on Ubuntu 18.04.3 LTS

```
$ bin/mruby -e 'puts "foo", "bar", "baz"'
foo
bar
baz
```

```
$ bin/mruby -e 'puts ["foo", "bar", "baz"]'
["foo", "bar", "baz"]
```

```
$ bin/mruby -e 'puts "foo", ["bar", "baz"]'
foo
["bar", "baz"]
```

* mruby (this PR was patched) on Ubuntu 18.04.3 LTS

```
$ bin/mruby -e 'puts "foo", "bar", "baz"'
foo
bar
baz
```

```
$ bin/mruby -e 'puts ["foo", "bar", "baz"]'
foo
bar
baz
```

```
$ bin/mruby -e 'puts "foo", ["bar", "baz"]'
foo
bar
baz
```