### PR TITLE
vm.c: answer str[0] from C in OP_GETIDX0

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -2143,6 +2143,21 @@ vm_op_getidx0(mrb_state *mrb, uint32_t a, uint16_t b, mrb_sym *midp)
     }
     return VM_NEXT;
   }
+  else if (tt == MRB_TT_STRING) {
+    /* optimize only for String class; subclasses/singleton may override [] */
+    if (mrb_obj_ptr(recv)->c != mrb->string_class) goto getidx0_fallback;
+    {
+      /* mrb_str_aref() allocates, and an inline opcode never runs the cfunc
+         epilogue that would shrink the arena, so save and restore it here.
+         Unlike the Hash branch above, `ci` needs no refresh: this call cannot
+         run Ruby code and so cannot move the stack. */
+      int ai = mrb_gc_arena_save(mrb);
+      mrb_value val = mrb_str_aref(mrb, recv, mrb_fixnum_value(0), mrb_undef_value());
+      regs[a] = val;
+      mrb_gc_arena_restore(mrb, ai);
+    }
+    return VM_NEXT;
+  }
 getidx0_fallback:
   regs[a] = recv;
   SET_FIXNUM_VALUE(regs[a+1], 0);

--- a/test/t/gc.rb
+++ b/test/t/gc.rb
@@ -148,6 +148,18 @@ assert('OP_GETIDX does not retain a Hash default in the GC arena') do
   assert_operator GC.stat[:live] - base, :<, 5000
 end
 
+assert('OP_GETIDX0 does not retain a String result in the GC arena') do
+  s = "hello"
+  GC.start
+  base = GC.stat[:live]
+  i = 0
+  while i < 20000
+    s[0]
+    i += 1
+  end
+  assert_operator GC.stat[:live] - base, :<, 5000
+end
+
 assert('OP_GETIDX0 does not retain a Hash default in the GC arena') do
   h = Hash.new { Object.new }
   GC.start

--- a/test/t/string.rb
+++ b/test/t/string.rb
@@ -126,6 +126,34 @@ assert('String#[] with Range') do
   assert_equal 'xyz', k2
 end
 
+assert('String#[] redefined on String itself is bypassed by the index opcodes') do
+  # `OP_GETIDX` answers `s[1]` from C, and `OP_GETIDX0` answers `s[0]` the same
+  # way, whenever the receiver's class is exactly `String`. Both therefore
+  # bypass a redefinition installed on `String` itself, the same way the Array
+  # and Hash branches of those opcodes do. A subclass receiver fails the class
+  # guard and keeps reaching the redefinition.
+  String.class_eval do
+    alias_method :__aref_before_test, :[]
+    def [](*args)
+      :overridden
+    end
+  end
+  begin
+    s = 'hello'
+    sub = Class.new(String).new('hello')
+    assert_equal 'h', s[0]
+    assert_equal 'e', s[1]
+    assert_equal :overridden, sub[0]
+  ensure
+    String.class_eval do
+      alias_method :[], :__aref_before_test
+      # `remove_method` comes from mruby-metaprog, which the core test build
+      # does not have; the saved alias is harmless where it is missing.
+      remove_method :__aref_before_test if respond_to?(:remove_method, true)
+    end
+  end
+end
+
 assert('String#[]=') do
   # length of args is 1
   a = 'abc'


### PR DESCRIPTION
## The gap

`vm_op_getidx0()` answers `ary[0]` and `hash[0]` from C and has no String
branch, so `str[0]` is the one index form of the three that leaves the opcode
through `getidx0_fallback` and reaches `String#[]` as an ordinary send. Its
sibling `vm_op_getidx()` does have a String branch, so `str[1]` is already
answered in C. The two opcodes disagree about String for no reason other than
the branch never having been written.

## What it costs

| `n` | `str[0]` before | after |
|---|---|---|
| 800000 | 35 ms | 21 ms |
| 3200000 | 137 ms | 87 ms |

Best of seven runs each, alternating the two binaries, with
`while i < n; s[0]; i += 1; end` over a local. Both are linear, so this is a
constant factor rather than a complexity change.

## The arena restore is not optional

