### PR TITLE
mruby-regexp: Fix String#split compatibility

### DIFF
--- a/mrbgems/mruby-regexp/mrblib/string_regexp.rb
+++ b/mrbgems/mruby-regexp/mrblib/string_regexp.rb
@@ -84,6 +84,16 @@ class String
 
     limit_given = args.length > 0
     limit = limit_given ? args[0] : 0
+    if limit_given && !limit.is_a?(Integer)
+      if limit.respond_to?(:to_int)
+        limit = limit.to_int
+        unless limit.is_a?(Integer)
+          raise TypeError, "no implicit conversion of #{limit.class} to Integer)"
+        end
+      else
+        limit = limit.__to_int
+      end
+    end
     if pattern.nil? || pattern.is_a?(String)
       return limit_given ? __split(pattern, limit) : __split(pattern)
     end

--- a/mrbgems/mruby-regexp/mrblib/string_regexp.rb
+++ b/mrbgems/mruby-regexp/mrblib/string_regexp.rb
@@ -76,40 +76,68 @@ class String
 
   # Regexp-aware split.  Falls back to the C-defined split (aliased as
   # `__split` in mrb_mruby_regexp_gem_init before this override loads) for
-  # nil or simple-string patterns; converts string-with-backslash to a
-  # Regexp and handles regexp patterns in Ruby.
-  def split(pattern = nil, limit = -1)
-    return __split(pattern, limit) if pattern.nil?
-    if pattern.is_a?(String)
-      return __split(pattern, limit) if pattern.length == 1 || !pattern.include?('\\')
-      pattern = Regexp.new(Regexp.escape(pattern))
+  # nil or string patterns, and handles regexp patterns in Ruby.
+  def split(pattern = nil, *args)
+    if args.length > 1
+      raise ArgumentError, "wrong number of arguments (given #{args.length + 1}, expected 0..2)"
     end
+
+    limit_given = args.length > 0
+    limit = limit_given ? args[0] : 0
+    if pattern.nil? || pattern.is_a?(String)
+      return limit_given ? __split(pattern, limit) : __split(pattern)
+    end
+    return self.empty? ? [] : [self] if limit == 1
+    unless pattern.is_a?(Regexp)
+      raise TypeError, "wrong argument type #{pattern.class} (expected Regexp)"
+    end
+
     result = []
-    rest = self
+    field_start = 0
+    search_pos = 0
+    len = self.bytesize
     count = 0
-    while rest.length > 0
+    while search_pos <= len
       if limit > 0 && count >= limit - 1
-        result << rest
+        result << (self.byteslice(field_start..-1) || "")
         return result
       end
-      md = pattern.match(rest)
+      md = pattern.match(self, search_pos)
       break unless md
-      result << md.pre_match
-      rest = md.post_match
-      count += 1
-      # skip zero-length match at beginning
-      if md[0].length == 0
-        if rest.length > 0
-          result[-1] = result[-1] + rest[0]
-          rest = rest[1..-1] || ""
+      match_start = md.__byte_begin(0)
+      match_end = md.__byte_end(0)
+
+      if match_start == match_end
+        rest = self.byteslice(match_end..-1)
+        if rest && rest.bytesize > 0
+          char = rest[0]
+          search_pos = match_end + char.bytesize
         else
-          break
+          search_pos = match_end + 1
         end
+        next if match_start == field_start
+      end
+
+      result << self.byteslice(field_start, match_start - field_start)
+      count += 1
+
+      if match_start == match_end
+        field_start = match_end
+      else
+        field_start = match_end
+        search_pos = match_end
+      end
+      i = 1
+      while i < md.length
+        result << md[i] unless md[i].nil?
+        i += 1
       end
     end
-    result << rest
-    # remove trailing empty strings if no limit
-    if limit < 0
+    if len > 0 && field_start <= len && (field_start < len || limit != 0)
+      result << self.byteslice(field_start..-1)
+    end
+
+    if limit == 0
       while result.length > 0 && result[-1] == ""
         result.pop
       end

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -461,6 +461,8 @@ assert("String#split with regexp captures") do
   assert_equal ["a", "1", "b2c"], "a1b2c".split(/(\d)/, 2)
   assert_equal ["a", "1", "b", "2", "c"], "a1b2c".split(/(\d)/, 3)
   assert_equal ["a", "1", "b", "2", "c"], "a1b2c".split(/(\d)/, -1)
+  assert_equal ["hell"], "hello".split(/(x)?o/)
+  assert_equal ["hell", ""], "hello".split(/(x)?o/, -1)
 end
 
 assert("String#split with zero-width regexp") do

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -411,6 +411,70 @@ assert("String#split with regexp") do
   assert_equal ["a", "b", "c"], "a, b, c".split(/,\s*/)
 end
 
