### PR TITLE
vm.c: honor a `[]` redefinition installed on a core class

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -292,6 +292,19 @@ struct mrb_jmpbuf;
 
 typedef void (*mrb_atexit_func)(mrb_state*);
 
+/**
+ * Slots of `mrb_state.idx_class`, one per builtin the inline index opcodes
+ * (`OP_GETIDX`, `OP_GETIDX0`, `OP_SETIDX`) reimplement in C.
+ */
+enum mrb_idx_op_slot {
+  MRB_IDX_OP_ARY_AREF,          /* Array#[]  */
+  MRB_IDX_OP_HASH_AREF,         /* Hash#[]   */
+  MRB_IDX_OP_STR_AREF,          /* String#[] */
+  MRB_IDX_OP_ARY_ASET,          /* Array#[]= */
+  MRB_IDX_OP_HASH_ASET,         /* Hash#[]=  */
+  MRB_IDX_OP_SLOT_COUNT
+};
+
 #ifdef MRB_USE_TASK_SCHEDULER
 struct mrb_task;
 
@@ -395,6 +408,18 @@ struct mrb_state {
   mrb_atexit_func *atexit_stack;
 #endif
   uint16_t atexit_stack_len;
+
+  /* The inline index opcodes answer `[]` and `[]=` from C for a receiver whose
+     class is exactly Array, Hash or String, which would bypass a redefinition
+     installed on those classes themselves.  Each slot holds the core class
+     while the name still resolves to the builtin recorded in `idx_builtin`,
+     and NULL once it does not, so the class-pointer test the opcodes already
+     perform rejects a redefined operator at no extra cost.  NULL is safe as
+     the disabled value because no live object has a NULL class pointer.
+     Armed by mrb_idx_op_init(), rechecked by mrb_idx_op_update().  Placed at
+     the end of the struct so that adding them moves no existing field. */
+  struct RClass *idx_class[MRB_IDX_OP_SLOT_COUNT];
+  mrb_method_t idx_builtin[MRB_IDX_OP_SLOT_COUNT];
 
 #ifdef MRB_USE_TASK_SCHEDULER
   mrb_task_state task;                    /* Task scheduler state */

--- a/include/mruby/internal.h
+++ b/include/mruby/internal.h
@@ -29,6 +29,10 @@ size_t mrb_class_mt_memsize(mrb_state*, struct RClass*);
 mrb_value mrb_obj_extend(mrb_state*, mrb_value obj);
 #endif
 
+/* inline index opcode guards (class.c); see `idx_class` in `struct mrb_state` */
+void mrb_idx_op_init(mrb_state *mrb);
+void mrb_idx_op_update(mrb_state *mrb, mrb_sym mid);
+
 mrb_value mrb_obj_equal_m(mrb_state *mrb, mrb_value);
 
 /* debug */

--- a/mrbgems/mruby-regexp/mrblib/string_regexp.rb
+++ b/mrbgems/mruby-regexp/mrblib/string_regexp.rb
@@ -388,14 +388,15 @@ class String
   # (aliased as `__aref` above) for every other argument form, and handles a
   # regexp here.
   #
-  # `vm_op_getidx()` answers `str[Integer]`, `str[String]` and `str[Range]`
-  # from C without consulting the method table, so those three keep bypassing
-  # this override.  They are exactly the forms it would have handed back to
-  # `__aref` unchanged, so they cost nothing and behave as before, while a
-  # regexp index leaves the opcode through its fallback and arrives here as an
-  # ordinary send.  `str[i, len]` and every `slice` call are not opcode
-  # receivers and do arrive here, paying a Ruby frame on their way to
-  # `__aref`.
+  # Defining this disables the String branch of `vm_op_getidx()` and
+  # `vm_op_getidx0()` for the whole VM: those opcodes answer `str[Integer]`,
+  # `str[String]` and `str[Range]` from C only while `String#[]` is the builtin
+  # they reimplement, and installing this method makes it no longer so.  Every
+  # `str[i]` in the program therefore arrives here, pays a Ruby frame and two
+  # splat arrays, and reaches `__aref` with the same result as before.  That is
+  # the price of the regexp forms being reachable at all; the alternative,
+  # letting the opcode keep answering, is the redefinition being silently
+  # ignored for those three argument types.
   def [](*args)
     # Before any argument inspection, so that the non-regexp forms keep the
     # arity check `mrb_get_args()` does.  With no arguments at all `args[0]`
@@ -432,10 +433,9 @@ class String
   # regexp here.
   #
   # `vm_op_setidx()` optimizes Array and Hash only and sends `[]=` for every
-  # other receiver, so unlike the read side there is no opcode keeping the
-  # ordinary `str[i] = repl` off this override: it pays a Ruby frame on its
-  # way to `__aset`.  That is why the delegation guard is a single
-  # `Regexp ===`, before any other work.
+  # other receiver, so the ordinary `str[i] = repl` has always arrived here and
+  # paid a Ruby frame on its way to `__aset`.  That is why the delegation guard
+  # is a single `Regexp ===`, before any other work.
   def []=(*args)
     return __aset(*args) unless Regexp === args[0]
     unless args.length == 2 || args.length == 3

--- a/src/class.c
+++ b/src/class.c
@@ -1066,7 +1066,10 @@ mrb_define_method_raw(mrb_state *mrb, struct RClass *c, mrb_sym mid, mrb_method_
     }
   }
   mt_put(mrb, h, mid, flags, ptr);
