### PR TITLE
Skip adding empty input to mirb history

### DIFF
--- a/mrbgems/mruby-bin-mirb/tools/mirb/mirb.c
+++ b/mrbgems/mruby-bin-mirb/tools/mirb/mirb.c
@@ -607,7 +607,9 @@ main(int argc, char **argv)
     }
     strcpy(last_code_line, line);
     strcat(last_code_line, "\n");
-    MIRB_ADD_HISTORY(line);
+    if (strlen(line) > 0) {
+      MIRB_ADD_HISTORY(line);
+    }
     MIRB_LINE_FREE(line);
 #endif
 


### PR DESCRIPTION
In CRuby’s irb, executing an empty input does not add it to the history. However, in mruby’s mirb, even empty inputs are recorded in the history. This behavior can be inconvenient when trying to reuse previous inputs.

While using mirb, I found it frustrating to press the up arrow key and have to skip over empty inputs in the history. To improve the usability, I modified mirb so that empty inputs are no longer added to the history.