### PR TITLE
mruby-encoding: drop the unused `utf8_islead` macro

### DIFF
--- a/mrbgems/mruby-encoding/src/encoding.c
+++ b/mrbgems/mruby-encoding/src/encoding.c
@@ -17,8 +17,6 @@
 static mrb_value
 str_valid_enc_p(mrb_state *mrb, mrb_value str)
 {
-#define utf8_islead(c) ((unsigned char)((c)&0xc0) != 0x80)
-
   struct RString *s = mrb_str_ptr(str);
   if (RSTR_SINGLE_BYTE_P(s)) return mrb_true_value();
   if (RSTR_BINARY_P(s)) return mrb_true_value();


### PR DESCRIPTION
`mrbgems/mruby-encoding/src/encoding.c` defines `utf8_islead` at the head of
`str_valid_enc_p`, but the function never expands it. The macro has been dead
since the gem was added in 74bdae9 (`mruby-encoding: add Poorman's Encoding
gem`): `str_valid_enc_p` asks `mrb_utf8len` for the length of each character
and rejects a stray byte with the `len == 1 && (*p & 0x80)` test, so it never
inspects a continuation byte on its own.

`src/string.c` carries its own definition of the same name and keeps using it,
as does `mirb_buffer.c`. This change touches only the unused copy in the gem.

No behavior change. `rake` builds clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused internal code without changing encoding validation or observable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->