### PR TITLE
Improve source scanning for presym

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -25,12 +25,11 @@ end
 # load custom rules
 load "#{MRUBY_ROOT}/tasks/core.rake"
 load "#{MRUBY_ROOT}/tasks/mrblib.rake"
-
 load "#{MRUBY_ROOT}/tasks/mrbgems.rake"
 load "#{MRUBY_ROOT}/tasks/libmruby.rake"
-
+load "#{MRUBY_ROOT}/tasks/bin.rake"
+load "#{MRUBY_ROOT}/tasks/presym.rake"
 load "#{MRUBY_ROOT}/tasks/benchmark.rake"
-
 load "#{MRUBY_ROOT}/tasks/gitlab.rake"
 load "#{MRUBY_ROOT}/tasks/doc.rake"
 
@@ -38,219 +37,19 @@ load "#{MRUBY_ROOT}/tasks/doc.rake"
 # generic build targets, rules
 task :default => :all
 
-bin_path = ENV['INSTALL_DIR'] || "#{MRUBY_ROOT}/bin"
-
-if MRuby.targets['host']
-  target = MRuby.targets['host']
-  depfiles = target.bins.map do |bin|
-    install_path = target.exefile("#{bin_path}/#{bin}")
-    source_path = target.exefile("#{target.build_dir}/bin/#{bin}")
-
-    file install_path => source_path do |t|
-      install_D t.prerequisites.first, t.name
-    end
-    install_path
-  end
-else
-  depfiles = []
-end
-
-cfiles  = Dir.glob("#{MRUBY_ROOT}/src/*.c")
-rbfiles = Dir.glob("#{MRUBY_ROOT}/mrblib/**/*.rb")
-psfiles = []
-MRuby.each_target do |target|
-  gems.each do |gem|
-    current_dir = gem.dir.relative_path_from(Dir.pwd)
-    relative_from_root = gem.dir.relative_path_from(MRUBY_ROOT)
-    current_build_dir = File.expand_path "#{build_dir}/#{relative_from_root}"
-
-    if current_build_dir !~ /^#{Regexp.escape(build_dir)}/
-      current_build_dir = "#{build_dir}/mrbgems/#{gem.name}"
-    end
-
-    gem.bins.each do |bin|
-      exec = exefile("#{build_dir}/bin/#{bin}")
-      objs = Dir.glob("#{current_dir}/tools/#{bin}/*.{c,cpp,cxx,cc}").map { |f| objfile(f.pathmap("#{current_build_dir}/tools/#{bin}/%n")) }
-
-      file exec => objs + target.libraries do |t|
-        gem_flags = gems.map { |g| g.linker.flags }
-        gem_flags_before_libraries = gems.map { |g| g.linker.flags_before_libraries }
-        gem_flags_after_libraries = gems.map { |g| g.linker.flags_after_libraries }
-        gem_libraries = gems.map { |g| g.linker.libraries }
-        gem_library_paths = gems.map { |g| g.linker.library_paths }
-        linker.run t.name, t.prerequisites, gem_libraries, gem_library_paths, gem_flags, gem_flags_before_libraries, gem_flags_after_libraries
-      end
-
-      if target == MRuby.targets['host']
-        install_path = MRuby.targets['host'].exefile("#{bin_path}/#{bin}")
-
-        file install_path => exec do |t|
-          install_D t.prerequisites.first, t.name
-        end
-        depfiles += [ install_path ]
-      else
-        depfiles += [ exec ]
-      end
-    end
-
-    cfiles += Dir.glob(gem.dir+"/{src,core,tools/*}/*.c")
-    if gem.cdump?
-      rbfiles += Dir.glob(gem.dir+"/mrblib/**/*.rb")
-      psfiles += Dir.glob(gem.dir+"/**/presym")
-    end
-  end
-end
-
-mkdir_p "#{MRUBY_ROOT}/build"
-symbols = []
-psfiles.each do |file|
-  symbols += File.readlines(file).grep_v(/^# /)
-end
-symbols.each{|x| x.chomp!}
-presym_file="#{MRUBY_ROOT}/build/presym"
-presym_inc="#{presym_file}.inc"
-op_table = {
-  "!" => "not",
-  "!=" => "neq",
-  "!~" => "nmatch",
-  "%" => "mod",
-  "&" => "and",
-  "&&" => "andand",
-  "*" => "mul",
-  "**" => "pow",
-  "+" => "add",
-  "+@" => "plus",
-  "-" => "sub",
-  "-@" => "minus",
-  "/" => "div",
-  "<" => "lt",
-  "<=" => "le",
-  "<<" => "lshift",
-  "<=>" => "cmp",
-  "==" => "eq",
-  "===" => "eqq",
-  "=~" => "match",
-  ">" => "gt",
-  ">=" => "ge",
-  ">>" => "rshift",
-  "[]" => "aref",
-  "[]=" => "aset",
-  "^" => "xor",
-  "`" => "tick",
-  "|" => "or",
-  "||" => "oror",
-  "~" => "neg",
-}
-macro_to_symbol = {
-#      Macro               Symbol
-# [prefix, suffix] => [prefix, suffix]
-  ["CV"  , ""    ] => ["@@"  , ""    ],
-  ["IV"  , ""    ] => ["@"   , ""    ],
-  [""    , "_B"  ] => [""    , "!"   ],
-  [""    , "_Q"  ] => [""    , "?"   ],
-  [""    , "_E"  ] => [""    , "="   ],
-  [""    , ""    ] => [""    , ""    ],
-}
-
-file presym_file => cfiles+rbfiles+psfiles+[__FILE__] do
-  prefix_re = Regexp.union(*macro_to_symbol.keys.map(&:first).uniq)
-  suffix_re = Regexp.union(*macro_to_symbol.keys.map(&:last).uniq)
-  macro_re = /MRB_(#{prefix_re})SYM(#{suffix_re})\((\w+)\)/o
-  csymbols = cfiles.map do |f|
-    src = File.read(f)
-    src.gsub!(/\/\/.+(\n|$)/, "\n")
-    [src.scan(/intern_lit\([^\n"]*"([^\n "]*)"/),
-     src.scan(/mrb_define_method\([^\n"]*"([^\n"]*)"/),
-     src.scan(/mrb_define_class_method\([^\n"]*"([^\n"]*)"/),
-     src.scan(/mrb_define_class\([^\n"]*"([^\n"]*)"/),
-     src.scan(/mrb_define_module\([^\n"]*"([^\n"]*)"/),
-     src.scan(/mrb_define_module_function\([^\n"]*"([^\n"]*)"/),
-     src.scan(/mrb_define_const\([^\n"]*"([^\n"]*)"/),
-     src.scan(/mrb_define_global_const\([^\n"]*"([^\n"]*)"/),
-     src.scan(macro_re).map{|prefix, suffix, name|
-       macro_to_symbol[[prefix, suffix]] * name
-     }]
-  end
-  csymbols += File.readlines("#{MRUBY_ROOT}/include/mruby.h").grep(/define E_/).join.scan(/MRB_SYM\((\w+)\)/)
-
-  rbsymbols = rbfiles.map do |f|
-    src = File.read(f)
-    src.force_encoding(Encoding::BINARY)
-    [src.scan(/\bclass +([A-Z]\w*)/),
-     src.scan(/\bmodule +([A-Z]\w*)/),
-     src.scan(/\bdef +(\w+[!?=]?)/),
-     src.scan(/\balias +(\w+[!?]?)/),
-     src.scan(/\b([A-Z]\w*) *=[^=]/),
-     src.scan(/(\$[a-zA-Z_]\w*)/),
-     src.scan(/(\$[$!?0-9]\w*)/),
-     src.scan(/(@@?[a-zA-Z_]\w*)/),
-     src.scan(/[^.]\.([a-zA-Z_]\w*[!?]?)/),
-     src.scan(/\.([a-zA-Z_]\w* *=)/).map{|x|x.map{|s|s.gsub(' ', '')}},
-     src.scan(/\b([a-zA-Z_]\w*):/),
-     src.scan(/:([a-zA-Z_]\w*[!?=]?)/),
-     src.scan(/[\(\[\{ ]:"([^"]+)"/).map{|x|x.map{|s|s.gsub('\#', '#')}},
-     src.scan(/[ \(\[\{]:'([^']+)'/)
-    ]
-  end
-  symbols = (symbols+csymbols+rbsymbols+op_table.keys).flatten.compact.uniq.grep_v(/#/).map{|x| x.gsub("\n", '\n')}.sort_by!{|x| [x.bytesize, x]}
-  presyms = File.readlines(presym_file) rescue []
-  presyms.each{|x| x.chomp!}
-  if presyms != symbols
-    _pp "GEN", presym_file.relative_path
-    File.write(presym_file, symbols.join("\n"))
-    Rake::Task[presym_inc].invoke
-  end
-end
-
-task presym_inc do
-  presyms = File.readlines(presym_file)
-  presyms.each{|x| x.chomp!}
-  symbol_to_macro = macro_to_symbol.invert
-  prefix_re = Regexp.union(*symbol_to_macro.keys.map(&:first).uniq)
-  suffix_re = Regexp.union(*symbol_to_macro.keys.map(&:last).uniq)
-  sym_re = /\A(#{prefix_re})?([\w&&\D]\w*)(#{suffix_re})?\z/o
-  _pp "GEN", presym_inc.relative_path
-  File.open(presym_inc, "w") do |f|
-    f.puts "/* MRB_PRESYM_NAMED(lit, num, type, name) */"
-    f.puts "/* MRB_PRESYM_UNNAMED(lit, num) */"
-    presyms.each.with_index(1) do |sym, num|
-      if sym_re =~ sym && (affixes = symbol_to_macro[[$1, $3]])
-        f.puts %|MRB_PRESYM_NAMED("#{sym}", #{num}, #{affixes * 'SYM'}, #{$2})|
-      elsif name = op_table[sym]
-        f.puts %|MRB_PRESYM_NAMED("#{sym}", #{num}, OPSYM, #{name})|
-      elsif
-        f.puts %|MRB_PRESYM_UNNAMED("#{sym}", #{num})|
-      end
-    end
-    f.print "#define MRB_PRESYM_MAX #{presyms.size}"
-  end
-end
-
-desc "preallocated symbols"
-task :gensym => presym_file
-
-depfiles += MRuby.targets.map { |n, t|
-  t.libmruby_enabled? ? t.libraries : t.libmruby_core_static
-}.flatten
-
-depfiles += MRuby.targets.reject { |n, t| n == 'host' }.map { |n, t|
-  t.bins.map { |bin| t.exefile("#{t.build_dir}/bin/#{bin}") }
-}.flatten
-
 desc "build all targets, install (locally) in-repo"
-task :all => :build do
+task :all => :gensym do
+  Rake::Task[:build].invoke
   puts
   puts "Build summary:"
   puts
-  MRuby.each_target do
-    print_build_summary
+  MRuby.each_target do |build|
+    build.print_build_summary
   end
   MRuby::Lockfile.write
 end
 
-task :build => :gensym do
-  depfiles.each {|dep| Rake::Task[dep].invoke}
-end
+task :build => MRuby.targets.flat_map{|_, build| build.products}
 
 desc "run all mruby tests"
 task :test
@@ -274,19 +73,17 @@ end
 
 desc "clean all built and in-repo installed artifacts"
 task :clean do
-  MRuby.each_target do |t|
-    rm_rf t.build_dir
+  MRuby.each_target do |build|
+    rm_rf build.products
+    rm_rf build.build_dir
   end
-  rm_f depfiles
-  rm_f presym_file
-  rm_f presym_inc
   puts "Cleaned up target build folder"
 end
 
 desc "clean everything!"
 task :deep_clean => ["clean", "clean_doc"] do
-  MRuby.each_target do |t|
-    rm_rf t.gem_clone_dir
+  MRuby.each_target do |build|
+    rm_rf build.gem_clone_dir
   end
   puts "Cleaned up mrbgems build folder"
 end

--- a/build_config/appveyor.rb
+++ b/build_config/appveyor.rb
@@ -1,6 +1,6 @@
 def setup_option(conf)
-  conf.cc.flags[0].delete("/Zi") unless ENV['CFLAGS']
-  conf.cxx.flags[0].delete("/Zi") unless ENV['CFLAGS'] || ENV['CXXFLAGS']
+  conf.cc.compile_options.sub!(%r{/Zi }, "") unless ENV['CFLAGS']
+  conf.cxx.compile_options.sub!(%r{/Zi }, "") unless ENV['CFLAGS'] || ENV['CXXFLAGS']
   conf.linker.flags << "/DEBUG:NONE" unless ENV['LDFLAGS']
 end
 

--- a/build_config/mrbc.rb
+++ b/build_config/mrbc.rb
@@ -1,0 +1,11 @@
+MRuby::Build.new do |conf|
+  if ENV['VisualStudioVersion'] || ENV['VSINSTALLDIR']
+    conf.toolchain :visualcpp
+  else
+    conf.toolchain :gcc
+  end
+
+  conf.build_mrbc_exec
+  conf.disable_libmruby
+  conf.disable_presym
+end

--- a/include/mruby.h
+++ b/include/mruby.h
@@ -93,7 +93,6 @@
 #include <mruby/common.h>
 #include <mruby/value.h>
 #include <mruby/gc.h>
-#include <mruby/presym.h>
 #include <mruby/version.h>
 
 #ifndef MRB_NO_FLOAT
@@ -1409,6 +1408,8 @@ MRB_API void mrb_show_version(mrb_state *mrb);
 MRB_API void mrb_show_copyright(mrb_state *mrb);
 
 MRB_API mrb_value mrb_format(mrb_state *mrb, const char *format, ...);
+
+#include <mruby/presym.h>
 
 #if 0
 /* memcpy and memset does not work with gdb reverse-next on my box */

--- a/include/mruby/presym.h
+++ b/include/mruby/presym.h
@@ -7,42 +7,36 @@
 #ifndef MRUBY_PRESYM_H
 #define MRUBY_PRESYM_H
 
-#undef MRB_PRESYM_MAX
-#ifdef MRB_USE_ALL_SYMBOLS
-#define MRB_PRESYM_NAMED(lit, num, type, name) MRB_##type##__##name = (num),
+#if defined(MRB_PRESYM_SCANNING)
+# include <mruby/presym/scanning.h>
+#elif defined(MRB_NO_PRESYM)
+# include <mruby/presym/disable.h>
 #else
-#define MRB_PRESYM_NAMED(lit, num, type, name) MRB_##type##__##name = (num<<1),
+# include <mruby/presym/enable.h>
 #endif
-#define MRB_PRESYM_UNNAMED(lit, num)
-
-enum mruby_presym {
-#include <../build/presym.inc>
-};
-
-#undef MRB_PRESYM_NAMED
-#undef MRB_PRESYM_UNNAMED
 
 /*
- * For `MRB_OPSYM`, specify the names corresponding to operators (refer to
- * `op_table` in `Rakefile` for the names that can be specified for it).
- * Other than that, describe only word characters excluding leading and
- * ending punctuations.
+ * Where `mrb_intern_lit` is allowed for symbol interning, it is directly
+ * replaced by the symbol ID if presym is enabled by using the following
+ * macros.
  *
- * Example:
- *   MRB_OPSYM(and)  //=> &
- *   MRB_CVSYM(foo)  //=> @@foo
- *   MRB_IVSYM(foo)  //=> @foo
- *   MRB_SYM_B(foo)  //=> foo!
- *   MRB_SYM_Q(foo)  //=> foo?
- *   MRB_SYM_E(foo)  //=> foo=
- *   MRB_SYM(foo)    //=> foo
+ *   MRB_OPSYM(xor)  //=> ^      (Operator)
+ *   MRB_CVSYM(xor)  //=> @@xor  (Class Variable)
+ *   MRB_IVSYM(xor)  //=> @xor   (Instance Variable)
+ *   MRB_SYM_B(xor)  //=> xor!   (Method with Bang)
+ *   MRB_SYM_Q(xor)  //=> xor?   (Method with Question mark)
+ *   MRB_SYM_E(xor)  //=> xor=   (Method with Equal)
+ *   MRB_SYM(xor)    //=> xor    (Word characters)
+ *
+ * For `MRB_OPSYM`, specify the names corresponding to operators (see
+ * `MRuby::Presym::OPERATORS` in `lib/mruby/presym.rb for the names that can
+ * be specified for it). Other than that, describe only word characters
+ * excluding leading and ending punctuations.
+ *
+ * These macros are expanded to `mrb_intern_lit` if presym is disabled,
+ * therefore the mruby state variable is required. The above macros can be
+ * used when the variable name is `mrb`. If you want to use other variable
+ * names, you need to use macros with `_2` suffix, such as `MRB_SYM_2`.
  */
-#define MRB_OPSYM(name) MRB_OPSYM__##name  /* Operator */
-#define MRB_CVSYM(name) MRB_CVSYM__##name  /* Class Variable */
-#define MRB_IVSYM(name) MRB_IVSYM__##name  /* Instance Variable */
-#define MRB_SYM_B(name) MRB_SYM_B__##name  /* Method with Bang */
-#define MRB_SYM_Q(name) MRB_SYM_Q__##name  /* Method with Question mark */
-#define MRB_SYM_E(name) MRB_SYM_E__##name  /* Method with Equal */
-#define MRB_SYM(name)   MRB_SYM__##name    /* Word characters */
 
 #endif  /* MRUBY_PRESYM_H */

--- a/include/mruby/presym/disable.h
+++ b/include/mruby/presym/disable.h
@@ -1,0 +1,68 @@
+/**
+** @file mruby/presym/scanning.h - Disable Preallocated Symbols
+**
+** See Copyright Notice in mruby.h
+*/
+
+#ifndef MRUBY_PRESYM_DISABLE_H
+#define MRUBY_PRESYM_DISABLE_H
+
+#include <string.h>
+
+#define MRB_PRESYM_MAX 0
+
+#define MRB_OPSYM(name) MRB_OPSYM__##name(mrb)
+#define MRB_CVSYM(name) mrb_intern_lit(mrb, "@@" #name)
+#define MRB_IVSYM(name) mrb_intern_lit(mrb, "@" #name)
+#define MRB_SYM_B(name) mrb_intern_lit(mrb, #name "!")
+#define MRB_SYM_Q(name) mrb_intern_lit(mrb, #name "?")
+#define MRB_SYM_E(name) mrb_intern_lit(mrb, #name "=")
+#define MRB_SYM(name) mrb_intern_lit(mrb, #name)
+
+#define MRB_OPSYM_2(mrb, name) MRB_OPSYM__##name(mrb)
+#define MRB_CVSYM_2(mrb, name) mrb_intern_lit(mrb, "@@" #name)
+#define MRB_IVSYM_2(mrb, name) mrb_intern_lit(mrb, "@" #name)
+#define MRB_SYM_B_2(mrb, name) mrb_intern_lit(mrb, #name "!")
+#define MRB_SYM_Q_2(mrb, name) mrb_intern_lit(mrb, #name "?")
+#define MRB_SYM_E_2(mrb, name) mrb_intern_lit(mrb, #name "=")
+#define MRB_SYM_2(mrb, name) mrb_intern_lit(mrb, #name)
+
+#define MRB_OPSYM__not(mrb) mrb_intern_lit(mrb, "!")
+#define MRB_OPSYM__mod(mrb) mrb_intern_lit(mrb, "%")
+#define MRB_OPSYM__and(mrb) mrb_intern_lit(mrb, "&")
+#define MRB_OPSYM__mul(mrb) mrb_intern_lit(mrb, "*")
+#define MRB_OPSYM__add(mrb) mrb_intern_lit(mrb, "+")
+#define MRB_OPSYM__sub(mrb) mrb_intern_lit(mrb, "-")
+#define MRB_OPSYM__div(mrb) mrb_intern_lit(mrb, "/")
+#define MRB_OPSYM__lt(mrb) mrb_intern_lit(mrb, "<")
+#define MRB_OPSYM__gt(mrb) mrb_intern_lit(mrb, ">")
+#define MRB_OPSYM__xor(mrb) mrb_intern_lit(mrb, "^")
+#define MRB_OPSYM__tick(mrb) mrb_intern_lit(mrb, "`")
+#define MRB_OPSYM__or(mrb) mrb_intern_lit(mrb, "|")
+#define MRB_OPSYM__neg(mrb) mrb_intern_lit(mrb, "~")
+#define MRB_OPSYM__neq(mrb) mrb_intern_lit(mrb, "!=")
+#define MRB_OPSYM__nmatch(mrb) mrb_intern_lit(mrb, "!~")
+#define MRB_OPSYM__andand(mrb) mrb_intern_lit(mrb, "&&")
+#define MRB_OPSYM__pow(mrb) mrb_intern_lit(mrb, "**")
+#define MRB_OPSYM__plus(mrb) mrb_intern_lit(mrb, "+@")
+#define MRB_OPSYM__minus(mrb) mrb_intern_lit(mrb, "-@")
+#define MRB_OPSYM__lshift(mrb) mrb_intern_lit(mrb, "<<")
+#define MRB_OPSYM__le(mrb) mrb_intern_lit(mrb, "<=")
+#define MRB_OPSYM__eq(mrb) mrb_intern_lit(mrb, "==")
+#define MRB_OPSYM__match(mrb) mrb_intern_lit(mrb, "=~")
+#define MRB_OPSYM__ge(mrb) mrb_intern_lit(mrb, ">=")
+#define MRB_OPSYM__rshift(mrb) mrb_intern_lit(mrb, ">>")
+#define MRB_OPSYM__aref(mrb) mrb_intern_lit(mrb, "[]")
+#define MRB_OPSYM__oror(mrb) mrb_intern_lit(mrb, "||")
+#define MRB_OPSYM__cmp(mrb) mrb_intern_lit(mrb, "<=>")
+#define MRB_OPSYM__eqq(mrb) mrb_intern_lit(mrb, "===")
+#define MRB_OPSYM__aset(mrb) mrb_intern_lit(mrb, "[]=")
+
+#define MRB_PRESYM_DEFINE_VAR_AND_INITER(name, size, ...)                     \
+  static mrb_sym name[size];                                                  \
+  static void init_##name(mrb_state *mrb) {                                   \
+    mrb_sym name__[] = {__VA_ARGS__};                                         \
+    memcpy(name, name__, sizeof(name));                                       \
+  }
+
+#endif  /* MRUBY_PRESYM_DISABLE_H */

--- a/include/mruby/presym/enable.h
+++ b/include/mruby/presym/enable.h
@@ -1,0 +1,45 @@
+/**
+** @file mruby/presym/scanning.h - Enable Preallocated Symbols
+**
+** See Copyright Notice in mruby.h
+*/
+
+#ifndef MRUBY_PRESYM_ENABLE_H
+#define MRUBY_PRESYM_ENABLE_H
+
+#undef MRB_PRESYM_MAX
+#ifdef MRB_USE_ALL_SYMBOLS
+# define MRB_PRESYM_NAMED(lit, num, type, name) MRB_##type##__##name = (num),
+#else
+# define MRB_PRESYM_NAMED(lit, num, type, name) MRB_##type##__##name = (num<<1),
+#endif
+#define MRB_PRESYM_UNNAMED(lit, num)
+
+enum mruby_presym {
+# include <mruby/presym.inc>
+};
+
+#undef MRB_PRESYM_NAMED
+#undef MRB_PRESYM_UNNAMED
+
+#define MRB_OPSYM(name) MRB_OPSYM__##name
+#define MRB_CVSYM(name) MRB_CVSYM__##name
+#define MRB_IVSYM(name) MRB_IVSYM__##name
+#define MRB_SYM_B(name) MRB_SYM_B__##name
+#define MRB_SYM_Q(name) MRB_SYM_Q__##name
+#define MRB_SYM_E(name) MRB_SYM_E__##name
+#define MRB_SYM(name) MRB_SYM__##name
+
+#define MRB_OPSYM_2(mrb, name) MRB_OPSYM__##name
+#define MRB_CVSYM_2(mrb, name) MRB_CVSYM__##name
+#define MRB_IVSYM_2(mrb, name) MRB_IVSYM__##name
+#define MRB_SYM_B_2(mrb, name) MRB_SYM_B__##name
+#define MRB_SYM_Q_2(mrb, name) MRB_SYM_Q__##name
+#define MRB_SYM_E_2(mrb, name) MRB_SYM_E__##name
+#define MRB_SYM_2(mrb, name) MRB_SYM__##name
+
+#define MRB_PRESYM_DEFINE_VAR_AND_INITER(name, size, ...)                     \
+  static const mrb_sym name[] = {__VA_ARGS__};                                \
+  static void init_##name(mrb_state *mrb) {}
+
+#endif  /* MRUBY_PRESYM_ENABLE_H */

--- a/include/mruby/presym/scanning.h
+++ b/include/mruby/presym/scanning.h
@@ -1,0 +1,69 @@
+/**
+** @file mruby/presym/scanning.h - Scanning Preallocated Symbols
+**
+** See Copyright Notice in mruby.h
+*/
+
+#ifndef MRUBY_PRESYM_SCANNING_H
+#define MRUBY_PRESYM_SCANNING_H
+
+#define MRB_PRESYM_SCANNING_TAGGED(arg) <@! arg !@>
+
+#undef mrb_intern_lit
+#define mrb_intern_lit(mrb, name) MRB_PRESYM_SCANNING_TAGGED(name)
+#define mrb_define_method(mrb, c, name, f, a) MRB_PRESYM_SCANNING_TAGGED(name)
+#define mrb_define_class_method(mrb, c, name, f, a) MRB_PRESYM_SCANNING_TAGGED(name)
+#define mrb_define_class(mrb, name, s) MRB_PRESYM_SCANNING_TAGGED(name)
+#define mrb_define_module(mrb, name) MRB_PRESYM_SCANNING_TAGGED(name)
+#define mrb_define_module_function(mrb, c, name, f, s) MRB_PRESYM_SCANNING_TAGGED(name)
+#define mrb_define_const(mrb, c, name, v) MRB_PRESYM_SCANNING_TAGGED(name)
+#define mrb_define_global_const(mrb, name, v) MRB_PRESYM_SCANNING_TAGGED(name)
+
+#define MRB_OPSYM(name) MRB_OPSYM__##name(mrb)
+#define MRB_CVSYM(name) MRB_PRESYM_SCANNING_TAGGED("@@" #name)
+#define MRB_IVSYM(name) MRB_PRESYM_SCANNING_TAGGED("@" #name)
+#define MRB_SYM_B(name) MRB_PRESYM_SCANNING_TAGGED(#name "!")
+#define MRB_SYM_Q(name) MRB_PRESYM_SCANNING_TAGGED(#name "?")
+#define MRB_SYM_E(name) MRB_PRESYM_SCANNING_TAGGED(#name "=")
+#define MRB_SYM(name) MRB_PRESYM_SCANNING_TAGGED(#name)
+
+#define MRB_OPSYM_2(mrb, name) MRB_OPSYM__##name(mrb)
+#define MRB_CVSYM_2(mrb, name) MRB_PRESYM_SCANNING_TAGGED("@@" #name)
+#define MRB_IVSYM_2(mrb, name) MRB_PRESYM_SCANNING_TAGGED("@" #name)
+#define MRB_SYM_B_2(mrb, name) MRB_PRESYM_SCANNING_TAGGED(#name "!")
+#define MRB_SYM_Q_2(mrb, name) MRB_PRESYM_SCANNING_TAGGED(#name "?")
+#define MRB_SYM_E_2(mrb, name) MRB_PRESYM_SCANNING_TAGGED(#name "=")
+#define MRB_SYM_2(mrb, name) MRB_PRESYM_SCANNING_TAGGED(#name)
+
+#define MRB_OPSYM__not(mrb) MRB_PRESYM_SCANNING_TAGGED("!")
+#define MRB_OPSYM__mod(mrb) MRB_PRESYM_SCANNING_TAGGED("%")
+#define MRB_OPSYM__and(mrb) MRB_PRESYM_SCANNING_TAGGED("&")
+#define MRB_OPSYM__mul(mrb) MRB_PRESYM_SCANNING_TAGGED("*")
+#define MRB_OPSYM__add(mrb) MRB_PRESYM_SCANNING_TAGGED("+")
+#define MRB_OPSYM__sub(mrb) MRB_PRESYM_SCANNING_TAGGED("-")
+#define MRB_OPSYM__div(mrb) MRB_PRESYM_SCANNING_TAGGED("/")
+#define MRB_OPSYM__lt(mrb) MRB_PRESYM_SCANNING_TAGGED("<")
+#define MRB_OPSYM__gt(mrb) MRB_PRESYM_SCANNING_TAGGED(">")
+#define MRB_OPSYM__xor(mrb) MRB_PRESYM_SCANNING_TAGGED("^")
+#define MRB_OPSYM__tick(mrb) MRB_PRESYM_SCANNING_TAGGED("`")
+#define MRB_OPSYM__or(mrb) MRB_PRESYM_SCANNING_TAGGED("|")
+#define MRB_OPSYM__neg(mrb) MRB_PRESYM_SCANNING_TAGGED("~")
+#define MRB_OPSYM__neq(mrb) MRB_PRESYM_SCANNING_TAGGED("!=")
+#define MRB_OPSYM__nmatch(mrb) MRB_PRESYM_SCANNING_TAGGED("!~")
+#define MRB_OPSYM__andand(mrb) MRB_PRESYM_SCANNING_TAGGED("&&")
+#define MRB_OPSYM__pow(mrb) MRB_PRESYM_SCANNING_TAGGED("**")
+#define MRB_OPSYM__plus(mrb) MRB_PRESYM_SCANNING_TAGGED("+@")
+#define MRB_OPSYM__minus(mrb) MRB_PRESYM_SCANNING_TAGGED("-@")
+#define MRB_OPSYM__lshift(mrb) MRB_PRESYM_SCANNING_TAGGED("<<")
+#define MRB_OPSYM__le(mrb) MRB_PRESYM_SCANNING_TAGGED("<=")
+#define MRB_OPSYM__eq(mrb) MRB_PRESYM_SCANNING_TAGGED("==")
+#define MRB_OPSYM__match(mrb) MRB_PRESYM_SCANNING_TAGGED("=~")
+#define MRB_OPSYM__ge(mrb) MRB_PRESYM_SCANNING_TAGGED(">=")
+#define MRB_OPSYM__rshift(mrb) MRB_PRESYM_SCANNING_TAGGED(">>")
+#define MRB_OPSYM__aref(mrb) MRB_PRESYM_SCANNING_TAGGED("[]")
+#define MRB_OPSYM__oror(mrb) MRB_PRESYM_SCANNING_TAGGED("||")
+#define MRB_OPSYM__cmp(mrb) MRB_PRESYM_SCANNING_TAGGED("<=>")
+#define MRB_OPSYM__eqq(mrb) MRB_PRESYM_SCANNING_TAGGED("===")
+#define MRB_OPSYM__aset(mrb) MRB_PRESYM_SCANNING_TAGGED("[]=")
+
+#endif  /* MRUBY_PRESYM_SCANNING_H */

--- a/lib/mruby/build.rb
+++ b/lib/mruby/build.rb
@@ -5,6 +5,7 @@ require "mruby/build/command"
 module MRuby
   autoload :Gem, "mruby/gem"
   autoload :Lockfile, "mruby/lockfile"
+  autoload :Presym, "mruby/presym"
 
   class << self
     def targets
@@ -39,6 +40,7 @@ module MRuby
   class Build
     class << self
       attr_accessor :current
+
       def mruby_config_path
         path = ENV['MRUBY_CONFIG'] || ENV['CONFIG']
         if path.nil? || path.empty?
@@ -49,11 +51,16 @@ module MRuby
         end
         path
       end
+
+      def install_dir
+        @install_dir ||= ENV['INSTALL_DIR'] || "#{MRUBY_ROOT}/bin"
+      end
     end
+
     include Rake::DSL
     include LoadGems
     attr_accessor :name, :bins, :exts, :file_separator, :build_dir, :gem_clone_dir
-    attr_reader :libmruby_core_objs, :libmruby_objs, :gems, :toolchains, :gem_dir_to_repo_url
+    attr_reader :products, :libmruby_core_objs, :libmruby_objs, :gems, :toolchains, :presym, :mrbc_build, :gem_dir_to_repo_url
 
     alias libmruby libmruby_objs
 
@@ -61,16 +68,16 @@ module MRuby
     COMMANDS = COMPILERS + %w(linker archiver yacc gperf git exts mrbc)
     attr_block MRuby::Build::COMMANDS
 
-    Exts = Struct.new(:object, :executable, :library)
+    Exts = Struct.new(:object, :executable, :library, :preprocessed)
 
-    def initialize(name='host', build_dir=nil, &block)
+    def initialize(name='host', build_dir=nil, internal: false, &block)
       @name = name.to_s
 
       unless current = MRuby.targets[@name]
         if ENV['OS'] == 'Windows_NT'
-          @exts = Exts.new('.o', '.exe', '.a')
+          @exts = Exts.new('.o', '.exe', '.a', '.i')
         else
-          @exts = Exts.new('.o', '', '.a')
+          @exts = Exts.new('.o', '', '.a', '.i')
         end
 
         build_dir = build_dir || ENV['MRUBY_BUILD_DIR'] || "#{MRUBY_ROOT}/build"
@@ -89,6 +96,7 @@ module MRuby
         @git = Command::Git.new(self)
         @mrbc = Command::Mrbc.new(self)
 
+        @products = []
         @bins = []
         @gems = MRuby::Gem::List.new
         @libmruby_core_objs = []
@@ -101,6 +109,9 @@ module MRuby
         @enable_bintest = false
         @enable_test = false
         @enable_lock = true
+        @enable_presym = true
+        @mrbcfile_external = false
+        @internal = internal
         @toolchains = []
         @gem_dir_to_repo_url = {}
 
@@ -108,7 +119,14 @@ module MRuby
       end
 
       current.instance_eval(&block)
-      current.build_mrbc_exec if current.libmruby_enabled? && @name == "host"
+      if current.libmruby_enabled? && !current.mrbcfile_external?
+        if current.presym_enabled?
+          current.create_mrbc_build if current.host? || current.gems["mruby-bin-mrbc"]
+        elsif current.host?
+          current.build_mrbc_exec
+        end
+      end
+      current.presym = Presym.new(current) if current.presym_enabled?
       current.build_mrbtest if current.test_enabled?
     end
 
@@ -134,6 +152,17 @@ module MRuby
       @mrbc.compile_options += ' -g'
 
       @enable_debug = true
+    end
+
+    def presym_enabled?
+      @enable_presym
+    end
+
+    def disable_presym
+      if @enable_presym
+        @enable_presym = false
+        compilers.each{|c| c.defines << "MRB_NO_PRESYM"}
+      end
     end
 
     def disable_lock
@@ -187,8 +216,29 @@ module MRuby
       @cxx_abi_enabled = true
     end
 
-    def compile_as_cxx src, cxx_src, obj = nil, includes = []
-      obj = objfile(cxx_src) if obj.nil?
+    def compile_as_cxx(src, cxx_src = nil, obj = nil, includes = [])
+      #
+      # If `cxx_src` is specified, this method behaves the same as before as
+      # compatibility mode, but `.d` file is not read.
+      #
+      # If `cxx_src` is omitted, `.d` file is read by using mruby standard
+      # Rake rule (C++ source name is also changed).
+      #
+      if cxx_src
+        obj ||= cxx_src + @exts.object
+        dsts = [obj]
+        dsts << (cxx_src + @exts.preprocessed) if presym_enabled?
+        defines = []
+        include_paths = ["#{MRUBY_ROOT}/src", *includes]
+        dsts.each do |dst|
+          file dst => cxx_src do |t|
+            cxx.run t.name, t.prerequisites.first, defines, include_paths
+          end
+        end
+      else
+        cxx_src = "#{build_dir}/#{src.relative_path})".ext << "-cxx.cxx"
+        obj = cxx_src.ext(@exts.object)
+      end
 
       file cxx_src => [src, __FILE__] do |t|
         mkdir_p File.dirname t.name
@@ -204,10 +254,6 @@ extern "C" {
 }
 #endif
 EOS
-      end
-
-      file obj => cxx_src do |t|
-        cxx.run t.name, t.prerequisites.first, [], ["#{MRUBY_ROOT}/src"] + includes
       end
 
       obj
@@ -250,11 +296,11 @@ EOS
     end
 
     def build_mrbtest
-      gem :core => 'mruby-test'
+      gem :core => 'mruby-test' unless @gems['mruby-test']
     end
 
     def build_mrbc_exec
-      gem :core => 'mruby-bin-mrbc'
+      gem :core => 'mruby-bin-mrbc' unless @gems['mruby-bin-mrbc']
     end
 
     def locks
@@ -265,8 +311,21 @@ EOS
       return @mrbcfile if @mrbcfile
 
       gem_name = "mruby-bin-mrbc"
-      gem = gems[gem_name] || MRuby.targets["host"].gems[gem_name]
+      gem = @gems[gem_name]
+      gem ||= (host = MRuby.targets["host"]) && host.gems[gem_name]
+      unless gem
+        fail "external mrbc or mruby-bin-mrbc gem in current('#{@name}') or 'host' build is required"
+      end
       @mrbcfile = exefile("#{gem.build.build_dir}/bin/mrbc")
+    end
+
+    def mrbcfile=(path)
+      @mrbcfile = path
+      @mrbcfile_external = true
+    end
+
+    def mrbcfile_external?
+      @mrbcfile_external
     end
 
     def compilers
@@ -276,7 +335,7 @@ EOS
     end
 
     def define_rules
-      use_mrdb = @gems.find{|g| g.name == "mruby-bin-debugger"}
+      use_mrdb = @gems["mruby-bin-debugger"]
       compilers.each do |compiler|
         if respond_to?(:enable_gems?) && enable_gems?
           compiler.defines -= %w(MRB_NO_GEMS)
@@ -285,7 +344,10 @@ EOS
         end
         compiler.defines |= %w(MRB_USE_DEBUG_HOOK) if use_mrdb
       end
-      cc.define_rules(build_dir, MRUBY_ROOT)
+      [@cc, *(@cxx if cxx_exception_enabled?)].each do |compiler|
+        compiler.define_rules(@build_dir, MRUBY_ROOT, @exts.object)
+        compiler.define_rules(@build_dir, MRUBY_ROOT, @exts.preprocessed) if presym_enabled?
+      end
     end
 
     def filename(name)
@@ -346,7 +408,8 @@ EOS
       puts ">>> Bintest #{name} <<<"
       targets = @gems.select { |v| File.directory? "#{v.dir}/bintest" }.map { |v| filename v.dir }
       targets << filename(".") if File.directory? "./bintest"
-      env = {"BUILD_DIR" => @build_dir}
+      mrbc = @gems["mruby-bin-mrbc"] ? exefile("#{@build_dir}/bin/mrbc") : mrbcfile
+      env = {"BUILD_DIR" => @build_dir, "MRBCFILE" => mrbc}
       sh env, "ruby test/bintest.rb#{verbose_flag} #{targets.join ' '}"
     end
 
@@ -380,6 +443,41 @@ EOS
     def libraries
       [libmruby_static]
     end
+
+    def host?
+      @name == "host"
+    end
+
+    def internal?
+      @internal
+    end
+
+    protected
+
+    attr_writer :presym
+
+    def create_mrbc_build
+      exclusions = %i[@name @build_dir @gems @enable_test @enable_bintest @internal]
+      name = "#{@name}/mrbc"
+      MRuby.targets.delete(name)
+      build = self.class.new(name, internal: true){}
+      instance_variables.each do |n|
+        next if exclusions.include?(n)
+        v = instance_variable_get(n)
+        v = case v
+            when nil, true, false, Numeric; v
+            when String, Command; v.clone
+            else Marshal.load(Marshal.dump(v))  # deep clone
+            end
+        build.instance_variable_set(n, v)
+      end
+      build.build_mrbc_exec
+      build.disable_libmruby
+      build.disable_presym
+      @mrbc_build = build
+      self.mrbcfile = build.mrbcfile
+      build
+    end
   end # Build
 
   class CrossBuild < Build
@@ -392,7 +490,7 @@ EOS
     def initialize(name, build_dir=nil, &block)
       @test_runner = Command::CrossTestRunner.new(self)
       super
-      unless MRuby.targets['host']
+      unless mrbcfile_external? || MRuby.targets['host']
         # add minimal 'host'
         MRuby::Build.new('host') do |conf|
           if ENV['VisualStudioVersion'] || ENV['VSINSTALLDIR']
@@ -400,14 +498,11 @@ EOS
           else
             toolchain :gcc
           end
-          conf.gem :core => 'mruby-bin-mrbc'
+          conf.build_mrbc_exec
           conf.disable_libmruby
+          conf.disable_presym
         end
       end
-    end
-
-    def mrbcfile
-      MRuby.targets['host'].mrbcfile
     end
 
     def run_test
@@ -420,5 +515,9 @@ EOS
         @test_runner.run(mrbtest)
       end
     end
+
+    protected
+
+    def create_mrbc_build; end
   end # CrossBuild
 end # MRuby

--- a/lib/mruby/presym.rb
+++ b/lib/mruby/presym.rb
@@ -1,0 +1,113 @@
+module MRuby
+  class Presym
+    include Rake::DSL
+
+    OPERATORS = {
+      "!" => "not",
+      "%" => "mod",
+      "&" => "and",
+      "*" => "mul",
+      "+" => "add",
+      "-" => "sub",
+      "/" => "div",
+      "<" => "lt",
+      ">" => "gt",
+      "^" => "xor",
+      "`" => "tick",
+      "|" => "or",
+      "~" => "neg",
+      "!=" => "neq",
+      "!~" => "nmatch",
+      "&&" => "andand",
+      "**" => "pow",
+      "+@" => "plus",
+      "-@" => "minus",
+      "<<" => "lshift",
+      "<=" => "le",
+      "==" => "eq",
+      "=~" => "match",
+      ">=" => "ge",
+      ">>" => "rshift",
+      "[]" => "aref",
+      "||" => "oror",
+      "<=>" => "cmp",
+      "===" => "eqq",
+      "[]=" => "aset",
+    }.freeze
+
+    SYMBOL_TO_MACRO = {
+    #      Symbol      =>      Macro
+    # [prefix, suffix] => [prefix, suffix]
+      ["@@"  , ""    ] => ["CV"  , ""    ],
+      ["@"   , ""    ] => ["IV"  , ""    ],
+      [""    , "!"   ] => [""    , "_B"  ],
+      [""    , "?"   ] => [""    , "_Q"  ],
+      [""    , "="   ] => [""    , "_E"  ],
+      [""    , ""    ] => [""    , ""    ],
+    }.freeze
+
+    C_STR_LITERAL_RE = /"(?:[^\\\"]|\\.)*"/
+
+    def initialize(build)
+      @build = build
+    end
+
+    def scan(paths)
+      presym_hash = {}
+      paths.each {|path| read_preprocessed(presym_hash, path)}
+      presym_hash.keys.sort_by!{|sym| [c_literal_size(sym), sym]}
+    end
+
+    def read_list
+      File.readlines(list_path, mode: "r:binary").each(&:chomp!)
+    end
+
+    def write_list(presyms)
+      _pp "GEN", list_path.relative_path
+      File.binwrite(list_path, presyms.join("\n") << "\n")
+    end
+
+    def write_header(presyms)
+      prefix_re = Regexp.union(*SYMBOL_TO_MACRO.keys.map(&:first).uniq)
+      suffix_re = Regexp.union(*SYMBOL_TO_MACRO.keys.map(&:last).uniq)
+      sym_re = /\A(#{prefix_re})?([\w&&\D]\w*)(#{suffix_re})?\z/o
+      _pp "GEN", header_path.relative_path
+      mkdir_p(File.dirname(header_path))
+      File.open(header_path, "w:binary") do |f|
+        f.puts "/* MRB_PRESYM_NAMED(lit, num, type, name) */"
+        f.puts "/* MRB_PRESYM_UNNAMED(lit, num) */"
+        presyms.each.with_index(1) do |sym, num|
+          if sym_re =~ sym && (affixes = SYMBOL_TO_MACRO[[$1, $3]])
+            f.puts %|MRB_PRESYM_NAMED("#{sym}", #{num}, #{affixes * 'SYM'}, #{$2})|
+          elsif name = OPERATORS[sym]
+            f.puts %|MRB_PRESYM_NAMED("#{sym}", #{num}, OPSYM, #{name})|
+          elsif
+            f.puts %|MRB_PRESYM_UNNAMED("#{sym}", #{num})|
+          end
+        end
+        f.puts "#define MRB_PRESYM_MAX #{presyms.size}"
+      end
+    end
+
+    def list_path
+      @list_pat ||= "#{@build.build_dir}/presym".freeze
+    end
+
+    def header_path
+      @header_path ||= "#{@build.build_dir}/include/mruby/presym.inc".freeze
+    end
+
+    private
+
+    def read_preprocessed(presym_hash, path)
+      File.binread(path).scan(/<@! (.*?) !@>/) do |part,|
+        literals = part.scan(C_STR_LITERAL_RE)
+        presym_hash[literals.map{|l| l[1..-2]}.join] = true unless literals.empty?
+      end
+    end
+
+    def c_literal_size(literal_without_quote)
+      literal_without_quote.size  # TODO: consider escape sequence
+    end
+  end
+end

--- a/mrbgems/mruby-bin-mruby/mrbgem.rake
+++ b/mrbgems/mruby-bin-mruby/mrbgem.rake
@@ -7,6 +7,6 @@ MRuby::Gem::Specification.new('mruby-bin-mruby') do |spec|
   spec.add_test_dependency('mruby-print', :core => 'mruby-print')
 
   if build.cxx_exception_enabled?
-    build.compile_as_cxx("#{spec.dir}/tools/mruby/mruby.c", "#{spec.build_dir}/tools/mruby/mruby.cxx")
+    build.compile_as_cxx("#{spec.dir}/tools/mruby/mruby.c")
   end
 end

--- a/mrbgems/mruby-compiler/core/codegen.c
+++ b/mrbgems/mruby-compiler/core/codegen.c
@@ -819,7 +819,7 @@ for_body(codegen_scope *s, node *tree)
   genop_2(s, OP_BLOCK, cursp(), s->irep->rlen-1);
   push();pop(); /* space for a block */
   pop();
-  idx = new_sym(s, MRB_SYM(each));
+  idx = new_sym(s, MRB_SYM_2(s->mrb, each));
   genop_3(s, OP_SENDB, cursp(), idx, 0);
 }
 
@@ -1547,14 +1547,14 @@ codegen(codegen_scope *s, node *tree, int val)
               gen_move(s, cursp(), exc, 0);
               push_n(2); pop_n(2); /* space for one arg and a block */
               pop();
-              genop_3(s, OP_SEND, cursp(), new_sym(s, MRB_SYM(__case_eqq)), 1);
+              genop_3(s, OP_SEND, cursp(), new_sym(s, MRB_SYM_2(s->mrb, __case_eqq)), 1);
             }
             else {
               if (n4) {
                 codegen(s, n4->car, VAL);
               }
               else {
-                genop_2(s, OP_GETCONST, cursp(), new_sym(s, MRB_SYM(StandardError)));
+                genop_2(s, OP_GETCONST, cursp(), new_sym(s, MRB_SYM_2(s->mrb, StandardError)));
                 push();
               }
               pop();
@@ -1668,7 +1668,7 @@ codegen(codegen_scope *s, node *tree, int val)
         {
           node *n = tree->car->cdr;
           mrb_sym mid = nsym(n->cdr->car);
-          mrb_sym mnil = MRB_SYM_Q(nil);
+          mrb_sym mnil = MRB_SYM_Q_2(s->mrb, nil);
           if (mid == mnil && n->cdr->cdr->car == NULL) {
             nil_p = TRUE;
             codegen(s, n->car, VAL);
@@ -1804,10 +1804,10 @@ codegen(codegen_scope *s, node *tree, int val)
             gen_move(s, cursp(), head, 0);
             push(); push(); pop(); pop(); pop();
             if (nint(n->car->car) == NODE_SPLAT) {
-              genop_3(s, OP_SEND, cursp(), new_sym(s, MRB_SYM(__case_eqq)), 1);
+              genop_3(s, OP_SEND, cursp(), new_sym(s, MRB_SYM_2(s->mrb, __case_eqq)), 1);
             }
             else {
-              genop_3(s, OP_SEND, cursp(), new_sym(s, MRB_OPSYM(eqq)), 1);
+              genop_3(s, OP_SEND, cursp(), new_sym(s, MRB_OPSYM_2(s->mrb, eqq)), 1);
             }
           }
           else {
@@ -2333,7 +2333,7 @@ codegen(codegen_scope *s, node *tree, int val)
       pop_n(n+1);
       genop_2S(s, OP_BLKPUSH, cursp(), (ainfo<<4)|(lv & 0xf));
       if (sendv) n = CALL_MAXARGS;
-      genop_3(s, OP_SEND, cursp(), new_sym(s, MRB_SYM(call)), n);
+      genop_3(s, OP_SEND, cursp(), new_sym(s, MRB_SYM_2(s->mrb, call)), n);
       if (val) push();
     }
     break;
@@ -2582,7 +2582,7 @@ codegen(codegen_scope *s, node *tree, int val)
 
       default:
         if (val) {
-          int sym = new_sym(s, MRB_OPSYM(minus));
+          int sym = new_sym(s, MRB_OPSYM_2(s->mrb, minus));
           codegen(s, tree, VAL);
           pop();
           genop_3(s, OP_SEND, cursp(), sym, 0);
@@ -2655,7 +2655,7 @@ codegen(codegen_scope *s, node *tree, int val)
     {
       node *n;
       int ai = mrb_gc_arena_save(s->mrb);
-      int sym = new_sym(s, MRB_SYM(Kernel));
+      int sym = new_sym(s, MRB_SYM_2(s->mrb, Kernel));
 
       genop_1(s, OP_LOADSELF, cursp());
       push();
@@ -2674,7 +2674,7 @@ codegen(codegen_scope *s, node *tree, int val)
       }
       push();                   /* for block */
       pop_n(3);
-      sym = new_sym(s, MRB_OPSYM(tick)); /* ` */
+      sym = new_sym(s, MRB_OPSYM_2(s->mrb, tick)); /* ` */
       genop_3(s, OP_SEND, cursp(), sym, 1);
       if (val) push();
       mrb_gc_arena_restore(s->mrb, ai);
@@ -2694,7 +2694,7 @@ codegen(codegen_scope *s, node *tree, int val)
       genop_bs(s, OP_STRING, cursp(), off);
       push(); push();
       pop_n(3);
-      sym = new_sym(s, MRB_OPSYM(tick)); /* ` */
+      sym = new_sym(s, MRB_OPSYM_2(s->mrb, tick)); /* ` */
       genop_3(s, OP_SEND, cursp(), sym, 1);
       if (val) push();
       mrb_gc_arena_restore(s->mrb, ai);
@@ -2735,7 +2735,7 @@ codegen(codegen_scope *s, node *tree, int val)
       }
       push(); /* space for a block */
       pop_n(argc+2);
-      sym = new_sym(s, MRB_SYM(compile));
+      sym = new_sym(s, MRB_SYM_2(s->mrb, compile));
       genop_3(s, OP_SEND, cursp(), sym, argc);
       mrb_gc_arena_restore(s->mrb, ai);
       push();
@@ -2789,7 +2789,7 @@ codegen(codegen_scope *s, node *tree, int val)
       }
       push(); /* space for a block */
       pop_n(argc+2);
-      sym = new_sym(s, MRB_SYM(compile));
+      sym = new_sym(s, MRB_SYM_2(s->mrb, compile));
       genop_3(s, OP_SEND, cursp(), sym, argc);
       mrb_gc_arena_restore(s->mrb, ai);
       push();

--- a/mrbgems/mruby-compiler/core/parse.y
+++ b/mrbgems/mruby-compiler/core/parse.y
@@ -88,7 +88,7 @@ intern_gen(parser_state *p, const char *s, size_t len)
 }
 #define intern(s,len) intern_gen(p,(s),(len))
 
-#define intern_lit(s) mrb_intern_lit(p->mrb, s)
+#define intern_op(op) MRB_OPSYM_2(p->mrb, op)
 
 static void
 cons_free_gen(parser_state *p, node *cons)
@@ -314,14 +314,14 @@ static void
 local_add_blk(parser_state *p, mrb_sym blk)
 {
   /* allocate register for block */
-  local_add_f(p, blk ? blk : MRB_OPSYM(and));
+  local_add_f(p, blk ? blk : intern_op(and));
 }
 
 static void
 local_add_kw(parser_state *p, mrb_sym kwd)
 {
   /* allocate register for keywords hash */
-  local_add_f(p, kwd ? kwd : MRB_OPSYM(pow));
+  local_add_f(p, kwd ? kwd : intern_op(pow));
 }
 
 static node*
@@ -959,13 +959,13 @@ new_op_asgn(parser_state *p, node *a, mrb_sym op, node *b)
 static node*
 new_imaginary(parser_state *p, node *imaginary)
 {
-  return new_call(p, new_const(p, MRB_SYM(Kernel)), MRB_SYM(Complex), list1(list2(list3((node*)NODE_INT, (node*)strdup("0"), nint(10)), imaginary)), 1);
+  return new_call(p, new_const(p, MRB_SYM_2(p->mrb, Kernel)), MRB_SYM_2(p->mrb, Complex), list1(list2(list3((node*)NODE_INT, (node*)strdup("0"), nint(10)), imaginary)), 1);
 }
 
 static node*
 new_rational(parser_state *p, node *rational)
 {
-  return new_call(p, new_const(p, MRB_SYM(Kernel)), MRB_SYM(Rational), list1(list1(rational)), 1);
+  return new_call(p, new_const(p, MRB_SYM_2(p->mrb, Kernel)), MRB_SYM_2(p->mrb, Rational), list1(list1(rational)), 1);
 }
 
 /* (:int . i) */
@@ -1706,7 +1706,7 @@ command_asgn    : lhs '=' command_rhs
                     }
                 | primary_value '[' opt_call_args ']' tOP_ASGN command_rhs
                     {
-                      $$ = new_op_asgn(p, new_call(p, $1, MRB_OPSYM(aref), $3, '.'), $5, $6);
+                      $$ = new_op_asgn(p, new_call(p, $1, intern_op(aref), $3, '.'), $5, $6);
                     }
                 | primary_value call_op tIDENTIFIER tOP_ASGN command_rhs
                     {
@@ -1962,7 +1962,7 @@ mlhs_node       : variable
                     }
                 | primary_value '[' opt_call_args ']'
                     {
-                      $$ = new_call(p, $1, MRB_OPSYM(aref), $3, '.');
+                      $$ = new_call(p, $1, intern_op(aref), $3, '.');
                     }
                 | primary_value call_op tIDENTIFIER
                     {
@@ -2001,7 +2001,7 @@ lhs             : variable
                     }
                 | primary_value '[' opt_call_args ']'
                     {
-                      $$ = new_call(p, $1, MRB_OPSYM(aref), $3, '.');
+                      $$ = new_call(p, $1, intern_op(aref), $3, '.');
                     }
                 | primary_value call_op tIDENTIFIER
                     {
@@ -2089,36 +2089,36 @@ undef_list      : fsym
                     }
                 ;
 
-op              : '|'           { $$ = MRB_OPSYM(or);     }
-                | '^'           { $$ = MRB_OPSYM(xor);    }
-                | '&'           { $$ = MRB_OPSYM(and);    }
-                | tCMP          { $$ = MRB_OPSYM(cmp);    }
-                | tEQ           { $$ = MRB_OPSYM(eq);     }
-                | tEQQ          { $$ = MRB_OPSYM(eqq);    }
-                | tMATCH        { $$ = MRB_OPSYM(match);  }
-                | tNMATCH       { $$ = MRB_OPSYM(nmatch); }
-                | '>'           { $$ = MRB_OPSYM(gt);     }
-                | tGEQ          { $$ = MRB_OPSYM(ge);     }
-                | '<'           { $$ = MRB_OPSYM(lt);     }
-                | tLEQ          { $$ = MRB_OPSYM(le);     }
-                | tNEQ          { $$ = MRB_OPSYM(neq);    }
-                | tLSHFT        { $$ = MRB_OPSYM(lshift); }
-                | tRSHFT        { $$ = MRB_OPSYM(rshift); }
-                | '+'           { $$ = MRB_OPSYM(add);    }
-                | '-'           { $$ = MRB_OPSYM(sub);    }
-                | '*'           { $$ = MRB_OPSYM(mul);    }
-                | tSTAR         { $$ = MRB_OPSYM(mul);    }
-                | '/'           { $$ = MRB_OPSYM(div);    }
-                | '%'           { $$ = MRB_OPSYM(mod);    }
-                | tPOW          { $$ = MRB_OPSYM(pow);    }
-                | tDSTAR        { $$ = MRB_OPSYM(pow);    }
-                | '!'           { $$ = MRB_OPSYM(not);    }
-                | '~'           { $$ = MRB_OPSYM(neg);    }
-                | tUPLUS        { $$ = MRB_OPSYM(plus);   }
-                | tUMINUS       { $$ = MRB_OPSYM(minus);  }
-                | tAREF         { $$ = MRB_OPSYM(aref);   }
-                | tASET         { $$ = MRB_OPSYM(aset);   }
-                | '`'           { $$ = MRB_OPSYM(tick);   }
+op              : '|'           { $$ = intern_op(or);     }
+                | '^'           { $$ = intern_op(xor);    }
+                | '&'           { $$ = intern_op(and);    }
+                | tCMP          { $$ = intern_op(cmp);    }
+                | tEQ           { $$ = intern_op(eq);     }
+                | tEQQ          { $$ = intern_op(eqq);    }
+                | tMATCH        { $$ = intern_op(match);  }
+                | tNMATCH       { $$ = intern_op(nmatch); }
+                | '>'           { $$ = intern_op(gt);     }
+                | tGEQ          { $$ = intern_op(ge);     }
+                | '<'           { $$ = intern_op(lt);     }
+                | tLEQ          { $$ = intern_op(le);     }
+                | tNEQ          { $$ = intern_op(neq);    }
+                | tLSHFT        { $$ = intern_op(lshift); }
+                | tRSHFT        { $$ = intern_op(rshift); }
+                | '+'           { $$ = intern_op(add);    }
+                | '-'           { $$ = intern_op(sub);    }
+                | '*'           { $$ = intern_op(mul);    }
+                | tSTAR         { $$ = intern_op(mul);    }
+                | '/'           { $$ = intern_op(div);    }
+                | '%'           { $$ = intern_op(mod);    }
+                | tPOW          { $$ = intern_op(pow);    }
+                | tDSTAR        { $$ = intern_op(pow);    }
+                | '!'           { $$ = intern_op(not);    }
+                | '~'           { $$ = intern_op(neg);    }
+                | tUPLUS        { $$ = intern_op(plus);   }
+                | tUMINUS       { $$ = intern_op(minus);  }
+                | tAREF         { $$ = intern_op(aref);   }
+                | tASET         { $$ = intern_op(aset);   }
+                | '`'           { $$ = intern_op(tick);   }
                 ;
 
 reswords        : keyword__LINE__ | keyword__FILE__ | keyword__ENCODING__
@@ -2145,7 +2145,7 @@ arg             : lhs '=' arg_rhs
                     }
                 | primary_value '[' opt_call_args ']' tOP_ASGN arg_rhs
                     {
-                      $$ = new_op_asgn(p, new_call(p, $1, MRB_OPSYM(aref), $3, '.'), $5, $6);
+                      $$ = new_op_asgn(p, new_call(p, $1, intern_op(aref), $3, '.'), $5, $6);
                     }
                 | primary_value call_op tIDENTIFIER tOP_ASGN arg_rhs
                     {
@@ -2400,14 +2400,14 @@ paren_args      : '(' opt_call_args ')'
                 | '(' args comma tBDOT3 rparen
                     {
 #if 1
-                      mrb_sym r = MRB_OPSYM(mul);
-                      mrb_sym b = MRB_OPSYM(and);
+                      mrb_sym r = intern_op(mul);
+                      mrb_sym b = intern_op(and);
                       $$ = cons(push($2, new_splat(p, new_lvar(p, r))),
                                 new_block_arg(p, new_lvar(p, b)));
 #else
-                      mrb_sym r = MRB_OPSYM(mul);
-                      mrb_sym k = MRB_OPSYM(pow);
-                      mrb_sym b = MRB_OPSYM(and);
+                      mrb_sym r = intern_op(mul);
+                      mrb_sym k = intern_op(pow);
+                      mrb_sym b = intern_op(and);
                       $$ = cons(list2(push($2, new_splat(p, new_lvar(p, r))),
                                       new_kw_hash(p, list1(cons(new_kw_rest_args(p, 0), new_lvar(p, k))))),
                                 new_block_arg(p, new_lvar(p, b)));
@@ -2416,16 +2416,16 @@ paren_args      : '(' opt_call_args ')'
                 | '(' tBDOT3 rparen
                     {
 #if 1
-                      mrb_sym r = MRB_OPSYM(mul);
-                      mrb_sym b = MRB_OPSYM(and);
+                      mrb_sym r = intern_op(mul);
+                      mrb_sym b = intern_op(and);
                       if (local_var_p(p, r)  && local_var_p(p, b)) {
                         $$ = cons(list1(new_splat(p, new_lvar(p, r))),
                                   new_block_arg(p, new_lvar(p, b)));
                       }
 #else
-                      mrb_sym r = MRB_OPSYM(mul);
-                      mrb_sym k = MRB_OPSYM(pow);
-                      mrb_sym b = MRB_OPSYM(and);
+                      mrb_sym r = intern_op(mul);
+                      mrb_sym k = intern_op(pow);
+                      mrb_sym b = intern_op(and);
                       if (local_var_p(p, r) && local_var_p(p, k) && local_var_p(p, b)) {
                         $$ = cons(list2(new_splat(p, new_lvar(p, r)),
                                         new_kw_hash(p, list1(cons(new_kw_rest_args(p, 0), new_lvar(p, k))))),
@@ -3114,11 +3114,11 @@ method_call     : operation paren_args
                     }
                 | primary_value call_op paren_args
                     {
-                      $$ = new_call(p, $1, MRB_SYM(call), $3, $2);
+                      $$ = new_call(p, $1, MRB_SYM_2(p->mrb, call), $3, $2);
                     }
                 | primary_value tCOLON2 paren_args
                     {
-                      $$ = new_call(p, $1, MRB_SYM(call), $3, tCOLON2);
+                      $$ = new_call(p, $1, MRB_SYM_2(p->mrb, call), $3, tCOLON2);
                     }
                 | keyword_super paren_args
                     {
@@ -3130,7 +3130,7 @@ method_call     : operation paren_args
                     }
                 | primary_value '[' opt_call_args ']'
                     {
-                      $$ = new_call(p, $1, MRB_OPSYM(aref), $3, '.');
+                      $$ = new_call(p, $1, intern_op(aref), $3, '.');
                     }
                 ;
 
@@ -3513,15 +3513,15 @@ f_arglist_paren : '(' f_args rparen
                     {
 #if 1
                       /* til real keyword args implemented */
-                      mrb_sym r = MRB_OPSYM(mul);
-                      mrb_sym b = MRB_OPSYM(and);
+                      mrb_sym r = intern_op(mul);
+                      mrb_sym b = intern_op(and);
                       local_add_f(p, r);
                       $$ = new_args(p, $2, 0, r, 0,
                                     new_args_tail(p, 0, 0, b));
 #else
-                      mrb_sym r = MRB_OPSYM(mul);
-                      mrb_sym k = MRB_OPSYM(pow);
-                      mrb_sym b = MRB_OPSYM(and);
+                      mrb_sym r = intern_op(mul);
+                      mrb_sym k = intern_op(pow);
+                      mrb_sym b = intern_op(and);
                       local_add_f(p, r); local_add_f(p, k);
                       $$ = new_args(p, $2, 0, r, 0,
                                     new_args_tail(p, 0, new_kw_rest_args(p, nsym(k)), b));
@@ -3531,15 +3531,15 @@ f_arglist_paren : '(' f_args rparen
                     {
 #if 1
                       /* til real keyword args implemented */
-                      mrb_sym r = MRB_OPSYM(mul);
-                      mrb_sym b = MRB_OPSYM(and);
+                      mrb_sym r = intern_op(mul);
+                      mrb_sym b = intern_op(and);
                       local_add_f(p, r);
                       $$ = new_args(p, 0, 0, r, 0,
                                     new_args_tail(p, 0, 0, b));
 #else
-                      mrb_sym r = MRB_OPSYM(mul);
-                      mrb_sym k = MRB_OPSYM(pow);
-                      mrb_sym b = MRB_OPSYM(and);
+                      mrb_sym r = intern_op(mul);
+                      mrb_sym k = intern_op(pow);
+                      mrb_sym b = intern_op(and);
                       local_add_f(p, r); local_add_f(p, k);
                       $$ = new_args(p, 0, 0, r, 0,
                                     new_args_tail(p, 0, new_kw_rest_args(p, nsym(k)), b));
@@ -3705,7 +3705,7 @@ f_args          : f_arg ',' f_optarg ',' f_rest_arg opt_args_tail
                     }
                 | /* none */
                     {
-                      local_add_f(p, MRB_OPSYM(and));
+                      local_add_f(p, intern_op(and));
                       $$ = new_args(p, 0, 0, 0, 0, 0);
                     }
                 ;
@@ -3829,7 +3829,7 @@ f_rest_arg      : restarg_mark tIDENTIFIER
                     }
                 | restarg_mark
                     {
-                      local_add_f(p, MRB_OPSYM(mul));
+                      local_add_f(p, intern_op(mul));
                       $$ = -1;
                     }
                 ;
@@ -5086,7 +5086,7 @@ parser_yylex(parser_state *p)
   case '*':
     if ((c = nextc(p)) == '*') {
       if ((c = nextc(p)) == '=') {
-        pylval.id = MRB_OPSYM(pow);
+        pylval.id = intern_op(pow);
         p->lstate = EXPR_BEG;
         return tOP_ASGN;
       }
@@ -5104,7 +5104,7 @@ parser_yylex(parser_state *p)
     }
     else {
       if (c == '=') {
-        pylval.id = MRB_OPSYM(mul);
+        pylval.id = intern_op(mul);
         p->lstate = EXPR_BEG;
         return tOP_ASGN;
       }
@@ -5220,7 +5220,7 @@ parser_yylex(parser_state *p)
     }
     if (c == '<') {
       if ((c = nextc(p)) == '=') {
-        pylval.id = MRB_OPSYM(lshift);
+        pylval.id = intern_op(lshift);
         p->lstate = EXPR_BEG;
         return tOP_ASGN;
       }
@@ -5242,7 +5242,7 @@ parser_yylex(parser_state *p)
     }
     if (c == '>') {
       if ((c = nextc(p)) == '=') {
-        pylval.id = MRB_OPSYM(rshift);
+        pylval.id = intern_op(rshift);
         p->lstate = EXPR_BEG;
         return tOP_ASGN;
       }
@@ -5350,7 +5350,7 @@ parser_yylex(parser_state *p)
     if ((c = nextc(p)) == '&') {
       p->lstate = EXPR_BEG;
       if ((c = nextc(p)) == '=') {
-        pylval.id = MRB_OPSYM(andand);
+        pylval.id = intern_op(andand);
         p->lstate = EXPR_BEG;
         return tOP_ASGN;
       }
@@ -5362,7 +5362,7 @@ parser_yylex(parser_state *p)
       return tANDDOT;
     }
     else if (c == '=') {
-      pylval.id = MRB_OPSYM(and);
+      pylval.id = intern_op(and);
       p->lstate = EXPR_BEG;
       return tOP_ASGN;
     }
@@ -5389,7 +5389,7 @@ parser_yylex(parser_state *p)
     if ((c = nextc(p)) == '|') {
       p->lstate = EXPR_BEG;
       if ((c = nextc(p)) == '=') {
-        pylval.id = MRB_OPSYM(oror);
+        pylval.id = intern_op(oror);
         p->lstate = EXPR_BEG;
         return tOP_ASGN;
       }
@@ -5397,7 +5397,7 @@ parser_yylex(parser_state *p)
       return tOROP;
     }
     if (c == '=') {
-      pylval.id = MRB_OPSYM(or);
+      pylval.id = intern_op(or);
       p->lstate = EXPR_BEG;
       return tOP_ASGN;
     }
@@ -5421,7 +5421,7 @@ parser_yylex(parser_state *p)
       return '+';
     }
     if (c == '=') {
-      pylval.id = MRB_OPSYM(add);
+      pylval.id = intern_op(add);
       p->lstate = EXPR_BEG;
       return tOP_ASGN;
     }
@@ -5449,7 +5449,7 @@ parser_yylex(parser_state *p)
       return '-';
     }
     if (c == '=') {
-      pylval.id = MRB_OPSYM(sub);
+      pylval.id = intern_op(sub);
       p->lstate = EXPR_BEG;
       return tOP_ASGN;
     }
@@ -5772,7 +5772,7 @@ parser_yylex(parser_state *p)
       return tREGEXP_BEG;
     }
     if ((c = nextc(p)) == '=') {
-      pylval.id = MRB_OPSYM(div);
+      pylval.id = intern_op(div);
       p->lstate = EXPR_BEG;
       return tOP_ASGN;
     }
@@ -5791,7 +5791,7 @@ parser_yylex(parser_state *p)
 
   case '^':
     if ((c = nextc(p)) == '=') {
-      pylval.id = MRB_OPSYM(xor);
+      pylval.id = intern_op(xor);
       p->lstate = EXPR_BEG;
       return tOP_ASGN;
     }
@@ -5968,7 +5968,7 @@ parser_yylex(parser_state *p)
       }
     }
     if ((c = nextc(p)) == '=') {
-      pylval.id = MRB_OPSYM(mod);
+      pylval.id = intern_op(mod);
       p->lstate = EXPR_BEG;
       return tOP_ASGN;
     }

--- a/mrbgems/mruby-compiler/core/y.tab.c
+++ b/mrbgems/mruby-compiler/core/y.tab.c
@@ -1,4 +1,4 @@
-/* A Bison parser, made by GNU Bison 3.5.1.  */
+/* A Bison parser, made by GNU Bison 3.7.4.  */
 
 /* Bison implementation for Yacc-like parsers in C
 
@@ -34,6 +34,10 @@
 /* C LALR(1) parser skeleton written by Richard Stallman, by
    simplifying the original so-called "semantic" parser.  */
 
+/* DO NOT RELY ON FEATURES THAT ARE NOT DOCUMENTED in the manual,
+   especially those whose name start with YY_ or yy_.  They are
+   private implementation details that can be changed or removed.  */
+
 /* All symbols defined below should begin with yy or YY, to avoid
    infringing on user name space.  This should be done even for local
    variables, as they might otherwise be expanded by user macros.
@@ -41,14 +45,11 @@
    define necessary library symbols; they are noted "INFRINGES ON
    USER NAME SPACE" below.  */
 
-/* Undocumented macros, especially those whose name start with YY_,
-   are private implementation details.  Do not rely on them.  */
+/* Identify Bison output, and Bison version.  */
+#define YYBISON 30704
 
-/* Identify Bison output.  */
-#define YYBISON 1
-
-/* Bison version.  */
-#define YYBISON_VERSION "3.5.1"
+/* Bison version string.  */
+#define YYBISON_VERSION "3.7.4"
 
 /* Skeleton name.  */
 #define YYSKELETON_NAME "yacc.c"
@@ -151,7 +152,7 @@ intern_gen(parser_state *p, const char *s, size_t len)
 }
 #define intern(s,len) intern_gen(p,(s),(len))
 
-#define intern_lit(s) mrb_intern_lit(p->mrb, s)
+#define intern_op(op) MRB_OPSYM_2(p->mrb, op)
 
 static void
 cons_free_gen(parser_state *p, node *cons)
@@ -377,14 +378,14 @@ static void
 local_add_blk(parser_state *p, mrb_sym blk)
 {
   /* allocate register for block */
-  local_add_f(p, blk ? blk : MRB_OPSYM(and));
+  local_add_f(p, blk ? blk : intern_op(and));
 }
 
 static void
 local_add_kw(parser_state *p, mrb_sym kwd)
 {
   /* allocate register for keywords hash */
-  local_add_f(p, kwd ? kwd : MRB_OPSYM(pow));
+  local_add_f(p, kwd ? kwd : intern_op(pow));
 }
 
 static node*
@@ -1022,13 +1023,13 @@ new_op_asgn(parser_state *p, node *a, mrb_sym op, node *b)
 static node*
 new_imaginary(parser_state *p, node *imaginary)
 {
-  return new_call(p, new_const(p, MRB_SYM(Kernel)), MRB_SYM(Complex), list1(list2(list3((node*)NODE_INT, (node*)strdup("0"), nint(10)), imaginary)), 1);
+  return new_call(p, new_const(p, MRB_SYM_2(p->mrb, Kernel)), MRB_SYM_2(p->mrb, Complex), list1(list2(list3((node*)NODE_INT, (node*)strdup("0"), nint(10)), imaginary)), 1);
 }
 
 static node*
 new_rational(parser_state *p, node *rational)
 {
-  return new_call(p, new_const(p, MRB_SYM(Kernel)), MRB_SYM(Rational), list1(list1(rational)), 1);
+  return new_call(p, new_const(p, MRB_SYM_2(p->mrb, Kernel)), MRB_SYM_2(p->mrb, Rational), list1(list1(rational)), 1);
 }
 
 /* (:int . i) */
@@ -1431,7 +1432,7 @@ heredoc_end(parser_state *p)
 /* xxx ----------------------------- */
 
 
-#line 1435 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 1436 "mrbgems/mruby-compiler/core/y.tab.c"
 
 # ifndef YY_CAST
 #  ifdef __cplusplus
@@ -1454,14 +1455,6 @@ heredoc_end(parser_state *p)
 #  endif
 # endif
 
-/* Enabling verbose error messages.  */
-#ifdef YYERROR_VERBOSE
-# undef YYERROR_VERBOSE
-# define YYERROR_VERBOSE 1
-#else
-# define YYERROR_VERBOSE 1
-#endif
-
 
 /* Debug traces.  */
 #ifndef YYDEBUG
@@ -1471,132 +1464,137 @@ heredoc_end(parser_state *p)
 extern int yydebug;
 #endif
 
-/* Token type.  */
+/* Token kinds.  */
 #ifndef YYTOKENTYPE
 # define YYTOKENTYPE
   enum yytokentype
   {
-    keyword_class = 258,
-    keyword_module = 259,
-    keyword_def = 260,
-    keyword_begin = 261,
-    keyword_if = 262,
-    keyword_unless = 263,
-    keyword_while = 264,
-    keyword_until = 265,
-    keyword_for = 266,
-    keyword_undef = 267,
-    keyword_rescue = 268,
-    keyword_ensure = 269,
-    keyword_end = 270,
-    keyword_then = 271,
-    keyword_elsif = 272,
-    keyword_else = 273,
-    keyword_case = 274,
-    keyword_when = 275,
-    keyword_break = 276,
-    keyword_next = 277,
-    keyword_redo = 278,
-    keyword_retry = 279,
-    keyword_in = 280,
-    keyword_do = 281,
-    keyword_do_cond = 282,
-    keyword_do_block = 283,
-    keyword_do_LAMBDA = 284,
-    keyword_return = 285,
-    keyword_yield = 286,
-    keyword_super = 287,
-    keyword_self = 288,
-    keyword_nil = 289,
-    keyword_true = 290,
-    keyword_false = 291,
-    keyword_and = 292,
-    keyword_or = 293,
-    keyword_not = 294,
-    modifier_if = 295,
-    modifier_unless = 296,
-    modifier_while = 297,
-    modifier_until = 298,
-    modifier_rescue = 299,
-    keyword_alias = 300,
-    keyword_BEGIN = 301,
-    keyword_END = 302,
-    keyword__LINE__ = 303,
-    keyword__FILE__ = 304,
-    keyword__ENCODING__ = 305,
-    tIDENTIFIER = 306,
-    tFID = 307,
-    tGVAR = 308,
-    tIVAR = 309,
-    tCONSTANT = 310,
-    tCVAR = 311,
-    tLABEL_TAG = 312,
-    tINTEGER = 313,
-    tFLOAT = 314,
-    tCHAR = 315,
-    tXSTRING = 316,
-    tREGEXP = 317,
-    tSTRING = 318,
-    tSTRING_PART = 319,
-    tSTRING_MID = 320,
-    tNTH_REF = 321,
-    tBACK_REF = 322,
-    tREGEXP_END = 323,
-    tNUMPARAM = 324,
-    tUPLUS = 325,
-    tUMINUS = 326,
-    tPOW = 327,
-    tCMP = 328,
-    tEQ = 329,
-    tEQQ = 330,
-    tNEQ = 331,
-    tGEQ = 332,
-    tLEQ = 333,
-    tANDOP = 334,
-    tOROP = 335,
-    tMATCH = 336,
-    tNMATCH = 337,
-    tDOT2 = 338,
-    tDOT3 = 339,
-    tBDOT2 = 340,
-    tBDOT3 = 341,
-    tAREF = 342,
-    tASET = 343,
-    tLSHFT = 344,
-    tRSHFT = 345,
-    tCOLON2 = 346,
-    tCOLON3 = 347,
-    tOP_ASGN = 348,
-    tASSOC = 349,
-    tLPAREN = 350,
-    tLPAREN_ARG = 351,
-    tRPAREN = 352,
-    tLBRACK = 353,
-    tLBRACE = 354,
-    tLBRACE_ARG = 355,
-    tSTAR = 356,
-    tDSTAR = 357,
-    tAMPER = 358,
-    tLAMBDA = 359,
-    tANDDOT = 360,
-    tSYMBEG = 361,
-    tREGEXP_BEG = 362,
-    tWORDS_BEG = 363,
-    tSYMBOLS_BEG = 364,
-    tSTRING_BEG = 365,
-    tXSTRING_BEG = 366,
-    tSTRING_DVAR = 367,
-    tLAMBEG = 368,
-    tHEREDOC_BEG = 369,
-    tHEREDOC_END = 370,
-    tLITERAL_DELIM = 371,
-    tHD_LITERAL_DELIM = 372,
-    tHD_STRING_PART = 373,
-    tHD_STRING_MID = 374,
-    tLOWEST = 375,
-    tUMINUS_NUM = 376,
-    tLAST_TOKEN = 377
+    YYEMPTY = -2,
+    YYEOF = 0,                     /* "end of file"  */
+    YYerror = 256,                 /* error  */
+    YYUNDEF = 257,                 /* "invalid token"  */
+    keyword_class = 258,           /* keyword_class  */
+    keyword_module = 259,          /* keyword_module  */
+    keyword_def = 260,             /* keyword_def  */
+    keyword_begin = 261,           /* keyword_begin  */
+    keyword_if = 262,              /* keyword_if  */
+    keyword_unless = 263,          /* keyword_unless  */
+    keyword_while = 264,           /* keyword_while  */
+    keyword_until = 265,           /* keyword_until  */
+    keyword_for = 266,             /* keyword_for  */
+    keyword_undef = 267,           /* keyword_undef  */
+    keyword_rescue = 268,          /* keyword_rescue  */
+    keyword_ensure = 269,          /* keyword_ensure  */
+    keyword_end = 270,             /* keyword_end  */
+    keyword_then = 271,            /* keyword_then  */
+    keyword_elsif = 272,           /* keyword_elsif  */
+    keyword_else = 273,            /* keyword_else  */
+    keyword_case = 274,            /* keyword_case  */
+    keyword_when = 275,            /* keyword_when  */
+    keyword_break = 276,           /* keyword_break  */
+    keyword_next = 277,            /* keyword_next  */
+    keyword_redo = 278,            /* keyword_redo  */
+    keyword_retry = 279,           /* keyword_retry  */
+    keyword_in = 280,              /* keyword_in  */
+    keyword_do = 281,              /* keyword_do  */
+    keyword_do_cond = 282,         /* keyword_do_cond  */
+    keyword_do_block = 283,        /* keyword_do_block  */
+    keyword_do_LAMBDA = 284,       /* keyword_do_LAMBDA  */
+    keyword_return = 285,          /* keyword_return  */
+    keyword_yield = 286,           /* keyword_yield  */
+    keyword_super = 287,           /* keyword_super  */
+    keyword_self = 288,            /* keyword_self  */
+    keyword_nil = 289,             /* keyword_nil  */
+    keyword_true = 290,            /* keyword_true  */
+    keyword_false = 291,           /* keyword_false  */
+    keyword_and = 292,             /* keyword_and  */
+    keyword_or = 293,              /* keyword_or  */
+    keyword_not = 294,             /* keyword_not  */
+    modifier_if = 295,             /* modifier_if  */
+    modifier_unless = 296,         /* modifier_unless  */
+    modifier_while = 297,          /* modifier_while  */
+    modifier_until = 298,          /* modifier_until  */
+    modifier_rescue = 299,         /* modifier_rescue  */
+    keyword_alias = 300,           /* keyword_alias  */
+    keyword_BEGIN = 301,           /* keyword_BEGIN  */
+    keyword_END = 302,             /* keyword_END  */
+    keyword__LINE__ = 303,         /* keyword__LINE__  */
+    keyword__FILE__ = 304,         /* keyword__FILE__  */
+    keyword__ENCODING__ = 305,     /* keyword__ENCODING__  */
+    tIDENTIFIER = 306,             /* tIDENTIFIER  */
+    tFID = 307,                    /* tFID  */
+    tGVAR = 308,                   /* tGVAR  */
+    tIVAR = 309,                   /* tIVAR  */
+    tCONSTANT = 310,               /* tCONSTANT  */
+    tCVAR = 311,                   /* tCVAR  */
+    tLABEL_TAG = 312,              /* tLABEL_TAG  */
+    tINTEGER = 313,                /* tINTEGER  */
+    tFLOAT = 314,                  /* tFLOAT  */
+    tCHAR = 315,                   /* tCHAR  */
+    tXSTRING = 316,                /* tXSTRING  */
+    tREGEXP = 317,                 /* tREGEXP  */
+    tSTRING = 318,                 /* tSTRING  */
+    tSTRING_PART = 319,            /* tSTRING_PART  */
+    tSTRING_MID = 320,             /* tSTRING_MID  */
+    tNTH_REF = 321,                /* tNTH_REF  */
+    tBACK_REF = 322,               /* tBACK_REF  */
+    tREGEXP_END = 323,             /* tREGEXP_END  */
+    tNUMPARAM = 324,               /* tNUMPARAM  */
+    tUPLUS = 325,                  /* tUPLUS  */
+    tUMINUS = 326,                 /* tUMINUS  */
+    tPOW = 327,                    /* tPOW  */
+    tCMP = 328,                    /* tCMP  */
+    tEQ = 329,                     /* tEQ  */
+    tEQQ = 330,                    /* tEQQ  */
+    tNEQ = 331,                    /* tNEQ  */
+    tGEQ = 332,                    /* tGEQ  */
+    tLEQ = 333,                    /* tLEQ  */
+    tANDOP = 334,                  /* tANDOP  */
+    tOROP = 335,                   /* tOROP  */
+    tMATCH = 336,                  /* tMATCH  */
+    tNMATCH = 337,                 /* tNMATCH  */
+    tDOT2 = 338,                   /* tDOT2  */
+    tDOT3 = 339,                   /* tDOT3  */
+    tBDOT2 = 340,                  /* tBDOT2  */
+    tBDOT3 = 341,                  /* tBDOT3  */
+    tAREF = 342,                   /* tAREF  */
+    tASET = 343,                   /* tASET  */
+    tLSHFT = 344,                  /* tLSHFT  */
+    tRSHFT = 345,                  /* tRSHFT  */
+    tCOLON2 = 346,                 /* tCOLON2  */
+    tCOLON3 = 347,                 /* tCOLON3  */
+    tOP_ASGN = 348,                /* tOP_ASGN  */
+    tASSOC = 349,                  /* tASSOC  */
+    tLPAREN = 350,                 /* tLPAREN  */
+    tLPAREN_ARG = 351,             /* tLPAREN_ARG  */
+    tRPAREN = 352,                 /* tRPAREN  */
+    tLBRACK = 353,                 /* tLBRACK  */
+    tLBRACE = 354,                 /* tLBRACE  */
+    tLBRACE_ARG = 355,             /* tLBRACE_ARG  */
+    tSTAR = 356,                   /* tSTAR  */
+    tDSTAR = 357,                  /* tDSTAR  */
+    tAMPER = 358,                  /* tAMPER  */
+    tLAMBDA = 359,                 /* tLAMBDA  */
+    tANDDOT = 360,                 /* tANDDOT  */
+    tSYMBEG = 361,                 /* tSYMBEG  */
+    tREGEXP_BEG = 362,             /* tREGEXP_BEG  */
+    tWORDS_BEG = 363,              /* tWORDS_BEG  */
+    tSYMBOLS_BEG = 364,            /* tSYMBOLS_BEG  */
+    tSTRING_BEG = 365,             /* tSTRING_BEG  */
+    tXSTRING_BEG = 366,            /* tXSTRING_BEG  */
+    tSTRING_DVAR = 367,            /* tSTRING_DVAR  */
+    tLAMBEG = 368,                 /* tLAMBEG  */
+    tHEREDOC_BEG = 369,            /* tHEREDOC_BEG  */
+    tHEREDOC_END = 370,            /* tHEREDOC_END  */
+    tLITERAL_DELIM = 371,          /* tLITERAL_DELIM  */
+    tHD_LITERAL_DELIM = 372,       /* tHD_LITERAL_DELIM  */
+    tHD_STRING_PART = 373,         /* tHD_STRING_PART  */
+    tHD_STRING_MID = 374,          /* tHD_STRING_MID  */
+    tLOWEST = 375,                 /* tLOWEST  */
+    tUMINUS_NUM = 376,             /* tUMINUS_NUM  */
+    tLAST_TOKEN = 377              /* tLAST_TOKEN  */
   };
+  typedef enum yytokentype yytoken_kind_t;
 #endif
 
 /* Value type.  */
@@ -1611,7 +1609,7 @@ union YYSTYPE
     stack_type stack;
     const struct vtable *vars;
 
-#line 1615 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 1613 "mrbgems/mruby-compiler/core/y.tab.c"
 
 };
 typedef union YYSTYPE YYSTYPE;
@@ -1623,6 +1621,338 @@ typedef union YYSTYPE YYSTYPE;
 
 int yyparse (parser_state *p);
 
+
+/* Symbol kind.  */
+enum yysymbol_kind_t
+{
+  YYSYMBOL_YYEMPTY = -2,
+  YYSYMBOL_YYEOF = 0,                      /* "end of file"  */
+  YYSYMBOL_YYerror = 1,                    /* error  */
+  YYSYMBOL_YYUNDEF = 2,                    /* "invalid token"  */
+  YYSYMBOL_keyword_class = 3,              /* keyword_class  */
+  YYSYMBOL_keyword_module = 4,             /* keyword_module  */
+  YYSYMBOL_keyword_def = 5,                /* keyword_def  */
+  YYSYMBOL_keyword_begin = 6,              /* keyword_begin  */
+  YYSYMBOL_keyword_if = 7,                 /* keyword_if  */
+  YYSYMBOL_keyword_unless = 8,             /* keyword_unless  */
+  YYSYMBOL_keyword_while = 9,              /* keyword_while  */
+  YYSYMBOL_keyword_until = 10,             /* keyword_until  */
+  YYSYMBOL_keyword_for = 11,               /* keyword_for  */
+  YYSYMBOL_keyword_undef = 12,             /* keyword_undef  */
+  YYSYMBOL_keyword_rescue = 13,            /* keyword_rescue  */
+  YYSYMBOL_keyword_ensure = 14,            /* keyword_ensure  */
+  YYSYMBOL_keyword_end = 15,               /* keyword_end  */
+  YYSYMBOL_keyword_then = 16,              /* keyword_then  */
+  YYSYMBOL_keyword_elsif = 17,             /* keyword_elsif  */
+  YYSYMBOL_keyword_else = 18,              /* keyword_else  */
+  YYSYMBOL_keyword_case = 19,              /* keyword_case  */
+  YYSYMBOL_keyword_when = 20,              /* keyword_when  */
+  YYSYMBOL_keyword_break = 21,             /* keyword_break  */
+  YYSYMBOL_keyword_next = 22,              /* keyword_next  */
+  YYSYMBOL_keyword_redo = 23,              /* keyword_redo  */
+  YYSYMBOL_keyword_retry = 24,             /* keyword_retry  */
+  YYSYMBOL_keyword_in = 25,                /* keyword_in  */
+  YYSYMBOL_keyword_do = 26,                /* keyword_do  */
+  YYSYMBOL_keyword_do_cond = 27,           /* keyword_do_cond  */
+  YYSYMBOL_keyword_do_block = 28,          /* keyword_do_block  */
+  YYSYMBOL_keyword_do_LAMBDA = 29,         /* keyword_do_LAMBDA  */
+  YYSYMBOL_keyword_return = 30,            /* keyword_return  */
+  YYSYMBOL_keyword_yield = 31,             /* keyword_yield  */
+  YYSYMBOL_keyword_super = 32,             /* keyword_super  */
+  YYSYMBOL_keyword_self = 33,              /* keyword_self  */
+  YYSYMBOL_keyword_nil = 34,               /* keyword_nil  */
+  YYSYMBOL_keyword_true = 35,              /* keyword_true  */
+  YYSYMBOL_keyword_false = 36,             /* keyword_false  */
+  YYSYMBOL_keyword_and = 37,               /* keyword_and  */
+  YYSYMBOL_keyword_or = 38,                /* keyword_or  */
+  YYSYMBOL_keyword_not = 39,               /* keyword_not  */
+  YYSYMBOL_modifier_if = 40,               /* modifier_if  */
+  YYSYMBOL_modifier_unless = 41,           /* modifier_unless  */
+  YYSYMBOL_modifier_while = 42,            /* modifier_while  */
+  YYSYMBOL_modifier_until = 43,            /* modifier_until  */
+  YYSYMBOL_modifier_rescue = 44,           /* modifier_rescue  */
+  YYSYMBOL_keyword_alias = 45,             /* keyword_alias  */
+  YYSYMBOL_keyword_BEGIN = 46,             /* keyword_BEGIN  */
+  YYSYMBOL_keyword_END = 47,               /* keyword_END  */
+  YYSYMBOL_keyword__LINE__ = 48,           /* keyword__LINE__  */
+  YYSYMBOL_keyword__FILE__ = 49,           /* keyword__FILE__  */
+  YYSYMBOL_keyword__ENCODING__ = 50,       /* keyword__ENCODING__  */
+  YYSYMBOL_tIDENTIFIER = 51,               /* tIDENTIFIER  */
+  YYSYMBOL_tFID = 52,                      /* tFID  */
+  YYSYMBOL_tGVAR = 53,                     /* tGVAR  */
+  YYSYMBOL_tIVAR = 54,                     /* tIVAR  */
+  YYSYMBOL_tCONSTANT = 55,                 /* tCONSTANT  */
+  YYSYMBOL_tCVAR = 56,                     /* tCVAR  */
+  YYSYMBOL_tLABEL_TAG = 57,                /* tLABEL_TAG  */
+  YYSYMBOL_tINTEGER = 58,                  /* tINTEGER  */
+  YYSYMBOL_tFLOAT = 59,                    /* tFLOAT  */
+  YYSYMBOL_tCHAR = 60,                     /* tCHAR  */
+  YYSYMBOL_tXSTRING = 61,                  /* tXSTRING  */
+  YYSYMBOL_tREGEXP = 62,                   /* tREGEXP  */
+  YYSYMBOL_tSTRING = 63,                   /* tSTRING  */
+  YYSYMBOL_tSTRING_PART = 64,              /* tSTRING_PART  */
+  YYSYMBOL_tSTRING_MID = 65,               /* tSTRING_MID  */
+  YYSYMBOL_tNTH_REF = 66,                  /* tNTH_REF  */
+  YYSYMBOL_tBACK_REF = 67,                 /* tBACK_REF  */
+  YYSYMBOL_tREGEXP_END = 68,               /* tREGEXP_END  */
+  YYSYMBOL_tNUMPARAM = 69,                 /* tNUMPARAM  */
+  YYSYMBOL_tUPLUS = 70,                    /* tUPLUS  */
+  YYSYMBOL_tUMINUS = 71,                   /* tUMINUS  */
+  YYSYMBOL_tPOW = 72,                      /* tPOW  */
+  YYSYMBOL_tCMP = 73,                      /* tCMP  */
+  YYSYMBOL_tEQ = 74,                       /* tEQ  */
+  YYSYMBOL_tEQQ = 75,                      /* tEQQ  */
+  YYSYMBOL_tNEQ = 76,                      /* tNEQ  */
+  YYSYMBOL_tGEQ = 77,                      /* tGEQ  */
+  YYSYMBOL_tLEQ = 78,                      /* tLEQ  */
+  YYSYMBOL_tANDOP = 79,                    /* tANDOP  */
+  YYSYMBOL_tOROP = 80,                     /* tOROP  */
+  YYSYMBOL_tMATCH = 81,                    /* tMATCH  */
+  YYSYMBOL_tNMATCH = 82,                   /* tNMATCH  */
+  YYSYMBOL_tDOT2 = 83,                     /* tDOT2  */
+  YYSYMBOL_tDOT3 = 84,                     /* tDOT3  */
+  YYSYMBOL_tBDOT2 = 85,                    /* tBDOT2  */
+  YYSYMBOL_tBDOT3 = 86,                    /* tBDOT3  */
+  YYSYMBOL_tAREF = 87,                     /* tAREF  */
+  YYSYMBOL_tASET = 88,                     /* tASET  */
+  YYSYMBOL_tLSHFT = 89,                    /* tLSHFT  */
+  YYSYMBOL_tRSHFT = 90,                    /* tRSHFT  */
+  YYSYMBOL_tCOLON2 = 91,                   /* tCOLON2  */
+  YYSYMBOL_tCOLON3 = 92,                   /* tCOLON3  */
+  YYSYMBOL_tOP_ASGN = 93,                  /* tOP_ASGN  */
+  YYSYMBOL_tASSOC = 94,                    /* tASSOC  */
+  YYSYMBOL_tLPAREN = 95,                   /* tLPAREN  */
+  YYSYMBOL_tLPAREN_ARG = 96,               /* tLPAREN_ARG  */
+  YYSYMBOL_tRPAREN = 97,                   /* tRPAREN  */
+  YYSYMBOL_tLBRACK = 98,                   /* tLBRACK  */
+  YYSYMBOL_tLBRACE = 99,                   /* tLBRACE  */
+  YYSYMBOL_tLBRACE_ARG = 100,              /* tLBRACE_ARG  */
+  YYSYMBOL_tSTAR = 101,                    /* tSTAR  */
+  YYSYMBOL_tDSTAR = 102,                   /* tDSTAR  */
+  YYSYMBOL_tAMPER = 103,                   /* tAMPER  */
+  YYSYMBOL_tLAMBDA = 104,                  /* tLAMBDA  */
+  YYSYMBOL_tANDDOT = 105,                  /* tANDDOT  */
+  YYSYMBOL_tSYMBEG = 106,                  /* tSYMBEG  */
+  YYSYMBOL_tREGEXP_BEG = 107,              /* tREGEXP_BEG  */
+  YYSYMBOL_tWORDS_BEG = 108,               /* tWORDS_BEG  */
+  YYSYMBOL_tSYMBOLS_BEG = 109,             /* tSYMBOLS_BEG  */
+  YYSYMBOL_tSTRING_BEG = 110,              /* tSTRING_BEG  */
+  YYSYMBOL_tXSTRING_BEG = 111,             /* tXSTRING_BEG  */
+  YYSYMBOL_tSTRING_DVAR = 112,             /* tSTRING_DVAR  */
+  YYSYMBOL_tLAMBEG = 113,                  /* tLAMBEG  */
+  YYSYMBOL_tHEREDOC_BEG = 114,             /* tHEREDOC_BEG  */
+  YYSYMBOL_tHEREDOC_END = 115,             /* tHEREDOC_END  */
+  YYSYMBOL_tLITERAL_DELIM = 116,           /* tLITERAL_DELIM  */
+  YYSYMBOL_tHD_LITERAL_DELIM = 117,        /* tHD_LITERAL_DELIM  */
+  YYSYMBOL_tHD_STRING_PART = 118,          /* tHD_STRING_PART  */
+  YYSYMBOL_tHD_STRING_MID = 119,           /* tHD_STRING_MID  */
+  YYSYMBOL_tLOWEST = 120,                  /* tLOWEST  */
+  YYSYMBOL_121_ = 121,                     /* '='  */
+  YYSYMBOL_122_ = 122,                     /* '?'  */
+  YYSYMBOL_123_ = 123,                     /* ':'  */
+  YYSYMBOL_124_ = 124,                     /* '>'  */
+  YYSYMBOL_125_ = 125,                     /* '<'  */
+  YYSYMBOL_126_ = 126,                     /* '|'  */
+  YYSYMBOL_127_ = 127,                     /* '^'  */
+  YYSYMBOL_128_ = 128,                     /* '&'  */
+  YYSYMBOL_129_ = 129,                     /* '+'  */
+  YYSYMBOL_130_ = 130,                     /* '-'  */
+  YYSYMBOL_131_ = 131,                     /* '*'  */
+  YYSYMBOL_132_ = 132,                     /* '/'  */
+  YYSYMBOL_133_ = 133,                     /* '%'  */
+  YYSYMBOL_tUMINUS_NUM = 134,              /* tUMINUS_NUM  */
+  YYSYMBOL_135_ = 135,                     /* '!'  */
+  YYSYMBOL_136_ = 136,                     /* '~'  */
+  YYSYMBOL_tLAST_TOKEN = 137,              /* tLAST_TOKEN  */
+  YYSYMBOL_138_ = 138,                     /* '{'  */
+  YYSYMBOL_139_ = 139,                     /* '}'  */
+  YYSYMBOL_140_ = 140,                     /* '['  */
+  YYSYMBOL_141_ = 141,                     /* ']'  */
+  YYSYMBOL_142_ = 142,                     /* ','  */
+  YYSYMBOL_143_ = 143,                     /* '`'  */
+  YYSYMBOL_144_ = 144,                     /* '('  */
+  YYSYMBOL_145_ = 145,                     /* ')'  */
+  YYSYMBOL_146_ = 146,                     /* ';'  */
+  YYSYMBOL_147_ = 147,                     /* '.'  */
+  YYSYMBOL_148_n_ = 148,                   /* '\n'  */
+  YYSYMBOL_YYACCEPT = 149,                 /* $accept  */
+  YYSYMBOL_program = 150,                  /* program  */
+  YYSYMBOL_151_1 = 151,                    /* $@1  */
+  YYSYMBOL_top_compstmt = 152,             /* top_compstmt  */
+  YYSYMBOL_top_stmts = 153,                /* top_stmts  */
+  YYSYMBOL_top_stmt = 154,                 /* top_stmt  */
+  YYSYMBOL_155_2 = 155,                    /* @2  */
+  YYSYMBOL_bodystmt = 156,                 /* bodystmt  */
+  YYSYMBOL_compstmt = 157,                 /* compstmt  */
+  YYSYMBOL_stmts = 158,                    /* stmts  */
+  YYSYMBOL_stmt = 159,                     /* stmt  */
+  YYSYMBOL_160_3 = 160,                    /* $@3  */
+  YYSYMBOL_command_asgn = 161,             /* command_asgn  */
+  YYSYMBOL_command_rhs = 162,              /* command_rhs  */
+  YYSYMBOL_expr = 163,                     /* expr  */
+  YYSYMBOL_defn_head = 164,                /* defn_head  */
+  YYSYMBOL_defs_head = 165,                /* defs_head  */
+  YYSYMBOL_166_4 = 166,                    /* $@4  */
+  YYSYMBOL_expr_value = 167,               /* expr_value  */
+  YYSYMBOL_command_call = 168,             /* command_call  */
+  YYSYMBOL_block_command = 169,            /* block_command  */
+  YYSYMBOL_cmd_brace_block = 170,          /* cmd_brace_block  */
+  YYSYMBOL_171_5 = 171,                    /* $@5  */
+  YYSYMBOL_command = 172,                  /* command  */
+  YYSYMBOL_mlhs = 173,                     /* mlhs  */
+  YYSYMBOL_mlhs_inner = 174,               /* mlhs_inner  */
+  YYSYMBOL_mlhs_basic = 175,               /* mlhs_basic  */
+  YYSYMBOL_mlhs_item = 176,                /* mlhs_item  */
+  YYSYMBOL_mlhs_list = 177,                /* mlhs_list  */
+  YYSYMBOL_mlhs_post = 178,                /* mlhs_post  */
+  YYSYMBOL_mlhs_node = 179,                /* mlhs_node  */
+  YYSYMBOL_lhs = 180,                      /* lhs  */
+  YYSYMBOL_cname = 181,                    /* cname  */
+  YYSYMBOL_cpath = 182,                    /* cpath  */
+  YYSYMBOL_fname = 183,                    /* fname  */
+  YYSYMBOL_fsym = 184,                     /* fsym  */
+  YYSYMBOL_undef_list = 185,               /* undef_list  */
+  YYSYMBOL_186_6 = 186,                    /* $@6  */
+  YYSYMBOL_op = 187,                       /* op  */
+  YYSYMBOL_reswords = 188,                 /* reswords  */
+  YYSYMBOL_arg = 189,                      /* arg  */
+  YYSYMBOL_aref_args = 190,                /* aref_args  */
+  YYSYMBOL_arg_rhs = 191,                  /* arg_rhs  */
+  YYSYMBOL_paren_args = 192,               /* paren_args  */
+  YYSYMBOL_opt_paren_args = 193,           /* opt_paren_args  */
+  YYSYMBOL_opt_call_args = 194,            /* opt_call_args  */
+  YYSYMBOL_call_args = 195,                /* call_args  */
+  YYSYMBOL_command_args = 196,             /* command_args  */
+  YYSYMBOL_197_7 = 197,                    /* @7  */
+  YYSYMBOL_block_arg = 198,                /* block_arg  */
+  YYSYMBOL_opt_block_arg = 199,            /* opt_block_arg  */
+  YYSYMBOL_comma = 200,                    /* comma  */
+  YYSYMBOL_args = 201,                     /* args  */
+  YYSYMBOL_mrhs = 202,                     /* mrhs  */
+  YYSYMBOL_primary = 203,                  /* primary  */
+  YYSYMBOL_204_8 = 204,                    /* @8  */
+  YYSYMBOL_205_9 = 205,                    /* @9  */
+  YYSYMBOL_206_10 = 206,                   /* $@10  */
+  YYSYMBOL_207_11 = 207,                   /* $@11  */
+  YYSYMBOL_208_12 = 208,                   /* @12  */
+  YYSYMBOL_209_13 = 209,                   /* @13  */
+  YYSYMBOL_210_14 = 210,                   /* $@14  */
+  YYSYMBOL_211_15 = 211,                   /* $@15  */
+  YYSYMBOL_212_16 = 212,                   /* $@16  */
+  YYSYMBOL_213_17 = 213,                   /* $@17  */
+  YYSYMBOL_214_18 = 214,                   /* $@18  */
+  YYSYMBOL_215_19 = 215,                   /* $@19  */
+  YYSYMBOL_216_20 = 216,                   /* @20  */
+  YYSYMBOL_217_21 = 217,                   /* @21  */
+  YYSYMBOL_218_22 = 218,                   /* @22  */
+  YYSYMBOL_219_23 = 219,                   /* @23  */
+  YYSYMBOL_primary_value = 220,            /* primary_value  */
+  YYSYMBOL_then = 221,                     /* then  */
+  YYSYMBOL_do = 222,                       /* do  */
+  YYSYMBOL_if_tail = 223,                  /* if_tail  */
+  YYSYMBOL_opt_else = 224,                 /* opt_else  */
+  YYSYMBOL_for_var = 225,                  /* for_var  */
+  YYSYMBOL_f_margs = 226,                  /* f_margs  */
+  YYSYMBOL_227_24 = 227,                   /* $@24  */
+  YYSYMBOL_block_args_tail = 228,          /* block_args_tail  */
+  YYSYMBOL_opt_block_args_tail = 229,      /* opt_block_args_tail  */
+  YYSYMBOL_block_param = 230,              /* block_param  */
+  YYSYMBOL_opt_block_param = 231,          /* opt_block_param  */
+  YYSYMBOL_block_param_def = 232,          /* block_param_def  */
+  YYSYMBOL_233_25 = 233,                   /* $@25  */
+  YYSYMBOL_opt_bv_decl = 234,              /* opt_bv_decl  */
+  YYSYMBOL_bv_decls = 235,                 /* bv_decls  */
+  YYSYMBOL_bvar = 236,                     /* bvar  */
+  YYSYMBOL_f_larglist = 237,               /* f_larglist  */
+  YYSYMBOL_lambda_body = 238,              /* lambda_body  */
+  YYSYMBOL_do_block = 239,                 /* do_block  */
+  YYSYMBOL_240_26 = 240,                   /* $@26  */
+  YYSYMBOL_block_call = 241,               /* block_call  */
+  YYSYMBOL_method_call = 242,              /* method_call  */
+  YYSYMBOL_brace_block = 243,              /* brace_block  */
+  YYSYMBOL_244_27 = 244,                   /* @27  */
+  YYSYMBOL_245_28 = 245,                   /* @28  */
+  YYSYMBOL_case_body = 246,                /* case_body  */
+  YYSYMBOL_cases = 247,                    /* cases  */
+  YYSYMBOL_opt_rescue = 248,               /* opt_rescue  */
+  YYSYMBOL_exc_list = 249,                 /* exc_list  */
+  YYSYMBOL_exc_var = 250,                  /* exc_var  */
+  YYSYMBOL_opt_ensure = 251,               /* opt_ensure  */
+  YYSYMBOL_literal = 252,                  /* literal  */
+  YYSYMBOL_string = 253,                   /* string  */
+  YYSYMBOL_string_fragment = 254,          /* string_fragment  */
+  YYSYMBOL_string_rep = 255,               /* string_rep  */
+  YYSYMBOL_string_interp = 256,            /* string_interp  */
+  YYSYMBOL_257_29 = 257,                   /* @29  */
+  YYSYMBOL_xstring = 258,                  /* xstring  */
+  YYSYMBOL_regexp = 259,                   /* regexp  */
+  YYSYMBOL_heredoc = 260,                  /* heredoc  */
+  YYSYMBOL_heredoc_bodies = 261,           /* heredoc_bodies  */
+  YYSYMBOL_heredoc_body = 262,             /* heredoc_body  */
+  YYSYMBOL_heredoc_string_rep = 263,       /* heredoc_string_rep  */
+  YYSYMBOL_heredoc_string_interp = 264,    /* heredoc_string_interp  */
+  YYSYMBOL_265_30 = 265,                   /* @30  */
+  YYSYMBOL_words = 266,                    /* words  */
+  YYSYMBOL_symbol = 267,                   /* symbol  */
+  YYSYMBOL_basic_symbol = 268,             /* basic_symbol  */
+  YYSYMBOL_sym = 269,                      /* sym  */
+  YYSYMBOL_symbols = 270,                  /* symbols  */
+  YYSYMBOL_numeric = 271,                  /* numeric  */
+  YYSYMBOL_variable = 272,                 /* variable  */
+  YYSYMBOL_var_lhs = 273,                  /* var_lhs  */
+  YYSYMBOL_var_ref = 274,                  /* var_ref  */
+  YYSYMBOL_backref = 275,                  /* backref  */
+  YYSYMBOL_superclass = 276,               /* superclass  */
+  YYSYMBOL_277_31 = 277,                   /* $@31  */
+  YYSYMBOL_f_arglist_paren = 278,          /* f_arglist_paren  */
+  YYSYMBOL_f_arglist = 279,                /* f_arglist  */
+  YYSYMBOL_f_label = 280,                  /* f_label  */
+  YYSYMBOL_f_kw = 281,                     /* f_kw  */
+  YYSYMBOL_f_block_kw = 282,               /* f_block_kw  */
+  YYSYMBOL_f_block_kwarg = 283,            /* f_block_kwarg  */
+  YYSYMBOL_f_kwarg = 284,                  /* f_kwarg  */
+  YYSYMBOL_kwrest_mark = 285,              /* kwrest_mark  */
+  YYSYMBOL_f_kwrest = 286,                 /* f_kwrest  */
+  YYSYMBOL_args_tail = 287,                /* args_tail  */
+  YYSYMBOL_opt_args_tail = 288,            /* opt_args_tail  */
+  YYSYMBOL_f_args = 289,                   /* f_args  */
+  YYSYMBOL_f_bad_arg = 290,                /* f_bad_arg  */
+  YYSYMBOL_f_norm_arg = 291,               /* f_norm_arg  */
+  YYSYMBOL_f_arg_item = 292,               /* f_arg_item  */
+  YYSYMBOL_293_32 = 293,                   /* @32  */
+  YYSYMBOL_f_arg = 294,                    /* f_arg  */
+  YYSYMBOL_f_opt_asgn = 295,               /* f_opt_asgn  */
+  YYSYMBOL_f_opt = 296,                    /* f_opt  */
+  YYSYMBOL_f_block_opt = 297,              /* f_block_opt  */
+  YYSYMBOL_f_block_optarg = 298,           /* f_block_optarg  */
+  YYSYMBOL_f_optarg = 299,                 /* f_optarg  */
+  YYSYMBOL_restarg_mark = 300,             /* restarg_mark  */
+  YYSYMBOL_f_rest_arg = 301,               /* f_rest_arg  */
+  YYSYMBOL_blkarg_mark = 302,              /* blkarg_mark  */
+  YYSYMBOL_f_block_arg = 303,              /* f_block_arg  */
+  YYSYMBOL_opt_f_block_arg = 304,          /* opt_f_block_arg  */
+  YYSYMBOL_singleton = 305,                /* singleton  */
+  YYSYMBOL_306_33 = 306,                   /* $@33  */
+  YYSYMBOL_assoc_list = 307,               /* assoc_list  */
+  YYSYMBOL_assocs = 308,                   /* assocs  */
+  YYSYMBOL_label_tag = 309,                /* label_tag  */
+  YYSYMBOL_assoc = 310,                    /* assoc  */
+  YYSYMBOL_operation = 311,                /* operation  */
+  YYSYMBOL_operation2 = 312,               /* operation2  */
+  YYSYMBOL_operation3 = 313,               /* operation3  */
+  YYSYMBOL_dot_or_colon = 314,             /* dot_or_colon  */
+  YYSYMBOL_call_op = 315,                  /* call_op  */
+  YYSYMBOL_call_op2 = 316,                 /* call_op2  */
+  YYSYMBOL_opt_terms = 317,                /* opt_terms  */
+  YYSYMBOL_opt_nl = 318,                   /* opt_nl  */
+  YYSYMBOL_rparen = 319,                   /* rparen  */
+  YYSYMBOL_trailer = 320,                  /* trailer  */
+  YYSYMBOL_term = 321,                     /* term  */
+  YYSYMBOL_nl = 322,                       /* nl  */
+  YYSYMBOL_terms = 323,                    /* terms  */
+  YYSYMBOL_none = 324                      /* none  */
+};
+typedef enum yysymbol_kind_t yysymbol_kind_t;
 
 
 
@@ -1723,6 +2053,7 @@ typedef int yytype_uint16;
 
 #define YYSIZEOF(X) YY_CAST (YYPTRDIFF_T, sizeof (X))
 
+
 /* Stored state numbers (used for stacks). */
 typedef yytype_int16 yy_state_t;
 
@@ -1740,6 +2071,7 @@ typedef int yy_state_fast_t;
 #  define YY_(Msgid) Msgid
 # endif
 #endif
+
 
 #ifndef YY_ATTRIBUTE_PURE
 # if defined __GNUC__ && 2 < __GNUC__ + (96 <= __GNUC_MINOR__)
@@ -1798,7 +2130,7 @@ typedef int yy_state_fast_t;
 
 #define YY_ASSERT(E) ((void) (0 && (E)))
 
-#if ! defined yyoverflow || YYERROR_VERBOSE
+#if 1
 
 /* The parser invokes alloca or malloc; define the necessary symbols.  */
 
@@ -1863,8 +2195,7 @@ void free (void *); /* INFRINGES ON USER NAME SPACE */
 #   endif
 #  endif
 # endif
-#endif /* ! defined yyoverflow || YYERROR_VERBOSE */
-
+#endif /* 1 */
 
 #if (! defined yyoverflow \
      && (! defined __cplusplus \
@@ -1940,14 +2271,16 @@ union yyalloc
 /* YYNSTATES -- Number of states.  */
 #define YYNSTATES  1061
 
-#define YYUNDEFTOK  2
+/* YYMAXUTOK -- Last valid token kind.  */
 #define YYMAXUTOK   377
 
 
 /* YYTRANSLATE(TOKEN-NUM) -- Symbol number corresponding to TOKEN-NUM
    as returned by yylex, with out-of-bounds checking.  */
-#define YYTRANSLATE(YYX)                                                \
-  (0 <= (YYX) && (YYX) <= YYMAXUTOK ? yytranslate[YYX] : YYUNDEFTOK)
+#define YYTRANSLATE(YYX)                                \
+  (0 <= (YYX) && (YYX) <= YYMAXUTOK                     \
+   ? YY_CAST (yysymbol_kind_t, yytranslate[YYX])        \
+   : YYSYMBOL_YYUNDEF)
 
 /* YYTRANSLATE[TOKEN-NUM] -- Symbol number corresponding to TOKEN-NUM
    as returned by yylex.  */
@@ -2061,26 +2394,34 @@ static const yytype_int16 yyrline[] =
 };
 #endif
 
-#if YYDEBUG || YYERROR_VERBOSE || 1
+/** Accessing symbol of state STATE.  */
+#define YY_ACCESSING_SYMBOL(State) YY_CAST (yysymbol_kind_t, yystos[State])
+
+#if 1
+/* The user-facing name of the symbol whose (internal) number is
+   YYSYMBOL.  No bounds checking.  */
+static const char *yysymbol_name (yysymbol_kind_t yysymbol) YY_ATTRIBUTE_UNUSED;
+
 /* YYTNAME[SYMBOL-NUM] -- String name of the symbol SYMBOL-NUM.
    First, the terminals, then, starting at YYNTOKENS, nonterminals.  */
 static const char *const yytname[] =
 {
-  "$end", "error", "$undefined", "keyword_class", "keyword_module",
-  "keyword_def", "keyword_begin", "keyword_if", "keyword_unless",
-  "keyword_while", "keyword_until", "keyword_for", "keyword_undef",
-  "keyword_rescue", "keyword_ensure", "keyword_end", "keyword_then",
-  "keyword_elsif", "keyword_else", "keyword_case", "keyword_when",
-  "keyword_break", "keyword_next", "keyword_redo", "keyword_retry",
-  "keyword_in", "keyword_do", "keyword_do_cond", "keyword_do_block",
-  "keyword_do_LAMBDA", "keyword_return", "keyword_yield", "keyword_super",
-  "keyword_self", "keyword_nil", "keyword_true", "keyword_false",
-  "keyword_and", "keyword_or", "keyword_not", "modifier_if",
-  "modifier_unless", "modifier_while", "modifier_until", "modifier_rescue",
-  "keyword_alias", "keyword_BEGIN", "keyword_END", "keyword__LINE__",
-  "keyword__FILE__", "keyword__ENCODING__", "tIDENTIFIER", "tFID", "tGVAR",
-  "tIVAR", "tCONSTANT", "tCVAR", "tLABEL_TAG", "tINTEGER", "tFLOAT",
-  "tCHAR", "tXSTRING", "tREGEXP", "tSTRING", "tSTRING_PART", "tSTRING_MID",
+  "\"end of file\"", "error", "\"invalid token\"", "keyword_class",
+  "keyword_module", "keyword_def", "keyword_begin", "keyword_if",
+  "keyword_unless", "keyword_while", "keyword_until", "keyword_for",
+  "keyword_undef", "keyword_rescue", "keyword_ensure", "keyword_end",
+  "keyword_then", "keyword_elsif", "keyword_else", "keyword_case",
+  "keyword_when", "keyword_break", "keyword_next", "keyword_redo",
+  "keyword_retry", "keyword_in", "keyword_do", "keyword_do_cond",
+  "keyword_do_block", "keyword_do_LAMBDA", "keyword_return",
+  "keyword_yield", "keyword_super", "keyword_self", "keyword_nil",
+  "keyword_true", "keyword_false", "keyword_and", "keyword_or",
+  "keyword_not", "modifier_if", "modifier_unless", "modifier_while",
+  "modifier_until", "modifier_rescue", "keyword_alias", "keyword_BEGIN",
+  "keyword_END", "keyword__LINE__", "keyword__FILE__",
+  "keyword__ENCODING__", "tIDENTIFIER", "tFID", "tGVAR", "tIVAR",
+  "tCONSTANT", "tCVAR", "tLABEL_TAG", "tINTEGER", "tFLOAT", "tCHAR",
+  "tXSTRING", "tREGEXP", "tSTRING", "tSTRING_PART", "tSTRING_MID",
   "tNTH_REF", "tBACK_REF", "tREGEXP_END", "tNUMPARAM", "tUPLUS", "tUMINUS",
   "tPOW", "tCMP", "tEQ", "tEQQ", "tNEQ", "tGEQ", "tLEQ", "tANDOP", "tOROP",
   "tMATCH", "tNMATCH", "tDOT2", "tDOT3", "tBDOT2", "tBDOT3", "tAREF",
@@ -2126,9 +2467,15 @@ static const char *const yytname[] =
   "call_op2", "opt_terms", "opt_nl", "rparen", "trailer", "term", "nl",
   "terms", "none", YY_NULLPTR
 };
+
+static const char *
+yysymbol_name (yysymbol_kind_t yysymbol)
+{
+  return yytname[yysymbol];
+}
 #endif
 
-# ifdef YYPRINT
+#ifdef YYPRINT
 /* YYTOKNUM[NUM] -- (External) token number corresponding to the
    (internal) symbol number NUM (which must be that of a token).  */
 static const yytype_int16 yytoknum[] =
@@ -2149,7 +2496,7 @@ static const yytype_int16 yytoknum[] =
       45,    42,    47,    37,   376,    33,   126,   377,   123,   125,
       91,    93,    44,    96,    40,    41,    59,    46,    10
 };
-# endif
+#endif
 
 #define YYPACT_NINF (-838)
 
@@ -5171,10 +5518,10 @@ static const yytype_int8 yyr2[] =
 };
 
 
+enum { YYENOMEM = -2 };
+
 #define yyerrok         (yyerrstatus = 0)
 #define yyclearin       (yychar = YYEMPTY)
-#define YYEMPTY         (-2)
-#define YYEOF           0
 
 #define YYACCEPT        goto yyacceptlab
 #define YYABORT         goto yyabortlab
@@ -5200,10 +5547,9 @@ static const yytype_int8 yyr2[] =
       }                                                           \
   while (0)
 
-/* Error token number */
-#define YYTERROR        1
-#define YYERRCODE       256
-
+/* Backward compatibility with an undocumented macro.
+   Use YYerror or YYUNDEF. */
+#define YYERRCODE YYUNDEF
 
 
 /* Enable debugging if requested.  */
@@ -5221,18 +5567,18 @@ do {                                            \
 } while (0)
 
 /* This macro is provided for backward compatibility. */
-#ifndef YY_LOCATION_PRINT
-# define YY_LOCATION_PRINT(File, Loc) ((void) 0)
-#endif
+# ifndef YY_LOCATION_PRINT
+#  define YY_LOCATION_PRINT(File, Loc) ((void) 0)
+# endif
 
 
-# define YY_SYMBOL_PRINT(Title, Type, Value, Location)                    \
+# define YY_SYMBOL_PRINT(Title, Kind, Value, Location)                    \
 do {                                                                      \
   if (yydebug)                                                            \
     {                                                                     \
       YYFPRINTF (stderr, "%s ", Title);                                   \
       yy_symbol_print (stderr,                                            \
-                  Type, Value, p); \
+                  Kind, Value, p); \
       YYFPRINTF (stderr, "\n");                                           \
     }                                                                     \
 } while (0)
@@ -5243,7 +5589,8 @@ do {                                                                      \
 `-----------------------------------*/
 
 static void
-yy_symbol_value_print (FILE *yyo, int yytype, YYSTYPE const * const yyvaluep, parser_state *p)
+yy_symbol_value_print (FILE *yyo,
+                       yysymbol_kind_t yykind, YYSTYPE const * const yyvaluep, parser_state *p)
 {
   FILE *yyoutput = yyo;
   YYUSE (yyoutput);
@@ -5251,11 +5598,11 @@ yy_symbol_value_print (FILE *yyo, int yytype, YYSTYPE const * const yyvaluep, pa
   if (!yyvaluep)
     return;
 # ifdef YYPRINT
-  if (yytype < YYNTOKENS)
-    YYPRINT (yyo, yytoknum[yytype], *yyvaluep);
+  if (yykind < YYNTOKENS)
+    YYPRINT (yyo, yytoknum[yykind], *yyvaluep);
 # endif
   YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
-  YYUSE (yytype);
+  YYUSE (yykind);
   YY_IGNORE_MAYBE_UNINITIALIZED_END
 }
 
@@ -5265,12 +5612,13 @@ yy_symbol_value_print (FILE *yyo, int yytype, YYSTYPE const * const yyvaluep, pa
 `---------------------------*/
 
 static void
-yy_symbol_print (FILE *yyo, int yytype, YYSTYPE const * const yyvaluep, parser_state *p)
+yy_symbol_print (FILE *yyo,
+                 yysymbol_kind_t yykind, YYSTYPE const * const yyvaluep, parser_state *p)
 {
   YYFPRINTF (yyo, "%s %s (",
-             yytype < YYNTOKENS ? "token" : "nterm", yytname[yytype]);
+             yykind < YYNTOKENS ? "token" : "nterm", yysymbol_name (yykind));
 
-  yy_symbol_value_print (yyo, yytype, yyvaluep, p);
+  yy_symbol_value_print (yyo, yykind, yyvaluep, p);
   YYFPRINTF (yyo, ")");
 }
 
@@ -5303,7 +5651,8 @@ do {                                                            \
 `------------------------------------------------*/
 
 static void
-yy_reduce_print (yy_state_t *yyssp, YYSTYPE *yyvsp, int yyrule, parser_state *p)
+yy_reduce_print (yy_state_t *yyssp, YYSTYPE *yyvsp,
+                 int yyrule, parser_state *p)
 {
   int yylno = yyrline[yyrule];
   int yynrhs = yyr2[yyrule];
@@ -5315,9 +5664,8 @@ yy_reduce_print (yy_state_t *yyssp, YYSTYPE *yyvsp, int yyrule, parser_state *p)
     {
       YYFPRINTF (stderr, "   $%d = ", yyi + 1);
       yy_symbol_print (stderr,
-                       yystos[+yyssp[yyi + 1 - yynrhs]],
-                       &yyvsp[(yyi + 1) - (yynrhs)]
-                                              , p);
+                       YY_ACCESSING_SYMBOL (+yyssp[yyi + 1 - yynrhs]),
+                       &yyvsp[(yyi + 1) - (yynrhs)], p);
       YYFPRINTF (stderr, "\n");
     }
 }
@@ -5332,8 +5680,8 @@ do {                                    \
    multiple parsers can coexist.  */
 int yydebug;
 #else /* !YYDEBUG */
-# define YYDPRINTF(Args)
-# define YY_SYMBOL_PRINT(Title, Type, Value, Location)
+# define YYDPRINTF(Args) ((void) 0)
+# define YY_SYMBOL_PRINT(Title, Kind, Value, Location)
 # define YY_STACK_PRINT(Bottom, Top)
 # define YY_REDUCE_PRINT(Rule)
 #endif /* !YYDEBUG */
@@ -5356,12 +5704,60 @@ int yydebug;
 #endif
 
 
-#if YYERROR_VERBOSE
+/* Context of a parse error.  */
+typedef struct
+{
+  yy_state_t *yyssp;
+  yysymbol_kind_t yytoken;
+} yypcontext_t;
 
-# ifndef yystrlen
-#  if defined __GLIBC__ && defined _STRING_H
-#   define yystrlen(S) (YY_CAST (YYPTRDIFF_T, strlen (S)))
-#  else
+/* Put in YYARG at most YYARGN of the expected tokens given the
+   current YYCTX, and return the number of tokens stored in YYARG.  If
+   YYARG is null, return the number of expected tokens (guaranteed to
+   be less than YYNTOKENS).  Return YYENOMEM on memory exhaustion.
+   Return 0 if there are more than YYARGN expected tokens, yet fill
+   YYARG up to YYARGN. */
+static int
+yypcontext_expected_tokens (const yypcontext_t *yyctx,
+                            yysymbol_kind_t yyarg[], int yyargn)
+{
+  /* Actual size of YYARG. */
+  int yycount = 0;
+  int yyn = yypact[+*yyctx->yyssp];
+  if (!yypact_value_is_default (yyn))
+    {
+      /* Start YYX at -YYN if negative to avoid negative indexes in
+         YYCHECK.  In other words, skip the first -YYN actions for
+         this state because they are default actions.  */
+      int yyxbegin = yyn < 0 ? -yyn : 0;
+      /* Stay within bounds of both yycheck and yytname.  */
+      int yychecklim = YYLAST - yyn + 1;
+      int yyxend = yychecklim < YYNTOKENS ? yychecklim : YYNTOKENS;
+      int yyx;
+      for (yyx = yyxbegin; yyx < yyxend; ++yyx)
+        if (yycheck[yyx + yyn] == yyx && yyx != YYSYMBOL_YYerror
+            && !yytable_value_is_error (yytable[yyx + yyn]))
+          {
+            if (!yyarg)
+              ++yycount;
+            else if (yycount == yyargn)
+              return 0;
+            else
+              yyarg[yycount++] = YY_CAST (yysymbol_kind_t, yyx);
+          }
+    }
+  if (yyarg && yycount == 0 && 0 < yyargn)
+    yyarg[0] = YYSYMBOL_YYEMPTY;
+  return yycount;
+}
+
+
+
+
+#ifndef yystrlen
+# if defined __GLIBC__ && defined _STRING_H
+#  define yystrlen(S) (YY_CAST (YYPTRDIFF_T, strlen (S)))
+# else
 /* Return the length of YYSTR.  */
 static YYPTRDIFF_T
 yystrlen (const char *yystr)
@@ -5371,13 +5767,13 @@ yystrlen (const char *yystr)
     continue;
   return yylen;
 }
-#  endif
 # endif
+#endif
 
-# ifndef yystpcpy
-#  if defined __GLIBC__ && defined _STRING_H && defined _GNU_SOURCE
-#   define yystpcpy stpcpy
-#  else
+#ifndef yystpcpy
+# if defined __GLIBC__ && defined _STRING_H && defined _GNU_SOURCE
+#  define yystpcpy stpcpy
+# else
 /* Copy YYSRC to YYDEST, returning the address of the terminating '\0' in
    YYDEST.  */
 static char *
@@ -5391,10 +5787,10 @@ yystpcpy (char *yydest, const char *yysrc)
 
   return yyd - 1;
 }
-#  endif
 # endif
+#endif
 
-# ifndef yytnamerr
+#ifndef yytnamerr
 /* Copy to YYRES the contents of YYSTR after stripping away unnecessary
    quotes and backslashes, so that it's suitable for yyerror.  The
    heuristic is that double-quoting is unnecessary unless the string
@@ -5409,7 +5805,6 @@ yytnamerr (char *yyres, const char *yystr)
     {
       YYPTRDIFF_T yyn = 0;
       char const *yyp = yystr;
-
       for (;;)
         switch (*++yyp)
           {
@@ -5443,31 +5838,15 @@ yytnamerr (char *yyres, const char *yystr)
   else
     return yystrlen (yystr);
 }
-# endif
+#endif
 
-/* Copy into *YYMSG, which is of size *YYMSG_ALLOC, an error message
-   about the unexpected token YYTOKEN for the state stack whose top is
-   YYSSP.
 
-   Return 0 if *YYMSG was successfully written.  Return 1 if *YYMSG is
-   not large enough to hold the message.  In that case, also set
-   *YYMSG_ALLOC to the required number of bytes.  Return 2 if the
-   required number of bytes is too large to store.  */
 static int
-yysyntax_error (YYPTRDIFF_T *yymsg_alloc, char **yymsg,
-                yy_state_t *yyssp, int yytoken)
+yy_syntax_error_arguments (const yypcontext_t *yyctx,
+                           yysymbol_kind_t yyarg[], int yyargn)
 {
-  enum { YYERROR_VERBOSE_ARGS_MAXIMUM = 5 };
-  /* Internationalized format string. */
-  const char *yyformat = YY_NULLPTR;
-  /* Arguments of yyformat: reported tokens (one for the "unexpected",
-     one per "expected"). */
-  char const *yyarg[YYERROR_VERBOSE_ARGS_MAXIMUM];
   /* Actual size of YYARG. */
   int yycount = 0;
-  /* Cumulated lengths of YYARG.  */
-  YYPTRDIFF_T yysize = 0;
-
   /* There are many possibilities here to consider:
      - If this state is a consistent state with a default action, then
        the only way this function was invoked is if the default action
@@ -5491,52 +5870,54 @@ yysyntax_error (YYPTRDIFF_T *yymsg_alloc, char **yymsg,
        one exception: it will still contain any token that will not be
        accepted due to an error action in a later state.
   */
-  if (yytoken != YYEMPTY)
+  if (yyctx->yytoken != YYSYMBOL_YYEMPTY)
     {
-      int yyn = yypact[+*yyssp];
-      YYPTRDIFF_T yysize0 = yytnamerr (YY_NULLPTR, yytname[yytoken]);
-      yysize = yysize0;
-      yyarg[yycount++] = yytname[yytoken];
-      if (!yypact_value_is_default (yyn))
-        {
-          /* Start YYX at -YYN if negative to avoid negative indexes in
-             YYCHECK.  In other words, skip the first -YYN actions for
-             this state because they are default actions.  */
-          int yyxbegin = yyn < 0 ? -yyn : 0;
-          /* Stay within bounds of both yycheck and yytname.  */
-          int yychecklim = YYLAST - yyn + 1;
-          int yyxend = yychecklim < YYNTOKENS ? yychecklim : YYNTOKENS;
-          int yyx;
-
-          for (yyx = yyxbegin; yyx < yyxend; ++yyx)
-            if (yycheck[yyx + yyn] == yyx && yyx != YYTERROR
-                && !yytable_value_is_error (yytable[yyx + yyn]))
-              {
-                if (yycount == YYERROR_VERBOSE_ARGS_MAXIMUM)
-                  {
-                    yycount = 1;
-                    yysize = yysize0;
-                    break;
-                  }
-                yyarg[yycount++] = yytname[yyx];
-                {
-                  YYPTRDIFF_T yysize1
-                    = yysize + yytnamerr (YY_NULLPTR, yytname[yyx]);
-                  if (yysize <= yysize1 && yysize1 <= YYSTACK_ALLOC_MAXIMUM)
-                    yysize = yysize1;
-                  else
-                    return 2;
-                }
-              }
-        }
+      int yyn;
+      if (yyarg)
+        yyarg[yycount] = yyctx->yytoken;
+      ++yycount;
+      yyn = yypcontext_expected_tokens (yyctx,
+                                        yyarg ? yyarg + 1 : yyarg, yyargn - 1);
+      if (yyn == YYENOMEM)
+        return YYENOMEM;
+      else
+        yycount += yyn;
     }
+  return yycount;
+}
+
+/* Copy into *YYMSG, which is of size *YYMSG_ALLOC, an error message
+   about the unexpected token YYTOKEN for the state stack whose top is
+   YYSSP.
+
+   Return 0 if *YYMSG was successfully written.  Return -1 if *YYMSG is
+   not large enough to hold the message.  In that case, also set
+   *YYMSG_ALLOC to the required number of bytes.  Return YYENOMEM if the
+   required number of bytes is too large to store.  */
+static int
+yysyntax_error (YYPTRDIFF_T *yymsg_alloc, char **yymsg,
+                const yypcontext_t *yyctx)
+{
+  enum { YYARGS_MAX = 5 };
+  /* Internationalized format string. */
+  const char *yyformat = YY_NULLPTR;
+  /* Arguments of yyformat: reported tokens (one for the "unexpected",
+     one per "expected"). */
+  yysymbol_kind_t yyarg[YYARGS_MAX];
+  /* Cumulated lengths of YYARG.  */
+  YYPTRDIFF_T yysize = 0;
+
+  /* Actual size of YYARG. */
+  int yycount = yy_syntax_error_arguments (yyctx, yyarg, YYARGS_MAX);
+  if (yycount == YYENOMEM)
+    return YYENOMEM;
 
   switch (yycount)
     {
-# define YYCASE_(N, S)                      \
+#define YYCASE_(N, S)                       \
       case N:                               \
         yyformat = S;                       \
-      break
+        break
     default: /* Avoid compiler warnings. */
       YYCASE_(0, YY_("syntax error"));
       YYCASE_(1, YY_("syntax error, unexpected %s"));
@@ -5544,17 +5925,23 @@ yysyntax_error (YYPTRDIFF_T *yymsg_alloc, char **yymsg,
       YYCASE_(3, YY_("syntax error, unexpected %s, expecting %s or %s"));
       YYCASE_(4, YY_("syntax error, unexpected %s, expecting %s or %s or %s"));
       YYCASE_(5, YY_("syntax error, unexpected %s, expecting %s or %s or %s or %s"));
-# undef YYCASE_
+#undef YYCASE_
     }
 
+  /* Compute error message size.  Don't count the "%s"s, but reserve
+     room for the terminator.  */
+  yysize = yystrlen (yyformat) - 2 * yycount + 1;
   {
-    /* Don't count the "%s"s in the final size, but reserve room for
-       the terminator.  */
-    YYPTRDIFF_T yysize1 = yysize + (yystrlen (yyformat) - 2 * yycount) + 1;
-    if (yysize <= yysize1 && yysize1 <= YYSTACK_ALLOC_MAXIMUM)
-      yysize = yysize1;
-    else
-      return 2;
+    int yyi;
+    for (yyi = 0; yyi < yycount; ++yyi)
+      {
+        YYPTRDIFF_T yysize1
+          = yysize + yytnamerr (YY_NULLPTR, yytname[yyarg[yyi]]);
+        if (yysize <= yysize1 && yysize1 <= YYSTACK_ALLOC_MAXIMUM)
+          yysize = yysize1;
+        else
+          return YYENOMEM;
+      }
   }
 
   if (*yymsg_alloc < yysize)
@@ -5563,7 +5950,7 @@ yysyntax_error (YYPTRDIFF_T *yymsg_alloc, char **yymsg,
       if (! (yysize <= *yymsg_alloc
              && *yymsg_alloc <= YYSTACK_ALLOC_MAXIMUM))
         *yymsg_alloc = YYSTACK_ALLOC_MAXIMUM;
-      return 1;
+      return -1;
     }
 
   /* Avoid sprintf, as that infringes on the user's name space.
@@ -5575,7 +5962,7 @@ yysyntax_error (YYPTRDIFF_T *yymsg_alloc, char **yymsg,
     while ((*yyp = *yyformat) != '\0')
       if (*yyp == '%' && yyformat[1] == 's' && yyi < yycount)
         {
-          yyp += yytnamerr (yyp, yyarg[yyi++]);
+          yyp += yytnamerr (yyp, yytname[yyarg[yyi++]]);
           yyformat += 2;
         }
       else
@@ -5586,25 +5973,28 @@ yysyntax_error (YYPTRDIFF_T *yymsg_alloc, char **yymsg,
   }
   return 0;
 }
-#endif /* YYERROR_VERBOSE */
+
 
 /*-----------------------------------------------.
 | Release the memory associated to this symbol.  |
 `-----------------------------------------------*/
 
 static void
-yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, parser_state *p)
+yydestruct (const char *yymsg,
+            yysymbol_kind_t yykind, YYSTYPE *yyvaluep, parser_state *p)
 {
   YYUSE (yyvaluep);
   YYUSE (p);
   if (!yymsg)
     yymsg = "Deleting";
-  YY_SYMBOL_PRINT (yymsg, yytype, yyvaluep, yylocationp);
+  YY_SYMBOL_PRINT (yymsg, yykind, yyvaluep, yylocationp);
 
   YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
-  YYUSE (yytype);
+  YYUSE (yykind);
   YY_IGNORE_MAYBE_UNINITIALIZED_END
 }
+
+
 
 
 
@@ -5616,7 +6006,7 @@ yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, parser_state *p)
 int
 yyparse (parser_state *p)
 {
-/* The lookahead symbol.  */
+/* Lookahead token kind.  */
 int yychar;
 
 
@@ -5627,45 +6017,41 @@ YY_INITIAL_VALUE (static YYSTYPE yyval_default;)
 YYSTYPE yylval YY_INITIAL_VALUE (= yyval_default);
 
     /* Number of syntax errors so far.  */
-    int yynerrs;
+    int yynerrs = 0;
 
-    yy_state_fast_t yystate;
+    yy_state_fast_t yystate = 0;
     /* Number of tokens to shift before error messages enabled.  */
-    int yyerrstatus;
+    int yyerrstatus = 0;
 
-    /* The stacks and their tools:
-       'yyss': related to states.
-       'yyvs': related to semantic values.
-
-       Refer to the stacks through separate pointers, to allow yyoverflow
+    /* Refer to the stacks through separate pointers, to allow yyoverflow
        to reallocate them elsewhere.  */
 
-    /* The state stack.  */
+    /* Their size.  */
+    YYPTRDIFF_T yystacksize = YYINITDEPTH;
+
+    /* The state stack: array, bottom, top.  */
     yy_state_t yyssa[YYINITDEPTH];
-    yy_state_t *yyss;
-    yy_state_t *yyssp;
+    yy_state_t *yyss = yyssa;
+    yy_state_t *yyssp = yyss;
 
-    /* The semantic value stack.  */
+    /* The semantic value stack: array, bottom, top.  */
     YYSTYPE yyvsa[YYINITDEPTH];
-    YYSTYPE *yyvs;
-    YYSTYPE *yyvsp;
-
-    YYPTRDIFF_T yystacksize;
+    YYSTYPE *yyvs = yyvsa;
+    YYSTYPE *yyvsp = yyvs;
 
   int yyn;
+  /* The return value of yyparse.  */
   int yyresult;
-  /* Lookahead token as an internal (translated) token number.  */
-  int yytoken = 0;
+  /* Lookahead symbol kind.  */
+  yysymbol_kind_t yytoken = YYSYMBOL_YYEMPTY;
   /* The variables used to return semantic value and location from the
      action routines.  */
   YYSTYPE yyval;
 
-#if YYERROR_VERBOSE
   /* Buffer for error messages, and its allocated size.  */
   char yymsgbuf[128];
   char *yymsg = yymsgbuf;
   YYPTRDIFF_T yymsg_alloc = sizeof yymsgbuf;
-#endif
 
 #define YYPOPSTACK(N)   (yyvsp -= (N), yyssp -= (N))
 
@@ -5673,15 +6059,8 @@ YYSTYPE yylval YY_INITIAL_VALUE (= yyval_default);
      Keep to zero when no symbol should be popped.  */
   int yylen = 0;
 
-  yyssp = yyss = yyssa;
-  yyvsp = yyvs = yyvsa;
-  yystacksize = YYINITDEPTH;
-
   YYDPRINTF ((stderr, "Starting parse\n"));
 
-  yystate = 0;
-  yyerrstatus = 0;
-  yynerrs = 0;
   yychar = YYEMPTY; /* Cause a token to be read.  */
   goto yysetstate;
 
@@ -5704,6 +6083,7 @@ yysetstate:
   YY_IGNORE_USELESS_CAST_BEGIN
   *yyssp = YY_CAST (yy_state_t, yystate);
   YY_IGNORE_USELESS_CAST_END
+  YY_STACK_PRINT (yyss, yyssp);
 
   if (yyss + yystacksize - 1 <= yyssp)
 #if !defined yyoverflow && !defined YYSTACK_RELOCATE
@@ -5749,7 +6129,7 @@ yysetstate:
           goto yyexhaustedlab;
         YYSTACK_RELOCATE (yyss_alloc, yyss);
         YYSTACK_RELOCATE (yyvs_alloc, yyvs);
-# undef YYSTACK_RELOCATE
+#  undef YYSTACK_RELOCATE
         if (yyss1 != yyssa)
           YYSTACK_FREE (yyss1);
       }
@@ -5788,17 +6168,28 @@ yybackup:
 
   /* Not known => get a lookahead token if don't already have one.  */
 
-  /* YYCHAR is either YYEMPTY or YYEOF or a valid lookahead symbol.  */
+  /* YYCHAR is either empty, or end-of-input, or a valid lookahead.  */
   if (yychar == YYEMPTY)
     {
-      YYDPRINTF ((stderr, "Reading a token: "));
+      YYDPRINTF ((stderr, "Reading a token\n"));
       yychar = yylex (&yylval, p);
     }
 
   if (yychar <= YYEOF)
     {
-      yychar = yytoken = YYEOF;
+      yychar = YYEOF;
+      yytoken = YYSYMBOL_YYEOF;
       YYDPRINTF ((stderr, "Now at end of input.\n"));
+    }
+  else if (yychar == YYerror)
+    {
+      /* The scanner already issued an error message, process directly
+         to error recovery.  But do not keep the error token as
+         lookahead, it is too special and may lead us to an endless
+         loop in error recovery. */
+      yychar = YYUNDEF;
+      yytoken = YYSYMBOL_YYerror;
+      goto yyerrlab1;
     }
   else
     {
@@ -5868,75 +6259,75 @@ yyreduce:
   YY_REDUCE_PRINT (yyn);
   switch (yyn)
     {
-  case 2:
+  case 2: /* $@1: %empty  */
 #line 1536 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       p->lstate = EXPR_BEG;
                       if (!p->locals) p->locals = cons(0,0);
                     }
-#line 5878 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6269 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 3:
+  case 3: /* program: $@1 top_compstmt  */
 #line 1541 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       p->tree = new_scope(p, (yyvsp[0].nd));
                       NODE_LINENO(p->tree, (yyvsp[0].nd));
                     }
-#line 5887 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6278 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 4:
+  case 4: /* top_compstmt: top_stmts opt_terms  */
 #line 1548 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[-1].nd);
                     }
-#line 5895 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6286 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 5:
+  case 5: /* top_stmts: none  */
 #line 1554 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_begin(p, 0);
                     }
-#line 5903 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6294 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 6:
+  case 6: /* top_stmts: top_stmt  */
 #line 1558 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_begin(p, (yyvsp[0].nd));
                       NODE_LINENO((yyval.nd), (yyvsp[0].nd));
                     }
-#line 5912 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6303 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 7:
+  case 7: /* top_stmts: top_stmts terms top_stmt  */
 #line 1563 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = push((yyvsp[-2].nd), newline_node((yyvsp[0].nd)));
                     }
-#line 5920 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6311 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 8:
+  case 8: /* top_stmts: error top_stmt  */
 #line 1567 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_begin(p, 0);
                     }
-#line 5928 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6319 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 10:
+  case 10: /* @2: %empty  */
 #line 1574 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = local_switch(p);
                       nvars_block(p);
                     }
-#line 5937 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6328 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 11:
+  case 11: /* top_stmt: keyword_BEGIN @2 '{' top_compstmt '}'  */
 #line 1579 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       yyerror(p, "BEGIN not supported");
@@ -5944,10 +6335,10 @@ yyreduce:
                       nvars_unnest(p);
                       (yyval.nd) = 0;
                     }
-#line 5948 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6339 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 12:
+  case 12: /* bodystmt: compstmt opt_rescue opt_else opt_ensure  */
 #line 1591 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       if ((yyvsp[-2].nd)) {
@@ -5970,154 +6361,154 @@ yyreduce:
                         }
                       }
                     }
-#line 5974 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6365 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 13:
+  case 13: /* compstmt: stmts opt_terms  */
 #line 1615 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[-1].nd);
                     }
-#line 5982 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6373 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 14:
+  case 14: /* stmts: none  */
 #line 1621 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_begin(p, 0);
                     }
-#line 5990 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6381 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 15:
+  case 15: /* stmts: stmt  */
 #line 1625 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_begin(p, (yyvsp[0].nd));
                       NODE_LINENO((yyval.nd), (yyvsp[0].nd));
                     }
-#line 5999 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6390 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 16:
+  case 16: /* stmts: stmts terms stmt  */
 #line 1630 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = push((yyvsp[-2].nd), newline_node((yyvsp[0].nd)));
                     }
-#line 6007 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6398 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 17:
+  case 17: /* stmts: error stmt  */
 #line 1634 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_begin(p, (yyvsp[0].nd));
                     }
-#line 6015 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6406 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 18:
+  case 18: /* $@3: %empty  */
 #line 1639 "mrbgems/mruby-compiler/core/parse.y"
                                      {p->lstate = EXPR_FNAME;}
-#line 6021 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6412 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 19:
+  case 19: /* stmt: keyword_alias fsym $@3 fsym  */
 #line 1640 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_alias(p, (yyvsp[-2].id), (yyvsp[0].id));
                     }
-#line 6029 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6420 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 20:
+  case 20: /* stmt: keyword_undef undef_list  */
 #line 1644 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[0].nd);
                     }
-#line 6037 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6428 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 21:
+  case 21: /* stmt: stmt modifier_if expr_value  */
 #line 1648 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_if(p, cond((yyvsp[0].nd)), (yyvsp[-2].nd), 0);
                     }
-#line 6045 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6436 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 22:
+  case 22: /* stmt: stmt modifier_unless expr_value  */
 #line 1652 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_unless(p, cond((yyvsp[0].nd)), (yyvsp[-2].nd), 0);
                     }
-#line 6053 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6444 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 23:
+  case 23: /* stmt: stmt modifier_while expr_value  */
 #line 1656 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_while(p, cond((yyvsp[0].nd)), (yyvsp[-2].nd));
                     }
-#line 6061 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6452 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 24:
+  case 24: /* stmt: stmt modifier_until expr_value  */
 #line 1660 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_until(p, cond((yyvsp[0].nd)), (yyvsp[-2].nd));
                     }
-#line 6069 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6460 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 25:
+  case 25: /* stmt: stmt modifier_rescue stmt  */
 #line 1664 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_mod_rescue(p, (yyvsp[-2].nd), (yyvsp[0].nd));
                     }
-#line 6077 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6468 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 26:
+  case 26: /* stmt: keyword_END '{' compstmt '}'  */
 #line 1668 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       yyerror(p, "END not supported");
                       (yyval.nd) = new_postexe(p, (yyvsp[-1].nd));
                     }
-#line 6086 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6477 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 28:
+  case 28: /* stmt: mlhs '=' command_call  */
 #line 1674 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_masgn(p, (yyvsp[-2].nd), (yyvsp[0].nd));
                     }
-#line 6094 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6485 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 29:
+  case 29: /* stmt: lhs '=' mrhs  */
 #line 1678 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_asgn(p, (yyvsp[-2].nd), new_array(p, (yyvsp[0].nd)));
                     }
-#line 6102 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6493 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 30:
+  case 30: /* stmt: mlhs '=' arg  */
 #line 1682 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_masgn(p, (yyvsp[-2].nd), (yyvsp[0].nd));
                     }
-#line 6110 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6501 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 31:
+  case 31: /* stmt: mlhs '=' mrhs  */
 #line 1686 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_masgn(p, (yyvsp[-2].nd), new_array(p, (yyvsp[0].nd)));
                     }
-#line 6118 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6509 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 32:
+  case 32: /* stmt: arg tASSOC tIDENTIFIER  */
 #line 1690 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       node *lhs = new_lvar(p, (yyvsp[0].id));
@@ -6125,116 +6516,116 @@ yyreduce:
                       assignable(p, lhs);
                       (yyval.nd) = new_asgn(p, lhs, (yyvsp[-2].nd));
                     }
-#line 6129 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6520 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 34:
+  case 34: /* command_asgn: lhs '=' command_rhs  */
 #line 1700 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_asgn(p, (yyvsp[-2].nd), (yyvsp[0].nd));
                     }
-#line 6137 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6528 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 35:
+  case 35: /* command_asgn: var_lhs tOP_ASGN command_rhs  */
 #line 1704 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_op_asgn(p, (yyvsp[-2].nd), (yyvsp[-1].id), (yyvsp[0].nd));
                     }
-#line 6145 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6536 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 36:
+  case 36: /* command_asgn: primary_value '[' opt_call_args ']' tOP_ASGN command_rhs  */
 #line 1708 "mrbgems/mruby-compiler/core/parse.y"
                     {
-                      (yyval.nd) = new_op_asgn(p, new_call(p, (yyvsp[-5].nd), MRB_OPSYM(aref), (yyvsp[-3].nd), '.'), (yyvsp[-1].id), (yyvsp[0].nd));
+                      (yyval.nd) = new_op_asgn(p, new_call(p, (yyvsp[-5].nd), intern_op(aref), (yyvsp[-3].nd), '.'), (yyvsp[-1].id), (yyvsp[0].nd));
                     }
-#line 6153 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6544 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 37:
+  case 37: /* command_asgn: primary_value call_op tIDENTIFIER tOP_ASGN command_rhs  */
 #line 1712 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_op_asgn(p, new_call(p, (yyvsp[-4].nd), (yyvsp[-2].id), 0, (yyvsp[-3].num)), (yyvsp[-1].id), (yyvsp[0].nd));
                     }
-#line 6161 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6552 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 38:
+  case 38: /* command_asgn: primary_value call_op tCONSTANT tOP_ASGN command_rhs  */
 #line 1716 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_op_asgn(p, new_call(p, (yyvsp[-4].nd), (yyvsp[-2].id), 0, (yyvsp[-3].num)), (yyvsp[-1].id), (yyvsp[0].nd));
                     }
-#line 6169 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6560 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 39:
+  case 39: /* command_asgn: primary_value tCOLON2 tCONSTANT tOP_ASGN command_call  */
 #line 1720 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       yyerror(p, "constant re-assignment");
                       (yyval.nd) = 0;
                     }
-#line 6178 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6569 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 40:
+  case 40: /* command_asgn: primary_value tCOLON2 tIDENTIFIER tOP_ASGN command_rhs  */
 #line 1725 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_op_asgn(p, new_call(p, (yyvsp[-4].nd), (yyvsp[-2].id), 0, tCOLON2), (yyvsp[-1].id), (yyvsp[0].nd));
                     }
-#line 6186 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6577 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 41:
+  case 41: /* command_asgn: backref tOP_ASGN command_rhs  */
 #line 1729 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       backref_error(p, (yyvsp[-2].nd));
                       (yyval.nd) = new_begin(p, 0);
                     }
