### PR TITLE
Move the `String#valid_encoding?` body into core as `mrb_str_valid_encoding_p`

### DIFF
--- a/include/mruby/internal.h
+++ b/include/mruby/internal.h
@@ -181,6 +181,16 @@ uint32_t mrb_byte_hash_step(const uint8_t*, mrb_int, uint32_t);
 mrb_int mrb_str_char_to_byte(mrb_state *mrb, mrb_value str, mrb_int off, mrb_int nchars);
 mrb_int mrb_str_byte_to_char(mrb_state *mrb, mrb_value str, mrb_int bi);
 
+/* Whether a string's bytes read as the encoding it is taken to have. A binary
+   string claims no encoding and is valid whatever its bytes are; any other
+   string is walked, and one that turns out to hold a byte standing for no
+   character is not valid. The single-byte flag is not read on the way in, so
+   the answer does not depend on whether the string has been measured before;
+   a string found to have one byte per character is marked on the way out. On
+   non-UTF-8 builds a string is bytes with no encoding to disagree with, and
+   this is always TRUE. */
+mrb_bool mrb_str_valid_encoding_p(mrb_state *mrb, mrb_value str);
+
 mrb_int mrb_utf8_to_buf(char *buf, uint32_t cp);
 #ifdef MRB_UTF8_STRING
 mrb_int mrb_utf8len(const char *str, const char *end);

--- a/mrbgems/mruby-encoding/src/encoding.c
+++ b/mrbgems/mruby-encoding/src/encoding.c
@@ -17,27 +17,7 @@
 static mrb_value
 str_valid_enc_p(mrb_state *mrb, mrb_value str)
 {
-  struct RString *s = mrb_str_ptr(str);
-  /* MRB_STR_SINGLE_BYTE says one byte per character, which every other reader
-     uses to index without decoding. A string of stray bytes has that property
-     too, so it cannot stand in for "valid" here: String#size sets the flag on
-     "a\x80" and this used to answer true for it afterwards. Only the loop
-     below decides. */
-  if (RSTR_BINARY_P(s)) return mrb_true_value();
-
-  mrb_int byte_len = RSTR_LEN(s);
-  mrb_int utf8_len = 0;
-  const char *p = RSTR_PTR(s);
-  const char *e = p + byte_len;
-  while (p < e) {
-    mrb_int len = mrb_utf8len(p, e);
-
-    if (len == 1 && (*p & 0x80)) return mrb_false_value();
-    p += len;
-    utf8_len++;
-  }
-  if (byte_len == utf8_len) RSTR_SET_SINGLE_BYTE_FLAG(s);
-  return mrb_true_value();
+  return mrb_bool_value(mrb_str_valid_encoding_p(mrb, str));
 }
 
 static mrb_value

--- a/mrbgems/mruby-encoding/test/string.rb
+++ b/mrbgems/mruby-encoding/test/string.rb
@@ -41,6 +41,29 @@ assert('String#valid_encoding?') do
   end
 end
 
+assert('String#valid_encoding? after a run of ASCII') do
+  # The walk skips ASCII a word at a time and decodes only where a byte leaves
+  # that range, so a broken byte has to be caught after such a run as well as
+  # at the head of the string.
+  if UTF8STRING
+    assert_true ("a" * 40).valid_encoding?
+    assert_true ("a" * 40 + "あ").valid_encoding?
+    assert_false ("a" * 40 + "\xfe").valid_encoding?
+    assert_false ("a" * 40 + "\xe3\x81").valid_encoding?  # 3-byte sequence cut short
+    assert_true ("a" * 40 + "\xe3\x81").b.valid_encoding?
+  end
+end
+
+assert('String#valid_encoding? of a shared substring') do
+  # A substring too long to embed shares the parent's buffer, so the walk has
+  # to stop where the substring ends rather than where the parent's bytes do.
+  if UTF8STRING
+    parent = "あ" * 40 + "\xfe"
+    assert_true parent.byteslice(0, 120).valid_encoding?
+    assert_false parent.byteslice(0, 121).valid_encoding?
+  end
+end
+
 assert('String#length of a binary string counts bytes') do
   # A byte-indexed string has one position per byte, which is what indexing it
   # already answered. Measuring it read the same string as UTF-8, so the length

