### PR TITLE
Fix deprecated `set-env` command error on GitHub Actions [ci skip]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,6 +67,7 @@ jobs:
     runs-on: windows-latest
     env:
       MRUBY_CONFIG: travis
+      ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     steps:
     - uses: actions/checkout@v1
     - uses: actions/cache@v1


### PR DESCRIPTION
I tried `$GITHUB_PATH` and `$GITHUB_ENV` instead of `set-env`, but
for some reason path was not recognized, so I changed to using
`ACTIONS_ALLOW_UNSECURE_COMMANDS`.