### PR TITLE
Add `pre-commit` hook `actionlint`

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -26,7 +26,6 @@ jobs:
           # VALIDATE_BASH_EXEC: true
           VALIDATE_DOCKERFILE_HADOLINT: true
           # VALIDATE_EDITORCONFIG: true
-          VALIDATE_GITHUB_ACTIONS: true
           VALIDATE_GITLEAKS: true
           # VALIDATE_SHELL_SHFMT: true
           DEFAULT_BRANCH: master

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,6 +41,10 @@ repos:
       - id: remove-tabs
         args: [--whitespaces-count, "2"]
         exclude: Makefile$
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.1
+    hooks:
+      - id: actionlint
   - repo: https://github.com/codespell-project/codespell
     rev: v2.3.0
     hooks:


### PR DESCRIPTION
Validate GitHub Actions with pre-commit.

Remove the Super-Linter GitHub Actions check.

It is more useful to run "actionlint" with pre-commit since the hooks run on our local machines on git commit.

We also run pre-commit on GitHub.

Whereas the Super-Linter tests only run on GitHub.

https://github.com/rhysd/actionlint/blob/main/docs/usage.md#pre-commit