### PR TITLE
Add support for squiggly heredocs

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -45,3 +45,4 @@ of this list.
    RIZAL Reckordp
    Rory O'Connell
    John Bampton
+   Seeker

--- a/include/mruby/compile.h
+++ b/include/mruby/compile.h
@@ -99,6 +99,7 @@ enum mrb_string_type {
 /* heredoc structure */
 struct mrb_parser_heredoc_info {
   mrb_bool allow_indent:1;
+  mrb_bool remove_indent:1;
   mrb_bool line_head:1;
   enum mrb_string_type type;
   const char *term;

--- a/mrbgems/mruby-compiler/core/parse.y
+++ b/mrbgems/mruby-compiler/core/parse.y
@@ -1358,10 +1358,10 @@ heredoc_end(parser_state *p)
     node *list = info->doc;
     node *list2 = NULL;
     while (list) {
-      if (list->car->car == NODE_STR) {
+      if (((enum node_type)(intptr_t)list->car->car) == NODE_STR) {
         node *pair = list->car->cdr;
-        const char *str = (char*) pair->car;
-        size_t len = (size_t) pair->cdr;
+        const char *str = (char*)pair->car;
+        size_t len = (size_t)pair->cdr;
         if (counting) {
           list2 = push(list2, pair);
         }
@@ -1392,10 +1392,10 @@ heredoc_end(parser_state *p)
     if (indent > 0) {
       while (list2) {
         node *pair = list2->car;
-        const char *str = (char*) pair->car;
-        size_t len = (size_t) pair->cdr;
-        pair->car = (node*) (str + indent);
-        pair->cdr = (node*) (len - indent);
+        const char *str = (char*)pair->car;
+        size_t len = (size_t)pair->cdr;
+        pair->car = (node*)(str + indent);
+        pair->cdr = (node*)(len - indent);
         list2 = list2->cdr;
       }
     }

--- a/mrbgems/mruby-compiler/core/y.tab.c
+++ b/mrbgems/mruby-compiler/core/y.tab.c
@@ -1,4 +1,4 @@
-/* A Bison parser, made by GNU Bison 3.5.1.  */
+/* A Bison parser, made by GNU Bison 3.7.4.  */
 
 /* Bison implementation for Yacc-like parsers in C
 
@@ -34,6 +34,10 @@
 /* C LALR(1) parser skeleton written by Richard Stallman, by
    simplifying the original so-called "semantic" parser.  */
 
+/* DO NOT RELY ON FEATURES THAT ARE NOT DOCUMENTED in the manual,
+   especially those whose name start with YY_ or yy_.  They are
+   private implementation details that can be changed or removed.  */
+
 /* All symbols defined below should begin with yy or YY, to avoid
    infringing on user name space.  This should be done even for local
    variables, as they might otherwise be expanded by user macros.
@@ -41,14 +45,11 @@
    define necessary library symbols; they are noted "INFRINGES ON
    USER NAME SPACE" below.  */
 
-/* Undocumented macros, especially those whose name start with YY_,
-   are private implementation details.  Do not rely on them.  */
+/* Identify Bison output, and Bison version.  */
+#define YYBISON 30704
 
-/* Identify Bison output.  */
-#define YYBISON 1
-
-/* Bison version.  */
-#define YYBISON_VERSION "3.5.1"
+/* Bison version string.  */
+#define YYBISON_VERSION "3.7.4"
 
 /* Skeleton name.  */
 #define YYSKELETON_NAME "yacc.c"
@@ -1414,6 +1415,55 @@ heredoc_treat_nextline(parser_state *p)
 static void
 heredoc_end(parser_state *p)
 {
+  parser_heredoc_info *info = parsing_heredoc_inf(p);
+  if (info->remove_indent) {
+    mrb_bool counting = TRUE;
+    size_t indent = -1;
+    node *list = info->doc;
+    node *list2 = NULL;
+    while (list) {
+      if (list->car->car == NODE_STR) {
+        node *pair = list->car->cdr;
+        const char *str = (char*) pair->car;
+        size_t len = (size_t) pair->cdr;
+        if (counting) {
+          list2 = push(list2, pair);
+        }
+        size_t spaces = 0;
+        for (size_t i = 0; i < len; i++) {
+          if (counting) {
+            if (ISSPACE(str[i])) {
+              ++spaces;
+            }
+            else {
+              counting = FALSE;
+              if (indent == -1 || spaces < indent) {
+                indent = spaces;
+              }
+            }
+          }
+          if (str[i] == '\n') {
+            counting = TRUE;
+            break;
+          }
+        }
+      }
+      else {
+        counting = FALSE;
+      }
+      list = list->cdr;
+    }
+    if (indent > 0) {
+      while (list2) {
+        node *pair = list2->car;
+        const char *str = (char*) pair->car;
+        size_t len = (size_t) pair->cdr;
+        pair->car = (node*) (str + indent);
+        pair->cdr = (node*) (len - indent);
+        list2 = list2->cdr;
+      }
+    }
+  }
   p->parsing_heredoc = p->parsing_heredoc->cdr;
   if (p->parsing_heredoc == NULL) {
     p->lstate = EXPR_BEG;
@@ -1431,7 +1481,7 @@ heredoc_end(parser_state *p)
 /* xxx ----------------------------- */
 
 
-#line 1435 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 1485 "mrbgems/mruby-compiler/core/y.tab.c"
 
 # ifndef YY_CAST
 #  ifdef __cplusplus
@@ -1454,14 +1504,6 @@ heredoc_end(parser_state *p)
 #  endif
 # endif
 
-/* Enabling verbose error messages.  */
-#ifdef YYERROR_VERBOSE
-# undef YYERROR_VERBOSE
-# define YYERROR_VERBOSE 1
-#else
-# define YYERROR_VERBOSE 1
-#endif
-
 
 /* Debug traces.  */
 #ifndef YYDEBUG
@@ -1471,139 +1513,144 @@ heredoc_end(parser_state *p)
 extern int yydebug;
 #endif
 
-/* Token type.  */
+/* Token kinds.  */
 #ifndef YYTOKENTYPE
 # define YYTOKENTYPE
   enum yytokentype
   {
-    keyword_class = 258,
-    keyword_module = 259,
-    keyword_def = 260,
-    keyword_begin = 261,
-    keyword_if = 262,
-    keyword_unless = 263,
-    keyword_while = 264,
-    keyword_until = 265,
-    keyword_for = 266,
-    keyword_undef = 267,
-    keyword_rescue = 268,
-    keyword_ensure = 269,
-    keyword_end = 270,
-    keyword_then = 271,
-    keyword_elsif = 272,
-    keyword_else = 273,
-    keyword_case = 274,
-    keyword_when = 275,
-    keyword_break = 276,
-    keyword_next = 277,
-    keyword_redo = 278,
-    keyword_retry = 279,
-    keyword_in = 280,
-    keyword_do = 281,
-    keyword_do_cond = 282,
-    keyword_do_block = 283,
-    keyword_do_LAMBDA = 284,
-    keyword_return = 285,
-    keyword_yield = 286,
-    keyword_super = 287,
-    keyword_self = 288,
-    keyword_nil = 289,
-    keyword_true = 290,
-    keyword_false = 291,
-    keyword_and = 292,
-    keyword_or = 293,
-    keyword_not = 294,
-    modifier_if = 295,
-    modifier_unless = 296,
-    modifier_while = 297,
-    modifier_until = 298,
-    modifier_rescue = 299,
-    keyword_alias = 300,
-    keyword_BEGIN = 301,
-    keyword_END = 302,
-    keyword__LINE__ = 303,
-    keyword__FILE__ = 304,
-    keyword__ENCODING__ = 305,
-    tIDENTIFIER = 306,
-    tFID = 307,
-    tGVAR = 308,
-    tIVAR = 309,
-    tCONSTANT = 310,
-    tCVAR = 311,
-    tLABEL_TAG = 312,
-    tINTEGER = 313,
-    tFLOAT = 314,
-    tCHAR = 315,
-    tXSTRING = 316,
-    tREGEXP = 317,
-    tSTRING = 318,
-    tSTRING_PART = 319,
-    tSTRING_MID = 320,
-    tNTH_REF = 321,
-    tBACK_REF = 322,
-    tREGEXP_END = 323,
-    tNUMPARAM = 324,
-    tUPLUS = 325,
-    tUMINUS = 326,
-    tPOW = 327,
-    tCMP = 328,
-    tEQ = 329,
-    tEQQ = 330,
-    tNEQ = 331,
-    tGEQ = 332,
-    tLEQ = 333,
-    tANDOP = 334,
-    tOROP = 335,
-    tMATCH = 336,
-    tNMATCH = 337,
-    tDOT2 = 338,
-    tDOT3 = 339,
-    tBDOT2 = 340,
-    tBDOT3 = 341,
-    tAREF = 342,
-    tASET = 343,
-    tLSHFT = 344,
-    tRSHFT = 345,
-    tCOLON2 = 346,
-    tCOLON3 = 347,
-    tOP_ASGN = 348,
-    tASSOC = 349,
-    tLPAREN = 350,
-    tLPAREN_ARG = 351,
-    tRPAREN = 352,
-    tLBRACK = 353,
-    tLBRACE = 354,
-    tLBRACE_ARG = 355,
-    tSTAR = 356,
-    tDSTAR = 357,
-    tAMPER = 358,
-    tLAMBDA = 359,
-    tANDDOT = 360,
-    tSYMBEG = 361,
-    tREGEXP_BEG = 362,
-    tWORDS_BEG = 363,
-    tSYMBOLS_BEG = 364,
-    tSTRING_BEG = 365,
-    tXSTRING_BEG = 366,
-    tSTRING_DVAR = 367,
-    tLAMBEG = 368,
-    tHEREDOC_BEG = 369,
-    tHEREDOC_END = 370,
-    tLITERAL_DELIM = 371,
-    tHD_LITERAL_DELIM = 372,
-    tHD_STRING_PART = 373,
-    tHD_STRING_MID = 374,
-    tLOWEST = 375,
-    tUMINUS_NUM = 376,
-    tLAST_TOKEN = 377
+    YYEMPTY = -2,
+    YYEOF = 0,                     /* "end of file"  */
+    YYerror = 256,                 /* error  */
+    YYUNDEF = 257,                 /* "invalid token"  */
+    keyword_class = 258,           /* keyword_class  */
+    keyword_module = 259,          /* keyword_module  */
+    keyword_def = 260,             /* keyword_def  */
+    keyword_begin = 261,           /* keyword_begin  */
+    keyword_if = 262,              /* keyword_if  */
+    keyword_unless = 263,          /* keyword_unless  */
+    keyword_while = 264,           /* keyword_while  */
+    keyword_until = 265,           /* keyword_until  */
+    keyword_for = 266,             /* keyword_for  */
+    keyword_undef = 267,           /* keyword_undef  */
+    keyword_rescue = 268,          /* keyword_rescue  */
+    keyword_ensure = 269,          /* keyword_ensure  */
+    keyword_end = 270,             /* keyword_end  */
+    keyword_then = 271,            /* keyword_then  */
+    keyword_elsif = 272,           /* keyword_elsif  */
+    keyword_else = 273,            /* keyword_else  */
+    keyword_case = 274,            /* keyword_case  */
+    keyword_when = 275,            /* keyword_when  */
+    keyword_break = 276,           /* keyword_break  */
+    keyword_next = 277,            /* keyword_next  */
+    keyword_redo = 278,            /* keyword_redo  */
+    keyword_retry = 279,           /* keyword_retry  */
+    keyword_in = 280,              /* keyword_in  */
+    keyword_do = 281,              /* keyword_do  */
+    keyword_do_cond = 282,         /* keyword_do_cond  */
+    keyword_do_block = 283,        /* keyword_do_block  */
+    keyword_do_LAMBDA = 284,       /* keyword_do_LAMBDA  */
+    keyword_return = 285,          /* keyword_return  */
+    keyword_yield = 286,           /* keyword_yield  */
+    keyword_super = 287,           /* keyword_super  */
+    keyword_self = 288,            /* keyword_self  */
+    keyword_nil = 289,             /* keyword_nil  */
+    keyword_true = 290,            /* keyword_true  */
+    keyword_false = 291,           /* keyword_false  */
+    keyword_and = 292,             /* keyword_and  */
+    keyword_or = 293,              /* keyword_or  */
+    keyword_not = 294,             /* keyword_not  */
+    modifier_if = 295,             /* modifier_if  */
+    modifier_unless = 296,         /* modifier_unless  */
+    modifier_while = 297,          /* modifier_while  */
+    modifier_until = 298,          /* modifier_until  */
+    modifier_rescue = 299,         /* modifier_rescue  */
+    keyword_alias = 300,           /* keyword_alias  */
+    keyword_BEGIN = 301,           /* keyword_BEGIN  */
+    keyword_END = 302,             /* keyword_END  */
+    keyword__LINE__ = 303,         /* keyword__LINE__  */
+    keyword__FILE__ = 304,         /* keyword__FILE__  */
+    keyword__ENCODING__ = 305,     /* keyword__ENCODING__  */
+    tIDENTIFIER = 306,             /* tIDENTIFIER  */
+    tFID = 307,                    /* tFID  */
+    tGVAR = 308,                   /* tGVAR  */
+    tIVAR = 309,                   /* tIVAR  */
+    tCONSTANT = 310,               /* tCONSTANT  */
+    tCVAR = 311,                   /* tCVAR  */
+    tLABEL_TAG = 312,              /* tLABEL_TAG  */
+    tINTEGER = 313,                /* tINTEGER  */
+    tFLOAT = 314,                  /* tFLOAT  */
+    tCHAR = 315,                   /* tCHAR  */
+    tXSTRING = 316,                /* tXSTRING  */
+    tREGEXP = 317,                 /* tREGEXP  */
+    tSTRING = 318,                 /* tSTRING  */
+    tSTRING_PART = 319,            /* tSTRING_PART  */
+    tSTRING_MID = 320,             /* tSTRING_MID  */
+    tNTH_REF = 321,                /* tNTH_REF  */
+    tBACK_REF = 322,               /* tBACK_REF  */
+    tREGEXP_END = 323,             /* tREGEXP_END  */
+    tNUMPARAM = 324,               /* tNUMPARAM  */
+    tUPLUS = 325,                  /* tUPLUS  */
+    tUMINUS = 326,                 /* tUMINUS  */
+    tPOW = 327,                    /* tPOW  */
+    tCMP = 328,                    /* tCMP  */
+    tEQ = 329,                     /* tEQ  */
+    tEQQ = 330,                    /* tEQQ  */
+    tNEQ = 331,                    /* tNEQ  */
+    tGEQ = 332,                    /* tGEQ  */
+    tLEQ = 333,                    /* tLEQ  */
+    tANDOP = 334,                  /* tANDOP  */
+    tOROP = 335,                   /* tOROP  */
+    tMATCH = 336,                  /* tMATCH  */
+    tNMATCH = 337,                 /* tNMATCH  */
+    tDOT2 = 338,                   /* tDOT2  */
+    tDOT3 = 339,                   /* tDOT3  */
+    tBDOT2 = 340,                  /* tBDOT2  */
+    tBDOT3 = 341,                  /* tBDOT3  */
+    tAREF = 342,                   /* tAREF  */
+    tASET = 343,                   /* tASET  */
+    tLSHFT = 344,                  /* tLSHFT  */
+    tRSHFT = 345,                  /* tRSHFT  */
+    tCOLON2 = 346,                 /* tCOLON2  */
+    tCOLON3 = 347,                 /* tCOLON3  */
+    tOP_ASGN = 348,                /* tOP_ASGN  */
+    tASSOC = 349,                  /* tASSOC  */
+    tLPAREN = 350,                 /* tLPAREN  */
+    tLPAREN_ARG = 351,             /* tLPAREN_ARG  */
+    tRPAREN = 352,                 /* tRPAREN  */
+    tLBRACK = 353,                 /* tLBRACK  */
+    tLBRACE = 354,                 /* tLBRACE  */
+    tLBRACE_ARG = 355,             /* tLBRACE_ARG  */
+    tSTAR = 356,                   /* tSTAR  */
+    tDSTAR = 357,                  /* tDSTAR  */
+    tAMPER = 358,                  /* tAMPER  */
+    tLAMBDA = 359,                 /* tLAMBDA  */
+    tANDDOT = 360,                 /* tANDDOT  */
+    tSYMBEG = 361,                 /* tSYMBEG  */
+    tREGEXP_BEG = 362,             /* tREGEXP_BEG  */
+    tWORDS_BEG = 363,              /* tWORDS_BEG  */
+    tSYMBOLS_BEG = 364,            /* tSYMBOLS_BEG  */
+    tSTRING_BEG = 365,             /* tSTRING_BEG  */
+    tXSTRING_BEG = 366,            /* tXSTRING_BEG  */
+    tSTRING_DVAR = 367,            /* tSTRING_DVAR  */
+    tLAMBEG = 368,                 /* tLAMBEG  */
+    tHEREDOC_BEG = 369,            /* tHEREDOC_BEG  */
+    tHEREDOC_END = 370,            /* tHEREDOC_END  */
+    tLITERAL_DELIM = 371,          /* tLITERAL_DELIM  */
+    tHD_LITERAL_DELIM = 372,       /* tHD_LITERAL_DELIM  */
+    tHD_STRING_PART = 373,         /* tHD_STRING_PART  */
+    tHD_STRING_MID = 374,          /* tHD_STRING_MID  */
+    tLOWEST = 375,                 /* tLOWEST  */
+    tUMINUS_NUM = 376,             /* tUMINUS_NUM  */
+    tLAST_TOKEN = 377              /* tLAST_TOKEN  */
   };
+  typedef enum yytokentype yytoken_kind_t;
 #endif
 
 /* Value type.  */
 #if ! defined YYSTYPE && ! defined YYSTYPE_IS_DECLARED
 union YYSTYPE
 {
-#line 1377 "mrbgems/mruby-compiler/core/parse.y"
+#line 1426 "mrbgems/mruby-compiler/core/parse.y"
 
     node *nd;
     mrb_sym id;
@@ -1611,7 +1658,7 @@ union YYSTYPE
     stack_type stack;
     const struct vtable *vars;
 
-#line 1615 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 1662 "mrbgems/mruby-compiler/core/y.tab.c"
 
 };
 typedef union YYSTYPE YYSTYPE;
@@ -1623,6 +1670,338 @@ typedef union YYSTYPE YYSTYPE;
 
 int yyparse (parser_state *p);
 
+
+/* Symbol kind.  */
+enum yysymbol_kind_t
+{
+  YYSYMBOL_YYEMPTY = -2,
+  YYSYMBOL_YYEOF = 0,                      /* "end of file"  */
+  YYSYMBOL_YYerror = 1,                    /* error  */
+  YYSYMBOL_YYUNDEF = 2,                    /* "invalid token"  */
+  YYSYMBOL_keyword_class = 3,              /* keyword_class  */
+  YYSYMBOL_keyword_module = 4,             /* keyword_module  */
+  YYSYMBOL_keyword_def = 5,                /* keyword_def  */
+  YYSYMBOL_keyword_begin = 6,              /* keyword_begin  */
+  YYSYMBOL_keyword_if = 7,                 /* keyword_if  */
+  YYSYMBOL_keyword_unless = 8,             /* keyword_unless  */
+  YYSYMBOL_keyword_while = 9,              /* keyword_while  */
+  YYSYMBOL_keyword_until = 10,             /* keyword_until  */
+  YYSYMBOL_keyword_for = 11,               /* keyword_for  */
+  YYSYMBOL_keyword_undef = 12,             /* keyword_undef  */
+  YYSYMBOL_keyword_rescue = 13,            /* keyword_rescue  */
+  YYSYMBOL_keyword_ensure = 14,            /* keyword_ensure  */
+  YYSYMBOL_keyword_end = 15,               /* keyword_end  */
+  YYSYMBOL_keyword_then = 16,              /* keyword_then  */
+  YYSYMBOL_keyword_elsif = 17,             /* keyword_elsif  */
+  YYSYMBOL_keyword_else = 18,              /* keyword_else  */
+  YYSYMBOL_keyword_case = 19,              /* keyword_case  */
+  YYSYMBOL_keyword_when = 20,              /* keyword_when  */
+  YYSYMBOL_keyword_break = 21,             /* keyword_break  */
+  YYSYMBOL_keyword_next = 22,              /* keyword_next  */
+  YYSYMBOL_keyword_redo = 23,              /* keyword_redo  */
+  YYSYMBOL_keyword_retry = 24,             /* keyword_retry  */
+  YYSYMBOL_keyword_in = 25,                /* keyword_in  */
+  YYSYMBOL_keyword_do = 26,                /* keyword_do  */
+  YYSYMBOL_keyword_do_cond = 27,           /* keyword_do_cond  */
+  YYSYMBOL_keyword_do_block = 28,          /* keyword_do_block  */
+  YYSYMBOL_keyword_do_LAMBDA = 29,         /* keyword_do_LAMBDA  */
+  YYSYMBOL_keyword_return = 30,            /* keyword_return  */
+  YYSYMBOL_keyword_yield = 31,             /* keyword_yield  */
+  YYSYMBOL_keyword_super = 32,             /* keyword_super  */
+  YYSYMBOL_keyword_self = 33,              /* keyword_self  */
+  YYSYMBOL_keyword_nil = 34,               /* keyword_nil  */
+  YYSYMBOL_keyword_true = 35,              /* keyword_true  */
+  YYSYMBOL_keyword_false = 36,             /* keyword_false  */
+  YYSYMBOL_keyword_and = 37,               /* keyword_and  */
+  YYSYMBOL_keyword_or = 38,                /* keyword_or  */
+  YYSYMBOL_keyword_not = 39,               /* keyword_not  */
+  YYSYMBOL_modifier_if = 40,               /* modifier_if  */
+  YYSYMBOL_modifier_unless = 41,           /* modifier_unless  */
+  YYSYMBOL_modifier_while = 42,            /* modifier_while  */
+  YYSYMBOL_modifier_until = 43,            /* modifier_until  */
+  YYSYMBOL_modifier_rescue = 44,           /* modifier_rescue  */
+  YYSYMBOL_keyword_alias = 45,             /* keyword_alias  */
+  YYSYMBOL_keyword_BEGIN = 46,             /* keyword_BEGIN  */
+  YYSYMBOL_keyword_END = 47,               /* keyword_END  */
+  YYSYMBOL_keyword__LINE__ = 48,           /* keyword__LINE__  */
+  YYSYMBOL_keyword__FILE__ = 49,           /* keyword__FILE__  */
+  YYSYMBOL_keyword__ENCODING__ = 50,       /* keyword__ENCODING__  */
+  YYSYMBOL_tIDENTIFIER = 51,               /* tIDENTIFIER  */
+  YYSYMBOL_tFID = 52,                      /* tFID  */
+  YYSYMBOL_tGVAR = 53,                     /* tGVAR  */
+  YYSYMBOL_tIVAR = 54,                     /* tIVAR  */
+  YYSYMBOL_tCONSTANT = 55,                 /* tCONSTANT  */
+  YYSYMBOL_tCVAR = 56,                     /* tCVAR  */
+  YYSYMBOL_tLABEL_TAG = 57,                /* tLABEL_TAG  */
+  YYSYMBOL_tINTEGER = 58,                  /* tINTEGER  */
+  YYSYMBOL_tFLOAT = 59,                    /* tFLOAT  */
+  YYSYMBOL_tCHAR = 60,                     /* tCHAR  */
+  YYSYMBOL_tXSTRING = 61,                  /* tXSTRING  */
+  YYSYMBOL_tREGEXP = 62,                   /* tREGEXP  */
+  YYSYMBOL_tSTRING = 63,                   /* tSTRING  */
+  YYSYMBOL_tSTRING_PART = 64,              /* tSTRING_PART  */
+  YYSYMBOL_tSTRING_MID = 65,               /* tSTRING_MID  */
+  YYSYMBOL_tNTH_REF = 66,                  /* tNTH_REF  */
+  YYSYMBOL_tBACK_REF = 67,                 /* tBACK_REF  */
+  YYSYMBOL_tREGEXP_END = 68,               /* tREGEXP_END  */
+  YYSYMBOL_tNUMPARAM = 69,                 /* tNUMPARAM  */
+  YYSYMBOL_tUPLUS = 70,                    /* tUPLUS  */
+  YYSYMBOL_tUMINUS = 71,                   /* tUMINUS  */
+  YYSYMBOL_tPOW = 72,                      /* tPOW  */
+  YYSYMBOL_tCMP = 73,                      /* tCMP  */
+  YYSYMBOL_tEQ = 74,                       /* tEQ  */
+  YYSYMBOL_tEQQ = 75,                      /* tEQQ  */
+  YYSYMBOL_tNEQ = 76,                      /* tNEQ  */
+  YYSYMBOL_tGEQ = 77,                      /* tGEQ  */
+  YYSYMBOL_tLEQ = 78,                      /* tLEQ  */
+  YYSYMBOL_tANDOP = 79,                    /* tANDOP  */
+  YYSYMBOL_tOROP = 80,                     /* tOROP  */
+  YYSYMBOL_tMATCH = 81,                    /* tMATCH  */
+  YYSYMBOL_tNMATCH = 82,                   /* tNMATCH  */
+  YYSYMBOL_tDOT2 = 83,                     /* tDOT2  */
+  YYSYMBOL_tDOT3 = 84,                     /* tDOT3  */
+  YYSYMBOL_tBDOT2 = 85,                    /* tBDOT2  */
+  YYSYMBOL_tBDOT3 = 86,                    /* tBDOT3  */
+  YYSYMBOL_tAREF = 87,                     /* tAREF  */
+  YYSYMBOL_tASET = 88,                     /* tASET  */
+  YYSYMBOL_tLSHFT = 89,                    /* tLSHFT  */
+  YYSYMBOL_tRSHFT = 90,                    /* tRSHFT  */
+  YYSYMBOL_tCOLON2 = 91,                   /* tCOLON2  */
+  YYSYMBOL_tCOLON3 = 92,                   /* tCOLON3  */
+  YYSYMBOL_tOP_ASGN = 93,                  /* tOP_ASGN  */
+  YYSYMBOL_tASSOC = 94,                    /* tASSOC  */
+  YYSYMBOL_tLPAREN = 95,                   /* tLPAREN  */
+  YYSYMBOL_tLPAREN_ARG = 96,               /* tLPAREN_ARG  */
+  YYSYMBOL_tRPAREN = 97,                   /* tRPAREN  */
+  YYSYMBOL_tLBRACK = 98,                   /* tLBRACK  */
+  YYSYMBOL_tLBRACE = 99,                   /* tLBRACE  */
+  YYSYMBOL_tLBRACE_ARG = 100,              /* tLBRACE_ARG  */
+  YYSYMBOL_tSTAR = 101,                    /* tSTAR  */
+  YYSYMBOL_tDSTAR = 102,                   /* tDSTAR  */
+  YYSYMBOL_tAMPER = 103,                   /* tAMPER  */
+  YYSYMBOL_tLAMBDA = 104,                  /* tLAMBDA  */
+  YYSYMBOL_tANDDOT = 105,                  /* tANDDOT  */
+  YYSYMBOL_tSYMBEG = 106,                  /* tSYMBEG  */
+  YYSYMBOL_tREGEXP_BEG = 107,              /* tREGEXP_BEG  */
+  YYSYMBOL_tWORDS_BEG = 108,               /* tWORDS_BEG  */
+  YYSYMBOL_tSYMBOLS_BEG = 109,             /* tSYMBOLS_BEG  */
+  YYSYMBOL_tSTRING_BEG = 110,              /* tSTRING_BEG  */
+  YYSYMBOL_tXSTRING_BEG = 111,             /* tXSTRING_BEG  */
+  YYSYMBOL_tSTRING_DVAR = 112,             /* tSTRING_DVAR  */
+  YYSYMBOL_tLAMBEG = 113,                  /* tLAMBEG  */
+  YYSYMBOL_tHEREDOC_BEG = 114,             /* tHEREDOC_BEG  */
+  YYSYMBOL_tHEREDOC_END = 115,             /* tHEREDOC_END  */
+  YYSYMBOL_tLITERAL_DELIM = 116,           /* tLITERAL_DELIM  */
+  YYSYMBOL_tHD_LITERAL_DELIM = 117,        /* tHD_LITERAL_DELIM  */
+  YYSYMBOL_tHD_STRING_PART = 118,          /* tHD_STRING_PART  */
+  YYSYMBOL_tHD_STRING_MID = 119,           /* tHD_STRING_MID  */
+  YYSYMBOL_tLOWEST = 120,                  /* tLOWEST  */
+  YYSYMBOL_121_ = 121,                     /* '='  */
+  YYSYMBOL_122_ = 122,                     /* '?'  */
+  YYSYMBOL_123_ = 123,                     /* ':'  */
+  YYSYMBOL_124_ = 124,                     /* '>'  */
+  YYSYMBOL_125_ = 125,                     /* '<'  */
+  YYSYMBOL_126_ = 126,                     /* '|'  */
+  YYSYMBOL_127_ = 127,                     /* '^'  */
+  YYSYMBOL_128_ = 128,                     /* '&'  */
+  YYSYMBOL_129_ = 129,                     /* '+'  */
+  YYSYMBOL_130_ = 130,                     /* '-'  */
+  YYSYMBOL_131_ = 131,                     /* '*'  */
+  YYSYMBOL_132_ = 132,                     /* '/'  */
+  YYSYMBOL_133_ = 133,                     /* '%'  */
+  YYSYMBOL_tUMINUS_NUM = 134,              /* tUMINUS_NUM  */
+  YYSYMBOL_135_ = 135,                     /* '!'  */
+  YYSYMBOL_136_ = 136,                     /* '~'  */
+  YYSYMBOL_tLAST_TOKEN = 137,              /* tLAST_TOKEN  */
+  YYSYMBOL_138_ = 138,                     /* '{'  */
+  YYSYMBOL_139_ = 139,                     /* '}'  */
+  YYSYMBOL_140_ = 140,                     /* '['  */
+  YYSYMBOL_141_ = 141,                     /* ']'  */
+  YYSYMBOL_142_ = 142,                     /* ','  */
+  YYSYMBOL_143_ = 143,                     /* '`'  */
+  YYSYMBOL_144_ = 144,                     /* '('  */
+  YYSYMBOL_145_ = 145,                     /* ')'  */
+  YYSYMBOL_146_ = 146,                     /* ';'  */
+  YYSYMBOL_147_ = 147,                     /* '.'  */
+  YYSYMBOL_148_n_ = 148,                   /* '\n'  */
+  YYSYMBOL_YYACCEPT = 149,                 /* $accept  */
+  YYSYMBOL_program = 150,                  /* program  */
+  YYSYMBOL_151_1 = 151,                    /* $@1  */
+  YYSYMBOL_top_compstmt = 152,             /* top_compstmt  */
+  YYSYMBOL_top_stmts = 153,                /* top_stmts  */
+  YYSYMBOL_top_stmt = 154,                 /* top_stmt  */
+  YYSYMBOL_155_2 = 155,                    /* @2  */
+  YYSYMBOL_bodystmt = 156,                 /* bodystmt  */
+  YYSYMBOL_compstmt = 157,                 /* compstmt  */
+  YYSYMBOL_stmts = 158,                    /* stmts  */
+  YYSYMBOL_stmt = 159,                     /* stmt  */
+  YYSYMBOL_160_3 = 160,                    /* $@3  */
+  YYSYMBOL_command_asgn = 161,             /* command_asgn  */
+  YYSYMBOL_command_rhs = 162,              /* command_rhs  */
+  YYSYMBOL_expr = 163,                     /* expr  */
+  YYSYMBOL_defn_head = 164,                /* defn_head  */
+  YYSYMBOL_defs_head = 165,                /* defs_head  */
+  YYSYMBOL_166_4 = 166,                    /* $@4  */
+  YYSYMBOL_expr_value = 167,               /* expr_value  */
+  YYSYMBOL_command_call = 168,             /* command_call  */
+  YYSYMBOL_block_command = 169,            /* block_command  */
+  YYSYMBOL_cmd_brace_block = 170,          /* cmd_brace_block  */
+  YYSYMBOL_171_5 = 171,                    /* $@5  */
+  YYSYMBOL_command = 172,                  /* command  */
+  YYSYMBOL_mlhs = 173,                     /* mlhs  */
+  YYSYMBOL_mlhs_inner = 174,               /* mlhs_inner  */
+  YYSYMBOL_mlhs_basic = 175,               /* mlhs_basic  */
+  YYSYMBOL_mlhs_item = 176,                /* mlhs_item  */
+  YYSYMBOL_mlhs_list = 177,                /* mlhs_list  */
+  YYSYMBOL_mlhs_post = 178,                /* mlhs_post  */
+  YYSYMBOL_mlhs_node = 179,                /* mlhs_node  */
+  YYSYMBOL_lhs = 180,                      /* lhs  */
+  YYSYMBOL_cname = 181,                    /* cname  */
+  YYSYMBOL_cpath = 182,                    /* cpath  */
+  YYSYMBOL_fname = 183,                    /* fname  */
+  YYSYMBOL_fsym = 184,                     /* fsym  */
+  YYSYMBOL_undef_list = 185,               /* undef_list  */
+  YYSYMBOL_186_6 = 186,                    /* $@6  */
+  YYSYMBOL_op = 187,                       /* op  */
+  YYSYMBOL_reswords = 188,                 /* reswords  */
+  YYSYMBOL_arg = 189,                      /* arg  */
+  YYSYMBOL_aref_args = 190,                /* aref_args  */
+  YYSYMBOL_arg_rhs = 191,                  /* arg_rhs  */
+  YYSYMBOL_paren_args = 192,               /* paren_args  */
+  YYSYMBOL_opt_paren_args = 193,           /* opt_paren_args  */
+  YYSYMBOL_opt_call_args = 194,            /* opt_call_args  */
+  YYSYMBOL_call_args = 195,                /* call_args  */
+  YYSYMBOL_command_args = 196,             /* command_args  */
+  YYSYMBOL_197_7 = 197,                    /* @7  */
+  YYSYMBOL_block_arg = 198,                /* block_arg  */
+  YYSYMBOL_opt_block_arg = 199,            /* opt_block_arg  */
+  YYSYMBOL_comma = 200,                    /* comma  */
+  YYSYMBOL_args = 201,                     /* args  */
+  YYSYMBOL_mrhs = 202,                     /* mrhs  */
+  YYSYMBOL_primary = 203,                  /* primary  */
+  YYSYMBOL_204_8 = 204,                    /* @8  */
+  YYSYMBOL_205_9 = 205,                    /* @9  */
+  YYSYMBOL_206_10 = 206,                   /* $@10  */
+  YYSYMBOL_207_11 = 207,                   /* $@11  */
+  YYSYMBOL_208_12 = 208,                   /* @12  */
+  YYSYMBOL_209_13 = 209,                   /* @13  */
+  YYSYMBOL_210_14 = 210,                   /* $@14  */
+  YYSYMBOL_211_15 = 211,                   /* $@15  */
+  YYSYMBOL_212_16 = 212,                   /* $@16  */
+  YYSYMBOL_213_17 = 213,                   /* $@17  */
+  YYSYMBOL_214_18 = 214,                   /* $@18  */
+  YYSYMBOL_215_19 = 215,                   /* $@19  */
+  YYSYMBOL_216_20 = 216,                   /* @20  */
+  YYSYMBOL_217_21 = 217,                   /* @21  */
+  YYSYMBOL_218_22 = 218,                   /* @22  */
+  YYSYMBOL_219_23 = 219,                   /* @23  */
+  YYSYMBOL_primary_value = 220,            /* primary_value  */
+  YYSYMBOL_then = 221,                     /* then  */
+  YYSYMBOL_do = 222,                       /* do  */
+  YYSYMBOL_if_tail = 223,                  /* if_tail  */
+  YYSYMBOL_opt_else = 224,                 /* opt_else  */
+  YYSYMBOL_for_var = 225,                  /* for_var  */
+  YYSYMBOL_f_margs = 226,                  /* f_margs  */
+  YYSYMBOL_227_24 = 227,                   /* $@24  */
+  YYSYMBOL_block_args_tail = 228,          /* block_args_tail  */
+  YYSYMBOL_opt_block_args_tail = 229,      /* opt_block_args_tail  */
+  YYSYMBOL_block_param = 230,              /* block_param  */
+  YYSYMBOL_opt_block_param = 231,          /* opt_block_param  */
+  YYSYMBOL_block_param_def = 232,          /* block_param_def  */
+  YYSYMBOL_233_25 = 233,                   /* $@25  */
+  YYSYMBOL_opt_bv_decl = 234,              /* opt_bv_decl  */
+  YYSYMBOL_bv_decls = 235,                 /* bv_decls  */
+  YYSYMBOL_bvar = 236,                     /* bvar  */
+  YYSYMBOL_f_larglist = 237,               /* f_larglist  */
+  YYSYMBOL_lambda_body = 238,              /* lambda_body  */
+  YYSYMBOL_do_block = 239,                 /* do_block  */
+  YYSYMBOL_240_26 = 240,                   /* $@26  */
+  YYSYMBOL_block_call = 241,               /* block_call  */
+  YYSYMBOL_method_call = 242,              /* method_call  */
+  YYSYMBOL_brace_block = 243,              /* brace_block  */
+  YYSYMBOL_244_27 = 244,                   /* @27  */
+  YYSYMBOL_245_28 = 245,                   /* @28  */
+  YYSYMBOL_case_body = 246,                /* case_body  */
+  YYSYMBOL_cases = 247,                    /* cases  */
+  YYSYMBOL_opt_rescue = 248,               /* opt_rescue  */
+  YYSYMBOL_exc_list = 249,                 /* exc_list  */
+  YYSYMBOL_exc_var = 250,                  /* exc_var  */
+  YYSYMBOL_opt_ensure = 251,               /* opt_ensure  */
+  YYSYMBOL_literal = 252,                  /* literal  */
+  YYSYMBOL_string = 253,                   /* string  */
+  YYSYMBOL_string_fragment = 254,          /* string_fragment  */
+  YYSYMBOL_string_rep = 255,               /* string_rep  */
+  YYSYMBOL_string_interp = 256,            /* string_interp  */
+  YYSYMBOL_257_29 = 257,                   /* @29  */
+  YYSYMBOL_xstring = 258,                  /* xstring  */
+  YYSYMBOL_regexp = 259,                   /* regexp  */
+  YYSYMBOL_heredoc = 260,                  /* heredoc  */
+  YYSYMBOL_heredoc_bodies = 261,           /* heredoc_bodies  */
+  YYSYMBOL_heredoc_body = 262,             /* heredoc_body  */
+  YYSYMBOL_heredoc_string_rep = 263,       /* heredoc_string_rep  */
+  YYSYMBOL_heredoc_string_interp = 264,    /* heredoc_string_interp  */
+  YYSYMBOL_265_30 = 265,                   /* @30  */
+  YYSYMBOL_words = 266,                    /* words  */
+  YYSYMBOL_symbol = 267,                   /* symbol  */
+  YYSYMBOL_basic_symbol = 268,             /* basic_symbol  */
+  YYSYMBOL_sym = 269,                      /* sym  */
+  YYSYMBOL_symbols = 270,                  /* symbols  */
+  YYSYMBOL_numeric = 271,                  /* numeric  */
+  YYSYMBOL_variable = 272,                 /* variable  */
+  YYSYMBOL_var_lhs = 273,                  /* var_lhs  */
+  YYSYMBOL_var_ref = 274,                  /* var_ref  */
+  YYSYMBOL_backref = 275,                  /* backref  */
+  YYSYMBOL_superclass = 276,               /* superclass  */
+  YYSYMBOL_277_31 = 277,                   /* $@31  */
+  YYSYMBOL_f_arglist_paren = 278,          /* f_arglist_paren  */
+  YYSYMBOL_f_arglist = 279,                /* f_arglist  */
+  YYSYMBOL_f_label = 280,                  /* f_label  */
+  YYSYMBOL_f_kw = 281,                     /* f_kw  */
+  YYSYMBOL_f_block_kw = 282,               /* f_block_kw  */
+  YYSYMBOL_f_block_kwarg = 283,            /* f_block_kwarg  */
+  YYSYMBOL_f_kwarg = 284,                  /* f_kwarg  */
+  YYSYMBOL_kwrest_mark = 285,              /* kwrest_mark  */
+  YYSYMBOL_f_kwrest = 286,                 /* f_kwrest  */
+  YYSYMBOL_args_tail = 287,                /* args_tail  */
+  YYSYMBOL_opt_args_tail = 288,            /* opt_args_tail  */
+  YYSYMBOL_f_args = 289,                   /* f_args  */
+  YYSYMBOL_f_bad_arg = 290,                /* f_bad_arg  */
+  YYSYMBOL_f_norm_arg = 291,               /* f_norm_arg  */
+  YYSYMBOL_f_arg_item = 292,               /* f_arg_item  */
+  YYSYMBOL_293_32 = 293,                   /* @32  */
+  YYSYMBOL_f_arg = 294,                    /* f_arg  */
+  YYSYMBOL_f_opt_asgn = 295,               /* f_opt_asgn  */
+  YYSYMBOL_f_opt = 296,                    /* f_opt  */
+  YYSYMBOL_f_block_opt = 297,              /* f_block_opt  */
+  YYSYMBOL_f_block_optarg = 298,           /* f_block_optarg  */
+  YYSYMBOL_f_optarg = 299,                 /* f_optarg  */
+  YYSYMBOL_restarg_mark = 300,             /* restarg_mark  */
+  YYSYMBOL_f_rest_arg = 301,               /* f_rest_arg  */
+  YYSYMBOL_blkarg_mark = 302,              /* blkarg_mark  */
+  YYSYMBOL_f_block_arg = 303,              /* f_block_arg  */
+  YYSYMBOL_opt_f_block_arg = 304,          /* opt_f_block_arg  */
+  YYSYMBOL_singleton = 305,                /* singleton  */
+  YYSYMBOL_306_33 = 306,                   /* $@33  */
+  YYSYMBOL_assoc_list = 307,               /* assoc_list  */
+  YYSYMBOL_assocs = 308,                   /* assocs  */
+  YYSYMBOL_label_tag = 309,                /* label_tag  */
+  YYSYMBOL_assoc = 310,                    /* assoc  */
+  YYSYMBOL_operation = 311,                /* operation  */
+  YYSYMBOL_operation2 = 312,               /* operation2  */
+  YYSYMBOL_operation3 = 313,               /* operation3  */
+  YYSYMBOL_dot_or_colon = 314,             /* dot_or_colon  */
+  YYSYMBOL_call_op = 315,                  /* call_op  */
+  YYSYMBOL_call_op2 = 316,                 /* call_op2  */
+  YYSYMBOL_opt_terms = 317,                /* opt_terms  */
+  YYSYMBOL_opt_nl = 318,                   /* opt_nl  */
+  YYSYMBOL_rparen = 319,                   /* rparen  */
+  YYSYMBOL_trailer = 320,                  /* trailer  */
+  YYSYMBOL_term = 321,                     /* term  */
+  YYSYMBOL_nl = 322,                       /* nl  */
+  YYSYMBOL_terms = 323,                    /* terms  */
+  YYSYMBOL_none = 324                      /* none  */
+};
+typedef enum yysymbol_kind_t yysymbol_kind_t;
 
 
 
@@ -1723,6 +2102,7 @@ typedef int yytype_uint16;
 
 #define YYSIZEOF(X) YY_CAST (YYPTRDIFF_T, sizeof (X))
 
+
 /* Stored state numbers (used for stacks). */
 typedef yytype_int16 yy_state_t;
 
@@ -1740,6 +2120,7 @@ typedef int yy_state_fast_t;
 #  define YY_(Msgid) Msgid
 # endif
 #endif
+
 
 #ifndef YY_ATTRIBUTE_PURE
 # if defined __GNUC__ && 2 < __GNUC__ + (96 <= __GNUC_MINOR__)
@@ -1798,7 +2179,7 @@ typedef int yy_state_fast_t;
 
 #define YY_ASSERT(E) ((void) (0 && (E)))
 
-#if ! defined yyoverflow || YYERROR_VERBOSE
+#if 1
 
 /* The parser invokes alloca or malloc; define the necessary symbols.  */
 
@@ -1863,8 +2244,7 @@ void free (void *); /* INFRINGES ON USER NAME SPACE */
 #   endif
 #  endif
 # endif
-#endif /* ! defined yyoverflow || YYERROR_VERBOSE */
-
+#endif /* 1 */
 
 #if (! defined yyoverflow \
      && (! defined __cplusplus \
@@ -1940,14 +2320,16 @@ union yyalloc
 /* YYNSTATES -- Number of states.  */
 #define YYNSTATES  1061
 
-#define YYUNDEFTOK  2
+/* YYMAXUTOK -- Last valid token kind.  */
 #define YYMAXUTOK   377
 
 
 /* YYTRANSLATE(TOKEN-NUM) -- Symbol number corresponding to TOKEN-NUM
    as returned by yylex, with out-of-bounds checking.  */
-#define YYTRANSLATE(YYX)                                                \
-  (0 <= (YYX) && (YYX) <= YYMAXUTOK ? yytranslate[YYX] : YYUNDEFTOK)
+#define YYTRANSLATE(YYX)                                \
+  (0 <= (YYX) && (YYX) <= YYMAXUTOK                     \
+   ? YY_CAST (yysymbol_kind_t, yytranslate[YYX])        \
+   : YYSYMBOL_YYUNDEF)
 
 /* YYTRANSLATE[TOKEN-NUM] -- Symbol number corresponding to TOKEN-NUM
    as returned by yylex.  */
@@ -1997,90 +2379,98 @@ static const yytype_uint8 yytranslate[] =
   /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_int16 yyrline[] =
 {
-       0,  1536,  1536,  1536,  1547,  1553,  1557,  1562,  1566,  1572,
-    1574,  1573,  1587,  1614,  1620,  1624,  1629,  1633,  1639,  1639,
-    1643,  1647,  1651,  1655,  1659,  1663,  1667,  1672,  1673,  1677,
-    1681,  1685,  1689,  1696,  1699,  1703,  1707,  1711,  1715,  1719,
-    1724,  1728,  1735,  1736,  1740,  1744,  1745,  1749,  1753,  1757,
-    1761,  1765,  1775,  1774,  1789,  1798,  1799,  1802,  1803,  1810,
-    1809,  1824,  1828,  1833,  1837,  1842,  1846,  1851,  1855,  1859,
-    1863,  1867,  1873,  1877,  1883,  1884,  1890,  1894,  1898,  1902,
-    1906,  1910,  1914,  1918,  1922,  1926,  1932,  1933,  1939,  1943,
-    1949,  1953,  1959,  1963,  1967,  1971,  1975,  1979,  1985,  1991,
-    1998,  2002,  2006,  2010,  2014,  2018,  2024,  2030,  2035,  2041,
-    2045,  2048,  2052,  2056,  2063,  2064,  2065,  2066,  2071,  2078,
-    2079,  2082,  2086,  2086,  2092,  2093,  2094,  2095,  2096,  2097,
-    2098,  2099,  2100,  2101,  2102,  2103,  2104,  2105,  2106,  2107,
-    2108,  2109,  2110,  2111,  2112,  2113,  2114,  2115,  2116,  2117,
-    2118,  2119,  2120,  2121,  2124,  2124,  2124,  2125,  2125,  2126,
-    2126,  2126,  2127,  2127,  2127,  2127,  2128,  2128,  2128,  2129,
-    2129,  2129,  2130,  2130,  2130,  2130,  2131,  2131,  2131,  2131,
-    2132,  2132,  2132,  2132,  2133,  2133,  2133,  2133,  2134,  2134,
-    2134,  2134,  2135,  2135,  2138,  2142,  2146,  2150,  2154,  2158,
-    2162,  2167,  2172,  2177,  2181,  2185,  2189,  2193,  2197,  2201,
-    2205,  2209,  2213,  2217,  2221,  2225,  2229,  2233,  2237,  2241,
-    2245,  2249,  2253,  2257,  2261,  2265,  2269,  2273,  2277,  2281,
-    2285,  2289,  2293,  2297,  2301,  2305,  2309,  2313,  2317,  2321,
-    2325,  2333,  2342,  2351,  2361,  2367,  2368,  2373,  2377,  2384,
-    2388,  2396,  2400,  2416,  2442,  2443,  2446,  2447,  2448,  2453,
-    2458,  2465,  2471,  2476,  2481,  2486,  2493,  2493,  2504,  2510,
-    2514,  2520,  2521,  2524,  2530,  2536,  2541,  2548,  2553,  2558,
-    2565,  2566,  2567,  2568,  2569,  2570,  2571,  2572,  2576,  2581,
-    2580,  2592,  2596,  2591,  2601,  2601,  2605,  2609,  2613,  2617,
-    2622,  2627,  2631,  2635,  2639,  2643,  2647,  2648,  2654,  2660,
-    2653,  2672,  2680,  2688,  2688,  2688,  2695,  2695,  2695,  2702,
-    2708,  2713,  2715,  2712,  2724,  2722,  2740,  2745,  2738,  2762,
-    2760,  2776,  2786,  2797,  2801,  2805,  2809,  2815,  2822,  2823,
-    2824,  2827,  2828,  2831,  2832,  2840,  2841,  2847,  2851,  2854,
-    2858,  2862,  2866,  2871,  2875,  2879,  2883,  2889,  2888,  2898,
-    2902,  2906,  2910,  2916,  2921,  2926,  2930,  2934,  2938,  2942,
-    2946,  2950,  2954,  2958,  2962,  2966,  2970,  2974,  2978,  2982,
-    2988,  2993,  3000,  3000,  3004,  3009,  3016,  3020,  3026,  3027,
-    3030,  3035,  3038,  3042,  3048,  3052,  3059,  3058,  3073,  3083,
-    3087,  3092,  3099,  3103,  3107,  3111,  3115,  3119,  3123,  3127,
-    3131,  3138,  3137,  3152,  3151,  3167,  3175,  3184,  3187,  3194,
-    3197,  3201,  3202,  3205,  3209,  3212,  3216,  3219,  3220,  3221,
-    3222,  3225,  3226,  3232,  3233,  3234,  3238,  3244,  3245,  3251,
-    3256,  3255,  3266,  3270,  3276,  3280,  3286,  3290,  3296,  3299,
-    3300,  3303,  3309,  3315,  3316,  3319,  3326,  3325,  3339,  3343,
-    3350,  3355,  3362,  3368,  3369,  3370,  3371,  3372,  3376,  3382,
-    3386,  3392,  3393,  3394,  3398,  3404,  3408,  3412,  3416,  3420,
-    3426,  3430,  3436,  3440,  3444,  3448,  3452,  3456,  3464,  3471,
-    3482,  3483,  3487,  3491,  3490,  3506,  3512,  3530,  3550,  3551,
-    3557,  3563,  3569,  3576,  3581,  3588,  3592,  3598,  3602,  3608,
-    3609,  3612,  3616,  3622,  3626,  3630,  3634,  3640,  3645,  3650,
-    3654,  3658,  3662,  3666,  3670,  3674,  3678,  3682,  3686,  3690,
-    3694,  3698,  3702,  3707,  3713,  3718,  3723,  3728,  3733,  3740,
-    3744,  3751,  3756,  3755,  3767,  3771,  3777,  3785,  3793,  3801,
-    3805,  3811,  3815,  3821,  3822,  3825,  3830,  3837,  3838,  3841,
-    3847,  3851,  3857,  3862,  3862,  3887,  3888,  3894,  3899,  3905,
-    3906,  3909,  3915,  3920,  3930,  3937,  3938,  3939,  3942,  3943,
-    3944,  3945,  3948,  3949,  3950,  3953,  3954,  3957,  3961,  3967,
-    3968,  3974,  3975,  3978,  3979,  3982,  3985,  3986,  3987,  3990,
-    3991,  3992,  3995,  4002,  4003,  4007
+       0,  1585,  1585,  1585,  1596,  1602,  1606,  1611,  1615,  1621,
+    1623,  1622,  1636,  1663,  1669,  1673,  1678,  1682,  1688,  1688,
+    1692,  1696,  1700,  1704,  1708,  1712,  1716,  1721,  1722,  1726,
+    1730,  1734,  1738,  1745,  1748,  1752,  1756,  1760,  1764,  1768,
+    1773,  1777,  1784,  1785,  1789,  1793,  1794,  1798,  1802,  1806,
+    1810,  1814,  1824,  1823,  1838,  1847,  1848,  1851,  1852,  1859,
+    1858,  1873,  1877,  1882,  1886,  1891,  1895,  1900,  1904,  1908,
+    1912,  1916,  1922,  1926,  1932,  1933,  1939,  1943,  1947,  1951,
+    1955,  1959,  1963,  1967,  1971,  1975,  1981,  1982,  1988,  1992,
+    1998,  2002,  2008,  2012,  2016,  2020,  2024,  2028,  2034,  2040,
+    2047,  2051,  2055,  2059,  2063,  2067,  2073,  2079,  2084,  2090,
+    2094,  2097,  2101,  2105,  2112,  2113,  2114,  2115,  2120,  2127,
+    2128,  2131,  2135,  2135,  2141,  2142,  2143,  2144,  2145,  2146,
+    2147,  2148,  2149,  2150,  2151,  2152,  2153,  2154,  2155,  2156,
+    2157,  2158,  2159,  2160,  2161,  2162,  2163,  2164,  2165,  2166,
+    2167,  2168,  2169,  2170,  2173,  2173,  2173,  2174,  2174,  2175,
+    2175,  2175,  2176,  2176,  2176,  2176,  2177,  2177,  2177,  2178,
+    2178,  2178,  2179,  2179,  2179,  2179,  2180,  2180,  2180,  2180,
+    2181,  2181,  2181,  2181,  2182,  2182,  2182,  2182,  2183,  2183,
+    2183,  2183,  2184,  2184,  2187,  2191,  2195,  2199,  2203,  2207,
+    2211,  2216,  2221,  2226,  2230,  2234,  2238,  2242,  2246,  2250,
+    2254,  2258,  2262,  2266,  2270,  2274,  2278,  2282,  2286,  2290,
+    2294,  2298,  2302,  2306,  2310,  2314,  2318,  2322,  2326,  2330,
+    2334,  2338,  2342,  2346,  2350,  2354,  2358,  2362,  2366,  2370,
+    2374,  2382,  2391,  2400,  2410,  2416,  2417,  2422,  2426,  2433,
+    2437,  2445,  2449,  2465,  2491,  2492,  2495,  2496,  2497,  2502,
+    2507,  2514,  2520,  2525,  2530,  2535,  2542,  2542,  2553,  2559,
+    2563,  2569,  2570,  2573,  2579,  2585,  2590,  2597,  2602,  2607,
+    2614,  2615,  2616,  2617,  2618,  2619,  2620,  2621,  2625,  2630,
+    2629,  2641,  2645,  2640,  2650,  2650,  2654,  2658,  2662,  2666,
+    2671,  2676,  2680,  2684,  2688,  2692,  2696,  2697,  2703,  2709,
+    2702,  2721,  2729,  2737,  2737,  2737,  2744,  2744,  2744,  2751,
+    2757,  2762,  2764,  2761,  2773,  2771,  2789,  2794,  2787,  2811,
+    2809,  2825,  2835,  2846,  2850,  2854,  2858,  2864,  2871,  2872,
+    2873,  2876,  2877,  2880,  2881,  2889,  2890,  2896,  2900,  2903,
+    2907,  2911,  2915,  2920,  2924,  2928,  2932,  2938,  2937,  2947,
+    2951,  2955,  2959,  2965,  2970,  2975,  2979,  2983,  2987,  2991,
+    2995,  2999,  3003,  3007,  3011,  3015,  3019,  3023,  3027,  3031,
+    3037,  3042,  3049,  3049,  3053,  3058,  3065,  3069,  3075,  3076,
+    3079,  3084,  3087,  3091,  3097,  3101,  3108,  3107,  3122,  3132,
+    3136,  3141,  3148,  3152,  3156,  3160,  3164,  3168,  3172,  3176,
+    3180,  3187,  3186,  3201,  3200,  3216,  3224,  3233,  3236,  3243,
+    3246,  3250,  3251,  3254,  3258,  3261,  3265,  3268,  3269,  3270,
+    3271,  3274,  3275,  3281,  3282,  3283,  3287,  3293,  3294,  3300,
+    3305,  3304,  3315,  3319,  3325,  3329,  3335,  3339,  3345,  3348,
+    3349,  3352,  3358,  3364,  3365,  3368,  3375,  3374,  3388,  3392,
+    3399,  3404,  3411,  3417,  3418,  3419,  3420,  3421,  3425,  3431,
+    3435,  3441,  3442,  3443,  3447,  3453,  3457,  3461,  3465,  3469,
+    3475,  3479,  3485,  3489,  3493,  3497,  3501,  3505,  3513,  3520,
+    3531,  3532,  3536,  3540,  3539,  3555,  3561,  3579,  3599,  3600,
+    3606,  3612,  3618,  3625,  3630,  3637,  3641,  3647,  3651,  3657,
+    3658,  3661,  3665,  3671,  3675,  3679,  3683,  3689,  3694,  3699,
+    3703,  3707,  3711,  3715,  3719,  3723,  3727,  3731,  3735,  3739,
+    3743,  3747,  3751,  3756,  3762,  3767,  3772,  3777,  3782,  3789,
+    3793,  3800,  3805,  3804,  3816,  3820,  3826,  3834,  3842,  3850,
+    3854,  3860,  3864,  3870,  3871,  3874,  3879,  3886,  3887,  3890,
+    3896,  3900,  3906,  3911,  3911,  3936,  3937,  3943,  3948,  3954,
+    3955,  3958,  3964,  3969,  3979,  3986,  3987,  3988,  3991,  3992,
+    3993,  3994,  3997,  3998,  3999,  4002,  4003,  4006,  4010,  4016,
+    4017,  4023,  4024,  4027,  4028,  4031,  4034,  4035,  4036,  4039,
+    4040,  4041,  4044,  4051,  4052,  4056
 };
 #endif
 
-#if YYDEBUG || YYERROR_VERBOSE || 1
+/** Accessing symbol of state STATE.  */
+#define YY_ACCESSING_SYMBOL(State) YY_CAST (yysymbol_kind_t, yystos[State])
+
+#if 1
+/* The user-facing name of the symbol whose (internal) number is
+   YYSYMBOL.  No bounds checking.  */
+static const char *yysymbol_name (yysymbol_kind_t yysymbol) YY_ATTRIBUTE_UNUSED;
+
 /* YYTNAME[SYMBOL-NUM] -- String name of the symbol SYMBOL-NUM.
    First, the terminals, then, starting at YYNTOKENS, nonterminals.  */
 static const char *const yytname[] =
 {
-  "$end", "error", "$undefined", "keyword_class", "keyword_module",
-  "keyword_def", "keyword_begin", "keyword_if", "keyword_unless",
-  "keyword_while", "keyword_until", "keyword_for", "keyword_undef",
-  "keyword_rescue", "keyword_ensure", "keyword_end", "keyword_then",
-  "keyword_elsif", "keyword_else", "keyword_case", "keyword_when",
-  "keyword_break", "keyword_next", "keyword_redo", "keyword_retry",
-  "keyword_in", "keyword_do", "keyword_do_cond", "keyword_do_block",
-  "keyword_do_LAMBDA", "keyword_return", "keyword_yield", "keyword_super",
-  "keyword_self", "keyword_nil", "keyword_true", "keyword_false",
-  "keyword_and", "keyword_or", "keyword_not", "modifier_if",
-  "modifier_unless", "modifier_while", "modifier_until", "modifier_rescue",
-  "keyword_alias", "keyword_BEGIN", "keyword_END", "keyword__LINE__",
-  "keyword__FILE__", "keyword__ENCODING__", "tIDENTIFIER", "tFID", "tGVAR",
-  "tIVAR", "tCONSTANT", "tCVAR", "tLABEL_TAG", "tINTEGER", "tFLOAT",
-  "tCHAR", "tXSTRING", "tREGEXP", "tSTRING", "tSTRING_PART", "tSTRING_MID",
+  "\"end of file\"", "error", "\"invalid token\"", "keyword_class",
+  "keyword_module", "keyword_def", "keyword_begin", "keyword_if",
+  "keyword_unless", "keyword_while", "keyword_until", "keyword_for",
+  "keyword_undef", "keyword_rescue", "keyword_ensure", "keyword_end",
+  "keyword_then", "keyword_elsif", "keyword_else", "keyword_case",
+  "keyword_when", "keyword_break", "keyword_next", "keyword_redo",
+  "keyword_retry", "keyword_in", "keyword_do", "keyword_do_cond",
+  "keyword_do_block", "keyword_do_LAMBDA", "keyword_return",
+  "keyword_yield", "keyword_super", "keyword_self", "keyword_nil",
+  "keyword_true", "keyword_false", "keyword_and", "keyword_or",
+  "keyword_not", "modifier_if", "modifier_unless", "modifier_while",
+  "modifier_until", "modifier_rescue", "keyword_alias", "keyword_BEGIN",
+  "keyword_END", "keyword__LINE__", "keyword__FILE__",
+  "keyword__ENCODING__", "tIDENTIFIER", "tFID", "tGVAR", "tIVAR",
+  "tCONSTANT", "tCVAR", "tLABEL_TAG", "tINTEGER", "tFLOAT", "tCHAR",
+  "tXSTRING", "tREGEXP", "tSTRING", "tSTRING_PART", "tSTRING_MID",
   "tNTH_REF", "tBACK_REF", "tREGEXP_END", "tNUMPARAM", "tUPLUS", "tUMINUS",
   "tPOW", "tCMP", "tEQ", "tEQQ", "tNEQ", "tGEQ", "tLEQ", "tANDOP", "tOROP",
   "tMATCH", "tNMATCH", "tDOT2", "tDOT3", "tBDOT2", "tBDOT3", "tAREF",
@@ -2126,9 +2516,15 @@ static const char *const yytname[] =
   "call_op2", "opt_terms", "opt_nl", "rparen", "trailer", "term", "nl",
   "terms", "none", YY_NULLPTR
 };
+
+static const char *
+yysymbol_name (yysymbol_kind_t yysymbol)
+{
+  return yytname[yysymbol];
+}
 #endif
 
-# ifdef YYPRINT
+#ifdef YYPRINT
 /* YYTOKNUM[NUM] -- (External) token number corresponding to the
    (internal) symbol number NUM (which must be that of a token).  */
 static const yytype_int16 yytoknum[] =
@@ -2149,7 +2545,7 @@ static const yytype_int16 yytoknum[] =
       45,    42,    47,    37,   376,    33,   126,   377,   123,   125,
       91,    93,    44,    96,    40,    41,    59,    46,    10
 };
-# endif
+#endif
 
 #define YYPACT_NINF (-838)
 
@@ -5171,10 +5567,10 @@ static const yytype_int8 yyr2[] =
 };
 
 
+enum { YYENOMEM = -2 };
+
 #define yyerrok         (yyerrstatus = 0)
 #define yyclearin       (yychar = YYEMPTY)
-#define YYEMPTY         (-2)
-#define YYEOF           0
 
 #define YYACCEPT        goto yyacceptlab
 #define YYABORT         goto yyabortlab
@@ -5200,10 +5596,9 @@ static const yytype_int8 yyr2[] =
       }                                                           \
   while (0)
 
-/* Error token number */
-#define YYTERROR        1
-#define YYERRCODE       256
-
+/* Backward compatibility with an undocumented macro.
+   Use YYerror or YYUNDEF. */
+#define YYERRCODE YYUNDEF
 
 
 /* Enable debugging if requested.  */
@@ -5221,18 +5616,18 @@ do {                                            \
 } while (0)
 
 /* This macro is provided for backward compatibility. */
-#ifndef YY_LOCATION_PRINT
-# define YY_LOCATION_PRINT(File, Loc) ((void) 0)
-#endif
+# ifndef YY_LOCATION_PRINT
+#  define YY_LOCATION_PRINT(File, Loc) ((void) 0)
+# endif
 
 
-# define YY_SYMBOL_PRINT(Title, Type, Value, Location)                    \
+# define YY_SYMBOL_PRINT(Title, Kind, Value, Location)                    \
 do {                                                                      \
   if (yydebug)                                                            \
     {                                                                     \
       YYFPRINTF (stderr, "%s ", Title);                                   \
       yy_symbol_print (stderr,                                            \
-                  Type, Value, p); \
+                  Kind, Value, p); \
       YYFPRINTF (stderr, "\n");                                           \
     }                                                                     \
 } while (0)
@@ -5243,7 +5638,8 @@ do {                                                                      \
 `-----------------------------------*/
 
 static void
-yy_symbol_value_print (FILE *yyo, int yytype, YYSTYPE const * const yyvaluep, parser_state *p)
+yy_symbol_value_print (FILE *yyo,
+                       yysymbol_kind_t yykind, YYSTYPE const * const yyvaluep, parser_state *p)
 {
   FILE *yyoutput = yyo;
   YYUSE (yyoutput);
@@ -5251,11 +5647,11 @@ yy_symbol_value_print (FILE *yyo, int yytype, YYSTYPE const * const yyvaluep, pa
   if (!yyvaluep)
     return;
 # ifdef YYPRINT
-  if (yytype < YYNTOKENS)
-    YYPRINT (yyo, yytoknum[yytype], *yyvaluep);
+  if (yykind < YYNTOKENS)
+    YYPRINT (yyo, yytoknum[yykind], *yyvaluep);
 # endif
   YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
-  YYUSE (yytype);
+  YYUSE (yykind);
   YY_IGNORE_MAYBE_UNINITIALIZED_END
 }
 
@@ -5265,12 +5661,13 @@ yy_symbol_value_print (FILE *yyo, int yytype, YYSTYPE const * const yyvaluep, pa
 `---------------------------*/
 
 static void
-yy_symbol_print (FILE *yyo, int yytype, YYSTYPE const * const yyvaluep, parser_state *p)
+yy_symbol_print (FILE *yyo,
+                 yysymbol_kind_t yykind, YYSTYPE const * const yyvaluep, parser_state *p)
 {
   YYFPRINTF (yyo, "%s %s (",
-             yytype < YYNTOKENS ? "token" : "nterm", yytname[yytype]);
+             yykind < YYNTOKENS ? "token" : "nterm", yysymbol_name (yykind));
 
-  yy_symbol_value_print (yyo, yytype, yyvaluep, p);
+  yy_symbol_value_print (yyo, yykind, yyvaluep, p);
   YYFPRINTF (yyo, ")");
 }
 
@@ -5303,7 +5700,8 @@ do {                                                            \
 `------------------------------------------------*/
 
 static void
-yy_reduce_print (yy_state_t *yyssp, YYSTYPE *yyvsp, int yyrule, parser_state *p)
+yy_reduce_print (yy_state_t *yyssp, YYSTYPE *yyvsp,
+                 int yyrule, parser_state *p)
 {
   int yylno = yyrline[yyrule];
   int yynrhs = yyr2[yyrule];
@@ -5315,9 +5713,8 @@ yy_reduce_print (yy_state_t *yyssp, YYSTYPE *yyvsp, int yyrule, parser_state *p)
     {
       YYFPRINTF (stderr, "   $%d = ", yyi + 1);
       yy_symbol_print (stderr,
-                       yystos[+yyssp[yyi + 1 - yynrhs]],
-                       &yyvsp[(yyi + 1) - (yynrhs)]
-                                              , p);
+                       YY_ACCESSING_SYMBOL (+yyssp[yyi + 1 - yynrhs]),
+                       &yyvsp[(yyi + 1) - (yynrhs)], p);
       YYFPRINTF (stderr, "\n");
     }
 }
@@ -5332,8 +5729,8 @@ do {                                    \
    multiple parsers can coexist.  */
 int yydebug;
 #else /* !YYDEBUG */
-# define YYDPRINTF(Args)
-# define YY_SYMBOL_PRINT(Title, Type, Value, Location)
+# define YYDPRINTF(Args) ((void) 0)
+# define YY_SYMBOL_PRINT(Title, Kind, Value, Location)
 # define YY_STACK_PRINT(Bottom, Top)
 # define YY_REDUCE_PRINT(Rule)
 #endif /* !YYDEBUG */
@@ -5356,12 +5753,60 @@ int yydebug;
 #endif
 
 
-#if YYERROR_VERBOSE
+/* Context of a parse error.  */
+typedef struct
+{
+  yy_state_t *yyssp;
+  yysymbol_kind_t yytoken;
+} yypcontext_t;
 
-# ifndef yystrlen
-#  if defined __GLIBC__ && defined _STRING_H
-#   define yystrlen(S) (YY_CAST (YYPTRDIFF_T, strlen (S)))
-#  else
+/* Put in YYARG at most YYARGN of the expected tokens given the
+   current YYCTX, and return the number of tokens stored in YYARG.  If
+   YYARG is null, return the number of expected tokens (guaranteed to
+   be less than YYNTOKENS).  Return YYENOMEM on memory exhaustion.
+   Return 0 if there are more than YYARGN expected tokens, yet fill
+   YYARG up to YYARGN. */
+static int
+yypcontext_expected_tokens (const yypcontext_t *yyctx,
+                            yysymbol_kind_t yyarg[], int yyargn)
+{
+  /* Actual size of YYARG. */
+  int yycount = 0;
+  int yyn = yypact[+*yyctx->yyssp];
+  if (!yypact_value_is_default (yyn))
+    {
+      /* Start YYX at -YYN if negative to avoid negative indexes in
+         YYCHECK.  In other words, skip the first -YYN actions for
+         this state because they are default actions.  */
+      int yyxbegin = yyn < 0 ? -yyn : 0;
+      /* Stay within bounds of both yycheck and yytname.  */
+      int yychecklim = YYLAST - yyn + 1;
+      int yyxend = yychecklim < YYNTOKENS ? yychecklim : YYNTOKENS;
+      int yyx;
+      for (yyx = yyxbegin; yyx < yyxend; ++yyx)
+        if (yycheck[yyx + yyn] == yyx && yyx != YYSYMBOL_YYerror
+            && !yytable_value_is_error (yytable[yyx + yyn]))
+          {
+            if (!yyarg)
+              ++yycount;
+            else if (yycount == yyargn)
+              return 0;
+            else
+              yyarg[yycount++] = YY_CAST (yysymbol_kind_t, yyx);
+          }
+    }
+  if (yyarg && yycount == 0 && 0 < yyargn)
+    yyarg[0] = YYSYMBOL_YYEMPTY;
+  return yycount;
+}
+
+
+
+
+#ifndef yystrlen
+# if defined __GLIBC__ && defined _STRING_H
+#  define yystrlen(S) (YY_CAST (YYPTRDIFF_T, strlen (S)))
+# else
 /* Return the length of YYSTR.  */
 static YYPTRDIFF_T
 yystrlen (const char *yystr)
@@ -5371,13 +5816,13 @@ yystrlen (const char *yystr)
     continue;
   return yylen;
 }
-#  endif
 # endif
+#endif
 
-# ifndef yystpcpy
-#  if defined __GLIBC__ && defined _STRING_H && defined _GNU_SOURCE
-#   define yystpcpy stpcpy
-#  else
+#ifndef yystpcpy
+# if defined __GLIBC__ && defined _STRING_H && defined _GNU_SOURCE
+#  define yystpcpy stpcpy
+# else
 /* Copy YYSRC to YYDEST, returning the address of the terminating '\0' in
    YYDEST.  */
 static char *
@@ -5391,10 +5836,10 @@ yystpcpy (char *yydest, const char *yysrc)
 
   return yyd - 1;
 }
-#  endif
 # endif
+#endif
 
-# ifndef yytnamerr
+#ifndef yytnamerr
 /* Copy to YYRES the contents of YYSTR after stripping away unnecessary
    quotes and backslashes, so that it's suitable for yyerror.  The
    heuristic is that double-quoting is unnecessary unless the string
@@ -5409,7 +5854,6 @@ yytnamerr (char *yyres, const char *yystr)
     {
       YYPTRDIFF_T yyn = 0;
       char const *yyp = yystr;
-
       for (;;)
         switch (*++yyp)
           {
@@ -5443,31 +5887,15 @@ yytnamerr (char *yyres, const char *yystr)
   else
     return yystrlen (yystr);
 }
-# endif
+#endif
 
-/* Copy into *YYMSG, which is of size *YYMSG_ALLOC, an error message
-   about the unexpected token YYTOKEN for the state stack whose top is
-   YYSSP.
 
-   Return 0 if *YYMSG was successfully written.  Return 1 if *YYMSG is
-   not large enough to hold the message.  In that case, also set
-   *YYMSG_ALLOC to the required number of bytes.  Return 2 if the
-   required number of bytes is too large to store.  */
 static int
-yysyntax_error (YYPTRDIFF_T *yymsg_alloc, char **yymsg,
-                yy_state_t *yyssp, int yytoken)
+yy_syntax_error_arguments (const yypcontext_t *yyctx,
+                           yysymbol_kind_t yyarg[], int yyargn)
 {
-  enum { YYERROR_VERBOSE_ARGS_MAXIMUM = 5 };
-  /* Internationalized format string. */
-  const char *yyformat = YY_NULLPTR;
-  /* Arguments of yyformat: reported tokens (one for the "unexpected",
-     one per "expected"). */
-  char const *yyarg[YYERROR_VERBOSE_ARGS_MAXIMUM];
   /* Actual size of YYARG. */
   int yycount = 0;
-  /* Cumulated lengths of YYARG.  */
-  YYPTRDIFF_T yysize = 0;
-
   /* There are many possibilities here to consider:
      - If this state is a consistent state with a default action, then
        the only way this function was invoked is if the default action
@@ -5491,52 +5919,54 @@ yysyntax_error (YYPTRDIFF_T *yymsg_alloc, char **yymsg,
        one exception: it will still contain any token that will not be
        accepted due to an error action in a later state.
   */
-  if (yytoken != YYEMPTY)
+  if (yyctx->yytoken != YYSYMBOL_YYEMPTY)
     {
-      int yyn = yypact[+*yyssp];
-      YYPTRDIFF_T yysize0 = yytnamerr (YY_NULLPTR, yytname[yytoken]);
-      yysize = yysize0;
-      yyarg[yycount++] = yytname[yytoken];
-      if (!yypact_value_is_default (yyn))
-        {
-          /* Start YYX at -YYN if negative to avoid negative indexes in
-             YYCHECK.  In other words, skip the first -YYN actions for
-             this state because they are default actions.  */
-          int yyxbegin = yyn < 0 ? -yyn : 0;
-          /* Stay within bounds of both yycheck and yytname.  */
-          int yychecklim = YYLAST - yyn + 1;
-          int yyxend = yychecklim < YYNTOKENS ? yychecklim : YYNTOKENS;
-          int yyx;
-
-          for (yyx = yyxbegin; yyx < yyxend; ++yyx)
-            if (yycheck[yyx + yyn] == yyx && yyx != YYTERROR
-                && !yytable_value_is_error (yytable[yyx + yyn]))
-              {
-                if (yycount == YYERROR_VERBOSE_ARGS_MAXIMUM)
-                  {
-                    yycount = 1;
-                    yysize = yysize0;
-                    break;
-                  }
-                yyarg[yycount++] = yytname[yyx];
-                {
-                  YYPTRDIFF_T yysize1
-                    = yysize + yytnamerr (YY_NULLPTR, yytname[yyx]);
-                  if (yysize <= yysize1 && yysize1 <= YYSTACK_ALLOC_MAXIMUM)
-                    yysize = yysize1;
-                  else
-                    return 2;
-                }
-              }
-        }
+      int yyn;
+      if (yyarg)
+        yyarg[yycount] = yyctx->yytoken;
+      ++yycount;
+      yyn = yypcontext_expected_tokens (yyctx,
+                                        yyarg ? yyarg + 1 : yyarg, yyargn - 1);
+      if (yyn == YYENOMEM)
+        return YYENOMEM;
+      else
+        yycount += yyn;
     }
+  return yycount;
+}
+
+/* Copy into *YYMSG, which is of size *YYMSG_ALLOC, an error message
+   about the unexpected token YYTOKEN for the state stack whose top is
+   YYSSP.
+
+   Return 0 if *YYMSG was successfully written.  Return -1 if *YYMSG is
+   not large enough to hold the message.  In that case, also set
+   *YYMSG_ALLOC to the required number of bytes.  Return YYENOMEM if the
+   required number of bytes is too large to store.  */
+static int
+yysyntax_error (YYPTRDIFF_T *yymsg_alloc, char **yymsg,
+                const yypcontext_t *yyctx)
+{
+  enum { YYARGS_MAX = 5 };
+  /* Internationalized format string. */
+  const char *yyformat = YY_NULLPTR;
+  /* Arguments of yyformat: reported tokens (one for the "unexpected",
+     one per "expected"). */
+  yysymbol_kind_t yyarg[YYARGS_MAX];
+  /* Cumulated lengths of YYARG.  */
+  YYPTRDIFF_T yysize = 0;
+
+  /* Actual size of YYARG. */
+  int yycount = yy_syntax_error_arguments (yyctx, yyarg, YYARGS_MAX);
+  if (yycount == YYENOMEM)
+    return YYENOMEM;
 
   switch (yycount)
     {
-# define YYCASE_(N, S)                      \
+#define YYCASE_(N, S)                       \
       case N:                               \
         yyformat = S;                       \
-      break
+        break
     default: /* Avoid compiler warnings. */
       YYCASE_(0, YY_("syntax error"));
       YYCASE_(1, YY_("syntax error, unexpected %s"));
@@ -5544,17 +5974,23 @@ yysyntax_error (YYPTRDIFF_T *yymsg_alloc, char **yymsg,
       YYCASE_(3, YY_("syntax error, unexpected %s, expecting %s or %s"));
       YYCASE_(4, YY_("syntax error, unexpected %s, expecting %s or %s or %s"));
       YYCASE_(5, YY_("syntax error, unexpected %s, expecting %s or %s or %s or %s"));
-# undef YYCASE_
+#undef YYCASE_
     }
 
+  /* Compute error message size.  Don't count the "%s"s, but reserve
+     room for the terminator.  */
+  yysize = yystrlen (yyformat) - 2 * yycount + 1;
   {
-    /* Don't count the "%s"s in the final size, but reserve room for
-       the terminator.  */
-    YYPTRDIFF_T yysize1 = yysize + (yystrlen (yyformat) - 2 * yycount) + 1;
-    if (yysize <= yysize1 && yysize1 <= YYSTACK_ALLOC_MAXIMUM)
-      yysize = yysize1;
-    else
-      return 2;
+    int yyi;
+    for (yyi = 0; yyi < yycount; ++yyi)
+      {
+        YYPTRDIFF_T yysize1
+          = yysize + yytnamerr (YY_NULLPTR, yytname[yyarg[yyi]]);
+        if (yysize <= yysize1 && yysize1 <= YYSTACK_ALLOC_MAXIMUM)
+          yysize = yysize1;
+        else
+          return YYENOMEM;
+      }
   }
 
   if (*yymsg_alloc < yysize)
@@ -5563,7 +5999,7 @@ yysyntax_error (YYPTRDIFF_T *yymsg_alloc, char **yymsg,
       if (! (yysize <= *yymsg_alloc
              && *yymsg_alloc <= YYSTACK_ALLOC_MAXIMUM))
         *yymsg_alloc = YYSTACK_ALLOC_MAXIMUM;
-      return 1;
+      return -1;
     }
 
   /* Avoid sprintf, as that infringes on the user's name space.
@@ -5575,7 +6011,7 @@ yysyntax_error (YYPTRDIFF_T *yymsg_alloc, char **yymsg,
     while ((*yyp = *yyformat) != '\0')
       if (*yyp == '%' && yyformat[1] == 's' && yyi < yycount)
         {
-          yyp += yytnamerr (yyp, yyarg[yyi++]);
+          yyp += yytnamerr (yyp, yytname[yyarg[yyi++]]);
           yyformat += 2;
         }
       else
@@ -5586,25 +6022,28 @@ yysyntax_error (YYPTRDIFF_T *yymsg_alloc, char **yymsg,
   }
   return 0;
 }
-#endif /* YYERROR_VERBOSE */
+
 
 /*-----------------------------------------------.
 | Release the memory associated to this symbol.  |
 `-----------------------------------------------*/
 
 static void
-yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, parser_state *p)
+yydestruct (const char *yymsg,
+            yysymbol_kind_t yykind, YYSTYPE *yyvaluep, parser_state *p)
 {
   YYUSE (yyvaluep);
   YYUSE (p);
   if (!yymsg)
     yymsg = "Deleting";
-  YY_SYMBOL_PRINT (yymsg, yytype, yyvaluep, yylocationp);
+  YY_SYMBOL_PRINT (yymsg, yykind, yyvaluep, yylocationp);
 
   YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
-  YYUSE (yytype);
+  YYUSE (yykind);
   YY_IGNORE_MAYBE_UNINITIALIZED_END
 }
+
+
 
 
 
@@ -5616,7 +6055,7 @@ yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, parser_state *p)
 int
 yyparse (parser_state *p)
 {
-/* The lookahead symbol.  */
+/* Lookahead token kind.  */
 int yychar;
 
 
@@ -5627,45 +6066,41 @@ YY_INITIAL_VALUE (static YYSTYPE yyval_default;)
 YYSTYPE yylval YY_INITIAL_VALUE (= yyval_default);
 
     /* Number of syntax errors so far.  */
-    int yynerrs;
+    int yynerrs = 0;
 
-    yy_state_fast_t yystate;
+    yy_state_fast_t yystate = 0;
     /* Number of tokens to shift before error messages enabled.  */
-    int yyerrstatus;
+    int yyerrstatus = 0;
 
-    /* The stacks and their tools:
-       'yyss': related to states.
-       'yyvs': related to semantic values.
-
-       Refer to the stacks through separate pointers, to allow yyoverflow
+    /* Refer to the stacks through separate pointers, to allow yyoverflow
        to reallocate them elsewhere.  */
 
-    /* The state stack.  */
+    /* Their size.  */
+    YYPTRDIFF_T yystacksize = YYINITDEPTH;
+
+    /* The state stack: array, bottom, top.  */
     yy_state_t yyssa[YYINITDEPTH];
-    yy_state_t *yyss;
-    yy_state_t *yyssp;
+    yy_state_t *yyss = yyssa;
+    yy_state_t *yyssp = yyss;
 
-    /* The semantic value stack.  */
+    /* The semantic value stack: array, bottom, top.  */
     YYSTYPE yyvsa[YYINITDEPTH];
-    YYSTYPE *yyvs;
-    YYSTYPE *yyvsp;
-
-    YYPTRDIFF_T yystacksize;
+    YYSTYPE *yyvs = yyvsa;
+    YYSTYPE *yyvsp = yyvs;
 
   int yyn;
+  /* The return value of yyparse.  */
   int yyresult;
-  /* Lookahead token as an internal (translated) token number.  */
-  int yytoken = 0;
+  /* Lookahead symbol kind.  */
+  yysymbol_kind_t yytoken = YYSYMBOL_YYEMPTY;
   /* The variables used to return semantic value and location from the
      action routines.  */
   YYSTYPE yyval;
 
-#if YYERROR_VERBOSE
   /* Buffer for error messages, and its allocated size.  */
   char yymsgbuf[128];
   char *yymsg = yymsgbuf;
   YYPTRDIFF_T yymsg_alloc = sizeof yymsgbuf;
-#endif
 
 #define YYPOPSTACK(N)   (yyvsp -= (N), yyssp -= (N))
 
@@ -5673,15 +6108,8 @@ YYSTYPE yylval YY_INITIAL_VALUE (= yyval_default);
      Keep to zero when no symbol should be popped.  */
   int yylen = 0;
 
-  yyssp = yyss = yyssa;
-  yyvsp = yyvs = yyvsa;
-  yystacksize = YYINITDEPTH;
-
   YYDPRINTF ((stderr, "Starting parse\n"));
 
-  yystate = 0;
-  yyerrstatus = 0;
-  yynerrs = 0;
   yychar = YYEMPTY; /* Cause a token to be read.  */
   goto yysetstate;
 
@@ -5704,6 +6132,7 @@ yysetstate:
   YY_IGNORE_USELESS_CAST_BEGIN
   *yyssp = YY_CAST (yy_state_t, yystate);
   YY_IGNORE_USELESS_CAST_END
+  YY_STACK_PRINT (yyss, yyssp);
 
   if (yyss + yystacksize - 1 <= yyssp)
 #if !defined yyoverflow && !defined YYSTACK_RELOCATE
@@ -5749,7 +6178,7 @@ yysetstate:
           goto yyexhaustedlab;
         YYSTACK_RELOCATE (yyss_alloc, yyss);
         YYSTACK_RELOCATE (yyvs_alloc, yyvs);
-# undef YYSTACK_RELOCATE
+#  undef YYSTACK_RELOCATE
         if (yyss1 != yyssa)
           YYSTACK_FREE (yyss1);
       }
@@ -5788,17 +6217,28 @@ yybackup:
 
   /* Not known => get a lookahead token if don't already have one.  */
 
-  /* YYCHAR is either YYEMPTY or YYEOF or a valid lookahead symbol.  */
+  /* YYCHAR is either empty, or end-of-input, or a valid lookahead.  */
   if (yychar == YYEMPTY)
     {
-      YYDPRINTF ((stderr, "Reading a token: "));
+      YYDPRINTF ((stderr, "Reading a token\n"));
       yychar = yylex (&yylval, p);
     }
 
   if (yychar <= YYEOF)
     {
-      yychar = yytoken = YYEOF;
+      yychar = YYEOF;
+      yytoken = YYSYMBOL_YYEOF;
       YYDPRINTF ((stderr, "Now at end of input.\n"));
+    }
+  else if (yychar == YYerror)
+    {
+      /* The scanner already issued an error message, process directly
+         to error recovery.  But do not keep the error token as
+         lookahead, it is too special and may lead us to an endless
+         loop in error recovery. */
+      yychar = YYUNDEF;
+      yytoken = YYSYMBOL_YYerror;
+      goto yyerrlab1;
     }
   else
     {
@@ -5868,87 +6308,87 @@ yyreduce:
   YY_REDUCE_PRINT (yyn);
   switch (yyn)
     {
-  case 2:
-#line 1536 "mrbgems/mruby-compiler/core/parse.y"
+  case 2: /* $@1: %empty  */
+#line 1585 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       p->lstate = EXPR_BEG;
                       if (!p->locals) p->locals = cons(0,0);
                     }
-#line 5878 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6318 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 3:
-#line 1541 "mrbgems/mruby-compiler/core/parse.y"
+  case 3: /* program: $@1 top_compstmt  */
+#line 1590 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       p->tree = new_scope(p, (yyvsp[0].nd));
                       NODE_LINENO(p->tree, (yyvsp[0].nd));
                     }
-#line 5887 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6327 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 4:
-#line 1548 "mrbgems/mruby-compiler/core/parse.y"
+  case 4: /* top_compstmt: top_stmts opt_terms  */
+#line 1597 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[-1].nd);
                     }
-#line 5895 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6335 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 5:
-#line 1554 "mrbgems/mruby-compiler/core/parse.y"
+  case 5: /* top_stmts: none  */
+#line 1603 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_begin(p, 0);
                     }
-#line 5903 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6343 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 6:
-#line 1558 "mrbgems/mruby-compiler/core/parse.y"
+  case 6: /* top_stmts: top_stmt  */
+#line 1607 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_begin(p, (yyvsp[0].nd));
                       NODE_LINENO((yyval.nd), (yyvsp[0].nd));
                     }
