### PR TITLE
Raise `TypeError` with `super` inside `instance_eval` / `class_eval`

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -1725,13 +1725,12 @@ RETRY_TRY_BLOCK:
       else if (target_class->tt == MRB_TT_MODULE) {
         target_class = mrb_vm_ci_target_class(ci);
         if (target_class->tt != MRB_TT_ICLASS) {
-          mrb_value exc = mrb_exc_new_lit(mrb, E_RUNTIME_ERROR, "superclass info lost [mruby limitations]");
-          mrb_exc_set(mrb, exc);
-          goto L_RAISE;
+          goto super_typeerror;
         }
       }
       recv = regs[0];
       if (!mrb_obj_is_kind_of(mrb, recv, target_class)) {
+      super_typeerror: ;
         mrb_value exc = mrb_exc_new_lit(mrb, E_TYPE_ERROR,
                                             "self has wrong type to call super in this context");
         mrb_exc_set(mrb, exc);


### PR DESCRIPTION
Commit d0f60182af9114f6840d993d74f492e483302805 introduced an exception as a limitation of mruby.

Subsequent CRuby-2.7 has changed its behavior to raise an exception.
ref: https://github.com/ruby/ruby/commit/55b7ba368696033f2e89b77cbcd4a05dec97b139
