### PR TITLE
Rehash hash tables after element removal

### DIFF
--- a/test/t/hash.rb
+++ b/test/t/hash.rb
@@ -975,3 +975,43 @@ assert('test value omission') do
   y = 2
   assert_equal({x:1, y:2}, {x:, y:})
 end
+
+assert('hash tables are properly rehashed as necessary after #delete') do
+  keys = []
+  20.times { |key| keys << key }
+
+  root = {}
+  keys.each { |key| root[key] = true }
+
+  keys.each do |delete_key|
+    keys.each do |update_key|
+      next if update_key == delete_key
+
+      hash = root.dup
+      hash.delete(delete_key)
+      hash[update_key] = true
+
+      assert_equal(19, hash.size, "Hash size should not grow on update")
+      assert_equal(19, hash.keys.size, "Keys should not change on update")
+    end
+  end
+end
+
+assert('hash tables are properly rehashed as necessary after #shift') do
+  keys = []
+  20.times { |key| keys << key }
+
+  root = {}
+  keys.each { |key| root[key] = true }
+
+  keys.each do |update_key|
+    next if update_key == keys.first
+
+    hash = root.dup
+    hash.shift
+    hash[update_key] = true
+
+    assert_equal(19, hash.size, "Hash size should not grow on update")
+    assert_equal(19, hash.keys.size, "Keys should not change on update")
+  end
+end


### PR DESCRIPTION
This resolves errors where key updates following a deletion or shift could cause a hash to misreport its size or report duplicate keys.

In particular, insertions in the hash table implementation calculate a slot index based on the hashcode of the key. If that slot index is occupied, then it moves on to check a secondary slot, a tertiary slot, and so on until it finds an inactive slot. If some keys `A` and `B` both map to the same slot index, it could happen that `A` is added, then `B` is added, then `A` is removed from the hash — this leaves the slot that `B` *would* occupy inactive, and a subsequent update to `B` will be treated as an insertion.

This unexpected behavior shouldn't cause issues on hash reads, since the latest value will be seen first, but *does* cause the hash size to be misreported, the set of keys to include a duplicate entry, and [unconfirmed] may leave an unexpected value for `B` in place following a deletion of that key.

The simplest solution to this issue is to `rehash` following any entry removal, and that behavior is alluded to within `h_rehash`, but the additional cost of a rehash on each removal may be unreasonably high. In fact, most hash entries can be safely removed without requiring a rehash — a rehash on removal is only necessary when the removed entry had previously blocked an insertion.

This optimization is implemented by storing a parallel array of slot conflict markers, which are updated when adding data to the hash table, and tested on removal. A more optimal solution would likely involve packing these markers into the existing `ib` array.