### PR TITLE
Use Rake DSL instead of commands of `FileUtils`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -33,10 +33,9 @@ load "#{MRUBY_ROOT}/tasks/gitlab.rake"
 load "#{MRUBY_ROOT}/tasks/doc.rake"
 
 def install_D(src, dst)
-  opts = { :verbose => $verbose }
-  FileUtils.rm_f dst, opts
-  FileUtils.mkdir_p File.dirname(dst), opts
-  FileUtils.cp src, dst, opts
+  rm_f dst
+  mkdir_p File.dirname(dst)
+  cp src, dst
 end
 
 ##############################
@@ -144,16 +143,16 @@ end
 desc "clean all built and in-repo installed artifacts"
 task :clean do
   MRuby.each_target do |t|
-    FileUtils.rm_rf t.build_dir, { :verbose => $verbose }
+    rm_rf t.build_dir
   end
-  FileUtils.rm_f depfiles, { :verbose => $verbose }
+  rm_f depfiles
   puts "Cleaned up target build folder"
 end
 
 desc "clean everything!"
 task :deep_clean => ["clean", "clean_doc"] do
   MRuby.each_target do |t|
-    FileUtils.rm_rf t.gem_clone_dir, { :verbose => $verbose }
+    rm_rf t.gem_clone_dir
   end
   puts "Cleaned up mrbgems build folder"
 end

--- a/lib/mruby/build.rb
+++ b/lib/mruby/build.rb
@@ -173,7 +173,7 @@ module MRuby
       obj = objfile(cxx_src) if obj.nil?
 
       file cxx_src => [src, __FILE__] do |t|
-        FileUtils.mkdir_p File.dirname t.name
+        mkdir_p File.dirname t.name
         IO.write t.name, <<EOS
 #define __STDC_CONSTANT_MACROS
 #define __STDC_LIMIT_MACROS

--- a/lib/mruby/build/command.rb
+++ b/lib/mruby/build/command.rb
@@ -89,7 +89,7 @@ module MRuby
     end
 
     def run(outfile, infile, _defines=[], _include_paths=[], _flags=[])
