### PR TITLE
mruby-regexp: refuse a subject whose bytes are not UTF-8

### DIFF
--- a/mrbgems/mruby-regexp/mrblib/string_regexp.rb
+++ b/mrbgems/mruby-regexp/mrblib/string_regexp.rb
@@ -115,12 +115,17 @@ class String
     # get_pat.  Only the quoting is taken from it: get_pat_quoted also accepts
     # anything answering `to_str`, where `__check_pattern` keeps to a real
     # String, as `match` already does.
-    pattern = Regexp.new(Regexp.escape(pattern)) if String === pattern
+    literal = String === pattern
+    # CRuby searches for a literal byte by byte and never reads the subject as
+    # UTF-8 on the way, so quoting one into a Regexp here must not put the
+    # subject through a check CRuby does not make: `"a\x80b".sub("b", "!")`
+    # answers there, where the same call with `/b/` is refused.
+    pattern = Regexp.new(Regexp.escape(pattern)) if literal
     # A replacement argument wins over the block, as in CRuby.
     if args.length == 2
-      return Regexp.__sub_str(pattern, self, replacement.to_s)
+      return Regexp.__sub_str(pattern, self, replacement.to_s, literal)
     end
-    md = Regexp.__search(pattern, self)
+    md = Regexp.__search(pattern, self, 0, literal)
     return self.dup unless md
     md.pre_match + block.call(md[0]).to_s + md.post_match
   end
@@ -141,19 +146,23 @@ class String
     # Resolved here rather than left to `sub` because the match below decides
     # the return value, and a String pattern is a literal on both paths.
     pattern = Regexp.__check_pattern(args[0])
-    pattern = Regexp.new(Regexp.escape(pattern)) if String === pattern
+    literal = String === pattern
+    pattern = Regexp.new(Regexp.escape(pattern)) if literal
     raise FrozenError, "can't modify frozen String" if frozen?
     # Whether a substitution happened is a question about the match, not about
     # the result: `"aaa".sub!(/a/, "a")` returns self even though the string is
     # unchanged.  A full search and not `match?`, so a failed match clears $~.
-    return nil unless Regexp.__search(pattern, self)
+    return nil unless Regexp.__search(pattern, self, 0, literal)
     # `sub` matches again and publishes its own $~ over this one, leaving the
     # caller the match `sub` would have left, a block's own matches included.
     # The resolved pattern takes the place of the original argument so that a
-    # String is not quoted and compiled a second time.  Overwriting `self`
-    # afterwards is safe: a MatchData snapshots its subject, so $~ keeps
-    # describing the string as it was matched.
-    str = args.length == 2 ? self.sub(pattern, args[1], &block) : self.sub(pattern, &block)
+    # String is not quoted and compiled a second time; a literal goes down as
+    # the String it was instead, since that is what tells `sub` to leave the
+    # subject unread, and quoting it twice is the price of saying so.
+    # Overwriting `self` afterwards is safe: a MatchData snapshots its subject,
+    # so $~ keeps describing the string as it was matched.
+    down = literal ? args[0] : pattern
+    str = args.length == 2 ? self.sub(down, args[1], &block) : self.sub(down, &block)
     self.replace(str)
   end
 
@@ -169,12 +178,18 @@ class String
     # After the to_enum return above, so that `"abc".gsub(:b)` yields an
     # Enumerator and raises on the first iteration, as CRuby does.
     pattern = Regexp.__check_pattern(pattern)
-    pattern = Regexp.new(Regexp.escape(pattern)) if String === pattern
+    # A String pattern is a literal, as in `sub`, and reaches the subject the
+    # way CRuby reaches it: byte by byte, with no reading of it as UTF-8.
+    literal = String === pattern
+    pattern = Regexp.new(Regexp.escape(pattern)) if literal
     # A replacement argument wins over the block, as in CRuby.
     if args.length == 2
-      return Regexp.__gsub_str(pattern, self, replacement.to_s)
+      return Regexp.__gsub_str(pattern, self, replacement.to_s, literal)
     end
     # block case: keep in Ruby to avoid VM callback from C
+    # `__byte_search` leaves the encoding check to its caller, so run it here,
+    # once for the subject the loop below holds fixed.
+    Regexp.__check_encoding(self) unless literal
     parts = []
     pos = 0
     len = self.bytesize
@@ -227,12 +242,15 @@ class String
     end
     return to_enum(:gsub!, *args) if args.length == 1 && !block
     pattern = Regexp.__check_pattern(args[0])
-    pattern = Regexp.new(Regexp.escape(pattern)) if String === pattern
+    literal = String === pattern
+    pattern = Regexp.new(Regexp.escape(pattern)) if literal
     # As in `sub!`: the match decides the return value, and a failed search
     # clears $~.  What it publishes on success is replaced right away by the
     # last match of the `gsub` below, which is the one CRuby leaves behind.
-    return nil unless Regexp.__search(pattern, self)
-    str = args.length == 2 ? self.gsub(pattern, args[1], &block) : self.gsub(pattern, &block)
+    # A literal goes down as the String it was, for the reason `sub!` gives.
+    return nil unless Regexp.__search(pattern, self, 0, literal)
+    down = literal ? args[0] : pattern
+    str = args.length == 2 ? self.gsub(down, args[1], &block) : self.gsub(down, &block)
     self.replace(str)
   end
 
@@ -278,6 +296,8 @@ class String
     # branch of the check is unreachable here and nothing needs quoting.
     pattern = Regexp.__check_pattern(pattern)
 
+    # Once for the whole loop, as in `gsub`.
+    Regexp.__check_encoding(self)
     result = []
     field_start = 0
     search_pos = 0
@@ -505,9 +525,13 @@ class String
   # not at the match end, which is what keeps overlapping matches in view:
   # `"aaa".rindex(/aa/)` is 1, where resuming at the end would answer 0.
   def __regexp_rsearch(pattern, limit, bytes)
+    # The walk searches once per match position, so the encoding check goes
+    # here rather than in each of those searches, which is what the flag on
+    # `__search` below says.
+    Regexp.__check_encoding(self)
     found = nil
     pos = 0
-    while (md = Regexp.__search(pattern, self, pos))
+    while (md = Regexp.__search(pattern, self, pos, true))
       break if (bytes ? md.__byte_begin(0) : md.begin(0)) > limit
       found = md
       pos = md.begin(0) + 1
@@ -570,6 +594,8 @@ class String
     # not check for one either, and on a build without MRB_UTF8_STRING there
     # is nothing to check.
     return Regexp.__search(args[0], nil) if pos < 0 || pos > len
