### PR TITLE
mruby-task: add mrb_hal_task_switch_hook to the HAL contract

### DIFF
--- a/mrbgems/mruby-task/include/task_hal.h
+++ b/mrbgems/mruby-task/include/task_hal.h
@@ -130,6 +130,24 @@ void mrb_task_disable_irq(void);
 void mrb_hal_task_idle_cpu(mrb_state *mrb);
 
 /**
+ * Called by the scheduler each time it regains control from a task
+ * (timeslice expiry, block, or completion), in thread context.
+ *
+ * Gives the platform a periodic servicing point that fires even when the
+ * ready queue is never empty — mrb_hal_task_idle_cpu() only runs when no
+ * task is ready, so a compute-bound task would otherwise starve anything
+ * the platform services there (e.g. a polled network driver).
+ *
+ * Requirements:
+ * - Must be cheap when there is nothing to service (called every switch)
+ * - Must NOT sleep or wait for interrupts (that is idle_cpu's job)
+ * - Most ports need no servicing: provide an empty implementation
+ *
+ * @param mrb The mruby state (for context, may be unused)
+ */
+void mrb_hal_task_switch_hook(mrb_state *mrb);
+
+/**
  * Sleep for specified microseconds in wall-clock time
  *
  * Called by sleep functions when in root context (not in a task).

--- a/mrbgems/mruby-task/include/task_hal.h
+++ b/mrbgems/mruby-task/include/task_hal.h
@@ -130,22 +130,41 @@ void mrb_task_disable_irq(void);
 void mrb_hal_task_idle_cpu(mrb_state *mrb);
 
 /**
+ * Which scheduler control point is calling mrb_hal_task_switch_hook().
+ *
+ * More reasons may be added as the scheduler grows control points, without
+ * changing the hook's signature.
+ */
+typedef enum mrb_task_switch_reason {
+  /** A task returned control (timeslice expiry, block, or completion) */
+  MRB_TASK_SWITCH_TASK,
+  /** An idle GC step ran in the scheduler's pending-GC drain loop */
+  MRB_TASK_SWITCH_GC_STEP,
+} mrb_task_switch_reason;
+
+/**
  * Called by the scheduler each time it regains control from a task
- * (timeslice expiry, block, or completion), in thread context.
+ * (timeslice expiry, block, or completion) and after each GC step in its
+ * pending-GC drain loop, always in thread context.
  *
  * Gives the platform a periodic servicing point that fires even when the
  * ready queue is never empty — mrb_hal_task_idle_cpu() only runs when no
- * task is ready, so a compute-bound task would otherwise starve anything
- * the platform services there (e.g. a polled network driver).
+ * task is ready, so a compute-bound task (or a long GC drain) would
+ * otherwise starve anything the platform services there (e.g. a polled
+ * network driver).
  *
  * Requirements:
  * - Must be cheap when there is nothing to service (called every switch)
  * - Must NOT sleep or wait for interrupts (that is idle_cpu's job)
  * - Most ports need no servicing: provide an empty implementation
+ * - Ports that don't distinguish control points ignore `reason`; ports
+ *   that branch on it must service unrecognized values as if they were
+ *   MRB_TASK_SWITCH_TASK, so reasons added later never lose servicing
  *
  * @param mrb The mruby state (for context, may be unused)
+ * @param reason The control point being serviced (may be ignored)
  */
-void mrb_hal_task_switch_hook(mrb_state *mrb);
+void mrb_hal_task_switch_hook(mrb_state *mrb, mrb_task_switch_reason reason);
 
 /**
  * Sleep for specified microseconds in wall-clock time

--- a/mrbgems/mruby-task/ports/glib/task_hal.c
+++ b/mrbgems/mruby-task/ports/glib/task_hal.c
@@ -529,6 +529,13 @@ mrb_hal_task_idle_cpu(mrb_state *mrb)
 }
 
 void
+mrb_hal_task_switch_hook(mrb_state *mrb)
+{
+  (void)mrb;
+  /* Nothing to service on this platform */
+}
+
+void
 mrb_hal_task_sleep_us(mrb_state *mrb, mrb_int usec)
 {
   (void)mrb;

--- a/mrbgems/mruby-task/ports/glib/task_hal.c
+++ b/mrbgems/mruby-task/ports/glib/task_hal.c
@@ -529,9 +529,10 @@ mrb_hal_task_idle_cpu(mrb_state *mrb)
 }
 
 void
-mrb_hal_task_switch_hook(mrb_state *mrb)
+mrb_hal_task_switch_hook(mrb_state *mrb, mrb_task_switch_reason reason)
 {
   (void)mrb;
+  (void)reason;
   /* Nothing to service on this platform */
 }
 

--- a/mrbgems/mruby-task/ports/posix/task_hal.c
+++ b/mrbgems/mruby-task/ports/posix/task_hal.c
@@ -143,9 +143,10 @@ mrb_hal_task_idle_cpu(mrb_state *mrb)
 }
 
 void
