### PR TITLE
Cancel the warning disablement

### DIFF
--- a/include/mruby/gc.h
+++ b/include/mruby/gc.h
@@ -34,17 +34,6 @@ typedef enum {
   MRB_GC_STATE_SWEEP
 } mrb_gc_state;
 
-/* Disable MSVC warning "C4200: nonstandard extension used: zero-sized array
- * in struct/union" when in C++ mode */
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 4200)
-#endif
-
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
-
 typedef struct mrb_gc {
   struct mrb_heap_page *heaps;     /* all heaps pages */
   struct mrb_heap_page *free_heaps;/* heaps for allocation */


### PR DESCRIPTION
Suppress warnings for 0-length sequences is not required.

By commit f1a02dff580c846698c5ae327b9fb2959f34607c, it was introduced.
By commit 24939723d77291152298acc2fb6415b3d1fe2c24, pseudo-variable length arrays are now used and the warning suppression is no longer needed.
By commit e8841fbf5824a32e1983c7635e6e9a7be8f9b51d, moved the intervening code.
