### PR TITLE
Updating dreamcast_shelf build configuration.

### DIFF
--- a/build_config/dreamcast_shelf.rb
+++ b/build_config/dreamcast_shelf.rb
@@ -4,7 +4,7 @@
 # Requires KallistiOS (KOS)
 # http://gamedev.allusion.net/softprj/kos/
 #
-# Tested on GNU/Linux, macOS and Windows (throught MinGW-w64/MSYS2, Cygwin and DreamSDK).
+# Tested on GNU/Linux, macOS and Windows (through MinGW-w64/MSYS2, Cygwin and DreamSDK).
 # DreamSDK is based on MinGW/MSYS: https://dreamsdk.org/
 #
 # Input this command on the directory where mruby is installed:

--- a/build_config/dreamcast_shelf.rb
+++ b/build_config/dreamcast_shelf.rb
@@ -1,8 +1,14 @@
 # Cross Compiling configuration for the Sega Dreamcast
-# This configuration requires KallistiOS (KOS)
-# https://dreamcast.wiki
+# https://dreamcast.wiki/Using_Ruby_for_Sega_Dreamcast_development
 #
-# Tested on GNU/Linux, MinGW-w64/MSYS2, Cygwin, macOS and MinGW/MSYS (see below)
+# Requires KallistiOS (KOS)
+# http://gamedev.allusion.net/softprj/kos/
+#
+# Tested on GNU/Linux, macOS and Windows (throught MinGW-w64/MSYS2, Cygwin and DreamSDK).
+# DreamSDK is based on MinGW/MSYS: https://dreamsdk.org/
+#
+# Input this command on the directory where mruby is installed:
+#   make MRUBY_CONFIG=dreamcast_shelf
 #
 MRuby::CrossBuild.new("dreamcast") do |conf|
   toolchain :gcc
@@ -62,33 +68,52 @@ MRuby::CrossBuild.new("dreamcast") do |conf|
 
   # Disable C++ exception
   conf.disable_cxx_exception
-
+  
   # Gems from core
-  # removing mruby-io
-  conf.gem :core => "mruby-metaprog"
-  conf.gem :core => "mruby-pack"
-  conf.gem :core => "mruby-sprintf"
-  conf.gem :core => "mruby-print"
-  conf.gem :core => "mruby-math"
-  conf.gem :core => "mruby-time"
-  conf.gem :core => "mruby-struct"
-  conf.gem :core => "mruby-compar-ext"
-  conf.gem :core => "mruby-enum-ext"
-  conf.gem :core => "mruby-string-ext"
-  conf.gem :core => "mruby-numeric-ext"
+  # Some Gems are incompatible and were disabled.
+  
   conf.gem :core => "mruby-array-ext"
+  conf.gem :core => "mruby-binding"
+  conf.gem :core => "mruby-binding-core"
+  conf.gem :core => "mruby-catch"
+  conf.gem :core => "mruby-class-ext"
+  conf.gem :core => "mruby-cmath"
+  conf.gem :core => "mruby-compar-ext"
+  conf.gem :core => "mruby-compiler"
+  conf.gem :core => "mruby-complex"
+  conf.gem :core => "mruby-enum-chain"
+  conf.gem :core => "mruby-enum-ext"
+  conf.gem :core => "mruby-enum-lazy"
+  conf.gem :core => "mruby-enumerator"
+  conf.gem :core => "mruby-error"
+  conf.gem :core => "mruby-eval"
+  conf.gem :core => "mruby-exit"
+  conf.gem :core => "mruby-fiber"
   conf.gem :core => "mruby-hash-ext"
-  conf.gem :core => "mruby-range-ext"
-  conf.gem :core => "mruby-proc-ext"
-  conf.gem :core => "mruby-symbol-ext"
-  conf.gem :core => "mruby-random"
+  conf.gem :core => "mruby-inline-struct"
+#  conf.gem :core => "mruby-io"
+  conf.gem :core => "mruby-kernel-ext"
+  conf.gem :core => "mruby-math"
+  conf.gem :core => "mruby-metaprog"
+  conf.gem :core => "mruby-method"
+  conf.gem :core => "mruby-numeric-ext"
   conf.gem :core => "mruby-object-ext"
   conf.gem :core => "mruby-objectspace"
-  conf.gem :core => "mruby-fiber"
-  conf.gem :core => "mruby-enumerator"
-  conf.gem :core => "mruby-enum-lazy"
+  conf.gem :core => "mruby-os-memsize"
+  conf.gem :core => "mruby-pack"
+  conf.gem :core => "mruby-print"
+  conf.gem :core => "mruby-proc-binding"
+  conf.gem :core => "mruby-proc-ext"
+  conf.gem :core => "mruby-random"
+  conf.gem :core => "mruby-range-ext"
+  conf.gem :core => "mruby-rational"
+  conf.gem :core => "mruby-sleep"
+#  conf.gem :core => "mruby-socket"
+  conf.gem :core => "mruby-sprintf"
+  conf.gem :core => "mruby-string-ext"
+  conf.gem :core => "mruby-struct"
+  conf.gem :core => "mruby-symbol-ext"
+#  conf.gem :core => "mruby-test"
+#  conf.gem :core => "mruby-time"
   conf.gem :core => "mruby-toplevel-ext"
-  conf.gem :core => "mruby-kernel-ext"
-  conf.gem :core => "mruby-class-ext"
-  conf.gem :core => "mruby-compiler"
 end


### PR DESCRIPTION
This PR contains the updated `build_config` for the **Sega Dreamcast** video-game console.