### PR TITLE
Fix wrong column number in opcode.md

### DIFF
--- a/doc/internal/opcode.md
+++ b/doc/internal/opcode.md
@@ -12,7 +12,7 @@ have 106 instructions. Instructions can take 0 to 3 operands.
 ## operands
 
 The size of operands can be either 8bits, 16bits or 24bits.
-In the table.1 below, the second field describes the size
+In the table.1 below, the third field describes the size
 of operands.
 
 - B: 8bit


### PR DESCRIPTION
It seems like a new column was added to the beginning of the table, but the text was not updated accordingly.