### PR TITLE
mruby-task: survive OOM during task context initialization

### DIFF
--- a/mrbgems/mruby-task/src/task.c
+++ b/mrbgems/mruby-task/src/task.c
@@ -259,7 +259,14 @@ task_init_context(mrb_state *mrb, mrb_task *t, const struct RProc *proc)
   if (stbase == NULL || cibase == NULL) {
     mrb_free(mrb, stbase);
     mrb_free(mrb, cibase);
-    t->status = MRB_TASK_STATUS_DORMANT;
+    /* Mark only the CONTEXT as stopped. t->status must keep its
+     * current value: q_get_queue() derives a task's queue from
+     * t->status, so flipping it to DORMANT while the task is still
+     * linked in another queue would make every later q_delete search
+     * the wrong list (task_cleanup_if_stopped would then spin on an
+     * unremovable queue head). The scheduler's existing safety nets
+     * see c->status == MRB_TASK_STOPPED, unlink the task from its
+     * true queue, and transition it to DORMANT coherently. */
     c->status = MRB_TASK_STOPPED;
     mrb_exc_raise(mrb, mrb_obj_value(mrb->nomem_err));
   }

--- a/mrbgems/mruby-task/src/task.c
+++ b/mrbgems/mruby-task/src/task.c
@@ -248,7 +248,22 @@ task_init_context(mrb_state *mrb, mrb_task *t, const struct RProc *proc)
   if (proc->body.irep->nregs > slen) {
     slen += proc->body.irep->nregs;
   }
-  c->stbase = (mrb_value*)mrb_malloc(mrb, slen * sizeof(mrb_value));
+
+  /* Allocate both buffers atomically: mrb_malloc() raises on OOM via
+   * longjmp, which would leave a half-built context (ci == NULL) on a
+   * task that is still queued — the scheduler then dereferences it.
+   * Allocate with the non-raising variant, and on failure retire the
+   * task coherently BEFORE raising NoMemoryError. */
+  mrb_value *stbase = (mrb_value*)mrb_malloc_simple(mrb, slen * sizeof(mrb_value));
+  mrb_callinfo *cibase = (mrb_callinfo*)mrb_malloc_simple(mrb, TASK_CI_INIT_SIZE * sizeof(mrb_callinfo));
+  if (stbase == NULL || cibase == NULL) {
+    mrb_free(mrb, stbase);
+    mrb_free(mrb, cibase);
+    t->status = MRB_TASK_STATUS_DORMANT;
+    c->status = MRB_TASK_STOPPED;
+    mrb_exc_raise(mrb, mrb_obj_value(mrb->nomem_err));
+  }
+  c->stbase = stbase;
   c->stend = c->stbase + slen;
 
   /* Initialize stack values to nil */
@@ -264,9 +279,9 @@ task_init_context(mrb_state *mrb, mrb_task *t, const struct RProc *proc)
   /* Set receiver to top self */
   c->stbase[0] = mrb_top_self(mrb);
 
-  /* Initialize callinfo stack */
+  /* Initialize callinfo stack (allocated above) */
   static const mrb_callinfo ci_zero = { 0 };
-  c->cibase = (mrb_callinfo*)mrb_malloc(mrb, TASK_CI_INIT_SIZE * sizeof(mrb_callinfo));
+  c->cibase = cibase;
   c->ciend = c->cibase + TASK_CI_INIT_SIZE;
   c->ci = c->cibase;
   c->cibase[0] = ci_zero;
@@ -353,6 +368,21 @@ execute_task(mrb_state *mrb, mrb_task *t)
   mrb_callinfo *prev_ci;
   uint8_t prev_cci;
 
+  /* A task can lose its context without leaving the queues: OOM during
+   * task_init_context unwinds via longjmp before the context is built
+   * (ci == NULL). Retire such a task instead of dereferencing the hole
+   * — checked BEFORE the context switch so the scheduler's own context
+   * stays usable. */
+  if (t->c.ci == NULL || t->c.ci->proc == NULL) {
+    mrb_task_disable_irq();
+    mrb_task_q_delete(mrb, t);
+    t->status = MRB_TASK_STATUS_DORMANT;
+    t->c.status = MRB_TASK_STOPPED;
+    mrb_task_q_insert(mrb, t);
+    mrb_task_enable_irq();
+    return;
+  }
+
   /* Set task as running */
   t->timeslice = MRB_TIMESLICE_TICK_COUNT;
   t->status = MRB_TASK_STATUS_RUNNING;
@@ -370,11 +400,6 @@ execute_task(mrb_state *mrb, mrb_task *t)
   /* Save proc and PC to locals before calling mrb_vm_exec */
   const struct RProc *proc = t->c.ci->proc;
   const mrb_code *pc = t->c.ci->pc;
-
-  /* With C function boundary checks, proc should never be NULL on resume */
-  if (!proc) {
-    mrb_raise(mrb, E_RUNTIME_ERROR, "task context corrupted: no proc on resume");
-  }
 
   /* Set vmexec flag to prevent fiber_terminate from being called */
   t->c.vmexec = TRUE;


### PR DESCRIPTION
### Symptom

With `MRB_USE_TASK_SCHEDULER`, if the system is near heap exhaustion when a task's context is (re)initialized, the VM later crashes — or, on embedded targets, silently corrupts memory — at a point far removed from the failing allocation.

### Mechanism

`task_init_context()` allocates the task's VM stack and callinfo stack with `mrb_malloc()`, which raises `NoMemoryError` via longjmp on failure. A task whose (re)initialization failed that way stays linked in the scheduler queues with a zeroed context (`ci == NULL`). `execute_task()` then dereferences `t->c.ci->proc`.

On hosted builds that is a NULL-page segfault. On RP2350 (and other targets where address 0 is readable — e.g. boot ROM), the read *succeeds* and yields ROM bytes as a fake `RProc` pointer; the VM wanders off into wild reads and wild jumps, and the failure surfaces as heap corruption with no visible connection to the OOM that caused it. We observed exactly this in the field on a Raspberry Pi Pico 2 W running PicoRuby/R2P2: near heap exhaustion, every irb command re-initializes a sandbox task's context, and the resulting crashes ranged from allocator HardFaults to jumps through boot-code sequences.

### Fix (two layers)

- `task_init_context()` allocates both buffers with `mrb_malloc_simple()` and commits neither on failure; the task is retired coherently (`MRB_TASK_STATUS_DORMANT` / `MRB_TASK_STOPPED`) *before* `NoMemoryError` is raised, so it can never be scheduled with a half-built context.
- `execute_task()` retires a context-less task instead of dereferencing it — checked before `mrb->c` is switched, so the scheduler's own context stays usable. This makes the scheduler robust even if some other path produces the same state.

### Verification

Found and verified with an allocation-fault-injection harness on the PicoRuby POSIX build under AddressSanitizer (fail every Nth allocation in bursts, so the GC-and-retry in `mrb_realloc_simple` cannot absorb the failure): a deterministic SEGV at `execute_task()`'s `t->c.ci->proc` read after ~5,500 injected `NoMemoryError` unwinds; gone after this change, with the process surviving repeated storms (tasks die with clean `NoMemoryError`, the scheduler and remaining tasks keep running). On hardware (Pico 2 W), a heap-exhaustion repro that previously died in one of three corruption flavors now ends with a clean `NoMemoryError` cascade and no fault-status bits set.

(No portable mrbtest regression test is included: triggering the window requires failing a specific internal allocation. Happy to add one if there's an accepted pattern for OOM injection in the test suite.)