### PR TITLE
mruby-regexp: write the disabled flags in Regexp#to_s

### DIFF
--- a/mrbgems/mruby-regexp/README.md
+++ b/mrbgems/mruby-regexp/README.md
@@ -131,6 +131,11 @@ pattern analysis.
   only.
 - **Step limit on backtracking**: Patterns that require the
   backtracking engine are subject to a step limit.
+- **No inline extended mode**: `(?x)` and `(?x:...)` raise a
+  `RegexpError`, because extended mode is applied to the whole pattern
+  before it is parsed. A `-x` is accepted and ignored, so inside a
+  pattern that is itself extended it does not bring back the
+  whitespace that pass removed.
 
 ## Configuration
 

--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -593,7 +593,9 @@ compute_fixed_len(re_compiler *c, uint32_t start, uint32_t end)
    (':' or ')'). `base` is the option set in effect on entry; the resulting
    set is returned. Ruby's inline letters are i (IGNORECASE), m (DOTALL),
    x (EXTENDED). Extended mode is applied by a whole-pattern preprocessing
-   pass, so it cannot be scoped inline and is rejected here. */
+   pass that runs before the parser, so it cannot be scoped inline:
+   enabling it is rejected here, and see the 'x' branch below for why
+   disabling it is not. */
 static uint32_t
 parse_inline_flags(re_compiler *c, uint32_t base)
 {
@@ -605,8 +607,20 @@ parse_inline_flags(re_compiler *c, uint32_t base)
     if (oc == 'i') bit = RE_FLAG_IGNORECASE;
     else if (oc == 'm') bit = RE_FLAG_DOTALL;
     else if (oc == 'x') {
-      compile_error(c, "inline extended mode (?x) is not supported");
-      return base;  /* unreached: compile_error longjmps */
+      if (!negate) {
+        compile_error(c, "inline extended mode (?x) is not supported");
+        return base;  /* unreached: compile_error longjmps */
+      }
+      /* A '-x' is accepted and dropped. Regexp#to_s names every flag that
+         is off, so its result carries one whenever the pattern is not
+         extended, and rejecting it would make interpolation and
+         Regexp.new(re.to_s) raise for such a Regexp. Dropping it is exact
+         there, since the flag is already off. Inside a pattern that is
+         itself extended it is not: the preprocessing pass has removed the
+         whitespace by now and the scope cannot get it back. */
+      seen = TRUE;
+      next_char(c);
+      continue;
     }
     else if (oc == '-' && !negate) { negate = TRUE; next_char(c); continue; }
     else break;

--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -510,19 +510,52 @@ regexp_casefold_p(mrb_state *mrb, mrb_value self)
   return mrb_bool_value((get_iflags(mrb, self) & RE_FLAG_IGNORECASE) != 0);
 }
 
