### PR TITLE
mruby-task: exclude the tick IRQ while GC marks the task queues

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -293,6 +293,7 @@ typedef struct mrb_task_state {
   volatile mrb_bool switching;      /* Context switch pending flag */
   struct mrb_task *main_task;       /* Main task wrapper for root context */
   uint8_t scheduler_lock;           /* Lock counter for synchronous execution */
+  uint8_t irq_nesting;              /* Depth counter for scheduler-IRQ exclusion */
   mrb_bool loop_running;            /* Active mrb_task_run loop flag */
   mrb_bool exception_as_result;     /* Return unhandled task exceptions as values */
 } mrb_task_state;

--- a/mrbgems/mruby-task/include/task.h
+++ b/mrbgems/mruby-task/include/task.h
@@ -183,4 +183,40 @@ void mrb_task_q_delete(mrb_state *mrb, mrb_task *t);
 /* Task::Queue class registration - defined in task_queue.c */
 void mrb_init_task_queue(mrb_state *mrb, struct RClass *task_class);
 
+/*
+ * Nesting-safe scheduler-IRQ exclusion.
+ *
+ * The HAL primitives (mrb_task_disable_irq/mrb_task_enable_irq) are not
+ * required to nest (sigprocmask on POSIX, plain interrupt enable/disable
+ * on microcontrollers): a naive inner enable would reopen the exclusion
+ * for its outer section. Nesting does happen — GC marking
+ * (mrb_task_mark_all) excludes the tick, and a GC cycle can be triggered
+ * by an allocation made inside an already-excluded section (e.g.
+ * Task.stat building its result hash). Every scheduler-IRQ exclusion in
+ * this gem must therefore go through these counted helpers; only the
+ * outermost level touches the HAL.
+ *
+ * The depth counter is per-VM (mrb->task.irq_nesting) and is only ever
+ * accessed from the VM's own thread — the tick itself never takes the
+ * exclusion — so no atomicity is required, and multiple VMs on
+ * different threads stay independent even when the HAL shares one lock
+ * (as the Windows HAL does).
+ */
+static inline void
+mrb_task_excl_enter(mrb_state *mrb)
+{
+  if (mrb->task.irq_nesting++ == 0) {
+    mrb_task_disable_irq();
+  }
+}
+
+static inline void
+mrb_task_excl_exit(mrb_state *mrb)
+{
+  mrb_assert(mrb->task.irq_nesting > 0);
+  if (--mrb->task.irq_nesting == 0) {
+    mrb_task_enable_irq();
+  }
+}
+
 #endif /* MRUBY_TASK_H */

--- a/mrbgems/mruby-task/include/task_hal.h
+++ b/mrbgems/mruby-task/include/task_hal.h
@@ -75,13 +75,17 @@ void mrb_hal_task_final(mrb_state *mrb);
 /**
  * Enable timer interrupts (exit critical section)
  *
- * Called by the task scheduler when it's safe to allow timer interrupts.
- * Should enable timer interrupts/callbacks that were disabled by
+ * Called when it's safe to allow timer interrupts again. Should enable
+ * the timer interrupts/callbacks that were disabled by
  * mrb_task_disable_irq().
  *
- * Requirements:
- * - Must be reentrant (can be called multiple times)
- * - Should use nesting counter or equivalent for nested critical sections
+ * HAL implementers: this primitive is NOT required to nest — the
+ * scheduler only ever calls it at the outermost exclusion level.
+ * Scheduler/gem code must NOT call it directly: use the counted
+ * helpers mrb_task_excl_enter()/mrb_task_excl_exit() from task.h,
+ * which guarantee that property (see the invariant comment there).
+ *
+ * Typical implementations:
  * - On POSIX: unmask signals
  * - On Windows: leave critical section
  * - On embedded: enable timer interrupts
@@ -91,12 +95,16 @@ void mrb_task_enable_irq(void);
 /**
  * Disable timer interrupts (enter critical section)
  *
- * Called by the task scheduler before modifying shared task state.
- * Should disable timer interrupts/callbacks to prevent concurrent access.
+ * Called before shared task state is modified. Should disable timer
+ * interrupts/callbacks to prevent concurrent access.
  *
- * Requirements:
- * - Must be reentrant (can be called multiple times)
- * - Should use nesting counter or equivalent for nested critical sections
+ * HAL implementers: this primitive is NOT required to nest — the
+ * scheduler only ever calls it at the outermost exclusion level.
+ * Scheduler/gem code must NOT call it directly: use the counted
+ * helpers mrb_task_excl_enter()/mrb_task_excl_exit() from task.h,
+ * which guarantee that property (see the invariant comment there).
+ *
+ * Typical implementations:
  * - On POSIX: block signals
  * - On Windows: enter critical section
  * - On embedded: disable timer interrupts

--- a/mrbgems/mruby-task/src/task.c
+++ b/mrbgems/mruby-task/src/task.c
@@ -67,37 +67,6 @@ static const struct mrb_data_type mrb_task_type = {
 };
 
 /*
- * Nesting-safe scheduler-IRQ exclusion.
- *
- * The HAL primitives are not required to nest (sigprocmask on POSIX,
- * plain NVIC enable/disable on microcontrollers): a naive inner
- * enable would reopen the exclusion for its outer section. Nesting
- * does happen — GC marking (mrb_task_mark_all) excludes the tick, and
- * a GC cycle can be triggered by an allocation made inside an
- * already-excluded section (e.g. Task.stat building its result hash).
- * Every exclusion in this file therefore goes through this per-VM
- * depth counter; only the outermost level touches the HAL. The
- * counter is only ever accessed from the VM's own thread — the tick
- * itself never takes the exclusion.
- */
-static void
-task_irq_disable(mrb_state *mrb)
-{
-  if (mrb->task.irq_nesting++ == 0) {
-    mrb_task_disable_irq();
-  }
-}
-
-static void
-task_irq_enable(mrb_state *mrb)
-{
-  mrb_assert(mrb->task.irq_nesting > 0);
-  if (--mrb->task.irq_nesting == 0) {
-    mrb_task_enable_irq();
-  }
-}
-
-/*
  * GC marking function for all tasks
  * Called from gc.c during root_scan_phase
  */