-#line 6195 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6586 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 43:
+  case 43: /* command_rhs: command_call modifier_rescue stmt  */
 #line 1737 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_mod_rescue(p, (yyvsp[-2].nd), (yyvsp[0].nd));
                     }
-#line 6203 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6594 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 46:
+  case 46: /* expr: expr keyword_and expr  */
 #line 1746 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_and(p, (yyvsp[-2].nd), (yyvsp[0].nd));
                     }
-#line 6211 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6602 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 47:
+  case 47: /* expr: expr keyword_or expr  */
 #line 1750 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_or(p, (yyvsp[-2].nd), (yyvsp[0].nd));
                     }
-#line 6219 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6610 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 48:
+  case 48: /* expr: keyword_not opt_nl expr  */
 #line 1754 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_uni_op(p, cond((yyvsp[0].nd)), "!");
                     }
-#line 6227 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6618 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 49:
+  case 49: /* expr: '!' command_call  */
 #line 1758 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_uni_op(p, cond((yyvsp[0].nd)), "!");
                     }
-#line 6235 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6626 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 51:
+  case 51: /* defn_head: keyword_def fname  */
 #line 1766 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_def(p, (yyvsp[0].id), nint(p->cmdarg_stack), local_switch(p));
@@ -6242,18 +6633,18 @@ yyreduce:
                       p->in_def++;
                       nvars_block(p);
                     }
