### PR TITLE
Avoid warnings in `lib/**/*.rb`

### DIFF
--- a/lib/mruby/build/command.rb
+++ b/lib/mruby/build/command.rb
@@ -317,7 +317,7 @@ module MRuby
     end
 
     def commit_hash(dir)
-      `#{@command} --git-dir #{shellquote(dir +'/.git')} --work-tree #{shellquote(dir)} rev-parse --verify HEAD`.strip
+      `#{@command} --git-dir #{shellquote(dir + '/.git')} --work-tree #{shellquote(dir)} rev-parse --verify HEAD`.strip
     end
 
     def current_branch(dir)

--- a/lib/mruby/gem.rb
+++ b/lib/mruby/gem.rb
@@ -465,8 +465,8 @@ module MRuby
         table.instance_variable_set :@root_gems, ary
         class << table
           include TSort
-          def tsort_each_node &b
-            @root_gems.each &b
+          def tsort_each_node(&b)
+            @root_gems.each(&b)
           end
 
           def tsort_each_child(n, &b)


### PR DESCRIPTION
```console
% find -s lib -type f -name '*.rb' -exec ruby -cw {} \;
lib/mruby/build/command.rb:320: warning: `+' after local variable or literal is interpreted as binary operator
lib/mruby/build/command.rb:320: warning: even though it seems like unary operator
Syntax OK
Syntax OK
Syntax OK
Syntax OK
Syntax OK
lib/mruby/gem.rb:469: warning: `&' interpreted as argument prefix
Syntax OK
Syntax OK
Syntax OK
Syntax OK
```