### PR TITLE
Fix numbered parameters when used as a singleton

### DIFF
--- a/mrbgems/mruby-compiler/core/parse.y
+++ b/mrbgems/mruby-compiler/core/parse.y
@@ -2674,10 +2674,6 @@ primary         : literal
                 | heredoc
                 | var_ref
                 | backref
-                | tNUMPARAM
-                    {
-                      $$ = new_nvar(p, $1);
-                    }
                 | tFID
                     {
                       $$ = new_fcall(p, $1, 0);
@@ -3491,6 +3487,11 @@ symbol          : basic_symbol
                       }
                       $$ = new_dsym(p, new_dstr(p, n));
                     }
+                | tSYMBEG tNUMPARAM
+                    {
+                      mrb_sym sym = intern_numparam($2);
+                      $$ = new_sym(p, sym);
+                    }
                 ;
 
 basic_symbol    : tSYMBEG sym
@@ -3575,6 +3576,10 @@ var_lhs         : variable
 var_ref         : variable
                     {
                       $$ = var_reference(p, $1);
+                    }
+                | tNUMPARAM
+                    {
+                      $$ = new_nvar(p, $1);
                     }
                 | keyword_nil
                     {
@@ -6435,7 +6440,7 @@ parser_yylex(parser_state *p)
       break;
 
     case '_':
-      if (p->lstate != EXPR_FNAME && toklen(p) == 2 && ISDIGIT(tok(p)[1]) && p->nvars) {
+      if (toklen(p) == 2 && ISDIGIT(tok(p)[1]) && p->nvars) {
         int n = tok(p)[1] - '0';
         int nvar;
 

--- a/test/t/syntax.rb
+++ b/test/t/syntax.rb
@@ -718,6 +718,16 @@ assert('_0 is not numbered parameter') do
   assert_equal(:l, ->{_0}.call)
 end
 
+assert('numbered parameters in symbol name (https://github.com/mruby/mruby/issues/5295)') do
+  assert_equal([:_1], Array.new(1) {:_1})
+end
+
+assert('numbered parameters as singleton') do
+  o = Object.new
+  lambda { def _1.a(b) = "a#{b}" }.call(o)
+  assert_equal('ab', o.a('b'))
+end
+
 assert('argument forwarding') do
   c = Class.new {
     def a0(*a,&b)


### PR DESCRIPTION
It seems that using a numbered parameter as a singleton is generating an incorrect AST, so code like this is not working:

```ruby
o = Object.new
o.tap { def _1.a(b) = "a#{b}" }

=> undefined method '_1' (NoMethodError)
```

It generates the following AST:

```
00002               NODE_SDEF:
00002                 NODE_FCALL:
00002                   method='_1' (31195136)
00002                 :a
00002                   mandatory args:
00002                     NODE_ARG b
```

I tried to fix it, so it generates the following AST now:

```
00002               NODE_SDEF:
00002                 NODE_NVAR 1
00002                 :a
00002                   mandatory args:
00002                     NODE_ARG b
```

I'm not sure if this is the best way to fix it, so it's okay to fix it in another way if it's better.