### PR TITLE
Fix attr_reader-generated methods accepting extra arguments

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -2776,6 +2776,7 @@ mod_attr_define(mrb_state *mrb, mrb_value mod, mrb_value (*accessor)(mrb_state*,
 static mrb_value
 attr_reader(mrb_state *mrb, mrb_value obj)
 {
+  mrb_get_args(mrb, "");
   mrb_value name = mrb_proc_cfunc_env_get(mrb, 0);
   return mrb_iv_get(mrb, obj, to_sym(mrb, name));
 }

--- a/test/t/module.rb
+++ b/test/t/module.rb
@@ -163,6 +163,9 @@ assert('Module#attr_reader', '15.2.2.4.13') do
 
   AttrTestReader.cattr_val = 'test'
   assert_equal 'test', AttrTestReader.cattr
+
+  assert_raise(ArgumentError) { attr_instance.iattr(1) }
+  assert_raise(ArgumentError) { attr_instance.iattr(1, 2, 3) }
 end
 
 assert('Module#attr_writer', '15.2.2.4.14') do


### PR DESCRIPTION
Fixes #6751.

`attr_reader`-generated getter methods silently accept any number of arguments instead of raising `ArgumentError` like CRuby does:

```ruby
class User
  attr_reader :name
end

User.new.name(1, 2, 3)  # mruby: no error, CRuby: ArgumentError
```

The `attr_reader` C function was missing argument validation. `attr_writer` already had this covered via `mrb_get_arg1()`, but `attr_reader` had no equivalent check.

The fix adds `mrb_get_args(mrb, "")` to enforce zero arguments.