### PR TITLE
Print exception backtrace if possible without `-v` in test

### DIFF
--- a/test/assert.rb
+++ b/test/assert.rb
@@ -64,7 +64,7 @@ def assertion_string(err, str, iso=nil, e=nil, bt=nil)
       msg += "\n#{diff}" if diff && !diff.empty?
     end
   end
-  msg += "\nbacktrace:\n        #{bt.join("\n        ")}" if bt
+  msg += "\nbacktrace:\n        #{bt.join("\n        ")}" if bt && !bt.empty?
   msg
 end
 
@@ -122,8 +122,7 @@ def assert(str = 'assert', iso = '')
     $mrbtest_child_noassert[-2] += 1
     t_print('?')
   rescue Exception => e
-    bt = e.backtrace if $mrbtest_verbose
-    $asserts.push(assertion_string("#{e.class}: ", str, iso, e, bt))
+    $asserts.push(assertion_string("#{e.class}: ", str, iso, e, e.backtrace))
     $kill_test += 1
     t_print('X')
   ensure


### PR DESCRIPTION
Backtrace is useful for debugging.