### PR TITLE
internal.h: move writing a string's encoding and coderange inside

### DIFF
--- a/include/mruby/internal.h
+++ b/include/mruby/internal.h
@@ -155,6 +155,74 @@ size_t mrb_gc_mark_range(mrb_state *mrb, struct RRange *r);
 #endif
 
 /* string */
+
+/* Writing what a string's bytes are read as, and what reading them came back
+   with. mruby/string.h hands both fields back to anyone who asks, since what
+   they hold is a fact about the string and reading a fact costs the string
+   nothing. Writing one is the other thing: it is a claim, and a claim the
+   bytes do not support is caught nowhere. A wrong encoding index has the bytes
+   read as something they are not, and a string wrongly saying it reads whole
+   and sound walks straight through the check a regexp makes of its subject. So
+   the writes are offered where they can be answered for, which is inside the
+   library, rather than to whoever includes a header.
+
+   The values themselves stay in mruby/string.h: naming an answer is reading,
+   and what reads MRB_STR_CODERANGE_7BIT off a string has to be able to say
+   it. */
+#ifdef MRB_UTF8_STRING
+/* An answer is masked to the field's width on the way in, as an encoding index
+   is, so a fifth one lands wrong rather than reaching the bits beside it. Here
+   those bits are the encoding index rather than free ones, so an unmasked
+   write would not merely be a wrong answer: it would have the bytes read as
+   another encoding. What is written is one of the four either way, spelled
+   outright or read back out of another string's field, so nothing is left of
+   this at -O3. */
+# define RSTR_CODERANGE_SET(s, cr) \
+  ((s)->flags = ((s)->flags & ~MRB_STR_CODERANGE_MASK) | \
+                (((cr) & ((1 << MRB_STR_CODERANGE_BITS) - 1)) << MRB_STR_CODERANGE_SHIFT))
+#else
+/* A build that indexes by byte hands every byte back as a character and asks
+   the bytes nothing, so every string in it stands where 7BIT stands and there
+   is nothing to record. */
+# define RSTR_CODERANGE_SET(s, cr) ((void)0)
+#endif
+
+/* The index is masked to the width of the field it goes into, so an index the
+   field is too narrow for lands wrong rather than reaching the bits beside it.
+   Widening MRB_STR_ENCODING_BITS is what a build carrying that many encodings
+   needs; until then this keeps the mistake where it can be seen. Both operands
+   are constants at every call, so nothing is left of this at -O3. */
+#define RSTR_ENCODING_SET(s, e) \
+  ((s)->flags = ((s)->flags & ~MRB_STR_ENCODING_MASK) | \
+                (((e) & ((1 << MRB_STR_ENCODING_BITS) - 1)) << MRB_STR_ENCODING_SHIFT))
+/* A copy of a string is read the way the string it copies is, so the encoding
+   travels with the bytes rather than being left behind on the original. */
+#define RSTR_ENC_COPY(dst, src) RSTR_ENCODING_SET(dst, RSTR_ENCODING(src))
+/* A copy that ends up holding exactly the source's bytes reads them the same
+   way and stands exactly where the source stands, so the two answers travel
+   together. Splitting them apart would let a copy keep one and drop the
+   other, which is the way flags went missing when there was a macro per
+   flag.
+
+   The two fields sit side by side, so one mask spells both and the pair
+   crosses in a single read and a single write rather than one of each per
+   field. A build that indexes by byte keeps no coderange and writes those
+   bits nowhere, so what the mask carries across there is the zeros they
+   hold. */
+#define MRB_STR_ENC_CR_MASK (MRB_STR_ENCODING_MASK|MRB_STR_CODERANGE_MASK)
+#define RSTR_ENC_CR_COPY(dst, src) \
+  ((dst)->flags = ((dst)->flags & ~MRB_STR_ENC_CR_MASK) | \
+                  ((src)->flags & MRB_STR_ENC_CR_MASK))
+/* A subrange holds bytes of the source, so it is read the same way, but a cut
+   can leave a character in pieces and can also cut away the piece that spelled
+   none: it inherits neither soundness nor brokenness. Nothing but ASCII is
+   what survives being cut anywhere, so that is the one answer it carries
+   over. */
+#define RSTR_ENC_CR_COPY_FOR_SUBSTR(dst, src) \
+  (RSTR_ENC_COPY(dst, src), \
+   RSTR_CODERANGE_SET(dst, (RSTR_CODERANGE(src) == MRB_STR_CODERANGE_7BIT) \
+                           ? MRB_STR_CODERANGE_7BIT : MRB_STR_CODERANGE_UNKNOWN))
+
 void mrb_gc_free_str(mrb_state*, struct RString*);
 uint32_t mrb_str_hash(mrb_state *mrb, mrb_value str);
 mrb_value mrb_str_dump(mrb_state *mrb, mrb_value str);

