### PR TITLE
load.c: bounds-check symbol length in read_section_lv

### DIFF
--- a/src/load.c
+++ b/src/load.c
@@ -632,7 +632,7 @@ read_section_lv(mrb_state *mrb, const uint8_t *start, size_t size, mrb_irep *ire
   for (i = 0; i < syms_len; i++) {
     uint16_t const str_len = bin_to_uint16(bin);
     bin += sizeof(uint16_t);
-    if (bin > end) return MRB_DUMP_READ_FAULT;
+    if (bin + str_len > end) return MRB_DUMP_READ_FAULT;
     syms[i] = intern_func(mrb, (const char*)bin, str_len);
     bin += str_len;
   }


### PR DESCRIPTION
ASan, loading a crafted `.mrb` whose LVAR section declares a symbol length past the remaining bytes:

    ==ERROR: AddressSanitizer: heap-buffer-overflow, READ of size 256
        #1 sym_intern_common symbol.c:371
        #5 read_section_lv   load.c:636
        #6 read_irep         load.c:723
    0x6130000006f2 is located 0 bytes after 370-byte region

`read_section_lv` interns `str_len` bytes but only checks `bin > end`, so an oversized length reads past the buffer. `read_section_debug` already guards the equivalent read with `bin + f_len > end`; use the same check here.