### PR TITLE
Check more `MRB_ARGS_NONE()`

### DIFF
--- a/include/mruby/proc.h
+++ b/include/mruby/proc.h
@@ -83,6 +83,8 @@ struct RProc {
 } while (0)
 #define MRB_PROC_SCOPE 2048
 #define MRB_PROC_SCOPE_P(p) (((p)->flags & MRB_PROC_SCOPE) != 0)
+#define MRB_PROC_NOARG 4096 /* for MRB_PROC_CFUNC_FL, it would be something like MRB_ARGS_NONE() or MRB_METHOD_NOARG_FL */
+#define MRB_PROC_NOARG_P(p) (((p)->flags & MRB_PROC_NOARG) != 0)
 
 #define mrb_proc_ptr(v)    ((struct RProc*)(mrb_ptr(v)))
 

--- a/mrbgems/mruby-method/src/method.c
+++ b/mrbgems/mruby-method/src/method.c
@@ -293,7 +293,12 @@ method_search_vm(mrb_state *mrb, struct RClass **cp, mrb_sym mid)
     return NULL;
   if (MRB_METHOD_PROC_P(m))
     return MRB_METHOD_PROC(m);
-  return mrb_proc_new_cfunc(mrb, MRB_METHOD_FUNC(m));
+
+  struct RProc *proc = mrb_proc_new_cfunc(mrb, MRB_METHOD_FUNC(m));
+  if (MRB_METHOD_NOARG_P(m)) {
+    proc->flags |= MRB_PROC_NOARG;
+  }
+  return proc;
 }
 
 static mrb_value

--- a/mrbgems/mruby-method/test/method.rb
+++ b/mrbgems/mruby-method/test/method.rb
@@ -98,6 +98,9 @@ assert 'Method#call' do
   }.new
   assert_raise(LocalJumpError) { i.method(:bar).call }
   assert_equal 3, i.method(:bar).call { |i| i }
+
+  assert_raise(ArgumentError) { nil.method(:__id__).call nil, 1 }
+  assert_raise(ArgumentError) { nil.method(:__id__).call nil, opts: 1 }
 end
 
 assert 'Method#call for regression' do
@@ -208,6 +211,9 @@ assert 'Method#to_proc' do
     yield 39
   end
   assert_equal 42, o.bar(&3.method(:+))
+
+  assert_raise(ArgumentError) { nil.method(:__id__).to_proc.call nil, 1 }
+  assert_raise(ArgumentError) { nil.method(:__id__).to_proc.call nil, opts: 1 }
 end
 
 assert 'to_s' do
@@ -449,4 +455,7 @@ assert 'UnboundMethod#bind_call' do
   assert_equal(0, m.bind_call([]))
   assert_equal(1, m.bind_call([1]))
   assert_equal(2, m.bind_call([1,2]))
+
+  assert_raise(ArgumentError) { BasicObject.instance_method(:__id__).bind_call nil, 1 }
+  assert_raise(ArgumentError) { BasicObject.instance_method(:__id__).bind_call nil, opts: 1 }
 end

--- a/test/t/argumenterror.rb
+++ b/test/t/argumenterror.rb
@@ -30,3 +30,8 @@ assert("'wrong number of arguments' from mrb_get_args") do
   assert_argnum_error(1, 2){Object.const_set(:B)}
   assert_argnum_error(3, 2){Object.const_set(:C, 1, 2)}
 end
+
+assert('Call to MRB_ARGS_NONE method') do
+  assert_raise(ArgumentError) { nil.__id__ 1 }
+  assert_raise(ArgumentError) { nil.__id__ opts: 1 }
+end

--- a/test/t/kernel.rb
+++ b/test/t/kernel.rb
@@ -95,6 +95,9 @@ assert('Kernel#__send__', '15.3.1.3.4') do
   args = [:respond_to?, :nil?]
   assert_true __send__(*args)
   assert_equal [:respond_to?, :nil?], args
+
+  assert_raise(ArgumentError) { nil.__send__(:__id__, 1) }
+  assert_raise(ArgumentError) { nil.__send__(:__id__, opts: 1) }
 end
 
 assert('Kernel#block_given?', '15.3.1.3.6') do


### PR DESCRIPTION
The `__id__` method implemented in the C function has `MRB_ARGS_NONE()` specified, but it is also effective in the following cases.

```ruby
p nil.__id__ opts: 1 rescue p :a
p nil.method(:__id__).call 1 rescue p :b
p nil.method(:__id__).call opts: 1 rescue p :c
p nil.method(:__id__).to_proc.call 1 rescue p :d
p nil.method(:__id__).to_proc.call opts: 1 rescue p :e
p nil.method(:__id__).unbind.bind_call nil, 1 rescue p :f
p nil.method(:__id__).unbind.bind_call nil, opts: 1 rescue p :g
p nil.__send__ :__id__, 1 rescue p :h
p nil.__send__ :__id__, opts: 1 rescue p :i
```

After applying this patch, all items will output symbols in the same way as CRuby.

For this purpose, add `MRB_PROC_NOARG` to `struct RProc::flags`.