### PR TITLE
mruby-regexp: fix String#sub/#gsub argument handling

### DIFF
--- a/mrbgems/mruby-regexp/mrbgem.rake
+++ b/mrbgems/mruby-regexp/mrbgem.rake
@@ -4,7 +4,19 @@ MRuby::Gem::Specification.new('mruby-regexp') do |spec|
   spec.summary = 'Regexp class (built-in NFA engine)'
 
   spec.add_dependency 'mruby-string-ext', :core => 'mruby-string-ext'
-  # String#gsub without a block returns an enumerator; the test for that
-  # needs Enumerator (and thus Fiber).
-  spec.add_test_dependency 'mruby-enumerator', :core => 'mruby-enumerator'
+
+  # Enumerator is optional: only String#gsub without a block reaches `to_enum`,
+  # and without mruby-enumerator that is core Kernel#to_enum, which raises
+  # NotImplementedError -- the same deal as Kernel#loop and String#each_char
+  # (mruby-string-ext), neither of which depends on mruby-enumerator either.
+  # Declaring it unconditionally would drag Enumerator (and thus Fiber) into
+  # builds that never take that path. Depend on it only when the build has it
+  # anyway, so that mrbtest -- which runs each gem's tests in a state holding
+  # just its declared dependencies -- can exercise the enumerator path; the
+  # test skips itself when Enumerator is missing. A gem that only arrives
+  # through another gem's dependency is not visible here yet, which just means
+  # the test skips.
+  if build.gems.any? {|g| g.name == 'mruby-enumerator'}
+    spec.add_dependency 'mruby-enumerator', :core => 'mruby-enumerator'
+  end
 end

--- a/mrbgems/mruby-regexp/mrbgem.rake
+++ b/mrbgems/mruby-regexp/mrbgem.rake
@@ -4,4 +4,7 @@ MRuby::Gem::Specification.new('mruby-regexp') do |spec|
   spec.summary = 'Regexp class (built-in NFA engine)'
 
   spec.add_dependency 'mruby-string-ext', :core => 'mruby-string-ext'
+  # String#gsub without a block returns an enumerator; the test for that
+  # needs Enumerator (and thus Fiber).
+  spec.add_test_dependency 'mruby-enumerator', :core => 'mruby-enumerator'
 end

--- a/mrbgems/mruby-regexp/mrblib/string_regexp.rb
+++ b/mrbgems/mruby-regexp/mrblib/string_regexp.rb
@@ -46,10 +46,11 @@ class String
     unless (1..2).include?(args.length)
       raise ArgumentError, "wrong number of arguments (given #{args.length}, expected 1..2)"
     end
+    return to_enum(:gsub, *args) if args.length == 1 && !block
     pattern, replacement = *args
     pattern = Regexp.new(Regexp.escape(pattern)) if pattern.is_a?(String)
     # A replacement argument wins over the block, as in CRuby.
-    unless block && args.length == 1
+    if args.length == 2
       return pattern.__gsub_str(self, replacement.to_s)
     end
     # block case: keep in Ruby to avoid VM callback from C

--- a/mrbgems/mruby-regexp/mrblib/string_regexp.rb
+++ b/mrbgems/mruby-regexp/mrblib/string_regexp.rb
@@ -21,9 +21,20 @@ class String
     re =~ self
   end
 
-  def sub(pattern, replacement = nil, &block)
+  def sub(*args, &block)
+    # CRuby accepts 1..2 arguments with a block, but demands exactly 2
+    # without one, and reports the expected count accordingly.
+    if block
+      unless (1..2).include?(args.length)
+        raise ArgumentError, "wrong number of arguments (given #{args.length}, expected 1..2)"
+      end
+    elsif args.length != 2
+      raise ArgumentError, "wrong number of arguments (given #{args.length}, expected 2)"
+    end
+    pattern, replacement = *args
     pattern = Regexp.new(Regexp.escape(pattern)) if pattern.is_a?(String)
-    unless block
+    # A replacement argument wins over the block, as in CRuby.
+    if args.length == 2
       return pattern.__sub_str(self, replacement.to_s)
     end
     md = pattern.match(self)
@@ -31,9 +42,14 @@ class String
     md.pre_match + block.call(md[0]).to_s + md.post_match
   end
 
-  def gsub(pattern, replacement = nil, &block)
+  def gsub(*args, &block)
+    unless (1..2).include?(args.length)
+      raise ArgumentError, "wrong number of arguments (given #{args.length}, expected 1..2)"
+    end
+    pattern, replacement = *args
     pattern = Regexp.new(Regexp.escape(pattern)) if pattern.is_a?(String)
-    unless block
+    # A replacement argument wins over the block, as in CRuby.
+    unless block && args.length == 1
       return pattern.__gsub_str(self, replacement.to_s)
     end
     # block case: keep in Ruby to avoid VM callback from C

--- a/mrbgems/mruby-regexp/mrblib/string_regexp.rb
+++ b/mrbgems/mruby-regexp/mrblib/string_regexp.rb
@@ -46,6 +46,9 @@ class String
     unless (1..2).include?(args.length)
       raise ArgumentError, "wrong number of arguments (given #{args.length}, expected 1..2)"
     end
+    # Without mruby-enumerator this is core Kernel#to_enum, which raises
+    # NotImplementedError; every other path here stays usable, so the gem does
+    # not depend on Enumerator.
     return to_enum(:gsub, *args) if args.length == 1 && !block
     pattern, replacement = *args
     pattern = Regexp.new(Regexp.escape(pattern)) if pattern.is_a?(String)

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -539,6 +539,42 @@ assert("String#gsub") do
   assert_equal "h-ll-", "hello".gsub(Regexp.new("[eo]"), "-")
 end
 
