### PR TITLE
Avoid 'possible loss of data' casting in binary search

### DIFF
--- a/src/dump.c
+++ b/src/dump.c
@@ -1036,14 +1036,16 @@ sym_name_cvar_p(const char *name, mrb_int len)
 static const char*
 sym_operator_name(const char *sym_name, mrb_int len)
 {
-  mrb_sym start, idx;
   mrb_sym table_size = sizeof(operator_table)/sizeof(struct operator_symbol);
+  if (operator_table[table_size-1].sym_name_len < len) return NULL;
+
+  mrb_sym start, idx;
   int cmp;
   const struct operator_symbol *op_sym;
   for (start = 0; table_size != 0; table_size/=2) {
     idx = start+table_size/2;
     op_sym = &operator_table[idx];
-    cmp = (int)(len-op_sym->sym_name_len);
+    cmp = (int)len-(int)op_sym->sym_name_len;
     if (cmp == 0) {
       cmp = memcmp(sym_name, op_sym->sym_name, len);
       if (cmp == 0) return op_sym->name;

--- a/src/symbol.c
+++ b/src/symbol.c
@@ -31,11 +31,13 @@ static const struct {
 static mrb_sym
 presym_find(const char *name, size_t len)
 {
+  if (presym_table[MRB_PRESYM_MAX-1].len < len) return 0;
+
   mrb_sym start, idx, presym_size = MRB_PRESYM_MAX;
   int cmp;
   for (start = 0; presym_size != 0; presym_size/=2) {
     idx = start+presym_size/2;
-    cmp = (int)(len-presym_table[idx].len);
+    cmp = (int)len-(int)presym_table[idx].len;
     if (cmp == 0) {
       cmp = memcmp(name, presym_table[idx].name, len);
       if (cmp == 0) return idx+1;


### PR DESCRIPTION
Because it may not be expected result.
example: https://wandbox.org/permlink/F5Mp7IEJ1VY3CFLp