### PR TITLE
Remove macOS 12 from the build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,6 @@ jobs:
           - {os: ubuntu-20.04, cc: clang, cxx: clang++}
           - {os: macos-latest, cc: clang, cxx: clang++}
           - {os: macos-13, cc: clang, cxx: clang++}
-          - {os: macos-12, cc: clang, cxx: clang++}
           - {os: windows-latest, cc: gcc, cxx: g++, altname: "mingw-gcc"}
     env:
       MRUBY_CONFIG: ci/gcc-clang


### PR DESCRIPTION
The macOS 12 runner image will be removed by December 3rd, 2024.

refs https://github.com/mruby/mruby/pull/6005