### PR TITLE
Add LeakSan to detect memory leaks

### DIFF
--- a/build_config/clang-asan.rb
+++ b/build_config/clang-asan.rb
@@ -4,7 +4,7 @@ MRuby::Build.new do |conf|
   conf.gembox 'full-core'
 
   # Turn on `enable_debug` for better debugging
-  conf.enable_sanitizer "address,undefined"
+  conf.enable_sanitizer "address,undefined,leak"
   conf.enable_debug
   conf.enable_bintest
   conf.enable_test


### PR DESCRIPTION
The current commit contains a memory leak, this should detect that during testing.

@matz how to add this to the test matrix? When looking at the test github runs this is skipped apparently.