### PR TITLE
string.c: bound check `mrb_str_byte_to_char` before use

### DIFF
--- a/include/mruby/internal.h
+++ b/include/mruby/internal.h
@@ -174,8 +174,10 @@ uint32_t mrb_byte_hash_step(const uint8_t*, mrb_int, uint32_t);
    the string ends before `nchars` characters, the remaining byte length plus
    one is returned so out-of-range requests stay detectable. mrb_str_byte_to_char
    returns the character index for byte offset `bi` counted from the start of
-   the string, or -1 when `bi` is past the end or inside a multi-byte character.
-   On non-UTF-8 builds a byte is a character and both are identity. */
+   the string, or -1 when `bi` is outside the string or inside a multi-byte
+   character. On non-UTF-8 builds a byte is a character, so the conversions are
+   identity within the string, and mrb_str_byte_to_char still rejects an offset
+   outside it. */
 mrb_int mrb_str_char_to_byte(mrb_state *mrb, mrb_value str, mrb_int off, mrb_int nchars);
 mrb_int mrb_str_byte_to_char(mrb_state *mrb, mrb_value str, mrb_int bi);
 

--- a/src/string.c
+++ b/src/string.c
@@ -624,6 +624,7 @@ mrb_str_byte_to_char(mrb_state *mrb, mrb_value str, mrb_int bi)
 {
   (void)mrb;
   struct RString *s = mrb_str_ptr(str);
+  if (bi < 0 || RSTR_LEN(s) < bi) return -1;
   if (RSTR_SINGLE_BYTE_P(s) || RSTR_BINARY_P(s)) {
     return bi;
   }
@@ -633,7 +634,6 @@ mrb_str_byte_to_char(mrb_state *mrb, mrb_value str, mrb_int bi)
   const char *pivot = p + bi;
   mrb_int i = 0;
 
-  if (e < pivot) return -1;
   while (p < pivot) {
     if ((*p & 0x80) == 0) {
       const char *np = search_nonascii(p, pivot);
@@ -705,7 +705,7 @@ mrb_int
 mrb_str_byte_to_char(mrb_state *mrb, mrb_value str, mrb_int bi)
 {
   (void)mrb;
-  (void)str;
+  if (bi < 0 || RSTRING_LEN(str) < bi) return -1;
   return bi;
 }
 #define char_adjust(ptr, end) (ptr)


### PR DESCRIPTION
Follow-up to #7097, which promoted `chars2bytes` / `bytes2chars` to
`mrb_str_char_to_byte` / `mrb_str_byte_to_char`. This addresses a review
comment that arrived after the merge.

`mrb_str_byte_to_char` formed `p + bi` before testing the offset, so a byte
offset outside the string produced an out-of-bounds pointer, and the
single-byte and binary fast path returned that offset unchanged instead of
-1. Moving the bounds test to the top covers the fast path and the pointer
arithmetic alike, and the `e < pivot` test it replaces goes away.

The non-UTF-8 identity function gets the same test, so the documented
contract holds on every build: -1 when the offset lies outside the string,
and on UTF-8 builds also when it lands inside a multi-byte character. Without
this, the same call would answer differently depending on `MRB_UTF8_STRING`,
which is the opposite of what promoting these functions was for.

Every caller clamps the offset it passes today (`str_rindex` results,
`str_index_str_by_char`, and `re_byte_to_char` in mruby-regexp, which clamps
to `RSTRING_LEN` before calling), so no behavior changes. The check belongs
in the function now that it is internal API rather than a static confined to
`string.c`.

## Testing

- `rake test` with `build_config/host-debug.rb` (full-core, `MRB_UTF8_STRING`):
  mrbtest 2233 OK / 0 KO, bintest 116 OK.
- `rake test` with the default config (byte strings, identity conversion):
  mrbtest 2032 OK / 0 KO, bintest 105 OK.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - String byte-to-character conversion now rejects negative and out-of-range byte offsets consistently.
  - Invalid offsets return an error instead of producing unexpected character positions.
  - Non-UTF-8 conversions continue to behave as identity operations while enforcing valid bounds.

- **Documentation**
  - Clarified the accepted offset range and behavior for non-UTF-8 strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->