### PR TITLE
mruby-regexp: make a multibyte literal one atom

### DIFF
--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -929,6 +929,21 @@ compile_atom(re_compiler *c)
         break;
       }
     }
+    if (ch >= 128) {
+      /* Emit every byte of a multibyte character here, so the whole character
+         is one atom. Leaving the continuation bytes to the parse loop made
+         each of them an atom of its own, and a quantifier binds to the last
+         atom emitted: /Ā+/ compiled as \xC4(\x80)+ and matched one Ā in "ĀĀ".
+         An invalid lead byte has a charlen of 1 and still emits alone. */
+      int len = mrb_re_utf8_charlen(c->p - 1, c->src_end);
+      emit(c, RE_CHAR, (uint8_t)ch, 0);
+      for (int i = 1; i < len; i++) {
+        int b = next_char(c);
+        if (b < 0) break;
+        emit(c, RE_CHAR, (uint8_t)b, 0);
+      }
+      break;
+    }
     emit(c, RE_CHAR, (uint8_t)ch, 0);
     break;
   }

--- a/mrbgems/mruby-regexp/src/re_utf8.c
+++ b/mrbgems/mruby-regexp/src/re_utf8.c
@@ -7,7 +7,9 @@
 #include "re_internal.h"
 
 /* Return byte length of UTF-8 character at s.
-   Returns 1 for invalid sequences (treat as single byte). */
+   Returns 1 for invalid sequences (treat as single byte): a byte that starts
+   no sequence, a sequence cut short by end, and one whose continuation bytes
+   are not 10xxxxxx. */
 int
 mrb_re_utf8_charlen(const char *s, const char *end)
 {
@@ -22,6 +24,9 @@ mrb_re_utf8_charlen(const char *s, const char *end)
   else return 1;  /* invalid */
 
   if (s + len > end) return 1;  /* truncated */
+  for (int i = 1; i < len; i++) {
+    if (((uint8_t)s[i] & 0xc0) != 0x80) return 1;  /* invalid continuation */
+  }
   return len;
 }
 

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -529,6 +529,50 @@ assert("MatchData#begin / #end - index out of matches") do
   assert_nil md.end(2)
 end
 
+assert("Regexp - quantifier on a multibyte literal") do
+  # The bytes of a multibyte literal used to be separate atoms, so a
+  # quantifier bound to the last one: /Ā+/ was \xC4(\x80)+ and stopped after
+  # one Ā. The byte counts below are what tells the two apart.
+  assert_equal 4, "ĀĀ".match(/Ā+/)[0].bytesize
+  assert_equal 4, "ĀĀ".match(/Ā*/)[0].bytesize
+  assert_equal 6, "ĀĀĀ".match(/Ā{2,3}/)[0].bytesize
+  assert_true "ĀĀ".match?(/Ā{2}/)
+  assert_false "Ā".match?(/Ā{2}/)
+  # Three and four byte characters take the same path.
+  assert_equal 6, "日日".match(/日+/)[0].bytesize
+  assert_equal 8, "𝕏𝕏".match(/𝕏+/)[0].bytesize
+  # A quantified literal after another atom, and a non-greedy one.
+  assert_equal 5, "aĀĀ".match(/aĀ+/)[0].bytesize
+  assert_equal 2, "ĀĀ".match(/Ā+?/)[0].bytesize
+  # Scanning must not split a run into one match per character.
+  assert_equal [4, 2], "ĀĀxĀ".scan(/Ā+/).map { |s| s.bytesize }
+  # An optional multibyte literal that is absent still matches empty.
+  assert_equal 0, "z".match(/Ā?/)[0].bytesize
+end
+
+assert("Regexp - quantifier on an invalid multibyte literal") do
+  # A byte above 127 is one atom only while it starts a whole character. The
+  # sequences below never complete one, so each byte stands alone and the
+  # quantifier binds to the byte in front of it, not to the pair.
+  lead2 = "\xC4"  # starts a two byte character
+  lead3 = "\xE3"  # starts a three byte character
+  cont = "\x81"   # continuation byte
+
+  # "x" is not a continuation byte, so `+` repeats "x".
+  assert_equal 4, (lead2 + "xxx").match(Regexp.new(lead2 + "x+"))[0].bytesize
+  assert_equal 4, (lead3 + "abb").match(Regexp.new(lead3 + "ab+"))[0].bytesize
+  # The quantifier itself must not be taken for a continuation byte either.
+  assert_equal 2, (lead2 + lead2).match(Regexp.new(lead2 + "+"))[0].bytesize
+  # A sequence cut short by the end of the pattern emits its bytes one by one.
+  assert_equal 2, (lead3 + cont).match(Regexp.new(lead3 + cont))[0].bytesize
+  assert_equal 3, (lead3 + cont + cont).match(Regexp.new(lead3 + cont + "+"))[0].bytesize
+  # A valid character right after an invalid lead byte is still one atom.
+  assert_equal 5, (lead2 + "ĀĀ").match(Regexp.new(lead2 + "Ā+"))[0].bytesize
+  # The subject side reads the same way: `.` takes the lead byte alone.
+  assert_equal 1, (lead2 + "x").match(/./)[0].bytesize
+  assert_equal 2, "Ā".match(/./)[0].bytesize
+end
+
 assert("Regexp - multibyte (UTF-8) match extraction") do
   # Capture offsets are recorded in bytes; substring extraction must honor
   # them as byte ranges so multibyte matches are not corrupted.


