### PR TITLE
Scan ruby files in directories

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -114,12 +114,19 @@ MRuby.each_target do |target|
 end
 
 mkdir_p "#{MRUBY_ROOT}/build"
-cfiles = (Dir.glob("#{MRUBY_ROOT}/src/*.c")+
-          Dir.glob("#{MRUBY_ROOT}/mrbgems/**/*.c")+
-          Dir.glob("#{MRUBY_ROOT}/build/repos/**/{src,test,core}/*.c")).uniq
-rbfiles = (Dir.glob("#{MRUBY_ROOT}/{mrblib,test,test/t}/*.rb")+
-           Dir.glob("#{MRUBY_ROOT}/mrbgems/*/{mrblib,test}/*.rb")+
-           Dir.glob("#{MRUBY_ROOT}/build/repos/**/{mrblib,test}/*.rb")).uniq
+cfiles = (
+  Dir.glob("#{MRUBY_ROOT}/src/*.c")+
+  Dir.glob("#{MRUBY_ROOT}/mrbgems/**/*.c")+
+  Dir.glob("#{MRUBY_ROOT}/build/repos/**/{src,test,core}/*.c")
+).uniq
+rbfiles = (
+  Dir.glob("#{MRUBY_ROOT}/{mrblib,test,test/t}/*.rb")+
+  Dir.glob("#{MRUBY_ROOT}/{mrblib,test,test/t}/**/*.rb")+
+  Dir.glob("#{MRUBY_ROOT}/mrbgems/*/{mrblib,test}/*.rb")+
+  Dir.glob("#{MRUBY_ROOT}/mrbgems/*/{mrblib,test}/**/*.rb")+
+  Dir.glob("#{MRUBY_ROOT}/build/repos/**/{mrblib,test}/*.rb")+
+  Dir.glob("#{MRUBY_ROOT}/build/repos/**/{mrblib,test}/**/*.rb")
+).uniq
 psfiles = Dir.glob("#{MRUBY_ROOT}/{mrblib,mrbgems,test,build/repos}/**/presym")
 symbols = []
 psfiles.each do |file|

--- a/Rakefile
+++ b/Rakefile
@@ -120,11 +120,8 @@ cfiles = (
   Dir.glob("#{MRUBY_ROOT}/build/repos/**/{src,test,core}/*.c")
 ).uniq
 rbfiles = (
-  Dir.glob("#{MRUBY_ROOT}/{mrblib,test,test/t}/*.rb")+
   Dir.glob("#{MRUBY_ROOT}/{mrblib,test,test/t}/**/*.rb")+
-  Dir.glob("#{MRUBY_ROOT}/mrbgems/*/{mrblib,test}/*.rb")+
   Dir.glob("#{MRUBY_ROOT}/mrbgems/*/{mrblib,test}/**/*.rb")+
-  Dir.glob("#{MRUBY_ROOT}/build/repos/**/{mrblib,test}/*.rb")+
   Dir.glob("#{MRUBY_ROOT}/build/repos/**/{mrblib,test}/**/*.rb")
 ).uniq
 psfiles = Dir.glob("#{MRUBY_ROOT}/{mrblib,mrbgems,test,build/repos}/**/presym")


### PR DESCRIPTION
Old patterns skip ruby files like `mrblib/foo/bar.rb`. I've added glob patterns to improve coverage.