### PR TITLE
Fix codespell hook; fix spelling and update codespell ignored words list

### DIFF
--- a/.github/linters/codespell.txt
+++ b/.github/linters/codespell.txt
@@ -1,4 +1,6 @@
+abd
 ans
+catched
 celler
 clen
 delet
@@ -6,6 +8,7 @@ disabl
 filetest
 fo
 hel
+indx
 ist
 nd
 quitt

--- a/doc/guides/symbol.md
+++ b/doc/guides/symbol.md
@@ -71,7 +71,7 @@ header.
 For `MRB_OPSYM()`, specify the names corresponding to operators (see
 `MRuby::Presym::OPERATORS` in `lib/mruby/presym.rb` for the names that
 can be specified for it). Other than that, describe only word characters
-excluding leading and ending punctuations.
+excluding leading and ending punctuation.
 
 These macros are converted to static symbol IDs at compile time, unless
 preallocate symbols are disabled by `conf.disable_presym`. In that case,

--- a/doc/mruby3.4.md
+++ b/doc/mruby3.4.md
@@ -4,7 +4,7 @@
 
 # The language
 
-- mruby now supports `private` and `protected` visibitily ([b0db0bd](https://github.com/mruby/mruby/commit/b0db0bd))
+- mruby now supports `private` and `protected` visibility ([b0db0bd](https://github.com/mruby/mruby/commit/b0db0bd))
 - Maximum length of inlined symbols reduced from 5 to 4 characters to provide space for visibility flags ([6442a01](https://github.com/mruby/mruby/commit/6442a01))
 - Many methods are made private according to CRuby visibility ([4a0e806](https://github.com/mruby/mruby/commit/4a0e806))
 - Generate OP_SSEND for `self.method` type calls ([111fe4b](https://github.com/mruby/mruby/commit/111fe4b))

--- a/include/mruby/presym.h
+++ b/include/mruby/presym.h
@@ -30,7 +30,7 @@
  * For `MRB_OPSYM`, specify the names corresponding to operators (see
  * `MRuby::Presym::OPERATORS` in `lib/mruby/presym.rb` for the names that
  * can be specified for it). Other than that, describe only word characters
- * excluding leading and ending punctuations.
+ * excluding leading and ending punctuation.
  *
  * These macros are expanded to `mrb_intern_lit` if presym is disabled,
  * therefore the mruby state variable is required. The above macros can be


### PR DESCRIPTION
After updating from upstream master and running pre-commit locally I found that the codespell hook failed as seen in the image below:

![Screenshot from 2025-03-09 18-48-35](https://github.com/user-attachments/assets/9b297482-053d-4424-926f-518e03b93c20)
