### PR TITLE
pre-commit: update codespell.txt fixes codespell hook

### DIFF
--- a/.github/linters/codespell.txt
+++ b/.github/linters/codespell.txt
@@ -1,4 +1,6 @@
+abd
 ans
+catched
 celler
 clen
 delet


### PR DESCRIPTION
Currently the pre-commit codespell hook is failing on master.

There was a minor update to the codespell.txt file in #6488 that did not get merged in.

Image shows the failure before this PR fix:
 
![Screenshot from 2025-03-28 11-27-14](https://github.com/user-attachments/assets/879c7bbd-5805-48e6-a45f-47234e644915)
