### PR TITLE
Fix keyword arguments not be obtained with `mrb_get_args()`; Fix #4754

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -620,11 +620,11 @@ mrb_get_args(mrb_state *mrb, const char *format, ...)
       goto check_exit;
     case '!':
       break;
-    case '&': case '?':
-      if (opt) opt_skip = FALSE;
-      break;
     case ':':
       reqkarg = TRUE;
+      /* fall through */
+    case '&': case '?':
+      if (opt) opt_skip = FALSE;
       break;
     default:
       if (!opt) needargc ++;


### PR DESCRIPTION
If ":" is after "|" and there is no "?" or "*", the keyword argument could not be obtained and it was not initialized with `undef`.

For example: "|oo:"

----

Even before the patch (mruby-2.1.0), ":|o" and "|o*:" etc work without problems.

However, "|oo:" described as an example is not assigned to keyword arguments at all.
Therefore, if the variable is accessed as it is, SIGSEGV will be executed in some cases.

Sorry!