### PR TITLE
mruby-regexp: do not truncate a stored capture name length

### DIFF
--- a/mrbgems/mruby-regexp/include/re_internal.h
+++ b/mrbgems/mruby-regexp/include/re_internal.h
@@ -57,10 +57,18 @@ typedef struct {
   mrb_bool utf8_any;  /* match any non-ASCII byte if true */
 } re_charclass;
 
+/* Longest capture name that fits in re_named_capture::name_len. The bound
+   sits beside the field it describes so a later change of width is one line.
+   The widening inside the macro is not cosmetic: on a target whose argument
+   type is no wider than the field, the naive comparison is against a constant
+   that type cannot exceed, and the compiler reports it. */
+#define RE_MAX_NAME_LEN UINT32_MAX
+#define RE_NAME_LEN_FITS(n) ((uintmax_t)(n) <= RE_MAX_NAME_LEN)
+
 /* Named capture entry */
 typedef struct {
   const char *name;
-  uint16_t name_len;
+  uint32_t name_len;
   uint16_t group;
 } re_named_capture;
 

--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -613,7 +613,7 @@ compile_atom(re_compiler *c)
       uint32_t saved_flags = c->flags;
 
       const char *cap_name = NULL;
-      uint16_t cap_name_len = 0;
+      uint32_t cap_name_len = 0;
 
       if (peek(c) == '?' && c->p + 1 < c->src_end) {
         if (c->p[1] == ':') {
@@ -666,7 +666,8 @@ compile_atom(re_compiler *c)
           while (peek(c) != '>' && peek(c) >= 0) next_char(c);
           if (peek(c) != '>') compile_error(c, "unterminated named capture");
           if (c->p == cap_name) compile_error(c, "group name is empty");
-          cap_name_len = (uint16_t)(c->p - cap_name);
+          if (!RE_NAME_LEN_FITS(c->p - cap_name)) compile_error(c, "group name too long");
+          cap_name_len = (uint32_t)(c->p - cap_name);
           next_char(c);  /* skip > */
         }
         else if (c->p[1] == 'i' || c->p[1] == 'm' || c->p[1] == 'x' || c->p[1] == '-') {
@@ -813,14 +814,15 @@ compile_atom(re_compiler *c)
       while (peek(c) != close && peek(c) >= 0) next_char(c);
       if (peek(c) != close) compile_error(c, "unterminated backreference name");
       if (c->p == name) compile_error(c, "group name is empty");
-      uint16_t name_len = (uint16_t)(c->p - name);
+      if (!RE_NAME_LEN_FITS(c->p - name)) compile_error(c, "group name too long");
+      uint32_t name_len = (uint32_t)(c->p - name);
       next_char(c);  /* skip the closing > or ' */
 
       int group = -1;
       if (name_len > 0 && (name[0] == '-' || (name[0] >= '0' && name[0] <= '9'))) {
         mrb_bool relative = (name[0] == '-');
         int n = 0;
-        for (uint16_t i = (relative ? 1 : 0); i < name_len; i++) {
+        for (uint32_t i = (relative ? 1 : 0); i < name_len; i++) {
           if (name[i] < '0' || name[i] > '9') compile_error(c, "invalid backreference");
           n = n * 10 + (name[i] - '0');
           if (n > (int)c->num_captures - 1) compile_error(c, "undefined group name reference");
@@ -1295,7 +1297,7 @@ mrb_re_compile(mrb_state *mrb, const char *pattern, mrb_int len, uint32_t flags)
       pat->named_arena = (char*)mrb_malloc(mrb, total);
       size_t off = 0;
       for (uint16_t i = 0; i < c.num_named; i++) {
-        uint16_t n = c.named_captures[i].name_len;
+        uint32_t n = c.named_captures[i].name_len;
         memcpy(pat->named_arena + off, c.named_captures[i].name, n);
         pat->named_captures[i].name = pat->named_arena + off;
         off += n;

--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -622,12 +622,13 @@ matchdata_aref(mrb_state *mrb, mrb_value self)
     if (!mrb_nil_p(md->regexp)) {
       pat = DATA_GET_PTR(mrb, md->regexp, &regexp_type, mrb_regexp_pattern);
     }
-    /* A stored name never exceeds UINT16_MAX, so a longer request can name no
-       group. Rejecting it here keeps the cast in the loop lossless; without it
-       the length test truncates while the memcmp() next to it does not. */
-    if (pat && name_len <= UINT16_MAX) {
+    /* A stored name never exceeds RE_MAX_NAME_LEN, so a longer request can
+       name no group. Rejecting it here keeps the cast in the loop lossless;
+       without it the length test truncates while the memcmp() next to it does
+       not. */
+    if (pat && RE_NAME_LEN_FITS(name_len)) {
       for (uint16_t i = 0; i < pat->num_named; i++) {
-        if (pat->named_captures[i].name_len == (uint16_t)name_len &&
+        if (pat->named_captures[i].name_len == (uint32_t)name_len &&
             memcmp(pat->named_captures[i].name, name, name_len) == 0) {
           idx = pat->named_captures[i].group;
           goto found;

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -1260,6 +1260,34 @@ assert("MatchData#[] - group name longer than a uint16 length") do
   assert_equal "x", md[:abc]
 end
 
+assert("Regexp - group name longer than a uint16 length") do
+  # The name length used to live in a uint16_t and was truncated with a cast,
+  # so (uint16_t)65538 == 2 made this group answer to "ab" instead of to the
+  # name it was given.
+  long = "ab" + "A" * 65536
+  re = Regexp.new("(?<#{long}>x)")
+  assert_equal [long], re.named_captures.keys
+  assert_equal "x", re.match("x")[long]
+  assert_raise(IndexError) { re.match("x")["ab"] }
+
+  # two names that shared a truncation stay distinct, and the two APIs that
+  # resolve a name agree on which group it names
+  re = Regexp.new("(?<ab>x)(?<#{long}>y)")
+  md = re.match("xy")
+  assert_equal "x", md["ab"]
+  assert_equal "y", md[long]
+  assert_equal({ "ab" => "x", long => "y" }, md.named_captures)
+
+  # \k binds to the group the name was written on
+  re = Regexp.new("(?<ab>x)(?<#{long}>y)\\k<#{long}>")
+  assert_nil re.match("xyx")
+  assert_equal "xyy", re.match("xyy")[0]
+
+  # a name of exactly 65536 bytes is not the empty name
+  z = "Z" * 65536
+  assert_equal [z], Regexp.new("(?<#{z}>x)").named_captures.keys
+end
+
 assert("Regexp - named backreference \\k") do
   assert_equal "aa", "aa".match(/(?<n>\w)\k<n>/)[0]
   assert_equal "abba", "abba".match(/(?<a>.)(?<b>.)\k<b>\k<a>/)[0]


### PR DESCRIPTION
`compile_atom()` stores a named capture's name length in a `uint16_t` and
truncates to it with a cast rather than rejecting the name. The truncation is
silent, and every consumer of the stored name then works from the truncated
bytes: the pattern still compiles, the group still captures, but its name is no
longer the name that was written.

```ruby
n = "A" * 65539
re = Regexp.new("(?<#{n}>x)")
re.named_captures.keys.map(&:length)  # CRuby: [65539], mruby: [3]
re.match("x")[n]                      # CRuby: "x", mruby: IndexError
re.match("x")["AAA"]                  # CRuby: IndexError, mruby: "x"
```

The group exists and matched, but it cannot be reached by the name it was
given, and it answers to a three-byte name that appears nowhere in the pattern.

The `IndexError` on the second row is the current answer, not the historical
one: the lookup for a name longer than 65535 bytes used to read past the named
capture arena, and #7002 bounded it. That fix is about the read, and it leaves
the truncation this pull request is about exactly where it was.

## Two consumers disagree about the same name

The truncation is not confined to lookup by name. It also lets two groups
collapse onto one stored name, and the two APIs that resolve a name then pick
different groups.

```ruby
long = "ab" + "A" * 65536             # 65538 bytes, (uint16_t)65538 == 2
re = Regexp.new("(?<ab>x)(?<#{long}>y)")
re.named_captures
# CRuby: {"ab" => [1], "abAAA..." => [2]}
# mruby: {"ab" => [2]}
md = re.match("xy")
md["ab"]                              # mruby: "x", which is group 1
md.named_captures                     # mruby: {"ab" => "y"}, which is group 2
```

`MatchData#[]` scans the table and stops at the first entry, so `"ab"` resolves
to group 1. The `@named_captures` table and `MatchData#named_captures` are
Hashes keyed by the stored name and let the later entry overwrite the earlier
one, so the same name resolves to group 2 through `Regexp#named_captures`,
which derives from that table. One name, two answers, in one pattern.

## `\k` binds to the wrong group

The same collapse reaches the matcher, where it changes what the pattern
accepts.

```ruby
long = "ab" + "A" * 65536
re = Regexp.new("(?<ab>x)(?<#{long}>y)\\k<#{long}>")
re.match("xyx")                       # CRuby: nil, mruby: matches
re.match("xyy")                       # CRuby: matches, mruby: nil
```

The backreference was written against the second group and binds to the first.
This is a wrong answer from a pattern that compiled without complaint, not a
diagnostic gap.

## A name of exactly 65536 bytes becomes the empty name

`(uint16_t)65536 == 0`, so the name is truncated away entirely and the group
answers to `""`.

```ruby
z = "Z" * 65536
re = Regexp.new("(?<#{z}>x)")
re.named_captures.keys.map(&:length)  # CRuby: [65536], mruby: [0]
re.match("x")[""]                     # CRuby: IndexError, mruby: "x"
```

## Cause

Two casts in `compile_atom()`, one at capture registration and one at `\k`
resolution:

```c
cap_name_len = (uint16_t)(c->p - cap_name);
```

```c
uint16_t name_len = (uint16_t)(c->p - name);
```

`c->p - cap_name` is a `ptrdiff_t` over the pattern source, while
`re_named_capture::name_len` is a `uint16_t`. The truncated value is what gets
stored and what sizes the owned name arena, so nothing reads out of bounds: the
arena is built from the same truncated lengths that every reader uses. What is
lost is the rest of the name, and with it the identity of the group.

Every reader works from the stored length and is therefore consistent with the
truncation rather than with the pattern: the `\k` lookup, the
`@named_captures` table `Regexp#named_captures` derives from,
`MatchData#named_captures` and `MatchData#[]`.

## Fix

Widen `re_named_capture::name_len` to `uint32_t`, so a stored length is the
name's true length, and let every local, loop counter and comparison that
consumes it follow. All four wrong answers above then match CRuby.

On a 64-bit target the widening is free: the struct is
`const char *name; uint16_t name_len; uint16_t group;`, which already pads to
16 bytes, and `uint32_t name_len` still fits in 16 (measured with `cc`, both
sizes 16). On a 32-bit target it grows the entry from 8 bytes to 12. That is
the whole cost, paid per named capture.

The bound the cast needs does not go away with the wider field. `c->p -
cap_name` is a `ptrdiff_t` over the pattern source and nothing in
`mrb_re_compile()` limits the pattern's length, so a check has to sit in front
of the cast whatever the field's width is. It moves to `UINT32_MAX`, out of
reach of any pattern this gem can compile, and it is what keeps the cast
lossless.

The bound is spelled once, beside the field it describes, so a later change of
width is one line:

```c
#define RE_MAX_NAME_LEN UINT32_MAX
#define RE_NAME_LEN_FITS(n) ((uintmax_t)(n) <= RE_MAX_NAME_LEN)
```

The widening inside the macro is not cosmetic. On a target whose argument type
is no wider than the field, a `ptrdiff_t` on ILP32 or an `mrb_int` on
`MRB_INT32`, the naive comparison is against a constant the type cannot exceed,
and clang reports it:

```
warning: comparison of integers of different signs: 'int32_t' (aka 'int')
         and 'unsigned int' [-Wsign-compare]
```

`uintmax_t` rather than `uint64_t`: C99 makes the exact-width 64-bit types
optional (7.18.1.1p3), and every `uint64_t` in mruby today sits behind
`MRB_GC_PROFILE` or `MRB_INT64`, so a gem header should not require one
unconditionally. `CONTRIBUTING.md` asks for code as close to C99 as possible.

The guard #7002 put in `matchdata_aref()` stays, reading through the same
macro. It is what makes the cast on the line below it lossless, and dropping it
would put a truncating comparison back next to an untruncated `memcmp()`, one
edit away from the same overread. The test #7002 added alongside it needs
nothing either way: its pattern is `/(?<abc>x)/`, so the over-long name it
looks up resolves to no group whatever the field's width is.

### Alternative considered

Rejecting a name that does not fit is two lines and no representation change.
It turns four wrong answers into one `RegexpError` and leaves the
representation alone, but it is still a divergence from CRuby, which has no
such limit and resolves the full name. Widening makes all four cases agree with
CRuby instead, for one byte per entry on 32-bit targets and nothing on 64-bit
ones.

## Tests

One `assert()` in `mrbgems/mruby-regexp/test/regexp.rb`, immediately after
`assert("MatchData#[] - group name longer than a uint16 length")`, which is
#7002's test and the read-side counterpart of this one. It carries one
assertion per wrong answer above: the name survives lookup and
`Regexp#named_captures`, two names that shared a truncation stay distinct and
both APIs agree on which group each names, `\k` binds to the group its name was
written on, and a 65536-byte name is not the empty name.

Verified on `x86_64-linux`:

- Every reproduction above now matches CRuby 4.0.6.
- `rake test`: 1957 total, 1939 OK, 0 KO, 0 crash, and bintest 105 OK.
- An `MRB_INT32` build with clang and `-Wall -Wextra`: 1862 total, 1844 OK,
  0 KO, 0 crash, and no new warning from any `mruby-regexp` file.
- Struct size measured on x86_64 only, unchanged at 16 bytes. The 32-bit figure
  of 12 bytes is read from the layout, not measured; no `-m32` toolchain was
  available.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed regular expressions with named capture groups longer than 65,535 bytes.
  * Ensured long capture names remain distinct and work correctly with named-capture lookups, match indexing, and backreferences.
* **Tests**
  * Added regression coverage for capture names exceeding the previous length limit, including names exactly 65,536 bytes long.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->