### PR TITLE
Stop a broken string from being read one byte at a time

### DIFF
--- a/mrbgems/mruby-string-ext/src/string.c
+++ b/mrbgems/mruby-string-ext/src/string.c
@@ -1752,8 +1752,8 @@ str_chars_ary(mrb_state *mrb, mrb_value self)
   struct RString *s = mrb_str_ptr(self);
   const char *p = RSTR_PTR(s);
   const char *e = p + RSTR_LEN(s);
-  /* the count comes first: it is the exact capacity, and it settles the
-     single-byte flag the walk reads */
+  /* the count comes first: it is the exact capacity, and where every byte is
+     ASCII it also settles the single-byte flag the walk reads */
   mrb_value result = mrb_ary_new_capa(mrb, mrb_str_char_len(mrb, self));
 
 #ifdef MRB_UTF8_STRING

--- a/mrbgems/mruby-string-ext/test/string.rb
+++ b/mrbgems/mruby-string-ext/test/string.rb
@@ -1040,6 +1040,56 @@ assert('String#ord rejects malformed sequences') do
   assert_raise(ArgumentError) { "\xF4\x90\x80\x80".ord }
 end if UTF8STRING
 
+assert('a malformed sequence stays malformed once the string is counted') do
+  # Counting characters remembers a string that holds one per byte, so that
+  # whatever reads it next may step by bytes. Bytes that spell no character
+  # count one per byte as well, and were remembered the same way, after which
+  # they came back as the characters the string does not hold.
+  counters = {
+    "length"    => ->(s) { s.length },
+    "chars"     => ->(s) { s.chars },
+    "each_char" => ->(s) { s.each_char { |c| } },
+    "[]"        => ->(s) { s[0] },
+  }
+  broken = ["\x80", "\xE3\x81", "\xC0\xAF", "\xED\xA0\x80", "\xF4\x90\x80\x80",
+            "a\x80b", "あ\x80"]
+  # #ord reads the first character, so it answers wherever that one is whole
+  ord_answers = { "a\x80b" => 97, "あ\x80" => 12354 }
+
+  counters.each do |name, count|
+    broken.each do |str|
+      s = str.dup
+      count.call(s)
+      assert_raise(ArgumentError, "#{str.inspect}.codepoints after #{name}") { s.codepoints }
+    end
+    broken.each do |str|
+      s = str.dup
+      count.call(s)
+      want = ord_answers[str]
+      if want
+        assert_equal want, s.ord, "#{str.inspect}.ord after #{name}"
+      else
+        assert_raise(ArgumentError, "#{str.inspect}.ord after #{name}") { s.ord }
+      end
+    end
+
+    # scrub has nothing to replace only where the bytes read as characters
+    s = "\xED\xA0\x80"
+    count.call(s)
+    assert_equal "\u{FFFD}" * 3, s.scrub
+    s = "\xED\xA0\x80"
+    count.call(s)
+    assert_equal "???", s.scrub("?")
+
+    # an ASCII string does hold one character per byte, and is still read so
+    s = "abc"
+    count.call(s)
+    assert_equal [97, 98, 99], s.codepoints
+    assert_equal 97, s.ord
+    assert_equal "abc", s.scrub
+  end
+end if UTF8STRING
+
 assert('String#each_codepoint') do
   expect = [104, 101, 108, 108, 111, 33]
   cp = []

--- a/mrbgems/mruby-string-ext/test/string.rb
+++ b/mrbgems/mruby-string-ext/test/string.rb
@@ -27,6 +27,33 @@ assert('String#inspect of a binary string escapes every byte') do
   end
 end
 
+assert('String#inspect leaves a malformed sequence malformed') do
+  # `inspect` remembers a string it walked without meeting a character of
+  # several bytes, so that whatever reads it next may step by bytes. A byte
+  # spelling no character is escaped one at a time as well, and was remembered
+  # the same way, after which it came back as a character the string does not
+  # hold.
+  ["\x80", "\xE3\x81", "\xC0\xAF", "\xED\xA0\x80", "\xF4\x90\x80\x80",
+   "a\x80b"].each do |str|
+    s = str.dup
+    s.inspect
+    assert_raise(ArgumentError) { s.codepoints }
+  end
+
+  s = "\xED\xA0\x80"
+  s.inspect
+  assert_raise(ArgumentError) { s.ord }
+  s = "\xED\xA0\x80"
+  s.inspect
+  assert_equal "\u{FFFD}" * 3, s.scrub
+
+  # an ASCII string does hold one character per byte, and is still read so
+  s = "abc"
+  s.inspect
+  assert_equal [97, 98, 99], s.codepoints
+  assert_equal "abc", s.scrub
+end if UTF8STRING
+
 assert('String#strip') do
   s = "  abc  "
   assert_equal("abc", s.strip)

