### PR TITLE
Generate `LICENSE.yml` file

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -32,6 +32,7 @@ load "#{MRUBY_ROOT}/tasks/presym.rake"
 load "#{MRUBY_ROOT}/tasks/test.rake"
 load "#{MRUBY_ROOT}/tasks/benchmark.rake"
 load "#{MRUBY_ROOT}/tasks/doc.rake"
+load "#{MRUBY_ROOT}/tasks/license.rake"
 
 ##############################
 # generic build targets, rules

--- a/doc/guides/compile.md
+++ b/doc/guides/compile.md
@@ -338,6 +338,20 @@ When debugging mode is enabled
   * Because `-g` flag would be added to `mrbc` runner.
     * You can have better backtrace of mruby scripts with this.
 
+### Additional license terms
+
+The license terms set in the `conf.terms` property are printed as part of
+the `<build-dir>/LICENSE.yml` file.
+This initial value is an empty array (`[]`). If you want to add it, do the
+following:
+
+```ruby
+conf.terms << "path/to/ADDITIONAL-LICENSE"
+```
+
+The file path can be specified as an absolute path as well as a relative
+path based on the build directory.
+
 ## Cross-Compilation
 
 mruby can also be cross-compiled from one platform to another. To achieve
@@ -385,6 +399,8 @@ root directory. The structure of this directory will look like this:
     +- host
         |
         +- LEGAL        <- License description
+        |
+        +- LICENSE.yml  <- Collected license terms (Maybe incomplete)
         |
         +- bin          <- Binaries (mirb, mrbc and mruby)
         |

--- a/doc/guides/mrbgems.md
+++ b/doc/guides/mrbgems.md
@@ -115,6 +115,8 @@ The maximal GEM structure looks like this:
     |
     +- README.md        <- Readme for GEM
     |
+    +- LICENSE          <- License terms for GEM
+    |
     +- mrbgem.rake      <- GEM Specification
     |
     +- include/         <- Header for Ruby extension (will exported)
@@ -133,6 +135,7 @@ contains C/C++ files to extend mruby. The folder `include` contains C/C++ header
 files. The folder `test` contains C/C++ and pure Ruby files for testing purposes
 which will be used by `mrbtest`. `mrbgem.rake` contains the specification
 to compile C and Ruby files. `README.md` is a short description of your GEM.
+`LICENSE` is the License terms for dealing with your GEM.
 
 ## Build process
 
@@ -156,6 +159,7 @@ information purpose:
 
 * `spec.license` or `spec.licenses` (A single license or a list of them under which this GEM is licensed)
 * `spec.author` or `spec.authors` (Developer name or a list of them)
+* `spec.terms` (File path to license terms)
 * `spec.version` (Current version)
 * `spec.description` (Detailed description)
 * `spec.summary`
@@ -165,6 +169,9 @@ information purpose:
 * `spec.requirements` (External requirements as information for user)
 
 The `license` and `author` properties are required in every GEM!
