### PR TITLE
fix(task): sleep() no-arg suspends calling task, not queue head

### DIFF
--- a/mrbgems/mruby-task/src/task.c
+++ b/mrbgems/mruby-task/src/task.c
@@ -679,15 +679,17 @@ mrb_f_sleep(mrb_state *mrb, mrb_value self)
 
   if (n == 0) {
     /* No argument - suspend indefinitely */
-    mrb_task *t = q_ready_;
-    if (t) {
-      mrb_task_disable_irq();
-      mrb_task_q_delete(mrb, t);
-      t->status = MRB_TASK_STATUS_SUSPENDED;
-      mrb_task_q_insert(mrb, t);
-      mrb_task_enable_irq();
-      switching_ = TRUE;
+    if (mrb->c == mrb->root_c) {
+      /* Root context has no task to suspend */
+      return mrb_nil_value();
     }
+    mrb_task *t = MRB2TASK(mrb);
+    mrb_task_disable_irq();
+    mrb_task_q_delete(mrb, t);
+    t->status = MRB_TASK_STATUS_SUSPENDED;
+    mrb_task_q_insert(mrb, t);
+    mrb_task_enable_irq();
+    switching_ = TRUE;
     return mrb_nil_value();
   }
 

--- a/mrbgems/mruby-task/src/task.c
+++ b/mrbgems/mruby-task/src/task.c
@@ -683,6 +683,12 @@ mrb_f_sleep(mrb_state *mrb, mrb_value self)
       /* Root context has no task to suspend */
       return mrb_nil_value();
     }
+    mrb_callinfo *ci;
+    for (ci = mrb->c->ci; ci >= mrb->c->cibase; ci--) {
+      if (ci->cci > 0) {
+        mrb_raise(mrb, E_RUNTIME_ERROR, "can't sleep across C function boundary");
+      }
+    }
     mrb_task *t = MRB2TASK(mrb);
     mrb_task_disable_irq();
     mrb_task_q_delete(mrb, t);

--- a/mrbgems/mruby-task/test/task.rb
+++ b/mrbgems/mruby-task/test/task.rb
@@ -208,3 +208,24 @@ assert("Task#value returns exception object for unhandled task errors") do
   assert_kind_of RuntimeError, result
   assert_equal "boom", result.message
 end
+
+assert("sleep() no-arg suspends the calling task, not another") do
+  order = []
+
+  # high-priority task (runs first) - calls sleep() to suspend itself
+  high = Task.new(priority: 50) do
+    order << :high_start
+    sleep                 # should suspend THIS task, not low
+    order << :high_resume
+  end
+
+  # low-priority task - should keep running after high suspends
+  low = Task.new(priority: 200) do
+    order << :low_runs
+    high.resume           # wake high back up
+  end
+
+  Task.run
+
+  assert_equal [:high_start, :low_runs, :high_resume], order
+end


### PR DESCRIPTION
mrb_f_sleep() with no arguments used q_ready_ (the head of the ready queue) instead of the currently running task. When a lower-priority task called sleep(), the highest-priority ready task was incorrectly suspended instead.

Use MRB2TASK(mrb) to obtain the running task via pointer arithmetic, matching the pattern used by sleep_us_impl() and Task.pass. Also handle root-context calls which have no task to suspend.

Part of #6922.