### PR TITLE
Fix `${build_dir}/mrbgems/gem_init.c` generation condition; ref #5010

### DIFF
--- a/mrbgems/mruby-test/mrbgem.rake
+++ b/mrbgems/mruby-test/mrbgem.rake
@@ -146,20 +146,8 @@ MRuby::Gem::Specification.new('mruby-test') do |spec|
     end
   end
 
-  # store the last gem selection and make the re-build
-  # of the test gem depending on a change to the gem
-  # selection
-  active_gems_path = "#{build_dir}/active_gems_path.lst"
-  active_gem_list = File.read active_gems_path if File.exist? active_gems_path
-  current_gem_list = build.gems.map(&:name).join("\n")
-  task active_gems_path do |_t|
-    mkdir_p File.dirname(active_gems_path)
-    File.write active_gems_path, current_gem_list
-  end
-  file clib => active_gems_path if active_gem_list != current_gem_list
-
   file mlib => clib
-  file clib => [build.mrbcfile, __FILE__] do |_t|
+  file clib => ["#{build.build_dir}/mrbgems/active_gems.txt", build.mrbcfile, __FILE__] do |_t|
     _pp "GEN", "*.rb", "#{clib.relative_path}"
     mkdir_p File.dirname(clib)
     open(clib, 'w') do |f|


### PR DESCRIPTION
The `${build_dir}/mrbgems/gem_init.c` generation condition has been changed
at #5010, but it is somewhat insufficient, for example, there was a problem
with `rake && rake test`, which was also regenerated in `rake test`.