### PR TITLE
Call `super` before creating `host` build in `MRuby::CrossBuild#initialize`

### DIFF
--- a/lib/mruby/build.rb
+++ b/lib/mruby/build.rb
@@ -390,6 +390,8 @@ EOS
     attr_accessor :host_target, :build_target
 
     def initialize(name, build_dir=nil, &block)
+      @test_runner = Command::CrossTestRunner.new(self)
+      super
       unless MRuby.targets['host']
         # add minimal 'host'
         MRuby::Build.new('host') do |conf|
@@ -402,8 +404,6 @@ EOS
           conf.disable_libmruby
         end
       end
-      @test_runner = Command::CrossTestRunner.new(self)
-      super
     end
 
     def mrbcfile


### PR DESCRIPTION
Call `super` (`block`) ahead so that creation of the `host` build can be
skipped if pre-built `mrbc` can be specified in the future.

close #5213.