### PR TITLE
vm.c: restore the GC arena in the allocating inline opcodes

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -2077,9 +2077,11 @@ vm_op_getidx(mrb_state *mrb, uint32_t a, mrb_sym *midp)
   else if (tt == MRB_TT_HASH) {
     /* optimize only for Hash class; subclasses/singleton may override [] */
     if (mrb_obj_ptr(va)->c != mrb->hash_class) goto getidx_fallback;
+    int ai = mrb_gc_arena_save(mrb);
     va = mrb_hash_get(mrb, va, vb);
     ci = mrb->c->ci;
     regs[a] = va;
+    mrb_gc_arena_restore(mrb, ai);
     return VM_NEXT;
   }
   else if (tt == MRB_TT_STRING) {
@@ -2089,9 +2091,13 @@ vm_op_getidx(mrb_state *mrb, uint32_t a, mrb_sym *midp)
     case MRB_TT_INTEGER:
     case MRB_TT_STRING:
     case MRB_TT_RANGE:
-      va = mrb_str_aref(mrb, va, vb, mrb_undef_value());
-      regs[a] = va;
-      return VM_NEXT;
+      {
+        int ai = mrb_gc_arena_save(mrb);
+        va = mrb_str_aref(mrb, va, vb, mrb_undef_value());
+        regs[a] = va;
+        mrb_gc_arena_restore(mrb, ai);
+        return VM_NEXT;
+      }
     default:
       break;
     }
@@ -2127,10 +2133,13 @@ vm_op_getidx0(mrb_state *mrb, uint32_t a, uint16_t b, mrb_sym *midp)
     {
       /* same as the Hash branch of vm_op_getidx(): mrb_hash_get() can run a
          default proc and move the stack, so take the result first and store
-         it through the refreshed `regs` */
+         it through the refreshed `regs`. The arena is restored only after
+         that store, which is what roots the result. */
+      int ai = mrb_gc_arena_save(mrb);
       mrb_value val = mrb_hash_get(mrb, recv, mrb_fixnum_value(0));
       ci = mrb->c->ci;
       regs[a] = val;
+      mrb_gc_arena_restore(mrb, ai);
     }
     return VM_NEXT;
   }
@@ -2158,9 +2167,13 @@ vm_op_setidx(mrb_state *mrb, uint32_t a, mrb_sym *midp)
   case MRB_TT_HASH:
     /* optimize only for Hash class; subclasses/singleton may override []= */
     if (mrb_obj_ptr(va)->c != mrb->hash_class) goto setidx_fallback;
-    mrb_hash_set(mrb, va, vb, vc);
-    ci = mrb->c->ci;
-    regs[a] = vc;
+    {
+      int ai = mrb_gc_arena_save(mrb);
+      mrb_hash_set(mrb, va, vb, vc);
+      ci = mrb->c->ci;
+      regs[a] = vc;
+      mrb_gc_arena_restore(mrb, ai);
+    }
     return VM_NEXT;
   default:
   setidx_fallback:
@@ -3285,7 +3298,10 @@ RETRY_TRY_BLOCK:
     break
 #endif
 #ifdef MRB_USE_BIGINT
-#define OP_MATH_OVERFLOW_INT(op,x,y) regs[a] = mrb_bint_##op##_ii(mrb,x,y)
+#define OP_MATH_OVERFLOW_INT(op,x,y) do {                                   \
+  regs[a] = mrb_bint_##op##_ii(mrb,x,y);                                    \
+  mrb_gc_arena_restore(mrb, ai);                                            \
+} while (0)
 #else
 #define OP_MATH_OVERFLOW_INT(op,x,y) goto L_INT_OVERFLOW
 #endif

--- a/test/t/gc.rb
+++ b/test/t/gc.rb
@@ -115,3 +115,87 @@ assert('GC.generational_mode=') do
     GC.generational_mode = origin
   end
 end