--- a/include/mruby/string.h
+++ b/include/mruby/string.h
@@ -180,6 +180,13 @@ struct RStringEmbed {
   ((s)->flags = ((s)->flags & ~MRB_STR_ENCODING_MASK) | \
                 (((e) & ((1 << MRB_STR_ENCODING_BITS) - 1)) << MRB_STR_ENCODING_SHIFT))
 #define RSTR_BINARY_P(s) (RSTR_ENCODING(s) == MRB_STR_ENCODING_BINARY)
+/* Whether a character index into this string is already a byte index: every
+   byte of it stands for a character of its own. That is so where the bytes are
+   nothing but ASCII, and so where they are read as bytes to begin with. The
+   two arrive at it from different sides, which is why this is derived from
+   what the string carries rather than carried alongside it. */
+#define RSTR_SINGLE_BYTE_P(s) \
+  (RSTR_CODERANGE(s) == MRB_STR_CODERANGE_7BIT || RSTR_BINARY_P(s))
 /* A copy of a string is read the way the string it copies is, so the encoding
    travels with the bytes rather than being left behind on the original. */
 #define RSTR_ENC_COPY(dst, src) RSTR_ENCODING_SET(dst, RSTR_ENCODING(src))

--- a/include/mruby/string.h
+++ b/include/mruby/string.h
@@ -141,15 +141,11 @@ struct RStringEmbed {
    this at -O3. */
 # define RSTR_CODERANGE(s) \
   (((s)->flags & MRB_STR_CODERANGE_MASK) >> MRB_STR_CODERANGE_SHIFT)
-# define RSTR_CODERANGE_SET(s, cr) \
-  ((s)->flags = ((s)->flags & ~MRB_STR_CODERANGE_MASK) | \
-                (((cr) & ((1 << MRB_STR_CODERANGE_BITS) - 1)) << MRB_STR_CODERANGE_SHIFT))
 #else
 /* A build that indexes by byte hands every byte back as a character and asks
    the bytes nothing, so every string in it stands where 7BIT stands and there
    is nothing to record. */
 # define RSTR_CODERANGE(s) MRB_STR_CODERANGE_7BIT
-# define RSTR_CODERANGE_SET(s, cr) ((void)0)
 #endif
 
 /* The encoding a string's bytes are read as, named as an index into the set of
@@ -171,14 +167,6 @@ struct RStringEmbed {
 
 #define RSTR_ENCODING(s) \
   (((s)->flags & MRB_STR_ENCODING_MASK) >> MRB_STR_ENCODING_SHIFT)
-/* The index is masked to the width of the field it goes into, so an index the
-   field is too narrow for lands wrong rather than reaching the bits beside it.
-   Widening MRB_STR_ENCODING_BITS is what a build carrying that many encodings
-   needs; until then this keeps the mistake where it can be seen. Both operands
-   are constants at every call, so nothing is left of this at -O3. */
-#define RSTR_ENCODING_SET(s, e) \
-  ((s)->flags = ((s)->flags & ~MRB_STR_ENCODING_MASK) | \
-                (((e) & ((1 << MRB_STR_ENCODING_BITS) - 1)) << MRB_STR_ENCODING_SHIFT))
 #define RSTR_BINARY_P(s) (RSTR_ENCODING(s) == MRB_STR_ENCODING_BINARY)
 /* Whether a character index into this string is already a byte index: every
    byte of it stands for a character of its own. That is so where the bytes are
@@ -187,33 +175,10 @@ struct RStringEmbed {
    what the string carries rather than carried alongside it. */
 #define RSTR_SINGLE_BYTE_P(s) \
   (RSTR_CODERANGE(s) == MRB_STR_CODERANGE_7BIT || RSTR_BINARY_P(s))
-/* A copy of a string is read the way the string it copies is, so the encoding
-   travels with the bytes rather than being left behind on the original. */
-#define RSTR_ENC_COPY(dst, src) RSTR_ENCODING_SET(dst, RSTR_ENCODING(src))
-/* A copy that ends up holding exactly the source's bytes reads them the same
-   way and stands exactly where the source stands, so the two answers travel
-   together. Splitting them apart would let a copy keep one and drop the
-   other, which is the way flags went missing when there was a macro per
-   flag.
 
-   The two fields sit side by side, so one mask spells both and the pair
-   crosses in a single read and a single write rather than one of each per
-   field. A build that indexes by byte keeps no coderange and writes those
-   bits nowhere, so what the mask carries across there is the zeros they
-   hold. */
-#define MRB_STR_ENC_CR_MASK (MRB_STR_ENCODING_MASK|MRB_STR_CODERANGE_MASK)
-#define RSTR_ENC_CR_COPY(dst, src) \
-  ((dst)->flags = ((dst)->flags & ~MRB_STR_ENC_CR_MASK) | \
-                  ((src)->flags & MRB_STR_ENC_CR_MASK))
-/* A subrange holds bytes of the source, so it is read the same way, but a cut
-   can leave a character in pieces and can also cut away the piece that spelled
-   none: it inherits neither soundness nor brokenness. Nothing but ASCII is
-   what survives being cut anywhere, so that is the one answer it carries
-   over. */
-#define RSTR_ENC_CR_COPY_FOR_SUBSTR(dst, src) \
-  (RSTR_ENC_COPY(dst, src), \
-   RSTR_CODERANGE_SET(dst, (RSTR_CODERANGE(src) == MRB_STR_CODERANGE_7BIT) \
-                           ? MRB_STR_CODERANGE_7BIT : MRB_STR_CODERANGE_UNKNOWN))
+/* Writing either field is in mruby/internal.h. What is read back here is what
+   the bytes were found to be; what is written there is a claim about them,
+   which only what can make good on it should be spelling. */
 
 /**
  * Returns a pointer from a Ruby string

--- a/mrbgems/mruby-string-ext/src/string.c
+++ b/mrbgems/mruby-string-ext/src/string.c
@@ -1033,7 +1033,7 @@ str_ord(mrb_state* mrb, mrb_value str)
   if (p == e) {
     mrb_raise(mrb, E_ARGUMENT_ERROR, "empty string");
   }
-  if (RSTR_CODERANGE(s) == MRB_STR_CODERANGE_7BIT || RSTR_BINARY_P(s)) {
+  if (RSTR_SINGLE_BYTE_P(s)) {
     c = p[0];
   }
   else {
@@ -1123,7 +1123,7 @@ str_scrub_core(mrb_state *mrb, mrb_value self)
   }
 
   struct RString *s = mrb_str_ptr(self);
-  if (RSTR_CODERANGE(s) == MRB_STR_CODERANGE_7BIT || RSTR_BINARY_P(s)) {
+  if (RSTR_SINGLE_BYTE_P(s)) {
     return mrb_str_dup(mrb, self);
   }
 
@@ -1166,7 +1166,7 @@ str_scrub_chunks(mrb_state *mrb, mrb_value self)
 {
   mrb_value ary = mrb_ary_new(mrb);
   struct RString *s = mrb_str_ptr(self);
-  if (RSTR_CODERANGE(s) == MRB_STR_CODERANGE_7BIT || RSTR_BINARY_P(s)) {
+  if (RSTR_SINGLE_BYTE_P(s)) {
     mrb_ary_push(mrb, ary, mrb_str_dup(mrb, self));
     return ary;
   }
@@ -1201,7 +1201,7 @@ str_codepoints(mrb_state *mrb, mrb_value str)
 
   mrb->c->ci->mid = 0;
   mrb_value result = mrb_ary_new(mrb);
-  if (RSTR_CODERANGE(s) == MRB_STR_CODERANGE_7BIT || RSTR_BINARY_P(s)) {
+  if (RSTR_SINGLE_BYTE_P(s)) {
     while (p < e) {
       mrb_ary_push(mrb, result, mrb_int_value(mrb, (mrb_int)*p));
       p++;
@@ -1799,7 +1799,7 @@ str_chars_ary(mrb_state *mrb, mrb_value self)
   int ai = mrb_gc_arena_save(mrb);
 
 #ifdef MRB_UTF8_STRING
-  if (RSTR_CODERANGE(s) != MRB_STR_CODERANGE_7BIT && !RSTR_BINARY_P(s)) {
+  if (!RSTR_SINGLE_BYTE_P(s)) {
     while (p < e) {
       mrb_int char_len = mrb_utf8len(p, e);
       mrb_ary_push(mrb, result, mrb_str_new(mrb, p, char_len));

--- a/src/string.c
+++ b/src/string.c
@@ -728,7 +728,7 @@ mrb_str_char_to_byte(mrb_state *mrb, mrb_value str, mrb_int off, mrb_int idx)
 {
   (void)mrb;
   struct RString *s = mrb_str_ptr(str);
-  if (RSTR_CODERANGE(s) == MRB_STR_CODERANGE_7BIT || RSTR_BINARY_P(s)) {
+  if (RSTR_SINGLE_BYTE_P(s)) {
     return idx;
   }
 
@@ -769,7 +769,7 @@ mrb_str_byte_to_char(mrb_state *mrb, mrb_value str, mrb_int bi)
   (void)mrb;
   struct RString *s = mrb_str_ptr(str);
   if (bi < 0 || RSTR_LEN(s) < bi) return -1;
-  if (RSTR_CODERANGE(s) == MRB_STR_CODERANGE_7BIT || RSTR_BINARY_P(s)) {
+  if (RSTR_SINGLE_BYTE_P(s)) {
     return bi;
   }
 
@@ -2125,8 +2125,7 @@ mrb_str_chomp_bang(mrb_state *mrb, mrb_value str)
        a character of its own, and cutting there would leave a string that is
        not UTF-8: "あ".chomp("\x82") is the whole of the last byte of a
        three-byte character. CRuby reads that as no match. */
-    if (!RSTR_BINARY_P(s) && RSTR_CODERANGE(s) != MRB_STR_CODERANGE_7BIT &&
-        mrb_utf8_char_head(p, pp, p + len) != pp) {
+    if (!RSTR_SINGLE_BYTE_P(s) && mrb_utf8_char_head(p, pp, p + len) != pp) {
       return mrb_nil_value();
     }
 #endif
@@ -2437,7 +2436,7 @@ mrb_str_check_byte_pos(mrb_state *mrb, mrb_value str, mrb_int pos)
 {
 #ifdef MRB_UTF8_STRING
   struct RString *s = mrb_str_ptr(str);
-  if (RSTR_CODERANGE(s) == MRB_STR_CODERANGE_7BIT || RSTR_BINARY_P(s)) return;
+  if (RSTR_SINGLE_BYTE_P(s)) return;
 
   const char *b = RSTR_PTR(s);
   const char *p = b + pos;
@@ -2791,7 +2790,7 @@ static mrb_value
 mrb_str_rindex_m(mrb_state *mrb, mrb_value str)
 {
   struct RString *s = mrb_str_ptr(str);
-  if (RSTR_CODERANGE(s) == MRB_STR_CODERANGE_7BIT || RSTR_BINARY_P(s)) {
+  if (RSTR_SINGLE_BYTE_P(s)) {
     return mrb_str_byterindex_m(mrb, str);
   }
 


### PR DESCRIPTION
Stacked on #7178, which is the first commit here. The second commit is this PR's own change, and the diff to read is `git diff 33723b692..HEAD`. Merging #7178 first leaves this one a single commit.

`include/mruby/string.h` hands out both of a string's answers about its bytes and both ways of writing them:

```c
#define RSTR_CODERANGE(s)          /* read  */
#define RSTR_CODERANGE_SET(s, cr)  /* write */
#define RSTR_ENCODING(s)           /* read  */
#define RSTR_ENCODING_SET(s, e)    /* write */
#define RSTR_ENC_COPY(dst, src)
#define RSTR_ENC_CR_COPY(dst, src)
#define RSTR_ENC_CR_COPY_FOR_SUBSTR(dst, src)
```

Reading one is asking the string what its bytes were found to be, and asking costs it nothing. Writing one is making a claim about them, and a claim the bytes do not support is caught nowhere: a wrong encoding index has the bytes read as something they are not, and a string wrongly saying it reads whole and sound walks straight through the check a regexp makes of its subject before handing it to the engine.

This PR moves the writes to `include/mruby/internal.h`, which is where what has to be answered for already lives.

### The line CRuby draws in the same place

`rb_enc_str_coderange()` is in `include/ruby/encoding.h`; `ENC_CODERANGE_CLEAR` and `ENC_CODERANGE_SET` are in `internal/encoding/coderange.h`. Read published, written inside.

### What stays behind

The answers themselves. Naming one is reading, and what reads `MRB_STR_CODERANGE_7BIT` off a string has to be able to say it:

```c
#define MRB_STR_CODERANGE_UNKNOWN 0
#define MRB_STR_CODERANGE_7BIT    1
#define MRB_STR_CODERANGE_VALID   2
#define MRB_STR_CODERANGE_BROKEN  3
#define MRB_STR_ENCODING_DEFAULT  0
#define MRB_STR_ENCODING_BINARY   1
```

along with the `_SHIFT` / `_BITS` / `_MASK` triples the readers expand to, and `RSTR_CODERANGE`, `RSTR_ENCODING`, `RSTR_BINARY_P`, `RSTR_SINGLE_BYTE_P`.

### Nothing in the tree has to follow

Ten files write one of the fields, 46 writes in all:

```
$ git grep -c 'RSTR_CODERANGE_SET\|RSTR_ENCODING_SET\|RSTR_ENC_COPY\|RSTR_ENC_CR_COPY' -- '*.c'
mrbgems/mruby-encoding/src/encoding.c:2
mrbgems/mruby-regexp/src/regexp.c:1
mrbgems/mruby-sprintf/src/sprintf.c:2
mrbgems/mruby-string-bitops/src/string_bitops.c:1
mrbgems/mruby-string-ext/src/string.c:12
mrbgems/mruby-time/src/time.c:1
src/numeric.c:2
src/object.c:4
src/string.c:19
src/symbol.c:2
```

Every one of them already includes `mruby/internal.h`, and every one includes `mruby/string.h` before it:

```
mrbgems/mruby-encoding/src/encoding.c                string.h:2     internal.h:4
mrbgems/mruby-regexp/src/regexp.c                    string.h:10    internal.h:15
mrbgems/mruby-sprintf/src/sprintf.c                  string.h:8     internal.h:11
mrbgems/mruby-string-bitops/src/string_bitops.c      string.h:12    internal.h:13
mrbgems/mruby-string-ext/src/string.c                string.h:5     internal.h:7
mrbgems/mruby-time/src/time.c                        string.h:12    internal.h:13
src/numeric.c                                        string.h:10    internal.h:12
src/object.c                                         string.h:10    internal.h:12
src/string.c                                         string.h:16    internal.h:18
src/symbol.c                                         string.h:10    internal.h:17
```

So no `#include` line is added or moved:

```
$ git diff 33723b692..HEAD --stat
 include/mruby/internal.h | 68 ++++++++++++++++++++++++++++++++++++++++++++++++
 include/mruby/string.h   | 43 +++---------------------------
 2 files changed, 72 insertions(+), 39 deletions(-)

$ git diff 33723b692..HEAD | grep '^[+-]#include'
$
```

No `#ifdef MRUBY_STRING_H` guard is needed around the moved block either: what a macro spells has to be defined where it is expanded, not where it is written, and the four names it reaches for stay in `mruby/string.h`.

### The amalgamated header carries them

`lib/mruby/amalgam.rb` inlines `mruby/internal.h` whole, so the move needs no change there. Generating `mruby.h` on master and on this branch and comparing the two, sorted so a block that only moved does not show:

```
$ diff <(sort master/amalgam/mruby.h) <(sort this-pr/amalgam/mruby.h) | grep '^<'
$ diff <(sort master/amalgam/mruby.h) <(sort this-pr/amalgam/mruby.h) | grep '^>' | grep '#'
> #define RSTR_SINGLE_BYTE_P(s) \
> #else
> #endif
> #ifdef MRB_UTF8_STRING
```

Nothing is dropped, and what is added is #7178's macro and the `#ifdef MRB_UTF8_STRING` the moved block brings with it. The rest of the 40 added lines are the comments the two commits write. The moved writes land at `mruby.h:8800` onwards in the generated header, inside the `mruby/internal.h` section.

### Generated code

A move of macro definitions, so nothing changes in what is generated. `gcc 13.3.0 -O3`, x86-64, `.text` of `bin/mruby`, against the same objects built from master:

| build | master | this PR |
| --- | ---: | ---: |
| full-debug | 2636642 | 2636642 (±0) |
| bintest | 1820341 | 1820341 (±0) |
| cxx_abi | 1850166 | 1850166 (±0) |
| byte-string | 1795973 | 1795973 (±0) |
| `build_config/default.rb` | 1722135 | 1722135 (±0) |
| 32-bit, `full-core`, `i686-linux-gnu-gcc` | 1994304 | 1994304 (±0) |

Objects differing between this commit and #7178, comparing `objdump -d` over every `.o` in the build:

| build | objects | differing |
| --- | ---: | ---: |
| full-debug | 291 | 0 |
| bintest | 301 | 0 |
| cxx_abi | 291 | 0 |
| byte-string | 288 | 0 |
| `build_config/default.rb` | 270 | 0 |
| 32-bit | 291 | 0 |

`cxx_abi` is the one build in `ci/gcc-clang` that goes through the C++ compiler, and the moved block is reached from `mrbgems/mruby-string-bitops`, `mrbgems/mruby-time` and `src/symbol.c` there as everywhere else.

### Testing

`rake -m test`, on each commit, all green, 0 KO, 0 crash, 0 warnings, and the same counts as master:

| build | Total | OK | Skip |
| --- | ---: | ---: | ---: |
| full-debug | 2303 | 2300 | 3 |
| bintest | 2304 | 2293 | 11 |
| bintest, the binary tests | 117 | 117 | 0 |
| cxx_abi | 2304 | 2293 | 11 |
| byte-string | 2240 | 2194 | 46 |
| `build_config/default.rb` | 2086 | 2040 | 46 |
| 32-bit, `full-core`, `i686-linux-gnu-gcc` | 2284 | 2272 | 12 |
| the same, with `enable_debug` | 2284 | 2280 | 4 |

`build_config/host-m32.rb` needs a multilib toolchain, so the 32-bit build above is `full-core` with the compiler set to `i686-linux-gnu-gcc` instead.

No test accompanies the change. A macro spells what it spelled and is expanded where it was expanded, so no string answers anything different.

### For a gem outside the tree

One that writes either field has to include `mruby/internal.h` after this. That is a compile error and not a quiet change of behavior, which is what a gem making a claim about a string's bytes should get.

### Not in this PR

What the two fields mean, how wide they are, and where in the flags word they sit are all untouched. So is every write in the tree: the 46 above are the same 46, spelled the same way, in the same order.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Moved the macros that write a string's encoding index and character-range from the public string header to the internal one, leaving the reads and the named values where they were.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
