### PR TITLE
mruby-string-ext: read a `String#casecmp?` operand, not a copy of it

### DIFF
--- a/include/mruby/internal.h
+++ b/include/mruby/internal.h
@@ -257,6 +257,17 @@ mrb_int mrb_str_byte_to_char(mrb_state *mrb, mrb_value str, mrb_int bi);
    definition in string.c for what it reads and what it leaves behind. */
 mrb_bool mrb_str_valid_encoding_p(mrb_state *mrb, mrb_value str);
 
+#ifdef MRB_UTF8_STRING
+/* What RSTR_SINGLE_BYTE_P() reads, asking the bytes where the string does not
+   say rather than answering no for one nothing has read yet. See the
+   definition in string.c for what it leaves behind.
+
+   Only a build that reads its strings as characters has anything to tell a
+   single-byte string from, so a build indexing by byte carries no answer here
+   rather than one saying TRUE of every string. */
+mrb_bool mrb_str_single_byte_p(mrb_state *mrb, mrb_value str);
+#endif
+
 /* Raise IndexError when `pos` lands inside a character of `str`, and return
    otherwise. See the definition in string.c for which offsets are positions
    the string has; a build without MRB_UTF8_STRING has one per byte, so this

--- a/mrbgems/mruby-string-ext/src/string.c
+++ b/mrbgems/mruby-string-ext/src/string.c
@@ -1435,12 +1435,18 @@ str_casecmp(mrb_state *mrb, mrb_value self)
 #ifdef MRB_UTF8_STRING
 /* Whether a string holds anything the fold table could speak about. A string
    of nothing but ASCII does not, and one read as bytes spells no characters
-   at all, so neither needs the walk. */
+   at all, so neither needs the walk: those are the two a single-byte string is
+   arrived at from.
+
+   The reading is asked for rather than taken off the flags, so that a string
+   nobody has read through yet is read through here. The answer is left on the
+   string, so the next comparison of it is a flag away; sending it down the
+   folding path instead would copy it, read the copy, and throw the answer away
+   with the copy, which is a cost that never stops being paid. */
 static mrb_bool
-str_folds_beyond_ascii(mrb_value str)
+str_folds_beyond_ascii(mrb_state *mrb, mrb_value str)
 {
-  struct RString *s = mrb_str_ptr(str);
-  return RSTR_CODERANGE(s) != MRB_STR_CODERANGE_7BIT && !RSTR_BINARY_P(s);
+  return !mrb_str_single_byte_p(mrb, str);
 }
 
 /* Fold the one side the tables have nothing to say about. Only one of the two
@@ -1485,7 +1491,7 @@ str_casecmp_p(mrb_state *mrb, mrb_value self)
 
   /* Nothing above ASCII on either side leaves nothing for the tables to fold,
      and the two strings order by their bytes as they always have. */
