### PR TITLE
Avoid warnings with `ruby -cw`

### DIFF
--- a/mrbgems/mruby-array-ext/mrblib/array.rb
+++ b/mrbgems/mruby-array-ext/mrblib/array.rb
@@ -386,7 +386,6 @@ class Array
     end
 
     beg = len = 0
-    ary = []
     if block
       if arg0.nil? && arg1.nil? && arg2.nil?
         # ary.fill { |index| block }                    -> ary
@@ -660,7 +659,6 @@ class Array
     return to_enum :keep_if unless block
 
     idx = 0
-    len = self.size
     while idx < self.size do
       if block.call(self[idx])
         idx += 1

--- a/mrbgems/mruby-hash-ext/mrblib/hash.rb
+++ b/mrbgems/mruby-hash-ext/mrblib/hash.rb
@@ -116,7 +116,6 @@ class Hash
     nk.each {|k|
       h[k] = self[k]
     }
-    h
     self.replace(h)
   end
 
@@ -256,7 +255,6 @@ class Hash
   def keep_if(&block)
     return to_enum :keep_if unless block
 
-    keys = []
     self.each do |k, v|
       unless block.call([k, v])
         self.delete(k)

--- a/mrbgems/mruby-io/mrblib/io.rb
+++ b/mrbgems/mruby-io/mrblib/io.rb
@@ -209,7 +209,7 @@ class IO
     end
 
     array = []
-    while 1
+    while true
       begin
         _read_buf
       rescue EOFError
@@ -256,7 +256,7 @@ class IO
     end
 
     array = []
-    while 1
+    while true
       begin
         _read_buf
       rescue EOFError

--- a/mrbgems/mruby-string-ext/mrblib/string.rb
+++ b/mrbgems/mruby-string-ext/mrblib/string.rb
@@ -344,8 +344,6 @@ class String
   end
 
   def codepoints(&block)
-    len = self.size
-
     if block_given?
       self.split('').each do|x|
         block.call(x.ord)

--- a/mrbgems/mruby-toplevel-ext/mrblib/toplevel.rb
+++ b/mrbgems/mruby-toplevel-ext/mrblib/toplevel.rb
@@ -1,5 +1,5 @@
 
-def self.include (*modules)
+def self.include(*modules)
   self.class.include(*modules)
 end
 


### PR DESCRIPTION
```console
% for rb in `git ls-files '*/mrblib/*.rb' 'mrblib'`; do ruby30 -cw $rb > /dev/null; done
mrbgems/mruby-array-ext/mrblib/array.rb:389: warning: assigned but unused variable - ary
mrbgems/mruby-array-ext/mrblib/array.rb:663: warning: assigned but unused variable - len
mrbgems/mruby-hash-ext/mrblib/hash.rb:119: warning: possibly useless use of a variable in void context
mrbgems/mruby-hash-ext/mrblib/hash.rb:259: warning: assigned but unused variable - keys
mrbgems/mruby-io/mrblib/io.rb:229: warning: literal in condition
mrbgems/mruby-io/mrblib/io.rb:280: warning: literal in condition
mrbgems/mruby-string-ext/mrblib/string.rb:347: warning: assigned but unused variable - len
mrbgems/mruby-toplevel-ext/mrblib/toplevel.rb:2: warning: parentheses after method name is interpreted as an argument list, not a decomposed argument
```