### PR TITLE
mruby-io: Add include sys/time.h

### DIFF
--- a/mrbgems/mruby-io/src/io.c
+++ b/mrbgems/mruby-io/src/io.c
@@ -1065,6 +1065,7 @@ mrb_io_pid(mrb_state *mrb, mrb_value io)
   return mrb_nil_value();
 }
 
+static struct timeval;
 time2timeval(mrb_state *mrb, mrb_value time)
 {
   struct timeval t = { 0, 0 };

--- a/mrbgems/mruby-io/src/io.c
+++ b/mrbgems/mruby-io/src/io.c
@@ -14,6 +14,7 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/time.h>
 
 #if defined(_WIN32) || defined(_WIN64)
   #include <winsock.h>
@@ -1064,7 +1065,6 @@ mrb_io_pid(mrb_state *mrb, mrb_value io)
   return mrb_nil_value();
 }
 
-static struct timeval
 time2timeval(mrb_state *mrb, mrb_value time)
 {
   struct timeval t = { 0, 0 };


### PR DESCRIPTION
The incomplete type for `struct timeval` in mruby-io was not sufficient to compile it on my platform.  Got errors about unknown size for the type.

* Removed forward declaration of `struct timeval` in mruby-io
* Added include for sys/time.h, which defines `struct timeval`

