### PR TITLE
Use `mrb->object_class` instead if `MRB_PROC_TARGET_CLASS()` is `NULL`

### DIFF
--- a/src/variable.c
+++ b/src/variable.c
@@ -828,6 +828,7 @@ mrb_vm_const_get(mrb_state *mrb, mrb_sym sym)
   proc = proc->upper;
   while (proc) {
     c2 = MRB_PROC_TARGET_CLASS(proc);
+    if (!c2) c2 = mrb->object_class;
     if (c2 && iv_get(mrb, c2->iv, sym, &v)) {
       return v;
     }


### PR DESCRIPTION
Fix #5725

---

If necessary, I think it is preferable to add a `MRB_PROC_OR_CI_TARGET_CLASS()` to get the `target_class` from `ci` instead, for example.
