### PR TITLE
Publish only the match a backward search answers with

### DIFF
--- a/mrbgems/mruby-regexp/mrblib/string_regexp.rb
+++ b/mrbgems/mruby-regexp/mrblib/string_regexp.rb
@@ -538,19 +538,26 @@ class String
   # `Regexp.__byte_search` does not range check its position, so the walk
   # stops itself at the end of the subject.  An empty match there is the one
   # that reaches it: it leaves `pos` one past the last byte.
+  #
+  # The walk publishes none of what it passes over.  A search that publishes
+  # cuts the whole subject into the pre match and post match globals, and
+  # every match here but the last is one this method already means to
+  # replace, so publishing them costs the subject once per match and leaves
+  # behind nothing anything reads.  The answer is published below instead,
+  # which is where it was published from before.
   def __regexp_rsearch(pattern, limit)
     found = nil
     pos = 0
     size = self.bytesize
-    while pos <= size && (md = Regexp.__byte_search(pattern, self, pos))
+    while pos <= size && (md = Regexp.__byte_search(pattern, self, pos, false, false))
       start = md.__byte_begin(0)
       break if start > limit
       found = md
       pos = start + 1
     end
-    # The loop leaves behind whatever its last search published: the clear a
-    # failed one does, or a match past `limit` that is not the answer.  Both
-    # have to give way to what the search found.
+    # The globals still describe whatever they described before the call, the
+    # walk having said nothing to them, so the answer is published here and a
+    # search that found none clears them itself.
     found ? found.__set_globals : Regexp.__search(pattern, nil)
     found
   end

--- a/mrbgems/mruby-regexp/mrblib/string_regexp.rb
+++ b/mrbgems/mruby-regexp/mrblib/string_regexp.rb
@@ -515,24 +515,38 @@ class String
     md && md.begin(0)
   end
 
-  # The last match that starts at or before `limit`, or nil, with the match
-  # globals left describing it.  `limit` is a byte offset when `bytes` is
-  # true and a character offset otherwise, which is the whole of the
-  # difference between `byterindex` and `rindex`.
+  # The last match that starts at or before `limit`, a byte offset, or nil,
+  # with the match globals left describing it.
   #
   # The engine searches forward only, so this walks the subject from the
   # start and keeps the last match that qualifies: linear in the number of
   # positions a match starts at, where the backward search CRuby hands to
-  # Onig is not.  Each step resumes one character past the match start and
-  # not at the match end, which is what keeps overlapping matches in view:
+  # Onig is not.  Each step resumes one byte past the match start and not at
+  # the match end, which is what keeps overlapping matches in view:
   # `"aaa".rindex(/aa/)` is 1, where resuming at the end would answer 0.
-  def __regexp_rsearch(pattern, limit, bytes)
+  #
+  # The walk is in byte space so that its length is what it looks like.  A
+  # character offset is not a place the subject can be read from: every one
+  # handed to `Regexp.__search` is counted out from the start of the subject
+  # again, and every one read back off a match with `begin` is counted the
+  # same way, so a walk that speaks characters pays for the whole subject on
+  # every turn and takes quadratic time on a multibyte one.  Nothing is given
+  # up by leaving them: a byte inside a character is not a position a match
+  # can start at, and the engine steps over one on its own rather than seed a
+  # match attempt there, so `+ 1` reaches the next character by itself.
+  #
+  # `Regexp.__byte_search` does not range check its position, so the walk
+  # stops itself at the end of the subject.  An empty match there is the one
+  # that reaches it: it leaves `pos` one past the last byte.
+  def __regexp_rsearch(pattern, limit)
     found = nil
     pos = 0
-    while (md = Regexp.__search(pattern, self, pos))
-      break if (bytes ? md.__byte_begin(0) : md.begin(0)) > limit
+    size = self.bytesize
+    while pos <= size && (md = Regexp.__byte_search(pattern, self, pos))
+      start = md.__byte_begin(0)
+      break if start > limit
       found = md
-      pos = md.begin(0) + 1
+      pos = start + 1
     end
     # The loop leaves behind whatever its last search published: the clear a
     # failed one does, or a match past `limit` that is not the answer.  Both
@@ -568,7 +582,14 @@ class String
         pos = len
       end
     end
