### PR TITLE
string.h: drop `mrb_str_modify_keep_ascii()`

### DIFF
--- a/include/mruby/string.h
+++ b/include/mruby/string.h
@@ -221,8 +221,6 @@ struct RStringEmbed {
 #define RSTRING_CSTR(mrb,s)  mrb_string_cstr(mrb, s)
 
 MRB_API void mrb_str_modify(mrb_state *mrb, struct RString *s);
-/* mrb_str_modify() with keeping ASCII flag if set */
-MRB_API void mrb_str_modify_keep_ascii(mrb_state *mrb, struct RString *s);
 
 /**
  * Finds the index of a substring in a string

--- a/mrbgems/mruby-encoding/test/string.rb
+++ b/mrbgems/mruby-encoding/test/string.rb
@@ -47,7 +47,7 @@ end
 assert('String#valid_encoding? after an append inside a shared buffer') do
   # An append to a string sharing a buffer with room to spare writes in place
   # rather than detaching, and that path forgets the remembered answer on its
-  # own rather than through mrb_str_modify_keep_ascii(). Nothing else here
+  # own rather than through mrb_str_modify(). Nothing else here
   # reaches it: a string built by `*` or from a literal has no spare capacity,
   # so its sharers all take the detaching path instead.
   #

--- a/src/string.c
+++ b/src/string.c
@@ -1249,36 +1249,15 @@ mrb_locale_from_utf8(const char *utf8, int len)
  * @param s The RString structure to modify.
  *
  * Prepares a string for modification. If the string is shared or not extensible,
- * it will be unshared or converted to a normal string. This version keeps the
- * string standing at 7BIT if that is where it stood.
- * Raises an error if the string is frozen.
- */
-MRB_API void
-mrb_str_modify_keep_ascii(mrb_state *mrb, struct RString *s)
-{
-  mrb_check_frozen(mrb, s);
-  str_unshare_buffer(mrb, s);
-  /* A write that leaves the string holding nothing but ASCII leaves it
-     standing where it stood, and that is the caller's to keep. Anything else
-     the bytes were read as stops holding here. */
-  if (RSTR_CODERANGE(s) != MRB_STR_CODERANGE_7BIT) {
-    RSTR_CODERANGE_SET(s, MRB_STR_CODERANGE_UNKNOWN);
-  }
-}
-
-/*
- * @param mrb The mruby state.
- * @param s The RString structure to modify.
- *
- * Prepares a string for modification. Similar to `mrb_str_modify_keep_ascii`,
- * but also takes 7BIT back, assuming the modification might introduce
- * multi-byte characters.
+ * it will be unshared or converted to a normal string. What the bytes were read
+ * as stops holding here, so this is the prepare for a write that can change it.
  * Raises an error if the string is frozen.
  */
 MRB_API void
 mrb_str_modify(mrb_state *mrb, struct RString *s)
 {
-  mrb_str_modify_keep_ascii(mrb, s);
+  mrb_check_frozen(mrb, s);
+  str_unshare_buffer(mrb, s);
   RSTR_CODERANGE_SET(s, MRB_STR_CODERANGE_UNKNOWN);
 }
 
@@ -3213,7 +3192,7 @@ mrb_string_value_cstr(mrb_state *mrb, mrb_value *ptr)
   }
 
   /*
-   * Even after str_modify_keep_ascii(), NULL termination is not ensured if
+   * Even after mrb_str_modify(), NULL termination is not ensured if
    * RSTR_SET_LEN() is used explicitly (e.g. String#delete_suffix!).
    */
   str_unshare_buffer(mrb, ps);