+assert("String#sub/#gsub - replacement string takes precedence over the block") do
+  assert_equal "aXc", "abc".sub(/b/, "X") { "Y" }
+  assert_equal "aXcX", "abcb".gsub(/b/, "X") { "Y" }
+  # The block is only used when no replacement argument is given.
+  assert_equal "aYc", "abc".sub(/b/) { "Y" }
+  assert_equal "aYcY", "abcb".gsub(/b/) { "Y" }
+end
+
+assert("String#sub - wrong number of arguments") do
+  # Without a block CRuby demands exactly 2 arguments, and says so.
+  assert_raise_with_message(ArgumentError, "wrong number of arguments (given 0, expected 2)") do
+    "abc".sub
+  end
+  assert_raise_with_message(ArgumentError, "wrong number of arguments (given 1, expected 2)") do
+    "abc".sub(/b/)
+  end
+  assert_raise_with_message(ArgumentError, "wrong number of arguments (given 3, expected 2)") do
+    "abc".sub(/b/, "X", "Y")
+  end
+  assert_raise_with_message(ArgumentError, "wrong number of arguments (given 3, expected 1..2)") do
+    "abc".sub(/b/, "X", "Y") { "Z" }
+  end
+end
+
+assert("String#gsub - wrong number of arguments") do
+  assert_raise_with_message(ArgumentError, "wrong number of arguments (given 0, expected 1..2)") do
+    "abc".gsub
+  end
+  assert_raise_with_message(ArgumentError, "wrong number of arguments (given 3, expected 1..2)") do
+    "abc".gsub(/b/, "X", "Y")
+  end
+  assert_raise_with_message(ArgumentError, "wrong number of arguments (given 3, expected 1..2)") do
+    "abc".gsub(/b/, "X", "Y") { "Z" }
+  end
+end
+
 assert("String#sub with \\& \\` \\' specials") do
   # \& = full match
   assert_equal "a[bc]d", "abcd".sub(/bc/, '[\\&]')

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -575,6 +575,13 @@ assert("String#gsub - wrong number of arguments") do
   end
 end
 
+assert("String#gsub without a block returns an enumerator") do
+  assert_equal ["b", "b"], "abcb".gsub(/b/).to_a
+  assert_equal ["b", "b"], "abcb".gsub("b").to_a
+  # Iterating the enumerator with a block performs the substitution.
+  assert_equal "aBcB", "abcb".gsub(/b/).each { |m| m.upcase }
+end
+
 assert("String#sub with \\& \\` \\' specials") do
   # \& = full match
   assert_equal "a[bc]d", "abcd".sub(/bc/, '[\\&]')

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -576,6 +576,7 @@ assert("String#gsub - wrong number of arguments") do
 end
 
 assert("String#gsub without a block returns an enumerator") do
+  skip "Enumerator is not available" unless Object.const_defined?(:Enumerator)
   assert_equal ["b", "b"], "abcb".gsub(/b/).to_a
   assert_equal ["b", "b"], "abcb".gsub("b").to_a
   # Iterating the enumerator with a block performs the substitution.


### PR DESCRIPTION
`String#sub` and `String#gsub` in `mruby-regexp` branched on whether a block was given rather than on how many arguments were actually passed. Two behaviours diverged from CRuby as a result.

### 1. The block won over the replacement argument

```ruby
"abc".sub(/b/, "X") { "Y" }   #=> "aYc"  (CRuby: "aXc")
"abcb".gsub(/b/, "X") { "Y" } #=> "aYcY" (CRuby: "aXcX")
```

CRuby ignores the block whenever a replacement argument is present. Both methods now take a splat, so an omitted replacement can be told apart from an explicit one, and dispatch on the argument count instead.

This also lets them reject a bad argument count with the CRuby message. `gsub` always reports `1..2`; `sub` reports `1..2` with a block and exactly `2` without one, matching CRuby.

### 2. `gsub` without a block deleted every match

```ruby
"abcb".gsub(/b/) #=> "ac"  (CRuby: #<Enumerator: "abcb":gsub(/b/)>)
```

It fell through to `__gsub_str` with `nil.to_s` as the replacement. It now returns an enumerator over the matched substrings, so `gsub(pattern).each { ... }` performs the substitution as in CRuby.

`Enumerator` lives in `mruby-enumerator`, which `mruby-regexp` does not require at runtime — without it, `to_enum` is core `Kernel#to_enum`, which raises `NotImplementedError`, exactly as with `Kernel#loop` and `String#each_char` in `mruby-string-ext`. The gem declares the dependency only when the build already contains it, so no build gains Enumerator (and thus Fiber) it did not ask for. This is what lets the enumerator test run: mrbtest gives each gem's tests an `mrb_open_core()` state holding just its declared dependencies. When `Enumerator` is undefined the test skips itself. Both gems are in `stdlib.gembox`, so a normal build runs it.

### Notes

- `"abc".gsub(/b/, nil)` returns `"ac"` where CRuby raises `TypeError`. That predates this change and is left alone.
- `rake test` passes (1890 OK / 0 KO / 0 Crash).
- Checked against three build configs: default (test runs), `mruby-regexp` + `mruby-string-ext` only (test skips, neither Enumerator nor Fiber linked), and `mruby-regexp` + `mruby-set` where `mruby-enumerator` arrives transitively (test skips).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `String#sub` and `String#gsub` argument-count validation.
  * Ensured replacement arguments take precedence over blocks.
  * Preserved blockless `gsub` enumeration behavior.
  * Continued support for escaping string patterns.
  * Improved handling of invalid argument combinations with clear errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
