### PR TITLE
mruby-regexp: fix `MatchData#begin` / `#end` for a group name and an out-of-range index

### DIFF
--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -593,6 +593,45 @@ regexp_escape(mrb_state *mrb, mrb_value self)
 
 /* --- MatchData methods --- */
 
+/* Resolve a String or Symbol to the group it names. Shared by MatchData#[],
+   #begin and #end: the three disagree about what an out-of-range integer
+   means, but a name is looked up the same way for all of them. Does not
+   return when the name reaches no group. */
+static mrb_int
+matchdata_name_to_group(mrb_state *mrb, mrb_match_data *md, mrb_value arg)
+{
+  const char *name;
+  mrb_int name_len;
+  if (mrb_symbol_p(arg)) {
+    name = mrb_sym_name_len(mrb, mrb_symbol(arg), &name_len);
+  }
+  else {
+    name = RSTRING_PTR(arg);
+    name_len = RSTRING_LEN(arg);
+  }
+  /* look up name in regexp's named captures */
+  mrb_regexp_pattern *pat = NULL;
+  if (!mrb_nil_p(md->regexp)) {
+    pat = DATA_GET_PTR(mrb, md->regexp, &regexp_type, mrb_regexp_pattern);
+  }
+  /* A stored name never exceeds RE_MAX_NAME_LEN, so a longer request can
+     name no group. Rejecting it here keeps the cast in the loop lossless;
+     without it the length test truncates while the memcmp() next to it does
+     not. */
+  if (pat && RE_NAME_LEN_FITS(name_len)) {
+    for (uint16_t i = 0; i < pat->num_named; i++) {
+      if (pat->named_captures[i].name_len == (uint32_t)name_len &&
+          memcmp(pat->named_captures[i].name, name, name_len) == 0) {
+        return pat->named_captures[i].group;
+      }
+    }
+  }
+  /* A name that resolves to no group is a mistake at the point of the call,
+     not a failed match. CRuby raises here even when the pattern has no
+     named group at all. */
+  mrb_raisef(mrb, E_INDEX_ERROR, "undefined group name reference: %l", name, (size_t)name_len);
+}
+
 /*
  * MatchData#[](n)
  */
@@ -608,37 +647,7 @@ matchdata_aref(mrb_state *mrb, mrb_value self)
   mrb_int idx;
   if (mrb_string_p(arg) || mrb_symbol_p(arg)) {
     /* named capture access */
-    const char *name;
-    mrb_int name_len;
-    if (mrb_symbol_p(arg)) {
-      name = mrb_sym_name_len(mrb, mrb_symbol(arg), &name_len);
-    }
-    else {
-      name = RSTRING_PTR(arg);
-      name_len = RSTRING_LEN(arg);
-    }
-    /* look up name in regexp's named captures */
-    mrb_regexp_pattern *pat = NULL;
-    if (!mrb_nil_p(md->regexp)) {
-      pat = DATA_GET_PTR(mrb, md->regexp, &regexp_type, mrb_regexp_pattern);
-    }
-    /* A stored name never exceeds RE_MAX_NAME_LEN, so a longer request can
-       name no group. Rejecting it here keeps the cast in the loop lossless;
-       without it the length test truncates while the memcmp() next to it does
-       not. */
-    if (pat && RE_NAME_LEN_FITS(name_len)) {
-      for (uint16_t i = 0; i < pat->num_named; i++) {
-        if (pat->named_captures[i].name_len == (uint32_t)name_len &&
-            memcmp(pat->named_captures[i].name, name, name_len) == 0) {
-          idx = pat->named_captures[i].group;
-          goto found;
-        }
-      }
-    }
-    /* A name that resolves to no group is a mistake at the point of the call,
-       not a failed match. CRuby raises here even when the pattern has no
-       named group at all. */
-    mrb_raisef(mrb, E_INDEX_ERROR, "undefined group name reference: %l", name, (size_t)name_len);
+    idx = matchdata_name_to_group(mrb, md, arg);
   }
   else {
     idx = mrb_as_int(mrb, arg);
@@ -652,7 +661,6 @@ matchdata_aref(mrb_state *mrb, mrb_value self)
     }
   }
 
-found:
   if (idx >= md->num_captures) return mrb_nil_value();
   int start = md->captures[idx * 2];
   int end = md->captures[idx * 2 + 1];
@@ -697,14 +705,35 @@ matchdata_to_a(mrb_state *mrb, mrb_value self)
 /*
  * MatchData#begin(n) / MatchData#end(n)
  */
