### PR TITLE
Use `rake` instead of `minirake` in `.gitlab-ci.yml`

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,7 +11,7 @@ pretest:
     CC: gcc-4.7
     CXX: g++-4.7
     LD: gcc-4.7
-  script: "./minirake all test"
+  script: rake --verbose all test
 Test gcc-4.7 32bit:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
@@ -19,9 +19,9 @@ Test gcc-4.7 32bit:
     CC: gcc-4.7
     CXX: g++-4.7
     LD: gcc-4.7
-    CFLAGS: "-m32 -DMRB_WORD_BOXING=1"
+    CFLAGS: "-m32 "
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.7 32bit_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
@@ -29,9 +29,9 @@ Test gcc-4.7 32bit_utf8:
     CC: gcc-4.7
     CXX: g++-4.7
     LD: gcc-4.7
-    CFLAGS: "-m32 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    CFLAGS: "-m32 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.7 32bit_nan:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
@@ -41,7 +41,7 @@ Test gcc-4.7 32bit_nan:
     LD: gcc-4.7
     CFLAGS: "-m32 -DMRB_NAN_BOXING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.7 32bit_nan_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
@@ -51,7 +51,27 @@ Test gcc-4.7 32bit_nan_utf8:
     LD: gcc-4.7
     CFLAGS: "-m32 -DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
+Test gcc-4.7 32bit_word:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
+  variables:
+    CC: gcc-4.7
+    CXX: g++-4.7
+    LD: gcc-4.7
+    CFLAGS: "-m32 -DMRB_WORD_BOXING=1"
+    LDFLAGS: "-m32"
+  script: env; rake --verbose all test
+Test gcc-4.7 32bit_word_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
+  variables:
+    CC: gcc-4.7
+    CXX: g++-4.7
+    LD: gcc-4.7
+    CFLAGS: "-m32 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; rake --verbose all test
 Test gcc-4.7 32bit_int16:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
@@ -61,7 +81,7 @@ Test gcc-4.7 32bit_int16:
     LD: gcc-4.7
     CFLAGS: "-m32 -DMRB_INT16=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.7 32bit_int16_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
@@ -71,7 +91,7 @@ Test gcc-4.7 32bit_int16_utf8:
     LD: gcc-4.7
     CFLAGS: "-m32 -DMRB_INT16=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.7 32bit_int16_nan:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
@@ -81,7 +101,7 @@ Test gcc-4.7 32bit_int16_nan:
     LD: gcc-4.7
     CFLAGS: "-m32 -DMRB_INT16=1 -DMRB_NAN_BOXING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.7 32bit_int16_nan_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
@@ -91,7 +111,7 @@ Test gcc-4.7 32bit_int16_nan_utf8:
     LD: gcc-4.7
     CFLAGS: "-m32 -DMRB_INT16=1 -DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.7 32bit_int64:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
@@ -101,7 +121,7 @@ Test gcc-4.7 32bit_int64:
     LD: gcc-4.7
     CFLAGS: "-m32 -DMRB_INT64=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.7 32bit_int64_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
@@ -111,8 +131,28 @@ Test gcc-4.7 32bit_int64_utf8:
     LD: gcc-4.7
     CFLAGS: "-m32 -DMRB_INT64=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.7 32bit_float:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
+  variables:
+    CC: gcc-4.7
+    CXX: g++-4.7
+    LD: gcc-4.7
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1"
+    LDFLAGS: "-m32"
+  script: env; rake --verbose all test
+Test gcc-4.7 32bit_float_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
+  variables:
+    CC: gcc-4.7
+    CXX: g++-4.7
+    LD: gcc-4.7
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; rake --verbose all test
+Test gcc-4.7 32bit_float_word:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
   variables:
@@ -121,8 +161,8 @@ Test gcc-4.7 32bit_float:
     LD: gcc-4.7
     CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
-Test gcc-4.7 32bit_float_utf8:
+  script: env; rake --verbose all test
+Test gcc-4.7 32bit_float_word_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
   variables:
@@ -131,7 +171,7 @@ Test gcc-4.7 32bit_float_utf8:
     LD: gcc-4.7
     CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.7 32bit_float_int16:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
@@ -141,7 +181,7 @@ Test gcc-4.7 32bit_float_int16:
     LD: gcc-4.7
     CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT16=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.7 32bit_float_int16_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
@@ -151,7 +191,7 @@ Test gcc-4.7 32bit_float_int16_utf8:
     LD: gcc-4.7
     CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT16=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.7 32bit_float_int64:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
@@ -161,7 +201,7 @@ Test gcc-4.7 32bit_float_int64:
     LD: gcc-4.7
     CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT64=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.7 32bit_float_int64_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
@@ -171,7 +211,7 @@ Test gcc-4.7 32bit_float_int64_utf8:
     LD: gcc-4.7
     CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT64=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.7 64bit:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
@@ -179,9 +219,9 @@ Test gcc-4.7 64bit:
     CC: gcc-4.7
     CXX: g++-4.7
     LD: gcc-4.7
-    CFLAGS: "-DMRB_WORD_BOXING=1"
+    CFLAGS: ''
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.7 64bit_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
@@ -189,9 +229,9 @@ Test gcc-4.7 64bit_utf8:
     CC: gcc-4.7
     CXX: g++-4.7
     LD: gcc-4.7
-    CFLAGS: "-DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    CFLAGS: "-DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.7 64bit_nan:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
@@ -201,7 +241,7 @@ Test gcc-4.7 64bit_nan:
     LD: gcc-4.7
     CFLAGS: "-DMRB_NAN_BOXING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.7 64bit_nan_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
@@ -211,7 +251,27 @@ Test gcc-4.7 64bit_nan_utf8:
     LD: gcc-4.7
     CFLAGS: "-DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
+Test gcc-4.7 64bit_word:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
+  variables:
+    CC: gcc-4.7
+    CXX: g++-4.7
+    LD: gcc-4.7
+    CFLAGS: "-DMRB_WORD_BOXING=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
+Test gcc-4.7 64bit_word_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
+  variables:
+    CC: gcc-4.7
+    CXX: g++-4.7
+    LD: gcc-4.7
+    CFLAGS: "-DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
 Test gcc-4.7 64bit_int16:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
@@ -221,7 +281,7 @@ Test gcc-4.7 64bit_int16:
     LD: gcc-4.7
     CFLAGS: "-DMRB_INT16=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.7 64bit_int16_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
@@ -231,7 +291,7 @@ Test gcc-4.7 64bit_int16_utf8:
     LD: gcc-4.7
     CFLAGS: "-DMRB_INT16=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.7 64bit_int16_nan:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
@@ -241,7 +301,7 @@ Test gcc-4.7 64bit_int16_nan:
     LD: gcc-4.7
     CFLAGS: "-DMRB_INT16=1 -DMRB_NAN_BOXING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.7 64bit_int16_nan_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
@@ -251,8 +311,28 @@ Test gcc-4.7 64bit_int16_nan_utf8:
     LD: gcc-4.7
     CFLAGS: "-DMRB_INT16=1 -DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.7 64bit_int64:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
+  variables:
+    CC: gcc-4.7
+    CXX: g++-4.7
+    LD: gcc-4.7
+    CFLAGS: "-DMRB_INT64=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
+Test gcc-4.7 64bit_int64_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
+  variables:
+    CC: gcc-4.7
+    CXX: g++-4.7
+    LD: gcc-4.7
+    CFLAGS: "-DMRB_INT64=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
+Test gcc-4.7 64bit_int64_word:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
   variables:
@@ -261,8 +341,8 @@ Test gcc-4.7 64bit_int64:
     LD: gcc-4.7
     CFLAGS: "-DMRB_INT64=1 -DMRB_WORD_BOXING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
-Test gcc-4.7 64bit_int64_utf8:
+  script: env; rake --verbose all test
+Test gcc-4.7 64bit_int64_word_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
   variables:
@@ -271,8 +351,28 @@ Test gcc-4.7 64bit_int64_utf8:
     LD: gcc-4.7
     CFLAGS: "-DMRB_INT64=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.7 64bit_float:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
+  variables:
+    CC: gcc-4.7
+    CXX: g++-4.7
+    LD: gcc-4.7
+    CFLAGS: "-DMRB_USE_FLOAT=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
+Test gcc-4.7 64bit_float_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
+  variables:
+    CC: gcc-4.7
+    CXX: g++-4.7
+    LD: gcc-4.7
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
+Test gcc-4.7 64bit_float_word:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
   variables:
@@ -281,8 +381,8 @@ Test gcc-4.7 64bit_float:
     LD: gcc-4.7
     CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
-Test gcc-4.7 64bit_float_utf8:
+  script: env; rake --verbose all test
+Test gcc-4.7 64bit_float_word_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
   variables:
@@ -291,7 +391,7 @@ Test gcc-4.7 64bit_float_utf8:
     LD: gcc-4.7
     CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.7 64bit_float_int16:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
@@ -301,7 +401,7 @@ Test gcc-4.7 64bit_float_int16:
     LD: gcc-4.7
     CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT16=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.7 64bit_float_int16_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
@@ -311,8 +411,28 @@ Test gcc-4.7 64bit_float_int16_utf8:
     LD: gcc-4.7
     CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT16=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.7 64bit_float_int64:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
+  variables:
+    CC: gcc-4.7
+    CXX: g++-4.7
+    LD: gcc-4.7
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT64=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
+Test gcc-4.7 64bit_float_int64_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
+  variables:
+    CC: gcc-4.7
+    CXX: g++-4.7
+    LD: gcc-4.7
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT64=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
+Test gcc-4.7 64bit_float_int64_word:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
   variables:
@@ -321,8 +441,8 @@ Test gcc-4.7 64bit_float_int64:
     LD: gcc-4.7
     CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT64=1 -DMRB_WORD_BOXING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
-Test gcc-4.7 64bit_float_int64_utf8:
+  script: env; rake --verbose all test
+Test gcc-4.7 64bit_float_int64_word_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc47_0.7
   variables:
@@ -331,7 +451,7 @@ Test gcc-4.7 64bit_float_int64_utf8:
     LD: gcc-4.7
     CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT64=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.8 32bit:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
@@ -339,9 +459,9 @@ Test gcc-4.8 32bit:
     CC: gcc-4.8
     CXX: g++-4.8
     LD: gcc-4.8
-    CFLAGS: "-m32 -DMRB_WORD_BOXING=1"
+    CFLAGS: "-m32 "
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.8 32bit_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
@@ -349,9 +469,9 @@ Test gcc-4.8 32bit_utf8:
     CC: gcc-4.8
     CXX: g++-4.8
     LD: gcc-4.8
-    CFLAGS: "-m32 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    CFLAGS: "-m32 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.8 32bit_nan:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
@@ -361,7 +481,7 @@ Test gcc-4.8 32bit_nan:
     LD: gcc-4.8
     CFLAGS: "-m32 -DMRB_NAN_BOXING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.8 32bit_nan_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
@@ -371,7 +491,27 @@ Test gcc-4.8 32bit_nan_utf8:
     LD: gcc-4.8
     CFLAGS: "-m32 -DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
+Test gcc-4.8 32bit_word:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
+  variables:
+    CC: gcc-4.8
+    CXX: g++-4.8
+    LD: gcc-4.8
+    CFLAGS: "-m32 -DMRB_WORD_BOXING=1"
+    LDFLAGS: "-m32"
+  script: env; rake --verbose all test
+Test gcc-4.8 32bit_word_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
+  variables:
+    CC: gcc-4.8
+    CXX: g++-4.8
+    LD: gcc-4.8
+    CFLAGS: "-m32 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; rake --verbose all test
 Test gcc-4.8 32bit_int16:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
@@ -381,7 +521,7 @@ Test gcc-4.8 32bit_int16:
     LD: gcc-4.8
     CFLAGS: "-m32 -DMRB_INT16=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.8 32bit_int16_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
@@ -391,7 +531,7 @@ Test gcc-4.8 32bit_int16_utf8:
     LD: gcc-4.8
     CFLAGS: "-m32 -DMRB_INT16=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.8 32bit_int16_nan:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
@@ -401,7 +541,7 @@ Test gcc-4.8 32bit_int16_nan:
     LD: gcc-4.8
     CFLAGS: "-m32 -DMRB_INT16=1 -DMRB_NAN_BOXING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.8 32bit_int16_nan_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
@@ -411,7 +551,7 @@ Test gcc-4.8 32bit_int16_nan_utf8:
     LD: gcc-4.8
     CFLAGS: "-m32 -DMRB_INT16=1 -DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.8 32bit_int64:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
@@ -421,7 +561,7 @@ Test gcc-4.8 32bit_int64:
     LD: gcc-4.8
     CFLAGS: "-m32 -DMRB_INT64=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.8 32bit_int64_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
