### PR TITLE
Avoid redefining `MRB_WORDBOX_NO_FLOAT_TRUNCATE`

### DIFF
--- a/include/mruby/boxing_word.h
+++ b/include/mruby/boxing_word.h
@@ -7,7 +7,7 @@
 #ifndef MRUBY_BOXING_WORD_H
 #define MRUBY_BOXING_WORD_H
 
-#if defined(MRB_32BIT) && !defined(MRB_USE_FLOAT32)
+#if defined(MRB_32BIT) && !defined(MRB_USE_FLOAT32) && !defined(MRB_WORDBOX_NO_FLOAT_TRUNCATE)
 # define MRB_WORDBOX_NO_FLOAT_TRUNCATE
 #endif
 


### PR DESCRIPTION
Adding `MRB_WORDBOX_NO_FLOAT_TRUNCATE` to the build configuration in 32-bit CPU mode had a double definition.

```console
% cat myconf.rb
MRuby::Build.new do
  toolchain "clang"
  defines << "MRB_WORDBOX_NO_FLOAT_TRUNCATE"
  cc.flags << "-m32"
  linker.flags << "-m32"
  enable_debug
end

% rake CONFIG=myconf.rb
CPP   src/array.c -> build/host/src/array.pi
In file included from /var/tmp/mruby/src/array.c:7:
In file included from /var/tmp/mruby/include/mruby.h:115:
In file included from /var/tmp/mruby/include/mruby/value.h:203:
/var/tmp/mruby/include/mruby/boxing_word.h:11:10: warning:
      'MRB_WORDBOX_NO_FLOAT_TRUNCATE' macro redefined [-Wmacro-redefined]
# define MRB_WORDBOX_NO_FLOAT_TRUNCATE
         ^
<command line>:3:9: note: previous definition is here
#define MRB_WORDBOX_NO_FLOAT_TRUNCATE 1
        ^
1 warning generated.
...SNIP...
```