### PR TITLE
Introduce EditorConfig [skip ci]

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,43 @@
+# About this file, see:
+#   Website: https://editorconfig.org/
+#   For Emacs users: https://github.com/editorconfig/editorconfig-emacs
+#   For Vim users: https://github.com/editorconfig/editorconfig-vim
+
+root = true
+
+[*]
+indent_style = tab
+indent_size = 8
+tab_width = 8
+end_of_line = lf
+charset = utf-8
+insert_final_newline = true
+
+[{Makefile,Makefile.*,makefile,*.mk}]
+trim_trailing_whitespace = true
+#max_line_length = 80
+
+[*.{c,cc,C,cxx,cpp,h,hh,H,hxx,hpp,inc,y}]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+#max_line_length = 120
+
+[{*.rb,Rakefile,rakefile,*.rake,*.gemspec,*.gembox}]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+#max_line_length = 120
+
+[*.bat]
+end_of_line = crlf
+charset = latin1
+#max_line_length = 80
+
+[*.{yaml,yml}]
+indent_style = space
+indent_size = 2
+
+[*.md]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
Helps keep the text file format consistent.
Multiple text editors and IDEs support it, and there may be plugins even if it is not supported.
https://editorconfig.org/

There should be various opinions about the number of characters per line, so I intentionally commented it out.
Anyway, 80 characters is painful.

The intention is not to force the use of the corresponding editor.
I just hope to help anyone using a compatible editor.

I have a plugin installed and used on Vim.
