### PR TITLE
Fix incorrect prototype on declaration of mrb_protect_atexit

### DIFF
--- a/src/state.c
+++ b/src/state.c
@@ -183,7 +183,7 @@ mrb_free_context(mrb_state *mrb, struct mrb_context *c)
   mrb_free(mrb, c);
 }
 
-int mrb_protect_atexit(mrb_state *mrb);
+void mrb_protect_atexit(mrb_state *mrb);
 
   MRB_API void
 mrb_close(mrb_state *mrb)


### PR DESCRIPTION
`state.c` makes a prototype declaration for the private
`mrb_protect_atexit` which is defined in `error.c`. `error.c` defines
this function with a void return type, but `state.c` defines the
prototype with an `int` return type.

This mismatch prevents mruby from linking on stricter compilers like
emscripten.

## Declaration

https://github.com/mruby/mruby/blob/810d13dacdd4cdf6ce55de85266f3ac26da520ef/src/error.c#L594-L595