### PR TITLE
Get an irep symbol if it's `OP_GETSV` or `OP_SETSV`

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -1089,13 +1089,13 @@ RETRY_TRY_BLOCK:
     }
 
     CASE(OP_GETSV, BB) {
-      mrb_value val = mrb_vm_special_get(mrb, b);
+      mrb_value val = mrb_vm_special_get(mrb, syms[b]);
       regs[a] = val;
       NEXT;
     }
 
     CASE(OP_SETSV, BB) {
-      mrb_vm_special_set(mrb, b, regs[a]);
+      mrb_vm_special_set(mrb, syms[b], regs[a]);
       NEXT;
     }
 


### PR DESCRIPTION
It's a meaningless patch that has no effect at the moment, but I've noticed it, so I'm putting it out.