### PR TITLE
build_config: give the mrbc config a name of its own

### DIFF
--- a/build_config/mrbc.rb
+++ b/build_config/mrbc.rb
@@ -1,4 +1,6 @@
-MRuby::Build.new do |conf|
+# mrbc only build in a dedicated build directory (build/mrbc) so it does not
+# clobber a normal host build.
+MRuby::Build.new('mrbc') do |conf|
   if ENV['VisualStudioVersion'] || ENV['VSINSTALLDIR']
     conf.toolchain :visualcpp
   else


### PR DESCRIPTION
`build_config/mrbc.rb` opens an anonymous `MRuby::Build`, and an unnamed build is called `host` (`lib/mruby/build.rb:94`). The build tree is keyed by that name (`:107`), so `MRUBY_CONFIG=mrbc` aims a compiler only build, carrying `mruby-bin-mrbc` and nothing else, at `build/host`, on top of whatever a default build has left there, and never creates a directory of its own. This is the same shape as #7195 and #7197, on a config neither touches.

All of the transcripts below are from today's master, gcc 13.3.0, each starting from one clean default build.

### What it costs is decided by the timestamps in `build/host`

Run straight after a default build, rake finds every object it wants up to date, compiles nothing, and the tree is untouched:

```console
$ md5sum build/host/bin/mrbc
c6b0d6d168918de337fa27a8d5d2a262  build/host/bin/mrbc
$ wc -l build/host/include/mruby/presym/table.h
3161 build/host/include/mruby/presym/table.h
$ MRUBY_CONFIG=mrbc rake -j8             # exit 0
$ md5sum build/host/bin/mrbc
c6b0d6d168918de337fa27a8d5d2a262  build/host/bin/mrbc
$ wc -l build/host/include/mruby/presym/table.h
3161 build/host/include/mruby/presym/table.h
```

With a core source edited since, it rebuilds, and what it rebuilds is half the tree. It exits 0 while doing it:

```console
$ touch include/mruby.h src/*.c
$ MRUBY_CONFIG=mrbc rake -j8             # exit 0
...
      Config Name: host
 Output Directory: build/host
$ md5sum build/host/bin/mrbc
498ad7e2f0c3b9fc72708e5341af055d  build/host/bin/mrbc
$ wc -l build/host/include/mruby/presym/table.h
573 build/host/include/mruby/presym/table.h
$ md5sum build/host/bin/mruby build/host/lib/libmruby.a
9881d200e90c5a7df4a29a36b193fbab  build/host/bin/mruby
8dbb8c26becf449f5871f9e090c8a4ff  build/host/lib/libmruby.a
```

`build/host/bin/mruby` and `libmruby.a` are the default build's, holding the 3161 symbol table, while the presym headers beside them now describe 573, and `bin/mrbc` is a compiler built against those. `disable_libmruby` keeps the archive out of the way, so nothing announces the change. The repo `bin/` symlinks point into this tree as well, since `host?` builds install them (`:452`).

### The next default build does not put it back

It aborts, before it links anything, on a symbol the smaller table does not carry:

```console
$ rake -j8
include/mruby/presym.h:42:23: error: 'MRB_SYM__Rational' undeclared (first use in this function); did you mean 'MRB_SYM__generational'?
   42 | #define MRB_SYM(name) MRB_SYM__##name
      |                       ^~~~~~~~~
src/numeric.c:299:53: note: in expansion of macro 'MRB_SYM'
  299 |   if (mrb_integer_p(y) && mrb_class_defined_id(mrb, MRB_SYM(Rational))) {
      |                                                     ^~~~~~~
rake aborted!
Tasks: TOP => build => ... => build/host/src/numeric.o
```

and it goes on aborting the same way on every later run, because the presym list is what decides whether the headers get rewritten. `tasks/presym.rake` declares it as `file presym.list_path => ppps`, and the `mrbc` run rewrote `build/host/presym` along with the core `.pi` files it scanned, leaving it newer than the gem `.pi` files a default build would have to rescan to notice anything is missing:

```console
$ ls -l --time-style=+%H:%M:%S build/host/presym
-rw-rw-r-- 1 ... 00:30:03 build/host/presym
$ ls -lt --time-style=+%H:%M:%S build/host/src/vm.pi
-rw-rw-r-- 1 ... 00:30:03 build/host/src/vm.pi
$ ls -lt --time-style=+%H:%M:%S build/host/mrbgems/mruby-rational/gem_init.pi
-rw-rw-r-- 1 ... 00:28:57 build/host/mrbgems/mruby-rational/gem_init.pi
```

The task is up to date, the 573 symbol headers stay, and every core source naming a symbol outside them fails to compile. Recovery is `rm -rf build/host` plus a full rebuild.

### Naming it

The build is named after its config, which is what `build_config/asan.rb` and `build_config/gctest.rb` already do, and what 8b44a52 did for `host-cxx`. The rename is all this config needs: `build_mrbc_exec` supplies `mruby-bin-mrbc` itself (`:345`), and `disable_libmruby` means no internal mrbc build is created for it either way (`:152`).

### Verified

Through the same sequence that broke it:

```console
$ touch include/mruby.h src/*.c
$ MRUBY_CONFIG=mrbc rake -j8             # exit 0
...
      Config Name: mrbc
 Output Directory: build/mrbc
$ ls build/
host  mrbc
$ md5sum build/host/bin/mruby build/host/bin/mrbc build/host/lib/libmruby.a
9881d200e90c5a7df4a29a36b193fbab  build/host/bin/mruby
c6b0d6d168918de337fa27a8d5d2a262  build/host/bin/mrbc
8dbb8c26becf449f5871f9e090c8a4ff  build/host/lib/libmruby.a
$ wc -l build/host/include/mruby/presym/table.h
3161 build/host/include/mruby/presym/table.h
$ rake -j8                               # exit 0
```

The compiler it produces is the one it was producing before, byte for byte, and it still compiles for the host build's mruby:

```console
$ md5sum build/mrbc/bin/mrbc
498ad7e2f0c3b9fc72708e5341af055d  build/mrbc/bin/mrbc
$ wc -l build/mrbc/include/mruby/presym/table.h
573 build/mrbc/include/mruby/presym/table.h
$ cat /tmp/t.rb
p [1,2,3].map { |x| x.to_s }
p({a: 1}.keys)
p :sym
$ build/mrbc/bin/mrbc -o /tmp/t.mrb /tmp/t.rb
$ build/host/bin/mruby -b /tmp/t.mrb
["1", "2", "3"]
[:a]
:sym
```

### One thing changes for whoever runs this config

`bin/` symlinks are installed for a `host?` build (`:452`), so on master this config also pointed `bin/mrbc` at what it built. A named build does not, and the compiler is at `build/mrbc/bin/mrbc` instead. Run from a clean tree it now touches nothing else:

```console
$ MRUBY_CONFIG=mrbc rake -j8             # exit 0
$ ls build/
mrbc
```

### Environment

<details>

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-28-generic x86_64 |
| CPU | AMD Ryzen 9 5950X, 16 cores / 32 threads |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0 |
| binutils | GNU ld (GNU Binutils) 2.47.20260726 |
| CRuby running rake | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM |

The line each build gives `mrbgems/mruby-compiler/src/codegen.c`, read off `rake --verbose` with `-MMD -c`, the `-I` list and `-o` dropped. This file rather than `src/string.c`, because the `mrbc` build compiles no `src/*.c` to an object at all: with `disable_libmruby` nothing links them, and `tasks/presym.rake` seeds the scan from the object list so only their `.pi` files get built. Neither build calls `enable_debug`, so both take the gcc toolchain's own `-g -O3`:

```console
# default
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK mrbgems/mruby-compiler/src/codegen.c

# mrbc
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_GEMS -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 mrbgems/mruby-compiler/src/codegen.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the MRuby compiler build configuration to use a dedicated `mrbc` build name and output directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->