### PR TITLE
Improve `ensure`

### DIFF
--- a/doc/opcode.md
+++ b/doc/opcode.md
@@ -70,13 +70,9 @@ with `"`, either `OP_EXT1` or `OP_EXT2` or `OP_EXT2` can be prefixed.
 | OP_JMPIF'        | BS           | if R(a) pc=b                                           |
 | OP_JMPNOT'       | BS           | if !R(a) pc=b                                          |
 | OP_JMPNIL'       | BS           | if R(a)==nil pc=b                                      |
-| OP_ONERR         | S            | rescue_push(a)                                         |
 | OP_EXCEPT'       | B            | R(a) = exc                                             |
 | OP_RESCUE"       | BB           | R(b) = R(a).isa?(R(b))                                 |
-| OP_POPERR'       | B            | a.times{rescue_pop()}                                  |
 | OP_RAISEIF'      | B            | raise(R(a)) if R(a)                                    |
-| OP_EPUSH'        | B            | ensure_push(SEQ[a])                                    |
-| OP_EPOP'         | B            | A.times{ensure_pop().call}                             |
 | OP_SENDV"        | BB           | R(a) = call(R(a),Syms(b),*R(a+1))                      |
 | OP_SENDVB"       | BB           | R(a) = call(R(a),Syms(b),*R(a+1),&R(a+2))              |
 | OP_SEND"         | BBB          | R(a) = call(R(a),Syms(b),R(a+1),...,R(a+c))            |

--- a/doc/opcode.md
+++ b/doc/opcode.md
@@ -70,6 +70,7 @@ with `"`, either `OP_EXT1` or `OP_EXT2` or `OP_EXT2` can be prefixed.
 | OP_JMPIF'        | BS           | if R(a) pc=b                                           |
 | OP_JMPNOT'       | BS           | if !R(a) pc=b                                          |
 | OP_JMPNIL'       | BS           | if R(a)==nil pc=b                                      |
+| OP_JMPUNWIND     | S            | unwind_and_jump_to(a)                                  |
 | OP_EXCEPT'       | B            | R(a) = exc                                             |
 | OP_RESCUE"       | BB           | R(b) = R(a).isa?(R(b))                                 |
 | OP_RAISEIF'      | B            | raise(R(a)) if R(a)                                    |

--- a/doc/opcode.md
+++ b/doc/opcode.md
@@ -74,7 +74,7 @@ with `"`, either `OP_EXT1` or `OP_EXT2` or `OP_EXT2` can be prefixed.
 | OP_EXCEPT'       | B            | R(a) = exc                                             |
 | OP_RESCUE"       | BB           | R(b) = R(a).isa?(R(b))                                 |
 | OP_POPERR'       | B            | a.times{rescue_pop()}                                  |
-| OP_RAISE'        | B            | raise(R(a))                                            |
+| OP_RAISEIF'      | B            | raise(R(a)) if R(a)                                    |
 | OP_EPUSH'        | B            | ensure_push(SEQ[a])                                    |
 | OP_EPOP'         | B            | A.times{ensure_pop().call}                             |
 | OP_SENDV"        | BB           | R(a) = call(R(a),Syms(b),*R(a+1))                      |