-#line 5912 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6352 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 7:
-#line 1563 "mrbgems/mruby-compiler/core/parse.y"
+  case 7: /* top_stmts: top_stmts terms top_stmt  */
+#line 1612 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = push((yyvsp[-2].nd), newline_node((yyvsp[0].nd)));
                     }
-#line 5920 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6360 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 8:
-#line 1567 "mrbgems/mruby-compiler/core/parse.y"
+  case 8: /* top_stmts: error top_stmt  */
+#line 1616 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_begin(p, 0);
                     }
-#line 5928 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6368 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 10:
-#line 1574 "mrbgems/mruby-compiler/core/parse.y"
+  case 10: /* @2: %empty  */
+#line 1623 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = local_switch(p);
                       nvars_block(p);
                     }
-#line 5937 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6377 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 11:
-#line 1579 "mrbgems/mruby-compiler/core/parse.y"
+  case 11: /* top_stmt: keyword_BEGIN @2 '{' top_compstmt '}'  */
+#line 1628 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       yyerror(p, "BEGIN not supported");
                       local_resume(p, (yyvsp[-3].nd));
                       nvars_unnest(p);
                       (yyval.nd) = 0;
                     }
-#line 5948 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6388 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 12:
-#line 1591 "mrbgems/mruby-compiler/core/parse.y"
+  case 12: /* bodystmt: compstmt opt_rescue opt_else opt_ensure  */
+#line 1640 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       if ((yyvsp[-2].nd)) {
                         (yyval.nd) = new_rescue(p, (yyvsp[-3].nd), (yyvsp[-2].nd), (yyvsp[-1].nd));
