### PR TITLE
string.c: search bytes in `String#byterindex` and in `String#rindex` on a binary string

### DIFF
--- a/mrbgems/mruby-string-ext/test/string.rb
+++ b/mrbgems/mruby-string-ext/test/string.rb
@@ -850,6 +850,28 @@ assert('String#chop! on a binary string removes one byte') do
   end
 end
 
+assert('String#rindex on a binary string counts bytes') do
+  # `rindex` reads a byte-indexed string as UTF-8 unless the single-byte flag
+  # is already set, so it stepped over the bytes inside a multi-byte sequence
+  # and moved a negative position by characters. `index` counts bytes there,
+  # and the two have to meet.
+  if UTF8STRING
+    s = "aあb".b # "\x61\xe3\x81\x82\x62"
+    assert_equal 2, s.rindex("\x81".b)
+    assert_equal s.index("\x81".b), s.rindex("\x81".b)
+    assert_equal 1, s.rindex("\xe3".b)
+    assert_equal 4, s.rindex("b".b)
+    assert_equal 2, s.rindex("\x81".b, -2)
+    assert_equal 2, s.rindex("\x81".b, -3)
+    assert_nil s.rindex("\x81".b, 1)
+    assert_equal 4, s.rindex("b".b, -1)
+    # the same answers once #length has set the single-byte flag
+    assert_equal 5, s.length
+    assert_equal 2, s.rindex("\x81".b)
+    assert_equal 2, s.rindex("\x81".b, -2)
+  end
+end
+
 assert('String#codepoints') do
   expect = [104, 101, 108, 108, 111, 33]
   assert_equal expect, "hello!".codepoints

--- a/src/string.c
+++ b/src/string.c
@@ -2540,7 +2540,8 @@ mrb_str_byterindex_m(mrb_state *mrb, mrb_value str)
 static mrb_value
 mrb_str_rindex_m(mrb_state *mrb, mrb_value str)
 {
-  if (RSTR_SINGLE_BYTE_P(mrb_str_ptr(str))) {
+  struct RString *s = mrb_str_ptr(str);
+  if (RSTR_SINGLE_BYTE_P(s) || RSTR_BINARY_P(s)) {
     return mrb_str_byterindex_m(mrb, str);
   }
 

--- a/src/string.c
+++ b/src/string.c
@@ -966,7 +966,7 @@ str_replace(mrb_state *mrb, struct RString *s1, struct RString *s2)
 static mrb_int
 str_byterindex(mrb_value str, mrb_value sub, mrb_int pos)
 {
-  const char *s, *sbeg, *t;
+  const char *sbeg, *t;
   struct RString *ps = mrb_str_ptr(str);
   mrb_int len = RSTRING_LEN(sub);
   mrb_int slen = RSTR_LEN(ps);
@@ -980,12 +980,12 @@ str_byterindex(mrb_value str, mrb_value sub, mrb_int pos)
 
   sbeg = RSTR_PTR(ps);
   t = RSTRING_PTR(sub);
-  s = sbeg + pos;
-  while (sbeg <= s) {
-    if (memcmp(s, t, len) == 0) {
-      return (mrb_int)(s - sbeg);
+  /* count down an index rather than a pointer: stepping a pointer past the
+     first byte to end the search would leave the buffer */
+  for (mrb_int i = pos; 0 <= i; i--) {
+    if (memcmp(sbeg+i, t, len) == 0) {
+      return i;
     }
-    s--;
   }
   return -1;
 }
@@ -1013,10 +1013,13 @@ str_char_rindex(mrb_value str, mrb_value sub, mrb_int pos)
   t = RSTRING_PTR(sub);
   if (len) {
     s = char_adjust(s, send);
-    while (sbeg <= s) {
+    for (;;) {
       if ((mrb_int)(send - s) >= len && memcmp(s, t, len) == 0) {
         return (mrb_int)(s - sbeg);
       }
+      /* char_backtrack() answers the byte before `s`, which would leave the
+         buffer once the search has reached the first character */
+      if (s == sbeg) break;
       s = char_backtrack(sbeg, s);
     }
     return -1;

--- a/src/string.c
+++ b/src/string.c
@@ -708,8 +708,6 @@ mrb_str_byte_to_char(mrb_state *mrb, mrb_value str, mrb_int bi)
   (void)str;
   return bi;
 }
-#define char_adjust(ptr, end) (ptr)
-#define char_backtrack(ptr, end) ((end) - 1)
 #define str_index_str_by_char(mrb, str, sub, pos) str_index_str((mrb), (str), (sub), (pos))
 #endif
 
@@ -963,8 +961,41 @@ str_replace(mrb_state *mrb, struct RString *s1, struct RString *s2)
   return mrb_obj_value(s1);
 }
 
+/* Search backward for `sub` one byte at a time, the mirror of the forward
+   scan in str_index(). This is what a byte-indexed string answers with. */
 static mrb_int
-str_rindex(mrb_state *mrb, mrb_value str, mrb_value sub, mrb_int pos)
+str_byterindex(mrb_value str, mrb_value sub, mrb_int pos)
+{
+  const char *s, *sbeg, *t;
+  struct RString *ps = mrb_str_ptr(str);
+  mrb_int len = RSTRING_LEN(sub);
+  mrb_int slen = RSTR_LEN(ps);
+
+  /* substring longer than string */
+  if (slen < len) return -1;
+  if (slen - pos < len) {
+    pos = slen - len;
+  }
+  if (len == 0) return pos;
+
+  sbeg = RSTR_PTR(ps);
+  t = RSTRING_PTR(sub);
+  s = sbeg + pos;
+  while (sbeg <= s) {
+    if (memcmp(s, t, len) == 0) {
+      return (mrb_int)(s - sbeg);
+    }
+    s--;
+  }
+  return -1;
+}
+
+#ifdef MRB_UTF8_STRING
+/* Search backward for `sub` over character boundaries, so a match starting
+   inside a multi-byte character is stepped over rather than reported. This
+   is what a character-indexed string answers with. */
+static mrb_int
+str_char_rindex(mrb_value str, mrb_value sub, mrb_int pos)
 {
   const char *s, *sbeg, *send, *t;
   struct RString *ps = mrb_str_ptr(str);
@@ -994,6 +1025,7 @@ str_rindex(mrb_state *mrb, mrb_value str, mrb_value sub, mrb_int pos)
     return pos;
   }
 }
+#endif
 
 #ifdef _WIN32
 #include <stdlib.h>
@@ -2482,7 +2514,7 @@ mrb_str_byterindex_m(mrb_state *mrb, mrb_value str)
     }
     if (pos > len) pos = len;
   }
-  pos = str_rindex(mrb, str, sub, pos);
+  pos = str_byterindex(str, sub, pos);
   if (pos < 0) {
     return mrb_nil_value();
   }
@@ -2530,7 +2562,7 @@ mrb_str_rindex_m(mrb_state *mrb, mrb_value str)
     if (p == e) return mrb_nil_value();
     pos = (mrb_int)(e - p);
   }
