### PR TITLE
Perform Full-GC from `mrb_realloc_simple()` by `MRB_GC_STRESS + MRB_DEBUG`

### DIFF
--- a/doc/guides/mrbconf.md
+++ b/doc/guides/mrbconf.md
@@ -82,6 +82,8 @@ You can use mrbconfs with following ways:
 
 * When defined full GC is emitted per each `RBasic` allocation.
 * Mainly used in memory manager debugging.
+* If defined at the same time as `MRB_DEBUG`, full GC is emitted also per each heap allocation (`mrb_malloc()` or etc.).
+  This configuration slows down mruby execution by a factor of 2 to 3 or even more.
 
 `MRB_GC_TURN_OFF_GENERATIONAL`
 

--- a/src/gc.c
+++ b/src/gc.c
@@ -224,6 +224,9 @@ mrb_realloc_simple(mrb_state *mrb, void *p,  size_t len)
 {
   void *p2;
 
+#if defined(MRB_GC_STRESS) && defined(MRB_DEBUG)
+  mrb_full_gc(mrb);
+#endif
   p2 = (mrb->allocf)(mrb, p, len, mrb->allocf_ud);
   if (!p2 && len > 0 && mrb->gc.heaps) {
     mrb_full_gc(mrb);
@@ -921,6 +924,10 @@ obj_free(mrb_state *mrb, struct RBasic *obj, int end)
   default:
     break;
   }
+#if defined(MRB_GC_STRESS) && defined(MRB_DEBUG)
+  memset(obj, -1, sizeof(RVALUE));
+  paint_white(obj);
+#endif
   obj->tt = MRB_TT_FREE;
 }
 


### PR DESCRIPTION
It also fills the GC'ed object area with `0xff` for debugging purposes.

---

This PR substitutes for #5720.
Also, with only this PR, CI will report an error.
Overcoming the problem will be sent in another PR.
