### PR TITLE
Fix argument error when built with MRB_WITHOUT_FLOAT flag

### DIFF
--- a/src/numeric.c
+++ b/src/numeric.c
@@ -158,7 +158,7 @@ integral_div(mrb_state *mrb, mrb_value xv)
   if (y == 0) {
     mrb_raise(mrb, E_RUNTIME_ERROR, "devided by zero");
   }
-  return mrb_fixnum_value(mrb, mrb_fixnum(xv) / y);
+  return mrb_fixnum_value(mrb_fixnum(xv) / y);
 #else
   mrb_float x, y;
 


### PR DESCRIPTION
### Fixed Point
Fixed improper argument of mrb_fixnum_value().

### Error
When built with MRB_WITHOUT_FLOAT flag, build fails as below:
```
$ CFLAGS="-DMRB_WITHOUT_FLOAT" rake
CC    src/vm.c -> build/host/src/vm.o
CC    src/error.c -> build/host/src/error.o
CC    src/dump.c -> build/host/src/dump.o
CC    src/string.c -> build/host/src/string.o
CC    src/init.c -> build/host/src/init.o
CC    src/hash.c -> build/host/src/hash.o
CC    src/numeric.c -> build/host/src/numeric.o
/home/wataru/dev-mruby/src/numeric.c: In function ‘integral_div’:
/home/wataru/dev-mruby/src/numeric.c:161:27: warning: passing argument 1 of ‘mrb_fixnum_value’ makes integer from pointer without a cast [-Wint-conversion]
  161 |   return mrb_fixnum_value(mrb, mrb_fixnum(xv) / y);
      |                           ^~~
      |                           |
      |                           mrb_state * {aka struct mrb_state *}
In file included from /home/wataru/dev-mruby/include/mruby.h:90,
                 from /home/wataru/dev-mruby/src/numeric.c:15:
/home/wataru/dev-mruby/include/mruby/value.h:291:47: note: expected ‘mrb_int’ {aka ‘long int’} but argument is of type ‘mrb_state *’ {aka ‘struct mrb_state *’}
  291 | MRB_INLINE mrb_value mrb_fixnum_value(mrb_int i)
      |                                       ~~~~~~~~^
/home/wataru/dev-mruby/src/numeric.c:161:10: error: too many arguments to function ‘mrb_fixnum_value’
  161 |   return mrb_fixnum_value(mrb, mrb_fixnum(xv) / y);
      |          ^~~~~~~~~~~~~~~~
In file included from /home/wataru/dev-mruby/include/mruby.h:90,
                 from /home/wataru/dev-mruby/src/numeric.c:15:
/home/wataru/dev-mruby/include/mruby/value.h:291:22: note: declared here
  291 | MRB_INLINE mrb_value mrb_fixnum_value(mrb_int i)
      |                      ^~~~~~~~~~~~~~~~
/home/wataru/dev-mruby/src/numeric.c: In function ‘integral_div’:
/home/wataru/dev-mruby/src/numeric.c:161:27: warning: passing argument 1 of ‘mrb_fixnum_value’ makes integer from pointer without a cast [-Wint-conversion]
  161 |   return mrb_fixnum_value(mrb, mrb_fixnum(xv) / y);
      |                           ^~~
      |                           |
      |                           mrb_state * {aka struct mrb_state *}
In file included from /home/wataru/dev-mruby/include/mruby.h:90,
                 from /home/wataru/dev-mruby/src/numeric.c:15:
/home/wataru/dev-mruby/include/mruby/value.h:291:47: note: expected ‘mrb_int’ {aka ‘long int’} but argument is of type ‘mrb_state *’ {aka ‘struct mrb_state *’}
  291 | MRB_INLINE mrb_value mrb_fixnum_value(mrb_int i)
      |                                       ~~~~~~~~^
/home/wataru/dev-mruby/src/numeric.c:161:10: error: too many arguments to function ‘mrb_fixnum_value’
  161 |   return mrb_fixnum_value(mrb, mrb_fixnum(xv) / y);
      |          ^~~~~~~~~~~~~~~~
In file included from /home/wataru/dev-mruby/include/mruby.h:90,
                 from /home/wataru/dev-mruby/src/numeric.c:15:
/home/wataru/dev-mruby/include/mruby/value.h:291:22: note: declared here
  291 | MRB_INLINE mrb_value mrb_fixnum_value(mrb_int i)
      |                      ^~~~~~~~~~~~~~~~
rake aborted!
Command failed with status (1): [gcc -std=gnu99 -DMRB_WITHOUT_FLOAT -I"/hom...]
/home/wataru/dev-mruby/lib/mruby/build/command.rb:39:in `_run'
/home/wataru/dev-mruby/lib/mruby/build/command.rb:44:in `rescue in _run'
/home/wataru/dev-mruby/lib/mruby/build/command.rb:40:in `_run'
/home/wataru/dev-mruby/lib/mruby/build/command.rb:90:in `run'
/home/wataru/dev-mruby/lib/mruby/build/command.rb:113:in `block (2 levels) in define_rules'
/home/wataru/.rvm/gems/ruby-2.6.6/gems/rake-13.0.1/exe/rake:27:in `<top (required)>'
/home/wataru/.rvm/gems/ruby-2.6.6@metasploit-framework/bin/ruby_executable_hooks:24:in `eval'
/home/wataru/.rvm/gems/ruby-2.6.6@metasploit-framework/bin/ruby_executable_hooks:24:in `<main>'

Caused by:
Command failed with status (1): [gcc -std=gnu99 -DMRB_WITHOUT_FLOAT -I"/hom...]
/home/wataru/dev-mruby/lib/mruby/build/command.rb:41:in `_run'
/home/wataru/dev-mruby/lib/mruby/build/command.rb:90:in `run'
/home/wataru/dev-mruby/lib/mruby/build/command.rb:113:in `block (2 levels) in define_rules'
/home/wataru/.rvm/gems/ruby-2.6.6/gems/rake-13.0.1/exe/rake:27:in `<top (required)>'
/home/wataru/.rvm/gems/ruby-2.6.6@metasploit-framework/bin/ruby_executable_hooks:24:in `eval'
/home/wataru/.rvm/gems/ruby-2.6.6@metasploit-framework/bin/ruby_executable_hooks:24:in `<main>'
Tasks: TOP => default => all => /home/wataru/dev-mruby/build/host/lib/libmruby.flags.mak => /home/wataru/dev-mruby/build/host/lib/libmruby.a => /home/wataru/dev-mruby/build/host/src/numeric.o
(See full trace by running task with --trace)
```
After this fix, this error does not happen.
However, we have to edit another file as below to complete build without MRB_WITHOUT_FLOAT flag.


### Build
To build with MRB_WITHOUT_FLOAT flag, we have to edit mrbgems/default.gembox as belows:
```
--- a/mrbgems/default.gembox
+++ b/mrbgems/default.gembox
@@ -15,7 +15,7 @@ MRuby::GemBox.new do |conf|
   conf.gem :core => "mruby-print"
 
   # Use standard Math module
-  conf.gem :core => "mruby-math"
+  # conf.gem :core => "mruby-math"
 
   # Use standard Time class
   conf.gem :core => "mruby-time"
@@ -73,7 +73,7 @@ MRuby::GemBox.new do |conf|
 
   # Use Rational/Complex numbers
   conf.gem :core => "mruby-rational"
-  conf.gem :core => "mruby-complex"
+  # conf.gem :core => "mruby-complex"
```
