### PR TITLE
Read a string built out of two strings off both of them

### DIFF
--- a/mrbgems/mruby-encoding/test/string.rb
+++ b/mrbgems/mruby-encoding/test/string.rb
@@ -210,21 +210,21 @@ assert('String#encoding survives a copy') do
 end
 
 assert('what a string built out of a byte-read string claims') do
-  # A copy carries the byte reading with the bytes; nothing else that builds
-  # a string out of one does. Each of these hands back a string reporting
-  # UTF-8, most of them over bytes that refuse to read as it -- the state
-  # `Integer#chr` just stopped handing out, one derivation away. Pin where
-  # every answer stands before any of it moves.
+  # A copy carries the byte reading with the bytes, and so do the pieces cut
+  # out of the string and its repetitions. The sum, the shovel and the splice
+  # still hand back a string reporting UTF-8 over bytes that refuse to read
+  # as it -- the state `Integer#chr` just stopped handing out, one derivation
+  # away.
   if UTF8STRING
     b = "\xE3\x81\x82".b   # the bytes of a three-byte character, read as bytes
     assert_equal Encoding::BINARY, b.dup.encoding
     assert_equal Encoding::BINARY, b.reverse.encoding
     # a piece cut out of the string, and a repetition of it
-    assert_equal Encoding::UTF_8, b[0].encoding
-    assert_false b[0].valid_encoding?
-    assert_equal Encoding::UTF_8, b.chars[0].encoding
-    assert_equal Encoding::UTF_8, (171.chr * 2).encoding
-    assert_false (171.chr * 2).valid_encoding?
+    assert_equal Encoding::BINARY, b[0].encoding
+    assert_true b[0].valid_encoding?
+    assert_equal Encoding::BINARY, b.chars[0].encoding
+    assert_equal Encoding::BINARY, (171.chr * 2).encoding
+    assert_true (171.chr * 2).valid_encoding?
     # a sum with a byte-read operand on either side
     assert_equal Encoding::UTF_8, (171.chr + 171.chr).encoding
     assert_false (171.chr + 171.chr).valid_encoding?
@@ -240,5 +240,45 @@ assert('what a string built out of a byte-read string claims') do
     # rjust builds the pad first and drops it
     assert_equal Encoding::BINARY, 171.chr.ljust(3).encoding
     assert_equal Encoding::UTF_8, 171.chr.rjust(3).encoding
+  end
+end
+
+assert('a string cut out of a byte-read string') do
+  # A subrange of a byte-read string holds nothing but bytes of it, so it is
+  # read the same way. Every piece used to come back UTF-8, handing bytes that
+  # spell no character a claim they could not honor.
+  if UTF8STRING
+    b = "\xE3\x81\x82".b   # the bytes of a three-byte character, read as bytes
+    each_char_pieces = []
+    b.each_char { |c| each_char_pieces << c }
+    [b[0], b[0, 2], b[1..-1], b.chars[1], each_char_pieces[2],
+     b.byteslice(0, 2), b.dup.slice!(0)].each do |piece|
+      assert_equal Encoding::BINARY, piece.encoding
+      assert_true piece.valid_encoding?
+    end
+    assert_equal [0xE3], b[0].bytes
+    assert_equal [0x81, 0x82], b[1..-1].bytes
+    # what Integer#chr hands back for a stray byte stays byte-read when cut
+    assert_equal Encoding::BINARY, 171.chr[0].encoding
+    # splitting on a byte-read separator cuts byte-read pieces, and so does
+    # splitting on line ends
+    assert_equal Encoding::BINARY, b.split(b[1])[0].encoding
+    assert_equal Encoding::BINARY, "a\nb".b.lines[0].encoding
+    # a piece of a string read as UTF-8 goes on reading as UTF-8
+    assert_equal Encoding::UTF_8, "あい"[1].encoding
+    assert_equal "い", "あい"[1]
+  end
+end
+
+assert('a string built by repeating a byte-read string') do
+  # `*` lays the same bytes down over again, so what it builds is read the
+  # way the receiver was.
+  if UTF8STRING
+    s = 171.chr * 2
+    assert_equal [171, 171], s.bytes
+    assert_equal Encoding::BINARY, s.encoding
+    assert_true s.valid_encoding?
+    assert_equal Encoding::BINARY, ("abc".b * 2).encoding
+    assert_equal Encoding::UTF_8, ("あ" * 2).encoding
   end
 end

--- a/mrbgems/mruby-encoding/test/string.rb
+++ b/mrbgems/mruby-encoding/test/string.rb
@@ -211,10 +211,10 @@ end
 
 assert('what a string built out of a byte-read string claims') do
   # A copy carries the byte reading with the bytes, and so do the pieces cut
-  # out of the string and its repetitions. The sum, the shovel and the splice
-  # still hand back a string reporting UTF-8 over bytes that refuse to read
-  # as it -- the state `Integer#chr` just stopped handing out, one derivation
-  # away.
+  # out of the string, its repetitions and the pads built around it. The sum,
+  # the shovel and the splice still hand back a string reporting UTF-8 over
+  # bytes that refuse to read as it: the state `Integer#chr` just stopped
+  # handing out, one derivation away.
   if UTF8STRING
     b = "\xE3\x81\x82".b   # the bytes of a three-byte character, read as bytes
     assert_equal Encoding::BINARY, b.dup.encoding
@@ -236,10 +236,9 @@ assert('what a string built out of a byte-read string claims') do
     assert_false s.valid_encoding?
     assert_equal Encoding::UTF_8, [171.chr, 171.chr].join.encoding
     assert_equal Encoding::UTF_8, "ab".gsub("a", 171.chr).encoding
-    # ljust keeps the receiver's reading through the copy it pads after;
-    # rjust builds the pad first and drops it
+    # the receiver's bytes in wider clothes are read the way the receiver was
     assert_equal Encoding::BINARY, 171.chr.ljust(3).encoding
