### PR TITLE
Call functions directly from `mrb_ensure_float_type()`

### DIFF
--- a/mrbgems/mruby-bin-mrbc/tools/mrbc/mrbc.c
+++ b/mrbgems/mruby-bin-mrbc/tools/mrbc/mrbc.c
@@ -366,3 +366,18 @@ mrb_final_mrbgems(mrb_state *mrb)
 {
 }
 #endif
+
+#ifdef MRB_USE_COMPLEX
+mrb_value mrb_complex_to_f(mrb_state *mrb, mrb_value comp)
+{
+  mrb_raise(mrb, E_NOTIMP_ERROR, "unavailable for core only");
+}
+#endif
+
+#ifdef MRB_USE_RATIONAL
+mrb_value
+mrb_rational_to_f(mrb_state *mrb, mrb_value rat)
+{
+  mrb_raise(mrb, E_NOTIMP_ERROR, "unavailable for core only");
+}
+#endif

--- a/mrbgems/mruby-complex/src/complex.c
+++ b/mrbgems/mruby-complex/src/complex.c
@@ -105,8 +105,8 @@ complex_s_rect(mrb_state *mrb, mrb_value self)
   return complex_new(mrb, real, imaginary);
 }
 
-static mrb_value
-complex_to_f(mrb_state *mrb, mrb_value self)
+mrb_value
+mrb_complex_to_f(mrb_state *mrb, mrb_value self)
 {
   struct mrb_complex *p = complex_ptr(mrb, self);
 
@@ -415,7 +415,7 @@ void mrb_mruby_complex_gem_init(mrb_state *mrb)
   mrb_define_method(mrb, mrb->kernel_module, "Complex", complex_s_rect, MRB_ARGS_REQ(1)|MRB_ARGS_OPT(1));
   mrb_define_method(mrb, comp, "real", complex_real, MRB_ARGS_NONE());
   mrb_define_method(mrb, comp, "imaginary", complex_imaginary, MRB_ARGS_NONE());
-  mrb_define_method(mrb, comp, "to_f", complex_to_f, MRB_ARGS_NONE());
+  mrb_define_method(mrb, comp, "to_f", mrb_complex_to_f, MRB_ARGS_NONE());
   mrb_define_method(mrb, comp, "to_i", complex_to_i, MRB_ARGS_NONE());
   mrb_define_method(mrb, comp, "to_c", complex_to_c, MRB_ARGS_NONE());
   mrb_define_method(mrb, comp, "+", complex_add, MRB_ARGS_REQ(1));

--- a/mrbgems/mruby-rational/src/rational.c
+++ b/mrbgems/mruby-rational/src/rational.c
@@ -291,8 +291,8 @@ rat_float(struct mrb_rational *p)
   return f;
 }
 
-static mrb_value
-rational_to_f(mrb_state *mrb, mrb_value self)
+mrb_value
+mrb_rational_to_f(mrb_state *mrb, mrb_value self)
 {
   struct mrb_rational *p = rational_ptr(mrb, self);
   return mrb_float_value(mrb, rat_float(p));
@@ -394,7 +394,7 @@ rational_eq(mrb_state *mrb, mrb_value x)
   case MRB_TT_COMPLEX:
    {
       mrb_bool mrb_complex_eq(mrb_state *mrb, mrb_value, mrb_value);
-      result = mrb_complex_eq(mrb, y, rational_to_f(mrb, x));
+      result = mrb_complex_eq(mrb, y, mrb_rational_to_f(mrb, x));
       break;
     }
 #endif
@@ -712,7 +712,7 @@ void mrb_mruby_rational_gem_init(mrb_state *mrb)
   mrb_define_method(mrb, rat, "numerator", rational_numerator, MRB_ARGS_NONE());
   mrb_define_method(mrb, rat, "denominator", rational_denominator, MRB_ARGS_NONE());
 #ifndef MRB_NO_FLOAT
-  mrb_define_method(mrb, rat, "to_f", rational_to_f, MRB_ARGS_NONE());
+  mrb_define_method(mrb, rat, "to_f", mrb_rational_to_f, MRB_ARGS_NONE());
 #endif
   mrb_define_method(mrb, rat, "to_i", rational_to_i, MRB_ARGS_NONE());
   mrb_define_method(mrb, rat, "to_r", rational_to_r, MRB_ARGS_NONE());

--- a/src/object.c
+++ b/src/object.c
@@ -499,6 +499,9 @@ mrb_ensure_int_type(mrb_state *mrb, mrb_value val)
 }
 
 #ifndef MRB_NO_FLOAT
+mrb_value mrb_complex_to_f(mrb_state *mrb, mrb_value comp); // provided by mruby-complex with MRB_USE_COMPLEX
+mrb_value mrb_rational_to_f(mrb_state *mrb, mrb_value rat); // provided by mruby-rational with MRB_USE_RATIONAL
+
 MRB_API mrb_value
 mrb_ensure_float_type(mrb_state *mrb, mrb_value val)
 {
@@ -512,9 +515,15 @@ mrb_ensure_float_type(mrb_state *mrb, mrb_value val)
     case MRB_TT_FLOAT:
       return val;
 
+#ifdef MRB_USE_RATIONAL
     case MRB_TT_RATIONAL:
+      return mrb_rational_to_f(mrb, val);
+#endif
+
+#ifdef MRB_USE_COMPLEX
     case MRB_TT_COMPLEX:
-      return mrb_type_convert(mrb, val, MRB_TT_FLOAT, MRB_SYM(to_f));
+      return mrb_complex_to_f(mrb, val);
+#endif
 
     default:
       mrb_raisef(mrb, E_TYPE_ERROR, "%Y cannot be converted to Float", val);


### PR DESCRIPTION
ref. commit 7f40b645d2773c8f50c48ae4adf90488e164da55

Currently, the build configurations `MRB_USE_COMPLEX` and `MRB_USE_RATIONAL` are not listed in the documentation.
In other words, they are hidden settings.
They are defined in `mrbgems/mruby-{complex,rational}/mrbgem.rake`.
So this patch assumes that it is safe to refer to these functions in core-gems directly from core functions.

However, applications that link with `libmruby_core.a` will have compatibility issues.
In fact, `mrbgems/mruby-bin-mrbc` links with `libmruby_core.a`, so I had to prepare a dummy function.

- - -

If this patch is merged, we can close #5620, which is no longer needed.
