### PR TITLE
Fix Super-Linter button in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   </p>
   <h1>mruby</h1>
   <a href="https://github.com/marketplace/actions/super-linter">
-    <img src="https://github.com/mruby/mruby/workflows/Lint%20Code%20Base/badge.svg"
+    <img src="https://github.com/mruby/mruby/actions/workflows/super-linter.yml/badge.svg"
       alt="GitHub Super-Linter">
   </a>
 </div>


### PR DESCRIPTION
Updated the button to the latest format seen here:

https://github.com/marketplace/actions/super-linter#add-super-linter-badge-in-your-repository-readme

And the fixed button is seen here:

https://github.com/jbampton/mruby/tree/fix-super-linter-button