### PR TITLE
Enable `MRB_GC_STRESS` test on CI

### DIFF
--- a/appveyor_config.rb
+++ b/appveyor_config.rb
@@ -1,23 +1,10 @@
-MRuby::Build.new('debug') do |conf|
-  toolchain :visualcpp
-  enable_debug
-
-  # include all core GEMs
-  conf.gembox 'full-core'
-  conf.compilers.each do |c|
-    c.defines += %w(MRB_GC_STRESS MRB_GC_FIXED_ARENA MRB_METHOD_CACHE)
-  end
-
-  build_mrbc_exec
-end
-
 MRuby::Build.new('full-debug') do |conf|
   toolchain :visualcpp
   enable_debug
 
   # include all core GEMs
   conf.gembox 'full-core'
-  conf.cc.defines += %w(MRB_ENABLE_DEBUG_HOOK)
+  conf.cc.defines += %w(MRB_GC_STRESS MRB_METHOD_CACHE MRB_ENABLE_DEBUG_HOOK)
 
   conf.enable_test
 end

--- a/travis_config.rb
+++ b/travis_config.rb
@@ -1,24 +1,11 @@
-MRuby::Build.new('debug') do |conf|
-  toolchain :gcc
-  enable_debug
-
-  # include all core GEMs
-  conf.gembox 'full-core'
-  conf.cc.flags += %w(-Werror=declaration-after-statement)
-  conf.compilers.each do |c|
-    c.defines += %w(MRB_GC_STRESS MRB_GC_FIXED_ARENA MRB_METHOD_CACHE)
-  end
-
-  build_mrbc_exec
-end
-
 MRuby::Build.new('full-debug') do |conf|
   toolchain :gcc
   enable_debug
 
   # include all core GEMs
   conf.gembox 'full-core'
-  conf.cc.defines += %w(MRB_ENABLE_DEBUG_HOOK)
+  conf.cc.flags += %w(-Werror=declaration-after-statement)
+  conf.cc.defines += %w(MRB_GC_STRESS MRB_METHOD_CACHE MRB_ENABLE_DEBUG_HOOK)
 
   conf.enable_test
 end


### PR DESCRIPTION
The `debug` build target (`MRB_GC_STRESS` is enabled) on CI have been
compiled but not tested so far. However, I think testing with
`MRB_GC_STRESS` is effective (in fact, I found #4907 bug).

Therefore, I integrated `debug` and `full-debug` build targets to enable
`MRB_GC_STRESS` testing. Testing with `MRB_GC_STRESS` takes a little time,
but compiling takes more time, so CI execution time does not increase due to
decrease of build target.