### PR TITLE
mruby-regexp: pass the block through String#match

### DIFF
--- a/mrbgems/mruby-regexp/README.md
+++ b/mrbgems/mruby-regexp/README.md
@@ -47,6 +47,7 @@ simulation) with backtracking fallback.
 re = Regexp.new("pattern", Regexp::IGNORECASE)
 re = /pattern/i                   # literal syntax
 re.match("string")                # => MatchData or nil
+re.match("string") { |md| ... }   # => block result, or nil if no match
 re.match?("string")               # => true/false
 re =~ "string"                    # => index or nil
 re === "string"                   # => true/false (for case/when)
@@ -71,6 +72,7 @@ md.named_captures                 # => {"name" => "value", ...}
 
 # String methods
 str.match(re)                     # => MatchData or nil
+str.match(re) { |md| ... }        # => block result, or nil if no match
 str.match?(re)                    # => true/false
 str =~ re                         # => index or nil
 str.sub(re, replacement)          # replace first occurrence

--- a/mrbgems/mruby-regexp/mrblib/string_regexp.rb
+++ b/mrbgems/mruby-regexp/mrblib/string_regexp.rb
@@ -4,9 +4,9 @@ class String
   # back to the core implementation.
   alias __split split
 
-  def match(re, pos = 0)
+  def match(re, pos = 0, &block)
     re = Regexp.new(re) if re.is_a?(String)
-    re.match(self, pos)
+    re.match(self, pos, &block)
   end
 
   def match?(re, pos = 0)

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -532,6 +532,14 @@ assert("String#match - block") do
   called = false
   assert_nil("hello".match(Regexp.new("l"), 4) { called = true })
   assert_false called
+
+  called = false
+  result = "hello".match("l+") do
+    called = true
+    nil
+  end
+  assert_nil result
+  assert_true called
 end
 
 assert("String#match - break out of the block") do

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -521,6 +521,28 @@ assert("String#match") do
   assert_equal "world", md[2]
 end
 
+assert("String#match - block") do
+  assert_equal "L", "hello".match(Regexp.new("l")) { |md| md[0].upcase }
+  assert_equal "ll", "hello".match("l+") { |md| md[0] }
+
+  called = false
+  assert_nil("hello".match(Regexp.new("z")) { called = true })
+  assert_false called
+
+  called = false
+  assert_nil("hello".match(Regexp.new("l"), 4) { called = true })
+  assert_false called
+end
+
+assert("String#match - break out of the block") do
+  assert_equal :broke, "hello".match("l+") { break :broke }
+end
+
+assert("String#match - block sees the match globals") do
+  assert_equal "ll", "hello".match("l+") { $~[0] }
+  assert_equal "ll", "hello".match("l+") { Regexp.last_match(0) }
+end
+
 assert("String#=~") do
   assert_equal 1, "abc" =~ Regexp.new("b")
   assert_nil "abc" =~ Regexp.new("z")


### PR DESCRIPTION
`Regexp#match` yields the `MatchData` and returns the block result when a block
is given, but `String#match` dropped the block: it always returned the
`MatchData`, so the block was never called.

```ruby
"hello".match("l+") { |md| md[0].upcase }  # => #<MatchData ...> instead of "LL"
```

This forwards the block to `Regexp#match` instead of yielding in Ruby, which
keeps the "yield only on a successful match" rule in a single place.

Tests cover the successful and failing match, `break` out of the block (the
block now travels from a Ruby method through `&block` into a C `mrb_yield`),
and that `$~` / `Regexp.last_match` are already set while the block runs.
The no-match tests flip a flag inside the block rather than only asserting
`nil`, since `nil` is also what you get when the block does run and returns
`nil`.

The README API listing is updated as well: it showed only the
`MatchData`-returning call, so the block form was undiscoverable from the docs
even though both `Regexp#match` and `String#match` are meant to support it.

`rake test` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `String#match` now accepts blocks and provides match results within them.
  * Block return values and control flow are supported.
  * String patterns continue to be treated as regular expressions.

* **Bug Fixes**
  * Improved handling when matches fail or the starting position is out of range.

* **Documentation**
  * Documented block usage for `Regexp#match` and `String#match`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->