### PR TITLE
Read a copy of a byte-read string's bytes the way they were read

### DIFF
--- a/mrbgems/mruby-encoding/test/string.rb
+++ b/mrbgems/mruby-encoding/test/string.rb
@@ -210,21 +210,21 @@ assert('String#encoding survives a copy') do
 end
 
 assert('what a string built out of a byte-read string claims') do
-  # A copy carries the byte reading with the bytes; nothing else that builds
-  # a string out of one does. Each of these hands back a string reporting
-  # UTF-8, most of them over bytes that refuse to read as it -- the state
-  # `Integer#chr` just stopped handing out, one derivation away. Pin where
-  # every answer stands before any of it moves.
+  # A copy carries the byte reading with the bytes, and so do the pieces cut
+  # out of the string and its repetitions. The sum, the shovel and the splice
+  # still hand back a string reporting UTF-8 over bytes that refuse to read
+  # as it -- the state `Integer#chr` just stopped handing out, one derivation
+  # away.
   if UTF8STRING
     b = "\xE3\x81\x82".b   # the bytes of a three-byte character, read as bytes
     assert_equal Encoding::BINARY, b.dup.encoding
     assert_equal Encoding::BINARY, b.reverse.encoding
     # a piece cut out of the string, and a repetition of it
-    assert_equal Encoding::UTF_8, b[0].encoding
-    assert_false b[0].valid_encoding?
-    assert_equal Encoding::UTF_8, b.chars[0].encoding
-    assert_equal Encoding::UTF_8, (171.chr * 2).encoding
-    assert_false (171.chr * 2).valid_encoding?
+    assert_equal Encoding::BINARY, b[0].encoding
+    assert_true b[0].valid_encoding?
+    assert_equal Encoding::BINARY, b.chars[0].encoding
+    assert_equal Encoding::BINARY, (171.chr * 2).encoding
+    assert_true (171.chr * 2).valid_encoding?
     # a sum with a byte-read operand on either side
     assert_equal Encoding::UTF_8, (171.chr + 171.chr).encoding
     assert_false (171.chr + 171.chr).valid_encoding?
@@ -240,5 +240,45 @@ assert('what a string built out of a byte-read string claims') do
     # rjust builds the pad first and drops it
     assert_equal Encoding::BINARY, 171.chr.ljust(3).encoding
     assert_equal Encoding::UTF_8, 171.chr.rjust(3).encoding
+  end
+end
+
+assert('a string cut out of a byte-read string') do
+  # A subrange of a byte-read string holds nothing but bytes of it, so it is
+  # read the same way. Every piece used to come back UTF-8, handing bytes that
+  # spell no character a claim they could not honor.
+  if UTF8STRING
+    b = "\xE3\x81\x82".b   # the bytes of a three-byte character, read as bytes
+    each_char_pieces = []
+    b.each_char { |c| each_char_pieces << c }
+    [b[0], b[0, 2], b[1..-1], b.chars[1], each_char_pieces[2],
+     b.byteslice(0, 2), b.dup.slice!(0)].each do |piece|
+      assert_equal Encoding::BINARY, piece.encoding
+      assert_true piece.valid_encoding?
+    end
+    assert_equal [0xE3], b[0].bytes
+    assert_equal [0x81, 0x82], b[1..-1].bytes
+    # what Integer#chr hands back for a stray byte stays byte-read when cut
+    assert_equal Encoding::BINARY, 171.chr[0].encoding
+    # splitting on a byte-read separator cuts byte-read pieces, and so does
+    # splitting on line ends
+    assert_equal Encoding::BINARY, b.split(b[1])[0].encoding
+    assert_equal Encoding::BINARY, "a\nb".b.lines[0].encoding
+    # a piece of a string read as UTF-8 goes on reading as UTF-8
+    assert_equal Encoding::UTF_8, "あい"[1].encoding
+    assert_equal "い", "あい"[1]
+  end
+end
+
+assert('a string built by repeating a byte-read string') do
+  # `*` lays the same bytes down over again, so what it builds is read the
+  # way the receiver was.
+  if UTF8STRING
+    s = 171.chr * 2
+    assert_equal [171, 171], s.bytes
+    assert_equal Encoding::BINARY, s.encoding
+    assert_true s.valid_encoding?
+    assert_equal Encoding::BINARY, ("abc".b * 2).encoding
+    assert_equal Encoding::UTF_8, ("あ" * 2).encoding
   end
 end

