### PR TITLE
Sharing arrays with `ary_dup()`

### DIFF
--- a/src/array.c
+++ b/src/array.c
@@ -934,7 +934,9 @@ mrb_ary_set(mrb_state *mrb, mrb_value ary, mrb_int n, mrb_value val)
 static struct RArray*
 ary_dup(mrb_state *mrb, struct RArray *a)
 {
-  return ary_new_from_values(mrb, ARY_LEN(a), ARY_PTR(a));
+  struct RArray *dup = ary_new_capa(mrb, 0);
+  ary_replace(mrb, dup, a);
+  return dup;
 }
 
 MRB_API mrb_value


### PR DESCRIPTION
Until now, the array entity has always been allocated from the heap and copied. However, this allows the array entity to be shared with the source if possible.