### PR TITLE
Rename `.i` created for presym scan to `.pi`

### DIFF
--- a/lib/mruby/build.rb
+++ b/lib/mruby/build.rb
@@ -80,16 +80,16 @@ module MRuby
     COMMANDS = COMPILERS + %w(linker archiver yacc gperf git exts mrbc)
     attr_block MRuby::Build::COMMANDS
 
-    Exts = Struct.new(:object, :executable, :library, :preprocessed)
+    Exts = Struct.new(:object, :executable, :library, :presym_preprocessed)
 
     def initialize(name='host', build_dir=nil, internal: false, &block)
       @name = name.to_s
 
       unless current = MRuby.targets[@name]
         if ENV['OS'] == 'Windows_NT'
-          @exts = Exts.new('.o', '.exe', '.a', '.i')
+          @exts = Exts.new('.o', '.exe', '.a', '.pi')
         else
-          @exts = Exts.new('.o', '', '.a', '.i')
+          @exts = Exts.new('.o', '', '.a', '.pi')
         end
 
         build_dir = build_dir || ENV['MRUBY_BUILD_DIR'] || "#{MRUBY_ROOT}/build"
@@ -239,7 +239,7 @@ module MRuby
       if cxx_src
         obj ||= cxx_src + @exts.object
         dsts = [obj]
-        dsts << (cxx_src + @exts.preprocessed) if presym_enabled?
+        dsts << (cxx_src + @exts.presym_preprocessed) if presym_enabled?
         defines = []
         include_paths = ["#{MRUBY_ROOT}/src", *includes]
         dsts.each do |dst|
@@ -355,7 +355,7 @@ EOS
       end
       [@cc, *(@cxx if cxx_exception_enabled?)].each do |compiler|
         compiler.define_rules(@build_dir, MRUBY_ROOT, @exts.object)
-        compiler.define_rules(@build_dir, MRUBY_ROOT, @exts.preprocessed) if presym_enabled?
+        compiler.define_rules(@build_dir, MRUBY_ROOT, @exts.presym_preprocessed) if presym_enabled?
       end
     end
 

--- a/lib/mruby/gem.rb
+++ b/lib/mruby/gem.rb
@@ -89,7 +89,7 @@ module MRuby
 
       def setup_compilers
         (core? ? [@cc, *(@cxx if build.cxx_exception_enabled?)] : compilers).each do |compiler|
-          compiler.define_rules build_dir, @dir, @build.exts.preprocessed if build.presym_enabled?
+          compiler.define_rules build_dir, @dir, @build.exts.presym_preprocessed if build.presym_enabled?
           compiler.define_rules build_dir, @dir, @build.exts.object
           compiler.defines << %Q[MRBGEM_#{funcname.upcase}_VERSION=#{version}]
           compiler.include_paths << "#{@dir}/include" if File.directory? "#{@dir}/include"

--- a/tasks/presym.rake
+++ b/tasks/presym.rake
@@ -25,7 +25,7 @@ MRuby.each_target do |build|
     next unless File.extname(prereq) == build.exts.object
     next unless prereq.start_with?(build_dir)
     next if mrbc_build_dir && prereq.start_with?(mrbc_build_dir)
-    pps << prereq.ext(build.exts.preprocessed)
+    pps << prereq.ext(build.exts.presym_preprocessed)
   end
 
   file presym.list_path => pps do


### PR DESCRIPTION
This is because compiler's `-save-temps=obj` option creates `.i` with the
same name.