### PR TITLE
mruby-regexp: take away the MatchData constructor

### DIFF
--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -1516,6 +1516,13 @@ mrb_mruby_regexp_gem_init(mrb_state *mrb)
   /* MatchData class */
   struct RClass *md = mrb_define_class(mrb, "MatchData", mrb->object_class);
   MRB_SET_INSTANCE_TT(md, MRB_TT_CDATA);
+  /* A match is the only thing that builds one, through create_matchdata(),
+     which allocates the object itself rather than going through `new`. The
+     class defines no `initialize`, so `new` and `allocate` returned an
+     instance whose data type was never set, and every method on it raised
+     TypeError out of the DATA_GET_PTR guard. CRuby undefines both; so do we. */
+  mrb_undef_class_method(mrb, md, "new");
+  mrb_undef_class_method(mrb, md, "allocate");
 
   mrb_define_method(mrb, md, "[]", matchdata_aref, MRB_ARGS_REQ(1));
   mrb_define_method(mrb, md, "captures", matchdata_captures, MRB_ARGS_NONE());

--- a/mrbgems/mruby-regexp/test/match_data.rb
+++ b/mrbgems/mruby-regexp/test/match_data.rb
@@ -1,3 +1,19 @@
+assert("MatchData cannot be constructed") do
+  # A match builds the only MatchData there is. The class defines no
+  # `initialize`, so `new` and `allocate` used to hand back an instance with
+  # no data behind it, and every method on it raised TypeError instead. CRuby
+  # has neither constructor; a subclass inherits the absence.
+  assert_raise(NoMethodError) { MatchData.new }
+  assert_raise(NoMethodError) { MatchData.allocate }
+  assert_raise(NoMethodError) { Class.new(MatchData).new }
+  assert_raise(NoMethodError) { Class.new(MatchData).allocate }
+
+  # and matching itself is untouched
+  md = /(\w)(\d)/.match("a1")
+  assert_equal MatchData, md.class
+  assert_equal ["a1", "a", "1"], md.to_a
+end
+
 assert("MatchData#captures") do
   re = Regexp.new("(a)(b)(c)")
   md = re.match("abc")


### PR DESCRIPTION
`MatchData` is declared with `MRB_SET_INSTANCE_TT(md, MRB_TT_CDATA)` and no `initialize`, so `new` and `allocate` each handed back an instance whose data type was never set:

```console
$ bin/mruby -e 'p MatchData.new'
#<MatchData:0x62c1455103f8>
$ bin/mruby -e 'p MatchData.allocate'
#<MatchData:0x62c1455102b8>
```

CRuby undefines both, since a match is the only thing that produces a `MatchData`:

```console
$ ruby -e 'MatchData.new'
NoMethodError: undefined method 'new' for class MatchData
$ ruby -e 'MatchData.allocate'
NoMethodError: undefined method 'allocate' for class MatchData
```

### Nothing was unsafe

`mrb_data_check_type()` rejects an object whose `DATA_TYPE` is NULL, so every method `MatchData` defines raised out of the `DATA_GET_PTR` guard before reading anything:

```console
$ bin/mruby -e 'p MatchData.new.to_a'
-e:1:in to_a: uninitialized MatchData (expected MatchData) (TypeError)
```

That covers `[]`, `captures`, `to_a`, `length`, `size`, `begin`, `end`, `__byte_begin`, `__byte_end`, `__set_globals`, `pre_match`, `post_match`, `named_captures`, `string`, `regexp` and `to_s`. `names`, which `mrblib/regexp.rb` writes as `regexp.names`, raises out of the same guard on the call it makes. What the class inherits from `Object` answered as usual, which is how the `p` above printed anything at all. The object still should not have existed to be asked.

### The change

`create_matchdata()` builds the real ones with `mrb_data_object_alloc()` rather than through `new`, so undefining the two class methods takes the constructor away without touching how a match is made:

```c
mrb_undef_class_method(mrb, md, "new");
mrb_undef_class_method(mrb, md, "allocate");
```

A subclass inherits the absence, as it does in CRuby.

### Tests

`mrbgems/mruby-regexp/test/match_data.rb` gains one assertion block: the two class methods and a subclass of each raise `NoMethodError`, and a match still builds a `MatchData` whose `to_a` reads as it did. It asks nothing of the string it matches beyond ASCII, so it runs on every build below, the byte-indexed one included.

`rake -m test` over `ci/gcc-clang`, all five builds green, 0 KO, 0 crash, no new warnings:

| build | result |
| --- | --- |
| full-debug | 2313 tests, 2310 OK, 3 skip |
| bintest | 2313 tests, 2302 OK, 11 skip, plus 117 bintests |
| cxx_abi | 2313 tests, 2302 OK, 11 skip |
| byte-string | 2244 tests, 2196 OK, 48 skip |
| ascii-case | 2310 tests, 2297 OK, 13 skip |

Read off the `bintest` binary as well as the assertions:

```ruby
MatchData.new                 # NoMethodError: undefined method 'new' for Class
MatchData.allocate            # NoMethodError: undefined method 'allocate' for Class
/(\w)(\d)/.match("a1").to_a   #=> ["a1", "a", "1"]
```

The two lines the console blocks at the top show were read off the same build with the change reverted.

### Environment

<details>
<summary>Versions, and the compile line of every build named above</summary>

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS, Linux 7.0.0-28-generic x86_64 |
| CPU | AMD Ryzen 9 5950X, 16 cores |
| C compiler | gcc 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1) |
| Linker | GNU ld 2.47.20260726, and `g++` for `cxx_abi` |
| CRuby | 4.0.6 (2026-07-14) +PRISM, running rake |

What each build actually compiles `mrbgems/mruby-regexp/src/regexp.c` with, `-MMD -c`, the `-I` paths and `-o` stripped:

```console
# ci/gcc-clang, full-debug
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang, bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK

# ci/gcc-clang, cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang, byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang, ascii-case
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CASE -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

`-g -O3` is what the `gcc` toolchain sets. `full-debug` then appends `-g3 -O0` through `enable_debug()`, so that build is `-O0`, not `-O3`. `cxx_abi` is the C compiler driven as C++ with `-x c++ -std=gnu++03`, and `g++` links it.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented manually creating uninitialized `MatchData` objects through `new` or `allocate`.
  * Confirmed that regular regular-expression matching continues to produce valid match data.
  * Applied the same safeguards to `MatchData` subclasses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->