### PR TITLE
Define `Errno::EXXX` when needed

### DIFF
--- a/mrbgems/mruby-errno/mrblib/errno.rb
+++ b/mrbgems/mruby-errno/mrblib/errno.rb
@@ -1,0 +1,15 @@
+module Errno
+  def Errno.const_defined?(name)
+    __errno_defined?(name) or super
+  end
+
+  def Errno.const_missing(name)
+    __errno_define(name) or super
+  end
+
+  # Module#constants is defined in mruby-metaprog
+  # So, it's may be raised NoMethodError
+  def Errno.constants
+    __errno_list(super)
+  end
+end


### PR DESCRIPTION
If the `Errno::EXXX` class is defined minimally when needed, it will save about 17 KiB of RAM in a 32-bit environment.
Define the singular methods `.const_defined?`, `.const_missing` and `.constants` in the `Errno` module and act as if there are classes that have not yet been defined.

However, if real classes are enumerated, for example by the following code, the effect is lost.

```ruby
Errno.constants.map { |id| Errno.const_get(id) }
```

But I believe that such codes are rarely written with the intention of being written.

In this patch, the `Errno::EXXX#initialize` method is no longer defined for further memory reduction.
Instead, it has been merged into the `SystemCallError#initialize` method.

---

Initially, one of the candidates was to move `mruby-errno` from `stdlib.gembox` to another place.
However, in that case, if `mruby-errno` is used in embedded devices, it makes no sense at all.

Then I came up with this PR method and tried it.

The other way I thought of is to incorporate the class and the constant table (iv table) into the ROM like presym does.
This may be a challenge for the future, as it seems to be very difficult to achieve.