@@ -125,7 +94,7 @@ mrb_task_mark_all(mrb_state *mrb)
      links into garbage (observed on RP2350 as ASCII string bytes where
      next pointers should be). Exclude the scheduler IRQ for the whole
      walk — same family as the gc.iterating guard in vm.c. */
-  task_irq_disable(mrb);
+  mrb_task_excl_enter(mrb);
   for (qi = 0; qi < 4; qi++) {
     mrb_task *t = mrb->task.queues[qi];
     while (t) {
@@ -181,7 +150,7 @@ mrb_task_mark_all(mrb_state *mrb)
       t = t->next;
     }
   }
-  task_irq_enable(mrb);
+  mrb_task_excl_exit(mrb);
 }
 
 /*
@@ -262,13 +231,13 @@ task_cleanup_if_stopped(mrb_state *mrb, mrb_task *t)
 {
   if (t->status == MRB_TASK_STATUS_DORMANT || t->c.status == MRB_TASK_STOPPED) {
     /* Task is terminated but still in queue - remove it */
-    task_irq_disable(mrb);
+    mrb_task_excl_enter(mrb);
     mrb_task_q_delete(mrb, t);
     if (t->status != MRB_TASK_STATUS_DORMANT) {
       t->status = MRB_TASK_STATUS_DORMANT;
       mrb_task_q_insert(mrb, t);
     }
-    task_irq_enable(mrb);
+    mrb_task_excl_exit(mrb);
     return TRUE;
   }
   return FALSE;
@@ -342,7 +311,7 @@ task_init_context(mrb_state *mrb, mrb_task *t, const struct RProc *proc)
 static void
 wake_up_join_waiters(mrb_state *mrb, mrb_task *completed_task)
 {
-  task_irq_disable(mrb);
+  mrb_task_excl_enter(mrb);
   mrb_task *curr = q_waiting_;
   while (curr != NULL) {
     mrb_task *next = curr->next;
@@ -363,18 +332,18 @@ wake_up_join_waiters(mrb_state *mrb, mrb_task *completed_task)
     }
     curr = next;
   }
