### PR TITLE
 Run pre-commit with GitHub Actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,29 +4,29 @@ on: [pull_request]
 
 jobs:
   misspell:
-    name: Check Spelling
+    name: Check spelling with misspell
     runs-on: ubuntu-latest
     steps:
       - name: Check Out
         uses: actions/checkout@v2.3.4
       - name: Install
-        run: |
-          wget -O - -q https://git.io/misspell | sh -s -- -b .
+        run: wget -O - -q https://git.io/misspell | sh -s -- -b .
       - name: Misspell
-        run: |
-          git ls-files --empty-directory | xargs ./misspell -error
-  merge-conflict:
-    name: Merge Conflict
+        run: git ls-files --empty-directory | xargs ./misspell -error
+  pre-commit:
+    name: Run pre-commit
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
       - name: Check merge conflict
         run: |
-          grep "^<<<<<<< HEAD" $(git ls-files | xargs) && exit 1 || true
-  trailing-whitespace:
-    name: Trailing whitespace
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2.3.4
-      - name: Check for trailing whitespace
-        run: "! git grep -EIn $'[ \t]+$'"
+          python -m pip install --upgrade pip
+          pip install pre-commit
+      - name: Set PY
+        run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
+      - uses: actions/cache@v1
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
+      - name: Run pre-commit
+        run: pre-commit run --all-files

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -1,4 +1,4 @@
-name: Lint Code Base
+name: Super Linter
 
 on:
   push:
@@ -19,7 +19,5 @@ jobs:
           VALIDATE_BASH: true
           # VALIDATE_BASH_EXEC: true
           # VALIDATE_EDITORCONFIG: true
-          VALIDATE_MARKDOWN: true
           # VALIDATE_SHELL_SHFMT: true
-          VALIDATE_YAML: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,16 +27,37 @@ repos:
   #  hooks:
   #    - id: forbid-tabs
   #    - id: remove-tabs
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.0.0
+    hooks:
+      - id: codespell
+        name: Run codespell
+        description: Check spelling with codespell
+        entry: codespell --ignore-words=codespell.txt
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.27.1
     hooks:
       - id: markdownlint
         name: Run markdownlint
+        description: Checks the style of Markdown files
         entry: markdownlint -c .github/linters/.markdown-lint.yml .
+        types: [markdown]
+        files: \.(md|mdown|markdown)$
   - repo: https://github.com/adrienverge/yamllint
     rev: v1.26.1
     hooks:
       - id: yamllint
-        name: Check YAML files with yamllint
-        entry: yamllint --strict -c .github/linters/.yaml-lint.yml .
+        name: Run yamllint
+        description: Check YAML files with yamllint
+        entry: yamllint --strict -c .github/linters/.yaml-lint.yml
         types: [yaml]
+        files: \.(yaml|yml)$
+  - repo: local
+    hooks:
+      - id: sort-codespell-wordlist
+        name: Sort codespell.txt
+        description: Sort alphabetically and uniquify codespell.txt
+        entry: ./scripts/ci/pre-commit/sort-codespell-wordlist.sh
+        language: system
+        files: ^\.pre-commit-config\.yaml$|^codespell\.txt$
+        require_serial: true

--- a/build_config/IntelGalileo.rb
+++ b/build_config/IntelGalileo.rb
@@ -74,7 +74,7 @@ MRuby::CrossBuild.new("Galileo") do |conf|
   conf.gem :core => "mruby-fiber"
   conf.gem :core => "mruby-toplevel-ext"
 
-  #lightweigh regular expression
+  #lightweight regular expression
   conf.gem :github => "masamitsu-murase/mruby-hs-regexp", :branch => "master"
 
   #Arduino API

--- a/codespell.txt
+++ b/codespell.txt
@@ -1,0 +1,17 @@
+ans
+ba
+creat
+delet
+disabl
+filetest
+fo
+hel
+hist
+ist
+methid
+nd
+quitt
+remore
+runn
+sting
+upto

