### PR TITLE
mruby-task: return task result when mrb_task_run_once stops a task

### DIFF
--- a/mrbgems/mruby-task/README.md
+++ b/mrbgems/mruby-task/README.md
@@ -490,7 +490,7 @@ MRB_API mrb_value mrb_task_run(mrb_state *mrb);
 MRB_API mrb_value mrb_task_run_once(mrb_state *mrb);
 ```
 
-**`mrb_task_run_once()`** executes one ready task and returns. This is designed for WASM/JavaScript event loop integration where the scheduler should yield control back to the browser between task executions.
+**`mrb_task_run_once()`** executes one ready task and returns. This is designed for WASM/JavaScript event loop integration where the scheduler should yield control back to the browser between task executions. When the executed task stops during that step, the return value is the task result, including an exception object for unhandled task errors.
 
 ### Task Creation API
 

--- a/mrbgems/mruby-task/src/task.c
+++ b/mrbgems/mruby-task/src/task.c
@@ -579,6 +579,10 @@ mrb_task_run_once(mrb_state *mrb)
     mrb_incremental_gc(mrb);
   }
 
+  if (t->status == MRB_TASK_STATUS_DORMANT) {
+    return t->result;
+  }
+
   return mrb_true_value();
 }
 


### PR DESCRIPTION
Return the task result instead of `true` when the stepped task becomes dormant, so event-loop hosts (PicoRuby.wasm) can observe unhandled task exceptions.