### PR TITLE
string.c: write the case walk's answer into the buffer it is building

### DIFF
--- a/src/string.c
+++ b/src/string.c
@@ -2103,6 +2103,36 @@ case_kind_of(enum mrb_case_mode mode, mrb_bool first)
   }
 }
 
+/* Room in `o` for `need` more bytes past the `len` already written. The answer
+   is built with its length held apart from the string, so this grows the
+   buffer the way an append does without the questions an append from anywhere
+   has to ask: what is written here is this walk's own bytes, and where they
+   go is not somewhere the string can already be. */
+static char*
+case_out_room(mrb_state *mrb, struct RString *o, mrb_int len, mrb_int need)
+{
+  mrb_int capa = RSTR_CAPA(o);
+
+  if (capa - len < need) {
+    mrb_int want;
+    if (mrb_int_add_overflow(len, need, &want)) {
+      mrb_raise(mrb, E_ARGUMENT_ERROR, "string size too big");
+    }
+    while (capa < want) {
+      if (mrb_int_mul_overflow(capa, 2, &capa)) {
+        capa = want;
+        break;
+      }
+    }
+    /* Leaving the buffer takes the string's length with it, and what an
+       embedded string carries over is that many bytes: told nothing, it would
+       carry over none of what has been written so far. */
+    RSTR_SET_LEN(o, len);
+    resize_capa(mrb, o, capa);
+  }
+  return RSTR_PTR(o) + len;
+}
+
 /* Convert a string that holds characters the tables can speak about. A mapping
    changes how many bytes a character takes ("K" U+212A lower cases to the one
    byte of "k"), so the answer is built beside the string rather than over it,
@@ -2114,51 +2144,73 @@ str_case_convert_utf8(mrb_state *mrb, mrb_value str, enum mrb_case_mode mode)
   const char *p = RSTR_PTR(s);
   const char *pend = p + RSTR_LEN(s);
   mrb_value out = mrb_str_new_capa(mrb, RSTR_LEN(s));
+  struct RString *o = mrb_str_ptr(out);
+  mrb_int dlen = 0;
   mrb_bool modify = FALSE;
   mrb_bool ascii_only = TRUE;
   mrb_bool first = TRUE;
 
   while (p < pend) {
-    char buf[MRB_UNI_CASE_MAX_BYTES];
+    /* Room for whatever one character can map to, so neither branch below has
+       to ask again for the character it is about to write. */
+    char *d = case_out_room(mrb, o, dlen, MRB_UNI_CASE_MAX_BYTES);
+
+    if ((unsigned char)*p < 0x80) {
+      /* ASCII has no mapping to look up and takes one byte of the answer per
+         byte of the source, so a run of it is converted where it stands.
+         Reaching the tables for it, or the buffer through an append, is what
+         made a string of ASCII with one character among it cost as much per
+         byte as one made of characters. The run stops where the buffer does,
+         and the turn of the loop after it is what grows the buffer. */
+      const char *dend = RSTR_PTR(o) + RSTR_CAPA(o);
+      do {
+        int c = (unsigned char)*p++;
+        int r = ascii_case_conv(c, mode, first);
+        first = FALSE;
+        if (r != c) modify = TRUE;
+        *d++ = (char)r;
+      } while (p < pend && (unsigned char)*p < 0x80 && d < dend);
+      dlen = (mrb_int)(d - RSTR_PTR(o));
+      continue;
+    }
+
     const char *src = p;
     mrb_int clen;
     uint32_t cp = mrb_utf8_decode(p, pend, &clen);
     mrb_int n;
 
