### PR TITLE
Simplify `MRuby::Command#_run` to avoid duplicated compilation

### DIFF
--- a/lib/mruby/build/command.rb
+++ b/lib/mruby/build/command.rb
@@ -36,13 +36,7 @@ module MRuby
 
     private
     def _run(options, params={})
-      return sh command + ' ' + ( options % params ) if NotFoundCommands.key? @command
-      begin
-        sh build.filename(command) + ' ' + ( options % params )
-      rescue RuntimeError
-        NotFoundCommands[@command] = true
-        _run options, params
-      end
+      sh "#{build.filename(command)} #{options % params}"
     end
   end
 


### PR DESCRIPTION
ref: https://github.com/mruby/mruby/pull/4959#discussion_r402086196

Compiles twice because it falls back to `build.filename(command)` when
`command` fails. This process was added at 9968af4 to support `ccache gcc`
etc. At that time, it seems that it was necessary because
`build.filename(command)` quoted the whole `command`, but now it does not
quote, so we can just run `build.filename(command)`.

### Example

  ```console
  $ echo 1 > src/a.c
  $ rake -v
  ```

#### Before this patch:

  ```console
  (snip)
  gcc -std=gnu99 -g -O3 -Wall -Wundef -Wdeclaration-after-statement -Werror-implicit-function-declaration -Wwrite-strings -I"/mruby/mruby/include" -MMD -o "/mruby/mruby/build/host/src/a.o" -c "/mruby/mruby/src/a.c"
  /mruby/mruby/src/a.c:1:1: error: expected identifier or '('
  1
  ^
  1 error generated.
  gcc -std=gnu99 -g -O3 -Wall -Wundef -Wdeclaration-after-statement -Werror-implicit-function-declaration -Wwrite-strings -I"/mruby/mruby/include" -MMD -o "/mruby/mruby/build/host/src/a.o" -c "/mruby/mruby/src/a.c"
  /mruby/mruby/src/a.c:1:1: error: expected identifier or '('
  1
  ^
  1 error generated.
  rake aborted!
  (snip)
  ```

#### After this patch:

  ```console
  (snip)
  gcc -std=gnu99 -g -O3 -Wall -Wundef -Wdeclaration-after-statement -Werror-implicit-function-declaration -Wwrite-strings -I"/mruby/mruby/include" -MMD -o "/mruby/mruby/build/host/src/a.o" -c "/mruby/mruby/src/a.c"
  /mruby/mruby/src/a.c:1:1: error: expected identifier or '('
  1
  ^
  1 error generated.
  rake aborted!
  (snip)
  ```