### PR TITLE
Add mruby-string-bitops gem

### DIFF
--- a/mrbgems/mruby-string-bitops/README.md
+++ b/mrbgems/mruby-string-bitops/README.md
@@ -1,0 +1,87 @@
+# mruby-string-bitops
+
+Bit operations for `String`.
+Strings are treated as byte buffers; all operations are independent of
+string encoding.
+
+## Methods
+
+### Single-bit operations
+
+- `String#bit_get(offset, lsb_first: true)` - returns `0` or `1`, or
+  `nil` when `offset` is beyond the end of the string
+- `String#bit_set?(offset, lsb_first: true)` - returns `true` or
+  `false`, or `nil` when `offset` is beyond the end of the string
+- `String#bit_set(offset, lsb_first: true)` - sets the bit to 1;
+  returns `self`
+- `String#bit_clear(offset, lsb_first: true)` - sets the bit to 0;
+  returns `self`
+- `String#bit_flip(offset, lsb_first: true)` - inverts the bit;
+  returns `self`
+
+`offset` is a zero-based bit offset. By default, bits within each byte
+are numbered from least-significant to most-significant. With
+`lsb_first: false`, byte order is unchanged but bits within each byte
+are numbered from most-significant to least-significant.
+
+`IndexError` is raised when `offset` is negative, or (for the mutating
+methods) when it is beyond the end of the string.
+
+### Whole-string operations
+
+- `String#bit_count` - number of set bits (population count)
+- `String#bitwise_not` / `String#bitwise_not!` - bitwise complement
+- `String#bitwise_and(other)` / `String#bitwise_and!(other)`
+- `String#bitwise_or(other)` / `String#bitwise_or!(other)`
+- `String#bitwise_xor(other)` / `String#bitwise_xor!(other)`
+
+The binary operations require both strings to have the same byte
+length, otherwise `ArgumentError` is raised. The non-bang variants
+return a new string; the bang variants mutate `self` in place.
+
+## Example
+
+```ruby
+s = "\x00\x00"
+s.bit_set(3)          # => "\x08\x00"
+s.bit_set?(3)         # => true
+s.bit_count           # => 1
+
+"\xF0".bitwise_and("\xCC")  # => "\xC0"
+"\x0F".bitwise_or("\xF0")   # => "\xFF"
+"\xFF".bitwise_not          # => "\x00"
+```
+
+## Implementation notes
+
+The bulk kernels (`bit_count` and the `bitwise_*` family) process one
+machine word per iteration with 4x unrolling. The word width follows
+the pointer width of the target, so 32-bit targets (common for mruby)
+use 32-bit words and avoid emulated 64-bit arithmetic. On
+GNU-compatible compilers, word-aligned buffers are accessed directly
+through a `may_alias` word pointer, which yields true word loads even
+on cores without unaligned access support (e.g. Cortex-M0+).
+
+Note that alignment cannot be assumed: malloc'ed buffers are
+word-aligned, but embedded strings start right after the RString
+header, which on 64-bit builds leaves them only 4-byte aligned (on
+32-bit builds they are word-aligned). Buffers that miss the aligned
+fast path are still processed word-at-a-time through a `memcpy`-based
+loop; only the tail bytes go through a byte loop.
+
+## Differences from CRuby
+
+- Bit offsets are limited to `mrb_int`; the CRuby Bignum offset path
+  has no mruby equivalent. Offsets that do not fit in `mrb_int` raise
+  `RangeError` (CRuby raises `ArgumentError` for offsets beyond
+  `uint64_t`).
+
+Matching CRuby, binary operands are converted with `to_str` and bit
+offsets with `to_int`, and the results of the non-bang bitwise
+operations are BINARY (ASCII-8BIT) strings -- the binary flag is
+observable through `String#encoding` when mruby-encoding is in the
+build, and inert otherwise.
+
+## License
+
+MIT

--- a/mrbgems/mruby-string-bitops/README.md
+++ b/mrbgems/mruby-string-bitops/README.md
@@ -75,6 +75,9 @@ loop; only the tail bytes go through a byte loop.
   has no mruby equivalent. Offsets that do not fit in `mrb_int` raise
   `RangeError` (CRuby raises `ArgumentError` for offsets beyond
   `uint64_t`).
+- A `bit_count` result beyond `mrb_int` (reachable only on 32-bit
+  `mrb_int` builds with strings over 256MiB) becomes a Bignum when
+  mruby-bigint is present and raises `RangeError` otherwise.
 
 Matching CRuby, binary operands are converted with `to_str` and bit
 offsets with `to_int`, and the results of the non-bang bitwise

--- a/mrbgems/mruby-string-bitops/mrbgem.rake
+++ b/mrbgems/mruby-string-bitops/mrbgem.rake
@@ -1,0 +1,5 @@
+MRuby::Gem::Specification.new('mruby-string-bitops') do |spec|
+  spec.license = 'MIT'
+  spec.author  = 'mruby developers'
+  spec.summary = 'Bit operations for String'
+end

