### PR TITLE
mruby-regexp: ask the malformed sequence cases of a byte-indexed subject too

### DIFF
--- a/mrbgems/mruby-regexp/test/regexp_utf8.rb
+++ b/mrbgems/mruby-regexp/test/regexp_utf8.rb
@@ -378,6 +378,9 @@ assert("Regexp - invalid UTF-8 byte near pattern end") do
   assert_kind_of Regexp, re
   assert_equal 0, (re =~ "\xff")
   assert_nil (re =~ "x")
+  # The byte reaches the class the same way from a byte-indexed subject, which
+  # the engine walks through a branch of its own.
+  assert_equal 0, (re =~ "\xff".b)
 end
 
 assert("Regexp - truncated UTF-8 at subject end") do
@@ -385,6 +388,10 @@ assert("Regexp - truncated UTF-8 at subject end") do
   # past the end of the string buffer when matched against a class
   assert_nil ("ab\xf0" =~ /[cd]/)
   assert_equal 0, ("ab\xf0" =~ /[^cd]+$/)
+  # Byte-indexed the leader is a byte of its own, so the walk that reaches the
+  # end of the buffer is a different one and must stay inside it too.
+  assert_nil ("ab\xf0".b =~ /[cd]/)
+  assert_equal 0, ("ab\xf0".b =~ /[^cd]+$/)
 end
 
 assert("Regexp - overlong UTF-8 is not the character it spells") do
@@ -417,6 +424,21 @@ assert("Regexp - overlong UTF-8 is not the character it spells") do
   assert_equal 1, "\u{10FFFF}".scan(/./).size  # F4 8F BF BF
   assert_equal 0, ("\u{0800}" =~ Regexp.new("[\u{0800}]"))
   assert_equal 0, ("\u{10FFFF}" =~ Regexp.new("[\u{10FFFF}]"))
+  # None of this turns on how the subject is indexed: a byte-indexed one is
+  # decoded a byte at a time, so an overlong sequence is no more the character
+  # it spells there, and the answers are the same through that branch.
+  assert_nil ("\xC0\xBC".b =~ /[<]/)
+  assert_nil ("\xC0\xBC".b =~ /</)
+  assert_equal 0, ("\xC0\xBC".b =~ /[^<]/)
+  assert_equal "\xC0\xBC".b, "\xC0\xBC".b.gsub(/[<]/, "&lt;")
+  assert_nil ("\xE0\x80\xBC".b =~ /[<]/)
+  assert_false Regexp.new("[Ā]").match?("\xE0\x84\x80".b)
+  assert_false (/Ā/.match?("\xE0\x84\x80".b))
+  assert_equal 2, "\xC0\xBC".b.scan(/./).size
+  assert_equal 3, "\xED\xA0\x80".b.scan(/./).size
+  assert_equal 4, "\xF0\x80\x80\xBC".b.scan(/./).size
+  assert_equal 4, "\xF4\x90\x80\x80".b.scan(/./).size
+  assert_equal 4, "\xF5\x80\x80\x80".b.scan(/./).size
 end
 
 assert("Regexp - a pattern byte that starts no character is a byte in a class") do


### PR DESCRIPTION
Split out of #7110, which asked for one review of a behaviour change and a
large test rewrite at once. This is the second of four pieces, independent of
the first, and changes no behaviour.

Three cases turn on what a malformed sequence is rather than on how the subject
is indexed:

- whether an overlong sequence, a surrogate or a codepoint above U+10FFFF is the
  character it spells
- whether a lone leader at the end of the subject sends the walk past the string
  buffer
- whether a truncated leader in a character class sends it past the pattern
  buffer

Each is asked through a UTF-8 subject only.

### Why that is a different question to ask

The engine reads a byte-indexed subject through a branch of its own:
`mrb_re_charlen()` and `mrb_re_decode_char()` take a flag for one and hand back a
byte at a time. So the walk that must stay inside the buffer at the end of
`"ab\xf0"` is a different walk there, and the decode that must not turn `C0 BC`
into `<` is a different decode. The last two cases came from fuzzing, so the
walk is worth pinning on both sides.

### What this does

Asks each of them on that side as well, next to the case it answers.

### Verified

- `rake test` on a full-core build (`MRB_UTF8_STRING` through mruby-encoding):
  2249 tests, all green
- `rake test` on the default gembox (no `MRB_UTF8_STRING`): 2058 tests, all
  green
- `prek run --all-files` passes, except that `markdownlint` could not install
  locally (npm engine mismatch); no Markdown is touched here


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved regular expression handling for truncated or invalid UTF-8 sequences.
  * Ensured consistent behavior across byte-indexed and character-indexed text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->