### PR TITLE
Add WASI toolchain & build_config

### DIFF
--- a/build_config/wasi.rb
+++ b/build_config/wasi.rb
@@ -1,0 +1,15 @@
+# Requires wasi-sdk 26 or later; set WASI_SDK_PATH unless it is in /opt/wasi-sdk.
+#
+# Currently unsupported on wasm32-wasip1: "mruby-io", "mruby-dir", "mruby-socket"
+MRuby::CrossBuild.new('wasi') do |conf|
+  conf.toolchain :wasi
+
+  conf.gembox 'default-no-stdio'
+  conf.gembox 'stdlib-ext'
+  conf.gembox 'metaprog'
+
+  conf.gem core: 'mruby-bin-mruby'
+  conf.gem core: 'mruby-bin-mrbc'
+  conf.gem core: 'mruby-bin-strip'
+  conf.gem core: 'mruby-bin-config'
+end

--- a/tasks/toolchains/wasi.rake
+++ b/tasks/toolchains/wasi.rake
@@ -1,0 +1,22 @@
+MRuby::Toolchain.new(:wasi) do |conf, params|
+  toolchain :clang
+
+  wasi_sdk = ENV['WASI_SDK_PATH'] || '/opt/wasi-sdk'
+  bin = "#{wasi_sdk}/bin"
+  target = params[:target] || 'wasm32-wasip1'
+
+  # setjmp/longjmp via native WASM exception handling; requires wasi-sdk 26 or later
+  flags = %W(--target=#{target} --sysroot=#{wasi_sdk}/share/wasi-sysroot
+             -mllvm -wasm-enable-sjlj -mllvm -wasm-use-legacy-eh=false)
+
+  conf.cc.command = "#{bin}/clang"
+  conf.cxx.command = "#{bin}/clang++"
+  conf.linker.command = "#{bin}/clang"
+  conf.archiver.command = "#{bin}/llvm-ar"
+
+  [conf.cc, conf.cxx, conf.linker].each{|tool| tool.flags << flags}
+  conf.linker.libraries << 'setjmp'
+
+  # llvm-ar defaults to the Darwin format on macOS hosts, which overflows on long member paths
+  conf.archiver.archive_options = '--format=gnu rs "%{outfile}" %{objs}'
+end


### PR DESCRIPTION
Adds a `wasi` toolchain and build config for cross-compiling mruby with [wasi-sdk](https://github.com/WebAssembly/wasi-sdk), targeting `wasm32-wasip1`.

## Relation to the Emscripten toolchain

Emscripten targets the browser; wasi-sdk targets standalone WASI runtimes and non-web embedders. Emscripten's `-sSTANDALONE_WASM` emits a partly-WASI module rather than a pure WASI ABI, and does not reach the component model (`wasm32-wasip2`). The emscripten toolchain is untouched.

## setjmp/longjmp

mruby needs setjmp/longjmp, which wasi-sdk implements on top of the WASM exception-handling proposal. Hence `-mllvm -wasm-enable-sjlj` when compiling, `-lsetjmp` when linking, and `-mllvm -wasm-use-legacy-eh=false` for the standardized EH instructions. This requires wasi-sdk 26 or later.

## Usage

```sh
WASI_SDK_PATH=/path/to/wasi-sdk rake MRUBY_CONFIG=wasi
```

`WASI_SDK_PATH` defaults to `/opt/wasi-sdk`. The target is overridable, so the same toolchain covers preview 2:

```ruby
conf.toolchain :wasi, target: 'wasm32-wasip2'
```

## Verified

Built with wasi-sdk 33 on macOS arm64, run under Wasmtime 49 and Node 24 (`node:wasi`).

| | `wasm32-wasip1` | `wasm32-wasip2` |
| --- | --- | --- |
| build | ok | ok |
| output format | core module (`0x1`) | component (`0x1000d`) |
| run under Wasmtime 49 | ok | ok |
| exceptions, `break` / `return` from blocks | ok | ok |
| file I/O via preopened dir | ok | ok |
| `mrbc` -> `.mrb` -> `mruby -b` | ok | ok |
| run under Node 24 `node:wasi` | ok | n/a (preview1 only) |

## Limitations

`mruby-io`, `mruby-dir` and `mruby-socket` rely on POSIX APIs WASI has no counterpart for, such as `getpwnam` and `waitpid`; `mruby-bin-mirb` needs `signal.h`. The build config therefore uses `default-no-stdio`, as `build_config/dreamcast_shelf.rb` does for the same reason. `Kernel#puts` is defined in `mruby-io`, so this build has no I/O.

No core files are modified.

---

Today at [COSCUP 2026](https://coscup.org/2026/) in Taiwan I gave a talk in the Ruby Taiwan track ([讓 AI 接管你的應用，打造微秒級無縫的 Ruby 安全沙盒](https://coscup.org/2026/session/KZ9PTY/)) on the design of kobako, an mruby sandbox that boots in 4 microseconds on WebAssembly. It compiles mruby with wasi-sdk, which is why I would like this toolchain upstream.

[kobako](https://github.com/elct9620/kobako) is built on [beni](https://github.com/elct9620/beni), a Rust wrapper that both provides the toolchain compiling mruby and is the layer through which mruby is extended.

Today beni carries that toolchain itself:

```
  kobako
    |  (1) build toolchain
    |  (2) mruby bindings
    v
  beni
    |
    |  wasi.rake  <-- maintained inside beni
    v
  mruby + wasi-sdk
    |
    v
  libmruby.a (wasm32-wasip1)
```

With this PR it comes from mruby:

```
  kobako
    |  (1) build toolchain
    |  (2) mruby bindings
    v
  beni
    |
    |  conf.toolchain :wasi  <-- provided by mruby
    v
  mruby + wasi-sdk
    |
    v
  libmruby.a (wasm32-wasip1)
```

Both gems can then depend on mruby directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for cross-building MRuby applications for WASI and WebAssembly.
  * Added a configurable WASI toolchain using WASI SDK 26 or later.
  * Added support for specifying the WASI SDK location and optional compilation target.
* **Documentation**
  * Documented WASI SDK requirements and currently unsupported WebAssembly components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->