### PR TITLE
mruby-regexp: refuse a broken subject at the entry to `split`

### DIFF
--- a/mrbgems/mruby-regexp/mrblib/string_regexp.rb
+++ b/mrbgems/mruby-regexp/mrblib/string_regexp.rb
@@ -286,6 +286,13 @@ class String
     # could steer itself around the check below and reach `__split` instead.
     # `Module#===` reads the real type and cannot be redefined.
     if NilClass === pattern || String === pattern
+      # `__split` is core's `split`, which reaches no search of this gem's, so
+      # the subject would go unread on this path where every other one refuses
+      # it. CRuby refuses a String or nil pattern too, unlike the literal a
+      # search is given, which is why this is not the exemption `sub` takes.
+      # A limit of 1 hands the subject back whole without looking into it, and
+      # CRuby answers for that as well, so the check waits behind it.
+      Regexp.__check_encoding(self) unless limit == 1
       return limit_given ? __split(pattern, limit) : __split(pattern)
     end
     return self.empty? ? [] : [self] if limit == 1

--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -263,6 +263,24 @@ regexp_binary_string_p(mrb_state *mrb, mrb_value self)
   return mrb_bool_value(re_binary_string_p(str));
 }
 
+/*
+ * Regexp.__check_encoding(str)
+ *
+ * Internal: the check above, for the one caller that reaches no search of this
+ * gem's. `String#split` hands a String or nil pattern to core's `split`, which
+ * this gem keeps under `__split`, so nothing on that path passes an entry
+ * point that would ask the question.
+ */
+static mrb_value
+regexp_check_encoding(mrb_state *mrb, mrb_value self)
+{
+  (void)self;
+  mrb_value str;
+  mrb_get_args(mrb, "S", &str);
+  re_check_encoding(mrb, str);
+  return mrb_nil_value();
+}
+
 /* Publish `obj` and the thirteen names derived from its offsets, the
    counterpart of clear_match_globals(). Kept apart from create_matchdata() so
    that an existing MatchData can be republished without rebuilding it. */
@@ -1392,6 +1410,7 @@ mrb_mruby_regexp_gem_init(mrb_state *mrb)
   mrb_define_class_method(mrb, re, "escape", regexp_escape, MRB_ARGS_REQ(1));
   mrb_define_class_method(mrb, re, "quote", regexp_escape, MRB_ARGS_REQ(1));
   mrb_define_class_method(mrb, re, "__binary_string?", regexp_binary_string_p, MRB_ARGS_REQ(1));
+  mrb_define_class_method(mrb, re, "__check_encoding", regexp_check_encoding, MRB_ARGS_REQ(1));
   mrb_define_class_method(mrb, re, "__check_pattern", regexp_check_pattern, MRB_ARGS_REQ(1));
   mrb_define_class_method(mrb, re, "__search", regexp_s_search, MRB_ARGS_ARG(2, 2));
   mrb_define_class_method(mrb, re, "__byte_search", regexp_s_byte_search, MRB_ARGS_ARG(2, 2));

--- a/mrbgems/mruby-regexp/test/regexp_utf8.rb
+++ b/mrbgems/mruby-regexp/test/regexp_utf8.rb
@@ -617,11 +617,30 @@ assert("Regexp - a subject whose bytes are not UTF-8 is refused") do
   assert_equal broken.index("b"), $~.begin(0)
   assert_raise(ArgumentError) { broken.scan("b") }
 
+  # `split` is the other exception, and it takes every pattern with it: CRuby
+  # refuses a String, a nil and the awk form as well as a Regexp. A String
+  # pattern reaches core's `split` here, which searches for a literal without
+  # this gem in the way, so the refusal is asked for at the entry instead.
+  assert_raise(ArgumentError) { broken.split("b") }
+  assert_raise(ArgumentError) { broken.split }
+  assert_raise(ArgumentError) { broken.split(" ") }
+  assert_raise(ArgumentError) { broken.split("b", -1) }
+  assert_raise(ArgumentError) { broken.split("b", 2) }
+  # A limit of 1 hands the subject back whole without reading it, whatever the
+  # pattern, and CRuby answers for that too.
+  assert_equal [broken], broken.split("b", 1)
+  assert_equal [broken], broken.split(nil, 1)
+  assert_equal [broken], broken.split(" ", 1)
+  assert_equal [broken], broken.split(/b/, 1)
+  # The limit is converted before the subject is read, as in CRuby.
+  assert_raise(TypeError) { broken.split("b", "x") }
+
   # A byte-indexed subject is indexed by byte throughout, so its bytes make no
   # claim that could be broken and it goes through as it always did.
   assert_equal 4, (broken.b =~ /b/)
   assert_equal 4, broken.b.match(/b/).begin(0)
   assert_equal "あ\x80!".b, broken.b.sub(/b/, "!")
+  assert_equal ["あ\x80".b], broken.b.split("b")
 
   # A whole subject is untouched, including one the walk reads to the end.
   assert_equal 2, ("あいb" =~ /b/)


### PR DESCRIPTION
Builds on #7126 and #7127, which refuse a search whose subject holds a byte that spells no character and exempt the literal a quoted String pattern is searched for. `split` is what they left: CRuby refuses it whatever the pattern, and here a String or nil pattern answers.

```ruby
"あ\x80b".split("b")  # CRuby: ArgumentError, before this: ["あ\x80"]
"あ\x80b".split       # CRuby: ArgumentError, before this: ["あ\x80b"]
"あ\x80b".split(" ")  # CRuby: ArgumentError, before this: ["あ\x80b"]
```

`String#split` hands those three to core's `split`, which this gem keeps under `__split`, so the path reaches no search of the gem's and the check every other call runs never fires. The refusal goes at the entry instead, through a `Regexp.__check_encoding` class method that is `re_check_encoding()` under a name mrblib can call.

### On the name

#7110 carried a class method of this name to run the check once at the entry to each mrblib loop rather than once per match. It went away when the flag core leaves on a string it has read made the two placements measure the same. What brings it back is a path no search covers, not what a search costs.

### What stays as it is

`byteindex` with a String pattern, and `gsub` with a block over one, answer a broken subject in CRuby too, so they keep the exemption #7127 gives them. Their Regexp forms already refuse.

A limit of 1 hands the subject back whole without reading it, whatever the pattern, and CRuby answers there too, so the check waits behind it. The limit is converted before either way: `"あ\x80b".split("b", "x")` raises `TypeError` in both.

A binary subject goes through as it did, since `mrb_str_valid_encoding_p()` takes a byte-indexed string as valid whatever its bytes are.

### Checked

- `rake test` on the default gembox: 2040 assertions, 0 failures; bintest 105, 0 failures
- `rake test` on a full-core build (`MRB_UTF8_STRING`): 2259 assertions, 0 failures
- `rake test` on a build without `MRB_UTF8_STRING`, holding mruby-regexp and mruby-string-ext: 1037 assertions, 0 failures
- every `split` form above compared against CRuby 4.0.6, which agrees with all of them


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `String#split` handling for invalid UTF-8 strings.
  * Splitting invalid UTF-8 content now raises `ArgumentError` when applicable, while `limit == 1` preserves the original string.
  * Invalid, non-integer split limits now raise `TypeError` consistently.
  * Preserved regular-expression splitting behavior for byte-oriented strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->