### PR TITLE
CONTRIBUTING.md: name a protocol that `convert_type()` still dispatches

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -205,7 +205,7 @@ reason; where speed matters, define a C fast path (conventionally named with a
 
 The rule is about the responsibility of the function, not about the presence of
 `mrb_funcall*()`. Entering the VM is legitimate where dispatch is itself the
-specification: `convert_type()` in `src/object.c` for the `to_str` protocol,
+specification: `convert_type()` in `src/object.c` for the `to_proc` protocol,
 `mrb_obj_new()` in `src/class.c` running `initialize` and the `inherited`,
 `included` and `method_missing` hooks, the default proc in `src/hash.c`, and
 the `to_a` and `to_enum` delegations in `src/array.c`. When you rely on such a


### PR DESCRIPTION
## What

`CONTRIBUTING.md` cites `convert_type()` as serving the `to_str` protocol.
Nothing in the tree dispatches `to_str` any more, so the example names a use
that no longer exists.

## Why it currently reads as a contradiction

Two sections disagree on the surface.

`Coding conventions > Argument conversion`:

> mruby has no implicit conversion protocol, so do not dispatch `to_int` or
> `to_str` to convert an argument.

`Coding conventions > C code > Avoid re-entering the VM from C`:

> Entering the VM is legitimate where dispatch is itself the specification:
> `convert_type()` in `src/object.c` for the `to_str` protocol, ...

The second section's claim holds. `convert_type()` receives the method to
dispatch as an argument, so entering the VM is precisely its job, and the
function is rightly listed as a case the rule does not forbid. What is stale
is only the protocol chosen to illustrate it.

## Checking the tree

`to_str` and `to_int` appear in the C sources only as method definitions
(`Integer#to_int`, `String#to_str`), never as a method being dispatched.
`convert_type()` is reached through `mrb_type_convert()` and
`mrb_type_convert_check()`, which have four callers between them, and every
one of them passes something else:

- `src/vm.c:791` passes `to_proc`, converting a block argument
- `src/string.c:2271` passes `to_s`
- `mrbgems/mruby-kernel-ext/src/kernel.c:239` passes `to_s`
- `mrbgems/mruby-kernel-ext/src/kernel.c:256` passes `to_a`

## Choice of wording

This picks `to_proc` because converting a block argument cannot be anything
but a dispatch, which is the property the sentence illustrates. `to_s` fits
the same line length if you prefer it, and dropping the example label
entirely in favour of something like "whose dispatched method is its own
argument" would also work. Happy to change to either.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated C coding guidance to use the `to_proc` protocol as the example of legitimate VM re-entry through type conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->