### PR TITLE
mruby-regexp: accept a Regexp in String#index, #partition, #start_with? and their siblings

### DIFF
--- a/mrbgems/mruby-regexp/README.md
+++ b/mrbgems/mruby-regexp/README.md
@@ -94,6 +94,17 @@ str[re] = repl                    # replace the match
 str[re, capture] = repl           # replace a capture by index or name
 str.slice!(re)                    # remove and return the match, or nil
 str.slice!(re, capture)           # same, for a capture by index or name
+str.index(re)                     # => match start, or nil
+str.index(re, pos)                # => same, searching from pos
+str.rindex(re)                    # => last match start, or nil
+str.rindex(re, pos)               # => last match starting at or before pos
+str.byteindex(re)                 # => match start in bytes, or nil
+str.byteindex(re, pos)            # => same, searching from byte pos
+str.byterindex(re)                # => last match start in bytes, or nil
+str.byterindex(re, pos)           # => same, at or before byte pos
+str.partition(re)                 # => [before, match, after]
+str.rpartition(re)                # => [before, last match, after]
+str.start_with?(re)               # => true/false (anchored at the start)
 
 # Symbol methods (the String methods applied to the symbol's name)
 sym.match(re)                     # => MatchData or nil
@@ -136,6 +147,11 @@ pattern analysis.
   only.
 - **Step limit on backtracking**: Patterns that require the
   backtracking engine are subject to a step limit.
+- **Backward search walks forward**: the engine searches forward only,
+  so `rindex`, `byterindex` and `rpartition` walk the subject from the
+  start and keep the last match that qualifies. The cost grows with the
+  number of positions a match starts at, where CRuby hands the search to
+  Onig.
 - **No inline extended mode**: `(?x)` and `(?x:...)` raise a
   `RegexpError`, because extended mode is applied to the whole pattern
   before it is parsed. A `-x` is accepted and ignored, so inside a

--- a/mrbgems/mruby-regexp/mrblib/string_regexp.rb
+++ b/mrbgems/mruby-regexp/mrblib/string_regexp.rb
@@ -52,10 +52,14 @@ class String
   alias __aset []=
   alias __slice_bang slice!
 
-  # The two search methods of src/string.c whose regexp form is overridden at
-  # the end of this file.
+  # The four search methods of src/string.c whose regexp form is overridden at
+  # the end of this file.  On a build without MRB_UTF8_STRING the two of a
+  # pair are the same C function behind two method table entries, so each
+  # still needs its own capture.
   alias __index index
   alias __rindex rindex
+  alias __byteindex byteindex
+  alias __byterindex byterindex
 
   # `match` and `match?` accept a Regexp or a String and reject everything
   # else.  The check lives in C (see Regexp.__check_pattern) so that the
@@ -524,5 +528,51 @@ class String
     end
     md = __regexp_rsearch(args[0], pos, false)
     md && md.begin(0)
+  end
+
+  # Regexp-aware `byteindex`.  Falls back to the C-defined `byteindex`
+  # (aliased as `__byteindex` above) for every other argument form.
+  def byteindex(*args)
+    return __byteindex(*args) unless Regexp === args[0]
+    if args.length > 2
+      raise ArgumentError, "wrong number of arguments (given #{args.length}, expected 1..2)"
+    end
+    len = self.bytesize
+    pos = 0
+    if args.length > 1
+      pos = Integer.__ensure(args[1])
+      pos += len if pos < 0
+    end
+    # `__byte_match` takes the position as given and does not range check it,
+    # where `Regexp#match` answers nil for one outside the subject.  Both
+    # ends are a miss here, as they are for `mrb_str_byteindex_m()`.  An
+    # offset that lands inside a character is not an error: the C method does
+    # not check for one either, and on a build without MRB_UTF8_STRING there
+    # is nothing to check.
+    return args[0].match(nil) if pos < 0 || pos > len
+    md = args[0].__byte_match(self, pos)
+    md && md.__byte_begin(0)
+  end
+
+  # Regexp-aware `byterindex`.  Falls back to the C-defined `byterindex`
+  # (aliased as `__byterindex` above) for every other argument form.
+  def byterindex(*args)
+    return __byterindex(*args) unless Regexp === args[0]
+    if args.length > 2
+      raise ArgumentError, "wrong number of arguments (given #{args.length}, expected 1..2)"
+    end
+    len = self.bytesize
+    pos = len
+    if args.length > 1
+      pos = Integer.__ensure(args[1])
+      if pos < 0
+        pos += len
+        return args[0].match(nil) if pos < 0
+      elsif pos > len
+        pos = len
+      end
+    end
+    md = __regexp_rsearch(args[0], pos, true)
+    md && md.__byte_begin(0)
   end
 end

