### PR TITLE
change wording of the "overloading" section

### DIFF
--- a/doc/guides/language.md
+++ b/doc/guides/language.md
@@ -373,7 +373,7 @@ function return is supported.
 
 ### Array and String Subclasses
 
-`Array` and `String` does not support instance variables to reduce memory.
+`Array` and `String` do not support instance variables to reduce memory.
 This means subclassing `Array` or `String` and adding `@fields` will raise an error.
 
 ### Operator Overriding

--- a/doc/guides/language.md
+++ b/doc/guides/language.md
@@ -371,15 +371,15 @@ Fibers cannot cross C function boundaries. You cannot yield from a
 fiber inside a C-implemented method. Only `mrb_fiber_yield` at
 function return is supported.
 
-### Array Subclasses
+### Array and String Subclasses
 
-`Array` does not support instance variables to reduce memory. This
-means subclassing `Array` and adding `@fields` will raise an error.
+`Array` and `String` does not support instance variables to reduce memory.
+This means subclassing `Array` or `String` and adding `@fields` will raise an error.
 
 ### Operator Overriding
 
-Operators cannot be overridden by user code. Redefining `+` on
-`String` has no effect on the behavior of the `+` operator.
+Operators of primitive classes cannot be overridden by user code. 
+Redefining `String#+` has no effect on the behavior of the `+` __operator__.
 
 ### Module Loading Hooks
 

--- a/doc/limitations.md
+++ b/doc/limitations.md
@@ -111,7 +111,7 @@ Syntax error
 
 ## Operator modification
 
-Operators on some of the primitive classes cannot be overriden, as they are
+Operators on some of the primitive classes cannot be overridden, as they are
 optimized in the VM.
 
 ```ruby

--- a/doc/limitations.md
+++ b/doc/limitations.md
@@ -111,7 +111,8 @@ Syntax error
 
 ## Operator modification
 
-An operator can't be overwritten by the user.
+Operators on some of the primitive classes cannot be overriden, as they are
+optimized in the VM.
 
 ```ruby
 class String


### PR DESCRIPTION
the previous wording may have been taken as mruby not permitting the overloading of operators on any class