### PR TITLE
mruby-regexp: read the \u escape

### DIFF
--- a/mrbgems/mruby-regexp/README.md
+++ b/mrbgems/mruby-regexp/README.md
@@ -26,6 +26,21 @@ simulation) with backtracking fallback.
 - `(?<=...)` positive lookbehind (fixed-length only)
 - `(?<!...)` negative lookbehind (fixed-length only)
 
+### Character Escapes
+
+- `\n`, `\t`, `\r`, `\f`, `\v`, `\a`, `\e` control characters
+- `\NNN` octal, one to three digits
+- `\xHH` hex, one or two digits
+- `\uXXXX` Unicode codepoint, exactly four hex digits
+- `\u{...}` Unicode codepoints, one to six hex digits each, several of
+  them separated by spaces: `/\u{61 62}/` is `ab`
+
+Outside a character class the list form is a sequence rather than one
+atom, so a quantifier after it repeats the last codepoint only:
+`/\u{61 62}+/` is `ab+`. Inside a class every codepoint is a member of
+its own, and the last one can still open a range: `/[\u{61 62}-z]/` is
+`a` plus `b-z`.
+
 ### Anchors
 
 - `^` beginning of line
@@ -148,6 +163,8 @@ pattern analysis.
   Maximum 255 bytes.
 - **No Unicode properties**: `\p{Alpha}`, `\p{L}`, etc. are not
   supported.
+- **No `\x{...}` hex escape**: the hex escape is `\xHH`, so it reaches
+  `0xff` at most. Write `\u{...}` for a codepoint above that.
 - **ASCII case folding by default**: The `i` flag handles ASCII letters
   only unless the build defines `MRB_REGEXP_UNICODE_CASE`, which adds the
   Unicode foldings that pair one codepoint with one other. Without the

--- a/mrbgems/mruby-regexp/include/re_internal.h
+++ b/mrbgems/mruby-regexp/include/re_internal.h
@@ -161,6 +161,7 @@ void mrb_re_free(mrb_state *mrb, mrb_regexp_pattern *pat);
 /* UTF-8 helpers */
 int mrb_re_utf8_charlen(const char *s, const char *end);
 uint32_t mrb_re_utf8_decode(const char *s, const char *end, int *len);
+int mrb_re_utf8_encode(uint32_t cp, char *buf);
 mrb_bool mrb_re_is_word_char(uint32_t c);
 
 /* The two foldings whose result is an ASCII letter. Every build carries them,

--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -380,6 +380,17 @@ posix_class_bits(uint8_t *bits, const char *name, size_t len)
 #undef BRANGE
 }
 
+/* Value of one hex digit, or -1 for anything else (including the -1 that
+   peek() returns at the end of the pattern). */
+static int
+hex_value(int ch)
+{
+  if (ch >= '0' && ch <= '9') return ch - '0';
+  if (ch >= 'a' && ch <= 'f') return ch - 'a' + 10;
+  if (ch >= 'A' && ch <= 'F') return ch - 'A' + 10;
+  return -1;
+}
+
 static int
 parse_escape(re_compiler *c)
 {
@@ -419,12 +430,8 @@ parse_escape(re_compiler *c)
     int val = 0;
     int n = 0;
     while (n < 2) {
-      int d = peek(c);
-      int v;
-      if (d >= '0' && d <= '9') v = d - '0';
-      else if (d >= 'a' && d <= 'f') v = d - 'a' + 10;
-      else if (d >= 'A' && d <= 'F') v = d - 'A' + 10;
-      else break;
+      int v = hex_value(peek(c));
+      if (v < 0) break;
       val = val * 16 + v;
       next_char(c);
       n++;
@@ -433,6 +440,16 @@ parse_escape(re_compiler *c)
   }
   default: return ch;  /* literal: \., \\, \/, \(, etc. */
   }
+}
+
+/* Add one codepoint to the class: the ASCII bitmap and the codepoint range
+   list each hold one side of 128, and class_match() picks the side to read
+   from the codepoint alone. */
+static void
+class_add_member(re_compiler *c, re_charclass *cc, uint32_t cp)
+{
+  if (cp < 128) class_set_bit(cc, (uint8_t)cp);
+  else class_add_codepoint(c, cc, cp);
 }
 
 /* Read one character class atom: either an ASCII byte (0-127), a
@@ -537,8 +554,7 @@ compile_charclass(re_compiler *c)
       }
     }
     else {
-      if (cp < 128) class_set_bit(cc, (uint8_t)cp);
-      else class_add_codepoint(c, cc, cp);
+      class_add_member(c, cc, cp);
     }
   }
   next_char(c);  /* skip ']' */
@@ -772,6 +788,24 @@ parse_inline_flags(re_compiler *c, uint32_t base)
   }
   if (!seen) compile_error(c, "undefined (?...) sequence");
   return (base | on) & ~off;
