### PR TITLE
Read the pieces `partition` cuts the way the whole was read

### DIFF
--- a/mrbgems/mruby-encoding/test/string.rb
+++ b/mrbgems/mruby-encoding/test/string.rb
@@ -438,26 +438,26 @@ end
 
 assert('a byte-read string cut in three') do
   # `partition` and `rpartition` cut their pieces out of the receiver's bytes,
-  # and every piece comes back read as UTF-8 whatever the receiver was read
-  # as, most of them over bytes that refuse to read as it. Only the separator
-  # piece carries a reading of its own, being the argument handed back through
-  # `dup`. Pin where every answer stands before any of it moves.
+  # so the head and the tail are read the way the receiver was. The middle
+  # piece is the separator that was handed in and is read the way that was;
+  # where no separator is found there is none to hand back, and the empty
+  # pieces stand for places in the receiver instead.
   if UTF8STRING
     b = "a\xABb".b
     bin = Encoding::BINARY
     utf = Encoding::UTF_8
     assert_equal ["", "a", "\xABb"], b.partition("a")
     assert_equal ["a\xAB", "b", ""], b.rpartition("b")
-    assert_equal [utf, utf, utf], b.partition("a").map { |piece| piece.encoding }
-    assert_equal [utf, utf, utf], b.rpartition("b").map { |piece| piece.encoding }
-    assert_false b.partition("a")[2].valid_encoding?
-    # where the separator is found nowhere, the receiver comes back whole and
-    # the two empty pieces are cut out of nothing
-    assert_equal [bin, utf, utf], b.partition("x").map { |piece| piece.encoding }
-    assert_equal [utf, utf, bin], b.rpartition("x").map { |piece| piece.encoding }
+    assert_equal [bin, utf, bin], b.partition("a").map { |piece| piece.encoding }
+    assert_equal [bin, utf, bin], b.rpartition("b").map { |piece| piece.encoding }
+    assert_true b.partition("a")[2].valid_encoding?
+    # where the separator is found nowhere, the two empty pieces stand for
+    # places in the receiver and are read the way it is
+    assert_equal [bin, bin, bin], b.partition("x").map { |piece| piece.encoding }
+    assert_equal [bin, bin, bin], b.rpartition("x").map { |piece| piece.encoding }
     # an empty separator cuts nothing off either end
-    assert_equal [utf, utf, bin], b.partition("").map { |piece| piece.encoding }
-    assert_equal [bin, utf, utf], b.rpartition("").map { |piece| piece.encoding }
+    assert_equal [bin, utf, bin], b.partition("").map { |piece| piece.encoding }
+    assert_equal [bin, utf, bin], b.rpartition("").map { |piece| piece.encoding }
     # a separator read as bytes hands its own reading to the middle piece alone
     assert_equal [utf, bin, utf], "aあb".partition("a".b).map { |piece| piece.encoding }
     assert_equal [utf, bin, utf], "aあb".rpartition("b".b).map { |piece| piece.encoding }

--- a/mrbgems/mruby-encoding/test/string.rb
+++ b/mrbgems/mruby-encoding/test/string.rb
@@ -435,3 +435,33 @@ assert('a byte-read string padded to width') do
     assert_equal Encoding::UTF_8, "あ".center(3).encoding
   end
 end
+
+assert('a byte-read string cut in three') do
+  # `partition` and `rpartition` cut their pieces out of the receiver's bytes,
+  # and every piece comes back read as UTF-8 whatever the receiver was read
+  # as, most of them over bytes that refuse to read as it. Only the separator
+  # piece carries a reading of its own, being the argument handed back through
+  # `dup`. Pin where every answer stands before any of it moves.
+  if UTF8STRING
+    b = "a\xABb".b
+    bin = Encoding::BINARY
+    utf = Encoding::UTF_8
+    assert_equal ["", "a", "\xABb"], b.partition("a")
+    assert_equal ["a\xAB", "b", ""], b.rpartition("b")
+    assert_equal [utf, utf, utf], b.partition("a").map { |piece| piece.encoding }
+    assert_equal [utf, utf, utf], b.rpartition("b").map { |piece| piece.encoding }
+    assert_false b.partition("a")[2].valid_encoding?
+    # where the separator is found nowhere, the receiver comes back whole and
+    # the two empty pieces are cut out of nothing
+    assert_equal [bin, utf, utf], b.partition("x").map { |piece| piece.encoding }
+    assert_equal [utf, utf, bin], b.rpartition("x").map { |piece| piece.encoding }
+    # an empty separator cuts nothing off either end
+    assert_equal [utf, utf, bin], b.partition("").map { |piece| piece.encoding }
+    assert_equal [bin, utf, utf], b.rpartition("").map { |piece| piece.encoding }
+    # a separator read as bytes hands its own reading to the middle piece alone
+    assert_equal [utf, bin, utf], "aあb".partition("a".b).map { |piece| piece.encoding }
+    assert_equal [utf, bin, utf], "aあb".rpartition("b".b).map { |piece| piece.encoding }
+    # a receiver read as UTF-8 goes on being read that way
+    assert_equal [utf, utf, utf], "あい".partition("あ").map { |piece| piece.encoding }
+  end
+end

