### PR TITLE
hash: add `Hash#except`

### DIFF
--- a/mrbgems/mruby-hash-ext/mrblib/hash.rb
+++ b/mrbgems/mruby-hash-ext/mrblib/hash.rb
@@ -403,6 +403,26 @@ class Hash
     end
   end
 
+  ##
+  # call-seq:
+  #   hsh.except(:key) -> hsh
+  #
+  # Returns a copy of `self` that excludes entries
+  # for the given `keys`; any `keys` that are not
+  # found are ignored:
+  #
+  #   h = {foo: 0, bar: 1, baz: 2} # => {foo: 0, bar: 1, baz: 2}
+  #   h.except(:baz, :foo)         # => {bar: 1}
+  #   h.except(:bar, :nosuch)      # => {foo: 0, baz: 2}
+  def except(*keys)
+    hsh = {}
+    each do |k,v|
+      next if keys.include?(k)
+      hsh[k] = v
+    end
+    hsh
+  end
+
   alias filter select
   alias filter! select!
 end

--- a/mrbgems/mruby-hash-ext/test/hash.rb
+++ b/mrbgems/mruby-hash-ext/test/hash.rb
@@ -315,3 +315,28 @@ assert("Hash#except") do
   assert_equal({:a=>100}, h.except(:b, :c, :d))
   assert_equal(h, h.except)
 end
+
+assert('Hash#except') do
+  ##
+  # Without arguments
+  h = {foo: 0, bar: 1, baz: 2}
+  assert_equal(h, h.except)
+  assert_not_same(h, h.except)
+
+  ##
+  # With arguments
+  h = {foo: 0, bar: 1, baz: 2}
+  assert_equal({bar: 1}, h.except(:baz, :foo))
+  assert_equal({foo: 0, baz: 2}, h.except(:bar, :nosuch))
+
+  ##
+  # Subclass does not carry over
+  h = Class.new(Hash).new
+  assert_equal(Hash, h.except.class)
+
+  ##
+  # Default does not carry over
+  h = {foo: 0, bar: 1, baz: 2}
+  h.default = 42
+  assert_equal(nil, h.except.default)
+end


### PR DESCRIPTION
This commit increases compatibility with CRuby
by implementing the `Hash#except` method.

The CRuby version is implemented in C and the
mruby version is implemented in Ruby.

Both implementations have similar behavior:

* A duplicate Hash is returned without the given keys
* The duplicate Hash does not inherit the default of its parent
* The duplicate Hash does not inherit the class of its parent