### PR TITLE
Write `MRB_STR_BINARY` through accessors, as the other flags are

### DIFF
--- a/include/mruby/string.h
+++ b/include/mruby/string.h
@@ -126,6 +126,8 @@ struct RStringEmbed {
 #endif
 #define RSTR_SET_ASCII_FLAG(s) RSTR_SET_SINGLE_BYTE_FLAG(s)
 #define RSTR_BINARY_P(s) ((s)->flags & MRB_STR_BINARY)
+#define RSTR_SET_BINARY_FLAG(s) ((s)->flags |= MRB_STR_BINARY)
+#define RSTR_UNSET_BINARY_FLAG(s) ((s)->flags &= ~MRB_STR_BINARY)
 /* A copy of a string is byte-indexed exactly when the string it copies is, so
    the flag travels with the bytes rather than being left behind on the
    original. */

--- a/mrbgems/mruby-encoding/src/encoding.c
+++ b/mrbgems/mruby-encoding/src/encoding.c
@@ -69,10 +69,10 @@ str_force_encoding(mrb_state *mrb, mrb_value self)
   struct RString *s = mrb_str_ptr(self);
   if (MRB_STR_CASECMP_P(enc, ENC_ASCII_8BIT) ||
       MRB_STR_CASECMP_P(enc, ENC_BINARY)) {
-    s->flags |= MRB_STR_BINARY;
+    RSTR_SET_BINARY_FLAG(s);
   }
   else if (MRB_STR_CASECMP_P(enc, ENC_UTF8)) {
-    s->flags &= ~MRB_STR_BINARY;
+    RSTR_UNSET_BINARY_FLAG(s);
   }
   else {
     mrb_raisef(mrb, E_ARGUMENT_ERROR, "unknown encoding name - %v", enc);

--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -1163,7 +1163,7 @@ re_mark_spliced(mrb_value result, mrb_value subject, mrb_value replacement,
     while (p < e && !(*p & 0x80)) p++;
     if (p == e) return;
   }
-  mrb_str_ptr(result)->flags |= MRB_STR_BINARY;
+  RSTR_SET_BINARY_FLAG(mrb_str_ptr(result));
 }
 
 /*

--- a/mrbgems/mruby-sprintf/src/sprintf.c
+++ b/mrbgems/mruby-sprintf/src/sprintf.c
@@ -359,7 +359,7 @@ mark_written_bytes(mrb_value result, mrb_value src)
   const char *p = RSTR_PTR(s);
   const char *e = p + RSTR_LEN(s);
   while (p < e && !(*p & 0x80)) p++;
-  if (p < e) r->flags |= MRB_STR_BINARY;
+  if (p < e) RSTR_SET_BINARY_FLAG(r);
 }
 
 static mrb_value

--- a/mrbgems/mruby-string-bitops/src/string_bitops.c
+++ b/mrbgems/mruby-string-bitops/src/string_bitops.c
@@ -427,7 +427,7 @@ static mrb_value
 bitop_result_str(mrb_state *mrb, mrb_int len)
 {
   mrb_value result = mrb_str_new(mrb, NULL, len);
-  mrb_str_ptr(result)->flags |= MRB_STR_BINARY;
+  RSTR_SET_BINARY_FLAG(mrb_str_ptr(result));
   return result;
 }
 

--- a/mrbgems/mruby-string-ext/src/string.c
+++ b/mrbgems/mruby-string-ext/src/string.c
@@ -29,7 +29,7 @@ int_chr_binary(mrb_state *mrb, mrb_value num)
     RSTR_SET_ASCII_FLAG(mrb_str_ptr(str));
   }
   else {
-    mrb_str_ptr(str)->flags |= MRB_STR_BINARY;
+    RSTR_SET_BINARY_FLAG(mrb_str_ptr(str));
   }
   return str;
 }
@@ -125,7 +125,7 @@ str_mark_spliced_bytes(mrb_value recv, mrb_value src)
   const char *p = RSTR_PTR(s);
   const char *e = p + RSTR_LEN(s);
   while (p < e && !(*p & 0x80)) p++;
-  if (p < e) r->flags |= MRB_STR_BINARY;
+  if (p < e) RSTR_SET_BINARY_FLAG(r);
 }
 
 static void
@@ -1522,7 +1522,7 @@ static mrb_value
 str_b(mrb_state *mrb, mrb_value self)
 {
   mrb_value str = mrb_str_dup(mrb, self);
-  mrb_str_ptr(str)->flags |= MRB_STR_BINARY;
+  RSTR_SET_BINARY_FLAG(mrb_str_ptr(str));
   return str;
 }
 
@@ -1914,7 +1914,7 @@ str_rjust_core(mrb_state *mrb, mrb_value self)
   /* the padded string is the receiver's bytes in wider clothes, so it is
      read the way the receiver was, ASCII bytes and all */
   if (RSTR_BINARY_P(mrb_str_ptr(self))) {
-    mrb_str_ptr(result)->flags |= MRB_STR_BINARY;
+    RSTR_SET_BINARY_FLAG(mrb_str_ptr(result));
   }
   return result;
 }