+/* The flag letters of the displayed forms, in the order Ruby writes them.
+   Regexp#to_s and Regexp#inspect both walk this table, so the two cannot
+   drift apart. RE_FLAG_DOTALL is the other half of Ruby's `m` and is
+   always set together with RE_FLAG_MULTILINE, so testing one of the pair
+   is enough. */
+static const struct {
+  uint32_t bit;
+  char letter;
+} re_flag_letters[] = {
+  { RE_FLAG_MULTILINE,  'm' },
+  { RE_FLAG_IGNORECASE, 'i' },
+  { RE_FLAG_EXTENDED,   'x' },
+};
+
+#define RE_FLAG_LETTER_COUNT (sizeof(re_flag_letters) / sizeof(re_flag_letters[0]))
+
 /*
- * Regexp#to_s - CRuby-compatible (?flags:source) format
+ * Regexp#to_s - (?on-off:source) format
+ *
+ * The flags that are off are named after a '-', and that run is left out
+ * only when none of them are. Spelling them out is what keeps the result
+ * meaningful once it is interpolated into another pattern: written as
+ * "(?i:a)", the embedded source in /#{/a/i}b/m would pick up the
+ * enclosing pattern's flags instead of carrying only its own.
  */
 static mrb_value
 regexp_to_s(mrb_state *mrb, mrb_value self)
 {
   mrb_value src = mrb_iv_get(mrb, self, mrb_intern_lit(mrb, "@source"));
   uint32_t flags = get_iflags(mrb, self);
+  char off[RE_FLAG_LETTER_COUNT];
+  mrb_int noff = 0;
 
   mrb_value result = mrb_str_new_lit(mrb, "(?");
-  if (flags & RE_FLAG_IGNORECASE) mrb_str_cat_lit(mrb, result, "i");
-  if (flags & RE_FLAG_MULTILINE) mrb_str_cat_lit(mrb, result, "m");
-  if (flags & RE_FLAG_EXTENDED) mrb_str_cat_lit(mrb, result, "x");
+  for (size_t i = 0; i < RE_FLAG_LETTER_COUNT; i++) {
+    if (flags & re_flag_letters[i].bit) {
+      mrb_str_cat(mrb, result, &re_flag_letters[i].letter, 1);
+    }
+    else {
+      off[noff++] = re_flag_letters[i].letter;
+    }
+  }
+  if (noff > 0) {
+    mrb_str_cat_lit(mrb, result, "-");
+    mrb_str_cat(mrb, result, off, noff);
+  }
   mrb_str_cat_lit(mrb, result, ":");
   mrb_str_cat_str(mrb, result, src);
   mrb_str_cat_lit(mrb, result, ")");
@@ -538,9 +571,11 @@ regexp_inspect(mrb_state *mrb, mrb_value self)
   mrb_value result = mrb_str_new_lit(mrb, "/");
   mrb_str_cat_str(mrb, result, src);
   mrb_str_cat_lit(mrb, result, "/");
-  if (flags & RE_FLAG_IGNORECASE) mrb_str_cat_lit(mrb, result, "i");
-  if (flags & RE_FLAG_MULTILINE) mrb_str_cat_lit(mrb, result, "m");
-  if (flags & RE_FLAG_EXTENDED) mrb_str_cat_lit(mrb, result, "x");
+  for (size_t i = 0; i < RE_FLAG_LETTER_COUNT; i++) {
+    if (flags & re_flag_letters[i].bit) {
+      mrb_str_cat(mrb, result, &re_flag_letters[i].letter, 1);
+    }
+  }
   return result;
 }
 

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -479,8 +479,21 @@ assert("Regexp - inline options (?i) / (?i:...)") do
   assert_equal 0, (/(?m:a.b)/ =~ "a\nb")
   assert_nil (/a.b/ =~ "a\nb")
 
-  # x (extended) cannot be scoped inline with the current architecture.
+  # x (extended) cannot be scoped inline with the current architecture, so
+  # turning it on is rejected.
   assert_raise(RegexpError) { Regexp.new("(?x)a b") }
+  assert_raise(RegexpError) { Regexp.new("(?x:a b)") }
+
+  # Turning it off is accepted, because Regexp#to_s writes a '-x' for every
+  # pattern that is not extended and that form has to recompile.
+  assert_equal 0, (/(?-x:a b)/ =~ "a b")
+  assert_equal 0, (/(?i-mx:a)b/ =~ "Ab")
+  assert_true Regexp.new("(?-mix:a b)").match?("a b")
+
+  # The '-x' is dropped rather than honoured, so in a pattern that is
+  # itself extended the whitespace stays stripped. CRuby matches "a b"
+  # here.
+  assert_true Regexp.new("(?-x:a b)", Regexp::EXTENDED).match?("ab")
 end
 
 assert("Regexp - comment groups (?#...)") do
@@ -742,13 +755,32 @@ end
 assert("Regexp#inspect") do
   re = Regexp.new("abc", Regexp::IGNORECASE)
   assert_equal "/abc/i", re.inspect
+  # several flags are written in the m, i, x order, whatever order they
+  # were given in
+  assert_equal "/abc/mi", Regexp.new("abc", Regexp::IGNORECASE | Regexp::MULTILINE).inspect
+  assert_equal "/abc/mix", Regexp.new("abc", Regexp::IGNORECASE | Regexp::MULTILINE | Regexp::EXTENDED).inspect
 end
 
 assert("Regexp#to_s") do
