### PR TITLE
Fix cloning gem when destination path contains spaces

### DIFF
--- a/lib/mruby/build/command.rb
+++ b/lib/mruby/build/command.rb
@@ -25,11 +25,7 @@ module MRuby
     end
 
     def shellquote(s)
-      if ENV['OS'] == 'Windows_NT'
-        "\"#{s}\""
-      else
-        "#{s}"
-      end
+      "\"#{s}\""
     end
 
     private


### PR DESCRIPTION
This was how the clone command was previously being generated, for example:

```
git clone  --recursive --branch "master" --depth 1 https://github.com/mattn/mruby-onig-regexp.git /path/to mruby with spaces/mruby-3.1.0/build/repos/wasm/mruby-onig-regexp
```

Now it's changed so the path is quoted and will work when containing spaces:

```
git clone  --recursive --branch "master" --depth 1 https://github.com/mattn/mruby-onig-regexp.git "/path/to mruby with spaces/mruby-3.1.0/build/repos/wasm/mruby-onig-regexp"
```

Similar for the other commands.

Thank you!