### PR TITLE
Add MRB_API mrb_task_queue_push()

### DIFF
--- a/mrbgems/mruby-task/include/task.h
+++ b/mrbgems/mruby-task/include/task.h
@@ -184,6 +184,19 @@ void mrb_task_q_delete(mrb_state *mrb, mrb_task *t);
 /* Task::Queue class registration - defined in task_queue.c */
 void mrb_init_task_queue(mrb_state *mrb, struct RClass *task_class);
 
+typedef enum {
+  MRB_TASK_QUEUE_PUSH_OK = 0,
+  MRB_TASK_QUEUE_PUSH_CLOSED,
+  MRB_TASK_QUEUE_PUSH_INVALID,
+} mrb_task_queue_push_result;
+
+/* Push obj into a Task::Queue and wake one waiter. Invalid and closed queues
+ * are reported as results so C callbacks need no exception handling for those
+ * conditions. Exceptions from allocation and other mruby internals may still
+ * propagate. Do not call this from an interrupt handler or any context that
+ * would re-enter the VM. */
+MRB_API mrb_task_queue_push_result mrb_task_queue_push(mrb_state *mrb, mrb_value queue, mrb_value obj);
+
 /*
  * Nesting-safe scheduler-IRQ exclusion.
  *

--- a/mrbgems/mruby-task/src/task_queue.c
+++ b/mrbgems/mruby-task/src/task_queue.c
@@ -87,19 +87,41 @@ queue_initialize(mrb_state *mrb, mrb_value self)
   return self;
 }
 
+/*
+ * Report validation and closure as results so C callbacks can use this API
+ * without relying on exception handling.
+ */
+MRB_API mrb_task_queue_push_result
+mrb_task_queue_push(mrb_state *mrb, mrb_value self, mrb_value obj)
+{
+  if (!mrb_data_p(self) || DATA_TYPE(self) != &mrb_task_queue_type ||
+      DATA_PTR(self) == NULL) {
+    return MRB_TASK_QUEUE_PUSH_INVALID;
+  }
+  mrb_task_queue *q = (mrb_task_queue*)DATA_PTR(self);
+  if (q->closed) return MRB_TASK_QUEUE_PUSH_CLOSED;
+
+  mrb_value items = mrb_iv_get(mrb, self, MRB_IVSYM(items));
+  mrb_ary_push(mrb, items, obj);
+  queue_wake_one_waiter(mrb, q);
+  return MRB_TASK_QUEUE_PUSH_OK;
+}
+
 static mrb_value
 queue_push(mrb_state *mrb, mrb_value self)
 {
   mrb_value obj;
   mrb_get_args(mrb, "o", &obj);
-
-  mrb_task_queue *q = (mrb_task_queue*)mrb_data_get_ptr(mrb, self, &mrb_task_queue_type);
-  if (!q) mrb_raise(mrb, E_ARGUMENT_ERROR, "invalid queue");
-  if (q->closed) mrb_raise(mrb, task_error_class_, "queue closed");
-
-  mrb_value items = mrb_iv_get(mrb, self, MRB_IVSYM(items));
-  mrb_ary_push(mrb, items, obj);
-  queue_wake_one_waiter(mrb, q);
+  switch (mrb_task_queue_push(mrb, self, obj)) {
+    case MRB_TASK_QUEUE_PUSH_OK:
+      break;
+    case MRB_TASK_QUEUE_PUSH_CLOSED:
+      mrb_raise(mrb, task_error_class_, "queue closed");
+      break;
+    case MRB_TASK_QUEUE_PUSH_INVALID:
+      mrb_raise(mrb, E_ARGUMENT_ERROR, "invalid queue");
+      break;
+  }
   return self;
 }
 

--- a/mrbgems/mruby-task/src/task_queue.c
+++ b/mrbgems/mruby-task/src/task_queue.c
@@ -102,6 +102,7 @@ mrb_task_queue_push(mrb_state *mrb, mrb_value self, mrb_value obj)
   if (q->closed) return MRB_TASK_QUEUE_PUSH_CLOSED;
 
   mrb_value items = mrb_iv_get(mrb, self, MRB_IVSYM(items));
+  mrb_assert(mrb_array_p(items));
   mrb_ary_push(mrb, items, obj);
   queue_wake_one_waiter(mrb, q);
   return MRB_TASK_QUEUE_PUSH_OK;


### PR DESCRIPTION
Add `mrb_task_queue_push()` for delivering values from callbacks to a Task::Queue.

The API reports invalid and closed queues using status codes, allowing callback callers to handle these expected conditions without exception handling. Exceptions caused by allocation or other mruby internals may still propagate.

This API must not be called from an interrupt handler or any context that would re-enter the VM. It allocates Ruby objects and may trigger GC.

PicoRuby's BLE implementation for Raspberry Pi Pico W uses pico_cyw43_arch_lwip_poll rather than threadsafe_background, so its callbacks run synchronously in a context where pushing a Ruby object is permitted.