### PR TITLE
readfloat: keep one extra fraction digit (17 -> 18)

### DIFF
--- a/src/readfloat.c
+++ b/src/readfloat.c
@@ -144,7 +144,7 @@ mrb_read_float(const char *str, char **endp, double *fp)
   // Parse fractional part
   if (*p == '.') {
     p++;
-    while (ISDIGIT(*p) && frac_digits < 17) { // Limit precision to avoid overflow
+    while (ISDIGIT(*p) && frac_digits < 18) { // Limit precision to avoid overflow
       frac_part = frac_part * 10 + (*p - '0');
       frac_digits++;
       digits++;


### PR DESCRIPTION
`mrb_read_float` accumulates fractional digits into a `uint64_t` and previously stopped at 17 digits. 18 digits still fit (max value `10^18 - 1` ≈ 9.99e17, well below `UINT64_MAX` ≈ 1.84e19), and the next iteration's `frac_part * 10 + digit` also stays within range. Raising the cap to 18 preserves one more digit of input precision without overflow risk.

I checked that the 17 here is not tied to boxing (NaN / word boxing only affects how `mrb_value` stores a double, not the local `uint64_t` accumulator used during parsing), so bumping it is safe.