### PR TITLE
mruby-regexp: add the regexp form of `String#[]` and `String#slice`

### DIFF
--- a/mrbgems/mruby-regexp/README.md
+++ b/mrbgems/mruby-regexp/README.md
@@ -85,12 +85,17 @@ str.gsub(re, replacement)         # replace all occurrences
 str.gsub(re) { |m| ... }          # replace all with block
 str.scan(re)                      # => array of matches
 str.split(re)                     # => array of parts
+str[re]                           # => matched substring or nil
+str[re, capture]                  # => capture by index or name
+str.slice(re)                     # => same as str[re]
 
 # Symbol methods (the String methods applied to the symbol's name)
 sym.match(re)                     # => MatchData or nil
 sym.match(re) { |md| ... }        # => block result, or nil if no match
 sym.match?(re)                    # => true/false
 sym =~ re                         # => index or nil
+sym[re]                           # => matched substring or nil
+                                  #    (Symbol#[] comes from mruby-symbol-ext)
 
 # Global variables
 $~                                # last MatchData
@@ -125,9 +130,6 @@ pattern analysis.
   only.
 - **Step limit on backtracking**: Patterns that require the
   backtracking engine are subject to a step limit.
-- **No regexp form of `String#[]`**: `str[re]` and `str.slice(re)`
-  are not supported, and neither is `sym[re]`, which delegates to
-  them.
 
 ## Configuration
 

--- a/mrbgems/mruby-regexp/mrblib/string_regexp.rb
+++ b/mrbgems/mruby-regexp/mrblib/string_regexp.rb
@@ -4,6 +4,11 @@ class String
   # back to the core implementation.
   alias __split split
 
+  # The same for String#[], whose regexp form is overridden at the end of
+  # this file.  `slice` is a second method table entry for the same C
+  # function rather than an alias of `[]`, so this one capture serves both.
+  alias __aref []
+
   # `match` and `match?` accept a Regexp or a String and reject everything
   # else.  The check lives in C (see Regexp.__check_pattern) so that the
   # argument cannot steer it: it cannot pose as a Regexp, and there is no
@@ -212,4 +217,45 @@ class String
     end
     result
   end
+
+  # Regexp-aware element reference.  Falls back to the C-defined `[]`
+  # (aliased as `__aref` above) for every other argument form, and handles a
+  # regexp here.
+  #
+  # `vm_op_getidx()` answers `str[Integer]`, `str[String]` and `str[Range]`
+  # from C without consulting the method table, so those three keep bypassing
+  # this override.  They are exactly the forms it would have handed back to
+  # `__aref` unchanged, so they cost nothing and behave as before, while a
+  # regexp index leaves the opcode through its fallback and arrives here as an
+  # ordinary send.  `str[i, len]` and every `slice` call are not opcode
+  # receivers and do arrive here, paying a Ruby frame on their way to
+  # `__aref`.
+  def [](*args)
+    # Before any argument inspection, so that the non-regexp forms keep the
+    # arity check `mrb_get_args()` does.  With no arguments at all `args[0]`
+    # is nil, the guard fails, and `__aref()` raises the ArgumentError.
+    # `is_a?` is redefinable, so a Regexp denying its own type would slip
+    # past and fail in `__aref`; `Module#===` reads the real type.
+    return __aref(*args) unless Regexp === args[0]
+    if args.length > 2
+      raise ArgumentError, "wrong number of arguments (given #{args.length}, expected 1..2)"
+    end
+    # `match` and not `match?`: the match globals have to be published here,
+    # including the clearing a failed match does, and `match?` leaves them
+    # alone.  That is why the MatchData is fetched even with no capture
+    # argument, where only its `[0]` is used.
+    md = args[0].match(self)
+    return nil unless md
+    # The capture argument reaches `MatchData#[]` untouched: it already
+    # normalizes a negative index, answers nil for an index past the last
+    # group and raises IndexError for a name that resolves to none, which is
+    # what CRuby does for `str[re, capture]`.
+    md[args.length > 1 ? args[1] : 0]
+  end
+
+  # `slice` is registered separately from `[]` rather than aliased to it, so
+  # the override above would leave it on the C implementation.  This is also
+  # what makes `sym[re]` work: `Symbol#[]` is an alias of `Symbol#slice`,
+  # which delegates to `String#slice`.
+  alias slice []
 end

