### PR TITLE
codegen.c: exit headless `case` early if a condition is always true

### DIFF
--- a/mrbgems/mruby-compiler/core/codegen.c
+++ b/mrbgems/mruby-compiler/core/codegen.c
@@ -2606,6 +2606,25 @@ codegen(codegen_scope *s, node *tree, int val)
       }
       tree = tree->cdr;
       while (tree) {
+        if (!head) {
+          n = tree->car->car;
+          while (n) {
+            if (true_always(n->car)) {
+              codegen(s, tree->car->cdr, val);
+              if (val) pop();
+              uint32_t pos = cursp();
+              if (pos3 != JMPLINK_START) dispatch_linked(s, pos3);
+              if (val) {
+                if (cursp() != pos) {
+                  gen_move(s, cursp(), pos, 0);
+                }
+                push();
+              }
+              goto exit;
+            }
+            n = n->cdr;
+          }
+        }
         n = tree->car->car;
         pos1 = pos2 = JMPLINK_START;
         while (n) {


### PR DESCRIPTION
Without this, the following program would hang:

```rb
case
when true, false
  puts :success
end
```

Old VM instructions: (Notice the infinite loop created by `JMP 000`)

```
    2 000 JMP		000
    2 003 JMP		016
    3 006 LOADSYM	R2	:success	
    3 009 SSEND		R1	:puts	n=1
    3 013 JMP		018
    3 016 LOADNIL	R1		
    3 018 RETURN	R1		
    3 020 STOP
```

New VM instructions:

```
    3 000 LOADSYM	R2	:success	
    3 003 SSEND		R1	:puts	n=1
    3 007 RETURN	R1		
    3 009 STOP
```