### PR TITLE
[CI] Dependabot: add a cooldown period for new releases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,11 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Enforces security best practices by requiring a minimum age for new dependency releases before they are automatically updated by Dependabot.

This practice, known as a "cooldown period," helps mitigate supply chain attacks by allowing time for frequently published malicious packages to be identified.

https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown-