### PR TITLE
guard mrb_int overflow in ary_insert and ary_fill_exec

### DIFF
--- a/mrbgems/mruby-array-ext/src/array.c
+++ b/mrbgems/mruby-array-ext/src/array.c
@@ -1060,15 +1060,20 @@ ary_fill_exec(mrb_state *mrb, mrb_value self)
   struct RArray *ary = mrb_ary_ptr(self);
   mrb_int ary_len = ARY_LEN(ary);
 
+  mrb_int end;
+  if (mrb_int_add_overflow(start, length, &end)) {
+    mrb_raise(mrb, E_ARGUMENT_ERROR, "array size too big");
+  }
+
   /* Extend array if necessary */
-  if (start + length > ary_len) {
-    mrb_ary_resize(mrb, self, start + length);
+  if (end > ary_len) {
+    mrb_ary_resize(mrb, self, end);
     ary = mrb_ary_ptr(self);  /* refresh pointer after resize */
   }
 
   /* Ensure we don't go beyond array bounds */
   if (start >= ARY_LEN(ary) || length <= 0) return self;
-  if (start + length > ARY_LEN(ary)) {
+  if (end > ARY_LEN(ary)) {
     length = ARY_LEN(ary) - start;
   }
 
@@ -1399,7 +1404,10 @@ ary_insert(mrb_state *mrb, mrb_value self)
 
   mrb_ary_modify(mrb, mrb_ary_ptr(self));
 
-  mrb_int new_len = (idx > len ? idx : len) + argc;
+  mrb_int new_len;
+  if (mrb_int_add_overflow(idx > len ? idx : len, argc, &new_len)) {
+    mrb_raise(mrb, E_ARGUMENT_ERROR, "array size too big");
+  }
   mrb_ary_resize(mrb, self, new_len);
 
   if (idx < len) {

--- a/mrbgems/mruby-array-ext/test/array.rb
+++ b/mrbgems/mruby-array-ext/test/array.rb
@@ -411,6 +411,13 @@ assert("Array#fill") do
   # Test extending array
   a = [1, 2]
   assert_equal [1, 2, nil, nil, "x"], a.fill("x", 4, 1)
+
+  # start + length must not overflow mrb_int
+  # (shift width via a variable; the folded literal is unrepresentable on MRB_INT32)
+  bits = 63
+  a = [1, 2, 3, 4, 5]
+  assert_raise(ArgumentError, RangeError) { a.fill(0, 1, ~(-1 << bits)) }
+  assert_equal [1, 2, 3, 4, 5], a
 end
 
 
@@ -530,6 +537,13 @@ assert("Array#insert") do
   assert_equal "x", a[500]
   assert_equal 499, a[499]
   assert_equal 500, a[501]
+
+  # index + argc must not overflow mrb_int
+  # (shift width via a variable; the folded literal is unrepresentable on MRB_INT32)
+  bits = 63
+  a = [1, 2, 3, 4, 5]
+  assert_raise(ArgumentError, RangeError) { a.insert(~(-1 << bits), 99) }
+  assert_equal [1, 2, 3, 4, 5], a
 end
 
 assert("Array#bsearch") do


### PR DESCRIPTION
UBSan + ASan, from plain Ruby:

    array.c:1402:45: runtime error: signed integer overflow: 9223372036854775807 + 1 cannot be represented in type 'mrb_int'

    ERROR: AddressSanitizer: heap-buffer-overflow
    WRITE of size 8 at 0x604000000d78
        #1 ary_fill_with_nil array.c:179
        #2 mrb_ary_set       array.c:1118

`[1,2,3,4,5].insert(2**63-1, 0)` wraps `(idx > len ? idx : len) + argc`, so
`mrb_ary_resize` takes the shrink path and stores a negative length. The IndexError
raised right after leaves the array at size -9223372036854775808, and the next
`a[0] = 1` walks off the buffer.

`ary_fill_exec` has the same shape: the wrapped `start + length` defeats both the
extend test and the clamp below it, so the fill loop writes past the end. That one
is reachable from `Array#fill` on MRB_NO_BOXING builds, where `__fill_parse_arg`
hands the value through untruncated.

Counts that are large but don't wrap already raise ArgumentError "array size too big"
from `ary_check_too_big`, so both sites check with `mrb_int_add_overflow` and raise
the same error.
