### PR TITLE
mruby-regexp: add the regexp form of `String#[]` and `String#slice`

### DIFF
--- a/mrbgems/mruby-regexp/README.md
+++ b/mrbgems/mruby-regexp/README.md
@@ -127,6 +127,8 @@ pattern analysis.
   only.
 - **Step limit on backtracking**: Patterns that require the
   backtracking engine are subject to a step limit.
+- **No regexp form on the write side**: `str[re] = repl` and
+  `str.slice!(re)` are not supported. Reading with `str[re]` is.
 
 ## Configuration
 

--- a/mrbgems/mruby-regexp/README.md
+++ b/mrbgems/mruby-regexp/README.md
@@ -82,12 +82,17 @@ str.gsub(re, replacement)         # replace all occurrences
 str.gsub(re) { |m| ... }          # replace all with block
 str.scan(re)                      # => array of matches
 str.split(re)                     # => array of parts
+str[re]                           # => matched substring or nil
+str[re, capture]                  # => capture by index or name
+str.slice(re)                     # => same as str[re]
 
 # Symbol methods (the String methods applied to the symbol's name)
 sym.match(re)                     # => MatchData or nil
 sym.match(re) { |md| ... }        # => block result, or nil if no match
 sym.match?(re)                    # => true/false
 sym =~ re                         # => index or nil
+sym[re]                           # => matched substring or nil
+                                  #    (Symbol#[] comes from mruby-symbol-ext)
 
 # Global variables
 $~                                # last MatchData
@@ -122,9 +127,6 @@ pattern analysis.
   only.
 - **Step limit on backtracking**: Patterns that require the
   backtracking engine are subject to a step limit.
-- **No regexp form of `String#[]`**: `str[re]` and `str.slice(re)`
-  are not supported, and neither is `sym[re]`, which delegates to
-  them.
 
 ## Configuration
 

--- a/mrbgems/mruby-regexp/mrblib/string_regexp.rb
+++ b/mrbgems/mruby-regexp/mrblib/string_regexp.rb
@@ -138,6 +138,12 @@ class String
   # an override is not visible there.  That is harmless as long as this method
   # only delegates them, which is why the regexp branch is the only behaviour
   # added here.
+  #
+  # `str[0]` is the exception: a literal zero index compiles to OP_GETIDX0,
+  # which has no String branch at all and always sends, so it does arrive here
+  # and pays a Ruby frame and an argument array for what used to be a direct
+  # call into C, roughly four times the cost.  That is why the loops in `gsub`
+  # and `split` above read their one character with `__aref(0)`.
   def [](*args)
     # Checked before the argument is inspected, so the non-regexp forms keep
     # reporting the CRuby arity rather than silently ignoring an extra

--- a/mrbgems/mruby-regexp/mrblib/string_regexp.rb
+++ b/mrbgems/mruby-regexp/mrblib/string_regexp.rb
@@ -4,6 +4,12 @@ class String
   # back to the core implementation.
   alias __split split
 
+  # Same for String#[], which the override below replaces along with its
+  # `slice` twin.  `__aref` also serves as the internal spelling of `str[i]`
+  # inside this file: the loops in `gsub` and `split` would otherwise pay for
+  # a Ruby frame per iteration on a call that can never take a Regexp.
+  alias __aref []
+
   # `match` and `match?` accept a Regexp or a String and reject everything
   # else.  The check lives in C (see Regexp.__check_pattern) so that the
   # argument cannot steer it: it cannot pose as a Regexp, and there is no
@@ -96,7 +102,7 @@ class String
             pos = match_end + 1
           else
             rest = self.byteslice(match_end..-1)
-            char = rest[0]
+            char = rest.__aref(0)
             parts << char
             pos = match_end + char.bytesize
           end
@@ -122,6 +128,42 @@ class String
       result
     end
   end
