### PR TITLE
string.c: append into a shared buffer instead of copying it

### DIFF
--- a/mrbgems/mruby-string-ext/test/string.rb
+++ b/mrbgems/mruby-string-ext/test/string.rb
@@ -105,6 +105,77 @@ assert('String#concat') do
   end
 end
 
+assert('String#concat on a shared buffer') do
+  # An append to a string that shares its buffer writes into the spare
+  # capacity above what every other sharer can see, and each sharer has to
+  # keep the bytes it owns. Every string below is grown by appending before
+  # it is shared, since a string that was never appended to has no spare
+  # capacity and every append to it copies the buffer instead.
+
+  # The parent appends in place; an interior slice must not see it.
+  a = "a" * 100
+  a << "z" * 100
+  mid = a[0, 100]
+  a << "q"
+  assert_equal "a" * 100 + "z" * 100 + "q", a
+  assert_equal "a" * 100, mid
+  mid << "r"
+  assert_equal "a" * 100 + "r", mid
+  assert_equal "a" * 100 + "z" * 100 + "q", a
+
+  # Two strings that end at the same offset: the first append claims the
+  # bytes, and the other one has to take a copy of the buffer.
+  b = "b" * 100
+  b << "y" * 100
+  c = b.dup
+  b << "1"
+  c << "2"
+  assert_equal "b" * 100 + "y" * 100 + "1", b
+  assert_equal "b" * 100 + "y" * 100 + "2", c
+
+  # The same in the other order.
+  d = "d" * 100
+  d << "w" * 100
+  e = d.dup
+  e << "1"
+  d << "2"
+  assert_equal "d" * 100 + "w" * 100 + "1", e
+  assert_equal "d" * 100 + "w" * 100 + "2", d
+
+  # A tail slice ends where its parent does, so the same rule applies.
+  f = "f" * 100
+  f << "v" * 100
+  g = f[170, 30]
+  g << "1"
+  f << "2"
+  assert_equal "v" * 30 + "1", g
+  assert_equal "f" * 100 + "v" * 100 + "2", f
+
+  # Appending and slicing in a loop, the shape the copy made quadratic.
+  h = ""
+  50.times { h << "0123456789012345678901234567890123456789"; h[0, 30] }
+  assert_equal 2000, h.length
+  assert_equal "0123456789012345678901234567890123456789", h[-40, 40]
+
+  # Appending a slice of a buffer to the string it was taken from.
+  i = "i" * 100
+  i << "j" * 100
+  k = i[0, 40]
+  i << k
+  assert_equal "i" * 100 + "j" * 100 + "i" * 40, i
+  assert_equal "i" * 40, k
+
+  # A frozen sharer still raises, and does not stop the others.
+  l = "l" * 100
+  l << "m" * 100
+  n = l.dup
+  n.freeze
+  assert_raise(FrozenError) { n << "x" }
+  l << "y"
+  assert_equal "l" * 100 + "m" * 100 + "y", l
+  assert_equal "l" * 100 + "m" * 100, n
+end
+
 assert('String#casecmp') do
   assert_equal 1, "abcdef".casecmp("abcde")
   assert_equal 0, "aBcDeF".casecmp("abcdef")

--- a/src/string.c
+++ b/src/string.c
@@ -21,6 +21,10 @@
 typedef struct mrb_shared_string {
   int refcnt;
   mrb_int capa;
+  /* Offset past the last byte any sharer can see. Bytes at or above it are
+     dead to every sharer, so a writer may use them in place (str_modify_cat).
+     Only grows, as sharers are added. */
+  mrb_int reserved;
   char *ptr;
 } mrb_shared_string;
 
