### PR TITLE
codegen.c: chunk array literals at 64 elements to reduce register pressure

### DIFF
--- a/mrbgems/mruby-compiler/core/codegen.c
+++ b/mrbgems/mruby-compiler/core/codegen.c
@@ -3821,7 +3821,7 @@ codegen_array(codegen_scope *s, node *varnode, int val)
   node *elements = array->elements;
   int regular_elements = 0;
   int first = 1;
-  int slimit = GEN_VAL_STACK_MAX;
+  int slimit = GEN_LIT_ARY_MAX;
 
   if (!val) return;
 
@@ -3831,7 +3831,7 @@ codegen_array(codegen_scope *s, node *varnode, int val)
     return;
   }
 
-  if (cursp() >= GEN_LIT_ARY_MAX) slimit = INT16_MAX;
+  if (cursp() >= slimit) slimit = GEN_VAL_STACK_MAX;
 
   /* Process each element using cons-list iteration, handling splats */
   node *current = elements;


### PR DESCRIPTION
## Summary
- Array literals (e.g. 100 elements) were consuming up to 99 registers by loading all values before constructing the array
- Restore 3.4-era chunking at `GEN_LIT_ARY_MAX` (64 elements), capping `nregs` at 64 for any-size array literal
- This fixes compatibility with mruby/c which has a smaller register limit

fixes #6731

Co-authored-by: Claude <noreply@anthropic.com>