### PR TITLE
Optimise `mrb_iv_get`

### DIFF
--- a/include/mruby/boxing_nan.h
+++ b/include/mruby/boxing_nan.h
@@ -98,6 +98,16 @@ mrb_type(mrb_value o)
   }
 }
 
+MRB_INLINE enum mrb_vtype
+mrb_unboxed_type(mrb_value o)
+{
+  if (!mrb_float_p(o) && mrb_nb_tt(o) == MRB_NANBOX_TT_OBJECT && o.u != 0) {
+    return ((struct RBasic*)(uintptr_t)o.u)->tt;
+  } else {
+    return MRB_TT_FALSE;
+  }
+}
+
 #define NANBOX_SET_MISC_VALUE(r,t,i) NANBOX_SET_VALUE(r, MRB_NANBOX_TT_MISC, ((uint64_t)(t)<<32) | (i))
 
 #define mrb_float(o) mrb_nan_boxing_value_float(o)

--- a/include/mruby/boxing_no.h
+++ b/include/mruby/boxing_no.h
@@ -26,15 +26,16 @@ typedef struct mrb_value {
   enum mrb_vtype tt;
 } mrb_value;
 
-#define mrb_ptr(o)      (o).value.p
-#define mrb_cptr(o)     mrb_ptr(o)
+#define mrb_ptr(o)          (o).value.p
+#define mrb_cptr(o)         mrb_ptr(o)
 #ifndef MRB_NO_FLOAT
-#define mrb_float(o)    (o).value.f
+#define mrb_float(o)        (o).value.f
 #endif
-#define mrb_fixnum(o)   (o).value.i
-#define mrb_integer(o)  mrb_fixnum(o)
-#define mrb_symbol(o)   (o).value.sym
-#define mrb_type(o)     (o).tt
+#define mrb_fixnum(o)       (o).value.i
+#define mrb_integer(o)      mrb_fixnum(o)
+#define mrb_symbol(o)       (o).value.sym
+#define mrb_type(o)         (o).tt
+#define mrb_unboxed_type(o) (o).tt
 
 #define BOXNIX_SET_VALUE(o, ttt, attr, v) do {\
   (o).tt = ttt;\

--- a/include/mruby/boxing_word.h
+++ b/include/mruby/boxing_word.h
@@ -228,4 +228,17 @@ mrb_type(mrb_value o)
          mrb_val_union(o).bp->tt;
 }
 
+MRB_INLINE enum mrb_vtype
+mrb_unboxed_type(mrb_value o)
+{
+  if (mrb_nil_p(o)) {
+    return MRB_TT_FALSE;
+  } else if ((o.w & WORDBOX_IMMEDIATE_MASK) == 0) {
+    return mrb_val_union(o).bp->tt;
+  } else {
+    return MRB_TT_FALSE;
+  }
+}
+
+
 #endif  /* MRUBY_BOXING_WORD_H */

--- a/include/mruby/value.h
+++ b/include/mruby/value.h
@@ -143,16 +143,16 @@ static const unsigned int IEEE754_INFINITY_BITS_SINGLE = 0x7F800000;
   f(MRB_TT_OBJECT,      struct RObject,     "Object") \
   f(MRB_TT_CLASS,       struct RClass,      "Class") \
   f(MRB_TT_MODULE,      struct RClass,      "Module") \
-  f(MRB_TT_ICLASS,      struct RClass,      "iClass") \
   f(MRB_TT_SCLASS,      struct RClass,      "SClass") \
+  f(MRB_TT_HASH,        struct RHash,       "Hash") \
+  f(MRB_TT_CDATA,       struct RData,       "C data") \
+  f(MRB_TT_EXCEPTION,   struct RException,  "Exception") \
+  f(MRB_TT_ICLASS,      struct RClass,      "iClass") \
   f(MRB_TT_PROC,        struct RProc,       "Proc") \
   f(MRB_TT_ARRAY,       struct RArray,      "Array") \
-  f(MRB_TT_HASH,        struct RHash,       "Hash") \
   f(MRB_TT_STRING,      struct RString,     "String") \
   f(MRB_TT_RANGE,       struct RRange,      "Range") \
-  f(MRB_TT_EXCEPTION,   struct RException,  "Exception") \
   f(MRB_TT_ENV,         struct REnv,        "env") \
