### PR TITLE
Capture the return value of `Fiber.yield` via C; ref #5261

### DIFF
--- a/mrbgems/mruby-fiber/src/fiber.c
+++ b/mrbgems/mruby-fiber/src/fiber.c
@@ -225,6 +225,9 @@ fiber_switch(mrb_state *mrb, mrb_value self, mrb_int len, const mrb_value *a, mr
   }
   else {
     value = fiber_result(mrb, a, len);
+    if (vmexec) {
+      c->ci->stack[c->ci[1].acc] = value;
+    }
   }
 
   if (vmexec) {


### PR DESCRIPTION
Please note that this pull request contains #5272.

The argument of the second `mrb_fiber_resume()` is not the return value of `Fiber.yield`, so it will be corrected.
I will post the result of trying with a slightly modified code of #5261.

```c
#include <mruby.h>
#include <mruby/compile.h>
#include <mruby/string.h>
#include <stdio.h>

mrb_state* mrb;

void p(mrb_value value) {
    printf("--> %s\n", mrb_str_to_cstr(mrb, mrb_inspect(mrb, value)));
}

int main() {
    mrb = mrb_open();

    mrb_value fiber_class = mrb_obj_value(mrb_class_get(mrb, "Fiber"));

    mrb_value proc = mrb_load_string(mrb,
        "proc do |a| Fiber.yield(a + 1); end");
                  // ^~~~~~~~~~~~~~~~~~ ❓❓❓ What is this value?

    mrb_sym new = mrb_intern_cstr(mrb, "new");
    mrb_value fiber = mrb_funcall_with_block(mrb, fiber_class, new, 0, NULL, proc);

    mrb_value start_arg = mrb_fixnum_value(123);
    p(mrb_fiber_resume(mrb, fiber, 1, &start_arg));

    // ☕ ☕ ☕ Modify here ☕ ☕ ☕
    mrb_value second_arg = mrb_float_value(mrb, 1.41421356);
    p(mrb_fiber_resume(mrb, fiber, 1, &second_arg));
    // => 1.41421356 (expect)
    // => Fiber (when reported by #5261)
    // => nil (after commit a0c1e075e)
    // => 1.41421356 (patched this PR)

    p(mrb_fiber_resume(mrb, fiber, 0, NULL));
    p(mrb_fiber_resume(mrb, fiber, 0, NULL));
    p(mrb_fiber_resume(mrb, fiber, 0, NULL));
    p(mrb_fiber_resume(mrb, fiber, 0, NULL));
    p(mrb_fiber_resume(mrb, fiber, 0, NULL));
    p(mrb_fiber_resume(mrb, fiber, 0, NULL));
    p(mrb_fiber_resume(mrb, fiber, 0, NULL));
}
```