### PR TITLE
Enable markdownlint rule MD052

### DIFF
--- a/.github/linters/.markdown-lint.yml
+++ b/.github/linters/.markdown-lint.yml
@@ -27,6 +27,3 @@ MD040: false
 
 # MD041 first-line-heading/first-line-h1 - First line in a file should be a top-level heading
 MD041: false
-
-# MD052/reference-links-images Reference links and images should use a label that is defined
-MD052: false

--- a/doc/guides/gc-arena-howto.md
+++ b/doc/guides/gc-arena-howto.md
@@ -3,6 +3,7 @@
 _This is an English translation of [Matz's blog post][matz blog post]
 written in Japanese._
 _Some parts are updated to reflect recent changes._
+
 [matz blog post]: <https://www.rubyist.net/~matz/20130731.html>
 
 When you are extending mruby using C language, you may encounter


### PR DESCRIPTION
https://github.com/DavidAnson/markdownlint/blob/main/doc/md052.md

Fix Markdown reference link.

Previous to this fix the Markdown markup was broken as seen here:

https://github.com/mruby/mruby/blob/master/doc/guides/gc-arena-howto.md

But now looks better here:

https://github.com/jbampton/mruby/blob/fix-markdown-link/doc/guides/gc-arena-howto.md