### PR TITLE
refactor: only use certified GitHub Actions to increase security

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,8 +8,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'  # Version range or exact version of a Python version to use, using SemVer's version range syntax
+          architecture: 'x64'  # optional x64 or x86. Defaults to x64 if not specified
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install yamllint
       - name: 🧹 YAML Lint
-        uses: ibiqlik/action-yamllint@v3
+        run: |
+          # return non-zero exit code on warnings
+          yamllint --strict .
   markdownlint:
     name: 🍸 Markdown
     runs-on: ubuntu-latest


### PR DESCRIPTION
Official -> "The individual jobs in a workflow can interact with (and compromise) other jobs. For example, a job querying the environment variables used by a later job, writing files to a shared directory that a later job processes, or even more directly by interacting with the Docker socket and inspecting other running containers and executing commands in them.

This means that a compromise of a single action within a workflow can be very significant, as that compromised action would have access to all secrets configured on your repository, and can use the GITHUB_TOKEN to write to the repository. Consequently, there is significant risk in sourcing actions from third-party repositories on GitHub. "

https://docs.github.com/en/actions/learn-github-actions/security-hardening-for-github-actions#using-third-party-actions