### PR TITLE
Unify `eql?` receiver in `Hash` according to Ruby

### DIFF
--- a/src/hash.c
+++ b/src/hash.c
@@ -373,7 +373,7 @@ ht_put(mrb_state *mrb, htable *t, mrb_value key, mrb_value val)
         deleted++;
         continue;
       }
-      if (ht_hash_equal(mrb, t, k, key)) {
+      if (ht_hash_equal(mrb, t, key, k)) {
         seg->e[i].val = val;
         return;
       }
@@ -454,7 +454,7 @@ ht_get(mrb_state *mrb, htable *t, mrb_value key, mrb_value *vp)
         return FALSE;
       }
       if (mrb_undef_p(k)) continue;
-      if (ht_hash_equal(mrb, t, k, key)) {
+      if (ht_hash_equal(mrb, t, key, k)) {
         if (vp) *vp = seg->e[i].val;
         return TRUE;
       }


### PR DESCRIPTION
### Example

  ```ruby
  # example.rb
  class A
    def eql?(o)
      p self.class
      super
    end
    def hash
      1
    end
  end

  class B < A; end

  h = {A.new => 1}
  h[B.new]
  ```

#### Before this patch:

  ```console
  $ bin/mruby example.rb
  A
  ```

#### After this patch (same as Ruby)

  ```console
  $ bin/mruby example.rb
  B
  ```