### PR TITLE
Implement `to_hash` calling in implicit conversion contexts

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -1421,15 +1421,16 @@ get_args_v(mrb_state *mrb, mrb_args_format format, void** ptr, va_list *ap)
 
         p = GET_ARG(mrb_value*);
         if (pickarg) {
+          mrb_value arg = *pickarg;
           if (!(altmode && mrb_nil_p(*pickarg))) {
             switch (c) {
             case 'C': ensure_class_type(mrb, *pickarg); break;
-            case 'S': mrb_ensure_string_type(mrb, *pickarg); break;
-            case 'A': mrb_ensure_array_type(mrb, *pickarg); break;
-            case 'H': mrb_ensure_hash_type(mrb, *pickarg); break;
+            case 'S': arg = mrb_ensure_string_type(mrb, *pickarg); break;
+            case 'A': arg = mrb_ensure_array_type(mrb, *pickarg); break;
+            case 'H': arg = mrb_ensure_hash_type(mrb, *pickarg); break;
             }
           }
-          *p = *pickarg;
+          *p = arg;
         }
       }
       break;

--- a/src/hash.c
+++ b/src/hash.c
@@ -1962,7 +1962,7 @@ mrb_hash_merge(mrb_state *mrb, mrb_value hash1, mrb_value hash2)
   struct RHash *h1, *h2;
 
   hash_modify(mrb, hash1);
-  mrb_ensure_hash_type(mrb, hash2);
+  hash2 = mrb_ensure_hash_type(mrb, hash2);
   h1 = mrb_hash_ptr(hash1);
   h2 = mrb_hash_ptr(hash2);
 

--- a/src/vm.c
+++ b/src/vm.c
@@ -3099,7 +3099,7 @@ RETRY_TRY_BLOCK:
       int lim = a+b*2+1;
 
       hash = regs[a];
-      mrb_ensure_hash_type(mrb, hash);
+      mrb_assert(mrb_hash_p(hash));
       for (int i=a+1; i<lim; i+=2) {
         mrb_hash_set(mrb, hash, regs[i], regs[i+1]);
         ci = mrb->c->ci;


### PR DESCRIPTION
Previously mruby did not call `#to_hash` on objects in contexts like the keyword splat operator. This patch implements that feature for feature parity with CRuby. Additionally a call to `mrb_ensure_hash_type` in the implementation of `OP_HASHADD` has been changed to an `mrb_assert` as the only situation in which it could trigger would be if the bytecode itself contradicted its assumptions (a similar `assert` was already present in the implementation of `OP_HASHCAT`).