### PR TITLE
[remake] Allow config without host

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -46,16 +46,7 @@ task :default => :all
 
 bin_path = ENV['INSTALL_DIR'] || "#{MRUBY_ROOT}/bin"
 
-depfiles = MRuby.targets['host'].bins.map do |bin|
-  install_path = MRuby.targets['host'].exefile("#{bin_path}/#{bin}")
-  source_path = MRuby.targets['host'].exefile("#{MRuby.targets['host'].build_dir}/bin/#{bin}")
-
-  file install_path => source_path do |t|
-    install_D t.prerequisites.first, t.name
-  end
-
-  install_path
-end
+depfiles = MRuby::ExecTools.generate_task { |t| install_D t.prerequisites.first, t.name }
 
 MRuby.each_target do |target|
   gems.map do |gem|
@@ -107,9 +98,9 @@ depfiles += MRuby.targets.map { |n, t|
   t.libraries
 }.flatten
 
-depfiles += MRuby.targets.reject { |n, t| n == 'host' }.map { |n, t|
-  t.bins.map { |bin| t.exefile("#{t.build_dir}/bin/#{bin}") }
-}.flatten
+# depfiles += MRuby.targets.reject { |n, t| n == 'host' }.map { |n, t|
+#   t.bins.map { |bin| t.exefile("#{t.build_dir}/bin/#{bin}") }
+# }.flatten
 
 desc "build all targets, install (locally) in-repo"
 task :all => depfiles do

--- a/doc/guides/compile.md
+++ b/doc/guides/compile.md
@@ -471,7 +471,7 @@ MRuby::CrossBuild.new('Minimal') do |conf|
   toolchain :gcc
 
   conf.cc.defines = %w(MRB_DISABLE_STDIO)
