### PR TITLE
Add official pre-commit file-contents-sorter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,8 @@ repos:
       - id: check-yaml
       - id: detect-private-key
       - id: end-of-file-fixer
+      - id: file-contents-sorter
+        files: ^codespell\.txt$
       - id: fix-byte-order-marker
       - id: mixed-line-ending
       - id: trailing-whitespace
@@ -54,12 +56,3 @@ repos:
         entry: yamllint --strict -c .github/linters/.yaml-lint.yml
         types: [yaml]
         files: \.(yaml|yml)$
-  - repo: local
-    hooks:
-      - id: sort-codespell-wordlist
-        name: Sort codespell.txt
-        description: Sort alphabetically and uniquify codespell.txt
-        entry: ./scripts/ci/pre-commit/sort-codespell-wordlist.sh
-        language: system
-        files: ^\.pre-commit-config\.yaml$|^codespell\.txt$
-        require_serial: true

--- a/scripts/ci/pre-commit/sort-codespell-wordlist.sh
+++ b/scripts/ci/pre-commit/sort-codespell-wordlist.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-CODESPELL_WORDLIST="codespell.txt"
-temp_file=$(mktemp)
-sort <"${CODESPELL_WORDLIST}" | uniq >"${temp_file}"
-cat "${temp_file}" >"${CODESPELL_WORDLIST}"
-rm "${temp_file}"


### PR DESCRIPTION
Remove unneeded bash script sort-codespell-wordlist.sh

https://github.com/pre-commit/pre-commit-hooks#file-contents-sorter