### PR TITLE
Refine output of `mrb_print_error()`

### DIFF
--- a/src/error.c
+++ b/src/error.c
@@ -88,8 +88,8 @@ exc_exception(mrb_state *mrb, mrb_value self)
  * no message is set).
  */
 
-static mrb_value
-exc_to_s(mrb_state *mrb, mrb_value exc)
+mrb_value
+mrb_exc_to_s(mrb_state *mrb, mrb_value exc)
 {
   mrb_value mesg = mrb_attr_get(mrb, exc, mrb_intern_lit(mrb, "mesg"));
   struct RObject *p;
@@ -596,7 +596,7 @@ mrb_init_exception(mrb_state *mrb)
   mrb_define_class_method(mrb, exception, "exception", mrb_instance_new,  MRB_ARGS_OPT(1));
   mrb_define_method(mrb, exception, "exception",       exc_exception,     MRB_ARGS_OPT(1));
   mrb_define_method(mrb, exception, "initialize",      exc_initialize,    MRB_ARGS_OPT(1));
-  mrb_define_method(mrb, exception, "to_s",            exc_to_s,          MRB_ARGS_NONE());
+  mrb_define_method(mrb, exception, "to_s",            mrb_exc_to_s,      MRB_ARGS_NONE());
   mrb_define_method(mrb, exception, "message",         exc_message,       MRB_ARGS_NONE());
   mrb_define_method(mrb, exception, "inspect",         exc_inspect,       MRB_ARGS_NONE());
   mrb_define_method(mrb, exception, "backtrace",       mrb_exc_backtrace, MRB_ARGS_NONE());

--- a/src/print.c
+++ b/src/print.c
@@ -31,7 +31,6 @@ MRB_API void
 mrb_print_error(mrb_state *mrb)
 {
   mrb_print_backtrace(mrb);
-  printstr(mrb_funcall(mrb, mrb_obj_value(mrb->exc), "inspect", 0), stderr);
 }
 
 MRB_API void


### PR DESCRIPTION
The following improvements are made according to Ruby's behavior:

- Match location number to index.
- Remove duplicate most recent call output.
- Fix that first call is not output when array (unpacked) backtrace.

### Example

  ```ruby
  def a; raise "error!" end
  def b; a end
  begin
    b
  rescue => e
    e.backtrace if ARGV[0] == "unpack"  # unpack backtrace
    raise e
  end
  ```

#### Before this patch:

  ```console
  $ bin/mruby example.rb unpack
  trace (most recent call last):
    [0] example.rb:2:in b
    [1] example.rb:1:in a
  example.rb:1: error! (RuntimeError)
  ```

#### After this patch:

  ```console
  $ bin/mruby example.rb unpack
  trace (most recent call last):
    [2] example.rb:4
    [1] example.rb:2:in b
  example.rb:1:in a: error! (RuntimeError)
  ```