-#line 6246 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6637 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 52:
+  case 52: /* $@4: %empty  */
 #line 1775 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       p->lstate = EXPR_FNAME;
                     }
-#line 6254 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6645 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 53:
+  case 53: /* defs_head: keyword_def singleton dot_or_colon $@4 fname  */
 #line 1779 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_sdef(p, (yyvsp[-3].nd), (yyvsp[0].id), nint(p->cmdarg_stack), local_switch(p));
@@ -6263,10 +6654,10 @@ yyreduce:
                       nvars_block(p);
                       p->lstate = EXPR_ENDFN; /* force for args */
                     }
-#line 6267 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6658 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 54:
+  case 54: /* expr_value: expr  */
 #line 1790 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       if (!(yyvsp[0].nd)) (yyval.nd) = new_nil(p);
@@ -6274,1042 +6665,1042 @@ yyreduce:
                         (yyval.nd) = (yyvsp[0].nd);
                       }
                     }
-#line 6278 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6669 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 58:
+  case 58: /* block_command: block_call call_op2 operation2 command_args  */
 #line 1804 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_call(p, (yyvsp[-3].nd), (yyvsp[-1].id), (yyvsp[0].nd), (yyvsp[-2].num));
                     }
-#line 6286 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6677 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 59:
+  case 59: /* $@5: %empty  */
 #line 1810 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       local_nest(p);
                       nvars_nest(p);
                     }