--- a/src/string.c
+++ b/src/string.c
@@ -618,9 +618,22 @@ mrb_str_char_len(mrb_state *mrb, mrb_value str)
     return byte_len;
   }
   else {
-    mrb_int utf8_len = mrb_utf8_strlen(RSTR_PTR(s), byte_len);
+    const char *p = RSTR_PTR(s);
+    const char *e = p + byte_len;
+    const char *np = search_nonascii(p, e);
+
+    /* Every character a non-ASCII byte begins spells two bytes or more, and a
+       non-ASCII byte that begins none spells no character at all, so a string
+       holds one character per byte exactly when every byte of it is ASCII.
+       Counts that come out equal do not say that: a byte spelling no character
+       is counted as one too, so a string of them set the flag as well, and the
+       readers of it went on to hand those bytes back as characters. */
+    if (np == e) {
+      RSTR_SET_SINGLE_BYTE_FLAG(s);
+      return byte_len;
+    }
+    mrb_int utf8_len = (mrb_int)(np - p) + mrb_utf8_strlen(np, (mrb_int)(e - np));
     mrb_assert(utf8_len <= byte_len);
-    if (byte_len == utf8_len) RSTR_SET_SINGLE_BYTE_FLAG(s);
     return utf8_len;
   }
 }
@@ -632,9 +645,7 @@ mrb_str_valid_encoding_p(mrb_state *mrb, mrb_value str)
   (void)mrb;
   struct RString *s = mrb_str_ptr(str);
   /* A byte-indexed string makes no such claim, so it is valid whatever its
-     bytes are. MRB_STR_SINGLE_BYTE is deliberately not read here: it says one
-     byte per character, which a string of stray bytes satisfies too, so only
-     the walk below decides. */
+     bytes are. */
   if (RSTR_BINARY_P(s)) return TRUE;
   if (RSTR_VALID_ENC_P(s)) return TRUE;
 

--- a/src/string.c
+++ b/src/string.c
@@ -1737,7 +1737,8 @@ str_escape(mrb_state *mrb, mrb_value str, mrb_bool inspect)
   char buf[4];  /* `\x??` or UTF-8 character */
   mrb_value result = mrb_str_new_lit(mrb, "\"");
 #ifdef MRB_UTF8_STRING
-  uint32_t sb_flag = MRB_STR_SINGLE_BYTE;
+  uint32_t sb_flag = MRB_STR_SINGLE_BYTE;      /* what `result` comes out as */
+  uint32_t src_sb_flag = MRB_STR_SINGLE_BYTE;  /* what the walk found `str` to be */
 #endif
 
   p = RSTRING_PTR(str); pend = RSTRING_END(str);
