### PR TITLE
Set `MRB_STR_ASCII` flag to some stringize methods

### DIFF
--- a/mrbgems/mruby-time/src/time.c
+++ b/mrbgems/mruby-time/src/time.c
@@ -12,6 +12,7 @@
 #include <mruby/class.h>
 #include <mruby/data.h>
 #include <mruby/time.h>
+#include <mruby/string.h>
 
 #ifndef MRB_DISABLE_STDIO
 #include <stdio.h>
@@ -952,7 +953,9 @@ mrb_time_to_s(mrb_state *mrb, mrb_value self)
   struct mrb_time *tm = time_get_ptr(mrb, self);
   mrb_bool utc = tm->timezone == MRB_TIMEZONE_UTC;
   size_t len = (utc ? time_to_s_utc : time_to_s_local)(mrb, tm, buf, sizeof(buf));
-  return mrb_str_new(mrb, buf, len);
+  mrb_value str = mrb_str_new(mrb, buf, len);
+  RSTR_SET_ASCII_FLAG(mrb_str_ptr(str));
+  return str;
 }
 
 void

--- a/src/object.c
+++ b/src/object.c
@@ -83,13 +83,17 @@ mrb_true(mrb_state *mrb, mrb_value obj)
 static mrb_value
 nil_to_s(mrb_state *mrb, mrb_value obj)
 {
-  return mrb_str_new_frozen(mrb, 0, 0);
+  mrb_value str = mrb_str_new_frozen(mrb, 0, 0);
+  RSTR_SET_ASCII_FLAG(mrb_str_ptr(str));
+  return str;
 }
 
 static mrb_value
 nil_inspect(mrb_state *mrb, mrb_value obj)
 {
-  return mrb_str_new_lit_frozen(mrb, "nil");
+  mrb_value str = mrb_str_new_lit_frozen(mrb, "nil");
+  RSTR_SET_ASCII_FLAG(mrb_str_ptr(str));
+  return str;
 }
 
 /***********************************************************************
@@ -150,7 +154,9 @@ true_xor(mrb_state *mrb, mrb_value obj)
 static mrb_value
 true_to_s(mrb_state *mrb, mrb_value obj)
 {
-  return mrb_str_new_lit_frozen(mrb, "true");
+  mrb_value str = mrb_str_new_lit_frozen(mrb, "true");
+  RSTR_SET_ASCII_FLAG(mrb_str_ptr(str));
+  return str;
 }
 
 /* 15.2.5.3.4  */
@@ -257,7 +263,9 @@ false_or(mrb_state *mrb, mrb_value obj)
 static mrb_value
 false_to_s(mrb_state *mrb, mrb_value obj)
 {
-  return mrb_str_new_lit_frozen(mrb, "false");
+  mrb_value str = mrb_str_new_lit_frozen(mrb, "false");
+  RSTR_SET_ASCII_FLAG(mrb_str_ptr(str));
+  return str;
 }
 
 void


### PR DESCRIPTION
- `Fixnum#to_s`, `Fixnum#inspect`
- `Float#to_s`, `Float#inspect`
- `NilClass#to_s`, `NilClass#inspect`
- `FalseClass#to_s`, `FalseClass#inspect`
- `TrueClass#to_s`, `TrueClass#inspect`
- `Time#to_s`, `Time#inspect`