### PR TITLE
Stop immediate flush to stdout/stderr when running in parallel on CI

### DIFF
--- a/build_config/ci/gcc-clang.rb
+++ b/build_config/ci/gcc-clang.rb
@@ -1,4 +1,4 @@
-STDOUT.sync = STDERR.sync = true
+STDOUT.sync = STDERR.sync = true unless Rake.application.options.always_multitask
 
 MRuby::Build.new('full-debug') do |conf|
   conf.toolchain

--- a/build_config/ci/msvc.rb
+++ b/build_config/ci/msvc.rb
@@ -1,4 +1,4 @@
-STDOUT.sync = STDERR.sync = true
+STDOUT.sync = STDERR.sync = true unless Rake.application.options.always_multitask
 
 def setup_option(conf)
   conf.cc.compile_options.sub!(%r{/Zi }, "") unless ENV['CFLAGS']


### PR DESCRIPTION
During parallel execution (build), it is sometimes flushed before line
breaks, and lines are concatenated.