### PR TITLE
Need to mark `mrb_callinfo::blk`

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -658,6 +658,7 @@ mark_context(mrb_state *mrb, struct mrb_context *c)
   if (c->cibase) {
     for (ci = c->cibase; ci <= c->ci; ci++) {
       mrb_gc_mark(mrb, (struct RBasic*)ci->proc);
+      mrb_gc_mark(mrb, (struct RBasic*)ci->blk);
       mrb_gc_mark(mrb, (struct RBasic*)ci->u.target_class);
     }
   }


### PR DESCRIPTION
ref commit eecb6cc080d6c4028d3c8df2f446af7960a04b87

---

By applying and running the following temporary patch, I should be able to confirm that the block object has been collected.

```console
% git diff
diff --git a/src/vm.c b/src/vm.c
index 379f35492..1ef7835ec 100644
--- a/src/vm.c
+++ b/src/vm.c
@@ -410,6 +410,7 @@ cipop(mrb_state *mrb)

   mrb_vm_ci_env_set(c->ci, NULL); // make possible to free by GC if env is not needed
   struct RProc *b = c->ci->blk;
+  if (b) { fprintf(stderr, "(%s:%d) tt:%d, %p\n", __func__, __LINE__, (int)b->tt, (void *)b); }
   if (b && !MRB_PROC_STRICT_P(b) && MRB_PROC_ENV(b) == CI_ENV(&c->ci[-1])) {
     b->flags |= MRB_PROC_ORPHAN;
   }

% rake -m clean all
...snip...

% bin/mruby -e 'def m(&b) b = nil; GC.start; end; m{}'
(cipop:413) tt:13, 0x80079cc00
(cipop:413) tt:13, 0x80079c4e0
(cipop:413) tt:13, 0x80079c030
(cipop:413) tt:13, 0x80079bd00
(cipop:413) tt:13, 0x80079bb50
(cipop:413) tt:13, 0x800799f30
(cipop:413) tt:13, 0x800799ab0
(cipop:413) tt:13, 0x800799270
(cipop:413) tt:13, 0x8007982b0
(cipop:413) tt:13, 0x800797860
(cipop:413) tt:13, 0x800795430
(cipop:413) tt:13, 0x8007948f0
(cipop:413) tt:4, 0x8007943b0
```
