### PR TITLE
mruby.h: include mruby/presym.h for all source files

### DIFF
--- a/doc/guides/rom-method-table.md
+++ b/doc/guides/rom-method-table.md
@@ -79,7 +79,6 @@ Include `<mruby/class.h>` (which provides `mrb_mt_entry`,
 
 ```c
 #include <mruby/class.h>
-#include <mruby/presym.h>
 
 static const mrb_mt_entry my_rom_entries[] = {
   MRB_MT_ENTRY(my_method_a,  MRB_SYM(method_a), MRB_ARGS_REQ(1)),

--- a/examples/mrbgems/mruby-YOUR-bigint/core/bigint.c
+++ b/examples/mrbgems/mruby-YOUR-bigint/core/bigint.c
@@ -16,11 +16,6 @@
 #include <mruby/internal.h>
 
 /*
- * The "mruby/presym.h" file is placed at the end of the mruby header file.
- */
-#include <mruby/presym.h>
-
-/*
  * Define your own struct RBigint.
  *
  * - Object type must be MRB_TT_BIGINT.

--- a/include/mruby.h
+++ b/include/mruby.h
@@ -1015,7 +1015,7 @@ typedef const char *mrb_args_format;
  *      mrb_value str, kw_rest;
  *      uint32_t kw_num = 3;
  *      uint32_t kw_required = 1;
- *      // Note that `#include <mruby/presym.h>` is required beforehand because `MRB_SYM()` is used.
+ *      // `MRB_SYM()` is available via `mruby.h` (which includes `mruby/presym.h`).
  *      // If the usage of `MRB_SYM()` is not desired, replace it with `mrb_intern_lit()`.
  *      mrb_sym kw_names[] = { MRB_SYM(x), MRB_SYM(y), MRB_SYM(z) };
  *      mrb_value kw_values[kw_num];
@@ -1594,6 +1594,8 @@ MRB_API mrb_value mrb_format(mrb_state *mrb, const char *format, ...);
 
 #ifdef MRB_PRESYM_SCANNING
 # include <mruby/presym/scanning.h>
+#else
+# include <mruby/presym.h>
 #endif
 
 #if 0

--- a/mrbgems/hal-posix-socket/src/socket_hal.c
+++ b/mrbgems/hal-posix-socket/src/socket_hal.c
@@ -11,7 +11,6 @@
 #include <mruby/string.h>
 #include <mruby/class.h>
 #include <mruby/error.h>
-#include <mruby/presym.h>
 #include "socket_hal.h"
 
 #include <sys/types.h>

--- a/mrbgems/hal-win-socket/src/socket_hal.c
+++ b/mrbgems/hal-win-socket/src/socket_hal.c
@@ -15,7 +15,6 @@
 #include <mruby/string.h>
 #include <mruby/class.h>
 #include <mruby/error.h>
-#include <mruby/presym.h>
 #include "socket_hal.h"
 #include <winsock2.h>
 #include <ws2tcpip.h>

--- a/mrbgems/mruby-array-ext/src/array.c
+++ b/mrbgems/mruby-array-ext/src/array.c
@@ -7,7 +7,6 @@
 #include <mruby/data.h>
 #include <mruby/class.h>
 #include <mruby/internal.h>
-#include <mruby/presym.h>
 #include <mruby/khash.h>
 #include <mruby/error.h>
 

--- a/mrbgems/mruby-bin-debugger/tools/mrdb/apiprint.c
+++ b/mrbgems/mruby-bin-debugger/tools/mrdb/apiprint.c
@@ -12,7 +12,6 @@
 #include <mruby/numeric.h>
 #include <mruby/string.h>
 #include <mruby/internal.h>
-#include <mruby/presym.h>
 #include "apiprint.h"
 
 static void

--- a/mrbgems/mruby-bin-mirb/tools/mirb/mirb.c
+++ b/mrbgems/mruby-bin-mirb/tools/mirb/mirb.c
@@ -19,7 +19,6 @@
 #include <mruby/string.h>
 #include <mruby/variable.h>
 #include <mruby/error.h>
-#include <mruby/presym.h>
 #include <mruby/internal.h>
 
 #include <stdlib.h>

--- a/mrbgems/mruby-bin-mruby/tools/mruby/mruby.c
+++ b/mrbgems/mruby-bin-mruby/tools/mruby/mruby.c
@@ -12,7 +12,6 @@
 #include <mruby/variable.h>
 #include <mruby/proc.h>
 #include <mruby/error.h>
-#include <mruby/presym.h>
 
 #if defined(_WIN32)
 # include <io.h> /* for setmode */

--- a/mrbgems/mruby-binding/src/binding.c
+++ b/mrbgems/mruby-binding/src/binding.c
@@ -4,7 +4,6 @@
 #include <mruby/hash.h>
 #include <mruby/proc.h>
 #include <mruby/variable.h>
-#include <mruby/presym.h>
 #include <mruby/opcode.h>
 #include <mruby/debug.h>
 #include <mruby/internal.h>

--- a/mrbgems/mruby-binding/test/binding.c
+++ b/mrbgems/mruby-binding/test/binding.c
@@ -1,5 +1,4 @@
 #include <mruby.h>
-#include <mruby/presym.h>
 
 static mrb_value
 binding_in_c(mrb_state *mrb, mrb_value self)

--- a/mrbgems/mruby-catch/src/catch.c
+++ b/mrbgems/mruby-catch/src/catch.c
@@ -4,7 +4,6 @@
 #include <mruby/error.h>
 #include <mruby/proc.h>
 #include <mruby/opcode.h>
-#include <mruby/presym.h>
 
 /* Pre-defined symbols used by catch implementation */
 MRB_PRESYM_DEFINE_VAR_AND_INITER(catch_syms, 3, MRB_SYM(Object), MRB_SYM(new), MRB_SYM(call))

--- a/mrbgems/mruby-class-ext/src/class.c
+++ b/mrbgems/mruby-class-ext/src/class.c
@@ -5,7 +5,6 @@
 #include <mruby/proc.h>
 #include <mruby/variable.h>
 #include <mruby/internal.h>
-#include <mruby/presym.h>
 
 /*
  * Get the name of a module/class.

--- a/mrbgems/mruby-cmath/src/cmath.c
+++ b/mrbgems/mruby-cmath/src/cmath.c
@@ -10,7 +10,6 @@
 */
 
 #include <mruby.h>
-#include <mruby/presym.h>
 
 #ifdef MRB_NO_FLOAT
 # error CMath conflicts with 'MRB_NO_FLOAT' configuration

--- a/mrbgems/mruby-compiler/core/codegen.c
+++ b/mrbgems/mruby-compiler/core/codegen.c
@@ -46,7 +46,6 @@
 #include <mruby/numeric.h>
 #include <mruby/string.h>
 #include <mruby/debug.h>
-#include <mruby/presym.h>
 #include "node.h"
 #include <mruby/opcode.h>
 #include <mruby/re.h>

--- a/mrbgems/mruby-compiler/core/parse.y
+++ b/mrbgems/mruby-compiler/core/parse.y
@@ -23,7 +23,6 @@
 #include <mruby/string.h>
 #include <mruby/dump.h>
 #include <mruby/internal.h>
-#include <mruby/presym.h>
 #include "node.h"
 
 #define YYLEX_PARAM p

--- a/mrbgems/mruby-compiler/core/y.tab.c
+++ b/mrbgems/mruby-compiler/core/y.tab.c
@@ -85,7 +85,6 @@
 #include <mruby/string.h>
 #include <mruby/dump.h>
 #include <mruby/internal.h>
-#include <mruby/presym.h>
 #include "node.h"
 
 #define YYLEX_PARAM p

--- a/mrbgems/mruby-complex/src/complex.c
+++ b/mrbgems/mruby-complex/src/complex.c
@@ -2,7 +2,6 @@
 #include <mruby/class.h>
 #include <mruby/numeric.h>
 #include <mruby/internal.h>
-#include <mruby/presym.h>
 #include <float.h>
 
 #ifdef MRB_NO_FLOAT

--- a/mrbgems/mruby-data/src/data.c
+++ b/mrbgems/mruby-data/src/data.c
@@ -13,7 +13,6 @@
 #include <mruby/hash.h>
 #include <mruby/proc.h>
 #include <mruby/internal.h>
-#include <mruby/presym.h>
 
 #define RDATA_LEN(st) RARRAY_LEN(st)
 #define RDATA_PTR(st) RARRAY_PTR(st)

--- a/mrbgems/mruby-dir/src/dir.c
+++ b/mrbgems/mruby-dir/src/dir.c
@@ -10,7 +10,6 @@
 #include <mruby/data.h>
 #include <mruby/error.h>
 #include <mruby/string.h>
-#include <mruby/presym.h>
 #include "dir_hal.h"
 
 #include <string.h>

--- a/mrbgems/mruby-encoding/src/encoding.c
+++ b/mrbgems/mruby-encoding/src/encoding.c
@@ -2,7 +2,6 @@
 #include <mruby/string.h>
 #include <mruby/variable.h>
 #include <mruby/internal.h>
-#include <mruby/presym.h>
 
 #define ENC_ASCII_8BIT "ASCII-8BIT"
 #define ENC_BINARY     "BINARY"

--- a/mrbgems/mruby-errno/src/errno.c
+++ b/mrbgems/mruby-errno/src/errno.c
@@ -7,7 +7,6 @@
 #include <mruby/string.h>
 #include <mruby/variable.h>
 #include <mruby/internal.h>
-#include <mruby/presym.h>
 #include <errno.h>
 #include <string.h>
 

--- a/mrbgems/mruby-eval/src/eval.c
+++ b/mrbgems/mruby-eval/src/eval.c
@@ -6,7 +6,6 @@
 #include <mruby/proc.h>
 #include <mruby/opcode.h>
 #include <mruby/error.h>
-#include <mruby/presym.h>
 #include <mruby/variable.h>
 #include <mruby/internal.h>
 

--- a/mrbgems/mruby-exit/src/mruby_exit.c
+++ b/mrbgems/mruby-exit/src/mruby_exit.c
@@ -2,7 +2,6 @@
 #include <mruby.h>
 #include <mruby/error.h>
 #include <mruby/variable.h>
-#include <mruby/presym.h>
 
 #ifndef EXIT_SUCCESS
 # define EXIT_SUCCESS 0

--- a/mrbgems/mruby-fiber/src/fiber.c
+++ b/mrbgems/mruby-fiber/src/fiber.c
@@ -6,7 +6,6 @@
 #include <mruby/numeric.h>
 #include <mruby/proc.h>
 #include <mruby/string.h>
-#include <mruby/presym.h>
 
 #define fiber_ptr(o) ((struct RFiber*)mrb_ptr(o))
 

--- a/mrbgems/mruby-hash-ext/src/hash_ext.c
+++ b/mrbgems/mruby-hash-ext/src/hash_ext.c
@@ -9,7 +9,6 @@
 #include <mruby/hash.h>
 #include <mruby/class.h>
 #include <mruby/internal.h>
-#include <mruby/presym.h>
 
 /*
  * call-seq:

--- a/mrbgems/mruby-io/src/file.c
+++ b/mrbgems/mruby-io/src/file.c
@@ -10,7 +10,6 @@
 #include <mruby/io.h>
 #include <mruby/error.h>
 #include <mruby/internal.h>
-#include <mruby/presym.h>
 #include "io_hal.h"
 
 #include <sys/types.h>

--- a/mrbgems/mruby-io/src/file_test.c
+++ b/mrbgems/mruby-io/src/file_test.c
@@ -8,7 +8,6 @@
 #include <mruby/string.h>
 #include <mruby/io.h>
 #include <mruby/error.h>
-#include <mruby/presym.h>
 #include <mruby/internal.h>
 #include "io_hal.h"
 

--- a/mrbgems/mruby-io/src/io.c
+++ b/mrbgems/mruby-io/src/io.c
@@ -12,7 +12,6 @@
 #include <mruby/io.h>
 #include <mruby/error.h>
 #include <mruby/internal.h>
-#include <mruby/presym.h>
 #include "io_hal.h"
 
 #include <sys/types.h>

--- a/mrbgems/mruby-kernel-ext/src/kernel.c
+++ b/mrbgems/mruby-kernel-ext/src/kernel.c
@@ -8,7 +8,6 @@
 #include <mruby/proc.h>
 #include <mruby/class.h>
 #include <mruby/internal.h>
-#include <mruby/presym.h>
 
 /*
  * call-seq:

--- a/mrbgems/mruby-math/src/math.c
+++ b/mrbgems/mruby-math/src/math.c
@@ -11,7 +11,6 @@
 #endif
 
 #include <mruby/array.h>
-#include <mruby/presym.h>
 
 static void
 domain_error(mrb_state *mrb, const char *func)

--- a/mrbgems/mruby-metaprog/src/metaprog.c
+++ b/mrbgems/mruby-metaprog/src/metaprog.c
@@ -7,7 +7,6 @@
 #include <mruby/string.h>
 #include <mruby/internal.h>
 #include <mruby/khash.h>
-#include <mruby/presym.h>
 
 #define MT_PROTECTED MRB_METHOD_PROTECTED_FL
 #define MT_NOPRIV (MRB_METHOD_PRIVATE_FL|MT_PROTECTED)

--- a/mrbgems/mruby-method/src/method.c
+++ b/mrbgems/mruby-method/src/method.c
@@ -5,7 +5,6 @@
 #include <mruby/proc.h>
 #include <mruby/string.h>
 #include <mruby/internal.h>
-#include <mruby/presym.h>
 
 // Defined by mruby-proc-ext on which mruby-method depends
 mrb_value mrb_proc_parameters(mrb_state *mrb, mrb_value proc);

--- a/mrbgems/mruby-numeric-ext/src/numeric_ext.c
+++ b/mrbgems/mruby-numeric-ext/src/numeric_ext.c
@@ -4,7 +4,6 @@
 #include <mruby/string.h>
 #include <mruby/class.h>
 #include <mruby/internal.h>
-#include <mruby/presym.h>
 
 #ifndef MRB_NO_FLOAT
 static mrb_value flo_remainder(mrb_state *mrb, mrb_value self);

--- a/mrbgems/mruby-object-ext/src/object.c
+++ b/mrbgems/mruby-object-ext/src/object.c
@@ -4,7 +4,6 @@
 #include <mruby/hash.h>
 #include <mruby/proc.h>
 #include <mruby/internal.h>
-#include <mruby/presym.h>
 
 /*
  *  call-seq:

--- a/mrbgems/mruby-objectspace/src/mruby_objectspace.c
+++ b/mrbgems/mruby-objectspace/src/mruby_objectspace.c
@@ -10,7 +10,6 @@
 #include <mruby/proc.h>
 #include <mruby/value.h>
 #include <mruby/range.h>
-#include <mruby/presym.h>
 
 struct os_count_struct {
   mrb_int total;

--- a/mrbgems/mruby-pack/src/pack.c
+++ b/mrbgems/mruby-pack/src/pack.c
@@ -11,7 +11,6 @@
 #include <mruby/variable.h>
 #include <mruby/endian.h>
 #include <mruby/internal.h>
-#include <mruby/presym.h>
 
 #include <ctype.h>
 #include <string.h>

--- a/mrbgems/mruby-proc-binding/src/proc_binding.c
+++ b/mrbgems/mruby-proc-binding/src/proc_binding.c
@@ -1,5 +1,4 @@
 #include <mruby.h>
-#include <mruby/presym.h>
 #include <mruby/proc.h>
 #include <mruby/variable.h>
 

--- a/mrbgems/mruby-proc-ext/src/proc.c
+++ b/mrbgems/mruby-proc-ext/src/proc.c
@@ -6,7 +6,6 @@
 #include <mruby/string.h>
 #include <mruby/debug.h>
 #include <mruby/internal.h>
-#include <mruby/presym.h>
 
 /*
  *  call-seq:

--- a/mrbgems/mruby-random/src/random.c
+++ b/mrbgems/mruby-random/src/random.c
@@ -11,7 +11,6 @@
 #include <mruby/data.h>
 #include <mruby/array.h>
 #include <mruby/istruct.h>
-#include <mruby/presym.h>
 #include <mruby/range.h>
 #include <mruby/string.h>
 #include <mruby/internal.h>

--- a/mrbgems/mruby-range-ext/src/range.c
+++ b/mrbgems/mruby-range-ext/src/range.c
@@ -2,7 +2,6 @@
 #include <mruby/range.h>
 #include <mruby/class.h>
 #include <mruby/internal.h>
-#include <mruby/presym.h>
 
 static mrb_bool
 r_less(mrb_state *mrb, mrb_value a, mrb_value b, mrb_bool excl)

--- a/mrbgems/mruby-rational/src/rational.c
+++ b/mrbgems/mruby-rational/src/rational.c
@@ -2,7 +2,6 @@
 #include <mruby/class.h>
 #include <mruby/numeric.h>
 #include <mruby/internal.h>
-#include <mruby/presym.h>
 
 #ifndef MRB_NO_FLOAT
 #include <math.h>

--- a/mrbgems/mruby-set/src/set.c
+++ b/mrbgems/mruby-set/src/set.c
@@ -13,7 +13,6 @@
 #include <mruby/proc.h>
 #include <mruby/data.h>
 #include <mruby/internal.h>
-#include <mruby/presym.h>
 #include <mruby/error.h>
 #include <mruby/khash.h>
 

--- a/mrbgems/mruby-sleep/src/sleep.c
+++ b/mrbgems/mruby-sleep/src/sleep.c
@@ -37,7 +37,6 @@
 #endif
 
 #include <mruby.h>
-#include <mruby/presym.h>
 
 /*
  * call-seq:

--- a/mrbgems/mruby-socket/src/socket.c
+++ b/mrbgems/mruby-socket/src/socket.c
@@ -36,7 +36,6 @@
 #include <mruby/variable.h>
 #include <mruby/error.h>
 #include <mruby/internal.h>
-#include <mruby/presym.h>
 
 #include <mruby/io.h>
 #include "socket_hal.h"

--- a/mrbgems/mruby-sprintf/src/sprintf.c
+++ b/mrbgems/mruby-sprintf/src/sprintf.c
@@ -8,7 +8,6 @@
 #include <mruby/string.h>
 #include <mruby/hash.h>
 #include <mruby/numeric.h>
-#include <mruby/presym.h>
 #include <mruby/internal.h>
 #include <string.h>
 #include <ctype.h>

--- a/mrbgems/mruby-strftime/src/strftime.c
+++ b/mrbgems/mruby-strftime/src/strftime.c
@@ -8,7 +8,6 @@
 #include <mruby/string.h>
 #include <mruby/time.h>
 #include <mruby/class.h>
-#include <mruby/presym.h>
 #include <time.h>
 #include <string.h>
 

--- a/mrbgems/mruby-string-ext/src/string.c
+++ b/mrbgems/mruby-string-ext/src/string.c
@@ -5,7 +5,6 @@
 #include <mruby/string.h>
 #include <mruby/range.h>
 #include <mruby/internal.h>
-#include <mruby/presym.h>
 
 #define ENC_ASCII_8BIT "ASCII-8BIT"
 #define ENC_BINARY     "BINARY"

--- a/mrbgems/mruby-struct/src/struct.c
+++ b/mrbgems/mruby-struct/src/struct.c
@@ -14,7 +14,6 @@
 #include <mruby/range.h>
 #include <mruby/proc.h>
 #include <mruby/internal.h>
-#include <mruby/presym.h>
 
 #define RSTRUCT_LEN(st) RARRAY_LEN(st)
 #define RSTRUCT_PTR(st) RARRAY_PTR(st)

--- a/mrbgems/mruby-symbol-ext/src/symbol.c
+++ b/mrbgems/mruby-symbol-ext/src/symbol.c
@@ -3,7 +3,6 @@
 #include <mruby/class.h>
 #include <mruby/string.h>
 #include <mruby/internal.h>
-#include <mruby/presym.h>
 
 /*
  *  call-seq:

--- a/mrbgems/mruby-task/src/task.c
+++ b/mrbgems/mruby-task/src/task.c
@@ -12,7 +12,6 @@
 #include <mruby/gc.h>
 #include <mruby/hash.h>
 #include <mruby/internal.h>
-#include <mruby/presym.h>
 #include <mruby/proc.h>
 #include <mruby/string.h>
 #include <mruby/variable.h>

--- a/mrbgems/mruby-time/src/time.c
+++ b/mrbgems/mruby-time/src/time.c
@@ -11,7 +11,6 @@
 #include <mruby/time.h>
 #include <mruby/string.h>
 #include <mruby/internal.h>
-#include <mruby/presym.h>
 
 #ifdef MRB_NO_STDIO
 #include <string.h>

--- a/src/array.c
+++ b/src/array.c
@@ -11,7 +11,6 @@
 #include <mruby/range.h>
 #include <mruby/proc.h>
 #include <mruby/internal.h>
-#include <mruby/presym.h>
 #include "value_array.h"
 
 #define ARY_DEFAULT_LEN   4

--- a/src/backtrace.c
+++ b/src/backtrace.c
@@ -15,7 +15,6 @@
 #include <mruby/numeric.h>
 #include <mruby/data.h>
 #include <mruby/internal.h>
-#include <mruby/presym.h>
 
 #define MAX_IREP_REFCNT UINT16_MAX
 #define UNKNOWN_LINENO -1

--- a/src/cdump.c
+++ b/src/cdump.c
@@ -456,7 +456,6 @@ mrb_dump_irep_cstruct(mrb_state *mrb, const mrb_irep *irep, uint8_t flags, FILE 
                   "#include <mruby/irep.h>\n"
                   "#include <mruby/debug.h>\n"
                   "#include <mruby/proc.h>\n"
-                  "#include <mruby/presym.h>\n"
                   "\n") < 0) {
     return MRB_DUMP_WRITE_FAULT;
   }

--- a/src/class.c
+++ b/src/class.c
@@ -17,7 +17,6 @@
 #include <mruby/istruct.h>
 #include <mruby/opcode.h>
 #include <mruby/internal.h>
-#include <mruby/presym.h>
 
 /* mrb_mt_tbl, union mrb_mt_ptr, mrb_mt_entry defined in internal.h */
 #define MT_PROTECTED MRB_METHOD_PROTECTED_FL

--- a/src/enum.c
+++ b/src/enum.c
@@ -6,7 +6,6 @@
 
 #include <mruby.h>
 #include <mruby/proc.h>
-#include <mruby/presym.h>
 
 /* internal method `__update_hash(oldhash, index, itemhash)` */
 static mrb_value

--- a/src/error.c
+++ b/src/error.c
@@ -16,7 +16,6 @@
 #include <mruby/class.h>
 #include <mruby/throw.h>
 #include <mruby/internal.h>
-#include <mruby/presym.h>
 
 void
 mrb_exc_mesg_set(mrb_state *mrb, struct RException *exc, mrb_value mesg)

--- a/src/gc.c
+++ b/src/gc.c
@@ -22,7 +22,6 @@
 #include <mruby/error.h>
 #include <mruby/throw.h>
 #include <mruby/internal.h>
-#include <mruby/presym.h>
 
 #ifdef MRB_GC_STRESS
 #include <stdlib.h>

--- a/src/hash.c
+++ b/src/hash.c
@@ -13,7 +13,6 @@
 #include <mruby/variable.h>
 #include <mruby/proc.h>
 #include <mruby/internal.h>
-#include <mruby/presym.h>
 
 
 /*

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -14,7 +14,6 @@
 #include <mruby/error.h>
 #include <mruby/istruct.h>
 #include <mruby/internal.h>
-#include <mruby/presym.h>
 
 /*
  * Checks if the method `mid` for object `obj` is implemented by

--- a/src/numeric.c
+++ b/src/numeric.c
@@ -10,7 +10,6 @@
 #include <mruby/string.h>
 #include <mruby/class.h>
 #include <mruby/internal.h>
-#include <mruby/presym.h>
 #include <string.h>
 
 #ifndef MRB_NO_FLOAT

--- a/src/numops.c
+++ b/src/numops.c
@@ -7,7 +7,6 @@
 #include <mruby.h>
 #include <mruby/numeric.h>
 #include <mruby/internal.h>
-#include <mruby/presym.h>
 
 MRB_API mrb_value
 mrb_num_add(mrb_state *mrb, mrb_value x, mrb_value y)

--- a/src/object.c
+++ b/src/object.c
@@ -10,7 +10,6 @@
 #include <mruby/string.h>
 #include <mruby/class.h>
 #include <mruby/internal.h>
-#include <mruby/presym.h>
 
 /*
  * Checks if two mruby values, `v1` and `v2`, are identical.

--- a/src/print.c
+++ b/src/print.c
@@ -8,7 +8,6 @@
 #include <mruby/string.h>
 #include <mruby/variable.h>
 #include <mruby/error.h>
-#include <mruby/presym.h>
 #include <string.h>
 #if defined(_WIN32)
 # include <windows.h>

--- a/src/proc.c
+++ b/src/proc.c
@@ -12,7 +12,6 @@
 #include <mruby/array.h>
 #include <mruby/hash.h>
 #include <mruby/internal.h>
-#include <mruby/presym.h>
 
 static const mrb_code call_iseq[] = {
   OP_CALL,

--- a/src/range.c
+++ b/src/range.c
@@ -11,7 +11,6 @@
 #include <mruby/array.h>
 #include <mruby/numeric.h>
 #include <mruby/internal.h>
-#include <mruby/presym.h>
 
 #define RANGE_INITIALIZED_FLAG 1
 #define RANGE_INITIALIZED(p) ((p)->flags |= RANGE_INITIALIZED_FLAG)

--- a/src/string.c
+++ b/src/string.c
@@ -16,7 +16,6 @@
 #include <mruby/string.h>
 #include <mruby/numeric.h>
 #include <mruby/internal.h>
-#include <mruby/presym.h>
 #include <string.h>
 
 typedef struct mrb_shared_string {

--- a/src/symbol.c
+++ b/src/symbol.c
@@ -10,7 +10,6 @@
 #include <mruby/dump.h>
 #include <mruby/class.h>
 #include <mruby/internal.h>
-#include <mruby/presym.h>
 
 #ifndef MRB_PRESYM_SCANNING
 /* const uint16_t presym_length_table[]   */

--- a/src/variable.c
+++ b/src/variable.c
@@ -11,7 +11,6 @@
 #include <mruby/string.h>
 #include <mruby/variable.h>
 #include <mruby/internal.h>
-#include <mruby/presym.h>
 
 /* Instance variable table structure */
 typedef struct iv_tbl {

--- a/src/vm.c
+++ b/src/vm.c
@@ -20,7 +20,6 @@
 #include <mruby/throw.h>
 #include <mruby/dump.h>
 #include <mruby/internal.h>
-#include <mruby/presym.h>
 
 #ifdef MRB_NO_STDIO
 #if defined(__cplusplus)


### PR DESCRIPTION
## Summary
- Include `mruby/presym.h` from `mruby.h` so all source files automatically get presym definitions
- Remove redundant `#include "mruby/presym.h"` from 71 individual source files

Co-authored-by: Claude <noreply@anthropic.com>