### PR TITLE
mruby-regexp: raise TypeError for a String argument to String#=~

### DIFF
--- a/mrbgems/mruby-regexp/mrblib/string_regexp.rb
+++ b/mrbgems/mruby-regexp/mrblib/string_regexp.rb
@@ -15,6 +15,9 @@ class String
   end
 
   def =~(re)
+    # A String argument would dispatch back to this method and recurse, so
+    # reject it up front (CRuby raises the same TypeError).
+    raise TypeError, "type mismatch: String given" if re.is_a?(String)
     re =~ self
   end
 

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -521,6 +521,16 @@ assert("String#match") do
   assert_equal "world", md[2]
 end
 
+assert("String#=~") do
+  assert_equal 1, "abc" =~ Regexp.new("b")
+  assert_nil "abc" =~ Regexp.new("z")
+end
+
+assert("String#=~ with a String argument raises TypeError") do
+  assert_raise(TypeError) { "abc" =~ "b" }
+  assert_raise(TypeError) { "abc" !~ "b" }
+end
+
 assert("String#sub") do
   assert_equal "hXllo", "hello".sub(Regexp.new("e"), "X")
 end


### PR DESCRIPTION
`String#=~` defined by `mruby-regexp` delegates to `re =~ self`. When the argument is a
String, that dispatches back to `String#=~`, and the two recurse until the stack is
exhausted.

```ruby
"abc" =~ "b"
# CRuby: TypeError (type mismatch: String given)
# mruby: SystemStackError
```

CRuby's `rb_str_match()` branches on the argument type: `String` raises `TypeError`,
`Regexp` matches, and anything else is delegated to that object's `=~`. Rejecting
everything that is not a `Regexp` would therefore be too strict -- it would break the
duck-typed argument that CRuby accepts. Only the `String` case needs an explicit guard;
delegation already produces CRuby-compatible behaviour for the rest.

| argument | CRuby 4.0.6 | mruby (before) | mruby (after) |
| --- | --- | --- | --- |
| `String` | `TypeError` | `SystemStackError` | `TypeError` |
| `Regexp` | match position / `nil` | same | same |
| other, e.g. `42` | `NoMethodError` (`Object#=~` is gone in 4.0) | same | same |

`Kernel#!~` is `!(self =~ y)`, so `"abc" !~ "b"` now raises `TypeError` as well, matching
CRuby.

Tests for both the matching case and the `TypeError` are added to
`mrbgems/mruby-regexp/test/regexp.rb`.

One related divergence is left alone: `"abc" =~ nil` returns `nil` on CRuby (via
`NilClass#=~`) but raises `NoMethodError` on mruby. That is a `NilClass` question rather
than a `String#=~` one, so it is out of scope here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated `String#=~` to raise `TypeError` when passed a string, matching standard Ruby behavior.
  - Preserved pattern matching for supported inputs.
- **Tests**
  - Added coverage for matching, non-matching, and invalid string arguments to `String#=~` and `String#!~`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->