### PR TITLE
Fix failed build with `MRB_NAN_BOXING` and `enable_cxx_abi`

### DIFF
--- a/include/mruby/boxing_nan.h
+++ b/include/mruby/boxing_nan.h
@@ -92,7 +92,7 @@ mrb_type(mrb_value o)
   case MRB_NANBOX_TT_SYMBOL:
     return MRB_TT_SYMBOL;
   case MRB_NANBOX_TT_MISC:
-    return (enum mrb_vtype)(o.u >> 8) & 0x1f;
+    return (enum mrb_vtype)((o.u >> 8) & 0x1f);
   default:
     /* never happen */
     return MRB_TT_FLOAT;


### PR DESCRIPTION
```console
% c++ -xc++ -std=c++03 -S -Iinclude -DMRB_NAN_BOXING -DMRB_NO_PRESYM -o- src/array.c > /dev/null
In file included from src/array.c:7:
In file included from include/mruby.h:115:
In file included from include/mruby/value.h:201:
include/mruby/boxing_nan.h:95:12: error: cannot initialize return object of type 'enum mrb_vtype' with an rvalue of type 'int'
    return (enum mrb_vtype)(o.u >> 8) & 0x1f;
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```