### PR TITLE
Add `.gitattributes` for newline code normalization

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+*       text=auto eol=lf
+*.bat   text eol=crlf
+*.cmd   text eol=crlf
+*.png   binary


### PR DESCRIPTION
References:
  - [Git] リポジトリで改行コードを正規化する
    https://zenn.dev/murnana/articles/eol-and-gitattributes
  - 行終端を処理するようGitを設定する - GitHub Docs
    https://docs.github.com/ja/get-started/getting-started-with-git/configuring-git-to-handle-line-endings

---

The newline code of the batch file will be output as "CRLF".
The data retained in the repository will remain "LF", so there will be no difference in `mrbgems/mruby-bin-config/mruby-config.bat`.
If necessary, `rm mrbgems/mruby-bin-config/mruby-config.bat && git checkout -- mrbgems/mruby-bin-config/mruby-config.bat` will update the working file.

Also, if binary files such as JPEG are added in the future, they will not be treated as text, so it is expected that the data will not be automatically converted even if this is done.
This was confirmed just to be sure.
I am not sure if my memory is clear, but I believe git determines if a file is binary data or not by whether or not there is a "\0" within the first 4 KiB of the file.
