### PR TITLE
Use type tag for hash code in `ht_hash_func()`

### DIFF
--- a/src/hash.c
+++ b/src/hash.c
@@ -73,7 +73,7 @@ ht_hash_func(mrb_state *mrb, htable *t, mrb_value key)
 
   default:
     hv = mrb_funcall(mrb, key, "hash", 0);
-    h = (size_t)t ^ (size_t)mrb_fixnum(hv);
+    h = (size_t)tt ^ (size_t)mrb_fixnum(hv);
     break;
   }
   if (index && (index != t->index || capa != index->capa)) {


### PR DESCRIPTION
The function corresponding to `ht_hash_func()` was as follows in the days of
khash implementation (before d78acc7a).

  ```c
  mrb_hash_ht_hash_func(mrb_state *mrb, mrb_value key)
  {
    enum mrb_vtype t = mrb_type(key);
    ...
    switch (t) {
    ...
    default:
      hv = mrb_funcall(mrb, key, "hash", 0);
      h = (khint_t)t ^ (khint_t)mrb_fixnum(hv);
      break;
    }
    ...
  }
  ```

When switched to the segmented list implementation (d78acc7a), this function
was changed as follows.

  ```c
  sg_hash_func(mrb_state *mrb, seglist *t, mrb_value key)
  {
    enum mrb_vtype tt = mrb_type(key);
    ...
    switch (tt) {
    ...
    default:
      hv = mrb_funcall(mrb, key, "hash", 0);
      h = (size_t)t ^ (size_t)mrb_fixnum(hv);
      break;
    }
    ...
  }
  ```

Since the argument `t` was added, the variable for type tag was changed from
`t` to `tt`, but the variable used in the expression of `h` remained `t`.

Probably this is an omission of change, so fixed it.