### PR TITLE
Exclude the external project "lrama" from pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,7 @@ default_language_version:
   # force all unspecified Node hooks to run Node.js v22.14.0 LTS
   node: 22.14.0
 minimum_pre_commit_version: "3.2.0"
+exclude: "^tools/lrama/"
 repos:
   - repo: meta
     hooks:


### PR DESCRIPTION
@jbampton,
I don't think it should be maintained or controlled by the mruby project.
If you have any concerns or objections to this configuration change, I would appreciate your comments.
