### PR TITLE
Avoid triggering CodeQL on the "push" event for Dependabot branches

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,6 +2,7 @@ name: "Code scanning - action"
 
 on:
   push:
+    branches-ignore: "dependabot/**"
   pull_request:
   schedule:
     - cron: '0 19 * * 4'


### PR DESCRIPTION
refs #5699  

<img width="1281" alt="Screen Shot 2022-04-26 at 12 46 17 am" src="https://user-images.githubusercontent.com/418747/165113875-b4b1622e-8fc5-49a3-8fdf-8957cc131612.png">

