### PR TITLE
Fix build failure; ref #5194

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -93,7 +93,9 @@ MRuby.each_target do |target|
 end
 
 desc "preallocated symbols"
-task :gensym => MRuby.targets.values.map(&:presym_file)
+task :gensym do
+  MRuby.each_target{|build| Rake::Task[build.presym_file].invoke}
+end
 
 depfiles += MRuby.targets.map { |n, t|
   t.libraries

--- a/tasks/presym.rake
+++ b/tasks/presym.rake
@@ -41,11 +41,9 @@ macro_to_symbol = {
   [""    , ""    ] => [""    , ""    ],
 }
 
-core_cfiles = nil
-core_rbfiles = nil
+core_cfiles = Dir.glob("#{MRUBY_ROOT}/src/*.c")
+core_rbfiles = Dir.glob("#{MRUBY_ROOT}/mrblib/*.rb")
 MRuby.each_target do |build|
-  core_cfiles ||= Dir.glob("#{MRUBY_ROOT}/src/*.c")
-  core_rbfiles ||= Dir.glob("#{MRUBY_ROOT}/mrblib/*.rb")
   cfiles = core_cfiles.dup
   rbfiles = core_rbfiles.dup
   psfiles = []
@@ -58,8 +56,8 @@ MRuby.each_target do |build|
     if gem.cdump?
       rbfiles.concat(gem.rbfiles)
       psfiles.concat(Dir.glob(gem.dir+"/**/presym"))
-      gem.compilers.each {|c| c.include_paths << "#{build.build_dir}/include"}
     end
+    gem.compilers.each {|c| c.include_paths << "#{build.build_dir}/include"}
   end
 
   file presym_file => [*cfiles, *rbfiles, *psfiles, __FILE__] do


### PR DESCRIPTION
Fix the following two issues:

1. Compile failure when external gem is specified.
   * https://github.com/mruby/mruby/pull/5194#issuecomment-734303442
2. When there are multiple build targets, presym parsing sometimes fails or
   output result of presym is broken.
   * https://github.com/mruby/mruby/pull/5194#issuecomment-734322142

The root cause of 2 is unknown, but it seems to occur when presym parsing is
performed in parallel, therefore I change them so that they are not run in
parallel.