### PR TITLE
mruby-regexp: `String#split` steps by a byte through a binary subject

### DIFF
--- a/mrbgems/mruby-regexp/mrblib/string_regexp.rb
+++ b/mrbgems/mruby-regexp/mrblib/string_regexp.rb
@@ -278,6 +278,7 @@ class String
     search_pos = 0
     len = self.bytesize
     count = 0
+    binary = Regexp.__binary_string?(self)
     while search_pos <= len
       if limit > 0 && count >= limit - 1
         result << (self.byteslice(field_start..-1) || "")
@@ -289,12 +290,20 @@ class String
       match_end = md.__byte_end(0)
 
       if match_start == match_end
-        rest = self.byteslice(match_end..-1)
-        if rest && rest.bytesize > 0
-          char = rest[0]
-          search_pos = match_end + char.bytesize
-        else
+        if binary
+          # A byte-indexed subject has one position per byte, and the step
+          # below reads the rest of it as UTF-8: `byteslice` hands back a
+          # string without the flag, so its first element is a whole character
+          # again. `gsub` steps by a byte here for the same reason.
           search_pos = match_end + 1
+        else
+          rest = self.byteslice(match_end..-1)
+          if rest && rest.bytesize > 0
+            char = rest[0]
+            search_pos = match_end + char.bytesize
+          else
+            search_pos = match_end + 1
+          end
         end
         next if match_start == field_start
       end

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -918,6 +918,21 @@ assert("String#split - regexp search position is byte-based internally") do
   assert_equal ["あ", ",", "い", ",", "う"], "あ,い,う".split(/(,)/)
 end
 
+assert("String#split - a byte-indexed subject is split by byte") do
+  skip unless __ENCODING__ == "UTF-8"
+  # An empty match steps to the next position, and `String#b` makes every byte
+  # one. The step read the subject as UTF-8 and cleared a whole character,
+  # so a four-byte string came back in one piece.
+  s = "\u{1F600}".b   # F0 9F 98 80: four bytes, one character
+  assert_equal ["\xF0".b, "\x9F".b, "\x98".b, "\x80".b], s.split(//)
+  assert_equal 4, s.split(//).size
+  assert_equal ["a".b, "\xC3".b, "\xA9".b, "b".b], "a\u{E9}b".b.split(//)
+  # a subject read as UTF-8 is still split by character
+  assert_equal ["\u{1F600}"], "\u{1F600}".split(//)
+  # and the limit still counts fields, not bytes
+  assert_equal ["\xF0".b, "\x9F\x98\x80".b], s.split(//, 2)
+end
+
 assert("Regexp.escape") do
   assert_equal "a\\.b\\*c", Regexp.escape("a.b*c")
 


### PR DESCRIPTION
An empty match leaves `split` where it started, so the loop steps forward
before searching again. The step read the rest of the subject as UTF-8 and
cleared a whole character. A string marked by `String#b` has one position per
byte and `__byte_match` finds an empty match at every one of them, so the
fields came back joined.

```ruby
"\u{1F600}".b.split(//)  # ["\xF0\x9F\x98\x80"]    <- CRuby: ["\xF0", "\x9F", "\x98", "\x80"]
"a\u{E9}b".b.split(//)   # ["a", "\xC3\xA9", "b"]  <- CRuby: ["a", "\xC3", "\xA9", "b"]
"\u{1F600}".b.split("")  # ["\xF0", "\x9F", "\x98", "\x80"]   the core split, all along
```

The same subject came apart two ways depending on which spelling of the same
request was used.

## The change

`split` reads the flag off the subject with `Regexp.__binary_string?` and
steps by a byte, which is what `gsub` a few lines above already does at the
same point and for the same reason. Nothing else in the loop moves: a subject
read as UTF-8 still steps by a character, and the limit still counts fields.

## Why the step cannot read it off the slice

The step asks `byteslice` for the rest of the subject and takes its first
element. `byteslice` builds that string with `mrb_str_byte_subseq()`, which
copies `MRB_STR_SINGLE_BYTE` and not `MRB_STR_BINARY`, so the slice arrives
unmarked and its first element is a whole character again however the subject
was marked. Reading the flag off the subject asks nothing of the slice.
Whether a slice of a binary string should itself be binary is a question about
`src/string.c` and is left alone here.

## Testing

`rake test` is green on `full-core` with gcc on `x86_64-linux`, with and
without `MRB_REGEXP_UNICODE_CASE`: 2215 and 2214 asserts, no failures. The new
test fails without the change:

```
Fail: String#split - a byte-indexed subject is split by byte
  KO: 1   ->   KO: 0
```

Checked against CRuby 4.0.6, including the limit forms `split(//, 2)` and
`split(//, -1)`, an empty subject, and an ASCII subject marked by `String#b`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved `String#split` behavior with zero-length regular-expression matches.
  - Binary strings are now split byte by byte, while UTF-8 and other text strings continue to split by character.
  - Corrected handling at the end of strings and when a maximum field count is specified.

- **Tests**
  - Added coverage for binary-string splitting, UTF-8 character splitting, and field-count limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->