### PR TITLE
Implementing hash iterator.

### DIFF
--- a/include/mruby/hash.h
+++ b/include/mruby/hash.h
@@ -237,6 +237,9 @@ typedef struct mrb_hash_iterator {
 /*
  * Returns an iterator for the given hash.
  *
+ * NOTE: the iterator is considered invalid if the hash object is modified
+ * after the iterator is created. Use with caution.
+ *
  * @param h The target hash.
  */
 MRB_API mrb_hash_iterator mrb_hash_iterator_new(struct RHash *h);

--- a/include/mruby/hash.h
+++ b/include/mruby/hash.h
@@ -229,6 +229,47 @@ MRB_API void mrb_hash_merge(mrb_state *mrb, mrb_value hash1, mrb_value hash2);
 typedef int (mrb_hash_foreach_func)(mrb_state *mrb, mrb_value key, mrb_value val, void *data);
 MRB_API void mrb_hash_foreach(mrb_state *mrb, struct RHash *hash, mrb_hash_foreach_func *func, void *p);
 
+typedef struct mrb_hash_iterator {
+  struct hash_entry *entry;
+  uint32_t rem;
+} mrb_hash_iterator;
+
+/*
+ * Returns an iterator for the given hash.
+ *
+ * @param h The target hash.
+ */
+MRB_API mrb_hash_iterator mrb_hash_iterator_new(struct RHash *h);
+
+/*
+ * Moves to the next element in the iterator.
+ * Returns false if no more elements.
+ *
+ * @param it Pointer to the hash iterator.
+ */
+MRB_API mrb_bool mrb_hash_iterator_move_next(mrb_hash_iterator *it);
+
+/*
+ * Returns the number of items left in the iterator.
+ *
+ * @param it Pointer to the hash iterator.
+ */
+#define mrb_hash_iterator_remaining(it) ((it)->rem)
+
+/*
+ * Returns the key for the current hash element of the iterator.
+ *
+ * @param it Pointer to the hash iterator.
+ */
+MRB_API mrb_value mrb_hash_iterator_key(mrb_hash_iterator *it);
+
+/*
+ * Returns the value for the current hash element of the iterator.
+ *
+ * @param it Pointer to the hash iterator.
+ */
+MRB_API mrb_value mrb_hash_iterator_value(mrb_hash_iterator *it);
+
 MRB_END_DECL
 
 #endif  /* MRUBY_HASH_H */

--- a/mrbgems/mruby-test-hash-iterator/mrbgem.rake
+++ b/mrbgems/mruby-test-hash-iterator/mrbgem.rake
@@ -1,0 +1,5 @@
+MRuby::Gem::Specification.new('mruby-test-hash-iterator') do |spec|
+  spec.license = 'MIT'
+  spec.author  = 'mruby developers'
+  spec.summary = 'hash iterator test'
+end

--- a/mrbgems/mruby-test-hash-iterator/test/iterator.c
+++ b/mrbgems/mruby-test-hash-iterator/test/iterator.c
@@ -4,6 +4,7 @@
 #include <mruby/data.h>
 #include <mruby/hash.h>
 #include <mruby/value.h>
+#include <mruby/variable.h>
 
 struct hash_iterator {
   mrb_value hash;
@@ -13,7 +14,6 @@ struct hash_iterator {
 static void
 hash_iterator_free(mrb_state *mrb, void *p) {
   struct hash_iterator *iterator = (struct hash_iterator *)p;
-  mrb_gc_unregister(mrb, iterator->hash);
   mrb_free(mrb, iterator);
 }
 
@@ -32,7 +32,7 @@ hash_iterator_initialize(mrb_state *mrb, mrb_value self)
   mrb_data_init(self, iterator, &hash_iterator_type);
 
   iterator->hash = mrb_get_arg1(mrb);
-  mrb_gc_register(mrb, iterator->hash);
+  mrb_iv_set(mrb, self, mrb_intern_cstr(mrb, "hash"), iterator->hash);
 
   iterator->it = mrb_hash_iterator_new(mrb_hash_ptr(iterator->hash));
 

--- a/mrbgems/mruby-test-hash-iterator/test/iterator.c
+++ b/mrbgems/mruby-test-hash-iterator/test/iterator.c
@@ -1,24 +1,91 @@
 #include <mruby.h>
+#include <mruby/class.h>
 #include <mruby/compile.h>
+#include <mruby/data.h>
 #include <mruby/hash.h>
 #include <mruby/value.h>
 
-#include <assert.h>
-#include <stdlib.h>
+struct hash_iterator {
+  mrb_value hash;
+  mrb_hash_iterator it;
+};
+
+static void
+hash_iterator_free(mrb_state *mrb, void *p) {
+  struct hash_iterator *iterator = (struct hash_iterator *)p;
+  mrb_gc_unregister(mrb, iterator->hash);
+  mrb_free(mrb, iterator);
+}
+
+static mrb_data_type hash_iterator_type = {"HashIterator", hash_iterator_free};
+
+static mrb_value
+hash_iterator_initialize(mrb_state *mrb, mrb_value self)
+{
+  struct hash_iterator *iterator = (struct hash_iterator *)DATA_PTR(self);
+  if (iterator) {
+    hash_iterator_free(mrb, iterator);
+    mrb_data_init(self, NULL, &hash_iterator_type);
+  }
+
+  iterator = (struct hash_iterator *)mrb_malloc(mrb, sizeof(struct hash_iterator));
+  mrb_data_init(self, iterator, &hash_iterator_type);
+
+  iterator->hash = mrb_get_arg1(mrb);
+  mrb_gc_register(mrb, iterator->hash);
+
+  iterator->it = mrb_hash_iterator_new(mrb_hash_ptr(iterator->hash));
+
+  return self;
+}
+
+static mrb_value
+hash_iterator_move_next(mrb_state *mrb, mrb_value self)
+{
+  struct hash_iterator *iterator = (struct hash_iterator *)DATA_PTR(self);
+  mrb_bool has_next = mrb_hash_iterator_move_next(&iterator->it);
+
+  return mrb_bool_value(has_next);
+}
+
+static mrb_value
+hash_iterator_remaining(mrb_state *mrb, mrb_value self)
+{
+  struct hash_iterator *iterator = (struct hash_iterator *)DATA_PTR(self);
+  uint32_t remaining = mrb_hash_iterator_remaining(&iterator->it);
+
+  return mrb_int_value(mrb, (mrb_int)remaining);
+}
+
+static mrb_value
+hash_iterator_key(mrb_state *mrb, mrb_value self)
+{
+  struct hash_iterator *iterator = (struct hash_iterator *)DATA_PTR(self);
+
+  return mrb_hash_iterator_key(&iterator->it);
+}
+
+static mrb_value
+hash_iterator_value(mrb_state *mrb, mrb_value self)
+{
+  struct hash_iterator *iterator = (struct hash_iterator *)DATA_PTR(self);
+
+  return mrb_hash_iterator_value(&iterator->it);
+}
 
 #define CHECK(...) do { \
     mrb_bool result = (__VA_ARGS__); \
-    assert(result && (#__VA_ARGS__)); \
-    if (!result) { return EXIT_FAILURE; } \
+    if (!result) { \
+      mrb_raise(mrb, E_RUNTIME_ERROR, (#__VA_ARGS__)); \
+      return mrb_nil_value(); \
+    } \
   } while (0)
 
 #define CHECK_EQ(Expected, ...) \
   CHECK(mrb_eql(mrb, (Expected), (__VA_ARGS__)))
 
-int test1() {
-  mrb_state *mrb = mrb_open();
-  CHECK(mrb);
-
+static mrb_value
+hash_iterator_test1(mrb_state *mrb, mrb_value self) {
   int checkpoint = mrb_gc_arena_save(mrb);
   mrb_value hash = mrb_load_string(mrb, "{a: 10, b: 20, c: 30, d: 40, e: 50}");
   mrb_gc_arena_restore(mrb, checkpoint);
@@ -64,13 +131,11 @@ int test1() {
   CHECK(!mrb_hash_iterator_move_next(&iterator));
   CHECK(mrb_hash_iterator_remaining(&iterator) == 0);
 
-  return EXIT_SUCCESS;
+  return mrb_nil_value();
 }
 
-int test2() {
-  mrb_state *mrb = mrb_open();
-  CHECK(mrb);
-
+static mrb_value
+hash_iterator_test2(mrb_state *mrb, mrb_value self) {
   int checkpoint = mrb_gc_arena_save(mrb);
   mrb_value hash = mrb_load_string(mrb,
     "x = {a: 10, b: 20, c: 30, d: 40, e: 50}\n"
@@ -113,13 +178,11 @@ int test2() {
   CHECK(!mrb_hash_iterator_move_next(&iterator));
   CHECK(mrb_hash_iterator_remaining(&iterator) == 0);
 
-  return EXIT_SUCCESS;
+  return mrb_nil_value();
 }
 
-int test3() {
-  mrb_state *mrb = mrb_open();
-  CHECK(mrb);
-
+static mrb_value
+hash_iterator_test3(mrb_state *mrb, mrb_value self) {
   int checkpoint = mrb_gc_arena_save(mrb);
   mrb_value hash = mrb_load_string(mrb,
     "x = {a: 10, b: 20, c: 30, d: 40, e: 50}\n"
@@ -144,9 +207,22 @@ int test3() {
   CHECK(!mrb_hash_iterator_move_next(&iterator));
   CHECK(mrb_hash_iterator_remaining(&iterator) == 0);
 
-  return EXIT_SUCCESS;
+  return mrb_nil_value();
 }
 
-int main() {
-  return test1() | test2() | test3();
+void mrb_mruby_test_hash_iterator_gem_test(mrb_state *mrb)
+{
+  struct RClass *cls;
+
+  cls = mrb_define_class(mrb, "HashIterator", mrb->object_class);
+  MRB_SET_INSTANCE_TT(cls, MRB_TT_CDATA);
+  mrb_define_method(mrb, cls, "initialize", hash_iterator_initialize, MRB_ARGS_REQ(1));
+  mrb_define_method(mrb, cls, "move_next", hash_iterator_move_next, MRB_ARGS_NONE());
+  mrb_define_method(mrb, cls, "remaining", hash_iterator_remaining, MRB_ARGS_NONE());
+  mrb_define_method(mrb, cls, "key", hash_iterator_key, MRB_ARGS_NONE());
+  mrb_define_method(mrb, cls, "value", hash_iterator_value, MRB_ARGS_NONE());
+
+  mrb_define_class_method(mrb, cls, "test1", hash_iterator_test1, MRB_ARGS_NONE());
+  mrb_define_class_method(mrb, cls, "test2", hash_iterator_test2, MRB_ARGS_NONE());
+  mrb_define_class_method(mrb, cls, "test3", hash_iterator_test3, MRB_ARGS_NONE());
 }

--- a/mrbgems/mruby-test-hash-iterator/test/iterator.rb
+++ b/mrbgems/mruby-test-hash-iterator/test/iterator.rb
@@ -1,0 +1,306 @@
+##
+# HashIterator Test
+
+assert('HashIterator empty') do
+  iterator = HashIterator.new({})
+
+  assert_equal iterator.remaining, 0
+end
+
+assert('HashIterator 1 element') do
+  iterator = HashIterator.new({e: 50})
+
+  assert_equal 1, iterator.remaining
+  assert_equal :e, iterator.key
+  assert_equal 50, iterator.value
+
+  assert_false iterator.move_next
+  assert_equal 0, iterator.remaining
+end
+
+assert('HashIterator 2 elements') do
+  iterator = HashIterator.new({d: 40, e: 50})
+
+  assert_equal 2, iterator.remaining
+  assert_equal :d, iterator.key
+  assert_equal 40, iterator.value
+
+  assert_true iterator.move_next
+  assert_equal 1, iterator.remaining
+  assert_equal :e, iterator.key
+  assert_equal 50, iterator.value
+
+  assert_false iterator.move_next
+  assert_equal 0, iterator.remaining
+end
+
+assert('HashIterator 3 elements') do
+  iterator = HashIterator.new({c: 30, d: 40, e: 50})
+
+  assert_equal 3, iterator.remaining
+  assert_equal :c, iterator.key
+  assert_equal 30, iterator.value
+
+  assert_true iterator.move_next
+  assert_equal 2, iterator.remaining
+  assert_equal :d, iterator.key
+  assert_equal 40, iterator.value
+
+  assert_true iterator.move_next
+  assert_equal 1, iterator.remaining
+  assert_equal :e, iterator.key
+  assert_equal 50, iterator.value
+
+  assert_false iterator.move_next
+  assert_equal 0, iterator.remaining
+end
+
+assert('HashIterator 4 elements') do
+  iterator = HashIterator.new({b: 20, c: 30, d: 40, e: 50})
+
+  assert_equal 4, iterator.remaining
+  assert_equal :b, iterator.key
+  assert_equal 20, iterator.value
+
+  assert_true iterator.move_next
+  assert_equal 3, iterator.remaining
+  assert_equal :c, iterator.key
+  assert_equal 30, iterator.value
+
+  assert_true iterator.move_next
+  assert_equal 2, iterator.remaining
+  assert_equal :d, iterator.key
+  assert_equal 40, iterator.value
+
+  assert_true iterator.move_next
+  assert_equal 1, iterator.remaining
+  assert_equal :e, iterator.key
+  assert_equal 50, iterator.value
+
+  assert_false iterator.move_next
+  assert_equal 0, iterator.remaining
+end
+
+assert('HashIterator 5 elements') do
+  iterator = HashIterator.new({a: 10, b: 20, c: 30, d: 40, e: 50})
+
+  assert_equal 5, iterator.remaining
+  assert_equal :a, iterator.key
+  assert_equal 10, iterator.value
+
+  assert_true iterator.move_next
+  assert_equal 4, iterator.remaining
+  assert_equal :b, iterator.key
+  assert_equal 20, iterator.value
+
+  assert_true iterator.move_next
+  assert_equal 3, iterator.remaining
+  assert_equal :c, iterator.key
+  assert_equal 30, iterator.value
+
+  assert_true iterator.move_next
+  assert_equal 2, iterator.remaining
+  assert_equal :d, iterator.key
+  assert_equal 40, iterator.value
+
+  assert_true iterator.move_next
+  assert_equal 1, iterator.remaining
+  assert_equal :e, iterator.key
+  assert_equal 50, iterator.value
+
+  assert_false iterator.move_next
+  assert_equal 0, iterator.remaining
+end
+
+assert('HashIterator 5 elements, delete center') do
+  hash = {a: 10, b: 20, c: 30, d: 40, e: 50}
+  hash.delete(:c)
+
+  iterator = HashIterator.new(hash)
+
+  assert_equal 4, iterator.remaining
+  assert_equal :a, iterator.key
+  assert_equal 10, iterator.value
+
+  assert_true iterator.move_next
+  assert_equal 3, iterator.remaining
+  assert_equal :b, iterator.key
+  assert_equal 20, iterator.value
+
+  assert_true iterator.move_next
+  assert_equal 2, iterator.remaining
+  assert_equal :d, iterator.key
+  assert_equal 40, iterator.value
+
+  assert_true iterator.move_next
+  assert_equal 1, iterator.remaining
+  assert_equal :e, iterator.key
+  assert_equal 50, iterator.value
+
+  assert_false iterator.move_next
+  assert_equal 0, iterator.remaining
+end
+
+assert('HashIterator 5 elements, delete middle') do
+  hash = {a: 10, b: 20, c: 30, d: 40, e: 50}
+  hash.delete(:b)
+  hash.delete(:c)
+  hash.delete(:d)
+
+  iterator = HashIterator.new(hash)
+
+  assert_equal 2, iterator.remaining
+  assert_equal :a, iterator.key
+  assert_equal 10, iterator.value
+
+  assert_true iterator.move_next
+  assert_equal 1, iterator.remaining
+  assert_equal :e, iterator.key
+  assert_equal 50, iterator.value
+
+  assert_false iterator.move_next
+  assert_equal 0, iterator.remaining
+end
+
+assert('HashIterator 5 elements, delete first') do
+  hash = {a: 10, b: 20, c: 30, d: 40, e: 50}
+  hash.delete(:b)
+  hash.delete(:c)
+  hash.delete(:d)
+  hash.delete(:e)
+
+  iterator = HashIterator.new(hash)
+
+  assert_equal 1, iterator.remaining
+  assert_equal :a, iterator.key
+  assert_equal 10, iterator.value
+
+  assert_false iterator.move_next
+  assert_equal 0, iterator.remaining
+end
+
+assert('HashIterator 5 elements, delete left') do
+  hash = {a: 10, b: 20, c: 30, d: 40, e: 50}
+  hash.delete(:a)
+  hash.delete(:b)
+  hash.delete(:c)
+  hash.delete(:d)
+
+  iterator = HashIterator.new(hash)
+
+  assert_equal 1, iterator.remaining
+  assert_equal :e, iterator.key
+  assert_equal 50, iterator.value
+
+  assert_false iterator.move_next
+  assert_equal 0, iterator.remaining
+end
+
+assert('HashIterator 5 elements, delete last') do
+  hash = {a: 10, b: 20, c: 30, d: 40, e: 50}
+  hash.delete(:e)
+
+  iterator = HashIterator.new(hash)
+
+  assert_equal 4, iterator.remaining
+  assert_equal :a, iterator.key
+  assert_equal 10, iterator.value
+
+  assert_true iterator.move_next
+  assert_equal 3, iterator.remaining
+  assert_equal :b, iterator.key
+  assert_equal 20, iterator.value
+
+  assert_true iterator.move_next
+  assert_equal 2, iterator.remaining
+  assert_equal :c, iterator.key
+  assert_equal 30, iterator.value
+
+  assert_true iterator.move_next
+  assert_equal 1, iterator.remaining
+  assert_equal :d, iterator.key
+  assert_equal 40, iterator.value
+
+  assert_false iterator.move_next
+  assert_equal 0, iterator.remaining
+end
+
+assert('HashIterator 5 elements, delete right') do
+  hash = {a: 10, b: 20, c: 30, d: 40, e: 50}
+  hash.delete(:b)
+  hash.delete(:c)
+  hash.delete(:d)
+  hash.delete(:e)
+
+  iterator = HashIterator.new(hash)
+
+  assert_equal 1, iterator.remaining
+  assert_equal :a, iterator.key
+  assert_equal 10, iterator.value
+
+  assert_false iterator.move_next
+  assert_equal 0, iterator.remaining
+end
+
+assert('HashIterator 5 elements, delete even spots') do
+  hash = {a: 10, b: 20, c: 30, d: 40, e: 50}
+  hash.delete(:b)
+  hash.delete(:d)
+
+  iterator = HashIterator.new(hash)
+
+  assert_equal 3, iterator.remaining
+  assert_equal :a, iterator.key
+  assert_equal 10, iterator.value
+
+  assert_true iterator.move_next
+  assert_equal 2, iterator.remaining
+  assert_equal :c, iterator.key
+  assert_equal 30, iterator.value
+
+  assert_true iterator.move_next
+  assert_equal 1, iterator.remaining
+  assert_equal :e, iterator.key
+  assert_equal 50, iterator.value
+
+  assert_false iterator.move_next
+  assert_equal 0, iterator.remaining
+end
+
+assert('HashIterator 5 elements, delete odd spots') do
+  hash = {a: 10, b: 20, c: 30, d: 40, e: 50}
+  hash.delete(:a)
+  hash.delete(:c)
+  hash.delete(:e)
+
+  iterator = HashIterator.new(hash)
+
+  assert_equal 2, iterator.remaining
+  assert_equal :b, iterator.key
+  assert_equal 20, iterator.value
+
+  assert_true iterator.move_next
+  assert_equal 1, iterator.remaining
+  assert_equal :d, iterator.key
+  assert_equal 40, iterator.value
+
+  assert_false iterator.move_next
+  assert_equal 0, iterator.remaining
+end
+
+assert('HashIterator 5 elements, delete random order') do
+  hash = {a: 10, b: 20, c: 30, d: 40, e: 50}
+  hash.delete(:c)
+  hash.delete(:e)
+  hash.delete(:b)
+  hash.delete(:a)
+
+  iterator = HashIterator.new(hash)
+
+  assert_equal 1, iterator.remaining
+  assert_equal :d, iterator.key
+  assert_equal 40, iterator.value
+
+  assert_false iterator.move_next
+  assert_equal 0, iterator.remaining
+end

--- a/src/hash.c
+++ b/src/hash.c
@@ -1136,10 +1136,9 @@ mrb_hash_iterator_new(struct RHash *h)
 MRB_API mrb_bool
 mrb_hash_iterator_move_next(mrb_hash_iterator *it)
 {
-  if (0 < it->rem) {
+  if (0 < it->rem && 0 < --it->rem) {
     while (entry_deleted_p(++it->entry));
-    --it->rem;
-    return it->rem > 0;
+    return TRUE;
   }
 
   return FALSE;

--- a/src/hash.c
+++ b/src/hash.c
@@ -1111,6 +1111,52 @@ mrb_hash_foreach(mrb_state *mrb, struct RHash *h, mrb_hash_foreach_func *func, v
   });
 }
 
+MRB_API mrb_hash_iterator
+mrb_hash_iterator_new(struct RHash *h)
+{
+  mrb_hash_iterator it;
+
+  if (h_ar_p(h)) {
+    it.entry = ar_ea(h);
+    it.rem = ar_size(h);
+  } else {
+    it.entry = ht_ea(h);
+    it.rem = ht_size(h);
+  }
+
+  if (0 < it.rem) {
+    while (entry_deleted_p(it.entry)) {
+      ++it.entry;
+    }
+  }
+
+  return it;
+}
+
+MRB_API mrb_bool
+mrb_hash_iterator_move_next(mrb_hash_iterator *it)
+{
+  if (0 < it->rem) {
+    while (entry_deleted_p(++it->entry));
+    --it->rem;
+    return it->rem > 0;
+  }
+
+  return FALSE;
+}
+
+MRB_API mrb_value
+mrb_hash_iterator_key(mrb_hash_iterator *it)
+{
+  return it->entry->key;
+}
+
+MRB_API mrb_value
+mrb_hash_iterator_value(mrb_hash_iterator *it)
+{
+  return it->entry->val;
+}
+
 MRB_API mrb_value
 mrb_hash_new(mrb_state *mrb)
 {

--- a/test/t/hash_iterator.c
+++ b/test/t/hash_iterator.c
@@ -1,0 +1,152 @@
+#include <mruby.h>
+#include <mruby/compile.h>
+#include <mruby/hash.h>
+#include <mruby/value.h>
+
+#include <assert.h>
+#include <stdlib.h>
+
+#define CHECK(...) do { \
+    mrb_bool result = (__VA_ARGS__); \
+    assert(result && (#__VA_ARGS__)); \
+    if (!result) { return EXIT_FAILURE; } \
+  } while (0)
+
+#define CHECK_EQ(Expected, ...) \
+  CHECK(mrb_eql(mrb, (Expected), (__VA_ARGS__)))
+
+int test1() {
+  mrb_state *mrb = mrb_open();
+  CHECK(mrb);
+
+  int checkpoint = mrb_gc_arena_save(mrb);
+  mrb_value hash = mrb_load_string(mrb, "{a: 10, b: 20, c: 30, d: 40, e: 50}");
+  mrb_gc_arena_restore(mrb, checkpoint);
+
+  mrb_value a = mrb_symbol_value(mrb_intern_cstr(mrb, "a"));
+  mrb_value b = mrb_symbol_value(mrb_intern_cstr(mrb, "b"));
+  mrb_value c = mrb_symbol_value(mrb_intern_cstr(mrb, "c"));
+  mrb_value d = mrb_symbol_value(mrb_intern_cstr(mrb, "d"));
+  mrb_value e = mrb_symbol_value(mrb_intern_cstr(mrb, "e"));
+
+  mrb_value i10 = mrb_int_value(mrb, 10);
+  mrb_value i20 = mrb_int_value(mrb, 20);
+  mrb_value i30 = mrb_int_value(mrb, 30);
+  mrb_value i40 = mrb_int_value(mrb, 40);
+  mrb_value i50 = mrb_int_value(mrb, 50);
+
+  mrb_hash_iterator iterator = mrb_hash_iterator_new(mrb_hash_ptr(hash));
+
+  CHECK(mrb_hash_iterator_remaining(&iterator) == 5);
+  CHECK_EQ(a, mrb_hash_iterator_key(&iterator));
+  CHECK_EQ(i10, mrb_hash_iterator_value(&iterator));
+
+  CHECK(mrb_hash_iterator_move_next(&iterator));
+  CHECK(mrb_hash_iterator_remaining(&iterator) == 4);
+  CHECK_EQ(b, mrb_hash_iterator_key(&iterator));
+  CHECK_EQ(i20, mrb_hash_iterator_value(&iterator));
+
+  CHECK(mrb_hash_iterator_move_next(&iterator));
+  CHECK(mrb_hash_iterator_remaining(&iterator) == 3);
+  CHECK_EQ(c, mrb_hash_iterator_key(&iterator));
+  CHECK_EQ(i30, mrb_hash_iterator_value(&iterator));
+
+  CHECK(mrb_hash_iterator_move_next(&iterator));
+  CHECK(mrb_hash_iterator_remaining(&iterator) == 2);
+  CHECK_EQ(d, mrb_hash_iterator_key(&iterator));
+  CHECK_EQ(i40, mrb_hash_iterator_value(&iterator));
+
+  CHECK(mrb_hash_iterator_move_next(&iterator));
+  CHECK(mrb_hash_iterator_remaining(&iterator) == 1);
+  CHECK_EQ(e, mrb_hash_iterator_key(&iterator));
+  CHECK_EQ(i50, mrb_hash_iterator_value(&iterator));
+
+  CHECK(!mrb_hash_iterator_move_next(&iterator));
+  CHECK(mrb_hash_iterator_remaining(&iterator) == 0);
+
+  return EXIT_SUCCESS;
+}
+
+int test2() {
+  mrb_state *mrb = mrb_open();
+  CHECK(mrb);
+
+  int checkpoint = mrb_gc_arena_save(mrb);
+  mrb_value hash = mrb_load_string(mrb,
+    "x = {a: 10, b: 20, c: 30, d: 40, e: 50}\n"
+    "x.delete(:c)\n"
+    "x"
+  );
+  mrb_gc_arena_restore(mrb, checkpoint);
+
+  mrb_value a = mrb_symbol_value(mrb_intern_cstr(mrb, "a"));
+  mrb_value b = mrb_symbol_value(mrb_intern_cstr(mrb, "b"));
+  mrb_value d = mrb_symbol_value(mrb_intern_cstr(mrb, "d"));
+  mrb_value e = mrb_symbol_value(mrb_intern_cstr(mrb, "e"));
+
+  mrb_value i10 = mrb_int_value(mrb, 10);
+  mrb_value i20 = mrb_int_value(mrb, 20);
+  mrb_value i40 = mrb_int_value(mrb, 40);
+  mrb_value i50 = mrb_int_value(mrb, 50);
+
+  mrb_hash_iterator iterator = mrb_hash_iterator_new(mrb_hash_ptr(hash));
+
+  CHECK(mrb_hash_iterator_remaining(&iterator) == 4);
+  CHECK_EQ(a, mrb_hash_iterator_key(&iterator));
+  CHECK_EQ(i10, mrb_hash_iterator_value(&iterator));
+
+  CHECK(mrb_hash_iterator_move_next(&iterator));
+  CHECK(mrb_hash_iterator_remaining(&iterator) == 3);
+  CHECK_EQ(b, mrb_hash_iterator_key(&iterator));
+  CHECK_EQ(i20, mrb_hash_iterator_value(&iterator));
+
+  CHECK(mrb_hash_iterator_move_next(&iterator));
+  CHECK(mrb_hash_iterator_remaining(&iterator) == 2);
+  CHECK_EQ(d, mrb_hash_iterator_key(&iterator));
+  CHECK_EQ(i40, mrb_hash_iterator_value(&iterator));
+
+  CHECK(mrb_hash_iterator_move_next(&iterator));
+  CHECK(mrb_hash_iterator_remaining(&iterator) == 1);
+  CHECK_EQ(e, mrb_hash_iterator_key(&iterator));
+  CHECK_EQ(i50, mrb_hash_iterator_value(&iterator));
+
+  CHECK(!mrb_hash_iterator_move_next(&iterator));
+  CHECK(mrb_hash_iterator_remaining(&iterator) == 0);
+
+  return EXIT_SUCCESS;
+}
+
+int test3() {
+  mrb_state *mrb = mrb_open();
+  CHECK(mrb);
+
+  int checkpoint = mrb_gc_arena_save(mrb);
+  mrb_value hash = mrb_load_string(mrb,
+    "x = {a: 10, b: 20, c: 30, d: 40, e: 50}\n"
+    "x.delete(:c)\n"
+    "x.delete(:e)\n"
+    "x.delete(:b)\n"
+    "x.delete(:a)\n"
+    "x"
+  );
+  mrb_gc_arena_restore(mrb, checkpoint);
+
+  mrb_value d = mrb_symbol_value(mrb_intern_cstr(mrb, "d"));
+
+  mrb_value i40 = mrb_int_value(mrb, 40);
+
+  mrb_hash_iterator iterator = mrb_hash_iterator_new(mrb_hash_ptr(hash));
+
+  CHECK(mrb_hash_iterator_remaining(&iterator) == 1);
+  CHECK_EQ(d, mrb_hash_iterator_key(&iterator));
+  CHECK_EQ(i40, mrb_hash_iterator_value(&iterator));
+
+  CHECK(!mrb_hash_iterator_move_next(&iterator));
+  CHECK(mrb_hash_iterator_remaining(&iterator) == 0);
+
+  return EXIT_SUCCESS;
+}
+
+int main() {
+  return test1() | test2() | test3();
+}


### PR DESCRIPTION
`mrb_hash_foreach`, provides a foreach implementation on hashes using callbacks.

Although sufficient for ruby code, some C and C++ idioms can be made much simpler and easier with a good old `for` loop.

This pull request implements an iterator that allows user-controlled loops over hash elements in C code, as follows:
```
for (mrb_hash_iterator i = mrb_hash_iterator_new(h);
  mrb_hash_iterator_remaining(&i);
  mrb_hash_iterator_move_next(&i)
) {
  mrb_value key = mrb_hash_iterator_key(&i);
  mrb_value value = mrb_hash_iterator_value(&i);
  /* ... */
}
```

The code is comprised of `struct mrb_hash_iterator`, 4 accompanying functions and 1 macro with inline documentation.
```
MRB_API mrb_hash_iterator mrb_hash_iterator_new(struct RHash *h);
MRB_API mrb_bool mrb_hash_iterator_move_next(mrb_hash_iterator *it);
MRB_API mrb_value mrb_hash_iterator_key(mrb_hash_iterator *it);
MRB_API mrb_value mrb_hash_iterator_value(mrb_hash_iterator *it);
/* macro */ uint32_t mrb_hash_iterator_remaining(mrb_hash_iterator *it);
```