### PR TITLE
mruby-regexp: refuse a byte search offset inside a character

### DIFF
--- a/include/mruby/internal.h
+++ b/include/mruby/internal.h
@@ -189,6 +189,12 @@ mrb_int mrb_str_byte_to_char(mrb_state *mrb, mrb_value str, mrb_int bi);
    definition in string.c for what it reads and what it leaves behind. */
 mrb_bool mrb_str_valid_encoding_p(mrb_state *mrb, mrb_value str);
 
+/* Raise IndexError when `pos` lands inside a character of `str`, and return
+   otherwise. See the definition in string.c for which offsets are positions
+   the string has; a build without MRB_UTF8_STRING has one per byte, so this
+   is a no-op there. */
+void mrb_str_check_byte_pos(mrb_state *mrb, mrb_value str, mrb_int pos);
+
 /* Write the UTF-8 spelling of a codepoint into a buffer of at least four
    bytes, and return how many it took (1-4), or 0 for a value that spells no
    character. What counts as one, and why a surrogate does spell one here

--- a/mrbgems/mruby-regexp/mrblib/string_regexp.rb
+++ b/mrbgems/mruby-regexp/mrblib/string_regexp.rb
@@ -637,11 +637,13 @@ class String
     end
     # `__byte_search` takes the position as given and does not range check
     # it, where `Regexp.__search` answers nil for one outside the subject.
-    # Both ends are a miss here, as they are for `mrb_str_byteindex_m()`.  An
-    # offset that lands inside a character is not an error: the C method does
-    # not check for one either, and on a build without MRB_UTF8_STRING there
-    # is nothing to check.
+    # Both ends are a miss here, as they are for `mrb_str_byteindex_m()`.
     return Regexp.__search(args[0], nil) if pos < 0 || pos > len
+    # An offset that lands inside a character names no position the subject
+    # has, and the C method refuses one.  It is asked after the range test,
+    # where the C method asks it too, so an offset outside the subject stays a
+    # miss rather than becoming an error.
+    Regexp.__check_byte_pos(self, pos)
     md = Regexp.__byte_search(args[0], self, pos)
     md && md.__byte_begin(0)
   end
@@ -664,6 +666,9 @@ class String
         pos = len
       end
     end
+    # As in `byteindex` above, and after the same clamp: a position past the
+    # end of the subject has already been read as its end, which is a boundary.
+    Regexp.__check_byte_pos(self, pos)
     md = __regexp_rsearch(args[0], pos)
     md && md.__byte_begin(0)
   end

--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -284,6 +284,25 @@ regexp_check_encoding(mrb_state *mrb, mrb_value self)
   return mrb_nil_value();
 }
 
+/*
+ * Regexp.__check_byte_pos(str, pos)
+ *
+ * Internal: `mrb_str_check_byte_pos()`, for the byte searches this gem takes
+ * over. `String#byteindex` and `String#byterindex` reach the C methods that
+ * ask this for every argument form but a Regexp, and the answer a search gives
+ * may not turn on which of the two it was reached through.
+ */
+static mrb_value
+regexp_check_byte_pos(mrb_state *mrb, mrb_value self)
+{
+  (void)self;
+  mrb_value str;
+  mrb_int pos;
+  mrb_get_args(mrb, "Si", &str, &pos);
+  mrb_str_check_byte_pos(mrb, str, pos);
+  return mrb_nil_value();
+}
+
 /* Publish `obj` and the thirteen names derived from its offsets, the
    counterpart of clear_match_globals(). Kept apart from create_matchdata() so
    that an existing MatchData can be republished without rebuilding it. */
@@ -1449,6 +1468,7 @@ mrb_mruby_regexp_gem_init(mrb_state *mrb)
   mrb_define_class_method(mrb, re, "__binary_string?", regexp_binary_string_p, MRB_ARGS_REQ(1));
   mrb_define_class_method(mrb, re, "__check_encoding", regexp_check_encoding, MRB_ARGS_REQ(1));
   mrb_define_class_method(mrb, re, "__check_pattern", regexp_check_pattern, MRB_ARGS_REQ(1));
