### PR TITLE
Add `NilClass#=~`

### DIFF
--- a/mrbgems/mruby-regexp/mrblib/symbol_regexp.rb
+++ b/mrbgems/mruby-regexp/mrblib/symbol_regexp.rb
@@ -8,10 +8,10 @@
 # from here.  `sym[/re/]` is the direction still missing; it waits on the
 # regexp form of `String#slice`.
 #
-# Two differences from CRuby are inherited from `String#=~` rather than
-# introduced here: a String argument raises TypeError (CRuby does too), but so
-# does any other object that has no `=~` -- `:a =~ nil` raises NoMethodError
-# where CRuby returns nil.
+# The argument handling of `=~` is inherited from `String#=~` rather than
+# introduced here, and agrees with CRuby: a String argument raises TypeError,
+# and any other object is asked for its own `=~`, which `nil` answers and an
+# object without one rejects with NoMethodError.
 class Symbol
   def match(re, pos = 0, &block)
     self.to_s.match(re, pos, &block)

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -640,6 +640,15 @@ assert("String#=~ with a String argument raises TypeError") do
   assert_raise(TypeError) { "abc" !~ "b" }
 end
 
+assert("String#=~ dispatches to the argument") do
+  # A non-Regexp, non-String argument is answered by its own `=~`, so `nil`
+  # gets a value from `NilClass#=~` and everything else without one raises.
+  assert_nil "abc" =~ nil
+  assert_true "abc" !~ nil
+  assert_raise(NoMethodError) { "abc" =~ 1 }
+  assert_raise(NoMethodError) { "abc" =~ Object.new }
+end
+
 class StringMatchIsALiar
   def is_a?(klass)
     true

--- a/mrbgems/mruby-regexp/test/symbol_regexp.rb
+++ b/mrbgems/mruby-regexp/test/symbol_regexp.rb
@@ -65,8 +65,10 @@ assert("Symbol#=~") do
   assert_equal 2, :hello =~ Regexp.new("l")
   assert_nil :hello =~ Regexp.new("z")
 
-  # inherited from String#=~: a String argument is a type mismatch
+  # inherited from String#=~: a String argument is a type mismatch, and any
+  # other argument is answered by its own `=~`
   assert_raise(TypeError) { :hello =~ "l" }
+  assert_nil :hello =~ nil
 end
 
 assert("Symbol#=~ sets the match globals") do

--- a/src/object.c
+++ b/src/object.c
@@ -148,6 +148,23 @@ nil_inspect(mrb_state *mrb, mrb_value obj)
   return str;
 }
 
+/*
+ *  call-seq:
+ *     nil =~ other  -> nil
+ *
+ *  Always returns `nil`, as CRuby does.  It belongs here rather than in an
+ *  mrbgem because `Kernel#!~` is `!(self =~ other)` and is always present:
+ *  without this method `nil !~ other` raises even in a build carrying no gem
+ *  at all.  It is also what answers `str =~ nil` instead of raising, for a
+ *  `String#=~` that dispatches a non-String argument as `other =~ self`.
+ */
+
+static mrb_value
+nil_match(mrb_state *mrb, mrb_value obj)
+{
+  return mrb_nil_value();
+}
+
 /***********************************************************************
  *  Document-class: TrueClass
  *
@@ -328,6 +345,7 @@ static const mrb_mt_entry nil_rom_entries[] = {
   MRB_MT_ENTRY(mrb_true,    MRB_SYM_Q(nil), MRB_ARGS_NONE()),  /* 15.2.4.3.4  */
   MRB_MT_ENTRY(nil_to_s,    MRB_SYM(to_s),  MRB_ARGS_NONE()),  /* 15.2.4.3.5  */
   MRB_MT_ENTRY(nil_inspect, MRB_SYM(inspect), MRB_ARGS_NONE()),