-  if (!mrb->bootstrapping) mc_clear_by_id(mrb, mid);
+  if (!mrb->bootstrapping) {
+    mc_clear_by_id(mrb, mid);
+    mrb_idx_op_update(mrb, mid);
+  }
   if (modfunc) {
     /* module_function scope: also define a public method on the singleton
        class, so the module method (M.foo) mirrors the private instance one */
@@ -2106,7 +2109,12 @@ include_module_at(mrb_state *mrb, struct RClass *c, struct RClass *ins_pos, stru
   skip:
     m = m->super;
   }
-  if (!mrb->bootstrapping) mrb_method_cache_clear(mrb);
+  if (!mrb->bootstrapping) {
+    mrb_method_cache_clear(mrb);
+    /* An included or prepended module can carry both operators, and it is not
+       one method name that changed, so recheck every slot. */
+    mrb_idx_op_update(mrb, 0);
+  }
   return 0;
 }
 
@@ -2486,6 +2494,7 @@ mrb_mod_visibility(mrb_state *mrb, mrb_value mod, int vis)
       }
       mt_put(mrb, h, mid, m.flags, ptr);
       mc_clear_by_id(mrb, mid);
+      mrb_idx_op_update(mrb, mid);
     }
   }
 }
@@ -2797,6 +2806,93 @@ mc_clear_by_id(mrb_state *mrb, mrb_sym id)
   }
 }
 #endif // MRB_NO_METHOD_CACHE
+
+/*
+ * Guards for the inline index opcodes.
+ *
+ * `OP_GETIDX`, `OP_GETIDX0` and `OP_SETIDX` implement `[]` and `[]=` for an
+ * Array, Hash or String receiver in C, without a method lookup.  They may only
+ * do so while those classes still carry the builtin the opcode reimplements,
+ * so each (class, operator) pair keeps a slot in `mrb->idx_class` that holds
+ * the class while that is true and NULL once it is not.  The opcodes compare
+ * the receiver's class against the slot instead of against the core class, so
+ * a disarmed slot sends the operator like any other method and the check costs
+ * nothing while nothing is redefined.
+ *
+ * Validity is the resolved method itself, not merely "was `[]` assigned to":
+ * a slot is armed while `mid` resolves, from the core class, to exactly the
+ * `mrb_method_t` recorded at startup.  That covers `def`, `alias_method`,
+ * `undef_method`, `remove_method`, visibility changes and `prepend` without
+ * enumerating them, re-arms when an override is aliased back away, and stays
+ * armed when an unrelated module is included.
+ */
+
+static struct RClass*
+idx_op_class(mrb_state *mrb, int slot)
+{
+  switch (slot) {
+  case MRB_IDX_OP_ARY_AREF:  case MRB_IDX_OP_ARY_ASET:  return mrb->array_class;
+  case MRB_IDX_OP_HASH_AREF: case MRB_IDX_OP_HASH_ASET: return mrb->hash_class;
+  default:                                              return mrb->string_class;
+  }
+}
+
+static mrb_sym
+idx_op_mid(int slot)
+{
+  return slot < MRB_IDX_OP_ARY_ASET ? MRB_OPSYM(aref) : MRB_OPSYM(aset);
+}
+
+static void
+idx_op_refresh(mrb_state *mrb, int slot)
+{
+  /* A slot that startup never armed (the builtin was already gone, or the
+     state failed to initialize) stays off; there is nothing to compare to. */
+  if (mrb->idx_builtin[slot].as.func == NULL) return;
+
+  struct RClass *c = idx_op_class(mrb, slot);
+  struct RClass *base = c;
+  mrb_method_t m = mrb_vm_find_method(mrb, c, &c, idx_op_mid(slot));
+  mrb->idx_class[slot] =
+    (m.flags == mrb->idx_builtin[slot].flags &&
+     m.as.func == mrb->idx_builtin[slot].as.func) ? base : NULL;
+}
+
+/* Records the builtin `[]` / `[]=` of each core class and arms its slot.
+   Called once, after core initialization has installed them. */
+void
+mrb_idx_op_init(mrb_state *mrb)
+{
+  for (int slot = 0; slot < MRB_IDX_OP_SLOT_COUNT; slot++) {
+    struct RClass *c = idx_op_class(mrb, slot);
+    struct RClass *base = c;
+    mrb_method_t m = mrb_vm_find_method(mrb, c, &c, idx_op_mid(slot));
+    /* Only a C function is the builtin an index opcode reimplements.  Anything
+       else means the operator was already replaced before the state was handed
+       out, and the opcode must not answer for it. */
+    if (MRB_METHOD_UNDEF_P(m) || !MRB_METHOD_FUNC_P(m)) continue;
+    mrb->idx_builtin[slot] = m;
+    mrb->idx_class[slot] = base;
+  }
+}
+
+/* Rechecks the slots that `mid` can affect.  Call after any change to a method
+   table that could change what `[]` or `[]=` resolves to; pass 0 for `mid` when
+   the change is not tied to one name, as module inclusion is not. */
+void
+mrb_idx_op_update(mrb_state *mrb, mrb_sym mid)
+{
+  if (mrb->bootstrapping) return;
+  if (mid == 0 || mid == MRB_OPSYM(aref)) {
+    idx_op_refresh(mrb, MRB_IDX_OP_ARY_AREF);
+    idx_op_refresh(mrb, MRB_IDX_OP_HASH_AREF);
+    idx_op_refresh(mrb, MRB_IDX_OP_STR_AREF);
+  }
+  if (mid == 0 || mid == MRB_OPSYM(aset)) {
+    idx_op_refresh(mrb, MRB_IDX_OP_ARY_ASET);
+    idx_op_refresh(mrb, MRB_IDX_OP_HASH_ASET);
+  }
+}
 
 mrb_method_t
 mrb_vm_find_method(mrb_state *mrb, struct RClass *c, struct RClass **cp, mrb_sym mid)
