### PR TITLE
mruby-regexp: apply `/i` to character classes

### DIFF
--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -167,6 +167,13 @@ class_set_bit(re_charclass *cc, uint8_t ch)
   }
 }
 
+static mrb_bool
+class_get_bit(const re_charclass *cc, uint8_t ch)
+{
+  if (ch >= 128) return FALSE;
+  return (cc->bitmap[ch >> 3] >> (ch & 7)) & 1;
+}
+
 /* Append a non-ASCII codepoint range [lo, hi]. Both bounds must be >= 128. */
 static void
 class_add_range(re_compiler *c, re_charclass *cc, uint32_t lo, uint32_t hi)
@@ -465,6 +472,19 @@ compile_charclass(re_compiler *c)
     }
   }
   next_char(c);  /* skip ']' */
+
+  /* Fold ASCII letters under /i. This runs once the class is complete, so a
+     single pass covers every form the loop above merges into the bitmap:
+     POSIX brackets, shorthands, ranges and single literals. Negation is
+     applied at match time against this same bitmap (RE_NCLASS), so folding
+     the positive set also fixes [^a-c] under /i. Non-ASCII case folding is
+     out of scope, so the codepoint range list is left alone. */
+  if (c->flags & RE_FLAG_IGNORECASE) {
+    for (int ch = 'a'; ch <= 'z'; ch++) {
+      if (class_get_bit(cc, (uint8_t)ch)) class_set_bit(cc, (uint8_t)(ch - 32));
+      else if (class_get_bit(cc, (uint8_t)(ch - 32))) class_set_bit(cc, (uint8_t)ch);
+    }
+  }
 
   cc->negated = negated;
   emit(c, negated ? RE_NCLASS : RE_CLASS, (uint8_t)id, 0);

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -186,6 +186,9 @@ assert("Regexp - POSIX bracket classes") do
   assert_equal "snake_case", "snake_case".match(/[[:word:]]+/)[0]
   assert_equal "!", "ab!cd".match(/[[:punct:]]/)[0]
   assert_equal "AB", "abAB".match(/[[:upper:]]+/)[0]
+  # /i makes the two letter-case classes equivalent.
+  assert_equal "abAB", "abAB".match(/[[:upper:]]+/i)[0]
+  assert_equal "abAB", "abAB".match(/[[:lower:]]+/i)[0]
   # combine with literals and other classes
   assert_equal "a1", "a1-".match(/[a[:digit:]]+/)[0]
   assert_equal "ab12", "ab12 ".match(/[[:alpha:][:digit:]]+/)[0]
@@ -333,6 +336,24 @@ assert("Regexp - case insensitive") do
   assert_true re.match?("Abc")
 end
 
