### PR TITLE
Add `bin/mrbc --no-ext-ops` switch

### DIFF
--- a/include/mruby/compile.h
+++ b/include/mruby/compile.h
@@ -31,6 +31,7 @@ typedef struct mrbc_context {
   mrb_bool no_exec:1;
   mrb_bool keep_lv:1;
   mrb_bool no_optimize:1;
+  mrb_bool no_ext_ops:1;
   const struct RProc *upper;
 
   size_t parser_nerr;
@@ -155,6 +156,7 @@ struct mrb_parser_state {
 
   mrb_bool no_optimize:1;
   mrb_bool capture_errors:1;
+  mrb_bool no_ext_ops:1;
   const struct RProc *upper;
   struct mrb_parser_message error_buffer[10];
   struct mrb_parser_message warn_buffer[10];

--- a/mrbgems/mruby-bin-mrbc/tools/mrbc/mrbc.c
+++ b/mrbgems/mruby-bin-mrbc/tools/mrbc/mrbc.c
@@ -24,6 +24,7 @@ struct mrbc_args {
   mrb_bool check_syntax : 1;
   mrb_bool verbose      : 1;
   mrb_bool remove_lv    : 1;
+  mrb_bool no_ext_ops   : 1;
   uint8_t flags         : 4;
 };
 
@@ -40,6 +41,7 @@ usage(const char *name)
   "-S           dump C struct (requires -B)",
   "-s           define <symbol> as static variable",
   "--remove-lv  remove local variables",
+  "--no-ext-ops prohibit using OP_EXTs",
   "--verbose    run at verbose mode",
   "--version    print the version",
   "--copyright  print the copyright",
@@ -163,6 +165,10 @@ parse_args(mrb_state *mrb, int argc, char **argv, struct mrbc_args *args)
           args->remove_lv = TRUE;
           break;
         }
+        else if (strcmp(argv[i] + 2, "no-ext-ops") == 0) {
+          args->no_ext_ops = TRUE;
+          break;
+        }
         return -1;
       default:
         return i;
@@ -217,6 +223,7 @@ load_file(mrb_state *mrb, struct mrbc_args *args)
   if (args->verbose)
     c->dump_result = TRUE;
   c->no_exec = TRUE;
+  c->no_ext_ops = args->no_ext_ops;
   if (input[0] == '-' && input[1] == '\0') {
     infile = stdin;
   }

--- a/mrbgems/mruby-compiler/core/codegen.c
+++ b/mrbgems/mruby-compiler/core/codegen.c
@@ -167,6 +167,14 @@ codegen_realloc(codegen_scope *s, void *p, size_t len)
   return p;
 }
 
+static void
+check_no_ext_ops(codegen_scope *s, uint16_t a, uint16_t b)
+{
+  if (s->parser->no_ext_ops && (a | b) > 0xff) {
+    codegen_error(s, "need OP_EXTs instruction (currently OP_EXTs are prohibited)");
+  }
+}
+
 static int
 new_label(codegen_scope *s)
 {
@@ -235,6 +243,7 @@ static void
 genop_1(codegen_scope *s, mrb_code i, uint16_t a)
 {
   s->lastpc = s->pc;
+  check_no_ext_ops(s, a, 0);
   if (a > 0xff) {
     gen_B(s, OP_EXT1);
     gen_B(s, i);
@@ -250,6 +259,7 @@ static void
 genop_2(codegen_scope *s, mrb_code i, uint16_t a, uint16_t b)
 {
   s->lastpc = s->pc;
+  check_no_ext_ops(s, a, b);
   if (a > 0xff && b > 0xff) {
     gen_B(s, OP_EXT3);
     gen_B(s, i);
@@ -555,6 +565,7 @@ genjmp2(codegen_scope *s, mrb_code i, uint16_t a, uint32_t pc, int val)
   }
 
   if (a > 0xff) {
+    check_no_ext_ops(s, a, 0);
     gen_B(s, OP_EXT1);
     genop_0(s, i);
     gen_S(s, a);

--- a/mrbgems/mruby-compiler/core/parse.y
+++ b/mrbgems/mruby-compiler/core/parse.y
@@ -6569,6 +6569,7 @@ parser_init_cxt(parser_state *p, mrbc_context *cxt)
   }
   p->capture_errors = cxt->capture_errors;
   p->no_optimize = cxt->no_optimize;
+  p->no_ext_ops = cxt->no_ext_ops;
   p->upper = cxt->upper;
   if (cxt->partial_hook) {
     p->cxt = cxt;

--- a/mrbgems/mruby-compiler/core/y.tab.c
+++ b/mrbgems/mruby-compiler/core/y.tab.c
@@ -12796,6 +12796,7 @@ parser_init_cxt(parser_state *p, mrbc_context *cxt)
   }
   p->capture_errors = cxt->capture_errors;
   p->no_optimize = cxt->no_optimize;
+  p->no_ext_ops = cxt->no_ext_ops;
   p->upper = cxt->upper;
   if (cxt->partial_hook) {
     p->cxt = cxt;


### PR DESCRIPTION
Print an error if `OP_EXT[123]` is needed when generating mruby binary.
This may be useful for mruby/c.

Inspired by #5590.