### PR TITLE
fix use-after-free in String#lstrip!/rstrip!/strip!

### DIFF
--- a/mrbgems/mruby-string-ext/src/string.c
+++ b/mrbgems/mruby-string-ext/src/string.c
@@ -1617,12 +1617,12 @@ static mrb_value
 str_lstrip_bang(mrb_state *mrb, mrb_value self)
 {
   struct RString *s = mrb_str_ptr(self);
-  char *ptr = RSTR_PTR(s);
   mrb_int len = RSTR_LEN(s);
   mrb_int start = 0;
 
   mrb_check_frozen(mrb, mrb_obj_ptr(self));
   mrb_str_modify(mrb, s);
+  char *ptr = RSTR_PTR(s);
 
   /* Find first non-whitespace character */
   while (start < len && is_whitespace(ptr[start])) {
@@ -1662,12 +1662,12 @@ static mrb_value
 str_rstrip_bang(mrb_state *mrb, mrb_value self)
 {
   struct RString *s = mrb_str_ptr(self);
-  char *ptr = RSTR_PTR(s);
   mrb_int len = RSTR_LEN(s);
   mrb_int end = len;
 
   mrb_check_frozen(mrb, mrb_obj_ptr(self));
   mrb_str_modify(mrb, s);
+  char *ptr = RSTR_PTR(s);
 
   /* Find last non-whitespace character */
   while (end > 0 && is_whitespace_or_null(ptr[end - 1])) {
@@ -1699,7 +1699,6 @@ static mrb_value
 str_strip_bang(mrb_state *mrb, mrb_value self)
 {
   struct RString *s = mrb_str_ptr(self);
-  char *ptr = RSTR_PTR(s);
   mrb_int len = RSTR_LEN(s);
   mrb_int start = 0;
   mrb_int end = len;
@@ -1707,6 +1706,7 @@ str_strip_bang(mrb_state *mrb, mrb_value self)
 
   mrb_check_frozen(mrb, mrb_obj_ptr(self));
   mrb_str_modify(mrb, s);
+  char *ptr = RSTR_PTR(s);
 
   /* Find first non-whitespace character */
   while (start < len && is_whitespace(ptr[start])) {

--- a/mrbgems/mruby-string-ext/test/string.rb
+++ b/mrbgems/mruby-string-ext/test/string.rb
@@ -79,6 +79,26 @@ assert('String#rstrip!') do
   assert_equal("  abc", t)
 end
 
+assert('String#strip! family on a shared buffer') do
+  # A substring shares the parent's heap buffer, so the strip family must read
+  # the buffer pointer after mrb_str_modify unshares it. Reading it before means
+  # the copy and the terminator land in the parent's buffer instead.
+  base = ".        abcdefghijklmnopqrstuvwxyz0123456789"
+  view = base[1..-1]
+  assert_equal("abcdefghijklmnopqrstuvwxyz0123456789", view.lstrip!)
+  assert_equal(".        abcdefghijklmnopqrstuvwxyz0123456789", base)
+
+  base = "abcdefghijklmnopqrstuvwxyz0123456789        ."
+  view = base[0..-2]
+  assert_equal("abcdefghijklmnopqrstuvwxyz0123456789", view.rstrip!)
+  assert_equal("abcdefghijklmnopqrstuvwxyz0123456789        .", base)
+
+  base = ".        abcdefghijklmnopqrstuvwxyz0123456789        ."
+  view = base[1..-2]
+  assert_equal("abcdefghijklmnopqrstuvwxyz0123456789", view.strip!)
+  assert_equal(".        abcdefghijklmnopqrstuvwxyz0123456789        .", base)
+end
+
 assert('String#swapcase') do
   assert_equal "hELLO", "Hello".swapcase
   assert_equal "CyBeR_pUnK11", "cYbEr_PuNk11".swapcase


### PR DESCRIPTION
The three strip bang methods in mruby-string-ext read the receiver's buffer pointer into a local before calling mrb_str_modify. When the receiver shares its buffer with another string, a substring view or any shared/fshared/nofree string, mrb_str_modify unshares by copying the live bytes into a fresh allocation and dropping the old one, so that saved pointer is left dangling. The scan loops then read through it, and the memmove and the terminating NUL write through it: a heap use-after-free once a substring's parent has been collected, and a silent write into an unrelated live string's buffer while the parent is still around. I ran into it fuzzing lstrip!/rstrip!/strip! on shared substrings under AddressSanitizer, which reported a heap-use-after-free read in each. The other bang methods in this file already re-read the pointer after mrb_str_modify (str_del_prefix_bang does exactly that), so the fix moves the RSTR_PTR read below the modify call in all three. The added test strips a substring view and checks both the stripped result and that the shared parent is left untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved trimming behavior for substring views, ensuring `lstrip!`, `rstrip!`, and `strip!` return correct results without modifying the original parent string.

* **Tests**
  * Added regression coverage for trimming shared substring data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->