### PR TITLE
Share UTF-8 byte lengths and character heads between core and mruby-regexp

### DIFF
--- a/include/mruby/internal.h
+++ b/include/mruby/internal.h
@@ -190,8 +190,18 @@ mrb_int mrb_str_byte_to_char(mrb_state *mrb, mrb_value str, mrb_int bi);
 mrb_bool mrb_str_valid_encoding_p(mrb_state *mrb, mrb_value str);
 
 mrb_int mrb_utf8_to_buf(char *buf, uint32_t cp);
-#ifdef MRB_UTF8_STRING
+
+/* The byte length of the character at `str`, which has to be a byte of the
+   string rather than `end` itself, and 1 for a run of bytes that spells no
+   character. See the definition in string.c for what it rejects. */
 mrb_int mrb_utf8len(const char *str, const char *end);
+
+/* The byte the character covering `p` starts at, or `p` itself when `p` is
+   already a character boundary. A continuation byte that no lead byte reaches
+   is a boundary too. */
+const char *mrb_utf8_char_head(const char *beg, const char *p, const char *end);
+
+#ifdef MRB_UTF8_STRING
 mrb_int mrb_utf8_strlen(const char *str, mrb_int byte_len);
 #endif
 

--- a/mrbgems/mruby-regexp/include/re_internal.h
+++ b/mrbgems/mruby-regexp/include/re_internal.h
@@ -8,6 +8,7 @@
 #define MRB_RE_INTERNAL_H
 
 #include <mruby.h>
+#include <mruby/internal.h>
 #include <stdint.h>
 
 /* Bytecode instructions for the NFA engine */
