### PR TITLE
Remove unused `MRuby::Build#enable_{bin,}test=`

### DIFF
--- a/lib/mruby/build.rb
+++ b/lib/mruby/build.rb
@@ -55,7 +55,6 @@ module MRuby
     include LoadGems
     attr_accessor :name, :bins, :exts, :file_separator, :build_dir, :gem_clone_dir
     attr_reader :libmruby_objs, :gems, :toolchains, :gem_dir_to_repo_url
-    attr_writer :enable_bintest, :enable_test
 
     alias libmruby libmruby_objs
 


### PR DESCRIPTION
The writers seem to be unnecessary because `MRuby::Build#enable_{bin,}test`
are used from the beginning.