### PR TITLE
Escaping pipes in the code of table elements

### DIFF
--- a/doc/internal/opcode.md
+++ b/doc/internal/opcode.md
@@ -69,9 +69,9 @@ sign) of operands.
 | `OP_EXCEPT`        | `B`            | `R(a) = exc`                                               |
 | `OP_RESCUE`        | `BB`           | `R(b) = R(a).isa?(R(b))`                                   |
 | `OP_RAISEIF`       | `B`            | `raise(R(a)) if R(a)`                                      |
-| `OP_SSEND`         | `BBB`          | `R(a) = self.send(Syms(b),R(a+1)..,R(a+n+1):R(a+n+2)..) (c=n|k<<4)` |
+| `OP_SSEND`         | `BBB`          | `R(a) = self.send(Syms(b),R(a+1)..,R(a+n+1):R(a+n+2)..) (c=n\|k<<4)` |
 | `OP_SSENDB`        | `BBB`          | `R(a) = self.send(Syms(b),R(a+1)..,R(a+n+1):R(a+n+2)..,&R(a+n+2k+1))` |
-| `OP_SEND`          | `BBB`          | `R(a) = R(a).send(Syms(b),R(a+1)..,R(a+n+1):R(a+n+2)..) (c=n|k<<4)` |
+| `OP_SEND`          | `BBB`          | `R(a) = R(a).send(Syms(b),R(a+1)..,R(a+n+1):R(a+n+2)..) (c=n\|k<<4)` |
 | `OP_SENDB`         | `BBB`          | `R(a) = R(a).send(Syms(b),R(a+1)..,R(a+n+1):R(a+n+2)..,&R(a+n+2k+1))` |
 | `OP_CALL`          | `-`            | `R(0) = self.call(frame.argc, frame.argv)`                 |
 | `OP_SUPER`         | `BB`           | `R(a) = super(R(a+1),... ,R(a+b+1))`                       |

--- a/lib/mruby/doc.rb
+++ b/lib/mruby/doc.rb
@@ -34,6 +34,7 @@ module MRuby
             cmt.sub!(/\s*#.*/, "")
             cmt.sub!(/\b(?=L_\w+\b)/, "OP_")
             cmt.gsub!(/\b(Irep|Pool|R|Syms)\[([^\[\]]+)\]/, "\\1(\\2)")
+            cmt.gsub!(/[\\\|]/) { |m| "\\#{m}" } # Ruby-2.5 is not support "Numbered block parameter"
           end
           spec = opspecs[opr] or raise "unknown operand type: #{opr}"
           item = format(%(| %-18s | %-14s | %-58s |\n), "`OP_#{ins}`", "`#{spec[:modified] || opr}`", cmt && "`#{cmt}`")


### PR DESCRIPTION
ref. https://github.github.com/gfm/#example-200

- - -

The "yard" called by "mrbdoc" has several libraries available to parse Markdown.
Note: The preferred library can be changed with `mrbdoc -M <gem-name>`.

<https://github.com/lsegal/yard/blob/v0.9.28/lib/yard/templates/helpers/markup_helper.rb#L24-L34>
<https://github.com/lsegal/yard/blob/v0.9.28/lib/yard/templates/helpers/markup_helper.rb#L87-L116>

Ruby gem name   | Support table?  | Can pipes in codes inside tables be escapable?  | Note
:-------------: | :-------------: | :---------------------------------------------: | ---
redcarpet       | yes             | no
rdiscount       | yes             | yes
kramdown        | yes             | yes, but escaped characters remain
bluecloth       | no
maruku          | yes             | no                                              | HTML tags are not allowed in Markdown
rpeg-markdown   | ?               | ?                                               | `require "rpeg-markdown"` fails; archived repository
rdoc            | no              |                                                 | Maybe support in the next rdoc? <https://github.com/ruby/rdoc/pull/931>
commonmarker    | no              |                                                 | Maybe support in the next yard? <https://github.com/lsegal/yard/pull/1443>

- - -

In "doxygen", the `|` directive in `mrb_get_args()` in `include/mruby.h` is fine, but in `opcode.md` the escaping for pipe remains.
