### PR TITLE
Prohibit array changes by "a"/"*" specifier of `mrb_get_args()`

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -889,7 +889,7 @@ MRB_API struct RClass* mrb_define_module_under_id(mrb_state *mrb, struct RClass 
  * | `H`  | {Hash}         | {mrb_value}       | when `!` follows, the value may be `nil`           |
  * | `s`  | {String}       | const char *, {mrb_int} | Receive two arguments; `s!` gives (`NULL`,`0`) for `nil` |
  * | `z`  | {String}       | const char *      | `NULL` terminated string; `z!` gives `NULL` for `nil` |
- * | `a`  | {Array}        | {mrb_value} *, {mrb_int} | Receive two arguments; `a!` gives (`NULL`,`0`) for `nil` |
+ * | `a`  | {Array}        | const {mrb_value} *, {mrb_int} | Receive two arguments; `a!` gives (`NULL`,`0`) for `nil` |
  * | `f`  | {Integer}/{Float} | {mrb_float}    |                                                    |
  * | `i`  | {Integer}/{Float} | {mrb_int}      |                                                    |
  * | `b`  | boolean        | {mrb_bool}        |                                                    |
@@ -897,7 +897,7 @@ MRB_API struct RClass* mrb_define_module_under_id(mrb_state *mrb, struct RClass 
  * | `d`  | data           | void *, {mrb_data_type} const | 2nd argument will be used to check data type so it won't be modified; when `!` follows, the value may be `nil` |
  * | `I`  | inline struct  | void *          |                                                    |
  * | `&`  | block          | {mrb_value}       | &! raises exception if no block given.             |
- * | `*`  | rest arguments | {mrb_value} *, {mrb_int} | Receive the rest of arguments as an array; `*!` avoid copy of the stack.  |
+ * | `*`  | rest arguments | const {mrb_value} *, {mrb_int} | Receive the rest of arguments as an array; `*!` avoid copy of the stack.  |
  * | <code>\|</code> | optional     |                   | After this spec following specs would be optional. |
  * | `?`  | optional given | {mrb_bool}        | `TRUE` if preceding argument is given. Used to check optional argument is given. |
  * | `:`  | keyword args   | {mrb_kwargs} const | Get keyword arguments. @see mrb_kwargs |

--- a/mrbgems/mruby-array-ext/src/array.c
+++ b/mrbgems/mruby-array-ext/src/array.c
@@ -97,7 +97,7 @@ static mrb_value
 mrb_ary_values_at(mrb_state *mrb, mrb_value self)
 {
   mrb_int argc;
-  mrb_value *argv;
+  const mrb_value *argv;
 
   mrb_get_args(mrb, "*", &argv, &argc);
 

--- a/mrbgems/mruby-eval/src/eval.c
+++ b/mrbgems/mruby-eval/src/eval.c
@@ -149,7 +149,7 @@ static mrb_value
 f_instance_eval(mrb_state *mrb, mrb_value self)
 {
   mrb_value b;
-  mrb_int argc; mrb_value *argv;
+  mrb_int argc; const mrb_value *argv;
 
   mrb_get_args(mrb, "*!&", &argv, &argc, &b);
 

--- a/mrbgems/mruby-fiber/src/fiber.c
+++ b/mrbgems/mruby-fiber/src/fiber.c
@@ -255,7 +255,7 @@ fiber_switch(mrb_state *mrb, mrb_value self, mrb_int len, const mrb_value *a, mr
 static mrb_value
 fiber_resume(mrb_state *mrb, mrb_value self)
 {
-  mrb_value *a;
+  const mrb_value *a;
   mrb_int len;
   mrb_bool vmexec = FALSE;
 
@@ -315,7 +315,7 @@ static mrb_value
 fiber_transfer(mrb_state *mrb, mrb_value self)
 {
   struct mrb_context *c = fiber_check(mrb, self);
-  mrb_value* a;
+  const mrb_value* a;
   mrb_int len;
 
   fiber_check_cfunc(mrb, mrb->c);
@@ -374,7 +374,7 @@ mrb_fiber_yield(mrb_state *mrb, mrb_int len, const mrb_value *a)
 static mrb_value
 fiber_yield(mrb_state *mrb, mrb_value self)
 {
-  mrb_value *a;
+  const mrb_value *a;
   mrb_int len;
 
   mrb_get_args(mrb, "*!", &a, &len);

--- a/mrbgems/mruby-hash-ext/src/hash-ext.c
+++ b/mrbgems/mruby-hash-ext/src/hash-ext.c
@@ -22,7 +22,8 @@
 static mrb_value
 hash_values_at(mrb_state *mrb, mrb_value hash)
 {
-  mrb_value *argv, result;
+  const mrb_value *argv;
+  mrb_value result;
   mrb_int argc, i;
   int ai;
 
@@ -49,7 +50,8 @@ hash_values_at(mrb_state *mrb, mrb_value hash)
 static mrb_value
 hash_slice(mrb_state *mrb, mrb_value hash)
 {
-  mrb_value *argv, result;
+  const mrb_value *argv;
+  mrb_value result;
   mrb_int argc, i;
 
   mrb_get_args(mrb, "*", &argv, &argc);

--- a/mrbgems/mruby-io/src/file.c
+++ b/mrbgems/mruby-io/src/file.c
@@ -115,7 +115,7 @@ mrb_file_s_umask(mrb_state *mrb, mrb_value klass)
 static mrb_value
 mrb_file_s_unlink(mrb_state *mrb, mrb_value obj)
 {
-  mrb_value *argv;
+  const mrb_value *argv;
   mrb_value pathv;
   mrb_int argc, i;
   char *path;
@@ -533,7 +533,7 @@ static mrb_value
 mrb_file_s_chmod(mrb_state *mrb, mrb_value klass) {
   mrb_int mode;
   mrb_int argc, i;
-  mrb_value *filenames;
+  const mrb_value *filenames;
   int ai = mrb_gc_arena_save(mrb);
 
   mrb_get_args(mrb, "i*", &mode, &filenames, &argc);

--- a/mrbgems/mruby-io/src/io.c
+++ b/mrbgems/mruby-io/src/io.c
@@ -1154,7 +1154,7 @@ mrb_io_s_pipe(mrb_state *mrb, mrb_value klass)
 static mrb_value
 mrb_io_s_select(mrb_state *mrb, mrb_value klass)
 {
-  mrb_value *argv;
+  const mrb_value *argv;
   mrb_int argc;
   mrb_value read, read_io, write, except, timeout, list;
   struct timeval *tp, timerec;

--- a/mrbgems/mruby-metaprog/src/metaprog.c
+++ b/mrbgems/mruby-metaprog/src/metaprog.c
@@ -642,7 +642,7 @@ static mrb_value
 mrb_mod_remove_method(mrb_state *mrb, mrb_value mod)
 {
   mrb_int argc;
-  mrb_value *argv;
+  const mrb_value *argv;
   struct RClass *c = mrb_class_ptr(mod);
 
   mrb_get_args(mrb, "*", &argv, &argc);

--- a/mrbgems/mruby-method/src/method.c
+++ b/mrbgems/mruby-method/src/method.c
@@ -109,7 +109,7 @@ method_eql(mrb_state *mrb, mrb_value self)
 
 static mrb_value
 mcall(mrb_state *mrb, mrb_value recv, mrb_value proc, mrb_value name, struct RClass *owner,
-      mrb_int argc, mrb_value *argv, mrb_value block)
+      mrb_int argc, const mrb_value *argv, mrb_value block)
 {
   mrb_value ret;
   mrb_sym orig_mid = mrb->c->ci->mid;
@@ -142,7 +142,8 @@ method_call(mrb_state *mrb, mrb_value self)
   mrb_value recv = mrb_iv_get(mrb, self, MRB_SYM(_recv));
   struct RClass *owner = mrb_class_ptr(mrb_iv_get(mrb, self, MRB_SYM(_owner)));
   mrb_int argc;
-  mrb_value *argv, block;
+  const mrb_value *argv;
+  mrb_value block;
 
   mrb_get_args(mrb, "*&", &argv, &argc, &block);
   return mcall(mrb, recv, proc, name, owner, argc, argv, block);
@@ -156,7 +157,8 @@ method_bcall(mrb_state *mrb, mrb_value self)
   mrb_value recv = mrb_iv_get(mrb, self, MRB_SYM(_recv));
   mrb_value owner = mrb_iv_get(mrb, self, MRB_SYM(_owner));
   mrb_int argc;
-  mrb_value *argv, block;
+  const mrb_value *argv;
+  mrb_value block;
 
   mrb_get_args(mrb, "o*&", &recv, &argv, &argc, &block);
   bind_check(mrb, recv, owner);

--- a/mrbgems/mruby-print/src/print.c
+++ b/mrbgems/mruby-print/src/print.c
@@ -53,7 +53,7 @@ static mrb_value
 mrb_print(mrb_state *mrb, mrb_value self)
 {
   mrb_int argc, i;
-  mrb_value *argv;
+  const mrb_value *argv;
 
   mrb_get_args(mrb, "*", &argv, &argc);
   for (i=0; i<argc; i++) {
@@ -69,7 +69,7 @@ static mrb_value
 mrb_puts(mrb_state *mrb, mrb_value self)
 {
   mrb_int argc, i;
-  mrb_value *argv;
+  const mrb_value *argv;
 
   mrb_get_args(mrb, "*", &argv, &argc);
   for (i=0; i<argc; i++) {

--- a/mrbgems/mruby-proc-ext/test/proc.c
+++ b/mrbgems/mruby-proc-ext/test/proc.c
@@ -35,7 +35,7 @@ static mrb_value
 cfunc_env_get(mrb_state *mrb, mrb_value self)
 {
   mrb_sym n;
-  mrb_value *argv; mrb_int argc;
+  const mrb_value *argv; mrb_int argc;
   mrb_method_t m;
   struct RProc *p;
   mrb_get_args(mrb, "na", &n, &argv, &argc);

--- a/mrbgems/mruby-sprintf/src/sprintf.c
+++ b/mrbgems/mruby-sprintf/src/sprintf.c
@@ -517,7 +517,7 @@ static mrb_value
 mrb_f_sprintf(mrb_state *mrb, mrb_value obj)
 {
   mrb_int argc;
-  mrb_value *argv;
+  const mrb_value *argv;
 
   mrb_get_args(mrb, "*", &argv, &argc);
 

--- a/mrbgems/mruby-string-ext/src/string.c
+++ b/mrbgems/mruby-string-ext/src/string.c
@@ -194,7 +194,8 @@ mrb_str_concat_m(mrb_state *mrb, mrb_value self)
 static mrb_value
 mrb_str_start_with(mrb_state *mrb, mrb_value self)
 {
-  mrb_value *argv, sub;
+  const mrb_value *argv;
+  mrb_value sub;
   mrb_int argc, i;
   mrb_get_args(mrb, "*", &argv, &argc);
 
@@ -223,7 +224,8 @@ mrb_str_start_with(mrb_state *mrb, mrb_value self)
 static mrb_value
 mrb_str_end_with(mrb_state *mrb, mrb_value self)
 {
-  mrb_value *argv, sub;
+  const mrb_value *argv;
+  mrb_value sub;
   mrb_int argc, i;
   mrb_get_args(mrb, "*", &argv, &argc);
 

--- a/mrbgems/mruby-struct/src/struct.c
+++ b/mrbgems/mruby-struct/src/struct.c
@@ -262,12 +262,12 @@ static mrb_value
 mrb_struct_s_def(mrb_state *mrb, mrb_value klass)
 {
   mrb_value name, rest;
-  mrb_value *pargv;
+  const mrb_value *pargv;
   mrb_int argcnt;
   mrb_int i;
   mrb_value b, st;
   mrb_sym id;
-  mrb_value *argv;
+  const mrb_value *argv;
   mrb_int argc;
 
   name = mrb_nil_value();
@@ -321,7 +321,7 @@ num_members(mrb_state *mrb, struct RClass *klass)
 /*
  */
 static mrb_value
-mrb_struct_initialize_withArg(mrb_state *mrb, mrb_int argc, mrb_value *argv, mrb_value self)
+mrb_struct_initialize_withArg(mrb_state *mrb, mrb_int argc, const mrb_value *argv, mrb_value self)
 {
   struct RClass *klass = mrb_obj_class(mrb, self);
   mrb_int i, n;
@@ -343,7 +343,7 @@ mrb_struct_initialize_withArg(mrb_state *mrb, mrb_int argc, mrb_value *argv, mrb
 static mrb_value
 mrb_struct_initialize(mrb_state *mrb, mrb_value self)
 {
-  mrb_value *argv;
+  const mrb_value *argv;
   mrb_int argc;
 
   mrb_get_args(mrb, "*!", &argv, &argc);
@@ -646,7 +646,7 @@ static mrb_value
 mrb_struct_values_at(mrb_state *mrb, mrb_value self)
 {
   mrb_int argc;
-  mrb_value *argv;
+  const mrb_value *argv;
 
   mrb_get_args(mrb, "*", &argv, &argc);
 

--- a/mrbgems/mruby-test/driver.c
+++ b/mrbgems/mruby-test/driver.c
@@ -50,7 +50,7 @@ eval_test(mrb_state *mrb)
 static mrb_value
 t_print(mrb_state *mrb, mrb_value self)
 {
-  mrb_value *argv;
+  const mrb_value *argv;
   mrb_int argc;
   mrb_int i;
 

--- a/src/array.c
+++ b/src/array.c
@@ -280,7 +280,7 @@ static mrb_value
 mrb_ary_s_create(mrb_state *mrb, mrb_value klass)
 {
   mrb_value ary;
-  mrb_value *vals;
+  const mrb_value *vals;
   mrb_int len;
   struct RArray *a;
 
@@ -340,7 +340,7 @@ mrb_ary_plus(mrb_state *mrb, mrb_value self)
 {
   struct RArray *a1 = mrb_ary_ptr(self);
   struct RArray *a2;
-  mrb_value *ptr;
+  const mrb_value *ptr;
   mrb_int blen, len1;
 
   mrb_get_args(mrb, "a", &ptr, &blen);
@@ -615,7 +615,8 @@ static mrb_value
 mrb_ary_unshift_m(mrb_state *mrb, mrb_value self)
 {
   struct RArray *a = mrb_ary_ptr(self);
-  mrb_value *vals, *ptr;
+  const mrb_value *vals;
+  mrb_value *ptr;
   mrb_int alen, len;
 
   mrb_get_args(mrb, "*!", &vals, &alen);
@@ -832,7 +833,7 @@ aget_index(mrb_state *mrb, mrb_value index)
 #endif
   else {
     mrb_int i, argc;
-    mrb_value *argv;
+    const mrb_value *argv;
 
     mrb_get_args(mrb, "i*!", &i, &argv, &argc);
     return i;

--- a/src/class.c
+++ b/src/class.c
@@ -856,7 +856,7 @@ void mrb_hash_check_kdict(mrb_state *mrb, mrb_value self);
     H:      Hash           [mrb_value]            when ! follows, the value may be nil
     s:      String         [const char*,mrb_int]  Receive two arguments; s! gives (NULL,0) for nil
     z:      String         [const char*]          NUL terminated string; z! gives NULL for nil
-    a:      Array          [mrb_value*,mrb_int]   Receive two arguments; a! gives (NULL,0) for nil
+    a:      Array          [const mrb_value*,mrb_int] Receive two arguments; a! gives (NULL,0) for nil
     c:      Class/Module   [strcut RClass*]
     f:      Integer/Float  [mrb_float]
     i:      Integer/Float  [mrb_int]
@@ -865,7 +865,7 @@ void mrb_hash_check_kdict(mrb_state *mrb, mrb_value self);
     d:      data           [void*,mrb_data_type const] 2nd argument will be used to check data type so it won't be modified; when ! follows, the value may be nil
     I:      inline struct  [void*]
     &:      block          [mrb_value]            &! raises exception if no block given
-    *:      rest argument  [mrb_value*,mrb_int]   The rest of the arguments as an array; *! avoid copy of the stack
+    *:      rest argument  [const mrb_value*,mrb_int] The rest of the arguments as an array; *! avoid copy of the stack
     |:      optional                              Following arguments are optional
     ?:      optional given [mrb_bool]             true if preceding argument (optional) is given
     ':':    keyword args   [mrb_kwargs const]     Get keyword arguments
@@ -1083,10 +1083,10 @@ mrb_get_args(mrb_state *mrb, const char *format, ...)
       {
         mrb_value aa;
         struct RArray *a;
-        mrb_value **pb;
+        const mrb_value **pb;
         mrb_int *pl;
 
-        pb = va_arg(ap, mrb_value**);
+        pb = va_arg(ap, const mrb_value**);
         pl = va_arg(ap, mrb_int*);
         if (i < argc) {
           aa = argv[i++];
@@ -1215,11 +1215,11 @@ mrb_get_args(mrb_state *mrb, const char *format, ...)
 
     case '*':
       {
-        mrb_value **var;
+        const mrb_value **var;
         mrb_int *pl;
         mrb_bool nocopy = (altmode || !argv_on_stack) ? TRUE : FALSE;
 
-        var = va_arg(ap, mrb_value**);
+        var = va_arg(ap, const mrb_value**);
         pl = va_arg(ap, mrb_int*);
         if (argc > i) {
           *pl = argc-i;
@@ -1754,7 +1754,7 @@ static mrb_value
 mod_attr_define(mrb_state *mrb, mrb_value mod, mrb_value (*accessor)(mrb_state *, mrb_value), mrb_sym (*access_name)(mrb_state *, mrb_sym))
 {
   struct RClass *c = mrb_class_ptr(mod);
-  mrb_value *argv;
+  const mrb_value *argv;
   mrb_int argc, i;
   int ai;
 
@@ -1843,7 +1843,7 @@ mrb_value
 mrb_instance_new(mrb_state *mrb, mrb_value cv)
 {
   mrb_value obj, blk;
-  mrb_value *argv;
+  const mrb_value *argv;
   mrb_int argc;
   mrb_sym init;
 
@@ -2248,7 +2248,7 @@ mrb_mod_undef(mrb_state *mrb, mrb_value mod)
 {
   struct RClass *c = mrb_class_ptr(mod);
   mrb_int argc;
-  mrb_value *argv;
+  const mrb_value *argv;
 
   mrb_get_args(mrb, "*", &argv, &argc);
   while (argc--) {
@@ -2468,7 +2468,7 @@ mrb_mod_dup(mrb_state *mrb, mrb_value self)
 static mrb_value
 mrb_mod_module_function(mrb_state *mrb, mrb_value mod)
 {
-  mrb_value *argv;
+  const mrb_value *argv;
   mrb_int argc, i;
   mrb_sym mid;
   mrb_method_t m;

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -219,7 +219,7 @@ mrb_obj_class_m(mrb_state *mrb, mrb_value self)
 }
 
 static mrb_value
-mrb_obj_extend(mrb_state *mrb, mrb_int argc, mrb_value *argv, mrb_value obj)
+mrb_obj_extend(mrb_state *mrb, mrb_int argc, const mrb_value *argv, mrb_value obj)
 {
   mrb_int i;
 
@@ -264,7 +264,7 @@ mrb_obj_extend(mrb_state *mrb, mrb_int argc, mrb_value *argv, mrb_value obj)
 static mrb_value
 mrb_obj_extend_m(mrb_state *mrb, mrb_value self)
 {
-  mrb_value *argv;
+  const mrb_value *argv;
   mrb_int argc;
 
   mrb_get_args(mrb, "*", &argv, &argc);
@@ -524,7 +524,7 @@ static mrb_value
 mrb_obj_missing(mrb_state *mrb, mrb_value mod)
 {
   mrb_sym name;
-  mrb_value *a;
+  const mrb_value *a;
   mrb_int alen;
 
   mrb_get_args(mrb, "n*!", &name, &a, &alen);

--- a/src/vm.c
+++ b/src/vm.c
@@ -552,7 +552,8 @@ mrb_value
 mrb_f_send(mrb_state *mrb, mrb_value self)
 {
   mrb_sym name;
-  mrb_value block, *argv, *regs;
+  mrb_value block, *regs;
+  const mrb_value *argv;
   mrb_int argc, i, len;
   mrb_method_t m;
   struct RClass *c;


### PR DESCRIPTION
The "a"/"*" specifier of the `mrb_get_args()` function will now return `const mrb_value *`.
This is because it is difficult for the caller to check if it is an array object and write-barrier if necessary.
And it requires calling `mrb_ary_modify()` on the unmodified array object, which is also difficult (this is similar to #5087).

----

This is a part of #5097.