-  conf.bins = []
+  conf.bins.disable
 end
 ```
 

--- a/examples/targets/build_config_ArduinoDue.rb
+++ b/examples/targets/build_config_ArduinoDue.rb
@@ -68,7 +68,7 @@ MRuby::CrossBuild.new("ArduinoDue") do |conf|
   end
 
   #no executables
-  conf.bins = []
+  conf.bins.disable
 
   #do not build executable test
   conf.build_mrbtest_lib_only

--- a/examples/targets/build_config_IntelGalileo.rb
+++ b/examples/targets/build_config_IntelGalileo.rb
@@ -66,7 +66,7 @@ MRuby::CrossBuild.new("Galileo") do |conf|
   end
 
   #no executables
-  conf.bins = []
+  conf.bins.disable
 
   #do not build executable test
   conf.build_mrbtest_lib_only

--- a/examples/targets/build_config_RX630.rb
+++ b/examples/targets/build_config_RX630.rb
@@ -57,7 +57,7 @@ MRuby::CrossBuild.new("RX630") do |conf|
   end
 
   #no executables
-  conf.bins = []
+  conf.bins.disable
 
   #do not build executable test
   conf.build_mrbtest_lib_only

--- a/examples/targets/build_config_chipKITMax32.rb
+++ b/examples/targets/build_config_chipKITMax32.rb
@@ -64,7 +64,7 @@ MRuby::CrossBuild.new("chipKITMax32") do |conf|
   end
 
   #no executables
-  conf.bins = []
+  conf.bins.disable
 
   #do not build test executable
   conf.build_mrbtest_lib_only

--- a/examples/targets/build_config_dreamcast_shelf.rb
+++ b/examples/targets/build_config_dreamcast_shelf.rb
@@ -69,7 +69,7 @@ MRuby::CrossBuild.new("dreamcast") do |conf|
   end
 
   # No executables
-  conf.bins = []
+  conf.bins.disable
 
   # Do not build executable test
   conf.build_mrbtest_lib_only

--- a/lib/mruby/build/command.rb
+++ b/lib/mruby/build/command.rb
@@ -36,7 +36,11 @@ module MRuby
 
     private
     def _run(options, params={})
-      return sh command + ' ' + ( options % params ) if NotFoundCommands.key? @command
+      if NotFoundCommands.key? @command
+        cmd_line = command + ' ' + ( options % params )
+        warn cmd_line
+        return sh cmd_line
+      end
       begin
         sh build.filename(command) + ' ' + ( options % params )
       rescue RuntimeError

--- a/lib/mruby/exec_tools.rb
+++ b/lib/mruby/exec_tools.rb
@@ -1,0 +1,92 @@
+module MRuby
+	class ExecTools
+		MRBC_FILE = 'mrbc'
+		BIN_PATH = ENV['INSTALL_DIR'] || "#{MRUBY_ROOT}/bin"
+		BIN_TASK = []
+
+		def self.hire(build_dir)
+			new(build_dir, BIN_PATH)
+		end
+
+		def self.add_taskbin(build_exe, bin_exe)
+			return if MRuby::Build.current.kind_of?(MRuby::CrossBuild)
+			return if [build_exe, bin_exe].any?(&:nil?)
+			unless BIN_TASK.map(&:values).include?(build_exe)
+				BIN_TASK << { src: build_exe, output: bin_exe }
+			end
+		end
+
+		def self.generate_task(&block)
+			BIN_TASK.map do |task_properti|
+				Rake::FileTask.define_task(task_properti[:src] => task_properti[:output], &block)
+				task_properti[:src]
+			end
+		end
+
+		attr_reader :build_dir, :bin_path
+		attr_writer :extension
+
+		def initialize(build_dir, bin_path)
+			@active = true
+			@list = []
+			@build_dir = Pathname.new(build_dir)
+			@bin_path = Pathname.new(bin_path)
+
+			build_bin_dir = @build_dir.join('bin')
+			@build_dir.mkpath if Dir[@build_dir].empty?
+			build_bin_dir.mkpath if Dir[build_bin_dir].empty?
+		end
+
+		def <<(basename)
+			return unless @active
+			@list << basename
+			ext = File.extname(basename)
+			ext = @extension if ext.empty?
+			self.class.add_taskbin(bin_path(basename, ext), build_path(basename, ext))
+		end
+
+		def disable
+			@active = false
+		end
+
+		def disable?
+			!@active
+		end
+
+		def empty?
+			disable? || @list.empty?
+		end
+
+		def all_executable
+			@list.join(", ")
+		end
+
+		def mrbc
+			executable = exe(MRBC_FILE)
+			return executable if File.exist?(executable)
+			return MRuby.targets['host'].mrbcfile if host_target?
+			raise RuntimeError, "Couldn't find mrbc.exe \nBuild host first."
+		end
+
+		def exe(name)
+			exist?(name) ? bin_path(name) : build_path(name)
+		end
+
+		private
+		def exist?(name)
+			File.exist?(bin_path(name))
+		end
+
+		def build_path(name, ext = @extension)
+			@build_dir.join('bin').join(name).to_s + ext
+		end
+
+		def bin_path(name, ext = @extension)
+			@bin_path.join(name).to_s + ext
+		end
+
+		def host_target?
+			!MRuby.targets['host'].nil?
+		end
+	end
+end

--- a/lib/mruby/lockfile.rb
+++ b/lib/mruby/lockfile.rb
@@ -2,6 +2,7 @@ autoload :YAML, 'yaml'
 
 module MRuby
   autoload :Source, 'mruby/source'
+  autoload :ExecTools, 'mruby/exec_tools'
 
   class Lockfile
     class << self

--- a/mrbgems/mruby-bin-debugger/mrbgem.rake
+++ b/mrbgems/mruby-bin-debugger/mrbgem.rake
@@ -5,5 +5,5 @@ MRuby::Gem::Specification.new('mruby-bin-debugger') do |spec|
 
   spec.add_dependency('mruby-eval', :core => 'mruby-eval')
 
-  spec.bins = %w(mrdb)
+  spec.bins << %Q(mrdb)
 end

--- a/mrbgems/mruby-bin-mirb/mrbgem.rake
+++ b/mrbgems/mruby-bin-mirb/mrbgem.rake
@@ -28,6 +28,6 @@ MRuby::Gem::Specification.new('mruby-bin-mirb') do |spec|
     spec.cc.defines << "ENABLE_LINENOISE"
   end
 
-  spec.bins = %w(mirb)
+  spec.bins << %Q(mirb)
   spec.add_dependency('mruby-compiler', :core => 'mruby-compiler')
 end

--- a/mrbgems/mruby-bin-mrbc/mrbgem.rake
+++ b/mrbgems/mruby-bin-mrbc/mrbgem.rake
@@ -12,5 +12,5 @@ MRuby::Gem::Specification.new 'mruby-bin-mrbc' do |spec|
     build.linker.run t.name, t.prerequisites
   end
 
-  build.bins << 'mrbc' unless build.bins.find { |v| v == 'mrbc' }
+  build.bins << 'mrbc'
 end

--- a/mrbgems/mruby-bin-mruby/mrbgem.rake
+++ b/mrbgems/mruby-bin-mruby/mrbgem.rake
@@ -2,7 +2,7 @@ MRuby::Gem::Specification.new('mruby-bin-mruby') do |spec|
   spec.license = 'MIT'
   spec.author  = 'mruby developers'
   spec.summary = 'mruby command'
-  spec.bins = %w(mruby)
+  spec.bins << %Q(mruby)
   spec.add_dependency('mruby-compiler', :core => 'mruby-compiler')
   spec.add_dependency('mruby-error', :core => 'mruby-error')
   spec.add_test_dependency('mruby-print', :core => 'mruby-print')

--- a/mrbgems/mruby-bin-strip/mrbgem.rake
+++ b/mrbgems/mruby-bin-strip/mrbgem.rake
@@ -2,5 +2,5 @@ MRuby::Gem::Specification.new('mruby-bin-strip') do |spec|
   spec.license = 'MIT'
   spec.author  = 'mruby developers'
   spec.summary = 'irep dump debug section remover command'
-  spec.bins = %w(mruby-strip)
+  spec.bins << %Q(mruby-strip)
 end

--- a/tasks/toolchains/android.rake
+++ b/tasks/toolchains/android.rake
@@ -60,6 +60,10 @@ Higher NDK version will be use.
     @params = params
   end
 
+  def host_windows?
+    ENV['OS'] == 'Windows_NT'
+  end
+
   def bin_gcc(command)
     command = command.to_s
 
@@ -153,14 +157,6 @@ Higher NDK version will be use.
 
   def host_platform
     @host_platform ||= case RUBY_PLATFORM
-      when /cygwin|mswin|mingw|bccwin|wince|emx/i
-        path = home_path.join('toolchains', 'llvm' , 'prebuilt', 'windows*')
-        Dir.glob(path.to_s){ |item|
-          next if File.file?(item)
-          path = Pathname.new(item)
-          break
-        }
-        path.basename
       when /x86_64-darwin/i
         'darwin-x86_64'
       when /darwin/i
@@ -170,7 +166,17 @@ Higher NDK version will be use.
       when /linux/i
         'linux-x86'
       else
-        raise NotImplementedError, "Unknown host platform (#{RUBY_PLATFORM})"
+        if host_windows?
+          path = home_path.join('toolchains', 'llvm' , 'prebuilt', 'windows*')
+          Dir.glob(path.to_s){ |item|
+            next if File.file?(item)
+            path = Pathname.new(item)
+            break
+          }
+          path.basename
+        else
+          raise NotImplementedError, "Unknown host platform (#{RUBY_PLATFORM})"
+        end
       end
   end
 
@@ -298,8 +304,7 @@ Higher NDK version will be use.
   def cflags
     flags = []
 
-    case RUBY_PLATFORM
-    when /mswin|mingw|win32/
+    if host_windows?
       # Build for Android dont need window flag
       flags += %W(-U_WIN32 -U_WIN64)
     end


### PR DESCRIPTION
Skip the need on the host if there is still an mrbc in the bin folder. This commit makes it efficient for `CrossBuild` because it directly compiles for itself.

Config Example:
```ruby
MRuby::CrossBuild.new('android-armeabi') do |conf|
  params = {
    :arch => 'armeabi',
    :platform => 'android-23',
    :toolchain => :clang,
  }
  toolchain :android, params

  conf.gembox 'full-core'
