### PR TITLE
Rename `BITSIZE` to `BIT` and `BIT` to `BIT_POS` for consistency

### DIFF
--- a/include/mruby/boxing_word.h
+++ b/include/mruby/boxing_word.h
@@ -43,10 +43,10 @@ enum mrb_special_consts {
 #define MRB_IMMEDIATE_MASK  0x07
 
 #ifdef MRB_64BIT
-#define MRB_SYMBOL_BITSIZE  (sizeof(mrb_sym) * CHAR_BIT)
+#define MRB_SYMBOL_BIT      (sizeof(mrb_sym) * CHAR_BIT)
 #define MRB_SYMBOL_MAX      UINT32_MAX
 #else
-#define MRB_SYMBOL_BITSIZE  (sizeof(mrb_sym) * CHAR_BIT - MRB_SYMBOL_SHIFT)
+#define MRB_SYMBOL_BIT      (sizeof(mrb_sym) * CHAR_BIT - MRB_SYMBOL_SHIFT)
 #define MRB_SYMBOL_MAX      (UINT32_MAX >> MRB_SYMBOL_SHIFT)
 #endif
 

--- a/include/mruby/string.h
+++ b/include/mruby/string.h
@@ -115,8 +115,8 @@ MRB_API mrb_int mrb_str_strlen(mrb_state*, struct RString*);
 #define MRB_STR_POOL     16  /* status flags from here */
 #define MRB_STR_ASCII    32
 #define MRB_STR_EMBED_LEN_SHIFT 6
-#define MRB_STR_EMBED_LEN_BITSIZE 5
-#define MRB_STR_EMBED_LEN_MASK (((1 << MRB_STR_EMBED_LEN_BITSIZE) - 1) << MRB_STR_EMBED_LEN_SHIFT)
+#define MRB_STR_EMBED_LEN_BIT 5
+#define MRB_STR_EMBED_LEN_MASK (((1 << MRB_STR_EMBED_LEN_BIT) - 1) << MRB_STR_EMBED_LEN_SHIFT)
 #define MRB_STR_TYPE_MASK (MRB_STR_POOL - 1)
 
 

--- a/include/mruby/value.h
+++ b/include/mruby/value.h
@@ -169,9 +169,9 @@ typedef void mrb_value;
 #include "boxing_no.h"
 #endif
 
-#if !defined(MRB_SYMBOL_BITSIZE)
-#define MRB_SYMBOL_BITSIZE (sizeof(mrb_sym) * CHAR_BIT)
-#define MRB_SYMBOL_MAX      UINT32_MAX
+#if !defined(MRB_SYMBOL_BIT)
+#define MRB_SYMBOL_BIT (sizeof(mrb_sym) * CHAR_BIT)
+#define MRB_SYMBOL_MAX UINT32_MAX
 #endif
 
 #if INTPTR_MAX < MRB_INT_MAX

--- a/src/string.c
+++ b/src/string.c
@@ -2870,7 +2870,7 @@ mrb_init_string(mrb_state *mrb)
 {
   struct RClass *s;
 
-  mrb_static_assert(RSTRING_EMBED_LEN_MAX < (1 << MRB_STR_EMBED_LEN_BITSIZE),
+  mrb_static_assert(RSTRING_EMBED_LEN_MAX < (1 << MRB_STR_EMBED_LEN_BIT),
                     "pointer size too big for embedded string");
 
   mrb->string_class = s = mrb_define_class(mrb, "String", mrb->object_class);             /* 15.2.10 */

--- a/src/symbol.c
+++ b/src/symbol.c
@@ -20,12 +20,12 @@ typedef struct symbol_name {
   const char *name;
 } symbol_name;
 
-#define SYMBOL_INLINE_BIT       1
-#define SYMBOL_INLINE_LOWER_BIT 2
-#define SYMBOL_INLINE           (1 << (SYMBOL_INLINE_BIT - 1))
-#define SYMBOL_INLINE_LOWER     (1 << (SYMBOL_INLINE_LOWER_BIT - 1))
-#define SYMBOL_NORMAL_SHIFT     SYMBOL_INLINE_BIT
-#define SYMBOL_INLINE_SHIFT     SYMBOL_INLINE_LOWER_BIT
+#define SYMBOL_INLINE_BIT_POS       1
+#define SYMBOL_INLINE_LOWER_BIT_POS 2
+#define SYMBOL_INLINE               (1 << (SYMBOL_INLINE_BIT_POS - 1))
+#define SYMBOL_INLINE_LOWER         (1 << (SYMBOL_INLINE_LOWER_BIT_POS - 1))
+#define SYMBOL_NORMAL_SHIFT         SYMBOL_INLINE_BIT_POS
+#define SYMBOL_INLINE_SHIFT         SYMBOL_INLINE_LOWER_BIT_POS
 #ifdef MRB_ENABLE_ALL_SYMBOLS
 # define SYMBOL_INLINE_P(sym) FALSE
 # define SYMBOL_INLINE_LOWER_P(sym) FALSE
@@ -50,8 +50,8 @@ static const char pack_table[] = "_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRS
 static mrb_sym
 sym_inline_pack(const char *name, uint16_t len)
 {
-  const int lower_length_max = (MRB_SYMBOL_BITSIZE - 2) / 5;
-  const int mix_length_max   = (MRB_SYMBOL_BITSIZE - 2) / 6;
+  const int lower_length_max = (MRB_SYMBOL_BIT - 2) / 5;
+  const int mix_length_max   = (MRB_SYMBOL_BIT - 2) / 6;
 
   char c;
   const char *p;


### PR DESCRIPTION
The bit width terminology is unified to `BIT` according to `MRB_ INT_BIT`
and `CHAR_BIT`. Also the bit position terminology is unified to `BIT_POS`.