### PR TITLE
Partially allow overriding of `String#[]` methods

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -1261,7 +1261,15 @@ RETRY_TRY_BLOCK:
         regs[a] = mrb_hash_get(mrb, va, vb);
         break;
       case MRB_TT_STRING:
-        regs[a] = mrb_str_aref(mrb, va, vb, mrb_undef_value());
+        switch (mrb_type(vb)) {
+        case MRB_TT_INTEGER:
+        case MRB_TT_STRING:
+        case MRB_TT_RANGE:
+          regs[a] = mrb_str_aref(mrb, va, vb, mrb_undef_value());
+          break;
+        default:
+          goto getidx_fallback;
+        }
         break;
       default:
       getidx_fallback:


### PR DESCRIPTION
This is for the purpose of supporting `Regexp`.

- configuration and build

  ```console
  % cat regexp_config.rb
  MRuby::Lockfile.disable
  MRuby::Build.new do
    toolchain "clang"
    enable_debug
    gem core: "mruby-bin-mruby"
    gem core: "mruby-print"
    gem mgem: "mruby-onig-regexp"
    #gem mgem: "mruby-regexp-pcre"
  end

  % rake MRUBY_CONFIG=regexp_config.rb
  ```

- mruby HEAD (bec074e)

  ```console
  % build/host/bin/mruby -e 'p "abcdefg"[/.(?=...$)/]'
  -e:1: can't convert OnigRegexp into Integer (TypeError)
  ```

- with this patch

  ```console
  % build/host/bin/mruby -e 'p "abcdefg"[/.(?=...$)/]'
  "d"
  ```