### PR TITLE
Remove `charset = latin1` from `.editorconfig` for batch files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -29,8 +29,8 @@ indent_style = space
 trim_trailing_whitespace = true
 #max_line_length = 120
 
+# limitation to US-ASCII
 [*.bat]
-charset = latin1
 end_of_line = crlf
 #max_line_length = 80
 


### PR DESCRIPTION
The top `.editorconfig` rule `charset = utf-8` now applies to batch files

```
mruby % file -I mrbgems/mruby-bin-config/mruby-config.bat
mrbgems/mruby-bin-config/mruby-config.bat: text/x-msdos-batch; charset=us-ascii
```

US-ASCII (basic English) is a 7-bit, 128 characters code page, originally designed for telegraphy.

UTF-8 encoding uses the same encoding as 7-bit ASCII for its first 128 characters. So a text file that only contains characters from that range of the first 128 characters will be identical at a byte level whether encoded with UTF-8 or 7-bit ASCII.

https://stackoverflow.com/questions/11303405/force-encode-from-us-ascii-to-utf-8-iconv