### PR TITLE
mruby-regexp: close the pattern dispatch in the String overrides

### DIFF
--- a/mrbgems/mruby-regexp/mrblib/string_regexp.rb
+++ b/mrbgems/mruby-regexp/mrblib/string_regexp.rb
@@ -115,7 +115,7 @@ class String
     if args.length == 2
       return pattern.__sub_str(self, replacement.to_s)
     end
-    md = pattern.match(self)
+    md = Regexp.__search(pattern, self)
     return self.dup unless md
     md.pre_match + block.call(md[0]).to_s + md.post_match
   end
@@ -140,8 +140,8 @@ class String
     raise FrozenError, "can't modify frozen String" if frozen?
     # Whether a substitution happened is a question about the match, not about
     # the result: `"aaa".sub!(/a/, "a")` returns self even though the string is
-    # unchanged.  `match` and not `match?`, so a failed match clears $~.
-    return nil unless pattern.match(self)
+    # unchanged.  A full search and not `match?`, so a failed match clears $~.
+    return nil unless Regexp.__search(pattern, self)
     # `sub` matches again and publishes its own $~ over this one, leaving the
     # caller the match `sub` would have left, a block's own matches included.
     # The resolved pattern takes the place of the original argument so that a
@@ -223,10 +223,10 @@ class String
     return to_enum(:gsub!, *args) if args.length == 1 && !block
     pattern = Regexp.__check_pattern(args[0])
     pattern = Regexp.new(Regexp.escape(pattern)) if String === pattern
-    # As in `sub!`: the match decides the return value, and `match` clears $~
-    # when it fails.  What it publishes on success is replaced right away by
-    # the last match of the `gsub` below, which is the one CRuby leaves behind.
-    return nil unless pattern.match(self)
+    # As in `sub!`: the match decides the return value, and a failed search
+    # clears $~.  What it publishes on success is replaced right away by the
+    # last match of the `gsub` below, which is the one CRuby leaves behind.
+    return nil unless Regexp.__search(pattern, self)
     str = args.length == 2 ? self.gsub(pattern, args[1], &block) : self.gsub(pattern, &block)
     self.replace(str)
   end
@@ -350,11 +350,11 @@ class String
     if args.length > 2
       raise ArgumentError, "wrong number of arguments (given #{args.length}, expected 1..2)"
     end
-    # `match` and not `match?`: the match globals have to be published here,
-    # including the clearing a failed match does, and `match?` leaves them
-    # alone.  That is why the MatchData is fetched even with no capture
+    # A full search and not `match?`: the match globals have to be published
+    # here, including the clearing a failed match does, and `match?` leaves
+    # them alone.  That is why the MatchData is fetched even with no capture
     # argument, where only its `[0]` is used.
-    md = args[0].match(self)
+    md = Regexp.__search(args[0], self)
     return nil unless md
     # The capture argument reaches `MatchData#[]` untouched: it already
     # normalizes a negative index, answers nil for an index past the last
@@ -383,13 +383,13 @@ class String
     unless args.length == 2 || args.length == 3
       raise ArgumentError, "wrong number of arguments (given #{args.length}, expected 2..3)"
     end
-    # `match` and not `match?`, so that the match globals are published here
-    # including the clearing a failed match does.  CRuby searches before it
-    # checks the receiver for modification, which makes the order observable:
-    # a frozen receiver still leaves the match behind, and a pattern that does
-    # not match raises IndexError rather than FrozenError.  Letting the
-    # mutation below be what raises reproduces both.
-    md = args[0].match(self)
+    # A full search and not `match?`, so that the match globals are published
+    # here including the clearing a failed match does.  CRuby searches before
+    # it checks the receiver for modification, which makes the order
+    # observable: a frozen receiver still leaves the match behind, and a
+    # pattern that does not match raises IndexError rather than FrozenError.
+    # Letting the mutation below be what raises reproduces both.
+    md = Regexp.__search(args[0], self)
     raise IndexError, "regexp not matched" unless md
     group = args.length > 2 ? args[1] : 0
     if Integer === group
@@ -434,7 +434,7 @@ class String
     # the C check is not, but no other route to that check leaves the string
     # alone on the way.
     raise FrozenError, "can't modify frozen String" if frozen?
-    md = args[0].match(self)
+    md = Regexp.__search(args[0], self)
     return nil unless md
     group = args.length > 1 ? args[1] : 0
     if Integer === group
@@ -467,12 +467,13 @@ class String
     if args.length > 2
       raise ArgumentError, "wrong number of arguments (given #{args.length}, expected 1..2)"
     end
-    # `Regexp#match` normalizes a position the way `index` does and reads it
-    # with the same `mrb_get_args()` conversion, so the argument goes over
+    # `Regexp.__search` normalizes a position the way `index` does and reads
+    # it with the same `mrb_get_args()` conversion, so the argument goes over
     # unexamined: a negative one counts back from the end, and one that lands
     # outside the subject answers nil after clearing the match globals.
