### PR TITLE
Add `MRB_ALLOCV()` for temporary memory allocation

### DIFF
--- a/include/mrbconf.h
+++ b/include/mrbconf.h
@@ -120,6 +120,9 @@
 /* fixed size state atexit stack */
 //#define MRB_FIXED_STATE_ATEXIT_STACK
 
+/* maximum size to allocate on the stack in MRB_ALLOCV  */
+//#define MRB_ALLOCV_ON_STACK_MAX 256
+
 /* -DMRB_DISABLE_XXXX to drop following features */
 //#define MRB_DISABLE_STDIO /* use of stdio */
 

--- a/mrbgems/mruby-struct/src/struct.c
+++ b/mrbgems/mruby-struct/src/struct.c
@@ -123,29 +123,15 @@ mrb_struct_ref(mrb_state *mrb, mrb_value obj)
 static mrb_sym
 mrb_id_attrset(mrb_state *mrb, mrb_sym id)
 {
-#define ONSTACK_ALLOC_MAX 32
-#define ONSTACK_STRLEN_MAX (ONSTACK_ALLOC_MAX - 1) /* '=' character */
-
-  const char *name;
-  char *buf;
   mrb_int len;
   mrb_sym mid;
-  char onstack[ONSTACK_ALLOC_MAX];
+  const char *name = mrb_sym_name_len(mrb, id, &len);
+  MRB_ALLOCV(mrb, char, buf, len+1);
 
-  name = mrb_sym_name_len(mrb, id, &len);
-  if (len > ONSTACK_STRLEN_MAX) {
-    buf = (char *)mrb_malloc(mrb, (size_t)len+1);
-  }
-  else {
-    buf = onstack;
-  }
   memcpy(buf, name, (size_t)len);
   buf[len] = '=';
 
   mid = mrb_intern(mrb, buf, len+1);
-  if (buf != onstack) {
-    mrb_free(mrb, buf);
-  }
   return mid;
 }
 

--- a/src/class.c
+++ b/src/class.c
@@ -1407,18 +1407,15 @@ mrb_method_search(mrb_state *mrb, struct RClass* c, mrb_sym mid)
   return m;
 }
 
-#define ONSTACK_ALLOC_MAX 32
-
 static mrb_sym
 prepare_name_common(mrb_state *mrb, mrb_sym sym, const char *prefix, const char *suffix)
 {
-  char onstack[ONSTACK_ALLOC_MAX];
   mrb_int sym_len;
   const char *sym_str = mrb_sym_name_len(mrb, sym, &sym_len);
   size_t prefix_len = prefix ? strlen(prefix) : 0;
   size_t suffix_len = suffix ? strlen(suffix) : 0;
   size_t name_len = sym_len + prefix_len + suffix_len;
-  char *buf = name_len > sizeof(onstack) ? (char *)mrb_alloca(mrb, name_len) : onstack;
+  MRB_ALLOCV(mrb, char, buf, name_len);
   char *p = buf;
 
   if (prefix_len > 0) {


### PR DESCRIPTION
`MRB_ALLOCV(mrb, type, var, n)` defines `type *var` variable and assign
temporarily allocated memory for _n_ objects of type _type_. If the
allocation size is less than or equal to `MRB_ALLOCV_ON_STACK_MAX`, allocate
on the stack, otherwise use `mrb_alloca()`.

`MRB_ALLOCV_ON_STACK_MAX` is configurable in `mrbconf.h` (default is 256).