### PR TITLE
Fix regression for squiggly heredocs

### DIFF
--- a/include/mruby/compile.h
+++ b/include/mruby/compile.h
@@ -100,7 +100,6 @@ enum mrb_string_type {
 struct mrb_parser_heredoc_info {
   mrb_bool allow_indent:1;
   mrb_bool remove_indent:1;
-  char indent_char;
   size_t indent;
   mrb_ast_node *indented;
   mrb_bool line_head:1;

--- a/mrbgems/mruby-compiler/core/parse.y
+++ b/mrbgems/mruby-compiler/core/parse.y
@@ -4700,12 +4700,12 @@ parse_string(parser_state *p)
       pylval.nd = nd;
       if (head) {
         hinf->indented = push(hinf->indented, cons((node*)spaces, nd->cdr));
-        if ((hinf->indent == -1 || spaces < hinf->indent) && (!empty || !hinf->line_head))
+        if ((hinf->indent == -1 || spaces < hinf->indent) && (!empty || !line_head))
           hinf->indent = spaces;
       }
       return tHD_STRING_MID;
     }
-    if (hinf && hinf->line_head) {
+    if (hinf && hinf->line_head && empty) {
       if (ISSPACE(c)) {
         if (hinf->indent_char == -1)
           hinf->indent_char = c;

--- a/mrbgems/mruby-compiler/core/y.tab.c
+++ b/mrbgems/mruby-compiler/core/y.tab.c
@@ -11049,16 +11049,29 @@ parse_string(parser_state *p)
           if (hinf->remove_indent && hinf->indent > 0) {
             node *tmp = hinf->indented;
             while (tmp) {
-              node *n = tmp->car;
-              size_t indent = (size_t)n->car;
-              if (indent > hinf->indent)
-                indent = hinf->indent;
+              node *pair = tmp->car;
+              const char *str = (char*)pair->car;
+              size_t len = (size_t)pair->cdr;
+              size_t indent = 0;
+              size_t offset = 0;
+              for (size_t i = 0; i < len; i++) {
+                size_t size;
+                if (str[i] == '\n')
+                  break;
+                else if (str[i] == '\t')
+                  size = 8;
+                else if (ISSPACE(str[i]))
+                  size = 1;
+                else
+                  break;
+                if (indent + size > hinf->indent)
+                  break;
+                indent += size;
+                ++offset;
+              }
               if (indent > 0) {
-                node *pair = n->cdr;
-                const char *str = (char*)pair->car;
-                size_t len = (size_t)pair->cdr;
-                pair->car = (node*)(str + indent);
-                pair->cdr = (node*)(len - indent);
+                pair->car = (node*)(str + offset);
+                pair->cdr = (node*)(len - offset);
               }
               tmp = tmp->cdr;
             }
@@ -11084,19 +11097,17 @@ parse_string(parser_state *p)
       node *nd = new_str(p, tok(p), toklen(p));
       pylval.nd = nd;
       if (head) {
-        hinf->indented = push(hinf->indented, cons((node*)spaces, nd->cdr));
+        hinf->indented = push(hinf->indented, nd->cdr);
         if ((hinf->indent == -1 || spaces < hinf->indent) && (!empty || !line_head))
           hinf->indent = spaces;
       }
       return tHD_STRING_MID;
     }
     if (hinf && hinf->line_head && empty) {
-      if (ISSPACE(c)) {
-        if (hinf->indent_char == -1)
-          hinf->indent_char = c;
-        if (c == hinf->indent_char)
-          ++spaces;
-      }
+      if (c == '\t')
+        spaces += 8;
+      else if (ISSPACE(c))
+        ++spaces;
       else
         empty = FALSE;
     }
@@ -11174,7 +11185,7 @@ parse_string(parser_state *p)
         pylval.nd = nd;
         if (hinf) {
           if (head) {
-            hinf->indented = push(hinf->indented, cons((node*)spaces, nd->cdr));
+            hinf->indented = push(hinf->indented, nd->cdr);
             if (hinf->indent == -1 || spaces < hinf->indent)
               hinf->indent = spaces;
           }
@@ -11394,7 +11405,6 @@ heredoc_identifier(parser_state *p)
   info->type = (string_type)type;
   info->allow_indent = indent || squiggly;
   info->remove_indent = squiggly;
-  info->indent_char = -1;
   info->indent = -1;
   info->indented = NULL;
   info->line_head = TRUE;

--- a/mrbgems/mruby-compiler/core/y.tab.c
+++ b/mrbgems/mruby-compiler/core/y.tab.c
@@ -11085,12 +11085,12 @@ parse_string(parser_state *p)
       pylval.nd = nd;
       if (head) {
         hinf->indented = push(hinf->indented, cons((node*)spaces, nd->cdr));
-        if ((hinf->indent == -1 || spaces < hinf->indent) && (!empty || !hinf->line_head))
+        if ((hinf->indent == -1 || spaces < hinf->indent) && (!empty || !line_head))
           hinf->indent = spaces;
       }
       return tHD_STRING_MID;
     }
-    if (hinf && hinf->line_head) {
+    if (hinf && hinf->line_head && empty) {
       if (ISSPACE(c)) {
         if (hinf->indent_char == -1)
           hinf->indent_char = c;

--- a/test/t/literals.rb
+++ b/test/t/literals.rb
@@ -190,6 +190,10 @@ QQ2
 \tvvv
   vvv
   VVV
+  v3 = <<~VVV
+    v v v
+      vvv
+  VVV
 
   w = %W( 1 #{<<WWW} 3
 www
@@ -232,6 +236,7 @@ ZZZ
   assert_equal ["u1u\n", "u2u\n", "u\#{3}u\n"], u
   assert_equal "\nvvv\nvvv\n", v1
   assert_equal "\tvvv\n  vvv\n", v2
+  assert_equal "v v v\n  vvv\n", v3
   assert_equal ["1", "www\n", "3", "4", "5"], w
   assert_equal [1, "foo 222 333\n 444\n5\n bar\n6\n", 9], x
   assert_equal "", z


### PR DESCRIPTION
This fixes the issue @shuujii mentioned in #5249. (I forgot to check if spaces are at the beginning of the line before counting them as part of the indent.) Also, this PR includes a change to treat tabs as 8 spaces. (Thanks @shuujii! I wouldn't have noticed these things without your reviews!)

```ruby
# example.rb
p <<~EOS
 ( )
  a
EOS
p <<~EOS
	(hard tab)
      (6 spaces)
EOS
p <<~EOS
	(hard tab)
        (8 spaces)
EOS
p <<~EOS
	(hard tab)
          (10 spaces)
EOS
```

```console
$ ruby example.rb
"( )\n a\n"
"\t(hard tab)\n(6 spaces)\n"
"(hard tab)\n(8 spaces)\n"
"(hard tab)\n  (10 spaces)\n"
```

```console
$ mruby example.rb
"( )\n a\n"
"\t(hard tab)\n(6 spaces)\n"
"(hard tab)\n(8 spaces)\n"
"(hard tab)\n  (10 spaces)\n"
```