### PR TITLE
Revert "`env` referred from top-level callinfo should not be unshared; fix #4019"

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -375,7 +375,6 @@ mrb_env_unshare(mrb_state *mrb, struct REnv *e, mrb_bool noraise)
   if (e == NULL) return TRUE;
   if (!MRB_ENV_ONSTACK_P(e)) return TRUE;
   if (e->cxt != mrb->c) return TRUE;
-  if (e == CI_ENV(mrb->c->cibase)) return TRUE; /* for mirb */
 
   e->cxt = NULL; /* make possible to GC the fiber that generated the env */
 


### PR DESCRIPTION
This reverts commit 72581696d35e8da79a3a9d606294602c83abdf9f.

The #4012 that may have been the trigger for issue #4019 was later reverted by #4039 due to issue #4021.