### PR TITLE
build: hold the build's own defines in a separate list

### DIFF
--- a/lib/mruby/build.rb
+++ b/lib/mruby/build.rb
@@ -170,7 +170,7 @@ module MRuby
 
     def enable_debug
       compilers.each do |c|
-        c.defines += %w(MRB_DEBUG)
+        c.internal_defines += %w(MRB_DEBUG)
         c.setup_debug(self)
       end
       @mrbc.compile_options += ' -g'
@@ -225,7 +225,7 @@ module MRuby
       end
       @cxx_exception_enabled = true
       compilers.each { |c|
-        c.defines += %w(MRB_USE_CXX_EXCEPTION)
+        c.internal_defines += %w(MRB_USE_CXX_EXCEPTION)
         c.flags << c.cxx_exception_flag
       }
       linker.command = cxx.command if toolchains.find { |v| v == 'gcc' }
@@ -245,7 +245,7 @@ module MRuby
         raise "cxx_exception already enabled"
       end
       compilers.each { |c|
-        c.defines += %w(MRB_USE_CXX_EXCEPTION MRB_USE_CXX_ABI)
+        c.internal_defines += %w(MRB_USE_CXX_EXCEPTION MRB_USE_CXX_ABI)
         c.flags << c.cxx_compile_flag
         c.flags = c.flags.flatten - c.cxx_invalid_flags.flatten
       }
@@ -388,8 +388,9 @@ EOS
     end
 
     # True when this build compiles with -D<name>, whether the build config
-    # asked for it or a gem contributed it.  A gem reads this to configure
-    # itself against a capability another gem provides.
+    # asked for it, a gem contributed it, or the build added it from one of
+    # its own switches.  A gem reads this to configure itself against a
+    # capability another gem provides.
     #
     # Until `defines_final!` the answer would depend on how far down the gem
     # list the caller sits, since a gem contributes its defines when its own
@@ -406,8 +407,8 @@ EOS
       # A define may carry a value, as `FOO=1` does, so compare the name and
       # not the value.  The `-D` is the compiler's, added when the flags are
       # assembled, and is no part of the name.
-      [defines, *compilers.map(&:defines)].flatten
-        .any? {|d| d.to_s.split('=', 2).first == name}
+      return true if defines.flatten.any? {|d| d.to_s.split('=', 2).first == name}
+      compilers.any? {|c| c.has_define?(name)}
     end
 
     def define_rules

--- a/lib/mruby/build/command.rb
+++ b/lib/mruby/build/command.rb
@@ -36,6 +36,13 @@ module MRuby
 
   class Command::Compiler < Command
     attr_accessor :label, :flags, :include_paths, :defines, :source_exts
+    # Defines are held in two lists, split by who asked for them. `defines` is
+    # what the build config and the gems write. `internal_defines` is what the
+    # build adds on its own behalf, from its own switches (`enable_debug`,
+    # `enable_cxx_abi`) or from a toolchain. Both reach the compiler as `-D`;
+    # keeping them apart lets a toolchain set its own without overwriting what
+    # the config already wrote, and lets a caller ask for one list alone.
+    attr_accessor :internal_defines
     attr_accessor :compile_options, :option_define, :option_include_path, :out_ext
     attr_accessor :cxx_compile_flag, :cxx_exception_flag, :cxx_invalid_flags
     attr_writer :preprocess_options
@@ -48,6 +55,7 @@ module MRuby
       @source_exts = source_exts
       @include_paths = ["#{MRUBY_ROOT}/include"]
       @defines = []
+      @internal_defines = []
       @option_include_path = %q[-I"%s"]
       @option_define = %q[-D"%s"]
       @compile_options = %q[%{flags} -o "%{outfile}" -c "%{infile}"]
@@ -59,6 +67,18 @@ module MRuby
 
     def preprocess_options
       @preprocess_options ||= @compile_options.sub(/(?:\A|\s)\K-c(?=\s)/, "-E -P")
+    end
+
+    # True when this compiler compiles with -D<name>, whichever of the two
+    # lists it sits in. A gem asks this while its own mrbgem.rake body runs,
+    # where `Build#has_define?` refuses to answer because the gems that come
+    # after it have not contributed their defines yet.
+    def has_define?(name)
+      name = name.to_s
+      # A define may carry a value, as `FOO=1` does, so compare the name and
+      # not the value.
+      [defines, internal_defines].flatten
+        .any? {|d| d.to_s.split('=', 2).first == name}
     end
 
     def search_header_path(name)
@@ -73,7 +93,8 @@ module MRuby
     end
 
     def all_flags(_defines=[], _include_paths=[], _flags=[])
-      define_flags = [defines, _defines, build.defines].flatten.map{ |d| option_define % d }
+      define_flags = [defines, internal_defines, _defines, build.defines].flatten
+                       .map{ |d| option_define % d }
       include_path_flags = [include_paths, _include_paths].flatten.map do |f|
         option_include_path % filename(f)
       end

--- a/mrbgems/mruby-compiler/mrbgem.rake
+++ b/mrbgems/mruby-compiler/mrbgem.rake
@@ -30,7 +30,7 @@ MRuby::Gem::Specification.new('mruby-compiler') do |spec|
   elsif !cc.defines.include?('MRB_NO_GEMS')
     cc.defines << 'MRC_TARGET_MRUBY'
   end
-  cc.defines << 'MRC_DEBUG' if cc.defines.any? { |d| d.match?(/\AMRB_DEBUG(=|\z)/) }
+  cc.defines << 'MRC_DEBUG' if cc.has_define?('MRB_DEBUG')
   cc.defines << 'PRISM_BUILD_MINIMAL' unless cc.defines.include?('MRC_DEBUG')
   # PRISM_BUILD_MINIMAL stubs out pm_prettyprint(), so `mruby -v` can only dump
   # the AST where it is compiled in

