### PR TITLE
Avoid using `__ENCODING__` pseudo-variables

### DIFF
--- a/mrbgems/mruby-os-memsize/test/memsize.rb
+++ b/mrbgems/mruby-os-memsize/test/memsize.rb
@@ -11,7 +11,7 @@ assert 'ObjectSpace.memsize_of' do
 
   assert_not_equal ObjectSpace.memsize_of('a'), 0, 'memsize of str'
 
-  if __ENCODING__ == "UTF-8"
+  if "☺".size == 1
     assert_not_equal ObjectSpace.memsize_of("こんにちは世界"), 0, 'memsize of utf8 str'
   end
 

--- a/mrbgems/mruby-string-ext/mrblib/string.rb
+++ b/mrbgems/mruby-string-ext/mrblib/string.rb
@@ -402,7 +402,7 @@ class String
       e = max.ord
       while c <= e
         break if exclusive and c == e
-        yield c.chr(__ENCODING__)
+        yield c.chr("☺".size == 1 ? "UTF-8" : "ASCII-8BIT")
         c += 1
       end
       return self

--- a/mrbgems/mruby-string-ext/test/numeric.rb
+++ b/mrbgems/mruby-string-ext/test/numeric.rb
@@ -16,7 +16,7 @@ assert('Integer#chr') do
   assert_raise(ArgumentError) { 65.chr("ASCII-8BIT", 2) }
   assert_raise(TypeError) { 65.chr(:BINARY) }
 
-  if __ENCODING__ == "ASCII-8BIT"
+  if "☺".size == 3
     assert_raise(ArgumentError) { 65.chr("UTF-8") }
   else
     assert_equal("A", 65.chr("UTF-8"))

--- a/mrbgems/mruby-string-ext/test/string.rb
+++ b/mrbgems/mruby-string-ext/test/string.rb
@@ -2,7 +2,7 @@
 ##
 # String(Ext) Test
 
-UTF8STRING = __ENCODING__ == "UTF-8"
+UTF8STRING = "☺".size == 1
 
 def assert_upto(exp, receiver, *args)
   act = []

--- a/mrbgems/mruby-symbol-ext/test/symbol.rb
+++ b/mrbgems/mruby-symbol-ext/test/symbol.rb
@@ -14,7 +14,7 @@ end
   assert("Symbol##{n}") do
     assert_equal 5, :hello.__send__(n)
     assert_equal 4, :"aA\0b".__send__(n)
-    if __ENCODING__ == "UTF-8"
+    if "☺".size == 1
       assert_equal 8, :"こんにちは世界!".__send__(n)
       assert_equal 4, :"aあ\0b".__send__(n)
     else

--- a/test/t/string.rb
+++ b/test/t/string.rb
@@ -2,7 +2,7 @@
 ##
 # String ISO Test
 
-UTF8STRING = __ENCODING__ == "UTF-8"
+UTF8STRING = "☺".size == 1
 
 assert('String', '15.2.10') do
   assert_equal Class, String.class


### PR DESCRIPTION
`mruby-compiler` replaces the `__ENCODING__` pseudo-variable with a string literal.
In other words, `__ENCODING__` is not affected by `libmruby.a` at runtime.

So if `MRB_UTF8_STRING` was defined and there was no `mruby-bin-mrbc` gem, some tests would fail.

```console
% cat test_config.rb
MRuby::Build.new do
  toolchain "clang"
  enable_test
  enable_debug
end

MRuby::Build.new("utf8") do
  toolchain "clang"
  enable_test
  enable_debug
  defines << %w(MRB_UTF8_STRING)
  gem core: "mruby-string-ext"
  gem core: "mruby-symbol-ext"
end

% rake CONFIG=test_config.rb test
    ...SNIP...
>>> Test utf8 <<<
mrbtest - Embeddable Ruby Test

F.............F.......................................FF........................
................................................................................
................................................................................
................................................................................
................................................................................
................................................................................
................................................................................
................................................................................
......F.........................................................................
...................
Fail: Integer#chr (mrbgems: mruby-string-ext)
 - Assertion[14]
    ArgumentError expected but nothing was raised.
Fail: String#concat (mrbgems: mruby-string-ext)
 - Assertion[4]
    Expected: "H\xab"
      Actual: "H«"
 - Assertion[5]
    RangeError expected but nothing was raised.
Fail: Symbol#size (mrbgems: mruby-symbol-ext)
 - Assertion[3]
    Expected: 22
      Actual: 8
 - Assertion[4]
    Expected: 6
      Actual: 4
Fail: Symbol#length (mrbgems: mruby-symbol-ext)
 - Assertion[3]
    Expected: 22
      Actual: 8
 - Assertion[4]
    Expected: 6
      Actual: 4
Fail: String#inspect [15.2.10.5.46] (core)
 - Assertion[3]
    Expected: "\"\\xe3\\x82\\x8b\""
      Actual: "\"る\""
  Total: 739
     OK: 734
     KO: 5
  Crash: 0
Warning: 0
   Skip: 0
rake aborted!
```