### PR TITLE
Make Kernel#` public again

### DIFF
--- a/mrbgems/mruby-io/mrblib/kernel.rb
+++ b/mrbgems/mruby-io/mrblib/kernel.rb
@@ -1,5 +1,5 @@
 module Kernel
-  private def `(cmd) #`
+  def `(cmd) #`
     IO.popen(cmd) { |io| io.read }
   end
 


### PR DESCRIPTION
I'm updating one of my projects to use 3.4.0, and it uses `` Kernel#` `` to find and load a Linux kernel module. Making `` Kernel#` `` private broke that.

This reverts it to public, so that works again. Not sure if the original change was intentional?