### PR TITLE
Improve out-of-memory tolerance of `mrb_env_unshare()`

### DIFF
--- a/include/mruby/proc.h
+++ b/include/mruby/proc.h
@@ -36,7 +36,13 @@ struct REnv {
 #define MRB_ENV_BIDX(e) (((e)->flags >> 8) & 0xff)
 #define MRB_ENV_SET_BIDX(e,idx) ((e)->flags = (((e)->flags & ~(0xff<<8))|((unsigned int)(idx) & 0xff)<<8))
 
-void mrb_env_unshare(mrb_state*, struct REnv*);
+/*
+ * Returns TRUE on success.
+ * If the function fails:
+ * * Returns FALSE if noraise is TRUE.
+ * * Raises a NoMemoryError exception if noraise is FALSE.
+ */
+mrb_bool mrb_env_unshare(mrb_state*, struct REnv*, mrb_bool noraise);
 
 struct RProc {
   MRB_OBJECT_HEADER;

--- a/lib/mruby/gem.rb
+++ b/lib/mruby/gem.rb
@@ -225,7 +225,7 @@ module MRuby
             f.puts %Q[  }]
             f.puts %Q[  struct REnv *e = mrb_vm_ci_env(mrb->c->cibase);]
             f.puts %Q[  mrb_vm_ci_env_set(mrb->c->cibase, NULL);]
-            f.puts %Q[  mrb_env_unshare(mrb, e);]
+            f.puts %Q[  mrb_env_unshare(mrb, e, FALSE);]
           end
           f.puts %Q[  mrb_gc_arena_restore(mrb, ai);]
           f.puts %Q[}]

--- a/mrbgems/mruby-bin-mirb/tools/mirb/mirb.c
+++ b/mrbgems/mruby-bin-mirb/tools/mirb/mirb.c
@@ -519,7 +519,7 @@ main(int argc, char **argv)
     fclose(lfp);
     e = mrb_vm_ci_env(mrb->c->cibase);
     mrb_vm_ci_env_set(mrb->c->cibase, NULL);
-    mrb_env_unshare(mrb, e);
+    mrb_env_unshare(mrb, e, FALSE);
     mrbc_cleanup_local_variables(mrb, cxt);
   }
 

--- a/mrbgems/mruby-bin-mruby/tools/mruby/mruby.c
+++ b/mrbgems/mruby-bin-mruby/tools/mruby/mruby.c
@@ -342,7 +342,7 @@ main(int argc, char **argv)
       fclose(lfp);
       e = mrb_vm_ci_env(mrb->c->cibase);
       mrb_vm_ci_env_set(mrb->c->cibase, NULL);
-      mrb_env_unshare(mrb, e);
+      mrb_env_unshare(mrb, e, FALSE);
       mrbc_cleanup_local_variables(mrb, c);
     }
 

--- a/src/gc.c
+++ b/src/gc.c
@@ -839,7 +839,7 @@ obj_free(mrb_state *mrb, struct RBasic *obj, int end)
             struct REnv *e = ci->u.env;
             if (e && !mrb_object_dead_p(mrb, (struct RBasic*)e) &&
                 e->tt == MRB_TT_ENV && MRB_ENV_ONSTACK_P(e)) {
-              mrb_env_unshare(mrb, e);
+              mrb_env_unshare(mrb, e, TRUE);
             }
             ci--;
           }


### PR DESCRIPTION
Exception raising can now be controlled by the caller.

The main purpose on this patch is:

- Suppress exceptions from `obj_free()` in `src/gc.c` with `mrb_env_unshare()`.

- Consider the possibility that calls to `mrb_malloc()` may cause `e` objects to be subject to GC.

  When control is returned to `mrb_env_unshare()`, `struct free_obj::next` in the same offset as `struct REnv::stack` is rewritten.
  Unexpected results then occur when the object is reused.
  Also, if `mrb_heap_page` containing an `e` object is freed, it may cause `SIGSEGV` at that point.

- Protects the value of the stack on `callinfo` that just exits if GC occurs inside `mrb_env_unshare()`.

  ```ruby
  def m
    b = -> { b }
  end

  p m.call
  # => print block object, not nil
  ```

  This patch does not raise a `NoMemoryError` exception in `mrb_env_unshare()` and can detect that error.
  Thus, the problem fixed in # 3087 is not resurrected.

Also, it may seem that this patch should suppress exceptions raised by `cipop()` during `mrb_protect_error()` and `mrb_vm_exec()` unwinds.
However, `mrb_callinfo::u.env` by `CINFO_DIRECT` is not seen to be set.
So in that case `mrb_env_unshare()` is assumed to be originally exception-free.