### PR TITLE
string.c: keep one answer about a string's bytes, not three flags

### DIFF
--- a/include/mruby/string.h
+++ b/include/mruby/string.h
@@ -85,46 +85,41 @@ struct RStringEmbed {
 #define RSTR_FSHARED_P(s) ((s)->flags & MRB_STR_FSHARED)
 #define RSTR_NOFREE_P(s) ((s)->flags & MRB_STR_NOFREE)
 
+/* What reading the bytes as the encoding they carry has come back with: not
+   asked yet, nothing but ASCII, read whole and sound, or read and found
+   broken. The four are exclusive and cover every answer there is, so a string
+   keeps one of them rather than a flag per answer. UNKNOWN is 0, which is what
+   a fresh string is already filled with. */
+#define MRB_STR_CODERANGE_UNKNOWN 0
+#define MRB_STR_CODERANGE_7BIT    1
+#define MRB_STR_CODERANGE_VALID   2
+#define MRB_STR_CODERANGE_BROKEN  3
+
 #ifdef MRB_UTF8_STRING
-# define RSTR_SINGLE_BYTE_P(s) ((s)->flags & MRB_STR_SINGLE_BYTE)
-# define RSTR_SET_SINGLE_BYTE_FLAG(s) ((s)->flags |= MRB_STR_SINGLE_BYTE)
-# define RSTR_UNSET_SINGLE_BYTE_FLAG(s) ((s)->flags &= ~MRB_STR_SINGLE_BYTE)
-# define RSTR_WRITE_SINGLE_BYTE_FLAG(s, v) (RSTR_UNSET_SINGLE_BYTE_FLAG(s), (s)->flags |= v)
-# define RSTR_COPY_SINGLE_BYTE_FLAG(dst, src) RSTR_WRITE_SINGLE_BYTE_FLAG(dst, RSTR_SINGLE_BYTE_P(src))
-/* Set once a walk has read the whole string as UTF-8, so a later walk can be
-   skipped. Unlike MRB_STR_SINGLE_BYTE this is not a property a byte subrange
-   inherits, since a subrange can cut a character in half; copy it only where
-   the destination ends up holding exactly the source's bytes. */
-# define RSTR_VALID_ENC_P(s) ((s)->flags & MRB_STR_VALID_ENC)
-# define RSTR_SET_VALID_ENC_FLAG(s) ((s)->flags |= MRB_STR_VALID_ENC)
-# define RSTR_UNSET_VALID_ENC_FLAG(s) ((s)->flags &= ~MRB_STR_VALID_ENC)
-# define RSTR_COPY_VALID_ENC_FLAG(dst, src) \
-  ((dst)->flags = ((dst)->flags & ~MRB_STR_VALID_ENC) | RSTR_VALID_ENC_P(src))
-/* The other answer the same walk can come back with, kept so that a string
-   already read as broken is not read again on every later question. It is
-   forgotten wherever MRB_STR_VALID_ENC is, since a write to the bytes unmakes
-   either answer, and it travels only where the whole of the bytes travels. */
-# define RSTR_BROKEN_ENC_P(s) ((s)->flags & MRB_STR_BROKEN_ENC)
-# define RSTR_SET_BROKEN_ENC_FLAG(s) ((s)->flags |= MRB_STR_BROKEN_ENC)
-# define RSTR_UNSET_BROKEN_ENC_FLAG(s) ((s)->flags &= ~MRB_STR_BROKEN_ENC)
-# define RSTR_COPY_BROKEN_ENC_FLAG(dst, src) \
-  ((dst)->flags = ((dst)->flags & ~MRB_STR_BROKEN_ENC) | RSTR_BROKEN_ENC_P(src))
+/* Kept for now in the three bits that held the answers one at a time, one bit
+   per answer. Nothing writes two of them, so the order below only decides what
+   a combination no writer makes would read as. 7BIT says more than VALID: a
+   string of nothing but ASCII reads as UTF-8 as it stands, and it is also one
+   character per byte, which is the part every index on it wants. */
+# define RSTR_CODERANGE(s) \
+  (((s)->flags & MRB_STR_BROKEN_ENC) ? MRB_STR_CODERANGE_BROKEN : \
+   ((s)->flags & MRB_STR_SINGLE_BYTE) ? MRB_STR_CODERANGE_7BIT : \
+   ((s)->flags & MRB_STR_VALID_ENC) ? MRB_STR_CODERANGE_VALID : \
+   MRB_STR_CODERANGE_UNKNOWN)
+# define RSTR_CODERANGE_SET(s, cr) \
+  ((s)->flags = ((s)->flags & \
+                 ~(MRB_STR_SINGLE_BYTE|MRB_STR_VALID_ENC|MRB_STR_BROKEN_ENC)) | \
+                (((cr) == MRB_STR_CODERANGE_7BIT) ? MRB_STR_SINGLE_BYTE : \
+                 ((cr) == MRB_STR_CODERANGE_VALID) ? MRB_STR_VALID_ENC : \
+                 ((cr) == MRB_STR_CODERANGE_BROKEN) ? MRB_STR_BROKEN_ENC : 0))
 #else
-# define RSTR_SINGLE_BYTE_P(s) TRUE
-# define RSTR_SET_SINGLE_BYTE_FLAG(s) (void)0
-# define RSTR_UNSET_SINGLE_BYTE_FLAG(s) (void)0
-# define RSTR_WRITE_SINGLE_BYTE_FLAG(s, v) (void)0
-# define RSTR_COPY_SINGLE_BYTE_FLAG(dst, src) (void)0
-# define RSTR_VALID_ENC_P(s) TRUE
-# define RSTR_SET_VALID_ENC_FLAG(s) (void)0
-# define RSTR_UNSET_VALID_ENC_FLAG(s) (void)0
-# define RSTR_COPY_VALID_ENC_FLAG(dst, src) (void)0
-# define RSTR_BROKEN_ENC_P(s) FALSE
-# define RSTR_SET_BROKEN_ENC_FLAG(s) (void)0
-# define RSTR_UNSET_BROKEN_ENC_FLAG(s) (void)0
-# define RSTR_COPY_BROKEN_ENC_FLAG(dst, src) (void)0
+/* A build that indexes by byte hands every byte back as a character and asks
+   the bytes nothing, so every string in it stands where 7BIT stands and there
+   is nothing to record. */
+# define RSTR_CODERANGE(s) MRB_STR_CODERANGE_7BIT
+# define RSTR_CODERANGE_SET(s, cr) ((void)0)
 #endif
-#define RSTR_SET_ASCII_FLAG(s) RSTR_SET_SINGLE_BYTE_FLAG(s)
+
 /* The encoding a string's bytes are read as, named as an index into the set of
    encodings the build carries. Index 0 is that build's default, which is what
    a string that says nothing else holds: the literals the parser hands over,
@@ -151,6 +146,22 @@ struct RStringEmbed {
 /* A copy of a string is read the way the string it copies is, so the encoding
    travels with the bytes rather than being left behind on the original. */
 #define RSTR_ENC_COPY(dst, src) RSTR_ENCODING_SET(dst, RSTR_ENCODING(src))
+/* A copy that ends up holding exactly the source's bytes reads them the same
+   way and stands exactly where the source stands, so the two answers travel
+   together. Splitting them apart would let a copy keep one and drop the
+   other, which is the way flags went missing when there was a macro per
+   flag. */
+#define RSTR_ENC_CR_COPY(dst, src) \
+  (RSTR_ENC_COPY(dst, src), RSTR_CODERANGE_SET(dst, RSTR_CODERANGE(src)))
+/* A subrange holds bytes of the source, so it is read the same way, but a cut
+   can leave a character in pieces and can also cut away the piece that spelled
+   none: it inherits neither soundness nor brokenness. Nothing but ASCII is
+   what survives being cut anywhere, so that is the one answer it carries
+   over. */
+#define RSTR_ENC_CR_COPY_FOR_SUBSTR(dst, src) \
+  (RSTR_ENC_COPY(dst, src), \
+   RSTR_CODERANGE_SET(dst, (RSTR_CODERANGE(src) == MRB_STR_CODERANGE_7BIT) \
+                           ? MRB_STR_CODERANGE_7BIT : MRB_STR_CODERANGE_UNKNOWN))
 
 /**
  * Returns a pointer from a Ruby string

--- a/include/mruby/string.h
+++ b/include/mruby/string.h
@@ -125,14 +125,32 @@ struct RStringEmbed {
 # define RSTR_COPY_BROKEN_ENC_FLAG(dst, src) (void)0
 #endif
 #define RSTR_SET_ASCII_FLAG(s) RSTR_SET_SINGLE_BYTE_FLAG(s)
-#define RSTR_BINARY_P(s) ((s)->flags & MRB_STR_BINARY)
-#define RSTR_SET_BINARY_FLAG(s) ((s)->flags |= MRB_STR_BINARY)
-#define RSTR_UNSET_BINARY_FLAG(s) ((s)->flags &= ~MRB_STR_BINARY)
-/* A copy of a string is byte-indexed exactly when the string it copies is, so
-   the flag travels with the bytes rather than being left behind on the
-   original. */
-#define RSTR_COPY_BINARY_FLAG(dst, src) \
-  ((dst)->flags = ((dst)->flags & ~MRB_STR_BINARY) | RSTR_BINARY_P(src))
+/* The encoding a string's bytes are read as, named as an index into the set of
+   encodings the build carries. Index 0 is that build's default, which is what
+   a string that says nothing else holds: the literals the parser hands over,
+   the strings numbers and times spell themselves with. The zero a fresh string
+   is filled with therefore already says the default, and the path every string
+   is made on stores nothing.
+
+   A build without MRB_UTF8_STRING carries no UTF-8, so it names none: writing
+   the name there is a compile error rather than a quiet no-op. Such a build
+   still tells a byte-read string from a default one, since String#b and
+   Integer#chr mark one there too. */
+#define MRB_STR_ENCODING_DEFAULT 0
+#define MRB_STR_ENCODING_BINARY  1
+#ifdef MRB_UTF8_STRING
+# define MRB_STR_ENCODING_UTF8   MRB_STR_ENCODING_DEFAULT
+#endif
+
+#define RSTR_ENCODING(s) \
+  (((s)->flags & MRB_STR_BINARY) ? MRB_STR_ENCODING_BINARY : MRB_STR_ENCODING_DEFAULT)
+#define RSTR_ENCODING_SET(s, e) \
+  ((s)->flags = ((s)->flags & ~MRB_STR_BINARY) | \
+                (((e) == MRB_STR_ENCODING_BINARY) ? MRB_STR_BINARY : 0))
+#define RSTR_BINARY_P(s) (RSTR_ENCODING(s) == MRB_STR_ENCODING_BINARY)
+/* A copy of a string is read the way the string it copies is, so the encoding
+   travels with the bytes rather than being left behind on the original. */
+#define RSTR_ENC_COPY(dst, src) RSTR_ENCODING_SET(dst, RSTR_ENCODING(src))
 
 /**
  * Returns a pointer from a Ruby string

--- a/mrbgems/mruby-encoding/src/encoding.c
+++ b/mrbgems/mruby-encoding/src/encoding.c
@@ -69,10 +69,10 @@ str_force_encoding(mrb_state *mrb, mrb_value self)
   struct RString *s = mrb_str_ptr(self);
   if (MRB_STR_CASECMP_P(enc, ENC_ASCII_8BIT) ||
       MRB_STR_CASECMP_P(enc, ENC_BINARY)) {
-    RSTR_SET_BINARY_FLAG(s);
+    RSTR_ENCODING_SET(s, MRB_STR_ENCODING_BINARY);
   }
   else if (MRB_STR_CASECMP_P(enc, ENC_UTF8)) {
-    RSTR_UNSET_BINARY_FLAG(s);
+    RSTR_ENCODING_SET(s, MRB_STR_ENCODING_UTF8);
   }
   else {
     mrb_raisef(mrb, E_ARGUMENT_ERROR, "unknown encoding name - %v", enc);

--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -1205,7 +1205,7 @@ re_mark_spliced(mrb_value result, mrb_value subject, mrb_value replacement,
     while (p < e && !(*p & 0x80)) p++;
     if (p == e) return;
   }
-  RSTR_SET_BINARY_FLAG(mrb_str_ptr(result));
+  RSTR_ENCODING_SET(mrb_str_ptr(result), MRB_STR_ENCODING_BINARY);
 }
 
 /*

--- a/mrbgems/mruby-sprintf/src/sprintf.c
+++ b/mrbgems/mruby-sprintf/src/sprintf.c
@@ -359,7 +359,7 @@ mark_written_bytes(mrb_value result, mrb_value src)
   const char *p = RSTR_PTR(s);
   const char *e = p + RSTR_LEN(s);
   while (p < e && !(*p & 0x80)) p++;
-  if (p < e) RSTR_SET_BINARY_FLAG(r);
+  if (p < e) RSTR_ENCODING_SET(r, MRB_STR_ENCODING_BINARY);
 }
 
 static mrb_value
@@ -423,7 +423,7 @@ mrb_str_format(mrb_state *mrb, mrb_int argc, const mrb_value *argv, mrb_value fm
      built out of them is read the way the format string was read, ASCII bytes
      and all: the reading a receiver holds, which nothing written into it
      lifts. */
-  RSTR_COPY_BINARY_FLAG(mrb_str_ptr(result), mrb_str_ptr(fmt));
+  RSTR_ENC_COPY(mrb_str_ptr(result), mrb_str_ptr(fmt));
   buf = RSTRING_PTR(result);
   memset(buf, 0, bsiz);
 

--- a/mrbgems/mruby-string-bitops/src/string_bitops.c
+++ b/mrbgems/mruby-string-bitops/src/string_bitops.c
@@ -427,7 +427,7 @@ static mrb_value
 bitop_result_str(mrb_state *mrb, mrb_int len)
 {
   mrb_value result = mrb_str_new(mrb, NULL, len);
-  RSTR_SET_BINARY_FLAG(mrb_str_ptr(result));
+  RSTR_ENCODING_SET(mrb_str_ptr(result), MRB_STR_ENCODING_BINARY);
   return result;
 }
 

--- a/mrbgems/mruby-string-ext/src/string.c
+++ b/mrbgems/mruby-string-ext/src/string.c
@@ -26,7 +26,7 @@ int_chr_binary(mrb_state *mrb, mrb_value num)
      handing the byte back as a character. What it is instead is a string read
      by bytes, which is what MRB_STR_BINARY says. */
   if (cp < 0x80) {
-    RSTR_SET_ASCII_FLAG(mrb_str_ptr(str));
+    RSTR_CODERANGE_SET(mrb_str_ptr(str), MRB_STR_CODERANGE_7BIT);
   }
   else {
     RSTR_ENCODING_SET(mrb_str_ptr(str), MRB_STR_ENCODING_BINARY);
@@ -53,7 +53,7 @@ int_chr_utf8(mrb_state *mrb, mrb_value num)
   }
   str = mrb_str_new(mrb, utf8, len);
   if (len == 1) {
-    RSTR_SET_ASCII_FLAG(mrb_str_ptr(str));
+    RSTR_CODERANGE_SET(mrb_str_ptr(str), MRB_STR_CODERANGE_7BIT);
   }
   return str;
 }
