### PR TITLE
Introduce `mrb_ssize` type for buffer size on memory; ref #4483

### DIFF
--- a/include/mruby/array.h
+++ b/include/mruby/array.h
@@ -17,7 +17,7 @@ MRB_BEGIN_DECL
 
 typedef struct mrb_shared_array {
   int refcnt;
-  mrb_int len;
+  mrb_ssize len;
   mrb_value *ptr;
 } mrb_shared_array;
 
@@ -26,9 +26,9 @@ struct RArray {
   MRB_OBJECT_HEADER;
   union {
     struct {
-      mrb_int len;
+      mrb_ssize len;
       union {
-        mrb_int capa;
+        mrb_ssize capa;
         mrb_shared_array *shared;
       } aux;
       mrb_value *ptr;

--- a/include/mruby/string.h
+++ b/include/mruby/string.h
@@ -23,9 +23,9 @@ struct RString {
   MRB_OBJECT_HEADER;
   union {
     struct {
-      mrb_int len;
+      mrb_ssize len;
       union {
-        mrb_int capa;
+        mrb_ssize capa;
         struct mrb_shared_string *shared;
         struct RString *fshared;
       } aux;
@@ -54,7 +54,7 @@ struct RStringEmbed {
     RSTR_SET_EMBED_LEN((s),(n));\
   }\
   else {\
-    (s)->as.heap.len = (mrb_int)(n);\
+    (s)->as.heap.len = (mrb_ssize)(n);\
   }\
 } while (0)
 #define RSTR_EMBED_PTR(s) (((struct RStringEmbed*)(s))->ary)

--- a/include/mruby/value.h
+++ b/include/mruby/value.h
@@ -174,6 +174,14 @@ typedef void mrb_value;
 #define MRB_SYMBOL_MAX      UINT32_MAX
 #endif
 
+#if INTPTR_MAX < MRB_INT_MAX
+  typedef intptr_t mrb_ssize;
+# define MRB_SSIZE_MAX (INTPTR_MAX>>MRB_FIXNUM_SHIFT)
+#else
+  typedef mrb_int mrb_ssize;
+# define MRB_SSIZE_MAX MRB_INT_MAX
+#endif
+
 #ifndef mrb_immediate_p
 #define mrb_immediate_p(o) (mrb_type(o) < MRB_TT_FREE)
 #endif


### PR DESCRIPTION
Previously, `mrb_int` was used as the type that represents the buffer size
on memory, but the sizes of `RString` and `RArray` exceed 6 words when
`MRB_INT64` is enabled on 32-bit CPU.

I don't think it is necessary to be able to represent the buffer size on
memory that exceeds the virtual address space. Therefore, for this purpose,
introduce `mrb_ssize` which doesn't exceed the sizes of `mrb_int` and
pointer.

I think all `mrb_int` used for this purpose should be changed to
`mrb_ssize`, but currently only the members of the structures (`RString`,
`mrb_shared_string`, `RArray` and `mrb_shared_array`) are changed.