### PR TITLE
use WSAGetLastError() for errno on Windows

### DIFF
--- a/mrbgems/mruby-io/src/io.c
+++ b/mrbgems/mruby-io/src/io.c
@@ -1258,8 +1258,13 @@ mrb_io_s_select(mrb_state *mrb, mrb_value klass)
 retry:
   n = select(max, rp, wp, ep, tp);
   if (n < 0) {
+#ifdef _WIN32
+    if (WSAGetLastError() != WSAEINTR)
+      mrb_sys_fail(mrb, "select failed");
+#else
     if (errno != EINTR)
       mrb_sys_fail(mrb, "select failed");
+#endif
     if (tp == NULL)
       goto retry;
     interrupt_flag = 1;


### PR DESCRIPTION
The error of select(2) on Windows should be given from WSAGetLastError().

https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-select#return-value