-    if (cp < 0x80) {
-      buf[0] = (char)ascii_case_conv((int)cp, mode, first);
-      n = 1;
+    /* A run of bytes that spells no character has no case to convert, and
+       answering as though it were the byte it starts with would hand back a
+       string neither its own reading nor the caller asked for. */
+    if (clen == 1) {
+      mrb_raise(mrb, E_ARGUMENT_ERROR, "input string invalid");
     }
-    else {
-      /* A run of bytes that spells no character has no case to convert, and
-         answering as though it were the byte it starts with would hand back a
-         string neither its own reading nor the caller asked for. */
-      if (clen == 1) {
-        mrb_raise(mrb, E_ARGUMENT_ERROR, "input string invalid");
-      }
-      n = mrb_uni_case_map(case_kind_of(mode, first), cp, buf);
-      /* A character with no mapping stands as it is. */
-      if (n == 0) {
-        memcpy(buf, src, (size_t)clen);
-        n = clen;
-      }
+    n = mrb_uni_case_map(case_kind_of(mode, first), cp, d);
+    /* A character with no mapping stands as it is. */
+    if (n == 0) {
+      memcpy(d, src, (size_t)clen);
+      n = clen;
     }
     p += clen;
     first = FALSE;
 
-    if (n != clen || memcmp(buf, src, (size_t)n) != 0) modify = TRUE;
+    if (n != clen || memcmp(d, src, (size_t)n) != 0) modify = TRUE;
+    /* Only what a mapping wrote can be asked about here: a character maps to
+       characters, and ASCII maps to ASCII, so the run above answers itself. */
     for (mrb_int i = 0; i < n; i++) {
-      if ((unsigned char)buf[i] & 0x80) ascii_only = FALSE;
+      if ((unsigned char)d[i] & 0x80) ascii_only = FALSE;
     }
-    mrb_str_cat(mrb, out, buf, n);
+    dlen += n;
   }
 
   if (!modify) return FALSE;
 
+  RSTR_SET_LEN(o, dlen);
+  RSTR_PTR(o)[dlen] = '\0';
+
   /* Every byte of the source spelled a character, since the walk refuses one
      that does not, and every mapping spells characters, so what was written
      is sound. Nothing but ASCII is the stronger answer where it holds. */
-  struct RString *o = mrb_str_ptr(out);
   RSTR_CODERANGE_SET(o, ascii_only ? MRB_STR_CODERANGE_7BIT
                                    : MRB_STR_CODERANGE_VALID);
   str_replace(mrb, s, o);

--- a/test/t/string.rb
+++ b/test/t/string.rb
@@ -394,6 +394,21 @@ assert('String#upcase - Unicode') do
   assert_nil '日本'.upcase!
 end if UNICODECASE
 
+assert('String#upcase - an answer that outgrows an embedded buffer') do
+  # U+0390 is two bytes and upper cases to six, so a string short enough to
+  # live inside its own object converts to one that cannot. The answer is
+  # built beside the string, and a buffer that leaves an object carries over
+  # what the object says it holds: the walk has to say how much it has
+  # written, or the bytes written so far are dropped where the buffer moves.
+  assert_equal "Ϊ́" * 4, ("ΐ" * 4).upcase
+  assert_equal 24, ("ΐ" * 4).upcase.bytesize
+  # The same crossing one character at a time, so wherever the boundary of an
+  # embedded string falls, some length below walks over it.
+  1.upto(12) do |n|
+    assert_equal "Ϊ́" * n, ("ΐ" * n).upcase
+  end
+end if UNICODECASE
+
 assert('String#chomp', '15.2.10.5.9') do
   a = 'abc'.chomp
   b = ''.chomp


### PR DESCRIPTION
A string with one character above ASCII in it is converted a character at a time through an append, and that is what the whole string costs.

### What it costs

`str_case_convert_utf8()` builds the answer beside the string, since a mapping changes how many bytes a character takes, and it appended what it made of every character with `mrb_str_cat()`. An append from anywhere has questions to ask that an append of one's own bytes does not: it checks the length for overflow, works out whether the source overlaps the string, modifies the string, and carries the coderange across. Every character paid all of that, and every character was read through `mrb_utf8_decode()` first, ASCII included.

`String#downcase`, `#upcase`, `#capitalize` and `#swapcase` each keep an ASCII loop of their own and reach this walk only where the string holds more, so a string of ASCII with one character above it in the middle is walked whole. Over 100,000 characters that is **194 instructions per character**, where the ASCII loop those methods kept costs **9.5**.

### What changes

The walk writes into the buffer and holds the length beside it, so what it asks the string for is room for one more character's mapping, and only where fewer than that many bytes are left. A run of ASCII is converted where it stands, needing neither the decoder nor the tables.

The result is the same string. The coderange it records, the `nil` the bang forms answer with when nothing changed, and the `ArgumentError` for bytes that spell no character are all where they were.

### Speed

Instructions per call, callgrind on `bin/mruby`, as `Ir(2N) - Ir(N)` so the startup cancels. Every build is a clean one. `perf` is not available on this machine and its wall clock moves by up to 80% between runs of the same binary, so the instruction count is the measurement rather than a check on one. Every string is 100,000 characters but the last:

| call | master | this PR |
| --- | ---: | ---: |
| `downcase`, all ASCII, where the walk is not reached | 946,016 | 946,000 |
| `downcase`, one character above ASCII | 19,448,454 | 1,748,005 |
| `upcase`, one character above ASCII | 19,548,601 | 1,748,131 |
| `swapcase`, one character above ASCII | 19,449,096 | 1,948,469 |
| `capitalize`, one character above ASCII | 19,248,471 | 1,548,007 |
| `downcase`, 50,000 of U+00C9 | 31,304,731 | 25,491,515 |
| `upcase`, 50,000 of U+00DF, whose mapping grows | 24,854,725 | 19,291,468 |
| `downcase`, four characters | 2,906 | 2,263 |

The first row is the loop this walk is not reached from, which is what says the walk is where the cost was. The two long non-ASCII rows keep the walk for every character and save the append alone.

### Generated code

`.text` over every `.o`, each side built from an empty build directory, for the five builds `ci/gcc-clang` makes. `src/string.o` is the only object that moves in any of them:

| build | master | this PR |
| --- | ---: | ---: |
| full-debug | 3,474,822 | 3,475,876 (+1,054) |
| bintest | 2,351,723 | 2,354,995 (+3,272) |
| cxx_abi | 2,356,881 | 2,359,489 (+2,608) |
| byte-string | 2,285,149 | 2,285,149 (±0) |
| ascii-case | 2,311,380 | 2,311,380 (±0) |

The 3,272 bytes are an inlining decision rather than code. The walk is smaller than the one it replaces, and gcc now inlines it into the callers where `mode` reaches it as a constant, which is what the bytes are:

| symbol in `src/string.o` | master | this PR |
| --- | ---: | ---: |
| `mrb_str_case_convert_unicode()` | 1,601 | 1,426 |
| `mrb_str_downcase_bang()` | 156 | 1,094 |
| `mrb_str_upcase_bang()` | 156 | 1,102 |
| `mrb_str_capitalize_bang()` | 227 | 1,286 |
| `mrb_str_downcase()` | 212 | 539 |
| `mrb_str_upcase()` | 212 | 539 |

The builds that carry it are the ones already carrying the case tables. A build whose strings index by byte, and one that converts case by ASCII, compile none of this and measure to the byte what master measures.

A version that writes one character per turn of the loop rather than a run of them costs 128 bytes on `bintest` instead of 3,272 and lands at 3,548,010 instructions for the second row above rather than 1,748,005. It is the same fix at half the recovery; this PR is the other choice.

### Testing

`rake -m test` over `ci/gcc-clang` from an empty build directory, all five builds green, 0 KO, 0 crash, no new warnings:

| build | result |
| --- | --- |
| full-debug | 2313 tests, 2310 OK, 3 skip |
| bintest | 2313 tests, 2302 OK, 11 skip, plus 117 bintests |
| cxx_abi | 2313 tests, 2302 OK, 11 skip |
| byte-string | 2243 tests, 2195 OK, 48 skip |
| ascii-case | 2309 tests, 2296 OK, 13 skip |

`rake -m test` over `build_config/asan.rb` is green too, address and undefined sanitizers both: 2313 tests, 2310 OK, 3 skip, plus 79 bintests. Writing into a buffer the walk grows itself is what to run it for.

The new test is for what building beside the string costs. A buffer that leaves an object carries over as many bytes as the object says it holds, and the walk holds its length apart from the string, so it has to say how much it has written or the bytes written so far are dropped where the buffer moves. U+0390 is two bytes and upper cases to six, so a string short enough to live inside its own object converts to one that cannot:

```ruby
assert_equal "Ϊ́" * 4, ("ΐ" * 4).upcase
assert_equal 24, ("ΐ" * 4).upcase.bytesize
1.upto(12) do |n|
  assert_equal "Ϊ́" * n, ("ΐ" * n).upcase
end
```

That assertion fails on the version of this commit that does not record the length, which is how the case was found in the first place.

Against master over 2,000 randomly built strings, each put through `downcase`, `upcase`, `capitalize` and `swapcase` and both of the bang forms, the answers are identical: the bytes, the length, `valid_encoding?` and whether the bang form said it changed anything. The strings are 0 to 300 characters, spanning the lengths on both sides of what fits inside an object, and are drawn from ASCII, Latin-1, Latin Extended, Greek, Cyrillic, the Roman numerals, the ligatures whose mapping spells several characters, the fullwidth forms, Deseret and Hiragana. Identical under the sanitizers as well.

### Environment

<details>
<summary>Versions, and the compile line of every build named above</summary>

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS, Linux 7.0.0-28-generic x86_64 |
| CPU | AMD Ryzen 9 5950X, 16 cores |
| C compiler | gcc 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1) |
| Sanitizer compiler | clang 22.1.8 (Homebrew), which is what `build_config/asan.rb` picks |
| Linker | GNU ld 2.47.20260726, and `g++` for `cxx_abi` |
| Profiler | valgrind 3.27.1, callgrind |
| CRuby | 4.0.6 (2026-07-14) +PRISM, running rake |

