### PR TITLE
mruby-regexp: read a pattern the way the build reads a String

### DIFF
--- a/include/mruby/internal.h
+++ b/include/mruby/internal.h
@@ -201,11 +201,11 @@ void mrb_str_check_byte_pos(mrb_state *mrb, mrb_value str, mrb_int pos);
    while mrb_utf8len() says it does not, is in the definition in string.c. */
 mrb_int mrb_utf8_to_buf(char *buf, mrb_int cp);
 
-/* What a run of bytes spells is a question apart from whether String indexes
-   by character, so a gem that reads UTF-8 on its own asks for these by
-   defining MRB_UTF8_SCAN (mruby-regexp does, from its mrbgem.rake). A build
-   with neither that gem nor MRB_UTF8_STRING carries none of them. */
-#if defined(MRB_UTF8_STRING) || defined(MRB_UTF8_SCAN)
+/* UTF-8: what a run of bytes spells, and how many characters a string holds.
+   Only a build that indexes strings by character has to answer either, so a
+   build without MRB_UTF8_STRING carries none of them. What has to read a
+   string whatever the build encodes it in asks through mrb_enc_* below. */
+#ifdef MRB_UTF8_STRING
 /* The byte length of the character at `str`, which has to be a byte of the
    string rather than `end` itself, and 1 for a run of bytes that spells no
    character. See the definition in string.c for what it rejects. */
@@ -222,11 +222,54 @@ const char *mrb_utf8_char_head(const char *beg, const char *p, const char *end);
    byte over one byte, so a value of 0x80 or above beside *lenp == 1 marks an
    invalid sequence; whether that is an error is the caller's question. */
 uint32_t mrb_utf8_decode(const char *p, const char *e, mrb_int *lenp);
-#endif
 
-#ifdef MRB_UTF8_STRING
 mrb_int mrb_utf8_strlen(const char *str, mrb_int byte_len);
 #endif
+
+/* What a run of bytes spells, in whatever a build's strings are encoded in.
+   These are the three above where the build reads UTF-8, and one byte per
+   character where it does not, which is what a String is there. Anything that
+   has to read a string whatever the build indexes it by asks through these,
+   so that adding a codec is a change here rather than in every caller. The
+   spelling of a codepoint has no such answer and stays UTF-8: see
+   mrb_utf8_to_buf() above.
+
+   The byte-per-character answers are inline because a matcher asks them once
+   per byte; where the build reads bytes each call folds into the constant it
+   returns and the branch around it goes away. */
+static inline mrb_int
+mrb_enc_charlen(const char *p, const char *e)
+{
+#ifdef MRB_UTF8_STRING
+  return mrb_utf8len(p, e);
+#else
+  (void)p; (void)e;
+  return 1;
+#endif
+}
+
+static inline const char *
+mrb_enc_char_head(const char *beg, const char *p, const char *end)
+{
+#ifdef MRB_UTF8_STRING
+  return mrb_utf8_char_head(beg, p, end);
+#else
+  (void)beg; (void)end;
+  return p;  /* every byte starts a character of its own */
+#endif
+}
+
+static inline uint32_t
+mrb_enc_decode(const char *p, const char *e, mrb_int *lenp)
+{
+#ifdef MRB_UTF8_STRING
+  return mrb_utf8_decode(p, e, lenp);
+#else
+  (void)e;
+  *lenp = 1;
+  return (uint8_t)*p;
+#endif
+}
 
 /* attr accessor bodies (class.c); the VM compares function pointers against
    these to run attr calls without a full method-call frame */

--- a/include/mruby/internal.h
+++ b/include/mruby/internal.h
@@ -226,6 +226,17 @@ uint32_t mrb_utf8_decode(const char *p, const char *e, mrb_int *lenp);
 mrb_int mrb_utf8_strlen(const char *str, mrb_int byte_len);
 #endif
 
+/* Whether more than one byte can spell one character in what this build
+   reads. The three functions below answer what a given run of bytes spells,
+   which is what a reader wants; this is for the few places that have to know
+   the shape of the answer before they have bytes to ask about, such as
+   whether a set of single characters can hold a named codepoint at all. */
+#ifdef MRB_UTF8_STRING
+# define MRB_ENC_MULTIBYTE_P 1
+#else
+# define MRB_ENC_MULTIBYTE_P 0
+#endif
+
 /* What a run of bytes spells, in whatever a build's strings are encoded in.
    These are the three above where the build reads UTF-8, and one byte per
    character where it does not, which is what a String is there. Anything that

--- a/mrbgems/mruby-regexp/README.md
+++ b/mrbgems/mruby-regexp/README.md
@@ -158,6 +158,13 @@ pattern analysis.
 
 ## Limitations
 
+- **UTF-8 only where the build reads it**: the engine reads a pattern and a
+  subject the way the build's `String` reads them, so everything below about
+  characters holds on a build that defines `MRB_UTF8_STRING` (mruby-encoding
+  is what defines it). Where it is not defined a string is bytes and so is the
+  engine: `/./` matches one byte, `/Ā/` is two atoms of one byte each, and
+  `/i` folds ASCII letters and nothing else. A binary (`ASCII-8BIT`) subject
+  reads by byte on either build.
 - **Fixed-length lookbehind only**: `(?<=...)` and `(?<!...)`
   require a fixed-length pattern (no `*`, `+`, `?`, or alternation).
   Maximum 255 bytes.
@@ -165,13 +172,14 @@ pattern analysis.
   supported.
 - **No `\x{...}` hex escape**: the hex escape is `\xHH`, so it reaches
   `0xff` at most. Write `\u{...}` for a codepoint above that.
-- **No encodings**: a pattern is a byte string read as UTF-8, and there is no
-  encoding to consult about a byte that starts no whole character. Such a byte
-  is that byte, inside a character class as much as outside one: `[\xB5]` and
-  `\xB5` both hold the byte `0xB5`, and neither matches `µ`, which is `C2 B5`.
-  CRuby settles the same question with the pattern's encoding and raises
-  `RegexpError` for either spelling. A range whose ends are a byte and a
-  character (`[\x80-µ]`) names neither and raises `RegexpError`.
+- **No encodings**: a pattern is a byte string read the way the build reads a
+  String, and there is no encoding to consult about a byte that starts no
+  whole character. Such a byte is that byte, inside a character class as much
+  as outside one: `[\xB5]` and `\xB5` both hold the byte `0xB5`, and neither
+  matches `µ`, which is `C2 B5`. CRuby settles the same question with the
+  pattern's encoding and raises `RegexpError` for either spelling. A range
+  whose ends are a byte and a character (`[\x80-µ]`) names neither and raises
+  `RegexpError`.
 - **ASCII case folding by default**: The `i` flag handles ASCII letters
   only unless the build defines `MRB_REGEXP_UNICODE_CASE`, which adds the
   Unicode foldings that pair one codepoint with one other. Without the

--- a/mrbgems/mruby-regexp/include/re_internal.h
+++ b/mrbgems/mruby-regexp/include/re_internal.h
@@ -228,10 +228,17 @@ void mrb_re_case_unfold_range(uint32_t lo, uint32_t hi,
                               void (*add)(void *, uint32_t, uint32_t), void *user);
 #endif
 
+/* The byte length of the character at `s`, and its codepoint: every read of a
+   run of bytes in this gem goes through these two. A subject handed over as
+   binary is one character per byte; everything else is whatever core says a
+   run of bytes spells, which is one character per byte too on a build that
+   indexes Strings by byte. So the engine reads pattern and subject the way
+   the build reads a String, and the compiler passes FALSE for `binary`, a
+   pattern being read that same way. */
 static inline int
 mrb_re_charlen(const char *s, const char *end, mrb_bool binary)
 {
-  return binary ? 1 : (int)mrb_utf8len(s, end);
+  return binary ? 1 : (int)mrb_enc_charlen(s, end);
 }
 
 static inline uint32_t
