### PR TITLE
Add `RInteger` and `RFloat` to `RVALUE`

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -131,6 +131,12 @@ struct RVALUE {
     struct RBasic basic;
     struct RObject object;
     struct RClass klass;
+#if defined(MRB_WORD_BOXING) || (defined(MRB_NAN_BOXING) && defined(MRB_INT64))
+    struct RInteger integer;
+#endif
+#if defined(MRB_WORD_BOXING) && !defined(MRB_NO_FLOAT) && defined(MRB_WORDBOX_NO_FLOAT_TRUNCATE)
+    struct RFloat flt;
+#endif
     struct RString string;
     struct RArray array;
     struct RHash hash;


### PR DESCRIPTION
Enhances detection of object size mismatches.

---

This patch reveals that 32-bit builds fail in AppVeyor.
This is because many 32-bit systems require 8-byte alignment for `double` and `int64_t`.
