### PR TITLE
mruby-regexp: exempt a quoted String pattern from the subject check

### DIFF
--- a/mrbgems/mruby-regexp/mrblib/string_regexp.rb
+++ b/mrbgems/mruby-regexp/mrblib/string_regexp.rb
@@ -115,12 +115,17 @@ class String
     # get_pat.  Only the quoting is taken from it: get_pat_quoted also accepts
     # anything answering `to_str`, where `__check_pattern` keeps to a real
     # String, as `match` already does.
-    pattern = Regexp.new(Regexp.escape(pattern)) if String === pattern
+    literal = String === pattern
+    # CRuby searches for a literal byte by byte and never reads the subject as
+    # UTF-8 on the way, so quoting one into a Regexp here must not put the
+    # subject through a check CRuby does not make: `"a\x80b".sub("b", "!")`
+    # answers there, where the same call with `/b/` is refused.
+    pattern = Regexp.new(Regexp.escape(pattern)) if literal
     # A replacement argument wins over the block, as in CRuby.
     if args.length == 2
-      return Regexp.__sub_str(pattern, self, replacement.to_s)
+      return Regexp.__sub_str(pattern, self, replacement.to_s, literal)
     end
-    md = Regexp.__search(pattern, self)
+    md = Regexp.__search(pattern, self, 0, literal)
     return self.dup unless md
     md.pre_match + block.call(md[0]).to_s + md.post_match
   end
@@ -141,19 +146,23 @@ class String
     # Resolved here rather than left to `sub` because the match below decides
     # the return value, and a String pattern is a literal on both paths.
     pattern = Regexp.__check_pattern(args[0])
-    pattern = Regexp.new(Regexp.escape(pattern)) if String === pattern
+    literal = String === pattern
+    pattern = Regexp.new(Regexp.escape(pattern)) if literal
     raise FrozenError, "can't modify frozen String" if frozen?
     # Whether a substitution happened is a question about the match, not about
     # the result: `"aaa".sub!(/a/, "a")` returns self even though the string is
     # unchanged.  A full search and not `match?`, so a failed match clears $~.
-    return nil unless Regexp.__search(pattern, self)
+    return nil unless Regexp.__search(pattern, self, 0, literal)
     # `sub` matches again and publishes its own $~ over this one, leaving the
     # caller the match `sub` would have left, a block's own matches included.
     # The resolved pattern takes the place of the original argument so that a
-    # String is not quoted and compiled a second time.  Overwriting `self`
-    # afterwards is safe: a MatchData snapshots its subject, so $~ keeps
-    # describing the string as it was matched.
-    str = args.length == 2 ? self.sub(pattern, args[1], &block) : self.sub(pattern, &block)
+    # String is not quoted and compiled a second time; a literal goes down as
+    # the String it was instead, since that is what tells `sub` to leave the
+    # subject unread, and quoting it twice is the price of saying so.
+    # Overwriting `self` afterwards is safe: a MatchData snapshots its subject,
+    # so $~ keeps describing the string as it was matched.
+    down = literal ? args[0] : pattern
+    str = args.length == 2 ? self.sub(down, args[1], &block) : self.sub(down, &block)
     self.replace(str)
   end
 
@@ -169,10 +178,13 @@ class String
     # After the to_enum return above, so that `"abc".gsub(:b)` yields an
     # Enumerator and raises on the first iteration, as CRuby does.
     pattern = Regexp.__check_pattern(pattern)
-    pattern = Regexp.new(Regexp.escape(pattern)) if String === pattern
+    # A String pattern is a literal, as in `sub`, and reaches the subject the
+    # way CRuby reaches it: byte by byte, with no reading of it as UTF-8.
+    literal = String === pattern
+    pattern = Regexp.new(Regexp.escape(pattern)) if literal
     # A replacement argument wins over the block, as in CRuby.
     if args.length == 2
-      return Regexp.__gsub_str(pattern, self, replacement.to_s)
+      return Regexp.__gsub_str(pattern, self, replacement.to_s, literal)
     end
     # block case: keep in Ruby to avoid VM callback from C
     parts = []
