### PR TITLE
Omitting mruby-compiler in `MRuby::Build#build_mrbc_exec`

### DIFF
--- a/lib/mruby/build.rb
+++ b/lib/mruby/build.rb
@@ -341,9 +341,6 @@ EOS
     end
 
     def build_mrbc_exec
-      # Add the compiler before the executable so the latter's mrbgem.rake can
-      # see it in build.gems while it is evaluated.
-      gem :core => 'mruby-compiler' unless @gems['mruby-compiler']
       gem :core => 'mruby-bin-mrbc' unless @gems['mruby-bin-mrbc']
     end
 


### PR DESCRIPTION
Originally, mruby-bin-mrbc included a dependency to mruby-compiler, and the build issue was resolved by #6979.