### PR TITLE
mruby-regexp: refuse a subject whose bytes are not UTF-8 in the C searches

### DIFF
--- a/mrbgems/mruby-regexp/mrblib/string_regexp.rb
+++ b/mrbgems/mruby-regexp/mrblib/string_regexp.rb
@@ -115,12 +115,17 @@ class String
     # get_pat.  Only the quoting is taken from it: get_pat_quoted also accepts
     # anything answering `to_str`, where `__check_pattern` keeps to a real
     # String, as `match` already does.
-    pattern = Regexp.new(Regexp.escape(pattern)) if String === pattern
+    literal = String === pattern
+    # CRuby searches for a literal byte by byte and never reads the subject as
+    # UTF-8 on the way, so quoting one into a Regexp here must not put the
+    # subject through a check CRuby does not make: `"a\x80b".sub("b", "!")`
+    # answers there, where the same call with `/b/` is refused.
+    pattern = Regexp.new(Regexp.escape(pattern)) if literal
     # A replacement argument wins over the block, as in CRuby.
     if args.length == 2
-      return Regexp.__sub_str(pattern, self, replacement.to_s)
+      return Regexp.__sub_str(pattern, self, replacement.to_s, literal)
     end
-    md = Regexp.__search(pattern, self)
+    md = Regexp.__search(pattern, self, 0, literal)
     return self.dup unless md
     md.pre_match + block.call(md[0]).to_s + md.post_match
   end
@@ -141,19 +146,23 @@ class String
     # Resolved here rather than left to `sub` because the match below decides
     # the return value, and a String pattern is a literal on both paths.
     pattern = Regexp.__check_pattern(args[0])
-    pattern = Regexp.new(Regexp.escape(pattern)) if String === pattern
+    literal = String === pattern
+    pattern = Regexp.new(Regexp.escape(pattern)) if literal
     raise FrozenError, "can't modify frozen String" if frozen?
     # Whether a substitution happened is a question about the match, not about
     # the result: `"aaa".sub!(/a/, "a")` returns self even though the string is
     # unchanged.  A full search and not `match?`, so a failed match clears $~.
-    return nil unless Regexp.__search(pattern, self)
+    return nil unless Regexp.__search(pattern, self, 0, literal)
     # `sub` matches again and publishes its own $~ over this one, leaving the
     # caller the match `sub` would have left, a block's own matches included.
     # The resolved pattern takes the place of the original argument so that a
-    # String is not quoted and compiled a second time.  Overwriting `self`
-    # afterwards is safe: a MatchData snapshots its subject, so $~ keeps
-    # describing the string as it was matched.
-    str = args.length == 2 ? self.sub(pattern, args[1], &block) : self.sub(pattern, &block)
+    # String is not quoted and compiled a second time; a literal goes down as
+    # the String it was instead, since that is what tells `sub` to leave the
+    # subject unread, and quoting it twice is the price of saying so.
+    # Overwriting `self` afterwards is safe: a MatchData snapshots its subject,
+    # so $~ keeps describing the string as it was matched.
+    down = literal ? args[0] : pattern
+    str = args.length == 2 ? self.sub(down, args[1], &block) : self.sub(down, &block)
     self.replace(str)
   end
 
@@ -169,10 +178,13 @@ class String
     # After the to_enum return above, so that `"abc".gsub(:b)` yields an
     # Enumerator and raises on the first iteration, as CRuby does.
     pattern = Regexp.__check_pattern(pattern)
-    pattern = Regexp.new(Regexp.escape(pattern)) if String === pattern
+    # A String pattern is a literal, as in `sub`, and reaches the subject the
+    # way CRuby reaches it: byte by byte, with no reading of it as UTF-8.
+    literal = String === pattern
+    pattern = Regexp.new(Regexp.escape(pattern)) if literal
     # A replacement argument wins over the block, as in CRuby.
     if args.length == 2
-      return Regexp.__gsub_str(pattern, self, replacement.to_s)
+      return Regexp.__gsub_str(pattern, self, replacement.to_s, literal)
     end
     # block case: keep in Ruby to avoid VM callback from C
     parts = []
@@ -227,12 +239,15 @@ class String
     end
     return to_enum(:gsub!, *args) if args.length == 1 && !block
     pattern = Regexp.__check_pattern(args[0])
-    pattern = Regexp.new(Regexp.escape(pattern)) if String === pattern
+    literal = String === pattern
+    pattern = Regexp.new(Regexp.escape(pattern)) if literal
     # As in `sub!`: the match decides the return value, and a failed search
     # clears $~.  What it publishes on success is replaced right away by the
     # last match of the `gsub` below, which is the one CRuby leaves behind.
-    return nil unless Regexp.__search(pattern, self)
-    str = args.length == 2 ? self.gsub(pattern, args[1], &block) : self.gsub(pattern, &block)
+    # A literal goes down as the String it was, for the reason `sub!` gives.
+    return nil unless Regexp.__search(pattern, self, 0, literal)
+    down = literal ? args[0] : pattern
+    str = args.length == 2 ? self.gsub(down, args[1], &block) : self.gsub(down, &block)
     self.replace(str)
   end
 

--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -228,6 +228,31 @@ re_binary_string_p(mrb_value str)
   return RSTR_BINARY_P(RSTRING(str));
 }
 
+/* CRuby refuses a search whose subject holds a byte that spells no character,
+   and mruby answers for it. Refuse it here too, so that a program moved from
+   one to the other is told about the subject rather than handed a result the
+   other would not have produced.
+
+   A binary string is exempt because it is indexed by byte throughout, so its
+   bytes make no claim that could be broken. A quoted String pattern is exempt
+   for a narrower reason: CRuby searches for a literal byte by byte and reads
+   the subject as UTF-8 nowhere along the way, so `"a\x80b".sub("b", "!")`
+   answers there while the same call with `/b/` is refused.
+
+   The check walks the whole subject, so it runs once per search a method
+   makes and not once per match it finds: every entry point below checks what
+   arrives from Ruby, and the ones that loop in C over a subject do so after it
+   has been checked once. `__byte_search` is left out, since the mrblib loops
+   that drive it search the same subject over and over and want one check at
+   the entry to the method; that is the commit after this one. */
+static void
+re_check_encoding(mrb_state *mrb, mrb_value str)
+{
+  if (!mrb_str_valid_encoding_p(mrb, str)) {
+    mrb_raise(mrb, E_ARGUMENT_ERROR, "invalid byte sequence in UTF-8");
+  }
+}
+
 static mrb_value
 regexp_binary_string_p(mrb_state *mrb, mrb_value self)
 {
@@ -362,6 +387,7 @@ regexp_match(mrb_state *mrb, mrb_value self)
     return mrb_nil_value();
   }
 
