### PR TITLE
Disable linting of email addresses in markdown files

### DIFF
--- a/.github/linters/mlc_config.json
+++ b/.github/linters/mlc_config.json
@@ -1,7 +1,10 @@
 {
   "ignorePatterns": [
     {
-      "pattern": "^https://github.com/mruby/mruby/commit/.*"
+      "pattern": "^https://github.com/mruby/mruby/commit/"
+    },
+    {
+      "pattern": "^mailto:"
     }
   ]
 }


### PR DESCRIPTION
It seems like pull requests are failing in linting because some email addresses in markdown files are not accessible anymore.
Mostly, they are in the license section of the files, so they probably should not be removed. It's possible to whitelist them in the linter, but there are not too many email addresses in the markdown files in the first place, so it's easier to just disable linting of email addresses in markdown files (it's hard to imagine that this linting will help in any way).