@@ -185,7 +197,7 @@ class String
     # nothing to restore and keeps the cleared state, as CRuby does.
     last = nil
     while pos <= len
-      md = Regexp.__byte_search(pattern, self, pos)
+      md = Regexp.__byte_search(pattern, self, pos, literal)
       break unless md
       last = md
       # gsub works in byte space (match pos, byteslice). begin/end report
@@ -227,12 +239,15 @@ class String
     end
     return to_enum(:gsub!, *args) if args.length == 1 && !block
     pattern = Regexp.__check_pattern(args[0])
-    pattern = Regexp.new(Regexp.escape(pattern)) if String === pattern
+    literal = String === pattern
+    pattern = Regexp.new(Regexp.escape(pattern)) if literal
     # As in `sub!`: the match decides the return value, and a failed search
     # clears $~.  What it publishes on success is replaced right away by the
     # last match of the `gsub` below, which is the one CRuby leaves behind.
-    return nil unless Regexp.__search(pattern, self)
-    str = args.length == 2 ? self.gsub(pattern, args[1], &block) : self.gsub(pattern, &block)
+    # A literal goes down as the String it was, for the reason `sub!` gives.
+    return nil unless Regexp.__search(pattern, self, 0, literal)
+    down = literal ? args[0] : pattern
+    str = args.length == 2 ? self.gsub(down, args[1], &block) : self.gsub(down, &block)
     self.replace(str)
   end
 

--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -234,7 +234,11 @@ re_binary_string_p(mrb_value str)
    other would not have produced.
 
    A binary string is exempt because it is indexed by byte throughout, so its
-   bytes make no claim that could be broken.
+   bytes make no claim that could be broken. A quoted String pattern is exempt
+   for a narrower reason: CRuby searches for a literal byte by byte and reads
+   the subject as UTF-8 nowhere along the way, so `"a\x80b".sub("b", "!")`
+   answers there while the same call with `/b/` is refused. The searches a
+   literal reaches take a `checked` argument to say so.
 
    The check walks the whole subject, so every entry point below runs it on the
    subject it is handed and the C loops over a subject run it before the first
@@ -406,7 +410,7 @@ check_regexp_arg(mrb_state *mrb, mrb_value re)
 }
 
 /*
- * Regexp.__search(re, str, pos = 0)
+ * Regexp.__search(re, str, pos = 0, checked = false)
  *
  * Internal: `Regexp#match` with the pattern as an argument and no block form.
  * The String overrides in mrblib search through this so that the search never
@@ -414,14 +418,20 @@ check_regexp_arg(mrb_state *mrb, mrb_value re)
  * the note at the top of mrblib/string_regexp.rb. A nil subject clears the
  * match globals and answers nil, as `Regexp#match` does, which is what the
  * overrides use to report a miss.
+ *
+ * `checked` says the caller has settled the encoding question for the subject
+ * and this search must not ask it again. `sub`, `sub!`, `gsub` and `gsub!` set
+ * it when their pattern is a quoted String, which CRuby searches for without
+ * reading the subject as UTF-8 at all.
  */
 static mrb_value
 regexp_s_search(mrb_state *mrb, mrb_value klass)
 {
   mrb_value re, str;
   mrb_int pos = 0;
+  mrb_bool checked = FALSE;
 
-  mrb_get_args(mrb, "oo|i", &re, &str, &pos);
+  mrb_get_args(mrb, "oo|ib", &re, &str, &pos, &checked);
   check_regexp_arg(mrb, re);
   if (mrb_nil_p(str)) {
     clear_match_globals(mrb);
@@ -433,18 +443,20 @@ regexp_s_search(mrb_state *mrb, mrb_value klass)
     clear_match_globals(mrb);
     return mrb_nil_value();
   }
-  re_check_encoding(mrb, str);
+  if (!checked) re_check_encoding(mrb, str);
   return exec_match(mrb, re, str, pos);
 }
 
 /*
- * Regexp.__byte_search(re, str, pos = 0)
+ * Regexp.__byte_search(re, str, pos = 0, checked = false)
  *
  * Internal: the byte-offset search the mrblib loops of `gsub`, `split` and
  * `byteindex` drive themselves. No position normalization, because the
  * callers already work in byte space, and no operand conversion, because
  * they always pass a String. The subject is the one the loop holds fixed, so
- * the check reads the flag core left on it after the first turn.
+ * the check reads the flag core left on it after the first turn. `checked`
+ * carries the same meaning as in `__search`: `gsub` sets it for a block over
+ * a quoted String pattern.
  */
 static mrb_value
 regexp_s_byte_search(mrb_state *mrb, mrb_value klass)
