### PR TITLE
Make it possible that `libmruby.a` is not created

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -230,7 +230,7 @@ desc "preallocated symbols"
 task :gensym => presym_file
 
 depfiles += MRuby.targets.map { |n, t|
-  t.libraries
+  t.libmruby_enabled? ? t.libraries : t.libmruby_core_static
 }.flatten
 
 depfiles += MRuby.targets.reject { |n, t| n == 'host' }.map { |n, t|

--- a/build_config/no-float.rb
+++ b/build_config/no-float.rb
@@ -1,9 +1,3 @@
-MRuby::Build.new("host") do |conf|
-  # load specific toolchain settings
-  toolchain :gcc
-  conf.gem :core => "mruby-bin-mrbc"
-end
-
 # Define cross build settings
 MRuby::CrossBuild.new('no-float') do |conf|
   toolchain :gcc

--- a/lib/mruby/gem.rb
+++ b/lib/mruby/gem.rb
@@ -353,6 +353,10 @@ module MRuby
         @ary.each(&b)
       end
 
+      def [](name)
+        @ary.detect {|g| g.name == name}
+      end
+
       def <<(gem)
         unless @ary.detect {|g| g.dir == gem.dir }
           @ary << gem

--- a/mrbgems/default.gembox
+++ b/mrbgems/default.gembox
@@ -78,6 +78,9 @@ MRuby::GemBox.new do |conf|
   conf.gem :core => "mruby-rational"
   conf.gem :core => "mruby-complex"
 
+  # Generate mrbc command
+  conf.gem :core => "mruby-bin-mrbc"
+
   # Generate mirb command
   conf.gem :core => "mruby-bin-mirb"
 

--- a/mrbgems/mruby-bin-mrbc/mrbgem.rake
+++ b/mrbgems/mruby-bin-mrbc/mrbgem.rake
@@ -2,15 +2,14 @@ MRuby::Gem::Specification.new 'mruby-bin-mrbc' do |spec|
   spec.license = 'MIT'
   spec.author  = 'mruby developers'
   spec.summary = 'mruby compiler executable'
-
   spec.add_dependency 'mruby-compiler', :core => 'mruby-compiler'
 
   exec = exefile("#{build.build_dir}/bin/mrbc")
-  mrbc_objs = Dir.glob("#{spec.dir}/tools/mrbc/*.c").map { |f| objfile(f.pathmap("#{spec.build_dir}/tools/mrbc/%n")) }.flatten
+  mrbc_objs = Dir.glob("#{spec.dir}/tools/mrbc/*.c").map { |f| objfile(f.pathmap("#{spec.build_dir}/tools/mrbc/%n")) }
 
-  file exec => mrbc_objs + [build.libmruby_core_static] do |t|
+  file exec => mrbc_objs << build.libmruby_core_static do |t|
     build.linker.run t.name, t.prerequisites
   end
 
-  build.bins << 'mrbc' unless build.bins.find { |v| v == 'mrbc' }
+  build.bins << 'mrbc'
 end

--- a/mrbgems/mruby-compiler/mrbgem.rake
+++ b/mrbgems/mruby-compiler/mrbgem.rake
@@ -3,20 +3,18 @@ MRuby::Gem::Specification.new 'mruby-compiler' do |spec|
   spec.author  = 'mruby developers'
   spec.summary = 'mruby compiler library'
 
-  lex_def = "#{dir}/core/lex.def"
-  core_objs = Dir.glob("#{dir}/core/*.c").map { |f|
-    next nil if build.cxx_exception_enabled? and f =~ /(codegen|y\.tab)\.c$/
-    objfile(f.pathmap("#{build_dir}/core/%n"))
-  }.compact
-
-  if build.cxx_exception_enabled?
-    core_objs <<
-      build.compile_as_cxx("#{dir}/core/y.tab.c", "#{build_dir}/core/y.tab.cxx",
-                           objfile("#{build_dir}/y.tab"), ["#{dir}/core"]) <<
-      build.compile_as_cxx("#{dir}/core/codegen.c", "#{build_dir}/core/codegen.cxx")
-  else
-    core_objs << objfile("#{build_dir}/core/y.tab")
+  as_cxx_srcs = %w[codegen y.tab].map{|name| "#{dir}/core/#{name}.c"}
+  objs = Dir.glob("#{dir}/core/*.c").map do |src|
+    dst = src.pathmap("#{build_dir}/core/%n")
+    if build.cxx_exception_enabled? && as_cxx_srcs.include?(src)
+      build.compile_as_cxx(src, "#{dst}.cxx")
+    else
+      objfile(dst)
+    end
   end
+  build.libmruby_core_objs << objs
+
+  lex_def = "#{dir}/core/lex.def"
 
   # Parser
   file "#{dir}/core/y.tab.c" => ["#{dir}/core/parse.y", lex_def] do |t|
@@ -29,9 +27,6 @@ MRuby::Gem::Specification.new 'mruby-compiler' do |spec|
     gperf.run t.name, t.prerequisites.first
     replace_line_directive(t.name)
   end
-
-  file build.libmruby_core_static => core_objs
-  build.libmruby << core_objs
 
   def replace_line_directive(path)
     content = File.read(path).gsub(%r{

--- a/tasks/core.rake
+++ b/tasks/core.rake
@@ -9,9 +9,5 @@ MRuby.each_target do
       objfile(dst)
     end
   end
-  self.libmruby_objs << objs
-
-  file libmruby_core_static => objs do |t|
-    archiver.run t.name, t.prerequisites
-  end
+  self.libmruby_core_objs << objs
 end

--- a/tasks/libmruby.rake
+++ b/tasks/libmruby.rake
@@ -1,4 +1,10 @@
 MRuby.each_target do
+  file libmruby_core_static => libmruby_core_objs.flatten do |t|
+    archiver.run t.name, t.prerequisites
+  end
+
+  next unless libmruby_enabled?
+
   file libmruby_static => libmruby_objs.flatten do |t|
     archiver.run t.name, t.prerequisites
   end

--- a/tasks/mrblib.rake
+++ b/tasks/mrblib.rake
@@ -1,4 +1,6 @@
 MRuby.each_target do
+  next unless libmruby_enabled?
+
   src = "#{build_dir}/mrblib/mrblib.c"
   obj = objfile(src.ext)
   rbfiles = Dir["#{MRUBY_ROOT}/mrblib/*.rb"].sort!


### PR DESCRIPTION
Previously, `libmruby.a` was created even if only `mruby-bin-mrbc` or`
mruby-compiler` was specified for gem, but by specifying `disable_libmruby`,
the creation of `libmruby.a` can be suppressed.

### Note

The https://github.com/mruby/mruby/pull/5084#issuecomment-723521971
incompatibility seems to be difficult for users to avoid, so the original
behavior has been restored. Therefore, if we need `mrbc` other than the
`host` build, we need to explicitly specify `mruby-bin-mrbc` gem.

Due to the above changes, `build_config/boxing.rb` etc. will not work, but I
have added` mruby-bin-mrbc` to `default.gembox` to fix it. I don't think
this change is a big deal because originally `mruby-compiler` was included.