### PR TITLE
Add the pull request labeler Action

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,24 @@
+benchmark:
+  - benchmark/**/*
+build:
+  - Makefile
+  - Rakefile
+  - build_config/**/*
+  - lib/**/*
+  - tasks/**/*
+core:
+  - include/**/*
+  - mrblib/**/*
+  - src/**/*
+  - test/**/*
+doc:
+  - CONTRIBUTING.md
+  - README.md
+  - doc/**/*
+  - examples/**/*
+github:
+  - .github/**/*
+mrbgems:
+  - mrbgems/**/*
+oss-fuzz:
+  - oss-fuzz/**/*

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,14 @@
+name: Pull Request Labeler
+on:
+  - pull_request_target
+jobs:
+  triage:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v4
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          sync-labels: true


### PR DESCRIPTION
https://github.com/actions/labeler
https://github.com/marketplace/actions/labeler

Verified Action

We need to add the labels to this repo from `.github/labeler.yml` before this PR will work.

https://github.com/mruby/mruby/labels

The are now 14 labels to add and since the repository default labels are colored you might choose to make all of these 14 new labels the same color.   

We need to merge this pr before the labelling works.

Ready for review @matz 