### PR TITLE
mruby-io: Fixing compilation issue under the legacy MinGW environment

### DIFF
--- a/include/mruby/common.h
+++ b/include/mruby/common.h
@@ -82,6 +82,9 @@ MRB_BEGIN_DECL
 # elif defined(__MINGW32_MAJOR_VERSION)
 #  define MRB_MINGW32_VERSION  (__MINGW32_MAJOR_VERSION * 1000 + __MINGW32_MINOR_VERSION)
 # endif
+# if defined(__MINGW32__) && !defined(__MINGW64__)
+#   define MRB_MINGW32_LEGACY
+# endif
 #endif
 
 MRB_END_DECL

--- a/mrbgems/mruby-io/src/file.c
+++ b/mrbgems/mruby-io/src/file.c
@@ -66,7 +66,7 @@
 #define LOCK_UN 8
 #endif
 
-#ifndef _WIN32
+#if !defined(_WIN32) || defined(MRB_MINGW32_LEGACY)
 typedef struct stat         mrb_stat;
 # define mrb_stat(path, sb) stat(path, sb)
 # define mrb_fstat(fd, sb)  fstat(fd, sb)

--- a/mrbgems/mruby-io/src/io.c
+++ b/mrbgems/mruby-io/src/io.c
@@ -33,9 +33,11 @@
   typedef long fsuseconds_t;
   typedef int fmode_t;
   typedef int mrb_io_read_write_size;
-  #if !defined(_SSIZE_T_) && !defined(_SSIZE_T_DEFINED) && \
-      !defined(__have_typedef_ssize_t)
-  typedef SSIZE_T ssize_t;
+  #ifndef MRB_MINGW32_LEGACY
+    #if !defined(_SSIZE_T_) && !defined(_SSIZE_T_DEFINED) && \
+        !defined(__have_typedef_ssize_t)
+    typedef SSIZE_T ssize_t;
+    #endif
   #endif
 
   #ifndef O_TMPFILE


### PR DESCRIPTION
With recent changes in the `mruby-io` gem, it's now impossible to build **mruby** under the legacy MinGW environment. This little PR solve that issue.

The `MRB_MINGW32_LEGACY` macro has been added in `common.h` in order to identify the legacy MinGW environment. Please also note [MinGW](http://www.mingw.org) should not be confused with [MinGW-w64](http://www.mingw-w64.org).

For more info about MinGW defined macros used here, see: https://sourceforge.net/p/predef/wiki/Compilers/