### PR TITLE
Reenabling building for Android NDK

### DIFF
--- a/build_config/android_arm64_v8a.rb
+++ b/build_config/android_arm64_v8a.rb
@@ -2,7 +2,7 @@
 MRuby::CrossBuild.new('android-arm64-v8a') do |conf|
   params = {
     :arch => 'arm64-v8a',
-    :platform => 'android-24',
+    :sdk_version => 26,
     :toolchain => :clang,
   }
   toolchain :android, params

--- a/build_config/android_armeabi.rb
+++ b/build_config/android_armeabi.rb
@@ -2,7 +2,7 @@
 MRuby::CrossBuild.new('android-armeabi') do |conf|
   params = {
     :arch => 'armeabi',
-    :platform => 'android-24',
+    :sdk_version => 26,
     :toolchain => :clang,
   }
   toolchain :android, params

--- a/build_config/android_armeabi_v7a_neon_hard.rb
+++ b/build_config/android_armeabi_v7a_neon_hard.rb
@@ -4,7 +4,7 @@ MRuby::CrossBuild.new('android-armeabi-v7a-neon-hard') do |conf|
     :arch => 'armeabi-v7a',
     :mfpu => 'neon',
     :mfloat_abi => 'hard',
-    :platform => 'android-24',
+    :sdk_version => 26,
     :toolchain => :clang,
   }
   toolchain :android, params


### PR DESCRIPTION
I found that current android.rake does not comply to Build System Maintainers Guide for NDK (Android's Native Development Kit), and mruby cannot be compiled by recent versions of NDK.
https://android.googlesource.com/platform/ndk/+/master/docs/BuildSystemMaintainers.md#Sysroot

I updated android.rake and the corresponding build config files.  With this update, I checked NDK r19 and NDK r25(latest) can build mruby on macOS 12.5 (intel).