### PR TITLE
Storing method-id inside Symbol#to_proc

### DIFF
--- a/mrblib/symbol.rb
+++ b/mrblib/symbol.rb
@@ -1,7 +1,8 @@
 class Symbol
   def to_proc
+    mid = self
     ->(obj,*args,**opts,&block) do
-      obj.__send__(self, *args, **opts, &block)
+      obj.__send__(mid, *args, **opts, &block)
     end
   end
 end


### PR DESCRIPTION
When called in combination with a method like `*_eval` or `*_exec` that switches self, `__send__` was passed an object that was not necessarily a symbol as the method name.

This problem was discovered during the #6389 correction process.