@@ -431,8 +571,28 @@ Test gcc-4.8 32bit_int64_utf8:
     LD: gcc-4.8
     CFLAGS: "-m32 -DMRB_INT64=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.8 32bit_float:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
+  variables:
+    CC: gcc-4.8
+    CXX: g++-4.8
+    LD: gcc-4.8
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1"
+    LDFLAGS: "-m32"
+  script: env; rake --verbose all test
+Test gcc-4.8 32bit_float_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
+  variables:
+    CC: gcc-4.8
+    CXX: g++-4.8
+    LD: gcc-4.8
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; rake --verbose all test
+Test gcc-4.8 32bit_float_word:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
   variables:
@@ -441,8 +601,8 @@ Test gcc-4.8 32bit_float:
     LD: gcc-4.8
     CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
-Test gcc-4.8 32bit_float_utf8:
+  script: env; rake --verbose all test
+Test gcc-4.8 32bit_float_word_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
   variables:
@@ -451,7 +611,7 @@ Test gcc-4.8 32bit_float_utf8:
     LD: gcc-4.8
     CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.8 32bit_float_int16:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
@@ -461,7 +621,7 @@ Test gcc-4.8 32bit_float_int16:
     LD: gcc-4.8
     CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT16=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.8 32bit_float_int16_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
@@ -471,7 +631,7 @@ Test gcc-4.8 32bit_float_int16_utf8:
     LD: gcc-4.8
     CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT16=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.8 32bit_float_int64:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
@@ -481,7 +641,7 @@ Test gcc-4.8 32bit_float_int64:
     LD: gcc-4.8
     CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT64=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.8 32bit_float_int64_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
@@ -491,7 +651,7 @@ Test gcc-4.8 32bit_float_int64_utf8:
     LD: gcc-4.8
     CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT64=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.8 64bit:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
@@ -499,9 +659,9 @@ Test gcc-4.8 64bit:
     CC: gcc-4.8
     CXX: g++-4.8
     LD: gcc-4.8
-    CFLAGS: "-DMRB_WORD_BOXING=1"
+    CFLAGS: ''
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.8 64bit_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
@@ -509,9 +669,9 @@ Test gcc-4.8 64bit_utf8:
     CC: gcc-4.8
     CXX: g++-4.8
     LD: gcc-4.8
-    CFLAGS: "-DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    CFLAGS: "-DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.8 64bit_nan:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
@@ -521,7 +681,7 @@ Test gcc-4.8 64bit_nan:
     LD: gcc-4.8
     CFLAGS: "-DMRB_NAN_BOXING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.8 64bit_nan_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
@@ -531,7 +691,27 @@ Test gcc-4.8 64bit_nan_utf8:
     LD: gcc-4.8
     CFLAGS: "-DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
+Test gcc-4.8 64bit_word:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
+  variables:
+    CC: gcc-4.8
+    CXX: g++-4.8
+    LD: gcc-4.8
+    CFLAGS: "-DMRB_WORD_BOXING=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
+Test gcc-4.8 64bit_word_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
+  variables:
+    CC: gcc-4.8
+    CXX: g++-4.8
+    LD: gcc-4.8
+    CFLAGS: "-DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
 Test gcc-4.8 64bit_int16:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
@@ -541,7 +721,7 @@ Test gcc-4.8 64bit_int16:
     LD: gcc-4.8
     CFLAGS: "-DMRB_INT16=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.8 64bit_int16_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
@@ -551,7 +731,7 @@ Test gcc-4.8 64bit_int16_utf8:
     LD: gcc-4.8
     CFLAGS: "-DMRB_INT16=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.8 64bit_int16_nan:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
@@ -561,7 +741,7 @@ Test gcc-4.8 64bit_int16_nan:
     LD: gcc-4.8
     CFLAGS: "-DMRB_INT16=1 -DMRB_NAN_BOXING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.8 64bit_int16_nan_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
@@ -571,8 +751,28 @@ Test gcc-4.8 64bit_int16_nan_utf8:
     LD: gcc-4.8
     CFLAGS: "-DMRB_INT16=1 -DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.8 64bit_int64:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
+  variables:
+    CC: gcc-4.8
+    CXX: g++-4.8
+    LD: gcc-4.8
+    CFLAGS: "-DMRB_INT64=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
+Test gcc-4.8 64bit_int64_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
+  variables:
+    CC: gcc-4.8
+    CXX: g++-4.8
+    LD: gcc-4.8
+    CFLAGS: "-DMRB_INT64=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
+Test gcc-4.8 64bit_int64_word:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
   variables:
@@ -581,8 +781,8 @@ Test gcc-4.8 64bit_int64:
     LD: gcc-4.8
     CFLAGS: "-DMRB_INT64=1 -DMRB_WORD_BOXING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
-Test gcc-4.8 64bit_int64_utf8:
+  script: env; rake --verbose all test
+Test gcc-4.8 64bit_int64_word_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
   variables:
@@ -591,8 +791,28 @@ Test gcc-4.8 64bit_int64_utf8:
     LD: gcc-4.8
     CFLAGS: "-DMRB_INT64=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.8 64bit_float:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
+  variables:
+    CC: gcc-4.8
+    CXX: g++-4.8
+    LD: gcc-4.8
+    CFLAGS: "-DMRB_USE_FLOAT=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
+Test gcc-4.8 64bit_float_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
+  variables:
+    CC: gcc-4.8
+    CXX: g++-4.8
+    LD: gcc-4.8
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
+Test gcc-4.8 64bit_float_word:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
   variables:
@@ -601,8 +821,8 @@ Test gcc-4.8 64bit_float:
     LD: gcc-4.8
     CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
-Test gcc-4.8 64bit_float_utf8:
+  script: env; rake --verbose all test
+Test gcc-4.8 64bit_float_word_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
   variables:
@@ -611,7 +831,7 @@ Test gcc-4.8 64bit_float_utf8:
     LD: gcc-4.8
     CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.8 64bit_float_int16:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
@@ -621,7 +841,7 @@ Test gcc-4.8 64bit_float_int16:
     LD: gcc-4.8
     CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT16=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.8 64bit_float_int16_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
@@ -631,8 +851,28 @@ Test gcc-4.8 64bit_float_int16_utf8:
     LD: gcc-4.8
     CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT16=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.8 64bit_float_int64:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
+  variables:
+    CC: gcc-4.8
+    CXX: g++-4.8
+    LD: gcc-4.8
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT64=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
+Test gcc-4.8 64bit_float_int64_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
+  variables:
+    CC: gcc-4.8
+    CXX: g++-4.8
+    LD: gcc-4.8
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT64=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
+Test gcc-4.8 64bit_float_int64_word:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
   variables:
@@ -641,8 +881,8 @@ Test gcc-4.8 64bit_float_int64:
     LD: gcc-4.8
     CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT64=1 -DMRB_WORD_BOXING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
-Test gcc-4.8 64bit_float_int64_utf8:
+  script: env; rake --verbose all test
+Test gcc-4.8 64bit_float_int64_word_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc48_0.7
   variables:
@@ -651,7 +891,7 @@ Test gcc-4.8 64bit_float_int64_utf8:
     LD: gcc-4.8
     CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT64=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.9 32bit:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
@@ -659,9 +899,9 @@ Test gcc-4.9 32bit:
     CC: gcc-4.9
     CXX: g++-4.9
     LD: gcc-4.9
-    CFLAGS: "-m32 -DMRB_WORD_BOXING=1"
+    CFLAGS: "-m32 "
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.9 32bit_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
@@ -669,9 +909,9 @@ Test gcc-4.9 32bit_utf8:
     CC: gcc-4.9
     CXX: g++-4.9
     LD: gcc-4.9
-    CFLAGS: "-m32 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    CFLAGS: "-m32 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.9 32bit_nan:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
@@ -681,7 +921,7 @@ Test gcc-4.9 32bit_nan:
     LD: gcc-4.9
     CFLAGS: "-m32 -DMRB_NAN_BOXING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.9 32bit_nan_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
@@ -691,7 +931,27 @@ Test gcc-4.9 32bit_nan_utf8:
     LD: gcc-4.9
     CFLAGS: "-m32 -DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
+Test gcc-4.9 32bit_word:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
+  variables:
+    CC: gcc-4.9
+    CXX: g++-4.9
+    LD: gcc-4.9
+    CFLAGS: "-m32 -DMRB_WORD_BOXING=1"
+    LDFLAGS: "-m32"
+  script: env; rake --verbose all test
+Test gcc-4.9 32bit_word_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
+  variables:
+    CC: gcc-4.9
+    CXX: g++-4.9
+    LD: gcc-4.9
+    CFLAGS: "-m32 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; rake --verbose all test
 Test gcc-4.9 32bit_int16:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
@@ -701,7 +961,7 @@ Test gcc-4.9 32bit_int16:
     LD: gcc-4.9
     CFLAGS: "-m32 -DMRB_INT16=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.9 32bit_int16_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
@@ -711,7 +971,7 @@ Test gcc-4.9 32bit_int16_utf8:
     LD: gcc-4.9
     CFLAGS: "-m32 -DMRB_INT16=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.9 32bit_int16_nan:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
@@ -721,7 +981,7 @@ Test gcc-4.9 32bit_int16_nan:
     LD: gcc-4.9
     CFLAGS: "-m32 -DMRB_INT16=1 -DMRB_NAN_BOXING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.9 32bit_int16_nan_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
@@ -731,7 +991,7 @@ Test gcc-4.9 32bit_int16_nan_utf8:
     LD: gcc-4.9
     CFLAGS: "-m32 -DMRB_INT16=1 -DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.9 32bit_int64:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
@@ -741,7 +1001,7 @@ Test gcc-4.9 32bit_int64:
     LD: gcc-4.9
     CFLAGS: "-m32 -DMRB_INT64=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.9 32bit_int64_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
@@ -751,8 +1011,28 @@ Test gcc-4.9 32bit_int64_utf8:
     LD: gcc-4.9
     CFLAGS: "-m32 -DMRB_INT64=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.9 32bit_float:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
+  variables:
+    CC: gcc-4.9
+    CXX: g++-4.9
+    LD: gcc-4.9
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1"
+    LDFLAGS: "-m32"
+  script: env; rake --verbose all test
+Test gcc-4.9 32bit_float_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
+  variables:
+    CC: gcc-4.9
+    CXX: g++-4.9
+    LD: gcc-4.9
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; rake --verbose all test
+Test gcc-4.9 32bit_float_word:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
   variables:
@@ -761,8 +1041,8 @@ Test gcc-4.9 32bit_float:
     LD: gcc-4.9
     CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
-Test gcc-4.9 32bit_float_utf8:
+  script: env; rake --verbose all test
+Test gcc-4.9 32bit_float_word_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
   variables:
@@ -771,7 +1051,7 @@ Test gcc-4.9 32bit_float_utf8:
     LD: gcc-4.9
     CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.9 32bit_float_int16:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
@@ -781,7 +1061,7 @@ Test gcc-4.9 32bit_float_int16:
     LD: gcc-4.9
     CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT16=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.9 32bit_float_int16_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
@@ -791,7 +1071,7 @@ Test gcc-4.9 32bit_float_int16_utf8:
     LD: gcc-4.9
     CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT16=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.9 32bit_float_int64:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
@@ -801,7 +1081,7 @@ Test gcc-4.9 32bit_float_int64:
     LD: gcc-4.9
     CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT64=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.9 32bit_float_int64_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
@@ -811,7 +1091,7 @@ Test gcc-4.9 32bit_float_int64_utf8:
     LD: gcc-4.9
     CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT64=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.9 64bit:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
@@ -819,9 +1099,9 @@ Test gcc-4.9 64bit:
     CC: gcc-4.9
     CXX: g++-4.9
     LD: gcc-4.9
-    CFLAGS: "-DMRB_WORD_BOXING=1"
+    CFLAGS: ''
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.9 64bit_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
@@ -829,9 +1109,9 @@ Test gcc-4.9 64bit_utf8:
     CC: gcc-4.9
     CXX: g++-4.9
     LD: gcc-4.9
-    CFLAGS: "-DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    CFLAGS: "-DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.9 64bit_nan:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
@@ -841,7 +1121,7 @@ Test gcc-4.9 64bit_nan:
     LD: gcc-4.9
     CFLAGS: "-DMRB_NAN_BOXING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.9 64bit_nan_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
@@ -851,7 +1131,27 @@ Test gcc-4.9 64bit_nan_utf8:
     LD: gcc-4.9
     CFLAGS: "-DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
+Test gcc-4.9 64bit_word:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
+  variables:
+    CC: gcc-4.9
+    CXX: g++-4.9
+    LD: gcc-4.9
+    CFLAGS: "-DMRB_WORD_BOXING=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
+Test gcc-4.9 64bit_word_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
+  variables:
+    CC: gcc-4.9
+    CXX: g++-4.9
+    LD: gcc-4.9
+    CFLAGS: "-DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
 Test gcc-4.9 64bit_int16:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
