### PR TITLE
Rehash hashes when insertion encounters tombstones

### DIFF
--- a/test/t/hash.rb
+++ b/test/t/hash.rb
@@ -975,3 +975,43 @@ assert('test value omission') do
   y = 2
   assert_equal({x:1, y:2}, {x:, y:})
 end
+
+assert('hash tables are properly rehashed as necessary after #delete') do
+  keys = []
+  20.times { |key| keys << key }
+
+  root = {}
+  keys.each { |key| root[key] = true }
+
+  keys.each do |delete_key|
+    keys.each do |update_key|
+      next if update_key == delete_key
+
+      hash = root.dup
+      hash.delete(delete_key)
+      hash[update_key] = true
+
+      assert_equal(19, hash.size, "Hash size should not grow on update")
+      assert_equal(19, hash.keys.size, "Keys should not change on update")
+    end
+  end
+end
+
+assert('hash tables are properly rehashed as necessary after #shift') do
+  keys = []
+  20.times { |key| keys << key }
+
+  root = {}
+  keys.each { |key| root[key] = true }
+
+  keys.each do |update_key|
+    next if update_key == keys.first
+
+    hash = root.dup
+    hash.shift
+    hash[update_key] = true
+
+    assert_equal(19, hash.size, "Hash size should not grow on update")
+    assert_equal(19, hash.keys.size, "Keys should not change on update")
+  end
+end


### PR DESCRIPTION
This is an alternative resolution to the issue mentioned in #6414. This may be considered preferable, as it avoids the need for any additional storage, and defers rehashing until it is absolutely necessary.

Specifically, while #6414 triggers a rehash whenever a conflicted slot is removed, this PR defers the rehash until a hash write actually encounters a slot marked as deleted. Since writing to a previously deleted slot may result in redundant data (if the previous occupant of that slot had blocked another insertion), we cannot push the work any later; since knowing whether the slot had previously blocked another insertion requires additional storage, we cannot skip the rehash.

---

A third fix implementation was also considered, in which tombstones were treated as "occupied" for the purposes of hash writes. This would allow us to avoid coupling the intermittent cost of a rehash to either deletion or insertion, by paying the much cost of ongoing hash collision resolution until the hash resized (or was explicitly rehashed). In practice, this is tricky to manage without tracking the number of `empty` slots remaining in the hash or doing a full iteration of the hash first.