### PR TITLE
pre-commit: add `markdown-link-check` config and ignore links

### DIFF
--- a/.github/linters/mlc_config.json
+++ b/.github/linters/mlc_config.json
@@ -1,0 +1,7 @@
+{
+  "ignorePatterns": [
+    {
+      "pattern": "^https://github.com/mruby/mruby/commit/.*"
+    }
+  ]
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -72,7 +72,7 @@ repos:
       - id: markdown-link-check
         name: Run markdown-link-check
         description: Checks hyperlinks in Markdown files
-        args: [-q]
+        args: [--config=.github/linters/mlc_config.json, -q]
         types: [markdown]
         files: \.(md|mdown|markdown)$
   - repo: https://github.com/adrienverge/yamllint


### PR DESCRIPTION
https://github.com/tcort/markdown-link-check?tab=readme-ov-file#config-file-format

pre-commit has been failing sometimes on the `markdown-link-check`.

The failure is intermittent and distracting.

This pr aims to ignore the offending links


