### PR TITLE
Setting `Command#build` correctly in automatic "mrbc" build for presym

### DIFF
--- a/lib/mruby/build.rb
+++ b/lib/mruby/build.rb
@@ -500,7 +500,8 @@ EOS
         v = instance_variable_get(n)
         v = case v
             when nil, true, false, Numeric; v
-            when String, Command; v.clone
+            when String; v.clone
+            when Command; v.clone.tap { |u| u.build = build }
             else Marshal.load(Marshal.dump(v))  # deep clone
             end
         build.instance_variable_set(n, v)


### PR DESCRIPTION
This was the cause of the command line flag being affected by changes in the parent build.
So, for example, if `mruby-rational` was included, even the automatically added `mrbc` builds included `MRB_USE_RATIONAL`.
