### PR TITLE
mruby-string-ext: validate UTF-8 sequences with `mrb_utf8len`

### DIFF
--- a/mrbgems/mruby-string-ext/src/string.c
+++ b/mrbgems/mruby-string-ext/src/string.c
@@ -1027,27 +1027,8 @@ str_ord(mrb_state* mrb, mrb_value str)
 static mrb_int
 str_scrub_char_len(const unsigned char *p, const unsigned char *e)
 {
-  if (p[0] < 0x80) return 1;
-  mrb_int len = mrb_utf8len_table[p[0]>>3];
-  if (len < 2 || len > e - p) return -1;
-  for (mrb_int i = 1; i < len; i++) {
-    if ((p[i] & 0xc0) != 0x80) return -1;
-  }
-  mrb_int cp;
-  if (len == 2) {
-    cp = ((p[0] & 0x1f) << 6) | (p[1] & 0x3f);
-    if (cp < 0x80) return -1;
-  }
-  else if (len == 3) {
-    cp = ((p[0] & 0x0f) << 12) | ((p[1] & 0x3f) << 6) | (p[2] & 0x3f);
-    if (cp < 0x800) return -1;
-    if (cp >= 0xD800 && cp <= 0xDFFF) return -1;
-  }
-  else { /* len == 4 */
-    cp = ((p[0] & 0x07) << 18) | ((p[1] & 0x3f) << 12)
-       | ((p[2] & 0x3f) <<  6) |  (p[3] & 0x3f);
-    if (cp < 0x10000 || cp > 0x10FFFF) return -1;
-  }
+  mrb_int len = mrb_utf8len((const char*)p, (const char*)e);
+  if (len == 1 && p[0] >= 0x80) return -1;
   return len;
 }
 

--- a/mrbgems/mruby-string-ext/src/string.c
+++ b/mrbgems/mruby-string-ext/src/string.c
@@ -968,36 +968,26 @@ str_succ(mrb_state *mrb, mrb_value self)
 #ifdef MRB_UTF8_STRING
 extern const char mrb_utf8len_table[];
 
+/* Decodes the UTF-8 character starting at p, storing its byte length through
+   lenp when that is not NULL. mrb_utf8len() answers 1 for every sequence it
+   rejects, so a lead byte measured as one byte is invalid. */
 MRB_INLINE mrb_int
-utf8code(mrb_state* mrb, const unsigned char* p, const unsigned char *e)
+utf8code(mrb_state* mrb, const unsigned char* p, const unsigned char *e, mrb_int *lenp)
 {
-  if (p[0] < 0x80) return p[0];
-
-  mrb_int len = mrb_utf8len_table[p[0]>>3];
-  mrb_int cp = -1;
-  if (p+len <= e && len > 1 && (p[1] & 0xc0) == 0x80) {
-    if (len == 2)
-      cp = ((p[0] & 0x1f) << 6) + (p[1] & 0x3f);
-    else if ((p[2] & 0xc0) == 0x80) {
-      if (len == 3)
-        cp = ((p[0] & 0x0f) << 12) + ((p[1] & 0x3f) << 6) + (p[2] & 0x3f);
-      else if (len == 4 && (p[3] & 0xc0) == 0x80) {
-        cp = ((p[0] & 0x07) << 18) + ((p[1] & 0x3f) << 12)
-              + ((p[2] & 0x3f) << 6) + (p[3] & 0x3f);
-      }
+  mrb_int len = mrb_utf8len((const char*)p, (const char*)e);
+  if (lenp) *lenp = len;
+  if (len == 1) {
+    if (p[0] >= 0x80) {
+      mrb_raise(mrb, E_ARGUMENT_ERROR, "invalid UTF-8 byte sequence");
     }
+    return p[0];
   }
-  /* Reject overlong sequences, UTF-16 surrogates, and code points above
-     U+10FFFF (RFC 3629, Unicode D93b). */
-  if (cp >= 0 &&
-      ((len == 2 && cp >= 0x80) ||
-       (len == 3 && cp >= 0x800 && (cp < 0xD800 || 0xDFFF < cp)) ||
-       (len == 4 && cp >= 0x10000 && cp <= 0x10FFFF))) {
-    return cp;
+
+  mrb_int cp = p[0] & (0xff >> (len + 1));
+  for (mrb_int i = 1; i < len; i++) {
+    cp = (cp << 6) | (p[i] & 0x3f);
   }
-  mrb_raise(mrb, E_ARGUMENT_ERROR, "invalid UTF-8 byte sequence");
-  /* not reached */
-  return -1;
+  return cp;
 }
 
 static mrb_value
@@ -1015,7 +1005,7 @@ str_ord(mrb_state* mrb, mrb_value str)
     c = p[0];
   }
   else {
-    c = utf8code(mrb, p, e);
+    c = utf8code(mrb, p, e, NULL);
   }
   return mrb_fixnum_value(c);
 }
@@ -1156,9 +1146,10 @@ str_codepoints(mrb_state *mrb, mrb_value str)
   }
   else {
     while (p < e) {
-      mrb_int c = utf8code(mrb, p, e);
+      mrb_int len;
+      mrb_int c = utf8code(mrb, p, e, &len);
       mrb_ary_push(mrb, result, mrb_int_value(mrb, c));
-      p += mrb_utf8len_table[p[0]>>3];
+      p += len;
     }
   }
   return result;

--- a/mrbgems/mruby-string-ext/test/string.rb
+++ b/mrbgems/mruby-string-ext/test/string.rb
@@ -938,6 +938,26 @@ assert('String#codepoints(UTF-8)') do
   assert_equal expect, cp
 end if UTF8STRING
 
+assert('String#codepoints rejects malformed sequences') do
+  assert_raise(ArgumentError) { "\x80".codepoints }             # stray continuation
+  assert_raise(ArgumentError) { "\xE3\x81".codepoints }         # truncated
+  assert_raise(ArgumentError) { "\xC0\xAF".codepoints }         # overlong "/"
+  assert_raise(ArgumentError) { "\xED\xA0\x80".codepoints }     # surrogate U+D800
+  assert_raise(ArgumentError) { "\xF4\x90\x80\x80".codepoints } # > U+10FFFF
+  assert_raise(ArgumentError) { "\xF8\x88\x80\x80\x80".codepoints }
+  # the walk keeps its place: characters after a 4-byte one still decode
+  assert_equal [128169, 97], "\u{1F4A9}a".codepoints
+  assert_raise(ArgumentError) { "\u{1F4A9}\xC0\xAF".codepoints }
+end if UTF8STRING
+
+assert('String#ord rejects malformed sequences') do
+  assert_raise(ArgumentError) { "\x80".ord }
+  assert_raise(ArgumentError) { "\xE3\x81".ord }
+  assert_raise(ArgumentError) { "\xC0\xAF".ord }
+  assert_raise(ArgumentError) { "\xED\xA0\x80".ord }
+  assert_raise(ArgumentError) { "\xF4\x90\x80\x80".ord }
+end if UTF8STRING
+
 assert('String#each_codepoint') do
   expect = [104, 101, 108, 108, 111, 33]
   cp = []


### PR DESCRIPTION
`mrb_utf8len()` decides what counts as a UTF-8 character in core, under the
RFC 3629 rules it was given in #7093. mruby-string-ext decides it twice more,
in `utf8code()` and in `str_scrub_char_len()`, and both were taught those same
rules by hand in that same PR. Ask core instead.

### Reading a refusal

`mrb_utf8len()` answers 1 for every sequence it turns down. A real one-byte
character is a lead byte below 0x80, so a length of 1 on a byte at or above
0x80 is the refusal. That is the whole bridge; both helpers are a few lines on
top of it.

```c
static mrb_int
str_scrub_char_len(const unsigned char *p, const unsigned char *e)
{
  mrb_int len = mrb_utf8len((const char*)p, (const char*)e);
  if (len == 1 && p[0] >= 0x80) return -1;
  return len;
}
```

`utf8code()` keeps only the part core has no answer for, the code point itself,
and reports the byte length it decoded through a new `lenp` argument.
`String#codepoints` was stepping over characters by the raw
`mrb_utf8len_table`, which is the length a lead byte claims rather than the
length that was accepted; it now steps by what came back. The table is still
read by `String#chars`, so the declaration stays.

22 lines of C replace 50.

### Equivalence

Nothing here is meant to change behavior, so the old and new helpers were run
against each other over both leading bytes, nine representative tail bytes and
every available length from 1 to 4: 21,233,664 cases, with no difference in
the code point, in what is refused, or in the byte length.

### Tests

`String#ord` and `String#codepoints` had nothing holding them to the RFC 3629
rules; the tests for those go through `String#scrub`, which reads its lengths
from the other helper. The first commit pins them, and it passes both before
and after the two that follow.

### Verified

- `rake test` on a full-core build (`MRB_UTF8_STRING` through mruby-encoding):
  2243 tests, all green, at each of the three commits
- `rake test` on the default gembox (no `MRB_UTF8_STRING`): 2055 tests, all
  green
- `prek run --all-files` passes, except that `markdownlint` could not install
  locally (npm engine mismatch); no Markdown is touched here


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UTF-8 decoding for string operations.
  * `String#ord` and `String#codepoints` now correctly reject malformed UTF-8 sequences with `ArgumentError`.
  * UTF-8 scrubbing now consistently validates character sequences.

* **Tests**
  * Added coverage for malformed UTF-8, including invalid bytes following valid four-byte characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->