### PR TITLE
mruby-string-ext: skip four UTF-8 tests where they cannot run

### DIFF
--- a/mrbgems/mruby-string-ext/test/string.rb
+++ b/mrbgems/mruby-string-ext/test/string.rb
@@ -20,12 +20,10 @@ assert('String#inspect of a binary string escapes every byte') do
   # `inspect` passes a whole character through unescaped so it stays readable,
   # which a string holding no characters has nothing to gain from. `dump` on
   # the same string escaped every byte already, so the two agree there.
-  if UTF8STRING
-    assert_equal('"る"', "る".inspect)
-    assert_equal('"\xe3\x82\x8b"', "る".b.inspect)
-    assert_equal("る".b.dump, "る".b.inspect)
-  end
-end
+  assert_equal('"る"', "る".inspect)
+  assert_equal('"\xe3\x82\x8b"', "る".b.inspect)
+  assert_equal("る".b.dump, "る".b.inspect)
+end if UTF8STRING
 
 assert('String#inspect leaves a malformed sequence malformed') do
   # `inspect` remembers a string it walked without meeting a character of
@@ -921,84 +919,78 @@ assert('String#chop! on a binary string removes one byte') do
   # `chop!` cuts at the last character, and a byte-indexed string ends in a
   # byte rather than in a character. Reading it as UTF-8 took the whole of a
   # multi-byte sequence off, or all of a string that held only one.
-  if UTF8STRING
-    s = "\u{1F600}".b   # F0 9F 98 80: four bytes, one character
-    s.chop!
-    assert_equal "\xF0\x9F\x98".b, s
-    t = "a\u{1F600}".b
-    t.chop!
-    assert_equal "a\xF0\x9F\x98".b, t
-    # a string read as UTF-8 still loses the whole character
-    u = "\u{1F600}"
-    u.chop!
-    assert_equal "", u
-    # and the \r\n pair is still taken together
-    v = "a\r\n".b
-    v.chop!
-    assert_equal "a", v
-  end
-end
+  s = "\u{1F600}".b   # F0 9F 98 80: four bytes, one character
+  s.chop!
+  assert_equal "\xF0\x9F\x98".b, s
+  t = "a\u{1F600}".b
+  t.chop!
+  assert_equal "a\xF0\x9F\x98".b, t
+  # a string read as UTF-8 still loses the whole character
+  u = "\u{1F600}"
+  u.chop!
+  assert_equal "", u
+  # and the \r\n pair is still taken together
+  v = "a\r\n".b
+  v.chop!
+  assert_equal "a", v
+end if UTF8STRING
 
 assert('String#rindex on a binary string counts bytes') do
   # `rindex` reads a byte-indexed string as UTF-8 unless the single-byte flag
   # is already set, so it stepped over the bytes inside a multi-byte sequence
   # and moved a negative position by characters. `index` counts bytes there,
   # and the two have to meet.
-  if UTF8STRING
-    s = "aあb".b # "\x61\xe3\x81\x82\x62"
-    assert_equal 2, s.rindex("\x81".b)
-    assert_equal s.index("\x81".b), s.rindex("\x81".b)
-    assert_equal 1, s.rindex("\xe3".b)
-    assert_equal 4, s.rindex("b".b)
-    assert_equal 2, s.rindex("\x81".b, -2)
-    assert_equal 2, s.rindex("\x81".b, -3)
-    assert_nil s.rindex("\x81".b, 1)
-    assert_equal 4, s.rindex("b".b, -1)
-    # the same answers once #length has set the single-byte flag
-    assert_equal 5, s.length
-    assert_equal 2, s.rindex("\x81".b)
-    assert_equal 2, s.rindex("\x81".b, -2)
-  end
-end
+  s = "aあb".b # "\x61\xe3\x81\x82\x62"
+  assert_equal 2, s.rindex("\x81".b)
+  assert_equal s.index("\x81".b), s.rindex("\x81".b)
+  assert_equal 1, s.rindex("\xe3".b)
+  assert_equal 4, s.rindex("b".b)
+  assert_equal 2, s.rindex("\x81".b, -2)
+  assert_equal 2, s.rindex("\x81".b, -3)
+  assert_nil s.rindex("\x81".b, 1)
+  assert_equal 4, s.rindex("b".b, -1)
+  # the same answers once #length has set the single-byte flag
+  assert_equal 5, s.length
+  assert_equal 2, s.rindex("\x81".b)
+  assert_equal 2, s.rindex("\x81".b, -2)
+end if UTF8STRING
 
 assert('a needle that spells no character is found nowhere') do
   # A search reads its needle as the encoding the needle is taken to be in,
   # and bytes that spell no character name nothing to look for. CRuby answers
   # the same way. A byte-indexed needle claims no encoding, so it is still
   # searched for byte by byte, which is how the byte cases below get asked.
