### PR TITLE
Stop generating unnecessary C++ files in mruby-bin-mruby

### DIFF
--- a/mrbgems/mruby-bin-mruby/mrbgem.rake
+++ b/mrbgems/mruby-bin-mruby/mrbgem.rake
@@ -4,8 +4,4 @@ MRuby::Gem::Specification.new('mruby-bin-mruby') do |spec|
   spec.summary = 'mruby command'
   spec.bins = %w(mruby)
   spec.add_dependency('mruby-compiler', :core => 'mruby-compiler')
-
-  if build.cxx_exception_enabled?
-    build.compile_as_cxx("#{spec.dir}/tools/mruby/mruby.c")
-  end
 end


### PR DESCRIPTION
This is probably a remnant from when `MRB_TRY()` was used in the past.