### PR TITLE
mruby-compiler: check the three RITE counts the codegen does not

### DIFF
--- a/mrbgems/mruby-compiler/src/codegen.c
+++ b/mrbgems/mruby-compiler/src/codegen.c
@@ -1262,6 +1262,12 @@ scope_finish(mrc_codegen_scope *s)
 static mrc_pool_value*
 lit_pool_extend(mrc_codegen_scope *s)
 {
+  /* `plen` is what the dump writes the pool count into, and it is 16 bits
+     wide there and here, so the 65536th entry would wrap it to zero and leave
+     every OP_LOADL past that pointing outside the pool. */
+  if (s->irep->plen == 0xffff) {
+    codegen_error(s, "too many literals");
+  }
   if (s->irep->plen == s->pcapa) {
     s->pcapa *= 2;
     s->pool = (mrc_pool_value*)mrc_realloc(s->c, s->pool, sizeof(mrc_pool_value)*s->pcapa);

--- a/mrbgems/mruby-compiler/src/codegen.c
+++ b/mrbgems/mruby-compiler/src/codegen.c
@@ -1311,6 +1311,18 @@ new_sym(mrc_codegen_scope *s, mrc_sym sym)
   for (i=0; i<len; i++) {
     if (s->syms[i] == sym) return i;
   }
+  {
+    /* The dump writes a symbol name's length in 16 bits, and then walks the
+       cursor by the truncated count while copying the name in full, so a
+       longer name leaves the rest of the symbol block written over itself.
+       0xffff is one short of that, and spoken for: it is the length the dump
+       writes for a null symbol (MRC_DUMP_NULL_SYM_LEN), so a name that long
+       is read back as no symbol at all. */
+    mrc_int nlen = 0;
+    if (mrc_sym_name_len(s->c, sym, &nlen) && nlen >= MRC_DUMP_NULL_SYM_LEN) {
+      codegen_error(s, "symbol name too long");
+    }
+  }
   if (s->irep->slen >= s->scapa) {
     s->scapa *= 2;
     if (s->scapa > 0xffff) {

--- a/mrbgems/mruby-compiler/src/codegen.c
+++ b/mrbgems/mruby-compiler/src/codegen.c
@@ -1562,6 +1562,12 @@ new_lit_str(mrc_codegen_scope *s, const char *str, mrc_int len)
   int i;
   mrc_pool_value *pv;
 
+  /* The dump writes a pool string's length in 16 bits, so a longer one is
+     recorded truncated while its bytes are written in full, and every field
+     after it is read from the wrong offset. */
+  if (len > UINT16_MAX) {
+    codegen_error(s, "string literal too long");
+  }
   for (i=0; i<s->irep->plen; i++) {
     pv = &s->pool[i];
     if (pv->tt & IREP_TT_NFLAG) continue;

--- a/mrbgems/mruby-eval/test/eval.rb
+++ b/mrbgems/mruby-eval/test/eval.rb
@@ -65,6 +65,15 @@ assert 'eval deeply nested input does not crash the parser' do
   end
 end
 
+assert 'eval a string literal at the width of the pool length' do
+  # The dump records a pool string's length in 16 bits, so 65535 bytes is the
+  # longest one that survives the round trip into an mrb_irep.
+  assert_equal 65535, eval('"' + 'x' * 65535 + '"').size
+  assert_raise(SyntaxError) do
+    eval('"' + 'x' * 65536 + '"')
+  end
+end
+
 assert('String instance_eval') do
   obj = Object.new
   obj.instance_eval{ @test = 'test' }

--- a/mrbgems/mruby-eval/test/eval.rb
+++ b/mrbgems/mruby-eval/test/eval.rb
@@ -74,6 +74,16 @@ assert 'eval a string literal at the width of the pool length' do
   end
 end
 
+assert 'eval a symbol name at the width of the symbol length' do
+  # The dump records a symbol name's length in 16 bits too, and 0xffff of them
+  # is the length it writes for a null symbol, so 65534 bytes is the longest
+  # name that comes back as itself.
+  assert_equal 65534, eval(':"' + 'x' * 65534 + '"').to_s.size
+  assert_raise(SyntaxError) do
+    eval(':"' + 'x' * 65535 + '"')
+  end
+end
+
 assert('String instance_eval') do
   obj = Object.new
   obj.instance_eval{ @test = 'test' }


### PR DESCRIPTION
The RITE record keeps three counts in a `uint16_t`, and the compiler checks two of them. `new_sym()` refuses the symbol past the end of `slen`:

```c
  if (s->irep->slen >= s->scapa) {
    s->scapa *= 2;
    if (s->scapa > 0xffff) {
      codegen_error(s, "too many symbols");
    }
```

and `new_litbint()` refuses a magnitude past its own length byte:

```c
  plen = strlen(p);
  if (plen > 255) {
    codegen_error(s, "integer too big");
  }
```

Three more fields have no such check, and each of them is a defect of its own on a stock 64-bit `build_config/default.rb`.

## 1. The pool count wraps, and the VM runs off the pool

`plen` is 16 bits in `mrc_irep` as well as in the record. `lit_pool_extend()` grows against `pcapa`, which is 32 bits, so once `plen` wraps to zero the two are never equal again: nothing reallocates, the pool is written over from the start, and the count that reaches the dump is a few thousand while `OP_LOADL` still names indices above it.

```console
$ build/host/bin/mruby -e 'eval("[" + (0...70000).map { |i| "\"%06d\"" % i }.join(",") + "]")'
$ echo $?
139
```

## 2. A string literal of 65536 bytes is written whole under a truncated length

```c
      len = irep->pool[pool_no].tt>>2;
      mrc_assert_int_fit(mrc_int, len, uint16_t, UINT16_MAX);
      cur += mrc_uint16_to_bin((uint16_t)len, cur); /* data length */
      memcpy(cur, ptr, (size_t)len);
```

`mrc_assert_int_fit` is `((void)0)` unless `MRC_DEBUG`, so a release build writes a record it then refuses to load, and the loader reads every field after the string from the wrong offset:

```console
$ ruby -e "puts 's = \"' + ('a' * 65536) + '\"'" > big.rb
$ build/host/bin/mruby big.rb
$ echo $?
1
```

That is silent today; with #7204 it says `irep load error`. An `MRC_DEBUG` build stops on the assertion instead, so `ci/gcc-clang`'s `full-debug` aborts on the same file.

## 3. A symbol name that wide is read back as a different symbol, or as none

`write_syms_block()` copies the name in full and then advances the cursor by the truncated count, so the rest of the symbol block is written over itself. 0xffff is not available either: that is the length the dump writes for a null symbol. Neither case says anything, and neither is a failure at all from the outside:

```console
$ build/host/bin/mruby -e 'p eval(%q{:"} + "x" * 70000 + %q{"}).to_s.size'
4464
$ build/host/bin/mruby -e 'p eval(%q{:"} + "x" * 65535 + %q{"}).to_s.size'
-e:1: undefined method 'size' for  (NoMethodError)
```

70000 comes back as its first 4464 bytes, and 65535 as no symbol at all.

## The change

One `codegen_error()` per field, where the value enters the structure the dump walks. The boundaries are what the format can carry:

| | longest that works | first that is refused |
| --- | --- | --- |
| pool entries in one irep | 65535 | 65536, `too many literals` |
| string literal | 65535 bytes | 65536, `string literal too long` |
| symbol name | 65534 bytes | 65535, `symbol name too long` |

```console
$ build/host/bin/mruby big.rb                    # a 65536-byte string literal
big.rb:1: string literal too long
$ build/host/bin/mruby bigsym.rb                 # a 65535-byte symbol name
bigsym.rb:1: symbol name too long
$ build/host/bin/mruby ok.rb                     # 65535 bytes, prints its size
65535
$ build/host/bin/mruby oksym.rb                  # 65534 bytes, prints its size
65534
```

Reported as `codegen_error()` does it, so `eval` raises `SyntaxError` with the message the way it already does for `too many symbols`.

## Tests

`mrbgems/mruby-eval/test/eval.rb` gains one assertion per boundary, next to `eval deeply nested input does not crash the parser`, which is where a compiler limit is already asked about. Each writes the longest value that works beside the first one that is refused, so a boundary off by one fails.

The pool count has none. The shortest program that reaches it is 65536 distinct literals, and `new_lit_str()` scans the pool it has so far for each, so compiling it takes around ten seconds. Its boundary was checked by hand.

Reverting the two guards turns both new assertions red rather than dropping them: the string case raises `ScriptError` instead of `SyntaxError`, and the symbol case raises nothing at all.

## Verification

`rake -m test`, every build green, 0 KO, 0 crash, no new warnings. Each build gains the 2 new assertions.

| build | master | with this branch |
| --- | --- | --- |
| ci/gcc-clang full-debug | 2312 tests, 3 skip | 2314 tests, 3 skip |
| ci/gcc-clang bintest | 2312 tests, 11 skip, plus 117 bintests | 2314 tests, 11 skip, plus 117 bintests |
| ci/gcc-clang cxx_abi | 2312 tests, 11 skip | 2314 tests, 11 skip |
| ci/gcc-clang byte-string | 2243 tests, 48 skip | 2245 tests, 48 skip |
| ci/gcc-clang ascii-case | 2309 tests, 13 skip | 2311 tests, 13 skip |
| host-m32, `-m32`, full-core | 2292 tests, 4 skip | 2294 tests, 4 skip |
| host-i32, `-DMRB_INT32 -DMRB_NO_BOXING`, full-core | 2292 tests, 12 skip | 2294 tests, 12 skip |

Each commit was run green on its own over `build_config/default.rb`; the table is the branch tip. `full-debug` carries `MRC_DEBUG`, so its assertions are now unreachable rather than merely unfired.

The lookup added to `new_sym()` costs nothing measurable. `mrbc` over 20000 distinct symbols in one irep, best of 5: 992 ms on master, 968 ms here. That path is dominated by the linear scan `new_sym()` already does.

<details>
<summary>The 32-bit build configurations</summary>

`build_config/host-m32.rb` needs a multilib gcc this machine has no `-m32` runtime for, so an `i686-linux-gnu-gcc` cross toolchain stands in for it.

```ruby
MRuby::Build.new('host-m32') do |conf|
  toolchain :gcc
  conf.cc.command = 'i686-linux-gnu-gcc'
  conf.cxx.command = 'i686-linux-gnu-g++'
  conf.linker.command = 'i686-linux-gnu-gcc'
  conf.archiver.command = 'i686-linux-gnu-gcc-ar'

  conf.gembox 'full-core'

  conf.cc.flags << '-m32'
  conf.linker.flags << '-m32'

  conf.enable_debug
  conf.enable_test
end
```

`host-i32` is the host gcc with `conf.gembox 'full-core'` and `MRB_INT32` and `MRB_NO_BOXING` in `conf.cc.defines`.

</details>

### Environment

<details>
<summary>Versions</summary>

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS, Linux 7.0.0-28-generic x86_64 |
| CPU | AMD Ryzen 9 5950X, 16 cores |
| C compiler | gcc 13.3.0 and i686-linux-gnu-gcc 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1) |
| Linker | GNU ld 2.47.20260726, GNU ld 2.42 for i686, and `g++` for `cxx_abi` |
| CRuby | 4.0.6 (2026-07-14) +PRISM, running rake and generating the test programs |

</details>

<details>
<summary>Compile lines for codegen.c</summary>

`-MMD -c`, `-I` and `-o` dropped. Each build compiles the file twice, once for the internal `mrbc` and once for the VM's own compiler; the `-DMRB_NO_GEMS` line of each pair is left out here.

```console
# ci/gcc-clang full-debug, -O0 because enable_debug appends -g3 -O0
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DMRC_DEBUG -DMRC_DUMP_PRETTY -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-compiler/src/codegen.c

# ci/gcc-clang bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK mrbgems/mruby-compiler/src/codegen.c

# ci/gcc-clang cxx_abi, gcc -x c++ rather than g++, which only links
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-compiler/src/codegen.c

# ci/gcc-clang byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-compiler/src/codegen.c

# ci/gcc-clang ascii-case
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CASE -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-compiler/src/codegen.c

# host-m32
i686-linux-gnu-gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -m32 -g3 -O0 -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DMRC_DEBUG -DMRC_DUMP_PRETTY -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-compiler/src/codegen.c

# host-i32
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_INT32 -DMRB_NO_BOXING -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-compiler/src/codegen.c

# build_config/default.rb, where the transcripts above were run
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK mrbgems/mruby-compiler/src/codegen.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for oversized string literals, symbol names, and literal pools during compilation.
  * Compilation now reports clear errors when supported serialization limits are exceeded.

* **Tests**
  * Added coverage for maximum-length literals and symbols.
  * Added checks confirming that inputs beyond supported limits raise a syntax error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->