### PR TITLE
Remove byteorder constants; ref 87576b8

### DIFF
--- a/src/dump.c
+++ b/src/dump.c
@@ -13,9 +13,6 @@
 #include <mruby/numeric.h>
 #include <mruby/debug.h>
 
-#define FLAG_BYTEORDER_NATIVE 2
-#define FLAG_BYTEORDER_NONATIVE 0
-
 #ifndef MRB_WITHOUT_FLOAT
 #ifdef MRB_USE_FLOAT
 #define MRB_FLOAT_FMT "%.9g"


### PR DESCRIPTION
The `FLAG_BYTEORDER_NATIVE` and `FLAG_BYTEORDER_NONATIVE` are no longer needed.