### PR TITLE
Initialize all area of `struct sockaddr_un`

### DIFF
--- a/mrbgems/mruby-io/test/mruby_io_test.c
+++ b/mrbgems/mruby-io/test/mruby_io_test.c
@@ -80,7 +80,7 @@ mrb_io_test_io_setup(mrb_state *mrb, mrb_value self)
   FILE *fp;
   int i;
 #if !defined(_WIN32) && !defined(_WIN64)
-  struct sockaddr_un sun0;
+  struct sockaddr_un sun0 = { 0 }; /* Initialize them all because it is environment dependent */
 #endif
 
   mrb_gv_set(mrb, mrb_intern_cstr(mrb, "$mrbtest_io_msg"), mrb_str_new_cstr(mrb, msg));


### PR DESCRIPTION
Members of `struct sockaddr_un` are requesting the definitions of `sun_family` and `sun_path`.
https://pubs.opengroup.org/onlinepubs/009696699/basedefs/sys/un.h.html

But the other members are optional and environment dependent.

In fact, other members are defined in the BSD series.
from NetBSD-9.1 <https://github.com/NetBSD/src/blob/da504f75982b244b2288bc9970bbc203bd77a9c1/sys/sys/un.h#L49-L53>

```c
struct  sockaddr_un {
        unsigned char   sun_len;        /* sockaddr len excluding NUL */
        sa_family_t     sun_family;     /* AF_UNIX */
        char    sun_path[104];          /* path name (gag) */
};
```

I found this problem through valgrind on FreeBSD.