### PR TITLE
Disable some gems on build_config for playstationportable

### DIFF
--- a/build_config/playstationportable.rb
+++ b/build_config/playstationportable.rb
@@ -72,7 +72,9 @@ MRuby::CrossBuild.new("playstationportable") do |conf|
   conf.gem :core => "mruby-os-memsize"
   conf.gem :core => "mruby-proc-binding"
   conf.gem :core => "mruby-sleep"
-  conf.gem :core => "mruby-io"
-  conf.gem :core => "mruby-dir"
-  #conf.gem :core => "mruby-socket" unsupported
+  # Disabled until PSP-specific HALs are available; the POSIX HALs depend on
+  # APIs that the PSP SDK does not fully provide.
+  # conf.gem :core => "mruby-io"
+  # conf.gem :core => "mruby-dir"
+  # conf.gem :core => "mruby-socket"
 end


### PR DESCRIPTION
mruby-io and mruby-dir currently pull in POSIX-based IO/Dir support when no PSP-specific HAL is provided.
PSP is not a fully POSIX-compatible target, so the generated binary can crash at runtime when these APIs are used or initialized.
Disable them in the default PSP build config until a proper PSP HAL exists.
