### PR TITLE
Use namespaces according to Rake conventions

### DIFF
--- a/tasks/doc.rake
+++ b/tasks/doc.rake
@@ -1,48 +1,60 @@
 desc 'generate document'
-task :doc => [:api_doc, :capi_doc] do
+task :doc => %w[doc:api doc:capi]
 
-end
+namespace :doc do
+  desc 'generate yard docs'
+  task :api do
+    begin
+      sh "mrbdoc"
+    rescue
+      puts "ERROR: To generate yard documentation, you should install yard-mruby gem."
+      puts "  $ gem install yard-mruby yard-coderay"
+    end
+  end
 
-desc 'generate yard docs'
-task :api_doc do
-  begin
-    sh "mrbdoc"
-  rescue
-    puts "ERROR: To generate yard documentation, you should install yard-mruby gem."
-    puts "  $ gem install yard-mruby yard-coderay"
+  desc 'generate doxygen docs'
+  task :capi do
+    begin
+      sh "doxygen Doxyfile"
+    rescue
+      puts "ERROR: To generate C API documents, you need Doxygen."
+      puts "  $ sudo apt-get install doxygen"
+    end
+  end
+
+  desc 'clean all built docs'
+  task :clean => %w[clean:api clean:capi]
+
+  namespace :clean do
+    desc 'clean yard docs'
+    task :api do
+      rm_rf 'doc/api'
+    end
+
+    desc 'clean doxygen docs'
+    task :capi do
+      rm_rf 'doc/capi'
+    end
+  end
+
+  namespace :view do
+    desc 'open yard docs'
+    task :api do
+      sh 'xdg-open doc/api/index.html'
+    end
+
+    desc 'open doxygen docs'
+    task :capi do
+      sh 'xdg-open doc/capi/html/index.html'
+    end
   end
 end
 
-desc 'generate doxygen docs'
-task :capi_doc do
-  begin
-    sh "doxygen Doxyfile"
-  rescue
-    puts "ERROR: To generate C API documents, you need Doxygen."
-    puts "  $ sudo apt-get install doxygen"
-  end
-end
-
-desc 'clean all built docs'
-task :clean_api_doc do
-  rm_rf 'doc/api'
-end
-
-desc 'clean all built docs'
-task :clean_capi_doc do
-  rm_rf 'doc/capi'
-end
-
-desc 'clean all built docs'
-task :clean_doc => [:clean_api_doc, :clean_capi_doc] do
-end
-
-desc 'clean all built docs'
-task :view_api => [:api_doc] do
-  sh 'xdg-open doc/api/index.html'
-end
-
-desc 'clean all built docs'
-task :view_capi => [:capi_doc] do
-  sh 'xdg-open doc/capi/html/index.html'
-end
+# deprecated
+task "api_doc" => "doc:api"
+task "capi_doc" => "doc:capi"
+task "clean_doc" => "doc:clean"
+task "clean_api_doc" => "doc:clean:api"
+task "clean_capi_doc" => "doc:clean:capi"
+task "view_api" => "doc:view:api"
+task "view_capi" => "doc:view:capi"

--- a/tasks/gitlab.rake
+++ b/tasks/gitlab.rake
@@ -25,91 +25,97 @@ def run_cmd(cmd)
   raise 'error' unless system cmd
 end
 
