### PR TITLE
Make `MRuby::Build#enable_debug` compiler flag setting abstract

### DIFF
--- a/lib/mruby/build.rb
+++ b/lib/mruby/build.rb
@@ -167,9 +167,7 @@ module MRuby
     def enable_debug
       compilers.each do |c|
         c.defines += %w(MRB_DEBUG)
-        if toolchains.any? { |toolchain| toolchain == "gcc" }
-          c.flags += %w(-g3 -O0)
-        end
+        c.setup_debug(self)
       end
       @mrbc.compile_options += ' -g'
 

--- a/lib/mruby/build/command.rb
+++ b/lib/mruby/build/command.rb
@@ -172,6 +172,12 @@ module MRuby
     def object_ext?(path)
       File.extname(path) == build.exts.object
     end
+
+    # This method can be redefined as a singleton method where appropriate.
+    # Manipulate `flags`, `include_paths` and/or more if necessary.
+    def setup_debug(conf)
+      nil
+    end
   end
 
   class Command::Linker < Command

--- a/tasks/toolchains/gcc.rake
+++ b/tasks/toolchains/gcc.rake
@@ -20,6 +20,10 @@ MRuby::Toolchain.new(:gcc) do |conf, params|
     compiler.cxx_compile_flag = '-x c++ -std=gnu++03'
     compiler.cxx_exception_flag = '-fexceptions'
     compiler.cxx_invalid_flags = c_mandatory_flags + cxx_invalid_flags
+
+    def compiler.setup_debug(conf)
+      self.flags << %w(-g3 -O0)
+    end
   end
 
   conf.linker do |linker|


### PR DESCRIPTION
Previously, compiler flags were only added for GCC or similar. The situation has not changed, but it has become easier to improve.

I expect `MRuby::Command::Compiler#setup_debug` to be defined as a singleton method inside the block given to `MRuby::Toolchain.new`.
