### PR TITLE
mruby-bin-mrbc: define global_mrb for non-mruby targets

### DIFF
--- a/mrbgems/mruby-bin-mrbc/tools/mrbc/mrbc.c
+++ b/mrbgems/mruby-bin-mrbc/tools/mrbc/mrbc.c
@@ -12,7 +12,11 @@
 #include "mrc_compile.h"
 #include "mrc_pool.h"
 
+#if defined(MRC_TARGET_MRUBY)
 extern mrb_state *global_mrb; /* defined in mruby-compiler (ccontext.c) */
+#else
+#define global_mrb NULL
+#endif
 
 #define RITEBIN_EXT ".mrb"
 #define C_EXT       ".c"


### PR DESCRIPTION
PicoRuby builds its bootstrap mrbc without PICORB_VM_MRUBY so that the standalone compiler does not depend on mruby headers or generated presym definitions. As a result, MRC_TARGET_MRUBY is not defined and mruby-compiler does not provide global_mrb, causing mrbc to fail at link time with an undefined reference.

This patch lets mrbc use NULL when MRC_TARGET_MRUBY is not defined.

For normal mruby builds, the existing behavior is unchanged: mrbc declares the symbol extern and mruby-compiler's ccontext.c remains its definition.

This also keeps the ownership conditions complementary and avoids both undefined and duplicate symbol errors.