### PR TITLE
[cherry-pick] fix bigint on raspberry pi

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -1457,7 +1457,7 @@ RETRY_TRY_BLOCK:
 #ifdef MRB_USE_BIGINT
         {
           const char *s = irep->pool[b].u.str;
-          regs[a] = mrb_bint_new_str(mrb, s+2, (uint8_t)s[0], s[1]);
+          regs[a] = mrb_bint_new_str(mrb, s+2, (uint8_t)s[0], (int8_t)s[1]);
         }
         break;
 #else


### PR DESCRIPTION
this fixes an issue where base can be out of range on a raspberry pi.

(This pull request cherry-picks the referenced commit onto the stable branch as requested in https://github.com/mruby/mruby/issues/6625 )