### PR TITLE
Fix OP_DEBUG operand type and add NULL check for debug_op_hook

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -3319,12 +3319,9 @@ RETRY_TRY_BLOCK:
       NEXT;
     }
 
-    CASE(OP_DEBUG, Z) {
-      const mrb_code *pc = ci->pc;
-      FETCH_BBB();
-      ci->pc = pc;
+    CASE(OP_DEBUG, BBB) {
 #ifdef MRB_USE_DEBUG_HOOK
-      mrb->debug_op_hook(mrb, irep, ci->pc, regs);
+      if (mrb->debug_op_hook) mrb->debug_op_hook(mrb, irep, ci->pc, regs);
 #else
 #ifndef MRB_NO_STDIO
       printf("OP_DEBUG %d %d %d\n", a, b, c);


### PR DESCRIPTION
## Summary

- Fix `CASE(OP_DEBUG, Z)` to `CASE(OP_DEBUG, BBB)` to match the definition in `include/mruby/ops.h`
- Add NULL check before calling `debug_op_hook`

## Details

1. **Operand type mismatch**: `OP_DEBUG` is defined as `BBB` in `ops.h` but was declared as `Z` in the VM switch. The old code manually called `FETCH_BBB()` after the `CASE` macro, which breaks extended opcode handling (`OP_EXT1/2/3`).

2. **Missing NULL check**: When `MRB_USE_DEBUG_HOOK` is enabled, `mrb->debug_op_hook()` was called without checking if it's NULL first, which would crash if no hook is set.

Fixes #5686