### PR TITLE
symbol.c: copy the name of a symbol that symbol GC can free

### DIFF
--- a/src/symbol.c
+++ b/src/symbol.c
@@ -672,6 +672,29 @@ mrb_sym_name_len(mrb_state *mrb, mrb_sym sym, mrb_int *lenp)
 }
 
 /*
+ * Tells whether symbol GC may free the buffer holding the symbol's name.
+ *
+ * Only dynamic symbols own an individual allocation. Inline symbols carry
+ * their name in the value, presym names are static data and literal names
+ * come from the symbol pool, so none of those is ever freed and a string
+ * may share them.
+ */
+static mrb_bool
+sym_name_freeable_p(mrb_state *mrb, mrb_sym sym)
+{
+#if MRB_SYMBOL_MAX > 0
+  if (SYMBOL_INLINE_P(sym)) return FALSE;
+  if (sym <= MRB_PRESYM_MAX) return FALSE;
+  sym -= MRB_PRESYM_MAX;
+  if (sym > mrb->symidx) return FALSE;
+  return (mrb->sym_flags[sym] & SYM_FL_DYNAMIC) != 0;
+#else
+  (void)mrb; (void)sym;
+  return FALSE;
+#endif
+}
+
+/*
  * Symbol GC: mark and sweep unreferenced dynamic symbols.
  * Called lazily when dynamic symbol count reaches MRB_SYMBOL_MAX.
  */
@@ -978,7 +1001,7 @@ sym_name(mrb_state *mrb, mrb_value vsym)
   const char *name = mrb_sym_name_len(mrb, sym, &len);
 
   mrb_assert(name != NULL);
-  if (SYMBOL_INLINE_P(sym)) {
+  if (SYMBOL_INLINE_P(sym) || sym_name_freeable_p(mrb, sym)) {
     return mrb_str_new_frozen(mrb, name, len);
   }
   return mrb_str_new_static_frozen(mrb, name, len);
@@ -1154,7 +1177,8 @@ sym_inspect(mrb_state *mrb, mrb_value sym)
  * sym: The symbol to convert.
  *
  * Returns the mruby string value corresponding to the symbol.
- * If the symbol is an inline symbol, a new string is created.
+ * The name is copied for an inline symbol and for a dynamic symbol, whose
+ * name buffer symbol GC may free while the string is still alive.
  * Otherwise, a static string (sharing the symbol's name buffer) is returned.
  * Returns an undefined value if the symbol is invalid (though this should not happen).
  */
@@ -1169,6 +1193,9 @@ mrb_sym_str(mrb_state *mrb, mrb_sym sym)
     mrb_value str = mrb_str_new(mrb, name, len);
     RSTR_SET_ASCII_FLAG(mrb_str_ptr(str));
     return str;
+  }
+  if (sym_name_freeable_p(mrb, sym)) {
+    return mrb_str_new(mrb, name, len);
   }
   return mrb_str_new_static(mrb, name, len);
 }

--- a/test/t/symbol.rb
+++ b/test/t/symbol.rb
@@ -56,3 +56,22 @@ assert('Symbol, empty name') do
   assert_equal 0, :"".to_s.length
   assert_true :"".is_a?(Symbol)
 end
+
+assert('Symbol#to_s and Symbol#name outlive symbol GC') do
+  # Symbol GC frees the name buffer of a dynamic symbol. A returned string
+  # longer than the embedded limit used to share that buffer instead of
+  # copying it, so every later read of the string was a use after free.
+  name = "gc-target-symbol-" + "a" * 24
+  str = name.to_sym.to_s
+  frozen = name.to_sym.name
+
+  # Reach the dynamic symbol limit so a sweep runs, then hand the freed
+  # blocks to something else.
+  6000.times { |i| "gc-filler-symbol-name-#{i}".to_sym }
+  GC.start
+  reuse = []
+  3000.times { |i| reuse << "z" * 60 + i.to_s }
+
+  assert_equal name, str
+  assert_equal name, frozen
+end


### PR DESCRIPTION
`Symbol#to_s` and `Symbol#name` return a string that shares the symbol's name buffer,
which symbol GC can free.

For a dynamic symbol whose name is longer than `RSTRING_EMBED_LEN_MAX`, `Symbol#to_s`
returns a `RSTR_NOFREE` string pointing straight into the symbol table's name buffer.
Symbol GC does not treat such a string as a reference to the symbol, so it can sweep the
symbol and `mrb_free()` the buffer while the string is still alive. Every later read of
that string is a use after free.

```ruby
str = ("q" * 40).to_sym.to_s
6000.times { |i| "junk-symbol-with-a-long-name-#{i}".to_sym }
GC.start
a = []; 3000.times { |i| a << "Z" * 60 + i.to_s }
p str
```

| | result |
| --- | --- |
| CRuby 4.0.6 | `"qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq"` |
| mruby master | `"junk-symbol-with-a-long-name-4615\x00qqqqqq"` |

The exact garbage varies by run: it is whatever allocation happened to reuse the block.
Here the freed buffer was taken by a later symbol's packed name, so the string reports
that symbol's name plus the packed length byte.

`Symbol#name` has the same problem, and so does anything that keeps the result of
`mrb_obj_as_string()` for a symbol. `MatchData` makes it easy to hit by accident, because
it keeps the subject string for the lifetime of `$~`:

```ruby
md = ("target-" + "b" * 30).to_sym.to_s.match(/target/)
# ... same symbol churn ...
p md.string       #=> "junk-symbol-with-a-long-name-4097\x00bbb"
p md.post_match   #=> "ymbol-with-a-long-name-4097\x00bbb"
```

