### PR TITLE
Restrict `mrb_obj_alloc()` to accept only classes

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -1998,7 +1998,8 @@ mrb_prepend_module(mrb_state *mrb, struct RClass *c, struct RClass *m)
 {
   mrb_check_frozen(mrb, c);
   if (!(c->flags & MRB_FL_CLASS_IS_PREPENDED)) {
-    struct RClass *origin = MRB_OBJ_ALLOC(mrb, MRB_TT_ICLASS, c);
+    struct RClass *origin = MRB_OBJ_ALLOC(mrb, MRB_TT_ICLASS, NULL);
+    origin->c = c;
     origin->flags |= MRB_FL_CLASS_IS_ORIGIN | MRB_FL_CLASS_IS_INHERITED;
     origin->super = c->super;
     c->super = origin;

--- a/src/gc.c
+++ b/src/gc.c
@@ -472,13 +472,7 @@ mrb_obj_alloc(mrb_state *mrb, enum mrb_vtype ttype, struct RClass *cls)
   if (cls) {
     enum mrb_vtype tt;
 
-    switch (cls->tt) {
-    case MRB_TT_CLASS:
-    case MRB_TT_SCLASS:
-    case MRB_TT_MODULE:
-    case MRB_TT_ENV:
-      break;
-    default:
+    if (cls->tt != MRB_TT_CLASS) {
       mrb_raise(mrb, E_TYPE_ERROR, "allocation failure");
     }
     tt = MRB_INSTANCE_TT(cls);


### PR DESCRIPTION
Until now, the type tag of the `cls` parameter in `mrb_obj_alloc()` was not limited to `MRB_TT_CLASS`. The reason for this was that when performing `prepend` operation, objects with `MRB_TT_MODULE` or `MRB_TT_SCLASS` type tags were passed as the `cls` parameter.

This patch simplifies `mrb_obj_alloc()` itself by having the calling side perform the necessary processing.

***Compatibility Note***

When users call `mrb_obj_alloc()`, providing something other than a class (e.g., a module) will now cause a `TypeError` exception. If users intentionally want to provide a module or singleton class, they must pass `NULL` as the `cls` parameter and modify the class of the returned object.