### PR TITLE
Write a byte escape in upper case hex, as CRuby does

### DIFF
--- a/mrbgems/mruby-bin-debugger/bintest/print.rb
+++ b/mrbgems/mruby-bin-debugger/bintest/print.rb
@@ -371,7 +371,7 @@ SRC
 
   tc << {:cmd=>'p "str"',        :exp=>'$1 = "str"'}
   tc << {:cmd=>'p "s\tt\rr\n"',  :exp=>'$2 = "s\\tt\\rr\\n"'}
-  tc << {:cmd=>'p "\C-a\C-z"',   :exp=>'$3 = "\\x01\\x1a"'}
+  tc << {:cmd=>'p "\C-a\C-z"',   :exp=>'$3 = "\\x01\\x1A"'}
   tc << {:cmd=>'p "#{foo+bar}"', :exp=>'$4 = "foobar"'}
 
   tc << {:cmd=>'p \'str\'',          :exp=>'$5 = "str"'}
@@ -381,12 +381,12 @@ SRC
 
   tc << {:cmd=>'p %!str!',        :exp=>'$9 = "str"'}
   tc << {:cmd=>'p %!s\tt\rr\n!',  :exp=>'$10 = "s\\tt\\rr\\n"'}
-  tc << {:cmd=>'p %!\C-a\C-z!',   :exp=>'$11 = "\\x01\\x1a"'}
+  tc << {:cmd=>'p %!\C-a\C-z!',   :exp=>'$11 = "\\x01\\x1A"'}
   tc << {:cmd=>'p %!#{foo+bar}!', :exp=>'$12 = "foobar"'}
 
   tc << {:cmd=>'p %Q!str!',        :exp=>'$13 = "str"'}
   tc << {:cmd=>'p %Q!s\tt\rr\n!',  :exp=>'$14 = "s\\tt\\rr\\n"'}
-  tc << {:cmd=>'p %Q!\C-a\C-z!',   :exp=>'$15 = "\\x01\\x1a"'}
+  tc << {:cmd=>'p %Q!\C-a\C-z!',   :exp=>'$15 = "\\x01\\x1A"'}
   tc << {:cmd=>'p %Q!#{foo+bar}!', :exp=>'$16 = "foobar"'}
 
   tc << {:cmd=>'p %q!str!',          :exp=>'$17 = "str"'}

--- a/mrbgems/mruby-encoding/test/numeric.rb
+++ b/mrbgems/mruby-encoding/test/numeric.rb
@@ -35,7 +35,7 @@ assert('Integer#chr(binary) of a byte that spells no character') do
   assert_equal [171], s.codepoints
   assert_equal 171, s.ord
   assert_equal [171], s.scrub.bytes
-  assert_equal "\"\\xab\"", s.inspect
+  assert_equal "\"\\xAB\"", s.inspect
   assert_equal Encoding::BINARY, s.encoding
   assert_true s.valid_encoding?
   assert_equal Encoding::BINARY, s.dup.encoding

--- a/mrbgems/mruby-string-ext/test/string.rb
+++ b/mrbgems/mruby-string-ext/test/string.rb
@@ -12,7 +12,7 @@ end
 assert('String#dump') do
   assert_equal("\"\\x00\"", "\0".dump)
   assert_equal("\"foo\"", "foo".dump)
-  assert_equal('"\xe3\x82\x8b"', "る".dump)
+  assert_equal('"\xE3\x82\x8B"', "る".dump)
   assert_nothing_raised { ("\1" * 100).dump }   # regress #1210
 end
 
@@ -21,7 +21,7 @@ assert('String#inspect of a binary string escapes every byte') do
   # which a string holding no characters has nothing to gain from. `dump` on
   # the same string escaped every byte already, so the two agree there.
   assert_equal('"る"', "る".inspect)
-  assert_equal('"\xe3\x82\x8b"', "る".b.inspect)
+  assert_equal('"\xE3\x82\x8B"', "る".b.inspect)
   assert_equal("る".b.dump, "る".b.inspect)
 end if UTF8STRING
 

