### PR TITLE
mruby-encoding: stop defining MRB_UTF8_STRING for the whole build

### DIFF
--- a/build_config/asan.rb
+++ b/build_config/asan.rb
@@ -6,8 +6,8 @@ MRuby::Build.new('asan') do |conf|
 
   conf.gembox 'full-core'
 
-  # The UTF-8 decoders walk a string a byte at a time, and this is the only
-  # build that catches a walk that reads past the end.
+  # The UTF-8 decoders walk a string a byte at a time, and the sanitizer builds
+  # are what catch a walk that reads past the end.
   conf.cc.defines << 'MRB_UTF8_STRING'
 
   conf.enable_sanitizer "address,undefined"

--- a/build_config/asan.rb
+++ b/build_config/asan.rb
@@ -6,6 +6,10 @@ MRuby::Build.new('asan') do |conf|
 
   conf.gembox 'full-core'
 
+  # The UTF-8 decoders walk a string a byte at a time, and this is the only
+  # build that catches a walk that reads past the end.
+  conf.cc.defines << 'MRB_UTF8_STRING'
+
   conf.enable_sanitizer "address,undefined"
   conf.enable_debug
   conf.enable_bintest

--- a/build_config/boxing.rb
+++ b/build_config/boxing.rb
@@ -9,6 +9,9 @@ boxings.product(bits, ints) do |boxing, bit, int|
     conf.compilers.each do |c|
       c.defines << "MRB_#{boxing.upcase}_BOXING"
       c.defines << "MRB_INT#{int}"
+      # UTF-8 lengths and offsets are mrb_int, and these are the only builds
+      # that vary its width.
+      c.defines << "MRB_UTF8_STRING"
       c.flags << "-m#{bit}"
     end
     conf.linker.flags << "-m#{bit}"

--- a/build_config/ci/gcc-clang.rb
+++ b/build_config/ci/gcc-clang.rb
@@ -17,6 +17,12 @@ MRuby::Build.new('full-debug') do |conf|
   # mruby-regexp/test/ascii_case.rb needs, so both sides stay covered.
   conf.cc.defines << 'MRB_REGEXP_UNICODE_CASE'
 
+  # mruby-encoding no longer turns UTF-8 on for the whole build, so a build that
+  # wants it says so. The other builds in this file keep the default, which is
+  # what the non-UTF-8 side of mruby-encoding needs, so both sides stay covered
+  # without a job of their own.
+  conf.cc.defines << 'MRB_UTF8_STRING'
+
   conf.enable_test
 end
 

--- a/build_config/ci/gcc-clang.rb
+++ b/build_config/ci/gcc-clang.rb
@@ -59,13 +59,10 @@ end
 MRuby::Build.new('default') do |conf|
   conf.toolchain
 
-  # The one build here on the default gembox. It leaves out mruby-encoding,
-  # which is what defines MRB_UTF8_STRING, so its strings index by byte. The
-  # tests written as the byte-indexed mirror of the UTF-8 ones (String#scrub
-  # degrading to a no-op, the byte-counting halves of mruby-regexp and
-  # mruby-string-ext) run nowhere else: every other build in CI, here and in
-  # ci/msvc, takes full-core. Tests only, since the binaries this gembox adds
-  # are the same ones the bintest above already covers.
+  # The one build here on the default gembox. Every other build in CI, here and
+  # in ci/msvc, takes full-core, so the gems this gembox leaves out are only
+  # compiled away here. Tests only, since the binaries this gembox adds are the
+  # same ones the bintest above already covers.
   conf.gembox 'default'
 
   conf.enable_test

--- a/build_config/clang-asan.rb
+++ b/build_config/clang-asan.rb
@@ -2,6 +2,7 @@ MRuby::Build.new do |conf|
   conf.toolchain :clang
   # include the GEM box
   conf.gembox 'full-core'
+  conf.cc.defines << 'MRB_UTF8_STRING'
 
   # Turn on `enable_debug` for better debugging
   conf.enable_sanitizer "address,undefined"

--- a/mrbgems/mruby-encoding/README.md
+++ b/mrbgems/mruby-encoding/README.md
@@ -57,8 +57,8 @@ entry for:
   `ArgumentError: unknown encoding name - UTF-8`, as any other unknown name
   does.
 - `Integer#chr("UTF-8")` raises the same `ArgumentError`.