-    assert_equal Encoding::UTF_8, 171.chr.rjust(3).encoding
+    assert_equal Encoding::BINARY, 171.chr.rjust(3).encoding
   end
 end
 
@@ -280,5 +279,25 @@ assert('a string built by repeating a byte-read string') do
     assert_true s.valid_encoding?
     assert_equal Encoding::BINARY, ("abc".b * 2).encoding
     assert_equal Encoding::UTF_8, ("あ" * 2).encoding
+  end
+end
+
+assert('a byte-read string padded to width') do
+  # ljust, rjust and center hand back the receiver's bytes in wider clothes,
+  # so the result is read the way the receiver was, ASCII bytes and all.
+  if UTF8STRING
+    s = 171.chr
+    [s.ljust(3), s.rjust(3), s.center(4)].each do |padded|
+      assert_equal Encoding::BINARY, padded.encoding
+      assert_true padded.valid_encoding?
+    end
+    assert_equal [171, 32, 32], s.ljust(3).bytes
+    assert_equal [32, 32, 171], s.rjust(3).bytes
+    assert_equal [32, 171, 32, 32], s.center(4).bytes
+    # an ASCII receiver read as bytes keeps the byte reading too
+    assert_equal Encoding::BINARY, "abc".b.ljust(5).encoding
+    assert_equal Encoding::BINARY, "abc".b.rjust(5).encoding
+    assert_equal Encoding::BINARY, "abc".b.center(5).encoding
+    assert_equal Encoding::UTF_8, "あ".center(3).encoding
   end
 end

--- a/mrbgems/mruby-encoding/test/string.rb
+++ b/mrbgems/mruby-encoding/test/string.rb
@@ -210,11 +210,10 @@ assert('String#encoding survives a copy') do
 end
 
 assert('what a string built out of a byte-read string claims') do
-  # A copy carries the byte reading with the bytes, and so do the pieces cut
-  # out of the string, its repetitions, its sums and the pads built around it.
-  # The shovel and the splice still hand back a string reporting UTF-8 over
-  # bytes that refuse to read as it: the state `Integer#chr` just stopped
-  # handing out, one derivation away.
+  # A copy carries the byte reading with the bytes, and so does everything
+  # else here that builds a string out of them: the pieces cut out of the
+  # string, its repetitions and sums, and the strings its bytes are shoveled
+  # or spliced into, the pads included.
   if UTF8STRING
     b = "\xE3\x81\x82".b   # the bytes of a three-byte character, read as bytes
     assert_equal Encoding::BINARY, b.dup.encoding
@@ -232,10 +231,10 @@ assert('what a string built out of a byte-read string claims') do
     # a string the bytes were shoveled or spliced into
     s = ""
     s << 171.chr
-    assert_equal Encoding::UTF_8, s.encoding
-    assert_false s.valid_encoding?
-    assert_equal Encoding::UTF_8, [171.chr, 171.chr].join.encoding
-    assert_equal Encoding::UTF_8, "ab".gsub("a", 171.chr).encoding
+    assert_equal Encoding::BINARY, s.encoding
+    assert_true s.valid_encoding?
+    assert_equal Encoding::BINARY, [171.chr, 171.chr].join.encoding
+    assert_equal Encoding::BINARY, "ab".gsub("a", 171.chr).encoding
     # the receiver's bytes in wider clothes are read the way the receiver was
     assert_equal Encoding::BINARY, 171.chr.ljust(3).encoding
     assert_equal Encoding::BINARY, 171.chr.rjust(3).encoding
@@ -308,9 +307,85 @@ assert('String#+ with a byte-read operand') do
   end
 end
 
+assert('bytes shoveled or spliced into a string') do
+  # Bytes that were read as bytes and go above ASCII spell no character in
+  # the string they are appended or spliced into, so they hand it the byte
+  # reading along with themselves. ASCII bytes read the same under any
+  # reading and move nothing.
+  if UTF8STRING
+    s = ""
+    s << 171.chr
+    assert_equal Encoding::BINARY, s.encoding
+    assert_true s.valid_encoding?
+    assert_equal [171], s.bytes
+    # concat and interpolation reach the same append
+    t = "abc"
+    t.concat(171.chr)
+    assert_equal Encoding::BINARY, t.encoding
+    assert_equal Encoding::BINARY, "<#{171.chr}>".encoding
+    # so do join and the replacement gsub splices in
+    assert_equal Encoding::BINARY, [171.chr, 171.chr].join.encoding
+    assert_equal Encoding::BINARY, ["a", 171.chr].join("-").encoding
+    assert_equal Encoding::BINARY, "a\x80b".b.gsub("a", "-").encoding
+    assert_equal Encoding::BINARY, "ab".gsub("a", 171.chr).encoding
+    # ASCII bytes say nothing about the reading
+    u = ""
+    u << "abc".b
+    assert_equal Encoding::UTF_8, u.encoding
+    # an Integer is read as a code point, and a code point is a character
+    v = ""
+    v << 171
+    assert_equal Encoding::UTF_8, v.encoding
+    assert_equal [0xC2, 0xAB], v.bytes
+    # a byte-read receiver reads everything as bytes already; CRuby lifts one
+    # of ASCII bytes to the argument's reading, which is a claim this string
+    # never makes, so it stays as it is
+    w = "".b
+    w << "あ"
+    assert_equal Encoding::BINARY, w.encoding
+    assert_equal [0xE3, 0x81, 0x82], w.bytes
+    # a splice into the middle or the front is the same landing
+    x = "ab"
+    x.insert(1, 171.chr)
+    assert_equal Encoding::BINARY, x.encoding
+    assert_equal [97, 171, 98], x.bytes
+    y = "ab"
+    y.prepend(171.chr)
+    assert_equal Encoding::BINARY, y.encoding
+    z = "ab"
+    z[0, 1] = 171.chr
+    assert_equal Encoding::BINARY, z.encoding
+    assert_true z.valid_encoding?
+    # and a splice of ASCII bytes moves nothing, wherever it lands
+    za = "ab"
+    za.insert(1, "x".b)
+    za.prepend("y".b)
+    za[0, 1] = "z".b
+    assert_equal Encoding::UTF_8, za.encoding
+  end
+end
+
+assert('String#append_as_bytes leaves the reading alone') do
+  # append_as_bytes takes only the bytes of what it is given; the receiver's
+  # reading does not move, whatever lands in it. CRuby specifies exactly this.
+  if UTF8STRING
+    s = "あ"
+    s.append_as_bytes(171)
+    assert_equal Encoding::UTF_8, s.encoding
+    assert_false s.valid_encoding?
+    assert_equal [0xE3, 0x81, 0x82, 171], s.bytes
+    t = "あ"
+    t.append_as_bytes(171.chr)
+    assert_equal Encoding::UTF_8, t.encoding
+    assert_equal [0xE3, 0x81, 0x82, 171], t.bytes
+  end
+end
+
 assert('a byte-read string padded to width') do
   # ljust, rjust and center hand back the receiver's bytes in wider clothes,
