### PR TITLE
Include headers for malloc() explicitly; fix #6277

### DIFF
--- a/src/string.c
+++ b/src/string.c
@@ -6,6 +6,7 @@
 
 #ifdef _MSC_VER
 # define _CRT_NONSTDC_NO_DEPRECATE
+# define WIN32_LEAN_AND_MEAN
 #endif
 
 #include <mruby.h>
@@ -840,6 +841,8 @@ str_rindex(mrb_state *mrb, mrb_value str, mrb_value sub, mrb_int pos)
 }
 
 #ifdef _WIN32
+#include <stdlib.h>
+#include <malloc.h>
 #include <windows.h>
 
 char*


### PR DESCRIPTION
We need to include stdlib.h and malloc.h to use malloc()/free() but they aren't included in src/string.c with WIN32_LEAN_AND_MEAN. It generates build time warnings.

We can solve this by including stdlib.h and malloc.h explicitly.