### PR TITLE
numeric.c: make `Integer#eql?` answer false for a Float, big integers included

### DIFF
--- a/mrbgems/mruby-bigint/test/bigint.rb
+++ b/mrbgems/mruby-bigint/test/bigint.rb
@@ -31,6 +31,25 @@ assert 'Bigint ==' do
   end
 end
 
+assert 'Bigint eql?' do
+  n = 1<<70
+
+  assert_true n.eql?(1<<70)
+  assert_false n.eql?(1<<71)
+  assert_false n.eql?(0)
+  assert_false n.eql?(-n)
+
+  assert_false n.eql?('x')
+  assert_false n.eql?(nil)
+
+  # `eql?` compares class as well as value, so an equal Float is not eql? to a
+  # big integer even though `==` holds between the two.
+  if Object.const_defined?(:Float)
+    assert_false n.eql?(2.0**70)
+    assert_true n == (2.0**70)
+  end
+end
+
 assert 'Bigint +' do
   n = 1<<65
   assert_equal 36893488147419103232, n + 0

--- a/src/numeric.c
+++ b/src/numeric.c
@@ -638,6 +638,9 @@ num_eql(mrb_state *mrb, mrb_value x)
 
 #ifdef MRB_USE_BIGINT
   if (mrb_bigint_p(x)) {
+    /* `eql?` compares class as well as value, and `mrb_bint_cmp()` compares a
+       Float argument numerically, so reject non-Integer arguments up front. */
+    if (!mrb_bigint_p(y) && !mrb_integer_p(y)) return mrb_false_value();
     return mrb_bool_value(mrb_bint_cmp(mrb, x, y) == 0);
   }
 #endif

--- a/test/t/integer.rb
+++ b/test/t/integer.rb
@@ -190,6 +190,12 @@ assert('Integer#eql?', '15.2.8.3.16') do
   assert_true a
   assert_false b
   assert_false c
+
+  # `eql?` compares class as well as value, unlike `==`.
+  if Object.const_defined?(:Float)
+    assert_false 1.eql?(1.0)
+    assert_true 1 == 1.0
+  end
 end
 
 assert('Integer#floor', '15.2.8.3.17') do


### PR DESCRIPTION
`eql?` compares class as well as value, so an Integer is never `eql?` to a Float however equal their numeric values are. `num_eql()` enforces that on the Fixnum path with its `mrb_integer_p(y)` check, but the big-integer path delegates straight to `mrb_bint_cmp()`, and `mrb_bint_cmp()` converts a Float argument through `mrb_bint_as_float()` and compares numerically. A big integer therefore reported itself `eql?` to an equal Float:

```ruby
(2 ** 70).eql?(2.0 ** 70)   #=> true   (CRuby: false)
1.eql?(1.0)                 #=> false  (already correct)
```

The two integer representations disagreed on the same question, which also makes `eql?` inconsistent with `hash` for big integers and so affects Hash key lookup.

This rejects non-Integer arguments before reaching `mrb_bint_cmp()`, so both representations answer alike.

`Integer#==` is untouched. It is a separate function (`int_equal()`), and cross-type numeric equality is correct there and stays that way: `(1<<70) == (2.0**70)` remains true. The tests assert both halves side by side so the distinction is not lost to a later refactor.

After the change, on the default build (which pulls `math.gembox`, so `MRB_USE_BIGINT` is on):

```console
$ ./build/host/bin/mruby -e 'p((2**70).eql?(2.0**70)); p((2**70) == (2.0**70)); p(1.eql?(1.0)); p(1 == 1.0)'
false
true
false
true
```

Tests: a `Bigint eql?` case in `mrbgems/mruby-bigint/test/bigint.rb` covering value, sign, non-numeric arguments and the Float rule; and the Float rule added to the existing `Integer#eql?` case in `test/t/integer.rb` so the Fixnum path is pinned too. Both float sections use the `Object.const_defined?(:Float)` guard already conventional in those files, and the bigint case only compiles when the gem is included. With `src/numeric.c` reverted and the tests in place, `Bigint eql?` fails, so the new assertions do test the change.

`rake -m test`: mrbtest `Total: 2076, OK: 2047, KO: 0, Crash: 0, Warning: 0, Skip: 29`, bintest `Total: 105, OK: 105, KO: 0`. The one added test is the new `Bigint eql?` block.
