### PR TITLE
Check the Unicode range in `mrb_utf8_to_buf` instead of in its four callers

### DIFF
--- a/include/mruby/internal.h
+++ b/include/mruby/internal.h
@@ -189,7 +189,11 @@ mrb_int mrb_str_byte_to_char(mrb_state *mrb, mrb_value str, mrb_int bi);
    definition in string.c for what it reads and what it leaves behind. */
 mrb_bool mrb_str_valid_encoding_p(mrb_state *mrb, mrb_value str);
 
-mrb_int mrb_utf8_to_buf(char *buf, uint32_t cp);
+/* Write the UTF-8 spelling of a codepoint into a buffer of at least four
+   bytes, and return how many it took (1-4), or 0 for a value that spells no
+   character. What counts as one, and why a surrogate does spell one here
+   while mrb_utf8len() says it does not, is in the definition in string.c. */
+mrb_int mrb_utf8_to_buf(char *buf, mrb_int cp);
 
 /* What a run of bytes spells is a question apart from whether String indexes
    by character, so a gem that reads UTF-8 on its own asks for these two by

--- a/mrbgems/mruby-pack/src/pack.c
+++ b/mrbgems/mruby-pack/src/pack.c
@@ -777,13 +777,11 @@ pack_utf8(mrb_state *mrb, mrb_value o, mrb_value str, mrb_int sidx, int count, u
   int len;
   mrb_int c = mrb_integer(o);
 
-  /* mrb_utf8_to_buf() takes a uint32_t, which wraps a value outside the
-     Unicode range into a codepoint, so the range has to be checked on the
-     mrb_int before the cast. */
-  if (c < 0 || 0x10FFFF < c) {
+  /* A value that spells no character writes no byte. */
+  len = (int)mrb_utf8_to_buf(utf8, c);
+  if (len == 0) {
     mrb_raise(mrb, E_RANGE_ERROR, "pack(U): value out of range");
   }
-  len = (int)mrb_utf8_to_buf(utf8, (uint32_t)c);
 
   str = str_len_ensure(mrb, str, sidx + len);
   memcpy(RSTRING_PTR(str) + sidx, utf8, len);

--- a/mrbgems/mruby-pack/test/pack.rb
+++ b/mrbgems/mruby-pack/test/pack.rb
@@ -223,6 +223,18 @@ assert 'pack("U") with a value outside the Unicode range' do
   assert_raise(RangeError) { [wrapping].pack("U") } if wrapping.is_a?(Integer)
 end
 
+assert 'pack("U") with a UTF-16 surrogate' do
+  # A surrogate has a spelling here even though it is not a character: CRuby
+  # writes these three bytes too, and refuses the value in Integer#chr rather
+  # than here. unpack("U") reads them back, so the two stay a pair whatever
+  # the character scanner makes of the bytes.
+  assert_equal [0xED, 0xA0, 0x80], [0xD800].pack("U").unpack("C*")
+  assert_equal [0xED, 0xBF, 0xBF], [0xDFFF].pack("U").unpack("C*")
+  assert_equal [0xD800], [0xD800].pack("U").unpack("U*")
+  assert_equal [0xED, 0x9F, 0xBF], [0xD7FF].pack("U").unpack("C*")
+  assert_equal [0xEE, 0x80, 0x80], [0xE000].pack("U").unpack("C*")
+end
+
 assert 'unpack1' do
   d = 1234
   assert_equal(d, [d].pack("i").unpack1("i"))

--- a/mrbgems/mruby-pack/test/pack.rb
+++ b/mrbgems/mruby-pack/test/pack.rb
@@ -214,10 +214,11 @@ assert 'pack("U") with a value outside the Unicode range' do
   assert_equal [0xF4, 0x8F, 0xBF, 0xBF], [0x10FFFF].pack("U").unpack("C*")
   assert_raise(RangeError) { [0x110000].pack("U") }
 
-  # The encoder takes a uint32_t, so a value that wraps into the Unicode range
-  # must not come out as the character it wraps to. The shift is computed at
-  # run time because the constant folder would reject the literal on a build
-  # with a 32-bit mrb_int and no bigint, where there is nothing to test.
+  # A value that would land inside the Unicode range if it were truncated to
+  # 32 bits must not come out as the character it truncates to. The shift is
+  # computed at run time because the constant folder would reject the literal
+  # on a build with a 32-bit mrb_int and no bigint, where there is nothing to
+  # test.
   shift = 32
   wrapping = ((1 << shift) + 0x41) rescue nil
   assert_raise(RangeError) { [wrapping].pack("U") } if wrapping.is_a?(Integer)

--- a/mrbgems/mruby-pack/test/pack.rb
+++ b/mrbgems/mruby-pack/test/pack.rb
@@ -215,13 +215,23 @@ assert 'pack("U") with a value outside the Unicode range' do
   assert_raise(RangeError) { [0x110000].pack("U") }
 
   # A value that would land inside the Unicode range if it were truncated to
-  # 32 bits must not come out as the character it truncates to. The shift is
-  # computed at run time because the constant folder would reject the literal
-  # on a build with a 32-bit mrb_int and no bigint, where there is nothing to
-  # test.
+  # 32 bits must not come out as the character it truncates to.
+  # The shift width comes from a variable because `1 << 32` written out is
+  # constant folded, and the fold fails while this file is compiled on
+  # MRB_INT32 without bigint, dropping every test in it.
   shift = 32
-  wrapping = ((1 << shift) + 0x41) rescue nil
-  assert_raise(RangeError) { [wrapping].pack("U") } if wrapping.is_a?(Integer)
+  wrapping = nil
+  wide = begin
+    wrapping = (1 << shift) + 0x41  # RangeError where mrb_int is 32 bits and bigint is absent
+    [][wrapping]                    # nil for an mrb_int index, RangeError for a big integer
+    true
+  rescue RangeError
+    false
+  end
+  # A big integer is not an mrb_int either: `pack` refuses it while converting
+  # the element, so the encoder never sees the value and the truncation this
+  # guards against never runs.
+  assert_raise(RangeError) { [wrapping].pack("U") } if wide
 end
 
 assert 'pack("U") with a UTF-16 surrogate' do

--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -448,9 +448,11 @@ parse_escape(re_compiler *c)
   }
 }
 