+    # One search, but `__byte_search` still leaves the check to its caller.
+    Regexp.__check_encoding(self)
     md = Regexp.__byte_search(args[0], self, pos)
     md && md.__byte_begin(0)
   end

--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -228,6 +228,46 @@ re_binary_string_p(mrb_value str)
   return RSTR_BINARY_P(RSTRING(str));
 }
 
+/* CRuby refuses a search whose subject holds a byte that spells no character,
+   and mruby answers for it. Refuse it here too, so that a program moved from
+   one to the other is told about the subject rather than handed a result the
+   other would not have produced.
+
+   A binary string is exempt because it is indexed by byte throughout, so its
+   bytes make no claim that could be broken. A quoted String pattern is exempt
+   for a narrower reason: CRuby searches for a literal byte by byte and reads
+   the subject as UTF-8 nowhere along the way, so `"a\x80b".sub("b", "!")`
+   answers there while the same call with `/b/` is refused.
+
+   The check walks the whole subject, so it runs once per search a method
+   makes, not once per match it finds: the entry points below check what
+   arrives from Ruby, and the two that an mrblib loop drives (`__byte_search`,
+   and `__search` with the flag set) leave it to the loop, which checks the
+   subject it holds fixed before the first turn. */
+static void
+re_check_encoding(mrb_state *mrb, mrb_value str)
+{
+  if (!mrb_str_valid_encoding_p(mrb, str)) {
+    mrb_raise(mrb, E_ARGUMENT_ERROR, "invalid byte sequence in UTF-8");
+  }
+}
+
+/*
+ * Regexp.__check_encoding(str)
+ *
+ * Internal: the check itself, for the mrblib loops of `gsub`, `split`,
+ * `byteindex`, `rindex`, `byterindex` and `rpartition` to run once at the
+ * entry to the method.
+ */
+static mrb_value
+regexp_s_check_encoding(mrb_state *mrb, mrb_value klass)
+{
+  mrb_value str;
+  mrb_get_args(mrb, "S", &str);
+  re_check_encoding(mrb, str);
+  return mrb_nil_value();
+}
+
 static mrb_value
 regexp_binary_string_p(mrb_state *mrb, mrb_value self)
 {
@@ -362,6 +402,7 @@ regexp_match(mrb_state *mrb, mrb_value self)
     return mrb_nil_value();
   }
 
+  re_check_encoding(mrb, str);
   md = exec_match(mrb, self, str, pos);
   if (!mrb_nil_p(md) && !mrb_nil_p(block)) {
     return mrb_yield(mrb, block, md);
@@ -383,7 +424,7 @@ check_regexp_arg(mrb_state *mrb, mrb_value re)
 }
 
 /*
- * Regexp.__search(re, str, pos = 0)
+ * Regexp.__search(re, str, pos = 0, checked = false)
  *
  * Internal: `Regexp#match` with the pattern as an argument and no block form.
  * The String overrides in mrblib search through this so that the search never
@@ -391,14 +432,22 @@ check_regexp_arg(mrb_state *mrb, mrb_value re)
  * the note at the top of mrblib/string_regexp.rb. A nil subject clears the
  * match globals and answers nil, as `Regexp#match` does, which is what the
  * overrides use to report a miss.
+ *
+ * `checked` says the caller has settled the encoding question for the subject
+ * and this search must not ask it again. The backward search sets it because
+ * it ran `Regexp.__check_encoding` itself, keeping one check for a walk that
+ * searches once per match position; `sub!` and `gsub!` set it because their
+ * pattern is a quoted String, which CRuby searches for without reading the
+ * subject as UTF-8 at all.
  */
 static mrb_value
 regexp_s_search(mrb_state *mrb, mrb_value klass)
 {
   mrb_value re, str;
   mrb_int pos = 0;
+  mrb_bool checked = FALSE;
 
-  mrb_get_args(mrb, "oo|i", &re, &str, &pos);
+  mrb_get_args(mrb, "oo|ib", &re, &str, &pos, &checked);
   check_regexp_arg(mrb, re);
   if (mrb_nil_p(str)) {
     clear_match_globals(mrb);
@@ -410,6 +459,7 @@ regexp_s_search(mrb_state *mrb, mrb_value klass)
     clear_match_globals(mrb);
     return mrb_nil_value();
   }
+  if (!checked) re_check_encoding(mrb, str);
   return exec_match(mrb, re, str, pos);
 }
 
@@ -419,7 +469,8 @@ regexp_s_search(mrb_state *mrb, mrb_value klass)
  * Internal: the byte-offset search the mrblib loops of `gsub`, `split` and
  * `byteindex` drive themselves. No position normalization, because the
  * callers already work in byte space, and no operand conversion, because
- * they always pass a String.
+ * they always pass a String. The subject is checked by the caller, once for
+ * the whole loop.
  */
 static mrb_value
 regexp_s_byte_search(mrb_state *mrb, mrb_value klass)
@@ -445,6 +496,7 @@ exec_match_p(mrb_state *mrb, mrb_value re, mrb_value str, mrb_int pos)
 
   mrb_regexp_pattern *pat = DATA_GET_PTR(mrb, re, &regexp_type, mrb_regexp_pattern);
   if (!pat) mrb_raise(mrb, E_ARGUMENT_ERROR, "uninitialized Regexp");
+  re_check_encoding(mrb, str);
 
   int ncap = mrb_re_exec(mrb, pat, RSTRING_PTR(str), RSTRING_LEN(str), pos, NULL, 0,
                          re_binary_string_p(str));
@@ -493,6 +545,7 @@ regexp_match_op(mrb_state *mrb, mrb_value self)
     return mrb_nil_value();
   }
   str = match_operand(mrb, str);
+  re_check_encoding(mrb, str);
 
   mrb_value md = exec_match(mrb, self, str, 0);
   if (mrb_nil_p(md)) return mrb_nil_value();
@@ -516,6 +569,7 @@ regexp_case_match(mrb_state *mrb, mrb_value self)
 
   pat = DATA_GET_PTR(mrb, self, &regexp_type, mrb_regexp_pattern);
   if (!pat) return mrb_false_value();
+  re_check_encoding(mrb, str);
 
   md = exec_match(mrb, self, str, 0);
   return mrb_bool_value(!mrb_nil_p(md));
