### PR TITLE
mruby-regexp: measure a lookbehind in the characters its bytes spell

### DIFF
--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -838,14 +838,25 @@ compute_fixed_len(re_compiler *c, uint32_t start, uint32_t end, int *chars_out)
   while (pc < end) {
     re_inst inst = c->code[pc];
     switch (inst.op) {
-    case RE_CHAR:
-      /* a multibyte literal is a run of one-byte RE_CHAR instructions,
-         so each one is exactly one byte by construction, and the run is
-         one character per lead byte in it */
-      len += 1;
-      if ((inst.a & 0xC0) != 0x80) chars += 1;
-      pc++;
+    case RE_CHAR: {
+      /* A multibyte literal is a run of one-byte RE_CHAR instructions, and
+         what a byte spells depends on the bytes after it, so hand the run to
+         mrb_utf8len rather than read the lead bit alone: a continuation byte
+         no lead reaches is a character of its own, which is the rule the
+         executor rewinds by. Four bytes is the longest character there is,
+         and a run never splits one. */
+      char buf[4];
+      int n = 0;
+      while (n < 4 && pc + (uint32_t)n < end && c->code[pc + n].op == RE_CHAR) {
+        buf[n] = (char)c->code[pc + n].a;
+        n++;
+      }
+      int clen = (int)mrb_utf8len(buf, buf + n);
+      len += clen;
+      chars += 1;
+      pc += (uint32_t)clen;
       break;
+    }
     case RE_CLASS:
     case RE_NCLASS:
     case RE_ANY:

--- a/mrbgems/mruby-regexp/test/regexp_syntax.rb
+++ b/mrbgems/mruby-regexp/test/regexp_syntax.rb
@@ -795,6 +795,28 @@ assert("Regexp - lookbehind against a binary subject rewinds by bytes") do
   assert_equal "x", bin.match(/(?<=.)x/)[0]
 end
 
+assert("Regexp - lookbehind measures bytes that spell no character") do
+  # A byte no lead byte reaches is a character of its own, which is what the
+  # rewind steps back over, so the width has to count it as one. Counting the
+  # lead bytes of the run alone made such a byte part of the character before
+  # it, rewound too little, and the lookbehind then failed on text it
+  # describes, or succeeded where the negative form describes it.
+  assert_equal 2, ("\x80ab" =~ /(?<=\x80a)b/)
+  assert_nil ("\x80ab" =~ /(?<!\x80a)b/)
+  assert_nil ("ab" =~ /(?<=\x80a)b/)
+  # a sequence cut short spells no character either, so each of its bytes is
+  # one: E3 leads three bytes and only two follow it here
+  assert_equal 3, ("\xE3\x81ab" =~ /(?<=\xE3\x81a)b/)
+  # the same bytes written into the pattern rather than escaped
+  assert_equal 2, ("\x80ab" =~ Regexp.new("(?<=\x80a)b"))
+  # a byte-indexed subject counts the same bytes, and rewinds by them
+  assert_equal 2, ("\x80ab".b =~ Regexp.new("(?<=\x80a)b"))
+  assert_equal 3, ("\xE3\x81ab".b =~ Regexp.new("(?<=\xE3\x81a)b"))
+  # a whole character is still one whatever its byte count
+  assert_equal "b", "Āab".match(/(?<=Āa)b/)[0]
+  assert_nil "aab".match(/(?<=Āa)b/)
+end
+
 assert("Regexp - lookbehind measures an ASCII-only class") do
   assert_equal "x", "ax".match(/(?<=[a-z])x/)[0]
   assert_nil "1x".match(/(?<=[a-z])x/)


### PR DESCRIPTION
## Problem

`compute_fixed_len()` measures a lookbehind twice: in bytes for a byte-indexed
subject, and in characters for a UTF-8 one. The character count came from the
lead bytes of the `RE_CHAR` run, so a byte matching 10xxxxxx counted as zero.

The executor rewinds by another rule. `lookbehind_start()` steps back through
`mrb_re_utf8_interior_p()`, which asks `mrb_utf8_char_head()`, and there a
continuation byte that no lead byte reaches is a character of its own, the rule
`String` indexing walks by too. A lookbehind over bytes that spell no character
therefore rewound too little and began the sub-pattern past its own text.

```ruby
s = "\x80ab"
s =~ /\x80ab/                      # => 0, those bytes do match as a literal
s =~ /(?<=\x80a)b/                 # => nil, expected 2
s =~ /(?<!\x80a)b/                 # => 2, expected nil
"\xE3\x81ab" =~ /(?<=\xE3\x81a)b/  # => nil, expected 3
```

The negative form fails the other way around: it reports a match where the text
it refuses is present.

The byte count was right all along, so the same compiled pattern answered
differently depending on how the subject is indexed:

```ruby
"\x80ab".b =~ Regexp.new("(?<=\x80a)b")          # => 2
"\xE3\x81ab".b =~ Regexp.new("(?<=\xE3\x81a)b")  # => 3
```

## What CRuby says

CRuby (4.0.6) never reaches this measurement, because two earlier gates stop it:

```ruby
Regexp.new("(?<=\x80a)b")   # RegexpError: invalid multibyte character
"\x80ab" =~ /b/             # ArgumentError: invalid byte sequence in UTF-8
```

The first refuses a pattern holding bytes that spell no character, the second a
subject holding them, whatever the pattern. The one configuration it does run is
binary on both sides, and there it answers exactly what the byte count here
answers:

```ruby
"\x80ab".b =~ Regexp.new("(?<=\x80a)b".b)          # => 2
"\x80ab".b =~ Regexp.new("(?<!\x80a)b".b)          # => nil
"\xE3\x81ab".b =~ Regexp.new("(?<=\xE3\x81a)b".b)  # => 3
```

This engine carries no such refusal, so it answers where CRuby raises, and the
two units it measures the same lookbehind with have to agree on that answer.
They now do, on the value CRuby gives in the comparable configuration. The
control with a whole character agrees too: `"\u{100}ab" =~ /(?<=\u{100}a)b/` is
2 in CRuby and on an `MRB_UTF8_STRING` build, and a byte-indexed build reports
its byte offset there as it does everywhere. Whether the refusal itself belongs
in this engine is a separate question, untouched here.

## Fix

Gather the run of `RE_CHAR` instructions into a four byte window and step it
with `mrb_utf8len()`, which is what the rewind's `mrb_utf8_char_head()` agrees
with. Four bytes is the longest character there is, and a run never splits one
because `emit_char_bytes()` emits every byte of a character, so the window
reaches whatever character starts at the instruction. The inline
`(inst.a & 0xC0) != 0x80` test goes away with it, and the byte count keeps
coming out of the same walk.

A pattern whose bytes spell whole characters is unaffected: the run still
advances one character per lead byte.

## Tests

`mrbgems/mruby-regexp/test/regexp_syntax.rb` gains nine assertions beside the
other lookbehind width tests: a stray continuation byte, a sequence cut short,
the escaped and the raw spelling of the same pattern, the byte-indexed subject
that already answered correctly, and a whole multibyte character as the control.
Four of them fail before the change.

```
Fail: Regexp - lookbehind measures bytes that spell no character
 - Assertion[1]  Expected: 2 / Actual: nil
 - Assertion[2]  Expected 2 to be nil.
 - Assertion[4]  Expected: 3 / Actual: nil
 - Assertion[5]  Expected: 2 / Actual: nil
```

The offsets asserted are the ones both builds agree on, and the case involving a
whole multibyte character asserts the matched text instead of a position, so the
file needs no build guard.

`rake test` is green on the default build (2062 assertions, 105 bintests) and on
a `full-core` build, which carries `MRB_UTF8_STRING` (2255 assertions).
