### PR TITLE
class.h: avoid C99 designated initializers in MRB_MT_ENTRY

### DIFF
--- a/include/mruby/class.h
+++ b/include/mruby/class.h
@@ -100,10 +100,13 @@ void mrb_mc_clear_by_class(mrb_state *mrb, struct RClass* c);
 typedef int (mrb_mt_foreach_func)(mrb_state*,mrb_sym,mrb_method_t,void*);
 MRB_API void mrb_mt_foreach(mrb_state*, struct RClass*, mrb_mt_foreach_func*, void*);
 
-/* ROM method table types for static method registration */
+/* ROM method table types for static method registration.
+ * NOTE: `func` is kept as the first union member so that positional
+ * aggregate initialization in MRB_MT_ENTRY works without C99
+ * designated initializers (required for legacy C++ compilers). */
 union mrb_mt_ptr {
-  const struct RProc *proc;
   mrb_func_t func;
+  const struct RProc *proc;
 };
 
 /* entry combining function pointer, symbol key, and flags */
@@ -128,7 +131,7 @@ typedef struct mrb_mt_tbl {
 
 /* ROM table entry: 3rd param is MRB_ARGS_*() optionally OR'd with MRB_MT_PRIVATE. */
 #define MRB_MT_ENTRY(fn, sym, flags) \
-  { { .func = (fn) }, (sym), (flags) | MRB_MT_FUNC }
+  { { (fn) }, (sym), (flags) | MRB_MT_FUNC }
 #define MRB_MT_ASPEC(flags) ((mrb_aspec)((flags) & 0xffffff))
 
 /* "removed" tombstone: MRB_MT_FUNC flag set with NULL function pointer.


### PR DESCRIPTION
## Summary

Fixes #6789.

Older C++ compilers such as gcc 4.2.1 (used in FreeBSD base toolchains
for some cross-compile targets) do not support C99 struct field
designators (`.func = ...`) — not even as a GCC extension. This
blocks building mruby whenever an mrbgem pulls in C++ code and
triggers the `-cxx.cxx` wrapper around core `.c` files, causing
errors such as:

```
src/error.c:895: error: expected primary-expression before '.' token
```

## Change

- Reorder `union mrb_mt_ptr` so that `mrb_func_t func` is the first
  member.
- Drop the `.func =` designator from `MRB_MT_ENTRY`, relying on plain
  positional aggregate initialization.

Both are compatible with pre-C99 / pre-C++20 compilers. All 709
existing `MRB_MT_ENTRY` call sites are unaffected.

## Test plan

- [x] `MRUBY_CONFIG=ci/gcc-clang rake -m test:run:serial` (host cxx_abi build passes, 1811 OK / 0 KO)
- [ ] CI: cxx_abi, msvc, cosmopolitan