### PR TITLE
object_id of true, false, and undef are all 0

### DIFF
--- a/src/etc.c
+++ b/src/etc.c
@@ -107,10 +107,11 @@ mrb_obj_id(mrb_value obj)
     return MakeID(0); /* not define */
   case MRB_TT_FALSE:
     if (mrb_nil_p(obj))
-      return MakeID(1);
-    return MakeID(0);
+      return MakeID(4);
+    else
+      return MakeID(0);
   case MRB_TT_TRUE:
-    return MakeID(1);
+    return MakeID(2);
   case MRB_TT_SYMBOL:
     return MakeID(mrb_symbol(obj));
   case MRB_TT_FIXNUM:


### PR DESCRIPTION
Currently it looks like a bug where `object_id` of `true` and `false` is both zero. It looks like we expect the macro `MakeID2` as a bit shift `<<` instead of xor `^`.

This uses hardcoded values similar to how C Ruby uses a bitshift for special object names. I would prefer calculating the actual `intptr_t` of `nil`, `false` and `true` instances in the `mrb_state` though from what I can tell there aren't actual instances of these special values created? We also use `0` for free/undefined types and `false`. I did not change that, though I can if it's felt safe.

Before
```
> true.object_id
 => 0
> false.object_id
 => 0
> nil.object_id
 => 1
```

After

```
> true.object_id
 => 3
> false.object_id
 => 0
> nil.object_id
 => 4
```