@@ -861,7 +1161,7 @@ Test gcc-4.9 64bit_int16:
     LD: gcc-4.9
     CFLAGS: "-DMRB_INT16=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.9 64bit_int16_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
@@ -871,7 +1171,7 @@ Test gcc-4.9 64bit_int16_utf8:
     LD: gcc-4.9
     CFLAGS: "-DMRB_INT16=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.9 64bit_int16_nan:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
@@ -881,7 +1181,7 @@ Test gcc-4.9 64bit_int16_nan:
     LD: gcc-4.9
     CFLAGS: "-DMRB_INT16=1 -DMRB_NAN_BOXING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.9 64bit_int16_nan_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
@@ -891,8 +1191,28 @@ Test gcc-4.9 64bit_int16_nan_utf8:
     LD: gcc-4.9
     CFLAGS: "-DMRB_INT16=1 -DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.9 64bit_int64:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
+  variables:
+    CC: gcc-4.9
+    CXX: g++-4.9
+    LD: gcc-4.9
+    CFLAGS: "-DMRB_INT64=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
+Test gcc-4.9 64bit_int64_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
+  variables:
+    CC: gcc-4.9
+    CXX: g++-4.9
+    LD: gcc-4.9
+    CFLAGS: "-DMRB_INT64=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
+Test gcc-4.9 64bit_int64_word:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
   variables:
@@ -901,8 +1221,8 @@ Test gcc-4.9 64bit_int64:
     LD: gcc-4.9
     CFLAGS: "-DMRB_INT64=1 -DMRB_WORD_BOXING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
-Test gcc-4.9 64bit_int64_utf8:
+  script: env; rake --verbose all test
+Test gcc-4.9 64bit_int64_word_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
   variables:
@@ -911,8 +1231,28 @@ Test gcc-4.9 64bit_int64_utf8:
     LD: gcc-4.9
     CFLAGS: "-DMRB_INT64=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.9 64bit_float:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
+  variables:
+    CC: gcc-4.9
+    CXX: g++-4.9
+    LD: gcc-4.9
+    CFLAGS: "-DMRB_USE_FLOAT=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
+Test gcc-4.9 64bit_float_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
+  variables:
+    CC: gcc-4.9
+    CXX: g++-4.9
+    LD: gcc-4.9
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
+Test gcc-4.9 64bit_float_word:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
   variables:
@@ -921,8 +1261,8 @@ Test gcc-4.9 64bit_float:
     LD: gcc-4.9
     CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
-Test gcc-4.9 64bit_float_utf8:
+  script: env; rake --verbose all test
+Test gcc-4.9 64bit_float_word_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
   variables:
@@ -931,7 +1271,7 @@ Test gcc-4.9 64bit_float_utf8:
     LD: gcc-4.9
     CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.9 64bit_float_int16:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
@@ -941,7 +1281,7 @@ Test gcc-4.9 64bit_float_int16:
     LD: gcc-4.9
     CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT16=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.9 64bit_float_int16_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
@@ -951,8 +1291,28 @@ Test gcc-4.9 64bit_float_int16_utf8:
     LD: gcc-4.9
     CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT16=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-4.9 64bit_float_int64:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
+  variables:
+    CC: gcc-4.9
+    CXX: g++-4.9
+    LD: gcc-4.9
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT64=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
+Test gcc-4.9 64bit_float_int64_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
+  variables:
+    CC: gcc-4.9
+    CXX: g++-4.9
+    LD: gcc-4.9
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT64=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
+Test gcc-4.9 64bit_float_int64_word:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
   variables:
@@ -961,8 +1321,8 @@ Test gcc-4.9 64bit_float_int64:
     LD: gcc-4.9
     CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT64=1 -DMRB_WORD_BOXING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
-Test gcc-4.9 64bit_float_int64_utf8:
+  script: env; rake --verbose all test
+Test gcc-4.9 64bit_float_int64_word_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc49_0.7
   variables:
@@ -971,7 +1331,7 @@ Test gcc-4.9 64bit_float_int64_utf8:
     LD: gcc-4.9
     CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT64=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-5 32bit:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
@@ -979,9 +1339,9 @@ Test gcc-5 32bit:
     CC: gcc-5
     CXX: g++-5
     LD: gcc-5
-    CFLAGS: "-m32 -DMRB_WORD_BOXING=1"
+    CFLAGS: "-m32 "
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-5 32bit_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
@@ -989,9 +1349,9 @@ Test gcc-5 32bit_utf8:
     CC: gcc-5
     CXX: g++-5
     LD: gcc-5
-    CFLAGS: "-m32 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    CFLAGS: "-m32 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-5 32bit_nan:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
@@ -1001,7 +1361,7 @@ Test gcc-5 32bit_nan:
     LD: gcc-5
     CFLAGS: "-m32 -DMRB_NAN_BOXING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-5 32bit_nan_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
@@ -1011,7 +1371,27 @@ Test gcc-5 32bit_nan_utf8:
     LD: gcc-5
     CFLAGS: "-m32 -DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
+Test gcc-5 32bit_word:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
+  variables:
+    CC: gcc-5
+    CXX: g++-5
+    LD: gcc-5
+    CFLAGS: "-m32 -DMRB_WORD_BOXING=1"
+    LDFLAGS: "-m32"
+  script: env; rake --verbose all test
+Test gcc-5 32bit_word_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
+  variables:
+    CC: gcc-5
+    CXX: g++-5
+    LD: gcc-5
+    CFLAGS: "-m32 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; rake --verbose all test
 Test gcc-5 32bit_int16:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
@@ -1021,7 +1401,7 @@ Test gcc-5 32bit_int16:
     LD: gcc-5
     CFLAGS: "-m32 -DMRB_INT16=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-5 32bit_int16_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
@@ -1031,7 +1411,7 @@ Test gcc-5 32bit_int16_utf8:
     LD: gcc-5
     CFLAGS: "-m32 -DMRB_INT16=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-5 32bit_int16_nan:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
@@ -1041,7 +1421,7 @@ Test gcc-5 32bit_int16_nan:
     LD: gcc-5
     CFLAGS: "-m32 -DMRB_INT16=1 -DMRB_NAN_BOXING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-5 32bit_int16_nan_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
@@ -1051,7 +1431,7 @@ Test gcc-5 32bit_int16_nan_utf8:
     LD: gcc-5
     CFLAGS: "-m32 -DMRB_INT16=1 -DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-5 32bit_int64:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
@@ -1061,7 +1441,7 @@ Test gcc-5 32bit_int64:
     LD: gcc-5
     CFLAGS: "-m32 -DMRB_INT64=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-5 32bit_int64_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
@@ -1071,8 +1451,28 @@ Test gcc-5 32bit_int64_utf8:
     LD: gcc-5
     CFLAGS: "-m32 -DMRB_INT64=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-5 32bit_float:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
+  variables:
+    CC: gcc-5
+    CXX: g++-5
+    LD: gcc-5
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1"
+    LDFLAGS: "-m32"
+  script: env; rake --verbose all test
+Test gcc-5 32bit_float_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
+  variables:
+    CC: gcc-5
+    CXX: g++-5
+    LD: gcc-5
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; rake --verbose all test
+Test gcc-5 32bit_float_word:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
   variables:
@@ -1081,8 +1481,8 @@ Test gcc-5 32bit_float:
     LD: gcc-5
     CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
-Test gcc-5 32bit_float_utf8:
+  script: env; rake --verbose all test
+Test gcc-5 32bit_float_word_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
   variables:
@@ -1091,7 +1491,7 @@ Test gcc-5 32bit_float_utf8:
     LD: gcc-5
     CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-5 32bit_float_int16:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
@@ -1101,7 +1501,7 @@ Test gcc-5 32bit_float_int16:
     LD: gcc-5
     CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT16=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-5 32bit_float_int16_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
@@ -1111,7 +1511,7 @@ Test gcc-5 32bit_float_int16_utf8:
     LD: gcc-5
     CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT16=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-5 32bit_float_int64:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
@@ -1121,7 +1521,7 @@ Test gcc-5 32bit_float_int64:
     LD: gcc-5
     CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT64=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-5 32bit_float_int64_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
@@ -1131,7 +1531,7 @@ Test gcc-5 32bit_float_int64_utf8:
     LD: gcc-5
     CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT64=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-5 64bit:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
@@ -1139,9 +1539,9 @@ Test gcc-5 64bit:
     CC: gcc-5
     CXX: g++-5
     LD: gcc-5
-    CFLAGS: "-DMRB_WORD_BOXING=1"
+    CFLAGS: ''
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-5 64bit_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
@@ -1149,9 +1549,9 @@ Test gcc-5 64bit_utf8:
     CC: gcc-5
     CXX: g++-5
     LD: gcc-5
-    CFLAGS: "-DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    CFLAGS: "-DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-5 64bit_nan:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
@@ -1161,7 +1561,7 @@ Test gcc-5 64bit_nan:
     LD: gcc-5
     CFLAGS: "-DMRB_NAN_BOXING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-5 64bit_nan_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
@@ -1171,7 +1571,27 @@ Test gcc-5 64bit_nan_utf8:
     LD: gcc-5
     CFLAGS: "-DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
+Test gcc-5 64bit_word:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
+  variables:
+    CC: gcc-5
+    CXX: g++-5
+    LD: gcc-5
+    CFLAGS: "-DMRB_WORD_BOXING=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
+Test gcc-5 64bit_word_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
+  variables:
+    CC: gcc-5
+    CXX: g++-5
+    LD: gcc-5
+    CFLAGS: "-DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
 Test gcc-5 64bit_int16:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
@@ -1181,7 +1601,7 @@ Test gcc-5 64bit_int16:
     LD: gcc-5
     CFLAGS: "-DMRB_INT16=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-5 64bit_int16_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
@@ -1191,7 +1611,7 @@ Test gcc-5 64bit_int16_utf8:
     LD: gcc-5
     CFLAGS: "-DMRB_INT16=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-5 64bit_int16_nan:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
@@ -1201,7 +1621,7 @@ Test gcc-5 64bit_int16_nan:
     LD: gcc-5
     CFLAGS: "-DMRB_INT16=1 -DMRB_NAN_BOXING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-5 64bit_int16_nan_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
@@ -1211,8 +1631,28 @@ Test gcc-5 64bit_int16_nan_utf8:
     LD: gcc-5
     CFLAGS: "-DMRB_INT16=1 -DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-5 64bit_int64:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
+  variables:
+    CC: gcc-5
+    CXX: g++-5
+    LD: gcc-5
+    CFLAGS: "-DMRB_INT64=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
+Test gcc-5 64bit_int64_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
+  variables:
+    CC: gcc-5
+    CXX: g++-5
+    LD: gcc-5
+    CFLAGS: "-DMRB_INT64=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
+Test gcc-5 64bit_int64_word:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
   variables:
@@ -1221,8 +1661,8 @@ Test gcc-5 64bit_int64:
     LD: gcc-5
     CFLAGS: "-DMRB_INT64=1 -DMRB_WORD_BOXING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
-Test gcc-5 64bit_int64_utf8:
+  script: env; rake --verbose all test
+Test gcc-5 64bit_int64_word_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
   variables:
@@ -1231,8 +1671,28 @@ Test gcc-5 64bit_int64_utf8:
     LD: gcc-5
     CFLAGS: "-DMRB_INT64=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-5 64bit_float:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
+  variables:
+    CC: gcc-5
+    CXX: g++-5
+    LD: gcc-5
+    CFLAGS: "-DMRB_USE_FLOAT=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
+Test gcc-5 64bit_float_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
+  variables:
+    CC: gcc-5
+    CXX: g++-5
+    LD: gcc-5
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
+Test gcc-5 64bit_float_word:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
   variables:
@@ -1241,8 +1701,8 @@ Test gcc-5 64bit_float:
     LD: gcc-5
     CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
-Test gcc-5 64bit_float_utf8:
+  script: env; rake --verbose all test
+Test gcc-5 64bit_float_word_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
   variables:
@@ -1251,7 +1711,7 @@ Test gcc-5 64bit_float_utf8:
     LD: gcc-5
     CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-5 64bit_float_int16:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
@@ -1261,7 +1721,7 @@ Test gcc-5 64bit_float_int16:
     LD: gcc-5
     CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT16=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-5 64bit_float_int16_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
@@ -1271,8 +1731,28 @@ Test gcc-5 64bit_float_int16_utf8:
     LD: gcc-5
     CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT16=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-5 64bit_float_int64:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
