### PR TITLE
Stop `Integer#chr` from calling a stray byte a character

### DIFF
--- a/mrbgems/mruby-encoding/test/numeric.rb
+++ b/mrbgems/mruby-encoding/test/numeric.rb
@@ -36,15 +36,19 @@ assert('Integer#chr(binary) of a byte that spells no character') do
   assert_equal 171, s.ord
   assert_equal [171], s.scrub.bytes
   assert_equal "\"\\xab\"", s.inspect
-  assert_equal Encoding::UTF_8, s.encoding
-  assert_false s.valid_encoding?
+  assert_equal Encoding::BINARY, s.encoding
+  assert_true s.valid_encoding?
+  assert_equal Encoding::BINARY, s.dup.encoding
+  # and handing the same bytes to the UTF-8 reading says what they are there
+  assert_false s.force_encoding(Encoding::UTF_8).valid_encoding?
 
   # a lead byte with nothing behind it spells no character either
   e = 0xE3.chr
   assert_equal [0xE3], e.bytes
   assert_equal 1, e.length
-  assert_equal Encoding::UTF_8, e.encoding
-  assert_false e.valid_encoding?
+  assert_equal Encoding::BINARY, e.encoding
+  assert_true e.valid_encoding?
+  assert_false e.force_encoding(Encoding::UTF_8).valid_encoding?
 
   # ASCII spells a character of its own however the string is read
   a = 65.chr

--- a/mrbgems/mruby-encoding/test/numeric.rb
+++ b/mrbgems/mruby-encoding/test/numeric.rb
@@ -25,3 +25,41 @@ assert('Integer#chr') do
     assert_raise(RangeError) { 0x110000.chr.chr("UTF-8") }
   end
 end
+
+assert('Integer#chr(binary) of a byte that spells no character') do
+  # A byte of 0x80 and above spells no UTF-8 character on its own, so what
+  # `chr` hands back for one is read a byte at a time rather than decoded.
+  s = 171.chr
+  assert_equal [171], s.bytes
+  assert_equal 1, s.length
+  assert_equal [171], s.codepoints
+  assert_equal 171, s.ord
+  assert_equal [171], s.scrub.bytes
+  assert_equal "\"\\xab\"", s.inspect
+  assert_equal Encoding::UTF_8, s.encoding
+  assert_false s.valid_encoding?
+
+  # a lead byte with nothing behind it spells no character either
+  e = 0xE3.chr
+  assert_equal [0xE3], e.bytes
+  assert_equal 1, e.length
+  assert_equal Encoding::UTF_8, e.encoding
+  assert_false e.valid_encoding?
+
+  # ASCII spells a character of its own however the string is read
+  a = 65.chr
+  assert_equal [65], a.bytes
+  assert_equal 1, a.length
+  assert_equal [65], a.codepoints
+  assert_equal Encoding::UTF_8, a.encoding
+  assert_true a.valid_encoding?
+
+  # `<<` reads an Integer as a code point and `append_as_bytes` as a byte;
+  # neither takes anything from what `chr` returns but its bytes
+  s = "".dup
+  s << 171
+  assert_equal [0xC2, 0xAB], s.bytes
+  t = "".dup
+  t.append_as_bytes(171)
+  assert_equal [171], t.bytes
+end if __ENCODING__ == "UTF-8"

--- a/mrbgems/mruby-encoding/test/string.rb
+++ b/mrbgems/mruby-encoding/test/string.rb
@@ -43,8 +43,9 @@ assert('String#valid_encoding?') do
     assert_false "あ\xfe".valid_encoding?
     assert_true "あ\xfe".b.valid_encoding?
 
-    # Measuring a string of stray bytes marks it as one byte per character,
-    # which is true of it and says nothing about whether it is valid.
+    # Measuring a string counts a byte that spells no character as a position
+    # of its own, and marks nothing about the string that this answer is read
+    # off.
     s = "a\x80"
     assert_equal 2, s.size
     assert_false s.valid_encoding?
