### PR TITLE
Avoid creating temporary objects in `read_irep_record_1()`

### DIFF
--- a/include/mruby/string.h
+++ b/include/mruby/string.h
@@ -448,6 +448,7 @@ MRB_API int mrb_str_cmp(mrb_state *mrb, mrb_value str1, mrb_value str2);
 MRB_API char *mrb_str_to_cstr(mrb_state *mrb, mrb_value str);
 
 mrb_value mrb_str_pool(mrb_state *mrb, mrb_value str);
+mrb_value mrb_str_pool_from_str_len(mrb_state*, const char*, size_t, mrb_bool);
 uint32_t mrb_str_hash(mrb_state *mrb, mrb_value str);
 mrb_value mrb_str_dump(mrb_state *mrb, mrb_value str);
 

--- a/src/dump.c
+++ b/src/dump.c
@@ -149,6 +149,7 @@ get_pool_block_size(mrb_state *mrb, mrb_irep *irep)
     default:
       break;
     }
+    size ++; /* NUL terminal */
     mrb_gc_arena_restore(mrb, ai);
   }
 
@@ -201,6 +202,7 @@ write_pool_block(mrb_state *mrb, mrb_irep *irep, uint8_t *buf)
     cur += uint16_to_bin(len, cur); /* data length */
     memcpy(cur, char_ptr, (size_t)len);
     cur += len;
+    *cur ++ = '\0';
 
     mrb_gc_arena_restore(mrb, ai);
   }

--- a/src/string.c
+++ b/src/string.c
@@ -578,10 +578,17 @@ str_share(mrb_state *mrb, struct RString *orig, struct RString *s)
 mrb_value
 mrb_str_pool(mrb_state *mrb, mrb_value str)
 {
-  struct RString *s = (struct RString *)mrb_malloc(mrb, sizeof(struct RString));
   struct RString *orig = mrb_str_ptr(str);
   const char *p = RSTR_PTR(orig);
   size_t len = (size_t)RSTR_LEN(orig);
+
+  return mrb_str_pool_from_str_len(mrb, p, len, RSTR_NOFREE_P(orig));
+}
+
+mrb_value
+mrb_str_pool_from_str_len(mrb_state *mrb, const char *p, size_t len, mrb_bool nofree)
+{
+  struct RString *s = (struct RString *)mrb_malloc(mrb, sizeof(struct RString));
 
   s->tt = MRB_TT_STRING;
   s->c = mrb->string_class;
@@ -590,7 +597,7 @@ mrb_str_pool(mrb_state *mrb, mrb_value str)
   if (RSTR_EMBEDDABLE_P(len)) {
     str_init_embed(s, p, len);
   }
-  else if (RSTR_NOFREE_P(orig)) {
+  else if (nofree) {
     str_init_nofree(s, p, len);
   }
   else {


### PR DESCRIPTION
Since the irep pool element is now NUL terminated, break compatibility for mruby binary format.