### PR TITLE
mruby-compiler: reject a failed `ftell` before sizing the input buffer

### DIFF
--- a/mrbgems/mruby-bin-mrbc/bintest/mrbc.rb
+++ b/mrbgems/mruby-bin-mrbc/bintest/mrbc.rb
@@ -87,3 +87,22 @@ assert('mrbc -v disassembles like mruby -v') do
   assert_false from_mrbc.empty?, 'mrbc -v produced no disassembly'
   assert_equal from_mruby, from_mrbc
 end
+
+assert('non-seekable input file is rejected by size, not blamed on the read') do
+  # The file arm of the source reader sizes its buffer from ftell(). On a pipe
+  # ftell() fails, and before it was checked the -1 propagated into the
+  # allocation and the fread() count, surfacing as the misleading "cannot read
+  # program file"; the file opens and reads fine, only its size is unknown.
+  # Needs a genuinely unseekable path: `< file` would still be seekable.
+  skip 'no /dev/stdin' if /mswin(?!ce)|mingw|bccwin/ =~ RbConfig::CONFIG['host_os']
+  skip 'no /dev/stdin' unless File.exist?('/dev/stdin')
+
+  a = Tempfile.new('a.rb')
+  a.write("puts 1\n")
+  a.flush
+
+  result = `cat #{shellquote(a.path)} | #{cmd('mrbc')} -c /dev/stdin 2>&1`
+  assert_equal 1, $?.exitstatus
+  assert_include result, 'compile.c: cannot get size of program file. (/dev/stdin)'
+  assert_not_include result, 'cannot read program file'
+end