-  task_irq_enable(mrb);
+  mrb_task_excl_exit(mrb);
 }
 
 /* Change task state with IRQ protection and queue management */
 static void
 task_change_state(mrb_state *mrb, mrb_task *t, uint8_t new_status)
 {
-  task_irq_disable(mrb);
+  mrb_task_excl_enter(mrb);
   mrb_task_q_delete(mrb, t);
   t->status = new_status;
   mrb_task_q_insert(mrb, t);
-  task_irq_enable(mrb);
+  mrb_task_excl_exit(mrb);
 }
 
 typedef struct execute_task_vm_args {
@@ -467,11 +436,11 @@ execute_task(mrb_state *mrb, mrb_task *t)
   /* Handle task termination */
   if (t->c.status == MRB_TASK_STOPPED) {
     switching_ = FALSE;
-    task_irq_disable(mrb);
+    mrb_task_excl_enter(mrb);
     mrb_task_q_delete(mrb, t);
     t->status = MRB_TASK_STATUS_DORMANT;
     mrb_task_q_insert(mrb, t);
-    task_irq_enable(mrb);
+    mrb_task_excl_exit(mrb);
 
     /* Wake up tasks waiting on join */
     wake_up_join_waiters(mrb, t);
@@ -567,9 +536,9 @@ task_run_body(mrb_state *mrb, void *ud)
 
     /* No task ready - check if all tasks are done */
     if (!t) {
-      task_irq_disable(mrb);
+      mrb_task_excl_enter(mrb);
       mrb_bool exiting = !q_ready_ && !q_waiting_ && !q_suspended_;
-      task_irq_enable(mrb);
+      mrb_task_excl_exit(mrb);
       if (exiting) {
         /* All tasks are dormant - scheduler done */
         break;
@@ -686,7 +655,7 @@ sleep_us_impl(mrb_state *mrb, uint32_t usec)
   /* In task context - get current running task */
   t = MRB2TASK(mrb);
 
-  task_irq_disable(mrb);
+  mrb_task_excl_enter(mrb);
 
   /* Remove from ready queue */
   mrb_task_q_delete(mrb, t);
@@ -712,7 +681,7 @@ sleep_us_impl(mrb_state *mrb, uint32_t usec)
   }
   mrb_task_q_insert(mrb, t);
 
-  task_irq_enable(mrb);
+  mrb_task_excl_exit(mrb);
 
   /* Trigger context switch */
   switching_ = TRUE;
@@ -743,11 +712,11 @@ mrb_f_sleep(mrb_state *mrb, mrb_value self)
       }
     }
     mrb_task *t = MRB2TASK(mrb);
-    task_irq_disable(mrb);
+    mrb_task_excl_enter(mrb);
     mrb_task_q_delete(mrb, t);
     t->status = MRB_TASK_STATUS_SUSPENDED;
     mrb_task_q_insert(mrb, t);
-    task_irq_enable(mrb);
+    mrb_task_excl_exit(mrb);
     switching_ = TRUE;
     return mrb_nil_value();
   }
@@ -811,9 +780,9 @@ task_create_common(mrb_state *mrb, const struct RProc *proc,
   mrb_gc_register(mrb, task_obj);
   task_init_context(mrb, t, proc);
 
-  task_irq_disable(mrb);
+  mrb_task_excl_enter(mrb);
   mrb_task_q_insert(mrb, t);
-  task_irq_enable(mrb);
+  mrb_task_excl_exit(mrb);
 
   if (q_ready_ && q_ready_->status == MRB_TASK_STATUS_RUNNING) {
     if (t->priority < q_ready_->priority) {
@@ -994,7 +963,7 @@ mrb_task_s_stat(mrb_state *mrb, mrb_value self)
 {
   mrb_value data = mrb_hash_new(mrb);
 
-  task_irq_disable(mrb);
+  mrb_task_excl_enter(mrb);
 
   /* Add global scheduler state */
   mrb_hash_set(mrb, data, mrb_symbol_value(MRB_SYM(tick)), mrb_fixnum_value(tick_));
@@ -1006,7 +975,7 @@ mrb_task_s_stat(mrb_state *mrb, mrb_value self)
   mrb_hash_set(mrb, data, mrb_symbol_value(MRB_SYM(waiting)), mrb_stat_sub(mrb, q_waiting_));
   mrb_hash_set(mrb, data, mrb_symbol_value(MRB_SYM(suspended)), mrb_stat_sub(mrb, q_suspended_));
 
-  task_irq_enable(mrb);
+  mrb_task_excl_exit(mrb);
 
   return data;
 }
@@ -1165,7 +1134,7 @@ mrb_task_set_priority(mrb_state *mrb, mrb_value self)
     mrb_raise(mrb, E_ARGUMENT_ERROR, "priority must be 0-255");
   }
 
-  task_irq_disable(mrb);
+  mrb_task_excl_enter(mrb);
   t->priority = (uint8_t)priority;
 
   /* Re-sort in queue if task is ready */
@@ -1173,7 +1142,7 @@ mrb_task_set_priority(mrb_state *mrb, mrb_value self)
     mrb_task_q_delete(mrb, t);
     mrb_task_q_insert(mrb, t);
   }
-  task_irq_enable(mrb);
+  mrb_task_excl_exit(mrb);
 
   return mrb_fixnum_value(priority);
 }