@@ -1033,7 +1033,7 @@ str_ord(mrb_state* mrb, mrb_value str)
   if (p == e) {
     mrb_raise(mrb, E_ARGUMENT_ERROR, "empty string");
   }
-  if (RSTR_SINGLE_BYTE_P(s) || RSTR_BINARY_P(s)) {
+  if (RSTR_CODERANGE(s) == MRB_STR_CODERANGE_7BIT || RSTR_BINARY_P(s)) {
     c = p[0];
   }
   else {
@@ -1123,7 +1123,7 @@ str_scrub_core(mrb_state *mrb, mrb_value self)
   }
 
   struct RString *s = mrb_str_ptr(self);
-  if (RSTR_SINGLE_BYTE_P(s) || RSTR_BINARY_P(s)) {
+  if (RSTR_CODERANGE(s) == MRB_STR_CODERANGE_7BIT || RSTR_BINARY_P(s)) {
     return mrb_str_dup(mrb, self);
   }
 
@@ -1166,7 +1166,7 @@ str_scrub_chunks(mrb_state *mrb, mrb_value self)
 {
   mrb_value ary = mrb_ary_new(mrb);
   struct RString *s = mrb_str_ptr(self);
-  if (RSTR_SINGLE_BYTE_P(s) || RSTR_BINARY_P(s)) {
+  if (RSTR_CODERANGE(s) == MRB_STR_CODERANGE_7BIT || RSTR_BINARY_P(s)) {
     mrb_ary_push(mrb, ary, mrb_str_dup(mrb, self));
     return ary;
   }
@@ -1201,7 +1201,7 @@ str_codepoints(mrb_state *mrb, mrb_value str)
 
   mrb->c->ci->mid = 0;
   mrb_value result = mrb_ary_new(mrb);
-  if (RSTR_SINGLE_BYTE_P(s) || RSTR_BINARY_P(s)) {
+  if (RSTR_CODERANGE(s) == MRB_STR_CODERANGE_7BIT || RSTR_BINARY_P(s)) {
     while (p < e) {
       mrb_ary_push(mrb, result, mrb_int_value(mrb, (mrb_int)*p));
       p++;
@@ -1513,7 +1513,7 @@ str_ascii_only_p(mrb_state *mrb, mrb_value str)
     if (*p & 0x80) return mrb_false_value();
     p++;
   }
-  RSTR_SET_ASCII_FLAG(s);
+  RSTR_CODERANGE_SET(s, MRB_STR_CODERANGE_7BIT);
   return mrb_true_value();
 }
 
@@ -1788,11 +1788,11 @@ str_chars_ary(mrb_state *mrb, mrb_value self)
   const char *p = RSTR_PTR(s);
   const char *e = p + RSTR_LEN(s);
   /* the count comes first: it is the exact capacity, and where every byte is
-     ASCII it also settles the single-byte flag the walk reads */
+     ASCII it also settles at 7BIT the answer the walk reads */
   mrb_value result = mrb_ary_new_capa(mrb, mrb_str_char_len(mrb, self));
 
 #ifdef MRB_UTF8_STRING
-  if (!RSTR_SINGLE_BYTE_P(s) && !RSTR_BINARY_P(s)) {
+  if (RSTR_CODERANGE(s) != MRB_STR_CODERANGE_7BIT && !RSTR_BINARY_P(s)) {
     while (p < e) {
       mrb_int char_len = mrb_utf8len(p, e);
       mrb_ary_push(mrb, result, mrb_str_new(mrb, p, char_len));

--- a/mrbgems/mruby-string-ext/src/string.c
+++ b/mrbgems/mruby-string-ext/src/string.c
@@ -29,7 +29,7 @@ int_chr_binary(mrb_state *mrb, mrb_value num)
     RSTR_SET_ASCII_FLAG(mrb_str_ptr(str));
   }
   else {
-    RSTR_SET_BINARY_FLAG(mrb_str_ptr(str));
+    RSTR_ENCODING_SET(mrb_str_ptr(str), MRB_STR_ENCODING_BINARY);
   }
   return str;
 }
@@ -125,7 +125,7 @@ str_mark_spliced_bytes(mrb_value recv, mrb_value src)
   const char *p = RSTR_PTR(s);
   const char *e = p + RSTR_LEN(s);
   while (p < e && !(*p & 0x80)) p++;
-  if (p < e) RSTR_SET_BINARY_FLAG(r);
+  if (p < e) RSTR_ENCODING_SET(r, MRB_STR_ENCODING_BINARY);
 }
 
 static void
@@ -1459,7 +1459,7 @@ str_lines(mrb_state *mrb, mrb_value self)
     /* a line of a byte-read string is a subrange of its bytes, read the
        same way */
     mrb_value line = mrb_str_new(mrb, t, len);
-    RSTR_COPY_BINARY_FLAG(mrb_str_ptr(line), mrb_str_ptr(self));
+    RSTR_ENC_COPY(mrb_str_ptr(line), mrb_str_ptr(self));
     mrb_ary_push(mrb, result, line);
     mrb_gc_arena_restore(mrb, ai);
   }
@@ -1522,7 +1522,7 @@ static mrb_value
 str_b(mrb_state *mrb, mrb_value self)
 {
   mrb_value str = mrb_str_dup(mrb, self);
-  RSTR_SET_BINARY_FLAG(mrb_str_ptr(str));
+  RSTR_ENCODING_SET(mrb_str_ptr(str), MRB_STR_ENCODING_BINARY);
   return str;
 }
 
@@ -1806,7 +1806,7 @@ str_chars_ary(mrb_state *mrb, mrb_value self)
      way, so the marking goes with each one */
   while (p < e) {
     mrb_value piece = mrb_str_new(mrb, p, 1);
-    RSTR_COPY_BINARY_FLAG(mrb_str_ptr(piece), s);
+    RSTR_ENC_COPY(mrb_str_ptr(piece), s);
     mrb_ary_push(mrb, result, piece);
     p++;
   }
@@ -1914,7 +1914,7 @@ str_rjust_core(mrb_state *mrb, mrb_value self)
   /* the padded string is the receiver's bytes in wider clothes, so it is
      read the way the receiver was, ASCII bytes and all */
   if (RSTR_BINARY_P(mrb_str_ptr(self))) {
-    RSTR_SET_BINARY_FLAG(mrb_str_ptr(result));
+    RSTR_ENCODING_SET(mrb_str_ptr(result), MRB_STR_ENCODING_BINARY);
   }
   return result;
 }
@@ -1988,7 +1988,7 @@ str_center_core(mrb_state *mrb, mrb_value self)
   /* the padded string is the receiver's bytes in wider clothes, so it is
      read the way the receiver was, ASCII bytes and all */
   if (RSTR_BINARY_P(mrb_str_ptr(self))) {
-    RSTR_SET_BINARY_FLAG(mrb_str_ptr(result));
+    RSTR_ENCODING_SET(mrb_str_ptr(result), MRB_STR_ENCODING_BINARY);
   }
   return result;
 }
@@ -2058,7 +2058,7 @@ mrb_str_slice_bang(mrb_state *mrb, mrb_value self)
   /* the piece cut out is a subrange of the receiver's bytes, read the same
      way; copied rather than shared, since the memmove below would slide the
      receiver's remaining bytes through a shared buffer */
-  RSTR_COPY_BINARY_FLAG(mrb_str_ptr(result), str);
+  RSTR_ENC_COPY(mrb_str_ptr(result), str);
 
   mrb_str_modify(mrb, str);
   ptr = RSTRING_PTR(self);
@@ -2093,7 +2093,7 @@ static mrb_value
 str_cut_piece(mrb_state *mrb, mrb_value str, const char *p, mrb_int len)
 {
   mrb_value piece = mrb_str_new(mrb, p, len);
-  RSTR_COPY_BINARY_FLAG(mrb_str_ptr(piece), mrb_str_ptr(str));
+  RSTR_ENC_COPY(mrb_str_ptr(piece), mrb_str_ptr(str));
   return piece;
 }
 

--- a/mrbgems/mruby-time/src/time.c
+++ b/mrbgems/mruby-time/src/time.c
@@ -1489,7 +1489,7 @@ time_to_s(mrb_state *mrb, mrb_value self)
 #endif
   }
   mrb_value str = mrb_str_new(mrb, buf, len);
-  RSTR_SET_ASCII_FLAG(mrb_str_ptr(str));
+  RSTR_CODERANGE_SET(mrb_str_ptr(str), MRB_STR_CODERANGE_7BIT);
   return str;
 }
 