`mrb_str_aref()` returns a freshly allocated String, and an inline opcode never
runs the cfunc epilogue that would shrink the arena. That is the bug #7022
fixed across the allocating inline opcodes, including the Hash branch of this
same `vm_op_getidx0()`. A String branch written without the save and restore
would re-open it one index form later: the loop above becomes quadratic, and
under `MRB_GC_FIXED_ARENA`, which `build_config/ci/gcc-clang.rb` and
`build_config/ci/msvc.rb` both define, it raises instead:

```console
$ ./build/fixedarena/bin/mruby -e 's="hello"; i=0; while i < 20000; s[0]; i+=1; end'
-e:1: arena overflow error (NoMemoryError)
```

With the restore in place the same command prints nothing and exits 0.

Unlike the Hash branch above it, this one does not refresh `ci` afterwards:
`mrb_str_aref()` on a plain String with an Integer index cannot run Ruby code
and so cannot move the stack. The result needs no `mrb_gc_protect()` either,
since it is stored in `regs[a]` and the VM stack is a GC root, which is why the
cfunc epilogues can shrink unconditionally too.

## It changes what a redefined `String#[]` sees

The class guard reads the receiver's class, not whether `String#[]` has been
redefined, so the branch bypasses a redefinition installed on `String` itself:

```ruby
class String
  def [](i); "OVERRIDDEN"; end
end
s = "hello"
p s[0]              # => "OVERRIDDEN" before, "h" now
p s[1]              # => "e" before and now
p s.send(:[], 0)    # => "OVERRIDDEN" both ways

class Sub < String; end
p Sub.new("hello")[0]   # => "OVERRIDDEN" both ways
```

The change is to make `s[0]` agree with `s[1]`, which has ignored such a
redefinition ever since `vm_op_getidx()` gained its String branch. A subclass
receiver keeps reaching the override, because the guard rejects it. Whether the
existing `s[1]` behaviour is right is a separate and much larger question,
since the Array and Hash branches of both opcodes work the same way; this
change does not widen it beyond one more index form.

## Which shapes reach the opcode

`OP_GETIDX0` is emitted for a literal zero index only when the receiver is
already in a register: a local, a method argument, a block-local. These are
`OP_GETIDX0`, and slow before this change:

```ruby
s = "hello"; s[0]                          # GETIDX0
def m(u); u[0]; end                        # GETIDX0
[1].each { |x| t = "hi"; t[0] }            # GETIDX0
```

and these are not, because the receiver has to be materialized first, after
which the compiler emits the general `OP_GETIDX` with a `LOADI_0` beside it and
the String branch of that opcode answers it in C:

```ruby
s = "hello"; [1].each { s[0] }             # GETUPVAR + LOADI_0 + GETIDX
@iv[0]                                     # GETIV + LOADI_0 + GETIDX
```

A benchmark that puts the loop inside a block over an outer `s` therefore
measures the C path and shows no difference at all. The figures above all come
from a `while` loop over a local.

## The tests

`test/t/gc.rb` already carries an `OP_GETIDX0` arena assertion for the Hash
branch, added by #7022. The new one is a second assertion for the same opcode,
naming the branch it pins so the two do not read as one assertion moved. It
passes without this change, since there is nothing to leak without a String
branch, and is there to fail if the branch is ever added or rewritten without
the restore. Checked both ways: it passes with the branch as written, and fails
with the same branch minus the two arena calls.

`test/t/string.rb` gets an assertion for the redefinition case above, which
nothing in the suite covered, and it pins both index forms at once. It restores
`String#[]` in an `ensure`. The saved alias is removed only where
`remove_method` exists, since that comes from mruby-metaprog and the core test
build does not have it; for the same reason the assertion does not use `send`.

## Checked configurations

All at `mruby/mruby@9df343588`, with the change applied.

| build | result |
|---|---|
| host (`build_config/default.rb`) | 1961 OK, 0 KO, 0 Crash |
| `full-debug` (`MRB_GC_STRESS`, `MRB_USE_DEBUG_HOOK`) | 2138 OK, 0 KO, 0 Crash |
| `MRB_GC_FIXED_ARENA` + bintest | 2138 OK, 0 KO, 0 Crash |
| `cxx_abi` | 2138 OK, 0 KO, 0 Crash |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved string indexing at position 0 for faster execution with standard strings.

- **Bug Fixes**
  - Prevented temporary indexing results from being retained during garbage collection.
  - Ensured indexed access respects custom behavior for string subclasses while preserving optimized behavior for standard strings.

- **Tests**
  - Added coverage for garbage collection and string indexing overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->