### PR TITLE
[stable] backport: cap IO#puts recursion depth on cyclic arrays (mruby-io)

### DIFF
--- a/mrbgems/mruby-io/src/io.c
+++ b/mrbgems/mruby-io/src/io.c
@@ -992,10 +992,20 @@ io_puts_str(mrb_state *mrb, int fd, mrb_value str)
   }
 }
 
+/* Maximum nesting depth for puts with arrays; guards against cyclic and
+   pathologically deep arrays causing C stack overflow. */
+#define IO_PUTS_MAX_DEPTH 16
+
 /* Recursive helper for puts with arrays */
 static void
-io_puts_ary(mrb_state *mrb, int fd, mrb_value ary)
+io_puts_ary(mrb_state *mrb, int fd, mrb_value ary, int depth)
 {
+  if (depth >= IO_PUTS_MAX_DEPTH) {
+    mrb_value mark = mrb_str_new_lit(mrb, "[...]\n");
+    fd_write(mrb, fd, mark);
+    return;
+  }
+
   mrb_int len = RARRAY_LEN(ary);
 
   if (len == 0) {
@@ -1008,7 +1018,7 @@ io_puts_ary(mrb_state *mrb, int fd, mrb_value ary)
   for (mrb_int i = 0; i < len; i++) {
     mrb_value elem = RARRAY_PTR(ary)[i];
     if (mrb_array_p(elem)) {
-      io_puts_ary(mrb, fd, elem);  /* Recursive call for nested arrays */
+      io_puts_ary(mrb, fd, elem, depth + 1);
     }
     else {
       io_puts_str(mrb, fd, elem);
@@ -1040,7 +1050,7 @@ io_puts(mrb_state *mrb, mrb_value io)
   for (mrb_int i = 0; i < argc; i++) {
     mrb_value arg = argv[i];
     if (mrb_array_p(arg)) {
-      io_puts_ary(mrb, fd, arg);
+      io_puts_ary(mrb, fd, arg, 0);
     }
     else {
       io_puts_str(mrb, fd, arg);


### PR DESCRIPTION
stable still has the unbounded io_puts_ary recursion, so `a=[]; a<<a; puts a` (or any deeply self-nested array) blows the C stack. master fixed it on 2026-05-02 (7dfd560d) by capping the depth at IO_PUTS_MAX_DEPTH and printing `[...]` on overflow, the same way mruby-set already does — but stable never got it.

checked it on stable with an ASan build: `a=[]; a<<a; puts a` aborts with a stack overflow before the fix, and just prints `[...]` after cherry-picking 7dfd560d. originally an OSS-Fuzz find (clusterfuzz 6233530857488384).

plain cherry-pick (-x), no conflicts, original author kept. happy to rebase if you'd rather take it differently.

upstream: https://github.com/mruby/mruby/commit/7dfd560df8d0