### PR TITLE
Add mrb_task_set_scheduler_hook for pre-scheduling deferred work. Remove  mrb_hal_task_switch_hook instead

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -305,6 +305,8 @@ typedef struct mrb_task_state {
   uint8_t irq_nesting;              /* Depth counter for scheduler-IRQ exclusion */
   mrb_bool loop_running;            /* Active mrb_task_run loop flag */
   mrb_bool exception_as_result;     /* Return unhandled task exceptions as values */
+  void (*scheduler_hook)(struct mrb_state *mrb, void *ud); /* Pre-scheduling servicing hook */
+  void *scheduler_hook_ud;            /* Opaque argument for scheduler_hook */
 } mrb_task_state;
 #endif
 

--- a/mrbgems/mruby-task/include/task.h
+++ b/mrbgems/mruby-task/include/task.h
@@ -121,6 +121,14 @@ MRB_API void mrb_tick(mrb_state *mrb);
 MRB_API mrb_value mrb_task_run(mrb_state *mrb);
 MRB_API mrb_value mrb_task_run_once(mrb_state *mrb);
 
+/* Register a hook called in thread context at every scheduler entry,
+ * right before the ready-queue read: a task the hook makes ready
+ * (e.g. via mrb_task_queue_push) runs in the same iteration.
+ * One hook per mrb_state -- setting replaces, fn == NULL clears,
+ * composition is the embedder's concern, the caller owns ud.
+ * Must be cheap, never sleep, never re-enter the scheduler. */
+MRB_API void mrb_task_set_scheduler_hook(mrb_state *mrb, void (*fn)(mrb_state *mrb, void *ud), void *ud);
+
 /*
  * Task creation API
  */

--- a/mrbgems/mruby-task/include/task_hal.h
+++ b/mrbgems/mruby-task/include/task_hal.h
@@ -130,43 +130,6 @@ void mrb_task_disable_irq(void);
 void mrb_hal_task_idle_cpu(mrb_state *mrb);
 
 /**
- * Which scheduler control point is calling mrb_hal_task_switch_hook().
- *
- * More reasons may be added as the scheduler grows control points, without
- * changing the hook's signature.
- */
-typedef enum mrb_task_switch_reason {
-  /** A task returned control (timeslice expiry, block, or completion) */
-  MRB_TASK_SWITCH_TASK,
-  /** An idle GC step ran in the scheduler's pending-GC drain loop */
-  MRB_TASK_SWITCH_GC_STEP,
-} mrb_task_switch_reason;
-
-/**
- * Called by the scheduler each time it regains control from a task
- * (timeslice expiry, block, or completion) and after each GC step in its
- * pending-GC drain loop, always in thread context.
- *
- * Gives the platform a periodic servicing point that fires even when the
- * ready queue is never empty — mrb_hal_task_idle_cpu() only runs when no
- * task is ready, so a compute-bound task (or a long GC drain) would
- * otherwise starve anything the platform services there (e.g. a polled
- * network driver).
- *
- * Requirements:
- * - Must be cheap when there is nothing to service (called every switch)
- * - Must NOT sleep or wait for interrupts (that is idle_cpu's job)
- * - Most ports need no servicing: provide an empty implementation
- * - Ports that don't distinguish control points ignore `reason`; ports
- *   that branch on it must service unrecognized values as if they were
- *   MRB_TASK_SWITCH_TASK, so reasons added later never lose servicing
- *
- * @param mrb The mruby state (for context, may be unused)
- * @param reason The control point being serviced (may be ignored)
- */
-void mrb_hal_task_switch_hook(mrb_state *mrb, mrb_task_switch_reason reason);
-
-/**
  * Sleep for specified microseconds in wall-clock time
  *
  * Called by sleep functions when in root context (not in a task).

--- a/mrbgems/mruby-task/ports/glib/task_hal.c
+++ b/mrbgems/mruby-task/ports/glib/task_hal.c
@@ -529,14 +529,6 @@ mrb_hal_task_idle_cpu(mrb_state *mrb)
 }
 
 void
-mrb_hal_task_switch_hook(mrb_state *mrb, mrb_task_switch_reason reason)
-{
-  (void)mrb;
-  (void)reason;
-  /* Nothing to service on this platform */
-}
-
-void
 mrb_hal_task_sleep_us(mrb_state *mrb, mrb_int usec)
 {
   (void)mrb;

--- a/mrbgems/mruby-task/ports/posix/task_hal.c
+++ b/mrbgems/mruby-task/ports/posix/task_hal.c
@@ -143,14 +143,6 @@ mrb_hal_task_idle_cpu(mrb_state *mrb)
 }
 
 void
