### PR TITLE
Fix typo in doc/limitations.md

### DIFF
--- a/doc/limitations.md
+++ b/doc/limitations.md
@@ -237,7 +237,7 @@ end
 puts(a.nil? ? "truthy" : "falsy")
 ```
 
-Ruby outputs `falsy`. mruby outputs `truthy`.
+Ruby outputs `truthy`. mruby outputs `falsy`.
 
 ## Argument Destructuring
 


### PR DESCRIPTION
Since redefinition of "nil?" is possible in ruby, ruby's output should be "truthy".
And since redefinition of "nil?" is not possible in mruby, mruby's output should be "falsy".
It was the reversed.