### PR TITLE
Run the task only once when `parse.y` is updated

### DIFF
--- a/mrbgems/mruby-compiler/mrbgem.rake
+++ b/mrbgems/mruby-compiler/mrbgem.rake
@@ -12,18 +12,21 @@ MRuby::Gem::Specification.new 'mruby-compiler' do |spec|
     end
   end
   build.libmruby_core_objs << objs
+end
 
+if MRuby::Build.current.name == "host"
+  dir = __dir__
   lex_def = "#{dir}/core/lex.def"
 
   # Parser
   file "#{dir}/core/y.tab.c" => ["#{dir}/core/parse.y", lex_def] do |t|
-    yacc.run t.name, t.prerequisites.first
+    MRuby.targets["host"].yacc.run t.name, t.prerequisites.first
     replace_line_directive(t.name)
   end
 
   # Lexical analyzer
   file lex_def => "#{dir}/core/keywords" do |t|
-    gperf.run t.name, t.prerequisites.first
+    MRuby.targets["host"].gperf.run t.name, t.prerequisites.first
     replace_line_directive(t.name)
   end
 


### PR DESCRIPTION
Previously, the task was executed as many times as there were targets, including `mruby-compiler`.

```console
% rm mrbgems/mruby-compiler/core/y.tab.c
% rake `pwd`/mrbgems/mruby-compiler/core/y.tab.c
YACC  mrbgems/mruby-compiler/core/parse.y -> mrbgems/mruby-compiler/core/y.tab.c
YACC  mrbgems/mruby-compiler/core/parse.y -> mrbgems/mruby-compiler/core/y.tab.c
```