### PR TITLE
Added document "Layout of the mruby filesystem"

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ extensions in C and/or Ruby. For a guide on how to use mrbgems, consult the
 - [About the Compile](doc/guides/compile.md)
 - [About the Debugger with the `mrdb` Command](doc/guides/debugger.md)
 - [About GC Arena](doc/guides/gc-arena-howto.md)
+- [About the mruby directory structure](doc/guides/hier.md)
 - [About Linking with `libmruby`](doc/guides/link.md)
 - [About Memory Allocator Customization](doc/guides/memory.md)
 - [About Build-time Configurations](doc/guides/mrbconf.md)

--- a/doc/guides/hier.md
+++ b/doc/guides/hier.md
@@ -1,0 +1,62 @@
+<!-- summary: About the mruby directory structure -->
+
+# The mruby directory structure
+
+```text
++- 💎 mruby/                    The top directory of mruby.
+    |
+    +- 📁 .github/              GitHub configuration files for mruby project management.
+    |
+    +- 📁 benchmark/            Benchmarking files for mruby.
+    |
+    +- 📁 bin/                  Links to temporary executables after build. Auto-created.
+    |
+    +- 📁 build/                Default build output destination for mruby. Auto-created.
+    |   |
+    |   +- 📁 repos/            The git clone destination directory for GEMs that depend on the build configuration.
+    |   |
+    |   +- 📁 host/             The "host" build output directory.
+    |
+    +- 📁 build_config/         Build configuration files for various environments.
+    |
+    +- 📁 doc/                  Documentation for mruby.
+    |   |
+    |   +- 📁 guides/           Documentation for general users.
+    |   |
+    |   +- 📁 internal/         Documentation for internal implementations for developers.
+    |
+    +- 📁 examples/             Examples of mruby usages.
+    |   |
+    |   +- 📁 mrbgems/          Examples for creating custom GEM for mruby.
+    |
+    +- 📁 include/              C header files required when using mruby.
+    |
+    +- 📁 lib/                  Ruby scripts used for building mruby.
+    |
+    +- 📁 mrbgems/              A library collection of features not provided by mruby core only.
+    |   |                       See doc/guides/mrbgems.md file
+    |   |
+    |   +- 📁 mruby-*/          The directory of each GEMs.
+    |   |
+    |   +- 📃 *.gembox          A collection of GEMs grouped by features and purposes.
+    |
+    +- 📁 mrblib/               The core Ruby scripts that makes up the main body of mruby.
+    |
+    +- 📁 oss-fuzz/             Source code for The fuzzing-test.
+    |                           See https://github.com/google/oss-fuzz
+    |
+    +- 📁 src/                  The core C source code that makes up the main body of mruby.
+    |
+    +- 📁 tasks/                Rake tasks at build-time.
+    |   |
+    |   +- 📁 toolchains/       Definitions for the compiler, linker, archiver, etc. for each toolchain.
+    |
+    +- 📁 test/                 Ruby scripts needed for testing mruby.
+    |   |
+    |   +- 📁 t/                mruby test cases.
+    |
+    +- 📁 tools/                External programs used for the mruby project.
+        |
+        +- 📁 lrama/            LALR parser generator as an alternative to bison.
+                                Import from https://github.com/ruby/lrama
+```


### PR DESCRIPTION
This text was translated from Japanese to English by https://www.deepl.com/ .

---

  - The text at the beginning of the file is an OpenBSD imitation (https://man.openbsd.org/OpenBSD-7.6/hier), but further tracing led to 4.3BSD NET/2 (https://man.freebsd.org/cgi/man.cgi?query=hier&manpath=4.3BSD+NET%2F2).
  - I ran `rake doc:update-index` and it removed one blank line in the `README.md` file.
    It seems that some mistake was made last time and they got mixed up.
