### PR TITLE
Needs `mruby-proc-ext` by `mruby-proc-binding`

### DIFF
--- a/mrbgems/mruby-proc-binding/mrbgem.rake
+++ b/mrbgems/mruby-proc-binding/mrbgem.rake
@@ -4,6 +4,7 @@ MRuby::Gem::Specification.new('mruby-proc-binding') do |spec|
   spec.summary = 'Proc#binding method'
 
   spec.add_dependency('mruby-binding-core', :core => 'mruby-binding-core')
+  spec.add_dependency('mruby-proc-ext', :core => 'mruby-proc-ext')
   spec.add_test_dependency('mruby-binding', :core => 'mruby-binding')
   spec.add_test_dependency('mruby-compiler', :core => 'mruby-compiler')
 end


### PR DESCRIPTION
The `mruby-proc_source_location()` function used in `src/proc-binding.c` of `mruby-proc-binding` is defined in `mruby-proc-ext`.