### PR TITLE
prefer using `mrb_yield` to call block arguments

### DIFF
--- a/src/array.c
+++ b/src/array.c
@@ -320,7 +320,8 @@ mrb_ary_init(mrb_state *mrb, mrb_value ary)
       val = obj;
     }
     else {
-      val = mrb_funcall_id(mrb, blk, MRB_SYM(call), 1, mrb_fixnum_value(i));
+      mrb_assert(mrb_proc_p(blk));
+      val = mrb_yield(mrb, blk, mrb_fixnum_value(i));
     }
     mrb_ary_set(mrb, ary, i, val);
     mrb_gc_arena_restore(mrb, ai); // for mrb_funcall
@@ -1168,7 +1169,8 @@ mrb_ary_index_m(mrb_state *mrb, mrb_value self)
   }
   else {
     for (mrb_int i = 0; i < RARRAY_LEN(self); i++) {
-      mrb_value eq = mrb_funcall_id(mrb, blk, MRB_SYM(call), 1, RARRAY_PTR(self)[i]);
+      mrb_assert(mrb_proc_p(blk));
+      mrb_value eq = mrb_yield(mrb, blk, RARRAY_PTR(self)[i]);
       if (mrb_test(eq)) {
         return mrb_int_value(mrb, i);
       }
@@ -1208,7 +1210,8 @@ mrb_ary_rindex_m(mrb_state *mrb, mrb_value self)
       }
     }
     else {
-      mrb_value eq = mrb_funcall_id(mrb, blk, MRB_SYM(call), 1, RARRAY_PTR(self)[i]);
+      mrb_assert(mrb_proc_p(blk));
+      mrb_value eq = mrb_yield(mrb, blk, RARRAY_PTR(self)[i]);
       if (mrb_test(eq)) return mrb_int_value(mrb, i);
     }
     mrb_int len = RARRAY_LEN(self);
@@ -1581,7 +1584,8 @@ mrb_ary_delete(mrb_state *mrb, mrb_value self)
 
   if (i == j) {
     if (mrb_nil_p(blk)) return mrb_nil_value();
-    return mrb_funcall_id(mrb, blk, MRB_SYM(call), 1, obj);
+      mrb_assert(mrb_proc_p(blk));
+    return mrb_yield(mrb, blk, obj);
   }
 
   ARY_SET_LEN(ary, j);
@@ -1604,7 +1608,9 @@ sort_cmp(mrb_state *mrb, mrb_value ary, mrb_value *p, mrb_int a, mrb_int b, mrb_
     if (cmp == -2) cmp_failed(mrb, a, b);
   }
   else {
-    mrb_value c = mrb_funcall_id(mrb, blk, MRB_SYM(call), 2, p[a], p[b]);
+    mrb_assert(mrb_proc_p(blk));
+    mrb_value args[2] = {p[a], p[b]};
+    mrb_value c = mrb_yield_argv(mrb, blk, 2, args);
     if (mrb_nil_p(c) || !mrb_fixnum_p(c)) {
       cmp_failed(mrb, a, b);
     }


### PR DESCRIPTION
since a block argument is guaranteed to be a `Proc` this shouldn't cause any problems and brings a moderate speed boost for methods like `Array#sort!`