### PR TITLE
Fix behavior of `String#to_i`/`Kernel#Integer` to numbers starting with `_`

### DIFF
--- a/mrbgems/mruby-kernel-ext/test/kernel.rb
+++ b/mrbgems/mruby-kernel-ext/test/kernel.rb
@@ -55,11 +55,15 @@ assert('Kernel#Integer') do
   assert_operator(0, :eql?, Integer("0"))
   assert_operator(0, :eql?, Integer("00000"))
   assert_operator(123, :eql?, Integer('1_2_3'))
+  assert_operator(123, :eql?, Integer("\t\r\n\f\v 123 \t\r\n\f\v"))
   assert_raise(TypeError) { Integer(nil) }
   assert_raise(ArgumentError) { Integer('a') }
   assert_raise(ArgumentError) { Integer('4a5') }
   assert_raise(ArgumentError) { Integer('1_2__3') }
   assert_raise(ArgumentError) { Integer('68_') }
+  assert_raise(ArgumentError) { Integer('_68') }
+  assert_raise(ArgumentError) { Integer(' _68') }
+  assert_raise(ArgumentError) { Integer('6 8') }
   assert_raise(ArgumentError) { Integer("15\0") }
   assert_raise(ArgumentError) { Integer("15.0") }
   skip unless Object.const_defined?(:Float)
@@ -74,7 +78,9 @@ assert('Kernel#Float') do
   assert_operator(123.0, :eql?, Float('1_2_3'))
   assert_operator(12.34, :eql?, Float('1_2.3_4'))
   assert_operator(0.9, :eql?, Float('.9'))
+  assert_operator(0.9, :eql?, Float(" \t\r\n\f\v.9 \t\r\n\f\v"))
   assert_raise(TypeError) { Float(nil) }
+  assert_raise(ArgumentError) { Float("1. 5") }
   assert_raise(ArgumentError) { Float("1.5a") }
   assert_raise(ArgumentError) { Float("1.5\0") }
   assert_raise(ArgumentError) { Float('a') }
@@ -84,6 +90,7 @@ assert('Kernel#Float') do
   assert_raise(ArgumentError) { Float('68._7') }
   assert_raise(ArgumentError) { Float('68.7_') }
   assert_raise(ArgumentError) { Float('_68') }
+  assert_raise(ArgumentError) { Float(' _68') }
   assert_raise(ArgumentError) { Float('1_2.3__4') }
 end
 

--- a/src/string.c
+++ b/src/string.c
@@ -2354,7 +2354,7 @@ mrb_str_len_to_inum(mrb_state *mrb, const char *str, mrb_int len, mrb_int base, 
     if (*(p - 1) == '0')
       p--;
   }
-  if (p == pend) {
+  if (p == pend || *p == '_') {
     if (badcheck) goto bad;
     return mrb_fixnum_value(0);
   }

--- a/test/t/string.rb
+++ b/test/t/string.rb
@@ -699,10 +699,14 @@ assert('String#to_f', '15.2.10.5.38') do
   assert_operator(68.0, :eql?, '68_'.to_f)
   assert_operator(68.0, :eql?, '68._7'.to_f)
   assert_operator(68.7, :eql?, '68.7_'.to_f)
+  assert_operator(6.0, :eql?, '6 8.7'.to_f)
+  assert_operator(68.0, :eql?, '68. 7'.to_f)
   assert_operator(0.0, :eql?, '_68'.to_f)
+  assert_operator(0.0, :eql?, ' _68'.to_f)
   assert_operator(12.34, :eql?, '1_2.3_4'.to_f)
   assert_operator(12.3, :eql?, '1_2.3__4'.to_f)
   assert_operator(0.9, :eql?, '.9'.to_f)
+  assert_operator(0.9, :eql?, "\t\r\n\f\v .9 \t\r\n\f\v".to_f)
 end if Object.const_defined?(:Float)
 
 assert('String#to_i', '15.2.10.5.39') do
@@ -716,6 +720,10 @@ assert('String#to_i', '15.2.10.5.39') do
   assert_operator 12, :eql?, '1_2__3'.to_i
   assert_operator 123, :eql?, '1_2_3'.to_i
   assert_operator 68, :eql?, '68_'.to_i
+  assert_operator 0, :eql?, '_68'.to_i
+  assert_operator 0, :eql?, ' _68'.to_i
+  assert_operator 68, :eql?, "\t\r\n\f\v 68 \t\r\n\f\v".to_i
+  assert_operator 6, :eql?, ' 6 8 '.to_i
 end
 
 assert('String#to_s', '15.2.10.5.40') do


### PR DESCRIPTION
#### Before this patch:

  ```ruby
  Integer("_1")  #=> 1
  "_1".to_i      #=> 1
  ```

#### After this patch (same as Ruby):

  ```ruby
  Integer("_1")  #=> ArgumentError
  "_1".to_i      #=> 0
  ```