### PR TITLE
Put ls-lint and pre-commit in separate workflow files

### DIFF
--- a/.github/workflows/ls-lint.yml
+++ b/.github/workflows/ls-lint.yml
@@ -1,0 +1,17 @@
+# https://github.com/loeffel-io/ls-lint
+name: Lint
+
+on: [pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  ls-lint:
+    name: Run ls-lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ls-lint/action@v2.3.1
+        with:
+          config: .github/linters/.ls-lint.yml

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,5 +1,5 @@
 # https://pre-commit.com/
-name: Lint
+name: pre-commit
 
 on: [pull_request]
 
@@ -27,11 +27,3 @@ jobs:
         run: pre-commit run --color=always --all-files
       - name: Run manual pre-commit hooks
         run: pre-commit run --color=always --all-files --hook-stage manual
-  ls-lint:
-    name: Run ls-lint
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: ls-lint/action@v2.3.1
-        with:
-          config: .github/linters/.ls-lint.yml


### PR DESCRIPTION
Standardizes all workflows into separate files.

Minor clean up of workflow name and add a docs link