### PR TITLE
mruby-regexp: split a character class range at the ASCII boundary

### DIFF
--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -455,15 +455,14 @@ compile_charclass(re_compiler *c)
     if (peek(c) == '-' && c->p + 1 < c->src_end && c->p[1] != ']') {
       next_char(c);  /* skip '-' */
       uint32_t hi = read_class_atom(c);
-      if (cp < 128 && hi < 128) {
-        class_set_range(cc, (uint8_t)cp, (uint8_t)hi);
-      }
-      else {
-        /* Range that touches non-ASCII: store as codepoint range.
-           Mixed ASCII/non-ASCII ranges are rare; stash the whole span
-           in the codepoint list (the bitmap covers ASCII only, so a
-           non-ASCII upper bound forces the codepoint path). */
-        if (cp <= hi) class_add_range(c, cc, cp, hi);
+      /* A range that straddles the ASCII boundary is split in two: the
+         bitmap takes the half below 128 and the codepoint list the rest.
+         Neither half can hold the other, and class_match() picks the side
+         to read from the codepoint alone, so a span left whole in the
+         codepoint list is unreachable below 128. */
+      if (cp <= hi) {
+        if (cp < 128) class_set_range(cc, (uint8_t)cp, (uint8_t)(hi < 128 ? hi : 127));
+        if (hi >= 128) class_add_range(c, cc, cp < 128 ? 128 : cp, hi);
       }
     }
     else {

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -177,6 +177,36 @@ assert("Regexp - character class") do
   assert_equal "abc", md[0]
 end
 
+assert("Regexp - character class range across the ASCII boundary") do
+  # A range from an ASCII bound to a non-ASCII one used to be stored whole in
+  # the codepoint list, which the matcher never reads below 128, so the ASCII
+  # half of the range matched nothing.
+  assert_equal "a", "a".match(/[a-Ā]/)[0]
+  assert_equal "z", "z".match(/[a-Ā]/)[0]
+  assert_equal "{", "{".match(/[a-Ā]/)[0]      # 0x7b, inside a-Ā
+  assert_nil "A".match(/[a-Ā]/)                # 0x41, below the range
+  assert_nil "`".match(/[a-Ā]/)                # 0x60, just below 'a'
+  assert_equal "abĀz", "!abĀz!".match(/[a-Ā]+/)[0]
+  # The non-ASCII half still answers on its own.
+  assert_equal "Ā", "Ā".match(/[a-Ā]/)[0]
+  assert_equal "À", "À".match(/[a-Ā]/)[0]
+  assert_nil "ā".match(/[a-Ā]/)                # one past the upper bound
+  # Negation reads the same class, so it rejected the ASCII half it had to
+  # accept and accepted the half it had to reject.
+  assert_nil "a".match(/[^a-Ā]/)
+  assert_nil "Ā".match(/[^a-Ā]/)
+  assert_equal "A", "A".match(/[^a-Ā]/)[0]
+  assert_equal "ā", "ā".match(/[^a-Ā]/)[0]
+  # The /i fold walks the bitmap, so it reaches the ASCII half once that half
+  # is stored there. Non-ASCII case folding is still not applied.
+  assert_equal "A", "A".match(/[a-Ā]/i)[0]
+  assert_nil "A".match(/[^a-Ā]/i)
+  # Ranges that stay on one side of the boundary are unaffected.
+  assert_equal "b", "b".match(/[a-c]/)[0]
+  assert_equal "ą", "ą".match(/[Ā-Đ]/)[0]
+  assert_nil "a".match(/[Ā-Đ]/)
+end
+
 assert("Regexp - POSIX bracket classes") do
   # ASCII semantics, like this gem's \w/\d shorthands.
   assert_equal "abc", "123abc456".match(/[[:alpha:]]+/)[0]


### PR DESCRIPTION
`compile_charclass()` stores a range in one of two places. Both bounds below
128 go into the class bitmap through `class_set_range()`; anything else goes
into the codepoint list through `class_add_range()`. A range that starts in
ASCII and ends above it took the second path with the span left whole.

`class_match()` answers a codepoint below 128 from the bitmap alone and never
reads the codepoint list, so the ASCII half of such a range is unreachable.

```ruby
/[a-\u0100]/.match?("a")  # CRuby: true, mruby: false
/[a-\u0100]/.match?("z")  # CRuby: true, mruby: false
/[0-\u0100]/.match?("5")  # CRuby: true, mruby: false
```

The upper half still answers, so the class reads as half alive rather than
broken.

```ruby
/[a-\u0100]/.match?("\u0100")  # CRuby: true, mruby: true
```

A negated class is worse. Negation is applied at match time against the same
bitmap, so a class that matches nothing below 128 makes its negated form match
everything below 128, including the characters it was written to reject.
Nothing raises.

```ruby
/[^a-\u0100]/.match?("a")  # CRuby: false, mruby: true
```

## Fix

Split the range at the boundary instead of picking one side for the whole
span. The bitmap takes `cp` through 127 and the codepoint list takes 128
through `hi`.

A range that stays on one side reaches exactly one of the two calls and is
stored where it was before: `[a-c]` sets bitmap bits only, `[\u0100-\u0110]`
appends a codepoint range only. Only the straddling case changes, and it now
occupies both.

The `cp <= hi` guard moves out to cover both calls. It used to guard the
codepoint path alone, while the ASCII path relied on `class_set_range()`'s
loop not running for an inverted range. Neither call is reached now when
`cp > hi`, so a descending range still stores nothing.

This also restores `class_add_range()`'s documented contract that both of its
bounds are at least 128. The straddling case was the one caller that broke it.

`compute_first_set()` needs no change. `first_set_walk()` bails out on an
`RE_CLASS` whose codepoint list is non-empty, which a split range still leaves
non-empty, so the first-byte skip stays disabled for these patterns exactly as
it was.

## Scope

Non-ASCII case folding is unchanged and still out of scope: `/[\u0100]/i` does
not match `"\u0101"`. What this fixes is the ASCII half of a mixed range,
which the bitmap already knew how to hold.

#7049 folds `/i` into that same bitmap at the end of `compile_charclass()`, so
the two compose: with the ASCII half now stored where the fold walks,
`/[a-\u0100]/i` matches `"A"` and `/[^a-\u0100]/i` rejects it, both of which
agree with CRuby. That fold could not reach a straddling range on its own,
because the range never reached the bitmap.

## Tests

`mrbgems/mruby-regexp/test/regexp.rb`, a new
`Regexp - character class range across the ASCII boundary` block next to
`Regexp - character class`: the ASCII half of `[a-\u0100]`, both of its
boundaries (U+0060 below and U+0101 above), the non-ASCII half, a quantified
form, all four negated cases, the two `/i` forms, and two single-sided ranges
as regression guards.

It carries no `__ENCODING__` guard, unlike the other multibyte blocks in the
file. It reads only match results, never a character offset, so it runs on a
build without `MRB_UTF8_STRING`, which is what CI builds. With the guard the
block would never execute in CI.

Verified on `x86_64-linux`:

- Every reproduction above now agrees with CRuby 4.0.6.
- `rake test`: 1976 total, 1958 OK, 0 KO, 0 crash, and bintest 105 OK.
- An `MRB_INT32` build with clang and `-Wall -Wextra`: 1878 total, 1860 OK,
  0 KO, 0 crash, and no new warning from any `mruby-regexp` file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed regular expression character classes that span the ASCII and non-ASCII boundary.
  * Improved matching for positive, negated, quantified, and case-insensitive character ranges.
  * Preserved correct behavior for ranges entirely within ASCII or non-ASCII characters.

* **Tests**
  * Added regression coverage for boundary-spanning character-class ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->