### PR TITLE
mruby-regexp: reject non-Regexp patterns in `String#match` and `#match?`

### DIFF
--- a/mrbgems/mruby-regexp/mrblib/string_regexp.rb
+++ b/mrbgems/mruby-regexp/mrblib/string_regexp.rb
@@ -4,14 +4,34 @@ class String
   # back to the core implementation.
   alias __split split
 
+  # `match` and `match?` accept a Regexp or a String and reject everything
+  # else, so resolve the pattern in one place.  Without the check the argument
+  # would be handed `self` and the failure would surface as a NoMethodError
+  # naming the argument as the receiver, which says nothing about the pattern.
+  # CRuby names `nil`, `true` and `false` by value and everything else by
+  # class.  Private, so the gem does not grow String's public API with a
+  # helper only `match` and `match?` call.
+  private def __match_pattern(re)
+    return re if re.is_a?(Regexp)
+    return Regexp.new(re) if re.is_a?(String)
+    name = if re.nil?
+             "nil"
+           elsif re.equal?(true)
+             "true"
+           elsif re.equal?(false)
+             "false"
+           else
+             re.class.to_s
+           end
+    raise TypeError, "wrong argument type #{name} (expected Regexp)"
+  end
+
   def match(re, pos = 0, &block)
-    re = Regexp.new(re) if re.is_a?(String)
-    re.match(self, pos, &block)
+    __match_pattern(re).match(self, pos, &block)
   end
 
   def match?(re, pos = 0)
-    re = Regexp.new(re) if re.is_a?(String)
-    re.match?(self, pos)
+    __match_pattern(re).match?(self, pos)
   end
 
   def =~(re)

--- a/mrbgems/mruby-regexp/mrblib/string_regexp.rb
+++ b/mrbgems/mruby-regexp/mrblib/string_regexp.rb
@@ -5,35 +5,15 @@ class String
   alias __split split
 
   # `match` and `match?` accept a Regexp or a String and reject everything
-  # else, so resolve the pattern in one place.  Without the check the argument
-  # would be handed `self` and the failure would surface as a NoMethodError
-  # naming the argument as the receiver, which says nothing about the pattern.
-  # CRuby names `nil`, `true` and `false` by value and everything else by
-  # class.  The test goes through `Module#===` instead of `is_a?`, so an
-  # argument overriding `is_a?` cannot pose as a Regexp and turn the TypeError
-  # into a NoMethodError.  Private, so the gem does not grow String's public
-  # API with a helper only `match` and `match?` call.
-  private def __match_pattern(re)
-    return re if Regexp === re
-    return Regexp.new(re) if String === re
-    name = if re.nil?
-             "nil"
-           elsif re.equal?(true)
-             "true"
-           elsif re.equal?(false)
-             "false"
-           else
-             re.class.to_s
-           end
-    raise TypeError, "wrong argument type #{name} (expected Regexp)"
-  end
-
+  # else.  The check lives in C (see Regexp.__match_pattern) so that the
+  # argument cannot steer it: it cannot pose as a Regexp, and there is no
+  # helper on String for a subclass to redefine.
   def match(re, pos = 0, &block)
-    __match_pattern(re).match(self, pos, &block)
+    Regexp.__match_pattern(re).match(self, pos, &block)
   end
 
   def match?(re, pos = 0)
-    __match_pattern(re).match?(self, pos)
+    Regexp.__match_pattern(re).match?(self, pos)
   end
 
   def =~(re)

--- a/mrbgems/mruby-regexp/mrblib/string_regexp.rb
+++ b/mrbgems/mruby-regexp/mrblib/string_regexp.rb
@@ -9,11 +9,13 @@ class String
   # would be handed `self` and the failure would surface as a NoMethodError
   # naming the argument as the receiver, which says nothing about the pattern.
   # CRuby names `nil`, `true` and `false` by value and everything else by
-  # class.  Private, so the gem does not grow String's public API with a
-  # helper only `match` and `match?` call.
+  # class.  The test goes through `Module#===` instead of `is_a?`, so an
+  # argument overriding `is_a?` cannot pose as a Regexp and turn the TypeError
+  # into a NoMethodError.  Private, so the gem does not grow String's public
+  # API with a helper only `match` and `match?` call.
   private def __match_pattern(re)
