### PR TITLE
Fix crash caused by an incorrect node type check in `codegen_masgn`

### DIFF
--- a/mrbgems/mruby-compiler/core/codegen.c
+++ b/mrbgems/mruby-compiler/core/codegen.c
@@ -4386,7 +4386,7 @@ codegen_masgn(codegen_scope *s, node *varnode, node *rhs, int sp, int val)
   node *t = rhs ? rhs : masgn_n->rhs, *p;
   int rhs_reg = sp;
 
-  if (!val && t && node_to_int(t->car) == NODE_ARRAY && t->cdr && nosplat(t->cdr)) {
+  if (!val && t && get_node_type(t) == NODE_ARRAY && t->cdr && nosplat(t->cdr)) {
     /* fixed rhs */
     t = t->cdr;
     while (t) {


### PR DESCRIPTION
Use the dedicated function `get_node_type(t)` to correctly determine the node type, instead of the incorrect `node_to_int(t->car)` check.

OSS-Fuzz issue details:
https://oss-fuzz.com/testcase-detail/4760884737277952
https://g-issues.oss-fuzz.com/issues/449498801