### PR TITLE
Fix memory leak in `Kernel#eval`

### DIFF
--- a/mrbgems/mruby-eval/src/eval.c
+++ b/mrbgems/mruby-eval/src/eval.c
@@ -65,6 +65,7 @@ create_proc_from_string(mrb_state *mrb, const char *s, mrb_int len, mrb_value bi
 
   /* only occur when memory ran out */
   if (!p) {
+    mrbc_context_free(mrb, cxt);
     mrb_raise(mrb, E_RUNTIME_ERROR, "Failed to create parser state (out of memory)");
   }
 


### PR DESCRIPTION
The `mrbc_context` remained unreleased when the `mrb_parse_nstring()` function returned `NULL`.