### PR TITLE
Need to place static proc objects into 8-byte alignments

### DIFF
--- a/include/mruby/common.h
+++ b/include/mruby/common.h
@@ -59,6 +59,26 @@ MRB_BEGIN_DECL
 # define mrb_deprecated
 #endif
 
+/** Declare a type or object as an alignment requirement. */
+#ifndef mrb_alignas
+# if defined(__cplusplus) && __cplusplus >= 201103L
+#  // https://en.cppreference.com/w/cpp/language/alignas
+#  define mrb_alignas(n) alignas(n)
+# elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
+#  // https://en.cppreference.com/w/c/language/_Alignas
+#  define mrb_alignas(n) _Alignas(n)
+# elif defined(_MSC_VER) || defined(__INTEL_COMPILER)
+#  // https://learn.microsoft.com/en-us/cpp/cpp/align-cpp?view=msvc-170
+#  define mrb_alignas(n) __declspec(align(n))
+# elif defined(__GNUC__) || defined(__clang__)
+#  // https://gcc.gnu.org/onlinedocs/gcc/Common-Type-Attributes.html#index-aligned-type-attribute
+#  define mrb_alignas(n) __attribute__((aligned(n)))
+# else
+#  // `mrb_alignas` defined as dummy. If necessary, send issues to https://github.com/mruby/mruby .
+#  define mrb_alignas(n)
+# endif
+#endif
+
 /** Declare a function as always inlined. */
 #if defined _MSC_VER && _MSC_VER < 1900
 # ifndef __cplusplus

--- a/mrbgems/mruby-catch/src/catch.c
+++ b/mrbgems/mruby-catch/src/catch.c
@@ -37,6 +37,7 @@ static const mrb_irep catch_irep = {
   NULL,
   sizeof(catch_iseq),0,3,0,0
 };
+mrb_alignas(8)
 static const struct RProc catch_proc = {
   NULL, NULL, MRB_TT_PROC, MRB_GC_RED, MRB_FL_OBJ_IS_FROZEN | MRB_PROC_SCOPE | MRB_PROC_STRICT,
   { &catch_irep }, NULL, { NULL }

--- a/src/class.c
+++ b/src/class.c
@@ -2915,6 +2915,7 @@ static const mrb_irep new_irep = {
   sizeof(new_iseq), 0, 2, 0, 0,
 };
 
+mrb_alignas(8)
 static const struct RProc new_proc = {
   NULL, NULL, MRB_TT_PROC, MRB_GC_RED, MRB_FL_OBJ_IS_FROZEN | MRB_PROC_SCOPE | MRB_PROC_STRICT,
   { &new_irep }, NULL, { NULL }

--- a/src/proc.c
+++ b/src/proc.c
@@ -36,6 +36,7 @@ static const mrb_irep call_irep = {
   0,                                   /* refcnt */
 };
 
+mrb_alignas(8)
 static const struct RProc call_proc = {
   NULL, NULL, MRB_TT_PROC, MRB_GC_RED, MRB_FL_OBJ_IS_FROZEN | MRB_PROC_SCOPE | MRB_PROC_STRICT,
   { &call_irep }, NULL, { NULL }


### PR DESCRIPTION
Static proc objects defined as methods may be placed in 4-byte alignments in 32-bit environments.
This may be misinterpreted as an immediate value depending on the address.

Since C11 and C++11 have additional language features for byte alignment, corresponding compilers use them to define the `mrb_alignas()` macro.
For earlier compilers, they use their own extensions to define the `mrb_alignas()` macro.

GCC supports `__attribute__((aligned(alignment)))` since at least version 2.95.3 (1999).
https://gcc.gnu.org/onlinedocs/gcc-2.95.3/gcc_4.html#IDX305
According to GPT-4, support was added in version 2.7 (1995).

It is not known which version of Visual C++ added support for `__declspec(align(n))`.
According to GPT-4, at least Visual C++ 6.0 (1998) seems to support it.
Also, the documentation of past Intel C/C++ compilers that support `__declspec(align(n))` makes reference to support with Visual C++ 4.2 (1996).
https://www.intel.com/content/dam/www/public/ijkk/jp/ja/documents/developer/ccomp40j.pdf

---

I noticed this problem when building mruby for i386 with clang (version 18.1.5) on FreeBSD 14.1 amd64.

Running `bin/mrbtest` crashes due to `SIGSEGV`.
I use gdb because lldb did not track 32-bit binaries well.

  - build configuration file

    ```ruby
    MRuby::Lockfile.disable rescue nil

    MRuby::Build.new do
      toolchain "clang"
    end

    MRuby::Build.new("host32") do
      toolchain "clang"
      enable_debug
      enable_test
      enable_bintest

      [*compilers, linker].each do |bin|
        bin.flags << "-m32"
      end

      gem core: "mruby-eval"
    end
    ```

  - result with gdb

    ```console
    % gdb --args build/host32/bin/mrbtest -v
    GNU gdb (GDB) 14.1 [GDB v14.1 for FreeBSD]
    Copyright (C) 2023 Free Software Foundation, Inc.
    License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
    This is free software: you are free to change and redistribute it.
    There is NO WARRANTY, to the extent permitted by law.
    Type "show copying" and "show warranty" for details.
    This GDB was configured as "x86_64-portbld-freebsd14.0".
    Type "show configuration" for configuration details.
    For bug reporting instructions, please see:
    <https://www.gnu.org/software/gdb/bugs/>.
    Find the GDB manual and other documentation resources online at:
        <http://www.gnu.org/software/gdb/documentation/>.

    For help, type "help".
    Type "apropos word" to search for commands related to "word"...
    Reading symbols from build/host32/bin/mrbtest...
    (gdb) r

    ...SNIP...

    Binding#eval : .
    Binding#local_variables : .
    Binding#local_variable_set : .
    Binding#local_variable_get : .
    Binding#eval with Binding.new via UnboundMethod :
    Program received signal SIGSEGV, Segmentation fault.
    Address not mapped to object.
    0x004b9b3f in mrb_check_type (mrb=0x20a13800, x=..., t=MRB_TT_PROC) at /var/tmp/mruby-56c3d74/src/object.c:404
    404         ename = RSTRING_PTR(mrb_obj_as_string(mrb, x));
    (gdb) p (void *)x.w
    $1 = (void *) 0x4579f4 <new_proc>
    ```
