### PR TITLE
Replace "folder" with "directory" for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ rake view_capi
 mruby contains a package manager called *mrbgems*. To create extensions
 in C and/or Ruby you should create a *GEM*. For a documentation of how to
 use mrbgems consult the file [mrbgems.md](doc/guides/mrbgems.md).
-For example code of how to use mrbgems look into the folder [examples/mrbgems/](examples/mrbgems).
+For example code of how to use mrbgems look into the [examples/mrbgems/](examples/mrbgems) directory.
 
 ## License
 

--- a/Rakefile
+++ b/Rakefile
@@ -57,7 +57,7 @@ task :clean do
     rm_rf build.build_dir
     rm_f build.products
   end
-  puts "Cleaned up target build folder"
+  puts "Cleaned up target build directory"
 end
 
 desc "clean everything!"
@@ -65,7 +65,7 @@ task :deep_clean => %w[clean doc:clean] do
   MRuby.each_target do |build|
     rm_rf build.gem_clone_dir
   end
-  puts "Cleaned up mrbgems build folder"
+  puts "Cleaned up mrbgems build directory"
 end
 
 desc "run all pre-commit hooks against all files"

--- a/doc/guides/compile.md
+++ b/doc/guides/compile.md
@@ -376,7 +376,7 @@ end
 
 ## Build process
 
-During the build process the directory `build` will be created in the
+During the build process the `build` directory will be created in the
 root directory. The structure of this directory will look like this:
 
 ```

--- a/doc/guides/mrbgems.md
+++ b/doc/guides/mrbgems.md
@@ -160,9 +160,9 @@ The maximal GEM structure looks like this:
     +- test/            <- Test code (Ruby)
 ```
 
-The folder `mrblib` contains pure Ruby files to extend mruby. The folder `src`
-contains C/C++ files to extend mruby. The folder `include` contains C/C++ header
-files. The folder `test` contains C/C++ and pure Ruby files for testing purposes
+The `mrblib` directory contains pure Ruby files to extend mruby. The `src` directory
+contains C/C++ files to extend mruby. The `include` directory contains C/C++ header
+files. The `test` directory contains C/C++ and pure Ruby files for testing purposes
 which will be used by `mrbtest`. `mrbgem.rake` contains the specification
 to compile C and Ruby files. `README.md` is a short description of your GEM.
 
@@ -349,7 +349,7 @@ mrb_c_extension_example_gem_final(mrb_state* mrb) {
 
 mruby can be extended with pure Ruby. It is possible to override existing
 classes or add new ones in this way. Put all Ruby files into the `mrblib`
-folder.
+directory.
 
 ### Pre-Conditions
 
@@ -377,7 +377,7 @@ none
 
 mruby can be extended with C and Ruby at the same time. It is possible to
 override existing classes or add new ones in this way. Put all Ruby files
-into the `mrblib` folder and all C files into the `src` folder.
+into the `mrblib` directory and all C files into the `src` directory.
 
 mruby codes under `mrblib` directory would be executed after gem init C
 function is called. Make sure *mruby script* depends on *C code* and


### PR DESCRIPTION
Also, use "x/y/z directory" instead of "directory x/y/z" if there is no problem.

- - -

I see "directory" notation as more common than "folder" in mruby.

```console
% git grep -iE 'directory|directories' 68d67aee0 -- :^Doxyfile | wc
      91     790    9042
% git grep -iE 'folder' 68d67aee0 -- :^Doxyfile | wc
       8      78     711
```
