### PR TITLE
Rename `mrb_os_memsize_of_hash_table` to `mrb_hash_memsize`

### DIFF
--- a/include/mruby/hash.h
+++ b/include/mruby/hash.h
@@ -35,7 +35,7 @@ struct RHash {
 #define mrb_hash_ptr(v)    ((struct RHash*)(mrb_ptr(v)))
 #define mrb_hash_value(p)  mrb_obj_value((void*)(p))
 
-size_t mrb_os_memsize_of_hash_table(mrb_value obj);
+size_t mrb_hash_memsize(mrb_value obj);
 MRB_API mrb_value mrb_hash_new_capa(mrb_state *mrb, mrb_int capa);
 MRB_API mrb_value mrb_ensure_hash_type(mrb_state *mrb, mrb_value hash);
 MRB_API mrb_value mrb_check_hash_type(mrb_state *mrb, mrb_value hash);

--- a/mrbgems/mruby-os-memsize/src/memsize.c
+++ b/mrbgems/mruby-os-memsize/src/memsize.c
@@ -84,7 +84,7 @@ os_memsize_of_object(mrb_state* mrb, mrb_value obj)
     }
     case MRB_TT_HASH: {
       size += mrb_objspace_page_slot_size() +
-              mrb_os_memsize_of_hash_table(obj);
+              mrb_hash_memsize(obj);
       break;
     }
     case MRB_TT_ARRAY: {

--- a/src/hash.c
+++ b/src/hash.c
@@ -1031,7 +1031,7 @@ mrb_gc_free_hash(mrb_state *mrb, struct RHash *h)
 }
 
 size_t
-mrb_os_memsize_of_hash_table(mrb_value self)
+mrb_hash_memsize(mrb_value self)
 {
   struct RHash *h = mrb_hash_ptr(self);
   return h_ar_p(h) ? (ar_ea_capa(h) * sizeof(hash_entry)) :


### PR DESCRIPTION
* The term `hash_table` can be misleading because the return value of this
  function includes memory usage of entire `Hash` object, including not only
  hash table part but also entry list part, etc.
* This function takes a `Hash` object as a receiver and is defined in
  `src/hash.c`, so it is natural to have a `mrb_hash_` prefix.