### PR TITLE
Remove `# coding: utf-8` from Ruby files

### DIFF
--- a/mrbgems/mruby-pack/test/pack.rb
+++ b/mrbgems/mruby-pack/test/pack.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 PACK_IS_LITTLE_ENDIAN = "\x01\00".unpack('S')[0] == 0x01
 
 def assert_pack tmpl, packed, unpacked

--- a/mrbgems/mruby-string-ext/test/numeric.rb
+++ b/mrbgems/mruby-string-ext/test/numeric.rb
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 assert('Integer#chr') do
   assert_equal("A", 65.chr)
   assert_equal("B", 0x42.chr)

--- a/mrbgems/mruby-string-ext/test/string.rb
+++ b/mrbgems/mruby-string-ext/test/string.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 ##
 # String(Ext) Test
 

--- a/mrbgems/mruby-symbol-ext/test/symbol.rb
+++ b/mrbgems/mruby-symbol-ext/test/symbol.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 ##
 # Symbol(Ext) Test
 

--- a/mrblib/array.rb
+++ b/mrblib/array.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 ##
 # Array
 #

--- a/mruby-source.gemspec
+++ b/mruby-source.gemspec
@@ -1,4 +1,3 @@
-# coding: utf-8
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'mruby/source'

--- a/test/t/string.rb
+++ b/test/t/string.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 ##
 # String ISO Test
 


### PR DESCRIPTION
The default script encoding is Encoding::UTF-8 after v2.0.

https://ruby-doc.org/core-2.1.2/Encoding.html#class-Encoding-label-Script+encoding