end
```
Run it

```
$ rake MRUBY_CONFIG=examples/targets/build_config_android_armeabi.rb
CC    src/array.c -> build/android-armeabi/src/array.o
CC    src/backtrace.c -> build/android-armeabi/src/backtrace.o
CC    src/class.c -> build/android-armeabi/src/class.o
CC    src/codedump.c -> build/android-armeabi/src/codedump.o
CC    src/compar.c -> build/android-armeabi/src/compar.o
CC    src/crc.c -> build/android-armeabi/src/crc.o
CC    src/debug.c -> build/android-armeabi/src/debug.o
CC    src/dump.c -> build/android-armeabi/src/dump.o
CC    src/enum.c -> build/android-armeabi/src/enum.o
CC    src/error.c -> build/android-armeabi/src/error.o
CC    src/etc.c -> build/android-armeabi/src/etc.o
CC    src/fmt_fp.c -> build/android-armeabi/src/fmt_fp.o
CC    src/gc.c -> build/android-armeabi/src/gc.o
CC    src/hash.c -> build/android-armeabi/src/hash.o
CC    src/init.c -> build/android-armeabi/src/init.o
CC    src/kernel.c -> build/android-armeabi/src/kernel.o
CC    src/load.c -> build/android-armeabi/src/load.o
CC    src/numeric.c -> build/android-armeabi/src/numeric.o
CC    src/object.c -> build/android-armeabi/src/object.o
CC    src/pool.c -> build/android-armeabi/src/pool.o
CC    src/print.c -> build/android-armeabi/src/print.o
CC    src/proc.c -> build/android-armeabi/src/proc.o
CC    src/range.c -> build/android-armeabi/src/range.o
CC    src/state.c -> build/android-armeabi/src/state.o
CC    src/string.c -> build/android-armeabi/src/string.o
CC    src/symbol.c -> build/android-armeabi/src/symbol.o
CC    src/variable.c -> build/android-armeabi/src/variable.o
CC    src/version.c -> build/android-armeabi/src/version.o
CC    src/vm.c -> build/android-armeabi/src/vm.o
GEN   *.rb -> build/android-armeabi/mrblib/mrblib.c
      MRBC mrblib/00class.rb
      MRBC mrblib/10error.rb
      MRBC mrblib/array.rb
      MRBC mrblib/compar.rb
      MRBC mrblib/enum.rb
      MRBC mrblib/hash.rb
      MRBC mrblib/kernel.rb
      MRBC mrblib/numeric.rb
      MRBC mrblib/range.rb
      MRBC mrblib/string.rb
      MRBC mrblib/symbol.rb
