### PR TITLE
mruby-string-ext: `String#slice!` cuts a multibyte string by characters

### DIFF
--- a/mrbgems/mruby-string-ext/src/string.c
+++ b/mrbgems/mruby-string-ext/src/string.c
@@ -1993,67 +1993,6 @@ str_center_core(mrb_state *mrb, mrb_value self)
   return mrb_str_cat_str(mrb, result, right_padding);
 }
 
-#ifdef MRB_UTF8_STRING
-/*
- * Given a character index, find the byte offset in a UTF-8 string.
- * Returns -1 if the character index is out of bounds.
- */
-static mrb_int
-str_char_to_byte_offset(mrb_value str, mrb_int char_index)
-{
-  struct RString *s = mrb_str_ptr(str);
-  const char *p = RSTR_PTR(s);
-  mrb_int byte_len = RSTR_LEN(s);
-
-  if (RSTR_SINGLE_BYTE_P(s) || RSTR_BINARY_P(s)) {
-    return char_index;
-  }
-
-  if (char_index < 0) return -1;
-
-  mrb_int byte_offset = 0;
-  mrb_int current_char_index = 0;
-  while (byte_offset < byte_len && current_char_index < char_index) {
-    mrb_int char_len = mrb_utf8len(p + byte_offset, p + byte_len - byte_offset);
-    if (char_len == 0) break;
-    byte_offset += char_len;
-    current_char_index++;
-  }
-
-  if (current_char_index < char_index) return -1;
-  return byte_offset;
-}
-
-/*
- * Given a starting character index and a character length, find the byte length.
- */
-static mrb_int
-str_chars_to_byte_len(mrb_value str, mrb_int char_start, mrb_int char_len)
-{
-  struct RString *s = mrb_str_ptr(str);
-  const char *p = RSTR_PTR(s);
-  mrb_int str_byte_len = RSTR_LEN(s);
-
-  if (RSTR_SINGLE_BYTE_P(s) || RSTR_BINARY_P(s)) {
-    return char_len;
-  }
-
-  mrb_int start_byte_offset = str_char_to_byte_offset(str, char_start);
-  if (start_byte_offset == -1) return 0;
-
-  mrb_int byte_offset = start_byte_offset;
-  mrb_int current_char_len = 0;
-  while (byte_offset < str_byte_len && current_char_len < char_len) {
-    mrb_int cl = mrb_utf8len(p + byte_offset, p + str_byte_len - byte_offset);
-    if (cl == 0) break;
-    byte_offset += cl;
-    current_char_len++;
-  }
-
-  return byte_offset - start_byte_offset;
-}
-#endif
-
 static mrb_value
 mrb_str_slice_bang(mrb_state *mrb, mrb_value self)
 {
@@ -2111,13 +2050,8 @@ mrb_str_slice_bang(mrb_state *mrb, mrb_value self)
   }
   if (len < 0) len = 0;
 
