### PR TITLE
mruby-regexp: convert a Bigint `String#split` limit

### DIFF
--- a/mrbgems/mruby-regexp/mrblib/string_regexp.rb
+++ b/mrbgems/mruby-regexp/mrblib/string_regexp.rb
@@ -138,12 +138,10 @@ class String
     # `ary[obj]` and `"s" * obj` all reject an object that only defines
     # `to_int`; dispatching it here would leave this the one place in the tree
     # that accepts one, as the same reasoning keeps `match` off `to_str`.
-    # `is_a?` is redefinable, so a limit claiming to be an Integer would skip
-    # that conversion and reach the arithmetic below as itself. `Module#===`
-    # reads the real type and cannot be redefined.
-    if limit_given && !(Integer === limit)
-      limit = Integer.__ensure(limit)
-    end
+    # Every limit goes through it, an Integer included: a Bigint is an Integer
+    # and does not fit `mrb_int`, and `__ensure` is what narrows it and raises
+    # the `RangeError` `__split` raises on the string path.
+    limit = Integer.__ensure(limit) if limit_given
     # `nil?` and `is_a?` are redefinable, so an argument answering either one
     # could steer itself around the check below and reach `__split` instead.
     # `Module#===` reads the real type and cannot be redefined.

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -1155,6 +1155,22 @@ assert("String#split limit cannot pose as an Integer") do
   assert_raise(TypeError) { "a,b,c".split(/,/, StringSplitLimitComparable.new) }
 end
 
+assert("String#split with a Bigint limit") do
+  # A Bigint is an Integer, so a check on the class let one through unconverted
+  # and the split loop ran with a limit that does not fit `mrb_int`, while the
+  # String pattern raised in `__split`. The exponent is a variable because a
+  # constant power out of `mrb_int` range fails the build rather than raising.
+  exp = 70
+  begin
+    limit = 2 ** exp
+  rescue RangeError
+    skip "requires mruby-bigint"
+  end
+  assert_raise(RangeError) { "a,b,c".split(/,/, limit) }
+  assert_raise(RangeError) { "a,b,c".split(",", limit) }
+  assert_raise(RangeError) { "a,b,c".split(/,/, -limit) }
+end
+
 assert("String#split with empty regexp") do
   assert_equal ["a", "b", "c"], "abc".split(//)
   assert_equal ["a", "bc"], "abc".split(//, 2)


### PR DESCRIPTION
`String#split` in `mruby-regexp` converts its `limit` in mrblib
([`mrbgems/mruby-regexp/mrblib/string_regexp.rb:144-146`](https://github.com/mruby/mruby/blob/9360b3fd0/mrbgems/mruby-regexp/mrblib/string_regexp.rb#L144-L146)),
and the conversion is guarded so that it only runs for a limit that is not already an Integer:

```ruby
if limit_given && !(Integer === limit)
  limit = Integer.__ensure(limit)
end
```

A Bigint is a real `Integer`, so it passes the guard and is never converted. The regexp path
then runs the split loop with it. The nil and String patterns do not: they delegate to the core
`__split`, which takes an `mrb_int` and raises.

```ruby
big = 2 ** 70

"a,b,c".split(/,/, big)   # mruby: ["a", "b", "c"]                     CRuby: RangeError
"a,b,c".split(",",  big)  # mruby: RangeError: integer out of range    CRuby: RangeError
```

Two calls to one method with one argument, two answers, and the regexp one is not CRuby's.

`mruby-bigint` ships in `math.gembox`, which `default.gembox` includes, and `mruby-regexp`
comes in through `stdlib.gembox`, so a plain build reproduces this:

```console
$ rake
$ ./build/host/bin/mruby -e 'big = 2**70; p "a,b,c".split(/,/, big); p "a,b,c".split(",", big)'
["a", "b", "c"]
trace (most recent call last):
	[1] -e:1
-e:1:in __split: integer out of range (RangeError)
```

This has the same shape as the `is_a?` divergence #7004 closed, on the same argument, but the
guard admits a Bigint under every spelling it has had: `limit.is_a?(Integer)` and
`Integer === limit` both answer true for one.

## A Float limit is already right

Everything that is not an Integer goes through `Integer.__ensure`, so an out-of-range Float
never reaches the loop:

```ruby
"a,b,".split(/,/, 2.0 ** 70)   # mruby: RangeError: integer out of range
"a,b,".split(",",  2.0 ** 70)  # mruby: RangeError: integer out of range
                               # CRuby: RangeError: float 1.180591621e+21 out of range of integer
```

Both mruby paths agree with CRuby on the class here and differ only in wording. The Bigint is
the one case the guard lets through.

## The fix

```diff
-    if limit_given && !(Integer === limit)
-      limit = Integer.__ensure(limit)
-    end
+    limit = Integer.__ensure(limit) if limit_given
```

`Integer.__ensure` is `mrb_ensure_int_type()`
([`src/numeric.c:2331-2337`](https://github.com/mruby/mruby/blob/9360b3fd0/src/numeric.c#L2331-L2337),
[`src/object.c:675-685`](https://github.com/mruby/mruby/blob/9360b3fd0/src/object.c#L675-L685)),
which returns an Integer that fits `mrb_int` unchanged and narrows a Bigint through
`mrb_bint_as_int()`, raising `RangeError` when it does not fit
([`mrbgems/mruby-bigint/core/bigint.c:5506-5517`](https://github.com/mruby/mruby/blob/9360b3fd0/mrbgems/mruby-bigint/core/bigint.c#L5506-L5517)).
Both paths then raise, as CRuby does.

With the patch, `"a,b,c".split(/,/, 2 ** 70)` and `"a,b,c".split(",", 2 ** 70)` both raise
`RangeError: integer out of range`, and a negative Bigint limit raises as well.

The guard existed so that an ordinary Integer limit skipped the conversion, and it read the
type with `Module#===` rather than the redefinable `is_a?` so that a limit could not claim to
be an Integer and skip it too. Converting unconditionally covers that case as well, so removing
the guard does not reopen #7004. The cost is one conversion call for an Integer limit that used
to skip it, and `mrb_ensure_int_type()` returns such a limit unchanged.

## Tests

`rake test` covered none of this: 1967 tests, 1949 OK, 0 failures both with and without the
patch. The `String#split with a Bigint limit` assertions added to
`mrbgems/mruby-regexp/test/regexp.rb` fail on master and pass with the fix, and the suite is
then 1968 tests, 1950 OK, 0 failures. They skip when the build has no `mruby-bigint`, and the
exponent is a variable because a constant power out of `mrb_int` range fails the build rather
than raising.

Measured on `9360b3fd0` against CRuby 4.0.6 on x86_64 Linux, where `mrb_int` is 64 bits.

## Not addressed here

A limit that fits `mrb_int` but not a C `int` is accepted by both mruby paths, where CRuby
raises:

```ruby
"a,b,".split(/,/, 2 ** 40)   # mruby: ["a", "b", ""]   CRuby: RangeError: integer 1099511627776 too big to convert to 'int'
"a,b,".split(",",  2 ** 40)  # mruby: ["a", "b", ""]   CRuby: RangeError
```

The two paths agree with each other there, and accepting a wider limit follows from `mrb_int`
being the integer type of this implementation. Narrowing it to `int` is not proposed here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `String#split` handling for explicitly provided limits, including large integer values.
  * Values outside the supported range now consistently raise `RangeError` instead of being processed incorrectly.

* **Tests**
  * Added coverage for positive and negative large-integer split limits when Bigint support is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->