### PR TITLE
Removed unnecessary ISO section numbers for `Kernel.puts` [ci skip]

### DIFF
--- a/src/kernel.c
+++ b/src/kernel.c
@@ -578,7 +578,6 @@ mrb_init_kernel(mrb_state *mrb)
   mrb->kernel_module = krn = mrb_define_module(mrb, "Kernel");                                                    /* 15.3.1 */
   mrb_define_class_method(mrb, krn, "block_given?",         mrb_f_block_given_p_m,           MRB_ARGS_NONE());    /* 15.3.1.2.2  */
   mrb_define_class_method(mrb, krn, "iterator?",            mrb_f_block_given_p_m,           MRB_ARGS_NONE());    /* 15.3.1.2.5  */
-;     /* 15.3.1.2.11 */
   mrb_define_class_method(mrb, krn, "raise",                mrb_f_raise,                     MRB_ARGS_OPT(2));    /* 15.3.1.2.12 */
 
 


### PR DESCRIPTION
The `Kernel.puts` method is defined in the `mrbgems/mruby-print/mrblib/print.rb` file.