### PR TITLE
Share array entities if possible with `ary.replace(frozen_ary)`

### DIFF
--- a/src/array.c
+++ b/src/array.c
@@ -511,7 +511,7 @@ ary_replace(mrb_state *mrb, struct RArray *a, struct RArray *b)
     mrb_write_barrier(mrb, (struct RBasic*)a);
     return;
   }
-  if (!mrb_frozen_p(b) && len > ARY_REPLACE_SHARED_MIN) {
+  if (len > ARY_REPLACE_SHARED_MIN) {
     ary_make_shared(mrb, b);
     goto shared_b;
   }


### PR DESCRIPTION
Currently mruby is limited to always placing array entities on the rewritable heap. Therefore, if the original array was frozen and only rewritable objects survived the subsequent process, the array entity can be changed. If an array object that actually shared the array entity is frozen with `ary.freeze`, there should be no problem, since the shared state is still kept.