### PR TITLE
Explicit include stdio.h for muby-io

### DIFF
--- a/mrbgems/mruby-io/src/file.c
+++ b/mrbgems/mruby-io/src/file.c
@@ -16,6 +16,7 @@
 #include <limits.h>
 
 #include <errno.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #if defined(_WIN32) || defined(_WIN64)


### PR DESCRIPTION
Relate to <https://github.com/rails-engine/script_core/issues/3>

When compiling `mruby-io` on macOS, it will fail because

```
CC    mrbgems/mruby-io/src/file.c -> build/sandbox/mrbgems/mruby-io/src/file.o
/Users/tdegrunt/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/script_core-0.2.1/ext/enterprise_script_service/mruby/mrbgems/mruby-io/src/file.c:139:7: error: implicit
      declaration of function 'rename' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
  if (rename(src, dst) < 0) {
      ^
/Users/tdegrunt/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/script_core-0.2.1/ext/enterprise_script_service/mruby/mrbgems/mruby-io/src/file.c:139:7: note: did you mean
      'devname'?
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/stdlib.h:293:7: note: 'devname' declared here
char    *devname(dev_t, mode_t);
         ^
1 error generated.
rake aborted!

Command Failed: [gcc -std=gnu99 -g -O3 -Wall -Wundef -Wdeclaration-after-statement -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -fPIC -g3 -O3 -DMRB_DEBUG -D_GNU_SOURCE -DMRB_ENABLE_DEBUG_HOOK -DMRB_INT64 -DMRB_UTF8_STRING -DMRB_WORD_BOXING -DYYDEBUG -DMRB_DISABLE_STDIO -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -I/Users/tdegrunt/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/script_core-0.2.1/ext/enterprise_script_service/mruby/include -I/Users/tdegrunt/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/script_core-0.2.1/ext/enterprise_script_service/mruby/src -I/Users/tdegrunt/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/script_core-0.2.1/ext/enterprise_script_service/mruby/mrbgems/mruby-io/include -MMD -o /Users/tdegrunt/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/script_core-0.2.1/ext/enterprise_script_service/mruby/build/sandbox/mrbgems/mruby-io/src/file.o -c /Users/tdegrunt/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/script_core-0.2.1/ext/enterprise_script_service/mruby/mrbgems/mruby-io/src/file.c]
```

My friend told me GCC@macOS don't includes stdio.h by default, so I try to explict include stdio.h fix the build.