### PR TITLE
Fixed use-after-free by backtrace object

### DIFF
--- a/include/mruby/internal.h
+++ b/include/mruby/internal.h
@@ -61,6 +61,18 @@ mrb_value mrb_exc_mesg_get(mrb_state *mrb, struct RException *exc);
 mrb_value mrb_f_raise(mrb_state*, mrb_value);
 mrb_value mrb_make_exception(mrb_state *mrb, mrb_value exc, mrb_value mesg);
 
+struct RBacktrace {
+  MRB_OBJECT_HEADER;
+  size_t len;
+  struct mrb_backtrace_location *locations;
+};
+
+struct mrb_backtrace_location {
+  mrb_sym method_id;
+  int32_t idx;
+  const struct RProc *proc;
+};
+
 /* gc */
 void mrb_gc_mark_mt(mrb_state*, struct RClass*);
 size_t mrb_gc_mark_mt_size(mrb_state*, struct RClass*);

--- a/include/mruby/value.h
+++ b/include/mruby/value.h
@@ -159,7 +159,8 @@ static const unsigned int IEEE754_INFINITY_BITS_SINGLE = 0x7F800000;
   f(MRB_TT_BREAK,       struct RBreak,      "break") \
   f(MRB_TT_COMPLEX,     struct RComplex,    "Complex") \
   f(MRB_TT_RATIONAL,    struct RRational,   "Rational") \
-  f(MRB_TT_BIGINT,      struct RBigint,     "Integer")
+  f(MRB_TT_BIGINT,      struct RBigint,     "Integer") \
+  f(MRB_TT_BACKTRACE,   struct RBacktrace,  "backtrace")
 
 enum mrb_vtype {
 #define MRB_VTYPE_DEFINE(tt, type, name) tt,

--- a/mrbgems/mruby-os-memsize/src/memsize.c
+++ b/mrbgems/mruby-os-memsize/src/memsize.c
@@ -1,4 +1,5 @@
 #include <mruby.h>
+#include <mruby/error.h>
 #include <mruby/gc.h>
 #include <mruby/hash.h>
 #include <mruby/class.h>
@@ -166,6 +167,9 @@ os_memsize_of_object(mrb_state* mrb, mrb_value obj)
     case MRB_TT_CDATA:
     case MRB_TT_ISTRUCT:
       size += mrb_objspace_page_slot_size();
+      break;
+    case MRB_TT_BACKTRACE:
+      size += ((struct RBacktrace*)mrb_obj_ptr(obj))->len * sizeof(struct mrb_backtrace_location);
       break;
     /*  zero heap size types.
      *  immediate VM stack values, contained within mrb_state, or on C stack */

--- a/src/gc.c
+++ b/src/gc.c
@@ -688,6 +688,15 @@ gc_mark_children(mrb_state *mrb, mrb_gc *gc, struct RBasic *obj)
     mrb_gc_mark(mrb, (struct RBasic*)((struct RException*)obj)->backtrace);
     break;
 
+  case MRB_TT_BACKTRACE:
+    {
+      struct RBacktrace *bt = (struct RBacktrace*)obj;
+      for (size_t i = 0; i < bt->len; i++) {
+        mrb_gc_mark(mrb, (struct RBasic*)bt->locations[i].proc);
+      }
+    }
+    break;
+
   default:
     break;
   }
@@ -822,6 +831,12 @@ obj_free(mrb_state *mrb, struct RBasic *obj, int end)
     mrb_gc_free_bint(mrb, obj);
     break;
 #endif
+
+  case MRB_TT_BACKTRACE:
+    {
+      struct RBacktrace *bt = (struct RBacktrace*)obj;
+      mrb_free(mrb, bt->locations);
+    }
 
   default:
     break;
@@ -967,6 +982,10 @@ gc_gray_counts(mrb_state *mrb, mrb_gc *gc, struct RBasic *obj)
     if (((struct RException*)obj)->backtrace) {
       children++;
     }
+    break;
+
+  case MRB_TT_BACKTRACE:
+    children += ((struct RBacktrace*)obj)->len;
     break;
 
   default:


### PR DESCRIPTION
The `MRB_TT_BACKTRACE` object has been added for the purpose.

Previously, "use-after-free" could occur because the reference count in `backtrace_location::irep` was not incremented.

fixed #6160