@@ -62,14 +63,54 @@ assert('String#valid_encoding?') do
     assert_true "\u{E000}".valid_encoding?           # first code point after surrogates
     assert_true "\u{10FFFF}".valid_encoding?         # largest valid code point
 
-    # The same sequences, measured before they are asked about: counting each
-    # byte on its own is what marks the string one byte per character.
+    # The same sequences, measured before they are asked about
     ["\xC0\x80", "\xED\xA0\x80", "\xF5\x80\x80\x80"].each do |t|
       t.size
       assert_false t.valid_encoding?
     end
   else
     assert_true "\xfe".valid_encoding?
+  end
+end
+
+assert('String#valid_encoding? answers the same however the string was read first') do
+  # A string read once is marked as holding one character per byte where every
+  # byte of it is ASCII, and the answer here is taken off that mark rather than
+  # walked for. Nothing else a reading leaves behind may reach it, so ask the
+  # same question of the same bytes twice, once after a reading and once not.
+  if UTF8STRING
+    readings = [->(s) { s.length }, ->(s) { s.chars }, ->(s) { s[0] },
+                ->(s) { s.each_char { |c| } }, ->(s) { s.inspect },
+                ->(s) { s.ord rescue nil }, ->(s) { s.codepoints rescue nil }]
+    ["", "abc", "a" * 40, "あ", "あa", "a" * 40 + "\xfe", "\x80", "a\x80b",
+     "\xE3\x81", "\xC0\xAF", "\xED\xA0\x80", "\xF4\x90\x80\x80",
+     171.chr, 0xE3.chr, 65.chr].each do |base|
+      want = base.dup.valid_encoding?
+      readings.each do |read|
+        s = base.dup
+        read.call(s)
+        assert_equal want, s.valid_encoding?, "#{base.inspect} read first"
+      end
+    end
+  end
+end
+
+assert('a string that says it is UTF-8 and says it is valid spells its own bytes') do
+  # The encoding a string reports and the answer it gives for its own validity
+  # are kept apart on it, and either may be settled by a reading that never
+  # asked the other. Where the two say the bytes are UTF-8 and read as it, the
+  # code points taken off them have to spell those same bytes back.
+  if UTF8STRING
+    ["", "abc", "あ", "あa\u{1F600}", "\x80", "a\x80b", "\xED\xA0\x80",
+     "\xE3\x81", 171.chr, 0xE3.chr, 65.chr, "あ".b, "abc".b].each do |base|
+      [->(s) { s }, ->(s) { s.length; s }, ->(s) { s.inspect; s },
+       ->(s) { s.chars; s }].each do |read|
+        s = read.call(base.dup)
+        next unless s.encoding == Encoding::UTF_8 && s.valid_encoding?
+        back = s.codepoints.map { |cp| cp.chr("UTF-8") }.join
+        assert_equal s.bytes, back.bytes, "#{base.inspect} read first"
+      end
+    end
   end
 end
 

--- a/mrbgems/mruby-string-ext/src/string.c
+++ b/mrbgems/mruby-string-ext/src/string.c
@@ -1752,8 +1752,8 @@ str_chars_ary(mrb_state *mrb, mrb_value self)
   struct RString *s = mrb_str_ptr(self);
   const char *p = RSTR_PTR(s);
   const char *e = p + RSTR_LEN(s);
-  /* the count comes first: it is the exact capacity, and it settles the
-     single-byte flag the walk reads */
+  /* the count comes first: it is the exact capacity, and where every byte is
+     ASCII it also settles the single-byte flag the walk reads */
   mrb_value result = mrb_ary_new_capa(mrb, mrb_str_char_len(mrb, self));
 
 #ifdef MRB_UTF8_STRING

