### PR TITLE
Support libedit on mirb for FreeBSD

### DIFF
--- a/mrbgems/mruby-bin-mirb/mrbgem.rake
+++ b/mrbgems/mruby-bin-mirb/mrbgem.rake
@@ -5,6 +5,8 @@ MRuby::Gem::Specification.new('mruby-bin-mirb') do |spec|
 
   if spec.build.cc.search_header_path 'readline/readline.h'
     spec.cc.defines << "MRB_USE_READLINE"
+    spec.cc.defines << "MRB_READLINE_HEADER='<readline/readline.h>'"
+    spec.cc.defines << "MRB_READLINE_HISTORY='<readline/history.h>'"
     if spec.build.cc.search_header_path 'termcap.h'
       if MRUBY_BUILD_HOST_IS_CYGWIN || MRUBY_BUILD_HOST_IS_OPENBSD
         if spec.build.cc.search_header_path 'termcap.h'
@@ -33,6 +35,11 @@ MRuby::Gem::Specification.new('mruby-bin-mirb') do |spec|
         spec.linker.libraries << 'ncurses'
       end
     end
+  elsif spec.build.cc.search_header_path 'edit/readline/readline.h'
+    spec.cc.defines << "MRB_USE_READLINE"
+    spec.cc.defines << "MRB_READLINE_HEADER='<edit/readline/readline.h>'"
+    spec.cc.defines << "MRB_READLINE_HISTORY='<edit/readline/history.h>'"
+    spec.linker.libraries << "edit"
   elsif spec.build.cc.search_header_path 'linenoise.h'
     spec.cc.defines << "MRB_USE_LINENOISE"
   end

--- a/mrbgems/mruby-bin-mirb/tools/mirb/mirb.c
+++ b/mrbgems/mruby-bin-mirb/tools/mirb/mirb.c
@@ -39,8 +39,8 @@
 #endif
 
 #ifdef MRB_USE_READLINE
-#include <readline/readline.h>
-#include <readline/history.h>
+#include MRB_READLINE_HEADER
+#include MRB_READLINE_HISTORY
 #define MIRB_ADD_HISTORY(line) add_history(line)
 #define MIRB_READLINE(ch) readline(ch)
 #if !defined(RL_READLINE_VERSION) || RL_READLINE_VERSION < 0x600


### PR DESCRIPTION
Since FreeBSD 11, which came out over four years ago, "readline" has been removed from the base system.
I thought it was strange...
