### PR TITLE
ci: fix build

### DIFF
--- a/mrbgems/mruby-task/test/task.rb
+++ b/mrbgems/mruby-task/test/task.rb
@@ -81,6 +81,7 @@ end
 assert("Task#suspend doesn't raise") do
   task = Task.new { }
   assert_nothing_raised { task.suspend }
+  task.terminate
 end
 
 assert("Task#resume doesn't raise") do
@@ -186,7 +187,6 @@ end
 
 assert("Task.run inside Task.run is a noop") do
   assert_nothing_raised do
-    Task.list.each { |task| task.terminate if task.status == :SUSPENDED }
     Task.new { Task.run }
     Task.run
   end

--- a/mrbgems/mruby-task/test/task.rb
+++ b/mrbgems/mruby-task/test/task.rb
@@ -186,6 +186,7 @@ end
 
 assert("Task.run inside Task.run is a noop") do
   assert_nothing_raised do
+    Task.list.each { |task| task.terminate if task.status == :SUSPENDED }
     Task.new { Task.run }
     Task.run
   end


### PR DESCRIPTION
My previous commit introduced a test that would hang. 
This change fixes the test to terminate suspended tasks 
otherwise we will wait on them forever.