### PR TITLE
Makes `mrb_any_to_s()` accept an object whose class is `NULL`

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -1728,7 +1728,10 @@ mrb_class_real(struct RClass* cl)
 MRB_API const char*
 mrb_class_name(mrb_state *mrb, struct RClass* c)
 {
-  mrb_value name = class_name_str(mrb, c);
+  mrb_value name;
+
+  if (c == NULL) return NULL;
+  name = class_name_str(mrb, c);
   return RSTRING_PTR(name);
 }
 

--- a/src/string.c
+++ b/src/string.c
@@ -2759,7 +2759,7 @@ mrb_str_cat(mrb_state *mrb, mrb_value str, const char *ptr, size_t len)
 MRB_API mrb_value
 mrb_str_cat_cstr(mrb_state *mrb, mrb_value str, const char *ptr)
 {
-  return mrb_str_cat(mrb, str, ptr, strlen(ptr));
+  return mrb_str_cat(mrb, str, ptr, ptr ? strlen(ptr) : 0);
 }
 
 MRB_API mrb_value


### PR DESCRIPTION
When using `mrb_any_to_s()` for debugging purposes, giving an object whose class is `NULL` no longer causes a SIGSEGV and no crash.
This is achieved by making `mrb_class_name()` and `mrb_str_cat_cstr()` null safe.

----

I want to display a `MRB_TT_BREAK` object.