### PR TITLE
mruby-regexp: let a byte that starts no character begin a match

### DIFF
--- a/mrbgems/mruby-regexp/include/re_internal.h
+++ b/mrbgems/mruby-regexp/include/re_internal.h
@@ -160,10 +160,20 @@ mrb_re_decode_char(const char *s, const char *end, int *len, mrb_bool binary)
   return mrb_re_utf8_decode(s, end, len);
 }
 
+/* TRUE when s points into the middle of a character that starts earlier in
+   the string, so it is not a place a match may start at. A byte that looks
+   like a continuation byte but follows no lead byte that reaches it belongs
+   to no character and stands on its own. */
 static inline mrb_bool
-mrb_re_utf8_continuation_p(const char *s)
+mrb_re_utf8_interior_p(const char *str, const char *s, const char *end)
 {
-  return (((uint8_t)*s & 0xC0) == 0x80);
+  if (((uint8_t)*s & 0xC0) != 0x80) return FALSE;
+  for (int back = 1; back <= 3 && s - back >= str; back++) {
+    const char *lead = s - back;
+    if (((uint8_t)*lead & 0xC0) == 0x80) continue;  /* another continuation byte */
+    return mrb_re_utf8_charlen(lead, end) > back;
+  }
+  return FALSE;
 }
 
 /* Execute a match.

--- a/mrbgems/mruby-regexp/include/re_internal.h
+++ b/mrbgems/mruby-regexp/include/re_internal.h
@@ -168,7 +168,7 @@ static inline mrb_bool
 mrb_re_utf8_interior_p(const char *str, const char *s, const char *end)
 {
   if (((uint8_t)*s & 0xC0) != 0x80) return FALSE;
-  for (int back = 1; back <= 3 && s - back >= str; back++) {
+  for (int back = 1; back <= 3 && back <= s - str; back++) {
     const char *lead = s - back;
     if (((uint8_t)*lead & 0xC0) == 0x80) continue;  /* another continuation byte */
     return mrb_re_utf8_charlen(lead, end) > back;

--- a/mrbgems/mruby-regexp/src/re_exec.c
+++ b/mrbgems/mruby-regexp/src/re_exec.c
@@ -330,17 +330,18 @@ pike_vm(mrb_state *mrb, const mrb_regexp_pattern *pat,
          not a char boundary, and starting a thread there mis-decodes the
          char (e.g. a class match on a stray 0x82 instead of the leader's
          full codepoint). A byte that no lead byte reaches belongs to no
-         character and is a boundary of its own. */
-      if (!s.binary && curr.count == 0 && sp < str_end &&
-          mrb_re_utf8_interior_p(str, sp, str_end)) {
-        continue;
+         character and is a boundary of its own.
+         Threads seeded earlier are still stepped at this position, so the
+         test guards the seeding alone and never skips the iteration. */
+      if (s.binary || sp >= str_end ||
+          !mrb_re_utf8_interior_p(str, sp, str_end)) {
+        int slot = match_only ? 0 : pool_alloc(&s);
+        if (!match_only) memset(CAP(&s, slot), -1, sizeof(int) * ncap);
+        s.gen++;
+        s.cut = FALSE;
+        add_thread(&s, &curr, 0, slot, sp);
+        if (s.matched && curr.count == 0) break;
       }
-      int slot = match_only ? 0 : pool_alloc(&s);
-      if (!match_only) memset(CAP(&s, slot), -1, sizeof(int) * ncap);
-      s.gen++;
-      s.cut = FALSE;
-      add_thread(&s, &curr, 0, slot, sp);
-      if (s.matched && curr.count == 0) break;
     }
 
     if (sp >= str_end) break;

--- a/mrbgems/mruby-regexp/src/re_exec.c
+++ b/mrbgems/mruby-regexp/src/re_exec.c
@@ -326,11 +326,13 @@ pike_vm(mrb_state *mrb, const mrb_regexp_pattern *pat,
           if (sp > str_end) break;
         }
       }
