### PR TITLE
Define the `initialize_copy` and `respond_to_missing?` methods as private

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -1027,7 +1027,9 @@ mrb_define_method_raw(mrb_state *mrb, struct RClass *c, mrb_sym mid, mrb_method_
   }
 
   int flags = MT_KEY_FLG(m.flags);
-  if (mid == MRB_SYM(initialize)) {
+  if (mid == MRB_SYM(initialize) ||
+      mid == MRB_SYM(initialize_copy) ||
+      mid == MRB_SYM_Q(respond_to_missing)) {
     MRB_SET_VISIBILITY_FLAGS(flags, MT_PRIVATE);
   }
   else if ((flags & MT_VMASK) == MT_VDEFAULT) {


### PR DESCRIPTION
It is preferable for them to be private even when defined via `mrb_define_method()`.
This mimics CRuby's behavior.

ref: https://github.com/ruby/ruby/blob/v4.0.0/vm_method.c#L1329-L1336