### PR TITLE
`String#chars` splits where `String#length` counts

### DIFF
--- a/mrbgems/mruby-string-ext/src/string.c
+++ b/mrbgems/mruby-string-ext/src/string.c
@@ -966,8 +966,6 @@ str_succ(mrb_state *mrb, mrb_value self)
 }
 
 #ifdef MRB_UTF8_STRING
-extern const char mrb_utf8len_table[];
-
 /* Decodes the UTF-8 character starting at p, storing its byte length through
    lenp when that is not NULL. mrb_utf8len() answers 1 for every sequence it
    rejects, so a lead byte measured as one byte is invalid. */
@@ -1718,62 +1716,28 @@ static mrb_value
 str_chars_ary(mrb_state *mrb, mrb_value self)
 {
   struct RString *s = mrb_str_ptr(self);
-  const unsigned char *p = (unsigned char*)RSTR_PTR(s);
-  const unsigned char *e = p + RSTR_LEN(s);
+  const char *p = RSTR_PTR(s);
+  const char *e = p + RSTR_LEN(s);
+  /* the count comes first: it is the exact capacity, and it settles the
+     single-byte flag the walk reads */
+  mrb_value result = mrb_ary_new_capa(mrb, mrb_str_char_len(mrb, self));
 
-  /* Estimate character count for array pre-allocation */
-  mrb_int estimated_chars = RSTR_LEN(s);
-  if (!RSTR_SINGLE_BYTE_P(s) && !RSTR_BINARY_P(s)) {
-    estimated_chars = estimated_chars / 2; /* rough estimate for UTF-8 */
-  }
-  mrb_value result = mrb_ary_new_capa(mrb, estimated_chars);
-
-  if (RSTR_SINGLE_BYTE_P(s) || RSTR_BINARY_P(s)) {
-    /* ASCII/Binary: each byte is a character */
-    while (p < e) {
-      mrb_value char_str = mrb_str_new(mrb, (char*)p, 1);
-      mrb_ary_push(mrb, result, char_str);
-      p++;
-    }
-  }
-  else {
 #ifdef MRB_UTF8_STRING
-    /* UTF-8: handle multi-byte characters */
+  if (!RSTR_SINGLE_BYTE_P(s) && !RSTR_BINARY_P(s)) {
     while (p < e) {
-      mrb_int char_len = mrb_utf8len_table[p[0] >> 3];
-      if (char_len == 0 || char_len > 4 || p + char_len > e) {
-        /* Invalid UTF-8, treat as single byte */
-        char_len = 1;
-      }
-      else {
-        /* Validate UTF-8 sequence */
-        mrb_bool valid = TRUE;
-        if (char_len > 1) {
-          for (mrb_int i = 1; i < char_len; i++) {
-            if ((p[i] & 0xC0) != 0x80) {
-              valid = FALSE;
-              break;
-            }
-          }
-        }
-        if (!valid) {
-          char_len = 1;
-        }
-      }
-      mrb_value char_str = mrb_str_new(mrb, (char*)p, char_len);
-      mrb_ary_push(mrb, result, char_str);
+      mrb_int char_len = mrb_utf8len(p, e);
+      mrb_ary_push(mrb, result, mrb_str_new(mrb, p, char_len));
       p += char_len;
     }
-#else
-    /* Non-UTF8 build: treat as single bytes */
-    while (p < e) {
-      mrb_value char_str = mrb_str_new(mrb, (char*)p, 1);
-      mrb_ary_push(mrb, result, char_str);
-      p++;
-    }
-#endif
+    return result;
   }
+#endif
 
+  /* one character per byte */
+  while (p < e) {
+    mrb_ary_push(mrb, result, mrb_str_new(mrb, p, 1));
+    p++;
+  }
   return result;
 }
 

--- a/mrbgems/mruby-string-ext/src/string.c
+++ b/mrbgems/mruby-string-ext/src/string.c
@@ -1027,27 +1027,8 @@ str_ord(mrb_state* mrb, mrb_value str)
 static mrb_int
 str_scrub_char_len(const unsigned char *p, const unsigned char *e)
 {
-  if (p[0] < 0x80) return 1;
-  mrb_int len = mrb_utf8len_table[p[0]>>3];
-  if (len < 2 || len > e - p) return -1;
-  for (mrb_int i = 1; i < len; i++) {
-    if ((p[i] & 0xc0) != 0x80) return -1;
-  }
-  mrb_int cp;
-  if (len == 2) {
-    cp = ((p[0] & 0x1f) << 6) | (p[1] & 0x3f);
-    if (cp < 0x80) return -1;
-  }
-  else if (len == 3) {
-    cp = ((p[0] & 0x0f) << 12) | ((p[1] & 0x3f) << 6) | (p[2] & 0x3f);
-    if (cp < 0x800) return -1;
-    if (cp >= 0xD800 && cp <= 0xDFFF) return -1;
-  }
-  else { /* len == 4 */
-    cp = ((p[0] & 0x07) << 18) | ((p[1] & 0x3f) << 12)
-       | ((p[2] & 0x3f) <<  6) |  (p[3] & 0x3f);
-    if (cp < 0x10000 || cp > 0x10FFFF) return -1;
-  }
+  mrb_int len = mrb_utf8len((const char*)p, (const char*)e);
+  if (len == 1 && p[0] >= 0x80) return -1;
   return len;
 }
 

--- a/mrbgems/mruby-string-ext/src/string.c
+++ b/mrbgems/mruby-string-ext/src/string.c
@@ -968,36 +968,26 @@ str_succ(mrb_state *mrb, mrb_value self)
 #ifdef MRB_UTF8_STRING
 extern const char mrb_utf8len_table[];
 
+/* Decodes the UTF-8 character starting at p, storing its byte length through
+   lenp when that is not NULL. mrb_utf8len() answers 1 for every sequence it
+   rejects, so a lead byte measured as one byte is invalid. */
 MRB_INLINE mrb_int
-utf8code(mrb_state* mrb, const unsigned char* p, const unsigned char *e)
+utf8code(mrb_state* mrb, const unsigned char* p, const unsigned char *e, mrb_int *lenp)
 {
-  if (p[0] < 0x80) return p[0];
-
-  mrb_int len = mrb_utf8len_table[p[0]>>3];
-  mrb_int cp = -1;
-  if (p+len <= e && len > 1 && (p[1] & 0xc0) == 0x80) {
-    if (len == 2)
-      cp = ((p[0] & 0x1f) << 6) + (p[1] & 0x3f);
-    else if ((p[2] & 0xc0) == 0x80) {
-      if (len == 3)
-        cp = ((p[0] & 0x0f) << 12) + ((p[1] & 0x3f) << 6) + (p[2] & 0x3f);
-      else if (len == 4 && (p[3] & 0xc0) == 0x80) {
-        cp = ((p[0] & 0x07) << 18) + ((p[1] & 0x3f) << 12)
-              + ((p[2] & 0x3f) << 6) + (p[3] & 0x3f);
-      }
+  mrb_int len = mrb_utf8len((const char*)p, (const char*)e);
+  if (lenp) *lenp = len;
+  if (len == 1) {
+    if (p[0] >= 0x80) {
+      mrb_raise(mrb, E_ARGUMENT_ERROR, "invalid UTF-8 byte sequence");
     }
+    return p[0];
   }
-  /* Reject overlong sequences, UTF-16 surrogates, and code points above
-     U+10FFFF (RFC 3629, Unicode D93b). */
-  if (cp >= 0 &&
-      ((len == 2 && cp >= 0x80) ||
-       (len == 3 && cp >= 0x800 && (cp < 0xD800 || 0xDFFF < cp)) ||
-       (len == 4 && cp >= 0x10000 && cp <= 0x10FFFF))) {
-    return cp;
+
+  mrb_int cp = p[0] & (0xff >> (len + 1));
+  for (mrb_int i = 1; i < len; i++) {
+    cp = (cp << 6) | (p[i] & 0x3f);
   }
-  mrb_raise(mrb, E_ARGUMENT_ERROR, "invalid UTF-8 byte sequence");
-  /* not reached */
-  return -1;
+  return cp;
 }
 
 static mrb_value
@@ -1015,7 +1005,7 @@ str_ord(mrb_state* mrb, mrb_value str)
     c = p[0];
   }
   else {
-    c = utf8code(mrb, p, e);
+    c = utf8code(mrb, p, e, NULL);
   }
   return mrb_fixnum_value(c);
 }
@@ -1156,9 +1146,10 @@ str_codepoints(mrb_state *mrb, mrb_value str)
   }
   else {
     while (p < e) {
-      mrb_int c = utf8code(mrb, p, e);
+      mrb_int len;
+      mrb_int c = utf8code(mrb, p, e, &len);
       mrb_ary_push(mrb, result, mrb_int_value(mrb, c));
-      p += mrb_utf8len_table[p[0]>>3];
+      p += len;
     }
   }
   return result;

--- a/mrbgems/mruby-string-ext/test/string.rb
+++ b/mrbgems/mruby-string-ext/test/string.rb
@@ -858,6 +858,22 @@ assert('String#chars(UTF-8)') do
   assert_equal "こんにちは世界!", s
 end if UTF8STRING
 
+assert('String#chars splits a malformed sequence by byte') do
+  # A byte standing for no character is one position of its own, which is
+  # what #length counts it as.
+  assert_equal ["\xC0", "\x80"], "\xC0\x80".chars                          # overlong "/"
+  assert_equal ["\xED", "\xA0", "\x80"], "\xED\xA0\x80".chars              # surrogate U+D800
+  assert_equal ["\xF4", "\x90", "\x80", "\x80"], "\xF4\x90\x80\x80".chars  # > U+10FFFF
+  assert_equal ["\xE3", "\x81"], "\xE3\x81".chars                          # truncated
+  assert_equal ["a", "\x80", "b"], "a\x80b".chars                          # stray continuation
+  assert_equal ["あ", "\xFE", "い"], "あ\xFEい".chars                      # sequence leads nothing
+
+  ["\xC0\x80", "\xED\xA0\x80", "\xF4\x90\x80\x80", "\xE3\x81", "a\x80b",
+   "あ\xFEい", "あいu", "hello"].each do |str|
+    assert_equal str.length, str.chars.size
+  end
+end if UTF8STRING
+
 assert('String#each_char') do
   chars = []
   "hello!".each_char do |x|

--- a/mrbgems/mruby-string-ext/test/string.rb
+++ b/mrbgems/mruby-string-ext/test/string.rb
@@ -938,6 +938,26 @@ assert('String#codepoints(UTF-8)') do
   assert_equal expect, cp
 end if UTF8STRING
 
+assert('String#codepoints rejects malformed sequences') do
+  assert_raise(ArgumentError) { "\x80".codepoints }             # stray continuation
+  assert_raise(ArgumentError) { "\xE3\x81".codepoints }         # truncated
+  assert_raise(ArgumentError) { "\xC0\xAF".codepoints }         # overlong "/"
+  assert_raise(ArgumentError) { "\xED\xA0\x80".codepoints }     # surrogate U+D800
+  assert_raise(ArgumentError) { "\xF4\x90\x80\x80".codepoints } # > U+10FFFF
+  assert_raise(ArgumentError) { "\xF8\x88\x80\x80\x80".codepoints }
+  # the walk keeps its place: characters after a 4-byte one still decode
+  assert_equal [128169, 97], "\u{1F4A9}a".codepoints
+  assert_raise(ArgumentError) { "\u{1F4A9}\xC0\xAF".codepoints }
+end if UTF8STRING
+
+assert('String#ord rejects malformed sequences') do
+  assert_raise(ArgumentError) { "\x80".ord }
+  assert_raise(ArgumentError) { "\xE3\x81".ord }
+  assert_raise(ArgumentError) { "\xC0\xAF".ord }
+  assert_raise(ArgumentError) { "\xED\xA0\x80".ord }
+  assert_raise(ArgumentError) { "\xF4\x90\x80\x80".ord }
+end if UTF8STRING
+
 assert('String#each_codepoint') do
   expect = [104, 101, 108, 108, 111, 33]
   cp = []

--- a/src/string.c
+++ b/src/string.c
@@ -464,8 +464,8 @@ search_nonascii(const char *p, const char *e)
 
 #define utf8_islead(c) ((unsigned char)((c)&0xc0) != 0x80)
 
-extern const char mrb_utf8len_table[];
-const char mrb_utf8len_table[] = {
+/* the byte length a lead byte claims, read only through mrb_utf8len() */
+static const char mrb_utf8len_table[] = {
   1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
   0, 0, 0, 0, 0, 0, 0, 0, 2, 2, 2, 2, 3, 3, 4, 0
 };


### PR DESCRIPTION
`String#chars` measured characters by a rule of its own: the byte length the
lead byte claims, with the continuation bytes checked. Core stopped accepting
what RFC 3629 forbids in #7093, and this rule never did, so one string was cut
into fewer pieces than it was counted as having.

```ruby
"\xC0\x80".chars       #=> ["\xC0\x80"]      (CRuby: ["\xC0", "\x80"])
"\xC0\x80".length      #=> 2
"\xED\xA0\x80".chars   #=> ["\xED\xA0\x80"]  (CRuby: ["\xED", "\xA0", "\x80"])
"\xED\xA0\x80".length  #=> 3
```

An overlong encoding, a UTF-16 surrogate and a code point above U+10FFFF all
came back as one character each.

### The walk

`mrb_utf8len()` is the measure the count is taken by, so walking with it puts
`chars` and `length` back on the same footing. The rest of the helper follows
from that: `mrb_str_char_len()` gives the array a capacity that is the number
of characters rather than a byte length halved, and on its way there it settles
the single-byte flag the walk reads, which is what tells a byte-indexed string
apart. 31 lines replace 51.

### The table

The gem was reaching into `mrb_utf8len_table` directly, and this was its last
use. The table says what a lead byte claims and nothing about whether the bytes
after it deliver, which is the whole of what `mrb_utf8len()` goes on to check,
so cutting strings by it was the shape of the bug. Nothing outside `src/string.c`
reads it now, so it becomes static there.

### Base

Branched off #7105, which is still open, because that PR removes the gem's two
other uses of the table. The first three commits here are that PR and drop out
once it merges.

### Tests

The new assertions cover the three sequences RFC 3629 forbids, a truncated
sequence, a stray continuation byte and a lead byte that leads nothing, then
check `str.length == str.chars.size` over all of them. They fail on the first
three assertions before this change and pass after it.

### Verified

- `rake test` on a full-core build (`MRB_UTF8_STRING` through mruby-encoding):
  2244 tests, all green
- `rake test` on the default gembox (no `MRB_UTF8_STRING`): 2055 tests, all
  green
- `prek run --all-files` passes, except that `markdownlint` could not install
  locally (npm engine mismatch); no Markdown is touched here


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UTF-8 handling for `String#ord`, `String#codepoints`, and character extraction.
  * Invalid UTF-8 sequences are now rejected consistently instead of being decoded incorrectly.
  * `String#chars` now correctly separates malformed sequences into byte-level elements and reports accurate results.
  * Character slicing now uses precise UTF-8 character boundaries, improving behavior with multibyte text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->