### PR TITLE
Always enable the rational and complex literals

### DIFF
--- a/include/mrbconf.h
+++ b/include/mrbconf.h
@@ -62,9 +62,6 @@
 # endif
 #endif
 
-#define MRB_COMPLEX_NUMBERS
-#define MRB_RATIONAL_NUMBERS
-
 /* define on big endian machines; used by MRB_NAN_BOXING, etc. */
 #ifndef MRB_ENDIAN_BIG
 # if (defined(BYTE_ORDER) && defined(BIG_ENDIAN) && BYTE_ORDER == BIG_ENDIAN) || \


### PR DESCRIPTION
I think they can always be enabled because the regular expression literal is
always enabled.