CC    build/android-armeabi/mrblib/mrblib.c -> build/android-armeabi/mrblib/mrblib.o
CC    mrbgems/mruby-metaprog/src/metaprog.c -> build/android-armeabi/mrbgems/mruby-metaprog/src/metaprog.o
CC    build/android-armeabi/mrbgems/mruby-metaprog/gem_init.c -> build/android-armeabi/mrbgems/mruby-metaprog/gem_init.o
CC    mrbgems/mruby-io/src/file.c -> build/android-armeabi/mrbgems/mruby-io/src/file.o
CC    mrbgems/mruby-io/src/file_test.c -> build/android-armeabi/mrbgems/mruby-io/src/file_test.o
CC    mrbgems/mruby-io/src/io.c -> build/android-armeabi/mrbgems/mruby-io/src/io.o
CC    mrbgems/mruby-io/src/mruby_io_gem.c -> build/android-armeabi/mrbgems/mruby-io/src/mruby_io_gem.o
      MRBC mrbgems/mruby-io/mrblib/file.rb
      MRBC mrbgems/mruby-io/mrblib/file_constants.rb
      MRBC mrbgems/mruby-io/mrblib/io.rb
      MRBC mrbgems/mruby-io/mrblib/kernel.rb
CC    build/android-armeabi/mrbgems/mruby-io/gem_init.c -> build/android-armeabi/mrbgems/mruby-io/gem_init.o
CC    mrbgems/mruby-pack/src/pack.c -> build/android-armeabi/mrbgems/mruby-pack/src/pack.o
CC    build/android-armeabi/mrbgems/mruby-pack/gem_init.c -> build/android-armeabi/mrbgems/mruby-pack/gem_init.o
CC    mrbgems/mruby-sprintf/src/kernel.c -> build/android-armeabi/mrbgems/mruby-sprintf/src/kernel.o
CC    mrbgems/mruby-sprintf/src/sprintf.c -> build/android-armeabi/mrbgems/mruby-sprintf/src/sprintf.o
      MRBC mrbgems/mruby-sprintf/mrblib/string.rb
