### PR TITLE
Need a dependency to `mruby-compiler` for `mruby-bin-strip`

### DIFF
--- a/mrbgems/mruby-bin-strip/mrbgem.rake
+++ b/mrbgems/mruby-bin-strip/mrbgem.rake
@@ -2,5 +2,6 @@ MRuby::Gem::Specification.new('mruby-bin-strip') do |spec|
   spec.license = 'MIT'
   spec.author  = 'mruby developers'
   spec.summary = 'irep dump debug section remover command'
+  spec.add_dependency 'mruby-compiler', :core => 'mruby-compiler'
   spec.bins = %w(mruby-strip)
 end


### PR DESCRIPTION
It uses `mrb_irep_remove_lv()` defined in `mrbgems/mruby-compiler/core/codegen.c`.