### PR TITLE
Added `MRB_API` function to get only block arguments

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -1004,6 +1004,16 @@ MRB_API const mrb_value *mrb_get_argv(mrb_state *mrb);
  */
 MRB_API mrb_value mrb_get_arg1(mrb_state *mrb);
 
+/**
+ * Retrieve block argument from mrb_state.
+ */
+MRB_API mrb_value mrb_get_arg_block(mrb_state *mrb);
+
+/**
+ * Check if a block argument is given from mrb_state.
+ */
+MRB_API mrb_bool mrb_block_given_p(mrb_state *mrb);
+
 /* `strlen` for character string literals (use with caution or `strlen` instead)
     Adjacent string literals are concatenated in C/C++ in translation phase 6.
     If `lit` is not one, the compiler will report a syntax error:

--- a/mrbgems/mruby-eval/src/eval.c
+++ b/mrbgems/mruby-eval/src/eval.c
@@ -195,12 +195,7 @@ f_eval(mrb_state *mrb, mrb_value self)
 static mrb_value
 f_instance_eval(mrb_state *mrb, mrb_value self)
 {
-  mrb_value b;
-  mrb_int argc; const mrb_value *argv;
-
-  mrb_get_args(mrb, "*!&", &argv, &argc, &b);
-
-  if (mrb_nil_p(b)) {
+  if (!mrb_block_given_p(mrb)) {
     const char *s;
     mrb_int len;
     const char *file = NULL;
@@ -217,7 +212,7 @@ f_instance_eval(mrb_state *mrb, mrb_value self)
     return exec_irep(mrb, self, proc, NULL);
   }
   else {
-    mrb_get_args(mrb, "&", &b);
+    mrb_get_args(mrb, "");
     return mrb_obj_instance_eval(mrb, self);
   }
 }
@@ -225,12 +220,7 @@ f_instance_eval(mrb_state *mrb, mrb_value self)
 static mrb_value
 f_class_eval(mrb_state *mrb, mrb_value self)
 {
-  mrb_value b;
-  mrb_int argc; const mrb_value *argv;
-
-  mrb_get_args(mrb, "*!&", &argv, &argc, &b);
-
-  if (mrb_nil_p(b)) {
+  if (!mrb_block_given_p(mrb)) {
     const char *s;
     mrb_int len;
     const char *file = NULL;
@@ -245,7 +235,7 @@ f_class_eval(mrb_state *mrb, mrb_value self)
     return exec_irep(mrb, self, proc, NULL);
   }
   else {
-    mrb_get_args(mrb, "&", &b);
+    mrb_get_args(mrb, "");
     return mrb_mod_module_eval(mrb, self);
   }
 }

--- a/src/class.c
+++ b/src/class.c
@@ -859,6 +859,27 @@ mrb_get_arg1(mrb_state *mrb)
   return array_argv[0];
 }
 
+MRB_API mrb_value
+mrb_get_arg_block(mrb_state *mrb)
+{
+  const mrb_callinfo *ci = mrb->c->ci;
+  const mrb_value *stack = ci->stack;
+  int argc = ci->argc;
+
+  if (argc < 0) {
+    return stack[2];
+  }
+  else {
+    return stack[argc + 1];
+  }
+}
+
+MRB_API mrb_bool
+mrb_block_given_p(mrb_state *mrb)
+{
+  return !mrb_nil_p(mrb_get_arg_block(mrb));
+}
+
 void mrb_hash_check_kdict(mrb_state *mrb, mrb_value self);
 
 /*


### PR DESCRIPTION
`MRB_API` function added:
- ` mrb_get_arg_block()`
- ` mrb_block_given_p()` -- The name comes from CRuby's `rb_block_given_p ()`

At the same time, it applies to `f_instance_eval()` and `f_class_eval()` of `mruby-eval`.
