### PR TITLE
style/performance fixes

### DIFF
--- a/mrbgems/mruby-array-ext/mrblib/array.rb
+++ b/mrbgems/mruby-array-ext/mrblib/array.rb
@@ -498,7 +498,7 @@ class Array
 
     column_count = nil
     self.each do |row|
-      raise TypeError unless row.is_a?(Array)
+      raise TypeError unless Array === row
       column_count ||= row.size
       raise IndexError, 'element size differs' unless column_count == row.size
     end

--- a/mrbgems/mruby-compar-ext/mrblib/compar.rb
+++ b/mrbgems/mruby-compar-ext/mrblib/compar.rb
@@ -43,7 +43,7 @@ module Comparable
   def clamp(min, max=nil)
 
     if max.nil?
-      if min.kind_of?(Range)
+      if Range === min
         max = min.end
         if !max.nil? && min.exclude_end?
           raise ArgumentError, "cannot clamp with an exclusive range"

--- a/mrbgems/mruby-complex/mrblib/complex.rb
+++ b/mrbgems/mruby-complex/mrblib/complex.rb
@@ -80,7 +80,7 @@ class Complex < Numeric
   #   Complex(2, 3) <=> 1              #=> 1
   #
   def <=>(other)
-    return nil unless other.kind_of?(Numeric)
+    return nil unless Numeric === other
     self.to_f <=> other.to_f
   rescue
     nil

--- a/mrbgems/mruby-enum-ext/mrblib/enum.rb
+++ b/mrbgems/mruby-enum-ext/mrblib/enum.rb
@@ -785,14 +785,14 @@ module Enumerable
     if blk
       self.each do |v|
         v = blk.call(v)
-        raise TypeError, "wrong element type #{v.class} (expected Array)" unless v.is_a? Array
+        raise TypeError, "wrong element type #{v.class} (expected Array)" unless Array === v
         raise ArgumentError, "element has wrong array length (expected 2, was #{v.size})" if v.size != 2
         h[v[0]] = v[1]
       end
     else
       self.each do |*v|
         v = v.__svalue
-        raise TypeError, "wrong element type #{v.class} (expected Array)" unless v.is_a? Array
+        raise TypeError, "wrong element type #{v.class} (expected Array)" unless Array === v
         raise ArgumentError, "element has wrong array length (expected 2, was #{v.size})" if v.size != 2
         h[v[0]] = v[1]
       end

--- a/mrbgems/mruby-enumerator/mrblib/enumerator.rb
+++ b/mrbgems/mruby-enumerator/mrblib/enumerator.rb
@@ -133,7 +133,7 @@ class Enumerator
   end
 
   private def initialize_copy(obj)