+  variables:
+    CC: gcc-5
+    CXX: g++-5
+    LD: gcc-5
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT64=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
+Test gcc-5 64bit_float_int64_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
+  variables:
+    CC: gcc-5
+    CXX: g++-5
+    LD: gcc-5
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT64=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
+Test gcc-5 64bit_float_int64_word:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
   variables:
@@ -1281,8 +1761,8 @@ Test gcc-5 64bit_float_int64:
     LD: gcc-5
     CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT64=1 -DMRB_WORD_BOXING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
-Test gcc-5 64bit_float_int64_utf8:
+  script: env; rake --verbose all test
+Test gcc-5 64bit_float_int64_word_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc5_0.7
   variables:
@@ -1291,7 +1771,7 @@ Test gcc-5 64bit_float_int64_utf8:
     LD: gcc-5
     CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT64=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-6 32bit:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
@@ -1299,9 +1779,9 @@ Test gcc-6 32bit:
     CC: gcc-6
     CXX: g++-6
     LD: gcc-6
-    CFLAGS: "-m32 -DMRB_WORD_BOXING=1"
+    CFLAGS: "-m32 "
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-6 32bit_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
@@ -1309,9 +1789,9 @@ Test gcc-6 32bit_utf8:
     CC: gcc-6
     CXX: g++-6
     LD: gcc-6
-    CFLAGS: "-m32 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    CFLAGS: "-m32 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-6 32bit_nan:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
@@ -1321,7 +1801,7 @@ Test gcc-6 32bit_nan:
     LD: gcc-6
     CFLAGS: "-m32 -DMRB_NAN_BOXING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-6 32bit_nan_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
@@ -1331,7 +1811,27 @@ Test gcc-6 32bit_nan_utf8:
     LD: gcc-6
     CFLAGS: "-m32 -DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
+Test gcc-6 32bit_word:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
+  variables:
+    CC: gcc-6
+    CXX: g++-6
+    LD: gcc-6
+    CFLAGS: "-m32 -DMRB_WORD_BOXING=1"
+    LDFLAGS: "-m32"
+  script: env; rake --verbose all test
+Test gcc-6 32bit_word_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
+  variables:
+    CC: gcc-6
+    CXX: g++-6
+    LD: gcc-6
+    CFLAGS: "-m32 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; rake --verbose all test
 Test gcc-6 32bit_int16:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
@@ -1341,7 +1841,7 @@ Test gcc-6 32bit_int16:
     LD: gcc-6
     CFLAGS: "-m32 -DMRB_INT16=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-6 32bit_int16_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
@@ -1351,7 +1851,7 @@ Test gcc-6 32bit_int16_utf8:
     LD: gcc-6
     CFLAGS: "-m32 -DMRB_INT16=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-6 32bit_int16_nan:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
@@ -1361,7 +1861,7 @@ Test gcc-6 32bit_int16_nan:
     LD: gcc-6
     CFLAGS: "-m32 -DMRB_INT16=1 -DMRB_NAN_BOXING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-6 32bit_int16_nan_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
@@ -1371,7 +1871,7 @@ Test gcc-6 32bit_int16_nan_utf8:
     LD: gcc-6
     CFLAGS: "-m32 -DMRB_INT16=1 -DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-6 32bit_int64:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
@@ -1381,7 +1881,7 @@ Test gcc-6 32bit_int64:
     LD: gcc-6
     CFLAGS: "-m32 -DMRB_INT64=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-6 32bit_int64_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
@@ -1391,8 +1891,28 @@ Test gcc-6 32bit_int64_utf8:
     LD: gcc-6
     CFLAGS: "-m32 -DMRB_INT64=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-6 32bit_float:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
+  variables:
+    CC: gcc-6
+    CXX: g++-6
+    LD: gcc-6
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1"
+    LDFLAGS: "-m32"
+  script: env; rake --verbose all test
+Test gcc-6 32bit_float_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
+  variables:
+    CC: gcc-6
+    CXX: g++-6
+    LD: gcc-6
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; rake --verbose all test
+Test gcc-6 32bit_float_word:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
   variables:
@@ -1401,8 +1921,8 @@ Test gcc-6 32bit_float:
     LD: gcc-6
     CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
-Test gcc-6 32bit_float_utf8:
+  script: env; rake --verbose all test
+Test gcc-6 32bit_float_word_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
   variables:
@@ -1411,7 +1931,7 @@ Test gcc-6 32bit_float_utf8:
     LD: gcc-6
     CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-6 32bit_float_int16:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
@@ -1421,7 +1941,7 @@ Test gcc-6 32bit_float_int16:
     LD: gcc-6
     CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT16=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-6 32bit_float_int16_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
@@ -1431,7 +1951,7 @@ Test gcc-6 32bit_float_int16_utf8:
     LD: gcc-6
     CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT16=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-6 32bit_float_int64:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
@@ -1441,7 +1961,7 @@ Test gcc-6 32bit_float_int64:
     LD: gcc-6
     CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT64=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-6 32bit_float_int64_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
@@ -1451,7 +1971,7 @@ Test gcc-6 32bit_float_int64_utf8:
     LD: gcc-6
     CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT64=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-6 64bit:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
@@ -1459,9 +1979,9 @@ Test gcc-6 64bit:
     CC: gcc-6
     CXX: g++-6
     LD: gcc-6
-    CFLAGS: "-DMRB_WORD_BOXING=1"
+    CFLAGS: ''
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-6 64bit_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
@@ -1469,9 +1989,9 @@ Test gcc-6 64bit_utf8:
     CC: gcc-6
     CXX: g++-6
     LD: gcc-6
-    CFLAGS: "-DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    CFLAGS: "-DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-6 64bit_nan:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
@@ -1481,7 +2001,7 @@ Test gcc-6 64bit_nan:
     LD: gcc-6
     CFLAGS: "-DMRB_NAN_BOXING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-6 64bit_nan_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
@@ -1491,7 +2011,27 @@ Test gcc-6 64bit_nan_utf8:
     LD: gcc-6
     CFLAGS: "-DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
+Test gcc-6 64bit_word:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
+  variables:
+    CC: gcc-6
+    CXX: g++-6
+    LD: gcc-6
+    CFLAGS: "-DMRB_WORD_BOXING=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
+Test gcc-6 64bit_word_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
+  variables:
+    CC: gcc-6
+    CXX: g++-6
+    LD: gcc-6
+    CFLAGS: "-DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
 Test gcc-6 64bit_int16:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
@@ -1501,7 +2041,7 @@ Test gcc-6 64bit_int16:
     LD: gcc-6
     CFLAGS: "-DMRB_INT16=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-6 64bit_int16_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
@@ -1511,7 +2051,7 @@ Test gcc-6 64bit_int16_utf8:
     LD: gcc-6
     CFLAGS: "-DMRB_INT16=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-6 64bit_int16_nan:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
@@ -1521,7 +2061,7 @@ Test gcc-6 64bit_int16_nan:
     LD: gcc-6
     CFLAGS: "-DMRB_INT16=1 -DMRB_NAN_BOXING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-6 64bit_int16_nan_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
@@ -1531,8 +2071,28 @@ Test gcc-6 64bit_int16_nan_utf8:
     LD: gcc-6
     CFLAGS: "-DMRB_INT16=1 -DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-6 64bit_int64:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
+  variables:
+    CC: gcc-6
+    CXX: g++-6
+    LD: gcc-6
+    CFLAGS: "-DMRB_INT64=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
+Test gcc-6 64bit_int64_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
+  variables:
+    CC: gcc-6
+    CXX: g++-6
+    LD: gcc-6
+    CFLAGS: "-DMRB_INT64=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
+Test gcc-6 64bit_int64_word:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
   variables:
@@ -1541,8 +2101,8 @@ Test gcc-6 64bit_int64:
     LD: gcc-6
     CFLAGS: "-DMRB_INT64=1 -DMRB_WORD_BOXING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
-Test gcc-6 64bit_int64_utf8:
+  script: env; rake --verbose all test
+Test gcc-6 64bit_int64_word_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
   variables:
@@ -1551,8 +2111,28 @@ Test gcc-6 64bit_int64_utf8:
     LD: gcc-6
     CFLAGS: "-DMRB_INT64=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-6 64bit_float:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
+  variables:
+    CC: gcc-6
+    CXX: g++-6
+    LD: gcc-6
+    CFLAGS: "-DMRB_USE_FLOAT=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
+Test gcc-6 64bit_float_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
+  variables:
+    CC: gcc-6
+    CXX: g++-6
+    LD: gcc-6
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
+Test gcc-6 64bit_float_word:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
   variables:
@@ -1561,8 +2141,8 @@ Test gcc-6 64bit_float:
     LD: gcc-6
     CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
-Test gcc-6 64bit_float_utf8:
+  script: env; rake --verbose all test
+Test gcc-6 64bit_float_word_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
   variables:
@@ -1571,7 +2151,7 @@ Test gcc-6 64bit_float_utf8:
     LD: gcc-6
     CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-6 64bit_float_int16:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
@@ -1581,7 +2161,7 @@ Test gcc-6 64bit_float_int16:
     LD: gcc-6
     CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT16=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-6 64bit_float_int16_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
@@ -1591,8 +2171,28 @@ Test gcc-6 64bit_float_int16_utf8:
     LD: gcc-6
     CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT16=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test gcc-6 64bit_float_int64:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
+  variables:
+    CC: gcc-6
+    CXX: g++-6
+    LD: gcc-6
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT64=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
+Test gcc-6 64bit_float_int64_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
+  variables:
+    CC: gcc-6
+    CXX: g++-6
+    LD: gcc-6
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT64=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
+Test gcc-6 64bit_float_int64_word:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
   variables:
@@ -1601,8 +2201,8 @@ Test gcc-6 64bit_float_int64:
     LD: gcc-6
     CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT64=1 -DMRB_WORD_BOXING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
-Test gcc-6 64bit_float_int64_utf8:
+  script: env; rake --verbose all test
+Test gcc-6 64bit_float_int64_word_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:gcc6_0.7
   variables:
@@ -1611,7 +2211,7 @@ Test gcc-6 64bit_float_int64_utf8:
     LD: gcc-6
     CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT64=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.5 32bit:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang35_0.7
@@ -1619,9 +2219,9 @@ Test clang-3.5 32bit:
     CC: clang-3.5
     CXX: clang++-3.5
     LD: clang-3.5
-    CFLAGS: "-m32 -DMRB_WORD_BOXING=1"
+    CFLAGS: "-m32 "
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.5 32bit_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang35_0.7
@@ -1629,9 +2229,9 @@ Test clang-3.5 32bit_utf8:
     CC: clang-3.5
     CXX: clang++-3.5
     LD: clang-3.5
-    CFLAGS: "-m32 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    CFLAGS: "-m32 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.5 32bit_nan:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang35_0.7
@@ -1641,7 +2241,7 @@ Test clang-3.5 32bit_nan:
     LD: clang-3.5
     CFLAGS: "-m32 -DMRB_NAN_BOXING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.5 32bit_nan_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang35_0.7
@@ -1651,7 +2251,27 @@ Test clang-3.5 32bit_nan_utf8:
     LD: clang-3.5
     CFLAGS: "-m32 -DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
+Test clang-3.5 32bit_word:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang35_0.7
+  variables:
+    CC: clang-3.5
+    CXX: clang++-3.5
+    LD: clang-3.5
+    CFLAGS: "-m32 -DMRB_WORD_BOXING=1"
+    LDFLAGS: "-m32"
+  script: env; rake --verbose all test
+Test clang-3.5 32bit_word_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang35_0.7
+  variables:
+    CC: clang-3.5
+    CXX: clang++-3.5
+    LD: clang-3.5
+    CFLAGS: "-m32 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; rake --verbose all test
 Test clang-3.5 32bit_int16:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang35_0.7
@@ -1661,7 +2281,7 @@ Test clang-3.5 32bit_int16:
     LD: clang-3.5
     CFLAGS: "-m32 -DMRB_INT16=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.5 32bit_int16_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang35_0.7
@@ -1671,7 +2291,7 @@ Test clang-3.5 32bit_int16_utf8:
     LD: clang-3.5
     CFLAGS: "-m32 -DMRB_INT16=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.5 32bit_int16_nan:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang35_0.7
@@ -1681,7 +2301,7 @@ Test clang-3.5 32bit_int16_nan:
     LD: clang-3.5
     CFLAGS: "-m32 -DMRB_INT16=1 -DMRB_NAN_BOXING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.5 32bit_int16_nan_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang35_0.7
@@ -1691,7 +2311,7 @@ Test clang-3.5 32bit_int16_nan_utf8:
     LD: clang-3.5
     CFLAGS: "-m32 -DMRB_INT16=1 -DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.5 32bit_int64:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang35_0.7
