### PR TITLE
Refine error message from `mrb_get_arg1`

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -840,7 +840,7 @@ mrb_get_arg1(mrb_state *mrb)
     array_argv = ARY_PTR(a);
   }
   if (argc != 1) {
-    mrb_raise(mrb, E_ARGUMENT_ERROR, "wrong number of arguments");
+    mrb_argnum_error(mrb, argc, 1, 1);
   }
   return array_argv[0];
 }


### PR DESCRIPTION
#### Before this patch:

```console
$ bin/mruby -e '{}.key?'
trace (most recent call last):
-e:1: wrong number of arguments (ArgumentError)
```

#### After this patch:

```console
$ bin/mruby -e '{}.key?'
trace (most recent call last):
-e:1: wrong number of arguments (given 0, expected 1) (ArgumentError)
```