### PR TITLE
mruby-test: regenerate the per-gem test wrapper when a `mrbgem.rake` it is generated from changes

### DIFF
--- a/mrbgems/mruby-test/mrbgem.rake
+++ b/mrbgems/mruby-test/mrbgem.rake
@@ -41,8 +41,18 @@ MRuby::Gem::Specification.new('mruby-test') do |spec|
     mrbtest_objs << test_rbobj
     dep_list = build.gems.tsort_dependencies([g.name], gem_table).select(&:generate_functions)
 
+    # The wrapper is generated from mrbgem.rake, not only from the test files:
+    # its body follows the gem's own test_rbfiles, test_preload and test_args,
+    # and it declares and calls the init/final function of every gem in
+    # dep_list, so an edit to the dependency graph of another gem changes it
+    # too. Track the rakefile of the gem and of each of its dependencies.
+    # (This tracks the test_preload path only; its contents stay untracked.)
+    gem_rakefiles = [g, *dep_list].map {|d| File.join(d.dir, "mrbgem.rake") }
+                                  .select {|f| File.exist?(f) }.uniq
+
     file test_rbobj => g.test_rbireps
-    file g.test_rbireps => [g.test_rbfiles, build.mrbcfile].flatten do |t|
+    # __FILE__ holds the generator itself, as in the mrbtest.c rule below.
+    file g.test_rbireps => [g.test_rbfiles, build.mrbcfile, gem_rakefiles, __FILE__].flatten do |t|
       _pp "GEN", t.name.relative_path
       mkdir_p File.dirname(t.name)
       tmpfile = t.name + ".tmp"


### PR DESCRIPTION
### Problem

The per-gem test wrapper `build/<target>/mrbgems/<gem>/gem_test.c` is generated from `mrbgem.rake`, not only from the test files it embeds. Its body follows the gem's `spec.test_rbfiles`, `spec.test_preload`, `spec.test_args` and `spec.test_objs` (via `custom_test_init?`), and it declares and calls the init/final function of every gem returned by `tsort_dependencies`.

The file task that generates it, however, listed only the test `.rb` files and `mrbc` as prerequisites:

```ruby
file g.test_rbireps => [g.test_rbfiles, build.mrbcfile].flatten do |t|
```

So editing a `mrbgem.rake` does not invalidate the wrapper. An incremental `rake test` keeps running the previously generated test set and reporting the previous result, until a test file happens to be touched or the build directory is cleaned. This is easy to mistake for a test that legitimately still passes (or still fails), which makes it an actively misleading failure mode when adding, removing or re-scoping a gem's tests.

### Reproduction

On a fully built tree (`rake test:build`), narrow one gem's test set without touching any test file. Append to `mrbgems/mruby-string-ext/mrbgem.rake`:

```ruby
spec.test_rbfiles = ["#{MRUBY_ROOT}/mrbgems/mruby-string-ext/test/string.rb"]
```

Then rebuild:

```console
$ rake test:build
$ ./build/host/bin/mrbtest | grep Total:
  Total: 2049
```

`gem_test.c` is byte-identical to before the edit and still embeds all three ireps; the count is unchanged. `touch mrbgems/mruby-string-ext/test/string.rb && rake test:build` then produces the expected single-irep wrapper and `Total: 2044`, confirming the stale artifact is the wrapper itself.

(Note that plain `rake` will not show this: the `mruby-test` gem is only loaded under the `test:build` task.)

### Fix

Add to the wrapper's prerequisites the `mrbgem.rake` of the gem and of each gem in its dependency list, plus `mruby-test/mrbgem.rake` itself, which holds the generator.

Tracking the dependency list is not defensive; it is load-bearing. Adding `spec.add_dependency 'mruby-math', core: 'mruby-math'` to `mrbgems/mruby-string-ext/mrbgem.rake` changes the wrapper of `mruby-regexp`, which depends on it, because `mruby-math`'s init/final calls are emitted there too. Tracking only the gem's own rakefile leaves that wrapper stale.

Both dependencies follow existing convention in the tree: `MRuby::Command::Compiler#define_rules` already records `mrbgem.rake` for a gem's C objects, and the sibling `mrbtest.c` rule already records `__FILE__` for its own generator. The per-gem test wrapper was simply missing both. The change is in mrbtest's rake rules only. No gem or core source is touched, and nothing is specific to any one gem.

The `File.exist?` filter keeps the rule safe for a `MRuby::Gem::Specification` that is not backed by an on-disk `mrbgem.rake`: a prerequisite that neither exists nor has a rule would abort the build. `define_rules` guards the same way.

One input remains untracked and is left for a separate change: the *contents* of the file named by `spec.test_preload` are embedded in the wrapper, but only its path is covered here. No in-tree gem currently sets `test_preload`.

### Verification

- Narrowing a gem's test set via `mrbgem.rake` alone, with no test file touched and `test/string.rb` older than the existing `gem_test.c`, now regenerates the wrapper and moves the count from `Total: 2049` to `Total: 2044`; reverting the edit restores `Total: 2049`.
- The cross-gem case above regenerates `mruby-regexp`'s wrapper from `bb189b91…` to `4c6a7f5f…`, with `grep -c GENERATED_TMP_mrb_mruby_math_gem_init` going from 0 to 2, the same content reached by force-touching that gem's own rakefile.
- `touch mrbgems/mruby-test/mrbgem.rake && rake test:build` regenerates all 50 wrappers, where previously it regenerated none.
- A cold build (`rake clean`, then full build) generates all wrappers and yields the same totals as before.

`rake -m test` on the current master with this change: `Total: 2075, OK: 2046, KO: 0, Crash: 0, Warning: 0, Skip: 29`, plus bintest `Total: 105, KO: 0, Crash: 0`. No behavioural change to the tests themselves is expected; this only makes an incremental build notice inputs it was already using.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test build reliability by ensuring generated test artifacts are refreshed when gem configuration or test dependencies change.
  * Preserved existing dependency-based test wrapper generation behavior.

* **Chores**
  * Updated test generation dependency tracking to reduce stale or outdated test results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->