### PR TITLE
fix ncurses linking issues

### DIFF
--- a/mrbgems/mruby-bin-mirb/mrbgem.rake
+++ b/mrbgems/mruby-bin-mirb/mrbgem.rake
@@ -33,6 +33,14 @@ MRuby::Gem::Specification.new('mruby-bin-mirb') do |spec|
       end
       if spec.build.cc.search_header_path 'curses.h'
         spec.linker.libraries << 'ncurses'
+        if spec.build.cc.search_header_path 'term.h'
+          spec.linker.libraries << 'tinfo'
+        end
+      elsif spec.build.cc.search_header_path 'ncursesw/curses.h'
+        spec.linker.libraries << 'ncursesw'
+        if spec.build.cc.search_header_path 'ncursesw/term.h'
+          spec.linker.libraries << 'tinfow'
+        end
       end
     end
   elsif spec.build.cc.search_header_path 'edit/readline/readline.h'


### PR DESCRIPTION
The build configuration for `mruby` assumes only the `ncurses` library needs to be linked because `tinfo` is implicitly pulled in.

In environments where ncurses is available only as a static library, `tinfo` needs to be linked explicitly (needed for functions like `tputs`.

This patch fixes that by linking `tinfo` if available.

It also fixes the build for environments where only the `ncursesw` version of the library (including wide character support) is present, while still giving preference to the `ncurses` version (without wide character support).