### PR TITLE
Fix builds for modern mingw; fix #4869

### DIFF
--- a/mrbgems/mruby-io/test/mruby_io_test.c
+++ b/mrbgems/mruby-io/test/mruby_io_test.c
@@ -18,7 +18,15 @@ typedef int mode_t;
 #define open _open
 #define close _close
 
-#if defined(_MSC_VER) || defined(__MINGW32__)
+#if defined(__MINGW64_VERSION_MAJOR)
+# define MRB_MINGW64_VERSION  (__MINGW64_VERSION_MAJOR * 1000 + __MINGW64_VERSION_MINOR)
+#elif defined(__MINGW32_MAJOR_VERSION)
+# define MRB_MINGW32_VERSION  (__MINGW32_MAJOR_VERSION * 1000 + __MINGW32_MINOR_VERSION)
+#endif
+
+#if defined(_MSC_VER) || \
+    (defined(MRB_MINGW32_VERSION) && MRB_MINGW32_VERSION < 3021) || \
+    (defined(MRB_MINGW64_VERSION) && MRB_MINGW64_VERSION < 4000)
 #include <sys/stat.h>
 
 static int


### PR DESCRIPTION
What I intended to fix in #4869 was a patch for an old MinGW.
Recent MinGWs have their own `mkstemp()` function.
I knew this after checking the patch #4903.

----

For your reference, the commits added to MinGW are also shown:
- mingw32: (2014-12-02) https://osdn.net/projects/mingw/scm/git/mingw-org-wsl/commits/ed7dcf1eb8b2fefb647b45a3f472524bb63fd870
- mingw-w64: (2015-01-07) https://sourceforge.net/p/mingw-w64/mingw-w64/ci/f713f639f6f017371c5176f4deab07d1a92473b4/

MinGW provided by the official package of FreeBSD is old.
(I did not know this....)
