### PR TITLE
No need to protect red objects

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -448,6 +448,7 @@ mrb_gc_destroy(mrb_state *mrb, mrb_gc *gc)
 static void
 gc_protect(mrb_state *mrb, mrb_gc *gc, struct RBasic *p)
 {
+  if (is_red(p)) return;
 #ifdef MRB_GC_FIXED_ARENA
   if (gc->arena_idx >= MRB_GC_ARENA_SIZE) {
     /* arena overflow error */


### PR DESCRIPTION
The object in `GC_RED` does not need to be marked, and the objects connected to this object should also not need to be marked.

- - -

Please reject this PR if there are future plans that require marking objects linked from objects in `GC_RED`.
