### PR TITLE
Remove location info from `Exception#inspect`

### DIFF
--- a/include/mruby/class.h
+++ b/include/mruby/class.h
@@ -90,6 +90,7 @@ mrb_value mrb_instance_new(mrb_state *mrb, mrb_value cv);
 void mrb_class_name_class(mrb_state*, struct RClass*, struct RClass*, mrb_sym);
 mrb_bool mrb_const_name_p(mrb_state*, const char*, mrb_int);
 mrb_value mrb_class_find_path(mrb_state*, struct RClass*);
+mrb_value mrb_mod_to_s(mrb_state*, mrb_value);
 void mrb_gc_mark_mt(mrb_state*, struct RClass*);
 size_t mrb_gc_mark_mt_size(mrb_state*, struct RClass*);
 void mrb_gc_free_mt(mrb_state*, struct RClass*);

--- a/src/string.c
+++ b/src/string.c
@@ -1095,7 +1095,6 @@ mrb_str_equal_m(mrb_state *mrb, mrb_value str1)
   return mrb_bool_value(mrb_str_equal(mrb, str1, str2));
 }
 /* ---------------------------------- */
-mrb_value mrb_mod_to_s(mrb_state *mrb, mrb_value klass);
 
 MRB_API mrb_value
 mrb_str_to_str(mrb_state *mrb, mrb_value str)

--- a/test/t/exception.rb
+++ b/test/t/exception.rb
@@ -352,8 +352,10 @@ assert('Exception 19') do
   assert_equal [true, true], Class4Exception19.new.a
 end
 
-assert('Exception#inspect without message') do
+assert('Exception#inspect') do
   assert_equal "Exception", Exception.new.inspect
+  assert_equal "Exception", Exception.new("").inspect
+  assert_equal "error! (Exception)", Exception.new("error!").inspect
 end
 
 assert('Exception#backtrace') do


### PR DESCRIPTION
Because location info (file name and line number) is kept in the backtrace,
it should not be kept in the result of `inspect` (and the exception object
itself), I think.

### Example

  ```ruby
  # example.rb
  begin
    raise "err"
  rescue => e
    p e
  end
  ```

#### Before this patch:

  ```
  $ bin/mruby example.rb
  example.rb:2: err (RuntimeError)
  ```

#### After this patch:

  ```
  $ bin/mruby example.rb
  err (RuntimeError)
  ```