-    # `match` and not `match?`, because those globals are part of the answer.
-    md = args.length > 1 ? args[0].match(self, args[1]) : args[0].match(self)
+    # A full search and not `match?`, because those globals are part of the
+    # answer.
+    md = args.length > 1 ? Regexp.__search(args[0], self, args[1]) : Regexp.__search(args[0], self)
     # `begin` reports character offsets, which is the space `index` answers
     # in; `byteindex` below is the same search read in the other space.
     md && md.begin(0)
@@ -492,15 +493,15 @@ class String
   def __regexp_rsearch(pattern, limit, bytes)
     found = nil
     pos = 0
-    while (md = pattern.match(self, pos))
+    while (md = Regexp.__search(pattern, self, pos))
       break if (bytes ? md.__byte_begin(0) : md.begin(0)) > limit
       found = md
       pos = md.begin(0) + 1
     end
-    # The loop leaves behind whatever its last `match` published: the clear a
+    # The loop leaves behind whatever its last search published: the clear a
     # failed one does, or a match past `limit` that is not the answer.  Both
     # have to give way to what the search found.
-    found ? found.__set_globals : pattern.match(nil)
+    found ? found.__set_globals : Regexp.__search(pattern, nil)
     found
   end
 
@@ -523,7 +524,7 @@ class String
         pos += len
         # Out of the subject at the negative end is a miss, and a miss
         # clears the match globals.
-        return args[0].match(nil) if pos < 0
+        return Regexp.__search(args[0], nil) if pos < 0
       elsif pos > len
         # Past the other end is not: `rindex` searches back from the end of
         # the subject, and `mrb_str_byterindex_m()` clamps for the same
@@ -549,12 +550,12 @@ class String
       pos += len if pos < 0
     end
     # `__byte_match` takes the position as given and does not range check it,
-    # where `Regexp#match` answers nil for one outside the subject.  Both
+    # where `Regexp.__search` answers nil for one outside the subject.  Both
     # ends are a miss here, as they are for `mrb_str_byteindex_m()`.  An
     # offset that lands inside a character is not an error: the C method does
     # not check for one either, and on a build without MRB_UTF8_STRING there
     # is nothing to check.
-    return args[0].match(nil) if pos < 0 || pos > len
+    return Regexp.__search(args[0], nil) if pos < 0 || pos > len
     md = args[0].__byte_match(self, pos)
     md && md.__byte_begin(0)
   end
@@ -572,7 +573,7 @@ class String
       pos = Integer.__ensure(args[1])
       if pos < 0
         pos += len
-        return args[0].match(nil) if pos < 0
+        return Regexp.__search(args[0], nil) if pos < 0
       elsif pos > len
         pos = len
       end
@@ -585,7 +586,7 @@ class String
   # (aliased as `__partition` above) for every other argument.
   def partition(sep)
     return __partition(sep) unless Regexp === sep
-    md = sep.match(self)
+    md = Regexp.__search(sep, self)
     # No match leaves the whole subject in the head, and the copy is a plain
     # String even when the receiver is a subclass, as `mrb_str_dup()` and
     # CRuby's `str_duplicate(rb_cString, str)` both hand back.
@@ -615,16 +616,17 @@ class String
     while i < args.length
       arg = args[i]
       if Regexp === arg
-        # A regexp is anchored at the start, not searched for, while `match`
-        # searches forward from its position.  The engine matches leftmost,
-        # so a pattern that can match at 0 does, which makes `begin(0) == 0`
-        # the anchored answer rather than an approximation of it.
-        md = arg.match(self)
+        # A regexp is anchored at the start, not searched for, while the
+        # search runs forward from its position.  The engine matches
+        # leftmost, so a pattern that can match at 0 does, which makes
+        # `begin(0) == 0` the anchored answer rather than an approximation
+        # of it.
+        md = Regexp.__search(arg, self)
         return true if md && md.begin(0) == 0
         # A match further along is not an answer and CRuby leaves none
-        # behind for one, so clear what the search published.  Matching
-        # against nil is how a Regexp clears the globals.
-        arg.match(nil) if md
+        # behind for one, so clear what the search published.  Searching
+        # nil is how the globals are cleared.
+        Regexp.__search(arg, nil) if md
       elsif __start_with?(arg)
         return true
       end

--- a/mrbgems/mruby-regexp/mrblib/string_regexp.rb
+++ b/mrbgems/mruby-regexp/mrblib/string_regexp.rb
@@ -174,13 +174,13 @@ class String
     pos = 0
     len = self.bytesize
     binary = Regexp.__binary_string?(self)
-    # The loop normally ends on a failed __byte_match, which clears $~ and the
-    # thirteen names that go with it. CRuby leaves the last match behind, so
-    # keep it and republish it below. A gsub that matched nothing has nothing
-    # to restore and keeps the cleared state, as CRuby does.
+    # The loop normally ends on a failed __byte_search, which clears $~ and
+    # the thirteen names that go with it. CRuby leaves the last match behind,
+    # so keep it and republish it below. A gsub that matched nothing has
+    # nothing to restore and keeps the cleared state, as CRuby does.
     last = nil
     while pos <= len
