### PR TITLE
Allow compiler name in build log to be customized

### DIFF
--- a/lib/mruby/build.rb
+++ b/lib/mruby/build.rb
@@ -78,10 +78,10 @@ module MRuby
         @file_separator = '/'
         @build_dir = "#{build_dir}/#{@name}"
         @gem_clone_dir = "#{build_dir}/repos/#{@name}"
-        @cc = Command::Compiler.new(self, %w(.c))
-        @cxx = Command::Compiler.new(self, %w(.cc .cxx .cpp))
-        @objc = Command::Compiler.new(self, %w(.m))
-        @asm = Command::Compiler.new(self, %w(.S .asm))
+        @cc = Command::Compiler.new(self, %w(.c), label: "CC")
+        @cxx = Command::Compiler.new(self, %w(.cc .cxx .cpp), label: "CXX")
+        @objc = Command::Compiler.new(self, %w(.m), label: "OBJC")
+        @asm = Command::Compiler.new(self, %w(.S .asm), label: "ASM")
         @linker = Command::Linker.new(self)
         @archiver = Command::Archiver.new(self)
         @yacc = Command::Yacc.new(self)

--- a/lib/mruby/build/command.rb
+++ b/lib/mruby/build/command.rb
@@ -39,13 +39,14 @@ module MRuby
   end
 
   class Command::Compiler < Command
-    attr_accessor :flags, :include_paths, :defines, :source_exts
+    attr_accessor :label, :flags, :include_paths, :defines, :source_exts
     attr_accessor :compile_options, :option_define, :option_include_path, :out_ext
     attr_accessor :cxx_compile_flag, :cxx_exception_flag, :cxx_invalid_flags
 
-    def initialize(build, source_exts=[])
+    def initialize(build, source_exts=[], label: "CC")
       super(build)
       @command = ENV['CC'] || 'cc'
+      @label = label
       @flags = [ENV['CFLAGS'] || []]
       @source_exts = source_exts
       @include_paths = ["#{MRUBY_ROOT}/include"]
@@ -78,7 +79,7 @@ module MRuby
 
     def run(outfile, infile, _defines=[], _include_paths=[], _flags=[])
       mkdir_p File.dirname(outfile)
-      _pp "CC", infile.relative_path, outfile.relative_path
+      _pp @label, infile.relative_path, outfile.relative_path
       _run compile_options, { :flags => all_flags(_defines, _include_paths, _flags),
                               :infile => filename(infile), :outfile => filename(outfile) }
     end


### PR DESCRIPTION
For example, in the case of the C++ compiler, it is output as
`CXX  build/host/src/gc.cxx -> build/host/src/gc.cxx.o` (FYI, in the case
of `enable_cxx_abi`, it outputs `CC ...` because the option to compile as
C++ is added to C compiler).