### PR TITLE
Prohibit array changes by `mrb_get_argv()`

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -991,7 +991,7 @@ MRB_API mrb_int mrb_get_argc(mrb_state *mrb);
  *
  * Correctly handles *splat arguments.
  */
-MRB_API mrb_value* mrb_get_argv(mrb_state *mrb);
+MRB_API const mrb_value *mrb_get_argv(mrb_state *mrb);
 
 /**
  * Retrieve the first and only argument from mrb_state.

--- a/src/array.c
+++ b/src/array.c
@@ -509,7 +509,7 @@ static mrb_value
 mrb_ary_push_m(mrb_state *mrb, mrb_value self)
 {
   mrb_int argc;
-  mrb_value *argv;
+  const mrb_value *argv;
   mrb_int len, len2;
   struct RArray *a;
 
@@ -947,7 +947,7 @@ mrb_ary_aset(mrb_state *mrb, mrb_value self)
 
   ary_modify(mrb, mrb_ary_ptr(self));
   if (mrb_get_argc(mrb) == 2) {
-    mrb_value *vs = mrb_get_argv(mrb);
+    const mrb_value *vs = mrb_get_argv(mrb);
     v1 = vs[0]; v2 = vs[1];
 
     /* a[n..m] = v */

--- a/src/class.c
+++ b/src/class.c
@@ -806,7 +806,7 @@ mrb_get_argc(mrb_state *mrb)
   return argc;
 }
 
-MRB_API mrb_value*
+MRB_API const mrb_value*
 mrb_get_argv(mrb_state *mrb)
 {
   mrb_int argc = mrb->c->ci->argc;


### PR DESCRIPTION
The `mrb_get_argv()` function will now return `const mrb_value *`.
This is because it is difficult for the caller to check if it is a splat argument (array object) and to write-barrier if necessary.

----

This is a part of #5097.
