### PR TITLE
Comment out `warn` used in the `Array#fetch` method

### DIFF
--- a/mrbgems/mruby-array-ext/mrblib/array.rb
+++ b/mrbgems/mruby-array-ext/mrblib/array.rb
@@ -325,7 +325,7 @@ class Array
   #
 
   def fetch(n, ifnone=NONE, &block)
-    warn "block supersedes default value argument" if !n.nil? && ifnone != NONE && block
+    #warn "block supersedes default value argument" if !n.nil? && ifnone != NONE && block
 
     idx = n
     if idx < 0


### PR DESCRIPTION
I get an error because the current mruby does not have a `Kernel#warn` method.
But the warning itself is useful and I'll just comment it out in case it's implemented in the future.