### PR TITLE
Ignore if `conf.enable_test` does not exist

### DIFF
--- a/tasks/test.rake
+++ b/tasks/test.rake
@@ -21,7 +21,8 @@ namespace :test do |test_ns|
     desc "build library tests"
     task :lib => :all do
       MRuby.each_target{|build| build.gem(core: 'mruby-test')}
-      test_build_ns["lib_without_loading_gem"].invoke
+      test = test_build_ns["lib_without_loading_gem"]
+      test.invoke if test
     end
   end
 


### PR DESCRIPTION
Because if the configuration file didn't contain any `conf.enable_test`, `rake test` would report an exception and exit.

```console
% cat my_config.rb
MRuby::Build.new { toolchain }

% rake MRUBY_CONFIG=my_config.rb test

  ...SNIP...

rake aborted!
NoMethodError: undefined method `invoke' for nil:NilClass
/var/tmp/mruby/tasks/test.rake:24:in `block (3 levels) in <top (required)>'
Tasks: TOP => test => test:build => test:build:lib
(See full trace by running task with --trace)
```