### PR TITLE
mruby-regexp: rewind a lookbehind by characters

### DIFF
--- a/mrbgems/mruby-regexp/include/re_internal.h
+++ b/mrbgems/mruby-regexp/include/re_internal.h
@@ -32,8 +32,12 @@ enum re_opcode {
   RE_BACKREF,    /* backreference: a = group number, offset = 1 if case-insensitive */
   RE_LOOKAHEAD,  /* positive lookahead: offset = end of sub-pattern */
   RE_NEG_LOOKAHEAD, /* negative lookahead: offset = end of sub-pattern */
-  RE_LOOKBEHIND,     /* positive lookbehind: a = byte length, offset = end */
-  RE_NEG_LOOKBEHIND, /* negative lookbehind: a = byte length, offset = end */
+  RE_LOOKBEHIND,     /* positive lookbehind: a = byte count, offset = end */
+  RE_NEG_LOOKBEHIND, /* negative lookbehind: a = byte count, offset = end */
+  RE_LB_WIDTH,       /* carrier after either lookbehind: a = character count.
+                        The executor rewinds by bytes against a binary subject
+                        and by characters otherwise, and the sub-pattern body
+                        starts past this instruction, at pc + 2. */
 };
 
 /* Bytecode instruction (4 bytes each for alignment) */

--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -784,15 +784,18 @@ parse_quantifier(re_compiler *c, int *min_out, int *max_out)
 }
 
 /*
- * Compute the fixed byte length consumed by bytecode in range [start, end).
- * Returns -1 if the pattern has variable length (quantifiers, alternation
- * with different-length branches, etc.).
- * Used for lookbehind: we need to know exactly how far back to look.
+ * Measure the bytecode in range [start, end) for a lookbehind, which must
+ * know exactly how far back to rewind. Returns the byte count a binary
+ * subject needs, one per consuming instruction since such a subject
+ * advances one byte whatever the instruction is, and stores in *chars_out
+ * the character count a UTF-8 subject needs. Returns -1 if the sub-pattern
+ * has no fixed width (quantifiers, alternation, etc.).
  */
 static int
-compute_fixed_len(re_compiler *c, uint32_t start, uint32_t end)
+compute_fixed_len(re_compiler *c, uint32_t start, uint32_t end, int *chars_out)
 {
   int len = 0;
+  int chars = 0;
   uint32_t pc = start;
 
   while (pc < end) {
@@ -800,28 +803,22 @@ compute_fixed_len(re_compiler *c, uint32_t start, uint32_t end)
     switch (inst.op) {
     case RE_CHAR:
       /* a multibyte literal is a run of one-byte RE_CHAR instructions,
-         so each one is exactly one byte by construction */
+         so each one is exactly one byte by construction, and the run is
+         one character per lead byte in it */
       len += 1;
+      if ((inst.a & 0xC0) != 0x80) chars += 1;
       pc++;
       break;
     case RE_CLASS:
-      /* a class that admits a multibyte character has no single byte
-         length: one holding both ASCII and non-ASCII members consumes one
-         byte here and two there. Rewinding by a wrong count lands in the
-         middle of a character, so refuse to measure it. */
-      if (!class_is_ascii_only(&c->classes[inst.a])) return -1;
-      len += 1;
-      pc++;
-      break;
     case RE_NCLASS:
-      /* the complement of an ASCII bitmap always admits non-ASCII */
-      return -1;
     case RE_ANY:
     case RE_ANY_NL:
-      /* . matches one character which can be 1-4 bytes in UTF-8.
-         For ASCII-only mode this is 1 byte; for safety, only allow
-         if we can determine it's ASCII context. Return -1 for now. */
-      return -1;
+      /* one character whatever its members can be, since the executor
+         hands a class one decoded character at a time */
+      len += 1;
+      chars += 1;
+      pc++;
+      break;
     case RE_SAVE:
       pc++;
       break;  /* zero-width */
@@ -840,11 +837,13 @@ compute_fixed_len(re_compiler *c, uint32_t start, uint32_t end)
       return -1;
     }
     case RE_MATCH:
+      *chars_out = chars;
       return len;
     default:
       return -1;  /* unknown/variable-length instruction */
     }
   }
+  *chars_out = chars;
   return len;
 }
 
