### PR TITLE
Avoid undefined behavior

### DIFF
--- a/src/codedump.c
+++ b/src/codedump.c
@@ -170,7 +170,7 @@ codedump(mrb_state *mrb, const mrb_irep *irep)
       print_lv_a(mrb, irep, a);
       break;
     CASE(OP_LOADI32, BSS);
-      printf("OP_LOADI32\tR%d\t%d\t", a, (int)(b<<16)+c);
+      printf("OP_LOADI32\tR%d\t%d\t", a, (int)(((uint32_t)b<<16)+c));
       print_lv_a(mrb, irep, a);
       break;
     CASE(OP_LOADI__1, B);

--- a/src/vm.c
+++ b/src/vm.c
@@ -1069,7 +1069,7 @@ RETRY_TRY_BLOCK:
       NEXT;
     }
 
-    
+
     CASE(OP_LOADL16, BS) {
       goto op_loadl;
     }
@@ -1135,7 +1135,7 @@ RETRY_TRY_BLOCK:
     }
 
     CASE(OP_LOADI32, BSS) {
-      SET_INT_VALUE(mrb, regs[a], ((mrb_int)b<<16)+c);
+      SET_INT_VALUE(mrb, regs[a], (mrb_int)(((uint32_t)b<<16)+c));
       NEXT;
     }
 


### PR DESCRIPTION
### ASAN report (`MRB_INT32`)

  ```console
  $ bin/mruby -ve '-0x40000000'
  mruby 3.0.0preview (2020-10-16)
  00001 NODE_SCOPE:
  00001   NODE_BEGIN:
  00001     NODE_NEGATE:
  00001       NODE_INT 40000000 base 16
  irep 0x6070000001e0 nregs=2 nlocals=1 pools=0 syms=0 reps=0 iseq=9
  file: -e
  /mruby/src/codedump.c:173:49: runtime error: left shift of 49152 by 16 places cannot be represented in type 'int'
  SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /mruby/src/codedump.c:173:49 in
      1 000 OP_LOADI32	R1	-1073741824
      1 006 OP_RETURN	R1
      1 008 OP_STOP

  /mruby/src/vm.c:1138:7: runtime error: left shift of 49152 by 16 places cannot be represented in type 'mrb_int' (aka 'int')
  SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /mruby/src/vm.c:1138:7 in
  ```