### PR TITLE
mruby-regexp, mruby-task: ask the build what it defines

### DIFF
--- a/mrbgems/mruby-regexp/mrbgem.rake
+++ b/mrbgems/mruby-regexp/mrbgem.rake
@@ -45,10 +45,15 @@ MRuby::Gem::Specification.new('mruby-regexp') do |spec|
   # patterns (one that /i folds them, the other that /i refuses to compile
   # them), so each belongs to exactly one of the two builds. Everything /i
   # does the same way in both is in the unconditional test files and
-  # always runs.
-  if build.cc.defines.include?('MRB_REGEXP_UNICODE_CASE')
-    spec.test_rbfiles -= ["#{spec.dir}/test/ascii_case.rb"]
-  else
-    spec.test_rbfiles -= ["#{spec.dir}/test/unicode_case.rb"]
+  # always runs. What the build defines can only be asked once every gem has
+  # had its say, which is what `build_settings` waits for; this gem sets no
+  # build command in the block above, so the reset that comes with it drops
+  # nothing.
+  spec.build_settings do
+    if build.has_define?('MRB_REGEXP_UNICODE_CASE')
+      spec.test_rbfiles -= ["#{spec.dir}/test/ascii_case.rb"]
+    else
+      spec.test_rbfiles -= ["#{spec.dir}/test/unicode_case.rb"]
+    end
   end
 end

--- a/mrbgems/mruby-task/mrbgem.rake
+++ b/mrbgems/mruby-task/mrbgem.rake
@@ -6,44 +6,50 @@ MRuby::Gem::Specification.new('mruby-task') do |spec|
   # Enable task scheduler globally (required for vm.c integration)
   spec.build.defines << 'MRB_USE_TASK_SCHEDULER'
 
-  if spec.for_windows?
-    spec.linker.libraries << "winmm"
-  end
-
-  ports = spec.build.effective_ports
-
-  # ports/glib/ needs glib-2.0 (GSource, GMainContext, GRecMutex) and
-  # gthread-2.0 (GThread). On modern distros gthread-2.0 is a transparent
-  # alias for glib-2.0; on older ones it's a separate .pc that pulls in
-  # -lpthread, so query it separately.
-  if ports.include?('glib')
-    unless spec.search_package('glib-2.0') && spec.search_package('gthread-2.0')
-      abort <<~MSG
-        [mruby-task] conf.ports :glib selected but pkg-config could not find
-        glib-2.0 / gthread-2.0. Install the GLib development headers
-        (Debian/Ubuntu: libglib2.0-dev; Fedora: glib2-devel; Arch: glib2;
-        macOS Homebrew: glib). For non-default install locations, set
-        PKG_CONFIG_PATH before invoking rake.
-      MSG
+  # What the build defines can only be asked once every gem has had its say,
+  # which is what `build_settings` waits for. The reset it comes with drops
+  # any build command set outside it, so the linker library and the
+  # pkg-config query below sit in here too.
+  spec.build_settings do
+    if spec.for_windows?
+      spec.linker.libraries << "winmm"
     end
-  end
 
-  # Optional demo tool that exercises the GLib HAL end-to-end (basic
-  # scheduling, priority ordering, timeslice preemption, auto-execution
-  # under a foreign GLib main loop). Default off; opt in from your
-  # build_config with:
-  #
-  #     conf.cc.defines << 'MRB_TASK_BUILD_DEMO'
-  #     conf.ports :glib
-  #     conf.gem core: 'mruby-task'
-  #
-  # When enabled, `rake` produces bin/mruby-task-demo from
-  # tools/mruby-task-demo/. The define is only inspected here -- the
-  # demo's C source does not condition on it.
-  if spec.build.cc.defines.include?('MRB_TASK_BUILD_DEMO')
-    unless ports.include?('glib')
-      abort '[mruby-task] MRB_TASK_BUILD_DEMO requires conf.ports :glib'
+    ports = spec.build.effective_ports
+
+    # ports/glib/ needs glib-2.0 (GSource, GMainContext, GRecMutex) and
+    # gthread-2.0 (GThread). On modern distros gthread-2.0 is a transparent
+    # alias for glib-2.0; on older ones it's a separate .pc that pulls in
+    # -lpthread, so query it separately.
+    if ports.include?('glib')
+      unless spec.search_package('glib-2.0') && spec.search_package('gthread-2.0')
+        abort <<~MSG
+          [mruby-task] conf.ports :glib selected but pkg-config could not find
+          glib-2.0 / gthread-2.0. Install the GLib development headers
+          (Debian/Ubuntu: libglib2.0-dev; Fedora: glib2-devel; Arch: glib2;
+          macOS Homebrew: glib). For non-default install locations, set
+          PKG_CONFIG_PATH before invoking rake.
+        MSG
+      end
     end
