### PR TITLE
Allow to change the output directory name of the `libmruby` file

### DIFF
--- a/build_config/default.rb
+++ b/build_config/default.rb
@@ -73,6 +73,9 @@ MRuby::Build.new do |conf|
   # file separator
   # conf.file_separator = '/'
 
+  # change library directory name from the default "lib" if necessary
+  # conf.libdir_name = 'lib64'
+
   # Turn on `enable_debug` for better debugging
   # conf.enable_debug
   conf.enable_bintest

--- a/doc/guides/compile.md
+++ b/doc/guides/compile.md
@@ -117,6 +117,36 @@ set the character via `conf.file_separator`.
 conf.file_separator = '/'
 ```
 
+### Name of library directory
+
+In some environments, the `libmruby.a` file requires a different directory name than `lib`.
+You can be changed to any name by the `conf.libdir_name` accessor.
+
+```ruby
+conf.libdir_name = 'lib64'
+```
+
+Alternatively, it can be changed via the environment variable `MRUBY_SYSTEM_LIBDIR_NAME` when
+the `rake` command is run.
+
+```console
+$ export MRUBY_SYSTEM_LIBDIR_NAME=lib64
+$ rake clean all
+```
+
+NOTES:
+
+- This environment variable `MRUBY_SYSTEM_LIBDIR_NAME` does not affect `MRuby::CrossBuild`.
+  In other words, if you want to change it for `MRuby::CrossBuild`, you must set it with `MRuby::CrossBuild#libdir_name=`.
+- If you want to switch this environment variable `MRUBY_SYSTEM_LIBDIR_NAME`, you must do `rake clean`.
+
+  A bad usage example is shown below.
+
+  ```console
+  $ rake clean all
+  $ rake MRUBY_SYSTEM_LIBDIR_NAME=lib64 install
+  ```
+
 ### C Compiler
 
 Configuration of the C compiler binary, flags and include paths.

--- a/lib/mruby/build.rb
+++ b/lib/mruby/build.rb
@@ -75,7 +75,7 @@ module MRuby
 
     include Rake::DSL
     include LoadGems
-    attr_accessor :name, :bins, :exts, :file_separator, :build_dir, :gem_clone_dir, :defines
+    attr_accessor :name, :bins, :exts, :file_separator, :build_dir, :gem_clone_dir, :defines, :libdir_name
     attr_reader :products, :libmruby_core_objs, :libmruby_objs, :gems, :toolchains, :presym, :mrbc_build, :gem_dir_to_repo_url
 
     alias libmruby libmruby_objs
@@ -101,6 +101,7 @@ module MRuby
         @file_separator = '/'
         @build_dir = "#{build_dir}/#{@name}"
         @gem_clone_dir = "#{build_dir}/repos/#{@name}"
+        @libdir_name = (self.kind_of?(MRuby::CrossBuild) ? nil : ENV["MRUBY_SYSTEM_LIBDIR_NAME"]) || "lib"
         @install_prefix = nil
         @defines = []
         @cc = Command::Compiler.new(self, %w(.c), label: "CC")
@@ -490,11 +491,11 @@ EOS
     end
 
     def libmruby_static
-      libfile("#{build_dir}/lib/libmruby")
+      libfile("#{build_dir}/#{libdir_name}/libmruby")
     end
 
     def libmruby_core_static
-      libfile("#{build_dir}/lib/libmruby_core")
+      libfile("#{build_dir}/#{libdir_name}/libmruby_core")
     end
 
     def libraries

--- a/mrbgems/mruby-bin-config/mrbgem.rake
+++ b/mrbgems/mruby-bin-config/mrbgem.rake
@@ -22,7 +22,7 @@ MRuby::Gem::Specification.new('mruby-bin-config') do |spec|
 
   mruby_config = name + suffix
   mruby_config_path = "#{mruby_config_dir}/#{mruby_config}"
-  make_cfg = "#{build.build_dir}/lib/libmruby.flags.mak"
+  make_cfg = "#{build.build_dir}/#{build.libdir_name}/libmruby.flags.mak"
   tmplt_path = "#{__dir__}/#{mruby_config}"
 
   if iscross

--- a/tasks/install.rake
+++ b/tasks/install.rake
@@ -18,7 +18,7 @@ MRuby.each_target do |build|
   task "install:full" => "install:full:#{build.name}"
 
   task "install:full:#{build.name}" => "install:bin:#{build.name}" do
-    Dir.glob(File.join(build.build_dir.gsub(/[\[\{\*\?]/, "\\\0"), "{include,lib}/**/*")) do |path|
+    Dir.glob(File.join(build.build_dir.gsub(/[\[\{\*\?]/, "\\\0"), "{include,#{libdir_name}}/**/*")) do |path|
       install_D path, File.join(prefix, path.relative_path_from(build.build_dir)) if File.file? path
     end
   end

--- a/tasks/libmruby.rake
+++ b/tasks/libmruby.rake
@@ -36,7 +36,7 @@ MRuby.each_target do
     end
   end
 
-  file "#{build_dir}/lib/libmruby.flags.mak" => [__FILE__, libmruby_static] do |t|
+  file "#{build_dir}/#{libdir_name}/libmruby.flags.mak" => [__FILE__, libmruby_static] do |t|
     mkdir_p File.dirname t.name
     open(t.name, 'w') do |f|
       f.puts <<~FLAGS_MAKE
@@ -73,7 +73,7 @@ MRuby.each_target do
       libgems = gems.reject{|g| g.bin?}
       gem_flags = libgems.map {|g| g.linker.flags }
       gem_library_paths = libgems.map {|g| g.linker.library_paths }
-      f.puts "MRUBY_LDFLAGS = #{linker.all_flags(gem_library_paths, gem_flags)} #{linker.option_library_path % "$(MRUBY_PACKAGE_DIR)/lib"}"
+      f.puts "MRUBY_LDFLAGS = #{linker.all_flags(gem_library_paths, gem_flags)} #{linker.option_library_path % "$(MRUBY_PACKAGE_DIR)/#{libdir_name}"}"
 
       gem_flags_before_libraries = libgems.map {|g| g.linker.flags_before_libraries }
       f.puts "MRUBY_LDFLAGS_BEFORE_LIBS = #{[linker.flags_before_libraries, gem_flags_before_libraries].flatten.join(' ')}"


### PR DESCRIPTION
Add the `MRuby::Build#libdir_name` accessor and the `MRUBY_SYSTEM_LIBDIR_NAME` environment variable.

Resolved #6240

---

I was thinking too hard when I commented on #6240.
This PR limits the modification of `lib/` to the build task (as described in the documentation).
