### PR TITLE
string.c: compare the first byte before `memcmp()` searching backward

### DIFF
--- a/src/string.c
+++ b/src/string.c
@@ -1127,10 +1127,15 @@ str_byterindex(mrb_value str, mrb_value sub, mrb_int pos)
 
   sbeg = RSTR_PTR(ps);
   t = RSTRING_PTR(sub);
+  /* The first byte has to match wherever the rest does, and comparing it here
+     settles all but the positions that carry it. Handing every position to
+     memcmp() instead pays for a call at each one, which is what the search
+     spends nearly all of its time on where the needle is not there to find. */
+  const char head = t[0];
   /* count down an index rather than a pointer: stepping a pointer past the
      first byte to end the search would leave the buffer */
   for (mrb_int i = pos; 0 <= i; i--) {
-    if (memcmp(sbeg+i, t, len) == 0) {
+    if (sbeg[i] == head && memcmp(sbeg+i, t, len) == 0) {
       return i;
     }
   }
@@ -1162,8 +1167,11 @@ str_char_rindex(mrb_value str, mrb_value sub, mrb_int pos)
     /* a match may start only at a character boundary, and `pos` need not be
        one: the clamp above answers the last byte `sub` fits at */
     s = mrb_utf8_char_head(sbeg, s, send);
+    /* see str_byterindex(): the first byte settles all but the positions
+       carrying it, and it is read here anyway to step back from */
+    const char head = t[0];
     for (;;) {
-      if ((mrb_int)(send - s) >= len && memcmp(s, t, len) == 0) {
+      if (*s == head && (mrb_int)(send - s) >= len && memcmp(s, t, len) == 0) {
         return (mrb_int)(s - sbeg);
       }
       /* the character before `s`, which there is none of once the search has


### PR DESCRIPTION
A backward search tries the needle at every position from `pos` down to the head, and hands each one to `memcmp()`:

```c
for (mrb_int i = pos; 0 <= i; i--) {
  if (memcmp(sbeg+i, t, len) == 0) {
    return i;
  }
}
```

Where the needle is not there, that is a call per byte of the string, and the call is what the search spends nearly all of its time on: `memcmp()` has to be entered, has its own head to run before it looks at anything, and then almost always disagrees on the first byte it reads.

The needle's first byte has to match wherever the rest of it does. Reading it inline settles every position but the ones that carry that byte, and only those reach `memcmp()`:

```c
const char head = t[0];
for (mrb_int i = pos; 0 <= i; i--) {
  if (sbeg[i] == head && memcmp(sbeg+i, t, len) == 0) {
    return i;
  }
}
```

`str_char_rindex()` searches the same way over character boundaries, and gets the same guard. There the byte is read at that position anyway, since stepping back to the previous character starts by looking at it.

Both functions have already returned by then for an empty needle, so `t[0]` is a byte of the needle in both. In `str_char_rindex()` the clamp above the loop puts `s` at the last byte the needle fits at, and the walk back only lowers it, so `*s` is inside the string at every turn.

### Measurements

The `bench-utf8` build under Environment at the end, whose compile line is `gcc -O3`, best of 5 runs of best of 5:

```ruby
a = "a" * 100000
200.times { a.rindex("zzz") }
200.times { a.byterindex("zzz") }

u = "あ" * 50000
200.times { u.rindex("zzz") }
```

| | master | this PR | |
| --- | --- | --- | --- |
| `a.rindex("zzz")` | 0.0588 | 0.0090 | 6.5x |
| `a.byterindex("zzz")` | 0.0515 | 0.0045 | 11.4x |
| `u.rindex("zzz")` | 0.0503 | 0.0358 | 1.4x |

The multi-byte receiver gains least because there the positions tried are characters rather than bytes, a third as many here, and stepping between them is work of its own that stays.

A search that finds its needle at the first position tried pays one byte comparison it did not pay before. A search that has to look for it is the case this is about.

### Generated code

`.text` over every `.o`, against the same objects built from master, for each of the four builds `ci/gcc-clang` makes. Their compile lines are under Environment at the end: `full-debug` is `-O0`, the other three are `-O3`.

| build | master | this PR |
| --- | --- | --- |
| full-debug | 2834967 | 2835018 (+51) |
| bintest | 1808046 | 1808110 (+64) |
| cxx_abi | 1817650 | 1817714 (+64) |
| byte-string | 1767586 | 1767618 (+32) |

`byte-string` is the build without `mruby-encoding`. `str_byterindex()` is what a string answers with there, so it gains the guard too, and `str_char_rindex()` is not compiled.

### Testing

`rake -m test` over `ci/gcc-clang`, all four builds green, 0 KO, 0 crash, no new warnings:

| build | result |
| --- | --- |
| full-debug | 2311 tests, 2308 OK, 3 skip |
| bintest | 2312 tests, 2301 OK, 11 skip, plus 117 bintests |
| cxx_abi | 2312 tests, 2301 OK, 11 skip |
| byte-string | 2243 tests, 2195 OK, 48 skip |

`rake -m test` over `build_config/asan.rb` is green too, address and undefined sanitizers both, tests and bintests. The reordered read is the reason to run it: the guard reads `*s` before the length check that used to come first.

Against master over 6720 cases of `String#index` and `String#rindex`, spanning ASCII, multi-byte, broken and binary receivers and needles with offsets on both sides of every edge, the answers are identical byte for byte, under the sanitizers as well.

No test accompanies the change. Both searches answer what they answered, so there is nothing new to pin.

### Environment

<details>
<summary>Versions, and the compile line of every build named above</summary>

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS, Linux 7.0.0-28-generic x86_64 |
| CPU | AMD Ryzen 9 5950X, 16 cores |
| C compiler | gcc 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1) |
| Sanitizer compiler | clang 22.1.8 (Homebrew), which is what `build_config/asan.rb` picks |
| Linker | GNU ld 2.47.20260726, and `g++` for `cxx_abi` |
| CRuby | 4.0.6 (2026-07-14) +PRISM, running rake |

The timings were taken on a build that is not one of the shipped configs, the default gembox with `mruby-encoding` added so that strings index by character:

```ruby
MRuby::Build.new('bench-utf8') do |conf|
  toolchain :gcc
  conf.cc.flags << '-O3'

  conf.gembox 'default'
  conf.gem :core => 'mruby-encoding'
end
```

What each build actually compiles `src/string.c` with, `-MMD -c`, the `-I` paths and `-o` stripped:

```console
# bench-utf8, the build every timing was taken on
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -O3 -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING

# ci/gcc-clang, full-debug
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_UNICODE_CASE -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang, bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK

# ci/gcc-clang, cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang, byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# build_config/asan.rb
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -fsanitize=address,undefined -g3 -O0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

`-g -O3` is what the `gcc` toolchain sets. `full-debug` and the sanitizer build then append `-g3 -O0` through `enable_debug()`, so those two are `-O0`, not `-O3`. `bench-utf8` appends a second `-O3` of its own, which changes nothing over the toolchain's. `cxx_abi` is the C compiler driven as C++ with `-x c++ -std=gnu++03`, and `g++` links it.

</details>
