### PR TITLE
tasks: enable rake docs to open on macOS

### DIFF
--- a/tasks/doc.rake
+++ b/tasks/doc.rake
@@ -22,6 +22,8 @@ namespace :doc do
       puts "  $ sudo apt-get install doxygen"
       puts "On RHEL-based systems:"
       puts "  $ sudo dnf install doxygen"
+      puts "On macOS-based systems:"
+      puts "  $ brew install doxygen"
     end
   end
 
@@ -43,12 +45,20 @@ namespace :doc do
   namespace :view do
     desc 'open yard docs'
     task :api do
-      sh 'xdg-open doc/api/index.html'
+      if RUBY_PLATFORM.include?('darwin')
+        sh 'open doc/api/index.html'
+      else
+        sh 'xdg-open doc/api/index.html'
+      end
     end
 
     desc 'open doxygen docs'
     task :capi do
-      sh 'xdg-open doc/capi/html/index.html'
+      if RUBY_PLATFORM.include?('darwin')
+        sh 'open doc/capi/html/index.html'
+      else
+        sh 'xdg-open doc/capi/html/index.html'
+      end
     end
   end
 end


### PR DESCRIPTION
The `xdg-open` command is not available on macOS.

macOS uses the `open` command.

Add info to install doxygen on macOS with Homebrew.

https://formulae.brew.sh/formula/doxygen