### PR TITLE
bug(presym): Fix mrb_cmp declaration of <=> symbol for funcall

### DIFF
--- a/src/numeric.c
+++ b/src/numeric.c
@@ -1578,7 +1578,7 @@ mrb_cmp(mrb_state *mrb, mrb_value obj1, mrb_value obj2)
       return -2;
     return mrb_str_cmp(mrb, obj1, obj2);
   default:
-    v = mrb_funcall_id(mrb, obj1, MRB_SYM(cmp), 1, obj2);
+    v = mrb_funcall_id(mrb, obj1, MRB_OPSYM(cmp), 1, obj2);
     if (mrb_nil_p(v) || !mrb_integer_p(v))
       return -2;
     return mrb_integer(v);


### PR DESCRIPTION
`mrb_cmp` uses `MRB_SYM` macro for `cmp` token, which uses the literal symbol `:cmp`. It should be using `MRB_OPSYM(cmp)` to use `:<=>`.

## Before

```
$ rake
$ ./bin/mirb
mirb - Embeddable Interactive Ruby Shell

> class A; include Comparable; def <=>(other); 1; end; end
 => :<=>
> A.new..A.new
undefined method 'cmp' (NoMethodError)
```

## After

```
$ rake
$ ./bin/mirb
mirb - Embeddable Interactive Ruby Shell

> class A; include Comparable; def <=>(other); 1; end; end
 => :<=>
> A.new..A.new
 => #<A:0x7fcb3000cbc0>..#<A:0x7fcb3000cb60>
```