@@ -1245,13 +1214,13 @@ mrb_task_join(mrb_state *mrb, mrb_value self)
   }
 
   /* Wait for task to complete */
-  task_irq_disable(mrb);
+  mrb_task_excl_enter(mrb);
   mrb_task_q_delete(mrb, current);
   current->status = MRB_TASK_STATUS_WAITING;
   current->reason = MRB_TASK_REASON_JOIN;
   current->wait.join = t;
   mrb_task_q_insert(mrb, current);
-  task_irq_enable(mrb);
+  mrb_task_excl_exit(mrb);
 
   /* Trigger context switch */
   switching_ = TRUE;
@@ -1306,10 +1275,10 @@ mrb_execute_proc_synchronously(mrb_state *mrb, mrb_value proc_val, mrb_int argc,
   t->self = task_obj;
 
   /* 3. Move task from DORMANT to READY */
-  task_irq_disable(mrb);
+  mrb_task_excl_enter(mrb);
   t->status = MRB_TASK_STATUS_READY;
   mrb_task_q_insert(mrb, t);
-  task_irq_enable(mrb);
+  mrb_task_excl_exit(mrb);
 
   /* 4. Execute the task in a dedicated loop (no context switching) */
   t->status = MRB_TASK_STATUS_RUNNING;
@@ -1331,9 +1300,9 @@ mrb_execute_proc_synchronously(mrb_state *mrb, mrb_value proc_val, mrb_int argc,
   }
 
   /* 6. Free the temporary task's resources */
-  task_irq_disable(mrb);
+  mrb_task_excl_enter(mrb);
   mrb_task_q_delete(mrb, t);
-  task_irq_enable(mrb);
+  mrb_task_excl_exit(mrb);
 
   /* Prevent double-free: clear Data object's type before freeing task */
   DATA_TYPE(task_obj) = NULL;
@@ -1480,12 +1449,12 @@ resume_task_internal(mrb_state *mrb, mrb_task *t)
        t->wait.queue.wakeup_tick != UINT32_MAX)) {
     uint32_t task_wakeup = t->reason == MRB_TASK_REASON_SLEEP ?
                            t->wait.wakeup_tick : t->wait.queue.wakeup_tick;
-    task_irq_disable(mrb);
+    mrb_task_excl_enter(mrb);
     if (wakeup_tick_ == UINT32_MAX ||
         (int32_t)(task_wakeup - wakeup_tick_) < 0) {
       wakeup_tick_ = task_wakeup;
     }
-    task_irq_enable(mrb);
+    mrb_task_excl_exit(mrb);
   }
 }
 
@@ -1513,12 +1482,12 @@ terminate_task_internal(mrb_state *mrb, mrb_task *t)
 
   mrb_bool was_running = (t->status == MRB_TASK_STATUS_RUNNING);
 
-  task_irq_disable(mrb);
+  mrb_task_excl_enter(mrb);
   mrb_task_q_delete(mrb, t);
   t->status = MRB_TASK_STATUS_DORMANT;
   t->c.status = MRB_TASK_STOPPED;
   mrb_task_q_insert(mrb, t);
-  task_irq_enable(mrb);
+  mrb_task_excl_exit(mrb);
 
   wake_up_join_waiters(mrb, t);
 

--- a/mrbgems/mruby-task/src/task.c
+++ b/mrbgems/mruby-task/src/task.c
@@ -67,6 +67,37 @@ static const struct mrb_data_type mrb_task_type = {
 };
 
 /*
+ * Nesting-safe scheduler-IRQ exclusion.
+ *
+ * The HAL primitives are not required to nest (sigprocmask on POSIX,
+ * plain NVIC enable/disable on microcontrollers): a naive inner
+ * enable would reopen the exclusion for its outer section. Nesting
+ * does happen — GC marking (mrb_task_mark_all) excludes the tick, and
+ * a GC cycle can be triggered by an allocation made inside an
+ * already-excluded section (e.g. Task.stat building its result hash).
+ * Every exclusion in this file therefore goes through this per-VM
+ * depth counter; only the outermost level touches the HAL. The
+ * counter is only ever accessed from the VM's own thread — the tick
+ * itself never takes the exclusion.
+ */
+static void
+task_irq_disable(mrb_state *mrb)
+{
+  if (mrb->task.irq_nesting++ == 0) {
+    mrb_task_disable_irq();
+  }
+}
+
+static void
+task_irq_enable(mrb_state *mrb)
+{
+  mrb_assert(mrb->task.irq_nesting > 0);
+  if (--mrb->task.irq_nesting == 0) {
+    mrb_task_enable_irq();
+  }
+}
+
+/*
  * GC marking function for all tasks
  * Called from gc.c during root_scan_phase
  */
