### PR TITLE
AUTHORS: update "as of" info for `year`

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,6 +1,6 @@
 # Authors of mruby (mruby developers)
 
-## The List of Contributors sorted by number of commits (as of 2022-01-08 4462e3d)
+## The List of Contributors sorted by number of commits (as of 2023-01-08 4462e3d)
 
    8860 Yukihiro "Matz" Matsumoto (@matz)*
     586 KOBAYASHI Shuji (@shuujii)


### PR DESCRIPTION
The AUTHORS file was last published on January 8th 2023