@@ -173,7 +174,6 @@ mrb_regexp_pattern* mrb_re_compile(mrb_state *mrb, const char *pattern, mrb_int 
 void mrb_re_free(mrb_state *mrb, mrb_regexp_pattern *pat);
 
 /* UTF-8 helpers */
-int mrb_re_utf8_charlen(const char *s, const char *end);
 uint32_t mrb_re_utf8_decode(const char *s, const char *end, int *len);
 mrb_bool mrb_re_is_word_char(uint32_t c);
 
@@ -232,7 +232,7 @@ void mrb_re_case_unfold_range(uint32_t lo, uint32_t hi,
 static inline int
 mrb_re_charlen(const char *s, const char *end, mrb_bool binary)
 {
-  return binary ? 1 : mrb_re_utf8_charlen(s, end);
+  return binary ? 1 : (int)mrb_utf8len(s, end);
 }
 
 static inline uint32_t
@@ -248,17 +248,15 @@ mrb_re_decode_char(const char *s, const char *end, int *len, mrb_bool binary)
 /* TRUE when s points into the middle of a character that starts earlier in
    the string, so it is not a place a match may start at. A byte that looks
    like a continuation byte but follows no lead byte that reaches it belongs
-   to no character and stands on its own. */
+   to no character and stands on its own, and there the head of the character
+   covering s is s itself. The matcher asks this at every position it tries,
+   so keep the answer for a byte that starts a character here rather than in
+   the call. */
 static inline mrb_bool
 mrb_re_utf8_interior_p(const char *str, const char *s, const char *end)
 {
-  if (((uint8_t)*s & 0xC0) != 0x80) return FALSE;
-  for (int back = 1; back <= 3 && back <= s - str; back++) {
-    const char *lead = s - back;
-    if (((uint8_t)*lead & 0xC0) == 0x80) continue;  /* another continuation byte */
-    return mrb_re_utf8_charlen(lead, end) > back;
-  }
-  return FALSE;
+  if (s >= end || ((uint8_t)*s & 0xC0) != 0x80) return FALSE;
+  return mrb_utf8_char_head(str, s, end) != s;
 }
 
 /* Execute a match.

--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -958,7 +958,7 @@ emit_char(re_compiler *c, uint8_t ch)
 static void
 emit_char_bytes(re_compiler *c, int ch)
 {
-  int len = mrb_re_utf8_charlen(c->p - 1, c->src_end);
+  int len = (int)mrb_utf8len(c->p - 1, c->src_end);
   emit(c, RE_CHAR, (uint8_t)ch, 0);
   for (int i = 1; i < len; i++) {
     int b = next_char(c);

--- a/mrbgems/mruby-regexp/src/re_utf8.c
+++ b/mrbgems/mruby-regexp/src/re_utf8.c
@@ -6,51 +6,16 @@
 
 #include "re_internal.h"
 
-/* Return byte length of UTF-8 character at s.
-   Returns 1 for invalid sequences (treat as single byte): a byte that starts
-   no sequence, a sequence cut short by end, one whose continuation bytes are
-   not 10xxxxxx, and one that spells a codepoint a shorter sequence already
-   holds, a surrogate, or a value above U+10FFFF. The last three are decided
-   by the lead byte together with the first continuation byte. */
-int
-mrb_re_utf8_charlen(const char *s, const char *end)
-{
-  uint8_t c = (uint8_t)*s;
-  uint8_t lo = 0x80, hi = 0xbf;  /* range the first continuation byte must fall in */
-  int len;
-
-  if (c < 0x80) return 1;
-  else if (c < 0xc2) return 1;  /* continuation byte, or an overlong two-byte lead */
-  else if (c < 0xe0) len = 2;
-  else if (c < 0xf0) {
-    len = 3;
-    if (c == 0xe0) lo = 0xa0;       /* below U+0800 */
-    else if (c == 0xed) hi = 0x9f;  /* U+D800 to U+DFFF */
-  }
-  else if (c < 0xf5) {
-    len = 4;
-    if (c == 0xf0) lo = 0x90;       /* below U+10000 */
-    else if (c == 0xf4) hi = 0x8f;  /* above U+10FFFF */
-  }
-  else return 1;  /* invalid */
-
-  if (s + len > end) return 1;  /* truncated */
-  if ((uint8_t)s[1] < lo || (uint8_t)s[1] > hi) return 1;
-  for (int i = 2; i < len; i++) {
-    if (((uint8_t)s[i] & 0xc0) != 0x80) return 1;  /* invalid continuation */
-  }
-  return len;
-}
-
 /* Decode a UTF-8 character and return its codepoint.
-   *len is set to the byte length consumed. Invalid or truncated
-   sequences consume a single byte, mirroring mrb_re_utf8_charlen. */
+   *len is set to the byte length consumed. mrb_utf8len() answers 1 for every
+   sequence it rejects, so those consume a single byte and come back as the
+   lead byte itself. */
 uint32_t
 mrb_re_utf8_decode(const char *s, const char *end, int *len)
 {
   uint8_t c = (uint8_t)s[0];
   uint32_t cp;
-  int n = mrb_re_utf8_charlen(s, end);
+  int n = (int)mrb_utf8len(s, end);
 
   *len = n;
   switch (n) {

--- a/src/string.c
+++ b/src/string.c
@@ -369,6 +369,76 @@ mrb_utf8_to_buf(char *buf, uint32_t cp)
   return 0;  /* invalid codepoint */
 }
 
+/* What a run of bytes spells is a question apart from whether String indexes
+   by character, and mruby-regexp asks the first one whatever the build does.
+   So this much is here in every build; what indexes a string by character
+   waits behind MRB_UTF8_STRING below. */
+
+#define utf8_islead(c) ((unsigned char)((c)&0xc0) != 0x80)
+
+/* the byte length a lead byte claims, read only through mrb_utf8len() */
+static const char mrb_utf8len_table[] = {
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+  0, 0, 0, 0, 0, 0, 0, 0, 2, 2, 2, 2, 3, 3, 4, 0
+};
+
+mrb_int
+mrb_utf8len(const char* p, const char* e)
+{
+  mrb_int len = mrb_utf8len_table[(unsigned char)p[0] >> 3];
+  if (len > e - p) return 1;
+  switch (len) {
+  case 0:
+    return 1;
+  case 4:
+    if (utf8_islead(p[3])) return 1;
+  case 3:
+    if (utf8_islead(p[2])) return 1;
+  case 2:
+    if (utf8_islead(p[1])) return 1;
+  }
+  /* Reject overlong sequences, UTF-16 surrogates, and code points above
+     U+10FFFF (RFC 3629, Unicode D93b). */
+  switch ((unsigned char)p[0]) {
+  case 0xC0: case 0xC1:                       /* overlong (< U+0080) */
+    return 1;
+  case 0xE0:                                  /* overlong (< U+0800) */
+    if ((unsigned char)p[1] < 0xA0) return 1;
+    break;
+  case 0xED:                                  /* surrogate (U+D800..U+DFFF) */
+    if ((unsigned char)p[1] > 0x9F) return 1;
+    break;
+  case 0xF0:                                  /* overlong (< U+10000) */
+    if ((unsigned char)p[1] < 0x90) return 1;
+    break;
+  case 0xF4:                                  /* above U+10FFFF */
+    if ((unsigned char)p[1] > 0x8F) return 1;
+    break;
+  case 0xF5: case 0xF6: case 0xF7:            /* above U+10FFFF */
+    return 1;
+  }
+  return len;
+}
+
+/* The byte the character covering `p` starts at, or `p` itself when `p` is
+   already a character boundary. A continuation byte belongs to the character
+   that reaches it; one that no lead byte reaches belongs to none and stands as
+   a character of its own. Whether a lead byte reaches is mrb_utf8len()'s
+   answer, so the boundaries found here are the ones the character count is
+   taken over. Reading back three bytes covers it, since nothing longer than
+   four bytes spells a character. */
+const char*
+mrb_utf8_char_head(const char *beg, const char *p, const char *end)
+{
+  if (p >= end || utf8_islead(p[0])) return p;
+  for (mrb_int back = 1; back <= 3 && back <= p - beg; back++) {
+    const char *lead = p - back;
+    if (!utf8_islead(lead[0])) continue;  /* another continuation byte */
+    return mrb_utf8len(lead, end) > back ? lead : p;
+  }
+  return p;
+}
+
 #ifdef MRB_UTF8_STRING
 
 #define NOASCII(c) ((c) & 0x80)
@@ -461,52 +531,6 @@ search_nonascii(const char *p, const char *e)
 }
 
 #endif  /* SIMPLE_SEARCH_NONASCII */
-
-#define utf8_islead(c) ((unsigned char)((c)&0xc0) != 0x80)
-
-/* the byte length a lead byte claims, read only through mrb_utf8len() */
-static const char mrb_utf8len_table[] = {
-  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-  0, 0, 0, 0, 0, 0, 0, 0, 2, 2, 2, 2, 3, 3, 4, 0
-};
-
-mrb_int
-mrb_utf8len(const char* p, const char* e)
-{
-  mrb_int len = mrb_utf8len_table[(unsigned char)p[0] >> 3];
-  if (len > e - p) return 1;
-  switch (len) {
-  case 0:
-    return 1;
-  case 4:
-    if (utf8_islead(p[3])) return 1;
-  case 3:
-    if (utf8_islead(p[2])) return 1;
-  case 2:
-    if (utf8_islead(p[1])) return 1;
-  }
-  /* Reject overlong sequences, UTF-16 surrogates, and code points above
-     U+10FFFF (RFC 3629, Unicode D93b). */
-  switch ((unsigned char)p[0]) {
-  case 0xC0: case 0xC1:                       /* overlong (< U+0080) */
-    return 1;
-  case 0xE0:                                  /* overlong (< U+0800) */
-    if ((unsigned char)p[1] < 0xA0) return 1;
-    break;
-  case 0xED:                                  /* surrogate (U+D800..U+DFFF) */
-    if ((unsigned char)p[1] > 0x9F) return 1;
-    break;
-  case 0xF0:                                  /* overlong (< U+10000) */
-    if ((unsigned char)p[1] < 0x90) return 1;
-    break;
-  case 0xF4:                                  /* above U+10FFFF */
-    if ((unsigned char)p[1] > 0x8F) return 1;
-    break;
-  case 0xF5: case 0xF6: case 0xF7:            /* above U+10FFFF */
-    return 1;
-  }
-  return len;
-}
 
 #if defined(__GNUC__) || __has_builtin(__builtin_popcount)
 # ifdef MRB_64BIT
@@ -687,25 +711,6 @@ mrb_str_byte_to_char(mrb_state *mrb, mrb_value str, mrb_int bi)
   }
   if (p != pivot) return -1;
   return i;
-}
-
-/* The byte the character covering `p` starts at, or `p` itself when `p` is
-   already a character boundary. A continuation byte belongs to the character
-   that reaches it; one that no lead byte reaches belongs to none and stands as
-   a character of its own. Whether a lead byte reaches is mrb_utf8len()'s
-   answer, so the boundaries found here are the ones the character count is
-   taken over. Reading back three bytes covers it, since nothing longer than
-   four bytes spells a character. */
-static const char*
-str_char_head(const char *beg, const char *p, const char *end)
-{
-  if (p >= end || utf8_islead(p[0])) return p;
-  for (mrb_int back = 1; back <= 3 && back <= p - beg; back++) {
-    const char *lead = p - back;
-    if (!utf8_islead(lead[0])) continue;  /* another continuation byte */
-    return mrb_utf8len(lead, end) > back ? lead : p;
-  }
-  return p;
 }
 
 static mrb_int
