### PR TITLE
Omit the `_WIN64` definition check

### DIFF
--- a/mrbgems/mruby-bin-mruby/tools/mruby/mruby.c
+++ b/mrbgems/mruby-bin-mruby/tools/mruby/mruby.c
@@ -14,7 +14,7 @@
 #include <mruby/error.h>
 #include <mruby/presym.h>
 
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 # include <io.h> /* for setmode */
 # include <fcntl.h>
 #endif
@@ -244,7 +244,7 @@ parse_args(mrb_state *mrb, int argc, char **argv, struct _args *args)
       argc--; argv++;
     }
   }
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
   if (args->rfp == stdin) {
     _setmode(_fileno(stdin), O_BINARY);
   }

--- a/mrbgems/mruby-dir/src/dir.c
+++ b/mrbgems/mruby-dir/src/dir.c
@@ -11,7 +11,7 @@
 #include <mruby/string.h>
 #include <mruby/presym.h>
 #include <sys/types.h>
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
   #define MAXPATHLEN 1024
  #if !defined(PATH_MAX)
   #define PATH_MAX MAX_PATH
@@ -173,7 +173,7 @@ mrb_dir_chdir(mrb_state *mrb, mrb_value klass)
 static mrb_value
 mrb_dir_chroot(mrb_state *mrb, mrb_value self)
 {
-#if defined(_WIN32) || defined(_WIN64) || defined(__ANDROID__) || defined(__MSDOS__)
+#if defined(_WIN32) || defined(__ANDROID__) || defined(__MSDOS__)
   mrb_raise(mrb, E_NOTIMP_ERROR, "chroot() unreliable on your system");
   return mrb_fixnum_value(0);
 #else
@@ -259,7 +259,7 @@ mrb_dir_rewind(mrb_state *mrb, mrb_value self)
 static mrb_value
 mrb_dir_seek(mrb_state *mrb, mrb_value self)
 {
-  #if defined(_WIN32) || defined(_WIN64) || defined(__ANDROID__)
+  #if defined(_WIN32) || defined(__ANDROID__)
   mrb_raise(mrb, E_NOTIMP_ERROR, "dirseek() unreliable on your system");
   return self;
   #else
@@ -280,7 +280,7 @@ mrb_dir_seek(mrb_state *mrb, mrb_value self)
 static mrb_value
 mrb_dir_tell(mrb_state *mrb, mrb_value self)
 {
-#if defined(_WIN32) || defined(_WIN64) || defined(__ANDROID__)
+#if defined(_WIN32) || defined(__ANDROID__)
   mrb_raise(mrb, E_NOTIMP_ERROR, "dirtell() unreliable on your system");
   return mrb_fixnum_value(0);
 #else

--- a/mrbgems/mruby-dir/test/dirtest.c
+++ b/mrbgems/mruby-dir/test/dirtest.c
@@ -5,7 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -60,7 +60,7 @@ mrb_dirtest_setup(mrb_state *mrb, mrb_value klass)
   mrb_cv_set(mrb, klass, mrb_intern_cstr(mrb, "pwd"), mrb_str_new_cstr(mrb, buf));
 
   /* create sandbox */
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
   snprintf(buf, sizeof(buf), "%s\\mruby-dir-test.XXXXXX", _getcwd(NULL,0));
   if ((_mktemp(buf) == NULL) || mkdir(buf,0) != 0) {
     mrb_raisef(mrb, E_RUNTIME_ERROR, "mkdtemp(%s) failed", buf);

--- a/mrbgems/mruby-io/src/file.c
+++ b/mrbgems/mruby-io/src/file.c
@@ -18,7 +18,7 @@
 #include <errno.h>
 #include <stdlib.h>
 #include <string.h>
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
   #include <windows.h>
   #include <io.h>
   #define NULL_FILE "NUL"
@@ -47,7 +47,7 @@
 
 #define FILE_SEPARATOR "/"
 
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
   #define PATH_SEPARATOR ";"
   #define FILE_ALT_SEPARATOR "\\"
   #define VOLUME_SEPARATOR ":"
@@ -99,7 +99,7 @@ flock(int fd, int operation)
 static mrb_value
 mrb_file_s_umask(mrb_state *mrb, mrb_value klass)
 {
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
   /* nothing to do on windows */
   return mrb_fixnum_value(0);
 
@@ -146,7 +146,7 @@ mrb_file_s_rename(mrb_state *mrb, mrb_value obj)
   char *src = mrb_locale_from_utf8(RSTRING_CSTR(mrb, from), -1);
   char *dst = mrb_locale_from_utf8(RSTRING_CSTR(mrb, to), -1);
   if (rename(src, dst) < 0) {
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
     if (CHMOD(dst, 0666) == 0 && UNLINK(dst) == 0 && rename(src, dst) == 0) {
       mrb_locale_free(src);
       mrb_locale_free(dst);
@@ -166,7 +166,7 @@ mrb_file_s_rename(mrb_state *mrb, mrb_value obj)
 static mrb_value
 mrb_file_dirname(mrb_state *mrb, mrb_value klass)
 {
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
   char dname[_MAX_DIR], vname[_MAX_DRIVE];
   char buffer[_MAX_DRIVE + _MAX_DIR];
   const char *utf8_path;
@@ -205,7 +205,7 @@ static mrb_value
 mrb_file_basename(mrb_state *mrb, mrb_value klass)
 {
   // NOTE: Do not use mrb_locale_from_utf8 here
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
   char bname[_MAX_DIR];
   char extname[_MAX_EXT];
   char buffer[_MAX_DIR + _MAX_EXT];
@@ -535,7 +535,7 @@ mrb_file_truncate(mrb_state *mrb, mrb_value self)
 static mrb_value
 mrb_file_s_symlink(mrb_state *mrb, mrb_value klass)
 {
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
   mrb_raise(mrb, E_NOTIMP_ERROR, "symlink is not supported on this platform");
 #else
   mrb_value from, to;
@@ -580,7 +580,7 @@ mrb_file_s_chmod(mrb_state *mrb, mrb_value klass)
 static mrb_value
 mrb_file_s_readlink(mrb_state *mrb, mrb_value klass)
 {
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
   mrb_raise(mrb, E_NOTIMP_ERROR, "readlink is not supported on this platform");
   return mrb_nil_value(); // unreachable
 #else
@@ -646,7 +646,7 @@ mrb_init_file(mrb_state *mrb)
   mrb_define_const_id(mrb, cnst, MRB_SYM(LOCK_NB), mrb_fixnum_value(LOCK_NB));
   mrb_define_const_id(mrb, cnst, MRB_SYM(SEPARATOR), mrb_str_new_cstr(mrb, FILE_SEPARATOR));
   mrb_define_const_id(mrb, cnst, MRB_SYM(PATH_SEPARATOR), mrb_str_new_cstr(mrb, PATH_SEPARATOR));
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
   mrb_define_const_id(mrb, cnst, MRB_SYM(ALT_SEPARATOR), mrb_str_new_cstr(mrb, FILE_ALT_SEPARATOR));
 #else
   mrb_define_const_id(mrb, cnst, MRB_SYM(ALT_SEPARATOR), mrb_nil_value());

--- a/mrbgems/mruby-io/src/file_test.c
+++ b/mrbgems/mruby-io/src/file_test.c
@@ -12,7 +12,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
   #define LSTAT stat
   #include <winsock.h>
 #else
@@ -118,7 +118,7 @@ mrb_filetest_s_directory_p(mrb_state *mrb, mrb_value klass)
 static mrb_value
 mrb_filetest_s_pipe_p(mrb_state *mrb, mrb_value klass)
 {
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
   mrb_raise(mrb, E_NOTIMP_ERROR, "pipe is not supported on this platform");
 #else
 #ifdef S_IFIFO
@@ -149,7 +149,7 @@ mrb_filetest_s_pipe_p(mrb_state *mrb, mrb_value klass)
 static mrb_value
 mrb_filetest_s_symlink_p(mrb_state *mrb, mrb_value klass)
 {
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
   mrb_raise(mrb, E_NOTIMP_ERROR, "symlink is not supported on this platform");
 #else
 #ifndef S_ISLNK
@@ -190,7 +190,7 @@ mrb_filetest_s_symlink_p(mrb_state *mrb, mrb_value klass)
 static mrb_value
 mrb_filetest_s_socket_p(mrb_state *mrb, mrb_value klass)
 {
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
   mrb_raise(mrb, E_NOTIMP_ERROR, "socket is not supported on this platform");
 #else
 #ifndef S_ISSOCK

--- a/mrbgems/mruby-io/src/io.c
+++ b/mrbgems/mruby-io/src/io.c
@@ -17,7 +17,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
   #include <winsock.h>
   #include <io.h>
   #include <basetsd.h>
@@ -783,7 +783,7 @@ fptr_finalize(mrb_state *mrb, struct mrb_io *fptr, int quiet)
 
 #ifndef MRB_NO_IO_POPEN
   if (fptr->pid != 0) {
-#if !defined(_WIN32) && !defined(_WIN64)
+#if !defined(_WIN32)
     pid_t pid;
     int status;
     do {

--- a/mrbgems/mruby-io/test/mruby_io_test.c
+++ b/mrbgems/mruby-io/test/mruby_io_test.c
@@ -3,7 +3,7 @@
 #include <errno.h>
 #include <string.h>
 
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 
 #include <winsock.h>
 #include <io.h>
@@ -79,7 +79,7 @@ mrb_io_test_io_setup(mrb_state *mrb, mrb_value self)
   mode_t mask;
   FILE *fp;
   int i;
-#if !defined(_WIN32) && !defined(_WIN64)
+#if !defined(_WIN32)
   struct sockaddr_un sun0 = { 0 }; /* Initialize them all because it is environment dependent */
 #endif
 
@@ -88,7 +88,7 @@ mrb_io_test_io_setup(mrb_state *mrb, mrb_value self)
   mask = umask(077);
   for (i = 0; i < IDX_COUNT; i++) {
     mrb_value fname = mrb_str_new_capa(mrb, 0);
-#if !defined(_WIN32) && !defined(_WIN64)
+#if !defined(_WIN32)
     /*
      * Workaround for not being able to bind a socket to some file systems
      * (e.g. vboxsf, NFS). [#4981]
@@ -129,7 +129,7 @@ mrb_io_test_io_setup(mrb_state *mrb, mrb_value self)
   }
   fclose(fp);
 
-#if !defined(_WIN32) && !defined(_WIN64)
+#if !defined(_WIN32)
   unlink(fnames[IDX_LINK]);
   if (symlink(basename(fnames[IDX_READ]), fnames[IDX_LINK]) == -1) {
     mrb_raise(mrb, E_RUNTIME_ERROR, "can't make a symbolic link");
@@ -214,7 +214,7 @@ mrb_io_test_rmdir(mrb_state *mrb, mrb_value klass)
 static mrb_value
 mrb_io_win_p(mrb_state *mrb, mrb_value klass)
 {
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 # if defined(__CYGWIN__) || defined(__CYGWIN32__)
   return mrb_false_value();
 # else

--- a/mrbgems/mruby-socket/test/sockettest.c
+++ b/mrbgems/mruby-socket/test/sockettest.c
@@ -3,7 +3,7 @@
 #include <mruby.h>
 #include <mruby/error.h>
 
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 
 #include <io.h>
 


### PR DESCRIPTION
Checking the official MSVC documentation, if `_WIN64` is defined, then `_WIN32` is also defined.
https://learn.microsoft.com/en-us/cpp/preprocessor/predefined-macros

I could not find any documentation on MinGW, but I assume it is not a problem.
