### PR TITLE
mruby-socket: skip the AF_INET6 test where IPv6 is unavailable

### DIFF
--- a/mrbgems/mruby-socket/mrbgem.rake
+++ b/mrbgems/mruby-socket/mrbgem.rake
@@ -9,6 +9,15 @@ MRuby::Gem::Specification.new('mruby-socket') do |spec|
   spec.add_dependency('mruby-error', :core => 'mruby-error')
   # spec.add_dependency('mruby-mtest')
 
+  # The tests need to tell one socket() failure from another - notably
+  # EAFNOSUPPORT, which is what a host without IPv6 answers and is a
+  # reason to skip a test rather than fail it. Without this gem
+  # mrb_sys_fail raises a bare RuntimeError whose message is just
+  # "socket", carrying no errno to match on. A test dependency rather
+  # than a runtime one: the library itself works without Errno being
+  # defined, only the tests need to name it.
+  spec.add_test_dependency('mruby-errno', :core => 'mruby-errno')
+
   if spec.for_windows?
     spec.linker.libraries << "wsock32"
     spec.linker.libraries << "ws2_32"

--- a/mrbgems/mruby-socket/test/udpsocket.rb
+++ b/mrbgems/mruby-socket/test/udpsocket.rb
@@ -2,7 +2,28 @@ assert('UDPSocket.new') do
   s = UDPSocket.new
   assert_true(s.is_a? UDPSocket)
   s.close
-  s = UDPSocket.new(Socket::AF_INET6)
+  true
+end
+
+assert('UDPSocket.new(AF_INET6)') do
+  # A kernel built without IPv6, or booted with ipv6.disable=1, fails
+  # socket(AF_INET6, SOCK_DGRAM, 0) with EAFNOSUPPORT. That is the host
+  # reporting it has no IPv6, not UDPSocket misbehaving, so skip rather
+  # than let the exception escape and be counted as a crash - the same
+  # shape as the rescue-then-skip in mruby-io's File tests.
+  #
+  # Separate from the AF_INET case above on purpose: sharing one assert
+  # meant that a host without IPv6 lost the IPv4 coverage as well.
+  # EAFNOSUPPORT specifically, not any failure: every other errno from
+  # socket() is a real fault and should still fail the run. Naming it
+  # needs Errno, which is why mrbgem.rake takes mruby-errno as a test
+  # dependency - without it this raises a bare RuntimeError("socket")
+  # and there is nothing to match on.
+  begin
+    s = UDPSocket.new(Socket::AF_INET6)
+  rescue Errno::EAFNOSUPPORT => e
+    skip e.message
+  end
   assert_true(s.is_a? UDPSocket)
   s.close
   true


### PR DESCRIPTION
`UDPSocket.new(Socket::AF_INET6)` in test/udpsocket.rb is unconditional. On a host without IPv6 - a kernel built without it, or booted with ipv6.disable=1, which is common in containers - socket(AF_INET6, SOCK_DGRAM, 0) fails with EAFNOSUPPORT, the exception escapes the assert block, and mrbtest counts it as a crash rather than a failure. `rake test` then exits non-zero on a machine where nothing is actually wrong.

Split the IPv6 case into its own assert and skip it when the address family is unsupported, the same rescue-then-skip shape mruby-io's File tests use for unavailable platform features.

Splitting matters rather than just wrapping the existing assert: sharing one assert meant a host without IPv6 lost the AF_INET coverage too, silently, because skip aborts the whole block.

The rescue names Errno::EAFNOSUPPORT specifically - every other errno from socket() is a real fault and should still fail the run. Naming it needs Errno to be defined, and mruby-socket depends on mruby-io and mruby-error, not mruby-errno; without that gem mrb_sys_fail raises a bare RuntimeError whose message is just "socket", with no errno to match on. So mrbgem.rake takes mruby-errno as a test dependency.

Verified on this commit's parent, in a build with mruby-socket enabled, on a host with no IPv6:

  before:  Total 2049  OK 2027  KO 0  Crash 1   rake test exits 1
  after:   Total 2050  OK 2028  KO 0  Crash 0   rake test exits 0
           Skip: UDPSocket.new(AF_INET6) => Address family not
                 supported by protocol - socket

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved UDP socket tests to handle environments where IPv6 is unavailable.
  - Other socket errors continue to be reported normally, improving test reliability across platforms.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->