### PR TITLE
Fix Windows build failure in mruby-bin-config

### DIFF
--- a/mrbgems/mruby-bin-config/mrbgem.rake
+++ b/mrbgems/mruby-bin-config/mrbgem.rake
@@ -21,14 +21,14 @@ MRuby::Gem::Specification.new('mruby-bin-config') do |spec|
   end
 
   mruby_config = name + suffix
-  mruby_config_path = "#{mruby_config_dir}/#{mruby_config}"
+  mruby_config_path = build.exefile("#{mruby_config_dir}/#{name}")
   make_cfg = "#{build.build_dir}/#{build.libdir_name}/libmruby.flags.mak"
   tmplt_path = "#{__dir__}/#{mruby_config}"
 
   if iscross
     build.products << mruby_config_path
   else
-    build.bins << mruby_config
+    build.bins << name
   end
 
   directory mruby_config_dir


### PR DESCRIPTION
## Problem

This bug was introduced in v4.0.0 and affects any downstream consumer building with `rake all test` on Windows with the `visualcpp` toolchain. It worked in v3.x because `products` was generated differently and did not expose the `.bat`/`.exe` mismatch described below.

On Windows with the `visualcpp` toolchain, `rake all test` fails immediately with:

```
rake aborted!
Don't know how to build task '.../build/host/bin/mruby-config.exe'
Did you mean?  .../build/host/bin/mruby-config
```

The root cause is a mismatch between the file task path and what the `build` task expects via `products`.

`build.bins << mruby_config` registers `"mruby-config.bat"` (with `.bat` suffix). When `define_installer_if_needed` resolves this through `exefile()`, it sees an existing extension and returns the name as-is — `"mruby-config.bat"`. However, the `build` task expects `"mruby-config.exe"` (i.e. `exefile("mruby-config")` with no extension). The mismatch causes rake to abort because no task is registered under `"mruby-config.exe"`.

## Why this wasn't caught by CI

The current `Windows-VC` CI job uses `rake -m test:run:serial`, which bypasses the `build` task entirely and therefore does not trigger `define_installer_if_needed`. The bug is only exposed when running `rake all test`, which is the standard full build + test invocation used by downstream consumers such as conda-forge.

## Reproduction log

https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=1510481&view=logs&jobId=fe7faf59-69bb-5487-b8fd-a35a7bda3a51&j=fe7faf59-69bb-5487-b8fd-a35a7bda3a51&t=55731638-dd49-5144-2129-5101b9dd1960

Relevant excerpt:

```
2026-04-24T04:07:22.4321674Z  │ │ rake aborted!
2026-04-24T04:07:22.4372738Z  │ │ Don't know how to build task '%SRC_DIR%/build/host/bin/mruby-config.exe' (See the list of available tasks with `rake --tasks`)
2026-04-24T04:07:22.4402498Z  │ │ Did you mean?  %SRC_DIR%/build/host/bin/mruby-config
```

## Fix

- Register `name` (`"mruby-config"`, without suffix) in `build.bins` instead of `mruby_config` (`"mruby-config.bat"`). This allows `exefile()` to correctly append `.exe` on Windows, matching what `products` expects.
- Derive `mruby_config_path` from `build.exefile("#{mruby_config_dir}/#{name}")` for consistency, so the file task path and `products` are in agreement.

The template file (`tmplt_path`) still correctly references `mruby_config` (i.e. `mruby-config.bat`) since that is the actual template on disk, and `exefile()` leaves names with existing extensions untouched.

## Note

Changing the `Windows-VC` CI job from `rake -m test:run:serial` to `rake all test` would have caught this regression. Consider updating the CI configuration to prevent similar issues in the future.