### PR TITLE
Enable markdownlint rule MD046 code-block-style

### DIFF
--- a/.github/linters/.markdown-lint.yml
+++ b/.github/linters/.markdown-lint.yml
@@ -33,6 +33,3 @@ MD026: false
 
 # MD040 fenced-code-language - Fenced code blocks should have a language specified
 MD040: false
-
-# MD046 code-block-style - Code block style
-MD046: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,13 +82,13 @@ on-demand.
 
 #### Insert a break after the function return value:
 
-    ```C
-    int
-    main(void)
-    {
-      ...
-    }
-    ```
+```c
+int
+main(void)
+{
+  ...
+}
+```
 
 ### Ruby code
 

--- a/doc/guides/mrbgems.md
+++ b/doc/guides/mrbgems.md
@@ -273,7 +273,7 @@ mrbgems expects that you have implemented a C method called
 by the name of your GEM. If you call your GEM `c_extension_example`, your
 initialisation method could look like this:
 
-```C
+```c
 void
 mrb_c_extension_example_gem_init(mrb_state* mrb) {
   struct RClass *class_cextension = mrb_define_module(mrb, "CExtension");
@@ -288,7 +288,7 @@ mrbgems expects that you have implemented a C method called
 by the name of your GEM. If you call your GEM `c_extension_example`, your
 finalizer method could look like this:
 
-```C
+```c
 void
 mrb_c_extension_example_gem_final(mrb_state* mrb) {
   free(someone);

--- a/doc/guides/symbol.md
+++ b/doc/guides/symbol.md
@@ -4,7 +4,7 @@ Symbols in `mruby` C source code is represented by `mrb_sym` which is alias of
 `uint32_t`.  Lower 30 bits are used for symbols so that higher 2 bits can be
 used as flags, e.g. `struct mt_elem` in `class.c`.
 
-```C
+```c
 struct mt_elem {
   union mt_ptr ptr;
   size_t func_p:1;


### PR DESCRIPTION
Fix C Markdown code block style