--- a/mrbgems/mruby-encoding/test/string.rb
+++ b/mrbgems/mruby-encoding/test/string.rb
@@ -211,10 +211,10 @@ end
 
 assert('what a string built out of a byte-read string claims') do
   # A copy carries the byte reading with the bytes, and so do the pieces cut
-  # out of the string and its repetitions. The sum, the shovel and the splice
-  # still hand back a string reporting UTF-8 over bytes that refuse to read
-  # as it -- the state `Integer#chr` just stopped handing out, one derivation
-  # away.
+  # out of the string, its repetitions and the pads built around it. The sum,
+  # the shovel and the splice still hand back a string reporting UTF-8 over
+  # bytes that refuse to read as it: the state `Integer#chr` just stopped
+  # handing out, one derivation away.
   if UTF8STRING
     b = "\xE3\x81\x82".b   # the bytes of a three-byte character, read as bytes
     assert_equal Encoding::BINARY, b.dup.encoding
@@ -236,10 +236,9 @@ assert('what a string built out of a byte-read string claims') do
     assert_false s.valid_encoding?
     assert_equal Encoding::UTF_8, [171.chr, 171.chr].join.encoding
     assert_equal Encoding::UTF_8, "ab".gsub("a", 171.chr).encoding
-    # ljust keeps the receiver's reading through the copy it pads after;
-    # rjust builds the pad first and drops it
+    # the receiver's bytes in wider clothes are read the way the receiver was
     assert_equal Encoding::BINARY, 171.chr.ljust(3).encoding
-    assert_equal Encoding::UTF_8, 171.chr.rjust(3).encoding
+    assert_equal Encoding::BINARY, 171.chr.rjust(3).encoding
   end
 end
 
@@ -280,5 +279,25 @@ assert('a string built by repeating a byte-read string') do
     assert_true s.valid_encoding?
     assert_equal Encoding::BINARY, ("abc".b * 2).encoding
     assert_equal Encoding::UTF_8, ("あ" * 2).encoding
+  end
+end
+
+assert('a byte-read string padded to width') do
+  # ljust, rjust and center hand back the receiver's bytes in wider clothes,
+  # so the result is read the way the receiver was, ASCII bytes and all.
+  if UTF8STRING
+    s = 171.chr
+    [s.ljust(3), s.rjust(3), s.center(4)].each do |padded|
+      assert_equal Encoding::BINARY, padded.encoding
+      assert_true padded.valid_encoding?
+    end
+    assert_equal [171, 32, 32], s.ljust(3).bytes
+    assert_equal [32, 32, 171], s.rjust(3).bytes
+    assert_equal [32, 171, 32, 32], s.center(4).bytes
+    # an ASCII receiver read as bytes keeps the byte reading too
+    assert_equal Encoding::BINARY, "abc".b.ljust(5).encoding
+    assert_equal Encoding::BINARY, "abc".b.rjust(5).encoding
+    assert_equal Encoding::BINARY, "abc".b.center(5).encoding
+    assert_equal Encoding::UTF_8, "あ".center(3).encoding
   end
 end

--- a/mrbgems/mruby-encoding/test/string.rb
+++ b/mrbgems/mruby-encoding/test/string.rb
@@ -208,3 +208,37 @@ assert('String#encoding survives a copy') do
     assert_equal Encoding::UTF_8, d.encoding
   end
 end