@@ -452,9 +464,11 @@ regexp_s_byte_search(mrb_state *mrb, mrb_value klass)
   mrb_value re, str;
   mrb_int pos = 0;
 
-  mrb_get_args(mrb, "oS|i", &re, &str, &pos);
+  mrb_bool checked = FALSE;
+
+  mrb_get_args(mrb, "oS|ib", &re, &str, &pos, &checked);
   check_regexp_arg(mrb, re);
-  re_check_encoding(mrb, str);
+  if (!checked) re_check_encoding(mrb, str);
   return exec_match(mrb, re, str, pos);
 }
 
@@ -1100,18 +1114,21 @@ has_backslash(const char *s, mrb_int len)
 }
 
 /*
- * Regexp.__gsub_str(re, str, replacement) - gsub core without block
+ * Regexp.__gsub_str(re, str, replacement, checked = false) - gsub core without block
+ *
+ * `checked` carries the same meaning as in `__search`.
  */
 static mrb_value
 regexp_s_gsub_str(mrb_state *mrb, mrb_value klass)
 {
   mrb_value re, str, replacement;
-  mrb_get_args(mrb, "oSS", &re, &str, &replacement);
+  mrb_bool checked = FALSE;
+  mrb_get_args(mrb, "oSS|b", &re, &str, &replacement, &checked);
   check_regexp_arg(mrb, re);
 
   mrb_regexp_pattern *pat = DATA_GET_PTR(mrb, re, &regexp_type, mrb_regexp_pattern);
   if (!pat) mrb_raise(mrb, E_ARGUMENT_ERROR, "uninitialized Regexp");
-  re_check_encoding(mrb, str);
+  if (!checked) re_check_encoding(mrb, str);
 
   const char *s = RSTRING_PTR(str);
   mrb_int slen = RSTRING_LEN(str);
@@ -1191,18 +1208,21 @@ regexp_s_gsub_str(mrb_state *mrb, mrb_value klass)
 }
 
 /*
- * Regexp.__sub_str(re, str, replacement) - sub core without block
+ * Regexp.__sub_str(re, str, replacement, checked = false) - sub core without block
+ *
+ * `checked` carries the same meaning as in `__search`.
  */
 static mrb_value
 regexp_s_sub_str(mrb_state *mrb, mrb_value klass)
 {
   mrb_value re, str, replacement;
-  mrb_get_args(mrb, "oSS", &re, &str, &replacement);
+  mrb_bool checked = FALSE;
+  mrb_get_args(mrb, "oSS|b", &re, &str, &replacement, &checked);
   check_regexp_arg(mrb, re);
 
   mrb_regexp_pattern *pat = DATA_GET_PTR(mrb, re, &regexp_type, mrb_regexp_pattern);
   if (!pat) mrb_raise(mrb, E_ARGUMENT_ERROR, "uninitialized Regexp");
-  re_check_encoding(mrb, str);
+  if (!checked) re_check_encoding(mrb, str);
 
   const char *s = RSTRING_PTR(str);
   mrb_int slen = RSTRING_LEN(str);
@@ -1373,8 +1393,8 @@ mrb_mruby_regexp_gem_init(mrb_state *mrb)
   mrb_define_class_method(mrb, re, "quote", regexp_escape, MRB_ARGS_REQ(1));
   mrb_define_class_method(mrb, re, "__binary_string?", regexp_binary_string_p, MRB_ARGS_REQ(1));
   mrb_define_class_method(mrb, re, "__check_pattern", regexp_check_pattern, MRB_ARGS_REQ(1));
-  mrb_define_class_method(mrb, re, "__search", regexp_s_search, MRB_ARGS_ARG(2, 1));
-  mrb_define_class_method(mrb, re, "__byte_search", regexp_s_byte_search, MRB_ARGS_ARG(2, 1));
+  mrb_define_class_method(mrb, re, "__search", regexp_s_search, MRB_ARGS_ARG(2, 2));
+  mrb_define_class_method(mrb, re, "__byte_search", regexp_s_byte_search, MRB_ARGS_ARG(2, 2));
   mrb_define_class_method(mrb, re, "__search_p", regexp_s_search_p, MRB_ARGS_ARG(2, 1));
 
   /* Instance methods */
@@ -1390,8 +1410,8 @@ mrb_mruby_regexp_gem_init(mrb_state *mrb)
   mrb_define_method(mrb, re, "hash", regexp_hash, MRB_ARGS_NONE());
   mrb_define_method(mrb, re, "options", regexp_options, MRB_ARGS_NONE());
   mrb_define_method(mrb, re, "casefold?", regexp_casefold_p, MRB_ARGS_NONE());
-  mrb_define_class_method(mrb, re, "__gsub_str", regexp_s_gsub_str, MRB_ARGS_REQ(3));
-  mrb_define_class_method(mrb, re, "__sub_str", regexp_s_sub_str, MRB_ARGS_REQ(3));
+  mrb_define_class_method(mrb, re, "__gsub_str", regexp_s_gsub_str, MRB_ARGS_ARG(3, 1));
+  mrb_define_class_method(mrb, re, "__sub_str", regexp_s_sub_str, MRB_ARGS_ARG(3, 1));
   mrb_define_class_method(mrb, re, "__scan", regexp_s_scan, MRB_ARGS_REQ(2));
 
   /* MatchData class */

--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -228,6 +228,28 @@ re_binary_string_p(mrb_value str)
   return RSTR_BINARY_P(RSTRING(str));
 }
 
