### PR TITLE
Need to restore the GC arena after some function calls

### DIFF
--- a/mrbgems/mruby-data/src/data.c
+++ b/mrbgems/mruby-data/src/data.c
@@ -366,10 +366,12 @@ mrb_data_equal(mrb_state *mrb, mrb_value s)
   mrb_value *ptr = RDATA_PTR(s);
   mrb_value *ptr2 = RDATA_PTR(s2);
   mrb_int len = RDATA_LEN(s);
+  int ai = mrb_gc_arena_save(mrb);
   for (mrb_int i=0; i<len; i++) {
     if (!mrb_equal(mrb, ptr[i], ptr2[i])) {
       return mrb_false_value();
     }
+    mrb_gc_arena_restore(mrb, ai);
   }
 
   return mrb_true_value();

--- a/mrbgems/mruby-metaprog/src/metaprog.c
+++ b/mrbgems/mruby-metaprog/src/metaprog.c
@@ -624,9 +624,11 @@ mrb_mod_remove_method(mrb_state *mrb, mrb_value mod)
 
   mrb_get_args(mrb, "*", &argv, &argc);
   mrb_check_frozen(mrb, c);
+  int ai = mrb_gc_arena_save(mrb);
   while (argc--) {
     mrb_remove_method(mrb, c, mrb_obj_to_sym(mrb, *argv));
     mrb_funcall_argv(mrb, mod, MRB_SYM(method_removed), 1, argv);
+    mrb_gc_arena_restore(mrb, ai);
     argv++;
   }
   return mod;

--- a/mrbgems/mruby-sprintf/src/sprintf.c
+++ b/mrbgems/mruby-sprintf/src/sprintf.c
@@ -303,6 +303,7 @@ mrb_str_format(mrb_state *mrb, mrb_int argc, const mrb_value *argv, mrb_value fm
   buf = RSTRING_PTR(result);
   memset(buf, 0, bsiz);
 
+  int ai = mrb_gc_arena_save(mrb);
   for (; p < end; p++) {
     const char *t;
     mrb_sym id = 0;
@@ -490,6 +491,7 @@ retry:
           if (width>0) FILL(' ', width-1);
           PUSH(c, n);
         }
+        mrb_gc_arena_restore(mrb, ai);
       }
       break;
 
@@ -536,6 +538,7 @@ retry:
           }
         }
         PUSH(RSTRING_PTR(str), len);
+        mrb_gc_arena_restore(mrb, ai);
       }
       break;
 

--- a/mrbgems/mruby-struct/src/struct.c
+++ b/mrbgems/mruby-struct/src/struct.c
@@ -514,10 +514,12 @@ mrb_struct_equal(mrb_state *mrb, mrb_value s)
   mrb_value *ptr = RSTRUCT_PTR(s);
   mrb_value *ptr2 = RSTRUCT_PTR(s2);
   mrb_int len = RSTRUCT_LEN(s);
+  int ai = mrb_gc_arena_save(mrb);
   for (mrb_int i=0; i<len; i++) {
     if (!mrb_equal(mrb, ptr[i], ptr2[i])) {
       return mrb_false_value();
     }
+    mrb_gc_arena_restore(mrb, ai);
   }
 
   return mrb_true_value();

--- a/src/array.c
+++ b/src/array.c
@@ -313,6 +313,7 @@ mrb_ary_init(mrb_state *mrb, mrb_value ary)
     ary_expand_capa(mrb, a, size);
   }
 
+  int ai = mrb_gc_arena_save(mrb);
   for (mrb_int i=0; i<size; i++) {
     mrb_value val;
     if (mrb_nil_p(blk)) {
@@ -322,6 +323,7 @@ mrb_ary_init(mrb_state *mrb, mrb_value ary)
       val = mrb_funcall_id(mrb, blk, MRB_SYM(call), 1, mrb_fixnum_value(i));
     }
     mrb_ary_set(mrb, ary, i, val);
+    mrb_gc_arena_restore(mrb, ai); // for mrb_funcall
   }
   return ary;
 }
@@ -1440,9 +1442,11 @@ mrb_ary_eq(mrb_state *mrb, mrb_value ary1)
   if (n == 1) return mrb_true_value();
   if (n == 0) return mrb_false_value();
 
+  int ai = mrb_gc_arena_save(mrb);
   for (mrb_int i=0; i<RARRAY_LEN(ary1); i++) {
     mrb_value eq = mrb_funcall_id(mrb, mrb_ary_entry(ary1, i), MRB_OPSYM(eq), 1, mrb_ary_entry(ary2, i));
     if (!mrb_test(eq)) return mrb_false_value();
+    mrb_gc_arena_restore(mrb, ai);
   }
   return mrb_true_value();
 }
@@ -1464,9 +1468,11 @@ mrb_ary_eql(mrb_state *mrb, mrb_value ary1)
   if (n == 1) return mrb_true_value();
   if (n == 0) return mrb_false_value();
 
+  int ai = mrb_gc_arena_save(mrb);
   for (mrb_int i=0; i<RARRAY_LEN(ary1); i++) {
     mrb_value eq = mrb_funcall_id(mrb, mrb_ary_entry(ary1, i), MRB_SYM_Q(eql), 1, mrb_ary_entry(ary2, i));
     if (!mrb_test(eq)) return mrb_false_value();
+    mrb_gc_arena_restore(mrb, ai);
   }
   return mrb_true_value();
 }


### PR DESCRIPTION
When calling `mrb_equal()` or `mrb_funcall()` family functions, the GC arena should be restored if the loop is repeated by a non-immediate return value.

In my opinion, restoring the GC arena is unnecessary when a non-immediate (true) value causes the function to return (e.g. the `mrb_ary_index_m()` function).

The patch does not take into account the case of recursive calls and may be incomplete.