+
+  # Regexp-aware element reference.  Only a Regexp is handled here; every
+  # other argument list goes back to the C-defined `[]` untouched.
+  #
+  # Note that `str[i]`, `str[range]` and `str["sub"]` never reach this method
+  # when the receiver is a String rather than a subclass: OP_GETIDX answers
+  # those three argument types from C without consulting the method table, so
+  # an override is not visible there.  That is harmless as long as this method
+  # only delegates them, which is why the regexp branch is the only behaviour
+  # added here.
+  def [](*args)
+    # Checked before the argument is inspected, so the non-regexp forms keep
+    # reporting the CRuby arity rather than silently ignoring an extra
+    # argument.
+    unless (1..2).include?(args.length)
+      raise ArgumentError, "wrong number of arguments (given #{args.length}, expected 1..2)"
+    end
+    # `is_a?` is redefinable, so an argument denying its own type could steer
+    # itself into `__aref` and be read as an index.  `Module#===` reads the
+    # real type.
+    return __aref(*args) unless Regexp === args[0]
+    # `match`, not `match?`: `$~` has to be set even when the match fails,
+    # where it becomes nil.  The MatchData is unused in the no-capture case,
+    # but the global is not.
+    md = args[0].match(self)
+    return nil unless md
+    # The capture argument is handed to MatchData#[] as it stands: an out of
+    # range index answers nil and a name that resolves to no group raises
+    # IndexError, which is what CRuby's rb_reg_nth_match() and
+    # rb_reg_backref_number() do respectively.
+    md[args.length == 2 ? args[1] : 0]
+  end
+
+  # CRuby reaches the same code for both names, and Symbol#slice (in
+  # mruby-symbol-ext) delegates here, which is what makes `sym[re]` work.
+  alias slice []
 
   # Regexp-aware split.  Falls back to the C-defined split (aliased as
   # `__split` in mrb_mruby_regexp_gem_init before this override loads) for
@@ -173,7 +215,7 @@ class String
       if match_start == match_end
         rest = self.byteslice(match_end..-1)
         if rest && rest.bytesize > 0
-          char = rest[0]
+          char = rest.__aref(0)
           search_pos = match_end + char.bytesize
         else
           search_pos = match_end + 1

--- a/mrbgems/mruby-regexp/mrblib/symbol_regexp.rb
+++ b/mrbgems/mruby-regexp/mrblib/symbol_regexp.rb
@@ -5,8 +5,9 @@
 #
 # This covers the symbol-on-the-left direction only.  The Regexp side converts
 # a symbol on its own, in `match_operand()` in regexp.c, so it needs nothing
-# from here.  `sym[/re/]` is the direction still missing; it waits on the
-# regexp form of `String#slice`.
+# from here.  `sym[/re/]` needs nothing either: Symbol#slice (mruby-symbol-ext,
+# which this gem does not depend on) delegates to String#slice, so it picks up
+# the regexp form from string_regexp.rb wherever that gem is built in.
 #
 # The argument handling of `=~` is inherited from `String#=~` rather than
 # introduced here, and agrees with CRuby: a String argument raises TypeError,

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -1441,3 +1441,91 @@ assert("Regexp - large non-ASCII character class does not overflow") do
   assert_nil (re =~ utf8.call(0x8081))
   assert_nil (re =~ "A")
 end