--- a/mrbgems/mruby-regexp/mrblib/string_regexp.rb
+++ b/mrbgems/mruby-regexp/mrblib/string_regexp.rb
@@ -61,6 +61,10 @@ class String
   alias __byteindex byteindex
   alias __byterindex byterindex
 
+  # The two from mruby-string-ext, which this gem depends on.
+  alias __partition partition
+  alias __rpartition rpartition
+
   # `match` and `match?` accept a Regexp or a String and reject everything
   # else.  The check lives in C (see Regexp.__check_pattern) so that the
   # argument cannot steer it: it cannot pose as a Regexp, and there is no
@@ -574,5 +578,30 @@ class String
     end
     md = __regexp_rsearch(args[0], pos, true)
     md && md.__byte_begin(0)
+  end
+
+  # Regexp-aware `partition`.  Falls back to the C-defined `partition`
+  # (aliased as `__partition` above) for every other argument.
+  def partition(sep)
+    return __partition(sep) unless Regexp === sep
+    md = sep.match(self)
+    # No match leaves the whole subject in the head, and the copy is a plain
+    # String even when the receiver is a subclass, as `mrb_str_dup()` and
+    # CRuby's `str_duplicate(rb_cString, str)` both hand back.
+    return [self.byteslice(0, self.bytesize), "", ""] unless md
+    [md.pre_match, md[0], md.post_match]
+  end
+
+  # Regexp-aware `rpartition`.  Falls back to the C-defined `rpartition`
+  # (aliased as `__rpartition` above) for every other argument.
+  def rpartition(sep)
+    return __rpartition(sep) unless Regexp === sep
+    # The last match anywhere in the subject, so the limit is its end and the
+    # walk below never stops early.
+    md = __regexp_rsearch(sep, self.length, false)
+    # No match puts the whole subject in the tail, which is the row this
+    # method is most often got wrong on.
+    return ["", "", self.byteslice(0, self.bytesize)] unless md
+    [md.pre_match, md[0], md.post_match]
   end
 end

--- a/mrbgems/mruby-regexp/mrblib/string_regexp.rb
+++ b/mrbgems/mruby-regexp/mrblib/string_regexp.rb
@@ -61,9 +61,10 @@ class String
   alias __byteindex byteindex
   alias __byterindex byterindex
 
-  # The two from mruby-string-ext, which this gem depends on.
+  # The three from mruby-string-ext, which this gem depends on.
   alias __partition partition
   alias __rpartition rpartition
+  alias __start_with? start_with?
 
   # `match` and `match?` accept a Regexp or a String and reject everything
   # else.  The check lives in C (see Regexp.__check_pattern) so that the
@@ -603,5 +604,32 @@ class String
     # method is most often got wrong on.
     return ["", "", self.byteslice(0, self.bytesize)] unless md
     [md.pre_match, md[0], md.post_match]
+  end
+
+  # Regexp-aware `start_with?`.  Takes any mix of patterns and hands each
+  # non-regexp one to the C-defined `start_with?` (aliased as
+  # `__start_with?` above), one at a time, so that a String keeps the C
+  # comparison and its error and the arguments are still read left to right.
+  def start_with?(*args)
+    i = 0
+    while i < args.length
+      arg = args[i]
+      if Regexp === arg
+        # A regexp is anchored at the start, not searched for, while `match`
+        # searches forward from its position.  The engine matches leftmost,
+        # so a pattern that can match at 0 does, which makes `begin(0) == 0`
+        # the anchored answer rather than an approximation of it.
+        md = arg.match(self)
+        return true if md && md.begin(0) == 0
+        # A match further along is not an answer and CRuby leaves none
+        # behind for one, so clear what the search published.  Matching
+        # against nil is how a Regexp clears the globals.
+        arg.match(nil) if md
+      elsif __start_with?(arg)
+        return true
+      end
+      i += 1
+    end
+    false
   end
 end

