### PR TITLE
Fix a syntax error in commented-out code

### DIFF
--- a/build_config/default.rb
+++ b/build_config/default.rb
@@ -42,7 +42,7 @@ MRuby::Build.new do |conf|
   #   linker.library_paths = []
   #   linker.option_library = '-l%s'
   #   linker.option_library_path = '-L%s'
-  #   linker.link_options = "%{flags} -o "%{outfile}" %{objs} %{libs}"
+  #   linker.link_options = %Q[%{flags} -o "%{outfile}" %{objs} %{libs}]
   # end
 
   # Archiver settings


### PR DESCRIPTION
By uncommenting the line changed by this commit, `ruby -c build_config/default.rb` complains of a syntax error due to the illegally nested double quotes.