### PR TITLE
Fixed acquisition of wrong target class in `Kernel#binding`

### DIFF
--- a/mrbgems/mruby-eval/test/binding.rb
+++ b/mrbgems/mruby-eval/test/binding.rb
@@ -62,3 +62,20 @@ assert "access local variables into procs" do
   bx.eval("a = 2")
   assert_equal 2, block.call
 end
+
+assert "Binding#eval on another target class" do
+  obj = Object.new
+  Module.new do
+    self::BINDING = obj.instance_eval { binding }
+
+    def self.eval(code)
+      self::BINDING.eval code
+    end
+
+    self.eval "def self.m1; :m1; end"
+    self.eval "def m2; :m2; end"
+  end
+
+  assert_equal :m1, obj.m1
+  assert_equal :m2, obj.m2
+end

--- a/src/proc.c
+++ b/src/proc.c
@@ -418,17 +418,12 @@ mrb_proc_get_caller(mrb_state *mrb, struct REnv **envp)
     if (envp) *envp = NULL;
   }
   else {
-    struct RClass *tc = MRB_PROC_TARGET_CLASS(proc);
     struct REnv *e = mrb_vm_ci_env(ci);
 
     if (e == NULL) {
       int nstacks = proc->body.irep->nlocals;
-      e = mrb_env_new(mrb, c, ci, nstacks, ci->stack, tc);
+      e = mrb_env_new(mrb, c, ci, nstacks, ci->stack, mrb_vm_ci_target_class(ci));
       ci->u.env = e;
-    }
-    else if (tc) {
-      e->c = tc;
-      mrb_field_write_barrier(mrb, (struct RBasic*)e, (struct RBasic*)tc);
     }
     if (envp) *envp = e;
   }


### PR DESCRIPTION
fixed #6089