--- a/mrbgems/mruby-compiler/src/compile.c
+++ b/mrbgems/mruby-compiler/src/compile.c
@@ -279,6 +279,14 @@ read_input_files(mrc_ccontext *c, const char **filenames, uint8_t **source, mrc_
       fseek(file, 0, SEEK_END);
       each_size = ftell(file);
       fseek(file, 0, SEEK_SET);
+      if (each_size < 0) {
+        /* Not a seekable file (a pipe, FIFO or terminal); its size cannot be
+           determined up front, so the read-it-all-at-once path below does not
+           apply. */
+        fprintf(stderr, "compile.c: cannot get size of program file. (%s)\n", filename);
+        fclose(file);
+        return -1;
+      }
       length += each_size;
       if (*source == NULL) {
         *source = (uint8_t *)mrc_malloc(c, length + 1);
@@ -286,7 +294,7 @@ read_input_files(mrc_ccontext *c, const char **filenames, uint8_t **source, mrc_
       else {
         *source = (uint8_t *)mrc_realloc(c, *source, length + 1);
       }
-      if (fread(*source + pos, sizeof(char), each_size, file) != each_size) {
+      if (fread(*source + pos, sizeof(char), (size_t)each_size, file) != (size_t)each_size) {
         fprintf(stderr, "compile.c: cannot read program file. (%s)\n", filename);
         fclose(file);
         return -1;


### PR DESCRIPTION
`read_input_files()` in `mrbgems/mruby-compiler/src/compile.c` decides how much to allocate for each input file with `fseek`/`ftell`/`fseek`, but never rejects a failed `ftell`:

```c
fseek(file, 0, SEEK_END);
each_size = ftell(file);
fseek(file, 0, SEEK_SET);
length += each_size;
```

On a non-seekable input, a pipe, a FIFO, a terminal, or a process substitution such as `mrbc <(cat foo.rb)`, `ftell` fails and returns `-1` (`ESPIPE`). `each_size` and `length` are `intptr_t`, so `length` becomes `-1`, the following `mrc_malloc(c, length + 1)` asks for zero bytes, and the `-1` is passed to `fread` as an element count, where it widens to `SIZE_MAX`.

That sounds worse than it is, and it is worth being precise: **this is a diagnostics bug, not a memory-safety one.** glibc refuses the `SIZE_MAX` request outright. Because the count exceeds the stdio buffer, `fread` takes the direct-read path and the kernel rejects the range before transferring anything, so it returns 0, sets the error indicator and writes nothing. I confirmed this under AddressSanitizer against a pipe, a FIFO and a process substitution: `ftell` `-1`/`ESPIPE`, `malloc(0)`, `fread` returning 0 with `ferror` set, and no heap-buffer-overflow. The buffered branch, which would copy into the zero-byte allocation, is unreachable here, because `fseek(SEEK_END)` fails on a non-seekable stream without reading and the stdio buffer is therefore empty at the `fread`. Nothing about that is promised by the standard, though, and reducing to a zero-size allocation plus a `SIZE_MAX` read count is not worth relying on.

What the user actually sees today is a wrong explanation:

```
$ mrbc <(cat foo.rb)
compile.c: cannot read program file. (/dev/fd/63)
Cannot open files: /dev/fd/63
```

The file opened, and it is perfectly readable; reading it is exactly what a stream-oriented reader would do without trouble. The only thing that failed was measuring its length up front, which is what this function's read-it-all-at-once strategy requires. Blaming the read sends anyone debugging this toward permissions or a corrupt file rather than toward the real constraint.

This change rejects a negative `ftell` and reports the real problem:

```
$ mrbc <(cat foo.rb)
compile.c: cannot get size of program file. (/dev/fd/63)
```

The stdin arm of the same loop already checks its own size for a negative value and errors out; this brings the file arm in line, and follows the existing `compile.c: cannot ... program file. (%s)` message style used elsewhere in the function.

With `each_size` now known non-negative at that point, the count passed to `fread` is cast to `size_t` at the comparison. That silences

```
compile.c:289:63: warning: comparison of integer expressions of different signedness:
                  'size_t' {aka 'long unsigned int'} and 'intptr_t' {aka 'long int'} [-Wsign-compare]
```

which appears when the translation unit is built with `-Wextra`. The warning and the missing check are the same defect: the compiler was pointing out that a possibly-negative value was about to be reinterpreted as a very large unsigned one. Fixing the check is what makes the cast honest rather than a way of hiding the warning.

### Scope, please read this before assuming the class is closed

This rejects a *failed* `ftell`; it does not validate `ftell`'s result, and it does not make the function robust against every implausible size. The case worth naming is a directory: `fopen` succeeds on one, `fseek(f, 0, SEEK_END)` succeeds, and `ftell` returns `LONG_MAX`, which is positive, so the new check passes and `length + 1` signed-overflows. That behaviour is unchanged by this patch and predates it; the commit message names it so the next reader is not misled. Files that report `ftell == 0` without being empty, such as `/proc/self/status` and `/dev/urandom`, likewise still compile as an empty program. Both would need a sanity bound on the size or a switch to incremental reading, which is a larger change to how this function buffers and is deliberately not attempted here.

Making non-seekable inputs actually work would mean the same incremental fallback. Users who want to pipe a program in can already do so via `mrbc -`, which takes that path.

Behaviour on seekable files is unchanged, verified with a regular file, multi-file input and the `-` stdin arm. A bintest in `mrbgems/mruby-bin-mrbc/bintest/mrbc.rb` pins the new message and exit status: bintest goes from `Total: 105` to `Total: 106`, all passing, and with `compile.c` alone reverted that one case fails with `Expected "compile.c: cannot read program file. (/dev/stdin)..." to include "compile.c: cannot get size of program file. (/dev/stdin)"`. `rake -m test` is otherwise unchanged: mrbtest `Total: 2075, OK: 2046, KO: 0, Crash: 0`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compiler handling of input streams whose size cannot be determined.
  * Reports a clear size-related error instead of an incorrect read failure.
  * Ensures affected input files are closed properly when processing is aborted.

* **Tests**
  * Added regression coverage for compiling Ruby source piped through standard input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->