@@ -5970,291 +6410,291 @@ yyreduce:
                         }
                       }
                     }
-#line 5974 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6414 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 13:
-#line 1615 "mrbgems/mruby-compiler/core/parse.y"
+  case 13: /* compstmt: stmts opt_terms  */
+#line 1664 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[-1].nd);
                     }
-#line 5982 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6422 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 14:
-#line 1621 "mrbgems/mruby-compiler/core/parse.y"
+  case 14: /* stmts: none  */
+#line 1670 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_begin(p, 0);
                     }
-#line 5990 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6430 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 15:
-#line 1625 "mrbgems/mruby-compiler/core/parse.y"
+  case 15: /* stmts: stmt  */
+#line 1674 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_begin(p, (yyvsp[0].nd));
                       NODE_LINENO((yyval.nd), (yyvsp[0].nd));
                     }
-#line 5999 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6439 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 16:
-#line 1630 "mrbgems/mruby-compiler/core/parse.y"
+  case 16: /* stmts: stmts terms stmt  */
+#line 1679 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = push((yyvsp[-2].nd), newline_node((yyvsp[0].nd)));
                     }
-#line 6007 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6447 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 17:
-#line 1634 "mrbgems/mruby-compiler/core/parse.y"
+  case 17: /* stmts: error stmt  */
+#line 1683 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_begin(p, (yyvsp[0].nd));
                     }
-#line 6015 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6455 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 18:
-#line 1639 "mrbgems/mruby-compiler/core/parse.y"
+  case 18: /* $@3: %empty  */
+#line 1688 "mrbgems/mruby-compiler/core/parse.y"
                                      {p->lstate = EXPR_FNAME;}
-#line 6021 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6461 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 19:
-#line 1640 "mrbgems/mruby-compiler/core/parse.y"
+  case 19: /* stmt: keyword_alias fsym $@3 fsym  */
+#line 1689 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_alias(p, (yyvsp[-2].id), (yyvsp[0].id));
                     }
-#line 6029 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6469 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 20:
-#line 1644 "mrbgems/mruby-compiler/core/parse.y"
+  case 20: /* stmt: keyword_undef undef_list  */
+#line 1693 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[0].nd);
                     }
-#line 6037 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6477 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 21:
-#line 1648 "mrbgems/mruby-compiler/core/parse.y"
+  case 21: /* stmt: stmt modifier_if expr_value  */
+#line 1697 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_if(p, cond((yyvsp[0].nd)), (yyvsp[-2].nd), 0);
                     }
-#line 6045 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6485 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 22:
-#line 1652 "mrbgems/mruby-compiler/core/parse.y"
+  case 22: /* stmt: stmt modifier_unless expr_value  */
+#line 1701 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_unless(p, cond((yyvsp[0].nd)), (yyvsp[-2].nd), 0);
                     }
-#line 6053 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6493 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 23:
-#line 1656 "mrbgems/mruby-compiler/core/parse.y"
+  case 23: /* stmt: stmt modifier_while expr_value  */
+#line 1705 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_while(p, cond((yyvsp[0].nd)), (yyvsp[-2].nd));
                     }
-#line 6061 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6501 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 24:
-#line 1660 "mrbgems/mruby-compiler/core/parse.y"
+  case 24: /* stmt: stmt modifier_until expr_value  */
+#line 1709 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_until(p, cond((yyvsp[0].nd)), (yyvsp[-2].nd));
                     }
