### PR TITLE
Avoid warnings from clang's "-Wembedded-directive"

### DIFF
--- a/include/mruby/boxing_nan.h
+++ b/include/mruby/boxing_nan.h
@@ -41,15 +41,14 @@ union mrb_value_ {
   uint64_t u;
 #ifdef MRB_64BIT
   void *p;
+# define BOXNAN_IMMEDIATE_VALUE uint32_t i
+#else
+# define BOXNAN_IMMEDIATE_VALUE union { uint32_t i; void *p; }
 #endif
   struct {
     MRB_ENDIAN_LOHI(
       uint32_t ttt;
-#ifdef MRB_64BIT
-      ,uint32_t i;
-#else
-      ,union { uint32_t i; void *p; };
-#endif
+      ,BOXNAN_IMMEDIATE_VALUE;
     )
   };
   mrb_value value;


### PR DESCRIPTION
If it gives clang-11.0 `-Wembedded-directive`, a warning will be reported in `include/mruby/boxing_nan.h`.

```
include/mruby/boxing_nan.h:48:2: warning: embedding a directive within macro arguments has undefined behavior [-Wembedded-directive]
include/mruby/boxing_nan.h:52:2: warning: embedding a directive within macro arguments has undefined behavior [-Wembedded-directive]
```

The cause of this is #5117.
ref. e993b83c509912f2d90ffece32c969a642f5df01