### PR TITLE
Merged `cygwin_filename()` into `filename()`.

### DIFF
--- a/lib/mruby/build.rb
+++ b/lib/mruby/build.rb
@@ -276,14 +276,6 @@ EOS
       end
     end
 
-    def cygwin_filename(name)
-      if name.is_a?(Array)
-        name.flatten.map { |n| cygwin_filename(n) }
-      else
-        '"%s"' % `cygpath -w "#{filename(name)}"`.strip
-      end
-    end
-
     def exefile(name)
       if name.is_a?(Array)
         name.flatten.map { |n| exefile(n) }

--- a/lib/mruby/build/command.rb
+++ b/lib/mruby/build/command.rb
@@ -4,7 +4,7 @@ module MRuby
   class Command
     include Rake::DSL
     extend Forwardable
-    def_delegators :@build, :filename, :objfile, :libfile, :exefile, :cygwin_filename
+    def_delegators :@build, :filename, :objfile, :libfile, :exefile
     attr_accessor :build, :command
 
     def initialize(build)
@@ -79,11 +79,7 @@ module MRuby
     def all_flags(_defines=[], _include_paths=[], _flags=[])
       define_flags = [defines, _defines].flatten.map{ |d| option_define % d }
       include_path_flags = [include_paths, _include_paths].flatten.map do |f|
-        if MRUBY_BUILD_HOST_IS_CYGWIN
-          option_include_path % cygwin_filename(f)
-        else
-          option_include_path % filename(f)
-        end
+        option_include_path % filename(f)
       end
       [flags, define_flags, include_path_flags, _flags].flatten.join(' ')
     end
@@ -91,13 +87,8 @@ module MRuby
     def run(outfile, infile, _defines=[], _include_paths=[], _flags=[])
       mkdir_p File.dirname(outfile)
       _pp "CC", infile.relative_path, outfile.relative_path
-      if MRUBY_BUILD_HOST_IS_CYGWIN
-        _run compile_options, { :flags => all_flags(_defines, _include_paths, _flags),
-                                :infile => cygwin_filename(infile), :outfile => cygwin_filename(outfile) }
-      else
-        _run compile_options, { :flags => all_flags(_defines, _include_paths, _flags),
-                                :infile => filename(infile), :outfile => filename(outfile) }
-      end
+      _run compile_options, { :flags => all_flags(_defines, _include_paths, _flags),
+                              :infile => filename(infile), :outfile => filename(outfile) }
     end
 
     def define_rules(build_dir, source_dir='')
@@ -191,11 +182,7 @@ module MRuby
 
     def all_flags(_library_paths=[], _flags=[])
       library_path_flags = [library_paths, _library_paths].flatten.map do |f|
-        if MRUBY_BUILD_HOST_IS_CYGWIN
-          option_library_path % cygwin_filename(f)
-        else
-          option_library_path % filename(f)
-        end
+        option_library_path % filename(f)
       end
       [flags, library_path_flags, _flags].flatten.join(' ')
     end
@@ -209,19 +196,11 @@ module MRuby
       library_flags = [libraries, _libraries].flatten.map { |d| option_library % d }
 
       _pp "LD", outfile.relative_path
-      if MRUBY_BUILD_HOST_IS_CYGWIN
-        _run link_options, { :flags => all_flags(_library_paths, _flags),
-                             :outfile => cygwin_filename(outfile) , :objs => cygwin_filename(objfiles).join(' '),
-                             :flags_before_libraries => [flags_before_libraries, _flags_before_libraries].flatten.join(' '),
-                             :flags_after_libraries => [flags_after_libraries, _flags_after_libraries].flatten.join(' '),
-                             :libs => library_flags.join(' ') }
-      else
-        _run link_options, { :flags => all_flags(_library_paths, _flags),
-                             :outfile => filename(outfile) , :objs => filename(objfiles).map{|f| %Q["#{f}"]}.join(' '),
-                             :flags_before_libraries => [flags_before_libraries, _flags_before_libraries].flatten.join(' '),
-                             :flags_after_libraries => [flags_after_libraries, _flags_after_libraries].flatten.join(' '),
-                             :libs => library_flags.join(' ') }
-      end
+      _run link_options, { :flags => all_flags(_library_paths, _flags),
+                            :outfile => filename(outfile) , :objs => filename(objfiles).map{|f| %Q["#{f}"]}.join(' '),
+                            :flags_before_libraries => [flags_before_libraries, _flags_before_libraries].flatten.join(' '),
+                            :flags_after_libraries => [flags_after_libraries, _flags_after_libraries].flatten.join(' '),
+                            :libs => library_flags.join(' ') }
     end
   end
 
@@ -237,11 +216,7 @@ module MRuby
     def run(outfile, objfiles)
       mkdir_p File.dirname(outfile)
       _pp "AR", outfile.relative_path
-      if MRUBY_BUILD_HOST_IS_CYGWIN
-        _run archive_options, { :outfile => cygwin_filename(outfile), :objs => cygwin_filename(objfiles).map{|f| %Q["#{f}"]}.join(' ') }
-      else
-        _run archive_options, { :outfile => filename(outfile), :objs => filename(objfiles).map{|f| %Q["#{f}"]}.join(' ') }
-      end
+      _run archive_options, { :outfile => filename(outfile), :objs => filename(objfiles).map{|f| %Q["#{f}"]}.join(' ') }
     end
   end
 


### PR DESCRIPTION
I removed `cygwin_filename()` method because Cygwin's pathnames are in UNIX format.
