### PR TITLE
Update gem spec for `mruby-sleep`

### DIFF
--- a/mrbgems/mruby-sleep/mrbgem.rake
+++ b/mrbgems/mruby-sleep/mrbgem.rake
@@ -1,5 +1,5 @@
 MRuby::Gem::Specification.new('mruby-sleep') do |spec|
   spec.license = 'MIT'
   spec.authors = ['MATSUMOTO Ryosuke', 'mruby developers']
-  spec.version = '0.0.1'
+  spec.summary = 'Kernel#sleep and Kernel#usleep'
 end


### PR DESCRIPTION
To align the spec like any other core mrbgems:
- Delete `spec.version`
- Set `spec.summary`