### PR TITLE
mruby-regexp: quote the pattern as written in `RegexpError` messages

### DIFF
--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -14,8 +14,10 @@
 /* Compiler state */
 typedef struct {
   mrb_state *mrb;
-  const char *src;     /* pattern source */
+  const char *src;     /* pattern source (preprocessed in extended mode) */
   const char *src_end;
+  const char *orig;    /* pattern as written, for error messages */
+  const char *orig_end;
   const char *p;       /* current position */
   re_inst *code;       /* instruction array */
   uint32_t code_len;
@@ -37,11 +39,13 @@ static void compile_alt(re_compiler *c);  /* forward */
 static void
 compile_error(re_compiler *c, const char *msg)
 {
-  /* Format the message before freeing c->stripped (which may alias c->src
-     in extended mode). c->src is not NUL-terminated, so use %l with the
-     explicit length from c->src_end. */
+  /* Quote c->orig, the pattern as written: in extended mode c->src points at
+     the buffer strip_extended() returned, so quoting it would drop the
+     free-spacing and the comments from the message. c->orig is the caller's
+     buffer, which outlives the compile. It is not NUL-terminated, so use %l
+     with the explicit length from c->orig_end. */
   mrb_value emsg = mrb_format(c->mrb, "%s: /%l/",
-                              msg, c->src, (size_t)(c->src_end - c->src));
+                              msg, c->orig, (size_t)(c->orig_end - c->orig));
 
   /* Free compile buffers before raising, since mrb_exc_raise longjmps out
      and the stack-local re_compiler is abandoned without a chance to clean
@@ -1247,6 +1251,9 @@ mrb_re_compile(mrb_state *mrb, const char *pattern, mrb_int len, uint32_t flags)
 {
   re_compiler c;
   memset(&c, 0, sizeof(c));
+
+  c.orig = pattern;
+  c.orig_end = pattern + len;
 
   if (flags & RE_FLAG_EXTENDED) {
     mrb_int slen;

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -598,6 +598,14 @@ assert("Regexp extended mode (x flag)") do
 
   # to_s shows x flag
   assert_equal "(?x:abc)", Regexp.new("abc", Regexp::EXTENDED).to_s
+
+  # errors quote the pattern as written, not the stripped text
+  assert_raise_with_message(RegexpError, "unterminated character class: /a # c\n[/") do
+    Regexp.new("a # c\n[", Regexp::EXTENDED)
+  end
+  assert_raise_with_message(RegexpError, "unmatched '(': /a b(/") do
+    Regexp.new("a b(", Regexp::EXTENDED)
+  end
 end
 
 assert("String#match") do


### PR DESCRIPTION
`compile_error()` formats the pattern the parser is reading. In `/x` mode that
is not the pattern the user wrote: `mrb_re_compile()` points `c->src` at the
buffer `strip_extended()` returns, so the message quotes text with the
free-spacing and the comments taken out.

```ruby
Regexp.new("a # c\n[", Regexp::EXTENDED)
# CRuby: RegexpError (premature end of char-class: /a # c\n[/x)
# mruby: RegexpError (unterminated character class: /a[/)
```

The comment that explained the pattern is gone from the message, and so is the
position the reader would use to find the error. Anything the pass removes goes
with it:

```ruby
Regexp.new("a b(", Regexp::EXTENDED)
# CRuby: RegexpError (end pattern with unmatched parenthesis: /a b(/x)
# mruby: RegexpError (unmatched '(': /ab(/)
```

This is a diagnostics bug, not a behavioural one. The same patterns are accepted
and rejected either way; only the text of the exception differs.

## Change

`re_compiler` gains `orig` and `orig_end` next to `src` and `src_end`.
`mrb_re_compile()` sets them from its arguments before the extended-mode block
replaces `pattern` and `len`, and `compile_error()` quotes them instead of
`src` and `src_end`. The parser keeps reading the preprocessed text; this only
changes what gets quoted. Ordinary patterns see no difference, since `c->src`
is then already the caller's buffer.

The new pointer outlives the compile. The single caller is `regexp_init()`,
which stores the same String in `@source` before passing `RSTRING_PTR()`, so
the bytes stay rooted across the allocating `mrb_format()`. It also never
points into `c->stripped`, so the message no longer depends on the free order
in `compile_error()`; the comment there is updated to say what is quoted and
why rather than to state a lifetime constraint that no longer applies.

## Out of scope

CRuby appends the flags, `/a # c\n[/x`. mruby's format string carries no flags
at all, for `/x` or for anything else, which is a separate difference. The
message wording (`unterminated character class` against CRuby's
`premature end of char-class`) is another one; this gem's messages differ from
Onigmo's throughout.

## Tests

Two `assert_raise_with_message` cases in `assert("Regexp extended mode (x flag)")`
pin the whole message for a comment-bearing pattern and a whitespace-bearing
one. No existing assertion depended on the old text: the `RegexpError` cases in
this file are all `assert_raise` without a message.

`rake test` passes (1940 OK, 0 KO).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved regular expression compilation errors in extended mode to display the original pattern, including whitespace and comments.
  * Preserved the correct pattern length in error messages for clearer diagnostics.

* **Tests**
  * Added coverage for unterminated character classes and unmatched opening parentheses in extended-mode regular expressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->