### PR TITLE
mruby-task: Introduce timeout_ms keyword to Task::Queue#pop

### DIFF
--- a/mrbgems/mruby-task/include/task.h
+++ b/mrbgems/mruby-task/include/task.h
@@ -39,9 +39,9 @@ struct mrb_task_queue;
  * Memory-optimized layout:
  * - Removed priority_preemption (always equals priority): 1 byte
  * - Removed started flag (inferred from c.status): 1 byte
- * - Unified wakeup_tick/join/mutex into single union: 4 bytes
+ * - Unified wait-specific state into a single union
  * - Removed redundant proc field (stored in c.ci->proc): 8 bytes
- * Total savings: ~18 bytes per task (14% reduction)
+ * Total savings on 32-bit targets: ~14 bytes per task
  */
 typedef struct mrb_task {
   struct mrb_task *next;           /* Linked list pointer */
@@ -56,7 +56,10 @@ typedef struct mrb_task {
     uint32_t wakeup_tick;          /* Tick count to wake up (REASON_SLEEP) */
     const struct mrb_task *join;   /* Task being waited on (REASON_JOIN) */
     void *mutex;                   /* Mutex pointer (REASON_MUTEX, reserved) */
-    struct mrb_task_queue *queue;  /* Queue being waited on (REASON_QUEUE) */
+    struct {
+      struct mrb_task_queue *target;
+      uint32_t wakeup_tick;        /* UINT32_MAX when no timeout */
+    } queue;                       /* Queue wait state (REASON_QUEUE) */
   } wait;
 
   mrb_value self;                  /* Ruby Task object reference */
@@ -65,6 +68,18 @@ typedef struct mrb_task {
 
   struct mrb_context c;            /* Execution context (stack, callinfo, etc) */
 } mrb_task;
+
+/* Normalize a freshly computed wakeup deadline so it can never equal the
+ * UINT32_MAX "no timed wakeup" sentinel used in the wait.wakeup_tick /
+ * wait.queue.wakeup_tick slots. The wrapping tick counter can, once every
+ * 2^32 ticks, produce a real deadline of exactly UINT32_MAX; left as-is the
+ * scheduler would mistake it for "no timeout" and never wake the task. Pulling
+ * it back by one tick removes the collision at a cost of at most one tick. */
+static inline uint32_t
+mrb_task_normalize_wakeup(uint32_t deadline)
+{
+  return deadline == UINT32_MAX ? UINT32_MAX - 1 : deadline;
+}
 
 /*
  * Task queue configuration

--- a/mrbgems/mruby-task/mrblib/queue.rb
+++ b/mrbgems/mruby-task/mrblib/queue.rb
@@ -22,16 +22,20 @@ class Task
     # that a closed-and-empty queue also returns nil, so a nil result does not
     # distinguish "timed out" from "closed" -- this mirrors CRuby's
     # Thread::Queue#pop(timeout:).
+    #
+    # __deadline converts the timeout into a fixed absolute tick once, and
+    # __pop_try compares it against the current tick with wrap-safe arithmetic
+    # in C. Keeping the deadline in C tick space (rather than recomputing a
+    # remaining time in Ruby) avoids the 32-bit wrap-around of Task.tick.
     def pop(non_block = false, timeout_ms: nil)
       unless timeout_ms.nil?
         raise ArgumentError, "timeout cannot be combined with non_block" if non_block
         raise TypeError, "timeout_ms must be an Integer" unless timeout_ms.is_a?(Integer)
         raise ArgumentError, "timeout_ms must be non-negative" if timeout_ms < 0
       end
-      deadline = timeout_ms.nil? ? nil : Task.tick + timeout_ms
+      deadline = timeout_ms.nil? ? nil : __deadline(timeout_ms)
       while true
-        remaining = deadline.nil? ? nil : deadline - Task.tick
-        v = __pop_try(non_block, remaining)
+        v = __pop_try(non_block, deadline)
         return nil if v.equal?(WAIT_TIMEOUT)
         return v unless v.equal?(WAIT_RETRY)
       end

--- a/mrbgems/mruby-task/mrblib/queue.rb
+++ b/mrbgems/mruby-task/mrblib/queue.rb
@@ -18,9 +18,21 @@ class Task
     # exits mrb_vm_exec, handing control back to the scheduler. This task does
     # not run again until a push (or close) moves it back to READY. The loop
     # body therefore executes at most once per wakeup event.
-    def pop(non_block = false)
-      loop do
-        v = __pop_try(non_block)
+    # When timeout_ms is given, pop returns nil once the deadline passes. Note
+    # that a closed-and-empty queue also returns nil, so a nil result does not
+    # distinguish "timed out" from "closed" -- this mirrors CRuby's
+    # Thread::Queue#pop(timeout:).
+    def pop(non_block = false, timeout_ms: nil)
+      unless timeout_ms.nil?
+        raise ArgumentError, "timeout cannot be combined with non_block" if non_block
+        raise TypeError, "timeout_ms must be an Integer" unless timeout_ms.is_a?(Integer)
+        raise ArgumentError, "timeout_ms must be non-negative" if timeout_ms < 0
+      end
+      deadline = timeout_ms.nil? ? nil : Task.tick + timeout_ms
+      while true
+        remaining = deadline.nil? ? nil : deadline - Task.tick
+        v = __pop_try(non_block, remaining)
+        return nil if v.equal?(WAIT_TIMEOUT)
         return v unless v.equal?(WAIT_RETRY)
       end
     end

--- a/mrbgems/mruby-task/ports/glib/task_hal.c
+++ b/mrbgems/mruby-task/ports/glib/task_hal.c
@@ -196,8 +196,11 @@ arm_locked(mrb_task_thread_state *s)
 
     mrb_task *w = vm->task.queues[MRB_TASK_QUEUE_WAITING];
     while (w) {
-      if (w->reason == MRB_TASK_REASON_SLEEP) {
-        uint32_t wake   = w->wait.wakeup_tick;
+      if (w->reason == MRB_TASK_REASON_SLEEP ||
+          (w->reason == MRB_TASK_REASON_QUEUE &&
+           w->wait.queue.wakeup_tick != UINT32_MAX)) {
+        uint32_t wake = w->reason == MRB_TASK_REASON_SLEEP ?
+                        w->wait.wakeup_tick : w->wait.queue.wakeup_tick;
         uint32_t tick   = vm->task.tick;
         int32_t  offset = (int32_t)(wake - tick);
         if (!has_sleep || offset < min_wake_offset) {

--- a/mrbgems/mruby-task/src/task.c
+++ b/mrbgems/mruby-task/src/task.c
@@ -464,17 +464,28 @@ mrb_tick(mrb_state *mrb)
     while (curr != NULL) {
       next = curr->next;
 
+      uint32_t curr_wakeup = UINT32_MAX;
       if (curr->reason == MRB_TASK_REASON_SLEEP) {
-        if ((int32_t)(curr->wait.wakeup_tick - tick_) <= 0) {
+        curr_wakeup = curr->wait.wakeup_tick;
+      }
+      else if (curr->reason == MRB_TASK_REASON_QUEUE) {
+        curr_wakeup = curr->wait.queue.wakeup_tick;
+      }
+
+      if (curr_wakeup != UINT32_MAX) {
+        if ((int32_t)(curr_wakeup - tick_) <= 0) {
           /* Time to wake up */
           mrb_task_q_delete(mrb, curr);
           curr->status = MRB_TASK_STATUS_READY;
           curr->reason = MRB_TASK_REASON_NONE;
+          curr->wait.queue.target = NULL;
+          curr->wait.queue.wakeup_tick = UINT32_MAX;
           mrb_task_q_insert(mrb, curr);
           switching_ = TRUE;
         }