--- a/mrbgems/mruby-regexp/mrblib/string_regexp.rb
+++ b/mrbgems/mruby-regexp/mrblib/string_regexp.rb
@@ -52,6 +52,11 @@ class String
   alias __aset []=
   alias __slice_bang slice!
 
+  # The two search methods of src/string.c whose regexp form is overridden at
+  # the end of this file.
+  alias __index index
+  alias __rindex rindex
+
   # `match` and `match?` accept a Regexp or a String and reject everything
   # else.  The check lives in C (see Regexp.__check_pattern) so that the
   # argument cannot steer it: it cannot pose as a Regexp, and there is no
@@ -444,5 +449,80 @@ class String
     removed = md[group]
     __aset(beg, len, "")
     removed
+  end
+
+  # Regexp-aware `index`.  Falls back to the C-defined `index` (aliased as
+  # `__index` above) for every other argument form.
+  def index(*args)
+    return __index(*args) unless Regexp === args[0]
+    if args.length > 2
+      raise ArgumentError, "wrong number of arguments (given #{args.length}, expected 1..2)"
+    end
+    # `Regexp#match` normalizes a position the way `index` does and reads it
+    # with the same `mrb_get_args()` conversion, so the argument goes over
+    # unexamined: a negative one counts back from the end, and one that lands
+    # outside the subject answers nil after clearing the match globals.
+    # `match` and not `match?`, because those globals are part of the answer.
+    md = args.length > 1 ? args[0].match(self, args[1]) : args[0].match(self)
+    # `begin` reports character offsets, which is the space `index` answers
+    # in; `byteindex` below is the same search read in the other space.
+    md && md.begin(0)
+  end
+
+  # The last match that starts at or before `limit`, or nil, with the match
+  # globals left describing it.  `limit` is a byte offset when `bytes` is
+  # true and a character offset otherwise, which is the whole of the
+  # difference between `byterindex` and `rindex`.
+  #
+  # The engine searches forward only, so this walks the subject from the
+  # start and keeps the last match that qualifies: linear in the number of
+  # positions a match starts at, where the backward search CRuby hands to
+  # Onig is not.  Each step resumes one character past the match start and
+  # not at the match end, which is what keeps overlapping matches in view:
+  # `"aaa".rindex(/aa/)` is 1, where resuming at the end would answer 0.
+  def __regexp_rsearch(pattern, limit, bytes)
+    found = nil
+    pos = 0
+    while (md = pattern.match(self, pos))
+      break if (bytes ? md.__byte_begin(0) : md.begin(0)) > limit
+      found = md
+      pos = md.begin(0) + 1
+    end
+    # The loop leaves behind whatever its last `match` published: the clear a
+    # failed one does, or a match past `limit` that is not the answer.  Both
+    # have to give way to what the search found.
+    found ? found.__set_globals : pattern.match(nil)
+    found
+  end
+
+  # Regexp-aware `rindex`.  Falls back to the C-defined `rindex` (aliased as
+  # `__rindex` above) for every other argument form.
+  def rindex(*args)
+    return __rindex(*args) unless Regexp === args[0]
+    if args.length > 2
+      raise ArgumentError, "wrong number of arguments (given #{args.length}, expected 1..2)"
+    end
+    len = self.length
+    pos = len
+    if args.length > 1
+      # The position is arithmetic here rather than an argument handed
+      # straight to the engine, so it has to be an Integer first.
+      # `Integer.__ensure` is `mrb_ensure_int_type()`, the same conversion
+      # `mrb_get_args()` performs for the `i` of the C method.
+      pos = Integer.__ensure(args[1])
+      if pos < 0
+        pos += len
+        # Out of the subject at the negative end is a miss, and a miss
+        # clears the match globals.
+        return args[0].match(nil) if pos < 0
+      elsif pos > len
+        # Past the other end is not: `rindex` searches back from the end of
+        # the subject, and `mrb_str_byterindex_m()` clamps for the same
+        # reason.  `"abc".rindex(/b/, 10)` is 1.
+        pos = len
+      end
+    end
+    md = __regexp_rsearch(args[0], pos, false)
+    md && md.begin(0)
   end
 end

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -2963,3 +2963,76 @@ assert("String#partition and String#rpartition delegate every non-regexp argumen
   assert_raise(TypeError) { "hello".partition(fake) }
   assert_raise(TypeError) { "hello".rpartition(fake) }
 end
+
+assert("String#start_with? with regexp") do
+  assert_true "hello".start_with?(/h/)
+  assert_true "hello".start_with?(/hel+/)
+  assert_true "hello".start_with?(//)
+  assert_false "hello".start_with?(/z/)
+
+  # anchored at the start rather than searched for, so a pattern that matches
+  # further along is not an answer
+  assert_false "hello".start_with?(/e/)
+  assert_true "hello".start_with?(/^h/)
+  assert_false "abc\ndef".start_with?(/^d/)
+
+  # several patterns, read left to right, in any mix of the two kinds
+  assert_true "hello".start_with?(/z/, /h/)
+  assert_true "hello".start_with?("z", /h/)
+  assert_true "hello".start_with?(/h/, "z")
+  assert_false "hello".start_with?(/z/, "z")
+  assert_false "hello".start_with?
+
+  # an argument after the one that answers is never looked at
+  assert_true "hello".start_with?(/h/, 1)
+
+  # `end_with?` is not part of this family: CRuby rejects a Regexp there too
+  assert_raise(TypeError) { "hello".end_with?(/o/) }
+end
+
+assert("String#start_with? with regexp sets the match globals") do
+  assert_true "hello".start_with?(/(h)(e)/)
+  assert_equal "h", $1
+  assert_equal "e", $2
+
+  # the pattern that answered, after the ones before it failed
+  assert_true "hello".start_with?(/z/, /(h)/)
+  assert_equal "h", $1
+
+  "zzz" =~ /z/
+  assert_false "hello".start_with?(/z/)
+  assert_nil $~
+
+  # a pattern that matches further along is refused, and its match is not
+  # left behind either
+  "zzz" =~ /z/
+  assert_false "hello".start_with?(/e/)
+  assert_nil $~
+
+  # a non-regexp argument leaves them as they were
+  "zzz" =~ /z/
+  assert_true "hello".start_with?("he")
+  assert_equal "z", $~[0]
+  "zzz" =~ /z/
+  assert_false "hello".start_with?
+  assert_equal "z", $~[0]
+end
+
+assert("String#start_with? delegates every non-regexp argument") do
+  assert_true "hello".start_with?("he")
+  assert_false "hello".start_with?("z")
+  assert_true "hello".start_with?("z", "he")
+  assert_raise(TypeError) { "hello".start_with?(1) }
+
+  re = /l+/
+  def re.is_a?(klass); false; end
+  assert_false "hello".start_with?(re)
+  head = /h/
+  def head.is_a?(klass); false; end
+  assert_true "hello".start_with?(head)
+
+  fake = Object.new
+  def fake.is_a?(klass); true; end
+  def fake.match(str, pos = 0); raise "must not be called"; end
+  assert_raise(TypeError) { "hello".start_with?(fake) }
+end

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -2886,3 +2886,80 @@ assert("String#byteindex and String#byterindex delegate every non-regexp argumen
   assert_raise(TypeError) { "hello".byteindex(fake) }
   assert_raise(TypeError) { "hello".byterindex(fake) }
 end
+
+assert("String#partition and String#rpartition with regexp") do
+  assert_equal ["he", "ll", "o"], "hello".partition(/l+/)
+  assert_equal ["hell", "o", ""], "hello".partition(/o/)
+  assert_equal ["hel", "l", "o"], "hello".rpartition(/l/)
+  assert_equal ["hello w", "o", "rld"], "hello world".rpartition(/o/)
+
+  # the three pieces come from the match itself, so a capture group changes
+  # nothing about where the subject is cut
+  assert_equal ["he", "llo", ""], "hello".partition(/(l+)(o)/)
+
+  # `rpartition` takes the last match, overlapping ones included
+  assert_equal ["", "aa", "a"], "aaa".partition(/aa/)
+  assert_equal ["a", "aa", ""], "aaa".rpartition(/aa/)
+
+  # no match leaves the subject whole: at the head for `partition` and at the
+  # tail for `rpartition`
+  assert_equal ["hello", "", ""], "hello".partition(/z/)
+  assert_equal ["", "", "hello"], "hello".rpartition(/z/)
+  assert_equal ["", "", ""], "".partition(/z/)
+  assert_equal ["", "", ""], "".rpartition(/z/)
+
+  # an empty match still cuts, at the first position for one and at the last
+  # for the other
+  assert_equal ["", "", "hello"], "hello".partition(//)
+  assert_equal ["hello", "", ""], "hello".rpartition(//)
+
+  # the unmatched subject comes back as a copy, and every piece is a plain
+  # String even for a subclass receiver, as in CRuby
+  s = "hello"
+  assert_false s.partition(/z/)[0].equal?(s)
+  sub = Class.new(String)
+  assert_equal [String, String, String], sub.new("hello").partition(/l/).map { |x| x.class }
+  assert_equal [String, String, String], sub.new("hello").rpartition(/z/).map { |x| x.class }
+end
+
+assert("String#partition and String#rpartition with regexp set the match globals") do
+  assert_equal ["a", "b", "cabc"], "abcabc".partition(/(b)/)
+  assert_equal 1, $~.begin(0)
+  assert_equal "b", $1
+
+  # the match `rpartition` stopped on, not one it walked past on the way there
+  assert_equal ["abca", "b", "c"], "abcabc".rpartition(/(b)/)
+  assert_equal 4, $~.begin(0)
+
+  "zzz" =~ /z/
+  assert_equal ["abc", "", ""], "abc".partition(/x/)
+  assert_nil $~
+  "zzz" =~ /z/
+  assert_equal ["", "", "abc"], "abc".rpartition(/x/)
+  assert_nil $~
+end
+
+assert("String#partition and String#rpartition delegate every non-regexp argument") do
+  assert_equal ["he", "ll", "o"], "hello".partition("ll")
+  assert_equal ["hello", "", ""], "hello".partition("z")
+  assert_equal ["hel", "l", "o"], "hello".rpartition("l")
+  assert_equal ["", "", "hello"], "hello".rpartition("z")
+
+  assert_raise(ArgumentError) { "hello".partition }
+  assert_raise(ArgumentError) { "hello".rpartition }
+  assert_raise(ArgumentError) { "hello".partition(/l/, 1) }
+  assert_raise(ArgumentError) { "hello".rpartition(/l/, 1) }
+  assert_raise(TypeError) { "hello".partition(1) }
+  assert_raise(TypeError) { "hello".rpartition(1) }
+
+  re = /l+/
+  def re.is_a?(klass); false; end
+  assert_equal ["he", "ll", "o"], "hello".partition(re)
+  assert_equal ["hel", "l", "o"], "hello".rpartition(re)
+
+  fake = Object.new
+  def fake.is_a?(klass); true; end
+  def fake.match(str, pos = 0); raise "must not be called"; end
+  assert_raise(TypeError) { "hello".partition(fake) }
+  assert_raise(TypeError) { "hello".rpartition(fake) }
+end

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -2806,3 +2806,83 @@ assert("String#index and String#rindex delegate every non-regexp argument") do
   assert_raise(TypeError) { "hello".index(fake) }
   assert_raise(TypeError) { "hello".rindex(fake) }
 end
+
+assert("String#byteindex and String#byterindex with regexp") do
+  assert_equal 1, "hello".byteindex(/e/)
+  assert_nil "hello".byteindex(/z/)
+  assert_equal 3, "hello".byteindex(/l/, 3)
+  assert_equal 3, "hello".byteindex(/l/, -2)
+  assert_nil "hello".byteindex(/l/, 6)
+  assert_nil "hello".byteindex(/l/, -10)
+
+  assert_equal 3, "hello".byterindex(/l/)
+  assert_nil "hello".byterindex(/z/)
+  assert_equal 1, "aaa".byterindex(/aa/)
+  assert_equal 2, "hello".byterindex(/l/, 2)
+  assert_equal 3, "hello".byterindex(/l/, 10)
+  assert_nil "hello".byterindex(/l/, -10)
+
+  # the same two searches read in the other space.  They part company with
+  # `index` and `rindex` only on a build with MRB_UTF8_STRING, where the
+  # answer and the position argument are both byte offsets
+  if __ENCODING__ == "UTF-8"
+    assert_equal 1, "あいうあいう".index(/い/)
+    assert_equal 3, "あいうあいう".byteindex(/い/)
+    assert_equal 4, "あいうあいう".rindex(/い/)
+    assert_equal 12, "あいうあいう".byterindex(/い/)
+    assert_equal 12, "あいうあいう".byteindex(/い/, 6)
+    assert_equal 3, "あいうあいう".byterindex(/い/, 6)
+  end
+end
+
+assert("String#byteindex and String#byterindex with regexp set the match globals") do
+  assert_equal 1, "abc".byteindex(/(b)/)
+  assert_equal "b", $1
+  assert_equal 4, "abcabc".byterindex(/(b)/)
+  assert_equal 4, $~.begin(0)
+
+  "zzz" =~ /z/
+  assert_nil "abc".byteindex(/x/)
+  assert_nil $~
+  "zzz" =~ /z/
+  assert_nil "abc".byterindex(/x/)
+  assert_nil $~
+
+  # a position outside the subject and a match that starts past the one asked
+  # for both clear them too
+  "zzz" =~ /z/
+  assert_nil "abc".byteindex(/b/, 10)
+  assert_nil $~
+  "zzz" =~ /z/
+  assert_nil "abc".byterindex(/c/, 1)
+  assert_nil $~
+end
+
+assert("String#byteindex and String#byterindex delegate every non-regexp argument") do
+  assert_equal 2, "hello".byteindex("l")
+  assert_equal 3, "hello".byteindex("l", 3)
+  assert_nil "hello".byteindex("z")
+  assert_equal 3, "hello".byterindex("l")
+  assert_equal 2, "hello".byterindex("l", 2)
+  assert_nil "hello".byterindex("z")
+
+  assert_raise(ArgumentError) { "hello".byteindex }
+  assert_raise(ArgumentError) { "hello".byterindex }
+  assert_raise(TypeError) { "hello".byteindex(1) }
+  assert_raise(TypeError) { "hello".byterindex(1) }
+  assert_raise(ArgumentError) { "hello".byteindex(/l/, 1, 2) }
+  assert_raise(ArgumentError) { "hello".byterindex(/l/, 1, 2) }
+  assert_raise(TypeError) { "hello".byteindex(/l/, nil) }
+  assert_raise(TypeError) { "hello".byterindex(/l/, nil) }
+
+  re = /l+/
+  def re.is_a?(klass); false; end
+  assert_equal 2, "hello".byteindex(re)
+  assert_equal 3, "hello".byterindex(re)
+
+  fake = Object.new
+  def fake.is_a?(klass); true; end
+  def fake.match(str, pos = 0); raise "must not be called"; end
+  assert_raise(TypeError) { "hello".byteindex(fake) }
+  assert_raise(TypeError) { "hello".byterindex(fake) }
+end

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -2693,3 +2693,116 @@ assert("String#slice! delegates every non-regexp argument") do
   assert_raise(TypeError) { "hello".slice!(nil) }
   assert_raise(FrozenError) { "hello".freeze.slice!(0) }
 end
+
+assert("String#index with regexp") do
+  assert_equal 1, "hello".index(/e/)
+  assert_equal 2, "hello".index(/l+/)
+  assert_nil "hello".index(/z/)
+  assert_equal 0, "hello".index(//)
+
+  # a start position, and a negative one counting back from the end
+  assert_equal 3, "hello".index(/l/, 3)
+  assert_equal 3, "hello".index(/l/, -2)
+  assert_nil "hello".index(/l/, 4)
+
+  # the end of the subject is a position a match can start at, and anything
+  # past either end is a miss
+  assert_equal 5, "hello".index(//, 5)
+  assert_nil "hello".index(//, 6)
+  assert_nil "hello".index(/l/, -10)
+end
+
+assert("String#rindex with regexp") do
+  assert_equal 3, "hello".rindex(/l/)
+  assert_nil "hello".rindex(/z/)
+  assert_equal 5, "hello".rindex(//)
+
+  # the last match and not the first, which is the whole of the difference
+  # from `index`
+  assert_equal 4, "abcabc".rindex(/b/)
+  # the last position a match starts at, so the longer match at 2 loses to
+  # the shorter one at 3
+  assert_equal 3, "hello".rindex(/l+/)
+  # and overlapping matches are in view: a walk that resumed at the match end
+  # would answer 0 here
+  assert_equal 1, "aaa".rindex(/aa/)
+
+  # the position bounds where the match starts, not where it ends
+  assert_equal 1, "abcabc".rindex(/bca/, 1)
+  assert_nil "abcabc".rindex(/bca/, 0)
+  assert_equal 2, "hello".rindex(/l/, 2)
+  assert_equal 3, "hello".rindex(/l/, -1)
+
+  # past the end of the subject clamps to it, where past the negative end is
+  # a miss
+  assert_equal 3, "hello".rindex(/l/, 10)
+  assert_nil "hello".rindex(/l/, -10)
+end
+
+assert("String#index and String#rindex with regexp set the match globals") do
+  assert_equal 1, "abc".index(/(b)/)
+  assert_equal "b", $1
+  assert_equal "b", Regexp.last_match(0)
+
+  # the match `rindex` stopped on, not one it walked past on the way there
+  assert_equal 4, "abcabc".rindex(/(b)/)
+  assert_equal 4, $~.begin(0)
+
+  # a failed match clears $~, which is why both search through `match` rather
+  # than `match?`
+  "zzz" =~ /z/
+  assert_nil "abc".index(/x/)
+  assert_nil $~
+  "zzz" =~ /z/
+  assert_nil "abc".rindex(/x/)
+  assert_nil $~
+
+  # so does a position that lands outside the subject
+  "zzz" =~ /z/
+  assert_nil "abc".index(/b/, 10)
+  assert_nil $~
+  "zzz" =~ /z/
+  assert_nil "abc".rindex(/b/, -10)
+  assert_nil $~
+
+  # and so does a match that starts past what the search asked for: `rindex`
+  # walks past it and does not leave it behind
+  "zzz" =~ /z/
+  assert_nil "abc".rindex(/c/, 1)
+  assert_nil $~
+end
+
+assert("String#index and String#rindex delegate every non-regexp argument") do
+  assert_equal 2, "hello".index("l")
+  assert_equal 3, "hello".index("l", 3)
+  assert_nil "hello".index("z")
+  assert_equal 3, "hello".rindex("l")
+  assert_equal 2, "hello".rindex("l", 2)
+  assert_nil "hello".rindex("z")
+
+  # a delegated call still gets the C arity check and the C errors
+  assert_raise(ArgumentError) { "hello".index }
+  assert_raise(ArgumentError) { "hello".rindex }
+  assert_raise(TypeError) { "hello".index(1) }
+  assert_raise(TypeError) { "hello".rindex(1) }
+  assert_raise(TypeError) { "hello".index("l", nil) }
+
+  # and the regexp form takes the arguments the C form takes
+  assert_raise(ArgumentError) { "hello".index(/l/, 1, 2) }
+  assert_raise(ArgumentError) { "hello".rindex(/l/, 1, 2) }
+  assert_raise(TypeError) { "hello".index(/l/, nil) }
+  assert_raise(TypeError) { "hello".rindex(/l/, nil) }
+
+  # `is_a?` is redefinable, so a Regexp denying its own type must still be
+  # searched for, and an object claiming to be one must not be
+  re = /l+/
+  def re.is_a?(klass); false; end
+  assert_equal 2, "hello".index(re)
+  assert_equal 3, "hello".rindex(re)
+
+  fake = Object.new
+  def fake.is_a?(klass); true; end
+  def fake.match(str, pos = 0); raise "must not be called"; end
+  assert_raise(TypeError) { "hello".index(fake) }
+  assert_raise(TypeError) { "hello".rindex(fake) }
+end


### PR DESCRIPTION
Seven `String` methods take a Regexp in CRuby and reach a C implementation here
that converts the argument to a String, so a Regexp is a `TypeError`. Four are
core (`index`, `rindex`, `byteindex` and `byterindex`, in `src/string.c`); the
other three come from mruby-string-ext (`partition`, `rpartition` and
`start_with?`), which mruby-regexp already depends on, so an override in the
gem's mrblib reaches both sets.

```ruby
"abc".index(/b/)        # CRuby: 1,    mruby: TypeError
"abc".rindex(/b/)       # CRuby: 1,    mruby: TypeError
"abc".byteindex(/b/)    # CRuby: 1,    mruby: TypeError
"abc".byterindex(/b/)   # CRuby: 1,    mruby: TypeError
"abc".partition(/b/)    # CRuby: ["a", "b", "c"], mruby: TypeError
"abc".rpartition(/b/)   # CRuby: ["a", "b", "c"], mruby: TypeError
"abc".start_with?(/a/)  # CRuby: true, mruby: TypeError
```

Nothing is unreachable today, since `=~` and `String#[]` cover the same ground.
What is missing is the spelling CRuby code uses, which means code carried over
raises instead of running.

This finishes the family. `String#[]` and `#slice` arrived in 46d88a80a,
`#sub!` and `#gsub!` in #7061, `#[]=` and `#slice!` in #7063; none of the three
touched any of these seven. `String#end_with?` is deliberately not in the list:
CRuby rejects a Regexp there too, and so does this build, so the two already
agree.

## Shape of the change

`mrbgems/mruby-regexp/mrblib/string_regexp.rb` already had the pattern to copy.
Each C method is captured under a private alias before the override replaces
it, and the override tests the argument with `Regexp === arg` rather than
`is_a?`, which is redefinable: anything that is not a Regexp goes back to the
captured C method untouched, so it keeps the C arity check and the C error
messages. The note at the top of that file sets out how far that guard goes and
where it stops.

One commit per pair, in the order the methods depend on each other, and a
last one for the README: the seven join the list of String methods that take
a Regexp here, and the walk described below joins the limitations.

`index` hands its position argument to `Regexp#match` unexamined: the two
normalize a position the same way and read it with the same `mrb_get_args()`
conversion.

`rindex` wants the last match that starts at or before its position, and the
match may run past that position, so `"abcabc".rindex(/bca/, 1)` is 1. The
engine has no backward search, so `__regexp_rsearch` walks the subject from the
start and keeps the last match that qualifies. That is linear in the number of
positions a match starts at, where the backward search CRuby hands to Onig is
not, which is the one cost worth naming here. Each step resumes one character
past the match start rather than at the match end, without which overlapping
matches stay invisible and `"aaa".rindex(/aa/)` answers 0 instead of 1.

`byteindex` and `byterindex` are the same two searches read in byte space.
`MatchData#begin` reports character offsets, which is the convention the rest of
the gem follows, so these two read `__byte_begin` instead. On a build without
`MRB_UTF8_STRING` the two spaces coincide and each pair answers the same number.

`partition` and `rpartition` build their three pieces from the match, so the row
worth naming is the one with no match, where the subject stays whole and the two
put it at opposite ends. The copy is a plain String even for a String subclass
receiver, as `mrb_str_dup()` and CRuby's `str_duplicate(rb_cString, str)` both
hand back. `rpartition` shares `__regexp_rsearch` with `rindex`.

`start_with?` reads its arguments left to right and hands each non-regexp one to
the C method one at a time, so a String keeps the C comparison and its error. A
regexp is anchored at the start rather than searched for, so the override checks
`begin(0) == 0`; the engine matches leftmost, so a pattern that can match at 0
does, which makes that check the anchored answer rather than an approximation of
it. `"abc".start_with?(/b/)` and `"abc\ndef".start_with?(/^d/)` are both false.

Two details the existing overrides settle already, and these follow:

- The match globals. Each search goes through `match` and not `match?`, so `$~`
  and the names derived from it are published, including the clearing a failed
  match does. CRuby sets them for all seven and clears them after a miss. That
  extends to the misses that are not a failed search: a position outside the
  subject, a match that starts past what `rindex` asked for, and a match
  `start_with?` refuses for starting later than 0 all leave the globals cleared.
  A non-regexp argument does not touch them, which falls out of leaving it to C.
- Character offsets against byte offsets, as above.

## Tests

`mrbgems/mruby-regexp/test/regexp.rb`, after the `String#[]`, `#[]=` and
`#slice!` regexp groups at the end of the file, in the same three groups per
method pair: the search itself, the match globals, and the delegation of every
non-regexp argument. The multibyte rows sit behind `__ENCODING__ == "UTF-8"`,
which is what the file already uses for the character-offset cases.

## Checked

Every row above, and every row in the new tests, was run against CRuby 4.0.6 and
compared: a table of 93 calls covering all seven methods, their positions at
both ends of the subject, their globals after a hit and after each kind of miss,
and the errors raised, is identical between the two, on the default build and on
one with `MRB_UTF8_STRING`. A second table of 37 multibyte calls is identical
too. `rake test` passes on both builds.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added regular-expression support to string search, partition, and prefix-checking methods.
  * Added forward and reverse searches with character- and byte-based position handling.
  * Added support for multiple patterns, anchored prefix checks, and match result tracking.

* **Bug Fixes**
  * Improved validation and handling of positions, empty matches, multibyte text, and invalid arguments.
  * Preserved existing behavior for non-regular-expression arguments.

* **Documentation**
  * Documented regular-expression support and reverse-search behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
