### PR TITLE
`mruby-time`: protect against incorrectly defined `_POSIX_TIMERS`

### DIFF
--- a/mrbgems/mruby-time/src/time.c
+++ b/mrbgems/mruby-time/src/time.c
@@ -83,6 +83,12 @@ double round(double x) {
 
 /** end of Time class configuration */
 
+/* protection against incorrectly defined _POSIX_TIMERS */
+#if (_POSIX_TIMERS + 0) == 0
+#undef _POSIX_TIMERS
+#define _POSIX_TIMERS 0
+#endif
+
 #if (defined(_POSIX_TIMERS) && _POSIX_TIMERS > 0) && defined(CLOCK_REALTIME)
 # define USE_CLOCK_GETTIME
 #endif


### PR DESCRIPTION
This update avoids the following error: `operator '&&' has no right operand` (related to `_POSIX_TIMERS`):

```
rake
CPP   mrbgems/mruby-time/src/time.c -> build/dreamcast/mrbgems/mruby-time/src/time.pi
/opt/toolchains/dc/kos-ports/mruby/build/mruby-3.2.0/mrbgems/mruby-time/src/time.c:88:47: error: operator '&&' has no right operand
   88 | # if (defined(_POSIX_TIMERS) && _POSIX_TIMERS > 0) && defined(CLOCK_REALTIME)
      |                                               ^
rake aborted!
Command failed with status (1): [C:\DreamSDK/msys/1.0/opt/toolchains/dc/sh-...]
/opt/toolchains/dc/kos-ports/mruby/build/mruby-3.2.0/lib/mruby/build/command.rb:33:in `_run'
/opt/toolchains/dc/kos-ports/mruby/build/mruby-3.2.0/lib/mruby/build/command.rb:95:in `run'
/opt/toolchains/dc/kos-ports/mruby/build/mruby-3.2.0/lib/mruby/build/command.rb:120:in `block (2 levels) in define_rules'
Tasks: TOP => default => all => gensym => /opt/toolchains/dc/kos-ports/mruby/build/mruby-3.2.0/build/dreamcast/presym => /opt/toolchains/dc/kos-ports/mruby/build/mruby-3.2.0/build/dreamcast/mrbgems/mruby-time/src/time.pi
(See full trace by running task with --trace)
```

See: https://stackoverflow.com/questions/48538243/macro-if-statement-returns-error-operator-has-no-right-operand