### PR TITLE
mruby-regexp: set $&, $`, $' and $+ after a match

### DIFF
--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -134,8 +134,12 @@ regexp_init(mrb_state *mrb, mrb_value self)
 /* Pre-interned symbols for $1-$9 (cached on first use) */
 static mrb_sym nth_syms[9];
 
+/* Pre-interned symbols for $&, $`, $' and $+ (cached on first use) */
+enum { LAST_MATCH, PRE_MATCH, POST_MATCH, LAST_PAREN, LAST_SYM_COUNT };
+static mrb_sym last_match_syms[LAST_SYM_COUNT];
+
 static void
-ensure_nth_syms(mrb_state *mrb)
+ensure_match_syms(mrb_state *mrb)
 {
   if (nth_syms[0]) return;
   nth_syms[0] = mrb_intern_lit(mrb, "$1");
@@ -147,15 +151,22 @@ ensure_nth_syms(mrb_state *mrb)
   nth_syms[6] = mrb_intern_lit(mrb, "$7");
   nth_syms[7] = mrb_intern_lit(mrb, "$8");
   nth_syms[8] = mrb_intern_lit(mrb, "$9");
+  last_match_syms[LAST_MATCH] = mrb_intern_lit(mrb, "$&");
+  last_match_syms[PRE_MATCH] = mrb_intern_lit(mrb, "$`");
+  last_match_syms[POST_MATCH] = mrb_intern_lit(mrb, "$'");
+  last_match_syms[LAST_PAREN] = mrb_intern_lit(mrb, "$+");
 }
 
 static void
 clear_match_globals(mrb_state *mrb)
 {
-  ensure_nth_syms(mrb);
+  ensure_match_syms(mrb);
   mrb_gv_set(mrb, mrb_intern_lit(mrb, "$~"), mrb_nil_value());
   for (int i = 0; i < 9; i++) {
     mrb_gv_set(mrb, nth_syms[i], mrb_nil_value());
+  }
+  for (int i = 0; i < LAST_SYM_COUNT; i++) {
+    mrb_gv_set(mrb, last_match_syms[i], mrb_nil_value());
   }
 }
 
@@ -265,7 +276,7 @@ regexp_binary_string_p(mrb_state *mrb, mrb_value self)
 static mrb_value
 create_matchdata(mrb_state *mrb, mrb_value regexp, mrb_value str, int *captures, int ncap)
 {
-  ensure_nth_syms(mrb);
+  ensure_match_syms(mrb);
 
   struct RClass *md_class = mrb_class_get(mrb, "MatchData");
   mrb_match_data *md = (mrb_match_data*)mrb_malloc(mrb, sizeof(mrb_match_data));
@@ -292,6 +303,25 @@ create_matchdata(mrb_state *mrb, mrb_value regexp, mrb_value str, int *captures,
     }
     mrb_gv_set(mrb, nth_syms[i], val);
   }
+
+  /* set $&, $` and $' from the whole-match offsets */
+  mrb_gv_set(mrb, last_match_syms[LAST_MATCH],
+             re_byte_substr(mrb, str, captures[0], captures[1] - captures[0]));
+  mrb_gv_set(mrb, last_match_syms[PRE_MATCH],
+             re_byte_substr(mrb, str, 0, captures[0]));
+  mrb_gv_set(mrb, last_match_syms[POST_MATCH],
+             re_byte_substr(mrb, str, captures[1], RSTRING_LEN(str) - captures[1]));
+
+  /* set $+ from the last group that actually participated, which is not
+     necessarily the last group in the pattern */
+  mrb_value last_paren = mrb_nil_value();
+  for (int g = md->num_captures - 1; g >= 1; g--) {
+    if (captures[g*2] >= 0) {
+      last_paren = re_byte_substr(mrb, str, captures[g*2], captures[g*2+1] - captures[g*2]);
+      break;
+    }
+  }
+  mrb_gv_set(mrb, last_match_syms[LAST_PAREN], last_paren);
 
   return obj;
 }

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -1354,6 +1354,33 @@ assert("$1-$9 cleared on no match") do
   assert_nil $1
 end
 