-    return re if re.is_a?(Regexp)
-    return Regexp.new(re) if re.is_a?(String)
+    return re if Regexp === re
+    return Regexp.new(re) if String === re
     name = if re.nil?
              "nil"
            elsif re.equal?(true)

--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -1089,6 +1089,32 @@ regexp_scan(mrb_state *mrb, mrb_value self)
   return ary;
 }
 
+/* Resolve the pattern given to String#match and #match?: a Regexp passes
+   through, a String is compiled via `Regexp.new`, everything else raises.
+   The test runs here rather than in Ruby so it never dispatches on the
+   argument, where a redefined `is_a?` or `class` could pose as a Regexp or
+   fake the type name. CRuby names `nil`, `true` and `false` by value and
+   everything else by class. */
+static mrb_value
+regexp_match_pattern(mrb_state *mrb, mrb_value self)
+{
+  mrb_value re;
+  mrb_get_args(mrb, "o", &re);
+
+  struct RClass *regexp_class = mrb_class_get_id(mrb, MRB_SYM(Regexp));
+  if (mrb_obj_is_kind_of(mrb, re, regexp_class)) return re;
+  if (mrb_string_p(re)) {
+    return mrb_funcall_argv1(mrb, mrb_obj_value(regexp_class), MRB_SYM(new), re);
+  }
+
+  const char *name;
+  if (mrb_nil_p(re)) name = "nil";
+  else if (mrb_true_p(re)) name = "true";
+  else if (mrb_false_p(re)) name = "false";
+  else name = mrb_obj_classname(mrb, re);
+  mrb_raisef(mrb, E_TYPE_ERROR, "wrong argument type %s (expected Regexp)", name);
+}
+
 /* --- Gem init --- */
 
 void
@@ -1108,6 +1134,7 @@ mrb_mruby_regexp_gem_init(mrb_state *mrb)
   mrb_define_class_method(mrb, re, "escape", regexp_escape, MRB_ARGS_REQ(1));
   mrb_define_class_method(mrb, re, "quote", regexp_escape, MRB_ARGS_REQ(1));
   mrb_define_class_method(mrb, re, "__binary_string?", regexp_binary_string_p, MRB_ARGS_REQ(1));
+  mrb_define_class_method(mrb, re, "__match_pattern", regexp_match_pattern, MRB_ARGS_REQ(1));
 
   /* Instance methods */
   mrb_define_method(mrb, re, "match", regexp_match, MRB_ARGS_ARG(1, 1)|MRB_ARGS_BLOCK());

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -571,6 +571,12 @@ class StringMatchIsALiar
   end
 end
 
+class StringMatchClassLiar
+  def class
+    Regexp
+  end
+end
+
 class StringMatchToStr
   def to_str
     "b"
@@ -581,6 +587,12 @@ class StringMatchRegexp < Regexp
 end
 
 class StringMatchString < String
+end
+
+class StringMatchHelperOverride < String
+  private def __match_pattern(re)
+    Regexp.new(re.to_s)
+  end
 end
 
 assert("String#match / #match? with a non-Regexp argument raise TypeError") do
@@ -620,6 +632,16 @@ assert("String#match / #match? with a non-Regexp argument raise TypeError") do
     "abc".match?(liar)
   end
 
+  # The type name in the message comes from the real class, so an argument
+  # redefining `class` cannot make the message name something else.
+  class_liar = StringMatchClassLiar.new
+  assert_raise_with_message(TypeError, "wrong argument type StringMatchClassLiar (expected Regexp)") do
+    "abc".match(class_liar)
+  end
+  assert_raise_with_message(TypeError, "wrong argument type StringMatchClassLiar (expected Regexp)") do
+    "abc".match?(class_liar)
+  end
+
   # CRuby converts an argument responding to `to_str` and matches with it.
   # mruby has no implicit String conversion in core, so the gem names such an
   # argument by class like any other, and this row stays an intentional
@@ -640,15 +662,22 @@ assert("String#match / #match? with a non-Regexp argument raise TypeError") do
     "abc".match?(nil, Object.new)
   end
 
