### PR TITLE
mruby-regexp: fix `MatchData#[]` for a negative index and an unknown name

### DIFF
--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -601,7 +601,10 @@ matchdata_aref(mrb_state *mrb, mrb_value self)
         }
       }
     }
-    return mrb_nil_value();
+    /* A name that resolves to no group is a mistake at the point of the call,
+       not a failed match. CRuby raises here even when the pattern has no
+       named group at all. */
+    mrb_raisef(mrb, E_INDEX_ERROR, "undefined group name reference: %l", name, (size_t)name_len);
   }
   else {
     idx = mrb_as_int(mrb, arg);

--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -605,10 +605,18 @@ matchdata_aref(mrb_state *mrb, mrb_value self)
   }
   else {
     idx = mrb_as_int(mrb, arg);
+    if (idx < 0) {
+      /* A negative index counts back from the last group. CRuby's
+         rb_reg_nth_match() drops the result unless it is positive, so the
+         lowest group a negative index reaches is 1, never the whole match:
+         /(a)(b)/.match("ab")[-3] is nil, not "ab". */
+      idx += md->num_captures;
+      if (idx <= 0) return mrb_nil_value();
+    }
   }
 
 found:
-  if (idx < 0 || idx >= md->num_captures) return mrb_nil_value();
+  if (idx >= md->num_captures) return mrb_nil_value();
   int start = md->captures[idx * 2];
   int end = md->captures[idx * 2 + 1];
   if (start < 0) return mrb_nil_value();

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -1058,6 +1058,15 @@ assert("MatchData#[] - negative index") do
   assert_nil md[5]
 end
 
+assert("MatchData#[] - undefined group name") do
+  md = /(?<x>a)/.match("a")
+  assert_equal "a", md[:x]
+  assert_raise(IndexError) { md[:zz] }
+  assert_raise(IndexError) { md["zz"] }
+  # a pattern without any named group raises just the same
+  assert_raise(IndexError) { /(a)/.match("a")[:zz] }
+end
+
 assert("Regexp - named backreference \\k") do
   assert_equal "aa", "aa".match(/(?<n>\w)\k<n>/)[0]
   assert_equal "abba", "abba".match(/(?<a>.)(?<b>.)\k<b>\k<a>/)[0]

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -1045,6 +1045,19 @@ assert("Regexp - named captures") do
   assert_equal "2026", md["year"]
 end
 
+assert("MatchData#[] - negative index") do
+  md = /(a)(b)/.match("ab")
+  assert_equal "b", md[-1]
+  assert_equal "a", md[-2]
+  # -num_captures and below are nil: a negative index never reaches group 0
+  assert_nil md[-3]
+  assert_nil md[-4]
+  # a group that did not participate is nil either way
+  assert_nil(/(a)|(b)/.match("a")[-1])
+  # out of range upwards stays nil
+  assert_nil md[5]
+end
+
 assert("Regexp - named backreference \\k") do
   assert_equal "aa", "aa".match(/(?<n>\w)\k<n>/)[0]
   assert_equal "abba", "abba".match(/(?<a>.)(?<b>.)\k<b>\k<a>/)[0]


### PR DESCRIPTION
`MatchData#[]` resolves its argument in two branches, and both answer `nil` for
an argument CRuby handles differently: a negative index is rejected outright,
and a name that resolves to no group is treated as a failed match.

```ruby
md = /(a)(b)/.match("ab")
md[-1]                       # CRuby: "b", mruby: nil
md[-2]                       # CRuby: "a", mruby: nil

/(?<x>a)/.match("a")[:zz]    # CRuby: IndexError, mruby: nil
/(?<x>a)/.match("a")["zz"]   # CRuby: IndexError, mruby: nil
```

Out-of-range positive indices already answer `nil` correctly and are unchanged.

## A negative index

`matchdata_aref()` tested `idx < 0` at the point where it reads the capture
table and gave up there, so counting back from the last group never worked.
Adding the group count in the numeric branch is the whole fix; the name branch
reaches the same label with a group number that is already non-negative, so
only the upper bound has to stay.

The lower bound follows CRuby's `rb_reg_nth_match()`, which discards the
adjusted index unless it is *positive* rather than merely non-negative:

```c
    else {
        nth += RMATCH_REGS(match)->num_regs;
        if (nth <= 0) return Qnil;
    }
```

Two consequences are worth stating, because both look like bugs until you read
that:

```ruby
md[-3]   # nil, not "ab": a negative index never reaches group 0
md[-4]   # nil, not IndexError: out of range downwards is nil like upwards
```

Both are pinned in the tests.

## An unknown group name

A `String` or `Symbol` that names no capture group answered `nil`, which is
indistinguishable from a group that matched nothing, so a typo in a named
capture surfaced somewhere far from the mistake. CRuby raises `IndexError`, and
it does so even when the pattern declares no named group at all:

```ruby
/(a)/.match("a")[:zz]   # CRuby: IndexError (undefined group name reference: zz)
```

The message is formatted with `%l` rather than `%v`. `%v` runs the value
through `mrb_obj_as_string()`, which dispatches `to_s`, so a redefined
`Symbol#to_s` could choose the text of an argument check. `%l` copies the bytes
directly, which also keeps `matchdata_aref()` free of any call back into the
VM.

## Deliberately not in this change

- The `md[start, length]` and `md[range]` forms, which CRuby also accepts.
  `[]` is defined here with `MRB_ARGS_REQ(1)`, and adding the extra forms is a
  larger piece of work.
- The `TypeError` message for an argument that is neither an index nor a name.
  `md[nil]` says `nil cannot be converted to Integer` where CRuby says
  `no implicit conversion from nil to integer`; that phrasing comes from
  `mrb_as_int()` and is mruby-wide, so it is not this gem's to change.
- `MatchData#begin` and `#end`, which take their argument as `"i"` and so
  reject a group name outright, and answer `nil` where CRuby raises. They are
  the same class of bug in the neighbouring methods, but their rules differ
  (they raise for every index they cannot use, including a negative one), so
  they are better handled on their own.

One more heads-up for whoever reviews this: the name lookup a few lines above
compares lengths after truncating the requested length to `uint16_t` while the
`memcmp()` next to it uses the untruncated length, which reads out of bounds
for a name longer than 65535 bytes. That is a memory-safety bug rather than a
compatibility one, it is reachable from plain Ruby, and it is not touched here.
I will send it as a separate one-line change so it can be reviewed and
backported on its own.

## Testing

Two `assert` blocks in `mrbgems/mruby-regexp/test/regexp.rb`, one per branch,
covering the CRuby rules above including the two counter-intuitive ones. Every
row in this description was checked against CRuby 4.0.6 rather than assumed.

`rake test` is green on a default host build:

| build | total | OK | KO |
| ----- | ----- | -- | -- |
| default (ASCII-8BIT) | 1933 | 1915 | 0 |

`bintest` is 105 OK, 0 KO. No existing test changed.

The two commits are independent and each passes the suite on its own, so
either can be dropped if only one of the two behaviours is wanted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `MatchData#[]` behavior for negative capture indices.
  * Prevented out-of-range negative indices from incorrectly selecting the full match.
  * Undefined named capture references now raise `IndexError` instead of returning `nil`.

* **Tests**
  * Added coverage for negative indices and missing named captures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->