### PR TITLE
Prevent full recompilation without changes to presym file

### DIFF
--- a/tasks/presym.rake
+++ b/tasks/presym.rake
@@ -29,7 +29,7 @@ MRuby.each_target do |build|
     end
   end
 
-  file presym.list_path => ppps do
+  presym_task = file presym.list_path => ppps do
     presyms = presym.scan(ppps)
     current_presyms = presym.read_list if File.exist?(presym.list_path)
     if presyms != current_presyms
@@ -41,6 +41,21 @@ MRuby.each_target do |build|
     end
   end
 
+  # Don't directly write dependency tasks in the "task" arguments.
+  # The rake system tracks dependencies recursively
+  # (see Rake::Task#all_prerequisite_tasks and #collect_prerequisites).
+  # Therefore, indirect dependencies from ".o" to ".pi" must be eliminated.
+  # ref. https://github.com/mruby/mruby/issues/6721
+  # This task acts a proxy-like for the "presym.list_path" task.
+  presym_proxy = task "gensym:update:#{build.name}" do
+    presym_task.invoke
+  end
+
+  # Override the "timestamp" method to reflect the presym file.
+  presym_proxy.define_singleton_method :timestamp do
+    presym_task.timestamp
+  end
+
   # Ensure .o files depend on presym headers being generated.
   # This is critical when a build's .o files are compiled during another
   # build's presym scanning chain (before :gensym completes), e.g.:
@@ -50,7 +65,7 @@ MRuby.each_target do |build|
     next unless File.extname(prereq) == build.exts.object
     next unless prereq.start_with?(build_dir)
     next if mrbc_build_dir && prereq.start_with?(mrbc_build_dir)
-    file prereq => presym.list_path
+    file prereq => presym_proxy
   end
 
   task gensym: presym.list_path


### PR DESCRIPTION
Commit b9a1a1fb2389e5b36dd0f0d9a6f95818f7f30af5 is a revert of commit 8df9a22a85afdfdf01b0a8a2f5fbaf299f29738c, differing only in the comment. This means the issue from https://github.com/mruby/mruby/issues/6721 has reappeared.

The cause of https://github.com/mruby/mruby/issues/6721, as stated in the commit message for commit 8df9a22a85afdfdf01b0a8a2f5fbaf299f29738c, is that each ".o" file has an indirect dependency on all ".pi" files through the presym file.

This patch therefore adds a cushion task `gensym:update:#{build.name}` between tasks. Its purpose is to hide the direct dependency from ".o" files to the presym file from the rake system.