-  # The helper doing the check stays out of String's public API.
-  assert_raise(NoMethodError) { "abc".__match_pattern("b") }
+  # The check lives on Regexp and no helper for it is defined on String, so a
+  # subclass defining a method by such a name cannot widen what `match` and
+  # `match?` accept.
+  assert_raise_with_message(TypeError, "wrong argument type Symbol (expected Regexp)") do
+    StringMatchHelperOverride.new("abc").match(:abc)
+  end
+  assert_raise_with_message(TypeError, "wrong argument type Symbol (expected Regexp)") do
+    StringMatchHelperOverride.new("abc").match?(:abc)
+  end
 
   # The accepted types still work.
   assert_equal "b", "abc".match(Regexp.new("b"))[0]
   assert_equal "b", "abc".match("b")[0]
   assert_true "abc".match?("b")
 
-  # The check goes through `Module#===`, so subclasses are accepted too.
+  # The check is by kind, so subclasses are accepted too.
   assert_equal "b", "abc".match(StringMatchRegexp.new("b"))[0]
   assert_true "abc".match?(StringMatchRegexp.new("b"))
   assert_equal "b", "abc".match(StringMatchString.new("b"))[0]

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -565,6 +565,46 @@ assert("String#=~ with a String argument raises TypeError") do
   assert_raise(TypeError) { "abc" !~ "b" }
 end
 
+assert("String#match / #match? with a non-Regexp argument raise TypeError") do
+  # nil, true and false are named by value, everything else by class.
+  assert_raise_with_message(TypeError, "wrong argument type nil (expected Regexp)") do
+    "abc".match(nil)
+  end
+  assert_raise_with_message(TypeError, "wrong argument type true (expected Regexp)") do
+    "abc".match(true)
+  end
+  assert_raise_with_message(TypeError, "wrong argument type false (expected Regexp)") do
+    "abc".match(false)
+  end
+  assert_raise_with_message(TypeError, "wrong argument type Symbol (expected Regexp)") do
+    "abc".match(:b)
+  end
+  assert_raise_with_message(TypeError, "wrong argument type Integer (expected Regexp)") do
+    "abc".match(1)
+  end
+  assert_raise_with_message(TypeError, "wrong argument type Array (expected Regexp)") do
+    "abc".match([])
+  end
+
+  assert_raise_with_message(TypeError, "wrong argument type nil (expected Regexp)") do
+    "abc".match?(nil)
+  end
+  assert_raise_with_message(TypeError, "wrong argument type Symbol (expected Regexp)") do
+    "abc".match?(:b)
+  end
+
+  # The pattern is rejected before pos is looked at.
+  assert_raise(TypeError) { "abc".match(nil, 99) }
+
+  # The helper doing the check stays out of String's public API.
+  assert_raise(NoMethodError) { "abc".__match_pattern("b") }
+
+  # The accepted types still work.
+  assert_equal "b", "abc".match(Regexp.new("b"))[0]
+  assert_equal "b", "abc".match("b")[0]
+  assert_true "abc".match?("b")
+end
+
 assert("String#sub") do
   assert_equal "hXllo", "hello".sub(Regexp.new("e"), "X")
 end

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -565,6 +565,12 @@ assert("String#=~ with a String argument raises TypeError") do
   assert_raise(TypeError) { "abc" !~ "b" }
 end
 
+class StringMatchIsALiar
+  def is_a?(klass)
+    true
+  end
+end
+
 assert("String#match / #match? with a non-Regexp argument raise TypeError") do
   # nil, true and false are named by value, everything else by class.
   assert_raise_with_message(TypeError, "wrong argument type nil (expected Regexp)") do
@@ -591,6 +597,15 @@ assert("String#match / #match? with a non-Regexp argument raise TypeError") do
   end
   assert_raise_with_message(TypeError, "wrong argument type Symbol (expected Regexp)") do
     "abc".match?(:b)
