### PR TITLE
Mrbgem gem_init.c: mrb_top_run, not mrb_load_proc

### DIFF
--- a/lib/mruby/gem.rb
+++ b/lib/mruby/gem.rb
@@ -214,7 +214,7 @@ module MRuby
           f.puts %Q[  mrb_#{funcname}_gem_init(mrb);] if objs != [objfile("#{build_dir}/gem_init")]
           unless rbfiles.empty?
             if cdump?
-              f.puts %Q[  mrb_load_proc(mrb, gem_mrblib_#{funcname}_proc);]
+              f.puts %Q[  mrb_top_run(mrb, gem_mrblib_#{funcname}_proc, mrb_top_self(mrb), 0);]
             else
               f.puts %Q[  mrb_load_irep(mrb, gem_mrblib_irep_#{funcname});]
             end


### PR DESCRIPTION
Some background: I am currently trying to load mrbgems compiled as dynamic libraries. This has been done before, I see that mattn's `mruby-require` library can load dynamically linked mrbgems:

https://github.com/mattn/mruby-require/blob/master/src/mrb_require.c#L340-L387

When an mrbgem contains ruby code in mrblib/, the gem_init.c generated by MRuby's build system embeds irep for the ruby. Under default circumstances, where neither presym nor cdump have been disabled, the irep is wrapped by a proc, which is loaded via `mrb_load_proc`. This does not work when the mrbgem's initialization function, e.g. `GENERATED_TMP_some_mrbgem_gem_init`, is called while the MRuby interpreter is already running -- which is not normally the case, but is for me when I'm loading mrbgems on-the-fly that have been compiled as dynamic libraries.

This change modifies the `mrb_load_proc` call to use `mrb_top_run` instead, which is safe to use even when the MRuby interpreter is active. Unless I am mistaken (which is very possible, as I'm still very new to MRuby's internals), `mrb_top_run` should be safe in the common case where the mrbgem is loaded during MRuby initialization.