### PR TITLE
Check first `0` when converting symbols into strings

### DIFF
--- a/src/symbol.c
+++ b/src/symbol.c
@@ -303,6 +303,7 @@ mrb_check_intern_str(mrb_state *mrb, mrb_value str)
 static const char*
 sym2name_len(mrb_state *mrb, mrb_sym sym, char *buf, mrb_int *lenp)
 {
+  if (sym == 0) goto outofsym;
   if (SYMBOL_INLINE_P(sym)) return sym_inline_unpack(sym, buf, lenp);
 
 #ifndef MRB_NO_PRESYM
@@ -313,7 +314,8 @@ sym2name_len(mrb_state *mrb, mrb_sym sym, char *buf, mrb_int *lenp)
 #endif
   sym -= MRB_PRESYM_MAX;
 
-  if (sym == 0 || mrb->symidx < sym) {
+  if (mrb->symidx < sym) {
+  outofsym:
     if (lenp) *lenp = 0;
     return NULL;
   }


### PR DESCRIPTION
This was because it caused `SIGSEGV` when `mruby -v` displayed an unnamed variable.

```console
% bin/mruby -ve 'call { |(a, b)| }'

  ...SNIP...

irep 0x8007d0050 nregs=3 nlocals=1 pools=0 syms=1 reps=1 iseq=12
file: -e
    1 000 OP_LOADSELF   R1
    1 002 OP_BLOCK      R2      I(0:0x8007d00a0)
    1 005 OP_SENDB      R1      :call   0
    1 009 OP_RETURN     R1
    1 011 OP_STOP

irep 0x8007d00a0 nregs=6 nlocals=5 pools=0 syms=0 reps=0 iseq=29
local variable names:
zsh: segmentation fault (core dumped)  bin/mruby -ve 'call { |(a, b)| }'
```