### PR TITLE
Using `mrb_realloc()` with `stack_extend_alloc()`

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -177,10 +177,7 @@ stack_extend_alloc(mrb_state *mrb, mrb_int room)
     size += room;
 #endif
 
-  newstack = (mrb_value *)mrb_realloc_simple(mrb, mrb->c->stbase, sizeof(mrb_value) * size);
-  if (newstack == NULL) {
-    mrb_exc_raise(mrb, mrb_obj_value(mrb->stack_err));
-  }
+  newstack = (mrb_value *)mrb_realloc(mrb, mrb->c->stbase, sizeof(mrb_value) * size);
   stack_clear(&(newstack[oldsize]), size - oldsize);
   envadjust(mrb, oldbase, newstack, oldsize);
   mrb->c->stbase = newstack;


### PR DESCRIPTION
Raising a `SystemStackError` exception in an out-of-memory situation will generate backtrace information. This can eventually lead to a `NoMemoryError` exception, and this process flow is completely undesirable.

In effect, this change means that it will include a revert of commit 0dbb9e6e411572b0c37e7be723d6dc3895387f96.