### PR TITLE
Build internal mrbc in an internal directory

### DIFF
--- a/lib/mruby/build.rb
+++ b/lib/mruby/build.rb
@@ -483,6 +483,7 @@ EOS
       name = "#{@name}/mrbc"
       MRuby.targets.delete(name)
       build = self.class.new(name, internal: true){}
+      build.build_dir = "#{@build_dir}/mrbc"
       instance_variables.each do |n|
         next if exclusions.include?(n)
         v = instance_variable_get(n)


### PR DESCRIPTION
I would be glad if it was created under the host's build directory.

  - `my_config.rb`

    ```ruby
    MRuby::Build.new("host", "build/to/custom/directory") do |conf|
      conf.toolchain "clang"
      conf.build_dir = "build/to/another/directory"
    end
    ```

  - current (output directory is `build/host/mrbc`)

    ```console
    % rake MRUBY_CONFIG=my_config.rb

    Build summary:

    ================================================
          Config Name: host
     Output Directory: build/to/another/directory
    ================================================

    ================================================
          Config Name: host/mrbc
     Output Directory: build/host/mrbc
             Binaries: mrbc
        Included Gems:
                 mruby-bin-mrbc - mruby compiler executable
                 mruby-compiler - mruby compiler library
    ================================================
    ```

  - this PR (output directory is `build/to/another/directory/mrbc`)

    ```console
    % rake MRUBY_CONFIG=my_config.rb

    Build summary:

    ================================================
          Config Name: host
     Output Directory: build/to/another/directory
    ================================================

    ================================================
          Config Name: host/mrbc
     Output Directory: build/to/another/directory/mrbc
             Binaries: mrbc
        Included Gems:
                 mruby-bin-mrbc - mruby compiler executable
                 mruby-compiler - mruby compiler library
    ================================================
    ```
