### PR TITLE
Fixed assertion in `ARGUMENT_NORMALIZE()` for `bidx`.

### DIFF
--- a/mrbgems/mruby-compiler/core/codegen.c
+++ b/mrbgems/mruby-compiler/core/codegen.c
@@ -1958,9 +1958,14 @@ gen_assignment(codegen_scope *s, node *tree, node *rhs, int sp, int val)
       push(); pop();
       s->sp = call;
       if (mid == MRB_OPSYM_2(s->mrb, aref) && n == 2) {
+        push_n(4); pop_n(4); /* self + idx + value + (invisible block for OP_SEND) */
         genop_1(s, OP_SETIDX, cursp());
       }
       else {
+        int st = 2 /* self + block */ +
+                 (((n >> 0) & 0x0f) < 15 ? ((n >> 0) & 0x0f)     : 1) +
+                 (((n >> 4) & 0x0f) < 15 ? ((n >> 4) & 0x0f) * 2 : 1);
+        push_n(st); pop_n(st);
         genop_3(s, noself ? OP_SSEND : OP_SEND, cursp(), new_sym(s, attrsym(s, mid)), n);
       }
       if (safe) {

--- a/src/vm.c
+++ b/src/vm.c
@@ -1256,7 +1256,7 @@ hash_new_from_regs(mrb_state *mrb, mrb_int argc, mrb_int idx)
     *(arg_info) = n | (nk<<4); \
   } \
   \
-  mrb_assert(bidx < irep->nregs+(arg_base)); \
+  mrb_assert(bidx < irep->nregs); \
   mrb_int new_bidx = (arg_base)+mrb_bidx(n, nk); \
   if ((insn) == OP_SEND) { \
     /* clear block argument */ \


### PR DESCRIPTION
It should be compared to the `irep->nregs` value as is.

At the same time, discovered problems have been fixed.