### PR TITLE
string.c: check the append size before mrb_str_cat() modifies

### DIFF
--- a/src/string.c
+++ b/src/string.c
@@ -3136,17 +3136,22 @@ mrb_str_cat(mrb_state *mrb, mrb_value str, const char *ptr, size_t len)
   ptrdiff_t off = -1;
 
   if (len == 0) return str;
+  /* `len` has to be known to fit in an `mrb_int` before it is used as one:
+     the conversion is otherwise free to make it negative, and the overflow
+     check takes `mrb_int` parameters, so it would not see it. Checking ahead
+     of the modification also leaves the string untouched when it raises. */
+  mrb_int total;
+  if (len > (size_t)MRB_INT_MAX ||
+      mrb_int_add_overflow(RSTR_LEN(s), (mrb_int)len, &total)) {
+  size_error:
+    mrb_raise(mrb, E_ARGUMENT_ERROR, "string size too big");
+  }
   mrb_str_modify(mrb, s);
   if (ptr >= RSTR_PTR(s) && ptr <= RSTR_PTR(s) + (size_t)RSTR_LEN(s)) {
       off = ptr - RSTR_PTR(s);
   }
 
   mrb_int capa = RSTR_CAPA(s);
-  mrb_int total;
-  if (mrb_int_add_overflow(RSTR_LEN(s), len, &total)) {
-  size_error:
-    mrb_raise(mrb, E_ARGUMENT_ERROR, "string size too big");
-  }
   if (capa <= total) {
     if (capa == 0) capa = 1;
     while (capa <= total) {


### PR DESCRIPTION
## Summary

`mrb_str_cat()` takes `len` as a `size_t` and hands it to `mrb_int_add_overflow()`, whose
parameters are `mrb_int`. A `len` above `MRB_INT_MAX` is therefore converted before the
check can see it, and the conversion yields a negative value on the builds mruby targets.
The addition then does not overflow, `total` comes out below the current length, the
capacity branch is skipped, and `memcpy()` still runs with the original `size_t` count,
writing past the buffer.

```c
mrb_str_cat(mrb, str, ptr, len);   /* len > MRB_INT_MAX */
```

Nothing inside mruby reaches this. Every internal caller passes a length that came from a
string, and `str_check_length()` keeps those below `MRB_INT_MAX`. An extension calling the
public `mrb_str_cat()` with a length it computed itself can, and a length arriving from
outside is exactly the case a size check is there for.

## The change

Reject a `len` that does not fit before it is converted:

```c
  if (len > (size_t)MRB_INT_MAX ||
      mrb_int_add_overflow(RSTR_LEN(s), (mrb_int)len, &total)) {
  size_error:
    mrb_raise(mrb, E_ARGUMENT_ERROR, "string size too big");
  }
```

The comparison is correct in both directions of the type mismatch. Where `size_t` is
narrower than `mrb_int`, `MRB_INT_MAX` is all ones in its low bits, so the conversion
lands on `SIZE_MAX` and the condition is never true. That is the right answer there, since
no `size_t` can exceed `MRB_INT_MAX` on such a build in the first place.

The whole size check moves ahead of `mrb_str_modify()` as well. `RSTR_LEN(s)` is the same
before and after that call, so the check reads the same value, and a string that is about
to raise is no longer unshared first.

## Relation to #7039 and #7043

Both touch the same handful of lines at the top of `mrb_str_cat()`. #7039 carries this
commit as its first of two, since it depends on the check being in place. #7043 is
independent of both. Whichever lands first, I will rebase the others onto it.

## Testing

`rake test` with `build_config/default.rb`, `MRUBY_CONFIG=asan rake test`
(`address,undefined`), and `MRUBY_CONFIG=ci/gcc-clang rake test`, which covers
`MRB_GC_STRESS` with `MRB_USE_DEBUG_HOOK`, `MRB_GC_FIXED_ARENA`, and the C++ ABI build.
`KO: 0` and `Crash: 0` on all of them.
