### PR TITLE
Walk the backward regexp search by byte

### DIFF
--- a/mrbgems/mruby-regexp/mrblib/string_regexp.rb
+++ b/mrbgems/mruby-regexp/mrblib/string_regexp.rb
@@ -515,24 +515,38 @@ class String
     md && md.begin(0)
   end
 
-  # The last match that starts at or before `limit`, or nil, with the match
-  # globals left describing it.  `limit` is a byte offset when `bytes` is
-  # true and a character offset otherwise, which is the whole of the
-  # difference between `byterindex` and `rindex`.
+  # The last match that starts at or before `limit`, a byte offset, or nil,
+  # with the match globals left describing it.
   #
   # The engine searches forward only, so this walks the subject from the
   # start and keeps the last match that qualifies: linear in the number of
   # positions a match starts at, where the backward search CRuby hands to
-  # Onig is not.  Each step resumes one character past the match start and
-  # not at the match end, which is what keeps overlapping matches in view:
+  # Onig is not.  Each step resumes one byte past the match start and not at
+  # the match end, which is what keeps overlapping matches in view:
   # `"aaa".rindex(/aa/)` is 1, where resuming at the end would answer 0.
-  def __regexp_rsearch(pattern, limit, bytes)
+  #
+  # The walk is in byte space so that its length is what it looks like.  A
+  # character offset is not a place the subject can be read from: every one
+  # handed to `Regexp.__search` is counted out from the start of the subject
+  # again, and every one read back off a match with `begin` is counted the
+  # same way, so a walk that speaks characters pays for the whole subject on
+  # every turn and takes quadratic time on a multibyte one.  Nothing is given
+  # up by leaving them: a byte inside a character is not a position a match
+  # can start at, and the engine steps over one on its own rather than seed a
+  # match attempt there, so `+ 1` reaches the next character by itself.
+  #
+  # `Regexp.__byte_search` does not range check its position, so the walk
+  # stops itself at the end of the subject.  An empty match there is the one
+  # that reaches it: it leaves `pos` one past the last byte.
+  def __regexp_rsearch(pattern, limit)
     found = nil
     pos = 0
-    while (md = Regexp.__search(pattern, self, pos))
-      break if (bytes ? md.__byte_begin(0) : md.begin(0)) > limit
+    size = self.bytesize
+    while pos <= size && (md = Regexp.__byte_search(pattern, self, pos))
+      start = md.__byte_begin(0)
+      break if start > limit
       found = md
-      pos = md.begin(0) + 1
+      pos = start + 1
     end
     # The loop leaves behind whatever its last search published: the clear a
     # failed one does, or a match past `limit` that is not the answer.  Both
@@ -568,7 +582,14 @@ class String
         pos = len
       end
     end
-    md = __regexp_rsearch(args[0], pos, false)
+    # The walk reads the subject by byte, so the character position it is to
+    # stop at has to be read as one here.  A position at the end of the
+    # subject is the end of its bytes and needs no reading, which is the form
+    # `rindex` is called in when it is called with one argument at all; only
+    # a position named by the caller is measured, once, where the walk would
+    # otherwise have measured one on every turn.
+    byte_pos = pos == len ? self.bytesize : self[0, pos].bytesize
+    md = __regexp_rsearch(args[0], byte_pos)
     md && md.begin(0)
   end
 
@@ -614,7 +635,7 @@ class String
         pos = len
       end
     end
-    md = __regexp_rsearch(args[0], pos, true)
+    md = __regexp_rsearch(args[0], pos)
     md && md.__byte_begin(0)
   end
 
@@ -636,7 +657,7 @@ class String
     return __rpartition(sep) unless Regexp === sep
     # The last match anywhere in the subject, so the limit is its end and the
     # walk below never stops early.
-    md = __regexp_rsearch(sep, self.length, false)
+    md = __regexp_rsearch(sep, self.bytesize)
     # No match puts the whole subject in the tail, which is the row this
     # method is most often got wrong on.
     return ["", "", self.byteslice(0, self.bytesize)] unless md

--- a/mrbgems/mruby-regexp/test/string_index.rb
+++ b/mrbgems/mruby-regexp/test/string_index.rb
@@ -344,6 +344,40 @@ assert("String#rindex with regexp") do
   assert_nil "hello".rindex(/l/, -10)
 end
 
+assert("String#rindex bounds the match start in characters") do
+  # The position `rindex` takes is a character offset and the one
+  # `byterindex` takes is a byte offset. On a single-byte subject the two
+  # name the same place, so only a multibyte one says which is being read.
+  skip unless __ENCODING__ == "UTF-8"
+  str = "あいうあいう"    # 6 characters, 18 bytes
+
+  assert_equal 4, str.rindex(/い/)
+  assert_equal 12, str.byterindex(/い/)
+
+  # 1 as a character offset is the second character, which the first `い` is;
+  # as a byte offset it is inside the first character and reaches no match at
+  # all
+  assert_equal 1, str.rindex(/い/, 1)
+  assert_nil str.rindex(/い/, 0)
+  assert_equal 3, str.byterindex(/い/, 3)
+
+  # 4 as a character offset reaches the second `い`, where the same number of
+  # bytes is still short of the first
+  assert_equal 4, str.rindex(/い/, 4)
+  assert_equal 1, str.rindex(/い/, 3)
+
+  # a negative position counts back in the same space it counts forward in
+  assert_equal 4, str.rindex(/い/, -1)
+  assert_equal 1, str.rindex(/い/, -3)
+
+  # overlapping matches stay in view across a multibyte character, where a
+  # walk that resumed at the match end would answer 0
+  assert_equal 1, "あああ".rindex(/ああ/)
+  assert_equal 3, "あああ".byterindex(/ああ/)
+  assert_equal ["あ", "ああ", ""], "あああ".rpartition(/ああ/)
+  assert_equal ["あい", "うあ", "いう"], str.rpartition(/うあ/)
+end
+
 assert("String#index and String#rindex with regexp set the match globals") do
   assert_equal 1, "abc".index(/(b)/)
   assert_equal "b", $1


