### PR TITLE
Added `MRB_OBJ_ALLOC()` macro that does not require a cast

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -1131,6 +1131,17 @@ MRB_API void *mrb_malloc_simple(mrb_state*, size_t);  /* return NULL if no memor
 MRB_API struct RBasic *mrb_obj_alloc(mrb_state*, enum mrb_vtype, struct RClass*);
 MRB_API void mrb_free(mrb_state*, void*);
 
+/**
+ * Allocates a Ruby object that matches the constant literal defined in
+ * `enum mrb_vtype` and returns a pointer to the corresponding C type.
+ *
+ * @param mrb   The current mruby state
+ * @param tt    The constant literal of `enum mrb_vtype`
+ * @param klass A Class object
+ * @return      Reference to the newly created object
+ */
+#define MRB_OBJ_ALLOC(mrb, tt, klass) ((MRB_VTYPE_TYPEOF(tt)*)mrb_obj_alloc(mrb, tt, klass))
+
 MRB_API mrb_value mrb_str_new(mrb_state *mrb, const char *p, size_t len);
 
 /**

--- a/include/mruby/value.h
+++ b/include/mruby/value.h
@@ -128,35 +128,47 @@ static const unsigned int IEEE754_INFINITY_BITS_SINGLE = 0x7F800000;
 # endif
 #endif
 
+#define MRB_VTYPE_FOREACH(f) \
+    /* mrb_vtype */     /* c type */        /* ruby class */ \
+  f(MRB_TT_FALSE,       void,               "false") \
+  f(MRB_TT_TRUE,        void,               "true") \
+  f(MRB_TT_SYMBOL,      void,               "Symbol") \
+  f(MRB_TT_UNDEF,       void,               "undefined") \
+  f(MRB_TT_FREE,        void,               "free") \
+  f(MRB_TT_FLOAT,       struct RFloat,      "Float") \
+  f(MRB_TT_INTEGER,     struct RInteger,    "Integer") \
+  f(MRB_TT_CPTR,        struct RCptr,       "cptr") \
+  f(MRB_TT_OBJECT,      struct RObject,     "Object") \
+  f(MRB_TT_CLASS,       struct RClass,      "Class") \
+  f(MRB_TT_MODULE,      struct RClass,      "Module") \
+  f(MRB_TT_ICLASS,      struct RClass,      "iClass") \
+  f(MRB_TT_SCLASS,      struct RClass,      "SClass") \
+  f(MRB_TT_PROC,        struct RProc,       "Proc") \
+  f(MRB_TT_ARRAY,       struct RArray,      "Array") \
+  f(MRB_TT_HASH,        struct RHash,       "Hash") \
+  f(MRB_TT_STRING,      struct RString,     "String") \
+  f(MRB_TT_RANGE,       struct RRange,      "Range") \
+  f(MRB_TT_EXCEPTION,   struct RException,  "Exception") \
+  f(MRB_TT_ENV,         struct REnv,        "env") \
+  f(MRB_TT_DATA,        struct RData,       "Data") \
+  f(MRB_TT_FIBER,       struct RFiber,      "Fiber") \
+  f(MRB_TT_ISTRUCT,     struct RIStruct,    "istruct") \
+  f(MRB_TT_BREAK,       struct RBreak,      "break") \
+  f(MRB_TT_COMPLEX,     struct RComplex,    "Complex") \
+  f(MRB_TT_RATIONAL,    struct RRational,   "Rational")
+
 enum mrb_vtype {
-  MRB_TT_FALSE = 0,
-  MRB_TT_TRUE,
-  MRB_TT_SYMBOL,
-  MRB_TT_UNDEF,
-  MRB_TT_FREE,
-  MRB_TT_FLOAT,
-  MRB_TT_INTEGER,
-  MRB_TT_CPTR,
-  MRB_TT_OBJECT,
-  MRB_TT_CLASS,
-  MRB_TT_MODULE,
-  MRB_TT_ICLASS,
-  MRB_TT_SCLASS,
-  MRB_TT_PROC,
-  MRB_TT_ARRAY,
-  MRB_TT_HASH,
-  MRB_TT_STRING,
-  MRB_TT_RANGE,
-  MRB_TT_EXCEPTION,
-  MRB_TT_ENV,
-  MRB_TT_DATA,
-  MRB_TT_FIBER,
-  MRB_TT_ISTRUCT,
-  MRB_TT_BREAK,
-  MRB_TT_COMPLEX,
-  MRB_TT_RATIONAL,
+#define MRB_VTYPE_DEFINE(tt, type, name) tt,
+  MRB_VTYPE_FOREACH(MRB_VTYPE_DEFINE)
+#undef MRB_VTYPE_DEFINE
   MRB_TT_MAXDEFINE
 };
