### PR TITLE
array.c: type check the argument of `Array#last`

### DIFF
--- a/src/array.c
+++ b/src/array.c
@@ -1554,7 +1554,7 @@ mrb_ary_last(mrb_state *mrb, mrb_value self)
     return mrb_nil_value();
   }
 
-  mrb_int size = mrb_integer(mrb_get_arg1(mrb));
+  mrb_int size = mrb_as_int(mrb, mrb_get_arg1(mrb));
   if (size < 0) {
     mrb_raise(mrb, E_ARGUMENT_ERROR, "negative array size");
   }

--- a/test/t/array.rb
+++ b/test/t/array.rb
@@ -265,7 +265,12 @@ assert('Array#last', '15.2.12.5.18') do
 
   a = [1,2,3]
   assert_equal(3, a.last)
+  assert_equal([2,3], a.last(2))
   assert_nil([].last)
+  assert_raise(TypeError) { a.last("2") }
+
+  skip unless Object.const_defined?(:Float)
+  assert_equal([2,3], a.last(2.0))
 end
 
 assert('Array#length', '15.2.12.5.19') do


### PR DESCRIPTION
`Array#last` reads its argument with `mrb_integer()`, which returns the integer
member of the value union without looking at the type:

```c
mrb_int size = mrb_integer(mrb_get_arg1(mrb));
```

So a `Float`, a `String` or `nil` is accepted and misread as a size, while
`Array#first` reads its argument with `mrb_get_args()` and therefore converts a
`Float` and rejects everything else:

```ruby
[1, 2, 3].first(2.9)  #=> [1, 2]
[1, 2, 3].last(2.9)   # ArgumentError: negative array size
[1, 2, 3].last("2")   #=> []
[1, 2, 3].last(nil)   #=> []
```

CRuby returns `[2, 3]` for `last(2.9)` and raises `TypeError` for the other two.

This reads the argument with `mrb_as_int()` instead, which is
`mrb_ensure_int_type()` as `CONTRIBUTING.md` asks for. It is the same idiom
`mrb_ary_delete_at()` already uses in the same file, and it keeps the
`mrb_get_args()` call out that 717f91e5c removed on purpose: that commit
replaced `mrb_get_args(mrb, "|i", &size)` with a raw read, and the conversion
the `i` specifier performed went away with it. BigInt truncation stays the same
as `Array#first`, which still goes through that specifier.

The misread size was rejected when negative and clamped to the array length
otherwise, so the result was wrong rather than unsafe.

After the fix:

```ruby
[1, 2, 3].last(2)    #=> [2, 3]
[1, 2, 3].last(2.9)  #=> [2, 3]
[1, 2, 3].last("2")  # TypeError: String cannot be converted to Integer
[1, 2, 3].last(nil)  # TypeError: nil cannot be converted to Integer
[1, 2, 3].last(-1)   # ArgumentError: negative array size
```

The test for `Array#last` covered only `last` with no argument and the negative
case, so `last(2)`, a `String` argument and a `Float` argument go in with the
fix, the `Float` one guarded the way `test/t/array.rb` already guards `Float`
cases.

`rake test` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `Array#last` argument handling for broader compatibility.
  * Invalid string arguments now correctly raise a `TypeError`.
  * Float arguments are accepted when supported.
  * Retrieving multiple final elements is now covered and behaves correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->