### PR TITLE
Prevent switch statement warning for `MRB_TT_SET`

### DIFF
--- a/mrbgems/mruby-os-memsize/src/memsize.c
+++ b/mrbgems/mruby-os-memsize/src/memsize.c
@@ -156,11 +156,11 @@ os_memsize_of_object(mrb_state* mrb, mrb_value obj)
       size += mrb_objspace_page_slot_size();
 #endif
       break;
-#if defined(MRB_USE_SET)
     case MRB_TT_SET:
+#if defined(MRB_USE_SET)
       size += mrb_set_memsize(obj);
-      break;
 #endif
+      break;
     case MRB_TT_BIGINT:
 #if defined(MRB_USE_BIGINT)
       size += mrb_bint_memsize(obj);


### PR DESCRIPTION
The `switch` statement in `os_memsize_of_object()` is intentionally designed without a `default` case, so that a warning is issued if it does not match the enumeration definition. Moving the `MRB_USE_SET` guard inside the `case MRB_TT_SET` prevents this warning, even if not included mruby-set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory-size reporting for set-type objects, including builds where set support is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->