### PR TITLE
pre-commit: add hook to ensure Makefiles are indented with tabs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,15 @@ repos:
         language: node
         additional_dependencies: ["prettier@3.7.4"]
         stages: [manual]
+      - id: check-makefile-indentation
+        name: check Makefiles are indented with tabs
+        description: ensures that Makefiles are indented with tabs
+        entry: ./scripts/check_makefiles_for_tabs.sh
+        language: system
+        files: "(?i)^makefile$"
+        pass_filenames: true # <-- Crucial change: pass filenames to the script
+        types: [file] # Ensure only regular files are passed, not directories
+        stages: [manual]
       - id: check-zip-file-is-not-committed
         name: disallow zip files
         description: Zip files are not allowed in the repository

--- a/scripts/check_makefiles_for_tabs.sh
+++ b/scripts/check_makefiles_for_tabs.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Iterate over all files passed as arguments by pre-commit
+for makefile in "$@"; do
+  # Check if the file exists and is a regular file
+  if [[ -f "$makefile" ]]; then
+    if grep -P '^\s' "$makefile" | grep -vP '^\t' > /dev/null; then
+      echo "Error: File '$makefile' contains spaces at the beginning of lines instead of tabs."
+      exit 1
+    fi
+  fi
+done
+exit 0


### PR DESCRIPTION
Manual hook added which runs a shell script.

Can be run locally manually by Linux or Mac users and we have this also running on the GitHub Actions CI.

Will fail if Makefiles uses spaces for indentation.

Can run the manual hooks with:

`pre-commit run check-makefile-indentation --all-files --hook-stage manual`