-#line 6295 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6686 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 60:
+  case 60: /* cmd_brace_block: tLBRACE_ARG $@5 opt_block_param compstmt '}'  */
 #line 1817 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_block(p, (yyvsp[-2].nd), (yyvsp[-1].nd));
                       local_unnest(p);
                       nvars_unnest(p);
                     }
-#line 6305 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6696 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 61:
+  case 61: /* command: operation command_args  */
 #line 1825 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_fcall(p, (yyvsp[-1].id), (yyvsp[0].nd));
                     }
-#line 6313 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6704 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 62:
+  case 62: /* command: operation command_args cmd_brace_block  */
 #line 1829 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       args_with_block(p, (yyvsp[-1].nd), (yyvsp[0].nd));
                       (yyval.nd) = new_fcall(p, (yyvsp[-2].id), (yyvsp[-1].nd));
                     }
-#line 6322 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6713 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 63:
+  case 63: /* command: primary_value call_op operation2 command_args  */
 #line 1834 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_call(p, (yyvsp[-3].nd), (yyvsp[-1].id), (yyvsp[0].nd), (yyvsp[-2].num));
                     }
-#line 6330 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6721 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 64:
+  case 64: /* command: primary_value call_op operation2 command_args cmd_brace_block  */
 #line 1838 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       args_with_block(p, (yyvsp[-1].nd), (yyvsp[0].nd));
                       (yyval.nd) = new_call(p, (yyvsp[-4].nd), (yyvsp[-2].id), (yyvsp[-1].nd), (yyvsp[-3].num));
                    }
