### PR TITLE
Add `gem.last_initializer`

### DIFF
--- a/lib/mruby/gem.rb
+++ b/lib/mruby/gem.rb
@@ -43,6 +43,7 @@ module MRuby
       def initialize(name, &block)
         @name = name
         @initializer = block
+        @last_initializer = nil
         @version = "0.0.0"
         @dependencies = []
         @conflicts = []
@@ -84,6 +85,7 @@ module MRuby
         build.libmruby_objs << @objs
 
         instance_eval(&@build_config_initializer) if @build_config_initializer
+        instance_eval(&@last_initializer) if @last_initializer
 
         repo_url = build.gem_dir_to_repo_url[dir]
         build.locks[repo_url]['version'] = version if repo_url
@@ -190,6 +192,14 @@ module MRuby
         Dir["#{@dir}/#{src_dir_from_gem_dir}/*{#{exts}}"].map do |f|
           objfile(f.relative_path_from(@dir).to_s.pathmap("#{build_dir}/%X"))
         end
+      end
+
+      # This method is for GEM authors.
+      #
+      # If the user wants to adjust GEM, provide block arguments to
+      # the `MRuby::Build#gem` method in the build configuration file.
+      def last_initializer(&block)
+        @last_initializer = block
       end
 
       def define_gem_init_builder


### PR DESCRIPTION
Provides a mechanism for the GEM author to do the final processing after the blocks specified in `build.gem` have been processed.

This allows GEM author and user code to be processed in the following order:

 1. The block passed to `MRuby::Gem::Specification.new` in `mrbgem.rake`
 2. The block passed to `MRuby::Build#gem` in the build configuration file.
 3. The block passed to `MRuby::Gem::Specification#last_initializer` in `MRuby::Gem::Specification.new`.

---

When performing library detection, I would like to use it to auto-detect when GEM users do not specify anything.
https://github.com/dearblue/mruby-stacktrace/blob/TENTATIVE.1/mrbgem.rake#L123-L144

So far, if desired to specify a block for default settings, this can be accomplished by directly assigning it to an instance variable.
However, when viewed as a public API, I do not believe this is the preferred method.
https://github.com/dearblue/mruby-stacktrace/blob/TENTATIVE.1/mrbgem.rake#L117
