### PR TITLE
pre-commit add manual hooks bundle `install` and `audit`

### DIFF
--- a/.github/linters/mlc_config.json
+++ b/.github/linters/mlc_config.json
@@ -1,6 +1,9 @@
 {
   "ignorePatterns": [
     {
+      "pattern": "^https://api.star-history.com"
+    },
+    {
       "pattern": "^https://github.com/mruby/mruby/commit/"
     },
     {

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -13,6 +13,9 @@ jobs:
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v6
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.4" # Not needed with a .ruby-version, .tool-versions or mise.toml
       - name: Install
         run: |
           python -m pip install --upgrade pip

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,24 @@ repos:
         language: node
         additional_dependencies: ["prettier@3.7.4"]
         stages: [manual]
+      - id: bundle-install
+        name: bundle-install
+        description: >-
+          Ensures that the local Ruby environment stays in sync by running 'bundle install'
+          whenever the Gemfile or Gemfile.lock is modified.
+        entry: bash -c 'bundle check || bundle install || { echo "bundle install failed"; exit 1; }'
+        language: system
+        stages: [manual]
+        files: ^(Gemfile|Gemfile\.lock)$
+      - id: bundle-audit
+        name: bundle-audit
+        description: >-
+          Updates the ruby-advisory-db and scans Gemfile.lock for known security
+          vulnerabilities in dependencies.
+        entry: bash -c 'bundle exec bundle-audit check --update'
+        language: system
+        stages: [manual]
+        files: ^Gemfile\.lock$
       - id: check-zip-file-is-not-committed
         name: disallow zip files
         description: Zip files are not allowed in the repository

--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,7 @@ gem 'rake'
 gem 'yard'
 gem 'yard-coderay'
 gem 'yard-mruby'
+
+group :development, :test do
+  gem 'bundler-audit', require: false
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,12 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    bundler-audit (0.9.3)
+      bundler (>= 1.2.0)
+      thor (~> 1.0)
     coderay (1.1.3)
     rake (13.3.1)
+    thor (1.4.0)
     yard (0.9.38)
     yard-coderay (0.1.0)
       coderay
@@ -12,14 +16,23 @@ GEM
 
 PLATFORMS
   ruby
-  x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES
+  bundler-audit
   rake
   yard
   yard-coderay
   yard-mruby
 
+CHECKSUMS
+  bundler-audit (0.9.3) sha256=81c8766c71e47d0d28a0f98c7eed028539f21a6ea3cd8f685eb6f42333c9b4e9
+  coderay (1.1.3) sha256=dc530018a4684512f8f38143cd2a096c9f02a1fc2459edcfe534787a7fc77d4b
+  rake (13.3.1) sha256=8c9e89d09f66a26a01264e7e3480ec0607f0c497a861ef16063604b1b08eb19c
+  thor (1.4.0) sha256=8763e822ccb0f1d7bee88cde131b19a65606657b847cc7b7b4b82e772bcd8a3d
+  yard (0.9.38) sha256=721fb82afb10532aa49860655f6cc2eaa7130889df291b052e1e6b268283010f
+  yard-coderay (0.1.0) sha256=38bb59aea471f14f4cc62085f4d7e5ac0338a10c115355d32977f73d5015163f
+  yard-mruby (0.3.0) sha256=f950f3e5c8bde7a4fee73bcf0e7c20f2365540deca8b60590f2e2eb069d264ef
+
 BUNDLED WITH
-   2.4.10
+  4.0.3


### PR DESCRIPTION
refs #6597 

# Ruby Dependency Hooks (Manual)

We use `pre-commit` to manage our local development checks. The hooks for `bundle-install` and `bundle-audit` are configured as **manual stages** to balance security with development speed.

## Why Manual Hooks?

### 1. Zero Friction Workflow
Standard hooks run on every `git commit`. Because `bundle-audit` requires a network connection to update its database, moving it to a `manual` stage ensures your daily commits remain instant.

### 2. Intelligent Triggering
Even though these are manual, they still respect the `files` filter. They will only run if `Gemfile` or `Gemfile.lock` have been modified, preventing wasted time during unrelated code changes.

### 3. Standardized Audits
Defining this in `.pre-commit-config.yaml` ensures every developer uses the same command and updates the `ruby-advisory-db` before scanning, keeping the team in sync.

---

## Usage Instructions

Trigger these before pushing a Pull Request or after modifying dependencies.

### Run all manual hooks
`pre-commit run --hook-stage manual`

### Run only the security audit
`pre-commit run bundle-audit --hook-stage manual`

### Run on all files (CI/CD mode)
`pre-commit run --all-files --hook-stage manual`

---

## Hook Descriptions

| Hook ID | Description |
| :--- | :--- |
| **bundle-install** | Ensures the local environment matches the Gemfile.lock. |
| **bundle-audit** | Checks for known vulnerabilities (CVEs) in your gems. |