### PR TITLE
Adding a serialized test task

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Compiler version
         run: ${{ env.CC }} --version
       - name: Build and test
-        run: rake -m test:build && rake test:run
+        run: rake -m test:run:serial
 
   Windows-VC:
     runs-on: windows-2022
@@ -52,4 +52,4 @@ jobs:
         shell: cmd
         run: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-          rake -m test:build && rake test:run
+          rake -m test:run:serial

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ env:
   - MRUBY_CONFIG=ci/gcc-clang
 
 script:
-  - rake -m test:build && rake test:run
+  - rake -m test:run:serial

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -44,5 +44,4 @@ init:
 
 build_script:
   - set MRUBY_CONFIG=ci/msvc
-  - rake -m test:build
-  - rake test:run
+  - rake -m test:run:serial

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   test:
     build:
       context: .
-    command: sh -c 'rake deep_clean && rake -m test:build && rake test:run'
+    command: sh -c 'rake deep_clean && rake -m test:run:serial'
     environment:
       - MRUBY_CONFIG=ci/gcc-clang
       - CC=gcc

--- a/tasks/test.rake
+++ b/tasks/test.rake
@@ -36,6 +36,21 @@ namespace :test do |test_ns|
     desc "run command binaries tests"
     task :bin
   end
+
+  desc "run all mruby tests serially"
+  task "run:serial" => "build" do
+    Rake::Task["test:run"].prerequisite_tasks.each(&:invoke)
+  end
+
+  desc "run library tests serially"
+  task "run:serial:bin" => "build:bin" do
+    Rake::Task["test:run:lib"].prerequisite_tasks.each(&:invoke)
+  end
+
+  desc "run command binaries tests serially"
+  task "run:serial:lib" => "build:lib" do
+    Rake::Task["test:run:bin"].prerequisite_tasks.each(&:invoke)
+  end
 end
 
 MRuby.each_target do |build|


### PR DESCRIPTION
Under normal circumstances, `rake -m test` will parallelize not only the build task, but also the test task. With this patch, `rake -m test:run:serial` will parallelize the build tasks, but the test tasks will be done one by one in sequence.

The name of the task to be added is as follows:

| tasks to be added     | corresponding exist tasks
| --------------------- | ----------------
| `test:run:serial`     | `test:run`
| `test:run:serial:bin` | `test:run:bin`
| `test:run:serial:lib` | `test:run:lib`