### PR TITLE
vm.c: restore the GC arena where the Float boxing macro allocates

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -2238,7 +2238,18 @@ vm_op_div(mrb_state *mrb, uint32_t a, mrb_sym *midp)
 
 #ifndef MRB_NO_FLOAT
   f = mrb_div_float(x, y);
-  SET_FLOAT_VALUE(mrb, regs[a], f);
+  {
+    /* This is the one boxing site of OP_DIV that sits outside mrb_vm_exec(),
+       so VM_SET_FLOAT_VALUE() and the arena index it restores to are not in
+       scope.  Saving here instead restores to the height on entry to this
+       branch rather than to the height on entry to the frame, which still
+       bounds the arena across a loop and is what the Integer branch above
+       already does.  The result needs no protection past the restore: it is
+       stored into regs[], and the VM stack is a GC root. */
+    int ai = mrb_gc_arena_save(mrb);
+    SET_FLOAT_VALUE(mrb, regs[a], f);
+    mrb_gc_arena_restore(mrb, ai);
+  }
 #endif
   return VM_NEXT;
 }
@@ -2317,6 +2328,23 @@ vm_call_proc(mrb_state *mrb, const struct RProc *p, mrb_int nargs,
 } while (0)
 #else
 #define VM_SET_INT_VALUE(r,n) SET_INT_VALUE(mrb,r,n)