-      /* Don't seed a new match attempt at a UTF-8 continuation byte --
-         a multi-byte char's interior is not a valid char boundary, and
-         starting a thread there mis-decodes the char (e.g. a class-
-         match on a stray 0x82 instead of the leader's full codepoint). */
-      if (!s.binary && curr.count == 0 && sp < str_end && mrb_re_utf8_continuation_p(sp)) {
+      /* Don't seed a new match attempt inside a character. Its interior is
+         not a char boundary, and starting a thread there mis-decodes the
+         char (e.g. a class match on a stray 0x82 instead of the leader's
+         full codepoint). A byte that no lead byte reaches belongs to no
+         character and is a boundary of its own. */
+      if (!s.binary && curr.count == 0 && sp < str_end &&
+          mrb_re_utf8_interior_p(str, sp, str_end)) {
         continue;
       }
       int slot = match_only ? 0 : pool_alloc(&s);
@@ -674,7 +676,7 @@ backtrack_exec(mrb_state *mrb, const mrb_regexp_pattern *pat,
       while (sp < str_end && !FIRST_BYTE_OK(pat, (uint8_t)*sp)) sp++;
       if (sp > str_end) break;
     }
-    if (!binary && sp < str_end && mrb_re_utf8_continuation_p(sp)) {
+    if (!binary && sp < str_end && mrb_re_utf8_interior_p(str, sp, str_end)) {
       continue;
     }
     memset(caps, -1, sizeof(int) * ncap);
@@ -697,7 +699,7 @@ backtrack_exec(mrb_state *mrb, const mrb_regexp_pattern *pat,
 static int
 literal_exec(const mrb_regexp_pattern *pat,
              const char *str, mrb_int len, mrb_int start,
-             int *captures, int captures_size)
+             int *captures, int captures_size, mrb_bool binary)
 {
   const char *sp = str + start;
   const char *str_end = str + len;
@@ -706,6 +708,10 @@ literal_exec(const mrb_regexp_pattern *pat,
   while (sp + plen <= str_end) {
     const char *found = (const char*)memchr(sp, pat->prefix[0], str_end - sp);
     if (!found || found + plen > str_end) return 0;
+    if (!binary && mrb_re_utf8_interior_p(str, found, str_end)) {
+      sp = found + 1;  /* not a char boundary, same rule as the other engines */
+      continue;
+    }
     if (plen == 1 || memcmp(found + 1, pat->prefix + 1, plen - 1) == 0) {
       /* match found */
       if (captures && captures_size >= 2) {
@@ -726,7 +732,7 @@ mrb_re_exec(mrb_state *mrb, const mrb_regexp_pattern *pat,
         int *captures, int captures_size, mrb_bool binary)
 {
   if (pat->is_literal) {
-    return literal_exec(pat, str, len, start, captures, captures_size);
+    return literal_exec(pat, str, len, start, captures, captures_size, binary);
   }
   if (pat->has_backref || pat->needs_backtrack) {
     return backtrack_exec(mrb, pat, str, len, start, captures, captures_size, binary);

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -692,6 +692,22 @@ assert("Regexp - a byte that belongs to no character is a match position") do
   assert_equal 3, ("あ" + b).match(Regexp.new(b)).pre_match.bytesize
 end
 
+assert("Regexp - an attempt in flight opens no match position inside a character") do
+  # "ĵ" is C4 B5 and "µ" is C2 B5, so the two share their trailing byte. That
+  # byte is the interior of "ĵ" and no match may start there, but the test
+  # for it only ran while nothing was in flight. The branch of `.?` that
+  # consumes the character parks a thread past it, and the attempt seeded at
+  # the shared byte then matched it on its own, cutting "ĵ" in half.
+  assert_nil "ĵ".match(/.?[µ]/)
+  assert_nil "ĵ".gsub(/.?[µ]/, "!").match(/!/)
+  assert_nil ("あ" + "ĵ").match(/.?[µ]/)
+  # A character the class does hold is still found through the same branch.
+  assert_equal 4, ("ĵ" + "µ").match(/.?[µ]/)[0].bytesize
+  assert_equal 5, ("あ" + "µ").match(/.?[µ]/)[0].bytesize
+  # And so is the byte itself where no lead byte reaches it.
+  assert_equal 2, ("x" + "\xb5").match(/.?[µ]/)[0].bytesize
+end
+
 assert("Regexp - multibyte (UTF-8) match extraction") do
   # Capture offsets are recorded in bytes; substring extraction must honor
   # them as byte ranges so multibyte matches are not corrupted.

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -670,6 +670,28 @@ assert("Regexp - quantifier on an invalid multibyte literal") do
   assert_equal 2, "Ā".match(/./)[0].bytesize
 end
 
+assert("Regexp - a byte that belongs to no character is a match position") do
+  # A byte in 0x80-0xBF is the interior of a character only while a lead byte
+  # in front of it reaches that far. One that stands on its own is a boundary
+  # like any other, and the engines used to disagree about it: the literal
+  # fast path matched there, the NFA never started a match there.
+  b = "\x81"
+  assert_equal 0, (b + b).match(Regexp.new(b + b)).begin(0)
+  assert_equal 2, (b + b).match(Regexp.new(b + "+"))[0].bytesize
+  assert_equal 2, (b + b).match(Regexp.new(b + "*"))[0].bytesize
+  assert_equal 1, (b + b).match(Regexp.new(b + "?"))[0].bytesize
+  assert_equal 1, ("x" + b + b).match(Regexp.new(b + "+")).begin(0)
+  # Inside a character there is still no match position.
+  assert_nil "あ".match(Regexp.new("\x81"))
+  assert_nil "あ".match(Regexp.new("\x82"))
+  assert_nil "\u{1D54F}".match(Regexp.new("\x95"))
+  # Next to one there is.
+  assert_equal 0, (b + "あ").match(Regexp.new(b)).begin(0)
+  # Through pre_match, since #begin counts characters where the build has
+  # them and bytes where it does not.
+  assert_equal 3, ("あ" + b).match(Regexp.new(b)).pre_match.bytesize
+end
+
 assert("Regexp - multibyte (UTF-8) match extraction") do
   # Capture offsets are recorded in bytes; substring extraction must honor
   # them as byte ranges so multibyte matches are not corrupted.


### PR DESCRIPTION
A match may not start inside a character, so `pike_vm()` (`re_exec.c:333`) and
`backtrack_exec()` (`re_exec.c:677`) refuse to seed an attempt at a byte in
0x80-0xBF. The test looks at the byte alone, and that is not the same
question: a byte no lead byte reaches is inside nothing. `literal_exec()`,
the fast path for a pure literal pattern, carries no such test at all, so the
three engines answer differently for the same pattern.

```ruby
b = "\x81"
Regexp.new(b + b)     =~ (b + b)  # 0,   literal fast path
Regexp.new(b + "{2}") =~ (b + b)  # 0,   literal fast path
Regexp.new(b + "+")   =~ (b + b)  # nil, pike VM
Regexp.new(b + "*")   =~ (b + b)  # 2,   pike VM, an empty match past both bytes
```

Which engine runs is an implementation detail of the pattern: `{2}` copies the
atom and keeps the pattern literal, `+` emits an `RE_SPLIT` and does not. The
first two lines are what the same subject read as binary gives, so the pike VM
is the one out of step.

Nothing raises in any of these, and no pattern whose first byte is ASCII or a
lead byte is affected, since neither can fall inside a character.

## Fix

Ask whether the byte is the interior of a character that starts earlier: walk
back to the nearest byte that is not a continuation byte and see whether the
length `mrb_re_utf8_charlen()` reports for it reaches this far. At most three
bytes are looked at, and only for a byte in 0x80-0xBF that the search has
stopped on.

`literal_exec()` takes the same test, so all three engines answer alike. It
needs the `binary` flag for that, which `mrb_re_exec()` already holds and
passes to the other two.

The fast path therefore changes in both directions: it declines a byte it used
to match, since `Regexp.new("\x81")` no longer finds the second byte of `"あ"`,
which is the rule the other two engines already followed.

A subject read as binary is unaffected: the whole test is skipped there, as
before.

## Tests

`mrbgems/mruby-regexp/test/regexp.rb`, a new
`Regexp - a byte that belongs to no character is a match position` block
before `Regexp - multibyte (UTF-8) match extraction`: the literal, `+`, `*`
and `?` forms over a stray byte, a stray byte after an ASCII one, the three
interior positions of a two and a four byte character, and a stray byte on
either side of a character. The last assertion goes through `pre_match`
`bytesize`, since `MatchData#begin` counts characters in a build that has them
and bytes in one that does not.

Verified on `x86_64-linux`:

- A consistency sweep of 6048 cases over bytes that never form a character
  together (`a`, `\x81`, `\xFF`), 168 patterns against 36 subjects, each run
  once as UTF-8 and once as binary. Every position in such a subject is a
  boundary, so the two readings have to agree: 539 disagreed before this
  change and none do after.
- `rake test`: 1976 total, 1958 OK, 0 KO, 0 crash, and bintest 105 OK.
- An `MRB_INT32` build with clang and `-Wall -Wextra`: 2045 total, 2035 OK,
  0 KO, 0 crash, and no new warning from any `mruby-regexp` file (`regexp.c`
  already emits four `-Wunused-parameter`).

## A start position inside a character, while an attempt runs

The test in `pike_vm()` carried one more term, `curr.count == 0`, which the
first commit kept: it skipped the whole loop iteration, so it could only run
while nothing was in flight, or a thread waiting at this position would have
been dropped with it. Any branch that keeps a thread alive past the character
therefore reopens the position.

`"ĵ"` is C4 B5 and `"µ"` is C2 B5, so the two share their trailing byte. The
branch of `.?` that consumes `"ĵ"` parks a thread past it, and the attempt seeded
at the shared byte then matches that byte on its own, cutting the character in
half.

```ruby
# "ĵ" is C4 B5, "µ" is C2 B5
"ĵ".match(/.?[µ]/)            # a match of the lone B5, CRuby: nil
"ĵ".gsub(/.?[µ]/, "!").bytes  # [196, 33], CRuby: [196, 181]
```

This one is older than the rest of the branch and reproduces on `master`.
`backtrack_exec()` never carried the term, and `/.?[µ](?=)/`, which the
backtracking engine runs, answers `nil` there already.

The second half of the guard is the fix: test the seeding alone instead of the
iteration. The `curr.count` term goes away, threads seeded earlier still step
at this position, and a start position inside a character stays closed however
many attempts are running.

Tests: a new `Regexp - an attempt in flight opens no match position inside a
character` block after the one above. The match and the `gsub` over the shared
byte, the same subject behind a three byte character, the two cases where the class
does hold the character that follows, and the shared byte where no lead byte
reaches it. Every case was read off CRuby 4.0.6 first, and the five that are
valid UTF-8 on both sides agree with it. `rake test` on `x86_64-linux`: 1989
total, 1970 OK, 0 KO, 0 crash, and bintest 105 OK. Reverting the C change
fails the block on its first three assertions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UTF-8 regular expression matching to avoid starting matches inside valid multibyte characters.
  * Corrected handling of standalone UTF-8 continuation bytes as independently matchable data.
  * Fixed literal and quantified matching positions and byte-based preceding-match sizing.

* **Tests**
  * Added regression coverage for standalone continuation bytes and multibyte-character boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

