### PR TITLE
pre-commit: add hook `forbid-submodules`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,7 @@ repos:
         args: [--unique]
         files: ^codespell\.txt$
       - id: fix-byte-order-marker
+      - id: forbid-submodules
       - id: mixed-line-ending
       - id: trailing-whitespace
   - repo: https://github.com/Lucas-C/pre-commit-hooks


### PR DESCRIPTION
https://github.com/pre-commit/pre-commit-hooks#forbid-submodules

If you want to ban them entirely use forbid-submodules.

Really this is just one extra check or test we can have.