### PR TITLE
doc: add a Claude Code rule for the C/Ruby boundary

### DIFF
--- a/.claude/rules/mruby-c-ruby-boundary.md
+++ b/.claude/rules/mruby-c-ruby-boundary.md
@@ -1,0 +1,134 @@
+---
+paths:
+  - "src/**/*.{c,h}"
+  - "include/**/*.h"
+  - "mrblib/**/*.rb"
+  - "mrbgems/*/src/*.{c,h}"
+  - "mrbgems/*/mrblib/*.rb"
+---
+
+# The C/Ruby boundary in mruby
+
+This rule states a convention that `CONTRIBUTING.md` leaves implicit. The Coding
+conventions there cover C99 conformance, keeping library dependencies minimal,
+the newline after a return type, and ISO/IEC 30170:2012 conformance for Ruby
+code. They say nothing about re-entering the VM.
+
+## Basic principle
+
+When a C function is designed as a type check, an argument check, a state
+check, a manipulation of an internal representation, or a low-level primitive,
+keep that work inside C as far as possible.
+
+Do not move object construction, method dispatch, policy decisions, or
+high-level control flow into C for convenience alone when Ruby can express them
+naturally.
+
+## Avoid re-entering the VM
+
+Do not re-enter the Ruby VM from a C helper whose purpose is argument
+validation, type determination, normalization, or inspection of internal state.
+
+In particular, do not perform any of the following inside a validation or
+normalization helper.
+
+- Ruby method dispatch through `mrb_funcall*`
+- Block invocation through `mrb_yield*`
+- Running user-definable initialization through `mrb_obj_new`,
+  `mrb_class_new_instance`, or an equivalent
+- Running Ruby code, bytecode, a `Proc`, or a `Fiber`
+- Conversion or object construction that calls a user-definable method
+
+For example, verify in C that an argument is a `String` or a `Regexp`, and
+perform the `String` to `Regexp` conversion in mrblib.
+
+The test is not whether the operation is a conversion, but whether it involves
+method dispatch.
+
+## Division of responsibility
+
+Take the following as the default split.
+
+### C side
+
+- Determining the actual type of an object
+- Access to internal representations
+- Low-level data manipulation
+- Conversions closed over internal representations, such as encoding
+  conversion, numeric representation conversion, or reading and writing struct
+  fields, that involve no method dispatch
+- Validation of arguments and state
+- Primitive operations that need no VM dispatch
+- Raising consistent exceptions
+
+### Ruby side
+
+- Calling Ruby methods
+- High-level construction of Ruby objects
+- Overridable behavior
+- Control flow that composes several primitives
+- Conversion or delegation that calls a user-definable method, such as
+  `Regexp.new`, `to_s`, or `to_a`
+
+## Exemptions
+
+This rule does not forbid calling into the Ruby VM from C outright.
+
+Entering the VM from C is acceptable when any of the following holds.
+
+- The very meaning of the API is Ruby method dispatch or block invocation
+- The same division of responsibility cannot be achieved on the Ruby side
+- The callback is intended as a public API or as an established design contract
+- Exception propagation, non-local control flow, re-entrancy, GC roots, and the
+  consistency of intermediate state have all been considered
+
+### Existing exempt cases
+
+None of the following violates this rule. Do not report them as violations.
+
+- `convert_type` in `src/object.c`, along with `mrb_convert_type`,
+  `mrb_check_convert_type`, and `mrb_check_string_type`. For implicit
+  conversion protocols such as `to_str`, the dispatch itself is the
+  specification.
+- `mrb_obj_new` in `src/class.c`, which calls `initialize`, and the hook
+  notifications `inherited`, `included`, `prepended`, `extended`,
+  `method_added`, and `method_missing`
+- The default proc invocation and the `Hash#default` delegation in `src/hash.c`
+- The `to_a` and `to_enum` delegations and the element comparisons in `==` and
+  `eql?` in `src/array.c`
+
+The earlier item about running initialization through `mrb_obj_new` forbids
+such calls from validation and normalization helpers. It does not cover the
+implementation of `mrb_obj_new` itself, nor APIs whose purpose is construction.
+
+When relying on an exemption, record why the call into the VM is necessary in a
+code comment or in the pull request description.
+
+## Review requirements
+
+When adding or changing code that enters the Ruby VM from C, check the
+following first.
+
+1. Is the call required by the meaning of the API, or is it merely an
+   implementation convenience?
+2. Can the call be moved to the mrblib side?
+3. Is the method being called immune to redefinition, inheritance, `prepend`,
+   and monkey patching?
+
+If the VM call is kept, continue with the following.
+
+4. Does intermediate state survive if Ruby code re-enters the same C API?
+5. Do Ruby exceptions and non-local control flow such as `break` propagate
+   correctly?
+6. Are the values that matter rooted against allocation during VM execution
+   (`mrb_gc_arena_save`, `mrb_gc_arena_restore`, `mrb_gc_protect`)? See
+   `mrb_gc_arena_restore(mrb, ai); /* for mrb_funcall */` in `src/array.c` for
+   a live example.
+7. Do argument validation, conversion, side effects, and the order in which
+   exceptions are raised preserve Ruby compatibility?
+8. Are there tests covering subclasses, method redefinition, exceptions,
+   re-entrancy, and block control flow?
+
+The mere presence of `mrb_funcall*` is not a problem in itself. Judge by the
+responsibility of the function in question and by whether the VM call is
+semantically necessary.

