### PR TITLE
Use `struct _stat32` instead of `struct __stat32`

### DIFF
--- a/mrbgems/mruby-io/src/file.c
+++ b/mrbgems/mruby-io/src/file.c
@@ -71,11 +71,11 @@ typedef struct stat         mrb_stat;
 # define mrb_stat(path, sb) stat(path, sb)
 # define mrb_fstat(fd, sb)  fstat(fd, sb)
 #elif defined MRB_INT32
-typedef struct __stat32     mrb_stat;
+typedef struct _stat32      mrb_stat;
 # define mrb_stat(path, sb) _stat32(path, sb)
 # define mrb_fstat(fd, sb)  _fstat32(fd, sb)
 #else
-typedef struct __stat64     mrb_stat;
+typedef struct _stat64      mrb_stat;
 # define mrb_stat(path, sb) _stat64(path, sb)
 # define mrb_fstat(fd, sb)  _fstat64(fd, sb)
 #endif


### PR DESCRIPTION
It is described as `struct __stat32` in the MSVC reference manual.
https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/stat-functions?view=vs-2019
But it doesn't really exist, so it must use `struct _stat32`.

It also replaces `struct __stat64` with `struct _stat64` to make it look nicer.