-#line 6069 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6509 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 25:
-#line 1664 "mrbgems/mruby-compiler/core/parse.y"
+  case 25: /* stmt: stmt modifier_rescue stmt  */
+#line 1713 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_mod_rescue(p, (yyvsp[-2].nd), (yyvsp[0].nd));
                     }
-#line 6077 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6517 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 26:
-#line 1668 "mrbgems/mruby-compiler/core/parse.y"
+  case 26: /* stmt: keyword_END '{' compstmt '}'  */
+#line 1717 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       yyerror(p, "END not supported");
                       (yyval.nd) = new_postexe(p, (yyvsp[-1].nd));
                     }
-#line 6086 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6526 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 28:
-#line 1674 "mrbgems/mruby-compiler/core/parse.y"
+  case 28: /* stmt: mlhs '=' command_call  */
+#line 1723 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_masgn(p, (yyvsp[-2].nd), (yyvsp[0].nd));
                     }
-#line 6094 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6534 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 29:
-#line 1678 "mrbgems/mruby-compiler/core/parse.y"
+  case 29: /* stmt: lhs '=' mrhs  */
+#line 1727 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_asgn(p, (yyvsp[-2].nd), new_array(p, (yyvsp[0].nd)));
                     }
-#line 6102 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6542 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 30:
-#line 1682 "mrbgems/mruby-compiler/core/parse.y"
+  case 30: /* stmt: mlhs '=' arg  */
+#line 1731 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_masgn(p, (yyvsp[-2].nd), (yyvsp[0].nd));
                     }
-#line 6110 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6550 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 31:
-#line 1686 "mrbgems/mruby-compiler/core/parse.y"
+  case 31: /* stmt: mlhs '=' mrhs  */
+#line 1735 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_masgn(p, (yyvsp[-2].nd), new_array(p, (yyvsp[0].nd)));
                     }
-#line 6118 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6558 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 32:
-#line 1690 "mrbgems/mruby-compiler/core/parse.y"
+  case 32: /* stmt: arg tASSOC tIDENTIFIER  */
+#line 1739 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       node *lhs = new_lvar(p, (yyvsp[0].id));
                       void_expr_error(p, (yyvsp[-2].nd));
                       assignable(p, lhs);
                       (yyval.nd) = new_asgn(p, lhs, (yyvsp[-2].nd));
                     }
-#line 6129 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6569 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 34:
-#line 1700 "mrbgems/mruby-compiler/core/parse.y"
+  case 34: /* command_asgn: lhs '=' command_rhs  */
+#line 1749 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_asgn(p, (yyvsp[-2].nd), (yyvsp[0].nd));
                     }
-#line 6137 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6577 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 35:
-#line 1704 "mrbgems/mruby-compiler/core/parse.y"
+  case 35: /* command_asgn: var_lhs tOP_ASGN command_rhs  */
+#line 1753 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_op_asgn(p, (yyvsp[-2].nd), (yyvsp[-1].id), (yyvsp[0].nd));
                     }
-#line 6145 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6585 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 36:
-#line 1708 "mrbgems/mruby-compiler/core/parse.y"
+  case 36: /* command_asgn: primary_value '[' opt_call_args ']' tOP_ASGN command_rhs  */
+#line 1757 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_op_asgn(p, new_call(p, (yyvsp[-5].nd), MRB_OPSYM(aref), (yyvsp[-3].nd), '.'), (yyvsp[-1].id), (yyvsp[0].nd));
                     }
-#line 6153 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6593 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 37:
-#line 1712 "mrbgems/mruby-compiler/core/parse.y"
+  case 37: /* command_asgn: primary_value call_op tIDENTIFIER tOP_ASGN command_rhs  */
+#line 1761 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_op_asgn(p, new_call(p, (yyvsp[-4].nd), (yyvsp[-2].id), 0, (yyvsp[-3].num)), (yyvsp[-1].id), (yyvsp[0].nd));
                     }
-#line 6161 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6601 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 38:
-#line 1716 "mrbgems/mruby-compiler/core/parse.y"
+  case 38: /* command_asgn: primary_value call_op tCONSTANT tOP_ASGN command_rhs  */
+#line 1765 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_op_asgn(p, new_call(p, (yyvsp[-4].nd), (yyvsp[-2].id), 0, (yyvsp[-3].num)), (yyvsp[-1].id), (yyvsp[0].nd));
                     }
-#line 6169 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6609 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 39:
-#line 1720 "mrbgems/mruby-compiler/core/parse.y"
+  case 39: /* command_asgn: primary_value tCOLON2 tCONSTANT tOP_ASGN command_call  */
+#line 1769 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       yyerror(p, "constant re-assignment");
                       (yyval.nd) = 0;
                     }
-#line 6178 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6618 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 40:
-#line 1725 "mrbgems/mruby-compiler/core/parse.y"
+  case 40: /* command_asgn: primary_value tCOLON2 tIDENTIFIER tOP_ASGN command_rhs  */
+#line 1774 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_op_asgn(p, new_call(p, (yyvsp[-4].nd), (yyvsp[-2].id), 0, tCOLON2), (yyvsp[-1].id), (yyvsp[0].nd));
                     }
-#line 6186 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6626 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 41:
-#line 1729 "mrbgems/mruby-compiler/core/parse.y"
+  case 41: /* command_asgn: backref tOP_ASGN command_rhs  */
+#line 1778 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       backref_error(p, (yyvsp[-2].nd));
                       (yyval.nd) = new_begin(p, 0);
                     }
-#line 6195 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6635 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 43:
-#line 1737 "mrbgems/mruby-compiler/core/parse.y"
+  case 43: /* command_rhs: command_call modifier_rescue stmt  */
+#line 1786 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_mod_rescue(p, (yyvsp[-2].nd), (yyvsp[0].nd));
                     }
-#line 6203 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6643 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 46:
-#line 1746 "mrbgems/mruby-compiler/core/parse.y"
+  case 46: /* expr: expr keyword_and expr  */
+#line 1795 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_and(p, (yyvsp[-2].nd), (yyvsp[0].nd));
                     }
-#line 6211 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6651 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 47:
-#line 1750 "mrbgems/mruby-compiler/core/parse.y"
+  case 47: /* expr: expr keyword_or expr  */
+#line 1799 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_or(p, (yyvsp[-2].nd), (yyvsp[0].nd));
                     }
-#line 6219 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6659 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 48:
-#line 1754 "mrbgems/mruby-compiler/core/parse.y"
+  case 48: /* expr: keyword_not opt_nl expr  */
+#line 1803 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_uni_op(p, cond((yyvsp[0].nd)), "!");
                     }
-#line 6227 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6667 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 49:
-#line 1758 "mrbgems/mruby-compiler/core/parse.y"
+  case 49: /* expr: '!' command_call  */
+#line 1807 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_uni_op(p, cond((yyvsp[0].nd)), "!");
                     }
-#line 6235 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6675 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 51:
-#line 1766 "mrbgems/mruby-compiler/core/parse.y"
+  case 51: /* defn_head: keyword_def fname  */
+#line 1815 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_def(p, (yyvsp[0].id), nint(p->cmdarg_stack), local_switch(p));
                       p->cmdarg_stack = 0;
                       p->in_def++;
                       nvars_block(p);
                     }
-#line 6246 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6686 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 52:
-#line 1775 "mrbgems/mruby-compiler/core/parse.y"
+  case 52: /* $@4: %empty  */
+#line 1824 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       p->lstate = EXPR_FNAME;
                     }
-#line 6254 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6694 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 53:
-#line 1779 "mrbgems/mruby-compiler/core/parse.y"
+  case 53: /* defs_head: keyword_def singleton dot_or_colon $@4 fname  */
+#line 1828 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_sdef(p, (yyvsp[-3].nd), (yyvsp[0].id), nint(p->cmdarg_stack), local_switch(p));
                       p->cmdarg_stack = 0;
@@ -6263,1054 +6703,1054 @@ yyreduce:
                       nvars_block(p);
                       p->lstate = EXPR_ENDFN; /* force for args */
                     }
-#line 6267 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6707 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 54:
-#line 1790 "mrbgems/mruby-compiler/core/parse.y"
+  case 54: /* expr_value: expr  */
+#line 1839 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       if (!(yyvsp[0].nd)) (yyval.nd) = new_nil(p);
                       else {
                         (yyval.nd) = (yyvsp[0].nd);
                       }
                     }
-#line 6278 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6718 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 58:
-#line 1804 "mrbgems/mruby-compiler/core/parse.y"
+  case 58: /* block_command: block_call call_op2 operation2 command_args  */
+#line 1853 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_call(p, (yyvsp[-3].nd), (yyvsp[-1].id), (yyvsp[0].nd), (yyvsp[-2].num));
                     }
-#line 6286 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6726 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 59:
-#line 1810 "mrbgems/mruby-compiler/core/parse.y"
+  case 59: /* $@5: %empty  */
+#line 1859 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       local_nest(p);
                       nvars_nest(p);
                     }
-#line 6295 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6735 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 60:
-#line 1817 "mrbgems/mruby-compiler/core/parse.y"
+  case 60: /* cmd_brace_block: tLBRACE_ARG $@5 opt_block_param compstmt '}'  */
+#line 1866 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_block(p, (yyvsp[-2].nd), (yyvsp[-1].nd));
                       local_unnest(p);
                       nvars_unnest(p);
                     }
-#line 6305 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6745 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 61:
-#line 1825 "mrbgems/mruby-compiler/core/parse.y"
+  case 61: /* command: operation command_args  */
+#line 1874 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_fcall(p, (yyvsp[-1].id), (yyvsp[0].nd));
                     }
-#line 6313 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6753 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 62:
-#line 1829 "mrbgems/mruby-compiler/core/parse.y"
+  case 62: /* command: operation command_args cmd_brace_block  */
+#line 1878 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       args_with_block(p, (yyvsp[-1].nd), (yyvsp[0].nd));
                       (yyval.nd) = new_fcall(p, (yyvsp[-2].id), (yyvsp[-1].nd));
                     }
-#line 6322 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6762 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 63:
-#line 1834 "mrbgems/mruby-compiler/core/parse.y"
+  case 63: /* command: primary_value call_op operation2 command_args  */
+#line 1883 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_call(p, (yyvsp[-3].nd), (yyvsp[-1].id), (yyvsp[0].nd), (yyvsp[-2].num));
                     }
-#line 6330 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6770 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 64:
-#line 1838 "mrbgems/mruby-compiler/core/parse.y"
+  case 64: /* command: primary_value call_op operation2 command_args cmd_brace_block  */
+#line 1887 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       args_with_block(p, (yyvsp[-1].nd), (yyvsp[0].nd));
                       (yyval.nd) = new_call(p, (yyvsp[-4].nd), (yyvsp[-2].id), (yyvsp[-1].nd), (yyvsp[-3].num));
                    }
-#line 6339 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6779 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 65:
-#line 1843 "mrbgems/mruby-compiler/core/parse.y"
+  case 65: /* command: primary_value tCOLON2 operation2 command_args  */
+#line 1892 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_call(p, (yyvsp[-3].nd), (yyvsp[-1].id), (yyvsp[0].nd), tCOLON2);
                     }
-#line 6347 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6787 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 66:
-#line 1847 "mrbgems/mruby-compiler/core/parse.y"
+  case 66: /* command: primary_value tCOLON2 operation2 command_args cmd_brace_block  */
+#line 1896 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       args_with_block(p, (yyvsp[-1].nd), (yyvsp[0].nd));
                       (yyval.nd) = new_call(p, (yyvsp[-4].nd), (yyvsp[-2].id), (yyvsp[-1].nd), tCOLON2);
                     }
-#line 6356 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6796 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 67:
-#line 1852 "mrbgems/mruby-compiler/core/parse.y"
+  case 67: /* command: keyword_super command_args  */
+#line 1901 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_super(p, (yyvsp[0].nd));
                     }
-#line 6364 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6804 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 68:
-#line 1856 "mrbgems/mruby-compiler/core/parse.y"
+  case 68: /* command: keyword_yield command_args  */
+#line 1905 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_yield(p, (yyvsp[0].nd));
                     }
-#line 6372 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6812 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 69:
-#line 1860 "mrbgems/mruby-compiler/core/parse.y"
+  case 69: /* command: keyword_return call_args  */
+#line 1909 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_return(p, ret_args(p, (yyvsp[0].nd)));
                     }
-#line 6380 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6820 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 70:
-#line 1864 "mrbgems/mruby-compiler/core/parse.y"
+  case 70: /* command: keyword_break call_args  */
+#line 1913 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_break(p, ret_args(p, (yyvsp[0].nd)));
                     }
-#line 6388 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6828 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 71:
-#line 1868 "mrbgems/mruby-compiler/core/parse.y"
+  case 71: /* command: keyword_next call_args  */
+#line 1917 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_next(p, ret_args(p, (yyvsp[0].nd)));
                     }
-#line 6396 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6836 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 72:
-#line 1874 "mrbgems/mruby-compiler/core/parse.y"
+  case 72: /* mlhs: mlhs_basic  */
+#line 1923 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[0].nd);
                     }
-#line 6404 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6844 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 73:
-#line 1878 "mrbgems/mruby-compiler/core/parse.y"
+  case 73: /* mlhs: tLPAREN mlhs_inner rparen  */
+#line 1927 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[-1].nd);
                     }
-#line 6412 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6852 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 75:
-#line 1885 "mrbgems/mruby-compiler/core/parse.y"
+  case 75: /* mlhs_inner: tLPAREN mlhs_inner rparen  */
+#line 1934 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[-1].nd);
                     }
-#line 6420 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6860 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 76:
-#line 1891 "mrbgems/mruby-compiler/core/parse.y"
+  case 76: /* mlhs_basic: mlhs_list  */
+#line 1940 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list1((yyvsp[0].nd));
                     }
-#line 6428 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6868 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 77:
-#line 1895 "mrbgems/mruby-compiler/core/parse.y"
+  case 77: /* mlhs_basic: mlhs_list mlhs_item  */
+#line 1944 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list1(push((yyvsp[-1].nd),(yyvsp[0].nd)));
                     }
-#line 6436 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6876 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 78:
-#line 1899 "mrbgems/mruby-compiler/core/parse.y"
+  case 78: /* mlhs_basic: mlhs_list tSTAR mlhs_node  */
+#line 1948 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list2((yyvsp[-2].nd), (yyvsp[0].nd));
                     }
-#line 6444 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6884 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 79:
-#line 1903 "mrbgems/mruby-compiler/core/parse.y"
+  case 79: /* mlhs_basic: mlhs_list tSTAR mlhs_node ',' mlhs_post  */
+#line 1952 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list3((yyvsp[-4].nd), (yyvsp[-2].nd), (yyvsp[0].nd));
                     }
-#line 6452 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6892 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 80:
-#line 1907 "mrbgems/mruby-compiler/core/parse.y"
+  case 80: /* mlhs_basic: mlhs_list tSTAR  */
+#line 1956 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list2((yyvsp[-1].nd), new_nil(p));
                     }
-#line 6460 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6900 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 81:
-#line 1911 "mrbgems/mruby-compiler/core/parse.y"
+  case 81: /* mlhs_basic: mlhs_list tSTAR ',' mlhs_post  */
+#line 1960 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list3((yyvsp[-3].nd), new_nil(p), (yyvsp[0].nd));
                     }
-#line 6468 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6908 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 82:
-#line 1915 "mrbgems/mruby-compiler/core/parse.y"
+  case 82: /* mlhs_basic: tSTAR mlhs_node  */
+#line 1964 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list2(0, (yyvsp[0].nd));
                     }
-#line 6476 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6916 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 83:
-#line 1919 "mrbgems/mruby-compiler/core/parse.y"
+  case 83: /* mlhs_basic: tSTAR mlhs_node ',' mlhs_post  */
+#line 1968 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list3(0, (yyvsp[-2].nd), (yyvsp[0].nd));
                     }
-#line 6484 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6924 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 84:
-#line 1923 "mrbgems/mruby-compiler/core/parse.y"
+  case 84: /* mlhs_basic: tSTAR  */
+#line 1972 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list2(0, new_nil(p));
                     }
-#line 6492 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6932 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 85:
-#line 1927 "mrbgems/mruby-compiler/core/parse.y"
+  case 85: /* mlhs_basic: tSTAR ',' mlhs_post  */
+#line 1976 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list3(0, new_nil(p), (yyvsp[0].nd));
                     }
-#line 6500 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6940 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 87:
-#line 1934 "mrbgems/mruby-compiler/core/parse.y"
+  case 87: /* mlhs_item: tLPAREN mlhs_inner rparen  */
+#line 1983 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_masgn(p, (yyvsp[-1].nd), NULL);
                     }
-#line 6508 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6948 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 88:
-#line 1940 "mrbgems/mruby-compiler/core/parse.y"
+  case 88: /* mlhs_list: mlhs_item ','  */
+#line 1989 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list1((yyvsp[-1].nd));
                     }
-#line 6516 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6956 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 89:
-#line 1944 "mrbgems/mruby-compiler/core/parse.y"
+  case 89: /* mlhs_list: mlhs_list mlhs_item ','  */
+#line 1993 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = push((yyvsp[-2].nd), (yyvsp[-1].nd));
                     }
-#line 6524 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6964 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 90:
-#line 1950 "mrbgems/mruby-compiler/core/parse.y"
+  case 90: /* mlhs_post: mlhs_item  */
+#line 1999 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list1((yyvsp[0].nd));
                     }
-#line 6532 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6972 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 91:
-#line 1954 "mrbgems/mruby-compiler/core/parse.y"
+  case 91: /* mlhs_post: mlhs_list mlhs_item  */
+#line 2003 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = push((yyvsp[-1].nd), (yyvsp[0].nd));
                     }
-#line 6540 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6980 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 92:
-#line 1960 "mrbgems/mruby-compiler/core/parse.y"
+  case 92: /* mlhs_node: variable  */
+#line 2009 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       assignable(p, (yyvsp[0].nd));
                     }
-#line 6548 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6988 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 93:
-#line 1964 "mrbgems/mruby-compiler/core/parse.y"
+  case 93: /* mlhs_node: primary_value '[' opt_call_args ']'  */
+#line 2013 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_call(p, (yyvsp[-3].nd), MRB_OPSYM(aref), (yyvsp[-1].nd), '.');
-                    }
-#line 6556 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 94:
-#line 1968 "mrbgems/mruby-compiler/core/parse.y"
-                    {
-                      (yyval.nd) = new_call(p, (yyvsp[-2].nd), (yyvsp[0].id), 0, (yyvsp[-1].num));
-                    }
-#line 6564 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 95:
-#line 1972 "mrbgems/mruby-compiler/core/parse.y"
-                    {
-                      (yyval.nd) = new_call(p, (yyvsp[-2].nd), (yyvsp[0].id), 0, tCOLON2);
-                    }
-#line 6572 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 96:
-#line 1976 "mrbgems/mruby-compiler/core/parse.y"
-                    {
-                      (yyval.nd) = new_call(p, (yyvsp[-2].nd), (yyvsp[0].id), 0, (yyvsp[-1].num));
-                    }
-#line 6580 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 97:
-#line 1980 "mrbgems/mruby-compiler/core/parse.y"
-                    {
-                      if (p->in_def || p->in_single)
-                        yyerror(p, "dynamic constant assignment");
-                      (yyval.nd) = new_colon2(p, (yyvsp[-2].nd), (yyvsp[0].id));
-                    }
-#line 6590 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 98:
-#line 1986 "mrbgems/mruby-compiler/core/parse.y"
-                    {
-                      if (p->in_def || p->in_single)
-                        yyerror(p, "dynamic constant assignment");
-                      (yyval.nd) = new_colon3(p, (yyvsp[0].id));
-                    }
-#line 6600 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 99:
-#line 1992 "mrbgems/mruby-compiler/core/parse.y"
-                    {
-                      backref_error(p, (yyvsp[0].nd));
-                      (yyval.nd) = 0;
-                    }
-#line 6609 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 100:
-#line 1999 "mrbgems/mruby-compiler/core/parse.y"
-                    {
-                      assignable(p, (yyvsp[0].nd));
-                    }
-#line 6617 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 101:
-#line 2003 "mrbgems/mruby-compiler/core/parse.y"
-                    {
-                      (yyval.nd) = new_call(p, (yyvsp[-3].nd), MRB_OPSYM(aref), (yyvsp[-1].nd), '.');
-                    }
-#line 6625 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 102:
-#line 2007 "mrbgems/mruby-compiler/core/parse.y"
-                    {
-                      (yyval.nd) = new_call(p, (yyvsp[-2].nd), (yyvsp[0].id), 0, (yyvsp[-1].num));
-                    }
-#line 6633 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 103:
-#line 2011 "mrbgems/mruby-compiler/core/parse.y"
-                    {
-                      (yyval.nd) = new_call(p, (yyvsp[-2].nd), (yyvsp[0].id), 0, tCOLON2);
-                    }
-#line 6641 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 104:
-#line 2015 "mrbgems/mruby-compiler/core/parse.y"
-                    {
-                      (yyval.nd) = new_call(p, (yyvsp[-2].nd), (yyvsp[0].id), 0, (yyvsp[-1].num));
-                    }
-#line 6649 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 105:
-#line 2019 "mrbgems/mruby-compiler/core/parse.y"
-                    {
-                      if (p->in_def || p->in_single)
-                        yyerror(p, "dynamic constant assignment");
-                      (yyval.nd) = new_colon2(p, (yyvsp[-2].nd), (yyvsp[0].id));
-                    }
-#line 6659 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 106:
-#line 2025 "mrbgems/mruby-compiler/core/parse.y"
-                    {
-                      if (p->in_def || p->in_single)
-                        yyerror(p, "dynamic constant assignment");
-                      (yyval.nd) = new_colon3(p, (yyvsp[0].id));
-                    }
-#line 6669 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 107:
-#line 2031 "mrbgems/mruby-compiler/core/parse.y"
-                    {
-                      backref_error(p, (yyvsp[0].nd));
-                      (yyval.nd) = 0;
-                    }
-#line 6678 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 108:
-#line 2036 "mrbgems/mruby-compiler/core/parse.y"
-                    {
-                      yyerror(p, "can't assign to numbered parameter");
-                    }
-#line 6686 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 109:
-#line 2042 "mrbgems/mruby-compiler/core/parse.y"
-                    {
-                      yyerror(p, "class/module name must be CONSTANT");
-                    }
-#line 6694 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 111:
-#line 2049 "mrbgems/mruby-compiler/core/parse.y"
-                    {
-                      (yyval.nd) = cons((node*)1, nsym((yyvsp[0].id)));
-                    }
-#line 6702 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 112:
-#line 2053 "mrbgems/mruby-compiler/core/parse.y"
-                    {
-                      (yyval.nd) = cons((node*)0, nsym((yyvsp[0].id)));
-                    }
-#line 6710 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 113:
-#line 2057 "mrbgems/mruby-compiler/core/parse.y"
-                    {
-                      void_expr_error(p, (yyvsp[-2].nd));
-                      (yyval.nd) = cons((yyvsp[-2].nd), nsym((yyvsp[0].id)));
-                    }
-#line 6719 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 117:
-#line 2067 "mrbgems/mruby-compiler/core/parse.y"
-                    {
-                      p->lstate = EXPR_ENDFN;
-                      (yyval.id) = (yyvsp[0].id);
-                    }
-#line 6728 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 118:
-#line 2072 "mrbgems/mruby-compiler/core/parse.y"
-                    {
-                      p->lstate = EXPR_ENDFN;
-                      (yyval.id) = (yyvsp[0].id);
-                    }
-#line 6737 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 121:
-#line 2083 "mrbgems/mruby-compiler/core/parse.y"
-                    {
-                      (yyval.nd) = new_undef(p, (yyvsp[0].id));
-                    }
-#line 6745 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 122:
-#line 2086 "mrbgems/mruby-compiler/core/parse.y"
-                                 {p->lstate = EXPR_FNAME;}
-#line 6751 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 123:
-#line 2087 "mrbgems/mruby-compiler/core/parse.y"
-                    {
-                      (yyval.nd) = push((yyvsp[-3].nd), nsym((yyvsp[0].id)));
-                    }
-#line 6759 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 124:
-#line 2092 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = MRB_OPSYM(or);     }
-#line 6765 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 125:
-#line 2093 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = MRB_OPSYM(xor);    }
-#line 6771 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 126:
-#line 2094 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = MRB_OPSYM(and);    }
-#line 6777 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 127:
-#line 2095 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = MRB_OPSYM(cmp);    }
-#line 6783 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 128:
-#line 2096 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = MRB_OPSYM(eq);     }
-#line 6789 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 129:
-#line 2097 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = MRB_OPSYM(eqq);    }
-#line 6795 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 130:
-#line 2098 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = MRB_OPSYM(match);  }
-#line 6801 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 131:
-#line 2099 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = MRB_OPSYM(nmatch); }
-#line 6807 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 132:
-#line 2100 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = MRB_OPSYM(gt);     }
-#line 6813 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 133:
-#line 2101 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = MRB_OPSYM(ge);     }
-#line 6819 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 134:
-#line 2102 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = MRB_OPSYM(lt);     }
-#line 6825 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 135:
-#line 2103 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = MRB_OPSYM(le);     }
-#line 6831 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 136:
-#line 2104 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = MRB_OPSYM(neq);    }
-#line 6837 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 137:
-#line 2105 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = MRB_OPSYM(lshift); }
-#line 6843 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 138:
-#line 2106 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = MRB_OPSYM(rshift); }
-#line 6849 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 139:
-#line 2107 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = MRB_OPSYM(add);    }
-#line 6855 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 140:
-#line 2108 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = MRB_OPSYM(sub);    }
-#line 6861 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 141:
-#line 2109 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = MRB_OPSYM(mul);    }
-#line 6867 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 142:
-#line 2110 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = MRB_OPSYM(mul);    }
-#line 6873 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 143:
-#line 2111 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = MRB_OPSYM(div);    }
-#line 6879 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 144:
-#line 2112 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = MRB_OPSYM(mod);    }
-#line 6885 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 145:
-#line 2113 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = MRB_OPSYM(pow);    }
-#line 6891 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 146:
-#line 2114 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = MRB_OPSYM(pow);    }
-#line 6897 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 147:
-#line 2115 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = MRB_OPSYM(not);    }
-#line 6903 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 148:
-#line 2116 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = MRB_OPSYM(neg);    }
-#line 6909 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 149:
-#line 2117 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = MRB_OPSYM(plus);   }
-#line 6915 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 150:
-#line 2118 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = MRB_OPSYM(minus);  }
-#line 6921 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 151:
-#line 2119 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = MRB_OPSYM(aref);   }
-#line 6927 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 152:
-#line 2120 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = MRB_OPSYM(aset);   }
-#line 6933 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 153:
-#line 2121 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = MRB_OPSYM(tick);   }
-#line 6939 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 194:
-#line 2139 "mrbgems/mruby-compiler/core/parse.y"
-                    {
-                      (yyval.nd) = new_asgn(p, (yyvsp[-2].nd), (yyvsp[0].nd));
-                    }
-#line 6947 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 195:
-#line 2143 "mrbgems/mruby-compiler/core/parse.y"
-                    {
-                      (yyval.nd) = new_op_asgn(p, (yyvsp[-2].nd), (yyvsp[-1].id), (yyvsp[0].nd));
-                    }
-#line 6955 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 196:
-#line 2147 "mrbgems/mruby-compiler/core/parse.y"
-                    {
-                      (yyval.nd) = new_op_asgn(p, new_call(p, (yyvsp[-5].nd), MRB_OPSYM(aref), (yyvsp[-3].nd), '.'), (yyvsp[-1].id), (yyvsp[0].nd));
-                    }
-#line 6963 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 197:
-#line 2151 "mrbgems/mruby-compiler/core/parse.y"
-                    {
-                      (yyval.nd) = new_op_asgn(p, new_call(p, (yyvsp[-4].nd), (yyvsp[-2].id), 0, (yyvsp[-3].num)), (yyvsp[-1].id), (yyvsp[0].nd));
-                    }
-#line 6971 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 198:
-#line 2155 "mrbgems/mruby-compiler/core/parse.y"
-                    {
-                      (yyval.nd) = new_op_asgn(p, new_call(p, (yyvsp[-4].nd), (yyvsp[-2].id), 0, (yyvsp[-3].num)), (yyvsp[-1].id), (yyvsp[0].nd));
-                    }
-#line 6979 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 199:
-#line 2159 "mrbgems/mruby-compiler/core/parse.y"
-                    {
-                      (yyval.nd) = new_op_asgn(p, new_call(p, (yyvsp[-4].nd), (yyvsp[-2].id), 0, tCOLON2), (yyvsp[-1].id), (yyvsp[0].nd));
-                    }
-#line 6987 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 200:
-#line 2163 "mrbgems/mruby-compiler/core/parse.y"
-                    {
-                      yyerror(p, "constant re-assignment");
-                      (yyval.nd) = new_begin(p, 0);
                     }
 #line 6996 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 201:
-#line 2168 "mrbgems/mruby-compiler/core/parse.y"
+  case 94: /* mlhs_node: primary_value call_op tIDENTIFIER  */
+#line 2017 "mrbgems/mruby-compiler/core/parse.y"
                     {
-                      yyerror(p, "constant re-assignment");
-                      (yyval.nd) = new_begin(p, 0);
+                      (yyval.nd) = new_call(p, (yyvsp[-2].nd), (yyvsp[0].id), 0, (yyvsp[-1].num));
                     }
-#line 7005 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7004 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 202:
-#line 2173 "mrbgems/mruby-compiler/core/parse.y"
+  case 95: /* mlhs_node: primary_value tCOLON2 tIDENTIFIER  */
+#line 2021 "mrbgems/mruby-compiler/core/parse.y"
                     {
-                      backref_error(p, (yyvsp[-2].nd));
-                      (yyval.nd) = new_begin(p, 0);
+                      (yyval.nd) = new_call(p, (yyvsp[-2].nd), (yyvsp[0].id), 0, tCOLON2);
                     }
-#line 7014 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7012 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 203:
-#line 2178 "mrbgems/mruby-compiler/core/parse.y"
+  case 96: /* mlhs_node: primary_value call_op tCONSTANT  */
+#line 2025 "mrbgems/mruby-compiler/core/parse.y"
                     {
-                      (yyval.nd) = new_dot2(p, (yyvsp[-2].nd), (yyvsp[0].nd));
+                      (yyval.nd) = new_call(p, (yyvsp[-2].nd), (yyvsp[0].id), 0, (yyvsp[-1].num));
                     }
-#line 7022 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7020 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 204:
-#line 2182 "mrbgems/mruby-compiler/core/parse.y"
+  case 97: /* mlhs_node: primary_value tCOLON2 tCONSTANT  */
+#line 2029 "mrbgems/mruby-compiler/core/parse.y"
                     {
-                      (yyval.nd) = new_dot2(p, (yyvsp[-1].nd), new_nil(p));
+                      if (p->in_def || p->in_single)
+                        yyerror(p, "dynamic constant assignment");
+                      (yyval.nd) = new_colon2(p, (yyvsp[-2].nd), (yyvsp[0].id));
                     }
 #line 7030 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 205:
