### PR TITLE
Ensure exact match for symbols like `foo!/foo?/foo=` on presym.inc generation

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -218,13 +218,13 @@ file presym_inc => presym_file do
         f.print "MRB_PRESYM_CSYM(#{sym}, #{i+1})\n"
       elsif op_table.key?(sym)
         f.print "MRB_PRESYM_QSYM(\"#{sym}\", #{op_table[sym]}, #{i+1})\n"
-      elsif /\A\w+\?\Z/ =~ sym
+      elsif /\A[A-Za-z_]\w*\?\Z/ =~ sym
         s = sym.dup; s[-1] = "_p"
         f.print "MRB_PRESYM_QSYM(\"#{sym}\", #{s}, #{i+1})\n"
-      elsif /\A\w+\!\Z/ =~ sym
+      elsif /\A[A-Za-z_]\w*\!\Z/ =~ sym
         s = sym.dup; s[-1] = "_b"
         f.print "MRB_PRESYM_QSYM(\"#{sym}\", #{s}, #{i+1})\n"
-      elsif /\A\w+\=\Z/ =~ sym
+      elsif /\A[A-Za-z_]\w*\=\Z/ =~ sym
         s = sym.dup; s[-1] = "_e"
         f.print "MRB_PRESYM_QSYM(\"#{sym}\", #{s}, #{i+1})\n"
       elsif /\A@@/ =~ sym

--- a/Rakefile
+++ b/Rakefile
@@ -173,7 +173,7 @@ file presym_file => cfiles+rbfiles+psfiles+[__FILE__] do
      src.scan(/mrb_define_global_const\([^\n"]*"([^\n"]*)"/),
      src.scan(/MRB_SYM\((\w+)\)/),
      src.scan(/MRB_QSYM\((\w+)\)/).map{|x,|
-       x.sub!(/_p$/, "?") || x.sub!(/_b$/, "!") || x.sub!(/_e$/, "=") || x.sub!(/^0_/, "@")  || x.sub!(/^00_/, "@@") 
+       x.sub!(/_p$/, "?") || x.sub!(/_b$/, "!") || x.sub!(/_e$/, "=") || x.sub!(/^0_/, "@")  || x.sub!(/^00_/, "@@")
      }.compact]
   end
   rbsymbols = rbfiles.map do |f|
@@ -218,13 +218,13 @@ file presym_inc => presym_file do
         f.print "MRB_PRESYM_CSYM(#{sym}, #{i+1})\n"
       elsif op_table.key?(sym)
         f.print "MRB_PRESYM_QSYM(\"#{sym}\", #{op_table[sym]}, #{i+1})\n"
-      elsif /\?\Z/ =~ sym
+      elsif /\A\w+\?\Z/ =~ sym
         s = sym.dup; s[-1] = "_p"
         f.print "MRB_PRESYM_QSYM(\"#{sym}\", #{s}, #{i+1})\n"
-      elsif /\!\Z/ =~ sym
+      elsif /\A\w+\!\Z/ =~ sym
         s = sym.dup; s[-1] = "_b"
         f.print "MRB_PRESYM_QSYM(\"#{sym}\", #{s}, #{i+1})\n"
-      elsif /\=\Z/ =~ sym
+      elsif /\A\w+\=\Z/ =~ sym
         s = sym.dup; s[-1] = "_e"
         f.print "MRB_PRESYM_QSYM(\"#{sym}\", #{s}, #{i+1})\n"
       elsif /\A@@/ =~ sym


### PR DESCRIPTION
* e.g. symbols like "foo[]=" make invalid C codes... even in comments!
* https://github.com/mattn/mruby-http/blob/master/src/mrb_http.c#L652