### PR TITLE
Add `rubocop` `pre-commit` hook; Remove redundant returns

### DIFF
--- a/.github/linters/.rubocop.yml
+++ b/.github/linters/.rubocop.yml
@@ -1,0 +1,6 @@
+AllCops:
+  DisabledByDefault: true
+  TargetRubyVersion: 3.3.0
+
+Style/RedundantReturn:
+  Enabled: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,6 +49,9 @@ repos:
   - repo: https://github.com/jumanjihouse/pre-commit-hooks
     rev: 3.0.0
     hooks:
+      - id: rubocop
+        args: [--config=.github/linters/.rubocop.yml]
+        exclude: ^test/t/syntax\.rb$|^test/t/vformat\.rb$
       - id: script-must-not-have-extension
         name: Local policy is to exclude extension from all shell files
         types: [shell]

--- a/benchmark/bm_so_lists.rb
+++ b/benchmark/bm_so_lists.rb
@@ -32,7 +32,7 @@ def test_lists
   else
     # compare li1 and li2 for equality
     if li1 != li2
-      return(0)
+      0
     else
       # return the length of the list
       li1.length

--- a/lib/mruby/build/command.rb
+++ b/lib/mruby/build/command.rb
@@ -371,7 +371,7 @@ module MRuby
 
     def emulator
       return "" unless @command
-      return [@command, *@flags].map{|c| shellquote(c)}.join(' ')
+      [@command, *@flags].map{|c| shellquote(c)}.join(' ')
     end
 
     def run(testbinfile)

--- a/lib/mruby/build/load_gems.rb
+++ b/lib/mruby/build/load_gems.rb
@@ -68,19 +68,19 @@ module MRuby
 
       def full_gemdir
         return @gemdir unless @path
-        return File.join(@gemdir, @path)
+        File.join(@gemdir, @path)
       end
 
-      def canonical?()  return @canonical;                  end
-      def git?()        return !!@repo;                     end
-      def gemname()     return File.basename(@gemdir);      end
+      def canonical?()  @canonical;                  end
+      def git?()        !!@repo;                     end
+      def gemname()     File.basename(@gemdir);      end
 
       def hash
-        return [@gemdir, @repo, @branch, @commit, @canonical, @path].hash
+        [@gemdir, @repo, @branch, @commit, @canonical, @path].hash
       end
 
       def ==(other)
-        return @gemdir == other.gemdir &&
+        @gemdir == other.gemdir &&
           @repo == other.repo &&
           @branch == other.branch &&
           @commit == other.commit &&
@@ -93,7 +93,7 @@ module MRuby
         desc = @gemdir
         desc += " -> #{@repo}/#{@branch}" if git?
         desc += "/#{commit}" if commit
-        return desc
+        desc
       end
     end
 
@@ -206,11 +206,11 @@ module MRuby
           gem_src = File.expand_path(gem_src, root_dir)
         end
 
-        return GemCheckout.new(gem_src, nil, nil, nil, @canonical)
+        GemCheckout.new(gem_src, nil, nil, nil, @canonical)
       end
 
       def fromCore!
-        return GemCheckout.new("#{@build.root}/mrbgems/#{@core}", nil, nil,
+        GemCheckout.new("#{@build.root}/mrbgems/#{@core}", nil, nil,
                                nil, @canonical)
       end
 
@@ -221,7 +221,7 @@ module MRuby
 
       def fromGitHub!
         url = "https://github.com/#{@github}.git"
-        return fromGit!(url, @branch)
+        fromGit!(url, @branch)
       end
 
       def fromBitBucket!
@@ -231,7 +231,7 @@ module MRuby
           url = "https://bitbucket.org/#{@bitbucket}.git"
         end
 
-        return fromGit!(url, @branch)
+        fromGit!(url, @branch)
       end
 
 
@@ -245,7 +245,7 @@ module MRuby
         url = mgem['repository']
         branch = mgem['branch'] || @branch
 
-        return fromGit!(url, branch)
+        fromGit!(url, branch)
       end
 
       # Fetch the contents of the named mgem item. Will clone the
@@ -265,7 +265,7 @@ module MRuby
         fail "unknown mgem protocol: #{conf['protocol']}" if
           conf['protocol'] != 'git'
 
-        return conf
+        conf
       end
 
 
@@ -304,7 +304,7 @@ module MRuby
           }
         end
 
-        return GemCheckout.new(repo_dir, url, branch, commit, @canonical,@path)
+        GemCheckout.new(repo_dir, url, branch, commit, @canonical,@path)
       end
 
 

--- a/lib/mruby/gem.rb
+++ b/lib/mruby/gem.rb
@@ -110,7 +110,7 @@ module MRuby
         elsif build.kind_of?(MRuby::Build)
           return ('A'..'Z').to_a.any? { |vol| Dir.exist?("#{vol}:") }
         end
-        return false
+        false
       end
 
       def disable_cdump

--- a/mrbgems/mruby-class-ext/mrblib/module.rb
+++ b/mrbgems/mruby-class-ext/mrblib/module.rb
@@ -29,9 +29,9 @@ class Module
   def <=(other)
     raise TypeError, 'compared with non class/module' unless other.is_a?(Module)
     if self.ancestors.include?(other)