--- a/mrbgems/mruby-string-bitops/src/string_bitops.c
+++ b/mrbgems/mruby-string-bitops/src/string_bitops.c
@@ -1,0 +1,587 @@
+/*
+** string_bitops.c - Basic bit operations for String
+*/
+
+/*
+ * mruby.h must come first: in C++ builds it defines the
+ * __STDC_*_MACROS feature macros before the first inclusion of
+ * stdint.h, which some toolchains (e.g. MinGW) require for
+ * UINTPTR_MAX and friends to be visible.
+ */
+#include <mruby.h>
+#include <mruby/string.h>
+#include <string.h>
+#include <stdint.h>
+#include <limits.h>
+
+#if defined(UINTPTR_MAX) && UINTPTR_MAX > 0xFFFFFFFFul
+typedef uint64_t bitop_word;
+# define BITOP_WORD_SIZE 8
+#else
+typedef uint32_t bitop_word;
+# define BITOP_WORD_SIZE 4
+#endif
+#define BITOP_WORD_BITS (BITOP_WORD_SIZE * 8)
+
+#ifndef __has_builtin
+# define __has_builtin(x) 0
+#endif
+
+#if defined(__GNUC__) || __has_builtin(__builtin_popcount)
+static unsigned int
+bitop_popcount(bitop_word word)
+{
+#if BITOP_WORD_SIZE == 8
+  return (unsigned int)__builtin_popcountll((unsigned long long)word);
+#elif UINT_MAX >= 0xFFFFFFFFul
+  /* int holds a 32-bit word; avoids the 64-bit helper where long is 64-bit */
+  return (unsigned int)__builtin_popcount((unsigned int)word);
+#else
+  return (unsigned int)__builtin_popcountl((unsigned long)word);
+#endif
+}
+#else
+static unsigned int
+bitop_popcount(bitop_word word)
+{
+  /* Generic SWAR popcount; the constants adapt to the word width. */
+  const bitop_word m1 = (bitop_word)~(bitop_word)0 / 3;    /* 0x55... */
+  const bitop_word m2 = (bitop_word)~(bitop_word)0 / 5;    /* 0x33... */
+  const bitop_word m4 = (bitop_word)~(bitop_word)0 / 17;   /* 0x0f... */
+  const bitop_word h01 = (bitop_word)~(bitop_word)0 / 255; /* 0x01... */
+
+  word -= (word >> 1) & m1;
+  word = (word & m2) + ((word >> 2) & m2);
+  word = (word + (word >> 4)) & m4;
+  return (unsigned int)((word * h01) >> (BITOP_WORD_BITS - 8));
+}
+#endif
+
+/*
+ * memcpy-based word loops, safe for any alignment.  They are the
+ * whole bulk path on non-GNU compilers, and the unaligned fallback
+ * on GNU-compatible ones.  The trailing byte loop of each kernel
+ * only handles the tail.
+ */
+#define BITOP_UNARY_MEMCPY_LOOP(dst, src, len, off, expr_word)               \
+  {                                                                          \
+    mrb_int aligned_end_ = (len) & ~(mrb_int)(BITOP_WORD_SIZE - 1);          \
+    for (; (off) < aligned_end_; (off) += BITOP_WORD_SIZE) {                 \
+      bitop_word w_;                                                         \
+      memcpy(&w_, (src) + (off), BITOP_WORD_SIZE);                           \
+      w_ = expr_word(w_);                                                    \
+      memcpy((dst) + (off), &w_, BITOP_WORD_SIZE);                           \
+    }                                                                        \
+  }
+
+#define BITOP_BINARY_MEMCPY_LOOP(dst, lhs, rhs, len, off, expr_word)         \
+  {                                                                          \
+    mrb_int aligned_end_ = (len) & ~(mrb_int)(BITOP_WORD_SIZE - 1);          \
+    for (; (off) < aligned_end_; (off) += BITOP_WORD_SIZE) {                 \
+      bitop_word l_, r_;                                                     \
+      memcpy(&l_, (lhs) + (off), BITOP_WORD_SIZE);                           \
+      memcpy(&r_, (rhs) + (off), BITOP_WORD_SIZE);                           \
+      l_ = expr_word(l_, r_);                                                \
+      memcpy((dst) + (off), &l_, BITOP_WORD_SIZE);                           \
+    }                                                                        \
+  }
+
+/*
+ * On GNU-compatible compilers, word-aligned buffers are processed
+ * through a word pointer; the may_alias type keeps that free of
+ * strict-aliasing issues.  Targets without unaligned load support
+ * (e.g. Cortex-M0+) still get true word loads this way, which a bare
+ * memcpy cannot guarantee.  Alignment is not a given, though:
+ * malloc'ed buffers are word-aligned, but embedded strings start
+ * right after the RString header, which on 64-bit builds leaves them
+ * only 4-byte aligned.  Unaligned buffers fall back to the memcpy
+ * word loops above.
+ */
+#if defined(__GNUC__)
+typedef bitop_word __attribute__((__may_alias__)) bitop_word_alias;
+# define BITOP_ALIGNED(ptrbits) (((ptrbits) & (BITOP_WORD_SIZE - 1)) == 0)
+
+/*
+** The bulk kernels process one machine word at a time.  The word type
+** follows the pointer width, so 32-bit targets (the common case for
+** mruby) use 32-bit words and avoid emulated 64-bit arithmetic.
+*/
+
+#define BITOP_DEFINE_UNARY_KERNEL(name, expr_word, expr_byte)                \
+static void                                                                  \
+name(unsigned char *dst, const unsigned char *src, mrb_int len)              \
+{                                                                            \
+  mrb_int off = 0;                                                           \
+  if (BITOP_ALIGNED((uintptr_t)dst | (uintptr_t)src)) {                      \
+    bitop_word_alias *dw = (bitop_word_alias*)dst;                           \
+    const bitop_word_alias *sw = (const bitop_word_alias*)src;               \
+    mrb_int words = len / BITOP_WORD_SIZE;                                   \
+    mrb_int i = 0;                                                           \
+    for (; i + 4 <= words; i += 4) {                                         \
+      bitop_word s0 = sw[i], s1 = sw[i+1], s2 = sw[i+2], s3 = sw[i+3];       \
+      dw[i]   = expr_word(s0);                                               \
+      dw[i+1] = expr_word(s1);                                               \
+      dw[i+2] = expr_word(s2);                                               \
+      dw[i+3] = expr_word(s3);                                               \
+    }                                                                        \
+    for (; i < words; i++) {                                                 \
+      dw[i] = expr_word(sw[i]);                                              \
+    }                                                                        \
+    off = words * BITOP_WORD_SIZE;                                           \
+  }                                                                          \
+  else                                                                       \
+    BITOP_UNARY_MEMCPY_LOOP(dst, src, len, off, expr_word)                   \
+  for (; off < len; off++) {                                                 \
+    dst[off] = expr_byte(src[off]);                                          \
+  }                                                                          \
+}
+
+#define BITOP_DEFINE_BINARY_KERNEL(name, expr_word, expr_byte)               \
+static void                                                                  \
+name(unsigned char *dst, const unsigned char *lhs,                           \
+     const unsigned char *rhs, mrb_int len)                                  \
+{                                                                            \
+  mrb_int off = 0;                                                           \
+  if (BITOP_ALIGNED((uintptr_t)dst | (uintptr_t)lhs | (uintptr_t)rhs)) {     \
+    bitop_word_alias *dw = (bitop_word_alias*)dst;                           \
+    const bitop_word_alias *lw = (const bitop_word_alias*)lhs;               \
+    const bitop_word_alias *rw = (const bitop_word_alias*)rhs;               \
+    mrb_int words = len / BITOP_WORD_SIZE;                                   \
+    mrb_int i = 0;                                                           \
+    for (; i + 4 <= words; i += 4) {                                         \
+      bitop_word l0 = lw[i], l1 = lw[i+1], l2 = lw[i+2], l3 = lw[i+3];       \
+      bitop_word r0 = rw[i], r1 = rw[i+1], r2 = rw[i+2], r3 = rw[i+3];       \
+      dw[i]   = expr_word(l0, r0);                                           \
+      dw[i+1] = expr_word(l1, r1);                                           \
+      dw[i+2] = expr_word(l2, r2);                                           \
+      dw[i+3] = expr_word(l3, r3);                                           \
+    }                                                                        \
+    for (; i < words; i++) {                                                 \
+      dw[i] = expr_word(lw[i], rw[i]);                                       \
+    }                                                                        \
+    off = words * BITOP_WORD_SIZE;                                           \
+  }                                                                          \
+  else                                                                       \
+    BITOP_BINARY_MEMCPY_LOOP(dst, lhs, rhs, len, off, expr_word)             \
+  for (; off < len; off++) {                                                 \
+    dst[off] = expr_byte(lhs[off], rhs[off]);                                \
+  }                                                                          \
+}
+
+#else /* generic compilers: memcpy word loops only */
+
+#define BITOP_DEFINE_UNARY_KERNEL(name, expr_word, expr_byte)                \
+static void                                                                  \
+name(unsigned char *dst, const unsigned char *src, mrb_int len)              \
+{                                                                            \
+  mrb_int off = 0;                                                           \
+  BITOP_UNARY_MEMCPY_LOOP(dst, src, len, off, expr_word)                     \
+  for (; off < len; off++) {                                                 \
+    dst[off] = expr_byte(src[off]);                                          \
+  }                                                                          \
+}
+
+#define BITOP_DEFINE_BINARY_KERNEL(name, expr_word, expr_byte)               \
+static void                                                                  \
+name(unsigned char *dst, const unsigned char *lhs,                           \
+     const unsigned char *rhs, mrb_int len)                                  \
+{                                                                            \
+  mrb_int off = 0;                                                           \
+  BITOP_BINARY_MEMCPY_LOOP(dst, lhs, rhs, len, off, expr_word)               \
+  for (; off < len; off++) {                                                 \
+    dst[off] = expr_byte(lhs[off], rhs[off]);                                \
+  }                                                                          \
+}
+
+#endif
+
+#define BITOP_NOT_WORD(x)    (~(x))
+#define BITOP_NOT_BYTE(x)    ((unsigned char)~(x))
+#define BITOP_AND_WORD(x, y) ((x) & (y))
+#define BITOP_AND_BYTE(x, y) ((unsigned char)((x) & (y)))
+#define BITOP_OR_WORD(x, y)  ((x) | (y))
+#define BITOP_OR_BYTE(x, y)  ((unsigned char)((x) | (y)))
+#define BITOP_XOR_WORD(x, y) ((x) ^ (y))
+#define BITOP_XOR_BYTE(x, y) ((unsigned char)((x) ^ (y)))
+
+BITOP_DEFINE_UNARY_KERNEL(bitop_not_kernel, BITOP_NOT_WORD, BITOP_NOT_BYTE)
+BITOP_DEFINE_BINARY_KERNEL(bitop_and_kernel, BITOP_AND_WORD, BITOP_AND_BYTE)
+BITOP_DEFINE_BINARY_KERNEL(bitop_or_kernel, BITOP_OR_WORD, BITOP_OR_BYTE)
+BITOP_DEFINE_BINARY_KERNEL(bitop_xor_kernel, BITOP_XOR_WORD, BITOP_XOR_BYTE)
+
+static mrb_int
+bitop_count_bits(const unsigned char *ptr, mrb_int len)
+{
+  mrb_int count = 0;
+  mrb_int off = 0;
+
+#if defined(__GNUC__)
+  if (BITOP_ALIGNED((uintptr_t)ptr)) {
+    const bitop_word_alias *pw = (const bitop_word_alias*)ptr;
+    mrb_int words = len / BITOP_WORD_SIZE;
+    mrb_int i = 0;
+    for (; i + 4 <= words; i += 4) {
+      count += bitop_popcount(pw[i]);
+      count += bitop_popcount(pw[i+1]);
+      count += bitop_popcount(pw[i+2]);
+      count += bitop_popcount(pw[i+3]);
+    }
+    for (; i < words; i++) {
+      count += bitop_popcount(pw[i]);
+    }
+    off = words * BITOP_WORD_SIZE;
+  }
+  else
+#endif
+  {
+    mrb_int aligned_end = len & ~(mrb_int)(BITOP_WORD_SIZE - 1);
+    for (; off < aligned_end; off += BITOP_WORD_SIZE) {
+      bitop_word w;
+      memcpy(&w, ptr + off, BITOP_WORD_SIZE);
+      count += bitop_popcount(w);
+    }
+  }
+  /* Pack the remaining bytes into one word and popcount it once. */
+  if (off < len) {
+    bitop_word w = 0;
+    unsigned int shift = 0;
+    for (; off < len; off++, shift += 8) {
+      w |= (bitop_word)ptr[off] << shift;
+    }
+    count += bitop_popcount(w);
+  }
+  return count;
+}
+
+/*
+ * Converts an offset argument to mrb_int.  Following CRuby's
+ * rb_to_int, non-numeric objects are converted via to_int; the
+ * numeric types are left to mrb_as_int, which handles Float (and
+ * Bigint/Rational/Complex when their gems are present) itself.
+ * to_int is dispatched manually: mrb_type_convert with
+ * MRB_TT_INTEGER would reject a Bigint returned by to_int with
+ * TypeError, while a directly passed Bigint reaches mrb_as_int and
+ * raises RangeError; both paths must agree.
+ */
+static mrb_int
+bitop_offset_from_index(mrb_state *mrb, mrb_value index)
+{
+  switch (mrb_type(index)) {
+  case MRB_TT_INTEGER:
+  case MRB_TT_FLOAT:
+  case MRB_TT_BIGINT:
+  case MRB_TT_RATIONAL:
+  case MRB_TT_COMPLEX:
+    break;
+  default:
+    if (mrb_respond_to(mrb, index, MRB_SYM(to_int))) {
+      mrb_value converted = mrb_funcall_argv(mrb, index, MRB_SYM(to_int), 0, NULL);
+      if (mrb_type(converted) == MRB_TT_INTEGER || mrb_type(converted) == MRB_TT_BIGINT) {
+        index = converted;
+        break;
+      }
+    }
+    mrb_raisef(mrb, E_TYPE_ERROR, "%t cannot be converted to Integer", index);
+  }
+  return mrb_as_int(mrb, index);
+}
+
+/*
+ * Scans "offset" and the optional "lsb_first" keyword argument.
+ * Returns the lsb_first flag (default true).
+ */
+static mrb_bool
+bitop_scan_offset(mrb_state *mrb, mrb_int *offset)
+{
+  mrb_value index;
+  mrb_bool lsb_first;
+  mrb_sym kw_names[1];
+  mrb_value kw_values[1];
+  mrb_kwargs kwargs;
+
+  kw_names[0] = MRB_SYM(lsb_first);
+  kwargs.num = 1;
+  kwargs.required = 0;
+  kwargs.table = kw_names;
+  kwargs.values = kw_values;
+  kwargs.rest = NULL;
+  mrb_get_args(mrb, "o:", &index, &kwargs);
+  if (mrb_undef_p(kw_values[0]) || mrb_true_p(kw_values[0])) {
+    lsb_first = TRUE;
+  }
+  else if (mrb_false_p(kw_values[0])) {
+    lsb_first = FALSE;
+  }
+  else {
+    mrb_raise(mrb, E_ARGUMENT_ERROR, "lsb_first must be true or false");
+  }
+  *offset = bitop_offset_from_index(mrb, index);
+  return lsb_first;
+}
+
+static mrb_int
+bitop_physical_index(mrb_int logical, mrb_bool lsb_first)
+{
+  if (lsb_first) return logical;
+  return (logical & ~(mrb_int)7) | (7 - (logical & 7));
+}
+
+/* Returns 0 or 1, or -1 when offset is beyond the end of str. */
+static int
+bitop_get_bit(mrb_state *mrb, mrb_value str)
+{
+  mrb_int offset, physical;
+  mrb_bool lsb_first = bitop_scan_offset(mrb, &offset);
+
+  if (offset < 0) {
+    mrb_raise(mrb, E_INDEX_ERROR, "bit index out of range");
+  }
+  /* Compare byte indexes to avoid overflowing len * 8. */
+  if (offset / 8 >= RSTRING_LEN(str)) {
+    return -1;
+  }
+  physical = bitop_physical_index(offset, lsb_first);
+  return (((unsigned char)RSTRING_PTR(str)[physical / 8]) >> (physical % 8)) & 1;
+}
+
+static mrb_value
+mrb_str_bit_get(mrb_state *mrb, mrb_value str)
+{
+  int bit = bitop_get_bit(mrb, str);
+  return bit < 0 ? mrb_nil_value() : mrb_fixnum_value(bit);
+}
+
+static mrb_value
+mrb_str_bit_set_p(mrb_state *mrb, mrb_value str)
+{
+  int bit = bitop_get_bit(mrb, str);
+  return bit < 0 ? mrb_nil_value() : mrb_bool_value(bit != 0);
+}
+
+enum bitop_mutation {
+  BITOP_MUT_SET,
+  BITOP_MUT_CLEAR,
+  BITOP_MUT_FLIP
+};
+
+static mrb_value
+bitop_mutate(mrb_state *mrb, mrb_value str, enum bitop_mutation mutation)
+{
+  mrb_int offset, physical;
+  mrb_bool lsb_first = bitop_scan_offset(mrb, &offset);
+  unsigned char *ptr;
+  unsigned char mask;
+
+  if (offset < 0 || offset / 8 >= RSTRING_LEN(str)) {
+    mrb_raise(mrb, E_INDEX_ERROR, "bit index out of range");
+  }
+  mrb_str_modify(mrb, mrb_str_ptr(str));
+  physical = bitop_physical_index(offset, lsb_first);
+  ptr = (unsigned char*)RSTRING_PTR(str);
+  mask = (unsigned char)(1u << (physical % 8));
+  switch (mutation) {
+  case BITOP_MUT_SET:
+    ptr[physical / 8] |= mask;
+    break;
+  case BITOP_MUT_CLEAR:
+    ptr[physical / 8] &= (unsigned char)~mask;
+    break;
+  case BITOP_MUT_FLIP:
+    ptr[physical / 8] ^= mask;
+    break;
+  }
+  return str;
+}
+
+static mrb_value
+mrb_str_bit_set(mrb_state *mrb, mrb_value str)
+{
+  return bitop_mutate(mrb, str, BITOP_MUT_SET);
+}
+
+static mrb_value
+mrb_str_bit_clear(mrb_state *mrb, mrb_value str)
+{
+  return bitop_mutate(mrb, str, BITOP_MUT_CLEAR);
+}
+
+static mrb_value
+mrb_str_bit_flip(mrb_state *mrb, mrb_value str)
+{
+  return bitop_mutate(mrb, str, BITOP_MUT_FLIP);
+}
+
+static mrb_value
+mrb_str_bit_count(mrb_state *mrb, mrb_value str)
+{
+  mrb_get_args(mrb, "");
+  return mrb_int_value(mrb, bitop_count_bits((const unsigned char*)RSTRING_PTR(str), RSTRING_LEN(str)));
+}
+
+/*
+ * Matches CRuby: the result of a non-bang bitwise operation is a
+ * BINARY (ASCII-8BIT) string.  The flag is observable through
+ * String#encoding when mruby-encoding is present, and inert
+ * otherwise.
+ */
+static mrb_value
+bitop_result_str(mrb_state *mrb, mrb_int len)
+{
+  mrb_value result = mrb_str_new(mrb, NULL, len);
+  mrb_str_ptr(result)->flags |= MRB_STR_BINARY;
+  return result;
+}
+
+static mrb_value
+mrb_str_bitwise_not(mrb_state *mrb, mrb_value str)
+{
+  mrb_int len;
+  mrb_value result;
+
+  mrb_get_args(mrb, "");
+  len = RSTRING_LEN(str);
+  result = bitop_result_str(mrb, len);
+  bitop_not_kernel((unsigned char*)RSTRING_PTR(result),
+                   (const unsigned char*)RSTRING_PTR(str), len);
+  return result;
+}
+
+static mrb_value
+mrb_str_bitwise_not_bang(mrb_state *mrb, mrb_value str)
+{
+  unsigned char *ptr;
+
+  mrb_get_args(mrb, "");
+  mrb_str_modify(mrb, mrb_str_ptr(str));
+  ptr = (unsigned char*)RSTRING_PTR(str);
+  bitop_not_kernel(ptr, ptr, RSTRING_LEN(str));
+  return str;
+}
+
+/*
+ * Converts the operand of a binary bitwise operation like CRuby's
+ * StringValue(): a real String passes through, anything else goes
+ * through to_str.  mrb_type_convert cannot be used here because on
+ * MRB_TT_STRING failure it falls back to any_to_s instead of raising.
+ */
+static mrb_value
+bitop_str_operand(mrb_state *mrb, mrb_value other)
+{
+  if (mrb_string_p(other)) {
+    return other;
+  }
+  if (mrb_respond_to(mrb, other, MRB_SYM(to_str))) {
+    mrb_value converted = mrb_funcall_argv(mrb, other, MRB_SYM(to_str), 0, NULL);
+    if (mrb_string_p(converted)) {
+      return converted;
+    }
+  }
+  mrb_raisef(mrb, E_TYPE_ERROR, "%t cannot be converted to String", other);
+}
+
+static void
+bitop_check_length(mrb_state *mrb, mrb_value str, mrb_value other)
+{
+  if (RSTRING_LEN(str) != RSTRING_LEN(other)) {
+    /* mrb_ssize can be narrower than mrb_int; %i reads an mrb_int */
+    mrb_raisef(mrb, E_ARGUMENT_ERROR, "operands must have the same length (%i vs %i)",
+               (mrb_int)RSTRING_LEN(str), (mrb_int)RSTRING_LEN(other));
+  }
+}
+
+typedef void (*bitop_binary_kernel)(unsigned char*, const unsigned char*,
+                                    const unsigned char*, mrb_int);
+
+static mrb_value
+bitop_binary(mrb_state *mrb, mrb_value str, bitop_binary_kernel kernel)
+{
+  mrb_value other, result;
+  mrb_int len;
+
+  mrb_get_args(mrb, "o", &other);
+  other = bitop_str_operand(mrb, other);
+  bitop_check_length(mrb, str, other);
+  len = RSTRING_LEN(str);
+  result = bitop_result_str(mrb, len);
+  kernel((unsigned char*)RSTRING_PTR(result),
+         (const unsigned char*)RSTRING_PTR(str),
+         (const unsigned char*)RSTRING_PTR(other), len);
+  return result;
+}
+
+static mrb_value
+bitop_binary_bang(mrb_state *mrb, mrb_value str, bitop_binary_kernel kernel)
+{
+  mrb_value other;
+  unsigned char *ptr;
+
+  mrb_get_args(mrb, "o", &other);
+  other = bitop_str_operand(mrb, other);
+  bitop_check_length(mrb, str, other);
+  mrb_str_modify(mrb, mrb_str_ptr(str));
+  ptr = (unsigned char*)RSTRING_PTR(str);
+  kernel(ptr, ptr, (const unsigned char*)RSTRING_PTR(other), RSTRING_LEN(str));
+  return str;
+}
+
+static mrb_value
+mrb_str_bitwise_and(mrb_state *mrb, mrb_value str)
+{
+  return bitop_binary(mrb, str, bitop_and_kernel);
+}
+
+static mrb_value
+mrb_str_bitwise_and_bang(mrb_state *mrb, mrb_value str)
+{
+  return bitop_binary_bang(mrb, str, bitop_and_kernel);
+}
+
+static mrb_value
+mrb_str_bitwise_or(mrb_state *mrb, mrb_value str)
+{
+  return bitop_binary(mrb, str, bitop_or_kernel);
+}
+
+static mrb_value
+mrb_str_bitwise_or_bang(mrb_state *mrb, mrb_value str)
+{
+  return bitop_binary_bang(mrb, str, bitop_or_kernel);
+}
+
+static mrb_value
+mrb_str_bitwise_xor(mrb_state *mrb, mrb_value str)
+{
+  return bitop_binary(mrb, str, bitop_xor_kernel);
+}
+
+static mrb_value
+mrb_str_bitwise_xor_bang(mrb_state *mrb, mrb_value str)
+{
+  return bitop_binary_bang(mrb, str, bitop_xor_kernel);
+}
+
+void
+mrb_mruby_string_bitops_gem_init(mrb_state *mrb)
+{
+  struct RClass *s = mrb->string_class;
+
+  mrb_define_method_id(mrb, s, MRB_SYM(bit_get), mrb_str_bit_get, MRB_ARGS_REQ(1)|MRB_ARGS_KEY(1, 0));
+  mrb_define_method_id(mrb, s, MRB_SYM_Q(bit_set), mrb_str_bit_set_p, MRB_ARGS_REQ(1)|MRB_ARGS_KEY(1, 0));
+  mrb_define_method_id(mrb, s, MRB_SYM(bit_set), mrb_str_bit_set, MRB_ARGS_REQ(1)|MRB_ARGS_KEY(1, 0));
+  mrb_define_method_id(mrb, s, MRB_SYM(bit_clear), mrb_str_bit_clear, MRB_ARGS_REQ(1)|MRB_ARGS_KEY(1, 0));
+  mrb_define_method_id(mrb, s, MRB_SYM(bit_flip), mrb_str_bit_flip, MRB_ARGS_REQ(1)|MRB_ARGS_KEY(1, 0));
+  mrb_define_method_id(mrb, s, MRB_SYM(bit_count), mrb_str_bit_count, MRB_ARGS_NONE());
+  mrb_define_method_id(mrb, s, MRB_SYM(bitwise_not), mrb_str_bitwise_not, MRB_ARGS_NONE());
+  mrb_define_method_id(mrb, s, MRB_SYM_B(bitwise_not), mrb_str_bitwise_not_bang, MRB_ARGS_NONE());
+  mrb_define_method_id(mrb, s, MRB_SYM(bitwise_and), mrb_str_bitwise_and, MRB_ARGS_REQ(1));
+  mrb_define_method_id(mrb, s, MRB_SYM_B(bitwise_and), mrb_str_bitwise_and_bang, MRB_ARGS_REQ(1));
+  mrb_define_method_id(mrb, s, MRB_SYM(bitwise_or), mrb_str_bitwise_or, MRB_ARGS_REQ(1));
+  mrb_define_method_id(mrb, s, MRB_SYM_B(bitwise_or), mrb_str_bitwise_or_bang, MRB_ARGS_REQ(1));
+  mrb_define_method_id(mrb, s, MRB_SYM(bitwise_xor), mrb_str_bitwise_xor, MRB_ARGS_REQ(1));
+  mrb_define_method_id(mrb, s, MRB_SYM_B(bitwise_xor), mrb_str_bitwise_xor_bang, MRB_ARGS_REQ(1));
+}
+
+void
+mrb_mruby_string_bitops_gem_final(mrb_state *mrb)
+{
+}