@@ -74,6 +105,19 @@ void
 mrb_task_mark_all(mrb_state *mrb)
 {
   int qi;
+
+  /* GC can run before mruby-task's gem init (allocations during
+     earlier gem inits trigger it, deterministically so under GC
+     stress). At that point the queues are necessarily empty AND the
+     HAL exclusion may not exist yet (the Windows HAL initializes its
+     CRITICAL_SECTION in mrb_hal_task_init) — return before touching
+     either. Tasks can only be queued after the HAL is initialized,
+     so non-empty queues imply the exclusion is safe to take. */
+  if (mrb->task.queues[0] == NULL && mrb->task.queues[1] == NULL &&
+      mrb->task.queues[2] == NULL && mrb->task.queues[3] == NULL) {
+    return;
+  }
+
   /* The tick IRQ relinks tasks between queues (sleep wakeups, timeslice
      rotation). A relink that lands mid-traversal makes this walk skip
      still-queued tasks; a skipped task's object is swept while its
@@ -81,7 +125,7 @@ mrb_task_mark_all(mrb_state *mrb)
      links into garbage (observed on RP2350 as ASCII string bytes where
      next pointers should be). Exclude the scheduler IRQ for the whole
      walk — same family as the gc.iterating guard in vm.c. */
-  mrb_task_disable_irq();
+  task_irq_disable(mrb);
   for (qi = 0; qi < 4; qi++) {
     mrb_task *t = mrb->task.queues[qi];
     while (t) {
@@ -137,7 +181,7 @@ mrb_task_mark_all(mrb_state *mrb)
       t = t->next;
     }
   }
-  mrb_task_enable_irq();
+  task_irq_enable(mrb);
 }
 
 /*
@@ -218,13 +262,13 @@ task_cleanup_if_stopped(mrb_state *mrb, mrb_task *t)
 {
   if (t->status == MRB_TASK_STATUS_DORMANT || t->c.status == MRB_TASK_STOPPED) {
     /* Task is terminated but still in queue - remove it */
-    mrb_task_disable_irq();
+    task_irq_disable(mrb);
     mrb_task_q_delete(mrb, t);
     if (t->status != MRB_TASK_STATUS_DORMANT) {
       t->status = MRB_TASK_STATUS_DORMANT;
       mrb_task_q_insert(mrb, t);
     }
-    mrb_task_enable_irq();
+    task_irq_enable(mrb);
     return TRUE;
   }
   return FALSE;
@@ -298,7 +342,7 @@ task_init_context(mrb_state *mrb, mrb_task *t, const struct RProc *proc)
 static void
 wake_up_join_waiters(mrb_state *mrb, mrb_task *completed_task)
 {
-  mrb_task_disable_irq();
+  task_irq_disable(mrb);
   mrb_task *curr = q_waiting_;
   while (curr != NULL) {
     mrb_task *next = curr->next;
@@ -319,18 +363,18 @@ wake_up_join_waiters(mrb_state *mrb, mrb_task *completed_task)
     }
     curr = next;
   }
