### PR TITLE
string.h: fold the coderange's three bits into a two-bit field

### DIFF
--- a/include/mruby/string.h
+++ b/include/mruby/string.h
@@ -51,17 +51,20 @@ struct RStringEmbed {
 #define MRB_STR_EMBED_LEN_BITS 5
 #define MRB_STR_EMBED_LEN_MASK (((1 << MRB_STR_EMBED_LEN_BITS) - 1) << MRB_STR_EMBED_LEN_SHIFT)
 
-#define MRB_STR_SINGLE_BYTE 32
-/* bit 4 is free, and bits 6..10 are the embedded length, so 11 is the first
-   one free above it */
-#define MRB_STR_VALID_ENC 2048
-#define MRB_STR_BROKEN_ENC 4096
+/* Where in the flags word the coderange sits. Its four answers are exclusive,
+   so two bits spell every one of them and spell nothing else. They sit in
+   bits 4-5 because a pair needs two bits in a row and that is the lowest pair
+   the word has free; bits 6..10 above them are the embedded length. Moving
+   them to where the layout wants them is for whenever the word is laid out
+   afresh. */
+#define MRB_STR_CODERANGE_SHIFT 4
+#define MRB_STR_CODERANGE_BITS 2
+#define MRB_STR_CODERANGE_MASK (((1 << MRB_STR_CODERANGE_BITS) - 1) << MRB_STR_CODERANGE_SHIFT)
 
 /* Where in the flags word the encoding index sits. Two bits name four
    encodings, which is more than the two a build carries now; widening them is
-   for whenever a third is carried. They sit above the flags rather than in
-   bit 4, the bit the index leaves behind, because a pair needs two bits in a
-   row and MRB_STR_SINGLE_BYTE holds the one beside it. Moving them down is
+   for whenever a third is carried. They sit above the flags rather than among
+   them, in the pair the coderange left free below them; moving them down is
    for whenever the word is laid out afresh. */
 #define MRB_STR_ENCODING_SHIFT 13
 #define MRB_STR_ENCODING_BITS 2
@@ -106,22 +109,22 @@ struct RStringEmbed {
 #define MRB_STR_CODERANGE_BROKEN  3
 
 #ifdef MRB_UTF8_STRING
-/* Kept for now in the three bits that held the answers one at a time, one bit
-   per answer. Nothing writes two of them, so the order below only decides what
-   a combination no writer makes would read as. 7BIT says more than VALID: a
-   string of nothing but ASCII reads as UTF-8 as it stands, and it is also one
-   character per byte, which is the part every index on it wants. */
+/* The answer read back is the field as it stands: the four are numbered 0..3
+   and the field is two bits wide, so every value it can hold names one of
+   them. That is what a field buys over a bit per answer, where a combination
+   nothing writes had to be given a reading anyway.
+
+   An answer is masked to the field's width on the way in, as an encoding index
+   is, so a fifth one lands wrong rather than reaching the bits beside it. Here
+   those bits are the embedded length rather than free ones, so an unmasked
+   write would not merely be a wrong answer: it would lengthen the string.
+   What is written is one of the four either way, spelled outright or read back
+   out of another string's field, so nothing is left of this at -O3. */
 # define RSTR_CODERANGE(s) \
-  (((s)->flags & MRB_STR_BROKEN_ENC) ? MRB_STR_CODERANGE_BROKEN : \
-   ((s)->flags & MRB_STR_SINGLE_BYTE) ? MRB_STR_CODERANGE_7BIT : \
-   ((s)->flags & MRB_STR_VALID_ENC) ? MRB_STR_CODERANGE_VALID : \
-   MRB_STR_CODERANGE_UNKNOWN)
+  (((s)->flags & MRB_STR_CODERANGE_MASK) >> MRB_STR_CODERANGE_SHIFT)
 # define RSTR_CODERANGE_SET(s, cr) \
-  ((s)->flags = ((s)->flags & \
-                 ~(MRB_STR_SINGLE_BYTE|MRB_STR_VALID_ENC|MRB_STR_BROKEN_ENC)) | \
-                (((cr) == MRB_STR_CODERANGE_7BIT) ? MRB_STR_SINGLE_BYTE : \
-                 ((cr) == MRB_STR_CODERANGE_VALID) ? MRB_STR_VALID_ENC : \
-                 ((cr) == MRB_STR_CODERANGE_BROKEN) ? MRB_STR_BROKEN_ENC : 0))
+  ((s)->flags = ((s)->flags & ~MRB_STR_CODERANGE_MASK) | \
+                (((cr) & ((1 << MRB_STR_CODERANGE_BITS) - 1)) << MRB_STR_CODERANGE_SHIFT))
 #else
 /* A build that indexes by byte hands every byte back as a character and asks
    the bytes nothing, so every string in it stands where 7BIT stands and there


### PR DESCRIPTION
`RString` keeps what reading its bytes as the encoding they carry came back with, and it keeps that answer in three separate bits, one per answer:

```c
#define RSTR_CODERANGE(s) \
  (((s)->flags & MRB_STR_BROKEN_ENC) ? MRB_STR_CODERANGE_BROKEN : \
   ((s)->flags & MRB_STR_SINGLE_BYTE) ? MRB_STR_CODERANGE_7BIT : \
   ((s)->flags & MRB_STR_VALID_ENC) ? MRB_STR_CODERANGE_VALID : \
   MRB_STR_CODERANGE_UNKNOWN)
```

The four answers are exclusive, so three bits can spell states no writer makes, and the order above is there only to decide what such a state would read as. "Not asked yet" has no value of its own either: it is the three bits all being clear, which the reader has to know to spell as `MRB_STR_CODERANGE_UNKNOWN`.

This PR gives the answer bits of its own. The set is closed at four, the same set CRuby names with `ENC_CODERANGE_*`, so two bits hold every one of them and can spell nothing besides.

### What goes into `include/mruby/string.h`

```c
#define MRB_STR_CODERANGE_SHIFT 4
#define MRB_STR_CODERANGE_BITS 2
#define MRB_STR_CODERANGE_MASK (((1 << MRB_STR_CODERANGE_BITS) - 1) << MRB_STR_CODERANGE_SHIFT)

# define RSTR_CODERANGE(s) \
  (((s)->flags & MRB_STR_CODERANGE_MASK) >> MRB_STR_CODERANGE_SHIFT)
# define RSTR_CODERANGE_SET(s, cr) \
  ((s)->flags = ((s)->flags & ~MRB_STR_CODERANGE_MASK) | \
                (((cr) & ((1 << MRB_STR_CODERANGE_BITS) - 1)) << MRB_STR_CODERANGE_SHIFT))
```

The three constants take the shape `MRB_STR_EMBED_LEN_SHIFT` / `_BITS` / `_MASK` and `MRB_STR_ENCODING_SHIFT` / `_BITS` / `_MASK` already use for the other two fields in the word.

`MRB_STR_CODERANGE_UNKNOWN` stays 0, so the zeroed flags of a freshly allocated string already say it and the path every string is made on still stores nothing.

The three bits go with the answers they held. Since f51a52e72 put the last readers and writers on the accessors, every mention of them on master is inside this header, and nothing outside it changes:

```
$ git grep -nE 'MRB_STR_SINGLE_BYTE|MRB_STR_VALID_ENC|MRB_STR_BROKEN_ENC'   # on master
include/mruby/string.h:54:#define MRB_STR_SINGLE_BYTE 32
include/mruby/string.h:57:#define MRB_STR_VALID_ENC 2048
include/mruby/string.h:58:#define MRB_STR_BROKEN_ENC 4096
include/mruby/string.h:64:   row and MRB_STR_SINGLE_BYTE holds the one beside it. Moving them down is
include/mruby/string.h:115:  (((s)->flags & MRB_STR_BROKEN_ENC) ? MRB_STR_CODERANGE_BROKEN : \
include/mruby/string.h:116:   ((s)->flags & MRB_STR_SINGLE_BYTE) ? MRB_STR_CODERANGE_7BIT : \
include/mruby/string.h:117:   ((s)->flags & MRB_STR_VALID_ENC) ? MRB_STR_CODERANGE_VALID : \
include/mruby/string.h:121:                 ~(MRB_STR_SINGLE_BYTE|MRB_STR_VALID_ENC|MRB_STR_BROKEN_ENC)) | \
include/mruby/string.h:122:                (((cr) == MRB_STR_CODERANGE_7BIT) ? MRB_STR_SINGLE_BYTE : \
include/mruby/string.h:123:                 ((cr) == MRB_STR_CODERANGE_VALID) ? MRB_STR_VALID_ENC : \
include/mruby/string.h:124:                 ((cr) == MRB_STR_CODERANGE_BROKEN) ? MRB_STR_BROKEN_ENC : 0))

$ git grep -nE 'MRB_STR_SINGLE_BYTE|MRB_STR_VALID_ENC|MRB_STR_BROKEN_ENC'   # on this branch
$
```

### Where the field sits

Bits 4-5 are the lowest pair the flags word has free. Bit 4 came free with 839b1640b, and bit 5 is the first of the three this PR folds.

| bit | before | after |
| --- | --- | --- |
| 0-3 | `MRB_STR_TYPE_MASK` | `MRB_STR_TYPE_MASK` |
| 4 | free | `MRB_STR_CODERANGE_MASK` |
| 5 | `MRB_STR_SINGLE_BYTE` | `MRB_STR_CODERANGE_MASK` |
| 6-10 | `MRB_STR_EMBED_LEN_MASK` | `MRB_STR_EMBED_LEN_MASK` |
| 11 | `MRB_STR_VALID_ENC` | free |
| 12 | `MRB_STR_BROKEN_ENC` | free |
| 13-14 | `MRB_STR_ENCODING_MASK` | `MRB_STR_ENCODING_MASK` |

Three bits go in and two come out, so bits 11-12 come free as a pair. Where the field finally sits is for whenever the word is laid out afresh, as is where the encoding index finally sits: neither move is in this PR.

### The write is masked to the field

`RSTR_ENCODING_SET()` masks its index to the width of its field as of f90657dfd. This write does the same, and here the reason is sharper: the bits above this field are the embedded length rather than free ones.

```c
RSTR_CODERANGE_SET(s, 4)   /* 4 << 4 == 64 == bit 6: one more embedded byte */
```

A fifth answer is a mistake either way, and widening `MRB_STR_CODERANGE_BITS` is what carrying one would need. What the mask decides is whether the mistake stays a wrong answer instead of becoming a longer string.

### The three bits leave a public header

`include/mruby/string.h` is a public header, so an out of tree gem that names one of the three stops compiling. That is the point, and it matters more here than it did for `MRB_STR_BINARY` in 839b1640b: those values are not merely unread now, they name parts of a field that reads back as a different answer.

| written by an out of tree gem | what it says now |
| --- | --- |
| `s->flags \|= 32` (`MRB_STR_SINGLE_BYTE`) | bit 5 alone, which is `MRB_STR_CODERANGE_VALID` |
| `s->flags \|= 2048` (`MRB_STR_VALID_ENC`) | a free bit, so the answer stays `MRB_STR_CODERANGE_UNKNOWN` |
| `s->flags \|= 4096` (`MRB_STR_BROKEN_ENC`) | a free bit, likewise |

An alias would keep every one of those compiling while it stopped meaning what it meant, which is the failure this shape is meant to prevent. A compile error names the lines to change, and what to change them to is the accessors that have been there since f51a52e72:

| was | is |
| --- | --- |
| `s->flags & MRB_STR_SINGLE_BYTE` | `RSTR_CODERANGE(s) == MRB_STR_CODERANGE_7BIT` |
| `s->flags & MRB_STR_VALID_ENC` | `RSTR_CODERANGE(s) == MRB_STR_CODERANGE_VALID` |
| `s->flags & MRB_STR_BROKEN_ENC` | `RSTR_CODERANGE(s) == MRB_STR_CODERANGE_BROKEN` |
| `s->flags \|= MRB_STR_SINGLE_BYTE` | `RSTR_CODERANGE_SET(s, MRB_STR_CODERANGE_7BIT)` |
| `s->flags &= ~MRB_STR_SINGLE_BYTE` | `RSTR_CODERANGE_SET(s, MRB_STR_CODERANGE_UNKNOWN)` |

Names in this family have left the header before: `MRB_STR_BINARY` in 839b1640b, `RSTR_SET_BINARY_FLAG()` and its companions in 48484672e, the unused unset macros in c18cd60c4, and the ASCII flag renamed to `MRB_STR_SINGLE_BYTE` in 57fd0edaa.

### Builds that index by byte

A build without `MRB_UTF8_STRING` keeps `RSTR_CODERANGE()` at `MRB_STR_CODERANGE_7BIT` and `RSTR_CODERANGE_SET()` a no-op, so it carries no field at all, exactly as before. `RSTR_ENC_CR_COPY()` and `RSTR_ENC_CR_COPY_FOR_SUBSTR()` still copy the encoding there, which `str_replace()` needs in every build.

### Generated code

`gcc -O3`, against the same objects built from master. Each of the four builds `ci/gcc-clang` makes:

| build | objects differing | `.text` |
| --- | --- | --- |
| full-debug | 6 of 217 | 2634682 to 2633722 (-960) |
| bintest | 6 of 226 | 1822157 to 1820549 (-1608) |
| cxx_abi | 6 of 217 | 1850734 to 1849878 (-856) |
| byte-string | 0 of 215 | 1800685, unchanged |

The objects that differ are the ones that name the accessors: `src/string.o`, `src/object.o`, `src/symbol.o`, `src/numeric.o`, `mruby-string-ext`, and `mruby-time`. Comparison is `objdump -d` over every `.o` in the build; every other object is identical instruction for instruction, and in `byte-string`, where the field does not exist, so is every object there is.

The shrinking is the immediate. On x86-64 a mask over bits 4 and 5 fits one byte and one that reaches bit 11 or 12 does not. Where the compiler has the flags word shifted down to work on, as in `mrb_str_byte_subseq()` asking whether the source is 7BIT and writing the answer, the instruction goes from six bytes to three:

```
   4552:  81 e1 20 10 00 00     and    $0x1020,%ecx        <- 7BIT set and BROKEN clear
   4558:  83 f9 20              cmp    $0x20,%ecx
   455b:  0f 94 c1              sete   %cl
   455e:  81 e2 df e7 ff ff     and    $0xffffe7df,%edx    <- clear the three
   456c:  c1 e1 05              shl    $0x5,%ecx

   4622:  83 e1 30              and    $0x30,%ecx          <- read the field
   4625:  83 f9 10              cmp    $0x10,%ecx
   4628:  0f 94 c1              sete   %cl
   462b:  83 e2 cf              and    $0xffffffcf,%edx    <- clear the field
   4636:  c1 e1 04              shl    $0x4,%ecx
```

Where it works on the word in place instead, the mask is shifted up past a byte either way and the instruction keeps its width, which is why some of the six differ in what they hold without changing size.

This gives back what 839b1640b took on when it put the encoding index in bits 13 and 14, for the field that is read and written far more often.

### Testing

`rake -m test` over `ci/gcc-clang`, all four builds green, 0 KO, 0 crash, 0 warnings:

| build | result |
| --- | --- |
| full-debug | 2302 tests, 2300 OK, 2 skip |
| bintest | 2303 tests, 2293 OK, 10 skip, plus 117 bintests |
| cxx_abi | 2303 tests, 2293 OK, 10 skip |
| byte-string | 2239 tests, 2210 OK, 29 skip |

`byte-string` is the build without `mruby-encoding`, where strings index by byte and no field is carried. The other three are what pin the fold: every path that records an answer or copies one runs there, `String#valid_encoding?` and `String#scrub` for the recording, `String#*` and `String#replace` for the whole copy, byte slicing for the copy that carries 7BIT alone.

No test accompanies the change. No string answers anything different, so there is nothing new to pin.

### Not in this PR

The encoding index does not move, the field does not go to its final position, and nothing new writes a coderange.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal string encoding metadata into a compact two-bit coderange field.
  * Updated coderange reading and writing to use the packed representation with bounds protection.
  * Replaced obsolete encoding flag constants with the new coderange field definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->