### PR TITLE
minor change: Utilize strlcpy and strlcat instead of strcpy and strcat

### DIFF
--- a/include/mruby/common.h
+++ b/include/mruby/common.h
@@ -122,6 +122,24 @@ MRB_BEGIN_DECL
 # endif
 #endif
 
+/** Declare size-bounded string copying and concatenation functions. */
+// The `__POSIX_VISIBLE` and `__BSD_VISIBLE` conditionals are from
+// OpenBSD's <string.h>.  The former refers to the POSIX.1-2024.
+#if ((defined(__POSIX_VISIBLE) && __POSIX_VISIBLE >= 202405) ||\
+     (defined(__BSD_VISIBLE) && __BSD_VISIBLE)) ||\
+    (defined(__GLIBC__) &&\
+     ((__GLIBC__ == 2 && __GLIBC_MINOR__ >= 38) || __GLIBC__ > 2))
+#define MRB_STRLCPY(dst, src, dstsize) strlcpy((dst), (src), (dstsize))
+#define MRB_STRLCAT(dst, src, dstsize) strlcat((dst), (src), (dstsize))
+#else
+#define MRB_STRLCPY(dst, src, dstsize) snprintf((dst), (dstsize), "%s", (src))
+#define MRB_STRLCAT(dst, src, dstsize) do {\
+    size_t tmp_len = strlen(dst);\
+    if (tmp_len < (dstsize))\
+      snprintf((dst) + tmp_len, (dstsize) - tmp_len, "%s", (src));\
+  } while (0)
+#endif
+
 MRB_END_DECL
 
 #endif  /* MRUBY_COMMON_H */

--- a/mrbgems/mruby-bin-debugger/tools/mrdb/apilist.c
+++ b/mrbgems/mruby-bin-debugger/tools/mrdb/apilist.c
@@ -10,6 +10,7 @@
 #include "apilist.h"
 #include "apistring.h"
 #include <mruby/compile.h>
+#include <mruby/common.h>
 #include <mruby/irep.h>
 #include <mruby/debug.h>
 
@@ -52,10 +53,10 @@ build_path(mrb_state *mrb, const char *dir, const char *base)
   memset(path, 0, len);
 
   if (strcmp(dir, ".")) {
-    strcat(path, dir);
-    strcat(path, "/");
+    MRB_STRLCAT(path, dir, len);
+    MRB_STRLCAT(path, "/", len);
   }
-  strcat(path, base);
+  MRB_STRLCAT(path, base, len);
 
   return path;
 }

--- a/mrbgems/mruby-bin-debugger/tools/mrdb/cmdmisc.c
+++ b/mrbgems/mruby-bin-debugger/tools/mrdb/cmdmisc.c
@@ -4,11 +4,13 @@
 */
 
 #include <ctype.h>
+#include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
 
 #include "apilist.h"
 #include "apistring.h"
+#include <mruby/common.h>
 #include <mruby/compile.h>
 
 typedef struct help_msg {
@@ -262,10 +264,11 @@ replace_ext(mrb_state *mrb, const char *filename, const char *ext)
     len = strlen(filename);
   }
 
-  s = (char*)mrb_malloc(mrb, len + strlen(ext) + 1);
+  size_t slen = len + strlen(ext) + 1;
+  s = (char*)mrb_malloc(mrb, slen);
   memset(s, '\0', len + strlen(ext) + 1);
   strncpy(s, filename, len);
-  strcat(s, ext);
+  MRB_STRLCAT(s, ext, slen);
 
   return s;
 }

--- a/mrbgems/mruby-bin-debugger/tools/mrdb/mrdb.c
+++ b/mrbgems/mruby-bin-debugger/tools/mrdb/mrdb.c
@@ -11,6 +11,7 @@
 #include <mruby/dump.h>
 #include <mruby/debug.h>
 #include <mruby/class.h>
+#include <mruby/common.h>
 #include <mruby/opcode.h>
 #include <mruby/variable.h>
 #include <mruby/proc.h>
@@ -19,6 +20,7 @@
 #include "mrdb.h"
 #include "apibreak.h"
 #include "apilist.h"
+#include "mrdbconf.h"
 
 void mrdb_state_free(mrb_state*);
 
@@ -274,7 +276,7 @@ get_command(mrb_state *mrb, mrdb_state *mrdb)
 
   if (i == 0 && feof(stdin)) {
     clearerr(stdin);
-    strcpy(mrdb->command, "quit");
+    MRB_STRLCPY(mrdb->command, "quit", MAX_COMMAND_LINE + 1);
     i += sizeof("quit") - 1;
   }
 