-mrb_hal_task_switch_hook(mrb_state *mrb, mrb_task_switch_reason reason)
-{
-  (void)mrb;
-  (void)reason;
-  /* Nothing to service on this platform */
-}
-
-void
 mrb_hal_task_sleep_us(mrb_state *mrb, mrb_int usec)
 {
   struct timespec start, now, sleep_time;

--- a/mrbgems/mruby-task/ports/win/task_hal.c
+++ b/mrbgems/mruby-task/ports/win/task_hal.c
@@ -123,14 +123,6 @@ mrb_hal_task_idle_cpu(mrb_state *mrb)
 }
 
 void
-mrb_hal_task_switch_hook(mrb_state *mrb, mrb_task_switch_reason reason)
-{
-  (void)mrb;
-  (void)reason;
-  /* Nothing to service on this platform */
-}
-
-void
 mrb_hal_task_sleep_us(mrb_state *mrb, mrb_int usec)
 {
   (void)mrb;

--- a/mrbgems/mruby-task/src/task.c
+++ b/mrbgems/mruby-task/src/task.c
@@ -605,11 +605,6 @@ task_run_body(mrb_state *mrb, void *ud)
         mrb_bool delayed = (q_ready_ != NULL);
         mrb_task_excl_exit(mrb);
         mrb_gc_scheduler_jitter(mrb, delayed);
-        /* This branch loops without reaching idle_cpu or the post-execute
-           hook below, so a long GC drain would otherwise be a third way to
-           starve platform servicing (mrb_task_run_once doesn't need this:
-           it returns to the host after one step). */
-        mrb_hal_task_switch_hook(mrb, MRB_TASK_SWITCH_GC_STEP);
         continue;
       }
       /* If there are tasks waiting or suspended, idle */
@@ -624,11 +619,6 @@ task_run_body(mrb_state *mrb, void *ud)
 
     /* Execute task using core logic */
     execute_task(mrb, t);