CC    build/android-armeabi/mrbgems/mruby-sprintf/gem_init.c -> build/android-armeabi/mrbgems/mruby-sprintf/gem_init.o
CC    mrbgems/mruby-print/src/print.c -> build/android-armeabi/mrbgems/mruby-print/src/print.o
      MRBC mrbgems/mruby-print/mrblib/print.rb
CC    build/android-armeabi/mrbgems/mruby-print/gem_init.c -> build/android-armeabi/mrbgems/mruby-print/gem_init.o
CC    mrbgems/mruby-math/src/math.c -> build/android-armeabi/mrbgems/mruby-math/src/math.o
CC    build/android-armeabi/mrbgems/mruby-math/gem_init.c -> build/android-armeabi/mrbgems/mruby-math/gem_init.o
CC    mrbgems/mruby-time/src/time.c -> build/android-armeabi/mrbgems/mruby-time/src/time.o
      MRBC mrbgems/mruby-time/mrblib/time.rb
CC    build/android-armeabi/mrbgems/mruby-time/gem_init.c -> build/android-armeabi/mrbgems/mruby-time/gem_init.o
CC    mrbgems/mruby-struct/src/struct.c -> build/android-armeabi/mrbgems/mruby-struct/src/struct.o
      MRBC mrbgems/mruby-struct/mrblib/struct.rb
CC    build/android-armeabi/mrbgems/mruby-struct/gem_init.c -> build/android-armeabi/mrbgems/mruby-struct/gem_init.o
      MRBC mrbgems/mruby-compar-ext/mrblib/compar.rb
CC    build/android-armeabi/mrbgems/mruby-compar-ext/gem_init.c -> build/android-armeabi/mrbgems/mruby-compar-ext/gem_init.o
      MRBC mrbgems/mruby-enum-ext/mrblib/enum.rb
CC    build/android-armeabi/mrbgems/mruby-enum-ext/gem_init.c -> build/android-armeabi/mrbgems/mruby-enum-ext/gem_init.o
CC    mrbgems/mruby-string-ext/src/string.c -> build/android-armeabi/mrbgems/mruby-string-ext/src/string.o
      MRBC mrbgems/mruby-string-ext/mrblib/string.rb
CC    build/android-armeabi/mrbgems/mruby-string-ext/gem_init.c -> build/android-armeabi/mrbgems/mruby-string-ext/gem_init.o
CC    mrbgems/mruby-numeric-ext/src/numeric_ext.c -> build/android-armeabi/mrbgems/mruby-numeric-ext/src/numeric_ext.o
      MRBC mrbgems/mruby-numeric-ext/mrblib/numeric_ext.rb
CC    build/android-armeabi/mrbgems/mruby-numeric-ext/gem_init.c -> build/android-armeabi/mrbgems/mruby-numeric-ext/gem_init.o
CC    mrbgems/mruby-array-ext/src/array.c -> build/android-armeabi/mrbgems/mruby-array-ext/src/array.o
      MRBC mrbgems/mruby-array-ext/mrblib/array.rb