--- a/mrbgems/mruby-string-ext/src/string.c
+++ b/mrbgems/mruby-string-ext/src/string.c
@@ -20,7 +20,17 @@ int_chr_binary(mrb_state *mrb, mrb_value num)
   }
   char c = (char)cp;
   mrb_value str = mrb_str_new(mrb, &c, 1);
-  RSTR_SET_ASCII_FLAG(mrb_str_ptr(str));
+  /* A byte below 0x80 is a character of its own and the string is ASCII. Above
+     it the byte spells no UTF-8 character at all, so the string is not one
+     character per byte and saying that it is left every reader of the flag
+     handing the byte back as a character. What it is instead is a string read
+     by bytes, which is what MRB_STR_BINARY says. */
+  if (cp < 0x80) {
+    RSTR_SET_ASCII_FLAG(mrb_str_ptr(str));
+  }
+  else {
+    mrb_str_ptr(str)->flags |= MRB_STR_BINARY;
+  }
   return str;
 }
 

--- a/mrbgems/mruby-string-ext/test/string.rb
+++ b/mrbgems/mruby-string-ext/test/string.rb
@@ -1040,6 +1040,56 @@ assert('String#ord rejects malformed sequences') do
   assert_raise(ArgumentError) { "\xF4\x90\x80\x80".ord }
 end if UTF8STRING
 
+assert('a malformed sequence stays malformed once the string is counted') do
+  # Counting characters remembers a string that holds one per byte, so that
+  # whatever reads it next may step by bytes. Bytes that spell no character
+  # count one per byte as well, and were remembered the same way, after which
+  # they came back as the characters the string does not hold.
+  counters = {
+    "length"    => ->(s) { s.length },
+    "chars"     => ->(s) { s.chars },
+    "each_char" => ->(s) { s.each_char { |c| } },
+    "[]"        => ->(s) { s[0] },
+  }
+  broken = ["\x80", "\xE3\x81", "\xC0\xAF", "\xED\xA0\x80", "\xF4\x90\x80\x80",
+            "a\x80b", "あ\x80"]
+  # #ord reads the first character, so it answers wherever that one is whole
+  ord_answers = { "a\x80b" => 97, "あ\x80" => 12354 }
+
+  counters.each do |name, count|
+    broken.each do |str|
+      s = str.dup
+      count.call(s)
+      assert_raise(ArgumentError, "#{str.inspect}.codepoints after #{name}") { s.codepoints }
+    end
+    broken.each do |str|
+      s = str.dup
+      count.call(s)
+      want = ord_answers[str]
+      if want
+        assert_equal want, s.ord, "#{str.inspect}.ord after #{name}"
+      else
+        assert_raise(ArgumentError, "#{str.inspect}.ord after #{name}") { s.ord }
+      end
+    end
+
+    # scrub has nothing to replace only where the bytes read as characters
+    s = "\xED\xA0\x80"
+    count.call(s)
+    assert_equal "\u{FFFD}" * 3, s.scrub
+    s = "\xED\xA0\x80"
+    count.call(s)
+    assert_equal "???", s.scrub("?")
+
+    # an ASCII string does hold one character per byte, and is still read so
+    s = "abc"
+    count.call(s)
+    assert_equal [97, 98, 99], s.codepoints
+    assert_equal 97, s.ord
+    assert_equal "abc", s.scrub
+  end
+end if UTF8STRING
+
 assert('String#each_codepoint') do
   expect = [104, 101, 108, 108, 111, 33]
   cp = []

--- a/mrbgems/mruby-string-ext/test/string.rb
+++ b/mrbgems/mruby-string-ext/test/string.rb
@@ -27,6 +27,33 @@ assert('String#inspect of a binary string escapes every byte') do
   end
 end
 
