### PR TITLE
Demotion mrb_f_raise() in kernel.c from MRB_API too

### DIFF
--- a/src/kernel.c
+++ b/src/kernel.c
@@ -411,7 +411,7 @@ mrb_false(mrb_state *mrb, mrb_value self)
  *     raise "Failed to create socket"
  *     raise ArgumentError, "No parameters", caller
  */
-MRB_API mrb_value
+mrb_value
 mrb_f_raise(mrb_state *mrb, mrb_value self)
 {
   mrb_value exc, mesg;


### PR DESCRIPTION
The prototype declaration of `mrb_f_raise()` has arleady demoted from `MRB_API` in a below commit.

https://github.com/mruby/mruby/commit/0898ce982eea706c9a7b814280cdda09e82abe17

However, the entity of `mrb_f_raise()` in kernel.c is set `MRB_API` yet.
Therefore, mruby occures build error with MSVC(in Visual Studio 2022) as below.

https://github.com/groonga/groonga/actions/runs/6310140553/job/17131485675#step:11:2067

The cause of the above error that we define both `mrb_f_raise()` with `MRB_API` and `mrb_f_raise()` without `MRB_API`.

---

The results of `rake test` of this PR.

```
>>> Test host <<<
mrbtest - Embeddable Ruby Test

.........................................................................................?.............................................................................................................................................................................................................................................................................................................................................................................?.....................................................................................................................................................................................................................................................?..................??.................................................................................................................................................................................................................................................................................................................................................................................................................................................................??...............................................................................................................................................................................................................................................
Skip: File.expand_path (with ENV) (mrbgems: mruby-io)
Skip: Proc#source_location (mrbgems: mruby-proc-ext)
Skip: Kernel.caller, Kernel#caller => backtrace isn't available (mrbgems: mruby-kernel-ext)
Skip: Method#source_location (mrbgems: mruby-method)
Skip: UnboundMethod#source_location (mrbgems: mruby-method)
Skip: GC in rescue => backtrace isn't available (core)
Skip: Method call in rescue => backtrace isn't available (core)
  Total: 1412
     OK: 1405
     KO: 0
  Crash: 0
Warning: 0
   Skip: 7
   Time: 0.05 seconds

>>> Bintest host <<<
bintest - Command Binary Test

..............................................................
  Total: 62
     OK: 62
     KO: 0
  Crash: 0
Warning: 0
   Skip: 0
   Time: 0.09 seconds
```