### PR TITLE
Make `mrb_static_assert()` a variable argument

### DIFF
--- a/include/mruby/boxing_nan.h
+++ b/include/mruby/boxing_nan.h
@@ -54,7 +54,7 @@ union mrb_value_ {
   mrb_value value;
 };
 
-mrb_static_assert1(sizeof(mrb_value) == sizeof(union mrb_value_));
+mrb_static_assert(sizeof(mrb_value) == sizeof(union mrb_value_));
 
 static inline union mrb_value_
 mrb_val_union(mrb_value v)

--- a/include/mruby/boxing_word.h
+++ b/include/mruby/boxing_word.h
@@ -130,7 +130,7 @@ union mrb_value_ {
   mrb_value value;
 };
 
-mrb_static_assert1(sizeof(mrb_value) == sizeof(union mrb_value_));
+mrb_static_assert(sizeof(mrb_value) == sizeof(union mrb_value_));
 
 static inline union mrb_value_
 mrb_val_union(mrb_value v)

--- a/mrbgems/mruby-random/src/random.c
+++ b/mrbgems/mruby-random/src/random.c
@@ -355,7 +355,7 @@ void mrb_mruby_random_gem_init(mrb_state *mrb)
   struct RClass *random;
   struct RClass *array = mrb->array_class;
 
-  mrb_static_assert1(sizeof(rand_state) <= ISTRUCT_DATA_SIZE);
+  mrb_static_assert(sizeof(rand_state) <= ISTRUCT_DATA_SIZE);
 
   mrb_define_method(mrb, mrb->kernel_module, "rand", random_f_rand, MRB_ARGS_OPT(1));
   mrb_define_method(mrb, mrb->kernel_module, "srand", random_f_srand, MRB_ARGS_OPT(1));

--- a/src/gc.c
+++ b/src/gc.c
@@ -200,7 +200,7 @@ gettimeofday_time(void)
 #define GC_RED MRB_GC_RED
 #define GC_WHITES (GC_WHITE_A | GC_WHITE_B)
 #define GC_COLOR_MASK 7
-mrb_static_assert1(MRB_GC_RED <= GC_COLOR_MASK);
+mrb_static_assert(MRB_GC_RED <= GC_COLOR_MASK);
 
 #define paint_gray(o) ((o)->color = GC_GRAY)
 #define paint_black(o) ((o)->color = GC_BLACK)

--- a/src/hash.c
+++ b/src/hash.c
@@ -69,8 +69,8 @@
 #define AR_MAX_SIZE 16
 #define H_MAX_SIZE EA_MAX_CAPA
 
-mrb_static_assert1(offsetof(struct RHash, iv) == offsetof(struct RObject, iv));
-mrb_static_assert1(AR_MAX_SIZE < (1 << MRB_HASH_AR_EA_CAPA_BIT));
+mrb_static_assert(offsetof(struct RHash, iv) == offsetof(struct RObject, iv));
+mrb_static_assert(AR_MAX_SIZE < (1 << MRB_HASH_AR_EA_CAPA_BIT));
 
 typedef struct hash_entry {
   mrb_value key;
@@ -243,7 +243,7 @@ DEFINE_SWITCHER(ht, HT)
   * assumptions.
   */
 # define HT_ASSERT_SAFE_READ(attr_name)                                       \
-  mrb_static_assert1(                                                         \
+  mrb_static_assert(                                                          \
     offsetof(hash_table, attr_name) + sizeof(((hash_table*)0)->attr_name) <=  \
     sizeof(hash_entry))
 HT_ASSERT_SAFE_READ(ea);

--- a/src/load.c
+++ b/src/load.c
@@ -98,7 +98,7 @@ read_irep_record_1(mrb_state *mrb, const uint8_t *bin, size_t *len, uint8_t flag
   if (irep->ilen > 0) {
     size_t data_len = sizeof(mrb_code) * irep->ilen +
                       sizeof(struct mrb_irep_catch_handler) * irep->clen;
-    mrb_static_assert1(sizeof(struct mrb_irep_catch_handler) == 13);
+    mrb_static_assert(sizeof(struct mrb_irep_catch_handler) == 13);
     if (SIZE_ERROR_MUL(irep->ilen, sizeof(mrb_code))) {
       return FALSE;
     }


### PR DESCRIPTION
`mrb_static_assert()` extends the macro function to take one or two arguments.
If the argument is other than that, an error will occur.

References:
- static_assert のメッセージ省略を許可 - cpprefjp C++日本語リファレンス
  https://cpprefjp.github.io/lang/cpp17/extending_static_assert.html
- c - Overloading Macro on Number of Arguments - Stack Overflow
  https://stackoverflow.com/a/11763277

- - -

The message omission of `static_assert ()` was introduced in C++17, but in C it is likely to be introduced in C23.