-  # so the result is read the way the receiver was, ASCII bytes and all.
+  # so the result is read the way the receiver was, ASCII bytes and all. A
+  # pad read as bytes marks the result the way any appended byte-read bytes
+  # do.
   if UTF8STRING
     s = 171.chr
     [s.ljust(3), s.rjust(3), s.center(4)].each do |padded|
@@ -324,6 +399,10 @@ assert('a byte-read string padded to width') do
     assert_equal Encoding::BINARY, "abc".b.ljust(5).encoding
     assert_equal Encoding::BINARY, "abc".b.rjust(5).encoding
     assert_equal Encoding::BINARY, "abc".b.center(5).encoding
+    # a byte-read pad above ASCII marks a plain receiver's result
+    assert_equal Encoding::BINARY, "ab".center(4, 255.chr).encoding
+    # a byte-read pad of ASCII bytes moves nothing
+    assert_equal Encoding::UTF_8, "ab".center(4, "-".b).encoding
     assert_equal Encoding::UTF_8, "あ".center(3).encoding
   end
 end

--- a/mrbgems/mruby-encoding/test/string.rb
+++ b/mrbgems/mruby-encoding/test/string.rb
@@ -211,8 +211,8 @@ end
 
 assert('what a string built out of a byte-read string claims') do
   # A copy carries the byte reading with the bytes, and so do the pieces cut
-  # out of the string, its repetitions and the pads built around it. The sum,
-  # the shovel and the splice still hand back a string reporting UTF-8 over
+  # out of the string, its repetitions, its sums and the pads built around it.
+  # The shovel and the splice still hand back a string reporting UTF-8 over
   # bytes that refuse to read as it: the state `Integer#chr` just stopped
   # handing out, one derivation away.
   if UTF8STRING
@@ -226,9 +226,9 @@ assert('what a string built out of a byte-read string claims') do
     assert_equal Encoding::BINARY, (171.chr * 2).encoding
     assert_true (171.chr * 2).valid_encoding?
     # a sum with a byte-read operand on either side
-    assert_equal Encoding::UTF_8, (171.chr + 171.chr).encoding
-    assert_false (171.chr + 171.chr).valid_encoding?
-    assert_equal Encoding::UTF_8, ("abc" + 171.chr).encoding
+    assert_equal Encoding::BINARY, (171.chr + 171.chr).encoding
+    assert_true (171.chr + 171.chr).valid_encoding?
+    assert_equal Encoding::BINARY, ("abc" + 171.chr).encoding
     # a string the bytes were shoveled or spliced into
     s = ""
     s << 171.chr
@@ -279,6 +279,32 @@ assert('a string built by repeating a byte-read string') do
     assert_true s.valid_encoding?
     assert_equal Encoding::BINARY, ("abc".b * 2).encoding
     assert_equal Encoding::UTF_8, ("あ" * 2).encoding
+  end
+end
+
+assert('String#+ with a byte-read operand') do
+  if UTF8STRING
+    bin = 171.chr   # a byte spelling no character, read as bytes
+    # a byte-read operand carrying a byte above ASCII hands the sum bytes no
+    # other reading holds, so its reading wins
+    [bin + bin, "abc" + bin, bin + "abc", "" + bin].each do |s|
+      assert_equal Encoding::BINARY, s.encoding
+      assert_true s.valid_encoding?
+    end
+    assert_equal [97, 98, 99, 171], ("abc" + bin).bytes
+    # CRuby refuses these pairs outright; here the sum says nothing rather
+    # than something false
+    assert_equal Encoding::BINARY, ("あ" + bin).encoding
+    assert_equal Encoding::BINARY, (bin + "あ").encoding
+    # a byte-read operand of ASCII bytes reads as the other operand as it
+    # stands, so it yields to it
+    assert_equal Encoding::UTF_8, ("abc".b + "あ").encoding
+    assert_equal Encoding::UTF_8, ("あ" + "abc".b).encoding
+    assert_true ("abc".b + "あ").valid_encoding?
+    # two byte-read operands stay byte-read even over ASCII bytes
+    assert_equal Encoding::BINARY, ("abc".b + "def".b).encoding
+    # and two UTF-8 operands are what they were
+    assert_equal Encoding::UTF_8, ("あ" + "い").encoding
   end
 end
 

--- a/mrbgems/mruby-encoding/test/string.rb
+++ b/mrbgems/mruby-encoding/test/string.rb
@@ -208,3 +208,37 @@ assert('String#encoding survives a copy') do
     assert_equal Encoding::UTF_8, d.encoding
   end
 end
