### PR TITLE
vm.c: fix envadjust rebasing stack pointers off a freed pointer

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -134,22 +134,22 @@ static inline void
 envadjust(mrb_state *mrb, mrb_value *oldbase, mrb_value *newbase)
 {
   mrb_callinfo *ci = mrb->c->cibase;
-  /*
-   * Byte-level calculation to avoid truncation when allocator alignment is
-   * smaller than sizeof(mrb_value).
-   * eg: MRB_NO_BOXING + MRB_INT64 with MRB_32BIT => sizeof(mrb_value)=16
-   *     And when memory allocator's alignment is 8 bytes
-   * Pointer subtraction on mrb_value* would truncate (8/16 -> 0).
-   * So, we use char* for pointer calculation to get the correct offset in bytes,
-   * then apply that offset to mrb_value* pointers.
-   */
-  ptrdiff_t off = (char *)newbase - (char *)oldbase;
 
-  if (off == 0) return;
+  if (newbase == oldbase) return;
+
   while (ci <= mrb->c->ci) {
     struct REnv *e = mrb_vm_ci_env(ci);
 
-    mrb_value *new_stack = (mrb_value *)((char *)ci->stack + off);
+    /*
+     * Byte-level calculation to avoid truncation when allocator alignment is
+     * smaller than sizeof(mrb_value).
+     * eg: MRB_NO_BOXING + MRB_INT64 with MRB_32BIT => sizeof(mrb_value)=16
+     *     And when memory allocator's alignment is 8 bytes
+     * Pointer subtraction on mrb_value* would truncate (8/16 -> 0).
+     * So, we use char* for pointer calculation to get the correct offset in
+     * bytes, then apply that offset to mrb_value* pointers.
+     */
+    mrb_value *new_stack = (mrb_value *)((char *)newbase + ((char *)ci->stack - (char *)oldbase));
 
     if (e) {
       mrb_assert(e->cxt == mrb->c && MRB_ENV_ONSTACK_P(e));


### PR DESCRIPTION
After stack_extend_alloc() reallocs the VM stack, envadjust() rebased each frame's stack pointer with `(char *)ci->stack + off`, where `ci->stack` still points into the old stack buffer that realloc has already freed.

In many cases, this computes the correct new address, so it has been harmless in practice. But it is pointer arithmetic derived from a freed pointer (undefined behavior), and a memory-safe C implementation that tracks pointer provenance and bounds traps on the first write through the rebased pointer.

I should have derived the new pointer from newbase instead:

```c
newbase + (ci->stack - oldbase)
```

This yields the identical address at no extra cost, but carries the new buffer's bounds.

Actually, I myself introduced this bug in commit d95ebe4a2308ec40dcd6bc8893b28c76175220d7

I noticed it when running under Fil-C, which reported:

```
filc safety error: cannot write pointer to free object.
    pointer: 0x73e1cdf86f88,0x73e1cb563050,0x73e1cb563050,aux=0x73e1cb563580,free
    expected 4 writable bytes.
semantic origin:
    (r2p2) mrbgems/picoruby-mruby/lib/mruby/src/vm.c:100:5: stack_clear
check scheduled at:
    (r2p2) mrbgems/picoruby-mruby/lib/mruby/src/vm.c:100:5: stack_clear
    (r2p2) mrbgems/picoruby-mruby/lib/mruby/src/vm.c:1891:7: vm_op_enter
    (r2p2) mrbgems/picoruby-mruby/lib/mruby/src/vm.c:3012:11: mrb_vm_exec
    (r2p2) mrbgems/picoruby-mruby/lib/mruby/mrbgems/mruby-task/src/task.c:383:21: execute_task_vm
    (r2p2) mrbgems/picoruby-mruby/lib/mruby/src/vm.c:568:14: mrb_protect_error
    (r2p2) mrbgems/picoruby-mruby/lib/mruby/mrbgems/mruby-task/src/task.c:447:15: execute_task
    (r2p2) mrbgems/picoruby-mruby/lib/mruby/mrbgems/mruby-task/src/task.c:620:5: task_run_body
    (r2p2) mrbgems/picoruby-mruby/lib/mruby/src/vm.c:568:14: mrb_protect_error
    (r2p2) mrbgems/picoruby-mruby/lib/mruby/mrbgems/mruby-task/src/task.c:650:22: mrb_task_run
    (r2p2) mrbgems/picoruby-bin-r2p2/tools/r2p2/r2p2.c:216:5: main
    (libc.so) src/env/__libc_start_main.c:79:7: __libc_start_main
    (libpizlo.so) <runtime>: start_program
[405503] filc panic: thwarted a futile attempt to violate memory safety.
Trace/breakpoint trap (core dumped)
```