-    md = __regexp_rsearch(args[0], pos, false)
+    # The walk reads the subject by byte, so the character position it is to
+    # stop at has to be read as one here.  A position at the end of the
+    # subject is the end of its bytes and needs no reading, which is the form
+    # `rindex` is called in when it is called with one argument at all; only
+    # a position named by the caller is measured, once, where the walk would
+    # otherwise have measured one on every turn.
+    byte_pos = pos == len ? self.bytesize : self[0, pos].bytesize
+    md = __regexp_rsearch(args[0], byte_pos)
     md && md.begin(0)
   end
 
@@ -614,7 +635,7 @@ class String
         pos = len
       end
     end
-    md = __regexp_rsearch(args[0], pos, true)
+    md = __regexp_rsearch(args[0], pos)
     md && md.__byte_begin(0)
   end
 
@@ -636,7 +657,7 @@ class String
     return __rpartition(sep) unless Regexp === sep
     # The last match anywhere in the subject, so the limit is its end and the
     # walk below never stops early.
-    md = __regexp_rsearch(sep, self.length, false)
+    md = __regexp_rsearch(sep, self.bytesize)
     # No match puts the whole subject in the tail, which is the row this
     # method is most often got wrong on.
     return ["", "", self.byteslice(0, self.bytesize)] unless md

--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -324,9 +324,12 @@ set_match_globals(mrb_state *mrb, mrb_value obj, mrb_value str, int *captures, i
   mrb_gv_set(mrb, last_match_syms[LAST_PAREN], last_paren);
 }
 
-/* Create MatchData from captures */
+/* Create MatchData from captures. `publish` says whether the match becomes the
+   one the match globals describe; a caller that will publish a match of its
+   own choosing passes FALSE and leaves them where they were. */
 static mrb_value
-create_matchdata(mrb_state *mrb, mrb_value regexp, mrb_value str, int *captures, int ncap)
+create_matchdata(mrb_state *mrb, mrb_value regexp, mrb_value str, int *captures, int ncap,
+                 mrb_bool publish)
 {
   /* Snapshot the subject: MatchData reports the string as it was at match
      time, so later in-place changes to it must not be visible here. */
@@ -347,7 +350,7 @@ create_matchdata(mrb_state *mrb, mrb_value regexp, mrb_value str, int *captures,
   mrb_iv_set(mrb, obj, mrb_intern_lit(mrb, "source"), str);
   mrb_iv_set(mrb, obj, mrb_intern_lit(mrb, "regexp"), regexp);
 
-  set_match_globals(mrb, obj, str, captures, md->num_captures);
+  if (publish) set_match_globals(mrb, obj, str, captures, md->num_captures);
 
   return obj;
 }
@@ -363,9 +366,11 @@ match_operand(mrb_state *mrb, mrb_value obj)
 
 /* Internal: execute match and create MatchData.
    Returns MatchData on match, nil on no match.
-   Sets $~ and $1-$9 globals. */
+   Sets $~ and $1-$9 globals, unless `publish` says the caller owns them: a
+   search that publishes nothing clears nothing either, so the globals come
+   out of it exactly as they went in. */
 static mrb_value
-exec_match(mrb_state *mrb, mrb_value self, mrb_value str, mrb_int pos)
+exec_match(mrb_state *mrb, mrb_value self, mrb_value str, mrb_int pos, mrb_bool publish)
 {
   mrb_regexp_pattern *pat = DATA_GET_PTR(mrb, self, &regexp_type, mrb_regexp_pattern);
   if (!pat) mrb_raise(mrb, E_ARGUMENT_ERROR, "uninitialized Regexp");
@@ -378,10 +383,10 @@ exec_match(mrb_state *mrb, mrb_value self, mrb_value str, mrb_int pos)
 
   if (ncap == 0) {
     mrb_free(mrb, captures);
-    clear_match_globals(mrb);
+    if (publish) clear_match_globals(mrb);
     return mrb_nil_value();
   }
-  mrb_value md = create_matchdata(mrb, self, str, captures, cap_size);
+  mrb_value md = create_matchdata(mrb, self, str, captures, cap_size, publish);
   mrb_free(mrb, captures);
   return md;
 }
@@ -410,7 +415,7 @@ regexp_match(mrb_state *mrb, mrb_value self)
   }
 
   re_check_encoding(mrb, str);