CC    build/android-armeabi/mrbgems/mruby-array-ext/gem_init.c -> build/android-armeabi/mrbgems/mruby-array-ext/gem_init.o
CC    mrbgems/mruby-hash-ext/src/hash-ext.c -> build/android-armeabi/mrbgems/mruby-hash-ext/src/hash-ext.o
      MRBC mrbgems/mruby-hash-ext/mrblib/hash.rb
CC    build/android-armeabi/mrbgems/mruby-hash-ext/gem_init.c -> build/android-armeabi/mrbgems/mruby-hash-ext/gem_init.o
CC    mrbgems/mruby-range-ext/src/range.c -> build/android-armeabi/mrbgems/mruby-range-ext/src/range.o
      MRBC mrbgems/mruby-range-ext/mrblib/range.rb
CC    build/android-armeabi/mrbgems/mruby-range-ext/gem_init.c -> build/android-armeabi/mrbgems/mruby-range-ext/gem_init.o
CC    mrbgems/mruby-proc-ext/src/proc.c -> build/android-armeabi/mrbgems/mruby-proc-ext/src/proc.o
      MRBC mrbgems/mruby-proc-ext/mrblib/proc.rb
CC    build/android-armeabi/mrbgems/mruby-proc-ext/gem_init.c -> build/android-armeabi/mrbgems/mruby-proc-ext/gem_init.o
CC    mrbgems/mruby-symbol-ext/src/symbol.c -> build/android-armeabi/mrbgems/mruby-symbol-ext/src/symbol.o
      MRBC mrbgems/mruby-symbol-ext/mrblib/symbol.rb
CC    build/android-armeabi/mrbgems/mruby-symbol-ext/gem_init.c -> build/android-armeabi/mrbgems/mruby-symbol-ext/gem_init.o
CC    mrbgems/mruby-random/src/random.c -> build/android-armeabi/mrbgems/mruby-random/src/random.o
CC    build/android-armeabi/mrbgems/mruby-random/gem_init.c -> build/android-armeabi/mrbgems/mruby-random/gem_init.o
CC    mrbgems/mruby-object-ext/src/object.c -> build/android-armeabi/mrbgems/mruby-object-ext/src/object.o
      MRBC mrbgems/mruby-object-ext/mrblib/object.rb
CC    build/android-armeabi/mrbgems/mruby-object-ext/gem_init.c -> build/android-armeabi/mrbgems/mruby-object-ext/gem_init.o
CC    mrbgems/mruby-objectspace/src/mruby_objectspace.c -> build/android-armeabi/mrbgems/mruby-objectspace/src/mruby_objectspace.o
CC    build/android-armeabi/mrbgems/mruby-objectspace/gem_init.c -> build/android-armeabi/mrbgems/mruby-objectspace/gem_init.o
CC    mrbgems/mruby-fiber/src/fiber.c -> build/android-armeabi/mrbgems/mruby-fiber/src/fiber.o
CC    build/android-armeabi/mrbgems/mruby-fiber/gem_init.c -> build/android-armeabi/mrbgems/mruby-fiber/gem_init.o
      MRBC mrbgems/mruby-enumerator/mrblib/enumerator.rb
CC    build/android-armeabi/mrbgems/mruby-enumerator/gem_init.c -> build/android-armeabi/mrbgems/mruby-enumerator/gem_init.o
      MRBC mrbgems/mruby-enum-lazy/mrblib/lazy.rb
CC    build/android-armeabi/mrbgems/mruby-enum-lazy/gem_init.c -> build/android-armeabi/mrbgems/mruby-enum-lazy/gem_init.o
CC    build/android-armeabi/mrbgems/mruby-toplevel-ext/gem_init.c -> build/android-armeabi/mrbgems/mruby-toplevel-ext/gem_init.o
CC    mrbgems/mruby-kernel-ext/src/kernel.c -> build/android-armeabi/mrbgems/mruby-kernel-ext/src/kernel.o
CC    build/android-armeabi/mrbgems/mruby-kernel-ext/gem_init.c -> build/android-armeabi/mrbgems/mruby-kernel-ext/gem_init.o
CC    mrbgems/mruby-class-ext/src/class.c -> build/android-armeabi/mrbgems/mruby-class-ext/src/class.o
      MRBC mrbgems/mruby-class-ext/mrblib/module.rb
