### PR TITLE
string.c: remember that a string was read as broken

### DIFF
--- a/include/mruby/string.h
+++ b/include/mruby/string.h
@@ -56,6 +56,7 @@ struct RStringEmbed {
 #define MRB_STR_STATE_MASK 48
 /* bits 6..10 are the embedded length, so 11 is the first one free */
 #define MRB_STR_VALID_ENC 2048
+#define MRB_STR_BROKEN_ENC 4096
 
 #define RSTR_EMBED_P(s) ((s)->flags & MRB_STR_EMBED)
 #define RSTR_SET_EMBED_FLAG(s) ((s)->flags |= MRB_STR_EMBED)
@@ -100,6 +101,15 @@ struct RStringEmbed {
 # define RSTR_UNSET_VALID_ENC_FLAG(s) ((s)->flags &= ~MRB_STR_VALID_ENC)
 # define RSTR_COPY_VALID_ENC_FLAG(dst, src) \
   ((dst)->flags = ((dst)->flags & ~MRB_STR_VALID_ENC) | RSTR_VALID_ENC_P(src))
+/* The other answer the same walk can come back with, kept so that a string
+   already read as broken is not read again on every later question. It is
+   forgotten wherever MRB_STR_VALID_ENC is, since a write to the bytes unmakes
+   either answer, and it travels only where the whole of the bytes travels. */
+# define RSTR_BROKEN_ENC_P(s) ((s)->flags & MRB_STR_BROKEN_ENC)
+# define RSTR_SET_BROKEN_ENC_FLAG(s) ((s)->flags |= MRB_STR_BROKEN_ENC)
+# define RSTR_UNSET_BROKEN_ENC_FLAG(s) ((s)->flags &= ~MRB_STR_BROKEN_ENC)
+# define RSTR_COPY_BROKEN_ENC_FLAG(dst, src) \
+  ((dst)->flags = ((dst)->flags & ~MRB_STR_BROKEN_ENC) | RSTR_BROKEN_ENC_P(src))
 #else
 # define RSTR_SINGLE_BYTE_P(s) TRUE
 # define RSTR_SET_SINGLE_BYTE_FLAG(s) (void)0
@@ -110,6 +120,10 @@ struct RStringEmbed {
 # define RSTR_SET_VALID_ENC_FLAG(s) (void)0
 # define RSTR_UNSET_VALID_ENC_FLAG(s) (void)0
 # define RSTR_COPY_VALID_ENC_FLAG(dst, src) (void)0
+# define RSTR_BROKEN_ENC_P(s) FALSE
+# define RSTR_SET_BROKEN_ENC_FLAG(s) (void)0
+# define RSTR_UNSET_BROKEN_ENC_FLAG(s) (void)0
+# define RSTR_COPY_BROKEN_ENC_FLAG(dst, src) (void)0
 #endif
 #define RSTR_SET_ASCII_FLAG(s) RSTR_SET_SINGLE_BYTE_FLAG(s)
 #define RSTR_BINARY_P(s) ((s)->flags & MRB_STR_BINARY)

--- a/mrbgems/mruby-encoding/test/string.rb
+++ b/mrbgems/mruby-encoding/test/string.rb
@@ -4,10 +4,13 @@
 UTF8STRING = __ENCODING__ == "UTF-8"
 
 assert('String#valid_encoding? survives what the string goes through') do
-  # The answer is remembered on the string, so every way of changing its bytes
-  # has to forget it again, and the two places a copy keeps the bytes whole
-  # have to carry it along. Each pair asks the same question of the same
-  # bytes, once with the answer already remembered and once without.
+  # The answer is remembered on the string, either way it came out, so every
+  # way of changing its bytes has to forget it again, and the two places a copy
+  # keeps the bytes whole have to carry it along. Each pair asks the same
+  # question of the same bytes, once with the answer already remembered and
+  # once without. The bases below start out both valid and broken, and the
+  # changes below both break and repair, so each remembered answer is asked
+  # for after a change that unmakes it.
   if UTF8STRING
     [->(s) { s << "\x80" },
      ->(s) { s.concat("\xC0") },
@@ -21,8 +24,14 @@ assert('String#valid_encoding? survives what the string goes through') do
      ->(s) { s * 2 },
      ->(s) { s.dup },
      ->(s) { s.byteslice(0, 1) || s },
-     ->(s) { s[0, 1] || s }].each do |op|
-      ["あ", "あa", "あい", "あ" * 40].each do |base|
+     ->(s) { s[0, 1] || s },
+     ->(s) { s << "\x82" },
+     ->(s) { s.replace("ok") },
+     ->(s) { s * 0 },
+     ->(s) { s.b },
+     ->(s) { s.clear; s }].each do |op|
+      ["あ", "あa", "あい", "あ" * 40,
+       "\x80", "a\x80b", "\xE3\x81", "\xED\xA0\x80", "\xE3\x81" * 40].each do |base|
         warm = base.dup
         warm.valid_encoding?          # remember the answer before the change
         cold = base.dup

--- a/src/string.c
+++ b/src/string.c
@@ -1491,6 +1491,12 @@ mrb_str_times(mrb_state *mrb, mrb_value self)
   /* a repetition of a byte-read string holds nothing but its bytes over
      again, so it is read the same way */
   RSTR_COPY_BINARY_FLAG(str2, mrb_str_ptr(self));
+  /* A repetition of broken bytes reaches the same broken place the first copy
+     does, so it is broken too. Nought copies keep none of the bytes, and an
+     empty string is not broken whatever it was made from. */
+  if (len > 0) {
+    RSTR_COPY_BROKEN_ENC_FLAG(str2, mrb_str_ptr(self));
+  }
 
   return mrb_obj_value(str2);
 }

--- a/src/string.c
+++ b/src/string.c
@@ -692,6 +692,9 @@ mrb_str_valid_encoding_p(mrb_state *mrb, mrb_value str)
      bytes are. */
   if (RSTR_BINARY_P(s)) return TRUE;
   if (RSTR_VALID_ENC_P(s)) return TRUE;
+  /* The walk below reads the whole string to answer FALSE, so a string already
+     read as broken is answered off the mark that walk left instead. */
+  if (RSTR_BROKEN_ENC_P(s)) return FALSE;
   /* A string of one character per byte holds nothing but ASCII, and ASCII
      reads as UTF-8 as it stands, so it is valid without a walk. This is what
      a string counted before it is asked about comes in carrying. */
@@ -704,7 +707,10 @@ mrb_str_valid_encoding_p(mrb_state *mrb, mrb_value str)
   mrb_bool valid = TRUE;
   mrb_int utf8_len = utf8_strlen_check(RSTR_PTR(s), byte_len, &valid);
 
-  if (!valid) return FALSE;
+  if (!valid) {
+    RSTR_SET_BROKEN_ENC_FLAG(s);
+    return FALSE;
+  }
   if (byte_len == utf8_len) RSTR_SET_SINGLE_BYTE_FLAG(s);
   RSTR_SET_VALID_ENC_FLAG(s);
   return TRUE;
@@ -1000,8 +1006,10 @@ mrb_str_byte_subseq(mrb_state *mrb, mrb_value str, mrb_int beg, mrb_int len)
   }
   RSTR_COPY_SINGLE_BYTE_FLAG(s, orig);
   /* A subrange of a byte-read string holds nothing but bytes of it, so it is
-     read the same way. MRB_STR_VALID_ENC stays behind: cutting can leave a
-     character in pieces, and validity is not a property a subrange inherits. */
+     read the same way. Neither answer about the encoding travels with it:
+     cutting can leave a character in pieces, and it can also cut away the
+     piece that spelled none, so a subrange inherits validity in neither
+     direction. */
   RSTR_COPY_BINARY_FLAG(s, orig);
   return mrb_obj_value(s);
 }
