### PR TITLE
Avoid losing the upper digits for mruby binary

### DIFF
--- a/src/dump.c
+++ b/src/dump.c
@@ -51,7 +51,7 @@ get_iseq_block_size(mrb_state *mrb, const mrb_irep *irep)
   size_t size = 0;
 
   size += sizeof(uint16_t); /* clen */
-  size += sizeof(uint16_t); /* ilen */
+  size += sizeof(uint32_t); /* ilen */
   size += irep->ilen * sizeof(mrb_code); /* iseq(n) */
   size += irep->clen * sizeof(struct mrb_irep_catch_handler);
 
@@ -66,7 +66,7 @@ write_iseq_block(mrb_state *mrb, const mrb_irep *irep, uint8_t *buf, uint8_t fla
                   irep->clen * sizeof(struct mrb_irep_catch_handler);
 
   cur += uint16_to_bin(irep->clen, cur); /* number of catch handlers */
-  cur += uint16_to_bin(irep->ilen, cur); /* number of opcode */
+  cur += uint32_to_bin(irep->ilen, cur); /* number of opcode */
   memcpy(cur, irep->iseq, seqlen);
   cur += seqlen;
 

--- a/src/load.c
+++ b/src/load.c
@@ -85,15 +85,15 @@ read_irep_record_1(mrb_state *mrb, const uint8_t *bin, size_t *len, uint8_t flag
   src += sizeof(uint16_t);
 
   /* number of child irep */
-  irep->rlen = (uint8_t)bin_to_uint16(src);
+  irep->rlen = bin_to_uint16(src);
   src += sizeof(uint16_t);
 
   /* Binary Data Section */
   /* ISEQ BLOCK (and CATCH HANDLER TABLE BLOCK) */
   irep->clen = bin_to_uint16(src);  /* number of catch handler */
   src += sizeof(uint16_t);
-  irep->ilen = bin_to_uint16(src);
-  src += sizeof(uint16_t);
+  irep->ilen = bin_to_uint32(src);
+  src += sizeof(uint32_t);
 
   if (irep->ilen > 0) {
     size_t data_len = sizeof(mrb_code) * irep->ilen +


### PR DESCRIPTION
- `rlen` keeps 16 bits.
- `ilen` keeps 32 bits.

Note that this change will break mruby binary format compatibility.