### PR TITLE
Fix take over file scope variables with `mruby` and `mirb` command

### DIFF
--- a/include/mruby/compile.h
+++ b/include/mruby/compile.h
@@ -42,6 +42,7 @@ MRB_API mrbc_context* mrbc_context_new(mrb_state *mrb);
 MRB_API void mrbc_context_free(mrb_state *mrb, mrbc_context *cxt);
 MRB_API const char *mrbc_filename(mrb_state *mrb, mrbc_context *c, const char *s);
 MRB_API void mrbc_partial_hook(mrb_state *mrb, mrbc_context *c, int (*partial_hook)(struct mrb_parser_state*), void*data);
+MRB_API void mrbc_cleanup_local_variables(mrb_state *mrb, mrbc_context *c);
 
 /* AST node structure */
 typedef struct mrb_ast_node {

--- a/lib/mruby/gem.rb
+++ b/lib/mruby/gem.rb
@@ -171,6 +171,7 @@ module MRuby
           f.puts %Q[]
           f.puts %Q[void GENERATED_TMP_mrb_#{funcname}_gem_init(mrb_state *mrb) {]
           f.puts %Q[  int ai = mrb_gc_arena_save(mrb);]
+          f.puts %Q[  struct REnv *e;] unless rbfiles.empty?
           f.puts %Q[  mrb_#{funcname}_gem_init(mrb);] if objs != [objfile("#{build_dir}/gem_init")]
           unless rbfiles.empty?
             f.puts %Q[  mrb_load_irep(mrb, gem_mrblib_irep_#{funcname});]
@@ -179,6 +180,9 @@ module MRuby
             f.puts %Q[    mrb_close(mrb);]
             f.puts %Q[    exit(EXIT_FAILURE);]
             f.puts %Q[  }]
+            f.puts %Q[  e = mrb->c->cibase->env;]
+            f.puts %Q[  mrb->c->cibase->env = NULL;]
+            f.puts %Q[  mrb_env_unshare(mrb, e);]
           end
           f.puts %Q[  mrb_gc_arena_restore(mrb, ai);]
           f.puts %Q[}]
@@ -205,6 +209,7 @@ module MRuby
         f.puts %Q[#include <stdlib.h>] unless rbfiles.empty?
         f.puts %Q[#include <mruby.h>]
         f.puts %Q[#include <mruby/irep.h>] unless rbfiles.empty?
+        f.puts %Q[#include <mruby/proc.h>] unless rbfiles.empty?
       end
 
       def print_gem_test_header(f)

--- a/mrbgems/mruby-bin-mirb/tools/mirb/mirb.c
+++ b/mrbgems/mruby-bin-mirb/tools/mirb/mirb.c
@@ -491,10 +491,6 @@ main(int argc, char **argv)
 
   cxt = mrbc_context_new(mrb);
 
-#ifndef DISABLE_MIRB_UNDERSCORE
-  decl_lv_underscore(mrb, cxt);
-#endif
-
   /* Load libraries */
   for (i = 0; i < args.libc; i++) {
     FILE *lfp = fopen(args.libv[i], "r");
@@ -505,7 +501,12 @@ main(int argc, char **argv)
     }
     mrb_load_file_cxt(mrb, lfp, cxt);
     fclose(lfp);
+    mrbc_cleanup_local_variables(mrb, cxt);
   }
+
+#ifndef DISABLE_MIRB_UNDERSCORE
+  decl_lv_underscore(mrb, cxt);
+#endif
 
   cxt->capture_errors = TRUE;
   cxt->lineno = 1;

--- a/mrbgems/mruby-bin-mirb/tools/mirb/mirb.c
+++ b/mrbgems/mruby-bin-mirb/tools/mirb/mirb.c
@@ -493,6 +493,7 @@ main(int argc, char **argv)
 
   /* Load libraries */
   for (i = 0; i < args.libc; i++) {
+    struct REnv *e;
     FILE *lfp = fopen(args.libv[i], "r");
     if (lfp == NULL) {
       printf("Cannot open library file. (%s)\n", args.libv[i]);
@@ -501,6 +502,9 @@ main(int argc, char **argv)
     }
     mrb_load_file_cxt(mrb, lfp, cxt);
     fclose(lfp);
+    e = mrb->c->cibase->env;
+    mrb->c->cibase->env = NULL;
+    mrb_env_unshare(mrb, e);
     mrbc_cleanup_local_variables(mrb, cxt);
   }
 

--- a/mrbgems/mruby-bin-mruby/tools/mruby/mruby.c
+++ b/mrbgems/mruby-bin-mruby/tools/mruby/mruby.c
@@ -317,6 +317,7 @@ main(int argc, char **argv)
         v = mrb_load_file_cxt(mrb, lfp, c);
       }
       fclose(lfp);
+      mrbc_cleanup_local_variables(mrb, c);
     }
 
     /* Load program */

--- a/mrbgems/mruby-bin-mruby/tools/mruby/mruby.c
+++ b/mrbgems/mruby-bin-mruby/tools/mruby/mruby.c
@@ -6,6 +6,7 @@
 #include <mruby/compile.h>
 #include <mruby/dump.h>
 #include <mruby/variable.h>
+#include <mruby/proc.h>
 
 struct _args {
   FILE *rfp;
@@ -303,6 +304,7 @@ main(int argc, char **argv)
 
     /* Load libraries */
     for (i = 0; i < args.libc; i++) {
+      struct REnv *e;
       FILE *lfp = fopen(args.libv[i], args.mrbfile ? "rb" : "r");
       if (lfp == NULL) {
         fprintf(stderr, "%s: Cannot open library file: %s\n", *argv, args.libv[i]);
@@ -317,6 +319,9 @@ main(int argc, char **argv)
         v = mrb_load_file_cxt(mrb, lfp, c);
       }
       fclose(lfp);
+      e = mrb->c->cibase->env;
+      mrb->c->cibase->env = NULL;
+      mrb_env_unshare(mrb, e);
       mrbc_cleanup_local_variables(mrb, c);
     }
 

--- a/mrbgems/mruby-compiler/core/parse.y
+++ b/mrbgems/mruby-compiler/core/parse.y
@@ -6303,6 +6303,16 @@ mrbc_partial_hook(mrb_state *mrb, mrbc_context *c, int (*func)(struct mrb_parser
 }
 
 MRB_API void
+mrbc_cleanup_local_variables(mrb_state *mrb, mrbc_context *c)
+{
+  if (c->syms) {
+    mrb_free(mrb, c->syms);
+    c->syms = NULL;
+    c->slen = 0;
+  }
+}
+
+MRB_API void
 mrb_parser_set_filename(struct mrb_parser_state *p, const char *f)
 {
   mrb_sym sym;


### PR DESCRIPTION
- Add `mrbc_cleanup_local_variables()` function with `MRB_API`
- In `mirb` command, the `_` variable is defined after the `-r` switch