### PR TITLE
build_config: give each host build config a name of its own

### DIFF
--- a/build_config/host-f32.rb
+++ b/build_config/host-f32.rb
@@ -1,4 +1,6 @@
-MRuby::Build.new do |conf|
+# MRB_USE_FLOAT32 build in a dedicated build directory (build/host-f32) so it
+# does not clobber a normal host build.
+MRuby::Build.new('host-f32') do |conf|
   # load specific toolchain settings
   toolchain :gcc
 

--- a/build_config/host-gprof.rb
+++ b/build_config/host-gprof.rb
@@ -1,4 +1,6 @@
-MRuby::Build.new do |conf|
+# gprof build in a dedicated build directory (build/host-gprof) so it does not
+# clobber a normal host build.
+MRuby::Build.new('host-gprof') do |conf|
   # load specific toolchain settings
   toolchain :gcc
 

--- a/build_config/host-m32-f32.rb
+++ b/build_config/host-m32-f32.rb
@@ -1,4 +1,6 @@
-MRuby::Build.new do |conf|
+# 32-bit MRB_USE_FLOAT32 build in a dedicated build directory
+# (build/host-m32-f32) so it does not clobber a normal host build.
+MRuby::Build.new('host-m32-f32') do |conf|
   # load specific toolchain settings
   toolchain :gcc
 

--- a/build_config/host-m32.rb
+++ b/build_config/host-m32.rb
@@ -1,4 +1,6 @@
-MRuby::Build.new do |conf|
+# 32-bit build in a dedicated build directory (build/host-m32) so it does not
+# clobber a normal host build.
+MRuby::Build.new('host-m32') do |conf|
   # load specific toolchain settings
   toolchain :gcc
 

--- a/build_config/host-nofloat.rb
+++ b/build_config/host-nofloat.rb
@@ -1,4 +1,6 @@
-MRuby::Build.new do |conf|
+# MRB_NO_FLOAT build in a dedicated build directory (build/host-nofloat) so it
+# does not clobber a normal host build.
+MRuby::Build.new('host-nofloat') do |conf|
   # load specific toolchain settings
   toolchain :gcc
 
@@ -8,6 +10,9 @@ MRuby::Build.new do |conf|
   conf.gembox "stdlib-io"
   conf.gembox "metaprog"
 
+  # none of the gemboxes above supplies mrbc, and a build that is not named
+  # 'host' cannot borrow one from a 'host' target that is not being built
+  conf.gem :core => 'mruby-bin-mrbc'
   conf.gem :core => 'mruby-bin-mruby'
   conf.gem :core => 'mruby-bin-mirb'
 

--- a/build_config/host-shared.rb
+++ b/build_config/host-shared.rb
@@ -1,7 +1,7 @@
 # Build mruby with a shared libmruby.so (in addition to the usual
 # libmruby.a / executables).
 #
-# Produces (in build/host/lib/):
+# Produces (in build/host-shared/lib/):
 #   libmruby.a              the static archive (as in the default build)
 #   libmruby.so             the shared library, with SONAME=libmruby.so.<MAJOR>.<MINOR>
 #   libmruby.so.<MAJOR>.<MINOR>  symlink to libmruby.so (matches SONAME)
@@ -14,7 +14,7 @@
 #
 # The shared library is built FROM the static archive via
 # `-Wl,--whole-archive`, so the existing static-build pipeline (including
-# the test infrastructure) is unaffected.  Executables in build/host/bin
+# the test infrastructure) is unaffected.  Executables in build/host-shared/bin
 # remain statically linked; distros that want dynamically-linked
 # executables can rebuild them against the .so.
 #
@@ -22,7 +22,9 @@
 
 require "mruby/source"
 
-MRuby::Build.new do |conf|
+# Shared-library build in a dedicated build directory (build/host-shared) so
+# it does not clobber a normal host build.
+MRuby::Build.new('host-shared') do |conf|
   conf.toolchain
 
   # include the GEM box
@@ -42,7 +44,7 @@ end
 # Add the shared-library targets as a post-build pass, so the default
 # static-build pipeline remains untouched.
 MRuby.each_target do
-  next unless name == "host"
+  next unless name == "host-shared"
 
   libdir = File.join(build_dir, libdir_name)
   vermap = File.join(build_dir, "libmruby.map")


### PR DESCRIPTION
Six configs open an anonymous `MRuby::Build`, and an unnamed build is called `host` (`lib/mruby/build.rb:94`). The build tree is keyed by that name (`:107`), so each of them aims its objects at `build/host`, on top of whatever a default build has left there, and none of them ever creates a directory of its own:

```
build_config/host-f32.rb
build_config/host-gprof.rb
build_config/host-m32.rb
build_config/host-m32-f32.rb
build_config/host-nofloat.rb
build_config/host-shared.rb
```

