### PR TITLE
string.c: read String#chop! back from the last byte

### DIFF
--- a/mrbgems/mruby-string-ext/test/string.rb
+++ b/mrbgems/mruby-string-ext/test/string.rb
@@ -891,8 +891,8 @@ assert('String#each_char(UTF-8)') do
 end if UTF8STRING
 
 assert('String#chop! on a binary string removes one byte') do
-  # `chop!` walks to the last character, and a byte-indexed string ends in a
-  # byte rather than in a character. Walking it as UTF-8 took the whole of a
+  # `chop!` cuts at the last character, and a byte-indexed string ends in a
+  # byte rather than in a character. Reading it as UTF-8 took the whole of a
   # multi-byte sequence off, or all of a string that held only one.
   if UTF8STRING
     s = "\u{1F600}".b   # F0 9F 98 80: four bytes, one character

--- a/src/string.c
+++ b/src/string.c
@@ -2045,14 +2045,12 @@ mrb_str_chop_bang(mrb_state *mrb, mrb_value str)
       len = RSTR_LEN(s) - 1;
     }
     else {
-      const char* t = RSTR_PTR(s), *p = t;
-      const char* e = p + RSTR_LEN(s);
-      while (p<e) {
-        mrb_int clen = mrb_utf8len(p, e);
-        if (p + clen>=e) break;
-        p += clen;
-      }
-      len = p - t;
+      /* The last character starts at the head of the one covering the last
+         byte, which is read backwards from there rather than by walking the
+         whole string. */
+      const char* t = RSTR_PTR(s);
+      const char* e = t + RSTR_LEN(s);
+      len = mrb_utf8_char_head(t, e-1, e) - t;
     }
 #else
     len = RSTR_LEN(s) - 1;

--- a/test/t/string.rb
+++ b/test/t/string.rb
@@ -403,6 +403,22 @@ assert('String#chop!(UTF-8)', '15.2.10.5.12') do
   assert_equal c, 'あいう'
 end if UTF8STRING
 
+assert('String#chop! cuts where String#length counts a character') do
+  # The last character starts where the character covering the last byte
+  # starts, and a byte that no lead byte reaches is a character of its own.
+  assert_equal "あ", "あ\x82".chop
+  assert_equal "\x80\x80", "\x80\x80\x80".chop
+  # A sequence RFC 3629 forbids spells no character, so its bytes stand alone.
+  assert_equal "\xC0", "\xC0\x80".chop
+  assert_equal "\xED\xA0", "\xED\xA0\x80".chop
+  # A lead byte the string end cuts short reaches none of the bytes after it.
+  assert_equal "a\xE3", "a\xE3\x81".chop
+  # a whole character still goes at once, however many bytes it spells
+  assert_equal "", "\u{1F600}".chop
+  # and the \r\n pair is still taken together after one
+  assert_equal "あ", "あ\r\n".chop
+end if UTF8STRING
+
 assert('String#downcase', '15.2.10.5.13') do
   a = 'ABC'.downcase
   b = 'ABC'


### PR DESCRIPTION
## Problem

`String#chop!` finds the start of the last character by walking the whole string
from the front, one character at a time. That is O(n) for a single call and
quadratic for a loop that chops a string down. An ASCII receiver pays it too,
since the walk is not skipped for one.

```c
const char* t = RSTR_PTR(s), *p = t;
const char* e = p + RSTR_LEN(s);
while (p<e) {
  mrb_int clen = mrb_utf8len(p, e);
  if (p + clen>=e) break;
  p += clen;
}
len = p - t;
```

## Change

`mrb_utf8_char_head()` answers the same question from the other end, reading back
at most three bytes, since nothing longer than four bytes spells a character.

```c
const char* t = RSTR_PTR(s);
const char* e = t + RSTR_LEN(s);
len = mrb_utf8_char_head(t, e-1, e) - t;
```

`str_char_rindex()` and `mrb_str_rindex_m()` already read a boundary this way.
The byte-indexed branch and the `\r\n` pair are untouched.

## Why the two agree

Every byte after a lead byte inside a multi-byte character is a continuation
byte, since that is what `mrb_utf8len()` requires before it answers more than 1.
So the front walk can step over neither a lead byte nor a stray continuation
byte: it lands on each of them, and those are exactly the boundaries
`mrb_utf8_char_head()` reads back to. Whether a lead byte reaches a given
continuation byte is `mrb_utf8len()`'s answer on both sides, so an overlong
sequence, a surrogate, and a lead byte the string end cuts short are read the
same way by either.

Checked as well as argued. With both functions lifted into a standalone harness,
the old and new cuts agree on all 137,560 strings of length 1 to 4 over 19 bytes
chosen at the interesting boundaries (0x80, 0x8F, 0x90, 0x9F, 0xA0, 0xBF, 0xC0,
0xC1, 0xE0, 0xED, 0xF0, 0xF4, 0xF5, 0xFF among them) and on 2,000,000 random
byte strings of length 1 to 12. The same cases were then run through builds of
`bin/mruby` from before and after, byte for byte.

## Measurements

gcc 13.3.0, `-O3`, x86_64, `full-core` gembox with `MRB_UTF8_STRING`.

| | before | after |
|---|---|---|
| `s.chop` 1000 times, `s` = 100k characters (300 KB) | 0.410 s | 0.135 s |
| `s.chop!` 20,000 times down a 20k-character string | 0.538 s | 0.001 s |
| `s.chop` 1000 times, `s` = 90 KB of ASCII | 0.237 s | 0.009 s |
| `s.chop!` 20,000 times down 20 KB of ASCII | 0.508 s | 0.001 s |

The first row still carries the copy `chop` makes, which is most of what is
left of it.

## Tests

`String#chop!` had no case ending in a byte that spells no character, so one is
added in the commit before the change and passes on both sides of it: a stray
continuation byte, a string of nothing else, an overlong sequence and a
surrogate RFC 3629 forbids, and a truncated lead byte, next to a four-byte
character and the `\r\n` pair.

`rake test` with the config above: 2255 examples, 0 failures, 0 crashes. The
default host config passes its unit tests too (2061 examples, 0 failures); the
`bintest` failure it shows there (`uninitialized constant digits::other_excl`,
from `mruby-range-ext`) is present on an untouched tree and unrelated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `String#chop!` handling for UTF-8 strings, including invalid, truncated, and multibyte character sequences.
  * Preserved correct byte-based behavior for binary strings and non-UTF-8 configurations.
  * Ensured CRLF endings continue to be handled correctly.

* **Tests**
  * Added coverage for UTF-8 edge cases and standalone continuation bytes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->