@@ -1988,7 +1988,7 @@ str_center_core(mrb_state *mrb, mrb_value self)
   /* the padded string is the receiver's bytes in wider clothes, so it is
      read the way the receiver was, ASCII bytes and all */
   if (RSTR_BINARY_P(mrb_str_ptr(self))) {
-    mrb_str_ptr(result)->flags |= MRB_STR_BINARY;
+    RSTR_SET_BINARY_FLAG(mrb_str_ptr(result));
   }
   return result;
 }

--- a/src/string.c
+++ b/src/string.c
@@ -1419,7 +1419,7 @@ mrb_str_plus(mrb_state *mrb, mrb_value a, mrb_value b)
   if ((RSTR_BINARY_P(s) && RSTR_BINARY_P(s2)) ||
       (RSTR_BINARY_P(s) && !str_ascii_p(s)) ||
       (RSTR_BINARY_P(s2) && !str_ascii_p(s2))) {
-    t->flags |= MRB_STR_BINARY;
+    RSTR_SET_BINARY_FLAG(t);
   }
 
   return mrb_obj_value(t);
@@ -1851,7 +1851,7 @@ str_replace_partial(mrb_state *mrb, mrb_value src, mrb_int pos, mrb_int end, mrb
        their reading over, ASCII bytes move nothing */
     struct RString *repp = mrb_str_ptr(rep);
     if (!RSTR_BINARY_P(str) && RSTR_BINARY_P(repp) && !str_ascii_p(repp)) {
-      str->flags |= MRB_STR_BINARY;
+      RSTR_SET_BINARY_FLAG(str);
     }
   }
   RSTR_SET_LEN(str, newlen);
@@ -3638,7 +3638,7 @@ mrb_str_cat_str(mrb_state *mrb, mrb_value str, mrb_value str2)
   mrb_bool binary = !RSTR_BINARY_P(s) && RSTR_BINARY_P(s2) && !str_ascii_p(s2);
   mrb_value ret = mrb_str_cat(mrb, str, RSTRING_PTR(str2), RSTRING_LEN(str2));
   if (binary) {
-    mrb_str_ptr(ret)->flags |= MRB_STR_BINARY;
+    RSTR_SET_BINARY_FLAG(mrb_str_ptr(ret));
   }
   return ret;
 }
@@ -3879,7 +3879,7 @@ sub_replace(mrb_state *mrb, mrb_value self)
   if ((RSTR_BINARY_P(mrb_str_ptr(replace)) && !str_ascii_p(mrb_str_ptr(replace))) ||
       (match_taken && RSTR_BINARY_P(mrb_str_ptr(pat)) && !str_ascii_p(mrb_str_ptr(pat))) ||
       (self_taken && RSTR_BINARY_P(mrb_str_ptr(self)) && !str_ascii_p(mrb_str_ptr(self)))) {
-    mrb_str_ptr(result)->flags |= MRB_STR_BINARY;
+    RSTR_SET_BINARY_FLAG(mrb_str_ptr(result));
   }
   return result;
 }


### PR DESCRIPTION
`include/mruby/string.h` gives each string flag a named way in and out. Three of the four are complete, and one is not:

| flag | predicate | set | unset | copy |
| --- | --- | --- | --- | --- |
| `MRB_STR_SINGLE_BYTE` | `RSTR_SINGLE_BYTE_P` | `RSTR_SET_SINGLE_BYTE_FLAG` | `RSTR_UNSET_SINGLE_BYTE_FLAG` | `RSTR_COPY_SINGLE_BYTE_FLAG` |
| `MRB_STR_VALID_ENC` | `RSTR_VALID_ENC_P` | `RSTR_SET_VALID_ENC_FLAG` | `RSTR_UNSET_VALID_ENC_FLAG` | `RSTR_COPY_VALID_ENC_FLAG` |
| `MRB_STR_BROKEN_ENC` | `RSTR_BROKEN_ENC_P` | `RSTR_SET_BROKEN_ENC_FLAG` | `RSTR_UNSET_BROKEN_ENC_FLAG` | `RSTR_COPY_BROKEN_ENC_FLAG` |
| `MRB_STR_BINARY` | `RSTR_BINARY_P` | none | none | `RSTR_COPY_BINARY_FLAG` |

