### PR TITLE
lib/mruby/build/command.rb: narrow down poppen mode

### DIFF
--- a/lib/mruby/build/command.rb
+++ b/lib/mruby/build/command.rb
@@ -341,7 +341,7 @@ module MRuby
       opt << " -s" if static
       cmd = %["#{filename @command}" #{opt} #{filename(infiles).map{|f| %["#{f}"]}.join(' ')}]
       puts cmd if Rake.verbose
-      IO.popen(cmd, 'r+') do |io|
+      IO.popen(cmd, 'r') do |io|
         out.puts io.read
       end
       # if mrbc execution fail, drop the file


### PR DESCRIPTION
The mode specified in IO.popen is r+, but since write is not needed for a pipe stream with a child process here, it seems better to narrow the permission.
