### PR TITLE
Update pre-commit Node.js version to `v22.14.0 LTS`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,8 @@ default_stages: [pre-commit, pre-push]
 default_language_version:
   # force all unspecified Python hooks to run python3
   python: python3
-  node: 22.2.0
+  # force all unspecified Node hooks to run Node.js v22.14.0 LTS
+  node: 22.14.0
 minimum_pre_commit_version: "3.2.0"
 repos:
   - repo: meta


### PR DESCRIPTION
Node.js `v22.14.0` is the LTS version we should be now using.

https://nodejs.org/en

And seen on the pre-commit site we can set the node version as default.

For node they use nodeenv. 

https://pre-commit.com/#overriding-language-version

And here shows how nodeenv uses and lists its version numbers without the `v` prefix:

`nodeenv --list`

https://github.com/ekalinin/nodeenv?tab=readme-ov-file#advanced