-mrb_hal_task_switch_hook(mrb_state *mrb)
+mrb_hal_task_switch_hook(mrb_state *mrb, mrb_task_switch_reason reason)
 {
   (void)mrb;
+  (void)reason;
   /* Nothing to service on this platform */
 }
 

--- a/mrbgems/mruby-task/ports/posix/task_hal.c
+++ b/mrbgems/mruby-task/ports/posix/task_hal.c
@@ -143,6 +143,13 @@ mrb_hal_task_idle_cpu(mrb_state *mrb)
 }
 
 void
+mrb_hal_task_switch_hook(mrb_state *mrb)
+{
+  (void)mrb;
+  /* Nothing to service on this platform */
+}
+
+void
 mrb_hal_task_sleep_us(mrb_state *mrb, mrb_int usec)
 {
   struct timespec start, now, sleep_time;

--- a/mrbgems/mruby-task/ports/win/task_hal.c
+++ b/mrbgems/mruby-task/ports/win/task_hal.c
@@ -123,9 +123,10 @@ mrb_hal_task_idle_cpu(mrb_state *mrb)
 }
 
 void
-mrb_hal_task_switch_hook(mrb_state *mrb)
+mrb_hal_task_switch_hook(mrb_state *mrb, mrb_task_switch_reason reason)
 {
   (void)mrb;
+  (void)reason;
   /* Nothing to service on this platform */
 }
 

--- a/mrbgems/mruby-task/ports/win/task_hal.c
+++ b/mrbgems/mruby-task/ports/win/task_hal.c
@@ -123,6 +123,13 @@ mrb_hal_task_idle_cpu(mrb_state *mrb)
 }
 
 void
+mrb_hal_task_switch_hook(mrb_state *mrb)
+{
+  (void)mrb;
+  /* Nothing to service on this platform */
+}
+
+void
 mrb_hal_task_sleep_us(mrb_state *mrb, mrb_int usec)
 {
   (void)mrb;

--- a/mrbgems/mruby-task/src/task.c
+++ b/mrbgems/mruby-task/src/task.c
@@ -599,6 +599,11 @@ task_run_body(mrb_state *mrb, void *ud)
         mrb_bool delayed = (q_ready_ != NULL);
         mrb_task_excl_exit(mrb);
         mrb_gc_scheduler_jitter(mrb, delayed);
+        /* This branch loops without reaching idle_cpu or the post-execute
+           hook below, so a long GC drain would otherwise be a third way to
+           starve platform servicing (mrb_task_run_once doesn't need this:
+           it returns to the host after one step). */
+        mrb_hal_task_switch_hook(mrb);
         continue;
       }
       /* If there are tasks waiting or suspended, idle */
@@ -613,6 +618,11 @@ task_run_body(mrb_state *mrb, void *ud)
 
     /* Execute task using core logic */
     execute_task(mrb, t);
