### PR TITLE
Consider proc to be GC'ed if fiber is terminated

### DIFF
--- a/mrbgems/mruby-fiber/src/fiber.c
+++ b/mrbgems/mruby-fiber/src/fiber.c
@@ -382,7 +382,7 @@ fiber_to_s(mrb_state *mrb, mrb_value self)
   const char *file;
   int32_t line;
   const struct RProc *p = f->cxt->cibase->proc;
-  if (!MRB_PROC_CFUNC_P(p) && !MRB_PROC_ALIAS_P(p) &&
+  if (f->cxt->status != MRB_FIBER_TERMINATED && !MRB_PROC_CFUNC_P(p) && !MRB_PROC_ALIAS_P(p) &&
       mrb_debug_get_position(mrb, p->body.irep, 0, &line, &file)) {
     mrb_str_cat_cstr(mrb, s, file);
     mrb_str_cat_lit(mrb, s, ":");


### PR DESCRIPTION
When fiber is terminated, the pointer indicated by `f->cxt->cibase->proc` is not protected from GC.
I should have done this patch way as of commit ca9e8d91e4651ccf62ebdd9a5bc5855a754af38a (#6105).

---

When this patch is not applied, the GC'd object will be touched.

```console
% lldb16 -- bin/mruby -e 'a = Fiber.new { Fiber.current }.resume; GC.start; p a'
(lldb) target create "bin/mruby"
Current executable set to '/usr/home/dearblue/candybox/ruby/mruby.git/bin/mruby' (x86_64).
(lldb) settings set -- target.run-args  "-e" "a = Fiber.new { Fiber.current }.resume; GC.start; p a"
(lldb) b mrbgems/mruby-fiber/src/fiber.c:385
Breakpoint 1: where = mruby`fiber_to_s + 343 at fiber.c:385:28, address = 0x00000000002e16a7
(lldb) r
Process 23679 launched: '/usr/home/dearblue/candybox/ruby/mruby.git/bin/mruby' (x86_64)
Process 23679 stopped
* thread #1, name = 'mruby', stop reason = breakpoint 1.1
    frame #0: 0x00000000002e16a7 mruby`fiber_to_s(mrb=0x0000000824eb8000, self=(w = 34979292992)) at fiber.c:385:28
   382    const char *file;
   383    int32_t line;
   384    const struct RProc *p = f->cxt->cibase->proc;
-> 385    if (!MRB_PROC_CFUNC_P(p) && !MRB_PROC_ALIAS_P(p) &&
   386        mrb_debug_get_position(mrb, p->body.irep, 0, &line, &file)) {
   387      mrb_str_cat_cstr(mrb, s, file);
   388      mrb_str_cat_lit(mrb, s, ":");
(lldb) p p->tt
(const mrb_vtype) $0 = MRB_TT_FREE
```
