### PR TITLE
Fix `Integer#==` reading a Bigint receiver as `mrb_int`

### DIFF
--- a/mrbgems/mruby-bigint/test/bigint.rb
+++ b/mrbgems/mruby-bigint/test/bigint.rb
@@ -3,6 +3,34 @@ assert 'Bigint basic' do
   assert_equal 36893488147419103232, n
 end
 
+assert 'Bigint ==' do
+  n = 1<<64
+
+  # A Bigint receiver used to be read as a plain `mrb_int`, so `==` compared
+  # the low bits of the magnitude instead of the number itself.
+  assert_false n == 0
+  assert_false n + 5 == 5
+  assert_false n - 1 == -1
+  assert_false(-(n + 5) == 5)
+  assert_false (1<<160) + 5 == 5
+  assert_false (1<<192) + 5 == 5
+  assert_false n.zero?
+  assert_false [n].include?(0)
+
+  assert_true n == 1<<64
+  assert_false n == 1<<65
+  assert_false n == -n
+  assert_false 5 == n + 5
+
+  assert_false n == 'x'
+  assert_false n == nil
+
+  if Object.const_defined?(:Float)
+    assert_true (1<<70) == (2.0**70)
+    assert_false (1<<70) == (2.0**71)
+  end
+end
+
 assert 'Bigint +' do
   n = 1<<65
   assert_equal 36893488147419103232, n + 0