-      md = pattern.__byte_match(self, pos)
+      md = Regexp.__byte_search(pattern, self, pos)
       break unless md
       last = md
       # gsub works in byte space (match pos, byteslice). begin/end report
@@ -283,7 +283,7 @@ class String
         result << (self.byteslice(field_start..-1) || "")
         return result
       end
-      md = pattern.__byte_match(self, search_pos)
+      md = Regexp.__byte_search(pattern, self, search_pos)
       break unless md
       match_start = md.__byte_begin(0)
       match_end = md.__byte_end(0)
@@ -549,14 +549,14 @@ class String
       pos = Integer.__ensure(args[1])
       pos += len if pos < 0
     end
-    # `__byte_match` takes the position as given and does not range check it,
-    # where `Regexp.__search` answers nil for one outside the subject.  Both
-    # ends are a miss here, as they are for `mrb_str_byteindex_m()`.  An
+    # `__byte_search` takes the position as given and does not range check
+    # it, where `Regexp.__search` answers nil for one outside the subject.
+    # Both ends are a miss here, as they are for `mrb_str_byteindex_m()`.  An
     # offset that lands inside a character is not an error: the C method does
     # not check for one either, and on a build without MRB_UTF8_STRING there
     # is nothing to check.
     return Regexp.__search(args[0], nil) if pos < 0 || pos > len
-    md = args[0].__byte_match(self, pos)
+    md = Regexp.__byte_search(args[0], self, pos)
     md && md.__byte_begin(0)
   end
 

--- a/mrbgems/mruby-regexp/mrblib/string_regexp.rb
+++ b/mrbgems/mruby-regexp/mrblib/string_regexp.rb
@@ -9,32 +9,27 @@
 # check to reject everything that is not a Regexp.  `[]`, `[]=` and `slice!`
 # read the real class with `Regexp === pattern` and leave anything else to the
 # built-in method they aliased.  `=~` rejects a String, which would recurse
-# back into this method, and hands anything else to the argument's own `=~`,
-# as CRuby does.
+# back into this method, and hands anything that is not a Regexp to the
+# argument's own `=~`, as CRuby does.
 #
-# That is where the guarantee ends.  With the type established, each override
-# calls ordinary methods on the pattern (`match`, `match?`, `=~`,
-# `__byte_match`, `__sub_str`, `__gsub_str`, `__scan`) and on the MatchData it
-# hands back (`[]`, `pre_match`, `post_match`, `begin`, `end`, `size`,
-# `length`, `__byte_begin`, `__byte_end`, `__set_globals`).  Every one of
-# those is defined with `mrb_define_method()`, so a singleton method on the
-# pattern replaces it and the override follows the replacement; the `__`
-# prefix is a naming convention, not a protection.
+# With the type established, each override reaches the engine through class
+# methods that take the pattern as an argument (`Regexp.__search`,
+# `__byte_search`, `__search_p`, `__sub_str`, `__gsub_str`, `__scan`), so
+# nothing rewritten on the pattern instance is consulted on the way: the C
+# side searches, and the loops and blocks stay here.  The MatchData those
+# searches answer is built in C too, so what the overrides read from it
+# (`[]`, `pre_match`, `begin` and the rest) cannot have been planted by an
+# argument.  What remains reachable is a class-wide redefinition of a
+# MatchData method, which is the same category as redefining `String#sub`
+# itself and is not steered by the argument.
 #
-# CRuby is open the same way in `rb_str_match_m()`, which dispatches `match` to
-# the pattern on purpose, and closed everywhere else: `rb_str_sub_bang()`,
-# `rb_str_subpat()`, `rb_str_subpat_set()` and `rb_str_slice_bang()` call
-# `rb_reg_search()` directly, and `String#match?` and `String#=~` search a real
-# Regexp without asking it anything.  The overrides here dispatch on every
-# path, so a rewritten pattern reaches results CRuby would not give it.
-#
-# The gem accepts that rather than closing it.  Reaching it takes rewriting a
-# method on a Regexp instance and then passing that instance to a String
-# method; nothing here is reachable from ordinary input, because an argument
-# that is not a Regexp is rejected, compiled into a Regexp built here, or left
-# to the built-in method the override aliased; `=~` alone forwards it to the
-# argument, which CRuby does too.  The type checks in front of the searches
-# are claims about the argument, not about a pattern its owner has rewritten.
+# `String#match` is the one deliberate exception: it dispatches `match` to
+# the pattern because CRuby's `rb_str_match_m()` does so on purpose, and
+# following that is the correct behaviour, not a hole.  The `=~` forward for
+# a non-Regexp argument is the same shape, from `rb_str_match()`.  Everywhere
+# else the gem is closed the way CRuby is: `rb_str_sub_bang()`,
+# `rb_str_subpat()` and the rest reach the engine without asking the pattern
+# anything.
 class String
   # Capture the C-defined String#split under `__split` before the override
   # below replaces it, so the override can delegate non-regexp patterns

--- a/mrbgems/mruby-regexp/mrblib/string_regexp.rb
+++ b/mrbgems/mruby-regexp/mrblib/string_regexp.rb
@@ -78,10 +78,13 @@ class String
     re.match(self, pos, &block)
   end
 
