### PR TITLE
super-linter: set `VALIDATE_GITHUB_ACTIONS` to `true`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install pre-commit
       - name: Set PY
-        run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
+        run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> "$GITHUB_ENV"
       - uses: actions/cache@v4
         with:
           path: ~/.cache/pre-commit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,8 +33,8 @@ jobs:
           gunzip -c "$destdir/$packagename.tar.gz" | xz > "$destdir/$packagename.tar.xz"
 
           (
-            cd "$destdir"
-            sha256sum * > .sha256
+            cd "$destdir" || exit
+            sha256sum -- * > .sha256
             mv .sha256 "$packagename.sha256"
           )
       - name: Release

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -25,6 +25,7 @@ jobs:
           VALIDATE_BASH: true
           # VALIDATE_BASH_EXEC: true
           # VALIDATE_EDITORCONFIG: true
+          VALIDATE_GITHUB_ACTIONS: true
           VALIDATE_GITLEAKS: true
           # VALIDATE_SHELL_SHFMT: true
           DEFAULT_BRANCH: master


### PR DESCRIPTION
Flag to enable the linting process of the GitHub Actions.

Another check or test we can have.

https://github.com/super-linter/super-linter?tab=readme-ov-file#configure-super-linter

Lint shell script. Tested with ShellCheck

https://www.shellcheck.net/