### PR TITLE
Added more description of the `MRB_HEAP_PAGE_SIZE` configuration

### DIFF
--- a/doc/guides/mrbconf.md
+++ b/doc/guides/mrbconf.md
@@ -123,6 +123,11 @@ end
 
 - Defines value is `1024`.
 - Specifies number of `RBasic` per each heap page.
+- To calculate the number of bytes per heap page, it is "(size of management data per heap page) + (size per object) * `MRB_HEAP_PAGE_SIZE`".
+  In mruby 3.1.0, the "size of management data per heap page" is 6 words, also "size per object" is 6 words.
+  For a 32-bit CPU, `(6 * 4) + (6 * 4) * MRB_HEAP_PAGE_SIZE` gives the bytes of size per heap page.
+  Conversely, for example, to keep the size per heap page to 4 Ki bytes,
+  calculate `(4096 - (6 * 4)) / (6 * 4)` to specify `MRB_HEAP_PAGE_SIZE=169`.
 
 ## Memory pool configuration
 


### PR DESCRIPTION
The actual size that `malloc()` allocates depends on the environment, so I believe it will be helpful.

For reference:

  - In glibc-2.36 it is allocated on a 2-word boundary  
    ref. <https://sourceware.org/git/?p=glibc.git;a=blob;f=malloc/malloc.c;hb=glibc-2.36#l1162>
  - In FreeBSD userspace, jemalloc is used, so the granularity is a bit larger  
    ref. <https://jemalloc.net/jemalloc.3.html#size_classes>
  - In FreeBSD kernel space, it is rounded up to the power of 2  
    ref. <https://www.freebsd.org/cgi/man.cgi?malloc(9)#IMPLEMENTATION_NOTES>