@@ -109,6 +113,8 @@ static struct RString*
 str_init_shared(mrb_state *mrb, const struct RString *orig, struct RString *s, mrb_shared_string *shared)
 {
   if (shared) {
+    mrb_int end = (mrb_int)(orig->as.heap.ptr - shared->ptr) + orig->as.heap.len;
+    if (shared->reserved < end) shared->reserved = end;
     shared->refcnt++;
   }
   else {
@@ -116,6 +122,7 @@ str_init_shared(mrb_state *mrb, const struct RString *orig, struct RString *s, m
     shared->refcnt = 1;
     shared->ptr = orig->as.heap.ptr;
     shared->capa = orig->as.heap.aux.capa;
+    shared->reserved = orig->as.heap.len;
   }
   s->as.heap.ptr = orig->as.heap.ptr;
   s->as.heap.len = orig->as.heap.len;
@@ -766,10 +773,8 @@ str_share(mrb_state *mrb, struct RString *orig, struct RString *s)
     str_init_fshared(orig, s, orig->as.heap.aux.fshared);
   }
   else {
-    if (orig->as.heap.aux.capa > orig->as.heap.len) {
-      orig->as.heap.ptr = (char*)mrb_realloc(mrb, orig->as.heap.ptr, len+1);
-      orig->as.heap.aux.capa = (mrb_ssize)len;
-    }
+    /* Spare capacity is kept, not trimmed: it lies above `reserved`, so
+       `orig` can still append into it without copying the buffer. */
     str_init_shared(mrb, orig, s, NULL);
     str_init_shared(mrb, orig, orig, s->as.heap.aux.shared);
   }
@@ -3118,6 +3123,37 @@ mrb_str_dump(mrb_state *mrb, mrb_value str)
   return str_escape(mrb, str, FALSE);
 }
 
+/* mrb_str_modify() for appending `addlen` bytes at the end of `s`.
+   An append only touches [len, len+addlen), which no other sharer of the
+   buffer can see, so the buffer copy that mrb_str_modify() would do can be
+   skipped as long as the write stays inside the shared allocation. Growing
+   past it still has to detach, but capacity grows geometrically, so the
+   copies are amortized instead of one per append.
+   `addlen` must not be negative: it would pass the capacity guard below and
+   then lower `reserved`, handing bytes another sharer still reads to the
+   appender. mrb_str_cat() rejects a length that does not fit beforehand.
+   Returns the usable capacity of `s`. */
+static mrb_int
+str_modify_cat(mrb_state *mrb, struct RString *s, mrb_int addlen)
+{
+  mrb_assert(addlen >= 0);
+  if (RSTR_SHARED_P(s)) {
+    mrb_check_frozen(mrb, s);
+    mrb_shared_string *shared = s->as.heap.aux.shared;
+    mrb_int off = (mrb_int)(s->as.heap.ptr - shared->ptr);
+    mrb_int capa = shared->capa - off;
+    if (off + s->as.heap.len >= shared->reserved && addlen < capa - s->as.heap.len) {
+      /* The appended bytes belong to `s` from now on, so no other sharer may
+         write over them. */
+      shared->reserved = off + s->as.heap.len + addlen;
+      RSTR_UNSET_SINGLE_BYTE_FLAG(s);
+      return capa;
+    }
+  }
+  mrb_str_modify(mrb, s);
+  return RSTR_CAPA(s);
+}
+
 /*
  * @param mrb The mruby state.
  * @param str The mruby string to append to (modified in place).
@@ -3146,12 +3182,11 @@ mrb_str_cat(mrb_state *mrb, mrb_value str, const char *ptr, size_t len)
   size_error:
     mrb_raise(mrb, E_ARGUMENT_ERROR, "string size too big");
   }
-  mrb_str_modify(mrb, s);
+  mrb_int capa = str_modify_cat(mrb, s, (mrb_int)len);
   if (ptr >= RSTR_PTR(s) && ptr <= RSTR_PTR(s) + (size_t)RSTR_LEN(s)) {
       off = ptr - RSTR_PTR(s);
   }
 
-  mrb_int capa = RSTR_CAPA(s);
   if (capa <= total) {
     if (capa == 0) capa = 1;
     while (capa <= total) {

--- a/src/string.c
+++ b/src/string.c
@@ -3136,17 +3136,22 @@ mrb_str_cat(mrb_state *mrb, mrb_value str, const char *ptr, size_t len)
   ptrdiff_t off = -1;
 
   if (len == 0) return str;
+  /* `len` has to be known to fit in an `mrb_int` before it is used as one:
+     the conversion is otherwise free to make it negative, and the overflow
+     check takes `mrb_int` parameters, so it would not see it. Checking ahead
+     of the modification also leaves the string untouched when it raises. */
+  mrb_int total;
+  if (len > (size_t)MRB_INT_MAX ||
+      mrb_int_add_overflow(RSTR_LEN(s), (mrb_int)len, &total)) {
+  size_error:
+    mrb_raise(mrb, E_ARGUMENT_ERROR, "string size too big");
+  }
   mrb_str_modify(mrb, s);
   if (ptr >= RSTR_PTR(s) && ptr <= RSTR_PTR(s) + (size_t)RSTR_LEN(s)) {
       off = ptr - RSTR_PTR(s);
   }
 
   mrb_int capa = RSTR_CAPA(s);