+/* CRuby refuses a search whose subject holds a byte that spells no character,
+   and mruby answers for it. Refuse it here too, so that a program moved from
+   one to the other is told about the subject rather than handed a result the
+   other would not have produced.
+
+   A binary string is exempt because it is indexed by byte throughout, so its
+   bytes make no claim that could be broken.
+
+   The check walks the whole subject, so every entry point below runs it on the
+   subject it is handed and the C loops over a subject run it before the first
+   turn. Two searches are driven from mrblib once per match rather than once per
+   call, `__byte_search` and the `__search` the backward search steps, and they
+   check too: core remembers a string it has read as valid UTF-8, so every turn
+   after the first costs a flag test and not a walk. */
+static void
+re_check_encoding(mrb_state *mrb, mrb_value str)
+{
+  if (!mrb_str_valid_encoding_p(mrb, str)) {
+    mrb_raise(mrb, E_ARGUMENT_ERROR, "invalid byte sequence in UTF-8");
+  }
+}
+
 static mrb_value
 regexp_binary_string_p(mrb_state *mrb, mrb_value self)
 {
@@ -362,6 +384,7 @@ regexp_match(mrb_state *mrb, mrb_value self)
     return mrb_nil_value();
   }
 
+  re_check_encoding(mrb, str);
   md = exec_match(mrb, self, str, pos);
   if (!mrb_nil_p(md) && !mrb_nil_p(block)) {
     return mrb_yield(mrb, block, md);
@@ -410,6 +433,7 @@ regexp_s_search(mrb_state *mrb, mrb_value klass)
     clear_match_globals(mrb);
     return mrb_nil_value();
   }
+  re_check_encoding(mrb, str);
   return exec_match(mrb, re, str, pos);
 }
 
@@ -419,7 +443,8 @@ regexp_s_search(mrb_state *mrb, mrb_value klass)
  * Internal: the byte-offset search the mrblib loops of `gsub`, `split` and
  * `byteindex` drive themselves. No position normalization, because the
  * callers already work in byte space, and no operand conversion, because
- * they always pass a String.
+ * they always pass a String. The subject is the one the loop holds fixed, so
+ * the check reads the flag core left on it after the first turn.
  */
 static mrb_value
 regexp_s_byte_search(mrb_state *mrb, mrb_value klass)