+  # Unlike `match`, the search does not dispatch on the pattern: CRuby's
+  # `rb_str_match_m_p()` resolves the argument and searches it directly,
+  # where `rb_str_match_m()` sends `match` to it on purpose.
   def match?(re, pos = 0)
     re = Regexp.__check_pattern(re)
     re = Regexp.new(re) if String === re
-    re.match?(self, pos)
+    Regexp.__search_p(re, self, pos)
   end
 
   def =~(re)
@@ -90,6 +93,13 @@ class String
     # redefinable, so a String subclass denying its own type would slip past
     # the guard and recurse anyway; `Module#===` reads the real type.
     raise TypeError, "type mismatch: String given" if String === re
+    # A real Regexp is searched here rather than asked, as CRuby's
+    # `rb_str_match()` does: it sends `=~` to the argument only when the
+    # argument is not a Regexp, which is what the tail below keeps doing.
+    if Regexp === re
+      md = Regexp.__search(re, self)
+      return md && md.begin(0)
+    end
     re =~ self
   end
 

--- a/mrbgems/mruby-regexp/mrblib/string_regexp.rb
+++ b/mrbgems/mruby-regexp/mrblib/string_regexp.rb
@@ -113,7 +113,7 @@ class String
     pattern = Regexp.new(Regexp.escape(pattern)) if String === pattern
     # A replacement argument wins over the block, as in CRuby.
     if args.length == 2
-      return pattern.__sub_str(self, replacement.to_s)
+      return Regexp.__sub_str(pattern, self, replacement.to_s)
     end
     md = Regexp.__search(pattern, self)
     return self.dup unless md
@@ -167,7 +167,7 @@ class String
     pattern = Regexp.new(Regexp.escape(pattern)) if String === pattern
     # A replacement argument wins over the block, as in CRuby.
     if args.length == 2
-      return pattern.__gsub_str(self, replacement.to_s)
+      return Regexp.__gsub_str(pattern, self, replacement.to_s)
     end
     # block case: keep in Ruby to avoid VM callback from C
     parts = []
@@ -234,7 +234,7 @@ class String
   def scan(pattern)
     pattern = Regexp.__check_pattern(pattern)
     pattern = Regexp.new(Regexp.escape(pattern)) if String === pattern
-    result = pattern.__scan(self)
+    result = Regexp.__scan(pattern, self)
     if block_given?
       result.each { |m| yield m }
       self

--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -1080,15 +1080,16 @@ has_backslash(const char *s, mrb_int len)
 }
 
 /*
- * Regexp#__gsub_str(str, replacement) - gsub core without block
+ * Regexp.__gsub_str(re, str, replacement) - gsub core without block
  */
 static mrb_value
-regexp_gsub_str(mrb_state *mrb, mrb_value self)
+regexp_s_gsub_str(mrb_state *mrb, mrb_value klass)
 {
-  mrb_value str, replacement;
-  mrb_get_args(mrb, "SS", &str, &replacement);
+  mrb_value re, str, replacement;
+  mrb_get_args(mrb, "oSS", &re, &str, &replacement);
+  check_regexp_arg(mrb, re);
 
-  mrb_regexp_pattern *pat = DATA_GET_PTR(mrb, self, &regexp_type, mrb_regexp_pattern);
+  mrb_regexp_pattern *pat = DATA_GET_PTR(mrb, re, &regexp_type, mrb_regexp_pattern);
   if (!pat) mrb_raise(mrb, E_ARGUMENT_ERROR, "uninitialized Regexp");
 
   const char *s = RSTRING_PTR(str);
@@ -1159,7 +1160,7 @@ regexp_gsub_str(mrb_state *mrb, mrb_value self)
 
   /* set $~ from last match */
   if (last_ncap > 0) {
-    create_matchdata(mrb, self, str, last_captures, last_ncap);
+    create_matchdata(mrb, re, str, last_captures, last_ncap);
   }
   else {
     clear_match_globals(mrb);
@@ -1169,15 +1170,16 @@ regexp_gsub_str(mrb_state *mrb, mrb_value self)
 }
 
 /*
- * Regexp#__sub_str(str, replacement) - sub core without block
+ * Regexp.__sub_str(re, str, replacement) - sub core without block
  */
 static mrb_value
-regexp_sub_str(mrb_state *mrb, mrb_value self)
+regexp_s_sub_str(mrb_state *mrb, mrb_value klass)
 {
-  mrb_value str, replacement;
-  mrb_get_args(mrb, "SS", &str, &replacement);
+  mrb_value re, str, replacement;
+  mrb_get_args(mrb, "oSS", &re, &str, &replacement);
+  check_regexp_arg(mrb, re);
 
-  mrb_regexp_pattern *pat = DATA_GET_PTR(mrb, self, &regexp_type, mrb_regexp_pattern);
+  mrb_regexp_pattern *pat = DATA_GET_PTR(mrb, re, &regexp_type, mrb_regexp_pattern);
   if (!pat) mrb_raise(mrb, E_ARGUMENT_ERROR, "uninitialized Regexp");
 
   const char *s = RSTRING_PTR(str);
@@ -1216,21 +1218,22 @@ regexp_sub_str(mrb_state *mrb, mrb_value self)
     mrb_str_cat(mrb, result, s + captures[1], slen - captures[1]);
   }
 
-  create_matchdata(mrb, self, str, captures, cap_size);
+  create_matchdata(mrb, re, str, captures, cap_size);
   mrb_free(mrb, captures);
   return result;
 }
 
 /*
- * Regexp#__scan(str) - scan core, returns array
+ * Regexp.__scan(re, str) - scan core, returns array
  */
 static mrb_value