-  mrb_task_enable_irq();
+  task_irq_enable(mrb);
 }
 
 /* Change task state with IRQ protection and queue management */
 static void
 task_change_state(mrb_state *mrb, mrb_task *t, uint8_t new_status)
 {
-  mrb_task_disable_irq();
+  task_irq_disable(mrb);
   mrb_task_q_delete(mrb, t);
   t->status = new_status;
   mrb_task_q_insert(mrb, t);
-  mrb_task_enable_irq();
+  task_irq_enable(mrb);
 }
 
 typedef struct execute_task_vm_args {
@@ -423,11 +467,11 @@ execute_task(mrb_state *mrb, mrb_task *t)
   /* Handle task termination */
   if (t->c.status == MRB_TASK_STOPPED) {
     switching_ = FALSE;
-    mrb_task_disable_irq();
+    task_irq_disable(mrb);
     mrb_task_q_delete(mrb, t);
     t->status = MRB_TASK_STATUS_DORMANT;
     mrb_task_q_insert(mrb, t);
-    mrb_task_enable_irq();
+    task_irq_enable(mrb);
 
     /* Wake up tasks waiting on join */
     wake_up_join_waiters(mrb, t);
@@ -523,9 +567,9 @@ task_run_body(mrb_state *mrb, void *ud)
 
     /* No task ready - check if all tasks are done */
     if (!t) {
-      mrb_task_disable_irq();
+      task_irq_disable(mrb);
       mrb_bool exiting = !q_ready_ && !q_waiting_ && !q_suspended_;
-      mrb_task_enable_irq();
+      task_irq_enable(mrb);
       if (exiting) {
         /* All tasks are dormant - scheduler done */
         break;
@@ -642,7 +686,7 @@ sleep_us_impl(mrb_state *mrb, uint32_t usec)
   /* In task context - get current running task */
   t = MRB2TASK(mrb);
 
-  mrb_task_disable_irq();
+  task_irq_disable(mrb);
 
   /* Remove from ready queue */
   mrb_task_q_delete(mrb, t);
@@ -668,7 +712,7 @@ sleep_us_impl(mrb_state *mrb, uint32_t usec)
   }
   mrb_task_q_insert(mrb, t);
 
-  mrb_task_enable_irq();
+  task_irq_enable(mrb);
 
   /* Trigger context switch */
   switching_ = TRUE;
@@ -699,11 +743,11 @@ mrb_f_sleep(mrb_state *mrb, mrb_value self)
       }
     }
     mrb_task *t = MRB2TASK(mrb);
-    mrb_task_disable_irq();
+    task_irq_disable(mrb);
     mrb_task_q_delete(mrb, t);
     t->status = MRB_TASK_STATUS_SUSPENDED;
     mrb_task_q_insert(mrb, t);
-    mrb_task_enable_irq();
+    task_irq_enable(mrb);
     switching_ = TRUE;
     return mrb_nil_value();
   }
@@ -767,9 +811,9 @@ task_create_common(mrb_state *mrb, const struct RProc *proc,
   mrb_gc_register(mrb, task_obj);
   task_init_context(mrb, t, proc);
 
-  mrb_task_disable_irq();
+  task_irq_disable(mrb);
   mrb_task_q_insert(mrb, t);
-  mrb_task_enable_irq();
+  task_irq_enable(mrb);
 
   if (q_ready_ && q_ready_->status == MRB_TASK_STATUS_RUNNING) {
     if (t->priority < q_ready_->priority) {
@@ -950,7 +994,7 @@ mrb_task_s_stat(mrb_state *mrb, mrb_value self)
 {
   mrb_value data = mrb_hash_new(mrb);
 
-  mrb_task_disable_irq();
+  task_irq_disable(mrb);
 
   /* Add global scheduler state */
   mrb_hash_set(mrb, data, mrb_symbol_value(MRB_SYM(tick)), mrb_fixnum_value(tick_));
@@ -962,7 +1006,7 @@ mrb_task_s_stat(mrb_state *mrb, mrb_value self)
   mrb_hash_set(mrb, data, mrb_symbol_value(MRB_SYM(waiting)), mrb_stat_sub(mrb, q_waiting_));
   mrb_hash_set(mrb, data, mrb_symbol_value(MRB_SYM(suspended)), mrb_stat_sub(mrb, q_suspended_));
 
-  mrb_task_enable_irq();
+  task_irq_enable(mrb);
 
   return data;
 }
@@ -1121,7 +1165,7 @@ mrb_task_set_priority(mrb_state *mrb, mrb_value self)
     mrb_raise(mrb, E_ARGUMENT_ERROR, "priority must be 0-255");
   }
 
-  mrb_task_disable_irq();
+  task_irq_disable(mrb);
   t->priority = (uint8_t)priority;
 
   /* Re-sort in queue if task is ready */
@@ -1129,7 +1173,7 @@ mrb_task_set_priority(mrb_state *mrb, mrb_value self)
     mrb_task_q_delete(mrb, t);
     mrb_task_q_insert(mrb, t);
   }
-  mrb_task_enable_irq();
+  task_irq_enable(mrb);
 
   return mrb_fixnum_value(priority);
 }
