### PR TITLE
Avoid `IOError` when returning from `Dir.open`

### DIFF
--- a/mrbgems/mruby-dir/mrblib/dir.rb
+++ b/mrbgems/mruby-dir/mrblib/dir.rb
@@ -36,7 +36,10 @@ class Dir
         begin
           block.call(d)
         ensure
-          d.close
+          begin
+            d.close
+          rescue IOError
+          end
         end
       else
         self.new(path)


### PR DESCRIPTION
Ignore `IOError` if `Dir#close` was done in the block.