### PR TITLE
mruby-regexp: drop the private UTF-8 encoder in favor of `mrb_utf8_to_buf`

### DIFF
--- a/mrbgems/mruby-regexp/include/re_internal.h
+++ b/mrbgems/mruby-regexp/include/re_internal.h
@@ -175,7 +175,6 @@ void mrb_re_free(mrb_state *mrb, mrb_regexp_pattern *pat);
 /* UTF-8 helpers */
 int mrb_re_utf8_charlen(const char *s, const char *end);
 uint32_t mrb_re_utf8_decode(const char *s, const char *end, int *len);
-int mrb_re_utf8_encode(uint32_t cp, char *buf);
 mrb_bool mrb_re_is_word_char(uint32_t c);
 
 /* The two foldings whose result is an ASCII letter. Every build carries them,

--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -9,6 +9,7 @@
 
 #include "re_internal.h"
 #include <mruby/error.h>
+#include <mruby/internal.h>
 #include <string.h>
 
 /* Compiler state */
@@ -449,7 +450,7 @@ parse_escape(re_compiler *c)
 
 /* Reject what has no UTF-8 encoding. CRuby reports both a surrogate and a
    value past the last plane as "invalid Unicode range", so neither ever
-   reaches mrb_re_utf8_encode(). */
+   reaches mrb_utf8_to_buf(). */
 static void
 check_unicode_cp(re_compiler *c, uint32_t cp)
 {
@@ -1038,7 +1039,7 @@ emit_codepoint(re_compiler *c, uint32_t cp)
   }
   if ((c->flags & RE_FLAG_IGNORECASE) && emit_cp_folded(c, cp)) return;
   char buf[4];
-  int len = mrb_re_utf8_encode(cp, buf);
+  int len = (int)mrb_utf8_to_buf(buf, cp);
   for (int i = 0; i < len; i++) {
     emit(c, RE_CHAR, (uint8_t)buf[i], 0);
   }

--- a/mrbgems/mruby-regexp/src/re_utf8.c
+++ b/mrbgems/mruby-regexp/src/re_utf8.c
@@ -74,34 +74,6 @@ mrb_re_utf8_decode(const char *s, const char *end, int *len)
   }
 }
 
-/* Encode a codepoint as UTF-8 into buf and return the byte length, at most 4.
-   Callers reject a surrogate and anything above U+10FFFF before they get
-   here, so every input has an encoding. */
-int
-mrb_re_utf8_encode(uint32_t cp, char *buf)
-{
-  if (cp < 0x80) {
-    buf[0] = (char)cp;
-    return 1;
-  }
-  if (cp < 0x800) {
-    buf[0] = (char)(0xc0 | (cp >> 6));
-    buf[1] = (char)(0x80 | (cp & 0x3f));
-    return 2;
-  }
-  if (cp < 0x10000) {
-    buf[0] = (char)(0xe0 | (cp >> 12));
-    buf[1] = (char)(0x80 | ((cp >> 6) & 0x3f));
-    buf[2] = (char)(0x80 | (cp & 0x3f));
-    return 3;
-  }
-  buf[0] = (char)(0xf0 | (cp >> 18));
-  buf[1] = (char)(0x80 | ((cp >> 12) & 0x3f));
-  buf[2] = (char)(0x80 | ((cp >> 6) & 0x3f));
-  buf[3] = (char)(0x80 | (cp & 0x3f));
-  return 4;
-}
-
 /* Check if character is a "word" character (\w): [a-zA-Z0-9_] */
 mrb_bool
 mrb_re_is_word_char(uint32_t c)


### PR DESCRIPTION
The regexp gem carried a private UTF-8 encoder, `mrb_re_utf8_encode` in
re_utf8.c, whose implementation is byte for byte the same as
`mrb_utf8_to_buf` in src/string.c. This PR deletes the private copy and
switches its only caller, `emit_codepoint` in re_compile.c, to the
shared function.

Using the shared encoder from a gem follows existing practice:
mruby-sprintf, mruby-pack, and mruby-string-ext all call
`mrb_utf8_to_buf` through `<mruby/internal.h>`, and regexp.c in this
gem already includes that header.

The one difference between the two functions is that `mrb_utf8_to_buf`
returns 0 for a codepoint above U+10FFFF, where the private copy
assumed the caller had validated its input. The compiler satisfies that
assumption: every codepoint reaching `emit_codepoint` comes through
`check_unicode_cp`, which rejects surrogates and anything past the last
plane as "invalid Unicode range" before encoding, matching CRuby:

```ruby
/\u{110000}/   # regexp.rb:1: invalid Unicode range (SyntaxError)
```

So the zero-length case is unreachable and no caller changes behavior.

Net effect: 3 insertions, 31 deletions, no functional change.
`rake test` passes (2050 tests, 0 failures; bintest 105 OK).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal Unicode handling in regular expression processing.
  * Updated Unicode encoding references to use the runtime’s standard implementation.
  * Removed redundant internal encoding logic without changing user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->