-  mrb_int total;
-  if (mrb_int_add_overflow(RSTR_LEN(s), len, &total)) {
-  size_error:
-    mrb_raise(mrb, E_ARGUMENT_ERROR, "string size too big");
-  }
   if (capa <= total) {
     if (capa == 0) capa = 1;
     while (capa <= total) {


### PR DESCRIPTION
## Summary

Taking a substring longer than `RSTRING_EMBED_LEN_MAX` (27 bytes on a 64-bit build)
shares the parent's buffer, and `str_share()` trims the parent's spare capacity away when
it does. Every later append to the parent therefore has to unshare, which copies the
entire buffer. A loop that appends and looks at a slice does O(N) work per iteration and
O(N^2) in total, even when the slice is dropped immediately and nothing is retained.

An append only writes `[len, len + addlen)`, a region no other holder of the buffer can
see, so that copy is the conservative "never write into a shared buffer" rule rather than
something correctness needs. This adds a `reserved` watermark to `mrb_shared_string`, the
offset past the last byte any sharer can see, stops trimming spare capacity on share, and
routes `mrb_str_cat()` through a new `str_modify_cat()` that appends in place when the
string ends at or above the watermark and the write stays inside the allocation. Growing
past the allocation still detaches, but capacity grows geometrically, so those copies are
amortized instead of one per append.

The first of the two commits here is the one sent separately as #7038, and it is a
prerequisite rather than a cleanup. `mrb_str_cat()` takes `len` as a `size_t` and hands it
to `mrb_int_add_overflow()`, whose parameters are `mrb_int`, so a length above
`MRB_INT_MAX` reaches the check already converted and negative. That is a latent
out-of-bounds `memcpy()` on master on its own, and with the watermark in place it would
additionally *lower* the watermark, which is the one way a co-sharer can be handed bytes
another string still reads. If #7038 lands first, this branch rebases onto it and the
commit disappears from here.

#7043 is a third change to the same handful of lines, independent of both this and #7038.
Whichever of the three lands first, I will rebase the others onto it.

## Measurements

`build_config/default.rb` (`-g -O3`), gcc 13.3.0, Linux x86_64, 64-bit build, no boxing
overrides. Time and peak RSS from `/usr/bin/time`, each run under a 6 GB `RLIMIT_AS`.
CRuby 4.0.6 is there for scale, not as a target.

Dropping the slice at once, so nothing is retained and the live data is one string:

```ruby
s = ""
n.times { s << "abcdefghijabcdefghij"; s[0, 30] }
```

| N | before | after | CRuby 4.0.6 |
| ---: | --- | --- | --- |
| 10000 | 0.55 s / 96.8 MB | 0.00 s / 3.8 MB | 0.04 s / 13.9 MB |
| 20000 | 2.71 s / 193.0 MB | 0.00 s / 3.8 MB | 0.04 s / 13.9 MB |
| 40000 | 8.40 s / 388.0 MB | 0.00 s / 4.5 MB | 0.04 s / 15.2 MB |
| 80000 | 35.19 s / 778.1 MB | 0.01 s / 5.5 MB | 0.05 s / 16.2 MB |

`dup` alone, with no slicing at all:

```ruby
s = ""
n.times { s << "0123456789012345678901234567890123456789"; t = s.dup }
```

| N | before | after | CRuby 4.0.6 |
| ---: | --- | --- | --- |
| 5000 | 0.25 s / 91.5 MB | 0.00 s / 3.8 MB | 0.39 s / 61.0 MB |
| 10000 | 1.02 s / 191.4 MB | 0.00 s / 3.8 MB | 1.04 s / 61.3 MB |
| 20000 | 3.82 s / 382.4 MB | 0.00 s / 4.5 MB | 2.86 s / 61.5 MB |
| 40000 | 16.90 s / 772.6 MB | 0.01 s / 5.4 MB | 7.28 s / 61.5 MB |

Consuming a line buffer, the shape an incremental parser or a log scanner has. The slice
is most of the buffer here, so no threshold on slice size would cover it:

```ruby
buf = ""
n.times do |i|
  buf << "hello world this is a line of text\n"
  if (i % 3) == 0
    idx = buf.index("\n")
    buf = buf[(idx + 1)..-1]
  end
end
```

| N | before | after | CRuby 4.0.6 |
| ---: | --- | --- | --- |
| 25000 | 1.10 s / 111.8 MB | 0.00 s / 5.0 MB | 1.17 s / 59.9 MB |
| 50000 | 5.16 s / 233.1 MB | 0.01 s / 5.7 MB | 3.53 s / 61.8 MB |
| 100000 | 20.54 s / 472.4 MB | 0.03 s / 6.7 MB | 8.71 s / 55.1 MB |

What is left grows linearly. The first loop:

| N | after |
| ---: | --- |
| 80000 | 0.02 s / 5.6 MB |
| 160000 | 0.05 s / 8.2 MB |
| 320000 | 0.10 s / 13.3 MB |
| 640000 | 0.14 s / 23.0 MB |

Retaining every slice is quadratic in memory on master and in CRuby alike, because each
retained slice pins a full-length snapshot. It stops being quadratic here, since every
slice and the parent go on sharing one buffer:

```ruby
subs = []
s = ""
n.times { s << "0123456789012345678901234567890123456789"; subs << s[-30, 30] }
```

| N | before | after | CRuby 4.0.6 |
| ---: | --- | --- | --- |
| 2000 | 0.05 s / 80.2 MB | 0.00 s / 3.8 MB | 0.13 s / 97.3 MB |
| 5000 | 0.41 s / 486.7 MB | 0.00 s / 4.0 MB | 0.36 s / 507.7 MB |
| 10000 | 1.25 s / 1927.0 MB | 0.00 s / 4.5 MB | 1.04 s / 1947.7 MB |

Shapes with no shared buffer in them are unchanged, best of seven interleaved runs at
n = 2000000:

| shape | before | after |
| --- | --- | --- |
| `s << "abcdefghijabcdefghij"` | 0.16 s | 0.16 s |
| `src[100, 200]` | 0.18 s | 0.19 s |
| `a + "z"` | 0.31 s | 0.32 s |
| `"#{a}:#{a}"` | 0.29 s | 0.29 s |
| `s.sub("quick", "slow")` | 2.97 s | 3.00 s |

## The invariant

The watermark must only ever grow. `str_init_shared()` raises it to the end of every
string that joins the buffer, and an in-place append raises it past the bytes it claims.
Otherwise two strings sharing one buffer would both write at the same offset and silently
corrupt each other:

```ruby
s1 = "a" * 100
s1 << "z" * 100
s1 = s1[0, 100]
s2 = s1.dup
s1 << "x"
s2 << "y"
s1              # "a" * 100 + "x"
s2              # "a" * 100 + "y"
```

Whichever of the two appends first claims the bytes; the other no longer ends at the
watermark and copies the buffer as it did before. The same holds for a tail slice and its
parent, whose ends coincide: the first append wins and the second one detaches. Both
orders, the interior-slice case, appending a slice of a buffer to the string it came from,
and a frozen sharer are covered by the test added to `mruby-string-ext`.

## Consequences

- A `const char*` obtained from `mrb_string_value_cstr()` can lose its NUL terminator when
  another string sharing the buffer is appended to, because the in-place write can land on
  that byte. Ruby level code is unaffected: `mrb_string_value_cstr()` already detects a
  missing terminator and unshares. The repair is not free, though, since it then returns a
  pointer into a fresh allocation, so an extension caching the pointer across mruby
  operations is left holding a stale pointer rather than merely an unterminated one.
- Keeping spare capacity on share means a retained `dup` or slice of a string built by
  appending can pin up to twice the bytes it does today. I could not get this to show up
  in peak RSS, because the untouched tail of the allocation is never faulted in, but the
  virtual size is real.

`MRB_STR_FSHARED` strings and growth through `mrb_str_resize()` still detach in full.
Neither shape measured here needs otherwise, and both are room for a follow-up rather than
part of this change.

## Testing

All green, `KO: 0` and `Crash: 0` everywhere:

- `rake test` with `build_config/default.rb`
- `MRUBY_CONFIG=asan rake test` (`address,undefined`)
- `MRUBY_CONFIG=ci/gcc-clang rake test`, which covers `MRB_GC_STRESS` with
  `MRB_USE_DEBUG_HOOK`, `MRB_GC_FIXED_ARENA`, and the C++ ABI build
- `MRB_UTF8_STRING`
- `MRB_INT32` with `MRB_WORD_BOXING` and `MRB_UTF8_STRING`
- `MRB_NAN_BOXING`

The `MRB_NAN_BOXING` build fails three `mruby-string-bitops` assertions, and fails the
same three on master with this branch reverted, so they are not from this change.
