### PR TITLE
`dreamcast_shelf build config`: complete overhaul

### DIFF
--- a/build_config/dreamcast_shelf.rb
+++ b/build_config/dreamcast_shelf.rb
@@ -4,113 +4,80 @@
 # Requires KallistiOS (KOS)
 # http://gamedev.allusion.net/softprj/kos/
 #
-# Tested on GNU/Linux, macOS and Windows (through MinGW-w64/MSYS2, Cygwin and DreamSDK).
+# This configuration has been improved to be used as KallistiOS Port (kos-ports)
+# Updated: 2023-12-24
+#
+# Tested on GNU/Linux, macOS and Windows (MinGW-w64/MSYS2, Cygwin, DreamSDK)
 # DreamSDK is based on MinGW/MSYS: https://dreamsdk.org/
 #
-# Input this command on the directory where mruby is installed:
-#   make MRUBY_CONFIG=dreamcast_shelf
+# Install mruby for Sega Dreamcast using the "mruby" kos-port.
 #
 MRuby::CrossBuild.new("dreamcast") do |conf|
   toolchain :gcc
 
-  # Support for DreamSDK (based on MinGW/MSYS)
-  # To compile mruby with DreamSDK, RubyInstaller for Windows should be installed
-  DREAMSDK_HOME = ENV["DREAMSDK_HOME"]
-  MSYS_ROOT = !(DREAMSDK_HOME.nil? || DREAMSDK_HOME.empty?) ? "#{DREAMSDK_HOME}/msys/1.0" : ""
+  # Getting critical environment variables
+  KOS_BASE = ENV["KOS_BASE"]
+  KOS_CC_BASE = ENV["KOS_CC_BASE"]
 
-  # Setting paths
-  DREAMCAST_PATH = "#{MSYS_ROOT}/opt/toolchains/dc"
-  KOS_PATH = "#{DREAMCAST_PATH}/kos"
-  BIN_PATH = "#{DREAMCAST_PATH}/sh-elf/bin"
+  if (KOS_BASE.nil? || KOS_BASE.empty? || KOS_CC_BASE.nil? || KOS_CC_BASE.empty?)
+    raise "Error: KallistiOS is required; KOS_BASE/KOS_CC_BASE needs to be declared; Stop."
+  end
 
   # C compiler
-  # Flags were extracted from KallistiOS environment files
+  # All flags and settings below were extracted from KallistiOS environment files
   conf.cc do |cc|
-    cc.command = "#{BIN_PATH}/sh-elf-gcc"
-    cc.include_paths << ["#{KOS_PATH}/include", "#{KOS_PATH}/kernel/arch/dreamcast/include", "#{KOS_PATH}/addons/include", "#{KOS_PATH}/../kos-ports/include"]
-    cc.flags << ["-O2", "-fomit-frame-pointer", "-ml", "-m4-single-only", "-ffunction-sections", "-fdata-sections", "-Wall", "-g", "-fno-builtin", "-ml", "-m4-single-only", "-Wl,-Ttext=0x8c010000", "-Wl,--gc-sections", "-T#{KOS_PATH}/utils/ldscripts/shlelf.xc", "-nodefaultlibs"]
+    cc.command = "#{KOS_CC_BASE}/bin/sh-elf-gcc"
+    cc.include_paths << ["#{KOS_BASE}/include", "#{KOS_BASE}/kernel/arch/dreamcast/include", "#{KOS_BASE}/addons/include", "#{KOS_BASE}/../kos-ports/include"]
+    cc.flags << ["-O2", "-fomit-frame-pointer", "-fno-builtin", "-ml", "-m4-single-only", "-ffunction-sections", "-fdata-sections", "-matomic-model=soft-imask", "-ftls-model=local-exec", "-Wall", "-g"]
     cc.compile_options = %Q[%{flags} -o "%{outfile}" -c "%{infile}"]
     cc.defines << %w(_arch_dreamcast)
     cc.defines << %w(_arch_sub_pristine)
   end
 
-  # C++ compiler
+  # C++ compiler  
   conf.cxx do |cxx|
     cxx.command = conf.cc.command.dup
     cxx.include_paths = conf.cc.include_paths.dup
     cxx.flags = conf.cc.flags.dup
-    cxx.flags << %w(-fno-rtti -fno-exceptions)
+    cxx.flags << %w(-fno-operator-names)
     cxx.defines = conf.cc.defines.dup
     cxx.compile_options = conf.cc.compile_options.dup
   end
 
   # Linker
-  # There is an issue when making the mruby library with KallistiOS:
-  # 'newlib_kill.o' and 'newlib_getpid.o' aren't found so they are explicitly
-  # specified here at least for now.
   conf.linker do |linker|
