### PR TITLE
Avoid including `presym.inc` in existing header files

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -1303,26 +1303,26 @@ MRB_API mrb_value mrb_vformat(mrb_state *mrb, const char *format, va_list ap);
    + those E_* macros requires mrb_state* variable named mrb.
    + exception objects obtained from those macros are local to mrb
 */
-#define E_RUNTIME_ERROR             (mrb_exc_get_id(mrb, MRB_SYM(RuntimeError)))
-#define E_TYPE_ERROR                (mrb_exc_get_id(mrb, MRB_SYM(TypeError)))
-#define E_ZERODIV_ERROR             (mrb_exc_get_id(mrb, MRB_SYM(ZeroDivisionError)))
-#define E_ARGUMENT_ERROR            (mrb_exc_get_id(mrb, MRB_SYM(ArgumentError)))
-#define E_INDEX_ERROR               (mrb_exc_get_id(mrb, MRB_SYM(IndexError)))
-#define E_RANGE_ERROR               (mrb_exc_get_id(mrb, MRB_SYM(RangeError)))
-#define E_NAME_ERROR                (mrb_exc_get_id(mrb, MRB_SYM(NameError)))
-#define E_NOMETHOD_ERROR            (mrb_exc_get_id(mrb, MRB_SYM(NoMethodError)))
-#define E_SCRIPT_ERROR              (mrb_exc_get_id(mrb, MRB_SYM(ScriptError)))
-#define E_SYNTAX_ERROR              (mrb_exc_get_id(mrb, MRB_SYM(SyntaxError)))
-#define E_LOCALJUMP_ERROR           (mrb_exc_get_id(mrb, MRB_SYM(LocalJumpError)))
-#define E_REGEXP_ERROR              (mrb_exc_get_id(mrb, MRB_SYM(RegexpError)))
-#define E_FROZEN_ERROR              (mrb_exc_get_id(mrb, MRB_SYM(FrozenError)))
+#define E_RUNTIME_ERROR      mrb_exc_get_id(mrb, mrb_intern_lit(mrb, "RuntimeError"))
+#define E_TYPE_ERROR         mrb_exc_get_id(mrb, mrb_intern_lit(mrb, "TypeError"))
+#define E_ZERODIV_ERROR      mrb_exc_get_id(mrb, mrb_intern_lit(mrb, "ZeroDivisionError"))
+#define E_ARGUMENT_ERROR     mrb_exc_get_id(mrb, mrb_intern_lit(mrb, "ArgumentError"))
+#define E_INDEX_ERROR        mrb_exc_get_id(mrb, mrb_intern_lit(mrb, "IndexError"))
+#define E_RANGE_ERROR        mrb_exc_get_id(mrb, mrb_intern_lit(mrb, "RangeError"))
+#define E_NAME_ERROR         mrb_exc_get_id(mrb, mrb_intern_lit(mrb, "NameError"))
+#define E_NOMETHOD_ERROR     mrb_exc_get_id(mrb, mrb_intern_lit(mrb, "NoMethodError"))
+#define E_SCRIPT_ERROR       mrb_exc_get_id(mrb, mrb_intern_lit(mrb, "ScriptError"))
+#define E_SYNTAX_ERROR       mrb_exc_get_id(mrb, mrb_intern_lit(mrb, "SyntaxError"))
+#define E_LOCALJUMP_ERROR    mrb_exc_get_id(mrb, mrb_intern_lit(mrb, "LocalJumpError"))
+#define E_REGEXP_ERROR       mrb_exc_get_id(mrb, mrb_intern_lit(mrb, "RegexpError"))
+#define E_FROZEN_ERROR       mrb_exc_get_id(mrb, mrb_intern_lit(mrb, "FrozenError"))
 
-#define E_NOTIMP_ERROR              (mrb_exc_get_id(mrb, MRB_SYM(NotImplementedError)))
+#define E_NOTIMP_ERROR       mrb_exc_get_id(mrb, mrb_intern_lit(mrb, "NotImplementedError"))
 #ifndef MRB_NO_FLOAT
-#define E_FLOATDOMAIN_ERROR         (mrb_exc_get_id(mrb, MRB_SYM(FloatDomainError)))
+#define E_FLOATDOMAIN_ERROR  mrb_exc_get_id(mrb, mrb_intern_lit(mrb, "FloatDomainError"))
 #endif
 
-#define E_KEY_ERROR                 (mrb_exc_get_id(mrb, MRB_SYM(KeyError)))
+#define E_KEY_ERROR          mrb_exc_get_id(mrb, mrb_intern_lit(mrb, "KeyError"))
 
 MRB_API mrb_value mrb_yield(mrb_state *mrb, mrb_value b, mrb_value arg);
 MRB_API mrb_value mrb_yield_argv(mrb_state *mrb, mrb_value b, mrb_int argc, const mrb_value *argv);
@@ -1389,7 +1389,7 @@ MRB_API mrb_value mrb_fiber_alive_p(mrb_state *mrb, mrb_value fib);
  *
  * Implemented in mruby-fiber
  */
-#define E_FIBER_ERROR (mrb_exc_get_id(mrb, MRB_SYM(FiberError)))
+#define E_FIBER_ERROR mrb_exc_get_id(mrb, mrb_intern_lit(mrb, "FiberError"))
 MRB_API void mrb_stack_extend(mrb_state*, mrb_int);
 
 /* memory pool implementation */
@@ -1409,7 +1409,9 @@ MRB_API void mrb_show_copyright(mrb_state *mrb);
 
 MRB_API mrb_value mrb_format(mrb_state *mrb, const char *format, ...);
 
-#include <mruby/presym.h>
+#ifdef MRB_PRESYM_SCANNING
+# include <mruby/presym/scanning.h>
+#endif
 
 #if 0
 /* memcpy and memset does not work with gdb reverse-next on my box */

--- a/include/mruby/hash.h
+++ b/include/mruby/hash.h
@@ -212,8 +212,6 @@ MRB_API mrb_value mrb_hash_dup(mrb_state *mrb, mrb_value hash);
 MRB_API void mrb_hash_merge(mrb_state *mrb, mrb_value hash1, mrb_value hash2);
 
 #define RHASH(hash) ((struct RHash*)(mrb_ptr(hash)))
-#define RHASH_IFNONE(hash) mrb_iv_get(mrb, (hash), MRB_SYM(ifnone))
-#define RHASH_PROCDEFAULT(hash) RHASH_IFNONE(hash)
 
 #define MRB_HASH_IB_BIT_BIT         5
 #define MRB_HASH_AR_EA_CAPA_BIT     5

--- a/include/mruby/presym.h
+++ b/include/mruby/presym.h
@@ -7,11 +7,9 @@
 #ifndef MRUBY_PRESYM_H
 #define MRUBY_PRESYM_H
 
-#if defined(MRB_PRESYM_SCANNING)
-# include <mruby/presym/scanning.h>
-#elif defined(MRB_NO_PRESYM)
+#if defined(MRB_NO_PRESYM)
 # include <mruby/presym/disable.h>
-#else
+#elif !defined(MRB_PRESYM_SCANNING)
 # include <mruby/presym/enable.h>
 #endif
 

--- a/include/mruby/presym/scanning.h
+++ b/include/mruby/presym/scanning.h
@@ -23,7 +23,6 @@
 #define mrb_define_const(mrb, c, name, v) MRB_PRESYM_SCANNING_TAGGED(name)
 #define mrb_define_global_const(mrb, name, v) MRB_PRESYM_SCANNING_TAGGED(name)
 
-
 #define MRB_OPSYM(name) MRB_OPSYM__##name(mrb)
 #define MRB_CVSYM(name) MRB_PRESYM_SCANNING_TAGGED("@@" #name)
 #define MRB_IVSYM(name) MRB_PRESYM_SCANNING_TAGGED("@" #name)

--- a/mrbgems/mruby-array-ext/src/array.c
+++ b/mrbgems/mruby-array-ext/src/array.c
@@ -3,6 +3,7 @@
 #include <mruby/array.h>
 #include <mruby/range.h>
 #include <mruby/hash.h>
+#include <mruby/presym.h>
 
 /*
  *  call-seq:

--- a/mrbgems/mruby-bin-debugger/tools/mrdb/apiprint.c
+++ b/mrbgems/mruby-bin-debugger/tools/mrdb/apiprint.c
@@ -11,6 +11,7 @@
 #include <mruby/error.h>
 #include <mruby/numeric.h>
 #include <mruby/string.h>
+#include <mruby/presym.h>
 #include "apiprint.h"
 
 static void

--- a/mrbgems/mruby-bin-mirb/tools/mirb/mirb.c
+++ b/mrbgems/mruby-bin-mirb/tools/mirb/mirb.c
@@ -18,6 +18,7 @@
 #include <mruby/dump.h>
 #include <mruby/string.h>
 #include <mruby/variable.h>
+#include <mruby/presym.h>
 
 #include <stdlib.h>
 #include <string.h>

--- a/mrbgems/mruby-compiler/core/codegen.c
+++ b/mrbgems/mruby-compiler/core/codegen.c
@@ -15,6 +15,7 @@
 #include <mruby/numeric.h>
 #include <mruby/string.h>
 #include <mruby/debug.h>
+#include <mruby/presym.h>
 #include "node.h"
 #include <mruby/opcode.h>
 #include <mruby/re.h>

--- a/mrbgems/mruby-compiler/core/parse.y
+++ b/mrbgems/mruby-compiler/core/parse.y
@@ -22,6 +22,7 @@
 #include <mruby/throw.h>
 #include <mruby/string.h>
 #include <mruby/dump.h>
+#include <mruby/presym.h>
 #include "node.h"
 
 #define YYLEX_PARAM p

--- a/mrbgems/mruby-compiler/core/y.tab.c
+++ b/mrbgems/mruby-compiler/core/y.tab.c
@@ -1,4 +1,4 @@
-/* A Bison parser, made by GNU Bison 3.5.1.  */
+/* A Bison parser, made by GNU Bison 3.7.4.  */
 
 /* Bison implementation for Yacc-like parsers in C
 
@@ -34,6 +34,10 @@
 /* C LALR(1) parser skeleton written by Richard Stallman, by
    simplifying the original so-called "semantic" parser.  */
 
+/* DO NOT RELY ON FEATURES THAT ARE NOT DOCUMENTED in the manual,
+   especially those whose name start with YY_ or yy_.  They are
+   private implementation details that can be changed or removed.  */
+
 /* All symbols defined below should begin with yy or YY, to avoid
    infringing on user name space.  This should be done even for local
    variables, as they might otherwise be expanded by user macros.
@@ -41,14 +45,11 @@
    define necessary library symbols; they are noted "INFRINGES ON
    USER NAME SPACE" below.  */
 
-/* Undocumented macros, especially those whose name start with YY_,
-   are private implementation details.  Do not rely on them.  */
+/* Identify Bison output, and Bison version.  */
+#define YYBISON 30704
 
-/* Identify Bison output.  */
-#define YYBISON 1
-
-/* Bison version.  */
-#define YYBISON_VERSION "3.5.1"
+/* Bison version string.  */
+#define YYBISON_VERSION "3.7.4"
 
 /* Skeleton name.  */
 #define YYSKELETON_NAME "yacc.c"
@@ -85,6 +86,7 @@
 #include <mruby/throw.h>
 #include <mruby/string.h>
 #include <mruby/dump.h>
+#include <mruby/presym.h>
 #include "node.h"
 
 #define YYLEX_PARAM p
@@ -1432,7 +1434,7 @@ heredoc_end(parser_state *p)
 /* xxx ----------------------------- */
 
 
-#line 1436 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 1438 "mrbgems/mruby-compiler/core/y.tab.c"
 
 # ifndef YY_CAST
 #  ifdef __cplusplus
@@ -1455,14 +1457,6 @@ heredoc_end(parser_state *p)
 #  endif
 # endif
 
-/* Enabling verbose error messages.  */
-#ifdef YYERROR_VERBOSE
-# undef YYERROR_VERBOSE
-# define YYERROR_VERBOSE 1
-#else
-# define YYERROR_VERBOSE 1
-#endif
-
 
 /* Debug traces.  */
 #ifndef YYDEBUG
@@ -1472,139 +1466,144 @@ heredoc_end(parser_state *p)
 extern int yydebug;
 #endif
 
-/* Token type.  */
+/* Token kinds.  */
 #ifndef YYTOKENTYPE
 # define YYTOKENTYPE
   enum yytokentype
   {
-    keyword_class = 258,
-    keyword_module = 259,
-    keyword_def = 260,
-    keyword_begin = 261,
-    keyword_if = 262,
-    keyword_unless = 263,
-    keyword_while = 264,
-    keyword_until = 265,
-    keyword_for = 266,
-    keyword_undef = 267,
-    keyword_rescue = 268,
-    keyword_ensure = 269,
-    keyword_end = 270,
-    keyword_then = 271,
-    keyword_elsif = 272,
-    keyword_else = 273,
-    keyword_case = 274,
-    keyword_when = 275,
-    keyword_break = 276,
-    keyword_next = 277,
-    keyword_redo = 278,
-    keyword_retry = 279,
-    keyword_in = 280,
-    keyword_do = 281,
-    keyword_do_cond = 282,
-    keyword_do_block = 283,
-    keyword_do_LAMBDA = 284,
-    keyword_return = 285,
-    keyword_yield = 286,
-    keyword_super = 287,
-    keyword_self = 288,
-    keyword_nil = 289,
-    keyword_true = 290,
-    keyword_false = 291,
-    keyword_and = 292,
-    keyword_or = 293,
-    keyword_not = 294,
-    modifier_if = 295,
-    modifier_unless = 296,
-    modifier_while = 297,
-    modifier_until = 298,
-    modifier_rescue = 299,
-    keyword_alias = 300,
-    keyword_BEGIN = 301,
-    keyword_END = 302,
-    keyword__LINE__ = 303,
-    keyword__FILE__ = 304,
-    keyword__ENCODING__ = 305,
-    tIDENTIFIER = 306,
-    tFID = 307,
-    tGVAR = 308,
-    tIVAR = 309,
-    tCONSTANT = 310,
-    tCVAR = 311,
-    tLABEL_TAG = 312,
-    tINTEGER = 313,
-    tFLOAT = 314,
-    tCHAR = 315,
-    tXSTRING = 316,
-    tREGEXP = 317,
-    tSTRING = 318,
-    tSTRING_PART = 319,
-    tSTRING_MID = 320,
-    tNTH_REF = 321,
-    tBACK_REF = 322,
-    tREGEXP_END = 323,
-    tNUMPARAM = 324,
-    tUPLUS = 325,
-    tUMINUS = 326,
-    tPOW = 327,
-    tCMP = 328,
-    tEQ = 329,
-    tEQQ = 330,
-    tNEQ = 331,
-    tGEQ = 332,
-    tLEQ = 333,
-    tANDOP = 334,
-    tOROP = 335,
-    tMATCH = 336,
-    tNMATCH = 337,
-    tDOT2 = 338,
-    tDOT3 = 339,
-    tBDOT2 = 340,
-    tBDOT3 = 341,
-    tAREF = 342,
-    tASET = 343,
-    tLSHFT = 344,
-    tRSHFT = 345,
-    tCOLON2 = 346,
-    tCOLON3 = 347,
-    tOP_ASGN = 348,
-    tASSOC = 349,
-    tLPAREN = 350,
-    tLPAREN_ARG = 351,
-    tRPAREN = 352,
-    tLBRACK = 353,
-    tLBRACE = 354,
-    tLBRACE_ARG = 355,
-    tSTAR = 356,
-    tDSTAR = 357,
-    tAMPER = 358,
-    tLAMBDA = 359,
-    tANDDOT = 360,
-    tSYMBEG = 361,
-    tREGEXP_BEG = 362,
-    tWORDS_BEG = 363,
-    tSYMBOLS_BEG = 364,
-    tSTRING_BEG = 365,
-    tXSTRING_BEG = 366,
-    tSTRING_DVAR = 367,
-    tLAMBEG = 368,
-    tHEREDOC_BEG = 369,
-    tHEREDOC_END = 370,
-    tLITERAL_DELIM = 371,
-    tHD_LITERAL_DELIM = 372,
-    tHD_STRING_PART = 373,
-    tHD_STRING_MID = 374,
-    tLOWEST = 375,
-    tUMINUS_NUM = 376,
-    tLAST_TOKEN = 377
+    YYEMPTY = -2,
+    YYEOF = 0,                     /* "end of file"  */
+    YYerror = 256,                 /* error  */
+    YYUNDEF = 257,                 /* "invalid token"  */
+    keyword_class = 258,           /* keyword_class  */
+    keyword_module = 259,          /* keyword_module  */
+    keyword_def = 260,             /* keyword_def  */
+    keyword_begin = 261,           /* keyword_begin  */
+    keyword_if = 262,              /* keyword_if  */
+    keyword_unless = 263,          /* keyword_unless  */
+    keyword_while = 264,           /* keyword_while  */
+    keyword_until = 265,           /* keyword_until  */
+    keyword_for = 266,             /* keyword_for  */
+    keyword_undef = 267,           /* keyword_undef  */
+    keyword_rescue = 268,          /* keyword_rescue  */
+    keyword_ensure = 269,          /* keyword_ensure  */
+    keyword_end = 270,             /* keyword_end  */
+    keyword_then = 271,            /* keyword_then  */
+    keyword_elsif = 272,           /* keyword_elsif  */
+    keyword_else = 273,            /* keyword_else  */
+    keyword_case = 274,            /* keyword_case  */
+    keyword_when = 275,            /* keyword_when  */
+    keyword_break = 276,           /* keyword_break  */
+    keyword_next = 277,            /* keyword_next  */
+    keyword_redo = 278,            /* keyword_redo  */
+    keyword_retry = 279,           /* keyword_retry  */
+    keyword_in = 280,              /* keyword_in  */
+    keyword_do = 281,              /* keyword_do  */
+    keyword_do_cond = 282,         /* keyword_do_cond  */
+    keyword_do_block = 283,        /* keyword_do_block  */
+    keyword_do_LAMBDA = 284,       /* keyword_do_LAMBDA  */
+    keyword_return = 285,          /* keyword_return  */
+    keyword_yield = 286,           /* keyword_yield  */
+    keyword_super = 287,           /* keyword_super  */
+    keyword_self = 288,            /* keyword_self  */
+    keyword_nil = 289,             /* keyword_nil  */
+    keyword_true = 290,            /* keyword_true  */
+    keyword_false = 291,           /* keyword_false  */
+    keyword_and = 292,             /* keyword_and  */
+    keyword_or = 293,              /* keyword_or  */
+    keyword_not = 294,             /* keyword_not  */
+    modifier_if = 295,             /* modifier_if  */
+    modifier_unless = 296,         /* modifier_unless  */
+    modifier_while = 297,          /* modifier_while  */
+    modifier_until = 298,          /* modifier_until  */
+    modifier_rescue = 299,         /* modifier_rescue  */
+    keyword_alias = 300,           /* keyword_alias  */
+    keyword_BEGIN = 301,           /* keyword_BEGIN  */
+    keyword_END = 302,             /* keyword_END  */
+    keyword__LINE__ = 303,         /* keyword__LINE__  */
+    keyword__FILE__ = 304,         /* keyword__FILE__  */
+    keyword__ENCODING__ = 305,     /* keyword__ENCODING__  */
+    tIDENTIFIER = 306,             /* tIDENTIFIER  */
+    tFID = 307,                    /* tFID  */
+    tGVAR = 308,                   /* tGVAR  */
+    tIVAR = 309,                   /* tIVAR  */
+    tCONSTANT = 310,               /* tCONSTANT  */
+    tCVAR = 311,                   /* tCVAR  */
+    tLABEL_TAG = 312,              /* tLABEL_TAG  */
+    tINTEGER = 313,                /* tINTEGER  */
+    tFLOAT = 314,                  /* tFLOAT  */
+    tCHAR = 315,                   /* tCHAR  */
+    tXSTRING = 316,                /* tXSTRING  */
+    tREGEXP = 317,                 /* tREGEXP  */
+    tSTRING = 318,                 /* tSTRING  */
+    tSTRING_PART = 319,            /* tSTRING_PART  */
+    tSTRING_MID = 320,             /* tSTRING_MID  */
+    tNTH_REF = 321,                /* tNTH_REF  */
+    tBACK_REF = 322,               /* tBACK_REF  */
+    tREGEXP_END = 323,             /* tREGEXP_END  */
+    tNUMPARAM = 324,               /* tNUMPARAM  */
+    tUPLUS = 325,                  /* tUPLUS  */
+    tUMINUS = 326,                 /* tUMINUS  */
+    tPOW = 327,                    /* tPOW  */
+    tCMP = 328,                    /* tCMP  */
+    tEQ = 329,                     /* tEQ  */
+    tEQQ = 330,                    /* tEQQ  */
+    tNEQ = 331,                    /* tNEQ  */
+    tGEQ = 332,                    /* tGEQ  */
+    tLEQ = 333,                    /* tLEQ  */
+    tANDOP = 334,                  /* tANDOP  */
+    tOROP = 335,                   /* tOROP  */
+    tMATCH = 336,                  /* tMATCH  */
+    tNMATCH = 337,                 /* tNMATCH  */
+    tDOT2 = 338,                   /* tDOT2  */
+    tDOT3 = 339,                   /* tDOT3  */
+    tBDOT2 = 340,                  /* tBDOT2  */
+    tBDOT3 = 341,                  /* tBDOT3  */
+    tAREF = 342,                   /* tAREF  */
+    tASET = 343,                   /* tASET  */
+    tLSHFT = 344,                  /* tLSHFT  */
+    tRSHFT = 345,                  /* tRSHFT  */
+    tCOLON2 = 346,                 /* tCOLON2  */
+    tCOLON3 = 347,                 /* tCOLON3  */
+    tOP_ASGN = 348,                /* tOP_ASGN  */
+    tASSOC = 349,                  /* tASSOC  */
+    tLPAREN = 350,                 /* tLPAREN  */
+    tLPAREN_ARG = 351,             /* tLPAREN_ARG  */
+    tRPAREN = 352,                 /* tRPAREN  */
+    tLBRACK = 353,                 /* tLBRACK  */
+    tLBRACE = 354,                 /* tLBRACE  */
+    tLBRACE_ARG = 355,             /* tLBRACE_ARG  */
+    tSTAR = 356,                   /* tSTAR  */
+    tDSTAR = 357,                  /* tDSTAR  */
+    tAMPER = 358,                  /* tAMPER  */
+    tLAMBDA = 359,                 /* tLAMBDA  */
+    tANDDOT = 360,                 /* tANDDOT  */
+    tSYMBEG = 361,                 /* tSYMBEG  */
+    tREGEXP_BEG = 362,             /* tREGEXP_BEG  */
+    tWORDS_BEG = 363,              /* tWORDS_BEG  */
+    tSYMBOLS_BEG = 364,            /* tSYMBOLS_BEG  */
+    tSTRING_BEG = 365,             /* tSTRING_BEG  */
+    tXSTRING_BEG = 366,            /* tXSTRING_BEG  */
+    tSTRING_DVAR = 367,            /* tSTRING_DVAR  */
+    tLAMBEG = 368,                 /* tLAMBEG  */
+    tHEREDOC_BEG = 369,            /* tHEREDOC_BEG  */
+    tHEREDOC_END = 370,            /* tHEREDOC_END  */
+    tLITERAL_DELIM = 371,          /* tLITERAL_DELIM  */
+    tHD_LITERAL_DELIM = 372,       /* tHD_LITERAL_DELIM  */
+    tHD_STRING_PART = 373,         /* tHD_STRING_PART  */
+    tHD_STRING_MID = 374,          /* tHD_STRING_MID  */
+    tLOWEST = 375,                 /* tLOWEST  */
+    tUMINUS_NUM = 376,             /* tUMINUS_NUM  */
+    tLAST_TOKEN = 377              /* tLAST_TOKEN  */
   };
+  typedef enum yytokentype yytoken_kind_t;
 #endif
 
 /* Value type.  */
 #if ! defined YYSTYPE && ! defined YYSTYPE_IS_DECLARED
 union YYSTYPE
 {
-#line 1378 "mrbgems/mruby-compiler/core/parse.y"
+#line 1379 "mrbgems/mruby-compiler/core/parse.y"
 
     node *nd;
     mrb_sym id;
@@ -1612,7 +1611,7 @@ union YYSTYPE
     stack_type stack;
     const struct vtable *vars;
 
-#line 1616 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 1615 "mrbgems/mruby-compiler/core/y.tab.c"
 
 };
 typedef union YYSTYPE YYSTYPE;
@@ -1624,6 +1623,338 @@ typedef union YYSTYPE YYSTYPE;
 
 int yyparse (parser_state *p);
 
