### PR TITLE
Use mrb_malloc()/mrb_free() for mrb_utf8_from_locale()/mrb_locale_from_utf8(); fix #6277

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -1215,15 +1215,15 @@ MRB_API mrb_value mrb_obj_freeze(mrb_state*, mrb_value);
 #define mrb_str_new_lit_frozen(mrb,lit) mrb_obj_freeze(mrb,mrb_str_new_lit(mrb,lit))
 
 #ifdef _WIN32
-MRB_API char* mrb_utf8_from_locale(const char *p, int len);
-MRB_API char* mrb_locale_from_utf8(const char *p, int len);
-#define mrb_locale_free(p) free(p)
-#define mrb_utf8_free(p) free(p)
+MRB_API char* mrb_utf8_from_locale(mrb_state *mrb, const char *p, int len);
+MRB_API char* mrb_locale_from_utf8(mrb_state *mrb, const char *p, int len);
+#define mrb_locale_free(mrb, p) mrb_free((mrb), (p))
+#define mrb_utf8_free(mrb, p) mrb_free((mrb), (p))
 #else
-#define mrb_utf8_from_locale(p, l) ((char*)(p))
-#define mrb_locale_from_utf8(p, l) ((char*)(p))
-#define mrb_locale_free(p)
-#define mrb_utf8_free(p)
+#define mrb_utf8_from_locale(mrb, p, l) ((char*)(p))
+#define mrb_locale_from_utf8(mrb, p, l) ((char*)(p))
+#define mrb_locale_free(mrb, p)
+#define mrb_utf8_free(mrb, p)
 #endif
 
 /**

--- a/mrbgems/mruby-bin-mirb/tools/mirb/mirb.c
+++ b/mrbgems/mruby-bin-mirb/tools/mirb/mirb.c
@@ -129,9 +129,9 @@ p(mrb_state *mrb, mrb_value obj, int prompt)
   if (!mrb_string_p(val)) {
     val = mrb_obj_as_string(mrb, obj);
   }
-  msg = mrb_locale_from_utf8(RSTRING_PTR(val), (int)RSTRING_LEN(val));
+  msg = mrb_locale_from_utf8(mrb, RSTRING_PTR(val), (int)RSTRING_LEN(val));
   fwrite(msg, strlen(msg), 1, stdout);
-  mrb_locale_free(msg);
+  mrb_locale_free(mrb, msg);
   putc('\n', stdout);
 }
 
@@ -481,10 +481,10 @@ main(int argc, char **argv)
 
   ARGV = mrb_ary_new_capa(mrb, args.argc);
   for (i = 0; i < args.argc; i++) {
-    char* utf8 = mrb_utf8_from_locale(args.argv[i], -1);
+    char* utf8 = mrb_utf8_from_locale(mrb, args.argv[i], -1);
     if (utf8) {
       mrb_ary_push(mrb, ARGV, mrb_str_new_cstr(mrb, utf8));
-      mrb_utf8_free(utf8);
+      mrb_utf8_free(mrb, utf8);
     }
   }
   mrb_define_global_const(mrb, "ARGV", ARGV);
@@ -612,7 +612,7 @@ main(int argc, char **argv)
       strcpy(ruby_code, last_code_line);
     }
 
-    utf8 = mrb_utf8_from_locale(ruby_code, -1);
+    utf8 = mrb_utf8_from_locale(mrb, ruby_code, -1);
     if (!utf8) abort();
 
     /* parse code */
@@ -626,7 +626,7 @@ main(int argc, char **argv)
     parser->lineno = cxt->lineno;
     mrb_parser_parse(parser, cxt);
     code_block_open = is_code_block_open(parser);
