### PR TITLE
gha: replace `Ubuntu 18.04` with `Ubuntu 22.04` in `build` workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,8 +6,8 @@ permissions:
   contents: read
 
 jobs:
-  Ubuntu-1804-gcc:
-    runs-on: ubuntu-18.04
+  Ubuntu-2204-gcc:
+    runs-on: ubuntu-22.04
     timeout-minutes: 10
     env:
       MRUBY_CONFIG: ci/gcc-clang
@@ -21,8 +21,8 @@ jobs:
       - name: Build and test
         run: rake -m test:build && rake test:run
 
-  Ubuntu-1804-clang:
-    runs-on: ubuntu-18.04
+  Ubuntu-2204-clang:
+    runs-on: ubuntu-22.04
     timeout-minutes: 10
     env:
       MRUBY_CONFIG: ci/gcc-clang


### PR DESCRIPTION
https://github.blog/changelog/2022-08-09-github-actions-ubuntu-22-04-is-now-generally-available-on-github-hosted-runners/