+  end
+
+  # An argument claiming to be a Regexp through `is_a?` is still rejected.
+  liar = StringMatchIsALiar.new
+  assert_raise_with_message(TypeError, "wrong argument type StringMatchIsALiar (expected Regexp)") do
+    "abc".match(liar)
+  end
+  assert_raise_with_message(TypeError, "wrong argument type StringMatchIsALiar (expected Regexp)") do
+    "abc".match?(liar)
   end
 
   # The pattern is rejected before pos is looked at.

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -609,7 +609,12 @@ assert("String#match / #match? with a non-Regexp argument raise TypeError") do
   end
 
   # The pattern is rejected before pos is looked at.
-  assert_raise(TypeError) { "abc".match(nil, 99) }
+  assert_raise_with_message(TypeError, "wrong argument type nil (expected Regexp)") do
+    "abc".match(nil, Object.new)
+  end
+  assert_raise_with_message(TypeError, "wrong argument type nil (expected Regexp)") do
+    "abc".match?(nil, Object.new)
+  end
 
   # The helper doing the check stays out of String's public API.
   assert_raise(NoMethodError) { "abc".__match_pattern("b") }

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -577,6 +577,12 @@ class StringMatchToStr
   end
 end
 
+class StringMatchRegexp < Regexp
+end
+
+class StringMatchString < String
+end
+
 assert("String#match / #match? with a non-Regexp argument raise TypeError") do
   # nil, true and false are named by value, everything else by class.
   assert_raise_with_message(TypeError, "wrong argument type nil (expected Regexp)") do
@@ -641,6 +647,12 @@ assert("String#match / #match? with a non-Regexp argument raise TypeError") do
   assert_equal "b", "abc".match(Regexp.new("b"))[0]
   assert_equal "b", "abc".match("b")[0]
   assert_true "abc".match?("b")
+
+  # The check goes through `Module#===`, so subclasses are accepted too.
+  assert_equal "b", "abc".match(StringMatchRegexp.new("b"))[0]
+  assert_true "abc".match?(StringMatchRegexp.new("b"))
+  assert_equal "b", "abc".match(StringMatchString.new("b"))[0]
+  assert_true "abc".match?(StringMatchString.new("b"))
 end
 
 assert("String#sub") do

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -571,6 +571,12 @@ class StringMatchIsALiar
   end
 end
 
+class StringMatchToStr
+  def to_str
+    "b"
+  end
+end
+
 assert("String#match / #match? with a non-Regexp argument raise TypeError") do
   # nil, true and false are named by value, everything else by class.
   assert_raise_with_message(TypeError, "wrong argument type nil (expected Regexp)") do
@@ -606,6 +612,18 @@ assert("String#match / #match? with a non-Regexp argument raise TypeError") do
   end
   assert_raise_with_message(TypeError, "wrong argument type StringMatchIsALiar (expected Regexp)") do
     "abc".match?(liar)
+  end
+
+  # CRuby converts an argument responding to `to_str` and matches with it.
+  # mruby has no implicit String conversion in core, so the gem names such an
+  # argument by class like any other, and this row stays an intentional
+  # difference rather than a gap to close.
+  to_str = StringMatchToStr.new
+  assert_raise_with_message(TypeError, "wrong argument type StringMatchToStr (expected Regexp)") do
+    "abc".match(to_str)
+  end
+  assert_raise_with_message(TypeError, "wrong argument type StringMatchToStr (expected Regexp)") do
+    "abc".match?(to_str)
   end
 
   # The pattern is rejected before pos is looked at.


### PR DESCRIPTION
`String#match` and `#match?` converted a `String` argument to a `Regexp`
and handed `self` straight to anything else, so a pattern of the wrong
type reached a method call it does not respond to.  The failure named the
argument as the receiver, which says nothing about the pattern being
wrong.

```ruby
"abc".match(:b)   # CRuby: TypeError, mruby: NoMethodError for :b
"abc".match(nil)  # CRuby: TypeError, mruby: NoMethodError for nil
```

Resolve the pattern in one helper so both methods reject the same set,
and follow CRuby in naming `nil`, `true` and `false` by value and
everything else by class.  The check runs before `pos` is inspected,
matching CRuby's order.

```ruby
"abc".match(:b)       # TypeError: wrong argument type Symbol (expected Regexp)
"abc".match(nil, 99)  # TypeError on the pattern, not an error about pos
```