@@ -429,6 +454,7 @@ regexp_s_byte_search(mrb_state *mrb, mrb_value klass)
 
   mrb_get_args(mrb, "oS|i", &re, &str, &pos);
   check_regexp_arg(mrb, re);
+  re_check_encoding(mrb, str);
   return exec_match(mrb, re, str, pos);
 }
 
@@ -445,6 +471,7 @@ exec_match_p(mrb_state *mrb, mrb_value re, mrb_value str, mrb_int pos)
 
   mrb_regexp_pattern *pat = DATA_GET_PTR(mrb, re, &regexp_type, mrb_regexp_pattern);
   if (!pat) mrb_raise(mrb, E_ARGUMENT_ERROR, "uninitialized Regexp");
+  re_check_encoding(mrb, str);
 
   int ncap = mrb_re_exec(mrb, pat, RSTRING_PTR(str), RSTRING_LEN(str), pos, NULL, 0,
                          re_binary_string_p(str));
@@ -493,6 +520,7 @@ regexp_match_op(mrb_state *mrb, mrb_value self)
     return mrb_nil_value();
   }
   str = match_operand(mrb, str);
+  re_check_encoding(mrb, str);
 
   mrb_value md = exec_match(mrb, self, str, 0);
   if (mrb_nil_p(md)) return mrb_nil_value();
@@ -516,6 +544,7 @@ regexp_case_match(mrb_state *mrb, mrb_value self)
 
   pat = DATA_GET_PTR(mrb, self, &regexp_type, mrb_regexp_pattern);
   if (!pat) return mrb_false_value();
+  re_check_encoding(mrb, str);
 
   md = exec_match(mrb, self, str, 0);
   return mrb_bool_value(!mrb_nil_p(md));
@@ -1082,6 +1111,7 @@ regexp_s_gsub_str(mrb_state *mrb, mrb_value klass)
 
   mrb_regexp_pattern *pat = DATA_GET_PTR(mrb, re, &regexp_type, mrb_regexp_pattern);
   if (!pat) mrb_raise(mrb, E_ARGUMENT_ERROR, "uninitialized Regexp");
+  re_check_encoding(mrb, str);
 
   const char *s = RSTRING_PTR(str);
   mrb_int slen = RSTRING_LEN(str);
@@ -1172,6 +1202,7 @@ regexp_s_sub_str(mrb_state *mrb, mrb_value klass)
 
   mrb_regexp_pattern *pat = DATA_GET_PTR(mrb, re, &regexp_type, mrb_regexp_pattern);
   if (!pat) mrb_raise(mrb, E_ARGUMENT_ERROR, "uninitialized Regexp");
+  re_check_encoding(mrb, str);
 
   const char *s = RSTRING_PTR(str);
   mrb_int slen = RSTRING_LEN(str);
@@ -1226,6 +1257,7 @@ regexp_s_scan(mrb_state *mrb, mrb_value klass)
 
   mrb_regexp_pattern *pat = DATA_GET_PTR(mrb, re, &regexp_type, mrb_regexp_pattern);
   if (!pat) mrb_raise(mrb, E_ARGUMENT_ERROR, "uninitialized Regexp");
+  re_check_encoding(mrb, str);
 
   const char *s = RSTRING_PTR(str);
   mrb_int slen = RSTRING_LEN(str);

--- a/mrbgems/mruby-regexp/test/regexp_syntax.rb
+++ b/mrbgems/mruby-regexp/test/regexp_syntax.rb
@@ -801,14 +801,27 @@ assert("Regexp - lookbehind measures bytes that spell no character") do
   # lead bytes of the run alone made such a byte part of the character before
   # it, rewound too little, and the lookbehind then failed on text it
   # describes, or succeeded where the negative form describes it.
