### PR TITLE
Exclude `<build-dir>/mrbc/**/*` from rake target rules

### DIFF
--- a/lib/mruby/build/command.rb
+++ b/lib/mruby/build/command.rb
@@ -104,9 +104,9 @@ module MRuby
       rakedep = File.exist?(gemrake) ? [ gemrake ] : []
 
       if build_dir.include? "mrbgems/"
-        generated_file_matcher = Regexp.new("^#{Regexp.escape build_dir}/(.*)#{Regexp.escape out_ext}$")
+        generated_file_matcher = Regexp.new("^#{Regexp.escape build_dir}/(?!mrbc/)(.*)#{Regexp.escape out_ext}$")
       else
-        generated_file_matcher = Regexp.new("^#{Regexp.escape build_dir}/(?!mrbgems/.+/)(.*)#{Regexp.escape out_ext}$")
+        generated_file_matcher = Regexp.new("^#{Regexp.escape build_dir}/(?!mrbc/|mrbgems/.+/)(.*)#{Regexp.escape out_ext}$")
       end
       source_exts.each do |ext, compile|
         rule generated_file_matcher => [


### PR DESCRIPTION
Prevents the auto-generated mrbc target source code from being compiled under host conditions.

This is because a build error occurred when `conf.enable_cxx_exception` was set.