### PR TITLE
Suppress presym in `mruby/ext/io.h` file

### DIFF
--- a/mrbgems/mruby-io/include/mruby/ext/io.h
+++ b/mrbgems/mruby-io/include/mruby/ext/io.h
@@ -6,7 +6,6 @@
 #define MRUBY_IO_H
 
 #include <mruby.h>
-#include <mruby/presym.h>
 
 #ifdef MRB_NO_STDIO
 # error IO and File conflicts 'MRB_NO_STDIO' in your build configuration
@@ -66,8 +65,8 @@ struct mrb_io {
 #define MRB_O_DSYNC             0x00008000
 #define MRB_O_RSYNC             0x00010000
 
-#define E_IO_ERROR              mrb_exc_get_id(mrb, MRB_SYM(IOError))
-#define E_EOF_ERROR             mrb_exc_get_id(mrb, MRB_SYM(EOFError))
+#define E_IO_ERROR              mrb_exc_get_id(mrb, MRB_ERROR_SYM(IOError))
+#define E_EOF_ERROR             mrb_exc_get_id(mrb, MRB_ERROR_SYM(EOFError))
 
 int mrb_io_fileno(mrb_state *mrb, mrb_value io);
 


### PR DESCRIPTION
When defining macro constants for error classes in public header files, it is preferable to use `MRB_ERROR_SYM()`.