### PR TITLE
pre-commit: add hook `detect-aws-credentials`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,8 @@ repos:
       - id: check-shebang-scripts-are-executable
       - id: check-vcs-permalinks
       - id: check-yaml
+      - id: detect-aws-credentials
+        args: [--allow-missing-credentials]
       - id: detect-private-key
       - id: end-of-file-fixer
       - id: file-contents-sorter


### PR DESCRIPTION
https://github.com/pre-commit/pre-commit-hooks#detect-aws-credentials

Another check or test we can have.

"--allow-missing-credentials - Allow hook to pass when no credentials are detected."