### PR TITLE
Specify tasks as dependencies rather then manual invocation

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -39,7 +39,8 @@ load "#{MRUBY_ROOT}/tasks/doc.rake"
 task :default => :all
 
 desc "build all targets, install (locally) in-repo"
-task :all => %w[gensym build] do
+task :all => :gensym do |t|
+  Rake::Task[t.scope.path_with_task_name('build')].invoke
   puts
   puts "Build summary:"
   puts

--- a/Rakefile
+++ b/Rakefile
@@ -39,8 +39,7 @@ load "#{MRUBY_ROOT}/tasks/doc.rake"
 task :default => :all
 
 desc "build all targets, install (locally) in-repo"
-task :all => :gensym do
-  Rake::Task[:build].invoke
+task :all => %w[gensym build] do
   puts
   puts "Build summary:"
   puts

--- a/tasks/test.rake
+++ b/tasks/test.rake
@@ -1,7 +1,5 @@
 desc "build and run all mruby tests"
-task :test => "test:build" do
-  Rake::Task["test:run"].invoke
-end
+task :test => %w[test:build test:run]
 
 namespace :test do |test_ns|
   desc "build and run library tests"

--- a/tasks/test.rake
+++ b/tasks/test.rake
@@ -1,5 +1,7 @@
 desc "build and run all mruby tests"
-task :test => %w[test:build test:run]
+task :test => "test:build" do |t|
+  Rake::Task[t.scope.path_with_task_name('test:run')].invoke
+end
 
 namespace :test do |test_ns|
   desc "build and run library tests"


### PR DESCRIPTION
Fixes failures when you wrapped all mruby tasks under a namespace