### PR TITLE
mruby 3.0.0-preview.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ of the Ministry of Economy, Trade and Industry of Japan.
 
 ## How to get mruby
 
+The preview version 3.0.0 of mruby can be downloaded via the following URL: [https://github.com/mruby/mruby/archive/3.0.0-preview.zip](https://github.com/mruby/mruby/archive/3.0.0-preview.zip)
+
 The stable version 2.1.2 of mruby can be downloaded via the following URL: [https://github.com/mruby/mruby/archive/2.1.2.zip](https://github.com/mruby/mruby/archive/2.1.2.zip)
 
 The latest development version of mruby can be downloaded via the following URL: [https://github.com/mruby/mruby/zipball/master](https://github.com/mruby/mruby/zipball/master)

--- a/include/mruby/version.h
+++ b/include/mruby/version.h
@@ -27,7 +27,7 @@ MRB_BEGIN_DECL
 /*
  * The version of Ruby used by mruby.
  */
-#define MRUBY_RUBY_VERSION "2.0"
+#define MRUBY_RUBY_VERSION "3.0"
 
 /*
  * Ruby engine.
@@ -37,17 +37,17 @@ MRB_BEGIN_DECL
 /*
  * Major release version number.
  */
-#define MRUBY_RELEASE_MAJOR 2
+#define MRUBY_RELEASE_MAJOR 3
 
 /*
  * Minor release version number.
  */
-#define MRUBY_RELEASE_MINOR 1
+#define MRUBY_RELEASE_MINOR 0
 
 /*
  * Tiny release version number.
  */
-#define MRUBY_RELEASE_TEENY 2
+#define MRUBY_RELEASE_TEENY 0
 
 /*
  * The mruby version.
@@ -67,12 +67,12 @@ MRB_BEGIN_DECL
 /*
  * Release month.
  */
-#define MRUBY_RELEASE_MONTH 8
+#define MRUBY_RELEASE_MONTH 10
 
 /*
  * Release day.
  */
-#define MRUBY_RELEASE_DAY 6
+#define MRUBY_RELEASE_DAY 16
 
 /*
  * Release date as a string.


### PR DESCRIPTION
Change mruby version to `3.0.0` for preview.

Some document (e.g. `doc/limitations.md`) has not changed yet.