### PR TITLE
Add `MRB_DEBUG_ALWAYS_GC` configuration

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -224,6 +224,9 @@ mrb_realloc_simple(mrb_state *mrb, void *p,  size_t len)
 {
   void *p2;
 
+#ifdef MRB_DEBUG_ALWAYS_GC
+  mrb_full_gc(mrb);
+#endif
   p2 = (mrb->allocf)(mrb, p, len, mrb->allocf_ud);
   if (!p2 && len > 0 && mrb->gc.heaps) {
     mrb_full_gc(mrb);


### PR DESCRIPTION
Many widely known modern desktop operating systems have a mechanism called memory overcommitment, which usually makes it difficult to make `malloc()` fail.
By introducing this configuration, `mrb_full_gc()` is forced by `mrb_realloc_simple()`.
This is intended for debugging mruby's internal implementation, but may be useful for general users as well.
However, there are still problems with mruby at this time.