--- a/src/numeric.c
+++ b/src/numeric.c
@@ -475,7 +475,7 @@ flo_to_s(mrb_state *mrb, mrb_value flt)
     str = mrb_float_to_str(mrb, flt, NULL);
   }
 
-  RSTR_SET_ASCII_FLAG(mrb_str_ptr(str));
+  RSTR_CODERANGE_SET(mrb_str_ptr(str), MRB_STR_CODERANGE_7BIT);
   return str;
 }
 
@@ -2038,7 +2038,7 @@ mrb_integer_to_str(mrb_state *mrb, mrb_value x, mrb_int base)
   const char *p = mrb_int_to_cstr(buf, sizeof(buf), val, base);
   mrb_assert(p != NULL);
   mrb_value str = mrb_str_new_cstr(mrb, p);
-  RSTR_SET_ASCII_FLAG(mrb_str_ptr(str));
+  RSTR_CODERANGE_SET(mrb_str_ptr(str), MRB_STR_CODERANGE_7BIT);
   return str;
 }
 

--- a/src/object.c
+++ b/src/object.c
@@ -136,7 +136,7 @@ static mrb_value
 nil_to_s(mrb_state *mrb, mrb_value obj)
 {
   mrb_value str = mrb_str_new_frozen(mrb, NULL, 0);
-  RSTR_SET_ASCII_FLAG(mrb_str_ptr(str));
+  RSTR_CODERANGE_SET(mrb_str_ptr(str), MRB_STR_CODERANGE_7BIT);
   return str;
 }
 