-- `String#valid_encoding?` answers true for every string, since bytes are all a
-  byte-indexed string claims to be.
+- `String#valid_encoding?` answers true for every string, because every sequence
+  of bytes is valid where the string is read as bytes.
 
 This is what CRuby does with a name it has no encoding for. To tell the two
 builds apart, compare `__ENCODING__` against `"UTF-8"`.

--- a/mrbgems/mruby-encoding/README.md
+++ b/mrbgems/mruby-encoding/README.md
@@ -7,8 +7,8 @@ This mrbgem provides a lightweight, "poorman's" encoding functionality for mruby
 - **License:** MIT
 - **Author:** mruby developers
 - **Supported Encodings:**
-  - `Encoding::UTF_8`
   - `Encoding::ASCII_8BIT` (aliased as `Encoding::BINARY`)
+  - `Encoding::UTF_8`, only in a build that defines `MRB_UTF8_STRING`
 
 ## Functionality
 
@@ -32,6 +32,7 @@ A module (not a class, unlike standard Ruby) that holds encoding constants.
   - Changes the string's reported encoding to the specified `encoding_name` (e.g., "UTF-8", "ASCII-8BIT", "BINARY").
   - The actual byte sequence of the string is not changed.
   - Raises an `ArgumentError` if an unsupported encoding name is provided.
+    Without `MRB_UTF8_STRING`, `"UTF-8"` is such a name.
 
 ### `Integer` Method
 
@@ -40,7 +41,27 @@ A module (not a class, unlike standard Ruby) that holds encoding constants.
   - If `encoding_name` is "UTF-8", the integer is treated as a Unicode codepoint.
   - If `encoding_name` is "ASCII-8BIT" or "BINARY" (the default), the integer is treated as a byte value (0-255).
   - Raises a `RangeError` if the integer is out of the valid range for the specified encoding.
-  - Raises an `ArgumentError` for unknown encoding names.
+  - Raises an `ArgumentError` for unknown encoding names, which without
+    `MRB_UTF8_STRING` includes `"UTF-8"`.
+
+## Builds without `MRB_UTF8_STRING`
+
+This gem does not define `MRB_UTF8_STRING` for the build; a build that wants
+UTF-8 defines it itself. Without it mruby reads a string as bytes, so there is
+no UTF-8 for this gem to name and UTF-8 becomes an encoding the build has no
+entry for:
+
+- `Encoding::UTF_8` is not defined, so naming it raises `NameError`.
+- `String#encoding` answers `Encoding::BINARY` for every string.
+- `String#force_encoding("UTF-8")` raises
+  `ArgumentError: unknown encoding name - UTF-8`, as any other unknown name
+  does.
+- `Integer#chr("UTF-8")` raises the same `ArgumentError`.
+- `String#valid_encoding?` answers true for every string, since bytes are all a
+  byte-indexed string claims to be.
+
+This is what CRuby does with a name it has no encoding for. To tell the two
+builds apart, compare `__ENCODING__` against `"UTF-8"`.
 
 ## Usage Example
 
@@ -48,49 +69,36 @@ A module (not a class, unlike standard Ruby) that holds encoding constants.
 # main.rb
 if __ENCODING__ == "UTF-8"
   s = "helloあ"
-  puts s.encoding  #=> Encoding::UTF_8
+  puts s.encoding        #=> UTF-8
   puts s.valid_encoding? #=> true
 
-  s2 = "\xff".force_encoding("UTF-8")
-  puts s2.valid_encoding? #=> false
+  # the bytes are not touched, only the way they are read
+  bytes = "\xE3\x81\x82"      # UTF-8 bytes for "あ"
+  puts bytes.encoding         #=> UTF-8
+  puts bytes.length           #=> 1
+  puts bytes.b.length         #=> 3
+
+  broken = "\xff\xfe".force_encoding("UTF-8")
+  puts broken.valid_encoding? #=> false
 
   s3 = "world"
   s3.force_encoding("BINARY")
-  puts s3.encoding #=> Encoding::BINARY
-  puts s3.valid_encoding? #=> true (ASCII-8BIT strings are generally considered valid)
+  puts s3.encoding            #=> ASCII-8BIT
+  puts s3.valid_encoding?     #=> true
 
