### PR TITLE
string.c: step `String#rindex` by the characters `String#length` counts

### DIFF
--- a/src/string.c
+++ b/src/string.c
@@ -2616,10 +2616,13 @@ mrb_str_rindex_m(mrb_state *mrb, mrb_value str)
   else {
     const char *p = RSTRING_PTR(str);
     const char *e = RSTRING_END(str);
-    while (pos++ < 0 && p < e) {
+    /* a negative `pos` counts characters back from the end, and landing on the
+       first character is the last step that stays in the string */
+    while (pos < 0) {
+      if (e == p) return mrb_nil_value();
       e = char_backtrack(p, e);
+      pos++;
     }
-    if (p == e) return mrb_nil_value();
     pos = (mrb_int)(e - p);
   }
   pos = str_char_rindex(str, sub, pos);

--- a/src/string.c
+++ b/src/string.c
@@ -689,26 +689,23 @@ mrb_str_byte_to_char(mrb_state *mrb, mrb_value str, mrb_int bi)
   return i;
 }
 
+/* The byte the character covering `p` starts at, or `p` itself when `p` is
+   already a character boundary. A continuation byte belongs to the character
+   that reaches it; one that no lead byte reaches belongs to none and stands as
+   a character of its own. Whether a lead byte reaches is mrb_utf8len()'s
+   answer, so the boundaries found here are the ones the character count is
+   taken over. Reading back three bytes covers it, since nothing longer than
+   four bytes spells a character. */
 static const char*
-char_adjust(const char *ptr, const char *end)
+str_char_head(const char *beg, const char *p, const char *end)
 {
-  ptrdiff_t len = end - ptr;
-  if (len < 1 || utf8_islead(ptr[0])) return ptr;
-  if (len > 1 && utf8_islead(ptr[1])) return ptr+1;
-  if (len > 2 && utf8_islead(ptr[2])) return ptr+2;
-  if (len > 3 && utf8_islead(ptr[3])) return ptr+3;
-  return ptr;
-}
-
-static const char*
-char_backtrack(const char *ptr, const char *end)
-{
-  ptrdiff_t len = end - ptr;
-  if (len < 1 || utf8_islead(end[-1])) return end-1;
-  if (len > 1 && utf8_islead(end[-2])) return end-2;
-  if (len > 2 && utf8_islead(end[-3])) return end-3;
-  if (len > 3 && utf8_islead(end[-4])) return end-4;
-  return end - 1;
+  if (p >= end || utf8_islead(p[0])) return p;
+  for (mrb_int back = 1; back <= 3 && back <= p - beg; back++) {
+    const char *lead = p - back;
+    if (!utf8_islead(lead[0])) continue;  /* another continuation byte */
+    return mrb_utf8len(lead, end) > back ? lead : p;
+  }
+  return p;
 }
 
 static mrb_int
@@ -1068,15 +1065,17 @@ str_char_rindex(mrb_value str, mrb_value sub, mrb_int pos)
   s = sbeg + pos;
   t = RSTRING_PTR(sub);
   if (len) {
-    s = char_adjust(s, send);
+    /* a match may start only at a character boundary, and `pos` need not be
+       one: the clamp above answers the last byte `sub` fits at */
+    s = str_char_head(sbeg, s, send);
     for (;;) {
       if ((mrb_int)(send - s) >= len && memcmp(s, t, len) == 0) {
         return (mrb_int)(s - sbeg);
       }
-      /* char_backtrack() answers the byte before `s`, which would leave the
-         buffer once the search has reached the first character */
+      /* the character before `s`, which there is none of once the search has
+         reached the first one */
       if (s == sbeg) break;
-      s = char_backtrack(sbeg, s);
+      s = str_char_head(sbeg, s-1, send);
     }
     return -1;
   }