@@ -242,7 +249,7 @@ mrb_re_decode_char(const char *s, const char *end, int *len, mrb_bool binary)
     return (uint8_t)*s;
   }
   mrb_int n;
-  uint32_t cp = mrb_utf8_decode(s, end, &n);
+  uint32_t cp = mrb_enc_decode(s, end, &n);
   if (len) *len = (int)n;
   return cp;
 }
@@ -255,10 +262,10 @@ mrb_re_decode_char(const char *s, const char *end, int *len, mrb_bool binary)
    so keep the answer for a byte that starts a character here rather than in
    the call. */
 static inline mrb_bool
-mrb_re_utf8_interior_p(const char *str, const char *s, const char *end)
+mrb_re_char_interior_p(const char *str, const char *s, const char *end)
 {
   if (s >= end || ((uint8_t)*s & 0xC0) != 0x80) return FALSE;
-  return mrb_utf8_char_head(str, s, end) != s;
+  return mrb_enc_char_head(str, s, end) != s;
 }
 
 /* Execute a match.

--- a/mrbgems/mruby-regexp/mrbgem.rake
+++ b/mrbgems/mruby-regexp/mrbgem.rake
@@ -5,13 +5,6 @@ MRuby::Gem::Specification.new('mruby-regexp') do |spec|
 
   spec.add_dependency 'mruby-string-ext', :core => 'mruby-string-ext'
 
-  # The engine reads UTF-8 whatever a build's strings index by, so it asks core
-  # for the functions that answer what a run of bytes spells. They wait
-  # behind MRB_UTF8_STRING otherwise, and this build has no reason to set that:
-  # mruby-encoding is what does, and the default gembox carries this gem
-  # without it.
-  spec.build.defines << 'MRB_UTF8_SCAN'
-
   # Enumerator is optional: only String#gsub without a block reaches `to_enum`,
   # and without mruby-enumerator that is core Kernel#to_enum, which raises
   # NotImplementedError -- the same deal as Kernel#loop and String#each_char

--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -1050,9 +1050,20 @@ emit_codepoint(re_compiler *c, uint32_t cp)
     emit_char(c, (uint8_t)cp);
     return;
   }
-  if ((c->flags & RE_FLAG_IGNORECASE) && emit_cp_folded(c, cp)) return;
   char buf[4];
   int len = (int)mrb_utf8_to_buf(buf, (mrb_int)cp);
+  /* Fold only a spelling the engine reads back as the one character it spells.
+     What the fold emits is a class, and a class compares one decoded
+     character; where the build decodes bytes it never sees this one, so the
+     class would answer for a lone byte of the same number rather than for the
+     character the pattern names. The bytes below name it on either build,
+     which is the fallback a character the pattern spells already takes there,
+     through the length emit_char_folded() reads. */
+  if ((c->flags & RE_FLAG_IGNORECASE) &&
+      mrb_re_charlen(buf, buf + len, FALSE) == len &&
+      emit_cp_folded(c, cp)) {
+    return;
+  }
   for (int i = 0; i < len; i++) {
     emit(c, RE_CHAR, (uint8_t)buf[i], 0);
   }

--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -598,8 +598,8 @@ read_class_atom(re_compiler *c, re_charclass *cc, mrb_bool *is_byte)
   }
   /* Multi-byte UTF-8 leader: decode the full codepoint. An invalid leader
      decodes as itself over one byte, so it is a byte like the rest. */
-  mrb_int len = 0;
-  uint32_t cp = mrb_utf8_decode(c->p, c->src_end, &len);
+  int len = 0;
+  uint32_t cp = mrb_re_decode_char(c->p, c->src_end, &len, FALSE);
   c->p += len;
   if (len == 1) *is_byte = TRUE;
   return cp;