+
+/* Symbol kind.  */
+enum yysymbol_kind_t
+{
+  YYSYMBOL_YYEMPTY = -2,
+  YYSYMBOL_YYEOF = 0,                      /* "end of file"  */
+  YYSYMBOL_YYerror = 1,                    /* error  */
+  YYSYMBOL_YYUNDEF = 2,                    /* "invalid token"  */
+  YYSYMBOL_keyword_class = 3,              /* keyword_class  */
+  YYSYMBOL_keyword_module = 4,             /* keyword_module  */
+  YYSYMBOL_keyword_def = 5,                /* keyword_def  */
+  YYSYMBOL_keyword_begin = 6,              /* keyword_begin  */
+  YYSYMBOL_keyword_if = 7,                 /* keyword_if  */
+  YYSYMBOL_keyword_unless = 8,             /* keyword_unless  */
+  YYSYMBOL_keyword_while = 9,              /* keyword_while  */
+  YYSYMBOL_keyword_until = 10,             /* keyword_until  */
+  YYSYMBOL_keyword_for = 11,               /* keyword_for  */
+  YYSYMBOL_keyword_undef = 12,             /* keyword_undef  */
+  YYSYMBOL_keyword_rescue = 13,            /* keyword_rescue  */
+  YYSYMBOL_keyword_ensure = 14,            /* keyword_ensure  */
+  YYSYMBOL_keyword_end = 15,               /* keyword_end  */
+  YYSYMBOL_keyword_then = 16,              /* keyword_then  */
+  YYSYMBOL_keyword_elsif = 17,             /* keyword_elsif  */
+  YYSYMBOL_keyword_else = 18,              /* keyword_else  */
+  YYSYMBOL_keyword_case = 19,              /* keyword_case  */
+  YYSYMBOL_keyword_when = 20,              /* keyword_when  */
+  YYSYMBOL_keyword_break = 21,             /* keyword_break  */
+  YYSYMBOL_keyword_next = 22,              /* keyword_next  */
+  YYSYMBOL_keyword_redo = 23,              /* keyword_redo  */
+  YYSYMBOL_keyword_retry = 24,             /* keyword_retry  */
+  YYSYMBOL_keyword_in = 25,                /* keyword_in  */
+  YYSYMBOL_keyword_do = 26,                /* keyword_do  */
+  YYSYMBOL_keyword_do_cond = 27,           /* keyword_do_cond  */
+  YYSYMBOL_keyword_do_block = 28,          /* keyword_do_block  */
+  YYSYMBOL_keyword_do_LAMBDA = 29,         /* keyword_do_LAMBDA  */
+  YYSYMBOL_keyword_return = 30,            /* keyword_return  */
+  YYSYMBOL_keyword_yield = 31,             /* keyword_yield  */
+  YYSYMBOL_keyword_super = 32,             /* keyword_super  */
+  YYSYMBOL_keyword_self = 33,              /* keyword_self  */
+  YYSYMBOL_keyword_nil = 34,               /* keyword_nil  */
+  YYSYMBOL_keyword_true = 35,              /* keyword_true  */
+  YYSYMBOL_keyword_false = 36,             /* keyword_false  */
+  YYSYMBOL_keyword_and = 37,               /* keyword_and  */
+  YYSYMBOL_keyword_or = 38,                /* keyword_or  */
+  YYSYMBOL_keyword_not = 39,               /* keyword_not  */
+  YYSYMBOL_modifier_if = 40,               /* modifier_if  */
+  YYSYMBOL_modifier_unless = 41,           /* modifier_unless  */
+  YYSYMBOL_modifier_while = 42,            /* modifier_while  */
+  YYSYMBOL_modifier_until = 43,            /* modifier_until  */
+  YYSYMBOL_modifier_rescue = 44,           /* modifier_rescue  */
+  YYSYMBOL_keyword_alias = 45,             /* keyword_alias  */
+  YYSYMBOL_keyword_BEGIN = 46,             /* keyword_BEGIN  */
+  YYSYMBOL_keyword_END = 47,               /* keyword_END  */
+  YYSYMBOL_keyword__LINE__ = 48,           /* keyword__LINE__  */
+  YYSYMBOL_keyword__FILE__ = 49,           /* keyword__FILE__  */
+  YYSYMBOL_keyword__ENCODING__ = 50,       /* keyword__ENCODING__  */
+  YYSYMBOL_tIDENTIFIER = 51,               /* tIDENTIFIER  */
+  YYSYMBOL_tFID = 52,                      /* tFID  */
+  YYSYMBOL_tGVAR = 53,                     /* tGVAR  */
+  YYSYMBOL_tIVAR = 54,                     /* tIVAR  */
+  YYSYMBOL_tCONSTANT = 55,                 /* tCONSTANT  */
+  YYSYMBOL_tCVAR = 56,                     /* tCVAR  */
+  YYSYMBOL_tLABEL_TAG = 57,                /* tLABEL_TAG  */
+  YYSYMBOL_tINTEGER = 58,                  /* tINTEGER  */
+  YYSYMBOL_tFLOAT = 59,                    /* tFLOAT  */
+  YYSYMBOL_tCHAR = 60,                     /* tCHAR  */
+  YYSYMBOL_tXSTRING = 61,                  /* tXSTRING  */
+  YYSYMBOL_tREGEXP = 62,                   /* tREGEXP  */
+  YYSYMBOL_tSTRING = 63,                   /* tSTRING  */
+  YYSYMBOL_tSTRING_PART = 64,              /* tSTRING_PART  */
+  YYSYMBOL_tSTRING_MID = 65,               /* tSTRING_MID  */
+  YYSYMBOL_tNTH_REF = 66,                  /* tNTH_REF  */
+  YYSYMBOL_tBACK_REF = 67,                 /* tBACK_REF  */
+  YYSYMBOL_tREGEXP_END = 68,               /* tREGEXP_END  */
+  YYSYMBOL_tNUMPARAM = 69,                 /* tNUMPARAM  */
+  YYSYMBOL_tUPLUS = 70,                    /* tUPLUS  */
+  YYSYMBOL_tUMINUS = 71,                   /* tUMINUS  */
+  YYSYMBOL_tPOW = 72,                      /* tPOW  */
+  YYSYMBOL_tCMP = 73,                      /* tCMP  */
+  YYSYMBOL_tEQ = 74,                       /* tEQ  */
+  YYSYMBOL_tEQQ = 75,                      /* tEQQ  */
+  YYSYMBOL_tNEQ = 76,                      /* tNEQ  */
+  YYSYMBOL_tGEQ = 77,                      /* tGEQ  */
+  YYSYMBOL_tLEQ = 78,                      /* tLEQ  */
+  YYSYMBOL_tANDOP = 79,                    /* tANDOP  */
+  YYSYMBOL_tOROP = 80,                     /* tOROP  */
+  YYSYMBOL_tMATCH = 81,                    /* tMATCH  */
+  YYSYMBOL_tNMATCH = 82,                   /* tNMATCH  */
+  YYSYMBOL_tDOT2 = 83,                     /* tDOT2  */
+  YYSYMBOL_tDOT3 = 84,                     /* tDOT3  */
+  YYSYMBOL_tBDOT2 = 85,                    /* tBDOT2  */
+  YYSYMBOL_tBDOT3 = 86,                    /* tBDOT3  */
+  YYSYMBOL_tAREF = 87,                     /* tAREF  */
+  YYSYMBOL_tASET = 88,                     /* tASET  */
+  YYSYMBOL_tLSHFT = 89,                    /* tLSHFT  */
+  YYSYMBOL_tRSHFT = 90,                    /* tRSHFT  */
+  YYSYMBOL_tCOLON2 = 91,                   /* tCOLON2  */
+  YYSYMBOL_tCOLON3 = 92,                   /* tCOLON3  */
+  YYSYMBOL_tOP_ASGN = 93,                  /* tOP_ASGN  */
+  YYSYMBOL_tASSOC = 94,                    /* tASSOC  */
+  YYSYMBOL_tLPAREN = 95,                   /* tLPAREN  */
+  YYSYMBOL_tLPAREN_ARG = 96,               /* tLPAREN_ARG  */
+  YYSYMBOL_tRPAREN = 97,                   /* tRPAREN  */
+  YYSYMBOL_tLBRACK = 98,                   /* tLBRACK  */
+  YYSYMBOL_tLBRACE = 99,                   /* tLBRACE  */
+  YYSYMBOL_tLBRACE_ARG = 100,              /* tLBRACE_ARG  */
+  YYSYMBOL_tSTAR = 101,                    /* tSTAR  */
+  YYSYMBOL_tDSTAR = 102,                   /* tDSTAR  */
+  YYSYMBOL_tAMPER = 103,                   /* tAMPER  */
+  YYSYMBOL_tLAMBDA = 104,                  /* tLAMBDA  */
+  YYSYMBOL_tANDDOT = 105,                  /* tANDDOT  */
+  YYSYMBOL_tSYMBEG = 106,                  /* tSYMBEG  */
+  YYSYMBOL_tREGEXP_BEG = 107,              /* tREGEXP_BEG  */
+  YYSYMBOL_tWORDS_BEG = 108,               /* tWORDS_BEG  */
+  YYSYMBOL_tSYMBOLS_BEG = 109,             /* tSYMBOLS_BEG  */
+  YYSYMBOL_tSTRING_BEG = 110,              /* tSTRING_BEG  */
+  YYSYMBOL_tXSTRING_BEG = 111,             /* tXSTRING_BEG  */
+  YYSYMBOL_tSTRING_DVAR = 112,             /* tSTRING_DVAR  */
+  YYSYMBOL_tLAMBEG = 113,                  /* tLAMBEG  */
+  YYSYMBOL_tHEREDOC_BEG = 114,             /* tHEREDOC_BEG  */
+  YYSYMBOL_tHEREDOC_END = 115,             /* tHEREDOC_END  */
+  YYSYMBOL_tLITERAL_DELIM = 116,           /* tLITERAL_DELIM  */
+  YYSYMBOL_tHD_LITERAL_DELIM = 117,        /* tHD_LITERAL_DELIM  */
+  YYSYMBOL_tHD_STRING_PART = 118,          /* tHD_STRING_PART  */
+  YYSYMBOL_tHD_STRING_MID = 119,           /* tHD_STRING_MID  */
+  YYSYMBOL_tLOWEST = 120,                  /* tLOWEST  */
+  YYSYMBOL_121_ = 121,                     /* '='  */
+  YYSYMBOL_122_ = 122,                     /* '?'  */
+  YYSYMBOL_123_ = 123,                     /* ':'  */
+  YYSYMBOL_124_ = 124,                     /* '>'  */
+  YYSYMBOL_125_ = 125,                     /* '<'  */
+  YYSYMBOL_126_ = 126,                     /* '|'  */
+  YYSYMBOL_127_ = 127,                     /* '^'  */
+  YYSYMBOL_128_ = 128,                     /* '&'  */
+  YYSYMBOL_129_ = 129,                     /* '+'  */
+  YYSYMBOL_130_ = 130,                     /* '-'  */
+  YYSYMBOL_131_ = 131,                     /* '*'  */
+  YYSYMBOL_132_ = 132,                     /* '/'  */
+  YYSYMBOL_133_ = 133,                     /* '%'  */
+  YYSYMBOL_tUMINUS_NUM = 134,              /* tUMINUS_NUM  */
+  YYSYMBOL_135_ = 135,                     /* '!'  */
+  YYSYMBOL_136_ = 136,                     /* '~'  */
+  YYSYMBOL_tLAST_TOKEN = 137,              /* tLAST_TOKEN  */
+  YYSYMBOL_138_ = 138,                     /* '{'  */
+  YYSYMBOL_139_ = 139,                     /* '}'  */
+  YYSYMBOL_140_ = 140,                     /* '['  */
+  YYSYMBOL_141_ = 141,                     /* ']'  */
+  YYSYMBOL_142_ = 142,                     /* ','  */
+  YYSYMBOL_143_ = 143,                     /* '`'  */
+  YYSYMBOL_144_ = 144,                     /* '('  */
+  YYSYMBOL_145_ = 145,                     /* ')'  */
+  YYSYMBOL_146_ = 146,                     /* ';'  */
+  YYSYMBOL_147_ = 147,                     /* '.'  */
+  YYSYMBOL_148_n_ = 148,                   /* '\n'  */
+  YYSYMBOL_YYACCEPT = 149,                 /* $accept  */
+  YYSYMBOL_program = 150,                  /* program  */
+  YYSYMBOL_151_1 = 151,                    /* $@1  */
+  YYSYMBOL_top_compstmt = 152,             /* top_compstmt  */
+  YYSYMBOL_top_stmts = 153,                /* top_stmts  */
+  YYSYMBOL_top_stmt = 154,                 /* top_stmt  */
+  YYSYMBOL_155_2 = 155,                    /* @2  */
+  YYSYMBOL_bodystmt = 156,                 /* bodystmt  */
+  YYSYMBOL_compstmt = 157,                 /* compstmt  */
+  YYSYMBOL_stmts = 158,                    /* stmts  */
+  YYSYMBOL_stmt = 159,                     /* stmt  */
+  YYSYMBOL_160_3 = 160,                    /* $@3  */
+  YYSYMBOL_command_asgn = 161,             /* command_asgn  */
+  YYSYMBOL_command_rhs = 162,              /* command_rhs  */
+  YYSYMBOL_expr = 163,                     /* expr  */
+  YYSYMBOL_defn_head = 164,                /* defn_head  */
+  YYSYMBOL_defs_head = 165,                /* defs_head  */
+  YYSYMBOL_166_4 = 166,                    /* $@4  */
+  YYSYMBOL_expr_value = 167,               /* expr_value  */
+  YYSYMBOL_command_call = 168,             /* command_call  */
+  YYSYMBOL_block_command = 169,            /* block_command  */
+  YYSYMBOL_cmd_brace_block = 170,          /* cmd_brace_block  */
+  YYSYMBOL_171_5 = 171,                    /* $@5  */
+  YYSYMBOL_command = 172,                  /* command  */
+  YYSYMBOL_mlhs = 173,                     /* mlhs  */
+  YYSYMBOL_mlhs_inner = 174,               /* mlhs_inner  */
+  YYSYMBOL_mlhs_basic = 175,               /* mlhs_basic  */
+  YYSYMBOL_mlhs_item = 176,                /* mlhs_item  */
+  YYSYMBOL_mlhs_list = 177,                /* mlhs_list  */
+  YYSYMBOL_mlhs_post = 178,                /* mlhs_post  */
+  YYSYMBOL_mlhs_node = 179,                /* mlhs_node  */
+  YYSYMBOL_lhs = 180,                      /* lhs  */
+  YYSYMBOL_cname = 181,                    /* cname  */
+  YYSYMBOL_cpath = 182,                    /* cpath  */
+  YYSYMBOL_fname = 183,                    /* fname  */
+  YYSYMBOL_fsym = 184,                     /* fsym  */
+  YYSYMBOL_undef_list = 185,               /* undef_list  */
+  YYSYMBOL_186_6 = 186,                    /* $@6  */
+  YYSYMBOL_op = 187,                       /* op  */
+  YYSYMBOL_reswords = 188,                 /* reswords  */
+  YYSYMBOL_arg = 189,                      /* arg  */
+  YYSYMBOL_aref_args = 190,                /* aref_args  */
+  YYSYMBOL_arg_rhs = 191,                  /* arg_rhs  */
+  YYSYMBOL_paren_args = 192,               /* paren_args  */
+  YYSYMBOL_opt_paren_args = 193,           /* opt_paren_args  */
+  YYSYMBOL_opt_call_args = 194,            /* opt_call_args  */
+  YYSYMBOL_call_args = 195,                /* call_args  */
+  YYSYMBOL_command_args = 196,             /* command_args  */
+  YYSYMBOL_197_7 = 197,                    /* @7  */
+  YYSYMBOL_block_arg = 198,                /* block_arg  */
+  YYSYMBOL_opt_block_arg = 199,            /* opt_block_arg  */
+  YYSYMBOL_comma = 200,                    /* comma  */
+  YYSYMBOL_args = 201,                     /* args  */
+  YYSYMBOL_mrhs = 202,                     /* mrhs  */
+  YYSYMBOL_primary = 203,                  /* primary  */
+  YYSYMBOL_204_8 = 204,                    /* @8  */
+  YYSYMBOL_205_9 = 205,                    /* @9  */
+  YYSYMBOL_206_10 = 206,                   /* $@10  */
+  YYSYMBOL_207_11 = 207,                   /* $@11  */
+  YYSYMBOL_208_12 = 208,                   /* @12  */
+  YYSYMBOL_209_13 = 209,                   /* @13  */
+  YYSYMBOL_210_14 = 210,                   /* $@14  */
+  YYSYMBOL_211_15 = 211,                   /* $@15  */
+  YYSYMBOL_212_16 = 212,                   /* $@16  */
+  YYSYMBOL_213_17 = 213,                   /* $@17  */
+  YYSYMBOL_214_18 = 214,                   /* $@18  */
+  YYSYMBOL_215_19 = 215,                   /* $@19  */
+  YYSYMBOL_216_20 = 216,                   /* @20  */
+  YYSYMBOL_217_21 = 217,                   /* @21  */
+  YYSYMBOL_218_22 = 218,                   /* @22  */
+  YYSYMBOL_219_23 = 219,                   /* @23  */
+  YYSYMBOL_primary_value = 220,            /* primary_value  */
+  YYSYMBOL_then = 221,                     /* then  */
+  YYSYMBOL_do = 222,                       /* do  */
+  YYSYMBOL_if_tail = 223,                  /* if_tail  */
+  YYSYMBOL_opt_else = 224,                 /* opt_else  */
+  YYSYMBOL_for_var = 225,                  /* for_var  */
+  YYSYMBOL_f_margs = 226,                  /* f_margs  */
+  YYSYMBOL_227_24 = 227,                   /* $@24  */
+  YYSYMBOL_block_args_tail = 228,          /* block_args_tail  */
+  YYSYMBOL_opt_block_args_tail = 229,      /* opt_block_args_tail  */
+  YYSYMBOL_block_param = 230,              /* block_param  */
+  YYSYMBOL_opt_block_param = 231,          /* opt_block_param  */
+  YYSYMBOL_block_param_def = 232,          /* block_param_def  */
+  YYSYMBOL_233_25 = 233,                   /* $@25  */
+  YYSYMBOL_opt_bv_decl = 234,              /* opt_bv_decl  */
+  YYSYMBOL_bv_decls = 235,                 /* bv_decls  */
+  YYSYMBOL_bvar = 236,                     /* bvar  */
+  YYSYMBOL_f_larglist = 237,               /* f_larglist  */
+  YYSYMBOL_lambda_body = 238,              /* lambda_body  */
+  YYSYMBOL_do_block = 239,                 /* do_block  */
+  YYSYMBOL_240_26 = 240,                   /* $@26  */
+  YYSYMBOL_block_call = 241,               /* block_call  */
+  YYSYMBOL_method_call = 242,              /* method_call  */
+  YYSYMBOL_brace_block = 243,              /* brace_block  */
+  YYSYMBOL_244_27 = 244,                   /* @27  */
+  YYSYMBOL_245_28 = 245,                   /* @28  */
+  YYSYMBOL_case_body = 246,                /* case_body  */
+  YYSYMBOL_cases = 247,                    /* cases  */
+  YYSYMBOL_opt_rescue = 248,               /* opt_rescue  */
+  YYSYMBOL_exc_list = 249,                 /* exc_list  */
+  YYSYMBOL_exc_var = 250,                  /* exc_var  */
+  YYSYMBOL_opt_ensure = 251,               /* opt_ensure  */
+  YYSYMBOL_literal = 252,                  /* literal  */
+  YYSYMBOL_string = 253,                   /* string  */
+  YYSYMBOL_string_fragment = 254,          /* string_fragment  */
+  YYSYMBOL_string_rep = 255,               /* string_rep  */
+  YYSYMBOL_string_interp = 256,            /* string_interp  */
+  YYSYMBOL_257_29 = 257,                   /* @29  */
+  YYSYMBOL_xstring = 258,                  /* xstring  */
+  YYSYMBOL_regexp = 259,                   /* regexp  */
+  YYSYMBOL_heredoc = 260,                  /* heredoc  */
+  YYSYMBOL_heredoc_bodies = 261,           /* heredoc_bodies  */
+  YYSYMBOL_heredoc_body = 262,             /* heredoc_body  */
+  YYSYMBOL_heredoc_string_rep = 263,       /* heredoc_string_rep  */
+  YYSYMBOL_heredoc_string_interp = 264,    /* heredoc_string_interp  */
+  YYSYMBOL_265_30 = 265,                   /* @30  */
+  YYSYMBOL_words = 266,                    /* words  */
+  YYSYMBOL_symbol = 267,                   /* symbol  */
+  YYSYMBOL_basic_symbol = 268,             /* basic_symbol  */
+  YYSYMBOL_sym = 269,                      /* sym  */
+  YYSYMBOL_symbols = 270,                  /* symbols  */
+  YYSYMBOL_numeric = 271,                  /* numeric  */
+  YYSYMBOL_variable = 272,                 /* variable  */
+  YYSYMBOL_var_lhs = 273,                  /* var_lhs  */
+  YYSYMBOL_var_ref = 274,                  /* var_ref  */
+  YYSYMBOL_backref = 275,                  /* backref  */
+  YYSYMBOL_superclass = 276,               /* superclass  */
+  YYSYMBOL_277_31 = 277,                   /* $@31  */
+  YYSYMBOL_f_arglist_paren = 278,          /* f_arglist_paren  */
+  YYSYMBOL_f_arglist = 279,                /* f_arglist  */
+  YYSYMBOL_f_label = 280,                  /* f_label  */
+  YYSYMBOL_f_kw = 281,                     /* f_kw  */
+  YYSYMBOL_f_block_kw = 282,               /* f_block_kw  */
+  YYSYMBOL_f_block_kwarg = 283,            /* f_block_kwarg  */
+  YYSYMBOL_f_kwarg = 284,                  /* f_kwarg  */
+  YYSYMBOL_kwrest_mark = 285,              /* kwrest_mark  */
+  YYSYMBOL_f_kwrest = 286,                 /* f_kwrest  */
+  YYSYMBOL_args_tail = 287,                /* args_tail  */
+  YYSYMBOL_opt_args_tail = 288,            /* opt_args_tail  */
+  YYSYMBOL_f_args = 289,                   /* f_args  */
+  YYSYMBOL_f_bad_arg = 290,                /* f_bad_arg  */
+  YYSYMBOL_f_norm_arg = 291,               /* f_norm_arg  */
+  YYSYMBOL_f_arg_item = 292,               /* f_arg_item  */
+  YYSYMBOL_293_32 = 293,                   /* @32  */
+  YYSYMBOL_f_arg = 294,                    /* f_arg  */
+  YYSYMBOL_f_opt_asgn = 295,               /* f_opt_asgn  */
+  YYSYMBOL_f_opt = 296,                    /* f_opt  */
+  YYSYMBOL_f_block_opt = 297,              /* f_block_opt  */
+  YYSYMBOL_f_block_optarg = 298,           /* f_block_optarg  */
+  YYSYMBOL_f_optarg = 299,                 /* f_optarg  */
+  YYSYMBOL_restarg_mark = 300,             /* restarg_mark  */
+  YYSYMBOL_f_rest_arg = 301,               /* f_rest_arg  */
+  YYSYMBOL_blkarg_mark = 302,              /* blkarg_mark  */
+  YYSYMBOL_f_block_arg = 303,              /* f_block_arg  */
+  YYSYMBOL_opt_f_block_arg = 304,          /* opt_f_block_arg  */
+  YYSYMBOL_singleton = 305,                /* singleton  */
+  YYSYMBOL_306_33 = 306,                   /* $@33  */
+  YYSYMBOL_assoc_list = 307,               /* assoc_list  */
+  YYSYMBOL_assocs = 308,                   /* assocs  */
+  YYSYMBOL_label_tag = 309,                /* label_tag  */
+  YYSYMBOL_assoc = 310,                    /* assoc  */
+  YYSYMBOL_operation = 311,                /* operation  */
+  YYSYMBOL_operation2 = 312,               /* operation2  */
+  YYSYMBOL_operation3 = 313,               /* operation3  */
+  YYSYMBOL_dot_or_colon = 314,             /* dot_or_colon  */
+  YYSYMBOL_call_op = 315,                  /* call_op  */
+  YYSYMBOL_call_op2 = 316,                 /* call_op2  */
+  YYSYMBOL_opt_terms = 317,                /* opt_terms  */
+  YYSYMBOL_opt_nl = 318,                   /* opt_nl  */
+  YYSYMBOL_rparen = 319,                   /* rparen  */
+  YYSYMBOL_trailer = 320,                  /* trailer  */
+  YYSYMBOL_term = 321,                     /* term  */
+  YYSYMBOL_nl = 322,                       /* nl  */
+  YYSYMBOL_terms = 323,                    /* terms  */
+  YYSYMBOL_none = 324                      /* none  */
+};
+typedef enum yysymbol_kind_t yysymbol_kind_t;
 
 
 
@@ -1724,6 +2055,7 @@ typedef int yytype_uint16;
 
 #define YYSIZEOF(X) YY_CAST (YYPTRDIFF_T, sizeof (X))
 
+
 /* Stored state numbers (used for stacks). */
 typedef yytype_int16 yy_state_t;
 
@@ -1741,6 +2073,7 @@ typedef int yy_state_fast_t;
 #  define YY_(Msgid) Msgid
 # endif
 #endif
+
 
 #ifndef YY_ATTRIBUTE_PURE
 # if defined __GNUC__ && 2 < __GNUC__ + (96 <= __GNUC_MINOR__)
@@ -1799,7 +2132,7 @@ typedef int yy_state_fast_t;
 
 #define YY_ASSERT(E) ((void) (0 && (E)))
 
-#if ! defined yyoverflow || YYERROR_VERBOSE
+#if 1
 
 /* The parser invokes alloca or malloc; define the necessary symbols.  */
 
@@ -1864,8 +2197,7 @@ void free (void *); /* INFRINGES ON USER NAME SPACE */
 #   endif
 #  endif
 # endif
-#endif /* ! defined yyoverflow || YYERROR_VERBOSE */
-
+#endif /* 1 */
 
 #if (! defined yyoverflow \
      && (! defined __cplusplus \
@@ -1941,14 +2273,16 @@ union yyalloc
 /* YYNSTATES -- Number of states.  */
 #define YYNSTATES  1061
 
-#define YYUNDEFTOK  2
+/* YYMAXUTOK -- Last valid token kind.  */
 #define YYMAXUTOK   377
 
 
 /* YYTRANSLATE(TOKEN-NUM) -- Symbol number corresponding to TOKEN-NUM
    as returned by yylex, with out-of-bounds checking.  */
-#define YYTRANSLATE(YYX)                                                \
-  (0 <= (YYX) && (YYX) <= YYMAXUTOK ? yytranslate[YYX] : YYUNDEFTOK)
+#define YYTRANSLATE(YYX)                                \
+  (0 <= (YYX) && (YYX) <= YYMAXUTOK                     \
+   ? YY_CAST (yysymbol_kind_t, yytranslate[YYX])        \
+   : YYSYMBOL_YYUNDEF)
 
 /* YYTRANSLATE[TOKEN-NUM] -- Symbol number corresponding to TOKEN-NUM
    as returned by yylex.  */
@@ -1998,90 +2332,98 @@ static const yytype_uint8 yytranslate[] =
   /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_int16 yyrline[] =
 {
-       0,  1537,  1537,  1537,  1548,  1554,  1558,  1563,  1567,  1573,
-    1575,  1574,  1588,  1615,  1621,  1625,  1630,  1634,  1640,  1640,
-    1644,  1648,  1652,  1656,  1660,  1664,  1668,  1673,  1674,  1678,
-    1682,  1686,  1690,  1697,  1700,  1704,  1708,  1712,  1716,  1720,
-    1725,  1729,  1736,  1737,  1741,  1745,  1746,  1750,  1754,  1758,
-    1762,  1766,  1776,  1775,  1790,  1799,  1800,  1803,  1804,  1811,
-    1810,  1825,  1829,  1834,  1838,  1843,  1847,  1852,  1856,  1860,
-    1864,  1868,  1874,  1878,  1884,  1885,  1891,  1895,  1899,  1903,
-    1907,  1911,  1915,  1919,  1923,  1927,  1933,  1934,  1940,  1944,
-    1950,  1954,  1960,  1964,  1968,  1972,  1976,  1980,  1986,  1992,
-    1999,  2003,  2007,  2011,  2015,  2019,  2025,  2031,  2036,  2042,
-    2046,  2049,  2053,  2057,  2064,  2065,  2066,  2067,  2072,  2079,
-    2080,  2083,  2087,  2087,  2093,  2094,  2095,  2096,  2097,  2098,
-    2099,  2100,  2101,  2102,  2103,  2104,  2105,  2106,  2107,  2108,
-    2109,  2110,  2111,  2112,  2113,  2114,  2115,  2116,  2117,  2118,
-    2119,  2120,  2121,  2122,  2125,  2125,  2125,  2126,  2126,  2127,
-    2127,  2127,  2128,  2128,  2128,  2128,  2129,  2129,  2129,  2130,
-    2130,  2130,  2131,  2131,  2131,  2131,  2132,  2132,  2132,  2132,
-    2133,  2133,  2133,  2133,  2134,  2134,  2134,  2134,  2135,  2135,
-    2135,  2135,  2136,  2136,  2139,  2143,  2147,  2151,  2155,  2159,
-    2163,  2168,  2173,  2178,  2182,  2186,  2190,  2194,  2198,  2202,
-    2206,  2210,  2214,  2218,  2222,  2226,  2230,  2234,  2238,  2242,
-    2246,  2250,  2254,  2258,  2262,  2266,  2270,  2274,  2278,  2282,
-    2286,  2290,  2294,  2298,  2302,  2306,  2310,  2314,  2318,  2322,
-    2326,  2334,  2343,  2352,  2362,  2368,  2369,  2374,  2378,  2385,
-    2389,  2397,  2401,  2417,  2443,  2444,  2447,  2448,  2449,  2454,
-    2459,  2466,  2472,  2477,  2482,  2487,  2494,  2494,  2505,  2511,
-    2515,  2521,  2522,  2525,  2531,  2537,  2542,  2549,  2554,  2559,
-    2566,  2567,  2568,  2569,  2570,  2571,  2572,  2573,  2577,  2582,
-    2581,  2593,  2597,  2592,  2602,  2602,  2606,  2610,  2614,  2618,
-    2623,  2628,  2632,  2636,  2640,  2644,  2648,  2649,  2655,  2661,
-    2654,  2673,  2681,  2689,  2689,  2689,  2696,  2696,  2696,  2703,
-    2709,  2714,  2716,  2713,  2725,  2723,  2741,  2746,  2739,  2763,
-    2761,  2777,  2787,  2798,  2802,  2806,  2810,  2816,  2823,  2824,
-    2825,  2828,  2829,  2832,  2833,  2841,  2842,  2848,  2852,  2855,
-    2859,  2863,  2867,  2872,  2876,  2880,  2884,  2890,  2889,  2899,
-    2903,  2907,  2911,  2917,  2922,  2927,  2931,  2935,  2939,  2943,
-    2947,  2951,  2955,  2959,  2963,  2967,  2971,  2975,  2979,  2983,
-    2989,  2994,  3001,  3001,  3005,  3010,  3017,  3021,  3027,  3028,
-    3031,  3036,  3039,  3043,  3049,  3053,  3060,  3059,  3074,  3084,
-    3088,  3093,  3100,  3104,  3108,  3112,  3116,  3120,  3124,  3128,
-    3132,  3139,  3138,  3153,  3152,  3168,  3176,  3185,  3188,  3195,
-    3198,  3202,  3203,  3206,  3210,  3213,  3217,  3220,  3221,  3222,
-    3223,  3226,  3227,  3233,  3234,  3235,  3239,  3245,  3246,  3252,
-    3257,  3256,  3267,  3271,  3277,  3281,  3287,  3291,  3297,  3300,
-    3301,  3304,  3310,  3316,  3317,  3320,  3327,  3326,  3340,  3344,
-    3351,  3356,  3363,  3369,  3370,  3371,  3372,  3373,  3377,  3383,
-    3387,  3393,  3394,  3395,  3399,  3405,  3409,  3413,  3417,  3421,
-    3427,  3431,  3437,  3441,  3445,  3449,  3453,  3457,  3465,  3472,
-    3483,  3484,  3488,  3492,  3491,  3507,  3513,  3531,  3551,  3552,
-    3558,  3564,  3570,  3577,  3582,  3589,  3593,  3599,  3603,  3609,
-    3610,  3613,  3617,  3623,  3627,  3631,  3635,  3641,  3646,  3651,
-    3655,  3659,  3663,  3667,  3671,  3675,  3679,  3683,  3687,  3691,
-    3695,  3699,  3703,  3708,  3714,  3719,  3724,  3729,  3734,  3741,
-    3745,  3752,  3757,  3756,  3768,  3772,  3778,  3786,  3794,  3802,
-    3806,  3812,  3816,  3822,  3823,  3826,  3831,  3838,  3839,  3842,
-    3848,  3852,  3858,  3863,  3863,  3888,  3889,  3895,  3900,  3906,
-    3907,  3910,  3916,  3921,  3931,  3938,  3939,  3940,  3943,  3944,
-    3945,  3946,  3949,  3950,  3951,  3954,  3955,  3958,  3962,  3968,
-    3969,  3975,  3976,  3979,  3980,  3983,  3986,  3987,  3988,  3991,
-    3992,  3993,  3996,  4003,  4004,  4008
+       0,  1538,  1538,  1538,  1549,  1555,  1559,  1564,  1568,  1574,
+    1576,  1575,  1589,  1616,  1622,  1626,  1631,  1635,  1641,  1641,
+    1645,  1649,  1653,  1657,  1661,  1665,  1669,  1674,  1675,  1679,
+    1683,  1687,  1691,  1698,  1701,  1705,  1709,  1713,  1717,  1721,
+    1726,  1730,  1737,  1738,  1742,  1746,  1747,  1751,  1755,  1759,
+    1763,  1767,  1777,  1776,  1791,  1800,  1801,  1804,  1805,  1812,
+    1811,  1826,  1830,  1835,  1839,  1844,  1848,  1853,  1857,  1861,
+    1865,  1869,  1875,  1879,  1885,  1886,  1892,  1896,  1900,  1904,
+    1908,  1912,  1916,  1920,  1924,  1928,  1934,  1935,  1941,  1945,
+    1951,  1955,  1961,  1965,  1969,  1973,  1977,  1981,  1987,  1993,
+    2000,  2004,  2008,  2012,  2016,  2020,  2026,  2032,  2037,  2043,
+    2047,  2050,  2054,  2058,  2065,  2066,  2067,  2068,  2073,  2080,
+    2081,  2084,  2088,  2088,  2094,  2095,  2096,  2097,  2098,  2099,
+    2100,  2101,  2102,  2103,  2104,  2105,  2106,  2107,  2108,  2109,
+    2110,  2111,  2112,  2113,  2114,  2115,  2116,  2117,  2118,  2119,
+    2120,  2121,  2122,  2123,  2126,  2126,  2126,  2127,  2127,  2128,
+    2128,  2128,  2129,  2129,  2129,  2129,  2130,  2130,  2130,  2131,
+    2131,  2131,  2132,  2132,  2132,  2132,  2133,  2133,  2133,  2133,
+    2134,  2134,  2134,  2134,  2135,  2135,  2135,  2135,  2136,  2136,
+    2136,  2136,  2137,  2137,  2140,  2144,  2148,  2152,  2156,  2160,
+    2164,  2169,  2174,  2179,  2183,  2187,  2191,  2195,  2199,  2203,
+    2207,  2211,  2215,  2219,  2223,  2227,  2231,  2235,  2239,  2243,
+    2247,  2251,  2255,  2259,  2263,  2267,  2271,  2275,  2279,  2283,
+    2287,  2291,  2295,  2299,  2303,  2307,  2311,  2315,  2319,  2323,
+    2327,  2335,  2344,  2353,  2363,  2369,  2370,  2375,  2379,  2386,
+    2390,  2398,  2402,  2418,  2444,  2445,  2448,  2449,  2450,  2455,
+    2460,  2467,  2473,  2478,  2483,  2488,  2495,  2495,  2506,  2512,
+    2516,  2522,  2523,  2526,  2532,  2538,  2543,  2550,  2555,  2560,
+    2567,  2568,  2569,  2570,  2571,  2572,  2573,  2574,  2578,  2583,
+    2582,  2594,  2598,  2593,  2603,  2603,  2607,  2611,  2615,  2619,
+    2624,  2629,  2633,  2637,  2641,  2645,  2649,  2650,  2656,  2662,
+    2655,  2674,  2682,  2690,  2690,  2690,  2697,  2697,  2697,  2704,
+    2710,  2715,  2717,  2714,  2726,  2724,  2742,  2747,  2740,  2764,
+    2762,  2778,  2788,  2799,  2803,  2807,  2811,  2817,  2824,  2825,
+    2826,  2829,  2830,  2833,  2834,  2842,  2843,  2849,  2853,  2856,
+    2860,  2864,  2868,  2873,  2877,  2881,  2885,  2891,  2890,  2900,
+    2904,  2908,  2912,  2918,  2923,  2928,  2932,  2936,  2940,  2944,
+    2948,  2952,  2956,  2960,  2964,  2968,  2972,  2976,  2980,  2984,
+    2990,  2995,  3002,  3002,  3006,  3011,  3018,  3022,  3028,  3029,
+    3032,  3037,  3040,  3044,  3050,  3054,  3061,  3060,  3075,  3085,
+    3089,  3094,  3101,  3105,  3109,  3113,  3117,  3121,  3125,  3129,
+    3133,  3140,  3139,  3154,  3153,  3169,  3177,  3186,  3189,  3196,
+    3199,  3203,  3204,  3207,  3211,  3214,  3218,  3221,  3222,  3223,
+    3224,  3227,  3228,  3234,  3235,  3236,  3240,  3246,  3247,  3253,
+    3258,  3257,  3268,  3272,  3278,  3282,  3288,  3292,  3298,  3301,
+    3302,  3305,  3311,  3317,  3318,  3321,  3328,  3327,  3341,  3345,
+    3352,  3357,  3364,  3370,  3371,  3372,  3373,  3374,  3378,  3384,
+    3388,  3394,  3395,  3396,  3400,  3406,  3410,  3414,  3418,  3422,
+    3428,  3432,  3438,  3442,  3446,  3450,  3454,  3458,  3466,  3473,
+    3484,  3485,  3489,  3493,  3492,  3508,  3514,  3532,  3552,  3553,
+    3559,  3565,  3571,  3578,  3583,  3590,  3594,  3600,  3604,  3610,
+    3611,  3614,  3618,  3624,  3628,  3632,  3636,  3642,  3647,  3652,
+    3656,  3660,  3664,  3668,  3672,  3676,  3680,  3684,  3688,  3692,
+    3696,  3700,  3704,  3709,  3715,  3720,  3725,  3730,  3735,  3742,
+    3746,  3753,  3758,  3757,  3769,  3773,  3779,  3787,  3795,  3803,
+    3807,  3813,  3817,  3823,  3824,  3827,  3832,  3839,  3840,  3843,
+    3849,  3853,  3859,  3864,  3864,  3889,  3890,  3896,  3901,  3907,
+    3908,  3911,  3917,  3922,  3932,  3939,  3940,  3941,  3944,  3945,
+    3946,  3947,  3950,  3951,  3952,  3955,  3956,  3959,  3963,  3969,
+    3970,  3976,  3977,  3980,  3981,  3984,  3987,  3988,  3989,  3992,
+    3993,  3994,  3997,  4004,  4005,  4009
 };
 #endif
 
-#if YYDEBUG || YYERROR_VERBOSE || 1
+/** Accessing symbol of state STATE.  */
+#define YY_ACCESSING_SYMBOL(State) YY_CAST (yysymbol_kind_t, yystos[State])
+
+#if 1
+/* The user-facing name of the symbol whose (internal) number is
+   YYSYMBOL.  No bounds checking.  */
+static const char *yysymbol_name (yysymbol_kind_t yysymbol) YY_ATTRIBUTE_UNUSED;
+
 /* YYTNAME[SYMBOL-NUM] -- String name of the symbol SYMBOL-NUM.
    First, the terminals, then, starting at YYNTOKENS, nonterminals.  */
 static const char *const yytname[] =
 {
-  "$end", "error", "$undefined", "keyword_class", "keyword_module",
-  "keyword_def", "keyword_begin", "keyword_if", "keyword_unless",
-  "keyword_while", "keyword_until", "keyword_for", "keyword_undef",
-  "keyword_rescue", "keyword_ensure", "keyword_end", "keyword_then",
-  "keyword_elsif", "keyword_else", "keyword_case", "keyword_when",
-  "keyword_break", "keyword_next", "keyword_redo", "keyword_retry",
-  "keyword_in", "keyword_do", "keyword_do_cond", "keyword_do_block",
-  "keyword_do_LAMBDA", "keyword_return", "keyword_yield", "keyword_super",
-  "keyword_self", "keyword_nil", "keyword_true", "keyword_false",
-  "keyword_and", "keyword_or", "keyword_not", "modifier_if",
-  "modifier_unless", "modifier_while", "modifier_until", "modifier_rescue",
-  "keyword_alias", "keyword_BEGIN", "keyword_END", "keyword__LINE__",
-  "keyword__FILE__", "keyword__ENCODING__", "tIDENTIFIER", "tFID", "tGVAR",
-  "tIVAR", "tCONSTANT", "tCVAR", "tLABEL_TAG", "tINTEGER", "tFLOAT",
-  "tCHAR", "tXSTRING", "tREGEXP", "tSTRING", "tSTRING_PART", "tSTRING_MID",
+  "\"end of file\"", "error", "\"invalid token\"", "keyword_class",
+  "keyword_module", "keyword_def", "keyword_begin", "keyword_if",
+  "keyword_unless", "keyword_while", "keyword_until", "keyword_for",
+  "keyword_undef", "keyword_rescue", "keyword_ensure", "keyword_end",
+  "keyword_then", "keyword_elsif", "keyword_else", "keyword_case",
+  "keyword_when", "keyword_break", "keyword_next", "keyword_redo",
+  "keyword_retry", "keyword_in", "keyword_do", "keyword_do_cond",
+  "keyword_do_block", "keyword_do_LAMBDA", "keyword_return",
+  "keyword_yield", "keyword_super", "keyword_self", "keyword_nil",
+  "keyword_true", "keyword_false", "keyword_and", "keyword_or",
+  "keyword_not", "modifier_if", "modifier_unless", "modifier_while",
+  "modifier_until", "modifier_rescue", "keyword_alias", "keyword_BEGIN",
+  "keyword_END", "keyword__LINE__", "keyword__FILE__",
+  "keyword__ENCODING__", "tIDENTIFIER", "tFID", "tGVAR", "tIVAR",
+  "tCONSTANT", "tCVAR", "tLABEL_TAG", "tINTEGER", "tFLOAT", "tCHAR",
+  "tXSTRING", "tREGEXP", "tSTRING", "tSTRING_PART", "tSTRING_MID",
   "tNTH_REF", "tBACK_REF", "tREGEXP_END", "tNUMPARAM", "tUPLUS", "tUMINUS",
   "tPOW", "tCMP", "tEQ", "tEQQ", "tNEQ", "tGEQ", "tLEQ", "tANDOP", "tOROP",
   "tMATCH", "tNMATCH", "tDOT2", "tDOT3", "tBDOT2", "tBDOT3", "tAREF",
@@ -2127,9 +2469,15 @@ static const char *const yytname[] =
   "call_op2", "opt_terms", "opt_nl", "rparen", "trailer", "term", "nl",
   "terms", "none", YY_NULLPTR
 };
+
+static const char *
+yysymbol_name (yysymbol_kind_t yysymbol)
+{
+  return yytname[yysymbol];
+}
 #endif
 
-# ifdef YYPRINT
+#ifdef YYPRINT
 /* YYTOKNUM[NUM] -- (External) token number corresponding to the
    (internal) symbol number NUM (which must be that of a token).  */
 static const yytype_int16 yytoknum[] =
@@ -2150,7 +2498,7 @@ static const yytype_int16 yytoknum[] =
       45,    42,    47,    37,   376,    33,   126,   377,   123,   125,
       91,    93,    44,    96,    40,    41,    59,    46,    10
 };
