### PR TITLE
string.c: a binary string is measured in bytes

### DIFF
--- a/mrbgems/mruby-encoding/test/string.rb
+++ b/mrbgems/mruby-encoding/test/string.rb
@@ -15,6 +15,43 @@ assert('String#valid_encoding?') do
   end
 end
 
+assert('String#length of a binary string counts bytes') do
+  # A byte-indexed string has one position per byte, which is what indexing it
+  # already answered. Measuring it read the same string as UTF-8, so the length
+  # disagreed with every index taken off it.
+  if UTF8STRING
+    s = "\u{1F600}".b   # F0 9F 98 80: four bytes, one character
+    assert_equal 4, s.size
+    assert_equal 4, s.length
+    assert_equal 4, s.bytesize
+    assert_equal 4, s.chars.size
+    assert_equal "\x9F".b, s[1]
+    assert_equal "\x80".b, s[3]
+    assert_equal "\x80".b, s[-1]
+    assert_equal "\xF0\x9F".b, s[0, 2]
+    assert_equal "\x9F\x98".b, s.slice(1, 2)
+    # the length is not cached as a property of the bytes: force_encoding can
+    # hand the same bytes back to the UTF-8 reading
+    s.force_encoding(Encoding::UTF_8)
+    assert_equal 1, s.size
+    t = "\u{1F600}"
+    assert_equal 1, t.size
+    t.force_encoding(Encoding::BINARY)
+    assert_equal 4, t.size
+  end
+end
+
+assert('String#reverse! on a binary string reverses bytes') do
+  if UTF8STRING
+    s = "\u{1F600}".b
+    s.reverse!
+    assert_equal "\x80\x98\x9F\xF0".b, s
+    u = "a\u{1F600}b"
+    u.reverse!
+    assert_equal "b\u{1F600}a", u
+  end
+end
+
 assert('String#encoding') do
   if UTF8STRING
     a = "あ"

--- a/src/string.c
+++ b/src/string.c
@@ -532,6 +532,19 @@ utf8_strlen(mrb_value str)
   struct RString *s = mrb_str_ptr(str);
   mrb_int byte_len = RSTR_LEN(s);
 
+  /* A byte-indexed string has one position per byte, which is what
+     chars2bytes() and bytes2chars() already answer for it. Asked here only
+     about the single-byte flag, the same string was measured as UTF-8 and
+     reported a length its own indexing did not agree with.
+
+     The flag below is deliberately not set on the way out: it says the bytes
+     hold nothing multi-byte, while this returns early because of how the
+     string is read. force_encoding() can take MRB_STR_BINARY away again, and
+     a flag set here would outlive the reason for it. */
+  if (RSTR_BINARY_P(s)) {
+    return byte_len;
+  }
+
   if (RSTR_SINGLE_BYTE_P(s)) {
     return byte_len;
   }


### PR DESCRIPTION
`chars2bytes()` and `bytes2chars()` both ask `RSTR_BINARY_P()` before deciding
whether an index counts bytes or characters, so a string marked by `String#b`
is indexed by byte. `utf8_strlen()` asks only about the single-byte flag, so
the same string is measured as UTF-8. One string answers two ways, and the
length is the one every method bounded by it believes.

```ruby
s = "\u{1F600}".b   # F0 9F 98 80: four bytes, one character

s.size          # 1     <- CRuby: 4
s.bytesize      # 4
s[0]            # "\xF0"   indexed as a byte all along
s[1]            # nil   <- CRuby: "\x9F"
s[3]            # nil   <- CRuby: "\x80"
s[0, 2]         # "\xF0"   <- CRuby: "\xF0\x9F"
s.slice(1, 2)   # ""    <- CRuby: "\x9F\x98"
s.chars.size    # 4, walking bytes and disagreeing with s.size
s.reverse!      # the string unchanged: one character reversed is itself
```

## The change

`utf8_strlen()` returns the byte length for a binary string, which is what its
two neighbours already answer for the index. One condition.

The single-byte flag is deliberately not set on that path. That flag says the
bytes hold nothing multi-byte, while the early return is about how the string
is read, and `force_encoding` can hand the same bytes back to the UTF-8
reading:

```ruby
s = "\u{1F600}".b
s.size                             # 4
s.force_encoding(Encoding::UTF_8)
s.size                             # 1, not a cached 4
```

## What this does not reach

`String#reverse` copies the string first, and `str_replace()` does not carry
`MRB_STR_BINARY` to the copy, so it still reads the copy as UTF-8. `#reverse!`
is fixed here. #7080 makes the flag survive a copy, and with the two together
the copying form follows. Neither change depends on the other landing first,
and they merge cleanly in either order: they touch different functions in
`src/string.c` and add their tests at different points in the same file.

`String#inspect` and `String#chop!` each walk `mrb_utf8len()` themselves rather
than going through the length, so a binary string is read as UTF-8 there for a
reason of their own. Those are separate fixes and are not mixed in here.

`mrb_str_index_m()` and `mrb_str_rindex_m()` take a byte path on the same flag
the others read, and are left alone. The general path they fall into converts
through `bytes2chars()`, which returns the byte offset for a binary string
already, so the answer is the same either way and this would be a speed-up
rather than a fix.

## Testing

`rake test` is green on `full-core` with gcc on `x86_64-linux`: 2216 asserts,
no failures. Both new tests fail without the change:

```
Fail: String#length of a binary string counts bytes
Fail: String#reverse! on a binary string reverses bytes
  KO: 2   ->   KO: 0
```

Merged with #7080 locally, `rake test` is green as well (2218 asserts), and
`String#reverse` joins `#reverse!` in answering in bytes.

Checked against CRuby 4.0.6 over `size`, `length`, `bytesize`, `[]` by index
and by pair, `slice`, `chars`, `each_char`, `reverse!`, `center`, `ljust`,
`rjust` and `insert`, on a four-byte one-character subject and on a mixed one:
every case agrees afterwards except the ones listed above as out of reach.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected string length handling for binary strings so lengths are reported in bytes.
  * Improved behavior for indexing, slicing, encoding changes, and reversing binary and multibyte UTF-8 strings.

* **Tests**
  * Added coverage for UTF-8 string operations, including byte-based lengths and `String#reverse!`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->