### PR TITLE
Immediately flush output to stdout/stderr so that logs are not mixed on CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Build and test
         # If build and test are separated like `rake && rake test`, somehow
         # it will be fully built even at `rake test`, so it is not separated.
-        run: rake -E STDOUT.sync=true test
+        run: rake test
 
   Windows-Cygwin:
     needs: Check-Skip
@@ -130,9 +130,7 @@ jobs:
         run: ${{ env.CC }} --version
       - name: Build and test
         shell: cmd
-        run: |
-          ruby /usr/bin/rake -E STDOUT.sync=true -m
-          ruby /usr/bin/rake -E STDOUT.sync=true test
+        run: ruby /usr/bin/rake -m && ruby /usr/bin/rake test
       - name: Set PATH for cache archiving (tar)
         # set Windows path so that Cygwin tar is not used for cache archiving
         run: echo '::set-env name=PATH::C:\windows\System32'
@@ -150,4 +148,4 @@ jobs:
         shell: cmd
         run: |
           call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-          rake -E STDOUT.sync=true -m && rake -E STDOUT.sync=true test
+          rake -m && rake test

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,9 @@ language: c
 jobs:
   - os: linux
   - os: osx
-    before_install:
-      - HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_CLEANUP=1 brew install bison
-      - export PATH="/usr/local/opt/bison/bin:$PATH"
 
 env:
   - MRUBY_CONFIG=ci/gcc-clang
 
 script:
-  - rake gensym && rake -m && rake test
+  - rake -m && rake test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,6 +41,5 @@ init:
 
 build_script:
   - set MRUBY_CONFIG=ci/msvc
-  - rake gensym
-  - rake -m all
-  - rake -E $stdout.sync=true test
+  - rake -m
+  - rake test

--- a/build_config/ci/gcc-clang.rb
+++ b/build_config/ci/gcc-clang.rb
@@ -1,3 +1,5 @@
+STDOUT.sync = STDERR.sync = true
+
 MRuby::Build.new('full-debug') do |conf|
   conf.toolchain
   conf.enable_debug

--- a/build_config/ci/msvc.rb
+++ b/build_config/ci/msvc.rb
@@ -1,3 +1,5 @@
+STDOUT.sync = STDERR.sync = true
+
 def setup_option(conf)
   conf.cc.compile_options.sub!(%r{/Zi }, "") unless ENV['CFLAGS']
   conf.cxx.compile_options.sub!(%r{/Zi }, "") unless ENV['CFLAGS'] || ENV['CXXFLAGS']
@@ -5,7 +7,7 @@ def setup_option(conf)
 end
 
 MRuby::Build.new do |conf|
-  toolchain :visualcpp
+  conf.toolchain :visualcpp
 
   # include all core GEMs
   conf.gembox 'full-core'


### PR DESCRIPTION
Set in build configuration to enable on all CI platforms.