+#endif
+
+/* The same for an mrb_float.  Under word boxing SET_FLOAT_VALUE() heap-
+   allocates an RFloat for a value the mrb_value word cannot hold inline: every
+   float under MRB_WORDBOX_NO_INLINE_FLOAT, and otherwise a subnormal, an
+   exponent outside the inlinable range, or a rotation that would collide with
+   a sentinel.  The other boxing modes store the float in the mrb_value itself
+   and never allocate, so there this expands to the bare store.  As above the
+   restore is skipped when the store produced an immediate, which is the inline
+   float fast path, and `ai` is mrb_vm_exec()'s saved arena index. */
+#ifdef MRB_WORD_BOXING
+#define VM_SET_FLOAT_VALUE(r,f) do {                                        \
+  SET_FLOAT_VALUE(mrb, r, f);                                               \
+  if (!mrb_immediate_p(r)) mrb_gc_arena_restore(mrb, ai);                   \
+} while (0)
+#else
+#define VM_SET_FLOAT_VALUE(r,f) SET_FLOAT_VALUE(mrb,r,f)
 #endif
 
 /**
@@ -2443,7 +2471,7 @@ RETRY_TRY_BLOCK:
 #endif
 #ifndef MRB_NO_FLOAT
       case IREP_TT_FLOAT:
-        regs[a] = mrb_float_value(mrb, irep->pool[b].u.f);
+        VM_SET_FLOAT_VALUE(regs[a], irep->pool[b].u.f);
         break;
 #endif
       default:
@@ -3328,7 +3356,7 @@ RETRY_TRY_BLOCK:
   case TYPES2(OP_MATH_TT_##t1, OP_MATH_TT_##t2):                                \
     {                                                                           \
       mrb_float z = mrb_##t1(regs[a]) OP_MATH_OP_##op_name mrb_##t2(regs[a+1]); \
-      SET_FLOAT_VALUE(mrb, regs[a], z);                                         \
+      VM_SET_FLOAT_VALUE(regs[a], z);                                           \
     }                                                                           \
     break
 #endif
@@ -3409,7 +3437,7 @@ RETRY_TRY_BLOCK:
   case MRB_TT_FLOAT:                                                        \
     {                                                                       \
       mrb_float z = mrb_float(regs[a]) OP_MATH_OP_##op_name b;              \
-      SET_FLOAT_VALUE(mrb, regs[a], z);                                     \
+      VM_SET_FLOAT_VALUE(regs[a], z);                                       \
     }                                                                       \
     break
 #endif
@@ -3429,7 +3457,7 @@ RETRY_TRY_BLOCK:
   case MRB_TT_FLOAT:                                                        \
     {                                                                       \
       mrb_float z = mrb_float(regs[a]) OP_MATH_OP_##op_name c;              \
-      SET_FLOAT_VALUE(mrb, regs[a], z);                                     \
+      VM_SET_FLOAT_VALUE(regs[a], z);                                       \
     }                                                                       \
     break
 #endif

--- a/test/t/gc.rb
+++ b/test/t/gc.rb
@@ -298,3 +298,87 @@ assert('OP_LOADI32 does not retain a boxed Integer in the GC arena') do
   assert_operator GC.stat[:live] - base, :<, 100
   assert_equal 1073741824, z
 end
+
+# The Float branches of the same opcodes box through `SET_FLOAT_VALUE()`, which
+# under word boxing heap-allocates an RFloat whenever the mrb_value word cannot
+# hold the value inline.  With `MRB_WORDBOX_NO_INLINE_FLOAT` that is every
+# Float; without it, on a 64-bit host, it is a subnormal, an exponent outside
+# the inlinable range, or a rotation that would collide with a sentinel.
+# `5.0e-324` and `1.0e100` are on the wrong side of both bounds, so the loops
+# allocate under either setting.  The immediate-operand opcodes are run only on
+# `1.0e100`, since a subnormal plus a non-zero integer is an ordinary Float that
+# does inline.  On a boxing mode that keeps the Float in the word the loops
+# retain nothing and the assertions hold trivially.
+
+assert('OP_MATH does not retain a boxed Float in the GC arena') do
+  [1.0e100, 5.0e-324].each do |x|
+    zero = 0.0
+    one = 1.0
+    y = nil
+    GC.start
+    base = GC.stat[:live]
+    i = 0
+    while i < 20000
+      y = x + zero   # OP_ADD
+      y = x - zero   # OP_SUB
+      y = x * one    # OP_MUL
+      i += 1
+    end
+    GC.start
+    assert_operator GC.stat[:live] - base, :<, 100
+    assert_equal x, y
+  end
+end
+
+assert('OP_DIV does not retain a boxed Float in the GC arena') do
+  # OP_DIV boxes from a helper outside the interpreter loop, so it restores to
+  # its own saved arena index rather than to the frame's.
+  [1.0e100, 5.0e-324].each do |x|
+    one = 1.0
+    y = nil
+    GC.start
+    base = GC.stat[:live]
+    i = 0
+    while i < 20000
+      y = x / one
+      i += 1
+    end
+    GC.start
+    assert_operator GC.stat[:live] - base, :<, 100
+    assert_equal x, y
+  end
+end
+
+assert('OP_ADDI does not retain a boxed Float in the GC arena') do
+  x = 1.0e100
+  y = nil
+  GC.start
+  base = GC.stat[:live]
+  i = 0
+  while i < 20000
+    y = x + 1   # OP_ADDI
+    y = x - 1   # OP_SUBI
+    x += 1      # OP_ADDILV, the fused local form
+    x -= 1      # OP_SUBILV
+    i += 1
+  end
+  GC.start
+  assert_operator GC.stat[:live] - base, :<, 100
+  assert_equal 1.0e100, x
+  assert_equal 1.0e100, y
+end
+
+assert('OP_LOADL does not retain a boxed Float in the GC arena') do
+  y = nil
+  GC.start
+  base = GC.stat[:live]
+  i = 0
+  while i < 20000
+    y = 1.0e100
+    y = 5.0e-324
+    i += 1
+  end
+  GC.start
+  assert_operator GC.stat[:live] - base, :<, 100
+  assert_equal 5.0e-324, y
+end

--- a/test/t/gc.rb
+++ b/test/t/gc.rb
@@ -119,10 +119,21 @@ end
 # The inline `[]`, `[]=` and arithmetic opcodes answer from C without a method
 # call, so the arena restore that every cfunc return performs never runs for
 # them.  What they allocate then stays arena-protected for the rest of the
-# enclosing method.  `GC.stat` is itself a cfunc, so it reads the count before
-# its own restore and still sees what the loop pinned.  The loop bodies below
-# are built only from opcodes that do not restore, since a single send in the
-# body would empty the arena and hide the retention.
+# enclosing method.  The loop bodies below are built only from opcodes that do
+# not restore, since a single send in the body would empty the arena and hide
+# the retention.
+#
+# Each assertion runs a full GC while the arena still holds what the loop left
+# there.  The arena is a GC root, so exactly the pinned objects survive that
+# collection and the rise in `GC.stat[:live]` counts them and nothing else.
+# The `GC.start` has to be the first send after the loop: any cfunc return
+# drains the arena, so reading `GC.stat` first would discard the very thing
+# being measured.
+#
+# A retaining branch pins one object per iteration and reports the full 20000.
+# The margin below covers the few objects `GC.stat` allocates for its own
+# result; it is not slack for a partial leak, and a branch that retains on even
+# a small fraction of the iterations is over it.
 
 assert('OP_GETIDX does not retain its result in the GC arena') do
   s = "hello"
@@ -133,7 +144,8 @@ assert('OP_GETIDX does not retain its result in the GC arena') do
     s[1]
     i += 1
   end
-  assert_operator GC.stat[:live] - base, :<, 5000
+  GC.start
+  assert_operator GC.stat[:live] - base, :<, 100
 end
 
 assert('OP_GETIDX does not retain a Hash default in the GC arena') do
@@ -145,7 +157,8 @@ assert('OP_GETIDX does not retain a Hash default in the GC arena') do
     h[1]
     i += 1
   end
-  assert_operator GC.stat[:live] - base, :<, 5000
+  GC.start
+  assert_operator GC.stat[:live] - base, :<, 100
 end
 
 assert('OP_GETIDX0 does not retain a String result in the GC arena') do
@@ -157,7 +170,8 @@ assert('OP_GETIDX0 does not retain a String result in the GC arena') do
     s[0]
     i += 1
   end
-  assert_operator GC.stat[:live] - base, :<, 5000
+  GC.start
+  assert_operator GC.stat[:live] - base, :<, 100
 end
 
 assert('OP_GETIDX0 does not retain a Hash default in the GC arena') do
@@ -169,7 +183,8 @@ assert('OP_GETIDX0 does not retain a Hash default in the GC arena') do
     h[0]
     i += 1
   end
-  assert_operator GC.stat[:live] - base, :<, 5000
+  GC.start
+  assert_operator GC.stat[:live] - base, :<, 100
 end
 
 assert('OP_SETIDX does not retain a duplicated Hash key in the GC arena') do
@@ -182,7 +197,8 @@ assert('OP_SETIDX does not retain a duplicated Hash key in the GC arena') do
     h[k] = 1
     i += 1
   end
-  assert_operator GC.stat[:live] - base, :<, 5000
+  GC.start
+  assert_operator GC.stat[:live] - base, :<, 100
 end
 
 assert('OP_ADD does not retain an overflowed Integer in the GC arena') do
@@ -208,7 +224,8 @@ assert('OP_ADD does not retain an overflowed Integer in the GC arena') do
       x + x
       i += 1
     end
-    assert_operator GC.stat[:live] - base, :<, 5000
+    GC.start
+    assert_operator GC.stat[:live] - base, :<, 100
   end
 end
 
@@ -239,7 +256,8 @@ assert('OP_ADD does not retain a boxed Integer in the GC arena') do
       x + 1     # OP_ADDI
       i += 1
     end
-    assert_operator GC.stat[:live] - base, :<, 5000
+    GC.start
+    assert_operator GC.stat[:live] - base, :<, 100
   end
 end
 
@@ -258,7 +276,8 @@ assert('OP_DIV does not retain a boxed Integer in the GC arena') do
       x / one
       i += 1
     end
-    assert_operator GC.stat[:live] - base, :<, 5000
+    GC.start
+    assert_operator GC.stat[:live] - base, :<, 100
   end
 end
 
@@ -275,6 +294,7 @@ assert('OP_LOADI32 does not retain a boxed Integer in the GC arena') do
     z = 1073741824
     i += 1
   end
-  assert_operator GC.stat[:live] - base, :<, 5000
+  GC.start
+  assert_operator GC.stat[:live] - base, :<, 100
   assert_equal 1073741824, z
 end


### PR DESCRIPTION
`VM_SET_INT_VALUE()` restores the GC arena at the Integer boxing sites in the interpreter loop, because those opcodes answer inline and have no cfunc epilogue behind them to shrink it. The Float sites box through `SET_FLOAT_VALUE()`, which under word boxing heap-allocates an `RFloat` whenever the `mrb_value` word cannot hold the value inline, and none of them restore. Each iteration of a loop built from those opcodes pins one more object, the mark phase then walks all of them, and the loop is quadratic.

This is not confined to `MRB_WORDBOX_NO_INLINE_FLOAT`, where every Float is a heap object. Default 64-bit word boxing also sends a subnormal, an exponent outside [-255, +256], and a rotation that would collide with a sentinel to `mrb_obj_alloc()` (`mrb_word_boxing_float_value()` in `src/etc.c`), so an ordinary host build is affected too.

There are five boxing sites:

| site | opcodes |
| --- | --- |
| `OP_LOADL`, `IREP_TT_FLOAT` | OP_LOADL |
| `OP_MATH_CASE_FLOAT` | OP_ADD, OP_SUB, OP_MUL |
| `OP_MATHI_CASE_FLOAT` | OP_ADDI, OP_SUBI |
| `OP_MATHILV_CASE_FLOAT` | OP_ADDILV, OP_SUBILV |
| Float tail of `vm_op_div()` | OP_DIV |

Four of them sit inside `mrb_vm_exec()` and take a new `VM_SET_FLOAT_VALUE()` built to the same shape as the Integer macro: store, then restore unless the store produced an immediate, which is the inline-float fast path and allocates nothing. On a boxing mode that keeps the Float in the word it expands to the bare store.

`vm_op_div()` is a helper outside `mrb_vm_exec()`, so neither the macro nor the arena index it restores to is in scope. Rather than thread `ai` through the signature, it saves its own index around the store and restores to the height on entry to that branch instead of to the height on entry to the frame. That still bounds the arena across a loop, and it is exactly what the Integer branch a few lines above in the same function already does. It is also strictly the more conservative of the two: nothing allocates between entry to `vm_op_div()` and the save, since the type switch only reads `mrb_type()`, `mrb_integer()` and `mrb_float()` and `mrb_div_float()` is float arithmetic, so the restore pops exactly the one `RFloat` the store created and never anything the caller pushed. Either way the result needs no `mrb_gc_protect()`: it is stored into `regs[]`, and the VM stack is a GC root, which is the same reason the cfunc epilogues can shrink unconditionally.

### Measurements

x86-64. Each figure is from a 20000-iteration `while` loop whose body holds only the opcode under test and `i += 1`. `GC.start` is run as the first send after the loop, while the arena still roots what the loop left there, since any cfunc return would drain it first, so the rise in `GC.stat[:live]` across that collection is the number of pinned objects. The last digit varies by one or two with what happens to be live when the base count is read; only the order of magnitude is meaningful.

Default word boxing, `x = 1.0e100`:

| loop body | before | after |
| --- | ---: | ---: |
| `y = x + zero` | ~20000 | <= 2 |
| `y = x - zero` | ~20000 | <= 2 |
| `y = x * one` | ~20000 | <= 2 |
| `y = x / one` | ~20000 | <= 2 |
| `y = x + 1` | ~20000 | <= 2 |
| `y = x - 1` | ~20000 | <= 2 |
| `x += 1; x -= 1` | ~40000 | <= 2 |
| `y = 1.0e100` | ~20000 | <= 2 |

That is one pinned object per boxing store, and two per iteration for the fused pair. A subnormal (`5.0e-324`) gives the same figures, except through OP_ADDI and OP_SUBI where a non-zero integer operand normalises the result so nothing is allocated. Under `MRB_WORDBOX_NO_INLINE_FLOAT` the same figures hold for an ordinary `1.5`.

Cost of the retention, `while i < n; y = x + z; i += 1; end` with `x = 1.0e100`:

| n | before | after |
| --- | ---: | ---: |
| 200000 | 1975 ms | 8 ms |
| 800000 | 153357 ms | 29 ms |

Under `MRB_GC_FIXED_ARENA`, which the `bintest` build in `build_config/ci/gcc-clang.rb` defines, the same loop is not slow but broken. On that build:

```console
$ ./build/bintest/bin/mruby -e 'x = 1.0e100; i = 0; while i < 20000; x + x; i += 1; end; puts "completed"'
trace (most recent call last):
-e:1: NoMemoryError      # before: gc_arena_keep() raises once the arena fills
completed                # after
```

### Tests

The first commit is test-only and rewrites how the existing arena assertions in `test/t/gc.rb` measure. They read `GC.stat[:live]` immediately after the loop and compare the rise against a fixed 5000. That does catch a branch that stops restoring altogether, since reverting the `OP_GETIDX` String restore takes the first assertion from 1 to 20000 and it fails, but the count it reads is the mutator's live set mid-cycle, not what the arena pinned, so a passing run already reports 29 to 806 objects of incremental-sweep lag and the threshold has to clear that. Against the reverted restore, a branch that retained on 4000 of the 20000 iterations reported 4000 and still passed; so did 1000, and 200.

Running the full GC before reading removes the slack entirely: the arena is a GC root, so exactly the pinned objects survive and everything else is swept. The `GC.start` has to be the first send after the loop, because any cfunc return drains the arena. Every assertion now reports 1 on a restoring tree (`OP_SETIDX` reports 2), the margin drops from 5000 to 100, and the 4000, 1000 and 200 partial leaks are all reported exactly and all fail. The smallest leak the assertions can miss goes from roughly 22% of the iterations to 0.5%.

The second commit adds four Float assertions in that shape, covering all five sites at both a subnormal and an out-of-range exponent so they bite on a default host build as well as under `MRB_WORDBOX_NO_INLINE_FLOAT`. With `src/vm.c` reverted and the tests in place, all four fail:

```
Fail: OP_MATH does not retain a boxed Float in the GC arena (core)
Fail: OP_DIV does not retain a boxed Float in the GC arena (core)
Fail: OP_ADDI does not retain a boxed Float in the GC arena (core)
Fail: OP_LOADL does not retain a boxed Float in the GC arena (core)
```

`rake -m test` on the default host build passes at each of the two commits: mrbtest `Total: 2075, KO: 0` after the first and `Total: 2079, OK: 2050, KO: 0, Crash: 0, Warning: 0, Skip: 29` after the second, with bintest `Total: 105, OK: 105, KO: 0`. `MRUBY_CONFIG=ci/gcc-clang rake all` builds clean, and so does `MRUBY_CONFIG=no-float rake all`: under `MRB_NO_FLOAT` the new macro is defined but never expanded, since all five sites sit inside `#ifndef MRB_NO_FLOAT`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved floating-point arithmetic, division, and literal loading across supported boxing configurations.
  * Prevented unnecessary memory retention during repeated floating-point operations.
  * Ensured boxed floating-point results preserve their expected values.

* **Tests**
  * Expanded garbage-collection coverage for floating-point operations.
  * Added checks for memory growth and correct results across arithmetic scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->