-  md = exec_match(mrb, self, str, pos);
+  md = exec_match(mrb, self, str, pos, TRUE);
   if (!mrb_nil_p(md) && !mrb_nil_p(block)) {
     return mrb_yield(mrb, block, md);
   }
@@ -465,11 +470,11 @@ regexp_s_search(mrb_state *mrb, mrb_value klass)
     return mrb_nil_value();
   }
   if (!checked) re_check_encoding(mrb, str);
-  return exec_match(mrb, re, str, pos);
+  return exec_match(mrb, re, str, pos, TRUE);
 }
 
 /*
- * Regexp.__byte_search(re, str, pos = 0, checked = false)
+ * Regexp.__byte_search(re, str, pos = 0, checked = false, publish = true)
  *
  * Internal: the byte-offset search the mrblib loops of `gsub`, `split` and
  * `byteindex` drive themselves. No position normalization, because the
@@ -478,6 +483,12 @@ regexp_s_search(mrb_state *mrb, mrb_value klass)
  * the check reads the flag core left on it after the first turn. `checked`
  * carries the same meaning as in `__search`: `gsub` sets it for a block over
  * a quoted String pattern.
+ *
+ * `publish` says whether the match becomes the one the match globals describe.
+ * A loop that walks past a match on the way to the one it wants clears it:
+ * `rindex` and its family pass FALSE and publish the match they settled on
+ * with `MatchData#__set_globals`. `gsub` and `scan` cannot, since the block
+ * they call reads the globals of the match it was handed.
  */
 static mrb_value
 regexp_s_byte_search(mrb_state *mrb, mrb_value klass)
@@ -486,11 +497,12 @@ regexp_s_byte_search(mrb_state *mrb, mrb_value klass)
   mrb_int pos = 0;
 
   mrb_bool checked = FALSE;
+  mrb_bool publish = TRUE;
 
-  mrb_get_args(mrb, "oS|ib", &re, &str, &pos, &checked);
+  mrb_get_args(mrb, "oS|ibb", &re, &str, &pos, &checked, &publish);
   check_regexp_arg(mrb, re);
   if (!checked) re_check_encoding(mrb, str);
-  return exec_match(mrb, re, str, pos);
+  return exec_match(mrb, re, str, pos, publish);
 }
 
 /* Internal: the search of `match?`, run with a NULL capture buffer so that
@@ -557,7 +569,7 @@ regexp_match_op(mrb_state *mrb, mrb_value self)
   str = match_operand(mrb, str);
   re_check_encoding(mrb, str);
 
-  mrb_value md = exec_match(mrb, self, str, 0);
+  mrb_value md = exec_match(mrb, self, str, 0, TRUE);
   if (mrb_nil_p(md)) return mrb_nil_value();
 
   mrb_match_data *m = DATA_GET_PTR(mrb, md, &matchdata_type, mrb_match_data);
@@ -581,7 +593,7 @@ regexp_case_match(mrb_state *mrb, mrb_value self)
   if (!pat) return mrb_false_value();
   re_check_encoding(mrb, str);
 
-  md = exec_match(mrb, self, str, 0);
+  md = exec_match(mrb, self, str, 0, TRUE);
   return mrb_bool_value(!mrb_nil_p(md));
 }
 
@@ -1239,7 +1251,7 @@ regexp_s_gsub_str(mrb_state *mrb, mrb_value klass)
 
   /* set $~ from last match */
   if (last_ncap > 0) {
-    create_matchdata(mrb, re, str, last_captures, last_ncap);
+    create_matchdata(mrb, re, str, last_captures, last_ncap, TRUE);
   }
   else {
     clear_match_globals(mrb);
@@ -1302,7 +1314,7 @@ regexp_s_sub_str(mrb_state *mrb, mrb_value klass)
     mrb_str_cat(mrb, result, s + captures[1], slen - captures[1]);
   }
 
-  create_matchdata(mrb, re, str, captures, cap_size);
+  create_matchdata(mrb, re, str, captures, cap_size, TRUE);
   mrb_free(mrb, captures);
   re_mark_spliced(result, str, replacement, TRUE);
   return result;
