### PR TITLE
amalgam: write the build's defines into the generated header

### DIFF
--- a/doc/guides/amalgamation.md
+++ b/doc/guides/amalgamation.md
@@ -139,11 +139,22 @@ Typical sizes depend on included gems:
 - Local includes (`.cstub` files) are automatically inlined
 - Generated files (`mrblib.c`, `gem_init.c`) are included
 
-### Gem Defines
+### Build Configuration Defines
 
-Gems that add preprocessor defines affecting core structures are
-automatically detected and included at the top of `mruby.h`.
-Supported patterns: `MRB_USE_*`, `MRB_UTF8_*`, `HAVE_MRUBY_*`.
+The defines the build compiles with are written at the top of `mruby.h`, so
+that including it is enough to get the same `mrb_value` layout, integer width
+and feature set as the build the amalgamation was generated from. Both the
+defines the build configuration names (`conf.cc.defines`) and the ones gems
+contribute (`spec.build.defines`) are emitted. Each is wrapped in `#ifndef`,
+so passing the same define on the command line is not a redefinition.
+
+Two kinds are not written, and are left to whoever compiles the amalgamation:
+
+- `MRB_DEBUG`, which only decides whether `mrb_assert` checks. `-DNDEBUG`
+  above is the same kind of choice.
+- `MRB_USE_CXX_EXCEPTION` and `MRB_USE_CXX_ABI`, which require a C++
+  compiler. `mruby.c` is C, so a header that demanded them could not be
+  compiled as generated.
 
 ### Build Order
 

--- a/lib/mruby/amalgam.rb
+++ b/lib/mruby/amalgam.rb
@@ -250,25 +250,43 @@ module MRuby
 
       PREAMBLE
 
-      # Add build-level defines from gems (e.g., MRB_USE_TASK_SCHEDULER)
-      gem_defines = collect_gem_defines
-      unless gem_defines.empty?
-        f.puts "/* Gem-required defines */"
-        gem_defines.each do |d|
-          f.puts "#define #{d}"
+      build_defines = collect_build_defines
+      unless build_defines.empty?
+        f.puts "/* Build configuration defines */"
+        build_defines.each do |name, value|
+          f.puts "#ifndef #{name}"
+          f.puts(value ? "#define #{name} #{value}" : "#define #{name}")
+          f.puts "#endif"
         end
         f.puts
       end
     end
 
-    # Collect defines added by gems that affect core headers
-    def collect_gem_defines
-      defines = []
-      @build.defines.each do |d|
-        # Include defines that affect mrb_state or core functionality
-        defines << d if d =~ /^MRB_USE_|^MRB_UTF8_|^HAVE_MRUBY_/
+    # The defines this build compiles with, which the consumer must compile with
+    # too: they decide the layout of `mrb_value` and `mrb_state` and which
+    # functions exist, so a header read without them describes a different
+    # mruby than the one in mruby.c. The build config writes most of them
+    # (`MRB_NO_STDIO`, `MRB_INT64`, the boxing choice), a gem writes the rest
+    # through `spec.build.defines` (`MRB_USE_BIGINT`, `HAVE_MRUBY_IO_GEM`);
+    # neither is distinguishable from the header's side, so both are emitted.
+    #
+    # `internal_defines` is left out on purpose: it holds what the build adds
+    # from its own switches, and `MRB_USE_CXX_ABI` there would make the header
+    # unusable from C. `cxx.defines` is left out for the same reason, the
+    # amalgam being C. The consumer that wants a C++ build passes those itself.
+    def collect_build_defines
+      defines = {}
+      [@build.defines, @build.cc.defines].flatten.each do |d|
+        name, value = d.to_s.split("=", 2)
+        next unless name =~ /\A[A-Za-z_][A-Za-z0-9_]*\z/
+        next if name.start_with?("__STDC_")
+        # First writer wins, `@build.defines` over `@build.cc.defines`, which is
+        # the way the two land on the command line: `all_flags` puts
+        # `build.defines` last and the last `-D` of a name is the one in effect.
+        # `||=` would be wrong here, a valueless define holding nil.
+        defines[name] = value unless defines.key?(name)
       end
-      defines.uniq.sort
+      defines.sort
     end
 
     def write_header_postamble(f)

--- a/lib/mruby/build.rb
+++ b/lib/mruby/build.rb
@@ -170,7 +170,7 @@ module MRuby
 
     def enable_debug
       compilers.each do |c|
