### PR TITLE
Freezing objects by the "asz" specifier of `mrb_get_args()`

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -1067,9 +1067,13 @@ get_args_v(mrb_state *mrb, mrb_args_format format, void** ptr, va_list *ap)
             *pl = 0;
           }
           else {
-            mrb_ensure_string_type(mrb, *pickarg);
-            *ps = RSTRING_PTR(*pickarg);
-            *pl = RSTRING_LEN(*pickarg);
+            mrb_value s = *pickarg;
+            mrb_ensure_string_type(mrb, s);
+            if (!mrb_frozen_p(mrb_basic_ptr(s))) {
+              s = mrb_obj_freeze(mrb, mrb_str_dup(mrb, s));
+            }
+            *ps = RSTRING_PTR(s);
+            *pl = RSTRING_LEN(s);
           }
         }
       }
@@ -1085,15 +1089,18 @@ get_args_v(mrb_state *mrb, mrb_args_format format, void** ptr, va_list *ap)
             *ps = NULL;
           }
           else {
-            mrb_ensure_string_type(mrb, *pickarg);
-            *ps = RSTRING_CSTR(mrb, *pickarg);
+            mrb_value s = *pickarg;
+            mrb_ensure_string_type(mrb, s);
+            if (!mrb_frozen_p(mrb_basic_ptr(s))) {
+              s = mrb_obj_freeze(mrb, mrb_str_dup(mrb, s));
+            }
+            *ps = RSTRING_CSTR(mrb, s);
           }
         }
       }
       break;
     case 'a':
       {
-        struct RArray *a;
         const mrb_value **pb;
         mrb_int *pl;
 
@@ -1106,10 +1113,16 @@ get_args_v(mrb_state *mrb, mrb_args_format format, void** ptr, va_list *ap)
             *pl = 0;
           }
           else {
-            mrb_ensure_array_type(mrb, *pickarg);
-            a = mrb_ary_ptr(*pickarg);
-            *pb = ARY_PTR(a);
-            *pl = ARY_LEN(a);
+            mrb_value a = *pickarg;
+            mrb_ensure_array_type(mrb, a);
+            if (!mrb_frozen_p(mrb_basic_ptr(a))) {
+              mrb_value dup = mrb_ary_new(mrb);
+              mrb_ary_replace(mrb, dup, a);
+              mrb_obj_freeze(mrb, dup);
+              a = dup;
+            }
+            *pb = RARRAY_PTR(a);
+            *pl = RARRAY_LEN(a);
           }
         }
       }


### PR DESCRIPTION
The `a`, `s`, and `z` specifiers of `mrb_get_args()` allow you to get the address for an element of an object.

If the caller of `mrb_get_args()` subsequently calls `mrb_vm_exec()`, an operation may be performed that changes the address obtained. When the caller references the changed address in a subsequent operation, use-after-free is established.

Since this patch makes the address immutable, it will copy the object and freeze it if necessary. Note that the price of safety is a reduction in both memory usage and processing speed. If this is a concern, users are encouraged to use the `A` and `S` specifiers.