### PR TITLE
mruby-bin-mrbc: take the target define from the compiler gem

### DIFF
--- a/mrbgems/mruby-bin-mrbc/mrbgem.rake
+++ b/mrbgems/mruby-bin-mrbc/mrbgem.rake
@@ -10,24 +10,20 @@ MRuby::Gem::Specification.new 'mruby-bin-mrbc' do |spec|
   build.bins << exe_name
 
   build_settings do
+    # The compiler gem is set up by the time this block runs, whatever order
+    # the gems were processed in.
+    compiler = build.gems['mruby-compiler']
+
     spec.cc.include_paths << "#{MRUBY_ROOT}/mrbgems/mruby-compiler/lib/prism/include"
 
     # The layout of struct mrc_ccontext depends on MRC_TARGET_*; the tool's own
     # translation units must use the same target define as mruby-compiler,
     # otherwise field offsets (e.g. diagnostic_list) disagree across the link.
-    spec.cc.defines.flatten!
-    if spec.cc.defines.include?('PICORB_VM_MRUBY')
-      spec.cc.defines << 'MRC_TARGET_MRUBY'
-    elsif spec.cc.defines.include?('PICORB_VM_MRUBYC')
-      spec.cc.defines << 'MRC_TARGET_MRUBYC'
-    elsif !spec.cc.defines.include?('MRB_NO_GEMS')
-      spec.cc.defines << 'MRC_TARGET_MRUBY'
-    end
+    # Copy the one that gem settled on rather than deriving it a second time
+    # from the same build: two derivations can disagree, a copy cannot.
+    spec.cc.defines += compiler.cc.defines.flatten.grep(/\AMRC_TARGET_/)
 
     mrbc_prism_objs = Dir.glob("#{dir}/tools/mrbc/*.c").map { |f| objfile(f.pathmap("#{build_dir}/tools/mrbc/%n")) }
-    # Ensure the compiler gem is set up so its objs are available regardless of
-    # the order in which gems are processed (setup is idempotent).
-    compiler = build.gems['mruby-compiler']
     mrbc_prism_objs += compiler.objs
     mrbc_prism_objs.delete_if { |o| o.include?('gem_init') || o.include?('mruby_compat') }
 


### PR DESCRIPTION
`MRC_TARGET_*` decides the layout of `struct mrc_ccontext`, so `mruby-bin-mrbc`'s translation units and `mruby-compiler`'s have to carry the same one. Each derives it on its own today, from the same three questions:

```ruby
if cc.defines.include?('PICORB_VM_MRUBY')
  cc.defines << 'MRC_TARGET_MRUBY'
elsif cc.defines.include?('PICORB_VM_MRUBYC')
  cc.defines << 'MRC_TARGET_MRUBYC'
elsif !cc.defines.include?('MRB_NO_GEMS')
  cc.defines << 'MRC_TARGET_MRUBY'
end
```

The two derivations read the same list at different moments. `mruby-compiler` reads its copy while the GEMs are being set up; `mruby-bin-mrbc` asks from `build_settings`, whose reset hands it a copy taken once every GEM is set up. A `PICORB_VM_*` that arrives in between is in one answer and not the other:

```ruby
MRuby::Build.new('probe') do |conf|
  conf.toolchain
  conf.gembox 'full-core'
  conf.gem "#{MRUBY_ROOT}/examples/mrbgems/c_extension_example" do |g|
    g.build.cc.defines << 'PICORB_VM_MRUBYC'
  end
end
```

`mruby-compiler` answers `MRC_TARGET_MRUBY` there and the tool answers `MRC_TARGET_MRUBYC`, both compiling under `-DPICORB_VM_MRUBYC`. Nothing fails: the two disagree about where the fields of `struct mrc_ccontext` are, and that reaches the link as offsets, not as an error.

This PR copies what `mruby-compiler` settled on instead of deriving it a second time:

```ruby
spec.cc.defines += compiler.cc.defines.flatten.grep(/\AMRC_TARGET_/)
```

The GEM is set up by the time this block runs, whatever order the GEMs were processed in, so the copy holds whatever it decided. A build that defines `MRB_NO_GEMS` with no `PICORB_VM_*` still gets no target define on either side, which is what the `mrbc` sub-build does.

`spec.cc.defines.flatten!` goes with the `include?` calls it was there for: a build configuration may push an array, which `include?` cannot see through. The compile line flattens the list again when it assembles the flags.

### Verified

Both GEMs answer `MRC_TARGET_MRUBY` on the probe above, and the `mrbc` sub-build gets no target define on either side, as before.

`MRUBY_CONFIG=ci/gcc-clang rake -m test`, four builds and the bintests, KO 0:

```
bintest       117 bintests
bintest       2303   Skip 10
byte-string   2239   Skip 29
cxx_abi       2303   Skip 10
full-debug    2302   Skip 2
```

`MRUBY_CONFIG=default rake -m test`, `Total 2085 KO 0` plus 106 bintests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compiler configuration handling during builds.
  * Ensured target-specific compiler definitions are applied consistently, improving build reliability across supported configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->