### PR TITLE
Parallelize compilation only on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ matrix:
 
 env:
   - MRUBY_CONFIG=travis_config.rb
-script: "rake -m -E '$stdout.sync=true' all test"
+script: "rake -m && rake test"


### PR DESCRIPTION
Parallel execution of tests makes log difficult to see due to mixing.