-    raise TypeError, "can't copy type #{obj.class}" unless obj.kind_of? Enumerator
+    raise TypeError, "can't copy type #{obj.class}" unless Enumerator === obj
     raise TypeError, "can't copy execution context" if obj.instance_eval{@fib}
     meth = args = kwd = fib = nil
     obj.instance_eval {
@@ -780,7 +780,7 @@ module Enumerable
         when last_value
           arr << element
         else
-          raise 'symbols beginning with an underscore are reserved' if value.is_a?(Symbol) && value.to_s[0] == '_'
+          raise 'symbols beginning with an underscore are reserved' if Symbol === value && value.to_s[0] == '_'
           y.yield [last_value, arr] if arr.size > 0
           last_value, arr = value, [element]
         end

--- a/mrbgems/mruby-io/mrblib/file.rb
+++ b/mrbgems/mruby-io/mrblib/file.rb
@@ -17,7 +17,7 @@ class File < IO
   #   f = File.new("tmpfile",  "a")
   #
   def initialize(fd_or_path, mode = "r", perm = 0666)
-    if fd_or_path.kind_of? Integer
+    if Integer === fd_or_path
       super(fd_or_path, mode)
     else
       @path = fd_or_path

--- a/mrbgems/mruby-range-ext/mrblib/range.rb
+++ b/mrbgems/mruby-range-ext/mrblib/range.rb
@@ -74,8 +74,8 @@ class Range
     raise RangeError, "cannot get the maximum of endless range" if last.nil?
 
     # fast path for numerics
-    if val.kind_of?(Numeric) && last.kind_of?(Numeric)
-      raise TypeError if exclude_end? && !last.kind_of?(Integer)
+    if Numeric === val && Numeric === last
+      raise TypeError if exclude_end? && !(Integer === last)
       return nil if val > last
       return nil if val == last && exclude_end?
 
@@ -109,7 +109,7 @@ class Range
     return val if last.nil?
 
     # fast path for numerics
-    if val.kind_of?(Numeric) && last.kind_of?(Numeric)
+    if Numeric === val && Numeric === last
       return nil if val > last
       return nil if val == last && exclude_end?
 
@@ -132,7 +132,7 @@ class Range
   #   (1..5).overlap?(7..9) #=> false
   #
   def overlap?(other)
-    raise TypeError, "argument must be a range" unless other.kind_of?(Range)
+    raise TypeError, "argument must be a range" unless Range === other
 
     self_begin = self.begin
     other_end = other.end

--- a/mrbgems/mruby-rational/mrblib/rational.rb
+++ b/mrbgems/mruby-rational/mrblib/rational.rb
@@ -42,7 +42,7 @@ class Rational < Numeric
   #   Rational(1, 3) <=> 0.3             #=> 1
   #
   def <=>(other)
-    return nil unless other.kind_of?(Numeric)
+    return nil unless Numeric === other
     self.to_f <=> other.to_f
   rescue
     nil

--- a/mrbgems/mruby-socket/mrblib/socket.rb
+++ b/mrbgems/mruby-socket/mrblib/socket.rb
@@ -12,7 +12,7 @@ class Addrinfo
   #
   def initialize(sockaddr, family=Socket::PF_UNSPEC, socktype=0, protocol=0)
     @hostname = nil
-    if sockaddr.is_a? Array
+    if Array === sockaddr
       sary = sockaddr
       if sary[0] == 'AF_INET' || sary[0] == 'AF_INET6'
         @sockaddr = Socket.sockaddr_in(sary[1], sary[3])
@@ -870,7 +870,7 @@ class Socket < BasicSocket
   #   sock.bind(addrinfo)
   #
   def bind(sockaddr)
-    sockaddr = sockaddr.to_sockaddr if sockaddr.is_a? Addrinfo
+    sockaddr = sockaddr.to_sockaddr if Addrinfo === sockaddr
     Socket._bind(self.fileno, sockaddr)
     0
   end
@@ -885,7 +885,7 @@ class Socket < BasicSocket
   #   sock.connect(addrinfo)
   #
   def connect(sockaddr)
-    sockaddr = sockaddr.to_sockaddr if sockaddr.is_a? Addrinfo
+    sockaddr = sockaddr.to_sockaddr if Addrinfo === sockaddr
     Socket._connect(self.fileno, sockaddr)
     0
   end
@@ -948,7 +948,7 @@ class UNIXSocket < BasicSocket
   #   UNIXSocket.new("/tmp/socket") { |s| s.write("data") }
   #
   def initialize(path, &block)
-    if self.is_a? UNIXServer
+    if UNIXServer === self
       super(path, "r")
     else
       super(Socket._socket(Socket::AF_UNIX, Socket::SOCK_STREAM, 0), "r+")

--- a/mrbgems/mruby-sprintf/mrblib/string.rb
+++ b/mrbgems/mruby-sprintf/mrblib/string.rb
@@ -15,7 +15,7 @@ class String
   #   "%{foo}f" % { :foo => 1 }                 #=> "1f"
   #
   def %(args)
-    if args.is_a? Array
+    if Array === args
       sprintf(self, *args)
     else
       sprintf(self, args)

--- a/mrbgems/mruby-string-ext/mrblib/string.rb
+++ b/mrbgems/mruby-string-ext/mrblib/string.rb
@@ -101,7 +101,7 @@ class String
   #     "07".upto("11").to_a  #=> ["07", "08", "09", "10", "11"]
   def upto(max, exclusive=false, &block)
     return to_enum(:upto, max, exclusive) unless block
-    raise TypeError, "no implicit conversion of #{max.class} into String" unless max.kind_of? String
+    raise TypeError, "no implicit conversion of #{max.class} into String" unless String === max
 
     len = self.length
     maxlen = max.length

--- a/mrbgems/mruby-symbol-ext/mrblib/symbol.rb
+++ b/mrbgems/mruby-symbol-ext/mrblib/symbol.rb
@@ -40,7 +40,7 @@ class Symbol
   # Case-insensitive version of `Symbol#<=>`.
 
   def casecmp(other)
-    return nil unless other.kind_of?(Symbol)
+    return nil unless Symbol === other
     lhs =  self.to_s; lhs.upcase!
     rhs = other.to_s.upcase
     lhs <=> rhs

--- a/mrbgems/mruby-task/mrblib/queue.rb
+++ b/mrbgems/mruby-task/mrblib/queue.rb
@@ -30,7 +30,7 @@ class Task
     def pop(non_block = false, timeout_ms: nil)
       unless timeout_ms.nil?
         raise ArgumentError, "timeout cannot be combined with non_block" if non_block
-        raise TypeError, "timeout_ms must be an Integer" unless timeout_ms.is_a?(Integer)
+        raise TypeError, "timeout_ms must be an Integer" unless Integer === timeout_ms
         raise ArgumentError, "timeout_ms must be non-negative" if timeout_ms < 0
       end
       deadline = timeout_ms.nil? ? nil : __deadline(timeout_ms)

--- a/mrblib/array.rb
+++ b/mrblib/array.rb
@@ -59,7 +59,7 @@ class Array
     idx = 0
     len = size
     while idx < len
-      self[idx] = block.call(self[idx])
+      self[idx] = yield(self[idx])
       idx += 1
     end
     self

--- a/mrblib/enum.rb
+++ b/mrblib/enum.rb
@@ -25,7 +25,7 @@ module Enumerable
   # ISO 15.3.2.2.1
   def all?(&block)
     if block
-      self.each {|*val| return false unless block.call(*val)}
+      self.each {|*val| return false unless yield(*val)}
     else
       self.each {|*val| return false unless val.__svalue}
     end
@@ -42,7 +42,7 @@ module Enumerable
   # ISO 15.3.2.2.2
   def any?(&block)
     if block
-      self.each {|*val| return true if block.call(*val)}
+      self.each {|*val| return true if yield(*val)}
     else
       self.each {|*val| return true if val.__svalue}
     end
@@ -60,7 +60,7 @@ module Enumerable
     return to_enum(:collect) unless block
 
     ary = []
-    self.each {|*val| ary.push(block.call(*val))}
+    self.each {|*val| ary.push(yield(*val))}
     ary
   end
 
@@ -76,7 +76,7 @@ module Enumerable
     return to_enum(:detect, ifnone) unless block
 
     self.each {|*val|
-      if block.call(*val)
+      if yield(*val)
         return val.__svalue
       end
     }
@@ -95,7 +95,7 @@ module Enumerable
 
     i = 0
     self.each {|*val|
-      block.call(val.__svalue, i)
+      yield(val.__svalue, i)
       i += 1
     }
     self
@@ -133,7 +133,7 @@ module Enumerable
 
     ary = []
     self.each {|*val|
-      ary.push(val.__svalue) if block.call(*val)
+      ary.push(val.__svalue) if yield(*val)
     }
     ary
   end
@@ -151,7 +151,7 @@ module Enumerable
     self.each {|*val|
       sv = val.__svalue
       if pattern === sv
-        ary.push((block)? block.call(*val): sv)
+        ary.push((block)? yield(*val): sv)
       end
     }
     ary
@@ -231,7 +231,7 @@ module Enumerable
         flag = false
       else
         if block
-          result = val if block.call(val, result) > 0
+          result = val if yield(val, result) > 0
         else
           result = val if (val <=> result) > 0
         end
@@ -258,7 +258,7 @@ module Enumerable
         flag = false
       else
         if block
-          result = val if block.call(val, result) < 0
+          result = val if yield(val, result) < 0
         else
           result = val if (val <=> result) < 0
         end
@@ -289,7 +289,7 @@ module Enumerable
     ary_T = []
     ary_F = []
     self.each {|*val|
-      if block.call(*val)
+      if yield(*val)
         ary_T.push(val.__svalue)
       else
         ary_F.push(val.__svalue)
@@ -310,7 +310,7 @@ module Enumerable
 
     ary = []
     self.each {|*val|
-      ary.push(val.__svalue) unless block.call(*val)
+      ary.push(val.__svalue) unless yield(*val)
     }
     ary
   end

--- a/mrblib/hash.rb
+++ b/mrblib/hash.rb
@@ -25,7 +25,7 @@ class Hash
   # ISO 15.2.13.4.8
   def delete(key, &block)
     if block && !self.has_key?(key)
-      return block.call(key)
+      return yield(key)
     end
     self.__delete(key)
   end
@@ -59,7 +59,7 @@ class Hash
     len = self.size
     i = 0
     while i < len
-      block.call([keys[i], vals[i]])
+      yield([keys[i], vals[i]])
       i += 1
     end
     self
@@ -87,7 +87,7 @@ class Hash
   def each_key(&block)
     return to_enum(:each_key) unless block
 
-    self.keys.each {|k| block.call(k)}
+    self.keys.each {|k| yield(k)}
     self
   end
 
@@ -112,7 +112,7 @@ class Hash
   def each_value(&block)
     return to_enum(:each_value) unless block
 
-    self.values.each {|v| block.call(v)}
+    self.values.each {|v| yield(v)}
     self
   end
 
@@ -148,7 +148,7 @@ class Hash
       i += 1
       raise TypeError, "Hash required (#{other.class} given)" unless Hash === other
       other.each_key {|k|
-        h[k] = (self.has_key?(k))? block.call(k, self[k], other[k]): other[k]
+        h[k] = (self.has_key?(k))? yield(k, self[k], other[k]): other[k]
       }
     end
     h
@@ -169,7 +169,7 @@ class Hash
 
     keys = []
     self.each {|k,v|
-      if block.call([k, v])
+      if yield([k, v])
         keys.push(k)
       end
     }
@@ -200,7 +200,7 @@ class Hash
 
     h = {}
     self.each {|k,v|
-      unless block.call([k, v])
+      unless yield([k, v])
         h[k] = v
       end
     }
@@ -222,7 +222,7 @@ class Hash
 
     keys = []
     self.each {|k,v|
-      unless block.call([k, v])
+      unless yield([k, v])
         keys.push(k)
       end
     }
@@ -253,7 +253,7 @@ class Hash
 
     h = {}
     self.each {|k,v|
-      if block.call([k, v])
+      if yield([k, v])
         h[k] = v
       end
     }

--- a/mrblib/numeric.rb
+++ b/mrblib/numeric.rb
@@ -106,20 +106,20 @@ class Integer
 
     i = __coerce_step_counter(step)
     if num == self || step.infinite?
-      block.call(i) if step > 0 && i <= (num||i) || step < 0 && i >= (num||-i)
+      yield(i) if step > 0 && i <= (num||i) || step < 0 && i >= (num||-i)
     elsif num == nil
       while true
-        block.call(i)
+        yield(i)
         i += step
       end
     elsif step > 0
       while i <= num
-        block.call(i)
+        yield(i)
         i += step
       end
     else
       while i >= num
-        block.call(i)
+        yield(i)
         i += step
       end
     end
@@ -138,20 +138,20 @@ class Float
 
     i = self
     if num == self || step.infinite?
-      block.call(i) if step > 0 && i <= (num||i) || step < 0 && i >= (num||-i)
+      yield(i) if step > 0 && i <= (num||i) || step < 0 && i >= (num||-i)
     elsif num == nil
       while true
-        block.call(i)
+        yield(i)
         i += step
       end
     elsif step > 0
       while i <= num
-        block.call(i)
+        yield(i)
         i += step
       end
     else
       while i >= num
-        block.call(i)
+        yield(i)
         i += step
       end
     end

--- a/mrblib/range.rb
+++ b/mrblib/range.rb
@@ -20,7 +20,7 @@ class Range
     val = self.begin
     last = self.end
 
-    if val.kind_of?(Integer) && last.nil?
+    if Integer === val && last.nil?
       i = val
       while true
         block.call(i)
@@ -29,7 +29,7 @@ class Range
       return self
     end
 
-    if val.kind_of?(String) && last.nil?
+    if String === val && last.nil?
       if val.respond_to? :__upto_endless
         return val.__upto_endless(&block)
       else
@@ -37,7 +37,7 @@ class Range
       end
     end
 
-    if val.kind_of?(Integer) && last.kind_of?(Integer) # integers are special
+    if Integer === val && Integer === last # integers are special
       lim = last
       lim += 1 unless exclude_end?
       i = val
@@ -48,7 +48,7 @@ class Range
       return self
     end
 
-    if val.kind_of?(String) && last.kind_of?(String) # strings are special
+    if String === val && String === last # strings are special
       if val.respond_to? :upto
         return val.upto(last, exclude_end?, &block)
       else

--- a/mrblib/range.rb
+++ b/mrblib/range.rb
@@ -23,7 +23,7 @@ class Range
     if Integer === val && last.nil?
       i = val
       while true
-        block.call(i)
+        yield(i)
         i += 1
       end
       return self
@@ -42,7 +42,7 @@ class Range
       lim += 1 unless exclude_end?
       i = val
       while i < lim
-        block.call(i)
+        yield(i)
         i += 1
       end
       return self
@@ -61,14 +61,14 @@ class Range
     return self if (val <=> last) > 0
 
     while (val <=> last) < 0
-      block.call(val)
+      yield(val)
       val = val.succ
       if str_each
         break if val.size > last.size
       end
     end
 
-    block.call(val) if !exclude_end? && (val <=> last) == 0
+    yield(val) if !exclude_end? && (val <=> last) == 0
     self
   end
 

--- a/mrblib/string.rb
+++ b/mrblib/string.rb
@@ -18,7 +18,7 @@ class String
       block.call(self)
       return self
     end
-    raise TypeError unless separator.is_a?(String)
+    raise TypeError unless String === separator
 
     paragraph_mode = false
     if separator.empty?

--- a/mrblib/string.rb
+++ b/mrblib/string.rb
@@ -15,7 +15,7 @@ class String
     return to_enum(:each_line, separator) unless block
 
     if separator.nil?
-      block.call(self)
+      yield(self)
       return self
     end
     raise TypeError unless String === separator
@@ -33,12 +33,12 @@ class String
     while (pointer = string.byteindex(separator, start))
       pointer += sep_len
       pointer += 1 while paragraph_mode && string.getbyte(pointer) == 10 # 10 == \n
-      block.call(string.byteslice(start, pointer - start))
+      yield(string.byteslice(start, pointer - start))
       start = pointer
     end
     return self if start == self_len
 
-    block.call(string.byteslice(start, self_len - start))
+    yield(string.byteslice(start, self_len - start))
     self
   end
 
@@ -64,7 +64,7 @@ class String
       result << self.byteslice(offset, found - offset)
       offset = found + plen
       result << if block
-        block.call(pattern).to_s
+        yield(pattern).to_s
       else
         self.__sub_replace(replace, pattern, found)
       end
@@ -124,7 +124,7 @@ class String
     result << self.byteslice(0, found)
     offset = found + pattern.length
     result << if block
-      block.call(pattern).to_s
+      yield(pattern).to_s
     else
       self.__sub_replace(replace, pattern, found)
     end
@@ -152,7 +152,7 @@ class String
     return to_enum(:each_byte, &block) unless block
     pos = 0
     while pos < bytesize
-      block.call(getbyte(pos))
+      yield(getbyte(pos))
       pos += 1
     end
     self


### PR DESCRIPTION
the code under `$repo/mrblib/` has been changed to use `yield` instead of `&.call`
due to the `OP_BLKCALL` optimization

similarly, checks of the form `var.{is_a?, kind_of?}(Class)` have been changed into `Class === var` (aside from test, and prism source)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Standardized internal type validation across array, numeric, range, string, symbol, I/O, socket, and collection operations.
  - Streamlined block execution across enumerable, hash, numeric, range, array, and string methods.
  - Preserved existing method signatures, iteration behavior, return values, formatting, comparisons, and error handling.

- **Bug Fixes**
  - Improved consistency of type handling and callback execution without changing expected application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->