### PR TITLE
test/bintest.rb: tokenize ENV['EMULATOR'] via Shellwords.split

### DIFF
--- a/test/bintest.rb
+++ b/test/bintest.rb
@@ -1,4 +1,5 @@
 $:.unshift File.dirname(File.dirname(File.expand_path(__FILE__)))
+require 'shellwords'
 require 'test/assert.rb'
 
 GEMNAME = ""
@@ -16,7 +17,7 @@ def cmd_list(s)
   path_list = [cmd_bin(s)]
 
   emu = ENV['EMULATOR']
-  path_list.unshift emu if emu && !emu.empty?
+  path_list.unshift(*Shellwords.split(emu)) if emu && !emu.empty?
 
   path_list
 end


### PR DESCRIPTION
# Cross-build bintests crash with `Errno::ENOENT` when `test_runner.command` is set

## Summary

Cross-builds that set `conf.test_runner.command` (e.g. to a qemu-user binary so `mrbtest` can be exercised under emulation) crash *every* bintest in `mruby-bin-mruby` with `Errno::ENOENT`, even though the emulator binary exists at the configured path.

Reproduced on `3.3.0`, `3.4.0`, `4.0.0`, and current `master`. Affected file: `test/bintest.rb`.

## Repro

`build_config/default.rb`:

```ruby
MRuby::Build.new('host') do |conf|
  conf.toolchain :gcc
  conf.disable_libmruby
  conf.disable_presym
end

MRuby::CrossBuild.new('aarch64-unknown-linux-musl') do |conf|
  conf.toolchain :gcc
  conf.host_target       = 'aarch64-unknown-linux-musl'
  conf.mrbcfile          = '/path/to/host/bin/mrbc'  # external native mrbc
  conf.test_runner.command = '/nix/store/.../bin/qemu-aarch64'
  conf.enable_test
  conf.enable_bintest
end
```

With cross gcc in `CC`, run `rake`. `mrbtest` runs fine under qemu; `bintest` fails for every test in `mrbgems/mruby-bin-mruby/bintest/mruby.rb` with:

```
Errno::ENOENT: regression for #1564 => No such file or directory - "/nix/store/.../bin/qemu-aarch64" (mrbgems: mruby-bin-mruby)
backtrace:
  …/ruby/2.7.0/open3.rb:213:in `spawn'
  …/test/bintest.rb cmd_list
  …/mrbgems/mruby-bin-mruby/bintest/mruby.rb:5:in `assert_mruby'
```

The `qemu-aarch64` binary exists at the reported path, is executable, and runs fine directly. The `ENOENT` comes from Open3 trying to exec a filename that includes literal `"` characters.

## Root cause

`Command::CrossTestRunner#emulator` (in `lib/mruby/build/command.rb`) returns the runner command as a single shell-quoted string:

```ruby
def emulator
  return "" unless @command
  return [@command, *@flags].map { |c| shellquote(c) }.join(' ')
end
```

`shellquote(s)` wraps `s` in double quotes (`"#{s}"`). That is correct for `Build#run_test`, which interpolates the return value into a shell command line via `sh` — the shell strips the quotes before exec.

`CrossBuild#run_bintest` (in `lib/mruby/build.rb`) reuses the same value, but propagates it through `ENV['EMULATOR']` instead of through a shell:

```ruby
env = {
  "BUILD_DIR" => @build_dir,
  "MRBCFILE"  => mrbc,
  "EMULATOR"  => @test_runner.emulator,
}
sh env, "ruby #{bintest} …"
```

`test/bintest.rb` then reads the env var and unshifts it onto an argv array that gets passed to `Open3.capture3`:

```ruby
def cmd_list(s)
  path_list = [cmd_bin(s)]
  emu = ENV['EMULATOR']
  path_list.unshift emu if emu && !emu.empty?
  path_list
end
```

`Open3.capture3(*path_list)` is the multi-arg form — Ruby exec's `path_list[0]` directly, no shell, no quote-stripping. So the literal `"/nix/store/…/qemu-aarch64"` (with the quotes) is passed to `execve(2)`, which returns `ENOENT`.

Native builds work because `@command` is `nil` on a regular `MRuby::Build`, so `emulator` returns `""`, the unshift is skipped, and `Open3` invokes the binary directly.

## Fix

Tokenize `ENV['EMULATOR']` with `Shellwords.split` and splat the result, so the same shell-quoted string round-trips through the env var correctly:

```ruby
require 'shellwords'

def cmd_list(s)
  path_list = [cmd_bin(s)]
  emu = ENV['EMULATOR']
  path_list.unshift(*Shellwords.split(emu)) if emu && !emu.empty?
  path_list
end
```

This also handles multi-token emulators (`qemu-aarch64 -L /sysroot mruby …`) correctly, which the current code does not — even ignoring the quoting bug, it concatenates the whole emulator command into `argv[0]`.

Verified with a cross-build of mruby for `aarch64-unknown-linux-musl` against qemu-user 8.2.10:
- before: 75 bintests, 17 crashes, 0 ok
- after: 100 bintests, 0 crashes, 100 ok
