### PR TITLE
Simplify `uvenv()`

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -231,17 +231,6 @@ uvenv(mrb_state *mrb, mrb_int up)
   }
   e = MRB_PROC_ENV(proc);
   if (e) return e;              /* proc has enclosed env */
-  else {
-    mrb_callinfo *ci = mrb->c->ci;
-    mrb_callinfo *cb = mrb->c->cibase;
-
-    while (cb <= ci) {
-      if (ci->proc == proc) {
-        return mrb_vm_ci_env(ci);
-      }
-      ci--;
-    }
-  }
   return NULL;
 }
 


### PR DESCRIPTION
The part removed in this patch was introduced by commit c7c9543bed57db12fd8aa57391e0b652ee27cb23.

The current mechanism should be able to trace from block objects created by `eval` to higher level blocks without any problems.