### PR TITLE
Silence GCC warning in `time.c` on Travis CI

### DIFF
--- a/mrbgems/mruby-time/src/time.c
+++ b/mrbgems/mruby-time/src/time.c
@@ -257,7 +257,7 @@ mrb_to_time_t(mrb_state *mrb, mrb_value obj, time_t *usec)
       {
         mrb_int i = mrb_int(mrb, obj);
 
-        if ((MRB_INT_MAX > MRB_TIME_MAX && i > 0 && i > MRB_TIME_MAX) ||
+        if ((MRB_INT_MAX > MRB_TIME_MAX && i > 0 && i > (mrb_int)MRB_TIME_MAX) ||
             (MRB_TIME_MIN > MRB_INT_MIN && MRB_TIME_MIN > i)) {
           goto out_of_range;
         }


### PR DESCRIPTION
Silence the following warnings:

  ```
  /mruby/mrbgems/mruby-time/src/time.c:260:55: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
    if ((MRB_INT_MAX > MRB_TIME_MAX && i > 0 && i > MRB_TIME_MAX) ||
                                                  ^
  ```