### PR TITLE
Fix build when `MRB_NO_FLOAT` is defined

### DIFF
--- a/mrbgems/mruby-compiler/core/codegen.c
+++ b/mrbgems/mruby-compiler/core/codegen.c
@@ -5676,6 +5676,7 @@ codegen_range(codegen_scope *s, node *varnode, int val, mrb_bool exclusive)
   push();
 }
 
+#ifndef MRB_NO_FLOAT
 static void
 codegen_float(codegen_scope *s, node *varnode, int val)
 {
@@ -5688,6 +5689,7 @@ codegen_float(codegen_scope *s, node *varnode, int val)
 
   gen_load_op2(s, OP_LOADL, off, val);
 }
+#endif
 
 /* Variable-sized simple node generation functions */
 static void
@@ -6773,9 +6775,11 @@ codegen(codegen_scope *s, node *tree, int val)
     codegen_range(s, tree, val, TRUE);
     break;
 
+#ifndef MRB_NO_FLOAT
   case NODE_FLOAT:
     codegen_float(s, tree, val);
     break;
+#endif
 
   case NODE_SELF:
     codegen_self(s, tree, val);

--- a/src/class.c
+++ b/src/class.c
@@ -1317,8 +1317,12 @@ static inline uint8_t
 fast_fmt_ok(char c)
 {
   switch (c) {
+#ifndef MRB_NO_FLOAT
+  case 'f':
+    return 1;
+#endif
   case 'o': case 'S': case 'A': case 'H': case 'i': case 'b':
-  case 'f': case 'n': case 'z': case 'c': case 's': case 'a':
+  case 'n': case 'z': case 'c': case 's': case 'a':
     return 1;
   case '|':
     return 2;
@@ -1413,11 +1417,13 @@ get_args_fast(mrb_state *mrb, const char *format, void** ptr, va_list *ap)
       *bp = mrb_test(argv[i++]);
       break;
     }
+#ifndef MRB_NO_FLOAT
     case 'f': {
       mrb_float *fp = GET_ARG(mrb_float*);
       *fp = mrb_as_float(mrb, argv[i++]);
       break;
     }
+#endif
     case 'n': {
       mrb_sym *np = GET_ARG(mrb_sym*);
       *np = to_sym(mrb, argv[i++]);


### PR DESCRIPTION
Hello

I was experimenting with different build options, and 
I noticed when I defined `MRB_NO_FLOAT` the build
would fail in `mruby-compiler` and `class.c`.