### PR TITLE
Fix `ARGV` value in `mruby` command (regression by #4827)

### DIFF
--- a/mrbgems/mruby-bin-mruby/bintest/mruby.rb
+++ b/mrbgems/mruby-bin-mruby/bintest/mruby.rb
@@ -39,6 +39,11 @@ assert '$0 value' do
   assert_equal '"-e"', `#{cmd('mruby')} -e #{shellquote('p $0')}`.chomp
 end
 
+assert 'ARGV value' do
+  assert_mruby(%{["ab", "cde"]\n}, "", true, %w[-e p(ARGV) ab cde])
+  assert_mruby("[]\n", "", true, %w[-e p(ARGV)])
+end
+
 assert('float literal') do
   script, bin = Tempfile.new('test.rb'), Tempfile.new('test.mrb')
   File.write script.path, 'p [3.21, 2e308.infinite?, -2e308.infinite?]'

--- a/mrbgems/mruby-bin-mruby/tools/mruby/mruby.c
+++ b/mrbgems/mruby-bin-mruby/tools/mruby/mruby.c
@@ -189,8 +189,8 @@ parse_args(mrb_state *mrb, int argc, char **argv, struct _args *args)
     }
   }
 
+  argc = opts->argc; argv = opts->argv;
   if (args->cmdline == NULL) {
-    argc = opts->argc; argv = opts->argv;
     if (*argv == NULL) args->rfp = stdin;
     else {
       args->rfp = strcmp(argv[0], "-") == 0 ?


### PR DESCRIPTION
#### Before this patch:

  ```
  $ bin/mruby -e 'p ARGV' a b
  ["bin/mruby", "-e", "p ARGV", "a", "b"]
  ```

#### After this patch:

  ```
  $ bin/mruby -e 'p ARGV' a b
  ["a", "b"]
  ```