### PR TITLE
Small improvements to `Module#{include,prepend}`

### DIFF
--- a/mrblib/00class.rb
+++ b/mrblib/00class.rb
@@ -22,7 +22,8 @@ class Module
 
   # 15.2.2.4.27
   def include(*args)
-    args.reverse.each do |m|
+    args.reverse!
+    args.each do |m|
       m.append_features(self)
       m.included(self)
     end
@@ -30,7 +31,8 @@ class Module
   end
 
   def prepend(*args)
-    args.reverse.each do |m|
+    args.reverse!
+    args.each do |m|
       m.prepend_features(self)
       m.prepended(self)
     end


### PR DESCRIPTION
Array objects obtained as splat arguments are generated within the method.
Therefore, it is safe to perform destructive operations.