+  re_check_encoding(mrb, str);
   md = exec_match(mrb, self, str, pos);
   if (!mrb_nil_p(md) && !mrb_nil_p(block)) {
     return mrb_yield(mrb, block, md);
@@ -383,7 +409,7 @@ check_regexp_arg(mrb_state *mrb, mrb_value re)
 }
 
 /*
- * Regexp.__search(re, str, pos = 0)
+ * Regexp.__search(re, str, pos = 0, checked = false)
  *
  * Internal: `Regexp#match` with the pattern as an argument and no block form.
  * The String overrides in mrblib search through this so that the search never
@@ -391,14 +417,20 @@ check_regexp_arg(mrb_state *mrb, mrb_value re)
  * the note at the top of mrblib/string_regexp.rb. A nil subject clears the
  * match globals and answers nil, as `Regexp#match` does, which is what the
  * overrides use to report a miss.
+ *
+ * `checked` says the caller has settled the encoding question for the subject
+ * and this search must not ask it again. `sub`, `sub!`, `gsub` and `gsub!` set
+ * it when their pattern is a quoted String, which CRuby searches for without
+ * reading the subject as UTF-8 at all.
  */
 static mrb_value
 regexp_s_search(mrb_state *mrb, mrb_value klass)
 {
   mrb_value re, str;
   mrb_int pos = 0;
+  mrb_bool checked = FALSE;
 
-  mrb_get_args(mrb, "oo|i", &re, &str, &pos);
+  mrb_get_args(mrb, "oo|ib", &re, &str, &pos, &checked);
   check_regexp_arg(mrb, re);
   if (mrb_nil_p(str)) {
     clear_match_globals(mrb);
@@ -410,6 +442,7 @@ regexp_s_search(mrb_state *mrb, mrb_value klass)
     clear_match_globals(mrb);
     return mrb_nil_value();
   }
+  if (!checked) re_check_encoding(mrb, str);
   return exec_match(mrb, re, str, pos);
 }
 
@@ -445,6 +478,7 @@ exec_match_p(mrb_state *mrb, mrb_value re, mrb_value str, mrb_int pos)
 
   mrb_regexp_pattern *pat = DATA_GET_PTR(mrb, re, &regexp_type, mrb_regexp_pattern);
   if (!pat) mrb_raise(mrb, E_ARGUMENT_ERROR, "uninitialized Regexp");
+  re_check_encoding(mrb, str);
 
   int ncap = mrb_re_exec(mrb, pat, RSTRING_PTR(str), RSTRING_LEN(str), pos, NULL, 0,
                          re_binary_string_p(str));
@@ -493,6 +527,7 @@ regexp_match_op(mrb_state *mrb, mrb_value self)
     return mrb_nil_value();
   }
   str = match_operand(mrb, str);
+  re_check_encoding(mrb, str);
 
   mrb_value md = exec_match(mrb, self, str, 0);
   if (mrb_nil_p(md)) return mrb_nil_value();
@@ -516,6 +551,7 @@ regexp_case_match(mrb_state *mrb, mrb_value self)
 
   pat = DATA_GET_PTR(mrb, self, &regexp_type, mrb_regexp_pattern);
   if (!pat) return mrb_false_value();
+  re_check_encoding(mrb, str);
 
   md = exec_match(mrb, self, str, 0);
   return mrb_bool_value(!mrb_nil_p(md));