-# endif
+#endif
 
 #define YYPACT_NINF (-838)
 
@@ -5172,10 +5520,10 @@ static const yytype_int8 yyr2[] =
 };
 
 
+enum { YYENOMEM = -2 };
+
 #define yyerrok         (yyerrstatus = 0)
 #define yyclearin       (yychar = YYEMPTY)
-#define YYEMPTY         (-2)
-#define YYEOF           0
 
 #define YYACCEPT        goto yyacceptlab
 #define YYABORT         goto yyabortlab
@@ -5201,10 +5549,9 @@ static const yytype_int8 yyr2[] =
       }                                                           \
   while (0)
 
-/* Error token number */
-#define YYTERROR        1
-#define YYERRCODE       256
-
+/* Backward compatibility with an undocumented macro.
+   Use YYerror or YYUNDEF. */
+#define YYERRCODE YYUNDEF
 
 
 /* Enable debugging if requested.  */
@@ -5222,18 +5569,18 @@ do {                                            \
 } while (0)
 
 /* This macro is provided for backward compatibility. */
-#ifndef YY_LOCATION_PRINT
-# define YY_LOCATION_PRINT(File, Loc) ((void) 0)
-#endif
+# ifndef YY_LOCATION_PRINT
+#  define YY_LOCATION_PRINT(File, Loc) ((void) 0)
+# endif
 
 
-# define YY_SYMBOL_PRINT(Title, Type, Value, Location)                    \
+# define YY_SYMBOL_PRINT(Title, Kind, Value, Location)                    \
 do {                                                                      \
   if (yydebug)                                                            \
     {                                                                     \
       YYFPRINTF (stderr, "%s ", Title);                                   \
       yy_symbol_print (stderr,                                            \
-                  Type, Value, p); \
+                  Kind, Value, p); \
       YYFPRINTF (stderr, "\n");                                           \
     }                                                                     \
 } while (0)
@@ -5244,7 +5591,8 @@ do {                                                                      \
 `-----------------------------------*/
 
 static void
-yy_symbol_value_print (FILE *yyo, int yytype, YYSTYPE const * const yyvaluep, parser_state *p)
+yy_symbol_value_print (FILE *yyo,
+                       yysymbol_kind_t yykind, YYSTYPE const * const yyvaluep, parser_state *p)
 {
   FILE *yyoutput = yyo;
   YYUSE (yyoutput);
@@ -5252,11 +5600,11 @@ yy_symbol_value_print (FILE *yyo, int yytype, YYSTYPE const * const yyvaluep, pa
   if (!yyvaluep)
     return;
 # ifdef YYPRINT
-  if (yytype < YYNTOKENS)
-    YYPRINT (yyo, yytoknum[yytype], *yyvaluep);
+  if (yykind < YYNTOKENS)
+    YYPRINT (yyo, yytoknum[yykind], *yyvaluep);
 # endif
   YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
-  YYUSE (yytype);
+  YYUSE (yykind);
   YY_IGNORE_MAYBE_UNINITIALIZED_END
 }
 
@@ -5266,12 +5614,13 @@ yy_symbol_value_print (FILE *yyo, int yytype, YYSTYPE const * const yyvaluep, pa
 `---------------------------*/
 
 static void
-yy_symbol_print (FILE *yyo, int yytype, YYSTYPE const * const yyvaluep, parser_state *p)
+yy_symbol_print (FILE *yyo,
+                 yysymbol_kind_t yykind, YYSTYPE const * const yyvaluep, parser_state *p)
 {
   YYFPRINTF (yyo, "%s %s (",
-             yytype < YYNTOKENS ? "token" : "nterm", yytname[yytype]);
+             yykind < YYNTOKENS ? "token" : "nterm", yysymbol_name (yykind));
 
-  yy_symbol_value_print (yyo, yytype, yyvaluep, p);
+  yy_symbol_value_print (yyo, yykind, yyvaluep, p);
   YYFPRINTF (yyo, ")");
 }
 
@@ -5304,7 +5653,8 @@ do {                                                            \
 `------------------------------------------------*/
 
 static void
-yy_reduce_print (yy_state_t *yyssp, YYSTYPE *yyvsp, int yyrule, parser_state *p)
+yy_reduce_print (yy_state_t *yyssp, YYSTYPE *yyvsp,
+                 int yyrule, parser_state *p)
 {
   int yylno = yyrline[yyrule];
   int yynrhs = yyr2[yyrule];
@@ -5316,9 +5666,8 @@ yy_reduce_print (yy_state_t *yyssp, YYSTYPE *yyvsp, int yyrule, parser_state *p)
     {
       YYFPRINTF (stderr, "   $%d = ", yyi + 1);
       yy_symbol_print (stderr,
-                       yystos[+yyssp[yyi + 1 - yynrhs]],
-                       &yyvsp[(yyi + 1) - (yynrhs)]
-                                              , p);
+                       YY_ACCESSING_SYMBOL (+yyssp[yyi + 1 - yynrhs]),
+                       &yyvsp[(yyi + 1) - (yynrhs)], p);
       YYFPRINTF (stderr, "\n");
     }
 }
@@ -5333,8 +5682,8 @@ do {                                    \
    multiple parsers can coexist.  */
 int yydebug;
 #else /* !YYDEBUG */
-# define YYDPRINTF(Args)
-# define YY_SYMBOL_PRINT(Title, Type, Value, Location)
+# define YYDPRINTF(Args) ((void) 0)
+# define YY_SYMBOL_PRINT(Title, Kind, Value, Location)
 # define YY_STACK_PRINT(Bottom, Top)
 # define YY_REDUCE_PRINT(Rule)
 #endif /* !YYDEBUG */
@@ -5357,12 +5706,60 @@ int yydebug;
 #endif
 
 
-#if YYERROR_VERBOSE
+/* Context of a parse error.  */
+typedef struct
+{
+  yy_state_t *yyssp;
+  yysymbol_kind_t yytoken;
+} yypcontext_t;
 
-# ifndef yystrlen
-#  if defined __GLIBC__ && defined _STRING_H
-#   define yystrlen(S) (YY_CAST (YYPTRDIFF_T, strlen (S)))
-#  else
+/* Put in YYARG at most YYARGN of the expected tokens given the
+   current YYCTX, and return the number of tokens stored in YYARG.  If
+   YYARG is null, return the number of expected tokens (guaranteed to
+   be less than YYNTOKENS).  Return YYENOMEM on memory exhaustion.
+   Return 0 if there are more than YYARGN expected tokens, yet fill
+   YYARG up to YYARGN. */
+static int
+yypcontext_expected_tokens (const yypcontext_t *yyctx,
+                            yysymbol_kind_t yyarg[], int yyargn)
+{
+  /* Actual size of YYARG. */
+  int yycount = 0;
+  int yyn = yypact[+*yyctx->yyssp];
+  if (!yypact_value_is_default (yyn))
+    {
+      /* Start YYX at -YYN if negative to avoid negative indexes in
+         YYCHECK.  In other words, skip the first -YYN actions for
+         this state because they are default actions.  */
+      int yyxbegin = yyn < 0 ? -yyn : 0;
+      /* Stay within bounds of both yycheck and yytname.  */
+      int yychecklim = YYLAST - yyn + 1;
+      int yyxend = yychecklim < YYNTOKENS ? yychecklim : YYNTOKENS;
+      int yyx;
+      for (yyx = yyxbegin; yyx < yyxend; ++yyx)
+        if (yycheck[yyx + yyn] == yyx && yyx != YYSYMBOL_YYerror
+            && !yytable_value_is_error (yytable[yyx + yyn]))
+          {
+            if (!yyarg)
+              ++yycount;
+            else if (yycount == yyargn)
+              return 0;
+            else
+              yyarg[yycount++] = YY_CAST (yysymbol_kind_t, yyx);
+          }
+    }
+  if (yyarg && yycount == 0 && 0 < yyargn)
+    yyarg[0] = YYSYMBOL_YYEMPTY;
+  return yycount;
+}
+
+
+
+
+#ifndef yystrlen
+# if defined __GLIBC__ && defined _STRING_H
+#  define yystrlen(S) (YY_CAST (YYPTRDIFF_T, strlen (S)))
+# else
 /* Return the length of YYSTR.  */
 static YYPTRDIFF_T
 yystrlen (const char *yystr)
@@ -5372,13 +5769,13 @@ yystrlen (const char *yystr)
     continue;
   return yylen;
 }
-#  endif
 # endif
+#endif
 
-# ifndef yystpcpy
-#  if defined __GLIBC__ && defined _STRING_H && defined _GNU_SOURCE
-#   define yystpcpy stpcpy
-#  else
+#ifndef yystpcpy
+# if defined __GLIBC__ && defined _STRING_H && defined _GNU_SOURCE
+#  define yystpcpy stpcpy
+# else
 /* Copy YYSRC to YYDEST, returning the address of the terminating '\0' in
    YYDEST.  */
 static char *
@@ -5392,10 +5789,10 @@ yystpcpy (char *yydest, const char *yysrc)
 
   return yyd - 1;
 }
-#  endif
 # endif
+#endif
 
-# ifndef yytnamerr
+#ifndef yytnamerr
 /* Copy to YYRES the contents of YYSTR after stripping away unnecessary
    quotes and backslashes, so that it's suitable for yyerror.  The
    heuristic is that double-quoting is unnecessary unless the string
@@ -5410,7 +5807,6 @@ yytnamerr (char *yyres, const char *yystr)
     {
       YYPTRDIFF_T yyn = 0;
       char const *yyp = yystr;
-
       for (;;)
         switch (*++yyp)
           {
@@ -5444,31 +5840,15 @@ yytnamerr (char *yyres, const char *yystr)
   else
     return yystrlen (yystr);
 }
-# endif
+#endif
 
-/* Copy into *YYMSG, which is of size *YYMSG_ALLOC, an error message
-   about the unexpected token YYTOKEN for the state stack whose top is
-   YYSSP.
 
-   Return 0 if *YYMSG was successfully written.  Return 1 if *YYMSG is
-   not large enough to hold the message.  In that case, also set
-   *YYMSG_ALLOC to the required number of bytes.  Return 2 if the
-   required number of bytes is too large to store.  */
 static int
-yysyntax_error (YYPTRDIFF_T *yymsg_alloc, char **yymsg,
-                yy_state_t *yyssp, int yytoken)
+yy_syntax_error_arguments (const yypcontext_t *yyctx,
+                           yysymbol_kind_t yyarg[], int yyargn)
 {
-  enum { YYERROR_VERBOSE_ARGS_MAXIMUM = 5 };
-  /* Internationalized format string. */
-  const char *yyformat = YY_NULLPTR;
-  /* Arguments of yyformat: reported tokens (one for the "unexpected",
-     one per "expected"). */
-  char const *yyarg[YYERROR_VERBOSE_ARGS_MAXIMUM];
   /* Actual size of YYARG. */
   int yycount = 0;
-  /* Cumulated lengths of YYARG.  */
-  YYPTRDIFF_T yysize = 0;
-
   /* There are many possibilities here to consider:
      - If this state is a consistent state with a default action, then
        the only way this function was invoked is if the default action
@@ -5492,52 +5872,54 @@ yysyntax_error (YYPTRDIFF_T *yymsg_alloc, char **yymsg,
        one exception: it will still contain any token that will not be
        accepted due to an error action in a later state.
   */
-  if (yytoken != YYEMPTY)
+  if (yyctx->yytoken != YYSYMBOL_YYEMPTY)
     {
-      int yyn = yypact[+*yyssp];
-      YYPTRDIFF_T yysize0 = yytnamerr (YY_NULLPTR, yytname[yytoken]);
-      yysize = yysize0;
-      yyarg[yycount++] = yytname[yytoken];
-      if (!yypact_value_is_default (yyn))
-        {
-          /* Start YYX at -YYN if negative to avoid negative indexes in
-             YYCHECK.  In other words, skip the first -YYN actions for
-             this state because they are default actions.  */
-          int yyxbegin = yyn < 0 ? -yyn : 0;
-          /* Stay within bounds of both yycheck and yytname.  */
-          int yychecklim = YYLAST - yyn + 1;
-          int yyxend = yychecklim < YYNTOKENS ? yychecklim : YYNTOKENS;
-          int yyx;
-
-          for (yyx = yyxbegin; yyx < yyxend; ++yyx)
-            if (yycheck[yyx + yyn] == yyx && yyx != YYTERROR
-                && !yytable_value_is_error (yytable[yyx + yyn]))
-              {
-                if (yycount == YYERROR_VERBOSE_ARGS_MAXIMUM)
-                  {
-                    yycount = 1;
-                    yysize = yysize0;
-                    break;
-                  }
-                yyarg[yycount++] = yytname[yyx];
-                {
-                  YYPTRDIFF_T yysize1
-                    = yysize + yytnamerr (YY_NULLPTR, yytname[yyx]);
-                  if (yysize <= yysize1 && yysize1 <= YYSTACK_ALLOC_MAXIMUM)
-                    yysize = yysize1;
-                  else
-                    return 2;
-                }
-              }
-        }
+      int yyn;
+      if (yyarg)
+        yyarg[yycount] = yyctx->yytoken;
+      ++yycount;
+      yyn = yypcontext_expected_tokens (yyctx,
+                                        yyarg ? yyarg + 1 : yyarg, yyargn - 1);
+      if (yyn == YYENOMEM)
+        return YYENOMEM;
+      else
+        yycount += yyn;
     }
+  return yycount;
+}
+
+/* Copy into *YYMSG, which is of size *YYMSG_ALLOC, an error message
+   about the unexpected token YYTOKEN for the state stack whose top is
+   YYSSP.
+
+   Return 0 if *YYMSG was successfully written.  Return -1 if *YYMSG is
+   not large enough to hold the message.  In that case, also set
+   *YYMSG_ALLOC to the required number of bytes.  Return YYENOMEM if the
+   required number of bytes is too large to store.  */
+static int
+yysyntax_error (YYPTRDIFF_T *yymsg_alloc, char **yymsg,
+                const yypcontext_t *yyctx)
+{
+  enum { YYARGS_MAX = 5 };
+  /* Internationalized format string. */
+  const char *yyformat = YY_NULLPTR;
+  /* Arguments of yyformat: reported tokens (one for the "unexpected",
+     one per "expected"). */
+  yysymbol_kind_t yyarg[YYARGS_MAX];
+  /* Cumulated lengths of YYARG.  */
+  YYPTRDIFF_T yysize = 0;
+
+  /* Actual size of YYARG. */
+  int yycount = yy_syntax_error_arguments (yyctx, yyarg, YYARGS_MAX);
+  if (yycount == YYENOMEM)
+    return YYENOMEM;
 
   switch (yycount)
     {
-# define YYCASE_(N, S)                      \
+#define YYCASE_(N, S)                       \
       case N:                               \
         yyformat = S;                       \
-      break
+        break
     default: /* Avoid compiler warnings. */
       YYCASE_(0, YY_("syntax error"));
       YYCASE_(1, YY_("syntax error, unexpected %s"));
@@ -5545,17 +5927,23 @@ yysyntax_error (YYPTRDIFF_T *yymsg_alloc, char **yymsg,
       YYCASE_(3, YY_("syntax error, unexpected %s, expecting %s or %s"));
       YYCASE_(4, YY_("syntax error, unexpected %s, expecting %s or %s or %s"));
       YYCASE_(5, YY_("syntax error, unexpected %s, expecting %s or %s or %s or %s"));
-# undef YYCASE_
+#undef YYCASE_
     }
 
+  /* Compute error message size.  Don't count the "%s"s, but reserve
+     room for the terminator.  */
+  yysize = yystrlen (yyformat) - 2 * yycount + 1;
   {
-    /* Don't count the "%s"s in the final size, but reserve room for
-       the terminator.  */
-    YYPTRDIFF_T yysize1 = yysize + (yystrlen (yyformat) - 2 * yycount) + 1;
-    if (yysize <= yysize1 && yysize1 <= YYSTACK_ALLOC_MAXIMUM)
-      yysize = yysize1;
-    else
-      return 2;
+    int yyi;
+    for (yyi = 0; yyi < yycount; ++yyi)
+      {
+        YYPTRDIFF_T yysize1
+          = yysize + yytnamerr (YY_NULLPTR, yytname[yyarg[yyi]]);
+        if (yysize <= yysize1 && yysize1 <= YYSTACK_ALLOC_MAXIMUM)
+          yysize = yysize1;
+        else
+          return YYENOMEM;
+      }
   }
 
   if (*yymsg_alloc < yysize)
@@ -5564,7 +5952,7 @@ yysyntax_error (YYPTRDIFF_T *yymsg_alloc, char **yymsg,
       if (! (yysize <= *yymsg_alloc
              && *yymsg_alloc <= YYSTACK_ALLOC_MAXIMUM))
         *yymsg_alloc = YYSTACK_ALLOC_MAXIMUM;
-      return 1;
+      return -1;
     }
 
   /* Avoid sprintf, as that infringes on the user's name space.
@@ -5576,7 +5964,7 @@ yysyntax_error (YYPTRDIFF_T *yymsg_alloc, char **yymsg,
     while ((*yyp = *yyformat) != '\0')
       if (*yyp == '%' && yyformat[1] == 's' && yyi < yycount)
         {
-          yyp += yytnamerr (yyp, yyarg[yyi++]);
+          yyp += yytnamerr (yyp, yytname[yyarg[yyi++]]);
           yyformat += 2;
         }
       else
@@ -5587,25 +5975,28 @@ yysyntax_error (YYPTRDIFF_T *yymsg_alloc, char **yymsg,
   }
   return 0;
 }
-#endif /* YYERROR_VERBOSE */
+
 
 /*-----------------------------------------------.
 | Release the memory associated to this symbol.  |
 `-----------------------------------------------*/
 
 static void
-yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, parser_state *p)
+yydestruct (const char *yymsg,
+            yysymbol_kind_t yykind, YYSTYPE *yyvaluep, parser_state *p)
 {
   YYUSE (yyvaluep);
   YYUSE (p);
   if (!yymsg)
     yymsg = "Deleting";
-  YY_SYMBOL_PRINT (yymsg, yytype, yyvaluep, yylocationp);
+  YY_SYMBOL_PRINT (yymsg, yykind, yyvaluep, yylocationp);
 
   YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
-  YYUSE (yytype);
+  YYUSE (yykind);
   YY_IGNORE_MAYBE_UNINITIALIZED_END
 }
+
+
 
 
 
@@ -5617,7 +6008,7 @@ yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, parser_state *p)
 int
 yyparse (parser_state *p)
 {
-/* The lookahead symbol.  */
+/* Lookahead token kind.  */
 int yychar;
 
 
@@ -5628,45 +6019,41 @@ YY_INITIAL_VALUE (static YYSTYPE yyval_default;)
 YYSTYPE yylval YY_INITIAL_VALUE (= yyval_default);
 
     /* Number of syntax errors so far.  */
-    int yynerrs;
+    int yynerrs = 0;
 
-    yy_state_fast_t yystate;
+    yy_state_fast_t yystate = 0;
     /* Number of tokens to shift before error messages enabled.  */
-    int yyerrstatus;
+    int yyerrstatus = 0;
 
-    /* The stacks and their tools:
-       'yyss': related to states.
-       'yyvs': related to semantic values.
-
-       Refer to the stacks through separate pointers, to allow yyoverflow
+    /* Refer to the stacks through separate pointers, to allow yyoverflow
        to reallocate them elsewhere.  */
 
-    /* The state stack.  */
+    /* Their size.  */
+    YYPTRDIFF_T yystacksize = YYINITDEPTH;
+
+    /* The state stack: array, bottom, top.  */
     yy_state_t yyssa[YYINITDEPTH];
-    yy_state_t *yyss;
-    yy_state_t *yyssp;
+    yy_state_t *yyss = yyssa;
+    yy_state_t *yyssp = yyss;
 
-    /* The semantic value stack.  */
+    /* The semantic value stack: array, bottom, top.  */
     YYSTYPE yyvsa[YYINITDEPTH];
-    YYSTYPE *yyvs;
-    YYSTYPE *yyvsp;
-
-    YYPTRDIFF_T yystacksize;
+    YYSTYPE *yyvs = yyvsa;
+    YYSTYPE *yyvsp = yyvs;
 
   int yyn;
+  /* The return value of yyparse.  */
   int yyresult;
-  /* Lookahead token as an internal (translated) token number.  */
-  int yytoken = 0;
+  /* Lookahead symbol kind.  */
+  yysymbol_kind_t yytoken = YYSYMBOL_YYEMPTY;
   /* The variables used to return semantic value and location from the
      action routines.  */
   YYSTYPE yyval;
 
-#if YYERROR_VERBOSE
   /* Buffer for error messages, and its allocated size.  */
   char yymsgbuf[128];
   char *yymsg = yymsgbuf;
   YYPTRDIFF_T yymsg_alloc = sizeof yymsgbuf;
-#endif
 
 #define YYPOPSTACK(N)   (yyvsp -= (N), yyssp -= (N))
 
@@ -5674,15 +6061,8 @@ YYSTYPE yylval YY_INITIAL_VALUE (= yyval_default);
      Keep to zero when no symbol should be popped.  */
   int yylen = 0;
 
-  yyssp = yyss = yyssa;
-  yyvsp = yyvs = yyvsa;
-  yystacksize = YYINITDEPTH;
-
   YYDPRINTF ((stderr, "Starting parse\n"));
 
-  yystate = 0;
-  yyerrstatus = 0;
-  yynerrs = 0;
   yychar = YYEMPTY; /* Cause a token to be read.  */
   goto yysetstate;
 
@@ -5705,6 +6085,7 @@ yysetstate:
   YY_IGNORE_USELESS_CAST_BEGIN
   *yyssp = YY_CAST (yy_state_t, yystate);
   YY_IGNORE_USELESS_CAST_END
+  YY_STACK_PRINT (yyss, yyssp);
 
   if (yyss + yystacksize - 1 <= yyssp)
 #if !defined yyoverflow && !defined YYSTACK_RELOCATE
@@ -5750,7 +6131,7 @@ yysetstate:
           goto yyexhaustedlab;
         YYSTACK_RELOCATE (yyss_alloc, yyss);
         YYSTACK_RELOCATE (yyvs_alloc, yyvs);
-# undef YYSTACK_RELOCATE
+#  undef YYSTACK_RELOCATE
         if (yyss1 != yyssa)
           YYSTACK_FREE (yyss1);
       }
@@ -5789,17 +6170,28 @@ yybackup:
 
   /* Not known => get a lookahead token if don't already have one.  */
 
-  /* YYCHAR is either YYEMPTY or YYEOF or a valid lookahead symbol.  */
+  /* YYCHAR is either empty, or end-of-input, or a valid lookahead.  */
   if (yychar == YYEMPTY)
     {
-      YYDPRINTF ((stderr, "Reading a token: "));
+      YYDPRINTF ((stderr, "Reading a token\n"));
       yychar = yylex (&yylval, p);
     }
 
   if (yychar <= YYEOF)
     {
-      yychar = yytoken = YYEOF;
+      yychar = YYEOF;
+      yytoken = YYSYMBOL_YYEOF;
       YYDPRINTF ((stderr, "Now at end of input.\n"));
+    }
+  else if (yychar == YYerror)
+    {
+      /* The scanner already issued an error message, process directly
+         to error recovery.  But do not keep the error token as
+         lookahead, it is too special and may lead us to an endless
+         loop in error recovery. */
+      yychar = YYUNDEF;
+      yytoken = YYSYMBOL_YYerror;
+      goto yyerrlab1;
     }
   else
     {
@@ -5869,87 +6261,87 @@ yyreduce:
   YY_REDUCE_PRINT (yyn);
   switch (yyn)
     {
-  case 2:
-#line 1537 "mrbgems/mruby-compiler/core/parse.y"
+  case 2: /* $@1: %empty  */
+#line 1538 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       p->lstate = EXPR_BEG;
                       if (!p->locals) p->locals = cons(0,0);
                     }
-#line 5879 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6271 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 3:
-#line 1542 "mrbgems/mruby-compiler/core/parse.y"
+  case 3: /* program: $@1 top_compstmt  */
+#line 1543 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       p->tree = new_scope(p, (yyvsp[0].nd));
                       NODE_LINENO(p->tree, (yyvsp[0].nd));
                     }
-#line 5888 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6280 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 4:
-#line 1549 "mrbgems/mruby-compiler/core/parse.y"
+  case 4: /* top_compstmt: top_stmts opt_terms  */
+#line 1550 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[-1].nd);
                     }
-#line 5896 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6288 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 5:
-#line 1555 "mrbgems/mruby-compiler/core/parse.y"
+  case 5: /* top_stmts: none  */
+#line 1556 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_begin(p, 0);
                     }
-#line 5904 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6296 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 6:
-#line 1559 "mrbgems/mruby-compiler/core/parse.y"
+  case 6: /* top_stmts: top_stmt  */
+#line 1560 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_begin(p, (yyvsp[0].nd));
                       NODE_LINENO((yyval.nd), (yyvsp[0].nd));
                     }
-#line 5913 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6305 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 7:
-#line 1564 "mrbgems/mruby-compiler/core/parse.y"
+  case 7: /* top_stmts: top_stmts terms top_stmt  */
+#line 1565 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = push((yyvsp[-2].nd), newline_node((yyvsp[0].nd)));
                     }
-#line 5921 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6313 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 8:
-#line 1568 "mrbgems/mruby-compiler/core/parse.y"
+  case 8: /* top_stmts: error top_stmt  */
+#line 1569 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_begin(p, 0);
                     }
-#line 5929 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6321 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 10:
-#line 1575 "mrbgems/mruby-compiler/core/parse.y"
+  case 10: /* @2: %empty  */
+#line 1576 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = local_switch(p);
                       nvars_block(p);
                     }
-#line 5938 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6330 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 11:
-#line 1580 "mrbgems/mruby-compiler/core/parse.y"
+  case 11: /* top_stmt: keyword_BEGIN @2 '{' top_compstmt '}'  */
+#line 1581 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       yyerror(p, "BEGIN not supported");
                       local_resume(p, (yyvsp[-3].nd));
                       nvars_unnest(p);
                       (yyval.nd) = 0;
                     }
-#line 5949 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6341 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 12:
-#line 1592 "mrbgems/mruby-compiler/core/parse.y"
+  case 12: /* bodystmt: compstmt opt_rescue opt_else opt_ensure  */
+#line 1593 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       if ((yyvsp[-2].nd)) {
                         (yyval.nd) = new_rescue(p, (yyvsp[-3].nd), (yyvsp[-2].nd), (yyvsp[-1].nd));
@@ -5971,291 +6363,291 @@ yyreduce:
                         }
                       }
                     }
-#line 5975 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6367 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 13:
-#line 1616 "mrbgems/mruby-compiler/core/parse.y"
+  case 13: /* compstmt: stmts opt_terms  */
+#line 1617 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[-1].nd);
                     }
-#line 5983 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6375 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 14:
-#line 1622 "mrbgems/mruby-compiler/core/parse.y"
+  case 14: /* stmts: none  */
+#line 1623 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_begin(p, 0);
                     }
-#line 5991 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6383 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 15:
-#line 1626 "mrbgems/mruby-compiler/core/parse.y"
+  case 15: /* stmts: stmt  */
+#line 1627 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_begin(p, (yyvsp[0].nd));
                       NODE_LINENO((yyval.nd), (yyvsp[0].nd));
                     }
-#line 6000 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6392 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 16:
-#line 1631 "mrbgems/mruby-compiler/core/parse.y"
+  case 16: /* stmts: stmts terms stmt  */
+#line 1632 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = push((yyvsp[-2].nd), newline_node((yyvsp[0].nd)));
                     }
