### PR TITLE
Assign after `mrb_irep_incref()` in `mrb_proc_new()`

### DIFF
--- a/src/proc.c
+++ b/src/proc.c
@@ -67,10 +67,10 @@ mrb_proc_new(mrb_state *mrb, const mrb_irep *irep)
     p->upper = ci->proc;
     p->e.target_class = tc;
   }
-  p->body.irep = irep;
   if (irep) {
     mrb_irep_incref(mrb, (mrb_irep*)irep);
   }
+  p->body.irep = irep;
 
   return p;
 }


### PR DESCRIPTION
ref. 28ccc664e5dcd3f9d55173e9afde77c4705a9ab6