### PR TITLE
Delay test code build until `rake test`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Compiler version
         run: ${{ env.CC }} --version
       - name: Build and test
-        run: rake -m && rake test
+        run: rake -m test:build && rake test:run
 
   Ubuntu-1804-gcc:
     needs: Check-Skip
@@ -40,7 +40,7 @@ jobs:
       - name: Compiler version
         run: ${{ env.CC }} --version
       - name: Build and test
-        run: rake -m && rake test
+        run: rake -m test:build && rake test:run
 
   Ubuntu-1804-clang:
     needs: Check-Skip
@@ -55,7 +55,7 @@ jobs:
       - name: Compiler version
         run: ${{ env.CC }} --version
       - name: Build and test
-        run: rake -m && rake test
+        run: rake -m test:build && rake test:run
 
   macOS:
     needs: Check-Skip
@@ -70,7 +70,7 @@ jobs:
       - name: Compiler version
         run: ${{ env.CC }} --version
       - name: Build and test
-        run: rake -m && rake test
+        run: rake -m test:build && rake test:run
 
   Windows-MinGW:
     needs: Check-Skip
@@ -85,9 +85,7 @@ jobs:
       - name: Compiler version
         run: ${{ env.CC }} --version
       - name: Build and test
-        # If build and test are separated like `rake && rake test`, somehow
-        # it will be fully built even at `rake test`, so it is not separated.
-        run: rake test
+        run: rake -m test:build && rake test:run
 
   Windows-Cygwin:
     needs: Check-Skip
@@ -130,7 +128,7 @@ jobs:
         run: ${{ env.CC }} --version
       - name: Build and test
         shell: cmd
-        run: ruby /usr/bin/rake -m && ruby /usr/bin/rake test
+        run: ruby /usr/bin/rake -m test:build && ruby /usr/bin/rake test:run
       - name: Set PATH for cache archiving (tar)
         # set Windows path so that Cygwin tar is not used for cache archiving
         run: echo '::set-env name=PATH::C:\windows\System32'
@@ -148,4 +146,4 @@ jobs:
         shell: cmd
         run: |
           call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-          rake -m && rake test
+          rake -m test:build && rake test:run

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ env:
   - MRUBY_CONFIG=ci/gcc-clang
 
 script:
-  - rake -m && rake test
+  - rake -m test:build && rake test:run

--- a/Rakefile
+++ b/Rakefile
@@ -29,6 +29,7 @@ load "#{MRUBY_ROOT}/tasks/mrbgems.rake"
 load "#{MRUBY_ROOT}/tasks/libmruby.rake"
 load "#{MRUBY_ROOT}/tasks/bin.rake"
 load "#{MRUBY_ROOT}/tasks/presym.rake"
+load "#{MRUBY_ROOT}/tasks/test.rake"
 load "#{MRUBY_ROOT}/tasks/benchmark.rake"
 load "#{MRUBY_ROOT}/tasks/gitlab.rake"
 load "#{MRUBY_ROOT}/tasks/doc.rake"
@@ -51,37 +52,17 @@ end
 
 task :build => MRuby.targets.flat_map{|_, build| build.products}
 
-desc "run all mruby tests"
-task :test
-MRuby.each_target do
-  if test_enabled?
-    t = :"test_#{self.name}"
-    task t => ["all"] do
-      run_test
-    end
-    task :test => t
-  end
-
-  if bintest_enabled?
-    t = :"bintest_#{self.name}"
-    task t => ["all"] do
-      run_bintest
-    end
-    task :test => t
-  end
-end
-
 desc "clean all built and in-repo installed artifacts"
 task :clean do
   MRuby.each_target do |build|
-    rm_rf build.products
     rm_rf build.build_dir
+    rm_f build.products
   end
   puts "Cleaned up target build folder"
 end
 
 desc "clean everything!"
-task :deep_clean => ["clean", "clean_doc"] do
+task :deep_clean => %w[clean doc:clean] do
   MRuby.each_target do |build|
     rm_rf build.gem_clone_dir
   end

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,5 +41,5 @@ init:
 
 build_script:
   - set MRUBY_CONFIG=ci/msvc
-  - rake -m
-  - rake test
+  - rake -m test:build
+  - rake test:run

--- a/tasks/bin.rake
+++ b/tasks/bin.rake
@@ -1,35 +1,23 @@
-install_task = ->(src) do
-  dst = "#{MRuby::Build.install_dir}/#{File.basename(src)}"
-  file dst => src do
-    install_D src, dst
-  end
-  dst
-end
-
 MRuby.each_target do |build|
   if build.host? && build.mrbc_build && !build.gems["mruby-bin-mrbc"]
     exe = build.exefile("#{build.mrbc_build.build_dir}/bin/mrbc")
-    build.products << install_task.(exe)
+    build.products << build.define_installer(exe)
   end
 
-  build.bins.each do |bin|
-    exe = build.exefile("#{build.build_dir}/bin/#{bin}")
-    build.products << (build.host? ? install_task.(exe) : exe)
-  end
+  build.bins.each{|bin| build.products << define_installer_if_needed(bin)}
 
