### PR TITLE
Execution beyond the context of the fiber resume is required for some…

### DIFF
--- a/mrbgems/mruby-fiber/src/fiber.c
+++ b/mrbgems/mruby-fiber/src/fiber.c
@@ -308,7 +308,6 @@ fiber_resume(mrb_state *mrb, mrb_value self)
   const mrb_value *a;
   mrb_int len;
 
-  fiber_check_cfunc(mrb, mrb->c);
   mrb_get_args(mrb, "*!", &a, &len);
   return fiber_switch(mrb, self, len, a, TRUE, FALSE);
 }


### PR DESCRIPTION
Hello. This PR is related to the following:
https://github.com/mruby/mruby/issues/6060

Originally, there was an issue in mruby where the stack would get corrupted when executing Fiber#resume in a C context, and as a workaround, there is the approach of wrapping Fiber execution in a Proc.
https://github.com/mruby/mruby/issues/3056

This workaround is used in [h2o](https://github.com/h2o/h2o) and [ngx_mruby](https://github.com/matsumotory/ngx_mrby).

However, with the addition of this commit included in mruby 3.2 and later, this workaround will no longer function.
https://github.com/mruby/mruby/pull/5782

My request is that until the issue with Fiber is resolved, I would like to request permission to continue using this workaround.
I would appreciate it if you could consider this.