### PR TITLE
Fixed build NaN boxing with 32-bit CPU mode

### DIFF
--- a/include/mruby/boxing_nan.h
+++ b/include/mruby/boxing_nan.h
@@ -41,7 +41,11 @@ union mrb_value_ {
   struct {
     MRB_ENDIAN_LOHI(
       uint32_t ttt;
+#ifdef MRB_64BIT
       ,uint32_t i;
+#else
+      ,union { uint32_t i; void *p; };
+#endif
     )
   };
 };


### PR DESCRIPTION
`SET_CPTR_VALUE()` requires the `p` field on 32-bit CPU mode.