Because the two are missing, every place that turns the binary flag on or off reaches past the header and names the bit itself. Before this change:

```
$ grep -rn "flags |= MRB_STR_BINARY\|flags &= ~MRB_STR_BINARY" . --include='*.c'
mrbgems/mruby-encoding/src/encoding.c:72:    s->flags |= MRB_STR_BINARY;
mrbgems/mruby-encoding/src/encoding.c:75:    s->flags &= ~MRB_STR_BINARY;
mrbgems/mruby-regexp/src/regexp.c:1166:  mrb_str_ptr(result)->flags |= MRB_STR_BINARY;
mrbgems/mruby-sprintf/src/sprintf.c:362:  if (p < e) r->flags |= MRB_STR_BINARY;
mrbgems/mruby-string-ext/src/string.c:32:    mrb_str_ptr(str)->flags |= MRB_STR_BINARY;
mrbgems/mruby-string-ext/src/string.c:128:  if (p < e) r->flags |= MRB_STR_BINARY;
mrbgems/mruby-string-ext/src/string.c:1525:  mrb_str_ptr(str)->flags |= MRB_STR_BINARY;
mrbgems/mruby-string-ext/src/string.c:1917:    mrb_str_ptr(result)->flags |= MRB_STR_BINARY;
mrbgems/mruby-string-ext/src/string.c:1991:    mrb_str_ptr(result)->flags |= MRB_STR_BINARY;
mrbgems/mruby-string-bitops/src/string_bitops.c:430:  mrb_str_ptr(result)->flags |= MRB_STR_BINARY;
src/string.c:1422:    t->flags |= MRB_STR_BINARY;
src/string.c:1854:      str->flags |= MRB_STR_BINARY;
src/string.c:3641:    mrb_str_ptr(ret)->flags |= MRB_STR_BINARY;
src/string.c:3882:    mrb_str_ptr(result)->flags |= MRB_STR_BINARY;
```

Fourteen sites, one `src` file and five gems. After it, the same grep finds the two macro bodies in the header and nothing else.

### What this adds

```c
#define RSTR_SET_BINARY_FLAG(s) ((s)->flags |= MRB_STR_BINARY)
#define RSTR_UNSET_BINARY_FLAG(s) ((s)->flags &= ~MRB_STR_BINARY)
```

They sit next to `RSTR_BINARY_P()` rather than inside the `#ifdef MRB_UTF8_STRING` block the other three flags' accessors are in. A build without `MRB_UTF8_STRING` still tells a byte read string from the rest, and `String#b` and `String#force_encoding("BINARY")` still write the flag there, so the accessors have to be real in that build, exactly as `RSTR_BINARY_P()` already is.

`RSTR_COPY_BINARY_FLAG()` keeps the body it has. Expressing it through the new unset would change what it compiles to and buy nothing: this change adds the two ways in that were missing, it does not rebuild the ones already there.

### What this changes

* **Generated code: nothing.** Each macro expands to the expression its call sites spelled out, so only parentheses move. `gcc -S -O3` with the full-core defines over the six sources that change gives assembly identical to the assembly before this change, byte for byte.
* **Public header: two lines.** `lib/mruby/amalgam.rb` inlines `include/mruby/string.h` whole, so the amalgamated header gains them too. Nothing is removed or renamed, so code outside this repository is unaffected.
* **Ruby level behavior: none.** No new test comes with this change, because there is no new answer to pin.

### Testing

* full-core gembox, `MRB_UTF8_STRING` on: 2286 tests, 2276 OK, 10 skip, 0 KO, 0 crash, no new warnings.
* default gembox, where `mruby-encoding` is absent and strings index by byte: 2070 tests, 2042 OK, 28 skip, 0 KO, 0 crash.

### Still left out

Two writes to other string flags still name the bit directly. Neither is a binary flag write, and each wants its own reasoning:

* `mrbgems/mruby-string-ext/src/string.c`, in `str_ascii_only_p()`: `flags |= MRB_STR_SINGLE_BYTE`, where `RSTR_SET_SINGLE_BYTE_FLAG()` exists but compiles to nothing without `MRB_UTF8_STRING`, so swapping it in is a behavior question, not a spelling one.
* `mrbgems/mruby-sprintf/src/sprintf.c`, around line 624: `RSTR_SET_EMBED_LEN()` written out by hand, next to a branch that sets the heap length to a different value. Folding the pair into `RSTR_SET_LEN()` is not a rename.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency when handling binary strings across string, encoding, regular expression, formatting, and bit-operation features.
  * Preserved binary-string behavior during concatenation, replacement, appending, substitution, conversion, and byte manipulation.
* **Refactor**
  * Standardized internal handling of binary-string status for more reliable behavior across supported operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->