### PR TITLE
Remove unreachable code in `OP_R_BREAK`

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -2332,14 +2332,6 @@ RETRY_TRY_BLOCK:
               goto L_BREAK_ERROR;
             }
           }
-          /* break from fiber block */
-          if (ci == mrb->c->cibase && ci->pc) {
-            struct mrb_context *c = mrb->c;
-
-            mrb->c = c->prev;
-            c->prev = NULL;
-            ci = mrb->c->ci;
-          }
           proc = proc->upper;
           while (mrb->c->cibase < ci && ci[-1].proc != proc) {
             ci--;


### PR DESCRIPTION
Termination of fiber by `break` results in a `LocalJumpError`, so the indicated code will not be executed.

---

I wrote this in a definitive way in my commit message, but please confirm.

In current mruby, `break` requires an `env` in the running `proc`.
Also, `break` that jumps over the fiber is prevented by comparing `e->cxt` and `mrb->c`.
I can't think of a condition to reach that part.

A quick check with `git blame` shows that the commit where this block was introduced is https://github.com/mruby/mruby/commit/6bd3d88eddb8932bd02fadfbf2235c3cba2ad624.
I tried the code in the linked https://github.com/mruby/mruby/issues/1766 and the code block was never reached.

I don't think there is any problem with deleting it. How about it?