-desc 'recreate docker images for GitLab builds'
-task :gitlab_dockers do
-  CI_COMPILERS.each do |compiler|
-    tag = ci_image_tag(compiler)
-    filename = "Dockerfile.#{tag}"
-    File.open(filename, 'wb') do |f|
-      f << "# #{compiler} - #{tag}\n"
-      f << "FROM #{CI_BASE}\n"
-      f << "RUN apt-get update && apt-get install -y git ruby2.3 ruby2.3-dev bison\n"
-      f << "RUN apt-get update && apt-get install -y binutils manpages\n"
-      f << "RUN apt-get update && apt-get install -y #{compiler}\n"
-      if compiler['gcc']
-        f << "RUN apt-get update && apt-get install -y libx32#{compiler}-dev\n"
-        f << "RUN apt-get update && apt-get install --no-install-recommends -y #{compiler}-multilib\n"
+namespace :gitlab do
+  desc 'recreate docker images for GitLab builds'
+  task :dockers do
+    CI_COMPILERS.each do |compiler|
+      tag = ci_image_tag(compiler)
+      filename = "Dockerfile.#{tag}"
+      File.open(filename, 'wb') do |f|
+        f << "# #{compiler} - #{tag}\n"
+        f << "FROM #{CI_BASE}\n"
+        f << "RUN apt-get update && apt-get install -y git ruby2.3 ruby2.3-dev bison\n"
+        f << "RUN apt-get update && apt-get install -y binutils manpages\n"
+        f << "RUN apt-get update && apt-get install -y #{compiler}\n"
+        if compiler['gcc']
+          f << "RUN apt-get update && apt-get install -y libx32#{compiler}-dev\n"
+          f << "RUN apt-get update && apt-get install --no-install-recommends -y #{compiler}-multilib\n"
+        end
+        f << "RUN dpkg --add-architecture i386\n"
+        f << "RUN apt-get update && apt-get install -y linux-libc-dev:i386\n"
+        if compiler['clang']
+          f << "RUN apt-get update && apt-get install --no-install-recommends -y libc6-dev-i386\n"
+          f << "RUN apt-get update && apt-get install -y gcc gcc-multilib\n"
+        end
       end
-      f << "RUN dpkg --add-architecture i386\n"
-      f << "RUN apt-get update && apt-get install -y linux-libc-dev:i386\n"
-      if compiler['clang']
-        f << "RUN apt-get update && apt-get install --no-install-recommends -y libc6-dev-i386\n"
-        f << "RUN apt-get update && apt-get install -y gcc gcc-multilib\n"
-      end
+      docker_tag = ci_docker_tag(compiler)
+      cmd1 = "docker build -t #{docker_tag} -f #{filename} ."
+      cmd2 = "docker push #{docker_tag}"
+      run_cmd cmd1
+      run_cmd cmd2
+      File.delete(filename)
     end
-    docker_tag = ci_docker_tag(compiler)
-    cmd1 = "docker build -t #{docker_tag} -f #{filename} ."
-    cmd2 = "docker push #{docker_tag}"
-    run_cmd cmd1
-    run_cmd cmd2
-    File.delete(filename)
   end
-end
 
-desc 'create build configurations and update .gitlab-ci.yml'
-task :gitlab_config do
-  require 'yaml'
+  desc 'create build configurations and update .gitlab-ci.yml'
+  task :config do
+    require 'yaml'
 
