### PR TITLE
readfloat: correctly round fraction via division by exact 10^n

### DIFF
--- a/src/readfloat.c
+++ b/src/readfloat.c
@@ -168,10 +168,11 @@ mrb_read_float(const char *str, char **endp, double *fp)
     res = (double)int_part;
   }
   else {
-    // Fast path: combine integer and fractional parts
+    // Divide by the exact 10^n (exact for n <= 22) rather than multiplying
+    // by the inexact 10^-n, so the fraction is correctly rounded.
     res = (double)int_part;
     if (frac_digits > 0) {
-      res += (double)frac_part * mrb_pow10(-frac_digits);
+      res += (double)frac_part / mrb_pow10(frac_digits);
     }
   }
 


### PR DESCRIPTION
`mrb_read_float` used `frac * pow10_negative[n]` to apply the fractional scale. Since `10^-n = 1/(2^n * 5^n)` leaves a factor of `5^n` in the denominator, it cannot be represented as `m * 2^e` and `pow10_negative[n]` is only a rounded approximation — the multiplication leaves up to ~1 ulp of error.

Dividing by `pow10_positive[n]` instead makes the divisor exact for `n <= 22` (there `10^n = 2^n * 5^n` fits in the 52-bit mantissa), leaving the division as the only rounding step — the result is correctly rounded. `"0.3".to_f` now matches the `0.3` literal and `strtod("0.3")` bit-for-bit.

Sorry — this was already wrong in the original `strtod.c` I wrote that this file descends from.