### PR TITLE
Fix arguments check to `Array#each`

### DIFF
--- a/src/array.c
+++ b/src/array.c
@@ -1304,6 +1304,7 @@ init_ary_each(mrb_state *mrb, struct RClass *ary)
   each_irep->nregs = 7;
   each_irep->nlocals = 3;
   p = mrb_proc_new(mrb, each_irep);
+  p->flags |= MRB_PROC_SCOPE | MRB_PROC_STRICT;
   MRB_METHOD_FROM_PROC(m, p);
   mrb_define_method_raw(mrb, ary, mrb_intern_lit(mrb, "each"), m);
 }


### PR DESCRIPTION
#### Before this patch:

  ```
  $ mruby -e '[].each(1){}'  #=> no error
  ```

#### After this patch:

  ```
  $ mruby -e '[].each(1){}'  #=> ArgumentError: wrong number of arguments
  ```