--- a/include/mruby.h
+++ b/include/mruby.h
@@ -138,8 +138,6 @@ typedef struct {
   mrb_sym mid;
   struct RProc *proc;
   mrb_value *stackent;
-  uint16_t ridx;
-  uint16_t epos;
   struct REnv *env;
   const mrb_code *pc;           /* return address */
   const mrb_code *err;          /* error position */
@@ -165,11 +163,6 @@ struct mrb_context {
 
   mrb_callinfo *ci;
   mrb_callinfo *cibase, *ciend;
-
-  uint16_t *rescue;                       /* exception handler stack */
-  uint16_t rsize;
-  struct RProc **ensure;                  /* ensure handler stack */
-  uint16_t esize, eidx;
 
   enum mrb_fiber_state status : 4;
   mrb_bool vmexec : 1;
@@ -290,7 +283,6 @@ typedef struct mrb_state {
   mrb_atexit_func *atexit_stack;
 #endif
   uint16_t atexit_stack_len;
-  uint16_t ecall_nest;                    /* prevent infinite recursive ecall() */
 } mrb_state;
 
 /**

--- a/include/mruby/error.h
+++ b/include/mruby/error.h
@@ -66,6 +66,39 @@ mrb_break_value_set(struct RBreak *brk, mrb_value val)
 #define mrb_break_proc_get(brk) ((brk)->proc)
 #define mrb_break_proc_set(brk, p) ((brk)->proc = p)
 
+#define RBREAK_TAG_FOREACH(f) \
+  f(RBREAK_TAG_BREAK, 0) \
+  f(RBREAK_TAG_BREAK_UPPER, 1) \
+  f(RBREAK_TAG_BREAK_INTARGET, 2) \
+  f(RBREAK_TAG_RETURN_BLOCK, 3) \
+  f(RBREAK_TAG_RETURN, 4) \
+  f(RBREAK_TAG_RETURN_TOPLEVEL, 5) \
+  f(RBREAK_TAG_JUMP, 6) \
+  f(RBREAK_TAG_STOP, 7)
+
+#define RBREAK_TAG_DEFINE(tag, i) tag = i,
+enum {
+  RBREAK_TAG_FOREACH(RBREAK_TAG_DEFINE)
+};
+#undef RBREAK_TAG_DEFINE
+
+#define RBREAK_TAG_BIT          3
+#define RBREAK_TAG_BIT_OFF      8
+#define RBREAK_TAG_MASK         (~(~UINT32_C(0) << RBREAK_TAG_BIT))
+
+static inline uint32_t
+mrb_break_tag_get(struct RBreak *brk)
+{
+  return (brk->flags >> RBREAK_TAG_BIT_OFF) & RBREAK_TAG_MASK;
+}
+
+static inline void
+mrb_break_tag_set(struct RBreak *brk, uint32_t tag)
+{
+  brk->flags &= ~(RBREAK_TAG_MASK << RBREAK_TAG_BIT_OFF);
+  brk->flags |= (tag & RBREAK_TAG_MASK) << RBREAK_TAG_BIT_OFF;
+}
+
 /**
  * Protect
  *

--- a/include/mruby/ops.h
+++ b/include/mruby/ops.h
@@ -48,13 +48,9 @@ OPCODE(JMP,        S)        /* pc=a */
 OPCODE(JMPIF,      BS)       /* if R(a) pc=b */
 OPCODE(JMPNOT,     BS)       /* if !R(a) pc=b */
 OPCODE(JMPNIL,     BS)       /* if R(a)==nil pc=b */
-OPCODE(ONERR,      S)        /* rescue_push(a) */
 OPCODE(EXCEPT,     B)        /* R(a) = exc */
 OPCODE(RESCUE,     BB)       /* R(b) = R(a).isa?(R(b)) */
-OPCODE(POPERR,     B)        /* a.times{rescue_pop()} */
 OPCODE(RAISEIF,    B)        /* raise(R(a)) if R(a) */
-OPCODE(EPUSH,      B)        /* ensure_push(SEQ[a]) */
-OPCODE(EPOP,       B)        /* A.times{ensure_pop().call} */
 OPCODE(SENDV,      BB)       /* R(a) = call(R(a),Syms(b),*R(a+1)) */
 OPCODE(SENDVB,     BB)       /* R(a) = call(R(a),Syms(b),*R(a+1),&R(a+2)) */
 OPCODE(SEND,       BBB)      /* R(a) = call(R(a),Syms(b),R(a+1),...,R(a+c)) */

--- a/include/mruby/ops.h
+++ b/include/mruby/ops.h
@@ -48,6 +48,7 @@ OPCODE(JMP,        S)        /* pc=a */
 OPCODE(JMPIF,      BS)       /* if R(a) pc=b */
 OPCODE(JMPNOT,     BS)       /* if !R(a) pc=b */
 OPCODE(JMPNIL,     BS)       /* if R(a)==nil pc=b */
+OPCODE(JMPUNWIND,  S)        /* unwind_and_jump_to(a) */
 OPCODE(EXCEPT,     B)        /* R(a) = exc */
 OPCODE(RESCUE,     BB)       /* R(b) = R(a).isa?(R(b)) */
 OPCODE(RAISEIF,    B)        /* raise(R(a)) if R(a) */

--- a/include/mruby/ops.h
+++ b/include/mruby/ops.h
@@ -52,7 +52,7 @@ OPCODE(ONERR,      S)        /* rescue_push(a) */
 OPCODE(EXCEPT,     B)        /* R(a) = exc */
 OPCODE(RESCUE,     BB)       /* R(b) = R(a).isa?(R(b)) */
 OPCODE(POPERR,     B)        /* a.times{rescue_pop()} */
-OPCODE(RAISE,      B)        /* raise(R(a)) */
+OPCODE(RAISEIF,    B)        /* raise(R(a)) if R(a) */
 OPCODE(EPUSH,      B)        /* ensure_push(SEQ[a]) */
 OPCODE(EPOP,       B)        /* A.times{ensure_pop().call} */
 OPCODE(SENDV,      BB)       /* R(a) = call(R(a),Syms(b),*R(a+1)) */

--- a/mrbgems/mruby-compiler/core/codegen.c
+++ b/mrbgems/mruby-compiler/core/codegen.c
@@ -1537,7 +1537,7 @@ codegen(codegen_scope *s, node *tree, int val)
         }
         if (pos1) {
           dispatch(s, pos1);
-          genop_1(s, OP_RAISE, exc);
+          genop_1(s, OP_RAISEIF, exc);
         }
       }
       pop();

