### PR TITLE
Read what sprintf builds the way its bytes were read

### DIFF
--- a/mrbgems/mruby-sprintf/mrbgem.rake
+++ b/mrbgems/mruby-sprintf/mrbgem.rake
@@ -2,4 +2,17 @@ MRuby::Gem::Specification.new('mruby-sprintf') do |spec|
   spec.license = 'MIT'
   spec.author  = 'mruby developers'
   spec.summary = 'standard Kernel#sprintf method'
+
+  # Whether a string is read as bytes or as UTF-8 is only visible through
+  # mruby-encoding, which this gem does not depend on, so a test asking what
+  # a formatted string is read as skips itself in the state mrbtest builds for
+  # this gem. Every such test skips in every configuration, which leaves the
+  # answer unasserted rather than asserted somewhere else.
+  #
+  # Take the dependency in the test state when the build already carries the
+  # gem. A build without mruby-encoding is unchanged, and no build gains a gem
+  # it did not already have.
+  if build.gems.any? {|g| g.name == 'mruby-encoding'}
+    spec.add_test_dependency 'mruby-encoding', :core => 'mruby-encoding'
+  end
 end

--- a/mrbgems/mruby-sprintf/src/sprintf.c
+++ b/mrbgems/mruby-sprintf/src/sprintf.c
@@ -345,6 +345,23 @@ get_hash(mrb_state *mrb, mrb_value *hash, mrb_int argc, const mrb_value *argv)
   *hash = tmp;
 }
 
+/* Bytes that were read as bytes and go above ASCII spell no character in the
+   string they are written into, so they hand it the byte reading along with
+   themselves, the same as an append through mrb_str_cat_str(). ASCII bytes
+   read the same under any reading and move nothing. */
+static void
+mark_written_bytes(mrb_value result, mrb_value src)
+{
+  struct RString *r = mrb_str_ptr(result);
+  struct RString *s = mrb_str_ptr(src);
+
+  if (RSTR_BINARY_P(r) || !RSTR_BINARY_P(s)) return;
+  const char *p = RSTR_PTR(s);
+  const char *e = p + RSTR_LEN(s);
+  while (p < e && !(*p & 0x80)) p++;
+  if (p < e) r->flags |= MRB_STR_BINARY;
+}
+
 static mrb_value
 mrb_str_format(mrb_state *mrb, mrb_int argc, const mrb_value *argv, mrb_value fmt)
 {
@@ -402,6 +419,11 @@ mrb_str_format(mrb_state *mrb, mrb_int argc, const mrb_value *argv, mrb_value fm
   }
   if (bsiz > 4096) bsiz = 4096;
   result = mrb_str_new_capa(mrb, bsiz);
+  /* The bytes between the specifiers are the format string's own, so what is
+     built out of them is read the way the format string was read, ASCII bytes
+     and all: the reading a receiver holds, which nothing written into it
+     lifts. */
+  RSTR_COPY_BINARY_FLAG(mrb_str_ptr(result), mrb_str_ptr(fmt));
   buf = RSTRING_PTR(result);
   memset(buf, 0, bsiz);
 
@@ -558,6 +580,7 @@ retry:
             if (RSTRING_LEN(tmp) != 1) {
               mrb_raise(mrb, E_ARGUMENT_ERROR, "%c requires a character");
             }
+            mark_written_bytes(result, tmp);
             c = RSTRING_PTR(tmp);
             clen = (int)RSTRING_LEN(tmp);
           }
@@ -589,6 +612,10 @@ retry:
           /* Convert to string (with inspect for %p) */
           if (spec.subtype == 1) arg = mrb_inspect(mrb, arg); /* 'p' format */
           str = mrb_obj_as_string(mrb, arg);
+          /* What the argument is read as is a property of the argument, so
+             precision cutting the byte above ASCII off the written part moves
+             nothing. This is where CRuby lands on every pair it accepts. */
+          mark_written_bytes(result, str);
           len = RSTRING_LEN(str);
 
           /* Update result string length for embedded strings */

--- a/mrbgems/mruby-sprintf/test/sprintf.rb
+++ b/mrbgems/mruby-sprintf/test/sprintf.rb
@@ -172,29 +172,28 @@ end
 assert('what the string sprintf builds claims') do
   # The bytes go through: a byte-read argument lands in the result whole, and
   # a byte-read format string lays its own bytes down as they are. The reading
-  # that goes with them does not: every one of these comes back reporting
-  # UTF-8, most of them over bytes that refuse to read as it, the state
-  # `Integer#chr` stopped handing out one derivation away. Whether a string is
-  # read as bytes or as UTF-8 is only visible through mruby-encoding, so ask
-  # only where it is present. Pin where the answers stand before any of them
-  # move.
+  # goes with them now: the format string's own reading is what the result is
+  # built with, and an argument read as bytes and going above ASCII hands it
+  # over the way any appended byte-read bytes do. Whether a string is read as
+  # bytes or as UTF-8 is only visible through mruby-encoding, so ask only
+  # where it is present.
   skip unless "".respond_to?(:encoding)
   skip unless __ENCODING__ == "UTF-8"
   bin = 171.chr   # a byte spelling no character, read as bytes
   assert_equal [171], ("%s" % [bin]).bytes
