### PR TITLE
Fix the first operand of `struct mrb_insn_data` to 32 bits

### DIFF
--- a/include/mruby/irep.h
+++ b/include/mruby/irep.h
@@ -114,7 +114,7 @@ MRB_API mrb_value mrb_load_irep_buf_cxt(mrb_state*, const void*, size_t, mrbc_co
 
 struct mrb_insn_data {
   uint8_t insn;
-  uint16_t a;
+  uint32_t a;
   uint16_t b;
   uint16_t c;
   const mrb_code *addr;


### PR DESCRIPTION
Because there is `W` type, at least 24 bits must be represented.

---

I was not sure whether to make it a bit field or not, but decided not to worry about padding since it is limited to function arguments and return values.
