### PR TITLE
Fix mruby-task: wrapping by critical section and setting initial task receiver to top_self

### DIFF
--- a/mrbgems/mruby-task/src/task.c
+++ b/mrbgems/mruby-task/src/task.c
@@ -460,9 +460,9 @@ mrb_task_run(mrb_state *mrb)
     /* No task ready - check if all tasks are done */
     if (!t) {
       mrb_task_disable_irq();
-      mrb_bool exitting = !q_ready_ && !q_waiting_ && !q_suspended_;
+      mrb_bool exiting = !q_ready_ && !q_waiting_ && !q_suspended_;
       mrb_task_enable_irq();
-      if (exitting) {
+      if (exiting) {
         /* All tasks are dormant - scheduler done */
         break;
       }


### PR DESCRIPTION
This pull request makes two improvements:

## Fix mrb_task_run to prevent returning unexpectedly

Old code:

```c
t = q_ready_;

/* No task ready - check if all tasks are done */
if (!t) {
  /* If there are tasks waiting or suspended, idle */
  if (q_waiting_ || q_suspended_) {
    mrb_hal_task_idle_cpu(mrb);
    continue;
```

IRQ possibly happens between `t = q_ready_;` and `if (q_waiting_ || q_suspended_) {` and, for example, a waiting task may move to the ready queue.
As a result, the infinite loop in mrb_task_run unexpectedly breaks in spite of not all the task is dormant.
This patch fixes the issue above by setting the `exiting` condition with a critical section.

## Set initial task receiver to top_self for stability

The current implementation of `task_init_context` inheriting a receiver from the parent task is unstable and causes critical faults, especially on microcontrollers.

- It leads to a HardFault on devices like Raspberry Pi Pico 2 by accessing a potentially NULL `mrb->c->ci`.
- Even when `mrb->c->ci` is not NULL, this incomplete context copy causes other memory errors (SEGV).

This patch reverts to the safer, previous behavior, which I implemented in picoruby/picoruby, of always initializing a new task's receiver to `top_self`, ensuring predictable and
robust operation.
I could easily reproduce this fault on Raspberry Pi Pico 2, while I rarely encountered it on POSIX. It was likely masked on POSIX systems for some reasons, like unpredictable nature of undefined behavior, I guess.