### PR TITLE
Needs `cipop()` before crossing the C boundary

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -2395,10 +2395,8 @@ RETRY_TRY_BLOCK:
           if (mrb->c->ci == ci) {
             break;
           }
-          else if (mrb->c->ci->cci == CINFO_NONE) {
-            cipop(mrb);
-          }
-          else {
+          cipop(mrb);
+          if (mrb->c->ci[1].cci != CINFO_NONE) {
             mrb->exc = (struct RObject*)break_new(mrb, RBREAK_TAG_BREAK, proc, v);
             mrb_gc_arena_restore(mrb, ai);
             mrb->c->vmexec = FALSE;


### PR DESCRIPTION
fix #6108

---

The cause was that control was being transferred from the `break` CI to the caller of `Class.new` without `cipop()`.

https://github.com/mruby/mruby/commit/2e881d3297246cde89b2f9134c3495d985e57f6d?diff=split#diff-b7d97be9c98fd50d49b9f2d6ee9bd3e4da589e223eeb0a06824d7af57d23efe6L2378-L2383

I thought I had moved the ↑ block to the ↓ block, but something important was lost.

https://github.com/mruby/mruby/commit/2e881d3297246cde89b2f9134c3495d985e57f6d?diff=split#diff-b7d97be9c98fd50d49b9f2d6ee9bd3e4da589e223eeb0a06824d7af57d23efe6R2378-R2386
