### PR TITLE
Improve compliance with C++ standards

### DIFF
--- a/mrbgems/mruby-io/src/file.c
+++ b/mrbgems/mruby-io/src/file.c
@@ -90,7 +90,8 @@ flock(int fd, int operation)
   DWORD flags;
   flags = ((operation & LOCK_NB) ? LOCKFILE_FAIL_IMMEDIATELY : 0)
           | ((operation & LOCK_SH) ? LOCKFILE_EXCLUSIVE_LOCK : 0);
-  OVERLAPPED ov = (OVERLAPPED){0};
+  static const OVERLAPPED zero_ov = {0};
+  OVERLAPPED ov = zero_ov;
   return LockFileEx(h, flags, 0, 0xffffffff, 0xffffffff, &ov) ? 0 : -1;
 }
 #endif

--- a/src/dump.c
+++ b/src/dump.c
@@ -81,7 +81,7 @@ dump_float(mrb_state *mrb, uint8_t *buf, mrb_float f)
   union {
     double f;
     char s[sizeof(double)];
-  } u = {.f = (double)f};
+  } u = {(double)f};
 
   if (littleendian) {
     memcpy(buf, u.s, sizeof(double));


### PR DESCRIPTION
  - Avoid "Designated initializer"
    C++20 is required for C++.
  - Avoid "Compound literals"
    Not available for C++.
