### PR TITLE
Add `mrb_num_args_error()` for "wrong number of arguments" error

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -1232,6 +1232,7 @@ MRB_API mrb_noreturn void mrb_raise(mrb_state *mrb, struct RClass *c, const char
 MRB_API mrb_noreturn void mrb_raisef(mrb_state *mrb, struct RClass *c, const char *fmt, ...);
 MRB_API mrb_noreturn void mrb_name_error(mrb_state *mrb, mrb_sym id, const char *fmt, ...);
 MRB_API mrb_noreturn void mrb_frozen_error(mrb_state *mrb, void *frozen_obj);
+MRB_API mrb_noreturn void mrb_num_args_error(mrb_state *mrb, mrb_int argc, int min, int max);
 MRB_API void mrb_warn(mrb_state *mrb, const char *fmt, ...);
 MRB_API mrb_noreturn void mrb_bug(mrb_state *mrb, const char *fmt, ...);
 MRB_API void mrb_print_backtrace(mrb_state *mrb);

--- a/mrbgems/mruby-io/src/io.c
+++ b/mrbgems/mruby-io/src/io.c
@@ -1060,7 +1060,7 @@ mrb_io_s_select(mrb_state *mrb, mrb_value klass)
   mrb_get_args(mrb, "*", &argv, &argc);
 
   if (argc < 1 || argc > 4) {
-    mrb_raisef(mrb, E_ARGUMENT_ERROR, "wrong number of arguments (%i for 1..4)", argc);
+    mrb_num_args_error(mrb, argc, 1, 4);
   }
 
   timeout = mrb_nil_value();

--- a/mrbgems/mruby-socket/src/socket.c
+++ b/mrbgems/mruby-socket/src/socket.c
@@ -476,7 +476,7 @@ mrb_basicsocket_setsockopt(mrb_state *mrb, mrb_value self)
     optname = mrb_fixnum(mrb_funcall(mrb, so, "optname", 0));
     optval = mrb_funcall(mrb, so, "data", 0);
   } else {
-    mrb_raisef(mrb, E_ARGUMENT_ERROR, "wrong number of arguments (%i for 3)", argc);
+    mrb_num_args_error(mrb, argc, 3, 3);
   }
 
   s = socket_fd(mrb, self);

--- a/mrbgems/mruby-struct/src/struct.c
+++ b/mrbgems/mruby-struct/src/struct.c
@@ -274,7 +274,7 @@ mrb_struct_s_def(mrb_state *mrb, mrb_value klass)
   name = mrb_nil_value();
   mrb_get_args(mrb, "*&", &argv, &argc, &b);
   if (argc == 0) { /* special case to avoid crash */
-    mrb_raise(mrb, E_ARGUMENT_ERROR, "wrong number of arguments");
+    mrb_num_args_error(mrb, argc, 1, -1);
   }
   else {
     pargv = argv;

--- a/src/error.c
+++ b/src/error.c
@@ -530,7 +530,7 @@ exception_call:
 
       break;
     default:
-      mrb_raisef(mrb, E_ARGUMENT_ERROR, "wrong number of arguments (%i for 0..3)", argc);
+      mrb_num_args_error(mrb, argc, 0, 3);
       break;
   }
   if (argc > 0) {
@@ -584,6 +584,19 @@ MRB_API mrb_noreturn void
 mrb_frozen_error(mrb_state *mrb, void *frozen_obj)
 {
   mrb_raisef(mrb, E_FROZEN_ERROR, "can't modify frozen %t", mrb_obj_value(frozen_obj));
+}
+
+MRB_API mrb_noreturn void
+mrb_num_args_error(mrb_state *mrb, mrb_int argc, int min, int max)
+{
+#define FMT(exp) "wrong number of arguments (given %i, expected " exp ")"
+  if (min == max)
+    mrb_raisef(mrb, E_ARGUMENT_ERROR, FMT("%d"), argc, min);
+  else if (max < 0)
+    mrb_raisef(mrb, E_ARGUMENT_ERROR, FMT("%d+"), argc, min);
+  else
+    mrb_raisef(mrb, E_ARGUMENT_ERROR, FMT("%d..%d"), argc, min, max);
+#undef FMT
 }
 
 void

--- a/src/hash.c
+++ b/src/hash.c
@@ -800,7 +800,7 @@ mrb_hash_init(mrb_state *mrb, mrb_value hash)
   mrb_hash_modify(mrb, hash);
   if (!mrb_nil_p(block)) {
     if (ifnone_p) {
-      mrb_raise(mrb, E_ARGUMENT_ERROR, "wrong number of arguments");
+      mrb_num_args_error(mrb, 1, 0, 0);
     }
     RHASH(hash)->flags |= MRB_HASH_PROC_DEFAULT;
     ifnone = block;

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -384,7 +384,7 @@ mrb_obj_extend(mrb_state *mrb, mrb_int argc, mrb_value *argv, mrb_value obj)
   mrb_int i;
 
   if (argc == 0) {
-    mrb_raise(mrb, E_ARGUMENT_ERROR, "wrong number of arguments (at least 1)");
+    mrb_num_args_error(mrb, argc, 1, -1);
   }
   for (i = 0; i < argc; i++) {
     mrb_check_type(mrb, argv[i], MRB_TT_MODULE);


### PR DESCRIPTION
To unify the style of messages.