### PR TITLE
mruby-regexp: make an escaped multibyte literal one atom

### DIFF
--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -388,7 +388,12 @@ read_class_atom(re_compiler *c)
 {
   if (peek(c) == '\\') {
     next_char(c);
-    return (uint32_t)parse_escape(c);
+    /* A backslash before a multibyte character has no escape meaning, so let
+       the decode below read the whole codepoint: [\Ā] is [Ā]. parse_escape()
+       returns one byte, which left the continuation byte as a class atom of
+       its own. A trailing backslash (peek < 0) still reaches parse_escape(),
+       which reports it. */
+    if (peek(c) < 0xC0) return (uint32_t)parse_escape(c);
   }
   uint8_t b = (uint8_t)*c->p;
   if (b < 0xC0) {
@@ -641,6 +646,25 @@ parse_inline_flags(re_compiler *c, uint32_t base)
   }
   if (!seen) compile_error(c, "undefined (?...) sequence");
   return (base | on) & ~off;
+}
+
+/* Emit every byte of the character whose lead byte `ch` was just consumed, so
+   the whole character is one atom. Leaving the continuation bytes to the parse
+   loop made each of them an atom of its own, and a quantifier binds to the last
+   atom emitted: /Ā+/ compiled as \xC4(\x80)+ and matched one Ā in "ĀĀ". An
+   invalid lead byte has a charlen of 1 and still emits alone. Every atom that
+   consumes a character has to emit all of its bytes before returning, since
+   what compile_quantified() repeats is the bytes that atom emitted. */
+static void
+emit_char_bytes(re_compiler *c, int ch)
+{
+  int len = mrb_re_utf8_charlen(c->p - 1, c->src_end);
+  emit(c, RE_CHAR, (uint8_t)ch, 0);
+  for (int i = 1; i < len; i++) {
+    int b = next_char(c);
+    if (b < 0) break;
+    emit(c, RE_CHAR, (uint8_t)b, 0);
+  }
 }
 
 /* Compile a single atom (character, class, group, etc.) */
@@ -916,6 +940,16 @@ compile_atom(re_compiler *c)
       emit(c, RE_BACKREF, (uint8_t)group, (c->flags & RE_FLAG_IGNORECASE) ? 1 : 0);
       c->has_backref = TRUE;
     }
+    else if (ch >= 0xC0) {
+      /* A backslash before a multibyte character has no escape meaning: \Ā is
+         Ā. parse_escape() returns one byte, which left the continuation bytes
+         to the parse loop as atoms of their own, so emit the whole character
+         here as the unescaped spelling does. The dispatch has to happen before
+         parse_escape() reads the letter, since \xNN and octal \NNN name a byte
+         rather than a character. */
+      next_char(c);
+      emit_char_bytes(c, ch);
+    }
     else {
       ch = parse_escape(c);
       if (c->flags & RE_FLAG_IGNORECASE) {
@@ -978,18 +1012,7 @@ compile_atom(re_compiler *c)
       }
     }
     if (ch >= 128) {
-      /* Emit every byte of a multibyte character here, so the whole character
-         is one atom. Leaving the continuation bytes to the parse loop made
-         each of them an atom of its own, and a quantifier binds to the last
-         atom emitted: /Ā+/ compiled as \xC4(\x80)+ and matched one Ā in "ĀĀ".
-         An invalid lead byte has a charlen of 1 and still emits alone. */
-      int len = mrb_re_utf8_charlen(c->p - 1, c->src_end);
-      emit(c, RE_CHAR, (uint8_t)ch, 0);
-      for (int i = 1; i < len; i++) {
-        int b = next_char(c);
-        if (b < 0) break;
-        emit(c, RE_CHAR, (uint8_t)b, 0);
-      }
+      emit_char_bytes(c, ch);
       break;
     }
     emit(c, RE_CHAR, (uint8_t)ch, 0);

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -660,6 +660,36 @@ assert("Regexp - quantifier on a multibyte literal") do
   assert_equal 0, "z".match(/Ā?/)[0].bytesize
 end
 
+assert("Regexp - quantifier on an escaped multibyte literal") do
+  # A backslash before a character with no escape meaning is just that
+  # character, so \Ā has to be one atom exactly like Ā. The escape path used
+  # to emit the lead byte alone and leave the continuation byte to the parse
+  # loop, so the quantifier bound to that byte instead.
+  # The /.../ spelling cannot show this, because the lexer drops the backslash
+  # before the gem sees the pattern: /\Ā/.source is the two bytes of Ā alone.
+  # A pattern built at runtime arrives through Regexp.new with the backslash
+  # still in it.
+  assert_equal 4, Regexp.new("\\Ā+").match("ĀĀ")[0].bytesize
+  assert_equal 6, Regexp.new("\\ĀĀĀ").match("ĀĀĀ")[0].bytesize
+  assert_true Regexp.new("\\Ā{2}").match?("ĀĀ")
+  assert_false Regexp.new("\\Ā{2}").match?("Ā")
+  assert_equal 6, Regexp.new("\\日+").match("日日")[0].bytesize
+  assert_equal 8, Regexp.new("\\𝕏+").match("𝕏𝕏")[0].bytesize
+  assert_equal 5, Regexp.new("a\\Ā+").match("aĀĀ")[0].bytesize
+  assert_equal 2, Regexp.new("\\Ā+?").match("ĀĀ")[0].bytesize
+  # Inside [...] the same escape has to read as one codepoint, or the class
+  # holds the lead byte and the continuation byte as two wrong members.
+  assert_true Regexp.new("[\\Ā]").match?("Ā")
+  assert_false Regexp.new("[\\Ā]").match?("Ä")
+  assert_true Regexp.new("[\\Ā-\\ā]").match?("ā")
+  assert_false Regexp.new("[\\Ā-\\ā]").match?("Ă")
+  # A raw byte escape names a byte rather than a character, so it keeps taking
+  # the parse_escape path and the quantifier binds to that one byte. CRuby
+  # joins byte escapes that spell a valid UTF-8 sequence into one character
+  # and matches four bytes here; closing that gap is a separate change.
+  assert_equal 2, Regexp.new("\\xC4\\x80+").match("ĀĀ")[0].bytesize
+end
+
 assert("Regexp - quantifier on an invalid multibyte literal") do
   # A byte above 127 is one atom only while it starts a whole character. The
   # sequences below never complete one, so each byte stands alone and the


