### PR TITLE
Add `tools/lrama` to `.prettierignore`

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@
 build
 coverage
 doc/internal/opcode.md
+tools/lrama


### PR DESCRIPTION
Prettier uses an ignore file to exclude files from formatting when running with pre-commit and also when running standalone from the command line.

This is detailed on the CLI docs page:

https://prettier.io/docs/cli