### PR TITLE
Change `MRB_WITH_IO_PREAD_PWRITE` configuration name

### DIFF
--- a/build_config/i586-pc-msdosdjgpp.rb
+++ b/build_config/i586-pc-msdosdjgpp.rb
@@ -15,13 +15,13 @@ MRuby::CrossBuild.new("i586-pc-msdosdjgpp") do |conf|
 
   conf.cc do |cc|
     cc.command = DJGPP_PATH ? File.join(DJGPP_PATH, GCC) : GCC
-    cc.defines << 'MRB_WITHOUT_IO_PREAD_PWRITE'
+    cc.defines << 'MRB_NO_IO_PREAD_PWRITE'
     cc.defines << 'MRB_UTF8_STRING'
   end
 
   conf.cxx do |cxx|
     cxx.command = DJGPP_PATH ? File.join(DJGPP_PATH, GXX) : GXX
-    cxx.defines << 'MRB_WITHOUT_IO_PREAD_PWRITE'
+    cxx.defines << 'MRB_NO_IO_PREAD_PWRITE'
     cxx.defines << 'MRB_UTF8_STRING'
   end
 

--- a/mrbgems/mruby-io/include/mruby/ext/io.h
+++ b/mrbgems/mruby-io/include/mruby/ext/io.h
@@ -15,11 +15,11 @@
 extern "C" {
 #endif
 
-#if defined(MRB_WITHOUT_IO_PREAD_PWRITE)
-# undef MRB_WITH_IO_PREAD_PWRITE
-#elif !defined(MRB_WITH_IO_PREAD_PWRITE)
-# if defined(__unix__) || defined(__MACH__)
-#  define MRB_WITH_IO_PREAD_PWRITE
+#if defined(MRB_NO_IO_PREAD_PWRITE) || defined(MRB_WITHOUT_IO_PREAD_PWRITE)
+# undef MRB_USE_IO_PREAD_PWRITE
+#elif !defined(MRB_USE_IO_PREAD_PWRITE)
+# if defined(__unix__) || defined(__MACH__) || defined(MRB_WITH_IO_PREAD_PWRITE)
+#  define MRB_USE_IO_PREAD_PWRITE
 # endif
 #endif
 

--- a/mrbgems/mruby-io/src/io.c
+++ b/mrbgems/mruby-io/src/io.c
@@ -1502,7 +1502,7 @@ io_sync(mrb_state *mrb, mrb_value io)
   return mrb_bool_value(fptr->sync);
 }
 
-#ifndef MRB_WITH_IO_PREAD_PWRITE
+#ifndef MRB_USE_IO_PREAD_PWRITE
 # define io_pread   mrb_notimplement_m
 # define io_pwrite  mrb_notimplement_m
 #else
@@ -1541,7 +1541,7 @@ io_pwrite(mrb_state *mrb, mrb_value io)
 
   return io_write_common(mrb, pwrite, io_get_write_fptr(mrb, io), RSTRING_PTR(buf), RSTRING_LEN(buf), value2off(mrb, off));
 }
-#endif /* MRB_WITH_IO_PREAD_PWRITE */
+#endif /* MRB_USE_IO_PREAD_PWRITE */
 
 static mrb_value
 io_ungetc(mrb_state *mrb, mrb_value io)

--- a/mrbgems/mruby-io/test/io.rb
+++ b/mrbgems/mruby-io/test/io.rb
@@ -589,7 +589,7 @@ assert('IO#sysseek') do
 end
 
 assert('IO#pread') do
-  skip "IO#pread is not implemented on this configuration" unless MRubyIOTestUtil::MRB_WITH_IO_PREAD_PWRITE
+  skip "IO#pread is not implemented on this configuration" unless MRubyIOTestUtil::MRB_USE_IO_PREAD_PWRITE
 
   IO.open(IO.sysopen($mrbtest_io_rfname, 'r'), 'r') do |io|
     assert_equal $mrbtest_io_msg.byteslice(5, 8), io.pread(8, 5)
@@ -601,7 +601,7 @@ assert('IO#pread') do
 end
 
 assert('IO#pwrite') do
-  skip "IO#pwrite is not implemented on this configuration" unless MRubyIOTestUtil::MRB_WITH_IO_PREAD_PWRITE
+  skip "IO#pwrite is not implemented on this configuration" unless MRubyIOTestUtil::MRB_USE_IO_PREAD_PWRITE
 
   IO.open(IO.sysopen($mrbtest_io_wfname, 'w+'), 'w+') do |io|
     assert_equal 6, io.pwrite("Warld!", 7)

--- a/mrbgems/mruby-io/test/mruby_io_test.c
+++ b/mrbgems/mruby-io/test/mruby_io_test.c
@@ -225,10 +225,10 @@ mrb_io_win_p(mrb_state *mrb, mrb_value klass)
 #endif
 }
 
-#ifdef MRB_WITH_IO_PREAD_PWRITE
-# define MRB_WITH_IO_PREAD_PWRITE_ENABLED TRUE
+#ifdef MRB_USE_IO_PREAD_PWRITE
+# define MRB_USE_IO_PREAD_PWRITE_ENABLED TRUE
 #else
-# define MRB_WITH_IO_PREAD_PWRITE_ENABLED FALSE
+# define MRB_USE_IO_PREAD_PWRITE_ENABLED FALSE
 #endif
 
 void
@@ -242,7 +242,7 @@ mrb_mruby_io_gem_test(mrb_state* mrb)
   mrb_define_class_method(mrb, io_test, "rmdir", mrb_io_test_rmdir, MRB_ARGS_REQ(1));
   mrb_define_class_method(mrb, io_test, "win?", mrb_io_win_p, MRB_ARGS_NONE());
 
-  mrb_define_const(mrb, io_test, "MRB_WITH_IO_PREAD_PWRITE", mrb_bool_value(MRB_WITH_IO_PREAD_PWRITE_ENABLED));
+  mrb_define_const(mrb, io_test, "MRB_USE_IO_PREAD_PWRITE", mrb_bool_value(MRB_USE_IO_PREAD_PWRITE_ENABLED));
 
   const char *env_home = getenv("HOME");
 #ifdef _WIN32


### PR DESCRIPTION
Change to `MRB_USE_IO_PREAD_PWRITE` for consistency with mruby configuration macros.
Similarly, `MRB_WITHOUT_IO_PREAD_PWRITE` is changed to `MRB_NO_IO_PREAD_PWRITE`.

The previous names are available for compatibility but are deprecated.
