### PR TITLE
mruby-task: Detach envs from a task stack before freeing it

### DIFF
--- a/mrbgems/mruby-task/src/task.c
+++ b/mrbgems/mruby-task/src/task.c
@@ -55,9 +55,9 @@ task_unshare_envs(mrb_state *mrb, struct mrb_context *c)
    * one element before the start of an array is undefined behavior. */
   for (ci = c->ci; ; ci--) {
     struct REnv *e = ci->u.env;
-    /* mrb_env_unshare() allocates and can therefore run a GC cycle. The
-     * task is already unlinked here, so an env that nothing else refers
-     * to may be swept mid-walk; check liveness before touching it. */
+    /* mrb_env_unshare() allocates and can therefore run a GC cycle. In
+     * teardown paths the task may already be unlinked, so an env that no
+     * other object refers to may be swept mid-walk; check liveness first. */
     if (e && !mrb_object_dead_p(mrb, (struct RBasic*)e) &&
         e->tt == MRB_TT_ENV && MRB_ENV_ONSTACK_P(e)) {
       mrb_env_unshare(mrb, e, TRUE);

--- a/mrbgems/mruby-task/src/task.c
+++ b/mrbgems/mruby-task/src/task.c
@@ -35,6 +35,37 @@
 /* Maximum value for scheduler_lock (uint8_t max) */
 #define MRB_TASK_SCHEDULER_LOCK_MAX 255
 
+/* Detach envs that live on this task's stack before the stack goes away.
+ * An escaped closure keeps its REnv alive after the task is gone; if the
+ * env still points into the freed stack, the next GC marks garbage and
+ * crashes in mrb_gc_mark. mruby does the same for fibers in gc.c's
+ * MRB_TT_FIBER free path.
+ *
+ * Only called while the VM is alive. A task stays GC-registered for its
+ * whole life, so the GC frees one only while tearing the heap down, and
+ * there detaching would be both pointless (no later marking) and unsafe
+ * (the env's page may already be gone). */
+static void
+task_unshare_envs(mrb_state *mrb, struct mrb_context *c)
+{
+  mrb_callinfo *ci;
+
+  if (!c->cibase || !c->ci) return;
+  /* Stop AT cibase rather than decrementing past it: forming a pointer
+   * one element before the start of an array is undefined behavior. */
+  for (ci = c->ci; ; ci--) {
+    struct REnv *e = ci->u.env;
+    /* mrb_env_unshare() allocates and can therefore run a GC cycle. The
+     * task is already unlinked here, so an env that nothing else refers
+     * to may be swept mid-walk; check liveness before touching it. */
+    if (e && !mrb_object_dead_p(mrb, (struct RBasic*)e) &&
+        e->tt == MRB_TT_ENV && MRB_ENV_ONSTACK_P(e)) {
+      mrb_env_unshare(mrb, e, TRUE);
+    }
+    if (ci == c->cibase) break;
+  }
+}
+
 /*
  * Task data type for GC
  */
@@ -1407,6 +1438,12 @@ mrb_execute_proc_synchronously(mrb_state *mrb, mrb_value proc_val, mrb_int argc,
   if (mrb_obj_ptr(result) == mrb->exc) {
     mrb->exc = NULL;  /* Clear exception */
   }
+  /* From here on the task is unlinked, its context is STOPPED and (for an
+   * exception result) mrb->exc is cleared, so nothing the GC walks refers
+   * to the result any more. task_unshare_envs() below allocates and can
+   * therefore run a GC cycle: protect the result before that point, not
+   * after the teardown. */
+  mrb_gc_protect(mrb, result);
 
   /* 6. Free the temporary task's resources */
   mrb_task_excl_enter(mrb);
@@ -1417,6 +1454,7 @@ mrb_execute_proc_synchronously(mrb_state *mrb, mrb_value proc_val, mrb_int argc,
   DATA_TYPE(task_obj) = NULL;
 
   /* Free context resources directly (bypass GC since we own this task) */
+  task_unshare_envs(mrb, &t->c);
   if (t->c.stbase) {
     mrb_free(mrb, t->c.stbase);
     t->c.stbase = NULL;
@@ -1639,6 +1677,7 @@ mrb_close_task(mrb_state *mrb, mrb_value task)
   mrb_task_excl_exit(mrb);
 
   DATA_PTR(task) = NULL;
+  task_unshare_envs(mrb, &t->c);
   mrb_task_free(mrb, t);
 }
 
@@ -1686,6 +1725,7 @@ mrb_task_init_context(mrb_state *mrb, mrb_value task, struct RProc *proc)
   struct mrb_context *c = &t->c;
 
   /* Cleanup existing context if any */
+  task_unshare_envs(mrb, c);
   if (c->stbase) {
     mrb_free(mrb, c->stbase);
     c->stbase = NULL;

--- a/mrbgems/mruby-task/test/task.rb
+++ b/mrbgems/mruby-task/test/task.rb
@@ -359,3 +359,74 @@ assert("scheduler hook cleared with NULL stops firing") do
   assert_true 1 <= fired
   assert_equal fired, TaskTest.probe_count(0)
 end
+
+# Envs on a task stack must be detached before the stack is freed
+
+assert("closure escaping a closed task survives GC") do
+  t = Task.new(name: "escaper") do
+    a1 = 1; a2 = 2; a3 = 3; a4 = 4; a5 = 5; a6 = 6
+    $task_escaped_proc = -> { a1 + a2 + a3 + a4 + a5 + a6 }
+    Task.current.suspend
+  end
+  Task.pass
+  assert_equal 21, $task_escaped_proc.call
+  t.terminate
+  t.close                 # frees the task's stack
+  GC.start                # marks the escaped env; must not read freed memory
+  junk = []
+  i = 0
+  while i < 200
+    junk << "x" * 64      # reuse the freed stack region
+    i += 1
+  end
+  GC.start
+  assert_equal 21, $task_escaped_proc.call
+  $task_escaped_proc = nil
+end
+
+assert("closure escaping a task whose context is reinitialized survives GC") do
+  t = Task.new(name: "reinit") do
+    b1 = 7; b2 = 8; b3 = 9
+    $task_escaped_proc2 = -> { b1 + b2 + b3 }
+    Task.current.suspend
+  end
+  Task.pass
+  assert_equal 24, $task_escaped_proc2.call
+  t.terminate
+  # Reuse the task's context for another proc: the old stack is freed
+  # inside mrb_task_init_context, with the escaped env still pointing at it.
+  TaskTest.reinit_context(t) { 0 }
+  GC.start
+  junk = []
+  i = 0
+  while i < 200
+    junk << "y" * 48
+    i += 1
+  end
+  GC.start
+  assert_equal 24, $task_escaped_proc2.call
+  $task_escaped_proc2 = nil
+  t.close
+end
+
+assert("closure escaping a synchronously executed proc survives GC") do
+  result = TaskTest.run_sync do
+    c1 = 10; c2 = 20
+    $task_escaped_proc3 = -> { c1 + c2 }
+    "sync-result"
+  end
+  # The teardown frees the temporary task's stack; both the returned
+  # object and the escaped env must survive it.
+  assert_equal "sync-result", result
+  GC.start
+  junk = []
+  i = 0
+  while i < 200
+    junk << "z" * 48
+    i += 1
+  end
+  GC.start
+  assert_equal 30, $task_escaped_proc3.call
+  assert_equal "sync-result", result
+  $task_escaped_proc3 = nil
+end

--- a/mrbgems/mruby-task/test/tasktest.c
+++ b/mrbgems/mruby-task/test/tasktest.c
@@ -1,6 +1,7 @@
 #include <time.h>
 #include <mruby.h>
 #include <mruby/class.h>
+#include <mruby/proc.h>
 #include "task.h"
 
 /* Burn CPU until `ms` milliseconds of CPU time have elapsed, then raise.
@@ -98,6 +99,34 @@ tasktest_run_once(mrb_state *mrb, mrb_value self)
   return mrb_task_run_once(mrb);
 }
 
+
+/* Drive mrb_task_init_context(): reuse an existing task's context for a
+   new proc. The old context's stack is freed inside, which is where an
+   escaped env must have been detached. */
+static mrb_value
+tasktest_reinit_context(mrb_state *mrb, mrb_value self)
+{
+  mrb_value task, blk;
+  mrb_get_args(mrb, "o&", &task, &blk);
+  if (mrb_nil_p(blk)) {
+    mrb_raise(mrb, E_ARGUMENT_ERROR, "block required");
+  }
+  mrb_task_init_context(mrb, task, mrb_proc_ptr(blk));
+  return mrb_nil_value();
+}
+
+/* Drive the synchronous-execution teardown path. */
+static mrb_value
+tasktest_run_sync(mrb_state *mrb, mrb_value self)
+{
+  mrb_value blk;
+  mrb_get_args(mrb, "&", &blk);
+  if (mrb_nil_p(blk)) {
+    mrb_raise(mrb, E_ARGUMENT_ERROR, "block required");
+  }
+  return mrb_execute_proc_synchronously(mrb, blk, 0, NULL);
+}
+
 void
 mrb_mruby_task_gem_test(mrb_state* mrb)
 {
@@ -108,4 +137,6 @@ mrb_mruby_task_gem_test(mrb_state* mrb)
   mrb_define_module_function(mrb, tasktest, "install_wake_hook", tasktest_install_wake_hook, MRB_ARGS_REQ(1));
   mrb_define_module_function(mrb, tasktest, "clear_hook", tasktest_clear_hook, MRB_ARGS_NONE());
   mrb_define_module_function(mrb, tasktest, "run_once", tasktest_run_once, MRB_ARGS_NONE());
+  mrb_define_module_function(mrb, tasktest, "reinit_context", tasktest_reinit_context, MRB_ARGS_REQ(1) | MRB_ARGS_BLOCK());
+  mrb_define_module_function(mrb, tasktest, "run_sync", tasktest_run_sync, MRB_ARGS_BLOCK());
 }


### PR DESCRIPTION
A closure created inside a task keeps its REnv alive after the task is gone. While the task lives that env is "on stack": e->stack points into the task's own stack buffer. Freeing the buffer without detaching the env leaves the pointer dangling, and the next GC that marks the env reads freed memory:

```
    #0 mrb_gc_mark            gc.c:1022
    #1 gc_mark_children       gc.c:920    <- MRB_TT_ENV, e->stack[i]
    #7 mrb_full_gc
    #8 mrb_obj_alloc_core                 <- any allocation can trigger it
```

mruby already does this for fibers: the MRB_TT_FIBER free path in gc.c walks the callinfo chain and calls mrb_env_unshare() on every on-stack env before releasing the context. Tasks own an equivalent context but had no such step.

Add task_unshare_envs() and call it from the three places that release a live task's stack: mrb_close_task, mrb_task_init_context (context reuse) and the synchronous-execution teardown. Notes on the edges:

- Not called from mrb_task_free. A task stays GC-registered for its whole life, so the GC frees one only while tearing the heap down, where detaching is both pointless (nothing marks the env afterwards) and unsafe (its page may already be gone) -- the same reason gc.c guards the fiber path with its `end` flag.
- mrb_env_unshare() allocates, so it can run a GC cycle. The task is already unlinked by then, hence an env reachable only from the callinfo chain can be swept mid-walk: each entry is checked with mrb_object_dead_p() before it is touched. For the same reason the synchronous teardown now protects its result value *before* the walk, not after it -- at that point the result is referenced only by a C local (the task is unlinked and mrb->exc was cleared).
- The walk stops at cibase instead of decrementing past it; forming a pointer before the start of an array is undefined behavior.

Reproduction, deterministic before the fix:

```ruby
    t = Task.new { a = 1; $esc = -> { a }; Task.current.suspend }
    Task.pass
    t.terminate; t.close
    GC.start                 # SEGV in mrb_gc_mark
```

Tests: three cases in mruby-task/test/task.rb call an escaped closure after the owning task's stack is gone -- via Task#close, via context reuse (mrb_task_init_context) and via synchronous execution, the last also asserting the returned object survived. Two C helpers in tasktest.c reach the paths that have no Ruby-visible entry point. They crash mrbtest without this patch and pass with it (805 tests, KO 0).