### PR TITLE
mruby-bigint: compile as C++ when CXX exceptions enabled

### DIFF
--- a/mrbgems/mruby-bigint/mrbgem.rake
+++ b/mrbgems/mruby-bigint/mrbgem.rake
@@ -5,6 +5,10 @@ MRuby::Gem::Specification.new('mruby-bigint') do |spec|
   spec.build.defines << "MRB_USE_BIGINT"
 
   spec.build.libmruby_core_objs << Dir.glob(File.join(__dir__, "core/**/*.c")).map { |fn|
-    objfile(fn.relative_path_from(__dir__).pathmap("#{spec.build_dir}/%X"))
+    if spec.build.cxx_exception_enabled?
+      spec.build.compile_as_cxx(fn)
+    else
+      objfile(fn.relative_path_from(__dir__).pathmap("#{spec.build_dir}/%X"))
+    end
   }
 end


### PR DESCRIPTION
Since commit 9471b132c added MRB_TRY/MRB_CATCH to bigint.c for exception-safe cleanup, the file includes <mruby/throw.h> which requires C++ compilation when MRB_USE_CXX_EXCEPTION is defined.

Follow the same pattern as mruby-compiler to compile bigint sources as C++ when cxx_exception_enabled? is true.

Fixes: #6702