### PR TITLE
mruby-regexp: fix wrong comments on the String#split override

### DIFF
--- a/mrbgems/mruby-bin-mruby/bintest/mruby.rb
+++ b/mrbgems/mruby-bin-mruby/bintest/mruby.rb
@@ -194,8 +194,8 @@ assert('String#split still works when mruby-regexp is loaded') do
   # The regexp-aware override in mruby-regexp/mrblib/string_regexp.rb used to
   # replace the C-defined String#split, leaving its `return super if ...`
   # fast paths with no method to delegate to (NoMethodError).  Now the
-  # override delegates via `__split`, an alias of the original C method
-  # installed in mrb_mruby_regexp_gem_init before mrblib runs.
+  # override delegates via `__split`, an alias of the original C method made
+  # at the top of that class body before the override replaces it.
   assert_mruby(%Q(["a", "b", "c"]\n), "", true,
                ["-e", 'p "a,b,c".split(",")'])
   assert_mruby(%Q(["abc", "abc", "abc"]\n), "", true,

--- a/mrbgems/mruby-regexp/mrblib/string_regexp.rb
+++ b/mrbgems/mruby-regexp/mrblib/string_regexp.rb
@@ -193,8 +193,8 @@ class String
   end
 
   # Regexp-aware split.  Falls back to the C-defined split (aliased as
-  # `__split` in mrb_mruby_regexp_gem_init before this override loads) for
-  # nil or string patterns, and handles regexp patterns in Ruby.
+  # `__split` above) for nil or string patterns, and handles regexp patterns
+  # in Ruby.
   def split(pattern = nil, *args)
     if args.length > 1
       raise ArgumentError, "wrong number of arguments (given #{args.length + 1}, expected 0..2)"
@@ -202,7 +202,7 @@ class String
 
     limit_given = args.length > 0
     limit = limit_given ? args[0] : 0
-    # `__to_int` is `mrb_ensure_integer_type()`, which asks the object nothing.
+    # `Integer.__ensure` is `mrb_ensure_int_type()`, which asks the object nothing.
     # mruby has no implicit conversion protocol in core, so `Array.new(obj)`,
     # `ary[obj]` and `"s" * obj` all reject an object that only defines
     # `to_int`; dispatching it here would leave this the one place in the tree


### PR DESCRIPTION
Three comments around the `String#split` override describe mechanisms that are not
there. Comments only; no behavior change.

### `__split` is a Ruby alias, not a C one

`mrbgems/mruby-regexp/mrblib/string_regexp.rb` says:

```ruby
  # Regexp-aware split.  Falls back to the C-defined split (aliased as
  # `__split` in mrb_mruby_regexp_gem_init before this override loads) for
  # nil or string patterns, and handles regexp patterns in Ruby.
```

`__split` is not installed anywhere in C. `mrb_mruby_regexp_gem_init()` defines
`Regexp` and `MatchData` and their methods only, and never touches `String`;
nothing under `mrbgems/mruby-regexp/src/` mentions `__split`. The alias is made
in Ruby, at the top of the class body in the same file:

```ruby
  alias __split split
```

The fix points the parenthetical there:

```ruby
  # Regexp-aware split.  Falls back to the C-defined split (aliased as
  # `__split` above) for nil or string patterns, and handles regexp patterns
  # in Ruby.
```

That is the wording the file already uses for its three other captured methods.
`String#[]` reads "Falls back to the C-defined `[]` (aliased as `__aref`
above)", and `String#[]=` and `String#slice!` say the same for `__aset` and
`__slice_bang`. Deleting the clause instead would leave `split` the only one of
the four saying nothing about where its fallback comes from.

### The bintest repeats it

`mrbgems/mruby-bin-mruby/bintest/mruby.rb` makes the same claim about the same
helper, so it is corrected in the same change.

### `__to_int` no longer exists

Inside the override, the limit conversion is explained as:

```ruby
    # `__to_int` is `mrb_ensure_integer_type()`, which asks the object nothing.
```

Two things are wrong with the one line. `__to_int` was bound to
`mrb_ensure_int_type()`, not `mrb_ensure_integer_type()`; the two differ on a
BigInt, which the first narrows and the second returns unchanged. And `__to_int`
is gone: it was removed by the change closing #7014, which replaced the call with
`Integer.__ensure(limit)`. The same comment block already names `__ensure` five
lines on, so the paragraph contradicted itself. It now reads:

```ruby
    # `Integer.__ensure` is `mrb_ensure_int_type()`, which asks the object nothing.
```

### Testing

The change touches comments only, so there is nothing to reproduce and no
behavior to compare against CRuby. `ruby -c` passes on both edited files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified internal comments describing how `String#split` delegates to its aliased implementation.
  * Documented the integer conversion helper used by `String#split`.
  * Updated regression test commentary for improved accuracy.

* **Bug Fixes**
  * No runtime behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->