### PR TITLE
Reorganize `mcall()` in `mruby-method`

### DIFF
--- a/mrbgems/mruby-eval/src/eval.c
+++ b/mrbgems/mruby-eval/src/eval.c
@@ -131,15 +131,6 @@ exec_irep(mrb_state *mrb, mrb_value self, struct RProc *proc, mrb_func_t posthoo
 {
   /* no argument passed from eval() */
   mrb->c->ci->argc = 0;
-  if (mrb->c->ci->acc < 0) {
-    ptrdiff_t cioff = mrb->c->ci - mrb->c->cibase;
-    mrb_value ret = mrb_top_run(mrb, proc, self, 0);
-    if (mrb->exc) {
-      mrb_exc_raise(mrb, mrb_obj_value(mrb->exc));
-    }
-    mrb->c->ci = mrb->c->cibase + cioff;
-    return ret;
-  }
   /* clear block */
   mrb->c->ci->stack[1] = mrb_nil_value();
   return mrb_exec_irep(mrb, self, proc, posthook);

--- a/src/vm.c
+++ b/src/vm.c
@@ -585,7 +585,9 @@ mrb_exec_irep(mrb_state *mrb, mrb_value self, struct RProc *p, mrb_func_t postho
   else {
     mrb_value ret;
     if (MRB_PROC_CFUNC_P(p)) {
+      cipush(mrb, 0, CI_ACC_DIRECT, mrb_vm_ci_target_class(ci), p, ci->mid, ci->argc);
       ret = MRB_PROC_CFUNC(p)(mrb, self);
+      cipop(mrb);
     }
     else {
       int keep = (ci->argc < 0 ? 1 : ci->argc) + 2 /* receiver + block */;


### PR DESCRIPTION
Use `mrb_exec_irep()`. If possible, re-entry into the VM will be suppressed.

Note that due to the effect of being a tail-call, the backtrace of `Method#call` will be lost, and it will look as if the target method was called directly.

This change fixes the problem of infinite loops when redefining methods that make block calls using `mruby-method`.

```console
% bin/mruby -e 'mm = method(:proc); define_method(:proc, ->(*a, &b) { mm.call(*a, &b) }); p proc { 1 }'
trace (most recent call last):
        [257] -e:1
        [256] -e:1:in proc
        [255] -e:1:in proc
        ...SNIP...
        [1] -e:1:in proc
-e:1:in proc: stack level too deep (SystemStackError)
```

Also, this PR contains a patch to extend `mrb_exec_irep()`.