## Cause

`mrb_sym_str()` hands the raw name pointer to `mrb_str_new_static()`, and
`str_new_static()` copies only when the name fits inline:

```c
if (RSTR_EMBEDDABLE_P(len)) {
  return str_init_embed(mrb_obj_alloc_string(mrb), p, len);
}
return str_init_nofree(mrb_obj_alloc_string(mrb), p, len);
```

That was safe while symbol names lived forever. It no longer is: a dynamic symbol gets an
individual `mrb_malloc()` and symbol GC frees it in phase 3 of `mrb_symbol_gc()`:

```c
mrb_free(mrb, (void*)mrb->symtbl[i]);
mrb->symtbl[i] = NULL;  /* tombstone */
```

Nothing connects the two. `sym_gc_mark_object()` walks classes, ivars, arrays, hashes, env
and the stack looking for `mrb_symbol_p()` values, and `MRB_TT_STRING` falls into its
`default: break;`. A string is the one kind of object that can keep a symbol's name alive
without holding the symbol, and it is exactly the case that is not scanned.

The name length is what decides between safe and corrupt, at `RSTRING_EMBED_LEN_MAX`
(27 on a 64-bit build):

| symbol name length | result after the churn above |
| --- | --- |
| 26 | `"qqqqqqqqqqqqqqqqqqqqqqqqqq"` |
| 27 | `"qqqqqqqqqqqqqqqqqqqqqqqqqqq"` |
| 28 | `"junk-symbol-with-a-long-name"` |

`MRB_SYMBOL_MAX` defaults to 4096, so a default build is affected; only `MRB_SYMBOL_MAX 0`
is immune. Presym and literal symbols are safe, because their names are either static data
or pool allocated and are never individually freed.

## Fix

Copy the name in `mrb_sym_str()` and `sym_name()` when the symbol is one symbol GC can
reclaim, and keep the zero copy path for everything else. Only a dynamic symbol gets an
individual allocation: a presym name is static data, a literal name comes from the symbol
pool and an inline symbol carries its name in the value, so none of those is ever freed.

The cost is one allocation per `to_s` of a long dynamic symbol. Short names were already
copied by `str_init_embed()`, and symbols from source literals, which is nearly all of
them in practice, keep sharing the buffer.

### Alternatives considered

Marking from the string side would mean recognising, during symbol GC, that a `RSTR_NOFREE`
string's pointer lands inside the symbol table, then mapping it back to a symbol index.
That is a linear scan per string over `mrb->symtbl` for a case that copying avoids
outright, and it does not compose with `str_init_nofree()` strings that legitimately point
at static data.

Freezing the returned string does not help either: the problem is the lifetime of the
buffer, not mutation of the string.

### Where the fix belongs

This came up twice in review, on #6993 and on #6995, both times as "a `MatchData` holding a
symbol derived string can outlive the symbol". Neither PR was the right place. The same use
after free reproduces with `Symbol#to_s` alone and no regexp anywhere, and patching
`match_operand()` in mruby-regexp would close the `Regexp#match(:sym)` route while leaving
`Symbol#to_s`, `Symbol#name`, `"#{sym}"` and every other `mrb_obj_as_string()` caller open.

## Verification

`test/t/symbol.rb` gains a test that fails on master and passes with the patch:

```
Fail: Symbol#to_s and Symbol#name outlive symbol GC (core)
 - Assertion[1]
    Expected: "gc-target-symbol-aaaaaaaaaaaaaaaaaaaaaaaa"
      Actual: "gc-filler-symbol-name-4959\x00aaaaaaaaaaaaaa"
```

`rake test` passes on a plain host build (1943 assertions, 0 KO, 0 crash) and on
`build_config/clang-asan.rb` (2120 assertions, 0 KO, 0 crash).

Under ASan the use after free is reported directly. The shortest repro needs a small
`MRB_SYMBOL_MAX` so the sweep runs early, and in that shape the tombstone guard from #7018
has to be in place first, otherwise the null deref in `migrate_to_hash_table()` lands
before this bug can be read back. With `MRB_SYMBOL_MAX=16` and that guard applied:

```ruby
s = ("dynamic-target-name-" + "a" * 12).to_sym.to_s
40.times { |i| "filler-symbol-name-#{i}".to_sym }
p s
```

```
==236534==ERROR: AddressSanitizer: heap-use-after-free on address 0x7c0f05fe05d1
READ of size 1 at 0x7c0f05fe05d1 thread T0
    #0 str_escape        src/string.c:1586
    #1 mrb_str_inspect   src/string.c:3240
    #2 mrb_vm_exec       src/vm.c:2947
    ...
freed by thread T0 here:
    #2 mrb_free          src/gc.c:387
    #3 mrb_symbol_gc     src/symbol.c:838
    #4 sym_intern        src/symbol.c:428
    #5 mrb_intern        src/symbol.c:465
    #6 mrb_intern_str    src/symbol.c:512
```

With the patch the same build prints `"dynamic-target-name-aaaaaaaaaaaa"` and ASan is
silent. The two changes are independent; only that shortcut repro is shared.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `Symbol#to_s` and `Symbol#name` so returned strings remain valid after dynamic symbol garbage collection and memory reuse.
  * Improved handling of symbol names to prevent returned strings from referencing reclaimable storage.

* **Tests**
  * Added regression coverage for symbol string validity after garbage collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->