### PR TITLE
Detect newly added mrbgems when re-creating gem_init.c

### DIFF
--- a/tasks/mrbgems.rake
+++ b/tasks/mrbgems.rake
@@ -7,7 +7,7 @@ MRuby.each_target do
     # loader all gems
     self.libmruby_objs << objfile("#{build_dir}/mrbgems/gem_init")
     file objfile("#{build_dir}/mrbgems/gem_init") => ["#{build_dir}/mrbgems/gem_init.c", "#{build_dir}/LEGAL"]
-    file "#{build_dir}/mrbgems/gem_init.c" => [MRUBY_CONFIG, __FILE__] do |t|
+    file "#{build_dir}/mrbgems/gem_init.c" => [MRUBY_CONFIG, __FILE__, *Dir.glob("#{build_dir}/mrbgems/mruby-*/*.c")] do |t|
       mkdir_p "#{build_dir}/mrbgems"
       open(t.name, 'w') do |f|
         gem_func_gems = gems.select { |g| g.generate_functions }


### PR DESCRIPTION
When building current mruby, adding new mgems by modifying `build_config.rb` or `mrbgems.rake` will additonally check out mgems into project. That is as we expect.

But `#{build_dir}/mrbgems/gem_init.c` won't be re-generated and re-built for now.

That file should have a dependency to mgems' directories and source files.