### PR TITLE
Perform GC before deleting directories

### DIFF
--- a/mrbgems/mruby-dir/test/dir.rb
+++ b/mrbgems/mruby-dir/test/dir.rb
@@ -133,5 +133,6 @@ assert('Dir#seek') do
 end
 
 assert('DirTest.teardown') do
+  GC.start
   assert_nothing_raised{DirTest.teardown}
 end


### PR DESCRIPTION
In some environments, the test will fail because the directory in use cannot be deleted.
This problem was encountered when building 32-bit binary with mingw32 on FreeBSD and running on wine.