### PR TITLE
appveyor: add job for Visual Studio 2022

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,10 @@ shallow_clone: true
 
 environment:
   matrix:
+    - job_name: Visual Studio 2022 64bit
+      visualcpp: C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat
+      appveyor_build_worker_image: Visual Studio 2022
+
     - job_name: Visual Studio 2019 64bit
       visualcpp: C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars64.bat
       appveyor_build_worker_image: Visual Studio 2019


### PR DESCRIPTION
Visual Studio 2022 on Windows is now a 64-bit application.

https://www.appveyor.com/docs/build-environment/#build-worker-images

https://learn.microsoft.com/en-us/visualstudio/ide/whats-new-visual-studio-2022?view=vs-2022#visual-studio-2022-is-64-bit