### PR TITLE
mruby-regexp: ask the byte cases of a byte-indexed subject alone

### DIFF
--- a/mrbgems/mruby-regexp/test/regexp_utf8.rb
+++ b/mrbgems/mruby-regexp/test/regexp_utf8.rb
@@ -56,16 +56,16 @@ assert("Regexp - /i does not read a byte above 127 as a character") do
   # path would take a lone 0xB5 for U+00B5 and answer /i for a character the
   # pattern does not hold. A literal compares bytes, with or without /i.
   micro = "\xB5"        # U+00B5 is "\xC2\xB5"; the byte on its own is not it
-  assert_equal 0, (Regexp.new(micro, Regexp::IGNORECASE) =~ micro)
   assert_nil (Regexp.new(micro, Regexp::IGNORECASE) =~ "\u00B5")
   # A sequence cut short by the end of the pattern reads the same way.
   lead = "\xC3"         # starts a two byte character and never completes one
-  assert_equal 0, (Regexp.new(lead, Regexp::IGNORECASE) =~ lead)
   assert_nil (Regexp.new(lead, Regexp::IGNORECASE) =~ "\u00E3")
   # What /i folds is settled when the pattern is compiled, so a byte-indexed
   # subject puts the same question to the engine, which reads one through a
   # branch of its own: `mrb_re_exec` takes the flag and every step it drives,
-  # the fold included, turns on it.
+  # the fold included, turns on it. It is also the subject the question has a
+  # definite answer on: read as UTF-8 the byte spells nothing for the fold to
+  # be about.
   assert_equal 0, (Regexp.new(micro, Regexp::IGNORECASE) =~ micro.b)
   assert_equal 0, (Regexp.new(lead, Regexp::IGNORECASE) =~ lead.b)
 end
@@ -129,29 +129,24 @@ assert("Regexp - quantifier on an invalid multibyte literal") do
   lead3 = "\xE3"  # starts a three byte character
   cont = "\x81"   # continuation byte
 
+  # What the quantifier binds to is settled when the pattern is compiled, so
+  # the subjects below are byte-indexed, where each of these bytes is a byte
+  # and the byte counts they report are offsets into what was asked.
   # "x" is not a continuation byte, so `+` repeats "x".
-  assert_equal 4, (lead2 + "xxx").match(Regexp.new(lead2 + "x+"))[0].bytesize
-  assert_equal 4, (lead3 + "abb").match(Regexp.new(lead3 + "ab+"))[0].bytesize
-  # The quantifier itself must not be taken for a continuation byte either.
-  assert_equal 2, (lead2 + lead2).match(Regexp.new(lead2 + "+"))[0].bytesize
-  # A sequence cut short by the end of the pattern emits its bytes one by one.
-  assert_equal 2, (lead3 + cont).match(Regexp.new(lead3 + cont))[0].bytesize
-  assert_equal 3, (lead3 + cont + cont).match(Regexp.new(lead3 + cont + "+"))[0].bytesize
-  # A valid character right after an invalid lead byte is still one atom.
-  assert_equal 5, (lead2 + "ĀĀ").match(Regexp.new(lead2 + "Ā+"))[0].bytesize
-  # The subject side reads the same way: `.` takes the lead byte alone.
-  assert_equal 1, (lead2 + "x").match(/./)[0].bytesize
-  assert_equal 2, "Ā".match(/./)[0].bytesize
-  # What the quantifier binds to belongs to the pattern, so the answers above
-  # hold for a byte-indexed subject as well, and that is where the engine's
-  # own branch for one gets to state them.
   assert_equal 4, (lead2 + "xxx").b.match(Regexp.new(lead2 + "x+"))[0].bytesize
   assert_equal 4, (lead3 + "abb").b.match(Regexp.new(lead3 + "ab+"))[0].bytesize
+  # The quantifier itself must not be taken for a continuation byte either.
   assert_equal 2, (lead2 + lead2).b.match(Regexp.new(lead2 + "+"))[0].bytesize
