### PR TITLE
mruby-task: don't accumulate a GC arena entry per execution slice

### DIFF
--- a/mrbgems/mruby-task/src/task.c
+++ b/mrbgems/mruby-task/src/task.c
@@ -384,7 +384,14 @@ execute_task(mrb_state *mrb, mrb_task *t)
      mrb_vm_exec() in task mode, so the scheduler protect frame stays intact. */
   execute_task_vm_args args = { t, proc, pc };
   mrb_bool error = FALSE;
+  /* mrb_protect_error() roots its result in the GC arena (+1 entry,
+   * never popped by the caller loop): one slot per execution slice
+   * accumulates forever and pins every slice's result object. The
+   * result is already reachable — and marked — through t->result
+   * (mrb_task_mark_all), so the arena root is redundant here. */
+  int ai = mrb_gc_arena_save(mrb);
   t->result = mrb_protect_error(mrb, execute_task_vm, &args, &error);
+  mrb_gc_arena_restore(mrb, ai);
   mrb->task.exception_as_result = FALSE;
 
   /* Clear vmexec flag */


### PR DESCRIPTION
### Problem

`mrb_protect_error()` intentionally roots its result in the GC arena (`mrb_gc_arena_restore` followed by `mrb_gc_protect(result)`) so its caller can consume the value safely. `execute_task()` calls it once per scheduling slice, and the scheduler loop never pops those entries — so the arena grows by one slot per slice, forever. Because the arena auto-extends (`gc_arena_keep`), there is no arena-overflow error: just silently accumulating permanent GC roots, each pinning that slice's result object.

On an irb-style workload every command's result was retained permanently: measured at 1.2 KB per command on PicoRuby/R2P2 (each command's result string stayed live through any number of `GC.start` calls), the dominant per-command memory growth on the device.

### Fix

Save/restore the arena around the `mrb_protect_error()` call in `execute_task()`. The result is already reachable — and marked — through `t->result` (`mrb_task_mark_all` marks it), so the arena root is redundant at this call site.

### Verification

Full test suite green on the POSIX HAL (1854/1854, 0 crash). Retained growth for a string-producing shell command drops from +1244 B/command to ~0 (measured via allocator statistics on the PicoRuby POSIX build across 15-command batches, full GC between measurements).
