### PR TITLE
mruby-regexp: keep a character class open past `[:name:]` and a leading `]`

### DIFF
--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -1140,6 +1140,19 @@ strip_extended(mrb_state *mrb, const char *src, mrb_int len, mrb_int *out_len)
       continue;
     }
     if (in_class) {
+      /* compile_charclass() consumes a POSIX bracket as a unit, so the ']'
+         of [:name:] does not end the class. Copy it whole and keep the
+         class open; a malformed bracket falls through and the '[' is
+         copied as an ordinary member, which is what the parser does too. */
+      if (ch == '[' && src + 1 < end && src[1] == ':') {
+        const char *q = src + 2;
+        while (q < end && *q != ':' && *q != ']') q++;
+        if (q + 1 < end && *q == ':' && q[1] == ']') {
+          q += 2;
+          while (src < q) buf[o++] = *src++;
+          continue;
+        }
+      }
       if (ch == ']') in_class = FALSE;
       buf[o++] = *src++;
       continue;
@@ -1147,6 +1160,10 @@ strip_extended(mrb_state *mrb, const char *src, mrb_int len, mrb_int *out_len)
     if (ch == '[') {
       in_class = TRUE;
       buf[o++] = *src++;
+      /* A ']' written first is a literal member, optionally after '^',
+         mirroring the `first` flag in compile_charclass(). */
+      if (src < end && *src == '^') buf[o++] = *src++;
+      if (src < end && *src == ']') buf[o++] = *src++;
       continue;
     }
     if (ch == '#') {

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -589,6 +589,27 @@ assert("Regexp extended mode (x flag)") do
   re = Regexp.new('[ ]', Regexp::EXTENDED)
   assert_true re.match?(" ")
 
+  # a POSIX bracket does not end the class, so what follows it is still
+  # class content
+  re = Regexp.new('[[:alpha:] ]', Regexp::EXTENDED)
+  assert_true re.match?(" ")
+  assert_true re.match?("a")
+
+  re = Regexp.new('[[:alpha:]#x]', Regexp::EXTENDED)
+  assert_true re.match?("#")
+
+  assert_equal " 1 ", Regexp.new('[[:digit:] ]+', Regexp::EXTENDED).match(" 1 ")[0]
+
+  # a ']' written first in a class is a literal member, so the class is
+  # still open after it
+  re = Regexp.new('[] ]', Regexp::EXTENDED)
+  assert_true re.match?(" ")
+  assert_true re.match?("]")
+
+  re = Regexp.new('[^] ]', Regexp::EXTENDED)
+  assert_false re.match?(" ")
+  assert_true re.match?("a")
+
   # escaped whitespace is preserved
   re = Regexp.new('a\\ b', Regexp::EXTENDED)
   assert_true re.match?("a b")


### PR DESCRIPTION
The `/x` preprocessing pass ends a character class at the first `]` it sees, so
class content written after a POSIX bracket or after a leading literal `]` is
treated as free-spacing text and stripped.

`strip_extended()` clears its `in_class` flag on any `]`. `compile_charclass()`
does not: the `]` that closes `[:alpha:]` is consumed inside the class, and a
`]` written first in a class is a literal member. The two disagree, so the pass
hands the parser a pattern the user did not write, and the parser compiles it
without complaint.

```ruby
Regexp.new("[[:alpha:] ]", Regexp::EXTENDED) =~ " "
# CRuby: 0
# mruby: nil     the space is stripped, leaving /[[:alpha:]]/
```

A `#` after the bracket starts a line comment, so the rest of the class is lost
rather than a single character.

```ruby
Regexp.new("[[:alpha:]#x]", Regexp::EXTENDED)
# CRuby: compiles, matches "#"
# mruby: RegexpError (unterminated character class: /[[:alpha:]#x]/)
```

The literal `]` diverges in both directions: one drops a character the class was
meant to contain, the other keeps one it was meant to exclude.

```ruby
Regexp.new("[] ]", Regexp::EXTENDED) =~ " "
# CRuby: 0
# mruby: nil

Regexp.new("[^] ]", Regexp::EXTENDED) =~ " "
# CRuby: nil
# mruby: 0
```

Only `/x` patterns are affected. `mrb_re_compile()` runs the pass only when
`RE_FLAG_EXTENDED` is set, so an ordinary pattern never reaches it.

## Fix

Both additions are written to agree with `compile_charclass()` rather than to
re-derive character class rules.

- Inside a class, a POSIX bracket is copied as a unit. On `[` followed by `:`,
  scan to the first `:` or `]`; if the terminator is `:]`, copy through it
  without touching `in_class`. Otherwise fall through and copy the `[` as an
  ordinary member, which is the same outcome the parser reaches when it resets
  to its saved position.
- On entering a class, an optional `^` and then an optional `]` are copied
  before returning to the loop, mirroring the `first` flag in
  `compile_charclass()`.

Both sit after the backslash pass-through, which stays first, so `\]` inside a
class keeps its existing handling and never reaches either branch. The pass
keeps its single `in_class` flag and its output buffer: neither addition emits
more bytes than it consumes, so the buffer bound is unchanged.

## Behaviour

Measured against CRuby 4.0.6.

| Pattern (`Regexp::EXTENDED`) | CRuby | before | after |
|---|---|---|---|
| `[[:alpha:] ] =~ " "` | `0` | `nil` | `0` |
| `[[:digit:] ]+` over `" 1 "` | `" 1 "` | `"1"` | `" 1 "` |
| `[[:alpha:]#x] =~ "#"` | `0` | `RegexpError` | `0` |
| `[] ] =~ " "` | `0` | `nil` | `0` |
| `[^] ] =~ " "` | `nil` | `0` | `nil` |

CRuby warns `character class has ']' without escape` for the last two, and its
parser rejects the literal form `/[]]/` outright, but `Regexp.new` accepts the
string form and reads the `]` as a literal, which is what mruby's parser does
too.

## Tests

The four cases above are added to `assert("Regexp extended mode (x flag)")` in
`mrbgems/mruby-regexp/test/regexp.rb`, next to the existing case for whitespace
inside a character class. The block's other assertions cover the regression
side: free-spacing outside a class must keep working.

`rake test` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved extended-mode regular expressions to correctly handle POSIX character classes such as `[:alpha:]`.
  * Preserved spaces, `#`, and literal closing brackets inside character classes.
  * Ensured quantifiers and negated character classes behave correctly in these cases.

* **Tests**
  * Added coverage for POSIX classes and extended character-class parsing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->