### PR TITLE
Ignore `mruby-bin-config` in cross-building

### DIFF
--- a/lib/mruby/build.rb
+++ b/lib/mruby/build.rb
@@ -116,9 +116,10 @@ module MRuby
         @toolchains = []
         @gem_dir_to_repo_url = {}
 
-        MRuby.targets[@name] = self.class.current = current = self
+        MRuby.targets[@name] = current = self
       end
 
+      MRuby::Build.current = current
       current.instance_eval(&block)
       current.build_mrbc_exec if current.libmruby_enabled? && @name == "host"
       current.build_mrbtest if current.test_enabled?

--- a/mrbgems/mruby-bin-config/mrbgem.rake
+++ b/mrbgems/mruby-bin-config/mrbgem.rake
@@ -1,4 +1,8 @@
-unless MRuby::Build.current.kind_of?(MRuby::CrossBuild)
+if MRuby::Build.current.kind_of?(MRuby::CrossBuild)
+  gemname = File.basename File.dirname __FILE__
+  buildname = MRuby::Build.current.name
+  $stderr.puts "WARN  #{gemname} - This mrbgem is ignored within #{buildname}"
+else
   MRuby::Gem::Specification.new('mruby-bin-config') do |spec|
     name = 'mruby-config'
     spec.license = 'MIT'


### PR DESCRIPTION
If it adds `mruby-bin-config` inside `MRuby::CrossBuild`, the build will fail.

```ruby
# mingw32_config.rb

MRuby::CrossBuild.new("cross-mingw32") do |conf|
  toolchain "gcc"

  compilers.each { |cc| cc.command = "mingw32-#{cc.command}" }
  linker.command = "mingw32-gcc"
  archiver.command = "mingw32-ar"
  exts.executable = ".exe"

  gem core: "mruby-bin-config"
end
```

```console
% rake30 MRUBY_CONFIG=mingw32_config.rb
...SNIP...
rake aborted!
Don't know how to build task '/var/tmp/mruby/build/cross-mingw32/bin/mruby-config.exe' (See the list of available tasks with `rake --tasks`)
```

I think I was able to build it before, but as far as I can see `mrbgems/mruby-bin-config/mrbgem.rake`, It's trying to ignore it in cross build.
https://github.com/mruby/mruby/blob/08d4365252d421f71800992b34684e320ce41ca6/mrbgems/mruby-bin-config/mrbgem.rake#L1

However, `MRuby::Build.current` and `MRuby::CrossBuild.current` are treated differently and were not previously ignored as intended.
https://github.com/mruby/mruby/blob/08d4365252d421f71800992b34684e320ce41ca6/lib/mruby/build.rb#L119

I fixed it and made it output in the form of a warning so that I could see that it was ignored.

```console
% rake30 MRUBY_CONFIG=mingw32_config.rb
WARN  mruby-bin-config - This mrbgem is ignored within cross-mingw32
...SNIP...
```