-  assert_equal 2, ("\x80ab" =~ /(?<=\x80a)b/)
-  assert_nil ("\x80ab" =~ /(?<!\x80a)b/)
+  #
+  # A subject whose bytes spell no character is refused wherever an encoding
+  # reads them, so the character rewind is asked of the build that reads none,
+  # and the byte rewind below puts the same question to the same bytes in
+  # either build.
+  if __ENCODING__ == "UTF-8"
+    assert_raise(ArgumentError) { "\x80ab" =~ /(?<=\x80a)b/ }
+    assert_raise(ArgumentError) { "\x80ab" =~ /(?<!\x80a)b/ }
+    assert_raise(ArgumentError) { "\xE3\x81ab" =~ /(?<=\xE3\x81a)b/ }
+    assert_raise(ArgumentError) { "\x80ab" =~ Regexp.new("(?<=\x80a)b") }
+  else
+    assert_equal 2, ("\x80ab" =~ /(?<=\x80a)b/)
+    assert_nil ("\x80ab" =~ /(?<!\x80a)b/)
+    # a sequence cut short spells no character either, so each of its bytes is
+    # one: E3 leads three bytes and only two follow it here
+    assert_equal 3, ("\xE3\x81ab" =~ /(?<=\xE3\x81a)b/)
+    # the same bytes written into the pattern rather than escaped
+    assert_equal 2, ("\x80ab" =~ Regexp.new("(?<=\x80a)b"))
+  end
+  # a subject that spells characters throughout is read in either build
   assert_nil ("ab" =~ /(?<=\x80a)b/)
-  # a sequence cut short spells no character either, so each of its bytes is
-  # one: E3 leads three bytes and only two follow it here
-  assert_equal 3, ("\xE3\x81ab" =~ /(?<=\xE3\x81a)b/)
-  # the same bytes written into the pattern rather than escaped
-  assert_equal 2, ("\x80ab" =~ Regexp.new("(?<=\x80a)b"))
   # a byte-indexed subject counts the same bytes, and rewinds by them
   assert_equal 2, ("\x80ab".b =~ Regexp.new("(?<=\x80a)b"))
   assert_equal 3, ("\xE3\x81ab".b =~ Regexp.new("(?<=\xE3\x81a)b"))

--- a/mrbgems/mruby-regexp/test/regexp_utf8.rb
+++ b/mrbgems/mruby-regexp/test/regexp_utf8.rb
@@ -599,6 +599,24 @@ assert("Regexp - a subject whose bytes are not UTF-8 is refused") do
   assert_raise(ArgumentError) { broken.dup.slice!(/b/) }
   assert_raise(ArgumentError) { broken.dup[/b/] = "!" }
 
+  # A String pattern is a literal, which CRuby searches for byte by byte
+  # without reading the subject as UTF-8, so these answer there and here.
+  # `scan` is the exception CRuby itself makes: it refuses a literal too.
+  assert_equal "あ\x80!", broken.sub("b", "!")
+  assert_equal "あ\x80!", broken.gsub("b", "!")
+  assert_equal "あ\x80!", broken.sub("b") { "!" }
+  assert_equal "あ\x80!", broken.gsub("b") { "!" }
+  bang = broken.dup
+  bang.sub!("b", "!")
+  assert_equal "あ\x80!", bang
+  bang = broken.dup
+  bang.gsub!("b", "!")
+  assert_equal "あ\x80!", bang
+  # The position it publishes is the one the string's own indexing answers.
+  broken.sub("b", "!")
+  assert_equal broken.index("b"), $~.begin(0)
+  assert_raise(ArgumentError) { broken.scan("b") }
+
   # A byte-indexed subject is indexed by byte throughout, so its bytes make no
   # claim that could be broken and it goes through as it always did.
   assert_equal 4, (broken.b =~ /b/)

--- a/mrbgems/mruby-regexp/test/regexp_utf8.rb
+++ b/mrbgems/mruby-regexp/test/regexp_utf8.rb
@@ -217,29 +217,38 @@ assert("Regexp - a byte-indexed subject is reported in bytes") do
   assert_equal 1, (("x" + u) =~ Regexp.new("\u{1F600}"))
 end
 