@@ -1098,6 +1106,7 @@ str_replace(mrb_state *mrb, struct RString *s1, struct RString *s2)
   if (s1 == s2) return mrb_obj_value(s1);
   RSTR_COPY_SINGLE_BYTE_FLAG(s1, s2);
   RSTR_COPY_VALID_ENC_FLAG(s1, s2);
+  RSTR_COPY_BROKEN_ENC_FLAG(s1, s2);
   RSTR_COPY_BINARY_FLAG(s1, s2);
   if (RSTR_SHARED_P(s1)) {
     str_decref(mrb, s1->as.heap.aux.shared);
@@ -1270,6 +1279,7 @@ mrb_str_modify_keep_ascii(mrb_state *mrb, struct RString *s)
   /* Every in-place write reaches here, including the ones that keep the string
      ASCII, so this is where the walk's answer stops holding. */
   RSTR_UNSET_VALID_ENC_FLAG(s);
+  RSTR_UNSET_BROKEN_ENC_FLAG(s);
 }
 
 /*
@@ -3482,6 +3492,7 @@ str_modify_cat(mrb_state *mrb, struct RString *s, mrb_int addlen)
       shared->reserved = off + s->as.heap.len + addlen;
       RSTR_UNSET_SINGLE_BYTE_FLAG(s);
       RSTR_UNSET_VALID_ENC_FLAG(s);
+      RSTR_UNSET_BROKEN_ENC_FLAG(s);
       return capa;
     }
   }


### PR DESCRIPTION
`mrb_str_valid_encoding_p()` marks a string whose bytes it has read as UTF-8,
and answers a later question off that mark rather than by another walk. Only
the answer of true is kept that way. A string holding a byte that spells no
character leaves nothing behind, so every question after the first walks it
again, however many times it is asked: once per needle in `str_index_str()`,
once per call at the entry to `split`, once per subject handed to the regexp
engine. This keeps the other answer the same walk comes back with.

## The mark

`MRB_STR_BROKEN_ENC` takes the bit next to `MRB_STR_VALID_ENC`, with the four
accessors beside the ones it mirrors. The two marks stand or fall together,
since a write to the bytes unmakes either answer:

* `mrb_str_valid_encoding_p()` leaves one where the walk reaches the end and
  the other where it fails.
* `mrb_str_modify_keep_ascii()` unmakes both. Every in-place write reaches
  there.
* The shared appending path in `str_modify_cat()` unmakes both.
* `str_replace()` writes over the bytes without passing either of those, so it
  takes both answers from the string it copies. This one is not an
  optimization: without it a broken string that `replace` makes valid keeps
  saying it is broken.
* `mrb_str_times()` carries both, guarded as described below.
* `mrb_str_byte_subseq()` carries neither, as it already carried neither of
  the answer it had. A cut leaves a character in pieces, and it also cuts away
  the piece that spelled none, so a subrange inherits validity in neither
  direction. The comment there said this about one mark and now says it about
  both.

```ruby
"a\x80".valid_encoding?                  #=> false
"a\x80".byteslice(0, 1).valid_encoding?  #=> true
"あ".valid_encoding?                     #=> true
"あ".byteslice(0, 1).valid_encoding?     #=> false
```

## Where the two marks part

`*` is the one place. A repetition of broken bytes reaches the same broken
place the first copy does, so the result is broken too. Nought copies keep
none of the bytes, though, and an empty string is not broken whatever it was
made from, so the mark travels only where something was copied. The mark
beside it needs no such guard, since an empty string is valid either way.

## `force_encoding`

A byte-indexed string is answered before either mark is read, so a broken
string that `force_encoding` makes binary still says it is valid, and one made
UTF-8 again meets the mark it left. The bytes did not change, only what they
are taken to be, so that is the answer to give.

## Builds without `MRB_UTF8_STRING`

There is no encoding for a string to break, and the mark is nothing there, as
the one beside it already is. `mrb_str_valid_encoding_p()` keeps answering
true for every string.

## Tests

Nothing a program can see changes, so the tests here are what stops a mark
from outliving the bytes it was left for. `String#valid_encoding? survives
what the string goes through` already asks the same question of the same bytes
twice, once with the answer remembered and once without, but every base it
started from was valid and every change it made broke them, so it only ever
asked about a mark left by an answer of true. It now starts from broken bases
as well, and makes changes that repair them.

The test commit comes first and passes on its own, since the answers it asks
for are what they were. What it pins is the mark. Two mutations show that it
reaches the code: dropping the line that unmakes the mark in
`mrb_str_modify_keep_ascii()`, and dropping the guard on nought copies in
`mrb_str_times()`. Each one fails it. A third came up while writing this: with
`str_replace()` left out of the second commit, the test failed there too,
which is why that line sits with the rest rather than with `*`.

## Testing

| build | UTF-8 | mrbtest | bintest |
|---|---|---|---|
| `full-debug` | yes | 2278, KO 0 | |
| `host` | yes | 2278, KO 0 | 116, KO 0 |
| `cxx_abi` | yes | 2277, KO 0 | |
| `default` | no | 2065, KO 0 | 105, KO 0 |

Each of the three commits was built and run on its own against the last two of
those, and all three are green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UTF-8 encoding validation for strings by caching invalid results.
  * Ensured encoding status is correctly updated after string mutations, slicing, replacement, and repetition.
  * Prevented zero-length repetitions and substrings from incorrectly inheriting invalid encoding status.
* **Tests**
  * Expanded coverage for valid, malformed UTF-8, binary, and mutation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->