### PR TITLE
gc.c: Add gc->collecting flag and gc_drive()

### DIFF
--- a/include/mruby/gc.h
+++ b/include/mruby/gc.h
@@ -56,6 +56,8 @@ typedef struct mrb_gc {
   mrb_bool generational  :1;       /* generational GC mode */
   mrb_bool full          :1;       /* major GC mode */
   mrb_bool out_of_memory :1;       /* out-of-memory error occurred */
+  mrb_bool collecting    :1;       /* mark/sweep engine is on the stack;
+                                      suppresses reentrant emergency GC */
   size_t step_limit;               /* 0=unlimited, >0=absolute step cap */
   size_t malloc_increase;          /* malloc bytes since last GC cycle */
   size_t malloc_threshold;         /* 0=disabled, >0=bytes to trigger GC */

--- a/src/gc.c
+++ b/src/gc.c
@@ -1354,7 +1354,7 @@ run_incremental(mrb_state *mrb, mrb_gc *gc, size_t limit, mrb_bool run_to_root)
 
   if (run_to_root) {
     do {
-      incremental_gc(mrb, gc, limit);
+      result += incremental_gc(mrb, gc, limit);
     } while (gc->state != MRB_GC_STATE_ROOT);
   }
   else {

--- a/src/gc.c
+++ b/src/gc.c
@@ -208,6 +208,8 @@ mrb_static_assert(MRB_GC_RED <= GC_COLOR_MASK);
 
 mrb_noreturn void mrb_raise_nomemory(mrb_state *mrb);
 
+static void incremental_gc_finish(mrb_state *mrb, mrb_gc *gc);
+
 MRB_API void*
 mrb_realloc_simple(mrb_state *mrb, void *p,  size_t len)
 {
@@ -219,8 +221,24 @@ mrb_realloc_simple(mrb_state *mrb, void *p,  size_t len)
   }
 #endif
   p2 = mrb_basic_alloc_func(p, len);
-  if (!p2 && len > 0 && mrb->gc.heaps && mrb->gc.state != MRB_GC_STATE_SWEEP) {
-    mrb_full_gc(mrb);
+  if (!p2 && len > 0 && mrb->gc.heaps && !mrb->gc.collecting) {
+    /* collecting == FALSE means no mark/sweep is running on the stack, so
+       this failure is a mutator allocation, not one from inside the GC
+       engine (e.g. an RData dfree during sweep). Recovery runs only here; a
+       reentrant failure falls through to raise NoMemoryError as before.
+       gc_drive() sets collecting. */
+    if (mrb->gc.state == MRB_GC_STATE_SWEEP) {
+      /* Mid-sweep: starting a new mark cycle here is unsafe, but finishing
+         the in-progress sweep is safe and is exactly what reclaims memory.
+         Without this an allocation failure while parked in SWEEP raised
+         NoMemoryError even though free slots were about to be produced. */
+      if (!mrb->gc.disabled && !mrb->gc.iterating) {
+        incremental_gc_finish(mrb, &mrb->gc);
+      }
+    }
+    else {
+      mrb_full_gc(mrb);
+    }
     p2 = mrb_basic_alloc_func(p, len);
   }
 
@@ -1326,29 +1344,95 @@ incremental_gc(mrb_state *mrb, mrb_gc *gc, size_t limit)
   }
 }
 
+/* The bare engine loop. With run_to_root, drives a whole cycle to
+   MRB_GC_STATE_ROOT; otherwise advances one step bounded by `limit`.
+   Returns the work done. */
+static size_t
+run_incremental(mrb_state *mrb, mrb_gc *gc, size_t limit, mrb_bool run_to_root)
+{
+  size_t result = 0;
+
+  if (run_to_root) {
+    do {
+      incremental_gc(mrb, gc, limit);
+    } while (gc->state != MRB_GC_STATE_ROOT);
+  }
+  else {
+    while (result < limit) {
+      result += incremental_gc(mrb, gc, limit);
+      if (gc->state == MRB_GC_STATE_ROOT)
+        break;
+    }
+  }
+  return result;
+}
+
+/* Drive the incremental collector with the reentrancy guard held.
+ *
+ * gc->collecting marks that a mark/sweep is running on the C stack. While it
+ * is set, the emergency GC in mrb_realloc_simple is suppressed, so an
+ * allocation failure raised from *inside* sweep (e.g. an RData dfree that
+ * allocates) cannot recursively re-drive the same sweep -- which would
+ * corrupt the page-list walk and could overflow the stack.
+ *
+ * Every path that can sweep funnels through this helper (incremental_gc is
+ * only ever called from here), so all callers -- mrb_incremental_gc,
+ * mrb_full_gc, clear_all_old, change_gen_gc_mode and the emergency path --
+ * are covered without each having to manage the flag.
+ *
+ * When an outer jmp buffer exists, wrap the run in MRB_TRY/MRB_CATCH so the
+ * flag is restored on both normal return and a longjmp out of a dfree (so it
+ * can never leak and permanently wedge emergency GC), then rethrow. When
+ * there is no outer handler (mrb->jmp == NULL, e.g. GC invoked from embedder
+ * C code), do NOT install a temporary handler: a raise then follows mruby's
+ * normal uncaught path (report and abort) instead of longjmp'ing to a NULL
+ * buffer -- and since that aborts the process, the unrestored flag is moot.
+ */
+static size_t
+gc_drive(mrb_state *mrb, mrb_gc *gc, size_t limit, mrb_bool run_to_root)
+{
+  mrb_bool was_collecting = gc->collecting;
+  size_t result = 0;
+
+  gc->collecting = TRUE;
+
+  if (mrb->jmp) {
+    struct mrb_jmpbuf *prev_jmp = mrb->jmp;
+    struct mrb_jmpbuf c_jmp;
+
+    MRB_TRY(&c_jmp) {
+      mrb->jmp = &c_jmp;
+      result = run_incremental(mrb, gc, limit, run_to_root);
+      mrb->jmp = prev_jmp;
+      gc->collecting = was_collecting;
+    } MRB_CATCH(&c_jmp) {
+      gc->collecting = was_collecting;
+      mrb->jmp = prev_jmp;
+      MRB_THROW(prev_jmp);
+    } MRB_END_EXC(&c_jmp);
+  }
+  else {
+    result = run_incremental(mrb, gc, limit, run_to_root);
+    gc->collecting = was_collecting;
+  }
+
+  return result;
+}
+
 static void
 incremental_gc_finish(mrb_state *mrb, mrb_gc *gc)
 {
-  do {
-    incremental_gc(mrb, gc, SIZE_MAX);
-  } while (gc->state != MRB_GC_STATE_ROOT);
+  gc_drive(mrb, gc, SIZE_MAX, TRUE);
 }
 
 static void
 incremental_gc_step(mrb_state *mrb, mrb_gc *gc)
 {
-  size_t limit = 0, result = 0;
-  limit = (GC_STEP_SIZE/100) * gc->step_ratio;
+  size_t limit = (GC_STEP_SIZE/100) * gc->step_ratio;
   if (gc->step_limit > 0 && limit > gc->step_limit) {
     limit = gc->step_limit;
   }
-  while (result < limit) {
-    result += incremental_gc(mrb, gc, limit);
-    if (gc->state == MRB_GC_STATE_ROOT)
-      break;
-  }
-
-  gc->gc_debt -= (mrb_int)result;
+  gc->gc_debt -= (mrb_int)gc_drive(mrb, gc, limit, FALSE);
 }
 
 static void


### PR DESCRIPTION
## Background

`mrb_realloc_simple()` only attempted the emergency full GC when the collector was not in `MRB_GC_STATE_SWEEP`, so an allocation failure raised while the collector was parked in SWEEP raised NoMemoryError without any recovery attempt --- even though completing the sweep is exactly what frees memory.

Firstly, I wanted to fix this small bug, but the resulting patch ended up adding a `gc->collecting` flag and a `gc_drive()` function.

## Fix

### Introduce `gc->collecting` flag

Starting a new mark cycle mid-sweep is unsafe, which is why the emergency path in `mrb_realloc_simple()` skipped SWEEP entirely, but finishing the in-progress sweep is basically safe.

At the same time, `state != SWEEP` test also doubled as a reentrancy guard: it kept an allocation failure raised from *inside* a running sweep (e.g., an RData dfree that allocates) from recursively re-driving the same sweep, which would corrupt the page-list walk and could overflow the stack. Restore that protection with a `gc->collecting` flag that marks the mark/sweep engine as being on the stack; emergency recovery runs only when it is clear.

### Introduce `gc_drive()`

The collecting flag is managed in one place --- `gc_drive()`: the sole caller of `incremental_gc()` and the common lower layer of `incremental_gc_finish()` and `incremental_gc_step()`. Every sweeping path (mrb_incremental_gc, mrb_full_gc, clear_all_old, change_gen_gc_mode, and the emergency path) funnels through it, so none has to manage the flag itself.

`gc_drive()` restores the flag on both normal return and a longjmp out of a dfree, so it can never leak and permanently wedge emergency GC:

- With an outer jmp buffer, it wraps the run in MRB_TRY/MRB_CATCH and rethrows after restoring.
- With no outer handler (mrb->jmp == NULL, e.g. GC called straight from embedder C code), it installs no temporary handler, so a raise follows mruby's normal uncaught path (report and abort) rather than longjmp'ing to a NULL buffer; the process aborts, so the unrestored flag is moot.

Non-SWEEP, non-reentrant behavior is unchanged.