-  puts 65.chr #=> "A" (defaults to ASCII-8BIT)
-  puts 230.chr("UTF-8") #=> "æ" (if U+00E6 is æ)
-  # For mruby, this might be different based on actual UTF-8 char mapping
-  # For example, 12354.chr("UTF-8") might be "あ"
+  puts 12354.chr("UTF-8")     #=> "あ"
+  # 0x110000.chr("UTF-8")     #=> RangeError
 else
   s = "hello"
-  puts s.encoding #=> Encoding::BINARY (or ASCII-8BIT)
+  puts s.encoding             #=> ASCII-8BIT
 
-  # Attempting to force to UTF-8 in a non-UTF-8 mruby build might be limited
-  # or behave as ASCII-8BIT depending on mruby's core string handling.
+  s.force_encoding("BINARY")  # a name this build has
+  # s.force_encoding("UTF-8") #=> ArgumentError: unknown encoding name - UTF-8
+  # Encoding::UTF_8           #=> NameError: uninitialized constant Encoding::UTF_8
+  # 12354.chr("UTF-8")        #=> ArgumentError: unknown encoding name - UTF-8
 end
 
-# Force encoding
-my_string = "\xE3\x81\x82" # UTF-8 bytes for "あ"
-puts my_string.encoding # Might be BINARY by default if not created as UTF-8 literal
-
-my_string.force_encoding("UTF-8")
-puts my_string.encoding #=> Encoding::UTF_8
-puts my_string #=> あ
-
-invalid_utf8 = "\xff\xfe"
-invalid_utf8.force_encoding("UTF-8")
-puts invalid_utf8.valid_encoding? #=> false
-
-# Integer#chr
-puts 65.chr # => "A"
-puts 65.chr("BINARY") # => "A"
-
-# When mruby is compiled with MRB_UTF8_STRING
-if Object.const_defined?(:MRB_UTF8_STRING)
-  puts 12354.chr("UTF-8") # => "あ"
-  # puts 0x110000.chr("UTF-8") #=> RangeError
-end
-
+# Integer#chr reads a byte value whatever the build
+puts 65.chr           #=> "A"
+puts 65.chr("BINARY") #=> "A"
 ```

--- a/mrbgems/mruby-encoding/mrbgem.rake
+++ b/mrbgems/mruby-encoding/mrbgem.rake
@@ -3,6 +3,5 @@ MRuby::Gem::Specification.new('mruby-encoding') do |spec|
   spec.author  = 'mruby developers'
   spec.summary = "Poorman's Encoding for mruby"
   spec.build.defines << "HAVE_MRUBY_ENCODING_GEM"
-  spec.build.defines << "MRB_UTF8_STRING"
   spec.add_test_dependency 'mruby-string-ext'
 end

--- a/mrbgems/mruby-encoding/src/encoding.c
+++ b/mrbgems/mruby-encoding/src/encoding.c
@@ -63,6 +63,9 @@ str_encoding(mrb_state *mrb, mrb_value self)
  *   str = "hello"
  *   str.force_encoding("ASCII-8BIT")  #=> "hello"
  *   str.encoding                      #=> "ASCII-8BIT"
+ *
+ * Without MRB_UTF8_STRING, "UTF-8" is an encoding this build does not know,
+ * and naming it raises ArgumentError as any other unknown name does.
  */
 static mrb_value
 str_force_encoding(mrb_state *mrb, mrb_value self)
@@ -76,9 +79,11 @@ str_force_encoding(mrb_state *mrb, mrb_value self)
       MRB_STR_CASECMP_P(enc, ENC_BINARY)) {
     s->flags |= MRB_STR_BINARY;
   }
+#ifdef MRB_UTF8_STRING
   else if (MRB_STR_CASECMP_P(enc, ENC_UTF8)) {
     s->flags &= ~MRB_STR_BINARY;
   }
+#endif
   else {
     mrb_raisef(mrb, E_ARGUMENT_ERROR, "unknown encoding name - %v", enc);
   }
@@ -105,7 +110,9 @@ mrb_mruby_encoding_gem_init(mrb_state* mrb)
   mrb_value b = mrb_str_new_lit_frozen(mrb, ENC_ASCII_8BIT);
   mrb_define_const_id(mrb, e, MRB_SYM(ASCII_8BIT), b);
   mrb_define_const_id(mrb, e, MRB_SYM(BINARY), b);
+#ifdef MRB_UTF8_STRING
   mrb_define_const_id(mrb, e, MRB_SYM(UTF_8), mrb_str_new_lit_frozen(mrb, ENC_UTF8));
+#endif
 }
 
 void

--- a/mrbgems/mruby-encoding/src/encoding.c
+++ b/mrbgems/mruby-encoding/src/encoding.c
@@ -36,15 +36,20 @@ get_encoding(mrb_state *mrb, mrb_sym enc)
  *
  *   "hello".encoding          #=> "UTF-8"
  *   "\xff\xfe".encoding       #=> "ASCII-8BIT"
+ *
+ * Without MRB_UTF8_STRING there is no UTF-8 to name, so every string is
+ * ASCII-8BIT (BINARY).
  */
 static mrb_value
 str_encoding(mrb_state *mrb, mrb_value self)
 {
+#ifdef MRB_UTF8_STRING
   struct RString *s = mrb_str_ptr(self);
-  if (RSTR_BINARY_P(s)) {
-    return get_encoding(mrb, MRB_SYM(BINARY));
+  if (!RSTR_BINARY_P(s)) {
+    return get_encoding(mrb, MRB_SYM(UTF_8));
   }
-  return get_encoding(mrb, MRB_SYM(UTF_8));
+#endif
+  return get_encoding(mrb, MRB_SYM(BINARY));
 }
 
 /*

--- a/mrbgems/mruby-encoding/test/string.rb
+++ b/mrbgems/mruby-encoding/test/string.rb
@@ -410,3 +410,18 @@ assert('a byte-read string padded to width') do
     assert_equal Encoding::UTF_8, "あ".center(3).encoding
   end
 end
+
+assert('a build without UTF-8 does not know the name') do
+  # There is no UTF-8 here for a string to be read as, so "UTF-8" is a name
+  # this build has no encoding for, and it is turned away the way any other
+  # such name is. CRuby answers the same for a name it has no entry for.
+  assert_raise(ArgumentError) { "hello".force_encoding("UTF-8") }
+  assert_raise(ArgumentError) { "hello".force_encoding("utf-8") }
+  assert_raise(NameError) { Encoding::UTF_8 }
+
+  # the names it does have are unaffected
+  s = "hello"
+  assert_equal s, s.force_encoding("ASCII-8BIT")
+  assert_equal s, s.force_encoding("BINARY")
+  assert_equal Encoding::BINARY, s.encoding
+end unless UTF8STRING

--- a/mrbgems/mruby-encoding/test/string.rb
+++ b/mrbgems/mruby-encoding/test/string.rb
@@ -185,6 +185,10 @@ assert('String#encoding') do
   else
     a = "hello"
     assert_equal Encoding::BINARY, a.encoding
+    # `b` sets the byte-indexed flag, but with no UTF-8 to read a string as
+    # instead, every string answers the same way whether the flag is on or not
+    assert_equal Encoding::BINARY, a.b.encoding
+    assert_equal Encoding::BINARY, "\xff\xfe".encoding
   end
 end
 

--- a/mrbgems/mruby-regexp/mrbgem.rake
+++ b/mrbgems/mruby-regexp/mrbgem.rake
@@ -8,8 +8,8 @@ MRuby::Gem::Specification.new('mruby-regexp') do |spec|
   # The engine reads UTF-8 whatever a build's strings index by, so it asks core
   # for the functions that answer what a run of bytes spells. They wait
   # behind MRB_UTF8_STRING otherwise, and this build has no reason to set that:
-  # mruby-encoding is what does, and the default gembox carries this gem
-  # without it.
+  # a build that wants UTF-8 asks for it in build_config, and the default
+  # gembox carries this gem without it.
   spec.build.defines << 'MRB_UTF8_SCAN'
 
   # Enumerator is optional: only String#gsub without a block reaches `to_enum`,

--- a/mrbgems/mruby-string-ext/mrbgem.rake
+++ b/mrbgems/mruby-string-ext/mrbgem.rake
@@ -7,7 +7,7 @@ MRuby::Gem::Specification.new('mruby-string-ext') do |spec|
   # multibyte length/index) and their non-UTF-8 no-op mirror are split with a
   # `skip unless/if` on whether a multibyte char reports length 1, so they
   # cover complementary build modes. Forcing UTF-8 on every test build would
-  # leave the non-UTF-8 mirror unreachable. UTF-8 coverage comes from
-  # full-core builds (mruby-encoding defines MRB_UTF8_STRING); the mirror runs
-  # on gemboxes without it.
+  # leave the non-UTF-8 mirror unreachable. UTF-8 coverage comes from the
+  # builds that ask for MRB_UTF8_STRING themselves (see build_config); the
+  # mirror runs on the builds that do not.
 end


### PR DESCRIPTION
`mruby-encoding` sets `MRB_UTF8_STRING` in `spec.build.defines`, and that is the only thing turning UTF-8 on in a full-core build (the only other place the define appears is `build_config/i586-pc-msdosdjgpp.rb`). The gem therefore cannot be used without making the whole build read strings as UTF-8, and a full-core build has no way to be byte-indexed.

This series leaves the define to the build and lets the gem stand on both sides.

## What a build without `MRB_UTF8_STRING` answers

| | with UTF-8 | without |
|---|---|---|
| `"hello".encoding` | `UTF-8` | `ASCII-8BIT` |
| `str.force_encoding("UTF-8")` | switches how the string is read | `ArgumentError: unknown encoding name - UTF-8` |
| `Encoding::UTF_8` | `"UTF-8"` | `NameError` |
| `str.valid_encoding?` | walks the bytes | `true`, unchanged |
| `65.chr("UTF-8")` | `"A"` | `ArgumentError`, unchanged |

UTF-8 is then an encoding the build has no entry for, and CRuby turns such a name away in exactly this way: `force_encoding("NOSUCH")` and `Integer#chr("NOSUCH")` raise `ArgumentError: unknown encoding name - %s`, which is the message this gem already raises, and `Encoding::NOSUCH` raises `NameError`. No new bit on `RString` is needed.

