### PR TITLE
Get object properties after `mrb_get_args()`

### DIFF
--- a/mrbgems/mruby-array-ext/src/array.c
+++ b/mrbgems/mruby-array-ext/src/array.c
@@ -264,12 +264,14 @@ mrb_ary_compact_bang(mrb_state *mrb, mrb_value self)
 static mrb_value
 mrb_ary_rotate(mrb_state *mrb, mrb_value self)
 {
+  mrb_int count=1;
+  mrb_get_args(mrb, "|i", &count);
+
   mrb_value ary = mrb_ary_new(mrb);
   mrb_int len = RARRAY_LEN(self);
   mrb_value *p = RARRAY_PTR(self);
-  mrb_int count=1, idx;
+  mrb_int idx;
 
-  mrb_get_args(mrb, "|i", &count);
   if (len <= 0) return ary;
   if (count < 0) {
     idx = len - (~count % len) - 1;
@@ -313,12 +315,14 @@ rev(mrb_value *p, mrb_int beg, mrb_int end)
 static mrb_value
 mrb_ary_rotate_bang(mrb_state *mrb, mrb_value self)
 {
+  mrb_int count=1;
+  mrb_get_args(mrb, "|i", &count);
+
   struct RArray *a = mrb_ary_ptr(self);
   mrb_int len = ARY_LEN(a);
   mrb_value *p = ARY_PTR(a);
-  mrb_int count=1, idx;
+  mrb_int idx;
 
-  mrb_get_args(mrb, "|i", &count);
   mrb_ary_modify(mrb, a);
   if (len == 0 || count == 0) return self;
   if (count == 1) {

--- a/src/string.c
+++ b/src/string.c
@@ -2047,9 +2047,11 @@ static mrb_value
 mrb_str_rindex(mrb_state *mrb, mrb_value str)
 {
   mrb_value sub;
-  mrb_int pos, len = RSTRING_CHAR_LEN(str);
+  mrb_int pos;
+  int argc = mrb_get_args(mrb, "S|i", &sub, &pos);
+  mrb_int len = RSTRING_CHAR_LEN(str);
 
-  if (mrb_get_args(mrb, "S|i", &sub, &pos) == 1) {
+  if (argc == 1) {
     pos = len;
   }
   else {
@@ -2828,16 +2830,18 @@ static mrb_value
 mrb_str_byteslice(mrb_state *mrb, mrb_value str)
 {
   mrb_value a1;
-  mrb_int str_len = RSTRING_LEN(str), beg, len;
+  mrb_int str_len, beg, len;
   mrb_bool empty = TRUE;
 
   len = mrb_get_argc(mrb);
   switch (len) {
   case 2:
     mrb_get_args(mrb, "ii", &beg, &len);
+    str_len = RSTRING_LEN(str);
     break;
   case 1:
     a1 = mrb_get_arg1(mrb);
+    str_len = RSTRING_LEN(str);
     if (mrb_range_p(a1)) {
       if (mrb_range_beg_len(mrb, a1, &beg, &len, str_len, TRUE) != MRB_RANGE_OK) {
         return mrb_nil_value();


### PR DESCRIPTION
ref. #5613

I checked with Valgrind, and the methods that can cause use-after-free are `Array#rotate`, `Array#rotate!`, and `String#byteslice`.
Since `String#rindex` uses `RSTRING_LEN()` indirectly inside the function, no reference to the out-of-bounds range is generated.

- - -

memo: `git grep -EnC16 'mrb_get_args.*".*[fi].*"'`