### PR TITLE
Don't assign the result of `mrb_funcall()` directly to `regs`

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -3112,7 +3112,9 @@ RETRY_TRY_BLOCK:
       {                                                                     \
         mrb_value arg = mrb_int_value(mrb, c);                              \
         mrb_sym mid = MRB_OPSYM(op_name);                                   \
-        regs[a] = mrb_funcall_argv(mrb, regs[a], mid, 1, &arg);             \
+        mrb_value v = mrb_funcall_argv(mrb, regs[a], mid, 1, &arg);         \
+        ci = mrb->c->ci;                                                    \
+        regs[a] = v;                                                        \
         mrb_gc_arena_restore(mrb, ai);                                      \
       }                                                                     \
       break;                                                                \


### PR DESCRIPTION
There are two reasons:

  - If the mruby call stack is extended, the `ci` variable may become invalid.
  - The C language does not specify the order in which the left-hand and right-hand sides of an assignment expression are evaluated. Therefore, if the mruby data stack is extended, `ci->stack` may become invalid.