### PR TITLE
Protect when call Fiber#resume from C function.

### DIFF
--- a/mrbgems/mruby-fiber/src/fiber.c
+++ b/mrbgems/mruby-fiber/src/fiber.c
@@ -267,6 +267,7 @@ fiber_resume(mrb_state *mrb, mrb_value self)
   mrb_int len;
   mrb_bool vmexec = FALSE;
 
+  fiber_check_cfunc(mrb, mrb->c);
   mrb_get_args(mrb, "*!", &a, &len);
   if (mrb->c->ci->cci > 0) {
     vmexec = TRUE;


### PR DESCRIPTION
When call `Fiber#resume` from C function like `mrb_funcall()` and fiber raise a exception, mruby's stack is broken.

Add `fiber_check_cfunc` in fiber_resume() to make this problem as safe error.
Because fiber can't cross C function boundary.

This change has a breaking change, when fiber raises no exception.
Before this change, mrb_funcall() make fiber run normally.
After this change, mrb_funcall() sets mrb->exc.


Reproduction code:
```c
#include "mruby.h"
#include "mruby/compile.h"

int main(int argc, char **argv)
{
    struct mrb_state *mrb = mrb_open();
    mrb_value fiber = mrb_load_string(mrb, "Fiber.new { raise 'err' }"); // raise in fiber

    mrb_funcall(mrb, fiber, "resume", 0); // corrupse ruby's stack.

    mrb_load_string(mrb, "1"); // # SEGV in mrb_vm_ci_target_class() 

    mrb_close(mrb);
    return 0;
}
```

See: #5781 

