### PR TITLE
fix typo in mrbgems/mruby-io/src/io.c

### DIFF
--- a/mrbgems/mruby-io/src/io.c
+++ b/mrbgems/mruby-io/src/io.c
@@ -94,7 +94,7 @@ io_get_open_fptr(mrb_state *mrb, mrb_value io)
 # define MRB_NO_IO_POPEN 1
 #endif
 
-#ifndef MRB_NO_IO_POEPN
+#ifndef MRB_NO_IO_POPEN
 static void
 io_set_process_status(mrb_state *mrb, pid_t pid, int status)
 {


### PR DESCRIPTION
MRB_NO_IO_POEPN -> MRB_NO_IO_POPEN