-#line 6008 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6400 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 17:
-#line 1635 "mrbgems/mruby-compiler/core/parse.y"
+  case 17: /* stmts: error stmt  */
+#line 1636 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_begin(p, (yyvsp[0].nd));
                     }
-#line 6016 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6408 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 18:
-#line 1640 "mrbgems/mruby-compiler/core/parse.y"
-                                     {p->lstate = EXPR_FNAME;}
-#line 6022 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 19:
+  case 18: /* $@3: %empty  */
 #line 1641 "mrbgems/mruby-compiler/core/parse.y"
+                                     {p->lstate = EXPR_FNAME;}
+#line 6414 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 19: /* stmt: keyword_alias fsym $@3 fsym  */
+#line 1642 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_alias(p, (yyvsp[-2].id), (yyvsp[0].id));
                     }
-#line 6030 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6422 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 20:
-#line 1645 "mrbgems/mruby-compiler/core/parse.y"
+  case 20: /* stmt: keyword_undef undef_list  */
+#line 1646 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[0].nd);
                     }
-#line 6038 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6430 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 21:
-#line 1649 "mrbgems/mruby-compiler/core/parse.y"
+  case 21: /* stmt: stmt modifier_if expr_value  */
+#line 1650 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_if(p, cond((yyvsp[0].nd)), (yyvsp[-2].nd), 0);
                     }
-#line 6046 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6438 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 22:
-#line 1653 "mrbgems/mruby-compiler/core/parse.y"
+  case 22: /* stmt: stmt modifier_unless expr_value  */
+#line 1654 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_unless(p, cond((yyvsp[0].nd)), (yyvsp[-2].nd), 0);
                     }
-#line 6054 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6446 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 23:
-#line 1657 "mrbgems/mruby-compiler/core/parse.y"
+  case 23: /* stmt: stmt modifier_while expr_value  */
+#line 1658 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_while(p, cond((yyvsp[0].nd)), (yyvsp[-2].nd));
                     }
-#line 6062 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6454 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 24:
-#line 1661 "mrbgems/mruby-compiler/core/parse.y"
+  case 24: /* stmt: stmt modifier_until expr_value  */
+#line 1662 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_until(p, cond((yyvsp[0].nd)), (yyvsp[-2].nd));
                     }
-#line 6070 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6462 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 25:
-#line 1665 "mrbgems/mruby-compiler/core/parse.y"
+  case 25: /* stmt: stmt modifier_rescue stmt  */
+#line 1666 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_mod_rescue(p, (yyvsp[-2].nd), (yyvsp[0].nd));
                     }
-#line 6078 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6470 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 26:
-#line 1669 "mrbgems/mruby-compiler/core/parse.y"
+  case 26: /* stmt: keyword_END '{' compstmt '}'  */
+#line 1670 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       yyerror(p, "END not supported");
                       (yyval.nd) = new_postexe(p, (yyvsp[-1].nd));
                     }
-#line 6087 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6479 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 28:
-#line 1675 "mrbgems/mruby-compiler/core/parse.y"
+  case 28: /* stmt: mlhs '=' command_call  */
+#line 1676 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_masgn(p, (yyvsp[-2].nd), (yyvsp[0].nd));
                     }
-#line 6095 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6487 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 29:
-#line 1679 "mrbgems/mruby-compiler/core/parse.y"
+  case 29: /* stmt: lhs '=' mrhs  */
+#line 1680 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_asgn(p, (yyvsp[-2].nd), new_array(p, (yyvsp[0].nd)));
                     }
-#line 6103 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6495 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 30:
-#line 1683 "mrbgems/mruby-compiler/core/parse.y"
+  case 30: /* stmt: mlhs '=' arg  */
+#line 1684 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_masgn(p, (yyvsp[-2].nd), (yyvsp[0].nd));
                     }
-#line 6111 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6503 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 31:
-#line 1687 "mrbgems/mruby-compiler/core/parse.y"
+  case 31: /* stmt: mlhs '=' mrhs  */
+#line 1688 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_masgn(p, (yyvsp[-2].nd), new_array(p, (yyvsp[0].nd)));
                     }
-#line 6119 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6511 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 32:
-#line 1691 "mrbgems/mruby-compiler/core/parse.y"
+  case 32: /* stmt: arg tASSOC tIDENTIFIER  */
+#line 1692 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       node *lhs = new_lvar(p, (yyvsp[0].id));
                       void_expr_error(p, (yyvsp[-2].nd));
                       assignable(p, lhs);
                       (yyval.nd) = new_asgn(p, lhs, (yyvsp[-2].nd));
                     }
-#line 6130 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6522 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 34:
-#line 1701 "mrbgems/mruby-compiler/core/parse.y"
+  case 34: /* command_asgn: lhs '=' command_rhs  */
+#line 1702 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_asgn(p, (yyvsp[-2].nd), (yyvsp[0].nd));
                     }
-#line 6138 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6530 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 35:
-#line 1705 "mrbgems/mruby-compiler/core/parse.y"
+  case 35: /* command_asgn: var_lhs tOP_ASGN command_rhs  */
+#line 1706 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_op_asgn(p, (yyvsp[-2].nd), (yyvsp[-1].id), (yyvsp[0].nd));
                     }
-#line 6146 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6538 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 36:
-#line 1709 "mrbgems/mruby-compiler/core/parse.y"
+  case 36: /* command_asgn: primary_value '[' opt_call_args ']' tOP_ASGN command_rhs  */
+#line 1710 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_op_asgn(p, new_call(p, (yyvsp[-5].nd), intern_op(aref), (yyvsp[-3].nd), '.'), (yyvsp[-1].id), (yyvsp[0].nd));
                     }
-#line 6154 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6546 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 37:
-#line 1713 "mrbgems/mruby-compiler/core/parse.y"
+  case 37: /* command_asgn: primary_value call_op tIDENTIFIER tOP_ASGN command_rhs  */
+#line 1714 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_op_asgn(p, new_call(p, (yyvsp[-4].nd), (yyvsp[-2].id), 0, (yyvsp[-3].num)), (yyvsp[-1].id), (yyvsp[0].nd));
                     }
-#line 6162 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6554 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 38:
-#line 1717 "mrbgems/mruby-compiler/core/parse.y"
+  case 38: /* command_asgn: primary_value call_op tCONSTANT tOP_ASGN command_rhs  */
+#line 1718 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_op_asgn(p, new_call(p, (yyvsp[-4].nd), (yyvsp[-2].id), 0, (yyvsp[-3].num)), (yyvsp[-1].id), (yyvsp[0].nd));
                     }
-#line 6170 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6562 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 39:
-#line 1721 "mrbgems/mruby-compiler/core/parse.y"
+  case 39: /* command_asgn: primary_value tCOLON2 tCONSTANT tOP_ASGN command_call  */
+#line 1722 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       yyerror(p, "constant re-assignment");
                       (yyval.nd) = 0;
                     }
-#line 6179 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6571 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 40:
-#line 1726 "mrbgems/mruby-compiler/core/parse.y"
+  case 40: /* command_asgn: primary_value tCOLON2 tIDENTIFIER tOP_ASGN command_rhs  */
+#line 1727 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_op_asgn(p, new_call(p, (yyvsp[-4].nd), (yyvsp[-2].id), 0, tCOLON2), (yyvsp[-1].id), (yyvsp[0].nd));
                     }
-#line 6187 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6579 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 41:
-#line 1730 "mrbgems/mruby-compiler/core/parse.y"
+  case 41: /* command_asgn: backref tOP_ASGN command_rhs  */
+#line 1731 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       backref_error(p, (yyvsp[-2].nd));
                       (yyval.nd) = new_begin(p, 0);
                     }
-#line 6196 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6588 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 43:
-#line 1738 "mrbgems/mruby-compiler/core/parse.y"
+  case 43: /* command_rhs: command_call modifier_rescue stmt  */
+#line 1739 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_mod_rescue(p, (yyvsp[-2].nd), (yyvsp[0].nd));
                     }
-#line 6204 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6596 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 46:
-#line 1747 "mrbgems/mruby-compiler/core/parse.y"
+  case 46: /* expr: expr keyword_and expr  */
+#line 1748 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_and(p, (yyvsp[-2].nd), (yyvsp[0].nd));
                     }
-#line 6212 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6604 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 47:
-#line 1751 "mrbgems/mruby-compiler/core/parse.y"
+  case 47: /* expr: expr keyword_or expr  */
+#line 1752 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_or(p, (yyvsp[-2].nd), (yyvsp[0].nd));
                     }
-#line 6220 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6612 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 48:
-#line 1755 "mrbgems/mruby-compiler/core/parse.y"
+  case 48: /* expr: keyword_not opt_nl expr  */
+#line 1756 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_uni_op(p, cond((yyvsp[0].nd)), "!");
                     }
-#line 6228 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6620 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 49:
-#line 1759 "mrbgems/mruby-compiler/core/parse.y"
+  case 49: /* expr: '!' command_call  */
+#line 1760 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_uni_op(p, cond((yyvsp[0].nd)), "!");
                     }
-#line 6236 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6628 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 51:
-#line 1767 "mrbgems/mruby-compiler/core/parse.y"
+  case 51: /* defn_head: keyword_def fname  */
+#line 1768 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_def(p, (yyvsp[0].id), nint(p->cmdarg_stack), local_switch(p));
                       p->cmdarg_stack = 0;
                       p->in_def++;
                       nvars_block(p);
                     }
-#line 6247 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6639 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 52:
-#line 1776 "mrbgems/mruby-compiler/core/parse.y"
+  case 52: /* $@4: %empty  */
+#line 1777 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       p->lstate = EXPR_FNAME;
                     }
-#line 6255 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6647 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 53:
-#line 1780 "mrbgems/mruby-compiler/core/parse.y"
+  case 53: /* defs_head: keyword_def singleton dot_or_colon $@4 fname  */
+#line 1781 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_sdef(p, (yyvsp[-3].nd), (yyvsp[0].id), nint(p->cmdarg_stack), local_switch(p));
                       p->cmdarg_stack = 0;
@@ -6264,1054 +6656,1054 @@ yyreduce:
                       nvars_block(p);
                       p->lstate = EXPR_ENDFN; /* force for args */
                     }
-#line 6268 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6660 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 54:
-#line 1791 "mrbgems/mruby-compiler/core/parse.y"
+  case 54: /* expr_value: expr  */
+#line 1792 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       if (!(yyvsp[0].nd)) (yyval.nd) = new_nil(p);
                       else {
                         (yyval.nd) = (yyvsp[0].nd);
                       }
                     }
-#line 6279 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6671 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 58:
-#line 1805 "mrbgems/mruby-compiler/core/parse.y"
+  case 58: /* block_command: block_call call_op2 operation2 command_args  */
+#line 1806 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_call(p, (yyvsp[-3].nd), (yyvsp[-1].id), (yyvsp[0].nd), (yyvsp[-2].num));
                     }
-#line 6287 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6679 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 59:
-#line 1811 "mrbgems/mruby-compiler/core/parse.y"
+  case 59: /* $@5: %empty  */
+#line 1812 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       local_nest(p);
                       nvars_nest(p);
                     }
-#line 6296 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6688 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 60:
-#line 1818 "mrbgems/mruby-compiler/core/parse.y"
+  case 60: /* cmd_brace_block: tLBRACE_ARG $@5 opt_block_param compstmt '}'  */
+#line 1819 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_block(p, (yyvsp[-2].nd), (yyvsp[-1].nd));
                       local_unnest(p);
                       nvars_unnest(p);
                     }
-#line 6306 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6698 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 61:
-#line 1826 "mrbgems/mruby-compiler/core/parse.y"
+  case 61: /* command: operation command_args  */
+#line 1827 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_fcall(p, (yyvsp[-1].id), (yyvsp[0].nd));
                     }
-#line 6314 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6706 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 62:
-#line 1830 "mrbgems/mruby-compiler/core/parse.y"
+  case 62: /* command: operation command_args cmd_brace_block  */
+#line 1831 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       args_with_block(p, (yyvsp[-1].nd), (yyvsp[0].nd));
                       (yyval.nd) = new_fcall(p, (yyvsp[-2].id), (yyvsp[-1].nd));
                     }
-#line 6323 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6715 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 63:
-#line 1835 "mrbgems/mruby-compiler/core/parse.y"
+  case 63: /* command: primary_value call_op operation2 command_args  */
+#line 1836 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_call(p, (yyvsp[-3].nd), (yyvsp[-1].id), (yyvsp[0].nd), (yyvsp[-2].num));
                     }
-#line 6331 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6723 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 64:
-#line 1839 "mrbgems/mruby-compiler/core/parse.y"
+  case 64: /* command: primary_value call_op operation2 command_args cmd_brace_block  */
+#line 1840 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       args_with_block(p, (yyvsp[-1].nd), (yyvsp[0].nd));
                       (yyval.nd) = new_call(p, (yyvsp[-4].nd), (yyvsp[-2].id), (yyvsp[-1].nd), (yyvsp[-3].num));
                    }
-#line 6340 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6732 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 65:
-#line 1844 "mrbgems/mruby-compiler/core/parse.y"
+  case 65: /* command: primary_value tCOLON2 operation2 command_args  */
+#line 1845 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_call(p, (yyvsp[-3].nd), (yyvsp[-1].id), (yyvsp[0].nd), tCOLON2);
                     }
-#line 6348 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6740 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 66:
-#line 1848 "mrbgems/mruby-compiler/core/parse.y"
+  case 66: /* command: primary_value tCOLON2 operation2 command_args cmd_brace_block  */
+#line 1849 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       args_with_block(p, (yyvsp[-1].nd), (yyvsp[0].nd));
                       (yyval.nd) = new_call(p, (yyvsp[-4].nd), (yyvsp[-2].id), (yyvsp[-1].nd), tCOLON2);
                     }
-#line 6357 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6749 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 67:
-#line 1853 "mrbgems/mruby-compiler/core/parse.y"
+  case 67: /* command: keyword_super command_args  */
+#line 1854 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_super(p, (yyvsp[0].nd));
                     }
-#line 6365 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6757 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 68:
-#line 1857 "mrbgems/mruby-compiler/core/parse.y"
+  case 68: /* command: keyword_yield command_args  */
+#line 1858 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_yield(p, (yyvsp[0].nd));
                     }
-#line 6373 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6765 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 69:
-#line 1861 "mrbgems/mruby-compiler/core/parse.y"
+  case 69: /* command: keyword_return call_args  */
+#line 1862 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_return(p, ret_args(p, (yyvsp[0].nd)));
                     }
-#line 6381 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6773 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 70:
-#line 1865 "mrbgems/mruby-compiler/core/parse.y"
+  case 70: /* command: keyword_break call_args  */
+#line 1866 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_break(p, ret_args(p, (yyvsp[0].nd)));
                     }
-#line 6389 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6781 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 71:
-#line 1869 "mrbgems/mruby-compiler/core/parse.y"
+  case 71: /* command: keyword_next call_args  */
+#line 1870 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_next(p, ret_args(p, (yyvsp[0].nd)));
                     }
-#line 6397 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6789 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 72:
-#line 1875 "mrbgems/mruby-compiler/core/parse.y"
+  case 72: /* mlhs: mlhs_basic  */
+#line 1876 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[0].nd);
                     }
-#line 6405 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6797 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 73:
-#line 1879 "mrbgems/mruby-compiler/core/parse.y"
+  case 73: /* mlhs: tLPAREN mlhs_inner rparen  */
+#line 1880 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[-1].nd);
                     }
-#line 6413 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6805 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 75:
-#line 1886 "mrbgems/mruby-compiler/core/parse.y"
+  case 75: /* mlhs_inner: tLPAREN mlhs_inner rparen  */
+#line 1887 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[-1].nd);
                     }
-#line 6421 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6813 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 76:
-#line 1892 "mrbgems/mruby-compiler/core/parse.y"
+  case 76: /* mlhs_basic: mlhs_list  */
+#line 1893 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list1((yyvsp[0].nd));
                     }
-#line 6429 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6821 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 77:
-#line 1896 "mrbgems/mruby-compiler/core/parse.y"
+  case 77: /* mlhs_basic: mlhs_list mlhs_item  */
+#line 1897 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list1(push((yyvsp[-1].nd),(yyvsp[0].nd)));
                     }
-#line 6437 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6829 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 78:
-#line 1900 "mrbgems/mruby-compiler/core/parse.y"
+  case 78: /* mlhs_basic: mlhs_list tSTAR mlhs_node  */
+#line 1901 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list2((yyvsp[-2].nd), (yyvsp[0].nd));
                     }
-#line 6445 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6837 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 79:
-#line 1904 "mrbgems/mruby-compiler/core/parse.y"
+  case 79: /* mlhs_basic: mlhs_list tSTAR mlhs_node ',' mlhs_post  */
+#line 1905 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list3((yyvsp[-4].nd), (yyvsp[-2].nd), (yyvsp[0].nd));
                     }
-#line 6453 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6845 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 80:
-#line 1908 "mrbgems/mruby-compiler/core/parse.y"
+  case 80: /* mlhs_basic: mlhs_list tSTAR  */
+#line 1909 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list2((yyvsp[-1].nd), new_nil(p));
                     }
-#line 6461 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6853 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 81:
-#line 1912 "mrbgems/mruby-compiler/core/parse.y"
+  case 81: /* mlhs_basic: mlhs_list tSTAR ',' mlhs_post  */
+#line 1913 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list3((yyvsp[-3].nd), new_nil(p), (yyvsp[0].nd));
                     }
-#line 6469 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6861 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 82:
-#line 1916 "mrbgems/mruby-compiler/core/parse.y"
+  case 82: /* mlhs_basic: tSTAR mlhs_node  */
+#line 1917 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list2(0, (yyvsp[0].nd));
                     }
-#line 6477 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6869 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 83:
-#line 1920 "mrbgems/mruby-compiler/core/parse.y"
+  case 83: /* mlhs_basic: tSTAR mlhs_node ',' mlhs_post  */
+#line 1921 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list3(0, (yyvsp[-2].nd), (yyvsp[0].nd));
                     }
-#line 6485 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6877 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 84:
-#line 1924 "mrbgems/mruby-compiler/core/parse.y"
+  case 84: /* mlhs_basic: tSTAR  */
+#line 1925 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list2(0, new_nil(p));
                     }
-#line 6493 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6885 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 85:
-#line 1928 "mrbgems/mruby-compiler/core/parse.y"
+  case 85: /* mlhs_basic: tSTAR ',' mlhs_post  */
+#line 1929 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list3(0, new_nil(p), (yyvsp[0].nd));
                     }
-#line 6501 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6893 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 87:
-#line 1935 "mrbgems/mruby-compiler/core/parse.y"
+  case 87: /* mlhs_item: tLPAREN mlhs_inner rparen  */
+#line 1936 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_masgn(p, (yyvsp[-1].nd), NULL);
                     }
-#line 6509 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6901 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 88:
-#line 1941 "mrbgems/mruby-compiler/core/parse.y"
+  case 88: /* mlhs_list: mlhs_item ','  */
+#line 1942 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list1((yyvsp[-1].nd));
                     }
-#line 6517 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6909 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 89:
-#line 1945 "mrbgems/mruby-compiler/core/parse.y"
+  case 89: /* mlhs_list: mlhs_list mlhs_item ','  */
+#line 1946 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = push((yyvsp[-2].nd), (yyvsp[-1].nd));
                     }
-#line 6525 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6917 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 90:
-#line 1951 "mrbgems/mruby-compiler/core/parse.y"
+  case 90: /* mlhs_post: mlhs_item  */
+#line 1952 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list1((yyvsp[0].nd));
                     }
-#line 6533 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6925 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 91:
-#line 1955 "mrbgems/mruby-compiler/core/parse.y"
+  case 91: /* mlhs_post: mlhs_list mlhs_item  */
+#line 1956 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = push((yyvsp[-1].nd), (yyvsp[0].nd));
                     }
-#line 6541 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6933 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 92:
-#line 1961 "mrbgems/mruby-compiler/core/parse.y"
+  case 92: /* mlhs_node: variable  */
+#line 1962 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       assignable(p, (yyvsp[0].nd));
                     }
-#line 6549 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6941 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 93:
-#line 1965 "mrbgems/mruby-compiler/core/parse.y"
+  case 93: /* mlhs_node: primary_value '[' opt_call_args ']'  */
+#line 1966 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_call(p, (yyvsp[-3].nd), intern_op(aref), (yyvsp[-1].nd), '.');
                     }
-#line 6557 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6949 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 94:
-#line 1969 "mrbgems/mruby-compiler/core/parse.y"
+  case 94: /* mlhs_node: primary_value call_op tIDENTIFIER  */
+#line 1970 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_call(p, (yyvsp[-2].nd), (yyvsp[0].id), 0, (yyvsp[-1].num));
                     }
-#line 6565 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6957 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 95:
-#line 1973 "mrbgems/mruby-compiler/core/parse.y"
+  case 95: /* mlhs_node: primary_value tCOLON2 tIDENTIFIER  */
+#line 1974 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_call(p, (yyvsp[-2].nd), (yyvsp[0].id), 0, tCOLON2);
                     }
-#line 6573 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6965 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 96:
-#line 1977 "mrbgems/mruby-compiler/core/parse.y"
+  case 96: /* mlhs_node: primary_value call_op tCONSTANT  */
+#line 1978 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_call(p, (yyvsp[-2].nd), (yyvsp[0].id), 0, (yyvsp[-1].num));
                     }
-#line 6581 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6973 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 97:
-#line 1981 "mrbgems/mruby-compiler/core/parse.y"
+  case 97: /* mlhs_node: primary_value tCOLON2 tCONSTANT  */
+#line 1982 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       if (p->in_def || p->in_single)
                         yyerror(p, "dynamic constant assignment");
                       (yyval.nd) = new_colon2(p, (yyvsp[-2].nd), (yyvsp[0].id));
                     }
-#line 6591 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6983 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 98:
-#line 1987 "mrbgems/mruby-compiler/core/parse.y"
+  case 98: /* mlhs_node: tCOLON3 tCONSTANT  */
+#line 1988 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       if (p->in_def || p->in_single)
                         yyerror(p, "dynamic constant assignment");
                       (yyval.nd) = new_colon3(p, (yyvsp[0].id));
                     }
-#line 6601 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 6993 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 99:
-#line 1993 "mrbgems/mruby-compiler/core/parse.y"
+  case 99: /* mlhs_node: backref  */
+#line 1994 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       backref_error(p, (yyvsp[0].nd));
                       (yyval.nd) = 0;
                     }
-#line 6610 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7002 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 100:
-#line 2000 "mrbgems/mruby-compiler/core/parse.y"
+  case 100: /* lhs: variable  */
+#line 2001 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       assignable(p, (yyvsp[0].nd));
                     }
-#line 6618 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7010 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 101:
-#line 2004 "mrbgems/mruby-compiler/core/parse.y"
+  case 101: /* lhs: primary_value '[' opt_call_args ']'  */
+#line 2005 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_call(p, (yyvsp[-3].nd), intern_op(aref), (yyvsp[-1].nd), '.');
                     }
-#line 6626 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7018 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 102:
-#line 2008 "mrbgems/mruby-compiler/core/parse.y"
+  case 102: /* lhs: primary_value call_op tIDENTIFIER  */
+#line 2009 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_call(p, (yyvsp[-2].nd), (yyvsp[0].id), 0, (yyvsp[-1].num));
                     }
-#line 6634 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7026 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 103:
-#line 2012 "mrbgems/mruby-compiler/core/parse.y"
+  case 103: /* lhs: primary_value tCOLON2 tIDENTIFIER  */
+#line 2013 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_call(p, (yyvsp[-2].nd), (yyvsp[0].id), 0, tCOLON2);
                     }
-#line 6642 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7034 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 104:
-#line 2016 "mrbgems/mruby-compiler/core/parse.y"
+  case 104: /* lhs: primary_value call_op tCONSTANT  */
+#line 2017 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_call(p, (yyvsp[-2].nd), (yyvsp[0].id), 0, (yyvsp[-1].num));
                     }
-#line 6650 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7042 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 105:
-#line 2020 "mrbgems/mruby-compiler/core/parse.y"
+  case 105: /* lhs: primary_value tCOLON2 tCONSTANT  */
+#line 2021 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       if (p->in_def || p->in_single)
                         yyerror(p, "dynamic constant assignment");
                       (yyval.nd) = new_colon2(p, (yyvsp[-2].nd), (yyvsp[0].id));
                     }
-#line 6660 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7052 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 106:
-#line 2026 "mrbgems/mruby-compiler/core/parse.y"
+  case 106: /* lhs: tCOLON3 tCONSTANT  */
+#line 2027 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       if (p->in_def || p->in_single)
                         yyerror(p, "dynamic constant assignment");
                       (yyval.nd) = new_colon3(p, (yyvsp[0].id));
                     }
-#line 6670 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7062 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 107:
-#line 2032 "mrbgems/mruby-compiler/core/parse.y"
+  case 107: /* lhs: backref  */
+#line 2033 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       backref_error(p, (yyvsp[0].nd));
                       (yyval.nd) = 0;
-                    }
-#line 6679 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 108:
-#line 2037 "mrbgems/mruby-compiler/core/parse.y"
-                    {
-                      yyerror(p, "can't assign to numbered parameter");
-                    }
-#line 6687 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 109:
-#line 2043 "mrbgems/mruby-compiler/core/parse.y"
-                    {
-                      yyerror(p, "class/module name must be CONSTANT");
-                    }
-#line 6695 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 111:
-#line 2050 "mrbgems/mruby-compiler/core/parse.y"
-                    {
-                      (yyval.nd) = cons(nint(1), nsym((yyvsp[0].id)));
-                    }
-#line 6703 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 112:
-#line 2054 "mrbgems/mruby-compiler/core/parse.y"
-                    {
-                      (yyval.nd) = cons(nint(0), nsym((yyvsp[0].id)));
-                    }
-#line 6711 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 113:
-#line 2058 "mrbgems/mruby-compiler/core/parse.y"
-                    {
-                      void_expr_error(p, (yyvsp[-2].nd));
-                      (yyval.nd) = cons((yyvsp[-2].nd), nsym((yyvsp[0].id)));
-                    }
-#line 6720 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 117:
-#line 2068 "mrbgems/mruby-compiler/core/parse.y"
-                    {
-                      p->lstate = EXPR_ENDFN;
-                      (yyval.id) = (yyvsp[0].id);
-                    }
-#line 6729 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 118:
-#line 2073 "mrbgems/mruby-compiler/core/parse.y"
-                    {
-                      p->lstate = EXPR_ENDFN;
-                      (yyval.id) = (yyvsp[0].id);
-                    }
-#line 6738 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 121:
-#line 2084 "mrbgems/mruby-compiler/core/parse.y"
-                    {
-                      (yyval.nd) = new_undef(p, (yyvsp[0].id));
-                    }
-#line 6746 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 122:
-#line 2087 "mrbgems/mruby-compiler/core/parse.y"
-                                 {p->lstate = EXPR_FNAME;}
-#line 6752 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 123:
-#line 2088 "mrbgems/mruby-compiler/core/parse.y"
-                    {
-                      (yyval.nd) = push((yyvsp[-3].nd), nsym((yyvsp[0].id)));
-                    }
-#line 6760 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 124:
-#line 2093 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = intern_op(or);     }
-#line 6766 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 125:
-#line 2094 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = intern_op(xor);    }
-#line 6772 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 126:
-#line 2095 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = intern_op(and);    }
-#line 6778 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 127:
-#line 2096 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = intern_op(cmp);    }
-#line 6784 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 128:
-#line 2097 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = intern_op(eq);     }
-#line 6790 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 129:
-#line 2098 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = intern_op(eqq);    }
-#line 6796 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 130:
-#line 2099 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = intern_op(match);  }
-#line 6802 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 131:
-#line 2100 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = intern_op(nmatch); }
-#line 6808 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 132:
-#line 2101 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = intern_op(gt);     }
-#line 6814 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 133:
-#line 2102 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = intern_op(ge);     }
-#line 6820 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 134:
-#line 2103 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = intern_op(lt);     }
-#line 6826 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 135:
-#line 2104 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = intern_op(le);     }
-#line 6832 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 136:
-#line 2105 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = intern_op(neq);    }
-#line 6838 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 137:
-#line 2106 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = intern_op(lshift); }
-#line 6844 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 138:
-#line 2107 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = intern_op(rshift); }
-#line 6850 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 139:
-#line 2108 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = intern_op(add);    }
-#line 6856 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 140:
-#line 2109 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = intern_op(sub);    }
-#line 6862 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 141:
-#line 2110 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = intern_op(mul);    }
-#line 6868 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 142:
-#line 2111 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = intern_op(mul);    }
-#line 6874 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 143:
-#line 2112 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = intern_op(div);    }
-#line 6880 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 144:
-#line 2113 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = intern_op(mod);    }
-#line 6886 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 145:
-#line 2114 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = intern_op(pow);    }
-#line 6892 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 146:
-#line 2115 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = intern_op(pow);    }
-#line 6898 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 147:
-#line 2116 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = intern_op(not);    }
-#line 6904 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 148:
-#line 2117 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = intern_op(neg);    }
-#line 6910 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 149:
-#line 2118 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = intern_op(plus);   }
-#line 6916 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 150:
-#line 2119 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = intern_op(minus);  }
-#line 6922 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 151:
-#line 2120 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = intern_op(aref);   }
-#line 6928 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 152:
-#line 2121 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = intern_op(aset);   }
-#line 6934 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 153:
-#line 2122 "mrbgems/mruby-compiler/core/parse.y"
-                                { (yyval.id) = intern_op(tick);   }
-#line 6940 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 194:
-#line 2140 "mrbgems/mruby-compiler/core/parse.y"
-                    {
-                      (yyval.nd) = new_asgn(p, (yyvsp[-2].nd), (yyvsp[0].nd));
-                    }
-#line 6948 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 195:
-#line 2144 "mrbgems/mruby-compiler/core/parse.y"
-                    {
-                      (yyval.nd) = new_op_asgn(p, (yyvsp[-2].nd), (yyvsp[-1].id), (yyvsp[0].nd));
-                    }
-#line 6956 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 196:
-#line 2148 "mrbgems/mruby-compiler/core/parse.y"
-                    {
-                      (yyval.nd) = new_op_asgn(p, new_call(p, (yyvsp[-5].nd), intern_op(aref), (yyvsp[-3].nd), '.'), (yyvsp[-1].id), (yyvsp[0].nd));
-                    }
-#line 6964 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 197:
-#line 2152 "mrbgems/mruby-compiler/core/parse.y"
-                    {
-                      (yyval.nd) = new_op_asgn(p, new_call(p, (yyvsp[-4].nd), (yyvsp[-2].id), 0, (yyvsp[-3].num)), (yyvsp[-1].id), (yyvsp[0].nd));
-                    }
-#line 6972 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 198:
-#line 2156 "mrbgems/mruby-compiler/core/parse.y"
-                    {
-                      (yyval.nd) = new_op_asgn(p, new_call(p, (yyvsp[-4].nd), (yyvsp[-2].id), 0, (yyvsp[-3].num)), (yyvsp[-1].id), (yyvsp[0].nd));
-                    }
-#line 6980 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 199:
-#line 2160 "mrbgems/mruby-compiler/core/parse.y"
-                    {
-                      (yyval.nd) = new_op_asgn(p, new_call(p, (yyvsp[-4].nd), (yyvsp[-2].id), 0, tCOLON2), (yyvsp[-1].id), (yyvsp[0].nd));
-                    }
-#line 6988 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 200:
-#line 2164 "mrbgems/mruby-compiler/core/parse.y"
-                    {
-                      yyerror(p, "constant re-assignment");
-                      (yyval.nd) = new_begin(p, 0);
-                    }
-#line 6997 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 201:
-#line 2169 "mrbgems/mruby-compiler/core/parse.y"
-                    {
-                      yyerror(p, "constant re-assignment");
-                      (yyval.nd) = new_begin(p, 0);
-                    }
-#line 7006 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 202:
-#line 2174 "mrbgems/mruby-compiler/core/parse.y"
-                    {
-                      backref_error(p, (yyvsp[-2].nd));
-                      (yyval.nd) = new_begin(p, 0);
-                    }
-#line 7015 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 203:
-#line 2179 "mrbgems/mruby-compiler/core/parse.y"
-                    {
-                      (yyval.nd) = new_dot2(p, (yyvsp[-2].nd), (yyvsp[0].nd));
-                    }
-#line 7023 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 204:
-#line 2183 "mrbgems/mruby-compiler/core/parse.y"
-                    {
-                      (yyval.nd) = new_dot2(p, (yyvsp[-1].nd), new_nil(p));
-                    }
-#line 7031 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 205:
-#line 2187 "mrbgems/mruby-compiler/core/parse.y"
-                    {
-                      (yyval.nd) = new_dot2(p, new_nil(p), (yyvsp[0].nd));
-                    }
-#line 7039 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 206:
-#line 2191 "mrbgems/mruby-compiler/core/parse.y"
-                    {
-                      (yyval.nd) = new_dot3(p, (yyvsp[-2].nd), (yyvsp[0].nd));
-                    }
-#line 7047 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 207:
-#line 2195 "mrbgems/mruby-compiler/core/parse.y"
-                    {
-                      (yyval.nd) = new_dot3(p, (yyvsp[-1].nd), new_nil(p));
-                    }
-#line 7055 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 208:
-#line 2199 "mrbgems/mruby-compiler/core/parse.y"
-                    {
-                      (yyval.nd) = new_dot3(p, new_nil(p), (yyvsp[0].nd));
-                    }
-#line 7063 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 209:
-#line 2203 "mrbgems/mruby-compiler/core/parse.y"
-                    {
-                      (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), "+", (yyvsp[0].nd));
                     }
 #line 7071 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 210:
