### PR TITLE
Small improvements for `mrb_gc_unregister()`

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -455,11 +455,10 @@ mrb_gc_unregister(mrb_state *mrb, mrb_value obj)
   }
   a = mrb_ary_ptr(table);
   mrb_ary_modify(mrb, a);
-  for (mrb_int i = 0; i < ARY_LEN(a); i++) {
-    if (mrb_ptr(ARY_PTR(a)[i]) == mrb_ptr(obj)) {
-      mrb_int len = ARY_LEN(a)-1;
-      mrb_value *ptr = ARY_PTR(a);
-
+  mrb_int len = ARY_LEN(a)-1;
+  mrb_value *ptr = ARY_PTR(a);
+  for (mrb_int i = 0; i <= len; i++) {
+    if (mrb_ptr(ptr[i]) == mrb_ptr(obj)) {
       ARY_SET_LEN(a, len);
       memmove(&ptr[i], &ptr[i + 1], (len - i) * sizeof(mrb_value));
       break;


### PR DESCRIPTION
`ARY_PTR()` and `ARY_LEN()` avoid using them in a loop if the array is not changed, since they involve branching.