### PR TITLE
Simplifying presym file generation actions

### DIFF
--- a/tasks/presym.rake
+++ b/tasks/presym.rake
@@ -34,12 +34,12 @@ MRuby.each_target do |build|
   file presym.list_path => ppps do
     presyms = presym.scan(ppps)
     current_presyms = presym.read_list if File.exist?(presym.list_path)
-    update = presyms != current_presyms
-    presym.write_list(presyms) if update
-    mkdir_p presym.header_dir
-    %w[id table].each do |type|
-      next if !update && File.exist?(presym.send("#{type}_header_path"))
-      presym.send("write_#{type}_header", presyms)
+    if presyms != current_presyms
+      mkdir_p presym.header_dir
+      %w[id table].each do |type|
+        presym.send("write_#{type}_header", presyms)
+      end
+      presym.write_list(presyms)
     end
   end
 


### PR DESCRIPTION
By performing output to presym files after header files, there is no longer a need to check for the existence of header files.
Furthermore, concentrating the file output logic into an "if" block eliminates the need for the `update` variable.

Strict atomicity between presym files and header files is still not guaranteed, as before.
If atomicity is truly required, it can be achieved by deleting the presym file before updating the header files.