### PR TITLE
Fixed prototype for mrb_time_at in time.h

### DIFF
--- a/mrbgems/mruby-time/include/mruby/time.h
+++ b/mrbgems/mruby-time/include/mruby/time.h
@@ -19,7 +19,7 @@ typedef enum mrb_timezone {
   MRB_TIMEZONE_LAST   = 3
 } mrb_timezone;
 
-MRB_API mrb_value mrb_time_at(mrb_state *mrb, time_t sec, time_t usec, mrb_timezone timezone);
+MRB_API mrb_value time_at(mrb_state *mrb, time_t sec, time_t usec, enum mrb_timezone zone);
 
 MRB_END_DECL
 


### PR DESCRIPTION
Function in `time.c` was changed from `mrb_time_at` to `time_at` but the prototype in `time.h` was not changed.