--- a/tasks/toolchains/visualcpp.rake
+++ b/tasks/toolchains/visualcpp.rake
@@ -9,7 +9,7 @@ MRuby::Toolchain.new(:visualcpp) do |conf, _params|
       compiler.command = ENV['CXX'] || 'cl.exe'
       compiler.flags = [*(ENV['CXXFLAGS'] || ENV['CFLAGS'] || compiler_flags + %w(/EHs))]
     end
-    compiler.defines = %w(MRB_STACK_EXTEND_DOUBLING)
+    compiler.internal_defines |= %w(MRB_STACK_EXTEND_DOUBLING)
     compiler.option_include_path = %q[/I"%s"]
     compiler.option_define = '/D%s'
     compiler.compile_options = %Q[/Zi /c /Fo"%{outfile}" %{flags} "%{infile}"]


### PR DESCRIPTION
`Command::Compiler#defines` holds two kinds of define at once. Most of what
lands there is what the build configuration and the gems asked for. Four sites
write the other kind, where the build adds a define on its own behalf because
one of its switches was flipped:

| site | define | switch |
| --- | --- | --- |
| `lib/mruby/build.rb` `enable_debug` | `MRB_DEBUG` | `conf.enable_debug` |
| `lib/mruby/build.rb` `enable_cxx_exception` | `MRB_USE_CXX_EXCEPTION` | `conf.enable_cxx_exception` |
| `lib/mruby/build.rb` `enable_cxx_abi` | `MRB_USE_CXX_EXCEPTION`, `MRB_USE_CXX_ABI` | `conf.enable_cxx_abi` |
| `tasks/toolchains/visualcpp.rake` | `MRB_STACK_EXTEND_DOUBLING` | `conf.toolchain :visualcpp` |

This PR moves those four into `internal_defines`, a second list on the same
object. `Command::Compiler#all_flags` reads both, so every build compiles with
the same `-D` set as before, and a build configuration keeps writing
`conf.cc.defines` the way it does today.

### The toolchain overwrote the configuration

The `visualcpp` site is not an append but an assignment:

```ruby
compiler.defines = %w(MRB_STACK_EXTEND_DOUBLING)
```

so a configuration that named its own defines before selecting the toolchain
lost them:

```ruby
MRuby::Build.new('msvc') do |conf|
  conf.cc.defines << 'MRB_NO_STDIO'
  toolchain :visualcpp
end
```

| | `cc.defines` | `cc.internal_defines` | `-D` on the command line |
| --- | --- | --- | --- |
| master | `["MRB_STACK_EXTEND_DOUBLING"]` | | `/DMRB_STACK_EXTEND_DOUBLING` |
| this PR | `["MRB_NO_STDIO"]` | `["MRB_STACK_EXTEND_DOUBLING"]` | `/DMRB_NO_STDIO /DMRB_STACK_EXTEND_DOUBLING` |

`MRB_NO_STDIO` was gone from the build, silently. Nothing in the tree is bitten
today: `build_config/ci/msvc.rb` and the other MSVC configurations call
`conf.toolchain :visualcpp` before they name a define, which is the one order
that survives. The toolchain now writes a list no configuration writes, so the
order stops mattering.

### `has_define?`

`Command::Compiler#has_define?` answers from both lists, comparing the name and
not the value so a define carrying one (`FOO=1`) still matches. `mruby-compiler`
is the one gem that has to read a build switch, and it reads it here:

```ruby
# mrbgems/mruby-compiler/mrbgem.rake
cc.defines << 'MRC_DEBUG' if cc.has_define?('MRB_DEBUG')
```

It cannot ask `build.has_define?`: that refuses to answer until
`defines_final!`, because a gem contributes its defines when its own
mrbgem.rake body runs, and this line runs during that pass. Asking the compiler
is the answer that does not depend on gem order, since the build wrote
`MRB_DEBUG` before any gem was set up. Without the change the test would read
`false` under `conf.enable_debug`, `MRC_DEBUG` would go missing, and
`PRISM_BUILD_MINIMAL` would stub out `pm_prettyprint()`, taking the AST dump of
`mruby -v` with it.

`Build#has_define?` covers `internal_defines` too, so a build switch stays
visible to a gem that asks about it from `spec.build_settings`.

### Testing

`rake -m test`, all green:

| build | tests |
| --- | --- |
| default `build_config/default.rb` | 2085 total, 2056 OK, 29 skip, 0 KO, 0 crash |
| full-core with `conf.enable_debug` | 2303 total, 2301 OK, 2 skip, 0 KO, 0 crash |
| full-core with `conf.enable_cxx_abi` | 2303 total, 2293 OK, 10 skip, 0 KO, 0 crash |

The debug build's `-D` set is unchanged and `MRC_DEBUG` survives the move:

```console
$ build/host-debug/bin/mruby -v -e 'p 1'
mruby 4.0.0 (2026-04-20)
@ ProgramNode (location: (1,0)-(1,3))
+-- locals: []
+-- statements:
...
```

The C++ ABI build compiles with `MRB_USE_CXX_EXCEPTION MRB_USE_CXX_ABI` as
before, and `mruby-compiler` still adds `__STDC_LIMIT_MACROS` and
`__STDC_CONSTANT_MACROS` from `build.cxx_abi_enabled?`.

No test accompanies the change. The Rake build has no test harness of its own,
and the three builds above are what exercises the four moved sites.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compiler configuration handling so debug and C++ build options are applied more consistently.
  * Ensured internally selected build settings are recognized when checking compiler capabilities.
  * Improved Visual C++ builds by correctly applying stack extension behavior.
  * Updated compiler configuration documentation to better reflect supported build settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->