### PR TITLE
Ignore git checkout if nil commit-hash

### DIFF
--- a/lib/mruby/build/load_gems.rb
+++ b/lib/mruby/build/load_gems.rb
@@ -364,6 +364,7 @@ module MRuby
       end
 
       def git_checkout_dependency(repo_dir, commit, branch)
+        return unless commit
         @build.git.run_checkout_detach(repo_dir, commit)
       end
     end


### PR DESCRIPTION
If there is no `.lock` file and no commit hash specified, avoid `git checkout --detach`.
This behavior will be the same as up to mruby-3.1.

ref. #5638