### PR TITLE
Fixed "Out-of-bounds Read" and "Divide-by-Zero" in `ary_product_group()`

### DIFF
--- a/mrbgems/mruby-array-ext/src/array.c
+++ b/mrbgems/mruby-array-ext/src/array.c
@@ -1395,8 +1395,14 @@ ary_product_group(mrb_state *mrb, mrb_value self_ary)
     mrb_value a = RARRAY_PTR(arys_ary)[j]; // arys[j]
     mrb_check_type(mrb, a, MRB_TT_ARRAY);
     mrb_int b = RARRAY_LEN(a);             // a.size
+    if (b <= 0) {
+      mrb_raise(mrb, E_ARGUMENT_ERROR, "cannot compute product with an empty array");
+    }
     mrb_ary_set(mrb, group, j + 1, RARRAY_PTR(a)[n % b]);
     n /= b;
+  }
+  if (n >= RARRAY_LEN(self_ary)) {
+    mrb_raise(mrb, E_INDEX_ERROR, "index out of range");
   }
   mrb_ary_set(mrb, group, 0, RARRAY_PTR(self_ary)[n]);
 


### PR DESCRIPTION
Reproduction:

  - Out-of-bounds Read

    ```console
    % build/host/bin/mruby -e '([nil] * 256).__product_group([[nil] * 256], 1 << 32, 256)'
    zsh: segmentation fault (core dumped)  build/host/bin/mruby -e
    ```

  - Divide-by-Zero

    ```console
    % build/host/bin/mruby -e '([nil] * 256).__product_group([[]], 1 << 32, 256)'
    zsh: floating point exception (core dumped)  build/host/bin/mruby -e '([nil] * 256).__product_group([[]], 1 << 32, 256)'
    ```
