### PR TITLE
ci: cover a build without MRB_UTF8_STRING

### DIFF
--- a/build_config/ci/gcc-clang.rb
+++ b/build_config/ci/gcc-clang.rb
@@ -49,3 +49,18 @@ MRuby::Build.new('cxx_abi') do |conf|
 
   conf.enable_cxx_abi
 end
+
+MRuby::Build.new('default') do |conf|
+  conf.toolchain
+
+  # The one build here on the default gembox. It leaves out mruby-encoding,
+  # which is what defines MRB_UTF8_STRING, so its strings index by byte. The
+  # tests written as the byte-indexed mirror of the UTF-8 ones (String#scrub
+  # degrading to a no-op, the byte-counting halves of mruby-regexp and
+  # mruby-string-ext) run nowhere else: every other build in CI, here and in
+  # ci/msvc, takes full-core. Tests only, since the binaries this gembox adds
+  # are the same ones the bintest above already covers.
+  conf.gembox 'default'
+
+  conf.enable_test
+end


### PR DESCRIPTION
## Problem

Every build in CI takes the `full-core` gembox: the three in
`build_config/ci/gcc-clang.rb` and the one in `build_config/ci/msvc.rb`.
`full-core` pulls in mruby-encoding, and that gem is what defines
`MRB_UTF8_STRING`:

```ruby
# mrbgems/mruby-encoding/mrbgem.rake
spec.build.defines << "MRB_UTF8_STRING"
```

So CI has never built a mruby whose strings index by byte, and the tests
written as the byte-indexed mirror of the UTF-8 ones have never run.
`String#scrub no-op on non-UTF-8 build` guards itself with
`skip if "あ".length == 1` and skipped on every job in the matrix. The
byte-counting halves of mruby-regexp and mruby-string-ext went the same
way.

Both gems assume that build exists. mruby-string-ext:

> UTF-8 coverage comes from full-core builds (mruby-encoding defines
> MRB_UTF8_STRING); the mirror runs on gemboxes without it.

and mruby-regexp, on why it sets `MRB_UTF8_SCAN`:

> mruby-encoding is what does, and the default gembox carries this gem
> without it.

Nothing in CI builds the default gembox. The Cosmopolitan job comes
closest, taking the stdlib gemboxes with no mruby-encoding, but
`build_config/cosmopolitan.rb` enables neither `enable_test` nor
`enable_bintest`, so `rake test:run:serial` builds no mrbtest for it and
runs no test there.

## Change

A fourth build in `build_config/ci/gcc-clang.rb` on the default gembox.

It rides the existing matrix rather than taking a job of its own, the
way the `MRB_REGEXP_UNICODE_CASE` coverage on `full-debug` does, so it
costs no runner and gets checked on Linux, macOS and mingw, under gcc
and clang, on ARM64 and on the one runner where `char` is unsigned. It
enables tests only: the binaries the default gembox adds are the ones
the bintest on the build above already covers.

## Verification

`rake -m test:run:serial MRUBY_CONFIG=ci/gcc-clang` from a clean build
directory, on Linux with gcc:

| build | gembox | total | KO | skip | warning |
| --- | --- | --- | --- | --- | --- |
| full-debug | full-core | 2268 | 0 | 2 | 0 |
| host | full-core | 2269 (+116 bintest) | 0 | 10 | 0 |
| cxx_abi | full-core | 2269 | 0 | 10 | 0 |
| default | default | 2067 | 0 | 23 | 4 |

The new build passes as it stands, so this adds coverage without
uncovering a failure.

## Cost

The new build comes to 270 compilation units against the 883 the three
existing ones come to together, so it adds about a third to the compile
work of every job in the GCC-CLANG matrix.

Job durations over the last eight master runs of this workflow, as a
reference point rather than a prediction, since runners vary:

| job | min | avg | max |
| --- | --- | --- | --- |
| windows-2025-mingw-gcc | 5m08s | 5m23s | 6m07s |
| windows-2022-mingw-gcc | 4m35s | 4m51s | 5m17s |
| ubuntu-24.04-gcc | 1m33s | 2m06s | 2m24s |
| ubuntu-22.04-clang | 1m43s | 2m00s | 2m05s |
| ubuntu-22.04-gcc | 1m42s | 1m58s | 2m13s |
| ubuntu-24.04-clang | 1m27s | 1m54s | 2m05s |
| macos-26-clang | 1m26s | 1m51s | 2m12s |
| ubuntu-24.04-arm-gcc | 1m47s | 1m50s | 1m54s |
| macos-15-clang | 1m33s | 1m44s | 2m02s |

A third more compile work on the worst mingw run seen there comes out
near eight minutes, inside the 10 minute timeout, and that scaling is
pessimistic because a job's checkout and setup do not grow with the
build. Everything outside mingw sits under three minutes either way.
`timeout-minutes: 10` is left alone, but mingw is where the margin is
thinnest, so raising it is a one line change if you would rather have
the room.

## Note on the four warnings

The new build reports 4 "no assertion" warnings, all in
`mrbgems/mruby-string-ext/test/string.rb`, where a test wraps its whole
body in `if UTF8STRING` and so runs empty when strings index by byte:

- `String#inspect of a binary string escapes every byte`
- `String#chop! on a binary string removes one byte`
- `String#rindex on a binary string counts bytes`
- `a needle that spells no character is found nowhere`

They are warnings rather than failures, and CI stays green. The rest of
that file writes the same condition as `end if UTF8STRING`, which
reports nothing. A separate PR will bring those four into that form.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added CI coverage using the default environment without UTF-8 string support.
  * Added validation for byte-indexed behavior.
  * Binary tests remain excluded from this build.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
