### PR TITLE
Add "mruby developers" into some gems; Resolve #4709

### DIFF
--- a/mrbgems/mruby-io/README.md
+++ b/mrbgems/mruby-io/README.md
@@ -171,6 +171,7 @@ Add the line below to your `build_config.rb`:
 ## License
 
 Copyright (c) 2013 Internet Initiative Japan Inc.
+Copyright (c) 2017 mruby developers
 
 Permission is hereby granted, free of charge, to any person obtaining a 
 copy of this software and associated documentation files (the "Software"), 

--- a/mrbgems/mruby-io/mrbgem.rake
+++ b/mrbgems/mruby-io/mrbgem.rake
@@ -1,6 +1,6 @@
 MRuby::Gem::Specification.new('mruby-io') do |spec|
   spec.license = 'MIT'
-  spec.authors = 'Internet Initiative Japan Inc.'
+  spec.authors = ['Internet Initiative Japan Inc.', 'mruby developers']
   spec.summary = 'IO and File class'
 
   spec.cc.include_paths << "#{build.root}/src"

--- a/mrbgems/mruby-pack/README.md
+++ b/mrbgems/mruby-pack/README.md
@@ -49,6 +49,7 @@ There is no dependency on other mrbgems.
 ## License
 
 Copyright (c) 2012 Internet Initiative Japan Inc.
+Copyright (c) 2017 mruby developers
 
 Permission is hereby granted, free of charge, to any person obtaining a 
 copy of this software and associated documentation files (the "Software"), 

--- a/mrbgems/mruby-pack/mrbgem.rake
+++ b/mrbgems/mruby-pack/mrbgem.rake
@@ -1,6 +1,6 @@
 MRuby::Gem::Specification.new('mruby-pack') do |spec|
   spec.license = 'MIT'
-  spec.authors = 'Internet Initiative Japan Inc.'
+  spec.authors = ['Internet Initiative Japan Inc.', 'mruby developers']
   spec.summary = 'Array#pack and String#unpack method'
 
   spec.cc.include_paths << "#{build.root}/src"

--- a/mrbgems/mruby-sleep/mrbgem.rake
+++ b/mrbgems/mruby-sleep/mrbgem.rake
@@ -1,5 +1,5 @@
 MRuby::Gem::Specification.new('mruby-sleep') do |spec|
   spec.license = 'MIT'
-  spec.authors = 'MATSUMOTO Ryosuke'
+  spec.authors = ['MATSUMOTO Ryosuke', 'mruby developers']
   spec.version = '0.0.1'
 end

--- a/mrbgems/mruby-sleep/src/mrb_sleep.c
+++ b/mrbgems/mruby-sleep/src/mrb_sleep.c
@@ -2,6 +2,7 @@
 ** mrb_sleep - sleep methods for mruby
 **
 ** Copyright (c) mod_mruby developers 2012-
+** Copyright (c) mruby developers 2018
 **
 ** Permission is hereby granted, free of charge, to any person obtaining
 ** a copy of this software and associated documentation files (the

--- a/mrbgems/mruby-socket/README.md
+++ b/mrbgems/mruby-socket/README.md
@@ -35,6 +35,7 @@ Date: Tue, 21 May 2013 04:31:30 GMT
 ## License
 
 Copyright (c) 2013 Internet Initiative Japan Inc.
+Copyright (c) 2017 mruby developers
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/mrbgems/mruby-socket/mrbgem.rake
+++ b/mrbgems/mruby-socket/mrbgem.rake
@@ -1,6 +1,6 @@
 MRuby::Gem::Specification.new('mruby-socket') do |spec|
   spec.license = 'MIT'
-  spec.authors = 'Internet Initiative Japan'
+  spec.authors = ['Internet Initiative Japan', 'mruby developers']
   spec.summary = 'standard socket class'
 
   spec.cc.include_paths << "#{build.root}/src"


### PR DESCRIPTION
It is writing side by side with the original authors.

----

Although it is redundant, it is the simplest description.
For your reference, list the added commits.

| gem name     | year | release | commit                                   |
| ------------ | ---- | ------- | ---------------------------------------- |
| mruby-io     | 2017 |   1.4.0 | d75266dd1bade53255044460a9cd74596addaa84 |
| mruby-pack   | 2017 |   1.4.0 | a5412d48fd1bb55288cb168a92efd0f2045781c1 |
| mruby-socket | 2017 |   1.4.0 | 73ef548c6386a1101b5d95654bcb142ab83149c7 |
| mruby-sleep  | 2018 |   2.0.0 | 44fdd53f2e5bac6fe1cbc2ceb653aa5f2de965e6 |

