### PR TITLE
mruby-regexp: correct regexp offset conversion for UTF-8 and binary strings

### DIFF
--- a/mrbgems/mruby-regexp/include/re_internal.h
+++ b/mrbgems/mruby-regexp/include/re_internal.h
@@ -131,16 +131,38 @@ mrb_regexp_pattern* mrb_re_compile(mrb_state *mrb, const char *pattern, mrb_int 
 /* Free a compiled pattern */
 void mrb_re_free(mrb_state *mrb, mrb_regexp_pattern *pat);
 
+/* UTF-8 helpers */
+int mrb_re_utf8_charlen(const char *s, const char *end);
+uint32_t mrb_re_utf8_decode(const char *s, int *len);
+mrb_bool mrb_re_is_word_char(uint32_t c);
+
+static inline int
+mrb_re_charlen(const char *s, const char *end, mrb_bool binary)
+{
+  return binary ? 1 : mrb_re_utf8_charlen(s, end);
+}
+
+static inline uint32_t
+mrb_re_decode_char(const char *s, int *len, mrb_bool binary)
+{
+  if (binary) {
+    if (len) *len = 1;
+    return (uint8_t)*s;
+  }
+  return mrb_re_utf8_decode(s, len);
+}
+
+static inline mrb_bool
+mrb_re_utf8_continuation_p(const char *s)
+{
+  return (((uint8_t)*s & 0xC0) == 0x80);
+}
+
 /* Execute a match.
    Returns number of captures filled (0 = no match).
    captures[2*n] = start, captures[2*n+1] = end for group n. */
 int mrb_re_exec(mrb_state *mrb, const mrb_regexp_pattern *pat,
             const char *str, mrb_int len, mrb_int start,
-            int *captures, int captures_size);
-
-/* UTF-8 helpers */
-int mrb_re_utf8_charlen(const char *s, const char *end);
-uint32_t mrb_re_utf8_decode(const char *s, int *len);
-mrb_bool mrb_re_is_word_char(uint32_t c);
+            int *captures, int captures_size, mrb_bool binary);
 
 #endif /* MRB_RE_INTERNAL_H */

--- a/mrbgems/mruby-regexp/mrblib/string_regexp.rb
+++ b/mrbgems/mruby-regexp/mrblib/string_regexp.rb
@@ -37,6 +37,7 @@ class String
     parts = []
     pos = 0
     len = self.bytesize
+    binary = Regexp.__binary_string?(self)
     while pos <= len
       md = pattern.__byte_match(self, pos)
       break unless md
@@ -47,11 +48,16 @@ class String
       parts << self.byteslice(pos, match_start - pos)
       parts << block.call(md[0]).to_s
       if match_start == match_end
-        rest = self.byteslice(match_end..-1)
-        if rest && rest.bytesize > 0
-          char = rest[0]
-          parts << char
-          pos = match_end + char.bytesize
+        if match_end < len
+          if binary
+            parts << self.byteslice(match_end, 1)
+            pos = match_end + 1
+          else
+            rest = self.byteslice(match_end..-1)
+            char = rest[0]
+            parts << char
+            pos = match_end + char.bytesize
+          end
         else
           pos = match_end + 1
         end

