### PR TITLE
docs: fix pre-commit manual hooks; fix link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ to both the Makefile and the Rakefile. Run them with:
 - `make checkupdate` or `rake checkupdate`
 
 To configure `pre-commit` you can modify the config file [.pre-commit-config.yaml](.pre-commit-config.yaml).
-We use [GitHub Actions](.github/workflows/lint.yml) to run `pre-commit` on every pull request.
+We use [GitHub Actions](.github/workflows/pre-commit.yml) to run `pre-commit` on every pull request.
 
 ### pre-commit quick links
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -134,7 +134,7 @@ mruby now supports pattern matching (case/in) syntax:
 - [#6525](https://github.com/mruby/mruby/pull/6525) Skip adding empty input to mirb history
 - [#6526](https://github.com/mruby/mruby/pull/6526) Add build config for Luckfox Pico embedded SBC
 - [#6528](https://github.com/mruby/mruby/pull/6528) misc: fix spelling
-- [#6530](https://github.com/mruby/mruby/pull/6530) Revert "class.c (find_visibility_scope): when callinfo returns, *ep == NULL; #6512"
+- [#6530](https://github.com/mruby/mruby/pull/6530) Revert "class.c (find_visibility_scope): when callinfo returns, \*ep == NULL; #6512"
 - [#6531](https://github.com/mruby/mruby/pull/6531) Improve method table performance by rehashing at 75% load factor
 - [#6532](https://github.com/mruby/mruby/pull/6532) Reverted method table optimizations to prioritize memory savings
 - [#6533](https://github.com/mruby/mruby/pull/6533) Fix calling `extended` callback

--- a/mrbgems/mruby-bin-debugger/README.md
+++ b/mrbgems/mruby-bin-debugger/README.md
@@ -17,23 +17,23 @@ mrdb [switches] programfile
 
 ## Debugger Commands
 
-| Command            | Abbreviation | Description                  |
-| ------------------ | ------------ | ---------------------------- |
-| `break`            | `b`          | Set a breakpoint             |
-| `continue`         | `c`          | Continue execution           |
-| `delete`           | `d`          | Delete breakpoints           |
-| `disable`          | `dis`        | Disable breakpoints          |
-| `enable`           | `en`         | Enable breakpoints           |
-| `eval`             | `ev`         | Evaluate expression          |
-| `help`             | `h`          | Show help                    |
-| `info breakpoints` | `i b`        | Show breakpoint information  |
-| `info locals`      | `i l`        | Show local variables         |
-| `list`             | `l`          | List source code             |
-| `print`            | `p`          | Print expression value       |
-| `quit`             | `q`          | Quit debugger                |
-| `run`              | `r`          | Run program                  |
-| `step`             | `s`          | Step into                    |
-| `next`             | `n`          | Step over                    |
+| Command            | Abbreviation | Description                 |
+| ------------------ | ------------ | --------------------------- |
+| `break`            | `b`          | Set a breakpoint            |
+| `continue`         | `c`          | Continue execution          |
+| `delete`           | `d`          | Delete breakpoints          |
+| `disable`          | `dis`        | Disable breakpoints         |
+| `enable`           | `en`         | Enable breakpoints          |
+| `eval`             | `ev`         | Evaluate expression         |
+| `help`             | `h`          | Show help                   |
+| `info breakpoints` | `i b`        | Show breakpoint information |
+| `info locals`      | `i l`        | Show local variables        |
+| `list`             | `l`          | List source code            |
+| `print`            | `p`          | Print expression value      |
+| `quit`             | `q`          | Quit debugger               |
+| `run`              | `r`          | Run program                 |
+| `step`             | `s`          | Step into                   |
+| `next`             | `n`          | Step over                   |
 
 ## Examples
 


### PR DESCRIPTION
Ran `pre-commit run --all-files --hook-stage manual` and this ran prettier.

We had a Markdown table reformated and an backslash escape added.

A link was also fixed.

Tested both the standard and manual hooks pass