### PR TITLE
mruby-regexp: rename `__match_pattern` to `__check_pattern`

### DIFF
--- a/mrbgems/mruby-regexp/mrblib/string_regexp.rb
+++ b/mrbgems/mruby-regexp/mrblib/string_regexp.rb
@@ -5,19 +5,19 @@ class String
   alias __split split
 
   # `match` and `match?` accept a Regexp or a String and reject everything
-  # else.  The check lives in C (see Regexp.__match_pattern) so that the
+  # else.  The check lives in C (see Regexp.__check_pattern) so that the
   # argument cannot steer it: it cannot pose as a Regexp, and there is no
   # helper on String for a subclass to redefine.  Compiling an accepted String
   # stays here, so the check does not have to call back into the VM; `String
   # ===` goes through `Module#===` and cannot be redefined either.
   def match(re, pos = 0, &block)
-    re = Regexp.__match_pattern(re)
+    re = Regexp.__check_pattern(re)
     re = Regexp.new(re) if String === re
     re.match(self, pos, &block)
   end
 
   def match?(re, pos = 0)
-    re = Regexp.__match_pattern(re)
+    re = Regexp.__check_pattern(re)
     re = Regexp.new(re) if String === re
     re.match?(self, pos)
   end
@@ -42,11 +42,11 @@ class String
       raise ArgumentError, "wrong number of arguments (given #{args.length}, expected 2)"
     end
     pattern, replacement = *args
-    pattern = Regexp.__match_pattern(pattern)
+    pattern = Regexp.__check_pattern(pattern)
     # Unlike `match`, a String pattern is quoted rather than compiled: it is a
     # literal here, the distinction CRuby draws between get_pat_quoted and
     # get_pat.  Only the quoting is taken from it: get_pat_quoted also accepts
-    # anything answering `to_str`, where `__match_pattern` keeps to a real
+    # anything answering `to_str`, where `__check_pattern` keeps to a real
     # String, as `match` already does.
     pattern = Regexp.new(Regexp.escape(pattern)) if String === pattern
     # A replacement argument wins over the block, as in CRuby.
@@ -69,7 +69,7 @@ class String
     pattern, replacement = *args
     # After the to_enum return above, so that `"abc".gsub(:b)` yields an
     # Enumerator and raises on the first iteration, as CRuby does.
-    pattern = Regexp.__match_pattern(pattern)
+    pattern = Regexp.__check_pattern(pattern)
     pattern = Regexp.new(Regexp.escape(pattern)) if String === pattern
     # A replacement argument wins over the block, as in CRuby.
     if args.length == 2
@@ -112,7 +112,7 @@ class String
   end
 
   def scan(pattern)
-    pattern = Regexp.__match_pattern(pattern)
+    pattern = Regexp.__check_pattern(pattern)
     pattern = Regexp.new(Regexp.escape(pattern)) if String === pattern
     result = pattern.__scan(self)
     if block_given?
@@ -149,8 +149,8 @@ class String
     end
     return self.empty? ? [] : [self] if limit == 1
     # nil and String patterns already went to __split above, so the String
-    # branch of the resolver is unreachable here and nothing needs quoting.
-    pattern = Regexp.__match_pattern(pattern)
+    # branch of the check is unreachable here and nothing needs quoting.
+    pattern = Regexp.__check_pattern(pattern)
 
     result = []
     field_start = 0

--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -1122,7 +1122,7 @@ regexp_scan(mrb_state *mrb, mrb_value self)
    needs no callback into the VM. CRuby names `nil`, `true` and `false` by
    value and everything else by class. */
 static mrb_value
