### PR TITLE
mruby-regexp: add `Regexp#names` and `MatchData#names`

### DIFF
--- a/mrbgems/mruby-regexp/README.md
+++ b/mrbgems/mruby-regexp/README.md
@@ -55,6 +55,7 @@ re.match(:symbol)                 # a Symbol is matched against its name
 re.source                         # => "pattern"
 re.options                        # => flags integer
 re.named_captures                 # => {"name" => [group_number], ...}
+re.names                          # => ["name", ...]
 Regexp.escape("a.b")              # => "a\\.b"
 Regexp.last_match(n)              # => nth capture from last match
 
@@ -71,6 +72,7 @@ md.end(0)                         # => match end position
 md.pre_match                      # => string before match
 md.post_match                     # => string after match
 md.named_captures                 # => {"name" => "value", ...}
+md.names                          # => ["name", ...]
 
 # String methods
 str.match(re)                     # => MatchData or nil

--- a/mrbgems/mruby-regexp/mrblib/regexp.rb
+++ b/mrbgems/mruby-regexp/mrblib/regexp.rb
@@ -14,6 +14,12 @@ class Regexp
     result
   end
 
+  # Return the capture names in group order
+  def names
+    table = @named_captures
+    table ? table.keys : []
+  end
+
   # options is implemented in C (internal flags -> Ruby constants conversion)
 
   def self.last_match(n = nil)
@@ -27,4 +33,8 @@ end
 
 class MatchData
   # named_captures is implemented in C via md->regexp
+
+  def names
+    regexp.names
+  end
 end

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -1214,6 +1214,15 @@ assert("Regexp#named_captures") do
   assert_equal({"a" => [1]}, re.named_captures)
 end
 
+assert("Regexp#names") do
+  assert_equal ["year", "month", "day"],
+               /(?<year>\d+)-(?<month>\d+)-(?<day>\d+)/.names
+  assert_equal [], /\d+/.names
+
+  # a name that is registered twice is reported once, as in CRuby
+  assert_equal ["tag"], /(?<tag>\w+)-(?<tag>\w+)/.names
+end
+
 assert("Regexp - empty group name") do
   # (?<>x) used to compile and answer to "", and in /x mode the stored name
   # pointed into the preprocessing buffer the compiler frees on the way out.
@@ -1285,6 +1294,11 @@ assert("MatchData#named_captures") do
   nc = md.named_captures
   assert_equal "user", nc["a"]
   assert_equal "host", nc["b"]
+end
+
+assert("MatchData#names") do
+  assert_equal ["a", "b"], /(?<a>\w+)@(?<b>\w+)/.match("user@host").names
+  assert_equal [], /\w+/.match("user").names
 end
 
 assert("Regexp - named captures survive /x preprocessing") do


### PR DESCRIPTION
Neither `Regexp` nor `MatchData` answers `names`, so code that asks a pattern for its
capture names raises `NoMethodError`.

```ruby
/(?<a>x)(?<b>y)/.names         # CRuby: ["a", "b"], mruby: NoMethodError
/(?<x>a)/.match("a").names     # CRuby: ["x"],      mruby: NoMethodError
```

Everything both methods need is already reachable from Ruby. `regexp_init()` stores a
name to group-number table in the `@named_captures` instance variable when the pattern
has a named group, and `MatchData#regexp` is already a C binding.

## Changes

- `Regexp#names` returns the keys of the `@named_captures` table, or `[]` when the
  pattern has no named group and the instance variable was never set. `regexp_init()`
  inserts in the order the compiler registered the groups, which is ascending group
  number, so the key order already matches CRuby's.
- `MatchData#names` is `regexp.names`. On an uninitialized receiver such as
  `MatchData.allocate` it raises the same `TypeError` that `MatchData#named_captures`
  already raises, because `MatchData#regexp` reads `DATA_PTR` through `DATA_GET_PTR()`.
- Both live in mrblib; no new C binding is required.
- Both are added to the Ruby API block in `mrbgems/mruby-regexp/README.md`.

A pattern with duplicate names registers one table entry per group and the Hash keeps
only the last of them, so `names` reports the name once, which is what CRuby answers
as well:

```ruby
/(?<a>x)|(?<a>b)/.names        # CRuby: ["a"], mruby: ["a"]
```

## Tests

New `assert("Regexp#names")` and `assert("MatchData#names")` in
`mrbgems/mruby-regexp/test/regexp.rb` cover a pattern with named groups and a pattern
with none.

`rake test` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `Regexp#names` to return named capture names in group order.
  * Added `MatchData#names` to return the named captures associated with a match.
  * Methods return an empty array when no named captures are present and handle repeated names consistently.

* **Documentation**
  * Documented both methods and their return values.

* **Tests**
  * Added coverage for ordering, empty results, and duplicate capture names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->