+
+assert('what a string built out of a byte-read string claims') do
+  # A copy carries the byte reading with the bytes; nothing else that builds
+  # a string out of one does. Each of these hands back a string reporting
+  # UTF-8, most of them over bytes that refuse to read as it -- the state
+  # `Integer#chr` just stopped handing out, one derivation away. Pin where
+  # every answer stands before any of it moves.
+  if UTF8STRING
+    b = "\xE3\x81\x82".b   # the bytes of a three-byte character, read as bytes
+    assert_equal Encoding::BINARY, b.dup.encoding
+    assert_equal Encoding::BINARY, b.reverse.encoding
+    # a piece cut out of the string, and a repetition of it
+    assert_equal Encoding::UTF_8, b[0].encoding
+    assert_false b[0].valid_encoding?
+    assert_equal Encoding::UTF_8, b.chars[0].encoding
+    assert_equal Encoding::UTF_8, (171.chr * 2).encoding
+    assert_false (171.chr * 2).valid_encoding?
+    # a sum with a byte-read operand on either side
+    assert_equal Encoding::UTF_8, (171.chr + 171.chr).encoding
+    assert_false (171.chr + 171.chr).valid_encoding?
+    assert_equal Encoding::UTF_8, ("abc" + 171.chr).encoding
+    # a string the bytes were shoveled or spliced into
+    s = ""
+    s << 171.chr
+    assert_equal Encoding::UTF_8, s.encoding
+    assert_false s.valid_encoding?
+    assert_equal Encoding::UTF_8, [171.chr, 171.chr].join.encoding
+    assert_equal Encoding::UTF_8, "ab".gsub("a", 171.chr).encoding
+    # ljust keeps the receiver's reading through the copy it pads after;
+    # rjust builds the pad first and drops it
+    assert_equal Encoding::BINARY, 171.chr.ljust(3).encoding
+    assert_equal Encoding::UTF_8, 171.chr.rjust(3).encoding
+  end
+end

--- a/mrbgems/mruby-regexp/mrbgem.rake
+++ b/mrbgems/mruby-regexp/mrbgem.rake
@@ -27,6 +27,13 @@ MRuby::Gem::Specification.new('mruby-regexp') do |spec|
     spec.add_dependency 'mruby-enumerator', :core => 'mruby-enumerator'
   end
 
+  # Same deal for what a piece of a match is read as: the marking a byte-read
+  # string carries is only visible through mruby-encoding, so mrbtest can only
+  # ask about it when that gem is part of the state.
+  if build.gems.any? {|g| g.name == 'mruby-encoding'}
+    spec.add_test_dependency 'mruby-encoding', :core => 'mruby-encoding'
+  end
+
   # Same deal for `Symbol#[]` and `#slice`, which live in mruby-symbol-ext and
   # delegate to the String methods: the regexp form is this gem's, so mrbtest
   # can only exercise it when that gem is part of the state.

--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -179,7 +179,10 @@ static mrb_value
 re_byte_substr(mrb_state *mrb, mrb_value str, mrb_int beg, mrb_int len)
 {
   if (beg < 0 || len < 0 || beg + len > RSTRING_LEN(str)) return mrb_nil_value();
-  return mrb_str_new(mrb, RSTRING_PTR(str) + beg, len);
+  mrb_value ret = mrb_str_new(mrb, RSTRING_PTR(str) + beg, len);
+  /* a piece of a byte-read subject is bytes of it, read the same way */
+  RSTR_COPY_BINARY_FLAG(mrb_str_ptr(ret), mrb_str_ptr(str));
+  return ret;
 }
 
 /* Convert a byte offset into str to a character offset, so MatchData#begin

--- a/mrbgems/mruby-regexp/test/regexp_utf8.rb
+++ b/mrbgems/mruby-regexp/test/regexp_utf8.rb
@@ -646,3 +646,19 @@ assert("Regexp - a subject whose bytes are not UTF-8 is refused") do
   assert_equal 2, ("あいb" =~ /b/)
   assert_equal 1, ("a\u{10FFFF}b" =~ /b\z|\u{10FFFF}/)
 end
+
+assert("Regexp - a piece of a byte-read subject is byte-read") do
+  # What a match hands back is bytes of the subject, read the way the subject
+  # was. Encoding introspection lives in mruby-encoding, which this gem does
+  # not depend on, so ask only where it is present.
+  skip unless "".respond_to?(:encoding)
+  skip unless __ENCODING__ == "UTF-8"
+  subject = "a\x80b".b
+  assert_equal Encoding::BINARY, subject.match(/a/)[0].encoding
+  subject =~ /a/
+  assert_equal Encoding::BINARY, $~[0].encoding
+  assert_equal Encoding::BINARY, $&.encoding
+  assert_equal Encoding::BINARY, subject.scan(/./)[0].encoding
+  # a piece of a subject read as UTF-8 goes on reading as UTF-8
+  assert_equal Encoding::UTF_8, "あb".match(/b/)[0].encoding
+end

--- a/mrbgems/mruby-string-ext/src/string.c
+++ b/mrbgems/mruby-string-ext/src/string.c
@@ -1885,7 +1885,13 @@ str_rjust_core(mrb_state *mrb, mrb_value self)
     }
   }
 
-  return mrb_str_cat_str(mrb, padding, self);
+  mrb_value result = mrb_str_cat_str(mrb, padding, self);
+  /* the padded string is the receiver's bytes in wider clothes, so it is
+     read the way the receiver was, ASCII bytes and all */
+  if (RSTR_BINARY_P(mrb_str_ptr(self))) {
+    mrb_str_ptr(result)->flags |= MRB_STR_BINARY;
+  }
+  return result;
 }
 
 /*
@@ -1953,7 +1959,13 @@ str_center_core(mrb_state *mrb, mrb_value self)
   }
 
   mrb_value result = mrb_str_cat_str(mrb, left_padding, self);
-  return mrb_str_cat_str(mrb, result, right_padding);
+  result = mrb_str_cat_str(mrb, result, right_padding);
+  /* the padded string is the receiver's bytes in wider clothes, so it is
+     read the way the receiver was, ASCII bytes and all */
+  if (RSTR_BINARY_P(mrb_str_ptr(self))) {
+    mrb_str_ptr(result)->flags |= MRB_STR_BINARY;
+  }
+  return result;
 }
 
 static mrb_value

