### PR TITLE
`mrb_env_unshare()` to break the link to fiber

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -387,6 +387,8 @@ mrb_env_unshare(mrb_state *mrb, struct REnv *e, mrb_bool noraise)
   if (e->cxt != mrb->c) return TRUE;
   if (e == CI_ENV(mrb->c->cibase)) return TRUE; /* for mirb */
 
+  e->cxt = NULL; /* make possible to GC the fiber that generated the env */
+
   size_t len = (size_t)MRB_ENV_LEN(e);
   if (len == 0) {
     e->stack = NULL;


### PR DESCRIPTION
Currently `e->cxt` is used exclusively to check for `break` / `return` availability.
In other words, there is no need to maintain a reference to a fiber that has reached its end.
