### PR TITLE
Removed `mrb_jmpbuf_id` for C++ exceptions

### DIFF
--- a/include/mruby/throw.h
+++ b/include/mruby/throw.h
@@ -16,11 +16,11 @@
 # if defined(__cplusplus)
 
 #define MRB_TRY(buf) try {
-#define MRB_CATCH(buf) } catch(mrb_jmpbuf_impl e) { if (e != (buf)->impl) { throw e; }
+#define MRB_CATCH(buf) } catch(mrb_jmpbuf *e) { if (e != (buf)) { throw e; }
 #define MRB_END_EXC(buf)  }
 
-#define MRB_THROW(buf) throw((buf)->impl)
-typedef mrb_int mrb_jmpbuf_impl;
+#define MRB_THROW(buf) throw(buf)
+typedef void *mrb_jmpbuf_impl;
 
 # else
 # error "need to be compiled with C++ compiler"
@@ -50,16 +50,8 @@ typedef mrb_int mrb_jmpbuf_impl;
 
 #endif
 
-#if defined(MRB_USE_CXX_EXCEPTION)
-extern mrb_int mrb_jmpbuf_id;
-#endif
-
 struct mrb_jmpbuf {
   mrb_jmpbuf_impl impl;
-
-#if defined(MRB_USE_CXX_EXCEPTION)
-  mrb_jmpbuf() : impl(mrb_jmpbuf_id++) {}
-#endif
 };
 
 #endif  /* MRB_THROW_H */

--- a/src/vm.c
+++ b/src/vm.c
@@ -3120,7 +3120,3 @@ mrb_top_run(mrb_state *mrb, const struct RProc *proc, mrb_value self, mrb_int st
   }
   return mrb_vm_run(mrb, proc, self, stack_keep);
 }
-
-#if defined(MRB_USE_CXX_EXCEPTION) && defined(__cplusplus)
-mrb_int mrb_jmpbuf_id = 0;
-#endif


### PR DESCRIPTION
Use stack variable addresses as identifiers instead of global variable values. Since the stack variable address is uniquely determined within the call, there is no need to maintain a global variable.