### PR TITLE
string.c: compare the append source as an address, not as a pointer

### DIFF
--- a/src/string.c
+++ b/src/string.c
@@ -3188,9 +3188,16 @@ mrb_str_cat(mrb_state *mrb, mrb_value str, const char *ptr, size_t len)
      the same answer reached another way, or detaches `s` onto a fresh buffer
      and releases the old one, where `ptr` is neither inside the new buffer
      nor safe to read. Recording the offset ahead of the call covers both
-     without having to know which path ran. */
-  if (ptr >= RSTR_PTR(s) && ptr <= RSTR_PTR(s) + (size_t)RSTR_LEN(s)) {
-      off = ptr - RSTR_PTR(s);
+     without having to know which path ran.
+
+     `ptr` is allowed to come from anywhere, so it and `RSTR_PTR(s)` need not
+     point into the same object, and relational comparison and subtraction
+     between pointers that do not is undefined. Going through `uintptr_t`
+     leaves both on integers, where the whole range is ordered. */
+  uintptr_t ptr_addr = (uintptr_t)ptr;
+  uintptr_t str_addr = (uintptr_t)RSTR_PTR(s);
+  if (ptr_addr >= str_addr && ptr_addr <= str_addr + (uintptr_t)RSTR_LEN(s)) {
+      off = (ptrdiff_t)(ptr_addr - str_addr);
   }
   mrb_int capa = str_modify_cat(mrb, s, (mrb_int)len);
 


### PR DESCRIPTION
## Summary

`mrb_str_cat()` decides whether `ptr` points into the string it is appending to, so that
the source can be followed if the buffer moves under it:

```c
  if (ptr >= RSTR_PTR(s) && ptr <= RSTR_PTR(s) + (size_t)RSTR_LEN(s)) {
      off = ptr - RSTR_PTR(s);
  }
```

`ptr` is a parameter of a public API and may point into any object. When it points into
something other than `s`, which is the ordinary case for a plain append, the two pointers
are not into the same object, and C leaves the relational comparison undefined (C11
6.5.8p5). The subtraction on the line below is undefined on the same grounds (6.5.6p9),
though it only runs once the comparison has said the two are related.

That is the shape every pointer containment test has. There is no way to ask the question
in pointers alone: the operators that would ask it are defined only for operands already
known to be related.

## The change

Convert both operands to `uintptr_t` once and compare the addresses. Integers are ordered
across the whole range, so the test means what it is written to mean.

Nothing changes at runtime. Wherever the address space is flat, and that is everywhere
mruby builds, the addresses order the same way the pointers did, so the same appends are
recognized as overlapping and the same offset comes out.

`uintptr_t` is no new requirement either: `mrb_ptr_to_str()` in this file already uses it,
as does `is_pool_memory()` in `mrbgems/mruby-bigint/core/bigint.c`, which writes its own
containment test this way.

## Scope

The comparison has stood since `54132e436` (2014). No sanitizer flags it and no compiler I
am aware of exploits it, so this is a conformance change rather than a bug fix, which is
why it comes on its own rather than folded into anything.

## Relation to #7043

#7043 moves these same lines above `str_modify_cat()` without changing their form. The two
do not overlap in intent, only in position. Whichever lands first, I will rebase the other
onto it.

## Testing

`rake test` with `build_config/default.rb`, `MRUBY_CONFIG=asan rake test`
(`address,undefined`), and `MRUBY_CONFIG=ci/gcc-clang rake test`, which covers
`MRB_GC_STRESS` with `MRB_USE_DEBUG_HOOK`, `MRB_GC_FIXED_ARENA`, and the C++ ABI build.
`KO: 0` and `Crash: 0` on all of them.

No test comes with this. Undefined behavior that every current toolchain compiles into the
intended code is not something the suite can distinguish.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved string handling when source and destination memory regions overlap.
  * Prevented potential undefined behavior during string concatenation while preserving existing results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->