+}
+
+/* Emit one byte as an atom, for a character that is a single byte. Under /i an
+   ASCII letter becomes a class of its case counterparts instead, so any of them
+   matches. The multibyte spelling of the same job is emit_char_bytes() below. */
+static void
+emit_char(re_compiler *c, uint8_t ch)
+{
+  if ((c->flags & RE_FLAG_IGNORECASE) &&
+      ((ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z'))) {
+    uint16_t id = add_class(c);
+    class_set_bit(&c->classes[id], ch);
+    class_set_bit(&c->classes[id], (uint8_t)(ch ^ 0x20));  /* the other case */
+    class_add_fold_counterparts(c, id, ch);
+    emit(c, RE_CLASS, (uint8_t)id, 0);
+    return;
+  }
+  emit(c, RE_CHAR, ch, 0);
 }
 
 /* Emit every byte of the character whose lead byte `ch` was just consumed, so
@@ -1124,26 +1158,7 @@ compile_atom(re_compiler *c)
       if (!emit_char_folded(c, ch)) emit_char_bytes(c, ch);
     }
     else {
-      ch = parse_escape(c);
-      if (c->flags & RE_FLAG_IGNORECASE) {
-        if (ch >= 'A' && ch <= 'Z') {
-          uint16_t id = add_class(c);
-          class_set_bit(&c->classes[id], (uint8_t)ch);
-          class_set_bit(&c->classes[id], (uint8_t)(ch + 32));
-          class_add_fold_counterparts(c, id, (uint32_t)ch);
-          emit(c, RE_CLASS, (uint8_t)id, 0);
-          break;
-        }
-        else if (ch >= 'a' && ch <= 'z') {
-          uint16_t id = add_class(c);
-          class_set_bit(&c->classes[id], (uint8_t)ch);
-          class_set_bit(&c->classes[id], (uint8_t)(ch - 32));
-          class_add_fold_counterparts(c, id, (uint32_t)ch);
-          emit(c, RE_CLASS, (uint8_t)id, 0);
-          break;
-        }
-      }
-      emit(c, RE_CHAR, (uint8_t)ch, 0);
+      emit_char(c, (uint8_t)parse_escape(c));
     }
     break;
 
@@ -1170,29 +1185,11 @@ compile_atom(re_compiler *c)
       return;  /* not an atom */
     }
     next_char(c);
-    if ((c->flags & RE_FLAG_IGNORECASE) && ch < 128) {
-      if (ch >= 'A' && ch <= 'Z') {
-        uint16_t id = add_class(c);
-        class_set_bit(&c->classes[id], (uint8_t)ch);
-        class_set_bit(&c->classes[id], (uint8_t)(ch + 32));
-        class_add_fold_counterparts(c, id, (uint32_t)ch);
-        emit(c, RE_CLASS, (uint8_t)id, 0);
-        break;
-      }
-      else if (ch >= 'a' && ch <= 'z') {
-        uint16_t id = add_class(c);
-        class_set_bit(&c->classes[id], (uint8_t)ch);
-        class_set_bit(&c->classes[id], (uint8_t)(ch - 32));
-        class_add_fold_counterparts(c, id, (uint32_t)ch);
-        emit(c, RE_CLASS, (uint8_t)id, 0);
-        break;
-      }
-    }
     if (ch >= 128) {
       if (!emit_char_folded(c, ch)) emit_char_bytes(c, ch);
       break;
     }
-    emit(c, RE_CHAR, (uint8_t)ch, 0);
+    emit_char(c, (uint8_t)ch);
     break;
   }
 }

--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -32,6 +32,11 @@ typedef struct {
   mrb_bool has_backref;
   mrb_bool needs_backtrack;
   mrb_bool dont_capture;    /* pattern declares a named group: plain (...) does not capture */
+  uint32_t atom_start;      /* where the atom a quantifier binds to begins;
+                               compile_quantified sets it to the position
+                               before the atom, and a `\u{...}` list moves it
+                               forward so the quantifier repeats the last
+                               codepoint alone */
   char *stripped;           /* allocated buffer for pattern preprocessing */
 } re_compiler;
 
@@ -442,6 +447,91 @@ parse_escape(re_compiler *c)
   }
 }
 
