### PR TITLE
Remove unused `MRuby::Build#list_install_excludes` method

### DIFF
--- a/lib/mruby/build.rb
+++ b/lib/mruby/build.rb
@@ -542,14 +542,6 @@ EOS
       @install_prefix = dir&.to_s
     end
 
-    def list_install_excludes
-      install_excludes.flatten.flat_map { |e|
-        e.kind_of?(Proc) ? e.call(self) : e
-      }.map { |e|
-        File.join(build_dir, e)
-      }
-    end
-
     protected
 
     attr_writer :presym


### PR DESCRIPTION
This method was added by commit 0ac755dbc888020781e8ed19e417a5799217c7b3 (#6407). It was added during the initial conception, but was ultimately no longer needed.