### PR TITLE
Update Windows CI settings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     - name: build
       run: rake -m -j4 all
     - name: test
-      run: rake test
+      run: rake test -v
       env:
         MRUBY_CONFIG: travis_config.rb
 
@@ -25,7 +25,7 @@ jobs:
     - name: build
       run: rake -m -j4 all
     - name: test
-      run: rake test
+      run: rake test -v
       env:
         MRUBY_CONFIG: travis_config.rb
         CC: gcc
@@ -40,7 +40,7 @@ jobs:
     - name: build
       run: rake -m -j4 all
     - name: test
-      run: rake test
+      run: rake test -v
       env:
         MRUBY_CONFIG: travis_config.rb
         CC: clang
@@ -55,7 +55,7 @@ jobs:
     - name: build
       run: rake -m -j4 all
     - name: test
-      run: rake test
+      run: rake test -v
       env:
         MRUBY_CONFIG: travis_config.rb
 
@@ -99,4 +99,4 @@ jobs:
       shell: cmd
       run: C:\tools\cygwin\bin\ruby.exe /usr/bin/rake -E 'STDOUT.sync=true' test
       env:
-        MRUBY_CONFIG: appveyor_config.rb
+        MRUBY_CONFIG: travis_config.rb

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,51 +5,59 @@ on: [push, pull_request]
 jobs:
   Ubuntu-1604:
     runs-on: ubuntu-16.04
+    env:
+      MRUBY_CONFIG: travis_config.rb
     steps:
     - uses: actions/checkout@v1
     - name: apt
       run: sudo apt install ruby gperf
-    - name: build and test
-      run: rake -v test
-      env:
-        MRUBY_CONFIG: travis_config.rb
+    - name: build
+      run: rake -m
+    - name: test
+      run: rake test -v
 
   Ubuntu-1804-gcc:
     runs-on: ubuntu-18.04
+    env:
+      MRUBY_CONFIG: travis_config.rb
+      CC: gcc
+      CXX: g++
     steps:
     - uses: actions/checkout@v1
     - name: apt
       run: sudo apt install ruby gperf gcc g++
-    - name: build and test
-      run: rake -v test
-      env:
-        MRUBY_CONFIG: travis_config.rb
-        CC: gcc
-        CXX: g++
+    - name: build
+      run: rake -m
+    - name: test
+      run: rake test -v
 
   Ubuntu-1804-clang:
     runs-on: ubuntu-18.04
+    env:
+      MRUBY_CONFIG: travis_config.rb
+      CC: clang
+      CXX: clang++
     steps:
     - uses: actions/checkout@v1
     - name: apt
       run: sudo apt install ruby gperf
-    - name: build and test
-      run: rake -v test
-      env:
-        MRUBY_CONFIG: travis_config.rb
-        CC: clang
-        CXX: clang++
+    - name: build
+      run: rake -m
+    - name: test
+      run: rake test -v
 
   macOS:
     runs-on: macos-latest
+    env:
+      MRUBY_CONFIG: travis_config.rb
     steps:
     - uses: actions/checkout@v1
     - name: brew
       run: brew install ruby gperf
-    - name: build and test
-      run: rake -v test
-      env:
-        MRUBY_CONFIG: travis_config.rb
+    - name: build
+      run: rake -m
+    - name: test
+      run: rake test -v
 
   Windows-MinGW:
     runs-on: windows-latest
@@ -82,7 +90,12 @@ jobs:
     - name: Set ENV
       run: |
         echo '::set-env name=PATH::C:\tools\cygwin\bin;C:\tools\cygwin\usr\bin'
-    - name: build and test
+    - name: build
+      shell: cmd
+      run: C:\tools\cygwin\bin\ruby.exe /usr/bin/rake -E 'STDOUT.sync=true' -m
+      env:
+        MRUBY_CONFIG: travis_config.rb
+    - name: test
       shell: cmd
       run: C:\tools\cygwin\bin\ruby.exe /usr/bin/rake -E 'STDOUT.sync=true' -v test
       env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,10 +9,8 @@ jobs:
     - uses: actions/checkout@v1
     - name: apt
       run: sudo apt install ruby gperf
-    - name: build
-      run: rake -m -j4 all
-    - name: test
-      run: rake test -v
+    - name: build and test
+      run: rake -v test
       env:
         MRUBY_CONFIG: travis_config.rb
 
@@ -22,10 +20,8 @@ jobs:
     - uses: actions/checkout@v1
     - name: apt
       run: sudo apt install ruby gperf gcc g++
