### PR TITLE
Define `mrb_bigint_p()` always.

### DIFF
--- a/include/mruby/value.h
+++ b/include/mruby/value.h
@@ -316,7 +316,11 @@ struct RCptr {
 #endif
 #define mrb_test(o)   mrb_bool(o)
 #ifndef mrb_bigint_p
+#ifdef MRB_USE_BIGINT
 #define mrb_bigint_p(o) (mrb_type(o) == MRB_TT_BIGINT)
+#else
+#define mrb_bigint_p(o) FALSE
+#endif
 #endif
 
 /**

--- a/mrbgems/mruby-numeric-ext/src/numeric_ext.c
+++ b/mrbgems/mruby-numeric-ext/src/numeric_ext.c
@@ -190,11 +190,7 @@ int_powm(mrb_state *mrb, mrb_value x)
     return mrb_int_pow(mrb, x, mrb_get_arg1(mrb));
   }
   mrb_get_args(mrb, "oo", &e, &m);
-  if (!mrb_integer_p(e)
-#ifdef MRB_USE_BIGINT
-      && !mrb_bigint_p(e)
-#endif
-      ) {
+  if (!mrb_integer_p(e) && !mrb_bigint_p(e)) {
     mrb_raise(mrb, E_TYPE_ERROR, "int.pow(n,m): 2nd argument not allowed unless 1st argument is an integer");
   }
 #ifdef MRB_USE_BIGINT

--- a/src/range.c
+++ b/src/range.c
@@ -432,11 +432,7 @@ mrb_get_values_at(mrb_state *mrb, mrb_value obj, mrb_int olen, mrb_int argc, con
   for (mrb_int i = 0; i < argc; i++) {
     mrb_value v = argv[i];
 
-    if (mrb_integer_p(v)
-#ifdef MRB_USE_BIGINT
-        || mrb_bigint_p(v)
-#endif
-        ) {
+    if (mrb_integer_p(v) || mrb_bigint_p(v)) {
       mrb_int i = mrb_as_int(mrb, v);
       mrb_ary_push(mrb, result, func(mrb, obj, i));
     }


### PR DESCRIPTION
Define the `mrb_bigint_p()` macro function, which returns false if `MRB_USE_BIGINT` is undefined.