### PR TITLE
prettier: set `pass_filenames: false` to avoid multiple passes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,6 +24,7 @@ repos:
         files: \.(json|md|ya?ml)$
         language: node
         additional_dependencies: ["prettier@3.7.4"]
+        pass_filenames: false
         stages: [manual]
       - id: check-zip-file-is-not-committed
         name: disallow zip files

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,4 @@ build
 coverage
 doc/internal/opcode.md
 tools/lrama
+.venv


### PR DESCRIPTION
Updated `.prettierignore` to ignore the typical Python environment files from `.venv`

If you are running pre-commit locally you probably have a Python environment setup.

This PR speeds up the prettier hook and avoids multiple passes through the targetted files.

If you have a look at this job run:

https://github.com/mruby/mruby/actions/runs/20506201194/job/58921074132

You will see that the pre-commit manual hooks failed for the prettier check.

You can see there in the list of files under the prettier failed hook that there is the main group of files but they are repeated about 4 times in the list.  So prettier is doing about 4 passes through file list and extra over head etc.

And now my terminal log with a git explanation of how I tested this by adding 3 extra lines to the end of `docker-compose.yml` and then running prettier locally and the files list is only printed once as in each file path is listed only once.  Right at the end of the list only the `docker compose` file was formatted

```
mruby$ git log --oneline -n 1
3c7d19d41 (HEAD -> cleanup-prettier-pre-commit, origin/cleanup-prettier-pre-commit) prettier: set `pass_filenames: false` to avoid multiple passes

mruby$ git status
On branch cleanup-prettier-pre-commit
Your branch is up to date with 'origin/cleanup-prettier-pre-commit'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        modified:   docker-compose.yml

no changes added to commit (use "git add" and/or "git commit -a")
mruby$ git diff
diff --git a/docker-compose.yml b/docker-compose.yml
index ef6a2d6d4..cd199cae1 100644
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,3 +11,6 @@ services:
       - LD=gcc
       - SKIP=check-executables-have-shebangs
     working_dir: /app
+
+
+
mruby$ pre-commit run prettier --all-files --hook-stage manual
run prettier.............................................................Failed
- hook id: prettier
- files were modified by this hook

.github/linters/mlc_config.json 17ms (unchanged)
CONTRIBUTING.md 42ms (unchanged)
doc/guides/compile.md 43ms (unchanged)
doc/guides/debugger.md 16ms (unchanged)
doc/guides/gc-arena-howto.md 16ms (unchanged)
doc/guides/hier.md 4ms (unchanged)
doc/guides/link.md 8ms (unchanged)
doc/guides/memory.md 11ms (unchanged)
doc/guides/mrbconf.md 22ms (unchanged)
doc/guides/mrbgems.md 33ms (unchanged)
doc/guides/symbol.md 8ms (unchanged)
doc/internal/boxing.md 5ms (unchanged)
doc/limitations.md 12ms (unchanged)
doc/mruby3.0.md 14ms (unchanged)
doc/mruby3.1.md 19ms (unchanged)
doc/mruby3.2.md 6ms (unchanged)
doc/mruby3.3.md 31ms (unchanged)
doc/mruby3.4.md 38ms (unchanged)
examples/mrbgems/c_and_ruby_extension_example/README.md 1ms (unchanged)
examples/mrbgems/c_extension_example/README.md 1ms (unchanged)
examples/mrbgems/cdata_extension_example/README.md 1ms (unchanged)
examples/mrbgems/mruby-YOUR-bigint/TODO-HINT.md 3ms (unchanged)
examples/mrbgems/ruby_extension_example/README.md 1ms (unchanged)
mrbgems/hal-posix-task/README.md 5ms (unchanged)
mrbgems/hal-win-task/README.md 5ms (unchanged)
mrbgems/mruby-array-ext/README.md 15ms (unchanged)
mrbgems/mruby-benchmark/README.md 8ms (unchanged)
mrbgems/mruby-bigint/README-fgmp.md 6ms (unchanged)
mrbgems/mruby-bigint/README.md 3ms (unchanged)
mrbgems/mruby-bin-config/README.md 3ms (unchanged)
mrbgems/mruby-bin-debugger/README.md 4ms (unchanged)
mrbgems/mruby-bin-mirb/README.md 5ms (unchanged)
mrbgems/mruby-bin-mrbc/README.md 4ms (unchanged)
mrbgems/mruby-bin-mruby/README.md 3ms (unchanged)
mrbgems/mruby-bin-strip/README.md 2ms (unchanged)
mrbgems/mruby-binding/README.md 8ms (unchanged)
mrbgems/mruby-catch/README.md 4ms (unchanged)
mrbgems/mruby-class-ext/README.md 5ms (unchanged)
mrbgems/mruby-cmath/README.md 5ms (unchanged)
mrbgems/mruby-compar-ext/README.md 4ms (unchanged)
mrbgems/mruby-compiler/README.md 2ms (unchanged)
mrbgems/mruby-complex/README.md 4ms (unchanged)
mrbgems/mruby-data/README.md 4ms (unchanged)
mrbgems/mruby-dir/README.md 3ms (unchanged)
mrbgems/mruby-encoding/README.md 4ms (unchanged)
mrbgems/mruby-enum-chain/README.md 4ms (unchanged)
mrbgems/mruby-enum-ext/README.md 16ms (unchanged)
mrbgems/mruby-enum-lazy/README.md 4ms (unchanged)
mrbgems/mruby-enumerator/README.md 5ms (unchanged)
mrbgems/mruby-errno/README.md 4ms (unchanged)
mrbgems/mruby-error/README.md 10ms (unchanged)
mrbgems/mruby-eval/README.md 3ms (unchanged)
mrbgems/mruby-hash-ext/README.md 20ms (unchanged)
mrbgems/mruby-io/README.md 12ms (unchanged)
mrbgems/mruby-kernel-ext/README.md 6ms (unchanged)
mrbgems/mruby-math/README.md 5ms (unchanged)
mrbgems/mruby-metaprog/README.md 6ms (unchanged)
mrbgems/mruby-method/README.md 7ms (unchanged)
mrbgems/mruby-numeric-ext/README.md 4ms (unchanged)
mrbgems/mruby-object-ext/README.md 3ms (unchanged)
mrbgems/mruby-objectspace/README.md 3ms (unchanged)
mrbgems/mruby-os-memsize/README.md 3ms (unchanged)
mrbgems/mruby-pack/README.md 10ms (unchanged)
mrbgems/mruby-proc-binding/README.md 3ms (unchanged)
mrbgems/mruby-proc-ext/README.md 4ms (unchanged)
mrbgems/mruby-random/README.md 10ms (unchanged)
mrbgems/mruby-range-ext/README.md 3ms (unchanged)
mrbgems/mruby-rational/README.md 3ms (unchanged)
mrbgems/mruby-set/README.md 8ms (unchanged)
mrbgems/mruby-sleep/README.md 1ms (unchanged)
mrbgems/mruby-socket/README.md 3ms (unchanged)
mrbgems/mruby-sprintf/README.md 10ms (unchanged)
mrbgems/mruby-strftime/README.md 6ms (unchanged)
mrbgems/mruby-string-ext/README.md 16ms (unchanged)
mrbgems/mruby-struct/README.md 4ms (unchanged)
mrbgems/mruby-symbol-ext/README.md 3ms (unchanged)
mrbgems/mruby-task/README.md 18ms (unchanged)
mrbgems/mruby-test/README.md 1ms (unchanged)
mrbgems/mruby-time/README.md 8ms (unchanged)
mrbgems/mruby-toplevel-ext/README.md 2ms (unchanged)
NEWS.md 26ms (unchanged)
README.md 10ms (unchanged)
SECURITY.md 8ms (unchanged)
TODO.md 2ms (unchanged)
.github/linters/.hadolint.yaml 6ms (unchanged)
.pre-commit-config.yaml 13ms (unchanged)
.github/dependabot.yml 1ms (unchanged)
.github/labeler.yml 3ms (unchanged)
.github/linters/.ls-lint.yml 1ms (unchanged)
.github/linters/.markdown-lint.yml 1ms (unchanged)
.github/linters/.rubocop.yml 1ms (unchanged)
.github/linters/.yaml-lint.yml 1ms (unchanged)
.github/workflows/build.yml 4ms (unchanged)
.github/workflows/codeql-analysis.yml 2ms (unchanged)
.github/workflows/coverage.yml 2ms (unchanged)
.github/workflows/labeler.yml 1ms (unchanged)
.github/workflows/ls-lint.yml 1ms (unchanged)
.github/workflows/oss-fuzz.yml 1ms (unchanged)
.github/workflows/pre-commit.yml 1ms (unchanged)
.github/workflows/release.yml 1ms (unchanged)
.github/workflows/super-linter.yml 2ms (unchanged)
.travis.yml 1ms (unchanged)
appveyor.yml 2ms (unchanged)
docker-compose.yml 1ms
mruby$
```

---

From Google:

"When to use pass_filenames: false

Directory-based linters/tools: Some tools, especially in languages like Go or Terraform, perform analysis based on the entire directory context. Passing individual files can lead to false positives (e.g., "unused symbol" errors).

Tools that manage their own file discovery: If your hook's entry command (e.g., a Makefile target or a specific CLI tool) already finds the required files to check, you should set pass_filenames: false to avoid passing extra command-line arguments that the tool might not handle correctly.

Performance: For large codebases, running a tool on the whole project (pass_filenames: false) might be slow. The default pass_filenames: true behavior is often recommended for faster local checks, as it only runs on the changed files.

Hooks that use always_run: true: When a hook is set to run regardless of which files have changed, you often also set pass_filenames: false so that the command runs once on the entire project as intended."

---

So the prettier hook uses an entry command that finds its own files:

https://github.com/mruby/mruby/blob/9f0950da13596edcf64b821f696426445d323d01/.pre-commit-config.yaml#L23