-#line 6339 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6730 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 65:
+  case 65: /* command: primary_value tCOLON2 operation2 command_args  */
 #line 1843 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_call(p, (yyvsp[-3].nd), (yyvsp[-1].id), (yyvsp[0].nd), tCOLON2);
                     }
-#line 6347 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6738 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 66:
+  case 66: /* command: primary_value tCOLON2 operation2 command_args cmd_brace_block  */
 #line 1847 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       args_with_block(p, (yyvsp[-1].nd), (yyvsp[0].nd));
                       (yyval.nd) = new_call(p, (yyvsp[-4].nd), (yyvsp[-2].id), (yyvsp[-1].nd), tCOLON2);
                     }
-#line 6356 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6747 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 67:
+  case 67: /* command: keyword_super command_args  */
 #line 1852 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_super(p, (yyvsp[0].nd));
                     }
-#line 6364 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6755 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 68:
+  case 68: /* command: keyword_yield command_args  */
 #line 1856 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_yield(p, (yyvsp[0].nd));
                     }
-#line 6372 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6763 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 69:
+  case 69: /* command: keyword_return call_args  */
 #line 1860 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_return(p, ret_args(p, (yyvsp[0].nd)));
                     }
-#line 6380 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6771 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 70:
+  case 70: /* command: keyword_break call_args  */
 #line 1864 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_break(p, ret_args(p, (yyvsp[0].nd)));
                     }
-#line 6388 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6779 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 71:
+  case 71: /* command: keyword_next call_args  */
 #line 1868 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_next(p, ret_args(p, (yyvsp[0].nd)));
                     }
-#line 6396 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6787 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 72:
+  case 72: /* mlhs: mlhs_basic  */
 #line 1874 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[0].nd);
                     }
-#line 6404 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6795 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 73:
+  case 73: /* mlhs: tLPAREN mlhs_inner rparen  */
 #line 1878 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[-1].nd);
                     }
-#line 6412 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6803 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 75:
+  case 75: /* mlhs_inner: tLPAREN mlhs_inner rparen  */
 #line 1885 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[-1].nd);
                     }
-#line 6420 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6811 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 76:
+  case 76: /* mlhs_basic: mlhs_list  */
 #line 1891 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list1((yyvsp[0].nd));
                     }
-#line 6428 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6819 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 77:
+  case 77: /* mlhs_basic: mlhs_list mlhs_item  */
 #line 1895 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list1(push((yyvsp[-1].nd),(yyvsp[0].nd)));
                     }
-#line 6436 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6827 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 78:
+  case 78: /* mlhs_basic: mlhs_list tSTAR mlhs_node  */
 #line 1899 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list2((yyvsp[-2].nd), (yyvsp[0].nd));
                     }
-#line 6444 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6835 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 79:
+  case 79: /* mlhs_basic: mlhs_list tSTAR mlhs_node ',' mlhs_post  */
 #line 1903 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list3((yyvsp[-4].nd), (yyvsp[-2].nd), (yyvsp[0].nd));
                     }
-#line 6452 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6843 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 80:
+  case 80: /* mlhs_basic: mlhs_list tSTAR  */
 #line 1907 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list2((yyvsp[-1].nd), new_nil(p));
                     }
-#line 6460 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6851 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 81:
+  case 81: /* mlhs_basic: mlhs_list tSTAR ',' mlhs_post  */
 #line 1911 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list3((yyvsp[-3].nd), new_nil(p), (yyvsp[0].nd));
                     }
-#line 6468 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6859 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 82:
+  case 82: /* mlhs_basic: tSTAR mlhs_node  */
 #line 1915 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list2(0, (yyvsp[0].nd));
                     }
-#line 6476 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6867 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 83:
+  case 83: /* mlhs_basic: tSTAR mlhs_node ',' mlhs_post  */
 #line 1919 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list3(0, (yyvsp[-2].nd), (yyvsp[0].nd));
                     }
-#line 6484 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6875 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 84:
+  case 84: /* mlhs_basic: tSTAR  */
 #line 1923 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list2(0, new_nil(p));
                     }
-#line 6492 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6883 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 85:
+  case 85: /* mlhs_basic: tSTAR ',' mlhs_post  */
 #line 1927 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list3(0, new_nil(p), (yyvsp[0].nd));
                     }
-#line 6500 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6891 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 87:
+  case 87: /* mlhs_item: tLPAREN mlhs_inner rparen  */
 #line 1934 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_masgn(p, (yyvsp[-1].nd), NULL);
                     }
-#line 6508 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6899 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 88:
+  case 88: /* mlhs_list: mlhs_item ','  */
 #line 1940 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list1((yyvsp[-1].nd));
                     }
-#line 6516 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6907 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 89:
+  case 89: /* mlhs_list: mlhs_list mlhs_item ','  */
 #line 1944 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = push((yyvsp[-2].nd), (yyvsp[-1].nd));
                     }
-#line 6524 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6915 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 90:
+  case 90: /* mlhs_post: mlhs_item  */
 #line 1950 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list1((yyvsp[0].nd));
                     }
-#line 6532 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6923 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 91:
+  case 91: /* mlhs_post: mlhs_list mlhs_item  */
 #line 1954 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = push((yyvsp[-1].nd), (yyvsp[0].nd));
                     }
-#line 6540 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6931 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 92:
+  case 92: /* mlhs_node: variable  */
 #line 1960 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       assignable(p, (yyvsp[0].nd));
                     }
-#line 6548 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6939 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 93:
+  case 93: /* mlhs_node: primary_value '[' opt_call_args ']'  */
 #line 1964 "mrbgems/mruby-compiler/core/parse.y"
                     {
-                      (yyval.nd) = new_call(p, (yyvsp[-3].nd), MRB_OPSYM(aref), (yyvsp[-1].nd), '.');
+                      (yyval.nd) = new_call(p, (yyvsp[-3].nd), intern_op(aref), (yyvsp[-1].nd), '.');
                     }
-#line 6556 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6947 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 94:
+  case 94: /* mlhs_node: primary_value call_op tIDENTIFIER  */
 #line 1968 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_call(p, (yyvsp[-2].nd), (yyvsp[0].id), 0, (yyvsp[-1].num));
                     }
-#line 6564 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6955 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 95:
+  case 95: /* mlhs_node: primary_value tCOLON2 tIDENTIFIER  */
 #line 1972 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_call(p, (yyvsp[-2].nd), (yyvsp[0].id), 0, tCOLON2);
                     }
-#line 6572 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6963 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 96:
+  case 96: /* mlhs_node: primary_value call_op tCONSTANT  */
 #line 1976 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_call(p, (yyvsp[-2].nd), (yyvsp[0].id), 0, (yyvsp[-1].num));
                     }
-#line 6580 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6971 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 97:
+  case 97: /* mlhs_node: primary_value tCOLON2 tCONSTANT  */
 #line 1980 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       if (p->in_def || p->in_single)
                         yyerror(p, "dynamic constant assignment");
                       (yyval.nd) = new_colon2(p, (yyvsp[-2].nd), (yyvsp[0].id));
                     }
-#line 6590 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6981 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 98:
+  case 98: /* mlhs_node: tCOLON3 tCONSTANT  */
 #line 1986 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       if (p->in_def || p->in_single)
                         yyerror(p, "dynamic constant assignment");
                       (yyval.nd) = new_colon3(p, (yyvsp[0].id));
                     }
-#line 6600 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6991 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 99:
+  case 99: /* mlhs_node: backref  */
 #line 1992 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       backref_error(p, (yyvsp[0].nd));
                       (yyval.nd) = 0;
                     }
-#line 6609 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7000 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 100:
+  case 100: /* lhs: variable  */
 #line 1999 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       assignable(p, (yyvsp[0].nd));
                     }
-#line 6617 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7008 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 101:
+  case 101: /* lhs: primary_value '[' opt_call_args ']'  */
 #line 2003 "mrbgems/mruby-compiler/core/parse.y"
                     {
-                      (yyval.nd) = new_call(p, (yyvsp[-3].nd), MRB_OPSYM(aref), (yyvsp[-1].nd), '.');
+                      (yyval.nd) = new_call(p, (yyvsp[-3].nd), intern_op(aref), (yyvsp[-1].nd), '.');
                     }
-#line 6625 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7016 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 102:
+  case 102: /* lhs: primary_value call_op tIDENTIFIER  */
 #line 2007 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_call(p, (yyvsp[-2].nd), (yyvsp[0].id), 0, (yyvsp[-1].num));
                     }
-#line 6633 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7024 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 103:
+  case 103: /* lhs: primary_value tCOLON2 tIDENTIFIER  */
 #line 2011 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_call(p, (yyvsp[-2].nd), (yyvsp[0].id), 0, tCOLON2);
                     }
-#line 6641 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7032 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 104:
+  case 104: /* lhs: primary_value call_op tCONSTANT  */
 #line 2015 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_call(p, (yyvsp[-2].nd), (yyvsp[0].id), 0, (yyvsp[-1].num));
                     }
-#line 6649 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7040 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 105:
+  case 105: /* lhs: primary_value tCOLON2 tCONSTANT  */
 #line 2019 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       if (p->in_def || p->in_single)
                         yyerror(p, "dynamic constant assignment");
                       (yyval.nd) = new_colon2(p, (yyvsp[-2].nd), (yyvsp[0].id));
                     }
-#line 6659 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7050 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 106:
+  case 106: /* lhs: tCOLON3 tCONSTANT  */
 #line 2025 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       if (p->in_def || p->in_single)
                         yyerror(p, "dynamic constant assignment");
                       (yyval.nd) = new_colon3(p, (yyvsp[0].id));
                     }
-#line 6669 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7060 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 107:
+  case 107: /* lhs: backref  */
 #line 2031 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       backref_error(p, (yyvsp[0].nd));
                       (yyval.nd) = 0;
                     }
-#line 6678 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7069 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 108:
+  case 108: /* lhs: tNUMPARAM  */
 #line 2036 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       yyerror(p, "can't assign to numbered parameter");
                     }
-#line 6686 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7077 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 109:
+  case 109: /* cname: tIDENTIFIER  */
 #line 2042 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       yyerror(p, "class/module name must be CONSTANT");
                     }
-#line 6694 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7085 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 111:
+  case 111: /* cpath: tCOLON3 cname  */
 #line 2049 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = cons((node*)1, nsym((yyvsp[0].id)));
                     }
-#line 6702 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7093 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 112:
+  case 112: /* cpath: cname  */
 #line 2053 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = cons((node*)0, nsym((yyvsp[0].id)));
                     }
-#line 6710 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7101 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 113:
+  case 113: /* cpath: primary_value tCOLON2 cname  */
 #line 2057 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       void_expr_error(p, (yyvsp[-2].nd));
                       (yyval.nd) = cons((yyvsp[-2].nd), nsym((yyvsp[0].id)));
                     }
-#line 6719 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7110 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 117:
+  case 117: /* fname: op  */
 #line 2067 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       p->lstate = EXPR_ENDFN;
                       (yyval.id) = (yyvsp[0].id);
                     }
-#line 6728 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7119 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 118:
+  case 118: /* fname: reswords  */
 #line 2072 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       p->lstate = EXPR_ENDFN;
                       (yyval.id) = (yyvsp[0].id);
                     }
-#line 6737 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7128 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 121:
+  case 121: /* undef_list: fsym  */
 #line 2083 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_undef(p, (yyvsp[0].id));
                     }
-#line 6745 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7136 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 122:
+  case 122: /* $@6: %empty  */
 #line 2086 "mrbgems/mruby-compiler/core/parse.y"
                                  {p->lstate = EXPR_FNAME;}
-#line 6751 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7142 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 123:
+  case 123: /* undef_list: undef_list ',' $@6 fsym  */
 #line 2087 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = push((yyvsp[-3].nd), nsym((yyvsp[0].id)));
                     }
-#line 6759 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7150 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 124:
+  case 124: /* op: '|'  */
 #line 2092 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = MRB_OPSYM(or);     }
-#line 6765 "mrbgems/mruby-compiler/core/y.tab.c"
+                                { (yyval.id) = intern_op(or);     }
+#line 7156 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 125:
+  case 125: /* op: '^'  */
 #line 2093 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = MRB_OPSYM(xor);    }
-#line 6771 "mrbgems/mruby-compiler/core/y.tab.c"
+                                { (yyval.id) = intern_op(xor);    }
+#line 7162 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 126:
+  case 126: /* op: '&'  */
 #line 2094 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = MRB_OPSYM(and);    }
-#line 6777 "mrbgems/mruby-compiler/core/y.tab.c"
+                                { (yyval.id) = intern_op(and);    }
+#line 7168 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 127:
+  case 127: /* op: tCMP  */
 #line 2095 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = MRB_OPSYM(cmp);    }
-#line 6783 "mrbgems/mruby-compiler/core/y.tab.c"
+                                { (yyval.id) = intern_op(cmp);    }
+#line 7174 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 128:
+  case 128: /* op: tEQ  */
 #line 2096 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = MRB_OPSYM(eq);     }
-#line 6789 "mrbgems/mruby-compiler/core/y.tab.c"
+                                { (yyval.id) = intern_op(eq);     }
+#line 7180 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 129:
+  case 129: /* op: tEQQ  */
 #line 2097 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = MRB_OPSYM(eqq);    }
-#line 6795 "mrbgems/mruby-compiler/core/y.tab.c"
+                                { (yyval.id) = intern_op(eqq);    }
+#line 7186 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 130:
+  case 130: /* op: tMATCH  */
 #line 2098 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = MRB_OPSYM(match);  }
-#line 6801 "mrbgems/mruby-compiler/core/y.tab.c"
+                                { (yyval.id) = intern_op(match);  }
+#line 7192 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 131:
+  case 131: /* op: tNMATCH  */
 #line 2099 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = MRB_OPSYM(nmatch); }
-#line 6807 "mrbgems/mruby-compiler/core/y.tab.c"
+                                { (yyval.id) = intern_op(nmatch); }
+#line 7198 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 132:
+  case 132: /* op: '>'  */
 #line 2100 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = MRB_OPSYM(gt);     }
-#line 6813 "mrbgems/mruby-compiler/core/y.tab.c"
+                                { (yyval.id) = intern_op(gt);     }
+#line 7204 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 133:
+  case 133: /* op: tGEQ  */
 #line 2101 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = MRB_OPSYM(ge);     }
-#line 6819 "mrbgems/mruby-compiler/core/y.tab.c"
+                                { (yyval.id) = intern_op(ge);     }
+#line 7210 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 134:
+  case 134: /* op: '<'  */
 #line 2102 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = MRB_OPSYM(lt);     }
-#line 6825 "mrbgems/mruby-compiler/core/y.tab.c"
+                                { (yyval.id) = intern_op(lt);     }
+#line 7216 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 135:
+  case 135: /* op: tLEQ  */
 #line 2103 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = MRB_OPSYM(le);     }
-#line 6831 "mrbgems/mruby-compiler/core/y.tab.c"
+                                { (yyval.id) = intern_op(le);     }
+#line 7222 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 136:
+  case 136: /* op: tNEQ  */
 #line 2104 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = MRB_OPSYM(neq);    }
-#line 6837 "mrbgems/mruby-compiler/core/y.tab.c"
+                                { (yyval.id) = intern_op(neq);    }
+#line 7228 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 137:
+  case 137: /* op: tLSHFT  */
 #line 2105 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = MRB_OPSYM(lshift); }
-#line 6843 "mrbgems/mruby-compiler/core/y.tab.c"
+                                { (yyval.id) = intern_op(lshift); }
+#line 7234 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 138:
+  case 138: /* op: tRSHFT  */
 #line 2106 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = MRB_OPSYM(rshift); }
-#line 6849 "mrbgems/mruby-compiler/core/y.tab.c"
+                                { (yyval.id) = intern_op(rshift); }
+#line 7240 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 139:
+  case 139: /* op: '+'  */
 #line 2107 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = MRB_OPSYM(add);    }
-#line 6855 "mrbgems/mruby-compiler/core/y.tab.c"
+                                { (yyval.id) = intern_op(add);    }
+#line 7246 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 140:
+  case 140: /* op: '-'  */
 #line 2108 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = MRB_OPSYM(sub);    }
-#line 6861 "mrbgems/mruby-compiler/core/y.tab.c"
+                                { (yyval.id) = intern_op(sub);    }
+#line 7252 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 141:
+  case 141: /* op: '*'  */
 #line 2109 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = MRB_OPSYM(mul);    }
-#line 6867 "mrbgems/mruby-compiler/core/y.tab.c"
+                                { (yyval.id) = intern_op(mul);    }
+#line 7258 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 142:
+  case 142: /* op: tSTAR  */
 #line 2110 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = MRB_OPSYM(mul);    }
-#line 6873 "mrbgems/mruby-compiler/core/y.tab.c"
+                                { (yyval.id) = intern_op(mul);    }
+#line 7264 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 143:
+  case 143: /* op: '/'  */
 #line 2111 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = MRB_OPSYM(div);    }
-#line 6879 "mrbgems/mruby-compiler/core/y.tab.c"
+                                { (yyval.id) = intern_op(div);    }
+#line 7270 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 144:
+  case 144: /* op: '%'  */
 #line 2112 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = MRB_OPSYM(mod);    }
-#line 6885 "mrbgems/mruby-compiler/core/y.tab.c"
+                                { (yyval.id) = intern_op(mod);    }
+#line 7276 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 145:
+  case 145: /* op: tPOW  */
 #line 2113 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = MRB_OPSYM(pow);    }
-#line 6891 "mrbgems/mruby-compiler/core/y.tab.c"
+                                { (yyval.id) = intern_op(pow);    }
+#line 7282 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 146:
+  case 146: /* op: tDSTAR  */
 #line 2114 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = MRB_OPSYM(pow);    }
-#line 6897 "mrbgems/mruby-compiler/core/y.tab.c"
+                                { (yyval.id) = intern_op(pow);    }
+#line 7288 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 147:
+  case 147: /* op: '!'  */
 #line 2115 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = MRB_OPSYM(not);    }
-#line 6903 "mrbgems/mruby-compiler/core/y.tab.c"
+                                { (yyval.id) = intern_op(not);    }
+#line 7294 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 148:
+  case 148: /* op: '~'  */
 #line 2116 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = MRB_OPSYM(neg);    }
-#line 6909 "mrbgems/mruby-compiler/core/y.tab.c"
+                                { (yyval.id) = intern_op(neg);    }
+#line 7300 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 149:
+  case 149: /* op: tUPLUS  */
 #line 2117 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = MRB_OPSYM(plus);   }
-#line 6915 "mrbgems/mruby-compiler/core/y.tab.c"
+                                { (yyval.id) = intern_op(plus);   }
+#line 7306 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 150:
+  case 150: /* op: tUMINUS  */
 #line 2118 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = MRB_OPSYM(minus);  }
-#line 6921 "mrbgems/mruby-compiler/core/y.tab.c"
+                                { (yyval.id) = intern_op(minus);  }
+#line 7312 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 151:
+  case 151: /* op: tAREF  */
 #line 2119 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = MRB_OPSYM(aref);   }
-#line 6927 "mrbgems/mruby-compiler/core/y.tab.c"
+                                { (yyval.id) = intern_op(aref);   }
+#line 7318 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 152:
+  case 152: /* op: tASET  */
 #line 2120 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = MRB_OPSYM(aset);   }
-#line 6933 "mrbgems/mruby-compiler/core/y.tab.c"
+                                { (yyval.id) = intern_op(aset);   }
+#line 7324 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 153:
+  case 153: /* op: '`'  */
 #line 2121 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = MRB_OPSYM(tick);   }
-#line 6939 "mrbgems/mruby-compiler/core/y.tab.c"
+                                { (yyval.id) = intern_op(tick);   }
+#line 7330 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 194:
+  case 194: /* arg: lhs '=' arg_rhs  */
 #line 2139 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_asgn(p, (yyvsp[-2].nd), (yyvsp[0].nd));
                     }
-#line 6947 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7338 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 195:
+  case 195: /* arg: var_lhs tOP_ASGN arg_rhs  */
 #line 2143 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_op_asgn(p, (yyvsp[-2].nd), (yyvsp[-1].id), (yyvsp[0].nd));
                     }
-#line 6955 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7346 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 196:
+  case 196: /* arg: primary_value '[' opt_call_args ']' tOP_ASGN arg_rhs  */
 #line 2147 "mrbgems/mruby-compiler/core/parse.y"
                     {
-                      (yyval.nd) = new_op_asgn(p, new_call(p, (yyvsp[-5].nd), MRB_OPSYM(aref), (yyvsp[-3].nd), '.'), (yyvsp[-1].id), (yyvsp[0].nd));
+                      (yyval.nd) = new_op_asgn(p, new_call(p, (yyvsp[-5].nd), intern_op(aref), (yyvsp[-3].nd), '.'), (yyvsp[-1].id), (yyvsp[0].nd));
                     }
-#line 6963 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7354 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 197:
+  case 197: /* arg: primary_value call_op tIDENTIFIER tOP_ASGN arg_rhs  */
 #line 2151 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_op_asgn(p, new_call(p, (yyvsp[-4].nd), (yyvsp[-2].id), 0, (yyvsp[-3].num)), (yyvsp[-1].id), (yyvsp[0].nd));
                     }
-#line 6971 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7362 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 198:
+  case 198: /* arg: primary_value call_op tCONSTANT tOP_ASGN arg_rhs  */
 #line 2155 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_op_asgn(p, new_call(p, (yyvsp[-4].nd), (yyvsp[-2].id), 0, (yyvsp[-3].num)), (yyvsp[-1].id), (yyvsp[0].nd));
                     }
-#line 6979 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7370 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 199:
+  case 199: /* arg: primary_value tCOLON2 tIDENTIFIER tOP_ASGN arg_rhs  */
 #line 2159 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_op_asgn(p, new_call(p, (yyvsp[-4].nd), (yyvsp[-2].id), 0, tCOLON2), (yyvsp[-1].id), (yyvsp[0].nd));
                     }
