### PR TITLE
Allow `OP_RETURN_BLK` to cross C boundaries

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -2319,10 +2319,6 @@ RETRY_TRY_BLOCK:
       }
       /* check jump destination */
       while (cibase <= ci && ci->proc != dst) {
-        if (ci->cci > CINFO_NONE) { /* jump cross C boundary */
-          localjump_error(mrb, LOCALJUMP_ERROR_RETURN);
-          goto L_RAISE;
-        }
         ci--;
       }
       if (ci <= cibase) { /* no jump destination */


### PR DESCRIPTION
The restriction was introduced in commit b563bcb7ff87b859ccdfa30f5d7c3f06cb26a239 to resolve https://github.com/mruby/mruby/issues/3462. Subsequently, the `RBreak` object, introduced by mruby 1.3.0, allowed crossing the C boundary.

```ruby
def cross; Class.new { proc { return }.call }; end; cross
# => unexpected return (LocalJumpError) # without this patch
# => nothing raised                     # with this patch
```