### PR TITLE
Do not expand "included class" in `mrb_proc_new()`.

### DIFF
--- a/src/proc.c
+++ b/src/proc.c
@@ -52,15 +52,7 @@ mrb_proc_new(mrb_state *mrb, const mrb_irep *irep)
     struct RClass *tc = NULL;
 
     if (ci->proc) {
-      if (ci->proc->color != MRB_GC_RED) {
-        tc = MRB_PROC_TARGET_CLASS(ci->proc);
-      }
-      else {
-        tc = mrb_vm_ci_target_class(ci);
-        if (tc && tc->tt == MRB_TT_ICLASS) {
-          tc = tc->c;
-        }
-      }
+      tc = MRB_PROC_TARGET_CLASS(ci->proc);
     }
     if (tc == NULL) {
       tc = mrb_vm_ci_target_class(ci);


### PR DESCRIPTION
If `target_class->tt` is `MRB_TT_ICLASS`, it may cause loss of class inheritance relationships.
This problem is caused by #5402.

ref. #5725