### PR TITLE
Allow to exclude specific files in `rake install`

### DIFF
--- a/doc/guides/compile.md
+++ b/doc/guides/compile.md
@@ -637,6 +637,33 @@ To summarize:
 - For a build target other than "host", the default value of `MRuby::Build#install_prefix` is `<PREFIX>/mruby/<build-name>`.
 - If the environment variable `DESTDIR` is set, the actual write directory is `<DESTDIR>/<MRuby::Build#install_prefix>`.
 
+### Excluded files
+
+In some cases there are files that you do not want to install.
+In such cases, add a file path filter to the array object `MRuby::Build#install_excludes` to exclude them.
+
+The following is an object that can be defined as a file path filter.
+The `path` variable that appears is a relative path based on `MRuby::Build#build_dir`.
+
+- string objects: files matched by `string.match?(path)` are excluded.
+- regexp object: files matched by `regexp.match?(path)` are excluded.
+- proc object: files which return true with `proc.call(path)` are excluded.
+
+```ruby
+# exclude bin/mrbc
+conf.install_excludes << exefile("bin/mrbc")
+
+# exclude all files under lib/ directory
+conf.install_excludes << %r(^lib/)
+
+# exclude bin/mrbtest, but in this case it is recommended to use string instead of proc
+conf.install_excludes << proc { |path|
+  path == exefile("bin/mrbtest")
+}
+```
+
+By default, it contains only a proc object to exclude `libmruby_core`.
+
 ## Tips
 
 - If you see compilation troubles, try `rake clean` first.


### PR DESCRIPTION
Introduce the `MRuby::Build#install_excludes` attribute. This attribute is an array to which you add strings, regular expressions, and proc objects that will serve as filters to exclude.

This feature was inspired by @hoshiumiarata's comment. https://github.com/mruby/mruby/issues/6352#issuecomment-2426721517