### PR TITLE
Silence Clang warning with `MRB_INT32` and `MRB_64BIT` in `time.c`

### DIFF
--- a/mrbgems/mruby-time/src/time.c
+++ b/mrbgems/mruby-time/src/time.c
@@ -254,7 +254,8 @@ mrb_to_time_t(mrb_state *mrb, mrb_value obj, time_t *usec)
       {
         mrb_int i = mrb_int(mrb, obj);
 
-        if ((mrb_time_int)i > MRB_TIME_MAX || MRB_TIME_MIN > i) {
+        if ((MRB_INT_MAX > MRB_TIME_MAX && (mrb_time_int)i > MRB_TIME_MAX) ||
+            (MRB_TIME_MIN > MRB_INT_MIN && MRB_TIME_MIN > i)) {
           goto out_of_range;
         }
 


### PR DESCRIPTION
Silence the following warning:

  ```
  /mruby/mrbgems/mruby-time/src/time.c:258:60: warning: result of comparison of constant -9223372036854775808 with expression of type 'mrb_int' (aka 'int') is always false [-Wtautological-constant-out-of-range-compare]
        if ((mrb_time_int)i > MRB_TIME_MAX || MRB_TIME_MIN > i) {
                                              ~~~~~~~~~~~~ ^ ~
  ```