### PR TITLE
test: growing a shared string detaches its buffer

### DIFF
--- a/mrbgems/mruby-io/test/io.rb
+++ b/mrbgems/mruby-io/test/io.rb
@@ -334,6 +334,26 @@ assert('IO.sysopen, IO#sysread') do
   io.close
 end
 
+assert('IO#sysread into a shared buffer') do
+  # `sysread` resizes the buffer to the requested length and then reads into
+  # it from offset 0, and it is one of the callers of that resize which does
+  # not prepare the buffer for modification itself. Were the resize to leave
+  # the buffer shared, the read would write over bytes another string still
+  # holds. `BasicSocket#recv` resizes the same way and is not covered here.
+  fd = IO.sysopen $mrbtest_io_rfname
+  io = IO.new(fd)
+  begin
+    a = "a" * 100 + "z" * 100
+    a.bytesplice(100, 100, "")  # shorten it, to leave spare capacity behind
+    buf = a.dup                 # shares that buffer, and ends where `a` ends
+    io.sysread(150, buf)        # a different length, so the buffer grows first
+    assert_equal $mrbtest_io_msg, buf
+    assert_equal "a" * 100, a
+  ensure
+    io.close
+  end
+end
+
 assert('IO.sysopen, IO#syswrite') do
   fd = IO.sysopen $mrbtest_io_wfname, "w"
   io = IO.new(fd, "w")

--- a/mrbgems/mruby-string-ext/test/string.rb
+++ b/mrbgems/mruby-string-ext/test/string.rb
@@ -232,6 +232,60 @@ assert('String#concat on a shared buffer') do
   assert_equal "l" * 100 + "m" * 100, n
 end
 
+assert('String growth on a shared buffer') do
+  # An append writes only above the length every other sharer of the buffer
+  # can see, which is what lets `String#<<` above stay in the buffer. Growing
+  # a string any other way has no such guarantee, and a growth that kept the
+  # buffer shared would be seen through the other string. Every string here is
+  # appended to before it is shared, since one with no spare capacity has
+  # nothing to be grown into in place anyway.
+
+  # `insert` at the front memmoves from offset 0, over the whole slice.
+  a = "a" * 100
+  a << "z" * 100
+  a_slice = a[0, 150]
+  a.insert(0, "1234")
+  assert_equal "1234" + "a" * 100 + "z" * 100, a
+  assert_equal "a" * 100 + "z" * 50, a_slice
+
+  # `prepend`, the same shape as `insert` at 0.
+  c = "c" * 100
+  c << "x" * 100
+  c_slice = c[0, 150]
+  c.prepend("1234")
+  assert_equal "1234" + "c" * 100 + "x" * 100, c
+  assert_equal "c" * 100 + "x" * 50, c_slice
+
+  # The rest are contract rather than detection: what they write happens to
+  # land above the slice, or they take the buffer for reasons of their own.
+
+  # `insert` at the end writes above the slice, and moves only the length and
+  # the terminator of the buffer the slice reads.
+  b = "b" * 100
+  b << "y" * 100
+  b_slice = b[0, 150]
+  b.insert(-1, "1234")
+  assert_equal "b" * 100 + "y" * 100 + "1234", b
+  assert_equal "b" * 100 + "y" * 50, b_slice
+
+  # `succ!` writes a terminator over the string before it grows, so it has to
+  # hold the buffer by then whatever the growth does.
+  d = "z" * 100
+  d << "z" * 100
+  d_slice = d[0, 150]
+  d.succ!
+  assert_equal "a" * 201, d
+  assert_equal "z" * 150, d_slice
+
+  # The sharer is the one that grows, ending below what its parent holds.
+  e = "e" * 100
+  e << "w" * 100
+  e_slice = e[0, 150]
+  e_slice.insert(0, "1234")
+  assert_equal "1234" + "e" * 100 + "w" * 50, e_slice
+  assert_equal "e" * 100 + "w" * 100, e
+end
+
 assert('String#casecmp') do
   assert_equal 1, "abcdef".casecmp("abcde")
   assert_equal 0, "aBcDeF".casecmp("abcdef")

--- a/test/t/string.rb
+++ b/test/t/string.rb
@@ -1200,3 +1200,27 @@ assert('String#bytesplice') do
   # with an empty string
   assert_equal "012789", "0123456789".bytesplice(3, 4, "")
 end
