### PR TITLE
Fix assert_false to match FalseClass properly

### DIFF
--- a/test/assert.rb
+++ b/test/assert.rb
@@ -168,10 +168,10 @@ def assert_true(obj, msg = nil, diff = nil)
 end
 
 def assert_false(obj, msg = nil, diff = nil)
-  unless obj == false
+  unless ret = (obj == false)
     diff ||= "    Expected #{obj.inspect} to be false."
   end
-  assert_true(obj == false, msg, diff)
+  assert_true(ret, msg, diff)
 end
 
 def assert_equal(exp, act_or_msg = nil, msg = nil, &block)


### PR DESCRIPTION
Modified `assert_false` to match only `FalseClass`.

#### Notes

While the current implementation works fine for boolean falsiness evaluation, since L171 uses `obj == false` to match against `FalseClass`, I believe `assert_false` should be consistent and only match `FalseClass` specifically.

This change ensures semantic consistency in the assertion behavior.