-#line 2207 "mrbgems/mruby-compiler/core/parse.y"
+  case 108: /* lhs: tNUMPARAM  */
+#line 2038 "mrbgems/mruby-compiler/core/parse.y"
                     {
-                      (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), "-", (yyvsp[0].nd));
+                      yyerror(p, "can't assign to numbered parameter");
                     }
 #line 7079 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 211:
-#line 2211 "mrbgems/mruby-compiler/core/parse.y"
+  case 109: /* cname: tIDENTIFIER  */
+#line 2044 "mrbgems/mruby-compiler/core/parse.y"
                     {
-                      (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), "*", (yyvsp[0].nd));
+                      yyerror(p, "class/module name must be CONSTANT");
                     }
 #line 7087 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 212:
-#line 2215 "mrbgems/mruby-compiler/core/parse.y"
+  case 111: /* cpath: tCOLON3 cname  */
+#line 2051 "mrbgems/mruby-compiler/core/parse.y"
                     {
-                      (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), "/", (yyvsp[0].nd));
+                      (yyval.nd) = cons(nint(1), nsym((yyvsp[0].id)));
                     }
 #line 7095 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 213:
-#line 2219 "mrbgems/mruby-compiler/core/parse.y"
+  case 112: /* cpath: cname  */
+#line 2055 "mrbgems/mruby-compiler/core/parse.y"
                     {
-                      (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), "%", (yyvsp[0].nd));
+                      (yyval.nd) = cons(nint(0), nsym((yyvsp[0].id)));
                     }
 #line 7103 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 214:
-#line 2223 "mrbgems/mruby-compiler/core/parse.y"
+  case 113: /* cpath: primary_value tCOLON2 cname  */
+#line 2059 "mrbgems/mruby-compiler/core/parse.y"
+                    {
+                      void_expr_error(p, (yyvsp[-2].nd));
+                      (yyval.nd) = cons((yyvsp[-2].nd), nsym((yyvsp[0].id)));
+                    }
+#line 7112 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 117: /* fname: op  */
+#line 2069 "mrbgems/mruby-compiler/core/parse.y"
+                    {
+                      p->lstate = EXPR_ENDFN;
+                      (yyval.id) = (yyvsp[0].id);
+                    }
+#line 7121 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 118: /* fname: reswords  */
+#line 2074 "mrbgems/mruby-compiler/core/parse.y"
+                    {
+                      p->lstate = EXPR_ENDFN;
+                      (yyval.id) = (yyvsp[0].id);
+                    }
+#line 7130 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 121: /* undef_list: fsym  */
+#line 2085 "mrbgems/mruby-compiler/core/parse.y"
+                    {
+                      (yyval.nd) = new_undef(p, (yyvsp[0].id));
+                    }
+#line 7138 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 122: /* $@6: %empty  */
+#line 2088 "mrbgems/mruby-compiler/core/parse.y"
+                                 {p->lstate = EXPR_FNAME;}
+#line 7144 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 123: /* undef_list: undef_list ',' $@6 fsym  */
+#line 2089 "mrbgems/mruby-compiler/core/parse.y"
+                    {
+                      (yyval.nd) = push((yyvsp[-3].nd), nsym((yyvsp[0].id)));
+                    }
+#line 7152 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 124: /* op: '|'  */
+#line 2094 "mrbgems/mruby-compiler/core/parse.y"
+                                { (yyval.id) = intern_op(or);     }
+#line 7158 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 125: /* op: '^'  */
+#line 2095 "mrbgems/mruby-compiler/core/parse.y"
+                                { (yyval.id) = intern_op(xor);    }
+#line 7164 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 126: /* op: '&'  */
+#line 2096 "mrbgems/mruby-compiler/core/parse.y"
+                                { (yyval.id) = intern_op(and);    }
+#line 7170 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 127: /* op: tCMP  */
+#line 2097 "mrbgems/mruby-compiler/core/parse.y"
+                                { (yyval.id) = intern_op(cmp);    }
+#line 7176 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 128: /* op: tEQ  */
+#line 2098 "mrbgems/mruby-compiler/core/parse.y"
+                                { (yyval.id) = intern_op(eq);     }
+#line 7182 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 129: /* op: tEQQ  */
+#line 2099 "mrbgems/mruby-compiler/core/parse.y"
+                                { (yyval.id) = intern_op(eqq);    }
+#line 7188 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 130: /* op: tMATCH  */
+#line 2100 "mrbgems/mruby-compiler/core/parse.y"
+                                { (yyval.id) = intern_op(match);  }
+#line 7194 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 131: /* op: tNMATCH  */
+#line 2101 "mrbgems/mruby-compiler/core/parse.y"
+                                { (yyval.id) = intern_op(nmatch); }
+#line 7200 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 132: /* op: '>'  */
+#line 2102 "mrbgems/mruby-compiler/core/parse.y"
+                                { (yyval.id) = intern_op(gt);     }
+#line 7206 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 133: /* op: tGEQ  */
+#line 2103 "mrbgems/mruby-compiler/core/parse.y"
+                                { (yyval.id) = intern_op(ge);     }
+#line 7212 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 134: /* op: '<'  */
+#line 2104 "mrbgems/mruby-compiler/core/parse.y"
+                                { (yyval.id) = intern_op(lt);     }
+#line 7218 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 135: /* op: tLEQ  */
+#line 2105 "mrbgems/mruby-compiler/core/parse.y"
+                                { (yyval.id) = intern_op(le);     }
+#line 7224 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 136: /* op: tNEQ  */
+#line 2106 "mrbgems/mruby-compiler/core/parse.y"
+                                { (yyval.id) = intern_op(neq);    }
+#line 7230 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 137: /* op: tLSHFT  */
+#line 2107 "mrbgems/mruby-compiler/core/parse.y"
+                                { (yyval.id) = intern_op(lshift); }
+#line 7236 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 138: /* op: tRSHFT  */
+#line 2108 "mrbgems/mruby-compiler/core/parse.y"
+                                { (yyval.id) = intern_op(rshift); }
+#line 7242 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 139: /* op: '+'  */
+#line 2109 "mrbgems/mruby-compiler/core/parse.y"
+                                { (yyval.id) = intern_op(add);    }
+#line 7248 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 140: /* op: '-'  */
+#line 2110 "mrbgems/mruby-compiler/core/parse.y"
+                                { (yyval.id) = intern_op(sub);    }
+#line 7254 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 141: /* op: '*'  */
+#line 2111 "mrbgems/mruby-compiler/core/parse.y"
+                                { (yyval.id) = intern_op(mul);    }
+#line 7260 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 142: /* op: tSTAR  */
+#line 2112 "mrbgems/mruby-compiler/core/parse.y"
+                                { (yyval.id) = intern_op(mul);    }
+#line 7266 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 143: /* op: '/'  */
+#line 2113 "mrbgems/mruby-compiler/core/parse.y"
+                                { (yyval.id) = intern_op(div);    }
+#line 7272 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 144: /* op: '%'  */
+#line 2114 "mrbgems/mruby-compiler/core/parse.y"
+                                { (yyval.id) = intern_op(mod);    }
+#line 7278 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 145: /* op: tPOW  */
+#line 2115 "mrbgems/mruby-compiler/core/parse.y"
+                                { (yyval.id) = intern_op(pow);    }
+#line 7284 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 146: /* op: tDSTAR  */
+#line 2116 "mrbgems/mruby-compiler/core/parse.y"
+                                { (yyval.id) = intern_op(pow);    }
+#line 7290 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 147: /* op: '!'  */
+#line 2117 "mrbgems/mruby-compiler/core/parse.y"
+                                { (yyval.id) = intern_op(not);    }
+#line 7296 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 148: /* op: '~'  */
+#line 2118 "mrbgems/mruby-compiler/core/parse.y"
+                                { (yyval.id) = intern_op(neg);    }
+#line 7302 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 149: /* op: tUPLUS  */
+#line 2119 "mrbgems/mruby-compiler/core/parse.y"
+                                { (yyval.id) = intern_op(plus);   }
+#line 7308 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 150: /* op: tUMINUS  */
+#line 2120 "mrbgems/mruby-compiler/core/parse.y"
+                                { (yyval.id) = intern_op(minus);  }
+#line 7314 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 151: /* op: tAREF  */
+#line 2121 "mrbgems/mruby-compiler/core/parse.y"
+                                { (yyval.id) = intern_op(aref);   }
+#line 7320 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 152: /* op: tASET  */
+#line 2122 "mrbgems/mruby-compiler/core/parse.y"
+                                { (yyval.id) = intern_op(aset);   }
+#line 7326 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 153: /* op: '`'  */
+#line 2123 "mrbgems/mruby-compiler/core/parse.y"
+                                { (yyval.id) = intern_op(tick);   }
+#line 7332 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 194: /* arg: lhs '=' arg_rhs  */
+#line 2141 "mrbgems/mruby-compiler/core/parse.y"
+                    {
+                      (yyval.nd) = new_asgn(p, (yyvsp[-2].nd), (yyvsp[0].nd));
+                    }
+#line 7340 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 195: /* arg: var_lhs tOP_ASGN arg_rhs  */
+#line 2145 "mrbgems/mruby-compiler/core/parse.y"
+                    {
+                      (yyval.nd) = new_op_asgn(p, (yyvsp[-2].nd), (yyvsp[-1].id), (yyvsp[0].nd));
+                    }
+#line 7348 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 196: /* arg: primary_value '[' opt_call_args ']' tOP_ASGN arg_rhs  */
+#line 2149 "mrbgems/mruby-compiler/core/parse.y"
+                    {
+                      (yyval.nd) = new_op_asgn(p, new_call(p, (yyvsp[-5].nd), intern_op(aref), (yyvsp[-3].nd), '.'), (yyvsp[-1].id), (yyvsp[0].nd));
+                    }
+#line 7356 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 197: /* arg: primary_value call_op tIDENTIFIER tOP_ASGN arg_rhs  */
+#line 2153 "mrbgems/mruby-compiler/core/parse.y"
+                    {
+                      (yyval.nd) = new_op_asgn(p, new_call(p, (yyvsp[-4].nd), (yyvsp[-2].id), 0, (yyvsp[-3].num)), (yyvsp[-1].id), (yyvsp[0].nd));
+                    }
+#line 7364 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 198: /* arg: primary_value call_op tCONSTANT tOP_ASGN arg_rhs  */
+#line 2157 "mrbgems/mruby-compiler/core/parse.y"
+                    {
+                      (yyval.nd) = new_op_asgn(p, new_call(p, (yyvsp[-4].nd), (yyvsp[-2].id), 0, (yyvsp[-3].num)), (yyvsp[-1].id), (yyvsp[0].nd));
+                    }
+#line 7372 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 199: /* arg: primary_value tCOLON2 tIDENTIFIER tOP_ASGN arg_rhs  */
+#line 2161 "mrbgems/mruby-compiler/core/parse.y"
+                    {
+                      (yyval.nd) = new_op_asgn(p, new_call(p, (yyvsp[-4].nd), (yyvsp[-2].id), 0, tCOLON2), (yyvsp[-1].id), (yyvsp[0].nd));
+                    }
+#line 7380 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 200: /* arg: primary_value tCOLON2 tCONSTANT tOP_ASGN arg_rhs  */
+#line 2165 "mrbgems/mruby-compiler/core/parse.y"
+                    {
+                      yyerror(p, "constant re-assignment");
+                      (yyval.nd) = new_begin(p, 0);
+                    }
+#line 7389 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 201: /* arg: tCOLON3 tCONSTANT tOP_ASGN arg_rhs  */
+#line 2170 "mrbgems/mruby-compiler/core/parse.y"
+                    {
+                      yyerror(p, "constant re-assignment");
+                      (yyval.nd) = new_begin(p, 0);
+                    }
+#line 7398 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 202: /* arg: backref tOP_ASGN arg_rhs  */
+#line 2175 "mrbgems/mruby-compiler/core/parse.y"
+                    {
+                      backref_error(p, (yyvsp[-2].nd));
+                      (yyval.nd) = new_begin(p, 0);
+                    }
+#line 7407 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 203: /* arg: arg tDOT2 arg  */
+#line 2180 "mrbgems/mruby-compiler/core/parse.y"
+                    {
+                      (yyval.nd) = new_dot2(p, (yyvsp[-2].nd), (yyvsp[0].nd));
+                    }
+#line 7415 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 204: /* arg: arg tDOT2  */
+#line 2184 "mrbgems/mruby-compiler/core/parse.y"
+                    {
+                      (yyval.nd) = new_dot2(p, (yyvsp[-1].nd), new_nil(p));
+                    }
+#line 7423 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 205: /* arg: tBDOT2 arg  */
+#line 2188 "mrbgems/mruby-compiler/core/parse.y"
+                    {
+                      (yyval.nd) = new_dot2(p, new_nil(p), (yyvsp[0].nd));
+                    }
+#line 7431 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 206: /* arg: arg tDOT3 arg  */
+#line 2192 "mrbgems/mruby-compiler/core/parse.y"
+                    {
+                      (yyval.nd) = new_dot3(p, (yyvsp[-2].nd), (yyvsp[0].nd));
+                    }
+#line 7439 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 207: /* arg: arg tDOT3  */
+#line 2196 "mrbgems/mruby-compiler/core/parse.y"
+                    {
+                      (yyval.nd) = new_dot3(p, (yyvsp[-1].nd), new_nil(p));
+                    }
+#line 7447 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 208: /* arg: tBDOT3 arg  */
+#line 2200 "mrbgems/mruby-compiler/core/parse.y"
+                    {
+                      (yyval.nd) = new_dot3(p, new_nil(p), (yyvsp[0].nd));
+                    }
+#line 7455 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 209: /* arg: arg '+' arg  */
+#line 2204 "mrbgems/mruby-compiler/core/parse.y"
+                    {
+                      (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), "+", (yyvsp[0].nd));
+                    }
+#line 7463 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 210: /* arg: arg '-' arg  */
+#line 2208 "mrbgems/mruby-compiler/core/parse.y"
+                    {
+                      (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), "-", (yyvsp[0].nd));
+                    }
+#line 7471 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 211: /* arg: arg '*' arg  */
+#line 2212 "mrbgems/mruby-compiler/core/parse.y"
+                    {
+                      (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), "*", (yyvsp[0].nd));
+                    }
+#line 7479 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 212: /* arg: arg '/' arg  */
+#line 2216 "mrbgems/mruby-compiler/core/parse.y"
+                    {
+                      (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), "/", (yyvsp[0].nd));
+                    }
+#line 7487 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 213: /* arg: arg '%' arg  */
+#line 2220 "mrbgems/mruby-compiler/core/parse.y"
+                    {
+                      (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), "%", (yyvsp[0].nd));
+                    }
+#line 7495 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 214: /* arg: arg tPOW arg  */
+#line 2224 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), "**", (yyvsp[0].nd));
                     }
-#line 7111 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7503 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 215:
-#line 2227 "mrbgems/mruby-compiler/core/parse.y"
+  case 215: /* arg: tUMINUS_NUM tINTEGER tPOW arg  */
+#line 2228 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_uni_op(p, call_bin_op(p, (yyvsp[-2].nd), "**", (yyvsp[0].nd)), "-@");
                     }
-#line 7119 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7511 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 216:
-#line 2231 "mrbgems/mruby-compiler/core/parse.y"
+  case 216: /* arg: tUMINUS_NUM tFLOAT tPOW arg  */
+#line 2232 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_uni_op(p, call_bin_op(p, (yyvsp[-2].nd), "**", (yyvsp[0].nd)), "-@");
                     }
-#line 7127 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7519 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 217:
-#line 2235 "mrbgems/mruby-compiler/core/parse.y"
+  case 217: /* arg: tUPLUS arg  */
+#line 2236 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_uni_op(p, (yyvsp[0].nd), "+@");
                     }
-#line 7135 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7527 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 218:
-#line 2239 "mrbgems/mruby-compiler/core/parse.y"
+  case 218: /* arg: tUMINUS arg  */
+#line 2240 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_uni_op(p, (yyvsp[0].nd), "-@");
                     }
-#line 7143 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7535 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 219:
-#line 2243 "mrbgems/mruby-compiler/core/parse.y"
+  case 219: /* arg: arg '|' arg  */
+#line 2244 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), "|", (yyvsp[0].nd));
                     }
-#line 7151 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7543 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 220:
-#line 2247 "mrbgems/mruby-compiler/core/parse.y"
+  case 220: /* arg: arg '^' arg  */
+#line 2248 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), "^", (yyvsp[0].nd));
                     }
-#line 7159 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7551 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 221:
-#line 2251 "mrbgems/mruby-compiler/core/parse.y"
+  case 221: /* arg: arg '&' arg  */
+#line 2252 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), "&", (yyvsp[0].nd));
                     }
-#line 7167 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7559 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 222:
-#line 2255 "mrbgems/mruby-compiler/core/parse.y"
+  case 222: /* arg: arg tCMP arg  */
+#line 2256 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), "<=>", (yyvsp[0].nd));
                     }
-#line 7175 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7567 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 223:
-#line 2259 "mrbgems/mruby-compiler/core/parse.y"
+  case 223: /* arg: arg '>' arg  */
+#line 2260 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), ">", (yyvsp[0].nd));
                     }
-#line 7183 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7575 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 224:
-#line 2263 "mrbgems/mruby-compiler/core/parse.y"
+  case 224: /* arg: arg tGEQ arg  */
+#line 2264 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), ">=", (yyvsp[0].nd));
                     }
-#line 7191 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7583 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 225:
-#line 2267 "mrbgems/mruby-compiler/core/parse.y"
+  case 225: /* arg: arg '<' arg  */
+#line 2268 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), "<", (yyvsp[0].nd));
                     }
-#line 7199 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7591 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 226:
-#line 2271 "mrbgems/mruby-compiler/core/parse.y"
+  case 226: /* arg: arg tLEQ arg  */
+#line 2272 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), "<=", (yyvsp[0].nd));
                     }
-#line 7207 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7599 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 227:
-#line 2275 "mrbgems/mruby-compiler/core/parse.y"
+  case 227: /* arg: arg tEQ arg  */
+#line 2276 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), "==", (yyvsp[0].nd));
                     }
-#line 7215 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7607 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 228:
-#line 2279 "mrbgems/mruby-compiler/core/parse.y"
+  case 228: /* arg: arg tEQQ arg  */
+#line 2280 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), "===", (yyvsp[0].nd));
                     }
-#line 7223 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7615 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 229:
-#line 2283 "mrbgems/mruby-compiler/core/parse.y"
+  case 229: /* arg: arg tNEQ arg  */
+#line 2284 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), "!=", (yyvsp[0].nd));
                     }
-#line 7231 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7623 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 230:
-#line 2287 "mrbgems/mruby-compiler/core/parse.y"
+  case 230: /* arg: arg tMATCH arg  */
+#line 2288 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), "=~", (yyvsp[0].nd));
                     }
-#line 7239 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7631 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 231:
-#line 2291 "mrbgems/mruby-compiler/core/parse.y"
+  case 231: /* arg: arg tNMATCH arg  */
+#line 2292 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), "!~", (yyvsp[0].nd));
                     }
-#line 7247 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7639 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 232:
-#line 2295 "mrbgems/mruby-compiler/core/parse.y"
+  case 232: /* arg: '!' arg  */
+#line 2296 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_uni_op(p, cond((yyvsp[0].nd)), "!");
                     }
-#line 7255 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7647 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 233:
-#line 2299 "mrbgems/mruby-compiler/core/parse.y"
+  case 233: /* arg: '~' arg  */
+#line 2300 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_uni_op(p, cond((yyvsp[0].nd)), "~");
                     }
-#line 7263 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7655 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 234:
-#line 2303 "mrbgems/mruby-compiler/core/parse.y"
+  case 234: /* arg: arg tLSHFT arg  */
+#line 2304 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), "<<", (yyvsp[0].nd));
                     }
-#line 7271 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7663 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 235:
-#line 2307 "mrbgems/mruby-compiler/core/parse.y"
+  case 235: /* arg: arg tRSHFT arg  */
+#line 2308 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_bin_op(p, (yyvsp[-2].nd), ">>", (yyvsp[0].nd));
                     }
-#line 7279 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7671 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 236:
-#line 2311 "mrbgems/mruby-compiler/core/parse.y"
+  case 236: /* arg: arg tANDOP arg  */
+#line 2312 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_and(p, (yyvsp[-2].nd), (yyvsp[0].nd));
                     }
-#line 7287 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7679 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 237:
-#line 2315 "mrbgems/mruby-compiler/core/parse.y"
+  case 237: /* arg: arg tOROP arg  */
+#line 2316 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_or(p, (yyvsp[-2].nd), (yyvsp[0].nd));
                     }
-#line 7295 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7687 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 238:
-#line 2319 "mrbgems/mruby-compiler/core/parse.y"
+  case 238: /* arg: arg '?' arg opt_nl ':' arg  */
+#line 2320 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_if(p, cond((yyvsp[-5].nd)), (yyvsp[-3].nd), (yyvsp[0].nd));
                     }
-#line 7303 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7695 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 239:
-#line 2323 "mrbgems/mruby-compiler/core/parse.y"
+  case 239: /* arg: arg '?' arg opt_nl tLABEL_TAG arg  */
+#line 2324 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_if(p, cond((yyvsp[-5].nd)), (yyvsp[-3].nd), (yyvsp[0].nd));
                     }
-#line 7311 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7703 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 240:
-#line 2327 "mrbgems/mruby-compiler/core/parse.y"
+  case 240: /* arg: defn_head f_arglist_paren '=' arg  */
+#line 2328 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[-3].nd);
                       void_expr_error(p, (yyvsp[0].nd));
@@ -7319,11 +7711,11 @@ yyreduce:
                       nvars_unnest(p);
                       p->in_def--;
                     }
-#line 7323 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7715 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 241:
-#line 2335 "mrbgems/mruby-compiler/core/parse.y"
+  case 241: /* arg: defn_head f_arglist_paren '=' arg modifier_rescue arg  */
+#line 2336 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[-5].nd);
                       void_expr_error(p, (yyvsp[-2].nd));
@@ -7332,11 +7724,11 @@ yyreduce:
                       nvars_unnest(p);
                       p->in_def--;
                     }
-#line 7336 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7728 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 242:
-#line 2344 "mrbgems/mruby-compiler/core/parse.y"
+  case 242: /* arg: defs_head f_arglist_paren '=' arg  */
+#line 2345 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[-3].nd);
                       void_expr_error(p, (yyvsp[0].nd));
@@ -7345,11 +7737,11 @@ yyreduce:
                       p->in_def--;
                       p->in_single--;
                     }
-#line 7349 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7741 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 243:
-#line 2353 "mrbgems/mruby-compiler/core/parse.y"
+  case 243: /* arg: defs_head f_arglist_paren '=' arg modifier_rescue arg  */
+#line 2354 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[-5].nd);
                       void_expr_error(p, (yyvsp[-2].nd));
@@ -7359,71 +7751,71 @@ yyreduce:
                       p->in_def--;
                       p->in_single--;
                     }
-#line 7363 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7755 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 244:
-#line 2363 "mrbgems/mruby-compiler/core/parse.y"
+  case 244: /* arg: primary  */
+#line 2364 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[0].nd);
                     }
-#line 7371 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7763 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 246:
-#line 2370 "mrbgems/mruby-compiler/core/parse.y"
+  case 246: /* aref_args: args trailer  */
+#line 2371 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[-1].nd);
                       NODE_LINENO((yyval.nd), (yyvsp[-1].nd));
                     }
-#line 7380 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7772 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 247:
-#line 2375 "mrbgems/mruby-compiler/core/parse.y"
+  case 247: /* aref_args: args comma assocs trailer  */
+#line 2376 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = push((yyvsp[-3].nd), new_kw_hash(p, (yyvsp[-1].nd)));
                     }
-#line 7388 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7780 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 248:
-#line 2379 "mrbgems/mruby-compiler/core/parse.y"
+  case 248: /* aref_args: assocs trailer  */
+#line 2380 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = cons(new_kw_hash(p, (yyvsp[-1].nd)), 0);
                       NODE_LINENO((yyval.nd), (yyvsp[-1].nd));
                     }
-#line 7397 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7789 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 249:
-#line 2386 "mrbgems/mruby-compiler/core/parse.y"
+  case 249: /* arg_rhs: arg  */
+#line 2387 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[0].nd);
                     }
-#line 7405 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7797 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 250:
-#line 2390 "mrbgems/mruby-compiler/core/parse.y"
+  case 250: /* arg_rhs: arg modifier_rescue arg  */
+#line 2391 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       void_expr_error(p, (yyvsp[-2].nd));
                       void_expr_error(p, (yyvsp[0].nd));
                       (yyval.nd) = new_mod_rescue(p, (yyvsp[-2].nd), (yyvsp[0].nd));
                     }
-#line 7415 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7807 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 251:
-#line 2398 "mrbgems/mruby-compiler/core/parse.y"
+  case 251: /* paren_args: '(' opt_call_args ')'  */
+#line 2399 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[-1].nd);
                     }
-#line 7423 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7815 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 252:
-#line 2402 "mrbgems/mruby-compiler/core/parse.y"
+  case 252: /* paren_args: '(' args comma tBDOT3 rparen  */
+#line 2403 "mrbgems/mruby-compiler/core/parse.y"
                     {
 #if 1
                       mrb_sym r = intern_op(mul);
@@ -7439,11 +7831,11 @@ yyreduce:
                                 new_block_arg(p, new_lvar(p, b)));
 #endif
                     }
-#line 7443 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7835 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 253:
-#line 2418 "mrbgems/mruby-compiler/core/parse.y"
+  case 253: /* paren_args: '(' tBDOT3 rparen  */
+#line 2419 "mrbgems/mruby-compiler/core/parse.y"
                     {
 #if 1
                       mrb_sym r = intern_op(mul);
@@ -7467,373 +7859,373 @@ yyreduce:
                         (yyval.nd) = 0;
                       }
                     }
-#line 7471 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7863 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 258:
-#line 2450 "mrbgems/mruby-compiler/core/parse.y"
+  case 258: /* opt_call_args: args comma  */
+#line 2451 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = cons((yyvsp[-1].nd),0);
                       NODE_LINENO((yyval.nd), (yyvsp[-1].nd));
                     }
-#line 7480 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7872 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 259:
-#line 2455 "mrbgems/mruby-compiler/core/parse.y"
+  case 259: /* opt_call_args: args comma assocs comma  */
+#line 2456 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = cons(push((yyvsp[-3].nd), new_kw_hash(p, (yyvsp[-1].nd))), 0);
                       NODE_LINENO((yyval.nd), (yyvsp[-3].nd));
                     }
-#line 7489 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7881 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 260:
-#line 2460 "mrbgems/mruby-compiler/core/parse.y"
+  case 260: /* opt_call_args: assocs comma  */
+#line 2461 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = cons(list1(new_kw_hash(p, (yyvsp[-1].nd))), 0);
                       NODE_LINENO((yyval.nd), (yyvsp[-1].nd));
                     }
-#line 7498 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7890 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 261:
-#line 2467 "mrbgems/mruby-compiler/core/parse.y"
+  case 261: /* call_args: command  */
+#line 2468 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       void_expr_error(p, (yyvsp[0].nd));
                       (yyval.nd) = cons(list1((yyvsp[0].nd)), 0);
                       NODE_LINENO((yyval.nd), (yyvsp[0].nd));
                     }
-#line 7508 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7900 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 262:
-#line 2473 "mrbgems/mruby-compiler/core/parse.y"
+  case 262: /* call_args: args opt_block_arg  */
+#line 2474 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = cons((yyvsp[-1].nd), (yyvsp[0].nd));
                       NODE_LINENO((yyval.nd), (yyvsp[-1].nd));
                     }
-#line 7517 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7909 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 263:
-#line 2478 "mrbgems/mruby-compiler/core/parse.y"
+  case 263: /* call_args: assocs opt_block_arg  */
+#line 2479 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = cons(list1(new_kw_hash(p, (yyvsp[-1].nd))), (yyvsp[0].nd));
                       NODE_LINENO((yyval.nd), (yyvsp[-1].nd));
                     }
-#line 7526 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7918 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 264:
-#line 2483 "mrbgems/mruby-compiler/core/parse.y"
+  case 264: /* call_args: args comma assocs opt_block_arg  */
+#line 2484 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = cons(push((yyvsp[-3].nd), new_kw_hash(p, (yyvsp[-1].nd))), (yyvsp[0].nd));
                       NODE_LINENO((yyval.nd), (yyvsp[-3].nd));
                     }
-#line 7535 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7927 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 265:
-#line 2488 "mrbgems/mruby-compiler/core/parse.y"
+  case 265: /* call_args: block_arg  */
+#line 2489 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = cons(0, (yyvsp[0].nd));
                       NODE_LINENO((yyval.nd), (yyvsp[0].nd));
                     }
-#line 7544 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7936 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 266:
-#line 2494 "mrbgems/mruby-compiler/core/parse.y"
+  case 266: /* @7: %empty  */
+#line 2495 "mrbgems/mruby-compiler/core/parse.y"
                    {
                       (yyval.stack) = p->cmdarg_stack;
                       CMDARG_PUSH(1);
                     }
-#line 7553 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7945 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 267:
-#line 2499 "mrbgems/mruby-compiler/core/parse.y"
+  case 267: /* command_args: @7 call_args  */
+#line 2500 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       p->cmdarg_stack = (yyvsp[-1].stack);
                       (yyval.nd) = (yyvsp[0].nd);
                     }
-#line 7562 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7954 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 268:
-#line 2506 "mrbgems/mruby-compiler/core/parse.y"
+  case 268: /* block_arg: tAMPER arg  */
+#line 2507 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_block_arg(p, (yyvsp[0].nd));
                     }
-#line 7570 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7962 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 269:
-#line 2512 "mrbgems/mruby-compiler/core/parse.y"
+  case 269: /* opt_block_arg: comma block_arg  */
+#line 2513 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[0].nd);
                     }
-#line 7578 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7970 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 270:
-#line 2516 "mrbgems/mruby-compiler/core/parse.y"
+  case 270: /* opt_block_arg: none  */
+#line 2517 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = 0;
                     }
-#line 7586 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7978 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 273:
-#line 2526 "mrbgems/mruby-compiler/core/parse.y"
+  case 273: /* args: arg  */
+#line 2527 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       void_expr_error(p, (yyvsp[0].nd));
                       (yyval.nd) = cons((yyvsp[0].nd), 0);
                       NODE_LINENO((yyval.nd), (yyvsp[0].nd));
                     }
