### PR TITLE
Stirs internal state when `seed` is set in `Random`

### DIFF
--- a/mrbgems/mruby-random/src/random.c
+++ b/mrbgems/mruby-random/src/random.c
@@ -58,12 +58,17 @@ rand_init(rand_state *t)
 #endif
 }
 
+static uint32_t rand_uint32(rand_state *state);
+
 static uint32_t
 rand_seed(rand_state *t, uint32_t seed)
 {
   uint32_t old_seed = t->seed[SEEDPOS];
   rand_init(t);
   t->seed[SEEDPOS] = seed;
+  for (int i = 0; i < 10; i++) {
+    rand_uint32(t);
+  }
   return old_seed;
 }
 


### PR DESCRIPTION
This is to avoid the approximation of `Random#rand` when `seed`s are close together.

For example, the first `#rand` values after doing `Random#srand(0)` and `Random#srand(1)` are very similar.

Below is the sequence of mruby before this patch was given a `seed` of `0...20`:

```console
% bin/mruby -e 'r = Random.new; 20.times { |i| r.srand(i); puts "seed=%2d  %s" % [i, 10.times.map { "%0.3f" % r.rand }.join(" ")] }'
seed= 0  0.643 0.585 0.198 0.732 0.087 0.605 0.548 0.468 0.573 0.966
seed= 1  0.643 0.585 0.198 0.607 0.370 0.605 0.633 0.593 0.395 0.439
seed= 2  0.643 0.585 0.197 0.981 0.652 0.730 0.875 0.713 0.529 0.269
seed= 3  0.643 0.585 0.198 0.857 0.934 0.730 0.960 0.216 0.286 0.523
seed= 4  0.643 0.585 0.197 0.231 0.217 0.605 0.959 0.958 0.478 0.482
seed= 5  0.643 0.585 0.197 0.106 0.249 0.605 0.044 0.330 0.925 0.047
seed= 6  0.643 0.585 0.197 0.481 0.781 0.731 0.285 0.960 0.804 0.725
seed= 7  0.643 0.585 0.197 0.356 0.813 0.731 0.370 0.711 0.937 0.448
seed= 8  0.643 0.585 0.198 0.732 0.329 0.108 0.243 0.974 0.766 0.936
seed= 9  0.643 0.585 0.198 0.607 0.611 0.108 0.827 0.102 0.962 0.597
seed=10  0.643 0.585 0.198 0.981 0.393 0.233 0.569 0.723 0.472 0.805
seed=11  0.643 0.585 0.198 0.857 0.676 0.233 0.154 0.222 0.603 0.371
seed=12  0.643 0.585 0.198 0.231 0.458 0.108 0.654 0.979 0.928 0.577
seed=13  0.643 0.585 0.198 0.106 0.490 0.108 0.239 0.355 0.749 0.831
seed=14  0.643 0.585 0.198 0.481 0.523 0.233 0.981 0.486 0.505 0.131
seed=15  0.643 0.585 0.198 0.356 0.555 0.234 0.565 0.233 0.011 0.666
seed=16  0.643 0.585 0.197 0.730 0.573 0.611 0.904 0.512 0.971 0.153
seed=17  0.643 0.585 0.197 0.605 0.855 0.611 0.240 0.636 0.041 0.509
seed=18  0.643 0.585 0.196 0.979 0.137 0.736 0.229 0.765 0.674 0.832
seed=19  0.643 0.585 0.197 0.855 0.420 0.736 0.566 0.268 0.183 0.219
```