-#ifdef MRB_UTF8_STRING
-  mrb_int byte_beg = str_char_to_byte_offset(self, beg);
-  mrb_int byte_len = str_chars_to_byte_len(self, beg, len);
-#else
-  mrb_int byte_beg = beg;
-  mrb_int byte_len = len;
-#endif
+  mrb_int byte_beg = mrb_str_char_to_byte(mrb, self, 0, beg);
+  mrb_int byte_len = mrb_str_char_to_byte(mrb, self, byte_beg, len);
 
   if (byte_beg < 0 || byte_beg > RSTRING_LEN(self) || byte_beg + byte_len > RSTRING_LEN(self)) {
     return mrb_nil_value();

--- a/mrbgems/mruby-string-ext/src/string.c
+++ b/mrbgems/mruby-string-ext/src/string.c
@@ -2016,13 +2016,12 @@ mrb_str_slice_bang(mrb_state *mrb, mrb_value self)
     if (mrb_string_p(arg1)) {
       mrb_int pos = mrb_str_index(mrb, self, RSTRING_PTR(arg1), RSTRING_LEN(arg1), 0);
       if (pos == -1) return mrb_nil_value();
-#ifdef MRB_UTF8_STRING
-      beg = str_char_count(mrb_str_substr(mrb, self, 0, pos));
+      /* The search runs over bytes, so a match may start inside a character;
+         mrb_str_byte_to_char() answers -1 there, and a match no character
+         index reaches is no match. */
+      beg = mrb_str_byte_to_char(mrb, self, pos);
+      if (beg < 0) return mrb_nil_value();
       len = str_char_count(arg1);
-#else
-      beg = pos;
-      len = RSTRING_LEN(arg1);
-#endif
     }
     else if (mrb_range_p(arg1)) {
       if (mrb_range_beg_len(mrb, arg1, &beg, &len, str_len, TRUE) != MRB_RANGE_OK) {

--- a/mrbgems/mruby-string-ext/test/string.rb
+++ b/mrbgems/mruby-string-ext/test/string.rb
@@ -426,6 +426,32 @@ assert('String#slice!') do
   assert_raise(ArgumentError) { "foo".slice! }
 end
 
+assert('String#slice! with multibyte characters') do
+  a = "あいうえお"
+  assert_equal "えお", a.slice!(3, 2)
+  assert_equal "あいう", a
+
+  a = "あいう"
+  assert_equal "いう", a.slice!(1..2)
+  assert_equal "あ", a
+
+  a = "あいう"
+  assert_equal "う", a.slice!(-1)
+  assert_equal "あい", a
+
+  a = "aあいb"
+  assert_equal "あい", a.slice!(1, 2)
+  assert_equal "ab", a
+
+  a = "あい"
+  assert_equal "あい", a.slice!(0, 2)
+  assert_equal "", a
+
+  a = "あい"
+  assert_equal "", a.slice!(2, 1)
+  assert_equal "あい", a
+end if UTF8STRING
+
 assert('String#succ') do
   assert_equal "", "".succ
   assert_equal "1", "0".succ

--- a/mrbgems/mruby-string-ext/test/string.rb
+++ b/mrbgems/mruby-string-ext/test/string.rb
@@ -452,6 +452,26 @@ assert('String#slice! with multibyte characters') do
   assert_equal "あい", a
 end if UTF8STRING
 
+assert('String#slice! with a multibyte match') do
+  a = "あいう"
+  assert_equal "い", a.slice!("い")
+  assert_equal "あう", a
+
+  a = "あいう"
+  assert_equal "う", a.slice!("う")
+  assert_equal "あい", a
+
+  a = "あいう"
+  assert_nil a.slice!("え")
+  assert_equal "あいう", a
+
+  # the search runs over bytes, so a match starting inside a character is
+  # not a match
+  a = "あ"
+  assert_nil a.slice!("\x81\x82")
+  assert_equal "あ", a
+end if UTF8STRING
+
 assert('String#succ') do
   assert_equal "", "".succ
   assert_equal "1", "0".succ


### PR DESCRIPTION
`String#slice!` in mruby-string-ext converts between character indexes and byte
offsets on its own, and both directions are wrong on a multibyte string. The
result is a broken return value and a broken receiver:

```ruby
s = "あいうえお"
s.slice!(3, 2)  #=> "\xE3\x81"     (CRuby: "えお")
s               #=> "あいう\x88お"  (CRuby: "あいう")

s = "あいう"
s.slice!("い")   #=> ""            (CRuby: "い")
s               #=> "あいう"        (CRuby: "あう")
```

Two independent defects, one commit each.

### Character index to byte offset

`str_char_to_byte_offset()` and `str_chars_to_byte_len()` hand `mrb_utf8len()`
an end of `p + byte_len - byte_offset`. That is the end of the string only
while `byte_offset` is zero: every character consumed moves it one character
closer to the start. A character reaching past the moved end is measured as
truncated, which `mrb_utf8len()` reports as a single byte, so the conversion
answers an offset that lands inside a character.

`mrb_str_char_to_byte()` does this in core and is what `String#[]` goes
through, which is why `"あいうえお"[3, 2]` answers `"えお"` where `slice!` does
not. Both static helpers are deleted.

### Byte offset to character index

`mrb_str_index()` answers a byte offset, which was passed to
`mrb_str_substr()` as a character count. `mrb_str_byte_to_char()` is the
conversion this wants. It also settles the case the byte search can produce
and the old code could not express: an offset inside a character, which it
reports as -1. CRuby finds no match in that position, so `slice!` answers nil
for it.

Both core conversions are declared outside the `MRB_UTF8_STRING` guard and are
the identity on a build without UTF-8 support, so the guarded branches go away
with the helpers.

### Tests

Two assertions in `mrbgems/mruby-string-ext/test/string.rb`, guarded by the
`UTF8STRING` flag the file already uses. Each fails before its own commit and
passes after it. The existing `String#slice!` assertions are ASCII only, where
a character is a byte and neither defect shows.

### Verified

- `rake test` on a full-core build (`MRB_UTF8_STRING` through mruby-encoding):
  2237 tests, all green
- `rake test` on the default gembox (no `MRB_UTF8_STRING`): 2053 tests, all
  green
- `prek run --all-files` passes, except that `markdownlint` could not install
  locally (npm engine mismatch); no Markdown is touched here


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `String#slice!` handling for UTF-8 and multibyte strings.
  * Character-based indexes, ranges, negative indexes, and byte lengths now produce consistent results.
  * Prevented slicing from starting within a UTF-8 character.
  * Improved slicing by multibyte string matches, including unmatched and invalid byte-position cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->