-        c.defines += %w(MRB_DEBUG)
+        c.internal_defines += %w(MRB_DEBUG)
         c.setup_debug(self)
       end
       @mrbc.compile_options += ' -g'
@@ -225,7 +225,7 @@ module MRuby
       end
       @cxx_exception_enabled = true
       compilers.each { |c|
-        c.defines += %w(MRB_USE_CXX_EXCEPTION)
+        c.internal_defines += %w(MRB_USE_CXX_EXCEPTION)
         c.flags << c.cxx_exception_flag
       }
       linker.command = cxx.command if toolchains.find { |v| v == 'gcc' }
@@ -245,7 +245,7 @@ module MRuby
         raise "cxx_exception already enabled"
       end
       compilers.each { |c|
-        c.defines += %w(MRB_USE_CXX_EXCEPTION MRB_USE_CXX_ABI)
+        c.internal_defines += %w(MRB_USE_CXX_EXCEPTION MRB_USE_CXX_ABI)
         c.flags << c.cxx_compile_flag
         c.flags = c.flags.flatten - c.cxx_invalid_flags.flatten
       }
@@ -388,8 +388,9 @@ EOS
     end
 
     # True when this build compiles with -D<name>, whether the build config
-    # asked for it or a gem contributed it.  A gem reads this to configure
-    # itself against a capability another gem provides.
+    # asked for it, a gem contributed it, or the build added it from one of
+    # its own switches.  A gem reads this to configure itself against a
+    # capability another gem provides.
     #
     # Until `defines_final!` the answer would depend on how far down the gem
     # list the caller sits, since a gem contributes its defines when its own
@@ -406,8 +407,8 @@ EOS
       # A define may carry a value, as `FOO=1` does, so compare the name and
       # not the value.  The `-D` is the compiler's, added when the flags are
       # assembled, and is no part of the name.
-      [defines, *compilers.map(&:defines)].flatten
-        .any? {|d| d.to_s.split('=', 2).first == name}
+      return true if defines.flatten.any? {|d| d.to_s.split('=', 2).first == name}
+      compilers.any? {|c| c.has_define?(name)}
     end
 
     def define_rules

--- a/lib/mruby/build/command.rb
+++ b/lib/mruby/build/command.rb
@@ -36,6 +36,13 @@ module MRuby
 
   class Command::Compiler < Command
     attr_accessor :label, :flags, :include_paths, :defines, :source_exts
+    # Defines are held in two lists, split by who asked for them. `defines` is
+    # what the build config and the gems write. `internal_defines` is what the
+    # build adds on its own behalf, from its own switches (`enable_debug`,
+    # `enable_cxx_abi`) or from a toolchain. Both reach the compiler as `-D`;
+    # keeping them apart lets a toolchain set its own without overwriting what
+    # the config already wrote, and lets a caller ask for one list alone.
+    attr_accessor :internal_defines
     attr_accessor :compile_options, :option_define, :option_include_path, :out_ext
     attr_accessor :cxx_compile_flag, :cxx_exception_flag, :cxx_invalid_flags
     attr_writer :preprocess_options
@@ -48,6 +55,7 @@ module MRuby
       @source_exts = source_exts
       @include_paths = ["#{MRUBY_ROOT}/include"]
       @defines = []
+      @internal_defines = []
       @option_include_path = %q[-I"%s"]
       @option_define = %q[-D"%s"]
       @compile_options = %q[%{flags} -o "%{outfile}" -c "%{infile}"]
@@ -59,6 +67,18 @@ module MRuby
 
     def preprocess_options
       @preprocess_options ||= @compile_options.sub(/(?:\A|\s)\K-c(?=\s)/, "-E -P")
+    end
+
+    # True when this compiler compiles with -D<name>, whichever of the two
+    # lists it sits in. A gem asks this while its own mrbgem.rake body runs,
+    # where `Build#has_define?` refuses to answer because the gems that come
+    # after it have not contributed their defines yet.
+    def has_define?(name)
+      name = name.to_s
+      # A define may carry a value, as `FOO=1` does, so compare the name and
+      # not the value.
+      [defines, internal_defines].flatten
+        .any? {|d| d.to_s.split('=', 2).first == name}
     end
 
     def search_header_path(name)
@@ -73,7 +93,8 @@ module MRuby
     end
 
     def all_flags(_defines=[], _include_paths=[], _flags=[])
