### PR TITLE
Work around MSC optimization generating non functional code with Array#shuffle

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,6 +101,3 @@ jobs:
         rake -E "STDOUT.sync=true" -m -j4 test
       env:
         MRUBY_CONFIG: appveyor_config.rb
-        # TODO(take-cheeze): Re-enable /O2
-        CFLAGS: "/c /nologo /W3 /we4013 /Zi /MD /D_CRT_SECURE_NO_WARNINGS"
-        CXXFLAGS: "/c /nologo /W3 /Zi /MD /EHs /D_CRT_SECURE_NO_WARNINGS"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,7 +41,7 @@ environment:
       machine: x86
 
 init:
-  - call "%visualcpp%" "%machine%"
+  - call "%visualcpp%" %machine%
   # For using Rubyins4aller's Ruby 2.6 64bit
   # 2.6 is the highest supported Ruby version across all historical
   # Visual Studio AppVeyor images. Ruby 2.7 is only on the 2019 image.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,12 +32,12 @@ environment:
 
     - job_name: Visual Studio 2013 64bit
       visualcpp: C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat
-      appveyor_build_worker_image: Visual Studio 2013
+      appveyor_build_worker_image: Visual Studio 2015
       machine: x86_amd64
 
     - job_name: Visual Studio 2013 32bit
       visualcpp: C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat
-      appveyor_build_worker_image: Visual Studio 2013
+      appveyor_build_worker_image: Visual Studio 2015
       machine: x86
 
 init:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,40 +4,44 @@ shallow_clone: true
 
 environment:
   matrix:
-    # Visual Studio 2019 64bit
-    - visualcpp: C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars64.bat
+    - job_name: Visual Studio 2019 64bit
+      visualcpp: C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars64.bat
       appveyor_build_worker_image: Visual Studio 2019
 
-    # Visual Studio 2019 32bit
-    - visualcpp: C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars32.bat
+    - job_name: Visual Studio 2019 32bit
+      visualcpp: C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars32.bat
       appveyor_build_worker_image: Visual Studio 2019
 
-    # Visual Studio 2017 64bit
-    - visualcpp: C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat
+    - job_name: Visual Studio 2017 64bit
+      visualcpp: C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat
       appveyor_build_worker_image: Visual Studio 2017
 
-    # Visual Studio 2017 32bit
-    - visualcpp: C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars32.bat
+    - job_name: Visual Studio 2017 32bit
+      visualcpp: C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars32.bat
       appveyor_build_worker_image: Visual Studio 2017
 
-    # Visual Studio 2015 64bit
-    - visualcpp: C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvars64.bat
+    - job_name: Visual Studio 2015 64bit
+      visualcpp: C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat
       appveyor_build_worker_image: Visual Studio 2015
+      machine: x86_amd64
 
-    # Visual Studio 2015 32bit
-    - visualcpp: C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvars32.bat
+    - job_name: Visual Studio 2015 32bit
+      visualcpp: C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat
       appveyor_build_worker_image: Visual Studio 2015
+      machine: x86
 
-    # Visual Studio 2013 64bit
-    - visualcpp: C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvars64.bat
+    - job_name: Visual Studio 2013 64bit
+      visualcpp: C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat
       appveyor_build_worker_image: Visual Studio 2013
+      machine: x86_amd64
 
-    # Visual Studio 2013 32bit
-    - visualcpp: C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvars32.bat
+    - job_name: Visual Studio 2013 32bit
+      visualcpp: C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat
       appveyor_build_worker_image: Visual Studio 2013
+      machine: x86
 
 init:
-  - call "%visualcpp%"
+  - call "%visualcpp%" "%machine%"
   # For using Rubyins4aller's Ruby 2.6 64bit
   # 2.6 is the highest supported Ruby version across all historical
   # Visual Studio AppVeyor images. Ruby 2.7 is only on the 2019 image.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,43 +6,38 @@ environment:
   matrix:
     # Visual Studio 2019 64bit
     - visualcpp: C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars64.bat
-      os: Visual Studio 2019
+      appveyor_build_worker_image: Visual Studio 2019
 
     # Visual Studio 2019 32bit
     - visualcpp: C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars32.bat
-      os: Visual Studio 2019
-      machine: x86
+      appveyor_build_worker_image: Visual Studio 2019
 
     # Visual Studio 2017 64bit
     - visualcpp: C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat
-      os: Visual Studio 2017
+      appveyor_build_worker_image: Visual Studio 2017
 
     # Visual Studio 2017 32bit
-    - visualcpp: C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat
-      os: Visual Studio 2017
-      machine: x86
+    - visualcpp: C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars32.bat
+      appveyor_build_worker_image: Visual Studio 2017
 
     # Visual Studio 2015 64bit
-    - visualcpp: C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat
-      os: Visual Studio 2015
-      machine: amd64
+    - visualcpp: C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvars64.bat
+      appveyor_build_worker_image: Visual Studio 2015
 
     # Visual Studio 2015 32bit
