### PR TITLE
Feature: Scheduler Driven GC

### DIFF
--- a/build_config/gctest.rb
+++ b/build_config/gctest.rb
@@ -1,0 +1,22 @@
+# Task-scheduled GC test build (PicoRuby-independent).
+#
+# Runs the mruby core test suite plus the mruby-task gem tests under mrbtest,
+# with the scheduler and GC primitives compiled in. Keep this build focused:
+# unrelated default-gembox tests and bintests make this target noisy.
+#
+#   MRUBY_CONFIG=gctest rake test
+#
+MRuby::Build.new('gctest') do |conf|
+  conf.toolchain :gcc
+  conf.enable_debug
+
+  conf.cc.defines << 'MRB_INT64'
+  conf.cc.defines << 'MRB_NO_BOXING'
+  conf.cc.defines << 'MRB_GC_PROFILE'
+
+  conf.gem core: 'mruby-compiler'
+  conf.gem core: 'mruby-bin-mrbc'
+  conf.gem core: 'mruby-task'
+
+  conf.enable_test
+end

--- a/include/mruby.h
+++ b/include/mruby.h
@@ -1466,6 +1466,7 @@ MRB_API mrb_bool mrb_recursive_func_p(mrb_state *mrb, mrb_sym mid, mrb_value obj
 
 MRB_API void mrb_garbage_collect(mrb_state*);
 MRB_API void mrb_full_gc(mrb_state*);
+/* no-op while auto_step is disabled (task-scheduled GC); see src/gc.c */
 MRB_API void mrb_incremental_gc(mrb_state*);
 MRB_API void mrb_gc_mark(mrb_state*,struct RBasic*);
 #define mrb_gc_mark_value(mrb,val) do {\

--- a/include/mruby/gc.h
+++ b/include/mruby/gc.h
@@ -35,6 +35,19 @@ typedef enum {
   MRB_GC_STATE_SWEEP
 } mrb_gc_state;
 
+#ifdef MRB_GC_PROFILE
+/* Number of log2 duration buckets for the pause histogram: bucket i counts
+   pauses whose microsecond duration has its highest set bit at position i,
+   i.e. [2^(i-1), 2^i). Bucket 0 counts 0us pauses. 20 buckets reaches ~0.5s. */
+#define MRB_GC_PROFILE_NBUCKETS 20
+typedef struct mrb_gc_prof_hist {
+  uint64_t count;
+  uint64_t total_us;
+  uint64_t max_us;
+  uint32_t buckets[MRB_GC_PROFILE_NBUCKETS];
+} mrb_gc_prof_hist;
+#endif
+
 typedef struct mrb_gc {
   struct mrb_heap_page *heaps;     /* all heaps pages */
   struct mrb_heap_page *free_heaps;/* heaps for allocation */
@@ -58,9 +71,14 @@ typedef struct mrb_gc {
   mrb_bool out_of_memory :1;       /* out-of-memory error occurred */
   mrb_bool collecting    :1;       /* mark/sweep engine is on the stack;
                                       suppresses reentrant emergency GC */
+  mrb_bool auto_step     :1;       /* run GC steps on allocation (default on) */
+  mrb_bool sched_driven  :1;       /* task scheduler drives GC when idle (see
+                                      mrb_gc_scheduler_driven); implies auto_step off */
   size_t step_limit;               /* 0=unlimited, >0=absolute step cap */
   size_t malloc_increase;          /* malloc bytes since last GC cycle */
   size_t malloc_threshold;         /* 0=disabled, >0=bytes to trigger GC */
+  mrb_int debt_limit;              /* 0=disabled; when auto_step off, force a
+                                      sync step once gc_debt exceeds this */
 
 #ifdef MRB_GC_FIXED_ARENA
   struct RBasic *arena[MRB_GC_ARENA_SIZE]; /* GC protection array */
@@ -75,10 +93,69 @@ typedef struct mrb_gc {
   uint32_t minor_gc_count;                 /* minor GC count */
   uint32_t major_gc_count;                 /* major GC count */
 #endif
+
+#ifdef MRB_GC_PROFILE
+  mrb_gc_prof_hist prof_sync;   /* synchronous mutator pauses (mrb_incremental_gc/mrb_full_gc) */
+  mrb_gc_prof_hist prof_step;   /* scheduler-driven step pauses (work moved off the allocation path) */
+  mrb_gc_prof_hist prof_step_jitter; /* jitter GC steps actually injected: the
+                                        wall time of each step after which a task
+                                        was already READY (the step delayed it).
+                                        Upper-bounds the delay that task suffered.
+                                        Fed by the scheduler via mrb_gc_scheduler_jitter. */
+  uint64_t prof_last_step_us;   /* wall time of the most recent mrb_gc_step, so
+                                   the scheduler can attribute it as jitter */
+  mrb_gc_prof_hist *prof_target;/* histogram the outermost GC entry records into */
+  int prof_depth;               /* reentrancy guard so nested GC calls record once */
+  uint64_t prof_final_mark_max_us;   /* longest final_marking_phase (irreducible pause) */
+  size_t   prof_final_mark_max_live; /* live count at that longest final marking */
+  uint64_t prof_mark_work_total;     /* machine-independent: objects mark-scanned */
+  uint64_t prof_sweep_work_total;    /* machine-independent: slots swept */
+  uint32_t prof_emergency_count;     /* full GCs triggered by allocator OOM */
+#endif
 } mrb_gc;
 
 MRB_API mrb_bool mrb_object_dead_p(mrb_state *mrb, struct RBasic *object);
 MRB_API int mrb_gc_add_region(mrb_state *mrb, void *start, size_t size);
+
+/* Task-scheduled GC control.
+ *
+ * mrb_gc_scheduler_driven(mrb, TRUE) hands GC scheduling to the task
+ * scheduler: it turns auto_step off (so the allocation path stops driving
+ * collection) and disables generational mode (a minor cycle otherwise runs to
+ * completion inside one atomic step, defeating the point). The scheduler then
+ * advances the collector from its idle points -- see mrb_task_run /
+ * mrb_task_run_once. Enabling raises E_RUNTIME_ERROR while GC is disabled or
+ * an ObjectSpace iteration is running, leaving the flags unchanged; while
+ * scheduler-driven mode is on, re-enabling generational mode raises for the
+ * same reason (a minor cycle is one atomic step). Passing FALSE restores
+ * auto_step (standard mruby allocation-synchronous GC); it does not restore
+ * generational mode.
+ *
+ * mrb_gc_scheduler_pending() reports whether, in scheduler-driven mode, there is
+ * GC work worth doing right now (a cycle is in progress, collection is overdue
+ * by object debt, or malloc-backed byte pressure has built up past
+ * malloc_threshold). It is FALSE whenever scheduler-driven mode is off, so a
+ * caller can gate on it without checking the mode itself.
+ *
+ * mrb_gc_step() advances the incremental collector by one unit of work and
+ * returns the amount done (objects mark-scanned plus slots swept), or 0 while
+ * GC is disabled or an ObjectSpace iteration is in progress. It runs
+ * regardless of auto_step, so the task scheduler can drive collection while
+ * automatic (allocation-time) stepping is off. Note for embedders driving
+ * this directly: with generational mode still on, one call runs a whole
+ * minor cycle atomically -- go through mrb_gc_scheduler_driven (or disable
+ * generational mode first) to get finely divisible steps. */
+MRB_API void mrb_gc_scheduler_driven(mrb_state *mrb, mrb_bool enable);
+MRB_API mrb_bool mrb_gc_scheduler_pending(mrb_state *mrb);
+MRB_API mrb_int mrb_gc_step(mrb_state *mrb);
+
+/* Attribute the just-finished mrb_gc_step as jitter, if it delayed a task.
+ * The scheduler calls this right after an idle-point mrb_gc_step, passing
+ * whether a task became READY during that step. When it did, the step held the
+ * CPU while a task was due to run, so the step's wall time upper-bounds the
+ * jitter that task suffered; it is recorded into the prof_step_jitter
+ * histogram. A no-op unless built with MRB_GC_PROFILE. */
+MRB_API void mrb_gc_scheduler_jitter(mrb_state *mrb, mrb_bool delayed_task);
 
 #define MRB_GC_RED 7
 

--- a/mrbgems/mruby-task/README.md
+++ b/mrbgems/mruby-task/README.md
@@ -16,6 +16,8 @@ The primary purpose of `mruby-task` is to enable mruby applications to:
 - Synchronize tasks using `sleep`, `join` and `Task::Queue`.
 - Suspend and resume tasks programmatically.
 - Coordinate producers and consumers via `Task::Queue` without polling.
+- Drive garbage collection from the scheduler's idle points, so allocating
+  tasks never pause for GC (see [Task-Scheduled GC](#task-scheduled-gc)).
 
 ## Architecture
 
@@ -738,6 +740,86 @@ Task.run
 puts received.sort.inspect  # => [0, 1, 2]
 ```
 
+## Task-Scheduled GC
+
+By default, mruby drives its incremental GC from the allocation path: whichever
+task happens to allocate pays the GC pause, at a moment it does not control.
+`mruby-task` can instead move GC scheduling into the scheduler itself: GC steps
+run only when every task is waiting for a tick — the point where the scheduler
+would otherwise idle the CPU — so allocating tasks never pause for GC at all.
+
+Enable it with one call:
+
+```ruby
+origin_gen = GC.generational_mode
+GC.scheduler_driven = true    # auto_step off + generational off, in one call
+GC.step_limit = 1024          # optional: longest single GC pause you tolerate
+GC.debt_limit = 20_000        # optional: allocation-path backstop if starved
+
+Task.new { do_the_real_work }
+Task.run                      # scheduler runs GC only while all tasks sleep
+
+GC.scheduler_driven = false   # restores auto_step; generational mode stays off
+GC.generational_mode = origin_gen  # restore it yourself if you want it back
+```
+
+The scheduler drives collection from its idle points in both `mrb_task_run`
+and `mrb_task_run_once` (the WASM/event-loop driver advances GC one step per
+host tick). GC consumes strictly otherwise-idle CPU (the ready queue is empty)
+and yields the instant a tick wakes a task, so it never delays a wakeup. There
+is no Ruby GC task, no `Task.list` scan, and no task-switch overhead.
+
+### Primitives
+
+| Method                       | Description                                                                                                                                                        |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `GC.scheduler_driven = bool` | `true` hands GC scheduling to the scheduler (turns `auto_step` off and generational mode off); it drives GC from its idle points. Enabling raises while GC is disabled or ObjectSpace iteration is active, because generational mode cannot be changed safely then. `false` restores `auto_step` (stock allocation-synchronous GC) but does **not** restore generational mode — call `GC.generational_mode = true` yourself if you want it back. |
+| `GC.scheduler_driven`        | Whether scheduler-driven GC is on.                                                                                                                                 |
+| `GC.step_limit = n`          | Cap the work of one step (`0` = unlimited). Bounds the length of one non-preemptible GC pause. Not scheduler-driven-specific: also bounds ordinary auto_step-driven and manual `GC.step` pauses. |
+| `GC.debt_limit = n`          | Safety valve: while scheduler-driven, if the system is 100 % busy and debt exceeds `n`, the allocation path forces a bounded synchronous step. `0` disables. Only has an effect while scheduler-driven — there is no other way to turn `auto_step` off. |
+| `GC.malloc_threshold = n`    | Byte-pressure threshold (`GC.debt` counts objects, not bytes). Not scheduler-driven-specific: the ordinary allocation path also triggers an incremental GC cycle once malloc-backed growth crosses this threshold, even with `auto_step` on. Scheduler-driven GC additionally treats crossing it as a reason to step. |
+
+Observability (`GC.stat`) still reports `:debt`, `:state`, `:malloc_increase`,
+`:live`, and — under `MRB_GC_PROFILE` — the `:prof_sync_*` / `:prof_step_*`
+pause histograms.
+
+The equivalent C entry points are `mrb_gc_scheduler_driven()`,
+`mrb_gc_sched_pending()` and `mrb_gc_step()` (see `mruby/gc.h`).
+
+### Tuning
+
+- **Generational mode is turned off for you.** In generational mode a minor
+  cycle runs to completion inside a single step, and a step is one C call —
+  atomic with respect to preemption. On a large heap that is a long
+  non-preemptible pause, *worse* than the stock behaviour. `GC.scheduler_driven
+  = true` disables generational mode so steps stay finely divisible, and it
+  *stays* off: `GC.generational_mode = true` raises while scheduler-driven GC
+  is on. If GC is disabled or ObjectSpace is iterating, enabling
+  scheduler-driven GC raises instead of entering a mode it cannot make safe.
+- **`GC.step_limit`** bounds the pause of one step. Size it to the longest
+  delay your highest-priority task can tolerate: a step in progress cannot be
+  preempted, so a task becoming ready mid-step waits for the step to finish.
+- **`GC.debt_limit`** is the backstop for starvation: on a 100 %-busy system
+  the scheduler never idles, so it never steps and the heap would grow without
+  bound. The valve forces bounded synchronous steps once debt passes the cap.
+  It bounds heap *growth*, not latency — pick a cap small enough that the valve
+  fires before the heap bloats. Note the valve keys on *object* debt: a starved
+  workload whose pressure is purely malloc bytes (few objects, large buffers,
+  no idle time) is only backstopped by the out-of-memory emergency collection.
+
+### What it does not buy
+
+- Total GC work does not decrease — it increases (idle collection runs more
+  cycles), but the extra work consumes only idle time.
+- A system with no idle time gains nothing: the benefit assumes the typical
+  embedded shape of periodic tasks plus idle gaps.
+- `final_marking_phase` (the atomic root re-scan of all task stacks) is a
+  pause floor a step cannot subdivide; it grows with task count and stack
+  depth.
+- For C embedders: while `auto_step` is off, `mrb_incremental_gc()` silently
+  no-ops. `GC.start` / `mrb_full_gc()` and the out-of-memory emergency
+  collection keep working either way.
+
 ## Limitations and Compatibility
 
 ### Relationship with Fiber
@@ -770,7 +852,9 @@ tasks. The exception is not propagated to the scheduler.
 ### GC Integration
 
 Task contexts are registered with the garbage collector. Tasks and their
-stacks/callinfo are properly marked and freed.
+stacks/callinfo are properly marked and freed. GC scheduling can also be
+handed to the scheduler itself, which then collects at its idle points;
+see [Task-Scheduled GC](#task-scheduled-gc).
 
 ## Testing
 

--- a/mrbgems/mruby-task/include/task.h
+++ b/mrbgems/mruby-task/include/task.h
@@ -220,4 +220,7 @@ mrb_task_excl_exit(mrb_state *mrb)
   }
 }
 
+/* GC.scheduler_driven family - defined in gc.c */
+void mrb_init_task_gc(mrb_state *mrb);
+
 #endif /* MRUBY_TASK_H */

--- a/mrbgems/mruby-task/src/gc.c
+++ b/mrbgems/mruby-task/src/gc.c
@@ -1,0 +1,103 @@
+/*
+** gc.c - GC.scheduler_driven family
+**
+** See Copyright Notice in mruby.h
+*/
+
+#include <mruby.h>
+#include <mruby/gc.h>
+#include <mruby/presym.h>
+
+/* mrb_gc_scheduler_driven(), mrb_gc_scheduler_pending() and mrb_gc_step() (see
+   mruby/gc.h) are core, embedder-generic primitives: any custom scheduler
+   (this gem's mrb_task_run/mrb_task_run_once, or a from-scratch one) can
+   drive GC from its own idle points without linking this gem. What's
+   specific to mruby-task is the Ruby-level on/off switch below -- the
+   gc->sched_driven flag it toggles is read by mrb_gc_scheduler_pending(), which
+   in turn is only ever polled by this gem's scheduler loop.
+
+   GC.debt_limit lives here too, not in core: its only trigger condition is
+   "auto_step is off" (mrb_obj_alloc_core's safety valve), and the only way to
+   ever turn auto_step off from Ruby is GC.scheduler_driven= below -- there is
+   no GC.auto_step= at all. So unlike GC.step_limit/GC.malloc_threshold (which
+   affect the ordinary auto_step-on path too), GC.debt_limit is inert without
+   this gem. */
+
+static mrb_value
+gc_scheduler_driven_get(mrb_state *mrb, mrb_value obj)
+{
+  return mrb_bool_value(mrb->gc.sched_driven);
+}
+
+/*
+ *  call-seq:
+ *     GC.scheduler_driven = bool  -> bool
+ *
+ *  Hands GC scheduling to the task scheduler (true) or back to the allocation
+ *  path (false). Enabling stops the allocation path from driving collection
+ *  and disables generational mode; the scheduler then advances the collector
+ *  from its idle points. Enabling raises while GC is disabled or ObjectSpace
+ *  is iterating, and GC.generational_mode = true raises while this mode is
+ *  on (a generational minor cycle is one atomic step, which would defeat it).
+ *
+ *  Disabling restores auto_step (ordinary allocation-synchronous GC) but
+ *  does NOT restore generational mode -- that stays off until you explicitly
+ *  call GC.generational_mode = true. See mrb_gc_scheduler_driven in
+ *  mruby/gc.h.
+ */
+static mrb_value
+gc_scheduler_driven_set(mrb_state *mrb, mrb_value obj)
+{
+  mrb_bool flag;
+
+  mrb_get_args(mrb, "b", &flag);
+  mrb_gc_scheduler_driven(mrb, flag);
+  return mrb_bool_value(flag);
+}
+
+/*
+ *  call-seq:
+ *     GC.debt_limit -> int
+ *
+ *  Returns the scheduler-driven safety-valve threshold (0 = disabled). While
+ *  GC.scheduler_driven is on, if the scheduler never goes idle (the system is
+ *  100% busy) it never steps and the heap would grow without bound; once
+ *  GC.debt exceeds this limit, the allocation path forces a bounded
+ *  synchronous step instead. Bounds heap *growth*, not latency -- the forced
+ *  step is a real synchronous pause, same as stock GC.
+ */
+static mrb_value
+gc_debt_limit_get(mrb_state *mrb, mrb_value obj)
+{
+  return mrb_int_value(mrb, mrb->gc.debt_limit);
+}
+
+/*
+ *  call-seq:
+ *     GC.debt_limit = int -> int
+ *
+ *  Sets the scheduler-driven safety-valve threshold. See GC.debt_limit.
+ */
+static mrb_value
+gc_debt_limit_set(mrb_state *mrb, mrb_value obj)
+{
+  mrb_int limit;
+
+  mrb_get_args(mrb, "i", &limit);
+  if (limit < 0) {
+    mrb_raise(mrb, E_ARGUMENT_ERROR, "debt_limit must be non-negative");
+  }
+  mrb->gc.debt_limit = limit;
+  return mrb_int_value(mrb, limit);
+}
+
+void
+mrb_init_task_gc(mrb_state *mrb)
+{
+  struct RClass *gc = mrb_module_get_id(mrb, MRB_SYM(GC));
+
+  mrb_define_class_method_id(mrb, gc, MRB_SYM(scheduler_driven), gc_scheduler_driven_get, MRB_ARGS_NONE());
+  mrb_define_class_method_id(mrb, gc, MRB_SYM_E(scheduler_driven), gc_scheduler_driven_set, MRB_ARGS_REQ(1));
+  mrb_define_class_method_id(mrb, gc, MRB_SYM(debt_limit), gc_debt_limit_get, MRB_ARGS_NONE());
+  mrb_define_class_method_id(mrb, gc, MRB_SYM_E(debt_limit), gc_debt_limit_set, MRB_ARGS_REQ(1));
+}

--- a/mrbgems/mruby-task/src/task.c
+++ b/mrbgems/mruby-task/src/task.c
@@ -592,8 +592,13 @@ task_run_body(mrb_state *mrb, void *ud)
         mrb_gc_step(mrb);
         /* q_ready_ was empty above; if a task is READY now, mrb_tick woke it
            *during* the step, so the step delayed it. Record the step's wall
-           time as the jitter that task suffered (no-op without MRB_GC_PROFILE). */
-        mrb_gc_scheduler_jitter(mrb, q_ready_ != NULL);
+           time as the jitter that task suffered (no-op without MRB_GC_PROFILE).
+           q_ready_ is mutated by the mrb_tick IRQ, so read it under the
+           scheduler-IRQ exclusion to get a defined, non-cached load. */
+        mrb_task_excl_enter(mrb);
+        mrb_bool delayed = (q_ready_ != NULL);
+        mrb_task_excl_exit(mrb);
+        mrb_gc_scheduler_jitter(mrb, delayed);
         continue;
       }
       /* If there are tasks waiting or suspended, idle */
@@ -658,7 +663,13 @@ mrb_task_run_once(mrb_state *mrb)
        GC one step per tick. No-op unless GC.scheduler_driven is on. */
     if (mrb_gc_scheduler_pending(mrb)) {
       mrb_gc_step(mrb);
-      mrb_gc_scheduler_jitter(mrb, q_ready_ != NULL);
+      /* q_ready_ is mutated by the mrb_tick IRQ; read it under the
+         scheduler-IRQ exclusion to get a defined, non-cached load
+         (see the matching comment in task_run_body). */
+      mrb_task_excl_enter(mrb);
+      mrb_bool delayed = (q_ready_ != NULL);
+      mrb_task_excl_exit(mrb);
+      mrb_gc_scheduler_jitter(mrb, delayed);
       return mrb_true_value();
     }
     return mrb_nil_value();

--- a/mrbgems/mruby-task/src/task.c
+++ b/mrbgems/mruby-task/src/task.c
@@ -582,6 +582,20 @@ task_run_body(mrb_state *mrb, void *ud)
         /* All tasks are dormant - scheduler done */
         break;
       }
+      /* Task-scheduled GC: every remaining task is waiting for a tick, so this
+         CPU would otherwise idle. Spend it on one unit of GC and loop back to
+         re-check q_ready_ -- if mrb_tick woke a task meanwhile we hand it the
+         CPU immediately, so GC never delays a tick-driven wakeup. Only sleep
+         once there is no GC work left. No-op (returns FALSE) unless
+         GC.scheduler_driven is on. */
+      if (mrb_gc_scheduler_pending(mrb)) {
+        mrb_gc_step(mrb);
+        /* q_ready_ was empty above; if a task is READY now, mrb_tick woke it
+           *during* the step, so the step delayed it. Record the step's wall
+           time as the jitter that task suffered (no-op without MRB_GC_PROFILE). */
+        mrb_gc_scheduler_jitter(mrb, q_ready_ != NULL);
+        continue;
+      }
       /* If there are tasks waiting or suspended, idle */
       mrb_hal_task_idle_cpu(mrb);
       continue;
@@ -634,6 +648,19 @@ mrb_task_run_once(mrb_state *mrb)
 
   /* No task ready */
   if (!t) {
+    /* Task-scheduled GC, single-step variant. Unlike mrb_task_run we cannot
+       drain GC in a loop here: this call must stay non-blocking so the host
+       event loop keeps spinning, so advance the collector by exactly one unit
+       and return. Returning true (progress made) rather than nil tells a host
+       that branches on the result to pump again promptly; nil is reserved for
+       "truly idle", so GC never stalls because the host backed off to a long
+       sleep. Hosts that ignore the result (e.g. a fixed timer) still advance
+       GC one step per tick. No-op unless GC.scheduler_driven is on. */
+    if (mrb_gc_scheduler_pending(mrb)) {
+      mrb_gc_step(mrb);
+      mrb_gc_scheduler_jitter(mrb, q_ready_ != NULL);
+      return mrb_true_value();
+    }
     return mrb_nil_value();
   }
 
@@ -1677,6 +1704,9 @@ mrb_mruby_task_gem_init(mrb_state *mrb)
 
   /* Task::Queue */
   mrb_init_task_queue(mrb, task_class);
+
+  /* GC.scheduler_driven family */
+  mrb_init_task_gc(mrb);
 
   /* Class methods */
   mrb_define_class_method_id(mrb, task_class, MRB_SYM(new),     mrb_task_s_new,     MRB_ARGS_KEY(2,0)|MRB_ARGS_BLOCK());

--- a/mrbgems/mruby-task/test/gc_task.rb
+++ b/mrbgems/mruby-task/test/gc_task.rb
@@ -1,0 +1,122 @@
+# Scheduler-driven GC (GC.scheduler_driven, driven from task.c idle points)
+
+assert("GC.scheduler_driven toggles and forces generational mode off") do
+  origin_gen = GC.generational_mode
+  begin
+    GC.generational_mode = true
+    GC.scheduler_driven = true
+    assert_true GC.scheduler_driven
+    assert_false GC.generational_mode  # forced off (a minor cycle is one step)
+
+    GC.scheduler_driven = false
+    assert_false GC.scheduler_driven
+  ensure
+    GC.scheduler_driven = false
+    GC.generational_mode = origin_gen
+    GC.start
+  end
+end
+
+assert("GC.scheduler_driven= raises while GC disabled, flags unchanged") do
+  origin_gen = GC.generational_mode
+  begin
+    GC.generational_mode = true
+    GC.disable
+    assert_raise(RuntimeError) { GC.scheduler_driven = true }
+    GC.enable
+    assert_false GC.scheduler_driven
+    assert_true GC.generational_mode
+
+    # Raises even when generational mode is already off: the refusal is part
+    # of the enable contract itself, not a side effect of the mode switch.
+    GC.generational_mode = false
+    GC.disable
+    assert_raise(RuntimeError) { GC.scheduler_driven = true }
+    GC.enable
+    assert_false GC.scheduler_driven
+  ensure
+    GC.enable
+    GC.scheduler_driven = false
+    GC.generational_mode = origin_gen
+    GC.start
+  end
+end
+
+assert("GC.generational_mode= refuses to re-enable while scheduler-driven") do
+  origin_gen = GC.generational_mode
+  begin
+    GC.scheduler_driven = true
+    # A generational minor cycle completes inside one atomic step, which would
+    # silently defeat scheduler-driven stepping -- so this must raise.
+    assert_raise(RuntimeError) { GC.generational_mode = true }
+    assert_false GC.generational_mode
+    assert_true GC.scheduler_driven
+
+    GC.scheduler_driven = false
+    GC.generational_mode = true   # fine again once the mode is off
+    assert_true GC.generational_mode
+  ensure
+    GC.scheduler_driven = false
+    GC.generational_mode = origin_gen
+    GC.start
+  end
+end
+
+assert('GC.debt_limit= validates and round-trips') do
+  origin = GC.debt_limit
+  begin
+    assert_equal 50000, (GC.debt_limit = 50000)
+    assert_equal 50000, GC.debt_limit
+    assert_raise(ArgumentError) { GC.debt_limit = -1 }
+    assert_equal 0, (GC.debt_limit = 0)
+  ensure
+    GC.debt_limit = origin
+  end
+end
+
+assert("GC.scheduler_driven collects during scheduler idle") do
+  origin_gen = GC.generational_mode
+  origin_interval = GC.interval_ratio
+  begin
+    GC.generational_mode = false
+    GC.start
+    base = GC.stat[:live]
+
+    GC.step_limit = 256
+    # Smallest collection credit (clamps to GC_STEP_SIZE), so idle stepping
+    # kicks in after ~1k allocations instead of a fraction of the (large,
+    # mrbtest-inflated) live set -- keeps the workload below deterministic.
+    GC.interval_ratio = 100
+    GC.scheduler_driven = true
+    steps_before = GC.stat[:prof_step_count]  # nil unless MRB_GC_PROFILE
+
+    # Allocate garbage, then sleep so the scheduler goes idle and drives GC.
+    Task.new(name: "alloc") do
+      30.times do
+        400.times { "x" * 8 }
+        sleep_ms 1
+      end
+    end
+    Task.run   # returns once the alloc task is DORMANT (all queues empty)
+
+    # Sample BEFORE any GC.start: a full GC reclaims garbage regardless of
+    # scheduler_driven, so only a pre-GC.start reading can prove the idle
+    # steps did the collecting. The task churned >=24000 garbage strings
+    # (literal + product per iteration) with allocation-path GC off; staying
+    # well below that means scheduler-driven idle steps reclaimed them.
+    live_after_run = GC.stat[:live]
+    assert_true live_after_run < base + 6000,
+                "scheduler-driven GC did not reclaim during idle " \
+                "(#{base} -> #{live_after_run})"
+    if steps_before
+      assert_true GC.stat[:prof_step_count] > steps_before,
+                  "no scheduler-driven GC step ran"
+    end
+  ensure
+    GC.scheduler_driven = false
+    GC.step_limit = 0
+    GC.interval_ratio = origin_interval
+    GC.generational_mode = origin_gen
+    GC.start
+  end
+end

--- a/src/gc.c
+++ b/src/gc.c
@@ -32,6 +32,64 @@
 void mrb_task_mark_all(mrb_state *mrb);
 #endif
 
+#ifdef MRB_GC_PROFILE
+#include <time.h>
+#include <stdio.h>
+
+/* Monotonic microsecond clock for pause measurement. Returns 0 where no
+   monotonic clock is available, which degrades the histogram gracefully
+   (durations collapse to bucket 0) rather than breaking the build. */
+static uint64_t
+gc_prof_now_us(void)
+{
+#if defined(CLOCK_MONOTONIC)
+  struct timespec ts;
+  if (clock_gettime(CLOCK_MONOTONIC, &ts) == 0) {
+    return (uint64_t)ts.tv_sec * 1000000u + (uint64_t)ts.tv_nsec / 1000u;
+  }
+#endif
+  return 0;
+}
+
+static void
+gc_prof_record(mrb_gc_prof_hist *h, uint64_t us)
+{
+  unsigned i = 0;
+  uint64_t v = us;
+  h->count++;
+  h->total_us += us;
+  if (us > h->max_us) h->max_us = us;
+  while (v > 0 && i < MRB_GC_PROFILE_NBUCKETS - 1) { v >>= 1; i++; }
+  h->buckets[i]++;
+}
+
+/* Reentrancy-guarded pause timing: only the outermost GC entry starts the
+   clock and picks the target histogram, so a nested mrb_full_gc (e.g. major
+   GC escalation during a step) is attributed to whichever entry the mutator
+   actually called, not double-counted. Returns the start time; pass it back
+   to gc_prof_leave. */
+static uint64_t
+gc_prof_enter(mrb_gc *gc, mrb_gc_prof_hist *target)
+{
+  if (gc->prof_depth++ == 0) {
+    gc->prof_target = target;
+    return gc_prof_now_us();
+  }
+  return 0;
+}
+
+static uint64_t
+gc_prof_leave(mrb_gc *gc, uint64_t t0)
+{
+  if (--gc->prof_depth == 0 && gc->prof_target) {
+    uint64_t dt = gc_prof_now_us() - t0;
+    gc_prof_record(gc->prof_target, dt);
+    return dt;
+  }
+  return 0;
+}
+#endif
+
 /*
   = Tri-color Incremental Garbage Collection
 
@@ -208,7 +266,8 @@ mrb_static_assert(MRB_GC_RED <= GC_COLOR_MASK);
 
 mrb_noreturn void mrb_raise_nomemory(mrb_state *mrb);
 
-static void incremental_gc_finish(mrb_state *mrb, mrb_gc *gc);
+static size_t incremental_gc_finish(mrb_state *mrb, mrb_gc *gc);
+static size_t incremental_gc_run(mrb_state *mrb, mrb_gc *gc);
 
 MRB_API void*
 mrb_realloc_simple(mrb_state *mrb, void *p,  size_t len)
@@ -221,20 +280,26 @@ mrb_realloc_simple(mrb_state *mrb, void *p,  size_t len)
   }
 #endif
   p2 = mrb_basic_alloc_func(p, len);
-  if (!p2 && len > 0 && mrb->gc.heaps && !mrb->gc.collecting) {
+  if (!p2 && len > 0 && mrb->gc.heaps && !mrb->gc.collecting &&
+      !mrb->gc.disabled && !mrb->gc.iterating) {
     /* collecting == FALSE means no mark/sweep is running on the stack, so
        this failure is a mutator allocation, not one from inside the GC
        engine (e.g. an RData dfree during sweep). Recovery runs only here; a
        reentrant failure falls through to raise NoMemoryError as before.
-       gc_drive() sets collecting. */
+       gc_drive() sets collecting. disabled/iterating are checked here too so
+       the retry (and the emergency counter) only happen when recovery can
+       actually run. */
+#ifdef MRB_GC_PROFILE
+    mrb->gc.prof_emergency_count++;
+#endif
     if (mrb->gc.state == MRB_GC_STATE_SWEEP) {
       /* Mid-sweep: starting a new mark cycle here is unsafe, but finishing
          the in-progress sweep is safe and is exactly what reclaims memory.
          Without this an allocation failure while parked in SWEEP raised
-         NoMemoryError even though free slots were about to be produced. */
-      if (!mrb->gc.disabled && !mrb->gc.iterating) {
-        incremental_gc_finish(mrb, &mrb->gc);
-      }
+         NoMemoryError even though free slots were about to be produced.
+         Also matters when GC steps are driven off the allocation path
+         (auto_step off) and the heap can be parked in SWEEP for a while. */
+      incremental_gc_finish(mrb, &mrb->gc);
     }
     else {
       mrb_full_gc(mrb);
@@ -248,7 +313,7 @@ mrb_realloc_simple(mrb_state *mrb, void *p,  size_t len)
         mrb->gc.malloc_threshold > 0 &&
         mrb->gc.malloc_increase >= mrb->gc.malloc_threshold &&
         mrb->gc.state == MRB_GC_STATE_ROOT &&
-        !mrb->gc.disabled && !mrb->gc.iterating) {
+        !mrb->gc.disabled && !mrb->gc.iterating && mrb->gc.auto_step) {
       /* Only a fresh allocation (p == NULL) may drive the collector here. A
          realloc (p != NULL) has just freed the caller's old block, but the
          caller has not yet stored the returned pointer back into the object it
@@ -259,7 +324,12 @@ mrb_realloc_simple(mrb_state *mrb, void *p,  size_t len)
          pointer, a use-after-free. A fresh allocation frees nothing the caller
          references, so it is a safe point to step GC. Byte pressure from
          reallocs is not lost: malloc_increase keeps accumulating above and
-         fires at the next fresh allocation. */
+         fires at the next fresh allocation.
+
+         auto_step is part of the condition (not just relied on inside
+         mrb_incremental_gc) so malloc_increase is not cleared for a call
+         that would no-op -- the GC task reads malloc_increase as a byte
+         pressure signal. */
       mrb->gc.malloc_increase = 0;
       mrb_incremental_gc(mrb);
     }
@@ -460,6 +530,8 @@ mrb_gc_init(mrb_state *mrb, mrb_gc *gc)
   add_heap(mrb, gc);
   gc->interval_ratio = DEFAULT_GC_INTERVAL_RATIO;
   gc->step_ratio = DEFAULT_GC_STEP_RATIO;
+  gc->auto_step = TRUE;
+  gc->sched_driven = FALSE;
 #ifndef MRB_GC_TURN_OFF_GENERATIONAL
   gc->generational = TRUE;
   gc->full = TRUE;
@@ -607,43 +679,63 @@ mrb_obj_alloc_core(mrb_state *mrb, enum mrb_vtype ttype, struct RClass *cls)
   gc->gc_debt++;
   if (gc->gc_debt > 0) {
     mrb_incremental_gc(mrb);
+    /* Safety valve: when auto_step is off, mrb_incremental_gc no-ops and the
+       GC task is expected to drive collection. If it falls behind and debt
+       runs past debt_limit, force synchronous progress here so the worst
+       case stays bounded rather than growing the heap without limit. */
+    if (!gc->auto_step && gc->debt_limit > 0 && gc->gc_debt > gc->debt_limit &&
+        !gc->disabled && !gc->iterating) {
+#ifdef MRB_GC_PROFILE
+      uint64_t prof_t0 = gc_prof_enter(gc, &gc->prof_sync);
+#endif
+      incremental_gc_run(mrb, gc);
+#ifdef MRB_GC_PROFILE
+      gc_prof_leave(gc, prof_t0);
+#endif
+    }
   }
   gc_arena_keep(mrb, gc);
   if (gc->free_heaps == NULL) {
-    /* Free slots ran out: try to reclaim before growing. A full
-       collection finishes the (possibly half-run) incremental cycle
-       and sweeps its garbage, usually refilling the freelists without
-       adding a page. Growing immediately instead ratchets the page
-       count up to the workload's transient high-water mark and it
-       never comes back down — pages are only freed when COMPLETELY
-       empty, so fragmentation keeps them pinned. On fixed-arena
-       targets the pages eventually consume the whole arena even
-       though most of their slots are free.
+    /* Free slots ran out. Under the auto_step allocation-driven policy, try to
+       reclaim before growing: a full collection finishes the (possibly
+       half-run) incremental cycle and sweeps its garbage, usually refilling the
+       freelists without adding a page. Growing immediately instead ratchets the
+       page count up to the workload's transient high-water mark and it never
+       comes back down — pages are only freed when COMPLETELY empty, so
+       fragmentation keeps them pinned. On fixed-arena targets the pages
+       eventually consume the whole arena even though most of their slots are
+       free.
 
-       Only attempt the collection when the accounting shows real
-       slack (live well below capacity): if the heap is genuinely
-       full of live objects — e.g. a growing working set — collecting
-       before every page-add just burns time, so grow directly as
-       before. Walking the page list here is fine: growth events are
-       rare and the walk is a few pointer hops per page.
-       (mrb_full_gc() is a no-op while the GC is disabled or
-       iterating; we grow as before in that case, too.) */
-    size_t capacity = 0;
-    for (mrb_heap_page *page = gc->heaps; page; page = page->next) {
-      capacity += MRB_HEAP_PAGE_SIZE;
-    }
-    /* gc->live is inflated by dead-but-unswept objects at this point,
-       so it cannot distinguish "full of garbage" (reclaim!) from
-       "full of live data" (grow!). live_after_mark from the last
-       completed cycle is the garbage-free estimate of the true live
-       set: sweep decrements it as objects are freed. */
-    /* The !collecting guard mirrors mrb_realloc_simple(): allocation
-       can re-enter here from inside a running mark/sweep (an RData
-       dfree callback that allocates during the sweep phase), and
-       starting a nested collection there would corrupt the GC's
-       in-progress state. */
-    if (!gc->collecting && gc->live_after_mark + MRB_HEAP_PAGE_SIZE/2 < capacity) {
-      mrb_full_gc(mrb);
+       Skip the reclaim entirely under GC.scheduler_driven (auto_step off): the
+       allocation path must not run a synchronous collection there — it would
+       re-introduce exactly the pauses the mode removes and, by finishing the
+       cycle atomically, starve the scheduler's idle stepping. In that mode we
+       grow here and leave reclamation to the idle steps and the debt_limit
+       safety valve. Keeping the heap tight is not a goal of scheduler-driven
+       mode; bounded latency is.
+
+       The !collecting guard mirrors mrb_realloc_simple(): allocation can
+       re-enter here from inside a running mark/sweep (an RData dfree callback
+       that allocates during the sweep phase), and starting a nested collection
+       there would corrupt the GC's in-progress state. */
+    if (gc->auto_step && !gc->collecting) {
+      /* gc->live is inflated by dead-but-unswept objects at this point, so it
+         cannot distinguish "full of garbage" (reclaim!) from "full of live
+         data" (grow!). live_after_mark from the last completed cycle is the
+         garbage-free estimate of the true live set: sweep decrements it as
+         objects are freed. Only reclaim when the accounting shows real slack
+         (live well below capacity); otherwise a working set that is genuinely
+         growing would collect before every page-add and just burn time, so
+         grow directly. Walking the page list here is fine: growth events are
+         rare and the walk is a few pointer hops per page. (mrb_full_gc() is
+         also a no-op while GC is disabled or iterating; we grow then, too.) */
+      size_t capacity = 0;
+      for (mrb_heap_page *page = gc->heaps; page; page = page->next) {
+        capacity += MRB_HEAP_PAGE_SIZE;
+      }
+      if (gc->live_after_mark + MRB_HEAP_PAGE_SIZE/2 < capacity) {
+        mrb_full_gc(mrb);
+      }
     }
     if (gc->free_heaps == NULL) {
       add_heap(mrb, gc);
@@ -1372,16 +1464,35 @@ incremental_gc(mrb_state *mrb, mrb_gc *gc, size_t limit)
     return 0;
   case MRB_GC_STATE_MARK:
     if (gc->gray_stack_top > 0 || gc->gray_overflow) {
-      return incremental_marking_phase(mrb, gc, limit);
+      size_t tried_marks = incremental_marking_phase(mrb, gc, limit);
+#ifdef MRB_GC_PROFILE
+      gc->prof_mark_work_total += tried_marks;
+#endif
+      return tried_marks;
     }
     else {
+#ifdef MRB_GC_PROFILE
+      uint64_t fm0 = gc_prof_now_us();
+#endif
       final_marking_phase(mrb, gc);
+#ifdef MRB_GC_PROFILE
+      {
+        uint64_t fmdt = gc_prof_now_us() - fm0;
+        if (fmdt > gc->prof_final_mark_max_us) {
+          gc->prof_final_mark_max_us = fmdt;
+          gc->prof_final_mark_max_live = gc->live;
+        }
+      }
+#endif
       prepare_incremental_sweep(mrb, gc);
       return 0;
     }
   case MRB_GC_STATE_SWEEP: {
      size_t tried_sweep = 0;
      tried_sweep = incremental_sweep_phase(mrb, gc, limit);
+#ifdef MRB_GC_PROFILE
+     gc->prof_sweep_work_total += tried_sweep;
+#endif
      if (tried_sweep == 0)
        gc->state = MRB_GC_STATE_ROOT;
      return tried_sweep;
@@ -1426,8 +1537,8 @@ run_incremental(mrb_state *mrb, mrb_gc *gc, size_t limit, mrb_bool run_to_root)
  *
  * Every path that can sweep funnels through this helper (incremental_gc is
  * only ever called from here), so all callers -- mrb_incremental_gc,
- * mrb_full_gc, clear_all_old, change_gen_gc_mode and the emergency path --
- * are covered without each having to manage the flag.
+ * mrb_full_gc, clear_all_old, change_gen_gc_mode, gc_drive, and the emergency
+ * path -- are covered without each having to manage the flag.
  *
  * When an outer jmp buffer exists, wrap the run in MRB_TRY/MRB_CATCH so the
  * flag is restored on both normal return and a longjmp out of a dfree (so it
@@ -1456,6 +1567,15 @@ gc_drive(mrb_state *mrb, mrb_gc *gc, size_t limit, mrb_bool run_to_root)
       gc->collecting = was_collecting;
     } MRB_CATCH(&c_jmp) {
       gc->collecting = was_collecting;
+#ifdef MRB_GC_PROFILE
+      /* This longjmp is about to unwind every gc_prof_enter frame on the
+         stack: they all wrap gc_drive transitively and nothing between here
+         and them catches, so their gc_prof_leave calls never run. Reset the
+         depth, or profiling would silently stop recording for the rest of
+         the process (enter would never see depth 0 again). */
+      gc->prof_depth = 0;
+      gc->prof_target = NULL;
+#endif
       mrb->jmp = prev_jmp;
       MRB_THROW(prev_jmp);
     } MRB_END_EXC(&c_jmp);
@@ -1468,20 +1588,23 @@ gc_drive(mrb_state *mrb, mrb_gc *gc, size_t limit, mrb_bool run_to_root)
   return result;
 }
 
-static void
+static size_t
 incremental_gc_finish(mrb_state *mrb, mrb_gc *gc)
 {
-  gc_drive(mrb, gc, SIZE_MAX, TRUE);
+  return gc_drive(mrb, gc, SIZE_MAX, TRUE);
 }
 
-static void
+static size_t
 incremental_gc_step(mrb_state *mrb, mrb_gc *gc)
 {
   size_t limit = (GC_STEP_SIZE/100) * gc->step_ratio;
+  size_t result;
   if (gc->step_limit > 0 && limit > gc->step_limit) {
     limit = gc->step_limit;
   }
-  gc->gc_debt -= (mrb_int)gc_drive(mrb, gc, limit, FALSE);
+  result = gc_drive(mrb, gc, limit, FALSE);
+  gc->gc_debt -= (mrb_int)result;
+  return result;
 }
 
 static void
@@ -1503,19 +1626,22 @@ clear_all_old(mrb_state *mrb, mrb_gc *gc)
   gc->gray_overflow = FALSE;
 }
 
-MRB_API void
-mrb_incremental_gc(mrb_state *mrb)
+/* One unit of incremental GC progress plus the end-of-cycle bookkeeping.
+   This is the body of the GC engine with no policy guard: callers decide
+   whether it may run (mrb_incremental_gc honours disabled/auto_step;
+   mrb_gc_step drives it directly). Kept separate so the scheduler-driven and
+   automatic drivers share identical mark/sweep/debt/generational semantics. */
+static size_t
+incremental_gc_run(mrb_state *mrb, mrb_gc *gc)
 {
-  mrb_gc *gc = &mrb->gc;
-
-  if (gc->disabled || gc->iterating) return;
+  size_t work;
 
   if (is_minor_gc(gc)) {
 #ifdef MRB_GC_STATS
     gc->gc_total_count++;
     gc->minor_gc_count++;
 #endif
-    incremental_gc_finish(mrb, gc);
+    work = incremental_gc_finish(mrb, gc);
   }
   else {
 #ifdef MRB_GC_STATS
@@ -1524,7 +1650,7 @@ mrb_incremental_gc(mrb_state *mrb)
       gc->major_gc_count++;
     }
 #endif
-    incremental_gc_step(mrb, gc);
+    work = incremental_gc_step(mrb, gc);
   }
 
   if (gc->state == MRB_GC_STATE_ROOT) {
@@ -1555,6 +1681,30 @@ mrb_incremental_gc(mrb_state *mrb)
       gc->full = TRUE;
     }
   }
+
+  return work;
+}
+
+/* Advance the incremental collector by one policy-sized unit.
+ *
+ * NOTE: this honours the auto_step flag -- when collection is driven by the
+ * task scheduler instead (GC.scheduler_driven = true, auto_step off), this
+ * call silently no-ops. An embedder that needs unconditional collection must
+ * use mrb_full_gc(). */
+MRB_API void
+mrb_incremental_gc(mrb_state *mrb)
+{
+  mrb_gc *gc = &mrb->gc;
+
+  if (gc->disabled || gc->iterating || !gc->auto_step) return;
+
+#ifdef MRB_GC_PROFILE
+  uint64_t prof_t0 = gc_prof_enter(gc, &gc->prof_sync);
+#endif
+  incremental_gc_run(mrb, gc);
+#ifdef MRB_GC_PROFILE
+  gc_prof_leave(gc, prof_t0);
+#endif
 }
 
 /* Perform a full gc cycle */
@@ -1565,6 +1715,10 @@ mrb_full_gc(mrb_state *mrb)
 
   if (!mrb->c) return;
   if (gc->disabled || gc->iterating) return;
+
+#ifdef MRB_GC_PROFILE
+  uint64_t prof_t0 = gc_prof_enter(gc, &gc->prof_sync);
+#endif
 
 #ifdef MRB_GC_STATS
   gc->gc_total_count++;
@@ -1595,6 +1749,10 @@ mrb_full_gc(mrb_state *mrb)
 
 #ifdef MRB_USE_MALLOC_TRIM
   malloc_trim(0);
+#endif
+
+#ifdef MRB_GC_PROFILE
+  gc_prof_leave(gc, prof_t0);
 #endif
 }
 
@@ -1771,6 +1929,7 @@ gc_step_ratio_get(mrb_state *mrb, mrb_value obj)
  *
  *  Updates step span ratio of Incremental GC. Default value is 200(%).
  *  1 step of incrementalGC becomes long if a rate is big.
+ *  Must be positive.
  *
  */
 
@@ -1780,16 +1939,35 @@ gc_step_ratio_set(mrb_state *mrb, mrb_value obj)
   mrb_int ratio;
 
   mrb_get_args(mrb, "i", &ratio);
+  if (ratio <= 0) {
+    mrb_raise(mrb, E_ARGUMENT_ERROR, "step_ratio must be positive");
+  }
   mrb->gc.step_ratio = (int)ratio;
   return mrb_nil_value();
 }
 
+/*
+ *  call-seq:
+ *     GC.step_limit -> int
+ *
+ *  Returns the cap on the work done by one incremental GC step (0 = unlimited).
+ *  Applies to every step regardless of what drives it: the ordinary
+ *  allocation path, a manual GC.step, or a scheduler-driven step (see
+ *  mruby-task's GC.scheduler_driven). Bounds the length of the single
+ *  longest non-preemptible GC pause.
+ */
 static mrb_value
 gc_step_limit_get(mrb_state *mrb, mrb_value obj)
 {
   return mrb_int_value(mrb, (mrb_int)mrb->gc.step_limit);
 }
 
+/*
+ *  call-seq:
+ *     GC.step_limit = int -> int
+ *
+ *  Sets the cap on the work done by one incremental GC step. See GC.step_limit.
+ */
 static mrb_value
 gc_step_limit_set(mrb_state *mrb, mrb_value obj)
 {
@@ -1803,12 +1981,31 @@ gc_step_limit_set(mrb_state *mrb, mrb_value obj)
   return mrb_int_value(mrb, limit);
 }
 
+/*
+ *  call-seq:
+ *     GC.malloc_threshold -> int
+ *
+ *  Returns the malloc-backed byte-growth threshold that triggers an
+ *  incremental GC cycle (0 = disabled). Unlike GC.debt (which counts
+ *  objects), this catches workloads that allocate few but large
+ *  malloc-backed payloads (long String/Array buffers). It fires in two
+ *  places: the ordinary allocation path triggers GC.start's incremental
+ *  counterpart once malloc growth crosses this threshold even in stock
+ *  auto_step mode, and mruby-task's GC.scheduler_driven also treats crossing
+ *  it as a reason to step.
+ */
 static mrb_value
 gc_malloc_threshold_get(mrb_state *mrb, mrb_value obj)
 {
   return mrb_int_value(mrb, (mrb_int)mrb->gc.malloc_threshold);
 }
 
+/*
+ *  call-seq:
+ *     GC.malloc_threshold = int -> int
+ *
+ *  Sets the malloc-backed byte-growth threshold. See GC.malloc_threshold.
+ */
 static mrb_value
 gc_malloc_threshold_set(mrb_state *mrb, mrb_value obj)
 {
@@ -1829,6 +2026,15 @@ change_gen_gc_mode(mrb_state *mrb, mrb_gc *gc, mrb_bool enable)
     mrb_raise(mrb, E_RUNTIME_ERROR, "generational mode changed when GC disabled");
     return;
   }
+  if (enable && gc->sched_driven) {
+    /* Scheduler-driven mode requires generational off: a minor cycle runs to
+       completion inside one atomic step, which defeats fine-grained idle
+       stepping. Silently allowing this would re-introduce exactly the pauses
+       the mode exists to remove, so refuse. (mrb_gc_scheduler_driven itself
+       only ever disables generational mode here, never enables it.) */
+    mrb_raise(mrb, E_RUNTIME_ERROR, "generational mode conflicts with scheduler-driven GC");
+    return;
+  }
   if (is_generational(gc) && !enable) {
     clear_all_old(mrb, gc);
     mrb_assert(gc->state == MRB_GC_STATE_ROOT);
@@ -1840,6 +2046,97 @@ change_gen_gc_mode(mrb_state *mrb, mrb_gc *gc, mrb_bool enable)
     gc->full = FALSE;
   }
   gc->generational = enable;
+}
+
+/* One unit of incremental GC progress, unconditional except for the
+   disabled/iterating guard. This is the entry point the task scheduler drives
+   from its idle points; it deliberately ignores auto_step so collection still
+   advances while the allocation path is not driving it. Pauses are attributed
+   to prof_step (work moved off the allocation path). */
+MRB_API mrb_int
+mrb_gc_step(mrb_state *mrb)
+{
+  mrb_gc *gc = &mrb->gc;
+  size_t work;
+
+  if (gc->disabled || gc->iterating) return 0;
+
+#ifdef MRB_GC_PROFILE
+  {
+    uint64_t prof_t0 = gc_prof_enter(gc, &gc->prof_step);
+    work = incremental_gc_run(mrb, gc);
+    gc->prof_last_step_us = gc_prof_leave(gc, prof_t0);
+  }
+#else
+  work = incremental_gc_run(mrb, gc);
+#endif
+  return (mrb_int)work;
+}
+
+/* See mruby/gc.h. Records the last step's wall time as jitter when the
+   scheduler reports that step delayed a task. */
+MRB_API void
+mrb_gc_scheduler_jitter(mrb_state *mrb, mrb_bool delayed_task)
+{
+#ifdef MRB_GC_PROFILE
+  if (delayed_task) {
+    mrb_gc *gc = &mrb->gc;
+    gc_prof_record(&gc->prof_step_jitter, gc->prof_last_step_us);
+  }
+#else
+  (void)mrb;
+  (void)delayed_task;
+#endif
+}
+
+/* Whether scheduler-driven GC has work worth doing right now: a cycle is in
+   progress, collection is overdue by object debt, or malloc-backed byte
+   pressure has crossed malloc_threshold. Always FALSE when scheduler-driven
+   mode is off, so the scheduler can gate on this alone. Keeps the "is a step
+   warranted" policy inside gc.c; the scheduler only wires idle points to it. */
+MRB_API mrb_bool
+mrb_gc_scheduler_pending(mrb_state *mrb)
+{
+  mrb_gc *gc = &mrb->gc;
+
+  if (!gc->sched_driven || gc->disabled || gc->iterating) return FALSE;
+  if (gc->gc_debt > 0) return TRUE;
+  if (gc->state != MRB_GC_STATE_ROOT) return TRUE;
+  if (gc->malloc_threshold > 0 && gc->malloc_increase >= gc->malloc_threshold)
+    return TRUE;
+  return FALSE;
+}
+
+/* Hand GC scheduling to the task scheduler (enable) or back to the allocation
+   path (disable). See the header comment for the contract. */
+MRB_API void
+mrb_gc_scheduler_driven(mrb_state *mrb, mrb_bool enable)
+{
+  mrb_gc *gc = &mrb->gc;
+
+  if (enable) {
+    /* Refuse while GC is disabled or ObjectSpace is iterating, regardless of
+       whether generational mode happens to be on (change_gen_gc_mode below
+       would only catch the generational case): the contract is deterministic,
+       and the raise leaves the driver flags unchanged. */
+    if (gc->disabled || gc->iterating) {
+      mrb_raise(mrb, E_RUNTIME_ERROR, "scheduler-driven GC enabled when GC disabled");
+      return;
+    }
+    /* A minor cycle otherwise completes inside one atomic step, which defeats
+       incremental scheduler stepping, so drop to non-generational first.
+       change_gen_gc_mode refuses to re-enable generational mode while
+       sched_driven is set, so the two flags cannot get out of sync later. */
+    if (is_generational(gc)) {
+      change_gen_gc_mode(mrb, gc, FALSE);
+    }
+    gc->auto_step = FALSE;
+    gc->sched_driven = TRUE;
+  }
+  else {
+    gc->sched_driven = FALSE;
+    gc->auto_step = TRUE;
+  }
 }
 
 /*
@@ -1961,8 +2258,72 @@ gc_stat(mrb_state *mrb, mrb_value self)
   mrb_hash_set(mrb, hash, mrb_symbol_value(MRB_SYM(major)), mrb_int_value(mrb, (mrb_int)gc->major_gc_count));
 #endif
 
+#ifdef MRB_GC_PROFILE
+  /* Profiling keys are only present when MRB_GC_PROFILE is compiled in;
+     the interned literals avoid depending on presym regeneration. Two pause
+     populations are reported separately: :prof_sync_* are the synchronous
+     mutator pauses this feature aims to shrink, :prof_step_* are the pauses
+     relocated onto the scheduler's idle-time GC steps. */
+  {
+    int i;
+    mrb_gc_prof_hist *hs[3];
+    const char *pfx[3];
+    hs[0] = &gc->prof_sync;         pfx[0] = "prof_sync";
+    hs[1] = &gc->prof_step;         pfx[1] = "prof_step";
+    hs[2] = &gc->prof_step_jitter;  pfx[2] = "prof_step_jitter";
+    for (i = 0; i < 3; i++) {
+      char key[40];
+      int j;
+      mrb_value buckets;
+      snprintf(key, sizeof(key), "%s_count", pfx[i]);
+      mrb_hash_set(mrb, hash, mrb_symbol_value(mrb_intern_cstr(mrb, key)), mrb_int_value(mrb, (mrb_int)hs[i]->count));
+      snprintf(key, sizeof(key), "%s_total_us", pfx[i]);
+      mrb_hash_set(mrb, hash, mrb_symbol_value(mrb_intern_cstr(mrb, key)), mrb_int_value(mrb, (mrb_int)hs[i]->total_us));
+      snprintf(key, sizeof(key), "%s_max_us", pfx[i]);
+      mrb_hash_set(mrb, hash, mrb_symbol_value(mrb_intern_cstr(mrb, key)), mrb_int_value(mrb, (mrb_int)hs[i]->max_us));
+      snprintf(key, sizeof(key), "%s_hist", pfx[i]);
+      buckets = mrb_ary_new_capa(mrb, MRB_GC_PROFILE_NBUCKETS);
+      for (j = 0; j < MRB_GC_PROFILE_NBUCKETS; j++) {
+        mrb_ary_push(mrb, buckets, mrb_int_value(mrb, (mrb_int)hs[i]->buckets[j]));
+      }
+      mrb_hash_set(mrb, hash, mrb_symbol_value(mrb_intern_cstr(mrb, key)), buckets);
+    }
+    mrb_hash_set(mrb, hash, mrb_symbol_value(mrb_intern_lit(mrb, "prof_final_mark_max_us")), mrb_int_value(mrb, (mrb_int)gc->prof_final_mark_max_us));
+    mrb_hash_set(mrb, hash, mrb_symbol_value(mrb_intern_lit(mrb, "prof_final_mark_max_live")), mrb_int_value(mrb, (mrb_int)gc->prof_final_mark_max_live));
+    mrb_hash_set(mrb, hash, mrb_symbol_value(mrb_intern_lit(mrb, "prof_mark_work_total")), mrb_int_value(mrb, (mrb_int)gc->prof_mark_work_total));
+    mrb_hash_set(mrb, hash, mrb_symbol_value(mrb_intern_lit(mrb, "prof_sweep_work_total")), mrb_int_value(mrb, (mrb_int)gc->prof_sweep_work_total));
+    mrb_hash_set(mrb, hash, mrb_symbol_value(mrb_intern_lit(mrb, "prof_emergency_count")), mrb_int_value(mrb, (mrb_int)gc->prof_emergency_count));
+  }
+#endif
+
   return hash;
 }
+
+#ifdef MRB_GC_PROFILE
+/*
+ *  call-seq:
+ *     GC.reset_stat  -> nil
+ *
+ *  Zeroes the MRB_GC_PROFILE pause/work counters. Only defined when the
+ *  profiler is compiled in. Lets a benchmark discard warm-up before the
+ *  measured window.
+ */
+static mrb_value
+gc_reset_stat(mrb_state *mrb, mrb_value self)
+{
+  mrb_gc *gc = &mrb->gc;
+  memset(&gc->prof_sync, 0, sizeof(gc->prof_sync));
+  memset(&gc->prof_step, 0, sizeof(gc->prof_step));
+  memset(&gc->prof_step_jitter, 0, sizeof(gc->prof_step_jitter));
+  gc->prof_last_step_us = 0;
+  gc->prof_final_mark_max_us = 0;
+  gc->prof_final_mark_max_live = 0;
+  gc->prof_mark_work_total = 0;
+  gc->prof_sweep_work_total = 0;
+  gc->prof_emergency_count = 0;
+  return mrb_nil_value();
+}
+#endif
 
 void
 mrb_init_gc(mrb_state *mrb)
@@ -1980,6 +2341,9 @@ mrb_init_gc(mrb_state *mrb)
   gc = mrb_define_module_id(mrb, MRB_SYM(GC));
 
   mrb_define_class_method_id(mrb, gc, MRB_SYM(stat), gc_stat, MRB_ARGS_NONE());
+#ifdef MRB_GC_PROFILE
+  mrb_define_class_method(mrb, gc, "reset_stat", gc_reset_stat, MRB_ARGS_NONE());
+#endif
   mrb_define_class_method_id(mrb, gc, MRB_SYM(start), gc_start, MRB_ARGS_NONE());
   mrb_define_class_method_id(mrb, gc, MRB_SYM(enable), gc_enable, MRB_ARGS_NONE());
   mrb_define_class_method_id(mrb, gc, MRB_SYM(disable), gc_disable, MRB_ARGS_NONE());

--- a/test/t/gc.rb
+++ b/test/t/gc.rb
@@ -28,6 +28,8 @@ assert('GC.step_ratio=') do
   origin = GC.step_ratio
   begin
     assert_equal 150, (GC.step_ratio = 150)
+    assert_raise(ArgumentError) { GC.step_ratio = 0 }
+    assert_raise(ArgumentError) { GC.step_ratio = -1 }
   ensure
     GC.step_ratio = origin
   end


### PR DESCRIPTION
## Summary

This PR adds task-scheduled GC support for mruby-task.

Today, mruby advances incremental GC from the allocation path. In a task-based program, that means whichever task happens to allocate also pays the GC pause, at a point it does not control.

This PR adds a scheduler-driven mode:

- `GC.scheduler_driven = true` disables allocation-path GC stepping and lets mruby-task drive GC from scheduler idle points.
- `mrb_task_run()` drains GC work only while no task is ready.
- `mrb_task_run_once()` advances at most one GC step when no task is ready, so event-loop hosts remain non-blocking.
- `GC.debt_limit` provides a starvation backstop when the system never idles.
- `GC.malloc_threshold` lets scheduler-driven GC react to malloc-backed byte pressure, not only object debt.

The goal is not to reduce total GC work. The goal is to move GC work away from latency-sensitive allocating tasks and into time the scheduler would otherwise spend idle.

That claim — that GC pauses leave the allocating task — is only credible if it can be measured, so this PR also lands an `MRB_GC_PROFILE` measurement layer in the core GC. It records log-scale histograms of three separately-attributed pause classes — synchronous mutator pauses (`prof_sync`), scheduler-driven idle steps (`prof_step`), and the jitter those steps actually inject into a task that woke mid-step (`prof_step_jitter`) — alongside the final-marking pause floor, machine-independent mark/sweep work counters, and an emergency-GC count. All of it is surfaced through `GC.stat` and cleared by `GC.reset_stat`. Every number in the benchmark below is read from this layer, at the source, rather than inferred from a wall clock.

## API

New C-level GC primitives:

- `mrb_gc_scheduler_driven(mrb, enable)`
- `mrb_gc_scheduler_pending(mrb)`
- `mrb_gc_step(mrb)`

New Ruby methods provided by mruby-task:

- `GC.scheduler_driven`
- `GC.scheduler_driven = bool`
- `GC.debt_limit`
- `GC.debt_limit = int`

Related tuning/observability:

- `GC.step_limit`
- `GC.malloc_threshold`
- `GC.stat`
- `GC.reset_stat` when built with `MRB_GC_PROFILE`

`GC.scheduler_driven = true` turns generational GC off. This is intentional: a minor generational cycle completes inside one atomic GC step, which defeats the purpose of fine-grained scheduler-driven stepping. It stays off: `GC.generational_mode = true` raises while scheduler-driven GC is on, so the mode cannot be silently defeated. Enabling scheduler-driven GC raises while GC is disabled or ObjectSpace iteration is active (unconditionally, even when generational mode is already off), because collection cannot be scheduled safely then.

Behavior changes visible to existing code:

- `mrb_task_run_once()` now returns `true` (instead of `nil`) when it advanced GC by one step with no task ready, so a host that backs off to a long sleep on `nil` keeps pumping while GC work remains. `nil` still means "truly idle".
- `GC.step_ratio = n` now raises ArgumentError for `n <= 0`. A non-positive ratio made the per-step work budget zero, which could wedge the incremental stepper making no progress per step.

## Implementation Notes

The core GC changes are kept generic. The new C primitives are not specific to mruby-task; another embedder with its own event loop or RTOS scheduler could use the same primitives to drive GC from its own idle point.

mruby-task is the first user of those primitives:

- When the ready queue is empty and tasks are waiting, the scheduler checks `mrb_gc_scheduler_pending()`.
- If GC work is pending, it calls `mrb_gc_step()` instead of idling the CPU.
- If no GC work is pending, it calls the normal HAL idle hook.

Allocation-time `mrb_incremental_gc()` now respects `gc->auto_step`. `mrb_gc_step()` deliberately ignores auto_step, so the scheduler can continue advancing GC while allocation-path stepping is disabled.

The allocation path's reclaim-before-grow collection (a synchronous `mrb_full_gc()` on freelist exhaustion) is likewise gated on `auto_step`: under scheduler-driven GC a freelist exhaustion grows the heap and lets idle steps reclaim, instead of running a synchronous full collection. Without this gate the allocation path collects synchronously and completes the cycle atomically, so the scheduler never gets to step and the feature is inert (`sync_max > 0`, `step_count = 0`).

## Why debt_limit Exists

Scheduler-driven GC assumes the system has idle time. If the ready queue is never empty, idle-time GC never runs and the heap can grow without bound.

GC.debt_limit is a safety valve for that case. Once object debt exceeds the configured limit, allocation performs a bounded synchronous GC step. This bounds heap growth, but it is intentionally not a latency guarantee: if the valve fires, the workload is back to paying synchronous GC pauses.

Note that the valve keys on object debt. A starved workload whose pressure is purely malloc bytes (few objects, large buffers, no idle time) does not trip it; that case is backstopped only by the out-of-memory emergency collection in the allocator.

## Benchmark

Full benchmark data and reproduction scripts are here:

https://gist.github.com/hasumikin/2b308a7f894aeb060601ddddd02fd078

Benchmark setup:

- Linux / WSL2 host, pinned to one core with taskset -c 0
- 3 repeats per cell, medians reported; `MRB_GC_PROFILE` enabled
- allocator task churns a live object array, then sleeps one tick between iterations to give the scheduler an idle window (see the tick note below)
- a priority-0 controller ends each 3000ms run window
- GC-induced task delay is measured at the source: the scheduler records the wall time of every idle GC step after which a task was already READY (`GC.stat[:prof_step_jitter_*]`), attributing the delay to GC steps specifically rather than inferring it from a wake-interval probe
- main matrix varies live_set, churn, generational mode, and GC mode; a separate sweep varies the idle window

The idle window is tick-quantized. `Task#sleep_ms` floors its argument to whole ticks (`(usec/1000)/MRB_TICK_UNIT`) and the POSIX HAL only advances the tick on the periodic ~4ms SIGALRM, so `sleep_ms(1)` does not create a 1ms window — it floors to 0 ticks and the task wakes on the next tick edge, i.e. a real ~4ms window (any 1..3ms sleep is identical). Every run therefore drives the sleep in whole-tick multiples so the window is exactly N x MRB_TICK_UNIT (the main matrix uses `alloc_sleep_ms=4`, one tick); `iters ~= duration_ms / window` confirms it.

Framing: a GC step is a non-preemptible stop-the-world interval; it becomes task-visible jitter only if a task wakes during it. Scheduler-driven mode does not reduce total GC work — it relocates GC into idle windows so the stop-the-world tasks actually see collapses.

Core result: the synchronous pause the allocating task pays goes to exactly 0 in every scheduled cell, and the aggregate GC-induced delay (jitter) drops about an order of magnitude. Over the 3000ms window the stock allocator spends most of the run frozen in GC; scheduler-driven pays no synchronous pause and only a small residual jitter.

|                       | baseline                          | scheduled                         |
| Workload (churn=2000) | worst pause / pause total (count) | worst step / jitter total (count) |
|-----------------------|-----------------------------------|-----------------------------------|
| live=4000,  gen=FALSE |       454us /   223ms (3382x)     |      365us /   0ms (0x)           |
| live=40000, gen=FALSE |     2,075us / 2,144ms (3603x)     |    3,051us /  21ms (17x)          |
| live=80000, gen=FALSE |     4,691us / 2,496ms (1304x)     |   15,410us / 292ms (59x)          |
| live=80000, gen=TRUE  |     4,752us / 2,536ms (1158x)     |    9,047us / 289ms (62x)          |

At live=80000, churn=2000, baseline's 2,496ms of synchronous pause is ~83% of the 3000ms window; scheduler-driven pays ~292ms of task-visible jitter over 59 events (0 at every live=4000 cell).

Note the worst *single* step under scheduler-driven mode is now comparable to (not smaller than) baseline's worst pause. `step_limit` bounds ordinary steps to <32us, but a large live set overflows the fixed gray stack and forces an O(heap) `gc_gray_rescan` that `step_limit` does not cap. Bounding that worst single step (larger gray stack / resumable rescan) is future work; the synchronous-pause and cumulative-jitter wins do not depend on it.

Control arm: bounding step size alone does not reproduce the win. At live=80000, churn=2000, gen=0, `GC.step_limit = 1024` on allocation-driven GC still pays sync_max 4,690us, indistinguishable from baseline's 4,691us; only moving the decision of when to step into the scheduler drives it to 0. (Heap footprint is not scored: scheduler-driven mode runs a larger heap on purpose, growing rather than collecting synchronously.)

Idle-window sweep: at the heavy cell (live=80000, churn=2000, gen=0, scheduled), varying only the idle window in whole-tick multiples cleanly separates the two latency axes. Cumulative task-visible jitter collapses as the window grows, while the worst single step (the gray-rescan tail) stays flat because it is bounded by heap size, not idle time:

| Window       | step_count | worst step | jitter total | jitter count |
|--------------|------------|------------|--------------|--------------|
| 4ms (1 tick) |       8133 |   21,139us |        459ms |           60 |
| 8ms (2 tick) |       4646 |   15,025us |        128ms |           21 |
| 16ms (4 tick)|       2593 |   14,399us |       0.03ms |            1 |
| 32ms (8 tick)|       1423 |   17,137us |          0ms |            0 |

The benchmark also covers two edge cases:

### Byte pressure

A workload replacing a single ~1MB buffer every 8ms (2 ticks) barely changes object debt, so object-debt-only scheduling misses it.

| Mode  | malloc_threshold | step_count | final malloc_increase |
|-------|------------------|------------|-----------------------|
| off   |                0 |          5 |           305,000,561 |
| on    |        2,000,000 |        748 |             1,000,257 |

This is why malloc_threshold is part of the pending-GC policy.

### Starvation

When the allocator never sleeps, scheduler-driven GC has no idle point.

| Mode     | debt_limit | live_objects | malloc_increase | sync_max |
|----------|------------|--------------|-----------------|----------|
| no valve |          0 |   21,328,429 |     855,099,002 |      0us |
| valve    |     20,000 |    2,688,195 |      45,665,344 | 29,405us |

The valve bounds growth, but the cost is synchronous GC pause time. This matches the intended contract.

## Caveats

These are host-side benchmark numbers, not MCU numbers. The absolute microsecond values are not the portable part. The portable part is the shape:

- the synchronous pause on the allocating task goes to zero in scheduler-driven mode
- total GC work is unchanged and heap footprint is intentionally larger (scheduler-driven grows rather than collecting synchronously); footprint is not a goal, bounded latency is
- the cumulative task-visible stop-the-world drops about an order of magnitude, and shrinks further as the idle window grows (the window sweep drives it to zero at a 32ms window)
- the worst single step is comparable, window-independent, and currently unbounded by step_limit (gray-stack-overflow rescan, bounded by heap size not idle time)
- byte pressure needs a byte threshold, not only object debt
- starvation needs a synchronous backstop

The idle window is quantized to MRB_TICK_UNIT (4ms here); a sub-tick sleep rounds down to a whole tick, so windows are compared in ticks, not milliseconds — a build with a different tick unit yields a different absolute window.

Several tail metrics are within run-to-run noise at 3 repeats and are not load-bearing: the worst single step; the gen-on vs gen-off delta; and starvation iteration throughput.

final_marking_phase is still an irreducible pause floor. This benchmark has only a shallow task set, so it does not stress task-count × stack-depth root scanning.

## Tests

Added a focused gctest build config for this feature:

`MRUBY_CONFIG=gctest rake test`

The scheduler-idle test samples `GC.stat[:live]` before any `GC.start` (a full GC reclaims garbage regardless of the mode, so only a pre-`GC.start` reading proves the idle steps collected) and, under `MRB_GC_PROFILE`, additionally asserts that `prof_step_count` advanced.

Current result:

```text
  Total: 779
     OK: 779
     KO: 0
  Crash: 0
Warning: 0
   Skip: 0
```