### PR TITLE
Fix heap buffer overflow when dump irep

### DIFF
--- a/src/dump.c
+++ b/src/dump.c
@@ -293,6 +293,7 @@ get_irep_record_size_1(mrb_state *mrb, const mrb_irep *irep)
   size_t size = 0;
 
   size += get_irep_header_size(mrb);
+  size += sizeof(uint16_t);
   size += get_iseq_block_size(mrb, irep);
   size += get_catch_table_block_size(mrb, irep);
   size += get_pool_block_size(mrb, irep);


### PR DESCRIPTION
Currently, the size of writing in heap by write_irep_record() is bigger than The size that is calculated by get_irep_record_size.

Therefore, irep is dumped over the size of allocating memory when we execute dump_irep().

### Reproduce

`rake test` fail by the buffer overflow.
I used fc98aa290f6256ea64ca7792af483d4d31131cd5 in the following procedure.

```
% git clone git@github.com:kou/mruby-pp.git
% cd mruby-pp
% git submodule update --init
% git submodule update --remote
% rake test
% gdb --args "./mruby/build/host/bin/mrbc" -Bgem_mrblib_irep_mruby_pp -o- "./mrblib/0_prettyprint.rb" "./mrblib/1_pp.rb"
(gdb) b dump.c:804
(gdb) b dump.c:835
(gdb) start
(gdb) c
(gdb) p section_irep_size
$1 = 11990
(gdb) c
(gdb) p section_irep_size
$2 = 12002
```

### Cause

mruby write the following data in write_irep_record().

```
bin += uint16_to_bin(irep->clen, bin);
```

However, the size that is calclated by get_irep_record_size() doesn't include the size of `uint16_to_bin(irep->clen, bin)` as below.

```
static size_t
get_irep_record_size_1(mrb_state *mrb, const mrb_irep *irep)
{
  size_t size = 0;

  size += get_irep_header_size(mrb);
  size += get_iseq_block_size(mrb, irep);
  size += get_catch_table_block_size(mrb, irep);
  size += get_pool_block_size(mrb, irep);
  size += get_syms_block_size(mrb, irep);
  return size;
}
```
