### PR TITLE
`compile_as_cxx` should generate a path under` conf.build_dir`

### DIFF
--- a/lib/mruby/build.rb
+++ b/lib/mruby/build.rb
@@ -248,7 +248,7 @@ module MRuby
           end
         end
       else
-        cxx_src = "#{build_dir}/#{src.relative_path})".ext << "-cxx.cxx"
+        cxx_src = "#{build_dir}/#{src.relative_path.to_s.remove_leading_parents}".ext << "-cxx.cxx"
         obj = cxx_src.ext(@exts.object)
       end
 

--- a/lib/mruby/core_ext.rb
+++ b/lib/mruby/core_ext.rb
@@ -18,6 +18,10 @@ class String
   def relative_path
     relative_path_from(Dir.pwd)
   end
+
+  def remove_leading_parents
+    Pathname.new(".#{Pathname.new("/#{self}").cleanpath}").cleanpath.to_s
+  end
 end
 
 def install_D(src, dst)


### PR DESCRIPTION
If the current directory is different from `MRUBY_ROOT` and it has` conf.build_dir` and `conf.enable_cxx_exception` set, it was generating a pathname outside of` build_dir`.
As a result, in some cases files unrelated to mruby could be linked.

```console
% pwd
/tmp/mruby/1/2/3/4/5/6

% mruby_dir=/tmp/mruby/a/b/c/d/mruby

% cat my_config.rb
MRuby::Build.new("host", "build/to/custom/directory") do
  toolchain
  enable_cxx_exception
end

% rake MRUBY_CONFIG=my_config.rb -f $mruby_dir/Rakefile > logs
% grep CXX logs
CXX   a/b/c/d/mruby/src/error-cxx.cxx -> a/b/c/d/mruby/src/error-cxx.o
CXX   a/b/c/d/mruby/src/gc-cxx.cxx -> a/b/c/d/mruby/src/gc-cxx.o
CXX   a/b/c/d/mruby/src/vm-cxx.cxx -> a/b/c/d/mruby/src/vm-cxx.o
CXX   a/b/c/d/mruby/mrbgems/mruby-compiler/core/codegen-cxx.cxx -> a/b/c/d/mruby/mrbgems/mruby-compiler/core/codegen-cxx.o
CXX   a/b/c/d/mruby/mrbgems/mruby-compiler/core/y.tab-cxx.cxx -> a/b/c/d/mruby/mrbgems/mruby-compiler/core/y.tab-cxx.o
CXX   ../a/b/c/d/mruby/src/error-cxx.cxx -> ../a/b/c/d/mruby/src/error-cxx.o
CXX   ../a/b/c/d/mruby/src/gc-cxx.cxx -> ../a/b/c/d/mruby/src/gc-cxx.o
CXX   ../a/b/c/d/mruby/src/vm-cxx.cxx -> ../a/b/c/d/mruby/src/vm-cxx.o
```