### PR TITLE
Remove unnecessary branches in `L_RAISE` block

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -2212,7 +2212,6 @@ RETRY_TRY_BLOCK:
           }
         }
 
-        if (ch == NULL) goto L_STOP;
         if (FALSE) {
         L_CATCH_TAGGED_BREAK: /* from THROW_TAGGED_BREAK() or UNWIND_ENSURE() */
           ci = mrb->c->ci;


### PR DESCRIPTION
The previous `while` loop ends if the catch handler pointer `ch` is not `NULL`.

Supplement to #5843.