### PR TITLE
Add ObjectSpace.memsize_of

### DIFF
--- a/include/mruby/gc.h
+++ b/include/mruby/gc.h
@@ -21,6 +21,7 @@ struct mrb_state;
 #define MRB_EACH_OBJ_BREAK 1
 typedef int (mrb_each_object_callback)(struct mrb_state *mrb, struct RBasic *obj, void *data);
 void mrb_objspace_each_objects(struct mrb_state *mrb, mrb_each_object_callback *callback, void *data);
+const mrb_int mrb_objspace_page_slot_size();
 MRB_API void mrb_free_context(struct mrb_state *mrb, struct mrb_context *c);
 
 #ifndef MRB_GC_ARENA_SIZE

--- a/include/mruby/hash.h
+++ b/include/mruby/hash.h
@@ -23,6 +23,7 @@ struct RHash {
 #define mrb_hash_ptr(v)    ((struct RHash*)(mrb_ptr(v)))
 #define mrb_hash_value(p)  mrb_obj_value((void*)(p))
 
+mrb_int os_memsize_of_hash_table(mrb_value obj);
 MRB_API mrb_value mrb_hash_new_capa(mrb_state *mrb, mrb_int capa);
 MRB_API mrb_value mrb_ensure_hash_type(mrb_state *mrb, mrb_value hash);
 MRB_API mrb_value mrb_check_hash_type(mrb_state *mrb, mrb_value hash);

--- a/include/mruby/hash.h
+++ b/include/mruby/hash.h
@@ -23,7 +23,7 @@ struct RHash {
 #define mrb_hash_ptr(v)    ((struct RHash*)(mrb_ptr(v)))
 #define mrb_hash_value(p)  mrb_obj_value((void*)(p))
 
-mrb_int os_memsize_of_hash_table(mrb_value obj);
+mrb_int mrb_os_memsize_of_hash_table(mrb_value obj);
 MRB_API mrb_value mrb_hash_new_capa(mrb_state *mrb, mrb_int capa);
 MRB_API mrb_value mrb_ensure_hash_type(mrb_state *mrb, mrb_value hash);
 MRB_API mrb_value mrb_check_hash_type(mrb_state *mrb, mrb_value hash);

--- a/include/mruby/variable.h
+++ b/include/mruby/variable.h
@@ -35,6 +35,7 @@ mrb_value mrb_vm_cv_get(mrb_state*, mrb_sym);
 void mrb_vm_cv_set(mrb_state*, mrb_sym, mrb_value);
 mrb_value mrb_vm_const_get(mrb_state*, mrb_sym);
 void mrb_vm_const_set(mrb_state*, mrb_sym, mrb_value);
+mrb_int mrb_obj_iv_tbl_memsize(mrb_state*, mrb_value);
 MRB_API mrb_value mrb_const_get(mrb_state*, mrb_value, mrb_sym);
 MRB_API void mrb_const_set(mrb_state*, mrb_value, mrb_sym, mrb_value);
 MRB_API mrb_bool mrb_const_defined(mrb_state*, mrb_value, mrb_sym);

--- a/mrbgems/mruby-objectspace/mrbgem.rake
+++ b/mrbgems/mruby-objectspace/mrbgem.rake
@@ -2,4 +2,8 @@ MRuby::Gem::Specification.new('mruby-objectspace') do |spec|
   spec.license = 'MIT'
   spec.author  = 'mruby developers'
   spec.summary = 'ObjectSpace class'
+
+  spec.add_test_dependency('mruby-metaprog')
+  spec.add_test_dependency('mruby-method')
+  spec.add_test_dependency('mruby-fiber')
 end

--- a/mrbgems/mruby-objectspace/src/mruby_objectspace.c
+++ b/mrbgems/mruby-objectspace/src/mruby_objectspace.c
@@ -270,7 +270,7 @@ os_memsize_of_object(mrb_state* mrb, mrb_value obj, mrb_value recurse, mrb_int* 
     }
     case MRB_TT_HASH: {
       (*t) += mrb_objspace_page_slot_size() +
-              os_memsize_of_hash_table(obj);
+              mrb_os_memsize_of_hash_table(obj);
       if(!mrb_nil_p(recurse)) {
         os_memsize_of_object(mrb, mrb_hash_keys(mrb, obj), recurse, t);
         os_memsize_of_object(mrb, mrb_hash_values(mrb, obj), recurse, t);

--- a/mrbgems/mruby-objectspace/src/mruby_objectspace.c
+++ b/mrbgems/mruby-objectspace/src/mruby_objectspace.c
@@ -262,8 +262,12 @@ os_memsize_of_object(mrb_state* mrb, mrb_value obj, mrb_bool recurse, mrb_int* t
       break;
     }
     case MRB_TT_HASH: {
-      /*struct htable* htable = RHASH_TBL(obj);
-       * Need htable & segment struct defs */
+      (*t) += mrb_objspace_page_slot_size() +
+              os_memsize_of_hash_table(obj);
+      if(recurse) {
+        os_memsize_of_object(mrb, mrb_hash_keys(mrb, obj), recurse, t);
+        os_memsize_of_object(mrb, mrb_hash_values(mrb, obj), recurse, t);
+      }
       break;
     }
     case MRB_TT_ARRAY: {
@@ -325,7 +329,6 @@ os_memsize_of_object(mrb_state* mrb, mrb_value obj, mrb_bool recurse, mrb_int* t
     case MRB_TT_FREE:
     case MRB_TT_UNDEF:
     case MRB_TT_ENV:
-    case MRB_TT_ISTRUCT:
     /* never used, silences compiler warning
      * not having a default: clause lets the compiler tell us when there is a new
      * TT not accounted for */

--- a/mrbgems/mruby-objectspace/src/mruby_objectspace.c
+++ b/mrbgems/mruby-objectspace/src/mruby_objectspace.c
@@ -324,8 +324,10 @@ os_memsize_of_object(mrb_state* mrb, mrb_value obj, mrb_bool recurse, mrb_int* t
         ci_p++;
       }
 
-      for(i = 0; i <= f->cxt->esize; i++) {
-         os_memsize_of_irep(mrb, f->cxt->ensure[i]->body.irep, t);
+      if(f->cxt->esize) {
+        for(i = 0; i <= f->cxt->esize; i++) {
+          os_memsize_of_irep(mrb, f->cxt->ensure[i]->body.irep, t);
+        }
       }
 
       (*t) += mrb_objspace_page_slot_size() +

--- a/mrbgems/mruby-objectspace/src/mruby_objectspace.c
+++ b/mrbgems/mruby-objectspace/src/mruby_objectspace.c
@@ -196,7 +196,7 @@ os_memsize_of_ivars(mrb_state* mrb, mrb_value obj, mrb_bool recurse, mrb_int *t)
   if(recurse) {
     mrb_int r = (mrb_int)recurse;
     mrb_int *cb_data[2] = { &r, t };
-    mrb_iv_foreach(mrb, obj, os_memsize_ivar_cb, t);
+    mrb_iv_foreach(mrb, obj, os_memsize_ivar_cb, cb_data);
   }
 }
 
@@ -261,8 +261,8 @@ os_memsize_of_object(mrb_state* mrb, mrb_value obj, mrb_bool recurse, mrb_int* t
       break;
     }
     case MRB_TT_HASH: {
-      struct htable* htable = RHASH_TBL(obj);
-      /* Need htable & segment struct defs */
+      /*struct htable* htable = RHASH_TBL(obj);
+       * Need htable & segment struct defs */
       break;
     }
     case MRB_TT_ARRAY: {
@@ -302,10 +302,11 @@ os_memsize_of_object(mrb_state* mrb, mrb_value obj, mrb_bool recurse, mrb_int* t
       (*t) += sizeof(struct mrb_range_edges);
     #endif
       break;
-    case MRB_TT_FIBER:
-      struct RFiber* fiber = (struct RFiber*)mrb_ptr(obj);
+    case MRB_TT_FIBER: {
+      /*  struct RFiber* fiber = (struct RFiber*)mrb_ptr(obj); */
       (*t) += sizeof(struct mrb_context);
       break;
+    }
     /*  zero heap size types.
      *  immediate VM stack values, contained within mrb_state, mrb_heap_page,
      *  or on C stack */

--- a/mrbgems/mruby-objectspace/src/mruby_objectspace.c
+++ b/mrbgems/mruby-objectspace/src/mruby_objectspace.c
@@ -2,6 +2,14 @@
 #include <mruby/gc.h>
 #include <mruby/hash.h>
 #include <mruby/class.h>
+#include <mruby/object.h>
+#include <mruby/numeric.h>
+#include <mruby/string.h>
+#include <mruby/array.h>
+#include <mruby/variable.h>
+#include <mruby/proc.h>
+#include <mruby/value.h>
+#include <mruby/range.h>
 
 struct os_count_struct {
   mrb_int total;
@@ -168,12 +176,205 @@ os_each_object(mrb_state *mrb, mrb_value self)
   return mrb_fixnum_value(d.count);
 }
 
+static void os_memsize_of_object(mrb_state*,mrb_value,mrb_bool,mrb_int*);
+
+static int
+os_memsize_ivar_cb(mrb_state *mrb, mrb_sym _name, mrb_value obj, void *data)
+{
+  mrb_int *cb_data = (mrb_int *)data;
+  mrb_int recurse = *(&cb_data[0]);
+  mrb_int* total = &cb_data[1];
+
+  os_memsize_of_object(mrb, obj, (mrb_bool)(recurse), total);
+  return 0;
+}
+
+static void
+os_memsize_of_ivars(mrb_state* mrb, mrb_value obj, mrb_bool recurse, mrb_int *t)
+{
+  /* need iv segment table size */
+  if(recurse) {
+    mrb_int r = (mrb_int)recurse;
+    mrb_int *cb_data[2] = { &r, t };
+    mrb_iv_foreach(mrb, obj, os_memsize_ivar_cb, t);
+  }
+}
+
+static void
+os_memsize_of_irep(mrb_state* state, struct mrb_irep *irep, mrb_int* t)
+{
+  mrb_int i;
+  (*t) += (irep->slen * sizeof(mrb_sym)) +
+          (irep->plen * sizeof(mrb_code)) +
+          (irep->ilen * sizeof(mrb_code));
+
+  for(i = 0; i < irep->rlen; i++) {
+    os_memsize_of_irep(state, irep->reps[i], t);
+  }
+}
+
+static void
+os_memsize_of_method(mrb_state* mrb, mrb_value method_obj, mrb_int* t)
+{
+  mrb_value proc_value = mrb_obj_iv_get(mrb, mrb_obj_ptr(method_obj),
+                                        mrb_intern_lit(mrb, "_proc"));
+  struct RProc *proc = mrb_proc_ptr(proc_value);
+
+  (*t) += sizeof(struct RProc);
+  if(!MRB_PROC_CFUNC_P(proc)) os_memsize_of_irep(mrb, proc->body.irep, t);
+}
+
+static void
+os_memsize_of_methods(mrb_state* mrb, mrb_value obj, mrb_int* t)
+{
+  mrb_value method_list;
+  mrb_int i;
+  if(!mrb_respond_to(mrb, obj, mrb_intern_lit(mrb, "instance_methods"))) return;
+  method_list = mrb_funcall(mrb, obj, "instance_methods", 1, mrb_false_value());
+  for(i = 0; i < RARRAY_LEN(method_list); i++) {
+    mrb_value method = mrb_funcall(mrb, obj, "instance_method", 1,
+                                   mrb_ary_ref(mrb, method_list, i));
+    os_memsize_of_method(mrb, method, t);
+  }
+}
+
+static void
+os_memsize_of_object(mrb_state* mrb, mrb_value obj, mrb_bool recurse, mrb_int* t)
+{
+  switch(obj.tt) {
+    case MRB_TT_STRING:
+      (*t) += RSTRING_LEN(obj);
+      break;
+    case MRB_TT_CLASS:
+    case MRB_TT_MODULE:
+    case MRB_TT_EXCEPTION:
+    case MRB_TT_SCLASS:
+    case MRB_TT_ICLASS:
+    case MRB_TT_OBJECT: {
+      os_memsize_of_ivars(mrb, obj, recurse, t);
+      if(mrb_obj_is_kind_of(mrb, obj, mrb_class_get(mrb, "UnboundMethod"))) {
+        os_memsize_of_method(mrb, obj, t);
+      }
+      else {
+        os_memsize_of_methods(mrb, obj, t);
+      }
+      break;
+    }
+    case MRB_TT_HASH: {
+      struct htable* htable = RHASH_TBL(obj);
+      /* Need htable & segment struct defs */
+      break;
+    }
+    case MRB_TT_ARRAY: {
+      mrb_int len, i;
+      len = RARRAY_LEN(obj);
+      /* Arrays that do not fit within an RArray perform a heap allocation
+      *  storing an array of pointers to the original objects*/
+      if(len > MRB_ARY_EMBED_LEN_MAX) (*t) += sizeof(mrb_value *) * len;
+
+      if(recurse) {
+        for(i = 0; i < len; i++) {
+          os_memsize_of_object(mrb, ARY_PTR(mrb_ary_ptr(obj))[i], recurse, t);
+        }
+      }
+      break;
+    }
+    case MRB_TT_PROC: {
+      struct RProc* proc = mrb_proc_ptr(obj);
+      (*t) += MRB_ENV_LEN(proc->e.env) * sizeof(mrb_value);
+      if(!MRB_PROC_CFUNC_P(proc)) os_memsize_of_irep(mrb, proc->body.irep, t);
+      break;
+    }
+    case MRB_TT_DATA:
+      if(mrb_respond_to(mrb, obj, mrb_intern_lit(mrb, "memsize"))) {
+        (*t) += mrb_fixnum(mrb_funcall(mrb, obj, "memsize", 0));
+      }
+      break;
+    #ifndef MRB_WITHOUT_FLOAT
+    case MRB_TT_FLOAT:
+      #ifdef MRB_WORD_BOXING
+        (*t) += sizeof(struct RFloat);
+      #endif
+      break;
+    #endif
+    case MRB_TT_RANGE:
+    #ifndef MRB_RANGE_EMBED
+      (*t) += sizeof(struct mrb_range_edges);
+    #endif
+      break;
+    case MRB_TT_FIBER:
+      struct RFiber* fiber = (struct RFiber*)mrb_ptr(obj);
+      (*t) += sizeof(struct mrb_context);
+      break;
+    /*  zero heap size types.
+     *  immediate VM stack values, contained within mrb_state, mrb_heap_page,
+     *  or on C stack */
+    case MRB_TT_TRUE:
+    case MRB_TT_FALSE:
+    case MRB_TT_FIXNUM:
+    case MRB_TT_BREAK:
+    case MRB_TT_CPTR:
+    case MRB_TT_SYMBOL:
+    case MRB_TT_FREE:
+    case MRB_TT_UNDEF:
+    case MRB_TT_ENV:
+    case MRB_TT_ISTRUCT:
+    /* never used, silences compiler warning
+     * not having a default: clause lets the compiler tell us when there is a new
+     * TT not accounted for */
+    case MRB_TT_MAXDEFINE:
+      break;
+  }
+}
+
+/*
+ *  call-seq:
+ *    ObjectSpace.memsize_of(obj, recurse: false) -> Numeric
+ *
+ *  Returns the amount of heap memory allocated for object in size_t units.
+ *  Not all objects cause additional heap allocations beyond their object pointer
+ *  in the heap page and may return 0.
+ *
+ *  The return value depends on the definition of size_t on that platform,
+ *  therefore the value is not comparable across platform types.
+ *
+ *  Immediate values such as integers, booleans, symbols and unboxed float numbers
+ *  return 0. Additionally special objects which are small enough to fit inside an
+ *  object *  pointer, termed embedded objects, also return 0. Strings and arrays
+ *  below a compile-time defined size may be embedded.
+ *
+ *  Setting recurse: true descends into instance variables, array members,
+ *  and hash values recursively, calculating the child objects and adding to
+ *  the final sum.
+ *
+ */
+
+static mrb_value
+os_memsize_of(mrb_state *mrb, mrb_value self)
+{
+  mrb_int total;
+  mrb_value obj;
+  mrb_bool recurse;
+  const char *kw_names[1] = { "recurse" };
+  mrb_value kw_values[1];
+  const mrb_kwargs kwargs = { 1, kw_values, kw_names, 0, NULL };
+
+  mrb_get_args(mrb, "o:", &obj, &kwargs);
+  recurse = mrb_obj_eq(mrb, kw_values[0], mrb_true_value()) ? TRUE : FALSE;
+
+  total = 0;
+  os_memsize_of_object(mrb, obj, recurse, &total);
+
+  return mrb_fixnum_value(total);
+}
+
 void
 mrb_mruby_objectspace_gem_init(mrb_state *mrb)
 {
   struct RClass *os = mrb_define_module(mrb, "ObjectSpace");
   mrb_define_class_method(mrb, os, "count_objects", os_count_objects, MRB_ARGS_OPT(1));
   mrb_define_class_method(mrb, os, "each_object", os_each_object, MRB_ARGS_OPT(1));
+  mrb_define_class_method(mrb, os, "memsize_of", os_memsize_of, MRB_ARGS_REQ(1)|MRB_ARGS_OPT(1));
 }
 
 void

--- a/mrbgems/mruby-objectspace/src/mruby_objectspace.c
+++ b/mrbgems/mruby-objectspace/src/mruby_objectspace.c
@@ -373,20 +373,24 @@ os_memsize_of_object(mrb_state* mrb, mrb_value obj, mrb_value recurse, mrb_int* 
  *    ObjectSpace.memsize_of(obj, recurse: false) -> Numeric
  *
  *  Returns the amount of heap memory allocated for object in size_t units.
- *  Not all objects cause additional heap allocations beyond their object pointer
- *  in the heap page and may return 0.
  *
  *  The return value depends on the definition of size_t on that platform,
  *  therefore the value is not comparable across platform types.
  *
  *  Immediate values such as integers, booleans, symbols and unboxed float numbers
  *  return 0. Additionally special objects which are small enough to fit inside an
- *  object *  pointer, termed embedded objects, also return 0. Strings and arrays
- *  below a compile-time defined size may be embedded.
+ *  object pointer, termed embedded objects, will return the size of the object pointer.
+ *  Strings and arrays below a compile-time defined size may be embedded.
  *
  *  Setting recurse: true descends into instance variables, array members,
- *  and hash values recursively, calculating the child objects and adding to
- *  the final sum.
+ *  hash keys and hash values recursively, calculating the child objects and adding to
+ *  the final sum. It avoids infinite recursion and over counting objects by
+ *  internally tracking discovered object ids.
+ *
+ *  MRB_TT_DATA objects aren't calculated beyond their original page slot. However,
+ *  if the object implements a memsize method it will call that method and add the
+ *  return value to the total. This provides an opportunity for C based data structures
+ *  to report their memory usage.
  *
  */
 

--- a/mrbgems/mruby-objectspace/src/mruby_objectspace.c
+++ b/mrbgems/mruby-objectspace/src/mruby_objectspace.c
@@ -192,7 +192,7 @@ os_memsize_ivar_cb(mrb_state *mrb, mrb_sym _name, mrb_value obj, void *data)
 static void
 os_memsize_of_ivars(mrb_state* mrb, mrb_value obj, mrb_bool recurse, mrb_int *t)
 {
-  /* need iv segment table size */
+  (*t) += mrb_obj_iv_tbl_memsize(mrb, obj);
   if(recurse) {
     mrb_int r = (mrb_int)recurse;
     mrb_int *cb_data[2] = { &r, t };

--- a/mrbgems/mruby-objectspace/src/mruby_objectspace.c
+++ b/mrbgems/mruby-objectspace/src/mruby_objectspace.c
@@ -286,8 +286,8 @@ os_memsize_of_object(mrb_state* mrb, mrb_value obj, mrb_bool recurse, mrb_int* t
       break;
     }
     case MRB_TT_PROC: {
-      (*t) += mrb_objspace_page_slot_size();
       struct RProc* proc = mrb_proc_ptr(obj);
+      (*t) += mrb_objspace_page_slot_size();
       (*t) += MRB_ENV_LEN(proc->e.env) * sizeof(mrb_value);
       if(!MRB_PROC_CFUNC_P(proc)) os_memsize_of_irep(mrb, proc->body.irep, t);
       break;
@@ -312,7 +312,7 @@ os_memsize_of_object(mrb_state* mrb, mrb_value obj, mrb_bool recurse, mrb_int* t
               sizeof(struct mrb_range_edges);
     #endif
       break;
-    case MRB_TT_FIBER:
+    case MRB_TT_FIBER: {
       struct RFiber* f = (struct RFiber *)mrb_ptr(obj);
       mrb_callinfo *ci_p = f->cxt->cibase;
       ptrdiff_t stack_size = f->cxt->stend - f->cxt->stbase;
@@ -336,6 +336,7 @@ os_memsize_of_object(mrb_state* mrb, mrb_value obj, mrb_bool recurse, mrb_int* t
         stack_size +
         ci_size;
       break;
+    }
     case MRB_TT_ISTRUCT:
       (*t) += mrb_objspace_page_slot_size();
       break;

--- a/mrbgems/mruby-objectspace/test/objectspace.rb
+++ b/mrbgems/mruby-objectspace/test/objectspace.rb
@@ -93,9 +93,7 @@ assert 'ObjectSpace.memsize_of' do
   assert_not_equal class_obj_size, 0, 'Class obj not zero'
 
   empty_class_def_size = ObjectSpace.memsize_of Class.new
-
-  # need access to struct iv_tbl
-  # assert_not_equal empty_class_def_size, 0, 'Class def not zero'
+  assert_not_equal empty_class_def_size, 0, 'Class def not zero'
 
   class_without_methods = Class.new do
     @a = 1
@@ -125,12 +123,15 @@ assert 'ObjectSpace.memsize_of' do
   assert_not_equal m_size, 0, 'method size not zero'
 
   # collections
-  assert_equal ObjectSpace.memsize_of([]), 0, 'empty array size zero'
-  assert_not_equal ObjectSpace.memsize_of(Array.new(16)), 0, 'array size non zero'
+  assert_not_equal ObjectSpace.memsize_of([]), 0, 'empty array size not zero'
+  assert_not_equal ObjectSpace.memsize_of(Array.new(16)), 0, 'array size not zero'
 
   # fiber
-  assert_not_equal ObjectSpace.memsize_of(Fiber.new {}), 0, 'fiber non zero'
+  assert_not_equal ObjectSpace.memsize_of(Fiber.new {}), 0, 'fiber not zero'
 
-  skip 'No hash table support yet'
-  assert_equal ObjectSpace.memsize_of({}), 0, 'empty hash size zero'
+  #hash
+  assert_not_equal ObjectSpace.memsize_of({}), 0, 'empty hash size not zero'
+
+  # recursion
+
 end

--- a/mrbgems/mruby-objectspace/test/objectspace.rb
+++ b/mrbgems/mruby-objectspace/test/objectspace.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 assert('ObjectSpace.count_objects') do
   h = {}
   f = Fiber.new {} if Object.const_defined?(:Fiber)
@@ -57,4 +58,79 @@ end
 
 assert 'Check class pointer of ObjectSpace.each_object.' do
   assert_nothing_raised { ObjectSpace.each_object { |obj| !obj } }
+end
+
+assert 'ObjectSpace.memsize_of' do
+  # immediate literals
+  int_size = ObjectSpace.memsize_of 1
+  assert_equal int_size, 0, 'int zero'
+
+  sym_size = ObjectSpace.memsize_of :foo
+  assert_equal sym_size, 0, 'sym zero'
+
+  assert_equal ObjectSpace.memsize_of(true), int_size
+  assert_equal ObjectSpace.memsize_of(false), int_size
+
+  float_size = if Object.const_defined? :Float
+                 ObjectSpace.memsize_of 1.0
+               else
+                 nil
+               end
+
+  # need some way of asking if floats are boxed
+  assert_equal float_size, 0 if float_size
+
+  assert_not_equal ObjectSpace.memsize_of('a'), 0, 'memsize of str'
+
+  if __ENCODING__ == "UTF-8"
+    assert_not_equal ObjectSpace.memsize_of("こんにちは世界"), 0, 'memsize of utf8 str'
+  end
+
+  assert_not_equal ObjectSpace.memsize_of(0..1), 0, 'range not zero'
+
+  # class defs
+  class_obj_size = ObjectSpace.memsize_of Class
+  assert_not_equal class_obj_size, 0, 'Class obj not zero'
+
+  empty_class_def_size = ObjectSpace.memsize_of Class.new
+
+  # need access to struct iv_tbl
+  # assert_not_equal empty_class_def_size, 0, 'Class def not zero'
+
+  class_without_methods = Class.new do
+    @a = 1
+    @b = 2
+  end
+  class_total_size = empty_class_def_size + (int_size * 2)
+  assert_equal ObjectSpace.memsize_of(class_without_methods), class_total_size, 'class without methods size'
+
+  module_without_methods = Module.new do
+    @a = 1
+    @b = 2
+  end
+  module_total_size = empty_class_def_size + (int_size * 2)
+  assert_equal ObjectSpace.memsize_of(module_without_methods), module_total_size, 'module without methods size'
+
+  proc_size = ObjectSpace.memsize_of Proc.new { x = 1; x }
+  assert_not_equal proc_size, 0
+
+  class_with_methods = Class.new do
+    def foo
+      a = 0
+      a + 1
+    end
+  end
+
+  m_size = ObjectSpace.memsize_of class_with_methods.instance_method(:foo)
+  assert_not_equal m_size, 0, 'method size not zero'
+
+  # collections
+  assert_equal ObjectSpace.memsize_of([]), 0, 'empty array size zero'
+  assert_not_equal ObjectSpace.memsize_of(Array.new(16)), 0, 'array size non zero'
+
+  # fiber
+  assert_not_equal ObjectSpace.memsize_of(Fiber.new {}), 0, 'fiber non zero'
+
+  skip 'No hash table support yet'
+  assert_equal ObjectSpace.memsize_of({}), 0, 'empty hash size zero'
 end

--- a/src/gc.c
+++ b/src/gc.c
@@ -1599,6 +1599,13 @@ mrb_objspace_each_objects(mrb_state *mrb, mrb_each_object_callback *callback, vo
   }
 }
 
+const mrb_int
+mrb_objspace_page_slot_size()
+{
+  const mrb_int i = sizeof(RVALUE);
+  return i;
+}
+
 #ifdef GC_TEST
 #ifdef GC_DEBUG
 static mrb_value gc_test(mrb_state *, mrb_value);

--- a/src/hash.c
+++ b/src/hash.c
@@ -519,7 +519,7 @@ ht_foreach(mrb_state *mrb, htable *t, mrb_hash_foreach_func *func, void *p)
 }
 
 mrb_int
-os_memsize_of_hash_table(mrb_value obj)
+mrb_os_memsize_of_hash_table(mrb_value obj)
 {
   struct htable *h = mrb_hash_ptr(obj)->ht;
   mrb_int segkv_size = 0;

--- a/src/hash.c
+++ b/src/hash.c
@@ -518,6 +518,20 @@ ht_foreach(mrb_state *mrb, htable *t, mrb_hash_foreach_func *func, void *p)
   }
 }
 
+mrb_int
+os_memsize_of_hash_table(mrb_value obj)
+{
+  struct htable *h = mrb_hash_ptr(obj)->ht;
+  mrb_int segkv_size = 0;
+
+  if(h->index) segkv_size = (sizeof(struct segkv) * h->index->capa);
+
+  return sizeof(htable) +
+    sizeof(segindex) +
+    (sizeof(segment) * h->size) +
+    segkv_size;
+}
+
 /* Iterates over the hash table. */
 MRB_API void
 mrb_hash_foreach(mrb_state *mrb, struct RHash *hash, mrb_hash_foreach_func *func, void *p)

--- a/src/variable.c
+++ b/src/variable.c
@@ -4,6 +4,7 @@
 ** See Copyright Notice in mruby.h
 */
 
+#include <math.h>
 #include <mruby.h>
 #include <mruby/array.h>
 #include <mruby/class.h>
@@ -1126,6 +1127,14 @@ mrb_class_find_path(mrb_state *mrb, struct RClass *c)
     path = mrb_str_dup(mrb, path);
   }
   return path;
+}
+
+mrb_int
+mrb_obj_iv_tbl_memsize(mrb_state* mrb, mrb_value obj)
+{
+  return sizeof(iv_tbl) +
+    (sizeof(segment) * ceil(iv_size(mrb, mrb_obj_ptr(obj)->iv)/
+                            MRB_IV_SEGMENT_SIZE));
 }
 
 #define identchar(c) (ISALNUM(c) || (c) == '_' || !ISASCII(c))


### PR DESCRIPTION
Hello, this is my first significant contribution. I hope the review is not a burden.

This implements the mri method of `ObjectSpace.memsize_of`. With mruby we care a great deal about tracking resource use therefore I feel this is useful. All of the code is new, none copied. The mruby structures differ from C Ruby structures so existing C Ruby code isn't useful.

One difference between this implementation and the mri one is an addition of a `recurse` parameter. Specifying `ObjectSpace.memsize_of obj, recurse: true` will recursively descend into collection members and instance variables. Do let me know if I should not include this option and I will remove it.

Additionally, I added a protocol for `MRB_TT_DATA` objects. If a data object implements the `memsize` method this code will call that method and use it's return value for the size total. This allows a chance for including data objects into memory calculations, a gap I noticed from mri.