-      define_flags = [defines, _defines, build.defines].flatten.map{ |d| option_define % d }
+      define_flags = [defines, internal_defines, _defines, build.defines].flatten
+                       .map{ |d| option_define % d }
       include_path_flags = [include_paths, _include_paths].flatten.map do |f|
         option_include_path % filename(f)
       end

--- a/mrbgems/mruby-compiler/mrbgem.rake
+++ b/mrbgems/mruby-compiler/mrbgem.rake
@@ -30,7 +30,7 @@ MRuby::Gem::Specification.new('mruby-compiler') do |spec|
   elsif !cc.defines.include?('MRB_NO_GEMS')
     cc.defines << 'MRC_TARGET_MRUBY'
   end
-  cc.defines << 'MRC_DEBUG' if cc.defines.any? { |d| d.match?(/\AMRB_DEBUG(=|\z)/) }
+  cc.defines << 'MRC_DEBUG' if cc.has_define?('MRB_DEBUG')
   cc.defines << 'PRISM_BUILD_MINIMAL' unless cc.defines.include?('MRC_DEBUG')
   # PRISM_BUILD_MINIMAL stubs out pm_prettyprint(), so `mruby -v` can only dump
   # the AST where it is compiled in

--- a/tasks/toolchains/visualcpp.rake
+++ b/tasks/toolchains/visualcpp.rake
@@ -9,7 +9,7 @@ MRuby::Toolchain.new(:visualcpp) do |conf, _params|
       compiler.command = ENV['CXX'] || 'cl.exe'
       compiler.flags = [*(ENV['CXXFLAGS'] || ENV['CFLAGS'] || compiler_flags + %w(/EHs))]
     end
-    compiler.defines = %w(MRB_STACK_EXTEND_DOUBLING)
+    compiler.internal_defines |= %w(MRB_STACK_EXTEND_DOUBLING)
     compiler.option_include_path = %q[/I"%s"]
     compiler.option_define = '/D%s'
     compiler.compile_options = %Q[/Zi /c /Fo"%{outfile}" %{flags} "%{infile}"]


### PR DESCRIPTION
Stacked on #7175, which is the first commit here. The second commit is this
PR's own change, and the diff to read is `git diff <first commit>..HEAD`.
Merging #7175 first leaves this one a single commit.

`rake amalgam` writes a `mruby.h` that carries none of the defines the build
was configured with. `doc/guides/amalgamation.md` presents the output as two
files to drop into a project, and the compile examples pass nothing but `-I`
and `-DNDEBUG`, so whatever the header does not say is a difference between
the mruby in `mruby.c` and the mruby the consumer compiles against.

```console
$ MRUBY_CONFIG=minimal rake amalgam
$ cd build/minimal/amalgam && gcc -O0 -c -I. mruby.c -o mruby.o
$ nm mruby.o | grep ' U .*printf'
                 U fprintf
                 U printf
                 U snprintf
```

`build_config/minimal.rb` is three lines and one of them is
`conf.cc.defines << 'MRB_NO_STDIO'`. The amalgamation of the `minimal` build
is not a `minimal` mruby.

A configuration that asks for word boxing and 32-bit integers fails more
quietly. The header names neither, so the consumer gets what `mruby.h` picks by
default on a 64-bit host:

```c
printf("%zu %zu\n", sizeof(mrb_value), sizeof(mrb_int));
```

| | output |
| --- | --- |
| master | `8 8` |
| this PR | `8 4` |

`sizeof(mrb_int)` is 8 where the configuration asked for 4.
`sizeof(mrb_value)` agrees at 8 either way, word boxing being the default too,
which is the part that makes this hard to notice: an ABI difference that is
invisible in the size of the value the whole API passes around.

### Two things kept the defines out

`collect_gem_defines` read `@build.defines` and kept the names matching
`/^MRB_USE_|^MRB_UTF8_|^HAVE_MRUBY_/`.

No build configuration in the tree writes to `Build#defines`. Every
`build_config/` file that names a define writes it on a compiler, as
`conf.cc.defines` or through `conf.compilers.each`; `Build#defines` is written
only by gems, through `spec.build.defines`. So the emitted set was the gems'
contribution alone: seven defines for a default `host` build, none at all for
`minimal`.

The pattern is the second half. The defines that decide the layout of
`mrb_value` and `mrb_state` are outside it, so moving the configurations over
to `conf.defines` would not have been enough on its own:

