### PR TITLE
Wrap `mrb_raise()` and `mrb_raisef()` with macros

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -1566,4 +1566,6 @@ mrbmemset(void *s, int c, size_t n)
 
 MRB_END_DECL
 
+#include <mruby/addition.h>
+
 #endif  /* MRUBY_H */

--- a/include/mruby/addition.h
+++ b/include/mruby/addition.h
@@ -1,0 +1,30 @@
+/*
+** mruby/addition.h - additional defines for mruby.h
+**
+** See Copyright Notice in mruby.h
+**
+** This file collects the things that would prevent documentation generation if defined in mruby.h.
+*/
+
+#ifndef MRUBY_ADDITION_H
+#define MRUBY_ADDITION_H
+
+MRB_BEGIN_DECL
+
+mrb_noreturn void mrb_raise_str(mrb_state *mrb, struct RClass *c, mrb_value mesg_str);
+
+#define mrb_raise(mrb, c, mesg) do { \
+  mrb_value _exc_mesg = mrb_str_new_cstr(mrb, mesg); \
+  struct RClass *_exc_class = (c); \
+  mrb_raise_str(mrb, _exc_class, _exc_mesg); \
+} while (0)
+
+#define mrb_raisef(mrb, c, ...) do { \
+  mrb_value _exc_mesg = mrb_format(mrb, __VA_ARGS__); \
+  struct RClass *_exc_class = (c); \
+  mrb_raise_str(mrb, _exc_class, _exc_mesg); \
+} while (0)
+
+MRB_END_DECL
+
+#endif /* MRUBY_ADDITION_H */

--- a/mrbgems/mruby-sprintf/src/sprintf.c
+++ b/mrbgems/mruby-sprintf/src/sprintf.c
@@ -206,6 +206,9 @@ check_name_arg(mrb_state *mrb, int posarg, const char *name, size_t len)
   check_pos_arg(mrb, posarg, n),\
   (posarg = -1, GETNTHARG(n)))
 
+// Since a string literal is given, use-after-free does not occur when using the original mrb_raise
+#undef mrb_raise
+
 #define GETNTHARG(nth) \
   ((nth >= argc) ? (mrb_raise(mrb, E_ARGUMENT_ERROR, "too few arguments"), mrb_undef_value()) : argv[nth])
 

--- a/src/error.c
+++ b/src/error.c
@@ -214,12 +214,6 @@ mrb_exc_raise(mrb_state *mrb, mrb_value exc)
   exc_throw(mrb, exc);
 }
 
-MRB_API mrb_noreturn void
-mrb_raise(mrb_state *mrb, struct RClass *c, const char *msg)
-{
-  mrb_exc_raise(mrb, mrb_exc_new_str(mrb, c, mrb_str_new_cstr(mrb, msg)));
-}
-
 /*
  * <code>vsprintf</code> like formatting.
  *
@@ -395,19 +389,6 @@ static mrb_value
 error_va(mrb_state *mrb, struct RClass *c, const char *fmt, va_list ap)
 {
   return mrb_exc_new_str(mrb, c, mrb_vformat(mrb, fmt, ap));
-}
-
-MRB_API mrb_noreturn void
-mrb_raisef(mrb_state *mrb, struct RClass *c, const char *fmt, ...)
-{
-  va_list ap;
-
-  va_start(ap, fmt);
-
-  mrb_value exc = error_va(mrb, c, fmt, ap);
-  va_end(ap);
-
-  mrb_exc_raise(mrb, exc);
 }
 
 MRB_API mrb_noreturn void
@@ -718,4 +699,32 @@ mrb_init_exception(mrb_state *mrb)
 #ifdef MRB_GC_FIXED_ARENA
   mrb->arena_err = mrb_obj_ptr(mrb_exc_new_lit(mrb, nomem_error, "arena overflow error"));
 #endif
+}
+
+#undef mrb_raise
+#undef mrb_raisef
+
+MRB_API mrb_noreturn void
+mrb_raise(mrb_state *mrb, struct RClass *c, const char *msg)
+{
+  mrb_exc_raise(mrb, mrb_exc_new_str(mrb, c, mrb_str_new_cstr(mrb, msg)));
+}
+
+MRB_API mrb_noreturn void
+mrb_raisef(mrb_state *mrb, struct RClass *c, const char *fmt, ...)
+{
+  va_list ap;
+
+  va_start(ap, fmt);
+
+  mrb_value exc = error_va(mrb, c, fmt, ap);
+  va_end(ap);
+
+  mrb_exc_raise(mrb, exc);
+}
+
+mrb_noreturn void
+mrb_raise_str(mrb_state *mrb, struct RClass *c, mrb_value msg)
+{
+  mrb_exc_raise(mrb, mrb_exc_new_str(mrb, c, msg));
 }


### PR DESCRIPTION
This change is mainly to avoid use-after-free, which tends to occur when C strings are passed as arguments.

Here is a scenario in which use-after-free is valid:

  - Remove the `RuntimeError` class constant.
  - Define the `Object.const_missing` method.
  - The address to the C string is taken from the string object by `mrb_get_args()` and so on.
  - To resolve `E_RUNTIME_ERROR`, `Object.const_missing` is called via `mrb_exc_get_id()`.
  - Make a major change to the string object to invalidate the address of the C string.
  - The `mrb_str_new_cstr()` called by `mrb_raise()` references the invalidated C string.

This patch is reimplemented with macros to ensure that the string object is created and then `mrb_exc_get_id()` is called.

For compatibility when linked as shared object files or language bindings, the original function symbols are still available.

**INCOMPATIBILITY NOTE**:
These macro functions are now statements rather than expressions. So they can no longer be used inside the ternary and comma operators.