### PR TITLE
Improve `rake benchmark`

### DIFF
--- a/tasks/benchmark.rake
+++ b/tasks/benchmark.rake
@@ -5,7 +5,7 @@ end
 $dat_files = []
 
 def bm_files
-  Dir.glob("#{MRUBY_ROOT}/benchmark/bm_*.rb")
+  Dir.glob("#{MRUBY_ROOT}/benchmark/bm_*.rb").sort
 end
 
 def build_config_name
@@ -67,8 +67,8 @@ MRuby.each_target do |target|
       puts "..."
 
       data = (0...MRuby::BENCHMARK_REPEAT).map do |n|
-        str = %x{(time -f "%e %S %U" #{mruby_bin} #{bm_file}) 2>&1 >/dev/null}
-        str.split(' ').map(&:to_f)
+        str = %x{(time -p #{mruby_bin} #{bm_file}) 2>&1 >/dev/null}
+        str.scan(/\d+\.\d+$/).map(&:to_f) # [real, user, sys]
       end
 
       File.open(task.name, "w") do |f|


### PR DESCRIPTION
- Use POSIX format instead of GNU extension for `time` command.
  For example FreeBSD's `time(1)` does not have GNU extensions available.
- Sort `benchmark/bm_*.rb`.
  This is because the order of the bar graph cannot be uniquely determined depending on the result of `Dir.glob`.