--- a/mrbgems/mruby-string-ext/src/string.c
+++ b/mrbgems/mruby-string-ext/src/string.c
@@ -2086,6 +2086,17 @@ str_clear(mrb_state *mrb, mrb_value self)
   return self;
 }
 
+/* A piece cut out of a string holds nothing but bytes of it, so it is read the
+   way the string is. An empty piece stands for a place in the string and is
+   read the same way, having no bytes to say otherwise. */
+static mrb_value
+str_cut_piece(mrb_state *mrb, mrb_value str, const char *p, mrb_int len)
+{
+  mrb_value piece = mrb_str_new(mrb, p, len);
+  RSTR_COPY_BINARY_FLAG(mrb_str_ptr(piece), mrb_str_ptr(str));
+  return piece;
+}
+
 /*
  *  call-seq:
  *     str.partition(sep) -> [head, sep, tail]
@@ -2115,8 +2126,8 @@ str_partition(mrb_state *mrb, mrb_value self)
   mrb_value result_ary = mrb_ary_new_capa(mrb, 3);
 
   if (sep_len == 0) {
-    mrb_ary_push(mrb, result_ary, mrb_str_new_lit(mrb, ""));
-    mrb_ary_push(mrb, result_ary, mrb_str_new_lit(mrb, ""));
+    mrb_ary_push(mrb, result_ary, str_cut_piece(mrb, self, self_ptr, 0));
+    mrb_ary_push(mrb, result_ary, mrb_str_dup(mrb, sep));
     mrb_ary_push(mrb, result_ary, mrb_str_dup(mrb, self));
     return result_ary;
   }
@@ -2137,14 +2148,14 @@ str_partition(mrb_state *mrb, mrb_value self)
     mrb_int pre_len = found_ptr - self_ptr;
     mrb_int post_len = self_len - pre_len - sep_len;
 
-    mrb_ary_push(mrb, result_ary, mrb_str_new(mrb, self_ptr, pre_len));
+    mrb_ary_push(mrb, result_ary, str_cut_piece(mrb, self, self_ptr, pre_len));
     mrb_ary_push(mrb, result_ary, mrb_str_dup(mrb, sep));
-    mrb_ary_push(mrb, result_ary, mrb_str_new(mrb, found_ptr + sep_len, post_len));
+    mrb_ary_push(mrb, result_ary, str_cut_piece(mrb, self, found_ptr + sep_len, post_len));
   }
   else {
     mrb_ary_push(mrb, result_ary, mrb_str_dup(mrb, self));
-    mrb_ary_push(mrb, result_ary, mrb_str_new_lit(mrb, ""));
-    mrb_ary_push(mrb, result_ary, mrb_str_new_lit(mrb, ""));
+    mrb_ary_push(mrb, result_ary, str_cut_piece(mrb, self, self_ptr, 0));
+    mrb_ary_push(mrb, result_ary, str_cut_piece(mrb, self, self_ptr, 0));
   }
 
   return result_ary;
@@ -2180,8 +2191,8 @@ str_rpartition(mrb_state *mrb, mrb_value self)
 
   if (sep_len == 0) {
     mrb_ary_push(mrb, result_ary, mrb_str_dup(mrb, self));
-    mrb_ary_push(mrb, result_ary, mrb_str_new_lit(mrb, ""));
-    mrb_ary_push(mrb, result_ary, mrb_str_new_lit(mrb, ""));
+    mrb_ary_push(mrb, result_ary, mrb_str_dup(mrb, sep));
+    mrb_ary_push(mrb, result_ary, str_cut_piece(mrb, self, self_ptr, 0));
     return result_ary;
   }
 
@@ -2201,13 +2212,13 @@ str_rpartition(mrb_state *mrb, mrb_value self)
     mrb_int pre_len = found_ptr - self_ptr;
     mrb_int post_len = self_len - pre_len - sep_len;
 
-    mrb_ary_push(mrb, result_ary, mrb_str_new(mrb, self_ptr, pre_len));
+    mrb_ary_push(mrb, result_ary, str_cut_piece(mrb, self, self_ptr, pre_len));
     mrb_ary_push(mrb, result_ary, mrb_str_dup(mrb, sep));
-    mrb_ary_push(mrb, result_ary, mrb_str_new(mrb, found_ptr + sep_len, post_len));
+    mrb_ary_push(mrb, result_ary, str_cut_piece(mrb, self, found_ptr + sep_len, post_len));
   }
   else {
-    mrb_ary_push(mrb, result_ary, mrb_str_new_lit(mrb, ""));
-    mrb_ary_push(mrb, result_ary, mrb_str_new_lit(mrb, ""));
+    mrb_ary_push(mrb, result_ary, str_cut_piece(mrb, self, self_ptr, 0));
+    mrb_ary_push(mrb, result_ary, str_cut_piece(mrb, self, self_ptr, 0));
     mrb_ary_push(mrb, result_ary, mrb_str_dup(mrb, self));
   }
 


### PR DESCRIPTION
Follow-up to #7136, which carried the byte reading into every cut of a string but this one.

`String#partition` and `String#rpartition` build their pieces with `mrb_str_new()` and never look at what the string they cut was read as, so the pieces come back reading UTF-8 over bytes that refuse to read as it:

```ruby
b = "a\xABb".b

b.partition("a")   #=> ["", "a", "\xABb"]  head and tail UTF-8, invalid  (CRuby: ASCII-8BIT)
b.rpartition("b")  #=> ["a\xAB", "b", ""]  head and tail UTF-8, invalid  (CRuby: ASCII-8BIT)
b.partition("x")   #=> the two empty pieces UTF-8                        (CRuby: ASCII-8BIT)

b.split("a")       #=> ASCII-8BIT   (since #7136)
b.chars            #=> ASCII-8BIT
b[1, 2]            #=> ASCII-8BIT
```

Since 80c781b refuses a subject whose bytes do not read as UTF-8, this is no longer a mis-indexing but a refusal: `b[1, 2] =~ /b/` answers, while `b.partition("a")[2]`, the same two bytes, raises `ArgumentError`.

### The rule

The three pieces do not all come from one place, and CRuby reads each accordingly.

- **The head and the tail are cut out of the receiver.** They hold nothing but bytes of it, so they are read the way it is, ASCII bytes and all, which is what every other cut already does.
- **The middle piece is the separator that was handed in.** It is read the way that was, which `mrb_str_dup()` already gives it. An empty separator now comes back through that same dup rather than as a fresh literal, so it too answers the way it was handed in.
- **Where the separator is found nowhere there is none to hand back.** The two empty pieces stand for places in the receiver, so they carry the receiver's reading.

`str_cut_piece()` says the first and the last of these once for both methods: cut the bytes, then read them the way the string they were cut from was read. An empty piece goes through it as a cut of no bytes, which is what it is, rather than through `mrb_str_new_lit()` where no reading is at hand to carry.

This reproduces CRuby's answer for every pair it accepts. The pairs CRuby refuses with `Encoding::CompatibilityError` are separators found nowhere here, as they already were, so `"aあb".partition(171.chr)` hands the receiver back whole and says nothing about the reading rather than something false, the same choice #7137 made.

### Tests

The first commit pins where every answer stands before any of it moves; the second flips exactly the pins it changes. Both sit in mruby-encoding's test file next to the cuts #7136 pinned, since that gem already takes mruby-string-ext as a test dependency and the reading is only visible through it.

### Verification

Full suite green at every commit, on full-core with `MRB_UTF8_STRING` (2281 tests), the same with the C++ ABI (2281), and the default gembox, where mruby-encoding is absent and the new test skips (2066). 0 failures, 0 crashes, no new compiler warnings.

### Still left out

`Array#pack` / `String#unpack` and the Symbol round trip, the two #7143 named. Each is its own change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `String#partition` and `String#rpartition` to preserve byte-oriented string behavior across extracted pieces.
  * Corrected encoding propagation for found, missing, and empty separators.
  * Ensured separator encoding affects only the appropriate partition result.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->