### PR TITLE
Revise scope of role of `mrb_vm_run()`

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -1357,7 +1357,9 @@ mrb_vm_run(mrb_state *mrb, const struct RProc *proc, mrb_value self, mrb_int sta
   const mrb_irep *irep = proc->body.irep;
   mrb_value result;
   struct mrb_context *c = mrb->c;
+#ifdef MRB_DEBUG
   ptrdiff_t cioff = c->ci - c->cibase;
+#endif
   mrb_int nregs = irep->nregs;
 
   if (!c->stbase) {
@@ -1376,15 +1378,8 @@ mrb_vm_run(mrb_state *mrb, const struct RProc *proc, mrb_value self, mrb_int sta
   stack_clear(c->ci->stack + stack_keep, nregs - stack_keep);
   c->ci->stack[0] = self;
   result = mrb_vm_exec(mrb, proc, irep->iseq);
-  if (mrb->c != c) {
-    if (mrb->c->fib) {
-      mrb_write_barrier(mrb, (struct RBasic*)mrb->c->fib);
-    }
-    mrb->c = c;
-  }
-  else if (c->ci - c->cibase > cioff) {
-    c->ci = c->cibase + cioff;
-  }
+  mrb_assert(mrb->c == c);      /* do not switch fibers via mrb_vm_run(), unlike mrb_vm_exec() */
+  mrb_assert(c->ci == c->cibase || (c->ci - c->cibase) == cioff - 1);
   return result;
 }
 


### PR DESCRIPTION
`mrb_vm_run()` is,
  - It does not change the fiber context.
  - When control is returned, only one ci prepared by the caller is popped. If the ci equals cibase when called, the ci position does not change.

related commits:
  - commit 4e84bdb507885bd37b4b0fa6b6359ac8c8b7b886
  - commit 34dd258c638bfc9e8ffac6621f3918faff3d797f
  - commit ebd6636a1e90dd12cb0ef112e7f1e0ca511f5d3b
  - commit c6736357a72049a0eb2a31ccabcc3cd2baba7c9e
  - commit 23a4e7149dc4253caf5ed0a528ffe5c21c4afb80
  - commit 31a961acf16b7a9454ccb0f0ece91b79e95f7078

---

I have traced from the related commits to check the issues and they can no longer be reproduced.
