### PR TITLE
Fix dependencies of `y.tab.o`

### DIFF
--- a/mrbgems/mruby-compiler/mrbgem.rake
+++ b/mrbgems/mruby-compiler/mrbgem.rake
@@ -16,9 +16,6 @@ MRuby::Gem::Specification.new 'mruby-compiler' do |spec|
       build.compile_as_cxx("#{dir}/core/codegen.c", "#{build_dir}/core/codegen.cxx")
   else
     core_objs << objfile("#{build_dir}/core/y.tab")
-    file objfile("#{build_dir}/core/y.tab") => "#{dir}/core/y.tab.c" do |t|
-      cc.run t.name, t.prerequisites.first, [], ["#{dir}/core"]
-    end
   end
 
   # Parser


### PR DESCRIPTION
In the case of `y.tab.o`, `y.tab.d` was not read, so `y.tab.c` was not
recompiled by updating header files.

It seemed that the cause was overwriting the rake rule, so I deleted
unnecessary settings.