### PR TITLE
Improves out of memory messages for `eval`

### DIFF
--- a/mrbgems/mruby-eval/src/eval.c
+++ b/mrbgems/mruby-eval/src/eval.c
@@ -39,7 +39,7 @@ create_proc_from_string(mrb_state *mrb, const char *s, mrb_int len, mrb_value bi
 
   /* only occur when memory ran out */
   if (!p) {
-    mrb_raise(mrb, E_RUNTIME_ERROR, "Failed to create parser state.");
+    mrb_raise(mrb, E_RUNTIME_ERROR, "Failed to create parser state (out of memory)");
   }
 
   if (0 < p->nerr) {


### PR DESCRIPTION
The comment says that if `mrb_parse_nstring()` returns `NULL`, it is only out of memory.
I'm worried about compatibility if I set the exception class to `NoMemoryError`, so it's still `RuntimeError`.