### PR TITLE
Introduced `MRB_PRESYM_INIT_SYMBOLS()`

### DIFF
--- a/include/mruby/presym/disable.h
+++ b/include/mruby/presym/disable.h
@@ -60,9 +60,11 @@
 
 #define MRB_PRESYM_DEFINE_VAR_AND_INITER(name, size, ...)                     \
   static mrb_sym name[size];                                                  \
-  static void init_##name(mrb_state *mrb) {                                   \
+  static void presym_init_##name(mrb_state *mrb) {                            \
     mrb_sym name__[] = {__VA_ARGS__};                                         \
     memcpy(name, name__, sizeof(name));                                       \
   }
+
+#define MRB_PRESYM_INIT_SYMBOLS(mrb, name) presym_init_##name(mrb)
 
 #endif  /* MRUBY_PRESYM_DISABLE_H */

--- a/include/mruby/presym/enable.h
+++ b/include/mruby/presym/enable.h
@@ -26,8 +26,9 @@
 #define MRB_SYM_2(mrb, name) MRB_SYM__##name
 
 #define MRB_PRESYM_DEFINE_VAR_AND_INITER(name, size, ...)                     \
-  static const mrb_sym name[] = {__VA_ARGS__};                                \
-  static void init_##name(mrb_state *mrb) {}
+  static const mrb_sym name[] = {__VA_ARGS__};
+
+#define MRB_PRESYM_INIT_SYMBOLS(mrb, name) (void)(mrb)
 
 /* use MRB_SYM() for E_RUNTIME_ERROR etc. */
 #undef MRB_ERROR_SYM

--- a/src/class.c
+++ b/src/class.c
@@ -2817,7 +2817,7 @@ init_class_new(mrb_state *mrb, struct RClass *cls)
   struct RProc *p;
   mrb_method_t m;
 
-  init_new_syms(mrb);
+  MRB_PRESYM_INIT_SYMBOLS(mrb, new_syms);
   p = mrb_proc_new(mrb, &new_irep);
   MRB_METHOD_FROM_PROC(m, p);
   mrb_define_method_raw(mrb, cls, MRB_SYM(new), m);


### PR DESCRIPTION
The `init_SYMBOLS()` function implicitly defined in `MRB_PRESYM_DEFINE_VAR_AND_INITER()` requires some familiarity when trying to find it from the caller.
By introducing `MRB_PRESYM_INIT_SYMBOLS()`, it is possible to find directly from the identifier.