### PR TITLE
Move `mruby-errno` to `stdlib-io.gembox`

### DIFF
--- a/mrbgems/stdlib-io.gembox
+++ b/mrbgems/stdlib-io.gembox
@@ -9,4 +9,7 @@ MRuby::GemBox.new do |conf|
 
   # Use standard print/puts/p
   conf.gem :core => "mruby-print"
+
+  # Use errno extension for a good mruby-io/mruby-socket experience
+  conf.gem :core => "mruby-errno"
 end

--- a/mrbgems/stdlib.gembox
+++ b/mrbgems/stdlib.gembox
@@ -54,7 +54,4 @@ MRuby::GemBox.new do |conf|
 
   # Use class/module extension
   conf.gem :core => "mruby-class-ext"
-
-  # Use errno extension
-  conf.gem :core => "mruby-errno"
 end


### PR DESCRIPTION
This is because GEMs that use errno are currently limited to `mruby-io` and `mruby-socket`.