### PR TITLE
mrbgems: let a build take a gem back out of a gembox

### DIFF
--- a/doc/guides/compile.md
+++ b/doc/guides/compile.md
@@ -300,6 +300,15 @@ is not in the build fails, so a misspelled name does not pass for a build
 that quietly keeps the Gem. `conf.gems.reject!` takes a block instead and
 removes every Gem it matches, returning `nil` when it matches none.
 
+A Gem that another Gem in the build declares as a dependency cannot be
+removed this way: dependency resolution loads it again, and reports
+
+```
+gem 'mruby-string-ext' can't be removed; mruby-regexp depends on it
+```
+
+Removing the Gem that depends on it as well is what makes it go.
+
 There is a `RubyGem` (gem for CRuby) named `mgem` that help you to
 manage `mrbgems`. Try `gem install mgem`. `mgem` can show you the list
 of registered `mrbgems`.

--- a/doc/guides/compile.md
+++ b/doc/guides/compile.md
@@ -285,10 +285,20 @@ conf.gem :core => 'mruby-bin-mirb'
 
 # Integrate GemBox (set of Gems)
 conf.gembox "default"
+
+# ... and take one back out of it
+conf.gems.delete "mruby-socket"
 ```
 
 A GemBox is a set of Gems defined in `mrbgems/default.gembox` for example.
 It's just a set of `mrbgem` configurations.
+
+`conf.gems.delete` removes a Gem the configuration has already added, so a
+build can say "this GemBox, minus one" without restating the box. It has to
+come after the `gembox` line that brought the Gem in, and naming a Gem that
+is not in the build fails, so a misspelled name does not pass for a build
+that quietly keeps the Gem. `conf.gems.reject!` takes a block instead and
+removes every Gem it matches, returning `nil` when it matches none.
 
 There is a `RubyGem` (gem for CRuby) named `mgem` that help you to
 manage `mrbgems`. Try `gem install mgem`. `mgem` can show you the list

--- a/lib/mruby/gem.rb
+++ b/lib/mruby/gem.rb
@@ -422,6 +422,7 @@ module MRuby
 
       def initialize
         @ary = []
+        @removed = []
       end
 
       def each(&b)
@@ -445,10 +446,14 @@ module MRuby
       # Remove the gem named +name+ and return it.  Naming a gem that
       # is not in this build is a typo, not a no-op, so this fails;
       # use +reject!+ when a predicate matching nothing is acceptable.
+      #
+      # A gem another gem declares as a dependency comes back during
+      # dependency resolution; setup_dependencies says so when it does.
       def delete(name)
         gem = self[name]
         fail "Can't remove gem '#{name}'; it is not in this build" unless gem
         @ary.delete(gem)
+        @removed << name
         gem
       end
 
@@ -458,6 +463,7 @@ module MRuby
         gone = @ary.select(&block)
         return nil if gone.empty?
         @ary -= gone
+        @removed.concat(gone.map(&:name))
         self
       end
 
@@ -511,7 +517,7 @@ module MRuby
         default_gems = {}
         each do |g|
           g.dependencies.each do |dep|
-            default_gems[dep[:gem]] ||= default_gem_params(dep)
+            default_gems[dep[:gem]] ||= default_gem_params(dep).merge(:required_by => g.name)
           end
         end
 
@@ -519,12 +525,18 @@ module MRuby
           def_name, def_gem = default_gems.shift
           next if gem_table[def_name]
 
+          # The build config asked for this one to go, but a gem that
+          # stayed cannot be built without it.  Say so rather than
+          # letting the removal look like it took.
+          warn "gem '#{def_name}' can't be removed; #{def_gem[:required_by]} depends on it" if
+            @removed.include?(def_name)
+
           spec = gem_table[def_name] = build.gem(def_gem[:default])
           fail "Invalid gem name: #{spec.name} (Expected: #{def_name})" if spec.name != def_name
           spec.setup
 
           spec.dependencies.each do |dep|
-            default_gems[dep[:gem]] ||= default_gem_params(dep)
+            default_gems[dep[:gem]] ||= default_gem_params(dep).merge(:required_by => spec.name)
           end
         end
 

--- a/lib/mruby/gem.rb
+++ b/lib/mruby/gem.rb
@@ -442,6 +442,25 @@ module MRuby
         self
       end
 
+      # Remove the gem named +name+ and return it.  Naming a gem that
+      # is not in this build is a typo, not a no-op, so this fails;
+      # use +reject!+ when a predicate matching nothing is acceptable.
+      def delete(name)
+        gem = self[name]
+        fail "Can't remove gem '#{name}'; it is not in this build" unless gem
+        @ary.delete(gem)
+        gem
+      end
+
+      # Remove every gem for which the block returns true.  Returns
+      # nil when nothing was removed, like Array#reject!.
+      def reject!(&block)
+        gone = @ary.select(&block)
+        return nil if gone.empty?
+        @ary -= gone
+        self
+      end
+
       def empty?
         @ary.empty?
       end


### PR DESCRIPTION
Taking up the invitation at the end of #7142.

`MRuby::Gem::List` has `[]` and `<<` and nothing that removes, so a build config that wants a gembox minus one gem has to restate the box. `full-core.gembox` is a five line glob and can be re-globbed, as you showed; `default.gembox` cannot, and `build_config/i586-pc-msdosdjgpp.rb` pays for it in full:

```ruby
# All provided gems that can be reasonably made to compile:
# default.gembox, minus mruby-socket and replacing mruby-cmath with mruby-cmath-alt
conf.gembox "stdlib"
conf.gembox "stdlib-ext"