-
-    /* Platform servicing point — fires on every switch, so a compute-bound
-       task that keeps the ready queue full cannot starve it (idle_cpu only
-       runs when no task is ready). */
-    mrb_hal_task_switch_hook(mrb, MRB_TASK_SWITCH_TASK);
 
     /* Move to end of ready queue if still running (round-robin) */
     if (t->status == MRB_TASK_STATUS_READY) {
@@ -711,9 +701,6 @@ mrb_task_run_once(mrb_state *mrb)
 
   /* Execute task using core logic */
   execute_task(mrb, t);
-
-  /* Platform servicing point (see task_run_body) */
-  mrb_hal_task_switch_hook(mrb, MRB_TASK_SWITCH_TASK);
 
   /* Move to end of ready queue if still ready (round-robin) */
   if (t->status == MRB_TASK_STATUS_READY) {

--- a/mrbgems/mruby-task/src/task.c
+++ b/mrbgems/mruby-task/src/task.c
@@ -571,6 +571,12 @@ task_run_body(mrb_state *mrb, void *ud)
   (void)ud;
 
   while (1) {
+    /* Scheduler servicing point. Runs before the ready-queue read so
+       a task woken here (busy path, task termination, and idle return
+       all pass through this loop top) is picked up in this iteration. */
+    if (mrb->task.scheduler_hook) {
+      mrb->task.scheduler_hook(mrb, mrb->task.scheduler_hook_ud);
+    }
     t = q_ready_;
 
     /* No task ready - check if all tasks are done */
@@ -655,11 +661,24 @@ mrb_task_run(mrb_state *mrb)
   return result;
 }
 
+MRB_API void
+mrb_task_set_scheduler_hook(mrb_state *mrb, void (*fn)(mrb_state *mrb, void *ud), void *ud)
+{
+  mrb->task.scheduler_hook = fn;
+  mrb->task.scheduler_hook_ud = ud;
+}
+
 /* Single-step task execution for WASM event loop integration */
 MRB_API mrb_value
 mrb_task_run_once(mrb_state *mrb)
 {
-  mrb_task *t = q_ready_;
+  mrb_task *t;
+
+  /* Scheduler servicing point (see task_run_body) */
+  if (mrb->task.scheduler_hook) {
+    mrb->task.scheduler_hook(mrb, mrb->task.scheduler_hook_ud);
+  }
+  t = q_ready_;
 
   /* No task ready */
   if (!t) {
@@ -986,7 +1005,13 @@ mrb_task_s_list(mrb_state *mrb, mrb_value self)
 static void
 task_run_one_iteration(mrb_state *mrb)
 {
-  mrb_task *t = q_ready_;
+  mrb_task *t;
+
+  /* Scheduler servicing point (see task_run_body) */
+  if (mrb->task.scheduler_hook) {
+    mrb->task.scheduler_hook(mrb, mrb->task.scheduler_hook_ud);
+  }
+  t = q_ready_;
 
   /* No ready task - just return (sleep from root provides delays) */
   if (!t) {

--- a/mrbgems/mruby-task/test/task.rb
+++ b/mrbgems/mruby-task/test/task.rb
@@ -303,3 +303,59 @@ assert("exception raised from C after blocking is not leaked into Task#value") d
 
   assert_equal :rescued, child.value
 end
+
+# Scheduler hook tests (mrb_task_set_scheduler_hook)
+
+assert("scheduler hook fires at every scheduler entry") do
+  TaskTest.install_probe_hook(0)
+  c0 = TaskTest.probe_count(0)
+  Task.pass            # entry: task_run_one_iteration (root-context Task.pass)
+  c1 = TaskTest.probe_count(0)
+  TaskTest.run_once    # entry: mrb_task_run_once
+  c2 = TaskTest.probe_count(0)
+  Task.new(name: "hook_noop") { }
+  Task.run             # entry: task_run_body loop
+  c3 = TaskTest.probe_count(0)
+  TaskTest.clear_hook
+  assert_true c0 + 1 <= c1
+  assert_true c1 + 1 <= c2
+  assert_true c2 + 1 <= c3
+end
+
+assert("scheduler hook wakes a queue-blocked task in the same iteration") do
+  q = Task::Queue.new
+  ran = []
+  t = Task.new(name: "hook_waker") do
+    ran << q.pop
+  end
+  Task.pass  # runs the task until it parks inside q.pop
+  TaskTest.install_wake_hook(q)
+  # The hook fires before the ready-queue read, so the push it makes must
+  # wake the task and get it selected within this single Task.pass. If the
+  # hook ran after the read, a second pass would be needed.
+  Task.pass
+  TaskTest.clear_hook
+  assert_equal [42], ran
+end
+
+assert("setting a new scheduler hook replaces the previous one") do
+  TaskTest.install_probe_hook(0)
+  Task.pass
+  a_after_first = TaskTest.probe_count(0)
+  TaskTest.install_probe_hook(1)
+  Task.pass
+  TaskTest.clear_hook
+  assert_equal a_after_first, TaskTest.probe_count(0)
+  assert_true 1 <= TaskTest.probe_count(1)
+end
+
+assert("scheduler hook cleared with NULL stops firing") do
+  TaskTest.install_probe_hook(0)
+  Task.pass
+  fired = TaskTest.probe_count(0)
+  TaskTest.clear_hook
+  Task.pass
+  Task.pass
+  assert_true 1 <= fired
+  assert_equal fired, TaskTest.probe_count(0)
+end

--- a/mrbgems/mruby-task/test/tasktest.c
+++ b/mrbgems/mruby-task/test/tasktest.c
@@ -1,6 +1,7 @@
 #include <time.h>
 #include <mruby.h>
 #include <mruby/class.h>
+#include "task.h"
 
 /* Burn CPU until `ms` milliseconds of CPU time have elapsed, then raise.
    Blocking longer than MRB_TICK_UNIT * MRB_TIMESLICE_TICK_COUNT guarantees
@@ -21,9 +22,90 @@ tasktest_block_then_raise(mrb_state *mrb, mrb_value self)
   return mrb_nil_value(); /* not reached */
 }
 
+/* Scheduler-hook probes. Two counters so the replace semantics can be
+   observed: which counter grows tells which hook is installed. */
+static uint32_t probe_count_a;
+static uint32_t probe_count_b;
+
+static void
+tasktest_probe_hook(mrb_state *mrb, void *ud)
+{
+  (void)mrb;
+  uint32_t *count = (uint32_t *)ud;
+  (*count)++;
+}
+
+/* One-shot wake hook: on its first invocation after arming, push 42 into
+   the armed queue. The queue object is kept alive by the Ruby test scope;
+   the static mrb_value only mirrors it for the C callback. */
+static mrb_value wake_queue;
+static mrb_bool wake_armed;
+
+static void
+tasktest_wake_hook(mrb_state *mrb, void *ud)
+{
+  (void)ud;
+  if (wake_armed) {
+    wake_armed = FALSE;
+    mrb_task_queue_push(mrb, wake_queue, mrb_fixnum_value(42));
+  }
+}
+
+static mrb_value
+tasktest_install_probe_hook(mrb_state *mrb, mrb_value self)
+{
+  mrb_int which;
+  uint32_t *count;
+  mrb_get_args(mrb, "i", &which);
+  count = (which == 0) ? &probe_count_a : &probe_count_b;
+  *count = 0;
+  mrb_task_set_scheduler_hook(mrb, tasktest_probe_hook, count);
+  return mrb_nil_value();
+}
+
+static mrb_value
+tasktest_probe_count(mrb_state *mrb, mrb_value self)
+{
+  mrb_int which;
+  mrb_get_args(mrb, "i", &which);
+  return mrb_fixnum_value((mrb_int)((which == 0) ? probe_count_a : probe_count_b));
+}
+
+static mrb_value
+tasktest_install_wake_hook(mrb_state *mrb, mrb_value self)
+{
+  mrb_value q;
+  mrb_get_args(mrb, "o", &q);
+  wake_queue = q;
+  wake_armed = TRUE;
+  mrb_task_set_scheduler_hook(mrb, tasktest_wake_hook, NULL);
+  return mrb_nil_value();
+}
+
+static mrb_value
+tasktest_clear_hook(mrb_state *mrb, mrb_value self)
+{
+  mrb_task_set_scheduler_hook(mrb, NULL, NULL);
+  return mrb_nil_value();
+}
+
+/* Drive the mrb_task_run_once scheduler entry, which has no Ruby-facing
+   wrapper (Task.run covers task_run_body; Task.pass covers the
+   root-context helper). */
+static mrb_value
+tasktest_run_once(mrb_state *mrb, mrb_value self)
+{
+  return mrb_task_run_once(mrb);
+}
+
 void
 mrb_mruby_task_gem_test(mrb_state* mrb)
 {
   struct RClass *tasktest = mrb_define_module(mrb, "TaskTest");
   mrb_define_module_function(mrb, tasktest, "block_then_raise", tasktest_block_then_raise, MRB_ARGS_REQ(1));
+  mrb_define_module_function(mrb, tasktest, "install_probe_hook", tasktest_install_probe_hook, MRB_ARGS_REQ(1));
+  mrb_define_module_function(mrb, tasktest, "probe_count", tasktest_probe_count, MRB_ARGS_REQ(1));
+  mrb_define_module_function(mrb, tasktest, "install_wake_hook", tasktest_install_wake_hook, MRB_ARGS_REQ(1));
+  mrb_define_module_function(mrb, tasktest, "clear_hook", tasktest_clear_hook, MRB_ARGS_NONE());
+  mrb_define_module_function(mrb, tasktest, "run_once", tasktest_run_once, MRB_ARGS_NONE());
 }


### PR DESCRIPTION
## Motivation

PicoRuby is building an ISR-to-task event bridge: interrupt handlers only stage work (set flags), and a deferred handler wakes tasks blocked in Task::Queue#pop. This needs a servicing point that runs in thread context BEFORE the scheduler reads the ready queue, so a task woken there is picked up in the same iteration.

mrb_hal_task_switch_hook (https://github.com/mruby/mruby/pull/6942) cannot serve this, for three reasons:

1. Position: it fires AFTER task execution; waking-then-selecting requires firing before the ready-queue read.
2. Idle coverage: when every task is WAITING, no task switch happens and the hook never fires -- yet "all tasks asleep" is exactly when an ISR event needs to wake one.
3. Ownership: it is a compile-time HAL symbol owned by the port. Embedding code cannot attach deferred work at runtime without patching the port.

## What this patch adds

- mrb_task_set_scheduler_hook(mrb, fn, ud): a per-mrb_state hook invoked in thread context right before the ready-queue read, at every scheduler entry: the task_run_body loop top, mrb_task_run_once, and the Task.pass-from-root-context helper.
- API Contract: cheap, never sleeps, must not re-enter the scheduler.
    Cost when unset: one pointer check per scheduler iteration.
- Single-owner contract: one hook per mrb_state; setting a new hook replaces the previous one, and composing multiple consumers is the embedder's responsibility (no registry in mruby). The caller owns the lifetime of ud.
- No behavior change for existing code.
- Tests (mruby-task/test): the four contract properties, made deterministic without timing assumptions -- the hook fires at all three scheduler entries (Task.run, mrb_task_run_once via a C helper, and root-context Task.pass); an item the hook pushes into a
  Task::Queue wakes a blocked task within a SINGLE Task.pass, which discriminates the before-ready-read placement from an after-read one; setting a new hook replaces the previous; NULL clears.

## Relationship to https://github.com/mruby/mruby/pull/6942

For continuously pumped schedulers, the scheduler hook provides a corresponding servicing opportunity for every switch-hook control point, with a phase shift:

- In the continuous mrb_task_run loop, servicing moves from "right after task execution" to "at the next loop top" -- i.e. after the round-robin requeue and one incremental GC slice. Timeslice-bounded servicing is preserved (including the pending-GC drain loop, which passes the loop top on every step), and the loop top additionally covers idle iterations and the root-context Task.pass entry, which the switch hook never fires on.
- In mrb_task_run_once, servicing moves from post-run inside the same call to the entry of the NEXT call. A host that pumps run_once repeatedly still gets one servicing call per invocation, but at the opposite phase; a host that stops pumping gets no final post-run servicing.

On the `reason` argument: in https://github.com/mruby/mruby/pull/6942 the requirement was that the hook stay extensible without signature breaks, because it fires at several distinct control points; the extensible reason enum answered that.
The pre-selection hook meets the same requirement differently: it has a single uniform semantic --- "the scheduler is about to select the next task" --- so there are no control points to discriminate and nothing for a reason to say; per-registrant context travels in ud.
Every known implementation ignores reason today.

As far as I know, PicoRuby is the only consumer of mrb_hal_task_switch_hook --- https://github.com/mruby/mruby/pull/6942 was proposed for CYW43/lwIP pumping in PicoRuby (right?> @sylph01).
PicoRuby will migrate that servicing to a registered scheduler hook.

Removal of the switch hook is intentionally left to a separate commit bc6b58247be4224d37f8e21e18895c224dd065ab, so this additive change stands on its own.
The two hooks can alternatively coexist with distinct ownership models: HAL-owned compile-time servicing (switch hook) and runtime-registered embedder work (scheduler hook).

Which way would you prefer? @matz cc/ @sylph01

## Breaking change (commit 2 only, if this PR is merged as-is)

Commit 2 removes the public HAL API mrb_hal_task_switch_hook and the mrb_task_switch_reason enum from task_hal.h. Ports no longer need to provide the symbol. A port that serviced platform work in the switch hook registers an equivalent scheduler hook at init instead. As far as we know, PicoRuby is the only existing consumer and migrates accordingly. To keep the API, drop commit 2 --- commit 1 stands on its own.
