### PR TITLE
`iv_foreach()` needs to update the pointer at each loop

### DIFF
--- a/src/variable.c
+++ b/src/variable.c
@@ -187,9 +187,9 @@ static void
 iv_foreach(mrb_state *mrb, iv_tbl *t, mrb_iv_foreach_func *func, void *p)
 {
   if (t == NULL || t->alloc == 0 || t->size == 0) return;
-  mrb_sym   *keys = (mrb_sym*)&t->ptr[t->alloc];
-  mrb_value *vals =  t->ptr;
   for (int i = 0; i < t->size; i++) {
+    mrb_sym   *keys = (mrb_sym*)&t->ptr[t->alloc];
+    mrb_value *vals = t->ptr;
     if ((*func)(mrb, keys[i], vals[i], p) != 0) return;
   }
 }


### PR DESCRIPTION
When calling a user function, a pointer retrieved outside of a loop may be invalidated.

---

I have code that actually crashes mruby.
The revision of mruby is 2edfd96cbef5f5768168188254398478f72c5459.

<details>

```console
% cat iv_foreach.rb
$o = Object.new
$o.instance_variable_set :@a, Object.new
$o.instance_variable_set :@var0, 0
class << $o.instance_variable_get(:@a)
  def inspect
    10.times { $o.instance_variable_set :"@var#{_1}", _1 }
    super
  end
end

p $o

% valgrind bin/mruby iv_foreach.rb
==6786== Memcheck, a memory error detector
==6786== Copyright (C) 2002-2024, and GNU GPL'd, by Julian Seward et al.
==6786== Using Valgrind-3.25.1 and LibVEX; rerun with -h for copyright info
==6786== Command: bin/mruby iv_foreach.rb
==6786==
==6786== Invalid read of size 4
==6786==    at 0x28C763: iv_foreach (variable.c:193)
==6786==    by 0x28C763: mrb_obj_iv_inspect (variable.c:635)
==6786==    by 0x295E69: mrb_vm_exec (vm.c:0)
==6786==    by 0x2B3EA1: mrb_load_exec (parse.y:6935)
==6786==    by 0x2B41C0: mrb_load_detect_file_cxt (parse.y:6978)
==6786==    by 0x25F990: main (mruby.c:353)
==6786==  Address 0x5649374 is 36 bytes inside a block of size 48 free'd
==6786==    at 0x48502BC: free (vg_replace_malloc.c:993)
==6786==    by 0x272181: mrb_basic_alloc_func (allocf.c:30)
==6786==    by 0x28C03E: iv_rehash (variable.c:69)
==6786==    by 0x28C03E: iv_put (variable.c:102)
==6786==    by 0x28BEF8: mrb_obj_iv_set_force (variable.c:399)
==6786==    by 0x2ECDD1: mrb_obj_ivar_set (metaprog.c:109)
==6786==    by 0x295E69: mrb_vm_exec (vm.c:0)
==6786==    by 0x28F8A6: mrb_run (vm.c:3369)
==6786==    by 0x28F8A6: mrb_funcall_with_block (vm.c:833)
==6786==    by 0x2813AB: mrb_inspect (object.c:832)
==6786==    by 0x28C7E5: inspect_i (variable.c:611)
==6786==    by 0x28C7E5: iv_foreach (variable.c:193)
==6786==    by 0x28C7E5: mrb_obj_iv_inspect (variable.c:635)
==6786==    by 0x295E69: mrb_vm_exec (vm.c:0)
==6786==    by 0x2B3EA1: mrb_load_exec (parse.y:6935)
==6786==    by 0x2B41C0: mrb_load_detect_file_cxt (parse.y:6978)
==6786==  Block was alloc'd at
==6786==    at 0x4853371: realloc (vg_replace_malloc.c:1807)
==6786==    by 0x26FB85: mrb_realloc_simple (gc.c:197)
==6786==    by 0x26FB85: mrb_realloc (gc.c:211)
==6786==    by 0x26FB85: mrb_malloc (gc.c:227)
==6786==    by 0x26FB85: mrb_calloc (gc.c:245)
==6786==    by 0x28BF6B: iv_rehash (variable.c:52)
==6786==    by 0x28BF6B: iv_put (variable.c:77)
==6786==    by 0x28BEF8: mrb_obj_iv_set_force (variable.c:399)
==6786==    by 0x2ECDD1: mrb_obj_ivar_set (metaprog.c:109)
==6786==    by 0x295E69: mrb_vm_exec (vm.c:0)
==6786==    by 0x2B3EA1: mrb_load_exec (parse.y:6935)
==6786==    by 0x2B41C0: mrb_load_detect_file_cxt (parse.y:6978)
==6786==    by 0x25F990: main (mruby.c:353)
==6786==
==6786== Invalid read of size 8
==6786==    at 0x28C76B: iv_foreach (variable.c:193)
==6786==    by 0x28C76B: mrb_obj_iv_inspect (variable.c:635)
==6786==    by 0x295E69: mrb_vm_exec (vm.c:0)
==6786==    by 0x2B3EA1: mrb_load_exec (parse.y:6935)
==6786==    by 0x2B41C0: mrb_load_detect_file_cxt (parse.y:6978)
==6786==    by 0x25F990: main (mruby.c:353)
==6786==  Address 0x5649358 is 8 bytes inside a block of size 48 free'd
==6786==    at 0x48502BC: free (vg_replace_malloc.c:993)
==6786==    by 0x272181: mrb_basic_alloc_func (allocf.c:30)
==6786==    by 0x28C03E: iv_rehash (variable.c:69)
==6786==    by 0x28C03E: iv_put (variable.c:102)
==6786==    by 0x28BEF8: mrb_obj_iv_set_force (variable.c:399)
==6786==    by 0x2ECDD1: mrb_obj_ivar_set (metaprog.c:109)
==6786==    by 0x295E69: mrb_vm_exec (vm.c:0)
==6786==    by 0x28F8A6: mrb_run (vm.c:3369)
==6786==    by 0x28F8A6: mrb_funcall_with_block (vm.c:833)
==6786==    by 0x2813AB: mrb_inspect (object.c:832)
==6786==    by 0x28C7E5: inspect_i (variable.c:611)
==6786==    by 0x28C7E5: iv_foreach (variable.c:193)
==6786==    by 0x28C7E5: mrb_obj_iv_inspect (variable.c:635)
==6786==    by 0x295E69: mrb_vm_exec (vm.c:0)
==6786==    by 0x2B3EA1: mrb_load_exec (parse.y:6935)
==6786==    by 0x2B41C0: mrb_load_detect_file_cxt (parse.y:6978)
==6786==  Block was alloc'd at
==6786==    at 0x4853371: realloc (vg_replace_malloc.c:1807)
==6786==    by 0x26FB85: mrb_realloc_simple (gc.c:197)
==6786==    by 0x26FB85: mrb_realloc (gc.c:211)
==6786==    by 0x26FB85: mrb_malloc (gc.c:227)
==6786==    by 0x26FB85: mrb_calloc (gc.c:245)
==6786==    by 0x28BF6B: iv_rehash (variable.c:52)
==6786==    by 0x28BF6B: iv_put (variable.c:77)
==6786==    by 0x28BEF8: mrb_obj_iv_set_force (variable.c:399)
==6786==    by 0x2ECDD1: mrb_obj_ivar_set (metaprog.c:109)
==6786==    by 0x295E69: mrb_vm_exec (vm.c:0)
==6786==    by 0x2B3EA1: mrb_load_exec (parse.y:6935)
==6786==    by 0x2B41C0: mrb_load_detect_file_cxt (parse.y:6978)
==6786==    by 0x25F990: main (mruby.c:353)
==6786==
==6786== Invalid read of size 8
==6786==    at 0x28F707: mrb_val_union (boxing_word.h:141)
==6786==    by 0x28F707: mrb_class (class.h:30)
==6786==    by 0x28F707: mrb_funcall_with_block (vm.c:807)
==6786==    by 0x2813AB: mrb_inspect (object.c:832)
==6786==    by 0x28C7E5: inspect_i (variable.c:611)
==6786==    by 0x28C7E5: iv_foreach (variable.c:193)
==6786==    by 0x28C7E5: mrb_obj_iv_inspect (variable.c:635)
==6786==    by 0x295E69: mrb_vm_exec (vm.c:0)
==6786==    by 0x2B3EA1: mrb_load_exec (parse.y:6935)
==6786==    by 0x2B41C0: mrb_load_detect_file_cxt (parse.y:6978)
==6786==    by 0x25F990: main (mruby.c:353)
==6786==  Address 0x5a1000005a0 is not stack'd, malloc'd or (recently) free'd
==6786==
==6786==
==6786== Process terminating with default action of signal 11 (SIGSEGV): dumping core
==6786==  Access not within mapped region at address 0x5A1000005A0
==6786==    at 0x28F707: mrb_val_union (boxing_word.h:141)
==6786==    by 0x28F707: mrb_class (class.h:30)
==6786==    by 0x28F707: mrb_funcall_with_block (vm.c:807)
==6786==    by 0x2813AB: mrb_inspect (object.c:832)
==6786==    by 0x28C7E5: inspect_i (variable.c:611)
==6786==    by 0x28C7E5: iv_foreach (variable.c:193)
==6786==    by 0x28C7E5: mrb_obj_iv_inspect (variable.c:635)
==6786==    by 0x295E69: mrb_vm_exec (vm.c:0)
==6786==    by 0x2B3EA1: mrb_load_exec (parse.y:6935)
==6786==    by 0x2B41C0: mrb_load_detect_file_cxt (parse.y:6978)
==6786==    by 0x25F990: main (mruby.c:353)
==6786==  If you believe this happened as a result of a stack
==6786==  overflow in your program's main thread (unlikely but
==6786==  possible), you can try to increase the size of the
==6786==  main thread stack using the --main-stacksize= flag.
==6786==  The main thread stack size used in this run was 16777216.
==6786==
==6786== HEAP SUMMARY:
==6786==     in use at exit: 115,319 bytes in 672 blocks
==6786==   total heap usage: 804 allocs, 132 frees, 250,067 bytes allocated
==6786==
==6786== LEAK SUMMARY:
==6786==    definitely lost: 0 bytes in 0 blocks
==6786==    indirectly lost: 0 bytes in 0 blocks
==6786==      possibly lost: 0 bytes in 0 blocks
==6786==    still reachable: 115,319 bytes in 672 blocks
==6786==         suppressed: 0 bytes in 0 blocks
==6786== Rerun with --leak-check=full to see details of leaked memory
==6786==
==6786== For lists of detected and suppressed errors, rerun with: -s
==6786== ERROR SUMMARY: 11 errors from 3 contexts (suppressed: 0 from 0)
zsh: segmentation fault  valgrind bin/mruby iv_foreach.rb
```

</details>