A dummy encoding was considered and dropped. CRuby lets `force_encoding` through for a dummy encoding, so a build that turns the name away is not describing a dummy encoding but a missing one. Letting it through would need a bit saying "claims to be UTF-8", because a non-UTF-8 build does not set `MRB_STR_BINARY` on literals and so could not tell such a string from an ordinary one.

## `build_config`

With the gem no longer defining it, the builds that read the UTF-8 side name it themselves:

- `ci/gcc-clang.rb` `full-debug`: carries the UTF-8 tests of core and of the gems
- `asan.rb`, `clang-asan.rb`: the only builds that catch a decoder reading past the end of a string
- `boxing.rb`: the only builds that vary the width of `mrb_int`, which is what a UTF-8 length and offset are

That commit comes first and changes nothing on its own, since repeating a `-D` of the same name is harmless. It means the UTF-8 tests never go unread, not even for the one commit in between.

`bintest` and `cxx_abi` keep the default. They become full-core and byte-indexed, so a full-core build carrying `mruby-encoding` without UTF-8 runs in CI for the first time, without a job of its own. `ci/msvc.rb` is left alone.

That also retires the reason the `default` gembox build gave for itself in #7138: it was the one place the byte-indexed mirror of the UTF-8 tests ran, and now two more builds run it. What that build still holds alone is the default gembox, so the last commit says that instead.

## Testing

`MRUBY_CONFIG=ci/gcc-clang rake -m test`

| build | UTF-8 | mrbtest | bintest |
|---|---|---|---|
| `full-debug` | yes | 2277, KO 0 | |
| `bintest` | no | 2238, KO 0 | 116, KO 0 |
| `cxx_abi` | no | 2238, KO 0 | |
| `default` | no | 2065, KO 0 | |

`asan`, `clang-asan` and `boxing` were not built; each takes the same single line.

## About the history

Each behavior arrives as a failing test followed by the implementation, so the two commits carrying a `Test-Status: red` trailer do not pass on their own. I can fold each pair into one commit if every commit should be green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable UTF-8 string support for selected builds.
  * Non-UTF-8 builds now consistently use binary (`ASCII-8BIT`) string behavior and reject unavailable UTF-8 features.

* **Documentation**
  * Expanded encoding documentation with examples covering validation, byte lengths, invalid UTF-8, and conditional support.
  * Clarified how build configurations control UTF-8 and related test coverage.

* **Tests**
  * Added coverage for binary string encoding and unavailable UTF-8 functionality across supported builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->