@@ -1071,17 +1125,23 @@ has_backslash(const char *s, mrb_int len)
 }
 
 /*
- * Regexp.__gsub_str(re, str, replacement) - gsub core without block
+ * Regexp.__gsub_str(re, str, replacement, checked = false) - gsub core without block
+ *
+ * `checked` says the caller has settled the encoding question for the subject,
+ * which for `gsub` means the pattern is a quoted String and the search is a
+ * literal one that CRuby runs without reading the subject as UTF-8.
  */
 static mrb_value
 regexp_s_gsub_str(mrb_state *mrb, mrb_value klass)
 {
   mrb_value re, str, replacement;
-  mrb_get_args(mrb, "oSS", &re, &str, &replacement);
+  mrb_bool checked = FALSE;
+  mrb_get_args(mrb, "oSS|b", &re, &str, &replacement, &checked);
   check_regexp_arg(mrb, re);
 
   mrb_regexp_pattern *pat = DATA_GET_PTR(mrb, re, &regexp_type, mrb_regexp_pattern);
   if (!pat) mrb_raise(mrb, E_ARGUMENT_ERROR, "uninitialized Regexp");
+  if (!checked) re_check_encoding(mrb, str);
 
   const char *s = RSTRING_PTR(str);
   mrb_int slen = RSTRING_LEN(str);
@@ -1161,17 +1221,21 @@ regexp_s_gsub_str(mrb_state *mrb, mrb_value klass)
 }
 
 /*
- * Regexp.__sub_str(re, str, replacement) - sub core without block
+ * Regexp.__sub_str(re, str, replacement, checked = false) - sub core without block
+ *
+ * `checked` carries the same meaning as in `__gsub_str`.
  */
 static mrb_value
 regexp_s_sub_str(mrb_state *mrb, mrb_value klass)
 {
   mrb_value re, str, replacement;
-  mrb_get_args(mrb, "oSS", &re, &str, &replacement);
+  mrb_bool checked = FALSE;
+  mrb_get_args(mrb, "oSS|b", &re, &str, &replacement, &checked);
   check_regexp_arg(mrb, re);
 
   mrb_regexp_pattern *pat = DATA_GET_PTR(mrb, re, &regexp_type, mrb_regexp_pattern);
   if (!pat) mrb_raise(mrb, E_ARGUMENT_ERROR, "uninitialized Regexp");
+  if (!checked) re_check_encoding(mrb, str);
 
   const char *s = RSTRING_PTR(str);
   mrb_int slen = RSTRING_LEN(str);
@@ -1226,6 +1290,7 @@ regexp_s_scan(mrb_state *mrb, mrb_value klass)
 
   mrb_regexp_pattern *pat = DATA_GET_PTR(mrb, re, &regexp_type, mrb_regexp_pattern);
   if (!pat) mrb_raise(mrb, E_ARGUMENT_ERROR, "uninitialized Regexp");
+  re_check_encoding(mrb, str);
 
   const char *s = RSTRING_PTR(str);
   mrb_int slen = RSTRING_LEN(str);
@@ -1341,7 +1406,8 @@ mrb_mruby_regexp_gem_init(mrb_state *mrb)
   mrb_define_class_method(mrb, re, "quote", regexp_escape, MRB_ARGS_REQ(1));
   mrb_define_class_method(mrb, re, "__binary_string?", regexp_binary_string_p, MRB_ARGS_REQ(1));
   mrb_define_class_method(mrb, re, "__check_pattern", regexp_check_pattern, MRB_ARGS_REQ(1));
-  mrb_define_class_method(mrb, re, "__search", regexp_s_search, MRB_ARGS_ARG(2, 1));
+  mrb_define_class_method(mrb, re, "__check_encoding", regexp_s_check_encoding, MRB_ARGS_REQ(1));
+  mrb_define_class_method(mrb, re, "__search", regexp_s_search, MRB_ARGS_ARG(2, 2));
   mrb_define_class_method(mrb, re, "__byte_search", regexp_s_byte_search, MRB_ARGS_ARG(2, 1));
   mrb_define_class_method(mrb, re, "__search_p", regexp_s_search_p, MRB_ARGS_ARG(2, 1));
 
@@ -1358,8 +1424,8 @@ mrb_mruby_regexp_gem_init(mrb_state *mrb)
   mrb_define_method(mrb, re, "hash", regexp_hash, MRB_ARGS_NONE());
   mrb_define_method(mrb, re, "options", regexp_options, MRB_ARGS_NONE());
   mrb_define_method(mrb, re, "casefold?", regexp_casefold_p, MRB_ARGS_NONE());
-  mrb_define_class_method(mrb, re, "__gsub_str", regexp_s_gsub_str, MRB_ARGS_REQ(3));
-  mrb_define_class_method(mrb, re, "__sub_str", regexp_s_sub_str, MRB_ARGS_REQ(3));
+  mrb_define_class_method(mrb, re, "__gsub_str", regexp_s_gsub_str, MRB_ARGS_ARG(3, 1));
+  mrb_define_class_method(mrb, re, "__sub_str", regexp_s_sub_str, MRB_ARGS_ARG(3, 1));
   mrb_define_class_method(mrb, re, "__scan", regexp_s_scan, MRB_ARGS_REQ(2));
 
   /* MatchData class */

--- a/mrbgems/mruby-regexp/test/regexp_utf8.rb
+++ b/mrbgems/mruby-regexp/test/regexp_utf8.rb
@@ -55,12 +55,14 @@ assert("Regexp - /i does not read a byte above 127 as a character") do
   # A byte that starts no whole character decodes as itself, so the folding
   # path would take a lone 0xB5 for U+00B5 and answer /i for a character the
   # pattern does not hold. A literal compares bytes, with or without /i.
+  # The byte reaches the engine through a byte-indexed subject, since a UTF-8
+  # subject carrying it is refused before the match runs.
   micro = "\xB5"        # U+00B5 is "\xC2\xB5"; the byte on its own is not it
-  assert_equal 0, (Regexp.new(micro, Regexp::IGNORECASE) =~ micro)
+  assert_equal 0, (Regexp.new(micro, Regexp::IGNORECASE) =~ micro.b)
   assert_nil (Regexp.new(micro, Regexp::IGNORECASE) =~ "\u00B5")
   # A sequence cut short by the end of the pattern reads the same way.
   lead = "\xC3"         # starts a two byte character and never completes one
-  assert_equal 0, (Regexp.new(lead, Regexp::IGNORECASE) =~ lead)
+  assert_equal 0, (Regexp.new(lead, Regexp::IGNORECASE) =~ lead.b)
   assert_nil (Regexp.new(lead, Regexp::IGNORECASE) =~ "\u00E3")
 end
 
@@ -123,16 +125,19 @@ assert("Regexp - quantifier on an invalid multibyte literal") do
   lead3 = "\xE3"  # starts a three byte character
   cont = "\x81"   # continuation byte
 
+  # What the quantifier binds to is settled when the pattern is compiled, so
+  # the subjects below are byte-indexed: a UTF-8 subject holding these bytes
+  # is refused before the match runs.
   # "x" is not a continuation byte, so `+` repeats "x".
-  assert_equal 4, (lead2 + "xxx").match(Regexp.new(lead2 + "x+"))[0].bytesize
-  assert_equal 4, (lead3 + "abb").match(Regexp.new(lead3 + "ab+"))[0].bytesize
+  assert_equal 4, (lead2 + "xxx").b.match(Regexp.new(lead2 + "x+"))[0].bytesize
+  assert_equal 4, (lead3 + "abb").b.match(Regexp.new(lead3 + "ab+"))[0].bytesize
   # The quantifier itself must not be taken for a continuation byte either.
-  assert_equal 2, (lead2 + lead2).match(Regexp.new(lead2 + "+"))[0].bytesize
+  assert_equal 2, (lead2 + lead2).b.match(Regexp.new(lead2 + "+"))[0].bytesize
   # A sequence cut short by the end of the pattern emits its bytes one by one.
-  assert_equal 2, (lead3 + cont).match(Regexp.new(lead3 + cont))[0].bytesize
-  assert_equal 3, (lead3 + cont + cont).match(Regexp.new(lead3 + cont + "+"))[0].bytesize
+  assert_equal 2, (lead3 + cont).b.match(Regexp.new(lead3 + cont))[0].bytesize
+  assert_equal 3, (lead3 + cont + cont).b.match(Regexp.new(lead3 + cont + "+"))[0].bytesize
   # A valid character right after an invalid lead byte is still one atom.
-  assert_equal 5, (lead2 + "ĀĀ").match(Regexp.new(lead2 + "Ā+"))[0].bytesize
+  assert_equal 5, (lead2 + "ĀĀ").b.match(Regexp.new(lead2 + "Ā+"))[0].bytesize
   # The subject side reads the same way: `.` takes the lead byte alone.
   assert_equal 1, (lead2 + "x").match(/./)[0].bytesize
   assert_equal 2, "Ā".match(/./)[0].bytesize
@@ -142,19 +147,22 @@ assert("Regexp - a byte that belongs to no character is a match position") do
   # A byte in 0x80-0xBF is the interior of a character only while a lead byte
   # in front of it reaches that far. One that stands on its own is a boundary
   # like any other, and the engines used to disagree about it: the literal
-  # fast path matched there, the NFA never started a match there.
+  # fast path matched there, the NFA never started a match there. A UTF-8
+  # subject carrying such a byte is refused before the match runs, so the
+  # subjects below are byte-indexed.
   b = "\x81"
-  assert_equal 0, (b + b).match(Regexp.new(b + b)).begin(0)
-  assert_equal 2, (b + b).match(Regexp.new(b + "+"))[0].bytesize
-  assert_equal 2, (b + b).match(Regexp.new(b + "*"))[0].bytesize
-  assert_equal 1, (b + b).match(Regexp.new(b + "?"))[0].bytesize
-  assert_equal 1, ("x" + b + b).match(Regexp.new(b + "+")).begin(0)
-  # Inside a character there is still no match position.
+  assert_equal 0, (b + b).b.match(Regexp.new(b + b)).begin(0)
+  assert_equal 2, (b + b).b.match(Regexp.new(b + "+"))[0].bytesize
+  assert_equal 2, (b + b).b.match(Regexp.new(b + "*"))[0].bytesize
+  assert_equal 1, (b + b).b.match(Regexp.new(b + "?"))[0].bytesize
+  assert_equal 1, ("x" + b + b).b.match(Regexp.new(b + "+")).begin(0)
+  # Inside a character there is still no match position, and that subject is
+  # whole UTF-8, so it reaches the engine as it always did.
   assert_nil "あ".match(Regexp.new("\x81"))
   assert_nil "あ".match(Regexp.new("\x82"))
   assert_nil "\u{1D54F}".match(Regexp.new("\x95"))
   # Next to one there is.
-  assert_equal 0, (b + "あ").match(Regexp.new(b)).begin(0)
+  assert_equal 0, (b + "あ").b.match(Regexp.new(b)).begin(0)
   # Through pre_match, since #begin counts characters where the build has
   # them and bytes where it does not.
   assert_equal 3, ("あ" + b).match(Regexp.new(b)).pre_match.bytesize
@@ -174,7 +182,7 @@ assert("Regexp - an attempt in flight opens no match position inside a character
   assert_equal 5, ("あ" + "µ").match(/.?[µ]/)[0].bytesize
   # And so is a byte where no lead byte reaches it, through a class that holds
   # the byte. [µ] holds the character, whose trailing byte alone is not it.
-  assert_equal 2, ("x" + "\xb5").match(Regexp.new(".?[\xb5]"))[0].bytesize
+  assert_equal 2, ("x" + "\xb5").b.match(Regexp.new(".?[\xb5]"))[0].bytesize
   assert_nil ("x" + "\xb5").match(/.?[µ]/)
 end
 
@@ -216,6 +224,16 @@ assert("Regexp - match positions on malformed UTF-8 agree with string indexing")
   assert_equal "a", /a/.match(s, -3)[0]
   assert_nil /a/.match(s, -4)
   assert_equal "a", /a/.match("a\x80b", -3)[0]
+  # Read as bytes the same subject reports byte offsets, which its own
+  # indexing agrees with too.
+  b = "a\x80b".b
+  bm = /b/.match(b)
+  assert_equal 2, bm.begin(0)
+  assert_equal 3, bm.end(0)
+  assert_equal "b", b[bm.begin(0)]
+  assert_equal "b", /b/.match(b, 2)[0]
+  assert_equal "a", /a/.match(b, -3)[0]
+  assert_nil /a/.match(b, -4)
 end
 
 assert("Regexp - a match does not end inside a character") do
@@ -239,10 +257,11 @@ assert("Regexp - a match does not end inside a character") do
   # end of the match and keeps its own answer.
   assert_equal 2, j.match(Regexp.new("(?=\xc4)\xc4\xb5"))[0].bytesize
   # A byte no lead byte reaches is a boundary, so a byte pattern still works.
+  # Such a subject is refused as UTF-8, so it is byte-indexed here.
   b = "\x81"
-  assert_equal 1, (b + b).match(Regexp.new(b))[0].bytesize
-  assert_equal 2, (b + b).match(Regexp.new(b + "+"))[0].bytesize
-  assert_equal 1, ("a" + b).match(Regexp.new(b))[0].bytesize
+  assert_equal 1, (b + b).b.match(Regexp.new(b))[0].bytesize
+  assert_equal 2, (b + b).b.match(Regexp.new(b + "+"))[0].bytesize
+  assert_equal 1, ("a" + b).b.match(Regexp.new(b))[0].bytesize
   # Read as binary every position is a boundary, so nothing changes there.
   if Object.const_defined?(:Encoding)
     bin = j.dup.force_encoding("ASCII-8BIT")
@@ -376,15 +395,19 @@ assert("Regexp - invalid UTF-8 byte near pattern end") do
   # past the end of the pattern buffer
   re = Regexp.new("[   \xff ]")
   assert_kind_of Regexp, re
-  assert_equal 0, (re =~ "\xff")
+  assert_equal 0, (re =~ "\xff".b)
   assert_nil (re =~ "x")
 end
 
 assert("Regexp - truncated UTF-8 at subject end") do
   # a lone multi-byte leader at the end of the subject must not read
-  # past the end of the string buffer when matched against a class
+  # past the end of the string buffer when matched against a class.
+  # Byte-indexed as well, where the engine reads the leader as a byte of its
+  # own and the walk past it is a different one.
   assert_nil ("ab\xf0" =~ /[cd]/)
   assert_equal 0, ("ab\xf0" =~ /[^cd]+$/)
+  assert_nil ("ab\xf0".b =~ /[cd]/)
+  assert_equal 0, ("ab\xf0".b =~ /[^cd]+$/)
 end
 
 assert("Regexp - overlong UTF-8 is not the character it spells") do
@@ -399,8 +422,6 @@ assert("Regexp - overlong UTF-8 is not the character it spells") do
   assert_nil ("\xE0\x80\xBC" =~ /[<]/)
   assert_false Regexp.new("[Ā]").match?("\xE0\x84\x80")
   assert_false (/Ā/.match?("\xE0\x84\x80"))
-  # the pattern side decodes through the same helper
-  assert_false Regexp.new("[\xC0\xBC]").match?("<")
   # surrogates and codepoints above U+10FFFF encode no character either, so
   # each byte stands on its own
   assert_equal 2, "\xC0\xBC".scan(/./).size
@@ -408,6 +429,14 @@ assert("Regexp - overlong UTF-8 is not the character it spells") do
   assert_equal 4, "\xF0\x80\x80\xBC".scan(/./).size
   assert_equal 4, "\xF4\x90\x80\x80".scan(/./).size
   assert_equal 4, "\xF5\x80\x80\x80".scan(/./).size
+  # Byte-indexed the same bytes stand on their own too.
+  assert_equal 2, "\xC0\xBC".b.scan(/./).size
+  assert_equal 3, "\xED\xA0\x80".b.scan(/./).size
+  assert_equal 4, "\xF0\x80\x80\xBC".b.scan(/./).size
+  assert_equal 4, "\xF4\x90\x80\x80".b.scan(/./).size
+  assert_equal 4, "\xF5\x80\x80\x80".b.scan(/./).size
+  # the pattern side decodes through the same helper
+  assert_false Regexp.new("[\xC0\xBC]").match?("<")
   # the shortest spelling on each side of those bounds is still one character
   assert_equal 1, "\u{0080}".scan(/./).size    # C2 80
   assert_equal 1, "\u{0800}".scan(/./).size    # E0 A0 80
@@ -431,19 +460,19 @@ assert("Regexp - a pattern byte that starts no character is a byte in a class") 
   assert_nil (mu =~ Regexp.new("\xB5"))
   assert_equal mu.bytes, mu.gsub(Regexp.new("[\xB5]"), "!").bytes
   assert_equal mu.bytes, mu.gsub(Regexp.new("\xB5"), "!").bytes
-  assert_equal 0, ("\xB5" =~ Regexp.new("[\xB5]"))       # the byte alone is it
+  assert_equal 0, ("\xB5".b =~ Regexp.new("[\xB5]"))     # the byte alone is it
   assert_equal 1, (mu.b =~ Regexp.new("[\xB5]"))         # so is a byte subject
   assert_equal 0, (mu =~ Regexp.new("[^\xB5]"))
   # An escape names a byte too, which is what the literal path emits for it.
   assert_nil (mu =~ Regexp.new("[\\xB5]"))
-  assert_equal 0, ("\xB5" =~ Regexp.new("[\\xB5]"))
+  assert_equal 0, ("\xB5".b =~ Regexp.new("[\\xB5]"))
   # `\u` names a codepoint outright, so it is how the character gets spelled
   # where the byte of the same number will not do.
   assert_equal 0, (mu =~ Regexp.new("[\\u{B5}]"))
-  assert_nil ("\xB5" =~ Regexp.new("[\\u{B5}]"))
+  assert_nil ("\xB5".b =~ Regexp.new("[\\u{B5}]"))
   # An invalid leader is a byte on both sides for the same reason, which is
   # what "overlong UTF-8 is not the character it spells" pins for the class.
-  assert_equal 0, ("\xC0" =~ Regexp.new("[\xC0]"))
+  assert_equal 0, ("\xC0".b =~ Regexp.new("[\xC0]"))
   assert_nil ("À" =~ Regexp.new("[\xC0]"))               # C3 80
   # A byte range is how a continuation byte gets spelled, and it stays a range
   # of bytes: it holds no character of its own.
@@ -456,7 +485,7 @@ assert("Regexp - a pattern byte that starts no character is a byte in a class") 
   assert_raise(RegexpError) { Regexp.new("[µ-\x80]") }
   assert_raise(RegexpError) { Regexp.new("[\\u{B5}-\\xBF]") }
   # ASCII belongs to both, so it pairs with either.
-  assert_equal 0, ("\xFF" =~ Regexp.new("[\x00-\xFF]"))
+  assert_equal 0, ("\xFF".b =~ Regexp.new("[\x00-\xFF]"))
   assert_equal 0, ("µ" =~ Regexp.new("[\x00-\u{FF}]"))
 end
 

--- a/mrbgems/mruby-regexp/test/regexp_utf8.rb
+++ b/mrbgems/mruby-regexp/test/regexp_utf8.rb
@@ -138,8 +138,7 @@ assert("Regexp - quantifier on an invalid multibyte literal") do
   assert_equal 3, (lead3 + cont + cont).b.match(Regexp.new(lead3 + cont + "+"))[0].bytesize
   # A valid character right after an invalid lead byte is still one atom.
   assert_equal 5, (lead2 + "ĀĀ").b.match(Regexp.new(lead2 + "Ā+"))[0].bytesize
-  # The subject side reads the same way: `.` takes the lead byte alone.
-  assert_equal 1, (lead2 + "x").match(/./)[0].bytesize
+  # A whole character is one atom on the subject side too.
   assert_equal 2, "Ā".match(/./)[0].bytesize
 end
 
@@ -163,9 +162,15 @@ assert("Regexp - a byte that belongs to no character is a match position") do
   assert_nil "\u{1D54F}".match(Regexp.new("\x95"))
   # Next to one there is.
   assert_equal 0, (b + "あ").b.match(Regexp.new(b)).begin(0)
-  # Through pre_match, since #begin counts characters where the build has
-  # them and bytes where it does not.
-  assert_equal 3, ("あ" + b).match(Regexp.new(b)).pre_match.bytesize
+  # Which byte is the interior of a character is a question only a UTF-8
+  # subject asks, and one carrying a byte that starts none is refused before
+  # the engine sees it. Byte-indexed, the interior byte of "あ" is a match
+  # position like any other, so the answer would not be the same.
+  if __ENCODING__ == "UTF-8"
+    assert_raise(ArgumentError) { ("あ" + b).match(Regexp.new(b)) }
+  else
+    assert_equal 3, ("あ" + b).match(Regexp.new(b)).pre_match.bytesize
+  end
 end
 
 assert("Regexp - an attempt in flight opens no match position inside a character") do
@@ -182,8 +187,13 @@ assert("Regexp - an attempt in flight opens no match position inside a character
   assert_equal 5, ("あ" + "µ").match(/.?[µ]/)[0].bytesize
   # And so is a byte where no lead byte reaches it, through a class that holds
   # the byte. [µ] holds the character, whose trailing byte alone is not it.
+  # As UTF-8 that subject is refused; byte-indexed it reaches the engine.
   assert_equal 2, ("x" + "\xb5").b.match(Regexp.new(".?[\xb5]"))[0].bytesize
-  assert_nil ("x" + "\xb5").match(/.?[µ]/)
+  if __ENCODING__ == "UTF-8"
+    assert_raise(ArgumentError) { ("x" + "\xb5").match(/.?[µ]/) }
+  else
+    assert_nil ("x" + "\xb5").match(/.?[µ]/)
+  end
 end
 
 assert("Regexp - a byte-indexed subject is reported in bytes") do
@@ -204,33 +214,36 @@ assert("Regexp - a byte-indexed subject is reported in bytes") do
   assert_equal 1, (("x" + u) =~ Regexp.new("\u{1F600}"))
 end
 
-assert("Regexp - match positions on malformed UTF-8 agree with string indexing") do
-  # String indexing counts a byte no lead byte reaches as one character, but
-  # #begin used to count lead bytes only, so a stray continuation byte was
-  # zero width to it. Computing the length marks such a string single-byte
-  # and switches it to byte counting, so the same match reported one
-  # position before the length was known and another after.
+assert("Regexp - a subject whose bytes are not UTF-8 is refused whatever is known about it") do
+  # CRuby refuses a search on a subject like this, so the refusal must not
+  # depend on what mruby happens to know about the string when the search
+  # arrives: the single-byte flag that `#length` leaves behind says one byte
+  # per character, which a string of stray bytes satisfies too, and reading it
+  # would make the same call answer one way before a length was taken and
+  # another after.
   s = "a\x80b"
-  m = /b/.match(s)
-  before = m.begin(0)
-  assert_equal 3, s.length
-  assert_equal before, /b/.match(s).begin(0)
-  assert_equal 2, before
-  assert_equal "b", s[before]
-  assert_equal 3, m.end(0)
-  # A position argument walks the same characters, from either end. The
-  # fresh literal pins the walk on a string whose length is not known yet.
-  assert_equal "b", /b/.match(s, 2)[0]
-  assert_equal "a", /a/.match(s, -3)[0]
-  assert_nil /a/.match(s, -4)
-  assert_equal "a", /a/.match("a\x80b", -3)[0]
-  # Read as bytes the same subject reports byte offsets, which its own
-  # indexing agrees with too.
+  if __ENCODING__ == "UTF-8"
+    assert_raise(ArgumentError) { /b/.match(s) }
+    assert_equal 3, s.length
+    assert_raise(ArgumentError) { /b/.match(s) }
+    assert_raise(ArgumentError) { /b/.match(s, 2) }
+    assert_raise(ArgumentError) { /a/.match("a\x80b", -3) }
+  else
+    # A build with no UTF-8 to read the subject as reports byte positions for
+    # it, which is what the byte-indexed half below asserts either way.
+    assert_equal 2, /b/.match(s).begin(0)
+    assert_equal 3, s.length
+    assert_equal 2, /b/.match(s).begin(0)
+    assert_equal "b", /b/.match(s, 2)[0]
+    assert_equal "a", /a/.match("a\x80b", -3)[0]
+  end
+  # Read as bytes the same subject makes no claim to break, and every position
+  # it reports is a byte offset its own indexing agrees with.
   b = "a\x80b".b
-  bm = /b/.match(b)
-  assert_equal 2, bm.begin(0)
-  assert_equal 3, bm.end(0)
-  assert_equal "b", b[bm.begin(0)]
+  m = /b/.match(b)
+  assert_equal 2, m.begin(0)
+  assert_equal 3, m.end(0)
+  assert_equal "b", b[m.begin(0)]
   assert_equal "b", /b/.match(b, 2)[0]
   assert_equal "a", /a/.match(b, -3)[0]
   assert_nil /a/.match(b, -4)
@@ -402,10 +415,13 @@ end
 assert("Regexp - truncated UTF-8 at subject end") do
   # a lone multi-byte leader at the end of the subject must not read
   # past the end of the string buffer when matched against a class.
-  # Byte-indexed as well, where the engine reads the leader as a byte of its
-  # own and the walk past it is a different one.
-  assert_nil ("ab\xf0" =~ /[cd]/)
-  assert_equal 0, ("ab\xf0" =~ /[^cd]+$/)
+  # As UTF-8 the subject no longer reaches the engine at all, which is the
+  # stronger guard; byte-indexed it does, and must stay inside the buffer.
+  if __ENCODING__ == "UTF-8"
+    assert_raise(ArgumentError) { "ab\xf0" =~ /[cd]/ }
+  else
+    assert_nil ("ab\xf0" =~ /[cd]/)
+  end
   assert_nil ("ab\xf0".b =~ /[cd]/)
   assert_equal 0, ("ab\xf0".b =~ /[^cd]+$/)
 end
@@ -414,22 +430,40 @@ assert("Regexp - overlong UTF-8 is not the character it spells") do
   # C0 BC is the two-byte overlong spelling of "<" and E0 84 80 the three-byte
   # spelling of "Ā". A decoder that hands out a codepoint for these would let a
   # class hold a character the subject does not spell, so assert the class and
-  # the literal together against the same subject.
-  assert_nil ("\xC0\xBC" =~ /[<]/)
-  assert_nil ("\xC0\xBC" =~ /</)
-  assert_equal 0, ("\xC0\xBC" =~ /[^<]/)
-  assert_equal "\xC0\xBC", "\xC0\xBC".gsub(/[<]/, "&lt;")
-  assert_nil ("\xE0\x80\xBC" =~ /[<]/)
-  assert_false Regexp.new("[Ā]").match?("\xE0\x84\x80")
-  assert_false (/Ā/.match?("\xE0\x84\x80"))
-  # surrogates and codepoints above U+10FFFF encode no character either, so
-  # each byte stands on its own
-  assert_equal 2, "\xC0\xBC".scan(/./).size
-  assert_equal 3, "\xED\xA0\x80".scan(/./).size
-  assert_equal 4, "\xF0\x80\x80\xBC".scan(/./).size
-  assert_equal 4, "\xF4\x90\x80\x80".scan(/./).size
-  assert_equal 4, "\xF5\x80\x80\x80".scan(/./).size
-  # Byte-indexed the same bytes stand on their own too.
+  # the literal together against the same subject. RFC 3629 puts these
+  # sequences outside UTF-8, so where strings are read as UTF-8 the subject is
+  # refused before the engine decodes anything. A build without
+  # MRB_UTF8_STRING has no such reading and still runs the match.
+  if __ENCODING__ == "UTF-8"
+    assert_raise(ArgumentError) { "\xC0\xBC" =~ /[<]/ }
+    assert_raise(ArgumentError) { "\xC0\xBC" =~ /</ }
+    assert_raise(ArgumentError) { "\xC0\xBC" =~ /[^<]/ }
+    assert_raise(ArgumentError) { "\xC0\xBC".gsub(/[<]/, "&lt;") }
+    assert_raise(ArgumentError) { "\xE0\x80\xBC" =~ /[<]/ }
+    assert_raise(ArgumentError) { Regexp.new("[Ā]").match?("\xE0\x84\x80") }
+    assert_raise(ArgumentError) { /Ā/.match?("\xE0\x84\x80") }
+    assert_raise(ArgumentError) { "\xC0\xBC".scan(/./) }
+    assert_raise(ArgumentError) { "\xED\xA0\x80".scan(/./) }
+    assert_raise(ArgumentError) { "\xF0\x80\x80\xBC".scan(/./) }
+    assert_raise(ArgumentError) { "\xF4\x90\x80\x80".scan(/./) }
+    assert_raise(ArgumentError) { "\xF5\x80\x80\x80".scan(/./) }
+  else
+    assert_nil ("\xC0\xBC" =~ /[<]/)
+    assert_nil ("\xC0\xBC" =~ /</)
+    assert_equal 0, ("\xC0\xBC" =~ /[^<]/)
+    assert_equal "\xC0\xBC", "\xC0\xBC".gsub(/[<]/, "&lt;")
+    assert_nil ("\xE0\x80\xBC" =~ /[<]/)
+    assert_false Regexp.new("[Ā]").match?("\xE0\x84\x80")
+    assert_false (/Ā/.match?("\xE0\x84\x80"))
+    # surrogates and codepoints above U+10FFFF encode no character either, so
+    # each byte stands on its own
+    assert_equal 2, "\xC0\xBC".scan(/./).size
+    assert_equal 3, "\xED\xA0\x80".scan(/./).size
+    assert_equal 4, "\xF0\x80\x80\xBC".scan(/./).size
+    assert_equal 4, "\xF4\x90\x80\x80".scan(/./).size
+    assert_equal 4, "\xF5\x80\x80\x80".scan(/./).size
+  end
+  # Byte-indexed, each of those bytes stands on its own in either build.
   assert_equal 2, "\xC0\xBC".b.scan(/./).size
   assert_equal 3, "\xED\xA0\x80".b.scan(/./).size
   assert_equal 4, "\xF0\x80\x80\xBC".b.scan(/./).size
@@ -531,4 +565,64 @@ assert("Regexp - large non-ASCII character class does not overflow") do
   assert_equal 0, (re =~ utf8.call(0x8080))
   assert_nil (re =~ utf8.call(0x8081))
   assert_nil (re =~ "A")
+end
+
+assert("Regexp - a subject whose bytes are not UTF-8 is refused") do
+  # CRuby raises ArgumentError with this message for a subject holding a byte
+  # that stands for no character, and mruby answered for it, so a program
+  # moved from one to the other got a result CRuby would not have produced.
+  skip unless __ENCODING__ == "UTF-8"
+  broken = "あ\x80b"     # "あ" followed by a lone continuation byte
+
+  assert_raise(ArgumentError) { broken =~ /b/ }
+  assert_raise(ArgumentError) { /b/ =~ broken }
+  assert_raise(ArgumentError) { /b/.match(broken) }
+  assert_raise(ArgumentError) { /b/.match?(broken) }
+  assert_raise(ArgumentError) { /b/ === broken }
+  assert_raise(ArgumentError) { broken.match(/b/) }
+  assert_raise(ArgumentError) { broken.match?(/b/) }
+  assert_raise(ArgumentError) { broken.index(/b/) }
+  assert_raise(ArgumentError) { broken.rindex(/b/) }
+  assert_raise(ArgumentError) { broken.byteindex(/b/) }
+  assert_raise(ArgumentError) { broken.byterindex(/b/) }
+  assert_raise(ArgumentError) { broken[/b/] }
+  assert_raise(ArgumentError) { broken.sub(/b/, "!") }
+  assert_raise(ArgumentError) { broken.sub(/b/) { "!" } }
+  assert_raise(ArgumentError) { broken.gsub(/b/, "!") }
+  assert_raise(ArgumentError) { broken.gsub(/b/) { "!" } }
+  assert_raise(ArgumentError) { broken.scan(/b/) }
+  assert_raise(ArgumentError) { broken.split(/b/) }
+  assert_raise(ArgumentError) { broken.partition(/b/) }
+  assert_raise(ArgumentError) { broken.rpartition(/b/) }
+  assert_raise(ArgumentError) { broken.start_with?(/b/) }
+  assert_raise(ArgumentError) { broken.dup.slice!(/b/) }
+  assert_raise(ArgumentError) { broken.dup[/b/] = "!" }
+
+  # A String pattern is a literal, which CRuby searches for byte by byte
+  # without reading the subject as UTF-8, so these answer there and here.
+  # `scan` is the exception CRuby itself makes: it refuses a literal too.
+  assert_equal "あ\x80!", broken.sub("b", "!")
+  assert_equal "あ\x80!", broken.gsub("b", "!")
+  assert_equal "あ\x80!", broken.sub("b") { "!" }
+  assert_equal "あ\x80!", broken.gsub("b") { "!" }
+  bang = broken.dup
+  bang.sub!("b", "!")
+  assert_equal "あ\x80!", bang
+  bang = broken.dup
+  bang.gsub!("b", "!")
+  assert_equal "あ\x80!", bang
+  # The position it publishes is the one the string's own indexing answers.
+  broken.sub("b", "!")
+  assert_equal broken.index("b"), $~.begin(0)
+  assert_raise(ArgumentError) { broken.scan("b") }
+
+  # A byte-indexed subject is indexed by byte throughout, so its bytes make
+  # no claim that could be broken and it goes through as it always did.
+  assert_equal 4, (broken.b =~ /b/)
+  assert_equal 4, broken.b.match(/b/).begin(0)
+  assert_equal "あ\x80!".b, broken.b.sub(/b/, "!")
+
+  # A whole subject is untouched, including one the scan reads to the end.
+  assert_equal 2, ("あいb" =~ /b/)
+  assert_equal 1, ("a\u{10FFFF}b" =~ /b\z|\u{10FFFF}/)
 end


### PR DESCRIPTION
CRuby raises `ArgumentError` when a search is given a subject holding a byte
that spells no character. mruby answered for it, so the same program took a
result CRuby would not have produced:

```ruby
"あ\x80b" =~ /b/         # CRuby: ArgumentError, mruby: 2
"あ\x80b".scan(/./)      # CRuby: ArgumentError, mruby: ["あ", "\x80", "b"]
"\xC0\xBC" =~ /[^<]/     # CRuby: ArgumentError, mruby: 0
```

Refuse the search instead, for `=~`, `match`, `match?`, `===`, `index`,
`rindex`, `byteindex`, `byterindex`, `[]`, `[]=`, `sub`, `gsub`, `scan`,
`split`, `partition`, `rpartition`, `start_with?` and `slice!`. `String#scrub` is how a
subject like this becomes matchable.

### Two commits

The first moves the tests that ask what the engine does with a byte standing
for no character onto a byte-indexed subject. What each of them pins belongs to
the pattern, and a byte-indexed subject puts the same question to the engine,
so they keep asking it after the second commit refuses the UTF-8 subject they
used to go through. That commit changes no behavior and is green on its own.

The second is the refusal itself, which leaves it holding the check, the tests
whose answer it changes, and nothing else.

### What goes through untouched

A binary string is indexed by byte from end to end, so its bytes make no claim
that could be broken.

A quoted String pattern is exempt on the grounds CRuby exempts it: a literal is
searched for byte by byte, and the subject is read as UTF-8 nowhere along the
way.

```ruby
"あ\x80b".sub("b", "!")  #=> "あ\x80!" in both, where /b/ is refused in both
"あ\x80b".scan("b")      # ArgumentError in both: `scan` refuses a literal too
```

`sub`, `sub!`, `gsub` and `gsub!` quote a String pattern into a `Regexp` before
they search, so each carries the fact that it was a literal down to the search
rather than letting the quoting hide it.

A string derived from a binary one does not carry `MRB_STR_BINARY` with it, so
`b + ""` and `b.sub(...)` are refused where `b` itself is not. That gap predates
this change and is left as it is.

### Where the check runs

`re_check_encoding()` walks the whole subject, so it runs once per search a
method makes rather than once per match it finds.

The entry points that take a subject from Ruby check it themselves:
`Regexp#match`, `#=~`, `#===`, `#match?`, and the class methods `__search`,
`__search_p`, `__sub_str`, `__gsub_str` and `__scan`, the last three of which
loop in C over a subject already checked.

The two entry points an mrblib loop drives leave the check to that loop, which
runs it once on the subject it holds fixed. `Regexp.__check_encoding` at the top
of `gsub` with a block, of `split` and of `byteindex` covers their
`__byte_search` calls, and `__regexp_rsearch`, which backs `rindex`,
`byterindex` and `rpartition`, runs it and passes the flag that says so to
`__search`.

Checking inside those loops instead walks the subject once per match, which is
quadratic in the number of matches: `("あ," * 20000).split(/,/)` took 8 times as
long that way.

### Cost

What remains is one walk per search, which a whole subject pays as well. The
flag `String#length` leaves behind cannot stand in for the walk, since a string
of stray bytes has one byte per character too, so a subject searched twice is
walked twice.

The walk skips a run of ASCII a word at a time and decodes only where a byte
leaves that range, so the cost follows how much of the subject is multi-byte.
Measured at `-O3` on a full-core build, three runs each:

| | before | after |
|---|---|---|
| `("あ" * 100000 + "z") =~ /z/`, 200 times | 62 ms | 117 ms |
| the same over an ASCII subject of the same size | 11.8 ms | 12.0 ms |
| `"hello world" =~ /world/`, 100000 times | 139 ms | 140 ms |

### One known difference

An out of range positive `pos` still answers nil rather than raising, since
`re_char_to_byte()` rejects it before the check runs. CRuby raises there for
`Regexp#match`; for `index`, `rindex` and `byteindex` it answers nil as this
does.

### Tests

What a match position inside a whole character is remains pinned on subjects
that are whole UTF-8. A build without `MRB_UTF8_STRING` reads no encoding for
the bytes to break, so the cases that turn on one answer positions there and
branch on `__ENCODING__`.

The engine reads a byte-indexed subject through a branch of its own, so the
tests the first commit moved stop covering the UTF-8 one. `Regexp - truncated
UTF-8 at subject end` is the case where that mattered: it was a fuzz-derived
regression test for a read past the end of the string buffer, and the code path
it covered is no longer reachable from Ruby under this rule.

### Verified

- `rake test` on a full-core build (`MRB_UTF8_STRING` through mruby-encoding):
  2246 tests at the first commit and 2247 at the second, all green
- `rake test` on the default gembox (no `MRB_UTF8_STRING`): 2057 and 2058 tests,
  all green
- 30 String-argument methods compared against CRuby 4.0.6 on a broken subject.
  The two remaining differences are `split("b")`, which CRuby refuses and the
  aliased C `__split` still answers, and `slice!("b")`, which is wrong on whole
  UTF-8 too and is not this change
- `prek run --all-files` passes, except that `markdownlint` could not install
  locally (npm engine mismatch); no Markdown is touched here


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved UTF-8 validation across regular expression search, matching, splitting, scanning, and substitution operations.
  - Invalid UTF-8 subjects now raise `ArgumentError` consistently in UTF-8 builds.
  - Preserved byte-oriented behavior for literal string operations and binary data.
  - Improved handling of malformed, truncated, and overlong UTF-8 sequences, including character-class matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
