### PR TITLE
kernel.c (mrb_cmp_m): use mrb_equal instead of mrb_obj_equal.

### DIFF
--- a/src/kernel.c
+++ b/src/kernel.c
@@ -83,7 +83,7 @@ mrb_cmp_m(mrb_state *mrb, mrb_value self)
 {
   mrb_value arg = mrb_get_arg1(mrb);
 
-  if (mrb_obj_equal(mrb, self, arg))
+  if (mrb_equal(mrb, self, arg))
     return mrb_fixnum_value(0);
   return mrb_nil_value();
 }


### PR DESCRIPTION
`Kernel#<=>` should also call `#==` to check if the objects are equal.

```rb
class Foo
  def ==(_)
    true
  end
end
p Foo.new <=> Object.new # => 0
```

~~Admittedly, I'm not sure if this is worth the performance hit. Perhaps it would be better to simply revert c1697a9.~~