### PR TITLE
codedump.c: Use OP_LOADINEG instead of OP_LOADI #5869

### DIFF
--- a/src/codedump.c
+++ b/src/codedump.c
@@ -195,7 +195,7 @@ codedump(mrb_state *mrb, const mrb_irep *irep)
       print_lv_a(mrb, irep, a);
       break;
     CASE(OP_LOADINEG, BB):
-      printf("LOADI\tR%d\t-%d\t", a, b);
+      printf("LOADINEG\tR%d\t%d\t", a, b);
       print_lv_a(mrb, irep, a);
       break;
     CASE(OP_LOADI16, BS):


### PR DESCRIPTION
This is a modification of the following issue.
https://github.com/mruby/mruby/issues/5869

![image](https://user-images.githubusercontent.com/37442712/207733102-9303d24b-7029-46a9-a127-053fbf208d40.png)
