### PR TITLE
Define the typedef for `mrb_state` earlier

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -113,6 +113,8 @@
 
 #include "mrbconf.h"
 
+typedef struct mrb_state mrb_state;
+
 #include <mruby/common.h>
 #include <mruby/value.h>
 #include <mruby/gc.h>
@@ -155,8 +157,6 @@ typedef uint8_t mrb_code;
 typedef uint32_t mrb_aspec;
 
 typedef struct mrb_irep mrb_irep;
-
-struct mrb_state;
 
 #ifndef MRB_FIXED_STATE_ATEXIT_STACK_SIZE
 #define MRB_FIXED_STATE_ATEXIT_STACK_SIZE 5
@@ -224,7 +224,7 @@ mrb_static_assert_powerof2(MRB_METHOD_CACHE_SIZE);
  * @param self The self object
  * @return [mrb_value] The function's return value
  */
-typedef mrb_value (*mrb_func_t)(struct mrb_state *mrb, mrb_value self);
+typedef mrb_value (*mrb_func_t)(mrb_state *mrb, mrb_value self);
 
 typedef struct {
   uint32_t flags;                       /* method flags (no symbol packed) */
@@ -245,7 +245,7 @@ struct mrb_cache_entry {
 
 struct mrb_jmpbuf;
 
-typedef void (*mrb_atexit_func)(struct mrb_state*);
+typedef void (*mrb_atexit_func)(mrb_state*);
 
 #ifdef MRB_USE_TASK_SCHEDULER
 struct mrb_task;
@@ -260,7 +260,7 @@ typedef struct mrb_task_state {
 } mrb_task_state;
 #endif
 
-typedef struct mrb_state {
+struct mrb_state {
   struct mrb_jmpbuf *jmp;
 
   struct mrb_context *c;
@@ -307,12 +307,12 @@ typedef struct mrb_state {
 #endif
 
 #ifdef MRB_USE_DEBUG_HOOK
-  void (*code_fetch_hook)(struct mrb_state* mrb, const struct mrb_irep *irep, const mrb_code *pc, mrb_value *regs);
-  void (*debug_op_hook)(struct mrb_state* mrb, const struct mrb_irep *irep, const mrb_code *pc, mrb_value *regs);
+  void (*code_fetch_hook)(mrb_state* mrb, const struct mrb_irep *irep, const mrb_code *pc, mrb_value *regs);
+  void (*debug_op_hook)(mrb_state* mrb, const struct mrb_irep *irep, const mrb_code *pc, mrb_value *regs);
 #endif
 
 #ifdef MRB_BYTECODE_DECODE_OPTION
-  mrb_code (*bytecode_decoder)(struct mrb_state* mrb, mrb_code code);
+  mrb_code (*bytecode_decoder)(mrb_state* mrb, mrb_code code);
 #endif
 
   struct RClass *eException_class;
@@ -339,7 +339,7 @@ typedef struct mrb_state {
 #ifdef MRB_USE_TASK_SCHEDULER
   mrb_task_state task;                    /* Task scheduler state */
 #endif
-} mrb_state;
+};
 
 /**
  * Defines a new class.

--- a/include/mruby/boxing_nan.h
+++ b/include/mruby/boxing_nan.h
@@ -150,7 +150,7 @@ mrb_nan_boxing_value_int(mrb_value v)
 #define SET_TRUE_VALUE(r) NANBOX_SET_MISC_VALUE(r, MRB_TT_TRUE, 1)
 #define SET_BOOL_VALUE(r,b) NANBOX_SET_MISC_VALUE(r, (b) ? MRB_TT_TRUE : MRB_TT_FALSE, 1)
 #ifdef MRB_INT64
-MRB_API mrb_value mrb_boxing_int_value(struct mrb_state*, mrb_int);
+MRB_API mrb_value mrb_boxing_int_value(mrb_state*, mrb_int);
 #define SET_INT_VALUE(mrb, r, n) ((r) = mrb_boxing_int_value(mrb, n))
 #else
 #define SET_INT_VALUE(mrb, r, n) SET_FIXNUM_VALUE(r, n)

--- a/include/mruby/boxing_word.h
+++ b/include/mruby/boxing_word.h
@@ -165,11 +165,11 @@ mrb_val_union(mrb_value v)
   return x;
 }
 
-MRB_API mrb_value mrb_word_boxing_cptr_value(struct mrb_state*, void*);
+MRB_API mrb_value mrb_word_boxing_cptr_value(mrb_state*, void*);
 #ifndef MRB_NO_FLOAT
-MRB_API mrb_value mrb_word_boxing_float_value(struct mrb_state*, mrb_float);
+MRB_API mrb_value mrb_word_boxing_float_value(mrb_state*, mrb_float);
 #endif
-MRB_API mrb_value mrb_boxing_int_value(struct mrb_state*, mrb_int);
+MRB_API mrb_value mrb_boxing_int_value(mrb_state*, mrb_int);
 
 #if WORDBOX_IMMEDIATE_MASK == 0x3
 #define mrb_immediate_p(o) ((o).w & WORDBOX_IMMEDIATE_MASK || (o).w <= MRB_Qundef)

--- a/include/mruby/gc.h
+++ b/include/mruby/gc.h
@@ -14,15 +14,12 @@
  */
 MRB_BEGIN_DECL
 
-
-struct mrb_state;
-
 #define MRB_EACH_OBJ_OK 0
 #define MRB_EACH_OBJ_BREAK 1
-typedef int (mrb_each_object_callback)(struct mrb_state *mrb, struct RBasic *obj, void *data);
-void mrb_objspace_each_objects(struct mrb_state *mrb, mrb_each_object_callback *callback, void *data);
+typedef int (mrb_each_object_callback)(mrb_state *mrb, struct RBasic *obj, void *data);
+void mrb_objspace_each_objects(mrb_state *mrb, mrb_each_object_callback *callback, void *data);
 size_t mrb_objspace_page_slot_size(void);
-MRB_API void mrb_free_context(struct mrb_state *mrb, struct mrb_context *c);
+MRB_API void mrb_free_context(mrb_state *mrb, struct mrb_context *c);
 
 #ifndef MRB_GC_ARENA_SIZE
 #define MRB_GC_ARENA_SIZE 100
@@ -69,8 +66,8 @@ typedef struct mrb_gc {
   int arena_idx;
 } mrb_gc;
 
-MRB_API mrb_bool mrb_object_dead_p(struct mrb_state *mrb, struct RBasic *object);
-MRB_API int mrb_gc_add_region(struct mrb_state *mrb, void *start, size_t size);
+MRB_API mrb_bool mrb_object_dead_p(mrb_state *mrb, struct RBasic *object);
+MRB_API int mrb_gc_add_region(mrb_state *mrb, void *start, size_t size);
 
 #define MRB_GC_RED 7
 

--- a/include/mruby/value.h
+++ b/include/mruby/value.h
@@ -55,8 +55,6 @@ typedef uint8_t mrb_bool;
 # endif
 #endif
 
-struct mrb_state;
-
 #if defined _MSC_VER && _MSC_VER < 1800
 # define PRIo64 "llo"
 # define PRId64 "lld"
@@ -330,7 +328,7 @@ struct RCptr {
  */
 #ifndef MRB_NO_FLOAT
 MRB_INLINE mrb_value
-mrb_float_value(struct mrb_state *mrb, mrb_float f)
+mrb_float_value(mrb_state *mrb, mrb_float f)
 {
   mrb_value v;
   (void) mrb;
@@ -340,7 +338,7 @@ mrb_float_value(struct mrb_state *mrb, mrb_float f)
 #endif
 
 MRB_INLINE mrb_value
-mrb_cptr_value(struct mrb_state *mrb, void *p)
+mrb_cptr_value(mrb_state *mrb, void *p)
 {
   mrb_value v;
   (void) mrb;
@@ -352,7 +350,7 @@ mrb_cptr_value(struct mrb_state *mrb, void *p)
  * Returns an integer in Ruby.
  */
 MRB_INLINE mrb_value
-mrb_int_value(struct mrb_state *mrb, mrb_int i)
+mrb_int_value(mrb_state *mrb, mrb_int i)
 {
   mrb_value v;
   SET_INT_VALUE(mrb, v, i);

--- a/mrbgems/mruby-bin-debugger/tools/mrdb/apiprint.c
+++ b/mrbgems/mruby-bin-debugger/tools/mrdb/apiprint.c
@@ -34,7 +34,7 @@ mrdb_check_syntax(mrb_state *mrb, mrb_debug_context *dbg, const char *expr, size
 mrb_value
 mrb_debug_eval(mrb_state *mrb, mrb_debug_context *dbg, const char *expr, size_t len, mrb_bool *exc, int direct_eval)
 {
-  void (*tmp)(struct mrb_state*, const struct mrb_irep*, const mrb_code*, mrb_value*);
+  void (*tmp)(mrb_state*, const struct mrb_irep*, const mrb_code*, mrb_value*);
   mrb_value ruby_code;
   mrb_value s;
   mrb_value v;


### PR DESCRIPTION
This improves consistency with other definitions.