### PR TITLE
Demotion `mrb_f_raise()` from `MRB_API`

### DIFF
--- a/include/mruby/error.h
+++ b/include/mruby/error.h
@@ -37,9 +37,6 @@ MRB_API mrb_value mrb_exc_new_str(mrb_state *mrb, struct RClass* c, mrb_value st
 MRB_API mrb_value mrb_make_exception(mrb_state *mrb, mrb_int argc, const mrb_value *argv);
 MRB_API mrb_noreturn void mrb_no_method_error(mrb_state *mrb, mrb_sym id, mrb_value args, const char *fmt, ...);
 
-/* declaration for `fail` method */
-MRB_API mrb_value mrb_f_raise(mrb_state*, mrb_value);
-
 #if defined(MRB_64BIT) || defined(MRB_USE_FLOAT32) || defined(MRB_NAN_BOXING) || defined(MRB_WORD_BOXING)
 struct RBreak {
   MRB_OBJECT_HEADER;

--- a/include/mruby/internal.h
+++ b/include/mruby/internal.h
@@ -51,6 +51,7 @@ mrb_value mrb_exc_backtrace(mrb_state *mrb, mrb_value exc);
 mrb_value mrb_get_backtrace(mrb_state *mrb);
 void mrb_exc_mesg_set(mrb_state *mrb, struct RException *exc, mrb_value mesg);
 mrb_value mrb_exc_mesg_get(mrb_state *mrb, struct RException *exc);
+mrb_value mrb_f_raise(mrb_state*, mrb_value);
 
 /* gc */
 void mrb_gc_mark_mt(mrb_state*, struct RClass*);


### PR DESCRIPTION
This function is the entity of the `Kernel.#raise` or `Kernel#fail` method. I don't think users can use it whenever they want, and I don't think there is any need to expose it as an entity of a user-defined method.