-#line 6987 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7378 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 200:
+  case 200: /* arg: primary_value tCOLON2 tCONSTANT tOP_ASGN arg_rhs  */
 #line 2163 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       yyerror(p, "constant re-assignment");
                       (yyval.nd) = new_begin(p, 0);
                     }
-#line 6996 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7387 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 201:
+  case 201: /* arg: tCOLON3 tCONSTANT tOP_ASGN arg_rhs  */
 #line 2168 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       yyerror(p, "constant re-assignment");
                       (yyval.nd) = new_begin(p, 0);
                     }
-#line 7005 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7396 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 202:
+  case 202: /* arg: backref tOP_ASGN arg_rhs  */
 #line 2173 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       backref_error(p, (yyvsp[-2].nd));
                       (yyval.nd) = new_begin(p, 0);
                     }
-#line 7014 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7405 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 203:
+  case 203: /* arg: arg tDOT2 arg  */
 #line 2178 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_dot2(p, (yyvsp[-2].nd), (yyvsp[0].nd));
                     }
-#line 7022 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7413 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 204:
+  case 204: /* arg: arg tDOT2  */
 #line 2182 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_dot2(p, (yyvsp[-1].nd), new_nil(p));
                     }
-#line 7030 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7421 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 205:
+  case 205: /* arg: tBDOT2 arg  */
 #line 2186 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_dot2(p, new_nil(p), (yyvsp[0].nd));
                     }
-#line 7038 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7429 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 206:
+  case 206: /* arg: arg tDOT3 arg  */
 #line 2190 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_dot3(p, (yyvsp[-2].nd), (yyvsp[0].nd));
                     }
-#line 7046 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7437 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 207:
+  case 207: /* arg: arg tDOT3  */
 #line 2194 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_dot3(p, (yyvsp[-1].nd), new_nil(p));
                     }
-#line 7054 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7445 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 208:
+  case 208: /* arg: tBDOT3 arg  */
 #line 2198 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_dot3(p, new_nil(p), (yyvsp[0].nd));
                     }
-#line 7062 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7453 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 209:
+  case 209: /* arg: arg '+' arg  */
 #line 2202 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), "+", (yyvsp[0].nd));
                     }
-#line 7070 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7461 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 210:
+  case 210: /* arg: arg '-' arg  */
 #line 2206 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), "-", (yyvsp[0].nd));
                     }
-#line 7078 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7469 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 211:
+  case 211: /* arg: arg '*' arg  */
 #line 2210 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), "*", (yyvsp[0].nd));
                     }
-#line 7086 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7477 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 212:
+  case 212: /* arg: arg '/' arg  */
 #line 2214 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), "/", (yyvsp[0].nd));
                     }
-#line 7094 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7485 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 213:
+  case 213: /* arg: arg '%' arg  */
 #line 2218 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), "%", (yyvsp[0].nd));
                     }
-#line 7102 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7493 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 214:
+  case 214: /* arg: arg tPOW arg  */
 #line 2222 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), "**", (yyvsp[0].nd));
                     }
-#line 7110 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7501 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 215:
+  case 215: /* arg: tUMINUS_NUM tINTEGER tPOW arg  */
 #line 2226 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_uni_op(p, call_bin_op(p, (yyvsp[-2].nd), "**", (yyvsp[0].nd)), "-@");
                     }
-#line 7118 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7509 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 216:
+  case 216: /* arg: tUMINUS_NUM tFLOAT tPOW arg  */
 #line 2230 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_uni_op(p, call_bin_op(p, (yyvsp[-2].nd), "**", (yyvsp[0].nd)), "-@");
                     }
-#line 7126 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7517 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 217:
+  case 217: /* arg: tUPLUS arg  */
 #line 2234 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_uni_op(p, (yyvsp[0].nd), "+@");
                     }
-#line 7134 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7525 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 218:
+  case 218: /* arg: tUMINUS arg  */
 #line 2238 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_uni_op(p, (yyvsp[0].nd), "-@");
                     }
-#line 7142 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7533 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 219:
+  case 219: /* arg: arg '|' arg  */
 #line 2242 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), "|", (yyvsp[0].nd));
                     }
-#line 7150 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7541 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 220:
+  case 220: /* arg: arg '^' arg  */
 #line 2246 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), "^", (yyvsp[0].nd));
                     }
-#line 7158 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7549 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 221:
+  case 221: /* arg: arg '&' arg  */
 #line 2250 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), "&", (yyvsp[0].nd));
                     }
-#line 7166 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7557 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 222:
+  case 222: /* arg: arg tCMP arg  */
 #line 2254 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), "<=>", (yyvsp[0].nd));
                     }
-#line 7174 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7565 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 223:
+  case 223: /* arg: arg '>' arg  */
 #line 2258 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), ">", (yyvsp[0].nd));
                     }
-#line 7182 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7573 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 224:
+  case 224: /* arg: arg tGEQ arg  */
 #line 2262 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), ">=", (yyvsp[0].nd));
                     }
-#line 7190 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7581 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 225:
+  case 225: /* arg: arg '<' arg  */
 #line 2266 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), "<", (yyvsp[0].nd));
                     }
-#line 7198 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7589 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 226:
+  case 226: /* arg: arg tLEQ arg  */
 #line 2270 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), "<=", (yyvsp[0].nd));
                     }
-#line 7206 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7597 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 227:
+  case 227: /* arg: arg tEQ arg  */
 #line 2274 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), "==", (yyvsp[0].nd));
                     }
-#line 7214 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7605 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 228:
+  case 228: /* arg: arg tEQQ arg  */
 #line 2278 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), "===", (yyvsp[0].nd));
                     }
-#line 7222 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7613 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 229:
+  case 229: /* arg: arg tNEQ arg  */
 #line 2282 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), "!=", (yyvsp[0].nd));
                     }
-#line 7230 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7621 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 230:
+  case 230: /* arg: arg tMATCH arg  */
 #line 2286 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), "=~", (yyvsp[0].nd));
                     }
-#line 7238 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7629 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 231:
+  case 231: /* arg: arg tNMATCH arg  */
 #line 2290 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), "!~", (yyvsp[0].nd));
                     }
-#line 7246 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7637 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 232:
+  case 232: /* arg: '!' arg  */
 #line 2294 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_uni_op(p, cond((yyvsp[0].nd)), "!");
                     }
-#line 7254 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7645 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 233:
+  case 233: /* arg: '~' arg  */
 #line 2298 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_uni_op(p, cond((yyvsp[0].nd)), "~");
                     }
-#line 7262 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7653 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 234:
+  case 234: /* arg: arg tLSHFT arg  */
 #line 2302 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), "<<", (yyvsp[0].nd));
                     }
-#line 7270 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7661 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 235:
+  case 235: /* arg: arg tRSHFT arg  */
 #line 2306 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), ">>", (yyvsp[0].nd));
                     }
-#line 7278 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7669 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 236:
+  case 236: /* arg: arg tANDOP arg  */
 #line 2310 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_and(p, (yyvsp[-2].nd), (yyvsp[0].nd));
                     }
-#line 7286 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7677 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 237:
+  case 237: /* arg: arg tOROP arg  */
 #line 2314 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_or(p, (yyvsp[-2].nd), (yyvsp[0].nd));
                     }
-#line 7294 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7685 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 238:
+  case 238: /* arg: arg '?' arg opt_nl ':' arg  */
 #line 2318 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_if(p, cond((yyvsp[-5].nd)), (yyvsp[-3].nd), (yyvsp[0].nd));
                     }
-#line 7302 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7693 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 239:
+  case 239: /* arg: arg '?' arg opt_nl tLABEL_TAG arg  */
 #line 2322 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_if(p, cond((yyvsp[-5].nd)), (yyvsp[-3].nd), (yyvsp[0].nd));
                     }
-#line 7310 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7701 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 240:
+  case 240: /* arg: defn_head f_arglist_paren '=' arg  */
 #line 2326 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[-3].nd);
@@ -7318,10 +7709,10 @@ yyreduce:
                       nvars_unnest(p);
                       p->in_def--;
                     }
-#line 7322 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7713 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 241:
+  case 241: /* arg: defn_head f_arglist_paren '=' arg modifier_rescue arg  */
 #line 2334 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[-5].nd);
@@ -7331,10 +7722,10 @@ yyreduce:
                       nvars_unnest(p);
                       p->in_def--;
                     }
-#line 7335 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7726 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 242:
+  case 242: /* arg: defs_head f_arglist_paren '=' arg  */
 #line 2343 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[-3].nd);
@@ -7344,10 +7735,10 @@ yyreduce:
                       p->in_def--;
                       p->in_single--;
                     }
-#line 7348 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7739 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 243:
+  case 243: /* arg: defs_head f_arglist_paren '=' arg modifier_rescue arg  */
 #line 2352 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[-5].nd);
@@ -7358,103 +7749,103 @@ yyreduce:
                       p->in_def--;
                       p->in_single--;
                     }
-#line 7362 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7753 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 244:
+  case 244: /* arg: primary  */
 #line 2362 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[0].nd);
                     }
-#line 7370 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7761 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 246:
+  case 246: /* aref_args: args trailer  */
 #line 2369 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[-1].nd);
                       NODE_LINENO((yyval.nd), (yyvsp[-1].nd));
                     }
-#line 7379 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7770 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 247:
+  case 247: /* aref_args: args comma assocs trailer  */
 #line 2374 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = push((yyvsp[-3].nd), new_kw_hash(p, (yyvsp[-1].nd)));
                     }
-#line 7387 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7778 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 248:
+  case 248: /* aref_args: assocs trailer  */
 #line 2378 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = cons(new_kw_hash(p, (yyvsp[-1].nd)), 0);
                       NODE_LINENO((yyval.nd), (yyvsp[-1].nd));
                     }
-#line 7396 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7787 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 249:
+  case 249: /* arg_rhs: arg  */
 #line 2385 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[0].nd);
                     }
-#line 7404 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7795 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 250:
+  case 250: /* arg_rhs: arg modifier_rescue arg  */
 #line 2389 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       void_expr_error(p, (yyvsp[-2].nd));
                       void_expr_error(p, (yyvsp[0].nd));
                       (yyval.nd) = new_mod_rescue(p, (yyvsp[-2].nd), (yyvsp[0].nd));
                     }
-#line 7414 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7805 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 251:
+  case 251: /* paren_args: '(' opt_call_args ')'  */
 #line 2397 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[-1].nd);
                     }
-#line 7422 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7813 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 252:
+  case 252: /* paren_args: '(' args comma tBDOT3 rparen  */
 #line 2401 "mrbgems/mruby-compiler/core/parse.y"
                     {
 #if 1
-                      mrb_sym r = MRB_OPSYM(mul);
-                      mrb_sym b = MRB_OPSYM(and);
+                      mrb_sym r = intern_op(mul);
+                      mrb_sym b = intern_op(and);
                       (yyval.nd) = cons(push((yyvsp[-3].nd), new_splat(p, new_lvar(p, r))),
                                 new_block_arg(p, new_lvar(p, b)));
 #else
-                      mrb_sym r = MRB_OPSYM(mul);
-                      mrb_sym k = MRB_OPSYM(pow);
-                      mrb_sym b = MRB_OPSYM(and);
+                      mrb_sym r = intern_op(mul);
+                      mrb_sym k = intern_op(pow);
+                      mrb_sym b = intern_op(and);
                       (yyval.nd) = cons(list2(push((yyvsp[-3].nd), new_splat(p, new_lvar(p, r))),
                                       new_kw_hash(p, list1(cons(new_kw_rest_args(p, 0), new_lvar(p, k))))),
                                 new_block_arg(p, new_lvar(p, b)));
 #endif
                     }
-#line 7442 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7833 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 253:
+  case 253: /* paren_args: '(' tBDOT3 rparen  */
 #line 2417 "mrbgems/mruby-compiler/core/parse.y"
                     {
 #if 1
-                      mrb_sym r = MRB_OPSYM(mul);
-                      mrb_sym b = MRB_OPSYM(and);
+                      mrb_sym r = intern_op(mul);
+                      mrb_sym b = intern_op(and);
                       if (local_var_p(p, r)  && local_var_p(p, b)) {
                         (yyval.nd) = cons(list1(new_splat(p, new_lvar(p, r))),
                                   new_block_arg(p, new_lvar(p, b)));
                       }
 #else
-                      mrb_sym r = MRB_OPSYM(mul);
-                      mrb_sym k = MRB_OPSYM(pow);
-                      mrb_sym b = MRB_OPSYM(and);
+                      mrb_sym r = intern_op(mul);
+                      mrb_sym k = intern_op(pow);
+                      mrb_sym b = intern_op(and);
                       if (local_var_p(p, r) && local_var_p(p, k) && local_var_p(p, b)) {
                         (yyval.nd) = cons(list2(new_splat(p, new_lvar(p, r)),
                                         new_kw_hash(p, list1(cons(new_kw_rest_args(p, 0), new_lvar(p, k))))),
@@ -7466,372 +7857,372 @@ yyreduce:
                         (yyval.nd) = 0;
                       }
                     }
-#line 7470 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7861 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 258:
+  case 258: /* opt_call_args: args comma  */
 #line 2449 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = cons((yyvsp[-1].nd),0);
                       NODE_LINENO((yyval.nd), (yyvsp[-1].nd));
                     }
-#line 7479 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7870 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 259:
+  case 259: /* opt_call_args: args comma assocs comma  */
 #line 2454 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = cons(push((yyvsp[-3].nd), new_kw_hash(p, (yyvsp[-1].nd))), 0);
                       NODE_LINENO((yyval.nd), (yyvsp[-3].nd));
                     }
-#line 7488 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7879 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 260:
+  case 260: /* opt_call_args: assocs comma  */
 #line 2459 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = cons(list1(new_kw_hash(p, (yyvsp[-1].nd))), 0);
                       NODE_LINENO((yyval.nd), (yyvsp[-1].nd));
                     }
-#line 7497 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7888 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 261:
+  case 261: /* call_args: command  */
 #line 2466 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       void_expr_error(p, (yyvsp[0].nd));
                       (yyval.nd) = cons(list1((yyvsp[0].nd)), 0);
                       NODE_LINENO((yyval.nd), (yyvsp[0].nd));
                     }
-#line 7507 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7898 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 262:
+  case 262: /* call_args: args opt_block_arg  */
 #line 2472 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = cons((yyvsp[-1].nd), (yyvsp[0].nd));
                       NODE_LINENO((yyval.nd), (yyvsp[-1].nd));
                     }
-#line 7516 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7907 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 263:
+  case 263: /* call_args: assocs opt_block_arg  */
 #line 2477 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = cons(list1(new_kw_hash(p, (yyvsp[-1].nd))), (yyvsp[0].nd));
                       NODE_LINENO((yyval.nd), (yyvsp[-1].nd));
                     }
-#line 7525 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7916 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 264:
+  case 264: /* call_args: args comma assocs opt_block_arg  */
 #line 2482 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = cons(push((yyvsp[-3].nd), new_kw_hash(p, (yyvsp[-1].nd))), (yyvsp[0].nd));
                       NODE_LINENO((yyval.nd), (yyvsp[-3].nd));
                     }
-#line 7534 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7925 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 265:
+  case 265: /* call_args: block_arg  */
 #line 2487 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = cons(0, (yyvsp[0].nd));
                       NODE_LINENO((yyval.nd), (yyvsp[0].nd));
                     }
-#line 7543 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7934 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 266:
+  case 266: /* @7: %empty  */
 #line 2493 "mrbgems/mruby-compiler/core/parse.y"
                    {
                       (yyval.stack) = p->cmdarg_stack;
                       CMDARG_PUSH(1);
                     }
-#line 7552 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7943 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 267:
+  case 267: /* command_args: @7 call_args  */
 #line 2498 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       p->cmdarg_stack = (yyvsp[-1].stack);
                       (yyval.nd) = (yyvsp[0].nd);
                     }
-#line 7561 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7952 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 268:
+  case 268: /* block_arg: tAMPER arg  */
 #line 2505 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_block_arg(p, (yyvsp[0].nd));
                     }
-#line 7569 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7960 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 269:
+  case 269: /* opt_block_arg: comma block_arg  */
 #line 2511 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[0].nd);
                     }
-#line 7577 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7968 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 270:
+  case 270: /* opt_block_arg: none  */
 #line 2515 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = 0;
                     }
-#line 7585 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7976 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 273:
+  case 273: /* args: arg  */
 #line 2525 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       void_expr_error(p, (yyvsp[0].nd));
                       (yyval.nd) = cons((yyvsp[0].nd), 0);
                       NODE_LINENO((yyval.nd), (yyvsp[0].nd));
                     }
-#line 7595 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7986 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 274:
+  case 274: /* args: tSTAR arg  */
 #line 2531 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       void_expr_error(p, (yyvsp[0].nd));
                       (yyval.nd) = cons(new_splat(p, (yyvsp[0].nd)), 0);
                       NODE_LINENO((yyval.nd), (yyvsp[0].nd));
                     }
-#line 7605 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7996 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 275:
+  case 275: /* args: args comma arg  */
 #line 2537 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       void_expr_error(p, (yyvsp[0].nd));
                       (yyval.nd) = push((yyvsp[-2].nd), (yyvsp[0].nd));
                     }
-#line 7614 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8005 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 276:
+  case 276: /* args: args comma tSTAR arg  */
 #line 2542 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       void_expr_error(p, (yyvsp[0].nd));
                       (yyval.nd) = push((yyvsp[-3].nd), new_splat(p, (yyvsp[0].nd)));
                     }
-#line 7623 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8014 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 277:
+  case 277: /* mrhs: args comma arg  */
 #line 2549 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       void_expr_error(p, (yyvsp[0].nd));
                       (yyval.nd) = push((yyvsp[-2].nd), (yyvsp[0].nd));
                     }
-#line 7632 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8023 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 278:
+  case 278: /* mrhs: args comma tSTAR arg  */
 #line 2554 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       void_expr_error(p, (yyvsp[0].nd));
                       (yyval.nd) = push((yyvsp[-3].nd), new_splat(p, (yyvsp[0].nd)));
                     }
-#line 7641 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8032 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 279:
+  case 279: /* mrhs: tSTAR arg  */
 #line 2559 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       void_expr_error(p, (yyvsp[0].nd));
                       (yyval.nd) = list1(new_splat(p, (yyvsp[0].nd)));
                     }
-#line 7650 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8041 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 287:
+  case 287: /* primary: tNUMPARAM  */
 #line 2573 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_nvar(p, (yyvsp[0].num));
                     }
-#line 7658 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8049 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 288:
+  case 288: /* primary: tFID  */
 #line 2577 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_fcall(p, (yyvsp[0].id), 0);
                     }
-#line 7666 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8057 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 289:
+  case 289: /* @8: %empty  */
 #line 2581 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.stack) = p->cmdarg_stack;
                       p->cmdarg_stack = 0;
                     }
-#line 7675 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8066 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 290:
+  case 290: /* primary: keyword_begin @8 bodystmt keyword_end  */
 #line 2587 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       p->cmdarg_stack = (yyvsp[-2].stack);
                       (yyval.nd) = (yyvsp[-1].nd);
                     }
-#line 7684 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8075 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 291:
+  case 291: /* @9: %empty  */
 #line 2592 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.stack) = p->cmdarg_stack;
                       p->cmdarg_stack = 0;
                     }
-#line 7693 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8084 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 292:
+  case 292: /* $@10: %empty  */
 #line 2596 "mrbgems/mruby-compiler/core/parse.y"
                        {p->lstate = EXPR_ENDARG;}
-#line 7699 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8090 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 293:
+  case 293: /* primary: tLPAREN_ARG @9 stmt $@10 rparen  */
 #line 2597 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       p->cmdarg_stack = (yyvsp[-3].stack);
                       (yyval.nd) = (yyvsp[-2].nd);
                     }
-#line 7708 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8099 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 294:
+  case 294: /* $@11: %empty  */
 #line 2601 "mrbgems/mruby-compiler/core/parse.y"
                               {p->lstate = EXPR_ENDARG;}
-#line 7714 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8105 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 295:
+  case 295: /* primary: tLPAREN_ARG $@11 rparen  */
 #line 2602 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_nil(p);
                     }
-#line 7722 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8113 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 296:
+  case 296: /* primary: tLPAREN compstmt ')'  */
 #line 2606 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[-1].nd);
                     }
-#line 7730 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8121 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 297:
+  case 297: /* primary: primary_value tCOLON2 tCONSTANT  */
 #line 2610 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_colon2(p, (yyvsp[-2].nd), (yyvsp[0].id));
                     }
-#line 7738 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8129 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 298:
+  case 298: /* primary: tCOLON3 tCONSTANT  */
 #line 2614 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_colon3(p, (yyvsp[0].id));
                     }
-#line 7746 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8137 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 299:
+  case 299: /* primary: tLBRACK aref_args ']'  */
 #line 2618 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_array(p, (yyvsp[-1].nd));
                       NODE_LINENO((yyval.nd), (yyvsp[-1].nd));
                     }
-#line 7755 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8146 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 300:
+  case 300: /* primary: tLBRACE assoc_list '}'  */
 #line 2623 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_hash(p, (yyvsp[-1].nd));
                       NODE_LINENO((yyval.nd), (yyvsp[-1].nd));
                     }
-#line 7764 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8155 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 301:
+  case 301: /* primary: keyword_return  */
 #line 2628 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_return(p, 0);
                     }
-#line 7772 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8163 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 302:
+  case 302: /* primary: keyword_yield opt_paren_args  */
 #line 2632 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_yield(p, (yyvsp[0].nd));
                     }
-#line 7780 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8171 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 303:
+  case 303: /* primary: keyword_not '(' expr rparen  */
 #line 2636 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_uni_op(p, cond((yyvsp[-1].nd)), "!");
                     }
-#line 7788 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8179 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 304:
+  case 304: /* primary: keyword_not '(' rparen  */
 #line 2640 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_uni_op(p, new_nil(p), "!");
                     }
-#line 7796 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8187 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 305:
+  case 305: /* primary: operation brace_block  */
 #line 2644 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_fcall(p, (yyvsp[-1].id), cons(0, (yyvsp[0].nd)));
                     }
-#line 7804 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8195 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 307:
+  case 307: /* primary: method_call brace_block  */
 #line 2649 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       call_with_block(p, (yyvsp[-1].nd), (yyvsp[0].nd));
                       (yyval.nd) = (yyvsp[-1].nd);
                     }
-#line 7813 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8204 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 308:
+  case 308: /* @12: %empty  */
 #line 2654 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       local_nest(p);
                       (yyval.num) = p->lpar_beg;
                       p->lpar_beg = ++p->paren_nest;
                     }
-#line 7823 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8214 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 309:
+  case 309: /* @13: %empty  */
 #line 2660 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.stack) = p->cmdarg_stack;
                       p->cmdarg_stack = 0;
                     }
-#line 7832 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8223 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 310:
+  case 310: /* primary: tLAMBDA @12 f_larglist @13 lambda_body  */
 #line 2665 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       p->lpar_beg = (yyvsp[-3].num);
@@ -7840,107 +8231,107 @@ yyreduce:
                       p->cmdarg_stack = (yyvsp[-1].stack);
                       CMDARG_LEXPOP();
                     }
-#line 7844 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8235 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 311:
+  case 311: /* primary: keyword_if expr_value then compstmt if_tail keyword_end  */
 #line 2676 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_if(p, cond((yyvsp[-4].nd)), (yyvsp[-2].nd), (yyvsp[-1].nd));
                       SET_LINENO((yyval.nd), (yyvsp[-5].num));
                     }
-#line 7853 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8244 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 312:
+  case 312: /* primary: keyword_unless expr_value then compstmt opt_else keyword_end  */
 #line 2684 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_unless(p, cond((yyvsp[-4].nd)), (yyvsp[-2].nd), (yyvsp[-1].nd));
                       SET_LINENO((yyval.nd), (yyvsp[-5].num));
                     }
-#line 7862 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8253 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 313:
+  case 313: /* $@14: %empty  */
 #line 2688 "mrbgems/mruby-compiler/core/parse.y"
                                 {COND_PUSH(1);}
-#line 7868 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8259 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 314:
+  case 314: /* $@15: %empty  */
 #line 2688 "mrbgems/mruby-compiler/core/parse.y"
                                                               {COND_POP();}
-#line 7874 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8265 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 315:
+  case 315: /* primary: keyword_while $@14 expr_value do $@15 compstmt keyword_end  */
 #line 2691 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_while(p, cond((yyvsp[-4].nd)), (yyvsp[-1].nd));
                       SET_LINENO((yyval.nd), (yyvsp[-6].num));
                     }
-#line 7883 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8274 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 316:
+  case 316: /* $@16: %empty  */
 #line 2695 "mrbgems/mruby-compiler/core/parse.y"
                                 {COND_PUSH(1);}
-#line 7889 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8280 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 317:
+  case 317: /* $@17: %empty  */
 #line 2695 "mrbgems/mruby-compiler/core/parse.y"
                                                               {COND_POP();}
-#line 7895 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8286 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 318:
+  case 318: /* primary: keyword_until $@16 expr_value do $@17 compstmt keyword_end  */
 #line 2698 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_until(p, cond((yyvsp[-4].nd)), (yyvsp[-1].nd));
                       SET_LINENO((yyval.nd), (yyvsp[-6].num));
                     }
-#line 7904 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8295 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 319:
+  case 319: /* primary: keyword_case expr_value opt_terms case_body keyword_end  */
 #line 2705 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_case(p, (yyvsp[-3].nd), (yyvsp[-1].nd));
                     }
-#line 7912 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8303 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 320:
+  case 320: /* primary: keyword_case opt_terms case_body keyword_end  */
 #line 2709 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_case(p, 0, (yyvsp[-1].nd));
                     }
-#line 7920 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8311 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 321:
+  case 321: /* $@18: %empty  */
 #line 2713 "mrbgems/mruby-compiler/core/parse.y"
                   {COND_PUSH(1);}
-#line 7926 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8317 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 322:
+  case 322: /* $@19: %empty  */
 #line 2715 "mrbgems/mruby-compiler/core/parse.y"
                   {COND_POP();}
-#line 7932 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8323 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 323:
+  case 323: /* primary: keyword_for for_var keyword_in $@18 expr_value do $@19 compstmt keyword_end  */
 #line 2718 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_for(p, (yyvsp[-7].nd), (yyvsp[-4].nd), (yyvsp[-1].nd));
                       SET_LINENO((yyval.nd), (yyvsp[-8].num));
                     }
-#line 7941 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8332 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 324:
+  case 324: /* @20: %empty  */
 #line 2724 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       if (p->in_def || p->in_single)
@@ -7948,10 +8339,10 @@ yyreduce:
                       (yyval.nd) = local_switch(p);
                       nvars_block(p);
                     }
-#line 7952 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8343 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 325:
+  case 325: /* primary: keyword_class cpath superclass @20 bodystmt keyword_end  */
 #line 2732 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_class(p, (yyvsp[-4].nd), (yyvsp[-3].nd), (yyvsp[-1].nd));
@@ -7959,29 +8350,29 @@ yyreduce:
                       local_resume(p, (yyvsp[-2].nd));
                       nvars_unnest(p);
                     }
-#line 7963 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8354 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 326:
+  case 326: /* @21: %empty  */
 #line 2740 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.num) = p->in_def;
                       p->in_def = 0;
                     }
-#line 7972 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8363 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 327:
+  case 327: /* @22: %empty  */
 #line 2745 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = cons(local_switch(p), nint(p->in_single));
                       nvars_block(p);
                       p->in_single = 0;
                     }
-#line 7982 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8373 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 328:
+  case 328: /* primary: keyword_class tLSHFT expr @21 term @22 bodystmt keyword_end  */
 #line 2752 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_sclass(p, (yyvsp[-5].nd), (yyvsp[-1].nd));
@@ -7991,10 +8382,10 @@ yyreduce:
                       p->in_def = (yyvsp[-4].num);
                       p->in_single = intn((yyvsp[-2].nd)->cdr);
                     }
-#line 7995 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8386 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 329:
+  case 329: /* @23: %empty  */
 #line 2762 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       if (p->in_def || p->in_single)
@@ -8002,10 +8393,10 @@ yyreduce:
                       (yyval.nd) = local_switch(p);
                       nvars_block(p);
                     }
-#line 8006 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8397 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 330:
+  case 330: /* primary: keyword_module cpath @23 bodystmt keyword_end  */
 #line 2770 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_module(p, (yyvsp[-3].nd), (yyvsp[-1].nd));
@@ -8013,10 +8404,10 @@ yyreduce:
                       local_resume(p, (yyvsp[-2].nd));
                       nvars_unnest(p);
                     }
-#line 8017 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8408 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 331:
+  case 331: /* primary: defn_head f_arglist bodystmt keyword_end  */
 #line 2780 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[-3].nd);
@@ -8024,10 +8415,10 @@ yyreduce:
                       nvars_unnest(p);
                       p->in_def--;
                     }
-#line 8028 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8419 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 332:
+  case 332: /* primary: defs_head f_arglist bodystmt keyword_end  */
 #line 2790 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[-3].nd);
@@ -8036,450 +8427,450 @@ yyreduce:
                       p->in_def--;
                       p->in_single--;
                     }
-#line 8040 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8431 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 333:
+  case 333: /* primary: keyword_break  */
 #line 2798 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_break(p, 0);
                     }
-#line 8048 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8439 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 334:
+  case 334: /* primary: keyword_next  */
 #line 2802 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_next(p, 0);
                     }
-#line 8056 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8447 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 335:
+  case 335: /* primary: keyword_redo  */
 #line 2806 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_redo(p);
                     }
-#line 8064 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8455 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 336:
+  case 336: /* primary: keyword_retry  */
 #line 2810 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_retry(p);
                     }
-#line 8072 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8463 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 337:
+  case 337: /* primary_value: primary  */
 #line 2816 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[0].nd);
                       if (!(yyval.nd)) (yyval.nd) = new_nil(p);
                     }
-#line 8081 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8472 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 344:
+  case 344: /* if_tail: keyword_elsif expr_value then compstmt if_tail  */
 #line 2835 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_if(p, cond((yyvsp[-3].nd)), (yyvsp[-1].nd), (yyvsp[0].nd));
                     }
-#line 8089 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8480 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 346:
+  case 346: /* opt_else: keyword_else compstmt  */
 #line 2842 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[0].nd);
                     }
-#line 8097 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8488 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 347:
+  case 347: /* for_var: lhs  */
 #line 2848 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list1(list1((yyvsp[0].nd)));
                     }
-#line 8105 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8496 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 349:
+  case 349: /* f_margs: f_arg  */
 #line 2855 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list3((yyvsp[0].nd),0,0);
                     }
-#line 8113 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8504 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 350:
+  case 350: /* f_margs: f_arg ',' tSTAR f_norm_arg  */
 #line 2859 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list3((yyvsp[-3].nd), new_arg(p, (yyvsp[0].id)), 0);
                     }
-#line 8121 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8512 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 351:
+  case 351: /* f_margs: f_arg ',' tSTAR f_norm_arg ',' f_arg  */
 #line 2863 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list3((yyvsp[-5].nd), new_arg(p, (yyvsp[-2].id)), (yyvsp[0].nd));
                     }
-#line 8129 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8520 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 352:
+  case 352: /* f_margs: f_arg ',' tSTAR  */
 #line 2867 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       local_add_f(p, 0);
                       (yyval.nd) = list3((yyvsp[-2].nd), (node*)-1, 0);
                     }
-#line 8138 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8529 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 353:
+  case 353: /* f_margs: f_arg ',' tSTAR ',' f_arg  */
 #line 2872 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list3((yyvsp[-4].nd), (node*)-1, (yyvsp[0].nd));
                     }
-#line 8146 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8537 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 354:
+  case 354: /* f_margs: tSTAR f_norm_arg  */
 #line 2876 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list3(0, new_arg(p, (yyvsp[0].id)), 0);
                     }
-#line 8154 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8545 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 355:
+  case 355: /* f_margs: tSTAR f_norm_arg ',' f_arg  */
 #line 2880 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list3(0, new_arg(p, (yyvsp[-2].id)), (yyvsp[0].nd));
                     }
-#line 8162 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8553 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 356:
+  case 356: /* f_margs: tSTAR  */
 #line 2884 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       local_add_f(p, 0);
                       (yyval.nd) = list3(0, (node*)-1, 0);
                     }
-#line 8171 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8562 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 357:
+  case 357: /* $@24: %empty  */
 #line 2889 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       local_add_f(p, 0);
                     }
-#line 8179 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8570 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 358:
+  case 358: /* f_margs: tSTAR ',' $@24 f_arg  */
 #line 2893 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list3(0, (node*)-1, (yyvsp[0].nd));
                     }
-#line 8187 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8578 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 359:
+  case 359: /* block_args_tail: f_block_kwarg ',' f_kwrest opt_f_block_arg  */
 #line 2899 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args_tail(p, (yyvsp[-3].nd), (yyvsp[-1].nd), (yyvsp[0].id));
                     }
-#line 8195 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8586 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 360:
+  case 360: /* block_args_tail: f_block_kwarg opt_f_block_arg  */
 #line 2903 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args_tail(p, (yyvsp[-1].nd), 0, (yyvsp[0].id));
                     }
-#line 8203 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8594 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 361:
+  case 361: /* block_args_tail: f_kwrest opt_f_block_arg  */
 #line 2907 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args_tail(p, 0, (yyvsp[-1].nd), (yyvsp[0].id));
                     }
-#line 8211 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8602 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 362:
+  case 362: /* block_args_tail: f_block_arg  */
 #line 2911 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args_tail(p, 0, 0, (yyvsp[0].id));
                     }
-#line 8219 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8610 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 363:
+  case 363: /* opt_block_args_tail: ',' block_args_tail  */
 #line 2917 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[0].nd);
                     }
-#line 8227 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8618 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 364:
+  case 364: /* opt_block_args_tail: %empty  */
 #line 2921 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args_tail(p, 0, 0, 0);
                     }
-#line 8235 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8626 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 365:
+  case 365: /* block_param: f_arg ',' f_block_optarg ',' f_rest_arg opt_block_args_tail  */
 #line 2927 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, (yyvsp[-5].nd), (yyvsp[-3].nd), (yyvsp[-1].id), 0, (yyvsp[0].nd));
                     }
-#line 8243 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8634 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 366:
+  case 366: /* block_param: f_arg ',' f_block_optarg ',' f_rest_arg ',' f_arg opt_block_args_tail  */
 #line 2931 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, (yyvsp[-7].nd), (yyvsp[-5].nd), (yyvsp[-3].id), (yyvsp[-1].nd), (yyvsp[0].nd));
                     }
-#line 8251 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8642 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 367:
+  case 367: /* block_param: f_arg ',' f_block_optarg opt_block_args_tail  */
 #line 2935 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, (yyvsp[-3].nd), (yyvsp[-1].nd), 0, 0, (yyvsp[0].nd));
                     }
-#line 8259 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8650 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 368:
+  case 368: /* block_param: f_arg ',' f_block_optarg ',' f_arg opt_block_args_tail  */
 #line 2939 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, (yyvsp[-5].nd), (yyvsp[-3].nd), 0, (yyvsp[-1].nd), (yyvsp[0].nd));
                     }
-#line 8267 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8658 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 369:
+  case 369: /* block_param: f_arg ',' f_rest_arg opt_block_args_tail  */
 #line 2943 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, (yyvsp[-3].nd), 0, (yyvsp[-1].id), 0, (yyvsp[0].nd));
                     }
