### PR TITLE
mruby-regexp: return Arrays from `Regexp#named_captures`

### DIFF
--- a/mrbgems/mruby-regexp/README.md
+++ b/mrbgems/mruby-regexp/README.md
@@ -54,6 +54,7 @@ re === "string"                   # => true/false (for case/when)
 re.match(:symbol)                 # a Symbol is matched against its name
 re.source                         # => "pattern"
 re.options                        # => flags integer
+re.named_captures                 # => {"name" => [group_number], ...}
 Regexp.escape("a.b")              # => "a\\.b"
 Regexp.last_match(n)              # => nth capture from last match
 

--- a/mrbgems/mruby-regexp/mrblib/regexp.rb
+++ b/mrbgems/mruby-regexp/mrblib/regexp.rb
@@ -3,9 +3,15 @@ class Regexp
     new(pattern, *args)
   end
 
-  # Return named captures hash: {"name" => group_number, ...}
+  # Return named captures hash: {"name" => [group_number, ...], ...}
+  # @named_captures holds the internal name -> group_number table, so a fresh
+  # Hash is derived on every call and the caller cannot corrupt the table.
   def named_captures
-    @named_captures || {}
+    table = @named_captures
+    return {} unless table
+    result = {}
+    table.each { |name, group| result[name] = [group] }
+    result
   end
 
   # options is implemented in C (internal flags -> Ruby constants conversion)

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -1197,6 +1197,17 @@ assert("Regexp - named captures") do
   assert_equal "2026", md["year"]
 end
 
+assert("Regexp#named_captures") do
+  assert_equal({"year" => [1], "month" => [2], "day" => [3]},
+               /(?<year>\d+)-(?<month>\d+)-(?<day>\d+)/.named_captures)
+  assert_equal({}, /\d+/.named_captures)
+
+  # the returned Hash is a copy; mutating it must not affect a later call
+  re = /(?<a>x)/
+  re.named_captures["a"] = 99
+  assert_equal({"a" => [1]}, re.named_captures)
+end
+
 assert("Regexp - empty group name") do
   # (?<>x) used to compile and answer to "", and in /x mode the stored name
   # pointed into the preprocessing buffer the compiler frees on the way out.


### PR DESCRIPTION
`Regexp#named_captures` returns Integer values where CRuby returns Arrays.

```ruby
/(?<a>x)/.named_captures       # CRuby: {"a" => [1]}, mruby: {"a" => 1}
```

It also hands out the Hash stored in the `@named_captures` instance variable, so a
caller that writes into the returned Hash corrupts the Regexp for every later caller:

```ruby
re = /(?<a>x)/
re.named_captures["a"] = 99
re.named_captures              # CRuby: {"a" => [1]}, mruby: {"a" => 99}
```

CRuby uses an Array because one name can map to several group numbers, as in
`/(?<x>a)|(?<x>b)/`. mruby-regexp accepts such a pattern but does not handle it
correctly yet: the later group silently overwrites the earlier one in the Hash, and a
name lookup resolves to the first entry in the C table regardless of which alternative
matched. Duplicate names therefore still resolve wrongly with this change applied:

```ruby
/(?<a>x)|(?<a>b)/.named_captures  # CRuby: {"a" => [1, 2]}, mruby: {"a" => [2]}
/(?<a>x)|(?<a>b)/.match("b")[:a]  # CRuby: "b",             mruby: nil
```

That is a separate defect in the compiler and in name resolution, left out of this
change. The return type is aligned so that portable code can be written today.

## Changes

- `Regexp#named_captures` derives a fresh Hash from the `@named_captures` table on
  every call and wraps each group number in an Array. `regexp_init()` keeps filling the
  instance variable with the internal name to group-number table, and the public method
  becomes a derivation of it, which is also where the shared-Hash aliasing goes away.
- `MatchData#named_captures` is unaffected. It rebuilds its result from the compiled C
  table on every call and already answers name to captured string.
- `Regexp#named_captures` is added to the Ruby API block in
  `mrbgems/mruby-regexp/README.md`.

## Tests

A new `assert("Regexp#named_captures")` in `mrbgems/mruby-regexp/test/regexp.rb` covers
the Array value type, the empty Hash for a pattern with no named group, and that
mutating the returned Hash does not affect a later call.

`rake test` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced `Regexp#named_captures` to return each capture name with its corresponding group index.
  * Returns an empty hash when no named captures are present.

* **Bug Fixes**
  * Ensured each call returns an independent result, preventing changes from affecting later calls.

* **Documentation**
  * Added documentation describing the `named_captures` return format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->