### PR TITLE
Updates`mrb->c->ci` after `mrb_env_unshare()`

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -315,9 +315,8 @@ cipop(mrb_state *mrb)
   struct mrb_context *c = mrb->c;
   struct REnv *env = mrb_vm_ci_env(c->ci);
 
-  c->ci--;
   if (env) mrb_env_unshare(mrb, env);
-  return c->ci;
+  return --c->ci;
 }
 
 MRB_API mrb_value


### PR DESCRIPTION
If GC occurs in `mrb_malloc()` called by `mrb_env_unshare()`, `ci->u.env` may be destroyed.
If destroyed it, `ci->u.env->tt` becomes `MRB_TT_FREE`.
When control is returned to `mrb_env_unshare()`, `struct free_obj::next` in the same offset as `struct REnv::stack` is rewritten.
Unexpected results then occur when the object is reused.