### PR TITLE
string.c: reject UTF-8 sequences forbidden by RFC 3629

### DIFF
--- a/mrbgems/mruby-encoding/test/string.rb
+++ b/mrbgems/mruby-encoding/test/string.rb
@@ -10,6 +10,18 @@ assert('String#valid_encoding?') do
     assert_false "\xfe".valid_encoding?
     assert_false "あ\xfe".valid_encoding?
     assert_true "あ\xfe".b.valid_encoding?
+    # RFC 3629 restrictions
+    assert_false "\xC0\x80".valid_encoding?          # overlong NUL
+    assert_false "\xC1\xBF".valid_encoding?          # overlong (< U+0080)
+    assert_false "\xE0\x9F\xBF".valid_encoding?      # overlong (< U+0800)
+    assert_false "\xED\xA0\x80".valid_encoding?      # surrogate U+D800
+    assert_false "\xED\xBF\xBF".valid_encoding?      # surrogate U+DFFF
+    assert_false "\xF0\x8F\xBF\xBF".valid_encoding?  # overlong (< U+10000)
+    assert_false "\xF4\x90\x80\x80".valid_encoding?  # above U+10FFFF
+    assert_false "\xF5\x80\x80\x80".valid_encoding?  # above U+10FFFF
+    assert_true "\u{D7FF}".valid_encoding?           # last code point before surrogates
+    assert_true "\u{E000}".valid_encoding?           # first code point after surrogates
+    assert_true "\u{10FFFF}".valid_encoding?         # largest valid code point
   else
     assert_true "\xfe".valid_encoding?
   end

--- a/src/string.c
+++ b/src/string.c
@@ -485,6 +485,26 @@ mrb_utf8len(const char* p, const char* e)
   case 2:
     if (utf8_islead(p[1])) return 1;
   }
+  /* Reject overlong sequences, UTF-16 surrogates, and code points above
+     U+10FFFF (RFC 3629, Unicode D93b). */
+  switch ((unsigned char)p[0]) {
+  case 0xC0: case 0xC1:                       /* overlong (< U+0080) */
+    return 1;
+  case 0xE0:                                  /* overlong (< U+0800) */
+    if ((unsigned char)p[1] < 0xA0) return 1;
+    break;
+  case 0xED:                                  /* surrogate (U+D800..U+DFFF) */
+    if ((unsigned char)p[1] > 0x9F) return 1;
+    break;
+  case 0xF0:                                  /* overlong (< U+10000) */
+    if ((unsigned char)p[1] < 0x90) return 1;
+    break;
+  case 0xF4:                                  /* above U+10FFFF */
+    if ((unsigned char)p[1] > 0x8F) return 1;
+    break;
+  case 0xF5: case 0xF6: case 0xF7:            /* above U+10FFFF */
+    return 1;
+  }
   return len;
 }
 

--- a/test/t/string.rb
+++ b/test/t/string.rb
@@ -639,6 +639,20 @@ assert('String#size(UTF-8)', '15.2.10.5.33') do
   assert_equal 2, str[1, 2].size
 end if UTF8STRING
 
+assert('String#size(UTF-8) counts invalid sequences per byte') do
+  # RFC 3629: overlong forms, UTF-16 surrogates, and code points above
+  # U+10FFFF are not characters, so each of their bytes counts on its own
+  assert_equal 2, "\xC0\x80".size          # overlong NUL
+  assert_equal 3, "\xE0\x9F\xBF".size      # overlong (< U+0800)
+  assert_equal 3, "\xED\xA0\x80".size      # surrogate U+D800
+  assert_equal 4, "\xF0\x8F\xBF\xBF".size  # overlong (< U+10000)
+  assert_equal 4, "\xF4\x90\x80\x80".size  # above U+10FFFF
+  assert_equal 4, "\xF5\x80\x80\x80".size  # above U+10FFFF
+  assert_equal 1, "\u{D7FF}".size          # last code point before surrogates
+  assert_equal 1, "\u{E000}".size          # first code point after surrogates
+  assert_equal 1, "\u{10FFFF}".size        # largest valid code point
+end if UTF8STRING
+
 assert('String#slice', '15.2.10.5.34') do
   # length of args is 1
   a = 'abc'.slice(0)


### PR DESCRIPTION
## Problem

`mrb_utf8len()` checks only the length implied by the lead byte and that
the following bytes are continuation bytes (`80-BF`). That accepts three
classes of sequences the RFC 3629 grammar excludes from UTF-8:

- overlong encodings: `C0`/`C1` leads, `E0 80-9F`, `F0 80-8F`
- UTF-16 surrogates U+D800 to U+DFFF: `ED A0-BF`
- code points above U+10FFFF: `F4 90-BF`, `F5` to `F7` leads

Since `mrb_utf8len()` backs `String#size`, character indexing, and
`String#valid_encoding?`, these sequences were treated as valid
characters:

```ruby
s = "\xED\xA0\x80"     # encodes the surrogate U+D800
s.valid_encoding?      # CRuby: false, mruby before: true, after: false
s.size                 # CRuby: 3, mruby before: 1, after: 3

"\xC0\x80".size        # CRuby: 2, mruby before: 1, after: 2 (overlong NUL)
```

## Change

Add the lead-specific second byte range checks after the existing
continuation byte checks. A rejected sequence takes the same path as
every other invalid sequence: it counts one byte and moves on.

mruby-string-ext already enforces these rules in `utf8code()` behind
`String#ord` and in `str_scrub_char_len()` behind `String#scrub`; this
brings `mrb_utf8len()` in line with them. Boundary code points (U+D7FF,
U+E000, U+10FFFF) remain valid.

## Validation

- Exhaustive comparison against a direct transcription of the RFC 3629
  ABNF: all 1 to 3 byte windows and all 4 byte windows with `F0-FF`
  leads (285,278,464 windows in total, the remaining leads never read a
  fourth byte) return the character length for valid sequences and 1
  for everything else, with zero mismatches. The throwaway harness is
  not part of this PR.
- New tests: `String#size` counts each byte of a rejected sequence
  (test/t/string.rb) and `String#valid_encoding?` covers all three
  classes plus the valid boundary code points
  (mrbgems/mruby-encoding/test/string.rb).
- `rake test` passes with the default gembox and with full-core
  (`MRB_UTF8_STRING` enabled).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UTF-8 validation for string operations.
  * Invalid sequences, including overlong encodings, surrogate code points, and values above U+10FFFF, are now rejected correctly.
  * Valid boundary code points continue to be recognized correctly.

* **Tests**
  * Added coverage for valid and invalid UTF-8 byte sequences and string size handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->