### PR TITLE
load.c: reject undersized binary_size in read_binary_header

### DIFF
--- a/src/load.c
+++ b/src/load.c
@@ -676,7 +676,7 @@ read_binary_header(const uint8_t *bin, size_t bufsize, size_t *bin_size, uint8_t
 
   *bin_size = (size_t)bin_to_uint32(header->binary_size);
 
-  if (bufsize < *bin_size) {
+  if (*bin_size < sizeof(struct rite_binary_header) || bufsize < *bin_size) {
     return MRB_DUMP_READ_FAULT;
   }
 


### PR DESCRIPTION
The .mrb loader takes binary_size straight from the file header, and read_binary_header only checks it against the caller's buffer size, never against the size of the header itself. read_irep then subtracts sizeof(struct rite_binary_header) from that value unconditionally, so a binary_size below the 20-byte header wraps bin_size (a size_t) around to a huge number, the section-walk loop is entered, and bin_to_uint32 reads the section header past the end of the buffer. It is reachable from mrb_load_irep_buf with a 20-byte input whose binary_size is zero; AddressSanitizer reports a heap-buffer-overflow read at load.c:710. I ran into it feeding truncated headers through the buffer entry point rather than the file one, which already rejects this case with its buf_size <= header_size check. Putting the guard in read_binary_header covers every caller of the buffer path, and valid files are unaffected because a real binary_size is always larger than the header.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved binary validation by rejecting files with invalid declared sizes smaller than their headers.
  * Continued to reject files whose actual contents are shorter than the declared size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->