### PR TITLE
Take advantage of gembox

### DIFF
--- a/mrbgems/default-no-fpu.gembox
+++ b/mrbgems/default-no-fpu.gembox
@@ -1,0 +1,3 @@
+MRuby::GemBox.new do |conf|
+  gembox "stdlib"
+end

--- a/mrbgems/default-no-stdio.gembox
+++ b/mrbgems/default-no-stdio.gembox
@@ -1,0 +1,4 @@
+MRuby::GemBox.new do |conf|
+  gembox "stdlib"
+  gembox "math"
+end

--- a/mrbgems/default.gembox
+++ b/mrbgems/default.gembox
@@ -1,82 +1,9 @@
 MRuby::GemBox.new do |conf|
-  # Meta-programming features
-  conf.gem :core => "mruby-metaprog"
-
-  # Use standard IO/File class
-  conf.gem :core => "mruby-io"
-
-  # Use standard IO/File class
-  conf.gem :core => "mruby-socket"
-
-  # Use standard Array#pack, String#unpack methods
-  conf.gem :core => "mruby-pack"
-
-  # Use standard Kernel#sprintf method
-  conf.gem :core => "mruby-sprintf"
-
-  # Use standard print/puts/p
-  conf.gem :core => "mruby-print"
-
-  # Use standard Math module
-  conf.gem :core => "mruby-math"
-
-  # Use standard Time class
-  conf.gem :core => "mruby-time"
-
-  # Use standard Struct class
-  conf.gem :core => "mruby-struct"
-
-  # Use Comparable module extension
-  conf.gem :core => "mruby-compar-ext"
-
-  # Use Enumerable module extension
-  conf.gem :core => "mruby-enum-ext"
-
-  # Use String class extension
-  conf.gem :core => "mruby-string-ext"
-
-  # Use Numeric class extension
-  conf.gem :core => "mruby-numeric-ext"
-
-  # Use Array class extension
-  conf.gem :core => "mruby-array-ext"
-
-  # Use Hash class extension
-  conf.gem :core => "mruby-hash-ext"
-
-  # Use Range class extension
-  conf.gem :core => "mruby-range-ext"
-
-  # Use Proc class extension
-  conf.gem :core => "mruby-proc-ext"
-
-  # Use Symbol class extension
-  conf.gem :core => "mruby-symbol-ext"
-
-  # Use Random class
-  conf.gem :core => "mruby-random"
-
-  # Use Object class extension
-  conf.gem :core => "mruby-object-ext"
-
-  # Use ObjectSpace class
-  conf.gem :core => "mruby-objectspace"
-
-  # Use Fiber class
-  conf.gem :core => "mruby-fiber"
-
-  # Use Enumerator class (require mruby-fiber)
-  conf.gem :core => "mruby-enumerator"
-
-  # Use Enumerator::Lazy class (require mruby-enumerator)
-  conf.gem :core => "mruby-enum-lazy"
-
-  # Use toplevel object (main) methods extension
-  conf.gem :core => "mruby-toplevel-ext"
-
-  # Use Rational/Complex numbers
-  conf.gem :core => "mruby-rational"
-  conf.gem :core => "mruby-complex"
+  gembox "stdlib"
+  gembox "stdlib-ext"
+  gembox "stdlib-io"
+  gembox "math"
+  gembox "metaprog"
 
   # Generate mrbc command
   conf.gem :core => "mruby-bin-mrbc"
@@ -92,19 +19,4 @@ MRuby::GemBox.new do |conf|
 
   # Generate mruby-config command
   conf.gem :core => "mruby-bin-config"
-
-  # Use Kernel module extension
-  conf.gem :core => "mruby-kernel-ext"
-
-  # Use class/module extension
-  conf.gem :core => "mruby-class-ext"
-
-  # Use Method/UnboundMethod class
-  conf.gem :core => "mruby-method"
-
-  # Use eval()
-  conf.gem :core => "mruby-eval"
-
-  # Use mruby-compiler to build other mrbgems
-  conf.gem :core => "mruby-compiler"
 end

--- a/mrbgems/math.gembox
+++ b/mrbgems/math.gembox
@@ -1,0 +1,10 @@
+# It also works with MRB_NO_STDIO.
+
+MRuby::GemBox.new do |conf|
+  # Use standard Math module
+  conf.gem :core => "mruby-math"
+
+  # Use Rational/Complex numbers
+  conf.gem :core => "mruby-rational"
+  conf.gem :core => "mruby-complex"
+end

