### PR TITLE
mruby-dir: support UTF-8 directory paths on Windows

### DIFF
--- a/mrbgems/mruby-dir/include/dir_hal.h
+++ b/mrbgems/mruby-dir/include/dir_hal.h
@@ -5,6 +5,7 @@
 **
 ** Hardware Abstraction Layer for directory operations.
 ** Provides platform-independent interface for filesystem directory operations.
+** All path and entry name strings use UTF-8.
 */
 
 #ifndef MRUBY_DIR_HAL_H
@@ -22,13 +23,13 @@ typedef struct mrb_dir_handle mrb_dir_handle;
  * Directory Operations
  */
 
-/* Open directory for reading. Returns handle or NULL on error (sets errno). */
+/* Open a UTF-8 path for reading. Returns handle or NULL on error (sets errno). */
 mrb_dir_handle* mrb_hal_dir_open(mrb_state *mrb, const char *path);
 
 /* Close directory handle. Returns 0 on success, -1 on error. */
 int mrb_hal_dir_close(mrb_state *mrb, mrb_dir_handle *dir);
 
-/* Read next entry from directory. Returns name or NULL at end/error. */
+/* Read next entry as UTF-8. Returns name or NULL at end/error. */
 const char* mrb_hal_dir_read(mrb_state *mrb, mrb_dir_handle *dir);
 
 /* Rewind directory to beginning */
@@ -57,7 +58,7 @@ int mrb_hal_dir_rmdir(mrb_state *mrb, const char *path);
 /* Change current working directory. Returns 0 on success, -1 on error. */
 int mrb_hal_dir_chdir(mrb_state *mrb, const char *path);
 
-/* Get current working directory. Returns 0 on success, -1 on error. */
+/* Get current working directory as UTF-8. Returns 0 on success, -1 on error. */
 int mrb_hal_dir_getcwd(mrb_state *mrb, char *buf, size_t size);
 
 /* Change root directory (privileged operation). Returns -1 if unsupported (sets errno to ENOSYS). */

--- a/mrbgems/mruby-dir/ports/win/dir_hal.c
+++ b/mrbgems/mruby-dir/ports/win/dir_hal.c
@@ -3,7 +3,7 @@
 **
 ** See Copyright Notice in mruby.h
 **
-** Windows implementation for directory operations using _findfirst/_findnext APIs.
+** Windows implementation for directory operations using _wfindfirst/_wfindnext APIs.
 ** Provides POSIX-compatible interface on Windows.
 **
 ** Based on dirent.c by Kevlin Henney (kevlin@acm.org, kevlin@curbralan.com)
@@ -22,14 +22,57 @@
 #include <errno.h>
 #include <stdlib.h>
 #include <string.h>
+#include <wchar.h>
 
 /* Windows directory handle implementation */
 struct mrb_dir_handle {
-  intptr_t handle;          /* _findfirst/_findnext handle */
-  struct _finddata_t info;  /* Current entry info */
-  char *pattern;            /* Search pattern with wildcard */
-  int first;                /* Flag: haven't read first entry yet */
+  intptr_t handle;           /* _wfindfirst/_wfindnext handle */
+  struct _wfinddata_t info;  /* Current entry info */
+  wchar_t *pattern;          /* UTF-16 search pattern stored after this structure */
+  char *name;                /* Current entry name encoded as UTF-8 */
+  size_t name_capacity;      /* Allocated size of name */
+  int first;                 /* Flag: haven't read first entry yet */
 };
