### PR TITLE
host-cxx: use distinct build directory from host-debug

### DIFF
--- a/build_config/host-cxx.rb
+++ b/build_config/host-cxx.rb
@@ -1,4 +1,4 @@
-MRuby::Build.new do |conf|
+MRuby::Build.new('host-cxx') do |conf|
   conf.toolchain
 
   # include the default GEMs


### PR DESCRIPTION
## Summary

\`build_config/host-cxx.rb\` defaulted to \`MRuby::Build.new\` (no name),
which is equivalent to \`MRuby::Build.new('host')\`, so it shared
\`build/host/\` with \`build_config/host-debug.rb\`.

The two configs produce ABI-incompatible object files (C linkage
vs. C++-mangled names). Switching between configs without a
\`rake clean\` step silently mixes stale objects, producing confusing
undefined-reference errors at link time.

## Change

Name the C++ build \`'host-cxx'\` so it gets its own \`build/host-cxx/\`
directory. No external paths reference \`build/host/\` in a way that
this change would break.

## Test plan

- [x] \`rake CONFIG=host-cxx\`: outputs to \`build/host-cxx/\`
- [x] Switching \`host-cxx\` → \`host-debug\` without clean: both pass