### PR TITLE
Fix `MRB_TT_CPTR` object with `MRB_NAN_BOXING`

### DIFF
--- a/include/mruby/boxing_nan.h
+++ b/include/mruby/boxing_nan.h
@@ -44,6 +44,9 @@ typedef struct mrb_value {
           };
         )
       };
+#ifdef MRB_64BIT
+      struct RCptr *vp;
+#endif
     } value;
   };
 } mrb_value;
@@ -54,13 +57,15 @@ typedef struct mrb_value {
 #define mrb_type(o)     (enum mrb_vtype)((uint32_t)0xfff00000 < (o).value.ttt ? mrb_tt(o) : MRB_TT_FLOAT)
 #define mrb_ptr(o)      ((void*)((((uintptr_t)0x3fffffffffff)&((uintptr_t)((o).value.p)))<<2))
 #define mrb_float(o)    (o).f
-#define mrb_cptr(o)     mrb_ptr(o)
 #define mrb_fixnum(o)   (o).value.i
 #define mrb_symbol(o)   (o).value.sym
 
 #ifdef MRB_64BIT
+MRB_API mrb_value mrb_nan_boxing_cptr_value(struct mrb_state*, void*);
+#define mrb_cptr(o)     (((struct RCptr*)mrb_ptr(o))->p)
 #define BOXNAN_SHIFT_LONG_POINTER(v) (((uintptr_t)(v)>>34)&0x3fff)
 #else
+#define mrb_cptr(o)     ((o).value.p)
 #define BOXNAN_SHIFT_LONG_POINTER(v) 0
 #endif
 
@@ -90,7 +95,11 @@ typedef struct mrb_value {
 #define SET_INT_VALUE(r,n) BOXNAN_SET_VALUE(r, MRB_TT_FIXNUM, value.i, (n))
 #define SET_SYM_VALUE(r,v) BOXNAN_SET_VALUE(r, MRB_TT_SYMBOL, value.sym, (v))
 #define SET_OBJ_VALUE(r,v) BOXNAN_SET_OBJ_VALUE(r, (((struct RObject*)(v))->tt), (v))
-#define SET_CPTR_VALUE(mrb,r,v) BOXNAN_SET_OBJ_VALUE(r, MRB_TT_CPTR, v)
+#ifdef MRB_64BIT
+#define SET_CPTR_VALUE(mrb,r,v) ((r) = mrb_nan_boxing_cptr_value(mrb, v))
+#else
+#define SET_CPTR_VALUE(mrb,r,v) BOXNAN_SET_VALUE(r, MRB_TT_CPTR, value.p, v)
+#endif
 #define SET_UNDEF_VALUE(r) BOXNAN_SET_VALUE(r, MRB_TT_UNDEF, value.i, 0)
 
 #endif  /* MRUBY_BOXING_NAN_H */

--- a/include/mruby/boxing_word.h
+++ b/include/mruby/boxing_word.h
@@ -18,11 +18,6 @@ struct RFloat {
 };
 #endif
 
-struct RCptr {
-  MRB_OBJECT_HEADER;
-  void *p;
-};
-
 enum mrb_special_consts {
   MRB_Qnil    =  0,
   MRB_Qfalse  =  4,

--- a/include/mruby/value.h
+++ b/include/mruby/value.h
@@ -149,6 +149,13 @@ typedef void mrb_value;
 
 #endif
 
+#if defined(MRB_WORD_BOXING) || (defined(MRB_NAN_BOXING) && defined(MRB_64BIT))
+struct RCptr {
+  MRB_OBJECT_HEADER;
+  void *p;
+};
+#endif
+
 #if defined(MRB_NAN_BOXING)
 #include "boxing_nan.h"
 #elif defined(MRB_WORD_BOXING)

--- a/src/etc.c
+++ b/src/etc.c
@@ -140,7 +140,13 @@ mrb_obj_id(mrb_value obj)
   }
 }
 
+#if defined(MRB_NAN_BOXING) && defined(MRB_64BIT)
+#define mrb_xxx_boxing_cptr_value mrb_nan_boxing_cptr_value
+#endif
+
 #ifdef MRB_WORD_BOXING
+#define mrb_xxx_boxing_cptr_value mrb_word_boxing_cptr_value
+
 #ifndef MRB_WITHOUT_FLOAT
 MRB_API mrb_value
 mrb_word_boxing_float_value(mrb_state *mrb, mrb_float f)
@@ -164,17 +170,20 @@ mrb_word_boxing_float_pool(mrb_state *mrb, mrb_float f)
   return mrb_obj_value(nf);
 }
 #endif  /* MRB_WITHOUT_FLOAT */
+#endif  /* MRB_WORD_BOXING */
 
+#if defined(MRB_WORD_BOXING) || (defined(MRB_NAN_BOXING) && defined(MRB_64BIT))
 MRB_API mrb_value
-mrb_word_boxing_cptr_value(mrb_state *mrb, void *p)
+mrb_xxx_boxing_cptr_value(mrb_state *mrb, void *p)
 {
   mrb_value v;
+  struct RCptr *cptr = (struct RCptr*)mrb_obj_alloc(mrb, MRB_TT_CPTR, mrb->object_class);
 
-  v.value.p = mrb_obj_alloc(mrb, MRB_TT_CPTR, mrb->object_class);
-  v.value.vp->p = p;
+  SET_OBJ_VALUE(v, cptr);
+  cptr->p = p;
   return v;
 }
-#endif  /* MRB_WORD_BOXING */
+#endif
 
 #if defined _MSC_VER && _MSC_VER < 1900
 


### PR DESCRIPTION
Previously, if `MRB_NAN_BOXING` is defined, for example, `mrb_cptr_value()` could not keep an odd address.

If it is `MRB_32BIT`, it can be embedded in `NaN` as it is.

If it is `MRB_64BIT`, some operations are shared with `MRB_WORD_BOXING`.
In this case, the MRB_API function `mrb_nan_boxing_cptr_value()` is defined.