### PR TITLE
Include time.h for ios

### DIFF
--- a/mrbgems/mruby-io/src/io.c
+++ b/mrbgems/mruby-io/src/io.c
@@ -34,6 +34,7 @@
 
 #else
   #include <sys/wait.h>
+  #include <sys/time.h>
   #include <unistd.h>
   typedef size_t fsize_t;
   typedef time_t ftime_t;


### PR DESCRIPTION
An as-of-yet incomplete project of mine embedding mruby in iOS has revealed that `struct timeval` on recent versions of Darwin iOS is defined in `sys/time.h`.

This should have a minimal impact on other platforms.

<details>
If you wish to have a test for this I will be able to produce one in time. Currently I use a very hacked up xcode project file that includes a set of C files generated by mrbgems, and the project file is not fit for general consumption because it only includes a very specific set of mrbgems.

Once I have a working project file generation tool I will share it and this problem will become obvious, or if you have a minimal project using iOS you can see this issue.

I may be doing it wrong and could have been a build setting away from making mruby compile on iOS without this change, and would gladly take advice on how to proceed.