### PR TITLE
mruby-compiler: make `mrc_int` as wide as the VM's `mrb_int`

### DIFF
--- a/mrbgems/mruby-compiler/include/mrc_common.h
+++ b/mrbgems/mruby-compiler/include/mrc_common.h
@@ -27,7 +27,12 @@
   #include <mrubyc.h>
   #define mrb_state void
 #else
-  /* May be building standalone mrbc */
+  /* May be building standalone mrbc. mruby.h would declare a core API this
+     binary does not link, but mrbconf.h on its own is self-contained, and it
+     is what settles the target's mrb_int width -- which mrc_int has to match,
+     because this mrbc dumps irep for that target (see MRC_INT32 below). */
+  #include <stdint.h>
+  #include <mrbconf.h>
   #define mrb_state void
 #endif
 
@@ -114,6 +119,13 @@ typedef uint8_t mrc_bool;
 # ifndef TRUE
 #  define TRUE 1
 # endif
+#endif
+
+/* mrc_int must be as wide as the VM's mrb_int and no wider: the pool literals
+   and the constant folding below are dumped for a target whose loader rejects
+   an IREP_TT_INT64 entry unless it was built with MRB_INT64 (src/load.c). */
+#if defined(MRB_INT32) && !defined(MRC_INT32)
+#define MRC_INT32 1
 #endif
 
 #if !defined(MRC_INT32)