@@ -1701,7 +2321,7 @@ Test clang-3.5 32bit_int64:
     LD: clang-3.5
     CFLAGS: "-m32 -DMRB_INT64=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.5 32bit_int64_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang35_0.7
@@ -1711,8 +2331,28 @@ Test clang-3.5 32bit_int64_utf8:
     LD: clang-3.5
     CFLAGS: "-m32 -DMRB_INT64=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.5 32bit_float:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang35_0.7
+  variables:
+    CC: clang-3.5
+    CXX: clang++-3.5
+    LD: clang-3.5
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1"
+    LDFLAGS: "-m32"
+  script: env; rake --verbose all test
+Test clang-3.5 32bit_float_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang35_0.7
+  variables:
+    CC: clang-3.5
+    CXX: clang++-3.5
+    LD: clang-3.5
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; rake --verbose all test
+Test clang-3.5 32bit_float_word:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang35_0.7
   variables:
@@ -1721,8 +2361,8 @@ Test clang-3.5 32bit_float:
     LD: clang-3.5
     CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
-Test clang-3.5 32bit_float_utf8:
+  script: env; rake --verbose all test
+Test clang-3.5 32bit_float_word_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang35_0.7
   variables:
@@ -1731,7 +2371,7 @@ Test clang-3.5 32bit_float_utf8:
     LD: clang-3.5
     CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.5 32bit_float_int16:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang35_0.7
@@ -1741,7 +2381,7 @@ Test clang-3.5 32bit_float_int16:
     LD: clang-3.5
     CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT16=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.5 32bit_float_int16_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang35_0.7
@@ -1751,7 +2391,7 @@ Test clang-3.5 32bit_float_int16_utf8:
     LD: clang-3.5
     CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT16=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.5 32bit_float_int64:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang35_0.7
@@ -1761,7 +2401,7 @@ Test clang-3.5 32bit_float_int64:
     LD: clang-3.5
     CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT64=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.5 32bit_float_int64_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang35_0.7
@@ -1771,7 +2411,7 @@ Test clang-3.5 32bit_float_int64_utf8:
     LD: clang-3.5
     CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT64=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.5 64bit:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang35_0.7
@@ -1779,9 +2419,9 @@ Test clang-3.5 64bit:
     CC: clang-3.5
     CXX: clang++-3.5
     LD: clang-3.5
-    CFLAGS: "-DMRB_WORD_BOXING=1"
+    CFLAGS: ''
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.5 64bit_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang35_0.7
@@ -1789,9 +2429,9 @@ Test clang-3.5 64bit_utf8:
     CC: clang-3.5
     CXX: clang++-3.5
     LD: clang-3.5
-    CFLAGS: "-DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    CFLAGS: "-DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.5 64bit_nan:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang35_0.7
@@ -1801,7 +2441,7 @@ Test clang-3.5 64bit_nan:
     LD: clang-3.5
     CFLAGS: "-DMRB_NAN_BOXING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.5 64bit_nan_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang35_0.7
@@ -1811,7 +2451,27 @@ Test clang-3.5 64bit_nan_utf8:
     LD: clang-3.5
     CFLAGS: "-DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
+Test clang-3.5 64bit_word:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang35_0.7
+  variables:
+    CC: clang-3.5
+    CXX: clang++-3.5
+    LD: clang-3.5
+    CFLAGS: "-DMRB_WORD_BOXING=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
+Test clang-3.5 64bit_word_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang35_0.7
+  variables:
+    CC: clang-3.5
+    CXX: clang++-3.5
+    LD: clang-3.5
+    CFLAGS: "-DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
 Test clang-3.5 64bit_int16:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang35_0.7
@@ -1821,7 +2481,7 @@ Test clang-3.5 64bit_int16:
     LD: clang-3.5
     CFLAGS: "-DMRB_INT16=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.5 64bit_int16_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang35_0.7
@@ -1831,7 +2491,7 @@ Test clang-3.5 64bit_int16_utf8:
     LD: clang-3.5
     CFLAGS: "-DMRB_INT16=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.5 64bit_int16_nan:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang35_0.7
@@ -1841,7 +2501,7 @@ Test clang-3.5 64bit_int16_nan:
     LD: clang-3.5
     CFLAGS: "-DMRB_INT16=1 -DMRB_NAN_BOXING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.5 64bit_int16_nan_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang35_0.7
@@ -1851,8 +2511,28 @@ Test clang-3.5 64bit_int16_nan_utf8:
     LD: clang-3.5
     CFLAGS: "-DMRB_INT16=1 -DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.5 64bit_int64:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang35_0.7
+  variables:
+    CC: clang-3.5
+    CXX: clang++-3.5
+    LD: clang-3.5
+    CFLAGS: "-DMRB_INT64=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
+Test clang-3.5 64bit_int64_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang35_0.7
+  variables:
+    CC: clang-3.5
+    CXX: clang++-3.5
+    LD: clang-3.5
+    CFLAGS: "-DMRB_INT64=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
+Test clang-3.5 64bit_int64_word:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang35_0.7
   variables:
@@ -1861,8 +2541,8 @@ Test clang-3.5 64bit_int64:
     LD: clang-3.5
     CFLAGS: "-DMRB_INT64=1 -DMRB_WORD_BOXING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
-Test clang-3.5 64bit_int64_utf8:
+  script: env; rake --verbose all test
+Test clang-3.5 64bit_int64_word_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang35_0.7
   variables:
@@ -1871,8 +2551,28 @@ Test clang-3.5 64bit_int64_utf8:
     LD: clang-3.5
     CFLAGS: "-DMRB_INT64=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.5 64bit_float:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang35_0.7
+  variables:
+    CC: clang-3.5
+    CXX: clang++-3.5
+    LD: clang-3.5
+    CFLAGS: "-DMRB_USE_FLOAT=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
+Test clang-3.5 64bit_float_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang35_0.7
+  variables:
+    CC: clang-3.5
+    CXX: clang++-3.5
+    LD: clang-3.5
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
+Test clang-3.5 64bit_float_word:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang35_0.7
   variables:
@@ -1881,8 +2581,8 @@ Test clang-3.5 64bit_float:
     LD: clang-3.5
     CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
-Test clang-3.5 64bit_float_utf8:
+  script: env; rake --verbose all test
+Test clang-3.5 64bit_float_word_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang35_0.7
   variables:
@@ -1891,7 +2591,7 @@ Test clang-3.5 64bit_float_utf8:
     LD: clang-3.5
     CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.5 64bit_float_int16:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang35_0.7
@@ -1901,7 +2601,7 @@ Test clang-3.5 64bit_float_int16:
     LD: clang-3.5
     CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT16=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.5 64bit_float_int16_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang35_0.7
@@ -1911,8 +2611,28 @@ Test clang-3.5 64bit_float_int16_utf8:
     LD: clang-3.5
     CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT16=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.5 64bit_float_int64:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang35_0.7
+  variables:
+    CC: clang-3.5
+    CXX: clang++-3.5
+    LD: clang-3.5
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT64=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
+Test clang-3.5 64bit_float_int64_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang35_0.7
+  variables:
+    CC: clang-3.5
+    CXX: clang++-3.5
+    LD: clang-3.5
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT64=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
+Test clang-3.5 64bit_float_int64_word:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang35_0.7
   variables:
@@ -1921,8 +2641,8 @@ Test clang-3.5 64bit_float_int64:
     LD: clang-3.5
     CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT64=1 -DMRB_WORD_BOXING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
-Test clang-3.5 64bit_float_int64_utf8:
+  script: env; rake --verbose all test
+Test clang-3.5 64bit_float_int64_word_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang35_0.7
   variables:
@@ -1931,7 +2651,7 @@ Test clang-3.5 64bit_float_int64_utf8:
     LD: clang-3.5
     CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT64=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.6 32bit:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang36_0.7
@@ -1939,9 +2659,9 @@ Test clang-3.6 32bit:
     CC: clang-3.6
     CXX: clang++-3.6
     LD: clang-3.6
-    CFLAGS: "-m32 -DMRB_WORD_BOXING=1"
+    CFLAGS: "-m32 "
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.6 32bit_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang36_0.7
@@ -1949,9 +2669,9 @@ Test clang-3.6 32bit_utf8:
     CC: clang-3.6
     CXX: clang++-3.6
     LD: clang-3.6
-    CFLAGS: "-m32 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    CFLAGS: "-m32 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.6 32bit_nan:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang36_0.7
@@ -1961,7 +2681,7 @@ Test clang-3.6 32bit_nan:
     LD: clang-3.6
     CFLAGS: "-m32 -DMRB_NAN_BOXING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.6 32bit_nan_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang36_0.7
@@ -1971,7 +2691,27 @@ Test clang-3.6 32bit_nan_utf8:
     LD: clang-3.6
     CFLAGS: "-m32 -DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
+Test clang-3.6 32bit_word:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang36_0.7
+  variables:
+    CC: clang-3.6
+    CXX: clang++-3.6
+    LD: clang-3.6
+    CFLAGS: "-m32 -DMRB_WORD_BOXING=1"
+    LDFLAGS: "-m32"
+  script: env; rake --verbose all test
+Test clang-3.6 32bit_word_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang36_0.7
+  variables:
+    CC: clang-3.6
+    CXX: clang++-3.6
+    LD: clang-3.6
+    CFLAGS: "-m32 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; rake --verbose all test
 Test clang-3.6 32bit_int16:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang36_0.7
@@ -1981,7 +2721,7 @@ Test clang-3.6 32bit_int16:
     LD: clang-3.6
     CFLAGS: "-m32 -DMRB_INT16=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.6 32bit_int16_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang36_0.7
@@ -1991,7 +2731,7 @@ Test clang-3.6 32bit_int16_utf8:
     LD: clang-3.6
     CFLAGS: "-m32 -DMRB_INT16=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.6 32bit_int16_nan:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang36_0.7
@@ -2001,7 +2741,7 @@ Test clang-3.6 32bit_int16_nan:
     LD: clang-3.6
     CFLAGS: "-m32 -DMRB_INT16=1 -DMRB_NAN_BOXING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.6 32bit_int16_nan_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang36_0.7
@@ -2011,7 +2751,7 @@ Test clang-3.6 32bit_int16_nan_utf8:
     LD: clang-3.6
     CFLAGS: "-m32 -DMRB_INT16=1 -DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.6 32bit_int64:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang36_0.7
@@ -2021,7 +2761,7 @@ Test clang-3.6 32bit_int64:
     LD: clang-3.6
     CFLAGS: "-m32 -DMRB_INT64=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.6 32bit_int64_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang36_0.7
@@ -2031,8 +2771,28 @@ Test clang-3.6 32bit_int64_utf8:
     LD: clang-3.6
     CFLAGS: "-m32 -DMRB_INT64=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.6 32bit_float:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang36_0.7
+  variables:
+    CC: clang-3.6
+    CXX: clang++-3.6
+    LD: clang-3.6
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1"
+    LDFLAGS: "-m32"
+  script: env; rake --verbose all test
+Test clang-3.6 32bit_float_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang36_0.7
+  variables:
+    CC: clang-3.6
+    CXX: clang++-3.6
+    LD: clang-3.6
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; rake --verbose all test
+Test clang-3.6 32bit_float_word:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang36_0.7
   variables:
@@ -2041,8 +2801,8 @@ Test clang-3.6 32bit_float:
     LD: clang-3.6
     CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
-Test clang-3.6 32bit_float_utf8:
+  script: env; rake --verbose all test
+Test clang-3.6 32bit_float_word_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang36_0.7
   variables:
@@ -2051,7 +2811,7 @@ Test clang-3.6 32bit_float_utf8:
     LD: clang-3.6
     CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.6 32bit_float_int16:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang36_0.7
@@ -2061,7 +2821,7 @@ Test clang-3.6 32bit_float_int16:
     LD: clang-3.6
     CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT16=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.6 32bit_float_int16_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang36_0.7
@@ -2071,7 +2831,7 @@ Test clang-3.6 32bit_float_int16_utf8:
     LD: clang-3.6
     CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT16=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.6 32bit_float_int64:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang36_0.7
@@ -2081,7 +2841,7 @@ Test clang-3.6 32bit_float_int64:
     LD: clang-3.6
     CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT64=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.6 32bit_float_int64_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang36_0.7
@@ -2091,7 +2851,7 @@ Test clang-3.6 32bit_float_int64_utf8:
     LD: clang-3.6
     CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT64=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.6 64bit:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang36_0.7
@@ -2099,9 +2859,9 @@ Test clang-3.6 64bit:
     CC: clang-3.6
     CXX: clang++-3.6
     LD: clang-3.6
