### PR TITLE
Reorganize gem init final

### DIFF
--- a/lib/mruby/gem.rb
+++ b/lib/mruby/gem.rb
@@ -209,7 +209,6 @@ module MRuby
           f.puts %Q[void mrb_#{funcname}_gem_final(mrb_state *mrb);]
           f.puts %Q[]
           f.puts %Q[void GENERATED_TMP_mrb_#{funcname}_gem_init(mrb_state *mrb) {]
-          f.puts %Q[  int ai = mrb_gc_arena_save(mrb);]
           f.puts %Q[  gem_mrblib_#{funcname}_proc_init_syms(mrb);] if !rbfiles.empty? && cdump?
           f.puts %Q[  mrb_#{funcname}_gem_init(mrb);] if objs != [objfile("#{build_dir}/gem_init")]
           unless rbfiles.empty?
@@ -218,14 +217,7 @@ module MRuby
             else
               f.puts %Q[  mrb_load_irep(mrb, gem_mrblib_irep_#{funcname});]
             end
-            f.puts %Q[  if (mrb->exc) {]
-            f.puts %Q[    mrb_print_error(mrb);]
-            f.puts %Q[    mrb_close(mrb);]
-            f.puts %Q[    exit(EXIT_FAILURE);]
-            f.puts %Q[  }]
-            f.puts %Q[  mrb_vm_ci_env_clear(mrb, mrb->c->cibase);]
           end
-          f.puts %Q[  mrb_gc_arena_restore(mrb, ai);]
           f.puts %Q[}]
           f.puts %Q[]
           f.puts %Q[void GENERATED_TMP_mrb_#{funcname}_gem_final(mrb_state *mrb) {]

--- a/tasks/mrbgems.rake
+++ b/tasks/mrbgems.rake
@@ -13,15 +13,14 @@ MRuby.each_target do
       mkdir_p "#{build_dir}/mrbgems"
       open(t.name, 'w') do |f|
         gem_func_gems = gems.select { |g| g.generate_functions }
-        gem_func_decls = gem_func_gems.each_with_object('') do |g, s|
-          s << "void GENERATED_TMP_mrb_#{g.funcname}_gem_init(mrb_state*);\n" \
-               "void GENERATED_TMP_mrb_#{g.funcname}_gem_final(mrb_state*);\n"
-        end
-        gem_funcs = gem_func_gems.each_with_object('') do |g, s|
-          s << "  { GENERATED_TMP_mrb_#{g.funcname}_gem_init },\n"
-        end
-        gem_final_calls = gem_func_gems.reverse_each.with_object('') do |g, s|
-          s << "  GENERATED_TMP_mrb_#{g.funcname}_gem_final(mrb);\n"
+        gem_func_decls = ''
+        gem_funcs = ''
+        gem_func_gems.each do |g|
+          init = "GENERATED_TMP_mrb_#{g.funcname}_gem_init"
+          final = "GENERATED_TMP_mrb_#{g.funcname}_gem_final"
+          gem_func_decls << "void #{init}(mrb_state*);\n" \
+                            "void #{final}(mrb_state*);\n"
+          gem_funcs << "  { #{init}, #{final} },\n"
         end
         f.puts %Q[/*]
         f.puts %Q[ * This file contains a list of all]
@@ -36,24 +35,43 @@ MRuby.each_target do
         f.puts %Q[ */]
         f.puts %Q[]
         f.puts %Q[#include <mruby.h>]
+        f.puts %Q[#include <mruby/error.h>]
         f.puts %Q[#include <mruby/proc.h>]
         f.puts %Q[]
         f.write gem_func_decls
         f.puts %Q[]
         f.puts %Q[static const struct {]
         f.puts %Q[  void (*init)(mrb_state*);]
+        f.puts %Q[  void (*final)(mrb_state*);]
         f.puts %Q[} gem_funcs[] = {]
         f.write gem_funcs
         f.puts %Q[};]
         f.puts %Q[]
         f.puts %Q[#define NUM_GEMS ((int)(sizeof(gem_funcs) / sizeof(gem_funcs[0])))]
-        unless gem_final_calls.empty?
-          f.puts %Q[]
-          f.puts %Q[static void]
-          f.puts %Q[mrb_final_mrbgems(mrb_state *mrb) {]
-          f.write gem_final_calls
-          f.puts %Q[}]
-        end
+        f.puts %Q[]
+        f.puts %Q[struct final_mrbgems {]
+        f.puts %Q[  int i;]
+        f.puts %Q[  int ai;]
+        f.puts %Q[};]
+        f.puts %Q[]
+        f.puts %Q[static mrb_value]
+        f.puts %Q[final_mrbgems_body(mrb_state *mrb, void *ud) {]
+        f.puts %Q[  struct final_mrbgems *p = (struct final_mrbgems*)ud;]
+        f.puts %Q[  for (; p->i >= 0; p->i--) {]
+        f.puts %Q[    gem_funcs[p->i].final(mrb);]
+        f.puts %Q[    mrb_gc_arena_restore(mrb, p->ai);]
+        f.puts %Q[  }]
+        f.puts %Q[  return mrb_nil_value();]
+        f.puts %Q[}]
+        f.puts %Q[]
+        f.puts %Q[static void]
+        f.puts %Q[mrb_final_mrbgems(mrb_state *mrb) {]
+        f.puts %Q[  struct final_mrbgems a = { NUM_GEMS - 1, mrb_gc_arena_save(mrb) };]
+        f.puts %Q[  for (; a.i >= 0; a.i--) {]
+        f.puts %Q[    mrb_protect_error(mrb, final_mrbgems_body, &a, NULL);]
+        f.puts %Q[    mrb_gc_arena_restore(mrb, a.ai);]
+        f.puts %Q[  }]
+        f.puts %Q[}]
         f.puts %Q[]
         f.puts %Q[void]
         f.puts %Q[mrb_init_mrbgems(mrb_state *mrb) {]


### PR DESCRIPTION
The point is:

  - Don't call `exit()` when an exception occurs in `mrblib/*.rb`.
  - Ignore exceptions raised by gems finalizer.
