### PR TITLE
Create source code packages by adding release tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+name: Release Builds
+
+on:
+  push:
+    tags:
+      - "*.*.*"
+
+permissions: read-all
+
+jobs:
+  source:
+    name: Source Code Releasing
+    permissions:
+      contents: write
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+    steps:
+      - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
+        uses: actions/checkout@v4
+      - name: Builds
+        id: builds
+        run: |
+          tag=$(echo "$GITHUB_REF" | sed 's@^refs/tags/@@')
+          packagename="mruby-$tag"
+          destdir=packages
+
+          mkdir -p "$destdir"
+          git archive --format zip --prefix "$packagename/" -o "$destdir/$packagename.zip" "$GITHUB_REF"
+          git archive --format tar.gz --prefix "$packagename/" -o "$destdir/$packagename.tar.gz" "$GITHUB_REF"
+          gunzip -c "$destdir/$packagename.tar.gz" | xz > "$destdir/$packagename.tar.xz"
+
+          (
+            cd "$destdir"
+            sha256sum * > .sha256
+            mv .sha256 "$packagename.sha256"
+          )
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          #draft: true
+          prerelease: ${{ contains(github.ref, '-rc') }}
+          body_path: NEWS
+          files: packages/*


### PR DESCRIPTION
According to the [GitHub blog](https://github.blog/2023-02-21-update-on-the-future-stability-of-source-code-archives-and-hashes/), files by `git archive` are not guaranteed to have checksum persistence.
It is also stated that the archive file at this time is stable in bytes, but that this may change in the future.

---

Creating a tag in the format "x.y.z" will cause a build for release and the source code will be published in the form of a tarball.
If the tag name contains "-rc", it will be published as a "pre-release".
Release notes are taken from the contents of the `NEWS` file.

For GitHub Actions logs and previews, please follow the URL below (this repository will eventually be removed).

  - For version "192.168.0.1-rc"
      - https://github.com/dearblue/SANDBOX1/actions/runs/7348227811
      - https://github.com/dearblue/SANDBOX1/releases/tag/192.168.0.1-rc
  - For version "192.168.0.1"
      - https://github.com/dearblue/SANDBOX1/actions/runs/7348228299
      - https://github.com/dearblue/SANDBOX1/releases/tag/192.168.0.1
