### PR TITLE
string.c: `String#chop!` takes a byte off a binary string

### DIFF
--- a/mrbgems/mruby-string-ext/test/string.rb
+++ b/mrbgems/mruby-string-ext/test/string.rb
@@ -797,6 +797,28 @@ assert('String#each_char(UTF-8)') do
   assert_equal ["こ", "ん", "に", "ち", "は", "世", "界", "!"], chars
 end if UTF8STRING
 
+assert('String#chop! on a binary string removes one byte') do
+  # `chop!` walks to the last character, and a byte-indexed string ends in a
+  # byte rather than in a character. Walking it as UTF-8 took the whole of a
+  # multi-byte sequence off, or all of a string that held only one.
+  if UTF8STRING
+    s = "\u{1F600}".b   # F0 9F 98 80: four bytes, one character
+    s.chop!
+    assert_equal "\xF0\x9F\x98".b, s
+    t = "a\u{1F600}".b
+    t.chop!
+    assert_equal "a\xF0\x9F\x98".b, t
+    # a string read as UTF-8 still loses the whole character
+    u = "\u{1F600}"
+    u.chop!
+    assert_equal "", u
+    # and the \r\n pair is still taken together
+    v = "a\r\n".b
+    v.chop!
+    assert_equal "a", v
+  end
+end
+
 assert('String#codepoints') do
   expect = [104, 101, 108, 108, 111, 33]
   assert_equal expect, "hello!".codepoints

--- a/src/string.c
+++ b/src/string.c
@@ -1867,14 +1867,20 @@ mrb_str_chop_bang(mrb_state *mrb, mrb_value str)
   if (RSTR_LEN(s) > 0) {
     mrb_int len;
 #ifdef MRB_UTF8_STRING
-    const char* t = RSTR_PTR(s), *p = t;
-    const char* e = p + RSTR_LEN(s);
-    while (p<e) {
-      mrb_int clen = mrb_utf8len(p, e);
-      if (p + clen>=e) break;
-      p += clen;
+    if (RSTR_BINARY_P(s)) {
+      /* The last position of a byte-indexed string is its last byte. */
+      len = RSTR_LEN(s) - 1;
     }
-    len = p - t;
+    else {
+      const char* t = RSTR_PTR(s), *p = t;
+      const char* e = p + RSTR_LEN(s);
+      while (p<e) {
+        mrb_int clen = mrb_utf8len(p, e);
+        if (p + clen>=e) break;
+        p += clen;
+      }
+      len = p - t;
+    }
 #else
     len = RSTR_LEN(s) - 1;
 #endif


### PR DESCRIPTION
`mrb_str_chop_bang()` walks the string with `mrb_utf8len()` to find where the
last character starts. A string marked by `String#b` is read as bytes
everywhere else and ends in a byte rather than in a character, and the walk
never asked about the flag, so it took off the whole of a multi-byte sequence.

```ruby
"\u{1F600}".b.dup.chop!   # F0 9F 98 80: ""   <- CRuby: "\xF0\x9F\x98"
"a\u{1F600}".b.dup.chop!  # "a"                <- CRuby: "a\xF0\x9F\x98"
```

A string that held one character came back empty, which is the right answer
for a one-character string read as UTF-8 and was reached here by a rule that
does not apply to a string of bytes.

## The change

`mrb_str_chop_bang()` takes the last byte when `RSTR_BINARY_P()` says the
string is byte-indexed. The `\r\n` pair is still taken together, since that
test runs on the byte before the end either way.

## Related, not required

`String#chop` copies the string first and `str_replace()` does not carry
`MRB_STR_BINARY` to the copy, so it answers as before; #7080 makes the flag
survive a copy and the copying form follows. #7081 fixes the length for the
same kind of string, and `String#inspect` has a walk of its own. Each is a
separate fix and none depends on another landing first.

## Testing

`rake test` is green on `full-core` with gcc on `x86_64-linux`: 2215 asserts,
no failures. The new test fails without the change:

```
Fail: String#chop! on a binary string removes one byte
  KO: 1   ->   KO: 0
```

The test also pins what must not move: a string read as UTF-8 still loses the
whole character, and `"a\r\n".b` still loses both bytes of the pair. Checked
against CRuby 4.0.6.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `String#chop!` for binary strings in UTF-8 builds. It now removes exactly the final byte without incorrectly interpreting multi-byte data as text.
  * Preserved character-based behavior for regular UTF-8 strings, including correct handling of line endings.

* **Tests**
  * Added coverage for binary data, multi-byte UTF-8 strings, and CRLF line endings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->