### PR TITLE
mruby-regexp: test the F4 upper bound of the four-byte UTF-8 range

### DIFF
--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -2330,6 +2330,7 @@ assert("Regexp - overlong UTF-8 is not the character it spells") do
   assert_equal 2, "\xC0\xBC".scan(/./).size
   assert_equal 3, "\xED\xA0\x80".scan(/./).size
   assert_equal 4, "\xF0\x80\x80\xBC".scan(/./).size
+  assert_equal 4, "\xF4\x90\x80\x80".scan(/./).size
   assert_equal 4, "\xF5\x80\x80\x80".scan(/./).size
   # the shortest spelling on each side of those bounds is still one character
   assert_equal 1, "\u{0080}".scan(/./).size    # C2 80


### PR DESCRIPTION
Follow-up to #7068.

`mrb_re_utf8_charlen()` rejects a four-byte sequence that spells a codepoint past U+10FFFF by narrowing the first continuation byte to `0x80` through `0x8f` when the lead byte is `F4`. Nothing exercised that narrowing. The nearest existing case, `"\xF5\x80\x80\x80"`, carries a lead byte outside the four-byte range entirely, so it returns before any continuation byte is looked at.

Add `"\xF4\x90\x80\x80"`, the shortest spelling of U+110000. It takes the `F4` branch and scans as four separate bytes.

Test only, no behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected invalid UTF-8 handling so the sequence `F4 90 80 80` is processed as four separate bytes rather than a single character.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->