### PR TITLE
Remove "parse.y" directive

### DIFF
--- a/mrbgems/mruby-compiler/mrbgem.rake
+++ b/mrbgems/mruby-compiler/mrbgem.rake
@@ -15,12 +15,6 @@ MRuby::Gem::Specification.new 'mruby-compiler' do |spec|
 
   lex_def = "#{dir}/core/lex.def"
 
-  # Parser
-  file "#{dir}/core/y.tab.c" => ["#{dir}/core/parse.y", lex_def] do |t|
-    yacc.run t.name, t.prerequisites.first
-    replace_line_directive(t.name)
-  end
-
   # Lexical analyzer
   file lex_def => "#{dir}/core/keywords" do |t|
     gperf.run t.name, t.prerequisites.first


### PR DESCRIPTION
To be honest, I was really wondering why this is here, and I can't find any use for it.

It seems that compiling `y.tab.c` is all that is needed.

Am I missing something?