-    mrb_utf8_free(utf8);
+    mrb_utf8_free(mrb, utf8);
 
     if (code_block_open) {
       /* no evaluation of code */
@@ -634,15 +634,15 @@ main(int argc, char **argv)
     else {
       if (0 < parser->nwarn) {
         /* warning */
-        char* msg = mrb_locale_from_utf8(parser->warn_buffer[0].message, -1);
+        char* msg = mrb_locale_from_utf8(mrb, parser->warn_buffer[0].message, -1);
         printf("line %d: %s\n", parser->warn_buffer[0].lineno, msg);
-        mrb_locale_free(msg);
+        mrb_locale_free(mrb, msg);
       }
       if (0 < parser->nerr) {
         /* syntax error */
-        char* msg = mrb_locale_from_utf8(parser->error_buffer[0].message, -1);
+        char* msg = mrb_locale_from_utf8(mrb, parser->error_buffer[0].message, -1);
         printf("line %d: %s\n", parser->error_buffer[0].lineno, msg);
-        mrb_locale_free(msg);
+        mrb_locale_free(mrb, msg);
       }
       else {
         /* generate bytecode */

--- a/mrbgems/mruby-bin-mruby/tools/mruby/mruby.c
+++ b/mrbgems/mruby-bin-mruby/tools/mruby/mruby.c
@@ -296,10 +296,10 @@ main(int argc, char **argv)
     int ai = mrb_gc_arena_save(mrb);
     ARGV = mrb_ary_new_capa(mrb, args.argc);
     for (int i = 0; i < args.argc; i++) {
-      char* utf8 = mrb_utf8_from_locale(args.argv[i], -1);
+      char* utf8 = mrb_utf8_from_locale(mrb, args.argv[i], -1);
       if (utf8) {
         mrb_ary_push(mrb, ARGV, mrb_str_new_cstr(mrb, utf8));
-        mrb_utf8_free(utf8);
+        mrb_utf8_free(mrb, utf8);
       }
     }
     mrb_define_global_const(mrb, "ARGV", ARGV);
@@ -353,10 +353,10 @@ main(int argc, char **argv)
       v = mrb_load_detect_file_cxt(mrb, args.rfp, c);
     }
     else {
-      char* utf8 = mrb_utf8_from_locale(args.cmdline, -1);
+      char* utf8 = mrb_utf8_from_locale(mrb, args.cmdline, -1);
       if (!utf8) abort();
       v = mrb_load_string_cxt(mrb, utf8, c);
-      mrb_utf8_free(utf8);
+      mrb_utf8_free(mrb, utf8);
     }
 
     mrb_gc_arena_restore(mrb, ai);

--- a/mrbgems/mruby-io/src/file_test.c
+++ b/mrbgems/mruby-io/src/file_test.c
@@ -50,7 +50,7 @@ mrb_stat0(mrb_state *mrb, mrb_value obj, struct stat *st, int do_lstat)
     return -1;
   }
   else {
-    char *path = mrb_locale_from_utf8(RSTRING_CSTR(mrb, obj), -1);
+    char *path = mrb_locale_from_utf8(mrb, RSTRING_CSTR(mrb, obj), -1);
     int ret;
     if (do_lstat) {
       ret = LSTAT(path, st);
@@ -58,7 +58,7 @@ mrb_stat0(mrb_state *mrb, mrb_value obj, struct stat *st, int do_lstat)
     else {
       ret = stat(path, st);
     }
-    mrb_locale_free(path);
+    mrb_locale_free(mrb, path);
     return ret;
   }
 }

--- a/mrbgems/mruby-io/src/io.c
+++ b/mrbgems/mruby-io/src/io.c
@@ -885,7 +885,7 @@ static int
 io_cloexec_open(mrb_state *mrb, const char *pathname, int flags, fmode_t mode)
 {
   int retry = FALSE;
-  char *fname = mrb_locale_from_utf8(pathname, -1);
+  char *fname = mrb_locale_from_utf8(mrb, pathname, -1);
   int fd;
 
 #ifdef O_CLOEXEC
@@ -908,7 +908,7 @@ reopen:
     }
     mrb_sys_fail(mrb, RSTRING_CSTR(mrb, mrb_format(mrb, "open %s", pathname)));
   }
