### PR TITLE
Use `Rake.verbose` instead of `$verbose` and `$pp_show` in build scripts

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,7 @@ MRUBY_ROOT = File.dirname(File.expand_path(__FILE__))
 MRUBY_BUILD_HOST_IS_CYGWIN = RUBY_PLATFORM.include?('cygwin')
 MRUBY_BUILD_HOST_IS_OPENBSD = RUBY_PLATFORM.include?('openbsd')
 
-$verbose = Rake.verbose == true
+Rake.verbose(false) if Rake.verbose == Rake::DSL::DEFAULT
 
 $LOAD_PATH << File.join(MRUBY_ROOT, "lib")
 

--- a/lib/mruby-core-ext.rb
+++ b/lib/mruby-core-ext.rb
@@ -20,27 +20,8 @@ class String
   end
 end
 
-$pp_show = true
-
-if $verbose.nil?
-  if Rake.respond_to?(:verbose) && !Rake.verbose.nil?
-    if Rake.verbose.class == TrueClass
-      # verbose message logging
-      $pp_show = false
-    else
-      $pp_show = true
-      Rake.verbose(false)
-    end
-  else
-    # could not identify rake version
-    $pp_show = false
-  end
-else
-  $pp_show = false if $verbose
-end
-
 def _pp(cmd, src, tgt=nil, options={})
-  return unless $pp_show
+  return if Rake.verbose
 
   width = 5
   template = options[:indent] ? "%#{width*options[:indent]}s %s %s" : "%-#{width}s %s %s"

--- a/lib/mruby/build.rb
+++ b/lib/mruby/build.rb
@@ -320,7 +320,7 @@ EOS
     end
 
     def verbose_flag
-      $verbose ? ' -v' : ''
+      Rake.verbose ? ' -v' : ''
     end
 
     def run_test
@@ -386,7 +386,7 @@ EOS
     end
 
     def run_test
-      @test_runner.runner_options << ' -v' if $verbose
+      @test_runner.runner_options << verbose_flag
       mrbtest = exefile("#{build_dir}/bin/mrbtest")
       if (@test_runner.command == nil)
         puts "You should run #{mrbtest} on target device."

--- a/lib/mruby/build/command.rb
+++ b/lib/mruby/build/command.rb
@@ -342,7 +342,7 @@ module MRuby
         _pp "MRBC", f.relative_path, nil, :indent => 2
       end
       cmd = "#{filename @command} #{@compile_options % {:funcname => funcname}} #{filename(infiles).join(' ')}"
-      print("#{cmd}\n") if $verbose
+      puts cmd if Rake.verbose
       IO.popen(cmd, 'r+') do |io|
         out.puts io.read
       end


### PR DESCRIPTION
The incompatibility that the commands of `FileUtils` origin output verbose
by default due to the changes in d8a5163b and 26e6e75b is also fixed.