### PR TITLE
Fix build error with MSYS2.

### DIFF
--- a/lib/mruby/gem.rb
+++ b/lib/mruby/gem.rb
@@ -109,7 +109,8 @@ module MRuby
         if build.kind_of?(MRuby::CrossBuild)
           return %w(x86_64-w64-mingw32 i686-w64-mingw32).include?(build.host_target)
         elsif build.kind_of?(MRuby::Build)
-          return ('A'..'Z').to_a.any? { |vol| Dir.exist?("#{vol}:") }
+          return ('A'..'Z').to_a.any? { |vol| Dir.exist?("#{vol}:") } ||
+                 ('a'..'z').to_a.any? { |vol| Dir.exist?("/#{vol}/") }
         end
         return false
       end


### PR DESCRIPTION
A build script supports MSYS2 drive letters (e.g., '/c'), fixing build errors with MSYS2 MinGW.