### PR TITLE
Small improvements to `envadjust()`

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -121,31 +121,28 @@ static inline void
 envadjust(mrb_state *mrb, mrb_value *oldbase, mrb_value *newbase, size_t oldsize)
 {
   mrb_callinfo *ci = mrb->c->cibase;
+  ptrdiff_t delta = newbase - oldbase;
 
-  if (newbase == oldbase) return;
+  if (delta == 0) return;
   while (ci <= mrb->c->ci) {
     struct REnv *e = mrb_vm_ci_env(ci);
     mrb_value *st;
 
     if (e && MRB_ENV_ONSTACK_P(e) &&
-        (st = e->stack) && oldbase <= st && st < oldbase+oldsize) {
-      ptrdiff_t off = e->stack - oldbase;
-
-      e->stack = newbase + off;
+        (st = e->stack) && (size_t)(st - oldbase) < oldsize) {
+      e->stack += delta;
     }
 
     if (ci->proc && MRB_PROC_ENV_P(ci->proc) && e != MRB_PROC_ENV(ci->proc)) {
       e = MRB_PROC_ENV(ci->proc);
 
       if (e && MRB_ENV_ONSTACK_P(e) &&
-          (st = e->stack) && oldbase <= st && st < oldbase+oldsize) {
-        ptrdiff_t off = e->stack - oldbase;
-
-        e->stack = newbase + off;
+          (st = e->stack) && (size_t)(st - oldbase) < oldsize) {
+        e->stack += delta;
       }
     }
 
-    ci->stack = newbase + (ci->stack - oldbase);
+    ci->stack += delta;
     ci++;
   }
 }


### PR DESCRIPTION
  - Calculate the difference between `oldbase` and `newbase` only once outside the loop.
  - To make sure they are within range, the comparison is done only once instead of twice.