### PR TITLE
Get local variable names from orphan block; ref #3710

### DIFF
--- a/mrbgems/mruby-metaprog/src/metaprog.c
+++ b/mrbgems/mruby-metaprog/src/metaprog.c
@@ -146,24 +146,23 @@ mrb_local_variables(mrb_state *mrb, mrb_value self)
   while (proc) {
     if (MRB_PROC_CFUNC_P(proc)) break;
     irep = proc->body.irep;
-    if (!irep->lv) break;
-    for (i = 0; i + 1 < irep->nlocals; ++i) {
-      if (irep->lv[i].name) {
-        mrb_sym sym = irep->lv[i].name;
-        const char *name = mrb_sym_name(mrb, sym);
-        switch (name[0]) {
-        case '*': case '&':
-          break;
-        default:
-          mrb_hash_set(mrb, vars, mrb_symbol_value(sym), mrb_true_value());
-          break;
+    if (irep->lv) {
+      for (i = 0; i + 1 < irep->nlocals; ++i) {
+        if (irep->lv[i].name) {
+          mrb_sym sym = irep->lv[i].name;
+          const char *name = mrb_sym_name(mrb, sym);
+          switch (name[0]) {
+          case '*': case '&':
+            break;
+          default:
+            mrb_hash_set(mrb, vars, mrb_symbol_value(sym), mrb_true_value());
+            break;
+          }
         }
       }
     }
-    if (!MRB_PROC_ENV_P(proc)) break;
+    if (MRB_PROC_SCOPE_P(proc)) break;
     proc = proc->upper;
-    //if (MRB_PROC_SCOPE_P(proc)) break;
-    if (!proc->c) break;
   }
 
   return mrb_hash_keys(mrb, vars);

--- a/mrbgems/mruby-metaprog/test/metaprog.rb
+++ b/mrbgems/mruby-metaprog/test/metaprog.rb
@@ -114,6 +114,15 @@ assert('Kernel.local_variables', '15.3.1.2.7') do
     # Kernel#local_variables: 15.3.1.3.28
     local_variables.sort
   }.call(-1, -2)
+
+  a = Object.new
+  def a.hoge(vars, *, **)
+    Proc.new {
+      x, y = 1, 2
+      local_variables.sort
+    }
+  end
+  assert_equal([:vars, :x, :y]) { a.hoge(0).call }
 end
 
 assert('Kernel#define_singleton_method') do


### PR DESCRIPTION
This patch is resolve first case in #3710.