-  assert_equal Encoding::UTF_8, ("%s" % [bin]).encoding
-  assert_false ("%s" % [bin]).valid_encoding?
-  assert_equal Encoding::UTF_8, ("[%s]" % [bin]).encoding
-  assert_equal Encoding::UTF_8, ("%10s" % [bin]).encoding
-  assert_equal Encoding::UTF_8, ("%-10s" % [bin]).encoding
-  assert_equal Encoding::UTF_8, ("%<x>s" % {x: bin}).encoding
-  assert_equal Encoding::UTF_8, ("%{x}" % {x: bin}).encoding
-  assert_equal Encoding::UTF_8, ("%c" % [bin]).encoding
-  assert_equal Encoding::UTF_8, sprintf("%s", bin).encoding
+  ["%s" % [bin], "[%s]" % [bin], "%10s" % [bin], "%-10s" % [bin],
+   "%s %s" % [bin, "x"], "%<x>s" % {x: bin}, "%{x}" % {x: bin},
+   "%c" % [bin], sprintf("%s", bin)].each do |s|
+    assert_equal Encoding::BINARY, s.encoding
+    assert_true s.valid_encoding?
+  end
+  # what an argument is read as is a property of the argument, so precision
+  # cutting the byte above ASCII off the written part moves nothing
+  assert_equal Encoding::BINARY, ("%.1s" % ["a\xABb".force_encoding(Encoding::BINARY)]).encoding
   # a byte-read format string, with nothing written into it and with an
   # argument written into it
-  assert_equal Encoding::UTF_8, ("ab".force_encoding(Encoding::BINARY) % []).encoding
-  assert_equal Encoding::UTF_8, ("%s".force_encoding(Encoding::BINARY) % ["ab"]).encoding
+  assert_equal Encoding::BINARY, ("ab".force_encoding(Encoding::BINARY) % []).encoding
+  assert_equal Encoding::BINARY, ("%s".force_encoding(Encoding::BINARY) % ["ab"]).encoding
   # what says nothing about the reading either way: ASCII bytes read the same
   # under any reading, an Integer is a code point, and inspect builds a string
   # of its own

--- a/mrbgems/mruby-sprintf/test/sprintf.rb
+++ b/mrbgems/mruby-sprintf/test/sprintf.rb
@@ -168,3 +168,38 @@ assert('sprintf("%c") with a UTF-16 surrogate') do
   assert_equal "\xED\x9F\xBF", sprintf("%c", 0xD7FF)
   assert_equal "\xEE\x80\x80", sprintf("%c", 0xE000)
 end
+
+assert('what the string sprintf builds claims') do
+  # The bytes go through: a byte-read argument lands in the result whole, and
+  # a byte-read format string lays its own bytes down as they are. The reading
+  # that goes with them does not: every one of these comes back reporting
+  # UTF-8, most of them over bytes that refuse to read as it, the state
+  # `Integer#chr` stopped handing out one derivation away. Whether a string is
+  # read as bytes or as UTF-8 is only visible through mruby-encoding, so ask
+  # only where it is present. Pin where the answers stand before any of them
+  # move.
+  skip unless "".respond_to?(:encoding)
+  skip unless __ENCODING__ == "UTF-8"
+  bin = 171.chr   # a byte spelling no character, read as bytes
+  assert_equal [171], ("%s" % [bin]).bytes
+  assert_equal Encoding::UTF_8, ("%s" % [bin]).encoding
+  assert_false ("%s" % [bin]).valid_encoding?
+  assert_equal Encoding::UTF_8, ("[%s]" % [bin]).encoding
+  assert_equal Encoding::UTF_8, ("%10s" % [bin]).encoding
+  assert_equal Encoding::UTF_8, ("%-10s" % [bin]).encoding
+  assert_equal Encoding::UTF_8, ("%<x>s" % {x: bin}).encoding
+  assert_equal Encoding::UTF_8, ("%{x}" % {x: bin}).encoding
+  assert_equal Encoding::UTF_8, ("%c" % [bin]).encoding
+  assert_equal Encoding::UTF_8, sprintf("%s", bin).encoding
+  # a byte-read format string, with nothing written into it and with an
+  # argument written into it
+  assert_equal Encoding::UTF_8, ("ab".force_encoding(Encoding::BINARY) % []).encoding
+  assert_equal Encoding::UTF_8, ("%s".force_encoding(Encoding::BINARY) % ["ab"]).encoding
+  # what says nothing about the reading either way: ASCII bytes read the same
+  # under any reading, an Integer is a code point, and inspect builds a string
+  # of its own
+  assert_equal Encoding::UTF_8, ("%s" % ["ab".force_encoding(Encoding::BINARY)]).encoding
+  assert_equal Encoding::UTF_8, ("%c" % [171]).encoding
+  assert_equal Encoding::UTF_8, ("%d" % [171]).encoding
+  assert_equal Encoding::UTF_8, ("%p" % [bin]).encoding
+end


