### PR TITLE
Add macOS 15 to the build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,8 +20,8 @@ jobs:
           - {os: ubuntu-24.04, cc: clang, cxx: clang++}
           - {os: ubuntu-22.04, cc: gcc, cxx: g++}
           - {os: ubuntu-22.04, cc: clang, cxx: clang++}
-          - {os: macos-latest, cc: clang, cxx: clang++}
-          - {os: macos-13, cc: clang, cxx: clang++}
+          - {os: macos-15, cc: clang, cxx: clang++}
+          - {os: macos-14, cc: clang, cxx: clang++}
           - {os: windows-latest, cc: gcc, cxx: g++, altname: "mingw-gcc"}
     env:
       MRUBY_CONFIG: ci/gcc-clang


### PR DESCRIPTION
macOS 15 (Sequoia) is now available as a public beta in GitHub Actions

https://github.com/actions/runner-images/issues/10686

https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md