### PR TITLE
 vm.c: defer pending task switch while an exception is in flight

### DIFF
--- a/mrbgems/mruby-task/test/task.rb
+++ b/mrbgems/mruby-task/test/task.rb
@@ -248,3 +248,44 @@ assert("sleep() no-arg suspends the calling task, not another") do
 
   assert_equal [:high_start, :low_runs, :high_resume], order
 end
+
+assert("exception raised from C after blocking past the timeslice is rescuable") do
+  # TaskTest.block_then_raise busy-blocks longer than a timeslice before
+  # raising, so task.switching is pending when the exception dispatches.
+  # A pending switch must not preempt the catch-handler dispatch: honoring
+  # it between catch_handler_find and OP_EXCEPT swallowed the exception
+  # into the task result, and the rescue below saw nothing.
+  result = nil
+
+  Task.new do
+    result =
+      begin
+        TaskTest.block_then_raise(50)
+        :not_raised
+      rescue RuntimeError => e
+        "caught #{e.message}"
+      end
+  end
+
+  Task.run
+
+  assert_equal "caught raised after blocking", result
+end
+
+assert("exception raised from C after blocking is not leaked into Task#value") do
+  child = nil
+
+  Task.new do
+    child = Task.new do
+      begin
+        TaskTest.block_then_raise(50)
+      rescue RuntimeError
+        :rescued
+      end
+    end
+  end
+
+  Task.run
+
+  assert_equal :rescued, child.value
+end

--- a/mrbgems/mruby-task/test/tasktest.c
+++ b/mrbgems/mruby-task/test/tasktest.c
@@ -1,0 +1,29 @@
+#include <time.h>
+#include <mruby.h>
+#include <mruby/class.h>
+
+/* Burn CPU until `ms` milliseconds of CPU time have elapsed, then raise.
+   Blocking longer than MRB_TICK_UNIT * MRB_TIMESLICE_TICK_COUNT guarantees
+   the tick handler has expired the running task's timeslice, so
+   mrb->task.switching is pending when mrb_raise unwinds into the VM's
+   catch-handler dispatch — the window where a pending switch used to
+   swallow a handled exception into the task result. */
+static mrb_value
+tasktest_block_then_raise(mrb_state *mrb, mrb_value self)
+{
+  mrb_int ms;
+  mrb_get_args(mrb, "i", &ms);
+  clock_t end = clock() + (clock_t)(((double)ms / 1000.0) * (double)CLOCKS_PER_SEC);
+  while (clock() < end) {
+    /* busy-wait; ticks keep firing */
+  }
+  mrb_raise(mrb, E_RUNTIME_ERROR, "raised after blocking");
+  return mrb_nil_value(); /* not reached */
+}
+
+void
+mrb_mruby_task_gem_test(mrb_state* mrb)
+{
+  struct RClass *tasktest = mrb_define_module(mrb, "TaskTest");
+  mrb_define_module_function(mrb, tasktest, "block_then_raise", tasktest_block_then_raise, MRB_ARGS_REQ(1));
+}

--- a/src/vm.c
+++ b/src/vm.c
@@ -1631,6 +1631,21 @@ task_across_c_boundary(mrb_state *mrb)
    executing across a C call boundary (see task_across_c_boundary). A
    pending MRB_TASK_STOPPED is not deferred, since the task is going away.
 
+   A pending switch is likewise deferred while an exception is in flight
+   (mrb->exc set). The L_RAISE handler-found path repoints ci->pc at the
+   catch handler and falls into NEXT; honoring the switch there returns
+   early BEFORE OP_EXCEPT consumes the exception, so the scheduler's
+   execute_task_vm mistakes the already-handled exception for an
+   unhandled one, captures it as the task result and clears mrb->exc —
+   the resumed task then runs the rescue with no exception pending and
+   the begin block silently evaluates to nil. Observed in the field as a
+   C extension's mrb_raise being un-rescuable whenever it fires after a
+   long-blocking call (the timeslice always expires mid-call, so
+   task.switching is always pending at raise time). The same window
+   covers break/ensure unwinding, which carries RBreak in mrb->exc
+   across NEXT. Deferral is bounded: the handler's first instruction
+   consumes mrb->exc, so the switch happens one instruction later.
+
    mrb->jmp is restored to prev_jmp before returning, exactly as the
    normal return paths below do. mrb_vm_exec set mrb->jmp to its own
    stack-local c_jmp on entry; leaving it dangling after this early return
