### PR TITLE
Create a `mruby-config` that can be run on the host by cross-building

### DIFF
--- a/mrbgems/mruby-bin-config/mrbgem.rake
+++ b/mrbgems/mruby-bin-config/mrbgem.rake
@@ -1,30 +1,35 @@
-if MRuby::Build.current.kind_of?(MRuby::CrossBuild)
-  gemname = File.basename File.dirname __FILE__
-  buildname = MRuby::Build.current.name
-  $stderr.puts "WARN  #{gemname} - This mrbgem is ignored within #{buildname}"
-else
-  MRuby::Gem::Specification.new('mruby-bin-config') do |spec|
-    name = 'mruby-config'
-    spec.license = 'MIT'
-    spec.author  = 'mruby developers'
-    spec.summary = "#{name} command"
+iscross = MRuby::Build.current.kind_of?(MRuby::CrossBuild)
 
+MRuby::Gem::Specification.new('mruby-bin-config') do |spec|
+  name = 'mruby-config'
+  spec.license = 'MIT'
+  spec.author  = 'mruby developers'
+  spec.summary = "#{name} command"
+
+  if iscross
+    mruby_config_dir = "#{build.build_dir}/host-bin"
+  else
     mruby_config_dir = "#{build.build_dir}/bin"
-    mruby_config = name + (ENV['OS'] == 'Windows_NT' ? '.bat' : '')
-    mruby_config_path = "#{mruby_config_dir}/#{mruby_config}"
-    make_cfg = "#{build.build_dir}/lib/libmruby.flags.mak"
-    tmplt_path = "#{__dir__}/#{mruby_config}"
+  end
+  mruby_config = name + (ENV['OS'] == 'Windows_NT' ? '.bat' : '')
+  mruby_config_path = "#{mruby_config_dir}/#{mruby_config}"
+  make_cfg = "#{build.build_dir}/lib/libmruby.flags.mak"
+  tmplt_path = "#{__dir__}/#{mruby_config}"
+
+  if iscross
+    build.products << mruby_config_path
+  else
     build.bins << mruby_config
+  end
 
-    directory mruby_config_dir
+  directory mruby_config_dir
 
-    file mruby_config_path => [mruby_config_dir, make_cfg, tmplt_path] do |t|
-      config = Hash[File.readlines(make_cfg).map!(&:chomp).map! {|l|
-        l.gsub('\\"', '"').split(' = ', 2).map! {|s| s.sub(/^(?=.)/, 'echo ')}
-      }]
-      tmplt = File.read(tmplt_path)
-      File.write(t.name, tmplt.gsub(/(#{Regexp.union(*config.keys)})\b/, config))
-      chmod(0755, t.name)
-    end
+  file mruby_config_path => [mruby_config_dir, make_cfg, tmplt_path] do |t|
+    config = Hash[File.readlines(make_cfg).map!(&:chomp).map! {|l|
+      l.gsub('\\"', '"').split(' = ', 2).map! {|s| s.sub(/^(?=.)/, 'echo ')}
+    }]
+    tmplt = File.read(tmplt_path)
+    File.write(t.name, tmplt.gsub(/(#{Regexp.union(*config.keys)})\b/, config))
+    chmod(0755, t.name)
   end
 end


### PR DESCRIPTION
The output directory will be `host-bin`, so it will be output as `<build-dir>/host-bin/mruby-config`.

It's still not available for target devices.