### PR TITLE
Align "wrong number of arguments" messages

### DIFF
--- a/mrbgems/mruby-array-ext/mrblib/array.rb
+++ b/mrbgems/mruby-array-ext/mrblib/array.rb
@@ -382,7 +382,7 @@ class Array
 
   def fill(arg0=nil, arg1=nil, arg2=nil, &block)
     if arg0.nil? && arg1.nil? && arg2.nil? && !block
-      raise ArgumentError, "wrong number of arguments (0 for 1..3)"
+      raise ArgumentError, "wrong number of arguments (given 0, expected 1..3)"
     end
 
     beg = len = 0

--- a/mrbgems/mruby-proc-ext/mrblib/proc.rb
+++ b/mrbgems/mruby-proc-ext/mrblib/proc.rb
@@ -21,7 +21,7 @@ class Proc
       self_arity = self.arity
       if (self_arity >= 0 && arity != self_arity) ||
          (self_arity < 0 && abs[self_arity] > arity)
-        raise ArgumentError, "wrong number of arguments (#{arity} for #{abs[self_arity]})"
+        raise ArgumentError, "wrong number of arguments (given #{arity}, expected #{abs[self_arity]})"
       end
     end
 

--- a/mrbgems/mruby-string-ext/mrblib/string.rb
+++ b/mrbgems/mruby-string-ext/mrblib/string.rb
@@ -151,7 +151,7 @@ class String
   #
   def slice!(arg1, arg2=nil)
     raise FrozenError, "can't modify frozen String" if frozen?
-    raise "wrong number of arguments (for 1..2)" if arg1.nil? && arg2.nil?
+    raise ArgumentError, "wrong number of arguments (expected 1..2)" if arg1.nil? && arg2.nil?
 
     if !arg1.nil? && !arg2.nil?
       idx = arg1

--- a/mrblib/string.rb
+++ b/mrblib/string.rb
@@ -51,7 +51,7 @@ class String
   # ISO 15.2.10.5.18
   def gsub(*args, &block)
     return to_enum(:gsub, *args) if args.length == 1 && !block
-    raise ArgumentError, "wrong number of arguments" unless (1..2).include?(args.length)
+    raise ArgumentError, "wrong number of arguments (given #{args.length}, expected 1..2)" unless (1..2).include?(args.length)
 
     pattern, replace = *args
     plen = pattern.length

--- a/src/vm.c
+++ b/src/vm.c
@@ -963,13 +963,7 @@ argnum_error(mrb_state *mrb, mrb_int num)
   if (argc == 0 && mrb->c->ci->nk != 0 && !mrb_hash_empty_p(mrb, mrb->c->ci->stack[1])) {
     argc++;
   }
-  if (mrb->c->ci->mid) {
-    str = mrb_format(mrb, "'%n': wrong number of arguments (%i for %i)",
-                     mrb->c->ci->mid, argc, num);
-  }
-  else {
-    str = mrb_format(mrb, "wrong number of arguments (%i for %i)", argc, num);
-  }
+  str = mrb_format(mrb, "wrong number of arguments (given %i, expected %i)", argc, num);
   exc = mrb_exc_new_str(mrb, E_ARGUMENT_ERROR, str);
   mrb_exc_set(mrb, exc);
 }


### PR DESCRIPTION
Make "N for M" into the form "given N, expected M".

As I worked, I noticed that the `argnum_error()` function had a part to include the method name in the message.
I think this part is no longer needed by https://github.com/mruby/mruby/pull/5394.

  - Before this patch

    ```console
    % bin/mruby -e '[1, 2, 3].each 0'
    trace (most recent call last):
            [1] -e:1
    -e:1:in each: 'each': wrong number of arguments (1 for 0) (ArgumentError)
    ```

  - After this patch

    ```console
    % bin/mruby -e '[1, 2, 3].each 0'
    trace (most recent call last):
            [1] -e:1
    -e:1:in each: wrong number of arguments (given 1, expected 0) (ArgumentError)
    ```