-#line 2186 "mrbgems/mruby-compiler/core/parse.y"
+  case 98: /* mlhs_node: tCOLON3 tCONSTANT  */
+#line 2035 "mrbgems/mruby-compiler/core/parse.y"
                     {
-                      (yyval.nd) = new_dot2(p, new_nil(p), (yyvsp[0].nd));
+                      if (p->in_def || p->in_single)
+                        yyerror(p, "dynamic constant assignment");
+                      (yyval.nd) = new_colon3(p, (yyvsp[0].id));
                     }
-#line 7038 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7040 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 206:
-#line 2190 "mrbgems/mruby-compiler/core/parse.y"
+  case 99: /* mlhs_node: backref  */
+#line 2041 "mrbgems/mruby-compiler/core/parse.y"
                     {
-                      (yyval.nd) = new_dot3(p, (yyvsp[-2].nd), (yyvsp[0].nd));
+                      backref_error(p, (yyvsp[0].nd));
+                      (yyval.nd) = 0;
                     }
-#line 7046 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7049 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 207:
-#line 2194 "mrbgems/mruby-compiler/core/parse.y"
+  case 100: /* lhs: variable  */
+#line 2048 "mrbgems/mruby-compiler/core/parse.y"
                     {
-                      (yyval.nd) = new_dot3(p, (yyvsp[-1].nd), new_nil(p));
+                      assignable(p, (yyvsp[0].nd));
                     }
-#line 7054 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7057 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 208:
-#line 2198 "mrbgems/mruby-compiler/core/parse.y"
+  case 101: /* lhs: primary_value '[' opt_call_args ']'  */
+#line 2052 "mrbgems/mruby-compiler/core/parse.y"
                     {
-                      (yyval.nd) = new_dot3(p, new_nil(p), (yyvsp[0].nd));
+                      (yyval.nd) = new_call(p, (yyvsp[-3].nd), MRB_OPSYM(aref), (yyvsp[-1].nd), '.');
                     }
-#line 7062 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7065 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 209:
-#line 2202 "mrbgems/mruby-compiler/core/parse.y"
+  case 102: /* lhs: primary_value call_op tIDENTIFIER  */
+#line 2056 "mrbgems/mruby-compiler/core/parse.y"
                     {
-                      (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), "+", (yyvsp[0].nd));
+                      (yyval.nd) = new_call(p, (yyvsp[-2].nd), (yyvsp[0].id), 0, (yyvsp[-1].num));
                     }
-#line 7070 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7073 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 210:
-#line 2206 "mrbgems/mruby-compiler/core/parse.y"
+  case 103: /* lhs: primary_value tCOLON2 tIDENTIFIER  */
+#line 2060 "mrbgems/mruby-compiler/core/parse.y"
                     {
-                      (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), "-", (yyvsp[0].nd));
+                      (yyval.nd) = new_call(p, (yyvsp[-2].nd), (yyvsp[0].id), 0, tCOLON2);
                     }
-#line 7078 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7081 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 211:
-#line 2210 "mrbgems/mruby-compiler/core/parse.y"
+  case 104: /* lhs: primary_value call_op tCONSTANT  */
+#line 2064 "mrbgems/mruby-compiler/core/parse.y"
                     {
-                      (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), "*", (yyvsp[0].nd));
+                      (yyval.nd) = new_call(p, (yyvsp[-2].nd), (yyvsp[0].id), 0, (yyvsp[-1].num));
                     }
-#line 7086 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7089 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 212:
-#line 2214 "mrbgems/mruby-compiler/core/parse.y"
+  case 105: /* lhs: primary_value tCOLON2 tCONSTANT  */
+#line 2068 "mrbgems/mruby-compiler/core/parse.y"
                     {
-                      (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), "/", (yyvsp[0].nd));
+                      if (p->in_def || p->in_single)
+                        yyerror(p, "dynamic constant assignment");
+                      (yyval.nd) = new_colon2(p, (yyvsp[-2].nd), (yyvsp[0].id));
                     }
-#line 7094 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7099 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 213:
-#line 2218 "mrbgems/mruby-compiler/core/parse.y"
+  case 106: /* lhs: tCOLON3 tCONSTANT  */
+#line 2074 "mrbgems/mruby-compiler/core/parse.y"
                     {
-                      (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), "%", (yyvsp[0].nd));
+                      if (p->in_def || p->in_single)
+                        yyerror(p, "dynamic constant assignment");
+                      (yyval.nd) = new_colon3(p, (yyvsp[0].id));
                     }
-#line 7102 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7109 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 214:
-#line 2222 "mrbgems/mruby-compiler/core/parse.y"
+  case 107: /* lhs: backref  */
+#line 2080 "mrbgems/mruby-compiler/core/parse.y"
                     {
-                      (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), "**", (yyvsp[0].nd));
-                    }
-#line 7110 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 215:
-#line 2226 "mrbgems/mruby-compiler/core/parse.y"
-                    {
-                      (yyval.nd) = call_uni_op(p, call_bin_op(p, (yyvsp[-2].nd), "**", (yyvsp[0].nd)), "-@");
+                      backref_error(p, (yyvsp[0].nd));
+                      (yyval.nd) = 0;
                     }
 #line 7118 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 216:
-#line 2230 "mrbgems/mruby-compiler/core/parse.y"
+  case 108: /* lhs: tNUMPARAM  */
+#line 2085 "mrbgems/mruby-compiler/core/parse.y"
                     {
-                      (yyval.nd) = call_uni_op(p, call_bin_op(p, (yyvsp[-2].nd), "**", (yyvsp[0].nd)), "-@");
+                      yyerror(p, "can't assign to numbered parameter");
                     }
 #line 7126 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 217:
-#line 2234 "mrbgems/mruby-compiler/core/parse.y"
+  case 109: /* cname: tIDENTIFIER  */
+#line 2091 "mrbgems/mruby-compiler/core/parse.y"
                     {
-                      (yyval.nd) = call_uni_op(p, (yyvsp[0].nd), "+@");
+                      yyerror(p, "class/module name must be CONSTANT");
                     }
 #line 7134 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 218:
-#line 2238 "mrbgems/mruby-compiler/core/parse.y"
+  case 111: /* cpath: tCOLON3 cname  */
+#line 2098 "mrbgems/mruby-compiler/core/parse.y"
                     {
-                      (yyval.nd) = call_uni_op(p, (yyvsp[0].nd), "-@");
+                      (yyval.nd) = cons((node*)1, nsym((yyvsp[0].id)));
                     }
 #line 7142 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 219:
-#line 2242 "mrbgems/mruby-compiler/core/parse.y"
+  case 112: /* cpath: cname  */
+#line 2102 "mrbgems/mruby-compiler/core/parse.y"
                     {
-                      (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), "|", (yyvsp[0].nd));
+                      (yyval.nd) = cons((node*)0, nsym((yyvsp[0].id)));
                     }
 #line 7150 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 220:
-#line 2246 "mrbgems/mruby-compiler/core/parse.y"
+  case 113: /* cpath: primary_value tCOLON2 cname  */
+#line 2106 "mrbgems/mruby-compiler/core/parse.y"
+                    {
+                      void_expr_error(p, (yyvsp[-2].nd));
+                      (yyval.nd) = cons((yyvsp[-2].nd), nsym((yyvsp[0].id)));
+                    }
+#line 7159 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 117: /* fname: op  */
+#line 2116 "mrbgems/mruby-compiler/core/parse.y"
+                    {
+                      p->lstate = EXPR_ENDFN;
+                      (yyval.id) = (yyvsp[0].id);
+                    }
+#line 7168 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 118: /* fname: reswords  */
+#line 2121 "mrbgems/mruby-compiler/core/parse.y"
+                    {
+                      p->lstate = EXPR_ENDFN;
+                      (yyval.id) = (yyvsp[0].id);
+                    }
+#line 7177 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 121: /* undef_list: fsym  */
+#line 2132 "mrbgems/mruby-compiler/core/parse.y"
+                    {
+                      (yyval.nd) = new_undef(p, (yyvsp[0].id));
+                    }
+#line 7185 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 122: /* $@6: %empty  */
+#line 2135 "mrbgems/mruby-compiler/core/parse.y"
+                                 {p->lstate = EXPR_FNAME;}
+#line 7191 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 123: /* undef_list: undef_list ',' $@6 fsym  */
+#line 2136 "mrbgems/mruby-compiler/core/parse.y"
+                    {
+                      (yyval.nd) = push((yyvsp[-3].nd), nsym((yyvsp[0].id)));
+                    }
+#line 7199 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 124: /* op: '|'  */
+#line 2141 "mrbgems/mruby-compiler/core/parse.y"
+                                { (yyval.id) = MRB_OPSYM(or);     }
+#line 7205 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 125: /* op: '^'  */
+#line 2142 "mrbgems/mruby-compiler/core/parse.y"
+                                { (yyval.id) = MRB_OPSYM(xor);    }
+#line 7211 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 126: /* op: '&'  */
+#line 2143 "mrbgems/mruby-compiler/core/parse.y"
+                                { (yyval.id) = MRB_OPSYM(and);    }
+#line 7217 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 127: /* op: tCMP  */
+#line 2144 "mrbgems/mruby-compiler/core/parse.y"
+                                { (yyval.id) = MRB_OPSYM(cmp);    }
+#line 7223 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 128: /* op: tEQ  */
+#line 2145 "mrbgems/mruby-compiler/core/parse.y"
+                                { (yyval.id) = MRB_OPSYM(eq);     }
+#line 7229 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 129: /* op: tEQQ  */
+#line 2146 "mrbgems/mruby-compiler/core/parse.y"
+                                { (yyval.id) = MRB_OPSYM(eqq);    }
+#line 7235 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 130: /* op: tMATCH  */
+#line 2147 "mrbgems/mruby-compiler/core/parse.y"
+                                { (yyval.id) = MRB_OPSYM(match);  }
+#line 7241 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 131: /* op: tNMATCH  */
+#line 2148 "mrbgems/mruby-compiler/core/parse.y"
+                                { (yyval.id) = MRB_OPSYM(nmatch); }
+#line 7247 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 132: /* op: '>'  */
+#line 2149 "mrbgems/mruby-compiler/core/parse.y"
+                                { (yyval.id) = MRB_OPSYM(gt);     }
+#line 7253 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 133: /* op: tGEQ  */
+#line 2150 "mrbgems/mruby-compiler/core/parse.y"
+                                { (yyval.id) = MRB_OPSYM(ge);     }
+#line 7259 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 134: /* op: '<'  */
+#line 2151 "mrbgems/mruby-compiler/core/parse.y"
+                                { (yyval.id) = MRB_OPSYM(lt);     }
+#line 7265 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 135: /* op: tLEQ  */
+#line 2152 "mrbgems/mruby-compiler/core/parse.y"
+                                { (yyval.id) = MRB_OPSYM(le);     }
+#line 7271 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 136: /* op: tNEQ  */
+#line 2153 "mrbgems/mruby-compiler/core/parse.y"
+                                { (yyval.id) = MRB_OPSYM(neq);    }
+#line 7277 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 137: /* op: tLSHFT  */
+#line 2154 "mrbgems/mruby-compiler/core/parse.y"
+                                { (yyval.id) = MRB_OPSYM(lshift); }
+#line 7283 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 138: /* op: tRSHFT  */
+#line 2155 "mrbgems/mruby-compiler/core/parse.y"
+                                { (yyval.id) = MRB_OPSYM(rshift); }
+#line 7289 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 139: /* op: '+'  */
+#line 2156 "mrbgems/mruby-compiler/core/parse.y"
+                                { (yyval.id) = MRB_OPSYM(add);    }
+#line 7295 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 140: /* op: '-'  */
+#line 2157 "mrbgems/mruby-compiler/core/parse.y"
+                                { (yyval.id) = MRB_OPSYM(sub);    }
+#line 7301 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 141: /* op: '*'  */
+#line 2158 "mrbgems/mruby-compiler/core/parse.y"
+                                { (yyval.id) = MRB_OPSYM(mul);    }
+#line 7307 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 142: /* op: tSTAR  */
+#line 2159 "mrbgems/mruby-compiler/core/parse.y"
+                                { (yyval.id) = MRB_OPSYM(mul);    }
+#line 7313 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 143: /* op: '/'  */
+#line 2160 "mrbgems/mruby-compiler/core/parse.y"
+                                { (yyval.id) = MRB_OPSYM(div);    }
+#line 7319 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 144: /* op: '%'  */
+#line 2161 "mrbgems/mruby-compiler/core/parse.y"
+                                { (yyval.id) = MRB_OPSYM(mod);    }
+#line 7325 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 145: /* op: tPOW  */
+#line 2162 "mrbgems/mruby-compiler/core/parse.y"
+                                { (yyval.id) = MRB_OPSYM(pow);    }
+#line 7331 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 146: /* op: tDSTAR  */
+#line 2163 "mrbgems/mruby-compiler/core/parse.y"
+                                { (yyval.id) = MRB_OPSYM(pow);    }
+#line 7337 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 147: /* op: '!'  */
+#line 2164 "mrbgems/mruby-compiler/core/parse.y"
+                                { (yyval.id) = MRB_OPSYM(not);    }
+#line 7343 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 148: /* op: '~'  */
+#line 2165 "mrbgems/mruby-compiler/core/parse.y"
+                                { (yyval.id) = MRB_OPSYM(neg);    }
+#line 7349 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 149: /* op: tUPLUS  */
+#line 2166 "mrbgems/mruby-compiler/core/parse.y"
+                                { (yyval.id) = MRB_OPSYM(plus);   }
+#line 7355 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 150: /* op: tUMINUS  */
+#line 2167 "mrbgems/mruby-compiler/core/parse.y"
+                                { (yyval.id) = MRB_OPSYM(minus);  }
+#line 7361 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 151: /* op: tAREF  */
+#line 2168 "mrbgems/mruby-compiler/core/parse.y"
+                                { (yyval.id) = MRB_OPSYM(aref);   }
+#line 7367 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 152: /* op: tASET  */
+#line 2169 "mrbgems/mruby-compiler/core/parse.y"
+                                { (yyval.id) = MRB_OPSYM(aset);   }
+#line 7373 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 153: /* op: '`'  */
+#line 2170 "mrbgems/mruby-compiler/core/parse.y"
+                                { (yyval.id) = MRB_OPSYM(tick);   }
+#line 7379 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 194: /* arg: lhs '=' arg_rhs  */
+#line 2188 "mrbgems/mruby-compiler/core/parse.y"
+                    {
+                      (yyval.nd) = new_asgn(p, (yyvsp[-2].nd), (yyvsp[0].nd));
+                    }
+#line 7387 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 195: /* arg: var_lhs tOP_ASGN arg_rhs  */
+#line 2192 "mrbgems/mruby-compiler/core/parse.y"
+                    {
+                      (yyval.nd) = new_op_asgn(p, (yyvsp[-2].nd), (yyvsp[-1].id), (yyvsp[0].nd));
+                    }
+#line 7395 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 196: /* arg: primary_value '[' opt_call_args ']' tOP_ASGN arg_rhs  */
+#line 2196 "mrbgems/mruby-compiler/core/parse.y"
+                    {
+                      (yyval.nd) = new_op_asgn(p, new_call(p, (yyvsp[-5].nd), MRB_OPSYM(aref), (yyvsp[-3].nd), '.'), (yyvsp[-1].id), (yyvsp[0].nd));
+                    }
+#line 7403 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 197: /* arg: primary_value call_op tIDENTIFIER tOP_ASGN arg_rhs  */
+#line 2200 "mrbgems/mruby-compiler/core/parse.y"
+                    {
+                      (yyval.nd) = new_op_asgn(p, new_call(p, (yyvsp[-4].nd), (yyvsp[-2].id), 0, (yyvsp[-3].num)), (yyvsp[-1].id), (yyvsp[0].nd));
+                    }
+#line 7411 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 198: /* arg: primary_value call_op tCONSTANT tOP_ASGN arg_rhs  */
+#line 2204 "mrbgems/mruby-compiler/core/parse.y"
+                    {
+                      (yyval.nd) = new_op_asgn(p, new_call(p, (yyvsp[-4].nd), (yyvsp[-2].id), 0, (yyvsp[-3].num)), (yyvsp[-1].id), (yyvsp[0].nd));
+                    }
+#line 7419 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 199: /* arg: primary_value tCOLON2 tIDENTIFIER tOP_ASGN arg_rhs  */
+#line 2208 "mrbgems/mruby-compiler/core/parse.y"
+                    {
+                      (yyval.nd) = new_op_asgn(p, new_call(p, (yyvsp[-4].nd), (yyvsp[-2].id), 0, tCOLON2), (yyvsp[-1].id), (yyvsp[0].nd));
+                    }
+#line 7427 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 200: /* arg: primary_value tCOLON2 tCONSTANT tOP_ASGN arg_rhs  */
+#line 2212 "mrbgems/mruby-compiler/core/parse.y"
+                    {
+                      yyerror(p, "constant re-assignment");
+                      (yyval.nd) = new_begin(p, 0);
+                    }
+#line 7436 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 201: /* arg: tCOLON3 tCONSTANT tOP_ASGN arg_rhs  */
+#line 2217 "mrbgems/mruby-compiler/core/parse.y"
+                    {
+                      yyerror(p, "constant re-assignment");
+                      (yyval.nd) = new_begin(p, 0);
+                    }
+#line 7445 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 202: /* arg: backref tOP_ASGN arg_rhs  */
+#line 2222 "mrbgems/mruby-compiler/core/parse.y"
+                    {
+                      backref_error(p, (yyvsp[-2].nd));
+                      (yyval.nd) = new_begin(p, 0);
+                    }
+#line 7454 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 203: /* arg: arg tDOT2 arg  */
+#line 2227 "mrbgems/mruby-compiler/core/parse.y"
+                    {
+                      (yyval.nd) = new_dot2(p, (yyvsp[-2].nd), (yyvsp[0].nd));
+                    }
+#line 7462 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 204: /* arg: arg tDOT2  */
+#line 2231 "mrbgems/mruby-compiler/core/parse.y"
+                    {
+                      (yyval.nd) = new_dot2(p, (yyvsp[-1].nd), new_nil(p));
+                    }
+#line 7470 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 205: /* arg: tBDOT2 arg  */
+#line 2235 "mrbgems/mruby-compiler/core/parse.y"
+                    {
+                      (yyval.nd) = new_dot2(p, new_nil(p), (yyvsp[0].nd));
+                    }
+#line 7478 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 206: /* arg: arg tDOT3 arg  */
+#line 2239 "mrbgems/mruby-compiler/core/parse.y"
+                    {
+                      (yyval.nd) = new_dot3(p, (yyvsp[-2].nd), (yyvsp[0].nd));
+                    }
+#line 7486 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 207: /* arg: arg tDOT3  */
+#line 2243 "mrbgems/mruby-compiler/core/parse.y"
+                    {
+                      (yyval.nd) = new_dot3(p, (yyvsp[-1].nd), new_nil(p));
+                    }
+#line 7494 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 208: /* arg: tBDOT3 arg  */
+#line 2247 "mrbgems/mruby-compiler/core/parse.y"
+                    {
+                      (yyval.nd) = new_dot3(p, new_nil(p), (yyvsp[0].nd));
+                    }
+#line 7502 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 209: /* arg: arg '+' arg  */
+#line 2251 "mrbgems/mruby-compiler/core/parse.y"
+                    {
+                      (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), "+", (yyvsp[0].nd));
+                    }
+#line 7510 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 210: /* arg: arg '-' arg  */
+#line 2255 "mrbgems/mruby-compiler/core/parse.y"
+                    {
+                      (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), "-", (yyvsp[0].nd));
+                    }
+#line 7518 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 211: /* arg: arg '*' arg  */
+#line 2259 "mrbgems/mruby-compiler/core/parse.y"
+                    {
+                      (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), "*", (yyvsp[0].nd));
+                    }
+#line 7526 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 212: /* arg: arg '/' arg  */
+#line 2263 "mrbgems/mruby-compiler/core/parse.y"
+                    {
+                      (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), "/", (yyvsp[0].nd));
+                    }
+#line 7534 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 213: /* arg: arg '%' arg  */
+#line 2267 "mrbgems/mruby-compiler/core/parse.y"
+                    {
+                      (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), "%", (yyvsp[0].nd));
+                    }
+#line 7542 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 214: /* arg: arg tPOW arg  */
+#line 2271 "mrbgems/mruby-compiler/core/parse.y"
+                    {
+                      (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), "**", (yyvsp[0].nd));
+                    }
+#line 7550 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 215: /* arg: tUMINUS_NUM tINTEGER tPOW arg  */
+#line 2275 "mrbgems/mruby-compiler/core/parse.y"
+                    {
+                      (yyval.nd) = call_uni_op(p, call_bin_op(p, (yyvsp[-2].nd), "**", (yyvsp[0].nd)), "-@");
+                    }
+#line 7558 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 216: /* arg: tUMINUS_NUM tFLOAT tPOW arg  */
+#line 2279 "mrbgems/mruby-compiler/core/parse.y"
+                    {
+                      (yyval.nd) = call_uni_op(p, call_bin_op(p, (yyvsp[-2].nd), "**", (yyvsp[0].nd)), "-@");
+                    }
+#line 7566 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 217: /* arg: tUPLUS arg  */
+#line 2283 "mrbgems/mruby-compiler/core/parse.y"
+                    {
+                      (yyval.nd) = call_uni_op(p, (yyvsp[0].nd), "+@");
+                    }
+#line 7574 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 218: /* arg: tUMINUS arg  */
+#line 2287 "mrbgems/mruby-compiler/core/parse.y"
+                    {
+                      (yyval.nd) = call_uni_op(p, (yyvsp[0].nd), "-@");
+                    }
+#line 7582 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 219: /* arg: arg '|' arg  */
+#line 2291 "mrbgems/mruby-compiler/core/parse.y"
+                    {
+                      (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), "|", (yyvsp[0].nd));
+                    }
+#line 7590 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 220: /* arg: arg '^' arg  */
+#line 2295 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), "^", (yyvsp[0].nd));
                     }
-#line 7158 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7598 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 221:
-#line 2250 "mrbgems/mruby-compiler/core/parse.y"
+  case 221: /* arg: arg '&' arg  */
+#line 2299 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), "&", (yyvsp[0].nd));
                     }
-#line 7166 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7606 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 222:
-#line 2254 "mrbgems/mruby-compiler/core/parse.y"
+  case 222: /* arg: arg tCMP arg  */
+#line 2303 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), "<=>", (yyvsp[0].nd));
                     }
-#line 7174 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7614 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 223:
-#line 2258 "mrbgems/mruby-compiler/core/parse.y"
+  case 223: /* arg: arg '>' arg  */
+#line 2307 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), ">", (yyvsp[0].nd));
                     }
-#line 7182 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7622 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 224:
-#line 2262 "mrbgems/mruby-compiler/core/parse.y"
+  case 224: /* arg: arg tGEQ arg  */
+#line 2311 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), ">=", (yyvsp[0].nd));
                     }
-#line 7190 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7630 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 225:
-#line 2266 "mrbgems/mruby-compiler/core/parse.y"
+  case 225: /* arg: arg '<' arg  */
+#line 2315 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), "<", (yyvsp[0].nd));
                     }
-#line 7198 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7638 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 226:
-#line 2270 "mrbgems/mruby-compiler/core/parse.y"
+  case 226: /* arg: arg tLEQ arg  */
+#line 2319 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), "<=", (yyvsp[0].nd));
                     }
-#line 7206 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7646 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 227:
-#line 2274 "mrbgems/mruby-compiler/core/parse.y"
+  case 227: /* arg: arg tEQ arg  */
+#line 2323 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), "==", (yyvsp[0].nd));
                     }
-#line 7214 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7654 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 228:
-#line 2278 "mrbgems/mruby-compiler/core/parse.y"
+  case 228: /* arg: arg tEQQ arg  */
+#line 2327 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), "===", (yyvsp[0].nd));
                     }
-#line 7222 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7662 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 229:
-#line 2282 "mrbgems/mruby-compiler/core/parse.y"
+  case 229: /* arg: arg tNEQ arg  */
+#line 2331 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), "!=", (yyvsp[0].nd));
                     }
-#line 7230 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7670 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 230:
-#line 2286 "mrbgems/mruby-compiler/core/parse.y"
+  case 230: /* arg: arg tMATCH arg  */
+#line 2335 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), "=~", (yyvsp[0].nd));
                     }
-#line 7238 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7678 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 231:
-#line 2290 "mrbgems/mruby-compiler/core/parse.y"
+  case 231: /* arg: arg tNMATCH arg  */
+#line 2339 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), "!~", (yyvsp[0].nd));
                     }
-#line 7246 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7686 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 232:
-#line 2294 "mrbgems/mruby-compiler/core/parse.y"
+  case 232: /* arg: '!' arg  */
+#line 2343 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_uni_op(p, cond((yyvsp[0].nd)), "!");
                     }
-#line 7254 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7694 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 233:
-#line 2298 "mrbgems/mruby-compiler/core/parse.y"
+  case 233: /* arg: '~' arg  */
+#line 2347 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_uni_op(p, cond((yyvsp[0].nd)), "~");
                     }
-#line 7262 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7702 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 234:
-#line 2302 "mrbgems/mruby-compiler/core/parse.y"
+  case 234: /* arg: arg tLSHFT arg  */
+#line 2351 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), "<<", (yyvsp[0].nd));
                     }
-#line 7270 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7710 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 235:
-#line 2306 "mrbgems/mruby-compiler/core/parse.y"
+  case 235: /* arg: arg tRSHFT arg  */
+#line 2355 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), ">>", (yyvsp[0].nd));
                     }
-#line 7278 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7718 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 236:
-#line 2310 "mrbgems/mruby-compiler/core/parse.y"
+  case 236: /* arg: arg tANDOP arg  */
+#line 2359 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_and(p, (yyvsp[-2].nd), (yyvsp[0].nd));
                     }
-#line 7286 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7726 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 237:
-#line 2314 "mrbgems/mruby-compiler/core/parse.y"
+  case 237: /* arg: arg tOROP arg  */
+#line 2363 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_or(p, (yyvsp[-2].nd), (yyvsp[0].nd));
                     }
-#line 7294 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7734 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 238:
-#line 2318 "mrbgems/mruby-compiler/core/parse.y"
+  case 238: /* arg: arg '?' arg opt_nl ':' arg  */
+#line 2367 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_if(p, cond((yyvsp[-5].nd)), (yyvsp[-3].nd), (yyvsp[0].nd));
                     }
-#line 7302 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7742 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 239:
-#line 2322 "mrbgems/mruby-compiler/core/parse.y"
+  case 239: /* arg: arg '?' arg opt_nl tLABEL_TAG arg  */
+#line 2371 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_if(p, cond((yyvsp[-5].nd)), (yyvsp[-3].nd), (yyvsp[0].nd));
                     }
-#line 7310 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7750 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 240:
-#line 2326 "mrbgems/mruby-compiler/core/parse.y"
+  case 240: /* arg: defn_head f_arglist_paren '=' arg  */
+#line 2375 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[-3].nd);
                       void_expr_error(p, (yyvsp[0].nd));
@@ -7318,11 +7758,11 @@ yyreduce:
                       nvars_unnest(p);
                       p->in_def--;
                     }
-#line 7322 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7762 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 241:
-#line 2334 "mrbgems/mruby-compiler/core/parse.y"
+  case 241: /* arg: defn_head f_arglist_paren '=' arg modifier_rescue arg  */
+#line 2383 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[-5].nd);
                       void_expr_error(p, (yyvsp[-2].nd));
@@ -7331,11 +7771,11 @@ yyreduce:
                       nvars_unnest(p);
                       p->in_def--;
                     }
-#line 7335 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7775 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 242:
-#line 2343 "mrbgems/mruby-compiler/core/parse.y"
+  case 242: /* arg: defs_head f_arglist_paren '=' arg  */
+#line 2392 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[-3].nd);
                       void_expr_error(p, (yyvsp[0].nd));
@@ -7344,11 +7784,11 @@ yyreduce:
                       p->in_def--;
                       p->in_single--;
                     }
-#line 7348 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7788 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 243:
-#line 2352 "mrbgems/mruby-compiler/core/parse.y"
+  case 243: /* arg: defs_head f_arglist_paren '=' arg modifier_rescue arg  */
+#line 2401 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[-5].nd);
                       void_expr_error(p, (yyvsp[-2].nd));
@@ -7358,71 +7798,71 @@ yyreduce:
                       p->in_def--;
                       p->in_single--;
                     }
-#line 7362 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7802 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 244:
-#line 2362 "mrbgems/mruby-compiler/core/parse.y"
+  case 244: /* arg: primary  */
+#line 2411 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[0].nd);
                     }
-#line 7370 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7810 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 246:
-#line 2369 "mrbgems/mruby-compiler/core/parse.y"
+  case 246: /* aref_args: args trailer  */
+#line 2418 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[-1].nd);
                       NODE_LINENO((yyval.nd), (yyvsp[-1].nd));
                     }
-#line 7379 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7819 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 247:
-#line 2374 "mrbgems/mruby-compiler/core/parse.y"
+  case 247: /* aref_args: args comma assocs trailer  */
+#line 2423 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = push((yyvsp[-3].nd), new_kw_hash(p, (yyvsp[-1].nd)));
                     }
-#line 7387 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7827 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 248:
-#line 2378 "mrbgems/mruby-compiler/core/parse.y"
+  case 248: /* aref_args: assocs trailer  */
+#line 2427 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = cons(new_kw_hash(p, (yyvsp[-1].nd)), 0);
                       NODE_LINENO((yyval.nd), (yyvsp[-1].nd));
                     }
-#line 7396 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7836 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 249:
-#line 2385 "mrbgems/mruby-compiler/core/parse.y"
+  case 249: /* arg_rhs: arg  */
+#line 2434 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[0].nd);
                     }
-#line 7404 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7844 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 250:
-#line 2389 "mrbgems/mruby-compiler/core/parse.y"
+  case 250: /* arg_rhs: arg modifier_rescue arg  */
+#line 2438 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       void_expr_error(p, (yyvsp[-2].nd));
                       void_expr_error(p, (yyvsp[0].nd));
                       (yyval.nd) = new_mod_rescue(p, (yyvsp[-2].nd), (yyvsp[0].nd));
                     }
-#line 7414 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7854 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 251:
-#line 2397 "mrbgems/mruby-compiler/core/parse.y"
+  case 251: /* paren_args: '(' opt_call_args ')'  */
+#line 2446 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[-1].nd);
                     }
-#line 7422 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7862 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 252:
-#line 2401 "mrbgems/mruby-compiler/core/parse.y"
+  case 252: /* paren_args: '(' args comma tBDOT3 rparen  */
+#line 2450 "mrbgems/mruby-compiler/core/parse.y"
                     {
 #if 1
                       mrb_sym r = MRB_OPSYM(mul);
@@ -7438,11 +7878,11 @@ yyreduce:
                                 new_block_arg(p, new_lvar(p, b)));
 #endif
                     }
