### PR TITLE
Revert "Adjust environment when `mrb_exec_irep` happened."

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -142,16 +142,6 @@ envadjust(mrb_state *mrb, mrb_value *oldbase, mrb_value *newbase, size_t oldsize
         (st = e->stack) && (size_t)(st - oldbase) < oldsize) {
       e->stack += delta;
     }
-
-    if (ci->proc && MRB_PROC_ENV_P(ci->proc) && e != MRB_PROC_ENV(ci->proc)) {
-      e = MRB_PROC_ENV(ci->proc);
-
-      if (e && MRB_ENV_ONSTACK_P(e) &&
-          (st = e->stack) && (size_t)(st - oldbase) < oldsize) {
-        e->stack += delta;
-      }
-    }
-
     ci->stack += delta;
     ci++;
   }


### PR DESCRIPTION
This reverts commit 26e436e24797f0c3228bc9900615afe7d2e29ddf.

After investigation, it is possible to revert by commit e89cc9b9fabd4277804fd43666b198a29c25bc34.

The build configuration file used in the investigation is shown below.

```ruby
MRuby::Build.new do |conf|
  toolchain :clang

  enable_debug
  enable_bintest
  enable_test

  cc.command = "clang18"
  linker.command = "clang18"

  [cc, cxx].each { |c| c.defines << "MRB_GC_STRESS" }
  [cc, cxx, linker].each { |cmd| cmd.flags << %w(-fsanitize=address) }

  gem github: "iij/mruby-dir"       # rev: "89dceefa1250fb1ae868d4cb52498e9e24293cd1"
  gem github: "iij/mruby-env"       # rev: "056ae324451ef16a50c7887e117f0ea30921b71b"
  gem github: "iij/mruby-errno"     # rev: "b4415207ff6ea62360619c89a1cff83259dc4db0"
  gem github: "iij/mruby-require"   # rev: "f0634d785e5cbb73cd7d118ee36deff499e4181e"
  gem github: "iij/mruby-tempfile"  # rev: "9b883438547020dae328e34c8a2fe736171cd0ab"
end
```

Since the `rake` command needs to be from the past, we used the Ruby 2.6 version.