--- a/src/string.c
+++ b/src/string.c
@@ -525,8 +525,12 @@ static inline uint32_t popcount(bitint x)
 }
 #endif
 
-mrb_int
-mrb_utf8_strlen(const char *str, mrb_int byte_len)
+/* Counts characters, and when `validp` is given also reports whether every
+   sequence decoded as one character. The walk stops at the first broken
+   sequence, so the returned count is a character count only while `*validp`
+   stays TRUE. */
+static mrb_int
+utf8_strlen_check(const char *str, mrb_int byte_len, mrb_bool *validp)
 {
   const char *p = str;
   const char *e = str + byte_len;
@@ -539,11 +543,26 @@ mrb_utf8_strlen(const char *str, mrb_int byte_len)
     if (np == e) break;
     p = np;
     while (p < e && NOASCII(*p)) {
-      p += mrb_utf8len(p, e);
+      mrb_int clen = mrb_utf8len(p, e);
+
+      /* mrb_utf8len() answers 1 for a byte that leads no valid sequence. The
+         byte here is known to be non-ASCII, so a length of 1 means the string
+         carries a byte that stands for no character. */
+      if (validp && clen == 1) {
+        *validp = FALSE;
+        return len;
+      }
+      p += clen;
       len++;
     }
   }
   return len;
+}
+
+mrb_int
+mrb_utf8_strlen(const char *str, mrb_int byte_len)
+{
+  return utf8_strlen_check(str, byte_len, NULL);
 }
 
 static mrb_int
@@ -577,6 +596,27 @@ utf8_strlen(mrb_value str)
 }
 
 #define RSTRING_CHAR_LEN(s) utf8_strlen(s)
+
+/* whether a string's bytes read as the encoding it is taken to have */
+mrb_bool
+mrb_str_valid_encoding_p(mrb_state *mrb, mrb_value str)
+{
+  (void)mrb;
+  struct RString *s = mrb_str_ptr(str);
+  /* A byte-indexed string makes no such claim, so it is valid whatever its
+     bytes are. MRB_STR_SINGLE_BYTE is deliberately not read here: it says one
+     byte per character, which a string of stray bytes satisfies too, so only
+     the walk below decides. */
+  if (RSTR_BINARY_P(s)) return TRUE;
+
+  mrb_int byte_len = RSTR_LEN(s);
+  mrb_bool valid = TRUE;
+  mrb_int utf8_len = utf8_strlen_check(RSTR_PTR(s), byte_len, &valid);
+
+  if (!valid) return FALSE;
+  if (byte_len == utf8_len) RSTR_SET_SINGLE_BYTE_FLAG(s);
+  return TRUE;
+}
 
 /* map character index to byte offset index */
 mrb_int
@@ -711,6 +751,15 @@ mrb_str_byte_to_char(mrb_state *mrb, mrb_value str, mrb_int bi)
 #define char_adjust(ptr, end) (ptr)
 #define char_backtrack(ptr, end) ((end) - 1)
 #define str_index_str_by_char(mrb, str, sub, pos) str_index_str((mrb), (str), (sub), (pos))
+
+/* a string is bytes here, with no encoding to disagree with */
+mrb_bool
+mrb_str_valid_encoding_p(mrb_state *mrb, mrb_value str)
+{
+  (void)mrb;
+  (void)str;
+  return TRUE;
+}
 #endif
 
 /* memsearch_swar (SWAR stands for SIMD within a register)                 */


### PR DESCRIPTION
`String#valid_encoding?` in mruby-encoding walks the string with
`mrb_utf8len` and counts the characters. `mrb_utf8_strlen()` in `string.c`,
reached through `utf8_strlen()`, walks a string for the same purpose. The
two loops make the same decisions about how a UTF-8 string is read:

- the byte length of a character comes from `mrb_utf8len`
- the walk stops at the end of the range it was given, rather than at
  whatever bytes follow it
- a binary string is answered without walking it at all
- a string that turns out to hold as many characters as it has bytes is
  marked `MRB_STR_SINGLE_BYTE` on the way out

Only two steps are not shared: the gem tests each character for a byte that
stands for no character, and core skips runs of ASCII a word at a time.

