### PR TITLE
pre-commit: add hook `markdown-link-check`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,6 +57,11 @@ repos:
         entry: markdownlint -c .github/linters/.markdown-lint.yml .
         types: [markdown]
         files: \.(md|mdown|markdown)$
+  - repo: https://github.com/tcort/markdown-link-check
+    rev: v3.11.2
+    hooks:
+      - id: markdown-link-check
+        args: [-q]
   - repo: https://github.com/adrienverge/yamllint
     rev: v1.31.0
     hooks:

--- a/doc/mruby3.2.md
+++ b/doc/mruby3.2.md
@@ -32,9 +32,9 @@
 
 ## New bundled gems
 
-- mruby-errno from [https://github.com/iij/mruby-errno.git]
-- mruby-set from [https://github.com/yui-knk/mruby-set.git]
-- mruby-dir from [https://github.com/iij/mruby-dir.git]
+- mruby-errno from <https://github.com/iij/mruby-errno.git>
+- mruby-set from <https://github.com/yui-knk/mruby-set.git>
+- mruby-dir from <https://github.com/iij/mruby-dir.git>
 - mruby-data
 
 # Breaking Changes


### PR DESCRIPTION
Fix links in Markdown

https://github.com/tcort/markdown-link-check#run-as-a-pre-commit-hook