-#line 7442 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7882 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 253:
-#line 2417 "mrbgems/mruby-compiler/core/parse.y"
+  case 253: /* paren_args: '(' tBDOT3 rparen  */
+#line 2466 "mrbgems/mruby-compiler/core/parse.y"
                     {
 #if 1
                       mrb_sym r = MRB_OPSYM(mul);
@@ -7466,373 +7906,373 @@ yyreduce:
                         (yyval.nd) = 0;
                       }
                     }
-#line 7470 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7910 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 258:
-#line 2449 "mrbgems/mruby-compiler/core/parse.y"
+  case 258: /* opt_call_args: args comma  */
+#line 2498 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = cons((yyvsp[-1].nd),0);
                       NODE_LINENO((yyval.nd), (yyvsp[-1].nd));
                     }
-#line 7479 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7919 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 259:
-#line 2454 "mrbgems/mruby-compiler/core/parse.y"
+  case 259: /* opt_call_args: args comma assocs comma  */
+#line 2503 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = cons(push((yyvsp[-3].nd), new_kw_hash(p, (yyvsp[-1].nd))), 0);
                       NODE_LINENO((yyval.nd), (yyvsp[-3].nd));
                     }
-#line 7488 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7928 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 260:
-#line 2459 "mrbgems/mruby-compiler/core/parse.y"
+  case 260: /* opt_call_args: assocs comma  */
+#line 2508 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = cons(list1(new_kw_hash(p, (yyvsp[-1].nd))), 0);
                       NODE_LINENO((yyval.nd), (yyvsp[-1].nd));
                     }
-#line 7497 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7937 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 261:
-#line 2466 "mrbgems/mruby-compiler/core/parse.y"
+  case 261: /* call_args: command  */
+#line 2515 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       void_expr_error(p, (yyvsp[0].nd));
                       (yyval.nd) = cons(list1((yyvsp[0].nd)), 0);
                       NODE_LINENO((yyval.nd), (yyvsp[0].nd));
                     }
-#line 7507 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7947 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 262:
-#line 2472 "mrbgems/mruby-compiler/core/parse.y"
+  case 262: /* call_args: args opt_block_arg  */
+#line 2521 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = cons((yyvsp[-1].nd), (yyvsp[0].nd));
                       NODE_LINENO((yyval.nd), (yyvsp[-1].nd));
                     }
-#line 7516 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7956 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 263:
-#line 2477 "mrbgems/mruby-compiler/core/parse.y"
+  case 263: /* call_args: assocs opt_block_arg  */
+#line 2526 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = cons(list1(new_kw_hash(p, (yyvsp[-1].nd))), (yyvsp[0].nd));
                       NODE_LINENO((yyval.nd), (yyvsp[-1].nd));
                     }
-#line 7525 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7965 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 264:
-#line 2482 "mrbgems/mruby-compiler/core/parse.y"
+  case 264: /* call_args: args comma assocs opt_block_arg  */
+#line 2531 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = cons(push((yyvsp[-3].nd), new_kw_hash(p, (yyvsp[-1].nd))), (yyvsp[0].nd));
                       NODE_LINENO((yyval.nd), (yyvsp[-3].nd));
                     }
-#line 7534 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7974 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 265:
-#line 2487 "mrbgems/mruby-compiler/core/parse.y"
+  case 265: /* call_args: block_arg  */
+#line 2536 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = cons(0, (yyvsp[0].nd));
                       NODE_LINENO((yyval.nd), (yyvsp[0].nd));
                     }
-#line 7543 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7983 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 266:
-#line 2493 "mrbgems/mruby-compiler/core/parse.y"
+  case 266: /* @7: %empty  */
+#line 2542 "mrbgems/mruby-compiler/core/parse.y"
                    {
                       (yyval.stack) = p->cmdarg_stack;
                       CMDARG_PUSH(1);
                     }
-#line 7552 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7992 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 267:
-#line 2498 "mrbgems/mruby-compiler/core/parse.y"
+  case 267: /* command_args: @7 call_args  */
+#line 2547 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       p->cmdarg_stack = (yyvsp[-1].stack);
                       (yyval.nd) = (yyvsp[0].nd);
                     }
-#line 7561 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8001 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 268:
-#line 2505 "mrbgems/mruby-compiler/core/parse.y"
+  case 268: /* block_arg: tAMPER arg  */
+#line 2554 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_block_arg(p, (yyvsp[0].nd));
                     }
-#line 7569 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8009 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 269:
-#line 2511 "mrbgems/mruby-compiler/core/parse.y"
+  case 269: /* opt_block_arg: comma block_arg  */
+#line 2560 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[0].nd);
                     }
-#line 7577 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8017 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 270:
-#line 2515 "mrbgems/mruby-compiler/core/parse.y"
+  case 270: /* opt_block_arg: none  */
+#line 2564 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = 0;
                     }
-#line 7585 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8025 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 273:
-#line 2525 "mrbgems/mruby-compiler/core/parse.y"
+  case 273: /* args: arg  */
+#line 2574 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       void_expr_error(p, (yyvsp[0].nd));
                       (yyval.nd) = cons((yyvsp[0].nd), 0);
                       NODE_LINENO((yyval.nd), (yyvsp[0].nd));
                     }
-#line 7595 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8035 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 274:
-#line 2531 "mrbgems/mruby-compiler/core/parse.y"
+  case 274: /* args: tSTAR arg  */
+#line 2580 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       void_expr_error(p, (yyvsp[0].nd));
                       (yyval.nd) = cons(new_splat(p, (yyvsp[0].nd)), 0);
                       NODE_LINENO((yyval.nd), (yyvsp[0].nd));
                     }
-#line 7605 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8045 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 275:
-#line 2537 "mrbgems/mruby-compiler/core/parse.y"
+  case 275: /* args: args comma arg  */
+#line 2586 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       void_expr_error(p, (yyvsp[0].nd));
                       (yyval.nd) = push((yyvsp[-2].nd), (yyvsp[0].nd));
                     }
-#line 7614 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8054 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 276:
-#line 2542 "mrbgems/mruby-compiler/core/parse.y"
+  case 276: /* args: args comma tSTAR arg  */
+#line 2591 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       void_expr_error(p, (yyvsp[0].nd));
                       (yyval.nd) = push((yyvsp[-3].nd), new_splat(p, (yyvsp[0].nd)));
                     }
-#line 7623 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8063 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 277:
-#line 2549 "mrbgems/mruby-compiler/core/parse.y"
+  case 277: /* mrhs: args comma arg  */
+#line 2598 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       void_expr_error(p, (yyvsp[0].nd));
                       (yyval.nd) = push((yyvsp[-2].nd), (yyvsp[0].nd));
                     }
-#line 7632 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8072 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 278:
-#line 2554 "mrbgems/mruby-compiler/core/parse.y"
+  case 278: /* mrhs: args comma tSTAR arg  */
+#line 2603 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       void_expr_error(p, (yyvsp[0].nd));
                       (yyval.nd) = push((yyvsp[-3].nd), new_splat(p, (yyvsp[0].nd)));
                     }
-#line 7641 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8081 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 279:
-#line 2559 "mrbgems/mruby-compiler/core/parse.y"
+  case 279: /* mrhs: tSTAR arg  */
+#line 2608 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       void_expr_error(p, (yyvsp[0].nd));
                       (yyval.nd) = list1(new_splat(p, (yyvsp[0].nd)));
                     }
-#line 7650 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8090 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 287:
-#line 2573 "mrbgems/mruby-compiler/core/parse.y"
+  case 287: /* primary: tNUMPARAM  */
+#line 2622 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_nvar(p, (yyvsp[0].num));
                     }
-#line 7658 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8098 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 288:
-#line 2577 "mrbgems/mruby-compiler/core/parse.y"
+  case 288: /* primary: tFID  */
+#line 2626 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_fcall(p, (yyvsp[0].id), 0);
                     }
-#line 7666 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8106 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 289:
-#line 2581 "mrbgems/mruby-compiler/core/parse.y"
+  case 289: /* @8: %empty  */
+#line 2630 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.stack) = p->cmdarg_stack;
                       p->cmdarg_stack = 0;
                     }
-#line 7675 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8115 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 290:
-#line 2587 "mrbgems/mruby-compiler/core/parse.y"
+  case 290: /* primary: keyword_begin @8 bodystmt keyword_end  */
+#line 2636 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       p->cmdarg_stack = (yyvsp[-2].stack);
                       (yyval.nd) = (yyvsp[-1].nd);
                     }
-#line 7684 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8124 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 291:
-#line 2592 "mrbgems/mruby-compiler/core/parse.y"
+  case 291: /* @9: %empty  */
+#line 2641 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.stack) = p->cmdarg_stack;
                       p->cmdarg_stack = 0;
                     }
-#line 7693 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8133 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 292:
-#line 2596 "mrbgems/mruby-compiler/core/parse.y"
+  case 292: /* $@10: %empty  */
+#line 2645 "mrbgems/mruby-compiler/core/parse.y"
                        {p->lstate = EXPR_ENDARG;}
-#line 7699 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8139 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 293:
-#line 2597 "mrbgems/mruby-compiler/core/parse.y"
+  case 293: /* primary: tLPAREN_ARG @9 stmt $@10 rparen  */
+#line 2646 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       p->cmdarg_stack = (yyvsp[-3].stack);
                       (yyval.nd) = (yyvsp[-2].nd);
                     }
-#line 7708 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8148 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 294:
-#line 2601 "mrbgems/mruby-compiler/core/parse.y"
+  case 294: /* $@11: %empty  */
+#line 2650 "mrbgems/mruby-compiler/core/parse.y"
                               {p->lstate = EXPR_ENDARG;}
-#line 7714 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8154 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 295:
-#line 2602 "mrbgems/mruby-compiler/core/parse.y"
+  case 295: /* primary: tLPAREN_ARG $@11 rparen  */
+#line 2651 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_nil(p);
                     }
-#line 7722 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8162 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 296:
-#line 2606 "mrbgems/mruby-compiler/core/parse.y"
+  case 296: /* primary: tLPAREN compstmt ')'  */
+#line 2655 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[-1].nd);
                     }
-#line 7730 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8170 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 297:
-#line 2610 "mrbgems/mruby-compiler/core/parse.y"
+  case 297: /* primary: primary_value tCOLON2 tCONSTANT  */
+#line 2659 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_colon2(p, (yyvsp[-2].nd), (yyvsp[0].id));
                     }
-#line 7738 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8178 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 298:
-#line 2614 "mrbgems/mruby-compiler/core/parse.y"
+  case 298: /* primary: tCOLON3 tCONSTANT  */
+#line 2663 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_colon3(p, (yyvsp[0].id));
                     }
-#line 7746 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8186 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 299:
-#line 2618 "mrbgems/mruby-compiler/core/parse.y"
+  case 299: /* primary: tLBRACK aref_args ']'  */
+#line 2667 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_array(p, (yyvsp[-1].nd));
                       NODE_LINENO((yyval.nd), (yyvsp[-1].nd));
                     }
-#line 7755 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8195 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 300:
-#line 2623 "mrbgems/mruby-compiler/core/parse.y"
+  case 300: /* primary: tLBRACE assoc_list '}'  */
+#line 2672 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_hash(p, (yyvsp[-1].nd));
                       NODE_LINENO((yyval.nd), (yyvsp[-1].nd));
                     }
-#line 7764 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8204 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 301:
-#line 2628 "mrbgems/mruby-compiler/core/parse.y"
+  case 301: /* primary: keyword_return  */
+#line 2677 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_return(p, 0);
                     }
-#line 7772 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8212 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 302:
-#line 2632 "mrbgems/mruby-compiler/core/parse.y"
+  case 302: /* primary: keyword_yield opt_paren_args  */
+#line 2681 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_yield(p, (yyvsp[0].nd));
                     }
-#line 7780 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8220 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 303:
-#line 2636 "mrbgems/mruby-compiler/core/parse.y"
+  case 303: /* primary: keyword_not '(' expr rparen  */
+#line 2685 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_uni_op(p, cond((yyvsp[-1].nd)), "!");
                     }
-#line 7788 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8228 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 304:
-#line 2640 "mrbgems/mruby-compiler/core/parse.y"
+  case 304: /* primary: keyword_not '(' rparen  */
+#line 2689 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_uni_op(p, new_nil(p), "!");
                     }
-#line 7796 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8236 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 305:
-#line 2644 "mrbgems/mruby-compiler/core/parse.y"
+  case 305: /* primary: operation brace_block  */
+#line 2693 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_fcall(p, (yyvsp[-1].id), cons(0, (yyvsp[0].nd)));
                     }
-#line 7804 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8244 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 307:
-#line 2649 "mrbgems/mruby-compiler/core/parse.y"
+  case 307: /* primary: method_call brace_block  */
+#line 2698 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       call_with_block(p, (yyvsp[-1].nd), (yyvsp[0].nd));
                       (yyval.nd) = (yyvsp[-1].nd);
                     }
-#line 7813 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8253 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 308:
-#line 2654 "mrbgems/mruby-compiler/core/parse.y"
+  case 308: /* @12: %empty  */
+#line 2703 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       local_nest(p);
                       (yyval.num) = p->lpar_beg;
                       p->lpar_beg = ++p->paren_nest;
                     }
-#line 7823 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8263 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 309:
-#line 2660 "mrbgems/mruby-compiler/core/parse.y"
+  case 309: /* @13: %empty  */
+#line 2709 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.stack) = p->cmdarg_stack;
                       p->cmdarg_stack = 0;
                     }
-#line 7832 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8272 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 310:
-#line 2665 "mrbgems/mruby-compiler/core/parse.y"
+  case 310: /* primary: tLAMBDA @12 f_larglist @13 lambda_body  */
+#line 2714 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       p->lpar_beg = (yyvsp[-3].num);
                       (yyval.nd) = new_lambda(p, (yyvsp[-2].nd), (yyvsp[0].nd));
@@ -7840,149 +8280,149 @@ yyreduce:
                       p->cmdarg_stack = (yyvsp[-1].stack);
                       CMDARG_LEXPOP();
                     }
-#line 7844 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8284 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 311:
-#line 2676 "mrbgems/mruby-compiler/core/parse.y"
+  case 311: /* primary: keyword_if expr_value then compstmt if_tail keyword_end  */
+#line 2725 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_if(p, cond((yyvsp[-4].nd)), (yyvsp[-2].nd), (yyvsp[-1].nd));
                       SET_LINENO((yyval.nd), (yyvsp[-5].num));
                     }
-#line 7853 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8293 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 312:
-#line 2684 "mrbgems/mruby-compiler/core/parse.y"
+  case 312: /* primary: keyword_unless expr_value then compstmt opt_else keyword_end  */
+#line 2733 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_unless(p, cond((yyvsp[-4].nd)), (yyvsp[-2].nd), (yyvsp[-1].nd));
                       SET_LINENO((yyval.nd), (yyvsp[-5].num));
                     }
-#line 7862 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8302 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 313:
-#line 2688 "mrbgems/mruby-compiler/core/parse.y"
+  case 313: /* $@14: %empty  */
+#line 2737 "mrbgems/mruby-compiler/core/parse.y"
                                 {COND_PUSH(1);}
-#line 7868 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8308 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 314:
-#line 2688 "mrbgems/mruby-compiler/core/parse.y"
+  case 314: /* $@15: %empty  */
+#line 2737 "mrbgems/mruby-compiler/core/parse.y"
                                                               {COND_POP();}
-#line 7874 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8314 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 315:
-#line 2691 "mrbgems/mruby-compiler/core/parse.y"
+  case 315: /* primary: keyword_while $@14 expr_value do $@15 compstmt keyword_end  */
+#line 2740 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_while(p, cond((yyvsp[-4].nd)), (yyvsp[-1].nd));
                       SET_LINENO((yyval.nd), (yyvsp[-6].num));
                     }
-#line 7883 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8323 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 316:
-#line 2695 "mrbgems/mruby-compiler/core/parse.y"
+  case 316: /* $@16: %empty  */
+#line 2744 "mrbgems/mruby-compiler/core/parse.y"
                                 {COND_PUSH(1);}
-#line 7889 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8329 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 317:
-#line 2695 "mrbgems/mruby-compiler/core/parse.y"
+  case 317: /* $@17: %empty  */
+#line 2744 "mrbgems/mruby-compiler/core/parse.y"
                                                               {COND_POP();}
-#line 7895 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8335 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 318:
-#line 2698 "mrbgems/mruby-compiler/core/parse.y"
+  case 318: /* primary: keyword_until $@16 expr_value do $@17 compstmt keyword_end  */
+#line 2747 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_until(p, cond((yyvsp[-4].nd)), (yyvsp[-1].nd));
                       SET_LINENO((yyval.nd), (yyvsp[-6].num));
                     }
-#line 7904 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8344 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 319:
-#line 2705 "mrbgems/mruby-compiler/core/parse.y"
+  case 319: /* primary: keyword_case expr_value opt_terms case_body keyword_end  */
+#line 2754 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_case(p, (yyvsp[-3].nd), (yyvsp[-1].nd));
                     }
-#line 7912 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8352 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 320:
-#line 2709 "mrbgems/mruby-compiler/core/parse.y"
+  case 320: /* primary: keyword_case opt_terms case_body keyword_end  */
+#line 2758 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_case(p, 0, (yyvsp[-1].nd));
                     }
-#line 7920 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8360 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 321:
-#line 2713 "mrbgems/mruby-compiler/core/parse.y"
+  case 321: /* $@18: %empty  */
+#line 2762 "mrbgems/mruby-compiler/core/parse.y"
                   {COND_PUSH(1);}
-#line 7926 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8366 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 322:
-#line 2715 "mrbgems/mruby-compiler/core/parse.y"
+  case 322: /* $@19: %empty  */
+#line 2764 "mrbgems/mruby-compiler/core/parse.y"
                   {COND_POP();}
-#line 7932 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8372 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 323:
-#line 2718 "mrbgems/mruby-compiler/core/parse.y"
+  case 323: /* primary: keyword_for for_var keyword_in $@18 expr_value do $@19 compstmt keyword_end  */
+#line 2767 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_for(p, (yyvsp[-7].nd), (yyvsp[-4].nd), (yyvsp[-1].nd));
                       SET_LINENO((yyval.nd), (yyvsp[-8].num));
                     }
-#line 7941 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8381 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 324:
-#line 2724 "mrbgems/mruby-compiler/core/parse.y"
+  case 324: /* @20: %empty  */
+#line 2773 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       if (p->in_def || p->in_single)
                         yyerror(p, "class definition in method body");
                       (yyval.nd) = local_switch(p);
                       nvars_block(p);
                     }
-#line 7952 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8392 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 325:
-#line 2732 "mrbgems/mruby-compiler/core/parse.y"
+  case 325: /* primary: keyword_class cpath superclass @20 bodystmt keyword_end  */
+#line 2781 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_class(p, (yyvsp[-4].nd), (yyvsp[-3].nd), (yyvsp[-1].nd));
                       SET_LINENO((yyval.nd), (yyvsp[-5].num));
                       local_resume(p, (yyvsp[-2].nd));
                       nvars_unnest(p);
                     }
-#line 7963 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8403 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 326:
-#line 2740 "mrbgems/mruby-compiler/core/parse.y"
+  case 326: /* @21: %empty  */
+#line 2789 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.num) = p->in_def;
                       p->in_def = 0;
                     }
-#line 7972 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8412 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 327:
-#line 2745 "mrbgems/mruby-compiler/core/parse.y"
+  case 327: /* @22: %empty  */
+#line 2794 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = cons(local_switch(p), nint(p->in_single));
                       nvars_block(p);
                       p->in_single = 0;
                     }
-#line 7982 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8422 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 328:
-#line 2752 "mrbgems/mruby-compiler/core/parse.y"
+  case 328: /* primary: keyword_class tLSHFT expr @21 term @22 bodystmt keyword_end  */
+#line 2801 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_sclass(p, (yyvsp[-5].nd), (yyvsp[-1].nd));
                       SET_LINENO((yyval.nd), (yyvsp[-7].num));
@@ -7991,44 +8431,44 @@ yyreduce:
                       p->in_def = (yyvsp[-4].num);
                       p->in_single = intn((yyvsp[-2].nd)->cdr);
                     }
-#line 7995 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8435 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 329:
-#line 2762 "mrbgems/mruby-compiler/core/parse.y"
+  case 329: /* @23: %empty  */
+#line 2811 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       if (p->in_def || p->in_single)
                         yyerror(p, "module definition in method body");
                       (yyval.nd) = local_switch(p);
                       nvars_block(p);
                     }
-#line 8006 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8446 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 330:
-#line 2770 "mrbgems/mruby-compiler/core/parse.y"
+  case 330: /* primary: keyword_module cpath @23 bodystmt keyword_end  */
+#line 2819 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_module(p, (yyvsp[-3].nd), (yyvsp[-1].nd));
                       SET_LINENO((yyval.nd), (yyvsp[-4].num));
                       local_resume(p, (yyvsp[-2].nd));
                       nvars_unnest(p);
                     }
-#line 8017 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8457 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 331:
-#line 2780 "mrbgems/mruby-compiler/core/parse.y"
+  case 331: /* primary: defn_head f_arglist bodystmt keyword_end  */
+#line 2829 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[-3].nd);
                       defn_setup(p, (yyval.nd), (yyvsp[-2].nd), (yyvsp[-1].nd));
                       nvars_unnest(p);
                       p->in_def--;
                     }
-#line 8028 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8468 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 332:
-#line 2790 "mrbgems/mruby-compiler/core/parse.y"
+  case 332: /* primary: defs_head f_arglist bodystmt keyword_end  */
+#line 2839 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[-3].nd);
                       defs_setup(p, (yyval.nd), (yyvsp[-2].nd), (yyvsp[-1].nd));
@@ -8036,451 +8476,451 @@ yyreduce:
                       p->in_def--;
                       p->in_single--;
                     }
-#line 8040 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8480 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 333:
-#line 2798 "mrbgems/mruby-compiler/core/parse.y"
+  case 333: /* primary: keyword_break  */
+#line 2847 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_break(p, 0);
                     }
-#line 8048 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8488 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 334:
-#line 2802 "mrbgems/mruby-compiler/core/parse.y"
+  case 334: /* primary: keyword_next  */
+#line 2851 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_next(p, 0);
                     }
-#line 8056 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8496 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 335:
-#line 2806 "mrbgems/mruby-compiler/core/parse.y"
+  case 335: /* primary: keyword_redo  */
+#line 2855 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_redo(p);
                     }
-#line 8064 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8504 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 336:
-#line 2810 "mrbgems/mruby-compiler/core/parse.y"
+  case 336: /* primary: keyword_retry  */
+#line 2859 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_retry(p);
                     }
-#line 8072 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8512 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 337:
-#line 2816 "mrbgems/mruby-compiler/core/parse.y"
+  case 337: /* primary_value: primary  */
+#line 2865 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[0].nd);
                       if (!(yyval.nd)) (yyval.nd) = new_nil(p);
                     }
-#line 8081 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8521 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 344:
-#line 2835 "mrbgems/mruby-compiler/core/parse.y"
+  case 344: /* if_tail: keyword_elsif expr_value then compstmt if_tail  */
+#line 2884 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_if(p, cond((yyvsp[-3].nd)), (yyvsp[-1].nd), (yyvsp[0].nd));
                     }
-#line 8089 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8529 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 346:
-#line 2842 "mrbgems/mruby-compiler/core/parse.y"
+  case 346: /* opt_else: keyword_else compstmt  */
+#line 2891 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[0].nd);
                     }
-#line 8097 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8537 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 347:
-#line 2848 "mrbgems/mruby-compiler/core/parse.y"
+  case 347: /* for_var: lhs  */
+#line 2897 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list1(list1((yyvsp[0].nd)));
                     }
-#line 8105 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8545 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 349:
-#line 2855 "mrbgems/mruby-compiler/core/parse.y"
+  case 349: /* f_margs: f_arg  */
+#line 2904 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list3((yyvsp[0].nd),0,0);
                     }
-#line 8113 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8553 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 350:
-#line 2859 "mrbgems/mruby-compiler/core/parse.y"
+  case 350: /* f_margs: f_arg ',' tSTAR f_norm_arg  */
+#line 2908 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list3((yyvsp[-3].nd), new_arg(p, (yyvsp[0].id)), 0);
                     }
-#line 8121 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8561 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 351:
-#line 2863 "mrbgems/mruby-compiler/core/parse.y"
+  case 351: /* f_margs: f_arg ',' tSTAR f_norm_arg ',' f_arg  */
+#line 2912 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list3((yyvsp[-5].nd), new_arg(p, (yyvsp[-2].id)), (yyvsp[0].nd));
                     }
-#line 8129 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8569 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 352:
-#line 2867 "mrbgems/mruby-compiler/core/parse.y"
+  case 352: /* f_margs: f_arg ',' tSTAR  */
+#line 2916 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       local_add_f(p, 0);
                       (yyval.nd) = list3((yyvsp[-2].nd), (node*)-1, 0);
                     }
-#line 8138 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8578 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 353:
-#line 2872 "mrbgems/mruby-compiler/core/parse.y"
+  case 353: /* f_margs: f_arg ',' tSTAR ',' f_arg  */
+#line 2921 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list3((yyvsp[-4].nd), (node*)-1, (yyvsp[0].nd));
                     }
-#line 8146 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8586 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 354:
-#line 2876 "mrbgems/mruby-compiler/core/parse.y"
+  case 354: /* f_margs: tSTAR f_norm_arg  */
+#line 2925 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list3(0, new_arg(p, (yyvsp[0].id)), 0);
                     }
-#line 8154 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8594 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 355:
-#line 2880 "mrbgems/mruby-compiler/core/parse.y"
+  case 355: /* f_margs: tSTAR f_norm_arg ',' f_arg  */
+#line 2929 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list3(0, new_arg(p, (yyvsp[-2].id)), (yyvsp[0].nd));
                     }
-#line 8162 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8602 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 356:
-#line 2884 "mrbgems/mruby-compiler/core/parse.y"
+  case 356: /* f_margs: tSTAR  */
+#line 2933 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       local_add_f(p, 0);
                       (yyval.nd) = list3(0, (node*)-1, 0);
                     }
-#line 8171 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8611 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 357:
-#line 2889 "mrbgems/mruby-compiler/core/parse.y"
+  case 357: /* $@24: %empty  */
+#line 2938 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       local_add_f(p, 0);
                     }
-#line 8179 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8619 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 358:
-#line 2893 "mrbgems/mruby-compiler/core/parse.y"
+  case 358: /* f_margs: tSTAR ',' $@24 f_arg  */
+#line 2942 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list3(0, (node*)-1, (yyvsp[0].nd));
                     }
-#line 8187 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8627 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 359:
-#line 2899 "mrbgems/mruby-compiler/core/parse.y"
+  case 359: /* block_args_tail: f_block_kwarg ',' f_kwrest opt_f_block_arg  */
+#line 2948 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args_tail(p, (yyvsp[-3].nd), (yyvsp[-1].nd), (yyvsp[0].id));
                     }
-#line 8195 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8635 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 360:
-#line 2903 "mrbgems/mruby-compiler/core/parse.y"
+  case 360: /* block_args_tail: f_block_kwarg opt_f_block_arg  */
+#line 2952 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args_tail(p, (yyvsp[-1].nd), 0, (yyvsp[0].id));
                     }
-#line 8203 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8643 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 361:
-#line 2907 "mrbgems/mruby-compiler/core/parse.y"
+  case 361: /* block_args_tail: f_kwrest opt_f_block_arg  */
+#line 2956 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args_tail(p, 0, (yyvsp[-1].nd), (yyvsp[0].id));
                     }
-#line 8211 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8651 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 362:
-#line 2911 "mrbgems/mruby-compiler/core/parse.y"
+  case 362: /* block_args_tail: f_block_arg  */
+#line 2960 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args_tail(p, 0, 0, (yyvsp[0].id));
                     }
-#line 8219 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8659 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 363:
-#line 2917 "mrbgems/mruby-compiler/core/parse.y"
+  case 363: /* opt_block_args_tail: ',' block_args_tail  */
+#line 2966 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[0].nd);
                     }
-#line 8227 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8667 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 364:
-#line 2921 "mrbgems/mruby-compiler/core/parse.y"
+  case 364: /* opt_block_args_tail: %empty  */
+#line 2970 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args_tail(p, 0, 0, 0);
                     }
-#line 8235 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8675 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 365:
-#line 2927 "mrbgems/mruby-compiler/core/parse.y"
+  case 365: /* block_param: f_arg ',' f_block_optarg ',' f_rest_arg opt_block_args_tail  */
+#line 2976 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, (yyvsp[-5].nd), (yyvsp[-3].nd), (yyvsp[-1].id), 0, (yyvsp[0].nd));
                     }
-#line 8243 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8683 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 366:
-#line 2931 "mrbgems/mruby-compiler/core/parse.y"
+  case 366: /* block_param: f_arg ',' f_block_optarg ',' f_rest_arg ',' f_arg opt_block_args_tail  */
+#line 2980 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, (yyvsp[-7].nd), (yyvsp[-5].nd), (yyvsp[-3].id), (yyvsp[-1].nd), (yyvsp[0].nd));
                     }
-#line 8251 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8691 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 367:
-#line 2935 "mrbgems/mruby-compiler/core/parse.y"
+  case 367: /* block_param: f_arg ',' f_block_optarg opt_block_args_tail  */
+#line 2984 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, (yyvsp[-3].nd), (yyvsp[-1].nd), 0, 0, (yyvsp[0].nd));
                     }
-#line 8259 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8699 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 368:
-#line 2939 "mrbgems/mruby-compiler/core/parse.y"
+  case 368: /* block_param: f_arg ',' f_block_optarg ',' f_arg opt_block_args_tail  */
+#line 2988 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, (yyvsp[-5].nd), (yyvsp[-3].nd), 0, (yyvsp[-1].nd), (yyvsp[0].nd));
                     }
-#line 8267 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8707 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 369:
-#line 2943 "mrbgems/mruby-compiler/core/parse.y"
+  case 369: /* block_param: f_arg ',' f_rest_arg opt_block_args_tail  */
+#line 2992 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, (yyvsp[-3].nd), 0, (yyvsp[-1].id), 0, (yyvsp[0].nd));
                     }
-#line 8275 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8715 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 370:
-#line 2947 "mrbgems/mruby-compiler/core/parse.y"
+  case 370: /* block_param: f_arg ',' opt_block_args_tail  */
+#line 2996 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, (yyvsp[-2].nd), 0, 0, 0, (yyvsp[0].nd));
                     }
-#line 8283 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8723 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 371:
-#line 2951 "mrbgems/mruby-compiler/core/parse.y"
+  case 371: /* block_param: f_arg ',' f_rest_arg ',' f_arg opt_block_args_tail  */
+#line 3000 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, (yyvsp[-5].nd), 0, (yyvsp[-3].id), (yyvsp[-1].nd), (yyvsp[0].nd));
                     }
