### PR TITLE
 Support `MRB_DISABLE_STDIO` for mruby-sprintf; ref #4954

### DIFF
--- a/include/mruby/numeric.h
+++ b/include/mruby/numeric.h
@@ -37,6 +37,7 @@ MRB_API mrb_value mrb_fixnum_to_str(mrb_state *mrb, mrb_value x, mrb_int base);
 /* ArgumentError if format string doesn't match /%(\.[0-9]+)?[aAeEfFgG]/ */
 #ifndef MRB_WITHOUT_FLOAT
 MRB_API mrb_value mrb_float_to_str(mrb_state *mrb, mrb_value x, const char *fmt);
+MRB_API int mrb_float_to_cstr(mrb_state *mrb, char *buf, size_t len, const char *fmt, mrb_float f);
 MRB_API mrb_float mrb_to_flo(mrb_state *mrb, mrb_value x);
 MRB_API mrb_value mrb_int_value(mrb_state *mrb, mrb_float f);
 #endif

--- a/mrbgems/mruby-sprintf/test/sprintf.rb
+++ b/mrbgems/mruby-sprintf/test/sprintf.rb
@@ -8,6 +8,11 @@ assert('String#%') do
   assert_equal 15, ("%b" % (1<<14)).size
   skip unless Object.const_defined?(:Float)
   assert_equal "1.0", "%3.1f" % 1.01
+  assert_equal " 123456789.12", "% 4.2f" % 123456789.123456789
+  assert_equal "123456789.12", "%-4.2f" % 123456789.123456789
+  assert_equal "+123456789.12", "%+4.2f" % 123456789.123456789
+  assert_equal "123456789.12", "%04.2f" % 123456789.123456789
+  assert_equal "00000000123456789.12", "%020.2f" % 123456789.123456789
 end
 
 assert('String#% with inf') do

--- a/src/fmt_fp.c
+++ b/src/fmt_fp.c
@@ -359,7 +359,7 @@ fmt_core(struct fmt_args *f, const char *fmt, mrb_float flo)
   }
 }
 
-mrb_value
+MRB_API mrb_value
 mrb_float_to_str(mrb_state *mrb, mrb_value flo, const char *fmt)
 {
   struct fmt_args f;
@@ -375,7 +375,7 @@ mrb_float_to_str(mrb_state *mrb, mrb_value flo, const char *fmt)
 #include <mruby.h>
 #include <stdio.h>
 
-mrb_value
+MRB_API mrb_value
 mrb_float_to_str(mrb_state *mrb, mrb_value flo, const char *fmt)
 {
   char buf[25];


### PR DESCRIPTION
For "width specifier" and "specifier flags", I get diff `src/fmt_fp.c` and musl (`src/stdio/vfprintf.c` in `git://git.musl-libc.org/musl`) and combined them.
