### PR TITLE
Fix int_xor to call flo_xor.

### DIFF
--- a/src/numeric.c
+++ b/src/numeric.c
@@ -1455,7 +1455,7 @@ int_xor(mrb_state *mrb, mrb_value x)
     return mrb_bint_xor(mrb, mrb_as_bint(mrb, x), y);
   }
 #endif
-  bit_op(x, y, or, ^);
+  bit_op(x, y, xor, ^);
 }
 
 #define NUMERIC_SHIFT_WIDTH_MAX (MRB_INT_BIT-1)


### PR DESCRIPTION
This PR fixes the problem that `flo_xor` is not  called from `int_xor`.

Code like the following  works as expected:
```ruby
10^2.0
=> 10 #expected 8
````