### PR TITLE
pre-commit(tabs): use blacklist to exclude files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -32,6 +32,7 @@ trim_trailing_whitespace = true
 [*.bat]
 charset = latin1
 end_of_line = crlf
+indent_style = space
 #max_line_length = 80
 
 [*.{yaml,yml}]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,10 +31,10 @@ repos:
     rev: v1.3.1
     hooks:
       - id: forbid-tabs
-        files: \.(c|cc|C|cxx|cpp|gembox|gemspec|h|hh|H|hxx|hpp|inc|md|mdown|markdown|rake|rb|y|yaml|yml)$|^Rakefile$|^rakefile$
+        exclude: Makefile$|Makefile\..+$|makefile$|\.mk$
       - id: remove-tabs
         args: [--whitespaces-count, '2']
-        files: \.(c|cc|C|cxx|cpp|gembox|gemspec|h|hh|H|hxx|hpp|inc|md|mdown|markdown|rake|rb|y|yaml|yml)$|^Rakefile$|^rakefile$
+        exclude: Makefile$|Makefile\..+$|makefile$|\.mk$
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.2
     hooks:


### PR DESCRIPTION
Add `indent_style = space` to the `.editorconfig` file for batch files.