-#line 8275 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8666 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 370:
+  case 370: /* block_param: f_arg ',' opt_block_args_tail  */
 #line 2947 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, (yyvsp[-2].nd), 0, 0, 0, (yyvsp[0].nd));
                     }
-#line 8283 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8674 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 371:
+  case 371: /* block_param: f_arg ',' f_rest_arg ',' f_arg opt_block_args_tail  */
 #line 2951 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, (yyvsp[-5].nd), 0, (yyvsp[-3].id), (yyvsp[-1].nd), (yyvsp[0].nd));
                     }
-#line 8291 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8682 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 372:
+  case 372: /* block_param: f_arg opt_block_args_tail  */
 #line 2955 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, (yyvsp[-1].nd), 0, 0, 0, (yyvsp[0].nd));
                     }
-#line 8299 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8690 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 373:
+  case 373: /* block_param: f_block_optarg ',' f_rest_arg opt_block_args_tail  */
 #line 2959 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, 0, (yyvsp[-3].nd), (yyvsp[-1].id), 0, (yyvsp[0].nd));
                     }
-#line 8307 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8698 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 374:
+  case 374: /* block_param: f_block_optarg ',' f_rest_arg ',' f_arg opt_block_args_tail  */
 #line 2963 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, 0, (yyvsp[-5].nd), (yyvsp[-3].id), (yyvsp[-1].nd), (yyvsp[0].nd));
                     }
-#line 8315 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8706 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 375:
+  case 375: /* block_param: f_block_optarg opt_block_args_tail  */
 #line 2967 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, 0, (yyvsp[-1].nd), 0, 0, (yyvsp[0].nd));
                     }
-#line 8323 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8714 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 376:
+  case 376: /* block_param: f_block_optarg ',' f_arg opt_block_args_tail  */
 #line 2971 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, 0, (yyvsp[-3].nd), 0, (yyvsp[-1].nd), (yyvsp[0].nd));
                     }
-#line 8331 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8722 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 377:
+  case 377: /* block_param: f_rest_arg opt_block_args_tail  */
 #line 2975 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, 0, 0, (yyvsp[-1].id), 0, (yyvsp[0].nd));
                     }
-#line 8339 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8730 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 378:
+  case 378: /* block_param: f_rest_arg ',' f_arg opt_block_args_tail  */
 #line 2979 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, 0, 0, (yyvsp[-3].id), (yyvsp[-1].nd), (yyvsp[0].nd));
                     }
-#line 8347 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8738 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 379:
+  case 379: /* block_param: block_args_tail  */
 #line 2983 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, 0, 0, 0, 0, (yyvsp[0].nd));
                     }
-#line 8355 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8746 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 380:
+  case 380: /* opt_block_param: none  */
 #line 2989 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       local_add_blk(p, 0);
                       (yyval.nd) = 0;
                     }
-#line 8364 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8755 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 381:
+  case 381: /* opt_block_param: block_param_def  */
 #line 2994 "mrbgems/mruby-compiler/core/parse.y"
                    {
                       p->cmd_start = TRUE;
                       (yyval.nd) = (yyvsp[0].nd);
                     }
-#line 8373 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8764 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 382:
+  case 382: /* $@25: %empty  */
 #line 3000 "mrbgems/mruby-compiler/core/parse.y"
                       {local_add_blk(p, 0);}
-#line 8379 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8770 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 383:
+  case 383: /* block_param_def: '|' $@25 opt_bv_decl '|'  */
 #line 3001 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = 0;
                     }
-#line 8387 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8778 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 384:
+  case 384: /* block_param_def: tOROP  */
 #line 3005 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       local_add_blk(p, 0);
                       (yyval.nd) = 0;
                     }
-#line 8396 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8787 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 385:
+  case 385: /* block_param_def: '|' block_param opt_bv_decl '|'  */
 #line 3010 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[-2].nd);
                     }
-#line 8404 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8795 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 386:
+  case 386: /* opt_bv_decl: opt_nl  */
 #line 3017 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = 0;
                     }
-#line 8412 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8803 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 387:
+  case 387: /* opt_bv_decl: opt_nl ';' bv_decls opt_nl  */
 #line 3021 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = 0;
                     }
-#line 8420 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8811 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 390:
+  case 390: /* bvar: tIDENTIFIER  */
 #line 3031 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       local_add_f(p, (yyvsp[0].id));
                       new_bv(p, (yyvsp[0].id));
                     }
-#line 8429 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8820 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 392:
+  case 392: /* f_larglist: '(' f_args opt_bv_decl ')'  */
 #line 3039 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[-2].nd);
                     }
-#line 8437 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8828 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 393:
+  case 393: /* f_larglist: f_args  */
 #line 3043 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[0].nd);
                     }
-#line 8445 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8836 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 394:
+  case 394: /* lambda_body: tLAMBEG compstmt '}'  */
 #line 3049 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[-1].nd);
                     }
-#line 8453 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8844 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 395:
+  case 395: /* lambda_body: keyword_do_LAMBDA bodystmt keyword_end  */
 #line 3053 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[-1].nd);
                     }
-#line 8461 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8852 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 396:
+  case 396: /* $@26: %empty  */
 #line 3059 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       local_nest(p);
                       nvars_nest(p);
                     }
-#line 8470 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8861 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 397:
+  case 397: /* do_block: keyword_do_block $@26 opt_block_param bodystmt keyword_end  */
 #line 3066 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_block(p,(yyvsp[-2].nd),(yyvsp[-1].nd));
                       local_unnest(p);
                       nvars_unnest(p);
                     }
-#line 8480 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8871 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 398:
+  case 398: /* block_call: command do_block  */
 #line 3074 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       if ((yyvsp[-1].nd)->car == (node*)NODE_YIELD) {
@@ -8490,118 +8881,118 @@ yyreduce:
                       }
                       (yyval.nd) = (yyvsp[-1].nd);
                     }
-#line 8494 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8885 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 399:
+  case 399: /* block_call: block_call call_op2 operation2 opt_paren_args  */
 #line 3084 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_call(p, (yyvsp[-3].nd), (yyvsp[-1].id), (yyvsp[0].nd), (yyvsp[-2].num));
                     }
-#line 8502 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8893 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 400:
+  case 400: /* block_call: block_call call_op2 operation2 opt_paren_args brace_block  */
 #line 3088 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_call(p, (yyvsp[-4].nd), (yyvsp[-2].id), (yyvsp[-1].nd), (yyvsp[-3].num));
                       call_with_block(p, (yyval.nd), (yyvsp[0].nd));
                     }
-#line 8511 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8902 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 401:
+  case 401: /* block_call: block_call call_op2 operation2 command_args do_block  */
 #line 3093 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_call(p, (yyvsp[-4].nd), (yyvsp[-2].id), (yyvsp[-1].nd), (yyvsp[-3].num));
                       call_with_block(p, (yyval.nd), (yyvsp[0].nd));
                     }
-#line 8520 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8911 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 402:
+  case 402: /* method_call: operation paren_args  */
 #line 3100 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_fcall(p, (yyvsp[-1].id), (yyvsp[0].nd));
                     }
-#line 8528 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8919 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 403:
+  case 403: /* method_call: primary_value call_op operation2 opt_paren_args  */
 #line 3104 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_call(p, (yyvsp[-3].nd), (yyvsp[-1].id), (yyvsp[0].nd), (yyvsp[-2].num));
                     }
-#line 8536 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8927 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 404:
+  case 404: /* method_call: primary_value tCOLON2 operation2 paren_args  */
 #line 3108 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_call(p, (yyvsp[-3].nd), (yyvsp[-1].id), (yyvsp[0].nd), tCOLON2);
                     }
-#line 8544 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8935 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 405:
+  case 405: /* method_call: primary_value tCOLON2 operation3  */
 #line 3112 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_call(p, (yyvsp[-2].nd), (yyvsp[0].id), 0, tCOLON2);
                     }
-#line 8552 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8943 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 406:
+  case 406: /* method_call: primary_value call_op paren_args  */
 #line 3116 "mrbgems/mruby-compiler/core/parse.y"
                     {
-                      (yyval.nd) = new_call(p, (yyvsp[-2].nd), MRB_SYM(call), (yyvsp[0].nd), (yyvsp[-1].num));
+                      (yyval.nd) = new_call(p, (yyvsp[-2].nd), MRB_SYM_2(p->mrb, call), (yyvsp[0].nd), (yyvsp[-1].num));
                     }
-#line 8560 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8951 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 407:
+  case 407: /* method_call: primary_value tCOLON2 paren_args  */
 #line 3120 "mrbgems/mruby-compiler/core/parse.y"
                     {
-                      (yyval.nd) = new_call(p, (yyvsp[-2].nd), MRB_SYM(call), (yyvsp[0].nd), tCOLON2);
+                      (yyval.nd) = new_call(p, (yyvsp[-2].nd), MRB_SYM_2(p->mrb, call), (yyvsp[0].nd), tCOLON2);
                     }
-#line 8568 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8959 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 408:
+  case 408: /* method_call: keyword_super paren_args  */
 #line 3124 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_super(p, (yyvsp[0].nd));
                     }
-#line 8576 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8967 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 409:
+  case 409: /* method_call: keyword_super  */
 #line 3128 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_zsuper(p);
                     }
-#line 8584 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8975 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 410:
+  case 410: /* method_call: primary_value '[' opt_call_args ']'  */
 #line 3132 "mrbgems/mruby-compiler/core/parse.y"
                     {
-                      (yyval.nd) = new_call(p, (yyvsp[-3].nd), MRB_OPSYM(aref), (yyvsp[-1].nd), '.');
+                      (yyval.nd) = new_call(p, (yyvsp[-3].nd), intern_op(aref), (yyvsp[-1].nd), '.');
                     }
-#line 8592 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8983 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 411:
+  case 411: /* @27: %empty  */
 #line 3138 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       local_nest(p);
                       nvars_nest(p);
                       (yyval.num) = p->lineno;
                     }
-#line 8602 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8993 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 412:
+  case 412: /* brace_block: '{' @27 opt_block_param compstmt '}'  */
 #line 3145 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_block(p,(yyvsp[-2].nd),(yyvsp[-1].nd));
@@ -8609,20 +9000,20 @@ yyreduce:
                       local_unnest(p);
                       nvars_unnest(p);
                     }
-#line 8613 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9004 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 413:
+  case 413: /* @28: %empty  */
 #line 3152 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       local_nest(p);
                       nvars_nest(p);
                       (yyval.num) = p->lineno;
                     }
-#line 8623 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9014 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 414:
+  case 414: /* brace_block: keyword_do @28 opt_block_param bodystmt keyword_end  */
 #line 3159 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_block(p,(yyvsp[-2].nd),(yyvsp[-1].nd));
@@ -8630,18 +9021,18 @@ yyreduce:
                       local_unnest(p);
                       nvars_unnest(p);
                     }
-#line 8634 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9025 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 415:
+  case 415: /* case_body: keyword_when args then compstmt cases  */
 #line 3170 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = cons(cons((yyvsp[-3].nd), (yyvsp[-1].nd)), (yyvsp[0].nd));
                     }
-#line 8642 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9033 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 416:
+  case 416: /* cases: opt_else  */
 #line 3176 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       if ((yyvsp[0].nd)) {
@@ -8651,382 +9042,382 @@ yyreduce:
                         (yyval.nd) = 0;
                       }
                     }
-#line 8655 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9046 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 418:
+  case 418: /* opt_rescue: keyword_rescue exc_list exc_var then compstmt opt_rescue  */
 #line 3190 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list1(list3((yyvsp[-4].nd), (yyvsp[-3].nd), (yyvsp[-1].nd)));
                       if ((yyvsp[0].nd)) (yyval.nd) = append((yyval.nd), (yyvsp[0].nd));
                     }
-#line 8664 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9055 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 420:
+  case 420: /* exc_list: arg  */
 #line 3198 "mrbgems/mruby-compiler/core/parse.y"
                     {
                         (yyval.nd) = list1((yyvsp[0].nd));
                     }
-#line 8672 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9063 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 423:
+  case 423: /* exc_var: tASSOC lhs  */
 #line 3206 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[0].nd);
                     }
-#line 8680 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9071 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 425:
+  case 425: /* opt_ensure: keyword_ensure compstmt  */
 #line 3213 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[0].nd);
                     }
-#line 8688 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9079 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 432:
+  case 432: /* string: string string_fragment  */
 #line 3227 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = concat_string(p, (yyvsp[-1].nd), (yyvsp[0].nd));
                     }
-#line 8696 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9087 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 435:
+  case 435: /* string_fragment: tSTRING_BEG tSTRING  */
 #line 3235 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[0].nd);
                     }
-#line 8704 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9095 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 436:
+  case 436: /* string_fragment: tSTRING_BEG string_rep tSTRING  */
 #line 3239 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_dstr(p, push((yyvsp[-1].nd), (yyvsp[0].nd)));
                     }
-#line 8712 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9103 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 438:
+  case 438: /* string_rep: string_rep string_interp  */
 #line 3246 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = append((yyvsp[-1].nd), (yyvsp[0].nd));
                     }
-#line 8720 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9111 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 439:
+  case 439: /* string_interp: tSTRING_MID  */
 #line 3252 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list1((yyvsp[0].nd));
                     }
-#line 8728 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9119 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 440:
+  case 440: /* @29: %empty  */
 #line 3256 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = p->lex_strterm;
                       p->lex_strterm = NULL;
                     }
-#line 8737 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9128 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 441:
+  case 441: /* string_interp: tSTRING_PART @29 compstmt '}'  */
 #line 3262 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       p->lex_strterm = (yyvsp[-2].nd);
                       (yyval.nd) = list2((yyvsp[-3].nd), (yyvsp[-1].nd));
                     }
-#line 8746 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9137 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 442:
+  case 442: /* string_interp: tLITERAL_DELIM  */
 #line 3267 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list1(new_literal_delim(p));
                     }
-#line 8754 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9145 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 443:
+  case 443: /* string_interp: tHD_LITERAL_DELIM heredoc_bodies  */
 #line 3271 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list1(new_literal_delim(p));
                     }
-#line 8762 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9153 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 444:
+  case 444: /* xstring: tXSTRING_BEG tXSTRING  */
 #line 3277 "mrbgems/mruby-compiler/core/parse.y"
                     {
                         (yyval.nd) = (yyvsp[0].nd);
                     }
-#line 8770 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9161 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 445:
+  case 445: /* xstring: tXSTRING_BEG string_rep tXSTRING  */
 #line 3281 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_dxstr(p, push((yyvsp[-1].nd), (yyvsp[0].nd)));
                     }
-#line 8778 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9169 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 446:
+  case 446: /* regexp: tREGEXP_BEG tREGEXP  */
 #line 3287 "mrbgems/mruby-compiler/core/parse.y"
                     {
                         (yyval.nd) = (yyvsp[0].nd);
                     }
-#line 8786 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9177 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 447:
+  case 447: /* regexp: tREGEXP_BEG string_rep tREGEXP  */
 #line 3291 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_dregx(p, (yyvsp[-1].nd), (yyvsp[0].nd));
                     }
-#line 8794 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9185 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 451:
+  case 451: /* heredoc_body: tHEREDOC_END  */
 #line 3304 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       parser_heredoc_info * inf = parsing_heredoc_inf(p);
                       inf->doc = push(inf->doc, new_str(p, "", 0));
                       heredoc_end(p);
                     }
-#line 8804 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9195 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 452:
+  case 452: /* heredoc_body: heredoc_string_rep tHEREDOC_END  */
 #line 3310 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       heredoc_end(p);
                     }
-#line 8812 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9203 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 455:
+  case 455: /* heredoc_string_interp: tHD_STRING_MID  */
 #line 3320 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       parser_heredoc_info * inf = parsing_heredoc_inf(p);
                       inf->doc = push(inf->doc, (yyvsp[0].nd));
                       heredoc_treat_nextline(p);
                     }
-#line 8822 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9213 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 456:
+  case 456: /* @30: %empty  */
 #line 3326 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = p->lex_strterm;
                       p->lex_strterm = NULL;
                     }
-#line 8831 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9222 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 457:
+  case 457: /* heredoc_string_interp: tHD_STRING_PART @30 compstmt '}'  */
 #line 3332 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       parser_heredoc_info * inf = parsing_heredoc_inf(p);
                       p->lex_strterm = (yyvsp[-2].nd);
                       inf->doc = push(push(inf->doc, (yyvsp[-3].nd)), (yyvsp[-1].nd));
                     }
-#line 8841 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9232 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 458:
+  case 458: /* words: tWORDS_BEG tSTRING  */
 #line 3340 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_words(p, list1((yyvsp[0].nd)));
                     }
-#line 8849 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9240 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 459:
+  case 459: /* words: tWORDS_BEG string_rep tSTRING  */
 #line 3344 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_words(p, push((yyvsp[-1].nd), (yyvsp[0].nd)));
                     }
-#line 8857 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9248 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 460:
+  case 460: /* symbol: basic_symbol  */
 #line 3351 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       p->lstate = EXPR_ENDARG;
                       (yyval.nd) = new_sym(p, (yyvsp[0].id));
                     }
-#line 8866 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9257 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 461:
+  case 461: /* symbol: tSYMBEG tSTRING_BEG string_rep tSTRING  */
 #line 3356 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       p->lstate = EXPR_ENDARG;
                       (yyval.nd) = new_dsym(p, new_dstr(p, push((yyvsp[-1].nd), (yyvsp[0].nd))));
                     }
-#line 8875 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9266 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 462:
+  case 462: /* basic_symbol: tSYMBEG sym  */
 #line 3363 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.id) = (yyvsp[0].id);
                     }
-#line 8883 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9274 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 467:
+  case 467: /* sym: tSTRING  */
 #line 3373 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.id) = new_strsym(p, (yyvsp[0].nd));
                     }
-#line 8891 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9282 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 468:
+  case 468: /* sym: tSTRING_BEG tSTRING  */
 #line 3377 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.id) = new_strsym(p, (yyvsp[0].nd));
                     }
-#line 8899 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9290 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 469:
+  case 469: /* symbols: tSYMBOLS_BEG tSTRING  */
 #line 3383 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_symbols(p, list1((yyvsp[0].nd)));
                     }
-#line 8907 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9298 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 470:
+  case 470: /* symbols: tSYMBOLS_BEG string_rep tSTRING  */
 #line 3387 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_symbols(p, push((yyvsp[-1].nd), (yyvsp[0].nd)));
                     }
-#line 8915 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9306 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 473:
+  case 473: /* numeric: tUMINUS_NUM tINTEGER  */
 #line 3395 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = negate_lit(p, (yyvsp[0].nd));
                     }
-#line 8923 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9314 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 474:
+  case 474: /* numeric: tUMINUS_NUM tFLOAT  */
 #line 3399 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = negate_lit(p, (yyvsp[0].nd));
                     }
-#line 8931 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9322 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 475:
+  case 475: /* variable: tIDENTIFIER  */
 #line 3405 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_lvar(p, (yyvsp[0].id));
                     }
-#line 8939 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9330 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 476:
+  case 476: /* variable: tIVAR  */
 #line 3409 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_ivar(p, (yyvsp[0].id));
                     }
-#line 8947 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9338 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 477:
+  case 477: /* variable: tGVAR  */
 #line 3413 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_gvar(p, (yyvsp[0].id));
                     }
-#line 8955 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9346 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 478:
+  case 478: /* variable: tCVAR  */
 #line 3417 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_cvar(p, (yyvsp[0].id));
                     }
-#line 8963 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9354 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 479:
+  case 479: /* variable: tCONSTANT  */
 #line 3421 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_const(p, (yyvsp[0].id));
                     }
-#line 8971 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9362 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 480:
+  case 480: /* var_lhs: variable  */
 #line 3427 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       assignable(p, (yyvsp[0].nd));
                     }
-#line 8979 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9370 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 481:
+  case 481: /* var_lhs: tNUMPARAM  */
 #line 3431 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       yyerror(p, "can't assign to numbered parameter");
                     }
-#line 8987 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9378 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 482:
+  case 482: /* var_ref: variable  */
 #line 3437 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = var_reference(p, (yyvsp[0].nd));
                     }
-#line 8995 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9386 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 483:
+  case 483: /* var_ref: keyword_nil  */
 #line 3441 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_nil(p);
                     }
-#line 9003 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9394 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 484:
+  case 484: /* var_ref: keyword_self  */
 #line 3445 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_self(p);
                     }
-#line 9011 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9402 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 485:
+  case 485: /* var_ref: keyword_true  */
 #line 3449 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_true(p);
                     }
-#line 9019 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9410 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 486:
+  case 486: /* var_ref: keyword_false  */
 #line 3453 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_false(p);
                     }
-#line 9027 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9418 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 487:
+  case 487: /* var_ref: keyword__FILE__  */
 #line 3457 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       const char *fn = mrb_sym_name_len(p->mrb, p->filename_sym, NULL);
@@ -9035,10 +9426,10 @@ yyreduce:
                       }
                       (yyval.nd) = new_str(p, fn, strlen(fn));
                     }
-#line 9039 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9430 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 488:
+  case 488: /* var_ref: keyword__LINE__  */
 #line 3465 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       char buf[16];
@@ -9046,10 +9437,10 @@ yyreduce:
                       dump_int(p->lineno, buf);
                       (yyval.nd) = new_int(p, buf, 10, 0);
                     }
-#line 9050 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9441 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 489:
+  case 489: /* var_ref: keyword__ENCODING__  */
 #line 3472 "mrbgems/mruby-compiler/core/parse.y"
                     {
 #ifdef MRB_UTF8_STRING
@@ -9059,582 +9450,582 @@ yyreduce:
 #endif
                       (yyval.nd) = new_str(p, enc, strlen(enc));
                     }
-#line 9063 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9454 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 492:
+  case 492: /* superclass: %empty  */
 #line 3487 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = 0;
                     }
-#line 9071 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9462 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 493:
+  case 493: /* $@31: %empty  */
 #line 3491 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       p->lstate = EXPR_BEG;
                       p->cmd_start = TRUE;
                     }
-#line 9080 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9471 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 494:
+  case 494: /* superclass: '<' $@31 expr_value term  */
 #line 3496 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[-1].nd);
                     }
-#line 9088 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9479 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 495:
+  case 495: /* f_arglist_paren: '(' f_args rparen  */
 #line 3507 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[-1].nd);
                       p->lstate = EXPR_BEG;
                       p->cmd_start = TRUE;
                     }
-#line 9098 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9489 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 496:
+  case 496: /* f_arglist_paren: '(' f_arg ',' tBDOT3 rparen  */
 #line 3513 "mrbgems/mruby-compiler/core/parse.y"
                     {
 #if 1
                       /* til real keyword args implemented */
-                      mrb_sym r = MRB_OPSYM(mul);
-                      mrb_sym b = MRB_OPSYM(and);
+                      mrb_sym r = intern_op(mul);
+                      mrb_sym b = intern_op(and);
                       local_add_f(p, r);
                       (yyval.nd) = new_args(p, (yyvsp[-3].nd), 0, r, 0,
                                     new_args_tail(p, 0, 0, b));
 #else
-                      mrb_sym r = MRB_OPSYM(mul);
-                      mrb_sym k = MRB_OPSYM(pow);
-                      mrb_sym b = MRB_OPSYM(and);
+                      mrb_sym r = intern_op(mul);
+                      mrb_sym k = intern_op(pow);
+                      mrb_sym b = intern_op(and);
                       local_add_f(p, r); local_add_f(p, k);
                       (yyval.nd) = new_args(p, (yyvsp[-3].nd), 0, r, 0,
                                     new_args_tail(p, 0, new_kw_rest_args(p, nsym(k)), b));
 #endif
                     }
-#line 9120 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9511 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 497:
+  case 497: /* f_arglist_paren: '(' tBDOT3 rparen  */
 #line 3531 "mrbgems/mruby-compiler/core/parse.y"
                     {
 #if 1
                       /* til real keyword args implemented */
-                      mrb_sym r = MRB_OPSYM(mul);
-                      mrb_sym b = MRB_OPSYM(and);
+                      mrb_sym r = intern_op(mul);
+                      mrb_sym b = intern_op(and);
                       local_add_f(p, r);
                       (yyval.nd) = new_args(p, 0, 0, r, 0,
                                     new_args_tail(p, 0, 0, b));
 #else
-                      mrb_sym r = MRB_OPSYM(mul);
-                      mrb_sym k = MRB_OPSYM(pow);
-                      mrb_sym b = MRB_OPSYM(and);
+                      mrb_sym r = intern_op(mul);
+                      mrb_sym k = intern_op(pow);
+                      mrb_sym b = intern_op(and);
                       local_add_f(p, r); local_add_f(p, k);
                       (yyval.nd) = new_args(p, 0, 0, r, 0,
                                     new_args_tail(p, 0, new_kw_rest_args(p, nsym(k)), b));
 #endif
                     }
-#line 9142 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9533 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 499:
+  case 499: /* f_arglist: f_args term  */
 #line 3552 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[-1].nd);
                     }
-#line 9150 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9541 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 500:
+  case 500: /* f_label: tIDENTIFIER tLABEL_TAG  */
 #line 3558 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       local_nest(p);
                     }
-#line 9158 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9549 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 501:
+  case 501: /* f_kw: f_label arg  */
 #line 3564 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       void_expr_error(p, (yyvsp[0].nd));
                       (yyval.nd) = new_kw_arg(p, (yyvsp[-1].id), cons((yyvsp[0].nd), locals_node(p)));
                       local_unnest(p);
                     }
-#line 9168 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9559 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 502:
+  case 502: /* f_kw: f_label  */
 #line 3570 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_kw_arg(p, (yyvsp[0].id), 0);
                       local_unnest(p);
                     }
-#line 9177 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9568 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 503:
+  case 503: /* f_block_kw: f_label primary_value  */
 #line 3577 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_kw_arg(p, (yyvsp[-1].id), cons((yyvsp[0].nd), locals_node(p)));
                       local_unnest(p);
                     }
-#line 9186 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9577 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 504:
+  case 504: /* f_block_kw: f_label  */
 #line 3582 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_kw_arg(p, (yyvsp[0].id), 0);
                       local_unnest(p);
                     }
-#line 9195 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9586 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 505:
+  case 505: /* f_block_kwarg: f_block_kw  */
 #line 3589 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list1((yyvsp[0].nd));
                     }
-#line 9203 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9594 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 506:
+  case 506: /* f_block_kwarg: f_block_kwarg ',' f_block_kw  */
 #line 3593 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = push((yyvsp[-2].nd), (yyvsp[0].nd));
                     }
-#line 9211 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9602 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 507:
+  case 507: /* f_kwarg: f_kw  */
 #line 3599 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list1((yyvsp[0].nd));
                     }
-#line 9219 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9610 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 508:
+  case 508: /* f_kwarg: f_kwarg ',' f_kw  */
 #line 3603 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = push((yyvsp[-2].nd), (yyvsp[0].nd));
                     }
-#line 9227 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9618 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 511:
+  case 511: /* f_kwrest: kwrest_mark tIDENTIFIER  */
 #line 3613 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_kw_rest_args(p, nsym((yyvsp[0].id)));
                     }
-#line 9235 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9626 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 512:
+  case 512: /* f_kwrest: kwrest_mark  */
 #line 3617 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_kw_rest_args(p, 0);
                     }
-#line 9243 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9634 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 513:
+  case 513: /* args_tail: f_kwarg ',' f_kwrest opt_f_block_arg  */
 #line 3623 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args_tail(p, (yyvsp[-3].nd), (yyvsp[-1].nd), (yyvsp[0].id));
                     }
-#line 9251 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9642 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 514:
+  case 514: /* args_tail: f_kwarg opt_f_block_arg  */
 #line 3627 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args_tail(p, (yyvsp[-1].nd), 0, (yyvsp[0].id));
                     }
-#line 9259 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9650 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 515:
+  case 515: /* args_tail: f_kwrest opt_f_block_arg  */
 #line 3631 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args_tail(p, 0, (yyvsp[-1].nd), (yyvsp[0].id));
                     }
-#line 9267 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9658 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 516:
+  case 516: /* args_tail: f_block_arg  */
 #line 3635 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args_tail(p, 0, 0, (yyvsp[0].id));
                     }
-#line 9275 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9666 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 517:
+  case 517: /* opt_args_tail: ',' args_tail  */
 #line 3641 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[0].nd);
                     }
-#line 9283 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9674 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 518:
+  case 518: /* opt_args_tail: %empty  */
 #line 3645 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args_tail(p, 0, 0, 0);
                     }
-#line 9291 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9682 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 519:
+  case 519: /* f_args: f_arg ',' f_optarg ',' f_rest_arg opt_args_tail  */
 #line 3651 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, (yyvsp[-5].nd), (yyvsp[-3].nd), (yyvsp[-1].id), 0, (yyvsp[0].nd));
                     }
-#line 9299 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9690 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 520:
+  case 520: /* f_args: f_arg ',' f_optarg ',' f_rest_arg ',' f_arg opt_args_tail  */
 #line 3655 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, (yyvsp[-7].nd), (yyvsp[-5].nd), (yyvsp[-3].id), (yyvsp[-1].nd), (yyvsp[0].nd));
                     }
-#line 9307 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9698 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 521:
+  case 521: /* f_args: f_arg ',' f_optarg opt_args_tail  */
 #line 3659 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, (yyvsp[-3].nd), (yyvsp[-1].nd), 0, 0, (yyvsp[0].nd));
                     }
-#line 9315 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9706 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 522:
+  case 522: /* f_args: f_arg ',' f_optarg ',' f_arg opt_args_tail  */
 #line 3663 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, (yyvsp[-5].nd), (yyvsp[-3].nd), 0, (yyvsp[-1].nd), (yyvsp[0].nd));
                     }
-#line 9323 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9714 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 523:
+  case 523: /* f_args: f_arg ',' f_rest_arg opt_args_tail  */
 #line 3667 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, (yyvsp[-3].nd), 0, (yyvsp[-1].id), 0, (yyvsp[0].nd));
                     }
-#line 9331 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9722 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 524:
+  case 524: /* f_args: f_arg ',' f_rest_arg ',' f_arg opt_args_tail  */
 #line 3671 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, (yyvsp[-5].nd), 0, (yyvsp[-3].id), (yyvsp[-1].nd), (yyvsp[0].nd));
                     }
-#line 9339 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9730 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 525:
+  case 525: /* f_args: f_arg opt_args_tail  */
 #line 3675 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, (yyvsp[-1].nd), 0, 0, 0, (yyvsp[0].nd));
                     }
-#line 9347 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9738 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 526:
+  case 526: /* f_args: f_optarg ',' f_rest_arg opt_args_tail  */
 #line 3679 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, 0, (yyvsp[-3].nd), (yyvsp[-1].id), 0, (yyvsp[0].nd));
                     }
-#line 9355 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9746 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 527:
+  case 527: /* f_args: f_optarg ',' f_rest_arg ',' f_arg opt_args_tail  */
 #line 3683 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, 0, (yyvsp[-5].nd), (yyvsp[-3].id), (yyvsp[-1].nd), (yyvsp[0].nd));
                     }
-#line 9363 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9754 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 528:
+  case 528: /* f_args: f_optarg opt_args_tail  */
 #line 3687 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, 0, (yyvsp[-1].nd), 0, 0, (yyvsp[0].nd));
                     }
-#line 9371 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9762 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 529:
+  case 529: /* f_args: f_optarg ',' f_arg opt_args_tail  */
 #line 3691 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, 0, (yyvsp[-3].nd), 0, (yyvsp[-1].nd), (yyvsp[0].nd));
                     }
-#line 9379 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9770 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 530:
+  case 530: /* f_args: f_rest_arg opt_args_tail  */
 #line 3695 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, 0, 0, (yyvsp[-1].id), 0, (yyvsp[0].nd));
                     }
-#line 9387 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9778 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 531:
+  case 531: /* f_args: f_rest_arg ',' f_arg opt_args_tail  */
 #line 3699 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, 0, 0, (yyvsp[-3].id), (yyvsp[-1].nd), (yyvsp[0].nd));
                     }
-#line 9395 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9786 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 532:
+  case 532: /* f_args: args_tail  */
 #line 3703 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, 0, 0, 0, 0, (yyvsp[0].nd));
                     }
-#line 9403 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9794 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 533:
+  case 533: /* f_args: %empty  */
 #line 3707 "mrbgems/mruby-compiler/core/parse.y"
                     {
-                      local_add_f(p, MRB_OPSYM(and));
+                      local_add_f(p, intern_op(and));
                       (yyval.nd) = new_args(p, 0, 0, 0, 0, 0);
                     }
-#line 9412 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9803 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 534:
+  case 534: /* f_bad_arg: tCONSTANT  */
 #line 3714 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       yyerror(p, "formal argument cannot be a constant");
                       (yyval.nd) = 0;
                     }
-#line 9421 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9812 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 535:
+  case 535: /* f_bad_arg: tIVAR  */
 #line 3719 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       yyerror(p, "formal argument cannot be an instance variable");
                       (yyval.nd) = 0;
                     }
-#line 9430 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9821 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 536:
+  case 536: /* f_bad_arg: tGVAR  */
 #line 3724 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       yyerror(p, "formal argument cannot be a global variable");
                       (yyval.nd) = 0;
                     }
-#line 9439 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9830 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 537:
+  case 537: /* f_bad_arg: tCVAR  */
 #line 3729 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       yyerror(p, "formal argument cannot be a class variable");
                       (yyval.nd) = 0;
                     }
-#line 9448 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9839 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 538:
+  case 538: /* f_bad_arg: tNUMPARAM  */
 #line 3734 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       yyerror(p, "formal argument cannot be a numbered parameter");
                       (yyval.nd) = 0;
                     }
-#line 9457 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9848 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 539:
+  case 539: /* f_norm_arg: f_bad_arg  */
 #line 3741 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.id) = 0;
                     }
-#line 9465 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9856 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 540:
+  case 540: /* f_norm_arg: tIDENTIFIER  */
 #line 3745 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       local_add_f(p, (yyvsp[0].id));
                       (yyval.id) = (yyvsp[0].id);
                     }
-#line 9474 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9865 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 541:
+  case 541: /* f_arg_item: f_norm_arg  */
 #line 3752 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_arg(p, (yyvsp[0].id));
                     }
-#line 9482 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9873 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 542:
+  case 542: /* @32: %empty  */
 #line 3756 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = local_switch(p);
                     }
-#line 9490 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9881 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 543:
+  case 543: /* f_arg_item: tLPAREN @32 f_margs rparen  */
 #line 3760 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_masgn_param(p, (yyvsp[-1].nd), p->locals->car);
                       local_resume(p, (yyvsp[-2].nd));
                       local_add_f(p, 0);
                     }
-#line 9500 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9891 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 544:
+  case 544: /* f_arg: f_arg_item  */
 #line 3768 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list1((yyvsp[0].nd));
                     }
-#line 9508 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9899 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 545:
+  case 545: /* f_arg: f_arg ',' f_arg_item  */
 #line 3772 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = push((yyvsp[-2].nd), (yyvsp[0].nd));
                     }
-#line 9516 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9907 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 546:
+  case 546: /* f_opt_asgn: tIDENTIFIER '='  */
 #line 3778 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       local_add_f(p, (yyvsp[-1].id));
                       local_nest(p);
                       (yyval.id) = (yyvsp[-1].id);
                     }