@@ -1382,7 +1394,7 @@ regexp_s_scan(mrb_state *mrb, mrb_value klass)
   mrb_free(mrb, captures);
 
   if (last_ncap > 0) {
-    create_matchdata(mrb, re, str, last_captures, last_ncap);
+    create_matchdata(mrb, re, str, last_captures, last_ncap, TRUE);
   }
   else {
     clear_match_globals(mrb);
@@ -1438,7 +1450,7 @@ mrb_mruby_regexp_gem_init(mrb_state *mrb)
   mrb_define_class_method(mrb, re, "__check_encoding", regexp_check_encoding, MRB_ARGS_REQ(1));
   mrb_define_class_method(mrb, re, "__check_pattern", regexp_check_pattern, MRB_ARGS_REQ(1));
   mrb_define_class_method(mrb, re, "__search", regexp_s_search, MRB_ARGS_ARG(2, 2));
-  mrb_define_class_method(mrb, re, "__byte_search", regexp_s_byte_search, MRB_ARGS_ARG(2, 2));
+  mrb_define_class_method(mrb, re, "__byte_search", regexp_s_byte_search, MRB_ARGS_ARG(2, 3));
   mrb_define_class_method(mrb, re, "__search_p", regexp_s_search_p, MRB_ARGS_ARG(2, 1));
 
   /* Instance methods */

--- a/mrbgems/mruby-regexp/test/string_index.rb
+++ b/mrbgems/mruby-regexp/test/string_index.rb
@@ -344,6 +344,40 @@ assert("String#rindex with regexp") do
   assert_nil "hello".rindex(/l/, -10)
 end
 
+assert("String#rindex bounds the match start in characters") do
+  # The position `rindex` takes is a character offset and the one
+  # `byterindex` takes is a byte offset. On a single-byte subject the two
+  # name the same place, so only a multibyte one says which is being read.
+  skip unless __ENCODING__ == "UTF-8"
+  str = "あいうあいう"    # 6 characters, 18 bytes
+
+  assert_equal 4, str.rindex(/い/)
+  assert_equal 12, str.byterindex(/い/)
+
+  # 1 as a character offset is the second character, which the first `い` is;
+  # as a byte offset it is inside the first character and reaches no match at
+  # all
+  assert_equal 1, str.rindex(/い/, 1)
+  assert_nil str.rindex(/い/, 0)
+  assert_equal 3, str.byterindex(/い/, 3)
+
+  # 4 as a character offset reaches the second `い`, where the same number of
+  # bytes is still short of the first
+  assert_equal 4, str.rindex(/い/, 4)
+  assert_equal 1, str.rindex(/い/, 3)
+
+  # a negative position counts back in the same space it counts forward in
+  assert_equal 4, str.rindex(/い/, -1)
+  assert_equal 1, str.rindex(/い/, -3)
+
+  # overlapping matches stay in view across a multibyte character, where a
+  # walk that resumed at the match end would answer 0
+  assert_equal 1, "あああ".rindex(/ああ/)
+  assert_equal 3, "あああ".byterindex(/ああ/)
+  assert_equal ["あ", "ああ", ""], "あああ".rpartition(/ああ/)
+  assert_equal ["あい", "うあ", "いう"], str.rpartition(/うあ/)
+end
+
 assert("String#index and String#rindex with regexp set the match globals") do
   assert_equal 1, "abc".index(/(b)/)
   assert_equal "b", $1

--- a/mrbgems/mruby-regexp/test/string_index.rb
+++ b/mrbgems/mruby-regexp/test/string_index.rb
@@ -578,6 +578,45 @@ assert("String#partition and String#rpartition with regexp set the match globals
   assert_nil $~
 end
 
+assert("a backward search publishes every global of the match it settled on") do
+  # `$~` and `$1` are what the tests above read back. The rest of what a match
+  # leaves behind is published by the same act and is asserted here, since the
+  # walk these three share passes matches on the way to the one it answers
+  # with and none of those may be what is left standing.
+  assert_equal 4, "abcabc".rindex(/(b)(c)/)
+  assert_equal "bc", $&
+  assert_equal "abca", $`
+  assert_equal "", $'
+  assert_equal "b", $1
+  assert_equal "c", $2
+  assert_equal "c", $+
+  assert_equal "abca", $~.pre_match
+  assert_equal "", $~.post_match
+
+  assert_equal 4, "abcabc".byterindex(/(b)(c)/)
+  assert_equal "bc", $&
+  assert_equal "abca", $`
+
+  assert_equal ["abca", "bc", ""], "abcabc".rpartition(/(b)(c)/)
+  assert_equal "bc", $&
+  assert_equal "abca", $`
+  assert_equal "c", $+
+
+  # a group that did not take part leaves nil behind, and `$+` reaches past it
+  assert_equal 1, "abc".rindex(/(b)(z)?/)
+  assert_nil $2
+  assert_equal "b", $+
+
+  # and a search that finds nothing clears all of them, not `$~` alone
+  "zzz" =~ /(z)/
+  assert_nil "abc".rindex(/x/)
+  assert_nil $&
+  assert_nil $`
+  assert_nil $'
+  assert_nil $1
+  assert_nil $+
+end
+
 assert("String#partition and String#rpartition delegate every non-regexp argument") do
   assert_equal ["he", "ll", "o"], "hello".partition("ll")
   assert_equal ["hello", "", ""], "hello".partition("z")


### PR DESCRIPTION
Stacked on #7148, which this needs and whose commits it carries. Review the last two.

#7148 took the character counting out of the walk `String#rindex`, `String#byterindex` and `String#rpartition` share, and named what it did not fix: every search publishes its match, cutting the whole subject into the pre match and post match globals, so the walk still copies the subject once per match. This is that.

```
                                    #7148     here
("あb" *  5000).rindex(/b/)         0.007s    0.002s
("あb" * 10000).rindex(/b/)         0.019s    0.004s
("あb" * 20000).rindex(/b/)         0.060s    0.007s
("あb" * 10000).byterindex(/b/)     0.017s    0.004s
("あb" * 10000).rpartition(/b/)     0.016s    0.004s
("ab"  * 10000).rindex(/b/)         0.012s    0.004s
("ab"  * 20000).rindex(/b/)         0.034s    0.007s
```

Doubling the subject now doubles the time rather than tripling it. The single-byte subject was paying the same copy and had nothing to do with characters, which is why it moves too.

### What was being thrown away

A successful search publishes thirteen names: `$~`, `$1` through `$9`, the match, the two pieces the subject is cut into around it, and the last group that took part. Two of those thirteen are cut from the subject and together are the whole of it, so a search costs its subject once over whether or not anything reads the result.

The walk keeps the last match that qualifies, so every match it passes is published and then replaced by the next one. It already publishes its answer itself at the end, with `MatchData#__set_globals`, and clears for a miss. Nothing read what the searches published in between.

### Letting a search publish nothing

`Regexp.__byte_search` takes it as an argument, the way CRuby's `rb_reg_search0()` takes `set_backref_str`, and it reaches `exec_match()` and `create_matchdata()` from there. A search that publishes nothing clears nothing either, so the globals come out of it exactly as they went in and the caller owns them throughout; the walk passes FALSE and keeps the two lines that publish its answer or clear for a miss.

`gsub`, `scan` and `sub` cannot be told the same thing: the block they call reads the globals of the match it was handed, so those loops go on publishing every turn. The argument defaults to TRUE, so every other caller is where it was.

### Tests

The first commit asks for the eleven globals no test read back. `$~` and `$1` after a backward search are asserted already; the match, the two pieces, a second group, a group that did not take part, the last one that did, and the same set after a miss were not, and they are exactly what a walk that passes matches on the way to its answer has to get right. Every answer is CRuby's.

The second commit is where they start being published by one act rather than falling out of the last search. Keeping the walk's own publish but dropping its clear, which is the mistake this change makes available now that a failing search no longer clears, turns 6 of the new assertions red.

The differential from #7148 was rerun against this: 21,672 checks on the UTF-8 build and 24,552 on the byte-indexing one, comparing the answer, the exception where one is raised, and `$~`, `$&`, `` $` ``, `$'` and `$1` after every call. 0 mismatches.

### Verification

Full suite green at every commit on `build_config/ci/gcc-clang.rb`: full-core with `MRB_GC_STRESS` (2282), bintest (2283), the C++ ABI (2283), and the default gembox (2068). 0 failures, 0 crashes, no new compiler warnings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reverse regular-expression searches for multibyte text.
  * Corrected character-based and byte-based index limits, including negative positions, overlapping matches, and partitioning.
  * Ensured regular-expression match results are consistently updated after successful searches and cleared when searches fail.

* **Tests**
  * Added coverage for multibyte reverse searches, boundary conditions, overlapping matches, partitioning, and match-result handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->