+
+assert('what a string built out of a byte-read string claims') do
+  # A copy carries the byte reading with the bytes; nothing else that builds
+  # a string out of one does. Each of these hands back a string reporting
+  # UTF-8, most of them over bytes that refuse to read as it -- the state
+  # `Integer#chr` just stopped handing out, one derivation away. Pin where
+  # every answer stands before any of it moves.
+  if UTF8STRING
+    b = "\xE3\x81\x82".b   # the bytes of a three-byte character, read as bytes
+    assert_equal Encoding::BINARY, b.dup.encoding
+    assert_equal Encoding::BINARY, b.reverse.encoding
+    # a piece cut out of the string, and a repetition of it
+    assert_equal Encoding::UTF_8, b[0].encoding
+    assert_false b[0].valid_encoding?
+    assert_equal Encoding::UTF_8, b.chars[0].encoding
+    assert_equal Encoding::UTF_8, (171.chr * 2).encoding
+    assert_false (171.chr * 2).valid_encoding?
+    # a sum with a byte-read operand on either side
+    assert_equal Encoding::UTF_8, (171.chr + 171.chr).encoding
+    assert_false (171.chr + 171.chr).valid_encoding?
+    assert_equal Encoding::UTF_8, ("abc" + 171.chr).encoding
+    # a string the bytes were shoveled or spliced into
+    s = ""
+    s << 171.chr
+    assert_equal Encoding::UTF_8, s.encoding
+    assert_false s.valid_encoding?
+    assert_equal Encoding::UTF_8, [171.chr, 171.chr].join.encoding
+    assert_equal Encoding::UTF_8, "ab".gsub("a", 171.chr).encoding
+    # ljust keeps the receiver's reading through the copy it pads after;
+    # rjust builds the pad first and drops it
+    assert_equal Encoding::BINARY, 171.chr.ljust(3).encoding
+    assert_equal Encoding::UTF_8, 171.chr.rjust(3).encoding
+  end
+end

--- a/mrbgems/mruby-regexp/mrbgem.rake
+++ b/mrbgems/mruby-regexp/mrbgem.rake
@@ -27,6 +27,13 @@ MRuby::Gem::Specification.new('mruby-regexp') do |spec|
     spec.add_dependency 'mruby-enumerator', :core => 'mruby-enumerator'
   end
 
+  # Same deal for what a piece of a match is read as: the marking a byte-read
+  # string carries is only visible through mruby-encoding, so mrbtest can only
+  # ask about it when that gem is part of the state.
+  if build.gems.any? {|g| g.name == 'mruby-encoding'}
+    spec.add_test_dependency 'mruby-encoding', :core => 'mruby-encoding'
+  end
+
   # Same deal for `Symbol#[]` and `#slice`, which live in mruby-symbol-ext and
   # delegate to the String methods: the regexp form is this gem's, so mrbtest
   # can only exercise it when that gem is part of the state.