--- a/mrbgems/mruby-bin-mirb/tools/mirb/mirb.c
+++ b/mrbgems/mruby-bin-mirb/tools/mirb/mirb.c
@@ -14,6 +14,7 @@
 
 #include <mruby/array.h>
 #include <mruby/proc.h>
+#include <mruby/common.h>
 #include <mruby/compile.h>
 #include <mruby/dump.h>
 #include <mruby/string.h>
@@ -43,6 +44,8 @@ extern mrb_state *global_mrb; /* defined in mruby-compiler (ccontext.c) */
 #ifdef DISABLE_MIRB_UNDERSCORE
 # define MRB_NO_MIRB_UNDERSCORE
 #endif
+
+#define MAX_RUBY_CODE 4096
 
 static void
 p(mrb_state *mrb, mrb_value obj, mirb_highlighter *hl)
@@ -461,7 +464,7 @@ decl_lv_underscore(mrb_state *mrb, mrb_ccontext *cxt)
 int
 main(int argc, char **argv)
 {
-  char ruby_code[4096] = { 0 };
+  char ruby_code[MAX_RUBY_CODE] = { 0 };
   char last_code_line[1024] = { 0 };
   int last_char;
   size_t char_index;
@@ -596,7 +599,7 @@ main(int argc, char **argv)
         free(input);
         continue;
       }
-      strcpy(ruby_code, input);
+      MRB_STRLCPY(ruby_code, input, MAX_RUBY_CODE);
       free(input);
 
       /* Count lines for line number update */
@@ -662,7 +665,7 @@ main(int argc, char **argv)
       if (check_keyword(last_code_line, "quit") || check_keyword(last_code_line, "exit")) {
         break;
       }
-      strcpy(ruby_code, last_code_line);
+      MRB_STRLCPY(ruby_code, last_code_line, MAX_RUBY_CODE);
     }
 
   evaluate:

--- a/mrbgems/mruby-bin-mirb/tools/mirb/mirb.c
+++ b/mrbgems/mruby-bin-mirb/tools/mirb/mirb.c
@@ -659,7 +659,7 @@ main(int argc, char **argv)
         fputs("concatenated input string too long\n", stderr);
         continue;
       }
