### PR TITLE
pre-commit add official meta hook `check-useless-excludes`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,9 @@ repos:
       - id: check-hooks-apply
         name: run check-hooks-apply
         description: check hooks apply to the repository
+      - id: check-useless-excludes
+        name: run check-useless-excludes
+        description: clean up unnecessary exclusion patterns
   - repo: local
     hooks:
       - id: prettier


### PR DESCRIPTION
The `check-useless-excludes` hook is a feature found in the `pre-commit` framework, a popular tool for managing and maintaining Git pre-commit hooks. To understand what it does, let's break down the key terms:

**1. Exclusion Patterns:**

In software development, particularly with version control systems (like Git) and build systems, you often define "exclusion patterns." These are rules that tell the system to ignore certain files or directories. Common examples include:

* **Version Control (`.gitignore`):** You'll use `.gitignore` files to tell Git not to track temporary files, build artifacts (like compiled code, log files, `node_modules`), configuration files specific to a local environment, or sensitive data. This keeps your repository clean and focused on source code.
* **Build Systems:** Build systems (e.g., Maven, Gradle, webpack, Bazel) also use exclusion patterns to specify which files or directories should not be included in the build process, or which parts of the project to ignore when determining dependencies.

**2. Useless Excludes:**

An exclusion pattern becomes "useless" when it's no longer serving a purpose. This can happen for several reasons:

* **File/Directory Removed:** You had an exclusion for a specific file or directory (e.g., `temp_logs/`) that you later deleted from the project. The exclusion pattern for `temp_logs/` is now useless because the target no longer exists.
* **Redundant Exclusion:** A file or directory is already excluded by a more general pattern, making a more specific exclusion redundant. For example, if you have `*.log` to exclude all log files, and then also have `debug.log`, the `debug.log` exclusion is technically useless because `*.log` already covers it.
* **Never Matched:** The pattern was written incorrectly or for a file/directory that never existed in the first place, so it never actually excluded anything.
* **Covered by Global Exclusions:** A project-specific exclusion might be useless if the file type is already handled by a global `.gitignore` file configured for your entire system.

**3. `check-useless-excludes` Hook:**

This `pre-commit` hook (typically found under the `meta` repository in `pre-commit` configurations) aims to identify and flag these unnecessary exclusion patterns. Here's how it works and what it means:

* **Automated Cleanup:** When you run `pre-commit` (e.g., before making a Git commit), the `check-useless-excludes` hook analyzes your exclusion files (like `.gitignore`).
* **Identifies Redundancies/Non-existent Targets:** It checks if the patterns defined in your exclusion files actually match any existing files or directories within the repository that are *not* already ignored by other means (e.g., explicitly excluded by a hook's `files` or `exclude` configuration).
* **Provides Feedback:** If it finds a pattern that doesn't match anything, or matches something that's already excluded, it will typically report it as a "useless exclude." This often results in a warning or an error, depending on how strict your `pre-commit` configuration is.
* **Promotes Cleanliness:** The primary purpose is to help developers keep their exclusion files clean and efficient. Unnecessary exclusions can clutter these files, make them harder to read, and potentially lead to confusion or errors down the line. By removing them, you maintain a clearer and more maintainable project configuration.
* **Prevents Accidental Inclusions:** While less common for "useless" excludes, a pattern that *should* be excluding something but isn't (due to a typo, for example) could be highlighted by this hook, preventing files from accidentally being committed.

**In essence, the `check-useless-excludes` hook acts as a linter for your exclusion patterns, ensuring that every exclusion rule you've defined is actually serving a purpose and is correctly applied.** This contributes to a tidier codebase and more accurate version control and build processes.