--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -179,7 +179,10 @@ static mrb_value
 re_byte_substr(mrb_state *mrb, mrb_value str, mrb_int beg, mrb_int len)
 {
   if (beg < 0 || len < 0 || beg + len > RSTRING_LEN(str)) return mrb_nil_value();
-  return mrb_str_new(mrb, RSTRING_PTR(str) + beg, len);
+  mrb_value ret = mrb_str_new(mrb, RSTRING_PTR(str) + beg, len);
+  /* a piece of a byte-read subject is bytes of it, read the same way */
+  RSTR_COPY_BINARY_FLAG(mrb_str_ptr(ret), mrb_str_ptr(str));
+  return ret;
 }
 
 /* Convert a byte offset into str to a character offset, so MatchData#begin

--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -1134,6 +1134,26 @@ has_backslash(const char *s, mrb_int len)
   return memchr(s, '\\', len) != NULL;
 }
 
+/* What sub and gsub build is the subject's bytes with the replacement spliced
+   in, so it is read the way the subject was; a replacement that was read as
+   bytes and goes above ASCII hands its reading over the way any appended
+   byte-read bytes do. A gsub that matched nothing spliced nothing, so its
+   result holds the subject alone and the replacement says nothing about it.
+   This is where CRuby lands on every pair it accepts. */
+static void
+re_mark_spliced(mrb_value result, mrb_value subject, mrb_value replacement,
+                mrb_bool spliced)
+{
+  if (!re_binary_string_p(subject)) {
+    if (!spliced || !re_binary_string_p(replacement)) return;
+    const char *p = RSTRING_PTR(replacement);
+    const char *e = p + RSTRING_LEN(replacement);
+    while (p < e && !(*p & 0x80)) p++;
+    if (p == e) return;
+  }
+  mrb_str_ptr(result)->flags |= MRB_STR_BINARY;
+}
+
 /*
  * Regexp.__gsub_str(re, str, replacement, checked = false) - gsub core without block
  *
@@ -1225,6 +1245,7 @@ regexp_s_gsub_str(mrb_state *mrb, mrb_value klass)
     clear_match_globals(mrb);
   }
 
+  re_mark_spliced(result, str, replacement, last_ncap > 0);
   return result;
 }
 
@@ -1283,6 +1304,7 @@ regexp_s_sub_str(mrb_state *mrb, mrb_value klass)
 
   create_matchdata(mrb, re, str, captures, cap_size);
   mrb_free(mrb, captures);
+  re_mark_spliced(result, str, replacement, TRUE);
   return result;
 }
 

--- a/mrbgems/mruby-regexp/test/regexp_utf8.rb
+++ b/mrbgems/mruby-regexp/test/regexp_utf8.rb
@@ -646,3 +646,19 @@ assert("Regexp - a subject whose bytes are not UTF-8 is refused") do
   assert_equal 2, ("あいb" =~ /b/)
   assert_equal 1, ("a\u{10FFFF}b" =~ /b\z|\u{10FFFF}/)
 end
+
+assert("Regexp - a piece of a byte-read subject is byte-read") do
+  # What a match hands back is bytes of the subject, read the way the subject
+  # was. Encoding introspection lives in mruby-encoding, which this gem does
+  # not depend on, so ask only where it is present.
+  skip unless "".respond_to?(:encoding)
+  skip unless __ENCODING__ == "UTF-8"
+  subject = "a\x80b".b
+  assert_equal Encoding::BINARY, subject.match(/a/)[0].encoding
+  subject =~ /a/
+  assert_equal Encoding::BINARY, $~[0].encoding
+  assert_equal Encoding::BINARY, $&.encoding
+  assert_equal Encoding::BINARY, subject.scan(/./)[0].encoding
+  # a piece of a subject read as UTF-8 goes on reading as UTF-8
+  assert_equal Encoding::UTF_8, "あb".match(/b/)[0].encoding
+end

--- a/mrbgems/mruby-regexp/test/regexp_utf8.rb
+++ b/mrbgems/mruby-regexp/test/regexp_utf8.rb
@@ -671,3 +671,27 @@ assert("Regexp - a piece of a byte-read subject is byte-read") do
   # a piece of a subject read as UTF-8 goes on reading as UTF-8
   assert_equal Encoding::UTF_8, "あb".match(/b/)[0].encoding
 end
+
+assert("Regexp - what sub and gsub build out of a byte-read subject") do
+  # The result is the subject's bytes with the replacement spliced in, so it
+  # is read the way the subject was, and a replacement of byte-read bytes
+  # above ASCII marks a plain subject's result the way any appended byte-read
+  # bytes do.
+  skip unless "".respond_to?(:encoding)
+  skip unless __ENCODING__ == "UTF-8"
+  subject = "a\x80b".b
+  assert_equal Encoding::BINARY, subject.sub(/a/, "-").encoding
+  assert_equal Encoding::BINARY, subject.gsub(/a/, "-").encoding
+  assert_true subject.gsub(/a/, "-").valid_encoding?
+  assert_equal Encoding::BINARY, subject.gsub(/a/) { "-" }.encoding
+  assert_equal Encoding::BINARY, "ab".gsub(/a/, 171.chr).encoding
+  assert_equal Encoding::BINARY, "ab".sub(/a/, 171.chr).encoding
+  # a replacement of ASCII bytes moves nothing
+  assert_equal Encoding::UTF_8, "ab".gsub(/a/, "-".b).encoding
+  # and neither does one a search that matched nothing never spliced in
+  assert_equal Encoding::UTF_8, "ab".gsub(/x/, 171.chr).encoding
+  assert_equal Encoding::UTF_8, "ab".gsub("x", 171.chr).encoding
+  assert_equal Encoding::UTF_8, "ab".sub(/x/, 171.chr).encoding
+  # a byte-read subject is read as bytes whether anything was spliced or not
+  assert_equal Encoding::BINARY, subject.gsub(/x/, "-").encoding
+end

--- a/mrbgems/mruby-regexp/test/regexp_utf8.rb
+++ b/mrbgems/mruby-regexp/test/regexp_utf8.rb
@@ -543,12 +543,21 @@ assert("Regexp - large non-ASCII character class does not overflow") do
   # size-0 realloc and a write through NULL). See issue #6937.
   # Patterns are always parsed as UTF-8, so build the bytes directly to
   # exercise this in both MRB_UTF8_STRING and byte-string builds.
+  # append_as_bytes lays raw bytes into the string without moving how it is
+  # read; a sum of Integer#chr pieces would come back read as bytes, and a
+  # byte-read subject is answered by the byte on its own rather than the
+  # character it begins.
   utf8 = ->(cp) {
+    s = ""
     if cp < 0x800
-      (0xC0 | (cp >> 6)).chr + (0x80 | (cp & 0x3F)).chr
+      s.append_as_bytes(0xC0 | (cp >> 6))
+      s.append_as_bytes(0x80 | (cp & 0x3F))
     else
-      (0xE0 | (cp >> 12)).chr + (0x80 | ((cp >> 6) & 0x3F)).chr + (0x80 | (cp & 0x3F)).chr
+      s.append_as_bytes(0xE0 | (cp >> 12))
+      s.append_as_bytes(0x80 | ((cp >> 6) & 0x3F))
+      s.append_as_bytes(0x80 | (cp & 0x3F))
     end
+    s
   }
   s = "["
   i = 0x80

--- a/mrbgems/mruby-string-ext/src/string.c
+++ b/mrbgems/mruby-string-ext/src/string.c
@@ -1885,7 +1885,13 @@ str_rjust_core(mrb_state *mrb, mrb_value self)
     }
   }
 
-  return mrb_str_cat_str(mrb, padding, self);
+  mrb_value result = mrb_str_cat_str(mrb, padding, self);
+  /* the padded string is the receiver's bytes in wider clothes, so it is
+     read the way the receiver was, ASCII bytes and all */
+  if (RSTR_BINARY_P(mrb_str_ptr(self))) {
+    mrb_str_ptr(result)->flags |= MRB_STR_BINARY;
+  }
+  return result;
 }
 
 /*
@@ -1953,7 +1959,13 @@ str_center_core(mrb_state *mrb, mrb_value self)
   }
 
   mrb_value result = mrb_str_cat_str(mrb, left_padding, self);
-  return mrb_str_cat_str(mrb, result, right_padding);
+  result = mrb_str_cat_str(mrb, result, right_padding);
+  /* the padded string is the receiver's bytes in wider clothes, so it is
+     read the way the receiver was, ASCII bytes and all */
+  if (RSTR_BINARY_P(mrb_str_ptr(self))) {
+    mrb_str_ptr(result)->flags |= MRB_STR_BINARY;
+  }
+  return result;
 }
 
 static mrb_value

--- a/mrbgems/mruby-string-ext/src/string.c
+++ b/mrbgems/mruby-string-ext/src/string.c
@@ -111,6 +111,23 @@ str_swapcase(mrb_state *mrb, mrb_value self)
   return str;
 }
 
