### PR TITLE
Print errors by calling `mrb_print_backtrace()` without backtrace

### DIFF
--- a/src/error.c
+++ b/src/error.c
@@ -195,7 +195,7 @@ static mrb_noreturn void
 exc_throw(mrb_state *mrb, mrb_value exc)
 {
   if (!mrb->jmp) {
-    mrb_p(mrb, exc);
+    mrb_print_error(mrb);
     abort();
   }
   MRB_THROW(mrb->jmp);
@@ -576,7 +576,7 @@ mrb_core_init_protect(mrb_state *mrb, void (*body)(mrb_state *, void *), void *o
     err = 0;
   } MRB_CATCH(&c_jmp) {
     if (mrb->exc) {
-      mrb_p(mrb, mrb_obj_value(mrb->exc));
+      mrb_print_error(mrb);
       mrb->exc = NULL;
     }
     else {


### PR DESCRIPTION
- In case of `NoMemoryError` exceptions, the error message is now printed directly.
- Replaced `mrb_p()` used by #4250 with `mrb_print_error()`.

  ref. squashed commit f1523d24042ca3416dc5b9be7b3fc220ddaed896
  ref. subcommit da7d7f881bbbad9988a3a2b7bad8f2b72ff06bc6
  ref. subcommit d9c7b6be6eb54630b64eea5c35be241e551676e5

---

I don't remember for sure, but I think I used `mrb_p()` in #4250 because it sometimes didn't output and that was also the case before the change in commit da7d7f881bbbad9988a3a2b7bad8f2b72ff06bc6.
