### PR TITLE
Suppress "-Wtype-limits" warning for `mrb->c->eidx`

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -338,7 +338,7 @@ ecall(mrb_state *mrb)
   uint16_t i = --c->eidx;
   int nregs;
 
-  if (i<0) return;
+  mrb_assert(i != UINT16_MAX);
   /* restrict total call depth of ecall() */
   if (++mrb->ecall_nest > MRB_ECALL_DEPTH_MAX) {
     mrb_exc_raise(mrb, mrb_obj_value(mrb->stack_err));


### PR DESCRIPTION
\# This pull request has a aspect of raising the issue.
\# If you have a better solution, please adopt it.

All callers of `ecall()` make sure that `mrb->c->eidx` is greater than `0`.
The problem I want to raise is in `ecall()`.
Probably What it wants to do is check the overflow, but there is a problem.

  - `eidx` is `uint16_t`, so it cannot be less than `0`.
  - I think it is better to call `mrb_bug()` or use `mrb_assert()` when it gets trapped.