### PR TITLE
Fix use-after-free in `obj_free()` for env objects

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -788,7 +788,7 @@ obj_free(mrb_state *mrb, struct RBasic *obj, mrb_bool end)
 
           while (ce <= ci) {
             struct REnv *e = ci->u.env;
-            if (e && !is_dead(&mrb->gc, (struct RBasic*)e) &&
+            if (e && heap_p(&mrb->gc, (struct RBasic*)e) && !is_dead(&mrb->gc, (struct RBasic*)e) &&
                 e->tt == MRB_TT_ENV && MRB_ENV_ONSTACK_P(e)) {
               mrb_env_unshare(mrb, e, TRUE);
             }


### PR DESCRIPTION
A reference to an invalid address might occur in `is_dead()` of `obj_free()` called from `incremental_sweep_phase()`.
This would happen if the heap page was freed ahead of time in the same `incremental_sweep_phase()`.

fixed #6326