### PR TITLE
ci: skip CIFuzz on forks

### DIFF
--- a/.github/workflows/oss-fuzz.yml
+++ b/.github/workflows/oss-fuzz.yml
@@ -6,6 +6,7 @@ permissions:
 
 jobs:
   Fuzzing:
+    if: ${{ github.repository == 'mruby/mruby' }}
     runs-on: ubuntu-latest
     steps:
       - name: Build Fuzzers


### PR DESCRIPTION
The `CIFuzz` workflow builds against the `mruby` OSS-Fuzz project, so it can only succeed on the upstream repository. On forks every pull request run fails with a build error that says nothing about the change under review, which adds noise for contributors who run CI on their own fork before opening a PR.

Guard the job with `github.repository == 'mruby/mruby'`, matching the existing condition already used in `release.yml`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restricted CIFuzz workflow execution to the official mruby repository.
  * Existing build, fuzzing, and crash-artifact upload behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->