### PR TITLE
Fix `MRUBY_PACKAGE_DIR` in `mruby-config.bat`

### DIFF
--- a/mrbgems/mruby-bin-config/mruby-config.bat
+++ b/mrbgems/mruby-bin-config/mruby-config.bat
@@ -1,16 +1,6 @@
 @echo off
 
-call :init "%~dp0."
-goto top
-
-:init
-rem call init2 for treatments last directory separator
-call :init2 "%~dp1."
-goto :eof
-
-:init2
-set MRUBY_PACKAGE_DIR=%~f1
-goto :eof
+set MRUBY_PACKAGE_DIR=%~dp0..
 
 :top
 shift


### PR DESCRIPTION
Previously, the correct directory could not be obtained in some environments.
Therefore, changed the method to leave an element indicating the parent directory.

fix #6156