### PR TITLE
Fix typo in mruby3.2 docs

### DIFF
--- a/doc/mruby3.2.md
+++ b/doc/mruby3.2.md
@@ -17,7 +17,7 @@
 ## `mruby`
 
 - `-b` only specifies the script is the binary. The files loaded by `-r` are not affected by the option.
-- `mruby` now loads complied binary if the suffix is `.mrb`.
+- `mruby` now loads compiled binary if the suffix is `.mrb`.
 
 ## `mrbc`
 


### PR DESCRIPTION
## Summary
- fix a typo in mruby3.2 documentation

## Testing
- `grep -n compiled doc/mruby3.2.md`

------
https://chatgpt.com/codex/tasks/task_e_6879e62c3bf083269f9985959c9e6629