### PR DESCRIPTION
Follow-up to #7137, which named this seam among the ones it deliberately left out.

`sprintf` builds its result in a raw buffer and never looks at what the strings going into it were read as, so a byte-read argument loses that reading on the way through, and so does a byte-read format string:

```ruby
171.chr                #=> ASCII-8BIT, valid
"%s" % [171.chr]       #=> UTF-8, invalid   (CRuby: ASCII-8BIT)
"%c" % [171.chr]       #=> UTF-8, invalid   (CRuby: ASCII-8BIT)
"%<x>s" % {x: 171.chr} #=> UTF-8, invalid   (CRuby: ASCII-8BIT)
"%s".b % ["ab"]        #=> UTF-8            (CRuby: ASCII-8BIT)
```

Since 80c781b refuses a subject whose bytes do not read as UTF-8, this is no longer a mis-indexing but a refusal: `171.chr` matches against a pattern, while `"%s" % [171.chr]`, the same single byte, raises `ArgumentError`.

### The rule

The one #7137 settled, applied to the two places sprintf writes bytes it did not make itself.

- **The format string is the receiver.** What sprintf builds is the format string's own bytes with the arguments written between them, so the result is read the way the format string was read, ASCII bytes and all. That is the reading a receiver holds through an append, which nothing written into it lifts.
- **An argument is what is written in.** An argument read as bytes and going above ASCII spells no character where it lands, so it hands the result the byte reading along with itself. ASCII bytes read the same under any reading and move nothing.

Three sites: the result takes `MRB_STR_BINARY` from the format string where it is created, `%s`/`%p` marks from the string its argument converts to, and `%c` marks from a String argument. An Integer argument to `%c` is a code point rather than a byte, and the string `%p` builds for itself is one of its own, so neither marks anything.

What an argument is read as is a property of the argument, not of the part that reaches the buffer, so a precision cutting the byte above ASCII off the written part moves nothing: `"%.1s" % ["a\xABb".b]` is byte-read, as in CRuby.

This reproduces CRuby's answer for every pair it accepts. The pairs CRuby refuses with `Encoding::CompatibilityError` come out byte-read here rather than raising, the same choice #7137 made.

### Tests

The first commit pins where every answer stands before any of it moves; the second flips exactly the pins it changes.

Whether a string is read as bytes or as UTF-8 is only visible through mruby-encoding, which this gem does not depend on, so such a test skips itself in the state mrbtest builds for this gem, in every configuration. The first commit takes that dependency in the test state when the build already carries the gem, the way mruby-regexp does since #7136. A build without mruby-encoding is unchanged, and no build gains a gem it did not already have. The test asks `__ENCODING__` as well, since a build that reads every string as bytes has nothing for the marking to tell apart.

### Still left out

`Array#pack` and `String#unpack` mark nothing (`[171].pack("C")` reports UTF-8, invalid), and a Symbol has nowhere to keep the marking (`171.chr.to_sym.to_s` reports UTF-8). Each is its own change.

### Alongside #7142

#7142 leaves `MRB_UTF8_STRING` to the build, so carrying mruby-encoding stops meaning the build reads UTF-8, and a full-core build that indexes by byte runs in CI. That is what the `__ENCODING__` guard is for: redundant while the gem still sets the define, load-bearing once it does not. The two series share no file. `MRB_STR_BINARY` and `RSTR_COPY_BINARY_FLAG` do not wait on `MRB_UTF8_STRING`, so what this one adds to `sprintf.c` compiles and runs the same on either side; what changes is only whether `String#encoding` shows the marking.

### Verification

Full suite green at every commit, on full-core with `MRB_UTF8_STRING` (2279 tests), the same with the C++ ABI (2279), and the default gembox, where mruby-encoding is absent and the new test skips (2066). 0 failures, 0 crashes, no new compiler warnings.

Merged with #7142, full-core without `MRB_UTF8_STRING` is green as well (2239), the new test among the skips. That series turns the C++ ABI build into one of those, so its count above moves there once it lands.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `sprintf` and `String#%` handling of binary and UTF-8 strings.
  * Preserved binary encoding when formatting non-ASCII character and string values.
  * Ensured formatted output remains valid across precision limits and conversion types.
* **Tests**
  * Added coverage for encoding propagation, binary format strings, truncation, and UTF-8 output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
