### PR TITLE
boxing_nan.h: keep `nil` out of `mrb_false_p`

### DIFF
--- a/include/mruby/boxing_nan.h
+++ b/include/mruby/boxing_nan.h
@@ -164,7 +164,9 @@ MRB_API mrb_value mrb_boxing_int_value(mrb_state*, mrb_int);
 
 #define mrb_immediate_p(o) ((mrb_float_p(o) || mrb_nb_tt(o) != MRB_NANBOX_TT_OBJECT) || (o).u == 0)
 #define mrb_nil_p(o)  ((o).u == 0)
-#define mrb_false_p(o) (mrb_type(o) == MRB_TT_FALSE || (o).u == 0)
+/* `mrb_type` reports `MRB_TT_FALSE` for `nil` too, so the `nil` case has to be
+ * excluded here; the other boxings keep `nil` out of `mrb_false_p` as well. */
+#define mrb_false_p(o) (!mrb_nil_p(o) && mrb_type(o) == MRB_TT_FALSE)
 #define mrb_fixnum_p(o) (!mrb_float_p(o) && mrb_nb_tt(o)==MRB_NANBOX_TT_INTEGER)
 
 #endif  /* MRUBY_BOXING_NAN_H */

--- a/mrbgems/mruby-class-ext/test/module.rb
+++ b/mrbgems/mruby-class-ext/test/module.rb
@@ -52,6 +52,33 @@ assert 'Module#<=' do
   assert_raise(TypeError) { a <= Object.new }
 end
 
+assert 'Module#<=>' do
+  a = Class.new
+  b = Class.new(a)
+  c = Class.new(a)
+  d = Module.new
+  e = Class.new { include d }
+  f = Module.new { include d }
+
+  # compare class to class
+  assert_equal 0, a <=> a
+  assert_equal(-1, b <=> a)
+  assert_equal 1, a <=> b
+  assert_nil c <=> b
+
+  # compare class to module
+  assert_equal(-1, e <=> d)
+  assert_equal 1, d <=> e
+  assert_nil a <=> d
+
+  # compare module to module
+  assert_equal(-1, f <=> d)
+  assert_equal 1, d <=> f
+  assert_nil a <=> f
+
+  assert_nil a <=> Object.new
+end
+
 assert 'Module#name' do
   module Outer
     class Inner; end


### PR DESCRIPTION
`mrb_false_p` is true for `nil` under NaN boxing, so C code that tells `nil` apart from `false` behaves differently there than under the other two boxings.

## The macro

```c
#define mrb_nil_p(o)  ((o).u == 0)
#define mrb_false_p(o) (mrb_type(o) == MRB_TT_FALSE || (o).u == 0)
```

`nil` is `u == 0`, and `mrb_type` already returns `MRB_TT_FALSE` for it in the `MRB_NANBOX_TT_OBJECT` arm, so both operands match `nil`. The other two boxings keep `nil` out:

```c
/* boxing_word.h */
#define mrb_false_p(o) ((o).w == MRB_Qfalse)
/* value.h, no boxing */
#define mrb_false_p(o) (mrb_type(o) == MRB_TT_FALSE && !!mrb_fixnum(o))
```

## What it reaches

Five call sites branch on `mrb_false_p`, and all of them mean "exactly `false`":

- `mrbgems/mruby-class-ext/src/class.c` (`mrb_mod_cmp`)
- `mrbgems/mruby-string-bitops/src/string_bitops.c` (`bitop_scan_offset`)
- `mrbgems/mruby-exit/src/mruby_exit.c` (`get_status`)
- `mrbgems/mruby-socket/src/socket.c` (`mrb_socket_setsockopt`)
- `mrbgems/mruby-regexp/src/regexp.c` (`regexp_check_pattern`, which tests `mrb_nil_p` first and so is unaffected)

`Module#<=>` shows it from Ruby. `mod_compare_hierarchy` returns `nil` for two unrelated modules, and `mrb_mod_cmp` read that `nil` as `false`, which is its "self is an ancestor of other" branch:

```ruby
a = Class.new
b = Class.new(a)
c = Class.new(a)
c <=> b  #=> nil, but 1 under MRB_NAN_BOXING
```

`mruby-string-bitops` already has a test for its side, so `master` fails three assertions on a NaN boxing build:

```
Fail: String#bit_get (mrbgems: mruby-string-bitops)
 - Assertion[9]
    ArgumentError expected but nothing was raised.
Fail: String#bit_set? (mrbgems: mruby-string-bitops)
 - Assertion[9]
    ArgumentError expected but nothing was raised.
Fail: String#bit_set, #bit_clear, #bit_flip (mrbgems: mruby-string-bitops)
 - Assertion[19]
    ArgumentError expected but nothing was raised.
```

That is `bit_get(0, lsb_first: nil)` taking the `false` branch instead of raising `ArgumentError`.

## The change

`mrb_false_p` now excludes `nil`, matching the other two boxings. `mruby-class-ext` had no `Module#<=>` test at all, so this adds one next to the existing `Module#<` and `Module#<=` tests, following their setup.

## Testing

`rake test` is green on `full-core` builds covering the three boxings against both `MRB_INT64` and `MRB_INT32`, and on `build_config/ci/gcc-clang.rb`. Before the change, the same NaN boxing builds fail the three `mruby-string-bitops` assertions above plus the new `Module#<=>` one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved boolean checks so `nil` is no longer incorrectly treated as `false`.

- **Tests**
  - Added coverage for module and class comparisons, including inheritance, inclusion, identical and unrelated objects, and invalid comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->