--- a/doc/limitations.md
+++ b/doc/limitations.md
@@ -55,7 +55,7 @@ To reduce memory consumption `Array` does not support instance variables.
 ```ruby
 class Liste < Array
   def initialize(str = nil)
-    @feld = str
+    @field = str
   end
 end
 

--- a/include/mruby/array.h
+++ b/include/mruby/array.h
@@ -186,7 +186,7 @@ MRB_API mrb_value mrb_ary_pop(mrb_state *mrb, mrb_value ary);
  * @param mrb The mruby state reference.
  * @param ary The target array.
  * @param n The array index being referenced.
- * @param val The value being setted.
+ * @param val The value being set.
  */
 MRB_API void mrb_ary_set(mrb_state *mrb, mrb_value ary, mrb_int n, mrb_value val);
 

--- a/mrbgems/mruby-array-ext/mrblib/array.rb
+++ b/mrbgems/mruby-array-ext/mrblib/array.rb
@@ -875,7 +875,7 @@ class Array
   #    ary.to_h                ->   Hash
   #    ary.to_h{|item| ... }   ->   Hash
   #
-  # Returns the result of interpreting <i>aray</i> as an array of
+  # Returns the result of interpreting <i>array</i> as an array of
   # <tt>[key, value]</tt> pairs. If a block is given, it should
   # return <tt>[key, value]</tt> pairs to construct a hash.
   #

--- a/mrbgems/mruby-complex/src/complex.c
+++ b/mrbgems/mruby-complex/src/complex.c
@@ -425,10 +425,10 @@ void mrb_mruby_complex_gem_init(mrb_state *mrb)
   mrb_define_method(mrb, comp, "/", complex_div, MRB_ARGS_REQ(1));
   mrb_define_method(mrb, comp, "quo", complex_div, MRB_ARGS_REQ(1));
   mrb_define_method(mrb, comp, "==", complex_eq, MRB_ARGS_REQ(1));
-  mrb_define_method(mrb, mrb->integer_class, "/", cpx_int_div, MRB_ARGS_REQ(1)); /* overrride */
-  mrb_define_method(mrb, mrb->integer_class, "quo", cpx_int_quo, MRB_ARGS_REQ(1)); /* overrride */
-  mrb_define_method(mrb, mrb->float_class, "/", cpx_flo_div, MRB_ARGS_REQ(1)); /* overrride */
-  mrb_define_method(mrb, mrb->float_class, "quo", cpx_flo_div, MRB_ARGS_REQ(1)); /* overrride */
+  mrb_define_method(mrb, mrb->integer_class, "/", cpx_int_div, MRB_ARGS_REQ(1)); /* override */
+  mrb_define_method(mrb, mrb->integer_class, "quo", cpx_int_quo, MRB_ARGS_REQ(1)); /* override */
+  mrb_define_method(mrb, mrb->float_class, "/", cpx_flo_div, MRB_ARGS_REQ(1)); /* override */
+  mrb_define_method(mrb, mrb->float_class, "quo", cpx_flo_div, MRB_ARGS_REQ(1)); /* override */
 }
 
 void

--- a/mrbgems/mruby-error/src/exception.c
+++ b/mrbgems/mruby-error/src/exception.c
@@ -31,7 +31,7 @@ mrb_ensure(mrb_state *mrb, mrb_func_t body, mrb_value b_data, mrb_func_t ensure,
   mrb_gc_arena_restore(mrb, ai);
   mrb_gc_protect(mrb, result);
   if (error) {
-    mrb_exc_raise(mrb, result); /* rethrow catched exceptions */
+    mrb_exc_raise(mrb, result); /* rethrow caught exceptions */
   }
   return result;
 }

--- a/mrbgems/mruby-rational/src/rational.c
+++ b/mrbgems/mruby-rational/src/rational.c
@@ -728,8 +728,8 @@ void mrb_mruby_rational_gem_init(mrb_state *mrb)
   mrb_define_method(mrb, rat, "quo", rational_div, MRB_ARGS_REQ(1));
   mrb_define_method(mrb, mrb->integer_class, "to_r", fix_to_r, MRB_ARGS_NONE());
 #ifndef MRB_USE_COMPLEX
-  mrb_define_method(mrb, mrb->integer_class, "/", rational_int_div, MRB_ARGS_REQ(1)); /* overrride */
-  mrb_define_method(mrb, mrb->integer_class, "quo", rational_int_quo, MRB_ARGS_REQ(1)); /* overrride */
+  mrb_define_method(mrb, mrb->integer_class, "/", rational_int_div, MRB_ARGS_REQ(1)); /* override */
+  mrb_define_method(mrb, mrb->integer_class, "quo", rational_int_quo, MRB_ARGS_REQ(1)); /* override */
 #endif
   mrb_define_method(mrb, mrb->kernel_module, "Rational", rational_m, MRB_ARGS_ARG(1,1));
 }

--- a/scripts/ci/pre-commit/sort-codespell-wordlist.sh
+++ b/scripts/ci/pre-commit/sort-codespell-wordlist.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+CODESPELL_WORDLIST="codespell.txt"
+temp_file=$(mktemp)
+sort <"${CODESPELL_WORDLIST}" | uniq >"${temp_file}"
+cat "${temp_file}" >"${CODESPELL_WORDLIST}"
+rm "${temp_file}"

--- a/src/fmt_fp.c
+++ b/src/fmt_fp.c
@@ -8,7 +8,7 @@
   Routine for converting a single-precision
   floating point number into a string.
 
-  The code in this funcion was inspired from Fred Bayer's pdouble.c.
+  The code in this function was inspired from Fred Bayer's pdouble.c.
   Since pdouble.c was released as Public Domain, I'm releasing this
   code as public domain as well.
 

--- a/src/vm.c
+++ b/src/vm.c
@@ -2161,7 +2161,7 @@ RETRY_TRY_BLOCK:
             }
             /* check jump destination */
             while (cibase <= ci && ci->proc != dst) {
-              if (ci->acc < 0) { /* jump cross C boudary */
+              if (ci->acc < 0) { /* jump cross C boundary */
                 localjump_error(mrb, LOCALJUMP_ERROR_RETURN);
                 goto L_RAISE;
               }

--- a/test/t/unicode.rb
+++ b/test/t/unicode.rb
@@ -1,15 +1,15 @@
 # Test of the \u notation
 
 assert('bare \u notation test') do
-  # Mininum and maximum one byte characters
+  # Minimum and maximum one byte characters
   assert_equal("\x00", "\u0000")
   assert_equal("\x7F", "\u007F")
 
-  # Mininum and maximum two byte characters
+  # Minimum and maximum two byte characters
   assert_equal("\xC2\x80", "\u0080")
   assert_equal("\xDF\xBF", "\u07FF")
 
-  # Mininum and maximum three byte characters
+  # Minimum and maximum three byte characters
   assert_equal("\xE0\xA0\x80", "\u0800")
   assert_equal("\xEF\xBF\xBF", "\uFFFF")
 
@@ -17,19 +17,19 @@ assert('bare \u notation test') do
 end
 
 assert('braced \u notation test') do
-  # Mininum and maximum one byte characters
+  # Minimum and maximum one byte characters
   assert_equal("\x00", "\u{0000}")
   assert_equal("\x7F", "\u{007F}")
 
-  # Mininum and maximum two byte characters
+  # Minimum and maximum two byte characters
   assert_equal("\xC2\x80", "\u{0080}")
   assert_equal("\xDF\xBF", "\u{07FF}")
 
-  # Mininum and maximum three byte characters
+  # Minimum and maximum three byte characters
   assert_equal("\xE0\xA0\x80", "\u{0800}")
   assert_equal("\xEF\xBF\xBF", "\u{FFFF}")
 
-  # Mininum and maximum four byte characters
+  # Minimum and maximum four byte characters
   assert_equal("\xF0\x90\x80\x80", "\u{10000}")
   assert_equal("\xF4\x8F\xBF\xBF", "\u{10FFFF}")
 end


### PR DESCRIPTION
Running pre-commit with GitHub Actions now gives us more tests and coverage

Remove duplicate GitHub Actions for merge conflicts and trailing whitespace

Remove duplicate checks for markdownlint and yamllint from the GitHub Super-Linter

Add new custom pre-commit hook running with a shell script to sort alphabetically and uniquify codespell.txt

Add new pre-commit hook to check spelling with codespell

https://github.com/codespell-project/codespell

<img width="886" alt="Screen Shot 2021-05-05 at 11 56 43 pm" src="https://user-images.githubusercontent.com/418747/117152760-aadeee80-adfd-11eb-8e93-75e35899db19.png">

