### PR TITLE
To create a release package file in draft

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Release
         uses: softprops/action-gh-release@v2
         with:
-          # draft: true
+          draft: true
           prerelease: ${{ contains(github.ref_name, '-rc') }}
           body_path: NEWS
           files: packages/*


### PR DESCRIPTION
This is to allow final confirmation of the created release file. Release files in draft form cannot be downloaded by the general public.

---

This is related to #6133.
While #6133 makes a release announcement as soon as the tag is pushed, this patch creates the release announcement in a stubbed state, giving the administrator room for final review.

Since it will be invisible to everyone except the project manager, the release status must be changed if the file is to be made available to the public.
The release message can also be changed at this time.