@@ -1201,13 +1245,13 @@ mrb_task_join(mrb_state *mrb, mrb_value self)
   }
 
   /* Wait for task to complete */
-  mrb_task_disable_irq();
+  task_irq_disable(mrb);
   mrb_task_q_delete(mrb, current);
   current->status = MRB_TASK_STATUS_WAITING;
   current->reason = MRB_TASK_REASON_JOIN;
   current->wait.join = t;
   mrb_task_q_insert(mrb, current);
-  mrb_task_enable_irq();
+  task_irq_enable(mrb);
 
   /* Trigger context switch */
   switching_ = TRUE;
@@ -1262,10 +1306,10 @@ mrb_execute_proc_synchronously(mrb_state *mrb, mrb_value proc_val, mrb_int argc,
   t->self = task_obj;
 
   /* 3. Move task from DORMANT to READY */
-  mrb_task_disable_irq();
+  task_irq_disable(mrb);
   t->status = MRB_TASK_STATUS_READY;
   mrb_task_q_insert(mrb, t);
-  mrb_task_enable_irq();
+  task_irq_enable(mrb);
 
   /* 4. Execute the task in a dedicated loop (no context switching) */
   t->status = MRB_TASK_STATUS_RUNNING;
@@ -1287,9 +1331,9 @@ mrb_execute_proc_synchronously(mrb_state *mrb, mrb_value proc_val, mrb_int argc,
   }
 
   /* 6. Free the temporary task's resources */
-  mrb_task_disable_irq();
+  task_irq_disable(mrb);
   mrb_task_q_delete(mrb, t);
-  mrb_task_enable_irq();
+  task_irq_enable(mrb);
 
   /* Prevent double-free: clear Data object's type before freeing task */
   DATA_TYPE(task_obj) = NULL;
@@ -1436,12 +1480,12 @@ resume_task_internal(mrb_state *mrb, mrb_task *t)
        t->wait.queue.wakeup_tick != UINT32_MAX)) {
     uint32_t task_wakeup = t->reason == MRB_TASK_REASON_SLEEP ?
                            t->wait.wakeup_tick : t->wait.queue.wakeup_tick;
-    mrb_task_disable_irq();
+    task_irq_disable(mrb);
     if (wakeup_tick_ == UINT32_MAX ||
         (int32_t)(task_wakeup - wakeup_tick_) < 0) {
       wakeup_tick_ = task_wakeup;
     }
-    mrb_task_enable_irq();
+    task_irq_enable(mrb);
   }
 }
 
@@ -1469,12 +1513,12 @@ terminate_task_internal(mrb_state *mrb, mrb_task *t)
 
   mrb_bool was_running = (t->status == MRB_TASK_STATUS_RUNNING);
 
-  mrb_task_disable_irq();
+  task_irq_disable(mrb);
   mrb_task_q_delete(mrb, t);
   t->status = MRB_TASK_STATUS_DORMANT;
   t->c.status = MRB_TASK_STOPPED;
   mrb_task_q_insert(mrb, t);
-  mrb_task_enable_irq();
+  task_irq_enable(mrb);
 
   wake_up_join_waiters(mrb, t);
 
@@ -1613,6 +1657,7 @@ mrb_mruby_task_gem_init(mrb_state *mrb)
   /* Initialize main task to NULL and scheduler_lock to 0 */
   mrb->task.main_task = NULL;
   mrb->task.scheduler_lock = 0;
+  mrb->task.irq_nesting = 0;
   mrb->task.loop_running = FALSE;
   mrb->task.exception_as_result = FALSE;
 