| define | what it decides |
| --- | --- |
| `MRB_NO_BOXING`, `MRB_NAN_BOXING`, `MRB_WORD_BOXING` | the representation of `mrb_value` |
| `MRB_INT32`, `MRB_INT64` | the width of `mrb_int` |
| `MRB_NO_FLOAT` | whether `mrb_float` exists |
| `MRB_32BIT`, `MRB_64BIT` | the declared pointer width |
| `MRB_NO_STDIO` | the I/O half of `mrb_state` |
| `MRB_GC_FIXED_ARENA` | how the GC holds its arena |

### What is emitted

`@build.defines` and `@build.cc.defines`, every name that is a C identifier,
`NAME=VALUE` split into its two halves, each wrapped in `#ifndef` so a consumer
passing the same define on the command line is not redefining it. The
`#ifndef` and the identifier check follow `write_gem_cc_defines()`, which
already emits a gem's own compiler defines that way.

```c
/* Build configuration defines */
#ifndef MRB_HEAP_PAGE_SIZE
#define MRB_HEAP_PAGE_SIZE 64
#endif
#ifndef MRB_INT32
#define MRB_INT32
#endif
#ifndef MRB_WORD_BOXING
#define MRB_WORD_BOXING
#endif
```

A gem's contribution and a configuration's are emitted the same way. From the
header's side they are not distinguishable: `MRB_USE_BIGINT` arriving because
`mruby-bigint` is in the gembox changes `mrb_state` exactly as much as
`MRB_NO_STDIO` arriving from a configuration file.

Two kinds stay out, and the guide now says so.

* `internal_defines`, the list #7175 introduces for what the build adds from
  its own switches. `MRB_USE_CXX_ABI` in the header would make it unusable from
  C, which is what `mruby.c` is compiled as. A consumer who wants a C++ build
  passes those defines itself, and `MRB_DEBUG`, which only decides whether
  `mrb_assert` checks, is the same kind of choice as the `-DNDEBUG` the guide
  already leaves to the reader.
* `cxx.defines`, for the same reason: the generated source is C, so a define
  written only on the C++ compiler (`NN_SDK_BUILD_RELEASE` in
  `build_config/nintendo_switch.rb`) has no business in this header.

### Measurements

| build | defines in `mruby.h` on master | with this PR |
| --- | --- | --- |
| default `host` | 7 | the same 7 |
| `minimal` | 0 | 2 (`MRB_NO_GEMS`, `MRB_NO_STDIO`) |
| word boxing, `MRB_INT32`, `MRB_HEAP_PAGE_SIZE=64` | 0 | 3 |
| full-core with `enable_cxx_abi` and `MRB_GC_FIXED_ARENA`, the shape of `cxx_abi` in `build_config/ci/gcc-clang.rb` | 9 | 10, the tenth being `MRB_GC_FIXED_ARENA`; no `MRB_USE_CXX_*` on either side |

The default build is unchanged because `build_config/default.rb` names no
define of its own. Every other line is a define the build compiled with and the
consumer did not.

### Testing

`rake amalgam` is opt-in and no normal build goes through it, so `rake -m test`
on the default build is unmoved at 2085 tests, 2056 OK, 29 skip, 0 KO, 0 crash.

The `minimal` amalgamation compiles with `-I` alone, the way the guide tells a
consumer to, and the stdio it used to pull in is gone:

```console
$ MRUBY_CONFIG=minimal rake amalgam
$ grep -x '#define MRB_NO_STDIO' build/minimal/amalgam/mruby.h
#define MRB_NO_STDIO
$ cd build/minimal/amalgam && gcc -O0 -c -I. mruby.c -o mruby.o
$ nm mruby.o | grep ' U .*printf'
$
```

The generated `mruby.c` and `mruby_compiler.c` of the word-boxing configuration
above compile and link into a program that opens an `mrb_state`, loads a string
through `mrb_load_string()` and closes it again, which is where its `sizeof`
numbers come from.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Generated amalgamations now include validated, deduplicated build configuration defines with safe guards.
  * Improved handling of compiler-specific configuration options across toolchains.

* **Bug Fixes**
  * Amalgamated builds are now verified to compile without unresolved standard I/O references.

* **Documentation**
  * Updated amalgamation guidance to clarify build and compiler configuration defines, including excluded compiler-selected options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
