### PR TITLE
Fixed return value of `OP_RETURN_BLK` called directly under C function

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -2300,7 +2300,7 @@ RETRY_TRY_BLOCK:
 
       mrb_callinfo *ci = mrb->c->ci;
 
-      if (ci->cci != CINFO_NONE || !MRB_PROC_ENV_P(proc) || MRB_PROC_STRICT_P(proc)) {
+      if (!MRB_PROC_ENV_P(proc) || MRB_PROC_STRICT_P(proc)) {
         goto NORMAL_RETURN;
       }
 


### PR DESCRIPTION
```ruby
def cross; Class.new { return 1 }; end; p cross'
# => #<Class:0x8245cf170>               # without this patch
# => 1                                  # with this patch
```