### PR DESCRIPTION
`String#rindex`, `String#byterindex` and `String#rpartition` reach a Regexp answer through `__regexp_rsearch`, which walks the subject from the start and keeps the last match that starts at or before the limit, because the engine searches forward only. The walk spoke character offsets, and a character offset is not a place a subject can be read from:

```ruby
("ab" * 10000).rindex(/b/)   # 0.012s
("あb" * 10000).rindex(/b/)  # 0.584s   same match count, same walk
```

Every turn of that loop counted the whole subject, up to three times:

- `Regexp.__search(pattern, self, pos)` reaches the byte offset the engine takes by counting `pos` characters out from the start of the subject (`re_char_to_byte()`, then `mrb_str_char_to_byte(mrb, str, 0, char_off)`).
- `md.begin(0)` counts a byte offset back to a character offset the same way (`re_byte_to_char()`), and the loop asked for it twice: once for the `limit` test, once for the position to resume at.

Neither counts for anything on a single-byte subject, where `MRB_STR_SINGLE_BYTE` makes both conversions the identity. On a multibyte one the walk read the whole subject once per match and took quadratic time.

### Walk in bytes

Nothing is given up by leaving character space. A byte inside a character is not a position a match can start at, and the engine steps over one rather than seed an attempt there, in `nfa_exec()`, `bt_exec()` and `literal_exec()` alike (`mrb_re_utf8_interior_p()`), so resuming one byte past the match start reaches the next character by itself:

```ruby
Regexp.__byte_search(/./, "あb", 1).__byte_begin(0)  #=> 3, not 1
```

Resuming one position past the match start rather than at the match end is what keeps an overlapping match in view (`"aaa".rindex(/aa/)` is 1, where resuming at the end would answer 0). That is a statement about overlap and not about character boundaries, and one byte past keeps it exactly the way one character past did.

So `limit` is a byte offset for every caller, which is what `byterindex` already handed it, and the loop reads a match start with `__byte_begin(0)`. `rindex` reads the character position it was given into a byte one where it is given, once: the whole subject is its own byte length, which is the form `rindex` is in whenever it is called with one argument, and only a position the caller named is measured. `Regexp.__byte_search` does not range check its position, so the walk stops itself at the end of the subject.

### Numbers

Full-core build with `MRB_UTF8_STRING`, best of three:

```
                                     before    after
("あb" *  5000).rindex(/b/)          0.174s    0.007s
("あb" * 10000).rindex(/b/)          0.584s    0.019s
("あb" * 20000).rindex(/b/)          2.315s    0.060s
("あb" * 10000).byterindex(/b/)      0.393s    0.017s
("あb" * 10000).rpartition(/b/)      0.574s    0.016s
("ab"  * 10000).rindex(/b/)          0.012s    0.012s
```

Doubling the subject quadrupled the time before and roughly triples it now, which is the part this does not fix: every successful search publishes the pre match and post match globals, so the walk still copies the subject once per match. That is common to every search loop in the gem, `gsub`, `split` and `scan` included, and is its own change.

### Tests

The first commit pins where the answers stand before any of it moves. `rindex` bounds the match start in characters and `byterindex` bounds it in bytes, which is the whole of the difference between them, and no test said so: the ones that pass a position pass it to `"hello"`, where the two readings name the same place, and the one multibyte pair reads the answer back rather than the argument. The new test asks both with a position on `"あいうあいう"`, and asks whether an overlapping match still stands when the match ahead of it is multibyte. Every answer is CRuby's. It skips on a build that reads every string as bytes, where the two readings agree again.

Dropping the character position conversion the second commit adds turns 4 of its assertions red, including the one argument form.

Beyond the suite, a differential ran the character-space walk and the new byte-space one against each other over 27 subjects (ASCII, multibyte, 4 byte characters, byte-read, and bytes that read as no character) by 24 patterns (empty, literal, quantified, anchored, lookahead, lookbehind, backreference, alternation), at every position from past one end to past the other, comparing the answer, the exception where one is raised, and `$~`, `$&`, `` $` ``, `$'` and `$1` after the call. 21,672 checks on the UTF-8 build and 24,552 on the byte-indexing one, 0 mismatches.

### Verification

Full suite green at every commit on `build_config/ci/gcc-clang.rb`: full-core with `MRB_GC_STRESS` (2281), bintest (2282), the C++ ABI (2282), and the default gembox, where the new test skips (2067). 0 failures, 0 crashes, no new compiler warnings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reverse regular-expression searches for UTF-8 and other multibyte strings.
  * Corrected character-based limits for `rindex` and byte-based limits for `byterindex`.
  * Fixed `rpartition` behavior when processing multibyte text, including negative and overlapping-match scenarios.
* **Tests**
  * Added regression coverage for UTF-8 indexing, byte offsets, bounds, and partitioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->