### PR TITLE
Adding warnings for mrb_load functions leaking RProc objects

### DIFF
--- a/include/mruby/compile.h
+++ b/include/mruby/compile.h
@@ -180,7 +180,15 @@ MRB_API struct mrb_parser_state* mrb_parse_nstring(mrb_state*,const char*,size_t
 MRB_API struct RProc* mrb_generate_code(mrb_state*, struct mrb_parser_state*);
 MRB_API mrb_value mrb_load_exec(mrb_state *mrb, struct mrb_parser_state *p, mrbc_context *c);
 
-/* program load functions */
+/** program load functions 
+* Please note! Currently due to interactions with the GC calling these functions will 
+* leak one RProc object per function call.
+* To prevent this save the current memory arena before calling and restore the arena
+* right after, like so
+* int ai = mrb_gc_arena_save(mrb);
+* mrb_value status = mrb_load_string(mrb, buffer);
+* mrb_gc_arena_restore(mrb, ai);
+*/
 #ifndef MRB_DISABLE_STDIO
 MRB_API mrb_value mrb_load_file(mrb_state*,FILE*);
 MRB_API mrb_value mrb_load_file_cxt(mrb_state*,FILE*, mrbc_context *cxt);

--- a/include/mruby/irep.h
+++ b/include/mruby/irep.h
@@ -49,6 +49,16 @@ typedef struct mrb_irep {
 
 MRB_API mrb_irep *mrb_add_irep(mrb_state *mrb);
 
+/** load mruby bytecode functions
+* Please note! Currently due to interactions with the GC calling these functions will
+* leak one RProc object per function call.
+* To prevent this save the current memory arena before calling and restore the arena
+* right after, like so
+* int ai = mrb_gc_arena_save(mrb);
+* mrb_value status = mrb_load_irep(mrb, buffer);
+* mrb_gc_arena_restore(mrb, ai);
+*/
+
 /* @param [const uint8_t*] irep code, expected as a literal */
 MRB_API mrb_value mrb_load_irep(mrb_state*, const uint8_t*);
 


### PR DESCRIPTION
From discoveries in #5001, adding documentation on the unexpected behavior of calling mrb_load_* functions leaking RProc objects. I took a look at the load_iseq paths and they exhibit the same behavior, so I documented that as well.

@matz expressed concern that fixing the leaking behavior in the core `load_iseq` or `mrb_load_exec` functions may cause other GC problems, so best case we can do currently is explain the situation and demonstrate how to overcome it.