+
+assert("String#[] with regexp") do
+  assert_equal "ll", "hello"[/l+/]
+  assert_equal "ll", "hello".slice(/l+/)
+  assert_nil "hello"[/z/]
+  assert_nil "hello".slice(/z/)
+  assert_equal "", "hello"[//]
+
+  # the result is a plain String even for a subclass receiver, as in CRuby
+  sub = Class.new(String)
+  assert_equal String, sub.new("hello")[/l+/].class
+end
+
+assert("String#[] with regexp and capture") do
+  assert_equal "ll", "hello"[/(l+)(o)/, 1]
+  assert_equal "o", "hello"[/(l+)(o)/, 2]
+  assert_equal "llo", "hello"[/(l+)(o)/, 0]
+  assert_equal "ll", "hello"[/(?<x>l+)/, :x]
+  assert_equal "ll", "hello"[/(?<x>l+)/, "x"]
+  assert_equal "ll", "hello".slice(/(l+)/, 1)
+
+  # handed to MatchData#[]: a negative index counts back from the last group,
+  # an index past the last group is nil, and a name that resolves to no group
+  # is a mistake at the point of the call
+  assert_equal "o", "hello"[/(l+)(o)/, -1]
+  assert_nil "hello"[/(l+)/, 5]
+  assert_raise(IndexError) { "hello"[/(?<x>l+)/, :zz] }
+  assert_raise(IndexError) { "hello"[/(l+)/, "x"] }
+  assert_raise(TypeError) { "hello"[/(l+)/, nil] }
+
+  # a failed match answers nil without ever looking at the capture argument
+  assert_nil "hello"[/(?<x>z)/, :zz]
+  assert_nil "hello"[/(z)/, 1]
+end
+
+assert("String#[] with regexp sets the match globals") do
+  assert_equal "ll", "hello"[/l+/]
+  assert_equal "ll", $~[0]
+  assert_equal "ll", Regexp.last_match(0)
+
+  "hello"[/(l)(l)/, 2]
+  assert_equal "l", $1
+
+  # a failed match clears $~, which is why this goes through `match` rather
+  # than `match?`
+  assert_nil "hello"[/z/]
+  assert_nil $~
+end
+
+assert("String#[] delegates non-regexp arguments") do
+  assert_equal "e", "hello"[1]
+  assert_equal "e", "hello".slice(1)
+  assert_equal "ell", "hello"[1, 3]
+  assert_equal "ell", "hello".slice(1, 3)
+  assert_equal "ell", "hello"[1..3]
+  assert_equal "llo", "hello"[-3..-1]
+  assert_equal "ll", "hello"["ll"]
+  assert_nil "hello"["bye"]
+  assert_nil "hello"[12]
+  assert_nil "hello"[12, 1]
+
+  # the same delegation on a subclass receiver, which OP_GETIDX never
+  # shortcuts and which therefore always arrives through the override
+  sub = Class.new(String)
+  assert_equal "e", sub.new("hello")[1]
+  assert_equal "ell", sub.new("hello")[1..3]
+  assert_equal "ll", sub.new("hello")["ll"]
+
+  assert_raise(ArgumentError) { "hello"[] }
+  assert_raise(ArgumentError) { "hello"[1, 2, 3] }
+  assert_raise(ArgumentError) { "hello"[/l/, 1, 2] }
+  assert_raise(ArgumentError) { "hello".slice(1, 2, 3) }
+  assert_raise(TypeError) { "hello"[nil] }
+end
+
+assert("String#[] reads the real type of its argument") do
+  # `is_a?` is redefinable, so an object claiming not to be a Regexp must not
+  # be read as an index, and a non-Regexp claiming to be one must not be
+  # matched against
+  re = /l+/
+  def re.is_a?(klass); false; end
+  assert_equal "ll", "hello"[re]
+
+  fake = Object.new
+  def fake.is_a?(klass); true; end
+  def fake.match(str); raise "must not be called"; end
+  assert_raise(TypeError) { "hello"[fake] }
+end

--- a/mrbgems/mruby-regexp/test/symbol_regexp.rb
+++ b/mrbgems/mruby-regexp/test/symbol_regexp.rb
@@ -99,3 +99,20 @@ assert("Symbol - multibyte (UTF-8) name") do
   assert_false :"あいあ".match?(Regexp.new("い"), 2)
   assert_equal 1, :"あい" =~ Regexp.new("い")
 end
+
+assert("Symbol#[] with regexp") do
+  # Symbol#[] and #slice live in mruby-symbol-ext, which this gem does not
+  # depend on; they delegate to the String methods, so the regexp form
+  # arrives from string_regexp.rb wherever that gem is built in.
+  skip unless :hello.respond_to?(:slice)
+  assert_equal "ll", :hello[Regexp.new("l+")]
+  assert_equal "ll", :hello.slice(Regexp.new("l+"))
+  assert_equal "ll", :hello[Regexp.new("(?<x>l+)"), :x]
+  assert_equal "o", :hello[Regexp.new("(l+)(o)"), 2]
+  assert_nil :hello[Regexp.new("z")]
+
+  assert_equal "ll", :hello[Regexp.new("l+")]
+  assert_equal "ll", $~[0]
+  assert_nil :hello[Regexp.new("z")]
+  assert_nil $~
+end


### PR DESCRIPTION
## Problem

`String#[]` and its alias `String#slice` accept an Integer, a Range and a
String, but not a Regexp. Every regexp form fails with a `TypeError` naming
`Integer`, which does not hint at what is actually missing.

```ruby
"hello"[/l+/]            # CRuby: "ll",  mruby: TypeError (Regexp cannot be converted to Integer)
"hello".slice(/l+/)      # CRuby: "ll",  mruby: TypeError
"hello"[/(l+)(o)/, 1]    # CRuby: "ll",  mruby: TypeError
"hello"[/(?<x>l+)/, :x]  # CRuby: "ll",  mruby: TypeError
"hello"[/z/]             # CRuby: nil,   mruby: TypeError
:hello[/l+/]             # CRuby: "ll",  mruby: TypeError
```

`mrb_str_aref()` funnels every non-String, non-Range argument through an
Integer conversion, and `mruby-regexp` never overrode `[]` or `slice`.

## Solution

Override `[]` in `mrbgems/mruby-regexp/mrblib/string_regexp.rb` and alias
`slice` to it, in the shape `split` already uses in that file: capture the
C-defined method as `__aref`, check the arity, then delegate every argument
list that does not start with a Regexp straight back to C.

The type test is `Regexp === args[0]` rather than `is_a?`, for the reason
the `split` and `=~` comments already give: `is_a?` is redefinable, so an
argument could deny its own type and be read as an index instead, or claim
a type it does not have. `Module#===` reads the real type.

## Behaviour notes

- `$~` is set through `Regexp#match`, including to nil on a failed match,
  which is why `match?` is not used even in the no-capture case.
- The capture argument reaches `MatchData#[]` unchanged. A negative index
  is normalized, an index past the last group answers nil, and a name that
  resolves to no group raises `IndexError`. This matches CRuby, where
  `rb_reg_nth_match()` answers nil and `rb_reg_backref_number()` raises.
  #7000 is what made this delegation correct on its own.
- A failed match answers nil without inspecting the capture argument, as
  `rb_str_subpat()` does.
- The arity check comes before the argument is inspected, so
  `"a"[/a/, 1, 2]` raises `ArgumentError (given 3, expected 1..2)` rather
  than quietly ignoring the extra argument.
- One known divergence remains: a Float capture argument is accepted, since
  `MatchData#[]` reads it through `mrb_as_int()`. This is the same latitude
  the surrounding gem already takes.

## `OP_GETIDX` interaction

`vm_op_getidx()` answers an Integer, String or Range index for a receiver
whose class is exactly String directly from `mrb_str_aref()`, without
consulting the method table, so an override of `String#[]` is not visible
for those three forms. A Regexp index falls through to a send and does
reach the override.

This is safe here because the override only delegates those forms, and the
method comment records the constraint for whoever changes it next.

`str[0]` is the exception, and the one place this change costs anything.
A literal zero index compiles to `OP_GETIDX0`, which has a fast path for
Array and Hash and none for String, so it always sends and therefore does
reach the override. Measured over 1000000 iterations on the built binary,
`s[0]` goes from 48 ms to 193 ms, which is the Ruby frame and the argument
array; 48 ms is what `s.__aref(0)` still costs, and `__aref` is the same C
method `str[0]` reached before. Every other form is unaffected: `str[i]`
with a non-zero or non-literal index is answered by `OP_GETIDX` from C as
before, and `str[i, len]`, `str.slice(...)`, an explicit send and a String
subclass receiver were already sends.

The loops in `gsub` and `split` read one character with `str[0]` on every
iteration, so they now spell it `__aref(0)` and stay on the old path.

## Symbol

`Symbol#[]` and `Symbol#slice` are defined in `mruby-symbol-ext`, not in
core, and delegate to the String methods, so `sym[re]` follows from this
change with no implementation of its own. `mruby-regexp` does not depend on
`mruby-symbol-ext`, so the Symbol test skips itself where that gem is
absent, the same way the `to_enum` test in this gem skips without
`mruby-enumerator`.

## The write side is left alone

`str[re] = repl` and `str.slice!(re)` still raise the `TypeError` this PR
removes from the read side. `String#[]=` is core (`mrb_str_aset_m`) and
`String#slice!` is mruby-string-ext (`mrb_str_slice_bang`, registered as
`MRB_SYM_B(slice)`). Covering the capture form of the assignment would mean
adding C, since `MatchData#__byte_begin` takes an Integer and the name to
group resolution is private to `matchdata_aref()`, and the destructive side
brings the frozen check and the live reference a MatchData keeps to the
string it matched. Both belong with the rest of the destructive-method work,
so the README says so rather than claiming the regexp form is complete.

## Tests

`mrbgems/mruby-regexp/test/regexp.rb` covers the regexp form and its
`slice` twin, a subclass receiver, capture access by index and by name,
negative and out of range indices, an unknown name, a failed match, the
`$~` and `$1` globals on success and on failure, the delegated non-regexp
forms including the subclass path that always goes through the override,
the arity errors, and an argument that lies in `is_a?`.
`mrbgems/mruby-regexp/test/symbol_regexp.rb` covers `sym[re]` behind the
`mruby-symbol-ext` guard.

`rake test` passes.

## Documentation

Narrows the **No regexp form of `String#[]`** item in the gem README's
Limitations section to the write side, adds the forms to the usage examples,
and rewrites the clause in the `symbol_regexp.rb` header comment that
recorded `sym[/re/]` as still missing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added regular expression support to `String#[]` and `String#slice`, including capture and named-capture extraction.
  * Added regular expression slicing support for symbols where symbol slicing is available.
  * Preserved existing behavior for non-regexp indexing and slicing.

* **Documentation**
  * Documented regexp-based string and symbol slicing, including supported reads and unsupported writes.

* **Tests**
  * Added coverage for captures, match globals, validation, subclasses, unmatched patterns, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->