-#line 7596 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7988 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 274:
-#line 2532 "mrbgems/mruby-compiler/core/parse.y"
+  case 274: /* args: tSTAR arg  */
+#line 2533 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       void_expr_error(p, (yyvsp[0].nd));
                       (yyval.nd) = cons(new_splat(p, (yyvsp[0].nd)), 0);
                       NODE_LINENO((yyval.nd), (yyvsp[0].nd));
                     }
-#line 7606 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 7998 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 275:
-#line 2538 "mrbgems/mruby-compiler/core/parse.y"
+  case 275: /* args: args comma arg  */
+#line 2539 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       void_expr_error(p, (yyvsp[0].nd));
                       (yyval.nd) = push((yyvsp[-2].nd), (yyvsp[0].nd));
                     }
-#line 7615 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8007 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 276:
-#line 2543 "mrbgems/mruby-compiler/core/parse.y"
+  case 276: /* args: args comma tSTAR arg  */
+#line 2544 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       void_expr_error(p, (yyvsp[0].nd));
                       (yyval.nd) = push((yyvsp[-3].nd), new_splat(p, (yyvsp[0].nd)));
                     }
-#line 7624 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8016 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 277:
-#line 2550 "mrbgems/mruby-compiler/core/parse.y"
+  case 277: /* mrhs: args comma arg  */
+#line 2551 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       void_expr_error(p, (yyvsp[0].nd));
                       (yyval.nd) = push((yyvsp[-2].nd), (yyvsp[0].nd));
                     }
-#line 7633 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8025 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 278:
-#line 2555 "mrbgems/mruby-compiler/core/parse.y"
+  case 278: /* mrhs: args comma tSTAR arg  */
+#line 2556 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       void_expr_error(p, (yyvsp[0].nd));
                       (yyval.nd) = push((yyvsp[-3].nd), new_splat(p, (yyvsp[0].nd)));
                     }
-#line 7642 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8034 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 279:
-#line 2560 "mrbgems/mruby-compiler/core/parse.y"
+  case 279: /* mrhs: tSTAR arg  */
+#line 2561 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       void_expr_error(p, (yyvsp[0].nd));
                       (yyval.nd) = list1(new_splat(p, (yyvsp[0].nd)));
                     }
-#line 7651 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8043 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 287:
-#line 2574 "mrbgems/mruby-compiler/core/parse.y"
+  case 287: /* primary: tNUMPARAM  */
+#line 2575 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_nvar(p, (yyvsp[0].num));
                     }
-#line 7659 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8051 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 288:
-#line 2578 "mrbgems/mruby-compiler/core/parse.y"
+  case 288: /* primary: tFID  */
+#line 2579 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_fcall(p, (yyvsp[0].id), 0);
                     }
-#line 7667 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8059 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 289:
-#line 2582 "mrbgems/mruby-compiler/core/parse.y"
+  case 289: /* @8: %empty  */
+#line 2583 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.stack) = p->cmdarg_stack;
                       p->cmdarg_stack = 0;
                     }
-#line 7676 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8068 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 290:
-#line 2588 "mrbgems/mruby-compiler/core/parse.y"
+  case 290: /* primary: keyword_begin @8 bodystmt keyword_end  */
+#line 2589 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       p->cmdarg_stack = (yyvsp[-2].stack);
                       (yyval.nd) = (yyvsp[-1].nd);
                     }
-#line 7685 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8077 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 291:
-#line 2593 "mrbgems/mruby-compiler/core/parse.y"
+  case 291: /* @9: %empty  */
+#line 2594 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.stack) = p->cmdarg_stack;
                       p->cmdarg_stack = 0;
                     }
-#line 7694 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8086 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 292:
-#line 2597 "mrbgems/mruby-compiler/core/parse.y"
-                       {p->lstate = EXPR_ENDARG;}
-#line 7700 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 293:
+  case 292: /* $@10: %empty  */
 #line 2598 "mrbgems/mruby-compiler/core/parse.y"
+                       {p->lstate = EXPR_ENDARG;}
+#line 8092 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 293: /* primary: tLPAREN_ARG @9 stmt $@10 rparen  */
+#line 2599 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       p->cmdarg_stack = (yyvsp[-3].stack);
                       (yyval.nd) = (yyvsp[-2].nd);
                     }
-#line 7709 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8101 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 294:
-#line 2602 "mrbgems/mruby-compiler/core/parse.y"
-                              {p->lstate = EXPR_ENDARG;}
-#line 7715 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 295:
+  case 294: /* $@11: %empty  */
 #line 2603 "mrbgems/mruby-compiler/core/parse.y"
+                              {p->lstate = EXPR_ENDARG;}
+#line 8107 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 295: /* primary: tLPAREN_ARG $@11 rparen  */
+#line 2604 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_nil(p);
                     }
-#line 7723 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8115 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 296:
-#line 2607 "mrbgems/mruby-compiler/core/parse.y"
+  case 296: /* primary: tLPAREN compstmt ')'  */
+#line 2608 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[-1].nd);
                     }
-#line 7731 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8123 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 297:
-#line 2611 "mrbgems/mruby-compiler/core/parse.y"
+  case 297: /* primary: primary_value tCOLON2 tCONSTANT  */
+#line 2612 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_colon2(p, (yyvsp[-2].nd), (yyvsp[0].id));
                     }
-#line 7739 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8131 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 298:
-#line 2615 "mrbgems/mruby-compiler/core/parse.y"
+  case 298: /* primary: tCOLON3 tCONSTANT  */
+#line 2616 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_colon3(p, (yyvsp[0].id));
                     }
-#line 7747 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8139 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 299:
-#line 2619 "mrbgems/mruby-compiler/core/parse.y"
+  case 299: /* primary: tLBRACK aref_args ']'  */
+#line 2620 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_array(p, (yyvsp[-1].nd));
                       NODE_LINENO((yyval.nd), (yyvsp[-1].nd));
                     }
-#line 7756 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8148 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 300:
-#line 2624 "mrbgems/mruby-compiler/core/parse.y"
+  case 300: /* primary: tLBRACE assoc_list '}'  */
+#line 2625 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_hash(p, (yyvsp[-1].nd));
                       NODE_LINENO((yyval.nd), (yyvsp[-1].nd));
                     }
-#line 7765 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8157 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 301:
-#line 2629 "mrbgems/mruby-compiler/core/parse.y"
+  case 301: /* primary: keyword_return  */
+#line 2630 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_return(p, 0);
                     }
-#line 7773 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8165 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 302:
-#line 2633 "mrbgems/mruby-compiler/core/parse.y"
+  case 302: /* primary: keyword_yield opt_paren_args  */
+#line 2634 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_yield(p, (yyvsp[0].nd));
                     }
-#line 7781 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8173 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 303:
-#line 2637 "mrbgems/mruby-compiler/core/parse.y"
+  case 303: /* primary: keyword_not '(' expr rparen  */
+#line 2638 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_uni_op(p, cond((yyvsp[-1].nd)), "!");
                     }
-#line 7789 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8181 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 304:
-#line 2641 "mrbgems/mruby-compiler/core/parse.y"
+  case 304: /* primary: keyword_not '(' rparen  */
+#line 2642 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = call_uni_op(p, new_nil(p), "!");
                     }
-#line 7797 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8189 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 305:
-#line 2645 "mrbgems/mruby-compiler/core/parse.y"
+  case 305: /* primary: operation brace_block  */
+#line 2646 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_fcall(p, (yyvsp[-1].id), cons(0, (yyvsp[0].nd)));
                     }
-#line 7805 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8197 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 307:
-#line 2650 "mrbgems/mruby-compiler/core/parse.y"
+  case 307: /* primary: method_call brace_block  */
+#line 2651 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       call_with_block(p, (yyvsp[-1].nd), (yyvsp[0].nd));
                       (yyval.nd) = (yyvsp[-1].nd);
                     }
-#line 7814 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8206 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 308:
-#line 2655 "mrbgems/mruby-compiler/core/parse.y"
+  case 308: /* @12: %empty  */
+#line 2656 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       local_nest(p);
                       (yyval.num) = p->lpar_beg;
                       p->lpar_beg = ++p->paren_nest;
                     }
-#line 7824 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8216 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 309:
-#line 2661 "mrbgems/mruby-compiler/core/parse.y"
+  case 309: /* @13: %empty  */
+#line 2662 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.stack) = p->cmdarg_stack;
                       p->cmdarg_stack = 0;
                     }
-#line 7833 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8225 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 310:
-#line 2666 "mrbgems/mruby-compiler/core/parse.y"
+  case 310: /* primary: tLAMBDA @12 f_larglist @13 lambda_body  */
+#line 2667 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       p->lpar_beg = (yyvsp[-3].num);
                       (yyval.nd) = new_lambda(p, (yyvsp[-2].nd), (yyvsp[0].nd));
@@ -7841,149 +8233,149 @@ yyreduce:
                       p->cmdarg_stack = (yyvsp[-1].stack);
                       CMDARG_LEXPOP();
                     }
-#line 7845 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8237 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 311:
-#line 2677 "mrbgems/mruby-compiler/core/parse.y"
+  case 311: /* primary: keyword_if expr_value then compstmt if_tail keyword_end  */
+#line 2678 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_if(p, cond((yyvsp[-4].nd)), (yyvsp[-2].nd), (yyvsp[-1].nd));
                       SET_LINENO((yyval.nd), (yyvsp[-5].num));
                     }
-#line 7854 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8246 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 312:
-#line 2685 "mrbgems/mruby-compiler/core/parse.y"
+  case 312: /* primary: keyword_unless expr_value then compstmt opt_else keyword_end  */
+#line 2686 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_unless(p, cond((yyvsp[-4].nd)), (yyvsp[-2].nd), (yyvsp[-1].nd));
                       SET_LINENO((yyval.nd), (yyvsp[-5].num));
                     }
-#line 7863 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8255 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 313:
-#line 2689 "mrbgems/mruby-compiler/core/parse.y"
+  case 313: /* $@14: %empty  */
+#line 2690 "mrbgems/mruby-compiler/core/parse.y"
                                 {COND_PUSH(1);}
-#line 7869 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8261 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 314:
-#line 2689 "mrbgems/mruby-compiler/core/parse.y"
+  case 314: /* $@15: %empty  */
+#line 2690 "mrbgems/mruby-compiler/core/parse.y"
                                                               {COND_POP();}
-#line 7875 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8267 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 315:
-#line 2692 "mrbgems/mruby-compiler/core/parse.y"
+  case 315: /* primary: keyword_while $@14 expr_value do $@15 compstmt keyword_end  */
+#line 2693 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_while(p, cond((yyvsp[-4].nd)), (yyvsp[-1].nd));
                       SET_LINENO((yyval.nd), (yyvsp[-6].num));
                     }
-#line 7884 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8276 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 316:
-#line 2696 "mrbgems/mruby-compiler/core/parse.y"
+  case 316: /* $@16: %empty  */
+#line 2697 "mrbgems/mruby-compiler/core/parse.y"
                                 {COND_PUSH(1);}
-#line 7890 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8282 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 317:
-#line 2696 "mrbgems/mruby-compiler/core/parse.y"
+  case 317: /* $@17: %empty  */
+#line 2697 "mrbgems/mruby-compiler/core/parse.y"
                                                               {COND_POP();}
-#line 7896 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8288 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 318:
-#line 2699 "mrbgems/mruby-compiler/core/parse.y"
+  case 318: /* primary: keyword_until $@16 expr_value do $@17 compstmt keyword_end  */
+#line 2700 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_until(p, cond((yyvsp[-4].nd)), (yyvsp[-1].nd));
                       SET_LINENO((yyval.nd), (yyvsp[-6].num));
                     }
-#line 7905 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8297 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 319:
-#line 2706 "mrbgems/mruby-compiler/core/parse.y"
+  case 319: /* primary: keyword_case expr_value opt_terms case_body keyword_end  */
+#line 2707 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_case(p, (yyvsp[-3].nd), (yyvsp[-1].nd));
                     }
-#line 7913 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8305 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 320:
-#line 2710 "mrbgems/mruby-compiler/core/parse.y"
+  case 320: /* primary: keyword_case opt_terms case_body keyword_end  */
+#line 2711 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_case(p, 0, (yyvsp[-1].nd));
                     }
-#line 7921 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8313 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 321:
-#line 2714 "mrbgems/mruby-compiler/core/parse.y"
+  case 321: /* $@18: %empty  */
+#line 2715 "mrbgems/mruby-compiler/core/parse.y"
                   {COND_PUSH(1);}
-#line 7927 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8319 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 322:
-#line 2716 "mrbgems/mruby-compiler/core/parse.y"
+  case 322: /* $@19: %empty  */
+#line 2717 "mrbgems/mruby-compiler/core/parse.y"
                   {COND_POP();}
-#line 7933 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8325 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 323:
-#line 2719 "mrbgems/mruby-compiler/core/parse.y"
+  case 323: /* primary: keyword_for for_var keyword_in $@18 expr_value do $@19 compstmt keyword_end  */
+#line 2720 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_for(p, (yyvsp[-7].nd), (yyvsp[-4].nd), (yyvsp[-1].nd));
                       SET_LINENO((yyval.nd), (yyvsp[-8].num));
                     }
-#line 7942 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8334 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 324:
-#line 2725 "mrbgems/mruby-compiler/core/parse.y"
+  case 324: /* @20: %empty  */
+#line 2726 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       if (p->in_def || p->in_single)
                         yyerror(p, "class definition in method body");
                       (yyval.nd) = local_switch(p);
                       nvars_block(p);
                     }
-#line 7953 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8345 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 325:
-#line 2733 "mrbgems/mruby-compiler/core/parse.y"
+  case 325: /* primary: keyword_class cpath superclass @20 bodystmt keyword_end  */
+#line 2734 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_class(p, (yyvsp[-4].nd), (yyvsp[-3].nd), (yyvsp[-1].nd));
                       SET_LINENO((yyval.nd), (yyvsp[-5].num));
                       local_resume(p, (yyvsp[-2].nd));
                       nvars_unnest(p);
                     }
-#line 7964 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8356 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 326:
-#line 2741 "mrbgems/mruby-compiler/core/parse.y"
+  case 326: /* @21: %empty  */
+#line 2742 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.num) = p->in_def;
                       p->in_def = 0;
                     }
-#line 7973 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8365 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 327:
-#line 2746 "mrbgems/mruby-compiler/core/parse.y"
+  case 327: /* @22: %empty  */
+#line 2747 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = cons(local_switch(p), nint(p->in_single));
                       nvars_block(p);
                       p->in_single = 0;
                     }
-#line 7983 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8375 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 328:
-#line 2753 "mrbgems/mruby-compiler/core/parse.y"
+  case 328: /* primary: keyword_class tLSHFT expr @21 term @22 bodystmt keyword_end  */
+#line 2754 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_sclass(p, (yyvsp[-5].nd), (yyvsp[-1].nd));
                       SET_LINENO((yyval.nd), (yyvsp[-7].num));
@@ -7992,44 +8384,44 @@ yyreduce:
                       p->in_def = (yyvsp[-4].num);
                       p->in_single = intn((yyvsp[-2].nd)->cdr);
                     }
-#line 7996 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8388 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 329:
-#line 2763 "mrbgems/mruby-compiler/core/parse.y"
+  case 329: /* @23: %empty  */
+#line 2764 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       if (p->in_def || p->in_single)
                         yyerror(p, "module definition in method body");
                       (yyval.nd) = local_switch(p);
                       nvars_block(p);
                     }
-#line 8007 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8399 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 330:
-#line 2771 "mrbgems/mruby-compiler/core/parse.y"
+  case 330: /* primary: keyword_module cpath @23 bodystmt keyword_end  */
+#line 2772 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_module(p, (yyvsp[-3].nd), (yyvsp[-1].nd));
                       SET_LINENO((yyval.nd), (yyvsp[-4].num));
                       local_resume(p, (yyvsp[-2].nd));
                       nvars_unnest(p);
                     }
-#line 8018 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8410 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 331:
-#line 2781 "mrbgems/mruby-compiler/core/parse.y"
+  case 331: /* primary: defn_head f_arglist bodystmt keyword_end  */
+#line 2782 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[-3].nd);
                       defn_setup(p, (yyval.nd), (yyvsp[-2].nd), (yyvsp[-1].nd));
                       nvars_unnest(p);
                       p->in_def--;
                     }
-#line 8029 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8421 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 332:
-#line 2791 "mrbgems/mruby-compiler/core/parse.y"
+  case 332: /* primary: defs_head f_arglist bodystmt keyword_end  */
+#line 2792 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[-3].nd);
                       defs_setup(p, (yyval.nd), (yyvsp[-2].nd), (yyvsp[-1].nd));
@@ -8037,451 +8429,451 @@ yyreduce:
                       p->in_def--;
                       p->in_single--;
                     }
-#line 8041 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8433 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 333:
-#line 2799 "mrbgems/mruby-compiler/core/parse.y"
+  case 333: /* primary: keyword_break  */
+#line 2800 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_break(p, 0);
                     }
-#line 8049 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8441 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 334:
-#line 2803 "mrbgems/mruby-compiler/core/parse.y"
+  case 334: /* primary: keyword_next  */
+#line 2804 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_next(p, 0);
                     }
-#line 8057 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8449 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 335:
-#line 2807 "mrbgems/mruby-compiler/core/parse.y"
+  case 335: /* primary: keyword_redo  */
+#line 2808 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_redo(p);
                     }
-#line 8065 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8457 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 336:
-#line 2811 "mrbgems/mruby-compiler/core/parse.y"
+  case 336: /* primary: keyword_retry  */
+#line 2812 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_retry(p);
                     }
-#line 8073 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8465 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 337:
-#line 2817 "mrbgems/mruby-compiler/core/parse.y"
+  case 337: /* primary_value: primary  */
+#line 2818 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[0].nd);
                       if (!(yyval.nd)) (yyval.nd) = new_nil(p);
                     }
-#line 8082 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8474 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 344:
-#line 2836 "mrbgems/mruby-compiler/core/parse.y"
+  case 344: /* if_tail: keyword_elsif expr_value then compstmt if_tail  */
+#line 2837 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_if(p, cond((yyvsp[-3].nd)), (yyvsp[-1].nd), (yyvsp[0].nd));
                     }
-#line 8090 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8482 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 346:
-#line 2843 "mrbgems/mruby-compiler/core/parse.y"
+  case 346: /* opt_else: keyword_else compstmt  */
+#line 2844 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[0].nd);
                     }
-#line 8098 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8490 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 347:
-#line 2849 "mrbgems/mruby-compiler/core/parse.y"
+  case 347: /* for_var: lhs  */
+#line 2850 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list1(list1((yyvsp[0].nd)));
                     }
-#line 8106 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8498 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 349:
-#line 2856 "mrbgems/mruby-compiler/core/parse.y"
+  case 349: /* f_margs: f_arg  */
+#line 2857 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list3((yyvsp[0].nd),0,0);
                     }
-#line 8114 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8506 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 350:
-#line 2860 "mrbgems/mruby-compiler/core/parse.y"
+  case 350: /* f_margs: f_arg ',' tSTAR f_norm_arg  */
+#line 2861 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list3((yyvsp[-3].nd), new_arg(p, (yyvsp[0].id)), 0);
                     }
-#line 8122 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8514 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 351:
-#line 2864 "mrbgems/mruby-compiler/core/parse.y"
+  case 351: /* f_margs: f_arg ',' tSTAR f_norm_arg ',' f_arg  */
+#line 2865 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list3((yyvsp[-5].nd), new_arg(p, (yyvsp[-2].id)), (yyvsp[0].nd));
                     }
-#line 8130 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8522 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 352:
-#line 2868 "mrbgems/mruby-compiler/core/parse.y"
+  case 352: /* f_margs: f_arg ',' tSTAR  */
+#line 2869 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       local_add_f(p, 0);
                       (yyval.nd) = list3((yyvsp[-2].nd), nint(-1), 0);
                     }
-#line 8139 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8531 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 353:
-#line 2873 "mrbgems/mruby-compiler/core/parse.y"
+  case 353: /* f_margs: f_arg ',' tSTAR ',' f_arg  */
+#line 2874 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list3((yyvsp[-4].nd), nint(-1), (yyvsp[0].nd));
                     }
-#line 8147 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8539 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 354:
-#line 2877 "mrbgems/mruby-compiler/core/parse.y"
+  case 354: /* f_margs: tSTAR f_norm_arg  */
+#line 2878 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list3(0, new_arg(p, (yyvsp[0].id)), 0);
                     }
-#line 8155 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8547 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 355:
-#line 2881 "mrbgems/mruby-compiler/core/parse.y"
+  case 355: /* f_margs: tSTAR f_norm_arg ',' f_arg  */
+#line 2882 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list3(0, new_arg(p, (yyvsp[-2].id)), (yyvsp[0].nd));
                     }
-#line 8163 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8555 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 356:
-#line 2885 "mrbgems/mruby-compiler/core/parse.y"
+  case 356: /* f_margs: tSTAR  */
+#line 2886 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       local_add_f(p, 0);
                       (yyval.nd) = list3(0, nint(-1), 0);
                     }
-#line 8172 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8564 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 357:
-#line 2890 "mrbgems/mruby-compiler/core/parse.y"
+  case 357: /* $@24: %empty  */
+#line 2891 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       local_add_f(p, 0);
                     }
-#line 8180 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8572 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 358:
-#line 2894 "mrbgems/mruby-compiler/core/parse.y"
+  case 358: /* f_margs: tSTAR ',' $@24 f_arg  */
+#line 2895 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list3(0, nint(-1), (yyvsp[0].nd));
                     }
-#line 8188 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8580 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 359:
-#line 2900 "mrbgems/mruby-compiler/core/parse.y"
+  case 359: /* block_args_tail: f_block_kwarg ',' f_kwrest opt_f_block_arg  */
+#line 2901 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args_tail(p, (yyvsp[-3].nd), (yyvsp[-1].nd), (yyvsp[0].id));
                     }
-#line 8196 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8588 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 360:
-#line 2904 "mrbgems/mruby-compiler/core/parse.y"
+  case 360: /* block_args_tail: f_block_kwarg opt_f_block_arg  */
+#line 2905 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args_tail(p, (yyvsp[-1].nd), 0, (yyvsp[0].id));
                     }
-#line 8204 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8596 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 361:
-#line 2908 "mrbgems/mruby-compiler/core/parse.y"
+  case 361: /* block_args_tail: f_kwrest opt_f_block_arg  */
+#line 2909 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args_tail(p, 0, (yyvsp[-1].nd), (yyvsp[0].id));
                     }
-#line 8212 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8604 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 362:
-#line 2912 "mrbgems/mruby-compiler/core/parse.y"
+  case 362: /* block_args_tail: f_block_arg  */
+#line 2913 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args_tail(p, 0, 0, (yyvsp[0].id));
                     }
-#line 8220 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8612 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 363:
-#line 2918 "mrbgems/mruby-compiler/core/parse.y"
+  case 363: /* opt_block_args_tail: ',' block_args_tail  */
+#line 2919 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[0].nd);
                     }
-#line 8228 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8620 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 364:
-#line 2922 "mrbgems/mruby-compiler/core/parse.y"
+  case 364: /* opt_block_args_tail: %empty  */
+#line 2923 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args_tail(p, 0, 0, 0);
                     }
-#line 8236 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8628 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 365:
-#line 2928 "mrbgems/mruby-compiler/core/parse.y"
+  case 365: /* block_param: f_arg ',' f_block_optarg ',' f_rest_arg opt_block_args_tail  */
+#line 2929 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, (yyvsp[-5].nd), (yyvsp[-3].nd), (yyvsp[-1].id), 0, (yyvsp[0].nd));
                     }
-#line 8244 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8636 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 366:
-#line 2932 "mrbgems/mruby-compiler/core/parse.y"
+  case 366: /* block_param: f_arg ',' f_block_optarg ',' f_rest_arg ',' f_arg opt_block_args_tail  */
+#line 2933 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, (yyvsp[-7].nd), (yyvsp[-5].nd), (yyvsp[-3].id), (yyvsp[-1].nd), (yyvsp[0].nd));
                     }
-#line 8252 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8644 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 367:
-#line 2936 "mrbgems/mruby-compiler/core/parse.y"
+  case 367: /* block_param: f_arg ',' f_block_optarg opt_block_args_tail  */
+#line 2937 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, (yyvsp[-3].nd), (yyvsp[-1].nd), 0, 0, (yyvsp[0].nd));
                     }
-#line 8260 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8652 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 368:
-#line 2940 "mrbgems/mruby-compiler/core/parse.y"
+  case 368: /* block_param: f_arg ',' f_block_optarg ',' f_arg opt_block_args_tail  */
+#line 2941 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, (yyvsp[-5].nd), (yyvsp[-3].nd), 0, (yyvsp[-1].nd), (yyvsp[0].nd));
                     }
-#line 8268 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8660 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 369:
-#line 2944 "mrbgems/mruby-compiler/core/parse.y"
+  case 369: /* block_param: f_arg ',' f_rest_arg opt_block_args_tail  */
+#line 2945 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, (yyvsp[-3].nd), 0, (yyvsp[-1].id), 0, (yyvsp[0].nd));
                     }
-#line 8276 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8668 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 370:
-#line 2948 "mrbgems/mruby-compiler/core/parse.y"
+  case 370: /* block_param: f_arg ',' opt_block_args_tail  */
+#line 2949 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, (yyvsp[-2].nd), 0, 0, 0, (yyvsp[0].nd));
                     }
-#line 8284 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8676 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 371:
-#line 2952 "mrbgems/mruby-compiler/core/parse.y"
+  case 371: /* block_param: f_arg ',' f_rest_arg ',' f_arg opt_block_args_tail  */
+#line 2953 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, (yyvsp[-5].nd), 0, (yyvsp[-3].id), (yyvsp[-1].nd), (yyvsp[0].nd));
                     }
-#line 8292 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8684 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 372:
-#line 2956 "mrbgems/mruby-compiler/core/parse.y"
+  case 372: /* block_param: f_arg opt_block_args_tail  */
+#line 2957 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, (yyvsp[-1].nd), 0, 0, 0, (yyvsp[0].nd));
                     }
-#line 8300 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8692 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 373:
-#line 2960 "mrbgems/mruby-compiler/core/parse.y"
+  case 373: /* block_param: f_block_optarg ',' f_rest_arg opt_block_args_tail  */
+#line 2961 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, 0, (yyvsp[-3].nd), (yyvsp[-1].id), 0, (yyvsp[0].nd));
                     }
-#line 8308 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8700 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 374:
-#line 2964 "mrbgems/mruby-compiler/core/parse.y"
+  case 374: /* block_param: f_block_optarg ',' f_rest_arg ',' f_arg opt_block_args_tail  */
+#line 2965 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, 0, (yyvsp[-5].nd), (yyvsp[-3].id), (yyvsp[-1].nd), (yyvsp[0].nd));
                     }
-#line 8316 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8708 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 375:
-#line 2968 "mrbgems/mruby-compiler/core/parse.y"
+  case 375: /* block_param: f_block_optarg opt_block_args_tail  */
+#line 2969 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, 0, (yyvsp[-1].nd), 0, 0, (yyvsp[0].nd));
                     }
-#line 8324 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8716 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 376:
-#line 2972 "mrbgems/mruby-compiler/core/parse.y"
+  case 376: /* block_param: f_block_optarg ',' f_arg opt_block_args_tail  */
+#line 2973 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, 0, (yyvsp[-3].nd), 0, (yyvsp[-1].nd), (yyvsp[0].nd));
                     }
-#line 8332 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8724 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 377:
-#line 2976 "mrbgems/mruby-compiler/core/parse.y"
+  case 377: /* block_param: f_rest_arg opt_block_args_tail  */
+#line 2977 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, 0, 0, (yyvsp[-1].id), 0, (yyvsp[0].nd));
                     }
-#line 8340 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8732 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 378:
-#line 2980 "mrbgems/mruby-compiler/core/parse.y"
+  case 378: /* block_param: f_rest_arg ',' f_arg opt_block_args_tail  */
+#line 2981 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, 0, 0, (yyvsp[-3].id), (yyvsp[-1].nd), (yyvsp[0].nd));
                     }
-#line 8348 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8740 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 379:
-#line 2984 "mrbgems/mruby-compiler/core/parse.y"
+  case 379: /* block_param: block_args_tail  */
+#line 2985 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, 0, 0, 0, 0, (yyvsp[0].nd));
                     }
-#line 8356 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8748 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 380:
-#line 2990 "mrbgems/mruby-compiler/core/parse.y"
+  case 380: /* opt_block_param: none  */
+#line 2991 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       local_add_blk(p, 0);
                       (yyval.nd) = 0;
                     }
-#line 8365 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8757 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 381:
-#line 2995 "mrbgems/mruby-compiler/core/parse.y"
+  case 381: /* opt_block_param: block_param_def  */
+#line 2996 "mrbgems/mruby-compiler/core/parse.y"
                    {
                       p->cmd_start = TRUE;
                       (yyval.nd) = (yyvsp[0].nd);
                     }
-#line 8374 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8766 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 382:
-#line 3001 "mrbgems/mruby-compiler/core/parse.y"
-                      {local_add_blk(p, 0);}
-#line 8380 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 383:
+  case 382: /* $@25: %empty  */
 #line 3002 "mrbgems/mruby-compiler/core/parse.y"
+                      {local_add_blk(p, 0);}
+#line 8772 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 383: /* block_param_def: '|' $@25 opt_bv_decl '|'  */
+#line 3003 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = 0;
                     }
-#line 8388 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8780 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 384:
-#line 3006 "mrbgems/mruby-compiler/core/parse.y"
+  case 384: /* block_param_def: tOROP  */
+#line 3007 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       local_add_blk(p, 0);
                       (yyval.nd) = 0;
                     }
-#line 8397 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8789 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 385:
-#line 3011 "mrbgems/mruby-compiler/core/parse.y"
+  case 385: /* block_param_def: '|' block_param opt_bv_decl '|'  */
+#line 3012 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[-2].nd);
                     }
-#line 8405 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8797 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 386:
-#line 3018 "mrbgems/mruby-compiler/core/parse.y"
+  case 386: /* opt_bv_decl: opt_nl  */
+#line 3019 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = 0;
                     }
-#line 8413 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8805 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 387:
-#line 3022 "mrbgems/mruby-compiler/core/parse.y"
+  case 387: /* opt_bv_decl: opt_nl ';' bv_decls opt_nl  */
+#line 3023 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = 0;
                     }
-#line 8421 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8813 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 390:
-#line 3032 "mrbgems/mruby-compiler/core/parse.y"
+  case 390: /* bvar: tIDENTIFIER  */
+#line 3033 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       local_add_f(p, (yyvsp[0].id));
                       new_bv(p, (yyvsp[0].id));
                     }
-#line 8430 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8822 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 392:
-#line 3040 "mrbgems/mruby-compiler/core/parse.y"
+  case 392: /* f_larglist: '(' f_args opt_bv_decl ')'  */
+#line 3041 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[-2].nd);
                     }
-#line 8438 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8830 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 393:
-#line 3044 "mrbgems/mruby-compiler/core/parse.y"
+  case 393: /* f_larglist: f_args  */
+#line 3045 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[0].nd);
                     }
-#line 8446 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8838 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 394:
-#line 3050 "mrbgems/mruby-compiler/core/parse.y"
+  case 394: /* lambda_body: tLAMBEG compstmt '}'  */
+#line 3051 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[-1].nd);
                     }
-#line 8454 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8846 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 395:
-#line 3054 "mrbgems/mruby-compiler/core/parse.y"
+  case 395: /* lambda_body: keyword_do_LAMBDA bodystmt keyword_end  */
+#line 3055 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[-1].nd);
                     }
-#line 8462 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8854 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 396:
-#line 3060 "mrbgems/mruby-compiler/core/parse.y"
+  case 396: /* $@26: %empty  */
+#line 3061 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       local_nest(p);
                       nvars_nest(p);
                     }
-#line 8471 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8863 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 397:
-#line 3067 "mrbgems/mruby-compiler/core/parse.y"
+  case 397: /* do_block: keyword_do_block $@26 opt_block_param bodystmt keyword_end  */
+#line 3068 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_block(p,(yyvsp[-2].nd),(yyvsp[-1].nd));
                       local_unnest(p);
                       nvars_unnest(p);
                     }
