### PR TITLE
Support bit flags for `IO.open`

### DIFF
--- a/mrbgems/mruby-io/include/mruby/ext/io.h
+++ b/mrbgems/mruby-io/include/mruby/ext/io.h
@@ -19,13 +19,31 @@ struct mrb_io {
                is_socket:1;
 };
 
-#define FMODE_READABLE             0x00000001
-#define FMODE_WRITABLE             0x00000002
-#define FMODE_READWRITE            (FMODE_READABLE|FMODE_WRITABLE)
-#define FMODE_BINMODE              0x00000004
-#define FMODE_APPEND               0x00000040
-#define FMODE_CREATE               0x00000080
-#define FMODE_TRUNC                0x00000800
+#define MRB_O_RDONLY            0x0000
+#define MRB_O_WRONLY            0x0001
+#define MRB_O_RDWR              0x0002
+#define MRB_O_ACCMODE           (MRB_O_RDONLY | MRB_O_WRONLY | MRB_O_RDWR)
+#define MRB_O_NONBLOCK          0x0004
+#define MRB_O_APPEND            0x0008
+#define MRB_O_SYNC              0x0010
+#define MRB_O_NOFOLLOW          0x0020
+#define MRB_O_CREAT             0x0040
+#define MRB_O_TRUNC             0x0080
+#define MRB_O_EXCL              0x0100
+#define MRB_O_NOCTTY            0x0200
+#define MRB_O_DIRECT            0x0400
+#define MRB_O_BINARY            0x0800
+#define MRB_O_SHARE_DELETE      0x1000
+#define MRB_O_TMPFILE           0x2000
+#define MRB_O_NOATIME           0x4000
+#define MRB_O_DSYNC             0x00008000 /* Ignored with MRB_INT16 and MRB_WITHOUT_FLOAT */
+#define MRB_O_RSYNC             0x00010000 /* Ignored with MRB_INT16 and MRB_WITHOUT_FLOAT */
+
+#define MRB_O_RDONLY_P(f)       ((mrb_bool)(((f) & MRB_O_ACCMODE) == MRB_O_RDONLY))
+#define MRB_O_WRONLY_P(f)       ((mrb_bool)(((f) & MRB_O_ACCMODE) == MRB_O_WRONLY))
+#define MRB_O_RDWR_P(f)         ((mrb_bool)(((f) & MRB_O_ACCMODE) == MRB_O_RDWR))
+#define MRB_O_READABLE_P(f)     ((mrb_bool)((((f) & MRB_O_ACCMODE) | 2) == 2))
+#define MRB_O_WRITABLE_P(f)     ((mrb_bool)(((((f) & MRB_O_ACCMODE) + 1) & 2) == 2))
 
 #define E_IO_ERROR                 (mrb_class_get(mrb, "IOError"))
 #define E_EOF_ERROR                (mrb_class_get(mrb, "EOFError"))

--- a/mrbgems/mruby-io/mrblib/file_constants.rb
+++ b/mrbgems/mruby-io/mrblib/file_constants.rb
@@ -1,21 +1,5 @@
 class File
   module Constants
-    RDONLY   = 0
-    WRONLY   = 1
-    RDWR     = 2
-    NONBLOCK = 4
-    APPEND   = 8
-
-    BINARY   = 0
-    SYNC     = 128
-    NOFOLLOW = 256
-    CREAT    = 512
-    TRUNC    = 1024
-    EXCL     = 2048
-
-    NOCTTY   = 131072
-    DSYNC    = 4194304
-
     FNM_SYSCASE  = 0
     FNM_NOESCAPE = 1
     FNM_PATHNAME = 2

--- a/mrbgems/mruby-io/src/file.c
+++ b/mrbgems/mruby-io/src/file.c
@@ -505,4 +505,22 @@ mrb_init_file(mrb_state *mrb)
 #endif
   mrb_define_const(mrb, cnst, "NULL", mrb_str_new_cstr(mrb, NULL_FILE));
 
