### PR TITLE
refactor: remove trailing whitespace

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -27,12 +27,12 @@ INPUT                  = README.md \
 # Red for Ruby
 HTML_COLORSTYLE_HUE    = 359
 
-# The following expansions 
+# The following expansions
 ENABLE_PREPROCESSING   = YES
 MACRO_EXPANSION        = YES
 EXPAND_ONLY_PREDEF     = NO
-PREDEFINED             = 
-EXPAND_AS_DEFINED      = 
+PREDEFINED             =
+EXPAND_AS_DEFINED      =
 SKIP_FUNCTION_MACROS   = NO
 
 # This tells doxygen to search the places that make sense

--- a/doc/guides/debugger.md
+++ b/doc/guides/debugger.md
@@ -264,7 +264,7 @@ Example:
 
 ```
 (sample.rb:1) info breakpoints
-Num     Type           Enb What  
+Num     Type           Enb What
 1       breakpoint     y   at sample.rb:3                      -> file name,line number
 2       breakpoint     n   in Sample_class:sample_class_method -> [class:]method name
 3       breakpoint     y   in sample_global_method
@@ -274,8 +274,8 @@ Displaying the specified breakpoint number:
 
 ```
 (foo.rb:1) info breakpoints 1 3
-Num     Type           Enb What  
-1       breakpoint     y   at sample.rb:3  
+Num     Type           Enb What
+1       breakpoint     y   at sample.rb:3
 3       breakpoint     y   in sample_global_method
 ```
 


### PR DESCRIPTION
Pretty sure the rules are relaxed for code blocks when it comes to linting Markdown.

So the linter doesn't find the unneeded trailing whitespace in code blocks.

The `Doxyfile` is a text file and we don't have checking on the CI for those yet.