### PR TITLE
fix: `to_a` integer ranges with `begin > end` failing

### DIFF
--- a/src/range.c
+++ b/src/range.c
@@ -358,6 +358,10 @@ range_num_to_a(mrb_state *mrb, mrb_value range)
     if (mrb_integer_p(end)) {
       mrb_int a = mrb_integer(beg);
       mrb_int b = mrb_integer(end);
+
+      if (a > b) {
+        return mrb_ary_new_capa(mrb, 0);
+      }
       mrb_int len;
 
       if (mrb_int_sub_overflow(b, a, &len)) {


### PR DESCRIPTION
example of failure:
```rb
(-1..-4).to_a
# => array size too big (ArgumentError)
```

expected result (by cruby):
```rb
(-1..-4).to_a
# => []
```