+assert("$&, $`, $' and $+ global variables") do
+  /b(c)/ =~ "abcd"
+  assert_equal "bc", $&
+  assert_equal "a", $`
+  assert_equal "d", $'
+  assert_equal "c", $+
+
+  # $+ is the last group that participated, not the last group in the pattern
+  /(a)|(b)/ =~ "a"
+  assert_equal "a", $+
+
+  # a pattern without groups has no $+
+  /cd/ =~ "abcd"
+  assert_equal "cd", $&
+  assert_nil $+
+end
+
+assert("$&, $`, $' and $+ cleared on no match") do
+  /b(c)/ =~ "abcd"
+  assert_equal "bc", $&
+  /xyz/ =~ "abc"
+  assert_nil $&
+  assert_nil $`
+  assert_nil $'
+  assert_nil $+
+end
+
 assert("Regexp - consecutive optional quantifiers (#6853)") do
   # insert_inst was over-incrementing jump offsets that pointed *at* the
   # insertion site, sending earlier "skip this atom" SPLITs into the next


### PR DESCRIPTION
`create_matchdata()` assigns `$~` and `$1` to `$9`, but leaves the four remaining
match globals untouched. They read as `nil` after a match that already holds
everything they describe.

```ruby
/b(c)/ =~ "abc"
$&    # CRuby: "bc",  mruby: nil
$`    # CRuby: "a",   mruby: nil
$'    # CRuby: "",    mruby: nil
$+    # CRuby: "c",   mruby: nil
```

## Cause

Nothing below `regexp.c` treats these names specially.
`PM_BACK_REFERENCE_READ_NODE` in `codegen.c` emits a plain `OP_GETGV` on the
reference's own name, the same opcode `PM_GLOBAL_VARIABLE_READ_NODE` emits, so a
read of `$&` resolves through the ordinary global table just as `$1` does. The
compiler side already works; the four are simply never assigned.

## Change

Assign them in `create_matchdata()`, next to the `$1` to `$9` loop, from the same
capture array and through the same `re_byte_substr()` helper. That is the only
point at which a successful match is known together with both the subject and the
capture array, so its four call sites (`exec_match()`, `regexp_gsub_str()`,
`regexp_sub_str()` and `regexp_scan()`) inherit the assignment exactly as they
inherit `$~` today.

`$&`, `` $` `` and `$'` follow from the whole match offsets. The latter two are
the expressions `matchdata_pre()` and `matchdata_post()` evaluate, but those are
instance methods that need a receiver, so routing the globals through them would
mean a method dispatch from C for what one `re_byte_substr()` call does.

`$+` is the last group that actually participated, which is not
`captures[(num_captures-1)*2]`, because the last group in the pattern is
frequently the one that did not match:

```ruby
/(a)|(b)/ =~ "a"
$+    # "a", from group 1, since group 2 never participated
```

so it needs a backwards scan from `md->num_captures - 1` down to group 1. A
pattern with no groups leaves that scan with nothing to find and yields `nil`,
which is what CRuby reports.

`clear_match_globals()` sets the four to `nil` alongside `$~` and the `nth_syms`
loop. Without that a failed match leaves a stale `$&` visible, which is the same
defect in the other direction and is what the existing test for `$1` guards
against.

`ensure_nth_syms()` interns the four and is renamed to `ensure_match_syms()`, now
that it covers more than `$1` to `$9`. Both callers already invoke it, so no new
call site is needed and the interning stays out of the per-match path.

`regexp_match_p()` deliberately sets no match globals, and the existing
`Regexp#match? - does not update last match` test asserts that. It keeps setting
none.

## Cost and lifetime

`re_byte_substr()` allocates through `mrb_str_new()` and therefore copies the
bytes, so the four values describe the subject as it was at match time and no
later mutation of it can invalidate them.

The cost is four `mrb_gv_set()` calls per match on top of the nine the `$1` to
`$9` loop already issues, and four more strings retained until the next match or
the next clear. `` $` `` and `$'` are the ones that matter there, since between
them they can pin a copy of nearly the whole subject. Globals are a direct GC
root, so `mrb_gv_set()` needs no write barrier and none was added.

In `regexp_gsub_str()` and `regexp_scan()` the loop's `mrb_gc_arena_restore()`
runs before the trailing `create_matchdata()` call, so the new allocations are
made after the arena is already unwound.

## Known limit

Assigning `$~` directly still updates none of the four, because they are set only
from inside `create_matchdata()`. That is the existing behaviour of `$1` to `$9`,
which these four now share rather than diverge from; closing it would mean
deriving all of them from `$~` at read time, which is a separate change.

## Testing

`rake test` passes: 1950 tests, 0 failures, 0 crashes. It also passes with
`MRB_UTF8_STRING` enabled (1970 tests, 0 failures), where the four report the
same multibyte substrings as CRuby:

```console
$ cat t.rb
"日本語です" =~ /本(語)/
p [$&, $`, $', $+]
$ ./build/utf8/bin/mruby t.rb
["本語", "日", "です", "語"]
```

Behaviour checked against CRuby 4.0.6.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Regular expression matches now provide whole-match, pre-match, post-match, and last-capture values through the corresponding global match variables.
  * These values are cleared when a match fails.

* **Bug Fixes**
  * Corrected handling of global capture variables, including cases with optional or missing captures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->