### PR TITLE
Remove unused Rake rules

### DIFF
--- a/lib/mruby/build.rb
+++ b/lib/mruby/build.rb
@@ -277,8 +277,8 @@ EOS
           compiler.defines += %w(MRB_NO_GEMS)
         end
         compiler.defines |= %w(MRB_USE_DEBUG_HOOK) if use_mrdb
-        compiler.define_rules build_dir, File.expand_path(File.join(File.dirname(__FILE__), '..', '..'))
       end
+      cc.define_rules(build_dir, MRUBY_ROOT)
     end
 
     def filename(name)


### PR DESCRIPTION
Currently, the source file language in the core is C only, and C++,
Objective-C, and Assembly are not used, so Rake rules for them are removed.