@@ -144,7 +144,7 @@ static mrb_value
 nil_inspect(mrb_state *mrb, mrb_value obj)
 {
   mrb_value str = mrb_str_new_lit_frozen(mrb, "nil");
-  RSTR_SET_ASCII_FLAG(mrb_str_ptr(str));
+  RSTR_CODERANGE_SET(mrb_str_ptr(str), MRB_STR_CODERANGE_7BIT);
   return str;
 }
 
@@ -224,7 +224,7 @@ static mrb_value
 true_to_s(mrb_state *mrb, mrb_value obj)
 {
   mrb_value str = mrb_str_new_lit_frozen(mrb, "true");
-  RSTR_SET_ASCII_FLAG(mrb_str_ptr(str));
+  RSTR_CODERANGE_SET(mrb_str_ptr(str), MRB_STR_CODERANGE_7BIT);
   return str;
 }
 
@@ -333,7 +333,7 @@ static mrb_value
 false_to_s(mrb_state *mrb, mrb_value obj)
 {
   mrb_value str = mrb_str_new_lit_frozen(mrb, "false");
-  RSTR_SET_ASCII_FLAG(mrb_str_ptr(str));
+  RSTR_CODERANGE_SET(mrb_str_ptr(str), MRB_STR_CODERANGE_7BIT);
   return str;
 }
 

--- a/src/string.c
+++ b/src/string.c
@@ -647,18 +647,18 @@ mrb_str_char_len(mrb_state *mrb, mrb_value str)
 
   /* A byte-indexed string has one position per byte, which is what
      mrb_str_char_to_byte() and mrb_str_byte_to_char() already answer for it.
-     Asked here only about the single-byte flag, the same string was measured
-     as UTF-8 and reported a length its own indexing did not agree with.
+     Asked here only where the string stands, the same string was measured as
+     UTF-8 and reported a length its own indexing did not agree with.
 
-     The flag below is deliberately not set on the way out: it says the bytes
-     hold nothing multi-byte, while this returns early because of how the
-     string is read. force_encoding() can take MRB_STR_BINARY away again, and
-     a flag set here would outlive the reason for it. */
+     7BIT is deliberately not recorded on the way out: it says the bytes hold
+     nothing multi-byte, while this returns early because of how the string is
+     read. force_encoding() can take the byte reading away again, and an answer
+     recorded here would outlive the reason for it. */
   if (RSTR_BINARY_P(s)) {
     return byte_len;
   }
 
