### PR TITLE
mruby-regexp: type-check the `sub`, `gsub`, `scan`, `split` and `=~` pattern

### DIFF
--- a/mrbgems/mruby-regexp/mrblib/string_regexp.rb
+++ b/mrbgems/mruby-regexp/mrblib/string_regexp.rb
@@ -42,7 +42,13 @@ class String
       raise ArgumentError, "wrong number of arguments (given #{args.length}, expected 2)"
     end
     pattern, replacement = *args
-    pattern = Regexp.new(Regexp.escape(pattern)) if pattern.is_a?(String)
+    pattern = Regexp.__match_pattern(pattern)
+    # Unlike `match`, a String pattern is quoted rather than compiled: it is a
+    # literal here, the distinction CRuby draws between get_pat_quoted and
+    # get_pat.  Only the quoting is taken from it: get_pat_quoted also accepts
+    # anything answering `to_str`, where `__match_pattern` keeps to a real
+    # String, as `match` already does.
+    pattern = Regexp.new(Regexp.escape(pattern)) if String === pattern
     # A replacement argument wins over the block, as in CRuby.
     if args.length == 2
       return pattern.__sub_str(self, replacement.to_s)
@@ -61,7 +67,10 @@ class String
     # not depend on Enumerator.
     return to_enum(:gsub, *args) if args.length == 1 && !block
     pattern, replacement = *args
-    pattern = Regexp.new(Regexp.escape(pattern)) if pattern.is_a?(String)
+    # After the to_enum return above, so that `"abc".gsub(:b)` yields an
+    # Enumerator and raises on the first iteration, as CRuby does.
+    pattern = Regexp.__match_pattern(pattern)
+    pattern = Regexp.new(Regexp.escape(pattern)) if String === pattern
     # A replacement argument wins over the block, as in CRuby.
     if args.length == 2
       return pattern.__gsub_str(self, replacement.to_s)
@@ -103,7 +112,8 @@ class String
   end
 
   def scan(pattern)
-    pattern = Regexp.new(Regexp.escape(pattern)) if pattern.is_a?(String)
+    pattern = Regexp.__match_pattern(pattern)
+    pattern = Regexp.new(Regexp.escape(pattern)) if String === pattern
     result = pattern.__scan(self)
     if block_given?
       result.each { |m| yield m }
@@ -140,9 +150,9 @@ class String
       return limit_given ? __split(pattern, limit) : __split(pattern)
     end
     return self.empty? ? [] : [self] if limit == 1
-    unless pattern.is_a?(Regexp)
-      raise TypeError, "wrong argument type #{pattern.class} (expected Regexp)"
-    end
+    # nil and String patterns already went to __split above, so the String
+    # branch of the resolver is unreachable here and nothing needs quoting.
+    pattern = Regexp.__match_pattern(pattern)
 
     result = []
     field_start = 0

--- a/mrbgems/mruby-regexp/mrblib/string_regexp.rb
+++ b/mrbgems/mruby-regexp/mrblib/string_regexp.rb
@@ -24,8 +24,10 @@ class String
 
   def =~(re)
     # A String argument would dispatch back to this method and recurse, so
-    # reject it up front (CRuby raises the same TypeError).
-    raise TypeError, "type mismatch: String given" if re.is_a?(String)
+    # reject it up front (CRuby raises the same TypeError).  `is_a?` is
+    # redefinable, so a String subclass denying its own type would slip past
+    # the guard and recurse anyway; `Module#===` reads the real type.
+    raise TypeError, "type mismatch: String given" if String === re
     re =~ self
   end
 
@@ -131,7 +133,10 @@ class String
         limit = limit.__to_int
       end
     end
-    if pattern.nil? || pattern.is_a?(String)
+    # `nil?` and `is_a?` are redefinable, so an argument answering either one
+    # could steer itself around the check below and reach `__split` instead.
+    # `Module#===` reads the real type and cannot be redefined.
+    if NilClass === pattern || String === pattern
       return limit_given ? __split(pattern, limit) : __split(pattern)
     end
     return self.empty? ? [] : [self] if limit == 1

--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -1099,13 +1099,14 @@ regexp_scan(mrb_state *mrb, mrb_value self)
   return ary;
 }
 
