### PR TITLE
mruby-regexp: keep `$~` after `String#gsub` with a block

### DIFF
--- a/mrbgems/mruby-regexp/mrblib/string_regexp.rb
+++ b/mrbgems/mruby-regexp/mrblib/string_regexp.rb
@@ -80,9 +80,15 @@ class String
     pos = 0
     len = self.bytesize
     binary = Regexp.__binary_string?(self)
+    # The loop normally ends on a failed __byte_match, which clears $~ and the
+    # thirteen names that go with it. CRuby leaves the last match behind, so
+    # keep it and republish it below. A gsub that matched nothing has nothing
+    # to restore and keeps the cleared state, as CRuby does.
+    last = nil
     while pos <= len
       md = pattern.__byte_match(self, pos)
       break unless md
+      last = md
       # gsub works in byte space (match pos, byteslice). begin/end report
       # character offsets (CRuby-compatible), so use the byte accessors.
       match_start = md.__byte_begin(0)
@@ -108,6 +114,7 @@ class String
       end
     end
     parts << self.byteslice(pos..-1)
+    last.__set_globals if last
     parts.join
   end
 

--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -272,33 +272,21 @@ regexp_binary_string_p(mrb_state *mrb, mrb_value self)
   return mrb_bool_value(re_binary_string_p(str));
 }
 
