### PR TITLE
Correct the `MRuby::Build#define_installer`

### DIFF
--- a/lib/mruby/build.rb
+++ b/lib/mruby/build.rb
@@ -388,7 +388,7 @@ EOS
         define_installer_outline(src, dst) do
           File.write dst, <<~BATCHFILE
             @echo off
-            call "#{src}" %*
+            call "#{File.expand_path(src)}" %*
           BATCHFILE
         end
       end
@@ -396,8 +396,8 @@ EOS
       def define_installer(src)
         dst = "#{self.class.install_dir}/#{File.basename(src)}"
         define_installer_outline(src, dst) do
-          File.unlink(dst) if File.exist?(dst)
-          File.symlink(src, dst)
+          File.unlink(dst) rescue nil
+          File.symlink(File.expand_path(src), dst)
         end
       end
     end


### PR DESCRIPTION
This is a complement to #5928.
The previous PR had the following problem:

  - The `<INSTALL_DIR>/bin/*` file could not be replaced if the destination of the symbolic link was lost.
  - The wrong link destination was written if `MRuby::Build.install_dir` was a relative path.