@@ -1752,6 +1753,12 @@ str_escape(mrb_state *mrb, mrb_value str, mrb_bool inspect)
 #ifdef MRB_UTF8_STRING
     if (inspect) {
       mrb_int clen = mrb_utf8len(p, pend);
+      /* A non-ASCII byte either begins a character of several bytes or begins
+         no character at all, and either way `str` is not one byte per
+         character. The escape below turns the second into `\xNN`, so `result`
+         still is, and only a whole character copied across takes that from
+         it. */
+      if (NOASCII(*p)) src_sb_flag = 0;
       if (clen > 1) {
         mrb_str_cat(mrb, result, p, clen);
         p += clen-1;
@@ -1797,7 +1804,7 @@ str_escape(mrb_state *mrb, mrb_value str, mrb_bool inspect)
   mrb_str_cat_lit(mrb, result, "\"");
 #ifdef MRB_UTF8_STRING
   if (inspect) {
-    mrb_str_ptr(str)->flags |= sb_flag;
+    mrb_str_ptr(str)->flags |= src_sb_flag;
     mrb_str_ptr(result)->flags |= sb_flag;
   }
   else {

--- a/test/t/string.rb
+++ b/test/t/string.rb
@@ -78,6 +78,20 @@ assert('String#[](UTF-8)', '15.2.10.5.6') do
   assert_equal "世", "こんにちは世界"["世"]
 end if UTF8STRING
 
+assert('String#[](UTF-8) indexes a byte that spells no character on its own') do
+  # Such a byte is a position of its own, which is what String#length counts
+  # it as, and it takes that one position beside whole characters too.
+  s = "\xED\xA0\x80"
+  assert_equal "\xED", s[0]
+  assert_equal "\xA0", s[1]
+  assert_equal "\x80", s[2]
+  assert_nil s[3]
+  assert_equal "\xA0\x80", s[1, 2]
+  assert_equal "b", "a\xE3\x81b"[3]
+  assert_equal "\x80", "あ\x80"[1]
+  assert_equal "あ", "\x80あ"[1]
+end if UTF8STRING
+
 assert('String#[] with Range') do
   a1 = 'abc'[1..0]
   b1 = 'abc'[1..1]
@@ -795,6 +809,17 @@ assert('String#size(UTF-8) counts invalid sequences per byte') do
   assert_equal 1, "\u{D7FF}".size          # last code point before surrogates
   assert_equal 1, "\u{E000}".size          # first code point after surrogates
   assert_equal 1, "\u{10FFFF}".size        # largest valid code point
+end if UTF8STRING
+
+assert('String#size(UTF-8) counts a broken sequence beside whole characters') do
+  # The bytes of a broken sequence count one each wherever they sit, so a
+  # string that carries one counts more positions than it holds characters.
+  assert_equal 4, "abc\x80".size
+  assert_equal 4, "\x80abc".size
+  assert_equal 2, "あ\x80".size
+  assert_equal 2, "\x80あ".size
+  assert_equal 4, "a\xE3\x81b".size
+  assert_equal 4, "\u{1F600}\xC0\xAF\xC0".size
 end if UTF8STRING
 
 assert('String#slice', '15.2.10.5.34') do


### PR DESCRIPTION
## The flag

`MRB_STR_SINGLE_BYTE` says a string holds one character per byte, and its
readers take it as leave to step through the bytes without decoding them.
`RSTR_SET_ASCII_FLAG` is a second name for setting it, and `String#ascii_only?`
sets it exactly where every byte is ASCII.

Two places set it from a weaker fact. `mrb_str_char_len()` sets it when the
character count comes out equal to the byte count, and `str_escape()` sets it on
the receiver of `inspect` when the walk copied no character of several bytes
across. A byte that spells no character is counted as one, and is escaped one at
a time, so a string carrying nothing else satisfies both.

## What that cost

```ruby
s = "\xED\xA0\x80"
s.codepoints         # ArgumentError
s.length             #=> 3
s.codepoints         #=> [237, 160, 128]
s.ord                #=> 237, where it raised
s.scrub.bytes        #=> [237, 160, 128], where it was [239, 191, 189] * 3
```

`inspect` leaves the string the same way, and the flag survives `dup`,
`replace`, `String#*`, `freeze` and a byte slice, so the answer travels. CRuby
answers all of these the same way whatever ran before.

`String#scrub` is the one that matters most: a string of broken bytes is exactly
what it exists to repair, and it handed the string back untouched wherever
anything had counted it first.

## The change

Every character a non-ASCII byte begins spells two bytes or more, and a
non-ASCII byte that begins none spells no character at all, so a string holds
one character per byte exactly when every byte of it is ASCII. Both places now
ask that.

`mrb_str_char_len()` already looks for the first non-ASCII byte before it counts
anything, so where there is none the answer is the byte count and the flag
holds, and where there is one the count carries on from it. `str_escape()`
clears the receiver's flag as soon as it meets a non-ASCII byte. The flag it
puts on what `inspect` returns keeps its old rule, since `\xNN` is what a byte
spelling no character is escaped to and the return is still one character per
byte; only a whole character copied across takes that from it. The two answers
needed separating to say so.

## What does not change

`String#length`, `#size`, `#chars`, `#[]`, `#inspect` and `#dump` answer exactly
as before. A byte that spells no character is still counted as a character and
still takes an index of its own. The walks that `#chars` and `#[]` fall back to
without the flag read such a byte as one character anyway, which is what the
first commit pins.

## The cost

A string that is not all ASCII is counted every time it is asked. Broken strings
used to be counted once and remembered; they now join the class every valid
multi-byte string was already in. Counting a 100 KB string 2000 times:

| receiver | before | after |
| --- | --- | --- |
| all ASCII | 0.2 ms | 0.1 ms |
| valid multi-byte | 243 ms | 187 ms |
| bytes that spell no character | 0.5 ms | 196 ms |

The ASCII path is one `search_nonascii()` sweep either way, and the flag still
holds after the first count.

## What is left

`int_chr_binary()` in `mruby-string-ext` sets the flag on a one-byte string
whose byte may be `0x80` or above, and sets no `MRB_STR_BINARY` beside it. Under
the narrower meaning that is a false statement, though what it produces is what
CRuby produces:

```ruby
171.chr.codepoints        #=> [171] in CRuby and in mruby
171.chr.valid_encoding?   #=> true in CRuby, false in mruby
```

Setting `MRB_STR_BINARY` there instead would close it, and would settle the
second line as well. That is a separate change and is not in this PR.

With it closed, `mrb_str_valid_encoding_p()` could answer `true` from the flag
alone and feed the `MRB_STR_VALID_ENC` cache. This PR only removes the comment
that said the flag could not be read there.

## Tests

The first commit pins what a byte spelling no character counts and indexes as,
before anything moves. Each of the other two carries the cases its own change
decides, and taking either change back out fails that commit's assertions and no
others.

`rake test` is green on three builds: `full-core` with `MRB_UTF8_STRING`, the
`default` gembox without it, and `full-core` with `MRB_UTF8_STRING` and
`MRB_INT32`. Each commit was checked on its own. A sweep of nine broken strings
against twenty-four ways of touching one first found 91 places where the bytes
came back as characters, and none after.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of malformed UTF-8 strings.
  * String length, character access, iteration, inspection, and escaping now preserve invalid-byte information correctly.
  * Invalid and truncated byte sequences are counted and handled consistently instead of being incorrectly treated as ASCII.
  * Operations such as `ord`, `codepoints`, and `scrub` now produce the expected results for malformed strings while maintaining normal ASCII behavior.

* **Tests**
  * Added comprehensive coverage for invalid, truncated, mixed, and valid UTF-8 strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->