### PR TITLE
Enable MRB_METHOD_T_STRUCT by default on 32bit Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,9 +14,17 @@ environment:
     # Visual Studio 2017 64bit
     - visualcpp: C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat
 
+    # Visual Studio 2017 32bit
+    - visualcpp: C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat
+      machine: x86
+
     # Visual Studio 2015 64bit
     - visualcpp: C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat
       machine: amd64
+
+    # Visual Studio 2015 32bit
+    - visualcpp: C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat
+      machine: x86
 
     # Visual Studio 2013 64bit
     - visualcpp: C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat

--- a/include/mrbconf.h
+++ b/include/mrbconf.h
@@ -38,7 +38,12 @@
 
 /* add -DMRB_METHOD_T_STRUCT on machines that use higher bits of pointers */
 /* no MRB_METHOD_T_STRUCT requires highest 2 bits of function pointers to be zero */
-//#define MRB_METHOD_T_STRUCT
+#ifndef MRB_METHOD_T_STRUCT
+  // can't use highest 2 bits of function pointers on 32bit Windows.
+# if defined(_WIN32) && !defined(_WIN64)
+#   define MRB_METHOD_T_STRUCT
+# endif
+#endif
 
 /* add -DMRB_INT32 to use 32bit integer for mrb_int; conflict with MRB_INT64;
    Default for 32-bit CPU mode. */


### PR DESCRIPTION
Because we can't use the highest 2 bits of function pointers.

I couldn't reproduce this with the existing tests.
https://ci.appveyor.com/project/kou/mruby/builds/31199291/job/tkh6ady3xwxnvogj works well without `MRB_METHOD_T_STRUCT`.

But I added some 32bit Windows entries to `appveyor.yml`. I don't add "Visual Studio 2013 32bit" case because it failed with `Math.atan2` test:
https://ci.appveyor.com/project/kou/mruby/builds/31199291/job/tkh6ady3xwxnvogj

```text
Fail: Math.atan2 (mrbgems: mruby-math)
 - Assertion[5]
    Expected NaN to be 2.356194490192345.
 - Assertion[6]
    Expected NaN to be -2.356194490192345.
 - Assertion[7]
    Expected NaN to be 0.7853981633974483.
 - Assertion[8]
    Expected NaN to be -0.7853981633974483.
```

It's not related to this case.

I couldn't reproduce this with existing tests but our product, Groonga, is crashed without `MRB_METHOD_T_STRUCT`:
https://ci.appveyor.com/project/groonga/groonga/builds/31118559/job/8i0hq7crg0rpaucw#L7297

```text
#|C| c:\projects\groonga\vendor\mruby-source\src\vm.c:525:0: mrb_funcall_with_block(): <libgroonga>: <C:\projects\groonga\install\groonga-10.0.0-b5d38cc-x86-vs2017\bin\libgroo>
#|C| c:\projects\groonga\vendor\mruby-source\src\vm.c:441:60: mrb_funcall_with_block(): <libgroonga>: <C:\projects\groonga\install\groonga-10.0.0-b5d38cc-x86-vs2017\bin\libgroo>
#|C| c:\projects\groonga\vendor\mruby-source\src\vm.c:541:63: mrb_funcall_argv(): <libgroonga>: <C:\projects\groonga\install\groonga-10.0.0-b5d38cc-x86-vs2017\bin\libgroo>
#|C| c:\projects\groonga\vendor\mruby-source\src\class.c:1553:31: mrb_obj_new(): <libgroonga>: <C:\projects\groonga\install\groonga-10.0.0-b5d38cc-x86-vs2017\bin\libgroo>
#|C| c:\projects\groonga\vendor\mruby-source\src\error.c:31:23: mrb_exc_new_str(): <libgroonga>: <C:\projects\groonga\install\groonga-10.0.0-b5d38cc-x86-vs2017\bin\libgroo>
#|C| c:\projects\groonga\vendor\mruby-source\src\error.c:576:0: mrb_init_exception(): <libgroonga>: <C:\projects\groonga\install\groonga-10.0.0-b5d38cc-x86-vs2017\bin\libgroo>
#|C| c:\projects\groonga\vendor\mruby-source\src\init.c:43:0: mrb_init_core(): <libgroonga>: <C:\projects\groonga\install\groonga-10.0.0-b5d38cc-x86-vs2017\bin\libgroo>
#|C| c:\projects\groonga\vendor\mruby-source\src\state.c:43:50: mrb_open_core(): <libgroonga>: <C:\projects\groonga\install\groonga-10.0.0-b5d38cc-x86-vs2017\bin\libgroo>
#|C| c:\projects\groonga\vendor\mruby-source\src\state.c:71:11: mrb_open_allocf(): <libgroonga>: <C:\projects\groonga\install\groonga-10.0.0-b5d38cc-x86-vs2017\bin\libgroo>
```

`vm.c:525` is `mrb->c->stack = mrb->c->ci->stackent;` but the real crash line is `vm.c:524`: `val = MRB_METHOD_CFUNC(m)(mrb, self);`.

It seems that the highest 2 bits will be used in a process that has many functions like Groonga on 32bit Windows.

Groonga with mruby works well without `MRB_METHOD_T_STRUCT` on 64bit Windows.