-#line 8291 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8731 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 372:
-#line 2955 "mrbgems/mruby-compiler/core/parse.y"
+  case 372: /* block_param: f_arg opt_block_args_tail  */
+#line 3004 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, (yyvsp[-1].nd), 0, 0, 0, (yyvsp[0].nd));
                     }
-#line 8299 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8739 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 373:
-#line 2959 "mrbgems/mruby-compiler/core/parse.y"
+  case 373: /* block_param: f_block_optarg ',' f_rest_arg opt_block_args_tail  */
+#line 3008 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, 0, (yyvsp[-3].nd), (yyvsp[-1].id), 0, (yyvsp[0].nd));
                     }
-#line 8307 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8747 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 374:
-#line 2963 "mrbgems/mruby-compiler/core/parse.y"
+  case 374: /* block_param: f_block_optarg ',' f_rest_arg ',' f_arg opt_block_args_tail  */
+#line 3012 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, 0, (yyvsp[-5].nd), (yyvsp[-3].id), (yyvsp[-1].nd), (yyvsp[0].nd));
                     }
-#line 8315 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8755 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 375:
-#line 2967 "mrbgems/mruby-compiler/core/parse.y"
+  case 375: /* block_param: f_block_optarg opt_block_args_tail  */
+#line 3016 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, 0, (yyvsp[-1].nd), 0, 0, (yyvsp[0].nd));
                     }
-#line 8323 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8763 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 376:
-#line 2971 "mrbgems/mruby-compiler/core/parse.y"
+  case 376: /* block_param: f_block_optarg ',' f_arg opt_block_args_tail  */
+#line 3020 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, 0, (yyvsp[-3].nd), 0, (yyvsp[-1].nd), (yyvsp[0].nd));
                     }
-#line 8331 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8771 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 377:
-#line 2975 "mrbgems/mruby-compiler/core/parse.y"
+  case 377: /* block_param: f_rest_arg opt_block_args_tail  */
+#line 3024 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, 0, 0, (yyvsp[-1].id), 0, (yyvsp[0].nd));
                     }
-#line 8339 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8779 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 378:
-#line 2979 "mrbgems/mruby-compiler/core/parse.y"
+  case 378: /* block_param: f_rest_arg ',' f_arg opt_block_args_tail  */
+#line 3028 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, 0, 0, (yyvsp[-3].id), (yyvsp[-1].nd), (yyvsp[0].nd));
                     }
-#line 8347 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8787 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 379:
-#line 2983 "mrbgems/mruby-compiler/core/parse.y"
+  case 379: /* block_param: block_args_tail  */
+#line 3032 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, 0, 0, 0, 0, (yyvsp[0].nd));
                     }
-#line 8355 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8795 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 380:
-#line 2989 "mrbgems/mruby-compiler/core/parse.y"
+  case 380: /* opt_block_param: none  */
+#line 3038 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       local_add_blk(p, 0);
                       (yyval.nd) = 0;
                     }
-#line 8364 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8804 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 381:
-#line 2994 "mrbgems/mruby-compiler/core/parse.y"
+  case 381: /* opt_block_param: block_param_def  */
+#line 3043 "mrbgems/mruby-compiler/core/parse.y"
                    {
                       p->cmd_start = TRUE;
                       (yyval.nd) = (yyvsp[0].nd);
                     }
-#line 8373 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8813 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 382:
-#line 3000 "mrbgems/mruby-compiler/core/parse.y"
+  case 382: /* $@25: %empty  */
+#line 3049 "mrbgems/mruby-compiler/core/parse.y"
                       {local_add_blk(p, 0);}
-#line 8379 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8819 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 383:
-#line 3001 "mrbgems/mruby-compiler/core/parse.y"
+  case 383: /* block_param_def: '|' $@25 opt_bv_decl '|'  */
+#line 3050 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = 0;
                     }
-#line 8387 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8827 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 384:
-#line 3005 "mrbgems/mruby-compiler/core/parse.y"
+  case 384: /* block_param_def: tOROP  */
+#line 3054 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       local_add_blk(p, 0);
                       (yyval.nd) = 0;
                     }
-#line 8396 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8836 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 385:
-#line 3010 "mrbgems/mruby-compiler/core/parse.y"
+  case 385: /* block_param_def: '|' block_param opt_bv_decl '|'  */
+#line 3059 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[-2].nd);
                     }
-#line 8404 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8844 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 386:
-#line 3017 "mrbgems/mruby-compiler/core/parse.y"
+  case 386: /* opt_bv_decl: opt_nl  */
+#line 3066 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = 0;
                     }
-#line 8412 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8852 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 387:
-#line 3021 "mrbgems/mruby-compiler/core/parse.y"
+  case 387: /* opt_bv_decl: opt_nl ';' bv_decls opt_nl  */
+#line 3070 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = 0;
                     }
-#line 8420 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8860 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 390:
-#line 3031 "mrbgems/mruby-compiler/core/parse.y"
+  case 390: /* bvar: tIDENTIFIER  */
+#line 3080 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       local_add_f(p, (yyvsp[0].id));
                       new_bv(p, (yyvsp[0].id));
                     }
-#line 8429 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8869 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 392:
-#line 3039 "mrbgems/mruby-compiler/core/parse.y"
+  case 392: /* f_larglist: '(' f_args opt_bv_decl ')'  */
+#line 3088 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[-2].nd);
                     }
-#line 8437 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8877 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 393:
-#line 3043 "mrbgems/mruby-compiler/core/parse.y"
+  case 393: /* f_larglist: f_args  */
+#line 3092 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[0].nd);
                     }
-#line 8445 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8885 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 394:
-#line 3049 "mrbgems/mruby-compiler/core/parse.y"
+  case 394: /* lambda_body: tLAMBEG compstmt '}'  */
+#line 3098 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[-1].nd);
                     }
-#line 8453 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8893 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 395:
-#line 3053 "mrbgems/mruby-compiler/core/parse.y"
+  case 395: /* lambda_body: keyword_do_LAMBDA bodystmt keyword_end  */
+#line 3102 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[-1].nd);
                     }
-#line 8461 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8901 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 396:
-#line 3059 "mrbgems/mruby-compiler/core/parse.y"
+  case 396: /* $@26: %empty  */
+#line 3108 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       local_nest(p);
                       nvars_nest(p);
                     }
-#line 8470 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8910 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 397:
-#line 3066 "mrbgems/mruby-compiler/core/parse.y"
+  case 397: /* do_block: keyword_do_block $@26 opt_block_param bodystmt keyword_end  */
+#line 3115 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_block(p,(yyvsp[-2].nd),(yyvsp[-1].nd));
                       local_unnest(p);
                       nvars_unnest(p);
                     }
-#line 8480 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8920 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 398:
-#line 3074 "mrbgems/mruby-compiler/core/parse.y"
+  case 398: /* block_call: command do_block  */
+#line 3123 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       if ((yyvsp[-1].nd)->car == (node*)NODE_YIELD) {
                         yyerror(p, "block given to yield");
@@ -8490,159 +8930,159 @@ yyreduce:
                       }
                       (yyval.nd) = (yyvsp[-1].nd);
                     }
-#line 8494 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8934 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 399:
-#line 3084 "mrbgems/mruby-compiler/core/parse.y"
+  case 399: /* block_call: block_call call_op2 operation2 opt_paren_args  */
+#line 3133 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_call(p, (yyvsp[-3].nd), (yyvsp[-1].id), (yyvsp[0].nd), (yyvsp[-2].num));
                     }
-#line 8502 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8942 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 400:
-#line 3088 "mrbgems/mruby-compiler/core/parse.y"
+  case 400: /* block_call: block_call call_op2 operation2 opt_paren_args brace_block  */
+#line 3137 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_call(p, (yyvsp[-4].nd), (yyvsp[-2].id), (yyvsp[-1].nd), (yyvsp[-3].num));
                       call_with_block(p, (yyval.nd), (yyvsp[0].nd));
                     }
-#line 8511 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8951 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 401:
-#line 3093 "mrbgems/mruby-compiler/core/parse.y"
+  case 401: /* block_call: block_call call_op2 operation2 command_args do_block  */
+#line 3142 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_call(p, (yyvsp[-4].nd), (yyvsp[-2].id), (yyvsp[-1].nd), (yyvsp[-3].num));
                       call_with_block(p, (yyval.nd), (yyvsp[0].nd));
                     }
-#line 8520 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8960 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 402:
-#line 3100 "mrbgems/mruby-compiler/core/parse.y"
+  case 402: /* method_call: operation paren_args  */
+#line 3149 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_fcall(p, (yyvsp[-1].id), (yyvsp[0].nd));
                     }
-#line 8528 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8968 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 403:
-#line 3104 "mrbgems/mruby-compiler/core/parse.y"
+  case 403: /* method_call: primary_value call_op operation2 opt_paren_args  */
+#line 3153 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_call(p, (yyvsp[-3].nd), (yyvsp[-1].id), (yyvsp[0].nd), (yyvsp[-2].num));
                     }
-#line 8536 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8976 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 404:
-#line 3108 "mrbgems/mruby-compiler/core/parse.y"
+  case 404: /* method_call: primary_value tCOLON2 operation2 paren_args  */
+#line 3157 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_call(p, (yyvsp[-3].nd), (yyvsp[-1].id), (yyvsp[0].nd), tCOLON2);
                     }
-#line 8544 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8984 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 405:
-#line 3112 "mrbgems/mruby-compiler/core/parse.y"
+  case 405: /* method_call: primary_value tCOLON2 operation3  */
+#line 3161 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_call(p, (yyvsp[-2].nd), (yyvsp[0].id), 0, tCOLON2);
                     }
-#line 8552 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8992 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 406:
-#line 3116 "mrbgems/mruby-compiler/core/parse.y"
+  case 406: /* method_call: primary_value call_op paren_args  */
+#line 3165 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_call(p, (yyvsp[-2].nd), MRB_SYM(call), (yyvsp[0].nd), (yyvsp[-1].num));
                     }
-#line 8560 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9000 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 407:
-#line 3120 "mrbgems/mruby-compiler/core/parse.y"
+  case 407: /* method_call: primary_value tCOLON2 paren_args  */
+#line 3169 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_call(p, (yyvsp[-2].nd), MRB_SYM(call), (yyvsp[0].nd), tCOLON2);
                     }
-#line 8568 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9008 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 408:
-#line 3124 "mrbgems/mruby-compiler/core/parse.y"
+  case 408: /* method_call: keyword_super paren_args  */
+#line 3173 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_super(p, (yyvsp[0].nd));
                     }
-#line 8576 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9016 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 409:
-#line 3128 "mrbgems/mruby-compiler/core/parse.y"
+  case 409: /* method_call: keyword_super  */
+#line 3177 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_zsuper(p);
                     }
-#line 8584 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9024 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 410:
-#line 3132 "mrbgems/mruby-compiler/core/parse.y"
+  case 410: /* method_call: primary_value '[' opt_call_args ']'  */
+#line 3181 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_call(p, (yyvsp[-3].nd), MRB_OPSYM(aref), (yyvsp[-1].nd), '.');
                     }
-#line 8592 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9032 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 411:
-#line 3138 "mrbgems/mruby-compiler/core/parse.y"
+  case 411: /* @27: %empty  */
+#line 3187 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       local_nest(p);
                       nvars_nest(p);
                       (yyval.num) = p->lineno;
                     }
-#line 8602 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9042 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 412:
-#line 3145 "mrbgems/mruby-compiler/core/parse.y"
+  case 412: /* brace_block: '{' @27 opt_block_param compstmt '}'  */
+#line 3194 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_block(p,(yyvsp[-2].nd),(yyvsp[-1].nd));
                       SET_LINENO((yyval.nd), (yyvsp[-3].num));
                       local_unnest(p);
                       nvars_unnest(p);
                     }
-#line 8613 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9053 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 413:
-#line 3152 "mrbgems/mruby-compiler/core/parse.y"
+  case 413: /* @28: %empty  */
+#line 3201 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       local_nest(p);
                       nvars_nest(p);
                       (yyval.num) = p->lineno;
                     }
-#line 8623 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9063 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 414:
-#line 3159 "mrbgems/mruby-compiler/core/parse.y"
+  case 414: /* brace_block: keyword_do @28 opt_block_param bodystmt keyword_end  */
+#line 3208 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_block(p,(yyvsp[-2].nd),(yyvsp[-1].nd));
                       SET_LINENO((yyval.nd), (yyvsp[-3].num));
                       local_unnest(p);
                       nvars_unnest(p);
                     }
-#line 8634 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9074 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 415:
-#line 3170 "mrbgems/mruby-compiler/core/parse.y"
+  case 415: /* case_body: keyword_when args then compstmt cases  */
+#line 3219 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = cons(cons((yyvsp[-3].nd), (yyvsp[-1].nd)), (yyvsp[0].nd));
                     }
-#line 8642 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9082 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 416:
-#line 3176 "mrbgems/mruby-compiler/core/parse.y"
+  case 416: /* cases: opt_else  */
+#line 3225 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       if ((yyvsp[0].nd)) {
                         (yyval.nd) = cons(cons(0, (yyvsp[0].nd)), 0);
@@ -8651,383 +9091,383 @@ yyreduce:
                         (yyval.nd) = 0;
                       }
                     }
-#line 8655 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9095 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 418:
-#line 3190 "mrbgems/mruby-compiler/core/parse.y"
+  case 418: /* opt_rescue: keyword_rescue exc_list exc_var then compstmt opt_rescue  */
+#line 3239 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list1(list3((yyvsp[-4].nd), (yyvsp[-3].nd), (yyvsp[-1].nd)));
                       if ((yyvsp[0].nd)) (yyval.nd) = append((yyval.nd), (yyvsp[0].nd));
                     }
-#line 8664 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9104 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 420:
-#line 3198 "mrbgems/mruby-compiler/core/parse.y"
+  case 420: /* exc_list: arg  */
+#line 3247 "mrbgems/mruby-compiler/core/parse.y"
                     {
                         (yyval.nd) = list1((yyvsp[0].nd));
                     }
-#line 8672 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9112 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 423:
-#line 3206 "mrbgems/mruby-compiler/core/parse.y"
+  case 423: /* exc_var: tASSOC lhs  */
+#line 3255 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[0].nd);
                     }
-#line 8680 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9120 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 425:
-#line 3213 "mrbgems/mruby-compiler/core/parse.y"
+  case 425: /* opt_ensure: keyword_ensure compstmt  */
+#line 3262 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[0].nd);
                     }
-#line 8688 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9128 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 432:
-#line 3227 "mrbgems/mruby-compiler/core/parse.y"
+  case 432: /* string: string string_fragment  */
+#line 3276 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = concat_string(p, (yyvsp[-1].nd), (yyvsp[0].nd));
                     }
-#line 8696 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9136 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 435:
-#line 3235 "mrbgems/mruby-compiler/core/parse.y"
+  case 435: /* string_fragment: tSTRING_BEG tSTRING  */
+#line 3284 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[0].nd);
                     }
-#line 8704 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9144 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 436:
-#line 3239 "mrbgems/mruby-compiler/core/parse.y"
+  case 436: /* string_fragment: tSTRING_BEG string_rep tSTRING  */
+#line 3288 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_dstr(p, push((yyvsp[-1].nd), (yyvsp[0].nd)));
                     }
-#line 8712 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9152 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 438:
-#line 3246 "mrbgems/mruby-compiler/core/parse.y"
+  case 438: /* string_rep: string_rep string_interp  */
+#line 3295 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = append((yyvsp[-1].nd), (yyvsp[0].nd));
                     }
-#line 8720 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9160 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 439:
-#line 3252 "mrbgems/mruby-compiler/core/parse.y"
+  case 439: /* string_interp: tSTRING_MID  */
+#line 3301 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list1((yyvsp[0].nd));
                     }
-#line 8728 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9168 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 440:
-#line 3256 "mrbgems/mruby-compiler/core/parse.y"
+  case 440: /* @29: %empty  */
+#line 3305 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = p->lex_strterm;
                       p->lex_strterm = NULL;
                     }
-#line 8737 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9177 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 441:
-#line 3262 "mrbgems/mruby-compiler/core/parse.y"
+  case 441: /* string_interp: tSTRING_PART @29 compstmt '}'  */
+#line 3311 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       p->lex_strterm = (yyvsp[-2].nd);
                       (yyval.nd) = list2((yyvsp[-3].nd), (yyvsp[-1].nd));
                     }
-#line 8746 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9186 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 442:
-#line 3267 "mrbgems/mruby-compiler/core/parse.y"
+  case 442: /* string_interp: tLITERAL_DELIM  */
+#line 3316 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list1(new_literal_delim(p));
                     }
-#line 8754 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9194 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 443:
-#line 3271 "mrbgems/mruby-compiler/core/parse.y"
+  case 443: /* string_interp: tHD_LITERAL_DELIM heredoc_bodies  */
+#line 3320 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list1(new_literal_delim(p));
                     }
-#line 8762 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9202 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 444:
-#line 3277 "mrbgems/mruby-compiler/core/parse.y"
+  case 444: /* xstring: tXSTRING_BEG tXSTRING  */
+#line 3326 "mrbgems/mruby-compiler/core/parse.y"
                     {
                         (yyval.nd) = (yyvsp[0].nd);
                     }
-#line 8770 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9210 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 445:
-#line 3281 "mrbgems/mruby-compiler/core/parse.y"
+  case 445: /* xstring: tXSTRING_BEG string_rep tXSTRING  */
+#line 3330 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_dxstr(p, push((yyvsp[-1].nd), (yyvsp[0].nd)));
                     }
-#line 8778 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9218 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 446:
-#line 3287 "mrbgems/mruby-compiler/core/parse.y"
+  case 446: /* regexp: tREGEXP_BEG tREGEXP  */
+#line 3336 "mrbgems/mruby-compiler/core/parse.y"
                     {
                         (yyval.nd) = (yyvsp[0].nd);
                     }
-#line 8786 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9226 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 447:
-#line 3291 "mrbgems/mruby-compiler/core/parse.y"
+  case 447: /* regexp: tREGEXP_BEG string_rep tREGEXP  */
+#line 3340 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_dregx(p, (yyvsp[-1].nd), (yyvsp[0].nd));
                     }
-#line 8794 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9234 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 451:
-#line 3304 "mrbgems/mruby-compiler/core/parse.y"
+  case 451: /* heredoc_body: tHEREDOC_END  */
+#line 3353 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       parser_heredoc_info * inf = parsing_heredoc_inf(p);
                       inf->doc = push(inf->doc, new_str(p, "", 0));
                       heredoc_end(p);
                     }
-#line 8804 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9244 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 452:
-#line 3310 "mrbgems/mruby-compiler/core/parse.y"
+  case 452: /* heredoc_body: heredoc_string_rep tHEREDOC_END  */
+#line 3359 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       heredoc_end(p);
                     }
-#line 8812 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9252 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 455:
-#line 3320 "mrbgems/mruby-compiler/core/parse.y"
+  case 455: /* heredoc_string_interp: tHD_STRING_MID  */
+#line 3369 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       parser_heredoc_info * inf = parsing_heredoc_inf(p);
                       inf->doc = push(inf->doc, (yyvsp[0].nd));
                       heredoc_treat_nextline(p);
                     }
-#line 8822 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9262 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 456:
-#line 3326 "mrbgems/mruby-compiler/core/parse.y"
+  case 456: /* @30: %empty  */
+#line 3375 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = p->lex_strterm;
                       p->lex_strterm = NULL;
                     }
-#line 8831 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9271 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 457:
-#line 3332 "mrbgems/mruby-compiler/core/parse.y"
+  case 457: /* heredoc_string_interp: tHD_STRING_PART @30 compstmt '}'  */
+#line 3381 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       parser_heredoc_info * inf = parsing_heredoc_inf(p);
                       p->lex_strterm = (yyvsp[-2].nd);
                       inf->doc = push(push(inf->doc, (yyvsp[-3].nd)), (yyvsp[-1].nd));
                     }
-#line 8841 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9281 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 458:
-#line 3340 "mrbgems/mruby-compiler/core/parse.y"
+  case 458: /* words: tWORDS_BEG tSTRING  */
+#line 3389 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_words(p, list1((yyvsp[0].nd)));
                     }
-#line 8849 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9289 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 459:
-#line 3344 "mrbgems/mruby-compiler/core/parse.y"
+  case 459: /* words: tWORDS_BEG string_rep tSTRING  */
+#line 3393 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_words(p, push((yyvsp[-1].nd), (yyvsp[0].nd)));
                     }
-#line 8857 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9297 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 460:
-#line 3351 "mrbgems/mruby-compiler/core/parse.y"
+  case 460: /* symbol: basic_symbol  */
+#line 3400 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       p->lstate = EXPR_ENDARG;
                       (yyval.nd) = new_sym(p, (yyvsp[0].id));
                     }
-#line 8866 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9306 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 461:
-#line 3356 "mrbgems/mruby-compiler/core/parse.y"
+  case 461: /* symbol: tSYMBEG tSTRING_BEG string_rep tSTRING  */
+#line 3405 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       p->lstate = EXPR_ENDARG;
                       (yyval.nd) = new_dsym(p, new_dstr(p, push((yyvsp[-1].nd), (yyvsp[0].nd))));
                     }
-#line 8875 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9315 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 462:
-#line 3363 "mrbgems/mruby-compiler/core/parse.y"
+  case 462: /* basic_symbol: tSYMBEG sym  */
+#line 3412 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.id) = (yyvsp[0].id);
                     }
-#line 8883 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9323 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 467:
-#line 3373 "mrbgems/mruby-compiler/core/parse.y"
+  case 467: /* sym: tSTRING  */
+#line 3422 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.id) = new_strsym(p, (yyvsp[0].nd));
                     }
-#line 8891 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9331 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 468:
-#line 3377 "mrbgems/mruby-compiler/core/parse.y"
+  case 468: /* sym: tSTRING_BEG tSTRING  */
+#line 3426 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.id) = new_strsym(p, (yyvsp[0].nd));
                     }
-#line 8899 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9339 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 469:
-#line 3383 "mrbgems/mruby-compiler/core/parse.y"
+  case 469: /* symbols: tSYMBOLS_BEG tSTRING  */
+#line 3432 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_symbols(p, list1((yyvsp[0].nd)));
                     }
-#line 8907 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9347 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 470:
-#line 3387 "mrbgems/mruby-compiler/core/parse.y"
+  case 470: /* symbols: tSYMBOLS_BEG string_rep tSTRING  */
+#line 3436 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_symbols(p, push((yyvsp[-1].nd), (yyvsp[0].nd)));
                     }
-#line 8915 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9355 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 473:
-#line 3395 "mrbgems/mruby-compiler/core/parse.y"
+  case 473: /* numeric: tUMINUS_NUM tINTEGER  */
+#line 3444 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = negate_lit(p, (yyvsp[0].nd));
                     }
-#line 8923 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9363 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 474:
-#line 3399 "mrbgems/mruby-compiler/core/parse.y"
+  case 474: /* numeric: tUMINUS_NUM tFLOAT  */
+#line 3448 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = negate_lit(p, (yyvsp[0].nd));
                     }
-#line 8931 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9371 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 475:
-#line 3405 "mrbgems/mruby-compiler/core/parse.y"
+  case 475: /* variable: tIDENTIFIER  */
+#line 3454 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_lvar(p, (yyvsp[0].id));
                     }
-#line 8939 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9379 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 476:
-#line 3409 "mrbgems/mruby-compiler/core/parse.y"
+  case 476: /* variable: tIVAR  */
+#line 3458 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_ivar(p, (yyvsp[0].id));
                     }
-#line 8947 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9387 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 477:
-#line 3413 "mrbgems/mruby-compiler/core/parse.y"
+  case 477: /* variable: tGVAR  */
+#line 3462 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_gvar(p, (yyvsp[0].id));
                     }
-#line 8955 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9395 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 478:
-#line 3417 "mrbgems/mruby-compiler/core/parse.y"
+  case 478: /* variable: tCVAR  */
+#line 3466 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_cvar(p, (yyvsp[0].id));
                     }
-#line 8963 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9403 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 479:
-#line 3421 "mrbgems/mruby-compiler/core/parse.y"
+  case 479: /* variable: tCONSTANT  */
+#line 3470 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_const(p, (yyvsp[0].id));
                     }
-#line 8971 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9411 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 480:
-#line 3427 "mrbgems/mruby-compiler/core/parse.y"
+  case 480: /* var_lhs: variable  */
+#line 3476 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       assignable(p, (yyvsp[0].nd));
                     }
-#line 8979 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9419 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 481:
-#line 3431 "mrbgems/mruby-compiler/core/parse.y"
+  case 481: /* var_lhs: tNUMPARAM  */
+#line 3480 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       yyerror(p, "can't assign to numbered parameter");
                     }
-#line 8987 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9427 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 482:
-#line 3437 "mrbgems/mruby-compiler/core/parse.y"
+  case 482: /* var_ref: variable  */
+#line 3486 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = var_reference(p, (yyvsp[0].nd));
                     }
-#line 8995 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9435 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 483:
-#line 3441 "mrbgems/mruby-compiler/core/parse.y"
+  case 483: /* var_ref: keyword_nil  */
+#line 3490 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_nil(p);
                     }
-#line 9003 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9443 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 484:
-#line 3445 "mrbgems/mruby-compiler/core/parse.y"
+  case 484: /* var_ref: keyword_self  */
+#line 3494 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_self(p);
                     }
-#line 9011 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9451 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 485:
-#line 3449 "mrbgems/mruby-compiler/core/parse.y"
+  case 485: /* var_ref: keyword_true  */
+#line 3498 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_true(p);
                     }
-#line 9019 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9459 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 486:
-#line 3453 "mrbgems/mruby-compiler/core/parse.y"
+  case 486: /* var_ref: keyword_false  */
+#line 3502 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_false(p);
                     }
-#line 9027 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9467 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 487:
-#line 3457 "mrbgems/mruby-compiler/core/parse.y"
+  case 487: /* var_ref: keyword__FILE__  */
+#line 3506 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       const char *fn = mrb_sym_name_len(p->mrb, p->filename_sym, NULL);
                       if (!fn) {
@@ -9035,22 +9475,22 @@ yyreduce:
                       }
                       (yyval.nd) = new_str(p, fn, strlen(fn));
                     }
-#line 9039 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9479 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 488:
-#line 3465 "mrbgems/mruby-compiler/core/parse.y"
+  case 488: /* var_ref: keyword__LINE__  */
+#line 3514 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       char buf[16];
 
                       dump_int(p->lineno, buf);
                       (yyval.nd) = new_int(p, buf, 10, 0);
                     }
-#line 9050 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9490 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 489:
-#line 3472 "mrbgems/mruby-compiler/core/parse.y"
+  case 489: /* var_ref: keyword__ENCODING__  */
+#line 3521 "mrbgems/mruby-compiler/core/parse.y"
                     {
 #ifdef MRB_UTF8_STRING
                       const char *enc = "UTF-8";
@@ -9059,46 +9499,46 @@ yyreduce:
 #endif
                       (yyval.nd) = new_str(p, enc, strlen(enc));
                     }
-#line 9063 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9503 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 492:
-#line 3487 "mrbgems/mruby-compiler/core/parse.y"
+  case 492: /* superclass: %empty  */
+#line 3536 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = 0;
                     }
-#line 9071 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9511 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 493:
-#line 3491 "mrbgems/mruby-compiler/core/parse.y"
+  case 493: /* $@31: %empty  */
+#line 3540 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       p->lstate = EXPR_BEG;
                       p->cmd_start = TRUE;
                     }
-#line 9080 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9520 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 494:
-#line 3496 "mrbgems/mruby-compiler/core/parse.y"
+  case 494: /* superclass: '<' $@31 expr_value term  */
+#line 3545 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[-1].nd);
                     }
-#line 9088 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9528 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 495:
-#line 3507 "mrbgems/mruby-compiler/core/parse.y"
+  case 495: /* f_arglist_paren: '(' f_args rparen  */
+#line 3556 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[-1].nd);
                       p->lstate = EXPR_BEG;
                       p->cmd_start = TRUE;
                     }
-#line 9098 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9538 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 496:
-#line 3513 "mrbgems/mruby-compiler/core/parse.y"
+  case 496: /* f_arglist_paren: '(' f_arg ',' tBDOT3 rparen  */
+#line 3562 "mrbgems/mruby-compiler/core/parse.y"
                     {
 #if 1
                       /* til real keyword args implemented */
@@ -9116,11 +9556,11 @@ yyreduce:
                                     new_args_tail(p, 0, new_kw_rest_args(p, nsym(k)), b));
 #endif
                     }
-#line 9120 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9560 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 497:
-#line 3531 "mrbgems/mruby-compiler/core/parse.y"
+  case 497: /* f_arglist_paren: '(' tBDOT3 rparen  */
+#line 3580 "mrbgems/mruby-compiler/core/parse.y"
                     {
 #if 1
                       /* til real keyword args implemented */
@@ -9138,504 +9578,504 @@ yyreduce:
                                     new_args_tail(p, 0, new_kw_rest_args(p, nsym(k)), b));
 #endif
                     }
-#line 9142 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9582 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 499:
-#line 3552 "mrbgems/mruby-compiler/core/parse.y"
+  case 499: /* f_arglist: f_args term  */
+#line 3601 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[-1].nd);
                     }
-#line 9150 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9590 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 500:
-#line 3558 "mrbgems/mruby-compiler/core/parse.y"
+  case 500: /* f_label: tIDENTIFIER tLABEL_TAG  */
+#line 3607 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       local_nest(p);
                     }
-#line 9158 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9598 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 501:
-#line 3564 "mrbgems/mruby-compiler/core/parse.y"
+  case 501: /* f_kw: f_label arg  */
+#line 3613 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       void_expr_error(p, (yyvsp[0].nd));
                       (yyval.nd) = new_kw_arg(p, (yyvsp[-1].id), cons((yyvsp[0].nd), locals_node(p)));
                       local_unnest(p);
                     }
-#line 9168 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9608 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 502:
-#line 3570 "mrbgems/mruby-compiler/core/parse.y"
+  case 502: /* f_kw: f_label  */
+#line 3619 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_kw_arg(p, (yyvsp[0].id), 0);
                       local_unnest(p);
                     }
-#line 9177 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9617 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 503:
-#line 3577 "mrbgems/mruby-compiler/core/parse.y"
+  case 503: /* f_block_kw: f_label primary_value  */
+#line 3626 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_kw_arg(p, (yyvsp[-1].id), cons((yyvsp[0].nd), locals_node(p)));
                       local_unnest(p);
                     }
-#line 9186 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9626 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 504:
-#line 3582 "mrbgems/mruby-compiler/core/parse.y"
+  case 504: /* f_block_kw: f_label  */
+#line 3631 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_kw_arg(p, (yyvsp[0].id), 0);
                       local_unnest(p);
                     }