-  f(MRB_TT_CDATA,       struct RData,       "C data") \
   f(MRB_TT_FIBER,       struct RFiber,      "Fiber") \
   f(MRB_TT_STRUCT,      struct RArray,      "Struct") \
   f(MRB_TT_ISTRUCT,     struct RIStruct,    "istruct") \

--- a/src/variable.c
+++ b/src/variable.c
@@ -282,7 +282,7 @@ mrb_vm_special_set(mrb_state *mrb, mrb_sym i, mrb_value v)
 static mrb_bool
 obj_iv_p(mrb_value obj)
 {
-  switch (mrb_type(obj)) {
+  switch (mrb_unboxed_type(obj)) {
     case MRB_TT_OBJECT:
     case MRB_TT_CLASS:
     case MRB_TT_MODULE:


### PR DESCRIPTION
After Baltic Ruby and getting to talk to people about mruby there I decided to put some work in and started looking at how I could contribute to the project!

I started running optcarrot to find easy to fix perfomance issues in the profiler, and managed to make `mrb_iv_get` about 20% faster which in total speeds up that particular benchmark by about 2% on my M2 Mac Mini with only minor code changes. But since that code path should be hot in most cases it is probably worth it?

The two core changes are as follows

 1. Rearrange `MRB_VTYPE_FOREACH` so that the compiler can convert `obj_iv_p` into a range check, this seems to be the only place where this makes a big difference to performance so it felt worth it.
 2. Make a special variant of `mrb_type` for use in `obj_iv_p` that ignores boxed types since they cannot have instance variables anyhow.

I am not sure if `mrb_unboxed_type` is a good name though, I feel like it isn't but it might be good enough?

There are small gains with NaN boxing too, but they are a bit smaller.

# Before patches, word boxing (M2 Mac Mini, macOS 14.5) #

## Five normal runs ##

fps: 32.9310863275488
fps: 32.9696898237091
fps: 32.9290379935791
fps: 32.9442253316467
fps: 32.930724759119

## Three instrumented runs ##

The performance counters from Instruments here are not very useful to be honest but I included them since I pulled them out anyhow. Note that the percentages are the percentage of the total in the entire run.

| Total             | Self      | Cycles             | L1D Load Miss   | L1D Store Miss  | Branch miss     | Load µops           | Dispatch stall    | Symbol     |
| ----------------- | --------- | ------------------ | --------------- | --------------- | --------------- | ------------------- | ----------------- | ---------- |
| 1.01 s      14.0%	| 256.00 ms | 2965530328   14.0% | 1332376    3.5% | 1214577    4.3% | 5951241   13.6% |	4637217163   14.3% | 262544997   12.2% | mrb_iv_get |
| 961.00 ms   13.1%	| 273.00 ms | 2709470377   12.7% | 1175692    3.1% | 1239348    4.3% | 5471383   12.6% |	4259931402   13.1% | 283538200   12.0% | mrb_iv_get |
| 1.04 s      14.5%	| 260.00 ms | 3026314990   14.5% | 1106310    2.9% | 1104159    3.9% | 6374836   14.6% |	4780069212   14.9% | 247543986   12.2% | mrb_iv_get |

# After patches about 2% faster, word boxing (M2 Mac Mini, macOS 14.5) #

## Five normal runs ##

fps: 33.4577465475324
fps: 33.3409894683935
fps: 33.3799416005552
fps: 33.142213293828
fps: 33.2542619427094

## Three instrumented runs ##

| Total             | Self      | Cycles             | L1D Load Miss   | L1D Store Miss  | Branch miss     | Load µops           | Dispatch stall    | Symbol     |
| ----------------- | --------- | ------------------ | --------------- | --------------- | --------------- | ------------------- | ----------------- | ---------- |
| 797.00 ms   11.1%	| 797.00 ms |	2263684364   11.4% | 955245    2.8%	 | 913663    3.5%	 | 4727932   11.4% | 3629954349   11.8%	 | 237139177   10.4% | mrb_iv_get |
| 796.00 ms   11.2%	| 796.00 ms |	2280738010   10.8% | 969872    2.5%	 | 817803    2.9%	 | 4908663   11.0% | 3653639613   11.1%	 | 234380474    9.8% | mrb_iv_get |
| 799.00 ms   11.2%	| 799.00 ms |	2277257603   11.0% | 887822    2.3%	 | 812048    2.8%	 | 4803468   10.8% | 3663173470   11.3%	 | 226641653    9.7% | mrb_iv_get |

Ps. Thanks everyone for the cool work on mruby!