### PR TITLE
Fix here document with EOF

### DIFF
--- a/mrbgems/mruby-compiler/core/parse.y
+++ b/mrbgems/mruby-compiler/core/parse.y
@@ -4381,12 +4381,7 @@ parse_string(parser_state *p)
           }
         }
         if ((len-1 == hinf->term_len) && (strncmp(s, hinf->term, len-1) == 0)) {
-          if (c < 0) {
-            p->parsing_heredoc = NULL;
-          }
-          else {
-            return tHEREDOC_END;
-          }
+          return tHEREDOC_END;
         }
       }
       if (c < 0) {


### PR DESCRIPTION
#### Before this patch:

  ```
  $ bin/mruby -e 'p <<EOS
1
EOS'
  -e:4:0: can't find heredoc delimiter "EOS" anywhere before EOF
  -e:4:0: syntax error, unexpected $end, expecting tHEREDOC_END or tHD_STRING_PART or tHD_STRING_MID
  ```

#### After this patch (same as Ruby):

  ```
  $ bin/mruby -e 'p <<EOS
1
EOS'
  "1\n"
  ```