### PR TITLE
Test mruby-io in tmpdir when AF_UNIX cannot be created on cwd

### DIFF
--- a/mrbgems/mruby-io/test/mruby_io_test.c
+++ b/mrbgems/mruby-io/test/mruby_io_test.c
@@ -1,7 +1,6 @@
 #include <mruby/common.h>
 #include <sys/types.h>
 #include <errno.h>
-#include <assert.h>
 
 #if defined(_WIN32) || defined(_WIN64)
 
@@ -54,11 +53,12 @@ mkdtemp(char *temp)
   #include <sys/socket.h>
   #include <unistd.h>
   #include <sys/un.h>
+  #include <assert.h>
+  #include <fcntl.h>
 #endif
 
 #include <sys/stat.h>
 #include <stdlib.h>
-#include <fcntl.h>
 
 #include "mruby.h"
 #include "mruby/array.h"
@@ -71,7 +71,7 @@ int wd_save;
 int socket_available_p;
 
 #if !defined(_WIN32) && !defined(_WIN64)
-static int mrb_io_socket_abailable()
+static int mrb_io_socket_available()
 {
   int fd, retval = 1;
   struct sockaddr_un sun0;
@@ -114,7 +114,7 @@ mrb_io_test_io_setup(mrb_state *mrb, mrb_value self)
   int fd2, fd3;
   struct sockaddr_un sun0;
 
-  if(!(socket_available_p = mrb_io_socket_abailable())) {
+  if(!(socket_available_p = mrb_io_socket_available())) {
     char *tmpdir;
     wd_save = open(".", O_DIRECTORY);
     tmpdir = getenv("TMPDIR");

--- a/mrbgems/mruby-io/test/mruby_io_test.c
+++ b/mrbgems/mruby-io/test/mruby_io_test.c
@@ -70,6 +70,7 @@ mkdtemp(char *temp)
 int wd_save;
 int socket_available_p;
 
+#if !defined(_WIN32) && !defined(_WIN64)
 static int mrb_io_socket_abailable()
 {
   int fd, retval = 1;
@@ -95,6 +96,7 @@ sock_test_out:
   close(fd);
   return retval;
 }
+#endif
 
 static mrb_value
 mrb_io_test_io_setup(mrb_state *mrb, mrb_value self)
@@ -111,7 +113,6 @@ mrb_io_test_io_setup(mrb_state *mrb, mrb_value self)
 #if !defined(_WIN32) && !defined(_WIN64)
   int fd2, fd3;
   struct sockaddr_un sun0;
-#endif
 
   if(!(socket_available_p = mrb_io_socket_abailable())) {
     char *tmpdir;
@@ -122,6 +123,7 @@ mrb_io_test_io_setup(mrb_state *mrb, mrb_value self)
     else
       assert(!chdir("/tmp"));
   }
+#endif
 
   mask = umask(077);
   fd0 = mkstemp(rfname);
@@ -217,10 +219,12 @@ mrb_io_test_io_cleanup(mrb_state *mrb, mrb_value self)
   mrb_gv_set(mrb, mrb_intern_cstr(mrb, "$mrbtest_io_socketname"), mrb_nil_value());
   mrb_gv_set(mrb, mrb_intern_cstr(mrb, "$mrbtest_io_msg"), mrb_nil_value());
 
+#if !defined(_WIN32) && !defined(_WIN64)
   if(!socket_available_p) {
     assert(!fchdir(wd_save));
     close(wd_save);
   }
+#endif
 
   return mrb_nil_value();
 }

--- a/mrbgems/mruby-io/test/mruby_io_test.c
+++ b/mrbgems/mruby-io/test/mruby_io_test.c
@@ -99,16 +99,6 @@ sock_test_out:
 static mrb_value
 mrb_io_test_io_setup(mrb_state *mrb, mrb_value self)
 {
-  if(!(socket_available_p = mrb_io_socket_abailable())) {
-    char *tmpdir;
-    wd_save = open(".", O_DIRECTORY);
-    tmpdir = getenv("TMPDIR");
-    if (tmpdir)
-      assert(!chdir(tmpdir));
-    else
-      assert(!chdir("/tmp"));
-  }
-
   char rfname[]      = "tmp.mruby-io-test-r.XXXXXXXX";
   char wfname[]      = "tmp.mruby-io-test-w.XXXXXXXX";
   char symlinkname[] = "tmp.mruby-io-test-l.XXXXXXXX";
@@ -122,6 +112,16 @@ mrb_io_test_io_setup(mrb_state *mrb, mrb_value self)
   int fd2, fd3;
   struct sockaddr_un sun0;
 #endif
+
+  if(!(socket_available_p = mrb_io_socket_abailable())) {
+    char *tmpdir;
+    wd_save = open(".", O_DIRECTORY);
+    tmpdir = getenv("TMPDIR");
+    if (tmpdir)
+      assert(!chdir(tmpdir));
+    else
+      assert(!chdir("/tmp"));
+  }
 
   mask = umask(077);
   fd0 = mkstemp(rfname);


### PR DESCRIPTION
mruby-io cannot create temporary AF_UNIX socket when working directory is vboxfs or NFS.

This is a workaround to test in such kind of filesystems.