CC    build/android-armeabi/mrbgems/mruby-class-ext/gem_init.c -> build/android-armeabi/mrbgems/mruby-class-ext/gem_init.o
CC    mrbgems/mruby-method/src/method.c -> build/android-armeabi/mrbgems/mruby-method/src/method.o
      MRBC mrbgems/mruby-method/mrblib/kernel.rb
      MRBC mrbgems/mruby-method/mrblib/method.rb
CC    build/android-armeabi/mrbgems/mruby-method/gem_init.c -> build/android-armeabi/mrbgems/mruby-method/gem_init.o
CC    mrbgems/mruby-compiler/core/codegen.c -> build/android-armeabi/mrbgems/mruby-compiler/core/codegen.o
CC    mrbgems/mruby-error/src/exception.c -> build/android-armeabi/mrbgems/mruby-error/src/exception.o
CC    build/android-armeabi/mrbgems/mruby-error/gem_init.c -> build/android-armeabi/mrbgems/mruby-error/gem_init.o
CC    build/android-armeabi/mrbgems/gem_init.c -> build/android-armeabi/mrbgems/gem_init.o
AR    build/android-armeabi/lib/libmruby.a
CC    mrbgems/mruby-bin-mirb/tools/mirb/mirb.c -> build/android-armeabi/mrbgems/mruby-bin-mirb/tools/mirb/mirb.o
LD    build/android-armeabi/bin/mirb.exe
CC    mrbgems/mruby-bin-mruby/tools/mruby/mruby.c -> build/android-armeabi/mrbgems/mruby-bin-mruby/tools/mruby/mruby.o
LD    build/android-armeabi/bin/mruby.exe
CC    mrbgems/mruby-bin-strip/tools/mruby-strip/mruby-strip.c -> build/android-armeabi/mrbgems/mruby-bin-strip/tools/mruby-strip/mruby-strip.o
LD    build/android-armeabi/bin/mruby-strip.exe

Build summary:

================================================
      Config Name: android-armeabi
 Output Directory: build/android-armeabi
    Included Gems:
             mruby-metaprog - Meta-programming features for mruby
             mruby-io - IO and File class
             mruby-pack - Array#pack and String#unpack method
             mruby-sprintf - standard Kernel#sprintf method
             mruby-print - standard print/puts/p
             mruby-math - standard Math module
             mruby-time - standard Time class
             mruby-struct - standard Struct class
             mruby-compar-ext - Enumerable module extension
             mruby-enum-ext - Enumerable module extension
             mruby-string-ext - String class extension
             mruby-numeric-ext - Numeric class extension
             mruby-array-ext - Array class extension
             mruby-hash-ext - Hash class extension
             mruby-range-ext - Range class extension
             mruby-proc-ext - Proc class extension
             mruby-symbol-ext - Symbol class extension
             mruby-random - Random class
             mruby-object-ext - extensional methods shared by all objects
             mruby-objectspace - ObjectSpace class
             mruby-fiber - Fiber class
             mruby-enumerator - Enumerator class
             mruby-enum-lazy - Enumerator::Lazy class
             mruby-toplevel-ext - toplevel object (main) methods extension
             mruby-compiler - mruby compiler library
             mruby-bin-mirb - mirb command
               - Binaries: mirb
             mruby-error - extensional error handling
             mruby-bin-mruby - mruby command
               - Binaries: mruby
             mruby-bin-strip - irep dump debug section remover command
               - Binaries: mruby-strip
             mruby-kernel-ext - extensional function-like methods
             mruby-class-ext - class/module extension
             mruby-method - Method and UnboundMethod class
================================================
```

It's successful