### PR TITLE
Refine "wrong number of arguments" message in `mrb_get_args`

### DIFF
--- a/test/t/argumenterror.rb
+++ b/test/t/argumenterror.rb
@@ -1,6 +1,13 @@
 ##
 # ArgumentError ISO Test
 
+def assert_argnum_error(given, expected, &block)
+  assert("wrong number of arguments") do
+    message = "wrong number of arguments (given #{given}, expected #{expected})"
+    assert_raise_with_message(ArgumentError, message, &block)
+  end
+end
+
 assert('ArgumentError', '15.2.24') do
   e2 = nil
   a = []
@@ -13,4 +20,13 @@ assert('ArgumentError', '15.2.24') do
 
   assert_equal(Class, ArgumentError.class)
   assert_equal(ArgumentError, e2.class)
+end
+
+assert("'wrong number of arguments' from mrb_get_args") do
+  assert_argnum_error(0, "1+"){__send__}
+  assert_argnum_error(0, 1..2){Object.const_defined?}
+  assert_argnum_error(3, 1..2){Object.const_defined?(:A, true, 2)}
+  assert_argnum_error(2, 0..1){{}.default(1, 2)}
+  assert_argnum_error(1, 2){Object.const_set(:B)}
+  assert_argnum_error(3, 2){Object.const_set(:C, 1, 2)}
 end


### PR DESCRIPTION
#### Before this patch:

```ruby
__send__         #=> wrong number of arguments
{}.default(1,2)  #=> wrong number of arguments
```

#### After this patch:

```ruby
__send__         #=> wrong number of arguments (given 0, expected 1+)
{}.default(1,2)  #=> wrong number of arguments (given 2, expected 0..1)
```