### PR TITLE
Update `labeler.yml`: add label for the `tools` directory

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -71,3 +71,9 @@ oss-fuzz:
       - changed-files:
           - any-glob-to-any-file:
               - oss-fuzz/**/*
+
+tools:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file:
+              - tools/**/*

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -71,7 +71,6 @@ oss-fuzz:
       - changed-files:
           - any-glob-to-any-file:
               - oss-fuzz/**/*
-
 tools:
   - any:
       - changed-files:


### PR DESCRIPTION
PR #6384 was not auto labeled by the actions bot.

So the `tools` directory needs a label.

We should be consistent and have a label for all files and folders.

After this PR is merged we need to add a new label for `tools` here:

https://github.com/mruby/mruby/labels