### PR TITLE
pre-commit(shell): add hook `script-must-not-have-extension`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,6 +42,12 @@ repos:
         name: Run codespell
         description: Check spelling with codespell
         entry: codespell --ignore-words=codespell.txt
+  - repo: https://github.com/jumanjihouse/pre-commit-hooks
+    rev: 3.0.0
+    hooks:
+      - id: script-must-not-have-extension
+        name: Local policy is to exclude extension from all shell files
+        types: [shell]
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.32.2
     hooks:


### PR DESCRIPTION
```
mruby % file -I mrbgems/mruby-bin-config/mruby-config
mrbgems/mruby-bin-config/mruby-config: text/x-shellscript; charset=us-ascii
```

The Google shell style guide states:

Executables should have no extension (strongly preferred)

This hook checks for conformance.

https://github.com/jumanjihouse/pre-commit-hooks#script-must-not-have-extension

We are already using hooks from "jumanjihouse" in the `mgem-list` repo.

https://github.com/mruby/mgem-list/blob/f5904922d5fbc87f45c582b8ef759e2ebf16df79/.pre-commit-config.yaml#L39