### PR TITLE
Support `--` (end of options) to `mruby` command

### DIFF
--- a/mrbgems/mruby-bin-mruby/bintest/mruby.rb
+++ b/mrbgems/mruby-bin-mruby/bintest/mruby.rb
@@ -128,6 +128,10 @@ assert('mruby -r option (file not found)') do
   assert_mruby("", /\A.*: Cannot open library file: .*\n\z/, false, %w[-r _no_exists_])
 end
 
+assert('mruby --') do
+  assert_mruby(%{["-x", "1"]\n}, "", true, %w[-e p(ARGV) -- -x 1])
+end
+
 assert('mruby invalid short option') do
   assert_mruby("", /\A.*: invalid option -1 .*\n\z/, false, %w[-1])
 end

--- a/mrbgems/mruby-bin-mruby/tools/mruby/mruby.c
+++ b/mrbgems/mruby-bin-mruby/tools/mruby/mruby.c
@@ -64,21 +64,33 @@ options_init(struct options *opts, int argc, char **argv)
 static const char *
 options_opt(struct options *opts)
 {
+  /* concatenated short options (e.g. `-cv`) */
   if (*opts->short_opt && *++opts->opt) {
    short_opt:
     opts->short_opt[0] = *opts->opt;
     opts->short_opt[1] = 0;
     return opts->short_opt;
   }
+
   while (++opts->argv, --opts->argc) {
     opts->opt = *opts->argv;
+
+    /*  empty         || not start with `-`  || `-` */
     if (!opts->opt[0] || opts->opt[0] != '-' || !opts->opt[1]) return NULL;
+
     if (opts->opt[1] == '-') {
+      /* `--` */
+      if (!opts->opt[2]) {
+        ++opts->argv, --opts->argc;
+        return NULL;
+      }
+      /* long option */
       opts->opt += 2;
       *opts->short_opt = 0;
       return opts->opt;
     }
     else {
+      /* short option */
       ++opts->opt;
       goto short_opt;
     }
@@ -90,6 +102,7 @@ static const char *
 options_arg(struct options *opts)
 {
   if (*opts->short_opt && opts->opt[1]) {
+    /* concatenated short option and option argument (e.g. `-rLIBRARY`) */
     *opts->short_opt = 0;
     return opts->opt + 1;
   }


### PR DESCRIPTION
#### Before this patch:

  ```
  $ bin/mruby -e 'p ARGV' -- -x
  bin/mruby: invalid option -- (-h will show valid options)
  ```

#### After this patch:

  ```
  $ bin/mruby -e 'p ARGV' -- -x
  ["-x"]
  ```