### PR TITLE
Remove `MRB_ENV_CLOSED` flag

### DIFF
--- a/include/mruby/proc.h
+++ b/include/mruby/proc.h
@@ -26,16 +26,15 @@ MRB_BEGIN_DECL
 struct REnv {
   MRB_OBJECT_HEADER;
   mrb_value *stack;
-  struct mrb_context *cxt;
+  struct mrb_context *cxt; /* if not null, it means that the stack is shared with the call frame */
   mrb_sym mid;
 };
 
-/* flags (21bits): 1(close):1(touched):1(heap):8(cioff/bidx):8(stack_len) */
+/* flags (21bits): 5(ZERO):8(cioff/bidx):8(stack_len) */
 #define MRB_ENV_SET_LEN(e,len) ((e)->flags = (((e)->flags & ~0xff)|((unsigned int)(len) & 0xff)))
 #define MRB_ENV_LEN(e) ((mrb_int)((e)->flags & 0xff))
-#define MRB_ENV_CLOSED (1<<20)
-#define MRB_ENV_CLOSE(e) ((e)->flags |= MRB_ENV_CLOSED)
-#define MRB_ENV_ONSTACK_P(e) (((e)->flags & MRB_ENV_CLOSED) == 0)
+#define MRB_ENV_CLOSE(e) ((e)->cxt = NULL)
+#define MRB_ENV_ONSTACK_P(e) ((e)->cxt != NULL)
 #define MRB_ENV_BIDX(e) (((e)->flags >> 8) & 0xff)
 #define MRB_ENV_SET_BIDX(e,idx) ((e)->flags = (((e)->flags & ~(0xff<<8))|((unsigned int)(idx) & 0xff)<<8))
 

--- a/mrbgems/mruby-binding/src/binding.c
+++ b/mrbgems/mruby-binding/src/binding.c
@@ -92,7 +92,6 @@ binding_env_new_lvspace(mrb_state *mrb, const struct REnv *e)
 {
   struct REnv *env = MRB_OBJ_ALLOC(mrb, MRB_TT_ENV, NULL);
   mrb_value *stacks = (mrb_value*)mrb_calloc(mrb, 1, sizeof(mrb_value));
-  env->cxt = e ? e->cxt : mrb->c;
   env->mid = 0;
   env->stack = stacks;
   if (e && e->stack && MRB_ENV_LEN(e) > 0) {
@@ -101,7 +100,6 @@ binding_env_new_lvspace(mrb_state *mrb, const struct REnv *e)
   else {
     env->stack[0] = mrb_nil_value();
   }
-  env->flags = MRB_ENV_CLOSED;
   MRB_ENV_SET_LEN(env, 1);
   return env;
 }

--- a/src/vm.c
+++ b/src/vm.c
@@ -390,8 +390,6 @@ fiber_terminate(mrb_state *mrb, struct mrb_context *c, mrb_callinfo *ci)
     mrb_free(mrb, stack);
   }
   else {
-    env->cxt = NULL;
-
     size_t len = (size_t)MRB_ENV_LEN(env);
     if (len == 0) {
       env->stack = NULL;
@@ -429,8 +427,6 @@ mrb_env_unshare(mrb_state *mrb, struct REnv *e, mrb_bool noraise)
 {
   if (e == NULL) return TRUE;
   if (!MRB_ENV_ONSTACK_P(e)) return TRUE;
-
-  e->cxt = NULL; /* make possible to GC the fiber that generated the env */
 
   size_t len = (size_t)MRB_ENV_LEN(e);
   if (len == 0) {


### PR DESCRIPTION
Set `env->cxt` to `NULL` when it is detached from the call frame. In other words, we can determine if `env->cxt` is `NULL` or not.

Also, `mruby-binding` had been setting `env->cxt` unnecessarily, so this has been fixed.