### PR TITLE
chore: fix spelling

### DIFF
--- a/doc/guides/mrbgems.md
+++ b/doc/guides/mrbgems.md
@@ -1,7 +1,7 @@
 # mrbgems
 
 mrbgems is a library manager to integrate C and Ruby extension in an easy and
-standardised way into mruby. Conventinally, each mrbgem name is prefixed by
+standardised way into mruby. Conventionally, each mrbgem name is prefixed by
 `mruby-`, e.g. `mruby-time` for a gem that provides `Time` class functionality.
 
 ## Usage
@@ -372,7 +372,7 @@ See C and Ruby example.
 ## Binary gems
 
 Some gems can generate executables under `bin` directory. Those gems are called
-binary gems.  Names of binary gems are conventinally prefixed by `mruby-bin`,
+binary gems.  Names of binary gems are conventionally prefixed by `mruby-bin`,
 e.g. `mruby-bin-mirb` and `mruby-bin-strip`.
 
 To specify the name of executable, you need to specify `spec.bins` in the

--- a/include/mruby/array.h
+++ b/include/mruby/array.h
@@ -107,7 +107,7 @@ MRB_API mrb_value mrb_ary_new(mrb_state *mrb);
  *      Array[value1, value2, ...]
  *
  * @param mrb The mruby state reference.
- * @param size The numer of values.
+ * @param size The number of values.
  * @param vals The actual values.
  * @return The initialized array.
  */

--- a/mrbgems/mruby-bin-debugger/bintest/print.rb
+++ b/mrbgems/mruby-bin-debugger/bintest/print.rb
@@ -264,7 +264,7 @@ SRC
   BinTest_MrubyBinDebugger.test(src, tc)
 end
 
-assert('mruby-bin-debugger(print) same name:instance variabe') do
+assert('mruby-bin-debugger(print) same name:instance variable') do
   # ruby source (bp is break point)
   src = <<"SRC"
 @iv = 'top'
@@ -296,7 +296,7 @@ SRC
   BinTest_MrubyBinDebugger.test(src, tc)
 end
 
-# Kernel#instance_eval(string) does't work const.
+# Kernel#instance_eval(string) doesn't work const.
 =begin
 assert('mruby-bin-debugger(print) same name:const') do
   # ruby source (bp is break point)

--- a/mrbgems/mruby-cmath/mrbgem.rake
+++ b/mrbgems/mruby-cmath/mrbgem.rake
@@ -1,5 +1,5 @@
 # This `mruby-cmath` gem uses C99 _Complex features
-# You need C compler that support C99+
+# You need C compiler that support C99+
 MRuby::Gem::Specification.new('mruby-cmath') do |spec|
   spec.license = 'MIT'
   spec.author  = 'mruby developers'

--- a/mrbgems/mruby-cmath/src/cmath.c
+++ b/mrbgems/mruby-cmath/src/cmath.c
@@ -6,7 +6,7 @@
 
 /*
 ** This `mruby-cmath` gem uses C99 _Complex features
-** You need C compler that support C99+
+** You need C compiler that support C99+
 */
 
 #include <mruby.h>

--- a/mrbgems/mruby-compiler/core/parse.y
+++ b/mrbgems/mruby-compiler/core/parse.y
@@ -1450,7 +1450,7 @@ heredoc_end(parser_state *p)
 %token <nd>  tSTRING tSTRING_PART tSTRING_MID
 %token <nd>  tNTH_REF tBACK_REF
 %token <num> tREGEXP_END
-%token <num> tNUMPARAM "numbered paraemeter"
+%token <num> tNUMPARAM "numbered parameter"
 
 %type <nd> singleton string string_fragment string_rep string_interp xstring regexp
 %type <nd> literal numeric cpath symbol defn_head defs_head

--- a/mrbgems/mruby-compiler/core/y.tab.c
+++ b/mrbgems/mruby-compiler/core/y.tab.c
@@ -2085,7 +2085,7 @@ static const char *const yytname[] =
   "\"constant\"", "\"class variable\"", "\"label\"", "\"integer literal\"",
   "\"float literal\"", "\"character literal\"", "tXSTRING", "tREGEXP",
   "tSTRING", "tSTRING_PART", "tSTRING_MID", "tNTH_REF", "tBACK_REF",
-  "tREGEXP_END", "\"numbered paraemeter\"", "\"unary plus\"",
+  "tREGEXP_END", "\"numbered parameter\"", "\"unary plus\"",
   "\"unary minus\"", "\"<=>\"", "\"==\"", "\"===\"", "\"!=\"", "\">=\"",
   "\"<=\"", "\"&&\"", "\"||\"", "\"=~\"", "\"!~\"", "\"..\"", "\"...\"",
   "tBDOT2", "tBDOT3", "tAREF", "tASET", "\"<<\"", "\">>\"", "\"::\"",


### PR DESCRIPTION
Normally a single spell checker can't find all the mistakes or check all types of code.

These mistakes were found by another spell checker inside my editor with a more manual sift / find.