### PR TITLE
Fixed `File.expand_path`

### DIFF
--- a/mrbgems/mruby-io/mrblib/file.rb
+++ b/mrbgems/mruby-io/mrblib/file.rb
@@ -149,7 +149,7 @@ class File < IO
     if drive_prefix.empty?
       expanded_path
     else
-      drive_prefix + expanded_path.gsub("/", File::ALT_SEPARATOR)
+      drive_prefix + expanded_path
     end
   end
 

--- a/mrbgems/mruby-io/test/file.rb
+++ b/mrbgems/mruby-io/test/file.rb
@@ -210,13 +210,13 @@ assert('File.expand_path') do
   end
 end
 
-assert('File.expand_path (with ENV)') do
-  skip unless Object.const_defined?(:ENV) && ENV['HOME']
+assert('File.expand_path (with getenv(3))') do
+  skip unless MRubyIOTestUtil.const_defined?(:ENV_HOME)
 
-  assert_equal ENV['HOME'], File.expand_path("~/"),      "home"
-  assert_equal ENV['HOME'], File.expand_path("~/", "/"), "home with base_dir"
+  assert_equal MRubyIOTestUtil::ENV_HOME, File.expand_path("~/"),      "home"
+  assert_equal MRubyIOTestUtil::ENV_HOME, File.expand_path("~/", "/"), "home with base_dir"
 
-  assert_equal "#{ENV['HOME']}/user", File.expand_path("user", ENV['HOME']), "relative with base_dir"
+  assert_equal "#{MRubyIOTestUtil::ENV_HOME}/user", File.expand_path("user", MRubyIOTestUtil::ENV_HOME), "relative with base_dir"
 end
 
 assert('File.path') do

--- a/mrbgems/mruby-io/test/file.rb
+++ b/mrbgems/mruby-io/test/file.rb
@@ -204,7 +204,7 @@ assert('File.expand_path') do
   assert_equal "/", File.expand_path("../../../..", "/")
   if File._getwd[1] == ":"
     drive_letter = File._getwd[0]
-    assert_equal drive_letter + ":\\", File.expand_path(([".."] * 100).join("/"))
+    assert_equal drive_letter + ":/", File.expand_path(([".."] * 100).join("/"))
   else
     assert_equal "/", File.expand_path(([".."] * 100).join("/"))
   end

--- a/mrbgems/mruby-io/test/mruby_io_test.c
+++ b/mrbgems/mruby-io/test/mruby_io_test.c
@@ -243,4 +243,26 @@ mrb_mruby_io_gem_test(mrb_state* mrb)
   mrb_define_class_method(mrb, io_test, "win?", mrb_io_win_p, MRB_ARGS_NONE());
 
   mrb_define_const(mrb, io_test, "MRB_WITH_IO_PREAD_PWRITE", mrb_bool_value(MRB_WITH_IO_PREAD_PWRITE_ENABLED));
+
+  const char *env_home = getenv("HOME");
+#ifdef _WIN32
+  if (!env_home) {
+    env_home = getenv("USERPROFILE");
+  }
+#endif
+  if (env_home) {
+    char *utf8 = mrb_utf8_from_locale(env_home, strlen(env_home));
+    mrb_value path = mrb_str_new_cstr(mrb, utf8);
+#ifdef _WIN32
+    char *pathp = RSTRING_PTR(path);
+    const char *const pathend = pathp + RSTRING_LEN(path);
+    for (;;) {
+      pathp = memchr(pathp, '\\', pathend - pathp);
+      if (!pathp) break;
+      *pathp++ = '/';
+    }
+#endif
+    mrb_define_const(mrb, io_test, "ENV_HOME", path);
+    mrb_utf8_free(utf8);
+  }
 }


### PR DESCRIPTION
  - Improved `File.expand_path` test in `mruby-io

    Since `mruby-io` does not depend on `mruby-env` even for test builds, it is impossible that `ENV` constants are defined.
    Therefore, define `MRubyIOTestUtil::ENV_HOME` for alternative use.

  - Fix `File.expand_path` for Windows

      - The inner method `File._gethome` could be read as intending to use the `USERPROFILE` environment variable instead on Windows when the `HOME` environment variable is not available.
        In reality, however, this was not the case.
      - The result of `File.expand_path` should unify path separators with `/`, but it did not.
