### PR TITLE
mruby-compiler: report a failed irep round trip in `mrb_generate_code()`

### DIFF
--- a/mrbgems/mruby-compiler/src/mruby_compat.c
+++ b/mrbgems/mruby-compiler/src/mruby_compat.c
@@ -407,6 +407,24 @@ mrb_parse_string(mrb_state *mrb, const char *s, mrb_ccontext *c)
   return mrb_parse_nstring(mrb, s, strlen(s), c);
 }
 
+/* The dump and reload below is the one compiler-side failure codegen_error()
+   does not cover, and it leaves nothing on stderr on its own. Report it
+   through the same `quiet_errors` gate, so a caller that captures errors
+   (eval) still sees only the exception mrb_load_exec() raises. */
+static void
+report_roundtrip_error(mrc_ccontext *mc, const char *message)
+{
+#ifndef MRB_NO_STDIO
+  if (mc->quiet_errors) return;
+  if (mc->filename) {
+    fprintf(stderr, "%s: %s\n", mc->filename, message);
+  }
+  else {
+    fprintf(stderr, "%s\n", message);
+  }
+#endif
+}
+
 MRB_API struct RProc*
 mrb_generate_code(mrb_state *mrb, struct mrb_parser_state *p)
 {
@@ -425,11 +443,13 @@ mrb_generate_code(mrb_state *mrb, struct mrb_parser_state *p)
   mc = (mrc_ccontext*)p->ylval;
   irep = (mrc_irep*)p->tree;
   if (mrc_dump_irep(mc, irep, flags, &bin, &bin_size) != MRC_COMPAT_DUMP_OK) {
+    report_roundtrip_error(mc, "irep dump error");
     return NULL;
   }
   mir = mrb_read_irep_buf(mrb, bin, bin_size);
   mrc_free(mc, bin);
   if (!mir) {
+    report_roundtrip_error(mc, "irep load error");
     return NULL;
   }
   proc = mrb_proc_new(mrb, mir);


### PR DESCRIPTION
A program can end at exit 1 with nothing on either stream. On today's master, `build_config/default.rb`, x86-64:

```console
$ ruby -e "puts 's = \"' + ('a' * 65536) + '\"; p s.size'" > big.rb
$ build/host/bin/mruby big.rb
$ echo $?
1
```

65535 bytes of `a` runs and prints 65535. 65536 is the boundary, and it says nothing about it.

## Where the report went

Two of the three ways compilation can fail write to stderr themselves, under a gate a caller that captures errors turns off. `parse_source()`:

```c
  /* Unless the caller captures errors (e.g. eval), report parse errors to
     stderr like the bison parser does, so a syntax error is not a silent
     failure. Codegen errors take the same gate inside codegen_error(),
     through `quiet_errors`. */
  if (!c || !c->capture_errors) {
```

and `codegen_error()`:

```c
#ifndef MRC_NO_STDIO
  if (!s->c->quiet_errors) {
```

The third is the dump and reload that turns the `mrc_irep` into an `mrb_irep`, and it takes neither:

```c
  if (mrc_dump_irep(mc, irep, flags, &bin, &bin_size) != MRC_COMPAT_DUMP_OK) {
    return NULL;
  }
  mir = mrb_read_irep_buf(mrb, bin, bin_size);
  mrc_free(mc, bin);
  if (!mir) {
    return NULL;
  }
```

`mrb_load_exec()` does answer that `NULL`, by raising `ScriptError "codegen error"` and returning `undef`. What the front ends do with it is print it only when the value is not `undef`:

```c
    if (mrb->exc) {
      MRB_EXC_CHECK_EXIT(mrb, mrb->exc);
      if (!mrb_undef_p(v)) {
        mrb_print_error(mrb);
      }
      n = EXIT_FAILURE;
    }
```

which is 9bd17226d3, "Avoid duplicate message output (`SyntaxError`, `ScriptError` etc)": `undef` means the compiler already said it. `mruby`, `mrb` and `mrdb` all carry that shape. Here the compiler said nothing, so nobody does.

The exception is real, and a caller that reads exceptions rather than stderr has always seen it:

```console
$ build/host/bin/mruby -e 'p eval(%q{s = "} + "a" * 65536 + %q{"; s.size})'
trace (most recent call last):
	[1] -e:1
-e:1:in eval: codegen error (ScriptError)
```

## The change

`mrb_generate_code()` reports both failures through the same `quiet_errors` gate as the two beside it, so every front end gets the line and `eval` keeps getting only the exception:

```console
$ build/host/bin/mruby big.rb
big.rb: irep load error
$ echo $?
1
$ build/host/bin/mruby -e 'begin; eval(%q{s = "} + "a" * 65536 + %q{"}); rescue ScriptError => e; puts "rescued: " + e.message; end'
rescued: codegen error
```

`mrdb` prints it too. `mirb` does not, and this does not change that: it sets `capture_errors` so it can draw syntax errors itself with a caret, and answers a `NULL` from `mrb_generate_code()` with a bare `continue`. Giving it a line means routing this diagnostic through the parser's error buffer, which is a different change.

## What this does not fix

Why a 65536-byte string literal fails at all. `write_pool_block()` records a pool string's length in a `uint16_t`, and the only thing standing between a longer literal and a truncated record is an assertion that a release build compiles away:

```c
      len = irep->pool[pool_no].tt>>2;
      mrc_assert_int_fit(mrc_int, len, uint16_t, UINT16_MAX);
      cur += mrc_uint16_to_bin((uint16_t)len, cur); /* data length */
```

An `MRC_DEBUG` build stops there instead, which is `ci/gcc-clang`'s `full-debug` on the same file:

```console
$ build/full-debug/bin/mruby big.rb
mruby: mrbgems/mruby-compiler/src/dump.c:239: write_pool_block: Assertion `(len)>=0 && ((sizeof(len)<=sizeof(uint16_t))||(len<=(mrc_int)((65535))))' failed.
```

That is a separate defect and wants a separate fix. It is used here because it is the shortest program that reaches this code path on a stock build.

#7201 is the other way in that turned up this week: on an `MRB_INT32` build every integer literal from `2**31` to `2**63 - 1` was refused by the loader, and `mruby -e 'p 1<<31'` was silent for the reason above. With this commit and without #7201, that build answers:

```console
$ build/host-m32/bin/mruby -e 'p 1<<31'
-e: irep load error
```

Two unrelated defects, both invisible at the same place.

## Tests

None. `mrb_generate_code()` reaches this only when a dump and its reload disagree, which is a defect wherever it happens rather than something a test can ask for and keep. Pinning it to the 65536-byte literal would pin a test to the defect above staying unfixed.

## Verification

`rake -m test` over `ci/gcc-clang`, every build green, 0 KO, 0 crash, no new warnings, and the counts are master's to the test.

| build | master | with this commit |
| --- | --- | --- |
| full-debug | 2312 tests, 3 skip | 2312 tests, 3 skip |
| bintest | 2312 tests, 11 skip, plus 117 bintests | 2312 tests, 11 skip, plus 117 bintests |
| cxx_abi | 2312 tests, 11 skip | 2312 tests, 11 skip |
| byte-string | 2243 tests, 48 skip | 2243 tests, 48 skip |
| ascii-case | 2309 tests, 13 skip | 2309 tests, 13 skip |

`MRB_NO_STDIO` compiles the file with the report gone, warning free, checked on a `MRuby::CrossBuild` carrying `mruby-compiler` and `mruby-eval` (`build_config/minimal.rb` builds no gem, so it does not compile this file).

### Environment

<details>
<summary>Versions</summary>

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS, Linux 7.0.0-28-generic x86_64 |
| CPU | AMD Ryzen 9 5950X, 16 cores |
| C compiler | gcc 13.3.0 and i686-linux-gnu-gcc 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1) |
| Linker | GNU ld 2.47.20260726, GNU ld 2.42 for i686, and `g++` for `cxx_abi` |
| CRuby | 4.0.6 (2026-07-14) +PRISM, running rake and generating the test programs |

</details>

<details>
<summary>Compile lines for mruby_compat.c</summary>

`-MMD -c`, `-I` and `-o` dropped.

```console
# ci/gcc-clang full-debug, -O0 because enable_debug appends -g3 -O0
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DMRC_DEBUG -DMRC_DUMP_PRETTY -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-compiler/src/mruby_compat.c

# ci/gcc-clang bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK mrbgems/mruby-compiler/src/mruby_compat.c

# ci/gcc-clang cxx_abi, gcc -x c++ rather than g++, which only links
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-compiler/src/mruby_compat.c

# ci/gcc-clang byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-compiler/src/mruby_compat.c

# ci/gcc-clang ascii-case
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CASE -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-compiler/src/mruby_compat.c

# MRB_NO_STDIO, a CrossBuild with mruby-compiler and mruby-eval
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_STDIO -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 mrbgems/mruby-compiler/src/mruby_compat.c
```

</details>
