### PR TITLE
Avoid calling `mrb_gv_set()` from `mrb_gc_unregister()`

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -448,11 +448,7 @@ mrb_gc_unregister(mrb_state *mrb, mrb_value obj)
 
   if (mrb_immediate_p(obj)) return;
   table = mrb_gv_get(mrb, GC_ROOT_SYM);
-  if (mrb_nil_p(table)) return;
-  if (!mrb_array_p(table)) {
-    mrb_gv_set(mrb, GC_ROOT_SYM, mrb_nil_value());
-    return;
-  }
+  if (!mrb_array_p(table)) return;
   a = mrb_ary_ptr(table);
   mrb_ary_modify(mrb, a);
   for (mrb_int i = 0; i < ARY_LEN(a); i++) {


### PR DESCRIPTION
Should simply be ignored for the possibility of being called from `RData::dfree`.

---

Currently, use-after-free still occurs when called during `mrb_close()`.
I will send a patch to fix it after checking more.
