### PR TITLE
Brush up `build_config/host-shared.rb` file

### DIFF
--- a/build_config/host-shared.rb
+++ b/build_config/host-shared.rb
@@ -1,23 +1,20 @@
+# NOTE: Currently, this configuration file does not support VisualC++!
+#       Your help is needed!
+
 MRuby::Build.new do |conf|
   # load specific toolchain settings
-
-  # Gets set by the VS command prompts.
-  if ENV['VisualStudioVersion'] || ENV['VSINSTALLDIR']
-    toolchain :visualcpp
-  else
-    toolchain :gcc
-  end
+  conf.toolchain
 
   # include the GEM box
   conf.gembox 'default'
 
   # C compiler settings
-  conf.cc do |cc|
-    cc.flags = '-fPIC'
+  conf.compilers.each do |cc|
+    cc.flags << '-fPIC'
   end
 
   conf.archiver do |archiver|
-    archiver.command = 'gcc'
+    archiver.command = cc.command
     archiver.archive_options = '-shared -o %{outfile} %{objs}'
   end
 
@@ -28,6 +25,9 @@ MRuby::Build.new do |conf|
 
   # file separator
   # conf.file_separator = '/'
+
+  # enable this if better compatibility with C++ is desired
+  #conf.enable_cxx_exception
 
   # Turn on `enable_debug` for better debugging
   conf.enable_debug


### PR DESCRIPTION
Summary:

  - VisualC++ does not supported.
  - `cc.flags` must maintain array objects.
  - Enable C++ exceptions for C++ friendly.
