### PR TITLE
Reduced description of `mrb_init_core()`

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -6,44 +6,31 @@
 
 #include <mruby.h>
 
-void mrb_init_symtbl(mrb_state*);
-void mrb_init_class(mrb_state*);
-void mrb_init_object(mrb_state*);
-void mrb_init_kernel(mrb_state*);
-void mrb_init_enumerable(mrb_state*);
-void mrb_init_symbol(mrb_state*);
-void mrb_init_string(mrb_state*);
-void mrb_init_exception(mrb_state*);
-void mrb_init_proc(mrb_state*);
-void mrb_init_array(mrb_state*);
-void mrb_init_hash(mrb_state*);
-void mrb_init_numeric(mrb_state*);
-void mrb_init_range(mrb_state*);
-void mrb_init_gc(mrb_state*);
-void mrb_init_math(mrb_state*);
-void mrb_init_version(mrb_state*);
-void mrb_init_mrblib(mrb_state*);
+#define INIT_FUNC_FOREACH(def) \
+  def(mrb_init_symtbl) \
+  def(mrb_init_class) \
+  def(mrb_init_object) \
+  def(mrb_init_kernel) \
+  def(mrb_init_enumerable) \
+  def(mrb_init_symbol) \
+  def(mrb_init_string) \
+  def(mrb_init_exception) \
+  def(mrb_init_proc) \
+  def(mrb_init_array) \
+  def(mrb_init_hash) \
+  def(mrb_init_numeric) \
+  def(mrb_init_range) \
+  def(mrb_init_gc) \
+  def(mrb_init_version) \
+  def(mrb_init_mrblib)
+
+#define INIT_FUNC_DECLS(func) void func(mrb_state*);
+INIT_FUNC_FOREACH(INIT_FUNC_DECLS)
 
 #define DONE mrb_gc_arena_restore(mrb, 0);
 void
 mrb_init_core(mrb_state *mrb)
 {
-  mrb_init_symtbl(mrb); DONE;
-
-  mrb_init_class(mrb); DONE;
-  mrb_init_object(mrb); DONE;
-  mrb_init_kernel(mrb); DONE;
-  mrb_init_enumerable(mrb); DONE;
-
-  mrb_init_symbol(mrb); DONE;
-  mrb_init_string(mrb); DONE;
-  mrb_init_exception(mrb); DONE;
-  mrb_init_proc(mrb); DONE;
-  mrb_init_array(mrb); DONE;
-  mrb_init_hash(mrb); DONE;
-  mrb_init_numeric(mrb); DONE;
-  mrb_init_range(mrb); DONE;
-  mrb_init_gc(mrb); DONE;
-  mrb_init_version(mrb); DONE;
-  mrb_init_mrblib(mrb); DONE;
+#define INIT_FUNC_CALL(func) func(mrb); DONE;
+  INIT_FUNC_FOREACH(INIT_FUNC_CALL)
 }


### PR DESCRIPTION
Since `mrb_init_math()` does not exist, it is no longer declared as a prototype.