--- a/.claude/rules/mruby-c-ruby-boundary.md
+++ b/.claude/rules/mruby-c-ruby-boundary.md
@@ -4,7 +4,9 @@ paths:
   - "include/**/*.h"
   - "mrblib/**/*.rb"
   - "mrbgems/*/src/*.{c,h}"
+  - "mrbgems/*/include/**/*.h"
   - "mrbgems/*/mrblib/*.rb"
+  - "mrbgems/*/tools/*/*.c"
 ---
 
 # The C/Ruby boundary in mruby


### PR DESCRIPTION
This adds one Markdown file under `.claude/`, describing where the boundary
between C and Ruby lies in this tree. It documents an existing convention for
coding agents. It does not propose a new one, and it does not change any rule
that applies to human contributors.

`CONTRIBUTING.md` documents the coding conventions that a patch has to satisfy:
C99 conformance, keeping library dependencies minimal, the newline after a
return type, and ISO/IEC 30170:2012 conformance for Ruby code. It says nothing
about where the boundary between C and Ruby lies, in particular about when a C
function may call back into the VM. That convention exists, but it is currently
learned only through review.

### Background

In #6994 I added `Regexp.__match_pattern` in C so that `String#match` could
reject an argument that merely pretends to be a `Regexp`. The check ran in C,
but the accepted `String` was then compiled with
`mrb_funcall_argv1(Regexp, new, str)` in the same function.

In fd5e07545 matz split it: the type check stays in C, and the `Regexp.new`
construction moves to mrblib, because `Module#===` cannot be redefined either,
so the caller can compile the pattern without weakening the check.

The reasoning generalizes well beyond that one function, and I had no way to
find it stated anywhere in the tree. This patch writes it down.

### What this adds

A single documentation file, `.claude/rules/mruby-c-ruby-boundary.md`, stating:

- Keep type checks, argument validation, internal representation access, and
  low-level primitives inside C.
- Do not re-enter the VM from a helper whose purpose is validation or
  normalization. The test is not whether the operation is a conversion, but
  whether it involves method dispatch.
- The default split of responsibility between the C side and the Ruby side.
- The cases where entering the VM from C is legitimate, together with the
  existing code that relies on them, so that they are not mistaken for
  violations. This covers `convert_type` and the `to_str` protocol in
  `src/object.c`, `mrb_obj_new` and the `inherited` / `included` /
  `method_missing` hooks in `src/class.c`, the default proc in `src/hash.c`,
  and the `to_a` / `to_enum` delegations in `src/array.c`.
- A review checklist for changes that do enter the VM from C, covering
  re-entrancy, exception propagation, non-local exits, GC rooting, and
  evaluation order.

Every exemption listed is existing mruby code that stays exactly as it is.

### Note on the location

This introduces a `.claude/` directory, which the repository does not have
today. The path is what Claude Code loads automatically for files matching the
`paths:` list in the front matter, so an agent editing `src/*.c` or
`mrbgems/*/src/*.c` picks the convention up without being told.

If you would rather not carry a tool-specific directory, I am happy to move the
content into `CONTRIBUTING.md` or `doc/`, or to drop the front matter entirely.
The text itself is plain Markdown and does not depend on the location. Please
say which you prefer.

### Impact

Documentation only. Nothing here runs in CI, and no workflow, source, build, or
test file is touched. The file is formatted with `prettier@3.7.4`, matching the
manual `prettier` hook in `.pre-commit-config.yaml`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added development guidance clarifying responsibilities between C and Ruby code.
  * Documented validation, conversion, dispatch, exception handling, garbage collection, compatibility, and testing considerations.
  * Added review questions to support consistent implementation decisions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->