-  linker_attrs = build.gems.map{|gem| gem.linker.run_attrs}.transpose
+  linker_attrs = build.gems.linker_attrs
   build.gems.each do |gem|
     gem.bins.each do |bin|
       exe = build.exefile("#{build.build_dir}/bin/#{bin}")
       objs = Dir["#{gem.dir}/tools/#{bin}/*.{c,cpp,cxx,cc}"].map do |f|
         build.objfile(f.pathmap("#{gem.build_dir}/tools/#{bin}/%n"))
       end
-
       file exe => objs.concat(build.libraries) do |t|
         build.linker.run t.name, t.prerequisites, *linker_attrs
       end
 
-      build.products << (build.host? ? install_task.(exe) : exe)
+      build.products << define_installer_if_needed(bin)
     end
   end
 end

--- a/tasks/mrbgems.rake
+++ b/tasks/mrbgems.rake
@@ -1,11 +1,12 @@
 MRuby.each_target do
+  active_gems_txt = "#{build_dir}/mrbgems/active_gems.txt"
+
   if enable_gems?
     # set up all gems
     gems.each(&:setup)
     gems.check self
 
     # loader all gems
-    active_gems_txt = "#{build_dir}/mrbgems/active_gems.txt"
     self.libmruby_objs << objfile("#{build_dir}/mrbgems/gem_init")
     file objfile("#{build_dir}/mrbgems/gem_init") => ["#{build_dir}/mrbgems/gem_init.c", "#{build_dir}/LEGAL"]
     file "#{build_dir}/mrbgems/gem_init.c" => [active_gems_txt, MRUBY_CONFIG, __FILE__] do |t|
@@ -50,14 +51,15 @@ MRuby.each_target do
         f.puts %Q[}]
       end
     end
-    file active_gems_txt => :generate_active_gems_txt
-    task :generate_active_gems_txt do |t|
-      def t.timestamp; Time.at(0) end
-      active_gems = gems.sort_by(&:name).inject(""){|s, g| s << "#{g.name}\n"}
-      if !File.exist?(active_gems_txt) || File.read(active_gems_txt) != active_gems
-        mkdir_p File.dirname(active_gems_txt)
-        File.write(active_gems_txt, active_gems)
-      end
+  end
+
+  file active_gems_txt => :generate_active_gems_txt
+  task :generate_active_gems_txt do |t|
+    def t.timestamp; Time.at(0) end
+    active_gems = gems.sort_by(&:name).inject(""){|s, g| s << "#{g.name}\n"}
+    if !File.exist?(active_gems_txt) || File.read(active_gems_txt) != active_gems
+      mkdir_p File.dirname(active_gems_txt)
+      File.write(active_gems_txt, active_gems)
     end
   end
 

--- a/tasks/test.rake
+++ b/tasks/test.rake
@@ -1,0 +1,64 @@
+desc "build and run all mruby tests"
+task :test => "test:build" do
+  Rake::Task["test:run"].invoke
+end
+
+namespace :test do |test_ns|
+  desc "build and run library tests"
+  task :lib => "build:lib" do
+    test_ns["run:lib"].invoke
+  end
+
+  desc "build and run command binaries tests"
+  task :bin => :all do
+    test_ns["run:bin"].invoke
+  end
+
+  desc "build all mruby tests"
+  task :build => "build:lib"
+
+  namespace :build do
+    desc "build library tests"
+    task :lib
+  end
+
+  desc "run all mruby tests"
+  task :run
+
+  namespace :run do
+    desc "run library tests"
+    task :lib
+
+    desc "run command binaries tests"
+    task :bin
+  end
+end
+
+MRuby.each_target do |build|
+  if build.test_enabled?
+    t = task "test:build:lib:#{build.name}" => :all do
+      gem = build.gem(core: 'mruby-test')
+      gem.setup
+      gem.setup_compilers
+      Rake::Task[build.define_installer_if_needed("mrbtest")].invoke
+    end
+    task "test:build:lib" => t
+
+    t = task "test:run:lib:#{build.name}" do
+      build.run_test
+    end
+    task "test:run" => t
+    task "test:run:lib" => t
+  end
+  if build.bintest_enabled?
+    t = task "test:run:bin:#{build.name}" do
+      build.run_bintest
+    end
+    task "test:run" => t
+    task "test:run:bin" => t
+  end
+end
+
+task :clean do
+  rm_f "#{MRuby::Build.install_dir}/mrbtest"
+end


### PR DESCRIPTION
With this change, the test code will not be built unless `rake test` is
run, so there will be almost no side effects even if `enable_test` is
always set (but, gems specified by `add_test_dependency` are included
in `libmruby.a`).

Also added are `test: build` task, which only builds the test code
(including the main code), and `test: run` task, which only runs tests
independent of build. Therefore, the idiom for building in parallel and
not running tests in parallel is `rake -m test:build && rake test:run`.