### PR TITLE
mruby-regexp: add Symbol#match, #match? and #=~

### DIFF
--- a/mrbgems/mruby-regexp/README.md
+++ b/mrbgems/mruby-regexp/README.md
@@ -82,6 +82,12 @@ str.gsub(re) { |m| ... }          # replace all with block
 str.scan(re)                      # => array of matches
 str.split(re)                     # => array of parts
 
+# Symbol methods (the String methods applied to the symbol's name)
+sym.match(re)                     # => MatchData or nil
+sym.match(re) { |md| ... }        # => block result, or nil if no match
+sym.match?(re)                    # => true/false
+sym =~ re                         # => index or nil
+
 # Global variables
 $~                                # last MatchData
 ```
@@ -115,6 +121,15 @@ pattern analysis.
   only.
 - **Step limit on backtracking**: Patterns that require the
   backtracking engine are subject to a step limit.
+- **Symbols only on the left of a match**: `sym.match(re)`,
+  `sym.match?(re)` and `sym =~ re` work, but the Regexp side still
+  takes strings only. `re =~ sym`, `re.match(sym)` and
+  `re.match?(sym)` raise TypeError, `re === sym` returns false, and
+  therefore `syms.grep(re)` (which goes through `Regexp#===`) returns
+  `[]`.
+- **No regexp form of `String#[]`**: `str[re]` and `str.slice(re)`
+  are not supported, and neither is `sym[re]`, which delegates to
+  them.
 
 ## Configuration
 

--- a/mrbgems/mruby-regexp/mrblib/symbol_regexp.rb
+++ b/mrbgems/mruby-regexp/mrblib/symbol_regexp.rb
@@ -1,0 +1,28 @@
+# CRuby defines these on Symbol so that a symbol can be matched against a
+# regexp without spelling out the `to_s`.  They are the String methods applied
+# to the symbol's name, so delegate instead of repeating the pattern handling;
+# `$~` is set by the engine either way.
+#
+# This covers the symbol-on-the-left direction only.  The Regexp side still
+# rejects symbols -- `Regexp#=~`, `#match` and `#match?` raise TypeError and
+# `#===` returns false -- so `/^to_/ =~ :to_s` and `syms.grep(/^to_/)` (which
+# goes through `Regexp#===`) do not work yet.  That is a separate fix in
+# regexp.c, as is `sym[/re/]`, which needs the regexp form of `String#slice`.
+#
+# Two differences from CRuby are inherited from `String#=~` rather than
+# introduced here: a String argument raises TypeError (CRuby does too), but so
+# does any other object that has no `=~` -- `:a =~ nil` raises NoMethodError
+# where CRuby returns nil.
+class Symbol
+  def match(re, pos = 0, &block)
+    self.to_s.match(re, pos, &block)
+  end
+
+  def match?(re, pos = 0)
+    self.to_s.match?(re, pos)
+  end
+
+  def =~(re)
+    self.to_s =~ re
+  end
+end

--- a/mrbgems/mruby-regexp/test/symbol_regexp.rb
+++ b/mrbgems/mruby-regexp/test/symbol_regexp.rb
@@ -1,0 +1,99 @@
+assert("Symbol#match") do
+  md = :"hello world".match(Regexp.new("(\\w+)\\s(\\w+)"))
+  assert_equal "hello", md[1]
+  assert_equal "world", md[2]
+  assert_equal "hello world", md.string
+
+  # a String pattern is compiled, as it is for String#match
+  assert_equal "ll", :hello.match("l+")[0]
+
+  # pos is honoured, and counted in the symbol's name
+  assert_equal 3, :hello.match(Regexp.new("l"), 3).begin(0)
+  assert_nil :hello.match(Regexp.new("l"), 4)
+
+  # a negative pos counts back from the end of the name
+  assert_equal 3, :hello.match(Regexp.new("l"), -2).begin(0)
+  assert_nil :hello.match(Regexp.new("l"), -100)
+
+  assert_nil :hello.match(Regexp.new("z"))
+end
+
+assert("Symbol#match - empty symbol") do
+  assert_equal 0, :"".match(Regexp.new("")).begin(0)
+  assert_nil :"".match(Regexp.new("a"))
+  assert_true :"".match?(Regexp.new(""))
+  assert_false :"".match?(Regexp.new("a"))
+end
+
+assert("Symbol#match - block") do
+  assert_equal "LL", :hello.match("l+") { |md| md[0].upcase }
+  assert_equal :broke, :hello.match("l+") { break :broke }
+
+  called = false
+  assert_nil(:hello.match(Regexp.new("z")) { called = true })
+  assert_false called
+end
+
+assert("Symbol#match sets the match globals") do
+  assert_equal "ll", :hello.match("l+") { $~[0] }
+  :hello.match("l+")
+  assert_equal "ll", $~[0]
+  assert_equal "ll", Regexp.last_match(0)
+end
+
+assert("Symbol#match?") do
+  assert_true :hello.match?(Regexp.new("l+"))
+  assert_true :hello.match?("l+")
+  assert_false :hello.match?(Regexp.new("z"))
+
+  # pos is honoured, and counted in the symbol's name
+  assert_true :hello.match?(Regexp.new("l"), 3)
+  assert_false :hello.match?(Regexp.new("l"), 4)
+  assert_true :hello.match?(Regexp.new("l"), -2)
+  assert_false :hello.match?(Regexp.new("l"), -100)
+end
+
+assert("Symbol#match? - does not update last match") do
+  $~ = :matched.match("matched")
+  assert_true :hello.match?("l+")
+  assert_equal "matched", $~[0]
+  assert_false :hello.match?(Regexp.new("z"))
+  assert_equal "matched", $~[0]
+end
+
+assert("Symbol#=~") do
+  assert_equal 2, :hello =~ Regexp.new("l")
+  assert_nil :hello =~ Regexp.new("z")
+
+  # inherited from String#=~: a String argument is a type mismatch
+  assert_raise(TypeError) { :hello =~ "l" }
+end
+
+assert("Symbol#=~ sets the match globals") do
+  :hello =~ Regexp.new("l(l)")
+  assert_equal "ll", $~[0]
+  assert_equal "l", $1
+  assert_equal "l", Regexp.last_match(1)
+
+  assert_nil :hello =~ Regexp.new("z")
+  assert_nil $~
+end
+
+assert("Symbol#!~") do
+  assert_false :hello !~ Regexp.new("l")
+  assert_true :hello !~ Regexp.new("z")
+  assert_raise(TypeError) { :hello !~ "l" }
+end
+
+assert("Symbol - multibyte (UTF-8) name") do
+  # pos counts characters of the symbol's name, and begin/end report
+  # character offsets, just as they do for the equivalent String.
+  skip unless __ENCODING__ == "UTF-8"
+  assert_equal "い", :"あいう".match(Regexp.new("い"))[0]
+  assert_equal 2, :"あいあ".match(Regexp.new("あ"), 1).begin(0)
+  assert_equal 2, :"あいあ".match(Regexp.new("あ"), -1).begin(0)
+  assert_nil :"あいあ".match(Regexp.new("い"), 2)
+  assert_true :"あいあ".match?(Regexp.new("あ"), 2)
+  assert_false :"あいあ".match?(Regexp.new("い"), 2)
+  assert_equal 1, :"あい" =~ Regexp.new("い")
+end