-  if (str_folds_beyond_ascii(self) || str_folds_beyond_ascii(other)) {
+  if (str_folds_beyond_ascii(mrb, self) || str_folds_beyond_ascii(mrb, other)) {
     mrb_value a = mrb_str_dup(mrb, self);
     mrb_value b = mrb_str_dup(mrb, other);
     if (mrb_str_case_convert_unicode(mrb, a, MRB_CASE_FOLD) < 0) str_fold_ascii(mrb, a);

--- a/src/string.c
+++ b/src/string.c
@@ -728,8 +728,8 @@ str_ascii_p(struct RString *s)
    later caller down the walking path however plain the bytes are. A string is
    walked whole at most once here: the walk records what it finds, and it is
    the same walk the character indexing would go on to do anyway. */
-static mrb_bool
-str_single_byte_p(mrb_state *mrb, mrb_value str)
+mrb_bool
+mrb_str_single_byte_p(mrb_state *mrb, mrb_value str)
 {
   struct RString *s = mrb_str_ptr(str);
   if (RSTR_CODERANGE(s) == MRB_STR_CODERANGE_UNKNOWN) {
@@ -1058,7 +1058,7 @@ str_substr(mrb_state *mrb, mrb_value str, mrb_int beg, mrb_int len)
   struct RString *s = mrb_str_ptr(str);
   mrb_int slen = RSTR_LEN(s);
 
-  if (str_single_byte_p(mrb, str)) {
+  if (mrb_str_single_byte_p(mrb, str)) {
     return mrb_str_beg_len(slen, &beg, &len) ?
       mrb_str_byte_subseq(mrb, str, beg, len) : mrb_nil_value();
   }
@@ -2700,7 +2700,7 @@ mrb_str_byteindex_m(mrb_state *mrb, mrb_value str)
 static mrb_value
 mrb_str_index_m(mrb_state *mrb, mrb_value str)
 {
-  if (str_single_byte_p(mrb, str)) {
+  if (mrb_str_single_byte_p(mrb, str)) {
     return mrb_str_byteindex_m(mrb, str);
   }
 
@@ -2999,7 +2999,7 @@ mrb_str_byterindex_m(mrb_state *mrb, mrb_value str)
 static mrb_value
 mrb_str_rindex_m(mrb_state *mrb, mrb_value str)
 {
-  if (str_single_byte_p(mrb, str)) {
+  if (mrb_str_single_byte_p(mrb, str)) {
     return mrb_str_byterindex_m(mrb, str);
   }
 

--- a/src/string.c
+++ b/src/string.c
@@ -722,6 +722,22 @@ str_ascii_p(struct RString *s)
   return TRUE;
 }
 
+/* Whether a character index into this string is already a byte index, asking
+   the bytes where the string does not say. RSTR_SINGLE_BYTE_P() reads what is
+   recorded and answers no for a string nothing has read yet, which sends every
+   later caller down the walking path however plain the bytes are. A string is
+   walked whole at most once here: the walk records what it finds, and it is
+   the same walk the character indexing would go on to do anyway. */
+static mrb_bool
+str_single_byte_p(mrb_state *mrb, mrb_value str)
+{
+  struct RString *s = mrb_str_ptr(str);
+  if (RSTR_CODERANGE(s) == MRB_STR_CODERANGE_UNKNOWN) {
+    mrb_str_valid_encoding_p(mrb, str);
+  }
+  return RSTR_SINGLE_BYTE_P(s);
+}
+
 /* map character index to byte offset index */
 mrb_int
 mrb_str_char_to_byte(mrb_state *mrb, mrb_value str, mrb_int off, mrb_int idx)
@@ -2623,7 +2639,7 @@ mrb_str_byteindex_m(mrb_state *mrb, mrb_value str)
 static mrb_value
 mrb_str_index_m(mrb_state *mrb, mrb_value str)
 {
-  if (RSTR_CODERANGE(mrb_str_ptr(str)) == MRB_STR_CODERANGE_7BIT) {
+  if (str_single_byte_p(mrb, str)) {
     return mrb_str_byteindex_m(mrb, str);
   }
 
@@ -2922,8 +2938,7 @@ mrb_str_byterindex_m(mrb_state *mrb, mrb_value str)
 static mrb_value
 mrb_str_rindex_m(mrb_state *mrb, mrb_value str)
 {
-  struct RString *s = mrb_str_ptr(str);
-  if (RSTR_SINGLE_BYTE_P(s)) {
+  if (str_single_byte_p(mrb, str)) {
     return mrb_str_byterindex_m(mrb, str);
   }
 

--- a/src/string.c
+++ b/src/string.c
@@ -2273,6 +2273,14 @@ mrb_str_chomp_bang(mrb_state *mrb, mrb_value str)
     if (!RSTR_SINGLE_BYTE_P(s) && mrb_utf8_char_head(p, pp, p + len) != pp) {
       return mrb_nil_value();
     }
+    /* Cutting bytes that are nothing but ASCII leaves what the rest is read as
+       standing, non-ASCII and all, so the coderange str_modify_keep_cr() kept
+       is still the answer. Cutting a non-ASCII byte can have taken the last of
+       them, and a string of nothing but ASCII stands at 7BIT rather than
+       VALID: what it is has to be asked again. */
+    if (search_nonascii(pp, pp + rslen) != pp + rslen) {
+      RSTR_CODERANGE_SET(s, MRB_STR_CODERANGE_UNKNOWN);
+    }
 #endif
     RSTR_SET_LEN(s, len - rslen);
     p[RSTR_LEN(s)] = '\0';
@@ -2346,6 +2354,14 @@ mrb_str_chop_bang(mrb_state *mrb, mrb_value str)
         len--;
       }
     }
+#ifdef MRB_UTF8_STRING
+    /* see mrb_str_chomp_bang(): the character cut here is the last one, so a
+       non-ASCII lead byte at `len` is the whole of what leaves the string, and
+       it can have been the last non-ASCII there was. */
+    if ((signed char)RSTR_PTR(s)[len] < 0) {
+      RSTR_CODERANGE_SET(s, MRB_STR_CODERANGE_UNKNOWN);
+    }
+#endif
     RSTR_SET_LEN(s, len);
     RSTR_PTR(s)[len] = '\0';
     return str;

--- a/src/string.c
+++ b/src/string.c
@@ -1043,12 +1043,57 @@ mrb_str_beg_len(mrb_int str_len, mrb_int *begp, mrb_int *lenp)
   return TRUE;
 }
 
+#ifdef MRB_UTF8_STRING
+/* What a substring needs of the string is where two positions are, not how
+   many the string has. Counting the whole of it to find that out reads every
+   byte however near the head the range sits, so the walk here stops at the
+   range instead: forward to `beg` for a position counted from the head, and
+   backward from the end for one counted from there. A position past the end is
+   what the forward walk reports by coming back longer than the string, since
+   mrb_str_char_to_byte() answers one byte more than it reached when the string
+   ends before the index does. */
+static mrb_value
+str_substr(mrb_state *mrb, mrb_value str, mrb_int beg, mrb_int len)
+{
+  struct RString *s = mrb_str_ptr(str);
+  mrb_int slen = RSTR_LEN(s);
+
+  if (str_single_byte_p(mrb, str)) {
+    return mrb_str_beg_len(slen, &beg, &len) ?
+      mrb_str_byte_subseq(mrb, str, beg, len) : mrb_nil_value();
+  }
+  if (len < 0) return mrb_nil_value();
+
+  const char *o = RSTR_PTR(s);
+  mrb_int bbeg;
+  if (beg < 0) {
+    const char *e = o + slen;
+    const char *p = e;
+    for (mrb_int n = beg; n < 0; n++) {
+      /* stepping back off the first character leaves the string, which is the
+         negative index that names no position */
+      if (p == o) return mrb_nil_value();
+      p = mrb_utf8_char_head(o, p-1, e);
+    }
+    bbeg = (mrb_int)(p - o);
+  }
+  else {
+    bbeg = mrb_str_char_to_byte(mrb, str, 0, beg);
+    if (bbeg > slen) return mrb_nil_value();
+  }
+
+  mrb_int blen = mrb_str_char_to_byte(mrb, str, bbeg, len);
+  if (blen > slen - bbeg) blen = slen - bbeg;
+  return mrb_str_byte_subseq(mrb, str, bbeg, blen);
+}
+#else
 static mrb_value
 str_substr(mrb_state *mrb, mrb_value str, mrb_int beg, mrb_int len)
 {
   return mrb_str_beg_len(mrb_str_char_len(mrb, str), &beg, &len) ?
     str_subseq(mrb, str, beg, len) : mrb_nil_value();
 }
+#endif
 
 /*
  * @param mrb The mruby state.

--- a/test/t/string.rb
+++ b/test/t/string.rb
@@ -92,6 +92,17 @@ assert('String#[](UTF-8) indexes a byte that spells no character on its own') do
   assert_equal "あ", "\x80あ"[1]
 end if UTF8STRING
 
+assert('String#[](UTF-8) counts a negative index back from the end') do
+  # Stepping back off the first character leaves the string, so a negative
+  # index reaching past the head names no position rather than wrapping to
+  # one. The length the range asks for is clamped to what is left after it.
+  assert_equal "あ", "あい"[-2]
+  assert_nil "あい"[-3]
+  assert_equal "あ", "あい"[-2, 1]
+  assert_nil "あい"[-3, 1]
+  assert_equal "あい", "あい"[-2, 5]
+end if UTF8STRING
+
 assert('String#[] with Range') do
   a1 = 'abc'[1..0]
   b1 = 'abc'[1..1]


### PR DESCRIPTION
Stacked on #7187, whose three commits are the first three here and where `str_single_byte_p()` comes from. The fourth is this PR's own change, and the diff to read is `git diff cb767edb0..HEAD`. Merging #7187 first leaves this one a single commit. Every number below is given against master and against that branch both, the master column so the whole stack can be read at once and the middle one so this PR's own change can be.

`String#casecmp?` folds both sides before it compares them, and it decides whether the fold tables have anything to say about a string by reading the coderange off it:

```c
static mrb_bool
str_folds_beyond_ascii(mrb_value str)
{
  struct RString *s = mrb_str_ptr(str);
  return RSTR_CODERANGE(s) != MRB_STR_CODERANGE_7BIT && !RSTR_BINARY_P(s);
}
```

A string nothing has read yet records nothing, so it stands at `MRB_STR_CODERANGE_UNKNOWN` and reads here as a string that folds beyond ASCII, however plain its bytes are. What that answer sends it down is the folding path, which copies both operands, folds the copies and throws them away:

```c
if (str_folds_beyond_ascii(self) || str_folds_beyond_ascii(other)) {
  mrb_value a = mrb_str_dup(mrb, self);
  mrb_value b = mrb_str_dup(mrb, other);
  if (mrb_str_case_convert_unicode(mrb, a, MRB_CASE_FOLD) < 0) str_fold_ascii(mrb, a);
  ...
}
```

The walk that would have said "nothing but ASCII" is made on the copy, and it goes out with the copy. So the next comparison of the same string starts at UNKNOWN again and pays for the same two copies, and a pair of plain ASCII strings, which is what the method is mostly handed, never stops paying for the walk that would have said so.

### Ask the bytes, and leave the answer on the string

What the predicate spells out is what `str_single_byte_p()` in string.c already answers: it asks the bytes where the string does not say, and a string is single byte where it holds nothing but ASCII and where it is read as bytes, which are the two cases named here by hand. Publish it as `mrb_str_single_byte_p()` and ask it:

```c
static mrb_bool
str_folds_beyond_ascii(mrb_state *mrb, mrb_value str)
{
  return !mrb_str_single_byte_p(mrb, str);
}
```

The reading is left on the string it was made about rather than on a copy, so the first comparison walks and every one after it reads a flag. A pair holding nothing but ASCII then orders by its bytes the way it did before this method learned to fold.

A string read as bytes still costs nothing to answer for. The walk is made by `mrb_str_valid_encoding_p()`, which hands such a string back before it reads a byte of it.

The declaration goes inside the `MRB_UTF8_STRING` guard rather than beside `mrb_str_valid_encoding_p()`, which stands outside one. That check answers on both sides because mruby-regexp and mruby-string-ext call it without a guard; this one is asked from inside a guard on either side of it, and a build indexing by byte has no second way to arrive at a single byte string for the answer to be about.

### Measurements

The `bench-utf8` build under Environment at the end, whose compile line is `gcc -O3`, the three binaries run against each other five times over and the best of each taken:

```ruby
a = "abcdefgh"; b = "ABCDEFGH"
2_000_000.times { a.casecmp?(b) }

c = "a" * 4000; d = "A" * 4000
100_000.times { c.casecmp?(d) }

e = "aあbcde"; f = "Aあbcde"
500_000.times { e.casecmp?(f) }

xs = Array.new(100_000) { "aあbcde".dup }
ys = Array.new(100_000) { "Aあbcde".dup }
100_000.times { |i| xs[i].casecmp?(ys[i]) }

gs = Array.new(10_000) { ("a" * 3000 + "あ" * 300).dup }
hs = Array.new(10_000) { ("A" * 3000 + "あ" * 300).dup }
10_000.times { |i| gs[i].casecmp?(hs[i]) }
```

Each loop is written out as a `while` in the script that was run, so what is timed is the call rather than a block around it.

| ms | master | #7187 | this PR | |
| --- | --- | --- | --- | --- |
| 2,000,000 of an 8 byte ASCII pair | 189.2 | 194.2 | 69.9 | 2.7x |
| 100,000 of a 4000 byte ASCII pair | 1228.0 | 1311.0 | 348.3 | 3.5x |
| 500,000 of an 8 byte pair above ASCII, one pair | 169.0 | 165.0 | 164.2 | 1.0x |
| 100,000 of an 8 byte pair above ASCII, each fresh | 514.3 | 514.6 | 517.3 | 1.0x |
| 10,000 of a 3900 byte pair above ASCII, each fresh | 965.6 | 992.8 | 977.0 | 1.0x |

The last column is against master.

The first two rows are one flag read standing in for a pair of copies, and what separates them is the length of the pair: the longer the ASCII string, the more of it was being walked and copied for nothing.

The last three are where the reading cannot pay for itself. A pair holding a character above ASCII is folded as it was before, and the bottom two never read a flag back, since no pair in them is compared twice. Those are the rows to read for whether this is paid for elsewhere.

The two left columns are the same work timed twice: master and #7187 both fold, since neither has a flag to read, and the coderange goes out with the copy on both. What separates them is not this method. #7187 changes no function `casecmp?` calls, and its first two commits leave the second row where master has it; the third, the one that adds `str_substr()`'s walk to `src/string.c` and 720 of the 1,232 bytes that file's object gains, is where the middle column parts from the left one.

### Generated code

`.text` over every `.o`, against the same objects built from master and from this PR's base, for each of the four builds `ci/gcc-clang` makes. Their compile lines are under Environment at the end: `full-debug` is `-O0`, the other three are `-O3`. Each figure in brackets is against the column to its left.

| build | master | #7187 | this PR |
| --- | --- | --- | --- |
| full-debug | 2834967 | 2835611 (+644) | 2835590 (-21) |
| bintest | 1808046 | 1809278 (+1232) | 1809342 (+64) |
| cxx_abi | 1817650 | 1818402 (+752) | 1818482 (+80) |
| byte-string | 1767586 | 1767586 (±0) | 1767586 (±0) |

The two objects that move, and the only two, over the whole stack:

| | master | #7187 | this PR |
| --- | --- | --- | --- |
| bintest src/string.o | 48768 | 50000 (+1232) | 50112 (+112) |
| bintest mruby-string-ext/src/string.o | 20469 | 20469 (±0) | 20421 (-48) |

The middle column is #7187's `str_substr()` walk, which is all of what the stack adds to `src/string.o` before this PR reaches it and none of what it adds to the gem.

A published function needs one copy of itself to be called through where three inlined flag reads needed none, so `src/string.o` grows by the call it now has to be reachable through, and the gem falls by the two reads it spelled out. `full-debug` is the build where this PR's own change is a saving: at `-O0` the function was already a call, so publishing it costs nothing there and the gem still drops its two reads. `byte-string` is unchanged throughout, since what either PR touches stands inside `MRB_UTF8_STRING`.

### Testing

`rake -m test` over `ci/gcc-clang`, all four builds green, 0 KO, 0 crash, no new warnings:

| build | result |
| --- | --- |
| full-debug | 2312 tests, 2309 OK, 3 skip |
| bintest | 2313 tests, 2302 OK, 11 skip, plus 117 bintests |
| cxx_abi | 2313 tests, 2302 OK, 11 skip |
| byte-string | 2243 tests, 2195 OK, 48 skip |

`rake -m test` over `build_config/asan.rb` is green too, address and undefined sanitizers both: 2313 tests, 2310 OK, 3 skip, plus 79 bintests.

No test comes with this. The answers do not move; what moves is which of them is read off a flag and which is walked for, and there is nothing a script can ask a string that tells those two apart. What stands in for one is the comparison against the base binary, over 3480 cases: 58 operands spanning empty, short and long ASCII, Latin above ASCII, ß and ﬀ and the dotted and dotless i, Greek final sigma, Cyrillic, Japanese, an emoji, bytes that spell no character and bytes below space, taken as every ordered pair and each pair asked `casecmp?` and `casecmp` twice over, once while both operands are fresh and once after the first pair of calls has left its reading on them, plus every operand against a `Symbol` and an `Integer`. The answers are identical throughout, the `ArgumentError` that an operand spelling no character raises included. The same 3480 run identically on the `byte-string` build, and under the sanitizers, which report nothing.

### Environment

<details>
<summary>Versions, and the compile line of every build named above</summary>

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS, Linux 7.0.0-28-generic x86_64 |
| CPU | AMD Ryzen 9 5950X, 16 cores |
| C compiler | gcc 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1) |
| Sanitizer compiler | clang 22.1.8 (Homebrew), which is what `build_config/asan.rb` picks |
| Linker | GNU ld 2.47.20260726, and `g++` for `cxx_abi` |
| CRuby | 4.0.6 (2026-07-14) +PRISM, running rake |

The timings were taken on a build that is not one of the shipped configs, the default gembox with `mruby-encoding` added so that strings index by character:

```ruby
MRuby::Build.new('bench-utf8') do |conf|
  toolchain :gcc
  conf.cc.flags << '-O3'

  conf.gembox 'default'
  conf.gem :core => 'mruby-encoding'
end
```

What each build actually compiles `src/string.c` with, `-MMD -c`, the `-I` paths and `-o` stripped:

```console
# bench-utf8, the build every timing was taken on
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -O3 -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING

# ci/gcc-clang, full-debug
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_UNICODE_CASE -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang, bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK

# ci/gcc-clang, cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang, byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# build_config/asan.rb
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -fsanitize=address,undefined -g3 -O0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

`-g -O3` is what the `gcc` toolchain sets. `full-debug` and the sanitizer build then append `-g3 -O0` through `enable_debug()`, so those two are `-O0`, not `-O3`. `bench-utf8` appends a second `-O3` of its own, which changes nothing over the toolchain's. `cxx_abi` is the C compiler driven as C++ with `-x c++ -std=gnu++03`, and `g++` links it.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UTF-8 string indexing, including negative indexes, bounded lengths, and out-of-range handling.
  * Corrected UTF-8-aware case-insensitive comparisons and string searching for single-byte content.
  * Fixed cached string character information after `chomp!` and `chop!` remove non-ASCII characters.
  * Improved substring operations to return `nil` consistently for invalid positions or lengths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
