### PR TITLE
mruby-bigint: avoid C99 compound literal in MPZ_CTX_INIT

### DIFF
--- a/mrbgems/mruby-bigint/core/bigint.c
+++ b/mrbgems/mruby-bigint/core/bigint.c
@@ -50,11 +50,16 @@ typedef struct mpz_context {
   mpz_pool_t *pool;  /* NULL for heap-only operations */
 } mpz_ctx_t;
 
-/* Convenience macros for context creation */
+/* Convenience macros for context creation.
+ * Uses per-member assignment instead of a C99 compound literal with
+ * designated initializers so the file compiles as C++ on legacy
+ * toolchains (pre-C++20). */
 #define MPZ_CTX_INIT(mrb_ptr, ctx, pool_ptr) \
   mpz_pool_t pool ## _storage = {{0}};\
   mpz_pool_t *pool_ptr = &pool ## _storage;\
-  mpz_ctx_t ctx ## _struct = ((mpz_ctx_t){.mrb = (mrb_ptr), .pool = (pool_ptr)}); \
+  mpz_ctx_t ctx ## _struct; \
+  ctx ## _struct.mrb = (mrb_ptr); \
+  ctx ## _struct.pool = (pool_ptr); \
   mpz_ctx_t *ctx = &(ctx ## _struct);
 
 /* Access macros for readability */


### PR DESCRIPTION
## Summary

Follow-up to #6790 for the same C++-compatibility concern raised in
#6789.

`MPZ_CTX_INIT` used a C99 compound literal with designated
initializers:

```c
mpz_ctx_t ctx##_struct = ((mpz_ctx_t){.mrb = ..., .pool = ...});
```

Neither compound literals nor designated initializers are supported
by legacy C++ toolchains (notably gcc 4.x), so this macro breaks
builds that pull mruby into a C++ translation unit via the
`-cxx.cxx` wrapper.

## Change

Replace the compound literal with plain member assignment. The
resulting code is valid under C89/C++98 as well as modern
standards, and retains identical runtime behavior.

## Test plan

- [x] `MRUBY_CONFIG=ci/gcc-clang rake -m test:run:serial`
      (full-debug, host, bintest, cxx_abi: all 0 KO / 0 Crash)
- [ ] CI: cxx_abi, msvc, cosmopolitan