### PR TITLE
build_config: give the glib_hal_test config a name of its own

### DIFF
--- a/build_config/glib_hal_test.rb
+++ b/build_config/glib_hal_test.rb
@@ -1,4 +1,6 @@
-MRuby::Build.new do |conf|
+# mruby-task GLib HAL test build in a dedicated build directory
+# (build/glib_hal_test) so it does not clobber a normal host build.
+MRuby::Build.new('glib_hal_test') do |conf|
   # load specific toolchain settings
   conf.toolchain
 
@@ -83,6 +85,11 @@ MRuby::Build.new do |conf|
   conf.enable_test
   conf.ports :glib
   conf.cc.defines << 'MRB_TASK_BUILD_DEMO'
+  # this build loads no gembox, and a build that is not named 'host' cannot
+  # borrow mrbc from a 'host' target that is not being built
+  conf.gem core: 'mruby-bin-mrbc'
+  # mruby-bin-mrbc brings a bintest that disassembles through `mruby -v -c`
+  conf.gem core: 'mruby-bin-mruby'
   conf.gem core: 'mruby-task'
   conf.gem core: 'mruby-compiler'
 end

--- a/lib/mruby/gem.rb
+++ b/lib/mruby/gem.rb
@@ -648,8 +648,12 @@ module MRuby
       end
 
       def linker_attrs(gem=nil)
-        gems = self.reject{|g| g.bin?}  # library gems
-        gems << gem unless gem.nil?
+        # A gem that puts no object in libmruby.a contributes nothing to a link
+        # of it, so its linker options are its own binary's alone; ref #5210.
+        # One that does put objects there needs its options wherever libmruby.a
+        # is linked, whether or not it builds a binary as well.
+        gems = self.reject{|g| g.bin? && g.objs.empty?}
+        gems << gem unless gem.nil? || gems.include?(gem)
         gems.map{|g| g.linker.run_attrs}.transpose
       end
     end # List


### PR DESCRIPTION
> Stacked on #7203, whose commit is the first of the two here.  Only the second one, `build_config/glib_hal_test.rb`, belongs to this PR.

`build_config/glib_hal_test.rb` opens an anonymous `MRuby::Build`, and an unnamed build is called `host` (`lib/mruby/build.rb:94`). The build tree is keyed by that name (`:107`), so `MRUBY_CONFIG=glib_hal_test` aims its objects at `build/host`, on top of whatever a default build has left there, and never creates a directory of its own. This is the same shape as #7195, #7197 and #7199, on a config none of them touches.

All of the transcripts below are from today's master, gcc 13.3.0, glib 2.80.0.

### Sharing `build/host` breaks this config outright

It loads no gembox at all, so what it shares `build/host` with is a tree built from a different set of gems, and the presym scan cannot tell them apart. It reads the `.pi` files the compilers leave behind, and those are keyed on the source timestamp alone, so a `.pi` a default build preprocessed under its own defines is reused here unchanged. The result is a symbol table belonging to neither build, and this config aborts on the first core file that needs a symbol it lost:

```console
$ rake -j8                               # a default build, exit 0
$ MRUBY_CONFIG=glib_hal_test rake -j8
include/mruby/presym.h:42:23: error: 'MRB_SYM__print' undeclared here (not in a function); did you mean 'MRB_SYM__private'?
   42 | #define MRB_SYM(name) MRB_SYM__##name
      |                       ^~~~~~~~~
src/kernel.c:811:29: note: in expansion of macro 'MRB_SYM'
  811 |   MRB_MT_ENTRY(mrb_print_m, MRB_SYM(print), MRB_ARGS_ANY() | MRB_MT_PRIVATE),
      |                             ^~~~~~~
rake aborted!
Tasks: TOP => build => build/host/lib/libmruby.a => build/host/src/kernel.o
```

`MRB_SYM(p)` and `MRB_SYM(print)` sit behind `#ifndef HAVE_MRUBY_IO_GEM` (`src/kernel.c:809`). A default build carries `mruby-io` and its `kernel.pi` does not name them; this build carries no io gem and its `src/kernel.c` does. The stale `kernel.pi` is what gets scanned:

```console
$ md5sum build/host/src/kernel.pi        # before and after the run
358985be208e175586d7b6486c9726b9  build/host/src/kernel.pi
358985be208e175586d7b6486c9726b9  build/host/src/kernel.pi
```

The leak runs the other way too. `MRB_SYM(Rational)` reaches the table from the default build's `numeric.pi`, preprocessed with `-DMRB_USE_RATIONAL`, which this build never sets. Against the list the same config writes on a clean tree, this one is missing `p`, `print` and the ten `mrblib/*.rb` file names, and carries `Rational` that does not belong to it: 442 symbols on a clean tree, 431 here. The file names go missing for the same reason one step further along, since `enable_debug` appends `-g` to the mrbc options (`:176`), so this config's `mrblib.c` holds them and the default build's, reused here, does not.

### What it leaves behind when it does get through

Whether it gets that far is decided by the timestamps in `build/host`, so the config does build against a tree it does not clobber:

```console
$ rm -rf build/host
$ MRUBY_CONFIG=glib_hal_test rake -j8    # exit 0
$ ls build/host/bin/
mruby_task_demo
$ ls bin/
mirb  mrb  mrbc  mrdb  mruby  mruby-config  mruby-strip  mruby_task_demo
$ wc -l build/host/include/mruby/presym/table.h
889 build/host/include/mruby/presym/table.h
```

