### PR TITLE
mruby-sprintf: reject a `%c` argument with no UTF-8 encoding

### DIFF
--- a/mrbgems/mruby-sprintf/src/sprintf.c
+++ b/mrbgems/mruby-sprintf/src/sprintf.c
@@ -536,8 +536,13 @@ retry:
             /* Integer: encode directly to stack buffer (no allocation) */
             mrb_int code = mrb_integer(val);
 #ifdef MRB_UTF8_STRING
+            /* mrb_utf8_to_buf() writes nothing for a value it cannot encode,
+               and takes a uint32_t, which wraps a value outside the Unicode
+               range into a codepoint. Either way there is no byte to write. */
+            if (code < 0 || 0x10FFFF < code) {
+              mrb_raise(mrb, E_ARGUMENT_ERROR, "invalid character");
+            }
             clen = (int)mrb_utf8_to_buf(cbuf, (uint32_t)code);
-            if (clen == 0) clen = 1;  /* invalid codepoint: write single byte */
 #else
             cbuf[0] = (char)(code & 0xff);
             clen = 1;

--- a/mrbgems/mruby-sprintf/test/sprintf.rb
+++ b/mrbgems/mruby-sprintf/test/sprintf.rb
@@ -130,3 +130,18 @@ assert("sprintf with to_s mutating format string") do
   assert_equal "ok", result[0, 2]
   assert_equal "B" * 200, result[2..]
 end
+
+assert('sprintf("%c") with an integer that has no UTF-8 encoding') do
+  skip unless __ENCODING__ == "UTF-8"
+  # Nothing was written to the encoder's buffer for these, and %c used to emit
+  # whatever byte the stack happened to hold there.
+  assert_raise(ArgumentError) { sprintf("%c", 0x110000) }
+  assert_raise(ArgumentError) { sprintf("%c", -1) }
+  # The encoder takes a uint32_t, so a value that wraps into the Unicode range
+  # must not come out as the character it wraps to. The shift is computed at
+  # run time because the constant folder would reject the literal on a build
+  # with a 32-bit mrb_int and no bigint, where there is nothing to test.
+  shift = 32
+  wrapping = ((1 << shift) + 0x41) rescue nil
+  assert_raise(ArgumentError) { sprintf("%c", wrapping) } if wrapping.is_a?(Integer)
+end


### PR DESCRIPTION
`sprintf("%c", cp)` wrote an uninitialized stack byte for any integer
`mrb_utf8_to_buf()` cannot encode.

The encoder leaves its buffer untouched and returns 0 for a codepoint above
U+10FFFF. `%c` read that 0 as "invalid codepoint: write single byte" and
pushed `cbuf[0]`, which nothing had written:

```c
clen = (int)mrb_utf8_to_buf(cbuf, (uint32_t)code);
if (clen == 0) clen = 1;  /* invalid codepoint: write single byte */
```

On a `MRB_UTF8_STRING` build the emitted byte tracks whatever was on the
stack, so it changes with the surrounding format string:

```ruby
sprintf("%c", 0x110000).bytes              #=> [64]
sprintf("hello world %c", 0x110000).bytes  #=> [..., 200]
sprintf("%c", -1).bytes                    #=> [200]
```

A negative argument reaches the same path, since `mrb_int` is cast to
`uint32_t` and `-1` becomes 0xFFFFFFFF.

CRuby raises for both:

```ruby
sprintf("%c", 0x110000)  # ArgumentError: invalid character
sprintf("%c", -1)        # ArgumentError: invalid character
```

## Fix

Check the range before calling the encoder and raise the same
`ArgumentError` CRuby raises. The check has to come first rather than
testing the return value, because the cast to `uint32_t` wraps an
out-of-range value into a valid codepoint: `(1 << 32) + 0x41` would
otherwise print as `A`. With the range checked, `mrb_utf8_to_buf()` can no
longer return 0.

This matches `int_chr_utf8()` in mruby-string-ext, which likewise rejects
the value before calling the shared encoder.

## Scope

Surrogates are left alone. `mrb_utf8_to_buf()` encodes U+D800 to U+DFFF
while `mrb_utf8len()` rejects the resulting bytes, but CRuby has the same
asymmetry and produces the same output, so `%c` keeps matching it:

```ruby
sprintf("%c", 0xD800).bytes            #=> [237, 160, 128]
sprintf("%c", 0xD800).valid_encoding?  #=> false
```

The other callers of `mrb_utf8_to_buf()` are already safe: `pack_utf8()`
raises `RangeError` when the encoder answers 0, and `int_chr_utf8()` and
`check_unicode_cp()` reject the value beforehand.

Builds without `MRB_UTF8_STRING` are untouched: `%c` still takes the low
byte of the argument.

## Tests

A new case in `mrbgems/mruby-sprintf/test/sprintf.rb` covers the U+10FFFF,
negative, and wrapping arguments, skipped on builds that are not UTF-8. The
shift for the wrapping argument is computed at run time rather than written as
a literal, because on a build with a 32 bit `mrb_int` and no bigint the
constant folder rejects `1 << 32` while the file is being compiled and the
whole test file is dropped without a word. On such a build the value cannot be
constructed at all, so the assertion is skipped.

Suites pass:

* full-core with `MRB_UTF8_STRING`: 2250 tests, 0 failures
* default build: 2059 tests plus 105 bintests, 0 failures
* `MRB_INT32` without bigint: 1504 tests, 0 failures. With the literal form it
  is 1493, the difference being every mruby-sprintf test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UTF-8 character formatting to reject negative values and values outside the valid Unicode range.
  * Invalid character values now raise `ArgumentError` instead of producing unintended characters.

* **Tests**
  * Added regression coverage for invalid and overflowing character values in `sprintf`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->