### PR TITLE
Moved tests for `Integer#quo`

### DIFF
--- a/mrbgems/mruby-rational/test/rational.rb
+++ b/mrbgems/mruby-rational/test/rational.rb
@@ -309,3 +309,8 @@ assert 'Rational#**' do
   assert_float(16.0, (4r)**(2.0))
   assert_float(3.5**1.5, (7/2r)**(1.5))
 end
+
+assert 'Integer#quo' do
+  a = 6.quo(5)
+  assert_equal 6/5r, a
+end

--- a/test/t/integer.rb
+++ b/test/t/integer.rb
@@ -49,12 +49,7 @@ assert('Integer#/', '15.2.8.3.4') do
   assert_equal 2.0, b
 end
 
-if Object.const_defined?(:Rational)
-  assert('Integer#quo') do
-    a = 6.quo(5)
-    assert_equal 5/6r, a
-  end
-elsif Object.const_defined?(:Float)
+if Object.const_defined?(:Float)
   assert('Integer#quo') do
     a = 6.quo(5)
     assert_equal 1.2, a


### PR DESCRIPTION
The `Rational` class is never defined during core testing.