-  assert_equal "(?:abc)", Regexp.new("abc").to_s
-  assert_equal "(?i:abc)", Regexp.new("abc", Regexp::IGNORECASE).to_s
-  assert_equal "(?m:abc)", Regexp.new("abc", Regexp::MULTILINE).to_s
-  assert_equal "(?im:abc)", Regexp.new("abc", Regexp::IGNORECASE | Regexp::MULTILINE).to_s
+  assert_equal "(?-mix:abc)", Regexp.new("abc").to_s
+  assert_equal "(?i-mx:abc)", Regexp.new("abc", Regexp::IGNORECASE).to_s
+  assert_equal "(?m-ix:abc)", Regexp.new("abc", Regexp::MULTILINE).to_s
+  assert_equal "(?mi-x:abc)", Regexp.new("abc", Regexp::IGNORECASE | Regexp::MULTILINE).to_s
+  # the '-' run is dropped only when no flag is off
+  assert_equal "(?mix:abc)", Regexp.new("abc", Regexp::IGNORECASE | Regexp::MULTILINE | Regexp::EXTENDED).to_s
+
+  # the form recompiles, and the flags it names do not leak either way
+  assert_true Regexp.new(Regexp.new("abc", Regexp::IGNORECASE).to_s).match?("ABC")
+  assert_false Regexp.new(Regexp.new("abc").to_s + "d", Regexp::IGNORECASE).match?("ABCd")
+end
+
+assert("Regexp#to_s - interpolation") do
+  inner = Regexp.new("abc", Regexp::IGNORECASE)
+  # the inner Regexp keeps its own flags where the outer has none
+  assert_true(/#{inner}d/.match?("ABCd"))
+  assert_false(/#{inner}d/.match?("ABCD"))
+  # and does not pick up the outer ones
+  assert_false(/#{Regexp.new("abc")}d/i.match?("ABCd"))
 end
 
 assert("Regexp#== and Regexp#eql?") do
@@ -853,7 +885,7 @@ assert("Regexp extended mode (x flag)") do
   assert_equal "/abc/x", Regexp.new("abc", Regexp::EXTENDED).inspect
 
   # to_s shows x flag
-  assert_equal "(?x:abc)", Regexp.new("abc", Regexp::EXTENDED).to_s
+  assert_equal "(?x-mi:abc)", Regexp.new("abc", Regexp::EXTENDED).to_s
 
   # errors quote the pattern as written, not the stripped text
   assert_raise_with_message(RegexpError, "unterminated character class: /a # c\n[/") do


### PR DESCRIPTION
`Regexp#to_s` writes only the flags that are on (`regexp.c:523-525`), so the
`(?...)` form it produces says nothing about the ones that are off. CRuby names
those after a `-`, and that is what keeps the form meaningful once it is
interpolated into another pattern: without it, the enclosing pattern's flags
reach the embedded source. `Regexp#inspect` (`regexp.c:541-543`) repeats the
same run of tests and writes the letters in the `i`, `m`, `x` order, where Ruby
writes `m`, `i`, `x`.

```ruby
/a/.to_s       # CRuby: "(?-mix:a)", mruby: "(?:a)"
/a/i.to_s      # CRuby: "(?i-mx:a)", mruby: "(?i:a)"
/a/im.to_s     # CRuby: "(?mi-x:a)", mruby: "(?im:a)"
/a/im.inspect  # CRuby: "/a/mi",     mruby: "/a/im"
```

Nothing raises. The missing part turns into a different pattern only once the
result is used, which is where it is hardest to attribute:

```ruby
/#{/a/}b/i.match?("Ab")   # CRuby: false, mruby: true
/#{/a/}b/i.match?("aB")   # CRuby: true,  mruby: true
```

Interpolation goes through `to_s`: the compiler concatenates the parts of an
interpolated literal with `OP_STRCAT` and hands the result to `Regexp.compile`,
so `/#{/a/}b/i` compiles the source `(?:a)b` under `Regexp::IGNORECASE` and the
`a` is matched case-insensitively. `Regexp.new(re.to_s)` loses the flags the
same way.

## Fix

Emit the flags that are off after a `-`, dropping that run only when none of
them are, and take the letters of both forms from one shared table so the two
orders cannot drift apart again.

The new form has to recompile, and `parse_inline_flags()` rejected it. Every
`to_s` of a pattern that is not extended now carries a `-x`, while the `x`
branch (`re_compile.c:607-610`) raised `inline extended mode (?x) is not
supported` before it consulted `negate`, so it rejected an `x` in the disabled
run exactly like an enabled one. With the `to_s` change alone, every
interpolation of a Regexp would start raising `RegexpError`.

So a disabled `x` is accepted and dropped. That is exact whenever the enclosing
pattern is not extended, since the flag is already off there, which is the case
for every string `to_s` produces for such a pattern. Inside a pattern that is
itself extended it is not exact: `preprocess_pattern()` strips the whitespace
before the parser runs, so a scoped `-x` cannot bring it back.

```ruby
Regexp.new("(?-x:a b)", Regexp::EXTENDED).match?("ab")   # CRuby: false, mruby: true
Regexp.new("(?-x:a b)", Regexp::EXTENDED).match?("a b")  # CRuby: true,  mruby: false
```

An enabled `x` keeps raising, as it must: extended mode is applied to the whole
pattern before it is parsed and cannot be scoped inline at all. Both limits are
now in the gem's Limitations section, which said nothing about inline extended
mode before.

This does not repair the round trip for an extended Regexp, which was already
broken: `/a/x.to_s` was `"(?x:a)"` and is now `"(?x-mi:a)"`, and neither
recompiles.

## Tests

`mrbgems/mruby-regexp/test/regexp.rb`.

`Regexp#to_s` gains the disabled run in all four existing assertions, plus the
all-flags case where the `-` run is dropped, a round trip through
`Regexp.new`, and a case pinning that the flags do not leak in either
direction. `Regexp#inspect` gains two multi-flag cases, which are what the
order change is visible in. A new `Regexp#to_s - interpolation` block covers
the embedded Regexp keeping its own flags and picking up none of the outer
ones.

`Regexp - inline options (?i) / (?i:...)` gains the disabled `x` in both the
scoped and the toggle position, an enabled `x` in the scoped form next to the
toggle form already asserted there, and the inexact case inside an extended
pattern. `Regexp extended mode (x flag)` has its `to_s` expectation updated.

Verified on `x86_64-linux`:

- A differential sweep of 736 cases against CRuby 4.0.6: four pattern sources
  over the eight flag combinations, each checked for `to_s`, `inspect`, six
  subjects, and a round trip through `Regexp.new(re.to_s)`; every pair of
  inner and outer flag combinations for an interpolated Regexp; and 24
  hand-written inline flag runs, on and off, scoped and toggled, over the same
  eight combinations. 366 cases disagreed before this change and 268 after,
  with no case disagreeing that did not disagree before.
- All 268 remaining are outside what this changes: 260 involve inline extended
  mode, which is the limitation above, and 8 are `(?-:a b)`, an empty disabled
  run that mruby rejects as `undefined (?...) sequence` and CRuby accepts.
  That last one is an unrelated pre-existing gap and is left as is: `to_s`
  always names at least one flag, so it never produces that form.
- `rake test`: 1988 total, 1969 OK, 0 KO, 0 crash, and bintest 105 OK.
- An `MRB_INT32` build with clang and `-Wall -Wextra`: 1890 total, 1879 OK,
  0 KO, 0 crash, bintest 105 OK, and no new warning from any `mruby-regexp`
  file (`regexp.c` already emits four `-Wunused-parameter`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Regular expressions now accept inline disabling of extended mode (`?-x`).
  * Regular expression string and inspection output consistently displays enabled and disabled flags in normalized order.
  * Extended-mode flags are preserved in serialized regular expressions.

* **Bug Fixes**
  * Improved handling and reporting of inline regular-expression options.
  * Added clearer behavior for unsupported inline extended-mode constructs.

* **Documentation**
  * Documented limitations affecting inline extended-mode syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->