### PR TITLE
Minor cleanup in mrb_str_init

### DIFF
--- a/src/string.c
+++ b/src/string.c
@@ -1982,8 +1982,7 @@ mrb_str_init(mrb_state *mrb, mrb_value self)
   mrb_value str2;
 
   if (mrb_get_args(mrb, "|S", &str2) == 0) {
-    struct RString *s = str_new(mrb, 0, 0);
-    str2 = mrb_obj_value(s);
+    str2 = mrb_str_new(mrb, 0, 0);
   }
   str_replace(mrb, mrb_str_ptr(self), mrb_str_ptr(str2));
   return self;


### PR DESCRIPTION
This doesn't change any logic, mrb_str_new was manually inlined here and I think it is a bit easier to follow if we just call the function instead.

Feel free to close this if you disagree.