The helper is `Regexp.__match_pattern`, written in C, so nothing about the
check dispatches back to the argument.  In Ruby it would, in two ways.
`is_a?` is a normal method call, so an argument that overrides it can pose
as a `Regexp`, reach `.match(self, pos)` and raise `NoMethodError` where
CRuby raises `TypeError`.  Reading the type name from `re.class` likewise
lets the argument choose the name the message reports.  The C helper reads
the kind and the class name off the object without dispatching.

```ruby
class Liar
  def is_a?(klass) = true
end

class ClassLiar
  def class = Regexp
end

"abc".match(Liar.new)
# CRuby:  TypeError (wrong argument type Liar (expected Regexp))
# is_a?:  NoMethodError (undefined method 'match' for an instance of Liar)

"abc".match(ClassLiar.new)
# CRuby:     TypeError (wrong argument type ClassLiar (expected Regexp))
# re.class:  TypeError (wrong argument type Regexp (expected Regexp))
```

Putting it on `Regexp` rather than `String` also keeps it out of reach of
the receiver: `String` carries no helper for a subclass to redefine, and
`String`'s public API does not grow a method only `match` and `match?`
call.

```ruby
class Sub < String
  private def __match_pattern(re) = Regexp.new(re.to_s)
end

Sub.new("abc").match(:abc)
# on String:  a MatchData, the subclass widened what `match` accepts
# on Regexp:  TypeError (wrong argument type Symbol (expected Regexp))
```

The kind test accepts a subclass of the tested class, and that acceptance
is the part a future rewrite of the check could silently drop, so the
tests exercise a `Regexp` and a `String` subclass directly.

CRuby also accepts an object that defines `to_str`, converting it through
`rb_check_string_type` before the type check.  mruby has no implicit
`String` conversion in core, so `"a" + obj` and `"abc".index(obj)`
already raise `TypeError` for such an object; honouring `to_str` in
`match` alone would make the gem more permissive than the core it sits
on.  Rejecting `to_str` objects therefore stays an intentional
difference from CRuby.

`String#=~` deliberately keeps its current behaviour.  CRuby's
`rb_str_match` special-cases `String` only and dispatches everything else
as `other =~ self`.

```ruby
"abc" =~ 1    # CRuby: NoMethodError, mruby: NoMethodError
"abc" =~ nil  # CRuby: nil,           mruby: NoMethodError
```

A blanket type check would turn both into `TypeError`, losing the case
mruby already matches and freezing the other in a state it can never grow
out of.  `Object#=~` was removed in Ruby 3.2, so `nil` is the only
receiver left to dispatch to, and the NoMethodError becomes CRuby's `nil`
the moment core gains `NilClass#=~`.  That is a core fix rather than one
for this gem.

This becomes more urgent once `Symbol#match` exists (#6993).
`Symbol#match` and `#match?` delegate to `to_s`, so without the check the
receiver and the argument swap places and the call quietly succeeds.

```ruby
"abc".match(:b)  # without the check: :b.to_s.match("abc") -> nil
                 # with the check:    TypeError
```

A Symbol receiver goes the same way, since `Symbol#match` delegates to
`String#match` and inherits whatever check it has.

```ruby
:abc.match(:b)   # without the check: nil
                 # with the check:    TypeError
:abc.match?(:b)  # likewise false without the check
:abc.match(nil)  # NoMethodError without the check, TypeError with it
```

Both receivers are handled by the one helper this PR adds, so #6993 needs
no code of its own for them; only its tests for these rows have to wait
until the check exists.

#6993 touches none of the files this PR changes, so the two merge in either
order without a conflict. The order still matters for behaviour, though.
Merging #6993 first defines `Symbol#match`, which gives `"abc".match(:b)` a
receiver to dispatch to: it resolves to `:b.to_s.match("abc")` and quietly
returns nil where it used to raise NoMethodError. Merging this one first
closes that window, and #6993 needs no change either way.

`rake test` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for `String#match` and `String#match?`.
  - String patterns continue to work, while unsupported pattern types now produce clear `TypeError` messages.
  - Pattern validation now occurs before position validation for more consistent behavior.
  - Fixed handling of values that incorrectly identify themselves as regular expressions.
  - Improved support for valid regular expression and string subclasses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



