### PR TITLE
Fixed `MRuby::Build#define_installer`

### DIFF
--- a/lib/mruby/build.rb
+++ b/lib/mruby/build.rb
@@ -397,7 +397,7 @@ EOS
         dst = "#{self.class.install_dir}/#{File.basename(src)}"
         define_installer_outline(src, dst) do
           File.unlink(dst) rescue nil
-          File.symlink(File.expand_path(src), dst)
+          File.symlink(src.relative_path_from(self.class.install_dir), dst)
         end
       end
     end


### PR DESCRIPTION
Symbolic links were created with absolute paths, but to cope with path fluctuations between build and reference, they are now relative paths.

ref. #6084