### PR TITLE
Revert "Rakefile: make the whole thing parallel unless SERIAL=1"

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,6 @@ MRUBY_ROOT = File.dirname(File.expand_path(__FILE__))
 MRUBY_BUILD_HOST_IS_CYGWIN = RUBY_PLATFORM.include?('cygwin')
 MRUBY_BUILD_HOST_IS_OPENBSD = RUBY_PLATFORM.include?('openbsd')
 
-Rake.application.options.always_multitask = true unless ENV["SERIAL"]
 Rake.verbose(false) if Rake.verbose == Rake::DSL::DEFAULT
 
 $LOAD_PATH << File.join(MRUBY_ROOT, "lib")


### PR DESCRIPTION
This reverts commit fc624020e6ac13427e61d97a8e63b68f73073939.

The rake command runs sequentially by default, with optional parallel execution.
Enabling parallelization for mruby builds by default can make troubleshooting issues more difficult.
Furthermore, switching from parallel to sequential execution requires using environment variables instead of rake command switches, which may confuse users.
