### PR TITLE
Fixed compile error for `mrbgems/mruby-cmath` with `clang++`

### DIFF
--- a/mrbgems/mruby-cmath/src/cmath.c
+++ b/mrbgems/mruby-cmath/src/cmath.c
@@ -92,7 +92,7 @@ CXDIVc(mrb_complex a, mrb_complex b)
 
 #else
 
-#if defined(__cplusplus) && defined(__APPLE__)
+#if defined(__cplusplus) && (defined(__APPLE__) || (defined(__clang__) && (defined(__FreeBSD__) || defined(__OpenBSD__))))
 
 #ifdef MRB_USE_FLOAT32
 typedef std::complex<float> mrb_complex;


### PR DESCRIPTION
If the preprocessor check part is only `__clang__`, CI's such as `Ubuntu-2004-clang` will fail to compile.
This is why we limited the addition to FreeBSD and OpenBSD, which have `clang++` in their base systems.
DragonFly BSD and NetBSD have GCC built into their base systems, so nothing is changed.