### PR TITLE
mruby-regexp: reject overlong and out-of-range UTF-8 sequences

### DIFF
--- a/mrbgems/mruby-regexp/src/re_utf8.c
+++ b/mrbgems/mruby-regexp/src/re_utf8.c
@@ -8,23 +8,35 @@
 
 /* Return byte length of UTF-8 character at s.
    Returns 1 for invalid sequences (treat as single byte): a byte that starts
-   no sequence, a sequence cut short by end, and one whose continuation bytes
-   are not 10xxxxxx. */
+   no sequence, a sequence cut short by end, one whose continuation bytes are
+   not 10xxxxxx, and one that spells a codepoint a shorter sequence already
+   holds, a surrogate, or a value above U+10FFFF. The last three are decided
+   by the lead byte together with the first continuation byte. */
 int
 mrb_re_utf8_charlen(const char *s, const char *end)
 {
   uint8_t c = (uint8_t)*s;
+  uint8_t lo = 0x80, hi = 0xbf;  /* range the first continuation byte must fall in */
   int len;
 
   if (c < 0x80) return 1;
-  else if (c < 0xc0) return 1;  /* invalid continuation */
+  else if (c < 0xc2) return 1;  /* continuation byte, or an overlong two-byte lead */
   else if (c < 0xe0) len = 2;
-  else if (c < 0xf0) len = 3;
-  else if (c < 0xf8) len = 4;
+  else if (c < 0xf0) {
+    len = 3;
+    if (c == 0xe0) lo = 0xa0;       /* below U+0800 */
+    else if (c == 0xed) hi = 0x9f;  /* U+D800 to U+DFFF */
+  }
+  else if (c < 0xf5) {
+    len = 4;
+    if (c == 0xf0) lo = 0x90;       /* below U+10000 */
+    else if (c == 0xf4) hi = 0x8f;  /* above U+10FFFF */
+  }
   else return 1;  /* invalid */
 
   if (s + len > end) return 1;  /* truncated */
-  for (int i = 1; i < len; i++) {
+  if ((uint8_t)s[1] < lo || (uint8_t)s[1] > hi) return 1;
+  for (int i = 2; i < len; i++) {
     if (((uint8_t)s[i] & 0xc0) != 0x80) return 1;  /* invalid continuation */
   }
   return len;

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -2168,6 +2168,37 @@ assert("Regexp - truncated UTF-8 at subject end") do
   assert_equal 0, ("ab\xf0" =~ /[^cd]+$/)
 end
 
+assert("Regexp - overlong UTF-8 is not the character it spells") do
+  # C0 BC is the two-byte overlong spelling of "<" and E0 84 80 the three-byte
+  # spelling of "Ā". A class compares the decoded codepoint and a literal
+  # compares bytes, so a decoder that hands out a codepoint for these makes the
+  # two disagree about the same subject: assert them together.
+  assert_nil ("\xC0\xBC" =~ /[<]/)
+  assert_nil ("\xC0\xBC" =~ /</)
+  assert_equal 0, ("\xC0\xBC" =~ /[^<]/)
+  assert_equal "\xC0\xBC", "\xC0\xBC".gsub(/[<]/, "&lt;")
+  assert_nil ("\xE0\x80\xBC" =~ /[<]/)
+  assert_false Regexp.new("[Ā]").match?("\xE0\x84\x80")
+  assert_false (/Ā/.match?("\xE0\x84\x80"))
+  # the pattern side decodes through the same helper
+  assert_false Regexp.new("[\xC0\xBC]").match?("<")
+  # surrogates and codepoints above U+10FFFF encode no character either, so
+  # each byte stands on its own
+  assert_equal 2, "\xC0\xBC".scan(/./).size
+  assert_equal 3, "\xED\xA0\x80".scan(/./).size
+  assert_equal 4, "\xF0\x80\x80\xBC".scan(/./).size
+  assert_equal 4, "\xF5\x80\x80\x80".scan(/./).size
+  # the shortest spelling on each side of those bounds is still one character
+  assert_equal 1, "\u{0080}".scan(/./).size    # C2 80
+  assert_equal 1, "\u{0800}".scan(/./).size    # E0 A0 80
+  assert_equal 1, "\u{D7FF}".scan(/./).size    # ED 9F BF
+  assert_equal 1, "\u{E000}".scan(/./).size    # EE 80 80
+  assert_equal 1, "\u{10000}".scan(/./).size   # F0 90 80 80
+  assert_equal 1, "\u{10FFFF}".scan(/./).size  # F4 8F BF BF
+  assert_equal 0, ("\u{0800}" =~ Regexp.new("[\u{0800}]"))
+  assert_equal 0, ("\u{10FFFF}" =~ Regexp.new("[\u{10FFFF}]"))
+end
+
 assert("Regexp - pattern too large for its jump targets is refused") do
   # Jump targets live in a 16-bit field, so a program that outgrows the field
   # used to wrap them and jump to an unrelated instruction: the pattern then


### PR DESCRIPTION
`mrb_re_utf8_charlen()` checks that a sequence has the right number of continuation bytes and that they are shaped `10xxxxxx`, but not that the value they encode needed that many bytes. `mrb_re_utf8_decode()` then assembles the codepoint from whatever it was handed. An overlong encoding therefore decodes to the character it only pretends to be, which leaves the two paths through the engine disagreeing about the same subject: a character class matches it, the identical literal does not.

```ruby
"\xC0\xBC" =~ /[<]/            # before: 0,        after: nil
"\xC0\xBC" =~ /</              # before: nil,      after: nil
"\xC0\xBC".gsub(/[<]/, "&lt;") # before: "&lt;",   after: "\xC0\xBC"
"\xE0\x80\xBC" =~ /[<]/        # before: 0,        after: nil

Regexp.new("[Ā]").match?("\xE0\x84\x80")  # before: true,  after: false
/Ā/.match?("\xE0\x84\x80")                # before: false, after: false
```

`C0 BC` is the two-byte overlong spelling of `<`, and `E0 84 80` the three-byte spelling of `Ā`. CRuby raises `ArgumentError` (invalid byte sequence in UTF-8) on every one of these, since it refuses to match against a string that is not valid in its encoding at all.

Escaping code is where this shows. `s.gsub(/[<>&]/, ...)` and `s.gsub(/</, ...)` are interchangeable in every reading of the source, and here they are not: the class form rewrites the overlong bytes, the literal form leaves them. `[^<]` sides with the class, reading the same bytes as the `<` it excludes and passing them through, so it parts from the literal too. Whichever direction a filter needs, it cannot get it consistently from the same subject.

## Cause

`mrb_re_utf8_charlen()` derives a length from the lead byte and validates the continuation bytes. It has no minimum-value rule, so `C0` and `C1`, which can only ever start an overlong two-byte sequence, are accepted as leads, and `E0 8x`, `F0 8x` and the surrogate range `ED Ax` are accepted too. `mrb_re_utf8_decode()` then shifts the payload bits together and returns `0x3C` for `C0 BC`.

The two paths part company after that:

- A class compares the decoded codepoint, `class_match()`, so the overlong form hits the same bitmap bit as the real character.
- A literal compares bytes, `RE_CHAR`, so it never matches a spelling other than the one in the pattern.

Neither is wrong on its own terms. What is wrong is that the decoder promises a codepoint and delivers one for input that encodes none.

`read_class_atom()` decodes the pattern side through the same helper, so an overlong sequence written into a pattern currently joins the class as the character it imitates: `Regexp.new("[\xC0\xBC]").match?("<")` is `true`.

## Fix

Reject the overlong, surrogate and out-of-range forms in `mrb_re_utf8_charlen()`, returning 1 the way it already does for a truncated sequence and a bad continuation byte. Three rules cover it:

- a lead of `C0` or `C1` is never valid;
- a three-byte sequence needs the codepoint at or above `0x800`, which rules out `E0 80` through `E0 9F`, and outside the surrogate range `D800` to `DFFF`, which rules out `ED A0` through `ED BF`;
- a four-byte sequence needs the codepoint at or above `0x10000` and at most `0x10FFFF`, which rules out `F0 80` through `F0 8F` and anything above `F4 8F`.

All three are decidable from the lead byte together with the first continuation byte, so the check costs one range comparison ahead of the existing loop and needs no second pass. The function's own comment already described the shape of the contract; this extends it from well-formedness to validity, and the invalid bytes fall back to the byte-at-a-time treatment every other malformed input gets. Everything else decodes through this one function, `mrb_re_utf8_decode()` for the length and both engines through `mrb_re_charlen()` and `mrb_re_decode_char()`, so the pattern side is covered by the same change, with the pattern byte then landing in the class as its raw value.

Deliberately not proposed: raising on an invalid subject the way CRuby does. That would mean validating the whole string on every match, which is not what a byte-oriented mruby `String` can afford, and the fallback already gives a defined answer.

## Tests

`mrbgems/mruby-regexp/test/regexp.rb` gains `Regexp - overlong UTF-8 is not the character it spells`, next to the two blocks that already pin what malformed UTF-8 does here. The class and the literal are asserted in the same block, since the point is that they now agree. The block also pins the surrogate and above-`U+10FFFF` forms as byte-at-a-time, and the shortest valid spelling on each side of every new bound (`C2 80`, `E0 A0 80`, `ED 9F BF`, `EE 80 80`, `F0 90 80 80`, `F4 8F BF BF`) as one character, so the tightened ranges cannot drift.

`rake test` passes: 2009 assertions, 0 failures.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UTF-8 validation in regular expressions.
  * Invalid sequences, including overlong encodings, surrogate values, and out-of-range code points, are now handled correctly.
  * Valid boundary code points continue to match as single characters.

* **Tests**
  * Added regression coverage for invalid and valid UTF-8 sequences across literals, character classes, and wildcard matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->