### PR TITLE
mruby-regexp: apply `/i` to the backreference comparison

### DIFF
--- a/mrbgems/mruby-regexp/include/re_internal.h
+++ b/mrbgems/mruby-regexp/include/re_internal.h
@@ -29,7 +29,7 @@ enum re_opcode {
   RE_EOTNL,     /* assert end of text or before final \n (\Z) */
   RE_WBOUND,     /* assert word boundary (\b) */
   RE_NWBOUND,    /* assert non-word boundary (\B) */
-  RE_BACKREF,    /* backreference: operand = group number */
+  RE_BACKREF,    /* backreference: a = group number, offset = 1 if case-insensitive */
   RE_LOOKAHEAD,  /* positive lookahead: offset = end of sub-pattern */
   RE_NEG_LOOKAHEAD, /* negative lookahead: offset = end of sub-pattern */
   RE_LOOKBEHIND,     /* positive lookbehind: a = byte length, offset = end */

--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -764,7 +764,7 @@ compile_atom(re_compiler *c)
     ch = peek(c);
     if (ch >= '1' && ch <= '9') {
       next_char(c);
-      emit(c, RE_BACKREF, (uint8_t)(ch - '0'), 0);
+      emit(c, RE_BACKREF, (uint8_t)(ch - '0'), (c->flags & RE_FLAG_IGNORECASE) ? 1 : 0);
       c->has_backref = TRUE;
     }
     else if (ch == 'd' || ch == 'D' || ch == 'w' || ch == 'W' || ch == 's' || ch == 'S') {
@@ -845,7 +845,7 @@ compile_atom(re_compiler *c)
       if (group < 1 || group >= (int)c->num_captures) {
         compile_error(c, "undefined group name reference");
       }
-      emit(c, RE_BACKREF, (uint8_t)group, 0);
+      emit(c, RE_BACKREF, (uint8_t)group, (c->flags & RE_FLAG_IGNORECASE) ? 1 : 0);
       c->has_backref = TRUE;
     }
     else {

--- a/mrbgems/mruby-regexp/src/re_exec.c
+++ b/mrbgems/mruby-regexp/src/re_exec.c
@@ -53,6 +53,21 @@ class_match(const re_charclass *cc, uint32_t cp)
   return cc->utf8_any;
 }
 
+/* Compare two byte spans ignoring ASCII case. Folding stops at ASCII, like
+   every other ignorecase decision in this engine (see compile_atom()'s /i
+   handling, which only folds A-Z and a-z into a class bitmap). */
+static mrb_bool
+memcmp_ci(const char *a, const char *b, int len)
+{
+  for (int i = 0; i < len; i++) {
+    uint8_t ca = (uint8_t)a[i], cb = (uint8_t)b[i];
+    if (ca >= 'A' && ca <= 'Z') ca += 32;
+    if (cb >= 'A' && cb <= 'Z') cb += 32;
+    if (ca != cb) return FALSE;
+  }
+  return TRUE;
+}
+
 /*
  * Pike VM with optimized thread storage.
  *
@@ -587,7 +602,10 @@ bt_match(const mrb_regexp_pattern *pat, const char *str, const char *str_end,
         if (gs < 0 || ge < 0) return FALSE;
         int blen = ge - gs;
         if (sp + blen > str_end) return FALSE;
-        if (memcmp(sp, str + gs, blen) != 0) return FALSE;
+        if (inst.offset) {
+          if (!memcmp_ci(sp, str + gs, blen)) return FALSE;
+        }
+        else if (memcmp(sp, str + gs, blen) != 0) return FALSE;
         sp += blen;
         pc++;
       }

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -413,6 +413,12 @@ assert("Regexp - inline options (?i) / (?i:...)") do
   assert_equal 0, (/(a(?i)b)c/ =~ "aBc")
   assert_nil (/(a(?i)b)c/ =~ "aBC")       # trailing `c` is case-sensitive again
 
+  # A backreference takes the options in effect where it appears, not the
+  # pattern's own, so an inline toggle reaches it like any other atom.
+  assert_equal 0, (/(a)(?i)\1/ =~ "aA")
+  assert_equal 0, (/(a)(?i:\1)/ =~ "aA")
+  assert_nil (/(?-i:(a)\1)/i =~ "aA")
+
   # m enables dot-matches-newline for its scope.
   assert_equal 0, (/(?m:a.b)/ =~ "a\nb")
   assert_nil (/a.b/ =~ "a\nb")
@@ -1224,6 +1230,14 @@ assert("Regexp - backreference no match") do
   assert_nil /(\w+) \1/.match("hello world")
 end
 
+assert("Regexp - backreference under /i") do
+  # The comparison against the captured text has to fold case too, otherwise
+  # `\1` stays case-sensitive while the rest of the pattern does not.
+  assert_equal "aA", /(a)\1/i.match("aA")[0]
+  assert_equal "Hello hELLO", /(\w+) \1/i.match("Hello hELLO world")[0]
+  assert_nil /(a)\1/i.match("ab")
+end
+
 assert("Regexp - named captures") do
   md = /(?<year>\d+)-(?<month>\d+)-(?<day>\d+)/.match("2026-03-21")
   assert_equal "2026", md[:year]
@@ -1334,6 +1348,9 @@ assert("Regexp - named backreference \\k") do
   # numeric and relative forms
   assert_equal "aa", "aa".match(/(a)\k<1>/)[0]
   assert_equal "abba", "abba".match(/(.)(.)\k<-1>\k<-2>/)[0]
+  # /i folds the comparison against the captured text
+  assert_equal "aA", "aA".match(/(?<n>a)\k<n>/i)[0]
+  assert_nil "ab".match(/(?<n>a)\k<n>/i)
   # an unknown name is an error
   assert_raise(RegexpError) { Regexp.new("\\k<missing>") }
 end


### PR DESCRIPTION
A backreference ignored the `/i` flag: the `RE_BACKREF` case of `bt_match()`
compared the captured text with `memcmp()` unconditionally, so `\1` stayed
case-sensitive even when the rest of the pattern was folded.

```ruby
/(a)\1/i.match?("aA")           # CRuby: true, mruby: false
/(?<n>a)\k<n>/i.match?("aA")    # CRuby: true, mruby: false
/(a)(?i)\1/.match?("aA")        # CRuby: true, mruby: false
/(a)(?i:\1)/.match?("aA")       # CRuby: true, mruby: false
```

## Fix

The case sensitivity is now decided at compile time, per instruction, the
same way every other ignorecase decision in this engine is taken.
`compile_atom()` records `c->flags & RE_FLAG_IGNORECASE` in the `offset`
field of the emitted `RE_BACKREF` (unused for this opcode), and `bt_match()`
selects an ASCII case-insensitive comparison when the bit is set.

Reading `pat->flags` from the matcher would have been a smaller change but
the wrong one. `pat->flags` is the whole-pattern option set, whereas `(?i)`
and `(?i:...)` are a compile-time mechanism on the compiler's own `c->flags`
that is never written back to the pattern. That form would fold
`/(?-i:(a)\1)/i`, which must not fold, and would leave `/(a)(?i)\1/`
unfolded, which must.

Reusing `offset` needs no change to `re_inst`. It is safe for this opcode:
`insert_inst()` and `emit_atom_copy()` rewrite offsets only for `RE_JMP`,
`RE_SPLIT` and `RE_SPLITNG`, and `compute_fixed_len()` rejects `RE_BACKREF`
through its `default:` arm.

Only `bt_match()` had to change. A pattern with a backreference always sets
`has_backref`, so `mrb_re_exec()` dispatches it to the backtracking engine;
the Pike VM has no `RE_BACKREF` case at all. `literal_exec()` is unreachable
here because `is_literal` requires `!has_backref`.

Case folding stops at ASCII, consistent with the existing `/i` handling for
literals and character classes. Extending `/i` to non-ASCII is a separate
limitation and is left untouched.

## Tests

`mrbgems/mruby-regexp/test/regexp.rb`

- a new `Regexp - backreference under /i` assertion for `\1`
- `/i` cases added to `Regexp - named backreference \k`
- the inline forms `/(a)(?i)\1/`, `/(a)(?i:\1)/` and the `/(?-i:(a)\1)/i`
  control added to `Regexp - inline options (?i) / (?i:...)`

All new assertions were run against CRuby 4.0.6 and produce identical
results. `rake test` passes: 1968 total, 0 KO.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed case-insensitive matching for numeric and named regular-expression backreferences.
  * Inline and scoped case-insensitivity options now apply correctly to backreferences.
  * Scoped case-sensitive settings correctly override an outer case-insensitive option.
  * Exact matching behavior remains unchanged when case-insensitivity is not enabled.

* **Tests**
  * Added regression coverage for toggled, scoped, numeric, and named backreference matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->