### PR TITLE
mruby-regexp: reject a lookbehind over a multibyte character class

### DIFF
--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -289,6 +289,16 @@ class_add_shorthand(re_charclass *cc, int ch)
   }
 }
 
+/* TRUE when every character the class can match is ASCII, so it always
+   consumes exactly one byte. Non-ASCII codepoint ranges and the utf8_any
+   catch-all (set by \D, \W, \S, \H and [[:^alpha:]]) both admit multibyte
+   characters, whose width is not known until match time. */
+static mrb_bool
+class_is_ascii_only(const re_charclass *cc)
+{
+  return cc->num_ranges == 0 && !cc->utf8_any;
+}
+
 /* Set ASCII bits for a POSIX class name (e.g. "alpha") into a 128-bit map.
    Returns FALSE for an unknown name. Semantics are ASCII, like this gem's
    \w/\d shorthands; non-ASCII codepoints are not classified. */
@@ -560,11 +570,23 @@ compute_fixed_len(re_compiler *c, uint32_t start, uint32_t end)
     re_inst inst = c->code[pc];
     switch (inst.op) {
     case RE_CHAR:
-    case RE_CLASS:
-    case RE_NCLASS:
+      /* a multibyte literal is a run of one-byte RE_CHAR instructions,
+         so each one is exactly one byte by construction */
       len += 1;
       pc++;
       break;
+    case RE_CLASS:
+      /* a class that admits a multibyte character has no single byte
+         length: one holding both ASCII and non-ASCII members consumes one
+         byte here and two there. Rewinding by a wrong count lands in the
+         middle of a character, so refuse to measure it. */
+      if (!class_is_ascii_only(&c->classes[inst.a])) return -1;
+      len += 1;
+      pc++;
+      break;
+    case RE_NCLASS:
+      /* the complement of an ASCII bitmap always admits non-ASCII */
+      return -1;
     case RE_ANY:
     case RE_ANY_NL:
       /* . matches one character which can be 1-4 bytes in UTF-8.
@@ -1417,8 +1439,7 @@ first_set_walk(const re_inst *code, uint32_t code_len,
     case RE_CLASS: {
       const re_charclass *cc = &classes[code[pc].a];
       for (int i = 0; i < 16; i++) bm[i] |= cc->bitmap[i];
-      if (cc->utf8_any) return FALSE;  /* non-ASCII possible */
-      if (cc->num_ranges > 0) return FALSE;  /* non-ASCII codepoints possible */
+      if (!class_is_ascii_only(cc)) return FALSE;  /* non-ASCII possible */
       return TRUE;
     }
     case RE_NCLASS: {

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -2004,6 +2004,37 @@ assert("Regexp - negative lookbehind at string start") do
   assert_equal "a", md[0]
 end
 
+assert("Regexp - lookbehind rejects a class that can match a multibyte character") do
+  # A class holding non-ASCII members consumes one byte here and two there,
+  # so no single rewind width is right. Refusing the pattern beats rewinding
+  # into the middle of a character, where a positive lookbehind reports no
+  # match and a negative one reports a match.
+  assert_raise(RegexpError) { Regexp.new("(?<=[Ā])x") }
+  assert_raise(RegexpError) { Regexp.new("(?<![Ā])b") }
+  assert_raise(RegexpError) { Regexp.new("(?<=[Ā-ă])x") }
+  assert_raise(RegexpError) { Regexp.new("(?<=[aĀ])x") }
+  assert_raise(RegexpError) { Regexp.new("(?<=[Ā]{2})x") }
+  # a negated class always admits non-ASCII, whatever its members are
+  assert_raise(RegexpError) { Regexp.new("(?<=[^あ])x") }
+  assert_raise(RegexpError) { Regexp.new("(?<![^a])b") }
+  # the uppercase shorthands carry the same catch-all
+  assert_raise(RegexpError) { Regexp.new("(?<=a\\W)x") }
+  assert_raise(RegexpError) { Regexp.new("(?<=\\W\\W)x") }
+  assert_raise(RegexpError) { Regexp.new("(?<=\\D)x") }
+  assert_raise(RegexpError) { Regexp.new("(?<=\\S)x") }
+end
+
+assert("Regexp - lookbehind measures an ASCII-only class") do
+  assert_equal "x", "ax".match(/(?<=[a-z])x/)[0]
+  assert_nil "1x".match(/(?<=[a-z])x/)
+  assert_equal "x", "1x".match(/(?<=\d)x/)[0]
+  assert_equal "x", " x".match(/(?<=\s)x/)[0]
+  # a multibyte literal compiles to a run of one-byte instructions, so it
+  # keeps its exact width and must keep measuring
+  assert_equal "x", "Āx".match(/(?<=Ā)x/)[0]
+  assert_nil "bx".match(/(?<=Ā)x/)
+end
+
 assert("$1-$9 global variables") do
   /(\w+)\s(\w+)/ =~ "hello world"
   assert_equal "hello", $1


### PR DESCRIPTION
`compute_fixed_len()` counts a character class as exactly one byte, but a class can hold
non-ASCII codepoints, so a lookbehind over one rewinds by the wrong number of bytes and
lands in the middle of a character. A positive lookbehind then never matches, and a
negative lookbehind matches where it must not.

```ruby
"Āx" =~ /(?<=[Ā])x/      # CRuby: 1,   mruby: nil
"Āb" =~ /(?<![Ā])b/      # CRuby: nil, mruby: 2
"Ăx" =~ /(?<=[Ā-ă])x/    # CRuby: 1,   mruby: nil
"Āx" =~ /(?<=[aĀ])x/     # CRuby: 1,   mruby: nil
"ĀĀx" =~ /(?<=[Ā]{2})x/  # CRuby: 2,   mruby: nil
```

The indices differ between the two anyway, because CRuby counts characters where this
build counts bytes, so read the rows as match against no match. The ASCII side is
unaffected: `"ax" =~ /(?<=[aĀ])x/` answers 1 in both.

A negated class goes wrong in the opposite direction, since the rewind lands on a
continuation byte that the complement happily accepts:

```ruby
"あx" =~ /(?<=[^あ])x/    # CRuby: nil, mruby: 3
"あb" =~ /(?<![^あ])b/    # CRuby: 1,   mruby: nil
```

Shorthand like `\W`, `\S` and `\D` reaches the same broken position, but a bare
`(?<=\W)` hides it: the rewind lands on a continuation byte, `mrb_re_utf8_decode()`
hands that raw byte back as its own codepoint, and `utf8_any` accepts anything at or
above 128, so the wrong position answers right by accident. Put one more element beside
the class and the accident stops:

```ruby
"aあx" =~ /(?<=a\W)x/     # CRuby: 2,   mruby: nil
"aあb" =~ /(?<!a\W)b/     # CRuby: nil, mruby: 4
"あĀx" =~ /(?<=\W\W)x/    # CRuby: 2,   mruby: nil
```

## Cause

`compute_fixed_len()` folds `RE_CHAR`, `RE_CLASS` and `RE_NCLASS` into one arm and adds
1 byte for each. That is right for `RE_CHAR`, which is a single byte by construction,
and wrong for a class: `re_charclass` carries a non-ASCII codepoint range list beside
its ASCII bitmap, `class_match()` reads it for any codepoint at or above 128, and the
executor advances by the decoded character width, not by one byte.

The result is stored in `re_inst.a` and used as a raw byte count by both lookbehind
opcodes, which subtract it from `sp` and re-enter `bt_match()` there. With the count
short by one byte per multibyte class member, that position is a continuation byte, the
sub-pattern fails, and the failure is silent.

## Fix

A corrected constant is not available. A class can match characters of different widths
in the same position, so `[aĀ]` is one byte or two and `\W` is one to four. This patch
measures only a class that is ASCII throughout, and returns -1 for the rest, which is
what the function already does for `RE_ANY` and every other shape it cannot measure. A
lookbehind that cannot be measured raises `RegexpError` instead of answering wrongly.

`RE_NCLASS` always returns -1: the complement of an ASCII bitmap admits non-ASCII
whatever its members are. `RE_CHAR` keeps its own arm, since a multibyte literal is a
run of one-byte `RE_CHAR` instructions and so `(?<=Ā)x` measures correctly today.

`class_is_ascii_only()` names the test; `first_set_walk()` already spelled out the same
condition inline and now shares the helper.

Rewinding by characters instead of bytes would make every class work rather than raise,
and would also let `(?<=.)` compile, which CRuby accepts and this gem rejects today. It
needs a backwards UTF-8 helper and changes what `re_inst.a` means for the lookbehind
opcodes, so it is left for a separate change.

## Tests

Two cases next to the existing lookbehind group in
`mrbgems/mruby-regexp/test/regexp.rb`: one pins the patterns that now raise, including
the negated class and the uppercase shorthands, the other pins what must keep working,
`[a-z]`, `\d`, `\s` and the multibyte literal. `rake test` is clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed regular expression lookbehind validation for character classes that may match multibyte characters.
  * Negated character classes and multibyte-capable shorthands now correctly raise `RegexpError` when used in unsupported fixed-length lookbehinds.
  * Improved matching optimization without changing valid ASCII-only lookbehind behavior.

* **Tests**
  * Added regression coverage for multibyte character classes, shorthands, ASCII-only classes, and multibyte literals in lookbehinds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->