### PR TITLE
[CI] Add `prettier` to `pre-commit`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,16 +4,28 @@ default_stages: [pre-commit, pre-push]
 default_language_version:
   # force all unspecified Python hooks to run python3
   python: python3
+  node: 22.2.0
 minimum_pre_commit_version: "3.2.0"
 repos:
   - repo: meta
     hooks:
       - id: identity
       - id: check-hooks-apply
+        name: check hooks apply to the repository
+  - repo: local
+    hooks:
+      - id: prettier
+        name: run prettier
+        description: format files with prettier
+        entry: prettier --write .
+        files: \.(json|md|ya?ml)$
+        language: node
+        additional_dependencies: ["prettier@3.3.3"]
   - repo: https://github.com/gitleaks/gitleaks
     rev: v8.20.1
     hooks:
       - id: gitleaks
+        name: detect hardcoded secrets
   - repo: https://github.com/shssoichiro/oxipng
     rev: v9.1.2
     hooks:
@@ -50,32 +62,35 @@ repos:
     rev: v1.5.5
     hooks:
       - id: forbid-tabs
+        name: no-tabs checker
         exclude: Makefile$
       - id: remove-tabs
+        name: tabs remover
         args: [--whitespaces-count, "2"]
         exclude: Makefile$
   - repo: https://github.com/rhysd/actionlint
     rev: v1.7.3
     hooks:
       - id: actionlint
+        name: lint GitHub Actions workflow files
   - repo: https://github.com/codespell-project/codespell
     rev: v2.3.0
     hooks:
       - id: codespell
-        name: Run codespell
+        name: run codespell
         description: Check spelling with codespell
         args: [--ignore-words=.github/linters/codespell.txt]
   - repo: https://github.com/jumanjihouse/pre-commit-hooks
     rev: 3.0.0
     hooks:
       - id: script-must-not-have-extension
-        name: Local policy is to exclude extension from all shell files
+        name: local policy is to exclude extension from all shell files
         types: [shell]
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.42.0
     hooks:
       - id: markdownlint
-        name: Run markdownlint
+        name: run markdownlint
         description: Checks the style of Markdown files
         args: [--config=.github/linters/.markdown-lint.yml]
         types: [markdown]
@@ -84,7 +99,7 @@ repos:
     rev: v3.12.2
     hooks:
       - id: markdown-link-check
-        name: Run markdown-link-check
+        name: run markdown-link-check
         description: Checks hyperlinks in Markdown files
         args: [--config=.github/linters/mlc_config.json, -q]
         types: [markdown]
@@ -97,7 +112,7 @@ repos:
     rev: v1.35.1
     hooks:
       - id: yamllint
-        name: Run yamllint
+        name: run yamllint
         description: Check YAML files with yamllint
         args: [--strict, -c=.github/linters/.yaml-lint.yml]
         types: [yaml]

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+# Ignore artifacts:
+build
+coverage
+doc/internal/opcode.md

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "bracketSpacing": false
+}

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ extensions in C and/or Ruby. For a guide on how to use mrbgems, consult the
 -->
 
 <!-- BEGIN OF MRUBY DOCUMENT INDEX -->
+
 - [About the Limitations of mruby](doc/limitations.md)
 - [About the Compile](doc/guides/compile.md)
 - [About the Debugger with the `mrdb` Command](doc/guides/debugger.md)


### PR DESCRIPTION
Add `.prettierignore` and the `.prettierrc` config file. Prettier is currently targeting the `JSON`, `Markdown` and `YAML` files in the mruby repo.

Additional file types can be targetted with prettier via additional community plugins.

https://prettier.io/docs/en/

You can see all the languages that are supported on the homepage:

https://prettier.io/

This PR references a few other issues and PRs

We did have prettier running with pre-commit before that method was removed from prettier.

https://github.com/mruby/mruby/pull/6292

https://github.com/mruby/mruby/issues/6291

https://github.com/mruby/mruby/issues/6138

https://github.com/mruby/mruby/pull/5490

Perhaps we could add more npm software to pre-commit in future using new the `local` repo approach.

https://pre-commit.com/#repository-local-hooks

The best part is that it runs with pre-commit on our local machines on `git commit` and also when running `pre-commit run --all-files` or for example when running `make check`.

There were also some minor fixes / style changes in the pre-commit config to standardize casing.

https://www.npmjs.com/package/prettier?activeTab=readme