### PR TITLE
Pinning the Visual Studio version in GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,7 +140,7 @@ jobs:
         run: echo '::set-env name=PATH::C:\windows\System32'
 
   Windows-VC:
-    runs-on: windows-latest
+    runs-on: windows-2022
     timeout-minutes: 10
     env:
       MRUBY_CONFIG: ci/msvc
@@ -151,5 +151,5 @@ jobs:
       - name: Build and test
         shell: cmd
         run: |
-          call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
           rake -m test:build && rake test:run


### PR DESCRIPTION
Until now, `windows-latest` meant `windows-2019`, but now it seems that it is being replaced by `windows-2022` in stages.
At the same time, Visual Studio 2019 will be replaced by Visual Studio 2022.

Since mruby's CI is configured to assume Visual Studio 2019, we'll update this and explicitly specify `windows-2022`.

ref. https://github.com/actions/virtual-environments/issues/4856