-  mrb_locale_free(fname);
+  mrb_locale_free(mrb, fname);
 
   if (fd <= 2) {
     io_fd_cloexec(mrb, fd);

--- a/src/string.c
+++ b/src/string.c
@@ -6,6 +6,7 @@
 
 #ifdef _MSC_VER
 # define _CRT_NONSTDC_NO_DEPRECATE
+# define WIN32_LEAN_AND_MEAN
 #endif
 
 #include <mruby.h>
@@ -843,7 +844,7 @@ str_rindex(mrb_state *mrb, mrb_value str, mrb_value sub, mrb_int pos)
 #include <windows.h>
 
 char*
-mrb_utf8_from_locale(const char *str, int len)
+mrb_utf8_from_locale(mrb_state *mrb, const char *str, int len)
 {
   wchar_t* wcsp;
   char* mbsp;
@@ -854,26 +855,26 @@ mrb_utf8_from_locale(const char *str, int len)
   if (len == -1)
     len = (int)strlen(str);
   wcssize = MultiByteToWideChar(GetACP(), 0, str, len,  NULL, 0);
-  wcsp = (wchar_t*) malloc((wcssize + 1) * sizeof(wchar_t));
+  wcsp = (wchar_t*) mrb_malloc(mrb, (wcssize + 1) * sizeof(wchar_t));
   if (!wcsp)
     return NULL;
   wcssize = MultiByteToWideChar(GetACP(), 0, str, len, wcsp, wcssize + 1);
   wcsp[wcssize] = 0;
 
   mbssize = WideCharToMultiByte(CP_UTF8, 0, (LPCWSTR) wcsp, -1, NULL, 0, NULL, NULL);
-  mbsp = (char*) malloc((mbssize + 1));
+  mbsp = (char*) mrb_malloc(mrb, (mbssize + 1));
   if (!mbsp) {
-    free(wcsp);
+    mrb_free(mrb, wcsp);
     return NULL;
   }
   mbssize = WideCharToMultiByte(CP_UTF8, 0, (LPCWSTR) wcsp, -1, mbsp, mbssize, NULL, NULL);
   mbsp[mbssize] = 0;
-  free(wcsp);
+  mrb_free(mrb, wcsp);
   return mbsp;
 }
 
 char*
-mrb_locale_from_utf8(const char *utf8, int len)
+mrb_locale_from_utf8(mrb_state *mrb, const char *utf8, int len)
 {
   wchar_t* wcsp;
   char* mbsp;
@@ -884,20 +885,20 @@ mrb_locale_from_utf8(const char *utf8, int len)
   if (len == -1)
     len = (int)strlen(utf8);
   wcssize = MultiByteToWideChar(CP_UTF8, 0, utf8, len,  NULL, 0);
-  wcsp = (wchar_t*) malloc((wcssize + 1) * sizeof(wchar_t));
+  wcsp = (wchar_t*) mrb_malloc(mrb, (wcssize + 1) * sizeof(wchar_t));
   if (!wcsp)
     return NULL;
   wcssize = MultiByteToWideChar(CP_UTF8, 0, utf8, len, wcsp, wcssize + 1);
   wcsp[wcssize] = 0;
   mbssize = WideCharToMultiByte(GetACP(), 0, (LPCWSTR) wcsp, -1, NULL, 0, NULL, NULL);
-  mbsp = (char*) malloc((mbssize + 1));
+  mbsp = (char*) mrb_malloc(mrb, (mbssize + 1));
   if (!mbsp) {
-    free(wcsp);
+    mrb_free(mrb, wcsp);
     return NULL;
   }
   mbssize = WideCharToMultiByte(GetACP(), 0, (LPCWSTR) wcsp, -1, mbsp, mbssize, NULL, NULL);
   mbsp[mbssize] = 0;
-  free(wcsp);
+  mrb_free(mrb, wcsp);
   return mbsp;
 }
 #endif


### PR DESCRIPTION
We need to include stdlib.h and malloc.h to use malloc()/free() but they aren't included in src/string.c with WIN32_LEAN_AND_MEAN. It generates build time warnings.

We can solve this by including stdlib.h and malloc.h explicitly or use mrb_malloc()/mrb_free() instead of malloc()/free(). This change uses the latter to use our allocation functions.

But this breaks backward compatibility.