### PR TITLE
Add installation instructions for conda and Homebrew 

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ of the Ministry of Economy, Trade and Industry of Japan.
 
 To get mruby, you can download the stable version 3.4.0 from the official mruby
 GitHub repository or clone the trunk of the mruby source tree with the "git
-clone" command. You can also install and compile mruby using [ruby-install](https://github.com/postmodern/ruby-install), [ruby-build](https://github.com/rbenv/ruby-build), [rvm](https://github.com/rvm/rvm), [Homebrew](https://formulae.brew.sh/formula/mruby) or [conda](https://anaconda.org/channels/conda-forge/packages/mruby/overview).
+clone" command. You can also install and compile mruby using [ruby-install](https://github.com/postmodern/ruby-install), [ruby-build](https://github.com/rbenv/ruby-build), [rvm](https://github.com/rvm/rvm), [conda](https://anaconda.org/channels/conda-forge/packages/mruby/overview) or [Homebrew](https://formulae.brew.sh/formula/mruby).
 
 The latest development version of mruby can be downloaded via the following URL: [https://github.com/mruby/mruby/zipball/master](https://github.com/mruby/mruby/zipball/master)
 


### PR DESCRIPTION
I have registered pre-built mruby binaries and libraries (linux/mac/windows) on conda-forge (a community-based conda channel) so that mruby can be installed via conda.

https://github.com/conda-forge/staged-recipes/pull/32072

Additionally, since someone has already made mruby installable via Homebrew (linux/mac), I have also included this information in the README.