@@ -2615,12 +2614,13 @@ mrb_str_rindex_m(mrb_state *mrb, mrb_value str)
   }
   else {
     const char *p = RSTRING_PTR(str);
-    const char *e = RSTRING_END(str);
+    const char *send = RSTRING_END(str);
+    const char *e = send;
     /* a negative `pos` counts characters back from the end, and landing on the
        first character is the last step that stays in the string */
     while (pos < 0) {
       if (e == p) return mrb_nil_value();
-      e = char_backtrack(p, e);
+      e = str_char_head(p, e-1, send);
       pos++;
     }
     pos = (mrb_int)(e - p);

--- a/test/t/string.rb
+++ b/test/t/string.rb
@@ -649,6 +649,16 @@ assert('String#rindex(UTF-8)', '15.2.10.5.31') do
   assert_equal  3, broken.rindex("☁", 10)
 end if UTF8STRING
 
+assert('String#rindex reaches the first character from a negative position') do
+  # A negative `pos` counts characters back from the end, so minus the length
+  # names the first character rather than a step past it.
+  assert_equal 0, "あいう".rindex("あ", -3)
+  assert_nil "あいう".rindex("あ", -4)
+  assert_equal 3, "あいうあ".rindex("あ", -1)
+  assert_equal 0, "あいうあ".rindex("あ", -4)
+  assert_nil "あいうあ".rindex("あ", -5)
+end if UTF8STRING
+
 assert('String#byterindex searches bytes') do
   # `byterindex` answers byte positions, so it walks bytes the way
   # `byteindex` does. Walking characters instead, it passed over every byte

--- a/test/t/string.rb
+++ b/test/t/string.rb
@@ -659,6 +659,28 @@ assert('String#rindex reaches the first character from a negative position') do
   assert_nil "あいうあ".rindex("あ", -5)
 end if UTF8STRING
 
+assert('String#rindex steps by the characters String#length counts') do
+  # A byte that no lead byte reaches spells no character with its neighbours,
+  # so it is one position of its own, which is what #length counts it as.
+  str = "あ\x80x"
+  assert_equal 3, str.length
+  assert_equal 0, str.rindex("あ", -2)
+  assert_equal 1, str.rindex("\x80")
+  assert_equal str.index("\x80"), str.rindex("\x80")
+
+  # Searching backward from `pos` may not answer a position after it.
+  assert_nil str.rindex("x", 1)
+  assert_equal 2, str.rindex("x", 2)
+
+  # A sequence RFC 3629 forbids spells no character either, and its bytes
+  # stand alone the same way.
+  assert_equal 3, "\xC0\x80a".length
+  assert_equal 0, "\xC0\x80a".rindex("\xC0")
+  assert_equal 1, "\xC0\x80a".rindex("\x80")
+  assert_equal 3, "\xED\xA0\x80".length
+  assert_equal 2, "\xED\xA0\x80".rindex("\x80")
+end if UTF8STRING
+
 assert('String#byterindex searches bytes') do
   # `byterindex` answers byte positions, so it walks bytes the way
   # `byteindex` does. Walking characters instead, it passed over every byte


### PR DESCRIPTION
`String#rindex` walks a character-indexed receiver backward, and two things
about that walk were wrong. Both show only there: an ASCII or binary receiver
is handed to `String#byterindex`, which does not walk.

### Reaching the first character

A negative `pos` counts characters back from the end, so minus the length names
the first character. The walk stepped back that far and then read arriving at
the string start as having run out of string, which made `-length` and one step
past it answer alike:

```ruby
"あいう".rindex("あ", -3)  #=> nil  (CRuby: 0)
"あいう".rindex("あ", -4)  #=> nil
```

`String#byterindex` adds the length to `pos` rather than walking, so it was
already right: `"abc".rindex("a", -3)` is 0.

### Where a character starts

`char_adjust()` and `char_backtrack()` found a character start by looking for a
byte that is not a continuation byte, and never asked whether the byte they
found reaches that far. That is the whole of what `mrb_utf8len()` goes on to
check, so the walk and the character count disagreed wherever a lead byte
promises more than it delivers:

```ruby
"あ\x80x".length            #=> 3
"あ\x80x".chars             #=> ["あ", "\x80", "x"]
"あ\x80x".index("\x80")     #=> 1
"あ\x80x".rindex("\x80")    #=> nil
"あ\x80x".rindex("あ", -2)  #=> nil  (CRuby: 0)
```

`\x80` follows no lead byte that reaches it, so it is a character of its own,
which is what `#length` and `#chars` count it as. The walk stepped over it into
`あ` instead.

`char_adjust()` also rounded forward. `rindex` wants the last start at or
before `pos`, so a `pos` that is not a boundary belongs rounded toward the
start; rounding the other way let a backward search answer a position after the
one it was given:

```ruby
"あ\x80x".rindex("x", 1)  #=> 2  (CRuby: nil)
```

### One helper

`str_char_head(beg, p, end)` replaces both: the byte the character covering `p`
starts at, and `p` itself when `p` is already a boundary. It reads back at most
three bytes to a lead byte and keeps that lead only when `mrb_utf8len()` says it
reaches. Rounding is then always toward the start, and the character before `p`
is the head of `p-1`.

The bounded lookback is the forward walk rather than an approximation of it. If
a character covers `p` and starts `back` bytes earlier, every byte in between is
a continuation byte, so the nearest non-continuation byte going back is that
character's lead; and the lead cannot belong to some earlier character in turn,
since the lead byte of a multi-byte sequence is never a continuation byte. Three
bytes is the whole of the range, because nothing longer than four bytes spells a
character.

This is the rule mruby-regexp already applies in `mrb_re_utf8_interior_p()`, so
core and the regexp engine now agree on where a character starts.

### Against CRuby

Over `rindex` with eleven subjects holding malformed sequences of each kind,
seven needles that are valid UTF-8, and every position from `-length-1` to
`length+1`, the five differences from CRuby 4.0.6 are the ones above. After this
change there are none.

Differences remain for a needle that is itself malformed: CRuby answers `nil`
for those regardless of the subject, while mruby searches for the bytes.
`String#index` answers the same way, so that is a separate question about what a
malformed argument means, and nothing here changes it.

### Verified

- `rake test` on a full-core build (`MRB_UTF8_STRING` through mruby-encoding):
  2248 tests, all green
- `rake test` on the default gembox (no `MRB_UTF8_STRING`): 2057 tests, all
  green
- each commit is green on its own, and the test added by each fails on the
  commit before it
- `prek run --all-files` passes, except that `markdownlint` could not install
  locally (npm engine mismatch); no Markdown is touched here


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reverse substring searches for UTF-8 text, including searches starting at negative positions.
  * Corrected character-boundary handling for multibyte and invalid UTF-8 bytes.
  * Enforced position limits more consistently during backward searches.

* **Tests**
  * Added coverage for UTF-8 reverse searches at character boundaries and with invalid byte sequences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->