+  mrb_define_const(mrb, cnst, "RDONLY", mrb_fixnum_value(MRB_O_RDONLY));
+  mrb_define_const(mrb, cnst, "WRONLY", mrb_fixnum_value(MRB_O_WRONLY));
+  mrb_define_const(mrb, cnst, "RDWR", mrb_fixnum_value(MRB_O_RDWR));
+  mrb_define_const(mrb, cnst, "APPEND", mrb_fixnum_value(MRB_O_APPEND));
+  mrb_define_const(mrb, cnst, "CREAT", mrb_fixnum_value(MRB_O_CREAT));
+  mrb_define_const(mrb, cnst, "EXCL", mrb_fixnum_value(MRB_O_EXCL));
+  mrb_define_const(mrb, cnst, "TRUNC", mrb_fixnum_value(MRB_O_TRUNC));
+  mrb_define_const(mrb, cnst, "NONBLOCK", mrb_fixnum_value(MRB_O_NONBLOCK));
+  mrb_define_const(mrb, cnst, "NOCTTY", mrb_fixnum_value(MRB_O_NOCTTY));
+  mrb_define_const(mrb, cnst, "BINARY", mrb_fixnum_value(MRB_O_BINARY));
+  mrb_define_const(mrb, cnst, "SHARE_DELETE", mrb_fixnum_value(MRB_O_SHARE_DELETE));
+  mrb_define_const(mrb, cnst, "SYNC", mrb_fixnum_value(MRB_O_SYNC));
+  mrb_define_const(mrb, cnst, "DSYNC", mrb_fixnum_value(MRB_O_DSYNC));
+  mrb_define_const(mrb, cnst, "RSYNC", mrb_fixnum_value(MRB_O_RSYNC));
+  mrb_define_const(mrb, cnst, "NOFOLLOW", mrb_fixnum_value(MRB_O_NOFOLLOW));
+  mrb_define_const(mrb, cnst, "NOATIME", mrb_fixnum_value(MRB_O_NOATIME));
+  mrb_define_const(mrb, cnst, "DIRECT", mrb_fixnum_value(MRB_O_DIRECT));
+  mrb_define_const(mrb, cnst, "TMPFILE", mrb_fixnum_value(MRB_O_TMPFILE));
 }

--- a/mrbgems/mruby-io/src/io.c
+++ b/mrbgems/mruby-io/src/io.c
@@ -37,6 +37,10 @@
   typedef long fsuseconds_t;
   typedef int fmode_t;
 
+  #ifndef O_TMPFILE
+    #define O_TMPFILE O_TEMPORARY
+  #endif
+
 #else
   #include <sys/wait.h>
   #include <unistd.h>
@@ -56,6 +60,12 @@ typedef mrb_int pid_t;
 #include <stdio.h>
 #include <string.h>
 
+#define OPEN_ACCESS_MODE_FLAGS (O_RDONLY | O_WRONLY | O_RDWR)
+#define OPEN_RDONLY_P(f)       ((mrb_bool)(((f) & OPEN_ACCESS_MODE_FLAGS) == O_RDONLY))
+#define OPEN_WRONLY_P(f)       ((mrb_bool)(((f) & OPEN_ACCESS_MODE_FLAGS) == O_WRONLY))
+#define OPEN_RDWR_P(f)         ((mrb_bool)(((f) & OPEN_ACCESS_MODE_FLAGS) == O_RDWR))
+#define OPEN_READABLE_P(f)     ((mrb_bool)(OPEN_RDONLY_P(f) || OPEN_RDWR_P(f)))
+#define OPEN_WRITABLE_P(f)     ((mrb_bool)(OPEN_WRONLY_P(f) || OPEN_RDWR_P(f)))
 
 static void mrb_io_free(mrb_state *mrb, void *ptr);
 struct mrb_data_type mrb_io_type = { "IO", mrb_io_free };
