### PR TITLE
Allow tests to be disabled for specific gems; warn about disabled tests

### DIFF
--- a/doc/guides/mrbgems.md
+++ b/doc/guides/mrbgems.md
@@ -92,6 +92,21 @@ end
 However, it should be used with caution, as it may deviate from the intent
 of the gem's author.
 
+### Gem Testing
+
+If you enable unit tests in your build with `enable_test`, tests will be
+generated for all gems and their dependencies by default. If necessary, it is
+possible to suppress tests for a specific gem like so:
+
+```ruby
+conf.gem 'mruby-noisygem' do |g|
+  g.skip_test = true
+end
+```
+
+However, it is considered best practice to leave all tests enabled whenever
+possible. A warning message will be generated for each gem with disabled tests.
+
 ## GemBox
 
 There are instances when you wish to add a collection of mrbgems into mruby at

--- a/lib/mruby/gem.rb
+++ b/lib/mruby/gem.rb
@@ -36,6 +36,7 @@ module MRuby
       attr_accessor :export_include_paths
 
       attr_reader :generate_functions
+      attr_writer :skip_test
 
       attr_block MRuby::Build::COMMANDS
 
@@ -62,6 +63,7 @@ module MRuby
 
         @test_preload = nil # 'test/assert.rb'
         @test_args = {}
+        @skip_test = false
 
         @bins = []
         @cdump = true
@@ -85,6 +87,10 @@ module MRuby
 
         repo_url = build.gem_dir_to_repo_url[dir]
         build.locks[repo_url]['version'] = version if repo_url
+      end
+
+      def skip_test?
+        @skip_test
       end
 
       def setup_compilers

--- a/mrbgems/mruby-test/mrbgem.rake
+++ b/mrbgems/mruby-test/mrbgem.rake
@@ -144,14 +144,26 @@ MRuby::Gem::Specification.new('mruby-test') do |spec|
       f.puts %Q[ *   All manual changes will get lost.]
       f.puts %Q[ */]
       f.puts %Q[]
-      f.puts %Q[struct mrb_state;]
-      f.puts %Q[typedef struct mrb_state mrb_state;]
+      f.puts %Q[#include <mruby.h>]
+      f.puts %Q[#include <mruby/variable.h>]
+      f.puts %Q[#include <mruby/array.h>]
+      f.puts %Q[]
       build.gems.each do |g|
         f.puts %Q[void GENERATED_TMP_mrb_#{g.funcname}_gem_test(mrb_state *mrb);]
       end
       f.puts %Q[void mrbgemtest_init(mrb_state* mrb) {]
       build.gems.each do |g|
-        f.puts %Q[    GENERATED_TMP_mrb_#{g.funcname}_gem_test(mrb);]
+        if g.skip_test?
+          f.puts %Q[    do {]
+          f.puts %Q[      mrb_value asserts = mrb_gv_get(mrb, mrb_intern_lit(mrb, "$asserts"));]
+          f.puts %Q[      mrb_ary_push(mrb, asserts, mrb_str_new_lit(mrb, ]
+          f.puts %Q[                   "Warn: Skipping tests for gem (#{
+                                        g.name == 'mruby-test' ? 'core' : "mrbgems: #{g.name}"
+                                       })"));]
+          f.puts %Q[    } while (0);]
+        else
+          f.puts %Q[    GENERATED_TMP_mrb_#{g.funcname}_gem_test(mrb);]
+        end
       end
       f.puts %Q[}]
     end


### PR DESCRIPTION
**Purpose**

While it is preferable to leave all tests enabled, I had a need to disable tests for specific mgems while leaving all others enabled. For example, some mgems which my project requires contain unit tests that depend on remote servers, and the tests will always fail if those servers are not accessible (e.g. due to firewall restrictions or temporary internet outage). Thus, this PR makes it possible to disable some tests while leaving the rest of the test suite enabled.

**Syntax**

```ruby
conf.gem 'mruby-noisygem' do |g|
  g.skip_test = true
end
```

I think the assignment-style syntax, `g.skip_test = true|false`, might allow for more flexibility within a complex build script, but if a more declarative style (`g.skip_test`) is preferred, this is an easy change that I can make.

**Implementation Notes**

If `mruby-test/mrbgem.rake` encounters a gem with disabled tests, it simply does not generate a call to `GENERATED_TMP_mrb_#{g.funcname}_gem_test(mrb)`. Instead, it adds a warning to `$asserts` so that the builder won't forget that they have disabled these tests.

I considered also suppressing the generated test code in `gem_test.c`. If we did that, the generated `mrbtest` bin should be smaller. However, I decided to leave it in place, in case the builder wants to call the test functions directly for some reason (perhaps with a custom test driver, for example). Therefore, in this PR the test logic is still generated and its symbols are still exported as before, but it just isn't executed by the default `mrbtest`.

In order to add the warnings to `$asserts`, I had to `#include <mruby.h>` (and a few others) in the generated `mrbtest.c` and delete `typedef struct mrb_state mrb_state`. I am not sure if there was a specific reason that the original version relied upon a typedef instead of including `mruby.h`, so if a dependency on `mruby.h` is not desirable, then we could create a function in `driver.c` and call that function instead.

**Testing**

I did give some thought to writing a test case for the proposed behavior. I considered creating a dummy mgem, which contains a single assertion that always fails. Then, I could modify `build_config/ci/*.rb` to disable the dummy mgem test with `skip_test = true`. When the test passes, the dummy test would be disabled and therefore not generate a failing assertion. However, I decided to wait and see what you think about this approach. It seems heavy handed and maybe you know a better way. Also, I'm not sure where a dummy gem should live (would `test/` be a good location?). I am happy to add this kind of test case if desired.