### PR TITLE
Add support for partial backtraces

### DIFF
--- a/mrbgems/mruby-kernel-ext/test/kernel.rb
+++ b/mrbgems/mruby-kernel-ext/test/kernel.rb
@@ -20,6 +20,9 @@ assert('Kernel.caller, Kernel#caller') do
       bar(*args)
     end
   end
+
+  skip "backtrace isn't available" if(c.new.baz(0)[0].include?("unknown"))
+
   assert_equal "kernel.rb:#{caller_lineno}:in foo", c.new.baz(0)[0][-19..-1]
   assert_equal "bar", c.new.baz[0][-3..-1]
   assert_equal "foo", c.new.baz(0)[0][-3..-1]

--- a/mrbgems/mruby-proc-ext/test/proc.rb
+++ b/mrbgems/mruby-proc-ext/test/proc.rb
@@ -7,6 +7,9 @@ def enable_debug_info?
     raise
   rescue => e
     @enable_debug_info = !e.backtrace.empty?
+    if(@enable_debug_info && e.backtrace[0].include?("(unknown)"))
+       @enable_debug_info = false
+    end
   end
 end
 

--- a/src/backtrace.c
+++ b/src/backtrace.c
@@ -61,7 +61,6 @@ each_backtrace(mrb_state *mrb, ptrdiff_t ciidx, each_backtrace_func func, void *
 
     idx = (uint32_t)(pc - irep->iseq);
     loc.lineno = mrb_debug_get_line(mrb, irep, idx);
-    if (loc.lineno == -1) continue;
 
     loc.filename = mrb_debug_get_filename(mrb, irep, idx);
     if (!loc.filename) {
@@ -202,7 +201,12 @@ mrb_unpack_backtrace(mrb_state *mrb, mrb_value backtrace)
     const struct backtrace_location *entry = &bt[i];
     mrb_value btline;
 
-    btline = mrb_format(mrb, "%s:%d", entry->filename, (int)entry->lineno);
+    if (entry->lineno != -1) {//debug info was available
+      btline = mrb_format(mrb, "%s:%d", entry->filename, (int)entry->lineno);
+    }
+    else { //all that was left was the stack frame
+      btline = mrb_format(mrb, "%s:missing-lineno", entry->filename);
+    }
     if (entry->method_id != 0) {
       mrb_str_cat_lit(mrb, btline, ":in ");
       mrb_str_cat_cstr(mrb, btline, mrb_sym_name(mrb, entry->method_id));

--- a/test/t/exception.rb
+++ b/test/t/exception.rb
@@ -382,7 +382,8 @@ def backtrace_available?
   begin
     raise "XXX"
   rescue => exception
-    not exception.backtrace.empty?
+    return false if exception.backtrace.empty?
+    not exception.backtrace[0].include?("unknown")
   end
 end
 


### PR DESCRIPTION
Previously backtraces involving code built without debug information just silently hid stack frames from backtraces.

Consider the code:
```
[1,2].reverse_each do |val|
  val.invalid_method
end
```

Before this commit the output without debug symbols was:
```
trace (most recent call last):
        [1] test.rb:1
test.rb:2: undefined method 'invalid_method' (NoMethodError)
```

After this commit the output is:
```
trace (most recent call last):
        [2] test.rb:1
        [1] (unknown):missing-lineno:in reverse_each
test.rb:2: undefined method 'invalid_method' (NoMethodError)
```

With full debug information the second frame in the backtrace refers to the source in the mruby-array-ext gem.