### PR TITLE
Add fallback to local build_config.rb before using default configuration

### DIFF
--- a/lib/mruby/build.rb
+++ b/lib/mruby/build.rb
@@ -60,11 +60,7 @@ module MRuby
       def mruby_config_path
         path = ENV['MRUBY_CONFIG'] || ENV['CONFIG']
         if path.nil? || path.empty?
-          if File.file?("./build_config.rb")
-            path = "./build_config.rb"
-          else
-            path = "#{MRUBY_ROOT}/build_config/default.rb"
-          end
+          path = File.file?("./build_config.rb") ? "./build_config.rb" : "#{MRUBY_ROOT}/build_config/default.rb"
         elsif !File.file?(path) && !Pathname.new(path).absolute?
           f = "#{MRUBY_ROOT}/build_config/#{path}.rb"
           path = File.exist?(f) ? f : File.extname(path).empty? ? f : path

--- a/lib/mruby/build.rb
+++ b/lib/mruby/build.rb
@@ -60,7 +60,11 @@ module MRuby
       def mruby_config_path
         path = ENV['MRUBY_CONFIG'] || ENV['CONFIG']
         if path.nil? || path.empty?
-          path = "#{MRUBY_ROOT}/build_config/default.rb"
+          if File.file?("./build_config.rb")
+            path = "./build_config.rb"
+          else
+            path = "#{MRUBY_ROOT}/build_config/default.rb"
+          end
         elsif !File.file?(path) && !Pathname.new(path).absolute?
           f = "#{MRUBY_ROOT}/build_config/#{path}.rb"
           path = File.exist?(f) ? f : File.extname(path).empty? ? f : path


### PR DESCRIPTION
This change allows loading a local `build_config.rb` file when it exists in the current directory, instead of always using the default configuration.

**Use Case:**
I frequently work with multiple mruby projects and consolidate mruby source code. Currently, I need to specify `MRUBY_CONFIG=./build_config.rb` when running rake, which is cumbersome. This change eliminates that manual step.

**Implementation:**
- Checks for `./build_config.rb` before using `build_config/default.rb`