+assert('String#inspect leaves a malformed sequence malformed') do
+  # `inspect` remembers a string it walked without meeting a character of
+  # several bytes, so that whatever reads it next may step by bytes. A byte
+  # spelling no character is escaped one at a time as well, and was remembered
+  # the same way, after which it came back as a character the string does not
+  # hold.
+  ["\x80", "\xE3\x81", "\xC0\xAF", "\xED\xA0\x80", "\xF4\x90\x80\x80",
+   "a\x80b"].each do |str|
+    s = str.dup
+    s.inspect
+    assert_raise(ArgumentError) { s.codepoints }
+  end
+
+  s = "\xED\xA0\x80"
+  s.inspect
+  assert_raise(ArgumentError) { s.ord }
+  s = "\xED\xA0\x80"
+  s.inspect
+  assert_equal "\u{FFFD}" * 3, s.scrub
+
+  # an ASCII string does hold one character per byte, and is still read so
+  s = "abc"
+  s.inspect
+  assert_equal [97, 98, 99], s.codepoints
+  assert_equal "abc", s.scrub
+end if UTF8STRING
+
 assert('String#strip') do
   s = "  abc  "
   assert_equal("abc", s.strip)

--- a/src/string.c
+++ b/src/string.c
@@ -648,6 +648,13 @@ mrb_str_valid_encoding_p(mrb_state *mrb, mrb_value str)
      bytes are. */
   if (RSTR_BINARY_P(s)) return TRUE;
   if (RSTR_VALID_ENC_P(s)) return TRUE;
+  /* A string of one character per byte holds nothing but ASCII, and ASCII
+     reads as UTF-8 as it stands, so it is valid without a walk. This is what
+     a string counted before it is asked about comes in carrying. */
+  if (RSTR_SINGLE_BYTE_P(s)) {
+    RSTR_SET_VALID_ENC_FLAG(s);
+    return TRUE;
+  }
 
   mrb_int byte_len = RSTR_LEN(s);
   mrb_bool valid = TRUE;

--- a/src/string.c
+++ b/src/string.c
@@ -618,9 +618,22 @@ mrb_str_char_len(mrb_state *mrb, mrb_value str)
     return byte_len;
   }
   else {
-    mrb_int utf8_len = mrb_utf8_strlen(RSTR_PTR(s), byte_len);
+    const char *p = RSTR_PTR(s);
+    const char *e = p + byte_len;
+    const char *np = search_nonascii(p, e);
+
+    /* Every character a non-ASCII byte begins spells two bytes or more, and a
+       non-ASCII byte that begins none spells no character at all, so a string
+       holds one character per byte exactly when every byte of it is ASCII.
+       Counts that come out equal do not say that: a byte spelling no character
+       is counted as one too, so a string of them set the flag as well, and the
+       readers of it went on to hand those bytes back as characters. */
+    if (np == e) {
+      RSTR_SET_SINGLE_BYTE_FLAG(s);
+      return byte_len;
+    }
+    mrb_int utf8_len = (mrb_int)(np - p) + mrb_utf8_strlen(np, (mrb_int)(e - np));
     mrb_assert(utf8_len <= byte_len);
-    if (byte_len == utf8_len) RSTR_SET_SINGLE_BYTE_FLAG(s);
     return utf8_len;
   }
 }
@@ -632,9 +645,7 @@ mrb_str_valid_encoding_p(mrb_state *mrb, mrb_value str)
   (void)mrb;
   struct RString *s = mrb_str_ptr(str);
   /* A byte-indexed string makes no such claim, so it is valid whatever its
-     bytes are. MRB_STR_SINGLE_BYTE is deliberately not read here: it says one
-     byte per character, which a string of stray bytes satisfies too, so only
-     the walk below decides. */
+     bytes are. */
   if (RSTR_BINARY_P(s)) return TRUE;
   if (RSTR_VALID_ENC_P(s)) return TRUE;
 

--- a/src/string.c
+++ b/src/string.c
@@ -1737,7 +1737,8 @@ str_escape(mrb_state *mrb, mrb_value str, mrb_bool inspect)
   char buf[4];  /* `\x??` or UTF-8 character */
   mrb_value result = mrb_str_new_lit(mrb, "\"");
 #ifdef MRB_UTF8_STRING