-      strcat(ruby_code, last_code_line);
+      MRB_STRLCAT(ruby_code, last_code_line, MAX_RUBY_CODE);
     }
     else {
       if (check_keyword(last_code_line, "quit") || check_keyword(last_code_line, "exit")) {

--- a/mrbgems/mruby-bin-mirb/tools/mirb/mirb_completion.c
+++ b/mrbgems/mruby-bin-mirb/tools/mirb/mirb_completion.c
@@ -8,6 +8,7 @@
 #include "mirb_highlight.h"
 #include <mruby/array.h>
 #include <mruby/class.h>
+#include <mruby/common.h>
 #include <mruby/compile.h>
 #include <mruby/error.h>
 #include <mruby/gc.h>
@@ -23,6 +24,8 @@
 #ifdef _MSC_VER
 #define strdup _strdup
 #endif
+
+#define MAX_COMPLETION_LINE 1024
 
 /* strndup is not available on Windows (MSVC and MinGW) */
 #ifdef _WIN32
@@ -660,7 +663,7 @@ mirb_linenoise_completion(const char *buf, linenoiseCompletions *lc)
 {
   int cursor_pos = (int)strlen(buf);  /* linenoise completes at end */
   int i, prefix_start;
-  char completion_line[1024];
+  char completion_line[MAX_COMPLETION_LINE];
 
   /* Clear previous completions */
   mirb_completion_free(g_ctx);
@@ -679,7 +682,7 @@ mirb_linenoise_completion(const char *buf, linenoiseCompletions *lc)
     }
 
     /* Add completion */
-    strcpy(completion_line + prefix_start, g_ctx->completions[i]);
+    MRB_STRLCPY(completion_line + prefix_start, g_ctx->completions[i], MAX_COMPLETION_LINE);
 
     linenoiseAddCompletion(lc, completion_line);
   }

--- a/mrbgems/mruby-compiler/src/diagnostic.c
+++ b/mrbgems/mruby-compiler/src/diagnostic.c
@@ -1,4 +1,6 @@
 #include "../include/mrc_diagnostic.h"
+#include <mruby/common.h>
+#include <string.h>
 
 static void
 line_and_column_by_start_and_offset(const uint8_t *source_start, const uint8_t *location_start, uint32_t *line, uint32_t *column)
@@ -82,7 +84,7 @@ mrc_diagnostic_list_append(mrc_ccontext *c, const uint8_t * location_start, cons
   snprintf(buf, sizeof(buf), "%s, %s", diagnostic_code_str, message);
   size_t len = strlen(buf);
   list->message = (char *)mrc_malloc(c, len + 1);
-  strcpy(list->message, buf);
+  MRB_STRLCPY(list->message, buf, len + 1);
   list->message[len] = '\0';
   list->code = code;
 

--- a/mrbgems/mruby-dir/ports/win/dir_hal.c
+++ b/mrbgems/mruby-dir/ports/win/dir_hal.c
@@ -12,8 +12,10 @@
 */
 
 #include <mruby.h>
+#include <mruby/common.h>
 #include "dir_hal.h"
 
+#include <stddef.h>
 #include <windows.h>
 #include <direct.h>
 #include <io.h>
@@ -46,8 +48,9 @@ mrb_hal_dir_open(mrb_state *mrb, const char *path)
   suffix = (len > 0 && (path[len-1] == '/' || path[len-1] == '\\')) ? "*" : "/*";
 
   handle = (mrb_dir_handle*)mrb_malloc(mrb, sizeof(mrb_dir_handle));
-  handle->pattern = (char*)mrb_malloc(mrb, len + strlen(suffix) + 1);
-  strcpy(handle->pattern, path);
+  size_t plen = len + strlen(suffix) + 1;
+  handle->pattern = (char*)mrb_malloc(mrb, plen);
+  MRB_STRLCPY(handle->pattern, path, plen);
   strcat(handle->pattern, suffix);
 
   handle->handle = _findfirst(handle->pattern, &handle->info);

--- a/mrbgems/mruby-dir/ports/win/dir_hal.c
+++ b/mrbgems/mruby-dir/ports/win/dir_hal.c
@@ -51,7 +51,7 @@ mrb_hal_dir_open(mrb_state *mrb, const char *path)
   size_t plen = len + strlen(suffix) + 1;
   handle->pattern = (char*)mrb_malloc(mrb, plen);
   MRB_STRLCPY(handle->pattern, path, plen);
-  strcat(handle->pattern, suffix);
+  MRB_STRLCAT(handle->pattern, suffix, plen);
 
   handle->handle = _findfirst(handle->pattern, &handle->info);
   if (handle->handle == -1) {

--- a/src/numeric.c
+++ b/src/numeric.c
@@ -9,6 +9,7 @@
 #include <mruby/numeric.h>
 #include <mruby/string.h>
 #include <mruby/class.h>
+#include <mruby/common.h>
 #include <mruby/internal.h>
 #include <string.h>
 
@@ -410,6 +411,8 @@ num_fdiv(mrb_state *mrb, mrb_value x)
   return flo_div(mrb, mrb_ensure_float_type(mrb, x));
 }
 
+#define BUFFER_MAX 25
+
 /**
  * Converts an mrb_value float to a new mrb_value string.
  * It handles formatting to ensure the string representation includes a
@@ -425,7 +428,7 @@ num_fdiv(mrb_state *mrb, mrb_value x)
 mrb_value
 mrb_float_to_str(mrb_state *mrb, mrb_value flo, const char *fmt)
 {
-  char buf[25];
+  char buf[BUFFER_MAX];
 
   mrb_format_float(mrb_float(flo), buf, sizeof(buf), 'g', -2, '\0');
   for (char *p = buf; *p; p++) {
@@ -437,7 +440,7 @@ mrb_float_to_str(mrb_state *mrb, mrb_value flo, const char *fmt)
       goto exit;
     }
   }
-  strcat(buf, ".0");
+  MRB_STRLCAT(buf, ".0", BUFFER_MAX);
  exit:
   return mrb_str_new_cstr(mrb, buf);
 }


### PR DESCRIPTION
This changeset replaces `strcpy` with [`strlcpy`](https://man.openbsd.org/strlcpy) and `strcat` with `strlcat`.

These new functions is size-bounded and eliminate warnings like this (on OpenBSD, for instance):

```
ld: warning: diagnostic.c:85 (mrbgems/mruby-compiler/src/diagnostic.c:85)(diagnostic.o:(mrc_diagnostic_list_append) in archive /home/gemmaro/src/mruby/build/host/lib/libmruby.a): warning: strcpy() is almost always misused, please use strlcpy()
ld: warning: cmdmisc.c:268 (mrbgems/mruby-bin-debugger/tools/mrdb/cmdmisc.c:268)(/home/gemmaro/src/mruby/build/host/mrbgems/mruby-bin-debugger/tools/mrdb/cmdmisc.o:(replace_ext)): warning: strcat() is almost always misused, please use strlcat()
```

Related issues: #383 #4675

Thank you,