### PR TITLE
mruby-range-ext: pass the converted argument to `Array#last`

### DIFF
--- a/mrbgems/mruby-range-ext/mrblib/range.rb
+++ b/mrbgems/mruby-range-ext/mrblib/range.rb
@@ -50,7 +50,7 @@ class Range
     nv = args[0]
     n = nv.__to_int
     raise ArgumentError, "negative array size (or size too big)" unless 0 <= n
-    return self.to_a.last(nv)
+    return self.to_a.last(n)
   end
 
   ##

--- a/mrbgems/mruby-range-ext/test/range.rb
+++ b/mrbgems/mruby-range-ext/test/range.rb
@@ -42,6 +42,9 @@ assert('Range#last') do
   assert_raise(RangeError) { (10...).last }
   assert_equal [18, 19, 20], (10..20).last(3)
   assert_equal [17, 18, 19], (10...20).last(3)
+
+  skip unless Object.const_defined?(:Float)
+  assert_equal [18, 19, 20], (10..20).last(3.0)
 end
 
 assert('Range#size') do


### PR DESCRIPTION
`Range#last` converts its argument with `__to_int`, checks the converted value,
and then hands the original object to `Array#last`. The conversion result is
discarded:

```ruby
nv = args[0]
n = nv.__to_int
raise ArgumentError, "negative array size (or size too big)" unless 0 <= n
return self.to_a.last(nv)   # nv, not n
```

So a `Float` argument reaches `Array#last` and fails there, while `Range#first`
in the same file performs the same conversion and uses the converted value:

```ruby
(1..9).first(2.0)  #=> [1, 2]
(1..9).last(2.0)   # ArgumentError: negative array size
```

CRuby returns `[8, 9]` for the second. The error is also not the one
`Range#last` raises for a negative size, which reads "negative array size (or
size too big)" and is reached only when the converted value is negative.

Integer arguments were unaffected, since the converted value is then equal to
the original, which is why the existing tests passed. The test for `Range#last`
covered only Integer arguments, so a `Float` case goes in with the fix, guarded
the same way as the `Float` case in the `Range#first` test.

After the fix:

```ruby
(1..9).last(2)    #=> [8, 9]
(1..9).last(2.0)  #=> [8, 9]
(1..9).last(0)    #=> []
(1..9).last(-1)   # ArgumentError: negative array size (or size too big)
```

`rake test` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved range slicing so numeric arguments with decimal values are handled correctly.
  * Calling `(10..20).last(3.0)` now returns `[18, 19, 20]` as expected.

* **Tests**
  * Added coverage for decimal arguments passed to `Range#last`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->