### PR TITLE
gc: try to reclaim before growing the object heap

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -625,7 +625,12 @@ mrb_obj_alloc_core(mrb_state *mrb, enum mrb_vtype ttype, struct RClass *cls)
        "full of live data" (grow!). live_after_mark from the last
        completed cycle is the garbage-free estimate of the true live
        set: sweep decrements it as objects are freed. */
-    if (gc->live_after_mark + MRB_HEAP_PAGE_SIZE/2 < capacity) {
+    /* The !collecting guard mirrors mrb_realloc_simple(): allocation
+       can re-enter here from inside a running mark/sweep (an RData
+       dfree callback that allocates during the sweep phase), and
+       starting a nested collection there would corrupt the GC's
+       in-progress state. */
+    if (!gc->collecting && gc->live_after_mark + MRB_HEAP_PAGE_SIZE/2 < capacity) {
       mrb_full_gc(mrb);
     }
     if (gc->free_heaps == NULL) {

--- a/src/gc.c
+++ b/src/gc.c
@@ -598,7 +598,39 @@ mrb_obj_alloc_core(mrb_state *mrb, enum mrb_vtype ttype, struct RClass *cls)
   }
   gc_arena_keep(mrb, gc);
   if (gc->free_heaps == NULL) {
-    add_heap(mrb, gc);
+    /* Free slots ran out: try to reclaim before growing. A full
+       collection finishes the (possibly half-run) incremental cycle
+       and sweeps its garbage, usually refilling the freelists without
+       adding a page. Growing immediately instead ratchets the page
+       count up to the workload's transient high-water mark and it
+       never comes back down — pages are only freed when COMPLETELY
+       empty, so fragmentation keeps them pinned. On fixed-arena
+       targets the pages eventually consume the whole arena even
+       though most of their slots are free.
+
+       Only attempt the collection when the accounting shows real
+       slack (live well below capacity): if the heap is genuinely
+       full of live objects — e.g. a growing working set — collecting
+       before every page-add just burns time, so grow directly as
+       before. Walking the page list here is fine: growth events are
+       rare and the walk is a few pointer hops per page.
+       (mrb_full_gc() is a no-op while the GC is disabled or
+       iterating; we grow as before in that case, too.) */
+    size_t capacity = 0;
+    for (mrb_heap_page *page = gc->heaps; page; page = page->next) {
+      capacity += MRB_HEAP_PAGE_SIZE;
+    }
+    /* gc->live is inflated by dead-but-unswept objects at this point,
+       so it cannot distinguish "full of garbage" (reclaim!) from
+       "full of live data" (grow!). live_after_mark from the last
+       completed cycle is the garbage-free estimate of the true live
+       set: sweep decrements it as objects are freed. */
+    if (gc->live_after_mark + MRB_HEAP_PAGE_SIZE/2 < capacity) {
+      mrb_full_gc(mrb);
+    }
+    if (gc->free_heaps == NULL) {
+      add_heap(mrb, gc);
+    }
   }
 
   RVALUE *p = gc->free_heaps->freelist;


### PR DESCRIPTION
### Problem

A heap page is freed only when every slot on it dies in a single sweep. On long-running workloads, fragmentation pins nearly every page (one long-lived object is enough), so the page count behaves as a ratchet: any allocation burst that drains the freelists mid-cycle calls `add_heap()` even when the heap is mostly garbage, and the page is never returned. Hosts rarely notice, but on fixed-arena embedded targets the pages eventually consume the entire arena and the VM dies of `NoMemoryError` while most object slots are actually free.

Measured on PicoRuby/R2P2 (Raspberry Pi Pico 2 W, ~300 KB arena): one page (+44 KB of arena) per ~20 interactive shell commands, monotonic, with `GC.start` reclaiming nothing — an interactive session dies of heap exhaustion after ~110 commands with thousands of free slots on the books.

### Fix

When the freelists are empty in `mrb_obj_alloc_core()`, run a full collection before growing — but only when the previous cycle's garbage-free live estimate (`live_after_mark`, which sweep decrements as objects are freed) shows real slack against page capacity. `gc->live` cannot be used as the gate: at the exhaustion point it is inflated by dead-but-unswept objects, so it cannot distinguish "full of garbage" (worth collecting) from "full of live data" (grow immediately). Capacity is computed by walking the page list, which is a few pointer hops and only happens at (rare) growth events.

The slack test matters for performance: without it, allocation-heavy workloads with a genuinely growing live set pay a futile full collection per page-add — `bm_ao_render` regressed +43% in that configuration. With the test, `bm_ao_render` is unchanged (1.91s vs 1.90s baseline, and `bm_so_lists` identical), while the embedded ratchet is eliminated (page count pinned at the boot working set; retained memory growth per shell command reduced ~95%).

`mrb_full_gc()` is already a no-op when the GC is disabled or iterating, and is already called at this exact site under `MRB_GC_STRESS`, so the safety profile at this point is established; in those cases the heap grows exactly as before.

### Verification

Full test suite green on the POSIX HAL (1854/1854, 0 crash) and under the GC-stress full-debug config. On hardware, an interactive-shell soak that previously exhausted a 300 KB arena in ~110 commands now runs with a flat page count.