### PR TITLE
Add configuration for MinGW cross compilation [ci skip]

### DIFF
--- a/build_config/cross-mingw.rb
+++ b/build_config/cross-mingw.rb
@@ -1,0 +1,14 @@
+#
+# Ubuntu 20.04 requires at least `gcc-mingw-w64-x86-64` package as a
+# cross compiler.
+#
+
+MRuby::CrossBuild.new("cross-mingw") do |conf|
+  conf.toolchain :gcc
+  conf.host_target = "x86_64-w64-mingw32"  # required for `for_windows?` used by `mruby-socket` gem
+  conf.cc.command = "#{conf.host_target}-gcc-posix"
+  conf.linker.command = conf.cc.command
+  conf.archiver.command = "#{conf.host_target}-gcc-ar"
+  conf.exts.executable = ".exe"
+  conf.gembox "default"
+end


### PR DESCRIPTION
With this cross compiler configuration, all tests for full-core gembox on
Windows on GitHub Actions were successful.