+/* Reject what has no UTF-8 encoding. CRuby reports both a surrogate and a
+   value past the last plane as "invalid Unicode range", so neither ever
+   reaches mrb_re_utf8_encode(). */
+static void
+check_unicode_cp(re_compiler *c, uint32_t cp)
+{
+  if (cp > 0x10ffff || (cp >= 0xd800 && cp <= 0xdfff)) {
+    compile_error(c, "invalid Unicode range");
+  }
+}
+
+/* Separator between the codepoints of a `\u{...}` list. */
+static mrb_bool
+unicode_list_space(int ch)
+{
+  return ch == ' ' || ch == '\t' || ch == '\n' || ch == '\v' || ch == '\f' || ch == '\r';
+}
+
+/* Read the next codepoint of an open `\u{...}` list, or close it. Returns
+   FALSE once the `}` is consumed, leaving *more FALSE so the caller's loop
+   ends. */
+static mrb_bool
+unicode_escape_next(re_compiler *c, mrb_bool *more, uint32_t *out)
+{
+  if (!*more) return FALSE;
+  while (unicode_list_space(peek(c))) next_char(c);
+  if (peek(c) == '}') {
+    next_char(c);
+    *more = FALSE;
+    return FALSE;
+  }
+
+  uint32_t cp = 0;
+  int n = 0;
+  for (;;) {
+    int v = hex_value(peek(c));
+    if (v < 0) break;
+    next_char(c);
+    cp = cp * 16 + (uint32_t)v;
+    /* Six digits reach U+FFFFFF, past the last plane, so a seventh can only
+       be an overlong spelling. CRuby rejects `\u{0000061}` rather than
+       reading it as U+0061. */
+    if (++n > 6) compile_error(c, "invalid Unicode range");
+  }
+  /* Anything that is neither a hex digit nor the closing brace ends the
+     list: a separator CRuby does not take (`\u{61,62}`), or the end of the
+     pattern (`\u{61`). */
+  if (n == 0) compile_error(c, "invalid Unicode list");
+  check_unicode_cp(c, cp);
+  *out = cp;
+  return TRUE;
+}
+
+/* Read a `\u` escape and return its first codepoint; the backslash and the
+   `u` are already consumed. `\uXXXX` is exactly four hex digits and yields
+   one codepoint. `\u{...}` holds one or more, so *more is set and the rest
+   come from unicode_escape_next(). */
+static uint32_t
+unicode_escape_first(re_compiler *c, mrb_bool *more)
+{
+  *more = FALSE;
+  if (peek(c) == '{') {
+    next_char(c);
+    *more = TRUE;
+    uint32_t cp;
+    /* The list has to hold something: `\u{}` and `\u{ }` are errors, not an
+       escape that contributes nothing. */
+    if (!unicode_escape_next(c, more, &cp)) compile_error(c, "invalid Unicode list");
+    return cp;
+  }
+
+  /* Nothing at all after `\u` is reported apart from a bad digit, as CRuby
+     does: /\u/ is "too short escape sequence" while /\u6/ is not. */
+  if (peek(c) < 0) compile_error(c, "too short escape sequence");
+  uint32_t cp = 0;
+  for (int i = 0; i < 4; i++) {
+    int v = hex_value(peek(c));
+    if (v < 0) compile_error(c, "invalid Unicode escape");
+    next_char(c);
+    cp = cp * 16 + (uint32_t)v;
+  }
+  check_unicode_cp(c, cp);
+  return cp;
+}
+
 /* Add one codepoint to the class: the ASCII bitmap and the codepoint range
    list each hold one side of 128, and class_match() picks the side to read
    from the codepoint alone. */
@@ -456,10 +546,24 @@ class_add_member(re_compiler *c, re_charclass *cc, uint32_t cp)
    `\escape`, or a full multi-byte UTF-8 codepoint. Returns the
    codepoint and advances c->p. */
 static uint32_t