+  # A sequence cut short by the end of the pattern emits its bytes one by one.
   assert_equal 2, (lead3 + cont).b.match(Regexp.new(lead3 + cont))[0].bytesize
   assert_equal 3, (lead3 + cont + cont).b.match(Regexp.new(lead3 + cont + "+"))[0].bytesize
+  # A valid character right after an invalid lead byte is still one atom.
   assert_equal 5, (lead2 + "ĀĀ").b.match(Regexp.new(lead2 + "Ā+"))[0].bytesize
+  # The subject side reads the same way: `.` takes the lead byte alone.
   assert_equal 1, (lead2 + "x").b.match(/./)[0].bytesize
+  # A whole character is one atom on the subject side too, and that subject
+  # goes through as it always did.
+  assert_equal 2, "Ā".match(/./)[0].bytesize
 end
 
 assert("Regexp - a byte that belongs to no character is a match position") do
@@ -159,30 +154,22 @@ assert("Regexp - a byte that belongs to no character is a match position") do
   # in front of it reaches that far. One that stands on its own is a boundary
   # like any other, and the engines used to disagree about it: the literal
   # fast path matched there, the NFA never started a match there.
-  b = "\x81"
-  assert_equal 0, (b + b).match(Regexp.new(b + b)).begin(0)
-  assert_equal 2, (b + b).match(Regexp.new(b + "+"))[0].bytesize
-  assert_equal 2, (b + b).match(Regexp.new(b + "*"))[0].bytesize
-  assert_equal 1, (b + b).match(Regexp.new(b + "?"))[0].bytesize
-  assert_equal 1, ("x" + b + b).match(Regexp.new(b + "+")).begin(0)
-  # Inside a character there is still no match position.
-  assert_nil "あ".match(Regexp.new("\x81"))
-  assert_nil "あ".match(Regexp.new("\x82"))
-  assert_nil "\u{1D54F}".match(Regexp.new("\x95"))
-  # Next to one there is.
-  assert_equal 0, (b + "あ").match(Regexp.new(b)).begin(0)
-  # Through pre_match, since #begin counts characters where the build has
-  # them and bytes where it does not.
-  assert_equal 3, ("あ" + b).match(Regexp.new(b)).pre_match.bytesize
   # Where such a byte opens a match position is a question about the byte, so
-  # a byte-indexed subject asks it too, and there #begin is a byte offset that
-  # needs no pre_match to read.
+  # the subjects below are byte-indexed: there #begin is a byte offset, which
+  # is what pre_match used to be needed for.
+  b = "\x81"
   assert_equal 0, (b + b).b.match(Regexp.new(b + b)).begin(0)
   assert_equal 2, (b + b).b.match(Regexp.new(b + "+"))[0].bytesize
   assert_equal 2, (b + b).b.match(Regexp.new(b + "*"))[0].bytesize
   assert_equal 1, (b + b).b.match(Regexp.new(b + "?"))[0].bytesize
   assert_equal 1, ("x" + b + b).b.match(Regexp.new(b + "+")).begin(0)
+  # Next to one there is a match position too.
   assert_equal 0, (b + "あ").b.match(Regexp.new(b)).begin(0)
+  # Inside a character there is none, on a subject that is whole UTF-8 and
+  # reaches the engine as it always did.
+  assert_nil "あ".match(Regexp.new("\x81"))
+  assert_nil "あ".match(Regexp.new("\x82"))
+  assert_nil "\u{1D54F}".match(Regexp.new("\x95"))
 end
 
 assert("Regexp - an attempt in flight opens no match position inside a character") do
