### PR TITLE
Fix a build error occurs if the setup block for mruby-compiler is not called before mruby-bin-mrbc

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -20,8 +20,13 @@ end
 MRUBY_CONFIG = MRuby::Build.mruby_config_path
 load MRUBY_CONFIG
 
-# set up all gems
-MRuby.each_target do
+# define MRB_NO_GEMS and set up all gems
+MRuby.each_target do |build|
+  unless enable_gems? && libmruby_enabled?
+    compilers.each do |compiler|
+      compiler.defines << "MRB_NO_GEMS"
+    end
+  end
   gems.setup(self) if enable_gems?
 end
 

--- a/doc/guides/mrbgems.md
+++ b/doc/guides/mrbgems.md
@@ -333,6 +333,9 @@ spec.build_settings do
 end
 ```
 
+The block passed to `MRuby::Gem::Specification#build_settings` is called in the order of the dependent GEMs,
+after all setup blocks for GEMs including dependencies have been called.
+
 **NOTE**: Using the `build_settings` method will cause GEM's all build command settings
 directly written in the block passed to `MRuby::Gem::Specification.new` to be ignored.
 

--- a/lib/mruby/build.rb
+++ b/lib/mruby/build.rb
@@ -382,9 +382,6 @@ EOS
     end
 
     def define_rules
-      compilers.each do |compiler|
-        compiler.defines << "MRB_NO_GEMS" unless enable_gems? && libmruby_enabled?
-      end
       [@cc, *(@cxx if cxx_exception_enabled?)].each do |compiler|
         compiler.define_rules(@build_dir, MRUBY_ROOT, @exts.object)
         compiler.define_rules(@build_dir, MRUBY_ROOT, @exts.presym_preprocessed)

--- a/lib/mruby/gem.rb
+++ b/lib/mruby/gem.rb
@@ -486,11 +486,6 @@ module MRuby
         end
       end
 
-      def setup_build
-        each(&:setup_build)
-        self
-      end
-
       def setup_dependencies(build)
         gem_table = each_with_object({}) { |spec, h| h[spec.name] = spec }
 
@@ -584,6 +579,7 @@ module MRuby
 
         @ary = tsort_dependencies gem_table.keys, gem_table, true
 
+        each(&:setup_build)
         each(&:setup_compilers)
 
         each do |g|

--- a/mrbgems/mruby-bin-mrbc/mrbgem.rake
+++ b/mrbgems/mruby-bin-mrbc/mrbgem.rake
@@ -5,38 +5,34 @@ MRuby::Gem::Specification.new 'mruby-bin-mrbc' do |spec|
 
   spec.add_dependency 'mruby-compiler', core: 'mruby-compiler'
 
-  spec.cc.include_paths << "#{MRUBY_ROOT}/mrbgems/mruby-compiler/lib/prism/include"
-
-  # The layout of struct mrc_ccontext depends on MRC_TARGET_*; the tool's own
-  # translation units must use the same target define as mruby-compiler,
-  # otherwise field offsets (e.g. diagnostic_list) disagree across the link.
-  spec.cc.defines.flatten!
-  if spec.cc.defines.include?('PICORB_VM_MRUBY')
-    spec.cc.defines << 'MRC_TARGET_MRUBY'
-  elsif spec.cc.defines.include?('PICORB_VM_MRUBYC')
-    spec.cc.defines << 'MRC_TARGET_MRUBYC'
-  elsif !spec.cc.defines.include?('MRB_NO_GEMS')
-    spec.cc.defines << 'MRC_TARGET_MRUBY'
-  end
-
-  mrbc_prism_objs = Dir.glob("#{dir}/tools/mrbc/*.c").map { |f| objfile(f.pathmap("#{build_dir}/tools/mrbc/%n")) }
-  # Ensure the compiler gem is set up so its objs are available regardless of
-  # the order in which gems are processed (setup is idempotent).
-  compiler = build.gems['mruby-compiler']
-  if compiler.objs.nil?
-    saved = MRuby::Gem.current
-    compiler.setup
-    MRuby::Gem.current = saved
-  end
-  mrbc_prism_objs += compiler.objs
-  mrbc_prism_objs.delete_if { |o| o.include?('gem_init') || o.include?('mruby_compat') }
-
   exe_name = 'mrbc'
-
-  file exefile("#{build.build_dir}/bin/#{exe_name}") => mrbc_prism_objs do |t|
-    build.linker.run t.name, t.prerequisites
-  end
 
   build.bins << exe_name
 