@@ -1053,13 +1052,15 @@ compile_atom(re_compiler *c)
           mrb_bool negative = (c->p[2] == '!');
           next_char(c); next_char(c); next_char(c);  /* skip ?<= or ?<! */
           uint32_t lb_pos = emit(c, negative ? RE_NEG_LOOKBEHIND : RE_LOOKBEHIND, 0, 0);
+          emit(c, RE_LB_WIDTH, 0, 0);
           uint32_t sub_start = c->code_len;
           compile_alt(c);
           emit(c, RE_MATCH, 0, 0);
           c->code[lb_pos].offset = (uint16_t)c->code_len;
 
-          /* compute fixed byte length of lookbehind sub-pattern */
-          int fixed_len = compute_fixed_len(c, sub_start, c->code_len);
+          /* measure the sub-pattern for both rewind units */
+          int fixed_chars;
+          int fixed_len = compute_fixed_len(c, sub_start, c->code_len, &fixed_chars);
           if (fixed_len < 0) {
             compile_error(c, "lookbehind must be fixed length");
           }
@@ -1067,6 +1068,8 @@ compile_atom(re_compiler *c)
             compile_error(c, "lookbehind too long (max 255 bytes)");
           }
           c->code[lb_pos].a = (uint8_t)fixed_len;
+          /* the character count never exceeds the byte count, so it fits */
+          c->code[lb_pos + 1].a = (uint8_t)fixed_chars;
 
           if (peek(c) != ')') compile_error(c, "unmatched '('");
           next_char(c);

--- a/mrbgems/mruby-regexp/src/re_exec.c
+++ b/mrbgems/mruby-regexp/src/re_exec.c
@@ -568,6 +568,33 @@ pike_vm(mrb_state *mrb, const mrb_regexp_pattern *pat,
 }
 
 /*
+ * Where the lookbehind at pc starts matching from: sp rewound by the byte
+ * count in the opcode for a binary subject, and otherwise by the character
+ * count in the RE_LB_WIDTH that follows it. The backward walk steps over
+ * continuation bytes with mrb_re_utf8_interior_p(), which keeps it on the
+ * boundaries the forward decode uses, broken input included. Returns NULL
+ * when the text before sp runs out first.
+ */
+static const char*
+lookbehind_start(const mrb_regexp_pattern *pat, const char *str,
+                 const char *str_end, const char *sp, uint32_t pc,
+                 mrb_bool binary)
+{
+  if (binary) {
+    int lb_len = pat->code[pc].a;
+    return (sp - str < lb_len) ? NULL : sp - lb_len;
+  }
+  int nchars = pat->code[pc + 1].a;
+  while (nchars > 0) {
+    if (sp <= str) return NULL;
+    sp--;
+    while (sp > str && mrb_re_utf8_interior_p(str, sp, str_end)) sp--;
+    nchars--;
+  }
+  return sp;
+}
+
+/*
  * Backtracking engine for patterns with backreferences.
  * Step-limited to prevent ReDoS.
  */