-    - visualcpp: C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat
-      os: Visual Studio 2015
-      machine: x86
+    - visualcpp: C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvars32.bat
+      appveyor_build_worker_image: Visual Studio 2015
 
     # Visual Studio 2013 64bit
-    - visualcpp: C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat
-      os: Visual Studio 2013
-      machine: amd64
+    - visualcpp: C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvars64.bat
+      appveyor_build_worker_image: Visual Studio 2013
 
     # Visual Studio 2013 32bit
-    - visualcpp: C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat
-      os: Visual Studio 2013
-      machine: x86
+    - visualcpp: C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvars32.bat
+      appveyor_build_worker_image: Visual Studio 2013
+
 init:
-  - call "%visualcpp%" %machine%
+  - call "%visualcpp%"
   # For using Rubyins4aller's Ruby 2.6 64bit
   # 2.6 is the highest supported Ruby version across all historical
   # Visual Studio AppVeyor images. Ruby 2.7 is only on the 2019 image.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,11 +35,6 @@ environment:
       appveyor_build_worker_image: Visual Studio 2015
       machine: x86_amd64
 
-    - job_name: Visual Studio 2013 32bit
-      visualcpp: C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat
-      appveyor_build_worker_image: Visual Studio 2015
-      machine: x86
-
 init:
   - call "%visualcpp%" %machine%
   # For using Rubyins4aller's Ruby 2.6 64bit

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,37 +1,46 @@
 version: "{build}"
 
-os: Visual Studio 2019
-
 shallow_clone: true
 
 environment:
   matrix:
     # Visual Studio 2019 64bit
     - visualcpp: C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars64.bat
+      os: Visual Studio 2019
 
     # Visual Studio 2019 32bit
     - visualcpp: C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars32.bat
+      os: Visual Studio 2019
       machine: x86
 
     # Visual Studio 2017 64bit
     - visualcpp: C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat
+      os: Visual Studio 2017
 
     # Visual Studio 2017 32bit
     - visualcpp: C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat
+      os: Visual Studio 2017
       machine: x86
 
     # Visual Studio 2015 64bit
     - visualcpp: C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat
+      os: Visual Studio 2015
       machine: amd64
 
     # Visual Studio 2015 32bit
     - visualcpp: C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat
+      os: Visual Studio 2015
       machine: x86
 
     # Visual Studio 2013 64bit
     - visualcpp: C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat
+      os: Visual Studio 2013
       machine: amd64
 
+    # Visual Studio 2013 32bit
+    - visualcpp: C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat
+      os: Visual Studio 2013
+      machine: x86
 init:
   - call "%visualcpp%" %machine%
   # For using Rubyins4aller's Ruby 2.6 64bit

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,11 +1,18 @@
 version: "{build}"
 
-os: Visual Studio 2017
+os: Visual Studio 2019
 
 shallow_clone: true
 
 environment:
   matrix:
+    # Visual Studio 2019 64bit
+    - visualcpp: C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars64.bat
+
+    # Visual Studio 2019 32bit
+    - visualcpp: C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars32.bat
+      machine: x86
+
     # Visual Studio 2017 64bit
     - visualcpp: C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat
 
@@ -25,15 +32,14 @@ environment:
     - visualcpp: C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat
       machine: amd64
 
-
 init:
   - call "%visualcpp%" %machine%
-  # For using Rubyinstaller's Ruby 2.4 64bit
-  - set PATH=C:\Ruby24-x64\bin;%PATH%
+  # For using Rubyins4aller's Ruby 2.6 64bit
+  # 2.6 is the highest supported Ruby version across all historical
+  # Visual Studio AppVeyor images. Ruby 2.7 is only on the 2019 image.
+  - set PATH=C:\Ruby26-x64\bin;%PATH%
   - ruby --version
-
 
 build_script:
   - set MRUBY_CONFIG=appveyor_config.rb
-  - rake -m
-  - rake -E $stdout.sync=true test
+  - rake -E "$stdout.sync=true" -m -j4 test

--- a/mrbgems/mruby-random/src/random.c
+++ b/mrbgems/mruby-random/src/random.c
@@ -210,18 +210,18 @@ random_m_srand(mrb_state *mrb, mrb_value self)
  *  Shuffles elements in self in place.
  */
 
