### PR TITLE
Add new actions runner images to `build.yml`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,8 +20,8 @@ jobs:
           - {os: ubuntu-24.04, cc: clang, cxx: clang++}
           - {os: ubuntu-22.04, cc: gcc, cxx: g++}
           - {os: ubuntu-22.04, cc: clang, cxx: clang++}
+          - {os: macos-26, cc: clang, cxx: clang++}
           - {os: macos-15, cc: clang, cxx: clang++}
-          - {os: macos-14, cc: clang, cxx: clang++}
           - {os: windows-2025, cc: gcc, cxx: g++, altname: "mingw-gcc"}
           - {os: windows-2022, cc: gcc, cxx: g++, altname: "mingw-gcc"}
     env:


### PR DESCRIPTION
Adds macOS 26 and removes macOS 14

https://github.com/actions/runner-images#available-images