@@ -63,7 +73,7 @@ struct mrb_data_type mrb_io_type = { "IO", mrb_io_free };
 
 static struct mrb_io *io_get_open_fptr(mrb_state *mrb, mrb_value self);
 static int mrb_io_modestr_to_flags(mrb_state *mrb, const char *modestr);
-static int mrb_io_flags_to_modenum(mrb_state *mrb, int flags);
+static int mrb_io_mode_to_flags(mrb_state *mrb, mrb_value mode);
 static void fptr_finalize(mrb_state *mrb, struct mrb_io *fptr, int quiet);
 
 #if MRUBY_RELEASE_NO < 10000
@@ -113,30 +123,33 @@ io_set_process_status(mrb_state *mrb, pid_t pid, int status)
 static int
 mrb_io_modestr_to_flags(mrb_state *mrb, const char *mode)
 {
-  int flags = 0;
+  int flags;
   const char *m = mode;
 
   switch (*m++) {
     case 'r':
-      flags |= FMODE_READABLE;
+      flags = O_RDONLY;
       break;
     case 'w':
-      flags |= FMODE_WRITABLE | FMODE_CREATE | FMODE_TRUNC;
+      flags = O_WRONLY | O_CREAT | O_TRUNC;
       break;
     case 'a':
-      flags |= FMODE_WRITABLE | FMODE_APPEND | FMODE_CREATE;
+      flags = O_WRONLY | O_CREAT | O_APPEND;
       break;
     default:
       mrb_raisef(mrb, E_ARGUMENT_ERROR, "illegal access mode %s", mode);
+      flags = 0; /* not reached */
   }
 
   while (*m) {
     switch (*m++) {
       case 'b':
-        flags |= FMODE_BINMODE;
+#ifdef O_BINARY
+        flags |= O_BINARY;
+#endif
         break;
       case '+':
-        flags |= FMODE_READWRITE;
+        flags = (flags & ~OPEN_ACCESS_MODE_FLAGS) | O_RDWR;
         break;
       case ':':
         /* XXX: PASSTHROUGH*/
@@ -149,38 +162,72 @@ mrb_io_modestr_to_flags(mrb_state *mrb, const char *mode)
 }
 
 static int
-mrb_io_flags_to_modenum(mrb_state *mrb, int flags)
+mrb_io_mode_to_flags(mrb_state *mrb, mrb_value mode)
 {
-  int modenum = 0;
+  if (mrb_nil_p(mode)) {
+    return mrb_io_modestr_to_flags(mrb, "r");
+  }
+  else if (mrb_string_p(mode)) {
+    return mrb_io_modestr_to_flags(mrb, RSTRING_CSTR(mrb, mode));
+  }
+  else {
+    int flags = 0;
+    int flags0 = mrb_int(mrb, mode);
 
-  switch(flags & (FMODE_READABLE|FMODE_WRITABLE|FMODE_READWRITE)) {
-    case FMODE_READABLE:
-      modenum = O_RDONLY;
-      break;
-    case FMODE_WRITABLE:
-      modenum = O_WRONLY;
-      break;
-    case FMODE_READWRITE:
-      modenum = O_RDWR;
-      break;
-  }
+    switch (flags0 & MRB_O_ACCMODE) {
+      case MRB_O_RDONLY:
+        flags |= O_RDONLY;
+        break;
+      case MRB_O_WRONLY:
+        flags |= O_WRONLY;
+        break;
+      case MRB_O_RDWR:
+        flags |= O_RDWR;
+        break;
+      default:
+        mrb_raisef(mrb, E_ARGUMENT_ERROR, "illegal access mode %v", mode);
+    }
 
-  if (flags & FMODE_APPEND) {
-    modenum |= O_APPEND;
-  }
-  if (flags & FMODE_TRUNC) {
-    modenum |= O_TRUNC;
-  }
-  if (flags & FMODE_CREATE) {
-    modenum |= O_CREAT;
-  }
+    if (flags0 & MRB_O_APPEND)        flags |= O_APPEND;
+    if (flags0 & MRB_O_CREAT)         flags |= O_CREAT;
+    if (flags0 & MRB_O_EXCL)          flags |= O_EXCL;
+    if (flags0 & MRB_O_TRUNC)         flags |= O_TRUNC;
+#ifdef O_NONBLOCK
+    if (flags0 & MRB_O_NONBLOCK)      flags |= O_NONBLOCK;
+#endif
+#ifdef O_NOCTTY
+    if (flags0 & MRB_O_NOCTTY)        flags |= O_NOCTTY;
+#endif
 #ifdef O_BINARY
-  if (flags & FMODE_BINMODE) {
-    modenum |= O_BINARY;
-  }
+    if (flags0 & MRB_O_BINARY)        flags |= O_BINARY;
+#endif
+#ifdef O_SHARE_DELETE
+    if (flags0 & MRB_O_SHARE_DELETE)  flags |= O_SHARE_DELETE;
+#endif
+#ifdef O_SYNC
+    if (flags0 & MRB_O_SYNC)          flags |= O_SYNC;
+#endif
+#ifdef O_DSYNC
+    if (flags0 & MRB_O_DSYNC)         flags |= O_DSYNC;
+#endif
+#ifdef O_RSYNC
+    if (flags0 & MRB_O_RSYNC)         flags |= O_RSYNC;
+#endif
+#ifdef O_NOFOLLOW
+    if (flags0 & MRB_O_NOFOLLOW)      flags |= O_NOFOLLOW;
+#endif
+#ifdef O_NOATIME
+    if (flags0 & MRB_O_NOATIME)       flags |= O_NOATIME;
+#endif
+#ifdef O_DIRECT
+    if (flags0 & MRB_O_DIRECT)        flags |= O_DIRECT;
+#endif
+#ifdef O_TMPFILE
+    if (flags0 & MRB_O_TMPFILE)       flags |= O_TMPFILE;
 #endif
 
-  return modenum;
+    return flags;
+  }
 }
 
 static void
@@ -330,11 +377,11 @@ mrb_io_s_popen(mrb_state *mrb, mrb_value klass)
   ofd[0] = INVALID_HANDLE_VALUE;
   ofd[1] = INVALID_HANDLE_VALUE;
 
-  mrb_get_args(mrb, "S|SH", &cmd, &mode, &opt);
+  mrb_get_args(mrb, "S|oH", &cmd, &mode, &opt);
   io = mrb_obj_value(mrb_data_object_alloc(mrb, mrb_class_ptr(klass), NULL, &mrb_io_type));
 
   pname = RSTRING_CSTR(mrb, cmd);
-  flags = mrb_io_modestr_to_flags(mrb, RSTRING_CSTR(mrb, mode));
+  flags = mrb_io_mode_to_flags(mrb, mode);
 
   doexec = (strcmp("-", pname) != 0);
   opt_in = option_to_fd(mrb, opt, "in");
@@ -345,14 +392,14 @@ mrb_io_s_popen(mrb_state *mrb, mrb_value klass)
   saAttr.bInheritHandle = TRUE;
   saAttr.lpSecurityDescriptor = NULL;
 
-  if (flags & FMODE_READABLE) {
+  if (OPEN_READABLE_P(flags)) {
     if (!CreatePipe(&ofd[0], &ofd[1], &saAttr, 0)
         || !SetHandleInformation(ofd[0], HANDLE_FLAG_INHERIT, 0)) {
       mrb_sys_fail(mrb, "pipe");
     }
   }
 
-  if (flags & FMODE_WRITABLE) {
+  if (OPEN_WRITABLE_P(flags)) {
     if (!CreatePipe(&ifd[0], &ifd[1], &saAttr, 0)
         || !SetHandleInformation(ifd[1], HANDLE_FLAG_INHERIT, 0)) {
       mrb_sys_fail(mrb, "pipe");
@@ -366,11 +413,11 @@ mrb_io_s_popen(mrb_state *mrb, mrb_value klass)
     si.dwFlags |= STARTF_USESHOWWINDOW;
     si.wShowWindow = SW_HIDE;
     si.dwFlags |= STARTF_USESTDHANDLES;
-    if (flags & FMODE_READABLE) {
+    if (OPEN_READABLE_P(flags)) {
       si.hStdOutput = ofd[1];
       si.hStdError = ofd[1];
     }
-    if (flags & FMODE_WRITABLE) {
+    if (OPEN_WRITABLE_P(flags)) {
       si.hStdInput = ifd[0];
     }
     if (!CreateProcess(
@@ -394,8 +441,8 @@ mrb_io_s_popen(mrb_state *mrb, mrb_value klass)
   fptr->fd = _open_osfhandle((intptr_t)ofd[0], 0);
   fptr->fd2 = _open_osfhandle((intptr_t)ifd[1], 0);
   fptr->pid = pid;
-  fptr->readable = ((flags & FMODE_READABLE) != 0);
-  fptr->writable = ((flags & FMODE_WRITABLE) != 0);
+  fptr->readable = OPEN_READABLE_P(flags);
+  fptr->writable = OPEN_WRITABLE_P(flags);
   fptr->sync = 0;
 
   DATA_TYPE(io) = &mrb_io_type;
@@ -426,18 +473,18 @@ mrb_io_s_popen(mrb_state *mrb, mrb_value klass)
   int saved_errno;
   int opt_in, opt_out, opt_err;
 
-  mrb_get_args(mrb, "S|SH", &cmd, &mode, &opt);
+  mrb_get_args(mrb, "S|oH", &cmd, &mode, &opt);
   io = mrb_obj_value(mrb_data_object_alloc(mrb, mrb_class_ptr(klass), NULL, &mrb_io_type));
 
   pname = RSTRING_CSTR(mrb, cmd);
-  flags = mrb_io_modestr_to_flags(mrb, RSTRING_CSTR(mrb, mode));
+  flags = mrb_io_mode_to_flags(mrb, mode);
 
   doexec = (strcmp("-", pname) != 0);
   opt_in = option_to_fd(mrb, opt, "in");
   opt_out = option_to_fd(mrb, opt, "out");
   opt_err = option_to_fd(mrb, opt, "err");
 
-  if (flags & FMODE_READABLE) {
+  if (OPEN_READABLE_P(flags)) {
     if (pipe(pr) == -1) {
       mrb_sys_fail(mrb, "pipe");
     }
@@ -445,7 +492,7 @@ mrb_io_s_popen(mrb_state *mrb, mrb_value klass)
     mrb_fd_cloexec(mrb, pr[1]);
   }
 
-  if (flags & FMODE_WRITABLE) {
+  if (OPEN_WRITABLE_P(flags)) {
     if (pipe(pw) == -1) {
       if (pr[0] != -1) close(pr[0]);
       if (pr[1] != -1) close(pr[1]);
@@ -474,14 +521,14 @@ mrb_io_s_popen(mrb_state *mrb, mrb_value klass)
       if (opt_err != -1) {
         dup2(opt_err, 2);
       }
-      if (flags & FMODE_READABLE) {
+      if (OPEN_READABLE_P(flags)) {
         close(pr[0]);
         if (pr[1] != 1) {
           dup2(pr[1], 1);
           close(pr[1]);
         }
       }
-      if (flags & FMODE_WRITABLE) {
+      if (OPEN_WRITABLE_P(flags)) {
         close(pw[1]);
         if (pw[0] != 0) {
           dup2(pw[0], 0);
@@ -500,12 +547,12 @@ mrb_io_s_popen(mrb_state *mrb, mrb_value klass)
       break;
 
     default: /* parent */
-      if ((flags & FMODE_READABLE) && (flags & FMODE_WRITABLE)) {
+      if (OPEN_RDWR_P(flags)) {
         close(pr[1]);
         fd = pr[0];
         close(pw[0]);
         write_fd = pw[1];
-      } else if (flags & FMODE_READABLE) {
+      } else if (OPEN_RDONLY_P(flags)) {
         close(pr[1]);
         fd = pr[0];
       } else {
@@ -519,8 +566,8 @@ mrb_io_s_popen(mrb_state *mrb, mrb_value klass)
       fptr->fd = fd;
       fptr->fd2 = write_fd;
       fptr->pid = pid;
-      fptr->readable = ((flags & FMODE_READABLE) != 0);
-      fptr->writable = ((flags & FMODE_WRITABLE) != 0);
+      fptr->readable = OPEN_READABLE_P(flags);
+      fptr->writable = OPEN_WRITABLE_P(flags);
       fptr->sync = 0;
 
       DATA_TYPE(io) = &mrb_io_type;
@@ -530,11 +577,11 @@ mrb_io_s_popen(mrb_state *mrb, mrb_value klass)
 
     case -1: /* error */
       saved_errno = errno;
-      if (flags & FMODE_READABLE) {
+      if (OPEN_READABLE_P(flags)) {
         close(pr[0]);
         close(pr[1]);
       }
-      if (flags & FMODE_WRITABLE) {
+      if (OPEN_WRITABLE_P(flags)) {
         close(pw[0]);
         close(pw[1]);
       }
@@ -619,7 +666,7 @@ mrb_io_initialize(mrb_state *mrb, mrb_value io)
 
   mode = opt = mrb_nil_value();
 
-  mrb_get_args(mrb, "i|So", &fd, &mode, &opt);
+  mrb_get_args(mrb, "i|oo", &fd, &mode, &opt);
   if (mrb_nil_p(mode)) {
     mode = mrb_str_new_cstr(mrb, "r");
   }
@@ -627,7 +674,7 @@ mrb_io_initialize(mrb_state *mrb, mrb_value io)
     opt = mrb_hash_new(mrb);
   }
 
-  flags = mrb_io_modestr_to_flags(mrb, RSTRING_CSTR(mrb, mode));
+  flags = mrb_io_mode_to_flags(mrb, mode);
 
   mrb_iv_set(mrb, io, mrb_intern_cstr(mrb, "@buf"), mrb_str_new_cstr(mrb, ""));
 
@@ -642,8 +689,8 @@ mrb_io_initialize(mrb_state *mrb, mrb_value io)
   DATA_PTR(io) = fptr;
 
   fptr->fd = (int)fd;
-  fptr->readable = ((flags & FMODE_READABLE) != 0);
-  fptr->writable = ((flags & FMODE_WRITABLE) != 0);
+  fptr->readable = OPEN_READABLE_P(flags);
+  fptr->writable = OPEN_WRITABLE_P(flags);
   fptr->sync = 0;
   return io;
 }
@@ -798,20 +845,16 @@ mrb_io_s_sysopen(mrb_state *mrb, mrb_value klass)
   mrb_value mode = mrb_nil_value();
   mrb_int fd, perm = -1;
   const char *pat;
-  int flags, modenum;
+  int flags;
 
-  mrb_get_args(mrb, "S|Si", &path, &mode, &perm);
-  if (mrb_nil_p(mode)) {
-    mode = mrb_str_new_cstr(mrb, "r");
-  }
+  mrb_get_args(mrb, "S|oi", &path, &mode, &perm);
   if (perm < 0) {
     perm = 0666;
   }
 
   pat = RSTRING_CSTR(mrb, path);
-  flags = mrb_io_modestr_to_flags(mrb, RSTRING_CSTR(mrb, mode));
-  modenum = mrb_io_flags_to_modenum(mrb, flags);
-  fd = mrb_cloexec_open(mrb, pat, modenum, perm);
+  flags = mrb_io_mode_to_flags(mrb, mode);
+  fd = mrb_cloexec_open(mrb, pat, flags, perm);
   return mrb_fixnum_value(fd);
 }
 


### PR DESCRIPTION
Note that this bit flags are not compatible with the native flags defined in `#include <fcntl.h>`.