### PR TITLE
Restore `gc.disabled` when even out of memory

### DIFF
--- a/include/mruby/internal.h
+++ b/include/mruby/internal.h
@@ -50,6 +50,7 @@ void mrb_codedump_all_file(mrb_state *mrb, struct RProc *proc, FILE *out);
 #endif
 
 /* error */
+mrb_noreturn void mrb_raise_nomemory(mrb_state *mrb);
 mrb_value mrb_exc_inspect(mrb_state *mrb, mrb_value exc);
 mrb_value mrb_exc_backtrace(mrb_state *mrb, mrb_value exc);
 mrb_value mrb_get_backtrace(mrb_state *mrb);

--- a/src/gc.c
+++ b/src/gc.c
@@ -264,8 +264,6 @@ mrb_static_assert(MRB_GC_RED <= GC_COLOR_MASK);
 #define other_white_part(s) ((s)->current_white_part ^ GC_WHITES)
 #define is_dead(s, o) (((o)->gc_color & other_white_part(s) & GC_WHITES) || (o)->tt == MRB_TT_FREE)
 
-mrb_noreturn void mrb_raise_nomemory(mrb_state *mrb);
-
 static size_t incremental_gc_finish(mrb_state *mrb, mrb_gc *gc);
 static size_t incremental_gc_run(mrb_state *mrb, mrb_gc *gc);
 

--- a/src/vm.c
+++ b/src/vm.c
@@ -167,12 +167,16 @@ envadjust(mrb_state *mrb, mrb_value *oldbase, mrb_value *newbase)
    old buffer is freed before the base pointers are updated, so an incremental
    GC step triggered from inside the realloc would mark the freed buffer
    (use-after-free). */
-#define WITH_GC_DISABLED(mrb, body) do {       \
-  mrb_bool gc_disabled__ = (mrb)->gc.disabled; \
-  (mrb)->gc.disabled = TRUE;                   \
-  { body }                                     \
-  (mrb)->gc.disabled = gc_disabled__;          \
-} while (0)
+static inline void*
+mrb_realloc_with_gc_disabled(mrb_state *mrb, void *p, size_t size)
+{
+  mrb_bool gc_disabled = mrb->gc.disabled;
+  mrb->gc.disabled = TRUE;
+  p = mrb_realloc_simple(mrb, p, size);
+  mrb->gc.disabled = gc_disabled;
+  if (!p) mrb_raise_nomemory(mrb);
+  return p;
+}
 
 static void
 stack_extend_alloc(mrb_state *mrb, mrb_int room)
@@ -202,13 +206,11 @@ stack_extend_alloc(mrb_state *mrb, mrb_int room)
   }
 #endif
 
-  WITH_GC_DISABLED(mrb, {
-    mrb_value *newstack = (mrb_value*)mrb_realloc(mrb, mrb->c->stbase, sizeof(mrb_value) * size);
-    stack_clear(&(newstack[oldsize]), size - oldsize);
-    envadjust(mrb, oldbase, newstack);
-    mrb->c->stbase = newstack;
-    mrb->c->stend = mrb->c->stbase + size;
-  });
+  mrb_value *newstack = (mrb_value*)mrb_realloc_with_gc_disabled(mrb, mrb->c->stbase, sizeof(mrb_value) * size);
+  stack_clear(&(newstack[oldsize]), size - oldsize);
+  envadjust(mrb, oldbase, newstack);
+  mrb->c->stbase = newstack;
+  mrb->c->stend = mrb->c->stbase + size;
 
   /* Raise an exception if the new stack size will be too large,
      to prevent infinite recursion. However, do this only after resizing the stack, so mrb_raise has stack space to work with. */
@@ -396,11 +398,9 @@ cipush(mrb_state *mrb, mrb_int push_stacks, uint8_t cci, struct RClass *target_c
     if (size >= MRB_CALL_LEVEL_MAX) {
       mrb_exc_raise(mrb, mrb_obj_value(mrb->stack_err));
     }
-    WITH_GC_DISABLED(mrb, {
-      c->cibase = (mrb_callinfo*)mrb_realloc(mrb, c->cibase, sizeof(mrb_callinfo)*size*2);
-      c->ci = ci = c->cibase + size;
-      c->ciend = c->cibase + size * 2;
-    });
+    c->cibase = (mrb_callinfo*)mrb_realloc_with_gc_disabled(mrb, c->cibase, sizeof(mrb_callinfo)*size*2);
+    c->ci = ci = c->cibase + size;
+    c->ciend = c->cibase + size * 2;
   }
   ci->mid = mid;
   CI_PROC_SET(ci, proc);


### PR DESCRIPTION
`mrb_realloc()` may raise a `NoMemoryError` exception.