The repo `bin/` symlinks point into the result as well, because `host?` builds install them (`:452`). All of the transcripts below are from today's master, gcc 13.3.0, each starting from one clean default build.

### The four full-core configs

`host-f32` shows the shape, and it exits 0 while doing it:

```console
$ md5sum build/host/bin/mruby build/host/lib/libmruby.a
c5ab48eae68084c5cbf07fccaa5cf0db  build/host/bin/mruby
7156ead7b09d5deb56a44776fa23dc7a  build/host/lib/libmruby.a
$ build/host/bin/mruby -e 'p 0.1+0.2'
0.30000000000000004
$ MRUBY_CONFIG=host-f32 rake -j8         # exit 0
...
      Config Name: host
 Output Directory: build/host
$ ls build/
host
$ md5sum build/host/bin/mruby build/host/lib/libmruby.a
9ed6eedb366400055b1ffb780c81c842  build/host/bin/mruby
d4112da25dfdadf33ad214793396ceef  build/host/lib/libmruby.a
$ build/host/bin/mruby -e 'p 0.1+0.2'
0.30000001192092896
```

The damage outlives the run. `libmruby.a` is archived with `ar rs` (`lib/mruby/build/command.rb:258`), and `r` replaces but never removes, so members accumulate across config switches: 99 unique members before the `host-f32` run, 107 after, since `full-core.gembox` carries gems that `default.gembox` does not. Building the default config again does not recover the tree. It exits 0 and leaves one that cannot boot at all:

```console
$ rake -j8                               # exit 0
$ build/host/bin/mruby -e 'p 1'
(unknown):0: uninitialized constant digits::other_excl (NameError)
```

The presym tables are regenerated for the smaller gem set while the extra members stay in the archive, so the objects and the tables disagree about which symbol id is which. Recovery is `rm -rf build/host` plus a full rebuild.

### `host-nofloat`

This one relinks part of the tree and leaves the rest:

```console
$ md5sum build/host/bin/mruby build/host/bin/mrbc
c5ab48eae68084c5cbf07fccaa5cf0db  build/host/bin/mruby
2138e925f0e738d9240e0e71d82a3a73  build/host/bin/mrbc
$ MRUBY_CONFIG=host-nofloat rake -j8     # exit 0
$ md5sum build/host/bin/mruby build/host/bin/mrbc
f69af2ed9fd24b7ddcfb013114b8db8e  build/host/bin/mruby
2138e925f0e738d9240e0e71d82a3a73  build/host/bin/mrbc
$ echo 'p 1.5' > /tmp/f.rb
$ build/host/bin/mrbc -o /tmp/f.mrb /tmp/f.rb    # exit 0
```

`build/host/bin/mruby` is an `MRB_NO_FLOAT` binary and `bin/mruby` is that binary too, while the `mrbc` beside it is the default build's and goes on compiling a float literal, so the tree is not even a consistent `MRB_NO_FLOAT` build. `bin/mrbc` need not stay put either: `tasks/bin.rake:2` installs the internal `build/host/mrbc/bin/mrbc` over it for a `host?` build carrying no `mruby-bin-mrbc` gem of its own, and that one is compiled with `MRB_NO_FLOAT`. Which of the two the symlink ends up at is decided by which of them rake found out of date, so any measurement taken through this config silently measures a mixed tree.

### `host-shared`

What this one costs is decided by the timestamps in `build/host`, and both answers are wrong. Starting from a good default build, rake compares timestamps rather than compiler flags, finds every object up to date, recompiles nothing, and links the shared library out of the archive the default build left, which is not `-fPIC`:

```console
$ ls build/host/lib/
libmruby.a  libmruby.flags.mak
$ MRUBY_CONFIG=host-shared rake -j8
LD    build/host/lib/libmruby.so
ld: build/host/lib/libmruby.a(codegen.o): relocation R_X86_64_PC32 against symbol `stderr@@GLIBC_2.2.5' can not be used when making a shared object; recompile with -fPIC
ld: final link failed: bad value
rake aborted!
```

When the objects are out of date instead, the tree is rebuilt with `-fPIC` and `MRB_DEBUG` into `build/host` and the `.so` is produced there, and this one never announces itself afterwards. Both configs load the same gembox, so the object set matches, and the default build after it finds the tree up to date, exits 0, changes nothing and hands that foreign tree back. The `libmruby.so` and `libmruby.so.4.0` left in `build/host/lib` outlive every later default build, because nothing in the default pipeline knows about them.

### Naming them

Each build is named after its config file, which is what `build_config/asan.rb` and `build_config/gctest.rb` already do, and what 8b44a52 did for `host-cxx`. Nothing outside the configs refers to the directories these produce.

Two of the six need more than the rename:

- `host-nofloat` gains `conf.gem :core => 'mruby-bin-mrbc'`. The internal mrbc build is created only for a `host?` build or one that carries that gem (`:153`), and none of the gemboxes this config loads supplies it, so the rename on its own aborts in `mrbcfile` (`:364`) before compiling anything. `build_config/gctest.rb` is the same pair for the same reason.
- `host-shared` carries a post-build pass that adds the shared-library targets, and it picks its target by name. That has to follow the rename, or the config would build and produce no `.so` at all.

The other four need the rename alone: `full-core.gembox` supplies `mruby-bin-mrbc` through its glob.

### Verified

One clean default build, then each config in turn, `rake -j8` throughout:

| config | announced as | result |
| --- | --- | --- |
| default | `host`, `build/host` | exit 0 |
| `host-f32` | `host-f32`, `build/host-f32` | exit 0 |
| `host-gprof` | `host-gprof`, `build/host-gprof` | exit 0 |
| `host-nofloat` | `host-nofloat`, `build/host-nofloat` | exit 0 |
| `host-shared` | `host-shared`, `build/host-shared` | exit 0 |
| `host-m32` | `host-m32`, `build/host-m32` | exit 0, with `CC=i686-linux-gnu-gcc` |
| `host-m32-f32` | `host-m32-f32`, `build/host-m32-f32` | exit 0, same |

Afterwards each config has a directory of its own, `build/host` is byte-identical to what the default build left, and its archive holds the same 99 members it did:

```console
$ ls build/
host  host-f32  host-gprof  host-m32  host-m32-f32  host-nofloat  host-shared
$ md5sum build/host/bin/mruby build/host/bin/mrbc build/host/lib/libmruby.a
c5ab48eae68084c5cbf07fccaa5cf0db  build/host/bin/mruby
2138e925f0e738d9240e0e71d82a3a73  build/host/bin/mrbc
7156ead7b09d5deb56a44776fa23dc7a  build/host/lib/libmruby.a
$ ls build/host/lib/
libmruby.a  libmruby.flags.mak
$ ar t build/host/lib/libmruby.a | sort -u | wc -l
99
$ build/host/bin/mruby -e 'p 0.1+0.2'
0.30000000000000004
```

Each build also holds what it is supposed to:

```console
$ ls build/host-shared/lib/
libmruby.a  libmruby.flags.mak  libmruby.so  libmruby.so.4.0
$ objdump -p build/host-shared/lib/libmruby.so | grep SONAME
  SONAME               libmruby.so.4.0
$ build/host-f32/bin/mruby -e 'p 0.1+0.2'
0.30000001192092896
```

The two 32-bit configs need a toolchain the machine's own gcc cannot supply, since it carries no multilib libc and `-m32` stops at the first compile, on `bits/libc-header-start.h`. Pointing the gcc toolchain at `i686-linux-gnu-gcc` through the environment builds both:

```console
$ export CC=i686-linux-gnu-gcc CXX=i686-linux-gnu-g++ \
    LD=i686-linux-gnu-gcc AR=i686-linux-gnu-gcc-ar
$ MRUBY_CONFIG=host-m32 rake -j8         # exit 0
$ MRUBY_CONFIG=host-m32-f32 rake -j8     # exit 0
$ file build/host-m32/bin/mruby
ELF 32-bit LSB pie executable, Intel 80386, ..., interpreter /lib/ld-linux.so.2, ...
$ build/host-m32/bin/mruby -e 'p 1.class'
Integer
$ build/host-m32-f32/bin/mruby -e 'p 0.1+0.2'
0.30000001192092896
```

Whether the `MRB_NO_FLOAT` binary runs is a separate matter and is unchanged here. It fails to boot the same way it did when it was building into `build/host`:

```console
$ build/host-nofloat/bin/mruby -e 'p 1'
mrblib/kernel.rb:27:in module_function: wrong argument type Symbol (expected Symbol) (TypeError)
```

### Environment

<details>

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-28-generic x86_64 |
| CPU | AMD Ryzen 9 5950X, 16 cores / 32 threads |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0 |
| 32-bit C compiler | i686-linux-gnu-gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0 |
| binutils | GNU ld (GNU Binutils) 2.47.20260726 |
| CRuby running rake | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM |

The line each build gives `src/string.c`, read off `rake --verbose` with `-MMD -c`, the `-I` list and `-o` dropped. The four configs built here all call `enable_debug`, which appends `-g3 -O0` after the gcc toolchain's own `-g -O3`:

```console
# default
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK src/string.c

# host-f32
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_USE_FLOAT32 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c

# host-gprof
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -pg -g3 -O0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c

# host-nofloat
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_NO_FLOAT -DMRB_DEBUG -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM src/string.c

# host-shared
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -fPIC -g3 -O0 -DMRB_DEBUG -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK src/string.c
```

</details>
