### PR TITLE
mruby-regexp: share the pattern-skipping rules between the two prescans

### DIFF
--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -1630,7 +1630,7 @@ has_comment_group(const char *src, mrb_int len)
    Returns the position just past its closing "]", or NULL if it is not one.
    compile_charclass() consumes such a bracket as a unit, so its ']' does not
    end the class; a malformed one falls through and the '[' is an ordinary
-   member. Both scans below have to agree with the parser on this. */
+   member. The scan below has to agree with the parser on this. */
 static const char*
 skip_posix_bracket(const char *src, const char *end)
 {
@@ -1646,12 +1646,69 @@ skip_posix_bracket(const char *src, const char *end)
 }
 
 /*
+ * Step over the one construct at `src` that a pattern scan must not read
+ * into: an escape sequence, or a character class from its '[' through its
+ * ']'. Returns the position just past it, having updated *in_class, or NULL
+ * when the byte at `src` is neither and the caller has to handle it itself.
+ * A class spans several calls, with *in_class carrying the state between
+ * them, so the caller keeps one flag and starts it FALSE.
+ *
+ * preprocess_pattern() and has_named_group() both walk the pattern hunting
+ * for a "(?" opener, and both have to agree with the parser on when a '(' is
+ * an opener rather than an escaped or bracketed byte. The rules for that live
+ * here alone, so a correction to them cannot be made in one walk and missed
+ * in the other.
+ */
+static const char*
+skip_uninterpreted(const char *src, const char *end, mrb_bool *in_class)
+{
+  char ch = *src;
+
+  if (ch == '\\' && src + 1 < end) {
+    mrb_bool unicode = (src[1] == 'u');
+    src += 2;
+    /* A `\u{...}` list is a single escape rather than `\u` followed by a
+       brace group: it separates its codepoints with spaces, which the
+       free-spacing pass would otherwise remove, joining `\u{61 62}` into the
+       one codepoint `\u{6162}`. An unterminated list runs to the end. */
+    if (unicode && src < end && *src == '{') {
+      while (src < end) {
+        if (*src++ == '}') break;
+      }
+    }
+    return src;
+  }
+
+  if (*in_class) {
+    /* A POSIX bracket is consumed as a unit by compile_charclass(), so the
+       ']' that closes it does not close the class. */
+    const char *q = skip_posix_bracket(src, end);
+    if (q) return q;
+    if (ch == ']') *in_class = FALSE;
+    return src + 1;
+  }
+
+  if (ch == '[') {
+    *in_class = TRUE;
+    src++;
+    /* A ']' written first is a literal member, optionally after '^',
+       mirroring the `first` flag in compile_charclass(). */
+    if (src < end && *src == '^') src++;
+    if (src < end && *src == ']') src++;
+    return src;
+  }
+
+  return NULL;
+}
+
+/*
  * Rewrite the pattern before the parser sees it.
  * Removes (?#...) comment groups always, and in extended mode (/x) also
  * whitespace and #comments.
  * Whitespace inside [...] character classes is preserved, and so is a (?#
  * written there, which is a literal member rather than a comment group.
  * Escaped characters (\ followed by anything) are preserved.
+ * skip_uninterpreted() decides which bytes those are.
  */
 static char*
 preprocess_pattern(mrb_state *mrb, const char *src, mrb_int len,
@@ -1664,40 +1721,12 @@ preprocess_pattern(mrb_state *mrb, const char *src, mrb_int len,
 
   while (src < end) {
     char ch = *src;
-    if (ch == '\\' && src + 1 < end) {
-      mrb_bool unicode = (src[1] == 'u');
-      buf[o++] = *src++;
-      buf[o++] = *src++;
-      /* A `\u{...}` list separates its codepoints with spaces, so the brace
-         group has to be copied whole: the free-spacing pass below would
-         otherwise join `\u{61 62}` into the single codepoint `\u{6162}`. */
-      if (unicode && src < end && *src == '{') {
-        while (src < end) {
-          char u = *src;
-          buf[o++] = *src++;
-          if (u == '}') break;
-        }
-      }
-      continue;
-    }
-    if (in_class) {
-      /* Copy a POSIX bracket whole and keep the class open. */
-      const char *q = skip_posix_bracket(src, end);
-      if (q) {
-        while (src < q) buf[o++] = *src++;
-        continue;
-      }
-      if (ch == ']') in_class = FALSE;
-      buf[o++] = *src++;
-      continue;
-    }
-    if (ch == '[') {
-      in_class = TRUE;
-      buf[o++] = *src++;
-      /* A ']' written first is a literal member, optionally after '^',
-         mirroring the `first` flag in compile_charclass(). */
-      if (src < end && *src == '^') buf[o++] = *src++;
-      if (src < end && *src == ']') buf[o++] = *src++;
+    /* An escape or a character class is copied through untouched: neither
+       holds a comment group, and inside a class the free-spacing rules do
+       not apply. */
+    const char *skip = skip_uninterpreted(src, end, &in_class);
+    if (skip) {
+      while (src < skip) buf[o++] = *src++;
       continue;
     }
     if (ch == '(' && end - src >= 3 && src[1] == '?' && src[2] == '#') {
@@ -1748,9 +1777,8 @@ preprocess_pattern(mrb_state *mrb, const char *src, mrb_int len,
  * (?<name>...) is the only spelling of a definition this gem accepts; the
  * (?'name'...) form raises "undefined (?...) sequence", so the scan looks for
  * "(?<" alone. It excludes (?<= and (?<!, which are lookbehind rather than a
- * definition, and it skips escape pairs and character classes so that /\(?/
- * and /[(?<]/ are not false positives, with a POSIX bracket and a leading
- * literal ']' not ending a class, as in preprocess_pattern() above.
+ * definition, and it steps over escapes and character classes with
+ * skip_uninterpreted(), so that /\(?/ and /[(?<]/ are not false positives.
  *
  * A truncated "(?<" at the end of the pattern is counted as a named group,
  * which is harmless: the parser reaches the same bytes and raises there.
@@ -1763,25 +1791,9 @@ has_named_group(const char *src, mrb_int len)
 
   while (src < end) {
     char ch = *src;
-    if (ch == '\\' && src + 1 < end) {
-      src += 2;
-      continue;
-    }
-    if (in_class) {
-      const char *q = skip_posix_bracket(src, end);
-      if (q) {
-        src = q;
-        continue;
-      }
-      if (ch == ']') in_class = FALSE;
-      src++;
-      continue;
-    }
-    if (ch == '[') {
-      in_class = TRUE;
-      src++;
-      if (src < end && *src == '^') src++;
-      if (src < end && *src == ']') src++;
+    const char *skip = skip_uninterpreted(src, end, &in_class);
+    if (skip) {
+      src = skip;
       continue;
     }
     if (ch == '(' && end - src >= 3 && src[1] == '?' && src[2] == '<') {

--- a/mrbgems/mruby-regexp/test/regexp_syntax.rb
+++ b/mrbgems/mruby-regexp/test/regexp_syntax.rb
@@ -550,6 +550,78 @@ assert("Regexp - a named group makes plain groups non-capturing") do
   end
 end
 
+assert("Regexp - the /x pass and the named-group scan skip the same constructs") do
+  # Two walks read the pattern before the parser does: the /x free-spacing
+  # pass and the named-group pre-scan. Both have to step over the same
+  # escapes, character classes and POSIX brackets, so each row below is read
+  # by both at once. A rule lost from the free-spacing pass strips a space it
+  # should have kept; the same rule lost from the pre-scan turns a bracketed
+  # "(?<" into a phantom named group, which demotes the plain (b) that
+  # follows and shortens the match. Either way the row fails.
+  x = Regexp::EXTENDED
+
+  # an escape pair hides the '(' from both
+  assert_equal ["(<a>b", "b"],
+               Regexp.new('\(?<a> (b)', x).match("(<a>b").to_a
+
+  # a character class hides "(?<" and keeps its own spaces
+  assert_equal ["(?< b", "b"],
+               Regexp.new('[(?< a>]+ (b)', x).match("(?< b").to_a
+
+  # a ']' written first is a member, so the class runs past it
+  assert_equal ["] (?<b", "b"],
+               Regexp.new('[] (?<a>]+(b)', x).match("] (?<b").to_a
+  assert_equal ["zzb", "b"],
+               Regexp.new('[^] (?<a>]+(b)', x).match("zzb").to_a
+
+  # a POSIX bracket's ']' does not close the class either
+  assert_equal ["a (?<b", "b"],
+               Regexp.new('[[:alpha:] (?<a>]+(b)', x).match("a (?<b").to_a
+
+  # a `\u{...}` list is one escape, so its separating space survives /x and
+  # its bytes are not read as pattern syntax
+  assert_equal ["ab"], Regexp.new('\u{61 62}', x).match("ab").to_a
+  assert_equal ["abcd", "c", "d"],
+               Regexp.new('\u{61 62}(c)(d)', x).match("abcd").to_a
+  assert_equal ["abcd", "c"],
+               Regexp.new('\u{61 62}(?<n>c)(d)', x).match("abcd").to_a
+  assert_equal ["abcd", "c", "d"],
+               Regexp.new('[\u{61 62}]+(c)(d)', x).match("abcd").to_a
+
+  # With no whitespace, no #comment and no (?#...) to remove, /x rewrites
+  # nothing, so both compiles must agree; they do not take the same road,
+  # though: without /x the pre-scan reads the pattern as written, while with
+  # /x it reads what the free-spacing pass emitted. The two walks disagreeing
+  # about where a class or an escape ends is exactly what shows up here.
+  [
+    ['\(?<a>(b)',            "(<a>b"],
+    ['[(?<a>]+(b)',          "(?<b"],
+    ['[](?<a>]+(b)',         "](?<b"],
+    ['[^](?<a>]+(b)',        "zzb"],
+    ['[[:alpha:](?<a>]+(b)', "a(?<b"],
+    ['[\]](?<a>x)(y)',       "]xy"],
+    ['\\\\(?<a>x)(y)',       "\\xy"],
+    ['\u{61}(?<n>b)(c)',     "abc"],
+    ['[\u{61}]+(?<n>b)(c)',  "abc"],
+    ['(a)(?<b>b)',           "ab"],
+  ].each do |pat, subject|
+    assert_equal Regexp.new(pat).match(subject).to_a,
+                 Regexp.new(pat, x).match(subject).to_a
+  end
+
+  # A `\u{...}` list is not a place a named group can be declared, so the
+  # scan must not read "(?<" out of one. The list here is malformed either
+  # way and the pattern is rejected either way, but which error comes first
+  # depends on the scan: taking the "(?<" for a declaration turns on the
+  # demotion that rejects the leading \1 before the parser ever reaches the
+  # bad list. CRuby reports the list, and so does the scan that treats
+  # `\u{...}` as one escape.
+  assert_raise_with_message(RegexpError,
+                            "invalid Unicode list: /\\1\\u{(?<a>/") do
+    Regexp.new("\\1\\u{(?<a>")
+  end
+end
+
 assert("Regexp - case in when") do
   result = case "hello123"
            when /\d+/ then "has digits"


### PR DESCRIPTION
Two scans read a regexp pattern before the parser does:

- `preprocess_pattern()` removes `(?#...)` comment groups, and under `/x` also whitespace and `#` line comments;
- `has_named_group()` answers whether the pattern declares a `(?<name>...)` group, which is what lets `compile_atom()` demote a plain `(...)` written *before* the declaration that demotes it.

Both are hunting for a `(?` opener, so both have to agree with the parser about when a `(` is really an opener and not a byte hiding behind an escape or inside a character class. Each carried its own copy of those rules, and the copies had drifted apart.

Three rules matched: the escape pair, the class from `[` through `]` (with `^` and a leading literal `]` handled as `compile_charclass()` handles them), and the POSIX bracket, whose `]` must not close the class. The fourth did not. `preprocess_pattern()` treats `\u{...}` as one escape and copies the brace group whole, because the free-spacing pass would otherwise strip the spaces separating the list's codepoints and collapse `\u{61 62}` into the single codepoint `\u{6162}`. `has_named_group()` skipped `\u` as a plain two-byte escape and then walked into the braces.

### This is observable, in diagnostics

The divergence cannot change whether a pattern compiles: a well-formed `\u{...}` list contains only hex digits and separator whitespace, so it can hide neither a class opener nor a `(?<`, and every pattern that exposes the difference is malformed and rejected either way. But it changes *which* error is reported. `dont_capture` is computed from `has_named_group()` before parsing begins, while the Unicode list is validated during parsing, so a `(?<` mistaken for a declaration switches on the demotion that rejects a numbered backreference earlier in the pattern, before the parser ever reaches the malformed list:

```
Regexp.new("\\1\\u{(?<a>")

before: numbered backref/call is not allowed. (use name): /\1\u{(?<a>/
after:  invalid Unicode list: /\1\u{(?<a>/
CRuby:  invalid Unicode list: /\1\u{(?<a>/
```

Measured by differential testing between a build of this branch and a build of its base, over patterns assembled from the tokens that exercise these rules (`\u{`, `}`, `[`, `]`, `^`, `(?<`, `(`, `)`, `a`, space, `\1`, `[:alpha:]`), every sequence of one to four of them, each also with a `\1` prefix, 43,356 distinct patterns:

* **0** patterns change whether they compile.
* **643** change which error is reported, in three message pairs, and in both directions.
* Of those 643, the old code's message matched CRuby 4.0.6's on **1**; the new one matches on **604**. So unifying the walks moves the error reporting toward CRuby rather than away from it.

Every one of those patterns was already an error; no valid pattern is affected.

### The free-spacing pass is untouched

`preprocess_pattern()` now copies verbatim the span the shared helper returns, which is by construction the same span the inline code copied. Differentially: over 6,990 distinct patterns built the same way under `Regexp::EXTENDED` from a token set extended with `61 62`, `#` and a newline, and matching every pattern that compiled against twelve subjects, **no row where either side compiled differs at all**. The 39 rows that do differ are error-message changes of the kind above.

### The change

This moves the rules into one helper, `skip_uninterpreted()`, which steps over whichever construct starts at the current byte and reports the class state back through an `in_class` flag the caller owns. `preprocess_pattern()` copies the returned span verbatim; `has_named_group()` jumps over it, gaining the `\u{...}` rule it had been missing.

`has_comment_group()` is deliberately left alone. It is a third walk, but a naive `memchr` prefilter that visits every `(` and so returns TRUE iff the bytes `(?#` occur anywhere; its only possible error is a false positive costing one unnecessary `preprocess_pattern()` call. It is not a copy of these rules, and folding it in would only make the fast path slower.

### Tests

The new rows are read by both walks at once: each places a `(?<` and a following plain group behind a construct the rules must cross. A rule dropped from the free-spacing pass strips a space it should have kept inside a class; the same rule dropped from the named-group scan turns the bracketed `(?<` into a phantom named group and demotes the plain group. A final row pins the diagnostic above, which is the one behaviour this change deliberately alters.

`rake -m test`: mrbtest `Total: 2076, OK: 2047, KO: 0, Crash: 0, Warning: 0, Skip: 29` (2075 without this branch, so the block is the +1); bintest `Total: 105, OK: 105, KO: 0`. With `re_compile.c` alone reverted and the tests in place, that block fails, so it does test the change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved regular expression parsing for escaped characters, character classes, POSIX bracket expressions, and Unicode escape lists.
  * Fixed extended-mode (`/x`) handling so spaces and patterns are interpreted consistently.
  * Improved detection of named capture groups in complex expressions.
  * Malformed Unicode escape lists now report errors more reliably.

* **Tests**
  * Added regression coverage for these parsing scenarios and their error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->