### PR TITLE
Fix: never drive incremental GC from a realloc (use-after-free)

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -244,10 +244,22 @@ mrb_realloc_simple(mrb_state *mrb, void *p,  size_t len)
 
   if (p2 && len > 0) {
     mrb->gc.malloc_increase += len;
-    if (mrb->gc.malloc_threshold > 0 &&
+    if (p == NULL &&
+        mrb->gc.malloc_threshold > 0 &&
         mrb->gc.malloc_increase >= mrb->gc.malloc_threshold &&
         mrb->gc.state == MRB_GC_STATE_ROOT &&
         !mrb->gc.disabled && !mrb->gc.iterating) {
+      /* Only a fresh allocation (p == NULL) may drive the collector here. A
+         realloc (p != NULL) has just freed the caller's old block, but the
+         caller has not yet stored the returned pointer back into the object it
+         belongs to -- e.g. ht_adjust_ea() does `ea = ea_resize(...)` and only
+         then `ht_set_ea(h, ea)`, and ary_expand_capa() likewise. Running an
+         incremental mark in that window would mark the still-reachable
+         container (Hash/Array/String/...) while it holds the dangling old
+         pointer, a use-after-free. A fresh allocation frees nothing the caller
+         references, so it is a safe point to step GC. Byte pressure from
+         reallocs is not lost: malloc_increase keeps accumulating above and
+         fires at the next fresh allocation. */
       mrb->gc.malloc_increase = 0;
       mrb_incremental_gc(mrb);
     }

--- a/test/t/gc.rb
+++ b/test/t/gc.rb
@@ -83,6 +83,26 @@ assert('GC.malloc_threshold - triggers GC on large allocations') do
   end
 end
 
+assert('GC.malloc_threshold - does not mark through stale realloc buffers') do
+  origin = GC.malloc_threshold
+  begin
+    GC.malloc_threshold = 1
+    GC.start  # reset malloc_increase
+
+    h = {}
+    300.times { |i| h[i] = i }
+    assert_equal 300, h.size
+    300.times { |i| assert_equal i, h[i] }
+
+    a = []
+    1000.times { |i| a << i }
+    assert_equal 1000, a.size
+    1000.times { |i| assert_equal i, a[i] }
+  ensure
+    GC.malloc_threshold = origin
+  end
+end
+
 assert('GC.generational_mode=') do
   origin = GC.generational_mode
   begin

--- a/test/t/gc.rb
+++ b/test/t/gc.rb
@@ -73,7 +73,7 @@ assert('GC.malloc_threshold - triggers GC on large allocations') do
   origin = GC.malloc_threshold
   begin
     GC.malloc_threshold = 4096
-    GC.start  # reset malloc_increase
+    GC.start  # force a full GC cycle
     # allocate large strings to exceed threshold
     100.times { "x" * 1024 }
     stat = GC.stat


### PR DESCRIPTION
`mrb_realloc_simple()` drives a byte-pressure incremental GC step from any allocation that crosses `GC.malloc_threshold`, including reallocs. That is unsafe: a realloc frees the caller's old block, but the caller has not yet stored the new pointer back into the object that owns it, so stepping the collector in that window marks a live container through a dangling pointer.

Reproduction route (heap-use-after-free, confirmed with ASan):

1. `GC.malloc_threshold > 0` (byte-pressure GC enabled).
2. A GC-reachable container grows its internal buffer via mrb_realloc: - Hash:  ht_adjust_ea() does `ea = ea_resize(...)` (the realloc frees the old entry array) and only afterwards `ht_set_ea(h, ea)`. - Array: ary_expand_capa() does `p = mrb_realloc(a->as.heap.ptr, ...)` and only afterwards `a->as.heap.ptr = p`.
3. Inside `mrb_realloc_simple()`, after the realloc has freed the old buffer, malloc_increase crosses malloc_threshold and mrb_incremental_gc() runs.
4. That mark step reaches the same container, whose stored pointer still points at the just-freed old buffer -> mrb_gc_mark reads freed memory.

  e.g. `GC.malloc_threshold = 1; h = {}; 300.times { |i| h[i] = i }`.

The crash is timing/layout sensitive (it needs GC to fire during a resize realloc), which is why it stays latent under the normal test suite and only surfaces when heap/GC timing shifts. The byte-pressure trigger on the realloc success path was introduced in 4b866a84d ("gc.c: add step_limit and malloc_threshold for GC tuning").

## Fix

Only a fresh allocation (p == NULL) may drive the collector here. A fresh allocation frees nothing the caller still references, so it is a safe reentrancy point. Byte pressure from reallocs is not lost -- malloc_increase keeps accumulating and fires at the next fresh allocation.