+
+# The inline `[]`, `[]=` and arithmetic opcodes answer from C without a method
+# call, so the arena restore that every cfunc return performs never runs for
+# them.  What they allocate then stays arena-protected for the rest of the
+# enclosing method.  `GC.stat` is itself a cfunc, so it reads the count before
+# its own restore and still sees what the loop pinned.  The loop bodies below
+# are built only from opcodes that do not restore, since a single send in the
+# body would empty the arena and hide the retention.
+
+assert('OP_GETIDX does not retain its result in the GC arena') do
+  s = "hello"
+  GC.start
+  base = GC.stat[:live]
+  i = 0
+  while i < 20000
+    s[1]
+    i += 1
+  end
+  assert_operator GC.stat[:live] - base, :<, 5000
+end
+
+assert('OP_GETIDX does not retain a Hash default in the GC arena') do
+  h = Hash.new { Object.new }
+  GC.start
+  base = GC.stat[:live]
+  i = 0
+  while i < 20000
+    h[1]
+    i += 1
+  end
+  assert_operator GC.stat[:live] - base, :<, 5000
+end
+
+assert('OP_GETIDX0 does not retain a Hash default in the GC arena') do
+  h = Hash.new { Object.new }
+  GC.start
+  base = GC.stat[:live]
+  i = 0
+  while i < 20000
+    h[0]
+    i += 1
+  end
+  assert_operator GC.stat[:live] - base, :<, 5000
+end
+
+assert('OP_SETIDX does not retain a duplicated Hash key in the GC arena') do
+  h = {}
+  k = "a"
+  GC.start
+  base = GC.stat[:live]
+  i = 0
+  while i < 20000
+    h[k] = 1
+    i += 1
+  end
+  assert_operator GC.stat[:live] - base, :<, 5000
+end
+
+assert('OP_ADD does not retain an overflowed Integer in the GC arena') do
+  # The overflow branch promotes to a big integer, so it only exists with
+  # mruby-bigint.  The shift count is a variable because a constant shift is
+  # folded at compile time, and a folded result out of mrb_int range makes the
+  # build fail rather than raise.
+  begin
+    k = 62
+    x = 1 << k
+    x + x
+  rescue RangeError
+    skip "requires mruby-bigint"
+  end
+  # 1 << 30 overflows mrb_int on MRB_INT32 and 1 << 62 on MRB_INT64, so
+  # whichever width this build has, one of the two takes the overflow branch.
+  [30, 62].each do |shift|
+    x = 1 << shift
+    GC.start
+    base = GC.stat[:live]
+    i = 0
+    while i < 20000
+      x + x
+      i += 1
+    end
+    assert_operator GC.stat[:live] - base, :<, 5000
+  end
+end


### PR DESCRIPTION
## The bug

`OP_GETIDX`, `OP_GETIDX0`, `OP_SETIDX` and `OP_MATH` answer from C without going through a method call, so the arena shrink that every cfunc return performs never runs for them. Five of their branches allocate and leave the result in the GC arena, where it stays until the enclosing method returns.

| branch | what it leaves in the arena |
|---|---|
| `OP_GETIDX`, String | the substring `mrb_str_aref()` allocates |
| `OP_GETIDX`, Hash | what a default proc returns |
| `OP_GETIDX0`, Hash | the same |
| `OP_SETIDX`, Hash | the frozen dup `mrb_hash_set()` makes of a String key |
| `OP_MATH_OVERFLOW_INT` | the big integer an `mrb_int` overflow promotes to |

The Array branches return an element that already exists or write through an existing buffer, so they allocate nothing and are left alone. A Hash with a default value rather than a default proc allocates nothing either, and an Integer key needs no dup, which is why the plain shapes look clean.

## What it costs

A loop whose body is built only from opcodes that do not restore pins one object per iteration, and the mark phase then walks all of them, so the loop is quadratic. `GC.stat[:live]` shows the retention directly, at `n` = 20000:

| loop body | before | after |
|---|---|---|
| `s = "hello"; s[1]` | 20003 | 531 |
| `h = Hash.new { Object.new }; h[1]` | 20515 | 205 |
| `h = Hash.new { Object.new }; h[0]` | 20515 | 205 |
| `h = {}; k = "a"; h[k] = 1` | 20004 | 688 |
| `h = {1=>2}; h[1]` | 4 | 4 |
| `a = [0]; a[0] = 1` | 4 | 4 |

The signal is O(`n`) and the residue is O(1). In time, with `while i < n; s[1]; i += 1; end`:

| `n` | `s[1]` before | `s[1]` after | `a[1]`, unaffected |
|---|---|---|---|
| 200000 | 147 ms | 5 ms | 3 ms |
| 400000 | 562 ms | 11 ms | 6 ms |
| 800000 | 2437 ms | 22 ms | 13 ms |

and with `x = 4611686018427387904; while i < n; x + x; i += 1; end`:

| `n` | before | after |
|---|---|---|
| 400000 | 562 ms | 66 ms |
| 800000 | 2336 ms | 130 ms |
| 1600000 | 10758 ms | 253 ms |

## Under `MRB_GC_FIXED_ARENA` they are a hard error

`build_config/ci/gcc-clang.rb` and `build_config/ci/msvc.rb` define `MRB_GC_FIXED_ARENA`, which caps the arena instead of growing it. In such a build none of the five loops is merely slow:

