### PR TITLE
Retry `rake -m` on AppVeyor [skip travis]

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -47,4 +47,5 @@ install:
 build_script:
   - set YACC=.\win_flex_bison\win_bison.exe
   - set MRUBY_CONFIG=appveyor_config.rb
+  - rake -m
   - rake -E $stdout.sync=true test

--- a/appveyor_config.rb
+++ b/appveyor_config.rb
@@ -1,3 +1,8 @@
+def setup_option(conf)
+  conf.compilers.each{|c| c.flags[0].delete("/Zi")}
+  conf.linker.flags << "/DEBUG:NONE"
+end
+
 MRuby::Build.new('full-debug') do |conf|
   toolchain :visualcpp
   enable_debug
@@ -5,6 +10,7 @@ MRuby::Build.new('full-debug') do |conf|
   # include all core GEMs
   conf.gembox 'full-core'
   conf.cc.defines += %w(MRB_GC_STRESS MRB_METHOD_CACHE MRB_ENABLE_DEBUG_HOOK)
+  setup_option(conf)
 
   conf.enable_test
 end
@@ -17,6 +23,7 @@ MRuby::Build.new do |conf|
   conf.compilers.each do |c|
     c.defines += %w(MRB_GC_FIXED_ARENA)
   end
+  setup_option(conf)
   conf.enable_bintest
   conf.enable_test
 end
@@ -28,6 +35,7 @@ MRuby::Build.new('cxx_abi') do |conf|
   conf.compilers.each do |c|
     c.defines += %w(MRB_GC_FIXED_ARENA)
   end
+  setup_option(conf)
   conf.enable_bintest
   conf.enable_test
 


### PR DESCRIPTION
The following error occurs when using `rake -m` on AppVeyor:

  ```
  fatal error C1041: cannot open program database 'C:\projects\mruby\vc140.pdb'; if multiple CL.EXE write to the same .PDB file, please use /FS
  ```

Therefore, the issue is solved by not creating the PDB file. It is expected
to be somewhat faster by not generating debugging information (I don't think
debugging information is necessary for normal CI).