### PR TITLE
Reduce the minimum string buffer size from 128 to 63 bytes

### DIFF
--- a/doc/guides/mrbconf.md
+++ b/doc/guides/mrbconf.md
@@ -160,7 +160,7 @@ largest value of required alignment.
 * Used in `kh_init_ ## name` function.
 
 `MRB_STR_BUF_MIN_SIZE`
-* Default value is `128`.
+* Default value is `63`.
 * Specifies initial capacity of `RString` created by `mrb_str_buf_new` function..
 
 `MRB_NO_METHOD_CACHE`

--- a/include/mrbconf.h
+++ b/include/mrbconf.h
@@ -134,7 +134,7 @@
 //#define POOL_PAGE_SIZE 16000
 
 /* initial minimum size for string buffer */
-//#define MRB_STR_BUF_MIN_SIZE 128
+//#define MRB_STR_BUF_MIN_SIZE 63
 
 /* arena size */
 //#define MRB_GC_ARENA_SIZE 100
@@ -204,7 +204,7 @@
 # endif
 
 # ifndef MRB_STR_BUF_MIN_SIZE
-#  define MRB_STR_BUF_MIN_SIZE 32
+#  define MRB_STR_BUF_MIN_SIZE 31
 # endif
 
 # ifndef MRB_HEAP_PAGE_SIZE

--- a/src/string.c
+++ b/src/string.c
@@ -176,7 +176,7 @@ mrb_str_new_capa(mrb_state *mrb, size_t capa)
 }
 
 #ifndef MRB_STR_BUF_MIN_SIZE
-# define MRB_STR_BUF_MIN_SIZE 128
+# define MRB_STR_BUF_MIN_SIZE 63
 #endif
 
 MRB_API mrb_value


### PR DESCRIPTION
Similar change has been made in CRuby.

* https://github.com/ruby/ruby/pull/2151
* https://bugs.ruby-lang.org/issues/15802

Because mruby is more resource-saving oriented than CRuby, I think it's
better to reduce that.

In addition, the reason why 63 is used instead of 64 seems to be helpful as
follows.

* https://bugs.ruby-lang.org/issues/12025