### PR TITLE
Fix mrb_ro_data_p on Intel Mac

### DIFF
--- a/include/mruby/value.h
+++ b/include/mruby/value.h
@@ -446,10 +446,9 @@ mrb_ro_data_p(const char *p)
   struct mach_header *mhp;
 #endif
   mhp = _NSGetMachExecuteHeader();
-  unsigned long textsize, datasize;
+  unsigned long textsize;
   char *text = (char*)getsegmentdata(mhp, SEG_TEXT, &textsize);
-  char *data = (char*)getsegmentdata(mhp, SEG_DATA, &datasize);
-  return text + textsize < p && p < data + datasize;
+  return text <= p && p < text + textsize;
 }
 #endif  /* Linux or macOS */
 #endif  /* MRB_NO_DEFAULT_RO_DATA_P */


### PR DESCRIPTION
It seems that `mrbc` sometimes generates a broken bytecode file on Intel Mac.
After some debugging, I found that the problem is caused by the `mrb_ro_data_p` function.
It sometimes returns false-positive results, which leads to using a released memory area for symbols.
For this reason, some strings in the bytecode file are sometimes broken.
After some investigation, I found that constant strings in macOS are stored in the `__TEXT` segment, so it is probably enough to check that the pointer is in this segment (for some reason, it currently checks if the pointer is after the `_TEXT` segment).

Example:

```ruby
puts "Hello, World!"
```

The debug section of the bytecode is broken (there is no file name):

```
00000000: 5249 5445 3033 3030 0000 007f 4d41 545a  RITE0300....MATZ
00000010: 3030 3030 4952 4550 0000 0042 3033 3030  0000IREP...B0300
00000020: 0000 0036 0001 0004 0000 0000 0000 000a  ...6............
00000030: 5102 002d 0100 0138 0169 0001 0000 0d48  Q..-...8.i.....H
00000040: 656c 6c6f 2c20 576f 726c 6421 0000 0100  ello, World!....
00000050: 0470 7574 7300 4442 4700 0000 0021 0001  .puts.DBG....!..
00000060: 0002 9005 0000 0013 0001 0000 0000 0000  ................
00000070: 0000 0002 0200 0145 4e44 0000 0000 08    .......END.....
```

Expected:

```
00000000: 5249 5445 3033 3030 0000 0081 4d41 545a  RITE0300....MATZ
00000010: 3030 3030 4952 4550 0000 0042 3033 3030  0000IREP...B0300
00000020: 0000 0036 0001 0004 0000 0000 0000 000a  ...6............
00000030: 5102 002d 0100 0138 0169 0001 0000 0d48  Q..-...8.i.....H
00000040: 656c 6c6f 2c20 576f 726c 6421 0000 0100  ello, World!....
00000050: 0470 7574 7300 4442 4700 0000 0023 0001  .puts.DBG....#..
00000060: 0004 312e 7262 0000 0013 0001 0000 0000  ..1.rb..........
00000070: 0000 0000 0002 0200 0145 4e44 0000 0000  .........END....
00000080: 08    
```
