### PR TITLE
Add double quotes for cygwin filenames #4904

### DIFF
--- a/lib/mruby/build.rb
+++ b/lib/mruby/build.rb
@@ -280,7 +280,7 @@ EOS
       if name.is_a?(Array)
         name.flatten.map { |n| cygwin_filename(n) }
       else
-        `cygpath -w "#{filename(name)}"`.strip
+        '"%s"' % `cygpath -w "#{filename(name)}"`.strip
       end
     end
 


### PR DESCRIPTION
Double quotes for filenames was removed from both filename and cygwin_filename by the commit  b7bc03aa18f3cc5eac0bbd6690e24062df9fe837.
However cygwin needs it to recognize windows style file path.
