### PR TITLE
test: seed the group a backward search miss has to clear

### DIFF
--- a/mrbgems/mruby-regexp/test/string_index.rb
+++ b/mrbgems/mruby-regexp/test/string_index.rb
@@ -607,13 +607,17 @@ assert("a backward search publishes every global of the match it settled on") do
   assert_nil $2
   assert_equal "b", $+
 
-  # and a search that finds nothing clears all of them, not `$~` alone
-  "zzz" =~ /(z)/
+  # and a search that finds nothing clears all of them, not `$~` alone.  Two
+  # groups are seeded so that a `$2` left standing is one the clear missed
+  # rather than one no seed ever filled
+  "zzz" =~ /(z)(z)/
   assert_nil "abc".rindex(/x/)
+  assert_nil $~
   assert_nil $&
   assert_nil $`
   assert_nil $'
   assert_nil $1
+  assert_nil $2
   assert_nil $+
 end
 


### PR DESCRIPTION
Follow-up to #7149, on a review comment it left behind.

#7149 added a test that asks what a backward search leaves in the match globals, ending with the miss: a search that finds nothing clears all of them, not `$~` alone. The block seeded one group and read six names back, and two of the seven it means to cover were not covered.

`$~` is the one the comment names, and no assertion asked for it. `$2` was nil before the call, because `"zzz" =~ /(z)/` never filled it, so `assert_nil $2` would have passed on a clear that missed it just as well as on one that did not. Seeding `/(z)(z)/` is what makes the assertion stand for the clear.

```ruby
"zzz" =~ /(z)(z)/
"abc".rindex(/x/)   #=> nil
$~                  #=> nil
$2                  #=> nil, and it was "z" before the call
```

Every answer is CRuby's.

### Verification

Dropping the clear from `__regexp_rsearch`, which is the mistake the block is there to catch, turns 7 of its assertions red where it turned 5 before, `$~` and `$2` among them.

Full suite green on `build_config/ci/gcc-clang.rb`: full-core with `MRB_GC_STRESS` (2286), bintest (2286), the C++ ABI (2285), and the default gembox (2070). 0 failures, 0 crashes, no new compiler warnings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved regular-expression backward-search behavior by ensuring all match results are cleared after an unsuccessful search.
  * Added coverage for multiple capture groups to prevent stale match data from being retained.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->