### PR TITLE
Reduce memory copy in `mrb_str_inspect()` with UTF-8

### DIFF
--- a/src/string.c
+++ b/src/string.c
@@ -1219,12 +1219,7 @@ str_escape(mrb_state *mrb, mrb_value str, mrb_bool inspect)
     if (inspect) {
       mrb_int clen = mrb_utf8len(p, pend);
       if (clen > 1) {
-        mrb_int i;
-
-        for (i=0; i<clen; i++) {
-          buf[i] = p[i];
-        }
-        mrb_str_cat(mrb, result, buf, clen);
+        mrb_str_cat(mrb, result, p, clen);
         p += clen-1;
         ascii_flag = 0;
         continue;


### PR DESCRIPTION
:scream_cat: When I compiled optimally with gcc, I got a warning.
However, I could not understand why this warning was printed.

```console
% gcc12 -Iinclude -DMRB_NO_PRESYM -DMRB_UTF8_STRING -Wall -O3 -c src/string.c
src/string.c: In function 'str_escape':
src/string.c:1225:18: warning: writing 1 byte into a region of size 0 [-Wstringop-overflow=]
 1225 |           buf[i] = p[i];
      |           ~~~~~~~^~~~~~
src/string.c:1209:8: note: at offset 4 into destination object 'buf' of size 4
 1209 |   char buf[4];  /* `\x??` or UTF-8 character */
      |        ^~~
src/string.c:1225:18: warning: writing 1 byte into a region of size 0 [-Wstringop-overflow=]
 1225 |           buf[i] = p[i];
      |           ~~~~~~~^~~~~~
src/string.c:1209:8: note: at offset 5 into destination object 'buf' of size 4
 1209 |   char buf[4];  /* `\x??` or UTF-8 character */
      |        ^~~
```

By taking a larger buffer size, the warning went away.

```diff
diff --git a/src/string.c b/src/string.c
index 0e204118a..00a3b87b4 100644
--- a/src/string.c
+++ b/src/string.c
@@ -1206,7 +1206,7 @@ static mrb_value
 str_escape(mrb_state *mrb, mrb_value str, mrb_bool inspect)
 {
   const char *p, *pend;
-  char buf[4];  /* `\x??` or UTF-8 character */
+  char buf[7];  /* `\x??` or UTF-8 character */
   mrb_value result = mrb_str_new_lit(mrb, "\"");
 #ifdef MRB_UTF8_STRING
   uint32_t ascii_flag = MRB_STR_ASCII;
```

But I don't know what that means, so I suggest this PR method.