+  build_settings do
+    spec.cc.include_paths << "#{MRUBY_ROOT}/mrbgems/mruby-compiler/lib/prism/include"
+
+    # The layout of struct mrc_ccontext depends on MRC_TARGET_*; the tool's own
+    # translation units must use the same target define as mruby-compiler,
+    # otherwise field offsets (e.g. diagnostic_list) disagree across the link.
+    spec.cc.defines.flatten!
+    if spec.cc.defines.include?('PICORB_VM_MRUBY')
+      spec.cc.defines << 'MRC_TARGET_MRUBY'
+    elsif spec.cc.defines.include?('PICORB_VM_MRUBYC')
+      spec.cc.defines << 'MRC_TARGET_MRUBYC'
+    elsif !spec.cc.defines.include?('MRB_NO_GEMS')
+      spec.cc.defines << 'MRC_TARGET_MRUBY'
+    end
+
+    mrbc_prism_objs = Dir.glob("#{dir}/tools/mrbc/*.c").map { |f| objfile(f.pathmap("#{build_dir}/tools/mrbc/%n")) }
+    # Ensure the compiler gem is set up so its objs are available regardless of
+    # the order in which gems are processed (setup is idempotent).
+    compiler = build.gems['mruby-compiler']
+    mrbc_prism_objs += compiler.objs
+    mrbc_prism_objs.delete_if { |o| o.include?('gem_init') || o.include?('mruby_compat') }
+
+    file exefile("#{build.build_dir}/bin/#{exe_name}") => mrbc_prism_objs do |t|
+      build.linker.run t.name, t.prerequisites
+    end
+  end
 end

--- a/mrbgems/mruby-compiler/src/compile.c
+++ b/mrbgems/mruby-compiler/src/compile.c
@@ -197,7 +197,7 @@ mrc_pm_parser_init(mrc_parser_state *p, uint8_t **source, size_t size, mrc_ccont
 #ifndef MRC_NO_STDIO
 
 #define INITIAL_BUF_SIZE 1024
-static ssize_t
+static intptr_t
 append_from_stdin(mrc_ccontext *c, uint8_t **source, size_t source_length)
 {
   uint8_t *buffer = (uint8_t *)mrc_malloc(c, INITIAL_BUF_SIZE);
@@ -233,13 +233,13 @@ append_from_stdin(mrc_ccontext *c, uint8_t **source, size_t source_length)
   }
 }
 
-static ssize_t
+static intptr_t
 read_input_files(mrc_ccontext *c, const char **filenames, uint8_t **source, mrc_filename_table *filename_table)
 {
   int i = 0;
   size_t pos = 0;
-  ssize_t length = 0;
-  ssize_t each_size;
+  intptr_t length = 0;
+  intptr_t each_size;
   FILE *file;
   const char *filename = filenames[0];
   while (filename) {
@@ -351,7 +351,7 @@ mrc_parse_file_cxt(mrc_ccontext *c, const char **filenames, uint8_t **source)
   c->filename_table = (mrc_filename_table *)mrc_malloc(c, sizeof(mrc_filename_table) * filecount);
   c->filename_table_length = filecount;
   c->current_filename_index = 0;
-  ssize_t length = read_input_files(c, filenames, source, c->filename_table);
+  intptr_t length = read_input_files(c, filenames, source, c->filename_table);
   if (length < 0) {
     fprintf(stderr, "Cannot open files: ");
     for (size_t i = 0; i < filecount; i++) {

--- a/tasks/mrbgems.rake
+++ b/tasks/mrbgems.rake
@@ -2,7 +2,6 @@ MRuby.each_target do
   active_gems_txt = "#{build_dir}/mrbgems/active_gems.txt"
 
   if enable_gems?
-    gems.setup_build
     gems.check self
 
     # loader all gems


### PR DESCRIPTION
Fixed #6972

Fix this by changing the order in which the `build_settings` block is called to come after the dependent GEMs, and by enclosing the mruby-bin-mrbc compilation settings within the `build_settings` block.
However, in this state, mruby-bin-mrbc is built with `MRB_NO_GEMS` defined, while mruby-compiler is built with `MRB_NO_GEMS` undefined, resulting in a linking error in C++ ABI mode (`conf.enable_cxx_abi`). Therefore, the build system must be modified so that `mruby-compiler` is also built with `MRB_NO_GEMS` defined.
Furthermore, since mruby-compiler does not include `include/mruby.h` in this state, and `ssize_t` is undefined in MSVC, replace it with `intptr_t`.

---

If addressing issues with a stopgap fix while leaving several problems unresolved, the following single line is all that’s needed:

```patch
diff --git a/mrbgems/mruby-bin-mrbc/mrbgem.rake b/mrbgems/mruby-bin-mrbc/mrbgem.rake
index 24e46fb9e..498f17e58 100644
--- a/mrbgems/mruby-bin-mrbc/mrbgem.rake
+++ b/mrbgems/mruby-bin-mrbc/mrbgem.rake
@@ -23,6 +23,7 @@ MRuby::Gem::Specification.new 'mruby-bin-mrbc' do |spec|
   # Ensure the compiler gem is set up so its objs are available regardless of
   # the order in which gems are processed (setup is idempotent).
   compiler = build.gems['mruby-compiler']
+  compiler = build.gem core: "mruby-compiler" unless compiler
   if compiler.objs.nil?
     saved = MRuby::Gem.current
     compiler.setup
```
