### PR TITLE
Follow Ruby's behavior for numbered parameters in -> {}

### DIFF
--- a/mrbgems/mruby-compiler/core/parse.y
+++ b/mrbgems/mruby-compiler/core/parse.y
@@ -958,6 +958,7 @@ new_block(parser_state *p, node *a, node *b)
 static node*
 new_lambda(parser_state *p, node *a, node *b)
 {
+  a = setup_numparams(p, a);
   return list4((node*)NODE_LAMBDA, locals_node(p), a, b);
 }
 
@@ -7165,7 +7166,7 @@ mrb_parser_dump(mrb_state *mrb, node *tree, int offset)
 
   case NODE_LAMBDA:
     printf("NODE_LAMBDA:\n");
-    dump_prefix(tree, offset);
+    dump_prefix(tree, offset+1);
     goto block;
 
   case NODE_BLOCK:

--- a/test/t/syntax.rb
+++ b/test/t/syntax.rb
@@ -711,6 +711,7 @@ end
 assert('numbered parameters') do
   assert_equal(15, [1,2,3,4,5].reduce {_1+_2})
   assert_equal(45, Proc.new do _1 + _2 + _3 + _4 + _5 + _6 + _7 + _8 + _9 end.call(*[1, 2, 3, 4, 5, 6, 7, 8, 9]))
+  assert_equal(5, -> { _1 }.call(5))
 end
 
 assert('_0 is not numbered parameter') do


### PR DESCRIPTION
Numbered parameters were not allowed in -> {}, but Ruby allows them, so I changed the behavior to follow Ruby.
Also, I adjusted the lambda node offset in mrb_parser_dump (it printed the lambda body at the same indent as NODE_LAMBDA).