+assert("String#split delegates non-regexp patterns") do
+  assert_equal ["a", "b"], " a  b ".split
+  assert_equal ["a", "b"], " a  b ".split(nil)
+  assert_equal ["a", "b", "c"], "a,b,c".split(",")
+  assert_equal ["a", "b", "c"], "abc".split("")
+  assert_equal ["a", "b", "c", ""], "abc".split("", -1)
+  assert_equal ["a", "b"], "a\\b".split("\\")
+end
+
+assert("String#split with regexp limit") do
+  assert_equal ["a"], "a,".split(/,/, 0)
+  assert_equal ["a", ""], "a,".split(/,/, -1)
+  assert_equal ["a", ""], "a,".split(/,/, 2)
+  assert_equal ["a,b,"], "a,b,".split(/,/, 1)
+end
+
+assert("String#split with empty regexp") do
+  assert_equal ["a", "b", "c"], "abc".split(//)
+  assert_equal ["a", "bc"], "abc".split(//, 2)
+  assert_equal ["a", "b", "c"], "abc".split(//, 3)
+  assert_equal ["a", "b", "c", ""], "abc".split(//, 4)
+  assert_equal ["a", "b", "c", ""], "abc".split(//, -1)
+  assert_equal [], "".split(//, -1)
+  assert_equal ["a", ""], "a".split(//, -1)
+  assert_equal ["あ", "い"], "あい".split(//)
+  assert_equal ["あ", "い"], "あい".split(//, 2)
+  assert_equal ["あ", "い", ""], "あい".split(//, -1)
+end
+
+assert("String#split with invalid regexp pattern type") do
+  assert_raise(TypeError) { "abc".split(1) }
+  assert_equal ["abc"], "abc".split(1, 1)
+end
+
+assert("String#split with regexp captures") do
+  assert_equal ["a1b2c"], "a1b2c".split(/(\d)/, 1)
+  assert_equal ["a", "1", "b", "2", "c"], "a1b2c".split(/(\d)/)
+  assert_equal ["a", "1", "b2c"], "a1b2c".split(/(\d)/, 2)
+  assert_equal ["a", "1", "b", "2", "c"], "a1b2c".split(/(\d)/, 3)
+  assert_equal ["a", "1", "b", "2", "c"], "a1b2c".split(/(\d)/, -1)
+end
+
+assert("String#split with zero-width regexp") do
+  assert_equal ["ab"], "ab".split(/(?=b)/, 1)
+  assert_equal ["a", "b"], "ab".split(/(?=b)/, 2)
+  assert_equal ["a", "b"], "ab".split(/(?=b)/, 3)
+  assert_equal ["a", "bc"], "abc".split(/(?=b)/)
+  assert_equal ["a", "bc"], "abc".split(/(?=b)/, -1)
+  assert_equal ["abc"], "abc".split(/(?=a)/)
+  assert_equal ["abc"], "abc".split(/(?=a)/, -1)
+  assert_equal ["ab", "c"], "abc".split(/(?=c)/)
+  assert_equal ["abc"], "abc".split(/^/)
+  assert_equal ["abc", ""], "abc".split(/$/, -1)
+  assert_equal ["a", "b", "bc"], "abc".split(/(?=(b))/)
+end
+
+assert("String#split with multibyte regexp") do
+  assert_equal ["あ", "い"], "あい".split(/(?=い)/)
+  assert_equal ["あ", "い"], "あい".split(/(?=い)/, -1)
+  assert_equal ["あ", "い", "い"], "あい".split(/(?=(い))/)
+  assert_equal ["", "あ", "い"], "あい".split(/(あ)/)
+  assert_equal ["", "あ", "い"], "あい".split(/(あ)/, -1)
+end
+
 assert("Regexp - case in when") do
   result = case "hello123"
            when /\d+/ then "has digits"

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -425,6 +425,16 @@ assert("String#split with regexp limit") do
   assert_equal ["a", ""], "a,".split(/,/, -1)
   assert_equal ["a", ""], "a,".split(/,/, 2)
   assert_equal ["a,b,"], "a,b,".split(/,/, 1)
+  assert_raise(TypeError) { "a,b".split(/,/, nil) }
+  assert_equal ["a,b"], "a,b".split(/,/, 1.5)
+
+  limit = Object.new
+  def limit.to_int; 2; end
+  assert_equal ["a", "b"], "a,b".split(/,/, limit)
+
+  limit = Object.new
+  def limit.to_int; 1.5; end
+  assert_raise(TypeError) { "a,b".split(/,/, limit) }
 end
 
 assert("String#split with empty regexp") do


### PR DESCRIPTION
This updates the regexp-aware `String#split` override to:

- delegate `nil` and `String` patterns to the original core `String#split`
- preserve omitted-limit vs explicit-limit behavior
- handle positive, zero, negative, and `limit == 1` cases
- include regexp capture groups in split results
- handle empty regexp and zero-width regexp matches correctly
- use byte offsets for regexp-based slicing
- raise `TypeError` for invalid pattern types, while preserving Ruby's `limit == 1` behavior


Added tests for:

- non-regexp delegation
- regexp limits
- empty regexp split
- invalid pattern types
- regexp captures with limits
- zero-width regexp matches
- multibyte regexp split cases under UTF-8 builds