### PR TITLE
Improved `Object#define_singleton_method`

### DIFF
--- a/mrbgems/mruby-metaprog/src/metaprog.c
+++ b/mrbgems/mruby-metaprog/src/metaprog.c
@@ -401,21 +401,12 @@ mrb_obj_singleton_methods_m(mrb_state *mrb, mrb_value self)
   return mrb_obj_singleton_methods(mrb, recur, self);
 }
 
+mrb_value mrb_mod_define_method_m(mrb_state *mrb, struct RClass *c);
+
 static mrb_value
 mod_define_singleton_method(mrb_state *mrb, mrb_value self)
 {
-  struct RProc *p;
-  mrb_method_t m;
-  mrb_sym mid;
-  mrb_value blk = mrb_nil_value();
-
-  mrb_get_args(mrb, "n&!", &mid, &blk);
-  p = (struct RProc*)mrb_obj_alloc(mrb, MRB_TT_PROC, mrb->proc_class);
-  mrb_proc_copy(p, mrb_proc_ptr(blk));
-  p->flags |= MRB_PROC_STRICT;
-  MRB_METHOD_FROM_PROC(m, p);
-  mrb_define_method_raw(mrb, mrb_class_ptr(mrb_singleton_class(mrb, self)), mid, m);
-  return mrb_symbol_value(mid);
+  return mrb_mod_define_method_m(mrb, mrb_class_ptr(mrb_singleton_class(mrb, self)));
 }
 
 static mrb_bool

--- a/src/class.c
+++ b/src/class.c
@@ -2418,10 +2418,9 @@ mrb_mod_method_defined(mrb_state *mrb, mrb_value mod)
   return mrb_bool_value(mrb_obj_respond_to(mrb, mrb_class_ptr(mod), id));
 }
 
-static mrb_value
-mod_define_method(mrb_state *mrb, mrb_value self)
+mrb_value
+mrb_mod_define_method_m(mrb_state *mrb, struct RClass *c)
 {
-  struct RClass *c = mrb_class_ptr(self);
   struct RProc *p;
   mrb_method_t m;
   mrb_sym mid;
@@ -2452,9 +2451,15 @@ mod_define_method(mrb_state *mrb, mrb_value self)
 }
 
 static mrb_value
+mod_define_method(mrb_state *mrb, mrb_value self)
+{
+  return mrb_mod_define_method_m(mrb, mrb_class_ptr(self));
+}
+
+static mrb_value
 top_define_method(mrb_state *mrb, mrb_value self)
 {
-  return mod_define_method(mrb, mrb_obj_value(mrb->object_class));
+  return mrb_mod_define_method_m(mrb, mrb->object_class);
 }
 
 static mrb_value


### PR DESCRIPTION
Integrate the implementation with `Module#define_method`.

- Introduce the internal function `mrb_mod_define_method_m()` (no static)
- The `Object#define_singleton_method` method can now accept a second argument