--- a/src/string.c
+++ b/src/string.c
@@ -1835,6 +1835,12 @@ str_replace_partial(mrb_state *mrb, mrb_value src, mrb_int pos, mrb_int end, mrb
 
 #define IS_EVSTR(p,e) ((p) < (e) && (*(p) == '$' || *(p) == '@' || *(p) == '{'))
 
+/* A `\xNN` escape spells its byte in upper case, as CRuby writes it.
+   `mrb_digitmap` is lower case because `Integer#to_s` reads a number
+   through it and CRuby spells that in lower case, so the two cannot share
+   one table. */
+static const char escape_hexmap[] = "0123456789ABCDEF";
+
 static mrb_value
 str_escape(mrb_state *mrb, mrb_value str, mrb_bool inspect)
 {
@@ -1901,8 +1907,8 @@ str_escape(mrb_state *mrb, mrb_value str, mrb_bool inspect)
     }
     else {
       buf[1] = 'x';
-      buf[3] = mrb_digitmap[c % 16]; c /= 16;
-      buf[2] = mrb_digitmap[c % 16];
+      buf[3] = escape_hexmap[c % 16]; c /= 16;
+      buf[2] = escape_hexmap[c % 16];
       mrb_str_cat(mrb, result, buf, 4);
     }
   }

--- a/test/t/string.rb
+++ b/test/t/string.rb
@@ -994,10 +994,12 @@ end
 assert('String#inspect', '15.2.10.5.46') do
   assert_equal "\"\\x00\"", "\0".inspect
   assert_equal "\"foo\"", "foo".inspect
+  # a byte spelled out as hex reads out in upper case, the way CRuby writes it
+  assert_equal "\"\\xAB\"", "\xAB".inspect
   if UTF8STRING
     assert_equal '"る"', "る".inspect
   else
-    assert_equal '"\xe3\x82\x8b"', "る".inspect
+    assert_equal '"\xE3\x82\x8B"', "る".inspect
   end
 
   # should not raise an exception - regress #1210

--- a/test/t/vformat.rb
+++ b/test/t/vformat.rb
@@ -43,7 +43,7 @@ assert('mrb_vformat') do
   assert_equal 'percent: %', vf.z('percent: %%')
   assert_equal '"I": inspect char', vf.c('%!c: inspect char', ?I)
   assert_equal '709: inspect mrb_int', vf.i('%!i: inspect mrb_int', 709)
-  assert_equal '"a\x00b\xff"', vf.l('%!l', "a\000b\xFFc\000d", 4)
+  assert_equal '"a\x00b\xFF"', vf.l('%!l', "a\000b\xFFc\000d", 4)
   assert_equal ':"&.": inspect symbol', vf.n('%!n: inspect symbol', :'&.')
   assert_equal 'inspect "String"', vf.v('inspect %!v', 'String')
   assert_equal 'inspect Array: [1, :x, {}]', vf.v('inspect Array: %!v', [1,:x,{}])


### PR DESCRIPTION
`String#inspect` and `String#dump` write a byte that spells no character as `\xNN`, and mruby spells the two digits in lower case where CRuby spells them in upper case:

```ruby
171.chr.inspect  #=> "\"\\xAB\"" in CRuby, "\"\\xab\"" in mruby
"る".dump        #=> "\"\\xE3\\x82\\x8B\"" in CRuby, lower case in mruby
```

`str_escape()` takes the two digits from `mrb_digitmap`, the table `Integer#to_s` reads a number through. Lower case is right for that table, since CRuby spells a number in lower case as well, so the escape gets a table of its own rather than the shared one moving under both readers.

### What moves with it

Everything that prints through `str_escape()`: `String#inspect`, `String#dump`, `Symbol#inspect` of a name that has to be quoted, and the `%!` conversions of `mrb_vformat()`, which is what the debugger's `p` prints through.

### What stays

`mrb_ptr_to_str()` keeps `mrb_digitmap`, since CRuby writes the address in `#<Object:0x...>` in lower case too. `%X` in mruby-sprintf upper cases its own output through `toupper()` and never reads the table.

### Tests

The first commit moves every expectation that pinned the lower case spelling, and gives `String#inspect` a case of a single byte above ASCII, which it had none of. It fails without the second.

Five places held such an expectation: core `String#inspect` and `mrb_vformat`, mruby-string-ext's `String#dump` and its `inspect` of a byte-read string, mruby-encoding's `Integer#chr` above ASCII, and mruby-bin-debugger's bintest for `p`.

### Verification

At the tip, the full suite is green on `ci/gcc-clang` in full, which is `full-debug`, `bintest`, `cxx_abi` and the default gembox build, and on the plain `host` build. 0 failures, 0 crashes. The bintest run is included, since the debugger's `p` prints through this escape.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated string inspection, dumping, and formatting to use uppercase hexadecimal escapes, such as `\xAB`, for non-printable and binary characters.
  * Standardized escape output across regular, formatted, UTF-8, and non-UTF-8 strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->