+
+    /* Platform servicing point — fires on every switch, so a compute-bound
+       task that keeps the ready queue full cannot starve it (idle_cpu only
+       runs when no task is ready). */
+    mrb_hal_task_switch_hook(mrb);
 
     /* Move to end of ready queue if still running (round-robin) */
     if (t->status == MRB_TASK_STATUS_READY) {
@@ -682,6 +692,9 @@ mrb_task_run_once(mrb_state *mrb)
 
   /* Execute task using core logic */
   execute_task(mrb, t);
+
+  /* Platform servicing point (see task_run_body) */
+  mrb_hal_task_switch_hook(mrb);
 
   /* Move to end of ready queue if still ready (round-robin) */
   if (t->status == MRB_TASK_STATUS_READY) {

--- a/mrbgems/mruby-task/src/task.c
+++ b/mrbgems/mruby-task/src/task.c
@@ -603,7 +603,7 @@ task_run_body(mrb_state *mrb, void *ud)
            hook below, so a long GC drain would otherwise be a third way to
            starve platform servicing (mrb_task_run_once doesn't need this:
            it returns to the host after one step). */
-        mrb_hal_task_switch_hook(mrb);
+        mrb_hal_task_switch_hook(mrb, MRB_TASK_SWITCH_GC_STEP);
         continue;
       }
       /* If there are tasks waiting or suspended, idle */
@@ -622,7 +622,7 @@ task_run_body(mrb_state *mrb, void *ud)
     /* Platform servicing point — fires on every switch, so a compute-bound
        task that keeps the ready queue full cannot starve it (idle_cpu only
        runs when no task is ready). */
-    mrb_hal_task_switch_hook(mrb);
+    mrb_hal_task_switch_hook(mrb, MRB_TASK_SWITCH_TASK);
 
     /* Move to end of ready queue if still running (round-robin) */
     if (t->status == MRB_TASK_STATUS_READY) {
@@ -694,7 +694,7 @@ mrb_task_run_once(mrb_state *mrb)
   execute_task(mrb, t);
 
   /* Platform servicing point (see task_run_body) */
-  mrb_hal_task_switch_hook(mrb);
+  mrb_hal_task_switch_hook(mrb, MRB_TASK_SWITCH_TASK);
 
   /* Move to end of ready queue if still ready (round-robin) */
   if (t->status == MRB_TASK_STATUS_READY) {


### PR DESCRIPTION
## Summary

The scheduler's only platform servicing point today is `mrb_hal_task_idle_cpu()`, which runs when no task is READY. Platforms that must service an external stack from thread context hang that work off the idle hook — and it silently stops running under load.

This PR adds `mrb_hal_task_switch_hook()` to the task HAL: called at the scheduler's control points in thread context, with a cadence bounded by the timeslice regardless of what Ruby code is doing. Ports that need nothing provide an empty function (posix/win/glib implementations included).

## Problem: two loads defeat idle-only servicing

**1. A compute-bound task.** If the ready queue never empties, `mrb_hal_task_idle_cpu()` never runs. Field case: PicoRuby/R2P2 on a Raspberry Pi Pico 2 W (RP2350) drives the CYW43 WiFi chip and lwIP in poll mode, pumping `cyw43_arch_poll()` from the idle hook. lwIP in NO_SYS/poll mode is not interrupt-safe, so the tick interrupt is not an option — the pump *needs* a thread-context beat. With an open TCP connection and a pure-Ruby busy loop, the stack starved: 5/5 host-side probes stalled >25 s (the peer's kernel retransmits kept the connection alive; a liveness gap rather than a crash, but fatal for anything latency-sensitive: ACKs, retransmits, DHCP renewal all stop).

**2. A scheduler-driven GC drain (since #6938).** The pending-GC branch in `mrb_task_run()` loops `mrb_gc_step()` → `continue` without reaching the idle hook. That is the right priority order for GC vs. sleeping, but it makes a garbage-heavy idle phase a second way to never service the platform. Ordinary steps are tightly bounded, but #6938 documents an unbounded worst single step (the gray-stack-overflow rescan), and a long drain is many steps back-to-back either way.

## API

```c
/* task_hal.h */
void mrb_hal_task_switch_hook(mrb_state *mrb);
```

Contract (documented in the header): called each time the scheduler regains control from a task or completes an idle GC step; thread context; must be cheap when there is nothing to service; must NOT sleep or wait for interrupts (that remains `mrb_hal_task_idle_cpu()`'s job).

Call sites:

- `task_run_body()`, after every `execute_task()` return — i.e. on timeslice expiry, task block, or task completion. This bounds the servicing interval by the timeslice (`MRB_TIMESLICE_TICK_COUNT × MRB_TICK_UNIT`; 12 ms in the default config) even under a task that never yields.
- `task_run_body()`, after each `mrb_gc_step()` in the pending-GC drain branch — so a drain phase services the platform at step granularity.
- `mrb_task_run_once()`, after `execute_task()` only. The GC branch there deliberately does not call it: run_once returns to the host after one step, so the host's own event loop is the natural servicing point.

## Relationship to #6938

Complementary. #6938 moves GC work into idle windows; this hook guarantees platform servicing cadence independently of load. The drain-branch call is what keeps them composable: without it, enabling `GC.scheduler_driven` would reintroduce for garbage-heavy idle exactly the starvation this hook removes for compute-bound tasks.

## Verification

- `MRUBY_CONFIG=gctest rake test`: 788/788 OK (exercises the modified loop including the scheduler-driven GC paths; the hook is the posix no-op there).
- Device, compute-bound case, before/after (PicoRuby/R2P2 on Pico 2 W, CYW43 + lwIP poll mode, hook implemented as the cyw43 pump): board runs a 110 s pure-Ruby busy loop (~1.05 M iterations) with an open TCP connection; host pushes 5 payloads into the compute window and measures ACK latency via TCP_INFO. Idle-only pumping: 5/5 pushes stalled >25 s (recovery only after the loop ended). With the hook: 5/5 ACKed sub-second (0.20-0.30 s; one 3.6 s outlier consistent with the radio's known power-management wake bimodality, far below the starvation signature).
- Device, GC-drain case (same board, `GC.scheduler_driven = true`, built with MRB_GC_PROFILE): a workload alternating garbage churn with 30-50 ms sleeps, so idle windows are spent draining GC debt. Host pushed 13 probes across two runs into those windows: 13/13 ACKed in 0.20-0.30 s. GC.stat confirmed the drain branch was hot: prof_step_count=120, prof_sync_count=0 for the 60-cycle run — the idle windows really were mrb_gc_step() time, serviced by the new drain-branch hook call, not ordinary idle_cpu time.

## Notes

- Why not the tick interrupt: the beat must be thread-context — pollable stacks (lwIP NO_SYS being the canonical one) are not IRQ-safe, and a HAL hook in IRQ context would invite exactly the reentrancy bugs the poll model exists to avoid.
- Cost: one direct call per scheduler iteration. Ports with nothing to service provide an empty function; LTO builds can drop the call entirely.