### PR TITLE
Fix `mruby --verbose` (regression by #4827)

### DIFF
--- a/mrbgems/mruby-bin-mruby/bintest/mruby.rb
+++ b/mrbgems/mruby-bin-mruby/bintest/mruby.rb
@@ -128,6 +128,10 @@ assert('mruby -r option (file not found)') do
   assert_mruby("", /\A.*: Cannot open library file: .*\n\z/, false, %w[-r _no_exists_])
 end
 
+assert('mruby --verbose option') do
+  assert_mruby(/\A[^\n]*NODE.*\n:end\n\z/m, "", true, %w[--verbose -e p(:end)])
+end
+
 assert('mruby --') do
   assert_mruby(%{["-x", "1"]\n}, "", true, %w[-e p(ARGV) -- -x 1])
 end

--- a/mrbgems/mruby-bin-mruby/tools/mruby/mruby.c
+++ b/mrbgems/mruby-bin-mruby/tools/mruby/mruby.c
@@ -189,7 +189,6 @@ parse_args(mrb_state *mrb, int argc, char **argv, struct _args *args)
     }
     else if (strcmp(opt, "verbose") == 0) {
       args->verbose = TRUE;
-      break;
     }
     else if (strcmp(opt, "copyright") == 0) {
       mrb_show_copyright(mrb);


### PR DESCRIPTION
#### Before this patch:

  ```
  $ bin/mruby --verbose -e 'p 1'
  bin/mruby: Cannot open program file: --verbose
  ```

#### After this patch:

  ```
  $ bin/mruby --verbose -e 'p 1'
  00001 NODE_SCOPE:
  (snip)
  irep 0x7fe97041df30 nregs=4 nlocals=1 pools=0 syms=1 reps=0 iseq=11
  file: -e
      1 000 OP_LOADSELF R1
  (snip)

  1
  ```