### PR TITLE
chore: upgrade markdownlint GitHub Action node version to 14

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,8 +11,8 @@ jobs:
       - name: 🚀 Use Node.js
         uses: actions/setup-node@v2.1.5
         with:
-          node-version: '12.x'
-      - run: npm install -g markdownlint-cli@0.25.0
+          node-version: '14'
+      - run: npm install -g markdownlint-cli@0.27.1
       - run: markdownlint '**/*.md'
   misspell:
     name: 🥛 Check Spelling


### PR DESCRIPTION
Upgrade to  markdownlint-cli version 0.27.1