### PR TITLE
Fix that large integer is not GCed with Word-boxing

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -782,7 +782,6 @@ obj_free(mrb_state *mrb, struct RBasic *obj, int end)
   switch (obj->tt) {
     /* immediate - no mark */
   case MRB_TT_TRUE:
-  case MRB_TT_INTEGER:
   case MRB_TT_SYMBOL:
     /* cannot happen */
     return;


### PR DESCRIPTION
### Example (32-bit Word-boxing)

  ```ruby
  # example.rb
  int_count = ObjectSpace.count_objects[:T_INTEGER]||0
  int = 1<<30
  p (ObjectSpace.count_objects[:T_INTEGER]||0) - int_count
  int = nil
  GC.start
  p (ObjectSpace.count_objects[:T_INTEGER]||0) - int_count
  ```

#### Before this patch:

  ```console
  $ bin/mruby example.rb
  1
  1
  ```

#### After this patch:

  ```console
  $ bin/mruby example.rb
  1
  0
  ```