### PR TITLE
Asigns table properties after `mrb_calloc()`

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -73,9 +73,9 @@ mt_rehash(mrb_state *mrb, mt_tbl *t)
   khash_power2(new_alloc);
   if (old_alloc == new_alloc) return;
 
+  t->ptr = (union mt_ptr*)mrb_calloc(mrb, sizeof(union mt_ptr)+sizeof(mrb_sym), new_alloc);
   t->alloc = new_alloc;
   t->size = 0;
-  t->ptr = (union mt_ptr*)mrb_calloc(mrb, sizeof(union mt_ptr)+sizeof(mrb_sym), new_alloc);
   if (old_alloc == 0) return;
 
   mrb_sym *keys = (mrb_sym*)&old_ptr[old_alloc];

--- a/src/variable.c
+++ b/src/variable.c
@@ -49,9 +49,9 @@ iv_rehash(mrb_state *mrb, iv_tbl *t)
   khash_power2(new_alloc);
   if (old_alloc == new_alloc) return;
 
+  t->ptr = (mrb_value*)mrb_calloc(mrb, sizeof(mrb_value)+sizeof(mrb_sym), new_alloc);
   t->size = 0;
   t->alloc = new_alloc;
-  t->ptr = (mrb_value*)mrb_calloc(mrb, sizeof(mrb_value)+sizeof(mrb_sym), new_alloc);
   if (old_alloc == 0) return;
 
   mrb_sym *keys = (mrb_sym*)&old_ptr[old_alloc];


### PR DESCRIPTION
If GC occurs in `mrb_calloc()` called by `iv_rehash()` or `mt_rehash()`, the object as table data may be destroyed.