-assert("Regexp - match positions on malformed UTF-8 agree with string indexing") do
-  # String indexing counts a byte no lead byte reaches as one character, but
-  # #begin used to count lead bytes only, so a stray continuation byte was
-  # zero width to it. Computing the length marks such a string single-byte
-  # and switches it to byte counting, so the same match reported one
-  # position before the length was known and another after.
+assert("Regexp - a subject whose bytes are not UTF-8 is refused whatever is known about it") do
+  # The refusal must not turn on what the string happens to have been asked
+  # about: the single-byte flag `#length` leaves behind says one byte per
+  # character, which a string of stray bytes satisfies too, so reading it in
+  # place of walking the bytes would make the same call answer one way before
+  # a length was taken and another after. That is what #begin used to do here,
+  # counting lead bytes only until the flag switched it to counting bytes.
   s = "a\x80b"
-  m = /b/.match(s)
-  before = m.begin(0)
-  assert_equal 3, s.length
-  assert_equal before, /b/.match(s).begin(0)
-  assert_equal 2, before
-  assert_equal "b", s[before]
-  assert_equal 3, m.end(0)
-  # A position argument walks the same characters, from either end. The
-  # fresh literal pins the walk on a string whose length is not known yet.
-  assert_equal "b", /b/.match(s, 2)[0]
-  assert_equal "a", /a/.match(s, -3)[0]
+  if __ENCODING__ == "UTF-8"
+    assert_raise(ArgumentError) { /b/.match(s) }
+    assert_equal 3, s.length
+    assert_raise(ArgumentError) { /b/.match(s) }
+    # A position argument is no way around it either, from either end. The
+    # fresh literal puts the question to a string whose length is not known.
+    assert_raise(ArgumentError) { /b/.match(s, 2) }
+    assert_raise(ArgumentError) { /a/.match("a\x80b", -3) }
+  else
+    # A build that reads no encoding for these bytes to break has nothing to
+    # refuse, and reports the byte positions the half below asserts in either
+    # build.
+    assert_equal 2, /b/.match(s).begin(0)
+    assert_equal 3, s.length
+    assert_equal 2, /b/.match(s).begin(0)
+    assert_equal "b", /b/.match(s, 2)[0]
+    assert_equal "a", /a/.match("a\x80b", -3)[0]
+  end
+  # A position outside the subject is settled before the bytes are read, so it
+  # answers nil in either build rather than raising.
   assert_nil /a/.match(s, -4)
-  assert_equal "a", /a/.match("a\x80b", -3)[0]
-  # Read as bytes the same subject reports byte offsets, which its own
-  # indexing agrees with too, and a position argument walks it from either
-  # end in bytes.
+  # Read as bytes the same subject makes no claim that could be broken, and
+  # every position it reports is a byte offset its own indexing agrees with,
+  # walked from either end.
   bs = "a\x80b".b
   bm = /b/.match(bs)
   assert_equal 2, bm.begin(0)
@@ -554,4 +563,49 @@ assert("Regexp - large non-ASCII character class does not overflow") do
   assert_equal 0, (re =~ utf8.call(0x8080))
   assert_nil (re =~ utf8.call(0x8081))
   assert_nil (re =~ "A")
