### PR TITLE
Fix doc for limitation

### DIFF
--- a/doc/limitations.md
+++ b/doc/limitations.md
@@ -199,7 +199,7 @@ The re-defined `+` operator does not accept any arguments.
 ` 'ab' `
 Behavior of the operator wasn't changed.
 
-## `Kernel#binding` is not supported
+## `Kernel#binding` is not supported until [3.0.0 (2021-03-05)]
 
 `Kernel#binding` method is not supported.
 
@@ -210,7 +210,7 @@ $ ruby -e 'puts Proc.new {}.binding'
 #<Binding:0x00000e9deabb9950>
 ```
 
-#### mruby [3.1.0 (2022-05-12)]
+#### mruby [3.0.0 (2021-03-05)]
 
 ```
 $ ./bin/mruby -e 'puts Proc.new {}.binding'
@@ -218,6 +218,12 @@ trace (most recent call last):
         [0] -e:1
 -e:1: undefined method 'binding' (NoMethodError)
 ```
+
+#### mruby [3.1.0 (2022-05-12)]
+
+`binding` has been supported since 3.1.0.
+
+See also [mrbgems/mruby-binding](https://github.com/mruby/mruby/tree/master/mrbgems/mruby-binding) and [mrbgems/mruby-binding-core](https://github.com/mruby/mruby/tree/master/mrbgems/mruby-binding-core).
 
 ## `nil?` redefinition in conditional expressions
 


### PR DESCRIPTION
`binding` has been supported since 3.1.0.