### PR TITLE
Sign extension with `OP_LOADI32` in `get_int_operand()`

### DIFF
--- a/mrbgems/mruby-compiler/core/codegen.c
+++ b/mrbgems/mruby-compiler/core/codegen.c
@@ -771,7 +771,7 @@ get_int_operand(codegen_scope *s, struct mrb_insn_data *data, mrb_int *n)
     return TRUE;
 
   case OP_LOADI32:
-    *n = (mrb_int)((uint32_t)data->b<<16)+data->c;
+    *n = (int32_t)((uint32_t)data->b<<16)+data->c;
     return TRUE;
 
   case OP_LOADL:


### PR DESCRIPTION
Previously, the following code did not give the expected result.

```
% bin/mruby -e 'p "%08X" % ~(-1 << 16)'
"..F0000FFFF"

% ruby32 -e 'p "%08X" % ~(-1 << 24)'
"00FFFFFF"
```

For information: this problem arises in the process of folding numbers through optimisation.