### PR TITLE
Enable MRB_METHOD_T_STRUCT by default on 32bit GUN/Linux

### DIFF
--- a/include/mrbconf.h
+++ b/include/mrbconf.h
@@ -39,8 +39,9 @@
 /* add -DMRB_METHOD_T_STRUCT on machines that use higher bits of pointers */
 /* no MRB_METHOD_T_STRUCT requires highest 2 bits of function pointers to be zero */
 #ifndef MRB_METHOD_T_STRUCT
-  // can't use highest 2 bits of function pointers on 32bit Windows.
-# if defined(_WIN32) && !defined(_WIN64)
+  // can't use highest 2 bits of function pointers at least on 32bit
+  // Windows and 32bit Linux.
+# ifdef MRB_32BIT
 #   define MRB_METHOD_T_STRUCT
 # endif
 #endif


### PR DESCRIPTION
Hello,

We can't also use the highest 2 bits of function pointers on 32bit GNU/Linux same as https://github.com/mruby/mruby/pull/4948.

How about we decide whether 32bit architecture by using `MRB_32BIT`?