which is the shape the tree is left in either way. `MRB_TASK_BUILD_DEMO` gives `mruby-task` a `spec.bins`, and `bin/` symlinks are installed for a `host?` build (`:452`), so the demo lands in the repo `bin/` beside the default build's commands, and `build/host` holds an `-fsanitize` tree at `-O0` with an 889 symbol table where the default build's has 3161.

### Naming it

The build is named after its config, which is what `build_config/asan.rb` and `build_config/gctest.rb` already do, and what 8b44a52 did for `host-cxx`. Naming is not enough on its own here. The internal mrbc build is created only for a `host?` build or one carrying `mruby-bin-mrbc` (`:153`), and this config loads no gembox to supply it, so the rename alone stops before it compiles anything:

```console
$ MRUBY_CONFIG=glib_hal_test rake -j8
rake aborted!
external mrbc or mruby-bin-mrbc gem in current('glib_hal_test') or 'host' build is required
tasks/mrblib.rake:9
```

`build_config/gctest.rb` is the same pair for the same reason, a named build with an explicit `mruby-bin-mrbc` line.

`mruby-bin-mrbc` brings a bintest of its own, and the config already sets `enable_bintest`, where before the rename it had no bintest to run at all. One of its asserts compares the disassembly mrbc writes against the one `mruby -v -c` writes (`mrbgems/mruby-bin-mrbc/bintest/mrbc.rb:85`), and nothing here supplies that binary, so it ends the run:

```console
Errno::ENOENT: mrbc -v disassembles like mruby -v => No such file or directory - build/glib_hal_test/bin/mruby
  Total: 5    OK: 4   KO: 0   Crash: 1   Skip: 0
```

Add `mruby-bin-mruby` as well, so the test the compiler gem carries has what it asks for.

### Verified

Through the sequence that aborted:

```console
$ rake -j8                               # a default build, exit 0
$ MRUBY_CONFIG=glib_hal_test rake -j8    # exit 0
...
      Config Name: glib_hal_test
 Output Directory: build/glib_hal_test
$ ls build/
glib_hal_test  host
$ ls build/glib_hal_test/bin/
mrbc  mruby  mruby_task_demo
$ wc -l build/glib_hal_test/include/mruby/presym/table.h
889 build/glib_hal_test/include/mruby/presym/table.h
$ build/glib_hal_test/bin/mruby_task_demo
[t=    0 ms] main: spawning T2 + T3; running T1 (glib-only) on main thread
===== T3 (Task.run only): zombie/executioner + spinner/stopper + sleepers =====
...
```

and an existing host build is left byte-identical, with its own table and its own `bin/`:

```console
$ md5sum build/host/bin/mruby build/host/bin/mrbc build/host/lib/libmruby.a
9881d200e90c5a7df4a29a36b193fbab  build/host/bin/mruby
c6b0d6d168918de337fa27a8d5d2a262  build/host/bin/mrbc
8dbb8c26becf449f5871f9e090c8a4ff  build/host/lib/libmruby.a
$ ar t build/host/lib/libmruby.a | sort -u | wc -l
99
$ wc -l build/host/include/mruby/presym/table.h
3161 build/host/include/mruby/presym/table.h
$ ls bin/
mirb  mrb  mrbc  mrdb  mruby  mruby-config  mruby-strip
$ rake -j8                               # exit 0
$ build/host/bin/mruby -e 'p 1+1'
2
```

### `rake test`

It passes on top of #7203, which keeps the linker options of a gem whose objects are in `libmruby.a`. Without that commit mrbtest cannot be linked here at all: `MRB_TASK_BUILD_DEMO` makes `mruby-task` a bin gem, and `MRuby::Gem::List#linker_attrs` dropped the `-lglib-2.0` that `search_package` contributed from the mrbtest link line. With the two together:

```console
$ MRUBY_CONFIG=glib_hal_test rake -m test    # exit 0
bintest - Command Binary Test
  Total: 53    OK: 52   KO: 0    Crash: 0    Skip: 1
mrbtest - Embeddable Ruby Test
  Total: 832   OK: 831  KO: 0    Crash: 0    Skip: 1
$ ls bin/
mirb  mrb  mrbc  mrdb  mruby  mruby-config  mruby-strip
```

A default build is unaffected, and `rake -m test` on it stays green:

```console
$ rake -m test                               # exit 0
  Total: 2089  OK: 2041  KO: 0  Crash: 0  Skip: 48
```

### Environment

<details>

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-28-generic x86_64 |
| CPU | AMD Ryzen 9 5950X, 16 cores / 32 threads |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0 |
| binutils | GNU ld (GNU Binutils) 2.47.20260726 |
| glib | 2.80.0 |
| CRuby running rake | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM |

The line each build gives `src/string.c`, read off `rake --verbose` with `-MMD -c`, the `-I` list and `-o` dropped. `glib_hal_test` calls `enable_debug`, which appends `-g3 -O0` after the gcc toolchain's own `-g -O3`. The gembox difference the presym scan trips over is visible here as well, in the `-D` list:

```console
# default
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK src/string.c

# glib_hal_test
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -fsanitize=address,undefined -g3 -O0 -DMRB_TASK_BUILD_DEMO -DMRB_DEBUG -DMRB_USE_TASK_SCHEDULER src/string.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build Improvements**
  * Updated the GLib HAL test build with a dedicated output directory.
  * Included the core compiler and runtime components required for building and running the test suite.
  * Improved build configuration so components containing compiled objects are correctly included, including those that also provide command-line tools.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->