-    CFLAGS: "-DMRB_WORD_BOXING=1"
+    CFLAGS: ''
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.6 64bit_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang36_0.7
@@ -2109,9 +2869,9 @@ Test clang-3.6 64bit_utf8:
     CC: clang-3.6
     CXX: clang++-3.6
     LD: clang-3.6
-    CFLAGS: "-DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    CFLAGS: "-DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.6 64bit_nan:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang36_0.7
@@ -2121,7 +2881,7 @@ Test clang-3.6 64bit_nan:
     LD: clang-3.6
     CFLAGS: "-DMRB_NAN_BOXING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.6 64bit_nan_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang36_0.7
@@ -2131,7 +2891,27 @@ Test clang-3.6 64bit_nan_utf8:
     LD: clang-3.6
     CFLAGS: "-DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
+Test clang-3.6 64bit_word:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang36_0.7
+  variables:
+    CC: clang-3.6
+    CXX: clang++-3.6
+    LD: clang-3.6
+    CFLAGS: "-DMRB_WORD_BOXING=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
+Test clang-3.6 64bit_word_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang36_0.7
+  variables:
+    CC: clang-3.6
+    CXX: clang++-3.6
+    LD: clang-3.6
+    CFLAGS: "-DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
 Test clang-3.6 64bit_int16:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang36_0.7
@@ -2141,7 +2921,7 @@ Test clang-3.6 64bit_int16:
     LD: clang-3.6
     CFLAGS: "-DMRB_INT16=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.6 64bit_int16_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang36_0.7
@@ -2151,7 +2931,7 @@ Test clang-3.6 64bit_int16_utf8:
     LD: clang-3.6
     CFLAGS: "-DMRB_INT16=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.6 64bit_int16_nan:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang36_0.7
@@ -2161,7 +2941,7 @@ Test clang-3.6 64bit_int16_nan:
     LD: clang-3.6
     CFLAGS: "-DMRB_INT16=1 -DMRB_NAN_BOXING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.6 64bit_int16_nan_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang36_0.7
@@ -2171,8 +2951,28 @@ Test clang-3.6 64bit_int16_nan_utf8:
     LD: clang-3.6
     CFLAGS: "-DMRB_INT16=1 -DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.6 64bit_int64:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang36_0.7
+  variables:
+    CC: clang-3.6
+    CXX: clang++-3.6
+    LD: clang-3.6
+    CFLAGS: "-DMRB_INT64=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
+Test clang-3.6 64bit_int64_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang36_0.7
+  variables:
+    CC: clang-3.6
+    CXX: clang++-3.6
+    LD: clang-3.6
+    CFLAGS: "-DMRB_INT64=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
+Test clang-3.6 64bit_int64_word:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang36_0.7
   variables:
@@ -2181,8 +2981,8 @@ Test clang-3.6 64bit_int64:
     LD: clang-3.6
     CFLAGS: "-DMRB_INT64=1 -DMRB_WORD_BOXING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
-Test clang-3.6 64bit_int64_utf8:
+  script: env; rake --verbose all test
+Test clang-3.6 64bit_int64_word_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang36_0.7
   variables:
@@ -2191,8 +2991,28 @@ Test clang-3.6 64bit_int64_utf8:
     LD: clang-3.6
     CFLAGS: "-DMRB_INT64=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.6 64bit_float:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang36_0.7
+  variables:
+    CC: clang-3.6
+    CXX: clang++-3.6
+    LD: clang-3.6
+    CFLAGS: "-DMRB_USE_FLOAT=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
+Test clang-3.6 64bit_float_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang36_0.7
+  variables:
+    CC: clang-3.6
+    CXX: clang++-3.6
+    LD: clang-3.6
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
+Test clang-3.6 64bit_float_word:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang36_0.7
   variables:
@@ -2201,8 +3021,8 @@ Test clang-3.6 64bit_float:
     LD: clang-3.6
     CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
-Test clang-3.6 64bit_float_utf8:
+  script: env; rake --verbose all test
+Test clang-3.6 64bit_float_word_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang36_0.7
   variables:
@@ -2211,7 +3031,7 @@ Test clang-3.6 64bit_float_utf8:
     LD: clang-3.6
     CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.6 64bit_float_int16:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang36_0.7
@@ -2221,7 +3041,7 @@ Test clang-3.6 64bit_float_int16:
     LD: clang-3.6
     CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT16=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.6 64bit_float_int16_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang36_0.7
@@ -2231,8 +3051,28 @@ Test clang-3.6 64bit_float_int16_utf8:
     LD: clang-3.6
     CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT16=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.6 64bit_float_int64:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang36_0.7
+  variables:
+    CC: clang-3.6
+    CXX: clang++-3.6
+    LD: clang-3.6
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT64=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
+Test clang-3.6 64bit_float_int64_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang36_0.7
+  variables:
+    CC: clang-3.6
+    CXX: clang++-3.6
+    LD: clang-3.6
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT64=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
+Test clang-3.6 64bit_float_int64_word:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang36_0.7
   variables:
@@ -2241,8 +3081,8 @@ Test clang-3.6 64bit_float_int64:
     LD: clang-3.6
     CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT64=1 -DMRB_WORD_BOXING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
-Test clang-3.6 64bit_float_int64_utf8:
+  script: env; rake --verbose all test
+Test clang-3.6 64bit_float_int64_word_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang36_0.7
   variables:
@@ -2251,7 +3091,7 @@ Test clang-3.6 64bit_float_int64_utf8:
     LD: clang-3.6
     CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT64=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.7 32bit:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang37_0.7
@@ -2259,9 +3099,9 @@ Test clang-3.7 32bit:
     CC: clang-3.7
     CXX: clang++-3.7
     LD: clang-3.7
-    CFLAGS: "-m32 -DMRB_WORD_BOXING=1"
+    CFLAGS: "-m32 "
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.7 32bit_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang37_0.7
@@ -2269,9 +3109,9 @@ Test clang-3.7 32bit_utf8:
     CC: clang-3.7
     CXX: clang++-3.7
     LD: clang-3.7
-    CFLAGS: "-m32 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    CFLAGS: "-m32 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.7 32bit_nan:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang37_0.7
@@ -2281,7 +3121,7 @@ Test clang-3.7 32bit_nan:
     LD: clang-3.7
     CFLAGS: "-m32 -DMRB_NAN_BOXING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.7 32bit_nan_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang37_0.7
@@ -2291,7 +3131,27 @@ Test clang-3.7 32bit_nan_utf8:
     LD: clang-3.7
     CFLAGS: "-m32 -DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
+Test clang-3.7 32bit_word:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang37_0.7
+  variables:
+    CC: clang-3.7
+    CXX: clang++-3.7
+    LD: clang-3.7
+    CFLAGS: "-m32 -DMRB_WORD_BOXING=1"
+    LDFLAGS: "-m32"
+  script: env; rake --verbose all test
+Test clang-3.7 32bit_word_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang37_0.7
+  variables:
+    CC: clang-3.7
+    CXX: clang++-3.7
+    LD: clang-3.7
+    CFLAGS: "-m32 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; rake --verbose all test
 Test clang-3.7 32bit_int16:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang37_0.7
@@ -2301,7 +3161,7 @@ Test clang-3.7 32bit_int16:
     LD: clang-3.7
     CFLAGS: "-m32 -DMRB_INT16=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.7 32bit_int16_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang37_0.7
@@ -2311,7 +3171,7 @@ Test clang-3.7 32bit_int16_utf8:
     LD: clang-3.7
     CFLAGS: "-m32 -DMRB_INT16=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.7 32bit_int16_nan:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang37_0.7
@@ -2321,7 +3181,7 @@ Test clang-3.7 32bit_int16_nan:
     LD: clang-3.7
     CFLAGS: "-m32 -DMRB_INT16=1 -DMRB_NAN_BOXING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.7 32bit_int16_nan_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang37_0.7
@@ -2331,7 +3191,7 @@ Test clang-3.7 32bit_int16_nan_utf8:
     LD: clang-3.7
     CFLAGS: "-m32 -DMRB_INT16=1 -DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.7 32bit_int64:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang37_0.7
@@ -2341,7 +3201,7 @@ Test clang-3.7 32bit_int64:
     LD: clang-3.7
     CFLAGS: "-m32 -DMRB_INT64=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.7 32bit_int64_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang37_0.7
@@ -2351,8 +3211,28 @@ Test clang-3.7 32bit_int64_utf8:
     LD: clang-3.7
     CFLAGS: "-m32 -DMRB_INT64=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.7 32bit_float:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang37_0.7
+  variables:
+    CC: clang-3.7
+    CXX: clang++-3.7
+    LD: clang-3.7
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1"
+    LDFLAGS: "-m32"
+  script: env; rake --verbose all test
+Test clang-3.7 32bit_float_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang37_0.7
+  variables:
+    CC: clang-3.7
+    CXX: clang++-3.7
+    LD: clang-3.7
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; rake --verbose all test
+Test clang-3.7 32bit_float_word:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang37_0.7
   variables:
@@ -2361,8 +3241,8 @@ Test clang-3.7 32bit_float:
     LD: clang-3.7
     CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
-Test clang-3.7 32bit_float_utf8:
+  script: env; rake --verbose all test
+Test clang-3.7 32bit_float_word_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang37_0.7
   variables:
@@ -2371,7 +3251,7 @@ Test clang-3.7 32bit_float_utf8:
     LD: clang-3.7
     CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.7 32bit_float_int16:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang37_0.7
@@ -2381,7 +3261,7 @@ Test clang-3.7 32bit_float_int16:
     LD: clang-3.7
     CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT16=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.7 32bit_float_int16_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang37_0.7
@@ -2391,7 +3271,7 @@ Test clang-3.7 32bit_float_int16_utf8:
     LD: clang-3.7
     CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT16=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.7 32bit_float_int64:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang37_0.7
@@ -2401,7 +3281,7 @@ Test clang-3.7 32bit_float_int64:
     LD: clang-3.7
     CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT64=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.7 32bit_float_int64_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang37_0.7
@@ -2411,7 +3291,7 @@ Test clang-3.7 32bit_float_int64_utf8:
     LD: clang-3.7
     CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT64=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.7 64bit:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang37_0.7
@@ -2419,9 +3299,9 @@ Test clang-3.7 64bit:
     CC: clang-3.7
     CXX: clang++-3.7
     LD: clang-3.7
-    CFLAGS: "-DMRB_WORD_BOXING=1"
+    CFLAGS: ''
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.7 64bit_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang37_0.7
@@ -2429,9 +3309,9 @@ Test clang-3.7 64bit_utf8:
     CC: clang-3.7
     CXX: clang++-3.7
     LD: clang-3.7
-    CFLAGS: "-DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    CFLAGS: "-DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.7 64bit_nan:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang37_0.7
@@ -2441,7 +3321,7 @@ Test clang-3.7 64bit_nan:
     LD: clang-3.7
     CFLAGS: "-DMRB_NAN_BOXING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.7 64bit_nan_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang37_0.7
@@ -2451,7 +3331,27 @@ Test clang-3.7 64bit_nan_utf8:
     LD: clang-3.7
     CFLAGS: "-DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
+Test clang-3.7 64bit_word:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang37_0.7
+  variables:
+    CC: clang-3.7
+    CXX: clang++-3.7
+    LD: clang-3.7
+    CFLAGS: "-DMRB_WORD_BOXING=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
+Test clang-3.7 64bit_word_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang37_0.7
+  variables:
+    CC: clang-3.7
+    CXX: clang++-3.7
+    LD: clang-3.7
+    CFLAGS: "-DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
 Test clang-3.7 64bit_int16:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang37_0.7
@@ -2461,7 +3361,7 @@ Test clang-3.7 64bit_int16:
     LD: clang-3.7
     CFLAGS: "-DMRB_INT16=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.7 64bit_int16_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang37_0.7
@@ -2471,7 +3371,7 @@ Test clang-3.7 64bit_int16_utf8:
     LD: clang-3.7
     CFLAGS: "-DMRB_INT16=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.7 64bit_int16_nan:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang37_0.7
@@ -2481,7 +3381,7 @@ Test clang-3.7 64bit_int16_nan:
     LD: clang-3.7
     CFLAGS: "-DMRB_INT16=1 -DMRB_NAN_BOXING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.7 64bit_int16_nan_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang37_0.7
@@ -2491,8 +3391,28 @@ Test clang-3.7 64bit_int16_nan_utf8:
     LD: clang-3.7
     CFLAGS: "-DMRB_INT16=1 -DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.7 64bit_int64:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang37_0.7