+
+The `terms` property specifies the file path for the license terms.
+See [Specifying the License Terms](#specifying-the-license-terms) for more details.
 
 In case your GEM is depending on other GEMs please use
 `spec.add_dependency(gem, *requirements[, default_get_info])` like:
@@ -261,6 +268,30 @@ For example: when B depends to C and A depends to B, A will get include paths ex
 Exported include_paths are automatically appended to GEM local include_paths by rake.
 You can use `spec.export_include_paths` accessor if you want more complex build.
 
+### Specifying the License Terms
+
+The contents of the file set here will be reflected in the
+`<build-dir>/LICENSE.yml` file.
+
+The initial value of `spec.terms` is set automatically if there is a
+license terms file in the top directory of your GEM.
+The recognized file priorities are:
+
+```
+LICENSE > LICENSE.txt > LICENSE.md >
+  COPYRIGHT > COPYRIGHT.txt > COPYRIGHT.md >
+  COPYING > COPYING.txt > COPYING.md (lowest priorities)
+```
+
+The specification method is the same as `MRuby::Build#terms`, but there
+are some differences:
+
+* Specify as `spec.terms` (instead of `conf.terms`)
+* Initial value is different
+* The base directory of the relative path is the top directory of your GEM
+
+See [compile.md#Additional License terms](compile.md#additional-license-terms) for more details.
+
 ## C Extension
 
 mruby can be extended with C. This is possible by using the C API to
@@ -302,6 +333,8 @@ mrb_c_extension_example_gem_final(mrb_state* mrb) {
     |
     +- README.md        (Optional)
     |
+    +- LICENSE          (Optional, but Recommended)
+    |
     +- src/
     |   |
     |   +- example.c    <- C extension source
@@ -329,6 +362,8 @@ none
 +- ruby_extension_example/
     |
     +- README.md        (Optional)
+    |
+    +- LICENSE          (Optional, but Recommended)
     |
     +- mrblib/
     |   |
@@ -361,6 +396,8 @@ See C and Ruby example.
 +- c_and_ruby_extension_example/
     |
     +- README.md        (Optional)
+    |
+    +- LICENSE          (Optional, but Recommended)
     |
     +- mrblib/
     |   |
@@ -398,6 +435,8 @@ binary gems, to separate normal gems and binary gems.
 +- mruby-bin-example/
     |
     +- README.md        (Optional)
+    |
+    +- LICENSE          (Optional, but Recommended)
     |
     +- bintest/
     |   |

--- a/lib/mruby/build.rb
+++ b/lib/mruby/build.rb
@@ -73,6 +73,7 @@ module MRuby
     include LoadGems
     attr_accessor :name, :bins, :exts, :file_separator, :build_dir, :gem_clone_dir, :defines
     attr_reader :products, :libmruby_core_objs, :libmruby_objs, :gems, :toolchains, :presym, :mrbc_build, :gem_dir_to_repo_url
+    attr_accessor :terms
 
     alias libmruby libmruby_objs
 
@@ -127,6 +128,8 @@ module MRuby
         @internal = internal
         @toolchains = []
         @gem_dir_to_repo_url = {}
+
+        @terms = []
 
         MRuby.targets[@name] = current = self
       end
@@ -481,7 +484,7 @@ EOS
     attr_writer :presym
 
     def create_mrbc_build
-      exclusions = %i[@name @build_dir @gems @enable_test @enable_bintest @internal]
+      exclusions = %i[@name @build_dir @gems @terms @enable_test @enable_bintest @internal]
       name = "#{@name}/mrbc"
       MRuby.targets.delete(name)
       build = self.class.new(name, internal: true){}

--- a/lib/mruby/core_ext.rb
+++ b/lib/mruby/core_ext.rb
@@ -8,6 +8,63 @@ class Object
       end
     end
   end
+
+  def fileset_list_under(basedir)
+    [self].fileset_list_under(basedir)
+  end
+
+  def fileset_make_under(*dirs, prefix: nil)
+    [self].fileset_make_under(*dirs, prefix: prefix)
+  end
+end
+
+class Array
+  def fileset_list_under(basedir)
+    basedir = Pathname.new(basedir)
+    alist = []
+    _fileset_traverse_under(basedir, nil, nil, nil) do |path|
+      alist << path.to_path
+      nil
+    end
+    alist
+  end
+
+  def fileset_make_under(basedir, *dirs, prefix: nil)
+    basedir = Pathname.new(basedir)
+    prefix = "#{prefix}:" if prefix
+    alist = {}
+    _fileset_traverse_under(basedir, dirs, prefix, alist) do |path|
+      case path
+      when nil
+        nil
+      when Pathname # pathname + string'd-path
+        path.read
+      else
+        raise TypeError, "wrong type #{path.inspect}"
+      end
+    end
+    alist.empty? ? nil : alist
+  end
+
+  def _fileset_traverse_under(basedir, dirs, prefix, alist, &block)
+    flatten.each do |entry|
+      case entry
+      when nil
+        # do nothing
+      when String
+        path = basedir + entry
+        name = path.to_s.relative_path_under(basedir, *dirs)
+        entity = yield path
+        unless alist.nil? || entity.nil? || entity.empty?
+          key = "#{prefix}#{name}"
+          raise "conflict file name - #{key} for #{basedir}" if alist.key?(key)
+          alist[key] = entity
+        end
+      else
+        raise TypeError, "expect string only for `terms`, but actual #{entry.inspect}"
+      end
+    end
+  end
 end
 
 class String
@@ -17,6 +74,14 @@ class String
 
   def relative_path
     relative_path_from(Dir.pwd)
+  end
+
+  def relative_path_under(*dirs)
+    dirs.each do |dir|
+      return relative_path_from dir if start_with? File.join(dir, "/")
+    end
+
+    self
   end
 
   def remove_leading_parents

--- a/lib/mruby/gem.rb
+++ b/lib/mruby/gem.rb
@@ -20,7 +20,7 @@ module MRuby
       attr_accessor :version
       attr_accessor :description, :summary
       attr_accessor :homepage
-      attr_accessor :licenses, :authors
+      attr_accessor :licenses, :authors, :terms
       alias :license= :licenses=
       alias :author= :authors=
 
@@ -69,6 +69,15 @@ module MRuby
         @requirements = []
         @export_include_paths = []
         @export_include_paths << "#{dir}/include" if File.directory? "#{dir}/include"
+
+        @terms = []
+        %w[LICENSE COPYRIGHT COPYING].product(%W[#{} .txt .md]) do |fn, ext|
+          name = fn + ext
+          if File.exist?("#{dir}/#{name}")
+            @terms << name
+            break
+          end
+        end
 
         instance_eval(&@initializer)
 

--- a/tasks/license.rake
+++ b/tasks/license.rake
@@ -1,0 +1,76 @@
+require "yaml"
+require "pathname"
+
+MRuby.each_target do |build|
+  license_file = "#{build_dir}/LICENSE.yml"
+  build.products << license_file
+
+  task "license" => license_file
+
+  coreterms = ["LICENSE"]
+
+  termfiles = []
+  termfiles << coreterms.fileset_list_under(MRUBY_ROOT)
+  termfiles << build.terms.fileset_list_under(build.build_dir)
+  build.gems.each { |g|
+    termfiles << File.join(g.dir, "mrbgem.rake")
+    termfiles << g.terms.fileset_list_under(g.dir)
+  }
+  termfiles.flatten!
+  termfiles.compact!
+
+  file license_file => [__FILE__, MRuby::Build.mruby_config_path, *termfiles] do |t|
+    _pp "GEN", t.name.relative_path
+
+    info = {
+      "DISCLAIMER FOR THIS FILE" => <<~DISCLAIMER,
+        Please note that this file may NOT completely cover the license
+        terms of the copyrighted work generated based on the mruby build
+        configuration file.
+
+        If you suspect a shortage, please check if it is provided as a
+        separate file and contact the software provider.
+      DISCLAIMER
+      "mruby" => {
+        "AUTHORS" => "mruby developers",
+        "LICENSES" => "MIT",
+        "TERMS" => coreterms.fileset_make_under(MRUBY_ROOT, prefix: "mruby")
+      }
+    }
+
+    addterms = build.terms.fileset_make_under(build.build_dir, MRUBY_ROOT, prefix: "additional")
+    info["additional terms by build_config"] = addterms if addterms
+
+    if enable_gems?
+      gems_info = []
+
+      build.gems.each do |g|
+        gemterms = g.terms.fileset_make_under(g.dir, g.build_dir, MRUBY_ROOT, prefix: g.name)
+
+        unless gemterms
+          if g.core?
+            gemterms = "same as mruby's license"
+          else
+            $stderr.puts "WARNING: no such LICENSE files for #{Rake.verbose ? g.dir : g.name}"
+            gemterms = "<<<FOR THE DETAILED LICENSE TERMS OF THIS GEM, PLEASE CHECK DIRECTLY>>>"
+          end
+        end
+
+        gems_info << {
+          "NAME" => g.name,
+          "AUTHORS" => Array(g.authors).flatten.uniq,
+          "LICENSES" => Array(g.licenses).flatten.uniq,
+          "TERMS" => gemterms
+        }
+      end
+
+      info["mruby gems"] = gems_info unless gems_info.empty?
+    end
+
+    mkdir_p File.dirname(t.name)
+    File.binwrite(t.name, YAML.dump(info))
+  end
+end
+
+desc "generate LICENSE.yml file for each targets"
+task "license"


### PR DESCRIPTION


Outputs the `<build-dir>/LICENSE.yml` file by combining the `mruby/LICENSE` and the files related to the license terms for mrbgems added to the `build_config` file.
If it only wants to generate a `LICENSE.yml` file, run `rake license`.

Many common license terms are required to include themselves. Therefore, the purpose is to reduce the effort of users to put them together.
Note, however, that it is ideal and the generated `LICENSE.yml` file is probably incomplete.

If there is a license terms file in the top directory of mrbgem, it will be automatically collected.
Therefore, it is now recommended by the mrbgem author to put the `LICENSE` file in each top directory.
The target to be imported as a license clause file is one of the combinations of `["LICENSE","COPYRIGHT","COPYING"].product(["",".txt",".md"])`.
Priority: `LICENSE` > `LICENSE.txt` > `LICENSE.md` > ... > `COPYING.txt` > `COPYING.md`

In addition, the user can optionally change or add the file name through the `MRuby::Gem::Specification#terms` property.
If it specifies a relative path, the base directory is the top directory of each mrbgem.

```ruby
MRuby::Gem::Specification.new("my-gem") do |spec|
  spec.terms << "OPTIONAL-LICENSE-FILE"
  spec.terms << "path/to/ANOTHER-LICENSE-FILE"
  ...
end
```

The mrbgems that do not have a `LICENSE` file and are not set to` spec.terms` are now warned when `rake` is done.

License terms for the following will be extracted at build time if needed:
- `src/string.c`: Code from `strtod()`
- `mrbgems/mruby-sleep`
- `mrbgems/mruby-io`
- `mrbgems/mruby-socket`
- `mrbgems/mruby-pack`

The APIs added for users are:
- `lib/mruby/build.rb`
  - `MRuby::Build#terms` property
- `lib/mruby/gem.rb`
  - `MRuby::Gem::Specification#terms` property
- `lib/mruby/core_ext.rb`
  - `File.extract` method
