### PR TITLE
Revert "SHARED string is not required when sharing POOL string" (75949836)

### DIFF
--- a/src/string.c
+++ b/src/string.c
@@ -553,7 +553,7 @@ str_share(mrb_state *mrb, struct RString *orig, struct RString *s)
   size_t len = (size_t)orig->as.heap.len;
 
   mrb_assert(!RSTR_EMBED_P(orig));
-  if (RSTR_NOFREE_P(orig) || RSTR_POOL_P(orig)) {
+  if (RSTR_NOFREE_P(orig)) {
     str_init_nofree(s, orig->as.heap.ptr, len);
   }
   else if (RSTR_SHARED_P(orig)) {
@@ -562,7 +562,7 @@ str_share(mrb_state *mrb, struct RString *orig, struct RString *s)
   else if (RSTR_FSHARED_P(orig)) {
     str_init_fshared(orig, s, orig->as.heap.aux.fshared);
   }
-  else if (mrb_frozen_p(orig)) {
+  else if (mrb_frozen_p(orig) && !RSTR_POOL_P(orig)) {
     str_init_fshared(orig, s, orig);
   }
   else {


### PR DESCRIPTION
Because literal pool may be released by GC.

#### Example:

  ```ruby
  s1 = eval('"abcdefghijklmnopqrstuvwxyz01"')
  GC.start
  p s1  #=> "\x00\x00\x00\x00\x00\x00\x00\x90\x00\x00\x00\x00\x00\x00\x00\x90\x03\x00stuvwxyz01"
  ```