+
+static wchar_t*
+utf8_to_utf16(mrb_state *mrb, const char *utf8)
+{
+  int len = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, utf8, -1, NULL, 0);
+  wchar_t *utf16;
+
+  if (len == 0) {
+    errno = EINVAL;
+    return NULL;
+  }
+  utf16 = (wchar_t*)mrb_malloc(mrb, (size_t)len * sizeof(wchar_t));
+  if (MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, utf8, -1, utf16, len) == 0) {
+    mrb_free(mrb, utf16);
+    errno = EINVAL;
+    return NULL;
+  }
+  return utf16;
+}
+
+static int
+utf16_to_utf8(mrb_state *mrb, const wchar_t *utf16, char **buf, size_t *capacity)
+{
+  int len = WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, utf16, -1, NULL, 0, NULL, NULL);
+
+  if (len == 0) {
+    errno = EILSEQ;
+    return -1;
+  }
+  if ((size_t)len > *capacity) {
+    char *newbuf = (char*)mrb_realloc(mrb, *buf, (size_t)len);
+    *buf = newbuf;
+    *capacity = (size_t)len;
+  }
+  if (WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, utf16, -1, *buf, len, NULL, NULL) == 0) {
+    errno = EILSEQ;
+    return -1;
+  }
+  return 0;
+}
 
 /*
  * Directory Operations
@@ -39,21 +82,39 @@ mrb_dir_handle*
 mrb_hal_dir_open(mrb_state *mrb, const char *path)
 {
   mrb_dir_handle *handle;
-  size_t len = strlen(path);
-  const char *suffix;
+  const wchar_t *suffix;
+  int utf16_len = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, path, -1, NULL, 0);
+  size_t len;
+
+  if (utf16_len == 0) {
+    errno = EINVAL;
+    return NULL;
+  }
+
+  // Reserve enough trailing space for either "*" or "/*".
+  handle = (mrb_dir_handle*)mrb_malloc(mrb,
+    sizeof(mrb_dir_handle) + ((size_t)utf16_len + 2) * sizeof(wchar_t));
+  handle->pattern = (wchar_t*)(handle + 1);
+  handle->name = NULL;
+  handle->name_capacity = 0;
+
+  if (MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, path, -1,
+                          handle->pattern, utf16_len) == 0) {
+    mrb_free(mrb, handle);
+    errno = EINVAL;
+    return NULL;
+  }
+  len = (size_t)utf16_len - 1;
 
   /* Add wildcard suffix if needed */
-  suffix = (len > 0 && (path[len-1] == '/' || path[len-1] == '\\')) ? "*" : "/*";
+  suffix = (len > 0 && (handle->pattern[len-1] == L'/' || handle->pattern[len-1] == L'\\')) ? L"*" : L"/*";
+  wcscat(handle->pattern, suffix);
 
-  handle = (mrb_dir_handle*)mrb_malloc(mrb, sizeof(mrb_dir_handle));
-  handle->pattern = (char*)mrb_malloc(mrb, len + strlen(suffix) + 1);
-  strcpy(handle->pattern, path);
-  strcat(handle->pattern, suffix);
-
-  handle->handle = _findfirst(handle->pattern, &handle->info);
+  handle->handle = _wfindfirst(handle->pattern, &handle->info);
   if (handle->handle == -1) {
-    mrb_free(mrb, handle->pattern);
+    int saved_errno = errno;
     mrb_free(mrb, handle);
+    errno = saved_errno;
     return NULL;
   }
 
@@ -70,7 +131,7 @@ mrb_hal_dir_close(mrb_state *mrb, mrb_dir_handle *handle)
     result = _findclose(handle->handle);
   }
 
