### PR TITLE
Fix float constant redefinition warnings

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -76,6 +76,7 @@
 #include <mruby/version.h>
 
 #ifndef MRB_WITHOUT_FLOAT
+#include <float.h>
 #ifndef FLT_EPSILON
 #define FLT_EPSILON (1.19209290e-07f)
 #endif


### PR DESCRIPTION
Building and using `mruby.h` with the Microsoft compiler emits warnings

```
C:\Program Files (x86)\Windows Kits\10\include\10.0.18362.0\ucrt\float.h(69): warning C4005: 'DBL_EPSILON': macro redefinition
mruby.h(78): note: see previous definition of 'DBL_EPSILON'
C:\Program Files (x86)\Windows Kits\10\include\10.0.18362.0\ucrt\float.h(83): warning C4005: 'FLT_EPSILON': macro redefinition
mruby.h(75): note: see previous definition of 'FLT_EPSILON'
C:\Program Files (x86)\Windows Kits\10\include\10.0.18362.0\ucrt\float.h(98): warning C4005: 'LDBL_EPSILON': macro redefinition
mruby.h(81): note: see previous definition of 'LDBL_EPSILON'
```

Including `float.h` looks like it fixes the issue. It looks like we include `float.h` elsewhere so this looks like a safe addition.