+
+/* begin and end return an offset, and nil is not one, so an argument they
+   cannot use is an error rather than a missing result. That is stricter than
+   MatchData#[], which has nil to return for a group that did not participate
+   and reuses it for an index out of range. A group that exists but did not
+   participate is still nil here; only the argument itself raises. Does not
+   return when the argument reaches no group. */
+static mrb_int
+matchdata_group_arg(mrb_state *mrb, mrb_match_data *md, mrb_value arg)
+{
+  if (mrb_string_p(arg) || mrb_symbol_p(arg)) {
+    return matchdata_name_to_group(mrb, md, arg);
+  }
+  mrb_int idx = mrb_as_int(mrb, arg);
+  if (idx < 0 || idx >= md->num_captures) {
+    mrb_raisef(mrb, E_INDEX_ERROR, "index %i out of matches", idx);
+  }
+  return idx;
+}
+
 static mrb_value
 matchdata_begin(mrb_state *mrb, mrb_value self)
 {
-  mrb_int idx;
-  mrb_get_args(mrb, "i", &idx);
+  mrb_value arg;
+  mrb_get_args(mrb, "o", &arg);
 
   mrb_match_data *md = DATA_GET_PTR(mrb, self, &matchdata_type, mrb_match_data);
-  if (!md || idx < 0 || idx >= md->num_captures) return mrb_nil_value();
+  if (!md) return mrb_nil_value();
+  mrb_int idx = matchdata_group_arg(mrb, md, arg);
   int pos = md->captures[idx * 2];
   if (pos < 0) return mrb_nil_value();
   return mrb_int_value(mrb, re_byte_to_char(mrb, md->source, pos));
@@ -713,11 +742,12 @@ matchdata_begin(mrb_state *mrb, mrb_value self)
 static mrb_value
 matchdata_end(mrb_state *mrb, mrb_value self)
 {
-  mrb_int idx;
-  mrb_get_args(mrb, "i", &idx);
+  mrb_value arg;
+  mrb_get_args(mrb, "o", &arg);
 
   mrb_match_data *md = DATA_GET_PTR(mrb, self, &matchdata_type, mrb_match_data);
-  if (!md || idx < 0 || idx >= md->num_captures) return mrb_nil_value();
+  if (!md) return mrb_nil_value();
+  mrb_int idx = matchdata_group_arg(mrb, md, arg);
   int pos = md->captures[idx * 2 + 1];
   if (pos < 0) return mrb_nil_value();
   return mrb_int_value(mrb, re_byte_to_char(mrb, md->source, pos));

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -471,6 +471,32 @@ assert("MatchData#begin / #end") do
   assert_equal 3, md.end(0)
 end
 
+assert("MatchData#begin / #end - group name") do
+  md = /(?<x>b)(?<y>c)/.match("abcde")
+  assert_equal 1, md.begin(:x)
+  assert_equal 2, md.end(:x)
+  assert_equal 2, md.begin("y")
+  assert_equal 3, md.end("y")
+  assert_raise(IndexError) { md.begin(:zz) }
+  assert_raise(IndexError) { md.end("zz") }
+  # a pattern without any named group raises just the same
+  assert_raise(IndexError) { /(a)/.match("a").begin(:zz) }
+end
+
+assert("MatchData#begin / #end - index out of matches") do
+  # An offset has no nil to fall back on, so an index naming no group raises
+  # here where MatchData#[] returns nil.
+  md = /(a)(b)/.match("ab")
+  assert_raise(IndexError) { md.begin(3) }
+  assert_raise(IndexError) { md.end(3) }
+  assert_raise(IndexError) { md.begin(-1) }
+  assert_raise(IndexError) { md.end(-1) }
+  # a group that exists but did not participate is still nil
+  md = /(a)|(b)/.match("a")
+  assert_nil md.begin(2)
+  assert_nil md.end(2)
+end
+
 assert("Regexp - multibyte (UTF-8) match extraction") do
   # Capture offsets are recorded in bytes; substring extraction must honor
   # them as byte ranges so multibyte matches are not corrupted.
@@ -1296,6 +1322,16 @@ assert("MatchData#[] - group name longer than a uint16 length") do
   md = /(?<abc>x)/.match("x")
   assert_raise(IndexError) { md["abc" + "A" * 65536] }
   assert_equal "x", md[:abc]
+end
+
+assert("MatchData#begin / #end - group name longer than a stored name") do
+  # begin/end share the name lookup with MatchData#[], so the bound that keeps
+  # the memcmp() from being handed a length larger than what was measured
+  # covers them too.
+  md = /(?<abc>x)/.match("x")
+  assert_raise(IndexError) { md.begin("abc" + "A" * 65536) }
+  assert_raise(IndexError) { md.end("abc" + "A" * 65536) }
+  assert_equal 0, md.begin(:abc)
 end
 
 assert("Regexp - group name longer than a uint16 length") do


### PR DESCRIPTION
`MatchData#begin` and `#end` take their argument with `mrb_get_args(mrb, "i", &idx)`,
so a group name is a `TypeError` before the method body runs, and an index that names
no group returns `nil` instead of raising.

```ruby
md = /(?<_x>a)/.match("a")
md.begin(:_x)  # CRuby: 0,  mruby: TypeError (Symbol cannot be converted to Integer)
md.begin("_x") # CRuby: 0,  mruby: TypeError (String cannot be converted to Integer)
md.begin(:zz)  # CRuby: IndexError (undefined group name reference: zz)
               # mruby: TypeError (Symbol cannot be converted to Integer)

md = /(a)(b)/.match("ab")
md.begin(3)    # CRuby: IndexError (index 3 out of matches),  mruby: nil
md.begin(-1)   # CRuby: IndexError (index -1 out of matches), mruby: nil
md.end(-1)     # CRuby: IndexError (index -1 out of matches), mruby: nil
```

Both halves matter for the same reason: `begin` and `end` return an offset, and `nil`
is not one. Arithmetic on the result of a mistyped index fails somewhere else entirely,
while CRuby stops at the call.

## What changes

`matchdata_begin()` and `matchdata_end()` take their argument as `"o"` and resolve it
before reading the capture:

* a String or Symbol resolves through the pattern's named-capture table, raising
  `IndexError` with `undefined group name reference: NAME` when it is not there
* an Integer outside `0...num_captures`, negative included, raises `IndexError` with
  `index N out of matches`

This is deliberately stricter than `MatchData#[]`, and CRuby is stricter here too:
`[]` returns `nil` for an index out of range because a group that did not participate
is also `nil`, whereas `begin` has no such value to return. `[]`'s rules are untouched,
including the negative index it normalizes and the `nil` it returns out of range.

A group that exists but did not participate is still `nil`, which is the one result
that must not become a raise:

```ruby
/(a)|(b)/.match("a").begin(2)   # both: nil
```

The name lookup was the loop `matchdata_aref()` already ran. It moves into a shared
`matchdata_name_to_group()` and gains `begin` and `end` as callers. The
`RE_NAME_LEN_FITS()` bound travels with it rather than staying behind: it is what keeps
the `(uint32_t)name_len` cast in the loop lossless, so `begin` and `end` get the
over-long name rejected for free. The `IndexError` for an unknown name moves with it as
well, since all three methods want the same message.

`__byte_begin` and `__byte_end` stay on `"i"` and keep returning `nil`. They are private,
are called only as `md.__byte_begin(0)` from `String#gsub` and `#split` in
`mrblib/string_regexp.rb`, and should not pay for the lookup on every iteration.

The bindings do not change: `begin` and `end` were already `MRB_ARGS_REQ(1)`, which is
correct for an argument that is now an object rather than an integer.

## Verification

Before:

```console
$ ./build/host/bin/mruby -e 'p /(?<_x>a)/.match("a").begin(:_x)'
-e:1:in begin: Symbol cannot be converted to Integer (TypeError)
$ ./build/host/bin/mruby -e 'p /(a)(b)/.match("ab").begin(-1)'
nil
```

After, matching CRuby 4.0.6 on every line of the table above:

```console
$ ./build/host/bin/mruby -e 'p /(?<_x>a)/.match("a").begin(:_x)'
0
$ ./build/host/bin/mruby -e 'p /(a)(b)/.match("ab").begin(-1)'
-e:1:in begin: index -1 out of matches (IndexError)
```

## Tests

`mrbgems/mruby-regexp/test/regexp.rb` gains three blocks: the name cases beside the
existing `MatchData#begin / #end` assertion, the out-of-range cases including the
non-participating group that must stay `nil`, and the over-long name beside the
`MatchData#[]` regression test for the same bound, now that the lookup is shared.

`rake test` passes: 1970 assertions, 0 failures, no new compiler warnings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `MatchData#begin` and `MatchData#end` now support named capture groups using strings or symbols.
  * Named captures can be resolved consistently across match data access methods.

* **Bug Fixes**
  * Invalid capture names and indexes now raise `IndexError`.
  * Unmatched but valid capture groups continue to return `nil`.
  * Added support for correctly handling very long unknown capture names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->