### PR TITLE
string.h: drop the unused `MRB_STR_STATE_MASK`

### DIFF
--- a/include/mruby/string.h
+++ b/include/mruby/string.h
@@ -53,7 +53,6 @@ struct RStringEmbed {
 
 #define MRB_STR_BINARY    16
 #define MRB_STR_SINGLE_BYTE 32
-#define MRB_STR_STATE_MASK 48
 /* bits 6..10 are the embedded length, so 11 is the first one free */
 #define MRB_STR_VALID_ENC 2048
 #define MRB_STR_BROKEN_ENC 4096


### PR DESCRIPTION
`MRB_STR_STATE_MASK` has had no reader since it was added in 8c184d456. Before this change, a grep over the whole tree finds only the definition itself:

```
$ grep -rn "MRB_STR_STATE_MASK" .
./include/mruby/string.h:56:#define MRB_STR_STATE_MASK 48
```

No code reads or writes `MRB_STR_BINARY` and `MRB_STR_SINGLE_BYTE` as one group, which is the only thing a mask over the two is for.

The name has also stopped matching what it says. It reads as "the string's state bits", but `MRB_STR_VALID_ENC` and `MRB_STR_BROKEN_ENC` are state bits too and sit outside the mask, so anyone who reached for it to clear a string's state would leave those two standing. With no caller in the tree there is nothing to say which set the mask should cover, so this removes it instead of picking one.

### What this changes

* The generated object code is unchanged. The macro appears in no `#if` and no `#ifdef`, and no Ruby level behavior depends on it.
* `include/mruby/string.h` loses one line. It is a public header, and `lib/mruby/amalgam.rb` inlines it whole into the amalgamated header, so the line disappears there as well. Code outside this repository that names `MRB_STR_STATE_MASK` would stop compiling; nothing inside it does.

### Testing

`rake -m test` on the default build: 2040 OK, 0 KO.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an obsolete public string-state macro.
  * Existing encoding and binary string flags remain available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->