### PR TITLE
Fix NULL pointer dereference with mruby-os-memsize and mruby-method

### DIFF
--- a/mrbgems/mruby-os-memsize/src/memsize.c
+++ b/mrbgems/mruby-os-memsize/src/memsize.c
@@ -33,6 +33,7 @@ os_memsize_of_method(mrb_state* mrb, mrb_value method_obj)
   size_t size;
   mrb_value proc_value = mrb_obj_iv_get(mrb, mrb_obj_ptr(method_obj),
                                         mrb_intern_lit(mrb, "_proc"));
+  if (mrb_nil_p(proc_value)) return 0;
   struct RProc *proc = mrb_proc_ptr(proc_value);
 
   size = sizeof(struct RProc);


### PR DESCRIPTION
If it gets an insubstantial method object with `obj.method`, it will raise a `SIGSEGV` with `ObjectSpace.memsize_of(method)`.

---

```console
% cat memsizeof.rb
class Object
  def respond_to_missing?(mid, incpriv)
    return true if mid == :xyz
    super
  end
end

m = "".method(:xyz)
p ObjectSpace.memsize_of m

% bin/mruby memsizeof.rb
zsh: segmentation fault (core dumped)  bin/mruby memsizeof.rb
```