### PR TITLE
Support `undef` for `mrb_ary_splice()` instead of `[]`

### DIFF
--- a/include/mruby/array.h
+++ b/include/mruby/array.h
@@ -239,6 +239,7 @@ MRB_API mrb_value mrb_ary_entry(mrb_value ary, mrb_int offset);
  * @param head Beginning position of a replacement subsequence.
  * @param len Length of a replacement subsequence.
  * @param rpl The array of replacement elements.
+ *            It is possible to pass `mrb_undef_value()` instead of an empty array.
  * @return The receiver array.
  */
 MRB_API mrb_value mrb_ary_splice(mrb_state *mrb, mrb_value self, mrb_int head, mrb_int len, mrb_value rpl);

--- a/src/array.c
+++ b/src/array.c
@@ -732,6 +732,10 @@ mrb_ary_splice(mrb_state *mrb, mrb_value ary, mrb_int head, mrb_int len, mrb_val
       argv = ARY_PTR(r);
     }
   }
+  else if (mrb_undef_p(rpl)) {
+    argc = 0;
+    argv = NULL;
+  }
   else {
     argc = 1;
     argv = &rpl;


### PR DESCRIPTION
When removing elements from an array, it is possible to avoid creating an empty array.

Before this patch:

```c
mrb_ary_splice(mrb, ary, head, len, mrb_ary_new(mrb));
```

After this patch:

```c
mrb_ary_splice(mrb, ary, head, len, mrb_undef_value());
```