-  pos = str_rindex(mrb, str, sub, pos);
+  pos = str_char_rindex(str, sub, pos);
   if (pos >= 0) {
     pos = mrb_str_byte_to_char(mrb, str, pos);
     if (pos < 0) return mrb_nil_value();

--- a/test/t/string.rb
+++ b/test/t/string.rb
@@ -649,6 +649,25 @@ assert('String#rindex(UTF-8)', '15.2.10.5.31') do
   assert_equal  3, broken.rindex("☁", 10)
 end if UTF8STRING
 
+assert('String#byterindex searches bytes') do
+  # `byterindex` answers byte positions, so it walks bytes the way
+  # `byteindex` does. Walking characters instead, it passed over every byte
+  # inside a multi-byte sequence and reported nothing there.
+  str = "aあb" # "\x61\xe3\x81\x82\x62"
+  assert_equal 1, str.byterindex("\xe3")
+  assert_equal 2, str.byterindex("\x81")
+  assert_equal 3, str.byterindex("\x82")
+  assert_equal str.byteindex("\x81"), str.byterindex("\x81")
+  assert_equal 4, str.byterindex("b")
+  assert_equal 2, str.byterindex("\x81", 2)
+  assert_nil str.byterindex("\x81", 1)
+
+  assert_equal 3, 'abcabc'.byterindex('a')
+  assert_equal 0, 'abcabc'.byterindex('a', 1)
+  assert_equal 6, 'abcabc'.byterindex('')
+  assert_nil 'abc'.byterindex('d')
+end
+
 # assert('String#scan', '15.2.10.5.32') do
 #   # Not implemented yet
 # end


### PR DESCRIPTION
A backward search reads a string one way while the forward search reads it
another. `str_index()` scans bytes, but `str_rindex()` walked character
boundaries with `char_adjust()` / `char_backtrack()`, and both `String#rindex`
and `String#byterindex` went through it. Two pairs of methods disagree as a
result, and neither disagreement depends on malformed input.

## `byterindex` against `byteindex`

`byterindex` reports byte positions, so it has to be able to name a position
inside a multi-byte sequence. Walking characters, it never visited one:

```ruby
s = "aあb"
s.byteindex("\x81")   # => 2
s.byterindex("\x81")  # => nil, CRuby answers 2 for a byte-indexed subject
```

`str_byterindex()` now scans one byte at a time, the mirror of `str_index()`,
and backs `String#byterindex`. `str_char_rindex()` keeps the boundary walk and
backs `String#rindex`, where a match starting inside a character must be
passed over so the search continues to the character before it. The existing
`assert_nil broken.rindex("\x81")` in `test/t/string.rb` pins that half down
and still holds. A non-UTF-8 build reaches only the byte scan, so the
`char_adjust()` and `char_backtrack()` identity macros defined there are gone.

## `rindex` against `index` on a binary string

`rindex` dispatches to the byte search when the single-byte flag is set, but a
binary string that has not had its flag computed went on to the UTF-8 path, so
the walk moved over character boundaries and a negative position was counted
in characters. `index` counts bytes for the same string:

```ruby
s = "aあb".b
s.index("\x81".b)      # => 2
s.rindex("\x81".b)     # => nil, CRuby answers 2
s.rindex("\x81".b, -2) # => nil, CRuby answers 2
s.length               # marks the string single-byte
s.rindex("\x81".b)     # => 2
```

Adding `RSTR_BINARY_P` to that dispatch reads the string the way
`mrb_str_char_to_byte()` and `mrb_str_byte_to_char()` already read it. Every
value above now matches CRuby 4.0.6, before and after the flag is set.

## Testing

- `rake test` with `build_config/host-debug.rb` (full-core, `MRB_UTF8_STRING`):
  mrbtest 2235 OK / 0 KO, bintest 116 OK.
- `rake test` with the default config (byte strings): mrbtest 2033 OK / 0 KO,
  bintest 105 OK.
- Both new assertions were confirmed to fail against the implementation each
  commit replaces.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reverse string searches for binary and single-byte strings by consistently using byte offsets.
  * Preserved character-aware reverse searching for standard UTF-8 strings.
  * Corrected handling of negative positions, bounds, empty searches, missing matches, and multibyte content.
  * Ensured `String#byterindex` correctly searches by byte position, including within multibyte UTF-8 sequences.

* **Tests**
  * Added coverage for byte-based reverse searches across UTF-8, binary, and ASCII strings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->