+
+#define MRB_VTYPE_TYPEOF(tt) MRB_TYPEOF_##tt
+
+#define MRB_VTYPE_TYPEDEF(tt, type, name) typedef type MRB_VTYPE_TYPEOF(tt);
+MRB_VTYPE_FOREACH(MRB_VTYPE_TYPEDEF)
+#undef MRB_VTYPE_TYPEDEF
 
 /* for compatibility */
 #define MRB_TT_FIXNUM MRB_TT_INTEGER

--- a/mrbgems/mruby-binding-core/src/binding-core.c
+++ b/mrbgems/mruby-binding-core/src/binding-core.c
@@ -217,7 +217,7 @@ binding_source_location(mrb_state *mrb, mrb_value self)
 mrb_value
 mrb_binding_alloc(mrb_state *mrb)
 {
-  struct RObject *obj = (struct RObject*)mrb_obj_alloc(mrb, MRB_TT_OBJECT, mrb_class_get_id(mrb, MRB_SYM(Binding)));
+  struct RObject *obj = MRB_OBJ_ALLOC(mrb, MRB_TT_OBJECT, mrb_class_get_id(mrb, MRB_SYM(Binding)));
   return mrb_obj_value(obj);
 }
 
@@ -231,7 +231,7 @@ mrb_binding_wrap_lvspace(mrb_state *mrb, const struct RProc *proc, struct REnv *
 
   static const mrb_code iseq_dummy[] = { OP_RETURN, 0 };
 
-  struct RProc *lvspace = (struct RProc*)mrb_obj_alloc(mrb, MRB_TT_PROC, mrb->proc_class);
+  struct RProc *lvspace = MRB_OBJ_ALLOC(mrb, MRB_TT_PROC, mrb->proc_class);
   mrb_irep *irep = mrb_add_irep(mrb);
   irep->flags = MRB_ISEQ_NO_FREE;
   irep->iseq = iseq_dummy;
@@ -246,7 +246,7 @@ mrb_binding_wrap_lvspace(mrb_state *mrb, const struct RProc *proc, struct REnv *
     lvspace->flags |= MRB_PROC_ENVSET;
   }
 
-  *envp = (struct REnv*)mrb_obj_alloc(mrb, MRB_TT_ENV, NULL);
+  *envp = MRB_OBJ_ALLOC(mrb, MRB_TT_ENV, NULL);
   (*envp)->stack = (mrb_value*)mrb_calloc(mrb, 1, sizeof(mrb_value));
   (*envp)->stack[0] = lvspace->e.env ? lvspace->e.env->stack[0] : mrb_nil_value();
   (*envp)->cxt = lvspace->e.env ? lvspace->e.env->cxt : mrb->c;

--- a/mrbgems/mruby-catch/src/catch.c
+++ b/mrbgems/mruby-catch/src/catch.c
@@ -92,7 +92,7 @@ mrb_f_throw(mrb_state *mrb, mrb_value self)
 
   const mrb_callinfo *ci = find_catcher(mrb, tag);
   if (ci) {
-    struct RBreak *b = (struct RBreak *)mrb_obj_alloc(mrb, MRB_TT_BREAK, NULL);
+    struct RBreak *b = MRB_OBJ_ALLOC(mrb, MRB_TT_BREAK, NULL);
     mrb_break_value_set(b, obj);
     mrb_break_proc_set(b, ci[2].proc); /* Back to the closure in `catch` method */
     mrb_exc_raise(mrb, mrb_obj_value(b));

--- a/mrbgems/mruby-complex/src/complex.c
+++ b/mrbgems/mruby-complex/src/complex.c
@@ -50,7 +50,7 @@ static struct RBasic*
 complex_alloc(mrb_state *mrb, struct RClass *c, struct mrb_complex **p)
 {
   struct RComplex *s;
-  s = (struct RComplex*)mrb_obj_alloc(mrb, MRB_TT_COMPLEX, c);
+  s = MRB_OBJ_ALLOC(mrb, MRB_TT_COMPLEX, c);
 #ifdef COMPLEX_INLINE
   *p = &s->r;
 #else

--- a/mrbgems/mruby-fiber/src/fiber.c
+++ b/mrbgems/mruby-fiber/src/fiber.c
@@ -397,7 +397,7 @@ static mrb_value
 fiber_current(mrb_state *mrb, mrb_value self)
 {
   if (!mrb->c->fib) {
-    struct RFiber *f = (struct RFiber*)mrb_obj_alloc(mrb, MRB_TT_FIBER, mrb_class_ptr(self));
+    struct RFiber *f = MRB_OBJ_ALLOC(mrb, MRB_TT_FIBER, mrb_class_ptr(self));
 
     f->cxt = mrb->c;
     mrb->c->fib = f;

--- a/mrbgems/mruby-method/src/method.c
+++ b/mrbgems/mruby-method/src/method.c
@@ -81,7 +81,7 @@ method_missing_prepare(mrb_state *mrb, mrb_sym *mid, mrb_value recv, struct RCla
 static struct RObject *
 method_object_alloc(mrb_state *mrb, struct RClass *mclass)
 {
-  return (struct RObject*)mrb_obj_alloc(mrb, MRB_TT_OBJECT, mclass);
+  return MRB_OBJ_ALLOC(mrb, MRB_TT_OBJECT, mclass);
 }
 
 static struct RProc*

--- a/mrbgems/mruby-rational/src/rational.c
+++ b/mrbgems/mruby-rational/src/rational.c
@@ -37,7 +37,7 @@ static struct RBasic*
 rational_alloc(mrb_state *mrb, struct RClass *c, struct mrb_rational **p)
 {
   struct RRational *s;
-  s = (struct RRational*)mrb_obj_alloc(mrb, MRB_TT_RATIONAL, c);
+  s = MRB_OBJ_ALLOC(mrb, MRB_TT_RATIONAL, c);
 #ifdef RATIONAL_INLINE
   *p = &s->r;
 #else

--- a/src/array.c
+++ b/src/array.c
@@ -29,7 +29,7 @@ ary_new_capa(mrb_state *mrb, mrb_int capa)
   }
   blen = capa * sizeof(mrb_value);
 
-  a = (struct RArray*)mrb_obj_alloc(mrb, MRB_TT_ARRAY, mrb->array_class);
+  a = MRB_OBJ_ALLOC(mrb, MRB_TT_ARRAY, mrb->array_class);
   if (capa <= MRB_ARY_EMBED_LEN_MAX) {
     ARY_SET_EMBED_LEN(a, 0);
   }
@@ -831,7 +831,7 @@ ary_subseq(mrb_state *mrb, struct RArray *a, mrb_int beg, mrb_int len)
     return mrb_ary_new_from_values(mrb, len, ARY_PTR(a)+beg);
   }
   ary_make_shared(mrb, a);
-  b  = (struct RArray*)mrb_obj_alloc(mrb, MRB_TT_ARRAY, mrb->array_class);
+  b  = MRB_OBJ_ALLOC(mrb, MRB_TT_ARRAY, mrb->array_class);
   b->as.heap.ptr = a->as.heap.ptr + beg;
   b->as.heap.len = len;
   b->as.heap.aux.shared = a->as.heap.aux.shared;

--- a/src/class.c
+++ b/src/class.c
@@ -341,7 +341,7 @@ prepare_singleton_class(mrb_state *mrb, struct RBasic *o)
   struct RClass *sc, *c;
 
   if (o->c->tt == MRB_TT_SCLASS) return;
-  sc = (struct RClass*)mrb_obj_alloc(mrb, MRB_TT_SCLASS, mrb->class_class);
+  sc = MRB_OBJ_ALLOC(mrb, MRB_TT_SCLASS, mrb->class_class);
   sc->flags |= MRB_FL_CLASS_IS_INHERITED;
   sc->mt = mt_new(mrb);
   sc->iv = 0;
@@ -1355,7 +1355,7 @@ boot_defclass(mrb_state *mrb, struct RClass *super)
 {
   struct RClass *c;
 
-  c = (struct RClass*)mrb_obj_alloc(mrb, MRB_TT_CLASS, mrb->class_class);
+  c = MRB_OBJ_ALLOC(mrb, MRB_TT_CLASS, mrb->class_class);
   if (super) {
     c->super = super;
     mrb_field_write_barrier(mrb, (struct RBasic*)c, (struct RBasic*)super);
@@ -1378,7 +1378,7 @@ boot_initmod(mrb_state *mrb, struct RClass *mod)
 static struct RClass*
 include_class_new(mrb_state *mrb, struct RClass *m, struct RClass *super)
 {
-  struct RClass *ic = (struct RClass*)mrb_obj_alloc(mrb, MRB_TT_ICLASS, mrb->class_class);
+  struct RClass *ic = MRB_OBJ_ALLOC(mrb, MRB_TT_ICLASS, mrb->class_class);
   if (m->tt == MRB_TT_ICLASS) {
     m = m->c;
   }
@@ -1509,7 +1509,7 @@ mrb_prepend_module(mrb_state *mrb, struct RClass *c, struct RClass *m)
     else {
       c0 = c;
     }
-    origin = (struct RClass*)mrb_obj_alloc(mrb, MRB_TT_ICLASS, c0);
+    origin = MRB_OBJ_ALLOC(mrb, MRB_TT_ICLASS, c0);
     origin->flags |= MRB_FL_CLASS_IS_ORIGIN | MRB_FL_CLASS_IS_INHERITED;
     origin->super = c->super;
     c->super = origin;
@@ -2180,7 +2180,7 @@ mrb_class_new(mrb_state *mrb, struct RClass *super)
 MRB_API struct RClass*
 mrb_module_new(mrb_state *mrb)
 {
-  struct RClass *m = (struct RClass*)mrb_obj_alloc(mrb, MRB_TT_MODULE, mrb->module_class);
+  struct RClass *m = MRB_OBJ_ALLOC(mrb, MRB_TT_MODULE, mrb->module_class);
   boot_initmod(mrb, m);
   return m;
 }
@@ -2219,7 +2219,7 @@ mrb_alias_method(mrb_state *mrb, struct RClass *c, mrb_sym a, mrb_sym b)
     }
     else if (p->color != MRB_GC_RED) {
       struct RClass *tc = MRB_PROC_TARGET_CLASS(p);
-      struct REnv *e = (struct REnv*)mrb_obj_alloc(mrb, MRB_TT_ENV, NULL);
+      struct REnv *e = MRB_OBJ_ALLOC(mrb, MRB_TT_ENV, NULL);
 
       e->mid = b;
       if (tc) {
@@ -2529,7 +2529,7 @@ mrb_mod_define_method_m(mrb_state *mrb, struct RClass *c)
   if (mrb_nil_p(blk)) {
     mrb_raise(mrb, E_ARGUMENT_ERROR, "no block given");
   }
-  p = (struct RProc*)mrb_obj_alloc(mrb, MRB_TT_PROC, mrb->proc_class);
+  p = MRB_OBJ_ALLOC(mrb, MRB_TT_PROC, mrb->proc_class);
   mrb_proc_copy(p, mrb_proc_ptr(blk));
   p->flags |= MRB_PROC_STRICT;
   MRB_METHOD_FROM_PROC(m, p);
@@ -2938,7 +2938,7 @@ mrb_init_class(mrb_state *mrb)
   mrb_undef_method(mrb, cls, "extend_object");
   mrb_undef_method(mrb, cls, "module_function");
 
-  mrb->top_self = (struct RObject*)mrb_obj_alloc(mrb, MRB_TT_OBJECT, mrb->object_class);
+  mrb->top_self = MRB_OBJ_ALLOC(mrb, MRB_TT_OBJECT, mrb->object_class);
   mrb_define_singleton_method(mrb, mrb->top_self, "inspect", inspect_main, MRB_ARGS_NONE());
   mrb_define_singleton_method(mrb, mrb->top_self, "to_s", inspect_main, MRB_ARGS_NONE());
   mrb_define_singleton_method(mrb, mrb->top_self, "define_method", top_define_method, MRB_ARGS_ARG(1,1));

--- a/src/etc.c
+++ b/src/etc.c
@@ -15,7 +15,7 @@ mrb_data_object_alloc(mrb_state *mrb, struct RClass *klass, void *ptr, const mrb
 {
   struct RData *data;
 
-  data = (struct RData*)mrb_obj_alloc(mrb, MRB_TT_DATA, klass);
+  data = MRB_OBJ_ALLOC(mrb, MRB_TT_DATA, klass);
   data->data = ptr;
   data->type = type;
 
@@ -185,7 +185,7 @@ MRB_API mrb_value
 mrb_xxx_boxing_cptr_value(mrb_state *mrb, void *p)
 {
   mrb_value v;
-  struct RCptr *cptr = (struct RCptr*)mrb_obj_alloc(mrb, MRB_TT_CPTR, mrb->object_class);
+  struct RCptr *cptr = MRB_OBJ_ALLOC(mrb, MRB_TT_CPTR, mrb->object_class);
 
   SET_OBJ_VALUE(v, cptr);
   cptr->p = p;

--- a/src/gc.c
+++ b/src/gc.c
@@ -295,7 +295,7 @@ MRB_API void*
 mrb_alloca(mrb_state *mrb, size_t size)
 {
   struct RString *s;
-  s = (struct RString*)mrb_obj_alloc(mrb, MRB_TT_STRING, mrb->string_class);
+  s = MRB_OBJ_ALLOC(mrb, MRB_TT_STRING, mrb->string_class);
   return s->as.heap.ptr = (char*)mrb_malloc(mrb, size);
 }
 

--- a/src/hash.c
+++ b/src/hash.c
@@ -970,7 +970,7 @@ h_key_for(mrb_state *mrb, mrb_value key)
 static struct RHash*
 h_alloc(mrb_state *mrb)
 {
-  return (struct RHash*)mrb_obj_alloc(mrb, MRB_TT_HASH, mrb->hash_class);
+  return MRB_OBJ_ALLOC(mrb, MRB_TT_HASH, mrb->hash_class);
 }
 
 static void

--- a/src/object.c
+++ b/src/object.c
@@ -316,44 +316,15 @@ mrb_init_object(mrb_state *mrb)
   mrb_define_method(mrb, f, "inspect", false_to_s,  MRB_ARGS_NONE());
 }
 
-static const struct types {
-  const enum mrb_vtype type;
-  const char *name;
-} builtin_types[] = {
-/*    {MRB_TT_NIL,  "nil"}, */
-  {MRB_TT_FALSE,  "false"},
-  {MRB_TT_TRUE,   "true"},
-  {MRB_TT_INTEGER,"Integer"},
-  {MRB_TT_SYMBOL, "Symbol"},  /* :symbol */
-  {MRB_TT_MODULE, "Module"},
-  {MRB_TT_OBJECT, "Object"},
-  {MRB_TT_CLASS,  "Class"},
-  {MRB_TT_ICLASS, "iClass"},  /* internal use: mixed-in module holder */
-  {MRB_TT_SCLASS, "SClass"},
-  {MRB_TT_PROC,   "Proc"},
-#ifndef MRB_NO_FLOAT
-  {MRB_TT_FLOAT,  "Float"},
-#endif
-  {MRB_TT_ARRAY,  "Array"},
-  {MRB_TT_HASH,   "Hash"},
-  {MRB_TT_STRING, "String"},
-  {MRB_TT_RANGE,  "Range"},
-/*    {MRB_TT_BIGNUM,  "Bignum"}, */
-  {MRB_TT_DATA,   "Data"},  /* internal use: wrapped C pointers */
-/*    {MRB_TT_UNDEF,  "undef"}, */ /* internal use: #undef; should not happen */
-  {MRB_TT_MAXDEFINE,  0}
-};
-
 static const char*
 type_name(enum mrb_vtype t)
 {
-  const struct types *type = builtin_types;
-
-  while (type->type < MRB_TT_MAXDEFINE) {
-    if (type->type == t) return type->name;
-    type++;
+  switch (t) {
+#define MRB_VTYPE_NAME(tt, type, name) case tt: return name;
+    MRB_VTYPE_FOREACH(MRB_VTYPE_NAME)
+#undef MRB_VTYPE_NAME
+    default: return NULL;
   }
-  return NULL;
 }
 
 static mrb_value

--- a/src/proc.c
+++ b/src/proc.c
@@ -46,7 +46,7 @@ mrb_proc_new(mrb_state *mrb, const mrb_irep *irep)
   struct RProc *p;
   mrb_callinfo *ci = mrb->c->ci;
 
-  p = (struct RProc*)mrb_obj_alloc(mrb, MRB_TT_PROC, mrb->proc_class);
+  p = MRB_OBJ_ALLOC(mrb, MRB_TT_PROC, mrb->proc_class);
   if (ci) {
     struct RClass *tc = NULL;
 
@@ -81,7 +81,7 @@ mrb_env_new(mrb_state *mrb, struct mrb_context *c, mrb_callinfo *ci, int nstacks
   struct REnv *e;
   mrb_int bidx;
 
-  e = (struct REnv*)mrb_obj_alloc(mrb, MRB_TT_ENV, tc);
+  e = MRB_OBJ_ALLOC(mrb, MRB_TT_ENV, tc);
   MRB_ENV_SET_LEN(e, nstacks);
   bidx = ci->argc;
   if (bidx < 0) bidx = 2;
@@ -134,7 +134,7 @@ mrb_proc_new_cfunc(mrb_state *mrb, mrb_func_t func)
 {
   struct RProc *p;
 
-  p = (struct RProc*)mrb_obj_alloc(mrb, MRB_TT_PROC, mrb->proc_class);
+  p = MRB_OBJ_ALLOC(mrb, MRB_TT_PROC, mrb->proc_class);
   p->body.func = func;
   p->flags |= MRB_PROC_CFUNC_FL;
   p->upper = 0;
@@ -224,7 +224,7 @@ mrb_proc_s_new(mrb_state *mrb, mrb_value proc_class)
 
   /* Calling Proc.new without a block is not implemented yet */
   mrb_get_args(mrb, "&!", &blk);
-  p = (struct RProc *)mrb_obj_alloc(mrb, MRB_TT_PROC, mrb_class_ptr(proc_class));
+  p = MRB_OBJ_ALLOC(mrb, MRB_TT_PROC, mrb_class_ptr(proc_class));
   mrb_proc_copy(p, mrb_proc_ptr(blk));
   proc = mrb_obj_value(p);
   mrb_funcall_with_block(mrb, proc, MRB_SYM(initialize), 0, NULL, proc);
@@ -278,7 +278,7 @@ proc_lambda(mrb_state *mrb, mrb_value self)
   }
   p = mrb_proc_ptr(blk);
   if (!MRB_PROC_STRICT_P(p)) {
-    struct RProc *p2 = (struct RProc*)mrb_obj_alloc(mrb, MRB_TT_PROC, p->c);
+    struct RProc *p2 = MRB_OBJ_ALLOC(mrb, MRB_TT_PROC, p->c);
     mrb_proc_copy(p2, p);
     p2->flags |= MRB_PROC_STRICT;
     return mrb_obj_value(p2);

--- a/src/range.c
+++ b/src/range.c
@@ -88,7 +88,7 @@ range_ptr_init(mrb_state *mrb, struct RRange *r, mrb_value beg, mrb_value end, m
     }
   }
   else {
-    r = (struct RRange*)mrb_obj_alloc(mrb, MRB_TT_RANGE, mrb->range_class);
+    r = MRB_OBJ_ALLOC(mrb, MRB_TT_RANGE, mrb->range_class);
     range_ptr_alloc_edges(mrb, r);
   }
 

--- a/src/string.c
+++ b/src/string.c
@@ -32,7 +32,7 @@ typedef struct mrb_shared_string {
 
 const char mrb_digitmap[] = "0123456789abcdefghijklmnopqrstuvwxyz";
 
-#define mrb_obj_alloc_string(mrb) ((struct RString*)mrb_obj_alloc((mrb), MRB_TT_STRING, (mrb)->string_class))
+#define mrb_obj_alloc_string(mrb) MRB_OBJ_ALLOC((mrb), MRB_TT_STRING, (mrb)->string_class)
 
 static struct RString*
 str_init_normal_capa(mrb_state *mrb, struct RString *s,

--- a/src/vm.c
+++ b/src/vm.c
@@ -892,7 +892,7 @@ break_new(mrb_state *mrb, uint32_t tag, const struct RProc *p, mrb_value val)
 {
   struct RBreak *brk;
 
-  brk = (struct RBreak*)mrb_obj_alloc(mrb, MRB_TT_BREAK, NULL);
+  brk = MRB_OBJ_ALLOC(mrb, MRB_TT_BREAK, NULL);
   mrb_break_proc_set(brk, p);
   mrb_break_value_set(brk, val);
   mrb_break_tag_set(brk, tag);


### PR DESCRIPTION
Also, rewrite `type_name()` in `src/object.c` using `MRB_VTYPE_FOREACH()` added for implementation.