-/* Reject what has no UTF-8 encoding. CRuby reports both a surrogate and a
-   value past the last plane as "invalid Unicode range", so neither ever
-   reaches mrb_utf8_to_buf(). */
+/* Reject what a pattern may not name. CRuby reports both a surrogate and a
+   value past the last plane as "invalid Unicode range", and reports it where
+   the pattern is read rather than where it is emitted, so the check stays
+   here: mrb_utf8_to_buf() refuses the second on its own but spells the first,
+   and neither reaches it anyway. */
 static void
 check_unicode_cp(re_compiler *c, uint32_t cp)
 {
@@ -1039,7 +1041,7 @@ emit_codepoint(re_compiler *c, uint32_t cp)
   }
   if ((c->flags & RE_FLAG_IGNORECASE) && emit_cp_folded(c, cp)) return;
   char buf[4];
-  int len = (int)mrb_utf8_to_buf(buf, cp);
+  int len = (int)mrb_utf8_to_buf(buf, (mrb_int)cp);
   for (int i = 0; i < len; i++) {
     emit(c, RE_CHAR, (uint8_t)buf[i], 0);
   }

--- a/mrbgems/mruby-sprintf/src/sprintf.c
+++ b/mrbgems/mruby-sprintf/src/sprintf.c
@@ -536,13 +536,13 @@ retry:
             /* Integer: encode directly to stack buffer (no allocation) */
             mrb_int code = mrb_integer(val);
 #ifdef MRB_UTF8_STRING