### PR DESCRIPTION
CRuby defines `match`, `match?` and `=~` on Symbol so that a symbol can be
matched against a regexp without spelling out the `to_s`; mruby-regexp
provided none of them, so any regexp use on a symbol raised NoMethodError.

```ruby
:abc.match?(/b/)   # CRuby: true,  mruby: NoMethodError
:abc =~ /b/        # CRuby: 1,     mruby: NoMethodError
```

CRuby implements all three as the String method applied to the symbol's name
(`rb_sym2str` then `rb_str_match_m` / `rb_str_match`), so they delegate to
`to_s` rather than repeat the pattern handling. That inherits the String
pattern compilation, the `pos` argument, the block form, and the `TypeError`
for a String argument to `=~`. `$~` and `$1`-`$9` are set by the engine
itself, so delegating does not lose them.

`Symbol#match` needs the block to survive the delegation, which #6991 made
`String#match` do.

Delegating also inherits one difference from CRuby that is worth naming: for
an argument that is neither a Regexp nor a String, `String#=~` dispatches
`re =~ self`, so `:a =~ nil` raises NoMethodError where CRuby returns nil.
Fixing that belongs to `String#=~`, not to the Symbol wrapper.

The argument type of `match` and `match?` is inherited the same way, and
there it interacts with #6994. `String#match` currently hands `self` to
anything that is not a String, so once `Symbol#match` exists the receiver
and the argument swap places and a symbol pattern quietly matches instead of
raising:

```ruby
:abc.match(:b)   # without #6994: nil       (runs :b.to_s.match("abc"))
                 # with #6994:    TypeError (CRuby raises it too)
:abc.match?(:b)  # likewise false, then TypeError
```

#6994 adds that check in one helper on `String`, which both receivers go
through, so this PR needs no code for it. Merging #6994 first closes the
window; merging this one first opens it for as long as the two are apart.
The tests here therefore assert nothing about the argument type, and the
rows above are covered by #6994's tests instead.

This covers the symbol-on-the-left direction only. The Regexp side still
takes strings only, and rejects symbols in every entry point rather than just
in `#===`:

```ruby
/l/ =~ :hello        # TypeError (CRuby: 2)
/l/.match(:hello)    # TypeError (CRuby: MatchData)
/l/.match?(:hello)   # TypeError (CRuby: true)
/l/ === :hello       # false     (CRuby: true)
[:to_s, :abc].grep(/^to_/)  # [] -- Enumerable#grep goes through Regexp#===
```

`sym[/re/]` is a third gap: `mruby-symbol-ext` already delegates `Symbol#[]`
to `String#slice`, but this gem does not implement the regexp form of
`String#[]` / `#slice`, so `"hello"[/l+/]` does not work either. Both are
fixes on the String and Regexp side, so they are left alone here; the README
Limitations section and the comment in symbol_regexp.rb now spell them out.

`rake test` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added regular-expression matching methods to symbols: `match`, `match?`, and `=~`.
  * Supports matching against symbol text, including positions, offsets, blocks, and multibyte symbols.
* **Documentation**
  * Documented supported symbol regular-expression behavior and current limitations.
* **Tests**
  * Added comprehensive coverage for symbol matching, match state, edge cases, and invalid operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
