### PR TITLE
Use `git ls-files` instead of `find` in `spell-checker.yml` [ci skip]

### DIFF
--- a/.github/workflows/spell-checker.yml
+++ b/.github/workflows/spell-checker.yml
@@ -14,4 +14,4 @@ jobs:
           wget -O - -q https://git.io/misspell | sh -s -- -b .
       - name: 🌶️ Misspell
         run: |
-          find . -type f | xargs ./misspell -error
+          git ls-files --empty-directory | xargs ./misspell -error


### PR DESCRIPTION
To avoid including `.git` directory.