conf.gem :core => 'mruby-io'              # stdlib-io.gembox <- default.gembox
# No socket support in DJGPP
# conf.gem :core => 'mruby-socket'        # stdlib-io.gembox <- default.gembox
conf.gem :core => 'mruby-errno'           # stdlib-io.gembox <- default.gembox
...
```

Twelve lines hand-expanding one box, each carrying a comment naming the box the line came from, so that one gem can be left out.

The reach for this is `conf.gems.reject!`, which raises `NoMethodError`. `conf.gems.reject` is worse: it comes from `Enumerable`, builds a new `Array` and drops it, so the removal reads as if it worked and does nothing.

### What is added

`List#delete`, which names the gem, and `List#reject!`, which takes a predicate.

```ruby
conf.gembox 'full-core'
conf.gems.delete 'mruby-encoding'
```

`delete` fails when the name is not in the build rather than returning nil, following `Can't find gembox` and `Invalid gem name` elsewhere in the build system. A misspelled name is a typo, and a build that silently keeps the gem is the failure this method exists to remove. `reject!` keeps `Array` semantics and returns nil when it matches nothing, since a predicate matching nothing is not a mistake.

### Why removing after the fact is sound

The phase boundary this needs already exists. `Specification#initialize` stores the block and runs nothing (`gem.rb:46`); the body, including every `spec.build.defines <<`, runs in `Specification#setup` (`gem.rb:94`); and the Rakefile reaches `gems.setup` only after `load MRUBY_CONFIG` (`Rakefile:19-31`). So a gem removed while the build config is being read contributes nothing at all, not its objects and not its defines.

Measured on `full-core`, evaluating the config and running `gems.setup` with no compilation:

|                              | as is | minus `mruby-encoding` |
| ---------------------------- | ----- | ---------------------- |
| gems                         | 58    | 57                     |
| `MRB_UTF8_STRING`            | yes   | no                     |
| `HAVE_MRUBY_ENCODING_GEM`    | yes   | no                     |
| objs from `mruby-encoding`   | 2     | 0                      |

What stays behind after a removal is `enable_cxx_exception`, which `LoadGems#gem` decides from the gem's sources, and the `@gem_checkouts` entry for a gem fetched from git. No core gem has a `.cpp`, `.cxx` or `.cc` file under `src`, `test` or `tools`, so the first never fires for the gems a gembox carries; the second only shows up if a removed git gem is re-declared at another revision.

I did look at moving the `mrbgem.rake` load out of `conf.gem` so that nothing at all happens before the config is read. I am not proposing it. It buys the two residues above, neither of which a core gem can reach, so nothing in the tree could show it working. It also weakens this API rather than strengthening it: the list during config would hold requests, whose only name is the `:core =>` key or a URL basename, and the tree already treats that name and `spec.name` as separable, since `gem.rb:504` fails when they disagree. Removal by `spec.name` is exact today.

### The one thing removal cannot do

A gem that another gem in the build declares as a dependency comes back. Dependencies are declared in `Specification#setup`, a phase after `delete` runs, so `delete` cannot check against them, and `setup_dependencies` loads the gem again. `conf.gems.delete 'mruby-string-ext'` on `full-core` ends with the same 58 gems it started with.

Keeping it is right, since `mruby-regexp` cannot be built without it. Staying quiet is not, so the second commit records what was removed and says so when it comes back:

```
gem 'mruby-string-ext' can't be removed; mruby-regexp depends on it
```

23 gems in a `full-core` build with tests enabled are reachable this way, 17 without, the difference being `add_test_dependency`, which is `add_dependency` under `test_enabled? || bintest_enabled?`. `mruby-encoding` is in the larger list and is still removable, because `mruby-regexp` and `mruby-sprintf` guard that dependency on the gem being present and the guard is read after the removal.

Split into its own commit in case you would rather this said nothing, or failed instead. Failing reads well until you see where it lands: the config line that removed the gem is long gone by `gems.setup`, so the message would arrive without it.

### Not included

`build_config/i586-pc-msdosdjgpp.rb` could now say `conf.gembox "default"` and one `delete`, which is what its comment already claims it does. Its hand expansion is not equivalent to `default.gembox` though: besides `mruby-socket`, it is missing `mruby-env`, which `stdlib-io.gembox` carries and the comment does not mention. That looks like an expansion that was not kept up rather than a decision, but DJGPP is not built in CI and I cannot test it, so I left the file alone.

### Tests

There is no test suite for the build system, so the verification is builds. `MRUBY_CONFIG=ci/gcc-clang rake -m test` is green at every commit, 2281 / 2281 / 2280 tests and 116 bintests, KO 0.

Beyond that: `full-core` minus `mruby-encoding` builds and answers as a byte indexed build should, `"あ".length` is 3 and `Encoding` is undefined; a misspelled name fails at the build config line that wrote it; `reject!` returns self when it removes and nil when it does not.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for removing gems from a GemBox by name or condition.
  - Gem removal now reports errors when the specified gem is missing or required by another gem.
  - Removed dependencies may be automatically restored when required during dependency resolution.

- **Documentation**
  - Expanded gem compilation guidance with removal examples, behavior details, ordering requirements, and dependency-related errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->