### PR TITLE
Fix `MRB_FIXNUM_SHIFT` with `MRB_WORD_BOXING`, `MRB_INT32` and `MRB_64BIT`

### DIFF
--- a/include/mruby/boxing_nan.h
+++ b/include/mruby/boxing_nan.h
@@ -20,6 +20,7 @@
 #endif
 
 #define MRB_FIXNUM_SHIFT 0
+#define MRB_SYMBOL_SHIFT 0
 
 /* value representation by nan-boxing:
  *   float : FFFFFFFFFFFFFFFF FFFFFFFFFFFFFFFF FFFFFFFFFFFFFFFF FFFFFFFFFFFFFFFF

--- a/include/mruby/boxing_no.h
+++ b/include/mruby/boxing_no.h
@@ -8,6 +8,7 @@
 #define MRUBY_BOXING_NO_H
 
 #define MRB_FIXNUM_SHIFT 0
+#define MRB_SYMBOL_SHIFT 0
 
 union mrb_value_union {
 #ifndef MRB_WITHOUT_FLOAT

--- a/include/mruby/value.h
+++ b/include/mruby/value.h
@@ -169,10 +169,8 @@ typedef void mrb_value;
 #include "boxing_no.h"
 #endif
 
-#if !defined(MRB_SYMBOL_BIT)
-#define MRB_SYMBOL_BIT (sizeof(mrb_sym) * CHAR_BIT)
-#define MRB_SYMBOL_MAX UINT32_MAX
-#endif
+#define MRB_SYMBOL_BIT (sizeof(mrb_sym) * CHAR_BIT - MRB_SYMBOL_SHIFT)
+#define MRB_SYMBOL_MAX (UINT32_MAX >> MRB_SYMBOL_SHIFT)
 
 #if INTPTR_MAX < MRB_INT_MAX
   typedef intptr_t mrb_ssize;


### PR DESCRIPTION
### Example

  ```ruby
  # example.rb
  max32 = 2**30 - 1 + 2**30
  min32 = -max32-1
  [max32, max32+1, min32, min32-1].each{|n| p [n, n.class]}
  ```

#### Before this patch:

  ```
  $ bin/mruby example.rb
  [2147483647, Float]
  [2147483648, Float]
  [-2147483648, Float]
  [-2147483649, Float]
  ```

#### After this patch:

  ```
  $ bin/mruby example.rb
  [2147483647, Fixnum]
  [2147483648, Float]
  [-2147483648, Fixnum]
  [-2147483649, Float]
  ```