This moves the body into `string.c` as `mrb_str_valid_encoding_p` and
leaves the gem method as a wrapper. The one walk that remains does both:
it skips the ASCII a word at a time, and it reports the first byte that
stands for no character. Neither step can hide the other, since a skipped
byte is ASCII and therefore valid, and a continuation byte is never ASCII.

### Why this belongs in core

The method stays in the gem. `String#valid_encoding?` is defined by
mruby-encoding exactly as before, and a build without the gem gains no
method. What moves is the walk that core already performs for `String#size`
and character indexing, and the single byte flag that `utf8_strlen()` sets
while doing it.

### string.c

The body of `mrb_utf8_strlen` becomes a static `utf8_strlen_check(str,
byte_len, validp)`. With `validp` given, the walk stops at the first
non-ASCII byte that `mrb_utf8len` measures as one byte and sets `*validp`
to FALSE; the returned count is a character count only while `*validp`
stays TRUE. `mrb_utf8_strlen` calls it with `NULL`, so nothing changes for
its existing callers.

`mrb_str_valid_encoding_p(mrb, str)` sits on top of that worker with the
rules the gem has: a binary string is valid without a walk, and a string
whose character count equals its byte count gets the single byte flag. It
does not read that flag on the way in, keeping what 470396b established:
the flag says one byte per character, which a string of stray bytes
satisfies as well as an ASCII one.

### internal.h

The declaration sits with `mrb_str_char_to_byte` and `mrb_str_byte_to_char`,
outside the `MRB_UTF8_STRING` guard, so a caller does not need to guard the
call. Without UTF-8 support a string is a sequence of bytes with no encoding
to disagree with, and the function answers TRUE.

### mruby-encoding

`str_valid_enc_p` is now one line, and the gem no longer reaches into
`RSTR_LEN`, `RSTR_PTR` and `RSTR_SET_SINGLE_BYTE_FLAG` to answer this
question itself.

### Behavior

No change to what `String#valid_encoding?` answers, and no change to when
it sets the single byte flag. What changes is the cost of the walk, since
core skips runs of ASCII a word at a time through `search_nonascii()`
instead of calling `mrb_utf8len` on every byte. Measured with the default
gembox plus mruby-encoding, gcc -O3, 200 calls per case, best of five, both
binaries built with the same config on the same machine and run one after
the other:

| case | before | after |
| --- | --- | --- |
| 10000 ASCII bytes and one multi-byte character | 5.78 ms | 0.07 ms |
| 10000 ASCII bytes | 5.74 ms | 0.07 ms |
| 2500 multi-byte characters, 7500 bytes | 1.47 ms | 1.45 ms |
| one multi-byte character in every ten, 12000 bytes | 5.79 ms | 1.14 ms |

A string that is all multi-byte gains nothing, having no run of ASCII to
skip, and nothing measured got slower. `String#size` reaches the same walk
now, through `utf8_strlen_check(str, byte_len, NULL)`, and measures the same
as before.

Two tests are added for shapes the existing cases do not reach: a broken
byte found after a run of ASCII, and a substring long enough to share its
parent's buffer, whose walk has to stop at its own length.

### Testing

The gem is in no gembox, so a default `rake test` builds neither the gem
nor `MRB_UTF8_STRING`. Both sides were run from a clean `build/`:

- `MRUBY_CONFIG=host-debug rake test` (full-core, so the gem is in and
  `MRB_UTF8_STRING` is on): 2237 assertions, 0 KO, 0 crash, plus 116
  bintest.
- `rake test` with the default config: 2053 assertions, 0 KO, 0 crash, plus
  105 bintest. This is the build where `mrb_str_valid_encoding_p` answers
  TRUE without a walk.
- `MRUBY_CONFIG=minimal rake`, to confirm the function compiles where UTF-8
  support is absent.

`prek run --all-files` passes, except that `markdownlint` could not install
locally; no Markdown is touched here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added string encoding validation support through `mrb_str_valid_encoding_p`.
  * `String#valid_encoding?` now reliably handles UTF-8, binary strings, invalid trailing bytes, truncated sequences, and shared substrings.

* **Bug Fixes**
  * Improved detection of invalid UTF-8 sequences, including cases following long ASCII content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->