-    - name: build
-      run: rake -m -j4 all
-    - name: test
-      run: rake test -v
+    - name: build and test
+      run: rake -v test
       env:
         MRUBY_CONFIG: travis_config.rb
         CC: gcc
@@ -37,10 +33,8 @@ jobs:
     - uses: actions/checkout@v1
     - name: apt
       run: sudo apt install ruby gperf
-    - name: build
-      run: rake -m -j4 all
-    - name: test
-      run: rake test -v
+    - name: build and test
+      run: rake -v test
       env:
         MRUBY_CONFIG: travis_config.rb
         CC: clang
@@ -52,10 +46,8 @@ jobs:
     - uses: actions/checkout@v1
     - name: brew
       run: brew install ruby gperf
-    - name: build
-      run: rake -m -j4 all
-    - name: test
-      run: rake test -v
+    - name: build and test
+      run: rake -v test
       env:
         MRUBY_CONFIG: travis_config.rb
 
@@ -66,9 +58,7 @@ jobs:
     - name: chocolatey
       run: choco install -y ruby gperf
     - name: build
-      run: rake -E '$stdout.sync=true' -m -j4
-    - name: test
-      run: rake -E 'STDOUT.sync=true' test
+      run: rake -E 'STDOUT.sync=true' -v test
       env:
         MRUBY_CONFIG: travis_config.rb
         CFLAGS: -g -O1 -Wall -Wundef
@@ -92,11 +82,8 @@ jobs:
     - name: Set ENV
       run: |
         echo '::set-env name=PATH::C:\tools\cygwin\bin;C:\tools\cygwin\usr\bin'
-    - name: build
+    - name: build and test
       shell: cmd
-      run: C:\tools\cygwin\bin\ruby.exe /usr/bin/rake -m -j4 -E 'STDOUT.sync=true'
-    - name: test
-      shell: cmd
-      run: C:\tools\cygwin\bin\ruby.exe /usr/bin/rake -E 'STDOUT.sync=true' test
+      run: C:\tools\cygwin\bin\ruby.exe /usr/bin/rake -E 'STDOUT.sync=true' -v test
       env:
         MRUBY_CONFIG: travis_config.rb

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,8 +9,10 @@ jobs:
     - uses: actions/checkout@v1
     - name: apt
       run: sudo apt install ruby gperf
-    - name: build and test
-      run: rake -m -j4 all test
+    - name: build
+      run: rake -m -j4 all
+    - name: test
+      run: rake test
       env:
         MRUBY_CONFIG: travis_config.rb
 
@@ -20,8 +22,10 @@ jobs:
     - uses: actions/checkout@v1
     - name: apt
       run: sudo apt install ruby gperf gcc g++
-    - name: build and test
-      run: rake -m -j4 all test
+    - name: build
+      run: rake -m -j4 all
+    - name: test
+      run: rake test
       env:
         MRUBY_CONFIG: travis_config.rb
         CC: gcc
@@ -33,8 +37,10 @@ jobs:
     - uses: actions/checkout@v1
     - name: apt
       run: sudo apt install ruby gperf
-    - name: build and test
-      run: rake -m -j4 all test
+    - name: build
+      run: rake -m -j4 all
+    - name: test
+      run: rake test
       env:
         MRUBY_CONFIG: travis_config.rb
         CC: clang
@@ -46,8 +52,10 @@ jobs:
     - uses: actions/checkout@v1
     - name: brew
       run: brew install ruby gperf
-    - name: build and test
-      run: rake -m -j4 all test
+    - name: build
+      run: rake -m -j4 all
+    - name: test
+      run: rake test
       env:
         MRUBY_CONFIG: travis_config.rb
 
@@ -57,8 +65,10 @@ jobs:
     - uses: actions/checkout@v1
     - name: chocolatey
       run: choco install -y ruby gperf
-    - name: build and test
-      run: rake -E '$stdout.sync=true' -j4 test
+    - name: build
+      run: rake -E '$stdout.sync=true' -m -j4
+    - name: test
+      run: rake -E 'STDOUT.sync=true' test
       env:
         MRUBY_CONFIG: travis_config.rb
         CFLAGS: -g -O1 -Wall -Wundef
@@ -82,22 +92,11 @@ jobs:
     - name: Set ENV
       run: |
         echo '::set-env name=PATH::C:\tools\cygwin\bin;C:\tools\cygwin\usr\bin'
-    - name: build and test
+    - name: build
       shell: cmd
