### PR TITLE
Avoid surrounding `#if` when using `mrb_const_cache_clear()`

### DIFF
--- a/src/variable.c
+++ b/src/variable.c
@@ -1443,9 +1443,7 @@ mrb_const_set(mrb_state *mrb, mrb_value mod, mrb_sym sym, mrb_value v)
     mrb_class_name_class(mrb, mrb_class_ptr(mod), mrb_class_ptr(v), sym);
   }
   mrb_obj_iv_set(mrb, mrb_obj_ptr(mod), sym, v);
-#ifndef MRB_NO_CONST_CACHE
   mrb_const_cache_clear(mrb);
-#endif
 
   if (!mrb->bootstrapping) {
     mrb_value name = mrb_symbol_value(sym);
@@ -1472,9 +1470,7 @@ mrb_const_remove(mrb_state *mrb, mrb_value mod, mrb_sym sym)
 {
   mod_const_check(mrb, mod);
   mrb_iv_remove(mrb, mod, sym);
-#ifndef MRB_NO_CONST_CACHE
   mrb_const_cache_clear(mrb);
-#endif
 }
 
 /*
@@ -1492,9 +1488,7 @@ MRB_API void
 mrb_define_const_id(mrb_state *mrb, struct RClass *mod, mrb_sym name, mrb_value v)
 {
   mrb_obj_iv_set(mrb, (struct RObject*)mod, name, v);
-#ifndef MRB_NO_CONST_CACHE
   mrb_const_cache_clear(mrb);
-#endif
 }
 
 /*


### PR DESCRIPTION
`mrb_const_cache_clear()` is always available.