@@ -3780,6 +3876,7 @@ mrb_remove_method(mrb_state *mrb, struct RClass *c0, mrb_sym mid)
     mrb_name_error(mrb, mid, "method '%n' not defined in %C", mid, c);
   }
   mc_clear_by_id(mrb, mid);
+  mrb_idx_op_update(mrb, mid);
   if (c0->tt == MRB_TT_SCLASS) {
     mrb_sym cb = MRB_SYM(singleton_method_removed);
     mrb_value recv = mrb_iv_get(mrb, mrb_obj_value(c0), MRB_SYM(__attached__));

--- a/src/state.c
+++ b/src/state.c
@@ -60,6 +60,9 @@ mrb_open_core(void)
 
   mrb_method_cache_clear(mrb);
   mrb->bootstrapping = FALSE;
+  /* After bootstrapping, so that a core `[]` replaced from mrblib is recorded
+     as replaced rather than as the builtin. */
+  mrb_idx_op_init(mrb);
 
   return mrb;
 }

--- a/src/vm.c
+++ b/src/vm.c
@@ -2043,8 +2043,10 @@ vm_op_getidx(mrb_state *mrb, uint32_t a, mrb_sym *midp)
   /* Array case is most common - check first with branch hint */
   if (mrb_likely(tt == MRB_TT_ARRAY)) {
     struct RArray *ary = mrb_ary_ptr(va);
-    /* optimize only for Array class; subclasses/singleton may override [] */
-    if (mrb_unlikely(ary->c != mrb->array_class)) goto getidx_fallback;
+    /* optimize only for Array itself; a subclass or singleton may override [],
+       and mrb->idx_class[] is NULL while Array#[] is overridden, so the same
+       comparison rejects that too */
+    if (mrb_unlikely(ary->c != mrb->idx_class[MRB_IDX_OP_ARY_AREF])) goto getidx_fallback;
     if (mrb_likely(mrb_integer_p(vb))) {
       mrb_int idx = mrb_integer(vb);
       mrb_int len;
@@ -2075,8 +2077,8 @@ vm_op_getidx(mrb_state *mrb, uint32_t a, mrb_sym *midp)
     goto getidx_fallback;
   }
   else if (tt == MRB_TT_HASH) {
-    /* optimize only for Hash class; subclasses/singleton may override [] */
-    if (mrb_obj_ptr(va)->c != mrb->hash_class) goto getidx_fallback;
+    /* optimize only for Hash itself; see the Array branch above */
+    if (mrb_obj_ptr(va)->c != mrb->idx_class[MRB_IDX_OP_HASH_AREF]) goto getidx_fallback;
     int ai = mrb_gc_arena_save(mrb);
     va = mrb_hash_get(mrb, va, vb);
     ci = mrb->c->ci;
@@ -2085,8 +2087,8 @@ vm_op_getidx(mrb_state *mrb, uint32_t a, mrb_sym *midp)
     return VM_NEXT;
   }
   else if (tt == MRB_TT_STRING) {
-    /* optimize only for String class; subclasses/singleton may override [] */
-    if (mrb_obj_ptr(va)->c != mrb->string_class) goto getidx_fallback;
+    /* optimize only for String itself; see the Array branch above */
+    if (mrb_obj_ptr(va)->c != mrb->idx_class[MRB_IDX_OP_STR_AREF]) goto getidx_fallback;
     switch (mrb_type(vb)) {
     case MRB_TT_INTEGER:
     case MRB_TT_STRING:
@@ -2116,7 +2118,7 @@ vm_op_getidx0(mrb_state *mrb, uint32_t a, uint16_t b, mrb_sym *midp)
 
   if (mrb_likely(tt == MRB_TT_ARRAY)) {
     struct RArray *ary = mrb_ary_ptr(recv);
-    if (mrb_unlikely(ary->c != mrb->array_class)) goto getidx0_fallback;
+    if (mrb_unlikely(ary->c != mrb->idx_class[MRB_IDX_OP_ARY_AREF])) goto getidx0_fallback;
 #ifndef MRB_ARY_NO_EMBED
     if (ARY_EMBED_P(ary)) {
       regs[a] = ARY_EMBED_LEN(ary) > 0 ? ary->as.ary[0] : mrb_nil_value();
@@ -2129,7 +2131,7 @@ vm_op_getidx0(mrb_state *mrb, uint32_t a, uint16_t b, mrb_sym *midp)
     return VM_NEXT;
   }
   else if (tt == MRB_TT_HASH) {
-    if (mrb_obj_ptr(recv)->c != mrb->hash_class) goto getidx0_fallback;
+    if (mrb_obj_ptr(recv)->c != mrb->idx_class[MRB_IDX_OP_HASH_AREF]) goto getidx0_fallback;
     {
       /* same as the Hash branch of vm_op_getidx(): mrb_hash_get() can run a
          default proc and move the stack, so take the result first and store
@@ -2144,8 +2146,8 @@ vm_op_getidx0(mrb_state *mrb, uint32_t a, uint16_t b, mrb_sym *midp)
     return VM_NEXT;
   }
   else if (tt == MRB_TT_STRING) {
-    /* optimize only for String class; subclasses/singleton may override [] */
-    if (mrb_obj_ptr(recv)->c != mrb->string_class) goto getidx0_fallback;
+    /* optimize only for String itself; see vm_op_getidx() */
+    if (mrb_obj_ptr(recv)->c != mrb->idx_class[MRB_IDX_OP_STR_AREF]) goto getidx0_fallback;
     {
       /* mrb_str_aref() allocates, and an inline opcode never runs the cfunc
          epilogue that would shrink the arena, so save and restore it here.
@@ -2172,16 +2174,16 @@ vm_op_setidx(mrb_state *mrb, uint32_t a, mrb_sym *midp)
   mrb_value va = regs[a], vb = regs[a+1], vc = regs[a+2];
   switch (mrb_type(va)) {
   case MRB_TT_ARRAY:
-    /* optimize only for Array class; subclasses/singleton may override []= */
-    if (mrb_obj_ptr(va)->c != mrb->array_class) goto setidx_fallback;
+    /* optimize only for Array itself; see vm_op_getidx() */
+    if (mrb_obj_ptr(va)->c != mrb->idx_class[MRB_IDX_OP_ARY_ASET]) goto setidx_fallback;
     if (!mrb_integer_p(vb)) goto setidx_fallback;
     mrb_ary_set(mrb, va, mrb_integer(vb), vc);
     ci = mrb->c->ci;
     regs[a] = vc;
     return VM_NEXT;
   case MRB_TT_HASH:
-    /* optimize only for Hash class; subclasses/singleton may override []= */
-    if (mrb_obj_ptr(va)->c != mrb->hash_class) goto setidx_fallback;
+    /* optimize only for Hash itself; see vm_op_getidx() */
+    if (mrb_obj_ptr(va)->c != mrb->idx_class[MRB_IDX_OP_HASH_ASET]) goto setidx_fallback;
     {
       int ai = mrb_gc_arena_save(mrb);
       mrb_hash_set(mrb, va, vb, vc);

--- a/test/t/array.rb
+++ b/test/t/array.rb
@@ -65,6 +65,71 @@ assert('Array#[]', '15.2.12.5.4') do
   assert_equal("b", a[1.1])
 end
 
+assert('Array#[] redefined on Array itself reaches the redefinition') do
+  # `OP_GETIDX` answers `a[1]` from C and `OP_GETIDX0` answers `a[0]` the same
+  # way whenever the receiver's class is exactly `Array`, which they may only
+  # do while `Array#[]` is still the builtin they reimplement. Both test the
+  # receiver against `mrb->idx_class[]`, which the method table drops the
+  # moment `Array#[]` is replaced, so a redefinition installed on `Array`
+  # itself is honored as in CRuby. The results are read before the operator is
+  # put back because the assertions themselves index arrays.
+  Array.class_eval do
+    alias_method :__aref_before_test, :[]
+    def [](*args)
+      :overridden
+    end
+  end
+  begin
+    a = [7, 8]
+    sub = Class.new(Array).new
+    got0 = a[0]
+    got1 = a[1]
+    got_sub = sub[0]
+  ensure
+    Array.class_eval do
+      alias_method :[], :__aref_before_test
+      # `remove_method` comes from mruby-metaprog, which the core test build
+      # does not have; the saved alias is harmless where it is missing.
+      remove_method :__aref_before_test if respond_to?(:remove_method, true)
+    end
+  end
+  assert_equal :overridden, got0
+  assert_equal :overridden, got1
+  assert_equal :overridden, got_sub
+  # Aliasing the original implementation back re-arms the opcodes.
+  assert_equal 7, [7, 8][0]
+  assert_equal 8, [7, 8][1]
+end
+
+assert('Array#[]= redefined on Array itself reaches the redefinition') do
+  # `OP_SETIDX` answers `a[0] = 9` from C on the same terms; see the `[]` test
+  # above. A redefinition that stores nothing makes the difference visible in
+  # the receiver as well as in the return value.
+  Array.class_eval do
+    alias_method :__aset_before_test, :[]=
+    def []=(*args)
+      $aset_redefinition_args = args
+    end
+  end
+  begin
+    a = [7, 8]
+    a[0] = 9
+    seen = $aset_redefinition_args
+    untouched = a
+  ensure
+    Array.class_eval do
+      alias_method :[]=, :__aset_before_test
+      remove_method :__aset_before_test if respond_to?(:remove_method, true)
+    end
+    $aset_redefinition_args = nil
+  end
+  assert_equal [0, 9], seen
+  assert_equal [7, 8], untouched
+  a = [7, 8]
+  a[0] = 9
+  assert_equal [9, 8], a
+end
+
 assert('Array#[]=', '15.2.12.5.5') do
   a = Array.new
   assert_raise(ArgumentError) do

--- a/test/t/gc.rb
+++ b/test/t/gc.rb
@@ -135,11 +135,11 @@ end
 # result; it is not slack for a partial leak, and a branch that retains on even
 # a small fraction of the iterations is over it.
 #
-# A loop body measures the branch under test only while it reaches the opcode
-# rather than compiling down to a send.  Nothing in this tree redefines
-# `Hash#[]` or `Hash#[]=`, so the Hash loops below reach it as they stand;
-# mruby-regexp does replace `String#[]`, which is what
-# `with_builtin_string_aref` puts back.
+# An index opcode answers from C only while the operator it reimplements is
+# still the builtin, so a loop body stops being send-free the moment something
+# redefines that operator on the core class.  Nothing in this tree redefines
+# `Hash#[]` or `Hash#[]=`, so the Hash loops below need no help; mruby-regexp
+# does redefine `String#[]`, which is what `with_builtin_string_aref` puts back.
 
 # Runs the block with the C implementation of `String#[]` in place, so that
 # `s[0]` and `s[1]` inside it reach `OP_GETIDX0` and `OP_GETIDX` rather than

--- a/test/t/gc.rb
+++ b/test/t/gc.rb
@@ -134,18 +134,54 @@ end
 # The margin below covers the few objects `GC.stat` allocates for its own
 # result; it is not slack for a partial leak, and a branch that retains on even
 # a small fraction of the iterations is over it.
+#
+# A loop body measures the branch under test only while it reaches the opcode
+# rather than compiling down to a send.  Nothing in this tree redefines
+# `Hash#[]` or `Hash#[]=`, so the Hash loops below reach it as they stand;
+# mruby-regexp does replace `String#[]`, which is what
+# `with_builtin_string_aref` puts back.
+
+# Runs the block with the C implementation of `String#[]` in place, so that
+# `s[0]` and `s[1]` inside it reach `OP_GETIDX0` and `OP_GETIDX` rather than
+# compiling down to a send, whose cfunc return would drain the arena and pass
+# the assertion for the wrong reason.  mruby-regexp keeps the C implementation
+# under `__aref` when it replaces `String#[]`; where no gem replaced it there
+# is nothing to swap and the block runs as it stands.
+def with_builtin_string_aref
+  swapped = String.method_defined?(:__aref)
+  if swapped
+    String.class_eval do
+      alias_method :__aref_gc_test_saved, :[]
+      alias_method :[], :__aref
+    end
+  end
+  begin
+    yield
+  ensure
+    if swapped
+      String.class_eval do
+        alias_method :[], :__aref_gc_test_saved
+        # `remove_method` comes from mruby-metaprog, which the core test build
+        # does not have; the saved alias is harmless where it is missing.
+        remove_method :__aref_gc_test_saved if respond_to?(:remove_method, true)
+      end
+    end
+  end
+end
 
 assert('OP_GETIDX does not retain its result in the GC arena') do
-  s = "hello"
-  GC.start
-  base = GC.stat[:live]
-  i = 0
-  while i < 20000
-    s[1]
-    i += 1
+  with_builtin_string_aref do
+    s = "hello"
+    GC.start
+    base = GC.stat[:live]
+    i = 0
+    while i < 20000
+      s[1]
+      i += 1
+    end
+    GC.start
+    assert_operator GC.stat[:live] - base, :<, 100
   end
-  GC.start
-  assert_operator GC.stat[:live] - base, :<, 100
 end
 
 assert('OP_GETIDX does not retain a Hash default in the GC arena') do
@@ -162,16 +198,18 @@ assert('OP_GETIDX does not retain a Hash default in the GC arena') do
 end
 
 assert('OP_GETIDX0 does not retain a String result in the GC arena') do
-  s = "hello"
-  GC.start
-  base = GC.stat[:live]
-  i = 0
-  while i < 20000
-    s[0]
-    i += 1
+  with_builtin_string_aref do
+    s = "hello"
+    GC.start
+    base = GC.stat[:live]
+    i = 0
+    while i < 20000
+      s[0]
+      i += 1
+    end
+    GC.start
+    assert_operator GC.stat[:live] - base, :<, 100
   end
-  GC.start
-  assert_operator GC.stat[:live] - base, :<, 100
 end
 
 assert('OP_GETIDX0 does not retain a Hash default in the GC arena') do

--- a/test/t/hash.rb
+++ b/test/t/hash.rb
@@ -997,6 +997,58 @@ assert('test value omission') do
   assert_equal({x:1, y:2}, {x:, y:})
 end
 
+assert('Hash#[] and Hash#[]= redefined on Hash itself reach the redefinition') do
+  # `OP_GETIDX`, `OP_GETIDX0` and `OP_SETIDX` answer from C whenever the
+  # receiver's class is exactly `Hash`, which they may only do while `Hash#[]`
+  # and `Hash#[]=` are still the builtins they reimplement. Each tests the
+  # receiver against `mrb->idx_class[]`, which the method table drops the
+  # moment the operator is replaced, so a redefinition installed on `Hash`
+  # itself is honored as in CRuby.
+  Hash.class_eval do
+    alias_method :__aref_before_test, :[]
+    alias_method :__aset_before_test, :[]=
+    def [](*args)
+      :overridden
+    end
+    def []=(*args)
+      $hash_aset_redefinition_args = args
+    end
+  end
+  begin
+    h = {0 => :zero, 1 => :one}
+    got0 = h[0]
+    got1 = h[1]
+    h[2] = :two
+    seen = $hash_aset_redefinition_args
+    untouched = h.size
+    sub = Class.new(Hash).new
+    got_sub = sub[0]
+  ensure
+    Hash.class_eval do
+      alias_method :[], :__aref_before_test
+      alias_method :[]=, :__aset_before_test
+      # `remove_method` comes from mruby-metaprog, which the core test build
+      # does not have; the saved aliases are harmless where it is missing.
+      if respond_to?(:remove_method, true)
+        remove_method :__aref_before_test
+        remove_method :__aset_before_test
+      end
+    end
+    $hash_aset_redefinition_args = nil
+  end
+  assert_equal :overridden, got0
+  assert_equal :overridden, got1
+  assert_equal :overridden, got_sub
+  assert_equal [2, :two], seen
+  assert_equal 2, untouched
+  # Aliasing the original implementations back re-arms the opcodes.
+  h = {0 => :zero, 1 => :one}
+  h[2] = :two
+  assert_equal :zero, h[0]
+  assert_equal :one, h[1]
+  assert_equal 3, h.size
+end
+
 assert('Hash#[] with a default proc that grows the VM stack') do
   # The default proc re-enters the VM, and enough frames of it reallocate the
   # stack. `OP_GETIDX0` and `OP_GETIDX` answer from C, so each has to store its

--- a/test/t/string.rb
+++ b/test/t/string.rb
@@ -152,12 +152,15 @@ assert('String#[] with Range') do
   assert_equal 'xyz', k2
 end
 
-assert('String#[] redefined on String itself is bypassed by the index opcodes') do
+assert('String#[] redefined on String itself reaches the redefinition') do
   # `OP_GETIDX` answers `s[1]` from C, and `OP_GETIDX0` answers `s[0]` the same
-  # way, whenever the receiver's class is exactly `String`. Both therefore
-  # bypass a redefinition installed on `String` itself, the same way the Array
-  # and Hash branches of those opcodes do. A subclass receiver fails the class
-  # guard and keeps reaching the redefinition.
+  # way, whenever the receiver's class is exactly `String`. Answering from C is
+  # allowed only while `String#[]` is still the builtin those opcodes
+  # reimplement, so both test the receiver against `mrb->idx_class[]`, which
+  # the method table drops the moment `String#[]` is replaced. A redefinition
+  # installed on `String` itself is therefore honored, as in CRuby, and not
+  # only the subclass and singleton receivers that already failed the class
+  # test for the other reason.
   String.class_eval do
     alias_method :__aref_before_test, :[]
     def [](*args)
@@ -167,8 +170,8 @@ assert('String#[] redefined on String itself is bypassed by the index opcodes') 
   begin
     s = 'hello'
     sub = Class.new(String).new('hello')
-    assert_equal 'h', s[0]
-    assert_equal 'e', s[1]
+    assert_equal :overridden, s[0]
+    assert_equal :overridden, s[1]
     assert_equal :overridden, sub[0]
   ensure
     String.class_eval do
@@ -178,6 +181,10 @@ assert('String#[] redefined on String itself is bypassed by the index opcodes') 
       remove_method :__aref_before_test if respond_to?(:remove_method, true)
     end
   end
+  # Aliasing the original implementation back makes `String#[]` resolve to it
+  # again, which re-arms the opcodes.
+  assert_equal 'h', 'hello'[0]
+  assert_equal 'e', 'hello'[1]
 end
 
 assert('String#[]=') do


### PR DESCRIPTION
`OP_GETIDX`, `OP_GETIDX0` and `OP_SETIDX` answer `[]` and `[]=` from C for an Array, Hash or String receiver, guarded only by the receiver's class pointer being the core class. A redefinition installed on the core class itself passes that guard and is silently ignored; only a subclass or singleton receiver, which fails the pointer test for an unrelated reason, ever reached one.

```console
$ ruby -e 'class String; def [](i); "hooked"; end; end; p "ab"[0]'
"hooked"
$ mruby -e 'class String; def [](i); "hooked"; end; end; p "ab"[0]'
"a"
```

### The bypass is not self-consistent

`self[idx]` compiles to `OP_SSEND :[]` rather than to an index opcode:

```console
$ cat ssend.rb
def bar(i); self[i]; end
$ mrbc -v -o /dev/null ssend.rb
    1 007 SSEND		R3	:[]	n=1
```

so the mrblib core methods that index `self`, `Array#each` among them with its `yield self[idx]`, go through the method table and honor the very redefinition the opcode ignores. Redefining a core `[]` half-works today: iterators change, direct indexing does not.

```console
$ mruby -e 'class Array; def [](i); :x; end; end
            r = ""; [7,8].each {|y| r << y.to_s}
            puts r; puts [7,8][1].to_s'
xx
8
```

### What this changes

Each (class, operator) pair gets a slot in `mrb->idx_class[]`. The slot holds the core class while the name still resolves to the builtin the opcode reimplements, and NULL once it does not. The opcodes compare the receiver's class against that slot instead of against the core class, so a disarmed slot fails the comparison and the operator is sent like any other method. NULL is safe as the disabled value because no live object has a NULL class pointer.

```c
-    if (mrb_unlikely(ary->c != mrb->array_class)) goto getidx_fallback;
+    if (mrb_unlikely(ary->c != mrb->idx_class[MRB_IDX_OP_ARY_AREF])) goto getidx_fallback;
```

Validity is the resolved `mrb_method_t` itself, not a "was assigned" flag: a slot is armed while the operator resolves, from the core class, to exactly the method recorded at startup. That covers `def`, `alias_method`, `undef_method`, `remove_method`, visibility changes and `prepend` without enumerating them, re-arms when an override is aliased back away, and stays armed when a module without `[]` is included. The recheck hangs off the four places that already invalidate the method cache, `mrb_define_method_raw()`, `include_module_at()`, `mrb_mod_visibility()` and `mrb_remove_method()`, and returns immediately unless the changed name is `[]` or `[]=`.

`mrb_idx_op_init()` runs at the end of `mrb_open_core()`, after bootstrapping, so a core `[]` that mrblib itself replaces is recorded as replaced rather than as the builtin. A slot whose operator was already not a C function at that point is never armed.

### Cost on the fast path

The guard is the same single compare it always was. In the generated code only the displacement widens, because the slots sit past the method cache (`build_config/default.rb`, `objdump -d src/vm.o`, a String branch of the index opcodes):

```asm
 cmp    $0x12,%eax
-jne    5c7c <mrb_vm_exec+0x4bbc>
-mov    0x50(%rbp),%rax
+jne    5c7f <mrb_vm_exec+0x4bbf>
+mov    0x5fe8(%rbp),%rax
 cmp    %rax,(%rsi)
-jne    5c7c <mrb_vm_exec+0x4bbc>
+jne    5c7f <mrb_vm_exec+0x4bbf>
```

All eight guard sites, three in `vm_op_getidx()`, three in `vm_op_getidx0()` and two in `vm_op_setidx()`, change the same way, for `+16` bytes in `vm.o`.

Under callgrind the executed instruction count per iteration is unchanged for every one of them. Measured in a build without mruby-regexp, so that all eight are live; each figure is `Ir(200,000 iterations) - Ir(100,000 iterations)`, divided by `100,000`, which cancels startup:

| loop body | opcode | master | this PR |
| --- | --- | ---: | ---: |
| `ary[1]` | `OP_GETIDX` | 278.00 | 278.00 |
| `hsh[1]` | `OP_GETIDX` | 383.00 | 383.00 |
| `str[1]` | `OP_GETIDX` | 687.67 | 687.67 |
| `ary[0]` | `OP_GETIDX0` | 240.00 | 240.00 |
| `hsh[0]` | `OP_GETIDX0` | 486.00 | 486.00 |
| `str[0]` | `OP_GETIDX0` | 645.61 | 645.61 |
| `ary[1] = 9` | `OP_SETIDX` | 345.00 | 345.00 |
| `hsh[1] = 9` | `OP_SETIDX` | 401.00 | 401.00 |

### Size

`build_config/default.rb`, `.text` from `size`:

| | master | this PR | delta |
| --- | ---: | ---: | ---: |
| `src/vm.o` | 65,880 | 65,896 | +16 |
| `src/class.o` | 47,838 | 48,829 | +991 |
| `src/state.o` | 2,207 | 2,231 | +24 |
| `bin/mruby` | 1,721,255 | 1,722,303 | +1,048 |

`sizeof(struct mrb_state)` goes from 24,536 to 24,656, once per state: `5` class pointers plus `5` `mrb_method_t`. The slots sit at the end of the struct, so no existing field moves.

### One consequence is not free

mruby-regexp replaces `String#[]` with a Ruby method at gem initialization, so in a build that includes it the String read fast path is now correctly off and `str[i]` costs a send. The comment in `mrbgems/mruby-regexp/mrblib/string_regexp.rb` claiming the opcode keeps bypassing the override is corrected in the same commit.

```ruby
N = 2_000_000
def bench(name)
  best = nil
  25.times do
    t0 = Time.now
    yield
    t = Time.now - t0
    best = t if best.nil? || t < best
  end
  puts sprintf("%-10s %8.2f ns/iter", name, best * 1e9 / N)
end

str = "hello"
ary = [1, 2, 3, 4]
hsh = {1 => :a, 2 => :b}

bench("str[i]")  { i = 0; while i < N; str[1]; i += 1; end }
bench("str[0]")  { i = 0; while i < N; str[0]; i += 1; end }
bench("ary[i]")  { i = 0; while i < N; ary[1]; i += 1; end }
bench("ary[0]")  { i = 0; while i < N; ary[0]; i += 1; end }
bench("hash[k]") { i = 0; while i < N; hsh[1]; i += 1; end }
```

`build_config/default.rb`, which carries mruby-regexp, best of 25:

| | master | this PR | ratio |
| --- | ---: | ---: | ---: |
| `str[1]` | 31.52 ns | 130.29 ns | 4.13x |
| `str[0]` | 31.03 ns | 131.00 ns | 4.22x |
| `ary[1]` | 20.59 ns | 21.17 ns | 1.03x |
| `ary[0]` | 23.66 ns | 15.51 ns | 0.66x |
| `hsh[1]` | 27.01 ns | 25.05 ns | 0.93x |

Only the String read moves. The Array and Hash rows sit at the measurement floor on this box: run to run they swing by more than the difference between the two columns, in either direction, which is why the ratios there are noise and not a result. The same build under callgrind separates the two cleanly:

| loop body | master | this PR | ratio |
| --- | ---: | ---: | ---: |
| `str[1]` | 635.29 | 2379.17 | 3.74x |
| `str[0]` | 586.25 | 2346.17 | 4.00x |
| `ary[1]` | 308.00 | 308.00 | 1.00x |
| `ary[0]` | 264.00 | 264.00 | 1.00x |
| `hsh[1]` | 410.00 | 410.00 | 1.00x |
| `hsh[0]` | 507.00 | 506.00 | 1.00x |
| `ary[1] = 9` | 378.00 | 378.00 | 1.00x |
| `hsh[1] = 9` | 434.00 | 434.00 | 1.00x |

That slowdown is the price of the regexp forms of `String#[]` being reachable at all. A build without mruby-regexp keeps all eight fast paths, and `str[1]` there measures 38.25 ns on master and 39.02 ns with this PR, at the identical instruction count shown above.

### Tests

`test/t/string.rb` had a named test pinning the bypass as intended. It now pins the redefinition being honored, and Array and Hash gain the equivalent: two named tests in `test/t/array.rb`, one in `test/t/hash.rb`. Between them they cover the read, the write, a subclass receiver, the receiver being left untouched by a redefined `[]=`, and re-arming by aliasing the original implementation back.

The four GC arena assertions in `test/t/gc.rb` measure whether a C branch of `OP_GETIDX` or `OP_GETIDX0` leaves its result in the arena, and they measure it only while the loop body reaches the opcode. A send does not: its cfunc epilogue drains the arena, so the assertion would pass whatever the branch under test does. The first commit puts the C implementation back around the two String loops through a `with_builtin_string_aref` helper, which is a no-op where no gem replaced the operator. Without it those loop bodies would stop reaching the opcode in any build that carries mruby-regexp.

| build | config | Total | OK | KO | Skip |
| --- | --- | ---: | ---: | ---: | ---: |
| `host` | `build_config/default.rb` | 2,092 | 2,044 | 0 | 48 |
| `full-debug` | `build_config/ci/gcc-clang.rb` | 2,315 | 2,312 | 0 | 3 |
| `bintest` | `build_config/ci/gcc-clang.rb` | 2,315 | 2,304 | 0 | 11 |
| `cxx_abi` | `build_config/ci/gcc-clang.rb` | 2,315 | 2,304 | 0 | 11 |
| `byte-string` | `build_config/ci/gcc-clang.rb` | 2,246 | 2,198 | 0 | 48 |
| `ascii-case` | `build_config/ci/gcc-clang.rb` | 2,312 | 2,299 | 0 | 13 |
| `MRB_NO_BOXING` | full-core, `enable_debug` | 2,315 | 2,312 | 0 | 3 |
| `MRB_WORD_BOXING` | full-core, `enable_debug` | 2,315 | 2,312 | 0 | 3 |
| `MRB_NAN_BOXING` | full-core, `enable_debug` | 2,295 | 2,291 | 0 | 4 |
| `MRB_NO_METHOD_CACHE` | full-core, `enable_debug` | 2,315 | 2,312 | 0 | 3 |

`bintest` is green in both builds that enable it: 106 of 106 under `build_config/default.rb`, 117 of 117 under `build_config/ci/gcc-clang.rb`. Both commits are green on their own under `build_config/default.rb`.

### Environment

<details>

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-28-generic x86_64 |
| CPU | AMD Ryzen 9 5950X 16-Core Processor |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0 |
| binutils | GNU ld (GNU Binutils) 2.47.20260726 |
| valgrind | valgrind-3.27.1 |
| CRuby | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |

Compile line per build, `src/vm.c`, with `-MMD -c`, `-I` and `-o` removed:

```console
# build_config/default.rb, host
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK

# build_config/ci/gcc-clang.rb, full-debug
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# build_config/ci/gcc-clang.rb, bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK

# build_config/ci/gcc-clang.rb, cxx_abi (gcc -x c++; g++ links only)
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# build_config/ci/gcc-clang.rb, byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# build_config/ci/gcc-clang.rb, ascii-case
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CASE -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# full-core + enable_debug, one per boxing
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_NO_BOXING -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_WORD_BOXING -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_NAN_BOXING -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# full-core + enable_debug, MRB_NO_METHOD_CACHE
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_NO_METHOD_CACHE -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# the mruby-regexp-free timings and instruction counts
# (the second -O3 is the config repeating the toolchain default)
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -O3 -DHAVE_MRUBY_IO_GEM
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected indexed reads and writes for Array, Hash, and String when their indexing methods are overridden, removed, or redefined.
  * Ensured subclasses and objects with custom indexing behavior use the correct method dispatch instead of built-in shortcuts.
  * Preserved normal built-in indexing after temporary method overrides are restored.
* **Tests**
  * Added regression coverage for customized Array, Hash, and String indexing, including subclass behavior and garbage-collection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->