### PR TITLE
`Kernel#binding` responds only to calls from Ruby

### DIFF
--- a/mrbgems/mruby-binding-eval/test/binding.rb
+++ b/mrbgems/mruby-binding-eval/test/binding.rb
@@ -43,12 +43,6 @@ assert("Binding#local_variable_get") do
   }
 end
 
-assert "Kernel#binding and .eval from C" do
-  bind = binding_in_c
-  assert_equal 5, bind.eval("2 + 3")
-  assert_nothing_raised { bind.eval("self") }
-end
-
 assert "Binding#eval with Binding.new via UnboundMethod" do
   assert_raise(NoMethodError) { Class.instance_method(:new).bind_call(Binding) }
 end

--- a/mrbgems/mruby-binding/src/binding.c
+++ b/mrbgems/mruby-binding/src/binding.c
@@ -382,10 +382,13 @@ mrb_f_binding(mrb_state *mrb, mrb_value self)
   struct RProc *proc;
   struct REnv *env;
 
+  if (mrb->c->ci->cci != 0) {
+  caller_err:
+    mrb_raise(mrb, E_RUNTIME_ERROR, "Cannot create Binding object for non-Ruby caller");
+  }
   proc = (struct RProc*)mrb_proc_get_caller(mrb, &env);
   if (!env || MRB_PROC_CFUNC_P(proc)) {
-    proc = NULL;
-    env = NULL;
+    goto caller_err;
   }
   return mrb_binding_new(mrb, proc, self, env);
 }

--- a/mrbgems/mruby-binding/test/binding.c
+++ b/mrbgems/mruby-binding/test/binding.c
@@ -8,7 +8,7 @@ binding_in_c(mrb_state *mrb, mrb_value self)
 }
 
 void
-mrb_mruby_binding_eval_gem_test(mrb_state *mrb)
+mrb_mruby_binding_gem_test(mrb_state *mrb)
 {
   mrb_define_method(mrb, mrb->object_class, "binding_in_c", binding_in_c, MRB_ARGS_NONE());
 }

--- a/mrbgems/mruby-binding/test/binding.rb
+++ b/mrbgems/mruby-binding/test/binding.rb
@@ -58,3 +58,7 @@ assert("Binding#dup") do
   assert_equal 30, bind1.local_variable_get(:z)
   assert_equal 40, bind2.local_variable_get(:z)
 end
+
+assert "Kernel#binding and .eval from C" do
+  assert_raise(RuntimeError) { binding_in_c }
+end


### PR DESCRIPTION
This follows the behavior changed in CRuby 3.2.