### PR TITLE
mruby-exit: fix SystemExit#status inaccessible from Ruby

### DIFF
--- a/include/mruby/error.h
+++ b/include/mruby/error.h
@@ -26,7 +26,7 @@ struct RException {
 #define MRB_EXC_EXIT 65536
 #define MRB_EXC_EXIT_P(e) ((e)->flags & MRB_EXC_EXIT)
 /* retrieve status value from exc; need <mruby/variable.h> and <mruby/presym.h> */
-#define MRB_EXC_EXIT_STATUS(mrb,e) ((int)mrb_as_int((mrb),mrb_obj_iv_get((mrb),(e),MRB_SYM(status))))
+#define MRB_EXC_EXIT_STATUS(mrb,e) ((int)mrb_as_int((mrb),mrb_obj_iv_get((mrb),(e),MRB_IVSYM(status))))
 /* exit with SystemExit status */
 #define MRB_EXC_CHECK_EXIT(mrb,e) do {if (MRB_EXC_EXIT_P(e)) exit(MRB_EXC_EXIT_STATUS((mrb),(e)));} while (0)
 

--- a/mrbgems/mruby-exit/mrblib/mruby-exit.rb
+++ b/mrbgems/mruby-exit/mrblib/mruby-exit.rb
@@ -1,0 +1,5 @@
+class SystemExit
+  def status
+    @status
+  end
+end

--- a/mrbgems/mruby-exit/src/mruby_exit.c
+++ b/mrbgems/mruby-exit/src/mruby_exit.c
@@ -44,7 +44,7 @@ f_exit(mrb_state *mrb, mrb_value self)
   mrb_value exc = mrb_obj_new(mrb, mrb_exc_get_id(mrb, MRB_SYM(SystemExit)), 0, NULL);
   struct RException *e = mrb_exc_ptr(exc);
   e->flags |= MRB_EXC_EXIT;
-  mrb_iv_set(mrb, exc, MRB_SYM(status), mrb_int_value(mrb, (mrb_int)status));
+  mrb_iv_set(mrb, exc, MRB_IVSYM(status), mrb_int_value(mrb, (mrb_int)status));
   mrb_exc_raise(mrb, exc);
   /* not reached */
   return mrb_nil_value();


### PR DESCRIPTION
## Problem

`mruby-exit` stores the exit status using `MRB_SYM(status)` (plain `status` symbol) instead of `MRB_IVSYM(status)` (`@status` ivar symbol). Ruby's instance variable machinery only enumerates and accesses `@`-prefixed names, so the value is unreachable from Ruby code:

```ruby
begin
  exit 42
rescue SystemExit => e
  p e.instance_variables  # => []
  p e.instance_variable_get(:@status)  # => nil
end
```

The internal `MRB_EXC_EXIT_STATUS` macro in `error.h` reads with the same wrong symbol, so C consumers (e.g. `MRB_EXC_CHECK_EXIT`) work correctly — but Ruby callers diverge from CRuby behaviour. All other exception ivars in `src/error.c` (`@name`, `@args`) consistently use `MRB_IVSYM`.

Fixes #6888.

## Changes

- `mruby_exit.c`: `MRB_SYM(status)` → `MRB_IVSYM(status)` at the write site
- `error.h`: `MRB_EXC_EXIT_STATUS` macro updated to match (C callers remain consistent)
- `mrblib/mruby-exit.rb`: add `SystemExit#status` accessor to match CRuby

## After

```ruby
begin
  exit 42
rescue SystemExit => e
  p e.instance_variables              # => [:@status]
  p e.instance_variable_get(:@status) # => 42
  p e.status                          # => 42
end
```

---
_Generated by [Claude Code](https://claude.ai/code/session_018JRpuKQBupCU8iNrvdtrmv)_