### PR TITLE
mruby-regexp: list `String#sub!` and `#gsub!` in the README

### DIFF
--- a/mrbgems/mruby-regexp/README.md
+++ b/mrbgems/mruby-regexp/README.md
@@ -85,6 +85,10 @@ str.sub(re, replacement)          # replace first occurrence
 str.sub(re) { |m| ... }           # replace with block
 str.gsub(re, replacement)         # replace all occurrences
 str.gsub(re) { |m| ... }          # replace all with block
+str.sub!(re, replacement)         # => self, or nil if no match
+str.sub!(re) { |m| ... }          # same, replacing with the block result
+str.gsub!(re, replacement)        # => self, or nil if no match
+str.gsub!(re) { |m| ... }         # same, replacing with the block result
 str.scan(re)                      # => array of matches
 str.split(re)                     # => array of parts
 str[re]                           # => matched substring or nil


### PR DESCRIPTION
The `Ruby API` section of `mrbgems/mruby-regexp/README.md` lists the String
methods that take a Regexp in this gem. The bang pair added in b4f41f8d0
(#7061) never reached that list, so the README still reads as though only
`sub` and `gsub` accept a pattern.

```ruby
s = "hello world"
s.sub!(/o/, "0")   # => "hell0 world", documented nowhere
```

Documentation only, no behavior change. The four spellings go next to the
non-bang pair they mirror, and the comment states the one thing the bang form
differs on: self when a substitution took place and nil when the pattern did
not match, which is what `sub!` answers there today.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added documentation for the mutating `String` replacement methods `sub!` and `gsub!`.
  - Clarified supported replacement-string and block forms, along with return behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->