### PR TITLE
Hides the class of string objects allocated by `mrb_alloca()`

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -293,7 +293,7 @@ MRB_API void*
 mrb_alloca(mrb_state *mrb, size_t size)
 {
   struct RString *s;
-  s = MRB_OBJ_ALLOC(mrb, MRB_TT_STRING, mrb->string_class);
+  s = MRB_OBJ_ALLOC(mrb, MRB_TT_STRING, NULL);
   return s->as.heap.ptr = (char*)mrb_malloc(mrb, size);
 }
 


### PR DESCRIPTION
Prevents retrieval with the `ObjectSpace.each_object` method.