### PR TITLE
test: build wide shifts from a variable so the file still compiles

### DIFF
--- a/mrbgems/mruby-random/test/random.rb
+++ b/mrbgems/mruby-random/test/random.rb
@@ -170,7 +170,11 @@ assert("Kernel#rand integer range overflow") do
   # minimized mruby_fuzzer testcase. On 32-bit mrb_int (or when bigint
   # promotes the bounds) these take a different path, so probe the
   # integer-range path first and skip if absent.
-  hi = ((1 << 62) + (1 << 61)) rescue nil
+  # The shift width comes from a variable because `1 << 62` written out is
+  # constant folded, and the fold fails while this file is compiled on
+  # MRB_INT32 without bigint, dropping every test in it.
+  shift = 62
+  hi = ((1 << shift) + (1 << (shift - 1))) rescue nil
   if hi && (Integer === (rand(-hi..hi) rescue nil))
     lo = -hi
     # reversed wide range -> nil; old code overflowed `end - begin`.

--- a/mrbgems/mruby-random/test/random.rb
+++ b/mrbgems/mruby-random/test/random.rb
@@ -168,14 +168,24 @@ assert("Kernel#rand integer range overflow") do
   # 64-bit mrb_int builds. Such bounds used to overflow `end - begin` in C
   # (UndefinedBehaviorSanitizer signed-integer-overflow), found via a
   # minimized mruby_fuzzer testcase. On 32-bit mrb_int (or when bigint
-  # promotes the bounds) these take a different path, so probe the
-  # integer-range path first and skip if absent.
+  # promotes the bounds) these take a different path, so probe for the bounds
+  # themselves and skip where they are out of reach. The probe asks what the
+  # bounds are rather than what `rand` returns for them: the regression answers
+  # `nil` for the wide range too, so a `rand` guard would read that as "path
+  # absent" and skip the assertions written to catch it.
   # The shift width comes from a variable because `1 << 62` written out is
   # constant folded, and the fold fails while this file is compiled on
   # MRB_INT32 without bigint, dropping every test in it.
   shift = 62
-  hi = ((1 << shift) + (1 << (shift - 1))) rescue nil
-  if hi && (Integer === (rand(-hi..hi) rescue nil))
+  hi = nil
+  wide = begin
+    hi = (1 << shift) + (1 << (shift - 1))  # RangeError where mrb_int is 32 bits and bigint is absent
+    [][hi]                                  # nil for an mrb_int index, RangeError for a big integer
+    true
+  rescue RangeError
+    false
+  end
+  if wide
     lo = -hi
     # reversed wide range -> nil; old code overflowed `end - begin`.
     assert_nil(rand(hi..lo))

--- a/mrbgems/mruby-socket/test/addrinfo.rb
+++ b/mrbgems/mruby-socket/test/addrinfo.rb
@@ -25,8 +25,18 @@ assert('Addrinfo.getaddrinfo rejects out-of-range integer hints') do
   # constant folded, and the fold fails while this file is compiled on
   # MRB_INT32 without bigint, dropping every test in it.
   shift = 40
-  big = (1 << shift) rescue nil
-  skip "needs 64-bit mrb_int" unless big.kind_of?(Integer)
+  big = nil
+  wide = begin
+    big = 1 << shift  # RangeError where mrb_int is 32 bits and bigint is absent
+    [][big]           # nil for an mrb_int index, RangeError for a big integer
+    true
+  rescue RangeError
+    false
+  end
+  # A big integer is not an mrb_int either: the hints keep their unconverted
+  # type, `Addrinfo.getaddrinfo` leaves the field at its default, and the
+  # narrowing under test never runs.
+  skip "needs 64-bit mrb_int" unless wide
   assert_raise(RangeError) { Addrinfo.getaddrinfo("localhost", nil, big) }
   assert_raise(RangeError) { Addrinfo.getaddrinfo("localhost", nil, nil, nil, nil, big) }
 end

--- a/mrbgems/mruby-socket/test/addrinfo.rb
+++ b/mrbgems/mruby-socket/test/addrinfo.rb
@@ -21,9 +21,14 @@ end
 assert('Addrinfo.getaddrinfo rejects out-of-range integer hints') do
   # a 64-bit mrb_int that does not fit C int must raise, not be silently
   # truncated into a different but still-valid-looking hint (#6960)
