### PR TITLE
build: give `spec.build.defines` a reader that cannot lie

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -28,6 +28,11 @@ MRuby.each_target do |build|
     end
   end
   gems.setup(self) if enable_gems?
+
+  # The config has been read and every gem's mrbgem.rake body has run, so the
+  # defines a gem contributes are all in. `build.has_define?` answers from
+  # here on, and refuses before.
+  build.defines_final!
 end
 
 # load basic rules

--- a/doc/guides/mrbgems.md
+++ b/doc/guides/mrbgems.md
@@ -339,6 +339,35 @@ after all setup blocks for GEMs including dependencies have been called.
 **NOTE**: Using the `build_settings` method will cause GEM's all build command settings
 directly written in the block passed to `MRuby::Gem::Specification.new` to be ignored.
 
+### Asking what the build defines
+
+A GEM announces a capability to the rest of the build by adding to
+`spec.build.defines`, which becomes a `-D` on every translation unit:
+
+```ruby
+spec.build.defines << "HAVE_MRUBY_IO_GEM"
+```
+
+`MRuby::Build#has_define?` is how another GEM reads one back:
+
+```ruby
+spec.build_settings do
+  spec.cc.flags << "-any_flags" if build.has_define?("MRB_UTF8_STRING")
+end
+```
+
+It reports a define whether the build configuration asked for it or a GEM
+contributed it, and matches on the name alone, so a define added as `"FOO=1"`
+answers `has_define?("FOO")`. The `-D` belongs to the compiler flag and not to
+the define, so it is no part of the name to ask under.
+
+It has to be asked from `build_settings` and not from the block passed to
+`MRuby::Gem::Specification.new`. A GEM contributes its defines when its own
+block runs, and the blocks run in the order the GEMs were added, so during
+that phase the answer would depend on how far down the list the caller sits.
+`has_define?` raises there rather than hand back an answer that is right for
+some GEM orders and wrong for others.
+
 ## Platform Ports (ports/)
 
 A gem may ship platform-specific C sources under `ports/<name>/`

--- a/lib/mruby/build.rb
+++ b/lib/mruby/build.rb
@@ -110,6 +110,7 @@ module MRuby
         @install_prefix = nil
         @install_excludes = []
         @defines = []
+        @defines_final = false
         @cc = Command::Compiler.new(self, %w(.c), label: "CC")
         @cxx = Command::Compiler.new(self, %w(.cc .cxx .cpp), label: "CXX")
         @objc = Command::Compiler.new(self, %w(.m), label: "OBJC")
@@ -376,6 +377,37 @@ EOS
       COMPILERS.map do |c|
         instance_variable_get("@#{c}")
       end
+    end
+
+    # Declare that every gem in the build has had its mrbgem.rake run, so the
+    # defines gems contribute through `spec.build.defines` are all in.  Called
+    # once from the Rakefile, between loading the build config and defining
+    # any rule.
+    def defines_final!
+      @defines_final = true
+    end
+
+    # True when this build compiles with -D<name>, whether the build config
+    # asked for it or a gem contributed it.  A gem reads this to configure
+    # itself against a capability another gem provides.
+    #
+    # Until `defines_final!` the answer would depend on how far down the gem
+    # list the caller sits, since a gem contributes its defines when its own
+    # mrbgem.rake body runs.  Rather than hand back an answer that is right
+    # for some gem orders and wrong for others, this refuses to answer at all
+    # before then.  `spec.build_settings` is the hook that runs late enough.
+    def has_define?(name)
+      unless @defines_final
+        fail "build.has_define?(#{name.inspect}) cannot be answered while gems " \
+             "are still being set up, because a gem contributes its defines " \
+             "then. Ask from a `spec.build_settings` block instead."
+      end
+      name = name.to_s
+      # A define may carry a value, as `FOO=1` does, so compare the name and
+      # not the value.  The `-D` is the compiler's, added when the flags are
+      # assembled, and is no part of the name.
+      [defines, *compilers.map(&:defines)].flatten
+        .any? {|d| d.to_s.split('=', 2).first == name}
     end
 
     def define_rules


