### PR TITLE
Use rubygems.org links for yard-mruby and yard-coderay

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,8 +120,8 @@ unless there's a clear reason, e.g. the latest Ruby has changed behavior from IS
 ### mruby API
 
 - [YARD](https://yardoc.org/) - YARD is a documentation generation tool for the Ruby programming language
-- [yard-mruby](https://github.com/sagmor/yard-mruby) - Document MRuby sources with YARD
-- [yard-coderay](https://github.com/sagmor/yard-coderay) - Adds coderay syntax highlighting to YARD docs
+- [yard-mruby](https://rubygems.org/gems/yard-mruby) - Document MRuby sources with YARD
+- [yard-coderay](https://rubygems.org/gems/yard-coderay) - Adds coderay syntax highlighting to YARD docs
 
 ### C API
 

--- a/tasks/doc.rake
+++ b/tasks/doc.rake
@@ -12,8 +12,8 @@ namespace :doc do
       puts "ERROR: To generate yard documentation, you should install yard-mruby gem."
       puts "  $ gem install yard-mruby yard-coderay"
       puts "https://yardoc.org/"
-      puts "https://github.com/sagmor/yard-mruby"
-      puts "https://github.com/sagmor/yard-coderay"
+      puts "https://rubygems.org/gems/yard-mruby"
+      puts "https://rubygems.org/gems/yard-coderay"
     end
   end
 


### PR DESCRIPTION
The RubyGems website gives a much better overview of both Gems

A lot more quick links and statistics.

https://rubygems.org/gems/yard-mruby

https://rubygems.org/gems/yard-coderay