### PR TITLE
Revert "Delegate the care of a directly given block from `cipop()` to `cipush()`"

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -176,9 +176,9 @@ typedef struct {
   uint8_t n:4;                  /* (15=*) c=n|nk<<4 */
   uint8_t nk:4;                 /* (15=*) */
   uint8_t cci;                  /* called from C function */
-  uint8_t flags;                /* MRB_CI_COMPANION_BLOCK or zero */
   mrb_sym mid;
   const struct RProc *proc;
+  struct RProc *blk;
   mrb_value *stack;
   const mrb_code *pc;           /* current address on iseq of this proc */
   union {

--- a/include/mruby/internal.h
+++ b/include/mruby/internal.h
@@ -195,9 +195,6 @@ mrb_value mrb_obj_instance_eval(mrb_state*, mrb_value);
 mrb_value mrb_mod_module_eval(mrb_state*, mrb_value);
 mrb_value mrb_f_send(mrb_state *mrb, mrb_value self);
 
-/* mrb_callinfo::flags */
-#define MRB_CI_COMPANION_BLOCK  0x01    /* it means `method { ... }`, not `method(&blk)` */
-
 #ifdef MRB_USE_BIGINT
 mrb_value mrb_bint_new_int(mrb_state *mrb, mrb_int x);
 #ifdef MRB_INT64


### PR DESCRIPTION
This reverts commit ad2e626e7a937fb4de9a1647aa58ea45aa3936ec.

Because of the changes made by #6282, the following code caused a problem.

```ruby
b = proc { break "BAD!" }
p self.tap { b.call }
# (expected)    => break from proc-closure (LocalJumpError)
# (after #6282) => "BAD!"
```

I revived the `mrb_callinfo::blk` field to fix this, but it did not overcome the following problem.

```ruby
def m(&b); b = b.clone; GC.start; b.call; end
p m { break "OK!" }
# (expected)    => "OK!"
# (revived blk) => break from proc-closure (LocalJumpError)
```

---

<details>
<summary>Patch to revive the `blk` field</summary>

```patch
diff --git a/include/mruby.h b/include/mruby.h
index 490f344ac..552b92e96 100644
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -176,9 +176,9 @@ typedef struct {
   uint8_t n:4;                  /* (15=*) c=n|nk<<4 */
   uint8_t nk:4;                 /* (15=*) */
   uint8_t cci;                  /* called from C function */
-  uint8_t flags;                /* MRB_CI_COMPANION_BLOCK or zero */
   mrb_sym mid;
   const struct RProc *proc;
+  const struct RProc *blk;      /* block object passed directly at method call (weak reference) */
   mrb_value *stack;
   const mrb_code *pc;           /* current address on iseq of this proc */
   union {
diff --git a/include/mruby/internal.h b/include/mruby/internal.h
index d8e81eafe..9f8453eaa 100644
--- a/include/mruby/internal.h
+++ b/include/mruby/internal.h
@@ -195,9 +195,6 @@ mrb_value mrb_obj_instance_eval(mrb_state*, mrb_value);
 mrb_value mrb_mod_module_eval(mrb_state*, mrb_value);
 mrb_value mrb_f_send(mrb_state *mrb, mrb_value self);

-/* mrb_callinfo::flags */
-#define MRB_CI_COMPANION_BLOCK  0x01    /* it means `method { ... }`, not `method(&blk)` */
-
 #ifdef MRB_USE_BIGINT
 mrb_value mrb_bint_new_int(mrb_state *mrb, mrb_int x);
 #ifdef MRB_INT64
diff --git a/src/vm.c b/src/vm.c
index 3a30f65bd..1a5496822 100644
--- a/src/vm.c
+++ b/src/vm.c
@@ -349,13 +349,15 @@ cipush(mrb_state *mrb, mrb_int push_stacks, uint8_t cci, struct RClass *target_c
     c->ciend = c->cibase + size * 2;
   }
   ci = ++c->ci;
-  ci->flags = 0;
   if (blk && (blk->flags & (MRB_PROC_CFUNC_FL | MRB_PROC_ENVSET | MRB_PROC_ORPHAN)) == MRB_PROC_ENVSET &&
       blk->e.env == ci[-1].u.env) {
     mrb_assert(blk->color != MRB_GC_RED); // no exist red object with env set
-    ci->flags = MRB_CI_COMPANION_BLOCK;
+    ci->blk = blk;
     blk->flags |= MRB_PROC_ORPHAN;
   }
+  else {
+    ci->blk = NULL;
+  }
   ci->mid = mid;
   CI_PROC_SET(ci, proc);
   ci->stack = ci[-1].stack + push_stacks;
@@ -2303,11 +2305,12 @@ RETRY_TRY_BLOCK:
         }
       }
       mrb_callinfo *ci = mrb->c->ci;
+      const struct RProc *jumper = proc;
       proc = proc->upper;
       while (mrb->c->cibase < ci && ci[-1].proc != proc) {
         ci--;
       }
-      if (ci == mrb->c->cibase || !(ci->flags & MRB_CI_COMPANION_BLOCK)) {
+      if (ci == mrb->c->cibase || ci->blk != jumper) {
         goto L_BREAK_ERROR;
       }
       c = a; // release the "a" variable, which can handle 32-bit values
```
</details>

<details>
<summary>Patch to add new VM instructions (initial idea for #6282)</summary>

```patch
diff --git a/include/mruby/ops.h b/include/mruby/ops.h
index cda796f08..ba7fd05ee 100644
--- a/include/mruby/ops.h
+++ b/include/mruby/ops.h
@@ -59,10 +59,13 @@ OPCODE(RESCUE,     BB)       /* R[b] = R[a].isa?(R[b]) */
 OPCODE(RAISEIF,    B)        /* raise(R[a]) if R[a] */
 OPCODE(SSEND,      BBB)      /* R[a] = self.send(Syms[b],R[a+1]..,R[a+n+1]:R[a+n+2]..) (c=n|k<<4) */
 OPCODE(SSENDB,     BBB)      /* R[a] = self.send(Syms[b],R[a+1]..,R[a+n+1]:R[a+n+2]..,&R[a+n+2k+1]) */
+OPCODE(SSENDBI,    BBB)      /* R[a] = self.send(Syms[b],R[a+1]..,R[a+n+1]:R[a+n+2]..,&R[a+n+2k+1]) (as block immediate) */
 OPCODE(SEND,       BBB)      /* R[a] = R[a].send(Syms[b],R[a+1]..,R[a+n+1]:R[a+n+2]..) (c=n|k<<4) */
 OPCODE(SENDB,      BBB)      /* R[a] = R[a].send(Syms[b],R[a+1]..,R[a+n+1]:R[a+n+2]..,&R[a+n+2k+1]) */
+OPCODE(SENDBI,     BBB)      /* R[a] = R[a].send(Syms[b],R[a+1]..,R[a+n+1]:R[a+n+2]..,&R[a+n+2k+1]) (as block immediate) */
 OPCODE(CALL,       Z)        /* self.call(*, **, &) (But overlay the current call frame; tailcall) */
 OPCODE(SUPER,      BB)       /* R[a] = super(R[a+1],... ,R[a+b+1]) */
+OPCODE(SUPERBI,    BB)       /* R[a] = super(R[a+1],... ,R[a+b+1]) (as block immediate) */
 OPCODE(ARGARY,     BS)       /* R[a] = argument array (16=m5:r1:m5:d1:lv4) */
 OPCODE(ENTER,      W)        /* arg setup according to flags (23=m5:o5:r1:m5:k5:d1:b1) */
 OPCODE(KEY_P,      BB)       /* R[a] = kdict.key?(Syms[b]) */
diff --git a/include/mruby/proc.h b/include/mruby/proc.h
index aba08c183..a6b4b7c88 100644
--- a/include/mruby/proc.h
+++ b/include/mruby/proc.h
@@ -74,8 +74,6 @@ struct RProc {
 #define MRB_PROC_CFUNC(p) (p)->body.func
 #define MRB_PROC_STRICT 256
 #define MRB_PROC_STRICT_P(p) (((p)->flags & MRB_PROC_STRICT) != 0)
-#define MRB_PROC_ORPHAN 512
-#define MRB_PROC_ORPHAN_P(p) (((p)->flags & MRB_PROC_ORPHAN) != 0)
 #define MRB_PROC_ENVSET 1024
 #define MRB_PROC_ENV_P(p) (((p)->flags & MRB_PROC_ENVSET) != 0)
 #define MRB_PROC_ENV(p) (MRB_PROC_ENV_P(p) ? (p)->e.env : NULL)
diff --git a/mrbgems/mruby-compiler/core/codegen.c b/mrbgems/mruby-compiler/core/codegen.c
index 7e5351e64..ad92203ed 100644
--- a/mrbgems/mruby-compiler/core/codegen.c
+++ b/mrbgems/mruby-compiler/core/codegen.c
@@ -1716,7 +1716,7 @@ static void
 gen_call(codegen_scope *s, node *tree, int val, int safe)
 {
   mrb_sym sym = nsym(tree->cdr->car);
-  int skip = 0, n = 0, nk = 0, noop = no_optimize(s), noself = 0, blk = 0, sp_save = cursp();
+  int skip = 0, n = 0, nk = 0, noop = no_optimize(s), noself = 0, op = OP_SSEND, sp_save = cursp();

   if (!tree->car) {
     noself = noop = 1;
@@ -1750,7 +1750,7 @@ gen_call(codegen_scope *s, node *tree, int val, int safe)
     codegen(s, tree->cdr->cdr, VAL);
     pop();
     noop = 1;
-    blk = 1;
+    op = nint(tree->cdr->cdr->car) == NODE_BLOCK_ARG ? OP_SSENDB : OP_SSENDBI;
   }
   push();pop();
   s->sp = sp_save;
@@ -1791,10 +1791,11 @@ gen_call(codegen_scope *s, node *tree, int val, int safe)
     /* constant folding succeeded */
   }
   else if (noself){
-    genop_3(s, blk ? OP_SSENDB : OP_SSEND, cursp(), new_sym(s, sym), n|(nk<<4));
+    genop_3(s, op, cursp(), new_sym(s, sym), n|(nk<<4));
   }
   else {
-    genop_3(s, blk ? OP_SENDB : OP_SEND, cursp(), new_sym(s, sym), n|(nk<<4));
+    op += OP_SEND - OP_SSEND;
+    genop_3(s, op, cursp(), new_sym(s, sym), n|(nk<<4));
   }
   if (safe) {
     dispatch(s, skip);
diff --git a/src/codedump.c b/src/codedump.c
index 556e4f62d..e1774f0dd 100644
--- a/src/codedump.c
+++ b/src/codedump.c
@@ -331,6 +331,10 @@ codedump(mrb_state *mrb, const mrb_irep *irep, FILE *out)
       fprintf(out, "SSENDB\tR%d\t:%s\t", a, mrb_sym_dump(mrb, irep->syms[b]));
       print_args(c, out);
       break;
+    CASE(OP_SSENDBI, BBB):
+      fprintf(out, "SSENDBI\tR%d\t:%s\t", a, mrb_sym_dump(mrb, irep->syms[b]));
+      print_args(c, out);
+      break;
     CASE(OP_SEND, BBB):
       fprintf(out, "SEND\t\tR%d\t:%s\t", a, mrb_sym_dump(mrb, irep->syms[b]));
       print_args(c, out);
@@ -339,6 +343,10 @@ codedump(mrb_state *mrb, const mrb_irep *irep, FILE *out)
       fprintf(out, "SENDB\t\tR%d\t:%s\t", a, mrb_sym_dump(mrb, irep->syms[b]));
       print_args(c, out);
       break;
+    CASE(OP_SENDBI, BBB):
+      fprintf(out, "SENDBI\t\tR%d\t:%s\t", a, mrb_sym_dump(mrb, irep->syms[b]));
+      print_args(c, out);
+      break;
     CASE(OP_CALL, Z):
       fprintf(out, "CALL\n");
       break;
@@ -346,6 +354,10 @@ codedump(mrb_state *mrb, const mrb_irep *irep, FILE *out)
       fprintf(out, "SUPER\t\tR%d\t", a);
       print_args(b, out);
       break;
+    CASE(OP_SUPERBI, BB):
+      fprintf(out, "SUPERBI\t\tR%d\t", a);
+      print_args(b, out);
+      break;
     CASE(OP_ARGARY, BS):
       fprintf(out, "ARGARY\tR%d\t%d:%d:%d:%d (%d)\t", a,
              (b>>11)&0x3f,
diff --git a/src/proc.c b/src/proc.c
index ad177635f..e7d9ba675 100644
--- a/src/proc.c
+++ b/src/proc.c
@@ -250,10 +250,6 @@ mrb_proc_s_new(mrb_state *mrb, mrb_value proc_class)
   mrb_proc_copy(mrb, p, mrb_proc_ptr(blk));
   proc = mrb_obj_value(p);
   mrb_funcall_with_block(mrb, proc, MRB_SYM(initialize), 0, NULL, proc);
-  if (!MRB_PROC_STRICT_P(p) &&
-      mrb->c->ci > mrb->c->cibase && MRB_PROC_ENV(p) == mrb->c->ci[-1].u.env) {
-    p->flags |= MRB_PROC_ORPHAN;
-  }
   return proc;
 }

diff --git a/src/vm.c b/src/vm.c
index 3a30f65bd..b7cf88fad 100644
--- a/src/vm.c
+++ b/src/vm.c
@@ -329,11 +329,9 @@ mrb_vm_ci_env_clear(mrb_state *mrb, mrb_callinfo *ci)
 #define CINFO_DIRECT  2 // called method from C
 #define CINFO_RESUMED 3 // resumed by `Fiber.yield` (probably the main call is `mrb_fiber_resume()`)

-#define BLK_PTR(b) ((mrb_proc_p(b)) ? mrb_proc_ptr(b) : NULL)
-
 static inline mrb_callinfo*
 cipush(mrb_state *mrb, mrb_int push_stacks, uint8_t cci, struct RClass *target_class,
-       const struct RProc *proc, struct RProc *blk, mrb_sym mid, uint16_t argc)
+       const struct RProc *proc, mrb_sym mid, uint16_t argc)
 {
   struct mrb_context *c = mrb->c;
   mrb_callinfo *ci = c->ci;
@@ -349,13 +347,8 @@ cipush(mrb_state *mrb, mrb_int push_stacks, uint8_t cci, struct RClass *target_c
     c->ciend = c->cibase + size * 2;
   }
   ci = ++c->ci;
-  ci->flags = 0;
-  if (blk && (blk->flags & (MRB_PROC_CFUNC_FL | MRB_PROC_ENVSET | MRB_PROC_ORPHAN)) == MRB_PROC_ENVSET &&
-      blk->e.env == ci[-1].u.env) {
-    mrb_assert(blk->color != MRB_GC_RED); // no exist red object with env set
-    ci->flags = MRB_CI_COMPANION_BLOCK;
-    blk->flags |= MRB_PROC_ORPHAN;
-  }
+  const mrb_callinfo ci_zero = { 0 };
+  *ci = ci_zero;
   ci->mid = mid;
   CI_PROC_SET(ci, proc);
   ci->stack = ci[-1].stack + push_stacks;
@@ -722,7 +715,7 @@ mrb_funcall_with_block(mrb_state *mrb, mrb_value self, mrb_sym mid, mrb_int argc
       mrb_exc_raise(mrb, mrb_obj_value(mrb->stack_err));
     }
     blk = ensure_block(mrb, blk);
-    ci = cipush(mrb, n, CINFO_DIRECT, NULL, NULL, BLK_PTR(blk), 0, 0);
+    ci = cipush(mrb, n, CINFO_DIRECT, NULL, NULL, 0, 0);
     funcall_args_capture(mrb, 0, argc, argv, blk, ci);
     ci->u.target_class = mrb_class(mrb, self);
     m = mrb_vm_find_method(mrb, ci->u.target_class, &ci->u.target_class, mid);
@@ -804,7 +797,7 @@ exec_irep(mrb_state *mrb, mrb_value self, const struct RProc *p)
     stack_clear(ci->stack+keep, nregs-keep);
   }

-  cipush(mrb, 0, 0, NULL, NULL, NULL, 0, 0);
+  cipush(mrb, 0, 0, NULL, NULL, 0, 0);

   return self;
 }
@@ -822,7 +815,7 @@ mrb_exec_irep(mrb_state *mrb, mrb_value self, struct RProc *p)
       if (MRB_PROC_NOARG_P(p) && (ci->n > 0 || ci->nk > 0)) {
         check_method_noarg(mrb, ci);
       }
-      cipush(mrb, 0, CINFO_DIRECT, CI_TARGET_CLASS(ci), p, NULL, ci->mid, ci->n|(ci->nk<<4));
+      cipush(mrb, 0, CINFO_DIRECT, CI_TARGET_CLASS(ci), p, ci->mid, ci->n|(ci->nk<<4));
       ret = MRB_PROC_CFUNC(p)(mrb, self);
       cipop(mrb);
     }
@@ -974,7 +967,7 @@ eval_under(mrb_state *mrb, mrb_value self, mrb_value blk, struct RClass *c)
   mrb->c->ci->stack[0] = self;
   mrb->c->ci->stack[1] = self;
   stack_clear(mrb->c->ci->stack+2, nregs-2);
-  cipush(mrb, 0, 0, NULL, NULL, NULL, 0, 0);
+  cipush(mrb, 0, 0, NULL, NULL, 0, 0);

   return self;
 }
@@ -1051,7 +1044,7 @@ mrb_yield_with_class(mrb_state *mrb, mrb_value b, mrb_int argc, const mrb_value
   else {
     mid = ci->mid;
   }
-  ci = cipush(mrb, n, CINFO_DIRECT, NULL, NULL, NULL, mid, 0);
+  ci = cipush(mrb, n, CINFO_DIRECT, NULL, NULL, mid, 0);
   funcall_args_capture(mrb, 0, argc, argv, mrb_nil_value(), ci);
   ci->u.target_class = c;
   ci->proc = p;
@@ -1843,6 +1836,12 @@ RETRY_TRY_BLOCK:
     }
     goto L_SENDB;

+    CASE(OP_SSENDBI, BBB) {
+      regs[a] = regs[0];
+      c |= 0x100;
+    }
+    goto L_SENDB;
+
     CASE(OP_SEND, BBB)
     goto L_SENDB;

@@ -1862,6 +1861,7 @@ RETRY_TRY_BLOCK:
       mrb_value recv, blk;
       int n = c&0xf;
       int nk = (c>>4)&0xf;
+      uint8_t ciflags = c >> 8;
       mrb_int bidx = a + mrb_bidx(n,nk);
       mrb_int new_bidx = bidx;

@@ -1888,7 +1888,7 @@ RETRY_TRY_BLOCK:
         regs[new_bidx] = blk;
       }

-      ci = cipush(mrb, a, CINFO_DIRECT, NULL, NULL, BLK_PTR(blk), 0, c);
+      ci = cipush(mrb, a, CINFO_DIRECT, NULL, NULL, 0, c);
       recv = regs[0];
       ci->u.target_class = (insn == OP_SUPER) ? CI_TARGET_CLASS(ci - 1)->super : mrb_class(mrb, recv);
       m = mrb_vm_find_method(mrb, ci->u.target_class, &ci->u.target_class, mid);
@@ -1898,6 +1898,7 @@ RETRY_TRY_BLOCK:
       else {
         ci->mid = mid;
       }
+      ci->flags = ciflags;
       ci->cci = CINFO_NONE;

       if (MRB_METHOD_PROC_P(m)) {
@@ -1957,6 +1958,11 @@ RETRY_TRY_BLOCK:
       JUMP;
     }

+    CASE(OP_SENDBI, BBB) {
+      c |= 0x100;
+    }
+    goto L_SENDB;
+
     CASE(OP_CALL, Z) {
       mrb_callinfo *ci = mrb->c->ci;
       mrb_value recv = ci->stack[0];
@@ -2028,10 +2034,18 @@ RETRY_TRY_BLOCK:
       }

       c = b; // arg info
+      if (insn == OP_SUPERBI) {
+        insn = OP_SUPER;
+        c |= 0x100;
+      }
       regs[a] = recv;
       goto L_SENDB_SYM;
     }

+    CASE(OP_SUPERBI, BB) {
+      goto L_OP_SUPER_BODY;
+    }
+
     CASE(OP_ARGARY, BS) {
       mrb_int m1 = (b>>11)&0x3f;
       mrb_int r  = (b>>10)&0x1;
@@ -2977,7 +2991,7 @@ RETRY_TRY_BLOCK:
       p->flags |= MRB_PROC_SCOPE;

       /* prepare call stack */
-      cipush(mrb, a, 0, mrb_class_ptr(recv), p, NULL, 0, 0);
+      cipush(mrb, a, 0, mrb_class_ptr(recv), p, 0, 0);

       irep = p->body.irep;
       pool = irep->pool;
@@ -3130,7 +3144,7 @@ MRB_API mrb_value
 mrb_top_run(mrb_state *mrb, const struct RProc *proc, mrb_value self, mrb_int stack_keep)
 {
   if (mrb->c->cibase && mrb->c->ci > mrb->c->cibase) {
-    cipush(mrb, 0, CINFO_SKIP, mrb->object_class, NULL, NULL, 0, 0);
+    cipush(mrb, 0, CINFO_SKIP, mrb->object_class, NULL, 0, 0);
   }
   return mrb_vm_run(mrb, proc, self, stack_keep);
 }
```
</details>