+  variables:
+    CC: clang-3.7
+    CXX: clang++-3.7
+    LD: clang-3.7
+    CFLAGS: "-DMRB_INT64=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
+Test clang-3.7 64bit_int64_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang37_0.7
+  variables:
+    CC: clang-3.7
+    CXX: clang++-3.7
+    LD: clang-3.7
+    CFLAGS: "-DMRB_INT64=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
+Test clang-3.7 64bit_int64_word:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang37_0.7
   variables:
@@ -2501,8 +3421,8 @@ Test clang-3.7 64bit_int64:
     LD: clang-3.7
     CFLAGS: "-DMRB_INT64=1 -DMRB_WORD_BOXING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
-Test clang-3.7 64bit_int64_utf8:
+  script: env; rake --verbose all test
+Test clang-3.7 64bit_int64_word_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang37_0.7
   variables:
@@ -2511,8 +3431,28 @@ Test clang-3.7 64bit_int64_utf8:
     LD: clang-3.7
     CFLAGS: "-DMRB_INT64=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.7 64bit_float:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang37_0.7
+  variables:
+    CC: clang-3.7
+    CXX: clang++-3.7
+    LD: clang-3.7
+    CFLAGS: "-DMRB_USE_FLOAT=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
+Test clang-3.7 64bit_float_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang37_0.7
+  variables:
+    CC: clang-3.7
+    CXX: clang++-3.7
+    LD: clang-3.7
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
+Test clang-3.7 64bit_float_word:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang37_0.7
   variables:
@@ -2521,8 +3461,8 @@ Test clang-3.7 64bit_float:
     LD: clang-3.7
     CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
-Test clang-3.7 64bit_float_utf8:
+  script: env; rake --verbose all test
+Test clang-3.7 64bit_float_word_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang37_0.7
   variables:
@@ -2531,7 +3471,7 @@ Test clang-3.7 64bit_float_utf8:
     LD: clang-3.7
     CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.7 64bit_float_int16:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang37_0.7
@@ -2541,7 +3481,7 @@ Test clang-3.7 64bit_float_int16:
     LD: clang-3.7
     CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT16=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.7 64bit_float_int16_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang37_0.7
@@ -2551,8 +3491,28 @@ Test clang-3.7 64bit_float_int16_utf8:
     LD: clang-3.7
     CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT16=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.7 64bit_float_int64:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang37_0.7
+  variables:
+    CC: clang-3.7
+    CXX: clang++-3.7
+    LD: clang-3.7
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT64=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
+Test clang-3.7 64bit_float_int64_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang37_0.7
+  variables:
+    CC: clang-3.7
+    CXX: clang++-3.7
+    LD: clang-3.7
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT64=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
+Test clang-3.7 64bit_float_int64_word:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang37_0.7
   variables:
@@ -2561,8 +3521,8 @@ Test clang-3.7 64bit_float_int64:
     LD: clang-3.7
     CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT64=1 -DMRB_WORD_BOXING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
-Test clang-3.7 64bit_float_int64_utf8:
+  script: env; rake --verbose all test
+Test clang-3.7 64bit_float_int64_word_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang37_0.7
   variables:
@@ -2571,7 +3531,7 @@ Test clang-3.7 64bit_float_int64_utf8:
     LD: clang-3.7
     CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT64=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.8 32bit:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang38_0.7
@@ -2579,9 +3539,9 @@ Test clang-3.8 32bit:
     CC: clang-3.8
     CXX: clang++-3.8
     LD: clang-3.8
-    CFLAGS: "-m32 -DMRB_WORD_BOXING=1"
+    CFLAGS: "-m32 "
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.8 32bit_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang38_0.7
@@ -2589,9 +3549,9 @@ Test clang-3.8 32bit_utf8:
     CC: clang-3.8
     CXX: clang++-3.8
     LD: clang-3.8
-    CFLAGS: "-m32 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    CFLAGS: "-m32 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.8 32bit_nan:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang38_0.7
@@ -2601,7 +3561,7 @@ Test clang-3.8 32bit_nan:
     LD: clang-3.8
     CFLAGS: "-m32 -DMRB_NAN_BOXING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.8 32bit_nan_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang38_0.7
@@ -2611,7 +3571,27 @@ Test clang-3.8 32bit_nan_utf8:
     LD: clang-3.8
     CFLAGS: "-m32 -DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
+Test clang-3.8 32bit_word:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang38_0.7
+  variables:
+    CC: clang-3.8
+    CXX: clang++-3.8
+    LD: clang-3.8
+    CFLAGS: "-m32 -DMRB_WORD_BOXING=1"
+    LDFLAGS: "-m32"
+  script: env; rake --verbose all test
+Test clang-3.8 32bit_word_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang38_0.7
+  variables:
+    CC: clang-3.8
+    CXX: clang++-3.8
+    LD: clang-3.8
+    CFLAGS: "-m32 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; rake --verbose all test
 Test clang-3.8 32bit_int16:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang38_0.7
@@ -2621,7 +3601,7 @@ Test clang-3.8 32bit_int16:
     LD: clang-3.8
     CFLAGS: "-m32 -DMRB_INT16=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.8 32bit_int16_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang38_0.7
@@ -2631,7 +3611,7 @@ Test clang-3.8 32bit_int16_utf8:
     LD: clang-3.8
     CFLAGS: "-m32 -DMRB_INT16=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.8 32bit_int16_nan:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang38_0.7
@@ -2641,7 +3621,7 @@ Test clang-3.8 32bit_int16_nan:
     LD: clang-3.8
     CFLAGS: "-m32 -DMRB_INT16=1 -DMRB_NAN_BOXING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.8 32bit_int16_nan_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang38_0.7
@@ -2651,7 +3631,7 @@ Test clang-3.8 32bit_int16_nan_utf8:
     LD: clang-3.8
     CFLAGS: "-m32 -DMRB_INT16=1 -DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.8 32bit_int64:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang38_0.7
@@ -2661,7 +3641,7 @@ Test clang-3.8 32bit_int64:
     LD: clang-3.8
     CFLAGS: "-m32 -DMRB_INT64=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.8 32bit_int64_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang38_0.7
@@ -2671,8 +3651,28 @@ Test clang-3.8 32bit_int64_utf8:
     LD: clang-3.8
     CFLAGS: "-m32 -DMRB_INT64=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.8 32bit_float:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang38_0.7
+  variables:
+    CC: clang-3.8
+    CXX: clang++-3.8
+    LD: clang-3.8
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1"
+    LDFLAGS: "-m32"
+  script: env; rake --verbose all test
+Test clang-3.8 32bit_float_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang38_0.7
+  variables:
+    CC: clang-3.8
+    CXX: clang++-3.8
+    LD: clang-3.8
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; rake --verbose all test
+Test clang-3.8 32bit_float_word:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang38_0.7
   variables:
@@ -2681,8 +3681,8 @@ Test clang-3.8 32bit_float:
     LD: clang-3.8
     CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
-Test clang-3.8 32bit_float_utf8:
+  script: env; rake --verbose all test
+Test clang-3.8 32bit_float_word_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang38_0.7
   variables:
@@ -2691,7 +3691,7 @@ Test clang-3.8 32bit_float_utf8:
     LD: clang-3.8
     CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.8 32bit_float_int16:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang38_0.7
@@ -2701,7 +3701,7 @@ Test clang-3.8 32bit_float_int16:
     LD: clang-3.8
     CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT16=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.8 32bit_float_int16_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang38_0.7
@@ -2711,7 +3711,7 @@ Test clang-3.8 32bit_float_int16_utf8:
     LD: clang-3.8
     CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT16=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.8 32bit_float_int64:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang38_0.7
@@ -2721,7 +3721,7 @@ Test clang-3.8 32bit_float_int64:
     LD: clang-3.8
     CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT64=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.8 32bit_float_int64_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang38_0.7
@@ -2731,7 +3731,7 @@ Test clang-3.8 32bit_float_int64_utf8:
     LD: clang-3.8
     CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT64=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.8 64bit:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang38_0.7
@@ -2739,9 +3739,9 @@ Test clang-3.8 64bit:
     CC: clang-3.8
     CXX: clang++-3.8
     LD: clang-3.8
-    CFLAGS: "-DMRB_WORD_BOXING=1"
+    CFLAGS: ''
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.8 64bit_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang38_0.7
@@ -2749,9 +3749,9 @@ Test clang-3.8 64bit_utf8:
     CC: clang-3.8
     CXX: clang++-3.8
     LD: clang-3.8
-    CFLAGS: "-DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    CFLAGS: "-DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.8 64bit_nan:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang38_0.7
@@ -2761,7 +3761,7 @@ Test clang-3.8 64bit_nan:
     LD: clang-3.8
     CFLAGS: "-DMRB_NAN_BOXING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.8 64bit_nan_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang38_0.7
@@ -2771,7 +3771,27 @@ Test clang-3.8 64bit_nan_utf8:
     LD: clang-3.8
     CFLAGS: "-DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
+Test clang-3.8 64bit_word:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang38_0.7
+  variables:
+    CC: clang-3.8
+    CXX: clang++-3.8
+    LD: clang-3.8
+    CFLAGS: "-DMRB_WORD_BOXING=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
+Test clang-3.8 64bit_word_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang38_0.7
+  variables:
+    CC: clang-3.8
+    CXX: clang++-3.8
+    LD: clang-3.8
+    CFLAGS: "-DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
 Test clang-3.8 64bit_int16:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang38_0.7
@@ -2781,7 +3801,7 @@ Test clang-3.8 64bit_int16:
     LD: clang-3.8
     CFLAGS: "-DMRB_INT16=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.8 64bit_int16_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang38_0.7
@@ -2791,7 +3811,7 @@ Test clang-3.8 64bit_int16_utf8:
     LD: clang-3.8
     CFLAGS: "-DMRB_INT16=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.8 64bit_int16_nan:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang38_0.7
@@ -2801,7 +3821,7 @@ Test clang-3.8 64bit_int16_nan:
     LD: clang-3.8
     CFLAGS: "-DMRB_INT16=1 -DMRB_NAN_BOXING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.8 64bit_int16_nan_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang38_0.7
@@ -2811,8 +3831,28 @@ Test clang-3.8 64bit_int16_nan_utf8:
     LD: clang-3.8
     CFLAGS: "-DMRB_INT16=1 -DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.8 64bit_int64:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang38_0.7
+  variables:
+    CC: clang-3.8
+    CXX: clang++-3.8
+    LD: clang-3.8
+    CFLAGS: "-DMRB_INT64=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
+Test clang-3.8 64bit_int64_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang38_0.7
+  variables:
+    CC: clang-3.8
+    CXX: clang++-3.8
+    LD: clang-3.8
+    CFLAGS: "-DMRB_INT64=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
+Test clang-3.8 64bit_int64_word:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang38_0.7
   variables:
@@ -2821,8 +3861,8 @@ Test clang-3.8 64bit_int64:
     LD: clang-3.8
     CFLAGS: "-DMRB_INT64=1 -DMRB_WORD_BOXING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
-Test clang-3.8 64bit_int64_utf8:
+  script: env; rake --verbose all test
+Test clang-3.8 64bit_int64_word_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang38_0.7
   variables:
@@ -2831,8 +3871,28 @@ Test clang-3.8 64bit_int64_utf8:
     LD: clang-3.8
     CFLAGS: "-DMRB_INT64=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.8 64bit_float:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang38_0.7
+  variables:
+    CC: clang-3.8
+    CXX: clang++-3.8
+    LD: clang-3.8
+    CFLAGS: "-DMRB_USE_FLOAT=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
+Test clang-3.8 64bit_float_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang38_0.7
+  variables:
+    CC: clang-3.8
+    CXX: clang++-3.8
+    LD: clang-3.8
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
+Test clang-3.8 64bit_float_word:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang38_0.7
   variables:
@@ -2841,8 +3901,8 @@ Test clang-3.8 64bit_float:
     LD: clang-3.8
     CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
-Test clang-3.8 64bit_float_utf8:
+  script: env; rake --verbose all test
+Test clang-3.8 64bit_float_word_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang38_0.7
   variables:
@@ -2851,7 +3911,7 @@ Test clang-3.8 64bit_float_utf8:
     LD: clang-3.8
     CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.8 64bit_float_int16:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang38_0.7
@@ -2861,7 +3921,7 @@ Test clang-3.8 64bit_float_int16:
     LD: clang-3.8
     CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT16=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.8 64bit_float_int16_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang38_0.7
@@ -2871,8 +3931,28 @@ Test clang-3.8 64bit_float_int16_utf8:
     LD: clang-3.8
     CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT16=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.8 64bit_float_int64:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang38_0.7
