### PR TITLE
Update documentation for `mrb_top_run()`

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -1277,7 +1277,29 @@ MRB_API void mrb_close(mrb_state *mrb);
 MRB_API void* mrb_default_allocf(mrb_state*, void*, size_t, void*);
 
 MRB_API mrb_value mrb_top_self(mrb_state *mrb);
+
+/**
+ * Enter the mruby VM and execute the proc.
+ *
+ * @param mrb
+ *      The current mruby state.
+ * @param proc
+ *      An object containing `irep`.
+ *      If supplied an object containing anything other than `irep`, it will probably crash.
+ * @param self
+ *      `self` on the execution context of `proc`.
+ * @param stack_keep
+ *      Specifies the number of values to hold from the stack top.
+ *      Values on the stack outside this range will be initialized to `nil`.
+ *
+ * @note
+ *      When called from a C function defined as a method, the current stack is destroyed.
+ *      If you want to use arguments obtained by `mrb_get_args()` or other methods after `mrb_top_run()`,
+ *      you must protect them by `mrb_gc_protect()` or other ways before this function.
+ *      Or consider using `mrb_yield()` family functions.
+ */
 MRB_API mrb_value mrb_top_run(mrb_state *mrb, const struct RProc *proc, mrb_value self, mrb_int stack_keep);
+
 MRB_API mrb_value mrb_vm_run(mrb_state *mrb, const struct RProc *proc, mrb_value self, mrb_int stack_keep);
 MRB_API mrb_value mrb_vm_exec(mrb_state *mrb, const struct RProc *proc, const mrb_code *iseq);
 /* compatibility macros */

--- a/include/mruby/compile.h
+++ b/include/mruby/compile.h
@@ -190,15 +190,22 @@ MRB_API struct mrb_parser_state* mrb_parse_nstring(mrb_state*,const char*,size_t
 MRB_API struct RProc* mrb_generate_code(mrb_state*, struct mrb_parser_state*);
 MRB_API mrb_value mrb_load_exec(mrb_state *mrb, struct mrb_parser_state *p, mrb_ccontext *c);
 
-/** program load functions
-* Please note! Currently due to interactions with the GC calling these functions will
-* leak one RProc object per function call.
-* To prevent this save the current memory arena before calling and restore the arena
-* right after, like so
-* int ai = mrb_gc_arena_save(mrb);
-* mrb_value status = mrb_load_string(mrb, buffer);
-* mrb_gc_arena_restore(mrb, ai);
-*/
+/**
+ * program load functions
+ *
+ * Please note! Currently due to interactions with the GC calling these functions will
+ * leak one RProc object per function call.
+ * To prevent this save the current memory arena before calling and restore the arena
+ * right after, like so
+ *
+ *      int ai = mrb_gc_arena_save(mrb);
+ *      mrb_value status = mrb_load_string(mrb, buffer);
+ *      mrb_gc_arena_restore(mrb, ai);
+ *
+ * Also, when called from a C function defined as a method, the current stack is destroyed.
+ * If processing continues after this function, the objects obtained from the arguments
+ * must be protected as needed before this function.
+ */
 #ifndef MRB_NO_STDIO
 MRB_API mrb_value mrb_load_file(mrb_state*,FILE*);
 MRB_API mrb_value mrb_load_file_cxt(mrb_state*,FILE*, mrb_ccontext *cxt);

--- a/include/mruby/irep.h
+++ b/include/mruby/irep.h
@@ -84,15 +84,22 @@ struct mrb_irep {
 
 MRB_API mrb_irep *mrb_add_irep(mrb_state *mrb);
 
-/** load mruby bytecode functions
-* Please note! Currently due to interactions with the GC calling these functions will
-* leak one RProc object per function call.
-* To prevent this save the current memory arena before calling and restore the arena
-* right after, like so
-* int ai = mrb_gc_arena_save(mrb);
-* mrb_value status = mrb_load_irep(mrb, buffer);
-* mrb_gc_arena_restore(mrb, ai);
-*/
+/**
+ * load mruby bytecode functions
+ *
+ * Please note! Currently due to interactions with the GC calling these functions will
+ * leak one RProc object per function call.
+ * To prevent this save the current memory arena before calling and restore the arena
+ * right after, like so
+ *
+ *      int ai = mrb_gc_arena_save(mrb);
+ *      mrb_value status = mrb_load_irep(mrb, buffer);
+ *      mrb_gc_arena_restore(mrb, ai);
+ *
+ * Also, when called from a C function defined as a method, the current stack is destroyed.
+ * If processing continues after this function, the objects obtained from the arguments
+ * must be protected as needed before this function.
+ */
 
 /* @param [const uint8_t*] irep code, expected as a literal */
 MRB_API mrb_value mrb_load_irep(mrb_state*, const uint8_t*);


### PR DESCRIPTION
Also, add explanations for the `mrb_load_irep()` and `mrb_load_string()` families, which are indirect calls to `mrb_top_run()`.

---

I added a new feature to my mruby-gemcut and it took me a while to figure out the cause crash.
I need to call `mrb_top_run()` indirectly from inside the method, so using `mrb_proc_new_cfunc()` and `mrb_yield_with_class()` as workarounds.
[`Gemcut.facet` method](https://github.com/dearblue/mruby-gemcut/blob/67eb29bc650f436167226a177309009a8e69ebef/src/mruby-gemcut.c#L435-L456)

I was concerned about compatibility if I changed the behavior from within the mruby VM, so I added a note to the documentation first.
I can't think of a better way at this time.
