### PR TITLE
Do not include `stdint.h` before `mruby.h`; ref #4750

### DIFF
--- a/src/fmt_fp.c
+++ b/src/fmt_fp.c
@@ -30,7 +30,6 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include <limits.h>
 #include <string.h>
-#include <stdint.h>
 #include <math.h>
 #include <float.h>
 #include <ctype.h>


### PR DESCRIPTION
`MRB_WITHOUT_FLOAT` is *un*defined, and if you build it as C ++ ABI for `MRB_DISABLE_STDIO` or Windows, the situation will be the same as #4750.
So I will fix it.

I borrowed it from take-cheeze's without permission, but I am able to confirm it in the log data by GithubActions:
https://github.com/take-cheeze/mruby/runs/360977783#step:4:833