--- a/mrbgems/mruby-regexp/mrblib/symbol_regexp.rb
+++ b/mrbgems/mruby-regexp/mrblib/symbol_regexp.rb
@@ -5,8 +5,9 @@
 #
 # This covers the symbol-on-the-left direction only.  The Regexp side converts
 # a symbol on its own, in `match_operand()` in regexp.c, so it needs nothing
-# from here.  `sym[/re/]` is the direction still missing; it waits on the
-# regexp form of `String#slice`.
+# from here.  `sym[/re/]` needs nothing either: `Symbol#slice` (mruby-symbol-ext,
+# which this gem does not depend on) delegates to `String#slice`, so it picks
+# up the regexp form from string_regexp.rb wherever that gem is built in.
 #
 # The argument handling of `=~` is inherited from `String#=~` rather than
 # introduced here, and agrees with CRuby: a String argument raises TypeError,

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -1738,3 +1738,94 @@ assert("Regexp - large non-ASCII character class does not overflow") do
   assert_nil (re =~ utf8.call(0x8081))
   assert_nil (re =~ "A")
 end
+
+assert("String#[] with regexp") do
+  assert_equal "ll", "hello"[/l+/]
+  assert_equal "ll", "hello".slice(/l+/)
+  assert_nil "hello"[/z/]
+  assert_nil "hello".slice(/z/)
+  assert_equal "", "hello"[//]
+
+  # the result is a plain String even for a subclass receiver, as in CRuby
+  sub = Class.new(String)
+  assert_equal String, sub.new("hello")[/l+/].class
+end
+
+assert("String#[] with regexp and capture") do
+  assert_equal "llo", "hello"[/(l+)(o)/, 0]
+  assert_equal "ll", "hello"[/(l+)(o)/, 1]
+  assert_equal "o", "hello"[/(l+)(o)/, 2]
+  assert_equal "ll", "hello"[/(?<x>l+)/, :x]
+  assert_equal "ll", "hello"[/(?<x>l+)/, "x"]
+  assert_equal "ll", "hello".slice(/(l+)/, 1)
+
+  # a group that did not take part in the match answers nil
+  assert_nil "hello"[/(z)?(l+)/, 1]
+
+  # handed to MatchData#[] as it stands: a negative index counts back from
+  # the last group, an index past the last group is nil, and a name that
+  # resolves to no group is a mistake at the point of the call
+  assert_equal "o", "hello"[/(l+)(o)/, -1]
+  assert_nil "hello"[/(l+)/, 5]
+  assert_raise(IndexError) { "hello"[/(?<x>l+)/, :zz] }
+  assert_raise(IndexError) { "hello"[/(l+)/, "x"] }
+  assert_raise(TypeError) { "hello"[/(l+)/, nil] }
+
+  # a failed match answers nil without ever looking at the capture argument
+  assert_nil "hello"[/(z)/, 1]
+  assert_nil "hello"[/(?<x>z)/, :zz]
+end
+
+assert("String#[] with regexp sets the match globals") do
+  assert_equal "ll", "hello"[/l+/]
+  assert_equal "ll", $~[0]
+  assert_equal "ll", Regexp.last_match(0)
+
+  "hello"[/(l)(l)/, 2]
+  assert_equal "l", $1
+
+  # a failed match clears $~, which is why this goes through `match` rather
+  # than `match?`
+  assert_nil "hello"[/z/]
+  assert_nil $~
+end
+
+assert("String#[] delegates every non-regexp argument") do
+  assert_equal "e", "hello"[1]
+  assert_equal "e", "hello".slice(1)
+  assert_equal "ell", "hello"[1, 3]
+  assert_equal "ell", "hello".slice(1, 3)
+  assert_equal "ell", "hello"[1..3]
+  assert_equal "llo", "hello"[-3..-1]
+  assert_equal "ll", "hello"["ll"]
+  assert_nil "hello"["bye"]
+  assert_nil "hello"[12]
+  assert_nil "hello"[12, 1]
+
+  # the same delegation on a subclass receiver, which the inline index
+  # opcodes never answer and which therefore always arrives here
+  sub = Class.new(String)
+  assert_equal "e", sub.new("hello")[1]
+  assert_equal "ell", sub.new("hello")[1..3]
+  assert_equal "ll", sub.new("hello")["ll"]
+
+  # the arity and type errors are the ones the C method raises
+  assert_raise(ArgumentError) { "hello"[] }
+  assert_raise(ArgumentError) { "hello"[1, 2, 3] }
+  assert_raise(ArgumentError) { "hello".slice(1, 2, 3) }
+  assert_raise(ArgumentError) { "hello"[/l/, 1, 2] }
+  assert_raise(TypeError) { "hello"[nil] }
+end
+
+assert("String#[] reads the real type of its argument") do
+  # `is_a?` is redefinable, so a Regexp denying its own type must still be
+  # matched against, and an object claiming to be one must not be
+  re = /l+/
+  def re.is_a?(klass); false; end
+  assert_equal "ll", "hello"[re]
+
+  fake = Object.new
+  def fake.is_a?(klass); true; end
+  def fake.match(str); raise "must not be called"; end
+  assert_raise(TypeError) { "hello"[fake] }
+end

--- a/mrbgems/mruby-regexp/test/symbol_regexp.rb
+++ b/mrbgems/mruby-regexp/test/symbol_regexp.rb
@@ -99,3 +99,20 @@ assert("Symbol - multibyte (UTF-8) name") do
   assert_false :"あいあ".match?(Regexp.new("い"), 2)
   assert_equal 1, :"あい" =~ Regexp.new("い")
 end
+
+assert("Symbol#[] with regexp") do
+  # `Symbol#[]` and `#slice` live in mruby-symbol-ext, which this gem does not
+  # depend on; they delegate to the String methods, so the regexp form arrives
+  # from string_regexp.rb wherever that gem is built in.
+  skip unless :hello.respond_to?(:slice)
+  assert_equal "ll", :hello[Regexp.new("l+")]
+  assert_equal "ll", :hello.slice(Regexp.new("l+"))
+  assert_equal "ll", :hello[Regexp.new("(?<x>l+)"), :x]
+  assert_equal "o", :hello[Regexp.new("(l+)(o)"), 2]
+  assert_nil :hello[Regexp.new("z")]
+
+  # the non-regexp forms are untouched
+  assert_equal "e", :hello[1]
+  assert_equal "ell", :hello[1, 3]
+  assert_equal "ell", :hello[1..3]
+end


### PR DESCRIPTION
## Problem

`String#[]` and its `slice` twin accept an Integer, a String and a Range, but not a
Regexp. `str_convert_range()` in `src/string.c` funnels every non-String, non-Range
argument through `mrb_ensure_int_type()`, so the regexp forms raise a TypeError that names
Integer, which does not hint at what is actually missing. `mruby-regexp` never overrode
`[]` or `slice`, and the gem README listed this under Limitations.

```ruby
"hello"[/l+/]            # CRuby: "ll",  mruby: TypeError (Regexp cannot be converted to Integer)
"hello".slice(/l+/)      # CRuby: "ll",  mruby: TypeError
"hello"[/(l+)(o)/, 1]    # CRuby: "ll",  mruby: TypeError
"hello"[/(?<x>l+)/, :x]  # CRuby: "ll",  mruby: TypeError
"hello"[/z/]             # CRuby: nil,   mruby: TypeError
:hello[/l+/]             # CRuby: "ll",  mruby: TypeError
```

## Change

`mrbgems/mruby-regexp/mrblib/string_regexp.rb` overrides `[]`, following the pattern
`split` already uses in the same file: the C-defined method is aliased as `__aref`, and
the override hands every non-Regexp argument list straight back to it.

The delegation happens before any argument is inspected, so the non-regexp forms keep the
arity and type errors `mrb_get_args()` raises. With no arguments at all, `args[0]` is nil,
the guard fails, and `__aref()` raises the same ArgumentError as before. `Module#===` reads
the argument's real type, since `is_a?` is redefinable.

A Regexp goes through `Regexp#match` and not `#match?`: the match globals have to be
published here, including the clearing a failed match does, which is why the MatchData is
fetched even when no capture was asked for. The capture argument reaches `MatchData#[]`
untouched, which already gives the CRuby semantics: a negative index counts back from the
last group, an index past the last group is nil, and a name that resolves to no group
raises IndexError.

`slice` is a second method table entry for the same C function rather than an alias of
`[]`, in mruby and in CRuby alike, so the override is aliased to `slice` as well. That is
also what makes `sym[re]` work, and it needs no change of its own: `Symbol#[]` is an alias
of `Symbol#slice` in mruby-symbol-ext, which delegates to `String#slice`.

## Interaction with the inline index opcodes

`vm_op_getidx()` answers `str[Integer]`, `str[String]` and `str[Range]` from C, and
`vm_op_getidx0()` answers `str[0]`. Both guard on the receiver's class only, not on whether
`String#[]` has been redefined, so those forms keep bypassing this override. That is
harmless and desirable: they are exactly the ones the override would have delegated back to
`__aref()` unchanged, so behaviour is identical and they pay nothing. A Regexp index falls
into the `default` arm of the opcode's type switch, leaves through `getidx_fallback`, and
arrives here as an ordinary send.

`str[i, len]` and every `slice` call are not opcode receivers and do reach the override,
paying a Ruby frame on their way to `__aref` (measured at roughly 3x the direct C call on a
tight 300k-iteration loop). This is the cost of the feature living in mrblib; moving the
regexp branch into C would avoid it, at the price of a callback into the VM from
`str_convert_range()`.

## Documentation

The gem README loses its **No regexp form of `String#[]`** limitation and gains the new
forms in the usage list, and the header comment of `mrblib/symbol_regexp.rb` no longer says
`sym[/re/]` is missing.

The write side, `str[re] = repl` and `str.slice!(re)`, is deliberately out of scope: both
are destructive and belong with the other destructive-method work. The removed limitation
item was about reading only, so it is dropped rather than narrowed.

## Tests

`mrbgems/mruby-regexp/test/regexp.rb` gains assertions for the plain match, captures by
index / name / symbol, negative and out-of-range capture indexes, failed matches, the match
globals, the untouched non-regexp forms including a String subclass receiver (which the
opcodes never answer), the argument errors, and an argument that lies about its own type.
`test/symbol_regexp.rb` gains the `sym[re]` forms, guarded by a `skip` because mrbtest
builds this gem's tests without mruby-symbol-ext.

`rake test` passes with no failures, both in a default build and in one with
`MRB_UTF8_STRING`. Checked against CRuby 4.0.6.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added regular expression support to `String#[]` and `String#slice`, including capture selection and named captures.
  * Added support for regular expression indexing and slicing on symbols when symbol slicing is available.
  * Existing string and symbol indexing forms remain supported.

* **Bug Fixes**
  * Improved handling of unmatched patterns, invalid arguments, and lookalike regexp objects.

* **Documentation**
  * Updated regexp documentation to reflect the newly supported operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->