### PR TITLE
Added a dependency on 'yaml' to load_gems.rb.

### DIFF
--- a/lib/mruby/build/load_gems.rb
+++ b/lib/mruby/build/load_gems.rb
@@ -1,3 +1,5 @@
+require 'yaml'
+
 module MRuby
   module LoadGems
 


### PR DESCRIPTION
It appears that some execution paths no longer load YAML before it is
needed so we explicitly `require` it here.

Note that this change does **not** dynamically load the dependency the way some other code does.  I assumed that this was legacy behaviour but I can certainly change this if you would like.