+/* Bytes that were read as bytes and go above ASCII spell no character in the
+   string they are spliced into, so they hand it the byte reading along with
+   themselves, the same as an append through mrb_str_cat_str(). ASCII bytes
+   read the same under any reading and move nothing. */
+static void
+str_mark_spliced_bytes(mrb_value recv, mrb_value src)
+{
+  struct RString *r = mrb_str_ptr(recv);
+  struct RString *s = mrb_str_ptr(src);
+
+  if (RSTR_BINARY_P(r) || !RSTR_BINARY_P(s)) return;
+  const char *p = RSTR_PTR(s);
+  const char *e = p + RSTR_LEN(s);
+  while (p < e && !(*p & 0x80)) p++;
+  if (p < e) r->flags |= MRB_STR_BINARY;
+}
+
 static void
 str_concat(mrb_state *mrb, mrb_value self, mrb_value str, mrb_bool binary)
 {
@@ -128,7 +145,15 @@ str_concat(mrb_state *mrb, mrb_value self, mrb_value str, mrb_bool binary)
   }
   else
     mrb_ensure_string_type(mrb, str);
-  mrb_str_cat_str(mrb, self, str);
+  if (binary) {
+    /* append_as_bytes takes only the bytes of its argument, and a byte-read
+       receiver already reads everything as bytes, so neither lets the
+       argument's own reading move the receiver's. */
+    mrb_str_cat(mrb, self, RSTRING_PTR(str), RSTRING_LEN(str));
+  }
+  else {
+    mrb_str_cat_str(mrb, self, str);
+  }
 }
 
 static mrb_value
@@ -2232,6 +2257,7 @@ str_insert(mrb_state *mrb, mrb_value self)
   char *p = RSTRING_PTR(self);
   memmove(p + idx + insert_len, p + idx, self_len - idx);
   memcpy(p + idx, RSTRING_PTR(str_to_insert), insert_len);
+  str_mark_spliced_bytes(self, str_to_insert);
 
   return self;
 }
@@ -2305,6 +2331,7 @@ str_prepend(mrb_state *mrb, mrb_value self)
       memcpy(p + offset, src, arg_len);
       offset += arg_len;
     }
+    str_mark_spliced_bytes(self, argv[i]);
   }
 
   return self;

--- a/mrbgems/mruby-string-ext/src/string.c
+++ b/mrbgems/mruby-string-ext/src/string.c
@@ -1431,7 +1431,11 @@ str_lines(mrb_state *mrb, mrb_value self)
     while (p < e && *p != '\n') p++;
     if (*p == '\n') p++;
     mrb_int len = (mrb_int) (p - t);
-    mrb_ary_push(mrb, result, mrb_str_new(mrb, t, len));
+    /* a line of a byte-read string is a subrange of its bytes, read the
+       same way */
+    mrb_value line = mrb_str_new(mrb, t, len);
+    RSTR_COPY_BINARY_FLAG(mrb_str_ptr(line), mrb_str_ptr(self));
+    mrb_ary_push(mrb, result, line);
     mrb_gc_arena_restore(mrb, ai);
   }
   return result;
@@ -1773,9 +1777,12 @@ str_chars_ary(mrb_state *mrb, mrb_value self)
   }
 #endif
 
-  /* one character per byte */
+  /* one character per byte; a piece of a byte-read string is read the same
+     way, so the marking goes with each one */
   while (p < e) {
-    mrb_ary_push(mrb, result, mrb_str_new(mrb, p, 1));
+    mrb_value piece = mrb_str_new(mrb, p, 1);
+    RSTR_COPY_BINARY_FLAG(mrb_str_ptr(piece), s);
+    mrb_ary_push(mrb, result, piece);
     p++;
   }
   return result;
@@ -2011,6 +2018,10 @@ mrb_str_slice_bang(mrb_state *mrb, mrb_value self)
   }
 
   mrb_value result = mrb_str_new(mrb, RSTRING_PTR(self) + byte_beg, byte_len);
+  /* the piece cut out is a subrange of the receiver's bytes, read the same
+     way; copied rather than shared, since the memmove below would slide the
+     receiver's remaining bytes through a shared buffer */
+  RSTR_COPY_BINARY_FLAG(mrb_str_ptr(result), str);
 
   mrb_str_modify(mrb, str);
   ptr = RSTRING_PTR(self);

