### PR TITLE
Introduced `mrb_static_assert_object_size()`

### DIFF
--- a/include/mruby/object.h
+++ b/include/mruby/object.h
@@ -40,4 +40,8 @@ struct RFiber {
   struct mrb_context *cxt;
 };
 
+#define mrb_static_assert_object_size(st) \
+  mrb_static_assert(sizeof(st) <= sizeof(void*) * 6, \
+                    #st " size must be within 6 words")
+
 #endif  /* MRUBY_OBJECT_H */

--- a/mrbgems/mruby-bigint/core/bigint.h
+++ b/mrbgems/mruby-bigint/core/bigint.h
@@ -84,4 +84,6 @@ struct RBigint {
 
 #define RBIGINT(v) ((struct RBigint*)mrb_ptr(v))
 
+mrb_static_assert_object_size(struct RBigint);
+
 #endif  /* MRUBY_BIGINT_H */

--- a/mrbgems/mruby-complex/src/complex.c
+++ b/mrbgems/mruby-complex/src/complex.c
@@ -45,6 +45,8 @@ struct RComplex {
 #define complex_ptr(mrb, v) (&((struct RComplex*)mrb_obj_ptr(v))->r)
 #endif
 
+mrb_static_assert_object_size(struct RComplex);
+
 static struct RBasic*
 complex_alloc(mrb_state *mrb, struct RClass *c, struct mrb_complex **p)
 {
@@ -351,10 +353,6 @@ complex_div(mrb_state *mrb, mrb_value x)
 void mrb_mruby_complex_gem_init(mrb_state *mrb)
 {
   struct RClass *comp;
-
-#ifdef COMPLEX_INLINE
-  mrb_assert(sizeof(struct mrb_complex) < sizeof(void*)*3);
-#endif
 
   comp = mrb_define_class_id(mrb, MRB_SYM(Complex), mrb_class_get_id(mrb, MRB_SYM(Numeric)));
   MRB_SET_INSTANCE_TT(comp, MRB_TT_COMPLEX);

--- a/mrbgems/mruby-rational/src/rational.c
+++ b/mrbgems/mruby-rational/src/rational.c
@@ -40,6 +40,8 @@ struct RRational {
 #define rational_ptr(mrb, v) (&((struct RRational*)mrb_obj_ptr(v))->r)
 #endif
 
+mrb_static_assert_object_size(struct RRational);
+
 static struct RBasic*
 rational_alloc(mrb_state *mrb, struct RClass *c, struct mrb_rational **p)
 {

--- a/src/gc.c
+++ b/src/gc.c
@@ -1650,8 +1650,7 @@ mrb_init_gc(mrb_state *mrb)
 {
   struct RClass *gc;
 
-  mrb_static_assert(sizeof(RVALUE) <= sizeof(void*) * 6,
-                    "RVALUE size must be within 6 words");
+  mrb_static_assert_object_size(RVALUE);
 
   gc = mrb_define_module(mrb, "GC");
 


### PR DESCRIPTION
Asserts the size of the object structure is less than or equal to 6 words.