### PR TITLE
Upgrade pre-commit min version; add hook; pre-commit autoupdate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,22 +1,23 @@
 ---
 # https://pre-commit.com/
-default_stages: [commit, push]
+default_stages: [pre-commit, pre-push]
 default_language_version:
   # force all unspecified Python hooks to run python3
   python: python3
-minimum_pre_commit_version: "2.18.1"
+minimum_pre_commit_version: "3.2.0"
 repos:
   - repo: meta
     hooks:
       - id: identity
       - id: check-hooks-apply
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: check-added-large-files
       - id: check-case-conflict
       - id: check-executables-have-shebangs
         exclude: ^test/t/lang\.rb$
+      - id: check-illegal-windows-names
       - id: check-json
       - id: check-merge-conflict
       - id: check-shebang-scripts-are-executable
@@ -43,7 +44,7 @@ repos:
         args: [--whitespaces-count, "2"]
         exclude: Makefile$
   - repo: https://github.com/rhysd/actionlint
-    rev: v1.7.1
+    rev: v1.7.3
     hooks:
       - id: actionlint
   - repo: https://github.com/codespell-project/codespell
@@ -60,7 +61,7 @@ repos:
         name: Local policy is to exclude extension from all shell files
         types: [shell]
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.41.0
+    rev: v0.42.0
     hooks:
       - id: markdownlint
         name: Run markdownlint


### PR DESCRIPTION
https://github.com/pre-commit/pre-commit-hooks/releases/tag/v5.0.0

pre-commit-hooks now requires pre-commit>=3.2.0

https://github.com/pre-commit/pre-commit-hooks?tab=readme-ov-file#check-illegal-windows-names

https://pre-commit.com/#pre-commit-autoupdate

refs pre-commit/pre-commit#2808

https://pre-commit.com/#top_level-default_stages