### PR TITLE
Print error before cleanup in `codegen_error()`

### DIFF
--- a/mrbgems/mruby-compiler/core/codegen.c
+++ b/mrbgems/mruby-compiler/core/codegen.c
@@ -111,6 +111,15 @@ static void
 codegen_error(codegen_scope *s, const char *message)
 {
   if (!s) return;
+#ifndef MRB_NO_STDIO
+  if (s->filename_sym && s->lineno) {
+    const char *filename = mrb_sym_name_len(s->mrb, s->filename_sym, NULL);
+    fprintf(stderr, "%s:%d: %s\n", filename, s->lineno, message);
+  }
+  else {
+    fprintf(stderr, "%s\n", message);
+  }
+#endif
   while (s->prev) {
     codegen_scope *tmp = s->prev;
     if (s->irep) {
@@ -137,15 +146,6 @@ codegen_error(codegen_scope *s, const char *message)
     mrb_pool_close(s->mpool);
     s = tmp;
   }
-#ifndef MRB_NO_STDIO
-  if (s->filename_sym && s->lineno) {
-    const char *filename = mrb_sym_name_len(s->mrb, s->filename_sym, NULL);
-    fprintf(stderr, "%s:%d: %s\n", filename, s->lineno, message);
-  }
-  else {
-    fprintf(stderr, "%s\n", message);
-  }
-#endif
   MRB_THROW(s->mrb->jmp);
 }
 


### PR DESCRIPTION
Previously, it always pointed to the highest scope as the location of the error.

  - example code `code.rb`

    ```ruby
    huge_num = "1" + "0" * 300; eval <<CODE, nil, "test.rb", 1
    class Object
      module A
        #{huge_num}
      end
    end
    CODE
    ```

  - Before this patch

    ```console
    % bin/mruby code.rb
    test.rb:1: integer too big
    trace (most recent call last):
            [1] code.rb:1
    code.rb:1:in eval: codegen error (ScriptError)
    ```

  - After this patch

    ```console
    % bin/mruby code.rb
    test.rb:3: integer too big
    trace (most recent call last):
            [1] code.rb:1
    code.rb:1:in eval: codegen error (ScriptError)
    ```