### PR TITLE
Avoid array object creation with “unknown keyword” error

### DIFF
--- a/include/mruby/internal.h
+++ b/include/mruby/internal.h
@@ -81,6 +81,7 @@ void mrb_gc_free_mt(mrb_state*, struct RClass*);
 size_t mrb_hash_memsize(mrb_value obj);
 size_t mrb_gc_mark_hash(mrb_state*, struct RHash*);
 void mrb_gc_free_hash(mrb_state*, struct RHash*);
+mrb_value mrb_hash_first_key(mrb_state*, mrb_value);
 
 /* irep */
 struct mrb_insn_data mrb_decode_insn(const mrb_code *pc);

--- a/src/class.c
+++ b/src/class.c
@@ -1284,8 +1284,7 @@ get_args_v(mrb_state *mrb, mrb_args_format format, void** ptr, va_list *ap)
           *rest = ksrc;
         }
         else if (!mrb_hash_empty_p(mrb, ksrc)) {
-          ksrc = mrb_hash_keys(mrb, ksrc);
-          ksrc = RARRAY_PTR(ksrc)[0];
+          ksrc = mrb_hash_first_key(mrb, ksrc);
           mrb_raisef(mrb, E_ARGUMENT_ERROR, "unknown keyword: %v", ksrc);
         }
       }

--- a/src/hash.c
+++ b/src/hash.c
@@ -1130,6 +1130,15 @@ mrb_hash_foreach(mrb_state *mrb, struct RHash *h, mrb_hash_foreach_func *func, v
   }
 }
 
+mrb_value
+mrb_hash_first_key(mrb_state *mrb, mrb_value h)
+{
+  H_EACH(mrb_hash_ptr(h), entry) {
+    return entry->key;
+  }
+  return mrb_nil_value();
+}
+
 MRB_API mrb_value
 mrb_hash_new(mrb_state *mrb)
 {

--- a/src/vm.c
+++ b/src/vm.c
@@ -2276,8 +2276,7 @@ RETRY_TRY_BLOCK:
       mrb_value kdict;
 
       if (kidx >= 0 && mrb_hash_p(kdict=regs[kidx]) && !mrb_hash_empty_p(mrb, kdict)) {
-        mrb_value keys = mrb_hash_keys(mrb, kdict);
-        mrb_value key1 = RARRAY_PTR(keys)[0];
+        mrb_value key1 = mrb_hash_first_key(mrb, kdict);
         RAISE_FORMAT(mrb, E_ARGUMENT_ERROR, "unknown keyword: %v", key1);
       }
       NEXT;


### PR DESCRIPTION
It is sufficient to return the first element.