@@ -1071,17 +1107,23 @@ has_backslash(const char *s, mrb_int len)
 }
 
 /*
- * Regexp.__gsub_str(re, str, replacement) - gsub core without block
+ * Regexp.__gsub_str(re, str, replacement, checked = false) - gsub core without block
+ *
+ * `checked` says the caller has settled the encoding question for the subject,
+ * which for `gsub` means the pattern is a quoted String and the search is a
+ * literal one that CRuby runs without reading the subject as UTF-8.
  */
 static mrb_value
 regexp_s_gsub_str(mrb_state *mrb, mrb_value klass)
 {
   mrb_value re, str, replacement;
-  mrb_get_args(mrb, "oSS", &re, &str, &replacement);
+  mrb_bool checked = FALSE;
+  mrb_get_args(mrb, "oSS|b", &re, &str, &replacement, &checked);
   check_regexp_arg(mrb, re);
 
   mrb_regexp_pattern *pat = DATA_GET_PTR(mrb, re, &regexp_type, mrb_regexp_pattern);
   if (!pat) mrb_raise(mrb, E_ARGUMENT_ERROR, "uninitialized Regexp");
+  if (!checked) re_check_encoding(mrb, str);
 
   const char *s = RSTRING_PTR(str);
   mrb_int slen = RSTRING_LEN(str);
@@ -1161,17 +1203,21 @@ regexp_s_gsub_str(mrb_state *mrb, mrb_value klass)
 }
 
 /*
- * Regexp.__sub_str(re, str, replacement) - sub core without block
+ * Regexp.__sub_str(re, str, replacement, checked = false) - sub core without block
+ *
+ * `checked` carries the same meaning as in `__gsub_str`.
  */
 static mrb_value
 regexp_s_sub_str(mrb_state *mrb, mrb_value klass)
 {
   mrb_value re, str, replacement;
-  mrb_get_args(mrb, "oSS", &re, &str, &replacement);
+  mrb_bool checked = FALSE;
+  mrb_get_args(mrb, "oSS|b", &re, &str, &replacement, &checked);
   check_regexp_arg(mrb, re);
 
   mrb_regexp_pattern *pat = DATA_GET_PTR(mrb, re, &regexp_type, mrb_regexp_pattern);
   if (!pat) mrb_raise(mrb, E_ARGUMENT_ERROR, "uninitialized Regexp");
+  if (!checked) re_check_encoding(mrb, str);
 
   const char *s = RSTRING_PTR(str);
   mrb_int slen = RSTRING_LEN(str);
@@ -1226,6 +1272,7 @@ regexp_s_scan(mrb_state *mrb, mrb_value klass)
 
   mrb_regexp_pattern *pat = DATA_GET_PTR(mrb, re, &regexp_type, mrb_regexp_pattern);
   if (!pat) mrb_raise(mrb, E_ARGUMENT_ERROR, "uninitialized Regexp");
+  re_check_encoding(mrb, str);
 
   const char *s = RSTRING_PTR(str);
   mrb_int slen = RSTRING_LEN(str);
@@ -1341,7 +1388,7 @@ mrb_mruby_regexp_gem_init(mrb_state *mrb)
   mrb_define_class_method(mrb, re, "quote", regexp_escape, MRB_ARGS_REQ(1));
   mrb_define_class_method(mrb, re, "__binary_string?", regexp_binary_string_p, MRB_ARGS_REQ(1));
   mrb_define_class_method(mrb, re, "__check_pattern", regexp_check_pattern, MRB_ARGS_REQ(1));
-  mrb_define_class_method(mrb, re, "__search", regexp_s_search, MRB_ARGS_ARG(2, 1));
+  mrb_define_class_method(mrb, re, "__search", regexp_s_search, MRB_ARGS_ARG(2, 2));
   mrb_define_class_method(mrb, re, "__byte_search", regexp_s_byte_search, MRB_ARGS_ARG(2, 1));
   mrb_define_class_method(mrb, re, "__search_p", regexp_s_search_p, MRB_ARGS_ARG(2, 1));
 
@@ -1358,8 +1405,8 @@ mrb_mruby_regexp_gem_init(mrb_state *mrb)
   mrb_define_method(mrb, re, "hash", regexp_hash, MRB_ARGS_NONE());
   mrb_define_method(mrb, re, "options", regexp_options, MRB_ARGS_NONE());
   mrb_define_method(mrb, re, "casefold?", regexp_casefold_p, MRB_ARGS_NONE());
-  mrb_define_class_method(mrb, re, "__gsub_str", regexp_s_gsub_str, MRB_ARGS_REQ(3));
-  mrb_define_class_method(mrb, re, "__sub_str", regexp_s_sub_str, MRB_ARGS_REQ(3));
+  mrb_define_class_method(mrb, re, "__gsub_str", regexp_s_gsub_str, MRB_ARGS_ARG(3, 1));
+  mrb_define_class_method(mrb, re, "__sub_str", regexp_s_sub_str, MRB_ARGS_ARG(3, 1));
   mrb_define_class_method(mrb, re, "__scan", regexp_s_scan, MRB_ARGS_REQ(2));
 
   /* MatchData class */

--- a/mrbgems/mruby-regexp/test/regexp_utf8.rb
+++ b/mrbgems/mruby-regexp/test/regexp_utf8.rb
@@ -56,16 +56,15 @@ assert("Regexp - /i does not read a byte above 127 as a character") do
   # path would take a lone 0xB5 for U+00B5 and answer /i for a character the
   # pattern does not hold. A literal compares bytes, with or without /i.
   micro = "\xB5"        # U+00B5 is "\xC2\xB5"; the byte on its own is not it
-  assert_equal 0, (Regexp.new(micro, Regexp::IGNORECASE) =~ micro)
   assert_nil (Regexp.new(micro, Regexp::IGNORECASE) =~ "\u00B5")
   # A sequence cut short by the end of the pattern reads the same way.
   lead = "\xC3"         # starts a two byte character and never completes one
-  assert_equal 0, (Regexp.new(lead, Regexp::IGNORECASE) =~ lead)
   assert_nil (Regexp.new(lead, Regexp::IGNORECASE) =~ "\u00E3")
   # What /i folds is settled when the pattern is compiled, so a byte-indexed
   # subject puts the same question to the engine, which reads one through a
   # branch of its own: `mrb_re_exec` takes the flag and every step it drives,
-  # the fold included, turns on it.
+  # the fold included, turns on it. It is also the only subject left to put it
+  # through, now that one carrying the byte and read as UTF-8 is refused.
   assert_equal 0, (Regexp.new(micro, Regexp::IGNORECASE) =~ micro.b)
   assert_equal 0, (Regexp.new(lead, Regexp::IGNORECASE) =~ lead.b)
 end
@@ -129,29 +128,24 @@ assert("Regexp - quantifier on an invalid multibyte literal") do
   lead3 = "\xE3"  # starts a three byte character
   cont = "\x81"   # continuation byte
 
+  # What the quantifier binds to is settled when the pattern is compiled, so
+  # the subjects below are byte-indexed: one carrying these bytes and read as
+  # UTF-8 is refused before the match runs.
   # "x" is not a continuation byte, so `+` repeats "x".
-  assert_equal 4, (lead2 + "xxx").match(Regexp.new(lead2 + "x+"))[0].bytesize
-  assert_equal 4, (lead3 + "abb").match(Regexp.new(lead3 + "ab+"))[0].bytesize
-  # The quantifier itself must not be taken for a continuation byte either.
-  assert_equal 2, (lead2 + lead2).match(Regexp.new(lead2 + "+"))[0].bytesize
-  # A sequence cut short by the end of the pattern emits its bytes one by one.
-  assert_equal 2, (lead3 + cont).match(Regexp.new(lead3 + cont))[0].bytesize
-  assert_equal 3, (lead3 + cont + cont).match(Regexp.new(lead3 + cont + "+"))[0].bytesize
-  # A valid character right after an invalid lead byte is still one atom.
-  assert_equal 5, (lead2 + "ĀĀ").match(Regexp.new(lead2 + "Ā+"))[0].bytesize
-  # The subject side reads the same way: `.` takes the lead byte alone.
-  assert_equal 1, (lead2 + "x").match(/./)[0].bytesize
-  assert_equal 2, "Ā".match(/./)[0].bytesize
-  # What the quantifier binds to belongs to the pattern, so the answers above
-  # hold for a byte-indexed subject as well, and that is where the engine's
-  # own branch for one gets to state them.
   assert_equal 4, (lead2 + "xxx").b.match(Regexp.new(lead2 + "x+"))[0].bytesize
   assert_equal 4, (lead3 + "abb").b.match(Regexp.new(lead3 + "ab+"))[0].bytesize
+  # The quantifier itself must not be taken for a continuation byte either.
   assert_equal 2, (lead2 + lead2).b.match(Regexp.new(lead2 + "+"))[0].bytesize
+  # A sequence cut short by the end of the pattern emits its bytes one by one.
   assert_equal 2, (lead3 + cont).b.match(Regexp.new(lead3 + cont))[0].bytesize
   assert_equal 3, (lead3 + cont + cont).b.match(Regexp.new(lead3 + cont + "+"))[0].bytesize
+  # A valid character right after an invalid lead byte is still one atom.
   assert_equal 5, (lead2 + "ĀĀ").b.match(Regexp.new(lead2 + "Ā+"))[0].bytesize
+  # The subject side reads the same way: `.` takes the lead byte alone.
   assert_equal 1, (lead2 + "x").b.match(/./)[0].bytesize
+  # A whole character is one atom on the subject side too, and that subject
+  # goes through as it always did.
+  assert_equal 2, "Ā".match(/./)[0].bytesize
 end
 
 assert("Regexp - a byte that belongs to no character is a match position") do
@@ -159,30 +153,23 @@ assert("Regexp - a byte that belongs to no character is a match position") do
   # in front of it reaches that far. One that stands on its own is a boundary
   # like any other, and the engines used to disagree about it: the literal
   # fast path matched there, the NFA never started a match there.
+  # Where such a byte opens a match position is a question about the byte, and
+  # a subject carrying one and read as UTF-8 is refused before the match runs,
+  # so the subjects below are byte-indexed. There #begin is a byte offset,
+  # which is what pre_match used to be needed for.
   b = "\x81"
-  assert_equal 0, (b + b).match(Regexp.new(b + b)).begin(0)
-  assert_equal 2, (b + b).match(Regexp.new(b + "+"))[0].bytesize
-  assert_equal 2, (b + b).match(Regexp.new(b + "*"))[0].bytesize
-  assert_equal 1, (b + b).match(Regexp.new(b + "?"))[0].bytesize
-  assert_equal 1, ("x" + b + b).match(Regexp.new(b + "+")).begin(0)
-  # Inside a character there is still no match position.
-  assert_nil "あ".match(Regexp.new("\x81"))
-  assert_nil "あ".match(Regexp.new("\x82"))
-  assert_nil "\u{1D54F}".match(Regexp.new("\x95"))
-  # Next to one there is.
-  assert_equal 0, (b + "あ").match(Regexp.new(b)).begin(0)
-  # Through pre_match, since #begin counts characters where the build has
-  # them and bytes where it does not.
-  assert_equal 3, ("あ" + b).match(Regexp.new(b)).pre_match.bytesize
-  # Where such a byte opens a match position is a question about the byte, so
-  # a byte-indexed subject asks it too, and there #begin is a byte offset that
-  # needs no pre_match to read.
   assert_equal 0, (b + b).b.match(Regexp.new(b + b)).begin(0)
   assert_equal 2, (b + b).b.match(Regexp.new(b + "+"))[0].bytesize
   assert_equal 2, (b + b).b.match(Regexp.new(b + "*"))[0].bytesize
   assert_equal 1, (b + b).b.match(Regexp.new(b + "?"))[0].bytesize
   assert_equal 1, ("x" + b + b).b.match(Regexp.new(b + "+")).begin(0)
+  # Next to one there is a match position too.
   assert_equal 0, (b + "あ").b.match(Regexp.new(b)).begin(0)
+  # Inside a character there is none, on a subject that is whole UTF-8 and
+  # reaches the engine as it always did.
+  assert_nil "あ".match(Regexp.new("\x81"))
+  assert_nil "あ".match(Regexp.new("\x82"))
+  assert_nil "\u{1D54F}".match(Regexp.new("\x95"))
 end
 
 assert("Regexp - an attempt in flight opens no match position inside a character") do
@@ -199,11 +186,10 @@ assert("Regexp - an attempt in flight opens no match position inside a character
   assert_equal 5, ("あ" + "µ").match(/.?[µ]/)[0].bytesize
   # And so is a byte where no lead byte reaches it, through a class that holds
   # the byte. [µ] holds the character, whose trailing byte alone is not it.
-  assert_equal 2, ("x" + "\xb5").match(Regexp.new(".?[\xb5]"))[0].bytesize
-  assert_nil ("x" + "\xb5").match(/.?[µ]/)
-  # Byte-indexed the class holds that byte just the same, and the thread `.?`
-  # parks past it is stepped by the engine's byte-indexed branch. A class that
-  # holds the character rather than the byte still does not hold it.
+  # That subject is refused as UTF-8, so it is byte-indexed here, where the
+  # thread `.?` parks past the byte is stepped by the engine's own branch for
+  # one. A class that holds the character rather than the byte still does not
+  # hold it.
   assert_equal 2, ("x" + "\xb5").b.match(Regexp.new(".?[\xb5]"))[0].bytesize
   assert_nil ("x" + "\xb5").b.match(/.?[µ]/)
 end
@@ -226,29 +212,35 @@ assert("Regexp - a byte-indexed subject is reported in bytes") do
   assert_equal 1, (("x" + u) =~ Regexp.new("\u{1F600}"))
 end
 
-assert("Regexp - match positions on malformed UTF-8 agree with string indexing") do
-  # String indexing counts a byte no lead byte reaches as one character, but
-  # #begin used to count lead bytes only, so a stray continuation byte was
-  # zero width to it. Computing the length marks such a string single-byte
-  # and switches it to byte counting, so the same match reported one
-  # position before the length was known and another after.
+assert("Regexp - a subject whose bytes are not UTF-8 is refused whatever is known about it") do
+  # The refusal must not turn on what the string happens to have been asked
+  # about: the single-byte flag `#length` leaves behind says one byte per
+  # character, which a string of stray bytes satisfies too, so reading it in
+  # place of walking the bytes would make the same call answer one way before
+  # a length was taken and another after. That is what #begin used to do here,
+  # counting lead bytes only until the flag switched it to counting bytes.
   s = "a\x80b"
-  m = /b/.match(s)
-  before = m.begin(0)
-  assert_equal 3, s.length
-  assert_equal before, /b/.match(s).begin(0)
-  assert_equal 2, before
-  assert_equal "b", s[before]
-  assert_equal 3, m.end(0)
-  # A position argument walks the same characters, from either end. The
-  # fresh literal pins the walk on a string whose length is not known yet.
-  assert_equal "b", /b/.match(s, 2)[0]
-  assert_equal "a", /a/.match(s, -3)[0]
-  assert_nil /a/.match(s, -4)
-  assert_equal "a", /a/.match("a\x80b", -3)[0]
-  # Read as bytes the same subject reports byte offsets, which its own
-  # indexing agrees with too, and a position argument walks it from either
-  # end in bytes.
+  if __ENCODING__ == "UTF-8"
+    assert_raise(ArgumentError) { /b/.match(s) }
+    assert_equal 3, s.length
+    assert_raise(ArgumentError) { /b/.match(s) }
+    # A position argument is no way around it either, from either end. The
+    # fresh literal puts the question to a string whose length is not known.
+    assert_raise(ArgumentError) { /b/.match(s, 2) }
+    assert_raise(ArgumentError) { /a/.match("a\x80b", -3) }
+  else
+    # A build that reads no encoding for these bytes to break has nothing to
+    # refuse, and reports the byte positions the half below asserts in either
+    # build.
+    assert_equal 2, /b/.match(s).begin(0)
+    assert_equal 3, s.length
+    assert_equal 2, /b/.match(s).begin(0)
+    assert_equal "b", /b/.match(s, 2)[0]
+    assert_equal "a", /a/.match("a\x80b", -3)[0]
+  end
+  # Read as bytes the same subject makes no claim that could be broken, and
+  # every position it reports is a byte offset its own indexing agrees with,
+  # walked from either end.
   bs = "a\x80b".b
   bm = /b/.match(bs)
   assert_equal 2, bm.begin(0)
@@ -279,20 +271,16 @@ assert("Regexp - a match does not end inside a character") do
   # A lookaround ends at a position without consuming it, so it is not the
   # end of the match and keeps its own answer.
   assert_equal 2, j.match(Regexp.new("(?=\xc4)\xc4\xb5"))[0].bytesize
-  # A byte no lead byte reaches is a boundary, so a byte pattern still works.
-  b = "\x81"
-  assert_equal 1, (b + b).match(Regexp.new(b))[0].bytesize
-  assert_equal 2, (b + b).match(Regexp.new(b + "+"))[0].bytesize
-  assert_equal 1, ("a" + b).match(Regexp.new(b))[0].bytesize
   # Read as binary every position is a boundary, so nothing changes there.
   if Object.const_defined?(:Encoding)
     bin = j.dup.force_encoding("ASCII-8BIT")
     assert_equal 1, bin.match(Regexp.new("\xc4"))[0].bytesize
     assert_equal 2, bin.match(Regexp.new("\xc4."))[0].bytesize
   end
-  # A byte no lead byte reaches is a boundary there too, so the three answers
-  # above hold for a byte-indexed subject, whose own indexing agrees with the
-  # byte counts they report.
+  # A byte no lead byte reaches is a boundary too, so a byte pattern works
+  # there as well. Byte-indexed, since a subject carrying such a byte and read
+  # as UTF-8 is refused before the match runs.
+  b = "\x81"
   assert_equal 1, (b + b).b.match(Regexp.new(b))[0].bytesize
   assert_equal 2, (b + b).b.match(Regexp.new(b + "+"))[0].bytesize
   assert_equal 1, ("a" + b).b.match(Regexp.new(b))[0].bytesize
@@ -423,20 +411,18 @@ assert("Regexp - invalid UTF-8 byte near pattern end") do
   # past the end of the pattern buffer
   re = Regexp.new("[   \xff ]")
   assert_kind_of Regexp, re
-  assert_equal 0, (re =~ "\xff")
   assert_nil (re =~ "x")
-  # The byte reaches the class the same way from a byte-indexed subject, which
-  # the engine walks through a branch of its own.
+  # A subject that is the byte is refused as UTF-8, so it is byte-indexed
+  # here, where the engine walks the class through a branch of its own.
   assert_equal 0, (re =~ "\xff".b)
 end
 
 assert("Regexp - truncated UTF-8 at subject end") do
   # a lone multi-byte leader at the end of the subject must not read
-  # past the end of the string buffer when matched against a class
-  assert_nil ("ab\xf0" =~ /[cd]/)
-  assert_equal 0, ("ab\xf0" =~ /[^cd]+$/)
-  # Byte-indexed the leader is a byte of its own, so the walk that reaches the
-  # end of the buffer is a different one and must stay inside it too.
+  # past the end of the string buffer when matched against a class. As UTF-8
+  # that subject no longer reaches the engine at all, which is the stronger
+  # guard; byte-indexed it does, and the walk that reaches the end of the
+  # buffer there is one the engine still has to keep inside it.
   assert_nil ("ab\xf0".b =~ /[cd]/)
   assert_equal 0, ("ab\xf0".b =~ /[^cd]+$/)
 end
@@ -445,23 +431,28 @@ assert("Regexp - overlong UTF-8 is not the character it spells") do
   # C0 BC is the two-byte overlong spelling of "<" and E0 84 80 the three-byte
   # spelling of "Ā". A decoder that hands out a codepoint for these would let a
   # class hold a character the subject does not spell, so assert the class and
-  # the literal together against the same subject.
-  assert_nil ("\xC0\xBC" =~ /[<]/)
-  assert_nil ("\xC0\xBC" =~ /</)
-  assert_equal 0, ("\xC0\xBC" =~ /[^<]/)
-  assert_equal "\xC0\xBC", "\xC0\xBC".gsub(/[<]/, "&lt;")
-  assert_nil ("\xE0\x80\xBC" =~ /[<]/)
-  assert_false Regexp.new("[Ā]").match?("\xE0\x84\x80")
-  assert_false (/Ā/.match?("\xE0\x84\x80"))
-  # the pattern side decodes through the same helper
+  # the literal together against the same subject. RFC 3629 puts these
+  # sequences outside UTF-8, so a subject spelled with one is refused where
+  # strings are read as UTF-8 and the subjects below are byte-indexed. That is
+  # where the decode has to be asked anyway: the class must hold no character
+  # the bytes do not spell, whichever way the subject is indexed.
+  assert_nil ("\xC0\xBC".b =~ /[<]/)
+  assert_nil ("\xC0\xBC".b =~ /</)
+  assert_equal 0, ("\xC0\xBC".b =~ /[^<]/)
+  assert_equal "\xC0\xBC".b, "\xC0\xBC".b.gsub(/[<]/, "&lt;")
+  assert_nil ("\xE0\x80\xBC".b =~ /[<]/)
+  assert_false Regexp.new("[Ā]").match?("\xE0\x84\x80".b)
+  assert_false (/Ā/.match?("\xE0\x84\x80".b))
+  # the pattern side decodes through the same helper, and its subject here is
+  # whole UTF-8
   assert_false Regexp.new("[\xC0\xBC]").match?("<")
   # surrogates and codepoints above U+10FFFF encode no character either, so
   # each byte stands on its own
-  assert_equal 2, "\xC0\xBC".scan(/./).size
-  assert_equal 3, "\xED\xA0\x80".scan(/./).size
-  assert_equal 4, "\xF0\x80\x80\xBC".scan(/./).size
-  assert_equal 4, "\xF4\x90\x80\x80".scan(/./).size
-  assert_equal 4, "\xF5\x80\x80\x80".scan(/./).size
+  assert_equal 2, "\xC0\xBC".b.scan(/./).size
+  assert_equal 3, "\xED\xA0\x80".b.scan(/./).size
+  assert_equal 4, "\xF0\x80\x80\xBC".b.scan(/./).size
+  assert_equal 4, "\xF4\x90\x80\x80".b.scan(/./).size
+  assert_equal 4, "\xF5\x80\x80\x80".b.scan(/./).size
   # the shortest spelling on each side of those bounds is still one character
   assert_equal 1, "\u{0080}".scan(/./).size    # C2 80
   assert_equal 1, "\u{0800}".scan(/./).size    # E0 A0 80
@@ -471,21 +462,6 @@ assert("Regexp - overlong UTF-8 is not the character it spells") do
   assert_equal 1, "\u{10FFFF}".scan(/./).size  # F4 8F BF BF
   assert_equal 0, ("\u{0800}" =~ Regexp.new("[\u{0800}]"))
   assert_equal 0, ("\u{10FFFF}" =~ Regexp.new("[\u{10FFFF}]"))
-  # None of this turns on how the subject is indexed: a byte-indexed one is
-  # decoded a byte at a time, so an overlong sequence is no more the character
-  # it spells there, and the answers are the same through that branch.
-  assert_nil ("\xC0\xBC".b =~ /[<]/)
-  assert_nil ("\xC0\xBC".b =~ /</)
-  assert_equal 0, ("\xC0\xBC".b =~ /[^<]/)
-  assert_equal "\xC0\xBC".b, "\xC0\xBC".b.gsub(/[<]/, "&lt;")
-  assert_nil ("\xE0\x80\xBC".b =~ /[<]/)
-  assert_false Regexp.new("[Ā]").match?("\xE0\x84\x80".b)
-  assert_false (/Ā/.match?("\xE0\x84\x80".b))
-  assert_equal 2, "\xC0\xBC".b.scan(/./).size
-  assert_equal 3, "\xED\xA0\x80".b.scan(/./).size
-  assert_equal 4, "\xF0\x80\x80\xBC".b.scan(/./).size
-  assert_equal 4, "\xF4\x90\x80\x80".b.scan(/./).size
-  assert_equal 4, "\xF5\x80\x80\x80".b.scan(/./).size
 end
 
 assert("Regexp - a pattern byte that starts no character is a byte in a class") do
@@ -494,25 +470,27 @@ assert("Regexp - a pattern byte that starts no character is a byte in a class") 
   # meant two things depending on which side of the brackets it was written.
   # CRuby settles it with the pattern's encoding and raises RegexpError for
   # either spelling; this gem has no encoding to consult, so it reads the byte
-  # as the byte on both sides.
+  # as the byte on both sides. Which of the two a class holds belongs to the
+  # pattern, and a subject that is such a byte is refused where strings are
+  # read as UTF-8, so those subjects are byte-indexed below.
   mu = "\xC2\xB5"  # U+00B5 MICRO SIGN, two bytes
   assert_nil (mu =~ Regexp.new("[\xB5]"))
   assert_nil (mu =~ Regexp.new("\xB5"))
   assert_equal mu.bytes, mu.gsub(Regexp.new("[\xB5]"), "!").bytes
   assert_equal mu.bytes, mu.gsub(Regexp.new("\xB5"), "!").bytes
-  assert_equal 0, ("\xB5" =~ Regexp.new("[\xB5]"))       # the byte alone is it
-  assert_equal 1, (mu.b =~ Regexp.new("[\xB5]"))         # so is a byte subject
+  assert_equal 0, ("\xB5".b =~ Regexp.new("[\xB5]"))     # the byte alone is it
+  assert_equal 1, (mu.b =~ Regexp.new("[\xB5]"))         # and so is one inside
   assert_equal 0, (mu =~ Regexp.new("[^\xB5]"))
   # An escape names a byte too, which is what the literal path emits for it.
   assert_nil (mu =~ Regexp.new("[\\xB5]"))
-  assert_equal 0, ("\xB5" =~ Regexp.new("[\\xB5]"))
+  assert_equal 0, ("\xB5".b =~ Regexp.new("[\\xB5]"))
   # `\u` names a codepoint outright, so it is how the character gets spelled
   # where the byte of the same number will not do.
   assert_equal 0, (mu =~ Regexp.new("[\\u{B5}]"))
-  assert_nil ("\xB5" =~ Regexp.new("[\\u{B5}]"))
+  assert_nil ("\xB5".b =~ Regexp.new("[\\u{B5}]"))
   # An invalid leader is a byte on both sides for the same reason, which is
   # what "overlong UTF-8 is not the character it spells" pins for the class.
-  assert_equal 0, ("\xC0" =~ Regexp.new("[\xC0]"))
+  assert_equal 0, ("\xC0".b =~ Regexp.new("[\xC0]"))
   assert_nil ("À" =~ Regexp.new("[\xC0]"))               # C3 80
   # A byte range is how a continuation byte gets spelled, and it stays a range
   # of bytes: it holds no character of its own.
@@ -525,16 +503,8 @@ assert("Regexp - a pattern byte that starts no character is a byte in a class") 
   assert_raise(RegexpError) { Regexp.new("[µ-\x80]") }
   assert_raise(RegexpError) { Regexp.new("[\\u{B5}-\\xBF]") }
   # ASCII belongs to both, so it pairs with either.
-  assert_equal 0, ("\xFF" =~ Regexp.new("[\x00-\xFF]"))
-  assert_equal 0, ("µ" =~ Regexp.new("[\x00-\u{FF}]"))
-  # Which of the two a class holds belongs to the pattern, so a subject that
-  # is one such byte answers the same read as bytes, through the branch the
-  # engine keeps for a subject indexed that way.
-  assert_equal 0, ("\xB5".b =~ Regexp.new("[\xB5]"))
-  assert_equal 0, ("\xB5".b =~ Regexp.new("[\\xB5]"))
-  assert_nil ("\xB5".b =~ Regexp.new("[\\u{B5}]"))
-  assert_equal 0, ("\xC0".b =~ Regexp.new("[\xC0]"))
   assert_equal 0, ("\xFF".b =~ Regexp.new("[\x00-\xFF]"))
+  assert_equal 0, ("µ" =~ Regexp.new("[\x00-\u{FF}]"))
 end
 
 assert("Regexp - /i over a class of bytes asks for no case data") do
@@ -579,4 +549,64 @@ assert("Regexp - large non-ASCII character class does not overflow") do
   assert_equal 0, (re =~ utf8.call(0x8080))
   assert_nil (re =~ utf8.call(0x8081))
   assert_nil (re =~ "A")
+end
+
+assert("Regexp - a subject whose bytes are not UTF-8 is refused") do
+  # CRuby raises ArgumentError for a subject holding a byte that stands for no
+  # character, and mruby answered for it, so a program moved from one to the
+  # other took a result CRuby would not have produced. `String#scrub` is how a
+  # subject like this becomes matchable.
+  skip unless __ENCODING__ == "UTF-8"
+  broken = "あ\x80b"     # "あ" followed by a lone continuation byte
+
+  assert_raise(ArgumentError) { broken =~ /b/ }
+  assert_raise(ArgumentError) { /b/ =~ broken }
+  assert_raise(ArgumentError) { /b/.match(broken) }
+  assert_raise(ArgumentError) { /b/.match?(broken) }
+  assert_raise(ArgumentError) { /b/ === broken }
+  assert_raise(ArgumentError) { broken.match(/b/) }
+  assert_raise(ArgumentError) { broken.match?(/b/) }
+  assert_raise(ArgumentError) { broken.index(/b/) }
+  assert_raise(ArgumentError) { broken.rindex(/b/) }
+  assert_raise(ArgumentError) { broken.byterindex(/b/) }
+  assert_raise(ArgumentError) { broken[/b/] }
+  assert_raise(ArgumentError) { broken.sub(/b/, "!") }
+  assert_raise(ArgumentError) { broken.sub(/b/) { "!" } }
+  assert_raise(ArgumentError) { broken.gsub(/b/, "!") }
+  assert_raise(ArgumentError) { broken.scan(/b/) }
+  assert_raise(ArgumentError) { broken.partition(/b/) }
+  assert_raise(ArgumentError) { broken.rpartition(/b/) }
+  assert_raise(ArgumentError) { broken.start_with?(/b/) }
+  assert_raise(ArgumentError) { broken.dup.sub!(/b/, "!") }
+  assert_raise(ArgumentError) { broken.dup.gsub!(/b/, "!") }
+  assert_raise(ArgumentError) { broken.dup.slice!(/b/) }
+  assert_raise(ArgumentError) { broken.dup[/b/] = "!" }
+
+  # A String pattern is a literal, which CRuby searches for byte by byte
+  # without reading the subject as UTF-8, so these answer there and here.
+  # `scan` is the exception CRuby itself makes: it refuses a literal too.
+  assert_equal "あ\x80!", broken.sub("b", "!")
+  assert_equal "あ\x80!", broken.gsub("b", "!")
+  assert_equal "あ\x80!", broken.sub("b") { "!" }
+  assert_equal "あ\x80!", broken.gsub("b") { "!" }
+  bang = broken.dup
+  bang.sub!("b", "!")
+  assert_equal "あ\x80!", bang
+  bang = broken.dup
+  bang.gsub!("b", "!")
+  assert_equal "あ\x80!", bang
+  # The position it publishes is the one the string's own indexing answers.
+  broken.sub("b", "!")
+  assert_equal broken.index("b"), $~.begin(0)
+  assert_raise(ArgumentError) { broken.scan("b") }
+
+  # A byte-indexed subject is indexed by byte throughout, so its bytes make no
+  # claim that could be broken and it goes through as it always did.
+  assert_equal 4, (broken.b =~ /b/)
+  assert_equal 4, broken.b.match(/b/).begin(0)
+  assert_equal "あ\x80!".b, broken.b.sub(/b/, "!")
+
+  # A whole subject is untouched, including one the walk reads to the end.
+  assert_equal 2, ("あいb" =~ /b/)
+  assert_equal 1, ("a\u{10FFFF}b" =~ /b\z|\u{10FFFF}/)
 end


### PR DESCRIPTION
Third of the four pieces #7110 was split into, on top of #7115 and #7116.

CRuby raises `ArgumentError` when a search is given a subject holding a byte
that spells no character. mruby answered for it instead, so the same program
took a result CRuby would not have produced:

```ruby
"あ\x80b" =~ /b/         # CRuby: ArgumentError, mruby: 2
"あ\x80b".scan(/./)      # CRuby: ArgumentError, mruby: ["あ", "\x80", "b"]
"\xC0\xBC" =~ /[^<]/     # CRuby: ArgumentError, mruby: 0
```

Refuse the search instead, wherever the search itself runs in C: `=~`, `match`,
`match?`, `===`, `index`, `rindex`, `byterindex`, `[]`, `[]=`, `sub`, `sub!`,
`gsub` with a replacement, `gsub!`, `scan`, `partition`, `rpartition`,
`start_with?` and `slice!`. `String#scrub` is how a subject like this becomes
matchable.

### What is left for the fourth piece

`gsub` with a block, `split` and `byteindex` keep answering for now:

```ruby
"あ\x80b".split(/b/)        # ["あ\x80"], where "あ\x80b" =~ /b/ raises here
"あ\x80b".byteindex(/b/)    # 4
"あ\x80b".gsub(/b/) { "!" } # "あ\x80!"
```

Each drives `Regexp.__byte_search` from a loop in mrblib that searches the same
subject once per match, so a check in the search walks the whole subject again
for every match it finds. What they need is one check at the entry to the
method, which is the next piece, measured there at 105 ms against 1404 ms for
`("あ," * 20000).split(/,/)`.

`__regexp_rsearch`, which backs `rindex`, `byterindex` and `rpartition`, is a
loop of that kind too. It refuses here, because each of its searches checks;
the same piece hoists the check out of it.

### What goes through untouched

A binary string is indexed by byte from end to end, so its bytes make no claim
that could be broken.

A quoted String pattern is exempt on the grounds CRuby exempts it: a literal is
searched for byte by byte, and the subject is read as UTF-8 nowhere along the
way.

```ruby
"あ\x80b".sub("b", "!")  #=> "あ\x80!" in both, where /b/ is refused in both
"あ\x80b".scan("b")      # ArgumentError in both: `scan` refuses a literal too
```

`sub`, `sub!`, `gsub` and `gsub!` quote a String pattern into a `Regexp` before
they search, so each carries the fact that it was a literal down to the search
rather than letting the quoting hide it.

A string derived from a binary one does not carry `MRB_STR_BINARY` with it, so
`b + ""` and `b.sub(...)` are refused where `b` itself is not. That gap predates
this change and is left as it is.

### Where the check runs

`re_check_encoding()` walks the whole subject, so it runs once per search a
method makes rather than once per match it finds. `Regexp#match`, `#=~`, `#===`
and `#match?` check what arrives from Ruby, and so do the class methods
`__search`, `__search_p`, `__sub_str`, `__gsub_str` and `__scan`, the last three
of which loop in C over a subject already checked.

### Cost

What remains is one walk per search, which a whole subject pays as well. The
flag `String#length` leaves behind cannot stand in for the walk, since a string
of stray bytes has one byte per character too, so a subject searched twice is
walked twice.

The walk skips a run of ASCII a word at a time and decodes only where a byte
leaves that range, so the cost follows how much of the subject is multi-byte.
Measured at `-O3` on a full-core build, the fastest of seven runs each:

| | before | after |
|---|---|---|
| `("あ" * 100000 + "z") =~ /z/`, 200 times | 70 ms | 117 ms |
| the same over an ASCII subject of the same byte size | 7.7 ms | 6.6 ms |
| `"hello world" =~ /world/`, 100000 times | 213 ms | 149 ms |

The last two are inside the noise of the machine they were taken on, which is
what the second one answering faster after the change says.

### One known difference

An out of range positive `pos` still answers nil rather than raising, since
`re_char_to_byte()` rejects it before the check runs. CRuby raises there for
`Regexp#match`; for `index` and `rindex` it answers nil as this does.

### Tests

The tests whose subject this refuses are the ones #7115 and #7116 gave a
byte-indexed subject to ask through, so each keeps its question and loses only
the subject that no longer reaches the engine. What a match position inside a
whole character is stays pinned on subjects that are whole UTF-8.

`Regexp - truncated UTF-8 at subject end` is worth calling out: it was a
fuzz-derived regression test for a read past the end of the string buffer, and
the UTF-8 half of the walk it covered is no longer reachable from Ruby under
this rule. The byte-indexed half #7116 added still walks to the end of the
buffer and is what remains.

The one case that turns on what mruby knows about the string rather than on the
engine keeps both answers and branches on `__ENCODING__`, since a build without
`MRB_UTF8_STRING` reads no encoding for the bytes to break.

### Verified

- `rake test` on a full-core build (`MRB_UTF8_STRING` through mruby-encoding):
  2254 tests, all green
- `rake test` on the default gembox (no `MRB_UTF8_STRING`): 2061 tests, all
  green
- 34 calls on a broken subject compared against CRuby 4.0.6. All agree except
  the three the next piece takes (`byteindex`, `gsub` with a block, `split`),
  `split("b")`, which CRuby refuses and the aliased C `__split` still answers
  and which is not this change, and `String#inspect` on a byte-indexed string,
  which prints the bytes rather than escaping them
- `prek run --all-files` passes, except that `markdownlint` could not install
  locally (npm engine mismatch); no Markdown is touched here


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added UTF-8 validation for regular expression operations on text subjects.
  * Invalid UTF-8 now raises `ArgumentError` instead of producing unreliable matches.
  * Preserved byte-oriented matching for literal strings and byte-indexed data.
  * Improved consistency across matching, scanning, substitution, and global substitution operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->