### PR TITLE
Reorganize `mrb_cache_entry` and `mrb_method_t` types

### DIFF
--- a/doc/guides/mrbconf.md
+++ b/doc/guides/mrbconf.md
@@ -236,12 +236,6 @@ end
 - Ignored if `MRB_NO_METHOD_CACHE` is defined.
 - Need to be the power of 2.
 
-`MRB_USE_METHOD_T_STRUCT`
-
-- Use C struct to represent `mrb_method_t`
-- No `MRB_USE_METHOD_T_STRUCT` requires highest 2 bits of function pointers to be zero
-- Define this macro on machines that use higher bits of pointers
-
 `MRB_USE_ALL_SYMBOLS`
 
 - Make it available `Symbol.all_symbols` in `mrbgems/mruby-symbol-ext`

--- a/include/mrbconf.h
+++ b/include/mrbconf.h
@@ -48,16 +48,6 @@
 //#define MRB_METHOD_CACHE_SIZE (1<<8)
 //#define MRB_USE_INLINE_METHOD_CACHE
 
-/* add -DMRB_USE_METHOD_T_STRUCT on machines that use higher bits of function pointers */
-/* no MRB_USE_METHOD_T_STRUCT requires highest 2 bits of function pointers to be zero */
-#ifndef MRB_USE_METHOD_T_STRUCT
-  // can't use highest 2 bits of function pointers at least on 32bit
-  // Windows and 32bit Linux.
-# ifdef MRB_32BIT
-#   define MRB_USE_METHOD_T_STRUCT
-# endif
-#endif
-
 /* define on big endian machines; used by MRB_NAN_BOXING, etc. */
 #ifndef MRB_ENDIAN_BIG
 # if (defined(BYTE_ORDER) && defined(BIG_ENDIAN) && BYTE_ORDER == BIG_ENDIAN) || \
@@ -170,9 +160,6 @@
 //#define MRB_USE_ALL_SYMBOLS /* Symbol.all_symbols */
 
 /* obsolete configurations */
-#ifdef MRB_METHOD_T_STRUCT
-# define MRB_USE_METHOD_T_STRUCT
-#endif
 #if defined(DISABLE_STDIO) || defined(MRB_DISABLE_STDIO)
 # define MRB_NO_STDIO
 #endif

--- a/include/mruby.h
+++ b/include/mruby.h
@@ -230,22 +230,19 @@ mrb_static_assert_powerof2(MRB_METHOD_CACHE_SIZE);
  */
 typedef mrb_value (*mrb_func_t)(struct mrb_state *mrb, mrb_value self);
 
-#ifndef MRB_USE_METHOD_T_STRUCT
-typedef uintptr_t mrb_method_t;
-#else
 typedef struct {
-  uint8_t flags;
+  uint32_t flags;                       /* compatible with mt keys in class.c */
+
   union {
     struct RProc *proc;
     mrb_func_t func;
   };
 } mrb_method_t;
-#endif
 
 #ifndef MRB_NO_METHOD_CACHE
 struct mrb_cache_entry {
   struct RClass *c, *c0;
-  mrb_sym mid;
+  /* mrb_sym mid; // mid is stored in mrb_method_t::flags */
   mrb_method_t m;
 };
 #endif

--- a/include/mruby/proc.h
+++ b/include/mruby/proc.h
@@ -106,20 +106,6 @@ MRB_API mrb_value mrb_proc_cfunc_env_get(mrb_state *mrb, mrb_int idx);
 #define MRB_METHOD_FUNC_FL 1
 #define MRB_METHOD_NOARG_FL 2
 
