### PR TITLE
build_config: give the clang-asan config a name of its own

### DIFF
--- a/build_config/clang-asan.rb
+++ b/build_config/clang-asan.rb
@@ -1,4 +1,6 @@
-MRuby::Build.new do |conf|
+# Address/Undefined sanitizer build in a dedicated build directory
+# (build/clang-asan) so it does not clobber a normal host build.
+MRuby::Build.new('clang-asan') do |conf|
   conf.toolchain :clang
   # include the GEM box
   conf.gembox 'full-core'


### PR DESCRIPTION
`build_config/clang-asan.rb` opens an anonymous `MRuby::Build`, and an unnamed build is called `host` (`lib/mruby/build.rb:94`). The build tree is keyed by that name (`:107`), so `MRUBY_CONFIG=clang-asan` aims its `-fsanitize=address,undefined` objects at `build/host`, on top of whatever a default build has left there, and never creates a directory of its own. This is the same shape as #7195, on a config that PR does not touch.

All of the transcripts below are from today's master, starting from one clean default build.

### The clobber

It exits 0 while doing it:

```console
$ ls build/
host
$ md5sum build/host/bin/mruby build/host/lib/libmruby.a
9881d200e90c5a7df4a29a36b193fbab  build/host/bin/mruby
8dbb8c26becf449f5871f9e090c8a4ff  build/host/lib/libmruby.a
$ ar t build/host/lib/libmruby.a | sort -u | wc -l
99
$ MRUBY_CONFIG=clang-asan rake -j8       # exit 0
...
      Config Name: host
 Output Directory: build/host
$ ls build/
host
$ md5sum build/host/bin/mruby build/host/lib/libmruby.a
07a8c1484756e079a731e8af15944606  build/host/bin/mruby
5160fcdf4b7e757f4ac6f547fa7100c2  build/host/lib/libmruby.a
$ nm -D build/host/bin/mruby | grep -c asan
174
```

What is left in `build/host` is a sanitizer build at `-O0`, and the repo `bin/` symlinks point into it, because `host?` builds install them (`:452`).

### It does not stop at a tree that measures the wrong thing

`libmruby.a` is archived with `ar rs` (`lib/mruby/build/command.rb:258`); `r` replaces by member name, and an archive records only the base name, so it cannot hold two objects called `gem_init.o` apart. A default build's archive holds 155 members under 99 distinct names, 43 of them `gem_init.o`. After the `clang-asan` run it holds 173 under 107, 51 of them `gem_init.o`, since `full-core.gembox` carries gems that `default.gembox` does not. The next default build hands `ar rs` its own 43, which cannot name the 8 that came from those gems, and they stay compiled with `-fsanitize`.

`full-core.gembox` skips `mruby-bin-debugger` while `default.gembox` carries it, so the default build's `mrdb` link is the one that reaches those members, with plain gcc and no sanitizer runtime. It aborts, and goes on aborting on every later run:

```console
$ rake -j8
...
ld: build/host/lib/libmruby.a(gem_init.o): in function `asan.module_ctor':
gem_init.c:(.text.asan.module_ctor[asan.module_ctor]+0x5): undefined reference to `__asan_init'
gem_init.c:(.text.asan.module_ctor[asan.module_ctor]+0xa): undefined reference to `__asan_version_mismatch_check_v8'
gem_init.c:(.text.asan.module_ctor[asan.module_ctor]+0x24): undefined reference to `__asan_register_elf_globals'
collect2: error: ld returned 1 exit status
rake aborted!
Tasks: TOP => build => bin/mrdb => build/host/bin/mrdb
$ rake -j8
...same...
```

Recovery is `rm -rf build/host` plus a full rebuild.

### Naming it

The build is named after its config, which is what `build_config/asan.rb` and `build_config/gctest.rb` already do, and what 8b44a52 did for `host-cxx`. `full-core.gembox` supplies `mruby-bin-mrbc` through its glob, so the rename is all this config needs, and nothing outside the config refers to the directory it produces.

### Verified

One clean default build, then the sanitizer build, then the default config again, `rake -j8` throughout:

```console
$ MRUBY_CONFIG=clang-asan rake -j8       # exit 0
...
      Config Name: clang-asan
 Output Directory: build/clang-asan
$ ls build/
clang-asan  host
$ md5sum build/host/bin/mruby build/host/lib/libmruby.a
9881d200e90c5a7df4a29a36b193fbab  build/host/bin/mruby
8dbb8c26becf449f5871f9e090c8a4ff  build/host/lib/libmruby.a
$ ar t build/host/lib/libmruby.a | sort -u | wc -l
99
$ build/host/bin/mruby -e 'p 0.1+0.2'
0.30000000000000004
$ rake -j8                               # exit 0
```

The build it produces is the one it was producing before, and it is green:

```console
$ nm -D build/clang-asan/bin/mruby | grep -c asan
174
$ MRUBY_CONFIG=clang-asan rake -m test   # exit 0
bintest - Command Binary Test
  Total: 79    OK: 79    KO: 0    Crash: 0    Skip: 0
mrbtest - Embeddable Ruby Test
  Total: 2312  OK: 2309  KO: 0    Crash: 0    Skip: 3
```

### One symlink does not follow the rename

`mruby-bin-config` installs its product through `define_installer` rather than `define_installer_if_needed` (`mrbgems/mruby-bin-config/mrbgem.rake:31`), so `bin/mruby-config` follows whichever non-cross build ran last, named or not. That is what master already does for every named build carrying that gem, and it is unchanged here:

```console
$ MRUBY_CONFIG=bench rake -j8
$ ls -l bin/mruby-config
bin/mruby-config -> ../build/bench/bin/mruby-config
```

### A note on `build_config/asan.rb`

Once this config has a name, it and `build_config/asan.rb` are the same build under two names: both `conf.toolchain :clang`, both `conf.gembox 'full-core'`, both `conf.enable_sanitizer "address,undefined"`, `enable_debug`, `enable_bintest` and `enable_test`, with nothing else in either file. Whether one of them should go, and which name should survive, is yours to say. `clang-asan` is the one `doc/mruby3.0.md:14` names and `test/t/hash.rb:1005` points at; `asan.rb` is the one whose commit message says it backs a local pre-push hook. This PR changes neither of those things and leaves both files in place.

### Environment

<details>

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-28-generic x86_64 |
| CPU | AMD Ryzen 9 5950X, 16 cores / 32 threads |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0 |
| C compiler for `clang-asan` | Homebrew clang version 22.1.8 |
| binutils | GNU ld (GNU Binutils) 2.47.20260726 |
| CRuby running rake | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM |

The line each build gives `src/string.c`, read off `rake --verbose` with `-MMD -c`, the `-I` list and `-o` dropped. `clang-asan` calls `enable_debug`, which appends `-g3 -O0` after the clang toolchain's own `-g -O3`:

```console
# default
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK src/string.c

# clang-asan
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -fsanitize=address,undefined -g3 -O0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build Configuration**
  * Added a dedicated `clang-asan` sanitizer build configuration.
  * Preserved sanitizer checks, debug settings, binary tests, and the full test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->