### PR TITLE
Ensure initialization of `RVALUE_zero` in `mrb_obj_alloc`

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -107,8 +107,14 @@ struct free_obj {
   struct RBasic *next;
 };
 
+struct RVALUE_initializer {
+  MRB_OBJECT_HEADER;
+  char padding[sizeof(void*) * 4 - sizeof(uint32_t)];
+};
+
 typedef struct {
   union {
+    struct RVALUE_initializer init;  /* must be first member to ensure initialization */
     struct free_obj free;
     struct RBasic basic;
     struct RObject object;


### PR DESCRIPTION
Union initialization initializes the first member. The first member of
`RVALUE` is `struct free_obj`, but because it is only 4-words, it seems that
initialization after the 5th word is not ensured.

Therefore, I created 6-words `struct RVALUE_initializer` for initialization
and made it the first member.