### PR TITLE
string.c: walk to a substring's range rather than count the string

### DIFF
--- a/src/string.c
+++ b/src/string.c
@@ -722,6 +722,22 @@ str_ascii_p(struct RString *s)
   return TRUE;
 }
 
+/* Whether a character index into this string is already a byte index, asking
+   the bytes where the string does not say. RSTR_SINGLE_BYTE_P() reads what is
+   recorded and answers no for a string nothing has read yet, which sends every
+   later caller down the walking path however plain the bytes are. A string is
+   walked whole at most once here: the walk records what it finds, and it is
+   the same walk the character indexing would go on to do anyway. */
+static mrb_bool
+str_single_byte_p(mrb_state *mrb, mrb_value str)
+{
+  struct RString *s = mrb_str_ptr(str);
+  if (RSTR_CODERANGE(s) == MRB_STR_CODERANGE_UNKNOWN) {
+    mrb_str_valid_encoding_p(mrb, str);
+  }
+  return RSTR_SINGLE_BYTE_P(s);
+}
+
 /* map character index to byte offset index */
 mrb_int
 mrb_str_char_to_byte(mrb_state *mrb, mrb_value str, mrb_int off, mrb_int idx)
@@ -2623,7 +2639,7 @@ mrb_str_byteindex_m(mrb_state *mrb, mrb_value str)
 static mrb_value
 mrb_str_index_m(mrb_state *mrb, mrb_value str)
 {
-  if (RSTR_CODERANGE(mrb_str_ptr(str)) == MRB_STR_CODERANGE_7BIT) {
+  if (str_single_byte_p(mrb, str)) {
     return mrb_str_byteindex_m(mrb, str);
   }
 
@@ -2922,8 +2938,7 @@ mrb_str_byterindex_m(mrb_state *mrb, mrb_value str)
 static mrb_value
 mrb_str_rindex_m(mrb_state *mrb, mrb_value str)
 {
-  struct RString *s = mrb_str_ptr(str);
-  if (RSTR_SINGLE_BYTE_P(s)) {
+  if (str_single_byte_p(mrb, str)) {
     return mrb_str_byterindex_m(mrb, str);
   }
 

--- a/src/string.c
+++ b/src/string.c
@@ -2273,6 +2273,14 @@ mrb_str_chomp_bang(mrb_state *mrb, mrb_value str)
     if (!RSTR_SINGLE_BYTE_P(s) && mrb_utf8_char_head(p, pp, p + len) != pp) {
       return mrb_nil_value();
     }
+    /* Cutting bytes that are nothing but ASCII leaves what the rest is read as
+       standing, non-ASCII and all, so the coderange str_modify_keep_cr() kept
+       is still the answer. Cutting a non-ASCII byte can have taken the last of
+       them, and a string of nothing but ASCII stands at 7BIT rather than
+       VALID: what it is has to be asked again. */
+    if (search_nonascii(pp, pp + rslen) != pp + rslen) {
+      RSTR_CODERANGE_SET(s, MRB_STR_CODERANGE_UNKNOWN);
+    }
 #endif
     RSTR_SET_LEN(s, len - rslen);
     p[RSTR_LEN(s)] = '\0';
@@ -2346,6 +2354,14 @@ mrb_str_chop_bang(mrb_state *mrb, mrb_value str)
         len--;
       }
     }
+#ifdef MRB_UTF8_STRING
+    /* see mrb_str_chomp_bang(): the character cut here is the last one, so a
+       non-ASCII lead byte at `len` is the whole of what leaves the string, and
+       it can have been the last non-ASCII there was. */
+    if ((signed char)RSTR_PTR(s)[len] < 0) {
+      RSTR_CODERANGE_SET(s, MRB_STR_CODERANGE_UNKNOWN);
+    }
+#endif
     RSTR_SET_LEN(s, len);
     RSTR_PTR(s)[len] = '\0';
     return str;

--- a/src/string.c
+++ b/src/string.c
@@ -1043,12 +1043,57 @@ mrb_str_beg_len(mrb_int str_len, mrb_int *begp, mrb_int *lenp)
   return TRUE;
 }
 
+#ifdef MRB_UTF8_STRING
+/* What a substring needs of the string is where two positions are, not how
+   many the string has. Counting the whole of it to find that out reads every
+   byte however near the head the range sits, so the walk here stops at the
+   range instead: forward to `beg` for a position counted from the head, and
+   backward from the end for one counted from there. A position past the end is
+   what the forward walk reports by coming back longer than the string, since
+   mrb_str_char_to_byte() answers one byte more than it reached when the string
+   ends before the index does. */
+static mrb_value
+str_substr(mrb_state *mrb, mrb_value str, mrb_int beg, mrb_int len)
+{
+  struct RString *s = mrb_str_ptr(str);
+  mrb_int slen = RSTR_LEN(s);
+
+  if (str_single_byte_p(mrb, str)) {
+    return mrb_str_beg_len(slen, &beg, &len) ?
+      mrb_str_byte_subseq(mrb, str, beg, len) : mrb_nil_value();
+  }
+  if (len < 0) return mrb_nil_value();
+
+  const char *o = RSTR_PTR(s);
+  mrb_int bbeg;
+  if (beg < 0) {
+    const char *e = o + slen;
+    const char *p = e;
+    for (mrb_int n = beg; n < 0; n++) {
+      /* stepping back off the first character leaves the string, which is the
+         negative index that names no position */
+      if (p == o) return mrb_nil_value();
+      p = mrb_utf8_char_head(o, p-1, e);
+    }
+    bbeg = (mrb_int)(p - o);
+  }
+  else {
+    bbeg = mrb_str_char_to_byte(mrb, str, 0, beg);
+    if (bbeg > slen) return mrb_nil_value();
+  }
+
+  mrb_int blen = mrb_str_char_to_byte(mrb, str, bbeg, len);
+  if (blen > slen - bbeg) blen = slen - bbeg;
+  return mrb_str_byte_subseq(mrb, str, bbeg, blen);
+}
+#else
 static mrb_value
 str_substr(mrb_state *mrb, mrb_value str, mrb_int beg, mrb_int len)
 {
   return mrb_str_beg_len(mrb_str_char_len(mrb, str), &beg, &len) ?
     str_subseq(mrb, str, beg, len) : mrb_nil_value();
 }
+#endif
 
 /*
  * @param mrb The mruby state.

--- a/test/t/string.rb
+++ b/test/t/string.rb
@@ -92,6 +92,17 @@ assert('String#[](UTF-8) indexes a byte that spells no character on its own') do
   assert_equal "あ", "\x80あ"[1]
 end if UTF8STRING
 
+assert('String#[](UTF-8) counts a negative index back from the end') do
+  # Stepping back off the first character leaves the string, so a negative
+  # index reaching past the head names no position rather than wrapping to
+  # one. The length the range asks for is clamped to what is left after it.
+  assert_equal "あ", "あい"[-2]
+  assert_nil "あい"[-3]
+  assert_equal "あ", "あい"[-2, 1]
+  assert_nil "あい"[-3, 1]
+  assert_equal "あい", "あい"[-2, 5]
+end if UTF8STRING
+
 assert('String#[] with Range') do
   a1 = 'abc'[1..0]
   b1 = 'abc'[1..1]


### PR DESCRIPTION
`str_substr()` is what `String#[]` and `String#slice` cut a piece of a string with. It asks the string how many characters it has, hands that to `mrb_str_beg_len()` to turn the range into two non-negative numbers, and walks to them:

```c
static mrb_value
str_substr(mrb_state *mrb, mrb_value str, mrb_int beg, mrb_int len)
{
  return mrb_str_beg_len(mrb_str_char_len(mrb, str), &beg, &len) ?
    str_subseq(mrb, str, beg, len) : mrb_nil_value();
}
```

The count is a walk over every byte of the string. What the cut needs is where two positions are, and both of them can be near an end: `s[0]` and `s[-1]` name a position one step from a boundary and read the whole string to find it.

This PR walks to the range instead. Three commits, each green on its own.

### `str_single_byte_p()`

`RSTR_SINGLE_BYTE_P()` reports what the coderange records, and a string nothing has read yet records nothing, so it answers no however plain the bytes are. Standing on that answer sends the caller down the character path, and the walk that gets it there is thrown away when the walk it then does records what it found.

`str_single_byte_p()` asks the bytes where the coderange does not say:

```c
static mrb_bool
str_single_byte_p(mrb_state *mrb, mrb_value str)
{
  struct RString *s = mrb_str_ptr(str);
  if (RSTR_CODERANGE(s) == MRB_STR_CODERANGE_UNKNOWN) {
    mrb_str_valid_encoding_p(mrb, str);
  }
  return RSTR_SINGLE_BYTE_P(s);
}
```

A string is walked whole at most once here: the walk records what it finds, and it is the same walk the character indexing would have gone on to do.

`String#rindex` moves onto it, and so does `String#index`, which was reading the coderange for 7BIT alone and so left a binary string on the character path that a byte search answers.

`str_substr()` asks through this rather than reading `RSTR_SINGLE_BYTE_P()`, and asking is what keeps the byte path reachable at all. Reading alone would leave a string nothing has read yet on the walking path for good, because once `mrb_str_char_len()` is gone from `str_substr()` nothing on the way records anything: an ASCII receiver cut more than once then walks every time, 37x slower than master at `s[50000]` and 20x at `s[0]` and `s[-1]`. Asking costs one read of the bytes on the first cut, which is the read `mrb_str_char_len()` was already doing there, so the first cut costs what it did and every cut after it is a byte offset. A multi-byte string cut exactly once and then let go pays that read for nothing, and paid it on master too.

### `chomp!` and `chop!` ask again

`str_modify_keep_cr()` keeps the coderange across a write that cannot change it, and cutting bytes that are nothing but ASCII is such a write: what the rest is read as stands, non-ASCII and all. Cutting a non-ASCII byte can have taken the last of them, and a string of nothing but ASCII stands at 7BIT rather than VALID, so `chomp!` and `chop!` leave a VALID that no longer describes the bytes.

That coderange was only ever read as a hint, so nothing answered wrongly on master. It costs a walk at every later reader that could have taken the single byte path, and this PR turns `str_substr()` into one more of those readers. So both cuts now say when they cannot vouch for what they kept:

```c
/* mrb_str_chomp_bang() */
if (search_nonascii(pp, pp + rslen) != pp + rslen) {
  RSTR_CODERANGE_SET(s, MRB_STR_CODERANGE_UNKNOWN);
}

/* mrb_str_chop_bang(): the character cut is the last one, so its lead byte
   at `len` is the whole of what leaves the string */
if ((signed char)RSTR_PTR(s)[len] < 0) {
  RSTR_CODERANGE_SET(s, MRB_STR_CODERANGE_UNKNOWN);
}
```

Cutting `"\n"` off an ASCII line, which is what these are mostly asked to do, keeps the answer it kept before.

### The walk stops at the range

```c
if (str_single_byte_p(mrb, str)) {
  return mrb_str_beg_len(slen, &beg, &len) ?
    mrb_str_byte_subseq(mrb, str, beg, len) : mrb_nil_value();
}
if (len < 0) return mrb_nil_value();

const char *o = RSTR_PTR(s);
mrb_int bbeg;
if (beg < 0) {
  const char *e = o + slen;
  const char *p = e;
  for (mrb_int n = beg; n < 0; n++) {
    /* stepping back off the first character leaves the string, which is the
       negative index that names no position */
    if (p == o) return mrb_nil_value();
    p = mrb_utf8_char_head(o, p-1, e);
  }
  bbeg = (mrb_int)(p - o);
}
else {
  bbeg = mrb_str_char_to_byte(mrb, str, 0, beg);
  if (bbeg > slen) return mrb_nil_value();
}

mrb_int blen = mrb_str_char_to_byte(mrb, str, bbeg, len);
if (blen > slen - bbeg) blen = slen - bbeg;
return mrb_str_byte_subseq(mrb, str, bbeg, blen);
```

A position counted from the head is walked to from the head, and one counted from the end is walked back from the end. Neither reads past where it lands.

Nothing counts the string, so nothing holds a character count to compare a position against, and the two ways a range can name no position are read off the walks themselves:

- A negative index reaching past the head is the walk back running out of string, which is `p == o` with steps still to take.
- A non-negative index past the end is the forward walk coming back longer than the string. `mrb_str_char_to_byte()` answers one byte more than it reached when the string ends before the index does, so `bbeg > slen` is exactly that case and only that case: an index equal to the character count lands on `e` with nothing left over, and answers `slen`.

The length is clamped to what is left after `bbeg`, which is what `mrb_str_beg_len()` did with it before.

A single byte string keeps the counting form, since there a character index is a byte index and the count is `RSTR_LEN()`. So does the build without `MRB_UTF8_STRING`: `str_substr()` there is the old two-liner, under `#else`.

### Measurements

The `bench-utf8` build under Environment at the end, whose compile line is `gcc -O3`, best of 5 runs of best of 5:

```ruby
u = "あ" * 50000
20000.times { u[0] }
20000.times { u[-1] }
20000.times { u[0, 3] }
20000.times { u[-3, 3] }
20000.times { u[25000] }
```

| | master | this PR | |
| --- | --- | --- | --- |
| `u[0]` | 2.7229 | 0.0013 | 2094x |
| `u[-1]` | 5.5642 | 0.0014 | 3974x |
| `u[0, 3]` | 2.7258 | 0.0037 | 737x |
| `u[-3, 3]` | 5.5668 | 0.0038 | 1465x |
| `u[25000]` | 4.1463 | 1.3625 | 3.0x |

The four ratios at the ends are what a 50000 character string makes them and nothing more: the figure they divide into is the loop and the allocation, not the reading of a string. `a[0]` on a 100000 byte ASCII receiver, in the table below, answers in that same 0.0013 on both sides without ever walking anything. So the ends stop costing what the string's length decides, and how many times that is depends on how long the string was.

The middle is the ratio to read: `u[25000]` keeps one walk of the two it did, and 3.0 is where that lands whatever the length.

`u[-1]` costs twice `u[0]` on master because the count and the walk to the position are both the whole string; here it is the one step back that the negative index asks for.

What does not move:

```ruby
a = "a" * 100000
20000.times { a[0] }
20000.times { a[-1] }
20000.times { a[50000] }
200000.times { "hello world"[3] }
200000.times { "hello world"[2, 4] }
200000.times { "あいうえお"[3] }
200000.times { "hello\n".chomp! }
200000.times { "helloあ".chop! }
```

| | master | this PR |
| --- | --- | --- |
| `a[0]`, `a[-1]`, `a[50000]` | 0.0013 | 0.0013 |
| `"hello world"[3]` | 0.0130 | 0.0133 |
| `"hello world"[2, 4]` | 0.0364 | 0.0372 |
| `"あいうえお"[3]` | 0.0174 | 0.0151 |
| `"hello\n".chomp!` | 0.0149 | 0.0146 |
| `"helloあ".chop!` | 0.0136 | 0.0137 |

`a` is the ASCII receiver, which reaches the byte path in both and stays there. The short strings are where the walk was never the cost, and the two cuts are the ones the second commit adds a read to.

### Generated code

`.text` over every `.o`, against the same objects built from master, for each of the four builds `ci/gcc-clang` makes. Their compile lines are under Environment at the end: `full-debug` is `-O0`, the other three are `-O3`.

| build | master | this PR |
| --- | --- | --- |
| full-debug | 2834967 | 2835611 (+644) |
| bintest | 1808046 | 1809278 (+1232) |
| cxx_abi | 1817650 | 1818402 (+752) |
| byte-string | 1767586 | 1767586 (±0) |

`str_substr()` grows from a two-liner into two walks and the reading of their ends, and `str_single_byte_p()` is new. `byte-string` is the build without `mruby-encoding`, where the `#else` definition is what compiles and nothing here reaches.

### Testing

`rake -m test` over `ci/gcc-clang`, all four builds green, 0 KO, 0 crash, no new warnings:

| build | result |
| --- | --- |
| full-debug | 2312 tests, 2309 OK, 3 skip |
| bintest | 2313 tests, 2302 OK, 11 skip, plus 117 bintests |
| cxx_abi | 2313 tests, 2302 OK, 11 skip |
| byte-string | 2243 tests, 2195 OK, 48 skip |

`rake -m test` over `build_config/asan.rb` is green too, address and undefined sanitizers both, tests and bintests. The walk back off the head is what to run it for.

The new test pins the negative index, which is the range this PR gives a reading of its own:

```ruby
assert_equal "あ", "あい"[-2]
assert_nil "あい"[-3]
assert_equal "あ", "あい"[-2, 1]
assert_nil "あい"[-3, 1]
assert_equal "あい", "あい"[-2, 5]
```

Against master over 8789 cases of `String#[]`, spanning ASCII, multi-byte, broken and binary receivers with every index and length and both kinds of range on both sides of every edge, the answers are identical byte for byte, under the sanitizers as well. So are 6720 cases of `String#index` and `String#rindex`, and 48 of `chomp!` and `chop!` read again afterwards through `[]`, `index`, `rindex`, `reverse`, `upcase`, `length` and `valid_encoding?`.

### Environment

<details>
<summary>Versions, and the compile line of every build named above</summary>

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS, Linux 7.0.0-28-generic x86_64 |
| CPU | AMD Ryzen 9 5950X, 16 cores |
| C compiler | gcc 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1) |
| Sanitizer compiler | clang 22.1.8 (Homebrew), which is what `build_config/asan.rb` picks |
| Linker | GNU ld 2.47.20260726, and `g++` for `cxx_abi` |
| CRuby | 4.0.6 (2026-07-14) +PRISM, running rake |

The timings were taken on a build that is not one of the shipped configs, the default gembox with `mruby-encoding` added so that strings index by character:

```ruby
MRuby::Build.new('bench-utf8') do |conf|
  toolchain :gcc
  conf.cc.flags << '-O3'

  conf.gembox 'default'
  conf.gem :core => 'mruby-encoding'
end
```

What each build actually compiles `src/string.c` with, `-MMD -c`, the `-I` paths and `-o` stripped:

```console
# bench-utf8, the build every timing was taken on
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -O3 -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING

# ci/gcc-clang, full-debug
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_UNICODE_CASE -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang, bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK

# ci/gcc-clang, cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang, byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# build_config/asan.rb
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -fsanitize=address,undefined -g3 -O0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

`-g -O3` is what the `gcc` toolchain sets. `full-debug` and the sanitizer build then append `-g3 -O0` through `enable_debug()`, so those two are `-O0`, not `-O3`. `bench-utf8` appends a second `-O3` of its own, which changes nothing over the toolchain's. `cxx_abi` is the C compiler driven as C++ with `-x c++ -std=gnu++03`, and `g++` links it.

</details>
