### PR TITLE
Replace `tempirep` with `RProc`

### DIFF
--- a/src/proc.c
+++ b/src/proc.c
@@ -52,7 +52,9 @@ mrb_proc_new(mrb_state *mrb, const mrb_irep *irep)
     p->e.target_class = tc;
   }
   p->body.irep = irep;
-  mrb_irep_incref(mrb, (mrb_irep*)irep);
+  if (irep) {
+    mrb_irep_incref(mrb, (mrb_irep*)irep);
+  }
 
   return p;
 }


### PR DESCRIPTION
Previously I used the `RData` object to avoid a memory leak in `mrb_irep` if `src/load.c` failed.
ref: https://github.com/mruby/mruby/pull/4250
commit: f1523d24042ca3416dc5b9be7b3fc220ddaed896

Considering that the `RProc` object will be created in the subsequent process, it is preferable to create the `RProc` object from the beginning.
Along with this, the inside of `read_irep()` is replaced with the processing centered on the `RProc` object.

The global function that returns the `mrb_irep` pointer is still provided for compatibility.