### PR TITLE
Replace `gsub` with `tr`

### DIFF
--- a/lib/mruby/gem.rb
+++ b/lib/mruby/gem.rb
@@ -170,7 +170,7 @@ module MRuby
       end
 
       def funcname
-        @funcname ||= @name.gsub('-', '_')
+        @funcname ||= @name.tr('-', '_')
       end
 
       def compilers

--- a/test/bintest.rb
+++ b/test/bintest.rb
@@ -44,7 +44,7 @@ ARGV.each do |gem|
 
   case RbConfig::CONFIG['host_os']
   when /mswin(?!ce)|mingw|bccwin/
-    gem = gem.gsub('\\', '/')
+    gem = gem.tr('\\', '/')
   end
 
   Dir["#{gem}/bintest/**/*.rb"].each do |file|


### PR DESCRIPTION
Using `tr` is faster than `gsub` when replacing a single character in a string with another single character