### PR TITLE
Revert "Implement Ruby2.7's frozen strings from `Symbol#to_s`"

### DIFF
--- a/mrbgems/mruby-class-ext/src/class.c
+++ b/mrbgems/mruby-class-ext/src/class.c
@@ -5,7 +5,11 @@
 static mrb_value
 mrb_mod_name(mrb_state *mrb, mrb_value self)
 {
-  return mrb_class_path(mrb, mrb_class_ptr(self));
+  mrb_value name =  mrb_class_path(mrb, mrb_class_ptr(self));
+  if (mrb_string_p(name)) {
+    MRB_SET_FROZEN_FLAG(mrb_basic_ptr(name));
+  }
+  return name;
 }
 
 static mrb_value

--- a/mrbgems/mruby-symbol-ext/mrblib/symbol.rb
+++ b/mrbgems/mruby-symbol-ext/mrblib/symbol.rb
@@ -10,7 +10,7 @@ class Symbol
   # Same as <code>sym.to_s.capitalize.intern</code>.
 
   def capitalize
-    self.to_s.capitalize.to_sym
+    (self.to_s.capitalize! || self).to_sym
   end
 
   ##
@@ -20,7 +20,7 @@ class Symbol
   # Same as <code>sym.to_s.downcase.intern</code>.
 
   def downcase
-    self.to_s.downcase.to_sym
+    (self.to_s.downcase! || self).to_sym
   end
 
   ##
@@ -30,7 +30,7 @@ class Symbol
   # Same as <code>sym.to_s.upcase.intern</code>.
 
   def upcase
-    self.to_s.upcase.to_sym
+    (self.to_s.upcase! || self).to_sym
   end
 
   ##
@@ -41,7 +41,7 @@ class Symbol
 
   def casecmp(other)
     return nil unless other.kind_of?(Symbol)
-    lhs =  self.to_s.upcase
+    lhs =  self.to_s; lhs.upcase!
     rhs = other.to_s.upcase
     lhs <=> rhs
   end

--- a/src/class.c
+++ b/src/class.c
@@ -65,23 +65,21 @@ mrb_class_name_class(mrb_state *mrb, struct RClass *outer, struct RClass *c, mrb
     name = mrb_symbol_value(id);
   }
   else {
-    const char *n;
-    mrb_int len;
-    mrb_value outer_name = mrb_class_path(mrb, outer);
-
-    if (mrb_nil_p(outer_name)) {      /* unnamed outer class */
+    name = mrb_class_path(mrb, outer);
+    if (mrb_nil_p(name)) {      /* unnamed outer class */
       if (outer != mrb->object_class && outer != c) {
         mrb_obj_iv_set_force(mrb, (struct RObject*)c, mrb_intern_lit(mrb, "__outer__"),
                              mrb_obj_value(outer));
       }
       return;
     }
-    n = mrb_sym_name_len(mrb, id, &len);
-    name = mrb_str_new_capa(mrb, RSTRING_LEN(outer_name) + 2 + len);
-    mrb_str_cat_str(mrb, name, outer_name);
-    mrb_str_cat_lit(mrb, name, "::");
-    mrb_str_cat(mrb, name, n, len);
-    MRB_SET_FROZEN_FLAG(mrb_obj_ptr(name));
+    else {
+      mrb_int len;
+      const char *n = mrb_sym_name_len(mrb, id, &len);
+
+      mrb_str_cat_lit(mrb, name, "::");
+      mrb_str_cat(mrb, name, n, len);
+    }
   }
   mrb_obj_iv_set_force(mrb, (struct RObject*)c, nsym, name);
 }
@@ -1718,7 +1716,7 @@ mrb_class_path(mrb_state *mrb, struct RClass *c)
     /* toplevel class/module */
     return mrb_sym_str(mrb, mrb_symbol(path));
   }
-  return path;
+  return mrb_str_dup(mrb, path);
 }
 
 MRB_API struct RClass*
@@ -1885,8 +1883,7 @@ mrb_mod_to_s(mrb_state *mrb, mrb_value klass)
     return mrb_str_cat_lit(mrb, str, ">");
   }
   else {
-    mrb_value str = class_name_str(mrb, mrb_class_ptr(klass));
-    return mrb_frozen_p(mrb_basic_ptr(str)) ? mrb_str_dup(mrb, str) : str;
+    return class_name_str(mrb, mrb_class_ptr(klass));
   }
 }
 

--- a/src/symbol.c
+++ b/src/symbol.c
@@ -517,18 +517,14 @@ mrb_sym_str(mrb_state *mrb, mrb_sym sym)
 {
   mrb_int len;
   const char *name = mrb_sym_name_len(mrb, sym, &len);
-  mrb_value str;
 
   if (!name) return mrb_undef_value(); /* can't happen */
   if (SYMBOL_INLINE_P(sym)) {
-    str = mrb_str_new(mrb, name, len);
+    mrb_value str = mrb_str_new(mrb, name, len);
     RSTR_SET_ASCII_FLAG(mrb_str_ptr(str));
+    return str;
   }
-  else {
-    str = mrb_str_new_static(mrb, name, len);
-  }
-  MRB_SET_FROZEN_FLAG(mrb_str_ptr(str));
-  return str;
+  return mrb_str_new_static(mrb, name, len);
 }
 
 static const char*

--- a/src/variable.c
+++ b/src/variable.c
@@ -1123,7 +1123,7 @@ mrb_class_find_path(mrb_state *mrb, struct RClass *c)
     iv_del(mrb, c->iv, mrb_intern_lit(mrb, "__outer__"), NULL);
     iv_put(mrb, c->iv, mrb_intern_lit(mrb, "__classname__"), path);
     mrb_field_write_barrier_value(mrb, (struct RBasic*)c, path);
-    MRB_SET_FROZEN_FLAG(mrb_obj_ptr(path));
+    path = mrb_str_dup(mrb, path);
   }
   return path;
 }


### PR DESCRIPTION
This feature was reverted from Ruby 2.7.