### PR TITLE
Add `Docker` to build and run all `mruby` tests. Run `pre-commit` and generate `YARD` docs with Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+.DS_Store
+.idea
+.vscode
+*.bak
+*.iml
+*.ipr
+*.swp
+*.tmp
+
+/.yardoc
+/bin
+/build
+/doc/api
+/doc/capi

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ compile_flags.txt
 cscope.files
 cscope.out
 tags
+!Gemfile.lock

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,69 @@ We use [GitHub Actions](.github/workflows/lint.yml) to run `pre-commit` on every
 - [pre-commit autoupdate](https://pre-commit.com/#pre-commit-autoupdate)
 - [Temporarily disabling hooks](https://pre-commit.com/#temporarily-disabling-hooks)
 
+## Docker
+
+We have both a `Dockerfile` and `docker-compose.yml` files in the repository root.
+You can run these with the command line or use
+[Docker Desktop](https://www.docker.com/products/docker-desktop/).
+
+The Docker image is running Debian bullseye with Ruby and Python installed.
+You can build the Docker image with:
+
+`$ docker-compose build test`
+
+So far we just have one service: `test`. Running the default `docker-compose`
+command will create the Docker image, spin up a container and then build and
+run all mruby tests.
+
+The default `docker-compose` command is:
+
+`$ docker-compose -p mruby run test`
+
+You can also use Make or Rake to run the default `docker-compose`
+command from above:
+
+- `make composetest`
+- `rake composetest`
+
+List your Docker images with:
+
+```console
+$ docker images
+REPOSITORY   TAG       IMAGE ID       CREATED          SIZE
+mruby-test   latest    ec60f9536948   29 seconds ago   1.29GB
+```
+
+You can also run any custom `docker-compose` command which will override
+the default. For example to run `pre-commit run --all-files` type:
+
+`$ docker-compose -p mruby run test pre-commit run --all-files`
+
+For convenience, you can also run `pre-commit` with:
+
+- `make composecheck`
+- `rake composecheck`
+
+The bonus of running `pre-commit` with `docker-compose` is that you won't need
+to install `pre-commit` and the hooks on your local machine. And that also
+means you won't need to install `brew`, `conda` or `pip`.
+
+Note limitation: currently running `pre-commit` with `docker-compose` we
+skip the `check-executables-have-shebangs` hook.
+
+Two more examples of custom `docker-compose` commands are:
+
+- `$ docker-compose -p mruby run test ls`
+- `$ docker-compose -p mruby run test rake doc:api`
+
+If you want to test using a different `docker-compose` YAML config file you
+can use the `-f` flag:
+
+`$ docker-compose -p mruby -f docker-compose.test.yml run test`
+
+- <https://docs.docker.com/compose/>
+- <https://docs.docker.com/engine/reference/commandline/cli/>
+
 ## Spell Checking
 
 We are using `pre-commit` to run [codespell](https://github.com/codespell-project/codespell)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM ruby:3.2.2-bullseye
+
+RUN apt-get update && apt-get install --no-install-recommends -y python3-pip shellcheck \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY Gemfile .
+
+COPY Gemfile.lock .
+
+COPY .pre-commit-config.yaml .
+
+RUN bundle install && pip3 install pre-commit && git init . && pre-commit install-hooks
+
+COPY . .

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+gem 'rake'
+gem 'yard'
+gem 'yard-coderay'
+gem 'yard-mruby'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,27 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    coderay (1.1.3)
+    rake (13.0.6)
+    webrick (1.7.0)
+    yard (0.9.28)
+      webrick (~> 1.7.0)
+    yard-coderay (0.1.0)
+      coderay
+      yard
+    yard-mruby (0.3.0)
+      yard (~> 0.9.0)
+
+PLATFORMS
+  ruby
+  x86_64-darwin-21
+  x86_64-linux
+
+DEPENDENCIES
+  rake
+  yard
+  yard-coderay
+  yard-mruby
+
+BUNDLED WITH
+   2.4.10

--- a/Makefile
+++ b/Makefile
@@ -25,3 +25,11 @@ checkinstall :
 checkupdate :
 	pre-commit autoupdate
 .PHONY : checkupdate
+
+composecheck :
+	docker-compose -p mruby run test pre-commit run --all-files
+.PHONY : composecheck
+
+composetest :
+	docker-compose -p mruby run test
+.PHONY : composetest

--- a/Rakefile
+++ b/Rakefile
@@ -82,3 +82,13 @@ desc "check the pre-commit hooks for updates"
 task :checkupdate do
   sh "pre-commit autoupdate"
 end
+
+desc "run all pre-commit hooks against all files with docker-compose"
+task :composecheck do
+  sh "docker-compose -p mruby run test pre-commit run --all-files"
+end
+
+desc "build and run all mruby tests with docker-compose"
+task :composetest do
+  sh "docker-compose -p mruby run test"
+end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3'
+services:
+  test:
+    build:
+      context: .
+    command: sh -c 'rake deep_clean && rake -m test:build && rake test:run'
+    environment:
+      - MRUBY_CONFIG=ci/gcc-clang
+      - CC=gcc
+      - CXX=g++
+      - LD=gcc
+      - SKIP=check-executables-have-shebangs
+    working_dir: /app


### PR DESCRIPTION
This is a first pass at adding Docker for `mruby`. 
  
So far just installing and running `pre-commit` but in future both Make and/or Rake tasks could be added for further testing.  I can add more Docker docs in future too.

For ease of use there is Docker Desktop:

https://www.docker.com/products/docker-desktop/

Some images here:

<img width="1267" alt="Screen Shot 2023-04-03 at 1 25 30 am" src="https://user-images.githubusercontent.com/418747/229363722-8336836d-291a-406c-af82-e9fd4f6bf6a4.png">

<img width="1262" alt="Screen Shot 2023-04-03 at 1 25 52 am" src="https://user-images.githubusercontent.com/418747/229363740-03529de4-c17c-4554-8815-212a85773a30.png">

<img width="1267" alt="Screen Shot 2023-04-03 at 1 23 36 am" src="https://user-images.githubusercontent.com/418747/229363760-8c5332bc-4995-4f4a-ad8a-3306909fa475.png">

