### PR TITLE
ci: name the bintest build in `ci/gcc-clang`

### DIFF
--- a/build_config/ci/gcc-clang.rb
+++ b/build_config/ci/gcc-clang.rb
@@ -20,7 +20,7 @@ MRuby::Build.new('full-debug') do |conf|
   conf.enable_test
 end
 
-MRuby::Build.new do |conf|
+MRuby::Build.new('bintest') do |conf|
   conf.toolchain
 
   # include all core GEMs


### PR DESCRIPTION
`build_config/ci/gcc-clang.rb` defines three builds, and two of them carry a
name. The middle one is written as `MRuby::Build.new do |conf|`, so
`MRuby::Build#initialize` gives it the default `host`, and every line CI prints
for it reads `>>> Test host <<<`.

That name says nothing about the build. What separates it from its two siblings
is that it is the only one in the file that calls `enable_bintest`, and the
only one that adds `mruby-bin-debugger` back after the `full-core` gembox
leaves it out. This names it `bintest` after that coverage, so the CI log and
the build directory both say which of the three is speaking.

```diff
-MRuby::Build.new do |conf|
+MRuby::Build.new('bintest') do |conf|
```

## Why the `host` name is free to give up here

`host` is load bearing elsewhere, so it is worth spelling out that no part of
it applies to this file.

* `MRuby::Build#mrbcfile` falls back to the `mrbc` of a `host` target only for
  a build that is not itself `host`. All three builds here are `MRuby::Build`
  rather than `MRuby::CrossBuild`, and each pulls `mruby-bin-mrbc` in through
  `full-core`, so every one of them already has its own.
* `install_prefix` sends a non `host` build to `<prefix>/mruby/<name>`, and
  `define_installer_if_needed` defines an installer into `MRUBY_ROOT/bin` only
  when `host?` answers true. Both run under `rake install`.
* `rake clean` removes `mrbtest` from `MRUBY_ROOT/bin` for the `host` target.

The workflows that read this config run `rake -m test:run:serial`
(`build.yml`) and `rake test` (`coverage.yml`). Neither installs nor cleans, and
`run_test` and `run_bintest` reach the binaries through `build_dir` and the
`BUILD_DIR` environment variable rather than through `bin/`, so none of the
above is on the path CI takes.

The one real cost is for a developer who points `MRUBY_CONFIG` at this config
by hand: the `bin/` entries stop appearing, because only a `host` build
installs them. `build_config/default.rb` is the config for that use, and this
file exists to be read by the two workflows above.

`build_config/ci/msvc.rb` is left alone. It holds a single build, so there is no
sibling for a name to tell it apart from, and the default reads fine there.

## Verification

`MRUBY_CONFIG=ci/gcc-clang rake -m test` on Linux with gcc:

| run | result |
| --- | --- |
| Test cxx_abi | 2269 total, 2259 OK, 0 KO, 0 crash, 10 skip |
| Test full-debug | 2269 total, 2259 OK, 0 KO, 0 crash, 10 skip |
| Test bintest | 2268 total, 2266 OK, 0 KO, 0 crash, 2 skip |
| Bintest bintest | 116 total, 116 OK, 0 KO, 0 crash |

The bintest run is the one the rename could have broken, since it resolves
`mrdb` and the other binaries at run time; it stays green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Explicitly named the binary test build configuration for clearer build identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->