### PR TITLE
Milk-V Build Config: update GPIO gem URL

### DIFF
--- a/build_config/milkv_duo.rb
+++ b/build_config/milkv_duo.rb
@@ -102,6 +102,6 @@ MRuby::CrossBuild.new("milkv_duo") do |conf|
   conf.gem 'mrbgems/mruby-time/'
   conf.gem 'mrbgems/mruby-toplevel-ext/'
 
-  # mruby bindings for WiringX (GPIO).
-  # conf.gem :github => 'denko-rb/mruby-milkv-wiringx'
+  # GPIO, ADC, PWM, I2C and SPI support for Milk-V Duo
+  # conf.gem :github => 'denko-rb/mruby-milkv-duo'
 end


### PR DESCRIPTION
Sorry for such a trivial change. When I started writing the GPIO gem for this board, I thought its `WiringX` C library could do everything, so I named the gem after it. It didn't have all the features I needed, so I'm changing the gem name to be more generic.