### PR TITLE
ops.h: update `OP_ARYDUP` instruction and rename  to `OP_ARYSPLAT`

### DIFF
--- a/doc/internal/opcode.md
+++ b/doc/internal/opcode.md
@@ -95,7 +95,7 @@ sign) of operands.
 | `OP_ARRAY2`        | `BBB`          | `R(a) = ary_new(R(b),R(b+1)..R(b+c))`                      |
 | `OP_ARYCAT`        | `B`            | `ary_cat(R(a),R(a+1))`                                     |
 | `OP_ARYPUSH`       | `BB`           | `ary_push(R(a),R(a+1)..R(a+b))`                            |
-| `OP_ARYDUP`        | `B`            | `R(a) = ary_dup(R(a))`                                     |
+| `OP_ARYSPLAT`      | `B`            | `R(a) = ary_splat(R(a))`                                   |
 | `OP_AREF`          | `BBB`          | `R(a) = R(b)[c]`                                           |
 | `OP_ASET`          | `BBB`          | `R(b)[c] = R(a)`                                           |
 | `OP_APOST`         | `BBB`          | `*R(a),R(a+1)..R(a+c) = R(a)[b..]`                         |

--- a/include/mruby/ops.h
+++ b/include/mruby/ops.h
@@ -87,7 +87,7 @@ OPCODE(ARRAY,      BB)       /* R[a] = ary_new(R[a],R[a+1]..R[a+b]) */
 OPCODE(ARRAY2,     BBB)      /* R[a] = ary_new(R[b],R[b+1]..R[b+c]) */
 OPCODE(ARYCAT,     B)        /* ary_cat(R[a],R[a+1]) */
 OPCODE(ARYPUSH,    BB)       /* ary_push(R[a],R[a+1]..R[a+b]) */
-OPCODE(ARYDUP,     B)        /* R[a] = ary_dup(R[a]) */
+OPCODE(ARYSPLAT,   B)        /* R[a] = ary_splat(R[a]) */
 OPCODE(AREF,       BBB)      /* R[a] = R[b][c] */
 OPCODE(ASET,       BBB)      /* R[b][c] = R[a] */
 OPCODE(APOST,      BBB)      /* *R[a],R[a+1]..R[a+c] = R[a][b..] */

--- a/mrbgems/mruby-compiler/core/codegen.c
+++ b/mrbgems/mruby-compiler/core/codegen.c
@@ -2202,7 +2202,7 @@ gen_retval(codegen_scope *s, node *tree)
   if (nint(tree->car) == NODE_SPLAT) {
     codegen(s, tree, VAL);
     pop();
-    genop_1(s, OP_ARYDUP, cursp());
+    genop_1(s, OP_ARYSPLAT, cursp());
   }
   else {
     codegen(s, tree, VAL);

--- a/src/codedump.c
+++ b/src/codedump.c
@@ -476,8 +476,8 @@ codedump(mrb_state *mrb, const mrb_irep *irep)
       printf("ARYPUSH\tR%d\t%d\t", a, b);
       print_lv_a(mrb, irep, a);
       break;
-    CASE(OP_ARYDUP, B):
-      printf("ARYDUP\tR%d\t", a);
+    CASE(OP_ARYSPLAT, B):
+      printf("ARYSPLAT\tR%d\t", a);
       print_lv_a(mrb, irep, a);
       break;
     CASE(OP_AREF, BBB):

--- a/src/vm.c
+++ b/src/vm.c
@@ -2748,15 +2748,10 @@ RETRY_TRY_BLOCK:
       NEXT;
     }
 
-    CASE(OP_ARYDUP, B) {
-      mrb_value ary = regs[a];
-      if (mrb_array_p(ary)) {
-        ary = mrb_ary_new_from_values(mrb, RARRAY_LEN(ary), RARRAY_PTR(ary));
-      }
-      else {
-        ary = mrb_ary_new_from_values(mrb, 1, &ary);
-      }
+    CASE(OP_ARYSPLAT, B) {
+      mrb_value ary = mrb_ary_splat(mrb, regs[a]);
       regs[a] = ary;
+      mrb_gc_arena_restore(mrb, ai);
       NEXT;
     }
 


### PR DESCRIPTION
Transforms the value of a splat inside an array or a return statement. For example, `return *nil` should return `nil.to_a`, while `return *1` should return `[1]`