### PR TITLE
Add Emscripten toolchain & build_config

### DIFF
--- a/build_config/emscripten-cxx.rb
+++ b/build_config/emscripten-cxx.rb
@@ -1,0 +1,12 @@
+# Make sure to add these compile options:
+#   build/emscripten-cxx/host-bin/mruby-config --cxxflags
+#
+# Make sure to add these link options:
+#   build/emscripten-cxx/host-bin/mruby-config --ldflags --libs
+MRuby::CrossBuild.new('emscripten-cxx') do |conf|
+  conf.toolchain :emscripten
+
+  conf.gembox 'default'
+
+  conf.enable_cxx_abi
+end

--- a/build_config/emscripten.rb
+++ b/build_config/emscripten.rb
@@ -1,0 +1,10 @@
+# Make sure to add these compile options:
+#   build/emscripten/host-bin/mruby-config --cflags
+#
+# Make sure to add these link options:
+#   build/emscripten/host-bin/mruby-config --ldflags --libs
+MRuby::CrossBuild.new('emscripten') do |conf|
+  conf.toolchain :emscripten
+
+  conf.gembox 'default'
+end

--- a/mrbgems/mruby-cmath/src/cmath.c
+++ b/mrbgems/mruby-cmath/src/cmath.c
@@ -92,7 +92,9 @@ CXDIVc(mrb_complex a, mrb_complex b)
 
 #else
 
-#if defined(__cplusplus) && (defined(__APPLE__) || (defined(__clang__) && (defined(__FreeBSD__) || defined(__OpenBSD__))))
+#if defined(__cplusplus) && \
+    (defined(__APPLE__) || defined(__EMSCRIPTEN__) || \
+     (defined(__clang__) && (defined(__FreeBSD__) || defined(__OpenBSD__))))
 
 #ifdef MRB_USE_FLOAT32
 typedef std::complex<float> mrb_complex;

--- a/tasks/toolchains/emscripten.rake
+++ b/tasks/toolchains/emscripten.rake
@@ -1,0 +1,36 @@
+MRuby::Toolchain.new(:emscripten) do |conf|
+  toolchain :clang
+
+  # See:
+  # - https://emscripten.org/docs/tools_reference/emcc.html
+  # - https://emscripten.org/docs/tools_reference/settings_reference.html
+  # - https://github.com/emscripten-core/emscripten/blob/main/src/settings.js
+  compile_and_link_flags = [
+  ]
+  compile_flags = [
+    *compile_and_link_flags,
+    '-Wno-unused-but-set-variable',
+  ]
+  link_flags = [
+    *compile_and_link_flags,
+  ]
+
+  conf.cc do |cc|
+    cc.command = 'emcc'
+    cc.flags.concat(compile_flags) unless ENV['CFLAGS']
+  end
+
+  conf.cxx do |cxx|
+    cxx.command = 'em++'
+    cxx.flags.concat(compile_flags) unless ENV['CXXFLAGS'] || ENV['CFLAGS']
+  end
+
+  conf.linker do |linker|
+    linker.command = 'emcc'
+    linker.flags.concat(link_flags) unless ENV['LDFLAGS']
+  end
+
+  conf.archiver do |archiver|
+    archiver.command = 'emar'
+  end
+end


### PR DESCRIPTION
Adds support for Emscripten. Also related: #5453

## Notes

### 1. tasks/toolchains/emscripten.rake

Because Emscripten includes a lot options that should be used for both Compile & Link, I have a `compile_and_link_flags` var for convenience. This was really useful for me when testing and/or adding flags to improve code optimization, etc. I also provided doc links.

### 2. build_config/emscripten.rb & emscripten-cxx.rb

Just linking `libmruby.a` gave me a bunch of issues. See [emscripten/issues/23858](https://github.com/emscripten-core/emscripten/issues/23858). Using the `mruby-config` flags fixed my issue. Therefore, I added a comment about this in both of these files to ensure people use these flags when linking mruby to their Emscripten app.

### 3. mrbgems/mruby-cmath/src/cmath.c

This wouldn't compile in C++. I figured out it's because of this if-statement. I'm wondering why it isn't just `#if defined(__cplusplus)`? Maybe some other system breaks with it, not sure.