### PR TITLE
Fixed `Kernel#.eval` crash when given a custom defined `Binding` instance

### DIFF
--- a/mrbgems/mruby-eval/src/eval.c
+++ b/mrbgems/mruby-eval/src/eval.c
@@ -29,14 +29,14 @@ create_proc_from_string(mrb_state *mrb, const char *s, mrb_int len, mrb_value bi
           mrb_obj_class(mrb, binding));
     }
     scope_obj = mrb_iv_get(mrb, binding, MRB_SYM(proc));
-    mrb_assert(mrb_proc_p(scope_obj));
+    mrb_check_type(mrb, scope_obj, MRB_TT_PROC);
     scope = mrb_proc_ptr(scope_obj);
     if (MRB_PROC_CFUNC_P(scope)) {
       e = NULL;
     }
     else {
       mrb_value env = mrb_iv_get(mrb, binding, MRB_SYM(env));
-      mrb_assert(mrb_env_p(env));
+      mrb_check_type(mrb, env, MRB_TT_ENV);
       e = (struct REnv *)mrb_obj_ptr(env);
       mrb_assert(e != NULL);
     }


### PR DESCRIPTION
```console
% bin/mruby -e 'class Binding; end; eval "1", Binding.new'
zsh: segmentation fault (core dumped)  bin/mruby -e 'class Binding; end; eval "1", Binding.new'
```

orz

After the fix it does not crash, but it is difficult to understand the error.
Not so soon, but may improve eventually with another PR.

```console
% bin/mruby -e 'class Binding; end; eval "1", Binding.new'
trace (most recent call last):
        [1] -e:1
-e:1:in eval: wrong argument type nil (expected Proc) (TypeError)
```