+  mrb_define_class_method(mrb, re, "__check_byte_pos", regexp_check_byte_pos, MRB_ARGS_REQ(2));
   mrb_define_class_method(mrb, re, "__search", regexp_s_search, MRB_ARGS_ARG(2, 2));
   mrb_define_class_method(mrb, re, "__byte_search", regexp_s_byte_search, MRB_ARGS_ARG(2, 3));
   mrb_define_class_method(mrb, re, "__search_p", regexp_s_search_p, MRB_ARGS_ARG(2, 1));

--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -299,6 +299,13 @@ regexp_check_byte_pos(mrb_state *mrb, mrb_value self)
   mrb_value str;
   mrb_int pos;
   mrb_get_args(mrb, "Si", &str, &pos);
+  /* The mrblib callers read the position against the byte length and answer
+     both ends themselves before asking this, so one outside the subject
+     reaches here only from a direct call. There is no boundary to ask about
+     at a position the subject does not have, and mrb_str_check_byte_pos()
+     would read behind RSTRING_PTR(str) looking for one. A backstop, as
+     check_regexp_arg() below is for a pattern. */
+  if (pos < 0 || pos > RSTRING_LEN(str)) return mrb_nil_value();
   mrb_str_check_byte_pos(mrb, str, pos);
   return mrb_nil_value();
 }

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -179,6 +179,28 @@ assert("Regexp.escape") do
   assert_true Regexp.new(Regexp.escape("a # b"), Regexp::EXTENDED).match?("a # b")
 end
 
+assert("Regexp.__check_byte_pos passes a position the subject does not have") do
+  # `String#byteindex` and `String#byterindex` read the position against the
+  # byte length and answer both ends themselves before asking this, so one
+  # outside the subject arrives only from a direct call. A position the subject
+  # does not have sits on no boundary, and looking for one would read behind
+  # the subject.
+  s = "あいう"
+  assert_nil Regexp.__check_byte_pos(s, -1)
+  assert_nil Regexp.__check_byte_pos(s, -1000000)
+  assert_nil Regexp.__check_byte_pos(s, s.bytesize + 1)
+  assert_nil Regexp.__check_byte_pos(s, 1000000)
+
+  # the ones it does have are still asked
+  assert_nil Regexp.__check_byte_pos(s, 0)
+  assert_nil Regexp.__check_byte_pos(s, s.bytesize)
+  if __ENCODING__ == "UTF-8"
+    assert_raise(IndexError) { Regexp.__check_byte_pos(s, 1) }
+  else
+    assert_nil Regexp.__check_byte_pos(s, 1)
+  end
+end
+
 assert("Regexp#inspect") do
   re = Regexp.new("abc", Regexp::IGNORECASE)
   assert_equal "/abc/i", re.inspect

--- a/mrbgems/mruby-regexp/test/string_index.rb
+++ b/mrbgems/mruby-regexp/test/string_index.rb
@@ -474,6 +474,58 @@ assert("String#byteindex and String#byterindex with regexp") do
   end
 end
 
