### PR TITLE
Fix mismatched braces in `extern "C"` blocks when compiling as C++

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -27,9 +27,6 @@
 extern "C" {
 #endif
 void abort(void);
-#if defined(__cplusplus)
-}  /* extern "C" { */
-#endif
 #endif
 
 #define STACK_INIT_SIZE 128
@@ -3082,7 +3079,4 @@ mrb_top_run(mrb_state *mrb, const struct RProc *proc, mrb_value self, mrb_int st
 } /* end of extern "C" */
 # endif
 mrb_int mrb_jmpbuf::jmpbuf_id = 0;
-# if !defined(MRB_USE_CXX_ABI)
-extern "C" {
-# endif
 #endif


### PR DESCRIPTION
When compiling mruby with `-DMRB_USE_CXX_EXCEPTION`, clang fails to
compile and emits these warnings:

    vendor/mruby/src/vm.c:3066:1: error: extraneous closing brace ('}')
    } /* end of extern "C" */
    ^
    vendor/mruby/src/vm.c:3072:7: error: expected '}'
    #endif
          ^
    vendor/mruby/src/vm.c:3070:12: note: to match this '{'
    extern "C" {
               ^
    2 errors generated.

Fixup the implementation of the `extern "C"` block in `vm.c`.