### PR TITLE
Move global function for build to `lib/mruby/core_ext.rb`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -33,12 +33,6 @@ load "#{MRUBY_ROOT}/tasks/benchmark.rake"
 load "#{MRUBY_ROOT}/tasks/gitlab.rake"
 load "#{MRUBY_ROOT}/tasks/doc.rake"
 
-def install_D(src, dst)
-  rm_f dst
-  mkdir_p File.dirname(dst)
-  cp src, dst
-end
-
 ##############################
 # generic build targets, rules
 task :default => :all
@@ -177,7 +171,7 @@ file presym_file => cfiles+rbfiles+psfiles+[__FILE__] do
      }]
   end
   csymbols += File.readlines("#{MRUBY_ROOT}/include/mruby.h").grep(/define E_/).join.scan(/MRB_SYM\((\w+)\)/)
-  
+
   rbsymbols = rbfiles.map do |f|
     src = File.read(f)
     src.force_encoding(Encoding::BINARY)

--- a/lib/mruby/core_ext.rb
+++ b/lib/mruby/core_ext.rb
@@ -20,6 +20,12 @@ class String
   end
 end
 
+def install_D(src, dst)
+  rm_f dst
+  mkdir_p File.dirname(dst)
+  cp src, dst
+end
+
 def _pp(cmd, src, tgt=nil, options={})
   return if Rake.verbose
 


### PR DESCRIPTION
Because `_pp` is originally defined in `lib/mruby/core_ext.rb`, other global
functions are moved to the file.