-            /* mrb_utf8_to_buf() writes nothing for a value it cannot encode,
-               and takes a uint32_t, which wraps a value outside the Unicode
-               range into a codepoint. Either way there is no byte to write. */
-            if (code < 0 || 0x10FFFF < code) {
+            /* A value that spells no character writes no byte, and is what
+               CRuby reports here as an invalid character rather than as a
+               range error. */
+            clen = (int)mrb_utf8_to_buf(cbuf, code);
+            if (clen == 0) {
               mrb_raise(mrb, E_ARGUMENT_ERROR, "invalid character");
             }
-            clen = (int)mrb_utf8_to_buf(cbuf, (uint32_t)code);
 #else
             cbuf[0] = (char)(code & 0xff);
             clen = 1;

--- a/mrbgems/mruby-sprintf/test/sprintf.rb
+++ b/mrbgems/mruby-sprintf/test/sprintf.rb
@@ -137,10 +137,11 @@ assert('sprintf("%c") with an integer that has no UTF-8 encoding') do
   # whatever byte the stack happened to hold there.
   assert_raise(ArgumentError) { sprintf("%c", 0x110000) }
   assert_raise(ArgumentError) { sprintf("%c", -1) }
-  # The encoder takes a uint32_t, so a value that wraps into the Unicode range
-  # must not come out as the character it wraps to. The shift is computed at
-  # run time because the constant folder would reject the literal on a build
-  # with a 32-bit mrb_int and no bigint, where there is nothing to test.
+  # A value that would land inside the Unicode range if it were truncated to
+  # 32 bits must not come out as the character it truncates to. The shift is
+  # computed at run time because the constant folder would reject the literal
+  # on a build with a 32-bit mrb_int and no bigint, where there is nothing to
+  # test.
   shift = 32
   wrapping = ((1 << shift) + 0x41) rescue nil
   assert_raise(ArgumentError) { sprintf("%c", wrapping) } if wrapping.is_a?(Integer)

--- a/mrbgems/mruby-sprintf/test/sprintf.rb
+++ b/mrbgems/mruby-sprintf/test/sprintf.rb
@@ -138,13 +138,23 @@ assert('sprintf("%c") with an integer that has no UTF-8 encoding') do
   assert_raise(ArgumentError) { sprintf("%c", 0x110000) }
   assert_raise(ArgumentError) { sprintf("%c", -1) }
   # A value that would land inside the Unicode range if it were truncated to
-  # 32 bits must not come out as the character it truncates to. The shift is
-  # computed at run time because the constant folder would reject the literal
-  # on a build with a 32-bit mrb_int and no bigint, where there is nothing to
-  # test.
+  # 32 bits must not come out as the character it truncates to.
+  # The shift width comes from a variable because `1 << 32` written out is
+  # constant folded, and the fold fails while this file is compiled on
+  # MRB_INT32 without bigint, dropping every test in it.
   shift = 32
-  wrapping = ((1 << shift) + 0x41) rescue nil
-  assert_raise(ArgumentError) { sprintf("%c", wrapping) } if wrapping.is_a?(Integer)
+  wrapping = nil
+  wide = begin
+    wrapping = (1 << shift) + 0x41  # RangeError where mrb_int is 32 bits and bigint is absent
+    [][wrapping]                    # nil for an mrb_int index, RangeError for a big integer
+    true
+  rescue RangeError
+    false
+  end
+  # A big integer is not an mrb_int either: `%c` takes it down the branch for
+  # an argument that is not an integer and refuses it there, so the encoder
+  # never sees the value and the truncation this guards against never runs.
+  assert_raise(ArgumentError) { sprintf("%c", wrapping) } if wide
 end
 
 assert('sprintf("%c") with a UTF-16 surrogate') do

--- a/mrbgems/mruby-sprintf/test/sprintf.rb
+++ b/mrbgems/mruby-sprintf/test/sprintf.rb
@@ -145,3 +145,15 @@ assert('sprintf("%c") with an integer that has no UTF-8 encoding') do
   wrapping = ((1 << shift) + 0x41) rescue nil
   assert_raise(ArgumentError) { sprintf("%c", wrapping) } if wrapping.is_a?(Integer)
 end
+
+assert('sprintf("%c") with a UTF-16 surrogate') do
+  skip unless __ENCODING__ == "UTF-8"
+  # A surrogate has a spelling here even though it is not a character: CRuby
+  # writes these three bytes too, and refuses the value in Integer#chr rather
+  # than here. So what the encoder writes is wider than what the character
+  # scanner reads back, and the string it builds is not valid UTF-8.
+  assert_equal "\xED\xA0\x80", sprintf("%c", 0xD800)
+  assert_equal "\xED\xBF\xBF", sprintf("%c", 0xDFFF)
+  assert_equal "\xED\x9F\xBF", sprintf("%c", 0xD7FF)
+  assert_equal "\xEE\x80\x80", sprintf("%c", 0xE000)
+end

--- a/mrbgems/mruby-string-ext/src/string.c
+++ b/mrbgems/mruby-string-ext/src/string.c
@@ -33,11 +33,14 @@ int_chr_utf8(mrb_state *mrb, mrb_value num)
   mrb_int len;
   mrb_value str;
 
-  /* Reject negative, above U+10FFFF, and UTF-16 surrogates (RFC 3629). */
-  if (cp < 0 || 0x10FFFF < cp || (0xD800 <= cp && cp <= 0xDFFF)) {
+  /* A value outside the Unicode range spells no character and comes back as a
+     zero length. A surrogate does spell one to the encoder, because CRuby's
+     sprintf("%c") and pack("U") spell one; Integer#chr is where CRuby refuses
+     it, so the refusal belongs here rather than in the encoder. */
+  len = mrb_utf8_to_buf(utf8, cp);
+  if (len == 0 || (0xD800 <= cp && cp <= 0xDFFF)) {
     mrb_raisef(mrb, E_RANGE_ERROR, "%v out of char range", num);
   }
-  len = mrb_utf8_to_buf(utf8, (uint32_t)cp);
   str = mrb_str_new(mrb, utf8, len);
   if (len == 1) {
     RSTR_SET_ASCII_FLAG(mrb_str_ptr(str));

--- a/src/string.c
+++ b/src/string.c
@@ -336,15 +336,26 @@ mrb_gc_free_str(mrb_state *mrb, struct RString *str)
 #define MASK01 0x01010101ul
 #endif
 
-/*
- * Encode a Unicode codepoint to UTF-8 bytes.
- * buf must have at least 4 bytes of space.
- * Returns the number of bytes written (1-4), or 0 for invalid codepoint.
- */
+/* Encode a Unicode codepoint to UTF-8 bytes, into a buffer of at least four.
+   Returns the number of bytes written (1-4), or 0 for a value outside
+   U+0000..U+10FFFF, which spells no character. The value arrives as an
+   mrb_int so that a negative one and one past the range are both this
+   function's answer to give; a caller reporting them differs only in which
+   exception it raises, and each raises what CRuby raises there.
+
+   A surrogate does encode. What CRuby writes for one is what mruby writes:
+   sprintf("%c", 0xD800) and [0xD800].pack("U") both yield ED A0 80 there.
+   Reading those bytes back is a separate question, and mrb_utf8len() answers
+   it by RFC 3629, under which a surrogate spells nothing. So what this writes
+   is deliberately wider than what that reads, and a string built from one is
+   valid_encoding? == false. */
 mrb_int
-mrb_utf8_to_buf(char *buf, uint32_t cp)
+mrb_utf8_to_buf(char *buf, mrb_int cp)
 {
-  if (cp < 0x80) {
+  if (cp < 0) {
+    return 0;
+  }
+  else if (cp < 0x80) {
     buf[0] = (char)cp;
     return 1;
   }
@@ -366,7 +377,7 @@ mrb_utf8_to_buf(char *buf, uint32_t cp)
     buf[3] = (char)(0x80 | (cp & 0x3F));
     return 4;
   }
-  return 0;  /* invalid codepoint */
+  return 0;  /* above U+10FFFF */
 }
 
 /* What a run of bytes spells is a question apart from whether String indexes


### PR DESCRIPTION
## The duplication

`mrb_utf8_to_buf()` took a `uint32_t`, so a value outside the Unicode range
wraps into a codepoint under the cast: `(uint32_t)(0x100000000 + 0x41)` is
`0x41`, and the encoder would spell `A`. Every caller therefore had to test
the range on the `mrb_int` before the call, and all four spelled the same
bound out:

| caller | check before the call |
| --- | --- |
| `mruby-sprintf`, `%c` | `code < 0 \|\| 0x10FFFF < code` |
| `mruby-pack`, `pack("U")` | `c < 0 \|\| 0x10FFFF < c` |
| `mruby-string-ext`, `Integer#chr` | `cp < 0 \|\| 0x10FFFF < cp \|\| surrogate` |
| `mruby-regexp`, `\u{...}` | `cp > 0x10ffff \|\| surrogate` |

Because all four rejected anything above U+10FFFF first, the `return 0` the
encoder already carried for a value it cannot spell was unreachable from
every one of them. Two of the four also carried a copy of the same comment
explaining the cast.

## The change

Take an `mrb_int`. The cast disappears, and with it the reason the bound
could not live in one place. Each caller keeps only the part that genuinely
differs between them, which is the exception:

```ruby
sprintf("%c", 0x110000)   # ArgumentError: invalid character
[0x110000].pack("U")      # RangeError
0x110000.chr("UTF-8")     # RangeError
```

CRuby 4.0.6 raises those same three, so this split is not one the encoder can
absorb.

## What stays where, and why

`Integer#chr` keeps its surrogate test. A surrogate is a value the encoder
does spell, and CRuby spells it too:

```ruby
sprintf("%c", 0xD800).bytes   #=> [237, 160, 128]
[0xD800].pack("U").bytes      #=> [237, 160, 128]
0xD800.chr("UTF-8")           # RangeError: invalid codepoint 0xD800 in UTF-8
```

So refusing a surrogate is a rule of `Integer#chr` rather than a rule of
UTF-8 encoding. It also means what `mrb_utf8_to_buf()` writes is deliberately
wider than what `mrb_utf8len()` reads back under RFC 3629, and

```ruby
sprintf("%c", 0xD800).valid_encoding?   #=> false
```

in CRuby as well as in mruby. The encoder's comment now states that where the
encoder is defined, instead of leaving it to be inferred from which callers
happen to carry a surrogate test.

`mruby-regexp` keeps `check_unicode_cp()`. It reports at the point the
pattern is read rather than at the point bytes are emitted, and the message
carries the pattern:

```ruby
Regexp.new("\\u{D800}")   # RegexpError: invalid Unicode range: /\u{D800}/
```

Its codepoint also comes from a hex scan capped at six digits, so it can
never reach the encoder unchecked.

`mruby-pack` gained its own version of this check in #7114, for the same
reason the other three carried one. With the cast gone, that reason is gone
with it.

## Tests

The first commit pins what the encoder spells for a surrogate, before
anything moves. The upper bound, negative values and the truncation case
already had tests; the writing side had none. Adding a surrogate rejection to
`mrb_utf8_to_buf()` fails exactly the two new assertions and nothing else.

No behavior change. Three builds, one with `MRB_UTF8_STRING`, one without,
and one with `MRB_UTF8_STRING` and `MRB_INT32`, agree with the previous code
on `-1`, `-0x10FFFF`, `0`, `0x7F`, `0x80`, `0x7FF`, `0x800`, `0xD7FF`,
`0xD800`, `0xDFFF`, `0xE000`, `0xFFFF`, `0x10000`, `0x10FFFF`, `0x110000`,
`0x7FFFFFFF` and 32-bit truncation candidates, across `sprintf("%c")`,
`pack("U")`, `Integer#chr("UTF-8")` and `String#<<`. `rake test` is green on
all three, and each commit was checked on its own.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved UTF-8 handling for integer-to-character conversions across packing, formatting, regular expressions, and string utilities.
  - Invalid negative, oversized, and out-of-range code points are now rejected consistently.
  - UTF-16 surrogate values now produce consistent UTF-8 output and round-trip behavior where supported.
  - `%c` formatting reports a clear “invalid character” error for unsupported values.

- **Tests**
  - Expanded coverage for surrogate code points, adjacent Unicode characters, exact UTF-8 bytes, and values exceeding 32-bit ranges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->