### PR TITLE
Remove `mrb_final_mrbgems()` in `mrbc.c`

### DIFF
--- a/mrbgems/mruby-bin-mrbc/tools/mrbc/mrbc.c
+++ b/mrbgems/mruby-bin-mrbc/tools/mrbc/mrbc.c
@@ -368,9 +368,4 @@ void
 mrb_init_mrbgems(mrb_state *mrb)
 {
 }
-
-void
-mrb_final_mrbgems(mrb_state *mrb)
-{
-}
 #endif


### PR DESCRIPTION
The current `mrb_final_mrbgems()` function is only referenced in the `mrbgem/gem_init.c` file.

Also, the definition in that file makes it a static function.