### PR TITLE
Fixed class method visibility via `module_function`

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -2789,7 +2789,7 @@ mrb_mod_module_function(mrb_state *mrb, mrb_value mod)
     mrb_method_t m = mrb_method_search(mrb, rclass, mid);
 
     prepare_singleton_class(mrb, (struct RBasic*)rclass);
-    MRB_METHOD_SET_VISIBILITY(m, MT_PRIVATE);
+    MRB_METHOD_SET_VISIBILITY(m, MT_PUBLIC);
     mrb_define_method_raw(mrb, rclass->c, mid, m);
     mrb_gc_arena_restore(mrb, ai);
   }

--- a/test/t/module.rb
+++ b/test/t/module.rb
@@ -838,6 +838,9 @@ assert('Module#module_function') do
   end
 
   assert_true M.respond_to?(:modfunc)
+  assert_equal nil do
+    M.modfunc
+  end
 end
 
 assert('module with non-class/module outer raises TypeError') do


### PR DESCRIPTION
The following code should work

```ruby
module M
  def me
    p self
  end

  module_function :me
end

M.me
```