### PR TITLE
Refine build log for generated files

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -195,6 +195,7 @@ file presym_file => cfiles+rbfiles+psfiles+[__FILE__] do
   presyms = File.readlines(presym_file) rescue []
   presyms.each{|x| x.chomp!}
   if presyms != symbols
+    _pp "GEN", presym_file.relative_path
     File.write(presym_file, symbols.join("\n"))
     Rake::Task[presym_inc].invoke
   end
@@ -207,6 +208,7 @@ task presym_inc do
   prefix_re = Regexp.union(*symbol_to_macro.keys.uniq.map(&:first))
   suffix_re = Regexp.union(*symbol_to_macro.keys.uniq.map(&:last))
   macro_re = /\A(#{prefix_re})?([\w&&\D]\w*)(#{suffix_re})?\z/o
+  _pp "GEN", presym_inc.relative_path
   File.open(presym_inc, "w") do |f|
     f.puts "/* MRB_PRESYM_NAMED(lit, num, type, name) */"
     f.puts "/* MRB_PRESYM_UNNAMED(lit, num) */"

--- a/lib/mruby/build/command.rb
+++ b/lib/mruby/build/command.rb
@@ -308,8 +308,8 @@ module MRuby
     def run(out, infiles, funcname, cdump = true)
       @command ||= @build.mrbcfile
       infiles = [infiles].flatten
-      infiles.each do |f|
-        _pp "MRBC", f.relative_path, nil, :indent => 2
+      infiles.each_with_index do |f, i|
+        _pp i == 0 ? "MRBC" : "", f.relative_path, indent: 2
       end
       cmd = %Q["#{filename @command}" #{cdump ? "-S" : ""} #{@compile_options % {:funcname => funcname}} #{filename(infiles).map{|f| %Q["#{f}"]}.join(' ')}]
       puts cmd if Rake.verbose

--- a/lib/mruby/core_ext.rb
+++ b/lib/mruby/core_ext.rb
@@ -26,10 +26,10 @@ def install_D(src, dst)
   cp src, dst
 end
 
-def _pp(cmd, src, tgt=nil, options={})
+def _pp(cmd, src, tgt=nil, indent: nil)
   return if Rake.verbose
 
   width = 5
-  template = options[:indent] ? "%#{width*options[:indent]}s %s %s" : "%-#{width}s %s %s"
+  template = indent ? "%#{width * indent}s %s %s" : "%-#{width}s %s %s"
   puts template % [cmd, src, tgt ? "-> #{tgt}" : nil]
 end

--- a/lib/mruby/gem.rb
+++ b/lib/mruby/gem.rb
@@ -184,6 +184,7 @@ module MRuby
       end
 
       def generate_gem_init(fname)
+        _pp "GEN", fname.relative_path
         open(fname, 'w') do |f|
           print_gem_init_header f
           unless rbfiles.empty?

--- a/mrbgems/mruby-test/mrbgem.rake
+++ b/mrbgems/mruby-test/mrbgem.rake
@@ -26,6 +26,7 @@ MRuby::Gem::Specification.new('mruby-test') do |spec|
 
   file assert_lib => assert_c
   file assert_c => [assert_rb, build.mrbcfile] do |t|
+    _pp "GEN", t.name.relative_path
     mkdir_p File.dirname(t.name)
     open(t.name, 'w') do |f|
       mrbc.run f, assert_rb, 'mrbtest_assert_irep', false
@@ -41,6 +42,7 @@ MRuby::Gem::Specification.new('mruby-test') do |spec|
 
     file test_rbobj => g.test_rbireps
     file g.test_rbireps => [g.test_rbfiles, build.mrbcfile].flatten do |t|
+      _pp "GEN", t.name.relative_path
       mkdir_p File.dirname(t.name)
       open(t.name, 'w') do |f|
         g.print_gem_test_header(f)
@@ -148,7 +150,7 @@ MRuby::Gem::Specification.new('mruby-test') do |spec|
 
   file mlib => clib
   file clib => ["#{build.build_dir}/mrbgems/active_gems.txt", build.mrbcfile, __FILE__] do |_t|
-    _pp "GEN", "*.rb", "#{clib.relative_path}"
+    _pp "GEN", clib.relative_path
     mkdir_p File.dirname(clib)
     open(clib, 'w') do |f|
       f.puts %Q[/*]


### PR DESCRIPTION
* Output `GEN` log for generated files
* `MRBC` log is outputted one for each `mrbc` execution

#### Before this patch:

```console
CC    src/array.c -> build/host/src/array.o
(snip)
GEN   mrblib/*.rb -> build/host/mrblib/mrblib.c
      MRBC mrblib/00class.rb
      MRBC mrblib/10error.rb
(snip)
CC    mrbgems/mruby-time/src/time.c -> build/host/mrbgems/mruby-time/src/time.o
      MRBC mrbgems/mruby-time/mrblib/time.rb
(snip)
CC    mrbgems/mruby-socket/test/sockettest.c -> build/host/mrbgems/mruby-socket/test/sockettest.o
      MRBC mrbgems/mruby-socket/test/addrinfo.rb
      MRBC mrbgems/mruby-socket/test/basicsocket.rb
(snip)
```

#### After this patch:

```console
GEN   build/presym
GEN   build/presym.inc
CC    src/array.c -> build/host/src/array.o
(snip)
GEN   mrblib/*.rb -> build/host/mrblib/mrblib.c
      MRBC mrblib/00class.rb
           mrblib/10error.rb
(snip)
CC    mrbgems/mruby-time/src/time.c -> build/host/mrbgems/mruby-time/src/time.o
GEN   build/host/mrbgems/mruby-time/gem_init.c
      MRBC mrbgems/mruby-time/mrblib/time.rb
(snip)
CC    mrbgems/mruby-socket/test/sockettest.c -> build/host/mrbgems/mruby-socket/test/sockettest.o
GEN   build/host/mrbgems/mruby-socket/gem_test.c
      MRBC mrbgems/mruby-socket/test/addrinfo.rb
      MRBC mrbgems/mruby-socket/test/basicsocket.rb
(snip)
```