-regexp_scan(mrb_state *mrb, mrb_value self)
+regexp_s_scan(mrb_state *mrb, mrb_value klass)
 {
-  mrb_value str;
-  mrb_get_args(mrb, "S", &str);
+  mrb_value re, str;
+  mrb_get_args(mrb, "oS", &re, &str);
+  check_regexp_arg(mrb, re);
 
-  mrb_regexp_pattern *pat = DATA_GET_PTR(mrb, self, &regexp_type, mrb_regexp_pattern);
+  mrb_regexp_pattern *pat = DATA_GET_PTR(mrb, re, &regexp_type, mrb_regexp_pattern);
   if (!pat) mrb_raise(mrb, E_ARGUMENT_ERROR, "uninitialized Regexp");
 
   const char *s = RSTRING_PTR(str);
@@ -1293,7 +1296,7 @@ regexp_scan(mrb_state *mrb, mrb_value self)
   mrb_free(mrb, captures);
 
   if (last_ncap > 0) {
-    create_matchdata(mrb, self, str, last_captures, last_ncap);
+    create_matchdata(mrb, re, str, last_captures, last_ncap);
   }
   else {
     clear_match_globals(mrb);
@@ -1363,9 +1366,9 @@ mrb_mruby_regexp_gem_init(mrb_state *mrb)
   mrb_define_method(mrb, re, "hash", regexp_hash, MRB_ARGS_NONE());
   mrb_define_method(mrb, re, "options", regexp_options, MRB_ARGS_NONE());
   mrb_define_method(mrb, re, "casefold?", regexp_casefold_p, MRB_ARGS_NONE());
-  mrb_define_method(mrb, re, "__gsub_str", regexp_gsub_str, MRB_ARGS_REQ(2));
-  mrb_define_method(mrb, re, "__sub_str", regexp_sub_str, MRB_ARGS_REQ(2));
-  mrb_define_method(mrb, re, "__scan", regexp_scan, MRB_ARGS_REQ(1));
+  mrb_define_class_method(mrb, re, "__gsub_str", regexp_s_gsub_str, MRB_ARGS_REQ(3));
+  mrb_define_class_method(mrb, re, "__sub_str", regexp_s_sub_str, MRB_ARGS_REQ(3));
+  mrb_define_class_method(mrb, re, "__scan", regexp_s_scan, MRB_ARGS_REQ(2));
 
   /* MatchData class */
   struct RClass *md = mrb_define_class(mrb, "MatchData", mrb->object_class);

--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -448,13 +448,23 @@ regexp_s_search(mrb_state *mrb, mrb_value klass)
   return exec_match(mrb, re, str, pos);
 }
 
+/*
+ * Regexp.__byte_search(re, str, pos = 0)
+ *
+ * Internal: the byte-offset search the mrblib loops of `gsub`, `split` and
+ * `byteindex` drive themselves. No position normalization, because the
+ * callers already work in byte space, and no operand conversion, because
+ * they always pass a String.
+ */
 static mrb_value
-regexp_match_byte(mrb_state *mrb, mrb_value self)
+regexp_s_byte_search(mrb_state *mrb, mrb_value klass)
 {
-  mrb_value str;
+  mrb_value re, str;
   mrb_int pos = 0;
-  mrb_get_args(mrb, "S|i", &str, &pos);
-  return exec_match(mrb, self, str, pos);
+
+  mrb_get_args(mrb, "oS|i", &re, &str, &pos);
+  check_regexp_arg(mrb, re);
+  return exec_match(mrb, re, str, pos);
 }
 
 /*
@@ -887,8 +897,8 @@ matchdata_byte_end(mrb_state *mrb, mrb_value self)
 }
 
 /* Private: republish $~ and the thirteen names derived from it. Used by the
-   mrblib loops that drive __byte_match themselves, where the failing call
-   that ends the loop clears the match the loop is supposed to leave behind.
+   mrblib loops that drive Regexp.__byte_search themselves, where the failing
+   call that ends the loop clears the match the loop is supposed to leave behind.
    The names other than $~ are not assignable from Ruby, so restoring them
    has to come from here. */
 static mrb_value
@@ -1338,10 +1348,10 @@ mrb_mruby_regexp_gem_init(mrb_state *mrb)
   mrb_define_class_method(mrb, re, "__binary_string?", regexp_binary_string_p, MRB_ARGS_REQ(1));
   mrb_define_class_method(mrb, re, "__check_pattern", regexp_check_pattern, MRB_ARGS_REQ(1));
   mrb_define_class_method(mrb, re, "__search", regexp_s_search, MRB_ARGS_ARG(2, 1));
+  mrb_define_class_method(mrb, re, "__byte_search", regexp_s_byte_search, MRB_ARGS_ARG(2, 1));
 
   /* Instance methods */
   mrb_define_method(mrb, re, "match", regexp_match, MRB_ARGS_ARG(1, 1)|MRB_ARGS_BLOCK());
-  mrb_define_method(mrb, re, "__byte_match", regexp_match_byte, MRB_ARGS_ARG(1, 1));
   mrb_define_method(mrb, re, "match?", regexp_match_p, MRB_ARGS_ARG(1, 1));
   mrb_define_method(mrb, re, "=~", regexp_match_op, MRB_ARGS_REQ(1));
   mrb_define_method(mrb, re, "===", regexp_case_match, MRB_ARGS_REQ(1));

--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -467,6 +467,25 @@ regexp_s_byte_search(mrb_state *mrb, mrb_value klass)
   return exec_match(mrb, re, str, pos);
 }
 
