### PR TITLE
Build configuration for MS-DOS and DJGPP

### DIFF
--- a/build_config/i586-pc-msdosdjgpp.rb
+++ b/build_config/i586-pc-msdosdjgpp.rb
@@ -1,0 +1,77 @@
+# Cross Compiling configuration for MS-DOS
+#
+# Requires DJGPP cross-compiler, see
+# https://github.com/andrewwutw/build-djgpp/releases
+
+MRuby::CrossBuild.new("i586-pc-msdosdjgpp") do |conf|
+  toolchain :gcc
+
+  # If DJGPP is not in the PATH, set this to the bin directory
+  DJGPP_PATH = nil
+
+  GCC = 'i586-pc-msdosdjgpp-gcc'
+  GXX = 'i586-pc-msdosdjgpp-g++'
+  AR  = 'i586-pc-msdosdjgpp-ar'
+
+  conf.cc do |cc|
+    cc.command = DJGPP_PATH ? File.join(DJGPP_PATH, GCC) : GCC
+    cc.defines << 'MRB_WITHOUT_IO_PREAD_PWRITE'
+    cc.defines << 'MRB_UTF8_STRING'
+  end
+
+  conf.cxx do |cxx|
+    cxx.command = DJGPP_PATH ? File.join(DJGPP_PATH, GXX) : GXX
+    cxx.defines << 'MRB_WITHOUT_IO_PREAD_PWRITE'
+    cxx.defines << 'MRB_UTF8_STRING'
+  end
+
+  conf.linker do |linker|
+    linker.command = DJGPP_PATH ? File.join(DJGPP_PATH, GXX) : GXX
+    linker.libraries = %w(m)
+  end
+
+  conf.archiver do |archiver|
+    archiver.command = DJGPP_PATH ? File.join(DJGPP_PATH, AR) : AR
+  end
+
+  # All provided gems that can be reasonably made to compile:
+  # default.gembox, minus mruby-socket and replacing mruby-cmath with mruby-cmath-alt
+  conf.gembox "stdlib"
+  conf.gembox "stdlib-ext"
+
+  conf.gem :core => 'mruby-io'              # stdlib-io.gembox <- default.gembox
+# No socket support in DJGPP
+# conf.gem :core => 'mruby-socket'          # stdlib-io.gembox <- default.gembox
+  conf.gem :core => 'mruby-print'           # stdlib-io.gembox <- default.gembox
+  conf.gem :core => 'mruby-errno'           # stdlib-io.gembox <- default.gembox
+  conf.gem :core => 'mruby-dir'             # stdlib-io.gembox <- default.gembox
+
+  conf.gem :core => 'mruby-bigint'          # math.gembox <- default.gembox
+  conf.gem :core => 'mruby-complex'         # math.gembox <- default.gembox
+  conf.gem :core => 'mruby-math'            # math.gembox <- default.gembox
+  conf.gem :core => 'mruby-rational'        # math.gembox <- default.gembox
+  # Alternative implementation of cmath, not requiring <complex.h>
+# conf.gem :github => 'chasonr/mruby-cmath-alt' # math.gembox <- default.gembox
+
+  conf.gembox "metaprog"
+
+  conf.gem :core => 'mruby-bin-mrbc'        # default.gembox
+  conf.gem :core => 'mruby-bin-debugger'    # default.gembox
+  conf.gem :core => 'mruby-bin-mirb'        # default.gembox
+  conf.gem :core => 'mruby-bin-mruby'       # default.gembox
+  conf.gem :core => 'mruby-bin-strip'       # default.gembox
+  conf.gem :core => 'mruby-bin-config'      # default.gembox
+
+  # Other compilable gems
+  conf.gem :core => 'mruby-binding'
+  conf.gem :core => 'mruby-catch'
+  conf.gem :core => 'mruby-enum-chain'
+  conf.gem :core => 'mruby-error'
+  conf.gem :core => 'mruby-exit'
+  conf.gem :core => 'mruby-os-memsize'
+  conf.gem :core => 'mruby-proc-binding'
+  conf.gem :core => 'mruby-sleep'
+
+  # For Onigmo regular expression support
+  conf.gem :github => 'mattn/mruby-onig-regexp'
+end

--- a/mrbgems/mruby-dir/src/dir.c
+++ b/mrbgems/mruby-dir/src/dir.c
@@ -166,7 +166,7 @@ mrb_dir_chdir(mrb_state *mrb, mrb_value klass)
 static mrb_value
 mrb_dir_chroot(mrb_state *mrb, mrb_value self)
 {
-#if defined(_WIN32) || defined(_WIN64) || defined(__ANDROID__)
+#if defined(_WIN32) || defined(_WIN64) || defined(__ANDROID__) || defined(__MSDOS__)
   mrb_raise(mrb, E_NOTIMP_ERROR, "chroot() unreliable on your system");
   return mrb_fixnum_value(0);
 #else

--- a/mrbgems/mruby-io/src/file.c
+++ b/mrbgems/mruby-io/src/file.c
@@ -38,7 +38,9 @@
   #define GETCWD getcwd
   #define CHMOD(a, b) chmod(a,b)
   #include <sys/file.h>
+#ifndef __DJGPP__
   #include <libgen.h>
+#endif
   #include <sys/param.h>
   #include <pwd.h>
 #endif

--- a/mrbgems/mruby-io/src/file_test.c
+++ b/mrbgems/mruby-io/src/file_test.c
@@ -20,7 +20,9 @@
   #include <sys/file.h>
   #include <sys/param.h>
   #include <sys/wait.h>
+#ifndef __DJGPP__
   #include <libgen.h>
+#endif
   #include <pwd.h>
   #include <unistd.h>
 #endif

--- a/mrbgems/mruby-io/src/io.c
+++ b/mrbgems/mruby-io/src/io.c
@@ -46,7 +46,11 @@
   #include <unistd.h>
   typedef size_t fsize_t;
   typedef time_t ftime_t;
+#ifdef __DJGPP__
+  typedef long fsuseconds_t;
+#else
   typedef suseconds_t fsuseconds_t;
+#endif
   typedef mode_t fmode_t;
   typedef ssize_t fssize_t;
 #endif


### PR DESCRIPTION
This provides a build configuration for MS-DOS, cross-compiled on Linux using DJGPP.

* Most gems compile unmodified, with a few flags set in the build configuration.
* mruby-dir compiles only if chroot is disabled.
* mruby-io requires a few changes to avoid the libgen.h file, which DJGPP does not have, and to define fsuseconds_t.
* mruby-socket does not compile.
* mruby-cmath does not compile, because DJGPP does not provide complex.h. I am working on an alternative implementation that does not require complex.h.