### PR TITLE
Fix out of bounds access by memcmp in String#rindex

### DIFF
--- a/src/string.c
+++ b/src/string.c
@@ -637,7 +637,7 @@ str_replace(mrb_state *mrb, struct RString *s1, struct RString *s2)
 static mrb_int
 str_rindex(mrb_state *mrb, mrb_value str, mrb_value sub, mrb_int pos)
 {
-  const char *s, *sbeg, *t;
+  const char *s, *sbeg, *send, *t;
   struct RString *ps = mrb_str_ptr(str);
   mrb_int len = RSTRING_LEN(sub);
 
@@ -647,12 +647,13 @@ str_rindex(mrb_state *mrb, mrb_value str, mrb_value sub, mrb_int pos)
     pos = RSTR_LEN(ps) - len;
   }
   sbeg = RSTR_PTR(ps);
+  send = sbeg + RSTR_LEN(ps);
   s = RSTR_PTR(ps) + pos;
   t = RSTRING_PTR(sub);
   if (len) {
-    s = char_adjust(sbeg, sbeg + RSTR_LEN(ps), s);
+    s = char_adjust(sbeg, send, s);
     while (sbeg <= s) {
-      if (memcmp(s, t, len) == 0) {
+      if ((mrb_int)(send - s) >= len && memcmp(s, t, len) == 0) {
         return (mrb_int)(s - RSTR_PTR(ps));
       }
       s = char_backtrack(sbeg, s);


### PR DESCRIPTION
If compiled with MRB_UTF8_STRING and using clang-asan config, one of the tests fails due to a read out of bounds. A simple test case for this can be found by creating a string long enough to force it to be non-embedded which also ends in a three-byte UTF-8 character followed by a single ASCII character, then search for index of the UTF-8 character:

`./bin/mruby -e '"XXXXXXXXXXXXXXXXXXXXXXXX香X".rindex("香")'`

This results in a crash due to reading out of bounds:

> ==48442==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x603000001cad at pc 0x0001093104b6 bp 0x7ffee759ce50 sp 0x7ffee759c5f8
READ of size 3 at 0x603000001cad thread T0
    #0 0x1093104b5 in MemcmpInterceptorCommon(void*, int (*)(void const*, void const*, unsigned long), void const*, void const*, unsigned long)+0x155 (libclang_rt.asan_osx_dynamic.dylib:x86_64h+0x1e4b5)
    #1 0x1093109ba in wrap_memcmp+0x6a (libclang_rt.asan_osx_dynamic.dylib:x86_64h+0x1e9ba)
    #2 0x1087df358 in str_rindex string.c:657
    #3 0x1087bb6ca in mrb_str_rindex_m string.c:2055
    #4 0x1088537ed in mrb_vm_exec vm.c:1663
    #5 0x108827e31 in mrb_vm_run vm.c:1138
    #6 0x10881c851 in mrb_top_run vm.c:3072
    #7 0x108a6fde0 in mrb_load_exec parse.y:6889
    #8 0x108a72a8b in mrb_load_nstring_cxt parse.y:6961
    #9 0x108a72e4d in mrb_load_string_cxt parse.y:6973
    #10 0x108644bc4 in main mruby.c:362
    #11 0x7fff20361620 in start+0x0 (libdyld.dylib:x86_64+0x15620)

The simple fix implemented is to just not do the memcmp until we're far enough into the string where a match is actually possible.