### PR TITLE
Remove unreachable blocks in `OP_RETURN`

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -2340,16 +2340,6 @@ RETRY_TRY_BLOCK:
 
       NORMAL_RETURN:
         ci = mrb->c->ci;
-
-        if (ci == mrb->c->cibase) {
-          struct mrb_context *c;
-          c = mrb->c;
-
-          if (c->prev && !c->vmexec && c->prev->ci == c->prev->cibase) {
-            RAISE_LIT(mrb, E_FIBER_ERROR, "double resume");
-          }
-        }
-
         v = regs[a];
         mrb_gc_protect(mrb, v);
         CHECKPOINT_RESTORE(RBREAK_TAG_BREAK) {


### PR DESCRIPTION
When `mrb->c->prev` is non `NULL` and `mrb->c->noexec` is false, switching source fiber should suspend with `Fiber#resume`.
In this case, the condition `mrb->c->ci == mrb->c->cibase` is not satisfied.

---

I wrote definitively in the commit message, but please check again.
I think the part I removed this time is a remnant for the fiber behavior up to Ruby 2.7.
