### PR TITLE
Fix calling `extended` callback

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -1681,8 +1681,8 @@ mrb_obj_extend(mrb_state *mrb, mrb_value obj)
     mrb_value mod = argv[argc];
     mrb_check_type(mrb, mod, MRB_TT_MODULE);
     mrb_include_module(mrb, mrb_class_ptr(cc), mrb_class_ptr(mod));
-    if (!mrb_func_basic_p(mrb, cc, extended, mrb_do_nothing)) {
-      mrb_funcall_argv(mrb, cc, extended, 1, &mod);
+    if (!mrb_func_basic_p(mrb, mod, extended, mrb_do_nothing)) {
+      mrb_funcall_argv(mrb, mod, extended, 1, &obj);
     }
   }
   return obj;

--- a/test/t/class.rb
+++ b/test/t/class.rb
@@ -477,3 +477,29 @@ assert('class with non-class/module outer raises TypeError') do
   assert_raise(TypeError) { class 0::C1; end }
   assert_raise(TypeError) { class []::C2; end }
 end
+
+assert('module with extended callback') do
+  module FooWithExtended
+    @@extended = []
+
+    def self.extended(base)
+      @@extended << base
+    end
+
+    def self.extended_classes
+      @@extended
+    end
+
+    def answer
+      42
+    end
+  end
+
+  class BarBeingExtended
+    extend FooWithExtended
+  end
+
+  assert_equal [BarBeingExtended], FooWithExtended.extended_classes
+  assert_true BarBeingExtended.respond_to?(:answer)
+  assert_equal 42, BarBeingExtended.answer
+end


### PR DESCRIPTION
It seems that between 3.4.0 and current HEAD the behaviour of `extend` has changed. I noticed it, because the test for `mruby-class-attribute` [failed when ran against head](https://github.com/katafrakt/mruby-class-attribute/actions/runs/15242364473/job/42981521865?pr=1). `git bisect` pointed me to 6c72f8b378fc8743ec1775b3e2d7dd507ec2b394 and indeed I noticed that the handling of `extended` callback seems to be looking for it in the singleton class of the object which is being extended instead of the extension module.

With this change, tests for `mruby-class-attribute` pass. I also added a test with the PR. Hope it does not break other things.