### PR TITLE
ci: read the byte-indexed side on full-core minus mruby-encoding

### DIFF
--- a/build_config/ci/gcc-clang.rb
+++ b/build_config/ci/gcc-clang.rb
@@ -50,17 +50,20 @@ MRuby::Build.new('cxx_abi') do |conf|
   conf.enable_cxx_abi
 end
 
-MRuby::Build.new('default') do |conf|
+MRuby::Build.new('byte-string') do |conf|
   conf.toolchain
 
-  # The one build here on the default gembox. It leaves out mruby-encoding,
-  # which is what defines MRB_UTF8_STRING, so its strings index by byte. The
-  # tests written as the byte-indexed mirror of the UTF-8 ones (String#scrub
+  # The one build here whose strings index by byte. mruby-encoding is what
+  # defines MRB_UTF8_STRING, so dropping it is what makes "あ".length 3, and
+  # the tests written as the byte-indexed mirror of the UTF-8 ones (String#scrub
   # degrading to a no-op, the byte-counting halves of mruby-regexp and
   # mruby-string-ext) run nowhere else: every other build in CI, here and in
-  # ci/msvc, takes full-core. Tests only, since the binaries this gembox adds
-  # are the same ones the bintest above already covers.
-  conf.gembox 'default'
+  # ci/msvc, keeps the gem. Taking it out of full-core rather than reaching for
+  # a smaller gembox keeps the rest of the box on the byte-indexed side too.
+  # Tests only, since the binaries full-core adds are the same ones the bintest
+  # above already covers.
+  conf.gembox 'full-core'
+  conf.gems.delete 'mruby-encoding'
 
   conf.enable_test
 end

--- a/doc/guides/compile.md
+++ b/doc/guides/compile.md
@@ -300,6 +300,15 @@ is not in the build fails, so a misspelled name does not pass for a build
 that quietly keeps the Gem. `conf.gems.reject!` takes a block instead and
 removes every Gem it matches, returning `nil` when it matches none.
 
+A Gem that another Gem in the build declares as a dependency cannot be
+removed this way: dependency resolution loads it again, and reports
+
+```
+gem 'mruby-string-ext' can't be removed; mruby-regexp depends on it
+```
+
+Removing the Gem that depends on it as well is what makes it go.
+
 There is a `RubyGem` (gem for CRuby) named `mgem` that help you to
 manage `mrbgems`. Try `gem install mgem`. `mgem` can show you the list
 of registered `mrbgems`.

--- a/doc/guides/compile.md
+++ b/doc/guides/compile.md
@@ -285,10 +285,20 @@ conf.gem :core => 'mruby-bin-mirb'
 
 # Integrate GemBox (set of Gems)
 conf.gembox "default"