@@ -734,9 +761,9 @@ bt_match(const mrb_regexp_pattern *pat, const char *str, const char *str_end,
 
     case RE_LOOKBEHIND:
       {
-        int lb_len = inst.a;
-        if (sp - str < lb_len) return FALSE;  /* not enough text before */
-        if (!bt_match(pat, str, str_end, sp - lb_len, pc + 1, captures, ncap, steps, depth + 1, binary))
+        const char *back = lookbehind_start(pat, str, str_end, sp, pc, binary);
+        if (!back) return FALSE;  /* not enough text before */
+        if (!bt_match(pat, str, str_end, back, pc + 2, captures, ncap, steps, depth + 1, binary))
           return FALSE;
         pc = inst.offset;
       }
@@ -744,11 +771,10 @@ bt_match(const mrb_regexp_pattern *pat, const char *str, const char *str_end,
 
     case RE_NEG_LOOKBEHIND:
       {
-        int lb_len = inst.a;
-        if (sp - str >= lb_len) {
-          if (bt_match(pat, str, str_end, sp - lb_len, pc + 1, captures, ncap, steps, depth + 1, binary))
-            return FALSE;
-        }
+        const char *back = lookbehind_start(pat, str, str_end, sp, pc, binary);
+        if (back &&
+            bt_match(pat, str, str_end, back, pc + 2, captures, ncap, steps, depth + 1, binary))
+          return FALSE;
         /* if not enough text before, negative lookbehind succeeds */
         pc = inst.offset;
       }

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -2160,24 +2160,45 @@ assert("Regexp - negative lookbehind at string start") do
   assert_equal "a", md[0]
 end
 
-assert("Regexp - lookbehind rejects a class that can match a multibyte character") do
-  # A class holding non-ASCII members consumes one byte here and two there,
-  # so no single rewind width is right. Refusing the pattern beats rewinding
-  # into the middle of a character, where a positive lookbehind reports no
-  # match and a negative one reports a match.
-  assert_raise(RegexpError) { Regexp.new("(?<=[Ā])x") }
-  assert_raise(RegexpError) { Regexp.new("(?<![Ā])b") }
-  assert_raise(RegexpError) { Regexp.new("(?<=[Ā-ă])x") }
-  assert_raise(RegexpError) { Regexp.new("(?<=[aĀ])x") }
-  assert_raise(RegexpError) { Regexp.new("(?<=[Ā]{2})x") }
-  # a negated class always admits non-ASCII, whatever its members are
-  assert_raise(RegexpError) { Regexp.new("(?<=[^あ])x") }
-  assert_raise(RegexpError) { Regexp.new("(?<![^a])b") }
+assert("Regexp - lookbehind over a class that can match a multibyte character") do
+  # A class consumes exactly one character whatever its members are, so the
+  # rewind steps back that many characters rather than assuming a byte each.
+  assert_equal "x", "Āx".match(/(?<=[Ā])x/)[0]
+  assert_nil "ax".match(/(?<=[Ā])x/)
+  assert_equal "x", "Āx".match(/(?<=[Ā-ă])x/)[0]
+  assert_equal "x", "ax".match(/(?<=[aĀ])x/)[0]
+  assert_equal "x", "Āx".match(/(?<=[aĀ])x/)[0]
+  assert_equal "x", "ĀĀx".match(/(?<=[Ā]{2})x/)[0]
+  assert_nil "aĀx".match(/(?<=[Ā]{2})x/)
+  assert_nil "Āx".match(/(?<=[Ā]{2})x/)
+  # a negated class admits non-ASCII, whatever its members are
+  assert_nil "あx".match(/(?<=[^あ])x/)
+  assert_equal "x", "ax".match(/(?<=[^あ])x/)[0]
+  assert_nil "Āb".match(/(?<![Ā])b/)
+  assert_equal "b", "ab".match(/(?<![Ā])b/)[0]
+  assert_equal "b", "ab".match(/(?<![^a])b/)[0]
+  assert_nil "あb".match(/(?<![^a])b/)
   # the uppercase shorthands carry the same catch-all
-  assert_raise(RegexpError) { Regexp.new("(?<=a\\W)x") }
-  assert_raise(RegexpError) { Regexp.new("(?<=\\W\\W)x") }
-  assert_raise(RegexpError) { Regexp.new("(?<=\\D)x") }
-  assert_raise(RegexpError) { Regexp.new("(?<=\\S)x") }
+  assert_equal "x", "aあx".match(/(?<=a\W)x/)[0]
+  assert_nil "aax".match(/(?<=a\W)x/)
+  assert_equal "x", "ああx".match(/(?<=\W\W)x/)[0]
+  assert_equal "x", "Āx".match(/(?<=\D)x/)[0]
+  assert_equal "x", "Āx".match(/(?<=\S)x/)[0]
+  # dot is one character by the same argument
+  assert_equal "x", "ax".match(/(?<=.)x/)[0]
+  assert_equal "x", "Āx".match(/(?<=.)x/)[0]
+  assert_nil "x".match(/(?<=.)x/)
+end
+
+assert("Regexp - lookbehind against a binary subject rewinds by bytes") do
+  # A binary subject advances one byte at a time, so the same compiled
+  # pattern rewinds by its byte count there: two for the literal Ā, and one
+  # for a class, which is handed the raw byte as its codepoint.
+  bin = "Āx".b
+  assert_equal "x", bin.match(/(?<=Ā)x/)[0]
+  assert_nil bin.match(/(?<=[Ā])x/)
+  assert_equal "x", bin.match(/(?<=[\x80])x/)[0]
+  assert_equal "x", bin.match(/(?<=.)x/)[0]
 end
 
 assert("Regexp - lookbehind measures an ASCII-only class") do


### PR DESCRIPTION
Follow-up to #7069, which stopped `compute_fixed_len()` from measuring a character
class that can match a non-ASCII codepoint. A lookbehind over one raises `RegexpError`
instead of rewinding into the middle of a character and answering wrongly. That traded
a wrong answer for an exception; it did not make the pattern work. These all raise
today and answer in CRuby:

```ruby
"Āx" =~ /(?<=[Ā])x/      # CRuby: 1,   mruby: RegexpError
"Āb" =~ /(?<![Ā])b/      # CRuby: nil, mruby: RegexpError
"あx" =~ /(?<=[^あ])x/    # CRuby: nil, mruby: RegexpError
"aあx" =~ /(?<=a\W)x/     # CRuby: 2,   mruby: RegexpError
"ax" =~ /(?<=.)x/        # CRuby: 1,   mruby: RegexpError
```

The last row is not a class at all: `RE_ANY` was rejected by `compute_fixed_len()` for
the same reason, and the same change lets it through. With this patch every row
answers; the indices differ from CRuby only where this build counts bytes and CRuby
counts characters, so the first row answers 2 here and 1 there for the same position.

## Why one count cannot do it

The count in `re_inst.a` is a byte count, and both lookbehind opcodes subtract it from
`sp` directly. A class has no fixed byte width, but it consumes exactly one character
whatever its members are, so a character count makes every class measurable. The
subject decides the unit, though, and the compiler does not know the subject:
`bt_match()` advances a binary subject one byte at a time and hands `class_match()`
the raw byte as its codepoint, so a byte count is right there, for a literal and for a
class alike. A character count is right for a class against a UTF-8 subject and wrong
for a multibyte literal, which is 2 bytes and 1 character. Storing only one of them
regresses the other:

```console
$ ./build/host/bin/mruby -e 's = "Āx".b; p(s =~ /(?<=Ā)x/)'
2
```

`(?<=Ā)x` measures correctly today because 2 is a byte count. Make it a character
count and the same pattern rewinds 1 byte against that subject, landing on `\x80`,
and stops matching.

## Fix

The lookbehind carries both numbers. `a` keeps the byte count, and a carrier
instruction, `RE_LB_WIDTH`, emitted right after the lookbehind holds the character
count; the sub-pattern body starts at `pc + 2`. The stream already holds logical units
spanning several 4-byte words, since a multibyte literal is a run of one-byte
`RE_CHAR` instructions forming one atom, so the carrier adds no new kind of shape.

- `compute_fixed_len()` returns both counts from its one walk. The byte count stays
  one per consuming instruction, because a binary subject advances one byte whatever
  the instruction is. The character count adds one per class or `RE_ANY` and counts
  only lead bytes across an `RE_CHAR` run. The `class_is_ascii_only()` test and the
  `RE_NCLASS` and `RE_ANY` rejections all disappear; `RE_SPLIT` stays rejected, so
  `(?<=ab|c)` keeps raising as before.
- The executor keeps `sp - a` for a binary subject and otherwise steps back
  `code[pc + 1].a` characters. The backward step is built on
  `mrb_re_utf8_interior_p()`, whose definition (a continuation byte no lead reaches
  is a character of its own) keeps the walk on the same boundaries the forward decode
  uses, broken input included. Running out of text keeps its current meaning: the
  positive form fails, the negative form succeeds.
- The landing stays exact without new checks: the rewind walks that many character
  boundaries, and each atom of a fixed-length sub-pattern consumes exactly one whole
  character going forward, so `RE_MATCH` arrives back at `sp` by the same argument as
  the byte version.
- The 255 limit stays a byte limit, and the character count never exceeds the byte
  count, so it fits the carrier's `uint8_t`.

## Tests

The case from #7069 that pinned the raising patterns flips to real match assertions,
covering the class forms, the negated classes, the shorthands and `(?<=.)`; the case
that pinned what must keep working is untouched. A new case pins binary subjects,
where the byte count is the one a character count would silently regress. `rake test`
is clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved regular-expression lookbehind support for character classes, shorthand classes, and multibyte characters.
  * Lookbehind now correctly handles both UTF-8 text and binary data.

* **Bug Fixes**
  * Fixed lookbehind position tracking to rewind by character width for text and by byte count for binary subjects.
  * Improved behavior when lookbehind patterns exceed the available input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->