-  configs = []
-  [true, false].each do |mode_32|
-    ['', 'MRB_USE_FLOAT32'].each do |float_conf|
-      ['', 'MRB_NAN_BOXING', 'MRB_WORD_BOXING'].each do |boxing_conf|
-        ['', 'MRB_UTF8_STRING'].each do |utf8_conf|
-          next if (float_conf == 'MRB_USE_FLOAT32') && (boxing_conf == 'MRB_NAN_BOXING')
-          next if (int_conf == 'MRB_INT64') && (boxing_conf == 'MRB_NAN_BOXING')
-          next if (int_conf == 'MRB_INT64') && (boxing_conf == 'MRB_WORD_BOXING') && mode_32
-          env = [float_conf, int_conf, boxing_conf, utf8_conf].map do |conf|
-            conf == '' ? nil : "-D#{conf}=1"
-          end.compact.join(' ')
-          bit = mode_32 ? '-m32 ' : ''
-          _info = ''
-          _info += mode_32 ? '32bit ' : '64bit '
-          _info += float_conf['USE'] ? 'float ' : ''
-          _info += int_conf['16'] ? 'int16 ' : ''
-          _info += int_conf['64'] ? 'int64 ' : ''
-          _info += boxing_conf['NAN'] ? 'nan ' : ''
-          _info += boxing_conf['WORD'] ? 'word ' : ''
-          _info += utf8_conf['UTF8'] ? 'utf8 ' : ''
-          _info = _info.gsub(/ +/, ' ').strip.tr(' ', '_')
-          configs << { '_info' => _info, 'CFLAGS' => "#{bit}#{env}", 'LDFLAGS' => bit.strip.to_s }
+    configs = []
+    [true, false].each do |mode_32|
+      ['', 'MRB_USE_FLOAT32'].each do |float_conf|
+        ['', 'MRB_NAN_BOXING', 'MRB_WORD_BOXING'].each do |boxing_conf|
+          ['', 'MRB_UTF8_STRING'].each do |utf8_conf|
+            next if (float_conf == 'MRB_USE_FLOAT32') && (boxing_conf == 'MRB_NAN_BOXING')
+            next if (int_conf == 'MRB_INT64') && (boxing_conf == 'MRB_NAN_BOXING')
+            next if (int_conf == 'MRB_INT64') && (boxing_conf == 'MRB_WORD_BOXING') && mode_32
+            env = [float_conf, int_conf, boxing_conf, utf8_conf].map do |conf|
+              conf == '' ? nil : "-D#{conf}=1"
+            end.compact.join(' ')
+            bit = mode_32 ? '-m32 ' : ''
+            _info = ''
+            _info += mode_32 ? '32bit ' : '64bit '
+            _info += float_conf['USE'] ? 'float ' : ''
+            _info += int_conf['16'] ? 'int16 ' : ''
+            _info += int_conf['64'] ? 'int64 ' : ''
+            _info += boxing_conf['NAN'] ? 'nan ' : ''
+            _info += boxing_conf['WORD'] ? 'word ' : ''
+            _info += utf8_conf['UTF8'] ? 'utf8 ' : ''
+            _info = _info.gsub(/ +/, ' ').strip.tr(' ', '_')
+            configs << { '_info' => _info, 'CFLAGS' => "#{bit}#{env}", 'LDFLAGS' => bit.strip.to_s }
+          end
         end
       end
     end
-  end
-  path = './.gitlab-ci.yml'
-  data = YAML.load_file(path)
-  data.keys.select do |key|
-    key.start_with? 'Test'
-  end.each do |key|
-    data.delete(key)
-  end
-  CI_COMPILERS.each do |compiler|
-    configs.each do |config|
-      name = "Test #{compiler} #{config['_info']}"
-      hash = {
-        'CC' => compiler,
-        'CXX' => compiler.gsub('gcc', 'g++').gsub('clang', 'clang++'),
-        'LD' => compiler
-      }
-      hash = hash.merge(config)
-      hash.delete('_info')
-      data[name] = {
-        'stage' => 'test',
-        'image' => ci_docker_tag(compiler),
-        'variables' => hash,
-        'script' => 'env; rake --verbose all test'
-      }
+    path = './.gitlab-ci.yml'
+    data = YAML.load_file(path)
+    data.keys.select do |key|
+      key.start_with? 'Test'
+    end.each do |key|
+      data.delete(key)
     end
+    CI_COMPILERS.each do |compiler|
+      configs.each do |config|
+        name = "Test #{compiler} #{config['_info']}"
+        hash = {
+          'CC' => compiler,
+          'CXX' => compiler.gsub('gcc', 'g++').gsub('clang', 'clang++'),
+          'LD' => compiler
+        }
+        hash = hash.merge(config)
+        hash.delete('_info')
+        data[name] = {
+          'stage' => 'test',
+          'image' => ci_docker_tag(compiler),
+          'variables' => hash,
+          'script' => 'env; rake --verbose all test'
+        }
+      end
+    end
+    File.open(path, 'w') { |f| YAML.dump(data, f) }
   end
-  File.open(path, 'w') { |f| YAML.dump(data, f) }
 end
+
+# deprecated
+task "gitlab_config" => "gitlab:config"
+task "gitlab_dockers" => "gitlab:dockers"


### PR DESCRIPTION
Change the Rake task to one that uses namespaces as follows (previous task
names can also be used for compatibility).

| Previous Task  |    New Task    |
|----------------|----------------|
| api_doc        | doc:api        |
| capi_doc       | doc:capi       |
| clean_doc      | doc:clean      |
| clean_api_doc  | doc:clean:api  |
| clean_capi_doc | doc:clean:capi |
| view_api       | doc:view:api   |
| view_capi      | doc:view:capi  |
| gitlab_config  | gitlab:config  |
| gitlab_dockers | gitlab:dockers |