### PR TITLE
Fix parallel build

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -232,7 +232,6 @@ end
 
 desc "preallocated symbols"
 task :gensym => presym_inc
-task :all => :gensym
 
 depfiles += MRuby.targets.map { |n, t|
   t.libraries
@@ -243,7 +242,7 @@ depfiles += MRuby.targets.reject { |n, t| n == 'host' }.map { |n, t|
 }.flatten
 
 desc "build all targets, install (locally) in-repo"
-task :all => depfiles do
+task :all => :build do
   puts
   puts "Build summary:"
   puts
@@ -251,6 +250,10 @@ task :all => depfiles do
     print_build_summary
   end
   MRuby::Lockfile.write
+end
+
+task :build => :gensym do
+  depfiles.each {|dep| Rake::Task[dep].invoke}
 end
 
 desc "run all mruby tests"

--- a/doc/mruby3.md
+++ b/doc/mruby3.md
@@ -3,12 +3,6 @@ User visible changes in `mruby3`
 
 # Build System
 
-## `presym` target
-
-The first compilation of `mruby` may require generation of a
-static symbol table named `build/presym`. You can generate
-the table by `rake gensym`.
-
 ## `build_config` directory
 
 Typical build configuration files are located in `build_config`


### PR DESCRIPTION
When `rake -m` and so on are used to build in parallel, building may be
started before presym files are generated. Then, for example, the following
error occurs and this issue is fixed.

```console
In file included from /Users/shuujii/mruby/mruby/include/mruby.h:92:
/mruby/mruby/include/mruby/presym.h:16:10: fatal error: '../build/presym.inc' file not found
#include <../build/presym.inc>
         ^~~~~~~~~~~~~~~~~~~~~
```