### PR TITLE
mruby-regexp: let mrbtest exercise `Symbol#[]` with a regexp

### DIFF
--- a/mrbgems/mruby-regexp/mrbgem.rake
+++ b/mrbgems/mruby-regexp/mrbgem.rake
@@ -19,4 +19,11 @@ MRuby::Gem::Specification.new('mruby-regexp') do |spec|
   if build.gems.any? {|g| g.name == 'mruby-enumerator'}
     spec.add_dependency 'mruby-enumerator', :core => 'mruby-enumerator'
   end
+
+  # Same deal for `Symbol#[]` and `#slice`, which live in mruby-symbol-ext and
+  # delegate to the String methods: the regexp form is this gem's, so mrbtest
+  # can only exercise it when that gem is part of the state.
+  if build.gems.any? {|g| g.name == 'mruby-symbol-ext'}
+    spec.add_dependency 'mruby-symbol-ext', :core => 'mruby-symbol-ext'
+  end
 end


### PR DESCRIPTION
`mrbgems/mruby-regexp/test/symbol_regexp.rb` asserts the regexp form of `Symbol#[]`,
guarded like this:

```ruby
assert("Symbol#[] with regexp") do
  skip unless :hello.respond_to?(:slice)
```

The guard is always false under `rake test`, so the assertion never runs.

mrbtest runs each gem's tests in a state of its own: `mrbgems/mruby-test/mrbgem.rake`
opens an `mrb_open_core()` state per gem and initialises it with `tsort_dependencies([g.name])`,
that gem's declared dependency closure and nothing else. `mruby-regexp` declares
`mruby-string-ext` (and `mruby-enumerator` when the build already has it), while
`Symbol#[]` and `Symbol#slice` come from `mruby-symbol-ext`
(`mrbgems/mruby-symbol-ext/mrblib/symbol.rb:72`, aliased as `[]` on line 76). So the run
reports:

```
Skip: Symbol#[] with regexp (mrbgems: mruby-regexp)
```

and the `sym[re]` path that the gem README lists among the supported Symbol methods has no
coverage in CI. The other assertions in the file do run: `Symbol#match`, `#match?` and `#=~`
are defined by this gem itself, so they are present in that state.

## Nothing is broken

The feature works in a build that has both gems, which is every `default.gembox` build,
since `stdlib.gembox` pulls in `mruby-regexp` and `mruby-symbol-ext`:

```console
$ ./build/host/bin/mruby -e 'p :hello[/l+/], :hello.slice(/(?<x>l+)/, :x), :hello[/z/]'
"ll"
"ll"
nil
```

The test is correct as written, and it is skipped for a structural reason rather than a
defect.

## The change

`mrbgems/mruby-regexp/mrbgem.rake` already has the pattern for this, added for
`mruby-enumerator`: depend on a gem only when the build has it anyway, so that mrbtest
sees it without dragging it into builds that do not want it.

```ruby
  if build.gems.any? {|g| g.name == 'mruby-symbol-ext'}
    spec.add_dependency 'mruby-symbol-ext', :core => 'mruby-symbol-ext'
  end
```

The `skip` guard stays: it is what keeps the test honest in a build that leaves
`mruby-symbol-ext` out.

## Verification

`rake test` on this branch: the assertion runs and passes, and the skip count drops from
19 to 18 with no failures (Total 1987, OK 1969, KO 0).

One wrinkle when reproducing it: the generated per-gem test wrapper does not depend on the
gem's `mrbgem.rake`, so an incremental build keeps reporting the old result until the gem's
test files are touched or the build directory is cleaned.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded regexp-related test coverage for symbol slicing features when the optional symbol extension is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->