### PR TITLE
Make array objects invisible in `mrb_gc_register()`

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -433,6 +433,7 @@ mrb_gc_register(mrb_state *mrb, mrb_value obj)
   mrb_gc_protect(mrb, obj);
   if (mrb_nil_p(table) || !mrb_array_p(table)) {
     table = mrb_ary_new(mrb);
+    mrb_obj_ptr(table)->c = NULL; /* hide from ObjectSpace.each_object */
     mrb_gv_set(mrb, GC_ROOT_SYM, table);
   }
   mrb_ary_push(mrb, table, obj);


### PR DESCRIPTION
Once the class is set, objects can be referenced and manipulated from the Ruby side by using `ObjectSpace.each_object`.
Also, currently `mrb_gc_unregister()` assumes that the element is a non-immediate object.
However, `mrb_gc_unregister()` does not read or write to the address, so there was no problem.