-    spec.bins = %w(mruby_task_demo)
+
+    # Optional demo tool that exercises the GLib HAL end-to-end (basic
+    # scheduling, priority ordering, timeslice preemption, auto-execution
+    # under a foreign GLib main loop). Default off; opt in from your
+    # build_config with:
+    #
+    #     conf.cc.defines << 'MRB_TASK_BUILD_DEMO'
+    #     conf.ports :glib
+    #     conf.gem core: 'mruby-task'
+    #
+    # When enabled, `rake` produces bin/mruby-task-demo from
+    # tools/mruby-task-demo/. The define is only inspected here -- the
+    # demo's C source does not condition on it.
+    if build.has_define?('MRB_TASK_BUILD_DEMO')
+      unless ports.include?('glib')
+        abort '[mruby-task] MRB_TASK_BUILD_DEMO requires conf.ports :glib'
+      end
+      spec.bins = %w(mruby_task_demo)
+    end
   end
 end


### PR DESCRIPTION
Two GEMs read a build define out of `build.cc.defines`, which is the C compiler's list alone. A build that sets the define through `conf.defines`, which puts it on every compiler, compiles under the `-D` and is not seen here, so the GEM configures itself for a build it is not in. One symptom is a failing test, the other is a tool that never appears.

### `mruby-regexp` hands mrbtest the wrong test file

```ruby
MRuby::Build.new('probe') do |conf|
  conf.toolchain
  conf.gembox 'full-core'
  conf.defines << 'MRB_REGEXP_UNICODE_CASE'
  conf.enable_test
end
```

The engine is compiled with Unicode simple case folding, and the GEM hands mrbtest `test/ascii_case.rb`, the file that asserts `/i` refuses the very patterns the engine now folds. On master:

```
Fail: Regexp - /i refuses what ASCII folding cannot answer (mrbgems: mruby-regexp)
  Total: 2303
     KO: 1
```

### `mruby-task` drops the tool the option asks for

`MRB_TASK_BUILD_DEMO` is a switch a build configuration throws to get `bin/mruby_task_demo`. Thrown through `conf.defines`, the GEM takes no binary, and nothing reports that the option went nowhere.

### Both ask `MRuby::Build#has_define?` instead

a3513b6f8 added that reader for this and left it without a caller. It spans `build.defines` and every compiler's list, and matches on the name, so a define written as `FOO=1` answers under `FOO`.

It has to be asked from `spec.build_settings`: a GEM contributes its defines while the GEMs are still being set up, so the answer during that phase depends on where the caller sits in the list, and `has_define?` refuses there rather than give one.

`build_settings` resets a GEM's build commands to the build's, so `mruby-task`'s `winmm` library and its pkg-config query move into the block along with the question. Left outside they would be set during setup and then dropped. `mruby-regexp` sets no build command in its own block, so nothing moves there.

### Verified

The `conf.defines` config above reports `Total 2302 KO 0`, one test fewer than the 2303 of the same config without the option, which is the ASCII file's two tests giving way to the Unicode file's one.

`MRUBY_CONFIG=ci/gcc-clang rake -m test`, four builds and the bintests, KO 0. `full-debug` sets the option through `conf.cc.defines` and still gets the Unicode file:

```
bintest       117 bintests
bintest       2303   Skip 10
byte-string   2239   Skip 29
cxx_abi       2303   Skip 10
full-debug    2302   Skip 2
```

`MRUBY_CONFIG=default rake -m test`, `Total 2085 KO 0` plus 106 bintests, on each commit of this PR.

For `mruby-task`, `build_config/glib_hal_test.rb` sets the option through `conf.cc.defines` and builds under `-fsanitize=address,undefined`: it produces `bin/mruby_task_demo`, and the demo runs every scenario through to `All scenarios completed.` The same config without the demo passes `rake -m test` with `Total 832 KO 0`, so the glib port still compiles and links from the flags this block gathers.

### Not fixed here

`rake test` on a build that turns the demo on cannot link `mrbtest`: `MRuby::Gem::List#linker_attrs` drops a GEM that owns a binary, and the glib libraries go with it. That is on master today and is a separate matter from which list the define is read out of.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build configuration so regular expression tests use the final Unicode case-folding settings.
  * Improved task-related builds by reliably detecting platform capabilities and demo requirements.
  * Preserved required Windows multimedia linking and GLib validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->