### PR TITLE
mruby-regexp: improve Regexp match compatibility

### DIFF
--- a/mrbgems/mruby-regexp/mrblib/string_regexp.rb
+++ b/mrbgems/mruby-regexp/mrblib/string_regexp.rb
@@ -38,7 +38,7 @@ class String
     pos = 0
     len = self.bytesize
     while pos <= len
-      md = pattern.match(self, pos)
+      md = pattern.__byte_match(self, pos)
       break unless md
       # gsub works in byte space (match pos, byteslice). begin/end report
       # character offsets (CRuby-compatible), so use the byte accessors.
@@ -112,7 +112,7 @@ class String
         result << (self.byteslice(field_start..-1) || "")
         return result
       end
-      md = pattern.match(self, search_pos)
+      md = pattern.__byte_match(self, search_pos)
       break unless md
       match_start = md.__byte_begin(0)
       match_end = md.__byte_end(0)

--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -192,6 +192,41 @@ re_byte_to_char(mrb_state *mrb, mrb_value str, mrb_int byte_off)
 #endif
 }
 
+/* Normalize Regexp#match positional argument for the regexp engine. Ruby's
+   pos is a character offset only when MRB_UTF8_STRING is enabled; otherwise
+   it already is a byte offset. Returns -1 for out-of-range offsets, which
+   Ruby treats as no match. */
+static mrb_int
+re_char_to_byte(mrb_state *mrb, mrb_value str, mrb_int char_off)
+{
+  (void)mrb;
+#ifdef MRB_UTF8_STRING
+  const char *p = RSTRING_PTR(str);
+  const char *e = p + RSTRING_LEN(str);
+  mrb_int char_len = re_byte_to_char(mrb, str, RSTRING_LEN(str));
+  mrb_int chars = 0;
+
+  if (char_off < 0) {
+    char_off += char_len;
+  }
+  if (char_off < 0 || char_off > char_len) return -1;
+  while (p < e && chars < char_off) {
+    p++;
+    while (p < e && (((unsigned char)*p & 0xC0) == 0x80)) {
+      p++;
+    }
+    chars++;
+  }
+  if (chars < char_off) return -1;
+  return (mrb_int)(p - RSTRING_PTR(str));
+#else
+  mrb_int len = RSTRING_LEN(str);
+  if (char_off < 0) char_off += len;
+  if (char_off < 0 || char_off > len) return -1;
+  return char_off;
+#endif
+}
+
 /* Create MatchData from captures */
 static mrb_value
 create_matchdata(mrb_state *mrb, mrb_value regexp, mrb_value str, int *captures, int ncap)