+assert("Regexp - case insensitive character class") do
+  # /i used to be folded in only where a single literal was emitted, so a
+  # character class ignored it entirely.
+  assert_true(/[abc]/i.match?("A"))
+  assert_true(/[a-c]/i.match?("A"))
+  assert_true(/[A-C]/i.match?("a"))
+  assert_true(/[a-c]+/i.match?("AB"))
+  assert_true Regexp.new("[a-c]", Regexp::IGNORECASE).match?("A")
+  # A negated class matched what it had to reject, which is a false positive.
+  assert_false(/[^a-c]/i.match?("A"))
+  assert_false(/[^A-C]/i.match?("a"))
+  assert_true(/[^a-c]/i.match?("d"))
+  # Folding must not widen the class beyond the ASCII letters.
+  assert_false(/[a-c]/i.match?("D"))
+  assert_false(/[\[]/i.match?("{"))  # `[` and `{` are 32 apart but are not a case pair
+  assert_false(/[@]/i.match?("`"))
+end
+
 assert("Regexp - repetition {n,m}") do
   assert_equal "aaa", Regexp.new("a{3}").match("aaaa")[0]
   assert_equal "aa", Regexp.new("a{2,3}").match("aa")[0]
@@ -408,6 +429,11 @@ assert("Regexp - inline options (?i) / (?i:...)") do
   assert_equal 0, (/(?i:abc)/ =~ "ABC")
   assert_nil (/(?i:a)b/ =~ "aB")          # option must not leak past the `)`
   assert_equal 0, (/(?i:ab)+/ =~ "AbaB")  # scoped group is still quantifiable
+
+  # A character class reads the inline-scoped flag, not the pattern-wide one.
+  assert_equal 0, (/(?i)[a-c]/ =~ "A")
+  assert_equal 0, (/(?i:[a-c])/ =~ "A")
+  assert_nil (/(?i:[a-c])[a-c]/ =~ "AB")  # option must not leak past the `)`
 
   # The toggle inside a group is confined to that group.
   assert_equal 0, (/(a(?i)b)c/ =~ "aBc")


### PR DESCRIPTION
`RE_FLAG_IGNORECASE` is folded in only where `compile_atom()` emits a single
literal character. `compile_charclass()` never reads the flag, so every `[...]`
ignores `/i`.

```ruby
/[abc]/i.match?("A")        # CRuby: true,  mruby: false
/[a-c]/i.match?("A")        # CRuby: true,  mruby: false
/[A-C]/i.match?("a")        # CRuby: true,  mruby: false
/[a-c]+/i.match?("AB")      # CRuby: true,  mruby: false
```

The inline and constructor forms of the flag reach the same code, so they fail
the same way.

```ruby
/(?i)[a-c]/.match?("A")                              # CRuby: true, mruby: false
Regexp.new("[a-c]", Regexp::IGNORECASE).match?("A")  # CRuby: true, mruby: false
```

POSIX bracket classes are affected too, since they are merged into the same
bitmap.

```ruby
/[[:lower:]]/i.match?("A")  # CRuby: true,  mruby: false
/[[:upper:]]/i.match?("a")  # CRuby: true,  mruby: false
```

A negated class is worse: it matches what it must reject, so a `/i` regexp
used for validation accepts input it should refuse. Nothing raises.

```ruby
/[^a-c]/i.match?("A")       # CRuby: false, mruby: true
```

## Fix

Fold the ASCII letters into the class bitmap at the end of
`compile_charclass()`, after the parse loop and before the class is committed
to an `RE_CLASS` or `RE_NCLASS`. That is the only point at which a `[...]` is
complete: the loop merges POSIX bracket bits, shorthands, ASCII ranges and
single literals into one bitmap, so a single pass there covers all four forms
and `[[:lower:]]` under `/i` picks up uppercase.

Negation is applied at match time against that same bitmap, so folding the
positive set fixes `[^a-c]` at the same time. `class_add_shorthand()` and
`posix_class_bits()` both run before the class is complete and would miss
plain literals and `a-c` ranges, so neither is the right place.

`class_get_bit()` is added alongside `class_set_bit()`. `re_compile.c` had no
bit-level reader for `re_charclass::bitmap`: `first_set_walk()` ORs whole
bytes, and the one bit test in the gem lives in `class_match()`, which is
`static` in another translation unit and takes a codepoint rather than a bit
index.

The fold has to happen at compile time rather than in the matcher for three
reasons. `class_match()` receives only a `re_charclass` and has no access to
any flags. `pat->flags` is the whole-pattern option set and so cannot see
inline `(?i:...)` scoping. And `compute_first_set()` derives `pat->first_bytes`
from the bitmap at compile time, which the matcher then uses to skip input; a
match time fold would leave that skip narrower than the class, and `/[a-c]/i`
would still fail on `"A"`.

Reading `c->flags` is what makes the inline forms work: `compile_atom()`
already saves, replaces and restores it around `(?i)` and `(?i:...)`, so the
class sees the scoped value with no further change.

The existing `IGNORECASE` blocks in `compile_atom()` are already correct for a
single literal and are left alone.

## Scope

Non-ASCII case folding is not addressed. The codepoint range list and
`cc->utf8_any` are untouched, and `class_add_range()` and
`class_add_codepoint()` are unchanged.

## Tests

`mrbgems/mruby-regexp/test/regexp.rb`:

- `Regexp - case insensitive character class`, a new block next to
  `Regexp - case insensitive`: the four positive forms, the
  `Regexp::IGNORECASE` constructor form, and both negated forms. It also
  guards the fold against widening the class past the ASCII letters, since
  `[` and `{` are 32 apart but are not a case pair.
- `Regexp - POSIX bracket classes`: `[[:upper:]]` and `[[:lower:]]` under
  `/i`, next to the existing `[[:upper:]]` assertion.
- `Regexp - inline options (?i) / (?i:...)`: `(?i)[a-c]`, `(?i:[a-c])`, and
  that the option does not leak past the closing paren.

Verified on `x86_64-linux`:

- Every reproduction above now matches CRuby 4.0.6.
- `rake test`: 1968 total, 1950 OK, 0 KO, 0 crash, and bintest 105 OK.
- An `MRB_INT32` build with clang and `-Wall -Wextra`: 1870 total, 1852 OK,
  0 KO, 0 crash, and no new warning from any `mruby-regexp` file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved case-insensitive regular expression matching for ASCII letters in character classes.
  * Added support for case-insensitive matching in ranges, shorthand classes, POSIX classes, and negated classes.
  * Ensured inline case-insensitive options remain limited to their intended scope.
  * Preserved existing behavior for non-ASCII character ranges.

* **Tests**
  * Added coverage for case-insensitive character classes, negation, POSIX classes, and ASCII boundary cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->