### PR TITLE
Fix boundary check for `OP_LOADI16`; ref fa8668c

### DIFF
--- a/mrbgems/mruby-compiler/core/codegen.c
+++ b/mrbgems/mruby-compiler/core/codegen.c
@@ -2448,7 +2448,7 @@ codegen(codegen_scope *s, node *tree, int val)
         }
         else if (i < 8) genop_1(s, OP_LOADI_0 + (uint8_t)i, cursp());
         else if (i <= 0xff) genop_2(s, OP_LOADI, cursp(), (uint16_t)i);
-        else if (i <= 0xffff) genop_2S(s, OP_LOADI16, cursp(), (uint16_t)i);
+        else if (i <= 0x7fff) genop_2S(s, OP_LOADI16, cursp(), (uint16_t)i);
         else {
           int off;
 


### PR DESCRIPTION
It was making a negative integer if the highest-order bit of a 16-bit integer was 1.

no patched:

```ruby
p 0x7fff  # => 32767
p 0x8000  # => -32768
p 0xffff  # => -1
p 0x10000 # => 65536
```