--- a/mrbgems/mruby-string-ext/src/string.c
+++ b/mrbgems/mruby-string-ext/src/string.c
@@ -1431,7 +1431,11 @@ str_lines(mrb_state *mrb, mrb_value self)
     while (p < e && *p != '\n') p++;
     if (*p == '\n') p++;
     mrb_int len = (mrb_int) (p - t);
-    mrb_ary_push(mrb, result, mrb_str_new(mrb, t, len));
+    /* a line of a byte-read string is a subrange of its bytes, read the
+       same way */
+    mrb_value line = mrb_str_new(mrb, t, len);
+    RSTR_COPY_BINARY_FLAG(mrb_str_ptr(line), mrb_str_ptr(self));
+    mrb_ary_push(mrb, result, line);
     mrb_gc_arena_restore(mrb, ai);
   }
   return result;
@@ -1773,9 +1777,12 @@ str_chars_ary(mrb_state *mrb, mrb_value self)
   }
 #endif
 
-  /* one character per byte */
+  /* one character per byte; a piece of a byte-read string is read the same
+     way, so the marking goes with each one */
   while (p < e) {
-    mrb_ary_push(mrb, result, mrb_str_new(mrb, p, 1));
+    mrb_value piece = mrb_str_new(mrb, p, 1);
+    RSTR_COPY_BINARY_FLAG(mrb_str_ptr(piece), s);
+    mrb_ary_push(mrb, result, piece);
     p++;
   }
   return result;
@@ -2011,6 +2018,10 @@ mrb_str_slice_bang(mrb_state *mrb, mrb_value self)
   }
 
   mrb_value result = mrb_str_new(mrb, RSTRING_PTR(self) + byte_beg, byte_len);
+  /* the piece cut out is a subrange of the receiver's bytes, read the same
+     way; copied rather than shared, since the memmove below would slide the
+     receiver's remaining bytes through a shared buffer */
+  RSTR_COPY_BINARY_FLAG(mrb_str_ptr(result), str);
 
   mrb_str_modify(mrb, str);
   ptr = RSTRING_PTR(self);

--- a/src/string.c
+++ b/src/string.c
@@ -983,6 +983,10 @@ mrb_str_byte_subseq(mrb_state *mrb, mrb_value str, mrb_int beg, mrb_int len)
     s->as.heap.len = (mrb_ssize)len;
   }
   RSTR_COPY_SINGLE_BYTE_FLAG(s, orig);
+  /* A subrange of a byte-read string holds nothing but bytes of it, so it is
+     read the same way. MRB_STR_VALID_ENC stays behind: cutting can leave a
+     character in pieces, and validity is not a property a subrange inherits. */
+  RSTR_COPY_BINARY_FLAG(s, orig);
   return mrb_obj_value(s);
 }
 
