### PR TITLE
Fixed wrong `MRuby::Build.current` at the top level of `mrbgem.rake`

### DIFF
--- a/lib/mruby/build/load_gems.rb
+++ b/lib/mruby/build/load_gems.rb
@@ -32,14 +32,21 @@ module MRuby
       gemrake = File.join(checkout.full_gemdir, "mrbgem.rake")
       fail "Can't find #{gemrake}" unless File.exist?(gemrake)
 
+      current_build = MRuby::Build.current
+      build = self.is_a?(MRuby::Build) ? self : MRuby::Build.current
+      MRuby::Build.current = build
       Gem.current = nil
-      load gemrake
+      begin
+        load gemrake
+      ensure
+        MRuby::Build.current = current_build
+      end
       return nil unless Gem.current
       current = Gem.current
 
       # Add it to gems
       current.dir = checkout.full_gemdir
-      current.build = self.is_a?(MRuby::Build) ? self : MRuby::Build.current
+      current.build = build
       current.build_config_initializer = block
       gems << current
 


### PR DESCRIPTION
Until now, GEMS added via `gem.add_dependency` retained the last `MRuby::Build.current` from the build configuration file, which was accessible from the top level of `mrbgem.rake`.