### PR TITLE
Add a .clangd so headers resolve their own types when opened directly

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,44 @@
+# Most headers in this tree are written to be included after mruby.h rather
+# than to be parsed on their own, so a language server pointed at one directly
+# resolves none of its types: they all decay to implicit int, and
+# go-to-definition falls back to a nearby identifier. Force-including mruby.h
+# gives clangd the context those headers already assume.
+#
+# The PathMatch list is deliberately narrow, so the vendored prism headers
+# under mrbgems/mruby-compiler/lib/prism/ are left alone.
+#
+# common.h and value.h are excluded because they sit on mruby.h's own include
+# chain: force-including it re-enters them through their include guards, which
+# leaves them worse off than with no configuration at all.
+If:
+  PathMatch:
+    - include/.*\.h
+    - src/.*\.h
+    - mrbgems/[^/]+/(include|src|core|tools)/.*\.h
+  PathExclude:
+    - mrbgems/mruby-compiler/include/.*
+    - include/mruby/common\.h
+    - include/mruby/value\.h
+
+CompileFlags:
+  Add:
+    - --include=mruby.h
+
+---
+# The compiler headers assume mrc_irep.h as well, which pulls in
+# mrc_ccontext.h and mrc_common.h.
+#
+# mrc_common.h is excluded for the same reason as common.h above.
+# mrc_ccontext.h is excluded because it forms a cycle with mrc_pool.h and
+# mrc_diagnostic.h, so re-entering it from a forced include only adds
+# "main file cannot be included recursively when building a preamble".
+If:
+  PathMatch: mrbgems/mruby-compiler/include/.*\.h
+  PathExclude:
+    - mrbgems/mruby-compiler/include/mrc_common\.h
+    - mrbgems/mruby-compiler/include/mrc_ccontext\.h
+
+CompileFlags:
+  Add:
+    - --include=mruby.h
+    - --include=mrc_irep.h


### PR DESCRIPTION
Closes #7134, where I asked whether this would be welcome. Opening a PR seemed
the faster way to have the actual file in front of you, and the configuration
here is a refinement of the one I sketched there: it now excludes the four
headers that the original made worse.

## The problem

Most headers in this tree are written to be included after `mruby.h`, not to be
parsed on their own. That is a deliberate property of the source, but it means a
language server pointed at one directly -- which is what an editor does the
moment you open the file -- resolves none of its types.

`include/mruby/internal.h` line 32:

```c
mrb_value mrb_obj_equal_m(mrb_state *mrb, mrb_value);
```

`textDocument/definition` on the first `mrb_value` answers with
`include/mruby/internal.h:32` -- that same line, the declaration of
`mrb_obj_equal_m`, found "heuristically using nearby identifier". Hover reports:

```text
function mrb_obj_equal_m
→ int
Parameters:
- int * mrb
- int
public: int mrb_obj_equal_m(int *mrb, int)
```

Every unresolved type has decayed to implicit `int`. The same holds in
`string.h`, `class.h`, `hash.h` and most of the rest.

Of the 87 tracked headers outside `oss-fuzz`, 35 produce parse errors when
checked on their own:

```sh
git ls-files '*.h' | grep -v '^oss-fuzz' | while read -r f; do
  n=$(clangd --check="$PWD/$f" 2>&1 | grep -cE '^E\[[^]]*\] \[[a-z_]+\] Line')
  [ "$n" -gt 0 ] && printf '%s\t%s\n' "$n" "$f"
done
```

## What this adds

A `.clangd` that force-includes `mruby.h` for the headers that assume it, and
`mrc_irep.h` as well for the compiler headers, which pulls in `mrc_ccontext.h`
and `mrc_common.h`.

The `PathMatch` list is deliberately narrow, so the vendored prism headers under
`mrbgems/mruby-compiler/lib/prism/` are left alone.

Four headers are excluded. `common.h`, `value.h` and `mrc_common.h` sit on
`mruby.h`'s own include chain, so a forced include re-enters them through their
include guards and leaves them worse off than no configuration at all --
`common.h` and `mrc_common.h` are clean without it, and `value.h` goes from 4
errors to 6. `mrc_ccontext.h` forms a cycle with `mrc_pool.h` and
`mrc_diagnostic.h`, so re-entering it only adds `main file cannot be included
recursively when building a preamble`.

## Result