-#line 8481 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8873 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 398:
-#line 3075 "mrbgems/mruby-compiler/core/parse.y"
+  case 398: /* block_call: command do_block  */
+#line 3076 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       if (typen((yyvsp[-1].nd)->car) == NODE_YIELD) {
                         yyerror(p, "block given to yield");
@@ -8491,159 +8883,159 @@ yyreduce:
                       }
                       (yyval.nd) = (yyvsp[-1].nd);
                     }
-#line 8495 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8887 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 399:
-#line 3085 "mrbgems/mruby-compiler/core/parse.y"
+  case 399: /* block_call: block_call call_op2 operation2 opt_paren_args  */
+#line 3086 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_call(p, (yyvsp[-3].nd), (yyvsp[-1].id), (yyvsp[0].nd), (yyvsp[-2].num));
                     }
-#line 8503 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8895 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 400:
-#line 3089 "mrbgems/mruby-compiler/core/parse.y"
+  case 400: /* block_call: block_call call_op2 operation2 opt_paren_args brace_block  */
+#line 3090 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_call(p, (yyvsp[-4].nd), (yyvsp[-2].id), (yyvsp[-1].nd), (yyvsp[-3].num));
                       call_with_block(p, (yyval.nd), (yyvsp[0].nd));
                     }
-#line 8512 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8904 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 401:
-#line 3094 "mrbgems/mruby-compiler/core/parse.y"
+  case 401: /* block_call: block_call call_op2 operation2 command_args do_block  */
+#line 3095 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_call(p, (yyvsp[-4].nd), (yyvsp[-2].id), (yyvsp[-1].nd), (yyvsp[-3].num));
                       call_with_block(p, (yyval.nd), (yyvsp[0].nd));
                     }
-#line 8521 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8913 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 402:
-#line 3101 "mrbgems/mruby-compiler/core/parse.y"
+  case 402: /* method_call: operation paren_args  */
+#line 3102 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_fcall(p, (yyvsp[-1].id), (yyvsp[0].nd));
                     }
-#line 8529 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8921 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 403:
-#line 3105 "mrbgems/mruby-compiler/core/parse.y"
+  case 403: /* method_call: primary_value call_op operation2 opt_paren_args  */
+#line 3106 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_call(p, (yyvsp[-3].nd), (yyvsp[-1].id), (yyvsp[0].nd), (yyvsp[-2].num));
                     }
-#line 8537 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8929 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 404:
-#line 3109 "mrbgems/mruby-compiler/core/parse.y"
+  case 404: /* method_call: primary_value tCOLON2 operation2 paren_args  */
+#line 3110 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_call(p, (yyvsp[-3].nd), (yyvsp[-1].id), (yyvsp[0].nd), tCOLON2);
                     }
-#line 8545 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8937 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 405:
-#line 3113 "mrbgems/mruby-compiler/core/parse.y"
+  case 405: /* method_call: primary_value tCOLON2 operation3  */
+#line 3114 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_call(p, (yyvsp[-2].nd), (yyvsp[0].id), 0, tCOLON2);
                     }
-#line 8553 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8945 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 406:
-#line 3117 "mrbgems/mruby-compiler/core/parse.y"
+  case 406: /* method_call: primary_value call_op paren_args  */
+#line 3118 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_call(p, (yyvsp[-2].nd), MRB_SYM_2(p->mrb, call), (yyvsp[0].nd), (yyvsp[-1].num));
                     }
-#line 8561 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8953 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 407:
-#line 3121 "mrbgems/mruby-compiler/core/parse.y"
+  case 407: /* method_call: primary_value tCOLON2 paren_args  */
+#line 3122 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_call(p, (yyvsp[-2].nd), MRB_SYM_2(p->mrb, call), (yyvsp[0].nd), tCOLON2);
                     }
-#line 8569 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8961 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 408:
-#line 3125 "mrbgems/mruby-compiler/core/parse.y"
+  case 408: /* method_call: keyword_super paren_args  */
+#line 3126 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_super(p, (yyvsp[0].nd));
                     }
-#line 8577 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8969 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 409:
-#line 3129 "mrbgems/mruby-compiler/core/parse.y"
+  case 409: /* method_call: keyword_super  */
+#line 3130 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_zsuper(p);
                     }
-#line 8585 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8977 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 410:
-#line 3133 "mrbgems/mruby-compiler/core/parse.y"
+  case 410: /* method_call: primary_value '[' opt_call_args ']'  */
+#line 3134 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_call(p, (yyvsp[-3].nd), intern_op(aref), (yyvsp[-1].nd), '.');
                     }
-#line 8593 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8985 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 411:
-#line 3139 "mrbgems/mruby-compiler/core/parse.y"
+  case 411: /* @27: %empty  */
+#line 3140 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       local_nest(p);
                       nvars_nest(p);
                       (yyval.num) = p->lineno;
                     }
-#line 8603 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 8995 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 412:
-#line 3146 "mrbgems/mruby-compiler/core/parse.y"
+  case 412: /* brace_block: '{' @27 opt_block_param compstmt '}'  */
+#line 3147 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_block(p,(yyvsp[-2].nd),(yyvsp[-1].nd));
                       SET_LINENO((yyval.nd), (yyvsp[-3].num));
                       local_unnest(p);
                       nvars_unnest(p);
                     }
-#line 8614 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9006 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 413:
-#line 3153 "mrbgems/mruby-compiler/core/parse.y"
+  case 413: /* @28: %empty  */
+#line 3154 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       local_nest(p);
                       nvars_nest(p);
                       (yyval.num) = p->lineno;
                     }
-#line 8624 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9016 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 414:
-#line 3160 "mrbgems/mruby-compiler/core/parse.y"
+  case 414: /* brace_block: keyword_do @28 opt_block_param bodystmt keyword_end  */
+#line 3161 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_block(p,(yyvsp[-2].nd),(yyvsp[-1].nd));
                       SET_LINENO((yyval.nd), (yyvsp[-3].num));
                       local_unnest(p);
                       nvars_unnest(p);
                     }
-#line 8635 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9027 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 415:
-#line 3171 "mrbgems/mruby-compiler/core/parse.y"
+  case 415: /* case_body: keyword_when args then compstmt cases  */
+#line 3172 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = cons(cons((yyvsp[-3].nd), (yyvsp[-1].nd)), (yyvsp[0].nd));
                     }
-#line 8643 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9035 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 416:
-#line 3177 "mrbgems/mruby-compiler/core/parse.y"
+  case 416: /* cases: opt_else  */
+#line 3178 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       if ((yyvsp[0].nd)) {
                         (yyval.nd) = cons(cons(0, (yyvsp[0].nd)), 0);
@@ -8652,383 +9044,383 @@ yyreduce:
                         (yyval.nd) = 0;
                       }
                     }
-#line 8656 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9048 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 418:
-#line 3191 "mrbgems/mruby-compiler/core/parse.y"
+  case 418: /* opt_rescue: keyword_rescue exc_list exc_var then compstmt opt_rescue  */
+#line 3192 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list1(list3((yyvsp[-4].nd), (yyvsp[-3].nd), (yyvsp[-1].nd)));
                       if ((yyvsp[0].nd)) (yyval.nd) = append((yyval.nd), (yyvsp[0].nd));
                     }
-#line 8665 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9057 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 420:
-#line 3199 "mrbgems/mruby-compiler/core/parse.y"
+  case 420: /* exc_list: arg  */
+#line 3200 "mrbgems/mruby-compiler/core/parse.y"
                     {
                         (yyval.nd) = list1((yyvsp[0].nd));
                     }
-#line 8673 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9065 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 423:
-#line 3207 "mrbgems/mruby-compiler/core/parse.y"
+  case 423: /* exc_var: tASSOC lhs  */
+#line 3208 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[0].nd);
                     }
-#line 8681 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9073 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 425:
-#line 3214 "mrbgems/mruby-compiler/core/parse.y"
+  case 425: /* opt_ensure: keyword_ensure compstmt  */
+#line 3215 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[0].nd);
                     }
-#line 8689 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9081 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 432:
-#line 3228 "mrbgems/mruby-compiler/core/parse.y"
+  case 432: /* string: string string_fragment  */
+#line 3229 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = concat_string(p, (yyvsp[-1].nd), (yyvsp[0].nd));
                     }
-#line 8697 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9089 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 435:
-#line 3236 "mrbgems/mruby-compiler/core/parse.y"
+  case 435: /* string_fragment: tSTRING_BEG tSTRING  */
+#line 3237 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[0].nd);
                     }
-#line 8705 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9097 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 436:
-#line 3240 "mrbgems/mruby-compiler/core/parse.y"
+  case 436: /* string_fragment: tSTRING_BEG string_rep tSTRING  */
+#line 3241 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_dstr(p, push((yyvsp[-1].nd), (yyvsp[0].nd)));
                     }
-#line 8713 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9105 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 438:
-#line 3247 "mrbgems/mruby-compiler/core/parse.y"
+  case 438: /* string_rep: string_rep string_interp  */
+#line 3248 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = append((yyvsp[-1].nd), (yyvsp[0].nd));
                     }
-#line 8721 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9113 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 439:
-#line 3253 "mrbgems/mruby-compiler/core/parse.y"
+  case 439: /* string_interp: tSTRING_MID  */
+#line 3254 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list1((yyvsp[0].nd));
                     }
-#line 8729 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9121 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 440:
-#line 3257 "mrbgems/mruby-compiler/core/parse.y"
+  case 440: /* @29: %empty  */
+#line 3258 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = p->lex_strterm;
                       p->lex_strterm = NULL;
                     }
-#line 8738 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9130 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 441:
-#line 3263 "mrbgems/mruby-compiler/core/parse.y"
+  case 441: /* string_interp: tSTRING_PART @29 compstmt '}'  */
+#line 3264 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       p->lex_strterm = (yyvsp[-2].nd);
                       (yyval.nd) = list2((yyvsp[-3].nd), (yyvsp[-1].nd));
                     }
-#line 8747 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9139 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 442:
-#line 3268 "mrbgems/mruby-compiler/core/parse.y"
+  case 442: /* string_interp: tLITERAL_DELIM  */
+#line 3269 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list1(new_literal_delim(p));
                     }
-#line 8755 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9147 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 443:
-#line 3272 "mrbgems/mruby-compiler/core/parse.y"
+  case 443: /* string_interp: tHD_LITERAL_DELIM heredoc_bodies  */
+#line 3273 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list1(new_literal_delim(p));
                     }
-#line 8763 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9155 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 444:
-#line 3278 "mrbgems/mruby-compiler/core/parse.y"
+  case 444: /* xstring: tXSTRING_BEG tXSTRING  */
+#line 3279 "mrbgems/mruby-compiler/core/parse.y"
                     {
                         (yyval.nd) = (yyvsp[0].nd);
                     }
-#line 8771 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9163 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 445:
-#line 3282 "mrbgems/mruby-compiler/core/parse.y"
+  case 445: /* xstring: tXSTRING_BEG string_rep tXSTRING  */
+#line 3283 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_dxstr(p, push((yyvsp[-1].nd), (yyvsp[0].nd)));
                     }
-#line 8779 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9171 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 446:
-#line 3288 "mrbgems/mruby-compiler/core/parse.y"
+  case 446: /* regexp: tREGEXP_BEG tREGEXP  */
+#line 3289 "mrbgems/mruby-compiler/core/parse.y"
                     {
                         (yyval.nd) = (yyvsp[0].nd);
                     }
-#line 8787 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9179 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 447:
-#line 3292 "mrbgems/mruby-compiler/core/parse.y"
+  case 447: /* regexp: tREGEXP_BEG string_rep tREGEXP  */
+#line 3293 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_dregx(p, (yyvsp[-1].nd), (yyvsp[0].nd));
                     }
-#line 8795 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9187 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 451:
-#line 3305 "mrbgems/mruby-compiler/core/parse.y"
+  case 451: /* heredoc_body: tHEREDOC_END  */
+#line 3306 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       parser_heredoc_info * inf = parsing_heredoc_inf(p);
                       inf->doc = push(inf->doc, new_str(p, "", 0));
                       heredoc_end(p);
                     }
-#line 8805 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9197 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 452:
-#line 3311 "mrbgems/mruby-compiler/core/parse.y"
+  case 452: /* heredoc_body: heredoc_string_rep tHEREDOC_END  */
+#line 3312 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       heredoc_end(p);
                     }
-#line 8813 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9205 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 455:
-#line 3321 "mrbgems/mruby-compiler/core/parse.y"
+  case 455: /* heredoc_string_interp: tHD_STRING_MID  */
+#line 3322 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       parser_heredoc_info * inf = parsing_heredoc_inf(p);
                       inf->doc = push(inf->doc, (yyvsp[0].nd));
                       heredoc_treat_nextline(p);
                     }
-#line 8823 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9215 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 456:
-#line 3327 "mrbgems/mruby-compiler/core/parse.y"
+  case 456: /* @30: %empty  */
+#line 3328 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = p->lex_strterm;
                       p->lex_strterm = NULL;
                     }
-#line 8832 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9224 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 457:
-#line 3333 "mrbgems/mruby-compiler/core/parse.y"
+  case 457: /* heredoc_string_interp: tHD_STRING_PART @30 compstmt '}'  */
+#line 3334 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       parser_heredoc_info * inf = parsing_heredoc_inf(p);
                       p->lex_strterm = (yyvsp[-2].nd);
                       inf->doc = push(push(inf->doc, (yyvsp[-3].nd)), (yyvsp[-1].nd));
                     }
-#line 8842 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9234 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 458:
-#line 3341 "mrbgems/mruby-compiler/core/parse.y"
+  case 458: /* words: tWORDS_BEG tSTRING  */
+#line 3342 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_words(p, list1((yyvsp[0].nd)));
                     }
-#line 8850 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9242 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 459:
-#line 3345 "mrbgems/mruby-compiler/core/parse.y"
+  case 459: /* words: tWORDS_BEG string_rep tSTRING  */
+#line 3346 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_words(p, push((yyvsp[-1].nd), (yyvsp[0].nd)));
                     }
-#line 8858 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9250 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 460:
-#line 3352 "mrbgems/mruby-compiler/core/parse.y"
+  case 460: /* symbol: basic_symbol  */
+#line 3353 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       p->lstate = EXPR_ENDARG;
                       (yyval.nd) = new_sym(p, (yyvsp[0].id));
                     }
-#line 8867 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9259 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 461:
-#line 3357 "mrbgems/mruby-compiler/core/parse.y"
+  case 461: /* symbol: tSYMBEG tSTRING_BEG string_rep tSTRING  */
+#line 3358 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       p->lstate = EXPR_ENDARG;
                       (yyval.nd) = new_dsym(p, new_dstr(p, push((yyvsp[-1].nd), (yyvsp[0].nd))));
                     }
-#line 8876 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9268 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 462:
-#line 3364 "mrbgems/mruby-compiler/core/parse.y"
+  case 462: /* basic_symbol: tSYMBEG sym  */
+#line 3365 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.id) = (yyvsp[0].id);
                     }
-#line 8884 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9276 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 467:
-#line 3374 "mrbgems/mruby-compiler/core/parse.y"
+  case 467: /* sym: tSTRING  */
+#line 3375 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.id) = new_strsym(p, (yyvsp[0].nd));
                     }
-#line 8892 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9284 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 468:
-#line 3378 "mrbgems/mruby-compiler/core/parse.y"
+  case 468: /* sym: tSTRING_BEG tSTRING  */
+#line 3379 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.id) = new_strsym(p, (yyvsp[0].nd));
                     }
-#line 8900 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9292 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 469:
-#line 3384 "mrbgems/mruby-compiler/core/parse.y"
+  case 469: /* symbols: tSYMBOLS_BEG tSTRING  */
+#line 3385 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_symbols(p, list1((yyvsp[0].nd)));
                     }
-#line 8908 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9300 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 470:
-#line 3388 "mrbgems/mruby-compiler/core/parse.y"
+  case 470: /* symbols: tSYMBOLS_BEG string_rep tSTRING  */
+#line 3389 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_symbols(p, push((yyvsp[-1].nd), (yyvsp[0].nd)));
                     }
-#line 8916 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9308 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 473:
-#line 3396 "mrbgems/mruby-compiler/core/parse.y"
+  case 473: /* numeric: tUMINUS_NUM tINTEGER  */
+#line 3397 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = negate_lit(p, (yyvsp[0].nd));
                     }
-#line 8924 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9316 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 474:
-#line 3400 "mrbgems/mruby-compiler/core/parse.y"
+  case 474: /* numeric: tUMINUS_NUM tFLOAT  */
+#line 3401 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = negate_lit(p, (yyvsp[0].nd));
                     }
-#line 8932 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9324 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 475:
-#line 3406 "mrbgems/mruby-compiler/core/parse.y"
+  case 475: /* variable: tIDENTIFIER  */
+#line 3407 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_lvar(p, (yyvsp[0].id));
                     }
-#line 8940 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9332 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 476:
-#line 3410 "mrbgems/mruby-compiler/core/parse.y"
+  case 476: /* variable: tIVAR  */
+#line 3411 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_ivar(p, (yyvsp[0].id));
                     }
-#line 8948 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9340 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 477:
-#line 3414 "mrbgems/mruby-compiler/core/parse.y"
+  case 477: /* variable: tGVAR  */
+#line 3415 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_gvar(p, (yyvsp[0].id));
                     }
-#line 8956 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9348 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 478:
-#line 3418 "mrbgems/mruby-compiler/core/parse.y"
+  case 478: /* variable: tCVAR  */
+#line 3419 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_cvar(p, (yyvsp[0].id));
                     }
-#line 8964 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9356 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 479:
-#line 3422 "mrbgems/mruby-compiler/core/parse.y"
+  case 479: /* variable: tCONSTANT  */
+#line 3423 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_const(p, (yyvsp[0].id));
                     }
-#line 8972 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9364 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 480:
-#line 3428 "mrbgems/mruby-compiler/core/parse.y"
+  case 480: /* var_lhs: variable  */
+#line 3429 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       assignable(p, (yyvsp[0].nd));
                     }
-#line 8980 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9372 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 481:
-#line 3432 "mrbgems/mruby-compiler/core/parse.y"
+  case 481: /* var_lhs: tNUMPARAM  */
+#line 3433 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       yyerror(p, "can't assign to numbered parameter");
                     }
-#line 8988 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9380 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 482:
-#line 3438 "mrbgems/mruby-compiler/core/parse.y"
+  case 482: /* var_ref: variable  */
+#line 3439 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = var_reference(p, (yyvsp[0].nd));
                     }
-#line 8996 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9388 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 483:
-#line 3442 "mrbgems/mruby-compiler/core/parse.y"
+  case 483: /* var_ref: keyword_nil  */
+#line 3443 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_nil(p);
                     }
-#line 9004 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9396 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 484:
-#line 3446 "mrbgems/mruby-compiler/core/parse.y"
+  case 484: /* var_ref: keyword_self  */
+#line 3447 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_self(p);
                     }
-#line 9012 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9404 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 485:
-#line 3450 "mrbgems/mruby-compiler/core/parse.y"
+  case 485: /* var_ref: keyword_true  */
+#line 3451 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_true(p);
                     }
-#line 9020 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9412 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 486:
-#line 3454 "mrbgems/mruby-compiler/core/parse.y"
+  case 486: /* var_ref: keyword_false  */
+#line 3455 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_false(p);
                     }
-#line 9028 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9420 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 487:
-#line 3458 "mrbgems/mruby-compiler/core/parse.y"
+  case 487: /* var_ref: keyword__FILE__  */
+#line 3459 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       const char *fn = mrb_sym_name_len(p->mrb, p->filename_sym, NULL);
                       if (!fn) {
@@ -9036,22 +9428,22 @@ yyreduce:
                       }
                       (yyval.nd) = new_str(p, fn, strlen(fn));
                     }
-#line 9040 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9432 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 488:
-#line 3466 "mrbgems/mruby-compiler/core/parse.y"
+  case 488: /* var_ref: keyword__LINE__  */
+#line 3467 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       char buf[16];
 
                       dump_int(p->lineno, buf);
                       (yyval.nd) = new_int(p, buf, 10, 0);
                     }
-#line 9051 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9443 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 489:
-#line 3473 "mrbgems/mruby-compiler/core/parse.y"
+  case 489: /* var_ref: keyword__ENCODING__  */
+#line 3474 "mrbgems/mruby-compiler/core/parse.y"
                     {
 #ifdef MRB_UTF8_STRING
                       const char *enc = "UTF-8";
@@ -9060,46 +9452,46 @@ yyreduce:
 #endif
                       (yyval.nd) = new_str(p, enc, strlen(enc));
                     }
-#line 9064 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9456 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 492:
-#line 3488 "mrbgems/mruby-compiler/core/parse.y"
+  case 492: /* superclass: %empty  */
+#line 3489 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = 0;
                     }
-#line 9072 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9464 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 493:
-#line 3492 "mrbgems/mruby-compiler/core/parse.y"
+  case 493: /* $@31: %empty  */
+#line 3493 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       p->lstate = EXPR_BEG;
                       p->cmd_start = TRUE;
                     }
-#line 9081 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9473 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 494:
-#line 3497 "mrbgems/mruby-compiler/core/parse.y"
+  case 494: /* superclass: '<' $@31 expr_value term  */
+#line 3498 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[-1].nd);
                     }
-#line 9089 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9481 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 495:
-#line 3508 "mrbgems/mruby-compiler/core/parse.y"
+  case 495: /* f_arglist_paren: '(' f_args rparen  */
+#line 3509 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[-1].nd);
                       p->lstate = EXPR_BEG;
                       p->cmd_start = TRUE;
                     }
-#line 9099 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9491 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 496:
-#line 3514 "mrbgems/mruby-compiler/core/parse.y"
+  case 496: /* f_arglist_paren: '(' f_arg ',' tBDOT3 rparen  */
+#line 3515 "mrbgems/mruby-compiler/core/parse.y"
                     {
 #if 1
                       /* til real keyword args implemented */
@@ -9117,11 +9509,11 @@ yyreduce:
                                     new_args_tail(p, 0, new_kw_rest_args(p, nsym(k)), b));
 #endif
                     }
-#line 9121 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9513 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 497:
-#line 3532 "mrbgems/mruby-compiler/core/parse.y"
+  case 497: /* f_arglist_paren: '(' tBDOT3 rparen  */
+#line 3533 "mrbgems/mruby-compiler/core/parse.y"
                     {
 #if 1
                       /* til real keyword args implemented */
@@ -9139,504 +9531,504 @@ yyreduce:
                                     new_args_tail(p, 0, new_kw_rest_args(p, nsym(k)), b));
 #endif
                     }
-#line 9143 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9535 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 499:
-#line 3553 "mrbgems/mruby-compiler/core/parse.y"
+  case 499: /* f_arglist: f_args term  */
+#line 3554 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[-1].nd);
                     }
-#line 9151 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9543 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 500:
-#line 3559 "mrbgems/mruby-compiler/core/parse.y"
+  case 500: /* f_label: tIDENTIFIER tLABEL_TAG  */
+#line 3560 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       local_nest(p);
                     }
-#line 9159 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9551 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 501:
-#line 3565 "mrbgems/mruby-compiler/core/parse.y"
+  case 501: /* f_kw: f_label arg  */
+#line 3566 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       void_expr_error(p, (yyvsp[0].nd));
                       (yyval.nd) = new_kw_arg(p, (yyvsp[-1].id), cons((yyvsp[0].nd), locals_node(p)));
                       local_unnest(p);
                     }
-#line 9169 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9561 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 502:
-#line 3571 "mrbgems/mruby-compiler/core/parse.y"
+  case 502: /* f_kw: f_label  */
+#line 3572 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_kw_arg(p, (yyvsp[0].id), 0);
                       local_unnest(p);
                     }
-#line 9178 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9570 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 503:
-#line 3578 "mrbgems/mruby-compiler/core/parse.y"
+  case 503: /* f_block_kw: f_label primary_value  */
+#line 3579 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_kw_arg(p, (yyvsp[-1].id), cons((yyvsp[0].nd), locals_node(p)));
                       local_unnest(p);
                     }
-#line 9187 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9579 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 504:
-#line 3583 "mrbgems/mruby-compiler/core/parse.y"
+  case 504: /* f_block_kw: f_label  */
+#line 3584 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_kw_arg(p, (yyvsp[0].id), 0);
                       local_unnest(p);
                     }
-#line 9196 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9588 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 505:
-#line 3590 "mrbgems/mruby-compiler/core/parse.y"
+  case 505: /* f_block_kwarg: f_block_kw  */
+#line 3591 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list1((yyvsp[0].nd));
                     }
-#line 9204 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9596 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 506:
-#line 3594 "mrbgems/mruby-compiler/core/parse.y"
+  case 506: /* f_block_kwarg: f_block_kwarg ',' f_block_kw  */
+#line 3595 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = push((yyvsp[-2].nd), (yyvsp[0].nd));
                     }
-#line 9212 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9604 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 507:
-#line 3600 "mrbgems/mruby-compiler/core/parse.y"
+  case 507: /* f_kwarg: f_kw  */
+#line 3601 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list1((yyvsp[0].nd));
                     }
-#line 9220 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9612 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 508:
-#line 3604 "mrbgems/mruby-compiler/core/parse.y"
+  case 508: /* f_kwarg: f_kwarg ',' f_kw  */
+#line 3605 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = push((yyvsp[-2].nd), (yyvsp[0].nd));
                     }
-#line 9228 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9620 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 511:
-#line 3614 "mrbgems/mruby-compiler/core/parse.y"
+  case 511: /* f_kwrest: kwrest_mark tIDENTIFIER  */
+#line 3615 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_kw_rest_args(p, nsym((yyvsp[0].id)));
                     }
-#line 9236 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9628 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 512:
-#line 3618 "mrbgems/mruby-compiler/core/parse.y"
+  case 512: /* f_kwrest: kwrest_mark  */
+#line 3619 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_kw_rest_args(p, 0);
                     }
-#line 9244 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9636 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 513:
-#line 3624 "mrbgems/mruby-compiler/core/parse.y"
+  case 513: /* args_tail: f_kwarg ',' f_kwrest opt_f_block_arg  */
+#line 3625 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args_tail(p, (yyvsp[-3].nd), (yyvsp[-1].nd), (yyvsp[0].id));
                     }
-#line 9252 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9644 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 514:
-#line 3628 "mrbgems/mruby-compiler/core/parse.y"
+  case 514: /* args_tail: f_kwarg opt_f_block_arg  */
+#line 3629 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args_tail(p, (yyvsp[-1].nd), 0, (yyvsp[0].id));
                     }
-#line 9260 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9652 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 515:
-#line 3632 "mrbgems/mruby-compiler/core/parse.y"
+  case 515: /* args_tail: f_kwrest opt_f_block_arg  */
+#line 3633 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args_tail(p, 0, (yyvsp[-1].nd), (yyvsp[0].id));
                     }
-#line 9268 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9660 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 516:
-#line 3636 "mrbgems/mruby-compiler/core/parse.y"
+  case 516: /* args_tail: f_block_arg  */
+#line 3637 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args_tail(p, 0, 0, (yyvsp[0].id));
                     }
-#line 9276 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9668 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 517:
-#line 3642 "mrbgems/mruby-compiler/core/parse.y"
+  case 517: /* opt_args_tail: ',' args_tail  */
+#line 3643 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[0].nd);
                     }
-#line 9284 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9676 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 518:
-#line 3646 "mrbgems/mruby-compiler/core/parse.y"
+  case 518: /* opt_args_tail: %empty  */
+#line 3647 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args_tail(p, 0, 0, 0);
                     }
-#line 9292 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9684 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 519:
-#line 3652 "mrbgems/mruby-compiler/core/parse.y"
+  case 519: /* f_args: f_arg ',' f_optarg ',' f_rest_arg opt_args_tail  */
+#line 3653 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, (yyvsp[-5].nd), (yyvsp[-3].nd), (yyvsp[-1].id), 0, (yyvsp[0].nd));
                     }
-#line 9300 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9692 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 520:
-#line 3656 "mrbgems/mruby-compiler/core/parse.y"
+  case 520: /* f_args: f_arg ',' f_optarg ',' f_rest_arg ',' f_arg opt_args_tail  */
+#line 3657 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, (yyvsp[-7].nd), (yyvsp[-5].nd), (yyvsp[-3].id), (yyvsp[-1].nd), (yyvsp[0].nd));
                     }
-#line 9308 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9700 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 521:
-#line 3660 "mrbgems/mruby-compiler/core/parse.y"
+  case 521: /* f_args: f_arg ',' f_optarg opt_args_tail  */
+#line 3661 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, (yyvsp[-3].nd), (yyvsp[-1].nd), 0, 0, (yyvsp[0].nd));
                     }
-#line 9316 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9708 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 522:
-#line 3664 "mrbgems/mruby-compiler/core/parse.y"
+  case 522: /* f_args: f_arg ',' f_optarg ',' f_arg opt_args_tail  */
+#line 3665 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, (yyvsp[-5].nd), (yyvsp[-3].nd), 0, (yyvsp[-1].nd), (yyvsp[0].nd));
                     }
-#line 9324 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9716 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 523:
-#line 3668 "mrbgems/mruby-compiler/core/parse.y"
+  case 523: /* f_args: f_arg ',' f_rest_arg opt_args_tail  */
+#line 3669 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, (yyvsp[-3].nd), 0, (yyvsp[-1].id), 0, (yyvsp[0].nd));
                     }
-#line 9332 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9724 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 524:
-#line 3672 "mrbgems/mruby-compiler/core/parse.y"
+  case 524: /* f_args: f_arg ',' f_rest_arg ',' f_arg opt_args_tail  */
+#line 3673 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, (yyvsp[-5].nd), 0, (yyvsp[-3].id), (yyvsp[-1].nd), (yyvsp[0].nd));
                     }
-#line 9340 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9732 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 525:
-#line 3676 "mrbgems/mruby-compiler/core/parse.y"
+  case 525: /* f_args: f_arg opt_args_tail  */
+#line 3677 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, (yyvsp[-1].nd), 0, 0, 0, (yyvsp[0].nd));
                     }
-#line 9348 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9740 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 526:
-#line 3680 "mrbgems/mruby-compiler/core/parse.y"
+  case 526: /* f_args: f_optarg ',' f_rest_arg opt_args_tail  */
+#line 3681 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, 0, (yyvsp[-3].nd), (yyvsp[-1].id), 0, (yyvsp[0].nd));
                     }
-#line 9356 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9748 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 527:
-#line 3684 "mrbgems/mruby-compiler/core/parse.y"
+  case 527: /* f_args: f_optarg ',' f_rest_arg ',' f_arg opt_args_tail  */
+#line 3685 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, 0, (yyvsp[-5].nd), (yyvsp[-3].id), (yyvsp[-1].nd), (yyvsp[0].nd));
                     }
-#line 9364 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9756 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 528:
-#line 3688 "mrbgems/mruby-compiler/core/parse.y"
+  case 528: /* f_args: f_optarg opt_args_tail  */
+#line 3689 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, 0, (yyvsp[-1].nd), 0, 0, (yyvsp[0].nd));
                     }
-#line 9372 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9764 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 529:
-#line 3692 "mrbgems/mruby-compiler/core/parse.y"
+  case 529: /* f_args: f_optarg ',' f_arg opt_args_tail  */
+#line 3693 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, 0, (yyvsp[-3].nd), 0, (yyvsp[-1].nd), (yyvsp[0].nd));
                     }
-#line 9380 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9772 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 530:
-#line 3696 "mrbgems/mruby-compiler/core/parse.y"
+  case 530: /* f_args: f_rest_arg opt_args_tail  */
+#line 3697 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, 0, 0, (yyvsp[-1].id), 0, (yyvsp[0].nd));
                     }
-#line 9388 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9780 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 531:
-#line 3700 "mrbgems/mruby-compiler/core/parse.y"
+  case 531: /* f_args: f_rest_arg ',' f_arg opt_args_tail  */
+#line 3701 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, 0, 0, (yyvsp[-3].id), (yyvsp[-1].nd), (yyvsp[0].nd));
                     }
-#line 9396 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9788 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 532:
-#line 3704 "mrbgems/mruby-compiler/core/parse.y"
+  case 532: /* f_args: args_tail  */
+#line 3705 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_args(p, 0, 0, 0, 0, (yyvsp[0].nd));
                     }
