### PR TITLE
Address stack-use-after-return in the mruby bigint implementation.

### DIFF
--- a/mrbgems/mruby-bigint/core/bigint.c
+++ b/mrbgems/mruby-bigint/core/bigint.c
@@ -2773,11 +2773,13 @@ bint_set(mpz_ctx_t *ctx, struct RBigint *b, mpz_t *x)
       mpz_set(ctx, &b->as.heap, x);
       mpz_clear(ctx, x);
     }
-    else
+    else {
 #endif
-    {
       mpz_move(ctx, &b->as.heap, x);
     }
+#if MRB_BIGINT_POOL_SIZE > 0
+  }
+#endif
 }
 
 static struct RBigint*


### PR DESCRIPTION
The fix is to modify `bint_set` to ensure that the data stored in the persistent `RBigint` object is allocated on the heap if it's not embedded. We check if the source `mpz_t` uses memory from the stack pool using `is_pool_memory`. If it does, we must perform a deep copy (`mpz_set`) to allocate new heap memory and copy the data, instead of moving the pointer (`mpz_move`). If the source is already on the heap, we retain the efficient `mpz_move`.


OSS-Fuzz testcase: https://oss-fuzz.com/testcase-detail/5279371075321856