### PR TITLE
Get from local only if there is no default branch name

### DIFF
--- a/lib/mruby/build/load_gems.rb
+++ b/lib/mruby/build/load_gems.rb
@@ -299,7 +299,7 @@ module MRuby
           @build.gem_dir_to_repo_url[repo_dir] = url
           @build.locks[url] = {
             'url' => url,
-            'branch' => @build.git.current_branch(repo_dir),
+            'branch' => branch || @build.git.current_branch(repo_dir),
             'commit' => @build.git.commit_hash(repo_dir),
           }
         end


### PR DESCRIPTION
The branch name of the cloned repository should be determined by the build configuration file.

fixes #6087

---

Previously, even when `gem "GEM-NAME", branch: "TAG-NAME"` was specified in the build configuration file, the `.lock` file would record `branch: HEAD`.
I don't think it would be necessary to get the branch name from local.