--- a/src/numeric.c
+++ b/src/numeric.c
@@ -1305,6 +1305,13 @@ int_equal(mrb_state *mrb, mrb_value x)
 {
   mrb_value y = mrb_get_arg1(mrb);
 
+#ifdef MRB_USE_BIGINT
+  if (mrb_bigint_p(x)) {
+    if (mrb_integer_p(y) || mrb_bigint_p(y) || mrb_float_p(y)) {
+      return mrb_bool_value(mrb_bint_cmp(mrb, x, y) == 0);
+    }
+  }
+#endif
   switch (mrb_type(y)) {
   case MRB_TT_INTEGER:
     return mrb_bool_value(mrb_integer(x) == mrb_integer(y));


### PR DESCRIPTION
`int_equal()` ([`src/numeric.c:1303-1310`](https://github.com/mruby/mruby/blob/66d3f0a02/src/numeric.c#L1303-L1310)) switches on the type of its argument and never looks at the receiver:

```c
static mrb_value
int_equal(mrb_state *mrb, mrb_value x)
{
  mrb_value y = mrb_get_arg1(mrb);

  switch (mrb_type(y)) {
  case MRB_TT_INTEGER:
    return mrb_bool_value(mrb_integer(x) == mrb_integer(y));
```

A Bigint is an `Integer` as far as the method table is concerned, so `x` can be
`MRB_TT_BIGINT`, and `mrb_integer()` is defined for `MRB_TT_INTEGER`. What comes back is not
the number:

```ruby
(2 ** 64 + 5) == 5     # mruby: true   CRuby: false
(2 ** 64) == 0         # mruby: true   CRuby: false
(2 ** 64 - 1) == -1    # mruby: true   CRuby: false
```

`mruby-bigint` ships in `math.gembox`, which `default.gembox` includes, so a plain build
reproduces this with no configuration:

```console
$ rake
$ ./build/host/bin/mruby -e 'p [(2**64 + 5) == 5, (2**64) == 0, (2**64).zero?]'
[true, true, true]
```

Only the Bigint-receiver direction is affected. `<=>`, `eql?` and `hash` all guard their
receiver, so `==` contradicts them on the same pair of objects, and `{0 => :zero}[2 ** 64]`
is correctly `nil` while `(2 ** 64) == 0` says the two are the same number.

## What the read lands on

Under `MRB_WORD_BOXING`, `mrb_integer()` on a non-immediate value is
`mrb_val_union(o).ip->i` ([`include/mruby/boxing_word.h:191-196`](https://github.com/mruby/mruby/blob/66d3f0a02/include/mruby/boxing_word.h#L191-L196)),
the `mrb_int` field of `struct RInteger`. `struct RBigint`
([`mrbgems/mruby-bigint/core/bigint.h:53-59`](https://github.com/mruby/mruby/blob/66d3f0a02/mrbgems/mruby-bigint/core/bigint.h#L53-L59))
places its union at that same offset, so for an embedded Bigint the read lands on the first
limbs of the magnitude, sign discarded:

```ruby
-(2 ** 64 + 5) == 5     # mruby: true    CRuby: false; the sign is discarded too
(2 ** 160 + 5) == 5     # mruby: true    CRuby: false; still inside the embedded array
(2 ** 192 + 5) == 5     # false, but only because the union now holds `mpz_t`
```

`RBIGINT_EMBED_SIZE_MAX` is `(sizeof(void*) * 3) / sizeof(mp_limb)`, six limbs on a 64-bit
host, so the change of behaviour at 192 bits is the embedded-to-heap switch: past it the
first word of the union is `mpz_t`'s limb pointer, and an address is what gets compared.

`MRB_NO_BOXING` and `MRB_NAN_BOXING` read the object pointer itself, so those builds print
false for the cases above. That is false by accident rather than because the receiver was
checked, and the missing guard still shows against a Float in every boxing:

```ruby
(2 ** 70) == (2.0 ** 70)    # mruby: false   CRuby: true
```

## What it reaches

`Numeric#zero?` is `self == 0`
([`mrbgems/mruby-numeric-ext/mrblib/numeric_ext.rb:11-13`](https://github.com/mruby/mruby/blob/66d3f0a02/mrbgems/mruby-numeric-ext/mrblib/numeric_ext.rb#L11-L13))
and `Integer` does not override it, so the same read decides it, and anything comparing with
`==` inherits it:

```ruby
(2 ** 64).zero?          # mruby: true    CRuby: false
[2 ** 64].include?(0)    # mruby: true    CRuby: false
```

## The fix

`mrb_bigint_p(x)` already opens more than twenty functions in `src/numeric.c`, including
`num_eql()` and every arithmetic entry point. `int_equal()` was the outlier.

A Bigint receiver now goes through `mrb_bint_cmp()`, which is what `num_eql()` uses for the
same job. The guard is restricted to Integer, Bigint and Float arguments, following the shape
`int_div()` already uses: `mrb_bint_cmp()` reports a type mismatch for Rational and Complex,
so letting those fall through to the existing switch keeps `(2 ** 70) == Rational(2 ** 70, 1)`
answering true.

With the patch, `(2**64 + 5) == 5`, `(2**64) == 0`, `(2**64 - 1) == -1`, `-(2**64 + 5) == 5`,
`(2**160 + 5) == 5`, `(2**64).zero?` and `[2**70].include?(0)` all become false;
`(2**70) == (2.0**70)` becomes true, which is what CRuby answers; and `5 == (2**70)`,
`(2**70) == (2**70)`, `(2**70) == Rational(2**70, 1)`, `(2**70) == "x"` and `(2**70) == nil`
are unchanged.

## Tests

`rake test` covered none of this: it reported 1956 tests, 1938 OK, 0 failures both with and
without the patch. The new `Bigint ==` assertions in `mrbgems/mruby-bigint/test/bigint.rb`
fail on master and pass with the fix.

Verified green with `rake test` on `build_config/host.rb` and on all three boxings
(`MRB_NO_BOXING`, `MRB_NAN_BOXING`, `MRB_WORD_BOXING`) with the `default` gembox.
`src/numeric.c` also compiles clean under `MRB_NO_FLOAT` with `MRB_USE_BIGINT`.

## Not addressed here

Two adjacent divergences survive this patch. They are a different bug and folding them in
would widen the change:

```ruby
(2.0 ** 70) == (2 ** 70)     # mruby: false   CRuby: true
(2 ** 70).eql?(2.0 ** 70)    # mruby: true    CRuby: false
```

The first is the Float receiver path. The second is `num_eql()` itself, which compares
through `mrb_bint_cmp()` without first requiring the argument to be an Integer, where `eql?`
should answer false for a Float outright.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved BigInt equality comparisons to evaluate the full numeric value.
  * Fixed comparisons between BigInts and integers, floating-point values, and other numeric types.
  * Added regression coverage for large values, negative numbers, arithmetic results, zero, and unrelated types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->