### PR TITLE
mruby-regexp: reject an empty group name

### DIFF
--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -665,6 +665,7 @@ compile_atom(re_compiler *c)
           cap_name = c->p;
           while (peek(c) != '>' && peek(c) >= 0) next_char(c);
           if (peek(c) != '>') compile_error(c, "unterminated named capture");
+          if (c->p == cap_name) compile_error(c, "group name is empty");
           cap_name_len = (uint16_t)(c->p - cap_name);
           next_char(c);  /* skip > */
         }
@@ -811,6 +812,7 @@ compile_atom(re_compiler *c)
       const char *name = c->p;
       while (peek(c) != close && peek(c) >= 0) next_char(c);
       if (peek(c) != close) compile_error(c, "unterminated backreference name");
+      if (c->p == name) compile_error(c, "group name is empty");
       uint16_t name_len = (uint16_t)(c->p - name);
       next_char(c);  /* skip the closing > or ' */
 

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -1197,6 +1197,20 @@ assert("Regexp - named captures") do
   assert_equal "2026", md["year"]
 end
 
+assert("Regexp - empty group name") do
+  # (?<>x) used to compile and answer to "", and in /x mode the stored name
+  # pointed into the preprocessing buffer the compiler frees on the way out.
+  assert_raise(RegexpError) { Regexp.new("(?<>x)") }
+  assert_raise(RegexpError) { Regexp.new("(?<>x) ", Regexp::EXTENDED) }
+  assert_raise(RegexpError) { Regexp.new("(?<>x)\\k<>") }
+  assert_raise(RegexpError) { Regexp.new("\\k<>") }
+  assert_raise(RegexpError) { Regexp.new("\\k''") }
+
+  # lookbehind is not a named group and is unaffected
+  assert_equal "b", Regexp.new("(?<=a)b").match("ab")[0]
+  assert_nil Regexp.new("(?<!a)b").match("ab")
+end
+
 assert("MatchData#[] - negative index") do
   md = /(a)(b)/.match("ab")
   assert_equal "b", md[-1]


### PR DESCRIPTION
`compile_atom()` accepts `(?<>` as a named capture whose name is zero bytes long.
CRuby rejects an empty group name at compile time; mruby registers it, and the
group is then reachable through every named capture API under the name `""`.

```ruby
re = Regexp.new("(?<>x)")   # CRuby: RegexpError (group name is empty)
re.named_captures           # mruby: {"" => 1}
re.match("x")[""]           # mruby: "x"
```

The backreference form goes the same way once such a group exists:

```ruby
Regexp.new("(?<>x)\k<>").match("xx")   # mruby: matches   CRuby: RegexpError
```

`\k<>` on its own raises in mruby, but for the wrong reason: it resolves to no
group and falls out of the range check as `undefined group name reference`. It
stops raising as soon as the pattern has an empty named group to resolve to,
which is the case above.

## Cause

The scan in the `(?<name>` branch stops immediately when the next byte is `>`,
`cap_name_len` is 0, and nothing tests it. `cap_name` is non-NULL, so the
registration block stores the entry like any other. The `\k<name>` branch scans
the same way.

## The arena guard leaves a dangling pointer

`mrb_re_compile()` copies capture names into an arena the regexp owns, because
until that point they point into the pattern source, which in `/x` mode is a
buffer the function frees before returning. The copy is guarded on the *total*
length of all names, so for a pattern whose named groups are all empty named,
`total` is 0, the arena is never allocated, and every
`pat->named_captures[i].name` keeps pointing at `c.stripped`:

```ruby
Regexp.new("(?<>x) ", Regexp::EXTENDED).named_captures   # mruby: {"" => 1}
```

Nothing dereferences it today, because every reader passes the matching
`name_len` of 0 to `mrb_str_new()` or `memcmp()`, so this is a latent condition
rather than a reproducible fault. Rejecting the empty name in the parser closes
it: `total` is now zero only when there are no named captures at all, which is
what the guard's comment says.

## Change

Two checks, one in each branch, using CRuby's `group name is empty` message:

```console
$ ./build/host/bin/mruby -e 'Regexp.new("(?<>x)")'
-e:0: group name is empty: /(?<>x)/ (RegexpError)
```

`(?<=...)` and `(?<!...)` are taken by the lookbehind branch, which tests
`c->p[2]`, so neither reaches the new check.

## Testing

`rake test` passes: 1943 tests, 0 failures, 0 crashes. Behaviour checked against
CRuby 4.0.6.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid regular expressions with empty named capture-group names or named backreferences now correctly raise `RegexpError`.
  * Extended-mode patterns now apply the same validation consistently.
  * Existing lookbehind behavior remains unchanged.

* **Tests**
  * Added regression coverage for invalid empty names and valid lookbehind expressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->