+/* Internal: the search of `match?`, run with a NULL capture buffer so that
+   it allocates no MatchData and leaves the match globals alone, which is the
+   whole point of `match?`. */
+static mrb_value
+exec_match_p(mrb_state *mrb, mrb_value re, mrb_value str, mrb_int pos)
+{
+  if (mrb_nil_p(str)) return mrb_false_value();
+  str = match_operand(mrb, str);
+  pos = re_char_to_byte(mrb, str, pos);
+  if (pos < 0) return mrb_false_value();
+
+  mrb_regexp_pattern *pat = DATA_GET_PTR(mrb, re, &regexp_type, mrb_regexp_pattern);
+  if (!pat) mrb_raise(mrb, E_ARGUMENT_ERROR, "uninitialized Regexp");
+
+  int ncap = mrb_re_exec(mrb, pat, RSTRING_PTR(str), RSTRING_LEN(str), pos, NULL, 0,
+                         re_binary_string_p(str));
+  return mrb_bool_value(ncap > 0);
+}
+
 /*
  * Regexp#match?(str, pos=0)
  */
@@ -476,17 +495,24 @@ regexp_match_p(mrb_state *mrb, mrb_value self)
   mrb_value str;
   mrb_int pos = 0;
   mrb_get_args(mrb, "o|i", &str, &pos);
-  if (mrb_nil_p(str)) return mrb_false_value();
-  str = match_operand(mrb, str);
-  pos = re_char_to_byte(mrb, str, pos);
-  if (pos < 0) return mrb_false_value();
+  return exec_match_p(mrb, self, str, pos);
+}
 
-  mrb_regexp_pattern *pat = DATA_GET_PTR(mrb, self, &regexp_type, mrb_regexp_pattern);
-  if (!pat) mrb_raise(mrb, E_ARGUMENT_ERROR, "uninitialized Regexp");
+/*
+ * Regexp.__search_p(re, str, pos = 0)
+ *
+ * Internal: `Regexp#match?` with the pattern as an argument, for the
+ * `String#match?` override; the same boundary as `Regexp.__search`.
+ */
+static mrb_value
+regexp_s_search_p(mrb_state *mrb, mrb_value klass)
+{
+  mrb_value re, str;
+  mrb_int pos = 0;
 
-  int ncap = mrb_re_exec(mrb, pat, RSTRING_PTR(str), RSTRING_LEN(str), pos, NULL, 0,
-                         re_binary_string_p(str));
-  return mrb_bool_value(ncap > 0);
+  mrb_get_args(mrb, "oo|i", &re, &str, &pos);
+  check_regexp_arg(mrb, re);
+  return exec_match_p(mrb, re, str, pos);
 }
 
 /*
@@ -1352,6 +1378,7 @@ mrb_mruby_regexp_gem_init(mrb_state *mrb)
   mrb_define_class_method(mrb, re, "__check_pattern", regexp_check_pattern, MRB_ARGS_REQ(1));
   mrb_define_class_method(mrb, re, "__search", regexp_s_search, MRB_ARGS_ARG(2, 1));
   mrb_define_class_method(mrb, re, "__byte_search", regexp_s_byte_search, MRB_ARGS_ARG(2, 1));
+  mrb_define_class_method(mrb, re, "__search_p", regexp_s_search_p, MRB_ARGS_ARG(2, 1));
 
   /* Instance methods */
   mrb_define_method(mrb, re, "match", regexp_match, MRB_ARGS_ARG(1, 1)|MRB_ARGS_BLOCK());

--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -404,6 +404,50 @@ regexp_match(mrb_state *mrb, mrb_value self)
   return md;
 }
 
