### PR TITLE
Add pre-commit ecosystem to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,27 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      bundler-dependencies:
+        patterns:
+          - "*"
     cooldown:
       default-days: 7
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      github-actions-dependencies:
+        patterns:
+          - "*"
     cooldown:
       default-days: 7
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    groups:
+      pre-commit-hooks:
+        patterns:
+          - "*"


### PR DESCRIPTION
Group dependabot updates to reduce repo noise

Add descriptive group labels

https://github.blog/changelog/2026-03-10-dependabot-now-supports-pre-commit-hooks/

https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#package-ecosystem-