### PR TITLE
Optimize even?/odd? for big integers

### DIFF
--- a/mrbgems/mruby-numeric-ext/src/numeric_ext.c
+++ b/mrbgems/mruby-numeric-ext/src/numeric_ext.c
@@ -232,8 +232,8 @@ int_even(mrb_state *mrb, mrb_value self)
 {
 #ifdef MRB_USE_BIGINT
   if (mrb_bigint_p(self)) {
-    mrb_value mod2 = mrb_bint_mod(mrb, self, mrb_fixnum_value(2));
-    if (mrb_integer(mod2) == 0) return mrb_true_value();
+    mrb_value and1 = mrb_bint_and(mrb, self, mrb_fixnum_value(1));
+    if (mrb_integer(and1) == 0) return mrb_true_value();
     return mrb_false_value();
   }
 #endif

--- a/mrbgems/mruby-numeric-ext/test/numeric.rb
+++ b/mrbgems/mruby-numeric-ext/test/numeric.rb
@@ -49,3 +49,29 @@ assert('Integer#ceildiv') do
   assert_equal(-8, (-2).pow(3))
 #  assert_equal(361, 9.pow(1024,1000))
 end
+
+assert('Integer#even?') do
+  assert_true(0.even?)
+  assert_true(2.even?)
+  assert_true(-2.even?)
+  assert_false(1.even?)
+  assert_false(-1.even?)
+
+  # assert_true((10**100).even?)
+  # assert_true((-10**100).even?)
+  # assert_false((10**100+1).even?)
+  # assert_false((-10**100-1).even?)
+end
+
+assert('Integer#odd?') do
+  assert_false(0.odd?)
+  assert_false(2.odd?)
+  assert_false(-2.odd?)
+  assert_true(1.odd?)
+  assert_true(-1.odd?)
+
+  # assert_false((10**100).odd?)
+  # assert_false((-10**100).odd?)
+  # assert_true((10**100+1).odd?)
+  # assert_true((-10**100-1).odd?)
+end


### PR DESCRIPTION
Using mod for big integers leads to poor performance, so I replaced it with bitwise AND.