### PR TITLE
Stricter type tag in `mrb_obj_alloc()`

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -482,12 +482,12 @@ mrb_obj_alloc(mrb_state *mrb, enum mrb_vtype ttype, struct RClass *cls)
       mrb_raise(mrb, E_TYPE_ERROR, "allocation failure");
     }
     tt = MRB_INSTANCE_TT(cls);
-    if (tt != MRB_TT_FALSE &&
-        ttype != MRB_TT_SCLASS &&
+    if (ttype != MRB_TT_SCLASS &&
         ttype != MRB_TT_ICLASS &&
         ttype != MRB_TT_ENV &&
         ttype != MRB_TT_BIGINT &&
-        ttype != tt) {
+        ttype != tt &&
+        !(cls == mrb->object_class && (ttype == MRB_TT_CPTR || ttype == MRB_TT_CDATA || ttype == MRB_TT_ISTRUCT))) {
       mrb_raisef(mrb, E_TYPE_ERROR, "allocation failure of %C", cls);
     }
   }


### PR DESCRIPTION
Instances cannot be created with `MRB_TT_FALSE`.

_**Compatibility Note**_

This change may cause runtime errors.
However, that is probably because it is not set correctly by `MRB_SET_INSTANCE_TT()`.

---

I have shown previously in https://github.com/mruby/mruby/pull/6097#discussion_r1383453371 about the stricter `mrb_obj_alloc()` and compatibility issues.
The cause of the problem is that mruby-lz4 tried to create an instance of its own class with `mrb_data_object_alloc()` while `MRB_SET_INSTANCE_TT()` was missing.
I think it is preferable to have a consistent instance type tag in a custom class.
