### PR TITLE
Delegate the care of a directly given block from `cipop()` to `cipush()`

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -176,9 +176,9 @@ typedef struct {
   uint8_t n:4;                  /* (15=*) c=n|nk<<4 */
   uint8_t nk:4;                 /* (15=*) */
   uint8_t cci;                  /* called from C function */
+  uint8_t flags;                /* MRB_CI_COMPANION_BLOCK or zero */
   mrb_sym mid;
   const struct RProc *proc;
-  struct RProc *blk;
   mrb_value *stack;
   const mrb_code *pc;           /* current address on iseq of this proc */
   union {

--- a/include/mruby/internal.h
+++ b/include/mruby/internal.h
@@ -195,6 +195,9 @@ mrb_value mrb_obj_instance_eval(mrb_state*, mrb_value);
 mrb_value mrb_mod_module_eval(mrb_state*, mrb_value);
 mrb_value mrb_f_send(mrb_state *mrb, mrb_value self);
 
+/* mrb_callinfo::flags */
+#define MRB_CI_COMPANION_BLOCK  0x01    /* it means `method { ... }`, not `method(&blk)` */
+
 #ifdef MRB_USE_BIGINT
 mrb_value mrb_bint_new_int(mrb_state *mrb, mrb_int x);
 #ifdef MRB_INT64

--- a/src/vm.c
+++ b/src/vm.c
@@ -360,9 +360,15 @@ cipush(mrb_state *mrb, mrb_int push_stacks, uint8_t cci, struct RClass *target_c
     c->ciend = c->cibase + size * 2;
   }
   ci = ++c->ci;
+  ci->flags = 0;
+  if (blk && (blk->flags & (MRB_PROC_CFUNC_FL | MRB_PROC_ENVSET | MRB_PROC_ORPHAN)) == MRB_PROC_ENVSET &&
+      blk->e.env == ci[-1].u.env) {
+    mrb_assert(blk->color != MRB_GC_RED); // no exist red object with env set
+    ci->flags = MRB_CI_COMPANION_BLOCK;
+    ((struct RProc*)blk)->flags |= MRB_PROC_ORPHAN;
+  }
   ci->mid = mid;
   CI_PROC_SET(ci, proc);
-  ci->blk = blk;
   ci->stack = ci[-1].stack + push_stacks;
   ci->n = argc & 0xf;
   ci->nk = (argc>>4) & 0xf;
@@ -474,11 +480,6 @@ cipop(mrb_state *mrb)
   struct REnv *env = CI_ENV(ci);
 
   ci_env_set(ci, NULL); // make possible to free env by GC if not needed
-  struct RProc *b = ci->blk;
-  if (b && !mrb_object_dead_p(mrb, (struct RBasic*)b) && b->tt == MRB_TT_PROC &&
-      !MRB_PROC_STRICT_P(b) && MRB_PROC_ENV(b) == CI_ENV(&ci[-1])) {
-    b->flags |= MRB_PROC_ORPHAN;
-  }
   if (env && !mrb_env_unshare(mrb, env, TRUE)) {
     c->ci--; // exceptions are handled at the method caller; see #3087
     mrb_exc_raise(mrb, mrb_obj_value(mrb->nomem_err));
@@ -2305,14 +2306,27 @@ RETRY_TRY_BLOCK:
       }
 
       if (MRB_PROC_STRICT_P(proc)) goto NORMAL_RETURN;
-      if (MRB_PROC_ORPHAN_P(proc) || !MRB_PROC_ENV_P(proc) || !MRB_ENV_ONSTACK_P(MRB_PROC_ENV(proc))) {
+      if (!MRB_PROC_ENV_P(proc)) {
       L_BREAK_ERROR:
         RAISE_LIT(mrb, E_LOCALJUMP_ERROR, "break from proc-closure");
       }
       else {
         struct REnv *e = MRB_PROC_ENV(proc);
 
-        if (e->cxt != mrb->c) {
+        if (!MRB_ENV_ONSTACK_P(e) || e->cxt != mrb->c) {
+          goto L_BREAK_ERROR;
+        }
+
+        mrb_callinfo *birth_ci = mrb->c->ci - 1;
+        for (; birth_ci >= mrb->c->cibase; birth_ci--) {
+          if (e == birth_ci->u.env) {
+            if (!(birth_ci[1].flags & MRB_CI_COMPANION_BLOCK)) {
+              goto L_BREAK_ERROR;
+            }
+            break;
+          }
+        }
+        if (birth_ci < mrb->c->cibase) {
           goto L_BREAK_ERROR;
         }
       }


### PR DESCRIPTION
Outlines:
  - Removed `mrb_callinfo::blk`
  - Added `mrb_callinfo::flags`
  - Added `MRB_CI_COMPANION_BLOCK` flag

---

Evaluation of `benchmark/` by `valgrind --tool=cachegrind`.

| ref | commit hash
| --- | ---
| 3.2.0 | 87260e7bb1a9edfb2ce9b41549c4142129061ca5
| 3.3.0 | 32279e4128527bab4c961854b9cce727a060abea
| master | 0a11af74f46f3dadf7a63c18350582f56967897f
| This PR | ad2e626e7a937fb4de9a1647aa58ea45aa3936ec

The first half is the result of building with `gcc13 -O3` and the second half with `gcc13 -Os`.

```
###  cachegrind.report.bm_ao_render.rb (-O3)  ###
         52,089,700,230 (100.0%)  PROGRAM TOTALS  /var/tmp/mruby/-O3/87260e7bb1a9edfb2ce9b41549c4142129061ca5
         51,181,880,488 (100.0%)  PROGRAM TOTALS  /var/tmp/mruby/-O3/32279e4128527bab4c961854b9cce727a060abea
         49,868,402,004 (100.0%)  PROGRAM TOTALS  /var/tmp/mruby/-O3/0a11af74f46f3dadf7a63c18350582f56967897f
         49,142,003,384 (100.0%)  PROGRAM TOTALS  /var/tmp/mruby/-O3/ad2e626e7a937fb4de9a1647aa58ea45aa3936ec
###  cachegrind.report.bm_app_lc_fizzbuzz.rb (-O3)  ###
        113,142,773,218 (100.0%)  PROGRAM TOTALS  /var/tmp/mruby/-O3/87260e7bb1a9edfb2ce9b41549c4142129061ca5
        109,835,348,760 (100.0%)  PROGRAM TOTALS  /var/tmp/mruby/-O3/32279e4128527bab4c961854b9cce727a060abea
        111,130,342,606 (100.0%)  PROGRAM TOTALS  /var/tmp/mruby/-O3/0a11af74f46f3dadf7a63c18350582f56967897f
        109,632,457,055 (100.0%)  PROGRAM TOTALS  /var/tmp/mruby/-O3/ad2e626e7a937fb4de9a1647aa58ea45aa3936ec
###  cachegrind.report.bm_fib.rb (-O3)  ###
         40,929,715,169 (100.0%)  PROGRAM TOTALS  /var/tmp/mruby/-O3/87260e7bb1a9edfb2ce9b41549c4142129061ca5
         40,577,677,322 (100.0%)  PROGRAM TOTALS  /var/tmp/mruby/-O3/32279e4128527bab4c961854b9cce727a060abea
         40,969,219,903 (100.0%)  PROGRAM TOTALS  /var/tmp/mruby/-O3/0a11af74f46f3dadf7a63c18350582f56967897f
         40,031,097,122 (100.0%)  PROGRAM TOTALS  /var/tmp/mruby/-O3/ad2e626e7a937fb4de9a1647aa58ea45aa3936ec
###  cachegrind.report.bm_so_lists.rb (-O3)  ###
          8,522,235,407 (100.0%)  PROGRAM TOTALS  /var/tmp/mruby/-O3/87260e7bb1a9edfb2ce9b41549c4142129061ca5
          7,631,663,865 (100.0%)  PROGRAM TOTALS  /var/tmp/mruby/-O3/32279e4128527bab4c961854b9cce727a060abea
          7,727,386,309 (100.0%)  PROGRAM TOTALS  /var/tmp/mruby/-O3/0a11af74f46f3dadf7a63c18350582f56967897f
          7,541,325,048 (100.0%)  PROGRAM TOTALS  /var/tmp/mruby/-O3/ad2e626e7a937fb4de9a1647aa58ea45aa3936ec

-----

###  cachegrind.report.bm_ao_render.rb (-Os)  ###
         74,225,703,810 (100.0%)  PROGRAM TOTALS  /var/tmp/mruby/-Os/87260e7bb1a9edfb2ce9b41549c4142129061ca5
         73,476,286,317 (100.0%)  PROGRAM TOTALS  /var/tmp/mruby/-Os/32279e4128527bab4c961854b9cce727a060abea
         72,352,438,226 (100.0%)  PROGRAM TOTALS  /var/tmp/mruby/-Os/0a11af74f46f3dadf7a63c18350582f56967897f
         71,751,683,217 (100.0%)  PROGRAM TOTALS  /var/tmp/mruby/-Os/ad2e626e7a937fb4de9a1647aa58ea45aa3936ec
###  cachegrind.report.bm_app_lc_fizzbuzz.rb (-Os)  ###
        152,467,661,758 (100.0%)  PROGRAM TOTALS  /var/tmp/mruby/-Os/87260e7bb1a9edfb2ce9b41549c4142129061ca5
        152,848,538,722 (100.0%)  PROGRAM TOTALS  /var/tmp/mruby/-Os/32279e4128527bab4c961854b9cce727a060abea
        152,391,614,189 (100.0%)  PROGRAM TOTALS  /var/tmp/mruby/-Os/0a11af74f46f3dadf7a63c18350582f56967897f
        151,519,743,117 (100.0%)  PROGRAM TOTALS  /var/tmp/mruby/-Os/ad2e626e7a937fb4de9a1647aa58ea45aa3936ec
###  cachegrind.report.bm_fib.rb (-Os)  ###
         60,395,889,742 (100.0%)  PROGRAM TOTALS  /var/tmp/mruby/-Os/87260e7bb1a9edfb2ce9b41549c4142129061ca5
         61,333,665,848 (100.0%)  PROGRAM TOTALS  /var/tmp/mruby/-Os/32279e4128527bab4c961854b9cce727a060abea
         61,412,528,682 (100.0%)  PROGRAM TOTALS  /var/tmp/mruby/-Os/0a11af74f46f3dadf7a63c18350582f56967897f
         60,787,116,179 (100.0%)  PROGRAM TOTALS  /var/tmp/mruby/-Os/ad2e626e7a937fb4de9a1647aa58ea45aa3936ec
###  cachegrind.report.bm_so_lists.rb (-Os)  ###
         12,963,015,554 (100.0%)  PROGRAM TOTALS  /var/tmp/mruby/-Os/87260e7bb1a9edfb2ce9b41549c4142129061ca5
         11,787,324,255 (100.0%)  PROGRAM TOTALS  /var/tmp/mruby/-Os/32279e4128527bab4c961854b9cce727a060abea
         11,823,083,270 (100.0%)  PROGRAM TOTALS  /var/tmp/mruby/-Os/0a11af74f46f3dadf7a63c18350582f56967897f
         11,619,017,677 (100.0%)  PROGRAM TOTALS  /var/tmp/mruby/-Os/ad2e626e7a937fb4de9a1647aa58ea45aa3936ec
```
