### PR TITLE
Match the `mrb_value` documentation to the current implementation

### DIFF
--- a/include/mruby/value.h
+++ b/include/mruby/value.h
@@ -183,8 +183,8 @@ MRB_VTYPE_FOREACH(MRB_VTYPE_TYPEDEF)
  *
  * Actual implementation depends on configured boxing type.
  *
- * @see mruby/boxing_no.h Default boxing representation
- * @see mruby/boxing_word.h Word representation
+ * @see mruby/boxing_word.h Word boxing representation (Default)
+ * @see mruby/boxing_no.h No boxing representation
  * @see mruby/boxing_nan.h Boxed double representation
  */
 typedef void mrb_value;


### PR DESCRIPTION
:black_cat: I wish I could be more consistent, but this is my limitation.
