### PR TITLE
Revert "class.c (find_visibility_scope): when callinfo returns, *ep == NULL; #6512"

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -764,7 +764,7 @@ find_visibility_scope(mrb_state *mrb, const struct RClass *c, int n, mrb_callinf
 
   if (check_visibility_break(p, c, ci, NULL)) {
     mrb_assert(ci->u.env);
-    *ep = NULL;
+    *ep = (ci->u.env->tt == MRB_TT_ENV ? ci->u.env : NULL);
     *cp = ci;
     return;
   }

--- a/test/t/module.rb
+++ b/test/t/module.rb
@@ -839,6 +839,16 @@ assert('method visibility with meta programming') do
     f.call
     c.new.bad!
   end
+
+  assert_raise NoMethodError do
+    c = Class.new {
+      -> { private }.call
+      def bad!
+        "BAD!"
+      end
+    }
+    c.new.bad!
+  end
 end
 
 assert('Module#module_function') do


### PR DESCRIPTION
This reverts commit 3879b95a6223846bc6763d84cb8c0282a6792d31.

This is because the code first reported in #6494 no longer works.
 
And added more test.
