### PR TITLE
Don't switch constant search path from modules to Object

### DIFF
--- a/src/variable.c
+++ b/src/variable.c
@@ -785,7 +785,7 @@ L_RETRY:
     c = c->super;
     if (!skip && c == mrb->object_class) break;
   }
-  if (!retry && base->tt == MRB_TT_MODULE) {
+  if (!retry && base->tt == MRB_TT_MODULE && skip) {
     c = mrb->object_class;
     retry = TRUE;
     goto L_RETRY;

--- a/test/t/syntax.rb
+++ b/test/t/syntax.rb
@@ -211,6 +211,7 @@ assert('Nested const reference') do
   end
   assert_equal "hello world", Syntax4Const::CONST1
   assert_equal "hello world", Syntax4Const::Const2.new.const1
+  assert_raise(NameError) { Syntax4Const::Object }
 end
 
 assert('Abbreviated variable assignment as returns') do


### PR DESCRIPTION
Previously, for example, it was possible to retrieve the `String` class as follows:

```console
% bin/mruby -e 'p Comparable::Enumerable::Errno::GC::Kernel::Math::ObjectSpace::String'
String
```

Note that this patch affects the API function `mrb_const_get()`.