### PR TITLE
Add a way to let other gems handle closing of fds in mruby-io

### DIFF
--- a/mrbgems/mruby-io/include/mruby/ext/io.h
+++ b/mrbgems/mruby-io/include/mruby/ext/io.h
@@ -41,7 +41,9 @@ struct mrb_io {
                writable:1,
                eof:1,
                sync:1,
-               is_socket:1;
+               is_socket:1,
+               close_fd:1,
+               close_fd2:1;
 };
 
 #define MRB_O_RDONLY            0x0000


### PR DESCRIPTION
I'm currently writing a gem which wants to integrate with mruby-io and mruby-socket.
At the moment mruby-io closes fds it didn't create itself and thus can cause problems when other gems except the fd to still be available.

This only changes how ```fptr_finalize``` handles the closing of fds and nothing else.
I've tried handling that in my gem by stopping a created mruby-io object from being garbage collected until it's not needed anymore, but that wasn't enough.
