### PR TITLE
Expose all header files of the gems for small compilation

### DIFF
--- a/tasks/libmruby.rake
+++ b/tasks/libmruby.rake
@@ -14,7 +14,8 @@ MRuby.each_target do
   file "#{build_dir}/lib/libmruby.flags.mak" => [__FILE__, libmruby_static] do |t|
     mkdir_p File.dirname t.name
     open(t.name, 'w') do |f|
-      f.puts "MRUBY_CFLAGS = #{cc.all_flags}"
+      gemincs = gems.map { |g| g.export_include_paths.map { |n| g.filename(n) } }.flatten.uniq
+      f.puts "MRUBY_CFLAGS = #{cc.all_flags([], gemincs)}"
 
       f.puts "MRUBY_CC = #{cc.command}"
       f.puts "MRUBY_LD = #{linker.command}"


### PR DESCRIPTION
After building mruby, if the user compiles and links to `libmruby.a`, expose the included directory of the captured gems.
This is a change to the `<build-dir> /lib/libmruby.flags.mak` file and will result in being added to `bin/mruby-config --cflags`.
This eliminates the need for the user to look up the path and add the compiler flag if the user wants to take advantage of her gems publishing features.

In the main build with `rake CONFIG=...`, there is no problem because it can only be seen from the gems that depends directly and indirectly as before.
However, when compiling independently by the user using `bin/mruby-config`, a header file name collision may occur if a unique header directory is added.