+assert("String#byteindex and String#byterindex take an offset inside a character") do
+  # A byte offset that lands inside a character names no position the string
+  # has, and `mrb_str_byteindex_m()` refuses one rather than search from the
+  # middle of a character.  This gem takes both methods over for a Regexp and
+  # asks nothing about the offset it is handed, so the two forms of the same
+  # search part company here.  CRuby raises for both.
+  skip unless __ENCODING__ == "UTF-8"
+  str = "あいうあいう"    # 6 characters, 18 bytes
+
+  assert_raise(IndexError) { str.byteindex("い", 1) }
+  assert_raise(IndexError) { str.byterindex("い", 1) }
+  assert_equal 3, str.byteindex(/い/, 1)
+  assert_nil str.byterindex(/い/, 1)
+
+  # a negative offset is read against the byte length first, so where it lands
+  # is the question asked of it too
+  assert_raise(IndexError) { "あ".byteindex("x", -1) }
+  assert_raise(IndexError) { "あ".byterindex("x", -1) }
+  assert_nil "あ".byteindex(/x/, -1)
+  assert_nil "あ".byterindex(/x/, -1)
+
+  # an offset on a boundary is a position either way, and the two forms agree
+  assert_equal 3, str.byteindex("い", 3)
+  assert_equal 3, str.byteindex(/い/, 3)
+  assert_equal 3, str.byterindex("い", 3)
+  assert_equal 3, str.byterindex(/い/, 3)
+
+  # so is every offset of a string that indexes by byte, whatever its bytes
+  # spell, and both forms take one
+  bin = "あ".b
+  assert_nil bin.byteindex("x", 1)
+  assert_nil bin.byteindex(/x/, 1)
+  assert_nil bin.byterindex("x", 1)
+  assert_nil bin.byterindex(/x/, 1)
+
+  # an offset before the string is a miss before it is a position, for either
+  # form.  The pattern is one the subject holds, so that a nil is the offset
+  # being answered rather than the search coming up empty on its own.
+  assert_nil "あ".byteindex("あ", -9)
+  assert_nil "あ".byteindex(/あ/, -9)
+  assert_nil "あ".byterindex("あ", -9)
+  assert_nil "あ".byterindex(/あ/, -9)
+
+  # past the far end the two methods part company, as they do for a String:
+  # `byteindex` misses, and `byterindex` reads the offset as the end it already
+  # searches back from
+  assert_nil "あ".byteindex("あ", 9)
+  assert_nil "あ".byteindex(/あ/, 9)
+  assert_equal 0, "あ".byterindex("あ", 9)
+  assert_equal 0, "あ".byterindex(/あ/, 9)
+end
+
 assert("String#byteindex and String#byterindex with regexp set the match globals") do
   assert_equal 1, "abc".byteindex(/(b)/)
   assert_equal "b", $1

--- a/mrbgems/mruby-regexp/test/string_index.rb
+++ b/mrbgems/mruby-regexp/test/string_index.rb
@@ -476,24 +476,22 @@ end
 
 assert("String#byteindex and String#byterindex take an offset inside a character") do
   # A byte offset that lands inside a character names no position the string
-  # has, and `mrb_str_byteindex_m()` refuses one rather than search from the
-  # middle of a character.  This gem takes both methods over for a Regexp and
-  # asks nothing about the offset it is handed, so the two forms of the same
-  # search part company here.  CRuby raises for both.
+  # has, and a byte search refuses one rather than search from the middle of a
+  # character, whichever form of it the search was reached through.
   skip unless __ENCODING__ == "UTF-8"
   str = "あいうあいう"    # 6 characters, 18 bytes
 
   assert_raise(IndexError) { str.byteindex("い", 1) }
   assert_raise(IndexError) { str.byterindex("い", 1) }
-  assert_equal 3, str.byteindex(/い/, 1)
-  assert_nil str.byterindex(/い/, 1)
+  assert_raise(IndexError) { str.byteindex(/い/, 1) }
+  assert_raise(IndexError) { str.byterindex(/い/, 1) }
 
   # a negative offset is read against the byte length first, so where it lands
   # is the question asked of it too
   assert_raise(IndexError) { "あ".byteindex("x", -1) }
   assert_raise(IndexError) { "あ".byterindex("x", -1) }
-  assert_nil "あ".byteindex(/x/, -1)
-  assert_nil "あ".byterindex(/x/, -1)
+  assert_raise(IndexError) { "あ".byteindex(/x/, -1) }
+  assert_raise(IndexError) { "あ".byterindex(/x/, -1) }
 
   # an offset on a boundary is a position either way, and the two forms agree
   assert_equal 3, str.byteindex("い", 3)

--- a/src/string.c
+++ b/src/string.c
@@ -2451,8 +2451,8 @@ mrb_str_include(mrb_state *mrb, mrb_value self)
    one. A byte-indexed string has a position per byte, so every offset is one.
    The boundaries are the ones String#length counts over, which is why a byte
    no lead byte reaches is one of them. */
-static void
-str_check_byte_pos(mrb_state *mrb, mrb_value str, mrb_int pos)
+void
+mrb_str_check_byte_pos(mrb_state *mrb, mrb_value str, mrb_int pos)
 {
 #ifdef MRB_UTF8_STRING
   struct RString *s = mrb_str_ptr(str);
@@ -2482,7 +2482,7 @@ mrb_str_byteindex_m(mrb_state *mrb, mrb_value str)
     }
   }
   if (pos > RSTRING_LEN(str)) return mrb_nil_value();
