### PR TITLE
Avoid the impact of object modifications caused by calls to `mrb_vm_exec()`

### DIFF
--- a/mrbgems/mruby-array-ext/src/array.c
+++ b/mrbgems/mruby-array-ext/src/array.c
@@ -79,11 +79,14 @@ ary_assoc(mrb_state *mrb, mrb_value ary)
 {
   mrb_value k = mrb_get_arg1(mrb);
 
+  int ai = mrb_gc_arena_save(mrb);
   for (mrb_int i = 0; i < RARRAY_LEN(ary); i++) {
     mrb_value v = mrb_check_array_type(mrb, RARRAY_PTR(ary)[i]);
+    mrb_gc_protect(mrb, v); // v may be removed from ary by mrb_equal()
     if (!mrb_nil_p(v) && RARRAY_LEN(v) > 0 &&
         mrb_equal(mrb, RARRAY_PTR(v)[0], k))
       return v;
+    mrb_gc_arena_restore(mrb, ai);
   }
   return mrb_nil_value();
 }
@@ -107,12 +110,15 @@ ary_rassoc(mrb_state *mrb, mrb_value ary)
 {
   mrb_value value = mrb_get_arg1(mrb);
 
+  int ai = mrb_gc_arena_save(mrb);
   for (mrb_int i = 0; i < RARRAY_LEN(ary); i++) {
     mrb_value v = RARRAY_PTR(ary)[i];
+    mrb_gc_protect(mrb, v); // v may be removed from ary by mrb_equal()
     if (mrb_array_p(v) &&
         RARRAY_LEN(v) > 1 &&
         mrb_equal(mrb, RARRAY_PTR(v)[1], value))
       return v;
+    mrb_gc_arena_restore(mrb, ai);
   }
   return mrb_nil_value();
 }
@@ -410,9 +416,12 @@ ary_init_temp_set(mrb_state *mrb, ary_set_t *set, mrb_int capacity)
 static void
 ary_populate_temp_set(mrb_state *mrb, ary_set_t *set, mrb_value ary)
 {
-  mrb_int len = RARRAY_LEN(ary);
-  for (mrb_int i = 0; i < len; i++) {
-    kh_put(ary_set, mrb, set, RARRAY_PTR(ary)[i]);
+  int ai = mrb_gc_arena_save(mrb);
+  for (mrb_int i = 0; i < RARRAY_LEN(ary); i++) {
+    mrb_value p = RARRAY_PTR(ary)[i];
+    mrb_gc_protect(mrb, p); // p may be removed from ary by kh_put(ary_set, ...)
+    kh_put(ary_set, mrb, set, p);
+    mrb_gc_arena_restore(mrb, ai);
   }
 }
 
@@ -461,12 +470,15 @@ ary_subtract_body(mrb_state *mrb, void *data)
     ary_populate_temp_set(mrb, ctx->set, ctx->argv[i]);
   }
 
+  int ai = mrb_gc_arena_save(mrb);
   for (mrb_int i = 0; i < RARRAY_LEN(ctx->self); i++) {
     mrb_value p = RARRAY_PTR(ctx->self)[i];
+    mrb_gc_protect(mrb, p); // p may be removed from self by kh_get(ary_set, ...)
     khiter_t k = kh_get(ary_set, mrb, ctx->set, p);
     if (kh_is_end(ctx->set, k)) {  /* key doesn't exist in any ary */
       mrb_ary_push(mrb, ctx->result, p);
     }
+    mrb_gc_arena_restore(mrb, ai);
   }
 
   return ctx->result;
