### PR TITLE
Avoid violations of the `mrb_static_assert()` standard

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -106,7 +106,7 @@
  *      mrb_static_assert(expect_condition, error_message);
  */
 # define mrb_static_assert(...) \
-    mrb_static_assert_expand(mrb_static_assert_selector(__VA_ARGS__, mrb_static_assert2, mrb_static_assert1)(__VA_ARGS__))
+    mrb_static_assert_expand(mrb_static_assert_selector(__VA_ARGS__, mrb_static_assert2, mrb_static_assert1, _)(__VA_ARGS__))
 #endif
 
 #include "mrbconf.h"


### PR DESCRIPTION
ref: #5564

```console
% cc -pedantic -S -Iinclude -DMRB_NO_PRESYM -o- src/array.c > /dev/null
In file included from src/array.c:7:
In file included from include/mruby.h:115:
In file included from include/mruby/value.h:204:
include/mruby/boxing_word.h:133:1: warning: must specify at least one argument for '...' parameter of variadic macro [-Wgnu-zero-variadic-macro-arguments]
mrb_static_assert(sizeof(mrb_value) == sizeof(union mrb_value_));
^
include/mruby.h:109:108: note: expanded from macro 'mrb_static_assert'
    mrb_static_assert_expand(mrb_static_assert_selector(__VA_ARGS__, mrb_static_assert2, mrb_static_assert1)(__VA_ARGS__))
                                                                                                           ^
include/mruby.h:100:10: note: macro 'mrb_static_assert_selector' defined here
# define mrb_static_assert_selector(a, b, name, ...) name
         ^
1 warning generated.
```