+
+assert('String#bytesplice on a shared buffer') do
+  # A longer replacement grows the string and then writes from `idx1`, which
+  # a string sharing the same buffer still reads, so growing has to take the
+  # buffer away from it. Each string is shortened before it is shared, to
+  # leave spare capacity behind: one that has none cannot be grown in place
+  # anyway, so it would not tell the two behaviours apart.
+  a = "a" * 100 + "z" * 100
+  a.bytesplice(100, 100, "")
+  a_slice = a[0, 60]
+  a.bytesplice(0, 1, "1234567890")
+  assert_equal "1234567890" + "a" * 99, a
+  assert_equal "a" * 60, a_slice
+
+  # The sharer is the one that grows, ending below what its parent holds.
+  # Contract rather than detection: that is already the case where a growth
+  # keeping the buffer would have to take a copy regardless.
+  b = "b" * 100 + "y" * 100
+  b.bytesplice(100, 100, "")
+  b_slice = b[0, 60]
+  b_slice.bytesplice(0, 1, "1234567890")
+  assert_equal "1234567890" + "b" * 59, b_slice
+  assert_equal "b" * 100, b
+end


### PR DESCRIPTION
`mrb_str_cat()` appends into a buffer it shares with other strings, because an append only writes `[len, len + addlen)`, a range no other sharer can see. Growth through `mrb_str_resize()` looks like the same opportunity, and it is not. Nothing in the suite said so; these tests do.

`mrb_str_resize()` is a public API that hands the buffer back to its caller and lets it write wherever it likes, and its callers write from the front: `String#insert` memmoves from the insertion index, `String#prepend` moves the whole content up from 0, `String#succ!` writes over the string from 0, `String#bytesplice` writes from `idx1`, and the callers in mruby-pack and mruby-io fill their buffers from offset 0. Keeping the buffer shared across the growth lets any of them overwrite bytes another string is still reading.

Most of those call `mrb_str_modify()` themselves before resizing, so they detach for their own reasons. `IO#sysread` and `BasicSocket#recv` do not: both resize a buffer supplied from Ruby and then read into it from offset 0, `io.c` calling `mrb_str_modify()` only on the branch where the length already matches and no resize happens. So the invariant is load-bearing today, and untested.

Two variants of the optimisation were built to check that:

* **A**: `str_modify_cat()`'s logic in `mrb_str_resize()`, nothing else changed.
* **B**: A, plus dropping the now-redundant `mrb_str_modify()` in `String#insert`, `String#prepend` and `String#bytesplice`.

Both pass the pre-existing suite with `KO: 0`. Variant A silently rewrites a string through `IO#sysread`:

```ruby
a = "a" * 100 + "z" * 100
a.bytesplice(100, 100, "")   # shorten, leaving spare capacity
buf = a.dup                  # shares that buffer
io.sysread(150, buf)         # grows it, then reads in from offset 0
a                            # overwritten, and never touched
```

and variant B additionally does it through `String#insert(0, ...)` and `String#prepend`:

```console
$ ./build/host/bin/mruby -e 'a = "a"*100; a << "z"*100; b = a[0,150]; a.insert(0,"XXXX"); p b[0,8]'
"XXXXaaaa"      # expected "aaaaaaaa"
```

With the tests in this PR, variant A fails on `IO#sysread into a shared buffer` (`KO: 1`) and variant B fails on that plus `String growth on a shared buffer` and `String#bytesplice on a shared buffer` (`KO: 3`).

The optimisation was measured before being rejected: on `s = ""; N.times { s.insert(-1, "...20 bytes..."); s[0, 30] }` it is indistinguishable from master over 9 repetitions per point, and both remain quadratic. `mrb_str_resize()` sizes the buffer to exactly the requested length, so there is none of the geometric growth that makes `mrb_str_cat()`'s in-place append amortize.

Some assertions here pin the invariant on shapes that cannot currently distinguish the two behaviours: `insert` at the end writes above the other sharer, and `succ!` writes a terminator in place before it grows. They are kept as contract and marked as such in the comments.

Tests only, no behaviour change. `rake -m test`: mrbtest `Total: 2078, OK: 2049, KO: 0, Crash: 0, Warning: 0, Skip: 29`, up from 2075 by the three new blocks; bintest `Total: 105, OK: 105, KO: 0`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added regression coverage for reading into resized, shared string buffers without altering the original string.
  - Added tests confirming string growth operations preserve independent contents when buffers are shared.
  - Added coverage for byte-level splicing with shared target and replacement strings.
  - Improved resource cleanup verification during I/O tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->