### PR TITLE
Allow to detect use-after-free after `mrb_irep_free()` for debugging

### DIFF
--- a/src/state.c
+++ b/src/state.c
@@ -161,6 +161,9 @@ mrb_irep_free(mrb_state *mrb, mrb_irep *irep)
   }
   mrb_free(mrb, (void*)irep->lv);
   mrb_debug_info_free(mrb, irep->debug_info);
+#ifdef MRB_DEBUG
+  memset(irep, -1, sizeof(*irep));
+#endif
   mrb_free(mrb, irep);
 }
 


### PR DESCRIPTION
Write invalid value to `irep` if `MRB_DEBUG` is defined by `MRuby::Build#enable_debug`.