### PR TITLE
Extend the Cygwin CI time limit to 15 minutes.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,7 +95,7 @@ jobs:
 
   Windows-Cygwin:
     runs-on: windows-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     env:
       ACTIONS_ALLOW_UNSECURE_COMMANDS: true
       MRUBY_CONFIG: ci/gcc-clang


### PR DESCRIPTION
The main reason for failure is to exceed the time limit, and even when it succeeds, there is less than a minute left.
The 10-minute time limit seems to be too short.