### PR TITLE
Removed comments mentioning `MRB_WITHOUT_FLOAT`; ref 2e661e8

### DIFF
--- a/mrbgems/mruby-io/include/mruby/ext/io.h
+++ b/mrbgems/mruby-io/include/mruby/ext/io.h
@@ -50,8 +50,8 @@ struct mrb_io {
 #define MRB_O_SHARE_DELETE      0x1000
 #define MRB_O_TMPFILE           0x2000
 #define MRB_O_NOATIME           0x4000
-#define MRB_O_DSYNC             0x00008000 /* Ignored with MRB_WITHOUT_FLOAT */
-#define MRB_O_RSYNC             0x00010000 /* Ignored with MRB_WITHOUT_FLOAT */
+#define MRB_O_DSYNC             0x00008000
+#define MRB_O_RSYNC             0x00010000
 
 #define MRB_O_RDONLY_P(f)       ((mrb_bool)(((f) & MRB_O_ACCMODE) == MRB_O_RDONLY))
 #define MRB_O_WRONLY_P(f)       ((mrb_bool)(((f) & MRB_O_ACCMODE) == MRB_O_WRONLY))


### PR DESCRIPTION
The comment is for messages when `MRB_INT16` and `MRB_WITHOUT_FLOAT` are specified at the same time.
The comment itself is no longer needed now that `MRB_INT16` is gone.