-  str_check_byte_pos(mrb, str, pos);
+  mrb_str_check_byte_pos(mrb, str, pos);
   /* see str_index_str() */
   if (!mrb_str_valid_encoding_p(mrb, sub)) return mrb_nil_value();
   pos = str_index_str(mrb, str, sub, pos);
@@ -2780,7 +2780,7 @@ mrb_str_byterindex_m(mrb_state *mrb, mrb_value str)
     }
     if (pos > len) pos = len;
   }
-  str_check_byte_pos(mrb, str, pos);
+  mrb_str_check_byte_pos(mrb, str, pos);
   /* see str_index_str() */
   if (!mrb_str_valid_encoding_p(mrb, sub)) return mrb_nil_value();
   pos = str_byterindex(str, sub, pos);


### PR DESCRIPTION
Follow-up to #7148, out of a review comment on it.

ecd891b46 gave `String#byteindex` and `String#byterindex` a check: a byte offset that lands inside a character names no position the string has, so a byte search refuses it rather than start from the middle of one. This gem takes both methods over for a Regexp argument, and that path asks nothing about the offset it is handed, so the same search answers one way for a String and another for a Regexp:

```ruby
"あいうあいう".byteindex("い", 1)    # IndexError
"あいうあいう".byteindex(/い/, 1)    #=> 3, searched from inside the first character
"あいうあいう".byterindex("い", 1)   # IndexError
"あいうあいう".byterindex(/い/, 1)   #=> nil
```

CRuby raises for all four.

### Where the question is asked

At the point the C methods ask it: after the offset has been read against the byte length and the ends have been answered, and of the offset the search will start from rather than the one the caller wrote. So an offset outside the subject stays a miss rather than becoming an error, at either end, and `byterindex` refuses over the position its clamp left, which for a position past the end is the end of the subject and a boundary.

`str_check_byte_pos()` becomes `mrb_str_check_byte_pos()` and moves into `mruby/internal.h`, so both paths refuse over one rule rather than two spellings of it. A binary receiver has a position per byte and is refused nothing, which is the core function's own first answer and comes along with it. The gem reaches it through `Regexp.__check_byte_pos`, beside `Regexp.__check_encoding` and `Regexp.__check_pattern`.

The walk is not asked. `__regexp_rsearch` resumes one byte past a match start, and `String#scan` one byte past a zero-width match; both are offsets inside a character on purpose, and the engine steps over one on its own.

### Tests

The first commit records where the two forms stand before anything moves, and where they already agree: an offset on a boundary, every offset of a string that indexes by byte, and an offset outside the string at either end. The second flips the four answers that were the gem's own.

Beyond the suite, a differential over 6 subjects (ASCII, multibyte, mixed, 4 byte characters, binary, empty) by 6 patterns (literal, any, ASCII literal, groups, zero-width, no match) at every offset from past one end to past the other, comparing the answer or the exception of `byteindex` and `byterindex` in both forms: 756 cases, of which 741 answer as CRuby does. The 15 that do not are a binary receiver searched for a pattern spelled in UTF-8, where CRuby raises `Encoding::CompatibilityError` and mruby reads the bytes; the two forms agree with each other there, and did before this.

### Verification

Full suite green at every commit on `build_config/ci/gcc-clang.rb`: full-core with `MRB_GC_STRESS` (2287), bintest (2287), the C++ ABI (2286), and the default gembox, where the new test skips (2071). 0 failures, 0 crashes, no new compiler warnings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved `String#byteindex` and `String#byterindex` handling for UTF-8 strings.
  - Positions inside a multibyte character now raise `IndexError`.
  - Valid character-boundary offsets continue to return correct byte positions.
  - Binary strings continue to accept byte-based offsets.
  - Out-of-range offsets consistently return `nil` for string and regular expression searches.
- **Tests**
  - Added coverage for UTF-8 boundaries, invalid offsets, binary strings, and out-of-range searches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->