### PR TITLE
Fix numbered parameters when used as hash keys

### DIFF
--- a/test/t/syntax.rb
+++ b/test/t/syntax.rb
@@ -723,6 +723,12 @@ assert('numbered parameters in symbol name (https://github.com/mruby/mruby/issue
   assert_equal([:_1], Array.new(1) {:_1})
 end
 
+assert('numbered parameters as hash key') do
+  h = {_1: 3}
+  assert_equal(3, h[:_1])
+  assert_equal(7, -> { _1 }.call(7))
+end
+
 assert('numbered parameters as singleton') do
   o = Object.new
   lambda { def _1.a(b) = "a#{b}" }.call(o)


### PR DESCRIPTION
It seems that `_1` ~ `_9` are not correctly handled when used as hash keys.
They are added to the mandatory arguments of the parent block.
This leads to a "numbered parameter used in outer block" error in the example below.

```ruby
def f(&); end
f do
  h = {_1: 3}
  -> { _1 }.call(7)
end
```

I tried to fix this by moving the part of numbered parameters handling from the lexer to the parser.
Also, I replaced warnings with errors (it seems that Ruby throws errors).