### PR TITLE
Fix breakage where builds except `host` don't refer` mrbc` in `host`

### DIFF
--- a/lib/mruby/build.rb
+++ b/lib/mruby/build.rb
@@ -320,12 +320,16 @@ EOS
       return @mrbcfile if @mrbcfile
 
       gem_name = "mruby-bin-mrbc"
-      gem = @gems[gem_name]
-      gem ||= (host = MRuby.targets["host"]) && host.gems[gem_name]
-      unless gem
-        fail "external mrbc or mruby-bin-mrbc gem in current('#{@name}') or 'host' build is required"
+      if (gem = @gems[gem_name])
+        @mrbcfile = exefile("#{gem.build.build_dir}/bin/mrbc")
+      elsif !host? && (host = MRuby.targets["host"])
+        if (gem = host.gems[gem_name])
+          @mrbcfile = exefile("#{gem.build.build_dir}/bin/mrbc")
+        elsif host.mrbcfile_external?
+          @mrbcfile = host.mrbcfile
+        end
       end
-      @mrbcfile = exefile("#{gem.build.build_dir}/bin/mrbc")
+      @mrbcfile || fail("external mrbc or mruby-bin-mrbc gem in current('#{@name}') or 'host' build is required")
     end
 
     def mrbcfile=(path)


### PR DESCRIPTION
Build error occurred under the following conditions.

* `host` build is presym enabled and unspecified `mruby-bin-mrbc` gem.
* Build except `host` unspecified `mruby-bin-mrbc` gem and mrbcfile.

### Example

#### Build configuration

```ruby
MRuby::Build.new{|conf| conf.toolchain}
MRuby::Build.new("host2"){|conf| conf.toolchain}
```

#### Error

```console
rake aborted!
external mrbc or mruby-bin-mrbc gem in current('host2') or 'host' build is required
/mruby/lib/mruby/build.rb:326:in `mrbcfile'
/mruby/tasks/mrblib.rake:9:in `block in <top (required)>'
/mruby/lib/mruby/build.rb:18:in `instance_eval'
/mruby/lib/mruby/build.rb:18:in `block in each_target'
/mruby/lib/mruby/build.rb:17:in `each'
/mruby/lib/mruby/build.rb:17:in `each_target'
/mruby/tasks/mrblib.rake:1:in `<top (required)>'
/mruby/Rakefile:27:in `load'
/mruby/Rakefile:27:in `<top (required)>'
```