+/* The pattern of a class-method search entry point arrives as an argument
+   rather than as `self`, so its type has to be established here. Every mrblib
+   caller passes a pattern that already went through `Regexp.__check_pattern`
+   or a `Regexp ===` guard, which makes this a backstop, not a gate. */
+static void
+check_regexp_arg(mrb_state *mrb, mrb_value re)
+{
+  if (!mrb_obj_is_kind_of(mrb, re, mrb_class_get_id(mrb, MRB_SYM(Regexp)))) {
+    mrb_raisef(mrb, E_TYPE_ERROR, "wrong argument type %s (expected Regexp)",
+               mrb_obj_classname(mrb, re));
+  }
+}
+
+/*
+ * Regexp.__search(re, str, pos = 0)
+ *
+ * Internal: `Regexp#match` with the pattern as an argument and no block form.
+ * The String overrides in mrblib search through this so that the search never
+ * dispatches on the pattern, where a singleton method would replace it; see
+ * the note at the top of mrblib/string_regexp.rb. A nil subject clears the
+ * match globals and answers nil, as `Regexp#match` does, which is what the
+ * overrides use to report a miss.
+ */
+static mrb_value
+regexp_s_search(mrb_state *mrb, mrb_value klass)
+{
+  mrb_value re, str;
+  mrb_int pos = 0;
+
+  mrb_get_args(mrb, "oo|i", &re, &str, &pos);
+  check_regexp_arg(mrb, re);
+  if (mrb_nil_p(str)) {
+    clear_match_globals(mrb);
+    return mrb_nil_value();
+  }
+  str = match_operand(mrb, str);
+  pos = re_char_to_byte(mrb, str, pos);
+  if (pos < 0) {
+    clear_match_globals(mrb);
+    return mrb_nil_value();
+  }
+  return exec_match(mrb, re, str, pos);
+}
+
 static mrb_value
 regexp_match_byte(mrb_state *mrb, mrb_value self)
 {
@@ -1293,6 +1337,7 @@ mrb_mruby_regexp_gem_init(mrb_state *mrb)
   mrb_define_class_method(mrb, re, "quote", regexp_escape, MRB_ARGS_REQ(1));
   mrb_define_class_method(mrb, re, "__binary_string?", regexp_binary_string_p, MRB_ARGS_REQ(1));
   mrb_define_class_method(mrb, re, "__check_pattern", regexp_check_pattern, MRB_ARGS_REQ(1));
+  mrb_define_class_method(mrb, re, "__search", regexp_s_search, MRB_ARGS_ARG(2, 1));
 
   /* Instance methods */
   mrb_define_method(mrb, re, "match", regexp_match, MRB_ARGS_ARG(1, 1)|MRB_ARGS_BLOCK());

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -3080,3 +3080,36 @@ assert("String#start_with? delegates every non-regexp argument") do
   def fake.match(str, pos = 0); raise "must not be called"; end
   assert_raise(TypeError) { "hello".start_with?(fake) }
 end
+
+assert("String overrides search a pattern whose `match` was rewritten") do
+  r = /l+/
+  def r.match(*args); "PWNED"; end
+
+  assert_equal "ll", "hello"[r]
+  assert_equal "ll", "hello".slice(r)
+  assert_equal "heLLo", "hello".sub(r) { |m| m.upcase }
+  assert_equal "heLLo", "hello".dup.sub!(r) { |m| m.upcase }
+  s = "hello".dup
+  s[r] = "X"
+  assert_equal "heXo", s
+  assert_equal "ll", "hello".dup.slice!(r)
+  assert_equal 2, "hello".index(r)
+  assert_equal 3, "hello".rindex(r)
+  assert_equal 2, "hello".byteindex(r)
+  assert_equal 3, "hello".byterindex(r)
+  assert_equal ["he", "ll", "o"], "hello".partition(r)
+  assert_equal ["hel", "l", "o"], "hello".rpartition(r)
+  assert_true "llama".start_with?(r)
+
+  # The quiet half of the same surface: a rewritten `match` answering nil
+  # used to decide the bang forms' return value, so they answered nil and
+  # left the receiver untouched.
+  quiet = /l+/
+  def quiet.match(*args); nil; end
+  s = "hello".dup
+  assert_equal "heXo", s.sub!(quiet, "X")
+  assert_equal "heXo", s
+  s = "hello".dup
+  assert_equal "heXo", s.gsub!(quiet, "X")
+  assert_equal "heXo", s
+end

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -3113,3 +3113,12 @@ assert("String overrides search a pattern whose `match` was rewritten") do
   assert_equal "heXo", s.gsub!(quiet, "X")
   assert_equal "heXo", s
 end
+
+assert("String overrides search a pattern whose `__byte_match` was rewritten") do
+  r = /l+/
+  def r.__byte_match(*args); "PWNED"; end
+
+  assert_equal "heLLo", "hello".gsub(r) { |m| m.upcase }
+  assert_equal ["he", "o"], "hello".split(r)
+  assert_equal 2, "hello".byteindex(r)
+end

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -3123,6 +3123,21 @@ assert("String overrides search a pattern whose `__byte_match` was rewritten") d
   assert_equal 2, "hello".byteindex(r)
 end
 
+assert("String#match? and String#=~ search a real pattern without asking it") do
+  r = /l+/
+  def r.match?(*args); "PWNED"; end
+  def r.=~(*args); 99; end
+
+  assert_true "hello".match?(r)
+  assert_equal 2, "hello" =~ r
+
+  # The forward for everything that is not a Regexp stays: CRuby sends `=~`
+  # to the argument there too.
+  o = Object.new
+  def o.=~(str); 42; end
+  assert_equal 42, "hello" =~ o
+end
+
 assert("String overrides run a pattern whose operation cores were rewritten") do
   r = /l+/
   def r.__sub_str(*args); "PWNED"; end

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -3122,3 +3122,20 @@ assert("String overrides search a pattern whose `__byte_match` was rewritten") d
   assert_equal ["he", "o"], "hello".split(r)
   assert_equal 2, "hello".byteindex(r)
 end
+
+assert("String overrides run a pattern whose operation cores were rewritten") do
+  r = /l+/
+  def r.__sub_str(*args); "PWNED"; end
+  def r.__gsub_str(*args); "PWNED"; end
+  def r.__scan(*args); "PWNED"; end
+
+  assert_equal "heXo", "hello".sub(r, "X")
+  assert_equal "heXo", "hello".gsub(r, "X")
+  assert_equal ["ll"], "hello".scan(r)
+  s = "hello".dup
+  assert_equal "heXo", s.sub!(r, "X")
+  assert_equal "heXo", s
+  s = "hello".dup
+  assert_equal "heXo", s.gsub!(r, "X")
+  assert_equal "heXo", s
+end


### PR DESCRIPTION
Follows #7067, which documented that the String overrides in
`mrbgems/mruby-regexp/mrblib/string_regexp.rb` reach their pattern through
ordinary Ruby-visible methods, and accepted that surface in the file comment.
This PR proposes the other side of that question: close the surface, because
working out the fix showed it is smaller than the comment assumed, and the
boundary it draws is the one CRuby already has.

## What was open

Every override reached the engine by calling methods on the pattern
(`match`, `match?`, `=~`, `__byte_match`, `__sub_str`, `__gsub_str`,
`__scan`), so a method rewritten on a Regexp instance replaced the search
itself, and every String method in this file followed the replacement:

```ruby
r = /l+/
def r.match(*args); "PWNED"; end

"hello"[r]  # CRuby: "ll", mruby: "P"
```

The quietest paths handed back the redefinition's own value with nothing
raising, so the caller had no way to tell:

```ruby
r = /l+/
def r.__sub_str(*args); "PWNED"; end

"hello".sub(r, "X")       # CRuby: "heXo", mruby: "PWNED"
"hello".dup.sub!(r, "X")  # CRuby: "heXo", mruby: "PWNED", written into the receiver
```

`String#match?` and `String#=~` diverged even one level earlier: their CRuby
counterparts `rb_str_match_m_p()` and `rb_str_match()` search a real Regexp
without asking it anything, so for these two the dispatch itself was the
divergence, before any redefinition enters.

## The shape of the fix

The overrides now reach the engine through class methods that take the
pattern as an argument: `Regexp.__search`, `Regexp.__byte_search` and
`Regexp.__search_p` are thin wrappers over the existing `exec_match()`, and
`__sub_str`, `__gsub_str` and `__scan` become class forms of the operation
cores they already were. A class method leaves no instance for a singleton
method to ride on, so the search stops being redefinable while the loops,
blocks and field lists stay in mrblib, which keeps the C side free of
callbacks into the VM.

This is architecture parity with CRuby rather than case-by-case behaviour
parity: CRuby's `rb_str_sub_bang()`, `rb_str_subpat()`, `rb_str_index_m()`
and the rest reach the engine through C internals that never consult the
pattern's method table, and now this gem does the same. Two consequences
fall out rather than being patched individually. A rewritten pattern method
no longer steers any String method, and the MatchData the overrides read
always comes from `create_matchdata()`, so no argument can have planted a
singleton method on it either; what remains reachable is a class-wide
redefinition of a MatchData method, the same category as redefining
`String#sub` itself.

Two dispatches stay, both deliberate and both CRuby's own shape:
`String#match` sends `match` to the pattern because `rb_str_match_m()` does
so on purpose, and `String#=~` still forwards an argument that is not a
Regexp to the argument's own `=~`, as `rb_str_match()` does. The file
comment from #7067 is rewritten in the last commit to describe exactly these
two exceptions instead of the open surface.

## Cost

Four internal instance methods are removed (`__byte_match`, `__sub_str`,
`__gsub_str`, `__scan`) and six class methods added, so the method table
grows by two entries net. The operation core bodies are unchanged apart from
taking the pattern as an argument; the new code is the three thin search
wrappers and a shared type-check backstop.

## Commits

Each commit closes one dispatch and carries a test that rewrites the method
it closes on a pattern instance and asserts the CRuby answer, receivers of
the bang forms included. Every CRuby answer above was checked against
CRuby 4.0.6.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the consistency and reliability of regular-expression operations on strings.
  * String searches, substitutions, scans, slicing, partitioning, and prefix checks now produce expected results even when regular-expression behavior is customized.
  * Preserved match-state handling across supported matching operations.
  * Fixed bang substitution methods to correctly modify the original string and return it when a match is found.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->