+end
+
+assert("Regexp - a subject whose bytes are not UTF-8 is refused") do
+  # CRuby raises ArgumentError for a subject holding a byte that stands for no
+  # character, and mruby answered for it, so a program moved from one to the
+  # other took a result CRuby would not have produced. `String#scrub` is how a
+  # subject like this becomes matchable.
+  skip unless __ENCODING__ == "UTF-8"
+  broken = "あ\x80b"     # "あ" followed by a lone continuation byte
+
+  assert_raise(ArgumentError) { broken =~ /b/ }
+  assert_raise(ArgumentError) { /b/ =~ broken }
+  assert_raise(ArgumentError) { /b/.match(broken) }
+  assert_raise(ArgumentError) { /b/.match?(broken) }
+  assert_raise(ArgumentError) { /b/ === broken }
+  assert_raise(ArgumentError) { broken.match(/b/) }
+  assert_raise(ArgumentError) { broken.match?(/b/) }
+  assert_raise(ArgumentError) { broken.index(/b/) }
+  assert_raise(ArgumentError) { broken.rindex(/b/) }
+  assert_raise(ArgumentError) { broken.byteindex(/b/) }
+  assert_raise(ArgumentError) { broken.byterindex(/b/) }
+  assert_raise(ArgumentError) { broken[/b/] }
+  assert_raise(ArgumentError) { broken.sub(/b/, "!") }
+  assert_raise(ArgumentError) { broken.sub(/b/) { "!" } }
+  assert_raise(ArgumentError) { broken.gsub(/b/, "!") }
+  assert_raise(ArgumentError) { broken.gsub(/b/) { "!" } }
+  assert_raise(ArgumentError) { broken.scan(/b/) }
+  assert_raise(ArgumentError) { broken.split(/b/) }
+  assert_raise(ArgumentError) { broken.partition(/b/) }
+  assert_raise(ArgumentError) { broken.rpartition(/b/) }
+  assert_raise(ArgumentError) { broken.start_with?(/b/) }
+  assert_raise(ArgumentError) { broken.dup.sub!(/b/, "!") }
+  assert_raise(ArgumentError) { broken.dup.gsub!(/b/, "!") }
+  assert_raise(ArgumentError) { broken.dup.slice!(/b/) }
+  assert_raise(ArgumentError) { broken.dup[/b/] = "!" }
+
+  # A byte-indexed subject is indexed by byte throughout, so its bytes make no
+  # claim that could be broken and it goes through as it always did.
+  assert_equal 4, (broken.b =~ /b/)
+  assert_equal 4, broken.b.match(/b/).begin(0)
+  assert_equal "あ\x80!".b, broken.b.sub(/b/, "!")
+
+  # A whole subject is untouched, including one the walk reads to the end.
+  assert_equal 2, ("あいb" =~ /b/)
+  assert_equal 1, ("a\u{10FFFF}b" =~ /b\z|\u{10FFFF}/)
 end


### PR DESCRIPTION
Builds on #7126, which refuses a search whose subject holds a byte that spells no character. That PR refuses one made with a String pattern as well, where CRuby answers: a literal is searched for byte by byte and the subject is read as UTF-8 nowhere along the way.

```ruby
"あ\x80b".sub("b", "!")    # CRuby: "あ\x80!", after #7126: ArgumentError
"あ\x80b".scan("b")        # ArgumentError in both
```

`sub`, `sub!`, `gsub` and `gsub!` quote a String pattern into a `Regexp` before they search, which hides what it was. This takes note of it before the quoting and carries the note down to the search: `Regexp.__search`, `__byte_search`, `__sub_str` and `__gsub_str` each take a `checked` argument saying the caller has settled the encoding question and the search must not ask it again.

`sub!` and `gsub!` search once themselves and then call `sub` and `gsub`, which search again. The resolved pattern used to go down to that second call so that a String was not quoted twice; a literal goes down as the String it was instead, since that is what tells `sub` to leave the subject unread. Quoting it a second time is the price of saying so.

### What stays as it is

`scan` is not exempt: CRuby refuses a literal there, so it keeps the check.

`index`, `partition`, `start_with?`, `slice!` and `[]` search a String pattern in core without reaching a Regexp at all, so they already answer what CRuby answers. So does `split`, which is where the two part company: `"あ\x80b".split("b")` answers here and raises in CRuby. That divergence predates both PRs and is left where it was.

This exemption was part of #7110, which is where it was argued from; it is split out here so that #7126 is the refusal alone. What #7110 carried and this does not is the `Regexp.__check_encoding` class method, which #7126 does without.

The first commit here is #7126, so this shows two until that one is merged.

### Checked

- `rake test` on the default gembox: 2063 assertions, 0 failures; bintest 105, 0 failures
- `rake test` on a full-core build (`MRB_UTF8_STRING`): 2257 assertions, 0 failures
- 14 calls with a String pattern over a broken subject compared against CRuby 4.0.6: every one agrees except `split`, which is the divergence named above


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Regexp matching and substitution now consistently reject invalid UTF-8 text with `ArgumentError`.
  - Literal string patterns preserve byte-oriented behavior, including for substitution and global substitution.
  - Binary strings continue to support byte-based matching without UTF-8 validation.
  - Matching behavior is now consistent across search, scanning, predicates, and replacement operations.

- **Tests**
  - Expanded coverage for malformed UTF-8, encoding-specific behavior, and literal string patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->