### PR TITLE
Add GitHub Actions workflow for coverage reporting

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,6 +1,6 @@
 name: Coverage
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   coverage:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,10 +28,10 @@ jobs:
         run: |
           {
             echo "# Coverage report"
-            echo "\`\`\`"
+            echo \`\`\`
             gcovr -e ".*_test.c" -e ".*/test/.*" -s --html-details -o coverage/ build
-            echo "\`\`\`"
-          } > $GITHUB_STEP_SUMMARY
+            echo \`\`\`
+          } > "$GITHUB_STEP_SUMMARY"
       - name: Upload coverage report
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-24.04
     env:
       MRUBY_CONFIG: ci/gcc-clang
-      CC: clang
-      CXX: clang++
-      LD: clang
+      CC: clang-18
+      CXX: clang++-18
+      LD: clang-18
       CFLAGS: -O0 -g --coverage
       CXXFLAGS: -O0 -g --coverage
       LDFLAGS: --coverage
@@ -30,7 +30,7 @@ jobs:
           {
             echo "# Coverage report"
             echo \`\`\`
-            gcovr --gcov-executable "llvm-cov gcov" -e ".*_test.c" -e ".*/test/.*" -s --html-details -o coverage/ build
+            gcovr --gcov-executable "llvm-cov-18 gcov" -e ".*_test.c" -e ".*/test/.*" -s --html-details -o coverage/ build
             echo \`\`\`
           } > "$GITHUB_STEP_SUMMARY"
       - name: Upload coverage report

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -26,10 +26,12 @@ jobs:
         run: pip install gcovr
       - name: Generate coverage report
         run: |
-          echo "# Coverage report" > $GITHUB_STEP_SUMMARY
-          echo \`\`\` >> $GITHUB_STEP_SUMMARY
-          gcovr -e ".*_test.c" -e ".*/test/.*" -s --html-details -o coverage/ build >> $GITHUB_STEP_SUMMARY
-          echo \`\`\` >> $GITHUB_STEP_SUMMARY
+          {
+            echo "# Coverage report"
+            echo \`\`\`
+            gcovr -e ".*_test.c" -e ".*/test/.*" -s --html-details -o coverage/ build
+            echo \`\`\`
+          } > $GITHUB_STEP_SUMMARY
       - name: Upload coverage report
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,38 @@
+name: Coverage
+
+on: [push]
+
+jobs:
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-24.04
+    env:
+      MRUBY_CONFIG: ci/gcc-clang
+      CC: gcc
+      CXX: g++
+      LD: gcc
+      CFLAGS: -O0 -g --coverage
+      LDFLAGS: --coverage
+    steps:
+      - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
+        uses: actions/checkout@v4
+      - name: Ruby version
+        run: ruby -v
+      - name: Compiler version
+        run: ${{ env.CC }} --version
+      - name: Build and test
+        run: rake test
+      - name: Install gcovr
+        run: pip install gcovr
+      - name: Generate coverage report
+        run: |
+          echo "# Coverage report" > $GITHUB_STEP_SUMMARY
+          echo \`\`\` >> $GITHUB_STEP_SUMMARY
+          gcovr -e ".*_test.c" -e ".*/test/.*" -s --html-details -o coverage/ build >> $GITHUB_STEP_SUMMARY
+          echo \`\`\` >> $GITHUB_STEP_SUMMARY
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-${{ github.sha }}
+          path: coverage/
+          retention-days: 14

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,9 +28,9 @@ jobs:
         run: |
           {
             echo "# Coverage report"
-            echo \`\`\`
+            echo "\`\`\`"
             gcovr -e ".*_test.c" -e ".*/test/.*" -s --html-details -o coverage/ build
-            echo \`\`\`
+            echo "\`\`\`"
           } > $GITHUB_STEP_SUMMARY
       - name: Upload coverage report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -37,4 +37,4 @@ jobs:
         with:
           name: coverage-${{ github.sha }}
           path: coverage/
-          retention-days: 14
+          retention-days: 3

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -8,10 +8,11 @@ jobs:
     runs-on: ubuntu-24.04
     env:
       MRUBY_CONFIG: ci/gcc-clang
-      CC: gcc
-      CXX: g++
-      LD: gcc
+      CC: clang
+      CXX: clang++
+      LD: clang
       CFLAGS: -O0 -g --coverage
+      CXXFLAGS: -O0 -g --coverage
       LDFLAGS: --coverage
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
@@ -29,7 +30,7 @@ jobs:
           {
             echo "# Coverage report"
             echo \`\`\`
-            gcovr -e ".*_test.c" -e ".*/test/.*" -s --html-details -o coverage/ build
+            gcovr --gcov-executable "llvm-cov gcov" -e ".*_test.c" -e ".*/test/.*" -s --html-details -o coverage/ build
             echo \`\`\`
           } > "$GITHUB_STEP_SUMMARY"
       - name: Upload coverage report


### PR DESCRIPTION
I experimented with adding a GitHub Actions workflow to report coverage.
The workflow is triggered on every push to the repository, generates a HTML coverage report and uploads it as an artifact.
Additionally, it shows the coverage percentage in the summary.

The decisions I made (not necessarily the best ones):
- It runs only on one OS (Ubuntu). It's possible to run on multiple configurations and then merge the results, but that seems like overkill to me.
- It uses Clang. At first, I tried to use GCC, but it seems that GCC generates invisible branches in the code in some cases. This leads to false positives in the coverage report. Clang takes a different "source code-first" approach, so it is more accurate.
- It uses gcovr. I also experimented with lcov, but it generated errors (it's possible to silence them, but I decided to use gcovr for now).
- It ignores `/test/` directories and `_test.c` files.
- The artifact will be available for ~2 weeks~ 3 days.

Sample summary:
<img width="1306" alt="image" src="https://github.com/user-attachments/assets/c4a5d5e2-c89b-42e1-887e-99b6eb7844b6">

Sample coverage report:
https://github.com/mruby/mruby/actions/runs/11910195640

I hope it will be useful, and I would be happy to hear any feedback.