### PR TITLE
Add `mrb_static_assert1()` macro

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -62,10 +62,14 @@
 #define mrb_assert_int_fit(t1,n,t2,max) ((void)0)
 #endif
 
-#if defined __STDC_VERSION__ && __STDC_VERSION__ >= 201112L
-#define mrb_static_assert(exp, str) _Static_assert(exp, str)
+#if (defined __STDC_VERSION__ && __STDC_VERSION__ >= 201112L) || \
+    (defined __cplusplus && __cplusplus >= 201103L)
+#include <assert.h>
+#define mrb_static_assert(exp, str) static_assert(exp, str)
+#define mrb_static_assert1(exp) static_assert(exp, #exp)
 #else
 #define mrb_static_assert(exp, str) mrb_assert(exp)
+#define mrb_static_assert1(exp) mrb_assert(exp)
 #endif
 
 #include "mrbconf.h"


### PR DESCRIPTION
This macro function is a variant of `mrb_static_assert()` that takes only one argument.

----

I'll use it in a patch that removes `ecall()` that I think I can suggest in the near future.
