### PR TITLE
Adjusting the stack for after it enters the virtual machine

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -930,6 +930,13 @@ mrb_block_given_p(mrb_state *mrb)
 MRB_API mrb_int
 mrb_get_args(mrb_state *mrb, const char *format, ...)
 {
+#define ADJUST_STACK() do { \
+  if (argv_on_stack) { \
+    ci = mrb->c->ci; \
+    argv = mrb->c->ci->stack + 1; \
+  } \
+} while (0)
+
   const char *fmt = format;
   char c;
   int i = 0;
@@ -1192,6 +1199,7 @@ mrb_get_args(mrb_state *mrb, const char *format, ...)
         p = va_arg(ap, mrb_float*);
         if (pickarg) {
           *p = mrb_as_float(mrb, *pickarg);
+          ADJUST_STACK();
         }
       }
       break;
@@ -1203,6 +1211,7 @@ mrb_get_args(mrb_state *mrb, const char *format, ...)
         p = va_arg(ap, mrb_int*);
         if (pickarg) {
           *p = mrb_as_int(mrb, *pickarg);
+          ADJUST_STACK();
         }
       }
       break;
@@ -1365,6 +1374,8 @@ mrb_get_args(mrb_state *mrb, const char *format, ...)
 finish:
   va_end(ap);
   return i;
+
+#undef ADJUST_STACK
 }
 
 static struct RClass*


### PR DESCRIPTION
ref. #5613.

I mentioned in #5540 that there was no reentrant to the virtual machine, but in fact it was still a possibility at that point.
Also, the variable `ci` needs to be recalculated at the same time.