### PR TITLE
mruby-regexp: do not truncate a POSIX bracket class name length

### DIFF
--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -271,7 +271,7 @@ class_add_shorthand(re_charclass *cc, int ch)
    Returns FALSE for an unknown name. Semantics are ASCII, like this gem's
    \w/\d shorthands; non-ASCII codepoints are not classified. */
 static mrb_bool
-posix_class_bits(uint8_t *bits, const char *name, uint16_t len)
+posix_class_bits(uint8_t *bits, const char *name, size_t len)
 {
 #define NAME_IS(s) (len == sizeof(s) - 1 && memcmp(name, s, len) == 0)
 #define BSET(ch)   (bits[(ch) >> 3] |= (uint8_t)(1u << ((ch) & 7)))
@@ -409,7 +409,7 @@ compile_charclass(re_compiler *c)
       while (peek(c) >= 0 && peek(c) != ':' && peek(c) != ']') next_char(c);
       if (peek(c) == ':' && c->p + 1 < c->src_end && c->p[1] == ']') {
         uint8_t bits[16] = {0};
-        if (!posix_class_bits(bits, name, (uint16_t)(c->p - name))) {
+        if (!posix_class_bits(bits, name, (size_t)(c->p - name))) {
           compile_error(c, "invalid POSIX bracket class");
         }
         next_char(c);  /* ':' */

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -194,6 +194,12 @@ assert("Regexp - POSIX bracket classes") do
   assert_equal "x", " x".match(/[^[:space:]]/)[0]
   # an unknown class name is an error
   assert_raise(RegexpError) { Regexp.new("[[:bogus:]]") }
+  # The name length used to be truncated with a (uint16_t) cast, so a name
+  # 65536 bytes longer than "alpha" compared equal to "alpha" and compiled
+  # as [[:alpha:]] instead of raising.
+  long = "alpha" + "A" * 65536
+  assert_raise(RegexpError) { Regexp.new("[[:#{long}:]]") }
+  assert_raise(RegexpError) { Regexp.new("[[:^#{long}:]]") }
 end
 
 assert("Regexp - \\b inside character class is backspace") do


### PR DESCRIPTION
`compile_charclass()` passes the length of a POSIX bracket class name to
`posix_class_bits()` through a `uint16_t` cast. The cast is silent, so a name
whose true length is congruent to a valid name's length modulo 65536 is
accepted, and the pattern compiles as the class named by the first few bytes
rather than raising `RegexpError`.

```ruby
name = "alpha" + "A" * 65536      # 65541 bytes, (uint16_t)65541 == 5
re = Regexp.new("[[:#{name}:]]")
# CRuby: RegexpError
# mruby: compiles, and behaves as /[[:alpha:]]/
re.match?("q")                    # mruby: true
re.match?("1")                    # mruby: false
```

The name that was written is not a POSIX bracket class name. mruby compares
only its first five bytes, finds `"alpha"`, and silently accepts the other
65536. The negated form goes down the same branch:

```ruby
name = "digit" + "A" * 65536
Regexp.new("[[:^#{name}:]]")      # mruby: compiles as /[[:^digit:]]/
```

Only lengths congruent to a valid name's length slip through. A name of
exactly 65536 bytes truncates to 0, no `NAME_IS` test matches a zero length,
and the pattern raises as it should.

## Cause

`name` is set right after `[:` and any `^`, and the scan runs to the first `:`
or `]`, so `c->p - name` is a `ptrdiff_t` over the pattern source with no upper
bound; nothing in `mrb_re_compile()` limits the pattern length. The length is
then narrowed at the call site:

```c
if (!posix_class_bits(bits, name, (uint16_t)(c->p - name))) {
  compile_error(c, "invalid POSIX bracket class");
}
```

`posix_class_bits()` takes the length as `uint16_t`, and its `NAME_IS` macro is

```c
#define NAME_IS(s) (len == sizeof(s) - 1 && memcmp(name, s, len) == 0)
```

so the truncated value decides both which literal can match and how many bytes
are compared. With the truncation, `len == 5` and `memcmp(name, "alpha", 5)`
succeeds, `posix_class_bits()` returns `TRUE`, and the `compile_error()` never
fires. The `:` and `]` are then consumed and the bits are merged into the
class, so the trailing filler bytes leave no trace in the compiled pattern.

This stays in bounds. `memcmp()` compares only the truncated number of bytes,
and the name lives in the pattern source, so nothing reads past an allocation.
The bug is a compatibility one: a pattern CRuby rejects compiles here, and it
compiles as something the pattern does not say.

CRuby 4.0.6 raises for both patterns above, with `invalid POSIX bracket type`
followed by the whole pattern. That is Onigmo's `parse_posix_bracket()`: on a
prefix hit it requires the next two bytes to be `:]`, which they are not here.

## Fix

Change `posix_class_bits()`'s `len` to `size_t` and drop the cast. `NAME_IS`
then compares the true length, every over-long name fails the
`len == sizeof(s) - 1` test, `posix_class_bits()` falls through to
`return FALSE`, and the `compile_error()` already at the call site raises with
no new call site and the same message `[[:bogus:]]` produces. The
short-circuit in `NAME_IS` keeps `memcmp()` bounded by the literal, so the
body of the function needs no other edit.

Guarding the `ptrdiff_t` against `UINT16_MAX` before the cast would work too,
but removing the narrowing is preferable to making it loud, and it costs one
parameter type.

## Tests

Two cases in `assert("Regexp - POSIX bracket classes")`, next to the existing
`assert_raise(RegexpError) { Regexp.new("[[:bogus:]]") }`, covering the plain
and negated over-long names. The block's existing assertions cover the
regression side: a valid name must keep compiling.

`rake test` passes on `x86_64-linux` with no new compiler warning.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of unusually long POSIX character-class names in regular expressions.
  * Invalid oversized class names now correctly raise `RegexpError` instead of being silently truncated or compiled incorrectly.
  * Applies to both standard and negated character classes.

* **Tests**
  * Added regression coverage for oversized POSIX character-class names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->