### PR TITLE
Make "bintest" independent of directory

### DIFF
--- a/lib/mruby/build.rb
+++ b/lib/mruby/build.rb
@@ -467,7 +467,8 @@ EOS
       targets << filename(".") if File.directory? "./bintest"
       mrbc = @gems["mruby-bin-mrbc"] ? exefile("#{@build_dir}/bin/mrbc") : mrbcfile
       env = {"BUILD_DIR" => @build_dir, "MRBCFILE" => mrbc}
-      sh env, "ruby test/bintest.rb#{verbose_flag} #{targets.join ' '}"
+      bintest = File.join(MRUBY_ROOT, "test/bintest.rb")
+      sh env, "ruby #{bintest}#{verbose_flag} #{targets.join ' '}"
     end
 
     def print_build_summary
@@ -612,7 +613,8 @@ EOS
         "MRBCFILE" => mrbc,
         "EMULATOR" => @test_runner.emulator,
       }
-      sh env, "ruby test/bintest.rb#{verbose_flag} #{targets.join ' '}"
+      bintest = File.join(MRUBY_ROOT, "test/bintest.rb")
+      sh env, "ruby #{bintest}#{verbose_flag} #{targets.join ' '}"
     end
 
     protected


### PR DESCRIPTION
Previously, "bintest" would fail to run unless `MRUBY_ROOT` and `Dir.pwd` were the same.