-regexp_match_pattern(mrb_state *mrb, mrb_value self)
+regexp_check_pattern(mrb_state *mrb, mrb_value self)
 {
   mrb_value re;
   mrb_get_args(mrb, "o", &re);
@@ -1157,7 +1157,7 @@ mrb_mruby_regexp_gem_init(mrb_state *mrb)
   mrb_define_class_method(mrb, re, "escape", regexp_escape, MRB_ARGS_REQ(1));
   mrb_define_class_method(mrb, re, "quote", regexp_escape, MRB_ARGS_REQ(1));
   mrb_define_class_method(mrb, re, "__binary_string?", regexp_binary_string_p, MRB_ARGS_REQ(1));
-  mrb_define_class_method(mrb, re, "__match_pattern", regexp_match_pattern, MRB_ARGS_REQ(1));
+  mrb_define_class_method(mrb, re, "__check_pattern", regexp_check_pattern, MRB_ARGS_REQ(1));
 
   /* Instance methods */
   mrb_define_method(mrb, re, "match", regexp_match, MRB_ARGS_ARG(1, 1)|MRB_ARGS_BLOCK());

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -684,7 +684,7 @@ class StringMatchStringDenier < String
 end
 
 class StringMatchHelperOverride < String
-  private def __match_pattern(re)
+  private def __check_pattern(re)
     Regexp.new(re.to_s)
   end
 end


### PR DESCRIPTION
The pattern type check is a single C function serving six `String` methods,
but it is still named after the two it was written for.

| caller | `string_regexp.rb` |
|---|---|
| `String#match` | [`:14`](https://github.com/mruby/mruby/blob/8f85a841391e4a73e1ed3c72ac6689250aabef17/mrbgems/mruby-regexp/mrblib/string_regexp.rb#L14) |
| `String#match?` | [`:20`](https://github.com/mruby/mruby/blob/8f85a841391e4a73e1ed3c72ac6689250aabef17/mrbgems/mruby-regexp/mrblib/string_regexp.rb#L20) |
| `String#sub` | [`:45`](https://github.com/mruby/mruby/blob/8f85a841391e4a73e1ed3c72ac6689250aabef17/mrbgems/mruby-regexp/mrblib/string_regexp.rb#L45) |
| `String#gsub` | [`:72`](https://github.com/mruby/mruby/blob/8f85a841391e4a73e1ed3c72ac6689250aabef17/mrbgems/mruby-regexp/mrblib/string_regexp.rb#L72) |
| `String#scan` | [`:115`](https://github.com/mruby/mruby/blob/8f85a841391e4a73e1ed3c72ac6689250aabef17/mrbgems/mruby-regexp/mrblib/string_regexp.rb#L115) |
| `String#split` | [`:153`](https://github.com/mruby/mruby/blob/8f85a841391e4a73e1ed3c72ac6689250aabef17/mrbgems/mruby-regexp/mrblib/string_regexp.rb#L153) |

Line numbers are those of mruby/mruby@8f85a84, the current master.

`match` and `match?` are two of six now, so the name points at a minority
of the callers.

`__check_pattern` names what the helper does rather than who calls it. It
is a check: an accepted argument comes back untouched, anything else
raises, and no caller treats the return value as a conversion.

- `match` and `match?` compile an accepted `String` themselves.
- `sub`, `gsub` and `scan` quote it first.
- `split` never sees one: nil and `String` patterns have already gone to
  `__split` by then, so that branch is unreachable.

The C function [`regexp_match_pattern()`](https://github.com/mruby/mruby/blob/8f85a841391e4a73e1ed3c72ac6689250aabef17/mrbgems/mruby-regexp/src/regexp.c#L1125)
is renamed to `regexp_check_pattern()` in the same change, so the mismatch
is not moved from the Ruby side of the binding to the C side.

The private `__check_pattern` on the
[`StringMatchHelperOverride`](https://github.com/mruby/mruby/blob/8f85a841391e4a73e1ed3c72ac6689250aabef17/mrbgems/mruby-regexp/test/regexp.rb#L686-L690)
test subclass is renamed too. It is not a caller, but the assertion built
on it is that a same-named method on the receiver cannot widen what the
check accepts, and that only means anything while the name matches the
helper.

### Compatibility

None affected. `__check_pattern` is an undocumented `__`-prefixed helper,
and the rename changes no observable behaviour.

### Why this was not folded into #7001

#7001 is what widened the caller set, and the rename was kept out of it
deliberately: it touches the `match` and `match?` lines, which #7001 does
not go near, and `CONTRIBUTING.md` asks that a pull request not mix
several things. The comment above the C function was updated there to name
all six callers instead, so the name and the reality did not contradict
each other in the meantime.

### Testing

`rake test` passes: 1922 OK, 0 KO, 18 skipped (all pre-existing).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated regular expression pattern validation across string matching, substitution, scanning, splitting, quoting, and compilation operations.
  * Preserved existing behavior while improving consistency in pattern checking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->