### PR TITLE
vm.c: remove the unexpanded integer case macros

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -3310,17 +3310,6 @@ RETRY_TRY_BLOCK:
   }                                                                         \
 } while(0);                                                                 \
   NEXT;
-#define OP_MATH_CASE_INTEGER(op_name)                                       \
-  case TYPES2(MRB_TT_INTEGER, MRB_TT_INTEGER):                              \
-    {                                                                       \
-      mrb_int x = mrb_integer(regs[a]), y = mrb_integer(regs[a+1]), z;      \
-      if (mrb_int_##op_name##_overflow(x, y, &z)) {                         \
-        OP_MATH_OVERFLOW_INT(op_name,x,y);                                  \
-      }                                                                     \
-      else                                                                  \
-        VM_SET_INT_VALUE(regs[a], z);                                       \
-    }                                                                       \
-    break
 #ifdef MRB_NO_FLOAT
 #define OP_MATH_CASE_FLOAT(op_name, t1, t2) (void)0
 #else
@@ -3391,17 +3380,6 @@ RETRY_TRY_BLOCK:
   }                                                                         \
 } while(0);                                                                 \
   NEXT;
-#define OP_MATHI_CASE_INTEGER(op_name)                                      \
-  case MRB_TT_INTEGER:                                                      \
-    {                                                                       \
-      mrb_int x = mrb_integer(regs[a]), y = (mrb_int)b, z;                  \
-      if (mrb_int_##op_name##_overflow(x, y, &z)) {                         \
-        OP_MATH_OVERFLOW_INT(op_name,x,y);                                  \
-      }                                                                     \
-      else                                                                  \
-        VM_SET_INT_VALUE(regs[a], z);                                       \
-    }                                                                       \
-    break
 #ifdef MRB_NO_FLOAT
 #define OP_MATHI_CASE_FLOAT(op_name) (void)0
 #else


### PR DESCRIPTION
`OP_MATH_CASE_INTEGER()` and `OP_MATHI_CASE_INTEGER()` sit alongside `OP_MATH()` and `OP_MATHI()` in `src/vm.c`, but neither macro is ever expanded.

Both dispatchers handle integer operands before the switch, in the `mrb_likely()` fast path:

```c
#define OP_MATH(op_name) do {                                               \
  uint16_t tt = TYPES2(mrb_type(regs[a]),mrb_type(regs[a+1]));              \
  if (mrb_likely(tt == TYPES2(MRB_TT_INTEGER, MRB_TT_INTEGER))) {           \
    ...                                                                     \
  }                                                                         \
  else switch (tt) {                                                        \
    OP_MATH_CASE_FLOAT(op_name, integer, float);                            \
    ...
```

So the switch only ever sees the non-integer type combinations, and the `case TYPES2(MRB_TT_INTEGER, MRB_TT_INTEGER):` / `case MRB_TT_INTEGER:` labels these two macros would emit have nowhere to be placed. The switch statements list `OP_MATH_CASE_FLOAT` / `OP_MATHI_CASE_FLOAT` and `OP_MATH_CASE_STRING_##op_name`, never the `_INTEGER` forms.

What they still contain is a second copy of that fast path: the same `mrb_int_##op_name##_overflow()` check, the same `OP_MATH_OVERFLOW_INT()` bigint promotion, the same `VM_SET_INT_VALUE()` boxing. Nothing ties the copies to the live code, so a change to the fast path leaves them stale, and a reader tracing the integer arithmetic path has to determine which of the two spellings actually runs.

Verification that this is a text-only change:

* `git grep -In "_CASE_INTEGER"` over the tree returns only the two `#define` lines. No token-pasting construct anywhere can assemble either name; the one nearby paste, `OP_MATH_CASE_STRING_##op_name()`, is fed `add`, `sub` or `mul`.
* `gcc -fsyntax-only -Wunused-macros` on `src/vm.c` reports both macros as unused.
* With the definitions removed, `gcc -E -P` over `src/vm.c` produces output byte-identical to the base revision, for the default build and for `MRB_NO_DIRECT_THREADING`, `MRB_USE_FLOAT32`, `MRB_NO_FLOAT`, `MRB_INT32`, `MRB_INT64`, `MRB_NAN_BOXING`, `MRB_WORD_BOXING` and `MRB_USE_BIGINT`. The preprocessed line counts range from 6860 to 7259 across those configurations, so they really do select different code and the identity is not vacuous.
* Under `MRB_DEBUG` the output is identical *except for* `__LINE__`. `include/mruby.h` maps `mrb_assert(p)` to `assert(p)`, which records the line number, so the four assertion sites below the deletion point shift up by exactly 22 lines (3693 to 3671, 3708 to 3686, 3953 to 3931, 4016 to 3994). Preprocessing both revisions through the same path so `__FILE__` matches, the diff is 8 lines and every one of them is assertion text. That is the only way removing an unexpanded `#define` can affect `-E` output.

No helper is left behind unused: `OP_MATH_OVERFLOW_INT`, `VM_SET_INT_VALUE` and `TYPES2` all remain in use by the live `OP_MATH()` / `OP_MATHI()` bodies, and the inline `case MRB_TT_INTEGER:` in `OP_MATHILV()` is a separate, live label this does not touch. The change is confined to the two definitions.

`rake -m test` passes with no change in counts: mrbtest `Total: 2075, OK: 2046, KO: 0, Crash: 0, Warning: 0, Skip: 29`, bintest `Total: 105, KO: 0, Crash: 0`.