The sweep goes from 35 failing headers to 9. 26 go from failing to clean, and
**no header ends up worse than it started** -- the ones that remain only lose
errors:

| header | before | after |
| --- | ---: | ---: |
| `include/mruby/array.h` | 18 | 1 |
| `include/mruby/boxing_nan.h` | 20 | 17 |
| `include/mruby/boxing_no.h` | 4 | 2 |
| `include/mruby/boxing_word.h` | 19 | 13 |
| `include/mruby/ops.h` | 1 | 1 |
| `include/mruby/value.h` | 4 | 4 |
| `mrbgems/mruby-bigint/core/bigint.h` | 3 | 1 |
| `mrbgems/mruby-compiler/include/mrc_ccontext.h` | 2 | 2 |
| `mrbgems/mruby-compiler/include/mrc_ops.h` | 1 | 1 |

The 26 that go from failing to clean:

```text
include/mruby/class.h        include/mruby/numeric.h   mrbgems/mruby-compiler/include/mrc_codedump.h
include/mruby/data.h         include/mruby/object.h    mrbgems/mruby-compiler/include/mrc_diagnostic.h
include/mruby/debug.h        include/mruby/range.h     mrbgems/mruby-compiler/include/mrc_endian.h
include/mruby/endian.h       include/mruby/re.h        mrbgems/mruby-compiler/include/mrc_irep_pool_type.h
include/mruby/error.h        include/mruby/string.h    mrbgems/mruby-compiler/include/mrc_pool.h
include/mruby/gc.h           include/mruby/variable.h  mrbgems/mruby-compiler/include/mrc_presym.h
include/mruby/hash.h                                   mrbgems/mruby-compiler/include/mrc_proc.h
include/mruby/internal.h                               mrbgems/mruby-regexp/src/re_cased.h
include/mruby/istruct.h                                mrbgems/mruby-regexp/src/re_casefold.h
include/mruby/mempool.h                                mrbgems/mruby-time/include/mruby/time.h
```

For the example above, definition now answers `include/mruby/boxing_word.h:141`
and hover reports:

```text
type-alias mrb_value
provided by "mruby/boxing_word.h"
Type: struct mrb_value
typedef struct mrb_value mrb_value
```

## What it deliberately does not fix

The remaining 9 are not reachable by configuration:

* `boxing_nan.h`, `boxing_no.h` -- only one boxing header is active per build,
  so the two the build did not pick report `redefinition of 'mrb_value'` once
  `mruby.h` has defined it. Force-including `mruby.h` cannot help here by
  construction.
* `ops.h`, `mrc_ops.h` -- X macro tables that expect `OPCODE()` from the
  includer, so they are not meant to parse standalone at all.
* `array.h`, `bigint.h` -- one `redefinition of '_mrb_static_assert_0'` each.
  With clang, `__GNUC__ * 100 + __GNUC_MINOR__` is 402, so `mrb_static_assert()`
  takes the `__COUNTER__`-based fallback in `mruby.h` even at `-std=gnu99`, and
  `__COUNTER__` restarts in the main file after the preamble.
* `boxing_word.h`, `value.h`, `mrc_ccontext.h` -- the include-chain and cycle
  cases described above. `boxing_word.h` still improves from 19 to 13, so it is
  left configured; the other two are excluded and keep their original counts.

## Why in the tree

`.vscode`, `.ccls*`, `compile_commands.json` and `compile_flags.txt` are all
gitignored, so editor and language server setup is clearly treated as a
per-developer concern here, and I would not argue with that in general. This one
seems different in kind: the headers deliberately depend on `mruby.h` having
been included first, so the include context a language server needs is a
property of the source tree rather than of any one developer's setup. `.clangd`
is inert to every build and to every tool that is not clangd.

If you would rather keep it out, I am happy to close this and send a one-line
`.gitignore` addition next to `.ccls*` instead.

## Verified with

```text
Homebrew clangd version 22.1.8
Features: mac+xpc
Platform: arm64-apple-darwin25.6.0
```

`compile_commands.json` generated with `MRUBY_CONFIG=ci/gcc-clang bear -- rake`,
so the commands clangd infers come from the `host`, `full-debug` and `cxx_abi`
builds.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Developer Experience**
  * Improved language-server support for project headers by automatically including required mruby declarations.
  * Added targeted handling for compiler headers while avoiding conflicts with vendored and recursive includes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->