### PR TITLE
`test/t/vformat.rb` uses `vf.i` with `%d` format → fails on strict-alignment 32-bit ABIs (MIPS o32)

### DIFF
--- a/test/t/vformat.rb
+++ b/test/t/vformat.rb
@@ -42,7 +42,7 @@ assert('mrb_vformat') do
   assert_equal '`S`: {a: 1, "b" => "c"}', vf.v('`S`: %S', {a: 1, "b" => ?c})
   assert_equal 'percent: %', vf.z('percent: %%')
   assert_equal '"I": inspect char', vf.c('%!c: inspect char', ?I)
-  assert_equal '709: inspect mrb_int', vf.i('%!d: inspect mrb_int', 709)
+  assert_equal '709: inspect mrb_int', vf.d('%!d: inspect mrb_int', 709)
   assert_equal '"a\x00b\xff"', vf.l('%!l', "a\000b\xFFc\000d", 4)
   assert_equal ':"&.": inspect symbol', vf.n('%!n: inspect symbol', :'&.')
   assert_equal 'inspect "String"', vf.v('inspect %!v', 'String')


### PR DESCRIPTION

## Summary

`test/t/vformat.rb` contains an assertion that mixes the wrong call-side helper with a `%d` format:

```ruby
assert_equal '709: inspect mrb_int', vf.i('%!d: inspect mrb_int', 709)
```

`vf.i` (the C side: `mrbgems/mruby-test/vformat.c::vf_s_format_i`) pushes an `mrb_int` (`int64_t` on standard `MRB_INT64` builds) into `va_list`:

```c
mrb_int i;
mrb_get_args(mrb, "Si", &fmt_str, &i);
return mrb_format(mrb, fmt, i);          // mrb_int → varargs
```

But the format string is `%!d`.  In `mrb_vformat` (`src/error.c`), `case 'd':` reads via `va_arg(ap, int)`:

```c
case 'd': case 'i':
#if MRB_INT_MAX < INT_MAX
    i = (mrb_int)va_arg(ap, int);
#else
    i = *p == 'd' ? (mrb_int)va_arg(ap, int) : va_arg(ap, mrb_int);
#endif
```

So the test pushes 8 bytes but the format tells `mrb_vformat` to read 4.

## Why it works on x86_64 / aarch64

Both ABIs pass `int64_t` varargs in slots that overlap with `int`-sized reads — reading 4 bytes from an `int64_t`-pushed slot returns the low 32 bits, which is the correct value for any int that fits in 32 bits (709 fits trivially).

## Why it fails on MIPS o32 (`mipsel-linux`, `mips-linux`)

The MIPS o32 ABI requires `int64_t` varargs to be 8-byte aligned, with explicit padding before the value if the previous slot was 4-aligned. `va_arg(ap, int)` advances by `sizeof(int)` (4) and reads 4 bytes from the aligned-to-int position — so on MIPS o32, the 4 bytes read are the padding (zeros) rather than the low half of the `int64_t`.

Concretely with `mipsel-unknown-linux-musl-gcc-12.2`, `mrbtest` reports:

```
Fail: mrb_vformat (core) - Assertion[37]
    Expected: "709: inspect mrb_int"
      Actual: "0: inspect mrb_int"
Total: 1813     OK: 1796     KO: 1
```

The bug is in the binary, not in `qemu-mipsel` — reproduces on both qemu 8.2.10 and 9.0.4 and would reproduce on real MIPS o32 hardware.

## Root cause

The contract of `mrb_vformat` is:

- `%d` reads `int` (caller pushes `int`)
- `%i` reads `mrb_int` (caller pushes `mrb_int`)

`vf_s_format_d` matches the contract — it explicitly casts to `int` before passing:

```c
mrb_int i; int d;
mrb_get_args(mrb, "Si", &fmt_str, &i);
d = (int)i;
return mrb_format(mrb, fmt, d);          // int → varargs
```

`vf_s_format_i` matches the contract for `%i` — pushes `mrb_int`.

The failing test calls `vf.i('%!d ...', 709)` — that's pushing `mrb_int` with a `%d` format, which violates the contract.

## Fix

Single character change in `test/t/vformat.rb`:

```diff
- assert_equal '709: inspect mrb_int', vf.i('%!d: inspect mrb_int', 709)
+ assert_equal '709: inspect mrb_int', vf.d('%!d: inspect mrb_int', 709)
```

`vf.d` casts to `int` before pushing, matching the `%d` format. The `inspect mrb_int` text in the format string is purely descriptive — it isn't a runtime instruction to mruby — so the assertion output is unchanged.

Tested: with this single-line patch, `mrbtest` on
`mipsel-unknown-linux-musl` reports `Total: 1813, OK: 1813, KO: 0`.

## Affected versions

3.3.0, 3.4.0, 4.0.0 — same code in `test/t/vformat.rb` and `src/error.c`.

## Environment for the report

- mruby: 3.3.0 (also reproduced by code inspection on 4.0.0)
- Build: standard `MRB_INT64` (default for `MRuby::Build`)
- Target: `mipsel-unknown-linux-musl` (and any `mips`/`mipsel` o32 ABI)
- Compiler: gcc 12.2 (cross), musl 1.2.x
- Test runner: `qemu-mipsel` 8.2.10 / 9.0.4 — bug present with either
- mrbtest line: `Fail: mrb_vformat (core) - Assertion[37]`