@@ -1067,7 +1072,7 @@ str_char_rindex(mrb_value str, mrb_value sub, mrb_int pos)
   if (len) {
     /* a match may start only at a character boundary, and `pos` need not be
        one: the clamp above answers the last byte `sub` fits at */
-    s = str_char_head(sbeg, s, send);
+    s = mrb_utf8_char_head(sbeg, s, send);
     for (;;) {
       if ((mrb_int)(send - s) >= len && memcmp(s, t, len) == 0) {
         return (mrb_int)(s - sbeg);
@@ -1075,7 +1080,7 @@ str_char_rindex(mrb_value str, mrb_value sub, mrb_int pos)
       /* the character before `s`, which there is none of once the search has
          reached the first one */
       if (s == sbeg) break;
-      s = str_char_head(sbeg, s-1, send);
+      s = mrb_utf8_char_head(sbeg, s-1, send);
     }
     return -1;
   }
@@ -2620,7 +2625,7 @@ mrb_str_rindex_m(mrb_state *mrb, mrb_value str)
        first character is the last step that stays in the string */
     while (pos < 0) {
       if (e == p) return mrb_nil_value();
-      e = str_char_head(p, e-1, send);
+      e = mrb_utf8_char_head(p, e-1, send);
       pos++;
     }
     pos = (mrb_int)(e - p);

--- a/test/t/string.rb
+++ b/test/t/string.rb
@@ -679,6 +679,12 @@ assert('String#rindex steps by the characters String#length counts') do
   assert_equal 1, "\xC0\x80a".rindex("\x80")
   assert_equal 3, "\xED\xA0\x80".length
   assert_equal 2, "\xED\xA0\x80".rindex("\x80")
+
+  # A lead byte the string end cuts short reaches none of the bytes that
+  # follow it, so those stand alone too.
+  assert_equal 3, "a\xE3\x81".length
+  assert_equal 1, "a\xE3\x81".rindex("\xE3")
+  assert_equal 2, "a\xE3\x81".rindex("\x81")
 end if UTF8STRING
 
 assert('String#byterindex searches bytes') do


### PR DESCRIPTION
mruby-regexp carries its own answers to two questions core already answers:
how many bytes the character at a pointer takes, and where the character
covering a pointer starts. `mrb_re_utf8_charlen()` and core's `mrb_utf8len()`
agree byte for byte, and `mrb_re_utf8_interior_p()` applies the same rule as the
`str_char_head()` that #7107 arrived at.

They are separate because core keeps `mrb_utf8len()` behind `MRB_UTF8_STRING`,
and the regexp engine has no such guard: it reads UTF-8 whatever a build's
strings index by. That is not a hypothetical configuration. mruby-regexp is in
the stdlib gembox and mruby-encoding is not, so the stock **default gembox
already builds the engine without `MRB_UTF8_STRING`**, decoding UTF-8 with its
own copy while core's sits compiled out.

### What moves

`MRB_UTF8_STRING` says a string indexes by character. What a run of bytes spells
is a question apart from that, so the two functions that only answer it come out
from under the guard:

- `mrb_utf8len()`, unchanged
- `mrb_utf8_char_head()`, which is #7107's `str_char_head()` renamed and
  declared in internal.h beside it

Nothing else follows. `mrb_utf8_strlen()`, the character and byte conversions
and the searches stay behind the guard, because those are the indexing.

### What the engine drops

- `mrb_re_utf8_charlen()` is deleted; `mrb_re_charlen()` and
  `emit_char_bytes()` call `mrb_utf8len()`
- `mrb_re_utf8_interior_p()` becomes `mrb_utf8_char_head(...) != s`
- `mrb_re_utf8_decode()` stays, since core offers no decoder, but takes its
  byte length from `mrb_utf8len()` too

The predicate keeps its own answer for a byte that starts a character, so most
of the positions the matcher tries stay a branch rather than a call. It also
stops reading `*s` at the end of the subject, where it used to lean on the
terminating NUL to answer the same way.

### Equivalence

Checked by brute force rather than argued:

- byte length, `mrb_re_utf8_charlen()` against `mrb_utf8len()`: 2,359,296 cases,
  both first bytes exhaustively, by nine representative tail bytes, by every
  available length from 1 to 4
- the predicate, before against after: 33,338,661 positions, every buffer of up
  to five bytes over a 23-value alphabet covering each lead, continuation and
  discriminant class, at every position

No differences in either. The same run checks each head against a forward walk
from the start of the buffer, which is what makes the three-byte lookback exact
rather than an approximation of one: if a character covers `p` and starts `back`
bytes earlier, every byte in between is a continuation byte, so the nearest
non-continuation byte going back is that character's lead, and that lead cannot
belong to an earlier character in turn.

### Size

Deleting one copy costs less than exposing the other, in both directions:

| build | before | after |
| --- | ---: | ---: |
| full-core | 1808085 | 1806989 |
| default gembox (no `MRB_UTF8_STRING`) | 1722079 | 1721479 |

`size(1)` text of `bin/mruby`, gcc `-O2` on x86-64.

### Base

Branched off #7107, which is still open, because `str_char_head()` arrives
there. The first two commits here are that PR and drop out once it merges.

### Verified

- `rake test` on a full-core build: 2248 tests, all green
- `rake test` on the default gembox, which is the build where the engine reads
  UTF-8 without `MRB_UTF8_STRING`: 2057 tests, all green
- each commit is green on its own
- `prek run --all-files` passes, except that `markdownlint` could not install
  locally (npm engine mismatch); no Markdown is touched here


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UTF-8 character boundary handling for string indexing and reverse searches.
  * Corrected `String#rindex` behavior with negative positions, multibyte characters, invalid UTF-8 bytes, and boundary limits.
  * Improved regular-expression processing of valid and invalid UTF-8 sequences.
* **Tests**
  * Added coverage for UTF-8-aware `String#rindex` behavior and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->