@@ -843,8 +843,8 @@ compute_fixed_len(re_compiler *c, uint32_t start, uint32_t end, int *chars_out)
     case RE_CHAR: {
       /* A multibyte literal is a run of one-byte RE_CHAR instructions, and
          what a byte spells depends on the bytes after it, so hand the run to
-         mrb_utf8len rather than read the lead bit alone: a continuation byte
-         no lead reaches is a character of its own, which is the rule the
+         mrb_re_charlen() rather than read the lead bit alone: a continuation
+         byte no lead reaches is a character of its own, which is the rule the
          executor rewinds by. Four bytes is the longest character there is,
          and a run never splits one. */
       char buf[4];
@@ -853,7 +853,7 @@ compute_fixed_len(re_compiler *c, uint32_t start, uint32_t end, int *chars_out)
         buf[n] = (char)c->code[pc + n].a;
         n++;
       }
-      int clen = (int)mrb_utf8len(buf, buf + n);
+      int clen = mrb_re_charlen(buf, buf + n, FALSE);
       len += clen;
       chars += 1;
       pc += (uint32_t)clen;
@@ -971,7 +971,7 @@ emit_char(re_compiler *c, uint8_t ch)
 static void
 emit_char_bytes(re_compiler *c, int ch)
 {
-  int len = (int)mrb_utf8len(c->p - 1, c->src_end);
+  int len = mrb_re_charlen(c->p - 1, c->src_end, FALSE);
   emit(c, RE_CHAR, (uint8_t)ch, 0);
   for (int i = 1; i < len; i++) {
     int b = next_char(c);
@@ -1028,8 +1028,8 @@ static mrb_bool
 emit_char_folded(re_compiler *c, int ch)
 {
   if (ch < 128 || !(c->flags & RE_FLAG_IGNORECASE)) return FALSE;
-  mrb_int len = 0;
-  uint32_t cp = mrb_utf8_decode(c->p - 1, c->src_end, &len);
+  int len = 0;
+  uint32_t cp = mrb_re_decode_char(c->p - 1, c->src_end, &len, FALSE);
   if (len == 1) return FALSE;
   if (!emit_cp_folded(c, cp)) return FALSE;
   c->p += len - 1;

--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -546,6 +546,33 @@ class_add_member(re_compiler *c, re_charclass *cc, uint32_t cp, mrb_bool is_byte
   else class_add_codepoint(c, cc, (is_byte ? RE_CLASS_BYTE : 0) | cp);
 }
 
+/* What a `\u` escape names, in the members a class can hold. On a build whose
+   characters are single bytes, a codepoint above ASCII is the bytes that spell
+   it, which is already what a character written out in the class comes to
+   there: read_class_atom() decodes one byte at a time, so `[Ā]` holds `\xC4`
+   and `\x80`. Naming the same character rather than spelling it out cannot
+   mean something else, so the escape contributes those bytes too. All but the
+   last join the class here, and the last is returned, so it can open a range
+   as any other atom would.
+
+   A range so opened is a range of bytes, since that is what both ends are.
+   The written out spelling reaches byte ends by its own route and comes to a
+   different span, which is what a range between two characters neither
+   spelling can express comes to on a build like this. */
+static uint32_t
+class_named_cp(re_compiler *c, re_charclass *cc, uint32_t cp, mrb_bool *is_byte)
+{
+  if (MRB_ENC_MULTIBYTE_P || cp < 0x80) return cp;
+
+  char buf[4];
+  int len = (int)mrb_utf8_to_buf(buf, (mrb_int)cp);
+  for (int i = 0; i < len - 1; i++) {
+    class_add_member(c, cc, (uint8_t)buf[i], TRUE);
+  }
+  *is_byte = TRUE;
+  return (uint8_t)buf[len - 1];
+}
+
 /* Read one character class atom: either an ASCII byte (0-127), a
    `\escape`, or a full multi-byte UTF-8 codepoint. Returns the value and
    advances c->p. *is_byte says which of the two the value is: TRUE for a
@@ -573,10 +600,12 @@ read_class_atom(re_compiler *c, re_charclass *cc, mrb_bool *is_byte)
          the last join the class here; the last is returned, so it can open a
          range as any other atom would: `[\u{61 62}-z]` is `a` plus `b-z`. */
       while (unicode_escape_next(c, &more, &nx)) {
-        class_add_member(c, cc, cp, FALSE);
+        mrb_bool member_byte = FALSE;
+        uint32_t member = class_named_cp(c, cc, cp, &member_byte);
+        class_add_member(c, cc, member, member_byte);
         cp = nx;
       }
-      return cp;
+      return class_named_cp(c, cc, cp, is_byte);
     }
     /* A backslash before a multibyte character has no escape meaning, so let
        the decode below read the whole codepoint: [\Ā] is [Ā]. parse_escape()

--- a/mrbgems/mruby-regexp/src/re_exec.c
+++ b/mrbgems/mruby-regexp/src/re_exec.c
@@ -272,7 +272,7 @@ add_thread(pike_state *s, re_threadlist *list,
          seeding loop applies to where a match opens. Killing the thread
          rather than the attempt lets a longer branch match instead. */
       if (inst.offset == 1 && !s->binary && sp < s->str_end &&
-          mrb_re_utf8_interior_p(s->str, sp, s->str_end)) {
+          mrb_re_char_interior_p(s->str, sp, s->str_end)) {
         return;
       }
       if (!s->match_only) {
@@ -436,7 +436,7 @@ pike_vm(mrb_state *mrb, const mrb_regexp_pattern *pat,
          Threads seeded earlier are still stepped at this position, so the
          test guards the seeding alone and never skips the iteration. */
       if (s.binary || sp >= str_end ||
-          !mrb_re_utf8_interior_p(str, sp, str_end)) {
+          !mrb_re_char_interior_p(str, sp, str_end)) {
         int slot = match_only ? 0 : pool_alloc(&s);
         if (!match_only) memset(CAP(&s, slot), -1, sizeof(int) * ncap);
         advance_gen(&s);
@@ -584,7 +584,7 @@ pike_vm(mrb_state *mrb, const mrb_regexp_pattern *pat,
  * Where the lookbehind at pc starts matching from: sp rewound by the byte
  * count in the opcode for a binary subject, and otherwise by the character
  * count in the RE_LB_WIDTH that follows it. The backward walk steps over
- * continuation bytes with mrb_re_utf8_interior_p(), which keeps it on the
+ * continuation bytes with mrb_re_char_interior_p(), which keeps it on the
  * boundaries the forward decode uses, broken input included. Returns NULL
  * when the text before sp runs out first.
  */
@@ -601,7 +601,7 @@ lookbehind_start(const mrb_regexp_pattern *pat, const char *str,
   while (nchars > 0) {
     if (sp <= str) return NULL;
     sp--;
-    while (sp > str && mrb_re_utf8_interior_p(str, sp, str_end)) sp--;
+    while (sp > str && mrb_re_char_interior_p(str, sp, str_end)) sp--;
     nchars--;
   }
   return sp;
@@ -685,7 +685,7 @@ bt_match(const mrb_regexp_pattern *pat, const char *str, const char *str_end,
            (see the Pike VM case). Failing here backtracks into the other
            branches, so a longer one can still match. */
         if (slot == 1 && !binary && sp < str_end &&
-            mrb_re_utf8_interior_p(str, sp, str_end)) {
+            mrb_re_char_interior_p(str, sp, str_end)) {
           return FALSE;
         }
         if (slot < ncap) {
@@ -824,7 +824,7 @@ backtrack_exec(mrb_state *mrb, const mrb_regexp_pattern *pat,
       while (sp < str_end && !FIRST_BYTE_OK(pat, (uint8_t)*sp)) sp++;
       if (sp > str_end) break;
     }
-    if (!binary && sp < str_end && mrb_re_utf8_interior_p(str, sp, str_end)) {
+    if (!binary && sp < str_end && mrb_re_char_interior_p(str, sp, str_end)) {
       continue;
     }
     memset(caps, -1, sizeof(int) * ncap);
@@ -856,13 +856,13 @@ literal_exec(const mrb_regexp_pattern *pat,
   while (sp + plen <= str_end) {
     const char *found = (const char*)memchr(sp, pat->prefix[0], str_end - sp);
     if (!found || found + plen > str_end) return 0;
-    if (!binary && mrb_re_utf8_interior_p(str, found, str_end)) {
+    if (!binary && mrb_re_char_interior_p(str, found, str_end)) {
       sp = found + 1;  /* not a char boundary, same rule as the other engines */
       continue;
     }
     if (plen == 1 || memcmp(found + 1, pat->prefix + 1, plen - 1) == 0) {
       if (!binary && found + plen < str_end &&
-          mrb_re_utf8_interior_p(str, found + plen, str_end)) {
+          mrb_re_char_interior_p(str, found + plen, str_end)) {
         sp = found + 1;  /* ends inside a character, same rule as the end of
                             group 0 in the other engines */
         continue;

--- a/mrbgems/mruby-regexp/test/ascii_case.rb
+++ b/mrbgems/mruby-regexp/test/ascii_case.rb
@@ -72,10 +72,17 @@ assert("Regexp - /i leaves alone what it can answer") do
   if __ENCODING__ == "UTF-8"
     assert_true(/\u{212a}/i.match?("k"))
     assert_true(/\u{212a}/i.match?("K"))
+    # A class holds the character the escape names, so the fold reaches the
+    # ASCII letter from it.
+    assert_true(/[\u{212a}]/i.match?("k"))
+    assert_false(/[^\u{212a}]/i.match?("K"))
   else
     assert_true(/\u{212a}/i.match?("\u{212a}"))
     assert_false(/\u{212a}/i.match?("k"))
+    # A class holds the bytes of that character instead, and a byte has no
+    # case, so /i adds nothing and the letter is not reached.
+    assert_true(/[\u{212a}]/i.match?("\u{212a}"))
+    assert_false(/[\u{212a}]/i.match?("k"))
+    assert_true(/[^\u{212a}]/i.match?("K"))
   end
-  assert_true(/[\u{212a}]/i.match?("k"))
-  assert_false(/[^\u{212a}]/i.match?("K"))
 end

--- a/mrbgems/mruby-regexp/test/ascii_case.rb
+++ b/mrbgems/mruby-regexp/test/ascii_case.rb
@@ -65,9 +65,17 @@ assert("Regexp - /i leaves alone what it can answer") do
   assert_false(/Ā/.match?("ā"))
   assert_true(/[^Ā]/.match?("ā"))
   # U+212A folds to ASCII 'k', which this build has without the table, so the
-  # `\u` spelling of it compiles and reaches both cases of the letter.
-  assert_true(/\u{212a}/i.match?("k"))
-  assert_true(/\u{212a}/i.match?("K"))
+  # `\u` spelling of it compiles and reaches both cases of the letter. Where
+  # the build reads its strings by byte the escape is the three bytes of the
+  # character instead, and /i adds nothing to a character read that way, so it
+  # matches what it names exactly as it does without /i.
+  if __ENCODING__ == "UTF-8"
+    assert_true(/\u{212a}/i.match?("k"))
+    assert_true(/\u{212a}/i.match?("K"))
+  else
+    assert_true(/\u{212a}/i.match?("\u{212a}"))
+    assert_false(/\u{212a}/i.match?("k"))
+  end
   assert_true(/[\u{212a}]/i.match?("k"))
   assert_false(/[^\u{212a}]/i.match?("K"))
 end

--- a/mrbgems/mruby-regexp/test/ascii_case.rb
+++ b/mrbgems/mruby-regexp/test/ascii_case.rb
@@ -5,6 +5,10 @@ assert("Regexp - /i refuses what ASCII folding cannot answer") do
   # Folding ASCII and carrying on would answer wrongly rather than narrowly:
   # the missing fold is a missed match in the plain and class forms, and the
   # same gap with the sign flipped is a false accept in the negated class.
+  #
+  # A build that reads its strings by byte has nothing to refuse: every source
+  # below is a run of bytes there, and a byte is no character to fold.
+  skip unless __ENCODING__ == "UTF-8"
   assert_raise(RegexpError) { Regexp.new("Ā", Regexp::IGNORECASE) }
   assert_raise(RegexpError) { Regexp.new("[Ā]", Regexp::IGNORECASE) }
   assert_raise(RegexpError) { Regexp.new("[^Ā]", Regexp::IGNORECASE) }

--- a/mrbgems/mruby-regexp/test/regexp_syntax.rb
+++ b/mrbgems/mruby-regexp/test/regexp_syntax.rb
@@ -221,6 +221,9 @@ assert("Regexp - /i folds an ASCII letter's class whole") do
   # folding "ASCII only" covers the whole of the equivalence class an ASCII
   # letter belongs to rather than the part of it that is ASCII. Left out, the
   # negated forms below would accept what they were written to reject.
+  # Both sources lie above ASCII, so they are characters to fold only where
+  # the pattern and the subject are read as characters.
+  skip unless __ENCODING__ == "UTF-8"
   kelvin = "K"
   long_s = "ſ"
   assert_true Regexp.new("k", Regexp::IGNORECASE).match?(kelvin)
@@ -829,6 +832,9 @@ end
 assert("Regexp - lookbehind over a class that can match a multibyte character") do
   # A class consumes exactly one character whatever its members are, so the
   # rewind steps back that many characters rather than assuming a byte each.
+  # A build that reads its strings by byte has one byte per character, so it
+  # has nothing here to tell the two rewinds apart.
+  skip unless __ENCODING__ == "UTF-8"
   assert_equal "x", "Āx".match(/(?<=[Ā])x/)[0]
   assert_nil "ax".match(/(?<=[Ā])x/)
   assert_equal "x", "Āx".match(/(?<=[Ā-ă])x/)[0]
@@ -859,7 +865,10 @@ end
 assert("Regexp - lookbehind against a binary subject rewinds by bytes") do
   # A binary subject advances one byte at a time, so the same compiled
   # pattern rewinds by its byte count there: two for the literal Ā, and one
-  # for a class, which is handed the raw byte as its codepoint.
+  # for a class, which is handed the raw byte as its codepoint. What this
+  # contrasts with is the character rewind, which a build reading its strings
+  # by byte does not have.
+  skip unless __ENCODING__ == "UTF-8"
   bin = "Āx".b
   assert_equal "x", bin.match(/(?<=Ā)x/)[0]
   assert_nil bin.match(/(?<=[Ā])x/)

--- a/mrbgems/mruby-regexp/test/regexp_utf8.rb
+++ b/mrbgems/mruby-regexp/test/regexp_utf8.rb
@@ -408,6 +408,27 @@ assert("Regexp - \\u escapes in a character class") do
   assert_equal ["c"], "abc".scan(/[^\u{61 62}]/)
 end
 
+assert("Regexp - a \\u escape in a class names what spelling it out names") do
+  # A class member is one character, and on a build whose characters are single
+  # bytes a character above ASCII is not one: `[Ā]` holds the two bytes that
+  # spell it, since read_class_atom() decodes one byte at a time there. Naming
+  # that character with an escape has to come to the same members, or the two
+  # halves of one pattern disagree about what the pattern holds.
+  skip if __ENCODING__ == "UTF-8"
+  spelled = Regexp.new("[\u{100}]")           # the character, written out
+  named = Regexp.new("[\\u{100}]")            # the same character, named
+  ["\u{100}", "\xC4".b, "\x80".b].each do |subject|
+    assert_equal spelled.match?(subject), named.match?(subject)
+  end
+  # The character the escape names is found through the bytes it holds, which
+  # is what the written out spelling answers too.
+  assert_true named.match?("\u{100}")
+  # An ASCII codepoint is a member of its own on either build, and a list still
+  # gives every codepoint a membership with the last one able to open a range.
+  assert_equal ["a", "b"], "abc".scan(/[\u{61 62}]/)
+  assert_equal ["a", "b", "c"], "abc-".scan(/[\u{61 62}-z]/)
+end
+
 assert("Regexp - malformed \\u escapes") do
   # each of these is a RegexpError in CRuby rather than a shorter codepoint
   # or literal text

--- a/mrbgems/mruby-regexp/test/regexp_utf8.rb
+++ b/mrbgems/mruby-regexp/test/regexp_utf8.rb
@@ -1,4 +1,13 @@
+# What a run of bytes spells is a question only a build that reads UTF-8 can
+# answer: core carries the scan behind MRB_UTF8_STRING, and a build without it
+# reads a String one byte per character, so the engine reads pattern and
+# subject that way too. Every block below that puts that question skips there,
+# whether it puts it to a subject read as UTF-8 or through a pattern spelling
+# a character in more than one byte. What holds on either build, a
+# byte-indexed subject among it, runs unguarded.
+
 assert("Regexp - dot advances by string mode") do
+  skip unless __ENCODING__ == "UTF-8"
   str = "\xC3\xA9x"
   assert_equal [[0xC3, 0xA9], [0x78]], str.scan(/./).map { |m| m.bytes }
   assert_equal [0x5A, 0x78], str.sub(/./, "Z").bytes
@@ -22,6 +31,7 @@ assert("Regexp - character class range across the ASCII boundary") do
   # A range from an ASCII bound to a non-ASCII one used to be stored whole in
   # the codepoint list, which the matcher never reads below 128, so the ASCII
   # half of the range matched nothing.
+  skip unless __ENCODING__ == "UTF-8"
   assert_equal "a", "a".match(/[a-Ā]/)[0]
   assert_equal "z", "z".match(/[a-Ā]/)[0]
   assert_equal "{", "{".match(/[a-Ā]/)[0]      # 0x7b, inside a-Ā
@@ -55,6 +65,7 @@ assert("Regexp - /i does not read a byte above 127 as a character") do
   # A byte that starts no whole character decodes as itself, so the folding
   # path would take a lone 0xB5 for U+00B5 and answer /i for a character the
   # pattern does not hold. A literal compares bytes, with or without /i.
+  skip unless __ENCODING__ == "UTF-8"
   micro = "\xB5"        # U+00B5 is "\xC2\xB5"; the byte on its own is not it
   assert_nil (Regexp.new(micro, Regexp::IGNORECASE) =~ "\u00B5")
   # A sequence cut short by the end of the pattern reads the same way.
@@ -78,6 +89,7 @@ assert("Regexp - quantifier on a multibyte literal") do
   # The bytes of a multibyte literal used to be separate atoms, so a
   # quantifier bound to the last one: /Ā+/ was \xC4(\x80)+ and stopped after
   # one Ā. The byte counts below are what tells the two apart.
+  skip unless __ENCODING__ == "UTF-8"
   assert_equal 4, "ĀĀ".match(/Ā+/)[0].bytesize
   assert_equal 4, "ĀĀ".match(/Ā*/)[0].bytesize
   assert_equal 6, "ĀĀĀ".match(/Ā{2,3}/)[0].bytesize
@@ -104,6 +116,7 @@ assert("Regexp - quantifier on an escaped multibyte literal") do
   # before the gem sees the pattern: /\Ā/.source is the two bytes of Ā alone.
   # A pattern built at runtime arrives through Regexp.new with the backslash
   # still in it.
+  skip unless __ENCODING__ == "UTF-8"
   assert_equal 4, Regexp.new("\\Ā+").match("ĀĀ")[0].bytesize
   assert_equal 6, Regexp.new("\\ĀĀĀ").match("ĀĀĀ")[0].bytesize
   assert_true Regexp.new("\\Ā{2}").match?("ĀĀ")
@@ -132,6 +145,7 @@ assert("Regexp - quantifier on an invalid multibyte literal") do
   # to is settled when the pattern is compiled, so the subjects carrying these
   # bytes are byte-indexed, where each of them is a byte and the byte counts
   # they report are offsets into what was asked.
+  skip unless __ENCODING__ == "UTF-8"
   lead2 = "\xC4"  # starts a two byte character
   lead3 = "\xE3"  # starts a three byte character
   cont = "\x81"   # continuation byte
@@ -164,6 +178,7 @@ assert("Regexp - a byte that belongs to no character is a match position") do
   # pre_match used to be needed for.
   # Inside a character there is still no match position, which is what a
   # subject read as UTF-8 is left to answer.
+  skip unless __ENCODING__ == "UTF-8"
   assert_nil "あ".match(Regexp.new("\x81"))
   assert_nil "あ".match(Regexp.new("\x82"))
   assert_nil "\u{1D54F}".match(Regexp.new("\x95"))
@@ -183,6 +198,7 @@ assert("Regexp - an attempt in flight opens no match position inside a character
   # for it only ran while nothing was in flight. The branch of `.?` that
   # consumes the character parks a thread past it, and the attempt seeded at
   # the shared byte then matched it on its own, cutting "ĵ" in half.
+  skip unless __ENCODING__ == "UTF-8"
   assert_nil "ĵ".match(/.?[µ]/)
   assert_nil "ĵ".gsub(/.?[µ]/, "!").match(/!/)
   assert_nil ("あ" + "ĵ").match(/.?[µ]/)
@@ -264,6 +280,7 @@ assert("Regexp - a match does not end inside a character") do
   # pattern holding a byte that reaches no character ends its match in the
   # middle of one. "ĵ" is C4 B5, and a pattern of the single byte C4 used to
   # match its lead byte alone and hand back half a character.
+  skip unless __ENCODING__ == "UTF-8"
   j = "ĵ"
   assert_nil j.match(Regexp.new("\xc4"))          # literal fast path
   assert_nil ("x" + j).match(Regexp.new("\xc4"))
@@ -377,6 +394,7 @@ assert("Regexp - \\u escapes") do
 end
 
 assert("Regexp - \\u escapes in a character class") do
+  skip unless __ENCODING__ == "UTF-8"
   assert_equal 0, (/[\u00b5]/ =~ "\xc2\xb5")
   assert_nil (/[\u00b5]/ =~ "u")
   assert_equal 0, (/[\u{3042}-\u{3044}]/ =~ "\xe3\x81\x83")
@@ -447,6 +465,7 @@ assert("Regexp - overlong UTF-8 is not the character it spells") do
   # not spell, whichever way the subject is indexed.
   # the pattern side decodes through the same helper, and its subject here is
   # whole UTF-8
+  skip unless __ENCODING__ == "UTF-8"
   assert_false Regexp.new("[\xC0\xBC]").match?("<")
   # the shortest spelling on each side of the RFC 3629 bounds is still one
   # character
@@ -487,6 +506,7 @@ assert("Regexp - a pattern byte that starts no character is a byte in a class") 
   # the subject side too, which is what each pair below turns on: the byte
   # answers for itself, and the character that carries it answers for the
   # character.
+  skip unless __ENCODING__ == "UTF-8"
   mu = "\xC2\xB5"  # U+00B5 MICRO SIGN, two bytes
   assert_nil (mu =~ Regexp.new("[\xB5]"))
   assert_nil (mu =~ Regexp.new("\xB5"))
@@ -541,8 +561,10 @@ assert("Regexp - large non-ASCII character class does not overflow") do
   # a class listing tens of thousands of non-ASCII codepoints used to
   # overflow the 16-bit range capacity (32768 * 2 wrapped to 0, feeding a
   # size-0 realloc and a write through NULL). See issue #6937.
-  # Patterns are always parsed as UTF-8, so build the bytes directly to
-  # exercise this in both MRB_UTF8_STRING and byte-string builds.
+  # Only a build that reads its patterns as UTF-8 can list that many members:
+  # where a pattern is bytes there are 128 non-ASCII members in all, so the
+  # loop below builds a handful of ranges and nothing can overflow.
+  skip unless __ENCODING__ == "UTF-8"
   # append_as_bytes lays raw bytes into the string without moving how it is
   # read; a sum of Integer#chr pieces would come back read as bytes, and a
   # byte-read subject is answered by the byte on its own rather than the

--- a/mrbgems/mruby-regexp/test/string_regexp.rb
+++ b/mrbgems/mruby-regexp/test/string_regexp.rb
@@ -724,9 +724,19 @@ assert("String#split with empty regexp") do
   assert_equal ["a", "b", "c", ""], "abc".split(//, -1)
   assert_equal [], "".split(//, -1)
   assert_equal ["a", ""], "a".split(//, -1)
-  assert_equal ["あ", "い"], "あい".split(//)
-  assert_equal ["あ", "い"], "あい".split(//, 2)
-  assert_equal ["あ", "い", ""], "あい".split(//, -1)
+  # An empty pattern splits at every position the subject has, which is one
+  # per character where the build reads characters and one per byte where it
+  # does not.
+  if __ENCODING__ == "UTF-8"
+    assert_equal ["あ", "い"], "あい".split(//)
+    assert_equal ["あ", "い"], "あい".split(//, 2)
+    assert_equal ["あ", "い", ""], "あい".split(//, -1)
+  else
+    bytes = ["\xE3", "\x81", "\x82", "\xE3", "\x81", "\x84"]
+    assert_equal bytes, "あい".split(//)
+    assert_equal ["\xE3", "\x81\x82\xE3\x81\x84"], "あい".split(//, 2)
+    assert_equal bytes + [""], "あい".split(//, -1)
+  end
 end
 
 assert("String#split with invalid regexp pattern type") do

--- a/mrbgems/mruby-regexp/test/unicode_case.rb
+++ b/mrbgems/mruby-regexp/test/unicode_case.rb
@@ -2,6 +2,11 @@
 # see the gem's mrbgem.rake. Without the option every assertion here would
 # fail, since /i then folds ASCII letters and nothing else.
 assert("Regexp - Unicode case folding under /i") do
+  # Every source and counterpart here lies above ASCII, so they are characters
+  # to fold only where the pattern and the subject are read as characters. A
+  # build that reads its strings by byte has the table and nothing to spend it
+  # on: the bytes below spell no character it can fold.
+  skip unless __ENCODING__ == "UTF-8"
   # A literal and its counterpart, in both directions.
   assert_equal "ā", "ā".match(/Ā/i)[0]
   assert_equal "Ā", "Ā".match(/ā/i)[0]

--- a/src/string.c
+++ b/src/string.c
@@ -380,12 +380,10 @@ mrb_utf8_to_buf(char *buf, mrb_int cp)
   return 0;  /* above U+10FFFF */
 }
 
-/* What a run of bytes spells is a question apart from whether String indexes
-   by character, and mruby-regexp asks the first one whatever the build does.
-   So this much is here for any build that asks, through MRB_UTF8_SCAN or
-   MRB_UTF8_STRING; what indexes a string by character waits behind the latter
-   alone, below. A build with neither carries none of it. */
-#if defined(MRB_UTF8_STRING) || defined(MRB_UTF8_SCAN)
+/* UTF-8: what a run of bytes spells, and what a string holds character by
+   character. Only a build that indexes strings by character has to answer
+   either, so a build without MRB_UTF8_STRING carries none of it. */
+#ifdef MRB_UTF8_STRING
 
 #define utf8_islead(c) ((unsigned char)((c)&0xc0) != 0x80)
 
@@ -484,10 +482,6 @@ mrb_utf8_decode(const char *p, const char *e, mrb_int *lenp)
     return c;  /* ASCII, or invalid/truncated byte returned as-is */
   }
 }
-
-#endif  /* MRB_UTF8_STRING || MRB_UTF8_SCAN */
-
-#ifdef MRB_UTF8_STRING
 
 #define NOASCII(c) ((c) & 0x80)
 


### PR DESCRIPTION
`MRB_UTF8_SCAN` let `mruby-regexp` reach core's UTF-8 scan by defining a macro
from its `mrbgem.rake`, so a gem decided how core compiled. Nothing else in
the tree asks for the scan. This retires the macro and puts the whole of a
build on one side: where `MRB_UTF8_STRING` is defined the engine reads
characters, and where it is not it reads bytes, pattern included.

### What changes for a build without `MRB_UTF8_STRING`

The engine already read a binary subject one byte per character. This puts the
pattern and every other string there on the same side:

```ruby
/./.match("あ")[0].bytesize   # 3 before, 1 now
/Ā/                           # one atom before, two atoms of one byte each now
/Ā/i                          # RegexpError before, ASCII folding now
"あいう".gsub(/./) { "x" }    # "xxx" before, "xxxxxxxxx" now
[\u{3042}]                    # held the character before, holds its bytes now
```

The last one follows from the second. A class member is one character, so a
character above ASCII in a class is the bytes that spell it, and `[Ā]` answers
for either of them rather than for the pair. A `\u` escape naming the same
character comes to the same members.

That is what CRuby answers for a string it reads as bytes:

```ruby
s = "\xE3\x81\x82".dup.force_encoding("ASCII-8BIT")
s =~ /./n
$~[0].bytesize    # => 1
```

So the build that indexes its Strings by byte stops being the one build where
`String#length` counts bytes and a Regexp counts characters.

### How

Core answers what a run of bytes spells, rather than the gem asking for a
scan it then has to guard:

```c
static inline mrb_int
mrb_enc_charlen(const char *p, const char *e)
{
#ifdef MRB_UTF8_STRING
  return mrb_utf8len(p, e);
#else
  (void)p; (void)e;
  return 1;
#endif
}
```

`mrb_enc_char_head()` and `mrb_enc_decode()` are the same shape. They sit
outside the `MRB_UTF8_STRING` block the way `mrb_str_char_len()` and
`mrb_str_valid_encoding_p()` already do, so the gem carries no `#ifdef` of its
own and a second codec would be a change in one place rather than in every
caller. They are inline because a matcher asks them once per byte: out of line
the byte build carries 3,320 bytes of text more and the build with
`mruby-encoding` 2,016.

The spelling of a codepoint has no such neutral answer and stays UTF-8, so
`\u{...}` names the same bytes on either build.

Four commits:

1. `mruby-regexp: read a pattern through the engine's character helpers`. The
   executor already asked through `mrb_re_charlen()` and
   `mrb_re_decode_char()`; the compiler asked core directly, so one question
   had two spellings. No behavior change.
2. `string.c: keep the UTF-8 scan behind MRB_UTF8_STRING alone`. The macro
   goes, `mrb_enc_*` arrives, and the gem reads through it.
3. `mruby-regexp: fold a named codepoint only where it is read back whole`. A
   bug the second commit exposes: `\u{e9}` under `/i` compiled to a class, and
   a class compares one decoded character, so where the build decodes bytes it
   answered for a lone `0xE9` byte and never for the character the escape
   names. Adding `/i` stopped the pattern matching what it named. It now takes
   the fold only where the spelling reads back as the one character it spells.
4. `mruby-regexp: name in a class what spelling it out names`. The class path
   had the same gap and the tests did not reach it: `[\u{3042}]` compiled to a
   member the matcher never produces on a byte build, so it matched nothing at
   all, silently, with or without `/i`, while `[あ]` written out held the bytes
   and answered. Found by review on this PR.

### Size

The `byte-string` build of `ci/gcc-clang`, x86_64-linux, gcc 13.3.0, text
segment, master `31bc19bf2` on the left.

Without `MRB_UTF8_STRING`:

```
src/string.o      37072 ->  36032   -1040
re_compile.o      22657 ->  22577     -80
re_exec.o         15442 ->  13537   -1905
re_utf8.o           198 ->    198       0
regexp.o          18005 ->  17621    -384
                                   ------
                                    -3409
```

With `MRB_UTF8_STRING`, the same five come to `-16` bytes, so the reading a
build already does costs it nothing.

### Tests

`MRUBY_CONFIG=ci/gcc-clang rake -m test`, all four builds and the bintests,
KO 0 and Crash 0:

```
byte-string   Total 2240   Skip 46
full-debug    Total 2303   Skip 3
bintest       Total 2304   Skip 11   + 117 bintests
cxx_abi       Total 2304   Skip 11
```

`byte-string` skips 17 more than master's 29. Those are the assertions that put a
question a byte build no longer takes: a subject read as UTF-8, or a pattern
spelling a character in more than one byte. Two of them say what they expect
of a byte build instead rather than skip, `String#split` with an empty pattern
and the character class overflow guard, since both still hold something there.

### What this reverses

`MRB_UTF8_SCAN` is two days old. `56a55f56d` added it so the gem could drop a
UTF-8 decoder of its own and call core's, which `47836c20d` had just put
behind `MRB_UTF8_STRING`. Retiring the macro is small.

The property the macro was added to preserve is not. `mruby-regexp` has read a
pattern as UTF-8 on every build since `1cfa153ff` created the gem, first
through that decoder of its own, and `56a55f56d` kept it deliberately: "the
engine reads UTF-8 whatever a build's strings index by, and the default gembox
already builds it that way".

So the question here is not whether a two day old macro should go. It is
whether reading a pattern as UTF-8 is right for a build whose Strings are
bytes, which has held since March and has been carried forward rather than
weighed on its own.

### What a class comes to here

A character class is a set of single characters, and on a build whose
characters are single bytes a character above ASCII is not one of them. It
becomes the bytes that spell it, so a class answers for each of them on its
own:

```ruby
/[Ā]/.match?("Ā")        # true
/[Ā]/.match?("\xC4".b)   # true, and Ā is not what that is
```

That is the byte reading of a class applied evenly, and `read_class_atom()`
already does it for any character it decodes in one byte. What changes here is
how often that happens: on master only a byte that starts no character reaches
it, and on a byte build every non-ASCII character does.

The way out of it is to keep the class holding characters and compile it down
to the byte sequences that spell them, so `[Ā]` answers for `Ā` alone. I built
that to find out what it costs, and the measurements are in [this gist][g].
The answer is not size: the lowering costs 3,136 bytes of text on the byte
build, which is most of what the table above removes, so the two come out
level. It is these three.

- Lowering a class needs the pattern read as UTF-8. Grouping `\xC4 \x80` into
  one member cannot be justified from the bytes, so the gem takes back the
  decoder `56a55f56d` removed and the build stops reading its pattern the way
  it reads a String, which is the whole of what this PR is for.
- Lowering only the positive form is cheap and wrong: with the negated form
  left as it is, `[^Ā]` matches `Ā`, the class accepting the character it was
  written to reject.
- Lowering the negated form means complementing over characters first, which
  turns `[^a]` and `\W` from one instruction into 43, costs 2.5x to 3.9x on
  the matches that use them, grows a compiled `Regexp` from 1,484 bytes to
  4,948, and stops `[^a]` matching a byte that spells no character. On a build
  whose reason to exist is binary data, that last one is backwards.

Gating the lowering to a class that names a character it cannot hold keeps the
speed and keeps the bytes, at 496 bytes of text. But then `[^a]` answers over
bytes while `[^Ā]` answers over characters, which is this PR's split moved from
the positive form to the negated one rather than closed.

So a class over-matches on a byte build, and I take that as the price of a
build reading one way throughout, rather than as a reason to have it read its
pattern one way and its subject another.

[g]: https://gist.github.com/takumin/8ba99d9d0abcaab687d00259ae6b6cae

### The decision this needs

Whether a build whose Strings index by byte should read its patterns the same
way. Everything above follows from that one answer, including the class.

If it should, this is ready to leave draft. If a class holding whole characters
matters more than a build reading one way throughout, then what master does is
the price of it and I will close this instead.

### Not in this PR

`MRB_REGEXP_UNICODE_CASE` and `re_cased.h` stay as they are. With the fourth
commit in, no pattern reaches their refusal on a byte build any more, which
makes them dead weight there, but tying the case data to what the engine reads
is a separate question and a separate change.





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Regular expressions now support encoding-aware matching in both UTF-8 and byte-oriented builds.
  * Unicode escapes and character classes behave consistently with the active string encoding.
  * String splitting and character indexing reflect UTF-8 characters or individual bytes as appropriate.

* **Bug Fixes**
  * Improved matching boundaries, lookbehind behavior, case folding, and handling of multibyte or malformed characters.

* **Documentation**
  * Updated regexp documentation to clarify encoding-dependent matching behavior and examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->