### PR TITLE
Fix mruby-io test for mingw32

### DIFF
--- a/mrbgems/mruby-io/test/mruby_io_test.c
+++ b/mrbgems/mruby-io/test/mruby_io_test.c
@@ -18,7 +18,7 @@ typedef int mode_t;
 #define open _open
 #define close _close
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) || defined(__MINGW32__)
 #include <sys/stat.h>
 
 static int


### PR DESCRIPTION
Need `mkstemp()` implements.