### PR TITLE
Use `git checkout` instead of `git reset`

### DIFF
--- a/lib/mruby/build/command.rb
+++ b/lib/mruby/build/command.rb
@@ -302,12 +302,12 @@ module MRuby
     end
 
     def run_checkout(dir, checksum_hash)
-      _pp "GIT CHECKOUT", checksum_hash
+      _pp "GIT CHECKOUT", dir, checksum_hash
       _run checkout_options, { :checksum_hash => checksum_hash, :repo_dir => shellquote(dir) }
     end
 
     def run_reset_hard(dir, checksum_hash)
-      _pp "GIT RESET", checksum_hash
+      _pp "GIT RESET", dir, checksum_hash
       _run reset_options, { :checksum_hash => checksum_hash, :repo_dir => shellquote(dir) }
     end
 

--- a/lib/mruby/build/command.rb
+++ b/lib/mruby/build/command.rb
@@ -279,7 +279,7 @@ module MRuby
 
   class Command::Git < Command
     attr_accessor :flags
-    attr_accessor :clone_options, :pull_options, :checkout_options, :reset_options
+    attr_accessor :clone_options, :pull_options, :checkout_options, :checkout_detach_options, :reset_options
 
     def initialize(build)
       super
@@ -288,6 +288,7 @@ module MRuby
       @clone_options = "clone %{flags} %{url} %{dir}"
       @pull_options = "--git-dir %{repo_dir}/.git --work-tree %{repo_dir} pull"
       @checkout_options = "--git-dir %{repo_dir}/.git --work-tree %{repo_dir} checkout %{checksum_hash}"
+      @checkout_detach_options = "--git-dir %{repo_dir}/.git --work-tree %{repo_dir} checkout --detach %{checksum_hash}"
       @reset_options = "--git-dir %{repo_dir}/.git --work-tree %{repo_dir} reset %{checksum_hash}"
     end
 
@@ -304,6 +305,11 @@ module MRuby
     def run_checkout(dir, checksum_hash)
       _pp "GIT CHECKOUT", dir, checksum_hash
       _run checkout_options, { :checksum_hash => checksum_hash, :repo_dir => shellquote(dir) }
+    end
+
+    def run_checkout_detach(dir, checksum_hash)
+      _pp "GIT CHECKOUT DETACH", dir, checksum_hash
+      _run checkout_detach_options, { :checksum_hash => checksum_hash, :repo_dir => shellquote(dir) }
     end
 
     def run_reset_hard(dir, checksum_hash)

--- a/lib/mruby/build/load_gems.rb
+++ b/lib/mruby/build/load_gems.rb
@@ -86,14 +86,13 @@ module MRuby
 
         if File.exist?(gemdir)
           if $pull_gems
-            git.run_pull gemdir, url
             # Jump to the top of the branch
-            git.run_checkout(gemdir, branch)
-            git.run_reset_hard gemdir, "origin/#{branch}"
+            git.run_checkout gemdir, branch
+            git.run_pull gemdir, url
           elsif params[:checksum_hash]
-            git.run_reset_hard(gemdir, params[:checksum_hash])
+            git.run_checkout_detach gemdir, params[:checksum_hash]
           elsif lock
-            git.run_reset_hard(gemdir, lock['commit'])
+            git.run_checkout_detach gemdir, lock['commit']
           end
         else
           options = [params[:options]] || []
@@ -105,9 +104,9 @@ module MRuby
 
           # Jump to the specified commit
           if params[:checksum_hash]
-            git.run_reset_hard gemdir, params[:checksum_hash]
+            git.run_checkout_detach gemdir, params[:checksum_hash]
           elsif lock
-            git.run_reset_hard gemdir, lock['commit']
+            git.run_checkout_detach gemdir, lock['commit']
           end
         end
 


### PR DESCRIPTION
With this change, if the checkout fails, it will stop with an error.

The purpose is to avoid deleting working branch history when developing gem.

Also, make sure that directories are also displayed during `git reset` and `git checkout`.

----

Removing the `.lock` file every time, or calling the `MRuby::Build#disable_lock` method can avoid losing the working branch, but I think it's better to raise an error.

This suggestion will be withdrawn if there are other good practices.
