### PR TITLE
Passes the nonexistent key as a block argument in `Array#delete`

### DIFF
--- a/mrblib/array.rb
+++ b/mrblib/array.rb
@@ -193,7 +193,7 @@ class Array
   def delete(key, &block)
     len = self.length
     ret = self.__delete(key)
-    return block&.call() if len == self.length
+    return block&.call(key) if len == self.length
 
     ret
   end

--- a/test/t/array.rb
+++ b/test/t/array.rb
@@ -449,6 +449,7 @@ end
 assert('Array#delete') do
   a = ["a", "b", "c"]
   assert_equal nil, a.delete("x")
+  assert_equal "x", a.delete("x") { _1 }
   assert_equal ["a", "b", "c"], a
   assert_equal "a", a.delete("a")
   assert_equal ["b", "c"], a

--- a/test/t/array.rb
+++ b/test/t/array.rb
@@ -445,3 +445,15 @@ assert('Array#freeze') do
     a[0] = 1
   end
 end
+
+assert('Array#delete') do
+  a = ["a", "b", "c"]
+  assert_equal nil, a.delete("x")
+  assert_equal ["a", "b", "c"], a
+  assert_equal "a", a.delete("a")
+  assert_equal ["b", "c"], a
+
+  a = [nil]
+  assert_equal nil, a.delete(nil) { "?" }
+  assert_equal [], a
+end


### PR DESCRIPTION
```ruby
a = %w(R G B A)
p a.delete("Y") { _1 }
# BEFORE => nil (same for mruby 3.3)
# AFTER  => "Y" (same for CRuby)
```

Also, the test code was not present, so I added it.
