### PR TITLE
Add `mruby` logo to the README

### DIFF
--- a/.github/linters/.markdown-lint.yml
+++ b/.github/linters/.markdown-lint.yml
@@ -19,5 +19,11 @@ MD025: false
 # MD026 no-trailing-punctuation - Trailing punctuation in heading
 MD026: false
 
+# MD033/no-inline-html - Inline HTML
+MD033: false
+
 # MD040 fenced-code-language - Fenced code blocks should have a language specified
 MD040: false
+
+# MD041 first-line-heading/first-line-h1 - First line in a file should be a top-level heading
+MD041: false

--- a/README.md
+++ b/README.md
@@ -1,6 +1,16 @@
-# mruby
-
-[![GitHub Super-Linter](https://github.com/mruby/mruby/workflows/Lint%20Code%20Base/badge.svg)](https://github.com/marketplace/actions/super-linter)
+<div align="center">
+  <p>
+    <a href="https://mruby.org/">
+      <img src="https://avatars.githubusercontent.com/u/1796512?s=200&v=4"
+        alt="The mruby programming language" title="mruby">
+    </a>
+  </p>
+  <h1>mruby</h1>
+  <a href="https://github.com/marketplace/actions/super-linter">
+    <img src="https://github.com/mruby/mruby/workflows/Lint%20Code%20Base/badge.svg"
+      alt="GitHub Super-Linter">
+  </a>
+</div>
 
 ## What is mruby
 


### PR DESCRIPTION
Center logo, mruby title and linter badge

Fix for YARD and Doxygen output