### PR TITLE
Protected `proc` objects given by `OP_DEF` on registers

### DIFF
--- a/mrbgems/mruby-compiler/core/codegen.c
+++ b/mrbgems/mruby-compiler/core/codegen.c
@@ -3763,6 +3763,7 @@ codegen(codegen_scope *s, node *tree, int val)
       genop_1(s, OP_SCLASS, cursp());
       push();
       genop_2(s, OP_METHOD, cursp(), idx);
+      push(); pop();
       pop();
       genop_2(s, OP_DEF, cursp(), sym);
       if (val) push();


### PR DESCRIPTION
If a GC occurs in `mrb_calloc()` called by `mt_rehash()` inside `mrb_define_method_raw(), the `proc` may be destroyed.