### PR TITLE
mruby-bigint: compare a big integer against a Float exactly

### DIFF
--- a/mrbgems/mruby-bigint/core/bigint.c
+++ b/mrbgems/mruby-bigint/core/bigint.c
@@ -5882,11 +5882,23 @@ mrb_bint_cmp(mrb_state *mrb, mrb_value x, mrb_value y)
 {
 #ifndef MRB_NO_FLOAT
   if (mrb_float_p(y)) {
-    mrb_float v1 = mrb_bint_as_float(mrb, x);
-    mrb_float v2 = mrb_float(y);
-    if (v1 == v2) return 0;
-    if (v1 > v2)  return 1;
-    return -1;
+    mrb_float f = mrb_float(y);
+    /* NaN and an infinity have no integer part to split off, so both are
+       answered before the split. */
+    if (isnan(f)) return -2;
+    if (isinf(f)) return f < 0 ? 1 : -1;
+    /* Split `y` where the exact comparison can be made: `trunc()` is exact and
+       neither arm below rounds the integer part, so the fraction is all that is
+       left to decide. `mrb_bint_new_float()` is written for what no `mrb_int`
+       holds, which is what every caller checks before reaching it. */
+    mrb_float fi = trunc(f);
+    mrb_value yi = FIXABLE_FLOAT(fi) ? mrb_int_value(mrb, (mrb_int)fi)
+                                     : mrb_bint_new_float(mrb, fi);
+    mrb_int c = mrb_bint_cmp(mrb, x, yi);
+    if (c != 0) return c;
+    if (f > fi) return -1;
+    if (f < fi) return 1;
+    return 0;
   }
 #endif
   mpz_t a;

--- a/mrbgems/mruby-bigint/test/bigint.rb
+++ b/mrbgems/mruby-bigint/test/bigint.rb
@@ -48,6 +48,19 @@ assert 'Bigint ==' do
     assert_false (1<<70) == 0.5
     assert_false (1<<70) == 1.5
     assert_false(-(1<<70) == -0.5)
+
+    # ...and every one of them written the other way round. `Float#==` had no
+    # arm for a big integer, so it fell through to false and the two
+    # directions disagreed about an equal pair.
+    assert_true (2.0**70) == (1<<70)
+    assert_false (2.0**71) == (1<<70)
+    assert_true(-2.0**70 == -(1<<70))
+    assert_false (2.0**70) == (1<<70) + 1
+    assert_false (2.0**70) == (1<<70) - 1
+    assert_false(-2.0**70 == -((1<<70) + 1))
+    assert_false (1.0/0.0) == (1<<70)
+    assert_false (0.0/0.0) == (1<<70)
+    assert_false 0.5 == (1<<70)
   end
 end
 
@@ -67,6 +80,8 @@ assert 'Bigint eql?' do
   if Object.const_defined?(:Float)
     assert_false n.eql?(2.0**70)
     assert_true n == (2.0**70)
+    assert_false (2.0**70).eql?(n)
+    assert_true (2.0**70) == n
   end
 end
 

--- a/mrbgems/mruby-bigint/test/bigint.rb
+++ b/mrbgems/mruby-bigint/test/bigint.rb
@@ -85,6 +85,47 @@ assert 'Bigint eql?' do
   end
 end
 
+assert 'Bigint <=>' do
+  n = 1<<70
+
+  assert_equal 0, n <=> (1<<70)
+  assert_equal(-1, n <=> (1<<71))
+  assert_equal 1, n <=> 0
+  assert_equal(-1, 0 <=> n)
+
+  assert_nil n <=> 'x'
+  assert_nil n <=> nil
+
+  # `cmpnum()` used to round the big integer to a Float before comparing it
+  # against one, which collapsed a whole neighbourhood onto the same answer.
+  if Object.const_defined?(:Float)
+    assert_equal 0, n <=> (2.0**70)
+    assert_equal 1, n + 1 <=> (2.0**70)
+    assert_equal(-1, n - 1 <=> (2.0**70))
+    assert_equal 0, (2.0**70) <=> n
+    assert_equal(-1, (2.0**70) <=> n + 1)
+    assert_equal 1, (2.0**70) <=> n - 1
+
+    assert_true n + 1 > (2.0**70)
+    assert_true (2.0**70) < n + 1
+    assert_true n - 1 < (2.0**70)
+    assert_true (2.0**70) > n - 1
+
+    assert_equal(-1, n <=> (1.0/0.0))
+    assert_equal 1, n <=> (-1.0/0.0)
+    assert_nil n <=> (0.0/0.0)
+    assert_nil (0.0/0.0) <=> n
+
+    # A Float with no integer part of its own is compared the same way.
+    assert_equal 1, n <=> 0.0
+    assert_equal 1, n <=> 0.5
+    assert_equal 1, n <=> -0.5
+    assert_equal(-1, -n <=> 0.5)
+    assert_equal(-1, 0.5 <=> n)
+    assert_equal 1, 0.5 <=> -n
+  end
+end
+
 assert 'Bigint +' do
   n = 1<<65
   assert_equal 36893488147419103232, n + 0

--- a/mrbgems/mruby-bigint/test/bigint.rb
+++ b/mrbgems/mruby-bigint/test/bigint.rb
@@ -28,6 +28,26 @@ assert 'Bigint ==' do
   if Object.const_defined?(:Float)
     assert_true (1<<70) == (2.0**70)
     assert_false (1<<70) == (2.0**71)
+
+    # A Float argument used to be compared by rounding the big integer to a
+    # Float, so every neighbour within half an ULP answered equal.
+    assert_false (1<<70) + 1 == (2.0**70)
+    assert_false (1<<70) - 1 == (2.0**70)
+    assert_false(-((1<<70) + 1) == (-2.0**70))
+    assert_true(-(1<<70) == (-2.0**70))
+
+    # Infinity and NaN reach the same comparison and have no integer part.
+    assert_false (1<<70) == (1.0/0.0)
+    assert_false (1<<70) == (-1.0/0.0)
+    assert_false (1<<70) == (0.0/0.0)
+
+    # A Float whose integer part an `mrb_int` holds, zero included, is carried
+    # over as one rather than built into a big integer.
+    assert_false (1<<70) == 0.0
+    assert_false (1<<70) == -0.0
+    assert_false (1<<70) == 0.5
+    assert_false (1<<70) == 1.5
+    assert_false(-(1<<70) == -0.5)
   end
 end
 

--- a/src/numeric.c
+++ b/src/numeric.c
@@ -681,6 +681,13 @@ flo_eq(mrb_state *mrb, mrb_value x)
     return mrb_bool_value(mrb_float(x) == (mrb_float)mrb_integer(y));
   case MRB_TT_FLOAT:
     return mrb_bool_value(mrb_float(x) == mrb_float(y));
+#ifdef MRB_USE_BIGINT
+  case MRB_TT_BIGINT:
+    /* `mrb_bint_cmp()` takes the big integer first and compares a Float
+       argument exactly; `int_equal()` makes the same call for the mirror
+       image of this comparison. */
+    return mrb_bool_value(mrb_bint_cmp(mrb, y, x) == 0);
+#endif
 #ifdef MRB_USE_RATIONAL
   case MRB_TT_RATIONAL:
     return mrb_bool_value(mrb_float(x) == mrb_as_float(mrb, y));

--- a/src/numeric.c
+++ b/src/numeric.c
@@ -2123,7 +2123,7 @@ cmpnum(mrb_state *mrb, mrb_value v1, mrb_value v2)
   }
 #ifdef MRB_USE_BIGINT
   else if (mrb_bigint_p(v1)) {
-    if (mrb_integer_p(v2) || mrb_bigint_p(v2)) {
+    if (mrb_integer_p(v2) || mrb_bigint_p(v2) || mrb_float_p(v2)) {
       return mrb_bint_cmp(mrb, v1, v2);
     }
     x = mrb_as_float(mrb, v1);
@@ -2133,12 +2133,20 @@ cmpnum(mrb_state *mrb, mrb_value v1, mrb_value v2)
     x = mrb_as_float(mrb, v1);
   }
 
+#ifdef MRB_USE_BIGINT
+  if (mrb_bigint_p(v2)) {
+    /* The switch below would convert `v2` with `mrb_as_float()` and lose the
+       low bits of a big integer. `mrb_bint_cmp()` keeps it exact. Negate the
+       result rather than the operands; -2 means incomparable, which has no
+       opposite. */
+    mrb_int c = mrb_bint_cmp(mrb, v2, mrb_float_value(mrb, x));
+    return c == -2 ? -2 : -c;
+  }
+#endif
+
   switch (mrb_type(v2)) {
 #ifdef MRB_USE_RATIONAL
   case MRB_TT_RATIONAL:
-#endif
-#ifdef MRB_USE_BIGINT
-  case MRB_TT_BIGINT:
 #endif
   case MRB_TT_INTEGER:
     if (mrb_fixnum_p(v2)) {


### PR DESCRIPTION
`Integer#==`, `Float#==` and `<=>` each answer a big integer against a Float their own way, and none of the three answers what CRuby does:

```ruby
(2**70 + 1) == (2.0**70)     # mruby: true   CRuby: false
(2.0**70) == (2**70)         # mruby: false  CRuby: true
(2**70 + 1) > (2.0**70)      # mruby: false  CRuby: true
(2**70) <=> (0.0/0.0)        # mruby: 0      CRuby: nil
```

A double carries 53 significant bits, so rounding a big integer onto one throws the rest away and every big integer within half an ULP of the argument becomes the same double. A whole neighbourhood then answers equal, which is the first line and the third. The second is a missing arm rather than a rounding: `flo_eq()` switches on its argument's type and has none for `MRB_TT_BIGINT`, so a big integer falls through to `default` and answers false however equal it is.

Three commits, one per route, each green on its own.

### `mrb_bint_cmp()` compares against the exact value

`mrb_bint_cmp()` is where `Integer#==` and `Object#==` send a Float argument, and it rounded the receiver to answer:

```c
mrb_float v1 = mrb_bint_as_float(mrb, x);
mrb_float v2 = mrb_float(y);
if (v1 == v2) return 0;
if (v1 > v2)  return 1;
return -1;
```

The exact answer is reachable without rounding anything. `trunc()` splits the argument into an integer part and a fraction, neither of them rounded, and an integral Float is carried into an integer exactly. So the receiver against the integer part decides the pair, and the fraction decides it only where those two come out equal:

```c
mrb_float fi = trunc(f);
mrb_value yi = FIXABLE_FLOAT(fi) ? mrb_int_value(mrb, (mrb_int)fi)
                                 : mrb_bint_new_float(mrb, fi);
mrb_int c = mrb_bint_cmp(mrb, x, yi);
if (c != 0) return c;
if (f > fi) return -1;
if (f < fi) return 1;
return 0;
```

The recursion is one call deep: `yi` is an integer, so it lands on the arm below the Float arm of the same function.

NaN and an infinity have no integer part to split off, so both are answered before the split: NaN is not comparable, which this function reports as -2, and an infinity is decided by its sign.

`mrb_bint_new_float()` is entered only for an integer part no `mrb_int` holds, which is the check every caller of it in the tree already makes. `flo_idiv()`, `flo_rounding_int()`, `flo_to_i()` and `mrb_complex_to_i()` all test `FIXABLE_FLOAT()` first and reach it only when that is false. So no big integer is built for a Float that a fixnum carries, a fraction included, whose integer part is zero.

### `Float#==` reaches it

`int_equal()` carries a `MRB_TT_BIGINT` arm. `flo_eq()` has none, so the two directions disagreed about the same pair:

```ruby
(2.0**70) == (2**70)   # mruby: false  CRuby: true
(2**70) == (2.0**70)   # mruby: true   CRuby: true
```

The arm is the mirror image of the one `int_equal()` already has, big integer first because that is the operand `mrb_bint_cmp()` takes:

```c
#ifdef MRB_USE_BIGINT
case MRB_TT_BIGINT:
  return mrb_bool_value(mrb_bint_cmp(mrb, y, x) == 0);
#endif
```

Both directions now run the same comparison, so the answer no longer depends on which operand is written first.

`eql?` stays false either way round, big integer and Float not being the same class.

### `<=>` reaches it in both orders

`cmpnum()` is what `Comparable` builds `<`, `>`, `<=` and `>=` on, and it reached `mrb_bint_cmp()` only when both operands were integers. With a Float on either side it converted the big integer with `mrb_as_float()` and compared two doubles:

```ruby
(2**70 + 1) <=> (2.0**70)   # mruby: 0      CRuby: 1
(2**70 + 1) > (2.0**70)     # mruby: false  CRuby: true
(2**70) <=> (0.0/0.0)       # mruby: 0      CRuby: nil
```

A big integer on the left is one more type in the test that is already there:

```c
if (mrb_integer_p(v2) || mrb_bigint_p(v2) || mrb_float_p(v2)) {
  return mrb_bint_cmp(mrb, v1, v2);
}
```

A big integer on the right has to be moved to the left to be passed, and the result negated rather than the operands swapped back:

```c
if (mrb_bigint_p(v2)) {
  mrb_int c = mrb_bint_cmp(mrb, v2, mrb_float_value(mrb, x));
  return c == -2 ? -2 : -c;
}
```

-2 is passed through untouched. It says the two are not comparable, which is not an ordering and has no opposite, and that is what leaves a NaN answering nil rather than 0.

`MRB_TT_BIGINT` no longer reaches the switch that follows, so its label comes off the group that converts the operand with `mrb_as_float()`.

### Generated code

`.text` over every `.o`, against the same objects built from master, for each of the five builds `ci/gcc-clang` makes. Their compile lines are under Environment at the end: `full-debug` is `-O0`, the other four are `-O3`.

| build | master | this PR |
| --- | --- | --- |
| full-debug | 2835536 | 2835975 (+439) |
| bintest | 1814383 | 1814911 (+528) |
| cxx_abi | 1823315 | 1823667 (+352) |
| byte-string | 1767618 | 1768146 (+528) |
| ascii-case | 1789418 | 1789946 (+528) |

The two objects that move, and the only two:

| | master | this PR |
| --- | --- | --- |
| full-debug mruby-bigint/core/bigint.o | 81437 | 81686 (+249) |
| full-debug src/numeric.o | 21810 | 22000 (+190) |
| bintest mruby-bigint/core/bigint.o | 92794 | 93178 (+384) |
| bintest src/numeric.o | 26540 | 26684 (+144) |
| cxx_abi mruby-bigint/core/bigint.o | 93597 | 93821 (+224) |
| cxx_abi src/numeric.o | 26508 | 26636 (+128) |

`byte-string` and `ascii-case` move by the same amounts as `bintest`: neither of the two files this PR touches reads how strings are indexed or what case table is compiled in.

A three line rounding becomes a split, a recursive call and two arms deciding the fraction, and `src/numeric.c` gains one switch arm and one early return. `cxx_abi` gains less than the C builds because the C compiler driven as C++ lays the function out differently, not because less is compiled.

### Testing

`rake -m test` over `ci/gcc-clang`, all five builds green, 0 KO, 0 crash, no new warnings:

| build | result |
| --- | --- |
| full-debug | 2313 tests, 2310 OK, 3 skip |
| bintest | 2313 tests, 2302 OK, 11 skip, plus 117 bintests |
| cxx_abi | 2313 tests, 2302 OK, 11 skip |
| byte-string | 2244 tests, 2196 OK, 48 skip |
| ascii-case | 2310 tests, 2297 OK, 13 skip |

`rake -m test` over `build_config/asan.rb` is green too, address and undefined sanitizers both: 2313 tests, 2310 OK, 3 skip, plus 79 bintests. That build is also the one with `MRB_DEBUG`, so it is what the assertion inside `mrb_bint_new_float()` answers to.

Everything this PR touches in `mrbgems/mruby-bigint/core/bigint.c` stands inside `#ifndef MRB_NO_FLOAT`. A build defining `MRB_NO_FLOAT` with the gem compiles clean and unchanged; it cannot run the tests, since `mruby-bigint` declares a test dependency on `mruby-numeric-ext`, which does not build without Float on master either.

The tests pin each route: the neighbourhood that used to answer equal, both directions of `==` and of `<=>`, the operators `Comparable` builds on `<=>`, an infinity of either sign, NaN answering nil, and a Float whose integer part a fixnum carries, zero and a bare fraction included.

What stands beside them is a comparison against CRuby over 5115 pairs, every one of them asked `==` and `<=>` in both directions, `eql?` in both directions, and all four of `<`, `>` written both ways round. The integers span 2^64 to 2^512 and their immediate neighbours in both signs; the Floats span the same range with a fraction added, plus zero of both signs, one, a bare fraction, 1e-300, 2^53, 2^62, 2^63, 1e300, both infinities and NaN. Master differs from CRuby on 333 of the 5115; this PR on none, and on none under the sanitizers either.

### Environment

<details>
<summary>Versions, and the compile line of every build named above</summary>

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS, Linux 7.0.0-28-generic x86_64 |
| CPU | AMD Ryzen 9 5950X, 16 cores |
| C compiler | gcc 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1) |
| Sanitizer compiler | clang 22.1.8 (Homebrew), which is what `build_config/asan.rb` picks |
| Linker | GNU ld 2.47.20260726, and `g++` for `cxx_abi` |
| CRuby | 4.0.6 (2026-07-14) +PRISM, running rake and answering the comparison above |

What each build actually compiles `src/numeric.c` with, `-MMD -c`, the `-I` paths and `-o` stripped:

```console
# ci/gcc-clang, full-debug
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang, bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK

# ci/gcc-clang, cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang, byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang, ascii-case
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CASE -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# build_config/asan.rb
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -fsanitize=address,undefined -g3 -O0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

`mrbgems/mruby-bigint/core/bigint.c` gets the same flags and defines in each build, plus `-DMRBGEM_MRUBY_BIGINT_VERSION=0.0.0`.

`-g -O3` is what the `gcc` toolchain sets. `full-debug` and the sanitizer build then append `-g3 -O0` through `enable_debug()`, so those two are `-O0`, not `-O3`. `cxx_abi` is the C compiler driven as C++ with `-x c++ -std=gnu++03`, and `g++` links it.

The build that answered the comparison against CRuby is the default config, `build_config/default.rb`, whose gembox brings in `mruby-bigint` through `math.gembox`. The sanitizer build answered it a second time.

The `MRB_NO_FLOAT` build named above is not one of the shipped configs:

```ruby
MRuby::Build.new('nofloat-bigint') do |conf|
  conf.toolchain :gcc
  conf.gem :core => 'mruby-bigint'
  conf.gem :core => 'mruby-bin-mrbc'
  conf.gem :core => 'mruby-bin-mruby'
  conf.compilers.each do |c|
    c.defines << 'MRB_NO_FLOAT'
  end
  conf.enable_debug
end
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved comparisons between BigInt and Float values without loss of integer precision.
  * Correctly handles fractional values, infinities, and NaN during equality and ordering comparisons.
  * Ensured consistent comparison results regardless of operand order.
  * Preserved expected behavior for non-numeric and incomparable values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->