### PR TITLE
Fixed when combined `mrb_fiber_resume()` and `Fiber#transfer`

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -2399,7 +2399,8 @@ RETRY_TRY_BLOCK:
           mrb->c = c->prev ? c->prev : mrb->root_c;
           c->prev = NULL;
           mrb->c->status = MRB_FIBER_RUNNING;
-          if (c->vmexec) {
+          if (c->vmexec ||
+              (mrb->c == mrb->root_c && mrb->c->ci == mrb->c->cibase) /* case using Fiber#transfer in mrb_fiber_resume() */) {
             mrb_gc_arena_restore(mrb, ai);
             c->vmexec = FALSE;
             mrb->jmp = prev_jmp;


### PR DESCRIPTION
For example, the following code was crashing.

```c
#include <mruby.h>
#include <mruby/compile.h>
#include <mruby/proc.h>

int
main(int argc, char *argv[])
{
  mrb_state *mrb = mrb_open();

  mrb_value fiber = mrb_load_string(mrb, "Fiber.new { Fiber.new { 12345.6789 }.transfer }");
  mrb_value res = mrb_fiber_resume(mrb, fiber, 0, NULL);
  mrb_p(mrb, res);

  mrb_close(mrb);

  return 0;
}
```

---

This PR contains a commit to integrate the code for `return` from `mrb_vm_exec()`.
If this is a problem, please let me know.
