### PR TITLE
Improves `ObjectSpace.count_objects`

### DIFF
--- a/mrbgems/mruby-objectspace/src/mruby_objectspace.c
+++ b/mrbgems/mruby-objectspace/src/mruby_objectspace.c
@@ -78,7 +78,7 @@ os_count_objects(mrb_state *mrb, mrb_value self)
   for (i = MRB_TT_FALSE; i < MRB_TT_MAXDEFINE; i++) {
     mrb_value type;
     switch (i) {
-#define COUNT_TYPE(t) case (MRB_T ## t): type = mrb_symbol_value(mrb_intern_lit(mrb, #t)); break;
+#define COUNT_TYPE(t) case (MRB_T ## t): type = mrb_symbol_value(MRB_SYM(t)); break;
       COUNT_TYPE(T_INTEGER);
       COUNT_TYPE(T_FLOAT);
       COUNT_TYPE(T_CPTR);
@@ -96,9 +96,12 @@ os_count_objects(mrb_state *mrb, mrb_value self)
       COUNT_TYPE(T_ENV);
       COUNT_TYPE(T_DATA);
       COUNT_TYPE(T_FIBER);
+      COUNT_TYPE(T_STRUCT);
       COUNT_TYPE(T_ISTRUCT);
+      COUNT_TYPE(T_BREAK);
       COUNT_TYPE(T_COMPLEX);
       COUNT_TYPE(T_RATIONAL);
+      COUNT_TYPE(T_BIGINT);
 #undef COUNT_TYPE
     default:
       type = mrb_fixnum_value(i); break;


### PR DESCRIPTION
- Support for `MRB_TT_STRUCT`, `MRB_TT_BREAK` and `MRB_TT_BIGINT`.
- Performs symbol value embedding with `MRB_SYM()`.