### PR TITLE
fix(task): self-termination now triggers context switch

### DIFF
--- a/mrbgems/mruby-task/src/task.c
+++ b/mrbgems/mruby-task/src/task.c
@@ -1450,6 +1450,8 @@ terminate_task_internal(mrb_state *mrb, mrb_task *t)
 {
   if (t->status == MRB_TASK_STATUS_DORMANT) return;
 
+  mrb_bool was_running = (t->status == MRB_TASK_STATUS_RUNNING);
+
   mrb_task_disable_irq();
   mrb_task_q_delete(mrb, t);
   t->status = MRB_TASK_STATUS_DORMANT;
@@ -1460,7 +1462,7 @@ terminate_task_internal(mrb_state *mrb, mrb_task *t)
   wake_up_join_waiters(mrb, t);
 
   /* If terminating self, trigger context switch */
-  if (t == q_ready_) {
+  if (was_running) {
     switching_ = TRUE;
   }
 }

--- a/mrbgems/mruby-task/test/task.rb
+++ b/mrbgems/mruby-task/test/task.rb
@@ -208,3 +208,22 @@ assert("Task#value returns exception object for unhandled task errors") do
   assert_kind_of RuntimeError, result
   assert_equal "boom", result.message
 end
+
+assert("Task#terminate on self triggers context switch to next task") do
+  order = []
+
+  Task.new(priority: 50) do
+    order << :a_start
+    Task.current.terminate  # self-terminate - must switch away
+    order << :a_zombie      # should never execute
+  end
+
+  Task.new(priority: 100) do
+    order << :b_runs
+  end
+
+  Task.run
+
+  assert_equal [:a_start, :b_runs], order
+  assert_false order.include?(:a_zombie)
+end


### PR DESCRIPTION
terminate_task_internal() moved the task to the dormant queue before checking `t == q_ready_` for the context-switch decision. Since the task was already removed from the ready queue, the comparison was always false, leaving a self-terminated task running as a zombie until the next natural exit point.

Capture `was_running` before the queue transition and use it for the switch decision.

Part of #6922 (see issue for a related sleep()-suspends-wrong-task bug, filed as a separate PR).