-  mrb_free(mrb, handle->pattern);
+  mrb_free(mrb, handle->name);
   mrb_free(mrb, handle);
 
   if (result == -1) {
@@ -84,32 +145,35 @@ mrb_hal_dir_close(mrb_state *mrb, mrb_dir_handle *handle)
 const char*
 mrb_hal_dir_read(mrb_state *mrb, mrb_dir_handle *handle)
 {
-  (void)mrb;
+  const wchar_t *name;
 
   if (handle->handle == -1) {
     errno = EBADF;
     return NULL;
   }
 
-  /* First call returns the result from _findfirst */
+  /* First call returns the result from _wfindfirst */
   if (handle->first) {
     handle->first = 0;
-    return handle->info.name;
+    name = handle->info.name;
+  }
+  else {
+    /* Subsequent calls use _wfindnext */
+    if (_wfindnext(handle->handle, &handle->info) == -1) {
+      return NULL;
+    }
+    name = handle->info.name;
   }
 
-  /* Subsequent calls use _findnext */
-  if (_findnext(handle->handle, &handle->info) == -1) {
+  if (utf16_to_utf8(mrb, name, &handle->name, &handle->name_capacity) == -1) {
     return NULL;
   }
-
-  return handle->info.name;
+  return handle->name;
 }
 
 void
 mrb_hal_dir_rewind(mrb_state *mrb, mrb_dir_handle *handle)
 {
-  (void)mrb;
-
   if (handle->handle == -1) {
     errno = EBADF;
     return;
@@ -117,7 +181,7 @@ mrb_hal_dir_rewind(mrb_state *mrb, mrb_dir_handle *handle)
 
   /* Close and reopen to rewind */
   _findclose(handle->handle);
-  handle->handle = _findfirst(handle->pattern, &handle->info);
+  handle->handle = _wfindfirst(handle->pattern, &handle->info);
   handle->first = 1;
 }
 
@@ -150,30 +214,81 @@ mrb_hal_dir_tell(mrb_state *mrb, mrb_dir_handle *handle)
 int
 mrb_hal_dir_mkdir(mrb_state *mrb, const char *path, int mode)
 {
+  wchar_t *utf16 = utf8_to_utf16(mrb, path);
+  int result;
+  int saved_errno;
+
   /* Windows _mkdir ignores mode parameter */
-  (void)mrb; (void)mode;
-  return _mkdir(path);
+  (void)mode;
+  if (utf16 == NULL) return -1;
+  result = _wmkdir(utf16);
+  saved_errno = errno;
+  mrb_free(mrb, utf16);
+  if (result == -1) errno = saved_errno;
+  return result;
 }
 
 int
 mrb_hal_dir_rmdir(mrb_state *mrb, const char *path)
 {
-  (void)mrb;
-  return _rmdir(path);
+  wchar_t *utf16 = utf8_to_utf16(mrb, path);
+  int result;
+  int saved_errno;
+
+  if (utf16 == NULL) return -1;
+  result = _wrmdir(utf16);
+  saved_errno = errno;
+  mrb_free(mrb, utf16);
+  if (result == -1) errno = saved_errno;
+  return result;
 }
 
 int
 mrb_hal_dir_chdir(mrb_state *mrb, const char *path)
 {
-  (void)mrb;
-  return _chdir(path);
+  wchar_t *utf16 = utf8_to_utf16(mrb, path);
+  int result;
+  int saved_errno;
+
+  if (utf16 == NULL) return -1;
+  result = _wchdir(utf16);
+  saved_errno = errno;
+  mrb_free(mrb, utf16);
+  if (result == -1) errno = saved_errno;
+  return result;
 }
 
 int
 mrb_hal_dir_getcwd(mrb_state *mrb, char *buf, size_t size)
 {
-  (void)mrb;
-  return _getcwd(buf, (int)size) ? 0 : -1;
+  wchar_t *utf16 = (wchar_t*)mrb_malloc(mrb, size * sizeof(wchar_t));
+  int len;
+
+  if (_wgetcwd(utf16, (int)size) == NULL) {
+    int saved_errno = errno;
+    mrb_free(mrb, utf16);
+    errno = saved_errno;
+    return -1;
+  }
+  len = WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, utf16, -1, NULL, 0, NULL, NULL);
+  if (len == 0) {
+    mrb_free(mrb, utf16);
+    errno = EILSEQ;
+    return -1;
+  }
+  if ((size_t)len > size) {
+    mrb_free(mrb, utf16);
+    errno = ERANGE;
+    return -1;
+  }
+  if (WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, utf16, -1,
+                          buf, len, NULL, NULL) == 0) {
+    mrb_free(mrb, utf16);
+    errno = EILSEQ;
+    return -1;
+  }
+  mrb_free(mrb, utf16);
+  return 0;
 }
 
 int
@@ -189,12 +304,20 @@ int
 mrb_hal_dir_is_directory(mrb_state *mrb, const char *path)
 {
   struct _stat sb;
-  (void)mrb;
+  wchar_t *utf16 = utf8_to_utf16(mrb, path);
+  int result;
+  int saved_errno;
 
-  if (_stat(path, &sb) == 0 && (sb.st_mode & _S_IFDIR)) {
-    return 1;
+  if (utf16 == NULL) return 0;
+
+  result = _wstat(utf16, &sb);
+  saved_errno = errno;
+  mrb_free(mrb, utf16);
+  if (result == -1) {
+    errno = saved_errno;
+    return 0;
   }
-  return 0;
+  return (sb.st_mode & _S_IFDIR) != 0;
 }
 
 /*

--- a/mrbgems/mruby-dir/src/dir.c
+++ b/mrbgems/mruby-dir/src/dir.c
@@ -246,6 +246,40 @@ skip_name_p(const char *name)
   return FALSE;
 }
 
+struct mrb_dir_iteration {
+  mrb_dir_handle *handle;
+  mrb_bool skip_special;
+};
+
+static mrb_value
+mrb_dir_empty_body(mrb_state *mrb, void *ptr)
+{
+  struct mrb_dir_iteration *ctx = (struct mrb_dir_iteration*)ptr;
+  const char *name;
+
+  while ((name = mrb_hal_dir_read(mrb, ctx->handle)) != NULL) {
+    if (!skip_name_p(name)) {
+      return mrb_false_value();
+    }
+  }
+  return mrb_true_value();
+}
+
+static mrb_value
+mrb_dir_collect_body(mrb_state *mrb, void *ptr)
+{
+  struct mrb_dir_iteration *ctx = (struct mrb_dir_iteration*)ptr;
+  mrb_value ary = mrb_ary_new(mrb);
+  const char *name;
+
+  while ((name = mrb_hal_dir_read(mrb, ctx->handle)) != NULL) {
+    if (!ctx->skip_special || !skip_name_p(name)) {
+      mrb_ary_push(mrb, ary, mrb_str_new_cstr(mrb, name));
+    }
+  }
+  return ary;
+}
+
 /*
  * call-seq:
  *   Dir.empty?(path_name) -> true or false
@@ -259,21 +293,18 @@ static mrb_value
 mrb_dir_empty(mrb_state *mrb, mrb_value self)
 {
   mrb_dir_handle *handle;
-  const char *name;
   const char *path;
-  mrb_value result = mrb_true_value();
+  mrb_value result;
 
   mrb_get_args(mrb, "z", &path);
   if ((handle = mrb_hal_dir_open(mrb, path)) == NULL) {
     mrb_sys_fail(mrb, path);
   }
-  while ((name = mrb_hal_dir_read(mrb, handle)) != NULL) {
-    if (!skip_name_p(name)) {
-      result = mrb_false_value();
-      break;
-    }
+
+  struct mrb_dir_iteration ctx = { handle, FALSE };
+  MRB_ENSURE(mrb, result, mrb_dir_empty_body, &ctx) {
+    mrb_hal_dir_close(mrb, handle);
   }
-  mrb_hal_dir_close(mrb, handle);
   return result;
 }
 
@@ -410,6 +441,7 @@ static mrb_value
 mrb_dir_entries(mrb_state *mrb, mrb_value klass)
 {
   const char *path;
+  mrb_value result;
 
   mrb_get_args(mrb, "z", &path);
 
@@ -418,14 +450,11 @@ mrb_dir_entries(mrb_state *mrb, mrb_value klass)
     mrb_sys_fail(mrb, path);
   }
 
-  mrb_value ary = mrb_ary_new(mrb);
-  const char *name;
-  while ((name = mrb_hal_dir_read(mrb, handle)) != NULL) {
-    mrb_ary_push(mrb, ary, mrb_str_new_cstr(mrb, name));
+  struct mrb_dir_iteration ctx = { handle, FALSE };
+  MRB_ENSURE(mrb, result, mrb_dir_collect_body, &ctx) {
+    mrb_hal_dir_close(mrb, handle);
   }
-
-  mrb_hal_dir_close(mrb, handle);
-  return ary;
+  return result;
 }
 
 /*
@@ -440,6 +469,7 @@ static mrb_value
 mrb_dir_children(mrb_state *mrb, mrb_value klass)
 {
   const char *path;
+  mrb_value result;
 
   mrb_get_args(mrb, "z", &path);
 
@@ -448,16 +478,11 @@ mrb_dir_children(mrb_state *mrb, mrb_value klass)
     mrb_sys_fail(mrb, path);
   }
 
-  mrb_value ary = mrb_ary_new(mrb);
-  const char *name;
-  while ((name = mrb_hal_dir_read(mrb, handle)) != NULL) {
-    if (!skip_name_p(name)) {
-      mrb_ary_push(mrb, ary, mrb_str_new_cstr(mrb, name));
-    }
+  struct mrb_dir_iteration ctx = { handle, TRUE };
+  MRB_ENSURE(mrb, result, mrb_dir_collect_body, &ctx) {
+    mrb_hal_dir_close(mrb, handle);
   }
-
-  mrb_hal_dir_close(mrb, handle);
-  return ary;
+  return result;
 }
 
 void

--- a/mrbgems/mruby-dir/test/dir.rb
+++ b/mrbgems/mruby-dir/test/dir.rb
@@ -4,10 +4,12 @@ end
 
 assert('DirTest.setup') do
   assert_nothing_raised{DirTest.setup}
+  assert_equal 0, Dir.mkdir(DirTest.sandbox + "/日本語")
 end
 
 assert('Dir.chdir') do
   assert_equal 0, Dir.chdir(DirTest.sandbox)
+  assert_equal DirTest::ENOENT, DirTest.operation_errno(:chdir, DirTest.sandbox + "/nosuchdir")
 end
 
 assert('Dir.entries') do
@@ -16,8 +18,17 @@ assert('Dir.entries') do
   assert_true a.include?("b")
 end
 
+assert('Dir.children') do
+  children = Dir.children(DirTest.sandbox)
+  assert_true children.include?("a")
+  assert_true children.include?("b")
+  assert_false children.include?(".")
+  assert_false children.include?("..")
+end
+
 assert('Dir.exist?') do
   assert_true Dir.exist?(DirTest.sandbox)
+  assert_true Dir.exist?(DirTest.sandbox + "/日本語")
   assert_false Dir.exist?(DirTest.sandbox + "/nosuchdir")
 end
 
@@ -31,6 +42,13 @@ end
 assert('Dir.getwd') do
   s = Dir.getwd
   assert_true s.kind_of? String
+
+  name = "半角アルファベットや記号以外が使われた長いディレクトリ名"
+  path = DirTest.sandbox + "/" + name
+  Dir.mkdir(path)
+  Dir.chdir(path) do
+    assert_true Dir.getwd.include?(name)
+  end
 end
 
 assert('Dir.mkdir') do
@@ -38,9 +56,15 @@ assert('Dir.mkdir') do
   m2 = DirTest.sandbox + "/mkdir2"
   assert_equal 0, Dir.mkdir(m1)
   assert_equal 0, Dir.mkdir(m2, 0765)
+
+  assert_equal DirTest::EEXIST, DirTest.operation_errno(:mkdir, m1)
 end
 
 assert('Dir.delete') do
+  japanese = DirTest.sandbox + "/delete-日本語"
+  Dir.mkdir(japanese)
+  assert_equal 0, Dir.delete(japanese)
+
   s = DirTest.sandbox + "/delete"
   Dir.mkdir(s)
   assert_true Dir.exist?(s)
@@ -50,6 +74,8 @@ assert('Dir.delete') do
 end
 
 assert('Dir.open') do
+  assert_equal DirTest::ENOENT, DirTest.operation_errno(:open, DirTest.sandbox + "/nosuchdir")
+
   a = []
   Dir.open(DirTest.sandbox) { |d|
     d.each_child { |s| a << s }
@@ -87,6 +113,21 @@ assert('Dir#read') do
   d.close
   assert_true a.include?("a")
   assert_true a.include?("b")
+
+  japanese = DirTest.sandbox + "/日本語"
+  child = japanese + "/子"
+  Dir.mkdir(child)
+  begin
+    names = []
+    d = Dir.open(japanese)
+    while s = d.read
+      names << s
+    end
+    d.close
+    assert_true names.include?("子")
+  ensure
+    Dir.delete(child) if Dir.exist?(child)
+  end
 end
 
 assert('Dir#rewind') do

--- a/mrbgems/mruby-dir/test/dirtest.c
+++ b/mrbgems/mruby-dir/test/dirtest.c
@@ -4,6 +4,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <errno.h>
 
 #include <mruby.h>
 #include <mruby/string.h>
@@ -114,12 +115,51 @@ mrb_dirtest_sandbox(mrb_state *mrb, mrb_value klass)
   return mrb_cv_get(mrb, klass, mrb_intern_cstr(mrb, "sandbox"));
 }
 
+static mrb_value
+mrb_dirtest_operation_errno(mrb_state *mrb, mrb_value klass)
+{
+  mrb_sym operation;
+  mrb_dir_handle *dirp;
+  const char *path;
+
+  (void)klass;
+  mrb_get_args(mrb, "nz", &operation, &path);
+  errno = 0;
+
+  if (operation == mrb_intern_lit(mrb, "mkdir")) {
+    if (mrb_hal_dir_mkdir(mrb, path, 0) == 0) {
+      return mrb_fixnum_value(0);
+    }
+    return mrb_fixnum_value(errno);
+  }
+  if (operation == mrb_intern_lit(mrb, "open")) {
+    dirp = mrb_hal_dir_open(mrb, path);
+    if (dirp == NULL) {
+      return mrb_fixnum_value(errno);
+    }
+    mrb_hal_dir_close(mrb, dirp);
+    return mrb_fixnum_value(0);
+  }
+  if (operation == mrb_intern_lit(mrb, "chdir")) {
+    if (mrb_hal_dir_chdir(mrb, path) == 0) {
+      return mrb_fixnum_value(0);
+    }
+    return mrb_fixnum_value(errno);
+  }
+
+  mrb_raise(mrb, E_ARGUMENT_ERROR, "unsupported directory operation");
+  return mrb_nil_value();
+}
+
 void
 mrb_mruby_dir_gem_test(mrb_state *mrb)
 {
   struct RClass *c = mrb_define_module(mrb, "DirTest");
 
+  mrb_define_const(mrb, c, "EEXIST", mrb_fixnum_value(EEXIST));
+  mrb_define_const(mrb, c, "ENOENT", mrb_fixnum_value(ENOENT));
   mrb_define_class_method(mrb, c, "sandbox", mrb_dirtest_sandbox, MRB_ARGS_NONE());
   mrb_define_class_method(mrb, c, "setup", mrb_dirtest_setup, MRB_ARGS_NONE());
   mrb_define_class_method(mrb, c, "teardown", mrb_dirtest_teardown, MRB_ARGS_NONE());
+  mrb_define_class_method(mrb, c, "operation_errno", mrb_dirtest_operation_errno, MRB_ARGS_REQ(2));
 }


### PR DESCRIPTION
## Summary

The Windows implementation of `mruby-dir` used the narrow-character CRT
directory APIs. As a result, UTF-8 paths and directory entry names could not
be handled reliably when they contained characters outside the active Windows
code page.

This change defines the directory HAL interface as UTF-8 and performs
UTF-8/UTF-16 conversion at the Windows platform boundary.

## Changes

- replace `_findfirst` and `_findnext` with their wide-character variants
- use wide-character APIs for `mkdir`, `rmdir`, `chdir`, `getcwd`, and `stat`
- convert directory entry names from UTF-16 to UTF-8
- preserve `errno` while releasing temporary conversion buffers
- ensure directory handles are closed if entry collection raises an exception
- add tests covering Japanese directory paths and entry names
- add tests for error propagation from directory operations