-/* Create MatchData from captures */
-static mrb_value
-create_matchdata(mrb_state *mrb, mrb_value regexp, mrb_value str, int *captures, int ncap)
+/* Publish `obj` and the thirteen names derived from its offsets, the
+   counterpart of clear_match_globals(). Kept apart from create_matchdata() so
+   that an existing MatchData can be republished without rebuilding it. */
+static void
+set_match_globals(mrb_state *mrb, mrb_value obj, mrb_value str, int *captures, int num_captures)
 {
   ensure_match_syms(mrb);
 
-  struct RClass *md_class = mrb_class_get(mrb, "MatchData");
-  mrb_match_data *md = (mrb_match_data*)mrb_malloc(mrb, sizeof(mrb_match_data));
-  md->source = str;
-  md->regexp = regexp;
-  md->num_captures = ncap / 2;
-  md->captures = (int*)mrb_malloc(mrb, sizeof(int) * ncap);
-  memcpy(md->captures, captures, sizeof(int) * ncap);
-
-  mrb_value obj = mrb_obj_value(mrb_data_object_alloc(mrb, md_class, md, &matchdata_type));
-  /* Keep `source` and `regexp` GC-reachable via instance variables.
-   * The mrb_values are also held in mrb_match_data, but C-allocated
-   * structs are not scanned by the GC. */
-  mrb_iv_set(mrb, obj, mrb_intern_lit(mrb, "source"), str);
-  mrb_iv_set(mrb, obj, mrb_intern_lit(mrb, "regexp"), regexp);
   mrb_gv_set(mrb, mrb_intern_lit(mrb, "$~"), obj);
 
   /* set $1-$9 from captures */
   for (int i = 0; i < 9; i++) {
     mrb_value val = mrb_nil_value();
     int g = i + 1;
-    if (g < md->num_captures && captures[g*2] >= 0) {
+    if (g < num_captures && captures[g*2] >= 0) {
       val = re_byte_substr(mrb, str, captures[g*2], captures[g*2+1] - captures[g*2]);
     }
     mrb_gv_set(mrb, nth_syms[i], val);
@@ -315,13 +303,35 @@ create_matchdata(mrb_state *mrb, mrb_value regexp, mrb_value str, int *captures,
   /* set $+ from the last group that actually participated, which is not
      necessarily the last group in the pattern */
   mrb_value last_paren = mrb_nil_value();
-  for (int g = md->num_captures - 1; g >= 1; g--) {
+  for (int g = num_captures - 1; g >= 1; g--) {
     if (captures[g*2] >= 0) {
       last_paren = re_byte_substr(mrb, str, captures[g*2], captures[g*2+1] - captures[g*2]);
       break;
     }
   }
   mrb_gv_set(mrb, last_match_syms[LAST_PAREN], last_paren);
+}
+
+/* Create MatchData from captures */
+static mrb_value
+create_matchdata(mrb_state *mrb, mrb_value regexp, mrb_value str, int *captures, int ncap)
+{
+  struct RClass *md_class = mrb_class_get(mrb, "MatchData");
+  mrb_match_data *md = (mrb_match_data*)mrb_malloc(mrb, sizeof(mrb_match_data));
+  md->source = str;
+  md->regexp = regexp;
+  md->num_captures = ncap / 2;
+  md->captures = (int*)mrb_malloc(mrb, sizeof(int) * ncap);
+  memcpy(md->captures, captures, sizeof(int) * ncap);
+
+  mrb_value obj = mrb_obj_value(mrb_data_object_alloc(mrb, md_class, md, &matchdata_type));
+  /* Keep `source` and `regexp` GC-reachable via instance variables.
+   * The mrb_values are also held in mrb_match_data, but C-allocated
+   * structs are not scanned by the GC. */
+  mrb_iv_set(mrb, obj, mrb_intern_lit(mrb, "source"), str);
+  mrb_iv_set(mrb, obj, mrb_intern_lit(mrb, "regexp"), regexp);
+
+  set_match_globals(mrb, obj, str, captures, md->num_captures);
 
   return obj;
 }
@@ -750,6 +760,20 @@ matchdata_byte_end(mrb_state *mrb, mrb_value self)
   int pos = md->captures[idx * 2 + 1];
   if (pos < 0) return mrb_nil_value();
   return mrb_int_value(mrb, pos);
+}
+
+/* Private: republish $~ and the thirteen names derived from it. Used by the
+   mrblib loops that drive __byte_match themselves, where the failing call
+   that ends the loop clears the match the loop is supposed to leave behind.
+   The names other than $~ are not assignable from Ruby, so restoring them
+   has to come from here. */
+static mrb_value
+matchdata_set_globals(mrb_state *mrb, mrb_value self)
+{
+  mrb_match_data *md = DATA_GET_PTR(mrb, self, &matchdata_type, mrb_match_data);
+  if (!md) return mrb_nil_value();
+  set_match_globals(mrb, self, md->source, md->captures, md->num_captures);
+  return self;
 }
 
 /*
@@ -1221,6 +1245,7 @@ mrb_mruby_regexp_gem_init(mrb_state *mrb)
   mrb_define_method(mrb, md, "end", matchdata_end, MRB_ARGS_REQ(1));
   mrb_define_method(mrb, md, "__byte_begin", matchdata_byte_begin, MRB_ARGS_REQ(1));
   mrb_define_method(mrb, md, "__byte_end", matchdata_byte_end, MRB_ARGS_REQ(1));
+  mrb_define_method(mrb, md, "__set_globals", matchdata_set_globals, MRB_ARGS_NONE());
   mrb_define_method(mrb, md, "pre_match", matchdata_pre, MRB_ARGS_NONE());
   mrb_define_method(mrb, md, "post_match", matchdata_post, MRB_ARGS_NONE());
   mrb_define_method(mrb, md, "named_captures", matchdata_named_captures, MRB_ARGS_NONE());

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -1469,6 +1469,47 @@ assert("$&, $`, $' and $+ cleared on no match") do
   assert_nil $+
 end
 
+assert("String#gsub with block leaves the last match behind") do
+  # The block form drives the search from mrblib, and the failed match that
+  # ends the loop used to clear the match the loop was supposed to leave.
+  $~ = nil
+  "hello".gsub(/l/) { |m| m }
+  assert_equal "l", $~[0]
+
+  # every name a match publishes, not just $~
+  $~ = nil
+  "a1b22c".gsub(/([a-c])(\d+)/) { |m| m }
+  assert_equal "b22", $~[0]
+  assert_equal "b22", $&
+  assert_equal "a1", $`
+  assert_equal "c", $'
+  assert_equal "b", $1
+  assert_equal "22", $2
+  assert_equal "22", $+
+
+  # a block that matches on its own does not get the last word
+  $~ = nil
+  "hello".gsub(/l/) { |m| /z+/ =~ "zzz"; m }
+  assert_equal "l", $~[0]
+
+  # a zero-width match at the end of the subject ends the loop on the
+  # `pos <= len` test rather than a failed match, and lands the same way
+  $~ = nil
+  "ab".gsub(/x*/) { "-" }
+  assert_equal "", $~[0]
+  assert_equal 2, $~.begin(0)
+
+  # matching nothing clears, as it does everywhere else
+  /b(c)/ =~ "abcd"
+  "hello".gsub(/z/) { |m| m }
+  assert_nil $~
+  assert_nil $&
+  assert_nil $`
+  assert_nil $'
+  assert_nil $1
+  assert_nil $+
+end
+
 assert("Regexp - consecutive optional quantifiers (#6853)") do
   # insert_inst was over-incrementing jump offsets that pointed *at* the
   # insertion site, sending earlier "skip this atom" SPLITs into the next


### PR DESCRIPTION
Every substitution method agrees with CRuby about what `$~` holds afterwards, except `gsub` with a block, which clears it.

```ruby
$~ = nil
"hello".gsub(/l/) { |m| m }
$~    # CRuby: #<MatchData "l">, mruby: nil
```

| Expression | CRuby | mruby |
|---|---|---|
| `"hello".sub(/l/) { \|m\| m }` | `"l"` | `"l"` |
| `"hello".sub(/l/, "L")` | `"l"` | `"l"` |
| `"hello".scan(/l/)` | `"l"` | `"l"` |
| `"hello".gsub(/l/, "L")` | `"l"` | `"l"` |
| `"hello".gsub(/l/) { \|m\| m }` | `"l"` | **nil** |
| `"hello".gsub(/z/, "L")` | nil | nil |
| `"hello".split(/l/)` | nil | nil |

The cells show `$~ && $~[0]` after the expression, read in the same scope, since `$~` is frame local in CRuby. `split` clears `$~` in CRuby too, so it is not a divergence.

`$1` through `$9`, `$&`, `` $` ``, `$'` and `$+` go with `$~`. A match publishes all fourteen names at once and the failure that ends the loop clears all fourteen, so the block form loses the lot.

```ruby
$~ = nil
"hello".gsub(/l(l)?/) { |m| m }
[$~, $&, $`, $', $1, $+]
# CRuby: [#<MatchData "ll" 1:"l">, "ll", "he", "o", "l", "l"]
# mruby: [nil, nil, nil, nil, nil, nil]
```

## Cause

The block path of `gsub` is a loop in `mrbgems/mruby-regexp/mrblib/string_regexp.rb`, which drives the search itself and normally ends on a call that fails:

```ruby
while pos <= len
  md = pattern.__byte_match(self, pos)
  break unless md
```

A failed match calls `clear_match_globals()`, which sets all fourteen names to nil, so the failure that terminates the loop overwrites the last successful match. The replacement string path does not go through this loop: it is `Regexp#__gsub_str`, which is C and republishes the last match itself, which is why only the block form diverges.

One case already came out right by accident: a zero-width match at the end of the subject advances `pos` past the end, so the `pos <= len` test ends the loop with no failing call and the match survives. The divergence was not even uniform within `gsub`.

## Fix

`$~` is a plain global in mruby rather than the frame local of CRuby, so mrblib could restore that one on its own, but the other thirteen are not assignable from Ruby: the parser rejects `$1 = md[1]` and `$& = md[0]`, as CRuby does. `create_matchdata()` already computes all fourteen, but it builds a fresh `MatchData` out of a captures array, so it cannot be handed the `md` the loop is already holding.

This splits the publishing tail of `create_matchdata()` into `set_match_globals()`, which takes an existing `MatchData` and its offsets, and exposes it as `MatchData#__set_globals`. The loop then keeps the last match and republishes it once the loop is over, and the values stay computed in exactly one place.

A `gsub` that matches nothing has nothing to restore and keeps the cleared state, as CRuby does. The zero-width tail case now takes the same route as every other case, where restoring the match it kept anyway is a no-op, so the two routes agree by construction rather than by coincidence.

## Testing

`mrbgems/mruby-regexp/test/regexp.rb` gains a case covering all fourteen names after a block `gsub`, a block that runs its own match, the zero-width tail, and a `gsub` that matches nothing.

All green, `KO: 0` and `Crash: 0` everywhere:

- `rake test` with `build_config/default.rb`
- `MRUBY_CONFIG=asan rake test` (`address,undefined`)
- `MRUBY_CONFIG=ci/gcc-clang rake test`, which covers `MRB_GC_STRESS` with
  `MRB_USE_DEBUG_HOOK`, `MRB_GC_FIXED_ARENA`, and the C++ ABI build
- `MRB_UTF8_STRING`
- `MRB_INT32` with `MRB_WORD_BOXING` and `MRB_UTF8_STRING`
- `MRB_NAN_BOXING`

The `MRB_NAN_BOXING` build fails three `mruby-string-bitops` assertions, and fails the same three with this branch reverted, so they are not from this change.
