### PR TITLE
mruby-regexp: test break out of the Regexp#match block

### DIFF
--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -35,6 +35,10 @@ assert("Regexp#match - block") do
   assert_nil(/xyz/.match("abcd") { |md| md[0] })
 end
 
+assert("Regexp#match - break out of the block") do
+  assert_equal :broke, /l+/.match("hello") { break :broke }
+end
+
 assert("Regexp#match?") do
   re = Regexp.new("abc")
   assert_true re.match?("xabcy")


### PR DESCRIPTION
`Regexp#match` accepts a block (`MRB_ARGS_BLOCK()` in `regexp.c`, yielded in
`regexp_match()`), but the suite only covered the value the block returns
normally:

```ruby
assert("Regexp#match - block") do
  result = /bc/.match("abcd") { |md| [md[0], md.begin(0)] }
  assert_equal ["bc", 1], result
  assert_nil(/xyz/.match("abcd") { |md| md[0] })
end
```

Nothing exercised a non-local exit from that block. The behaviour is correct
today, because `mrb_yield()` propagates the break:

```console
$ ./build/host/bin/mruby -e 'p(/l+/.match("hello") { break :broke })'
:broke
```

That is an easy property to lose when `regexp_match()` is refactored -- for
example if the yield moves behind an error-handling wrapper, or is replaced by
a call that swallows the break state. The regression would be silent: the
method would return the `MatchData` instead of the break value.

Test-only; no implementation change.

Related to #6991, which adds the same coverage for `String#match` once the
block is forwarded there. This one stands on its own and touches a different
part of the test file, so the two do not conflict.

`rake test` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `Regexp#match` to return the value provided by a block when it exits early with `break`.

* **Tests**
  * Added regression coverage for early block exits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->