The instruction counts and the symbol sizes were taken on a build that is not one of the shipped configs, `full-core` at `-O3` with nothing else on it:

```ruby
MRuby::Build.new('perf-utf8') do |conf|
  conf.toolchain :gcc
  conf.gembox 'full-core'
  conf.cc.flags = %w(-O3 -g -std=gnu99 -Wall -Wundef)
  conf.enable_test
end
```

What each build actually compiles `src/string.c` with, `-MMD -c`, the `-I` paths and `-o` stripped:

```console
# perf-utf8, the build the instruction counts and symbol sizes come from
gcc -O3 -g -std=gnu99 -Wall -Wundef -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang, full-debug
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang, bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK

# ci/gcc-clang, cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang, byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang, ascii-case
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CASE -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# build_config/asan.rb
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -fsanitize=address,undefined -g3 -O0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

`-g -O3` is what the `gcc` toolchain sets. `full-debug` and the sanitizer build then append `-g3 -O0` through `enable_debug()`, so those two are `-O0`, not `-O3`. `perf-utf8` replaces the toolchain's flags rather than appending to them. `cxx_abi` is the C compiler driven as C++ with `-x c++ -std=gnu++03`, and `g++` links it.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UTF-8 Unicode uppercase conversion for strings requiring expanded output.
  * Invalid UTF-8 input is now rejected consistently during case conversion.
  * Improved handling of ASCII and mixed Unicode text during uppercase conversion.

* **Tests**
  * Added regression coverage for uppercase conversions that expand string length across multiple input sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->