-      run: C:\tools\cygwin\bin\ruby.exe /usr/bin/rake -m -j4 -E 'STDOUT.sync=true' test
+      run: C:\tools\cygwin\bin\ruby.exe /usr/bin/rake -m -j4 -E 'STDOUT.sync=true'
+    - name: test
+      shell: cmd
+      run: C:\tools\cygwin\bin\ruby.exe /usr/bin/rake -E 'STDOUT.sync=true' test
       env:
         MRUBY_CONFIG: travis_config.rb
-
-  Windows-VC:
-    runs-on: windows-latest
-    steps:
-    - uses: actions/checkout@v1
-    - name: chocolatey
-      run: choco install -y ruby gperf
-    - name: build and test
-      shell: cmd
-      run: |
-        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-        rake -E "STDOUT.sync=true" -m -j4 test
-      env:
-        MRUBY_CONFIG: appveyor_config.rb

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,4 +99,4 @@ jobs:
       shell: cmd
       run: C:\tools\cygwin\bin\ruby.exe /usr/bin/rake -E 'STDOUT.sync=true' test
       env:
-        MRUBY_CONFIG: travis_config.rb
+        MRUBY_CONFIG: appveyor_config.rb

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     - name: build
       run: rake -m
     - name: test
-      run: rake test -v
+      run: rake test
 
   Ubuntu-1804-gcc:
     runs-on: ubuntu-18.04
@@ -29,7 +29,7 @@ jobs:
     - name: build
       run: rake -m
     - name: test
-      run: rake test -v
+      run: rake test
 
   Ubuntu-1804-clang:
     runs-on: ubuntu-18.04
@@ -44,7 +44,7 @@ jobs:
     - name: build
       run: rake -m
     - name: test
-      run: rake test -v
+      run: rake test
 
   macOS:
     runs-on: macos-latest
@@ -57,7 +57,7 @@ jobs:
     - name: build
       run: rake -m
     - name: test
-      run: rake test -v
+      run: rake test
 
   Windows-MinGW:
     runs-on: windows-latest
@@ -66,7 +66,7 @@ jobs:
     - name: chocolatey
       run: choco install -y ruby gperf
     - name: build
-      run: rake -E 'STDOUT.sync=true' -v test
+      run: rake -E 'STDOUT.sync=true' test
       env:
         MRUBY_CONFIG: travis_config.rb
         CFLAGS: -g -O1 -Wall -Wundef
@@ -97,6 +97,6 @@ jobs:
         MRUBY_CONFIG: travis_config.rb
     - name: test
       shell: cmd
-      run: C:\tools\cygwin\bin\ruby.exe /usr/bin/rake -E 'STDOUT.sync=true' -v test
+      run: C:\tools\cygwin\bin\ruby.exe /usr/bin/rake -E 'STDOUT.sync=true' test
       env:
         MRUBY_CONFIG: travis_config.rb

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,4 +41,4 @@ init:
 build_script:
   - set MRUBY_CONFIG=appveyor_config.rb
   - rake -E "$stdout.sync=true" -m -j4
-  - rake test -v
+  - rake test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,4 +41,4 @@ init:
 build_script:
   - set MRUBY_CONFIG=appveyor_config.rb
   - rake -E "$stdout.sync=true" -m -j4
-  - rake test
+  - rake test -v

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,11 +30,6 @@ environment:
       appveyor_build_worker_image: Visual Studio 2015
       machine: x86
 
-    - job_name: Visual Studio 2013 64bit
-      visualcpp: C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat
-      appveyor_build_worker_image: Visual Studio 2015
-      machine: x86_amd64
-
 init:
   - call "%visualcpp%" %machine%
   # For using Rubyins4aller's Ruby 2.6 64bit
@@ -45,4 +40,5 @@ init:
 
 build_script:
   - set MRUBY_CONFIG=appveyor_config.rb
-  - rake -E "$stdout.sync=true" -m -j4 test
+  - rake -E "$stdout.sync=true" -m -j4
+  - rake test


### PR DESCRIPTION
Following from discussion on #5028 

- Does not use `rake -m` for avoiding mixing output from rake tasks. Further, it appears building with `-m` introduces other issues while performing separate build and test tasks. The project builds in less than a minute so I do not think the parallelization helps.
- Removes MSC build from github actions
- Removes VS 2013 from Appveyor matrix as 2013 is no longer supported by MS (https://docs.microsoft.com/en-us/visualstudio/releases/2019/servicing)

@shuujii I think this addresses your comments?