### PR TITLE
Change mrbc_args.flags bit width from 2 to 3.

### DIFF
--- a/mrbgems/mruby-bin-mrbc/tools/mrbc/mrbc.c
+++ b/mrbgems/mruby-bin-mrbc/tools/mrbc/mrbc.c
@@ -26,7 +26,7 @@ struct mrbc_args {
   mrb_bool verbose      : 1;
   mrb_bool no_ext_ops   : 1;
   mrb_bool no_optimize  : 1;
-  uint8_t flags         : 2;
+  uint8_t flags         : 3;
 };
 
 static void


### PR DESCRIPTION
mrbc command's --remove-lv option is not work now.
Because define the MRB_DUMP_NO_LVAR value is 4, but mrbc_args.flags bit field width is 2 bit.
This pull request fixes this.