--- a/mrbgems/mruby-compiler/core/codegen.c
+++ b/mrbgems/mruby-compiler/core/codegen.c
@@ -41,7 +41,6 @@ enum looptype {
 struct loopinfo {
   enum looptype type;
   int pc0, pc1, pc2, pc3, acc;
-  int ensure_level;
   struct loopinfo *prev;
 };
 
@@ -62,7 +61,6 @@ typedef struct scope {
   mrb_bool mscope:1;
 
   struct loopinfo *loop;
-  int ensure_level;
   mrb_sym filename_sym;
   uint16_t lineno;
 
@@ -1469,16 +1467,19 @@ codegen(codegen_scope *s, node *tree, int val)
     {
       int noexc, exend, pos1, pos2, tmp;
       struct loopinfo *lp;
+      int catch_entry, begin, end;
 
       if (tree->car == NULL) goto exit;
       lp = loop_push(s, LOOP_BEGIN);
       lp->pc0 = new_label(s);
-      lp->pc1 = genjmp(s, OP_ONERR, 0);
+      catch_entry = catch_hander_new(s);
+      begin = s->pc;
       codegen(s, tree->car, VAL);
       pop();
       lp->type = LOOP_RESCUE;
+      end = s->pc;
       noexc = genjmp(s, OP_JMP, 0);
-      dispatch(s, lp->pc1);
+      catch_hander_set(s, catch_entry, MRB_CATCH_RESCUE, begin, end, s->pc);
       tree = tree->cdr;
       exend = 0;
       pos1 = 0;
@@ -1543,7 +1544,6 @@ codegen(codegen_scope *s, node *tree, int val)
       pop();
       tree = tree->cdr;
       dispatch(s, noexc);
-      genop_1(s, OP_POPERR, 1);
       if (tree->car) {
         codegen(s, tree->car, val);
       }
@@ -1559,14 +1559,22 @@ codegen(codegen_scope *s, node *tree, int val)
     if (!tree->cdr || !tree->cdr->cdr ||
         (nint(tree->cdr->cdr->car) == NODE_BEGIN &&
          tree->cdr->cdr->cdr)) {
+      int catch_entry, begin, end, target;
       int idx;
 
-      s->ensure_level++;
-      idx = scope_body(s, tree->cdr, NOVAL);
-      genop_1(s, OP_EPUSH, idx);
+      catch_entry = catch_hander_new(s);
+      begin = s->pc;
       codegen(s, tree->car, val);
-      s->ensure_level--;
-      genop_1(s, OP_EPOP, 1);
+      end = target = s->pc;
+      push();
+      idx = cursp();
+      genop_1(s, OP_EXCEPT, idx);
+      push();
+      codegen(s, tree->cdr->cdr, NOVAL);
+      pop();
+      genop_1(s, OP_RAISEIF, idx);
+      pop();
+      catch_hander_set(s, catch_entry, MRB_CATCH_ENSURE, begin, end, target);
     }
     else {                      /* empty ensure ignored */
       codegen(s, tree->car, val);
@@ -2028,18 +2036,20 @@ codegen(codegen_scope *s, node *tree, int val)
       if ((len == 2 && name[0] == '|' && name[1] == '|') &&
           (nint(tree->car->car) == NODE_CONST ||
            nint(tree->car->car) == NODE_CVAR)) {
-        int onerr, noexc, exc;
+        int catch_entry, begin, end;
+        int noexc, exc;
         struct loopinfo *lp;
 
-        onerr = genjmp(s, OP_ONERR, 0);
         lp = loop_push(s, LOOP_BEGIN);
-        lp->pc1 = onerr;
+        lp->pc0 = new_label(s);
+        catch_entry = catch_hander_new(s);
+        begin = s->pc;
         exc = cursp();
         codegen(s, tree->car, VAL);
-        lp->type = LOOP_RESCUE;
-        genop_1(s, OP_POPERR, 1);
+        end = s->pc;
         noexc = genjmp(s, OP_JMP, 0);
-        dispatch(s, onerr);
+        lp->type = LOOP_RESCUE;
+        catch_hander_set(s, catch_entry, MRB_CATCH_RESCUE, begin, end, s->pc);
         genop_1(s, OP_EXCEPT, exc);
         genop_1(s, OP_LOADF, exc);
         dispatch(s, noexc);
@@ -2292,11 +2302,8 @@ codegen(codegen_scope *s, node *tree, int val)
       raise_error(s, "unexpected next");
     }
     else if (s->loop->type == LOOP_NORMAL) {
-      if (s->ensure_level > s->loop->ensure_level) {
-        genop_1(s, OP_EPOP, s->ensure_level - s->loop->ensure_level);
-      }
       codegen(s, tree, NOVAL);
-      genjmp(s, OP_JMP, s->loop->pc0);
+      genjmp(s, OP_JMPUNWIND, s->loop->pc0);
     }
     else {
       if (tree) {
@@ -2316,10 +2323,7 @@ codegen(codegen_scope *s, node *tree, int val)
       raise_error(s, "unexpected redo");
     }
     else {
-      if (s->ensure_level > s->loop->ensure_level) {
-        genop_1(s, OP_EPOP, s->ensure_level - s->loop->ensure_level);
-      }
-      genjmp(s, OP_JMP, s->loop->pc2);
+      genjmp(s, OP_JMPUNWIND, s->loop->pc2);
     }
     if (val) push();
     break;
@@ -2327,32 +2331,16 @@ codegen(codegen_scope *s, node *tree, int val)
   case NODE_RETRY:
     {
       const char *msg = "unexpected retry";
+      const struct loopinfo *lp = s->loop;
 
-      if (!s->loop) {
+      while (lp && lp->type != LOOP_RESCUE) {
+        lp = lp->prev;
+      }
+      if (!lp) {
         raise_error(s, msg);
       }
       else {
-        struct loopinfo *lp = s->loop;
-        int n = 0;
-
-        while (lp && lp->type != LOOP_RESCUE) {
-          if (lp->type == LOOP_BEGIN) {
-            n++;
-          }
-          lp = lp->prev;
-        }
-        if (!lp) {
-          raise_error(s, msg);
-        }
-        else {
-          if (n > 0) {
-            genop_1(s, OP_POPERR, n);
-          }
-          if (s->ensure_level > lp->ensure_level) {
-            genop_1(s, OP_EPOP, s->ensure_level - lp->ensure_level);
-          }
-          genjmp(s, OP_JMP, lp->pc0);
-        }
+        genjmp(s, OP_JMPUNWIND, lp->pc0);
       }
       if (val) push();
     }
@@ -3141,7 +3129,6 @@ loop_push(codegen_scope *s, enum looptype t)
   p->type = t;
   p->pc0 = p->pc1 = p->pc2 = p->pc3 = 0;
   p->prev = s->loop;
-  p->ensure_level = s->ensure_level;
   p->acc = cursp();
   s->loop = p;
 
@@ -3157,7 +3144,6 @@ loop_break(codegen_scope *s, node *tree)
   }
   else {
     struct loopinfo *loop;
-    int n = 0;
 
     if (tree) {
       gen_retval(s, tree);
@@ -3166,7 +3152,6 @@ loop_break(codegen_scope *s, node *tree)
     loop = s->loop;
     while (loop) {
       if (loop->type == LOOP_BEGIN) {
-        n++;
         loop = loop->prev;
       }
       else if (loop->type == LOOP_RESCUE) {
@@ -3180,20 +3165,14 @@ loop_break(codegen_scope *s, node *tree)
       raise_error(s, "unexpected break");
       return;
     }
-    if (n > 0) {
-      genop_1(s, OP_POPERR, n);
-    }
 
     if (loop->type == LOOP_NORMAL) {
       int tmp;
 
-      if (s->ensure_level > s->loop->ensure_level) {
-        genop_1(s, OP_EPOP, s->ensure_level - s->loop->ensure_level);
-      }
       if (tree) {
         gen_move(s, loop->acc, cursp(), 0);
       }
-      tmp = genjmp(s, OP_JMP, loop->pc3);
+      tmp = genjmp(s, OP_JMPUNWIND, loop->pc3);
       loop->pc3 = tmp;
     }
     else {

--- a/mrbgems/mruby-os-memsize/src/memsize.c
+++ b/mrbgems/mruby-os-memsize/src/memsize.c
@@ -131,8 +131,6 @@ os_memsize_of_object(mrb_state* mrb, mrb_value obj)
       size += mrb_objspace_page_slot_size() +
         sizeof(struct RFiber) +
         sizeof(struct mrb_context) +
-        sizeof(struct RProc *) * f->cxt->esize +
-        sizeof(uint16_t *) * f->cxt->rsize +
         sizeof(mrb_value) * stack_size +
         sizeof(mrb_callinfo) * ci_size;
       break;

--- a/src/codedump.c
+++ b/src/codedump.c
@@ -502,8 +502,8 @@ codedump(mrb_state *mrb, mrb_irep *irep)
       printf("OP_RESCUE\tR%d\tR%d", a, b);
       print_lv_ab(mrb, irep, a, b);
       break;
-    CASE(OP_RAISE, B):
-      printf("OP_RAISE\tR%d\t\t", a);
+    CASE(OP_RAISEIF, B):
+      printf("OP_RAISEIF\tR%d\t\t", a);
       print_lv_a(mrb, irep, a);
       break;
     CASE(OP_POPERR, B):

--- a/src/codedump.c
+++ b/src/codedump.c
@@ -488,12 +488,6 @@ codedump(mrb_state *mrb, mrb_irep *irep)
         printf("OP_ERR\t%s\n", RSTRING_PTR(s));
       }
       break;
-    CASE(OP_EPUSH, B):
-      printf("OP_EPUSH\t\t:I(%d:%p)\n", a, irep->reps[a]);
-      break;
-    CASE(OP_ONERR, S):
-      printf("OP_ONERR\t%03d\n", a);
-      break;
     CASE(OP_EXCEPT, B):
       printf("OP_EXCEPT\tR%d\t\t", a);
       print_lv_a(mrb, irep, a);
@@ -505,12 +499,6 @@ codedump(mrb_state *mrb, mrb_irep *irep)
     CASE(OP_RAISEIF, B):
       printf("OP_RAISEIF\tR%d\t\t", a);
       print_lv_a(mrb, irep, a);
-      break;
-    CASE(OP_POPERR, B):
-      printf("OP_POPERR\t%d\t\t\n", a);
-      break;
-    CASE(OP_EPOP, B):
-      printf("OP_EPOP\t%d\n", a);
       break;
 
     CASE(OP_DEBUG, BBB):

--- a/src/codedump.c
+++ b/src/codedump.c
@@ -4,6 +4,7 @@
 #include <mruby/opcode.h>
 #include <mruby/string.h>
 #include <mruby/proc.h>
+#include <mruby/dump.h>
 
 #ifndef MRB_DISABLE_STDIO
 static void
@@ -85,6 +86,34 @@ codedump(mrb_state *mrb, mrb_irep *irep)
       char const *s = mrb_sym_dump(mrb, irep->lv[i - 1].name);
       int n = irep->lv[i - 1].r ? irep->lv[i - 1].r : i;
       printf("  R%d:%s\n", n, s ? s : "");
+    }
+  }
+
+  if (irep->clen > 0) {
+    int i = irep->clen;
+    const struct mrb_irep_catch_hander *e = mrb_irep_catch_handler_table(irep);
+
+    for (; i > 0; i --, e ++) {
+      int begin = bin_to_uint16(e->begin);
+      int end = bin_to_uint16(e->end);
+      int target = bin_to_uint16(e->target);
+      char buf[20];
+      const char *type;
+
+      switch (e->type) {
+        case MRB_CATCH_RESCUE:
+          type = "rescue";
+          break;
+        case MRB_CATCH_ENSURE:
+          type = "ensure";
+          break;
+        default:
+          buf[0] = '\0';
+          snprintf(buf, sizeof(buf), "0x%02x <unknown>", (int)e->type);
+          type = buf;
+          break;
+      }
+      printf("catch type: %-8s begin: %04d end: %04d target: %04d\n", type, begin, end, target);
     }
   }
 

--- a/src/codedump.c
+++ b/src/codedump.c
@@ -258,6 +258,9 @@ codedump(mrb_state *mrb, mrb_irep *irep)
     CASE(OP_JMP, S):
       printf("OP_JMP\t\t%03d\n", a);
       break;
+    CASE(OP_JMPUNWIND, S):
+      printf("OP_JMPUNWIND\t%03d\n", a);
+      break;
     CASE(OP_JMPIF, BS):
       printf("OP_JMPIF\tR%d\t%03d\t", a, b);
       print_lv_a(mrb, irep, a);

--- a/src/gc.c
+++ b/src/gc.c
@@ -633,7 +633,6 @@ mark_context_stack(mrb_state *mrb, struct mrb_context *c)
 static void
 mark_context(mrb_state *mrb, struct mrb_context *c)
 {
-  int i;
   mrb_callinfo *ci;
 
  start:
@@ -649,10 +648,6 @@ mark_context(mrb_state *mrb, struct mrb_context *c)
       mrb_gc_mark(mrb, (struct RBasic*)ci->proc);
       mrb_gc_mark(mrb, (struct RBasic*)ci->target_class);
     }
-  }
-  /* mark ensure stack */
-  for (i=0; i<c->eidx; i++) {
-    mrb_gc_mark(mrb, (struct RBasic*)c->ensure[i]);
   }
   /* mark fibers */
   mrb_gc_mark(mrb, (struct RBasic*)c->fib);
@@ -1003,9 +998,6 @@ gc_gray_counts(mrb_state *mrb, mrb_gc *gc, struct RBasic *obj)
       }
       if (c->stbase + i > c->stend) i = c->stend - c->stbase;
       children += i;
-
-      /* mark ensure stack */
-      children += c->eidx;
 
       /* mark closure */
       if (c->cibase) {

--- a/src/load.c
+++ b/src/load.c
@@ -94,27 +94,30 @@ read_irep_record_1(mrb_state *mrb, const uint8_t *bin, size_t *len, uint8_t flag
   src += sizeof(uint16_t);
 
   /* Binary Data Section */
-  /* ISEQ BLOCK */
+  /* ISEQ BLOCK (and CATCH HANDLER TABLE BLOCK) */
+  irep->clen = bin_to_uint16(src);  /* number of catch handler */
+  src += sizeof(uint16_t);
   irep->ilen = (uint16_t)bin_to_uint32(src);
   src += sizeof(uint32_t);
   src += skip_padding(src);
 
   if (irep->ilen > 0) {
+    size_t data_len = sizeof(mrb_code) * irep->ilen +
+                      sizeof(struct mrb_irep_catch_hander) * irep->clen;
+    mrb_static_assert1(sizeof(struct mrb_irep_catch_hander) == 7);
     if (SIZE_ERROR_MUL(irep->ilen, sizeof(mrb_code))) {
       return NULL;
     }
     if ((flags & FLAG_SRC_MALLOC) == 0) {
       irep->iseq = (mrb_code*)src;
-      src += sizeof(mrb_code) * irep->ilen;
       irep->flags |= MRB_ISEQ_NO_FREE;
     }
     else {
-      size_t data_len = sizeof(mrb_code) * irep->ilen;
       void *buf = mrb_malloc(mrb, data_len);
       irep->iseq = (mrb_code *)buf;
       memcpy(buf, src, data_len);
-      src += data_len;
     }
+    src += data_len;
   }
 
   /* POOL BLOCK */

--- a/src/state.c
+++ b/src/state.c
@@ -170,8 +170,6 @@ mrb_free_context(mrb_state *mrb, struct mrb_context *c)
   if (!c) return;
   mrb_free(mrb, c->stbase);
   mrb_free(mrb, c->cibase);
-  mrb_free(mrb, c->rescue);
-  mrb_free(mrb, c->ensure);
   mrb_free(mrb, c);
 }
 

--- a/src/vm.c
+++ b/src/vm.c
@@ -1979,7 +1979,8 @@ RETRY_TRY_BLOCK:
         case OP_R_RETURN:
           /* Fall through to OP_R_NORMAL otherwise */
           if (ci->acc >=0 && MRB_PROC_ENV_P(proc) && !MRB_PROC_STRICT_P(proc)) {
-            mrb_callinfo *cibase = mrb->c->cibase;
+            mrb_callinfo *cibase;
+            cibase = mrb->c->cibase;
             dst = top_proc(mrb, proc);
 
             if (MRB_PROC_ENV_P(dst)) {
@@ -2018,7 +2019,8 @@ RETRY_TRY_BLOCK:
         case OP_R_NORMAL:
         NORMAL_RETURN:
           if (ci == mrb->c->cibase) {
-            struct mrb_context *c = mrb->c;
+            struct mrb_context *c;
+            c = mrb->c;
 
             if (!c->prev) { /* toplevel return */
               regs[irep->nlocals] = v;


### PR DESCRIPTION
## Summary

Details are described in the commit message, but if there are any deficiencies, please point out.

- Remove the function `ecall()`
- Extend mruby binary format
- Remove `OP_PUSHERR`, `OP_POPERR`, `OP_EPUSH` and `OP_EPOP`
- Extend `OP_EXCEPT`
- Extend `OP_RAISE` and rename to `OP_RAISEIF`
- Added instruction `OP_JUW`
- Extend `RBreak` object (with "tag")
- Resolves #1888

## Binary size

The binary was built with the following `build_config.rb`.

```ruby
MRuby::Build.new do
  toolchain "gcc"
  gembox "full-core"
  enable_test
end
```

`1.9742bce19/bin/mruby` is currentry master (9742bce19), `2.925422003/bin/mruby` is this pull request (925422003).

```console
% strip -so mruby.1 1.9742bce19/bin/mruby
% strip -so mruby.2 2.925422003/bin/mruby
% ll mruby.1 mruby.2
-rwxr-xr-x  1 dearblue  wheel  844264  8月  8 11:37 mruby.1
-rwxr-xr-x  1 dearblue  wheel  845096  8月  8 11:37 mruby.2
```

## Benchmark

Result by `rake MRUBY_CONFIG=benchmark/build_config_boxing.rb benchmark`.
I think that it is a change in the degree of error.

- Currentry master (9742bce19)  
  ![boxing](https://user-images.githubusercontent.com/6077921/89700078-4b36de00-d966-11ea-9528-25be98fc4773.png)
- This pull request (925422003)  
  ![boxing](https://user-images.githubusercontent.com/6077921/89700088-5558dc80-d966-11ea-8a2a-7b1b640d4df8.png)

## Heap usage

It is measured with `valgrind --tool=massif`.
It is built by `build_config.rb` of "Binary size" above.

### `mrbtest`

There is not much difference in peak value.
At some point this pull request seems to show more memory usage, but I don't know the details (order of test items?).

- Measuring method
  ```console
  % valgrind --tool=massif --stacks=yes --trace-children=no build/host/bin/mrbtest
  % ms_print --threshold=100 massif.out.* | head -n33
  ```
- Currentry master (9742bce19)
  ![Screen Shot 2020-08-08 at 10 39 14](https://user-images.githubusercontent.com/6077921/89700340-5be85380-d968-11ea-9d9d-e7dce25e329c.png)
- This pull request (925422003)
  ![Screen Shot 2020-08-08 at 10 39 17](https://user-images.githubusercontent.com/6077921/89700363-89350180-d968-11ea-8a3d-87e82a6b5d07.png)

### `mruby -e '1000000.times { begin; 1+1; rescue; 2+2; ensure; 3+3; end; }'`

Please note that this is a micro-benchmark, so in practice there will be no such difference.

- Measuring method
  ```console
  % valgrind --tool=massif --stacks=yes --trace-children=no build/host/bin/mruby -e '1000000.times { begin; 1+1; rescue; 2+2; ensure; 3+3; end; }'
  % ms_print --threshold=100 massif.out.* | head -n33
  ```
- Currentry master (9742bce19)
  ![Screen Shot 2020-08-08 at 10 06 41](https://user-images.githubusercontent.com/6077921/89700392-c26d7180-d968-11ea-8b8f-ada6fd2f4a39.png)
- This pull request (925422003)
  ![Screen Shot 2020-08-08 at 10 06 45](https://user-images.githubusercontent.com/6077921/89700395-c7cabc00-d968-11ea-85e8-4da4e76c1e6d.png)

