### PR TITLE
Fix unfinished changes

### DIFF
--- a/mrbgems/mruby-io/src/file.c
+++ b/mrbgems/mruby-io/src/file.c
@@ -283,7 +283,7 @@ static int
 mrb_file_is_absolute_path(const char *path)
 {
 #ifdef _WIN32
-#define IS_PATHSEP(x) (x == '/' || x == '\')
+#define IS_PATHSEP(x) (x == '/' || x == '\\')
   if (strlen(path) < 3) return 0;
   return (isalpha(path[0]) && path[1] == ':' && IS_PATHSEP(path[2]));
 #undef IS_PATHSEP

--- a/mrbgems/mruby-io/src/file.c
+++ b/mrbgems/mruby-io/src/file.c
@@ -284,8 +284,10 @@ mrb_file_is_absolute_path(const char *path)
 {
 #ifdef _WIN32
 #define IS_PATHSEP(x) (x == '/' || x == '\\')
-  if (strlen(path) < 3) return 0;
-  return (isalpha(path[0]) && path[1] == ':' && IS_PATHSEP(path[2]));
+  if (isalpha(path[0]))
+    return (strlen(path) > 2 && path[1] == ':' && IS_PATHSEP(path[2]));
+  else
+    return (IS_PATHSEP(path[0]) && IS_PATHSEP(path[1]));
 #undef IS_PATHSEP
 #else
   return (path[0] == '/');


### PR DESCRIPTION
Me again
There was a typo resulting in an error during compile.

```
#define IS_PATHSEP(x) (x == '/' || x == '\')
```
to
```
#define IS_PATHSEP(x) (x == '/' || x == '\\')
```

Just that.