-      return true
+      true
     elsif other.ancestors.include?(self)
-      return false
+      false
     end
   end
 
@@ -64,7 +64,7 @@ class Module
   #
   def >=(other)
     raise TypeError, 'compared with non class/module' unless other.is_a?(Module)
-    return other < self
+    other < self
   end
 
   ##
@@ -84,6 +84,6 @@ class Module
     cmp = self < other
     return -1 if cmp
     return 1 unless cmp.nil?
-    return nil
+    nil
   end
 end

--- a/mrbgems/mruby-compar-ext/mrblib/compar.rb
+++ b/mrbgems/mruby-compar-ext/mrblib/compar.rb
@@ -84,9 +84,9 @@ module Comparable
     if c.nil?
       raise ArgumentError, "comparison of #{self.class} with #{max.class} failed"
     elsif c > 0
-      return max
+      max
     else
-      return self
+      self
     end
   end
 end

--- a/mrbgems/mruby-enum-ext/mrblib/enum.rb
+++ b/mrbgems/mruby-enum-ext/mrblib/enum.rb
@@ -219,7 +219,7 @@ module Enumerable
       self.each do |*val|
         return val.__svalue
       end
-      return nil
+      nil
     when 1
       i = args[0].__to_int
       raise ArgumentError, "attempt to take negative size" if i < 0

--- a/mrbgems/mruby-io/mrblib/file.rb
+++ b/mrbgems/mruby-io/mrblib/file.rb
@@ -159,7 +159,7 @@ class File < IO
         f.each {|l| yield l}
       end
     else
-      return self.new(file)
+      self.new(file)
     end
   end
 
@@ -207,7 +207,7 @@ class File < IO
     fname = self.basename(filename)
     epos = fname.rindex('.')
     return '' if epos == 0 || epos.nil?
-    return fname[epos..-1]
+    fname[epos..-1]
   end
 
   def self.path(filename)

--- a/mrbgems/mruby-proc-ext/test/proc.rb
+++ b/mrbgems/mruby-proc-ext/test/proc.rb
@@ -10,7 +10,7 @@ def enable_debug_info?
     if @enable_debug_info && e.backtrace[0].include?("(unknown)")
       @enable_debug_info = false
     end
-    return @enable_debug_info
+    @enable_debug_info
   end
 end
 

--- a/mrbgems/mruby-range-ext/mrblib/range.rb
+++ b/mrbgems/mruby-range-ext/mrblib/range.rb
@@ -50,7 +50,7 @@ class Range
     nv = args[0]
     n = nv.__to_int
     raise ArgumentError, "negative array size (or size too big)" unless 0 <= n
-    return self.to_a.last(nv)
+    self.to_a.last(nv)
   end
 
   def max(&block)

--- a/mrbgems/mruby-symbol-ext/mrblib/symbol.rb
+++ b/mrbgems/mruby-symbol-ext/mrblib/symbol.rb
@@ -56,7 +56,7 @@ class Symbol
   def casecmp?(sym)
     c = self.casecmp(sym)
     return nil if c.nil?
-    return c == 0
+    c == 0
   end
 
   #

--- a/mrblib/array.rb
+++ b/mrblib/array.rb
@@ -119,7 +119,7 @@ class Array
       return false if self[i] != other[i]
       i += 1
     end
-    return true
+    true
   end
 
   ##
@@ -139,7 +139,7 @@ class Array
       return false unless self[i].eql?(other[i])
       i += 1
     end
-    return true
+    true
   end
 
   ##

--- a/mrblib/hash.rb
+++ b/mrblib/hash.rb
@@ -29,7 +29,7 @@ class Hash
       return false unless hash.key?(k)
       return false unless self[k] == hash[k]
     end
-    return true
+    true
   end
 
   ##
@@ -49,7 +49,7 @@ class Hash
       return false unless hash.key?(k)
       return false unless self[k].eql?(hash[k])
     end
-    return true
+    true
   end
 
   ##

--- a/test/assert.rb
+++ b/test/assert.rb
@@ -392,7 +392,7 @@ def _eval_assertion(meth, exp, act_or_msg, msg, block)
   else
     exp, act, msg = exp, act_or_msg, msg
   end
-  return exp.__send__(meth, act), exp, act, msg
+  [exp.__send__(meth, act), exp, act, msg]
 end
 
 ##

--- a/test/t/proc.rb
+++ b/test/t/proc.rb
@@ -110,19 +110,19 @@ assert('Proc#return_does_not_break_self') do
     end
     def return_array
       @block = Proc.new { self }
-      return []
+      []
     end
     def return_instance_variable
       @block = Proc.new { self }
-      return @block
+      @block
     end
     def return_const_fixnum
       @block = Proc.new { self }
-      return 123
+      123
     end
     def return_nil
       @block = Proc.new { self }
-      return nil
+      nil
     end
   end
 


### PR DESCRIPTION
We already run Rubocop on `mgem-list` as seen here:

https://github.com/mruby/mgem-list/blob/7944a361ab9acb0d673f15fbf0e2ce4b80f21514/.pre-commit-config.yaml#L46

This PR adds a basic Rubocop config file and the goal is to standardize the codebase.

Using `rubocop -A` the redundant returns have been autoremoved.