### PR TITLE
mruby-socket: reject a big integer getaddrinfo hint instead of ignoring it

### DIFF
--- a/mrbgems/mruby-socket/src/socket.c
+++ b/mrbgems/mruby-socket/src/socket.c
@@ -186,13 +186,18 @@ free_addrinfo(mrb_state *mrb, mrb_value addrinfo)
  *   Addrinfo.getaddrinfo("www.example.com", 80, Socket::AF_INET)
  */
 static int
-getaddrinfo_hint(mrb_state *mrb, mrb_int v, const char *name)
+getaddrinfo_hint(mrb_state *mrb, mrb_value val, const char *name)
 {
   /* getaddrinfo() hint fields are C int; reject values that would not
-     survive the narrowing rather than silently truncating them (#6960). */
+     survive the narrowing rather than silently truncating them (#6960).
+     A big integer outgrows mrb_int itself, so it never fits a C int either. */
+  if (mrb_bigint_p(val)) {
+    mrb_raisef(mrb, E_RANGE_ERROR, "getaddrinfo %s out of range: %v", name, val);
+  }
+  mrb_int v = mrb_integer(val);
 #if MRB_INT_MAX > INT_MAX
   if (v < INT_MIN || v > INT_MAX) {
-    mrb_raisef(mrb, E_RANGE_ERROR, "getaddrinfo %s out of range: %i", name, v);
+    mrb_raisef(mrb, E_RANGE_ERROR, "getaddrinfo %s out of range: %v", name, val);
   }
 #endif
   return (int)v;
@@ -223,18 +228,21 @@ mrb_addrinfo_getaddrinfo(mrb_state *mrb, mrb_value klass)
     mrb_raise(mrb, E_TYPE_ERROR, "service must be String, Integer, or nil");
   }
 
-  hints.ai_flags = getaddrinfo_hint(mrb, flags, "flags");
+  hints.ai_flags = getaddrinfo_hint(mrb, mrb_int_value(mrb, flags), "flags");
 
-  if (mrb_integer_p(family)) {
-    hints.ai_family = getaddrinfo_hint(mrb, mrb_integer(family), "family");
+  /* an out of range hint reaches here as a big integer wherever bigint is
+     built in, and `mrb_integer_p` alone would leave the field at its default
+     rather than report the value as out of range */
+  if (mrb_integer_p(family) || mrb_bigint_p(family)) {
+    hints.ai_family = getaddrinfo_hint(mrb, family, "family");
   }
 
-  if (mrb_integer_p(socktype)) {
-    hints.ai_socktype = getaddrinfo_hint(mrb, mrb_integer(socktype), "socktype");
+  if (mrb_integer_p(socktype) || mrb_bigint_p(socktype)) {
+    hints.ai_socktype = getaddrinfo_hint(mrb, socktype, "socktype");
   }
 
-  if (mrb_integer_p(protocol)) {
-    hints.ai_protocol = getaddrinfo_hint(mrb, mrb_integer(protocol), "protocol");
+  if (mrb_integer_p(protocol) || mrb_bigint_p(protocol)) {
+    hints.ai_protocol = getaddrinfo_hint(mrb, protocol, "protocol");
   }
 
   int error = getaddrinfo(hostname, servname, &hints, &addr);

--- a/mrbgems/mruby-socket/test/addrinfo.rb
+++ b/mrbgems/mruby-socket/test/addrinfo.rb
@@ -26,6 +26,25 @@ assert('Addrinfo.getaddrinfo rejects out-of-range integer hints') do
   assert_raise(RangeError) { Addrinfo.getaddrinfo("localhost", nil, nil, nil, nil, 1 << 40) }
 end
 
+assert('Addrinfo.getaddrinfo rejects a big integer hint') do
+  # a hint too wide for mrb_int arrives as a big integer, which used to miss
+  # the `mrb_integer_p` check and leave the field at its default: the caller
+  # asked for something unrepresentable and got an unhinted lookup instead
+  # The shift width comes from a variable because a literal wide shift is
+  # constant folded, and the fold fails where bigint is absent, dropping every
+  # test in this file.
+  shift = 70
+  big = begin
+    1 << shift
+  rescue RangeError
+    nil
+  end
+  skip "needs mruby-bigint" unless big
+  assert_raise(RangeError) { Addrinfo.getaddrinfo("localhost", nil, big) }
+  assert_raise(RangeError) { Addrinfo.getaddrinfo("localhost", nil, nil, big) }
+  assert_raise(RangeError) { Addrinfo.getaddrinfo("localhost", nil, nil, nil, big) }
+end
+
 assert('Addrinfo.foreach') do
   skip "localhost resolution unreliable in Windows getaddrinfo" if SocketTest.win?
   # assume Addrinfo.getaddrinfo works well


### PR DESCRIPTION
`Addrinfo.getaddrinfo` converts its `family`, `socktype` and `protocol` hints only under `mrb_integer_p`, which asks about representation rather than class. Where `mruby-bigint` is built in, a hint too wide for `mrb_int` arrives as `MRB_TT_BIGINT`, the conversion is skipped, and the field keeps the default from `struct addrinfo hints = {0}`. The caller asked for something unrepresentable and got an unhinted lookup back.

That inverts the narrowing check added in #6960: a value that fits `mrb_int` but not C `int` raises, while a larger one passes silently. On the default 64 bit build, which carries bigint:

```ruby
Addrinfo.getaddrinfo("localhost", nil, 2 ** 40)  # RangeError: getaddrinfo family out of range: 1099511627776
Addrinfo.getaddrinfo("localhost", nil, 2 ** 70)  # same results as no hint at all, afamily 2
```

It is not specific to `MRB_INT32`; any build carrying `mruby-bigint` has it, and `MRB_INT32` only lowers the threshold to `2 ** 32`.

## Change

`getaddrinfo_hint` now takes the `mrb_value` and rejects a big integer before reading it, so an out of range hint is reported the same way whatever its representation. The three call sites test `mrb_integer_p(v) || mrb_bigint_p(v)`. `mrb_bigint_p` is `FALSE` without `MRB_USE_BIGINT`, so a build without bigint compiles to what it had before.

`flags` is unaffected, because `mrb_get_args` already raises `RangeError` for a big integer passed to its `i` specifier. It moves to the new signature only to keep one entry point.

Values of other classes are still ignored rather than rejected, as before; narrowing that is a separate question from this one.

## Test

The new assertion fails on master (`KO: 1`) and passes with the change. Its shift width comes from a variable because a literal wide shift is constant folded, and the fold fails where bigint is absent.

| build | tests | result |
| --- | --- | --- |
| default host, 64 bit with bigint | 2059 | `KO: 0`, new test runs |
| `MRB_INT32` with bigint | 2136 | `KO: 0`, file not loaded |
| `MRB_INT32` without bigint, `mruby-socket` added | 1774 | `KO: 0`, file not loaded |

The two `MRB_INT32` builds do not reach this file: the literal `1 << 40` in the assertion above the new one folds to a value the 32 bit VM cannot load, so the whole file is dropped without a failure. That is the subject of #7117, and it is left alone here so the two changes do not touch the same lines. Applying that fix locally on top of this branch gives 2147 (`KO: 0`, new test runs and passes) with bigint and 1785 (`KO: 0`, new test skips) without it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of address resolution hints, including large integer values.
  * Values outside the supported range now raise a clear `RangeError` instead of being processed incorrectly.
  * Applied consistent validation across address family, socket type, protocol, and flags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->