### PR TITLE
Simplifying dependency addition for gensym task

### DIFF
--- a/tasks/presym.rake
+++ b/tasks/presym.rake
@@ -7,8 +7,6 @@ all_prerequisites = ->(task_name, prereqs) do
 end
 
 MRuby.each_target do |build|
-  gensym_task = task(:gensym)
-
   presym = build.presym
 
   include_dir = "#{build.build_dir}/include"
@@ -55,5 +53,5 @@ MRuby.each_target do |build|
     file prereq => presym.list_path
   end
 
-  gensym_task.enhance([presym.list_path])
+  task gensym: presym.list_path
 end


### PR DESCRIPTION
The `gensym_task` variable was only used for dependency addition and is no longer needed.