### PR TITLE
Small improves for `mrbgems/mruby-bigint/README.md` [ci skip]

### DIFF
--- a/mrbgems/mruby-bigint/README.md
+++ b/mrbgems/mruby-bigint/README.md
@@ -1,5 +1,5 @@
 # Multi-precision Integer extension for mruby
 
-This extension uses fgmp, which is a public domain implementation of a subset of the GNU gmp library by Mark Henderson <markh@wimsey.bc.ca>
-But it's heavily modified to fit with mruby. You can get the original source code from <https://github.com/deischi/fgmp.git>
-You can read the original README for fgmp in <README-fgmp.md>
+This extension uses fgmp, which is a public domain implementation of a subset of the GNU gmp library by Mark Henderson <markh@wimsey.bc.ca>.
+But it's heavily modified to fit with mruby. You can get the original source code from <https://github.com/deischi/fgmp.git>.
+You can read the original README for fgmp in [README-fgmp.md](README-fgmp.md).


### PR DESCRIPTION
- Add a period at the end of the line because markdown will combine lines if there are no blank lines.
- Enable link to `README-fgmp.md`.