-#ifndef MRB_USE_METHOD_T_STRUCT
-
-#define MRB_METHOD_FUNC_P(m) (((uintptr_t)(m))&MRB_METHOD_FUNC_FL)
-#define MRB_METHOD_NOARG_P(m) ((((uintptr_t)(m))&MRB_METHOD_NOARG_FL)?1:0)
-#define MRB_METHOD_NOARG_SET(m) ((m)=(mrb_method_t)(((uintptr_t)(m))|MRB_METHOD_NOARG_FL))
-#define MRB_METHOD_FUNC(m) ((mrb_func_t)((uintptr_t)(m)>>2))
-#define MRB_METHOD_FROM_FUNC(m,fn) ((m)=(mrb_method_t)((((uintptr_t)(fn))<<2)|MRB_METHOD_FUNC_FL))
-#define MRB_METHOD_FROM_PROC(m,pr) ((m)=(mrb_method_t)(pr))
-#define MRB_METHOD_PROC_P(m) (!MRB_METHOD_FUNC_P(m))
-#define MRB_METHOD_PROC(m) ((struct RProc*)(m))
-#define MRB_METHOD_UNDEF_P(m) ((m)==0)
-
-#else
-
 #define MRB_METHOD_FUNC_P(m) ((m).flags&MRB_METHOD_FUNC_FL)
 #define MRB_METHOD_NOARG_P(m) (((m).flags&MRB_METHOD_NOARG_FL)?1:0)
 #define MRB_METHOD_FUNC(m) ((m).func)
@@ -129,8 +115,6 @@ MRB_API mrb_value mrb_proc_cfunc_env_get(mrb_state *mrb, mrb_int idx);
 #define MRB_METHOD_PROC_P(m) (!MRB_METHOD_FUNC_P(m))
 #define MRB_METHOD_PROC(m) ((m).proc)
 #define MRB_METHOD_UNDEF_P(m) ((m).proc==NULL)
-
-#endif /* MRB_USE_METHOD_T_STRUCT */
 
 #define MRB_METHOD_CFUNC_P(m) (MRB_METHOD_FUNC_P(m)?TRUE:(MRB_METHOD_PROC(m)?(MRB_PROC_CFUNC_P(MRB_METHOD_PROC(m))):FALSE))
 #define MRB_METHOD_CFUNC(m) (MRB_METHOD_FUNC_P(m)?MRB_METHOD_FUNC(m):((MRB_METHOD_PROC(m)&&MRB_PROC_CFUNC_P(MRB_METHOD_PROC(m)))?MRB_PROC_CFUNC(MRB_METHOD_PROC(m)):NULL))


### PR DESCRIPTION
The purpose is to remove the `mid` field from the `mrb_cache_entry` structure. The resulting RAM requirement for the method cache is reduced from 5 words per entry to 4 words per entry for 32-bit CPUs.

The relevant changes are as follows:

  - Removed `MRB_USE_METHOD_T_STRUCT`.

    The `mrb_method_t` type is now always defined as a structure.

  - Include method IDs in `mrb_method_t`

    Change the `flags` member to `uint32_t`. The bitstring structure should be the same as the keys of the `mt` table in `class.c`.

I believe the impact on API compatibility with previous versions is minimal.

---

Attached is a benchmark comparison for your reference.
The targets are (1) the [current master](https://github.com/mruby/mruby/tree/61b1a4db8efecea4a09f7c4ce9449cd6f52f4bc6), (2) this PR, (3) [another alternative](https://github.com/dearblue/mruby/commit/b2bc93209565b578a81267cfe8bf8a0b6e4c2769) and (4) [3.3.0](https://github.com/mruby/mruby/tree/3.3.0).
Another alternative is to move the bits embedded in `struct mrb_cache_entry::mid` to `struct mrb_cache_entry::c0` (like "word-boxing"). [Link to difference](https://github.com/dearblue/mruby/commit/b2bc93209565b578a81267cfe8bf8a0b6e4c2769#diff-114597163077c0642dba00237dcabafba47b8e0486d136299bb669a15abae822L246-R252).

![bm-result-20240330T184902](https://github.com/mruby/mruby/assets/6077921/97829746-7509-4bab-a790-82081a7cde75)
