### PR TITLE
Remove `# coding: utf-8` from Ruby file

### DIFF
--- a/mrbgems/mruby-string-ext/test/string.rb
+++ b/mrbgems/mruby-string-ext/test/string.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 ##
 # String(Ext) Test
 


### PR DESCRIPTION
The default script encoding is Encoding::UTF-8 after v2.0.

https://ruby-doc.org/core-2.1.2/Encoding.html#class-Encoding-label-Script+encoding