+
+# ... and take one back out of it
+conf.gems.delete "mruby-socket"
 ```
 
 A GemBox is a set of Gems defined in `mrbgems/default.gembox` for example.
 It's just a set of `mrbgem` configurations.
+
+`conf.gems.delete` removes a Gem the configuration has already added, so a
+build can say "this GemBox, minus one" without restating the box. It has to
+come after the `gembox` line that brought the Gem in, and naming a Gem that
+is not in the build fails, so a misspelled name does not pass for a build
+that quietly keeps the Gem. `conf.gems.reject!` takes a block instead and
+removes every Gem it matches, returning `nil` when it matches none.
 
 There is a `RubyGem` (gem for CRuby) named `mgem` that help you to
 manage `mrbgems`. Try `gem install mgem`. `mgem` can show you the list

--- a/lib/mruby/gem.rb
+++ b/lib/mruby/gem.rb
@@ -422,6 +422,7 @@ module MRuby
 
       def initialize
         @ary = []
+        @removed = []
       end
 
       def each(&b)
@@ -445,10 +446,14 @@ module MRuby
       # Remove the gem named +name+ and return it.  Naming a gem that
       # is not in this build is a typo, not a no-op, so this fails;
       # use +reject!+ when a predicate matching nothing is acceptable.
+      #
+      # A gem another gem declares as a dependency comes back during
+      # dependency resolution; setup_dependencies says so when it does.
       def delete(name)
         gem = self[name]
         fail "Can't remove gem '#{name}'; it is not in this build" unless gem
         @ary.delete(gem)
+        @removed << name
         gem
       end
 
@@ -458,6 +463,7 @@ module MRuby
         gone = @ary.select(&block)
         return nil if gone.empty?
         @ary -= gone
+        @removed.concat(gone.map(&:name))
         self
       end
 
@@ -511,7 +517,7 @@ module MRuby
         default_gems = {}
         each do |g|
           g.dependencies.each do |dep|
-            default_gems[dep[:gem]] ||= default_gem_params(dep)
+            default_gems[dep[:gem]] ||= default_gem_params(dep).merge(:required_by => g.name)
           end
         end
 
@@ -519,12 +525,18 @@ module MRuby
           def_name, def_gem = default_gems.shift
           next if gem_table[def_name]
 
+          # The build config asked for this one to go, but a gem that
+          # stayed cannot be built without it.  Say so rather than
+          # letting the removal look like it took.
+          warn "gem '#{def_name}' can't be removed; #{def_gem[:required_by]} depends on it" if
+            @removed.include?(def_name)
+
           spec = gem_table[def_name] = build.gem(def_gem[:default])
           fail "Invalid gem name: #{spec.name} (Expected: #{def_name})" if spec.name != def_name
           spec.setup
 
           spec.dependencies.each do |dep|
-            default_gems[dep[:gem]] ||= default_gem_params(dep)
+            default_gems[dep[:gem]] ||= default_gem_params(dep).merge(:required_by => spec.name)
           end
         end
 

--- a/lib/mruby/gem.rb
+++ b/lib/mruby/gem.rb
@@ -442,6 +442,25 @@ module MRuby
         self
       end
 
+      # Remove the gem named +name+ and return it.  Naming a gem that
+      # is not in this build is a typo, not a no-op, so this fails;
+      # use +reject!+ when a predicate matching nothing is acceptable.
+      def delete(name)
+        gem = self[name]
+        fail "Can't remove gem '#{name}'; it is not in this build" unless gem
+        @ary.delete(gem)
+        gem
+      end
+
+      # Remove every gem for which the block returns true.  Returns
+      # nil when nothing was removed, like Array#reject!.
+      def reject!(&block)
+        gone = @ary.select(&block)
+        return nil if gone.empty?
+        @ary -= gone
+        self
+      end
+
       def empty?
         @ary.empty?
       end


### PR DESCRIPTION
Stacked on #7154, whose two commits this branch carries. Only the last commit is new here.

The fourth build in `ci/gcc-clang` exists so that the tests written as the byte indexed mirror of the UTF-8 ones run somewhere: `String#scrub` degrading to a no-op, the byte counting halves of `mruby-regexp` and `mruby-string-ext`. It reached that by taking the default gembox, which is the smaller box that happens not to carry `mruby-encoding`. What it wants is the gem gone, not a smaller box, and with #7154 it can say so.

```ruby
conf.gembox 'full-core'
conf.gems.delete 'mruby-encoding'
```

This is the configuration you built in #7142 when you showed that a byte indexed full-core build is available today. It answers the same way:

```console
$ build/byte-string/bin/mruby -e 'p "あ".length, "あ"[0], defined?(Encoding), defined?(Struct), defined?(Rational), defined?(Regexp)'
3
"\xe3"
nil
"constant"
"constant"
"constant"
```

### What it changes

|              | default gembox | full-core minus `mruby-encoding` |
| ------------ | -------------- | -------------------------------- |
| Total        | 2066           | 2220                             |
| Skip         | 26             | 26                               |
| KO           | 0              | 0                                |

154 more tests at the same skip count. Nine gems come under byte indexed test that were not: `mruby-benchmark`, `mruby-bin-mrb`, `mruby-cmath`, `mruby-exit`, `mruby-os-memsize`, `mruby-strftime`, `mruby-string-bitops`, `mruby-task`, `mruby-test-inline-struct`. The one gem the default gembox had and `full-core` does not is `mruby-bin-debugger`, which the `bintest` build in this file already adds by name, so no gem loses a build.

The build is renamed `byte-string` after what it reads, since it is no longer the default gembox.

### What it costs

No CI build loads `mrbgems/default.gembox` after this. The five boxes it nests are still loaded, by the Cosmopolitan job, which names `stdlib`, `stdlib-ext`, `stdlib-io`, `math` and `metaprog` directly; what loses coverage is the six lines of the wrapper.

#7138 added this build for the byte indexed tests rather than for the gembox, and before it no CI build read `default.gembox` either, so this is a return to that rather than a new gap. Still, it is a real one, and if you would rather keep a build on the box I can add it back as a fifth rather than trade it.

### Tests

`MRUBY_CONFIG=ci/gcc-clang rake -m test`, all four builds and the bintests, KO 0:

```
byte-string   Total 2220   Skip 26
full-debug    Total 2280   Skip 2
bintest       Total 2281   Skip 10   + 116 bintests
cxx_abi       Total 2281   Skip 10
```

No `can't be removed` warning is printed. `mruby-regexp` and `mruby-sprintf` declare `mruby-encoding` as a test dependency only when it is present, and that guard is read after the removal.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added gem list management options to remove specific gems or filter gems by criteria.
  * Dependency resolution now warns when a removed gem must be restored to satisfy another gem.
* **Documentation**
  * Expanded GemBox configuration guidance, including gem removal syntax, ordering, error handling, filtering behavior, and dependency limitations.
* **Build Improvements**
  * Updated the default test configuration to validate byte-oriented string behavior using the full core configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->