### PR TITLE
mruby-regexp: keep the pike VM's visited keys from wrapping

### DIFF
--- a/mrbgems/mruby-regexp/src/re_exec.c
+++ b/mrbgems/mruby-regexp/src/re_exec.c
@@ -131,6 +131,24 @@ pool_copy(pike_state *s, int src_slot)
 
 #define CAP(s, slot) (&(s)->cap_pool[(slot) * (s)->ncap])
 
+/* Hand this step's closure a fresh block of visited keys. A step reserves one
+   key per epsilon pass, so the counter climbs faster than the single step it
+   used to; on a long enough subject it would wrap, leaving marks from earlier
+   steps outranking every fresh key and the closure adding nothing. Clear the
+   marks and start the keys over when that comes into reach, which also keeps
+   a live key below RE_LOOP_STOP. */
+static void
+advance_gen(pike_state *s)
+{
+  if (s->key_max > UINT32_MAX - 2 * s->pass_span) {
+    memset(s->visited, 0, sizeof(uint32_t) * (s->pat->code_len + 1));
+    s->gen = 0;
+    s->key_max = s->pass_span - 1;
+  }
+  s->gen += s->pass_span;
+  s->key_max += s->pass_span;
+}
+
 /* TRUE once this step's closure has walked the loop head at pc, which means
    the body just ran without consuming: an empty iteration. */
 static mrb_bool
@@ -144,7 +162,8 @@ loop_head_seen(pike_state *s, uint32_t pc)
    target's branch walks under, or RE_LOOP_STOP when the body matched empty
    and the repetition therefore has to stop. An ordinary fork, or one closing
    a loop whose body always consumes (`a` is 0, see mark_empty_loops()), has
-   no empty iteration to account for and keeps the current key. */
+   no empty iteration to account for and keeps the current key. advance_gen()
+   holds every live key below the sentinel. */
 #define RE_LOOP_STOP UINT32_MAX
 
 static uint32_t
@@ -347,8 +366,8 @@ pike_vm(mrb_state *mrb, const mrb_regexp_pattern *pat,
   s.binary = binary;
   s.cut = FALSE;
   s.pass_span = RE_PASS_SPAN(pat->loop_depth);
-  s.gen = s.pass_span;
-  s.key_max = s.gen + s.pass_span - 1;
+  s.gen = 0;
+  s.key_max = s.pass_span - 1;
   if (match_only) {
     s.pool_capa = 1;
     s.pool_next = 0;
@@ -404,8 +423,7 @@ pike_vm(mrb_state *mrb, const mrb_regexp_pattern *pat,
           !mrb_re_utf8_interior_p(str, sp, str_end)) {
         int slot = match_only ? 0 : pool_alloc(&s);
         if (!match_only) memset(CAP(&s, slot), -1, sizeof(int) * ncap);
-        s.gen += s.pass_span;
-        s.key_max += s.pass_span;
+        advance_gen(&s);
         s.cut = FALSE;
         add_thread(&s, &curr, 0, slot, sp, s.gen);
         if (s.matched && curr.count == 0) break;
@@ -435,8 +453,7 @@ pike_vm(mrb_state *mrb, const mrb_regexp_pattern *pat,
       s.pool_next = curr.count;
     }
 
-    s.gen += s.pass_span;
-    s.key_max += s.pass_span;
+    advance_gen(&s);
     s.cut = FALSE;
     next.count = 0;
 


### PR DESCRIPTION
Follow-up to #7071, which landed before this could be folded in.

That change has a step reserve one visited key per epsilon pass rather than a
single key, so `s.gen` climbs by up to `2 * pass_span` per input byte where it
used to climb by up to 2. `gen` and `key_max` are `uint32_t`, so the counter
wraps near 430 MB of subject instead of near 2 GB.

Past a wrap, `visited[]` still holds the large keys earlier steps wrote.
`add_thread()` returns at `s->visited[pc] >= key` for every `pc`, the closure
adds nothing, and the match silently fails. A wrapped key can also land on
`UINT32_MAX`, which `re_loop_back()` returns as its `RE_LOOP_STOP` sentinel, so
an ordinary fork would read as a loop that has to stop.

Both advance sites move into `advance_gen()`, which clears the marks and starts
the keys over before the counter can reach either. `visited[]` only ever
describes the closure being built, so clearing it costs one `memset()` per wrap
and loses nothing; the guard also holds every live key below the sentinel.

## Verification

`rake test` passes.

The wrap itself needs a subject too large to test directly, so the restart path
was exercised by lowering the threshold to fire on every step. With that build,
`rake test` stays green and both differential sweeps against CRuby 4.0.6 (the
12870-row structured sweep and the 56000-row random sweep used in #7071)
produce output identical to the build without the guard. The threshold was then
restored and the sweeps re-run to confirm the shipped build is unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved regular expression processing stability by safely handling internal state rollover during extended matching operations.
  * Prevented potential matching errors after prolonged or repeated regular expression evaluations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->