### PR TITLE
Share the UTF-8 decoder between core, mruby-regexp and mruby-string-ext

### DIFF
--- a/include/mruby/internal.h
+++ b/include/mruby/internal.h
@@ -192,9 +192,9 @@ mrb_bool mrb_str_valid_encoding_p(mrb_state *mrb, mrb_value str);
 mrb_int mrb_utf8_to_buf(char *buf, uint32_t cp);
 
 /* What a run of bytes spells is a question apart from whether String indexes
-   by character, so a gem that reads UTF-8 on its own asks for these two by
+   by character, so a gem that reads UTF-8 on its own asks for these by
    defining MRB_UTF8_SCAN (mruby-regexp does, from its mrbgem.rake). A build
-   with neither that gem nor MRB_UTF8_STRING carries neither function. */
+   with neither that gem nor MRB_UTF8_STRING carries none of them. */
 #if defined(MRB_UTF8_STRING) || defined(MRB_UTF8_SCAN)
 /* The byte length of the character at `str`, which has to be a byte of the
    string rather than `end` itself, and 1 for a run of bytes that spells no
@@ -205,6 +205,13 @@ mrb_int mrb_utf8len(const char *str, const char *end);
    already a character boundary. A continuation byte that no lead byte reaches
    is a boundary too. */
 const char *mrb_utf8_char_head(const char *beg, const char *p, const char *end);
+
+/* The codepoint of the character at `p`, which has to be a byte of the string
+   rather than `e` itself, with the byte length consumed always stored through
+   `lenp`. A run of bytes that spells no character comes back as its first
+   byte over one byte, so a value of 0x80 or above beside *lenp == 1 marks an
+   invalid sequence; whether that is an error is the caller's question. */
+uint32_t mrb_utf8_decode(const char *p, const char *e, mrb_int *lenp);
 #endif
 
 #ifdef MRB_UTF8_STRING

