### PR TITLE
super-linter: set `VALIDATE_GITLEAKS` to `true`

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -25,7 +25,8 @@ jobs:
           VALIDATE_BASH: true
           # VALIDATE_BASH_EXEC: true
           # VALIDATE_EDITORCONFIG: true
+          VALIDATE_GITLEAKS: true
           # VALIDATE_SHELL_SHFMT: true
           DEFAULT_BRANCH: master
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VALIDATE_ALL_CODEBASE: false
+          VALIDATE_ALL_CODEBASE: true


### PR DESCRIPTION
Flag to enable the linting process of the secrets.

Just another check or test we can have.

Set VALIDATE_ALL_CODEBASE: true

https://github.com/super-linter/super-linter?tab=readme-ov-file#configure-super-linter