### PR TITLE
mruby-regexp: support `(?#...)` comment groups

### DIFF
--- a/mrbgems/mruby-regexp/README.md
+++ b/mrbgems/mruby-regexp/README.md
@@ -16,6 +16,7 @@ simulation) with backtracking fallback.
 - `\D`, `\W`, `\S` negated shortcuts
 - `(...)` capture group
 - `(?:...)` non-capturing group
+- `(?#...)` comment group
 - `(?<name>...)` named capture group
 - `|` alternation
 - `\1`-`\9` backreferences

--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -14,7 +14,7 @@
 /* Compiler state */
 typedef struct {
   mrb_state *mrb;
-  const char *src;     /* pattern source (preprocessed in extended mode) */
+  const char *src;     /* pattern source, preprocessed (see preprocess_pattern) */
   const char *src_end;
   const char *orig;    /* pattern as written, for error messages */
   const char *orig_end;
@@ -31,7 +31,7 @@ typedef struct {
   uint16_t num_named;
   mrb_bool has_backref;
   mrb_bool needs_backtrack;
-  char *stripped;           /* allocated buffer for x-mode preprocessing */
+  char *stripped;           /* allocated buffer for pattern preprocessing */
 } re_compiler;
 
 static void compile_alt(re_compiler *c);  /* forward */
@@ -39,11 +39,12 @@ static void compile_alt(re_compiler *c);  /* forward */
 static void
 compile_error(re_compiler *c, const char *msg)
 {
-  /* Quote c->orig, the pattern as written: in extended mode c->src points at
-     the buffer strip_extended() returned, so quoting it would drop the
-     free-spacing and the comments from the message. c->orig is the caller's
-     buffer, which outlives the compile. It is not NUL-terminated, so use %l
-     with the explicit length from c->orig_end. */
+  /* Quote c->orig, the pattern as written: when the pattern is preprocessed
+     c->src points at the buffer preprocess_pattern() returned, so quoting it
+     would drop the free-spacing, the comments and the (?#...) groups from the
+     message. c->orig is the caller's buffer, which outlives the compile. It
+     is not NUL-terminated, so use %l with the explicit length from
+     c->orig_end. */
   mrb_value emsg = mrb_format(c->mrb, "%s: /%l/",
                               msg, c->orig, (size_t)(c->orig_end - c->orig));
 
@@ -719,12 +720,19 @@ compile_atom(re_compiler *c)
             compile_error(c, "undefined (?...) sequence");
           }
         }
