### PR TITLE
Allow recycling fibers by GC if not referenced directly

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -190,10 +190,12 @@ mrb_realloc_simple(mrb_state *mrb, void *p,  size_t len)
   void *p2;
 
 #if defined(MRB_GC_STRESS) && defined(MRB_DEBUG)
-  mrb_full_gc(mrb);
+  if (mrb->gc.state != MRB_GC_STATE_SWEEP) {
+    mrb_full_gc(mrb);
+  }
 #endif
   p2 = (mrb->allocf)(mrb, p, len, mrb->allocf_ud);
-  if (!p2 && len > 0 && mrb->gc.heaps) {
+  if (!p2 && len > 0 && mrb->gc.heaps && mrb->gc.state != MRB_GC_STATE_SWEEP) {
     mrb_full_gc(mrb);
     p2 = (mrb->allocf)(mrb, p, len, mrb->allocf_ud);
   }

--- a/src/vm.c
+++ b/src/vm.c
@@ -429,7 +429,6 @@ mrb_env_unshare(mrb_state *mrb, struct REnv *e, mrb_bool noraise)
 {
   if (e == NULL) return TRUE;
   if (!MRB_ENV_ONSTACK_P(e)) return TRUE;
-  if (e->cxt != mrb->c) return TRUE;
 
   e->cxt = NULL; /* make possible to GC the fiber that generated the env */
 


### PR DESCRIPTION
The patch assumes that `struct REnv::cxt` only performs checks with the `OP_BREAK` and `OP_RETURN_BLK` instructions, and does not reference the entity.
Therefore, by changing to a weak reference, it is possible to collect fibers that are no longer directly referenced while in the suspended state.

However, we need to detach the living env objects that remain in the call stack of the fiber.
So, in effect, it involves a revert of following commits.
  - commit a3365d8b3fc957b1d1fd89526440358aa9402fc3
  - commit 57ffa1c1508f01434806b1b7301f4ae982eb9ae0

Examples of the effects of change are shown below.
Note that it was built with `rake MRUBY_CONFIG=host-debug`.

```ruby
f = Fiber.new { (x, y, z) = "X", "Y", "Z"; Fiber.yield -> { [x, y, z] } }
g = f.resume
GC.start
p ObjectSpace.memsize_of_all
# => 59532
g.call
# => ["X", "Y", "Z"]
f = nil
GC.start
ObjectSpace.memsize_of_all
# BEFORE => 59532
# AFTER  => 58044
g.call
# => ["X", "Y", "Z"]
```

---

In addition, it also takes the necessary precautions to prevent the possibility of infinite loops with this change.
