### PR TITLE
Convert to string before output in `puts`

### DIFF
--- a/mrbgems/mruby-print/mrblib/print.rb
+++ b/mrbgems/mruby-print/mrblib/print.rb
@@ -28,6 +28,7 @@ module Kernel
       if s.kind_of?(Array)
         puts(*s)
       else
+        s = s.to_s
         print s
         print "\n" if (s[-1] != "\n")
       end


### PR DESCRIPTION
For example, evaluating `puts nil` raised `NoMethodError` before.