### PR TITLE
Enable Task and Fiber coexistence

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -187,11 +187,14 @@ enum mrb_fiber_state {
   MRB_FIBER_SUSPENDED,
   MRB_FIBER_TRANSFERRED,
   MRB_FIBER_TERMINATED,
+  MRB_TASK_CREATED,
+  MRB_TASK_STOPPED,
 };
 
-/* Task context status aliases */
-#define MRB_TASK_CREATED MRB_FIBER_CREATED
-#define MRB_TASK_STOPPED MRB_FIBER_TERMINATED
+enum mrb_context_type {
+  MRB_CONTEXT_FIBER = 0,
+  MRB_CONTEXT_TASK  = 1,
+};
 
 struct mrb_context {
   struct mrb_context *prev;
@@ -203,6 +206,7 @@ struct mrb_context {
 
   enum mrb_fiber_state status : 4;
   mrb_bool vmexec : 1;
+  enum mrb_context_type type : 1;
   struct RFiber *fib;
 };
 

--- a/mrbgems/mruby-task/mrbgem.rake
+++ b/mrbgems/mruby-task/mrbgem.rake
@@ -6,6 +6,8 @@ MRuby::Gem::Specification.new('mruby-task') do |spec|
   # Enable task scheduler globally (required for vm.c integration)
   spec.build.defines << 'MRB_USE_TASK_SCHEDULER'
 
+  spec.add_test_dependency 'mruby-fiber', core: 'mruby-fiber'
+
   # Check if HAL gem is loaded
   # HAL gems must be explicitly specified in build config (recommended) or via auto-selection below
   spec.build.gems.one? { |g| g.name =~ /^hal-.*-task$/ } or begin

--- a/mrbgems/mruby-task/src/task.c
+++ b/mrbgems/mruby-task/src/task.c
@@ -295,6 +295,7 @@ task_init_context(mrb_state *mrb, mrb_task *t, const struct RProc *proc)
   ci->pc = proc->body.irep->iseq;  /* Initialize PC to start of bytecode */
 
   c->status = MRB_TASK_CREATED;
+  c->type = MRB_CONTEXT_TASK;
 }
 
 /*
@@ -1480,6 +1481,7 @@ mrb_task_reset_context(mrb_state *mrb, mrb_value task)
   struct mrb_context *c = &t->c;
   c->ci = c->cibase;
   c->status = MRB_TASK_CREATED;
+  c->type = MRB_CONTEXT_TASK;
   if (c->ci) {
     mrb_vm_ci_target_class_set(c->ci, mrb->object_class);
   }

--- a/mrbgems/mruby-task/test/task.rb
+++ b/mrbgems/mruby-task/test/task.rb
@@ -183,3 +183,80 @@ assert("Task.new with block doesn't execute immediately") do
   # Block should not execute until scheduler runs
   assert_false executed
 end
+
+# Fiber inside Task tests (requires mruby-fiber)
+#
+# Test specific behavior of fibers running inside tasks.
+# Since Task.pass only runs one task per call. Earlier assert blocks
+# may have created tasks that are still in the ready queue, so a single
+# Task.pass could execute a stale task instead of ours.
+# So `Task.pass until t.status == :DORMANT` ensures we keep passing
+# until our specific task completes.
+
+assert("Fiber inside Task: basic resume/yield") do
+  results = []
+  t = Task.new(name: "fiber_basic") do
+    f = Fiber.new do |x|
+      Fiber.yield(x * 2)
+      x * 3
+    end
+    results << f.resume(10)
+    results << f.resume
+    results << :done
+  end
+  Task.pass until t.status == :DORMANT
+  assert_equal [20, 30, :done], results
+end
+
+assert("Fiber inside Task: multiple fibers") do
+  results = []
+  t = Task.new(name: "multi_fiber") do
+    f1 = Fiber.new { |x| Fiber.yield(x); x + 1 }
+    f2 = Fiber.new { |x| Fiber.yield(x * 10); x * 100 }
+    results << f1.resume(1)
+    results << f2.resume(2)
+    results << f1.resume
+    results << f2.resume
+  end
+  Task.pass until t.status == :DORMANT
+  assert_equal [1, 20, 2, 200], results
+end
+
+assert("Fiber inside Task: fiber completes then task completes") do
+  result = nil
+  t = Task.new(name: "fiber_complete") do
+    f = Fiber.new { 42 }
+    result = f.resume
+  end
+  Task.pass until t.status == :DORMANT
+  assert_equal 42, result
+end
+
+assert("Fiber inside Task: no crash after GC") do
+  tasks = []
+  10.times do |i|
+    tasks << Task.new(name: "gc_#{i}") do
+      f = Fiber.new { Fiber.yield(:mid); :end }
+      f.resume
+      f.resume
+    end
+  end
+  Task.pass until tasks.all? { |t| t.status == :DORMANT }
+  GC.start
+  assert_true true
+end
+
+assert("Fiber inside Task: alive? works") do
+  alive_mid = nil
+  alive_end = nil
+  t = Task.new(name: "fiber_alive") do
+    f = Fiber.new { Fiber.yield }
+    f.resume
+    alive_mid = f.alive?
+    f.resume
+    alive_end = f.alive?
+  end
+  Task.pass until t.status == :DORMANT
+  assert_true alive_mid
+  assert_false alive_end
+end

--- a/src/vm.c
+++ b/src/vm.c
@@ -1557,7 +1557,8 @@ prepare_tagged_break(mrb_state *mrb, uint32_t tag, const mrb_callinfo *return_ci
 
 #ifdef MRB_USE_TASK_SCHEDULER
 #define RETURN_IF_TASK_STOPPED(mrb) do { \
-  if ((mrb)->task.switching || (mrb)->c->status == MRB_TASK_STOPPED) \
+  if (mrb->c->type == MRB_CONTEXT_TASK && \
+      ((mrb)->task.switching || (mrb)->c->status == MRB_TASK_STOPPED)) \
     return mrb_nil_value(); \
 } while (0)
 #define TASK_STOP(mrb) do { \
@@ -2857,7 +2858,7 @@ RETRY_TRY_BLOCK:
         }
 
 #ifdef MRB_USE_TASK_SCHEDULER
-        if (mrb->c->status == MRB_TASK_CREATED) {
+        if (c->type == MRB_CONTEXT_TASK) {
           mrb_gc_arena_restore(mrb, ai);
           mrb->jmp = prev_jmp;
           TASK_STOP(mrb);


### PR DESCRIPTION
This patch makes it possible to use Task and Fiber at the same time.

## Implementation

- Add `enum mrb_context_type` (MRB_CONTEXT_FIBER / MRB_CONTEXT_TASK) as a 1-bit field in `struct mrb_context`; does not increase its size
- Use `mrb_context_type` in vm.c to distinguish task contexts from fiber/root contexts, instead of relying on `mrb_fiber_state` which changes during execution
- Extend `enum mrb_fiber_state` by adding MRB_TASK_CREATED and MRB_TASK_STOPPED as proper enum values, replacing the previous `#define` aliases for MRB_FIBER_CREATED and MRB_FIBER_TERMINATED
- Add `mruby-fiber` as a test dependency of `mruby-task`
- Add tests that create fibers inside a task

----

(I considered using a union at the `mrb_fiber_state` section to more clearly separate the fiber and task, but the implementation would become too complex, so I committed the current version)