-      FileUtils.mkdir_p File.dirname(outfile)
+      mkdir_p File.dirname(outfile)
       _pp "CC", infile.relative_path, outfile.relative_path
       if MRUBY_BUILD_HOST_IS_CYGWIN
         _run compile_options, { :flags => all_flags(_defines, _include_paths, _flags),
@@ -205,7 +205,7 @@ module MRuby
     end
 
     def run(outfile, objfiles, _libraries=[], _library_paths=[], _flags=[], _flags_before_libraries=[], _flags_after_libraries=[])
-      FileUtils.mkdir_p File.dirname(outfile)
+      mkdir_p File.dirname(outfile)
       library_flags = [libraries, _libraries].flatten.map { |d| option_library % d }
 
       _pp "LD", outfile.relative_path
@@ -235,7 +235,7 @@ module MRuby
     end
 
     def run(outfile, objfiles)
-      FileUtils.mkdir_p File.dirname(outfile)
+      mkdir_p File.dirname(outfile)
       _pp "AR", outfile.relative_path
       if MRUBY_BUILD_HOST_IS_CYGWIN
         _run archive_options, { :outfile => cygwin_filename(outfile), :objs => cygwin_filename(objfiles).join(' ') }
@@ -255,7 +255,7 @@ module MRuby
     end
 
     def run(outfile, infile)
-      FileUtils.mkdir_p File.dirname(outfile)
+      mkdir_p File.dirname(outfile)
       _pp "YACC", infile.relative_path, outfile.relative_path
       _run compile_options, { :outfile => filename(outfile) , :infile => filename(infile) }
     end
@@ -271,7 +271,7 @@ module MRuby
     end
 
     def run(outfile, infile)
-      FileUtils.mkdir_p File.dirname(outfile)
+      mkdir_p File.dirname(outfile)
       _pp "GPERF", infile.relative_path, outfile.relative_path
       _run compile_options, { :outfile => filename(outfile) , :infile => filename(infile) }
     end

--- a/lib/mruby/build/load_gems.rb
+++ b/lib/mruby/build/load_gems.rb
@@ -57,7 +57,7 @@ module MRuby
         if File.exist? mgem_list_dir
           git.run_pull mgem_list_dir, mgem_list_url if $pull_gems
         else
-          FileUtils.mkdir_p mgem_list_dir
+          mkdir_p mgem_list_dir
           git.run_clone mgem_list_dir, mgem_list_url, "--depth 1"
         end
 
@@ -99,7 +99,7 @@ module MRuby
           options << "--recursive"
           options << "--branch \"#{branch}\""
           options << "--depth 1" unless params[:checksum_hash]
-          FileUtils.mkdir_p "#{gem_clone_dir}"
+          mkdir_p "#{gem_clone_dir}"
           git.run_clone gemdir, url, options
 
           # Jump to the specified commit

--- a/lib/mruby/gem.rb
+++ b/lib/mruby/gem.rb
@@ -157,7 +157,7 @@ module MRuby
       def define_gem_init_builder
         file objfile("#{build_dir}/gem_init") => [ "#{build_dir}/gem_init.c", File.join(dir, "mrbgem.rake") ]
         file "#{build_dir}/gem_init.c" => [build.mrbcfile, __FILE__] + [rbfiles].flatten do |t|
-          FileUtils.mkdir_p build_dir
+          mkdir_p build_dir
           generate_gem_init("#{build_dir}/gem_init.c")
         end
       end

--- a/mrbgems/mruby-bin-config/mrbgem.rake
+++ b/mrbgems/mruby-bin-config/mrbgem.rake
@@ -17,7 +17,7 @@ unless MRuby::Build.current.kind_of?(MRuby::CrossBuild)
       }]
       tmplt = File.read(tmplt_path)
       File.write(t.name, tmplt.gsub(/(#{Regexp.union(*config.keys)})\b/, config))
-      FileUtils.chmod(0755, t.name)
+      chmod(0755, t.name)
     end
   end
 end

--- a/mrbgems/mruby-compiler/mrbgem.rake
+++ b/mrbgems/mruby-compiler/mrbgem.rake
@@ -26,7 +26,7 @@ MRuby::Gem::Specification.new 'mruby-compiler' do |spec|
 
   # Parser
   file "#{current_build_dir}/core/y.tab.c" => ["#{current_dir}/core/parse.y", lex_def] do |t|
-    FileUtils.mkdir_p File.dirname t.name
+    mkdir_p File.dirname t.name
     yacc.run t.name, t.prerequisites.first
   end
 

--- a/mrbgems/mruby-test/mrbgem.rake
+++ b/mrbgems/mruby-test/mrbgem.rake
@@ -40,7 +40,7 @@ MRuby::Gem::Specification.new('mruby-test') do |spec|
 
     file test_rbobj => g.test_rbireps
     file g.test_rbireps => [g.test_rbfiles, build.mrbcfile].flatten do |t|
-      FileUtils.mkdir_p File.dirname(t.name)
+      mkdir_p File.dirname(t.name)
       open(t.name, 'w') do |f|
         g.print_gem_test_header(f)
         test_preload = g.test_preload and [g.dir, MRUBY_ROOT].map {|dir|
@@ -152,12 +152,12 @@ MRuby::Gem::Specification.new('mruby-test') do |spec|
   active_gem_list = if File.exist? active_gems_path
                       File.read active_gems_path
                     else
-                      FileUtils.mkdir_p File.dirname(active_gems_path)
+                      mkdir_p File.dirname(active_gems_path)
                       nil
                     end
   current_gem_list = build.gems.map(&:name).join("\n")
   task active_gems_path do |_t|
-    FileUtils.mkdir_p File.dirname(active_gems_path)
+    mkdir_p File.dirname(active_gems_path)
     File.write active_gems_path, current_gem_list
   end
   file clib => active_gems_path if active_gem_list != current_gem_list
@@ -165,7 +165,7 @@ MRuby::Gem::Specification.new('mruby-test') do |spec|
   file mlib => clib
   file clib => [build.mrbcfile, __FILE__] do |_t|
     _pp "GEN", "*.rb", "#{clib.relative_path}"
-    FileUtils.mkdir_p File.dirname(clib)
+    mkdir_p File.dirname(clib)
     open(clib, 'w') do |f|
       f.puts %Q[/*]
       f.puts %Q[ * This file contains a list of all]

--- a/mrblib/mrblib.rake
+++ b/mrblib/mrblib.rake
@@ -8,7 +8,7 @@ MRuby.each_target do
   file objfile("#{current_build_dir}/mrblib") => "#{current_build_dir}/mrblib.c"
   file "#{current_build_dir}/mrblib.c" => [mrbcfile, __FILE__] + Dir.glob("#{current_dir}/*.rb").sort do |t|
     _, _, *rbfiles = t.prerequisites
-    FileUtils.mkdir_p File.dirname(t.name)
+    mkdir_p File.dirname(t.name)
     open(t.name, 'w') do |f|
       _pp "GEN", "*.rb", "#{t.name.relative_path}"
       f.puts File.read("#{current_dir}/init_mrblib.c")

--- a/tasks/doc.rake
+++ b/tasks/doc.rake
@@ -25,12 +25,12 @@ end
 
 desc 'clean all built docs'
 task :clean_api_doc do
-  FileUtils.rm_rf 'doc/api'
+  rm_rf 'doc/api'
 end
 
 desc 'clean all built docs'
 task :clean_capi_doc do
-  FileUtils.rm_rf 'doc/capi'
+  rm_rf 'doc/capi'
 end
 
 desc 'clean all built docs'

--- a/tasks/libmruby.rake
+++ b/tasks/libmruby.rake
@@ -4,7 +4,7 @@ MRuby.each_target do
   end
 
   file "#{build_dir}/lib/libmruby.flags.mak" => [__FILE__, libmruby_static] do |t|
-    FileUtils.mkdir_p File.dirname t.name
+    mkdir_p File.dirname t.name
     open(t.name, 'w') do |f|
       f.puts "MRUBY_CFLAGS = #{cc.all_flags}"
 

--- a/tasks/mrbgems.rake
+++ b/tasks/mrbgems.rake
@@ -8,7 +8,7 @@ MRuby.each_target do
     self.libmruby_objs << objfile("#{build_dir}/mrbgems/gem_init")
     file objfile("#{build_dir}/mrbgems/gem_init") => ["#{build_dir}/mrbgems/gem_init.c", "#{build_dir}/LEGAL"]
     file "#{build_dir}/mrbgems/gem_init.c" => [MRUBY_CONFIG, __FILE__] do |t|
-      FileUtils.mkdir_p "#{build_dir}/mrbgems"
+      mkdir_p "#{build_dir}/mrbgems"
       open(t.name, 'w') do |f|
         gem_func_gems = gems.select { |g| g.generate_functions }
         gem_func_decls = gem_func_gems.each_with_object('') do |g, s|
@@ -53,7 +53,7 @@ MRuby.each_target do
 
   # legal documents
   file "#{build_dir}/LEGAL" => [MRUBY_CONFIG, __FILE__] do |t|
-    FileUtils.mkdir_p File.dirname t.name
+    mkdir_p File.dirname t.name
     open(t.name, 'w+') do |f|
      f.puts <<LEGAL
 Copyright (c) #{Time.now.year} mruby developers


### PR DESCRIPTION
- Respect `--verbose(-v)` and `--dry-run(-n)` options.
- Silence warnings to keyword arguments on Ruby 2.7.