### PR TITLE
Fix behavior of `Kernel#Integer` to numbers ending with `_` and spaces

### DIFF
--- a/mrbgems/mruby-kernel-ext/test/kernel.rb
+++ b/mrbgems/mruby-kernel-ext/test/kernel.rb
@@ -61,6 +61,7 @@ assert('Kernel#Integer') do
   assert_raise(ArgumentError) { Integer('4a5') }
   assert_raise(ArgumentError) { Integer('1_2__3') }
   assert_raise(ArgumentError) { Integer('68_') }
+  assert_raise(ArgumentError) { Integer('68_ ') }
   assert_raise(ArgumentError) { Integer('_68') }
   assert_raise(ArgumentError) { Integer(' _68') }
   assert_raise(ArgumentError) { Integer('6 8') }
@@ -89,6 +90,7 @@ assert('Kernel#Float') do
   assert_raise(ArgumentError) { Float('68_') }
   assert_raise(ArgumentError) { Float('68._7') }
   assert_raise(ArgumentError) { Float('68.7_') }
+  assert_raise(ArgumentError) { Float('68.7_ ') }
   assert_raise(ArgumentError) { Float('_68') }
   assert_raise(ArgumentError) { Float(' _68') }
   assert_raise(ArgumentError) { Float('1_2.3__4') }

--- a/src/string.c
+++ b/src/string.c
@@ -2393,9 +2393,10 @@ mrb_str_len_to_inum(mrb_state *mrb, const char *str, mrb_int len, mrb_int base, 
   }
   val = (mrb_int)n;
   if (badcheck) {
-    if (p == str) goto bad; /* no number */
+    if (p == str) goto bad;             /* no number */
+    if (*(p - 1) == '_') goto bad;      /* trailing '_' */
     while (p<pend && ISSPACE(*p)) p++;
-    if (p<pend) goto bad;       /* trailing garbage */
+    if (p<pend) goto bad;               /* trailing garbage */
   }
 
   return mrb_fixnum_value(sign ? val : -val);

--- a/test/t/string.rb
+++ b/test/t/string.rb
@@ -699,6 +699,7 @@ assert('String#to_f', '15.2.10.5.38') do
   assert_operator(68.0, :eql?, '68_'.to_f)
   assert_operator(68.0, :eql?, '68._7'.to_f)
   assert_operator(68.7, :eql?, '68.7_'.to_f)
+  assert_operator(68.7, :eql?, '68.7_ '.to_f)
   assert_operator(6.0, :eql?, '6 8.7'.to_f)
   assert_operator(68.0, :eql?, '68. 7'.to_f)
   assert_operator(0.0, :eql?, '_68'.to_f)
@@ -720,6 +721,7 @@ assert('String#to_i', '15.2.10.5.39') do
   assert_operator 12, :eql?, '1_2__3'.to_i
   assert_operator 123, :eql?, '1_2_3'.to_i
   assert_operator 68, :eql?, '68_'.to_i
+  assert_operator 68, :eql?, '68_ '.to_i
   assert_operator 0, :eql?, '_68'.to_i
   assert_operator 0, :eql?, ' _68'.to_i
   assert_operator 68, :eql?, "\t\r\n\f\v 68 \t\r\n\f\v".to_i


### PR DESCRIPTION
#### Before this patch:

  ```ruby
  Integer("1_ ")  #=> 1
  ```

#### After this patch (same as Ruby):

  ```ruby
  Integer("1_ ")  #=> ArgumentError
  ```