### PR TITLE
remove redundant `mrb_hash_get` call

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -2703,9 +2703,10 @@ RETRY_TRY_BLOCK:
       if (kidx < 0 || !mrb_hash_p(kdict=regs[kidx]) || !mrb_hash_key_p(mrb, kdict, k)) {
         RAISE_FORMAT(mrb, E_ARGUMENT_ERROR, "missing keyword: %v", k);
       }
+
       v = mrb_hash_delete_key(mrb, kdict, k);
-      regs[a] = v;
       ci = mrb->c->ci;
+      regs[a] = v;
       NEXT;
     }
 


### PR DESCRIPTION
`mrb_hash_delete` returns the removed element (which is guaranteed to exist due to the `mrb_hash_key_p` check), this prevents the hash from being searched twice.