### PR TITLE
Add pre-commit hook `check-zip-file-is-not-committed`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,14 @@ repos:
         language: node
         additional_dependencies: ["prettier@3.6.2"]
         stages: [manual]
+      - id: check-zip-file-is-not-committed
+        name: disallow zip files
+        description: Zip files are not allowed in the repository
+        language: fail
+        entry: |
+          Zip files are not allowed in the repository as they are hard to
+          track and have security implications. Please remove the zip file from the repository.
+        files: \.zip$
   - repo: https://github.com/gitleaks/gitleaks
     rev: v8.28.0
     hooks:


### PR DESCRIPTION
Zip files should not be allowed in the repository as they are hard to track and have security implications.