### PR TITLE
Fixed a build error in mruby-config

### DIFF
--- a/mrbgems/mruby-bin-config/mrbgem.rake
+++ b/mrbgems/mruby-bin-config/mrbgem.rake
@@ -5,13 +5,16 @@ unless MRuby::Build.current.kind_of?(MRuby::CrossBuild)
     spec.author  = 'mruby developers'
     spec.summary = "#{name} command"
 
+    mruby_config_dir = "#{build.build_dir}/bin"
     mruby_config = name + (ENV['OS'] == 'Windows_NT' ? '.bat' : '')
-    mruby_config_path = "#{build.build_dir}/bin/#{mruby_config}"
+    mruby_config_path = "#{mruby_config_dir}/#{mruby_config}"
     make_cfg = "#{build.build_dir}/lib/libmruby.flags.mak"
     tmplt_path = "#{__dir__}/#{mruby_config}"
     build.bins << mruby_config
 
-    file mruby_config_path => [make_cfg, tmplt_path] do |t|
+    directory mruby_config_dir
+
+    file mruby_config_path => [mruby_config_dir, make_cfg, tmplt_path] do |t|
       config = Hash[File.readlines(make_cfg).map!(&:chomp).map! {|l|
         l.gsub('\\"', '"').split(' = ', 2).map! {|s| s.sub(/^(?=.)/, 'echo ')}
       }]


### PR DESCRIPTION
The build error occurred when the "build/XXX/bin" directory did not exist.