### PR TITLE
Fixed heap buffer overflow in `#method_missing`

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -697,7 +697,9 @@ prepare_missing(mrb_state *mrb, mrb_callinfo *ci, mrb_value recv, mrb_sym mid, m
   }
   else {
     mrb_assert(ci->nk == 15);
-    argv[1] = argv[ci->n];
+    if (ci->n != CALL_MAXARGS) {
+      argv[1] = argv[ci->n];    /* keyword arguments */
+    }
     argv[2] = blk;
   }
   argv[0] = args;               /* must be replaced after saving argv[0] as it may be a keyword argument */


### PR DESCRIPTION
When `ci->n == CALL_MAXARGS`, the correct value is `argv[1] = argv[1]`. However, it was always `args[1] = args[ci->n]`, which caused objects outside the range to be picked up.

fixed #6584