@@ -500,13 +512,13 @@ ary_subtract_internal(mrb_state *mrb, mrb_value self, mrb_int argc, const mrb_va
     }
   }
   else {
-    mrb_int self_len = RARRAY_LEN(self);
-    for (mrb_int i = 0; i < self_len; i++) {
+    int ai = mrb_gc_arena_save(mrb);
+    for (mrb_int i = 0; i < RARRAY_LEN(self); i++) {
       mrb_value p = RARRAY_PTR(self)[i];
+      mrb_gc_protect(mrb, p); // p may be removed from self by mrb_equal()
       mrb_bool found = FALSE;
       for (mrb_int j = 0; j < argc; j++) {
-        mrb_int len = RARRAY_LEN(argv[j]);
-        for (mrb_int k = 0; k < len; k++) {
+        for (mrb_int k = 0; k < RARRAY_LEN(argv[j]); k++) {
           if (mrb_equal(mrb, p, RARRAY_PTR(argv[j])[k])) {
             found = TRUE;
             break;
@@ -517,6 +529,7 @@ ary_subtract_internal(mrb_state *mrb, mrb_value self, mrb_int argc, const mrb_va
       if (!found) {
         mrb_ary_push(mrb, result, p);
       }
+      mrb_gc_arena_restore(mrb, ai);
     }
   }
 
@@ -560,12 +573,10 @@ ary_difference(mrb_state *mrb, mrb_value self)
   return ary_subtract_internal(mrb, self, argc, argv);
 }
 
-
 static void
 add_uniq(mrb_state *mrb, mrb_value item, mrb_value result)
 {
-  const mrb_int len = RARRAY_LEN(result);
-  for (mrb_int i = 0; i < len; i++) {
+  for (mrb_int i = 0; i < RARRAY_LEN(result); i++) {
     if (mrb_eql(mrb, item, RARRAY_PTR(result)[i])) {
       return;
     }
@@ -585,15 +596,18 @@ static mrb_value
 ary_union_body(mrb_state *mrb, void *data)
 {
   struct ary_union_ctx *ctx = (struct ary_union_ctx *)data;
+  int ai = mrb_gc_arena_save(mrb);
 
   /* Add unique elements from self */
   for (mrb_int i = 0; i < RARRAY_LEN(ctx->self_copy); i++) {
     mrb_value elem = RARRAY_PTR(ctx->self_copy)[i];
+    mrb_gc_protect(mrb, elem); // elem may be removed from self_copy by kh_get(ary_set, ...)
     khiter_t k = kh_get(ary_set, mrb, ctx->set, elem);
     if (kh_is_end(ctx->set, k)) {
       kh_put(ary_set, mrb, ctx->set, elem);
       mrb_ary_push(mrb, ctx->result, elem);
     }
+    mrb_gc_arena_restore(mrb, ai);
   }
 
   /* Add unique elements from others */
@@ -601,11 +615,13 @@ ary_union_body(mrb_state *mrb, void *data)
     mrb_value other = ctx->argv[i];
     for (mrb_int j = 0; j < RARRAY_LEN(other); j++) {
       mrb_value elem = RARRAY_PTR(other)[j];
+      mrb_gc_protect(mrb, elem); // elem may be removed from other by kh_get(ary_set, ...)
       khiter_t k = kh_get(ary_set, mrb, ctx->set, elem);
       if (kh_is_end(ctx->set, k)) {
         kh_put(ary_set, mrb, ctx->set, elem);
         mrb_ary_push(mrb, ctx->result, elem);
       }
+      mrb_gc_arena_restore(mrb, ai);
     }
   }
 
@@ -637,19 +653,25 @@ ary_union_internal(mrb_state *mrb, mrb_value self, mrb_int argc, const mrb_value
     }
   }
   else {
+    int ai = mrb_gc_arena_save(mrb);
+
     /* Use linear search for small arrays */
     /* Add unique elements from self */
-    mrb_int alen = RARRAY_LEN(self);
-    for (mrb_int i = 0; i < alen; i++) {
-      add_uniq(mrb, RARRAY_PTR(self)[i], result);
+    for (mrb_int i = 0; i < RARRAY_LEN(self); i++) {
+      mrb_value p = RARRAY_PTR(self)[i];
+      mrb_gc_protect(mrb, p); // p may be removed from self by add_uniq()
+      add_uniq(mrb, p, result);
+      mrb_gc_arena_restore(mrb, ai);
     }
 
     /* Add unique elements from others */
     for (mrb_int i = 0; i < argc; i++) {
       mrb_value other = argv[i];
-      mrb_int olen = RARRAY_LEN(other);
-      for (mrb_int j = 0; j < olen; j++) {
-        add_uniq(mrb, RARRAY_PTR(other)[j], result);
+      for (mrb_int j = 0; j < RARRAY_LEN(other); j++) {
+        mrb_value p = RARRAY_PTR(other)[j];
+        mrb_gc_protect(mrb, p); // p may be removed from other by add_uniq()
+        add_uniq(mrb, p, result);
+        mrb_gc_arena_restore(mrb, ai);
       }
     }
   }
@@ -712,13 +734,16 @@ ary_intersection_body(mrb_state *mrb, void *data)
     ary_populate_temp_set(mrb, ctx->set, ctx->argv[i]);
   }
 
+  int ai = mrb_gc_arena_save(mrb);
   for (mrb_int i = 0; i < RARRAY_LEN(ctx->self); i++) {
     mrb_value p = RARRAY_PTR(ctx->self)[i];
+    mrb_gc_protect(mrb, p); // p may be removed from self by kh_get(ary_set, ...)
     khiter_t k = kh_get(ary_set, mrb, ctx->set, p);
     if (!kh_is_end(ctx->set, k)) {
       mrb_ary_push(mrb, ctx->result, p);
       kh_del(ary_set, mrb, ctx->set, k);
     }
+    mrb_gc_arena_restore(mrb, ai);
   }
 
   return ctx->result;
@@ -752,15 +777,15 @@ ary_intersection_internal(mrb_state *mrb, mrb_value self, mrb_int argc, const mr
     }
   }
   else {
-    mrb_int self_len = RARRAY_LEN(self);
-    for (mrb_int i = 0; i < self_len; i++) {
+    int ai = mrb_gc_arena_save(mrb);
+    for (mrb_int i = 0; i < RARRAY_LEN(self); i++) {
       mrb_value p = RARRAY_PTR(self)[i];
+      mrb_gc_protect(mrb, p); // p may be removed from self by mrb_equal()
       mrb_bool found_in_all = TRUE;
 
       for (mrb_int j = 0; j < argc; j++) {
         mrb_bool found_in_current_other = FALSE;
-        mrb_int len = RARRAY_LEN(argv[j]);
-        for (mrb_int k = 0; k < len; k++) {
+        for (mrb_int k = 0; k < RARRAY_LEN(argv[j]); k++) {
           if (mrb_equal(mrb, p, RARRAY_PTR(argv[j])[k])) {
             found_in_current_other = TRUE;
             break;
@@ -774,8 +799,7 @@ ary_intersection_internal(mrb_state *mrb, mrb_value self, mrb_int argc, const mr
 
       if (found_in_all) {
         mrb_bool already_added = FALSE;
-        mrb_int result_len = RARRAY_LEN(result);
-        for (mrb_int j = 0; j < result_len; j++) {
+        for (mrb_int j = 0; j < RARRAY_LEN(result); j++) {
           if (mrb_equal(mrb, p, RARRAY_PTR(result)[j])) {
             already_added = TRUE;
             break;
@@ -785,6 +809,7 @@ ary_intersection_internal(mrb_state *mrb, mrb_value self, mrb_int argc, const mr
           mrb_ary_push(mrb, result, p);
         }
       }
+      mrb_gc_arena_restore(mrb, ai);
     }
   }
   return result;
@@ -855,8 +880,12 @@ ary_intersect_p_body(mrb_state *mrb, void *data)
 
   ary_populate_temp_set(mrb, ctx->set, ctx->shorter_ary_copy);
 
+  int ai = mrb_gc_arena_save(mrb);
   for (mrb_int i = 0; i < RARRAY_LEN(ctx->longer_ary); i++) {
-    khiter_t k = kh_get(ary_set, mrb, ctx->set, RARRAY_PTR(ctx->longer_ary)[i]);
+    mrb_value p = RARRAY_PTR(ctx->longer_ary)[i];
+    mrb_gc_protect(mrb, p); // p may be removed from longer_ary by kh_get(ary_set, ...)
+    khiter_t k = kh_get(ary_set, mrb, ctx->set, p);
+    mrb_gc_arena_restore(mrb, ai);
     if (!kh_is_end(ctx->set, k)) {
       *ctx->found = TRUE;
       break;
@@ -906,12 +935,16 @@ ary_intersect_p(mrb_state *mrb, mrb_value self)
     }
   }
   else {
+    int ai = mrb_gc_arena_save(mrb);
     for (mrb_int i = 0; i < RARRAY_LEN(longer_ary); i++) {
+      mrb_value p = RARRAY_PTR(longer_ary)[i];
+      mrb_gc_protect(mrb, p); // p may be removed from longer_ary by mrb_equal()
       for (mrb_int j = 0; j < RARRAY_LEN(shorter_ary); j++) {
-        if (mrb_equal(mrb, RARRAY_PTR(longer_ary)[i], RARRAY_PTR(shorter_ary)[j])) {
+        if (mrb_equal(mrb, p, RARRAY_PTR(shorter_ary)[j])) {
           return mrb_true_value();
         }
       }
+      mrb_gc_arena_restore(mrb, ai);
     }
   }
 
@@ -1042,6 +1075,7 @@ ary_fill_exec(mrb_state *mrb, mrb_value self)
   }
 
   /* Fill the array */
+  mrb_ary_modify(mrb, ary);
   mrb_value *ptr = ARY_PTR(ary) + start;
   for (mrb_int i = 0; i < length; i++) {
     ptr[i] = obj;
@@ -1059,7 +1093,6 @@ struct ary_uniq_bang_ctx {
   mrb_value self_copy;
   mrb_value self;
   mrb_int *write_pos;
-  mrb_int len;
 };
 
 static mrb_value
@@ -1069,15 +1102,19 @@ ary_uniq_bang_body(mrb_state *mrb, void *data)
 
   ary_populate_temp_set(mrb, ctx->set, ctx->self_copy);
 
-  for (mrb_int read_pos = 0; read_pos < ctx->len; read_pos++) {
+  int ai = mrb_gc_arena_save(mrb);
+  for (mrb_int read_pos = 0; read_pos < RARRAY_LEN(ctx->self); read_pos++) {
     mrb_value elem = RARRAY_PTR(ctx->self)[read_pos];
+    mrb_gc_protect(mrb, elem); // elem may be removed from self by kh_get(ary_set, ...)
     khiter_t k = kh_get(ary_set, mrb, ctx->set, elem);
     if (!kh_is_end(ctx->set, k)) {
-      if (*ctx->write_pos != read_pos) {
+      if (*ctx->write_pos != read_pos && *ctx->write_pos < RARRAY_LEN(ctx->self)) {
+        mrb_ary_modify(mrb, mrb_ary_ptr(ctx->self));
         RARRAY_PTR(ctx->self)[*ctx->write_pos] = elem;
       }
       (*ctx->write_pos)++;
       kh_del(ary_set, mrb, ctx->set, k);
+      mrb_gc_arena_restore(mrb, ai);
     }
   }
 
@@ -1104,28 +1141,32 @@ ary_uniq_bang(mrb_state *mrb, mrb_value self)
     ary_set_t *set = &set_struct;
     ary_init_temp_set(mrb, set, len);
 
-    struct ary_uniq_bang_ctx ctx = { set, self_copy, self, &write_pos, len };
+    struct ary_uniq_bang_ctx ctx = { set, self_copy, self, &write_pos };
     mrb_value result;
     MRB_ENSURE(mrb, result, ary_uniq_bang_body, &ctx) {
       ary_destroy_temp_set(mrb, set);
     }
   }
   else {
-    for (mrb_int read_pos = 0; read_pos < len; read_pos++) {
+    int ai = mrb_gc_arena_save(mrb);
+    for (mrb_int read_pos = 0; read_pos < RARRAY_LEN(self); read_pos++) {
       mrb_value elem = RARRAY_PTR(self)[read_pos];
+      mrb_gc_protect(mrb, elem); // elem may be removed from self by mrb_equal()
       mrb_bool found = FALSE;
-      for (mrb_int j = 0; j < write_pos; j++) {
+      for (mrb_int j = 0; j < write_pos && j < RARRAY_LEN(self); j++) {
         if (mrb_equal(mrb, elem, RARRAY_PTR(self)[j])) {
           found = TRUE;
           break;
         }
       }
       if (!found) {
-        if (write_pos != read_pos) {
+        if (write_pos != read_pos && write_pos < RARRAY_LEN(self)) {
+          mrb_ary_modify(mrb, mrb_ary_ptr(self));
           RARRAY_PTR(self)[write_pos] = elem;
         }
         write_pos++;
       }
+      mrb_gc_arena_restore(mrb, ai);
     }
   }
 


### PR DESCRIPTION
Several methods defined in mruby-array-ext are written in C and may call `mrb_vm_exec()`.
If array objects are modified on the Ruby side, problems may arise in subsequent processing.

  - Using objects that have been removed from the array and garbage collected
  - Using pointers or array lengths that have become invalid due to changes to the array object
  - Modifying the contents of a shared array object directly

ref: https://github.com/mruby/mruby/issues/6662

---

This patch may be excessive, or it may not be comprehensive enough.

I’ve attached two examples of code that reproduce the issue, along with the results.

<details>
<summary>Use-after-free in objects caused by `Array#assoc`</summary>

```console
% cat #6662x1.rb
$list = []
$list[0] = Array.new(8192) { [0, 0] }.last # 単独のオブジェクトヒープページに配置させる
GC.start

key = Object.new
class << key
  def ==(o)
    $list.replace([])
    GC.start
    true
  end
end
$list[0][0] = key

$list.assoc(0).class

% valgrind -- build/host/bin/mruby #6662x1.rb
==70394== Memcheck, a memory error detector
==70394== Copyright (C) 2002-2024, and GNU GPL'd, by Julian Seward et al.
==70394== Using Valgrind-3.26.0 and LibVEX; rerun with -h for copyright info
==70394== Command: build/host/bin/mruby #6662x1.rb
==70394==
==70394== Invalid read of size 8
==70394==    at 0x4362BE: mrb_class (class.h:30)
==70394==    by 0x4362BE: mrb_vm_exec (vm.c:2298)
==70394==    by 0x4424D1: mrb_load_exec (parse.y:7797)
==70394==    by 0x4427EF: mrb_load_detect_file_cxt (parse.y:7840)
==70394==    by 0x403CB8: main (mruby.c:354)
==70394==  Address 0x56a1988 is 11,832 bytes inside a block of size 40,992 free'd
==70394==    at 0x48501FC: free (vg_replace_malloc.c:994)
==70394==    by 0x46C0B1: mrb_basic_alloc_func (allocf.c:30)
==70394==    by 0x415080: mrb_free (gc.c:284)
==70394==    by 0x415080: incremental_sweep_phase (gc.c:1215)
==70394==    by 0x415080: incremental_gc (gc.c:1264)
==70394==    by 0x413501: incremental_gc_finish (gc.c:1280)
==70394==    by 0x413501: mrb_full_gc (gc.c:1377)
==70394==    by 0x414858: gc_start (gc.c:1461)
==70394==    by 0x436566: mrb_vm_exec (vm.c:0)
==70394==    by 0x43002C: mrb_run (vm.c:3679)
==70394==    by 0x43002C: mrb_funcall_with_block (vm.c:842)
==70394==    by 0x420F42: mrb_equal (object.c:101)
==70394==    by 0x48D2FE: ary_assoc (array.c:85)
==70394==    by 0x436566: mrb_vm_exec (vm.c:0)
==70394==    by 0x4424D1: mrb_load_exec (parse.y:7797)
==70394==    by 0x4427EF: mrb_load_detect_file_cxt (parse.y:7840)
==70394==  Block was alloc'd at
==70394==    at 0x48532B1: realloc (vg_replace_malloc.c:1810)
==70394==    by 0x413DEB: mrb_realloc_simple (gc.c:221)
==70394==    by 0x413DEB: mrb_realloc (gc.c:235)
==70394==    by 0x413DEB: mrb_malloc (gc.c:251)
==70394==    by 0x413DEB: mrb_calloc (gc.c:270)
==70394==    by 0x413DEB: add_heap (gc.c:358)
==70394==    by 0x41396B: mrb_obj_alloc (gc.c:595)
==70394==    by 0x403FEF: ary_new_capa (array.c:50)
==70394==    by 0x4040A1: ary_new_from_values (array.c:123)
==70394==    by 0x4040A1: mrb_ary_new_from_values (array.c:145)
==70394==    by 0x433009: mrb_vm_exec (vm.c:0)
==70394==    by 0x4318BF: mrb_yield (vm.c:1324)
==70394==    by 0x40896A: mrb_ary_init (array.c:482)
==70394==    by 0x436566: mrb_vm_exec (vm.c:0)
==70394==    by 0x4424D1: mrb_load_exec (parse.y:7797)
==70394==    by 0x4427EF: mrb_load_detect_file_cxt (parse.y:7840)
==70394==    by 0x403CB8: main (mruby.c:354)
==70394==
==70394== Invalid read of size 8
==70394==    at 0x40E3B9: mrb_class (class.h:0)
==70394==    by 0x40E3B9: mrb_obj_class (class.c:3282)
==70394==    by 0x436566: mrb_vm_exec (vm.c:0)
==70394==    by 0x4424D1: mrb_load_exec (parse.y:7797)
==70394==    by 0x4427EF: mrb_load_detect_file_cxt (parse.y:7840)
==70394==    by 0x403CB8: main (mruby.c:354)
==70394==  Address 0x56a1988 is 11,832 bytes inside a block of size 40,992 free'd
==70394==    at 0x48501FC: free (vg_replace_malloc.c:994)
==70394==    by 0x46C0B1: mrb_basic_alloc_func (allocf.c:30)
==70394==    by 0x415080: mrb_free (gc.c:284)
==70394==    by 0x415080: incremental_sweep_phase (gc.c:1215)
==70394==    by 0x415080: incremental_gc (gc.c:1264)
==70394==    by 0x413501: incremental_gc_finish (gc.c:1280)
==70394==    by 0x413501: mrb_full_gc (gc.c:1377)
==70394==    by 0x414858: gc_start (gc.c:1461)
==70394==    by 0x436566: mrb_vm_exec (vm.c:0)
==70394==    by 0x43002C: mrb_run (vm.c:3679)
==70394==    by 0x43002C: mrb_funcall_with_block (vm.c:842)
==70394==    by 0x420F42: mrb_equal (object.c:101)
==70394==    by 0x48D2FE: ary_assoc (array.c:85)
==70394==    by 0x436566: mrb_vm_exec (vm.c:0)
==70394==    by 0x4424D1: mrb_load_exec (parse.y:7797)
==70394==    by 0x4427EF: mrb_load_detect_file_cxt (parse.y:7840)
==70394==  Block was alloc'd at
==70394==    at 0x48532B1: realloc (vg_replace_malloc.c:1810)
==70394==    by 0x413DEB: mrb_realloc_simple (gc.c:221)
==70394==    by 0x413DEB: mrb_realloc (gc.c:235)
==70394==    by 0x413DEB: mrb_malloc (gc.c:251)
==70394==    by 0x413DEB: mrb_calloc (gc.c:270)
==70394==    by 0x413DEB: add_heap (gc.c:358)
==70394==    by 0x41396B: mrb_obj_alloc (gc.c:595)
==70394==    by 0x403FEF: ary_new_capa (array.c:50)
==70394==    by 0x4040A1: ary_new_from_values (array.c:123)
==70394==    by 0x4040A1: mrb_ary_new_from_values (array.c:145)
==70394==    by 0x433009: mrb_vm_exec (vm.c:0)
==70394==    by 0x4318BF: mrb_yield (vm.c:1324)
==70394==    by 0x40896A: mrb_ary_init (array.c:482)
==70394==    by 0x436566: mrb_vm_exec (vm.c:0)
==70394==    by 0x4424D1: mrb_load_exec (parse.y:7797)
==70394==    by 0x4427EF: mrb_load_detect_file_cxt (parse.y:7840)
==70394==    by 0x403CB8: main (mruby.c:354)
==70394==
==70394==
==70394== HEAP SUMMARY:
==70394==     in use at exit: 0 bytes in 0 blocks
==70394==   total heap usage: 849 allocs, 849 frees, 634,133 bytes allocated
==70394==
==70394== All heap blocks were freed -- no leaks are possible
==70394==
==70394== For lists of detected and suppressed errors, rerun with: -s
==70394== ERROR SUMMARY: 2 errors from 2 contexts (suppressed: 0 from 0)
```

</details>

<details>
<summary>Use-after-free in objects caused by `Array#|`</summary>

```console
% cat #6662x2.rb
$a = Array.new(40) { Object.new }
$a.each do |e|
  class << e
    def hash = 0
    def eql?(o) = false
  end
end

$b = $a.slice!(20..)

$o = $b[0]
class << $o
  def eql?(o)
    ObjectSpace.each_object(Array) { |e|
      if e.__id__ != $b.__id__ && e[0] == $b[0] && e.size == $b.size
        $b.replace []
        e.replace []
      end
    }
    o = nil
    GC.start
    false
  end
end

$a | $b

% valgrind -- build/host/bin/mruby #6662x2.rb
==88305== Memcheck, a memory error detector
==88305== Copyright (C) 2002-2024, and GNU GPL'd, by Julian Seward et al.
==88305== Using Valgrind-3.26.0 and LibVEX; rerun with -h for copyright info
==88305== Command: build/host/bin/mruby #6662x2.rb
==88305==
==88305== Invalid read of size 4
==88305==    at 0x40D9D9: mrb_vm_find_method (class.c:0)
==88305==    by 0x42FF27: mrb_funcall_with_block (vm.c:820)
==88305==    by 0x41666A: mrb_obj_hash_code (hash.c:360)
==88305==    by 0x48CF29: ary_set_hash_func (array.c:18)
==88305==    by 0x48CF29: kh__key_idx_ary_set (array.c:28)
==88305==    by 0x48CF29: kh_put_ary_set (array.c:28)
==88305==    by 0x48FDB2: ary_union_body (array.c:606)
==88305==    by 0x42F5D6: mrb_protect_error (vm.c:532)
==88305==    by 0x48F802: ary_union_internal (array.c:635)
==88305==    by 0x48DCE5: ary_union (array.c:676)
==88305==    by 0x436566: mrb_vm_exec (vm.c:0)
==88305==    by 0x4424D1: mrb_load_exec (parse.y:7797)
==88305==    by 0x4427EF: mrb_load_detect_file_cxt (parse.y:7840)
==88305==    by 0x403CB8: main (mruby.c:354)
==88305==  Address 0x5666b90 is 0 bytes inside a block of size 24 free'd
==88305==    at 0x48501FC: free (vg_replace_malloc.c:994)
==88305==    by 0x46C0B1: mrb_basic_alloc_func (allocf.c:30)
==88305==    by 0x40A6F1: mt_free (class.c:171)
==88305==    by 0x40A6F1: mrb_gc_free_mt (class.c:301)
==88305==    by 0x414B3A: obj_free (gc.c:866)
==88305==    by 0x415112: incremental_sweep_phase (gc.c:1188)
==88305==    by 0x415112: incremental_gc (gc.c:1264)
==88305==    by 0x413501: incremental_gc_finish (gc.c:1280)
==88305==    by 0x413501: mrb_full_gc (gc.c:1377)
==88305==    by 0x414858: gc_start (gc.c:1461)
==88305==    by 0x436566: mrb_vm_exec (vm.c:0)
==88305==    by 0x43002C: mrb_run (vm.c:3679)
==88305==    by 0x43002C: mrb_funcall_with_block (vm.c:842)
==88305==    by 0x421BA5: mrb_eql (object.c:867)
==88305==    by 0x48FD44: ary_set_equal_func (array.c:24)
==88305==    by 0x48FD44: kh_get_ary_set (array.c:28)
==88305==    by 0x48FD44: ary_union_body (array.c:604)
==88305==    by 0x42F5D6: mrb_protect_error (vm.c:532)
==88305==  Block was alloc'd at
==88305==    at 0x48532B1: realloc (vg_replace_malloc.c:1810)
==88305==    by 0x413603: mrb_realloc_simple (gc.c:221)
==88305==    by 0x413603: mrb_realloc (gc.c:235)
==88305==    by 0x413603: mrb_malloc (gc.c:251)
==88305==    by 0x40B45B: mt_new (class.c:46)
==88305==    by 0x40B45B: mrb_define_method_raw (class.c:1008)
==88305==    by 0x432B44: mrb_vm_exec (vm.c:3529)
==88305==    by 0x4424D1: mrb_load_exec (parse.y:7797)
==88305==    by 0x4427EF: mrb_load_detect_file_cxt (parse.y:7840)
==88305==    by 0x403CB8: main (mruby.c:354)
==88305==
==88305== Invalid read of size 8
==88305==    at 0x40D9E1: mt_get (class.c:0)
==88305==    by 0x40D9E1: mrb_vm_find_method (class.c:2639)
==88305==    by 0x42FF27: mrb_funcall_with_block (vm.c:820)
==88305==    by 0x41666A: mrb_obj_hash_code (hash.c:360)
==88305==    by 0x48CF29: ary_set_hash_func (array.c:18)
==88305==    by 0x48CF29: kh__key_idx_ary_set (array.c:28)
==88305==    by 0x48CF29: kh_put_ary_set (array.c:28)
==88305==    by 0x48FDB2: ary_union_body (array.c:606)
==88305==    by 0x42F5D6: mrb_protect_error (vm.c:532)
==88305==    by 0x48F802: ary_union_internal (array.c:635)
==88305==    by 0x48DCE5: ary_union (array.c:676)
==88305==    by 0x436566: mrb_vm_exec (vm.c:0)
==88305==    by 0x4424D1: mrb_load_exec (parse.y:7797)
==88305==    by 0x4427EF: mrb_load_detect_file_cxt (parse.y:7840)
==88305==    by 0x403CB8: main (mruby.c:354)
==88305==  Address 0x5666b98 is 8 bytes inside a block of size 24 free'd
==88305==    at 0x48501FC: free (vg_replace_malloc.c:994)
==88305==    by 0x46C0B1: mrb_basic_alloc_func (allocf.c:30)
==88305==    by 0x40A6F1: mt_free (class.c:171)
==88305==    by 0x40A6F1: mrb_gc_free_mt (class.c:301)
==88305==    by 0x414B3A: obj_free (gc.c:866)
==88305==    by 0x415112: incremental_sweep_phase (gc.c:1188)
==88305==    by 0x415112: incremental_gc (gc.c:1264)
==88305==    by 0x413501: incremental_gc_finish (gc.c:1280)
==88305==    by 0x413501: mrb_full_gc (gc.c:1377)
==88305==    by 0x414858: gc_start (gc.c:1461)
==88305==    by 0x436566: mrb_vm_exec (vm.c:0)
==88305==    by 0x43002C: mrb_run (vm.c:3679)
==88305==    by 0x43002C: mrb_funcall_with_block (vm.c:842)
==88305==    by 0x421BA5: mrb_eql (object.c:867)
==88305==    by 0x48FD44: ary_set_equal_func (array.c:24)
==88305==    by 0x48FD44: kh_get_ary_set (array.c:28)
==88305==    by 0x48FD44: ary_union_body (array.c:604)
==88305==    by 0x42F5D6: mrb_protect_error (vm.c:532)
==88305==  Block was alloc'd at
==88305==    at 0x48532B1: realloc (vg_replace_malloc.c:1810)
==88305==    by 0x413603: mrb_realloc_simple (gc.c:221)
==88305==    by 0x413603: mrb_realloc (gc.c:235)
==88305==    by 0x413603: mrb_malloc (gc.c:251)
==88305==    by 0x40B45B: mt_new (class.c:46)
==88305==    by 0x40B45B: mrb_define_method_raw (class.c:1008)
==88305==    by 0x432B44: mrb_vm_exec (vm.c:3529)
==88305==    by 0x4424D1: mrb_load_exec (parse.y:7797)
==88305==    by 0x4427EF: mrb_load_detect_file_cxt (parse.y:7840)
==88305==    by 0x403CB8: main (mruby.c:354)
==88305==
==88305== Invalid read of size 4
==88305==    at 0x40D9F0: mt_get (class.c:93)
==88305==    by 0x40D9F0: mrb_vm_find_method (class.c:2639)
==88305==    by 0x42FF27: mrb_funcall_with_block (vm.c:820)
==88305==    by 0x41666A: mrb_obj_hash_code (hash.c:360)
==88305==    by 0x48CF29: ary_set_hash_func (array.c:18)
==88305==    by 0x48CF29: kh__key_idx_ary_set (array.c:28)
==88305==    by 0x48CF29: kh_put_ary_set (array.c:28)
==88305==    by 0x48FDB2: ary_union_body (array.c:606)
==88305==    by 0x42F5D6: mrb_protect_error (vm.c:532)
==88305==    by 0x48F802: ary_union_internal (array.c:635)
==88305==    by 0x48DCE5: ary_union (array.c:676)
==88305==    by 0x436566: mrb_vm_exec (vm.c:0)
==88305==    by 0x4424D1: mrb_load_exec (parse.y:7797)
==88305==    by 0x4427EF: mrb_load_detect_file_cxt (parse.y:7840)
==88305==    by 0x403CB8: main (mruby.c:354)
==88305==  Address 0x5666bf8 is 8 bytes inside a block of size 128 free'd
==88305==    at 0x48501FC: free (vg_replace_malloc.c:994)
==88305==    by 0x46C0B1: mrb_basic_alloc_func (allocf.c:30)
==88305==    by 0x40A6E6: mt_free (class.c:170)
==88305==    by 0x40A6E6: mrb_gc_free_mt (class.c:301)
==88305==    by 0x414B3A: obj_free (gc.c:866)
==88305==    by 0x415112: incremental_sweep_phase (gc.c:1188)
==88305==    by 0x415112: incremental_gc (gc.c:1264)
==88305==    by 0x413501: incremental_gc_finish (gc.c:1280)
==88305==    by 0x413501: mrb_full_gc (gc.c:1377)
==88305==    by 0x414858: gc_start (gc.c:1461)
==88305==    by 0x436566: mrb_vm_exec (vm.c:0)
==88305==    by 0x43002C: mrb_run (vm.c:3679)
==88305==    by 0x43002C: mrb_funcall_with_block (vm.c:842)
==88305==    by 0x421BA5: mrb_eql (object.c:867)
==88305==    by 0x48FD44: ary_set_equal_func (array.c:24)
==88305==    by 0x48FD44: kh_get_ary_set (array.c:28)
==88305==    by 0x48FD44: ary_union_body (array.c:604)
==88305==    by 0x42F5D6: mrb_protect_error (vm.c:532)
==88305==  Block was alloc'd at
==88305==    at 0x48532B1: realloc (vg_replace_malloc.c:1810)
==88305==    by 0x41357D: mrb_realloc_simple (gc.c:221)
==88305==    by 0x41357D: mrb_realloc (gc.c:235)
==88305==    by 0x40B575: mt_grow (class.c:35)
==88305==    by 0x40B575: mt_put (class.c:0)
==88305==    by 0x40B575: mrb_define_method_raw (class.c:1063)
==88305==    by 0x432B44: mrb_vm_exec (vm.c:3529)
==88305==    by 0x4424D1: mrb_load_exec (parse.y:7797)
==88305==    by 0x4427EF: mrb_load_detect_file_cxt (parse.y:7840)
==88305==    by 0x403CB8: main (mruby.c:354)
==88305==
==88305== Invalid read of size 4
==88305==    at 0x40DA10: mt_get (class.c:94)
==88305==    by 0x40DA10: mrb_vm_find_method (class.c:2639)
==88305==    by 0x42FF27: mrb_funcall_with_block (vm.c:820)
==88305==    by 0x41666A: mrb_obj_hash_code (hash.c:360)
==88305==    by 0x48CF29: ary_set_hash_func (array.c:18)
==88305==    by 0x48CF29: kh__key_idx_ary_set (array.c:28)
==88305==    by 0x48CF29: kh_put_ary_set (array.c:28)
==88305==    by 0x48FDB2: ary_union_body (array.c:606)
==88305==    by 0x42F5D6: mrb_protect_error (vm.c:532)
==88305==    by 0x48F802: ary_union_internal (array.c:635)
==88305==    by 0x48DCE5: ary_union (array.c:676)
==88305==    by 0x436566: mrb_vm_exec (vm.c:0)
==88305==    by 0x4424D1: mrb_load_exec (parse.y:7797)
==88305==    by 0x4427EF: mrb_load_detect_file_cxt (parse.y:7840)
==88305==    by 0x403CB8: main (mruby.c:354)
==88305==  Address 0x5666bfc is 12 bytes inside a block of size 128 free'd
==88305==    at 0x48501FC: free (vg_replace_malloc.c:994)
==88305==    by 0x46C0B1: mrb_basic_alloc_func (allocf.c:30)
==88305==    by 0x40A6E6: mt_free (class.c:170)
==88305==    by 0x40A6E6: mrb_gc_free_mt (class.c:301)
==88305==    by 0x414B3A: obj_free (gc.c:866)
==88305==    by 0x415112: incremental_sweep_phase (gc.c:1188)
==88305==    by 0x415112: incremental_gc (gc.c:1264)
==88305==    by 0x413501: incremental_gc_finish (gc.c:1280)
==88305==    by 0x413501: mrb_full_gc (gc.c:1377)
==88305==    by 0x414858: gc_start (gc.c:1461)
==88305==    by 0x436566: mrb_vm_exec (vm.c:0)
==88305==    by 0x43002C: mrb_run (vm.c:3679)
==88305==    by 0x43002C: mrb_funcall_with_block (vm.c:842)
==88305==    by 0x421BA5: mrb_eql (object.c:867)
==88305==    by 0x48FD44: ary_set_equal_func (array.c:24)
==88305==    by 0x48FD44: kh_get_ary_set (array.c:28)
==88305==    by 0x48FD44: ary_union_body (array.c:604)
==88305==    by 0x42F5D6: mrb_protect_error (vm.c:532)
==88305==  Block was alloc'd at
==88305==    at 0x48532B1: realloc (vg_replace_malloc.c:1810)
==88305==    by 0x41357D: mrb_realloc_simple (gc.c:221)
==88305==    by 0x41357D: mrb_realloc (gc.c:235)
==88305==    by 0x40B575: mt_grow (class.c:35)
==88305==    by 0x40B575: mt_put (class.c:0)
==88305==    by 0x40B575: mrb_define_method_raw (class.c:1063)
==88305==    by 0x432B44: mrb_vm_exec (vm.c:3529)
==88305==    by 0x4424D1: mrb_load_exec (parse.y:7797)
==88305==    by 0x4427EF: mrb_load_detect_file_cxt (parse.y:7840)
==88305==    by 0x403CB8: main (mruby.c:354)
==88305==
==88305== Invalid read of size 8
==88305==    at 0x40DA2F: mt_get (class.c:95)
==88305==    by 0x40DA2F: mrb_vm_find_method (class.c:2639)
==88305==    by 0x42FF27: mrb_funcall_with_block (vm.c:820)
==88305==    by 0x41666A: mrb_obj_hash_code (hash.c:360)
==88305==    by 0x48CF29: ary_set_hash_func (array.c:18)
==88305==    by 0x48CF29: kh__key_idx_ary_set (array.c:28)
==88305==    by 0x48CF29: kh_put_ary_set (array.c:28)
==88305==    by 0x48FDB2: ary_union_body (array.c:606)
==88305==    by 0x42F5D6: mrb_protect_error (vm.c:532)
==88305==    by 0x48F802: ary_union_internal (array.c:635)
==88305==    by 0x48DCE5: ary_union (array.c:676)
==88305==    by 0x436566: mrb_vm_exec (vm.c:0)
==88305==    by 0x4424D1: mrb_load_exec (parse.y:7797)
==88305==    by 0x4427EF: mrb_load_detect_file_cxt (parse.y:7840)
==88305==    by 0x403CB8: main (mruby.c:354)
==88305==  Address 0x5666bf0 is 0 bytes inside a block of size 128 free'd
==88305==    at 0x48501FC: free (vg_replace_malloc.c:994)
==88305==    by 0x46C0B1: mrb_basic_alloc_func (allocf.c:30)
==88305==    by 0x40A6E6: mt_free (class.c:170)
==88305==    by 0x40A6E6: mrb_gc_free_mt (class.c:301)
==88305==    by 0x414B3A: obj_free (gc.c:866)
==88305==    by 0x415112: incremental_sweep_phase (gc.c:1188)
==88305==    by 0x415112: incremental_gc (gc.c:1264)
==88305==    by 0x413501: incremental_gc_finish (gc.c:1280)
==88305==    by 0x413501: mrb_full_gc (gc.c:1377)
==88305==    by 0x414858: gc_start (gc.c:1461)
==88305==    by 0x436566: mrb_vm_exec (vm.c:0)
==88305==    by 0x43002C: mrb_run (vm.c:3679)
==88305==    by 0x43002C: mrb_funcall_with_block (vm.c:842)
==88305==    by 0x421BA5: mrb_eql (object.c:867)
==88305==    by 0x48FD44: ary_set_equal_func (array.c:24)
==88305==    by 0x48FD44: kh_get_ary_set (array.c:28)
==88305==    by 0x48FD44: ary_union_body (array.c:604)
==88305==    by 0x42F5D6: mrb_protect_error (vm.c:532)
==88305==  Block was alloc'd at
==88305==    at 0x48532B1: realloc (vg_replace_malloc.c:1810)
==88305==    by 0x41357D: mrb_realloc_simple (gc.c:221)
==88305==    by 0x41357D: mrb_realloc (gc.c:235)
==88305==    by 0x40B575: mt_grow (class.c:35)
==88305==    by 0x40B575: mt_put (class.c:0)
==88305==    by 0x40B575: mrb_define_method_raw (class.c:1063)
==88305==    by 0x432B44: mrb_vm_exec (vm.c:3529)
==88305==    by 0x4424D1: mrb_load_exec (parse.y:7797)
==88305==    by 0x4427EF: mrb_load_detect_file_cxt (parse.y:7840)
==88305==    by 0x403CB8: main (mruby.c:354)
==88305==
==88305== Invalid read of size 1
==88305==    at 0x431C88: mrb_vm_exec (vm.c:1727)
==88305==    by 0x43002C: mrb_run (vm.c:3679)
==88305==    by 0x43002C: mrb_funcall_with_block (vm.c:842)
==88305==    by 0x41666A: mrb_obj_hash_code (hash.c:360)
==88305==    by 0x48CF29: ary_set_hash_func (array.c:18)
==88305==    by 0x48CF29: kh__key_idx_ary_set (array.c:28)
==88305==    by 0x48CF29: kh_put_ary_set (array.c:28)
==88305==    by 0x48FDB2: ary_union_body (array.c:606)
==88305==    by 0x42F5D6: mrb_protect_error (vm.c:532)
==88305==    by 0x48F802: ary_union_internal (array.c:635)
==88305==    by 0x48DCE5: ary_union (array.c:676)
==88305==    by 0x436566: mrb_vm_exec (vm.c:0)
==88305==    by 0x4424D1: mrb_load_exec (parse.y:7797)
==88305==    by 0x4427EF: mrb_load_detect_file_cxt (parse.y:7840)
==88305==    by 0x403CB8: main (mruby.c:354)
==88305==  Address 0x900104 is not stack'd, malloc'd or (recently) free'd
==88305==
==88305==
==88305== Process terminating with default action of signal 11 (SIGSEGV): dumping core
==88305==  Access not within mapped region at address 0x900104
==88305==    at 0x431C88: mrb_vm_exec (vm.c:1727)
==88305==    by 0x43002C: mrb_run (vm.c:3679)
==88305==    by 0x43002C: mrb_funcall_with_block (vm.c:842)
==88305==    by 0x41666A: mrb_obj_hash_code (hash.c:360)
==88305==    by 0x48CF29: ary_set_hash_func (array.c:18)
==88305==    by 0x48CF29: kh__key_idx_ary_set (array.c:28)
==88305==    by 0x48CF29: kh_put_ary_set (array.c:28)
==88305==    by 0x48FDB2: ary_union_body (array.c:606)
==88305==    by 0x42F5D6: mrb_protect_error (vm.c:532)
==88305==    by 0x48F802: ary_union_internal (array.c:635)
==88305==    by 0x48DCE5: ary_union (array.c:676)
==88305==    by 0x436566: mrb_vm_exec (vm.c:0)
==88305==    by 0x4424D1: mrb_load_exec (parse.y:7797)
==88305==    by 0x4427EF: mrb_load_detect_file_cxt (parse.y:7840)
==88305==    by 0x403CB8: main (mruby.c:354)
==88305==  If you believe this happened as a result of a stack
==88305==  overflow in your program's main thread (unlikely but
==88305==  possible), you can try to increase the size of the
==88305==  main thread stack using the --main-stacksize= flag.
==88305==  The main thread stack size used in this run was 16777216.
==88305==
==88305== HEAP SUMMARY:
==88305==     in use at exit: 119,962 bytes in 902 blocks
==88305==   total heap usage: 1,159 allocs, 257 frees, 397,010 bytes allocated
==88305==
==88305== LEAK SUMMARY:
==88305==    definitely lost: 0 bytes in 0 blocks
==88305==    indirectly lost: 0 bytes in 0 blocks
==88305==      possibly lost: 0 bytes in 0 blocks
==88305==    still reachable: 119,962 bytes in 902 blocks
==88305==         suppressed: 0 bytes in 0 blocks
==88305== Rerun with --leak-check=full to see details of leaked memory
==88305==
==88305== For lists of detected and suppressed errors, rerun with: -s
==88305== ERROR SUMMARY: 6 errors from 6 contexts (suppressed: 0 from 0)
```

</details>