@@ -1649,6 +1664,7 @@ task_across_c_boundary(mrb_state *mrb)
    inside mrb_vm_exec (via NEXT / END_DISPATCH). */
 #define RETURN_IF_TASK_STOPPED(mrb) do { \
   if (((mrb)->task.switching && (mrb)->c != (mrb)->root_c && \
+       !(mrb)->exc && \
        !(mrb)->gc.iterating && !task_across_c_boundary(mrb)) || \
       (mrb)->c->status == MRB_TASK_STOPPED) { \
     (mrb)->jmp = prev_jmp; \


### PR DESCRIPTION
### Symptom

With `MRB_USE_TASK_SCHEDULER`, an exception raised by a C extension
function is silently **un-rescuable** whenever the function blocked
longer than one timeslice before raising: an enclosing `begin/rescue`
never runs, no error is reported, and the whole `begin...end`
expression evaluates to `nil`. The exception object instead leaks into
`Task#value` as if it had been unhandled.

Real-world instance: PicoRuby's `CYW43.connect_timeout` (Raspberry Pi
Pico W WiFi join, blocks up to its timeout, then raises on failure).
Its documented `rescue Network::ConnectTimeout` retry pattern can never
fire — every failure path that blocks first is affected, and the
timeslice reliably expires during any blocking call, so this is
deterministic, not a race.

### Mechanism

1. A task's timeslice expires during the blocking C call — `mrb_tick`
   sets `mrb->task.switching`.
2. The C function returns into `mrb_raise` → `MRB_THROW` → the VM's
   `L_RAISE` path finds the catch handler, sets
   `ci->pc = irep->iseq + handler`, and falls into `NEXT`.
3. `NEXT` expands `RETURN_IF_TASK_STOPPED`, which honors the pending
   switch and early-returns from `mrb_vm_exec` — **before `OP_EXCEPT`
   has consumed `mrb->exc`**.
4. The scheduler's `execute_task_vm` sees `mrb->exc` set after
   `mrb_vm_exec` returned and takes the unhandled-exception path:
   captures the (already handled!) exception into `t->result` and
   clears `mrb->exc`.
5. The task later resumes at the rescue handler's pc with no exception
   pending: `OP_EXCEPT` loads nil, the rescue clause matches nothing,
   and the begin block completes with nil.

The same window covers break/ensure unwinding, which carries `RBreak`
through `mrb->exc` across `NEXT` (`L_CATCH_TAGGED_BREAK`).

### Fix

Defer the switch while `mrb->exc` is set (one condition added to
`RETURN_IF_TASK_STOPPED`). The deferral is bounded: the catch handler's
first instruction consumes `mrb->exc`, so the switch happens one
instruction later. The `MRB_TASK_STOPPED` clause is deliberately
unchanged — a task killed mid-raise still terminates immediately, and
capturing the in-flight exception as its result is the intended
semantics there.

This is the same family as the guards already accumulated on this
early-return (gc.iterating for #6862, C call boundaries for #6864/#6868,
dangling jmp for #6863, root context for #6887): one more state in
which the early return must not preempt the VM.

### Tests

`test/tasktest.c` adds `TaskTest.block_then_raise(ms)`: busy-blocks
past the timeslice (50 ms vs. the 12 ms default) and then raises —
deterministically reproducing the window on any HAL. Two asserts:
rescue-ability inside the task, and `Task#value` not receiving the
handled exception.

Verified: [host] mrbtest, POSIX HAL — both tests fail before the fix,
pass after; full suite green (1904/1904, 0 crash). [hardware] RP2350
(Pico 2 W), the originating WiFi scenario — `rescue` now catches
`CYW43::ConnectTimeout` (12/12 iterations, was 0/12).