### PR TITLE
Fixed `mrb_jmpbuf::jmpbuf_id` to be a C++ linkage

### DIFF
--- a/include/mruby/common.h
+++ b/include/mruby/common.h
@@ -28,6 +28,11 @@
 # define MRB_END_DECL
 #endif
 
+#ifndef MRB_BEGIN_CXX_LINKAGE
+# define MRB_BEGIN_CXX_LINKAGE
+# define MRB_END_CXX_LINKAGE
+#endif
+
 #include <sys/types.h>
 #if defined _MSC_VER
 #include <BaseTsd.h>

--- a/lib/mruby/build.rb
+++ b/lib/mruby/build.rb
@@ -273,6 +273,8 @@ module MRuby
 
 #ifndef MRB_USE_CXX_ABI
 extern "C" {
+#define MRB_BEGIN_CXX_LINKAGE }
+#define MRB_END_CXX_LINKAGE   extern "C" {
 #endif
 #include "#{File.absolute_path src}"
 #ifndef MRB_USE_CXX_ABI

--- a/src/vm.c
+++ b/src/vm.c
@@ -3127,5 +3127,7 @@ mrb_top_run(mrb_state *mrb, const struct RProc *proc, mrb_value self, mrb_int st
 # if !defined(MRB_USE_CXX_ABI)
 } /* end of extern "C" */
 # endif
+MRB_BEGIN_CXX_LINKAGE
 mrb_int mrb_jmpbuf::jmpbuf_id = 0;
+MRB_END_CXX_LINKAGE
 #endif


### PR DESCRIPTION
Using `conf.enable_cxx_exception` in GCC (g++) caused a compile error.

ref. #5728