### PR TITLE
Refine `.travis.yml`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,6 @@ matrix:
     - os: osx
       osx_image: xcode7.1
 
-addons:
-  apt:
-    packages:
-      - gperf
-
 env:
   - MRUBY_CONFIG=travis_config.rb
-script: "./minirake -j4 all test"
+script: "rake -m -E '$stdout.sync=true' all test"


### PR DESCRIPTION
* Use `rake` instead of `minirake`.
* Remove `gperf` configuration.

Execution time seems to be reduced by about 15%.