-  uint32_t sb_flag = MRB_STR_SINGLE_BYTE;
+  uint32_t sb_flag = MRB_STR_SINGLE_BYTE;      /* what `result` comes out as */
+  uint32_t src_sb_flag = MRB_STR_SINGLE_BYTE;  /* what the walk found `str` to be */
 #endif
 
   p = RSTRING_PTR(str); pend = RSTRING_END(str);
@@ -1752,6 +1753,12 @@ str_escape(mrb_state *mrb, mrb_value str, mrb_bool inspect)
 #ifdef MRB_UTF8_STRING
     if (inspect) {
       mrb_int clen = mrb_utf8len(p, pend);
+      /* A non-ASCII byte either begins a character of several bytes or begins
+         no character at all, and either way `str` is not one byte per
+         character. The escape below turns the second into `\xNN`, so `result`
+         still is, and only a whole character copied across takes that from
+         it. */
+      if (NOASCII(*p)) src_sb_flag = 0;
       if (clen > 1) {
         mrb_str_cat(mrb, result, p, clen);
         p += clen-1;
@@ -1797,7 +1804,7 @@ str_escape(mrb_state *mrb, mrb_value str, mrb_bool inspect)
   mrb_str_cat_lit(mrb, result, "\"");
 #ifdef MRB_UTF8_STRING
   if (inspect) {
-    mrb_str_ptr(str)->flags |= sb_flag;
+    mrb_str_ptr(str)->flags |= src_sb_flag;
     mrb_str_ptr(result)->flags |= sb_flag;
   }
   else {

--- a/test/t/string.rb
+++ b/test/t/string.rb
@@ -78,6 +78,20 @@ assert('String#[](UTF-8)', '15.2.10.5.6') do
   assert_equal "世", "こんにちは世界"["世"]
 end if UTF8STRING
 
+assert('String#[](UTF-8) indexes a byte that spells no character on its own') do
+  # Such a byte is a position of its own, which is what String#length counts
+  # it as, and it takes that one position beside whole characters too.
+  s = "\xED\xA0\x80"
+  assert_equal "\xED", s[0]
+  assert_equal "\xA0", s[1]
+  assert_equal "\x80", s[2]
+  assert_nil s[3]
+  assert_equal "\xA0\x80", s[1, 2]
+  assert_equal "b", "a\xE3\x81b"[3]
+  assert_equal "\x80", "あ\x80"[1]
+  assert_equal "あ", "\x80あ"[1]
+end if UTF8STRING
+
 assert('String#[] with Range') do
   a1 = 'abc'[1..0]
   b1 = 'abc'[1..1]
@@ -795,6 +809,17 @@ assert('String#size(UTF-8) counts invalid sequences per byte') do
   assert_equal 1, "\u{D7FF}".size          # last code point before surrogates
   assert_equal 1, "\u{E000}".size          # first code point after surrogates
   assert_equal 1, "\u{10FFFF}".size        # largest valid code point
+end if UTF8STRING
+
+assert('String#size(UTF-8) counts a broken sequence beside whole characters') do
+  # The bytes of a broken sequence count one each wherever they sit, so a
+  # string that carries one counts more positions than it holds characters.
+  assert_equal 4, "abc\x80".size
+  assert_equal 4, "\x80abc".size
+  assert_equal 2, "あ\x80".size
+  assert_equal 2, "\x80あ".size
+  assert_equal 4, "a\xE3\x81b".size
+  assert_equal 4, "\u{1F600}\xC0\xAF\xC0".size
 end if UTF8STRING
 
 assert('String#slice', '15.2.10.5.34') do


### PR DESCRIPTION
Stacked on #7131, which narrowed `MRB_STR_SINGLE_BYTE` to mean that every byte
of the string is ASCII. Its three commits are the first three here and are not
part of this change; the three after them close the one place left that set the
flag on a byte spelling no character, and then put the narrower meaning to use.

## `Integer#chr`

`int_chr_binary()` takes any byte from 0 to 0xff, and set `MRB_STR_SINGLE_BYTE`
on whatever one-byte string it built. `RSTR_SET_ASCII_FLAG` is a second name for
setting that flag, and its readers take it as leave to step through the bytes
without decoding them. A byte of 0x80 and above spells no UTF-8
character at all, so the flag was a false statement about every such string,
and the string went on reporting UTF-8 while refusing to read as it:

```ruby
171.chr.encoding          #=> ASCII-8BIT in CRuby, UTF-8 in mruby
171.chr.valid_encoding?   #=> true in CRuby, false in mruby
```

`MRB_STR_BINARY` is what says a string is read by bytes, so set that instead,
and keep the ASCII flag for a byte below 0x80. CRuby draws the same line,
handing back US-ASCII below 0x80 and ASCII-8BIT above it; mruby has no
US-ASCII and reads such a string as UTF-8, which holds it exactly.

Nothing else about the string moves. The code points and the ordinal read off
it already came out right, through the branch a byte-indexed string takes
anyway, and `inspect` escaped the byte as `\xNN` before and escapes it as
`\xNN` now. `<<`, `concat` and `append_as_bytes` reach the same helper but
take only the bytes off what it returns, through `mrb_str_cat_str()`.

## `valid_encoding?`

With that closed, `MRB_STR_SINGLE_BYTE` is set nowhere but on a string of
ASCII bytes, and ASCII reads as UTF-8 as it stands. `mrb_str_valid_encoding_p()`
can answer `true` from the flag and leave the answer in `MRB_STR_VALID_ENC`,
which is where the walk would have put it.

That is what a string counted before it is asked about comes in carrying.
Asking 2000 counted 5 KB ASCII strings once each: 0.5 ms before, 0.2 ms after.
A string that was not counted first, and one that is not ASCII, are unaffected.

The order matters: the fast path on its own, without the first change, makes
`0xE3.chr` report UTF-8 and call itself valid, and the whole test suite still
passes. That is why the two are separate commits and why the test below asks
for the round trip rather than for either answer.

## What is left

`String#+` builds its result with `str_new()` and carries no flag over, so
`171.chr + "b"` still comes out as a UTF-8 string of a byte that spells
nothing, where CRuby gives `[171, 98]`. That is `mrb_str_plus()`, not this,
and is left alone here. `String#dup` does carry the flag, through
`str_replace()`.

## Tests

The fourth commit pins what `Integer#chr` hands back for a byte above ASCII
before anything moves, including the two answers the fifth changes.

The sixth adds two invariants. One asks `valid_encoding?` of the same bytes
twice, once after the string has been read by `length`, `chars`, `[]`,
`each_char`, `inspect`, `ord` or `codepoints`, and once not: the two have to
agree, which is what makes reading the answer off a flag sound. The other asks
that a string reporting UTF-8 and calling itself valid spells its own bytes
back from its code points, which is the check the flag cannot satisfy by
itself. Taking the `Integer#chr` change back out fails both and nothing else.

Two comments in the existing tests said that measuring a string of stray bytes
marks it one byte per character. That stopped being so in #7131 and is what
the last commit rests on, so they are dropped; the assertions under them stay.

`rake test` is green on three builds: `full-core` with `MRB_UTF8_STRING`, the
`default` gembox without it, and `full-core` with `MRB_UTF8_STRING` and
`MRB_INT32`. Each commit was checked on its own.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of malformed and incomplete UTF-8 strings.
  - Corrected character indexing, length, encoding validity, escaping, inspection, and scrubbing behavior for invalid bytes.
  - Ensured ASCII and binary strings are classified correctly.
  - Preserved consistent results after character-counting and read operations.

- **Tests**
  - Added comprehensive coverage for invalid UTF-8 sequences, standalone bytes, valid characters, codepoints, and custom scrub replacements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->