### PR TITLE
Remove unneeded `mruby-test` gem in `build_config/no-float.rb` [ci skip]

### DIFF
--- a/build_config/no-float.rb
+++ b/build_config/no-float.rb
@@ -8,7 +8,6 @@ MRuby::CrossBuild.new('no-float') do |conf|
   end
 
   conf.gem :core => "mruby-bin-mruby"
-  conf.gem :core => "mruby-test"
 
   conf.test_runner.command = 'env'
 


### PR DESCRIPTION
Use `enable_test` to enable the test.