-  if UTF8STRING
-    s = "aあb"                       # 61 E3 81 82 62
-    assert_nil s.index("\x81")
-    assert_nil s.rindex("\x81")
-    assert_nil s.byteindex("\x81")
-    assert_nil s.byterindex("\x81")
-    assert_nil s["\x81"]
-    assert_false s.include?("\x81")
-    assert_false s.end_with?("\x82")
-    assert_equal [s, "", ""], s.partition("\x81")
-    assert_equal ["", "", s], s.rpartition("\x81")
-    assert_equal s, s.chomp("\x82")
-    t = s.dup
-    assert_nil t.slice!("\x81")
-    assert_equal s, t
+  s = "aあb"                       # 61 E3 81 82 62
+  assert_nil s.index("\x81")
+  assert_nil s.rindex("\x81")
+  assert_nil s.byteindex("\x81")
+  assert_nil s.byterindex("\x81")
+  assert_nil s["\x81"]
+  assert_false s.include?("\x81")
+  assert_false s.end_with?("\x82")
+  assert_equal [s, "", ""], s.partition("\x81")
+  assert_equal ["", "", s], s.rpartition("\x81")
+  assert_equal s, s.chomp("\x82")
+  t = s.dup
+  assert_nil t.slice!("\x81")
+  assert_equal s, t
 
-    # byte-indexed, the same bytes are bytes and every search answers
-    b = s.b
-    assert_equal 2, b.index("\x81".b)
-    assert_equal 2, b.rindex("\x81".b)
-    assert_equal 2, b.byteindex("\x81".b)
-    assert_equal 2, b.byterindex("\x81".b)
-    assert_equal 1, b.byterindex("\xe3".b)
-    assert_true b.include?("\x81".b)
-    assert_equal 3, "あ\x80x".b.rindex("\x80".b)
-    assert_equal 2, "\xC0\x80a".b.rindex("a".b)
+  # byte-indexed, the same bytes are bytes and every search answers
+  b = s.b
+  assert_equal 2, b.index("\x81".b)
+  assert_equal 2, b.rindex("\x81".b)
+  assert_equal 2, b.byteindex("\x81".b)
+  assert_equal 2, b.byterindex("\x81".b)
+  assert_equal 1, b.byterindex("\xe3".b)
+  assert_true b.include?("\x81".b)
+  assert_equal 3, "あ\x80x".b.rindex("\x80".b)
+  assert_equal 2, "\xC0\x80a".b.rindex("a".b)
 
-    # a whole character is still found, and so is ASCII
-    assert_equal 1, s.index("あ")
-    assert_equal 2, s.index("b")
-    assert_equal 4, s.byterindex("b")
-  end
-end
+  # a whole character is still found, and so is ASCII
+  assert_equal 1, s.index("あ")
+  assert_equal 2, s.index("b")
+  assert_equal 4, s.byterindex("b")
+end if UTF8STRING
 
 assert('String#codepoints') do
   expect = [104, 101, 108, 108, 111, 33]


### PR DESCRIPTION
Four tests in `mrbgems/mruby-string-ext/test/string.rb` hold their `MRB_UTF8_STRING` guard inside the assertion block rather than on the `assert` call:

```ruby
assert('String#chop! on a binary string removes one byte') do
  if UTF8STRING
    s = "\u{1F600}".b
    s.chop!
    assert_equal "\xF0\x9F\x98".b, s
    ...
  end
end
```

On a build without `MRB_UTF8_STRING` the block still runs and reaches no assertion, which mrbtest counts as a warning:

```
Warn: String#inspect of a binary string escapes every byte => no assertion
Warn: String#chop! on a binary string removes one byte => no assertion
Warn: String#rindex on a binary string counts bytes => no assertion
Warn: a needle that spells no character is found nowhere => no assertion
...
Warning: 4
```

`MRB_UTF8_STRING` is turned on by `mruby-encoding`, which the `default` gembox does not carry, so a plain `rake test` is one of the builds that reports this.

The rest of the file already guards its UTF-8 tests on the `assert` call, so this PR moves these four to the same form:

```ruby
assert('String#chop! on a binary string removes one byte') do
  s = "\u{1F600}".b
  s.chop!
  assert_equal "\xF0\x9F\x98".b, s
  ...
end if UTF8STRING
```

A build that cannot run the test no longer defines it. The assertions themselves are unchanged, and the diff is the removal of the inner `if` plus one level of indentation.

The guard is needed in all four cases, since each asserts behaviour that only a UTF-8 build has: `"る".inspect` comes back with every byte escaped without it, `chop!` cuts a byte instead of a character, and a needle such as `"\x81"` is searched for as a byte rather than refused as a sequence that spells no character.

## Testing

`rake test` with the `default` gembox (`MRB_UTF8_STRING` off):

| | before | after |
| --- | --- | --- |
| Total | 2067 | 2063 |
| OK | 2040 | 2040 |
| KO | 0 | 0 |
| Warning | 4 | 0 |

The four tests that ran without asserting anything are the only ones that disappear; nothing that used to assert stops asserting.

A `full-core` build (`MRB_UTF8_STRING` on) still runs all four: `Total: 2269 / OK: 2259 / KO: 0 / Warning: 0`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Simplified conditional handling for UTF-8-specific string tests.
  * Preserved existing coverage for string inspection, binary `chop!`, binary `rindex`, and malformed-needle behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->