### PR TITLE
Allow `break` in `build_config`.

### DIFF
--- a/lib/mruby/build.rb
+++ b/lib/mruby/build.rb
@@ -131,15 +131,22 @@ module MRuby
       end
 
       MRuby::Build.current = current
-      current.instance_eval(&block)
-      if current.libmruby_enabled? && !current.mrbcfile_external?
-        if current.presym_enabled?
-          current.create_mrbc_build if current.host? || current.gems["mruby-bin-mrbc"]
-        elsif current.host?
-          current.build_mrbc_exec
+      begin
+        current.instance_eval(&block)
+      rescue Exception => err
+        raise
+      ensure
+        unless err
+          if current.libmruby_enabled? && !current.mrbcfile_external?
+            if current.presym_enabled?
+              current.create_mrbc_build if current.host? || current.gems["mruby-bin-mrbc"]
+            elsif current.host?
+              current.build_mrbc_exec
+            end
+          end
+          current.presym = Presym.new(current) if current.presym_enabled?
         end
       end
-      current.presym = Presym.new(current) if current.presym_enabled?
     end
 
     def libmruby_enabled?


### PR DESCRIPTION
If I break out of a block given to `MRuby::Build.new` with `break` or `throw`, I will get a seemingly inexplicable error because the `presym`-related initialization is not done.

```console
% cat build_config1.rb
MRuby::Build.new do
  toolchain
  break
end

% rake CONFIG=build_config1.rb
rake aborted!
external mrbc or mruby-bin-mrbc gem in current('host') or 'host' build is required
/var/tmp/mruby/lib/mruby/build.rb:332:in `mrbcfile'
/var/tmp/mruby/tasks/mrblib.rake:9:in `block in <top (required)>'
/var/tmp/mruby/lib/mruby/build.rb:18:in `instance_eval'
/var/tmp/mruby/lib/mruby/build.rb:18:in `block in each_target'
/var/tmp/mruby/lib/mruby/build.rb:17:in `each'
/var/tmp/mruby/lib/mruby/build.rb:17:in `each_target'
/var/tmp/mruby/tasks/mrblib.rake:1:in `<top (required)>'
/var/tmp/mruby/Rakefile:27:in `load'
/var/tmp/mruby/Rakefile:27:in `<top (required)>'
(See full trace by running task with --trace)
```

If a non-exceptional global jump occurs, it can be initialized by `ensure` to solve this problem.