### PR TITLE
Fix wrong assertion in `OP_SENDB`.

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -1912,7 +1912,6 @@ RETRY_TRY_BLOCK:
       }
 
       /* cfunc epilogue */
-      mrb_assert(mrb->c->ci > mrb->c->cibase);
       mrb_gc_arena_shrink(mrb, ai);
       if (mrb->exc) goto L_RAISE;
       ci = mrb->c->ci;
@@ -1929,6 +1928,7 @@ RETRY_TRY_BLOCK:
           syms = irep->syms;
         }
       }
+      mrb_assert(ci > mrb->c->cibase);
       ci->stack[0] = recv;
       /* pop stackpos */
       ci = cipop(mrb);


### PR DESCRIPTION
Assertions were failing on exit if started with `mrb_fiber_resume()`.

The bug that caused it was introduced by commit 42308c42b548c30e54663e70902fc3eca7b22ea8 (#6106). The bug was moved by commit 990e18ad59e8428bd644559d852a3842994b7e94.