-#line 9195 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9635 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 505:
-#line 3589 "mrbgems/mruby-compiler/core/parse.y"
+  case 505: /* f_block_kwarg: f_block_kw  */
+#line 3638 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list1((yyvsp[0].nd));
                     }
-#line 9203 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9643 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 506:
-#line 3593 "mrbgems/mruby-compiler/core/parse.y"
+  case 506: /* f_block_kwarg: f_block_kwarg ',' f_block_kw  */
+#line 3642 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = push((yyvsp[-2].nd), (yyvsp[0].nd));
                     }
-#line 9211 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9651 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 507:
-#line 3599 "mrbgems/mruby-compiler/core/parse.y"
+  case 507: /* f_kwarg: f_kw  */
+#line 3648 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list1((yyvsp[0].nd));
                     }
-#line 9219 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9659 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 508:
-#line 3603 "mrbgems/mruby-compiler/core/parse.y"
+  case 508: /* f_kwarg: f_kwarg ',' f_kw  */
+#line 3652 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = push((yyvsp[-2].nd), (yyvsp[0].nd));
                     }
-#line 9227 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9667 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 511:
-#line 3613 "mrbgems/mruby-compiler/core/parse.y"
+  case 511: /* f_kwrest: kwrest_mark tIDENTIFIER  */
+#line 3662 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_kw_rest_args(p, nsym((yyvsp[0].id)));
                     }
-#line 9235 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9675 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 512:
-#line 3617 "mrbgems/mruby-compiler/core/parse.y"
+  case 512: /* f_kwrest: kwrest_mark  */
+#line 3666 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_kw_rest_args(p, 0);
                     }
-#line 9243 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9683 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 513:
-#line 3623 "mrbgems/mruby-compiler/core/parse.y"
+  case 513: /* args_tail: f_kwarg ',' f_kwrest opt_f_block_arg  */
+#line 3672 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args_tail(p, (yyvsp[-3].nd), (yyvsp[-1].nd), (yyvsp[0].id));
                     }
-#line 9251 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9691 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 514:
-#line 3627 "mrbgems/mruby-compiler/core/parse.y"
+  case 514: /* args_tail: f_kwarg opt_f_block_arg  */
+#line 3676 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args_tail(p, (yyvsp[-1].nd), 0, (yyvsp[0].id));
                     }
-#line 9259 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9699 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 515:
-#line 3631 "mrbgems/mruby-compiler/core/parse.y"
+  case 515: /* args_tail: f_kwrest opt_f_block_arg  */
+#line 3680 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args_tail(p, 0, (yyvsp[-1].nd), (yyvsp[0].id));
                     }
-#line 9267 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9707 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 516:
-#line 3635 "mrbgems/mruby-compiler/core/parse.y"
+  case 516: /* args_tail: f_block_arg  */
+#line 3684 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args_tail(p, 0, 0, (yyvsp[0].id));
                     }
-#line 9275 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9715 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 517:
-#line 3641 "mrbgems/mruby-compiler/core/parse.y"
+  case 517: /* opt_args_tail: ',' args_tail  */
+#line 3690 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[0].nd);
                     }
-#line 9283 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9723 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 518:
-#line 3645 "mrbgems/mruby-compiler/core/parse.y"
+  case 518: /* opt_args_tail: %empty  */
+#line 3694 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args_tail(p, 0, 0, 0);
                     }
-#line 9291 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9731 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 519:
-#line 3651 "mrbgems/mruby-compiler/core/parse.y"
+  case 519: /* f_args: f_arg ',' f_optarg ',' f_rest_arg opt_args_tail  */
+#line 3700 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, (yyvsp[-5].nd), (yyvsp[-3].nd), (yyvsp[-1].id), 0, (yyvsp[0].nd));
                     }
-#line 9299 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9739 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 520:
-#line 3655 "mrbgems/mruby-compiler/core/parse.y"
+  case 520: /* f_args: f_arg ',' f_optarg ',' f_rest_arg ',' f_arg opt_args_tail  */
+#line 3704 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, (yyvsp[-7].nd), (yyvsp[-5].nd), (yyvsp[-3].id), (yyvsp[-1].nd), (yyvsp[0].nd));
                     }
-#line 9307 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9747 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 521:
-#line 3659 "mrbgems/mruby-compiler/core/parse.y"
+  case 521: /* f_args: f_arg ',' f_optarg opt_args_tail  */
+#line 3708 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, (yyvsp[-3].nd), (yyvsp[-1].nd), 0, 0, (yyvsp[0].nd));
                     }
-#line 9315 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9755 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 522:
-#line 3663 "mrbgems/mruby-compiler/core/parse.y"
+  case 522: /* f_args: f_arg ',' f_optarg ',' f_arg opt_args_tail  */
+#line 3712 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, (yyvsp[-5].nd), (yyvsp[-3].nd), 0, (yyvsp[-1].nd), (yyvsp[0].nd));
                     }
-#line 9323 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9763 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 523:
-#line 3667 "mrbgems/mruby-compiler/core/parse.y"
+  case 523: /* f_args: f_arg ',' f_rest_arg opt_args_tail  */
+#line 3716 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, (yyvsp[-3].nd), 0, (yyvsp[-1].id), 0, (yyvsp[0].nd));
                     }
-#line 9331 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9771 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 524:
-#line 3671 "mrbgems/mruby-compiler/core/parse.y"
+  case 524: /* f_args: f_arg ',' f_rest_arg ',' f_arg opt_args_tail  */
+#line 3720 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, (yyvsp[-5].nd), 0, (yyvsp[-3].id), (yyvsp[-1].nd), (yyvsp[0].nd));
                     }
-#line 9339 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9779 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 525:
-#line 3675 "mrbgems/mruby-compiler/core/parse.y"
+  case 525: /* f_args: f_arg opt_args_tail  */
+#line 3724 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, (yyvsp[-1].nd), 0, 0, 0, (yyvsp[0].nd));
                     }
-#line 9347 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9787 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 526:
-#line 3679 "mrbgems/mruby-compiler/core/parse.y"
+  case 526: /* f_args: f_optarg ',' f_rest_arg opt_args_tail  */
+#line 3728 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, 0, (yyvsp[-3].nd), (yyvsp[-1].id), 0, (yyvsp[0].nd));
                     }
-#line 9355 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9795 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 527:
-#line 3683 "mrbgems/mruby-compiler/core/parse.y"
+  case 527: /* f_args: f_optarg ',' f_rest_arg ',' f_arg opt_args_tail  */
+#line 3732 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, 0, (yyvsp[-5].nd), (yyvsp[-3].id), (yyvsp[-1].nd), (yyvsp[0].nd));
                     }
-#line 9363 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9803 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 528:
-#line 3687 "mrbgems/mruby-compiler/core/parse.y"
+  case 528: /* f_args: f_optarg opt_args_tail  */
+#line 3736 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, 0, (yyvsp[-1].nd), 0, 0, (yyvsp[0].nd));
                     }
-#line 9371 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9811 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 529:
-#line 3691 "mrbgems/mruby-compiler/core/parse.y"
+  case 529: /* f_args: f_optarg ',' f_arg opt_args_tail  */
+#line 3740 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, 0, (yyvsp[-3].nd), 0, (yyvsp[-1].nd), (yyvsp[0].nd));
                     }
-#line 9379 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9819 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 530:
-#line 3695 "mrbgems/mruby-compiler/core/parse.y"
+  case 530: /* f_args: f_rest_arg opt_args_tail  */
+#line 3744 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, 0, 0, (yyvsp[-1].id), 0, (yyvsp[0].nd));
                     }
-#line 9387 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9827 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 531:
-#line 3699 "mrbgems/mruby-compiler/core/parse.y"
+  case 531: /* f_args: f_rest_arg ',' f_arg opt_args_tail  */
+#line 3748 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, 0, 0, (yyvsp[-3].id), (yyvsp[-1].nd), (yyvsp[0].nd));
                     }
-#line 9395 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9835 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 532:
-#line 3703 "mrbgems/mruby-compiler/core/parse.y"
+  case 532: /* f_args: args_tail  */
+#line 3752 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, 0, 0, 0, 0, (yyvsp[0].nd));
                     }
-#line 9403 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9843 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 533:
-#line 3707 "mrbgems/mruby-compiler/core/parse.y"
+  case 533: /* f_args: %empty  */
+#line 3756 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       local_add_f(p, MRB_OPSYM(and));
                       (yyval.nd) = new_args(p, 0, 0, 0, 0, 0);
                     }
-#line 9412 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9852 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 534:
-#line 3714 "mrbgems/mruby-compiler/core/parse.y"
+  case 534: /* f_bad_arg: tCONSTANT  */
+#line 3763 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       yyerror(p, "formal argument cannot be a constant");
                       (yyval.nd) = 0;
                     }
-#line 9421 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9861 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 535:
-#line 3719 "mrbgems/mruby-compiler/core/parse.y"
+  case 535: /* f_bad_arg: tIVAR  */
+#line 3768 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       yyerror(p, "formal argument cannot be an instance variable");
                       (yyval.nd) = 0;
                     }
-#line 9430 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9870 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 536:
-#line 3724 "mrbgems/mruby-compiler/core/parse.y"
+  case 536: /* f_bad_arg: tGVAR  */
+#line 3773 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       yyerror(p, "formal argument cannot be a global variable");
                       (yyval.nd) = 0;
                     }
-#line 9439 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9879 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 537:
-#line 3729 "mrbgems/mruby-compiler/core/parse.y"
+  case 537: /* f_bad_arg: tCVAR  */
+#line 3778 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       yyerror(p, "formal argument cannot be a class variable");
                       (yyval.nd) = 0;
                     }
-#line 9448 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9888 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 538:
-#line 3734 "mrbgems/mruby-compiler/core/parse.y"
+  case 538: /* f_bad_arg: tNUMPARAM  */
+#line 3783 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       yyerror(p, "formal argument cannot be a numbered parameter");
                       (yyval.nd) = 0;
                     }
-#line 9457 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9897 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 539:
-#line 3741 "mrbgems/mruby-compiler/core/parse.y"
+  case 539: /* f_norm_arg: f_bad_arg  */
+#line 3790 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.id) = 0;
                     }
-#line 9465 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9905 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 540:
-#line 3745 "mrbgems/mruby-compiler/core/parse.y"
+  case 540: /* f_norm_arg: tIDENTIFIER  */
+#line 3794 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       local_add_f(p, (yyvsp[0].id));
                       (yyval.id) = (yyvsp[0].id);
                     }
-#line 9474 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9914 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 541:
-#line 3752 "mrbgems/mruby-compiler/core/parse.y"
+  case 541: /* f_arg_item: f_norm_arg  */
+#line 3801 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_arg(p, (yyvsp[0].id));
                     }
-#line 9482 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9922 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 542:
-#line 3756 "mrbgems/mruby-compiler/core/parse.y"
+  case 542: /* @32: %empty  */
+#line 3805 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = local_switch(p);
                     }
-#line 9490 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9930 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 543:
-#line 3760 "mrbgems/mruby-compiler/core/parse.y"
+  case 543: /* f_arg_item: tLPAREN @32 f_margs rparen  */
+#line 3809 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_masgn_param(p, (yyvsp[-1].nd), p->locals->car);
                       local_resume(p, (yyvsp[-2].nd));
                       local_add_f(p, 0);
                     }
-#line 9500 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9940 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 544:
-#line 3768 "mrbgems/mruby-compiler/core/parse.y"
+  case 544: /* f_arg: f_arg_item  */
+#line 3817 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list1((yyvsp[0].nd));
                     }
-#line 9508 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9948 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 545:
-#line 3772 "mrbgems/mruby-compiler/core/parse.y"
+  case 545: /* f_arg: f_arg ',' f_arg_item  */
+#line 3821 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = push((yyvsp[-2].nd), (yyvsp[0].nd));
                     }
-#line 9516 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9956 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 546:
-#line 3778 "mrbgems/mruby-compiler/core/parse.y"
+  case 546: /* f_opt_asgn: tIDENTIFIER '='  */
+#line 3827 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       local_add_f(p, (yyvsp[-1].id));
                       local_nest(p);
                       (yyval.id) = (yyvsp[-1].id);
                     }
-#line 9526 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9966 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 547:
-#line 3786 "mrbgems/mruby-compiler/core/parse.y"
+  case 547: /* f_opt: f_opt_asgn arg  */
+#line 3835 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       void_expr_error(p, (yyvsp[0].nd));
                       (yyval.nd) = cons(nsym((yyvsp[-1].id)), cons((yyvsp[0].nd), locals_node(p)));
                       local_unnest(p);
                     }
-#line 9536 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9976 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 548:
-#line 3794 "mrbgems/mruby-compiler/core/parse.y"
+  case 548: /* f_block_opt: f_opt_asgn primary_value  */
+#line 3843 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       void_expr_error(p, (yyvsp[0].nd));
                       (yyval.nd) = cons(nsym((yyvsp[-1].id)), cons((yyvsp[0].nd), locals_node(p)));
                       local_unnest(p);
                     }
-#line 9546 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9986 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 549:
-#line 3802 "mrbgems/mruby-compiler/core/parse.y"
+  case 549: /* f_block_optarg: f_block_opt  */
+#line 3851 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list1((yyvsp[0].nd));
                     }
-#line 9554 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9994 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 550:
-#line 3806 "mrbgems/mruby-compiler/core/parse.y"
+  case 550: /* f_block_optarg: f_block_optarg ',' f_block_opt  */
+#line 3855 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = push((yyvsp[-2].nd), (yyvsp[0].nd));
                     }
-#line 9562 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 10002 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 551:
-#line 3812 "mrbgems/mruby-compiler/core/parse.y"
+  case 551: /* f_optarg: f_opt  */
+#line 3861 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list1((yyvsp[0].nd));
                     }
-#line 9570 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 10010 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 552:
-#line 3816 "mrbgems/mruby-compiler/core/parse.y"
+  case 552: /* f_optarg: f_optarg ',' f_opt  */
+#line 3865 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = push((yyvsp[-2].nd), (yyvsp[0].nd));
                     }
-#line 9578 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 10018 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 555:
-#line 3826 "mrbgems/mruby-compiler/core/parse.y"
+  case 555: /* f_rest_arg: restarg_mark tIDENTIFIER  */
+#line 3875 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       local_add_f(p, (yyvsp[0].id));
                       (yyval.id) = (yyvsp[0].id);
                     }
-#line 9587 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 10027 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 556:
-#line 3831 "mrbgems/mruby-compiler/core/parse.y"
+  case 556: /* f_rest_arg: restarg_mark  */
+#line 3880 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       local_add_f(p, MRB_OPSYM(mul));
                       (yyval.id) = -1;
                     }
-#line 9596 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 10036 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 559:
-#line 3842 "mrbgems/mruby-compiler/core/parse.y"
+  case 559: /* f_block_arg: blkarg_mark tIDENTIFIER  */
+#line 3891 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.id) = (yyvsp[0].id);
                     }
-#line 9604 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 10044 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 560:
-#line 3848 "mrbgems/mruby-compiler/core/parse.y"
+  case 560: /* opt_f_block_arg: ',' f_block_arg  */
+#line 3897 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.id) = (yyvsp[0].id);
                     }
-#line 9612 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 10052 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 561:
-#line 3852 "mrbgems/mruby-compiler/core/parse.y"
+  case 561: /* opt_f_block_arg: none  */
+#line 3901 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.id) = 0;
                     }
-#line 9620 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 10060 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 562:
-#line 3858 "mrbgems/mruby-compiler/core/parse.y"
+  case 562: /* singleton: var_ref  */
+#line 3907 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[0].nd);
                       if (!(yyval.nd)) (yyval.nd) = new_nil(p);
                     }
-#line 9629 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 10069 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 563:
-#line 3862 "mrbgems/mruby-compiler/core/parse.y"
+  case 563: /* $@33: %empty  */
+#line 3911 "mrbgems/mruby-compiler/core/parse.y"
                       {p->lstate = EXPR_BEG;}
-#line 9635 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 10075 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 564:
-#line 3863 "mrbgems/mruby-compiler/core/parse.y"
+  case 564: /* singleton: '(' $@33 expr rparen  */
+#line 3912 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       if ((yyvsp[-1].nd) == 0) {
                         yyerror(p, "can't define singleton method for ().");
@@ -9658,55 +10098,55 @@ yyreduce:
                       }
                       (yyval.nd) = (yyvsp[-1].nd);
                     }
-#line 9662 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 10102 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 566:
-#line 3889 "mrbgems/mruby-compiler/core/parse.y"
+  case 566: /* assoc_list: assocs trailer  */
+#line 3938 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[-1].nd);
                     }
-#line 9670 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 10110 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 567:
-#line 3895 "mrbgems/mruby-compiler/core/parse.y"
+  case 567: /* assocs: assoc  */
+#line 3944 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list1((yyvsp[0].nd));
                       NODE_LINENO((yyval.nd), (yyvsp[0].nd));
                     }
-#line 9679 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 10119 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 568:
-#line 3900 "mrbgems/mruby-compiler/core/parse.y"
+  case 568: /* assocs: assocs comma assoc  */
+#line 3949 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = push((yyvsp[-2].nd), (yyvsp[0].nd));
                     }
-#line 9687 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 10127 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 571:
-#line 3910 "mrbgems/mruby-compiler/core/parse.y"
+  case 571: /* assoc: arg tASSOC arg  */
+#line 3959 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       void_expr_error(p, (yyvsp[-2].nd));
                       void_expr_error(p, (yyvsp[0].nd));
                       (yyval.nd) = cons((yyvsp[-2].nd), (yyvsp[0].nd));
                     }
-#line 9697 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 10137 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 572:
-#line 3916 "mrbgems/mruby-compiler/core/parse.y"
+  case 572: /* assoc: tIDENTIFIER label_tag arg  */
+#line 3965 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       void_expr_error(p, (yyvsp[0].nd));
                       (yyval.nd) = cons(new_sym(p, (yyvsp[-2].id)), (yyvsp[0].nd));
                     }
-#line 9706 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 10146 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 573:
-#line 3921 "mrbgems/mruby-compiler/core/parse.y"
+  case 573: /* assoc: string_fragment label_tag arg  */
+#line 3970 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       void_expr_error(p, (yyvsp[0].nd));
                       if ((yyvsp[-2].nd)->car == (node*)NODE_DSTR) {
@@ -9716,67 +10156,67 @@ yyreduce:
                         (yyval.nd) = cons(new_sym(p, new_strsym(p, (yyvsp[-2].nd))), (yyvsp[0].nd));
                       }
                     }
-#line 9720 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 10160 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 574:
-#line 3931 "mrbgems/mruby-compiler/core/parse.y"
+  case 574: /* assoc: tDSTAR arg  */
+#line 3980 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       void_expr_error(p, (yyvsp[0].nd));
                       (yyval.nd) = cons(new_kw_rest_args(p, 0), (yyvsp[0].nd));
                     }
-#line 9729 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 10169 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 587:
-#line 3958 "mrbgems/mruby-compiler/core/parse.y"
+  case 587: /* call_op: '.'  */
+#line 4007 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.num) = '.';
                     }
-#line 9737 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 10177 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 588:
-#line 3962 "mrbgems/mruby-compiler/core/parse.y"
+  case 588: /* call_op: tANDDOT  */
+#line 4011 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.num) = 0;
                     }
-#line 9745 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 10185 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 590:
-#line 3969 "mrbgems/mruby-compiler/core/parse.y"
+  case 590: /* call_op2: tCOLON2  */
+#line 4018 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.num) = tCOLON2;
                     }
-#line 9753 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 10193 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 599:
-#line 3990 "mrbgems/mruby-compiler/core/parse.y"
+  case 599: /* term: ';'  */
+#line 4039 "mrbgems/mruby-compiler/core/parse.y"
                       {yyerrok;}
-#line 9759 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 10199 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 602:
-#line 3996 "mrbgems/mruby-compiler/core/parse.y"
+  case 602: /* nl: '\n'  */
+#line 4045 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       p->lineno += (yyvsp[0].num);
                       p->column = 0;
                     }
-#line 9768 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 10208 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 605:
-#line 4007 "mrbgems/mruby-compiler/core/parse.y"
+  case 605: /* none: %empty  */
+#line 4056 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = 0;
                     }
-#line 9776 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 10216 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
 
-#line 9780 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 10220 "mrbgems/mruby-compiler/core/y.tab.c"
 
       default: break;
     }
@@ -9791,11 +10231,10 @@ yyreduce:
      case of YYERROR or YYBACKUP, subsequent parser actions might lead
      to an incorrect destructor call or verbose syntax error message
      before the lookahead is translated.  */
-  YY_SYMBOL_PRINT ("-> $$ =", yyr1[yyn], &yyval, &yyloc);
+  YY_SYMBOL_PRINT ("-> $$ =", YY_CAST (yysymbol_kind_t, yyr1[yyn]), &yyval, &yyloc);
 
   YYPOPSTACK (yylen);
   yylen = 0;
-  YY_STACK_PRINT (yyss, yyssp);
 
   *++yyvsp = yyval;
 
@@ -9819,49 +10258,43 @@ yyreduce:
 yyerrlab:
   /* Make sure we have latest lookahead translation.  See comments at
      user semantic actions for why this is necessary.  */
-  yytoken = yychar == YYEMPTY ? YYEMPTY : YYTRANSLATE (yychar);
-
+  yytoken = yychar == YYEMPTY ? YYSYMBOL_YYEMPTY : YYTRANSLATE (yychar);
   /* If not already recovering from an error, report this error.  */
   if (!yyerrstatus)
     {
       ++yynerrs;
-#if ! YYERROR_VERBOSE
-      yyerror (p, YY_("syntax error"));
-#else
-# define YYSYNTAX_ERROR yysyntax_error (&yymsg_alloc, &yymsg, \
-                                        yyssp, yytoken)
       {
+        yypcontext_t yyctx
+          = {yyssp, yytoken};
         char const *yymsgp = YY_("syntax error");
         int yysyntax_error_status;
-        yysyntax_error_status = YYSYNTAX_ERROR;
+        yysyntax_error_status = yysyntax_error (&yymsg_alloc, &yymsg, &yyctx);
         if (yysyntax_error_status == 0)
           yymsgp = yymsg;
-        else if (yysyntax_error_status == 1)
+        else if (yysyntax_error_status == -1)
           {
             if (yymsg != yymsgbuf)
               YYSTACK_FREE (yymsg);
-            yymsg = YY_CAST (char *, YYSTACK_ALLOC (YY_CAST (YYSIZE_T, yymsg_alloc)));
-            if (!yymsg)
+            yymsg = YY_CAST (char *,
+                             YYSTACK_ALLOC (YY_CAST (YYSIZE_T, yymsg_alloc)));
+            if (yymsg)
               {
-                yymsg = yymsgbuf;
-                yymsg_alloc = sizeof yymsgbuf;
-                yysyntax_error_status = 2;
+                yysyntax_error_status
+                  = yysyntax_error (&yymsg_alloc, &yymsg, &yyctx);
+                yymsgp = yymsg;
               }
             else
               {
-                yysyntax_error_status = YYSYNTAX_ERROR;
-                yymsgp = yymsg;
+                yymsg = yymsgbuf;
+                yymsg_alloc = sizeof yymsgbuf;
+                yysyntax_error_status = YYENOMEM;
               }
           }
         yyerror (p, yymsgp);
-        if (yysyntax_error_status == 2)
+        if (yysyntax_error_status == YYENOMEM)
           goto yyexhaustedlab;
       }
-# undef YYSYNTAX_ERROR
-#endif
     }
-
-
 
   if (yyerrstatus == 3)
     {
@@ -9911,13 +10344,14 @@ yyerrorlab:
 yyerrlab1:
   yyerrstatus = 3;      /* Each real token shifted decrements this.  */
 
+  /* Pop stack until we find a state that shifts the error token.  */
   for (;;)
     {
       yyn = yypact[yystate];
       if (!yypact_value_is_default (yyn))
         {
-          yyn += YYTERROR;
-          if (0 <= yyn && yyn <= YYLAST && yycheck[yyn] == YYTERROR)
+          yyn += YYSYMBOL_YYerror;
+          if (0 <= yyn && yyn <= YYLAST && yycheck[yyn] == YYSYMBOL_YYerror)
             {
               yyn = yytable[yyn];
               if (0 < yyn)
@@ -9931,7 +10365,7 @@ yyerrlab1:
 
 
       yydestruct ("Error: popping",
-                  yystos[yystate], yyvsp, p);
+                  YY_ACCESSING_SYMBOL (yystate), yyvsp, p);
       YYPOPSTACK (1);
       yystate = *yyssp;
       YY_STACK_PRINT (yyss, yyssp);
@@ -9943,7 +10377,7 @@ yyerrlab1:
 
 
   /* Shift the error token.  */
-  YY_SYMBOL_PRINT ("Shifting", yystos[yyn], yyvsp, yylsp);
+  YY_SYMBOL_PRINT ("Shifting", YY_ACCESSING_SYMBOL (yyn), yyvsp, yylsp);
 
   yystate = yyn;
   goto yynewstate;
@@ -9965,20 +10399,20 @@ yyabortlab:
   goto yyreturn;
 
 
-#if !defined yyoverflow || YYERROR_VERBOSE
+#if 1
 /*-------------------------------------------------.
 | yyexhaustedlab -- memory exhaustion comes here.  |
 `-------------------------------------------------*/
 yyexhaustedlab:
   yyerror (p, YY_("memory exhausted"));
   yyresult = 2;
-  /* Fall through.  */
+  goto yyreturn;
 #endif
 
 
-/*-----------------------------------------------------.
-| yyreturn -- parsing is finished, return the result.  |
-`-----------------------------------------------------*/
+/*-------------------------------------------------------.
+| yyreturn -- parsing is finished, clean up and return.  |
+`-------------------------------------------------------*/
 yyreturn:
   if (yychar != YYEMPTY)
     {
@@ -9995,20 +10429,19 @@ yyreturn:
   while (yyssp != yyss)
     {
       yydestruct ("Cleanup: popping",
-                  yystos[+*yyssp], yyvsp, p);
+                  YY_ACCESSING_SYMBOL (+*yyssp), yyvsp, p);
       YYPOPSTACK (1);
     }
 #ifndef yyoverflow
   if (yyss != yyssa)
     YYSTACK_FREE (yyss);
 #endif
-#if YYERROR_VERBOSE
   if (yymsg != yymsgbuf)
     YYSTACK_FREE (yymsg);
-#endif
   return yyresult;
 }
-#line 4011 "mrbgems/mruby-compiler/core/parse.y"
+
+#line 4060 "mrbgems/mruby-compiler/core/parse.y"
 
 #define pylval  (*((YYSTYPE*)(p->ylval)))
 
@@ -10907,6 +11340,7 @@ heredoc_identifier(parser_state *p)
   int c;
   int type = str_heredoc;
   mrb_bool indent = FALSE;
+  mrb_bool squiggly = FALSE;
   mrb_bool quote = FALSE;
   node *newnode;
   parser_heredoc_info *info;
@@ -10916,8 +11350,11 @@ heredoc_identifier(parser_state *p)
     pushback(p, c);
     return 0;
   }
-  if (c == '-') {
-    indent = TRUE;
+  if (c == '-' || c == '~') {
+    if (c == '-')
+      indent = TRUE;
+    if (c == '~')
+      squiggly = TRUE;
     c = nextc(p);
   }
   if (c == '\'' || c == '"') {
@@ -10944,6 +11381,7 @@ heredoc_identifier(parser_state *p)
     if (! identchar(c)) {
       pushback(p, c);
       if (indent) pushback(p, '-');
+      if (squiggly) pushback(p, '~');
       return 0;
     }
     newtok(p);
@@ -10960,7 +11398,8 @@ heredoc_identifier(parser_state *p)
   if (! quote)
     type |= STR_FUNC_EXPAND;
   info->type = (string_type)type;
-  info->allow_indent = indent;
+  info->allow_indent = indent || squiggly;
+  info->remove_indent = squiggly;
   info->line_head = TRUE;
   info->doc = NULL;
   p->heredocs_from_nextline = push(p->heredocs_from_nextline, newnode);

--- a/mrbgems/mruby-compiler/core/y.tab.c
+++ b/mrbgems/mruby-compiler/core/y.tab.c
@@ -1422,10 +1422,10 @@ heredoc_end(parser_state *p)
     node *list = info->doc;
     node *list2 = NULL;
     while (list) {
-      if (list->car->car == NODE_STR) {
+      if (((enum node_type)(intptr_t)list->car->car) == NODE_STR) {
         node *pair = list->car->cdr;
-        const char *str = (char*) pair->car;
-        size_t len = (size_t) pair->cdr;
+        const char *str = (char*)pair->car;
+        size_t len = (size_t)pair->cdr;
         if (counting) {
           list2 = push(list2, pair);
         }
@@ -1456,10 +1456,10 @@ heredoc_end(parser_state *p)
     if (indent > 0) {
       while (list2) {
         node *pair = list2->car;
-        const char *str = (char*) pair->car;
-        size_t len = (size_t) pair->cdr;
-        pair->car = (node*) (str + indent);
-        pair->cdr = (node*) (len - indent);
+        const char *str = (char*)pair->car;
+        size_t len = (size_t)pair->cdr;
+        pair->car = (node*)(str + indent);
+        pair->cdr = (node*)(len - indent);
         list2 = list2->cdr;
       }
     }

--- a/test/t/literals.rb
+++ b/test/t/literals.rb
@@ -162,6 +162,26 @@ qq
 QQ2
       "o")
 
+  r = <<~RRR
+    rrr
+      rrr
+  RRR
+  s = <<~"SSS"
+    sss
+      sss
+  SSS
+  t = <<~'TTT'
+    ttt
+      ttt
+  TTT
+  u = [<<~UUU1   , <<~"UUU2"   , <<~'UUU3' ]
+    u#{1}u
+  UUU1
+    u#{2}u
+  UUU2
+    u#{3}u
+  UUU3
+
   w = %W( 1 #{<<WWW} 3
 www
 WWW
@@ -197,6 +217,10 @@ ZZZ
   assert_equal [1, "nn1\n", 3, 4], n
   assert_equal "a $ q\n $ c $ d", q1
   assert_equal "l $ mqq\nn $ o", q2
+  assert_equal "rrr\n  rrr\n", r
+  assert_equal "sss\n  sss\n", s
+  assert_equal "ttt\n  ttt\n", t
+  assert_equal ["u1u\n", "u2u\n", "u\#{3}u\n"], u
   assert_equal ["1", "www\n", "3", "4", "5"], w
   assert_equal [1, "foo 222 333\n 444\n5\n bar\n6\n", 9], x
   assert_equal "", z


### PR DESCRIPTION
Hello, I have added support for [squiggly heredocs](https://ruby-doc.org/core-2.7.2/doc/syntax/literals_rdoc.html#label-Here+Documents+-28heredocs-29) to mruby. Please tell me if I did anything wrong! (Should I commit `y.tab.c`?)