### PR TITLE
Organize the include of header files

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -99,6 +99,7 @@
 #include <mruby/version.h>
 
 #ifndef MRB_NO_FLOAT
+#include <math.h>
 #include <float.h>
 #ifndef FLT_EPSILON
 #define FLT_EPSILON (1.19209290e-07f)

--- a/mrbgems/mruby-cmath/src/cmath.c
+++ b/mrbgems/mruby-cmath/src/cmath.c
@@ -15,7 +15,6 @@
 # error CMath conflicts with 'MRB_NO_FLOAT' configuration
 #endif
 
-#include <math.h>
 #include <complex.h>
 
 mrb_value mrb_complex_new(mrb_state *mrb, mrb_float real, mrb_float imag);

--- a/mrbgems/mruby-compiler/core/codegen.c
+++ b/mrbgems/mruby-compiler/core/codegen.c
@@ -4,9 +4,6 @@
 ** See Copyright Notice in mruby.h
 */
 
-#include <ctype.h>
-#include <string.h>
-#include <math.h>
 #include <mruby.h>
 #include <mruby/compile.h>
 #include <mruby/proc.h>
@@ -19,6 +16,8 @@
 #include <mruby/opcode.h>
 #include <mruby/re.h>
 #include <mruby/throw.h>
+#include <ctype.h>
+#include <string.h>
 
 #ifndef MRB_CODEGEN_LEVEL_MAX
 #define MRB_CODEGEN_LEVEL_MAX 1024

--- a/mrbgems/mruby-complex/src/complex.c
+++ b/mrbgems/mruby-complex/src/complex.c
@@ -2,7 +2,6 @@
 #include <mruby/class.h>
 #include <mruby/numeric.h>
 #include <mruby/presym.h>
-#include <math.h>
 
 #ifdef MRB_NO_FLOAT
 # error Complex conflicts with 'MRB_NO_FLOAT' configuration

--- a/mrbgems/mruby-math/src/math.c
+++ b/mrbgems/mruby-math/src/math.c
@@ -12,7 +12,6 @@
 
 #include <mruby/array.h>
 #include <mruby/presym.h>
-#include <math.h>
 
 static void
 domain_error(mrb_state *mrb, const char *func)

--- a/mrbgems/mruby-numeric-ext/src/numeric_ext.c
+++ b/mrbgems/mruby-numeric-ext/src/numeric_ext.c
@@ -1,7 +1,6 @@
 #include <mruby.h>
 #include <mruby/numeric.h>
 #include <mruby/presym.h>
-#include <math.h>
 
 /*
  *  call-seq:

--- a/mrbgems/mruby-range-ext/src/range.c
+++ b/mrbgems/mruby-range-ext/src/range.c
@@ -1,6 +1,5 @@
 #include <mruby.h>
 #include <mruby/range.h>
-#include <math.h>
 
 static mrb_bool
 r_le(mrb_state *mrb, mrb_value a, mrb_value b)

--- a/mrbgems/mruby-rational/src/rational.c
+++ b/mrbgems/mruby-rational/src/rational.c
@@ -155,7 +155,6 @@ rational_new_i(mrb_state *mrb, mrb_int n, mrb_int d)
 }
 
 #ifndef MRB_NO_FLOAT
-#include <math.h>
 
 #if defined(MRB_INT32) || defined(MRB_USE_FLOAT32)
 #define frexp_rat(x,exp) frexpf((float)x, exp)

--- a/mrbgems/mruby-sprintf/src/sprintf.c
+++ b/mrbgems/mruby-sprintf/src/sprintf.c
@@ -5,14 +5,11 @@
 */
 
 #include <mruby.h>
-#include <string.h>
 #include <mruby/string.h>
 #include <mruby/hash.h>
 #include <mruby/numeric.h>
 #include <mruby/presym.h>
-#ifndef MRB_NO_FLOAT
-#include <math.h>
-#endif
+#include <string.h>
 #include <ctype.h>
 
 #define BIT_DIGITS(N)   (((N)*146)/485 + 1)  /* log2(10) =~ 146/485 */

--- a/mrbgems/mruby-time/src/time.c
+++ b/mrbgems/mruby-time/src/time.c
@@ -4,10 +4,6 @@
 ** See Copyright Notice in mruby.h
 */
 
-#ifndef MRB_NO_FLOAT
-#include <math.h>
-#endif
-
 #include <mruby.h>
 #include <mruby/class.h>
 #include <mruby/data.h>

--- a/src/dump.c
+++ b/src/dump.c
@@ -4,12 +4,12 @@
 ** See Copyright Notice in mruby.h
 */
 
-#include <string.h>
-#include <math.h>
+#include <mruby.h>
 #include <mruby/dump.h>
 #include <mruby/string.h>
 #include <mruby/irep.h>
 #include <mruby/debug.h>
+#include <string.h>
 
 #ifndef MRB_NO_FLOAT
 #include <mruby/endian.h>

--- a/src/load.c
+++ b/src/load.c
@@ -4,8 +4,7 @@
 ** See Copyright Notice in mruby.h
 */
 
-#include <string.h>
-#include <math.h>
+#include <mruby.h>
 #include <mruby/dump.h>
 #include <mruby/irep.h>
 #include <mruby/proc.h>
@@ -14,6 +13,7 @@
 #include <mruby/error.h>
 #include <mruby/data.h>
 #include <mruby/endian.h>
+#include <string.h>
 
 #if SIZE_MAX < UINT32_MAX
 # error size_t must be at least 32 bits wide

--- a/src/numeric.c
+++ b/src/numeric.c
@@ -4,17 +4,13 @@
 ** See Copyright Notice in mruby.h
 */
 
-#ifndef MRB_NO_FLOAT
-#include <math.h>
-#endif
-#include <string.h>
-
 #include <mruby.h>
 #include <mruby/array.h>
 #include <mruby/numeric.h>
 #include <mruby/string.h>
 #include <mruby/class.h>
 #include <mruby/presym.h>
+#include <string.h>
 
 #ifndef MRB_NO_FLOAT
 #ifdef MRB_USE_FLOAT32

--- a/src/string.c
+++ b/src/string.c
@@ -15,9 +15,6 @@
 #include <mruby/string.h>
 #include <mruby/numeric.h>
 #include <mruby/presym.h>
-#ifndef MRB_NO_FLOAT
-#include <math.h>
-#endif
 #include <string.h>
 
 typedef struct mrb_shared_string {

--- a/src/vm.c
+++ b/src/vm.c
@@ -20,9 +20,6 @@
 #include <mruby/throw.h>
 #include <mruby/dump.h>
 #include <mruby/presym.h>
-#ifndef MRB_NO_FLOAT
-#include <math.h>
-#endif
 
 #ifdef MRB_NO_STDIO
 #if defined(__cplusplus)


### PR DESCRIPTION
- `#include <math.h>` is done in `mruby.h`.
  Eliminate the need to worry about the `MRB_NO_FLOAT` macro.

- Include mruby header files before standard header files.
  If the standard header file is already placed before `mruby.h`, the standard header file added in the future tends to be placed before `mruby.h`.

This change should some reduce the chances of macros that must be defined becoming undefined in C++ or including problematic header files in a particular mruby build configuration.
