### PR TITLE
Mrbgem gem_init.c: add headers for irep loading when cdump is disabled, but presym is enabled

### DIFF
--- a/lib/mruby/gem.rb
+++ b/lib/mruby/gem.rb
@@ -253,7 +253,7 @@ module MRuby
           f.puts %Q[#include <mruby.h>]
         else
           f.puts %Q[#include <stdlib.h>]
-          unless build.presym_enabled?
+          unless cdump?
             f.puts %Q[#include <mruby.h>]
             f.puts %Q[#include <mruby/proc.h>]
           end


### PR DESCRIPTION
When `disable_cdump` is declared on a Mrbgem spec, the procedure for loading MRuby code from the gem's `mrblib` directory is slightly different; instead of loading the mrblib code as a Proc built from the compiled irep, the compiled irep is loaded directly. The header files `mruby.h` and `mruby/proc.h` are needed only when the irep is loaded directly. They are currently included only when presym is disabled, they should be included whenever either presym is disabled *or* when `disable_cdump` is called. The `cdump?` predicate method happens to return true in either case (presym disabled *or* cdump disabled), so this change should be safe.