### PR TITLE
coverage: keep same-named functions from different builds apart

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -35,7 +35,7 @@ jobs:
           {
             echo "# Coverage report"
             echo \`\`\`
-            gcovr --gcov-executable "llvm-cov-18 gcov" --gcov-ignore-errors=source_not_found -e ".*_test.c" -e ".*/test/.*" -e ".*prism.*" -s --html-details -o coverage/ build
+            gcovr --gcov-executable "llvm-cov-18 gcov" --gcov-ignore-errors=source_not_found --merge-mode-functions=separate -e ".*_test.c" -e ".*/test/.*" -e ".*prism.*" -s --html-details -o coverage/ build
             echo \`\`\`
           } > "$GITHUB_STEP_SUMMARY"
       - name: Upload coverage report


### PR DESCRIPTION
The Coverage job on `master` has been failing since #7138 was merged. Every test in it passes; the job dies in the report step.

#7138 added a build on the default gembox to `ci/gcc-clang`, so for the first time the coverage run holds gcov data from a build without `MRB_UTF8_STRING` next to data from three that take `full-core`. A source file that defines a function twice, once under `#ifdef MRB_UTF8_STRING` and once under `#else`, then reaches gcovr as two functions of the same name on different lines of one file, and gcovr's default `strict` function merge mode treats that as an error:

```
gcovr.exceptions.GcovrMergeAssertionError: mrbgems/mruby-string-ext/src/string.c:1026 Got function str_ord on multiple lines: 1026, 1222.
        You can run gcovr with --merge-mode-functions=MERGE_MODE.
```

gcovr exits 64 and the job fails. `str_ord` is just where it stops first: `str_codepoints`, `str_scrub_core` and `mrb_str_char_len` are the same shape, so fixing one name at a time would not get the job green.

This passes `--merge-mode-functions=separate`. The two definitions are distinct function bodies and no single build ever holds both, so counting them as two functions is what the source says; the merging modes would instead fold them onto one line number, which describes neither build.

I reproduced the failure and the fix outside mruby with gcovr 8.6, on the smallest program of this shape: one `static` function defined twice under `#ifdef` and `#else`, compiled `--coverage` into two directories with the macro on and off. gcovr's default mode raises the same `GcovrMergeAssertionError` and exits 64; with `--merge-mode-functions=separate` the report is generated and counts both bodies.

This follows 01e1e2ba39923250b4fc03bd60af27af8b430d73, which reached for a gcovr flag the same way when the Prism sources made gcov fail to resolve paths.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated coverage reporting to separately merge function coverage data, improving the accuracy of coverage results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->