```console
$ ./build/fixedarena/bin/mruby -e 's="hello"; i=0; while i < 100000; s[1]; i+=1; end'
-e:1: arena overflow error (NoMemoryError)
$ ./build/fixedarena/bin/mruby -e 'x=4611686018427387904; i=0; while i < 100000; x+x; i+=1; end'
-e:1: arena overflow error (NoMemoryError)
$ ./build/fixedarena/bin/mruby -e 'h=Hash.new { Object.new }; i=0; while i < 100000; h[1]; i+=1; end'
-e:1:in allocate: NoMemoryError
$ ./build/fixedarena/bin/mruby -e 'h=Hash.new { Object.new }; i=0; while i < 100000; h[0]; i+=1; end'
-e:1:in allocate: NoMemoryError
$ ./build/fixedarena/bin/mruby -e 'h={}; k="a"; i=0; while i < 100000; h[k]=1; i+=1; end'
-e:1: arena overflow error (NoMemoryError)
```

All five raise after roughly 95 iterations, which is `MRB_GC_ARENA_SIZE` less what the setup already holds. The two default-proc loops report from `allocate` rather than with the `arena overflow error` message, since the arena is full when the proc allocates rather than when the opcode stores. All five print `ok` with the restores in place.

## Why this has gone unnoticed

The arena is restored to the baseline `mrb_vm_exec()` saves on entry, and several inline opcodes already restore to it after allocating: `OP_STRING`, `OP_ARRAY`, `OP_ARRAY2`, `OP_ARYCAT`, `OP_ARYSPLAT`, `OP_HASH`, and the String branch of `OP_MATH` a few lines above the macro this changes. So anything in the loop body that either sends or is one of those opcodes empties what the leaking opcode accumulated, and the loop is linear again, at `n` = 20000:

| loop body | growth in `live` |
|---|---|
| `s[1]` | 20003 |
| `s[1]; s.bytesize` (a send) | 531 |
| `s[1]; x = ""` (`OP_STRING`) | 89 |

A loop that indexes a string almost always does something with the result, and doing almost anything with it is a send. What is left is narrow but real, and the memory consequence needs no pathological loop: until the enclosing method returns, every substring is pinned, so a long loop holds the whole run of them live at once even though the program keeps none.

## The fix

Restore the arena around each allocating branch, exactly as the epilogues and the neighbouring opcodes do. The results need no `mrb_gc_protect()`: they are stored into `regs[]`, and the VM stack is a GC root, which is why the cfunc epilogues can shrink unconditionally too.

## The tests

Five assertions at the end of `test/t/gc.rb`, which already reads `GC.stat[:live]`. `GC.stat` is a cfunc, so it runs before the epilogue that would shrink the arena and still sees what the loop pinned. The threshold is `n / 4`, which leaves a factor of 4 below the signal and about 5 above the largest residue measured; a tighter one is a trap, since `GC.interval_ratio = 1000` alone takes the residue to 996.

The `OP_ADD` assertion is guarded rather than tested for. Without `mruby-bigint` the overflow raises `RangeError` instead of promoting, so the guard skips; the shift count is held in a variable because a constant shift is folded at compile time, and a folded result out of `mrb_int` range makes the build fail rather than raise. It then runs over both `1 << 30` and `1 << 62`, so that whichever width the build has, one of the two takes the overflow branch.

## Checked configurations

All at `mruby/mruby@fd6a18284`, with the change applied and reverted.

| build | with the change | without |
|---|---|---|
| host (`MRB_INT64`, bigint) | 1929 OK, 0 KO, 0 Crash | 5 KO |
| `MRB_INT32`, bigint | 1834 OK, 0 KO, 0 Crash | 5 KO |
| `MRB_GC_FIXED_ARENA` | 1929 OK, 0 KO, 0 Crash | |
| `MRB_INT64`, no bigint | 1756 OK, 0 KO, 0 Crash, `OP_ADD` skipped | |
| `MRB_INT32`, no bigint | 1678 OK, 0 KO, 0 Crash, `OP_ADD` skipped | |

The `MRB_INT32` rows are what the `1 << 30` case is for: the `OP_ADD` assertion fails there without the change, so it covers the overflow branch on that width too rather than passing vacuously.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory management during optimized indexing, hash operations, string access, and large-integer arithmetic.
  * Reduced unnecessary retention of temporary objects during repeated operations.

* **Tests**
  * Added regression coverage for memory growth across indexing, hash defaults, key assignment, and overflowing integer calculations.
  * Added compatibility handling for environments without large-integer support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->