### PR TITLE
Fix `SIGSEGV` caused by GC during fiber initialization

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -1020,13 +1020,11 @@ gc_gray_counts(mrb_state *mrb, mrb_gc *gc, struct RBasic *obj)
       mrb_callinfo *ci;
 
       if (!c || c->status == MRB_FIBER_TERMINATED) break;
+      if (!c->ci) break;
 
       /* mark stack */
       i = c->ci->stack - c->stbase;
-
-      if (c->ci) {
-        i += mrb_ci_nregs(c->ci);
-      }
+      i += mrb_ci_nregs(c->ci);
       if (c->stbase + i > c->stend) i = c->stend - c->stbase;
       children += i;
 


### PR DESCRIPTION
GC may occur in the `c->stbase = mrb_malloc()` part of the `fiber_init()` function.
The `SIGSEGV` happens because it references the `c->ci->stack` field without checking `c->ci`.
This is caused by #5272.