### PR TITLE
Suppress `-Wtautological-compare` warning

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -66,7 +66,7 @@ mrb_debug_get_filename(mrb_state *mrb, const mrb_irep *irep, ptrdiff_t pc)
 MRB_API int32_t
 mrb_debug_get_line(mrb_state *mrb, const mrb_irep *irep, size_t pc)
 {
-  if (irep && pc >= 0 && pc < irep->ilen) {
+  if (irep && pc < irep->ilen) {
     mrb_irep_debug_info_file* f = NULL;
     if (!irep->debug_info) {
       return -1;


### PR DESCRIPTION
```console
/mruby/src/debug.c:69:18: warning: comparison of unsigned expression >= 0 is always true [-Wtautological-compare]
  if (irep && pc >= 0 && pc < irep->ilen) {
              ~~ ^  ~
```