### PR TITLE
mruby-regexp: hold a character class's ranges sorted and free of overlaps

### DIFF
--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -191,31 +191,79 @@ class_get_bit(const re_charclass *cc, uint8_t ch)
   return (cc->bitmap[ch >> 3] >> (ch & 7)) & 1;
 }
 
-/* Append a non-ASCII codepoint range [lo, hi]. Both bounds must be >= 128. */
+/* Add a non-ASCII codepoint range [lo, hi]. Both bounds must be >= 128.
+
+   The list is held sorted by `lo`, with no two entries that overlap or touch.
+   A range the class already covers then costs nothing to add again: the
+   search below finds the entry holding it and widens that one where it has
+   to, rather than appending a second entry naming what the first already
+   accepts. Merging with the entry appended last left that to scan order, and
+   closing a class under folding has none: the folds of [U+0080-U+2FFF] land
+   inside the range that was written, and each of them appended an entry that
+   range already covered, 527 of them for that class alone.
+
+   Sorting them is the same answer at match time, where class_match() reads
+   the list through, and at emit time, where every entry is bytecode.
+
+   A byte range carries RE_CLASS_BYTE in both bounds, which is the top bit, so
+   the tagged entries sort above every codepoint and no gap of one can close
+   between the two kinds. */
 static void
 class_add_range(re_compiler *c, re_charclass *cc, uint32_t lo, uint32_t hi)
 {
-  /* Merge with the previous range when the new one is contiguous with or
-     overlaps it. Codepoints are appended in scan order, so an ascending run
-     (the common case, e.g. a long [...] enumeration) collapses to a single
-     range instead of one entry per codepoint. */
-  if (cc->num_ranges > 0) {
-    uint32_t *last = &cc->ranges[2 * (cc->num_ranges - 1)];
+  uint32_t n = cc->num_ranges;
+
+  /* Within one walk the ranges arrive ascending, so the entry standing
+     highest is usually the one the next range joins. Nothing stands above it
+     to close a gap to, which is what lets it be widened where it is. */
+  if (n > 0) {
+    uint32_t *last = &cc->ranges[2 * (n - 1)];
     if (lo >= last[0] && lo <= last[1] + 1) {
       if (hi > last[1]) last[1] = hi;
       return;
     }
   }
-  if (cc->num_ranges >= cc->range_capa) {
+
+  /* The first entry that reaches [lo, hi] or begins after it: everything
+     before it ends more than one below `lo` and cannot join. */
+  uint32_t i = 0, j = n;
+  while (i < j) {
+    uint32_t mid = i + (j - i) / 2;
+    if (cc->ranges[2 * mid + 1] + 1 < lo) i = mid + 1;
+    else j = mid;
+  }
+
+  if (i < n && cc->ranges[2 * i] <= hi + 1) {
+    /* It joins entry i. Widening it can close the gap to the entries above,
+       so they are swallowed and what is left of the list is closed up. */
+    uint32_t *r = &cc->ranges[2 * i];
+    if (lo < r[0]) r[0] = lo;
+    if (hi > r[1]) r[1] = hi;
+    uint32_t k = i + 1;
+    while (k < n && cc->ranges[2 * k] <= r[1] + 1) {
+      if (cc->ranges[2 * k + 1] > r[1]) r[1] = cc->ranges[2 * k + 1];
+      k++;
+    }
+    if (k > i + 1) {
+      memmove(&cc->ranges[2 * (i + 1)], &cc->ranges[2 * k],
+              sizeof(uint32_t) * 2 * (n - k));
+      cc->num_ranges = n - (k - i - 1);
+    }
+    return;
+  }
+
+  if (n >= cc->range_capa) {
     /* range_capa/num_ranges are uint32_t: doubling from 32768 no longer
        wraps to 0 (which fed a size-0 realloc and a write through NULL). */
     uint32_t new_capa = cc->range_capa ? cc->range_capa * 2 : 4;
     cc->ranges = (uint32_t*)mrb_realloc(c->mrb, cc->ranges, sizeof(uint32_t) * 2 * new_capa);
     cc->range_capa = new_capa;
   }
-  cc->ranges[2 * cc->num_ranges] = lo;
-  cc->ranges[2 * cc->num_ranges + 1] = hi;
-  cc->num_ranges++;
+  memmove(&cc->ranges[2 * (i + 1)], &cc->ranges[2 * i],
+          sizeof(uint32_t) * 2 * (n - i));
+  cc->ranges[2 * i] = lo;
+  cc->ranges[2 * i + 1] = hi;
+  cc->num_ranges = n + 1;
 }
 
 /* Add a single non-ASCII codepoint to the class. */
@@ -257,6 +305,25 @@ class_add_fold_counterparts(re_compiler *c, uint16_t id, uint32_t cp)
 }
 
 #ifdef RE_UNICODE_CASE
+/* The part of the class at or above `cp`, as the first range holding a member
+   that high. FALSE where the class holds none. The list is sorted, so this is
+   a search rather than a scan, and it answers against the list as it stands
+   rather than against a position taken before it moved. */
+static mrb_bool
+class_next_range(const re_charclass *cc, uint32_t cp, uint32_t *lo, uint32_t *hi)
+{
+  uint32_t n = cc->num_ranges, i = 0, j = n;
+  while (i < j) {
+    uint32_t mid = i + (j - i) / 2;
+    if (cc->ranges[2 * mid + 1] < cp) i = mid + 1;
+    else j = mid;
+  }
+  if (i >= n) return FALSE;
+  *lo = cc->ranges[2 * i] > cp ? cc->ranges[2 * i] : cp;
+  *hi = cc->ranges[2 * i + 1];
+  return TRUE;
+}
+
 /* Closure for the range walks, which report counterpart spans one at a time.
    A span can straddle 128 (U+017F folds to 's'), so it is split the same way
    a written range is. */
@@ -748,15 +815,25 @@ compile_charclass(re_compiler *c)
        the first already added. */
     class_fold_sink sink = { c, cc };
 
-    /* Round one: the fold of every member joins the class. The codepoint list
-       is read from a snapshot of its length, since the additions append to
-       the same list and an unbounded walk would keep folding what it just
-       added. */
-    uint32_t nranges = cc->num_ranges;
-    for (uint32_t i = 0; i < nranges; i++) {
-      if (cc->ranges[2 * i] & RE_CLASS_BYTE) continue;
-      mrb_uni_case_fold_range(cc->ranges[2 * i], cc->ranges[2 * i + 1],
-                             class_fold_add, &sink);
+    /* Round one: the fold of every member joins the class. Both rounds walk
+       the list by codepoint rather than by index, since class_add_range()
+       inserts where the order puts an entry and an index would name a
+       different entry after one did. A walk that starts each step above the
+       range it just handed over reaches every entry the round began with, and
+       terminates whatever the additions do.
+
+       What it may skip is an entry inserted behind the cursor, and neither
+       round has anything to say about one. Folding is idempotent, so the fold
+       of a fold this round added is the fold itself; and nothing folds to a
+       character that folds elsewhere, so a source the next round adds has no
+       source of its own. */
+    for (uint32_t cp = 0;;) {
+      uint32_t lo, hi;
+      /* The tagged byte ranges sort above every codepoint, so the first one
+         reached ends the walk rather than being stepped over. */
+      if (!class_next_range(cc, cp, &lo, &hi) || (lo & RE_CLASS_BYTE)) break;
+      mrb_uni_case_fold_range(lo, hi, class_fold_add, &sink);
+      cp = hi + 1;
     }
     for (int ch = 'A'; ch <= 'Z'; ch++) {
       if (class_get_bit(cc, (uint8_t)ch)) class_set_bit(cc, (uint8_t)(ch + 32));
@@ -766,11 +843,11 @@ compile_charclass(re_compiler *c)
        upwards, so the upper case letter set here is behind the cursor and is
        never asked for sources of its own, which is correct: nothing folds to
        an upper case letter. */
-    nranges = cc->num_ranges;
-    for (uint32_t i = 0; i < nranges; i++) {
-      if (cc->ranges[2 * i] & RE_CLASS_BYTE) continue;
-      mrb_uni_case_unfold_range(cc->ranges[2 * i], cc->ranges[2 * i + 1],
-                               class_fold_add, &sink);
+    for (uint32_t cp = 0;;) {
+      uint32_t lo, hi;
+      if (!class_next_range(cc, cp, &lo, &hi) || (lo & RE_CLASS_BYTE)) break;
+      mrb_uni_case_unfold_range(lo, hi, class_fold_add, &sink);
+      cp = hi + 1;
     }
     for (int ch = 0; ch < 128; ch++) {
       if (!class_get_bit(cc, (uint8_t)ch)) continue;

--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -839,22 +839,32 @@ compile_charclass(re_compiler *c)
       if (class_get_bit(cc, (uint8_t)ch)) class_set_bit(cc, (uint8_t)(ch + 32));
     }
 
-    /* Round two: every source of a member joins it too. The bitmap is walked
-       upwards, so the upper case letter set here is behind the cursor and is
-       never asked for sources of its own, which is correct: nothing folds to
-       an upper case letter. */
+    /* Round two: every source of a member joins it too. */
     for (uint32_t cp = 0;;) {
       uint32_t lo, hi;
       if (!class_next_range(cc, cp, &lo, &hi) || (lo & RE_CLASS_BYTE)) break;
       mrb_uni_case_unfold_range(lo, hi, class_fold_add, &sink);
       cp = hi + 1;
     }
+    /* An ASCII member can have a non-ASCII source (U+212A folds to 'k'),
+       which the range walk cannot reach: the bitmap holds no ranges. A run of
+       set bits is asked about in one question, since a question costs a walk
+       of the tables whatever it spans. The tables hold no ASCII source, ASCII
+       being what they are the rest of, so nothing this walk finds lands in
+       the bitmap and no run of it grows while it is being read. */
     for (int ch = 0; ch < 128; ch++) {
       if (!class_get_bit(cc, (uint8_t)ch)) continue;
-      if (ch >= 'a' && ch <= 'z') class_set_bit(cc, (uint8_t)(ch - 32));
-      /* An ASCII member can have a non-ASCII source (U+212A folds to 'k'),
-         which the range walk cannot reach: the bitmap holds no ranges. */
-      mrb_uni_case_unfold_range((uint32_t)ch, (uint32_t)ch, class_fold_add, &sink);
+      int end = ch;
+      while (end + 1 < 128 && class_get_bit(cc, (uint8_t)(end + 1))) end++;
+      mrb_uni_case_unfold_range((uint32_t)ch, (uint32_t)end, class_fold_add, &sink);
+      ch = end;
+    }
+    /* The upper case letter of a lower case member is the source the tables
+       do not hold, so it is set here. Nothing folds to an upper case letter,
+       which is what lets this come after the walk above rather than adding to
+       what that walk is asked about. */
+    for (int ch = 'a'; ch <= 'z'; ch++) {
+      if (class_get_bit(cc, (uint8_t)ch)) class_set_bit(cc, (uint8_t)(ch - 32));
     }
 #else
     /* The same closure, restricted to the foldings this build has. Refusing

--- a/mrbgems/mruby-regexp/test/regexp_utf8.rb
+++ b/mrbgems/mruby-regexp/test/regexp_utf8.rb
@@ -358,6 +358,30 @@ assert("Regexp - UTF-8 codepoints in character class") do
   assert_equal 0, ("₅" =~ /[a-z₀-₉]/)
 end
 
+assert("Regexp - a class holds the union of its ranges however they are written") do
+  # The ranges are held sorted and free of overlaps, so writing one inside
+  # another, writing a pair the wrong way round, or naming the same member
+  # twice all come to the class the union spells once. What it takes for that
+  # to hold is a search: only the range written last used to be widened, so
+  # anything written out of order was kept as a second entry naming what the
+  # first already accepted.
+  skip unless __ENCODING__ == "UTF-8"
+  [/[Ā-Ȁ]/, /[ƀ-ȀĀ-Ɛ]/,
+   /[Ā-Őő-Ȁ]/, /[Ā-ȀĠ-İ]/,
+   /[ȀĀ-ȀĀ]/].each do |re|
+    assert_equal 0, ("Ā" =~ re)
+    assert_equal 0, ("Ő" =~ re)
+    assert_equal 0, ("Ȁ" =~ re)
+    assert_nil ("ÿ" =~ re)
+    assert_nil ("ȁ" =~ re)
+    assert_nil ("a" =~ re)
+    # The negation reads the same class, so it draws the same boundary.
+    neg = Regexp.new("[^" + re.source[1..-1])
+    assert_nil ("Ő" =~ neg)
+    assert_equal 0, ("ȁ" =~ neg)
+  end
+end
+
 assert("Regexp - quantifier over multi-byte char class") do
   assert_equal "a#b#c", "a₀₁b₂c".gsub(/[₀-₉]+/, "#")
   assert_equal ["₀₁₂"], "₀₁₂".scan(/[₀-₉]+/)


### PR DESCRIPTION
Closing a character class under case folding for `/i` builds the ranges it then reads, and it read them the slowest way there is.

### What it costs

`class_add_range()` merged a new range only with the entry appended last, so what collapsed depended on the order the entries arrived in. A written class arrives in scan order and collapses well. The closure has no order at all: the folds of a range land back inside it and outside it by turns, and once one of them is appended above the range, every fold that follows lands below the entry standing last and is appended as a second entry naming what the first already accepts.

`/[\^@-\u2FFF]/i` is one written range. It left **527** entries after the round that adds the folds, and **1545** after the round that adds their sources. Both rounds walk the two case tables once per entry, so the entries the closure made are what the closure then reads.

The second commit is a smaller version of the same thing. An ASCII member can have a source outside ASCII, U+212A folding to `k` and U+017F to `s`, and the bitmap holds no ranges for the range walk to find those through, so the closure asked about every set bit on its own. A question costs a walk of both tables whatever it spans, and a class of 38 ASCII members paid 38 walks to learn about two characters.

### What changes

The range list is held sorted by `lo`, with no two entries that overlap or touch. A range the class already covers is then found and dropped rather than appended, and `/[\^@-\u2FFF]/i` closes to **10** entries. The entry standing highest is still checked before the search, since within one walk the ranges arrive ascending and that is the entry they join.

The two rounds then walk by codepoint rather than by index, an index no longer naming the same entry once an insertion moved it. A walk that resumes above the range it just handed over reaches every entry the round began with. What it may skip is an entry inserted behind it, and neither round has anything to say about one: folding is idempotent, so the fold of a fold the first round added is that fold, and nothing folds to a character that folds elsewhere, so a source the second round adds has no source of its own.

The ASCII bitmap is asked about a run of set bits at a time. The tables hold no ASCII source, ASCII being what they are the rest of, so nothing that walk finds lands in the bitmap and no run of it grows while it is being read.

Nothing here changes which characters a class holds.

### Speed

Instructions to compile one pattern under `/i`, callgrind on `bin/mruby`, as `Ir(2N) - Ir(N)` so the startup cancels. Every build below is a clean one. `perf` is not available on this machine and its wall clock moves by up to 80% between runs of the same binary, so the instruction count is the measurement rather than a check on one.

| pattern | master | first commit | this PR |
| ------- | -----: | -----------: | ------: |
| `[\^@-\u2FFF]` | 5,665,853 | 441,861 | 442,411 |
| `[\u0100-\u04FF]` | 2,229,149 | 290,907 | 291,440 |
| `[\u0400-\u04FF\u0100-\u017F]` | 1,502,007 | 113,868 | 114,348 |
| `[a-z0-9_]` | 382,946 | 383,251 | 54,786 |
| `[[:alpha:]]` | 530,353 | 530,463 | 47,375 |
| `[\^@-\uFFFF]` | 334,078 | 339,730 | 340,288 |
| `[\^@-\u{10FFFF}]` | 355,105 | 360,853 | 361,411 |
| `abc` | 42,057 | 42,053 | 42,058 |

The last two classes grow by under 2%. Their folds all land inside what was written, so the merge with the last entry already collapsed them to a single range, and what they pay is the search that finds it.

The shorter list is also what `class_match()` reads, once per character the bitmap cannot answer for:

| | master | this PR |
| --- | ---: | ---: |
| `/[\^@-\u2FFF]/i` over 2,000 characters holding no member | 32,299,368 | 1,604,305 |

### Generated code

`.text` over every `.o`, each side built from an empty build directory, for the five builds `ci/gcc-clang` makes. Their compile lines are under Environment at the end: `full-debug` is `-O0`, the other four are `-O3`.

| build | master | this PR |
| --- | ---: | ---: |
| full-debug | 3,474,822 | 3,475,609 (+787) |
| bintest | 2,351,723 | 2,351,555 (-168) |
| cxx_abi | 2,356,881 | 2,356,633 (-248) |
| byte-string | 2,285,149 | 2,285,517 (+368) |
| ascii-case | 2,311,380 | 2,311,748 (+368) |

`class_add_range()` grows into a search and an insertion, and the two builds that fold `/i` by Unicode get that back from the per-bit loop going away. `byte-string` and `ascii-case` fold `/i` without the tables and have no such loop to lose, so they carry the search alone.

### Testing

`rake -m test` over `ci/gcc-clang` from an empty build directory, all five builds green, 0 KO, 0 crash, no new warnings:

| build | result |
| --- | --- |
| full-debug | 2313 tests, 2310 OK, 3 skip |
| bintest | 2313 tests, 2302 OK, 11 skip, plus 117 bintests |
| cxx_abi | 2313 tests, 2302 OK, 11 skip |
| byte-string | 2244 tests, 2195 OK, 49 skip |
| ascii-case | 2310 tests, 2297 OK, 13 skip |

`rake -m test` over `build_config/asan.rb` is green too, address and undefined sanitizers both: 2313 tests, 2310 OK, 3 skip, plus 79 bintests. The insertion and the memmove behind it are what to run it for.

The new test pins the class rather than the list, since holding the ranges another way has to come to the same members:

```ruby
[/[Ā-Ȁ]/, /[ƀ-ȀĀ-Ɛ]/,
 /[Ā-Őő-Ȁ]/, /[Ā-ȀĠ-İ]/,
 /[ȀĀ-ȀĀ]/].each do |re|
  assert_equal 0, ("Ā" =~ re)
  assert_equal 0, ("Ő" =~ re)
  assert_equal 0, ("Ȁ" =~ re)
  assert_nil ("ÿ" =~ re)
  assert_nil ("ȁ" =~ re)
end
```

Against master over 3,000 randomly built `/i` classes, each asked about the same 300 subjects, the answers are identical: 900,000 comparisons spanning Latin, Greek, Cyrillic, Armenian, Georgian, Cherokee, Deseret, Osage and the fullwidth forms, the characters that fold across the ASCII boundary, the ones whose fold spells several characters, negated classes and classes written out of order. Identical under the sanitizers as well.

### Environment

<details>
<summary>Versions, and the compile line of every build named above</summary>

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS, Linux 7.0.0-28-generic x86_64 |
| CPU | AMD Ryzen 9 5950X, 16 cores |
| C compiler | gcc 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1) |
| Sanitizer compiler | clang 22.1.8 (Homebrew), which is what `build_config/asan.rb` picks |
| Linker | GNU ld 2.47.20260726, and `g++` for `cxx_abi` |
| Profiler | valgrind 3.27.1, callgrind |
| CRuby | 4.0.6 (2026-07-14) +PRISM, running rake |

The timings and the instruction counts were taken on a build that is not one of the shipped configs, `full-core` at `-O3` with nothing else on it:

```ruby
MRuby::Build.new('perf-utf8') do |conf|
  conf.toolchain :gcc
  conf.gembox 'full-core'
  conf.cc.flags = %w(-O3 -g -std=gnu99 -Wall -Wundef)
  conf.enable_test
end
```

What each build actually compiles `mrbgems/mruby-regexp/src/re_compile.c` with, `-MMD -c`, the `-I` paths and `-o` stripped:

```console
# perf-utf8, the build every number above was taken on
gcc -O3 -g -std=gnu99 -Wall -Wundef -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang, full-debug
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang, bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK

# ci/gcc-clang, cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang, byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang, ascii-case
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CASE -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# build_config/asan.rb
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -fsanitize=address,undefined -g3 -O0 -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

`-g -O3` is what the `gcc` toolchain sets. `full-debug` and the sanitizer build then append `-g3 -O0` through `enable_debug()`, so those two are `-O0`, not `-O3`. `perf-utf8` replaces the toolchain's flags rather than appending to them. `cxx_abi` is the C compiler driven as C++ with `-x c++ -std=gnu++03`, and `g++` links it.

</details>