+  MRB_MT_ENTRY(nil_match,   MRB_OPSYM(match), MRB_ARGS_REQ(1)),
 };
 
 static const mrb_mt_entry true_rom_entries[] = {

--- a/test/t/nil.rb
+++ b/test/t/nil.rb
@@ -33,6 +33,16 @@ assert('NilClass#to_s', '15.2.4.3.5') do
   assert_equal '', nil.to_s
 end
 
+assert('NilClass#=~') do
+  assert_nil nil =~ "a"
+  assert_nil nil =~ nil
+  assert_nil nil =~ Object.new
+  assert_true nil.respond_to?(:=~)
+  # `Kernel#!~` is `!(self =~ other)`, so it answers now that `=~` does.
+  assert_true nil !~ "a"
+  assert_raise(ArgumentError) { nil.=~() }
+end
+
 assert('safe navigation') do
   assert_nil nil&.size
   assert_equal 0, []&.size


### PR DESCRIPTION
`String#=~` dispatches an argument that is neither a Regexp nor a String as
`other =~ self`, which is what CRuby's `rb_str_match` does too. CRuby has a defined
answer for `nil` because `NilClass#=~` exists and returns `nil`; mruby had no `=~` on
`NilClass`, so the dispatch raised `NoMethodError`. `Kernel#!~` (`mrblib/kernel.rb:38`)
is `!(self =~ y)`, so it inherited the same hole: `!~` is listed among `nil`'s methods,
and calling it raised.

```ruby
"abc" =~ nil   # CRuby: nil,  mruby before: NoMethodError
nil !~ /a/     # CRuby: true, mruby before: NoMethodError
:a =~ nil      # CRuby: nil,  mruby before: NoMethodError (via Symbol#=~ -> String#=~)
```

`nil` is the only gap. `Object#=~` was removed in Ruby 3.2, so every other receiver
without its own `=~` raises `NoMethodError` in CRuby as well, and mruby already agrees.

```ruby
"abc" =~ 1                  # CRuby: NoMethodError, mruby: NoMethodError
"abc" =~ Object.new         # CRuby: NoMethodError, mruby: NoMethodError
Object.new.respond_to?(:=~) # CRuby: false
nil.respond_to?(:=~)        # CRuby: true
```

## Why the core and not an mrbgem

`=~` is not an ISO method of `NilClass` (ISO 15.2.4.3 lists `&`, `|`, `^`, `nil?` and
`to_s`), so `CONTRIBUTING.md` asks for a reason to add it to the core. `mruby-object-ext`
would otherwise be the natural home: it already extends `NilClass` with `to_a`, `to_h`,
`to_i` and `to_f` in a ROM table of its own.

The reason is `Kernel#!~`. It lives in core mrblib and is therefore present in every
build, including one that carries no gem at all, so `nil !~ x` is a hole no gem can
close. CRuby also answers `nil.respond_to?(:=~)` with true without loading anything;
making that depend on which gembox a build picks would be a worse surprise than the
space the method takes. That space is 48 bytes of `object.o` on x86_64: the method goes
into the existing `NilClass` ROM table, so it adds one entry and one function, and no
irep.

Declaring the entry `MRB_ARGS_REQ(1)` gives the arity check without a `mrb_get_args()`
call, the same way `false_and()` does.

## What is in the PR

- `src/object.c`: `nil_match()` and its ROM table entry.
- `test/t/nil.rb`: the core cases, which need no Regexp: any argument answers `nil`,
  `nil.respond_to?(:=~)`, the `!~` path, and the arity check.
- `mrbgems/mruby-regexp/test/`: the cases that do need Regexp, in the gem that owns the
  dispatch: `"abc" =~ nil`, `"abc" !~ nil`, `:hello =~ nil`, and the `NoMethodError`
  rows above, which pin that this change does not turn `=~` into a blanket type check.
- The header comment of `mrbgems/mruby-regexp/mrblib/symbol_regexp.rb` named this gap as
  behaviour inherited from `String#=~`. With `NilClass#=~` in place the argument handling
  of `Symbol#=~` agrees with CRuby on every argument type, so the comment is rewritten.

`=~` deliberately keeps dispatching rather than type-checking its argument, unlike
`match` and `match?` (#6988): a blanket `TypeError` would break the `nil` and the
`NoMethodError` rows above, both of which CRuby answers the way mruby now does.

Compared against CRuby 4.0.6. `rake test` passes, and `prek run --all-files` is clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for matching operations on `nil`, returning `nil` for all operands.
  * Added support for `nil !~` expressions.

* **Bug Fixes**
  * Improved matching behavior for strings and symbols with non-regular-expression operands.
  * Unsupported operands now raise the appropriate errors, while `nil` operands return expected results.

* **Tests**
  * Expanded coverage for matching, negated matching, operand delegation, and invalid arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->