### PR TITLE
Feature: Task#close

### DIFF
--- a/mrbgems/mruby-task/include/task.h
+++ b/mrbgems/mruby-task/include/task.h
@@ -138,6 +138,7 @@ MRB_API mrb_value mrb_execute_proc_synchronously(mrb_state *mrb, mrb_value proc,
 MRB_API void mrb_suspend_task(mrb_state *mrb, mrb_value task);
 MRB_API void mrb_resume_task(mrb_state *mrb, mrb_value task);
 MRB_API void mrb_terminate_task(mrb_state *mrb, mrb_value task);
+MRB_API void mrb_close_task(mrb_state *mrb, mrb_value task);
 MRB_API mrb_bool mrb_stop_task(mrb_state *mrb, mrb_value task);
 MRB_API mrb_value mrb_task_value(mrb_state *mrb, mrb_value task);
 MRB_API mrb_value mrb_task_status(mrb_state *mrb, mrb_value self);

--- a/mrbgems/mruby-task/src/task.c
+++ b/mrbgems/mruby-task/src/task.c
@@ -1268,6 +1268,13 @@ mrb_task_terminate(mrb_state *mrb, mrb_value self)
 }
 
 static mrb_value
+mrb_task_close(mrb_state *mrb, mrb_value self)
+{
+  mrb_close_task(mrb, self);
+  return mrb_nil_value();
+}
+
+static mrb_value
 mrb_task_join(mrb_state *mrb, mrb_value self)
 {
   mrb_task *t, *current;
@@ -1588,6 +1595,28 @@ mrb_terminate_task(mrb_state *mrb, mrb_value task)
   terminate_task_internal(mrb, t);
 }
 
+MRB_API void
+mrb_close_task(mrb_state *mrb, mrb_value task)
+{
+  task_check_scheduler_lock(mrb);
+
+  mrb_task *t = (mrb_task*)mrb_data_check_get_ptr(mrb, task, &mrb_task_type);
+  if (!t) return;
+
+  if (t == mrb->task.main_task ||
+      (mrb->c != mrb->root_c && t == MRB2TASK(mrb))) {
+    mrb_raise(mrb, E_RUNTIME_ERROR, "can't close current task");
+  }
+
+  terminate_task_internal(mrb, t);
+  mrb_task_excl_enter(mrb);
+  mrb_task_q_delete(mrb, t);
+  mrb_task_excl_exit(mrb);
+
+  DATA_PTR(task) = NULL;
+  mrb_task_free(mrb, t);
+}
+
 /*
  * Stop a task (mark as stopped but don't move to dormant)
  */
@@ -1739,6 +1768,7 @@ mrb_mruby_task_gem_init(mrb_state *mrb)
   mrb_define_method_id(mrb, task_class, MRB_SYM(suspend),     mrb_task_suspend,      MRB_ARGS_NONE());
   mrb_define_method_id(mrb, task_class, MRB_SYM(resume),      mrb_task_resume,       MRB_ARGS_NONE());
   mrb_define_method_id(mrb, task_class, MRB_SYM(terminate),   mrb_task_terminate,    MRB_ARGS_NONE());
+  mrb_define_method_id(mrb, task_class, MRB_SYM(close),       mrb_task_close,        MRB_ARGS_NONE());
   mrb_define_method_id(mrb, task_class, MRB_SYM(join),        mrb_task_join,         MRB_ARGS_NONE());
   mrb_define_method_id(mrb, task_class, MRB_SYM(value),       mrb_task_value,        MRB_ARGS_NONE());
 

--- a/mrbgems/mruby-task/test/task.rb
+++ b/mrbgems/mruby-task/test/task.rb
@@ -97,6 +97,20 @@ assert("Task#terminate doesn't raise") do
   assert_nothing_raised { task.terminate }
 end
 
+assert("Task#close removes task and is idempotent") do
+  ready_count = Task.stat[:ready][:count]
+  task = Task.new { }
+  assert_equal ready_count + 1, Task.stat[:ready][:count]
+  assert_nil task.close
+  assert_equal ready_count, Task.stat[:ready][:count]
+  assert_nil task.close
+  assert_raise(ArgumentError) { task.status }
+end
+
+assert("Task#close rejects current task") do
+  assert_raise(RuntimeError) { Task.current.close }
+end
+
 # Task.current tests
 
 assert("Task.current in root context") do


### PR DESCRIPTION
This patch adds `Task#close` to explicitly free task instances.

In R2P2 (PicoRuby), a single shell command spawns a single task. Without this feature, Task objects were leaking with every command executed.

`Task#terminate` transitions the task to the "Dormant" state, but since there are use cases where the reference needs to be retained, the task cannot be automatically freed.
Therefore, a new API for explicit closing is required.