--- a/src/string.c
+++ b/src/string.c
@@ -1815,6 +1815,13 @@ str_replace_partial(mrb_state *mrb, mrb_value src, mrb_int pos, mrb_int end, mrb
   memmove(strp + newlen - (len - end), strp + end, len - end);
   if (!mrb_nil_p(rep)) {
     memmove(strp + pos, RSTRING_PTR(rep), replen);
+    /* bytes spliced in mark the string they land in the way appended ones
+       do: byte-read bytes above ASCII spell no character here and hand
+       their reading over, ASCII bytes move nothing */
+    struct RString *repp = mrb_str_ptr(rep);
+    if (!RSTR_BINARY_P(str) && RSTR_BINARY_P(repp) && !str_ascii_p(repp)) {
+      str->flags |= MRB_STR_BINARY;
+    }
   }
   RSTR_SET_LEN(str, newlen);
   strp[newlen] = '\0';
@@ -3572,10 +3579,23 @@ mrb_str_cat_cstr(mrb_state *mrb, mrb_value str, const char *ptr)
 MRB_API mrb_value
 mrb_str_cat_str(mrb_state *mrb, mrb_value str, mrb_value str2)
 {
-  if (mrb_str_ptr(str) == mrb_str_ptr(str2)) {
-    mrb_str_modify(mrb, mrb_str_ptr(str));
+  struct RString *s = mrb_str_ptr(str);
+  struct RString *s2 = mrb_str_ptr(str2);
+
+  if (s == s2) {
+    mrb_str_modify(mrb, s);
   }
-  return mrb_str_cat(mrb, str, RSTRING_PTR(str2), RSTRING_LEN(str2));
+  /* Appended bytes that were read as bytes and go above ASCII spell no
+     character in the string they land in, so they hand it the byte reading
+     along with themselves. ASCII bytes read the same under any reading and
+     say nothing. Decided before the append so a raise leaves the string as
+     it was, applied after so it lands on the string the append made. */
+  mrb_bool binary = !RSTR_BINARY_P(s) && RSTR_BINARY_P(s2) && !str_ascii_p(s2);
+  mrb_value ret = mrb_str_cat(mrb, str, RSTRING_PTR(str2), RSTRING_LEN(str2));
+  if (binary) {
+    mrb_str_ptr(ret)->flags |= MRB_STR_BINARY;
+  }
+  return ret;
 }
 
 /*
@@ -3754,14 +3774,18 @@ mrb_str_byteslice(mrb_state *mrb, mrb_value str)
 static mrb_value
 sub_replace(mrb_state *mrb, mrb_value self)
 {
-  char *p, *match;
-  mrb_int plen, mlen;
+  mrb_value replace, pat;
   mrb_int found, offset;
+  mrb_bool self_taken = FALSE, match_taken = FALSE;
 
-  mrb_get_args(mrb, "ssi", &p, &plen, &match, &mlen, &found);
+  mrb_get_args(mrb, "SSi", &replace, &pat, &found);
   if (found < 0 || RSTRING_LEN(self) < found) {
     mrb_raise(mrb, E_RUNTIME_ERROR, "argument out of range");
   }
+  const char *p = RSTRING_PTR(replace);
+  mrb_int plen = RSTRING_LEN(replace);
+  const char *match = RSTRING_PTR(pat);
+  mrb_int mlen = RSTRING_LEN(pat);
   mrb_value result = mrb_str_new(mrb, 0, 0);
   for (mrb_int i=0; i<plen; i++) {
     if (p[i] != '\\' || i+1==plen) {
@@ -3775,14 +3799,17 @@ sub_replace(mrb_state *mrb, mrb_value self)
       break;
     case '`':
       mrb_str_cat(mrb, result, RSTRING_PTR(self), found);
+      self_taken = TRUE;
       break;
     case '&': case '0':
       mrb_str_cat(mrb, result, match, mlen);
+      match_taken = TRUE;
       break;
     case '\'':
       offset = found + mlen;
       if (RSTRING_LEN(self) > offset) {
         mrb_str_cat(mrb, result, RSTRING_PTR(self)+offset, RSTRING_LEN(self)-offset);
+        self_taken = TRUE;
       }
       break;
     case '1': case '2': case '3':
@@ -3794,6 +3821,14 @@ sub_replace(mrb_state *mrb, mrb_value self)
       mrb_str_cat(mrb, result, &p[i-1], 2);
       break;
     }
+  }
+  /* The splice holds bytes of the replacement and of whatever the escapes
+     copied in, so it is read as bytes exactly when one of those sources
+     handed it byte-read bytes above ASCII, the same as any other append. */
+  if ((RSTR_BINARY_P(mrb_str_ptr(replace)) && !str_ascii_p(mrb_str_ptr(replace))) ||
+      (match_taken && RSTR_BINARY_P(mrb_str_ptr(pat)) && !str_ascii_p(mrb_str_ptr(pat))) ||
+      (self_taken && RSTR_BINARY_P(mrb_str_ptr(self)) && !str_ascii_p(mrb_str_ptr(self)))) {
+    mrb_str_ptr(result)->flags |= MRB_STR_BINARY;
   }
   return result;
 }

--- a/src/string.c
+++ b/src/string.c
@@ -710,6 +710,21 @@ mrb_str_valid_encoding_p(mrb_state *mrb, mrb_value str)
   return TRUE;
 }
 
+/* whether every byte of the string is ASCII. A walk that finds nothing else
+   made the statement MRB_STR_SINGLE_BYTE makes, so the answer is left there
+   for the next asker to read off. */
+static mrb_bool
+str_ascii_p(struct RString *s)
+{
+  if (RSTR_SINGLE_BYTE_P(s)) return TRUE;
+
+  const char *p = RSTR_PTR(s);
+  const char *e = p + RSTR_LEN(s);
+  if (search_nonascii(p, e) != e) return FALSE;
+  RSTR_SET_SINGLE_BYTE_FLAG(s);
+  return TRUE;
+}
+
 /* map character index to byte offset index */
 mrb_int
 mrb_str_char_to_byte(mrb_state *mrb, mrb_value str, mrb_int off, mrb_int idx)
@@ -838,6 +853,7 @@ mrb_str_valid_encoding_p(mrb_state *mrb, mrb_value str)
   (void)str;
   return TRUE;
 }
+#define str_ascii_p(s) TRUE
 #endif
 
 /* memsearch_swar (SWAR stands for SIMD within a register)                 */
@@ -1367,6 +1383,19 @@ mrb_str_plus(mrb_state *mrb, mrb_value a, mrb_value b)
   char *pt = RSTR_PTR(t);
   memcpy(pt, p, slen);
   memcpy(pt + slen, p2, s2len);
+
+  /* The sum is read the way its parts were. Two byte-read operands stay that
+     way, and one byte-read operand carrying a byte above ASCII hands the sum
+     bytes no other reading holds, so its reading wins. A byte-read operand of
+     ASCII bytes reads as the other operand as it stands and yields to it,
+     which is where CRuby lands on every pair it accepts; the pairs it refuses
+     outright come out byte-read here, saying nothing rather than something
+     false. */
+  if ((RSTR_BINARY_P(s) && RSTR_BINARY_P(s2)) ||
+      (RSTR_BINARY_P(s) && !str_ascii_p(s)) ||
+      (RSTR_BINARY_P(s2) && !str_ascii_p(s2))) {
+    t->flags |= MRB_STR_BINARY;
+  }
 
   return mrb_obj_value(t);
 }

