### PR TITLE
io.c: fix out-of-bounds read in io_unget_data on buffer shrink

### DIFF
--- a/mrbgems/mruby-io/src/io.c
+++ b/mrbgems/mruby-io/src/io.c
@@ -1786,6 +1786,14 @@ io_unget_data(mrb_state *mrb, struct mrb_io *fptr, const char *ptr, mrb_int len)
     mrb_raise(mrb, E_ARGUMENT_ERROR, "total ungetc buffer exceeds maximum size");
   }
   if (buf->len + len > MRB_IO_BUF_SIZE) {
+    /* The realloc size is derived from buf->len, so a previously grown buffer
+       whose start is past that size would shrink below start and leave the
+       memmove below reading past the block. Compact the live data to the
+       front first (start becomes 0) so it stays within the new size. */
+    if (buf->start > 0) {
+      memmove(buf->mem, buf->mem+buf->start, buf->len);
+      buf->start = 0;
+    }
     fptr->buf = (struct mrb_io_buf*)mrb_realloc(mrb, buf, sizeof(struct mrb_io_buf)+buf->len+len-MRB_IO_BUF_SIZE);
     buf = fptr->buf;
   }

--- a/mrbgems/mruby-io/test/io.rb
+++ b/mrbgems/mruby-io/test/io.rb
@@ -337,6 +337,18 @@ assert('IO#ungetc') do
   io.close
 end
 
+assert('IO#ungetc after partial read of a grown buffer') do
+  # A large ungetc grows the buffer past MRB_IO_BUF_SIZE; a partial read
+  # advances buf->start; a second ungetc that crosses the threshold must
+  # keep the bytes still referenced by start when it resizes.
+  IO.pipe do |r, w|
+    r.ungetc("A" * 32767)
+    assert_equal "A" * 20000, r.read(20000)
+    r.ungetc("B")
+    assert_equal "B" + "A" * 12767, r.read(12768)
+  end
+end
+
 assert('IO#isatty') do
   skip "isatty is not supported on this platform" if MRubyIOTestUtil.win?
   begin


### PR DESCRIPTION
ASan on `IO#ungetc` — grow the buffer, partial read, then ungetc again:

    r, w = IO.pipe
    r.ungetc("A" * 32767)   # buffer grows past 4096, start=0, len=32767
    r.read(20000)           # partial read: start=20000, len=12767 (capacity kept)
    r.ungetc("B")           # +1 recrosses MRB_IO_BUF_SIZE -> realloc shrinks the block

    heap-buffer-overflow READ of size 12767 at io_unget_data io.c:1792
    0x... is located 7232 bytes after 12772-byte region allocated at io.c:1789

The realloc is sized from `buf->len`, but the memmove right after reads `buf->len`
bytes from `buf->mem+buf->start`. Once a prior ungetc has grown the buffer and a
partial read has advanced `start`, that realloc can end up smaller than
`start+len`, so the memmove reads past the block. Compact the live bytes to the
front before the realloc, the way `io_fill_buf_comp` already does.
