### PR TITLE
Corrected strange conditional in `mrb_vm_run()`

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -1320,7 +1320,7 @@ mrb_vm_run(mrb_state *mrb, const struct RProc *proc, mrb_value self, mrb_int sta
     nregs = stack_keep;
   else {
     struct REnv *e = CI_ENV(mrb->c->ci);
-    if (stack_keep == 0 || (e && irep->nlocals < MRB_ENV_LEN(e))) {
+    if (e && (stack_keep == 0 || irep->nlocals < MRB_ENV_LEN(e))) {
       ci_env_set(mrb->c->ci, NULL);
       mrb_env_unshare(mrb, e, FALSE);
     }


### PR DESCRIPTION
This was introduced in commit 365c151df0a8bd495328e012e0a27a8585b10355.
I should have checked env first.