--- a/mrbgems/mruby-string-bitops/src/string_bitops.c
+++ b/mrbgems/mruby-string-bitops/src/string_bitops.c
@@ -10,6 +10,7 @@
  */
 #include <mruby.h>
 #include <mruby/string.h>
+#include <mruby/internal.h>
 #include <string.h>
 #include <stdint.h>
 #include <limits.h>
@@ -209,10 +210,16 @@ BITOP_DEFINE_BINARY_KERNEL(bitop_and_kernel, BITOP_AND_WORD, BITOP_AND_BYTE)
 BITOP_DEFINE_BINARY_KERNEL(bitop_or_kernel, BITOP_OR_WORD, BITOP_OR_BYTE)
 BITOP_DEFINE_BINARY_KERNEL(bitop_xor_kernel, BITOP_XOR_WORD, BITOP_XOR_BYTE)
 
-static mrb_int
+/*
+ * The maximum count is len * 8, which can exceed MRB_INT_MAX on
+ * 32-bit mrb_int builds for strings over 256MiB, so accumulate in
+ * uint64_t; whether the total fits in mrb_int is decided when boxing
+ * the return value.
+ */
+static uint64_t
 bitop_count_bits(const unsigned char *ptr, mrb_int len)
 {
-  mrb_int count = 0;
+  uint64_t count = 0;
   mrb_int off = 0;
 
 #if defined(__GNUC__)
@@ -414,8 +421,18 @@ mrb_str_bit_flip(mrb_state *mrb, mrb_value str)
 static mrb_value
 mrb_str_bit_count(mrb_state *mrb, mrb_value str)
 {
+  uint64_t count;
+
   mrb_get_args(mrb, "");
-  return mrb_int_value(mrb, bitop_count_bits((const unsigned char*)RSTRING_PTR(str), RSTRING_LEN(str)));
+  count = bitop_count_bits((const unsigned char*)RSTRING_PTR(str), RSTRING_LEN(str));
+  if (count <= (uint64_t)MRB_INT_MAX) {
+    return mrb_int_value(mrb, (mrb_int)count);
+  }
+#ifdef MRB_USE_BIGINT
+  return mrb_bint_new_uint64(mrb, count);
+#else
+  mrb_raise(mrb, E_RANGE_ERROR, "bit count too big for Integer");
+#endif
 }
 
 /*

--- a/mrbgems/mruby-string-bitops/src/string_bitops.c
+++ b/mrbgems/mruby-string-bitops/src/string_bitops.c
@@ -288,7 +288,7 @@ bitop_offset_from_index(mrb_state *mrb, mrb_value index)
         break;
       }
     }
-    mrb_raisef(mrb, E_TYPE_ERROR, "%t cannot be converted to Integer", index);
+    mrb_raisef(mrb, E_TYPE_ERROR, "%Y cannot be converted to Integer", index);
   }
   return mrb_as_int(mrb, index);
 }
@@ -493,7 +493,7 @@ bitop_str_operand(mrb_state *mrb, mrb_value other)
       return converted;
     }
   }
-  mrb_raisef(mrb, E_TYPE_ERROR, "%t cannot be converted to String", other);
+  mrb_raisef(mrb, E_TYPE_ERROR, "%Y cannot be converted to String", other);
 }
 
 static void

--- a/mrbgems/mruby-string-bitops/test/string_bitops.rb
+++ b/mrbgems/mruby-string-bitops/test/string_bitops.rb
@@ -1,0 +1,211 @@
+# Tests for mruby-string-bitops
+# Ported from CRuby [Feature #22118] test/ruby/test_string.rb
+
+assert('String#bit_get') do
+  s = "\xAA\x80"
+  assert_equal 0, s.bit_get(0)
+  assert_equal 1, s.bit_get(1)
+  assert_equal 1, s.bit_get(7)
+  assert_equal 1, s.bit_get(0, lsb_first: false)
+  assert_equal 0, s.bit_get(1, lsb_first: false)
+  assert_equal 1, s.bit_get(8, lsb_first: false)
+  assert_nil s.bit_get(16)
+  assert_raise(IndexError) { s.bit_get(-1) }
+  assert_raise(ArgumentError) { s.bit_get(0, lsb_first: nil) }
+  # CRuby raises ArgumentError for offsets too large to represent.
+  # mruby has no Bignum bit offsets and raises RangeError instead:
+  # without mruby-bigint the power itself overflows, with it the
+  # offset conversion rejects the Bigint.  Either way this compiles
+  # in every build configuration (a float literal like 1e30 would
+  # not compile under MRB_NO_FLOAT).
+  assert_raise(RangeError) { s.bit_get(2 ** 100) }
+
+  # The Float path of the offset conversion, built without a float
+  # literal so MRB_NO_FLOAT builds can still compile this file.
+  if 1.respond_to?(:to_f)
+    huge = (1 << 30).to_f
+    huge = huge * huge * 16  # 2.0**64, beyond mrb_int in any build
+    assert_raise(RangeError) { s.bit_get(huge) }
+  end
+
+  # Offsets are converted with to_int like CRuby's rb_to_int.
+  o = Object.new
+  def o.to_int
+    1
+  end
+  assert_equal 1, s.bit_get(o)
+  assert_raise(TypeError) { s.bit_get("1") }
+
+  # A to_int returning a value beyond mrb_int raises RangeError, the
+  # same as passing such a value directly.  Without mruby-bigint the
+  # power itself raises RangeError; with it, the Bigint reaches the
+  # offset conversion.  Both configurations end in RangeError.
+  big = Object.new
+  def big.to_int
+    2 ** 100
+  end
+  assert_raise(RangeError) { s.bit_get(big) }
+end
+
+assert('String#bit_set?') do
+  s = "\xAA\x80"
+  assert_equal false, s.bit_set?(0)
+  assert_equal true, s.bit_set?(1)
+  assert_equal true, s.bit_set?(7)
+  assert_equal true, s.bit_set?(0, lsb_first: false)
+  assert_equal false, s.bit_set?(1, lsb_first: false)
+  assert_equal true, s.bit_set?(8, lsb_first: false)
+  assert_nil s.bit_set?(16)
+  assert_raise(IndexError) { s.bit_set?(-1) }
+  assert_raise(ArgumentError) { s.bit_set?(0, lsb_first: nil) }
+  assert_raise(RangeError) { s.bit_set?(2 ** 100) }
+end
+
+assert('String#bit_set, #bit_clear, #bit_flip') do
+  s = "\x00"
+  assert_equal s.object_id, s.bit_set(1).object_id
+  assert_equal "\x02", s
+  assert_equal s.object_id, s.bit_clear(1).object_id
+  assert_equal "\x00", s
+  assert_equal s.object_id, s.bit_flip(1).object_id
+  assert_equal "\x02", s
+  s.bit_flip(1)
+  assert_equal "\x00", s
+
+  s.bit_set(1, lsb_first: false)
+  assert_equal "\x40", s
+  s.bit_clear(1, lsb_first: false)
+  assert_equal "\x00", s
+
+  s = "\x00\x00"
+  s.bit_set(8, lsb_first: false)
+  assert_equal "\x00\x80", s
+  s.bit_clear(8, lsb_first: false)
+  assert_equal "\x00\x00", s
+  s.bit_flip(8, lsb_first: false)
+  assert_equal "\x00\x80", s
+
+  assert_raise(IndexError) { "\x00".bit_set(8) }
+  assert_raise(IndexError) { "\x00".bit_set(-1) }
+  assert_raise(IndexError) { "\x00".bit_clear(8) }
+  assert_raise(IndexError) { "\x00".bit_clear(-1) }
+  assert_raise(IndexError) { "\x00".bit_flip(8) }
+  assert_raise(IndexError) { "\x00".bit_flip(-1) }
+  assert_raise(ArgumentError) { "\x00".bit_set(0, lsb_first: nil) }
+  assert_raise(FrozenError) { "\x00".freeze.bit_set(0) }
+
+  shared = "fooXbar".split("X").last
+  shared.bit_set(0)
+  assert_equal "car", shared
+end
+
+assert('String#bit_count') do
+  assert_equal 0, "".bit_count
+  assert_equal 0, "\x00".bit_count
+  assert_equal 8, "\xFF".bit_count
+  assert_equal 8, "\xAA\xF0".bit_count
+  assert_raise(ArgumentError) { "\x00".bit_count(0) }
+  assert_raise(ArgumentError) { "\x00".bit_count(lsb_first: false) }
+end
+
+assert('String#bit_count (long strings)') do
+  # Exercise the word-at-a-time and unrolled paths.
+  assert_equal 0, ("\x00" * 100).bit_count
+  assert_equal 800, ("\xFF" * 100).bit_count
+  assert_equal 400, ("\xAA" * 100).bit_count
+  assert_equal 4 * 33, ("\x0F" * 33).bit_count
+  # 24 bytes: embedded (and thus only 4-byte aligned on 64-bit
+  # builds), exercising the unaligned memcpy word loop with no tail.
+  assert_equal 8 * 24, ("\xFF" * 24).bit_count
+  # 20 bytes: unaligned memcpy word loop plus a 4-byte tail on 64-bit.
+  assert_equal 4 * 20, ("\x0F" * 20).bit_count
+end
+
+assert('String#bitwise_not and #bitwise_not!') do
+  s = "\x00\xAA"
+  result = s.bitwise_not
+  assert_equal "\xFF\x55", result
+  assert_not_equal s.object_id, result.object_id
+  assert_equal "\x00\xAA", s
+
+  assert_equal s.object_id, s.bitwise_not!.object_id
+  assert_equal "\xFF\x55", s
+
+  # Like CRuby, the non-bang result is a BINARY string; observable
+  # only when mruby-encoding is in the build.
+  if "".respond_to?(:encoding)
+    assert_equal Encoding::BINARY, "\x00\xAA".bitwise_not.encoding
+  end
+
+  assert_raise(FrozenError) { "\x00".freeze.bitwise_not! }
+end
+
+assert('String#bitwise_and, #bitwise_or, #bitwise_xor') do
+  assert_equal "\xC0", "\xF0".bitwise_and("\xCC")
+  assert_equal "\xFC", "\xF0".bitwise_or("\x0C")
+  assert_equal "\x3C", "\xF0".bitwise_xor("\xCC")
+
+  s = "\xF0"
+  assert_equal s.object_id, s.bitwise_and!("\xCC").object_id
+  assert_equal "\xC0", s
+  assert_equal s.object_id, s.bitwise_or!("\x0C").object_id
+  assert_equal "\xCC", s
+  assert_equal s.object_id, s.bitwise_xor!("\xFF").object_id
+  assert_equal "\x33", s
+
+  # Operands are converted with to_str like CRuby's StringValue.
+  o = Object.new
+  def o.to_str
+    "\xCC"
+  end
+  assert_equal "\xC0", "\xF0".bitwise_and(o)
+  t = "\xF0"
+  t.bitwise_and!(o)
+  assert_equal "\xC0", t
+
+  if "".respond_to?(:encoding)
+    assert_equal Encoding::BINARY, "\xF0".bitwise_and("\xCC").encoding
+  end
+
+  # Length mismatch: other longer, shorter, and empty.
+  assert_raise(ArgumentError) { "\xF0".bitwise_and("\x00\x00") }
+  assert_raise(ArgumentError) { "\xF0".bitwise_and("") }
+  assert_raise(ArgumentError) { "\xF0".bitwise_or("\x00\x00") }
+  assert_raise(ArgumentError) { "\xF0".bitwise_or("") }
+  assert_raise(ArgumentError) { "\xF0".bitwise_xor("\x00\x00") }
+  assert_raise(ArgumentError) { "\xF0".bitwise_xor("") }
+  assert_raise(ArgumentError) { "\xF0".bitwise_and!("") }
+  assert_raise(ArgumentError) { "\xF0".bitwise_or!("") }
+  assert_raise(ArgumentError) { "\xF0".bitwise_xor!("") }
+  assert_raise(ArgumentError) { "\x00\x00".bitwise_or!("\x00") }
+  assert_raise(TypeError) { "\x00".bitwise_or(nil) }
+  assert_raise(TypeError) { "\x00".bitwise_or(0) }
+  assert_raise(FrozenError) { "\x00".freeze.bitwise_xor!("\x00") }
+end
+
+assert('String bitwise operations (long strings)') do
+  a = "\xAA" * 41
+  b = "\x0F" * 41
+  assert_equal "\x0A" * 41, a.bitwise_and(b)
+  assert_equal "\xAF" * 41, a.bitwise_or(b)
+  assert_equal "\xA5" * 41, a.bitwise_xor(b)
+  assert_equal "\x55" * 41, a.bitwise_not
+  assert_equal "\x00" * 41, a.bitwise_xor(a)
+
+  c = a.dup
+  c.bitwise_xor!(b)
+  c.bitwise_xor!(b)
+  assert_equal a, c
+
+  # 20-byte strings are embedded (only 4-byte aligned on 64-bit
+  # builds) and exercise the unaligned memcpy word loop of each
+  # kernel, including a 4-byte tail.
+  e = "\xAA" * 20
+  f = "\x0F" * 20
+  assert_equal "\x0A" * 20, e.bitwise_and(f)
+  assert_equal "\xAF" * 20, e.bitwise_or(f)
+  assert_equal "\xA5" * 20, e.bitwise_xor(f)
+  assert_equal "\x55" * 20, e.bitwise_not
+  e.bitwise_xor!(f)
+  assert_equal "\xA5" * 20, e
+end


### PR DESCRIPTION
Implement String bit operations from CRuby
(spec in https://bugs.ruby-lang.org/issues/22118): `bit_get`, `bit_set?`, `bit_set`, `bit_clear`, `bit_flip`, `bit_count`, and `bitwise_not/and/or/xor` with their bang`!` variants.

The port minds mruby-specific concerns: the bulk kernels use pointer-width words so 32-bit targets avoid emulated 64-bit arithmetic, word-aligned buffers get true word loads even on cores without unaligned access support (e.g. Cortex-M0+), and bit offsets are `mrb_int` with no Bignum path. See the gem's README.md for details and the intentional differences from CRuby.

I didn't add this gem to any gembox. @matz I leave this matter to you

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `mruby-string-bitops` with String bit access, mutation, counting, inversion, and binary bitwise operations.
  * Supports configurable bit order, operand conversion, large strings, and both in-place and non-mutating variants.
  * Added validation for invalid offsets, mismatched lengths, frozen strings, and unsupported inputs.

* **Documentation**
  * Added comprehensive usage guidance, examples, return values, errors, encoding behavior, and compatibility notes.

* **Tests**
  * Added coverage for bit operations, coercion, edge cases, encodings, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->