-  skip "needs 64-bit mrb_int" unless (1 << 40).kind_of?(Integer)
-  assert_raise(RangeError) { Addrinfo.getaddrinfo("localhost", nil, 1 << 40) }
-  assert_raise(RangeError) { Addrinfo.getaddrinfo("localhost", nil, nil, nil, nil, 1 << 40) }
+  # The shift width comes from a variable because `1 << 40` written out is
+  # constant folded, and the fold fails while this file is compiled on
+  # MRB_INT32 without bigint, dropping every test in it.
+  shift = 40
+  big = (1 << shift) rescue nil
+  skip "needs 64-bit mrb_int" unless big.kind_of?(Integer)
+  assert_raise(RangeError) { Addrinfo.getaddrinfo("localhost", nil, big) }
+  assert_raise(RangeError) { Addrinfo.getaddrinfo("localhost", nil, nil, nil, nil, big) }
 end
 
 assert('Addrinfo.foreach') do

--- a/test/t/string.rb
+++ b/test/t/string.rb
@@ -1088,7 +1088,11 @@ assert('String#bytesplice') do
 
   # check the overflow to index and length (to be pass without crash)
   assert_nothing_raised { "0123456789".bytesplice(8, ~(-1 << 31), "ab") } # for MRB_INT32
-  assert_nothing_raised { begin; "0123456789".bytesplice(8, ~(-1 << 63), "ab"); rescue ArgumentError, RangeError; end } # for MRB_INT64
+  # The shift width comes from a variable because `1 << 63` written out is
+  # constant folded, and the fold fails while this file is compiled on
+  # MRB_INT32 without bigint, dropping every test in it.
+  shift = 63
+  assert_nothing_raised { begin; "0123456789".bytesplice(8, ~(-1 << shift), "ab"); rescue ArgumentError, RangeError; end } # for MRB_INT64
 
   # check the negative index
   assert_equal "0ab3456789", "0123456789".bytesplice(-9, 2, "ab")


### PR DESCRIPTION
Three test files stop running entirely on a build with a 32 bit `mrb_int` and
no bigint, and nothing says so.

An integer literal that does not fit `mrb_int` is rejected while the file is
compiled, so a wide shift written out in full takes its whole file down with
it. The tests are not skipped and not failed. They are absent, and the suite
reports success with fewer tests than it had.

Counted with `MRB_INT32` and no bigint, before and after this change:

| file | literal | tests lost |
| --- | --- | --- |
| `test/t/string.rb` | `~(-1 << 63)` | 71 |
| `mrbgems/mruby-random/test/random.rb` | `1 << 62` | 13 |
| `mrbgems/mruby-socket/test/addrinfo.rb` | `1 << 40` | 10 |

Total 1503 tests before, 1732 after, on a build carrying all three gems.

Every one of these lines was already written to cope with a narrow `mrb_int`:

```ruby
# test/t/string.rb
assert_nothing_raised { begin; "0123456789".bytesplice(8, ~(-1 << 63), "ab"); rescue ArgumentError, RangeError; end }

# mrbgems/mruby-random/test/random.rb
hi = ((1 << 62) + (1 << 61)) rescue nil

# mrbgems/mruby-socket/test/addrinfo.rb
skip "needs 64-bit mrb_int" unless (1 << 40).kind_of?(Integer)
```

None of those guards ever ran, because nothing in the file was running yet
when the value was rejected.

## Fix

Take the shift width from a variable. The shift becomes a run time operation
that raises `RangeError` where `mrb_int` is too narrow, which is exactly what
the `rescue` and the `skip` beside it were written for. On a build where the
value fits, the tests run as before.

## Note

This is why CI has not caught it: the `MRB_INT32` builds that would show the
missing tests are not part of the matrix, and a build that only counts
successes cannot tell a passing file from an absent one.

The same pattern in test additions of mine is fixed in #7113 and #7114.

## Tests

* `MRB_INT32` without bigint (stdlib, stdlib-ext, mruby-pack, mruby-sprintf,
  mruby-socket, mruby-io): 1732 tests, 0 failures, against 1503 before
* default build: 2058 tests plus 105 bintests, 0 failures
* full-core with `MRB_UTF8_STRING`: 2249 tests, 0 failures


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved portability of integer-range and string overflow tests on 32-bit environments.
  * Updated networking address-info tests to run only when the runtime supports the required integer width.
  * Preserved existing validation for range and argument errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->