### PR DESCRIPTION

Eight core gems announce a capability to the rest of the build by adding to
`spec.build.defines`: `MRB_USE_BIGINT`, `MRB_UTF8_STRING`,
`HAVE_MRUBY_IO_GEM`, `MRB_USE_TASK_SCHEDULER` and the like. No gem reads one
back. The three `defines.include?` calls in `mrbgems/*/mrbgem.rake` all read
the gem's own `cc.defines` or one the build configuration set, never one
another gem contributed.

The channel is write-only for a reason. A gem contributes its defines when
its own mrbgem.rake body runs, and `MRuby::Gem::List#setup` runs those bodies
in the order the gems were added, so a gem that reads `build.defines` during
that phase gets an answer that depends on where it sits in the list.
`full-core.gembox` globs the directory, and `mruby-encoding` sorts before
`mruby-regexp`, so the one pairing that would be asked about today happens to
work. Naming the two gems in the other order is enough to break it:

```ruby
MRuby::Build.new('probe') do |conf|
  conf.gem :core => 'mruby-regexp'
  conf.gem :core => 'mruby-encoding'   # contributes MRB_UTF8_STRING
  conf.gembox 'default'
end
```

Read from `mruby-regexp`'s block, `build.defines.include?('MRB_UTF8_STRING')`
is `false` there and `true` with the two lines swapped. Both builds compile
with `-DMRB_UTF8_STRING`.

`MRuby::Build#has_define?` answers the same question and refuses to answer it
early:

```
build.has_define?("MRB_UTF8_STRING") cannot be answered while gems are still
being set up, because a gem contributes its defines then. Ask from a
`spec.build_settings` block instead.
```

`build_settings` is called from `MRuby::Gem::List#check`, after every gem's
setup, which is where the answer is stable. The Rakefile marks the boundary
once per target, right after `gems.setup`, so a build with no gems reaches it
too.

The reader spans both places a define can come from, `build.defines` and the
compilers' own, and matches on the name alone, so a define added as `FOO=1`
answers `has_define?("FOO")`. The `-D` belongs to the compiler flag and not to
the define, so it is no part of the name to ask under.

### Verified

On the config above and on `ci/gcc-clang`, printed from both phases:

```
probe-bad-order   setup: REFUSED       build_settings: true
full-debug        setup: REFUSED       build_settings: true
bintest           setup: REFUSED       build_settings: true
cxx_abi           setup: REFUSED       build_settings: true
byte-string       setup: REFUSED       build_settings: false
```

`byte-string` is `full-core` minus `mruby-encoding`, so `false` is the whole
of the difference. A define carrying a value (`PROBE_VALUED=7`) answers under
its name, and a name nothing defines answers `false`.

`MRUBY_CONFIG=ci/gcc-clang rake -m test`, all four builds and the bintests,
KO 0:

```
byte-string   Total 2227   Skip 29
full-debug    Total 2288   Skip 2
bintest       Total 2289   Skip 10   + 116 bintests
cxx_abi       Total 2289   Skip 10
```

### No caller yet

Nothing in the tree calls it. The gems that split their tests by build mode
(`mruby-string-ext`, `mruby-regexp`) do it at run time with `skip unless`,
which needs no build-time answer and stays the better tool for that job. This
is for a gem that has to configure itself, not its tests, against another
gem's capability, and it is offered so that the first one to need it finds a
question it cannot get wrong rather than an array it can read too early.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Build configurations can now define compiler capabilities and query whether named capabilities are available.
  * Capability checks recognize definitions from both the main build configuration and included gems.
  * Queries match capability names regardless of assigned values.

* **Bug Fixes**
  * Checks made before build configuration is complete now provide a clear error directing users to the appropriate configuration stage.

* **Documentation**
  * Added guidance for declaring and checking build capability definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