--- a/mrbgems/metaprog.gembox
+++ b/mrbgems/metaprog.gembox
@@ -1,0 +1,15 @@
+# It also works with MRB_NO_STDIO and MRB_NO_FLOAT.
+
+MRuby::GemBox.new do |conf|
+  # Meta-programming features
+  conf.gem :core => "mruby-metaprog"
+
+  # Use Method/UnboundMethod class
+  conf.gem :core => "mruby-method"
+
+  # Use eval()
+  conf.gem :core => "mruby-eval"
+
+  # Use mruby-compiler to build other mrbgems
+  conf.gem :core => "mruby-compiler"
+end

--- a/mrbgems/stdlib-ext.gembox
+++ b/mrbgems/stdlib-ext.gembox
@@ -1,0 +1,18 @@
+# It also works with MRB_NO_STDIO and MRB_NO_FLOAT.
+
+MRuby::GemBox.new do |conf|
+  # Use standard Array#pack, String#unpack methods
+  conf.gem :core => "mruby-pack"
+
+  # Use standard Kernel#sprintf method
+  conf.gem :core => "mruby-sprintf"
+
+  # Use standard Time class
+  conf.gem :core => "mruby-time"
+
+  # Use standard Struct class
+  conf.gem :core => "mruby-struct"
+
+  # Use Random class
+  conf.gem :core => "mruby-random"
+end

--- a/mrbgems/stdlib-io.gembox
+++ b/mrbgems/stdlib-io.gembox
@@ -1,0 +1,12 @@
+# It also works with MRB_NO_FLOAT.
+
+MRuby::GemBox.new do |conf|
+  # Use standard IO/File class
+  conf.gem :core => "mruby-io"
+
+  # Use standard IO/File class
+  conf.gem :core => "mruby-socket"
+
+  # Use standard print/puts/p
+  conf.gem :core => "mruby-print"
+end

--- a/mrbgems/stdlib.gembox
+++ b/mrbgems/stdlib.gembox
@@ -1,0 +1,54 @@
+# It also works with MRB_NO_STDIO and MRB_NO_FLOAT.
+
+MRuby::GemBox.new do |conf|
+  # Use Comparable module extension
+  conf.gem :core => "mruby-compar-ext"
+
+  # Use Enumerable module extension
+  conf.gem :core => "mruby-enum-ext"
+
+  # Use String class extension
+  conf.gem :core => "mruby-string-ext"
+
+  # Use Numeric class extension
+  conf.gem :core => "mruby-numeric-ext"
+
+  # Use Array class extension
+  conf.gem :core => "mruby-array-ext"
+
+  # Use Hash class extension
+  conf.gem :core => "mruby-hash-ext"
+
+  # Use Range class extension
+  conf.gem :core => "mruby-range-ext"
+
+  # Use Proc class extension
+  conf.gem :core => "mruby-proc-ext"
+
+  # Use Symbol class extension
+  conf.gem :core => "mruby-symbol-ext"
+
+  # Use Object class extension
+  conf.gem :core => "mruby-object-ext"
+
+  # Use ObjectSpace class
+  conf.gem :core => "mruby-objectspace"
+
+  # Use Fiber class
+  conf.gem :core => "mruby-fiber"
+
+  # Use Enumerator class (require mruby-fiber)
+  conf.gem :core => "mruby-enumerator"
+
+  # Use Enumerator::Lazy class (require mruby-enumerator)
+  conf.gem :core => "mruby-enum-lazy"
+
+  # Use toplevel object (main) methods extension
+  conf.gem :core => "mruby-toplevel-ext"
+
+  # Use Kernel module extension
+  conf.gem :core => "mruby-kernel-ext"
+
+  # Use class/module extension
+  conf.gem :core => "mruby-class-ext"
+end


### PR DESCRIPTION
I think that it is easy to use if it is divided according to the type of library and the general purpose.
It is a subdivision from the previous `default.gembox`.

By type gembox:
- `stdlib`: Add some standard Ruby methods not provided by core.
- `stdlib-ext`: Add some standard Ruby methods that are not provided by `stdlib`.
- `stdlib-io`: Provides `IO`, `File`, `Socket`, `print`, etc. Conflict with `MRB_NO_STDIO`
- `math`: Add a class related to math. Conflict with `MRB_NO_FLOAT`
- `metaprog`: Adds features related to metaprogramming.

Purpose gembox:
- `default.gembox`: Import the same gems as before
- `default-no-stdio.gembox`: Import the` stdlib` and `math`
- `default-no-fpu.gembox`: Import the` stdlib` only

---

I think there is room for debate about the gembox name and classification.