--- a/mrbgems/mruby-task/src/task.c
+++ b/mrbgems/mruby-task/src/task.c
@@ -74,6 +74,14 @@ void
 mrb_task_mark_all(mrb_state *mrb)
 {
   int qi;
+  /* The tick IRQ relinks tasks between queues (sleep wakeups, timeslice
+     rotation). A relink that lands mid-traversal makes this walk skip
+     still-queued tasks; a skipped task's object is swept while its
+     mrb_task stays linked, and the freed chunk's reuse turns the queue
+     links into garbage (observed on RP2350 as ASCII string bytes where
+     next pointers should be). Exclude the scheduler IRQ for the whole
+     walk — same family as the gc.iterating guard in vm.c. */
+  mrb_task_disable_irq();
   for (qi = 0; qi < 4; qi++) {
     mrb_task *t = mrb->task.queues[qi];
     while (t) {
@@ -129,6 +137,7 @@ mrb_task_mark_all(mrb_state *mrb)
       t = t->next;
     }
   }
+  mrb_task_enable_irq();
 }
 
 /*

--- a/mrbgems/mruby-task/src/task_queue.c
+++ b/mrbgems/mruby-task/src/task_queue.c
@@ -32,7 +32,7 @@ static struct RClass *task_error_class_;
 static void
 queue_wake_one_waiter(mrb_state *mrb, mrb_task_queue *q)
 {
-  mrb_task_disable_irq();
+  mrb_task_excl_enter(mrb);
   mrb_task *curr = q_waiting_;
   while (curr) {
     mrb_task *next = curr->next;
@@ -48,7 +48,7 @@ queue_wake_one_waiter(mrb_state *mrb, mrb_task_queue *q)
     }
     curr = next;
   }
-  mrb_task_enable_irq();
+  mrb_task_excl_exit(mrb);
 }
 
 /* Wake all tasks waiting on this queue (used by close) */
@@ -56,7 +56,7 @@ static void
 queue_wake_all_waiters(mrb_state *mrb, mrb_task_queue *q)
 {
   mrb_bool woke_any = FALSE;
-  mrb_task_disable_irq();
+  mrb_task_excl_enter(mrb);
   mrb_task *curr = q_waiting_;
   while (curr) {
     mrb_task *next = curr->next;
@@ -74,7 +74,7 @@ queue_wake_all_waiters(mrb_state *mrb, mrb_task_queue *q)
   if (woke_any) {
     switching_ = TRUE;
   }
-  mrb_task_enable_irq();
+  mrb_task_excl_exit(mrb);
 }
 
 static mrb_value
@@ -200,7 +200,7 @@ queue_pop_try(mrb_state *mrb, mrb_value self)
 
   /* Move current task to WAITING */
   mrb_task *current = MRB2TASK(mrb);
-  mrb_task_disable_irq();
+  mrb_task_excl_enter(mrb);
   mrb_task_q_delete(mrb, current);
   current->status = MRB_TASK_STATUS_WAITING;
   current->reason = MRB_TASK_REASON_QUEUE;
@@ -212,7 +212,7 @@ queue_pop_try(mrb_state *mrb, mrb_value self)
     wakeup_tick_ = deadline;
   }
   mrb_task_q_insert(mrb, current);
-  mrb_task_enable_irq();
+  mrb_task_excl_exit(mrb);
   switching_ = TRUE;
 
   /* Return sentinel; the Ruby pop loop will retry after wakeup */
@@ -267,7 +267,7 @@ queue_num_waiting(mrb_state *mrb, mrb_value self)
   mrb_task_queue *q = (mrb_task_queue*)mrb_data_get_ptr(mrb, self, &mrb_task_queue_type);
   if (!q) mrb_raise(mrb, E_ARGUMENT_ERROR, "invalid queue");
   uint32_t count = 0;
-  mrb_task_disable_irq();
+  mrb_task_excl_enter(mrb);
   mrb_task *curr = q_waiting_;
   while (curr) {
     if (curr->reason == MRB_TASK_REASON_QUEUE && curr->wait.queue.target == q) {
@@ -275,7 +275,7 @@ queue_num_waiting(mrb_state *mrb, mrb_value self)
     }
     curr = curr->next;
   }
-  mrb_task_enable_irq();
+  mrb_task_excl_exit(mrb);
   return mrb_int_value(mrb, (mrb_int)count);
 }
 


### PR DESCRIPTION
### Problem

`mrb_task_mark_all()` walks the four task queues while the scheduler tick (an interrupt on microcontroller HALs, a signal handler on the POSIX HAL) can concurrently relink tasks between queues (`q_waiting_` → `q_ready_` on wakeup). A queue node can be unlinked or relinked mid-walk, so the GC can skip live tasks (whose stacks then get swept while in use) or follow a stale `next` pointer.

### Fix

Hold the tick-IRQ exclusion (`mrb_task_disable_irq()` / `mrb_task_enable_irq()`) across the queue walk in `mrb_task_mark_all()`, the same discipline every queue-mutating path in task.c already follows.

### Notes

Found by code inspection while chasing a heap corruption on PicoRuby/RP2350 (the corruption itself turned out to be a different bug — see the companion PR "survive OOM during task context initialization" — but this window is real and the fix follows the existing locking convention). No behavior change outside the marking phase; full test suite green on the POSIX HAL.