### PR TITLE
Fixes keywords are lost with the `OP_SENDB`

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -1573,7 +1573,7 @@ RETRY_TRY_BLOCK:
       mrb_value recv;
 
       if (0 < nk && nk < 15) {  /* pack keyword arguments */
-        mrb_int kidx = a+n+1;
+        mrb_int kidx = a+(n==15?1:n)+1;
         mrb_value kdict = hash_new_from_values(mrb, nk, regs+kidx);
         regs[kidx] = kdict;
         nk = 15;


### PR DESCRIPTION
If a splat argument was passed, it could write out of range on the VM stack.

```console
% bin/mruby -e 'def m(*args, **opts, &blk) p [args, opts, blk] end; m(*%w(X Y Z), r: 1, g: 2, b: 3) {}'
[["X", "Y", "Z"], {}, #<Proc:0x80077d7d0>]
```