-#line 9404 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9796 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 533:
-#line 3708 "mrbgems/mruby-compiler/core/parse.y"
+  case 533: /* f_args: %empty  */
+#line 3709 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       local_add_f(p, intern_op(and));
                       (yyval.nd) = new_args(p, 0, 0, 0, 0, 0);
                     }
-#line 9413 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9805 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 534:
-#line 3715 "mrbgems/mruby-compiler/core/parse.y"
+  case 534: /* f_bad_arg: tCONSTANT  */
+#line 3716 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       yyerror(p, "formal argument cannot be a constant");
                       (yyval.nd) = 0;
                     }
-#line 9422 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9814 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 535:
-#line 3720 "mrbgems/mruby-compiler/core/parse.y"
+  case 535: /* f_bad_arg: tIVAR  */
+#line 3721 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       yyerror(p, "formal argument cannot be an instance variable");
                       (yyval.nd) = 0;
                     }
-#line 9431 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9823 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 536:
-#line 3725 "mrbgems/mruby-compiler/core/parse.y"
+  case 536: /* f_bad_arg: tGVAR  */
+#line 3726 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       yyerror(p, "formal argument cannot be a global variable");
                       (yyval.nd) = 0;
                     }
-#line 9440 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9832 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 537:
-#line 3730 "mrbgems/mruby-compiler/core/parse.y"
+  case 537: /* f_bad_arg: tCVAR  */
+#line 3731 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       yyerror(p, "formal argument cannot be a class variable");
                       (yyval.nd) = 0;
                     }
-#line 9449 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9841 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 538:
-#line 3735 "mrbgems/mruby-compiler/core/parse.y"
+  case 538: /* f_bad_arg: tNUMPARAM  */
+#line 3736 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       yyerror(p, "formal argument cannot be a numbered parameter");
                       (yyval.nd) = 0;
                     }
-#line 9458 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9850 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 539:
-#line 3742 "mrbgems/mruby-compiler/core/parse.y"
+  case 539: /* f_norm_arg: f_bad_arg  */
+#line 3743 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.id) = 0;
                     }
-#line 9466 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9858 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 540:
-#line 3746 "mrbgems/mruby-compiler/core/parse.y"
+  case 540: /* f_norm_arg: tIDENTIFIER  */
+#line 3747 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       local_add_f(p, (yyvsp[0].id));
                       (yyval.id) = (yyvsp[0].id);
                     }
-#line 9475 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9867 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 541:
-#line 3753 "mrbgems/mruby-compiler/core/parse.y"
+  case 541: /* f_arg_item: f_norm_arg  */
+#line 3754 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_arg(p, (yyvsp[0].id));
                     }
-#line 9483 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9875 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 542:
-#line 3757 "mrbgems/mruby-compiler/core/parse.y"
+  case 542: /* @32: %empty  */
+#line 3758 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = local_switch(p);
                     }
-#line 9491 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9883 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 543:
-#line 3761 "mrbgems/mruby-compiler/core/parse.y"
+  case 543: /* f_arg_item: tLPAREN @32 f_margs rparen  */
+#line 3762 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = new_masgn_param(p, (yyvsp[-1].nd), p->locals->car);
                       local_resume(p, (yyvsp[-2].nd));
                       local_add_f(p, 0);
                     }
-#line 9501 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9893 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 544:
-#line 3769 "mrbgems/mruby-compiler/core/parse.y"
+  case 544: /* f_arg: f_arg_item  */
+#line 3770 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list1((yyvsp[0].nd));
                     }
-#line 9509 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9901 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 545:
-#line 3773 "mrbgems/mruby-compiler/core/parse.y"
+  case 545: /* f_arg: f_arg ',' f_arg_item  */
+#line 3774 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = push((yyvsp[-2].nd), (yyvsp[0].nd));
                     }
-#line 9517 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9909 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 546:
-#line 3779 "mrbgems/mruby-compiler/core/parse.y"
+  case 546: /* f_opt_asgn: tIDENTIFIER '='  */
+#line 3780 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       local_add_f(p, (yyvsp[-1].id));
                       local_nest(p);
                       (yyval.id) = (yyvsp[-1].id);
                     }
-#line 9527 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9919 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 547:
-#line 3787 "mrbgems/mruby-compiler/core/parse.y"
+  case 547: /* f_opt: f_opt_asgn arg  */
+#line 3788 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       void_expr_error(p, (yyvsp[0].nd));
                       (yyval.nd) = cons(nsym((yyvsp[-1].id)), cons((yyvsp[0].nd), locals_node(p)));
                       local_unnest(p);
                     }
-#line 9537 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9929 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 548:
-#line 3795 "mrbgems/mruby-compiler/core/parse.y"
+  case 548: /* f_block_opt: f_opt_asgn primary_value  */
+#line 3796 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       void_expr_error(p, (yyvsp[0].nd));
                       (yyval.nd) = cons(nsym((yyvsp[-1].id)), cons((yyvsp[0].nd), locals_node(p)));
                       local_unnest(p);
                     }
-#line 9547 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9939 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 549:
-#line 3803 "mrbgems/mruby-compiler/core/parse.y"
+  case 549: /* f_block_optarg: f_block_opt  */
+#line 3804 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list1((yyvsp[0].nd));
                     }
-#line 9555 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9947 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 550:
-#line 3807 "mrbgems/mruby-compiler/core/parse.y"
+  case 550: /* f_block_optarg: f_block_optarg ',' f_block_opt  */
+#line 3808 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = push((yyvsp[-2].nd), (yyvsp[0].nd));
                     }
-#line 9563 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9955 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 551:
-#line 3813 "mrbgems/mruby-compiler/core/parse.y"
+  case 551: /* f_optarg: f_opt  */
+#line 3814 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list1((yyvsp[0].nd));
                     }
-#line 9571 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9963 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 552:
-#line 3817 "mrbgems/mruby-compiler/core/parse.y"
+  case 552: /* f_optarg: f_optarg ',' f_opt  */
+#line 3818 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = push((yyvsp[-2].nd), (yyvsp[0].nd));
                     }
-#line 9579 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9971 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 555:
-#line 3827 "mrbgems/mruby-compiler/core/parse.y"
+  case 555: /* f_rest_arg: restarg_mark tIDENTIFIER  */
+#line 3828 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       local_add_f(p, (yyvsp[0].id));
                       (yyval.id) = (yyvsp[0].id);
                     }
-#line 9588 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9980 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 556:
-#line 3832 "mrbgems/mruby-compiler/core/parse.y"
+  case 556: /* f_rest_arg: restarg_mark  */
+#line 3833 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       local_add_f(p, intern_op(mul));
                       (yyval.id) = -1;
                     }
-#line 9597 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9989 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 559:
-#line 3843 "mrbgems/mruby-compiler/core/parse.y"
+  case 559: /* f_block_arg: blkarg_mark tIDENTIFIER  */
+#line 3844 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.id) = (yyvsp[0].id);
                     }
-#line 9605 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 9997 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 560:
-#line 3849 "mrbgems/mruby-compiler/core/parse.y"
+  case 560: /* opt_f_block_arg: ',' f_block_arg  */
+#line 3850 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.id) = (yyvsp[0].id);
                     }
-#line 9613 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 10005 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 561:
-#line 3853 "mrbgems/mruby-compiler/core/parse.y"
+  case 561: /* opt_f_block_arg: none  */
+#line 3854 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.id) = 0;
                     }
-#line 9621 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 10013 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 562:
-#line 3859 "mrbgems/mruby-compiler/core/parse.y"
+  case 562: /* singleton: var_ref  */
+#line 3860 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[0].nd);
                       if (!(yyval.nd)) (yyval.nd) = new_nil(p);
                     }
-#line 9630 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 10022 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 563:
-#line 3863 "mrbgems/mruby-compiler/core/parse.y"
-                      {p->lstate = EXPR_BEG;}
-#line 9636 "mrbgems/mruby-compiler/core/y.tab.c"
-    break;
-
-  case 564:
+  case 563: /* $@33: %empty  */
 #line 3864 "mrbgems/mruby-compiler/core/parse.y"
+                      {p->lstate = EXPR_BEG;}
+#line 10028 "mrbgems/mruby-compiler/core/y.tab.c"
+    break;
+
+  case 564: /* singleton: '(' $@33 expr rparen  */
+#line 3865 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       if ((yyvsp[-1].nd) == 0) {
                         yyerror(p, "can't define singleton method for ().");
@@ -9659,55 +10051,55 @@ yyreduce:
                       }
                       (yyval.nd) = (yyvsp[-1].nd);
                     }
-#line 9663 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 10055 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 566:
-#line 3890 "mrbgems/mruby-compiler/core/parse.y"
+  case 566: /* assoc_list: assocs trailer  */
+#line 3891 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = (yyvsp[-1].nd);
                     }
-#line 9671 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 10063 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 567:
-#line 3896 "mrbgems/mruby-compiler/core/parse.y"
+  case 567: /* assocs: assoc  */
+#line 3897 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = list1((yyvsp[0].nd));
                       NODE_LINENO((yyval.nd), (yyvsp[0].nd));
                     }
-#line 9680 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 10072 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 568:
-#line 3901 "mrbgems/mruby-compiler/core/parse.y"
+  case 568: /* assocs: assocs comma assoc  */
+#line 3902 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = push((yyvsp[-2].nd), (yyvsp[0].nd));
                     }
-#line 9688 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 10080 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 571:
-#line 3911 "mrbgems/mruby-compiler/core/parse.y"
+  case 571: /* assoc: arg tASSOC arg  */
+#line 3912 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       void_expr_error(p, (yyvsp[-2].nd));
                       void_expr_error(p, (yyvsp[0].nd));
                       (yyval.nd) = cons((yyvsp[-2].nd), (yyvsp[0].nd));
                     }
-#line 9698 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 10090 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 572:
-#line 3917 "mrbgems/mruby-compiler/core/parse.y"
+  case 572: /* assoc: tIDENTIFIER label_tag arg  */
+#line 3918 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       void_expr_error(p, (yyvsp[0].nd));
                       (yyval.nd) = cons(new_sym(p, (yyvsp[-2].id)), (yyvsp[0].nd));
                     }
-#line 9707 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 10099 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 573:
-#line 3922 "mrbgems/mruby-compiler/core/parse.y"
+  case 573: /* assoc: string_fragment label_tag arg  */
+#line 3923 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       void_expr_error(p, (yyvsp[0].nd));
                       if (typen((yyvsp[-2].nd)->car) == NODE_DSTR) {
@@ -9717,67 +10109,67 @@ yyreduce:
                         (yyval.nd) = cons(new_sym(p, new_strsym(p, (yyvsp[-2].nd))), (yyvsp[0].nd));
                       }
                     }
-#line 9721 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 10113 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 574:
-#line 3932 "mrbgems/mruby-compiler/core/parse.y"
+  case 574: /* assoc: tDSTAR arg  */
+#line 3933 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       void_expr_error(p, (yyvsp[0].nd));
                       (yyval.nd) = cons(new_kw_rest_args(p, 0), (yyvsp[0].nd));
                     }
-#line 9730 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 10122 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 587:
-#line 3959 "mrbgems/mruby-compiler/core/parse.y"
+  case 587: /* call_op: '.'  */
+#line 3960 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.num) = '.';
                     }
-#line 9738 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 10130 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 588:
-#line 3963 "mrbgems/mruby-compiler/core/parse.y"
+  case 588: /* call_op: tANDDOT  */
+#line 3964 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.num) = 0;
                     }
-#line 9746 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 10138 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 590:
-#line 3970 "mrbgems/mruby-compiler/core/parse.y"
+  case 590: /* call_op2: tCOLON2  */
+#line 3971 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.num) = tCOLON2;
                     }
-#line 9754 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 10146 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 599:
-#line 3991 "mrbgems/mruby-compiler/core/parse.y"
+  case 599: /* term: ';'  */
+#line 3992 "mrbgems/mruby-compiler/core/parse.y"
                       {yyerrok;}
-#line 9760 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 10152 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 602:
-#line 3997 "mrbgems/mruby-compiler/core/parse.y"
+  case 602: /* nl: '\n'  */
+#line 3998 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       p->lineno += (yyvsp[0].num);
                       p->column = 0;
                     }
-#line 9769 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 10161 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
-  case 605:
-#line 4008 "mrbgems/mruby-compiler/core/parse.y"
+  case 605: /* none: %empty  */
+#line 4009 "mrbgems/mruby-compiler/core/parse.y"
                     {
                       (yyval.nd) = 0;
                     }
-#line 9777 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 10169 "mrbgems/mruby-compiler/core/y.tab.c"
     break;
 
 
-#line 9781 "mrbgems/mruby-compiler/core/y.tab.c"
+#line 10173 "mrbgems/mruby-compiler/core/y.tab.c"
 
       default: break;
     }
@@ -9792,11 +10184,10 @@ yyreduce:
      case of YYERROR or YYBACKUP, subsequent parser actions might lead
      to an incorrect destructor call or verbose syntax error message
      before the lookahead is translated.  */
-  YY_SYMBOL_PRINT ("-> $$ =", yyr1[yyn], &yyval, &yyloc);
+  YY_SYMBOL_PRINT ("-> $$ =", YY_CAST (yysymbol_kind_t, yyr1[yyn]), &yyval, &yyloc);
 
   YYPOPSTACK (yylen);
   yylen = 0;
-  YY_STACK_PRINT (yyss, yyssp);
 
   *++yyvsp = yyval;
 
@@ -9820,49 +10211,43 @@ yyreduce:
 yyerrlab:
   /* Make sure we have latest lookahead translation.  See comments at
      user semantic actions for why this is necessary.  */
-  yytoken = yychar == YYEMPTY ? YYEMPTY : YYTRANSLATE (yychar);
-
+  yytoken = yychar == YYEMPTY ? YYSYMBOL_YYEMPTY : YYTRANSLATE (yychar);
   /* If not already recovering from an error, report this error.  */
   if (!yyerrstatus)
     {
       ++yynerrs;
-#if ! YYERROR_VERBOSE
-      yyerror (p, YY_("syntax error"));
-#else
-# define YYSYNTAX_ERROR yysyntax_error (&yymsg_alloc, &yymsg, \
-                                        yyssp, yytoken)
       {
+        yypcontext_t yyctx
+          = {yyssp, yytoken};
         char const *yymsgp = YY_("syntax error");
         int yysyntax_error_status;
-        yysyntax_error_status = YYSYNTAX_ERROR;
+        yysyntax_error_status = yysyntax_error (&yymsg_alloc, &yymsg, &yyctx);
         if (yysyntax_error_status == 0)
           yymsgp = yymsg;
-        else if (yysyntax_error_status == 1)
+        else if (yysyntax_error_status == -1)
           {
             if (yymsg != yymsgbuf)
               YYSTACK_FREE (yymsg);
-            yymsg = YY_CAST (char *, YYSTACK_ALLOC (YY_CAST (YYSIZE_T, yymsg_alloc)));
-            if (!yymsg)
+            yymsg = YY_CAST (char *,
+                             YYSTACK_ALLOC (YY_CAST (YYSIZE_T, yymsg_alloc)));
+            if (yymsg)
               {
-                yymsg = yymsgbuf;
-                yymsg_alloc = sizeof yymsgbuf;
-                yysyntax_error_status = 2;
+                yysyntax_error_status
+                  = yysyntax_error (&yymsg_alloc, &yymsg, &yyctx);
+                yymsgp = yymsg;
               }
             else
               {
-                yysyntax_error_status = YYSYNTAX_ERROR;
-                yymsgp = yymsg;
+                yymsg = yymsgbuf;
+                yymsg_alloc = sizeof yymsgbuf;
+                yysyntax_error_status = YYENOMEM;
               }
           }
         yyerror (p, yymsgp);
-        if (yysyntax_error_status == 2)
+        if (yysyntax_error_status == YYENOMEM)
           goto yyexhaustedlab;
       }
-# undef YYSYNTAX_ERROR
-#endif
     }
-
-
 
   if (yyerrstatus == 3)
     {
@@ -9912,13 +10297,14 @@ yyerrorlab:
 yyerrlab1:
   yyerrstatus = 3;      /* Each real token shifted decrements this.  */
 
+  /* Pop stack until we find a state that shifts the error token.  */
   for (;;)
     {
       yyn = yypact[yystate];
       if (!yypact_value_is_default (yyn))
         {
-          yyn += YYTERROR;
-          if (0 <= yyn && yyn <= YYLAST && yycheck[yyn] == YYTERROR)
+          yyn += YYSYMBOL_YYerror;
+          if (0 <= yyn && yyn <= YYLAST && yycheck[yyn] == YYSYMBOL_YYerror)
             {
               yyn = yytable[yyn];
               if (0 < yyn)
@@ -9932,7 +10318,7 @@ yyerrlab1:
 
 
       yydestruct ("Error: popping",
-                  yystos[yystate], yyvsp, p);
+                  YY_ACCESSING_SYMBOL (yystate), yyvsp, p);
       YYPOPSTACK (1);
       yystate = *yyssp;
       YY_STACK_PRINT (yyss, yyssp);
@@ -9944,7 +10330,7 @@ yyerrlab1:
 
 
   /* Shift the error token.  */
-  YY_SYMBOL_PRINT ("Shifting", yystos[yyn], yyvsp, yylsp);
+  YY_SYMBOL_PRINT ("Shifting", YY_ACCESSING_SYMBOL (yyn), yyvsp, yylsp);
 
   yystate = yyn;
   goto yynewstate;
@@ -9966,20 +10352,20 @@ yyabortlab:
   goto yyreturn;
 
 
-#if !defined yyoverflow || YYERROR_VERBOSE
+#if 1
 /*-------------------------------------------------.
 | yyexhaustedlab -- memory exhaustion comes here.  |
 `-------------------------------------------------*/
 yyexhaustedlab:
   yyerror (p, YY_("memory exhausted"));
   yyresult = 2;
-  /* Fall through.  */
+  goto yyreturn;
 #endif
 
 
-/*-----------------------------------------------------.
-| yyreturn -- parsing is finished, return the result.  |
-`-----------------------------------------------------*/
+/*-------------------------------------------------------.
+| yyreturn -- parsing is finished, clean up and return.  |
+`-------------------------------------------------------*/
 yyreturn:
   if (yychar != YYEMPTY)
     {
@@ -9996,20 +10382,19 @@ yyreturn:
   while (yyssp != yyss)
     {
       yydestruct ("Cleanup: popping",
-                  yystos[+*yyssp], yyvsp, p);
+                  YY_ACCESSING_SYMBOL (+*yyssp), yyvsp, p);
       YYPOPSTACK (1);
     }
 #ifndef yyoverflow
   if (yyss != yyssa)
     YYSTACK_FREE (yyss);
 #endif
-#if YYERROR_VERBOSE
   if (yymsg != yymsgbuf)
     YYSTACK_FREE (yymsg);
-#endif
   return yyresult;
 }
-#line 4012 "mrbgems/mruby-compiler/core/parse.y"
+
+#line 4013 "mrbgems/mruby-compiler/core/parse.y"
 
 #define pylval  (*((YYSTYPE*)(p->ylval)))
 

--- a/mrbgems/mruby-complex/src/complex.c
+++ b/mrbgems/mruby-complex/src/complex.c
@@ -1,6 +1,7 @@
 #include <mruby.h>
 #include <mruby/class.h>
 #include <mruby/numeric.h>
+#include <mruby/presym.h>
 #include <math.h>
 
 #ifdef MRB_NO_FLOAT

--- a/mrbgems/mruby-eval/src/eval.c
+++ b/mrbgems/mruby-eval/src/eval.c
@@ -5,6 +5,7 @@
 #include <mruby/proc.h>
 #include <mruby/opcode.h>
 #include <mruby/error.h>
+#include <mruby/presym.h>
 
 struct REnv *mrb_env_new(mrb_state *mrb, struct mrb_context *c, mrb_callinfo *ci, int nstacks, mrb_value *stack, struct RClass *tc);
 mrb_value mrb_exec_irep(mrb_state *mrb, mrb_value self, struct RProc *p);

--- a/mrbgems/mruby-io/src/file.c
+++ b/mrbgems/mruby-io/src/file.c
@@ -8,6 +8,7 @@
 #include "mruby/string.h"
 #include "mruby/ext/io.h"
 #include "mruby/error.h"
+#include "mruby/presym.h"
 
 #include <sys/types.h>
 #include <sys/stat.h>

--- a/mrbgems/mruby-io/src/io.c
+++ b/mrbgems/mruby-io/src/io.c
@@ -11,6 +11,7 @@
 #include "mruby/variable.h"
 #include "mruby/ext/io.h"
 #include "mruby/error.h"
+#include "mruby/presym.h"
 
 #include <sys/types.h>
 #include <sys/stat.h>

--- a/mrbgems/mruby-kernel-ext/src/kernel.c
+++ b/mrbgems/mruby-kernel-ext/src/kernel.c
@@ -3,6 +3,7 @@
 #include <mruby/array.h>
 #include <mruby/hash.h>
 #include <mruby/range.h>
+#include <mruby/presym.h>
 
 static mrb_value
 mrb_f_caller(mrb_state *mrb, mrb_value self)

--- a/mrbgems/mruby-math/src/math.c
+++ b/mrbgems/mruby-math/src/math.c
@@ -11,6 +11,7 @@
 #endif
 
 #include <mruby/array.h>
+#include <mruby/presym.h>
 #include <math.h>
 
 static void

--- a/mrbgems/mruby-metaprog/src/metaprog.c
+++ b/mrbgems/mruby-metaprog/src/metaprog.c
@@ -5,6 +5,7 @@
 #include "mruby/proc.h"
 #include "mruby/class.h"
 #include "mruby/string.h"
+#include "mruby/presym.h"
 
 typedef enum {
   NOEX_PUBLIC    = 0x00,

--- a/mrbgems/mruby-method/src/method.c
+++ b/mrbgems/mruby-method/src/method.c
@@ -4,6 +4,7 @@
 #include "mruby/variable.h"
 #include "mruby/proc.h"
 #include "mruby/string.h"
+#include "mruby/presym.h"
 
 static struct RObject *
 method_object_alloc(mrb_state *mrb, struct RClass *mclass)

--- a/mrbgems/mruby-numeric-ext/src/numeric_ext.c
+++ b/mrbgems/mruby-numeric-ext/src/numeric_ext.c
@@ -1,6 +1,7 @@
 #include <limits.h>
 #include <mruby.h>
 #include <mruby/numeric.h>
+#include <mruby/presym.h>
 
 /*
  *  call-seq:

--- a/mrbgems/mruby-object-ext/src/object.c
+++ b/mrbgems/mruby-object-ext/src/object.c
@@ -3,6 +3,7 @@
 #include <mruby/class.h>
 #include <mruby/hash.h>
 #include <mruby/proc.h>
+#include <mruby/presym.h>
 
 /*
  *  call-seq:

--- a/mrbgems/mruby-objectspace/src/mruby_objectspace.c
+++ b/mrbgems/mruby-objectspace/src/mruby_objectspace.c
@@ -10,6 +10,7 @@
 #include <mruby/proc.h>
 #include <mruby/value.h>
 #include <mruby/range.h>
+#include <mruby/presym.h>
 
 struct os_count_struct {
   mrb_int total;

--- a/mrbgems/mruby-proc-ext/src/proc.c
+++ b/mrbgems/mruby-proc-ext/src/proc.c
@@ -4,6 +4,7 @@
 #include <mruby/array.h>
 #include <mruby/string.h>
 #include <mruby/debug.h>
+#include <mruby/presym.h>
 
 static mrb_value
 mrb_proc_lambda_p(mrb_state *mrb, mrb_value self)

--- a/mrbgems/mruby-random/src/random.c
+++ b/mrbgems/mruby-random/src/random.c
@@ -10,6 +10,7 @@
 #include <mruby/data.h>
 #include <mruby/array.h>
 #include <mruby/istruct.h>
+#include <mruby/presym.h>
 
 #include <time.h>
 

--- a/mrbgems/mruby-rational/src/rational.c
+++ b/mrbgems/mruby-rational/src/rational.c
@@ -2,6 +2,7 @@
 #include <mruby/class.h>
 #include <mruby/string.h>
 #include <mruby/numeric.h>
+#include <mruby/presym.h>
 
 struct mrb_rational {
   mrb_int numerator;

--- a/mrbgems/mruby-socket/src/socket.c
+++ b/mrbgems/mruby-socket/src/socket.c
@@ -42,6 +42,7 @@
 #include "mruby/string.h"
 #include "mruby/variable.h"
 #include "mruby/error.h"
+#include "mruby/presym.h"
 
 #include "mruby/ext/io.h"
 

--- a/mrbgems/mruby-sprintf/src/sprintf.c
+++ b/mrbgems/mruby-sprintf/src/sprintf.c
@@ -10,6 +10,7 @@
 #include <mruby/string.h>
 #include <mruby/hash.h>
 #include <mruby/numeric.h>
+#include <mruby/presym.h>
 #ifndef MRB_NO_FLOAT
 #include <math.h>
 #endif

--- a/mrbgems/mruby-struct/src/struct.c
+++ b/mrbgems/mruby-struct/src/struct.c
@@ -13,6 +13,7 @@
 #include <mruby/hash.h>
 #include <mruby/range.h>
 #include <mruby/proc.h>
+#include <mruby/presym.h>
 
 #define RSTRUCT_LEN(st) RARRAY_LEN(st)
 #define RSTRUCT_PTR(st) RARRAY_PTR(st)

--- a/mrbgems/mruby-time/src/time.c
+++ b/mrbgems/mruby-time/src/time.c
@@ -14,6 +14,7 @@
 #include <mruby/numeric.h>
 #include <mruby/time.h>
 #include <mruby/string.h>
+#include <mruby/presym.h>
 
 #ifdef MRB_NO_STDIO
 #include <string.h>

--- a/src/array.c
+++ b/src/array.c
@@ -10,7 +10,7 @@
 #include <mruby/string.h>
 #include <mruby/range.h>
 #include <mruby/proc.h>
-#include <mruby/opcode.h>
+#include <mruby/presym.h>
 #include "value_array.h"
 
 #define ARY_DEFAULT_LEN   4

--- a/src/backtrace.c
+++ b/src/backtrace.c
@@ -14,6 +14,7 @@
 #include <mruby/error.h>
 #include <mruby/numeric.h>
 #include <mruby/data.h>
+#include <mruby/presym.h>
 
 struct backtrace_location {
   int32_t lineno;

--- a/src/class.c
+++ b/src/class.c
@@ -17,6 +17,7 @@
 #include <mruby/data.h>
 #include <mruby/istruct.h>
 #include <mruby/opcode.h>
+#include <mruby/presym.h>
 
 union mt_ptr {
   struct RProc *proc;

--- a/src/dump.c
+++ b/src/dump.c
@@ -1222,7 +1222,10 @@ mrb_dump_irep_cstruct(mrb_state *mrb, const mrb_irep *irep, uint8_t flags, FILE 
   if (fp == NULL || initname == NULL || initname[0] == '\0') {
     return MRB_DUMP_INVALID_ARGUMENT;
   }
-  if (fprintf(fp, "#include <mruby.h>\n" "#include <mruby/proc.h>\n\n") < 0) {
+  if (fprintf(fp, "#include <mruby.h>\n"
+                  "#include <mruby/proc.h>\n"
+                  "#include <mruby/presym.h>\n"
+                  "\n") < 0) {
     return MRB_DUMP_WRITE_FAULT;
   }
   fputs("#define mrb_BRACED(...) {__VA_ARGS__}\n", fp);

--- a/src/error.c
+++ b/src/error.c
@@ -16,6 +16,7 @@
 #include <mruby/error.h>
 #include <mruby/class.h>
 #include <mruby/throw.h>
+#include <mruby/presym.h>
 
 MRB_API mrb_value
 mrb_exc_new(mrb_state *mrb, struct RClass *c, const char *ptr, size_t len)

--- a/src/gc.c
+++ b/src/gc.c
@@ -22,6 +22,7 @@
 #include <mruby/gc.h>
 #include <mruby/error.h>
 #include <mruby/throw.h>
+#include <mruby/presym.h>
 
 /*
   = Tri-color Incremental Garbage Collection

--- a/src/hash.c
+++ b/src/hash.c
@@ -11,6 +11,7 @@
 #include <mruby/hash.h>
 #include <mruby/string.h>
 #include <mruby/variable.h>
+#include <mruby/presym.h>
 
 /*
  * === Glossary
@@ -254,6 +255,8 @@ HT_ASSERT_SAFE_READ(ea_capa);
 #define h_ar_p(h) (!h_ht_p(h))
 #define h_ar_on(h) h_ht_off(h)
 #define lesser(a, b) ((a) < (b) ? (a) : (b))
+#define RHASH_IFNONE(hash) mrb_iv_get(mrb, (hash), MRB_SYM(ifnone))
+#define RHASH_PROCDEFAULT(hash) RHASH_IFNONE(hash)
 
 static uint32_t ib_upper_bound_for(uint32_t capa);
 static uint32_t ib_bit_to_capa(uint32_t bit);

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -13,6 +13,7 @@
 #include <mruby/variable.h>
 #include <mruby/error.h>
 #include <mruby/istruct.h>
+#include <mruby/presym.h>
 
 MRB_API mrb_bool
 mrb_func_basic_p(mrb_state *mrb, mrb_value obj, mrb_sym mid, mrb_func_t func)

--- a/src/numeric.c
+++ b/src/numeric.c
@@ -17,6 +17,7 @@
 #include <mruby/numeric.h>
 #include <mruby/string.h>
 #include <mruby/class.h>
+#include <mruby/presym.h>
 
 #ifndef MRB_NO_FLOAT
 #ifdef MRB_USE_FLOAT32

--- a/src/object.c
+++ b/src/object.c
@@ -9,6 +9,7 @@
 #include <mruby/numeric.h>
 #include <mruby/string.h>
 #include <mruby/class.h>
+#include <mruby/presym.h>
 
 MRB_API mrb_bool
 mrb_obj_eq(mrb_state *mrb, mrb_value v1, mrb_value v2)

--- a/src/print.c
+++ b/src/print.c
@@ -8,6 +8,7 @@
 #include <mruby/string.h>
 #include <mruby/variable.h>
 #include <mruby/error.h>
+#include <mruby/presym.h>
 #include <string.h>
 
 #ifndef MRB_NO_STDIO

--- a/src/proc.c
+++ b/src/proc.c
@@ -9,6 +9,7 @@
 #include <mruby/proc.h>
 #include <mruby/opcode.h>
 #include <mruby/data.h>
+#include <mruby/presym.h>
 
 static const mrb_code call_iseq[] = {
   OP_CALL,

--- a/src/range.c
+++ b/src/range.c
@@ -9,6 +9,7 @@
 #include <mruby/range.h>
 #include <mruby/string.h>
 #include <mruby/array.h>
+#include <mruby/presym.h>
 
 #define RANGE_INITIALIZED_MASK 1
 #define RANGE_INITIALIZED(p) ((p)->flags |= RANGE_INITIALIZED_MASK)

--- a/src/string.c
+++ b/src/string.c
@@ -22,6 +22,7 @@
 #include <mruby/range.h>
 #include <mruby/string.h>
 #include <mruby/numeric.h>
+#include <mruby/presym.h>
 
 typedef struct mrb_shared_string {
   int refcnt;

--- a/src/symbol.c
+++ b/src/symbol.c
@@ -11,6 +11,7 @@
 #include <mruby/string.h>
 #include <mruby/dump.h>
 #include <mruby/class.h>
+#include <mruby/presym.h>
 
 #ifndef MRB_NO_PRESYM
 

--- a/src/variable.c
+++ b/src/variable.c
@@ -10,6 +10,7 @@
 #include <mruby/proc.h>
 #include <mruby/string.h>
 #include <mruby/variable.h>
+#include <mruby/presym.h>
 
 struct iv_elem {
   mrb_sym key;

--- a/src/vm.c
+++ b/src/vm.c
@@ -24,6 +24,7 @@
 #include "value_array.h"
 #include <mruby/throw.h>
 #include <mruby/dump.h>
+#include <mruby/presym.h>
 
 #ifdef MRB_NO_STDIO
 #if defined(__cplusplus)


### PR DESCRIPTION
Addressed an issue where existing programs linking `libmruby.a` could only
be built by adding `<build-dir>/include` to compiler's include path.