### PR TITLE
Output an error if the `INTPTR_MAX` macro is undefined in C++

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -44,6 +44,9 @@
 #include <limits.h>
 
 #ifdef __cplusplus
+#ifndef UINTPTR_MAX
+#error Must be placed `#include <mruby.h>` before `#include <stdint.h>`
+#endif
 #ifndef SIZE_MAX
 #ifdef __SIZE_MAX__
 #define SIZE_MAX __SIZE_MAX__


### PR DESCRIPTION
When doing `conf.enable_cxx_abi` and compiling with FreeBSD + clang or MinGW, such as `INTPTR_MAX` constant macro is not defined if `#include <stdint.h>` precedes `#include <mruby.h>`.
Currently I get a warning when I use an undefined macro, but if I don't notice it I get confused in a link error.
It can be expected that the problem will be easier to understand by making a clear error.

Adding `-Werror=undef` as a compiler flag can also result in an error, but this can be a problem if the system header file itself uses undefined macros, for example.
This patch does minimal confirmation only, but has no side effects.