-        else if (curr->wait.wakeup_tick < next_wakeup) {
-          next_wakeup = curr->wait.wakeup_tick;
+        else if (next_wakeup == UINT32_MAX ||
+                 (int32_t)(curr_wakeup - next_wakeup) < 0) {
+          next_wakeup = curr_wakeup;
         }
       }
 
@@ -627,7 +638,7 @@ sleep_us_impl(mrb_state *mrb, uint32_t usec)
   t->status = MRB_TASK_STATUS_WAITING;
   t->reason = MRB_TASK_REASON_SLEEP;
   /* Convert microseconds to ticks (tick unit is in milliseconds) */
-  t->wait.wakeup_tick = tick_ + USEC_TO_TICKS(usec);
+  t->wait.wakeup_tick = mrb_task_normalize_wakeup(tick_ + USEC_TO_TICKS(usec));
 
   /* Update next wakeup time if this task wakes earlier.
    *
@@ -1399,11 +1410,15 @@ resume_task_internal(mrb_state *mrb, mrb_task *t)
    *     mrb_tick, which also rewrites this field. sleep_us_impl
    *     already wraps its update in the IRQ pair; we need the
    *     same here to match the locking discipline. */
-  if (t->reason == MRB_TASK_REASON_SLEEP) {
+  if (t->reason == MRB_TASK_REASON_SLEEP ||
+      (t->reason == MRB_TASK_REASON_QUEUE &&
+       t->wait.queue.wakeup_tick != UINT32_MAX)) {
+    uint32_t task_wakeup = t->reason == MRB_TASK_REASON_SLEEP ?
+                           t->wait.wakeup_tick : t->wait.queue.wakeup_tick;
     mrb_task_disable_irq();
     if (wakeup_tick_ == UINT32_MAX ||
-        (int32_t)(t->wait.wakeup_tick - wakeup_tick_) < 0) {
-      wakeup_tick_ = t->wait.wakeup_tick;
+        (int32_t)(task_wakeup - wakeup_tick_) < 0) {
+      wakeup_tick_ = task_wakeup;
     }
     mrb_task_enable_irq();
   }

--- a/mrbgems/mruby-task/src/task.c
+++ b/mrbgems/mruby-task/src/task.c
@@ -474,12 +474,16 @@ mrb_tick(mrb_state *mrb)
 
       if (curr_wakeup != UINT32_MAX) {
         if ((int32_t)(curr_wakeup - tick_) <= 0) {
-          /* Time to wake up */
+          /* Time to wake up. Only clear the queue-specific wait state when the
+           * task was actually waiting on a queue; for a SLEEP waiter the active
+           * union member is wait.wakeup_tick, not wait.queue. */
           mrb_task_q_delete(mrb, curr);
           curr->status = MRB_TASK_STATUS_READY;
+          if (curr->reason == MRB_TASK_REASON_QUEUE) {
+            curr->wait.queue.target = NULL;
+            curr->wait.queue.wakeup_tick = UINT32_MAX;
+          }
           curr->reason = MRB_TASK_REASON_NONE;
-          curr->wait.queue.target = NULL;
-          curr->wait.queue.wakeup_tick = UINT32_MAX;
           mrb_task_q_insert(mrb, curr);
           switching_ = TRUE;
         }

--- a/mrbgems/mruby-task/src/task_queue.c
+++ b/mrbgems/mruby-task/src/task_queue.c
@@ -25,6 +25,7 @@ static const struct mrb_data_type mrb_task_queue_type = {
 };
 
 static mrb_value wait_retry_;
+static mrb_value wait_timeout_;
 static struct RClass *task_error_class_;
 
 /* Wake the highest-priority task waiting on this queue */
@@ -35,11 +36,12 @@ queue_wake_one_waiter(mrb_state *mrb, mrb_task_queue *q)
   mrb_task *curr = q_waiting_;
   while (curr) {
     mrb_task *next = curr->next;
-    if (curr->reason == MRB_TASK_REASON_QUEUE && curr->wait.queue == q) {
+    if (curr->reason == MRB_TASK_REASON_QUEUE && curr->wait.queue.target == q) {
       mrb_task_q_delete(mrb, curr);
       curr->status = MRB_TASK_STATUS_READY;
       curr->reason = MRB_TASK_REASON_NONE;
-      curr->wait.queue = NULL;
+      curr->wait.queue.target = NULL;
+      curr->wait.queue.wakeup_tick = UINT32_MAX;
       mrb_task_q_insert(mrb, curr);
       switching_ = TRUE;
       break;
@@ -58,11 +60,12 @@ queue_wake_all_waiters(mrb_state *mrb, mrb_task_queue *q)
   mrb_task *curr = q_waiting_;
   while (curr) {
     mrb_task *next = curr->next;
-    if (curr->reason == MRB_TASK_REASON_QUEUE && curr->wait.queue == q) {
+    if (curr->reason == MRB_TASK_REASON_QUEUE && curr->wait.queue.target == q) {
       mrb_task_q_delete(mrb, curr);
       curr->status = MRB_TASK_STATUS_READY;
       curr->reason = MRB_TASK_REASON_NONE;
-      curr->wait.queue = NULL;
+      curr->wait.queue.target = NULL;
+      curr->wait.queue.wakeup_tick = UINT32_MAX;
       mrb_task_q_insert(mrb, curr);
       woke_any = TRUE;
     }
@@ -105,6 +108,7 @@ queue_push(mrb_state *mrb, mrb_value self)
  *   - the item if available
  *   - nil if closed and empty
  *   - raises Task::Error if non_block and empty
+ *   - Task::Queue::WAIT_TIMEOUT sentinel when timeout_ms has elapsed
  *   - Task::Queue::WAIT_RETRY sentinel if the current task was put to WAITING
  *
  * Ruby-level pop loops on WAIT_RETRY.
@@ -113,7 +117,8 @@ static mrb_value
 queue_pop_try(mrb_state *mrb, mrb_value self)
 {
   mrb_bool non_block = FALSE;
-  mrb_get_args(mrb, "|b", &non_block);
+  mrb_value timeout_value = mrb_nil_value();
+  mrb_get_args(mrb, "|bo", &non_block, &timeout_value);
 
   mrb_task_queue *q = (mrb_task_queue*)mrb_data_get_ptr(mrb, self, &mrb_task_queue_type);
   if (!q) mrb_raise(mrb, E_ARGUMENT_ERROR, "invalid queue");
@@ -133,6 +138,27 @@ queue_pop_try(mrb_state *mrb, mrb_value self)
   /* Non-blocking and empty */
   if (non_block) {
     mrb_raise(mrb, task_error_class_, "queue empty");
+  }
+
+  /* Validate/convert the timeout only on the blocking path. The item-available
+   * and closed cases above return early, so a bogus timeout_value is not
+   * inspected there; that is acceptable because the Ruby Queue#pop wrapper
+   * already validates timeout_ms (type and sign) before reaching this point.
+   * These checks are the defensive C-level backstop. */
+  uint32_t timeout_ticks = UINT32_MAX;
+  if (!mrb_nil_p(timeout_value)) {
+    if (!mrb_integer_p(timeout_value)) {
+      mrb_raise(mrb, E_TYPE_ERROR, "timeout_ms must be an Integer");
+    }
+    mrb_int timeout_ms = mrb_integer(timeout_value);
+    if (timeout_ms <= 0) {
+      return wait_timeout_;
+    }
+    uint64_t ticks = ((uint64_t)timeout_ms + MRB_TICK_UNIT - 1) / MRB_TICK_UNIT;
+    if (INT32_MAX < ticks) {
+      mrb_raise(mrb, E_RANGE_ERROR, "timeout_ms is too large");
+    }
+    timeout_ticks = (uint32_t)ticks;
   }
 
   /* Blocking pop only works inside a task */
@@ -157,7 +183,15 @@ queue_pop_try(mrb_state *mrb, mrb_value self)
   mrb_task_q_delete(mrb, current);
   current->status = MRB_TASK_STATUS_WAITING;
   current->reason = MRB_TASK_REASON_QUEUE;
-  current->wait.queue = q;
+  current->wait.queue.target = q;
+  current->wait.queue.wakeup_tick = timeout_ticks == UINT32_MAX ?
+                                    UINT32_MAX :
+                                    mrb_task_normalize_wakeup(tick_ + timeout_ticks);
+  if (current->wait.queue.wakeup_tick != UINT32_MAX &&
+      (wakeup_tick_ == UINT32_MAX ||
+       (int32_t)(current->wait.queue.wakeup_tick - wakeup_tick_) < 0)) {
+    wakeup_tick_ = current->wait.queue.wakeup_tick;
+  }
   mrb_task_q_insert(mrb, current);
   mrb_task_enable_irq();
   switching_ = TRUE;
@@ -217,7 +251,7 @@ queue_num_waiting(mrb_state *mrb, mrb_value self)
   mrb_task_disable_irq();
   mrb_task *curr = q_waiting_;
   while (curr) {
-    if (curr->reason == MRB_TASK_REASON_QUEUE && curr->wait.queue == q) {
+    if (curr->reason == MRB_TASK_REASON_QUEUE && curr->wait.queue.target == q) {
       count++;
     }
     curr = curr->next;
@@ -238,11 +272,13 @@ mrb_init_task_queue(mrb_state *mrb, struct RClass *task_class)
 
   /* Allocate and store WAIT_RETRY sentinel (rooted by the class constant table) */
   wait_retry_ = mrb_obj_new(mrb, mrb->object_class, 0, NULL);
+  wait_timeout_ = mrb_obj_new(mrb, mrb->object_class, 0, NULL);
   mrb_define_const_id(mrb, queue_class, MRB_SYM(WAIT_RETRY), wait_retry_);
+  mrb_define_const_id(mrb, queue_class, MRB_SYM(WAIT_TIMEOUT), wait_timeout_);
 
   mrb_define_method_id(mrb, queue_class, MRB_SYM(initialize),  queue_initialize,  MRB_ARGS_NONE());
   mrb_define_method_id(mrb, queue_class, MRB_SYM(__push),      queue_push,        MRB_ARGS_REQ(1));
-  mrb_define_method_id(mrb, queue_class, MRB_SYM(__pop_try),   queue_pop_try,     MRB_ARGS_OPT(1));
+  mrb_define_method_id(mrb, queue_class, MRB_SYM(__pop_try),   queue_pop_try,     MRB_ARGS_OPT(2));
   mrb_define_method_id(mrb, queue_class, MRB_SYM(size),        queue_size,        MRB_ARGS_NONE());
   mrb_define_method_id(mrb, queue_class, MRB_SYM(length),      queue_size,        MRB_ARGS_NONE());
   mrb_define_method_id(mrb, queue_class, MRB_SYM_Q(empty),     queue_empty_p,     MRB_ARGS_NONE());

--- a/mrbgems/mruby-task/src/task_queue.c
+++ b/mrbgems/mruby-task/src/task_queue.c
@@ -104,21 +104,51 @@ queue_push(mrb_state *mrb, mrb_value self)
 }
 
 /*
- * __pop_try: try to pop one item. Returns:
+ * __deadline: convert a millisecond timeout into an absolute tick deadline.
+ *
+ * The conversion (ceil to ticks, range check, sentinel normalization) is done
+ * once in C and the result is passed back to __pop_try on every retry. Working
+ * in C tick space keeps the comparison wrap-safe (see queue_pop_try) and avoids
+ * the 32-bit wrap-around of Task.tick that a Ruby-side remaining-time
+ * subtraction would suffer. timeout_ms is already validated as a non-negative
+ * Integer by Queue#pop; the checks here are the defensive C-level backstop.
+ */
+static mrb_value
+queue_deadline(mrb_state *mrb, mrb_value self)
+{
+  mrb_int timeout_ms;
+  mrb_get_args(mrb, "i", &timeout_ms);
+  if (timeout_ms < 0) {
+    mrb_raise(mrb, E_ARGUMENT_ERROR, "timeout_ms must be non-negative");
+  }
+
+  uint64_t ticks = ((uint64_t)timeout_ms + MRB_TICK_UNIT - 1) / MRB_TICK_UNIT;
+  if (INT32_MAX < ticks) {
+    mrb_raise(mrb, E_RANGE_ERROR, "timeout_ms is too large");
+  }
+
+  uint32_t deadline = mrb_task_normalize_wakeup(tick_ + (uint32_t)ticks);
+  return mrb_int_value(mrb, (mrb_int)deadline);
+}
+
+/*
+ * __pop_try: try to pop one item. Called as __pop_try(non_block, deadline)
+ * where deadline is an absolute tick (from __deadline) or nil for no timeout.
+ * Returns:
  *   - the item if available
  *   - nil if closed and empty
  *   - raises Task::Error if non_block and empty
- *   - Task::Queue::WAIT_TIMEOUT sentinel when timeout_ms has elapsed
+ *   - Task::Queue::WAIT_TIMEOUT sentinel when the deadline has passed
  *   - Task::Queue::WAIT_RETRY sentinel if the current task was put to WAITING
  *
- * Ruby-level pop loops on WAIT_RETRY.
+ * Ruby-level pop loops on WAIT_RETRY and maps WAIT_TIMEOUT to nil.
  */
 static mrb_value
 queue_pop_try(mrb_state *mrb, mrb_value self)
 {
   mrb_bool non_block = FALSE;
-  mrb_value timeout_value = mrb_nil_value();
-  mrb_get_args(mrb, "|bo", &non_block, &timeout_value);
+  mrb_value deadline_value = mrb_nil_value();
+  mrb_get_args(mrb, "|bo", &non_block, &deadline_value);
 
   mrb_task_queue *q = (mrb_task_queue*)mrb_data_get_ptr(mrb, self, &mrb_task_queue_type);
   if (!q) mrb_raise(mrb, E_ARGUMENT_ERROR, "invalid queue");
@@ -140,25 +170,16 @@ queue_pop_try(mrb_state *mrb, mrb_value self)
     mrb_raise(mrb, task_error_class_, "queue empty");
   }
 
-  /* Validate/convert the timeout only on the blocking path. The item-available
-   * and closed cases above return early, so a bogus timeout_value is not
-   * inspected there; that is acceptable because the Ruby Queue#pop wrapper
-   * already validates timeout_ms (type and sign) before reaching this point.
-   * These checks are the defensive C-level backstop. */
-  uint32_t timeout_ticks = UINT32_MAX;
-  if (!mrb_nil_p(timeout_value)) {
-    if (!mrb_integer_p(timeout_value)) {
-      mrb_raise(mrb, E_TYPE_ERROR, "timeout_ms must be an Integer");
-    }
-    mrb_int timeout_ms = mrb_integer(timeout_value);
-    if (timeout_ms <= 0) {
+  /* Deadline already reached (covers timeout_ms: 0) - give up without parking.
+   * The comparison is wrap-safe: deadline and tick_ are both uint32 tick counts
+   * and (int32_t)(deadline - tick_) stays correct across the tick wrap. */
+  mrb_bool has_deadline = !mrb_nil_p(deadline_value);
+  uint32_t deadline = 0;
+  if (has_deadline) {
+    deadline = (uint32_t)mrb_integer(deadline_value);
+    if ((int32_t)(deadline - tick_) <= 0) {
       return wait_timeout_;
     }
-    uint64_t ticks = ((uint64_t)timeout_ms + MRB_TICK_UNIT - 1) / MRB_TICK_UNIT;
-    if (INT32_MAX < ticks) {
-      mrb_raise(mrb, E_RANGE_ERROR, "timeout_ms is too large");
-    }
-    timeout_ticks = (uint32_t)ticks;
   }
 
   /* Blocking pop only works inside a task */
@@ -184,13 +205,11 @@ queue_pop_try(mrb_state *mrb, mrb_value self)
   current->status = MRB_TASK_STATUS_WAITING;
   current->reason = MRB_TASK_REASON_QUEUE;
   current->wait.queue.target = q;
-  current->wait.queue.wakeup_tick = timeout_ticks == UINT32_MAX ?
-                                    UINT32_MAX :
-                                    mrb_task_normalize_wakeup(tick_ + timeout_ticks);
-  if (current->wait.queue.wakeup_tick != UINT32_MAX &&
+  current->wait.queue.wakeup_tick = has_deadline ? deadline : UINT32_MAX;
+  if (has_deadline &&
       (wakeup_tick_ == UINT32_MAX ||
-       (int32_t)(current->wait.queue.wakeup_tick - wakeup_tick_) < 0)) {
-    wakeup_tick_ = current->wait.queue.wakeup_tick;
+       (int32_t)(deadline - wakeup_tick_) < 0)) {
+    wakeup_tick_ = deadline;
   }
   mrb_task_q_insert(mrb, current);
   mrb_task_enable_irq();
@@ -279,6 +298,7 @@ mrb_init_task_queue(mrb_state *mrb, struct RClass *task_class)
   mrb_define_method_id(mrb, queue_class, MRB_SYM(initialize),  queue_initialize,  MRB_ARGS_NONE());
   mrb_define_method_id(mrb, queue_class, MRB_SYM(__push),      queue_push,        MRB_ARGS_REQ(1));
   mrb_define_method_id(mrb, queue_class, MRB_SYM(__pop_try),   queue_pop_try,     MRB_ARGS_OPT(2));
+  mrb_define_method_id(mrb, queue_class, MRB_SYM(__deadline),  queue_deadline,    MRB_ARGS_REQ(1));
   mrb_define_method_id(mrb, queue_class, MRB_SYM(size),        queue_size,        MRB_ARGS_NONE());
   mrb_define_method_id(mrb, queue_class, MRB_SYM(length),      queue_size,        MRB_ARGS_NONE());
   mrb_define_method_id(mrb, queue_class, MRB_SYM_Q(empty),     queue_empty_p,     MRB_ARGS_NONE());

--- a/mrbgems/mruby-task/test/queue.rb
+++ b/mrbgems/mruby-task/test/queue.rb
@@ -161,3 +161,41 @@ assert("Task::Queue num_waiting reflects blocked task count") do
 
   assert_equal [1], counts
 end
+
+assert("Task::Queue pop returns nil after timeout") do
+  q = Task::Queue.new
+  result = :unset
+
+  Task.new { result = q.pop(timeout_ms: 8) }
+  Task.run
+
+  assert_nil result
+end
+
+assert("Task::Queue pop wakes on push before timeout") do
+  q = Task::Queue.new
+  result = nil
+
+  Task.new { result = q.pop(timeout_ms: 100) }
+  Task.new do
+    sleep_ms 4
+    q.push(:ready)
+  end
+  Task.run
+
+  assert_equal :ready, result
+end
+
+assert("Task::Queue pop with zero timeout still returns an available item") do
+  q = Task::Queue.new
+  q.push(:ready)
+  assert_equal :ready, q.pop(timeout_ms: 0)
+  assert_nil q.pop(timeout_ms: 0)
+end
+
+assert("Task::Queue timeout validates arguments") do
+  q = Task::Queue.new
+  assert_raise(TypeError) { q.pop(timeout_ms: 1.0) }
+  assert_raise(ArgumentError) { q.pop(timeout_ms: -1) }
+  assert_raise(ArgumentError) { q.pop(true, timeout_ms: 1) }
+end


### PR DESCRIPTION
This patch introduces `timeout_ms:` keyword to `Task::Queue#pop`, mirroring `Thread::Queue.pop(timeout:)` in CRuby. `timeout_ms` is preferable to `timeout:` in embedded systems