### PR TITLE
Skip --depth=1 when it's locked

### DIFF
--- a/lib/mruby/build/load_gems.rb
+++ b/lib/mruby/build/load_gems.rb
@@ -100,7 +100,7 @@ module MRuby
           options = [params[:options]] || []
           options << "--recursive"
           options << "--branch \"#{branch}\""
-          options << "--depth 1" unless params[:checksum_hash]
+          options << "--depth 1" unless params[:checksum_hash] || lock
           mkdir_p "#{gem_clone_dir}"
           git.run_clone gemdir, url, options
 


### PR DESCRIPTION
## Problem
When your build_config.rb.lock has a lock entry whose commit is older than the latest commit in the branch like this,

```
    https://github.com/ksss/mruby-file-stat.git:
      url: https://github.com/ksss/mruby-file-stat.git
      branch: master
      commit: 66cf135ff9642d96a6127a79b307f6314e606deb
      version: 0.0.0
```

it results in:

```
GIT   https://github.com/ksss/mruby-file-stat.git -> build/repos/host/mruby-file-stat
Cloning into '/home/mruby/code/mruby/build/repos/host/mruby-file-stat'...
GIT CHECKOUT DETACH /home/runner/work/mitamae/mitamae/mruby/build/repos/host/mruby-file-stat -> 66cf135ff9642d96a6127a79b307f6314e606deb
fatal: reference is not a tree: 66cf135ff9642d96a6127a79b307f6314e606deb
fatal: reference is not a tree: 66cf135ff9642d96a6127a79b307f6314e606deb
rake aborted!
```

## Solution
Do not use `--depth 1` for `git clone` when it's locked to a specific commit.