### PR DESCRIPTION
`bcacba1e1` made a multibyte literal a single atom, so `/Ā+/` repeats the whole
character instead of its last byte. A backslash in front of the same character
takes a different branch of `compile_atom()`, which never got the same
treatment: the escape path emits only the lead byte and lets the parse loop pick
up the continuation bytes as atoms of their own. The quantifier then binds to
the last of those. The same backslash inside `[...]` goes through
`read_class_atom()`, which splits the character the same way, so the class ends
up holding two wrong codepoints.

```ruby
Regexp.new("\\Ā+").match("ĀĀ")[0].bytesize  # CRuby: 4,     mruby: 2
Regexp.new("\\Ā{2}").match?("ĀĀ")           # CRuby: true,  mruby: false
Regexp.new("[\\Ā]").match?("Ā")             # CRuby: true,  mruby: false
Regexp.new("[\\Ā]").match?("Ä")             # CRuby: false, mruby: true
Regexp.new("\\Ā").match?("Ā")               # CRuby: true,  mruby: true
```

In CRuby `/\Ā/` and `/Ā/` are the same pattern: a backslash before a character
with no special meaning is just that character. Here they differ as soon as a
quantifier follows or a character class encloses them, which is exactly the bug
`bcacba1e1` fixed for the unescaped spelling.

The `/.../` literal spelling hides this, because the lexer strips the backslash
before the gem ever sees the pattern: `/\Ā/.source` is the two bytes of `Ā`
alone, so both `/\Ā+/` and `/[\Ā]/` behave. `Regexp.new` with a string, which is
how a pattern built at runtime arrives, does not.

## Cause

`compile_atom()` has two paths that can see the bytes of a multibyte character.
The default path asks `mrb_re_utf8_charlen()` how long the character is and
emits every byte of it before returning, so the atom the quantifier sees is the
whole character. The escape path calls `parse_escape()`, whose `default` arm
returns the single byte it read, and emits that one byte as `RE_CHAR`.
`compile_quantified()` measures the atom as what was emitted between `start` and
`code_len`, which is now one byte, and the remaining `0x80` is left for the next
turn of `compile_seq()` to emit as its own atom. So `\Ā+` compiles as `\xC4`
followed by `(\x80)+`, which matches `C4 80` and stops.

`read_class_atom()` carries the same split. Its own multibyte path decodes a
whole codepoint through `mrb_re_utf8_decode()`, but the escape path hands the
backslash to `parse_escape()` and gets one byte back. The continuation byte is
then read as a class atom of its own, so `[\Ā]` enumerates `U+00C4` and `U+0080`
where `[Ā]` enumerates `U+0100`.

## Fix

A backslash before a byte at or above `0xC0` has no escape meaning in this
parser, so route it away from `parse_escape()` in both places, before that
function consumes the letter.

- `compile_atom()` emits the whole character through `emit_char_bytes()`,
  extracted from the default branch that already did this for the unescaped
  spelling, so there is one description of what a character atom is instead of
  two.
- `read_class_atom()` falls through to the `mrb_re_utf8_decode()` path that
  `[Ā]` already takes.

The invariant the two share, and the one `compile_quantified()` depends on, is
that an atom that consumes a character has to emit all of that character's bytes
before it returns.

`parse_escape()` itself is unchanged. Returning an `int` byte is right for every
escape it is meant to serve; the multibyte case just should not reach it.

## Byte escapes are left as they are

`\xNN` and octal `\NNN` name a byte rather than a character, and the distinction
lives in the pattern text rather than in the value, which is why the dispatch has
to happen before `parse_escape()` reads the letter. They keep taking the old
path, so `Regexp.new("\\xC4\\x80+")` still repeats `\x80` alone. CRuby joins byte
escapes that spell a valid UTF-8 sequence into one character and matches four
bytes there. That is a pre-existing difference and closing it belongs to a
separate change; the test added here pins the current behaviour so the next
person sees which way it goes.

## Tests

`mrbgems/mruby-regexp/test/regexp.rb` gets a group next to the one `bcacba1e1`
added for the unescaped form, so the two spellings sit together. It covers the
quantifier and `{n}` forms, three and four byte characters, a quantified escape
after another atom, the non-greedy form, `[\Ā]` from both sides, an escaped range
inside a class, and one `\xNN` row for the byte escape above. Every assertion
except that last one matches CRuby 4.0.6.

`rake test`: 1991 OK, 0 KO.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed regular expressions so escaped UTF-8 characters are matched as complete characters.
  * Corrected quantifier behavior for escaped multibyte characters, including optional, bounded, greedy, and nongreedy patterns.
  * Preserved byte-oriented behavior for raw byte escapes.

* **Tests**
  * Added coverage for escaped two-, three-, and four-byte characters, character classes, ranges, and quantifier combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->