### PR TITLE
Split `presym_table` for reduced program size

### DIFF
--- a/include/mruby/presym/enable.h
+++ b/include/mruby/presym/enable.h
@@ -7,16 +7,7 @@
 #ifndef MRUBY_PRESYM_ENABLE_H
 #define MRUBY_PRESYM_ENABLE_H
 
-#undef MRB_PRESYM_MAX
-#define MRB_PRESYM_NAMED(lit, num, type, name) MRB_##type##__##name = (num),
-#define MRB_PRESYM_UNNAMED(lit, num)
-
-enum mruby_presym {
-# include <mruby/presym.inc>
-};
-
-#undef MRB_PRESYM_NAMED
-#undef MRB_PRESYM_UNNAMED
+#include <mruby/presym/id.h>
 
 #define MRB_OPSYM(name) MRB_OPSYM__##name
 #define MRB_CVSYM(name) MRB_CVSYM__##name

--- a/src/symbol.c
+++ b/src/symbol.c
@@ -15,31 +15,24 @@
 
 #ifndef MRB_NO_PRESYM
 
-# undef MRB_PRESYM_MAX
-# define MRB_PRESYM_NAMED(lit, num, type, name) {lit, sizeof(lit)-1},
-# define MRB_PRESYM_UNNAMED(lit, num) {lit, sizeof(lit)-1},
-
-static const struct {
-  const char *name;
-  uint16_t len;
-} presym_table[] = {
 #ifndef MRB_PRESYM_SCANNING
-# include <mruby/presym.inc>
+/* const uint16_t presym_length_table[]   */
+/* const char * const presym_name_table[] */
+# include <mruby/presym/table.h>
 #endif
-};
 
 static mrb_sym
 presym_find(const char *name, size_t len)
 {
-  if (presym_table[MRB_PRESYM_MAX-1].len < len) return 0;
+  if (presym_length_table[MRB_PRESYM_MAX-1] < len) return 0;
 
   mrb_sym start, idx, presym_size = MRB_PRESYM_MAX;
   int cmp;
   for (start = 0; presym_size != 0; presym_size/=2) {
     idx = start+presym_size/2;
-    cmp = (int)len-(int)presym_table[idx].len;
+    cmp = (int)len-(int)presym_length_table[idx];
     if (cmp == 0) {
-      cmp = memcmp(name, presym_table[idx].name, len);
+      cmp = memcmp(name, presym_name_table[idx], len);
       if (cmp == 0) return idx+1;
     }
     if (0 < cmp) {
@@ -54,8 +47,8 @@ static const char*
 presym_sym2name(mrb_sym sym, mrb_int *lenp)
 {
   if (sym > MRB_PRESYM_MAX) return NULL;
-  if (lenp) *lenp = presym_table[sym-1].len;
-  return presym_table[sym-1].name;
+  if (lenp) *lenp = presym_length_table[sym-1];
+  return presym_name_table[sym-1];
 }
 
 #endif  /* MRB_NO_PRESYM */

--- a/tasks/presym.rake
+++ b/tasks/presym.rake
@@ -33,7 +33,11 @@ MRuby.each_target do |build|
     current_presyms = presym.read_list if File.exist?(presym.list_path)
     update = presyms != current_presyms
     presym.write_list(presyms) if update
-    presym.write_header(presyms) if update || !File.exist?(presym.header_path)
+    mkdir_p presym.header_dir
+    %w[id table].each do |type|
+      next if !update && File.exist?(presym.send("#{type}_header_path"))
+      presym.send("write_#{type}_header", presyms)
+    end
   end
 
   gensym_task.enhance([presym.list_path])


### PR DESCRIPTION
Because a structure that is an element of `presym_table` has padding, split
it into individual arrays for name and length.

#### Result (64-bit CPU with full-core gembox)

|        |   mruby    | libmruby.a |
|--------|------------|------------|
| Before | 1,087,444B | 1,476,872B |
| After  | 1,079,340B | 1,469,784B |