-    linker.command="#{BIN_PATH}/sh-elf-gcc"
-    linker.flags << ["#{MSYS_ROOT}/opt/toolchains/dc/kos/kernel/build/newlib_kill.o", "#{MSYS_ROOT}/opt/toolchains/dc/kos/kernel/build/newlib_getpid.o", "-Wl,--start-group -lkallisti -lc -lgcc -Wl,--end-group"]
-    linker.library_paths << ["#{KOS_PATH}/lib/dreamcast", "#{KOS_PATH}/addons/lib/dreamcast", "#{KOS_PATH}/../kos-ports/lib"]
+    linker.command = "#{KOS_CC_BASE}/bin/sh-elf-gcc"
+    linker.flags << ["-Wl,-Ttext=0x8c010000", "-Wl,--gc-sections", "-T#{KOS_BASE}/utils/ldscripts/shlelf.xc", "-nodefaultlibs", "-Wl,--start-group -lkallisti -lc -lgcc -Wl,--end-group"]
+    linker.library_paths << ["#{KOS_BASE}/lib/dreamcast", "#{KOS_BASE}/addons/lib/dreamcast", "#{KOS_BASE}/../kos-ports/lib"]
   end
 
   # Archiver
   conf.archiver do |archiver|
-    archiver.command = "#{BIN_PATH}/sh-elf-ar"
+    archiver.command = "#{KOS_CC_BASE}/bin/sh-elf-ar"
     archiver.archive_options = 'rcs "%{outfile}" %{objs}'
   end
 
-  # No executables
+  # No executables needed for KallistiOS
   conf.bins = []
 
-  # Do not build executable test
+  # Do not build test binaries
   conf.build_mrbtest_lib_only
 
-  # Disable C++ exception
-  conf.disable_cxx_exception
+  # Gemboxes
+  conf.gembox "default-no-stdio"
+  conf.gembox "stdlib-ext"
+  conf.gembox "metaprog"
 
-  # Gems from core
-  # Some Gems are incompatible and were disabled.
-
-  conf.gem :core => "mruby-array-ext"
+  # Additional Gems
+  # Currently unsupported on KallistiOS: "mruby-io", "mruby-dir", "mruby-socket"
+  conf.gem :core => "mruby-binding"
   conf.gem :core => "mruby-catch"
-  conf.gem :core => "mruby-class-ext"
-  conf.gem :core => "mruby-cmath"
-  conf.gem :core => "mruby-compar-ext"
-  conf.gem :core => "mruby-compiler"
-  conf.gem :core => "mruby-complex"
   conf.gem :core => "mruby-enum-chain"
-  conf.gem :core => "mruby-enum-ext"
-  conf.gem :core => "mruby-enum-lazy"
-  conf.gem :core => "mruby-enumerator"
+  conf.gem :core => "mruby-errno"
   conf.gem :core => "mruby-error"
-  conf.gem :core => "mruby-eval"
   conf.gem :core => "mruby-exit"
-  conf.gem :core => "mruby-fiber"
-  conf.gem :core => "mruby-hash-ext"
-#  conf.gem :core => "mruby-io"
-  conf.gem :core => "mruby-kernel-ext"
-  conf.gem :core => "mruby-math"
-  conf.gem :core => "mruby-metaprog"
-  conf.gem :core => "mruby-method"
-  conf.gem :core => "mruby-numeric-ext"
-  conf.gem :core => "mruby-object-ext"
-  conf.gem :core => "mruby-objectspace"
   conf.gem :core => "mruby-os-memsize"
-  conf.gem :core => "mruby-pack"
   conf.gem :core => "mruby-print"
   conf.gem :core => "mruby-proc-binding"
-  conf.gem :core => "mruby-proc-ext"
-  conf.gem :core => "mruby-random"
-  conf.gem :core => "mruby-range-ext"
-  conf.gem :core => "mruby-rational"
   conf.gem :core => "mruby-sleep"
-#  conf.gem :core => "mruby-socket"
-  conf.gem :core => "mruby-sprintf"
-  conf.gem :core => "mruby-string-ext"
-  conf.gem :core => "mruby-struct"
-  conf.gem :core => "mruby-symbol-ext"
-#  conf.gem :core => "mruby-test"
-#  conf.gem :core => "mruby-time"
-  conf.gem :core => "mruby-toplevel-ext"
 end


### PR DESCRIPTION
This configuration is used to support the **Sega Dreamcast** system.
mruby is now officially supported as a KallistiOS Port in kos-ports. 
See: https://dreamcast.wiki/Using_Ruby_for_Sega_Dreamcast_development

This PR replaces: https://github.com/mruby/mruby/pull/6129
