### PR TITLE
Add `pre-commit` hook `pretty-format-json`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,6 +18,8 @@ repos:
       - id: check-executables-have-shebangs
         exclude: ^test/t/lang\.rb$
       - id: check-illegal-windows-names
+      - id: pretty-format-json
+        args: [--autofix, --no-sort-keys]
       - id: check-json
       - id: check-merge-conflict
       - id: check-shebang-scripts-are-executable


### PR DESCRIPTION
https://github.com/pre-commit/pre-commit-hooks?tab=readme-ov-file#pretty-format-json

From the official pre-commit team a minor feature to add.

We have one JSON file at `.github/linters/mlc_config.json`.