### PR TITLE
only use GEMNAME if defined in assert.rb

### DIFF
--- a/test/assert.rb
+++ b/test/assert.rb
@@ -56,7 +56,9 @@ def assertion_string(err, str, iso=nil, e=nil, bt=nil)
   msg = "#{err}#{str}"
   msg += " [#{iso}]" if iso && !iso.empty?
   msg += " => #{e}" if e && !e.to_s.empty?
-  msg += " (#{GEMNAME == 'mruby-test' ? 'core' : "mrbgems: #{GEMNAME}"})"
+  if Object.const_defined?(:GEMNAME)
+    msg += " (#{GEMNAME == 'mruby-test' ? 'core' : "mrbgems: #{GEMNAME}"})"
+  end
   if $mrbtest_assert
     $mrbtest_assert.each do |idx, assert_msg, diff|
       msg += "\n - Assertion[#{idx}]"


### PR DESCRIPTION
Check if the constant GEMNAME is defined before use in `assert.rb`

This is added to prevent an undefined constant error when using
`assert.rb` in other environments - for example, testing CRuby.

Before

```
ruby -I test -r assert -e "assert('w') { assert_true true; assert_true false }; report"
Traceback (most recent call last):
        2: from -e:1:in `<main>'
        1: from /home/user/mruby/test/assert.rb:107:in `assert'
/home/user/mruby/test/assert.rb:59:in `assertion_string': uninitialized constant GEMNAME (NameError)
        3: from -e:1:in `<main>'
        2: from /home/user/mruby/test/assert.rb:119:in `assert'
        1: from /home/user/mruby/test/assert.rb:125:in `rescue in assert'
/home/user/mruby/test/assert.rb:59:in `assertion_string': uninitialized constant GEMNAME (NameError)
```

After

```
ruby -I test -r assert -e "assert('w') { assert_true true; assert_true false }; report"
F
Fail: w
 - Assertion[2]
    Expected false to be true.
  Total: 1
     OK: 0
     KO: 1
  Crash: 0
Warning: 0
   Skip: 0
   Time: 0.0 seconds
```