### PR DESCRIPTION
`compile_atom()` emits a literal one byte at a time
(`re_compile.c:931`). For a character above 127 that means the lead byte and
each continuation byte become atoms of their own, and `compile_quantified()`
binds a quantifier to the last atom emitted. `/Ā+/` therefore compiled as
`\xC4(\x80)+`: the lead byte once, then the continuation byte repeated.

```ruby
/Ā+/.match("ĀĀ")[0]      # CRuby: "ĀĀ", mruby: "Ā"
/Ā*/.match("ĀĀ")[0]      # CRuby: "ĀĀ", mruby: "Ā"
/Ā{2}/.match?("ĀĀ")      # CRuby: true,  mruby: false
/Ā{2,3}/.match("ĀĀĀ")   # CRuby: a match, mruby: nil
```

Three and four byte characters go the same way, and a quantified literal
after another atom is affected too.

```ruby
/日+/.match("日日")[0]     # CRuby: "日日",   mruby: "日"
/𝕏+/.match("𝕏𝕏")[0]     # CRuby: "𝕏𝕏",   mruby: "𝕏"
/aĀ+/.match("aĀĀ")[0]   # CRuby: "aĀĀ", mruby: "aĀ"
```

Scanning turns one run into one match per character, which is the form most
likely to be noticed as wrong output rather than as a missing match.

```ruby
"ĀĀxĀ".scan(/Ā+/)  # CRuby: ["ĀĀ", "Ā"], mruby: ["Ā", "Ā", "Ā"]
```

Nothing raises in any of these.

## Fix

Emit every byte of the character in one go, so the atom spans the whole
character.

That is all it takes, because the quantifier machinery already works on a
span rather than on a single instruction: `emit_atom_copy()` copies the whole
`[start, code_len)` range for `{n,m}`, and the `RE_SPLIT` that
`insert_inst()` puts in front of the atom for `*` and `?` covers the range as
well. A group, which is many instructions, has always relied on this; a
multibyte literal was the one atom that did not produce a span.

Where the character ends comes from `mrb_re_utf8_charlen()`, which derived it
from the lead byte alone and never looked at the bytes that follow. That is too
loose to build an atom from. For the pattern bytes `C4 78 2B` it reports 2, so
`x` joins the atom and `+` repeats `\xC4x`; for `C4 2B` it reports 2 as well,
and the `+` itself is swallowed and stops being a quantifier at all.

```ruby
b = "\xC4"  # lead byte of a two byte character, standing on its own
Regexp.new(b + "x+").match(b + "xxx")[0].bytesize  # 2 without the check, 4 with it
Regexp.new(b + "+").match(b + b)                   # nil without the check, a match with it
```

So this checks the continuation bytes there as well. A sequence that never
completes keeps reporting a length of 1, its bytes stay atoms of their own, and
such a pattern reads as the bytes it is made of. `mrb_re_utf8_decode()` takes
its length from the same function, so the string being matched is read the same
way: `.` takes an incomplete lead byte alone instead of pairing it with
whatever follows.

Nothing downstream changes. `compute_fixed_len()` counts each `RE_CHAR` as one
byte and reaches the same total, `first_set_walk()` already returns early on a
lead byte above 127, and the literal prefix scan reads whatever run of
`RE_CHAR` it finds.

## Tests

`mrbgems/mruby-regexp/test/regexp.rb`, two new blocks before
`Regexp - multibyte (UTF-8) match extraction`.

`Regexp - quantifier on a multibyte literal`: `+`, `*`, `{n}` and `{n,m}` on
a two byte literal, the three and four byte cases, a quantified literal
preceded by another atom, a non-greedy form, `scan`, and an absent optional
literal. The assertions compare `bytesize`, since a match that stops one
character early is still a match and only the length tells the two apart.

`Regexp - quantifier on an invalid multibyte literal`: a lead byte followed by
an ASCII byte, a lead byte followed by the quantifier itself, a sequence cut
short by the end of the pattern, a valid character right after a stray lead
byte, and `.` over a stray lead byte on the subject side.

Verified on `x86_64-linux`:

- A differential sweep of 3223 cases against CRuby 4.0.6: four literals from
  one to four bytes, eleven quantifier forms, each plain, preceded by another
  atom and preceded by a lookbehind, over four subject lengths, plus five stray
  lead bytes with five followers each. 234 cases disagreed before this change
  and none do after. Patterns that are not valid UTF-8 are compared against a
  binary CRuby regexp, since CRuby rejects them outright while mruby has no
  encodings.
- `rake test`: 1977 total, 1959 OK, 0 KO, 0 crash, and bintest 105 OK.
- An `MRB_INT32` build with clang and `-Wall -Wextra`: 2046 total, 2036 OK,
  0 KO, 0 crash, and no new warning from any `mruby-regexp` file (`regexp.c`
  already emits four `-Wunused-parameter`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed regular expression handling for multibyte UTF-8 characters, ensuring complete characters are treated as single pattern atoms.
  * Improved quantifier, optional-match, non-greedy, and scanning behavior for multibyte literals.
  * Invalid or incomplete UTF-8 sequences continue to be handled safely.

* **Tests**
  * Added regression coverage for 2-, 3-, and 4-byte UTF-8 characters across supported quantifier patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
