### PR TITLE
Add `MRB_USE_SMALL_STRING_SEARCH` configuration

### DIFF
--- a/doc/guides/mrbconf.md
+++ b/doc/guides/mrbconf.md
@@ -179,3 +179,9 @@ largest value of required alignment.
 `MRB_ENABLE_ALL_SYMBOLS`
 * Make it available `Symbols.all_symbols` in `mrbgems/mruby-symbol-ext`
 * Increase heap memory usage.
+
+`MRB_USE_SMALL_STRING_SEARCH`
+* Switches the used string search algorithm to Naive Algorithm
+* Slows down
+* "Call stack memory" usage can probably be reduced to less than 10%
+  (in 32-bit CPU mode, you can expect to reduce usage from more than 1 kilobyte to less than 50 bytes)

--- a/include/mrbconf.h
+++ b/include/mrbconf.h
@@ -117,6 +117,9 @@
 /* fixed size state atexit stack */
 //#define MRB_FIXED_STATE_ATEXIT_STACK
 
+/* use Naive string search algorithm */
+//#define MRB_USE_SMALL_STRING_SEARCH
+
 /* -DMRB_DISABLE_XXXX to drop following features */
 //#define MRB_DISABLE_STDIO /* use of stdio */
 
@@ -164,6 +167,10 @@
 
 # ifndef MRB_HEAP_PAGE_SIZE
 #  define MRB_HEAP_PAGE_SIZE 256
+# endif
+
+# ifndef MRB_USE_SMALL_STRING_SEARCH
+#  define MRB_USE_SMALL_STRING_SEARCH
 # endif
 
 /* A profile for default mruby */

--- a/src/string.c
+++ b/src/string.c
@@ -507,6 +507,7 @@ str_index_str_by_char(mrb_state *mrb, mrb_value str, mrb_value sub, mrb_int pos)
 static inline mrb_int
 mrb_memsearch_qs(const unsigned char *xs, mrb_int m, const unsigned char *ys, mrb_int n)
 {
+#ifndef MRB_USE_SMALL_STRING_SEARCH
   const unsigned char *x = xs, *xe = xs + m;
   const unsigned char *y = ys;
   int i;
@@ -523,6 +524,15 @@ mrb_memsearch_qs(const unsigned char *xs, mrb_int m, const unsigned char *ys, mr
       return (mrb_int)(y - ys);
   }
   return -1;
+#else
+  const unsigned char *y = ys;
+  for (n -= m; n >= 0; n --, y ++) {
+    if (memcmp(xs, y, m) == 0) {
+      return (mrb_int)(y - ys);
+    }
+  }
+  return -1;
+#endif /* MRB_USE_SMALL_STRING_SEARCH */
 }
 
 static mrb_int


### PR DESCRIPTION
* Switches the used string search algorithm to Naive Algorithm
* Slows down
* "Call stack memory" usage can probably be reduced to less than 10% (in 32-bit CPU mode, you can expect to reduce usage from more than 1 kilobyte to less than 50 bytes)