-#if defined _MSC_VER && _MSC_VER >= 1900
-#pragma optimize( "", off )
-#endif
 static mrb_value
 mrb_ary_shuffle_bang(mrb_state *mrb, mrb_value ary)
 {
+  mrb_int i;
+  mrb_value max;
  /*
  * MSC compiler generating invalid instructions with optimization
  * enabled
  */
-  mrb_int i;
-  mrb_value max;
+#if defined _MSC_VER && _MSC_VER >= 1923
+  volatile
+#endif
   mrb_value r = mrb_nil_value();
   rand_state *random;
 

--- a/mrbgems/mruby-random/src/random.c
+++ b/mrbgems/mruby-random/src/random.c
@@ -210,9 +210,16 @@ random_m_srand(mrb_state *mrb, mrb_value self)
  *  Shuffles elements in self in place.
  */
 
+#if defined _MSC_VER && _MSC_VER >= 1900
+#pragma optimize( "", off )
+#endif
 static mrb_value
 mrb_ary_shuffle_bang(mrb_state *mrb, mrb_value ary)
 {
+ /*
+ * MSC compiler generating invalid instructions with optimization
+ * enabled
+ */
   mrb_int i;
   mrb_value max;
   mrb_value r = mrb_nil_value();

--- a/mrbgems/mruby-random/src/random.c
+++ b/mrbgems/mruby-random/src/random.c
@@ -215,15 +215,18 @@ mrb_ary_shuffle_bang(mrb_state *mrb, mrb_value ary)
 {
   mrb_int i;
   mrb_value max;
+  mrb_value r = mrb_nil_value();
+  rand_state *random;
+
  /*
- * MSC compiler generating invalid instructions with optimization
+ * MSC compiler bug generating invalid instructions with optimization
  * enabled
  */
 #if defined _MSC_VER && _MSC_VER >= 1923
-  volatile
+  volatile mrb_value rr;
+  rr = r;
+  r = rr;
 #endif
-  mrb_value r = mrb_nil_value();
-  rand_state *random;
 
   if (RARRAY_LEN(ary) > 1) {
     mrb_get_args(mrb, "|o", &r);

--- a/mrbgems/mruby-random/src/random.c
+++ b/mrbgems/mruby-random/src/random.c
@@ -220,12 +220,30 @@ mrb_ary_shuffle_bang(mrb_state *mrb, mrb_value ary)
 
  /*
  * MSC compiler bug generating invalid instructions with optimization
- * enabled
+ * enabled. MSC errantly uses a hardcoded value with optimizations on
+ * when using a fixed value from a union.
+ * Creating a temp volatile variable and reassigning back to the original
+ * value tricks the compiler to not perform this optimization;
  */
 #if defined _MSC_VER && _MSC_VER >= 1923
-  volatile mrb_value rr;
-  rr = r;
-  r = rr;
+  /* C++ will not cast away volatile easily, so we cannot do something like
+   * volatile mrb_value rr = r; r = (mrb_value)rr; with C++.
+   * That cast does work with C.
+   * We also have to trick the compiler to not optimize away the const_cast entirely
+   * by creating and manipulating an intermediate volatile pointer.
+   */
+  volatile mrb_value *v_r;
+  volatile mrb_int ii;
+  mrb_value *p_r;
+  v_r = &r;
+  ii = 2;
+  v_r = v_r + 2;
+#if defined __cplusplus
+  p_r = const_cast<mrb_value*>(v_r - ii);
+#else
+  p_r = (mrb_value*)v_r - ii;
+#endif
+  r = *p_r;
 #endif
 
   if (RARRAY_LEN(ary) > 1) {


### PR DESCRIPTION
Quite the interesting issue here.

Summary of changes
===

- Work around MSC and MSC++ compiler bug where it would optimize away a union access which may contain a static value in random.c

- Updated appveyor config, added MS 2019 compilers, and uses the highest Ruby version available on the appveyor image

- Removed special compiler flags in github actions MSC build

Description
===

Currently the tests with master fails with the Microsoft compiler v19 with optimizations enabled. This _only_ happens with MSC and from what I can determine only with MSC > 19. The simplest reproduction is the Ruby expression from the Random test

```ruby
[1, 2].shuffle Random.new
```

Passing a Random instance to an Array causes a segfault. I have some insight as to what happens though I do not know how to fix it besides disabling optimization entirely for the `mrb_ary_shuffle_bang` C function.

With optimizations enabled the MSC compiler infers some hard coded values incorrectly and stores them in registers. Code down the line treats the values in the registers as pointers which leads to a crash. I've tried expanding all the macros out, setting intermediate values as a part of the macro expansion, and marking the suspect variables as `volatile`. Using `declspec(noinline)` on all relevant functions it still does not fix it. Nothing I know how to do forces the compiler to stop over optimizing and generating hard numbers. However, I am no expert and I am well out of my depth at this point trying to debug optimized code.

More in depth, the MSC compiler hard sets register `rbx` to a literal `0x18` value when casting to `rand_state *`. This causes the pointer to go wild later in `random_rand` trying to follow a pointer to memory address `0x18` 

<img width="1920" alt="Annotation 2020-06-26 141756" src="https://user-images.githubusercontent.com/19547/85906149-4a852680-b7c2-11ea-8fc0-4ca72e78f70c.png">

<img width="1920" alt="Annotation 2020-06-26 143006" src="https://user-images.githubusercontent.com/19547/85906074-16116a80-b7c2-11ea-90f8-1151ce5d55cf.png">

 It also sets`rsi` to `0x2` breaking C calling conventions and overwriting the pointer to the `mrb_state*` stored in`rsi`. 
<img width="1920" alt="Annotation 2020-06-26 131541" src="https://user-images.githubusercontent.com/19547/85906082-1b6eb500-b7c2-11ea-8ca7-418383e9c458.png">