--- a/src/string.c
+++ b/src/string.c
@@ -983,6 +983,10 @@ mrb_str_byte_subseq(mrb_state *mrb, mrb_value str, mrb_int beg, mrb_int len)
     s->as.heap.len = (mrb_ssize)len;
   }
   RSTR_COPY_SINGLE_BYTE_FLAG(s, orig);
+  /* A subrange of a byte-read string holds nothing but bytes of it, so it is
+     read the same way. MRB_STR_VALID_ENC stays behind: cutting can leave a
+     character in pieces, and validity is not a property a subrange inherits. */
+  RSTR_COPY_BINARY_FLAG(s, orig);
   return mrb_obj_value(s);
 }
 
@@ -1445,6 +1449,9 @@ mrb_str_times(mrb_state *mrb, mrb_value self)
   p[RSTR_LEN(str2)] = '\0';
   RSTR_COPY_SINGLE_BYTE_FLAG(str2, mrb_str_ptr(self));
   RSTR_COPY_VALID_ENC_FLAG(str2, mrb_str_ptr(self));
+  /* a repetition of a byte-read string holds nothing but its bytes over
+     again, so it is read the same way */
+  RSTR_COPY_BINARY_FLAG(str2, mrb_str_ptr(self));
 
   return mrb_obj_value(str2);
 }


### PR DESCRIPTION
Stacked on #7136, which carried the byte reading onto a string built out of nothing but one byte-read string's bytes: the pieces cut out of it, its repetitions and the pads around it. Its four commits are the first four here and are not part of this change; the two after them answer the question a copy never raises.

When a string is built out of *two* strings, which operand's reading does the result get? Every seam that does this answered "UTF-8, whatever went in", so each of these resurrected the state #7132 removed:

```ruby
171.chr + 171.chr          #=> UTF-8, invalid   (CRuby: ASCII-8BIT)
buf = ""; buf << 171.chr   #=> UTF-8, invalid   (CRuby: ASCII-8BIT)
[171.chr, 171.chr].join    #=> UTF-8, invalid   (CRuby: ASCII-8BIT)
"ab".gsub("a", 171.chr)    #=> UTF-8, invalid   (CRuby: ASCII-8BIT)
"ab".center(4, 255.chr)    #=> UTF-8, invalid   (CRuby: ASCII-8BIT)
```

### The rule

**Bytes that were read as bytes and go above ASCII spell no character where they land, so they hand the result the byte reading along with themselves. ASCII bytes read the same under any reading and move nothing.**

- **Sums** — `+` now reads both operands: two byte-read operands stay byte-read; a byte-read operand with a byte above ASCII wins; an all-ASCII byte-read operand yields to the other side. That reproduces CRuby's answer for every pair it accepts; the pairs CRuby refuses with `Encoding::CompatibilityError` come out byte-read here, saying nothing rather than something false.
- **Appends and splices** — the rule sits in `mrb_str_cat_str()`, so `<<`, `concat`, interpolation, `join` and everything built on them take it; the splices that `memmove` instead carry it by hand (`insert`, `prepend`, `[]=`, `__sub_replace`, and mruby-regexp's `__sub_str`/`__gsub_str`). A pad argument reaches the result through the same append, which is what the two new `center` cases ask.

Whether a byte above ASCII is there is answered by `str_ascii_p()`, which reads `MRB_STR_SINGLE_BYTE` where a walk already settled it and leaves the flag behind where it walks itself: a walk that finds every byte ASCII made exactly the statement that flag makes.

`sub_replace()` took its replacement and match as `char *` through `mrb_get_args(mrb, "ssi", …)`, which is not enough to see what they were read as, so it takes them as `S` and reads the pointers off the values.

### Two receivers deliberately do not move

- `append_as_bytes` takes only the bytes of its argument. CRuby specifies exactly this, and there is a test pinning it.
- A byte-read receiver stays byte-read even where CRuby would lift an all-ASCII one to a UTF-8 argument's encoding. That lift makes a claim; staying byte-read makes none.

### Left out, on purpose

- `format`/`%` (mruby-sprintf) builds through a raw buffer and never sees the argument's flags, so `"%s" % 171.chr` still reports UTF-8. A separate seam.
- `Array#pack` marks nothing either (`[171].pack("C")` reports UTF-8, invalid). That is producer-side, the same kind of fix #7132 made for `chr`, and its own change.
- In builds without mruby-regexp, the pure-Ruby `gsub` rebuilds its result from pieces, so an all-ASCII result cut from a byte-read receiver comes back UTF-8 (`"ab".b.gsub("a", "-")`). The C path used with mruby-regexp gets this right; the Ruby path cannot see the receiver's flag from Ruby.

### Tests

The pin commit in #7136 recorded where each of these answers stood before anything moved; the two commits here flip exactly the pins they change. New matrix tests cover sums, appends, splices and `append_as_bytes` in mruby-encoding, and `sub`/`gsub` results in mruby-regexp.

The large-character-class regexp test built its pattern as sums of `chr` pieces, spelling raw bytes it means to have read as UTF-8. That spelling now honestly says byte-read, so it builds them with `append_as_bytes` instead, which lays bytes down without moving how the string is read.

Full suite green on `host-debug` (full-core, `MRB_UTF8_STRING`) and the default config (byte strings, `MRB_UTF8_SCAN` regexp), at every commit: 2278 + 116 and 2069 + 105 tests, 0 failures, 0 crashes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UTF-8 and binary string encoding handling across slicing, copying, repetition, concatenation, replacement, insertion, padding, and interpolation.
  * Preserved binary status when extracting substrings, lines, characters, and regular-expression matches.
  * Improved `sub` and `gsub` results when binary data or non-ASCII bytes are involved.
  * Preserved raw byte content during byte-oriented concatenation and append operations.

* **Tests**
  * Added comprehensive coverage for ASCII-only, UTF-8, and non-ASCII binary string behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->