### PR TITLE
fix: skip local build_config.rb when working in MRUBY_ROOT

### DIFF
--- a/lib/mruby/build.rb
+++ b/lib/mruby/build.rb
@@ -60,10 +60,10 @@ module MRuby
       def mruby_config_path
         path = ENV['MRUBY_CONFIG'] || ENV['CONFIG']
         if path.nil? || path.empty?
-          if Dir.pwd != MRUBY_ROOT && File.file?("./build_config.rb")
-            path = "./build_config.rb"
+          path = if Dir.pwd != MRUBY_ROOT && File.file?("./build_config.rb")
+            "./build_config.rb"
           else
-            path = "#{MRUBY_ROOT}/build_config/default.rb"
+            "#{MRUBY_ROOT}/build_config/default.rb"
           end
         elsif !File.file?(path) && !Pathname.new(path).absolute?
           f = "#{MRUBY_ROOT}/build_config/#{path}.rb"

--- a/lib/mruby/build.rb
+++ b/lib/mruby/build.rb
@@ -60,7 +60,11 @@ module MRuby
       def mruby_config_path
         path = ENV['MRUBY_CONFIG'] || ENV['CONFIG']
         if path.nil? || path.empty?
-          path = File.file?("./build_config.rb") ? "./build_config.rb" : "#{MRUBY_ROOT}/build_config/default.rb"
+          if Dir.pwd != MRUBY_ROOT && File.file?("./build_config.rb")
+            path = "./build_config.rb"
+          else
+            path = "#{MRUBY_ROOT}/build_config/default.rb"
+          end
         elsif !File.file?(path) && !Pathname.new(path).absolute?
           f = "#{MRUBY_ROOT}/build_config/#{path}.rb"
           path = File.exist?(f) ? f : File.extname(path).empty? ? f : path


### PR DESCRIPTION
ref: https://github.com/mruby/mruby/pull/6583#issuecomment-3136009214

Only use local build_config.rb when current directory != MRUBY_ROOT.