### PR TITLE
Fix message of `ThrowCatchJump` in `mruby-catch` gem

### DIFF
--- a/mrbgems/mruby-catch/mrblib/catch.rb
+++ b/mrbgems/mruby-catch/mrblib/catch.rb
@@ -2,7 +2,7 @@ class ThrowCatchJump < Exception
   def initialize(tag, val)
     @tag = tag
     @val = val
-    super("uncaught throw :#{tag}")
+    super("uncaught throw #{tag.inspect}")
   end
   def _tag
     @tag


### PR DESCRIPTION
### Example

```ruby
begin
  throw 1
rescue Exception => e
  puts e.message
end
```

#### Before this patch:

```console
$ bin/mruby example.rb
uncaught throw :1
```
#### After this patch (same as Ruby):

```console
$ bin/mruby example.rb
uncaught throw 1
```