### PR TITLE
Use `getsegmentdata` instead of deprecated `get_etext`/`get_edata`

### DIFF
--- a/include/mruby/value.h
+++ b/include/mruby/value.h
@@ -435,10 +435,20 @@ mrb_ro_data_p(const char *p)
 #elif defined(__APPLE__)
 #define MRB_LINK_TIME_RO_DATA_P
 #include <mach-o/getsect.h>
+#include <crt_externs.h>
 static inline mrb_bool
 mrb_ro_data_p(const char *p)
 {
-  return (char*)get_etext() < p && p < (char*)get_edata();
+#ifdef __LP64__
+  struct mach_header_64 *mhp;
+#else
+  struct mach_header *mhp;
+#endif
+  mhp = _NSGetMachExecuteHeader();
+  unsigned long textsize, datasize;
+  char *text = (char*)getsegmentdata(mhp, SEG_TEXT, &textsize);
+  char *data = (char*)getsegmentdata(mhp, SEG_DATA, &datasize);
+  return text + textsize < p && p < data + datasize;
 }
 #endif  /* Linux or macOS */
 #endif  /* MRB_NO_DEFAULT_RO_DATA_P */

--- a/include/mruby/value.h
+++ b/include/mruby/value.h
@@ -435,7 +435,7 @@ mrb_ro_data_p(const char *p)
 #elif defined(__APPLE__)
 #define MRB_LINK_TIME_RO_DATA_P
 #include <mach-o/getsect.h>
-#include <crt_externs.h>
+#include <crt_externs.h> // for _NSGetMachExecuteHeader
 static inline mrb_bool
 mrb_ro_data_p(const char *p)
 {


### PR DESCRIPTION
Starting with macOS Ventura, `get_etext` and `get_edata` are now deprecated:

```
mruby/include/mruby/value.h:441:17: warning: 'get_etext' is deprecated: first deprecated in macOS 13.0 - No longer supported [-Wdeprecated-declarations]
  return (char*)get_etext() < p && p < (char*)get_edata();
                ^
mruby/include/mruby/value.h:441:47: warning: 'get_edata' is deprecated: first deprecated in macOS 13.0 - No longer supported [-Wdeprecated-declarations]
  return (char*)get_etext() < p && p < (char*)get_edata();
                                              ^
```