@@ -259,6 +294,33 @@ static mrb_value
 regexp_match(mrb_state *mrb, mrb_value self)
 {
   mrb_value str;
+  mrb_value block = mrb_nil_value();
+  mrb_int pos = 0;
+  mrb_value md;
+
+  mrb_get_args(mrb, "o|i&", &str, &pos, &block);
+  if (mrb_nil_p(str)) {
+    clear_match_globals(mrb);
+    return mrb_nil_value();
+  }
+  str = mrb_ensure_string_type(mrb, str);
+  pos = re_char_to_byte(mrb, str, pos);
+  if (pos < 0) {
+    clear_match_globals(mrb);
+    return mrb_nil_value();
+  }
+
+  md = exec_match(mrb, self, str, pos);
+  if (!mrb_nil_p(md) && !mrb_nil_p(block)) {
+    return mrb_yield(mrb, block, md);
+  }
+  return md;
+}
+
+static mrb_value
+regexp_match_byte(mrb_state *mrb, mrb_value self)
+{
+  mrb_value str;
   mrb_int pos = 0;
   mrb_get_args(mrb, "S|i", &str, &pos);
   return exec_match(mrb, self, str, pos);
@@ -272,7 +334,11 @@ regexp_match_p(mrb_state *mrb, mrb_value self)
 {
   mrb_value str;
   mrb_int pos = 0;
-  mrb_get_args(mrb, "S|i", &str, &pos);
+  mrb_get_args(mrb, "o|i", &str, &pos);
+  if (mrb_nil_p(str)) return mrb_false_value();
+  str = mrb_ensure_string_type(mrb, str);
+  pos = re_char_to_byte(mrb, str, pos);
+  if (pos < 0) return mrb_false_value();
 
   mrb_regexp_pattern *pat = DATA_GET_PTR(mrb, self, &regexp_type, mrb_regexp_pattern);
   if (!pat) mrb_raise(mrb, E_ARGUMENT_ERROR, "uninitialized Regexp");
@@ -289,8 +355,11 @@ regexp_match_op(mrb_state *mrb, mrb_value self)
 {
   mrb_value str;
   mrb_get_args(mrb, "o", &str);
-  if (mrb_nil_p(str)) return mrb_nil_value();
-  mrb_ensure_string_type(mrb, str);
+  if (mrb_nil_p(str)) {
+    clear_match_globals(mrb);
+    return mrb_nil_value();
+  }
+  str = mrb_ensure_string_type(mrb, str);
 
   mrb_value md = exec_match(mrb, self, str, 0);
   if (mrb_nil_p(md)) return mrb_nil_value();
@@ -1002,7 +1071,8 @@ mrb_mruby_regexp_gem_init(mrb_state *mrb)
   mrb_define_class_method(mrb, re, "quote", regexp_escape, MRB_ARGS_REQ(1));
 
   /* Instance methods */
-  mrb_define_method(mrb, re, "match", regexp_match, MRB_ARGS_ARG(1, 1));
+  mrb_define_method(mrb, re, "match", regexp_match, MRB_ARGS_ARG(1, 1)|MRB_ARGS_BLOCK());
+  mrb_define_method(mrb, re, "__byte_match", regexp_match_byte, MRB_ARGS_ARG(1, 1));
   mrb_define_method(mrb, re, "match?", regexp_match_p, MRB_ARGS_ARG(1, 1));
   mrb_define_method(mrb, re, "=~", regexp_match_op, MRB_ARGS_REQ(1));
   mrb_define_method(mrb, re, "===", regexp_case_match, MRB_ARGS_REQ(1));

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -23,16 +23,43 @@ assert("Regexp#match - no match") do
   assert_nil re.match("abc")
 end
 
+assert("Regexp#match - nil argument") do
+  $~ = /abc/.match("abc")
+  assert_nil /abc/.match(nil)
+  assert_nil $~
+end
+
+assert("Regexp#match - block") do
+  result = /bc/.match("abcd") { |md| [md[0], md.begin(0)] }
+  assert_equal ["bc", 1], result
+  assert_nil(/xyz/.match("abcd") { |md| md[0] })
+end
+
 assert("Regexp#match?") do
   re = Regexp.new("abc")
   assert_true re.match?("xabcy")
   assert_false re.match?("xyz")
+  assert_false re.match?(nil)
+end
+
+assert("Regexp#match? - does not update last match") do
+  $~ = /matched/.match("matched")
+  assert_true /abc/.match?("abc")
+  assert_equal "matched", $~[0]
+  assert_false /xyz/.match?("abc")
+  assert_equal "matched", $~[0]
 end
 
 assert("Regexp#=~") do
   re = Regexp.new("bc")
   assert_equal 1, re =~ "abcd"
   assert_nil re =~ "xyz"
+end
+
+assert("Regexp#=~ - nil argument clears last match") do
+  $~ = /abc/.match("abc")
+  assert_nil(/abc/ =~ nil)
+  assert_nil $~
 end
 
 assert("Regexp#===") do
@@ -181,6 +208,25 @@ assert("Regexp - multibyte (UTF-8) match extraction") do
   assert_equal [1, 2], [m.begin(1), m.end(1)]
   assert_equal [2, 3], [m.begin(2), m.end(2)]
   assert_equal 2, "あいう".match(/う/).begin(0)
+
+  assert_equal 2, /あ/.match("あいあ", 2).begin(0)
+  assert_equal 2, /あ/.match("あいあ", -1).begin(0)
+  assert_nil /い/.match("あいあ", 2)
+  assert_nil /あ/.match("あいあ", 4)
+  assert_nil /あ/.match("あいあ", -4)
+  assert_true /あ/.match?("あいあ", 2)
+  assert_false /い/.match?("あいあ", 2)
+end
+
+assert("String#gsub - regexp search position is byte-based internally") do
+  skip unless __ENCODING__ == "UTF-8"
+  assert_equal "あ-い-う", "あ,い,う".gsub(/,/, "-")
+end
+
+assert("String#split - regexp search position is byte-based internally") do
+  skip unless __ENCODING__ == "UTF-8"
+  assert_equal ["あ", "い", "う"], "あ,い,う".split(/,/)
+  assert_equal ["あ", ",", "い", ",", "う"], "あ,い,う".split(/(,)/)
 end
 
 assert("Regexp.escape") do


### PR DESCRIPTION
This improves `mruby-regexp` compatibility around `Regexp#match`, `Regexp#match?`, `Regexp#=~`, and UTF-8 match positions.

Changes include:
- Support `Regexp#match` with a block.
- Make `Regexp#match(nil)` return `nil` and clear match globals.
- Make `Regexp#match?` return `false` for `nil` without updating `$~`.
- Make `Regexp#=~ nil` return `nil` and clear match globals.
- Convert public `pos` from character offset to byte offset only when `MRB_UTF8_STRING` is enabled.
- Keep byte-based internal scanning for `String#gsub` and `String#split` through `Regexp#__byte_match`.
- Use the return value from `mrb_ensure_string_type()` before accessing string internals.

The regexp engine consumes byte offsets, but Ruby-facing APIs expose character offsets when UTF-8 string support is enabled. Passing the public `pos` directly to the engine caused UTF-8 matches to start from the wrong byte position.

At the same time, `String#gsub` and `String#split` internally track byte positions because they combine match offsets with `byteslice` and MatchData byte accessors. Those internal loops must bypass public character-offset normalization, so this change adds a byte-oriented internal match entry point.

This also clarifies `$~` behavior:
- `Regexp#match(nil)` clears `$~`.
- `Regexp#=~ nil` clears `$~`.
- `Regexp#match?` does not update `$~`.