--- a/src/string.c
+++ b/src/string.c
@@ -1258,9 +1258,9 @@ mrb_str_modify_keep_ascii(mrb_state *mrb, struct RString *s)
 {
   mrb_check_frozen(mrb, s);
   str_unshare_buffer(mrb, s);
-  /* Every in-place write reaches here, including the ones that keep the string
-     ASCII, so this is where the walk's answer stops holding. What a string of
-     nothing but ASCII stands at is the caller's to keep. */
+  /* A write that leaves the string holding nothing but ASCII leaves it
+     standing where it stood, and that is the caller's to keep. Anything else
+     the bytes were read as stops holding here. */
   if (RSTR_CODERANGE(s) != MRB_STR_CODERANGE_7BIT) {
     RSTR_CODERANGE_SET(s, MRB_STR_CODERANGE_UNKNOWN);
   }
@@ -1280,6 +1280,30 @@ mrb_str_modify(mrb_state *mrb, struct RString *s)
 {
   mrb_str_modify_keep_ascii(mrb, s);
   RSTR_CODERANGE_SET(s, MRB_STR_CODERANGE_UNKNOWN);
+}
+
+/* mrb_str_modify() for a caller whose write leaves what the bytes read as
+   standing: it puts ASCII where ASCII stood, or it cuts where a character
+   ends. Such a write cannot turn a sound string unsound, so the answer the
+   string came in carrying is still the answer, and the next asker is spared
+   the walk that would arrive at it again.
+
+   Only a string already read as broken has to be asked again, since a write
+   is as likely to have mended it as to have left it broken. A string that
+   the write leaves holding nothing but ASCII keeps saying VALID rather than
+   moving to 7BIT: that is an answer worth less than the truth, not a wrong
+   one, and finding the truth is the walk this is here to skip.
+
+   The promise this asks of its caller cannot be checked here, which is why
+   it is not offered outside the library. */
+static void
+str_modify_keep_cr(mrb_state *mrb, struct RString *s)
+{
+  mrb_check_frozen(mrb, s);
+  str_unshare_buffer(mrb, s);
+  if (RSTR_CODERANGE(s) == MRB_STR_CODERANGE_BROKEN) {
+    RSTR_CODERANGE_SET(s, MRB_STR_CODERANGE_UNKNOWN);
+  }
 }
 
 /*
@@ -2016,7 +2040,7 @@ mrb_str_capitalize_bang(mrb_state *mrb, mrb_value str)
   struct RString *s = mrb_str_ptr(str);
   mrb_int len = RSTR_LEN(s);
 
-  mrb_str_modify_keep_ascii(mrb, s);
+  str_modify_keep_cr(mrb, s);
   char *p = RSTR_PTR(s);
   char *pend = RSTR_PTR(s) + len;
   if (len == 0 || p == NULL) return mrb_nil_value();
@@ -2069,7 +2093,7 @@ mrb_str_chomp_bang(mrb_state *mrb, mrb_value str)
   mrb_int argc = mrb_get_args(mrb, "|S", &rs);
   struct RString *s = mrb_str_ptr(str);
 
-  mrb_str_modify_keep_ascii(mrb, s);
+  str_modify_keep_cr(mrb, s);
   mrb_int len = RSTR_LEN(s);
   if (argc == 0) {
     if (len == 0) return mrb_nil_value();
@@ -2177,7 +2201,7 @@ mrb_str_chop_bang(mrb_state *mrb, mrb_value str)
 {
   struct RString *s = mrb_str_ptr(str);
 
-  mrb_str_modify_keep_ascii(mrb, s);
+  str_modify_keep_cr(mrb, s);
   if (RSTR_LEN(s) > 0) {
     mrb_int len;
 #ifdef MRB_UTF8_STRING
@@ -2249,7 +2273,7 @@ mrb_str_downcase_bang(mrb_state *mrb, mrb_value str)
   mrb_bool modify = FALSE;
   struct RString *s = mrb_str_ptr(str);
 
-  mrb_str_modify_keep_ascii(mrb, s);
+  str_modify_keep_cr(mrb, s);
   p = RSTR_PTR(s);
   pend = RSTR_PTR(s) + RSTR_LEN(s);
   while (p < pend) {
@@ -3428,7 +3452,7 @@ mrb_str_upcase_bang(mrb_state *mrb, mrb_value str)
   char *p, *pend;
   mrb_bool modify = FALSE;
 
-  mrb_str_modify_keep_ascii(mrb, s);
+  str_modify_keep_cr(mrb, s);
   p = RSTRING_PTR(str);
   pend = RSTRING_END(str);
   while (p < pend) {


### PR DESCRIPTION
Stacked on #7180, which is the first commit here. The second commit is this PR's own change, and the diff to read is `git diff 7e12663cf..HEAD`. Merging #7180 first leaves this one a single commit.

**This removes a published function, `mrb_str_modify_keep_ascii()`.**

With #7180 in, it has no caller left. What it offered was a prepare that keeps a string standing at 7BIT, and the promise a caller had to make to use it was that its write puts ASCII where ASCII stood. Every write that keeps that promise also keeps the wider one `str_modify_keep_cr()` wants, since an ASCII byte spells a character of its own in UTF-8. So the answer it gives is the same answer or a poorer one, and there is nothing it can be asked that the other cannot.

### Nothing calls it

On master it has five callers among the bang methods and one in `mrb_str_modify()`:

```
$ git grep -n modify_keep 406205fa0
include/mruby/string.h:225:MRB_API void mrb_str_modify_keep_ascii(mrb_state *mrb, struct RString *s);
mrbgems/mruby-encoding/test/string.rb:50:  # own rather than through mrb_str_modify_keep_ascii(). Nothing else here
src/string.c:1257:mrb_str_modify_keep_ascii(mrb_state *mrb, struct RString *s)
src/string.c:1273: * Prepares a string for modification. Similar to `mrb_str_modify_keep_ascii`,
src/string.c:1281:  mrb_str_modify_keep_ascii(mrb, s);
src/string.c:2019:  mrb_str_modify_keep_ascii(mrb, s);
src/string.c:2072:  mrb_str_modify_keep_ascii(mrb, s);
src/string.c:2180:  mrb_str_modify_keep_ascii(mrb, s);
src/string.c:2252:  mrb_str_modify_keep_ascii(mrb, s);
src/string.c:3192:   * Even after str_modify_keep_ascii(), NULL termination is not ensured if
src/string.c:3431:  mrb_str_modify_keep_ascii(mrb, s);
```

With #7180 in, the five are gone and what is left is the declaration, the definition, two comments naming it, and the one call inside `mrb_str_modify()`:

```
$ git grep -n modify_keep 7e12663cf
include/mruby/string.h:225:MRB_API void mrb_str_modify_keep_ascii(mrb_state *mrb, struct RString *s);
mrbgems/mruby-encoding/test/string.rb:50:  # own rather than through mrb_str_modify_keep_ascii(). Nothing else here
src/string.c:1257:mrb_str_modify_keep_ascii(mrb_state *mrb, struct RString *s)
src/string.c:1273: * Prepares a string for modification. Similar to `mrb_str_modify_keep_ascii`,
src/string.c:1281:  mrb_str_modify_keep_ascii(mrb, s);
```

and after this PR the name is nowhere:

```
$ git grep -n modify_keep_ascii
$
```

The two comments and the test comment go with it. That grep is over the whole tree, `doc/` included, so nothing published names it either.

### Why the two collapse into one

While 7BIT, VALID and BROKEN were three flags, keeping one of them and dropping the rest was a distinct thing to offer, and `mrb_str_modify_keep_ascii()` offered it:

```c
/* before the coderange became a field */
MRB_API void
mrb_str_modify_keep_ascii(mrb_state *mrb, struct RString *s)
{
  mrb_check_frozen(mrb, s);
  str_unshare_buffer(mrb, s);
  RSTR_UNSET_VALID_ENC_FLAG(s);
  RSTR_UNSET_BROKEN_ENC_FLAG(s);
}
```

With one field holding one of four answers, a prepare either keeps what the string says or takes it back to `MRB_STR_CODERANGE_UNKNOWN`. There is no third thing left for a second published prepare to do.

### What is left

```c
MRB_API void mrb_str_modify(mrb_state *mrb, struct RString *s);
```

a prepare that asks nothing of its caller, and `str_modify_keep_cr()` in string.c, which asks a promise no caller can be held to. This is the pair CRuby publishes and keeps back: `rb_str_modify()` in `include/ruby/intern.h`, `str_modify_keep_cr()` `static` in string.c.

`mrb_str_modify()` takes the two lines of prologue back rather than calling through the removed one:

```c
MRB_API void
mrb_str_modify(mrb_state *mrb, struct RString *s)
{
  mrb_check_frozen(mrb, s);
  str_unshare_buffer(mrb, s);
  RSTR_CODERANGE_SET(s, MRB_STR_CODERANGE_UNKNOWN);
}
```

### For a gem that called it

`mrb_str_modify()`. It is correct, and it pays for a walk the gem was promising to skip. The build says so rather than changing under it.

### Generated code

`gcc 13.3.0 -O3`, x86-64, against the same objects built from master. `.text` of `bin/mruby`, with #7180 in the middle column so the two commits can be read apart:

| build | master | #7180 | this PR |
| --- | ---: | ---: | ---: |
| full-debug | 2636642 | 2636810 | 2636658 (+16) |
| bintest | 1820341 | 1821341 | 1821389 (+1048) |
| cxx_abi | 1850166 | 1851846 | 1851886 (+1720) |
| byte-string | 1795973 | 1795973 | 1795013 (-960) |
| `build_config/default.rb` | 1722135 | 1722135 | 1721175 (-960) |
| 32-bit, `full-core`, `i686-linux-gnu-gcc` | 1994304 | 1995272 | 1994948 (+644) |
| the same, with `enable_debug` | 2344884 | 2345056 | 2344904 (+20) |

Objects differing between this commit and #7180, comparing `objdump -d` over every `.o` in the build:

| build | objects | differing | `src/string.o` `.text` |
| --- | ---: | ---: | ---: |
| full-debug | 291 | 1 | 50762 -> 50626 |
| bintest | 301 | 1 | 57826 -> 57882 |
| cxx_abi | 291 | 1 | 59085 -> 59133 |
| byte-string | 288 | 1 | 42074 -> 41122 |
| `build_config/default.rb` | 270 | 1 | 42074 -> 41122 |
| 32-bit | 291 | 1 | 62809 -> 62493 |

`src/string.o` and nothing else, in every build.

Where the strings index by byte, the removed function is the whole of it. Per symbol, `byte-string`:

```
mrb_str_modify_keep_ascii    838 -> gone
```

A published function whose body folds to `mrb_check_frozen()` and an unshare goes, and `.text` falls by 952 with the padding around it.

Where they index by character it is smaller and goes the other way, because `mrb_str_modify()` stops calling out. On master and in #7180 it is a call to `mrb_str_modify_keep_ascii()` followed by one field write, so a caller that inlines `mrb_str_modify()` still ends at that call. Here there is nothing to call, and `str_unshare_buffer()` comes along. `mrb_str_resize()` in `bintest`, #7180 above and this branch below, by the relocations of what it calls:

```
mrb_str_modify_keep_ascii

mrb_check_frozen   mrb_malloc x2   mrb_free x2   memcpy x2
```

which is where the +849 in the per-symbol account comes from:

```
mrb_str_modify_keep_ascii    942 -> gone
mrb_str_resize               208 -> 1057   (+849)
mrb_str_concat               442 ->  758   (+316)
mrb_str_cat                 1057 -> 1065     (+8)
mrb_str_aset_m              1496 -> 1480    (-16)
mrb_str_reverse_bang         418 ->  368    (-50)
mrb_str_append               574 ->  542    (-32)
mrb_str_cat_str              574 ->  542    (-32)
mrb_str_setbyte              294 ->  262    (-32)
str_bytesplice               807 ->  775    (-32)
```

+37 over the symbols, +56 in `.text`. `full-debug` is where gcc inlines least, and there the removal is nearly all of it:

```
mrb_str_modify_keep_ascii    123 -> gone
mrb_str_modify                82 ->  101    (+19)
```

### Testing

`rake -m test`, on each commit, all green, 0 KO, 0 crash, 0 warnings, and the same counts as master:

| build | Total | OK | Skip |
| --- | ---: | ---: | ---: |
| full-debug | 2303 | 2300 | 3 |
| bintest | 2304 | 2293 | 11 |
| bintest, the binary tests | 117 | 117 | 0 |
| cxx_abi | 2304 | 2293 | 11 |
| byte-string | 2240 | 2194 | 46 |
| `build_config/default.rb` | 2086 | 2040 | 46 |
| 32-bit, `full-core`, `i686-linux-gnu-gcc` | 2284 | 2272 | 12 |
| the same, with `enable_debug` | 2284 | 2280 | 4 |

`build_config/host-m32.rb` needs a multilib toolchain, so the 32-bit build above is `full-core` with the compiler set to `i686-linux-gnu-gcc` instead.

No test comes with this. A function with no caller is removed and the one line it held is written where its last caller stood, so no string answers anything different. The one test file that named it, `mrbgems/mruby-encoding/test/string.rb`, names `mrb_str_modify()` in a comment now and tests what it tested.

### Not in this PR

`mrb_str_modify()` does what it did: the two lines it reached for through the removed function are written where the call stood, and what it clears and when are unchanged. `str_modify_keep_cr()` gains no caller here either, so which other in-place writes could make its promise stays where #7180 left it. No other published string function is touched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **API Changes**
  * Removed the public `mrb_str_modify_keep_ascii()`, which #7180 left without a caller. `mrb_str_modify()` remains and is what a caller of the removed one wants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
