### PR TITLE
Revert "Rake: update task clean to remove `bin` and `build` folders"

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -53,8 +53,10 @@ task :build => MRuby.targets.flat_map{|_, build| build.products}
 
 desc "clean all built and in-repo installed artifacts"
 task :clean do
-  rm_rf "#{MRUBY_ROOT}/bin"
-  rm_rf "#{MRUBY_ROOT}/build"
+  MRuby.each_target do |build|
+    rm_rf build.build_dir
+    rm_f build.products
+  end
   puts "Cleaned up target build directory"
 end
 


### PR DESCRIPTION
Reverts mruby/mruby#6032
