### PR TITLE
Fixes `mrb_vm_ci_target_class_set()`

### DIFF
--- a/include/mruby/proc.h
+++ b/include/mruby/proc.h
@@ -157,13 +157,11 @@ static inline void
 mrb_vm_ci_target_class_set(mrb_callinfo *ci, struct RClass *tc)
 {
   struct REnv *e = ci->u.env;
-  if (e) {
-    if (e->tt == MRB_TT_ENV) {
-      e->c = tc;
-    }
-    else {
-      ci->u.target_class = tc;
-    }
+  if (e && e->tt == MRB_TT_ENV) {
+    e->c = tc;
+  }
+  else {
+    ci->u.target_class = tc;
   }
 }
 


### PR DESCRIPTION
If `ci->u.target_class` was `NULL`, the value of the argument was always ignored.
This problem is caused by #5272.

ref. #5725