### PR TITLE
Simplify the `.editorconfig` file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,37 +8,27 @@ root = true
 [*]
 charset = utf-8
 end_of_line = lf
-indent_size = 8
-indent_style = tab
+indent_size = 2
+indent_style = space
 insert_final_newline = true
 tab_width = 8
+trim_trailing_whitespace = true
 
 [{Makefile,Makefile.*,makefile,*.mk}]
-trim_trailing_whitespace = true
+indent_style = tab
 #max_line_length = 80
 
-[*.{c,cc,C,cxx,cpp,h,hh,H,hxx,hpp,inc,y}]
-indent_size = 2
-indent_style = space
-trim_trailing_whitespace = true
+#[*.{c,cc,C,cxx,cpp,h,hh,H,hxx,hpp,inc,y}]
 #max_line_length = 120
 
-[{*.rb,Rakefile,rakefile,*.rake,*.gemspec,*.gembox}]
-indent_size = 2
-indent_style = space
-trim_trailing_whitespace = true
+#[{*.rb,Rakefile,rakefile,*.rake,*.gemspec,*.gembox}]
 #max_line_length = 120
 
 # limitation to US-ASCII
 [*.bat]
 end_of_line = crlf
-indent_style = space
 #max_line_length = 80
 
-[*.{yaml,yml}]
-indent_size = 2
-indent_style = space
+#[*.{yaml,yml}]
 
-[*.md]
-indent_size = 2
-indent_style = space
+#[*.md]


### PR DESCRIPTION
We already have `trailing-whitespace` set globally in the `pre-commit` config and we are also using `spaces` instead of `tabs` except for "Makefiles" which have `tab_width = 8`

Perhaps in future we can enforce line lengths.

https://github.com/mruby/mruby/blob/92ca93c885a6e6d2facd8e9ca3dbf85ac3dce8c9/.pre-commit-config.yaml#L29

https://github.com/mruby/mruby/blob/92ca93c885a6e6d2facd8e9ca3dbf85ac3dce8c9/.pre-commit-config.yaml#L33