### PR TITLE
Remove broken Star History from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@
 - [License](#license)
 - [Note for License](#note-for-license)
 - [How to Contribute](#how-to-contribute)
-- [Star History](#star-history)
 - [Contributors](#contributors)
 
 ## What is mruby
@@ -173,10 +172,6 @@ Please ask us if you want to distribute your code under another license.
 
 To contribute to mruby, please refer to the [contribution guidelines][contribution-guidelines] and send a pull request to the [mruby GitHub repository](https://github.com/mruby/mruby).
 By contributing, you grant non-exclusive rights to your code under the MIT License.
-
-## Star History
-
-[![mruby Star History](https://api.star-history.com/svg?repos=mruby/mruby&type=Date)](https://www.star-history.com/#mruby/mruby&Date)
 
 ## Contributors
 


### PR DESCRIPTION
The Star History chart in the README is currently non-functional.

In June 2026, GitHub introduced API restrictions that prevent third parties from viewing star history data.
https://www.star-history.com/blog/github-stargazer-api-restriction/

Until star-history.com adapts to a different access method, the current link will just keep showing a broken image. I'm proposing we remove it from the README for now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the Star History section and its table-of-contents entry from the README.
  * Retained the Contributors section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->