### PR TITLE
Corrected the number of registers in the `Class#new` method

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -2873,7 +2873,7 @@ static const mrb_code new_iseq[] = {
 MRB_PRESYM_DEFINE_VAR_AND_INITER(new_syms, 2, MRB_SYM(allocate), MRB_SYM(initialize))
 
 static const mrb_irep new_irep = {
-  4, 5, 0, MRB_IREP_STATIC,
+  4, 6, 0, MRB_IREP_STATIC,
   new_iseq, NULL, new_syms, NULL, NULL, NULL,
   sizeof(new_iseq), 0, 2, 0, 0,
 };


### PR DESCRIPTION
`OP_SEND R4 :allocate 0` requires an an invisible `nil` block to `R5`.
If `R5` is not allocated, this can lead to unexpected results due to buffer overflow.
This problem is caused by #5565.

ref. commit 33792c2a029130bf38d676ae3cf0b51d5d54ffd5

I'm sorry.