-#line 9526 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9917 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 547:
+  case 547: /* f_opt: f_opt_asgn arg  */
 #line 3786 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       void_expr_error(p, (yyvsp[0].nd));
                       (yyval.nd) = cons(nsym((yyvsp[-1].id)), cons((yyvsp[0].nd), locals_node(p)));
                       local_unnest(p);
                     }
-#line 9536 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9927 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 548:
+  case 548: /* f_block_opt: f_opt_asgn primary_value  */
 #line 3794 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       void_expr_error(p, (yyvsp[0].nd));
                       (yyval.nd) = cons(nsym((yyvsp[-1].id)), cons((yyvsp[0].nd), locals_node(p)));
                       local_unnest(p);
                     }
-#line 9546 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9937 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 549:
+  case 549: /* f_block_optarg: f_block_opt  */
 #line 3802 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list1((yyvsp[0].nd));
                     }
-#line 9554 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9945 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 550:
+  case 550: /* f_block_optarg: f_block_optarg ',' f_block_opt  */
 #line 3806 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = push((yyvsp[-2].nd), (yyvsp[0].nd));
                     }
-#line 9562 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9953 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 551:
+  case 551: /* f_optarg: f_opt  */
 #line 3812 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list1((yyvsp[0].nd));
                     }
-#line 9570 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9961 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 552:
+  case 552: /* f_optarg: f_optarg ',' f_opt  */
 #line 3816 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = push((yyvsp[-2].nd), (yyvsp[0].nd));
                     }
-#line 9578 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9969 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 555:
+  case 555: /* f_rest_arg: restarg_mark tIDENTIFIER  */
 #line 3826 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       local_add_f(p, (yyvsp[0].id));
                       (yyval.id) = (yyvsp[0].id);
                     }
-#line 9587 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9978 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 556:
+  case 556: /* f_rest_arg: restarg_mark  */
 #line 3831 "mrbgems/mruby-compiler/core/parse.y"
                     {
-                      local_add_f(p, MRB_OPSYM(mul));
+                      local_add_f(p, intern_op(mul));
                       (yyval.id) = -1;
                     }
-#line 9596 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9987 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 559:
+  case 559: /* f_block_arg: blkarg_mark tIDENTIFIER  */
 #line 3842 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.id) = (yyvsp[0].id);
                     }
-#line 9604 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9995 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 560:
+  case 560: /* opt_f_block_arg: ',' f_block_arg  */
 #line 3848 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.id) = (yyvsp[0].id);
                     }
-#line 9612 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 10003 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 561:
+  case 561: /* opt_f_block_arg: none  */
 #line 3852 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.id) = 0;
                     }
-#line 9620 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 10011 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 562:
+  case 562: /* singleton: var_ref  */
 #line 3858 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[0].nd);
                       if (!(yyval.nd)) (yyval.nd) = new_nil(p);
                     }
-#line 9629 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 10020 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 563:
+  case 563: /* $@33: %empty  */
 #line 3862 "mrbgems/mruby-compiler/core/parse.y"
                       {p->lstate = EXPR_BEG;}
-#line 9635 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 10026 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 564:
+  case 564: /* singleton: '(' $@33 expr rparen  */
 #line 3863 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       if ((yyvsp[-1].nd) == 0) {
@@ -9658,54 +10049,54 @@ yyreduce:
                       }
                       (yyval.nd) = (yyvsp[-1].nd);
                     }
-#line 9662 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 10053 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 566:
+  case 566: /* assoc_list: assocs trailer  */
 #line 3889 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[-1].nd);
                     }
-#line 9670 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 10061 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 567:
+  case 567: /* assocs: assoc  */
 #line 3895 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list1((yyvsp[0].nd));
                       NODE_LINENO((yyval.nd), (yyvsp[0].nd));
                     }
-#line 9679 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 10070 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 568:
+  case 568: /* assocs: assocs comma assoc  */
 #line 3900 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = push((yyvsp[-2].nd), (yyvsp[0].nd));
                     }
-#line 9687 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 10078 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 571:
+  case 571: /* assoc: arg tASSOC arg  */
 #line 3910 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       void_expr_error(p, (yyvsp[-2].nd));
                       void_expr_error(p, (yyvsp[0].nd));
                       (yyval.nd) = cons((yyvsp[-2].nd), (yyvsp[0].nd));
                     }
-#line 9697 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 10088 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 572:
+  case 572: /* assoc: tIDENTIFIER label_tag arg  */
 #line 3916 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       void_expr_error(p, (yyvsp[0].nd));
                       (yyval.nd) = cons(new_sym(p, (yyvsp[-2].id)), (yyvsp[0].nd));
                     }
-#line 9706 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 10097 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 573:
+  case 573: /* assoc: string_fragment label_tag arg  */
 #line 3921 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       void_expr_error(p, (yyvsp[0].nd));
@@ -9716,67 +10107,67 @@ yyreduce:
                         (yyval.nd) = cons(new_sym(p, new_strsym(p, (yyvsp[-2].nd))), (yyvsp[0].nd));
                       }
                     }
-#line 9720 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 10111 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 574:
+  case 574: /* assoc: tDSTAR arg  */
 #line 3931 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       void_expr_error(p, (yyvsp[0].nd));
                       (yyval.nd) = cons(new_kw_rest_args(p, 0), (yyvsp[0].nd));
                     }
-#line 9729 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 10120 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 587:
+  case 587: /* call_op: '.'  */
 #line 3958 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.num) = '.';
                     }
-#line 9737 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 10128 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 588:
+  case 588: /* call_op: tANDDOT  */
 #line 3962 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.num) = 0;
                     }
-#line 9745 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 10136 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 590:
+  case 590: /* call_op2: tCOLON2  */
 #line 3969 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.num) = tCOLON2;
                     }
-#line 9753 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 10144 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 599:
+  case 599: /* term: ';'  */
 #line 3990 "mrbgems/mruby-compiler/core/parse.y"
                       {yyerrok;}
-#line 9759 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 10150 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 602:
+  case 602: /* nl: '\n'  */
 #line 3996 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       p->lineno += (yyvsp[0].num);
                       p->column = 0;
                     }
-#line 9768 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 10159 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 605:
+  case 605: /* none: %empty  */
 #line 4007 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = 0;
                     }
-#line 9776 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 10167 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
 
-#line 9780 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 10171 "mrbgems/mruby-compiler/core/y.tab.c"
 
       default: break;
     }
@@ -9791,11 +10182,10 @@ yyreduce:
      case of YYERROR or YYBACKUP, subsequent parser actions might lead
      to an incorrect destructor call or verbose syntax error message
      before the lookahead is translated.  */
-  YY_SYMBOL_PRINT ("-> $$ =", yyr1[yyn], &yyval, &yyloc);
+  YY_SYMBOL_PRINT ("-> $$ =", YY_CAST (yysymbol_kind_t, yyr1[yyn]), &yyval, &yyloc);
 
   YYPOPSTACK (yylen);
   yylen = 0;
-  YY_STACK_PRINT (yyss, yyssp);
 
   *++yyvsp = yyval;
 
@@ -9819,49 +10209,43 @@ yyreduce:
 yyerrlab:
   /* Make sure we have latest lookahead translation.  See comments at
      user semantic actions for why this is necessary.  */
-  yytoken = yychar == YYEMPTY ? YYEMPTY : YYTRANSLATE (yychar);
-
+  yytoken = yychar == YYEMPTY ? YYSYMBOL_YYEMPTY : YYTRANSLATE (yychar);
   /* If not already recovering from an error, report this error.  */
   if (!yyerrstatus)
     {
       ++yynerrs;
-#if ! YYERROR_VERBOSE
-      yyerror (p, YY_("syntax error"));
-#else
-# define YYSYNTAX_ERROR yysyntax_error (&yymsg_alloc, &yymsg, \
-                                        yyssp, yytoken)
       {
+        yypcontext_t yyctx
+          = {yyssp, yytoken};
         char const *yymsgp = YY_("syntax error");
         int yysyntax_error_status;
-        yysyntax_error_status = YYSYNTAX_ERROR;
+        yysyntax_error_status = yysyntax_error (&yymsg_alloc, &yymsg, &yyctx);
         if (yysyntax_error_status == 0)
           yymsgp = yymsg;
-        else if (yysyntax_error_status == 1)
+        else if (yysyntax_error_status == -1)
           {
             if (yymsg != yymsgbuf)
               YYSTACK_FREE (yymsg);
-            yymsg = YY_CAST (char *, YYSTACK_ALLOC (YY_CAST (YYSIZE_T, yymsg_alloc)));
-            if (!yymsg)
+            yymsg = YY_CAST (char *,
+                             YYSTACK_ALLOC (YY_CAST (YYSIZE_T, yymsg_alloc)));
+            if (yymsg)
               {
-                yymsg = yymsgbuf;
-                yymsg_alloc = sizeof yymsgbuf;
-                yysyntax_error_status = 2;
+                yysyntax_error_status
+                  = yysyntax_error (&yymsg_alloc, &yymsg, &yyctx);
+                yymsgp = yymsg;
               }
             else
               {
-                yysyntax_error_status = YYSYNTAX_ERROR;
-                yymsgp = yymsg;
+                yymsg = yymsgbuf;
+                yymsg_alloc = sizeof yymsgbuf;
+                yysyntax_error_status = YYENOMEM;
               }
           }
         yyerror (p, yymsgp);
-        if (yysyntax_error_status == 2)
+        if (yysyntax_error_status == YYENOMEM)
           goto yyexhaustedlab;
       }
-# undef YYSYNTAX_ERROR
-#endif
     }
-
-
 
   if (yyerrstatus == 3)
     {
@@ -9911,13 +10295,14 @@ yyerrorlab:
 yyerrlab1:
   yyerrstatus = 3;      /* Each real token shifted decrements this.  */
 
+  /* Pop stack until we find a state that shifts the error token.  */
   for (;;)
     {
       yyn = yypact[yystate];
       if (!yypact_value_is_default (yyn))
         {
-          yyn += YYTERROR;
-          if (0 <= yyn && yyn <= YYLAST && yycheck[yyn] == YYTERROR)
+          yyn += YYSYMBOL_YYerror;
+          if (0 <= yyn && yyn <= YYLAST && yycheck[yyn] == YYSYMBOL_YYerror)
             {
               yyn = yytable[yyn];
               if (0 < yyn)
@@ -9931,7 +10316,7 @@ yyerrlab1:
 
 
       yydestruct ("Error: popping",
-                  yystos[yystate], yyvsp, p);
+                  YY_ACCESSING_SYMBOL (yystate), yyvsp, p);
       YYPOPSTACK (1);
       yystate = *yyssp;
       YY_STACK_PRINT (yyss, yyssp);
@@ -9943,7 +10328,7 @@ yyerrlab1:
 
 
   /* Shift the error token.  */
-  YY_SYMBOL_PRINT ("Shifting", yystos[yyn], yyvsp, yylsp);
+  YY_SYMBOL_PRINT ("Shifting", YY_ACCESSING_SYMBOL (yyn), yyvsp, yylsp);
 
   yystate = yyn;
   goto yynewstate;
@@ -9965,20 +10350,20 @@ yyabortlab:
   goto yyreturn;
 
 
-#if !defined yyoverflow || YYERROR_VERBOSE
+#if 1
 /*-------------------------------------------------.
 | yyexhaustedlab -- memory exhaustion comes here.  |
 `-------------------------------------------------*/
 yyexhaustedlab:
   yyerror (p, YY_("memory exhausted"));
   yyresult = 2;
-  /* Fall through.  */
+  goto yyreturn;
 #endif
 
 
-/*-----------------------------------------------------.
-| yyreturn -- parsing is finished, return the result.  |
-`-----------------------------------------------------*/
+/*-------------------------------------------------------.
+| yyreturn -- parsing is finished, clean up and return.  |
+`-------------------------------------------------------*/
 yyreturn:
   if (yychar != YYEMPTY)
     {
@@ -9995,19 +10380,18 @@ yyreturn:
   while (yyssp != yyss)
     {
       yydestruct ("Cleanup: popping",
-                  yystos[+*yyssp], yyvsp, p);
+                  YY_ACCESSING_SYMBOL (+*yyssp), yyvsp, p);
       YYPOPSTACK (1);
     }
 #ifndef yyoverflow
   if (yyss != yyssa)
     YYSTACK_FREE (yyss);
 #endif
-#if YYERROR_VERBOSE
   if (yymsg != yymsgbuf)
     YYSTACK_FREE (yymsg);
-#endif
   return yyresult;
 }
+
 #line 4011 "mrbgems/mruby-compiler/core/parse.y"
 
 #define pylval  (*((YYSTYPE*)(p->ylval)))
@@ -11087,7 +11471,7 @@ parser_yylex(parser_state *p)
   case '*':
     if ((c = nextc(p)) == '*') {
       if ((c = nextc(p)) == '=') {
-        pylval.id = MRB_OPSYM(pow);
+        pylval.id = intern_op(pow);
         p->lstate = EXPR_BEG;
         return tOP_ASGN;
       }
@@ -11105,7 +11489,7 @@ parser_yylex(parser_state *p)
     }
     else {
       if (c == '=') {
-        pylval.id = MRB_OPSYM(mul);
+        pylval.id = intern_op(mul);
         p->lstate = EXPR_BEG;
         return tOP_ASGN;
       }
@@ -11221,7 +11605,7 @@ parser_yylex(parser_state *p)
     }
     if (c == '<') {
       if ((c = nextc(p)) == '=') {
-        pylval.id = MRB_OPSYM(lshift);
+        pylval.id = intern_op(lshift);
         p->lstate = EXPR_BEG;
         return tOP_ASGN;
       }
@@ -11243,7 +11627,7 @@ parser_yylex(parser_state *p)
     }
     if (c == '>') {
       if ((c = nextc(p)) == '=') {
-        pylval.id = MRB_OPSYM(rshift);
+        pylval.id = intern_op(rshift);
         p->lstate = EXPR_BEG;
         return tOP_ASGN;
       }
@@ -11351,7 +11735,7 @@ parser_yylex(parser_state *p)
     if ((c = nextc(p)) == '&') {
       p->lstate = EXPR_BEG;
       if ((c = nextc(p)) == '=') {
-        pylval.id = MRB_OPSYM(andand);
+        pylval.id = intern_op(andand);
         p->lstate = EXPR_BEG;
         return tOP_ASGN;
       }
@@ -11363,7 +11747,7 @@ parser_yylex(parser_state *p)
       return tANDDOT;
     }
     else if (c == '=') {
-      pylval.id = MRB_OPSYM(and);
+      pylval.id = intern_op(and);
       p->lstate = EXPR_BEG;
       return tOP_ASGN;
     }
@@ -11390,7 +11774,7 @@ parser_yylex(parser_state *p)
     if ((c = nextc(p)) == '|') {
       p->lstate = EXPR_BEG;
       if ((c = nextc(p)) == '=') {
-        pylval.id = MRB_OPSYM(oror);
+        pylval.id = intern_op(oror);
         p->lstate = EXPR_BEG;
         return tOP_ASGN;
       }
@@ -11398,7 +11782,7 @@ parser_yylex(parser_state *p)
       return tOROP;
     }
     if (c == '=') {
-      pylval.id = MRB_OPSYM(or);
+      pylval.id = intern_op(or);
       p->lstate = EXPR_BEG;
       return tOP_ASGN;
     }
@@ -11422,7 +11806,7 @@ parser_yylex(parser_state *p)
       return '+';
     }
     if (c == '=') {
-      pylval.id = MRB_OPSYM(add);
+      pylval.id = intern_op(add);
       p->lstate = EXPR_BEG;
       return tOP_ASGN;
     }
@@ -11450,7 +11834,7 @@ parser_yylex(parser_state *p)
       return '-';
     }
     if (c == '=') {
-      pylval.id = MRB_OPSYM(sub);
+      pylval.id = intern_op(sub);
       p->lstate = EXPR_BEG;
       return tOP_ASGN;
     }
@@ -11773,7 +12157,7 @@ parser_yylex(parser_state *p)
       return tREGEXP_BEG;
     }
     if ((c = nextc(p)) == '=') {
-      pylval.id = MRB_OPSYM(div);
+      pylval.id = intern_op(div);
       p->lstate = EXPR_BEG;
       return tOP_ASGN;
     }
@@ -11792,7 +12176,7 @@ parser_yylex(parser_state *p)
 
   case '^':
     if ((c = nextc(p)) == '=') {
-      pylval.id = MRB_OPSYM(xor);
+      pylval.id = intern_op(xor);
       p->lstate = EXPR_BEG;
       return tOP_ASGN;
     }
@@ -11969,7 +12353,7 @@ parser_yylex(parser_state *p)
       }
     }
     if ((c = nextc(p)) == '=') {
-      pylval.id = MRB_OPSYM(mod);
+      pylval.id = intern_op(mod);
       p->lstate = EXPR_BEG;
       return tOP_ASGN;
     }

--- a/mrbgems/mruby-compiler/mrbgem.rake
+++ b/mrbgems/mruby-compiler/mrbgem.rake
@@ -5,13 +5,13 @@ MRuby::Gem::Specification.new 'mruby-compiler' do |spec|
 
   as_cxx_srcs = %w[codegen y.tab].map{|name| "#{dir}/core/#{name}.c"}
   objs = Dir.glob("#{dir}/core/*.c").map do |src|
-    dst = src.pathmap("#{build_dir}/core/%n")
     if build.cxx_exception_enabled? && as_cxx_srcs.include?(src)
-      build.compile_as_cxx(src, "#{dst}.cxx")
+      build.compile_as_cxx(src)
     else
-      objfile(dst)
+      objfile(src.pathmap("#{build_dir}/core/%n"))
     end
   end
+  objs << objfile("#{build_dir}/core/y.tab")
   build.libmruby_core_objs << objs
 
   lex_def = "#{dir}/core/lex.def"

--- a/mrbgems/mruby-error/mrbgem.rake
+++ b/mrbgems/mruby-error/mrbgem.rake
@@ -4,7 +4,7 @@ MRuby::Gem::Specification.new('mruby-error') do |spec|
   spec.summary = 'extensional error handling'
 
   if build.cxx_exception_enabled?
-    @objs << build.compile_as_cxx("#{spec.dir}/src/exception.c", "#{spec.build_dir}/src/exception.cxx")
-    @objs.delete_if { |v| v == objfile("#{spec.build_dir}/src/exception") }
+    objs << build.compile_as_cxx("#{spec.dir}/src/exception.c")
+    objs.delete_if { |v| v == objfile("#{spec.build_dir}/src/exception") }
   end
 end

--- a/src/class.c
+++ b/src/class.c
@@ -2791,7 +2791,8 @@ static const mrb_code new_iseq[] = {
   OP_RETURN, 0x0             /* OP_RETURN    R0 */
 };
 
-const mrb_sym new_syms[] = { MRB_SYM(allocate), MRB_SYM(initialize) };
+MRB_PRESYM_DEFINE_VAR_AND_INITER(new_syms, 2, MRB_SYM(allocate), MRB_SYM(initialize))
+
 static const mrb_irep new_irep = {
   3, 6, 0, MRB_IREP_STATIC,
   new_iseq, NULL, new_syms, NULL, NULL, NULL,
@@ -2804,6 +2805,7 @@ init_class_new(mrb_state *mrb, struct RClass *cls)
   struct RProc *p;
   mrb_method_t m;
 
+  init_new_syms(mrb);
   p = mrb_proc_new(mrb, &new_irep);
   MRB_METHOD_FROM_PROC(m, p);
   mrb_define_method_raw(mrb, cls, MRB_SYM(new), m);

--- a/src/debug.c
+++ b/src/debug.c
@@ -66,7 +66,7 @@ mrb_debug_get_filename(mrb_state *mrb, const mrb_irep *irep, uint32_t pc)
 MRB_API int32_t
 mrb_debug_get_line(mrb_state *mrb, const mrb_irep *irep, uint32_t pc)
 {
-  if (irep && pc < irep->ilen) {
+  if (irep && pc >= 0 && pc < irep->ilen) {
     mrb_irep_debug_info_file* f = NULL;
     if (!irep->debug_info) {
       return -1;

--- a/src/symbol.c
+++ b/src/symbol.c
@@ -12,15 +12,19 @@
 #include <mruby/dump.h>
 #include <mruby/class.h>
 
-#undef MRB_PRESYM_MAX
-#define MRB_PRESYM_NAMED(lit, num, type, name) {lit, sizeof(lit)-1},
-#define MRB_PRESYM_UNNAMED(lit, num) {lit, sizeof(lit)-1},
+#ifndef MRB_NO_PRESYM
+
+# undef MRB_PRESYM_MAX
+# define MRB_PRESYM_NAMED(lit, num, type, name) {lit, sizeof(lit)-1},
+# define MRB_PRESYM_UNNAMED(lit, num) {lit, sizeof(lit)-1},
 
 static const struct {
   const char *name;
   uint16_t len;
 } presym_table[] = {
-#include <../build/presym.inc>
+#ifndef MRB_PRESYM_SCANNING
+# include <mruby/presym.inc>
+#endif
 };
 
 static mrb_sym
@@ -50,6 +54,8 @@ presym_sym2name(mrb_sym sym, mrb_int *lenp)
   if (lenp) *lenp = presym_table[sym-1].len;
   return presym_table[sym-1].name;
 }
+
+#endif  /* MRB_NO_PRESYM */
 
 /* ------------------------------------------------------ */
 typedef struct symbol_name {
@@ -147,9 +153,11 @@ find_symbol(mrb_state *mrb, const char *name, size_t len, uint8_t *hashp)
   symbol_name *sname;
   uint8_t hash;
 
+#ifndef MRB_NO_PRESYM
   /* presym */
   i = presym_find(name, len);
   if (i > 0) return i<<SYMBOL_SHIFT;
+#endif
 
   /* inline symbol */
   i = sym_inline_pack(name, len);
@@ -306,10 +314,12 @@ sym2name_len(mrb_state *mrb, mrb_sym sym, char *buf, mrb_int *lenp)
   if (SYMBOL_INLINE_P(sym)) return sym_inline_unpack(sym, buf, lenp);
 
   sym >>= SYMBOL_SHIFT;
+#ifndef MRB_NO_PRESYM
   {
     const char *name = presym_sym2name(sym, lenp);
     if (name) return name;
   }
+#endif
   sym -= MRB_PRESYM_MAX;
 
   if (sym == 0 || mrb->symidx < sym) {

--- a/tasks/benchmark.rake
+++ b/tasks/benchmark.rake
@@ -50,7 +50,7 @@ end
 
 
 MRuby.each_target do |target|
-  next if target.name == 'host'
+  next if target.name == 'host' || target.internal?
   mruby_bin = "#{target.build_dir}/bin/mruby"
 
   bm_files.each do |bm_file|

--- a/tasks/bin.rake
+++ b/tasks/bin.rake
@@ -1,0 +1,35 @@
+install_task = ->(src) do
+  dst = "#{MRuby::Build.install_dir}/#{File.basename(src)}"
+  file dst => src do
+    install_D src, dst
+  end
+  dst
+end
+
+MRuby.each_target do |build|
+  if build.host? && build.mrbc_build && !build.gems["mruby-bin-mrbc"]
+    exe = build.exefile("#{build.mrbc_build.build_dir}/bin/mrbc")
+    build.products << install_task.(exe)
+  end
+
+  build.bins.each do |bin|
+    exe = build.exefile("#{build.build_dir}/bin/#{bin}")
+    build.products << (build.host? ? install_task.(exe) : exe)
+  end
+
+  linker_attrs = build.gems.map{|gem| gem.linker.run_attrs}.transpose
+  build.gems.each do |gem|
+    gem.bins.each do |bin|
+      exe = build.exefile("#{build.build_dir}/bin/#{bin}")
+      objs = Dir["#{gem.dir}/tools/#{bin}/*.{c,cpp,cxx,cc}"].map do |f|
+        build.objfile(f.pathmap("#{gem.build_dir}/tools/#{bin}/%n"))
+      end
+
+      file exe => objs.concat(build.libraries) do |t|
+        build.linker.run t.name, t.prerequisites, *linker_attrs
+      end
+
+      build.products << (build.host? ? install_task.(exe) : exe)
+    end
+  end
+end

--- a/tasks/core.rake
+++ b/tasks/core.rake
@@ -2,11 +2,10 @@ as_cxx_srcs = %w[vm error gc].map{|name| "#{MRUBY_ROOT}/src/#{name}.c"}
 
 MRuby.each_target do
   objs = Dir.glob("#{MRUBY_ROOT}/src/*.c").map do |src|
-    dst = src.pathmap("#{build_dir}/src/%n")
     if cxx_exception_enabled? && as_cxx_srcs.include?(src)
-      compile_as_cxx(src, "#{dst}.cxx")
+      compile_as_cxx(src)
     else
-      objfile(dst)
+      objfile(src.pathmap("#{build_dir}/src/%n"))
     end
   end
   self.libmruby_core_objs << objs

--- a/tasks/libmruby.rake
+++ b/tasks/libmruby.rake
@@ -3,6 +3,8 @@ MRuby.each_target do
     archiver.run t.name, t.prerequisites
   end
 
+  products << libmruby_core_static
+
   next unless libmruby_enabled?
 
   file libmruby_static => libmruby_objs.flatten do |t|
@@ -27,4 +29,6 @@ MRuby.each_target do
       f.puts "MRUBY_LIBMRUBY_PATH = #{libmruby_static}"
     end
   end
+
+  products << libmruby_static
 end

--- a/tasks/presym.rake
+++ b/tasks/presym.rake
@@ -1,0 +1,41 @@
+all_prerequisites = ->(task_name, prereqs) do
+  Rake::Task[task_name].prerequisites.each do |prereq_name|
+    next if prereqs[prereq_name]
+    prereqs[prereq_name] = true
+    all_prerequisites.(Rake::Task[prereq_name].name, prereqs)
+  end
+end
+
+MRuby.each_target do |build|
+  gensym_task = task(:gensym)
+  next unless build.presym_enabled?
+
+  presym = build.presym
+
+  include_dir = "#{build.build_dir}/include"
+  build.compilers.each{|c| c.include_paths << include_dir}
+  build.gems.each{|gem| gem.compilers.each{|c| c.include_paths << include_dir}}
+
+  prereqs = {}
+  pps = []
+  mrbtest = "#{build.class.install_dir}/mrbtest"
+  mrbc_build_dir = "#{build.mrbc_build.build_dir}/" if build.mrbc_build
+  build.products.each do |product|
+    all_prerequisites.(product, prereqs) unless product == mrbtest
+  end
+  prereqs.each_key do |prereq|
+    next unless File.extname(prereq) == build.exts.object
+    next if mrbc_build_dir && prereq.start_with?(mrbc_build_dir)
+    pps << prereq.ext(build.exts.preprocessed)
+  end
+
+  file presym.list_path => pps do
+    presyms = presym.scan(pps)
+    current_presyms = presym.read_list if File.exist?(presym.list_path)
+    update = presyms != current_presyms
+    presym.write_list(presyms) if update
+    presym.write_header(presyms) if update || !File.exist?(presym.header_path)
+  end
+
+  gensym_task.enhance([presym.list_path])
+end

--- a/tasks/toolchains/gcc.rake
+++ b/tasks/toolchains/gcc.rake
@@ -3,6 +3,7 @@ MRuby::Toolchain.new(:gcc) do |conf, params|
   compiler_flags = %w(-g -O3 -Wall -Wundef)
   c_mandatory_flags = %w(-std=gnu99)
   cxx_invalid_flags = %w(-Werror-implicit-function-declaration)
+  compile_opt = '%{flags} -MMD -MF "%{outfile}.d" -o "%{outfile}" "%{infile}"'
 
   [conf.cc, conf.objc, conf.asm, conf.cxx].each do |compiler|
     if compiler == conf.cxx
@@ -14,7 +15,8 @@ MRuby::Toolchain.new(:gcc) do |conf, params|
     end
     compiler.option_include_path = %q[-I"%s"]
     compiler.option_define = '-D%s'
-    compiler.compile_options = %q[%{flags} -MMD -o "%{outfile}" -c "%{infile}"]
+    compiler.compile_options = "-c #{compile_opt}"
+    compiler.preprocess_options = "-E -P #{compile_opt}"
     compiler.cxx_compile_flag = '-x c++ -std=gnu++03'
     compiler.cxx_exception_flag = '-fexceptions'
     compiler.cxx_invalid_flags = c_mandatory_flags + cxx_invalid_flags

--- a/tasks/toolchains/openwrt.rake
+++ b/tasks/toolchains/openwrt.rake
@@ -1,23 +1,18 @@
 # usage of environmental variables to set the
 # cross compiling toolchain proper
 MRuby::Toolchain.new(:openwrt) do |conf|
-  [conf.cc, conf.objc, conf.asm].each do |cc|
-    cc.command = ENV['TARGET_CC']
-    cc.flags = ENV['TARGET_CFLAGS']
-    cc.include_paths = ["#{MRUBY_ROOT}/include"]
+  [conf.cc, conf.cxx, conf.objc, conf.asm].each do |cc|
+    if cc == conf.cxx
+      cc.command = ENV['TARGET_CXX']
+      cc.flags = ENV['TARGET_CXXFLAGS']
+    else
+      cc.command = ENV['TARGET_CC']
+      cc.flags = ENV['TARGET_CFLAGS']
+    end
     cc.option_include_path = %q[-I"%s"]
     cc.option_define = '-D%s'
-    cc.compile_options = %q[%{flags} -MMD -o "%{outfile}" -c "%{infile}"]
+    cc.compile_options = %q[%{flags} -MMD -MF "%{outfile}.d" -o "%{outfile}" -c "%{infile}"]
   end
-
-  [conf.cxx].each do |cxx|
-    cxx.command = ENV['TARGET_CXX']
-    cxx.flags = ENV['TARGET_CXXFLAGS']
-    cxx.include_paths = ["#{MRUBY_ROOT}/include"]
-    cxx.option_include_path = %q[-I"%s"]
-    cxx.option_define = '-D%s'
-    cxx.compile_options = %q[%{flags} -MMD -o "%{outfile}" -c "%{infile}"]
-   end
 
   conf.linker do |linker|
     linker.command = ENV['TARGET_CC']

--- a/test/bintest.rb
+++ b/test/bintest.rb
@@ -4,7 +4,8 @@ require 'test/assert.rb'
 GEMNAME = ""
 
 def cmd(s)
-  path = "#{ENV['BUILD_DIR']}/bin/#{s}"
+  path = s == "mrbc" ? ENV['MRBCFILE'] : "#{ENV['BUILD_DIR']}/bin/#{s}"
+  path = path.sub(/\.exe\z/, "")
   if /mswin(?!ce)|mingw|bccwin/ =~ RbConfig::CONFIG['host_os']
     path = "#{path}.exe".tr("/", "\\")
   end


### PR DESCRIPTION
The accuracy is greatly improved by using the C preprocessor to scan C
sources for presym. C preprocessor can perfectly interpret all comments and
preprocessor directives, so it can detect all symbols defined, for example
`mrbgems/mruby-socket/src/const.cstub`.

Also, as described later, this change will greatly improve the accuracy of
presym detection from Ruby sources.

## Result

The number of lines in the `presym` file for all gems is as follows:

  ```console
  Previous:   999 (false positive = 89, undetected = 297)
  New:       1207
  ```

## Build process

The new build process (with presym) is as follows:

1. Build `mrbc` without presym (more on building without presym later).
2. Compile Ruby sources to C struct format with the `mrbc` created in
   step 1, and create` mrblib.c` and `gem_init.c`. Note that the symbols
   in the created files are output as `MRB_SYM` family macros or
   `mrb_intern_lit` instead of IDs (details will be described later).
3. C preprocessor processes C sources including the created files of
   step 2 and outputs them as `.i` files. In these files, for example,
   `MRB_IVSYM(foo)` is converted to `<@! "@" "foo" !@>` and
   `mrb_define_module(mrb, "Foo")` is converted to `<@! "Foo" !@>`.
4. Scan the files created in step 3 and create `presym` and` presym.inc`
   files.

The files created in step 2 should output all static symbols defined in Ruby
sources, including local variables, so we can detect all presyms by just
scanning C sources without scanning Ruby sources directly.

Further, by this process, the files to be scanned becomes the same as the
files to be compiled, so that there is no excess or deficiency.

## Related changes

The following changes have been made in relation to realizing this feature.

### Allow build without presym

It enables build without presym to achieve the "Build process: 1". This
incorporates #5202, see its issue for details.

Note that when presym is enabled, even adding a local variable to a Ruby
source may change contents of presym and require recompilation of almost
all C sources. This is inconvenient, especially during trial and error in
development, but this feature is also useful because it does not cause
this problem if presym is disabled.

### Automatically create build target for `mrbc` without presym

The `mrbc` used in the "Build process: 1" will be built by automatically
creating a build target for it. The build name is `SOURCE_BUILD_NAME/mrbc`.

### Constantize output of C struct format by `mrbc`

To realizing the "Build process: 2", as mentioned above, symbol IDs are not
output directly in C struct format output by `mrbc`. As a result, the output
becomes constant regardless of the state of presym at the time of `mrbc`
build, and it is possible to detect symbols of Ruby sources in the same way
as other C sources.

Note that `mrb_intern_lit` is used for symbols that do not become presym,
but in this state, the corresponding element in the symbol array cannot be
statically initialized, so it is initialized at run time (therefore, in this
case, the `const` qualifier is not added to the symbol array).

### Specify arbitrary `mrbc` file

To realizing the "Build process: 2", enabled to specify `mrbc` created by
another build target or pre-built` mrbc`. Use `MRuby::Build#mrbcfile =` to
specify it explicitly. You can omit the "Build process: 1" by specifying
pre-built `mrbc`, and you can always use an optimized build to compile Ruby
sources faster. I think changes that affect the output of `mrbc` are rare,
so in many cases it helps to improve efficiency.

With presym, the build will be a little slower due to more build steps, but
this feature will improve it a bit.

### Create presym files for each build target

This feature was proposed at #5194 and merged once, but was reverted in
5c205e6e due to problems especially with cross-compilation. It has been
introduced again because this change solves the problem.

The presym files will be created below.

* `build/NAME/presym`
* `build/NAME/include/mruby/presym.inc`

### Other changes

* Because presym detection accuracy is greatly improved as mentioned above,
  `MRuby::Gem::Specification#cdump?` is set to true by default, and
  `disable_cdump` is added instead of `enable_cdump`. Also, support for gem
  specific presym files has been discontinued (https://github.com/mruby/mruby/issues/5151#issuecomment-730967232).
* Previously, `mrbc` was automatically created for the `host` build, but it
  will not be created if the build target for `mrbc` mentioned above is
  automatically created. At this time, `mrbc` file of the `mrbc` build is
  copied to` bin/`.
* Two types of `.d` files will be created, `.o.d` and `.i.d`. oThis is
  because if `.i` depends on `presym.inc`, the dependency will circulate, so
  the `.d` file cannot be shared.
* Changed file created with `enable_cxx_exception` to `X-cxx.cxx` from
  `X.cxx` to use the mruby standard Rake rule.

### Note

Almost all C sources will need to be recompiled if there are any changes to
`persym.inc` (if not recompiled properly, it will often result in run-time
error). If `gcc` toolchain is used, dependencies are resolved by the `.d`
file, so it become automatically recompile target, but if not (e.g. MSVC),
it is necessary to manually make it recompile target.

Also, even if `gcc` toolchain is used, it may not become recompile target if
external gems does not use the mruby standard Rake rule. In particular, if
the standard rule is overwritten, such as
https://github.com/mruby/mruby/pull/5112/files, `.d` file will not be read,
so be careful.