### PR TITLE
Move bigint implementation files to `mruby-bigint`

### DIFF
--- a/include/mruby/bigint.h
+++ b/include/mruby/bigint.h
@@ -85,33 +85,6 @@ struct RBigint {
 
 #define RBIGINT(v) ((struct RBigint*)mrb_ptr(v))
 
-mrb_value mrb_bint_new_int(mrb_state *mrb, mrb_int x);
-mrb_value mrb_bint_add(mrb_state *mrb, mrb_value x, mrb_value y);
-mrb_value mrb_bint_sub(mrb_state *mrb, mrb_value x, mrb_value y);
-mrb_value mrb_bint_mul(mrb_state *mrb, mrb_value x, mrb_value y);
-mrb_value mrb_bint_div(mrb_state *mrb, mrb_value x, mrb_value y);
-mrb_value mrb_bint_divmod(mrb_state *mrb, mrb_value x, mrb_value y);
-mrb_value mrb_bint_add_ii(mrb_state *mrb, mrb_int x, mrb_int y);
-mrb_value mrb_bint_sub_ii(mrb_state *mrb, mrb_int x, mrb_int y);
-mrb_value mrb_bint_mul_ii(mrb_state *mrb, mrb_int x, mrb_int y);
-mrb_value mrb_bint_div_ii(mrb_state *mrb, mrb_int x, mrb_int y);
-mrb_value mrb_bint_mod(mrb_state *mrb, mrb_value x, mrb_value y);
-mrb_value mrb_bint_rem(mrb_state *mrb, mrb_value x, mrb_value y);
-mrb_value mrb_bint_pow(mrb_state *mrb, mrb_value x, mrb_value y);
-mrb_value mrb_bint_powm(mrb_state *mrb, mrb_value x, mrb_int y, mrb_value z);
-mrb_value mrb_bint_and(mrb_state *mrb, mrb_value x, mrb_value y);
-mrb_value mrb_bint_or(mrb_state *mrb, mrb_value x, mrb_value y);
-mrb_value mrb_bint_xor(mrb_state *mrb, mrb_value x, mrb_value y);
-mrb_value mrb_bint_rev(mrb_state *mrb, mrb_value x);
-mrb_value mrb_bint_lshift(mrb_state *mrb, mrb_value x, mrb_int width);
-mrb_value mrb_bint_rshift(mrb_state *mrb, mrb_value x, mrb_int width);
-mrb_value mrb_bint_to_s(mrb_state *mrb, mrb_value x, mrb_int base);
-#ifndef MRB_NO_FLOAT
-mrb_float mrb_bint_as_float(mrb_state *mrb, mrb_value x);
-#endif
-mrb_int mrb_bint_as_int(mrb_state *mrb, mrb_value x);
-mrb_int mrb_bint_cmp(mrb_state *mrb, mrb_value x, mrb_value y);
-void mrb_gc_free_bint(mrb_state *mrb, struct RBasic *x);
 #endif
 
 #endif  /* MRB_USE_BIGINT */

--- a/mrbgems/mruby-bigint/README.md
+++ b/mrbgems/mruby-bigint/README.md
@@ -3,7 +3,3 @@
 This extension uses fgmp, which is a public domain implementation of a subset of the GNU gmp library by Mark Henderson <markh@wimsey.bc.ca>
 But it's heavily modified to fit with mruby. You can get the original source code from <https://github.com/deischi/fgmp.git>
 You can read the original README for fgmp in <README-fgmp.md>
-
-## Implementation
-
-This mrbgem is only to turn on `MRB_USE_BIGINT` flag. The implementation resides in `include/mruby/bigint.h` and `src/bigint.c`.

--- a/mrbgems/mruby-bigint/core/bigint.c
+++ b/mrbgems/mruby-bigint/core/bigint.c
@@ -3,16 +3,15 @@
 **
 ** See Copyright Notice in mruby.h
 */
-#ifdef MRB_USE_BIGINT
 
 #include <mruby.h>
 #include <mruby/object.h>
 #include <mruby/numeric.h>
-#include <mruby/bigint.h>
 #include <mruby/array.h>
 #include <mruby/string.h>
 #include <mruby/internal.h>
 #include <string.h>
+#include "bigint.h"
 
 static void
 mpz_init(mrb_state *mrb, mpz_t *s)
@@ -1458,4 +1457,3 @@ mrb_bint_rshift(mrb_state *mrb, mrb_value x, mrb_int width)
   }
   return bint_norm(mrb, b2);
 }
-#endif  /* MRB_USE_BIGINT */

--- a/mrbgems/mruby-bigint/core/bigint.h
+++ b/mrbgems/mruby-bigint/core/bigint.h
@@ -3,7 +3,6 @@
 **
 ** See Copyright Notice in mruby.h
 */
-#ifdef MRB_USE_BIGINT
 
 #ifndef MRUBY_BIGINT_H
 #define MRUBY_BIGINT_H
@@ -85,6 +84,4 @@ struct RBigint {
 
 #define RBIGINT(v) ((struct RBigint*)mrb_ptr(v))
 
-#endif
-
-#endif  /* MRB_USE_BIGINT */
+#endif  /* MRUBY_BIGINT_H */

--- a/mrbgems/mruby-bigint/mrbgem.rake
+++ b/mrbgems/mruby-bigint/mrbgem.rake
@@ -3,4 +3,8 @@ MRuby::Gem::Specification.new('mruby-bigint') do |spec|
   spec.author  = 'mruby developers'
   spec.summary = 'Integer class extension to multiple-precision'
   spec.build.defines << "MRB_USE_BIGINT"
+
+  spec.build.libmruby_core_objs << Dir.glob(File.join(__dir__, "core/**/*.c")).map { |fn|
+    objfile(fn.relative_path_from(__dir__).pathmap("#{spec.build_dir}/%X"))
+  }
 end

--- a/mrbgems/mruby-numeric-ext/src/numeric_ext.c
+++ b/mrbgems/mruby-numeric-ext/src/numeric_ext.c
@@ -4,8 +4,6 @@
 #include <mruby/presym.h>
 
 #ifdef MRB_USE_BIGINT
-#include <mruby/bigint.h>
-
 static mrb_value
 bint_allbits(mrb_state *mrb, mrb_value x, mrb_value y)
 {


### PR DESCRIPTION
Users can now switch to their own implementation of GEM.
However, we do not guarantee that this will not be a problem in the current situation.
This may need to be improved in the future.

And, a part of `bigint.h` has been removed because it duplicates `include/mruby/internal.h`.

 - - -

  - `mrbgems/mruby-bigint/core/bigint.h` ⬅ `include/mruby/bigint.h`
  - `mrbgems/mruby-bigint/core/bigint.c` ⬅ `src/bigint.c`

The files are placed in ***the `core/` directory***. Note that it is ***not the `src/` directory***.

I also plan to add tips for creating custom GEMs to `mrbgems/mruby-bigint/README.md`, using the GNU Multi-Precision Library as an example.
