### PR TITLE
mruby-regexp: stop truncating a group name to a uint16_t

### DIFF
--- a/mrbgems/mruby-regexp/include/re_internal.h
+++ b/mrbgems/mruby-regexp/include/re_internal.h
@@ -60,9 +60,19 @@ typedef struct {
 /* Named capture entry */
 typedef struct {
   const char *name;
-  uint16_t name_len;
+  uint32_t name_len;
   uint16_t group;
 } re_named_capture;
+
+/* Longest group name re_named_capture::name_len can hold. The compiler
+   rejects anything longer instead of narrowing to the field, so a stored
+   length is always the name's true length.
+
+   RE_NAME_LEN_FITS() widens before comparing: where the argument's type is
+   no wider than the field (ptrdiff_t on ILP32, mrb_int on MRB_INT32) the
+   comparison is otherwise constant, which compilers warn about. */
+#define RE_MAX_NAME_LEN UINT32_MAX
+#define RE_NAME_LEN_FITS(n) ((uintmax_t)(n) <= RE_MAX_NAME_LEN)
 
 /* Compiled regexp pattern */
 typedef struct mrb_regexp_pattern {

--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -613,7 +613,7 @@ compile_atom(re_compiler *c)
       uint32_t saved_flags = c->flags;
 
       const char *cap_name = NULL;
-      uint16_t cap_name_len = 0;
+      uint32_t cap_name_len = 0;
 
       if (peek(c) == '?' && c->p + 1 < c->src_end) {
         if (c->p[1] == ':') {
@@ -665,7 +665,8 @@ compile_atom(re_compiler *c)
           cap_name = c->p;
           while (peek(c) != '>' && peek(c) >= 0) next_char(c);
           if (peek(c) != '>') compile_error(c, "unterminated named capture");
-          cap_name_len = (uint16_t)(c->p - cap_name);
+          if (!RE_NAME_LEN_FITS(c->p - cap_name)) compile_error(c, "group name too long");
+          cap_name_len = (uint32_t)(c->p - cap_name);
           next_char(c);  /* skip > */
         }
         else if (c->p[1] == 'i' || c->p[1] == 'm' || c->p[1] == 'x' || c->p[1] == '-') {
@@ -811,14 +812,15 @@ compile_atom(re_compiler *c)
       const char *name = c->p;
       while (peek(c) != close && peek(c) >= 0) next_char(c);
       if (peek(c) != close) compile_error(c, "unterminated backreference name");
-      uint16_t name_len = (uint16_t)(c->p - name);
+      if (!RE_NAME_LEN_FITS(c->p - name)) compile_error(c, "group name too long");
+      uint32_t name_len = (uint32_t)(c->p - name);
       next_char(c);  /* skip the closing > or ' */
 
       int group = -1;
       if (name_len > 0 && (name[0] == '-' || (name[0] >= '0' && name[0] <= '9'))) {
         mrb_bool relative = (name[0] == '-');
         int n = 0;
-        for (uint16_t i = (relative ? 1 : 0); i < name_len; i++) {
+        for (uint32_t i = (relative ? 1 : 0); i < name_len; i++) {
           if (name[i] < '0' || name[i] > '9') compile_error(c, "invalid backreference");
           n = n * 10 + (name[i] - '0');
         }
@@ -1292,7 +1294,7 @@ mrb_re_compile(mrb_state *mrb, const char *pattern, mrb_int len, uint32_t flags)
       pat->named_arena = (char*)mrb_malloc(mrb, total);
       size_t off = 0;
       for (uint16_t i = 0; i < c.num_named; i++) {
-        uint16_t n = c.named_captures[i].name_len;
+        uint32_t n = c.named_captures[i].name_len;
         memcpy(pat->named_arena + off, c.named_captures[i].name, n);
         pat->named_captures[i].name = pat->named_arena + off;
         off += n;

--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -592,12 +592,12 @@ matchdata_aref(mrb_state *mrb, mrb_value self)
     if (!mrb_nil_p(md->regexp)) {
       pat = DATA_GET_PTR(mrb, md->regexp, &regexp_type, mrb_regexp_pattern);
     }
-    /* A stored name never exceeds UINT16_MAX, so a longer request can name no
-       group. Rejecting it here keeps the cast in the loop lossless; without it
-       the length test truncates while the memcmp() next to it does not. */
-    if (pat && name_len <= UINT16_MAX) {
+    /* A stored name never exceeds RE_MAX_NAME_LEN, so a longer request can name
+       no group. Rejecting it here keeps the cast in the loop lossless; without
+       it the length test truncates while the memcmp() next to it does not. */
+    if (pat && RE_NAME_LEN_FITS(name_len)) {
       for (uint16_t i = 0; i < pat->num_named; i++) {
-        if (pat->named_captures[i].name_len == (uint16_t)name_len &&
+        if (pat->named_captures[i].name_len == (uint32_t)name_len &&
             memcmp(pat->named_captures[i].name, name, name_len) == 0) {
           idx = pat->named_captures[i].group;
           goto found;

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -1229,6 +1229,34 @@ assert("MatchData#[] - group name longer than a uint16 length") do
   assert_equal "x", md[:abc]
 end
 
+assert("Regexp - group name longer than a uint16 length") do
+  # The name length used to live in a uint16_t and was truncated with a cast,
+  # so (uint16_t)65538 == 2 made this group answer to "ab" instead of to the
+  # name it was given.
+  long = "ab" + "A" * 65536
+  re = Regexp.new("(?<#{long}>x)")
+  assert_equal [long], re.named_captures.keys
+  assert_equal "x", re.match("x")[long]
+  assert_raise(IndexError) { re.match("x")["ab"] }
+
+  # two names that shared a truncation stay distinct, and the two APIs that
+  # resolve a name agree on which group it names
+  re = Regexp.new("(?<ab>x)(?<#{long}>y)")
+  md = re.match("xy")
+  assert_equal "x", md["ab"]
+  assert_equal "y", md[long]
+  assert_equal({ "ab" => "x", long => "y" }, md.named_captures)
+
+  # \k<name> binds to the group the name was written on
+  re = Regexp.new("(?<ab>x)(?<#{long}>y)\\k<#{long}>")
+  assert_nil re.match("xyx")
+  assert_equal "xyy", re.match("xyy")[0]
+
+  # a name of exactly 65536 bytes is not the empty name
+  z = "Z" * 65536
+  assert_equal [z], Regexp.new("(?<#{z}>x)").named_captures.keys
+end
+
 assert("Regexp - named backreference \\k") do
   assert_equal "aa", "aa".match(/(?<n>\w)\k<n>/)[0]
   assert_equal "abba", "abba".match(/(?<a>.)(?<b>.)\k<b>\k<a>/)[0]


### PR DESCRIPTION
Split out of #7002 rather than folded into it. That pull request fixed a heap-buffer-overflow
read in `MatchData#[]` for an over-long group name, and closed it with a one-line bound on the
requested length. This one is the compile side of the same `uint16_t`: entirely in bounds, and
entirely a compatibility bug. #7002 said the compile-side truncation was consistent and not
worth a guard of its own, which was right about the memory safety and wrong about the
behaviour.

`re_named_capture::name_len` was a `uint16_t`, and `compile_atom()` narrowed to it with a cast
rather than rejecting the name. The truncation was silent, and every reader worked from the
truncated bytes, so nothing read out of bounds: the arena was built from the same truncated
lengths every reader used. What was lost was the rest of the name, and with it the identity of
the group.

```ruby
n = "A" * 65539
re = Regexp.new("(?<#{n}>x)")
re.named_captures.keys.map(&:length)
# CRuby: [65539]
# mruby: [3]

re.match("x")[n]
# CRuby: "x"
# mruby: IndexError

re.match("x")["AAA"]
# CRuby: IndexError
# mruby: "x"
```

The group existed and matched, but it could not be reached by the name it was given, and it
answered to a three-byte name that appeared nowhere in the pattern.

## Two consumers disagreed about the same name

The truncation also let two groups collapse onto one stored name, and the two APIs that
resolve a name then picked different groups.

```ruby
long = "ab" + "A" * 65536              # length 65538, (uint16_t)65538 == 2
re = Regexp.new("(?<ab>x)(?<#{long}>y)")
md = re.match("xy")

md["ab"]
# mruby: "x", group 1

md.named_captures
# mruby: {"ab" => "y"}, group 2
```

`MatchData#[]` scans the table and stops at the first entry, so `"ab"` resolved to group 1.
`Regexp#named_captures` and `MatchData#named_captures` build a Hash and let the later entry
overwrite the earlier one, so the same name resolved to group 2. One name, two answers, in one
pattern.

## `\k<name>` bound to the wrong group

The same collapse reached the matcher, where it changed what the pattern accepts.

```ruby
long = "ab" + "A" * 65536
re = Regexp.new("(?<ab>x)(?<#{long}>y)\\k<#{long}>")

re.match("xyx")
# CRuby: nil
# mruby: matches

re.match("xyy")
# CRuby: matches
# mruby: nil
```

The backreference was written against the second group and bound to the first. That is a wrong
answer from a pattern that compiled without complaint, not a diagnostic gap.

## A name of exactly 65536 bytes became the empty name

`(uint16_t)65536 == 0`, so the name was truncated away entirely and the group answered to `""`.

```ruby
z = "Z" * 65536
re = Regexp.new("(?<#{z}>x)")
re.named_captures.keys.map(&:length)
# CRuby: [65536]
# mruby: [0]

re.match("x")[""]
# CRuby: IndexError
# mruby: "x"
```

## What this changes

`re_named_capture::name_len` is a `uint32_t`, and the locals, loop counters and comparisons
that consume it follow. Every answer above now matches CRuby.

The alternative was to reject a name that does not fit, which is two lines and no
representation change. It was not taken because the limit is not one the design needs. The
gem's other `uint16_t` limits are structural: `RE_MAX_CAPTURES` is 32 because two functions in
`regexp.c` hold `int last_captures[RE_MAX_CAPTURES * 2]` on the stack, and `re_inst.offset`
sizes every instruction. A name's length is neither. On a 64-bit target the struct is unchanged
at 16 bytes, since `const char *name; uint16_t name_len; uint16_t group;` already padded to
that, and on a 32-bit target the entry grows from 8 bytes to 12. Trading four wrong answers for
that seemed the better side of the deal.

The bound the cast needs does not go away with the wider field. `c->p - cap_name` is a
`ptrdiff_t` over the pattern source and nothing limits the pattern's length, so a check has to
sit in front of the cast whatever the field's width is. It moves to `UINT32_MAX`, out of reach
of any pattern this gem can compile, and it is what keeps the cast lossless.

`RE_MAX_NAME_LEN` spells that bound once, beside the field it describes, so a later change of
width is one line. `RE_NAME_LEN_FITS()` widens to `uintmax_t` before comparing, which is not
cosmetic: on a target whose argument type is no wider than the field, a `ptrdiff_t` on ILP32 or
an `mrb_int` on `MRB_INT32`, the naive comparison is against a constant the type cannot exceed,
and clang reports it.

```
warning: comparison of integers of different signs: 'int32_t' (aka 'int')
         and 'unsigned int' [-Wsign-compare]
```

`uintmax_t` rather than `uint64_t` because C99 makes the exact-width 64-bit types optional and
every `uint64_t` in mruby today sits behind `MRB_GC_PROFILE` or `MRB_INT64`.

The guard #7002 added to `matchdata_aref()` stays, now reading through the same macro. It is
what makes the cast on the line below it lossless, and dropping it would put a truncating
comparison back next to an untruncated `memcmp()`, one edit away from the same overread.

## Testing

- `rake test` on the host build: 1942 total, 1924 OK, 0 KO, 0 crash, and bintest 105 OK.
- An `MRB_INT32` build with clang and `-Wall -Wextra`: 1847 total, 1829 OK, 0 KO, 0 crash, and
  no warnings from any `mruby-regexp` file.
- The struct size was measured on x86_64 only. The 32-bit figure above is read from the layout,
  not measured.

The new test sits next to #7002's, which is the read-side counterpart of this one.

Related to #7002.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed handling of very long named regular-expression captures and backreferences.
  - Prevented capture-name length truncation during matching and lookup.
  - Added safe validation for names exceeding the previously supported 16-bit length range.
  - Improved behavior for duplicate and exactly 65,536-byte capture names.

- **Tests**
  - Expanded coverage for long named captures, named backreferences, and capture lookup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->