### PR TITLE
language.md: remove unnecessary bold markup from "operator"

### DIFF
--- a/doc/guides/language.md
+++ b/doc/guides/language.md
@@ -378,8 +378,8 @@ This means subclassing `Array` or `String` and adding `@fields` will raise an er
 
 ### Operator Overriding
 
-Operators of primitive classes cannot be overridden by user code. 
-Redefining `String#+` has no effect on the behavior of the `+` __operator__.
+Operators of primitive classes cannot be overridden by user code.
+Redefining `String#+` has no effect on the behavior of the `+` operator.
 
 ### Module Loading Hooks
 


### PR DESCRIPTION
## Summary
- Remove unnecessary bold markup (`**operator**`) from `language.md`, replacing with plain text

Co-authored-by: Claude <noreply@anthropic.com>