-read_class_atom(re_compiler *c)
+read_class_atom(re_compiler *c, re_charclass *cc)
 {
   if (peek(c) == '\\') {
     next_char(c);
+    if (peek(c) == 'u') {
+      next_char(c);
+      mrb_bool more;
+      uint32_t cp = unicode_escape_first(c, &more);
+      uint32_t nx;
+      /* Every codepoint of a `\u{...}` list is a member of its own. All but
+         the last join the class here; the last is returned, so it can open a
+         range as any other atom would: `[\u{61 62}-z]` is `a` plus `b-z`. */
+      while (unicode_escape_next(c, &more, &nx)) {
+        class_add_member(c, cc, cp);
+        cp = nx;
+      }
+      return cp;
+    }
     /* A backslash before a multibyte character has no escape meaning, so let
        the decode below read the whole codepoint: [\Ā] is [Ā]. parse_escape()
        returns one byte, which left the continuation byte as a class atom of
@@ -537,12 +641,12 @@ compile_charclass(re_compiler *c)
       }
     }
 
-    uint32_t cp = read_class_atom(c);
+    uint32_t cp = read_class_atom(c, cc);
 
     /* check for range a-z (or U+xxxx-U+yyyy) */
     if (peek(c) == '-' && c->p + 1 < c->src_end && c->p[1] != ']') {
       next_char(c);  /* skip '-' */
-      uint32_t hi = read_class_atom(c);
+      uint32_t hi = read_class_atom(c, cc);
       /* A range that straddles the ASCII boundary is split in two: the
          bitmap takes the half below 128 and the codepoint list the rest.
          Neither half can hold the other, and class_match() picks the side
@@ -827,26 +931,17 @@ emit_char_bytes(re_compiler *c, int ch)
   }
 }
 
-/* Emit a non-ASCII literal under /i as a class rather than a run of bytes, and
-   report whether it did. A counterpart need not have the same byte length
+/* Emit a non-ASCII codepoint under /i as a class rather than a run of bytes,
+   and report whether it did. A counterpart need not have the same byte length
    (U+212A folds to 'k'), which a byte-wise RE_CHAR run cannot express, while
    RE_CLASS decodes one codepoint and compares that whatever its width. A
    character with no counterpart, which is most of the non-ASCII range and
    every script without case in it, falls back to the bytes and costs /i
    nothing. A character this build cannot fold is refused rather than answered
-   without the folding it needs.
-
-   A byte that starts no whole character is not a character to fold. It decodes
-   as one byte and hands back its own value, which would read a lone 0xB5 as
-   U+00B5 and answer /i for a character the pattern does not hold, so it falls
-   back to the bytes like every other invalid sequence in the literal path. */
+   without the folding it needs. The caller has already established /i. */
 static mrb_bool
-emit_char_folded(re_compiler *c, int ch)
+emit_cp_folded(re_compiler *c, uint32_t cp)
 {
-  if (ch < 128 || !(c->flags & RE_FLAG_IGNORECASE)) return FALSE;
-  int len = 0;
-  uint32_t cp = mrb_re_utf8_decode(c->p - 1, c->src_end, &len);
-  if (len == 1) return FALSE;
   if (mrb_re_needs_case_data(cp, cp)) {
     compile_error(c, "/i needs MRB_REGEXP_UNICODE_CASE for this character");
   }
@@ -863,15 +958,55 @@ emit_char_folded(re_compiler *c, int ch)
   if (f != cp) { alt[n++] = f; alt[n++] = f - 32; }
 #endif
   if (n == 0) return FALSE;
-  c->p += len - 1;
   uint16_t id = add_class(c);
   class_add_codepoint(c, &c->classes[id], cp);
   for (int i = 0; i < n; i++) {
-    if (alt[i] < 128) class_set_bit(&c->classes[id], (uint8_t)alt[i]);
-    else class_add_codepoint(c, &c->classes[id], alt[i]);
+    class_add_member(c, &c->classes[id], alt[i]);
   }
   emit(c, RE_CLASS, (uint8_t)id, 0);
   return TRUE;
+}
+
+/* The same for a character the pattern spells out, whose bytes the caller is
+   partway through: the codepoint comes from the pattern, and the bytes it took
+   are consumed only once the class is emitted.
+
+   A byte that starts no whole character is not a character to fold. It decodes
+   as one byte and hands back its own value, which would read a lone 0xB5 as
+   U+00B5 and answer /i for a character the pattern does not hold, so it falls
+   back to the bytes like every other invalid sequence in the literal path. */
+static mrb_bool
+emit_char_folded(re_compiler *c, int ch)
+{
+  if (ch < 128 || !(c->flags & RE_FLAG_IGNORECASE)) return FALSE;
+  int len = 0;
+  uint32_t cp = mrb_re_utf8_decode(c->p - 1, c->src_end, &len);
+  if (len == 1) return FALSE;
+  if (!emit_cp_folded(c, cp)) return FALSE;
+  c->p += len - 1;
+  return TRUE;
+}
+
+/* Emit one codepoint as an atom: a run of RE_CHAR, one per UTF-8 byte. This is
+   emit_char_bytes() for a codepoint the pattern names rather than spells, so
+   the bytes come from the encoder instead of from the pattern. The run has to
+   be a single atom just the same, or a following quantifier binds to the last
+   byte alone. Naming a character does not change what /i does with it, so the
+   folded spelling is tried first, as it is for a character the pattern
+   spells. */
+static void
+emit_codepoint(re_compiler *c, uint32_t cp)
+{
+  if (cp < 128) {
+    emit_char(c, (uint8_t)cp);
+    return;
+  }
+  if ((c->flags & RE_FLAG_IGNORECASE) && emit_cp_folded(c, cp)) return;
+  char buf[4];
+  int len = mrb_re_utf8_encode(cp, buf);
+  for (int i = 0; i < len; i++) {
+    emit(c, RE_CHAR, (uint8_t)buf[i], 0);
+  }
 }
 
 /* Compile a single atom (character, class, group, etc.) */
@@ -1147,6 +1282,22 @@ compile_atom(re_compiler *c)
       emit(c, RE_BACKREF, (uint8_t)group, (c->flags & RE_FLAG_IGNORECASE) ? 1 : 0);
       c->has_backref = TRUE;
     }
+    else if (ch == 'u') {
+      next_char(c);  /* skip u */
+      mrb_bool more;
+      uint32_t cp = unicode_escape_first(c, &more);
+      uint32_t nx;
+      /* A `\u{...}` list is a sequence of atoms rather than one, so a
+         quantifier after it repeats the last codepoint only: /\u{61 62}+/
+         is `a` followed by `b+`. Moving atom_start past the codepoints
+         already emitted is what leaves the last one as the target. */
+      while (unicode_escape_next(c, &more, &nx)) {
+        emit_codepoint(c, cp);
+        c->atom_start = c->code_len;
+        cp = nx;
+      }
+      emit_codepoint(c, cp);
+    }
     else if (ch >= 0xC0) {
       /* A backslash before a multibyte character has no escape meaning: \Ā is
          Ā. parse_escape() returns one byte, which left the continuation bytes
@@ -1224,9 +1375,17 @@ emit_atom_copy(re_compiler *c, uint32_t start, uint32_t size)
 static void
 compile_quantified(re_compiler *c)
 {
-  uint32_t start = c->code_len;
+  uint32_t begin = c->code_len;
+  /* atom_start normally stays at `begin`; compile_atom moves it only for a
+     `\u{...}` list, whose leading codepoints are atoms of their own. Saving
+     and restoring it keeps a nested compile_quantified (inside a group) from
+     leaving its own atom behind for this one. */
+  uint32_t saved_atom_start = c->atom_start;
+  c->atom_start = begin;
   compile_atom(c);
-  if (c->code_len == start) return;  /* no atom emitted */
+  uint32_t start = c->atom_start;
+  c->atom_start = saved_atom_start;
+  if (c->code_len == begin) return;  /* no atom emitted */
 
   int ch = peek(c);
   if (ch == '*' || ch == '+' || ch == '?') {
@@ -1453,8 +1612,19 @@ preprocess_pattern(mrb_state *mrb, const char *src, mrb_int len,
   while (src < end) {
     char ch = *src;
     if (ch == '\\' && src + 1 < end) {
+      mrb_bool unicode = (src[1] == 'u');
       buf[o++] = *src++;
       buf[o++] = *src++;
+      /* A `\u{...}` list separates its codepoints with spaces, so the brace
+         group has to be copied whole: the free-spacing pass below would
+         otherwise join `\u{61 62}` into the single codepoint `\u{6162}`. */
+      if (unicode && src < end && *src == '{') {
+        while (src < end) {
+          char u = *src;
+          buf[o++] = *src++;
+          if (u == '}') break;
+        }
+      }
       continue;
     }
     if (in_class) {

--- a/mrbgems/mruby-regexp/src/re_utf8.c
+++ b/mrbgems/mruby-regexp/src/re_utf8.c
@@ -74,6 +74,34 @@ mrb_re_utf8_decode(const char *s, const char *end, int *len)
   }
 }
 
+/* Encode a codepoint as UTF-8 into buf and return the byte length, at most 4.
+   Callers reject a surrogate and anything above U+10FFFF before they get
+   here, so every input has an encoding. */
+int
+mrb_re_utf8_encode(uint32_t cp, char *buf)
+{
+  if (cp < 0x80) {
+    buf[0] = (char)cp;
+    return 1;
+  }
+  if (cp < 0x800) {
+    buf[0] = (char)(0xc0 | (cp >> 6));
+    buf[1] = (char)(0x80 | (cp & 0x3f));
+    return 2;
+  }
+  if (cp < 0x10000) {
+    buf[0] = (char)(0xe0 | (cp >> 12));
+    buf[1] = (char)(0x80 | ((cp >> 6) & 0x3f));
+    buf[2] = (char)(0x80 | (cp & 0x3f));
+    return 3;
+  }
+  buf[0] = (char)(0xf0 | (cp >> 18));
+  buf[1] = (char)(0x80 | ((cp >> 12) & 0x3f));
+  buf[2] = (char)(0x80 | ((cp >> 6) & 0x3f));
+  buf[3] = (char)(0x80 | (cp & 0x3f));
+  return 4;
+}
+
 /* Check if character is a "word" character (\w): [a-zA-Z0-9_] */
 mrb_bool
 mrb_re_is_word_char(uint32_t c)

--- a/mrbgems/mruby-regexp/test/ascii_case.rb
+++ b/mrbgems/mruby-regexp/test/ascii_case.rb
@@ -23,6 +23,14 @@ assert("Regexp - /i refuses what ASCII folding cannot answer") do
   # build has no data to tell it apart from one that would have folded.
   assert_raise(RegexpError) { Regexp.new("ß", Regexp::IGNORECASE) }
   assert_raise(RegexpError) { Regexp.new("ﬀ", Regexp::IGNORECASE) }
+  # A `\u` escape names a character rather than spelling it out, and naming one
+  # does not make it a character this build can fold. Both spellings of the
+  # escape reach the refusal, in the literal path and in the class path alike.
+  assert_raise(RegexpError) { Regexp.new("\\u{100}", Regexp::IGNORECASE) }
+  assert_raise(RegexpError) { Regexp.new("\\u0100", Regexp::IGNORECASE) }
+  assert_raise(RegexpError) { Regexp.new("[\\u{100}]", Regexp::IGNORECASE) }
+  assert_raise(RegexpError) { Regexp.new("[^\\u{100}]", Regexp::IGNORECASE) }
+  assert_raise(RegexpError) { Regexp.new("[\\u{100}-\\u{102}]", Regexp::IGNORECASE) }
   # The message names the option, so hitting this says what to do about it.
   begin
     Regexp.new("Ā", Regexp::IGNORECASE)
@@ -45,4 +53,10 @@ assert("Regexp - /i leaves alone what it can answer") do
   assert_true(/Ā/.match?("Ā"))
   assert_false(/Ā/.match?("ā"))
   assert_true(/[^Ā]/.match?("ā"))
+  # U+212A folds to ASCII 'k', which this build has without the table, so the
+  # `\u` spelling of it compiles and reaches both cases of the letter.
+  assert_true(/\u{212a}/i.match?("k"))
+  assert_true(/\u{212a}/i.match?("K"))
+  assert_true(/[\u{212a}]/i.match?("k"))
+  assert_false(/[^\u{212a}]/i.match?("K"))
 end

--- a/mrbgems/mruby-regexp/test/ascii_case.rb
+++ b/mrbgems/mruby-regexp/test/ascii_case.rb
@@ -23,19 +23,26 @@ assert("Regexp - /i refuses what ASCII folding cannot answer") do
   # build has no data to tell it apart from one that would have folded.
   assert_raise(RegexpError) { Regexp.new("ß", Regexp::IGNORECASE) }
   assert_raise(RegexpError) { Regexp.new("ﬀ", Regexp::IGNORECASE) }
+  # The message names the option, so hitting this says what to do about it.
+  refused = "/i needs MRB_REGEXP_UNICODE_CASE for this character"
+  assert_raise_with_message(RegexpError, "#{refused}: /Ā/") do
+    Regexp.new("Ā", Regexp::IGNORECASE)
+  end
   # A `\u` escape names a character rather than spelling it out, and naming one
   # does not make it a character this build can fold. Both spellings of the
   # escape reach the refusal, in the literal path and in the class path alike.
-  assert_raise(RegexpError) { Regexp.new("\\u{100}", Regexp::IGNORECASE) }
-  assert_raise(RegexpError) { Regexp.new("\\u0100", Regexp::IGNORECASE) }
-  assert_raise(RegexpError) { Regexp.new("[\\u{100}]", Regexp::IGNORECASE) }
-  assert_raise(RegexpError) { Regexp.new("[^\\u{100}]", Regexp::IGNORECASE) }
-  assert_raise(RegexpError) { Regexp.new("[\\u{100}-\\u{102}]", Regexp::IGNORECASE) }
-  # The message names the option, so hitting this says what to do about it.
-  begin
-    Regexp.new("Ā", Regexp::IGNORECASE)
-  rescue RegexpError => e
-    assert_true e.message.include?("MRB_REGEXP_UNICODE_CASE")
+  # Each asserts the message rather than the class alone, since a `\u` pattern
+  # has reasons of its own to raise `RegexpError` and a complaint about the
+  # escape's own spelling would otherwise pass for this refusal.
+  ["\\u0100", "\\u{100}"].each do |src|
+    assert_raise_with_message(RegexpError, "#{refused}: /#{src}/") do
+      Regexp.new(src, Regexp::IGNORECASE)
+    end
+  end
+  ["[\\u{100}]", "[^\\u{100}]", "[\\u{100}-\\u{102}]"].each do |src|
+    assert_raise_with_message(RegexpError, "#{refused} class: /#{src}/") do
+      Regexp.new(src, Regexp::IGNORECASE)
+    end
   end
 end
 

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -2329,6 +2329,75 @@ assert("Regexp - octal and hex escapes") do
   assert_equal 0, (/\x7/ =~ "\a")
 end
 
+assert("Regexp - \\u escapes") do
+  # `\u` used to be unknown to the engine, which dropped the backslash and
+  # left the rest as literal text: /\u00b5/ matched "u00b5" rather than "µ".
+  assert_equal 0, (/\u00b5/ =~ "\xc2\xb5")
+  assert_nil (/\u00b5/ =~ "u00b5")
+  assert_equal 0, (/\u{b5}/ =~ "\xc2\xb5")
+  assert_nil (/\u{b5}/ =~ "u{b5}")
+  assert_equal 0, (/\u0061/ =~ "a")
+  assert_equal 0, (/\u{3042}/ =~ "\xe3\x81\x82")
+  assert_equal 0, (/\u{10FFFF}/ =~ "\xf4\x8f\xbf\xbf")
+
+  # a codepoint is one atom, so a quantifier repeats the whole character
+  # rather than its last UTF-8 byte
+  assert_equal ["\xe3\x81\x82\xe3\x81\x82"], "\xe3\x81\x82\xe3\x81\x82".scan(/\u{3042}+/)
+  assert_equal 0, (/\u{3042}{2}/ =~ "\xe3\x81\x82\xe3\x81\x82")
+
+  # the list form is a sequence of atoms, so a following quantifier binds
+  # to the last codepoint alone: /\u{61 62}+/ is `ab+`
+  assert_equal "ab", "abbb"[/\u{61 62}/]
+  assert_equal "abbb", "abbb"[/\u{61 62}+/]
+  assert_nil ("b" =~ /\u{61 62}/)
+
+  # /x strips whitespace before the pattern is parsed, but not the spaces
+  # that separate the codepoints of a list
+  assert_equal 0, (Regexp.new("\\u{61 62}", Regexp::EXTENDED) =~ "ab")
+
+  # /i folds an ASCII letter reached through `\u`, like a literal one
+  assert_equal 0, (/\u0061/i =~ "A")
+end
+
+assert("Regexp - \\u escapes in a character class") do
+  assert_equal 0, (/[\u00b5]/ =~ "\xc2\xb5")
+  assert_nil (/[\u00b5]/ =~ "u")
+  assert_equal 0, (/[\u{3042}-\u{3044}]/ =~ "\xe3\x81\x83")
+  assert_nil (/[\u{3042}-\u{3044}]/ =~ "\xe3\x81\x85")
+  assert_equal 0, (/[a-\u{7a}]/ =~ "q")
+
+  # every codepoint of a list is a member of its own, and the last one can
+  # still open a range
+  assert_equal ["a", "b"], "abc".scan(/[\u{61 62}]/)
+  assert_equal ["a", "b", "c"], "abc-".scan(/[\u{61 62}-z]/)
+  assert_equal ["c"], "abc".scan(/[^\u{61 62}]/)
+end
+
+assert("Regexp - malformed \\u escapes") do
+  # each of these is a RegexpError in CRuby rather than a shorter codepoint
+  # or literal text
+  assert_raise_with_message(RegexpError, "invalid Unicode escape: /\\uXX/") do
+    Regexp.new("\\uXX")
+  end
+  assert_raise_with_message(RegexpError, "too short escape sequence: /\\u/") do
+    Regexp.new("\\u")
+  end
+  assert_raise(RegexpError) { Regexp.new("\\u061") }       # fewer than four digits
+  assert_raise(RegexpError) { Regexp.new("\\u{}") }        # empty list
+  assert_raise(RegexpError) { Regexp.new("\\u{ }") }       # list of no codepoints
+  assert_raise(RegexpError) { Regexp.new("\\u{61") }       # unterminated list
+  assert_raise(RegexpError) { Regexp.new("\\u{61,62}") }   # comma is not a separator
+  assert_raise(RegexpError) { Regexp.new("\\u{0000061}") } # more than six digits
+  assert_raise(RegexpError) { Regexp.new("\\uD800") }      # surrogate
+  assert_raise(RegexpError) { Regexp.new("[\\u{110000}]") }
+
+  # /\u{3042}/ used to be read as the quantifier `u{3042}`, so a codepoint
+  # out of range was reported as a repeat count the pattern never wrote
+  assert_raise_with_message(RegexpError, "invalid Unicode range: /\\u{110000}/") do
+    Regexp.new("\\u{110000}")
+  end
+end
+
 assert("Regexp - \\h and \\H hex-digit shorthands") do
   assert_equal 0, (/\h/ =~ "f")
   assert_nil (/\h/ =~ "g")

--- a/mrbgems/mruby-regexp/test/unicode_case.rb
+++ b/mrbgems/mruby-regexp/test/unicode_case.rb
@@ -35,6 +35,18 @@ assert("Regexp - Unicode case folding under /i") do
   assert_equal "K", "K".match(/k/i)[0]
   assert_equal "k", "k".match(/K/i)[0]
   assert_equal "ſ", "ſ".match(/s/i)[0]
+  # A `\u` escape names the character another pattern would spell out, so /i
+  # folds it the same way either spelling is folded. That holds for both
+  # spellings of the escape, and inside a class as well as outside one.
+  assert_equal "ā", "ā".match(/\u{100}/i)[0]
+  assert_equal "Ā", "Ā".match(/\u{101}/i)[0]
+  assert_equal "ā", "ā".match(/\u0100/i)[0]
+  assert_equal "ā", "ā".match(/[\u{100}]/i)[0]
+  assert_nil "ā".match(/[^\u{100}]/i)
+  # A range written with escapes closes under folding as the spelled one does:
+  # U+0103 folds from U+0102, which the range holds.
+  assert_equal "ă", "ă".match(/[\u{100}-\u{102}]/i)[0]
+  assert_nil "ą".match(/[\u{100}-\u{102}]/i)
   # Backreferences compare folded too.
   assert_equal "Āā", "Āā".match(/(Ā)\1/i)[0]
   # Without /i nothing folds.


### PR DESCRIPTION
The regexp engine has no `\u` escape. `parse_escape()`
(`re_compile.c:339`) knows `\n`, `\t`, `\r`, `\f`, `\v`, `\a`, `\e`, `\b`, the
octal form `\NNN` and the hex form `\xHH`, and returns every other escaped
character as itself (`re_compile.c:389`). `\u` is not among them, so the
backslash is dropped and the `u` becomes an ordinary literal, along with
whatever follows it.

```ruby
"µ"     =~ /\u00b5/     # CRuby: 0,   mruby: nil
"u00b5" =~ /\u00b5/     # CRuby: nil, mruby: 0
"µ"     =~ /\u{b5}/     # CRuby: 0,   mruby: nil
"u{b5}" =~ /\u{b5}/     # CRuby: nil, mruby: 0
"µ"     =~ /[\u00b5]/   # CRuby: 0,   mruby: nil
"あ"    =~ /\u{3042}/   # CRuby: 0,   mruby: nil
"ab"    =~ /\u{61 62}/  # CRuby: 0,   mruby: nil
```

The parser is not involved. `/\u00b5/.source` is `"\\u00b5"` in both, so the
escape reaches the engine intact and the engine is where it is lost.

## Cause

What the leftover text means depends on the spelling, and neither reading is
the one that was written.

`\uXXXX` leaves five ASCII characters. A pattern that means one codepoint
quietly means `u00b5`, and a subject that happens to carry that text matches. A
short `\uXX`, which is a `RegexpError` in CRuby, likewise matches the text
`uXX`.

`\u{...}` leaves a `u` followed by a brace group, so a body that reads as a
repetition count becomes a quantifier on the `u`. `/\u{3042}/` is `u{3042}`,
which matches 3042 `u`s and nothing else, and `/\u{110000}/` raises
`RegexpError: quantifier too large`, naming something the pattern never said. A
body that is not a count stays literal, so `/\u{b5}/` matches `u{b5}`, and
`/\u{}/` matches `u{}` where CRuby raises `invalid Unicode list`.

```ruby
("u" * 3042) =~ /\u{3042}/  # CRuby: nil, mruby: 0
"uXX"        =~ /\uXX/      # CRuby: RegexpError (invalid Unicode escape),
                            # mruby: 0
/\u{110000}/                # CRuby: RegexpError (invalid Unicode range),
                            # mruby: RegexpError (quantifier too large)
```

So the quiet wrong answer is the common case, but it is not the only one: the
`\u{...}` spelling can also fail loudly under a message about a quantifier the
author never wrote.

Neither the README's `Pattern Syntax` list nor its `Limitations` section said
anything about `\u`, and the character escapes that do work (`\n`, `\t`,
`\xHH`, `\NNN`) were not listed either, so the gap was not written down
anywhere.

## Fix

Read the escape. `unicode_escape_first()` takes `\uXXXX` as exactly four hex
digits, or opens a `\u{...}` list whose codepoints `unicode_escape_next()`
yields one at a time, one to six hex digits each and whitespace between them.

A codepoint above 127 has to become its UTF-8 byte sequence, which is a run of
`RE_CHAR`, the same shape `emit_char_bytes()` already emits for a multibyte
character written literally in the pattern (`re_compile.c:681`), and for the
same reason: the run has to be one atom, or a following quantifier binds to the
last byte alone. `emit_codepoint()` is that function for a codepoint the
pattern names rather than spells, so the bytes come from
`mrb_re_utf8_encode()`, the encoding counterpart of the
`mrb_re_utf8_decode()` the gem already has.

The `\u` branch sits ahead of the `ch >= 0xC0` branch `0e96b2c2d` added, which
routes a backslash before a multibyte character away from `parse_escape()`.
`u` is below `0xC0`, so the order is what keeps `\u` from reaching
`parse_escape()` as a literal `u`; the same holds for the `peek(c) < 0xC0`
guard in `read_class_atom()`.

The list form is where the two contexts part.

Outside a character class `/\u{61 62}/` is a sequence of atoms rather than one,
and a quantifier after it repeats the last codepoint only, so `/\u{61 62}+/` is
`a` followed by `b+`. `compile_quantified()` used to take the atom's start from
the position it saved before calling `compile_atom()`; it now takes it from
`c->atom_start`, which the `\u` case moves past every codepoint but the last.
The field is saved and restored around the call, so a nested
`compile_quantified()` inside a group leaves nothing behind for the outer one.

Inside a class each codepoint is a member of its own, and `read_class_atom()`
adds all but the last to the class itself and returns the last, so it can still
open a range: `/[\u{61 62}-z]/` is `a` plus `b-z`, which is how CRuby reads it.
`read_class_atom()` takes the class for that, and `class_add_member()` routes a
member to the ASCII bitmap or the codepoint range list.

The malformed spellings raise rather than fall back on a shorter codepoint or
on literal text, with CRuby's messages: `invalid Unicode escape` for a `\uXXXX`
with fewer than four hex digits, `too short escape sequence` for a bare `\u` at
the end of the pattern, `invalid Unicode list` for `\u{}`, for a separator
CRuby does not take and for an unterminated group, and `invalid Unicode range`
for more than six digits, for a surrogate and for anything above U+10FFFF. A
surrogate and an out of range value have no UTF-8 encoding, so rejecting them
is also what keeps `mrb_re_utf8_encode()` total.

One more pass had to learn about the escape. Whitespace separates the
codepoints of a list, and `preprocess_pattern()` strips whitespace for `/x`
before the parser runs, so it now copies a `\u{...}` group whole; without that
`/\u{61 62}/x` would join into the single codepoint `\u{6162}`.

The executors are not touched. They see the `RE_CHAR` run and the class
members any other pattern produces.

The change comes in two commits: the first lifts out the three pieces the
escape reuses (`emit_char()`, `class_add_member()`, `hex_value()`) with no
behaviour change, the second reads the escape. `emit_char()` sits beside the
`emit_char_bytes()` that `0e96b2c2d` extracted and names the same job for a
character that is a single byte.

## Tests

Three cases in `mrbgems/mruby-regexp/test/regexp.rb`:

- `Regexp - \u escapes`: both spellings against the character and against the
  text they used to match, a codepoint in each UTF-8 length, the quantifier
  binding for a single codepoint and for a list, the `/x` case that the
  free-spacing pass would otherwise join, and the `/i` folding of an ASCII
  letter reached through `\u`.
- `Regexp - \u escapes in a character class`: single members, a codepoint
  range, a list, a list that opens a range, and a negated class.
- `Regexp - malformed \u escapes`: the eleven spellings CRuby refuses, with the
  message asserted for three of them, `\u{110000}` among them, since that is
  the one that used to raise about a quantifier instead.

Patterns are always parsed as UTF-8, so the subjects are written as explicit
bytes and the assertions hold in both `MRB_UTF8_STRING` and byte-string builds.

## Verified on x86_64-linux

- A differential sweep against CRuby 4.0.6 over 273 pattern and flag
  combinations and 4700 answers: 57 patterns under no flag, `/i` and `/x`
  against 20 subjects; 26 patterns exercising the interaction with groups,
  repetition counts, alternation and backreferences against the same subjects;
  27 malformed or boundary patterns under no flag and `/x` against 10 subjects;
  and 22 patterns crossing the escape with the escaped multibyte literal
  `0e96b2c2d` added, with the surrogate boundary and the astral plane, against
  10 subjects. Every answer and every error class and message agrees with
  CRuby. The one difference left is that mruby's `RegexpError` message does not
  carry the flag suffix (`/\uXX/` where CRuby writes `/\uXX/i`), which is how
  `compile_error()` has always formatted a pattern and is unrelated to this
  change.
- `rake test`: 2020 total, 2002 OK, 0 KO, 0 crash, and bintest 105 OK.
- `MRUBY_CONFIG=build_config/asan.rb rake test` (clang, ASAN and UBSan): 2197
  total, 2195 OK, 0 KO, 0 crash, no sanitizer report, and bintest 78 OK.
- A `full-core` build with `MRB_UTF8_STRING`: 2197 total, 2195 OK, 0 KO,
  0 crash, and bintest 78 OK. The sweep above runs there.
- `clang -Wall -Wextra` over `re_compile.c` and `re_utf8.c`: no new warning.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Unicode escape sequences in regular expressions, including fixed-width and braced formats.
  * Supports Unicode codepoint lists, character classes, quantifiers, extended mode, and case-insensitive matching.
  * Added UTF-8 encoding for valid Unicode codepoints.

* **Bug Fixes**
  * Invalid, malformed, surrogate, and out-of-range Unicode escapes now produce clear regular expression errors.

* **Documentation**
  * Documented supported character escapes, examples, and hexadecimal escape limitations.

* **Tests**
  * Added comprehensive coverage for Unicode escapes, case folding, and invalid input handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->