### PR TITLE
Remove `exc_caught` from `mrb_vm_exec()`

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -1432,15 +1432,13 @@ mrb_vm_exec(mrb_state *mrb, const struct RProc *proc, const mrb_code *pc)
   };
 #endif
 
-  volatile mrb_bool exc_caught = FALSE;
 RETRY_TRY_BLOCK:
 
   MRB_TRY(&c_jmp) {
 
-  if (exc_caught) {
-    exc_caught = FALSE;
+  if (mrb->exc) {
     mrb_gc_arena_restore(mrb, ai);
-    if (mrb->exc && mrb->exc->tt == MRB_TT_BREAK)
+    if (mrb->exc->tt == MRB_TT_BREAK)
       goto L_BREAK;
     goto L_RAISE;
   }
@@ -3130,7 +3128,6 @@ RETRY_TRY_BLOCK:
     while (ci > mrb->c->cibase && ci->cci == CINFO_DIRECT) {
       ci = cipop(mrb);
     }
-    exc_caught = TRUE;
     pc = ci->pc;
     goto RETRY_TRY_BLOCK;
   }


### PR DESCRIPTION
Only go to exception handling if `mrb->exc` is non-null.

This may cause some compatibility problems, but I doubt that it is necessary to maintain that compatibility.
Here is how I see the incompatibility with the change at this time:
  - If `mrb->exc` is non-null and `mrb_vm_exec()` is called, an exception will be thrown immediately.
  - If `MRB_THROW()` is used while `mrb->exc` is `NULL`, it will not go to exception handling.