--- a/mrbgems/mruby-regexp/include/re_internal.h
+++ b/mrbgems/mruby-regexp/include/re_internal.h
@@ -173,8 +173,7 @@ mrb_regexp_pattern* mrb_re_compile(mrb_state *mrb, const char *pattern, mrb_int 
 /* Free a compiled pattern */
 void mrb_re_free(mrb_state *mrb, mrb_regexp_pattern *pat);
 
-/* UTF-8 helpers */
-uint32_t mrb_re_utf8_decode(const char *s, const char *end, int *len);
+/* Word character (\w) test */
 mrb_bool mrb_re_is_word_char(uint32_t c);
 
 /* The two foldings whose result is an ASCII letter. Every build carries them,
@@ -242,7 +241,10 @@ mrb_re_decode_char(const char *s, const char *end, int *len, mrb_bool binary)
     if (len) *len = 1;
     return (uint8_t)*s;
   }
-  return mrb_re_utf8_decode(s, end, len);
+  mrb_int n;
+  uint32_t cp = mrb_utf8_decode(s, end, &n);
+  if (len) *len = (int)n;
+  return cp;
 }
 
 /* TRUE when s points into the middle of a character that starts earlier in

--- a/mrbgems/mruby-regexp/mrbgem.rake
+++ b/mrbgems/mruby-regexp/mrbgem.rake
@@ -6,7 +6,7 @@ MRuby::Gem::Specification.new('mruby-regexp') do |spec|
   spec.add_dependency 'mruby-string-ext', :core => 'mruby-string-ext'
 
   # The engine reads UTF-8 whatever a build's strings index by, so it asks core
-  # for the two functions that answer what a run of bytes spells. They wait
+  # for the functions that answer what a run of bytes spells. They wait
   # behind MRB_UTF8_STRING otherwise, and this build has no reason to set that:
   # mruby-encoding is what does, and the default gembox carries this gem
   # without it.

--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -596,8 +596,8 @@ read_class_atom(re_compiler *c, re_charclass *cc, mrb_bool *is_byte)
   }
   /* Multi-byte UTF-8 leader: decode the full codepoint. An invalid leader
      decodes as itself over one byte, so it is a byte like the rest. */
-  int len = 0;
-  uint32_t cp = mrb_re_utf8_decode(c->p, c->src_end, &len);
+  mrb_int len = 0;
+  uint32_t cp = mrb_utf8_decode(c->p, c->src_end, &len);
   c->p += len;
   if (len == 1) *is_byte = TRUE;
   return cp;
@@ -1015,8 +1015,8 @@ static mrb_bool
 emit_char_folded(re_compiler *c, int ch)
 {
   if (ch < 128 || !(c->flags & RE_FLAG_IGNORECASE)) return FALSE;
-  int len = 0;
-  uint32_t cp = mrb_re_utf8_decode(c->p - 1, c->src_end, &len);
+  mrb_int len = 0;
+  uint32_t cp = mrb_utf8_decode(c->p - 1, c->src_end, &len);
   if (len == 1) return FALSE;
   if (!emit_cp_folded(c, cp)) return FALSE;
   c->p += len - 1;

--- a/mrbgems/mruby-regexp/src/re_utf8.c
+++ b/mrbgems/mruby-regexp/src/re_utf8.c
@@ -1,43 +1,10 @@
 /*
-** re_utf8.c - UTF-8 utility functions for regexp engine
+** re_utf8.c - case folding and word characters for regexp engine
 **
 ** See Copyright Notice in mruby.h
 */
 
 #include "re_internal.h"
-
-/* Decode a UTF-8 character and return its codepoint.
-   *len is set to the byte length consumed. mrb_utf8len() answers 1 for every
-   sequence it rejects, so those consume a single byte and come back as the
-   lead byte itself. */
-uint32_t
-mrb_re_utf8_decode(const char *s, const char *end, int *len)
-{
-  uint8_t c = (uint8_t)s[0];
-  uint32_t cp;
-  int n = (int)mrb_utf8len(s, end);
-
-  *len = n;
-  switch (n) {
-  case 2:
-    cp = (c & 0x1f) << 6;
-    cp |= ((uint8_t)s[1] & 0x3f);
-    return cp;
-  case 3:
-    cp = (c & 0x0f) << 12;
-    cp |= ((uint8_t)s[1] & 0x3f) << 6;
-    cp |= ((uint8_t)s[2] & 0x3f);
-    return cp;
-  case 4:
-    cp = (c & 0x07) << 18;
-    cp |= ((uint8_t)s[1] & 0x3f) << 12;
-    cp |= ((uint8_t)s[2] & 0x3f) << 6;
-    cp |= ((uint8_t)s[3] & 0x3f);
-    return cp;
-  default:
-    return c;  /* ASCII, or invalid/truncated byte returned as-is */
-  }
-}
 
 /* Check if character is a "word" character (\w): [a-zA-Z0-9_] */
 mrb_bool

--- a/mrbgems/mruby-string-ext/src/string.c
+++ b/mrbgems/mruby-string-ext/src/string.c
@@ -967,25 +967,18 @@ str_succ(mrb_state *mrb, mrb_value self)
 
 #ifdef MRB_UTF8_STRING
 /* Decodes the UTF-8 character starting at p, storing its byte length through
-   lenp when that is not NULL. mrb_utf8len() answers 1 for every sequence it
-   rejects, so a lead byte measured as one byte is invalid. */
+   lenp when that is not NULL. mrb_utf8_decode() hands back a rejected
+   sequence as its lead byte over one byte; String treats that as an error. */
 MRB_INLINE mrb_int
 utf8code(mrb_state* mrb, const unsigned char* p, const unsigned char *e, mrb_int *lenp)
 {
-  mrb_int len = mrb_utf8len((const char*)p, (const char*)e);
+  mrb_int len;
+  uint32_t cp = mrb_utf8_decode((const char*)p, (const char*)e, &len);
   if (lenp) *lenp = len;
-  if (len == 1) {
-    if (p[0] >= 0x80) {
-      mrb_raise(mrb, E_ARGUMENT_ERROR, "invalid UTF-8 byte sequence");
-    }
-    return p[0];
+  if (len == 1 && p[0] >= 0x80) {
+    mrb_raise(mrb, E_ARGUMENT_ERROR, "invalid UTF-8 byte sequence");
   }
-
-  mrb_int cp = p[0] & (0xff >> (len + 1));
-  for (mrb_int i = 1; i < len; i++) {
-    cp = (cp << 6) | (p[i] & 0x3f);
-  }
-  return cp;
+  return (mrb_int)cp;
 }
 
 static mrb_value

--- a/src/string.c
+++ b/src/string.c
@@ -441,6 +441,39 @@ mrb_utf8_char_head(const char *beg, const char *p, const char *end)
   return p;
 }
 
+/* Decode a UTF-8 character and return its codepoint.
+   *lenp is set to the byte length consumed. mrb_utf8len() answers 1 for every
+   sequence it rejects, so those consume a single byte and come back as the
+   lead byte itself. */
+uint32_t
+mrb_utf8_decode(const char *p, const char *e, mrb_int *lenp)
+{
+  uint8_t c = (uint8_t)p[0];
+  uint32_t cp;
+  mrb_int n = mrb_utf8len(p, e);
+
+  *lenp = n;
+  switch (n) {
+  case 2:
+    cp = (c & 0x1f) << 6;
+    cp |= ((uint8_t)p[1] & 0x3f);
+    return cp;
+  case 3:
+    cp = (c & 0x0f) << 12;
+    cp |= ((uint8_t)p[1] & 0x3f) << 6;
+    cp |= ((uint8_t)p[2] & 0x3f);
+    return cp;
+  case 4:
+    cp = (c & 0x07) << 18;
+    cp |= ((uint8_t)p[1] & 0x3f) << 12;
+    cp |= ((uint8_t)p[2] & 0x3f) << 6;
+    cp |= ((uint8_t)p[3] & 0x3f);
+    return cp;
+  default:
+    return c;  /* ASCII, or invalid/truncated byte returned as-is */
+  }
+}
+
 #endif  /* MRB_UTF8_STRING || MRB_UTF8_SCAN */
 
 #ifdef MRB_UTF8_STRING


### PR DESCRIPTION
The tree assembles a codepoint from UTF-8 bytes in two places, and the two are the same function: `mrb_re_utf8_decode()` in mruby-regexp and `utf8code()` in mruby-string-ext each measure the character with `mrb_utf8len()` and then fold the same masks over the same bytes (the `0xff >> (len + 1)` one spells is the 0x1f, 0x0f, 0x07 the other names). They differ only in what an invalid sequence becomes: the engine matches the lead byte as a byte, `String#ord` and `String#codepoints` raise `ArgumentError`.

This is the decoder counterpart of #7094 (the encoder) and #7109 (the scanner and character heads): core gains the one missing piece and both gems call it. mruby-pack's `unpack("U")` decoder is left alone deliberately, since it implements CRuby's older, laxer dialect (surrogates pass; `malformed` and `redundant` are distinct errors), not the RFC 3629 reading `mrb_utf8len()` enforces.

### What core gains

```c
uint32_t mrb_utf8_decode(const char *p, const char *e, mrb_int *lenp);
```

The engine's body, moved beside the `mrb_utf8len()` it reads through, behind the same `MRB_UTF8_STRING || MRB_UTF8_SCAN` guard and declared next to it in internal.h. A sequence the scanner rejects comes back as its lead byte over one byte, so a value of 0x80 or above beside a length of 1 marks an invalid sequence, and whether that is an error stays the caller's question.

### What the gems drop

- mruby-regexp deletes `mrb_re_utf8_decode()`. The compiler calls core directly where it reads a class atom or folds a character the pattern spells out; the executor keeps `mrb_re_decode_char()`, which now narrows the length back to the engine's `int` at the same seam where `mrb_re_charlen()` already does. `re_utf8.c` keeps the case folding and the `\w` test.
- mruby-string-ext's `utf8code()` keeps only what is String's to decide, the `ArgumentError`. Its callers, `String#ord` and `String#codepoints`, are untouched.

### Equivalence

Checked by brute force rather than argued: both current implementations against the new function over 21,233,664 cases (both lead bytes exhaustively, nine representative tail bytes in each of the last two positions, every available length from 1 to 4), with no difference in the codepoint, the byte length, or the error condition.

### Size

text grows slightly instead of shrinking: 1,721,815 → 1,722,415 on the default gembox, 1,812,452 → 1,812,996 on a full-core host build. The decoder now lives in the TU whose scanner it calls, so the compiler inlines `mrb_utf8len()` into it (`nm` puts the new function at 494 bytes where the engine's was 163); the bytes buy back the call and drop the duplicate source.

### Verified

- `rake test` on the default gembox, where the engine reads UTF-8 without `MRB_UTF8_STRING`: 2037 tests, all green on each commit
- `MRUBY_CONFIG=ci/gcc-clang rake test` (full-core: `MRB_UTF8_STRING` everywhere, `MRB_REGEXP_UNICODE_CASE` on full-debug, and the C++ cxx_abi build): all green
- `MRUBY_CONFIG=minimal rake` builds, where neither define exists and the decoder compiles out with the rest of the scan
- `prek run --all-files` passes, except that `markdownlint` could not install locally (npm engine mismatch); no Markdown is touched here


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved UTF-8 decoding across strings and regular expressions.
  * Added consistent handling for valid, invalid, and truncated UTF-8 sequences.
* **Bug Fixes**
  * Improved UTF-8 character length reporting and error handling in string operations.
  * Standardized Unicode character decoding during regular-expression processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->