### PR TITLE
string.c: a binary string is inspected byte by byte

### DIFF
--- a/mrbgems/mruby-string-ext/test/string.rb
+++ b/mrbgems/mruby-string-ext/test/string.rb
@@ -16,6 +16,17 @@ assert('String#dump') do
   assert_nothing_raised { ("\1" * 100).dump }   # regress #1210
 end
 
+assert('String#inspect of a binary string escapes every byte') do
+  # `inspect` passes a whole character through unescaped so it stays readable,
+  # which a string holding no characters has nothing to gain from. `dump` on
+  # the same string escaped every byte already, so the two agree there.
+  if UTF8STRING
+    assert_equal('"る"', "る".inspect)
+    assert_equal('"\xe3\x82\x8b"', "る".b.inspect)
+    assert_equal("る".b.dump, "る".b.inspect)
+  end
+end
+
 assert('String#strip') do
   s = "  abc  "
   assert_equal("abc", s.strip)

--- a/src/string.c
+++ b/src/string.c
@@ -1575,6 +1575,12 @@ str_escape(mrb_state *mrb, mrb_value str, mrb_bool inspect)
 #endif
 
   p = RSTRING_PTR(str); pend = RSTRING_END(str);
+#ifdef MRB_UTF8_STRING
+  /* `inspect` passes a whole character through unescaped so it stays readable.
+     A byte-indexed string holds no characters to keep readable, so it escapes
+     byte by byte, which is what `dump` on the same string already did. */
+  if (RSTR_BINARY_P(mrb_str_ptr(str))) inspect = FALSE;
+#endif
   for (;p < pend; p++) {
     unsigned char c, cc;
 #ifdef MRB_UTF8_STRING


### PR DESCRIPTION
`str_escape()` serves both `inspect` and `dump`, and for `inspect` it passes a
whole UTF-8 character through unescaped so the result stays readable. A string
marked by `String#b` is read as bytes everywhere else and holds no characters
to keep readable, but the walk here never asked about the flag.

```ruby
"る".inspect      # "る"
"る".b.inspect    # "る"            <- CRuby: "\xE3\x82\x8B"
"る".b.dump       # "\xe3\x82\x8b"     escaped byte by byte all along
```

The same bytes were shown two ways by two methods whose only intended
difference is whether a printable character is escaped.

## The change

`str_escape()` reads `RSTR_BINARY_P()` and takes the `dump` path for a binary
string. One condition, and the answer it gives is the one `dump` already gave
for the same string.

## Related, not required

`String#b` marks the string, and several other places in `src/string.c` read
such a string as UTF-8 for reasons of their own: #7081 for the length,
#7080 for a copy losing the flag, and `String#chop!` walking characters. Each
is its own fix; none of them depends on this one and this one does not depend
on them.

## Testing

`rake test` is green on `full-core` with gcc on `x86_64-linux`: 2215 asserts,
no failures. The new test fails without the change:

```
Fail: String#inspect of a binary string escapes every byte
  KO: 1   ->   KO: 0
```

Checked against CRuby 4.0.6. The escapes differ in letter case (`\xe3` here,
`\xE3` there), which is what `dump` in this tree has always produced and is not
touched by this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved string inspection for binary data by escaping each byte consistently.
  * Preserved readable UTF-8 characters when inspecting valid UTF-8 strings.
  * Ensured binary string inspection matches the corresponding dump output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->