### PR TITLE
presym: generate valid C when the scan finds no symbols

### DIFF
--- a/lib/mruby/presym.rb
+++ b/lib/mruby/presym.rb
@@ -84,16 +84,20 @@ module MRuby
       sym_re = /\A(#{prefix_re})?([\w&&\D]\w*)(#{suffix_re})?\z/o
       _pp "GEN", id_header_path.relative_path
       File.open(id_header_path, "w:binary") do |f|
-        f.puts "enum mruby_presym {"
-        presyms.each.with_index(1) do |sym, num|
-          if sym_re =~ sym && (affixes = SYMBOL_TO_MACRO[[$1, $3]])
-            f.puts "  MRB_#{affixes * 'SYM'}__#{$2} = #{num},"
-          elsif name = OPERATORS[sym]
-            f.puts "  MRB_OPSYM__#{name} = #{num},"
+        # PicoRuby builds the VM core as a gem, so its mrbc build scans
+        # zero presyms. An empty enum is invalid C, so skip the enum then.
+        unless presyms.empty?
+          f.puts "enum mruby_presym {"
+          presyms.each.with_index(1) do |sym, num|
+            if sym_re =~ sym && (affixes = SYMBOL_TO_MACRO[[$1, $3]])
+              f.puts "  MRB_#{affixes * 'SYM'}__#{$2} = #{num},"
+            elsif name = OPERATORS[sym]
+              f.puts "  MRB_OPSYM__#{name} = #{num},"
+            end
           end
+          f.puts "};"
+          f.puts
         end
-        f.puts "};"
-        f.puts
         f.puts "#define MRB_PRESYM_MAX #{presyms.size}"
       end
     end


### PR DESCRIPTION
## Background

PicoRuby builds the VM core as a gem outside MRUBY_ROOT/src, so its internal mrbc build legitimately scans zero presyms. write_id_header then emits `enum mruby_presym {};`, which is invalid C, and every translation unit that includes mruby/presym.h fails to compile.

In-tree configs cannot hit this: even a disable_libmruby build such as build_config/mrbc.rb preprocesses MRUBY_ROOT/src/*.c for the scan and collects their symbols.

## Fix

Emit the enum only when there is at least one symbol; MRB_PRESYM_MAX is written either way.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed generated header output for configurations with no predefined symbols by omitting the empty symbol enumeration.
  * Preserved the maximum symbol count definition in all configurations.
  * Existing symbol numbering and enumeration generation remain unchanged when predefined symbols are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->