### PR TITLE
string.c: a copy of a binary string is binary

### DIFF
--- a/include/mruby/string.h
+++ b/include/mruby/string.h
@@ -98,6 +98,11 @@ struct RStringEmbed {
 #endif
 #define RSTR_SET_ASCII_FLAG(s) RSTR_SET_SINGLE_BYTE_FLAG(s)
 #define RSTR_BINARY_P(s) ((s)->flags & MRB_STR_BINARY)
+/* A copy of a string is byte-indexed exactly when the string it copies is, so
+   the flag travels with the bytes rather than being left behind on the
+   original. */
+#define RSTR_COPY_BINARY_FLAG(dst, src) \
+  ((dst)->flags = ((dst)->flags & ~MRB_STR_BINARY) | RSTR_BINARY_P(src))
 
 /**
  * Returns a pointer from a Ruby string

--- a/mrbgems/mruby-encoding/test/string.rb
+++ b/mrbgems/mruby-encoding/test/string.rb
@@ -28,3 +28,24 @@ assert('String#encoding') do
     assert_equal Encoding::BINARY, a.encoding
   end
 end
+
+assert('String#encoding survives a copy') do
+  # A copy holds the same bytes, so it is byte-indexed exactly when the string
+  # it copies is. The copy used to come back UTF-8, which made `size` and every
+  # offset computed from it read the bytes as characters again.
+  if UTF8STRING
+    a = "\u{1F600}".b   # F0 9F 98 80: four bytes, one character
+    assert_equal Encoding::BINARY, a.dup.encoding
+    assert_equal Encoding::BINARY, a.clone.encoding
+    assert_equal Encoding::BINARY, a.freeze.dup.encoding
+    b = "hello"
+    b.replace(a)
+    assert_equal Encoding::BINARY, b.encoding
+    # and a copy of a UTF-8 string is still UTF-8: the flag is copied, not set
+    c = "\u{1F600}"
+    assert_equal Encoding::UTF_8, c.dup.encoding
+    d = "x".b
+    d.replace(c)
+    assert_equal Encoding::UTF_8, d.encoding
+  end
+end

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -844,6 +844,24 @@ assert("Regexp - an attempt in flight opens no match position inside a character
   assert_equal 2, ("x" + "\xb5").match(/.?[µ]/)[0].bytesize
 end
 
+assert("Regexp - a byte-indexed subject is reported in bytes") do
+  # `String#b` marks the subject byte-indexed, and MatchData snapshots it with
+  # a copy. The copy came back as if it were UTF-8, so #begin counted the
+  # characters of a string that has none, and disagreed with #pre_match, which
+  # counts the same span in bytes.
+  s = "\u{1F600}".b  # F0 9F 98 80: four bytes, one character
+  assert_equal 3, (s =~ Regexp.new("\x80"))
+  assert_equal 3, s.byteindex(Regexp.new("\x80"))
+  md = s.match(Regexp.new("\x80"))
+  assert_equal 3, md.begin(0)
+  assert_equal 4, md.end(0)
+  assert_equal md.pre_match.bytesize, md.begin(0)
+  # the same subject read as UTF-8 counts characters, as it always has
+  u = "\u{1F600}"
+  assert_equal 0, (u =~ /./)
+  assert_equal 1, (("x" + u) =~ Regexp.new("\u{1F600}"))
+end
+
 assert("Regexp - a match does not end inside a character") do
   # A pattern is compiled byte by byte and RE_CHAR consumes one byte, so a
   # pattern holding a byte that reaches no character ends its match in the

--- a/src/string.c
+++ b/src/string.c
@@ -894,6 +894,7 @@ str_replace(mrb_state *mrb, struct RString *s1, struct RString *s2)
   mrb_check_frozen(mrb, s1);
   if (s1 == s2) return mrb_obj_value(s1);
   RSTR_COPY_SINGLE_BYTE_FLAG(s1, s2);
+  RSTR_COPY_BINARY_FLAG(s1, s2);
   if (RSTR_SHARED_P(s1)) {
     str_decref(mrb, s1->as.heap.aux.shared);
   }


### PR DESCRIPTION
`str_replace()` copies `MRB_STR_SINGLE_BYTE` from the string it copies and not
`MRB_STR_BINARY`, so every copy of a byte-indexed string comes back without the
flag that says to read it as bytes.

```ruby
s = "\u{1F600}".b   # F0 9F 98 80: four bytes, one character

s.encoding          # ASCII-8BIT
s.dup.encoding      # UTF-8   <- CRuby: ASCII-8BIT
s.clone.encoding    # UTF-8   <- CRuby: ASCII-8BIT
"x".replace(s)      # UTF-8   <- CRuby: ASCII-8BIT
```

## Why it is more than a label

`chars2bytes()` and `bytes2chars()` both read `MRB_STR_BINARY` to decide
whether an index is a byte or a character, so a copy that lost the flag has
every offset computed off it switch units.

`mruby-regexp` reaches this without the caller making a copy at all.
`create_matchdata()` snapshots the subject with `mrb_str_dup_frozen()`, so that
changing the subject afterwards is not visible through the `MatchData`. The
snapshot loses the flag, and `re_byte_to_char()` counts UTF-8 lead bytes over a
string that holds no characters:

```ruby
s = "\u{1F600}".b

s =~ Regexp.new("\x80")                        # 1  <- CRuby: 3
s.byteindex(Regexp.new("\x80"))                # 3, correct
md = s.match(Regexp.new("\x80"))
md.begin(0)                                    # 1
md.pre_match.bytesize                          # 3  <- disagrees with begin(0)
```

One `MatchData` reported the same span in two units.

## The change

Add `RSTR_COPY_BINARY_FLAG` beside `RSTR_COPY_SINGLE_BYTE_FLAG` and call it in
`str_replace()`. A copy holds the same bytes as what it copies, so it is
byte-indexed exactly when that is. Three lines.

The flag is copied rather than set, so a copy of a UTF-8 string stays UTF-8 and
`String#b`, which dups and then sets the flag, is unaffected.

## Testing

`rake test` is green on `full-core` with gcc on `x86_64-linux`: 2216 asserts,
no failures.

Both new tests fail without the change and pass with it:

```
Fail: String#encoding survives a copy (mrbgems: mruby-encoding)
Fail: Regexp - a byte-indexed subject is reported in bytes (mrbgems: mruby-regexp)
  KO: 2   ->   KO: 0
```

A differential sweep against CRuby 4.0.6, over a byte-indexed subject with a
byte-indexed pattern (0x80 to 0xFF in four shapes, with and without `/i`, ten
subjects, 10240 cells), reading the position with `=~`:

| | cells differing from CRuby |
| --- | --- |
| master | 310 |
| master + this change | 226 |
| master + #7078 | 84 |
| both | 0 |

The 84 this change closes are all offset reporting; the rest belong to #7078
and are unrelated to the flag.

## Not in this change

`String#*` and the substring family have the same gap at their own sites, and
`String#+` takes two strings, so which side decides is a rule to choose rather
than a flag to copy. `String#size` reads a binary string as UTF-8 for a
different reason: `utf8_strlen()` does not ask about the flag, while its two
neighbours do.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - String copies and replacements now preserve binary or UTF-8 encoding correctly.
  - Regular expression matching on binary strings now reports consistent byte-based positions.
  - `String#byteindex` and `MatchData#begin`/`end` now return correct offsets for binary data.
  - Existing UTF-8 strings continue to report character-based positions as expected.

- **Tests**
  - Added coverage for encoding preservation through duplication, cloning, freezing, and replacement.
  - Added regression tests for multibyte and binary string indexing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->