### PR TITLE
Remove `build/presym{,.inc}` by `rake clean` [ci skip]

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -278,6 +278,8 @@ task :clean do
     rm_rf t.build_dir
   end
   rm_f depfiles
+  rm_f presym_file
+  rm_f presym_inc
   puts "Cleaned up target build folder"
 end
 
@@ -286,7 +288,5 @@ task :deep_clean => ["clean", "clean_doc"] do
   MRuby.each_target do |t|
     rm_rf t.gem_clone_dir
   end
-  rm_f presym_file
-  rm_f presym_inc
   puts "Cleaned up mrbgems build folder"
 end


### PR DESCRIPTION
Currently, adding gems to build configuration and rebuilding does not
regenerate `presym`, which can lead to build errors.

Therefore in this case we need to remove the `presym` file and then rebuild
mruby, but when the` presym` file is regenerated we will need to recompile
most of the files, so it seems useful to have the `presym` file deleted by
`rake clean`.