### PR TITLE
Use `exec` instead of `system` in `minirake` for exit status

### DIFF
--- a/minirake
+++ b/minirake
@@ -1,2 +1,2 @@
 #! /usr/bin/env ruby
-system "rake", *ARGV
+exec "rake", *ARGV


### PR DESCRIPTION
#### Before this patch:

  ```console
  $ ./minirake --foo; echo $?
  invalid option: --foo
  0
  ```

#### After this patch:

  ```console
  $ ./minirake --foo; echo $?
  invalid option: --foo
  1
  ```