### PR TITLE
Remove test that depend on `mruby-enumerator` from `mruby-array-ext`

### DIFF
--- a/mrbgems/mruby-array-ext/test/array.rb
+++ b/mrbgems/mruby-array-ext/test/array.rb
@@ -195,12 +195,6 @@ assert("Array#reverse_each") do
     b << i
   end
   assert_equal [ "d", "c", "b", "a" ], b
-
-  if Object.const_defined?(:Enumerator)
-    assert_equal [ "d", "c", "b", "a" ], a.reverse_each.to_a
-  else
-    true
-  end
 end
 
 assert("Array#rotate") do


### PR DESCRIPTION
`Object.const_defined?(:Enumerator)` is always false because
`mruby-enumerator` is not specified in `test_dependency`. I don't
think this test is necessary.