### PR TITLE
Change the limits of OP_ADDI and OP_SUBI from 0-127 to 0-255.

### DIFF
--- a/mrbgems/mruby-compiler/core/codegen.c
+++ b/mrbgems/mruby-compiler/core/codegen.c
@@ -817,7 +817,7 @@ gen_addsub(codegen_scope *s, uint8_t op, uint16_t dst)
     mrb_int n0;
     if (addr_pc(s, data.addr) == s->lastlabel || !get_int_operand(s, &data0, &n0)) {
       /* OP_ADDI/OP_SUBI takes upto 8bits */
-      if (n > INT8_MAX || n < INT8_MIN) goto normal;
+      if (n > UINT8_MAX || n < -UINT8_MAX) goto normal;
       rewind_pc(s);
       if (n == 0) return;
       if (n > 0) {


### PR DESCRIPTION
It looks like OP_ADDI and OP_SUBI use unsigned 8-bit values, so they can handle values in the range of 0-255.
If I am wrong, it's okay to ignore/decline this pull request.