### PR TITLE
Fixes escape sequence bug and enhancements in Presym scanning

### DIFF
--- a/lib/mruby/presym.rb
+++ b/lib/mruby/presym.rb
@@ -46,6 +46,18 @@ module MRuby
 
     C_STR_LITERAL_RE = /"(?:[^\\\"]|\\.)*"/
 
+    ESCAPE_SEQUENCE_MAP = {
+      "a" => "\a",
+      "b" => "\b",
+      "e" => "\e",
+      "f" => "\f",
+      "n" => "\n",
+      "r" => "\r",
+      "t" => "\t",
+      "v" => "\v",
+    }
+    ESCAPE_SEQUENCE_MAP.keys.each { |k| ESCAPE_SEQUENCE_MAP[ESCAPE_SEQUENCE_MAP[k]] = k }
+
     def initialize(build)
       @build = build
     end
@@ -93,7 +105,18 @@ module MRuby
         f.puts "};"
         f.puts
         f.puts "static const char * const presym_name_table[] = {"
-        presyms.each{|sym| f.puts %|  "#{sym.gsub(/[\x01-\x1f\x7f-\xff\"\\]/n) { %(\\x%02x) % _1.ord }}",|}
+        presyms.each do |sym|
+          sym = sym.gsub(/([\x01-\x1f\x7f-\xff])|("|\\)/n) {
+            case
+            when $1
+              e = ESCAPE_SEQUENCE_MAP[$1]
+              e ? "\\#{e}" : '\\x%02x""' % $1.ord
+            when $2
+              "\\#$2"
+            end
+          }
+          f.puts %|  "#{sym}",|
+        end
         f.puts "};"
       end
     end
@@ -122,11 +145,12 @@ module MRuby
         unless literals.empty?
           literals = literals.map{|l| l[1..-2]}
           literals.each do |e|
-            e.gsub!(/\\x([0-9A-Fa-f]{1,2})|\\0([0-7]{,3})|\\(.)/) do
+            e.gsub!(/\\x([0-9A-Fa-f]{1,2})|\\(0[0-7]{,3})|\\([abefnrtv])|\\(.)/) do
               case
               when $1; $1.hex.chr(Encoding::BINARY)
               when $2; $2.oct.chr(Encoding::BINARY)
-              when $3; $3
+              when $3; ESCAPE_SEQUENCE_MAP[$3]
+              when $4; $4
               end
             end
           end


### PR DESCRIPTION
In #6011, a hexadecimal escape sequence followed by a hexadecimal character would cause a compile error. Also, avoid using "Numbered Parameter" which older Ruby does not have (e.g. AppVeyor).

ref. #6044

---

In the verification with `conf.enable_debug` in the build by MSVC:

  - Before this patch, I can see a compile error in the escape sequence part.
    https://github.com/dearblue/mruby/actions/runs/6122499107/job/16618399040#step:4:499
  - After this patch, there are no compile errors, but `mrbtest` fails.
    https://github.com/dearblue/mruby/actions/runs/6122499387/job/16618399785#step:4:2540

Fixed #6044