### PR TITLE
Support initializing structs via keyword arguments

### DIFF
--- a/mrbgems/mruby-struct/src/struct.c
+++ b/mrbgems/mruby-struct/src/struct.c
@@ -351,15 +351,18 @@ mrb_struct_initialize_withKw(mrb_state *mrb, mrb_value hash, mrb_value self)
     }
   }
 
+  /* Create a hash of valid members for faster lookup */
+  mrb_value members_hash = mrb_hash_new(mrb);
+  for (mrb_int i = 0; i < RARRAY_LEN(members); i++) {
+    mrb_hash_set(mrb, members_hash, RARRAY_PTR(members)[i], mrb_true_value());
+  }
 
   /* Check if all keys in the hash are valid members */
-  mrb_value keys = mrb_hash_keys(mrb, hash);
   mrb_value invalid_keys = mrb_ary_new(mrb);
-
+  mrb_value keys = mrb_hash_keys(mrb, hash);
   for (mrb_int i = 0; i < RARRAY_LEN(keys); i++) {
     mrb_value key = RARRAY_PTR(keys)[i];
-    mrb_value include_result = mrb_funcall(mrb, members, "include?", 1, key);
-    if (mrb_test(include_result) == FALSE) {
+    if (!mrb_hash_key_p(mrb, members_hash, key)) {
       mrb_ary_push(mrb, invalid_keys, key);
     }
   }

--- a/mrbgems/mruby-struct/test/struct.rb
+++ b/mrbgems/mruby-struct/test/struct.rb
@@ -276,7 +276,7 @@ end
 
 assert "Struct initialize when :keyword_init is false" do
   c = Struct.new(:foo, :bar, keyword_init: false)
-  
+
   o = c.new(1, 2)
   assert_equal 1, o.foo
   assert_equal 2, o.bar


### PR DESCRIPTION
This is my attempt to solve #6547. Adds initialization of structs via keyword arguments and support for `:keyword_init` options, that should behave the same way as in CRuby.

The exception is with `keyword_init: true` and attempting to initialize struct using positional arguments. In CRuby 3.4.1 I see:

```
(irb):11:in 'Struct#initialize': wrong number of arguments (given 2, expected 0) (ArgumentError)
```

... while here there's a more precise error message.