### PR TITLE
Fixed stack position of return value; ref #5272

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -1515,7 +1515,7 @@ RETRY_TRY_BLOCK:
         /* pop stackpos */
         ci = cipop(mrb);
         pc = ci->pc;
-        regs[ci->acc] = recv;
+        regs[ci[1].acc] = recv;
         irep = mrb->c->ci->proc->body.irep;
         pool = irep->pool;
         syms = irep->syms;


### PR DESCRIPTION
When I `#call` the "proc" object created by the `mrb_proc_new_cfunc()` function from Ruby space, the return value did not go into the correct stack position.
This can destroy the calling variable.

This issue is now caused by #5272. sorry.