### PR TITLE
Sorting the list of gems at build time by name

### DIFF
--- a/lib/mruby/build.rb
+++ b/lib/mruby/build.rb
@@ -336,7 +336,8 @@ EOS
       puts "         Binaries: #{@bins.join(', ')}" unless @bins.empty?
       unless @gems.empty?
         puts "    Included Gems:"
-        @gems.map do |gem|
+        gems = @gems.sort_by { |gem| gem.name }
+        gems.each do |gem|
           gem_version = " - #{gem.version}" if gem.version != '0.0.0'
           gem_summary = " - #{gem.summary}" if gem.summary
           puts "             #{gem.name}#{gem_version}#{gem_summary}"


### PR DESCRIPTION
Printing them in sorted order makes it easier to find the desired gem.
But it has come to completely ignore the dependency.