### PR TITLE
Improve determining C++ compiler in `tasks/toolchains/gcc.rake`

### DIFF
--- a/tasks/toolchains/gcc.rake
+++ b/tasks/toolchains/gcc.rake
@@ -6,7 +6,7 @@ MRuby::Toolchain.new(:gcc) do |conf, params|
 
   [conf.cc, conf.objc, conf.asm, conf.cxx].each do |compiler|
     if compiler == conf.cxx
-      compiler.command = ENV['CXX'] || default_command.sub(/cc|$/, '++')
+      compiler.command = ENV['CXX'] || conf.cc.command.sub(/g\Kcc|$/, '++')
       compiler.flags = [ENV['CXXFLAGS'] || ENV['CFLAGS'] || compiler_flags]
     else
       compiler.command = ENV['CC'] || default_command


### PR DESCRIPTION
* Consider `CC` envvar as C compiler on which to make the decision.
* Consider the case where C compiler is `ccache gcc`, etc.