### PR TITLE
mruby-pack: avoid signed overflow in pack_uu line count

### DIFF
--- a/mrbgems/mruby-pack/src/pack.c
+++ b/mrbgems/mruby-pack/src/pack.c
@@ -1459,7 +1459,8 @@ pack_uu(mrb_state *mrb, mrb_value src, mrb_value dst, mrb_int didx, int count)
   /* Calculate buffer size by accounting for per-line encoding
    * Each line encodes separately, so padding happens per line, not globally
    */
-  mrb_int num_lines = (slen + count - 1) / count;  /* Number of lines */
+  /* divide before adding to avoid overflow when count == INT_MAX */
+  mrb_int num_lines = slen / count + (slen % count ? 1 : 0);  /* Number of lines */
   mrb_int total_encoded = 0;
   mrb_int temp_slen = slen;
 

--- a/mrbgems/mruby-pack/test/pack.rb
+++ b/mrbgems/mruby-pack/test/pack.rb
@@ -61,6 +61,10 @@ assert('pack("u")') do
   packed_long = [long_data].pack("u")
   assert_equal [long_data], packed_long.unpack("u")
 
+  # Huge explicit line length must not overflow the buffer size calculation
+  assert_equal ["ab"].pack("u"), ["ab"].pack("u2147483647")
+  assert_equal ["ab"], ["ab"].pack("x124u2147483647")[124..-1].unpack("u")
+
   # Test that packed data ends with zero-length line for non-empty input
   packed = ["test"].pack("u")
   # Check if last two characters are backtick and newline


### PR DESCRIPTION
UBSan + ASan, clang, from `["ab"].pack("x124u2147483647")`:

    pack.c:1462:29: runtime error: signed integer overflow: 2 + 2147483647 cannot be represented in type 'int'

    ERROR: AddressSanitizer: heap-buffer-overflow
    WRITE of size 1 at 0x60d000000261
        #0 pack_uu pack.c:1509
        #1 mrb_pack_pack pack.c:1916
    0x60d000000261 is located 0 bytes after 129-byte region

`read_tmpl` takes any explicit count up to INT_MAX, so `slen + count - 1` wraps,
`num_lines` goes negative and `buffer_size` lands 4 bytes under what the emit
loop writes, leaving `str_len_ensure` short. `pack_hex` already divides first for
the same INT_MAX case, so use that shape here rather than a cast, which would
still wrap on MRB_INT32.
