### PR TITLE
Fix Task::Queue backing array growth after long FIFO use

### DIFF
--- a/mrbgems/mruby-task/src/task_queue.c
+++ b/mrbgems/mruby-task/src/task_queue.c
@@ -157,7 +157,12 @@ queue_pop_try(mrb_state *mrb, mrb_value self)
 
   /* Item available - return it */
   if (RARRAY_LEN(items) > 0) {
-    return mrb_ary_shift(mrb, items);
+    mrb_value item = mrb_ary_shift(mrb, items);
+    mrb_gc_protect(mrb, item);
+    if (RARRAY_LEN(items) == 0) {
+      mrb_ary_clear(mrb, items);
+    }
+    return item;
   }
 
   /* Closed and empty */


### PR DESCRIPTION
Task::Queue stores pending items in a Ruby Array and implements FIFO pop with mrb_ary_shift(). This works functionally, but it is a poor long-running queue pattern because mruby's Array#shift may keep a shared backing buffer instead of fully releasing the underlying storage as the logical length decreases. This ends in `ArgumentError: array size too big`.

## Fix

This patch clears the backing Array when the queue becomes empty immediately after a pop:

```c
item = mrb_ary_shift(...)
if RARRAY_LEN(items) == 0
  mrb_ary_clear(...)
end
return item
```

`mrb_ary_clear()` releases the Array backing storage, so an empty Task::Queue no longer retains the accumulated buffer state from previous FIFO operations. The public Queue behavior is unchanged: pop still returns the item, and closed/empty, non-blocking, timeout, and waiting semantics are untouched.

This is intentionally a small fix. A ring buffer or linked queue would be a more complete internal representation for Task::Queue (future work), but this patch addresses the observed long-running failure with minimal risk and without changing the API.