@@ -1445,6 +1449,9 @@ mrb_str_times(mrb_state *mrb, mrb_value self)
   p[RSTR_LEN(str2)] = '\0';
   RSTR_COPY_SINGLE_BYTE_FLAG(str2, mrb_str_ptr(self));
   RSTR_COPY_VALID_ENC_FLAG(str2, mrb_str_ptr(self));
+  /* a repetition of a byte-read string holds nothing but its bytes over
+     again, so it is read the same way */
+  RSTR_COPY_BINARY_FLAG(str2, mrb_str_ptr(self));
 
   return mrb_obj_value(str2);
 }


### PR DESCRIPTION
Follow-up to #7132.

That change stopped `Integer#chr` from calling a stray byte a character: a byte above ASCII now comes back as a byte-read (`MRB_STR_BINARY`) string instead of one reporting UTF-8 while refusing to read as it. But the marking died one derivation away. Only `dup`/`clone`/`replace` (and what they feed: `reverse`, `succ`, `swapcase`, …) carried the reading with the bytes, plus `ljust` by the accident of padding after a copy.

This is the half of the follow-up where nothing has to be decided: a string built out of nothing but one string's bytes is read the way that string was.

```ruby
171.chr[0]                 #=> UTF-8, invalid   (CRuby: ASCII-8BIT)
171.chr * 2                #=> UTF-8, invalid   (CRuby: ASCII-8BIT)
"\xE3\x81\x82".b.chars     #=> UTF-8, invalid pieces (CRuby: ASCII-8BIT)
171.chr.rjust(3)           #=> UTF-8, invalid   (CRuby: ASCII-8BIT)
```

### The rule

**A string holding nothing but the bytes of a byte-read string is read the same way.**

- **Pieces** — `mrb_str_byte_subseq()` (`[]`, `slice`, `split`, `each_char`, `byteslice`, …) copies `MRB_STR_BINARY` alongside the single-byte flag it already copied; `chars`, `slice!`, `lines`, and mruby-regexp's `re_byte_substr()` (MatchData, `$&`, `scan`) copy their pieces by hand and now carry the flag by hand. `MRB_STR_VALID_ENC` stays behind on a subrange as before: cutting can halve a character, and validity is not a property a subrange inherits.
- **Repetitions** — `*` copies the flag next to the two it already carried.
- **Pads** — `rjust`/`center` results are the receiver's bytes in wider clothes and now read the way the receiver was, like `ljust` always did.

The flag is copied, not set, so the pieces of a UTF-8 string are untouched.

### Where a decision is needed instead

Combining *two* strings raises a question this rule does not answer: which operand's reading the result gets. `+`, `<<`, `concat`, interpolation, `join`, `insert`, `prepend`, `[]=` and the `sub`/`gsub` splices all still hand back UTF-8, and a pad argument that was read as bytes moves nothing. That is a separate change and it is stacked on this one; the first commit here pins those answers where they stand today, so the follow-up flips exactly the pins it changes.

### A test that never ran

Whether a string is read as bytes or as UTF-8 is only visible through mruby-encoding, which mruby-regexp does not depend on, so a regexp test asking what a match hands back skips itself in every configuration. The second commit takes the dependency in the test state when the build already carries the gem, the way this gem already does for mruby-enumerator and mruby-symbol-ext. No build gains a gem it did not already have, and a build without mruby-encoding is unchanged.

### Tests

Full suite green on `host-debug` (full-core, `MRB_UTF8_STRING`) and the default config (byte strings, `MRB_UTF8_SCAN` regexp), at every commit: 2274 + 116 and 2068 + 105 tests, 0 failures, 0 crashes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved binary encoding behavior when extracting, slicing, repeating, padding, or otherwise deriving strings from byte-oriented data.
  - Ensured regular expression captures from binary strings retain binary semantics, while UTF-8 strings remain correctly encoded.
  - Prevented derived byte strings from incorrectly inheriting invalid-encoding status.

- **Tests**
  - Added coverage for encoding behavior across string operations and regular expression matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->