### PR TITLE
Fix spelling: `floating point` -> `floating-point`

### DIFF
--- a/build_config/cross-mingw-winetest.rb
+++ b/build_config/cross-mingw-winetest.rb
@@ -53,7 +53,7 @@
 #   4.  I recommend building 64-bit targets only.  Building a 32-bit
 #       Windows binary with i686-w64-mingw32 seems to work (at least,
 #       it did for me) but the resulting executable failed a number of
-#       unit tests due to small errors in some floating point
+#       unit tests due to small errors in some floating-point
 #       operations.  It's unclear if this indicates more serious problems.
 #
 

--- a/doc/internal/boxing.md
+++ b/doc/internal/boxing.md
@@ -25,11 +25,11 @@ The Word boxing packing bit patterns are like following:
 | symbol | xxxxxxxx xxxxxxxx xxxxxxxx xxxxxx10 |
 
 On 64 bit platform (unless `MRB_WORDBOX_NO_FLOAT_TRUNCATE`), float values are also packed in the `mrb_value`. In that case, we drop least significant 2 bits from mantissa.
-If you need full precision for floating point numbers, define `MRB_WORDBOX_NO_FLOAT_TRUNCATE`.
+If you need full precision for floating-point numbers, define `MRB_WORDBOX_NO_FLOAT_TRUNCATE`.
 
 ## NaN Boxing
 
-NaN boxing packs the Ruby data in a floating point numbers, which represent NaN (Not a Number) values. Under IEEE753 definitions every value that exponent is all set are considered as NaN. That means NaN can represent `2^51` values. NaN boxing is a teaching to pack the values in those NaN representation. In theory, 64 bits pointers are too big to fit in NaN, but practically most OS uses only 48 bits at most for pointers (except for some OS e.g. Solaris).
+NaN boxing packs the Ruby data in a floating-point numbers, which represent NaN (Not a Number) values. Under IEEE753 definitions every value that exponent is all set are considered as NaN. That means NaN can represent `2^51` values. NaN boxing is a teaching to pack the values in those NaN representation. In theory, 64 bits pointers are too big to fit in NaN, but practically most OS uses only 48 bits at most for pointers (except for some OS e.g. Solaris).
 
 The NaN boxing packing bit patterns are like following:
 
@@ -45,7 +45,7 @@ The NaN boxing packing bit patterns are like following:
 | ptr    | 01111111 11111100 PPPPPPPP PPPPPPPP PPPPPPPP PPPPPPPP PPPPPPPP PPPPPP01 |
 | nil    | 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000 |
 
-The object values appear far more frequently than floating point numbers, so we offset the value so that object pointers are unchanged. This technique is called "favor pointer"".
+The object values appear far more frequently than floating-point numbers, so we offset the value so that object pointers are unchanged. This technique is called "favor pointer"".
 
 ## No Boxing
 

--- a/doc/mruby3.0.md
+++ b/doc/mruby3.0.md
@@ -81,7 +81,7 @@ does not fit in `Fixnum` integers.
 
 ## `MRB_NAN_BOXING`
 
-Pack `mrb_value` in a floating pointer number. Nothing
+Pack `mrb_value` in a floating-point number. Nothing
 changed from previous versions.
 
 ## `MRB_USE_MALLOC_TRIM`

--- a/doc/mruby3.1.md
+++ b/doc/mruby3.1.md
@@ -155,12 +155,12 @@ Now takes 2 operands and pushes multiple entries to an array.
 
 ### Word Boxing
 
-`MRB_WORD_BOXING` now packs floating point numbers in the word, if the size of `mrb_float` is equal or smaller than the size of `mrb_int` by default.
+`MRB_WORD_BOXING` now packs floating-point numbers in the word, if the size of `mrb_float` is equal or smaller than the size of `mrb_int` by default.
 If the size of `mrb_float` and `mrb_int` are same, the last 2 bits in the `mrb_float` are trimmed and used as flags. If you need full precision, you need to define `MRB_WORDBOX_NO_FLOAT_TRUNCATE` as described above.
 
 ### NaN Boxing
 
-Previous NaN boxing packs values in NaN representation, but pointer retrievals are far more frequent than floating point number references. So we add constant offset to NaN representation to clear higher bits of pointer representation. This representation is called "Favor Pointer" NaN Boxing.
+Previous NaN boxing packs values in NaN representation, but pointer retrievals are far more frequent than floating-point number references. So we add constant offset to NaN representation to clear higher bits of pointer representation. This representation is called "Favor Pointer" NaN Boxing.
 
 Also, previous NaN boxing limit the size of `mrb_int` to 4 bytes (32 bits) to fit in NaN values. Now we allocate integer values in the heap, if the value does not fit in the 32 bit range, just like we did in Word Boxing.
 

--- a/src/fmt_fp.c
+++ b/src/fmt_fp.c
@@ -5,7 +5,7 @@
 /***********************************************************************
 
   Routine for converting a single-precision
-  floating point number into a string.
+  floating-point number into a string.
 
   The code in this function was inspired from Fred Bayer's pdouble.c.
   Since pdouble.c was released as Public Domain, I'm releasing this
@@ -254,7 +254,7 @@ mrb_format_float(mrb_float f, char *buf, size_t buf_size, char fmt, int prec, ch
     prec = 0;
   }
 
-  // We now have f as a floating point number between >= 1 and < 10
+  // We now have f as a floating-point number between >= 1 and < 10
   // (or equal to zero), and e contains the absolute value of the power of
   // 10 exponent. and (dec + 1) == the number of dgits before the decimal.
 

--- a/src/numeric.c
+++ b/src/numeric.c
@@ -884,7 +884,7 @@ flo_rounding(mrb_state *mrb, mrb_value num, double (*func)(double))
  *  When the precision is negative, the returned value is an integer
  *  with at least <code>ndigits.abs</code> trailing zeros.
  *
- *  Returns a floating point number when +ndigits+ is positive,
+ *  Returns a floating-point number when +ndigits+ is positive,
  *  otherwise returns an integer.
  *
  *     1.2.floor      #=> 1
@@ -907,7 +907,7 @@ flo_rounding(mrb_state *mrb, mrb_value num, double (*func)(double))
  *     34567.89.floor(2)   #=> 34567.89
  *     34567.89.floor(3)   #=> 34567.89
  *
- *  Note that the limited precision of floating point arithmetic
+ *  Note that the limited precision of floating-point arithmetic
  *  might lead to surprising results:
  *
  *     (0.3 / 0.1).floor  #=> 2 (!)
@@ -929,7 +929,7 @@ flo_floor(mrb_state *mrb, mrb_value num)
  *  When the precision is negative, the returned value is an integer
  *  with at least <code>ndigits.abs</code> trailing zeros.
  *
- *  Returns a floating point number when +ndigits+ is positive,
+ *  Returns a floating-point number when +ndigits+ is positive,
  *  otherwise returns an integer.
  *
  *     1.2.ceil      #=> 2
@@ -952,7 +952,7 @@ flo_floor(mrb_state *mrb, mrb_value num)
  *     34567.89.ceil(2)   #=> 34567.89
  *     34567.89.ceil(3)   #=> 34567.89
  *
- *  Note that the limited precision of floating point arithmetic
+ *  Note that the limited precision of floating-point arithmetic
  *  might lead to surprising results:
  *
  *     (2.1 / 0.7).ceil  #=> 4 (!)


### PR DESCRIPTION
https://en.wikipedia.org/wiki/Floating-point_arithmetic