### PR TITLE
Check if `.pi` build rules are defined

### DIFF
--- a/tasks/presym.rake
+++ b/tasks/presym.rake
@@ -17,7 +17,7 @@ MRuby.each_target do |build|
   build.gems.each{|gem| gem.compilers.each{|c| c.include_paths << include_dir}}
 
   prereqs = {}
-  pps = []
+  ppps = []
   build_dir = "#{build.build_dir}/"
   mrbc_build_dir = "#{build.mrbc_build.build_dir}/" if build.mrbc_build
   build.products.each{|product| all_prerequisites.(product, prereqs)}
@@ -25,11 +25,15 @@ MRuby.each_target do |build|
     next unless File.extname(prereq) == build.exts.object
     next unless prereq.start_with?(build_dir)
     next if mrbc_build_dir && prereq.start_with?(mrbc_build_dir)
-    pps << prereq.ext(build.exts.presym_preprocessed)
+    ppp = prereq.ext(build.exts.presym_preprocessed)
+    if Rake.application.lookup(ppp) ||
+       Rake.application.enhance_with_matching_rule(ppp)
+      ppps << ppp
+    end
   end
 
-  file presym.list_path => pps do
-    presyms = presym.scan(pps)
+  file presym.list_path => ppps do
+    presyms = presym.scan(ppps)
     current_presyms = presym.read_list if File.exist?(presym.list_path)
     update = presyms != current_presyms
     presym.write_list(presyms) if update


### PR DESCRIPTION
`.pi` files are created for `.o` files that `build.products` depends on, but
an error will occur if the build rule is unknown, so add a check.

I don't think this situation would normally arise. However, in
`mattn/mruby-onig-regexp`, when using bundled onigmo, onigmo's `.o` files
are added to dependency of `libmruby.a` in the second and subsequent builds,
and mruby does not know the build rule, so the following error had occured.

```console
rake aborted!
Don't know how to build task '/mruby/build/host/mrbgems/mruby-onig-regexp/onigmo-6.2.0/libonig_objs/ascii.pi' (See the list of available tasks with `rake --tasks`)
```