### PR TITLE
`_0` is not numbered parameter

### DIFF
--- a/test/t/syntax.rb
+++ b/test/t/syntax.rb
@@ -672,11 +672,15 @@ assert 'keyword arguments' do
   assert_equal([:a, nil, :c], m(a: :a, c: :c))
 end
 
-
 assert('numbered parameters') do
   assert_equal(15, [1,2,3,4,5].reduce {_1+_2})
   assert_equal(3, ->{_1+_2}.call(1,2))
   assert_equal(4, ->(a=->{_1}){a}.call.call(4))
   assert_equal(5, -> a: ->{_1} {a}.call.call(5))
   assert_equal(45, Proc.new do _1 + _2 + _3 + _4 + _5 + _6 + _7 + _8 + _9 end.call(*[1, 2, 3, 4, 5, 6, 7, 8, 9]))
+end
+
+assert('_0 is not numbered parameter') do
+  _0 = :l
+  assert_equal(:l, ->{_0}.call)
 end


### PR DESCRIPTION
#### Before this patch:

  ```console
  $ bin/mruby rb -e '_0=:l; p ->{_0}.()'
  -e:1:13: _0 is not available
  -e:1:13: syntax error, unexpected $end, expecting '}'
  ```

#### After this patch (same as Ruby):

  ```console
  $ bin/mruby rb -e '_0=:l; p ->{_0}.()'
  :l
  ```