### PR TITLE
internal.h: shorten the `mrb_str_valid_encoding_p` comment

### DIFF
--- a/include/mruby/internal.h
+++ b/include/mruby/internal.h
@@ -183,14 +183,10 @@ mrb_int mrb_str_char_len(mrb_state *mrb, mrb_value str);
 mrb_int mrb_str_char_to_byte(mrb_state *mrb, mrb_value str, mrb_int off, mrb_int nchars);
 mrb_int mrb_str_byte_to_char(mrb_state *mrb, mrb_value str, mrb_int bi);
 
-/* Whether a string's bytes read as the encoding it is taken to have. A binary
-   string claims no encoding and is valid whatever its bytes are; any other
-   string is walked, and one that turns out to hold a byte standing for no
-   character is not valid. The single-byte flag is not read on the way in, so
-   the answer does not depend on whether the string has been measured before;
-   a string found to have one byte per character is marked on the way out. On
-   non-UTF-8 builds a string is bytes with no encoding to disagree with, and
-   this is always TRUE. */
+/* Whether a string's bytes read as the encoding it is taken to have: FALSE for
+   one holding a byte that stands for no character, TRUE for a binary string
+   whatever its bytes are, and TRUE throughout on a non-UTF-8 build. See the
+   definition in string.c for what it reads and what it leaves behind. */
 mrb_bool mrb_str_valid_encoding_p(mrb_state *mrb, mrb_value str);
 
 mrb_int mrb_utf8_to_buf(char *buf, uint32_t cp);


### PR DESCRIPTION
The comment on the declaration of `mrb_str_valid_encoding_p`, added in #7105,
restated the one on the definition in string.c: which flag the walk declines to
read on the way in, why reading it would make the answer depend on whether the
string had been measured before, and which flag a string that walks to one byte
per character is left with.

A caller reading the header needs the answer the function gives, not how it
arrives at one. Keep the three answers it has to know, which are the two strings
the walk never touches and the one it rejects, and leave the rest at the
definition, where the code that does the walking is.

```c
/* Whether a string's bytes read as the encoding it is taken to have: FALSE for
   one holding a byte that stands for no character, TRUE for a binary string
   whatever its bytes are, and TRUE throughout on a non-UTF-8 build. See the
   definition in string.c for what it reads and what it leaves behind. */
mrb_bool mrb_str_valid_encoding_p(mrb_state *mrb, mrb_value str);
```

Comment only; no code changes.

### Verified

- `rake test` on a full-core build: 2246 tests, all green
- `prek run --all-files` passes, except that `markdownlint` could not install
  locally (npm engine mismatch); no Markdown is touched here


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified documentation for string encoding validation, including behavior for binary strings and non-UTF-8 encodings.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->