--- a/mrbgems/mruby-regexp/src/re_exec.c
+++ b/mrbgems/mruby-regexp/src/re_exec.c
@@ -84,6 +84,7 @@ typedef struct {
   const char *str_end;
   mrb_bool matched;
   mrb_bool match_only;    /* true: skip capture tracking (match? path) */
+  mrb_bool binary;        /* true: subject is byte-indexed ASCII-8BIT */
   mrb_bool cut;           /* a higher-priority thread matched this step:
                              stop adding/processing lower-priority threads */
   int *result_caps;       /* best match (ncap ints) */
@@ -239,7 +240,7 @@ add_thread(pike_state *s, re_threadlist *list,
 static int
 pike_vm(mrb_state *mrb, const mrb_regexp_pattern *pat,
         const char *str, mrb_int len, mrb_int start,
-        int *captures, int captures_size)
+        int *captures, int captures_size, mrb_bool binary)
 {
   const char *sp = str + start;
   const char *str_end = str + len;
@@ -263,6 +264,7 @@ pike_vm(mrb_state *mrb, const mrb_regexp_pattern *pat,
   s.str_end = str_end;
   s.matched = FALSE;
   s.match_only = match_only;
+  s.binary = binary;
   s.cut = FALSE;
   s.gen = 1;
   if (match_only) {
@@ -313,7 +315,7 @@ pike_vm(mrb_state *mrb, const mrb_regexp_pattern *pat,
          a multi-byte char's interior is not a valid char boundary, and
          starting a thread there mis-decodes the char (e.g. a class-
          match on a stray 0x82 instead of the leader's full codepoint). */
-      if (curr.count == 0 && sp < str_end && ((uint8_t)*sp & 0xC0) == 0x80) {
+      if (!s.binary && curr.count == 0 && sp < str_end && mrb_re_utf8_continuation_p(sp)) {
         continue;
       }
       int slot = match_only ? 0 : pool_alloc(&s);
@@ -352,13 +354,13 @@ pike_vm(mrb_state *mrb, const mrb_regexp_pattern *pat,
     next.count = 0;
 
     int ch = (uint8_t)*sp;
-    int advance = mrb_re_utf8_charlen(sp, str_end);
+    int advance = mrb_re_charlen(sp, str_end, s.binary);
     /* Decoded codepoint of the current input char. Identical to `ch`
        for ASCII; lazily decoded only when the char is multi-byte. */
     uint32_t curr_cp = (uint32_t)ch;
-    if (advance > 1) {
+    if (!s.binary && advance > 1) {
       int dlen = 0;
-      curr_cp = mrb_re_utf8_decode(sp, &dlen);
+      curr_cp = mrb_re_decode_char(sp, &dlen, s.binary);
     }
 
     for (int i = 0; i < curr.count; i++) {
@@ -461,7 +463,7 @@ pike_vm(mrb_state *mrb, const mrb_regexp_pattern *pat,
 static mrb_bool
 bt_match(const mrb_regexp_pattern *pat, const char *str, const char *str_end,
          const char *sp, uint32_t pc, int *captures, int ncap, int *steps,
-         int depth)
+         int depth, mrb_bool binary)
 {
   if (depth > MRB_REGEXP_RECURSION_LIMIT) return FALSE;
   while (pc < pat->code_len) {
@@ -476,21 +478,21 @@ bt_match(const mrb_regexp_pattern *pat, const char *str, const char *str_end,
 
     case RE_ANY:
       if (sp >= str_end || *sp == '\n') return FALSE;
-      sp += mrb_re_utf8_charlen(sp, str_end); pc++;
+      sp += mrb_re_charlen(sp, str_end, binary); pc++;
       break;
 
     case RE_ANY_NL:
       if (sp >= str_end) return FALSE;
-      sp += mrb_re_utf8_charlen(sp, str_end); pc++;
+      sp += mrb_re_charlen(sp, str_end, binary); pc++;
       break;
 
     case RE_CLASS:
       if (sp >= str_end) return FALSE;
       {
         int dlen = 0;
-        uint32_t cp_ = mrb_re_utf8_decode(sp, &dlen);
+        uint32_t cp_ = mrb_re_decode_char(sp, &dlen, binary);
         if (!class_match(&pat->classes[inst.a], cp_)) return FALSE;
-        sp += mrb_re_utf8_charlen(sp, str_end);
+        sp += mrb_re_charlen(sp, str_end, binary);
       }
       pc++;
       break;
@@ -499,9 +501,9 @@ bt_match(const mrb_regexp_pattern *pat, const char *str, const char *str_end,
       if (sp >= str_end) return FALSE;
       {
         int dlen = 0;
-        uint32_t cp_ = mrb_re_utf8_decode(sp, &dlen);
+        uint32_t cp_ = mrb_re_decode_char(sp, &dlen, binary);
         if (class_match(&pat->classes[inst.a], cp_)) return FALSE;
-        sp += mrb_re_utf8_charlen(sp, str_end);
+        sp += mrb_re_charlen(sp, str_end, binary);
       }
       pc++;
       break;
@@ -514,12 +516,12 @@ bt_match(const mrb_regexp_pattern *pat, const char *str, const char *str_end,
       break;
 
     case RE_SPLIT:
-      if (bt_match(pat, str, str_end, sp, pc + 1, captures, ncap, steps, depth + 1)) return TRUE;
+      if (bt_match(pat, str, str_end, sp, pc + 1, captures, ncap, steps, depth + 1, binary)) return TRUE;
       pc = inst.offset;
       break;
 
     case RE_SPLITNG:
-      if (bt_match(pat, str, str_end, sp, inst.offset, captures, ncap, steps, depth + 1)) return TRUE;
+      if (bt_match(pat, str, str_end, sp, inst.offset, captures, ncap, steps, depth + 1, binary)) return TRUE;
       pc++;
       break;
 
@@ -529,7 +531,7 @@ bt_match(const mrb_regexp_pattern *pat, const char *str, const char *str_end,
         if (slot < ncap) {
           int old = captures[slot];
           captures[slot] = (int)(sp - str);
-          if (bt_match(pat, str, str_end, sp, pc + 1, captures, ncap, steps, depth + 1)) return TRUE;
+          if (bt_match(pat, str, str_end, sp, pc + 1, captures, ncap, steps, depth + 1, binary)) return TRUE;
           captures[slot] = old;
         }
         return FALSE;
@@ -592,13 +594,13 @@ bt_match(const mrb_regexp_pattern *pat, const char *str, const char *str_end,
       break;
 
     case RE_LOOKAHEAD:
-      if (!bt_match(pat, str, str_end, sp, pc + 1, captures, ncap, steps, depth + 1))
+      if (!bt_match(pat, str, str_end, sp, pc + 1, captures, ncap, steps, depth + 1, binary))
         return FALSE;
       pc = inst.offset;
       break;
 
     case RE_NEG_LOOKAHEAD:
-      if (bt_match(pat, str, str_end, sp, pc + 1, captures, ncap, steps, depth + 1))
+      if (bt_match(pat, str, str_end, sp, pc + 1, captures, ncap, steps, depth + 1, binary))
         return FALSE;
       pc = inst.offset;
       break;
@@ -607,7 +609,7 @@ bt_match(const mrb_regexp_pattern *pat, const char *str, const char *str_end,
       {
         int lb_len = inst.a;
         if (sp - str < lb_len) return FALSE;  /* not enough text before */
-        if (!bt_match(pat, str, str_end, sp - lb_len, pc + 1, captures, ncap, steps, depth + 1))
+        if (!bt_match(pat, str, str_end, sp - lb_len, pc + 1, captures, ncap, steps, depth + 1, binary))
           return FALSE;
         pc = inst.offset;
       }
@@ -617,7 +619,7 @@ bt_match(const mrb_regexp_pattern *pat, const char *str, const char *str_end,
       {
         int lb_len = inst.a;
         if (sp - str >= lb_len) {
-          if (bt_match(pat, str, str_end, sp - lb_len, pc + 1, captures, ncap, steps, depth + 1))
+          if (bt_match(pat, str, str_end, sp - lb_len, pc + 1, captures, ncap, steps, depth + 1, binary))
             return FALSE;
         }
         /* if not enough text before, negative lookbehind succeeds */
@@ -635,7 +637,7 @@ bt_match(const mrb_regexp_pattern *pat, const char *str, const char *str_end,
 static int
 backtrack_exec(mrb_state *mrb, const mrb_regexp_pattern *pat,
                const char *str, mrb_int len, mrb_int start,
-               int *captures, int captures_size)
+               int *captures, int captures_size, mrb_bool binary)
 {
   const char *str_end = str + len;
   int ncap = pat->num_captures * 2;
@@ -654,10 +656,13 @@ backtrack_exec(mrb_state *mrb, const mrb_regexp_pattern *pat,
       while (sp < str_end && !FIRST_BYTE_OK(pat, (uint8_t)*sp)) sp++;
       if (sp > str_end) break;
     }
+    if (!binary && sp < str_end && mrb_re_utf8_continuation_p(sp)) {
+      continue;
+    }
     memset(caps, -1, sizeof(int) * ncap);
     int steps = 0;
 
-    if (bt_match(pat, str, str_end, sp, 0, caps, ncap, &steps, 0)) {
+    if (bt_match(pat, str, str_end, sp, 0, caps, ncap, &steps, 0, binary)) {
       if (captures) {
         int copy = ncap < captures_size ? ncap : captures_size;
         memcpy(captures, caps, sizeof(int) * copy);
@@ -700,13 +705,13 @@ literal_exec(const mrb_regexp_pattern *pat,
 int
 mrb_re_exec(mrb_state *mrb, const mrb_regexp_pattern *pat,
         const char *str, mrb_int len, mrb_int start,
-        int *captures, int captures_size)
+        int *captures, int captures_size, mrb_bool binary)
 {
   if (pat->is_literal) {
     return literal_exec(pat, str, len, start, captures, captures_size);
   }
   if (pat->has_backref || pat->needs_backtrack) {
-    return backtrack_exec(mrb, pat, str, len, start, captures, captures_size);
+    return backtrack_exec(mrb, pat, str, len, start, captures, captures_size, binary);
   }
-  return pike_vm(mrb, pat, str, len, start, captures, captures_size);
+  return pike_vm(mrb, pat, str, len, start, captures, captures_size, binary);
 }

--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -252,6 +252,15 @@ re_binary_string_p(mrb_value str)
   return RSTR_BINARY_P(RSTRING(str));
 }
 
+static mrb_value
+regexp_binary_string_p(mrb_state *mrb, mrb_value self)
+{
+  (void)self;
+  mrb_value str;
+  mrb_get_args(mrb, "S", &str);
+  return mrb_bool_value(re_binary_string_p(str));
+}
+
 /* Create MatchData from captures */
 static mrb_value
 create_matchdata(mrb_state *mrb, mrb_value regexp, mrb_value str, int *captures, int ncap)
@@ -1098,6 +1107,7 @@ mrb_mruby_regexp_gem_init(mrb_state *mrb)
   /* compile is defined in Ruby (mrblib) as alias for new */
   mrb_define_class_method(mrb, re, "escape", regexp_escape, MRB_ARGS_REQ(1));
   mrb_define_class_method(mrb, re, "quote", regexp_escape, MRB_ARGS_REQ(1));
+  mrb_define_class_method(mrb, re, "__binary_string?", regexp_binary_string_p, MRB_ARGS_REQ(1));
 
   /* Instance methods */
   mrb_define_method(mrb, re, "match", regexp_match, MRB_ARGS_ARG(1, 1)|MRB_ARGS_BLOCK());

--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -179,8 +179,13 @@ static mrb_int
 re_byte_to_char(mrb_state *mrb, mrb_value str, mrb_int byte_off)
 {
   (void)mrb;
+  if (byte_off < 0) return byte_off;
+
 #ifdef MRB_UTF8_STRING
-  const char *p = RSTRING_PTR(str);
+  struct RString *s = RSTRING(str);
+  if (RSTR_SINGLE_BYTE_P(s) || RSTR_BINARY_P(s)) return byte_off;
+
+  const char *p = RSTR_PTR(s);
   mrb_int chars = 0;
   for (mrb_int i = 0; i < byte_off; i++) {
     if (((unsigned char)p[i] & 0xC0) != 0x80) chars++;
@@ -191,25 +196,33 @@ re_byte_to_char(mrb_state *mrb, mrb_value str, mrb_int byte_off)
   return byte_off;
 #endif
 }
-
-/* Normalize Regexp#match positional argument for the regexp engine. Ruby's
-   pos is a character offset only when MRB_UTF8_STRING is enabled; otherwise
-   it already is a byte offset. Returns -1 for out-of-range offsets, which
-   Ruby treats as no match. */
+/* Normalize Regexp#match positional argument for the regexp engine.
+   For UTF-8 multibyte strings, Ruby's public pos is a character offset and
+   must be converted to a byte offset. For single-byte or binary strings,
+   the public pos is already byte-compatible. Returns -1 for out-of-range
+   offsets, which Ruby treats as no match. */
 static mrb_int
 re_char_to_byte(mrb_state *mrb, mrb_value str, mrb_int char_off)
 {
   (void)mrb;
 #ifdef MRB_UTF8_STRING
-  const char *p = RSTRING_PTR(str);
-  const char *e = p + RSTRING_LEN(str);
-  mrb_int char_len = re_byte_to_char(mrb, str, RSTRING_LEN(str));
+  struct RString *s = RSTRING(str);
+  mrb_int len = RSTR_LEN(s);
+  if (RSTR_SINGLE_BYTE_P(s) || RSTR_BINARY_P(s)) {
+    if (char_off < 0) char_off += len;
+    if (char_off < 0 || char_off > len) return -1;
+    return char_off;
+  }
+
+  const char *p = RSTR_PTR(s);
+  const char *e = p + len;
   mrb_int chars = 0;
 
   if (char_off < 0) {
+    mrb_int char_len = re_byte_to_char(mrb, str, len);
     char_off += char_len;
+    if (char_off < 0) return -1;
   }
-  if (char_off < 0 || char_off > char_len) return -1;
   while (p < e && chars < char_off) {
     p++;
     while (p < e && (((unsigned char)*p & 0xC0) == 0x80)) {
@@ -218,13 +231,19 @@ re_char_to_byte(mrb_state *mrb, mrb_value str, mrb_int char_off)
     chars++;
   }
   if (chars < char_off) return -1;
-  return (mrb_int)(p - RSTRING_PTR(str));
+  return (mrb_int)(p - RSTR_PTR(s));
 #else
   mrb_int len = RSTRING_LEN(str);
   if (char_off < 0) char_off += len;
   if (char_off < 0 || char_off > len) return -1;
   return char_off;
 #endif
+}
+
+static mrb_bool
+re_binary_string_p(mrb_value str)
+{
+  return RSTR_BINARY_P(RSTRING(str));
 }
 
 /* Create MatchData from captures */
@@ -275,7 +294,7 @@ exec_match(mrb_state *mrb, mrb_value self, mrb_value str, mrb_int pos)
   int *captures = (int*)mrb_malloc(mrb, sizeof(int) * cap_size);
   memset(captures, -1, sizeof(int) * cap_size);
   int ncap = mrb_re_exec(mrb, pat, RSTRING_PTR(str), RSTRING_LEN(str), pos,
-                     captures, cap_size);
+                     captures, cap_size, re_binary_string_p(str));
 
   if (ncap == 0) {
     mrb_free(mrb, captures);
@@ -343,7 +362,8 @@ regexp_match_p(mrb_state *mrb, mrb_value self)
   mrb_regexp_pattern *pat = DATA_GET_PTR(mrb, self, &regexp_type, mrb_regexp_pattern);
   if (!pat) mrb_raise(mrb, E_ARGUMENT_ERROR, "uninitialized Regexp");
 
-  int ncap = mrb_re_exec(mrb, pat, RSTRING_PTR(str), RSTRING_LEN(str), pos, NULL, 0);
+  int ncap = mrb_re_exec(mrb, pat, RSTRING_PTR(str), RSTRING_LEN(str), pos, NULL, 0,
+                         re_binary_string_p(str));
   return mrb_bool_value(ncap > 0);
 }
 
@@ -365,7 +385,7 @@ regexp_match_op(mrb_state *mrb, mrb_value self)
   if (mrb_nil_p(md)) return mrb_nil_value();
 
   mrb_match_data *m = DATA_GET_PTR(mrb, md, &matchdata_type, mrb_match_data);
-  return mrb_int_value(mrb, m->captures[0]);
+  return mrb_int_value(mrb, re_byte_to_char(mrb, m->source, m->captures[0]));
 }
 
 /*
@@ -848,6 +868,7 @@ regexp_gsub_str(mrb_state *mrb, mrb_value self)
   const char *rep = RSTRING_PTR(replacement);
   mrb_int rep_len = RSTRING_LEN(replacement);
   mrb_bool need_expand = has_backslash(rep, rep_len);
+  mrb_bool binary = re_binary_string_p(str);
 
   int ncap = pat->num_captures;
   int cap_size = ncap * 2;
@@ -861,7 +882,7 @@ regexp_gsub_str(mrb_state *mrb, mrb_value self)
 
   while (pos <= slen) {
     memset(captures, -1, sizeof(int) * cap_size);
-    int n = mrb_re_exec(mrb, pat, s, slen, pos, captures, cap_size);
+    int n = mrb_re_exec(mrb, pat, s, slen, pos, captures, cap_size, binary);
     if (n == 0) break;
 
     /* save last match for $~ */
@@ -887,7 +908,7 @@ regexp_gsub_str(mrb_state *mrb, mrb_value self)
        the whole character so multibyte text is not split. */
     if (captures[1] == captures[0]) {
       if (captures[1] < slen) {
-        int clen = mrb_re_utf8_charlen(s + captures[1], s + slen);
+        int clen = mrb_re_charlen(s + captures[1], s + slen, binary);
         mrb_str_cat(mrb, result, s + captures[1], clen);
         pos = captures[1] + clen;
       }
@@ -940,7 +961,7 @@ regexp_sub_str(mrb_state *mrb, mrb_value self)
   int *captures = (int*)mrb_malloc(mrb, sizeof(int) * cap_size);
   memset(captures, -1, sizeof(int) * cap_size);
 
-  int n = mrb_re_exec(mrb, pat, s, slen, 0, captures, cap_size);
+  int n = mrb_re_exec(mrb, pat, s, slen, 0, captures, cap_size, re_binary_string_p(str));
   if (n == 0) {
     mrb_free(mrb, captures);
     clear_match_globals(mrb);
@@ -986,6 +1007,7 @@ regexp_scan(mrb_state *mrb, mrb_value self)
 
   const char *s = RSTRING_PTR(str);
   mrb_int slen = RSTRING_LEN(str);
+  mrb_bool binary = re_binary_string_p(str);
   int ncap = pat->num_captures;
   int cap_size = ncap * 2;
   int *captures = (int*)mrb_malloc(mrb, sizeof(int) * cap_size);
@@ -998,7 +1020,7 @@ regexp_scan(mrb_state *mrb, mrb_value self)
 
   while (pos <= slen) {
     memset(captures, -1, sizeof(int) * cap_size);
-    int n = mrb_re_exec(mrb, pat, s, slen, pos, captures, cap_size);
+    int n = mrb_re_exec(mrb, pat, s, slen, pos, captures, cap_size, binary);
     if (n == 0) break;
 
     last_ncap = cap_size;

--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -185,6 +185,9 @@ re_byte_to_char(mrb_state *mrb, mrb_value str, mrb_int byte_off)
   struct RString *s = RSTRING(str);
   if (RSTR_SINGLE_BYTE_P(s) || RSTR_BINARY_P(s)) return byte_off;
 
+  mrb_int len = RSTR_LEN(s);
+  if (byte_off > len) byte_off = len;
+
   const char *p = RSTR_PTR(s);
   mrb_int chars = 0;
   for (mrb_int i = 0; i < byte_off; i++) {
@@ -222,6 +225,9 @@ re_char_to_byte(mrb_state *mrb, mrb_value str, mrb_int char_off)
     mrb_int char_len = re_byte_to_char(mrb, str, len);
     char_off += char_len;
     if (char_off < 0) return -1;
+  }
+  else if (char_off > len) {
+    return -1;
   }
   while (p < e && chars < char_off) {
     p++;

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -54,6 +54,27 @@ assert("Regexp#=~") do
   re = Regexp.new("bc")
   assert_equal 1, re =~ "abcd"
   assert_nil re =~ "xyz"
+  assert_equal __ENCODING__ == "UTF-8" ? 1 : 3, /い/ =~ "あい"
+end
+
+assert("Regexp - dot advances by string mode") do
+  str = "\xC3\xA9x"
+  assert_equal [[0xC3, 0xA9], [0x78]], str.scan(/./).map { |m| m.bytes }
+  assert_equal [0x5A, 0x78], str.sub(/./, "Z").bytes
+  assert_equal "195,120,", str.gsub(/./) { |m| "#{m.bytes[0]}," }
+
+  if Object.const_defined?(:Encoding)
+    bin = str.dup.force_encoding("ASCII-8BIT")
+    md = /x/.match(bin, 2)
+    assert_equal "x", md[0]
+    assert_equal 2, md.begin(0)
+    assert_true /x/.match?(bin, 2)
+    assert_equal 2, /x/ =~ bin
+
+    assert_equal [[0xC3], [0xA9], [0x78]], bin.scan(/./).map { |m| m.bytes }
+    assert_equal [0x5A, 0xA9, 0x78], bin.sub(/./, "Z").bytes
+    assert_equal "195,169,120,", bin.gsub(/./) { |m| "#{m.bytes[0]}," }
+  end
 end
 
 assert("Regexp#=~ - nil argument clears last match") do

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -596,6 +596,11 @@ assert("String#gsub with block and zero-width match") do
     assert_equal "い！ろは", "いろは".gsub(/(?=ろ)/) { "！" }
     assert_equal "！い！ろ！は！", "いろは".gsub(//) { "！" }
   end
+  bin = "\xC3\xA9x".b
+  assert_equal [45, 195, 45, 169, 45, 120, 45], bin.gsub(//, "-").bytes
+  assert_equal [45, 195, 45, 169, 45, 120, 45], bin.gsub(//) { "-" }.bytes
+  assert_equal [45, 195, 45, 169, 45, 120], bin.gsub(/(?=.)/, "-").bytes
+  assert_equal [45, 195, 45, 169, 45, 120], bin.gsub(/(?=.)/) { "-" }.bytes
 end
 
 assert("String#gsub date reformat") do


### PR DESCRIPTION
## Summary

This PR follows up on the review feedback from #6913 and fixes regexp offset conversion and binary string handling in `mruby-regexp`.

The main fixes are:

* Return character offsets from `Regexp#=~` when `MRB_UTF8_STRING` is enabled
* Preserve byte-indexed positions for `ASCII-8BIT` / `BINARY` strings
* Make the regexp engine advance byte-by-byte for forced binary strings
* Preserve the existing UTF-8 regexp character behavior for normal non-binary strings
* Preserve the observable mruby behavior for non-`MRB_UTF8_STRING` builds

## Details

### Return character offsets from `Regexp#=~`

In `MRB_UTF8_STRING` builds, `Regexp#=~` now converts the internal byte offset to a public character offset before returning it.

Without `MRB_UTF8_STRING`, the existing byte-offset behavior is preserved.

### Keep `Regexp#match(str, pos)` semantics unchanged

`Regexp#match(str, pos)` and `Regexp#match?(str, pos)` keep the same public semantics. This PR fixes the internal position conversion so that `ASCII-8BIT` / `BINARY` strings keep byte-indexed `pos` values instead of being converted as UTF-8 character offsets.

Normal non-binary strings in `MRB_UTF8_STRING` builds continue to use character offsets, and non-`MRB_UTF8_STRING` builds continue to use byte offsets.

### Pass binary string state into the regexp engine

`mrb_re_exec` now receives whether the subject string is binary. This allows the regexp engine to choose the correct advancement behavior:

* Normal non-binary strings: advance by UTF-8 regexp character length
* `ASCII-8BIT` / `BINARY` strings: advance by one byte

This applies to regexp execution paths including:

* Pike VM execution
* Backtracking execution
* `.` matching
* Character classes
* lookahead / lookbehind recursion
* zero-width match advancement in `gsub`

Small internal helpers were added to centralize the byte-vs-UTF-8 behavior:

* `mrb_re_charlen`
* `mrb_re_decode_char`
* `mrb_re_utf8_continuation_p`

## Affected behavior

The table below summarizes the effective units used by the affected APIs and regexp behavior.

Bold entries indicate behavior fixed by this PR.

| Method / behavior                      |   No `MRB_UTF8_STRING` | `MRB_UTF8_STRING` normal non-binary strings | `mruby-encoding` + `ASCII-8BIT` / `BINARY` strings |
| -------------------------------------- | ---------------------: | ------------------------------------------: | -------------------------------------------------: |
| `Regexp#=~` return value               |            byte offset |                        ***character offset*** |                                        byte offset |
| `Regexp#match(str, pos)` `pos`         |            byte offset |                            character offset |                                    ***byte offset*** |
| `Regexp#match?(str, pos)` `pos`        |            byte offset |                            character offset |                                    ***byte offset*** |
| `MatchData#begin(n)` / `#end(n)`       |            byte offset |                            character offset |                                        byte offset |
| `.` / character class advancement      | UTF-8 regexp character |                      UTF-8 regexp character |                                           ***byte*** |
| `String#scan(/./)`                     | UTF-8 regexp character |                      UTF-8 regexp character |                                           ***byte*** |
| `String#sub(/./)` / `String#gsub(/./)` | UTF-8 regexp character |                      UTF-8 regexp character |                                           ***byte*** |
| zero-width match advancement           | UTF-8 regexp character |                      UTF-8 regexp character |                                           ***byte*** |

Note that “UTF-8 regexp character” here means the unit used by the regexp engine while matching, such as how far `.` advances. It is different from public character offsets returned by APIs such as `Regexp#=~` or `MatchData#begin`.

For normal non-binary strings, the existing regexp engine behavior is preserved. For example, `\xC3\xA9` continues to be treated as one regexp character by `.`.

For forced `ASCII-8BIT` / `BINARY` strings, regexp matching now advances byte-by-byte.

## CRuby compatibility

Compatibility was checked against CRuby `4.0.4`.

The checked cases include:

* Normal non-binary strings
* Forced `ASCII-8BIT` / `BINARY` strings
* Out-of-range and negative `pos` behavior

In the checked cases, the `mruby-encoding` build now matches CRuby behavior.

Representative examples:

```ruby
s = "\xC3\xA9x"
bin = s.dup.force_encoding("ASCII-8BIT")

s.scan(/./).map(&:bytes)
# => [[195, 169], [120]]

s.sub(/./, "Z").bytes
# => [90, 120]

bin.scan(/./).map(&:bytes)
# => [[195], [169], [120]]

bin.sub(/./, "Z").bytes
# => [90, 169, 120]

/x/.match(bin, 2).begin(0)
# => 2
```

## Tests

Added tests covering three behavior groups:

* Normal non-binary strings and public character offsets
* Non-`MRB_UTF8_STRING` builds and existing byte-offset behavior
* Forced `ASCII-8BIT` / `BINARY` strings and byte-by-byte regexp advancement

## Verification

Successfully across three configurations:

* no `MRB_UTF8_STRING`, no `mruby-encoding`
* `MRB_UTF8_STRING` enabled, no `mruby-encoding`
* `MRB_UTF8_STRING` enabled with `mruby-encoding`