+        else if (c->p[1] == '#') {
+          /* preprocess_pattern() removes a terminated comment group before
+             the parser runs, so one reaching here was never closed. */
+          compile_error(c, "unterminated comment group");
+        }
         else {
           /* (?X) with an unsupported X: not one of the recognized (?: (?= (?!
-             (?<= (?<! (?<name> (?imx forms. The absent operator (?~...) and
-             conditionals (?(...)) are not implemented. Raise here rather than
-             falling through to the capturing-group path, which would leave
-             the stray `?` for compile_seq to spin on forever (A1). */
+             (?<= (?<! (?<name> (?imx forms. Comment groups (?#...) never get
+             here either, having been removed by preprocess_pattern(). The
+             absent operator (?~...) and conditionals (?(...)) are not
+             implemented. Raise here rather than falling through to the
+             capturing-group path, which would leave the stray `?` for
+             compile_seq to spin on forever (A1). */
           compile_error(c, "undefined (?...) sequence");
         }
       }
@@ -1140,12 +1148,31 @@ compile_alt(re_compiler *c)
 }
 
 /*
- * Strip whitespace and #comments for extended mode (/x flag).
- * Whitespace inside [...] character classes is preserved.
+ * Does the pattern hold a (?# comment group opener? Cheap pre-check so an
+ * ordinary pattern without one skips preprocess_pattern() and its malloc.
+ */
+static mrb_bool
+has_comment_group(const char *src, mrb_int len)
+{
+  const char *p = src, *end = src + len;
+  while (p < end && (p = (const char*)memchr(p, '(', (size_t)(end - p))) != NULL) {
+    if (end - p >= 3 && p[1] == '?' && p[2] == '#') return TRUE;
+    p++;
+  }
+  return FALSE;
+}
+
+/*
+ * Rewrite the pattern before the parser sees it.
+ * Removes (?#...) comment groups always, and in extended mode (/x) also
+ * whitespace and #comments.
+ * Whitespace inside [...] character classes is preserved, and so is a (?#
+ * written there, which is a literal member rather than a comment group.
  * Escaped characters (\ followed by anything) are preserved.
  */
 static char*
-strip_extended(mrb_state *mrb, const char *src, mrb_int len, mrb_int *out_len)
+preprocess_pattern(mrb_state *mrb, const char *src, mrb_int len,
+                   mrb_bool extended, mrb_int *out_len)
 {
   char *buf = (char*)mrb_malloc(mrb, len);
   mrb_int o = 0;
@@ -1186,14 +1213,39 @@ strip_extended(mrb_state *mrb, const char *src, mrb_int len, mrb_int *out_len)
       if (src < end && *src == ']') buf[o++] = *src++;
       continue;
     }
-    if (ch == '#') {
-      /* skip to end of line */
-      while (src < end && *src != '\n') src++;
+    if (ch == '(' && end - src >= 3 && src[1] == '?' && src[2] == '#') {
+      /* Comment group: ends at the first ')' not preceded by a backslash.
+         It does not nest, so (?#a(?#b)) closes at the first ')' and leaves
+         the second one to be reported as unmatched, as CRuby does.
+         Dropping the group here rather than in compile_atom() is what lets
+         it stand where an atom cannot: CRuby compiles "a(?#x)*" as "a*", and
+         an atom that emits no instruction cannot be a quantifier's target.
+         An unterminated group is copied through instead, so that
+         compile_atom() raises on it. */
+      const char *q = src + 3;
+      while (q < end && *q != ')') {
+        if (*q == '\\' && q + 1 < end) q++;
+        q++;
+      }
+      if (q < end) {
+        src = q + 1;
+        continue;
+      }
+      buf[o++] = *src++;
+      buf[o++] = *src++;
+      buf[o++] = *src++;
       continue;
     }
-    if (ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r' || ch == '\f' || ch == '\v') {
-      src++;
-      continue;
+    if (extended) {
+      if (ch == '#') {
+        /* skip to end of line */
+        while (src < end && *src != '\n') src++;
+        continue;
+      }
+      if (ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r' || ch == '\f' || ch == '\v') {
+        src++;
+        continue;
+      }
     }
     buf[o++] = *src++;
   }
@@ -1294,9 +1346,10 @@ mrb_re_compile(mrb_state *mrb, const char *pattern, mrb_int len, uint32_t flags)
   c.orig = pattern;
   c.orig_end = pattern + len;
 
-  if (flags & RE_FLAG_EXTENDED) {
+  if ((flags & RE_FLAG_EXTENDED) || has_comment_group(pattern, len)) {
     mrb_int slen;
-    c.stripped = strip_extended(mrb, pattern, len, &slen);
+    c.stripped = preprocess_pattern(mrb, pattern, len,
+                                    (flags & RE_FLAG_EXTENDED) != 0, &slen);
     pattern = c.stripped;
     len = slen;
   }
@@ -1333,7 +1386,8 @@ mrb_re_compile(mrb_state *mrb, const char *pattern, mrb_int len, uint32_t flags)
 
   /* Copy capture names into an owned arena. Until this point the names
      point into the pattern source (or into c.stripped, which gets freed
-     below in /x mode). After this loop the regexp owns its names. */
+     below when the pattern was preprocessed). After this loop the regexp
+     owns its names. */
   if (c.num_named > 0) {
     size_t total = 0;
     for (uint16_t i = 0; i < c.num_named; i++) total += c.named_captures[i].name_len;

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -453,6 +453,42 @@ assert("Regexp - inline options (?i) / (?i:...)") do
   assert_raise(RegexpError) { Regexp.new("(?x)a b") }
 end
 
+assert("Regexp - comment groups (?#...)") do
+  # The group is removed before the pattern is parsed, so it can stand
+  # anywhere, including where an atom cannot.
+  assert_true(/a(?#note)b/.match?("ab"))
+  assert_true Regexp.new("(?#lead)ab").match?("ab")
+  assert_true Regexp.new("ab(?#trail)").match?("ab")
+  assert_true Regexp.new("a(?#)b").match?("ab")          # empty comment
+  assert_true Regexp.new("a(?#no\nte)b").match?("ab")    # newline is comment text
+  assert_equal ["ab", "ab"], Regexp.new("(a(?#c)b)").match("ab").to_a
+
+  # The group is not an atom: a quantifier after it repeats what came before.
+  assert_equal 0, (Regexp.new("a(?#x)*") =~ "aaa")
+  assert_raise(RegexpError) { Regexp.new("(?#x)*") }
+
+  # A backslash escapes the following byte, so \) does not close the group.
+  assert_true Regexp.new("a(?#x\\)y)b").match?("ab")
+  # ... but an escaped backslash does not reach the ')', which then closes
+  # the group and leaves the second one unmatched.
+  assert_raise(RegexpError) { Regexp.new("a(?#x\\\\)y)b") }
+
+  # Comment groups do not nest: the first ')' closes, the second is unmatched.
+  assert_raise(RegexpError) { Regexp.new("x(?#a(?#b))y") }
+
+  # An unterminated group raises rather than swallowing the rest.
+  assert_raise_with_message(RegexpError, "unterminated comment group: /a(?#note/") do
+    Regexp.new("a(?#note")
+  end
+
+  # Inside a character class the same bytes are ordinary members.
+  assert_true Regexp.new("a[(?#c)]b").match?("a#b")
+  assert_true Regexp.new("a[(?#c)]b").match?("a(b")
+
+  # An escaped '(' does not open a comment group.
+  assert_raise(RegexpError) { Regexp.new("a\\(?#note)b") }
+end
+
 assert("MatchData#captures") do
   re = Regexp.new("(a)(b)(c)")
   md = re.match("abc")
@@ -695,6 +731,18 @@ assert("Regexp extended mode (x flag)") do
   # escaped whitespace is preserved
   re = Regexp.new('a\\ b', Regexp::EXTENDED)
   assert_true re.match?("a b")
+
+  # a comment group is removed ahead of the line-comment pass, so its ')'
+  # survives the '#' inside it
+  re = Regexp.new("a (?#note) b", Regexp::EXTENDED)
+  assert_true re.match?("ab")
+
+  re = Regexp.new("a (?#note) b # tail\nc", Regexp::EXTENDED)
+  assert_true re.match?("abc")
+
+  assert_raise_with_message(RegexpError, "unterminated comment group: /a (?#note/") do
+    Regexp.new("a (?#note", Regexp::EXTENDED)
+  end
 
   # inspect shows x flag
   assert_equal "/abc/x", Regexp.new("abc", Regexp::EXTENDED).inspect


### PR DESCRIPTION
`(?#...)` is a comment group: Ruby drops it from the pattern and compiles what is
left. The `(?` dispatch in `compile_atom()` recognises `(?:`, `(?=`, `(?!`,
`(?<=`, `(?<!`, `(?<name>` and the inline options, but has no `#` branch, so a
pattern holding a comment group falls through to `undefined (?...) sequence` and
does not compile at all.

```ruby
/a(?#note)b/.match?("ab")
# CRuby: true
# mruby: RegexpError (undefined (?...) sequence: /a(?#note)b/)

Regexp.new("a(?#x\\)y)b").match?("ab")
# CRuby: true
# mruby: RegexpError (undefined (?...) sequence: /a(?#x\)y)b/)

Regexp.new("(a(?#c)b)").match("ab").to_a
# CRuby: ["ab", "ab"]
# mruby: RegexpError (undefined (?...) sequence: /(a(?#c)b)/)
```

The group is not an atom, so a quantifier written after it repeats what came
before it:

```ruby
Regexp.new("a(?#x)*") =~ "aaa"
# CRuby: 0
# mruby: RegexpError (undefined (?...) sequence: /a(?#x)*/)
```

Under `/x` the same pattern fails for a second reason. Extended mode is
preprocessed over the whole pattern before the parser runs, and its `#` branch
skips to the end of the line, so `a (?#note) b` loses `#note) b` and leaves a
dangling `(?` at the end of the stripped buffer. A fix confined to
`compile_atom()` would leave this half broken, and comment groups written
alongside `/x` are where they are most common.

```ruby
Regexp.new("a (?#note) b", Regexp::EXTENDED).match?("ab")
# CRuby: true
# mruby: RegexpError (target of repeat operator is not specified: /a (?#note) b/)
```

## Fix

Remove the group in the preprocessing pass rather than in the parser.

That is what lets `a(?#x)*` compile as `a*`: the group has to be gone before the
quantifier is parsed. An atom is too late. `compile_quantified()` returns early
when `compile_atom()` emitted no instruction, so a comment group handled there
would leave the `*` with no target, and an atom that did emit one would change
what the pattern matches.

`strip_extended()` becomes `preprocess_pattern()` and takes the `/x` behaviour
as a flag. Comment group removal runs unconditionally, whitespace and `#`
line-comment stripping only when `RE_FLAG_EXTENDED` is set. `mrb_re_compile()`
now enters the pass when either the flag is set or `has_comment_group()` finds
`(?#` in the pattern, so an ordinary pattern without one still skips the pass
and its `mrb_malloc()`. That gate is a `memchr()` scan for `(`.

The new branch sits after the backslash pass-through and after the character
class branch, so the two ways of writing those bytes without meaning a comment
group keep the behaviour they have now:

```ruby
Regexp.new("a[(?#c)]b").match?("a#b")  # both: true, class member
Regexp.new("a\\(?#note)b")             # both: RegexpError, escaped '('
```

The group ends at the first `)` not preceded by a backslash, and it does not
nest, so `x(?#a(?#b))y` closes at the first `)` and reports the second as
unmatched, as CRuby does.

An unterminated group is copied through the pass instead of being dropped,
which is what the new `#` branch in `compile_atom()` is for: reaching it means
the group was never closed, and it raises rather than letting the rest of the
pattern be swallowed silently.

```ruby
Regexp.new("a(?#note")
# CRuby: RegexpError (end pattern in group)
# this PR: RegexpError (unterminated comment group)
```

Error messages still quote the pattern as written, since `compile_error()`
already quotes `c->orig` rather than the preprocessed buffer.

## Scope

Nothing outside the pattern compiler changes. The literal form `/a(?#note)b/`
already passed through the parser without complaint, which is why the
reproduction raises `RegexpError` rather than a parse-time error, so
`mruby-compiler` needs no change. `regexp.c` is not involved either, since the
failure happens during compilation before any `Regexp` method runs.

`(?~...)` and `(?(...)` remain unimplemented and still raise from the same
catch-all.

## Tests

`mrbgems/mruby-regexp/test/regexp.rb`:

- `Regexp - comment groups (?#...)`, a new block next to
  `Regexp - inline options (?i) / (?i:...)`, the nearest coverage of the same
  dispatch chain: the literal and constructor forms, leading, trailing and
  empty comments, a newline inside one, a comment inside a capture group, the
  quantifier target case, `\)` inside a comment and the escaped backslash that
  ends one early, the non-nesting case, the unterminated case with its message,
  the character class member, and the escaped `(`.
- `Regexp extended mode (x flag)`: a comment group under `/x`, one followed by
  an ordinary `#` line comment on the same line, and the unterminated case.

Verified on `x86_64-linux`:

- Every reproduction above now agrees with CRuby 4.0.6, error message wording
  aside.
- `rake test`: 1976 total, 1958 OK, 0 KO, 0 crash, and bintest 105 OK.
- An `MRB_INT32` build with clang and `-Wall -Wextra`: 1878 total, 1860 OK,
  0 KO, 0 crash, and no new warning from any `mruby-regexp` file.
- `build_config/clang-asan.rb`: 2153 total, 2143 OK, 0 KO, 0 crash, with no
  leak or invalid access reported.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `(?#...)` comment groups in regular expressions.
  * Documented regular-expression comment-group syntax.
  * Comment groups now work with extended-mode patterns and character classes.

* **Bug Fixes**
  * Unterminated comment groups now produce a specific parsing error.
  * Improved handling of escaped syntax, nesting, and quantifier interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->