### PR TITLE
Prohibit changes by `RARRAY_PTR()` and `ARY_PTR()`

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -889,7 +889,7 @@ MRB_API struct RClass* mrb_define_module_under_id(mrb_state *mrb, struct RClass 
  * | `H`  | {Hash}         | {mrb_value}       | when `!` follows, the value may be `nil`           |
  * | `s`  | {String}       | const char *, {mrb_int} | Receive two arguments; `s!` gives (`NULL`,`0`) for `nil` |
  * | `z`  | {String}       | const char *      | `NULL` terminated string; `z!` gives `NULL` for `nil` |
- * | `a`  | {Array}        | {mrb_value} *, {mrb_int} | Receive two arguments; `a!` gives (`NULL`,`0`) for `nil` |
+ * | `a`  | {Array}        | const {mrb_value} *, {mrb_int} | Receive two arguments; `a!` gives (`NULL`,`0`) for `nil` |
  * | `f`  | {Integer}/{Float} | {mrb_float}    |                                                    |
  * | `i`  | {Integer}/{Float} | {mrb_int}      |                                                    |
  * | `b`  | boolean        | {mrb_bool}        |                                                    |
@@ -897,7 +897,7 @@ MRB_API struct RClass* mrb_define_module_under_id(mrb_state *mrb, struct RClass 
  * | `d`  | data           | void *, {mrb_data_type} const | 2nd argument will be used to check data type so it won't be modified; when `!` follows, the value may be `nil` |
  * | `I`  | inline struct  | void *          |                                                    |
  * | `&`  | block          | {mrb_value}       | &! raises exception if no block given.             |
- * | `*`  | rest arguments | {mrb_value} *, {mrb_int} | Receive the rest of arguments as an array; `*!` avoid copy of the stack.  |
+ * | `*`  | rest arguments | const {mrb_value} *, {mrb_int} | Receive the rest of arguments as an array; `*!` avoid copy of the stack.  |
  * | <code>\|</code> | optional     |                   | After this spec following specs would be optional. |
  * | `?`  | optional given | {mrb_bool}        | `TRUE` if preceding argument is given. Used to check optional argument is given. |
  * | `:`  | keyword args   | {mrb_kwargs} const | Get keyword arguments. @see mrb_kwargs |
@@ -991,7 +991,7 @@ MRB_API mrb_int mrb_get_argc(mrb_state *mrb);
  *
  * Correctly handles *splat arguments.
  */
-MRB_API mrb_value* mrb_get_argv(mrb_state *mrb);
+MRB_API const mrb_value *mrb_get_argv(mrb_state *mrb);
 
 /**
  * Retrieve the first and only argument from mrb_state.

--- a/include/mruby/array.h
+++ b/include/mruby/array.h
@@ -64,9 +64,11 @@ struct RArray {
 #define ARY_SET_EMBED_LEN(a,len) ((a)->flags = ((a)->flags&~MRB_ARY_EMBED_MASK) | ((uint32_t)(len) + 1))
 #define ARY_EMBED_PTR(a) ((a)->as.ary)
 #endif
-  
+
 #define ARY_LEN(a) (ARY_EMBED_P(a)?ARY_EMBED_LEN(a):(a)->as.heap.len)
-#define ARY_PTR(a) (ARY_EMBED_P(a)?ARY_EMBED_PTR(a):(a)->as.heap.ptr)
+#define ARY_PTR(a) ((const mrb_value*)ARY_PTR_NEED_WB(a))
+/** Modifiable version of `ARY_PTR()`. But it needs write-barrier. */
+#define ARY_PTR_NEED_WB(a) (ARY_EMBED_P(a)?ARY_EMBED_PTR(a):(a)->as.heap.ptr)
 #define RARRAY_LEN(a) ARY_LEN(RARRAY(a))
 #define RARRAY_PTR(a) ARY_PTR(RARRAY(a))
 #define ARY_SET_LEN(a,n) do {\

--- a/mrbgems/mruby-array-ext/src/array.c
+++ b/mrbgems/mruby-array-ext/src/array.c
@@ -97,7 +97,7 @@ static mrb_value
 mrb_ary_values_at(mrb_state *mrb, mrb_value self)
 {
   mrb_int argc;
-  mrb_value *argv;
+  const mrb_value *argv;
 
   mrb_get_args(mrb, "*", &argv, &argc);
 
@@ -167,7 +167,7 @@ mrb_ary_slice_bang(mrb_state *mrb, mrb_value self)
   if (len > alen - i) len = alen - i;
 
   ary = mrb_ary_new_capa(mrb, len);
-  ptr = ARY_PTR(a);
+  ptr = ARY_PTR_NEED_WB(a);
   for (j = i, k = 0; k < len; ++j, ++k) {
     mrb_ary_push(mrb, ary, ptr[j]);
   }

--- a/mrbgems/mruby-eval/src/eval.c
+++ b/mrbgems/mruby-eval/src/eval.c
@@ -149,7 +149,7 @@ static mrb_value
 f_instance_eval(mrb_state *mrb, mrb_value self)
 {
   mrb_value b;
-  mrb_int argc; mrb_value *argv;
+  mrb_int argc; const mrb_value *argv;
 
   mrb_get_args(mrb, "*!&", &argv, &argc, &b);
 

--- a/mrbgems/mruby-fiber/src/fiber.c
+++ b/mrbgems/mruby-fiber/src/fiber.c
@@ -255,7 +255,7 @@ fiber_switch(mrb_state *mrb, mrb_value self, mrb_int len, const mrb_value *a, mr
 static mrb_value
 fiber_resume(mrb_state *mrb, mrb_value self)
 {
-  mrb_value *a;
+  const mrb_value *a;
   mrb_int len;
   mrb_bool vmexec = FALSE;
 
@@ -315,7 +315,7 @@ static mrb_value
 fiber_transfer(mrb_state *mrb, mrb_value self)
 {
   struct mrb_context *c = fiber_check(mrb, self);
-  mrb_value* a;
+  const mrb_value* a;
   mrb_int len;
 
   fiber_check_cfunc(mrb, mrb->c);
@@ -374,7 +374,7 @@ mrb_fiber_yield(mrb_state *mrb, mrb_int len, const mrb_value *a)
 static mrb_value
 fiber_yield(mrb_state *mrb, mrb_value self)
 {
-  mrb_value *a;
+  const mrb_value *a;
   mrb_int len;
 
   mrb_get_args(mrb, "*!", &a, &len);

--- a/mrbgems/mruby-hash-ext/src/hash-ext.c
+++ b/mrbgems/mruby-hash-ext/src/hash-ext.c
@@ -22,7 +22,8 @@
 static mrb_value
 hash_values_at(mrb_state *mrb, mrb_value hash)
 {
-  mrb_value *argv, result;
+  const mrb_value *argv;
+  mrb_value result;
   mrb_int argc, i;
   int ai;
 
@@ -49,7 +50,8 @@ hash_values_at(mrb_state *mrb, mrb_value hash)
 static mrb_value
 hash_slice(mrb_state *mrb, mrb_value hash)
 {
-  mrb_value *argv, result;
+  const mrb_value *argv;
+  mrb_value result;
   mrb_int argc, i;
 
   mrb_get_args(mrb, "*", &argv, &argc);

--- a/mrbgems/mruby-io/src/file.c
+++ b/mrbgems/mruby-io/src/file.c
@@ -115,7 +115,7 @@ mrb_file_s_umask(mrb_state *mrb, mrb_value klass)
 static mrb_value
 mrb_file_s_unlink(mrb_state *mrb, mrb_value obj)
 {
-  mrb_value *argv;
+  const mrb_value *argv;
   mrb_value pathv;
   mrb_int argc, i;
   char *path;
@@ -533,7 +533,7 @@ static mrb_value
 mrb_file_s_chmod(mrb_state *mrb, mrb_value klass) {
   mrb_int mode;
   mrb_int argc, i;
-  mrb_value *filenames;
+  const mrb_value *filenames;
   int ai = mrb_gc_arena_save(mrb);
 
   mrb_get_args(mrb, "i*", &mode, &filenames, &argc);

--- a/mrbgems/mruby-io/src/io.c
+++ b/mrbgems/mruby-io/src/io.c
@@ -1154,7 +1154,7 @@ mrb_io_s_pipe(mrb_state *mrb, mrb_value klass)
 static mrb_value
 mrb_io_s_select(mrb_state *mrb, mrb_value klass)
 {
-  mrb_value *argv;
+  const mrb_value *argv;
   mrb_int argc;
   mrb_value read, read_io, write, except, timeout, list;
   struct timeval *tp, timerec;

--- a/mrbgems/mruby-metaprog/src/metaprog.c
+++ b/mrbgems/mruby-metaprog/src/metaprog.c
@@ -642,7 +642,7 @@ static mrb_value
 mrb_mod_remove_method(mrb_state *mrb, mrb_value mod)
 {
   mrb_int argc;
-  mrb_value *argv;
+  const mrb_value *argv;
   struct RClass *c = mrb_class_ptr(mod);
 
   mrb_get_args(mrb, "*", &argv, &argc);

--- a/mrbgems/mruby-method/src/method.c
+++ b/mrbgems/mruby-method/src/method.c
@@ -109,7 +109,7 @@ method_eql(mrb_state *mrb, mrb_value self)
 
 static mrb_value
 mcall(mrb_state *mrb, mrb_value recv, mrb_value proc, mrb_value name, struct RClass *owner,
-      mrb_int argc, mrb_value *argv, mrb_value block)
+      mrb_int argc, const mrb_value *argv, mrb_value block)
 {
   mrb_value ret;
   mrb_sym orig_mid = mrb->c->ci->mid;
@@ -142,7 +142,8 @@ method_call(mrb_state *mrb, mrb_value self)
   mrb_value recv = mrb_iv_get(mrb, self, MRB_SYM(_recv));
   struct RClass *owner = mrb_class_ptr(mrb_iv_get(mrb, self, MRB_SYM(_owner)));
   mrb_int argc;
-  mrb_value *argv, block;
+  const mrb_value *argv;
+  mrb_value block;
 
   mrb_get_args(mrb, "*&", &argv, &argc, &block);
   return mcall(mrb, recv, proc, name, owner, argc, argv, block);
@@ -156,7 +157,8 @@ method_bcall(mrb_state *mrb, mrb_value self)
   mrb_value recv = mrb_iv_get(mrb, self, MRB_SYM(_recv));
   mrb_value owner = mrb_iv_get(mrb, self, MRB_SYM(_owner));
   mrb_int argc;
-  mrb_value *argv, block;
+  const mrb_value *argv;
+  mrb_value block;
 
   mrb_get_args(mrb, "o*&", &recv, &argv, &argc, &block);
   bind_check(mrb, recv, owner);

--- a/mrbgems/mruby-print/src/print.c
+++ b/mrbgems/mruby-print/src/print.c
@@ -53,7 +53,7 @@ static mrb_value
 mrb_print(mrb_state *mrb, mrb_value self)
 {
   mrb_int argc, i;
-  mrb_value *argv;
+  const mrb_value *argv;
 
   mrb_get_args(mrb, "*", &argv, &argc);
   for (i=0; i<argc; i++) {
@@ -69,7 +69,7 @@ static mrb_value
 mrb_puts(mrb_state *mrb, mrb_value self)
 {
   mrb_int argc, i;
-  mrb_value *argv;
+  const mrb_value *argv;
 
   mrb_get_args(mrb, "*", &argv, &argc);
   for (i=0; i<argc; i++) {

--- a/mrbgems/mruby-proc-ext/test/proc.c
+++ b/mrbgems/mruby-proc-ext/test/proc.c
@@ -35,7 +35,7 @@ static mrb_value
 cfunc_env_get(mrb_state *mrb, mrb_value self)
 {
   mrb_sym n;
-  mrb_value *argv; mrb_int argc;
+  const mrb_value *argv; mrb_int argc;
   mrb_method_t m;
   struct RProc *p;
   mrb_get_args(mrb, "na", &n, &argv, &argc);

--- a/mrbgems/mruby-random/src/random.c
+++ b/mrbgems/mruby-random/src/random.c
@@ -271,6 +271,9 @@ mrb_ary_shuffle_bang(mrb_state *mrb, mrb_value ary)
 #endif
 
   if (RARRAY_LEN(ary) > 1) {
+    struct RArray *ap;
+    mrb_value *ptr;
+
     mrb_get_args(mrb, "|o", &r);
 
     if (mrb_nil_p(r)) {
@@ -280,11 +283,12 @@ mrb_ary_shuffle_bang(mrb_state *mrb, mrb_value ary)
       random_check(mrb, r);
       random = random_ptr(r);
     }
-    mrb_ary_modify(mrb, mrb_ary_ptr(ary));
-    max = mrb_fixnum_value(RARRAY_LEN(ary));
-    for (i = RARRAY_LEN(ary) - 1; i > 0; i--)  {
+    ap = mrb_ary_ptr(ary);
+    mrb_ary_modify(mrb, ap);
+    max = mrb_fixnum_value(ARY_LEN(ap));
+    ptr = ARY_PTR_NEED_WB(ap);
+    for (i = ARY_LEN(ap) - 1; i > 0; i--)  {
       mrb_int j;
-      mrb_value *ptr = RARRAY_PTR(ary);
       mrb_value tmp;
 
       j = mrb_integer(random_rand(mrb, random, max));

--- a/mrbgems/mruby-sprintf/src/sprintf.c
+++ b/mrbgems/mruby-sprintf/src/sprintf.c
@@ -517,7 +517,7 @@ static mrb_value
 mrb_f_sprintf(mrb_state *mrb, mrb_value obj)
 {
   mrb_int argc;
-  mrb_value *argv;
+  const mrb_value *argv;
 
   mrb_get_args(mrb, "*", &argv, &argc);
 

--- a/mrbgems/mruby-string-ext/src/string.c
+++ b/mrbgems/mruby-string-ext/src/string.c
@@ -194,7 +194,8 @@ mrb_str_concat_m(mrb_state *mrb, mrb_value self)
 static mrb_value
 mrb_str_start_with(mrb_state *mrb, mrb_value self)
 {
-  mrb_value *argv, sub;
+  const mrb_value *argv;
+  mrb_value sub;
   mrb_int argc, i;
   mrb_get_args(mrb, "*", &argv, &argc);
 
@@ -223,7 +224,8 @@ mrb_str_start_with(mrb_state *mrb, mrb_value self)
 static mrb_value
 mrb_str_end_with(mrb_state *mrb, mrb_value self)
 {
-  mrb_value *argv, sub;
+  const mrb_value *argv;
+  mrb_value sub;
   mrb_int argc, i;
   mrb_get_args(mrb, "*", &argv, &argc);
 

--- a/mrbgems/mruby-test/driver.c
+++ b/mrbgems/mruby-test/driver.c
@@ -50,7 +50,7 @@ eval_test(mrb_state *mrb)
 static mrb_value
 t_print(mrb_state *mrb, mrb_value self)
 {
-  mrb_value *argv;
+  const mrb_value *argv;
   mrb_int argc;
   mrb_int i;
 

--- a/src/backtrace.c
+++ b/src/backtrace.c
@@ -81,7 +81,8 @@ print_backtrace(mrb_state *mrb, struct RObject *exc, mrb_value backtrace)
 {
   mrb_int i;
   mrb_int n = RARRAY_LEN(backtrace);
-  mrb_value *loc, mesg;
+  const mrb_value *loc;
+  mrb_value mesg;
   FILE *stream = stderr;
 
   if (n != 0) {

--- a/src/class.c
+++ b/src/class.c
@@ -806,15 +806,15 @@ mrb_get_argc(mrb_state *mrb)
   return argc;
 }
 
-MRB_API mrb_value*
+MRB_API const mrb_value*
 mrb_get_argv(mrb_state *mrb)
 {
   mrb_int argc = mrb->c->ci->argc;
-  mrb_value *array_argv = mrb->c->stack + 1;
+  const mrb_value *array_argv = mrb->c->stack + 1;
   if (argc < 0) {
     struct RArray *a = mrb_ary_ptr(*array_argv);
 
-    array_argv = ARY_PTR(a);
+    array_argv = ARY_PTR_NEED_WB(a);
   }
   return array_argv;
 }
@@ -823,7 +823,7 @@ MRB_API mrb_value
 mrb_get_arg1(mrb_state *mrb)
 {
   mrb_int argc = mrb->c->ci->argc;
-  mrb_value *array_argv = mrb->c->stack + 1;
+  const mrb_value *array_argv = mrb->c->stack + 1;
   if (argc < 0) {
     struct RArray *a = mrb_ary_ptr(*array_argv);
 
@@ -856,7 +856,7 @@ void mrb_hash_check_kdict(mrb_state *mrb, mrb_value self);
     H:      Hash           [mrb_value]            when ! follows, the value may be nil
     s:      String         [const char*,mrb_int]  Receive two arguments; s! gives (NULL,0) for nil
     z:      String         [const char*]          NUL terminated string; z! gives NULL for nil
-    a:      Array          [mrb_value*,mrb_int]   Receive two arguments; a! gives (NULL,0) for nil
+    a:      Array          [const mrb_value*,mrb_int] Receive two arguments; a! gives (NULL,0) for nil
     c:      Class/Module   [strcut RClass*]
     f:      Integer/Float  [mrb_float]
     i:      Integer/Float  [mrb_int]
@@ -865,7 +865,7 @@ void mrb_hash_check_kdict(mrb_state *mrb, mrb_value self);
     d:      data           [void*,mrb_data_type const] 2nd argument will be used to check data type so it won't be modified; when ! follows, the value may be nil
     I:      inline struct  [void*]
     &:      block          [mrb_value]            &! raises exception if no block given
-    *:      rest argument  [mrb_value*,mrb_int]   The rest of the arguments as an array; *! avoid copy of the stack
+    *:      rest argument  [const mrb_value*,mrb_int] The rest of the arguments as an array; *! avoid copy of the stack
     |:      optional                              Following arguments are optional
     ?:      optional given [mrb_bool]             true if preceding argument (optional) is given
     ':':    keyword args   [mrb_kwargs const]     Get keyword arguments
@@ -878,7 +878,7 @@ mrb_get_args(mrb_state *mrb, const char *format, ...)
   mrb_int i = 0;
   va_list ap;
   mrb_int argc = mrb->c->ci->argc;
-  mrb_value *array_argv = mrb->c->stack+1;
+  const mrb_value *array_argv = mrb->c->stack+1;
   mrb_bool argv_on_stack = argc >= 0;
   mrb_bool opt = FALSE;
   mrb_bool opt_skip = TRUE;
@@ -931,7 +931,7 @@ mrb_get_args(mrb_state *mrb, const char *format, ...)
   opt = FALSE;
   i = 0;
   while ((c = *format++)) {
-    mrb_value *argv = ARGV;
+    const mrb_value *argv = ARGV;
     mrb_bool altmode;
 
     switch (c) {
@@ -1083,10 +1083,10 @@ mrb_get_args(mrb_state *mrb, const char *format, ...)
       {
         mrb_value aa;
         struct RArray *a;
-        mrb_value **pb;
+        const mrb_value **pb;
         mrb_int *pl;
 
-        pb = va_arg(ap, mrb_value**);
+        pb = va_arg(ap, const mrb_value**);
         pl = va_arg(ap, mrb_int*);
         if (i < argc) {
           aa = argv[i++];
@@ -1215,11 +1215,11 @@ mrb_get_args(mrb_state *mrb, const char *format, ...)
 
     case '*':
       {
-        mrb_value **var;
+        const mrb_value **var;
         mrb_int *pl;
         mrb_bool nocopy = (altmode || !argv_on_stack) ? TRUE : FALSE;
 
-        var = va_arg(ap, mrb_value**);
+        var = va_arg(ap, const mrb_value**);
         pl = va_arg(ap, mrb_int*);
         if (argc > i) {
           *pl = argc-i;
@@ -1754,7 +1754,7 @@ static mrb_value
 mod_attr_define(mrb_state *mrb, mrb_value mod, mrb_value (*accessor)(mrb_state *, mrb_value), mrb_sym (*access_name)(mrb_state *, mrb_sym))
 {
   struct RClass *c = mrb_class_ptr(mod);
-  mrb_value *argv;
+  const mrb_value *argv;
   mrb_int argc, i;
   int ai;
 
@@ -1843,7 +1843,7 @@ mrb_value
 mrb_instance_new(mrb_state *mrb, mrb_value cv)
 {
   mrb_value obj, blk;
-  mrb_value *argv;
+  const mrb_value *argv;
   mrb_int argc;
   mrb_sym init;
 
@@ -2248,7 +2248,7 @@ mrb_mod_undef(mrb_state *mrb, mrb_value mod)
 {
   struct RClass *c = mrb_class_ptr(mod);
   mrb_int argc;
-  mrb_value *argv;
+  const mrb_value *argv;
 
   mrb_get_args(mrb, "*", &argv, &argc);
   while (argc--) {
@@ -2468,7 +2468,7 @@ mrb_mod_dup(mrb_state *mrb, mrb_value self)
 static mrb_value
 mrb_mod_module_function(mrb_state *mrb, mrb_value mod)
 {
-  mrb_value *argv;
+  const mrb_value *argv;
   mrb_int argc, i;
   mrb_sym mid;
   mrb_method_t m;

--- a/src/gc.c
+++ b/src/gc.c
@@ -515,7 +515,7 @@ mrb_gc_unregister(mrb_state *mrb, mrb_value obj)
   for (i = 0; i < ARY_LEN(a); i++) {
     if (mrb_ptr(ARY_PTR(a)[i]) == mrb_ptr(obj)) {
       mrb_int len = ARY_LEN(a)-1;
-      mrb_value *ptr = ARY_PTR(a);
+      mrb_value *ptr = ARY_PTR_NEED_WB(a);
 
       ARY_SET_LEN(a, len);
       memmove(&ptr[i], &ptr[i + 1], (len - i) * sizeof(mrb_value));
@@ -736,7 +736,7 @@ gc_mark_children(mrb_state *mrb, mrb_gc *gc, struct RBasic *obj)
     {
       struct RArray *a = (struct RArray*)obj;
       size_t i, e=ARY_LEN(a);
-      mrb_value *p = ARY_PTR(a);
+      const mrb_value *p = ARY_PTR(a);
 
       for (i=0; i<e; i++) {
         mrb_gc_mark_value(mrb, p[i]);

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -219,7 +219,7 @@ mrb_obj_class_m(mrb_state *mrb, mrb_value self)
 }
 
 static mrb_value
-mrb_obj_extend(mrb_state *mrb, mrb_int argc, mrb_value *argv, mrb_value obj)
+mrb_obj_extend(mrb_state *mrb, mrb_int argc, const mrb_value *argv, mrb_value obj)
 {
   mrb_int i;
 
@@ -264,7 +264,7 @@ mrb_obj_extend(mrb_state *mrb, mrb_int argc, mrb_value *argv, mrb_value obj)
 static mrb_value
 mrb_obj_extend_m(mrb_state *mrb, mrb_value self)
 {
-  mrb_value *argv;
+  const mrb_value *argv;
   mrb_int argc;
 
   mrb_get_args(mrb, "*", &argv, &argc);
@@ -524,7 +524,7 @@ static mrb_value
 mrb_obj_missing(mrb_state *mrb, mrb_value mod)
 {
   mrb_sym name;
-  mrb_value *a;
+  const mrb_value *a;
   mrb_int alen;
 
   mrb_get_args(mrb, "n*!", &name, &a, &alen);

--- a/src/vm.c
+++ b/src/vm.c
@@ -552,7 +552,8 @@ mrb_value
 mrb_f_send(mrb_state *mrb, mrb_value self)
 {
   mrb_sym name;
-  mrb_value block, *argv, *regs;
+  mrb_value block, *regs;
+  const mrb_value *argv;
   mrb_int argc, i, len;
   mrb_method_t m;
   struct RClass *c;
@@ -1705,7 +1706,7 @@ RETRY_TRY_BLOCK:
         regs[a] = mrb_ary_new_from_values(mrb, m1+m2+kd, stack);
       }
       else {
-        mrb_value *pp = NULL;
+        const mrb_value *pp = NULL;
         struct RArray *rest;
         mrb_int len = 0;
 
@@ -1718,16 +1719,16 @@ RETRY_TRY_BLOCK:
         regs[a] = mrb_ary_new_capa(mrb, m1+len+m2+kd);
         rest = mrb_ary_ptr(regs[a]);
         if (m1 > 0) {
-          stack_copy(ARY_PTR(rest), stack, m1);
+          stack_copy(ARY_PTR_NEED_WB(rest), stack, m1);
         }
         if (len > 0) {
-          stack_copy(ARY_PTR(rest)+m1, pp, len);
+          stack_copy(ARY_PTR_NEED_WB(rest)+m1, pp, len);
         }
         if (m2 > 0) {
-          stack_copy(ARY_PTR(rest)+m1+len, stack+m1+1, m2);
+          stack_copy(ARY_PTR_NEED_WB(rest)+m1+len, stack+m1+1, m2);
         }
         if (kd) {
-          stack_copy(ARY_PTR(rest)+m1+len+m2, stack+m1+m2+1, kd);
+          stack_copy(ARY_PTR_NEED_WB(rest)+m1+len+m2, stack+m1+m2+1, kd);
         }
         ARY_SET_LEN(rest, m1+len+m2+kd);
       }
@@ -1746,11 +1747,11 @@ RETRY_TRY_BLOCK:
       int b  = MRB_ASPEC_BLOCK(a);
       */
       mrb_int argc = mrb->c->ci->argc;
-      mrb_value *argv = regs+1;
-      mrb_value * const argv0 = argv;
+      const mrb_value *argv = regs+1;
+      const mrb_value * const argv0 = argv;
       mrb_int const len = m1 + o + r + m2;
       mrb_int const blk_pos = len + kd + 1;
-      mrb_value *blk = &argv[argc < 0 ? 1 : argc];
+      const mrb_value *blk = &argv[argc < 0 ? 1 : argc];
       mrb_value kdict = mrb_nil_value();
       mrb_int kargs = kd;
 


### PR DESCRIPTION
Previously, explicit write-barriers were required to change content using these macros.

From now on it can use `ARY_PTR_NEED_WB()` instead if it wants to get a pointer without `const` that requires write-barrier.
But if it wants to change only a few contents of the array object, the `mrb_ary_set()` function will be more useful.

With this change, the following function specifications will change:

- The `mrb_get_argv()` function will now return `const mrb_value *`.
  This is because it is difficult for the caller to check if it is a splat argument (array object) and to write-barrier if necessary.
- The "a"/"*" specifier of the `mrb_get_args()` function will now return `const mrb_value *`.
  This is because it is difficult for the caller to check if it is an array object and write-barrier if necessary.
  And it requires calling `mrb_ary_modify()` on the unmodified array object, which is also difficult (this is similar to #5087).