### PR TITLE
Refine `preprocess_options`; ref d95ffb036

### DIFF
--- a/build_config/default.rb
+++ b/build_config/default.rb
@@ -24,7 +24,7 @@ MRuby::Build.new do |conf|
   #   cc.defines = %w()
   #   cc.option_include_path = %q[-I"%s"]
   #   cc.option_define = '-D%s'
-  #   cc.compile_options = %Q[%{flags} -MMD -o "%{outfile}" -c "%{infile}"]
+  #   cc.compile_options = %Q[%{flags} -MMD -MF "%{outfile}".d -o "%{outfile}" -c "%{infile}"]
   # end
 
   # mrbc settings

--- a/lib/mruby/build/command.rb
+++ b/lib/mruby/build/command.rb
@@ -92,7 +92,7 @@ module MRuby
         opts = compile_options
       else
         label = "CPP"
-        opts = preprocess_options.gsub(/-MMD -MF .* -o/, "-o")
+        opts = preprocess_options
         flags << " -DMRB_PRESYM_SCANNING"
       end
       _pp label, infile.relative_path, outfile.relative_path

--- a/tasks/toolchains/gcc.rake
+++ b/tasks/toolchains/gcc.rake
@@ -3,7 +3,7 @@ MRuby::Toolchain.new(:gcc) do |conf, params|
   compiler_flags = %w(-g -O3 -Wall -Wundef)
   c_mandatory_flags = %w(-std=gnu99)
   cxx_invalid_flags = %w(-Werror-implicit-function-declaration)
-  compile_opt = '%{flags} -MMD -MF "%{outfile}.d" -o "%{outfile}" "%{infile}"'
+  compile_opt = '%{flags} -o "%{outfile}" "%{infile}"'
 
   [conf.cc, conf.objc, conf.asm, conf.cxx].each do |compiler|
     if compiler == conf.cxx
@@ -15,7 +15,7 @@ MRuby::Toolchain.new(:gcc) do |conf, params|
     end
     compiler.option_include_path = %q[-I"%s"]
     compiler.option_define = '-D%s'
-    compiler.compile_options = "-c #{compile_opt}"
+    compiler.compile_options = %|-MMD -MF "%{outfile}.d" -c #{compile_opt}|
     compiler.preprocess_options = "-E -P #{compile_opt}"
     compiler.cxx_compile_flag = '-x c++ -std=gnu++03'
     compiler.cxx_exception_flag = '-fexceptions'

--- a/tasks/toolchains/openwrt.rake
+++ b/tasks/toolchains/openwrt.rake
@@ -11,7 +11,8 @@ MRuby::Toolchain.new(:openwrt) do |conf|
     end
     cc.option_include_path = %q[-I"%s"]
     cc.option_define = '-D%s'
-    cc.compile_options = %q[%{flags} -MMD -MF "%{outfile}.d" -o "%{outfile}" -c "%{infile}"]
+    cc.compile_options = '%{flags} -MMD -MF "%{outfile}.d" -o "%{outfile}" -c "%{infile}"'
+    cc.preprocess_options = '%{flags} -o "%{outfile}" -E -P "%{infile}"'
   end
 
   conf.linker do |linker|


### PR DESCRIPTION
If we modify an option that may have been specified by users, we may
make unintended changes, so it is better not to modify it as much as
possible, IMO.