### PR TITLE
examples/mrbgems: clarify the caller

### DIFF
--- a/examples/mrbgems/c_and_ruby_extension_example/mrblib/example.rb
+++ b/examples/mrbgems/c_and_ruby_extension_example/mrblib/example.rb
@@ -1,5 +1,5 @@
 module CRubyExtension
   def CRubyExtension.ruby_method
-    puts "A Ruby Extension"
+    puts "#{self}: A Ruby Extension"
   end
 end

--- a/examples/mrbgems/c_and_ruby_extension_example/src/example.c
+++ b/examples/mrbgems/c_and_ruby_extension_example/src/example.c
@@ -1,10 +1,14 @@
 #include <mruby.h>
+#include <mruby/string.h>
 #include <stdio.h>
 
 static mrb_value
 mrb_c_method(mrb_state *mrb, mrb_value self)
 {
-  puts("A C Extension");
+  mrb_value self_str = mrb_str_to_str(mrb, self);
+
+  printf("%s: A C Extension\n", mrb_str_to_cstr(mrb, self_str));
+
   return self;
 }
 

--- a/examples/mrbgems/c_extension_example/src/example.c
+++ b/examples/mrbgems/c_extension_example/src/example.c
@@ -1,10 +1,14 @@
 #include <mruby.h>
+#include <mruby/string.h>
 #include <stdio.h>
 
 static mrb_value
 mrb_c_method(mrb_state *mrb, mrb_value self)
 {
-  puts("A C Extension");
+  mrb_value self_str = mrb_str_to_str(mrb, self);
+
+  printf("%s: A C Extension\n", mrb_str_to_cstr(mrb, self_str));
+
   return self;
 }
 

--- a/examples/mrbgems/ruby_extension_example/mrblib/example.rb
+++ b/examples/mrbgems/ruby_extension_example/mrblib/example.rb
@@ -1,5 +1,5 @@
 class RubyExtension
   def RubyExtension.ruby_method
-    puts "A Ruby Extension"
+    puts "#{self}: A Ruby Extension"
   end
 end


### PR DESCRIPTION
Before this commit:

```sh
mruby -e 'CRubyExtension.ruby_method' # => A Ruby Extension
mruby -e 'CRubyExtension.c_method'    # => A C Extension
mruby -e 'CExtension.c_method'        # => A C Extension
mruby -e 'RubyExtension.ruby_method'  # => A Ruby Extension
```

After this commit:

```sh
mruby -e 'CRubyExtension.ruby_method' # => CRubyExtension: A Ruby Extension
mruby -e 'CRubyExtension.c_method'    # => CRubyExtension: A C Extension
mruby -e 'CExtension.c_method'        # => CExtension: A C Extension
mruby -e 'RubyExtension.ruby_method'  # => RubyExtension: A Ruby Extension
```
