### PR TITLE
Remove redundant command execution in `header_search_paths`

### DIFF
--- a/tasks/toolchains/gcc.rake
+++ b/tasks/toolchains/gcc.rake
@@ -35,8 +35,7 @@ MRuby::Toolchain.new(:gcc) do |conf, params|
     def cc.header_search_paths
       if @header_search_command != command
         result = `echo | #{build.filename command} -x#{@header_search_language} -Wp,-v - -fsyntax-only 2>&1`
-        result = `echo | #{command} -x#{@header_search_language} -Wp,-v - -fsyntax-only 2>&1` if $?.exitstatus != 0
-        return include_paths if  $?.exitstatus != 0
+        return include_paths if $?.exitstatus != 0
 
         @frameworks = []
         @header_search_paths = result.lines.map { |v|


### PR DESCRIPTION
There is no need to execute command in duplicate for the same
reason as #5128.