### PR TITLE
mruby-sprintf: protect format string from mutation during callbacks

### DIFF
--- a/mrbgems/mruby-sprintf/src/sprintf.c
+++ b/mrbgems/mruby-sprintf/src/sprintf.c
@@ -380,6 +380,13 @@ mrb_str_format(mrb_state *mrb, mrb_int argc, const mrb_value *argv, mrb_value fm
   argc++;
   argv--;
   mrb_ensure_string_type(mrb, fmt);
+  /* Duplicate the format string so that to_s/inspect callbacks invoked
+     during the loop cannot invalidate p/end by mutating the original
+     via String#replace or similar. mrb_str_dup shares the underlying
+     buffer, so this is O(1); String#replace on the original goes
+     through str_replace which decrements the shared refcount, leaving
+     our copy's buffer intact. */
+  fmt = mrb_str_dup(mrb, fmt);
   p = RSTRING_PTR(fmt);
   end = p + RSTRING_LEN(fmt);
   blen = 0;

--- a/mrbgems/mruby-sprintf/test/sprintf.rb
+++ b/mrbgems/mruby-sprintf/test/sprintf.rb
@@ -90,3 +90,19 @@ assert("String#% invalid format") do
     "%?" % ""
   end
 end
+
+assert("sprintf with to_s mutating format string") do
+  # The to_s callback must not be able to invalidate sprintf's internal
+  # iteration pointers by mutating the format string.
+  fmt = "%s" + "B" * 200
+  mutator = Object.new
+  $sprintf_test_fmt = fmt
+  def mutator.to_s
+    $sprintf_test_fmt.replace("Z")
+    "ok"
+  end
+  result = sprintf(fmt, mutator)
+  assert_equal 202, result.length
+  assert_equal "ok", result[0, 2]
+  assert_equal "B" * 200, result[2..]
+end


### PR DESCRIPTION
## Summary
`mrb_str_format` captured raw C pointers (`p`, `end`) into the format string's buffer before the main loop. The `%s` and `%p` specifiers call `to_s` and `inspect`, which can invoke Ruby code that mutates the format string via `String#replace`, freeing or reallocating its buffer. The loop then continued iterating with dangling pointers, reading freed memory and potentially leaking adjacent heap contents into the result string.

## Fix
Duplicate the format string with `mrb_str_dup()` before the loop. This is O(1) because `mrb_str_dup` shares the underlying buffer; if the original is later mutated via `String#replace`, `str_replace` decrements the shared refcount, leaving our duplicate's buffer intact.

## Test plan
- [x] `rake CONFIG=host-debug all test:run:serial` — 1810 lib + 100 bintest OK
- [x] Regression test added: `to_s` callback calling `$fmt.replace("Z")` no longer corrupts sprintf output