-/* Check the pattern given to String#match and #match?: a Regexp or a String
-   passes through, everything else raises. The test runs here rather than in
-   Ruby so it never dispatches on the argument, where a redefined `is_a?` or
-   `class` could pose as a Regexp or fake the type name. Compiling a String
-   pattern is left to the caller, so this needs no callback into the VM.
-   CRuby names `nil`, `true` and `false` by value and everything else by
-   class. */
+/* Check the pattern given to String#match, #match?, #sub, #gsub, #scan and
+   #split: a Regexp or a String passes through, everything else raises. The
+   test runs here rather than in Ruby so it never dispatches on the argument,
+   where a redefined `is_a?` or `class` could pose as a Regexp or fake the type
+   name. What to do with an accepted String is left to the caller, which
+   compiles it for `match` and quotes it first for `sub` and friends, so this
+   needs no callback into the VM. CRuby names `nil`, `true` and `false` by
+   value and everything else by class. */
 static mrb_value
 regexp_match_pattern(mrb_state *mrb, mrb_value self)
 {

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -830,6 +830,50 @@ assert("String#gsub without a block returns an enumerator") do
   assert_equal "aBcB", "abcb".gsub(/b/).each { |m| m.upcase }
 end
 
+assert("String#sub / #gsub / #scan / #split with a non-Regexp pattern raise TypeError") do
+  # The same check `match` uses, so the naming matches: nil, true and false by
+  # value, everything else by class.
+  [
+    ["nil", nil], ["true", true], ["false", false],
+    ["Symbol", :b], ["Integer", 1], ["Array", []],
+  ].each do |name, pat|
+    message = "wrong argument type #{name} (expected Regexp)"
+    assert_raise_with_message(TypeError, message) { "abc".sub(pat, "X") }
+    assert_raise_with_message(TypeError, message) { "abc".gsub(pat, "X") }
+    assert_raise_with_message(TypeError, message) { "abc".sub(pat) { "X" } }
+    assert_raise_with_message(TypeError, message) { "abc".gsub(pat) { "X" } }
+    assert_raise_with_message(TypeError, message) { "abc".scan(pat) }
+    # split delegates nil to the core implementation instead of raising.
+    assert_raise_with_message(TypeError, message) { "abc".split(pat) } unless pat.nil?
+  end
+
+  # An argument claiming to be a Regexp through `is_a?` or `class` is still
+  # rejected, and still named by its real class.  `split` routes nil and String
+  # patterns to the core implementation, so it has to reach the same check
+  # without asking the argument what it is.
+  liar = StringMatchIsALiar.new
+  assert_raise_with_message(TypeError, "wrong argument type StringMatchIsALiar (expected Regexp)") do
+    "abc".sub(liar, "X")
+  end
+  assert_raise_with_message(TypeError, "wrong argument type StringMatchIsALiar (expected Regexp)") do
+    "abc".split(liar)
+  end
+  class_liar = StringMatchClassLiar.new
+  assert_raise_with_message(TypeError, "wrong argument type StringMatchClassLiar (expected Regexp)") do
+    "abc".gsub(class_liar, "X")
+  end
+  assert_raise_with_message(TypeError, "wrong argument type StringMatchClassLiar (expected Regexp)") do
+    "abc".split(class_liar)
+  end
+
+  # A Symbol answers `match`, which the block form of `sub` used to reach: it
+  # matched with the operands reversed and returned a string built from the
+  # symbol's name instead of raising.
+  assert_raise_with_message(TypeError, "wrong argument type Symbol (expected Regexp)") do
+    "ab".sub(:xaby) { "Z" }
+  end
+end
+
 assert("String#sub / #gsub / #scan / #split accept a Regexp subclass, and quote a String") do
   assert_equal "aXc", "abc".sub(StringMatchRegexp.new("b"), "X")
   assert_equal "aXcX", "abcb".gsub(StringMatchRegexp.new("b"), "X")
@@ -860,6 +904,21 @@ assert("String#=~ reads the real type of a String argument") do
   assert_raise_with_message(TypeError, "type mismatch: String given") do
     denier =~ denier
   end
+end
+
+assert("String#gsub / #split examine the pattern only where CRuby does") do
+  # gsub without a block builds the enumerator first, so the TypeError is
+  # raised on the first iteration rather than at the call.
+  if Object.const_defined?(:Enumerator)
+    enum = "abc".gsub(:b)
+    assert_raise_with_message(TypeError, "wrong argument type Symbol (expected Regexp)") do
+      enum.to_a
+    end
+  end
+
+  # split returns before looking at the pattern when the limit is 1.
+  assert_equal ["abc"], "abc".split(true, 1)
+  assert_equal [], "".split(:b, 1)
 end
 
 assert("String#sub with \\& \\` \\' specials") do

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -673,6 +673,16 @@ end
 class StringMatchString < String
 end
 
+class StringMatchStringDenier < String
+  def is_a?(klass)
+    false
+  end
+
+  def nil?
+    true
+  end
+end
+
 class StringMatchHelperOverride < String
   private def __match_pattern(re)
     Regexp.new(re.to_s)
@@ -818,6 +828,38 @@ assert("String#gsub without a block returns an enumerator") do
   assert_equal ["b", "b"], "abcb".gsub("b").to_a
   # Iterating the enumerator with a block performs the substitution.
   assert_equal "aBcB", "abcb".gsub(/b/).each { |m| m.upcase }
+end
+
+assert("String#sub / #gsub / #scan / #split accept a Regexp subclass, and quote a String") do
+  assert_equal "aXc", "abc".sub(StringMatchRegexp.new("b"), "X")
+  assert_equal "aXcX", "abcb".gsub(StringMatchRegexp.new("b"), "X")
+  assert_equal ["b", "b"], "abcb".scan(StringMatchRegexp.new("b"))
+  assert_equal ["a", "c"], "abc".split(StringMatchRegexp.new("b"))
+
+  # A String pattern is a literal here, not a pattern: `.` matches only `.`.
+  assert_equal "aXc", "a.c".sub(".", "X")
+  assert_equal "aXc", "a.c".gsub(".", "X")
+  assert_equal ["."], "a.c".scan(".")
+  assert_equal "a[.]c", "a.c".gsub(".") { |m| "[#{m}]" }
+  # A String subclass is accepted on the same terms.
+  assert_equal "aXc", "a.c".sub(StringMatchString.new("."), "X")
+  # Even one denying that it is a String, or claiming to be nil: `split` reads
+  # the real type before choosing between the core implementation and the
+  # regexp path.
+  assert_equal ["a", "c"], "a.c".split(StringMatchStringDenier.new("."))
+end
+
+assert("String#=~ reads the real type of a String argument") do
+  # `=~` dispatches everything but a String to the argument, so a String
+  # subclass denying its own type used to pass the guard and dispatch back
+  # here, recursing until the stack ran out instead of raising.
+  denier = StringMatchStringDenier.new("b")
+  assert_raise_with_message(TypeError, "type mismatch: String given") do
+    "abc" =~ denier
+  end
+  assert_raise_with_message(TypeError, "type mismatch: String given") do
+    denier =~ denier
+  end
 end
 
 assert("String#sub with \\& \\` \\' specials") do


### PR DESCRIPTION
`String#sub`, `#gsub` and `#scan` compiled a String pattern and passed
everything else through untouched, so a pattern that is neither a Regexp nor a
String reached an internal helper and failed there with a `NoMethodError`
naming it. `#split` did check its pattern, but built the message from the
class in every case, so `true` and `false` were named `TrueClass` and
`FalseClass`.

The block form of `#sub` was worse than a wrong message: it reached the
pattern through `match`, and a Symbol answers that call with the operands
reversed, so the symbol became the subject and the receiver the pattern.

```ruby
"ab".sub(:xaby) { "Z" }
# CRuby: TypeError (wrong argument type Symbol (expected Regexp))
# mruby: "xZy"
```

The type checks that did exist read the argument through `is_a?` and `nil?`,
both redefinable. `String#=~` rejects a String up front because dispatching
one to the argument would come straight back to this method and recurse, and a
String subclass denying that it is a String slipped past the guard into that
very recursion.

```ruby
class Denier < String
  def is_a?(klass)
    false
  end
end

d = Denier.new("b")
d =~ d   # CRuby: TypeError (type mismatch: String given)
         # mruby: SystemStackError (stack level too deep)
```

`String#split` has the mirror image of the problem: it sends `nil` and String
patterns to the core implementation before its own check is reached, so an
object answering `nil?` or `is_a?` could route itself to `__split` and never
reach the check at all.

## Changes

- `String#=~` and `#split` read the real type through `Module#===`, which
  cannot be redefined.
- `#sub`, `#gsub`, `#scan` and `#split` go through `Regexp.__match_pattern`,
  the check `match` and `match?` already use, which names `nil`, `true` and
  `false` by value and everything else by class.

The check stays in C so the argument cannot pose as a Regexp through a
redefined `is_a?` or `class`, and what to do with an accepted String stays in
Ruby, as fd5e07545 established: `match` compiles it, `sub`, `gsub` and `scan`
quote it first, and `split` needs no such line, having already sent `nil` and
String patterns to the core implementation before the check is reached.

Two orderings that already match CRuby are kept and pinned by a test:
`"abc".gsub(:b)` returns an Enumerator and raises on the first iteration, and
`"abc".split(true, 1)` returns `["abc"]` without examining the pattern. The
accept path is pinned as well, covering a Regexp subclass and a quoted String
pattern, so that the check can be reworked without the accepted cases moving
with it.

`rake test` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pattern validation across String regular-expression methods.
  * Invalid pattern types now consistently raise the appropriate errors.
  * String subclasses and objects mimicking type checks are handled correctly.
  * String patterns are treated literally where expected, preventing unintended regular-expression interpretation.
  * Improved behavior for `gsub` enumerators and `split` edge cases.
* **Tests**
  * Added regression coverage for validation, subclass handling, literal patterns, and edge-case behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->