+  variables:
+    CC: clang-3.8
+    CXX: clang++-3.8
+    LD: clang-3.8
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT64=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
+Test clang-3.8 64bit_float_int64_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang38_0.7
+  variables:
+    CC: clang-3.8
+    CXX: clang++-3.8
+    LD: clang-3.8
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT64=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
+Test clang-3.8 64bit_float_int64_word:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang38_0.7
   variables:
@@ -2881,8 +3961,8 @@ Test clang-3.8 64bit_float_int64:
     LD: clang-3.8
     CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT64=1 -DMRB_WORD_BOXING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
-Test clang-3.8 64bit_float_int64_utf8:
+  script: env; rake --verbose all test
+Test clang-3.8 64bit_float_int64_word_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang38_0.7
   variables:
@@ -2891,7 +3971,7 @@ Test clang-3.8 64bit_float_int64_utf8:
     LD: clang-3.8
     CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT64=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.9 32bit:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang39_0.7
@@ -2899,9 +3979,9 @@ Test clang-3.9 32bit:
     CC: clang-3.9
     CXX: clang++-3.9
     LD: clang-3.9
-    CFLAGS: "-m32 -DMRB_WORD_BOXING=1"
+    CFLAGS: "-m32 "
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.9 32bit_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang39_0.7
@@ -2909,9 +3989,9 @@ Test clang-3.9 32bit_utf8:
     CC: clang-3.9
     CXX: clang++-3.9
     LD: clang-3.9
-    CFLAGS: "-m32 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    CFLAGS: "-m32 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.9 32bit_nan:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang39_0.7
@@ -2921,7 +4001,7 @@ Test clang-3.9 32bit_nan:
     LD: clang-3.9
     CFLAGS: "-m32 -DMRB_NAN_BOXING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.9 32bit_nan_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang39_0.7
@@ -2931,7 +4011,27 @@ Test clang-3.9 32bit_nan_utf8:
     LD: clang-3.9
     CFLAGS: "-m32 -DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
+Test clang-3.9 32bit_word:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang39_0.7
+  variables:
+    CC: clang-3.9
+    CXX: clang++-3.9
+    LD: clang-3.9
+    CFLAGS: "-m32 -DMRB_WORD_BOXING=1"
+    LDFLAGS: "-m32"
+  script: env; rake --verbose all test
+Test clang-3.9 32bit_word_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang39_0.7
+  variables:
+    CC: clang-3.9
+    CXX: clang++-3.9
+    LD: clang-3.9
+    CFLAGS: "-m32 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; rake --verbose all test
 Test clang-3.9 32bit_int16:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang39_0.7
@@ -2941,7 +4041,7 @@ Test clang-3.9 32bit_int16:
     LD: clang-3.9
     CFLAGS: "-m32 -DMRB_INT16=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.9 32bit_int16_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang39_0.7
@@ -2951,7 +4051,7 @@ Test clang-3.9 32bit_int16_utf8:
     LD: clang-3.9
     CFLAGS: "-m32 -DMRB_INT16=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.9 32bit_int16_nan:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang39_0.7
@@ -2961,7 +4061,7 @@ Test clang-3.9 32bit_int16_nan:
     LD: clang-3.9
     CFLAGS: "-m32 -DMRB_INT16=1 -DMRB_NAN_BOXING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.9 32bit_int16_nan_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang39_0.7
@@ -2971,7 +4071,7 @@ Test clang-3.9 32bit_int16_nan_utf8:
     LD: clang-3.9
     CFLAGS: "-m32 -DMRB_INT16=1 -DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.9 32bit_int64:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang39_0.7
@@ -2981,7 +4081,7 @@ Test clang-3.9 32bit_int64:
     LD: clang-3.9
     CFLAGS: "-m32 -DMRB_INT64=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.9 32bit_int64_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang39_0.7
@@ -2991,8 +4091,28 @@ Test clang-3.9 32bit_int64_utf8:
     LD: clang-3.9
     CFLAGS: "-m32 -DMRB_INT64=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.9 32bit_float:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang39_0.7
+  variables:
+    CC: clang-3.9
+    CXX: clang++-3.9
+    LD: clang-3.9
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1"
+    LDFLAGS: "-m32"
+  script: env; rake --verbose all test
+Test clang-3.9 32bit_float_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang39_0.7
+  variables:
+    CC: clang-3.9
+    CXX: clang++-3.9
+    LD: clang-3.9
+    CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: "-m32"
+  script: env; rake --verbose all test
+Test clang-3.9 32bit_float_word:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang39_0.7
   variables:
@@ -3001,8 +4121,8 @@ Test clang-3.9 32bit_float:
     LD: clang-3.9
     CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
-Test clang-3.9 32bit_float_utf8:
+  script: env; rake --verbose all test
+Test clang-3.9 32bit_float_word_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang39_0.7
   variables:
@@ -3011,7 +4131,7 @@ Test clang-3.9 32bit_float_utf8:
     LD: clang-3.9
     CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.9 32bit_float_int16:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang39_0.7
@@ -3021,7 +4141,7 @@ Test clang-3.9 32bit_float_int16:
     LD: clang-3.9
     CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT16=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.9 32bit_float_int16_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang39_0.7
@@ -3031,7 +4151,7 @@ Test clang-3.9 32bit_float_int16_utf8:
     LD: clang-3.9
     CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT16=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.9 32bit_float_int64:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang39_0.7
@@ -3041,7 +4161,7 @@ Test clang-3.9 32bit_float_int64:
     LD: clang-3.9
     CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT64=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.9 32bit_float_int64_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang39_0.7
@@ -3051,7 +4171,7 @@ Test clang-3.9 32bit_float_int64_utf8:
     LD: clang-3.9
     CFLAGS: "-m32 -DMRB_USE_FLOAT=1 -DMRB_INT64=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: "-m32"
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.9 64bit:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang39_0.7
@@ -3059,9 +4179,9 @@ Test clang-3.9 64bit:
     CC: clang-3.9
     CXX: clang++-3.9
     LD: clang-3.9
-    CFLAGS: "-DMRB_WORD_BOXING=1"
+    CFLAGS: ''
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.9 64bit_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang39_0.7
@@ -3069,9 +4189,9 @@ Test clang-3.9 64bit_utf8:
     CC: clang-3.9
     CXX: clang++-3.9
     LD: clang-3.9
-    CFLAGS: "-DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    CFLAGS: "-DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.9 64bit_nan:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang39_0.7
@@ -3081,7 +4201,7 @@ Test clang-3.9 64bit_nan:
     LD: clang-3.9
     CFLAGS: "-DMRB_NAN_BOXING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.9 64bit_nan_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang39_0.7
@@ -3091,7 +4211,27 @@ Test clang-3.9 64bit_nan_utf8:
     LD: clang-3.9
     CFLAGS: "-DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
+Test clang-3.9 64bit_word:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang39_0.7
+  variables:
+    CC: clang-3.9
+    CXX: clang++-3.9
+    LD: clang-3.9
+    CFLAGS: "-DMRB_WORD_BOXING=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
+Test clang-3.9 64bit_word_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang39_0.7
+  variables:
+    CC: clang-3.9
+    CXX: clang++-3.9
+    LD: clang-3.9
+    CFLAGS: "-DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
 Test clang-3.9 64bit_int16:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang39_0.7
@@ -3101,7 +4241,7 @@ Test clang-3.9 64bit_int16:
     LD: clang-3.9
     CFLAGS: "-DMRB_INT16=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.9 64bit_int16_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang39_0.7
@@ -3111,7 +4251,7 @@ Test clang-3.9 64bit_int16_utf8:
     LD: clang-3.9
     CFLAGS: "-DMRB_INT16=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.9 64bit_int16_nan:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang39_0.7
@@ -3121,7 +4261,7 @@ Test clang-3.9 64bit_int16_nan:
     LD: clang-3.9
     CFLAGS: "-DMRB_INT16=1 -DMRB_NAN_BOXING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.9 64bit_int16_nan_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang39_0.7
@@ -3131,8 +4271,28 @@ Test clang-3.9 64bit_int16_nan_utf8:
     LD: clang-3.9
     CFLAGS: "-DMRB_INT16=1 -DMRB_NAN_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.9 64bit_int64:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang39_0.7
+  variables:
+    CC: clang-3.9
+    CXX: clang++-3.9
+    LD: clang-3.9
+    CFLAGS: "-DMRB_INT64=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
+Test clang-3.9 64bit_int64_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang39_0.7
+  variables:
+    CC: clang-3.9
+    CXX: clang++-3.9
+    LD: clang-3.9
+    CFLAGS: "-DMRB_INT64=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
+Test clang-3.9 64bit_int64_word:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang39_0.7
   variables:
@@ -3141,8 +4301,8 @@ Test clang-3.9 64bit_int64:
     LD: clang-3.9
     CFLAGS: "-DMRB_INT64=1 -DMRB_WORD_BOXING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
-Test clang-3.9 64bit_int64_utf8:
+  script: env; rake --verbose all test
+Test clang-3.9 64bit_int64_word_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang39_0.7
   variables:
@@ -3151,8 +4311,28 @@ Test clang-3.9 64bit_int64_utf8:
     LD: clang-3.9
     CFLAGS: "-DMRB_INT64=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.9 64bit_float:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang39_0.7
+  variables:
+    CC: clang-3.9
+    CXX: clang++-3.9
+    LD: clang-3.9
+    CFLAGS: "-DMRB_USE_FLOAT=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
+Test clang-3.9 64bit_float_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang39_0.7
+  variables:
+    CC: clang-3.9
+    CXX: clang++-3.9
+    LD: clang-3.9
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
+Test clang-3.9 64bit_float_word:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang39_0.7
   variables:
@@ -3161,8 +4341,8 @@ Test clang-3.9 64bit_float:
     LD: clang-3.9
     CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
-Test clang-3.9 64bit_float_utf8:
+  script: env; rake --verbose all test
+Test clang-3.9 64bit_float_word_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang39_0.7
   variables:
@@ -3171,7 +4351,7 @@ Test clang-3.9 64bit_float_utf8:
     LD: clang-3.9
     CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.9 64bit_float_int16:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang39_0.7
@@ -3181,7 +4361,7 @@ Test clang-3.9 64bit_float_int16:
     LD: clang-3.9
     CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT16=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.9 64bit_float_int16_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang39_0.7
@@ -3191,8 +4371,28 @@ Test clang-3.9 64bit_float_int16_utf8:
     LD: clang-3.9
     CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT16=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test
 Test clang-3.9 64bit_float_int64:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang39_0.7
+  variables:
+    CC: clang-3.9
+    CXX: clang++-3.9
+    LD: clang-3.9
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT64=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
+Test clang-3.9 64bit_float_int64_utf8:
+  stage: test
+  image: registry.gitlab.com/dabroz/mruby:clang39_0.7
+  variables:
+    CC: clang-3.9
+    CXX: clang++-3.9
+    LD: clang-3.9
+    CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT64=1 -DMRB_UTF8_STRING=1"
+    LDFLAGS: ''
+  script: env; rake --verbose all test
+Test clang-3.9 64bit_float_int64_word:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang39_0.7
   variables:
@@ -3201,8 +4401,8 @@ Test clang-3.9 64bit_float_int64:
     LD: clang-3.9
     CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT64=1 -DMRB_WORD_BOXING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
-Test clang-3.9 64bit_float_int64_utf8:
+  script: env; rake --verbose all test
+Test clang-3.9 64bit_float_int64_word_utf8:
   stage: test
   image: registry.gitlab.com/dabroz/mruby:clang39_0.7
   variables:
@@ -3211,4 +4411,4 @@ Test clang-3.9 64bit_float_int64_utf8:
     LD: clang-3.9
     CFLAGS: "-DMRB_USE_FLOAT=1 -DMRB_INT64=1 -DMRB_WORD_BOXING=1 -DMRB_UTF8_STRING=1"
     LDFLAGS: ''
-  script: env; ./minirake --verbose all test
+  script: env; rake --verbose all test

--- a/tasks/gitlab.rake
+++ b/tasks/gitlab.rake
@@ -80,7 +80,7 @@ task :gitlab_config do
             _info += int_conf['16'] ? 'int16 ' : ''
             _info += int_conf['64'] ? 'int64 ' : ''
             _info += boxing_conf['NAN'] ? 'nan ' : ''
-            _info += boxing_conf['word'] ? 'word ' : ''
+            _info += boxing_conf['WORD'] ? 'word ' : ''
             _info += utf8_conf['UTF8'] ? 'utf8 ' : ''
             _info = _info.gsub(/ +/, ' ').strip.tr(' ', '_')
             configs << { '_info' => _info, 'CFLAGS' => "#{bit}#{env}", 'LDFLAGS' => bit.strip.to_s }


### PR DESCRIPTION
There was an error in the `.gitlab-ci.yml` generation script, so it was also
fixed.