--- a/mrbgems/mruby-compiler/src/codegen.c
+++ b/mrbgems/mruby-compiler/src/codegen.c
@@ -3987,30 +3987,32 @@ gen_ensure(mrc_codegen_scope *s, mrc_node *tree, uint32_t catch_entry, uint32_t 
 static void
 gen_pm_integer(mrc_codegen_scope *s, const pm_integer_t *iv)
 {
+  mrc_uint value;
+  mrc_bool fits = FALSE;
+
   if (iv->length == 0) {
-    if (!iv->negative) {
-      gen_int(s, cursp(), (mrc_int)iv->value);
-    }
-    else {
-      gen_int(s, cursp(), (mrc_int)iv->value * -1);
-    }
-    return;
+    /* iv->value is a uint32_t, which is wider than mrc_int under MRC_INT32,
+       so the magnitude still has to be range-checked below. */
+    value = iv->value;
+    fits = TRUE;
   }
 #ifdef MRC_INT64
-  if (iv->length == 2) {
-    mrc_uint value = ((mrc_uint)iv->values[0])|((mrc_uint)iv->values[1] << 32);
-    mrc_bool fits = TRUE;
+  else if (iv->length == 2) {
+    value = ((mrc_uint)iv->values[0])|((mrc_uint)iv->values[1] << 32);
+    fits = TRUE;
+  }
+#endif
+  if (fits) {
     if (!iv->negative && MRC_INT_MAX < value) fits = FALSE;
     if (iv->negative) {
       if (value > (mrc_uint)MRC_INT_MIN) fits = FALSE;
       else value *= -1;
     }
-    if (fits) {
-      gen_int(s, cursp(), value);
-      return;
-    }
   }
-#endif
+  if (fits) {
+    gen_int(s, cursp(), (mrc_int)value);
+    return;
+  }
   {
     pm_buffer_t buf = {0};
     pm_integer_string(&buf, iv);

--- a/test/t/literals.rb
+++ b/test/t/literals.rb
@@ -35,6 +35,27 @@ assert('Literals Numerical', '8.7.6.2') do
   assert_equal 10.0, 1.0e+1
 end
 
+assert('Literals Numerical wider than mrb_int') do
+  # None of these fit mrb_int on MRB_INT32, so the compiler has to hand them
+  # to the VM as big integer literals.  A shift is written on the other side
+  # of each because a shift that overflows mrb_int is left to run time, which
+  # gives the same value by a path the literal does not share.  Without
+  # mruby-bigint the value cannot exist at all, and it is the literal that
+  # cannot be built where mrb_int is narrow, the shift where it is wide, so
+  # the guard holds one of each.
+  begin
+    n = 2147483648
+    m = (1 << 63) - 1
+  rescue RangeError
+    skip 'a value here is wider than mrb_int and mruby-bigint is absent'
+  end
+  assert_equal 1 << 31, n
+  assert_equal 4294967296, 1 << 32
+  assert_equal 9223372036854775807, m
+  assert_equal(-2147483649, -(1 << 31) - 1)
+  assert_equal 2147483648, 0x80000000
+end
+
 assert('Literals Strings Single Quoted', '8.7.6.3.2') do
   assert_equal 'abc', 'abc'
   assert_equal '\'', '\''


### PR DESCRIPTION
On an `MRB_INT32` build an integer literal from `2**31` to `2**63 - 1` is refused, and the source path says nothing about it:

```console
$ build/host-m32/bin/mruby -e 'p 1<<30'
1073741824
$ build/host-m32/bin/mruby -e 'p 1<<31'
$ echo $?
1
$ build/host-m32/bin/mruby -e 'p 2147483648'
$ echo $?
1
$ build/host-m32/bin/mruby -e 'p 9223372036854775808'
9223372036854775808
```

`2**63` and above answers because it is a bignum literal. `mruby-bigint` does not help: what fails is the compiler, before anything is run.

`mrbc` accepts the same program, and the bytecode names what happened:

```console
$ echo 'p 2147483648' > t.rb
$ build/host-m32/bin/mrbc -o t.mrb t.rb && build/host-m32/bin/mruby -b t.mrb
trace (most recent call last):
mrbgems/mruby-toplevel-ext/mrblib/toplevel.rb:1: irep load error (ScriptError)
```

## Why

`mrc_common.h` maps `MRB_NO_FLOAT` and `MRB_USE_FLOAT32` onto their `MRC_` counterparts, but nothing maps the integer width, so `MRC_INT32` is never defined and `mrc_int` is 64 bits in every build:

```c
#if !defined(MRC_INT32)
#define MRC_INT64 1
#endif
```

So the compiler folds constants at 64 bits, and `new_lit_int()` writes an `IREP_TT_INT64` pool entry for any literal too wide for `int32_t`, while `read_irep_record_1()` in `src/load.c` refuses that pool type unless the VM carries `MRB_INT64`:

```c
      case IREP_TT_INT64:
#ifdef MRB_INT64
        ...
#else
        return FALSE;
#endif
```

A 32-bit VM with a 64-bit compiler inside it.

## The width has to reach the compiler by two routes

The first is the mapping itself, and it serves a build that names `MRB_INT32` on the command line.

It changes nothing for a build that is 32-bit by architecture. The `mrbc` that compiles all of a build's Ruby code, `mrblib` and every gem's `mrblib` and tests, is a separate internal build (`create_mrbc_build()` in `lib/mruby/build.rb`) carrying `-DMRB_NO_GEMS`, and `mruby-compiler`'s `mrbgem.rake` withholds `MRC_TARGET_MRUBY` from such a build:

```ruby
  elsif !cc.defines.include?('MRB_NO_GEMS')
    cc.defines << 'MRC_TARGET_MRUBY'
  end
```

which is what decides whether `mrc_common.h` includes `mruby.h`. The two lines that compile `codegen.c` in one 32-bit build differ in exactly that:

```console
i686-linux-gnu-gcc ... -m32 -DMRB_NO_GEMS -DPRISM_XALLOCATOR ...           # the mrbc that compiles the build
i686-linux-gnu-gcc ... -m32 -DPRISM_XALLOCATOR ... -DMRC_TARGET_MRUBY ...  # the compiler inside the VM
```

The first one never sees a header of mruby's, so an `MRB_INT32` that `mrbconf.h` derived from the pointer width is invisible to it. `mrbconf.h` is self-contained and it is what settles the width, so it is included in that branch, and both routes end at the same answer.

## What a literal too wide for the target becomes

A bignum literal, which is what `2**63` and above already was. The VM loads it and either promotes it with `mruby-bigint` or, without the gem, raises where a variable shift already raises:

```console
$ build/host-m32-min/bin/mruby -e 'p 1<<31'          # a build without mruby-bigint
trace (most recent call last):
	[1] -e:1
-e:1:in <<: integer overflow in bit shift (RangeError)
$ build/host-m32-min/bin/mruby -e 'p 2147483648'
trace (most recent call last):
-e:1: integer overflow (RangeError)
```

Both were silent exit 1 before, the same way the transcript at the top is.

`gen_pm_integer()` had a range check on the `length == 2` case and none on the small one, where Prism keeps a literal that fits `uint32_t`. That case now asks the same question, which under `MRC_INT32` is a real one: `2147483648` reached `gen_int()` as `-2147483648` with the mapping in place and the check missing.

## `mruby-bigint`'s own tests are among the files this made unloadable

`mrbgems/mruby-bigint/test/bigint.rb` holds such literals, so on `MRB_INT32` none of its 20 assertions ran. `bin/mrbtest -v | grep -c '^Bigint'` answers 0 before and 19 after, 19 being how many of the 20 are named for the class, and the totals below carry all 20.

## Tests

`test/t/literals.rb` gains `Literals Numerical wider than mrb_int`, next to the ISO `Literals Numerical`. It writes each literal against a shift of the same value, because a shift that overflows `mrb_int` is left to run time and so arrives by a path the literal does not share. Without `mruby-bigint` the value cannot exist at all, and which of the two cannot be built depends on the width: the literal where `mrb_int` is narrow, the shift where it is wide, since `1 << 63` overflows a 64-bit `mrb_int` as well. The guard holds one of each and the assertion skips.

Reverting the range check alone turns it red on `host-m32`, `Fail: Literals Numerical wider than mrb_int`. Reverting the mapping does not: the file becomes unloadable and drops whole, which `mrbtest` does not report. That is a separate defect of `mrb_load_irep_cxt()` and is not touched here.

## Verification

`rake -m test`, every build green, 0 KO, 0 crash, no new warnings. The configurations that are not in the tree are given below; `build_config/host-m32.rb` needs a multilib gcc this machine has no `-m32` runtime for, so an `i686-linux-gnu-gcc` cross toolchain stands in for it.

| build | before | after |
| --- | --- | --- |
| host-m32, `-m32`, full-core with mruby-bigint | 2292 tests, 4 skip | 2313 tests, 4 skip |
| host-m32-min, `-m32`, stdlib gembox, no mruby-bigint | 1425 tests, 42 skip | 1426 tests, 43 skip |
| host-i32, `-DMRB_INT32 -DMRB_NO_BOXING`, full-core | 2292 tests, 12 skip | 2313 tests, 12 skip |
| host-nobigint, 64-bit, stdlib gembox, no mruby-bigint | 1425 tests, 42 skip | 1426 tests, 43 skip |
| ci/gcc-clang full-debug | 2312 tests, 3 skip | 2313 tests, 3 skip |
| ci/gcc-clang bintest | 2312 tests, 11 skip, plus 117 bintests | 2313 tests, 11 skip, plus 117 bintests |
| ci/gcc-clang cxx_abi | 2312 tests, 11 skip | 2313 tests, 11 skip |
| ci/gcc-clang byte-string | 2243 tests, 48 skip | 2244 tests, 48 skip |
| ci/gcc-clang ascii-case | 2309 tests, 13 skip | 2310 tests, 13 skip |

The builds that carry `mruby-bigint` at 64 bits move by the one assertion this PR adds. The two that have no `mruby-bigint`, `host-m32-min` and `host-nobigint`, move by the same one, which there is the skip. The two 32-bit builds carrying `mruby-bigint` move by 21: that assertion, and the 20 of `bigint.rb` that could not be loaded before.

Both commits are green on their own. The range check comes first and is inert until the mapping lands, since `uint32_t` is never wider than a 64-bit `mrc_int`.

<details>
<summary>The build configurations that are not in the tree</summary>

```ruby
# host-m32
MRuby::Build.new('host-m32') do |conf|
  toolchain :gcc
  conf.cc.command = 'i686-linux-gnu-gcc'
  conf.cxx.command = 'i686-linux-gnu-g++'
  conf.linker.command = 'i686-linux-gnu-gcc'
  conf.archiver.command = 'i686-linux-gnu-gcc-ar'

  conf.gembox 'full-core'

  conf.cc.flags << '-m32'
  conf.linker.flags << '-m32'

  conf.enable_debug
  conf.enable_test
end
```

`host-m32-min` is the same toolchain with `conf.gembox 'stdlib'` plus `mruby-bin-mruby` and `mruby-bin-mrbc`, and no `enable_debug`, which is the shortest way to a build without `mruby-bigint`. `host-i32` is the host gcc with `conf.gembox 'full-core'` and `MRB_INT32` and `MRB_NO_BOXING` in `conf.cc.defines`. `host-nobigint` is `host-m32-min` on the host gcc without `-m32`, which is a 64-bit `mrb_int` with no `mruby-bigint` behind it; `build_config/host-nofloat.rb` is the shape of that build which is in the tree.

</details>

### Environment

<details>
<summary>Versions</summary>

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS, Linux 7.0.0-28-generic x86_64 |
| CPU | AMD Ryzen 9 5950X, 16 cores |
| C compiler | gcc 13.3.0 and i686-linux-gnu-gcc 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1) |
| Linker | GNU ld 2.47.20260726, GNU ld 2.42 for i686, and `g++` for `cxx_abi` |
| CRuby | 4.0.6 (2026-07-14) +PRISM, running rake |

</details>

<details>
<summary>Compile lines for codegen.c</summary>

`-MMD -c`, `-I` and `-o` dropped. Each build compiles the file twice, once for the internal `mrbc` and once for the VM's own compiler, and the pair is what this PR is about.

```console
# host-m32
i686-linux-gnu-gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -m32 -g3 -O0 -DMRB_NO_GEMS -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_DEBUG -DMRC_DUMP_PRETTY -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_DEBUG codegen.c
i686-linux-gnu-gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -m32 -g3 -O0 -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DMRC_DEBUG -DMRC_DUMP_PRETTY -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER codegen.c

# host-m32-min
i686-linux-gnu-gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -m32 -DMRB_NO_GEMS -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 codegen.c
i686-linux-gnu-gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -m32 -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET codegen.c

# host-i32
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_INT32 -DMRB_NO_BOXING -DMRB_NO_GEMS -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 codegen.c
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_INT32 -DMRB_NO_BOXING -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER codegen.c

# host-nobigint
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_GEMS -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 codegen.c
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET codegen.c

# ci/gcc-clang full-debug, -O0 because enable_debug appends -g3 -O0
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_NO_GEMS -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_DEBUG -DMRC_DUMP_PRETTY -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_DEBUG codegen.c
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DMRC_DEBUG -DMRC_DUMP_PRETTY -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER codegen.c

# ci/gcc-clang bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_NO_GEMS -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 codegen.c
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK codegen.c

# ci/gcc-clang cxx_abi, gcc -x c++ rather than g++, which only links
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_NO_GEMS -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DPRISM_BUILD_MINIMAL -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI codegen.c
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER codegen.c

# ci/gcc-clang byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_GEMS -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 codegen.c
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER codegen.c

# ci/gcc-clang ascii-case
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CASE -DMRB_NO_GEMS -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 codegen.c
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CASE -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER codegen.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of integer literals across 32-bit and 64-bit configurations.
  * Large and boundary-value literals now correctly fall back to big integer representation instead of being truncated or misinterpreted.

* **Tests**
  * Added coverage for oversized decimal and hexadecimal literals, including positive and negative values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