-  if (RSTR_SINGLE_BYTE_P(s)) {
+  if (RSTR_CODERANGE(s) == MRB_STR_CODERANGE_7BIT) {
     return byte_len;
   }
   else {
@@ -673,7 +673,7 @@ mrb_str_char_len(mrb_state *mrb, mrb_value str)
        is counted as one too, so a string of them set the flag as well, and the
        readers of it went on to hand those bytes back as characters. */
     if (np == e) {
-      RSTR_SET_SINGLE_BYTE_FLAG(s);
+      RSTR_CODERANGE_SET(s, MRB_STR_CODERANGE_7BIT);
       return byte_len;
     }
     mrb_int utf8_len = (mrb_int)(np - p) + mrb_utf8_strlen(np, (mrb_int)(e - np));
@@ -691,43 +691,40 @@ mrb_str_valid_encoding_p(mrb_state *mrb, mrb_value str)
   /* A byte-indexed string makes no such claim, so it is valid whatever its
      bytes are. */
   if (RSTR_BINARY_P(s)) return TRUE;
-  if (RSTR_VALID_ENC_P(s)) return TRUE;
-  /* The walk below reads the whole string to answer FALSE, so a string already
-     read as broken is answered off the mark that walk left instead. */
-  if (RSTR_BROKEN_ENC_P(s)) return FALSE;
-  /* A string of one character per byte holds nothing but ASCII, and ASCII
-     reads as UTF-8 as it stands, so it is valid without a walk. This is what
-     a string counted before it is asked about comes in carrying. */
-  if (RSTR_SINGLE_BYTE_P(s)) {
-    RSTR_SET_VALID_ENC_FLAG(s);
-    return TRUE;
-  }
+  /* The walk below reads the whole string to answer either way, so a string
+     that has been walked already is answered off where it stands instead. A
+     string of one character per byte is one of those: it holds nothing but
+     ASCII, and ASCII reads as UTF-8 as it stands. This is what a string
+     counted before it is asked about comes in carrying. */
+  mrb_int cr = RSTR_CODERANGE(s);
+  if (cr == MRB_STR_CODERANGE_7BIT || cr == MRB_STR_CODERANGE_VALID) return TRUE;
+  if (cr == MRB_STR_CODERANGE_BROKEN) return FALSE;
 
   mrb_int byte_len = RSTR_LEN(s);
   mrb_bool valid = TRUE;
   mrb_int utf8_len = utf8_strlen_check(RSTR_PTR(s), byte_len, &valid);
 
   if (!valid) {
-    RSTR_SET_BROKEN_ENC_FLAG(s);
+    RSTR_CODERANGE_SET(s, MRB_STR_CODERANGE_BROKEN);
     return FALSE;
   }
-  if (byte_len == utf8_len) RSTR_SET_SINGLE_BYTE_FLAG(s);
-  RSTR_SET_VALID_ENC_FLAG(s);
+  RSTR_CODERANGE_SET(s, byte_len == utf8_len ? MRB_STR_CODERANGE_7BIT
+                                             : MRB_STR_CODERANGE_VALID);
   return TRUE;
 }
 
 /* whether every byte of the string is ASCII. A walk that finds nothing else
-   made the statement MRB_STR_SINGLE_BYTE makes, so the answer is left there
-   for the next asker to read off. */
+   has made the statement 7BIT makes, so the answer is left on the string for
+   the next asker to read off. */
 static mrb_bool
 str_ascii_p(struct RString *s)
 {
-  if (RSTR_SINGLE_BYTE_P(s)) return TRUE;
+  if (RSTR_CODERANGE(s) == MRB_STR_CODERANGE_7BIT) return TRUE;
 
   const char *p = RSTR_PTR(s);
   const char *e = p + RSTR_LEN(s);
   if (search_nonascii(p, e) != e) return FALSE;
-  RSTR_SET_SINGLE_BYTE_FLAG(s);
+  RSTR_CODERANGE_SET(s, MRB_STR_CODERANGE_7BIT);
   return TRUE;
 }
 
@@ -737,7 +734,7 @@ mrb_str_char_to_byte(mrb_state *mrb, mrb_value str, mrb_int off, mrb_int idx)
 {
   (void)mrb;
   struct RString *s = mrb_str_ptr(str);
-  if (RSTR_SINGLE_BYTE_P(s) || RSTR_BINARY_P(s)) {
+  if (RSTR_CODERANGE(s) == MRB_STR_CODERANGE_7BIT || RSTR_BINARY_P(s)) {
     return idx;
   }
 
@@ -778,7 +775,7 @@ mrb_str_byte_to_char(mrb_state *mrb, mrb_value str, mrb_int bi)
   (void)mrb;
   struct RString *s = mrb_str_ptr(str);
   if (bi < 0 || RSTR_LEN(s) < bi) return -1;
-  if (RSTR_SINGLE_BYTE_P(s) || RSTR_BINARY_P(s)) {
+  if (RSTR_CODERANGE(s) == MRB_STR_CODERANGE_7BIT || RSTR_BINARY_P(s)) {
     return bi;
   }
 
@@ -1004,13 +1001,7 @@ mrb_str_byte_subseq(mrb_state *mrb, mrb_value str, mrb_int beg, mrb_int len)
     s->as.heap.ptr += (mrb_ssize)beg;
     s->as.heap.len = (mrb_ssize)len;
   }
-  RSTR_COPY_SINGLE_BYTE_FLAG(s, orig);
-  /* A subrange of a byte-read string holds nothing but bytes of it, so it is
-     read the same way. Neither answer about the encoding travels with it:
-     cutting can leave a character in pieces, and it can also cut away the
-     piece that spelled none, so a subrange inherits validity in neither
-     direction. */
-  RSTR_ENC_COPY(s, orig);
+  RSTR_ENC_CR_COPY_FOR_SUBSTR(s, orig);
   return mrb_obj_value(s);
 }
 
@@ -1104,10 +1095,7 @@ str_replace(mrb_state *mrb, struct RString *s1, struct RString *s2)
 {
   mrb_check_frozen(mrb, s1);
   if (s1 == s2) return mrb_obj_value(s1);
-  RSTR_COPY_SINGLE_BYTE_FLAG(s1, s2);
-  RSTR_COPY_VALID_ENC_FLAG(s1, s2);
-  RSTR_COPY_BROKEN_ENC_FLAG(s1, s2);
-  RSTR_ENC_COPY(s1, s2);
+  RSTR_ENC_CR_COPY(s1, s2);
   if (RSTR_SHARED_P(s1)) {
     str_decref(mrb, s1->as.heap.aux.shared);
   }
@@ -1267,8 +1255,8 @@ mrb_locale_from_utf8(const char *utf8, int len)
  * @param s The RString structure to modify.
  *
  * Prepares a string for modification. If the string is shared or not extensible,
- * it will be unshared or converted to a normal string. This version preserves
- * the ASCII/single-byte nature of the string if it was already set.
+ * it will be unshared or converted to a normal string. This version keeps the
+ * string standing at 7BIT if that is where it stood.
  * Raises an error if the string is frozen.
  */
 MRB_API void
@@ -1277,9 +1265,11 @@ mrb_str_modify_keep_ascii(mrb_state *mrb, struct RString *s)
   mrb_check_frozen(mrb, s);
   str_unshare_buffer(mrb, s);
   /* Every in-place write reaches here, including the ones that keep the string
-     ASCII, so this is where the walk's answer stops holding. */
-  RSTR_UNSET_VALID_ENC_FLAG(s);
-  RSTR_UNSET_BROKEN_ENC_FLAG(s);
+     ASCII, so this is where the walk's answer stops holding. What a string of
+     nothing but ASCII stands at is the caller's to keep. */
+  if (RSTR_CODERANGE(s) != MRB_STR_CODERANGE_7BIT) {
+    RSTR_CODERANGE_SET(s, MRB_STR_CODERANGE_UNKNOWN);
+  }
 }
 
 /*
@@ -1287,15 +1277,15 @@ mrb_str_modify_keep_ascii(mrb_state *mrb, struct RString *s)
  * @param s The RString structure to modify.
  *
  * Prepares a string for modification. Similar to `mrb_str_modify_keep_ascii`,
- * but also unsets the single-byte flag, assuming the modification might
- * introduce multi-byte characters.
+ * but also takes 7BIT back, assuming the modification might introduce
+ * multi-byte characters.
  * Raises an error if the string is frozen.
  */
 MRB_API void
 mrb_str_modify(mrb_state *mrb, struct RString *s)
 {
   mrb_str_modify_keep_ascii(mrb, s);
-  RSTR_UNSET_SINGLE_BYTE_FLAG(s);
+  RSTR_CODERANGE_SET(s, MRB_STR_CODERANGE_UNKNOWN);
 }
 
 /*
@@ -1501,16 +1491,13 @@ mrb_str_times(mrb_state *mrb, mrb_value self)
     memcpy(p + n, p, len-n);
   }
   p[RSTR_LEN(str2)] = '\0';
-  RSTR_COPY_SINGLE_BYTE_FLAG(str2, mrb_str_ptr(self));
-  RSTR_COPY_VALID_ENC_FLAG(str2, mrb_str_ptr(self));
-  /* a repetition of a byte-read string holds nothing but its bytes over
-     again, so it is read the same way */
-  RSTR_ENC_COPY(str2, mrb_str_ptr(self));
-  /* A repetition of broken bytes reaches the same broken place the first copy
-     does, so it is broken too. Nought copies keep none of the bytes, and an
-     empty string is not broken whatever it was made from. */
-  if (len > 0) {
-    RSTR_COPY_BROKEN_ENC_FLAG(str2, mrb_str_ptr(self));
+  /* A repetition holds the receiver's bytes over again, so it is read the same
+     way and reaches the same broken place the first copy does. */
+  RSTR_ENC_CR_COPY(str2, mrb_str_ptr(self));
+  /* Nought copies keep none of the bytes, and an empty string is not broken
+     whatever it was made from. */
+  if (len == 0 && RSTR_CODERANGE(str2) == MRB_STR_CODERANGE_BROKEN) {
+    RSTR_CODERANGE_SET(str2, MRB_STR_CODERANGE_UNKNOWN);
   }
 
   return mrb_obj_value(str2);
@@ -1946,11 +1933,11 @@ str_escape(mrb_state *mrb, mrb_value str, mrb_bool inspect)
   mrb_str_cat_lit(mrb, result, "\"");
 #ifdef MRB_UTF8_STRING
   if (inspect) {
-    if (src_sb_flag) RSTR_SET_SINGLE_BYTE_FLAG(mrb_str_ptr(str));
-    if (sb_flag) RSTR_SET_SINGLE_BYTE_FLAG(mrb_str_ptr(result));
+    if (src_sb_flag) RSTR_CODERANGE_SET(mrb_str_ptr(str), MRB_STR_CODERANGE_7BIT);
+    if (sb_flag) RSTR_CODERANGE_SET(mrb_str_ptr(result), MRB_STR_CODERANGE_7BIT);
   }
   else {
-    RSTR_SET_SINGLE_BYTE_FLAG(mrb_str_ptr(result));
+    RSTR_CODERANGE_SET(mrb_str_ptr(result), MRB_STR_CODERANGE_7BIT);
   }
 #endif
 
@@ -2144,7 +2131,7 @@ mrb_str_chomp_bang(mrb_state *mrb, mrb_value str)
        a character of its own, and cutting there would leave a string that is
        not UTF-8: "あ".chomp("\x82") is the whole of the last byte of a
        three-byte character. CRuby reads that as no match. */
-    if (!RSTR_BINARY_P(s) && !RSTR_SINGLE_BYTE_P(s) &&
+    if (!RSTR_BINARY_P(s) && RSTR_CODERANGE(s) != MRB_STR_CODERANGE_7BIT &&
         mrb_utf8_char_head(p, pp, p + len) != pp) {
       return mrb_nil_value();
     }
@@ -2456,7 +2443,7 @@ mrb_str_check_byte_pos(mrb_state *mrb, mrb_value str, mrb_int pos)
 {
 #ifdef MRB_UTF8_STRING
   struct RString *s = mrb_str_ptr(str);
-  if (RSTR_SINGLE_BYTE_P(s) || RSTR_BINARY_P(s)) return;
+  if (RSTR_CODERANGE(s) == MRB_STR_CODERANGE_7BIT || RSTR_BINARY_P(s)) return;
 
   const char *b = RSTR_PTR(s);
   const char *p = b + pos;
@@ -2510,7 +2497,7 @@ mrb_str_byteindex_m(mrb_state *mrb, mrb_value str)
 static mrb_value
 mrb_str_index_m(mrb_state *mrb, mrb_value str)
 {
-  if (RSTR_SINGLE_BYTE_P(mrb_str_ptr(str))) {
+  if (RSTR_CODERANGE(mrb_str_ptr(str)) == MRB_STR_CODERANGE_7BIT) {
     return mrb_str_byteindex_m(mrb, str);
   }
 
@@ -2810,7 +2797,7 @@ static mrb_value
 mrb_str_rindex_m(mrb_state *mrb, mrb_value str)
 {
   struct RString *s = mrb_str_ptr(str);
-  if (RSTR_SINGLE_BYTE_P(s) || RSTR_BINARY_P(s)) {
+  if (RSTR_CODERANGE(s) == MRB_STR_CODERANGE_7BIT || RSTR_BINARY_P(s)) {
     return mrb_str_byterindex_m(mrb, str);
   }
 
@@ -3517,9 +3504,7 @@ str_modify_cat(mrb_state *mrb, struct RString *s, mrb_int addlen)
       /* The appended bytes belong to `s` from now on, so no other sharer may
          write over them. */
       shared->reserved = off + s->as.heap.len + addlen;
-      RSTR_UNSET_SINGLE_BYTE_FLAG(s);
-      RSTR_UNSET_VALID_ENC_FLAG(s);
-      RSTR_UNSET_BROKEN_ENC_FLAG(s);
+      RSTR_CODERANGE_SET(s, MRB_STR_CODERANGE_UNKNOWN);
       return capa;
     }
   }

--- a/src/string.c
+++ b/src/string.c
@@ -1010,7 +1010,7 @@ mrb_str_byte_subseq(mrb_state *mrb, mrb_value str, mrb_int beg, mrb_int len)
      cutting can leave a character in pieces, and it can also cut away the
      piece that spelled none, so a subrange inherits validity in neither
      direction. */
-  RSTR_COPY_BINARY_FLAG(s, orig);
+  RSTR_ENC_COPY(s, orig);
   return mrb_obj_value(s);
 }
 
@@ -1107,7 +1107,7 @@ str_replace(mrb_state *mrb, struct RString *s1, struct RString *s2)
   RSTR_COPY_SINGLE_BYTE_FLAG(s1, s2);
   RSTR_COPY_VALID_ENC_FLAG(s1, s2);
   RSTR_COPY_BROKEN_ENC_FLAG(s1, s2);
-  RSTR_COPY_BINARY_FLAG(s1, s2);
+  RSTR_ENC_COPY(s1, s2);
   if (RSTR_SHARED_P(s1)) {
     str_decref(mrb, s1->as.heap.aux.shared);
   }
@@ -1419,7 +1419,7 @@ mrb_str_plus(mrb_state *mrb, mrb_value a, mrb_value b)
   if ((RSTR_BINARY_P(s) && RSTR_BINARY_P(s2)) ||
       (RSTR_BINARY_P(s) && !str_ascii_p(s)) ||
       (RSTR_BINARY_P(s2) && !str_ascii_p(s2))) {
-    RSTR_SET_BINARY_FLAG(t);
+    RSTR_ENCODING_SET(t, MRB_STR_ENCODING_BINARY);
   }
 
   return mrb_obj_value(t);
@@ -1505,7 +1505,7 @@ mrb_str_times(mrb_state *mrb, mrb_value self)
   RSTR_COPY_VALID_ENC_FLAG(str2, mrb_str_ptr(self));
   /* a repetition of a byte-read string holds nothing but its bytes over
      again, so it is read the same way */
-  RSTR_COPY_BINARY_FLAG(str2, mrb_str_ptr(self));
+  RSTR_ENC_COPY(str2, mrb_str_ptr(self));
   /* A repetition of broken bytes reaches the same broken place the first copy
      does, so it is broken too. Nought copies keep none of the bytes, and an
      empty string is not broken whatever it was made from. */
@@ -1851,7 +1851,7 @@ str_replace_partial(mrb_state *mrb, mrb_value src, mrb_int pos, mrb_int end, mrb
        their reading over, ASCII bytes move nothing */
     struct RString *repp = mrb_str_ptr(rep);
     if (!RSTR_BINARY_P(str) && RSTR_BINARY_P(repp) && !str_ascii_p(repp)) {
-      RSTR_SET_BINARY_FLAG(str);
+      RSTR_ENCODING_SET(str, MRB_STR_ENCODING_BINARY);
     }
   }
   RSTR_SET_LEN(str, newlen);
@@ -3638,7 +3638,7 @@ mrb_str_cat_str(mrb_state *mrb, mrb_value str, mrb_value str2)
   mrb_bool binary = !RSTR_BINARY_P(s) && RSTR_BINARY_P(s2) && !str_ascii_p(s2);
   mrb_value ret = mrb_str_cat(mrb, str, RSTRING_PTR(str2), RSTRING_LEN(str2));
   if (binary) {
-    RSTR_SET_BINARY_FLAG(mrb_str_ptr(ret));
+    RSTR_ENCODING_SET(mrb_str_ptr(ret), MRB_STR_ENCODING_BINARY);
   }
   return ret;
 }
@@ -3879,7 +3879,7 @@ sub_replace(mrb_state *mrb, mrb_value self)
   if ((RSTR_BINARY_P(mrb_str_ptr(replace)) && !str_ascii_p(mrb_str_ptr(replace))) ||
       (match_taken && RSTR_BINARY_P(mrb_str_ptr(pat)) && !str_ascii_p(mrb_str_ptr(pat))) ||
       (self_taken && RSTR_BINARY_P(mrb_str_ptr(self)) && !str_ascii_p(mrb_str_ptr(self)))) {
-    RSTR_SET_BINARY_FLAG(mrb_str_ptr(result));
+    RSTR_ENCODING_SET(mrb_str_ptr(result), MRB_STR_ENCODING_BINARY);
   }
   return result;
 }

--- a/src/symbol.c
+++ b/src/symbol.c
@@ -1166,7 +1166,7 @@ sym_inspect(mrb_state *mrb, mrb_value sym)
     sp[1] = '"';
   }
 #ifdef MRB_UTF8_STRING
-  if (SYMBOL_INLINE_P(id)) RSTR_SET_ASCII_FLAG(mrb_str_ptr(str));
+  if (SYMBOL_INLINE_P(id)) RSTR_CODERANGE_SET(mrb_str_ptr(str), MRB_STR_CODERANGE_7BIT);
 #endif
   return str;
 }
@@ -1192,7 +1192,7 @@ mrb_sym_str(mrb_state *mrb, mrb_sym sym)
   if (!name) return mrb_undef_value(); /* can't happen */
   if (SYMBOL_INLINE_P(sym)) {
     mrb_value str = mrb_str_new(mrb, name, len);
-    RSTR_SET_ASCII_FLAG(mrb_str_ptr(str));
+    RSTR_CODERANGE_SET(mrb_str_ptr(str), MRB_STR_CODERANGE_7BIT);
     return str;
   }
   if (sym_name_freeable_p(mrb, sym)) {


### PR DESCRIPTION
Stacked on #7157, which is the first commit here. The second commit is this PR's own change, and the diff to read is `git diff <first commit>..HEAD`. Merging #7157 first leaves this one a single commit.

Reading a string's bytes as the encoding it carries comes back with one of four answers: not asked yet, nothing but ASCII, read whole and sound, read and found broken. `include/mruby/string.h` keeps them as three flags, `MRB_STR_SINGLE_BYTE`, `MRB_STR_VALID_ENC` and `MRB_STR_BROKEN_ENC`, each with a predicate, a set, an unset and a copy of its own.

No writer sets two of them, so the answers are exclusive already. What the three flags leave to their readers is the map from combinations back to answers:

```c
/* src/string.c, mrb_str_valid_encoding_p(): SINGLE_BYTE implies VALID_ENC,
   so the reader answers off one flag and then writes the other. */
if (RSTR_SINGLE_BYTE_P(s)) {
  RSTR_SET_VALID_ENC_FLAG(s);
  return TRUE;
}

/* src/string.c, str_replace(): a copy stands where its source stands,
   spelled once per flag. */
RSTR_COPY_SINGLE_BYTE_FLAG(s1, s2);
RSTR_COPY_VALID_ENC_FLAG(s1, s2);
RSTR_COPY_BROKEN_ENC_FLAG(s1, s2);
```

This PR gives the answer a name of its own. The three bits stay exactly where they are and the accessors are written over them, so what changes is the vocabulary and not the layout.

### What goes into `include/mruby/string.h`

```c
#define MRB_STR_CODERANGE_UNKNOWN 0
#define MRB_STR_CODERANGE_7BIT    1
#define MRB_STR_CODERANGE_VALID   2
#define MRB_STR_CODERANGE_BROKEN  3

#ifdef MRB_UTF8_STRING
# define RSTR_CODERANGE(s) \
  (((s)->flags & MRB_STR_BROKEN_ENC) ? MRB_STR_CODERANGE_BROKEN : \
   ((s)->flags & MRB_STR_SINGLE_BYTE) ? MRB_STR_CODERANGE_7BIT : \
   ((s)->flags & MRB_STR_VALID_ENC) ? MRB_STR_CODERANGE_VALID : \
   MRB_STR_CODERANGE_UNKNOWN)
# define RSTR_CODERANGE_SET(s, cr) /* writes all three bits */
#else
# define RSTR_CODERANGE(s) MRB_STR_CODERANGE_7BIT
# define RSTR_CODERANGE_SET(s, cr) ((void)0)
#endif

#define RSTR_ENC_CR_COPY(dst, src)
#define RSTR_ENC_CR_COPY_FOR_SUBSTR(dst, src)
```

The four answers are the set CRuby closes on in `ENC_CODERANGE_UNKNOWN`, `_7BIT`, `_VALID` and `_BROKEN`, and the names follow. UNKNOWN is 0 for the same reason it is 0 there: a fresh string is filled with zeroes and has been asked nothing.

The values are small integers rather than the flag positions CRuby uses, because here they are not positions of anything: they sit over three bits that are not adjacent, and `MRB_STR_SINGLE_BYTE|MRB_STR_VALID_ENC` is not the bit pattern of any answer. A build without `MRB_UTF8_STRING` reads every byte as a character and asks the bytes nothing, which is where 7BIT stands, so `RSTR_CODERANGE()` is that constant there and `RSTR_CODERANGE_SET()` records nothing. That is what `RSTR_SINGLE_BYTE_P()` and `RSTR_VALID_ENC_P()` being `TRUE` said before.

### Two copies, and why they carry the encoding too

The encoding travels with the answer in one macro rather than beside it in another, since a copy that keeps one and drops the other is how flags went missing on copy paths before (f71bd2297 and the whole of #7136 are that shape: a path that copied the bytes and left the flag behind on the original). The two copies stay outside the `#ifdef`, so a byte indexed build still carries the encoding across.

There are two because a subrange is not an exact copy. A cut can leave a character in pieces, and it can cut away the piece that spelled none, so a subrange inherits neither soundness nor brokenness. Nothing but ASCII survives being cut anywhere, so 7BIT is the one answer `mrb_str_byte_subseq()` carries over. CRuby splits the same two ways, in `rb_enc_cr_str_exact_copy()` and `rb_enc_cr_str_copy_for_substr()`; the second of those also walks the subrange to promote VALID to 7BIT, which is not what this code does today and is not added here.

### The sites

| kind | count | where |
| --- | --- | --- |
| reads | 16 | `RSTR_SINGLE_BYTE_P` 14, `RSTR_VALID_ENC_P` 1, `RSTR_BROKEN_ENC_P` 1 |
| writes | 15 | the sets and unsets of the three flags |
| copies | 7 into 3 | `mrb_str_byte_subseq()`, `str_replace()`, `String#*` |
| `RSTR_SET_ASCII_FLAG` | 12 | `src/object.c` (4), `mruby-string-ext` (3), `src/symbol.c` (2), `src/numeric.c` (2), `mruby-time` (1) |

`RSTR_SET_ASCII_FLAG()` was an alias for `RSTR_SET_SINGLE_BYTE_FLAG()`, and it goes with the flag it aliased. Its callers say `RSTR_CODERANGE_SET(s, MRB_STR_CODERANGE_7BIT)`, so there is one word for the answer rather than two.

### Writes where one flag became three bits

`RSTR_CODERANGE_SET()` writes all three bits where the old sets wrote one, so every converted write is a place where clearing the other two has to lose nothing. It does, because no writer sets two of them and 7BIT is the one answer that implies another. Three are worth naming:

* `mrb_str_valid_encoding_p()` no longer writes "sound" onto a string that is already nothing but ASCII. It is the one write that goes rather than moves.
* `mrb_str_modify_keep_ascii()` and `mrb_str_modify()` are where every in-place write passes and where the answer stops holding. As a pair they took soundness and brokenness away and then took ASCII away as well; now the first keeps 7BIT and writes UNKNOWN over anything else, and the second writes UNKNOWN. `str_modify_cat()`, which reaches neither when it appends into a shared buffer, writes UNKNOWN in one go instead of clearing three bits.
* `String#*` still refuses to call a nought times repetition broken. The receiver's answer is copied and then taken back off the empty result, which is where it stood before.

### Generated code

Two full-core builds, with `mruby-encoding` and with the gem removed from the box, gcc `-O3`, measured against the tree with #7157 alone:

| build | `.text` over the whole build |
| --- | --- |
| full-core without `mruby-encoding` | unchanged, every object identical instruction for instruction |
| full-core, `MRB_UTF8_STRING` | 1789338 -> 1787914 (-1424) |

Where the UTF-8 build moves:

| object | `.text` |
| --- | --- |
| `src/string.o` | 50944 -> 49328 (-1616) |
| `mruby-string-ext` | 19813 -> 19893 (+80) |
| `src/symbol.o` | 10496 -> 10544 (+48) |
| `src/object.o` | 6152 -> 6200 (+48) |
| `mruby-time` | 10277 -> 10293 (+16) |

Six objects change at all, and `src/numeric.o` changes without growing. The four that grow are the files whose only change is `RSTR_SET_ASCII_FLAG()` becoming a write of one answer: a bit set turns into a read, a mask and an or. Inside `src/string.o` the sites this PR touches move by tens of bytes in both directions (`mrb_str_times()` +68, `mrb_str_char_len()` +64, `mrb_str_modify_keep_ascii()` +64, `mrb_str_valid_encoding_p()` -41), and the largest single movers are functions this PR does not touch at all: `mrb_str_resize()` 1057 -> 208 and `mrb_str_to_s()` 665 -> 110, where the inliner rearranges around a `str_replace()` that is now four macro expansions shorter.

### Testing

`rake -m test` on both builds above, plus the C++ ABI build, all green:

* full-core with `MRB_UTF8_STRING`: 2291 tests, 2281 OK, 10 skip, 0 KO, 0 crash, 0 warnings.
* full-core without `mruby-encoding`, where strings index by byte: 2229 tests, 2200 OK, 29 skip, 0 KO, 0 crash, 0 warnings.
* the same box with `enable_cxx_abi`: 2291 tests, 2281 OK, 10 skip.

No test accompanies the change. No string answers anything different, so there is nothing new to pin.

### Not in this PR

The three bits are not folded into a two bit field, and none of them moves. `MRB_STR_SINGLE_BYTE`, `MRB_STR_VALID_ENC` and `MRB_STR_BROKEN_ENC` keep their values and are now named only inside the two accessors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved internal handling of string encoding and character validity.
  * String operations now better preserve encoding information when copying, slicing, combining, and transforming text.
  * Enhanced handling for ASCII, UTF-8, binary, valid, and invalid string content across common string operations.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->