### PR TITLE
Omit the backtrace if a pre-generated `NoMemoryError` is raised

### DIFF
--- a/src/error.c
+++ b/src/error.c
@@ -190,7 +190,7 @@ mrb_exc_set(mrb_state *mrb, mrb_value exc)
         (struct RBasic*)mrb->exc == mrb->gc.arena[mrb->gc.arena_idx-1]) {
       mrb->gc.arena_idx--;
     }
-    if (!mrb->gc.out_of_memory && !mrb_frozen_p(mrb->exc)) {
+    if (!mrb->gc.out_of_memory && mrb->exc != mrb->nomem_err && !mrb_frozen_p(mrb->exc)) {
       mrb_keep_backtrace(mrb, exc);
     }
   }


### PR DESCRIPTION
The pattern of using the `mrb_malloc_simple()` family of functions to directly raise a `NoMemoryError` is not unusual.
In fact, this pattern is also used in mrbgems/mruby-array-ext and mrbgems/mruby-task.
Managing `mrb_gc::out_of_memory` in these cases is cumbersome as well.
Therefore, the behavior has been changed so that when a pre-generated `NoMemoryError` is raised, the backtrace generation is always omitted.

ref. commit 586fbc2d207e1c94aa23e66c8f65b2500297ff97

---

Perhaps we could remove the `mrb_gc::out_of_memory` flag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of `NoMemoryError` exceptions to prevent retaining unnecessary backtrace data during memory exhaustion.
  * Preserved existing backtrace behavior for other applicable exceptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->