### PR TITLE
Fixes file header in src/{cdump,dump}.c [ci skip]

### DIFF
--- a/src/cdump.c
+++ b/src/cdump.c
@@ -1,5 +1,5 @@
 /*
-** dump.c - mruby binary dumper (mrbc binary format)
+** cdump.c - mruby binary dumper (in C)
 **
 ** See Copyright Notice in mruby.h
 */

--- a/src/dump.c
+++ b/src/dump.c
@@ -1,5 +1,5 @@
 /*
-** cdump.c - mruby binary dumper (in C)
+** dump.c - mruby binary dumper (mrbc binary format)
 **
 ** See Copyright Notice in mruby.h
 */


### PR DESCRIPTION
The file headers were pointing to each other's files.