### PR TITLE
mruby-regexp: escape whitespace, `#` and `-` in `Regexp.escape`

### DIFF
--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -578,9 +578,20 @@ regexp_escape(mrb_state *mrb, mrb_value self)
   for (mrb_int i = 0; i < len; i++) {
     char c = s[i];
     switch (c) {
+    /* Control characters become two-character escapes so that the result
+       stays printable; the rest are emitted as a backslash and the byte. */
+    case '\n': mrb_str_cat_lit(mrb, result, "\\n"); break;
+    case '\t': mrb_str_cat_lit(mrb, result, "\\t"); break;
+    case '\r': mrb_str_cat_lit(mrb, result, "\\r"); break;
+    case '\f': mrb_str_cat_lit(mrb, result, "\\f"); break;
+    case '\v': mrb_str_cat_lit(mrb, result, "\\v"); break;
     case '\\': case '.': case '*': case '+': case '?': case '|':
     case '(': case ')': case '[': case ']': case '{': case '}':
     case '^': case '$':
+    /* `#`, `-` and space are only special under `/x` or inside `[...]`,
+       but escaping them unconditionally keeps the result literal in
+       every mode. */
+    case '#': case '-': case ' ':
       mrb_str_cat_lit(mrb, result, "\\");
       /* fall through */
     default:

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -514,6 +514,30 @@ end
 
 assert("Regexp.escape") do
   assert_equal "a\\.b\\*c", Regexp.escape("a.b*c")
+
+  # characters that are only special under the x flag or inside [...]
+  assert_equal "a\\ b", Regexp.escape("a b")
+  assert_equal "a\\#b", Regexp.escape("a#b")
+  assert_equal "a\\-b", Regexp.escape("a-b")
+
+  # control characters become printable two-character escapes
+  assert_equal "a\\nb", Regexp.escape("a\nb")
+  assert_equal "a\\tb", Regexp.escape("a\tb")
+  assert_equal "a\\rb", Regexp.escape("a\rb")
+  assert_equal "a\\fb", Regexp.escape("a\fb")
+  assert_equal "a\\vb", Regexp.escape("a\vb")
+
+  # non-ASCII bytes pass through untouched
+  assert_equal "あ\\-い", Regexp.escape("あ-い")
+
+  # the escaped pattern matches the original literally in every mode
+  [" ", "#", "-", "\n", "\t", "\r", "\f", "\v"].each do |c|
+    src = Regexp.escape(c)
+    assert_true Regexp.new(src).match?(c)
+    assert_true Regexp.new(src, Regexp::EXTENDED).match?(c)
+  end
+  assert_true Regexp.new(Regexp.escape("a b"), Regexp::EXTENDED).match?("a b")
+  assert_true Regexp.new(Regexp.escape("a # b"), Regexp::EXTENDED).match?("a # b")
 end
 
 assert("Regexp#inspect") do


### PR DESCRIPTION
`Regexp.escape` escaped only `\ . * + ? | ( ) [ ] { } ^ $`. The characters that
are special under the `x` flag or inside a character class were returned
unchanged, so the guarantee that the result matches the input literally under
any flag combination did not hold:

```ruby
Regexp.escape("a b")    # CRuby: "a\\ b",  mruby: "a b"
Regexp.escape("a\nb")   # CRuby: "a\\nb",  mruby: "a\nb"  (raw newline)
Regexp.escape("a\tb")   # CRuby: "a\\tb",  mruby: "a\tb"
Regexp.escape("a#b")    # CRuby: "a\\#b",  mruby: "a#b"
Regexp.escape("a-b")    # CRuby: "a\\-b",  mruby: "a-b"

Regexp.new(Regexp.escape("a b"), Regexp::EXTENDED).match?("a b")
# CRuby: true
# mruby: false   <- the space is stripped as free-spacing
```

## Fix

In `regexp_escape()`, `#`, `-` and space join the existing fall-through list
that emits a backslash followed by the byte. `\t`, `\n`, `\v`, `\f` and `\r`
cannot join that list because CRuby emits them as the two-character sequences
`\t`, `\n`, `\v`, `\f`, `\r` rather than a backslash in front of a raw control
byte, so each gets its own arm.

The escaped output compiles back to the original character without any change
to the compiler. `parse_escape()` maps `\t`, `\n`, `\v`, `\f` and `\r` to the
control characters and returns any other escaped byte literally, which covers
`\ `, `\#` and `\-`. Under the `x` flag the escapes survive preprocessing
because `strip_extended()` copies a backslash and the byte after it verbatim,
ahead of the `#` comment skip and the whitespace skip.

The loop is byte-wise and every character handled here is ASCII, so UTF-8
continuation bytes are left untouched.

## Verification

Feeding every byte from 0 to 127 through `Regexp.escape` as a one-character
String and comparing with CRuby 4.0.6 produced 8 mismatches before this change
(`\t`, `\n`, `\v`, `\f`, `\r`, space, `#`, `-`) and 0 after it: the output is
now byte-identical on all 128 bytes. Each escaped form also matches its
original character through `Regexp.new`, both with and without
`Regexp::EXTENDED`.

`String#sub`, `#gsub` and `#scan` quote String patterns with
`Regexp.new(Regexp.escape(pattern))`. Their behaviour is unchanged, since the
new escapes compile to the same characters in the default mode they use.

## Tests

`assert("Regexp.escape")` in `mrbgems/mruby-regexp/test/regexp.rb` gains the
eight newly escaped characters, a non-ASCII passthrough case, and round-trip
cases that compile the escaped text back and match the original in both the
default mode and `Regexp::EXTENDED`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `Regexp.escape` to safely convert control characters and special characters into printable escaped forms.
  * Ensured spaces, `#`, and hyphens are escaped consistently.
  * Preserved non-ASCII bytes and literal matching across standard and extended regular expression modes.

* **Tests**
  * Expanded coverage for special characters, control characters, non-ASCII input, and extended-mode matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->