@@ -199,11 +186,9 @@ assert("Regexp - an attempt in flight opens no match position inside a character
   assert_equal 5, ("あ" + "µ").match(/.?[µ]/)[0].bytesize
   # And so is a byte where no lead byte reaches it, through a class that holds
   # the byte. [µ] holds the character, whose trailing byte alone is not it.
-  assert_equal 2, ("x" + "\xb5").match(Regexp.new(".?[\xb5]"))[0].bytesize
-  assert_nil ("x" + "\xb5").match(/.?[µ]/)
-  # Byte-indexed the class holds that byte just the same, and the thread `.?`
-  # parks past it is stepped by the engine's byte-indexed branch. A class that
-  # holds the character rather than the byte still does not hold it.
+  # That subject is byte-indexed, where the thread `.?` parks past the byte is
+  # stepped by the engine's own branch for one. A class that holds the
+  # character rather than the byte still does not hold it.
   assert_equal 2, ("x" + "\xb5").b.match(Regexp.new(".?[\xb5]"))[0].bytesize
   assert_nil ("x" + "\xb5").b.match(/.?[µ]/)
 end
@@ -279,20 +264,16 @@ assert("Regexp - a match does not end inside a character") do
   # A lookaround ends at a position without consuming it, so it is not the
   # end of the match and keeps its own answer.
   assert_equal 2, j.match(Regexp.new("(?=\xc4)\xc4\xb5"))[0].bytesize
-  # A byte no lead byte reaches is a boundary, so a byte pattern still works.
-  b = "\x81"
-  assert_equal 1, (b + b).match(Regexp.new(b))[0].bytesize
-  assert_equal 2, (b + b).match(Regexp.new(b + "+"))[0].bytesize
-  assert_equal 1, ("a" + b).match(Regexp.new(b))[0].bytesize
   # Read as binary every position is a boundary, so nothing changes there.
   if Object.const_defined?(:Encoding)
     bin = j.dup.force_encoding("ASCII-8BIT")
     assert_equal 1, bin.match(Regexp.new("\xc4"))[0].bytesize
     assert_equal 2, bin.match(Regexp.new("\xc4."))[0].bytesize
   end
-  # A byte no lead byte reaches is a boundary there too, so the three answers
-  # above hold for a byte-indexed subject, whose own indexing agrees with the
-  # byte counts they report.
+  # A byte no lead byte reaches is a boundary too, so a byte pattern works
+  # there as well, on a byte-indexed subject whose own indexing agrees with
+  # the byte counts below.
+  b = "\x81"
   assert_equal 1, (b + b).b.match(Regexp.new(b))[0].bytesize
   assert_equal 2, (b + b).b.match(Regexp.new(b + "+"))[0].bytesize
   assert_equal 1, ("a" + b).b.match(Regexp.new(b))[0].bytesize
@@ -423,20 +404,18 @@ assert("Regexp - invalid UTF-8 byte near pattern end") do
   # past the end of the pattern buffer
   re = Regexp.new("[   \xff ]")
   assert_kind_of Regexp, re
-  assert_equal 0, (re =~ "\xff")
   assert_nil (re =~ "x")
-  # The byte reaches the class the same way from a byte-indexed subject, which
-  # the engine walks through a branch of its own.
+  # The subject is byte-indexed, where the engine walks the class through a
+  # branch of its own.
   assert_equal 0, (re =~ "\xff".b)
 end
 
 assert("Regexp - truncated UTF-8 at subject end") do
   # a lone multi-byte leader at the end of the subject must not read
-  # past the end of the string buffer when matched against a class
-  assert_nil ("ab\xf0" =~ /[cd]/)
-  assert_equal 0, ("ab\xf0" =~ /[^cd]+$/)
-  # Byte-indexed the leader is a byte of its own, so the walk that reaches the
-  # end of the buffer is a different one and must stay inside it too.
+  # past the end of the string buffer when matched against a class. As UTF-8
+  # that subject no longer reaches the engine at all, which is the stronger
+  # guard; byte-indexed it does, and the walk that reaches the end of the
+  # buffer there is one the engine still has to keep inside it.
   assert_nil ("ab\xf0".b =~ /[cd]/)
   assert_equal 0, ("ab\xf0".b =~ /[^cd]+$/)
 end
@@ -445,23 +424,27 @@ assert("Regexp - overlong UTF-8 is not the character it spells") do
   # C0 BC is the two-byte overlong spelling of "<" and E0 84 80 the three-byte
   # spelling of "Ā". A decoder that hands out a codepoint for these would let a
   # class hold a character the subject does not spell, so assert the class and
-  # the literal together against the same subject.
-  assert_nil ("\xC0\xBC" =~ /[<]/)
-  assert_nil ("\xC0\xBC" =~ /</)
-  assert_equal 0, ("\xC0\xBC" =~ /[^<]/)
-  assert_equal "\xC0\xBC", "\xC0\xBC".gsub(/[<]/, "&lt;")
-  assert_nil ("\xE0\x80\xBC" =~ /[<]/)
-  assert_false Regexp.new("[Ā]").match?("\xE0\x84\x80")
-  assert_false (/Ā/.match?("\xE0\x84\x80"))
-  # the pattern side decodes through the same helper
+  # the literal together against the same subject. RFC 3629 puts these
+  # sequences outside UTF-8, so the subjects below are byte-indexed, which is
+  # where the decode has to answer anyway: the class must hold no character
+  # the bytes do not spell, whichever way the subject is indexed.
+  assert_nil ("\xC0\xBC".b =~ /[<]/)
+  assert_nil ("\xC0\xBC".b =~ /</)
+  assert_equal 0, ("\xC0\xBC".b =~ /[^<]/)
+  assert_equal "\xC0\xBC".b, "\xC0\xBC".b.gsub(/[<]/, "&lt;")
+  assert_nil ("\xE0\x80\xBC".b =~ /[<]/)
+  assert_false Regexp.new("[Ā]").match?("\xE0\x84\x80".b)
+  assert_false (/Ā/.match?("\xE0\x84\x80".b))
+  # the pattern side decodes through the same helper, and its subject here is
+  # whole UTF-8
   assert_false Regexp.new("[\xC0\xBC]").match?("<")
   # surrogates and codepoints above U+10FFFF encode no character either, so
   # each byte stands on its own
-  assert_equal 2, "\xC0\xBC".scan(/./).size
-  assert_equal 3, "\xED\xA0\x80".scan(/./).size
-  assert_equal 4, "\xF0\x80\x80\xBC".scan(/./).size
-  assert_equal 4, "\xF4\x90\x80\x80".scan(/./).size
-  assert_equal 4, "\xF5\x80\x80\x80".scan(/./).size
+  assert_equal 2, "\xC0\xBC".b.scan(/./).size
+  assert_equal 3, "\xED\xA0\x80".b.scan(/./).size
+  assert_equal 4, "\xF0\x80\x80\xBC".b.scan(/./).size
+  assert_equal 4, "\xF4\x90\x80\x80".b.scan(/./).size
+  assert_equal 4, "\xF5\x80\x80\x80".b.scan(/./).size
   # the shortest spelling on each side of those bounds is still one character
   assert_equal 1, "\u{0080}".scan(/./).size    # C2 80
   assert_equal 1, "\u{0800}".scan(/./).size    # E0 A0 80
@@ -471,21 +454,6 @@ assert("Regexp - overlong UTF-8 is not the character it spells") do
   assert_equal 1, "\u{10FFFF}".scan(/./).size  # F4 8F BF BF
   assert_equal 0, ("\u{0800}" =~ Regexp.new("[\u{0800}]"))
   assert_equal 0, ("\u{10FFFF}" =~ Regexp.new("[\u{10FFFF}]"))
-  # None of this turns on how the subject is indexed: a byte-indexed one is
-  # decoded a byte at a time, so an overlong sequence is no more the character
-  # it spells there, and the answers are the same through that branch.
-  assert_nil ("\xC0\xBC".b =~ /[<]/)
-  assert_nil ("\xC0\xBC".b =~ /</)
-  assert_equal 0, ("\xC0\xBC".b =~ /[^<]/)
-  assert_equal "\xC0\xBC".b, "\xC0\xBC".b.gsub(/[<]/, "&lt;")
-  assert_nil ("\xE0\x80\xBC".b =~ /[<]/)
-  assert_false Regexp.new("[Ā]").match?("\xE0\x84\x80".b)
-  assert_false (/Ā/.match?("\xE0\x84\x80".b))
-  assert_equal 2, "\xC0\xBC".b.scan(/./).size
-  assert_equal 3, "\xED\xA0\x80".b.scan(/./).size
-  assert_equal 4, "\xF0\x80\x80\xBC".b.scan(/./).size
-  assert_equal 4, "\xF4\x90\x80\x80".b.scan(/./).size
-  assert_equal 4, "\xF5\x80\x80\x80".b.scan(/./).size
 end
 
 assert("Regexp - a pattern byte that starts no character is a byte in a class") do
@@ -494,25 +462,27 @@ assert("Regexp - a pattern byte that starts no character is a byte in a class") 
   # meant two things depending on which side of the brackets it was written.
   # CRuby settles it with the pattern's encoding and raises RegexpError for
   # either spelling; this gem has no encoding to consult, so it reads the byte
-  # as the byte on both sides.
+  # as the byte on both sides. Which of the two a class holds belongs to the
+  # pattern, and a subject that is one such byte is byte-indexed below, where
+  # the byte is a byte on the subject side too.
   mu = "\xC2\xB5"  # U+00B5 MICRO SIGN, two bytes
   assert_nil (mu =~ Regexp.new("[\xB5]"))
   assert_nil (mu =~ Regexp.new("\xB5"))
   assert_equal mu.bytes, mu.gsub(Regexp.new("[\xB5]"), "!").bytes
   assert_equal mu.bytes, mu.gsub(Regexp.new("\xB5"), "!").bytes
-  assert_equal 0, ("\xB5" =~ Regexp.new("[\xB5]"))       # the byte alone is it
-  assert_equal 1, (mu.b =~ Regexp.new("[\xB5]"))         # so is a byte subject
+  assert_equal 0, ("\xB5".b =~ Regexp.new("[\xB5]"))     # the byte alone is it
+  assert_equal 1, (mu.b =~ Regexp.new("[\xB5]"))         # and so is one inside
   assert_equal 0, (mu =~ Regexp.new("[^\xB5]"))
   # An escape names a byte too, which is what the literal path emits for it.
   assert_nil (mu =~ Regexp.new("[\\xB5]"))
-  assert_equal 0, ("\xB5" =~ Regexp.new("[\\xB5]"))
+  assert_equal 0, ("\xB5".b =~ Regexp.new("[\\xB5]"))
   # `\u` names a codepoint outright, so it is how the character gets spelled
   # where the byte of the same number will not do.
   assert_equal 0, (mu =~ Regexp.new("[\\u{B5}]"))
-  assert_nil ("\xB5" =~ Regexp.new("[\\u{B5}]"))
+  assert_nil ("\xB5".b =~ Regexp.new("[\\u{B5}]"))
   # An invalid leader is a byte on both sides for the same reason, which is
   # what "overlong UTF-8 is not the character it spells" pins for the class.
-  assert_equal 0, ("\xC0" =~ Regexp.new("[\xC0]"))
+  assert_equal 0, ("\xC0".b =~ Regexp.new("[\xC0]"))
   assert_nil ("À" =~ Regexp.new("[\xC0]"))               # C3 80
   # A byte range is how a continuation byte gets spelled, and it stays a range
   # of bytes: it holds no character of its own.
@@ -525,16 +495,8 @@ assert("Regexp - a pattern byte that starts no character is a byte in a class") 
   assert_raise(RegexpError) { Regexp.new("[µ-\x80]") }
   assert_raise(RegexpError) { Regexp.new("[\\u{B5}-\\xBF]") }
   # ASCII belongs to both, so it pairs with either.
-  assert_equal 0, ("\xFF" =~ Regexp.new("[\x00-\xFF]"))
-  assert_equal 0, ("µ" =~ Regexp.new("[\x00-\u{FF}]"))
-  # Which of the two a class holds belongs to the pattern, so a subject that
-  # is one such byte answers the same read as bytes, through the branch the
-  # engine keeps for a subject indexed that way.
-  assert_equal 0, ("\xB5".b =~ Regexp.new("[\xB5]"))
-  assert_equal 0, ("\xB5".b =~ Regexp.new("[\\xB5]"))
-  assert_nil ("\xB5".b =~ Regexp.new("[\\u{B5}]"))
-  assert_equal 0, ("\xC0".b =~ Regexp.new("[\xC0]"))
   assert_equal 0, ("\xFF".b =~ Regexp.new("[\x00-\xFF]"))
+  assert_equal 0, ("µ" =~ Regexp.new("[\x00-\u{FF}]"))
 end
 
 assert("Regexp - /i over a class of bytes asks for no case data") do


### PR DESCRIPTION
Third of the pieces #7110 was split into, on top of #7115 and #7116, and test
only. Deleting assertions deserves its own pull request rather than a paragraph
inside one that changes behaviour, so here it is on its own.

Each of these cases asks what the engine does with a byte that stands for no
character, and since #7115 and #7116 it asks twice: once through a subject read
as UTF-8 that carries the byte, and once through a byte-indexed subject.

### Only one of the two subjects can answer

Read as UTF-8, the subject spells no character where that byte is. What a
quantifier binds to there, whether a class holds the byte, and where a match may
start are then answers about a decoder walking input no rule covers.

Byte-indexed, the same byte is a byte from end to end, every position reported is
a byte offset the subject's own indexing agrees with, and the engine reaches it
through the branch it keeps for exactly that: `mrb_re_charlen()` and
`mrb_re_decode_char()` advance a byte at a time, and the seeding guard skips
`mrb_re_utf8_interior_p()`, so no position is the interior of anything.

### What this does

Drops the UTF-8 subject from those cases and keeps the byte-indexed one. The
comment that explained each case moves to the assertion that still makes it,
which is most of what the diff shows as added.

Nothing a whole UTF-8 subject can ask is touched:

- a match position inside a character (`"あ".match(Regexp.new("\x81"))` and the
  `"ĵ"` cases) keeps its subject
- a class that holds a character rather than a byte (`mu =~ /[\xB5]/` and the
  `\u{B5}` spellings) keeps its subject
- the pattern side of an overlong sequence
  (`Regexp.new("[\xC0\xBC]").match?("<")`) keeps its subject
- `Regexp - match positions on malformed UTF-8 agree with string indexing` is
  left exactly as it is: what it pins is what mruby knows about the string
  rather than what the engine does with the bytes, so it belongs with the piece
  that changes its answer

The fuzz-derived buffer cases (`Regexp - invalid UTF-8 byte near pattern end`
and `Regexp - truncated UTF-8 at subject end`) keep a walk to the end of each
buffer, in the byte-indexed form #7116 added.

### Verified

- `rake test` on a full-core build (`MRB_UTF8_STRING` through mruby-encoding):
  2253 tests, all green
- `rake test` on the default gembox (no `MRB_UTF8_STRING`): 2060 tests, all
  green
- `prek run --all-files` passes, except that `markdownlint` could not install
  locally (npm engine mismatch); no Markdown is touched here


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded UTF-8 regular expression coverage for malformed, truncated, overlong, and invalid sequences.
  * Added validation for byte-based match positions, extraction offsets, character classes, and quantifier boundaries.
  * Improved coverage of decoding boundaries in both patterns and input text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->