### PR TITLE
mruby-bigint: normalize the result of `mrb_bint_pow()`

### DIFF
--- a/mrbgems/mruby-bigint/core/bigint.c
+++ b/mrbgems/mruby-bigint/core/bigint.c
@@ -5946,8 +5946,7 @@ mrb_bint_pow(mrb_state *mrb, mrb_value x, mrb_value y)
   MPZ_CTX_INIT(mrb, ctx, pool);
   mpz_pow(ctx, &z, &a, exp);
 
-  struct RBigint *b = bint_new(ctx, &z);
-  return mrb_obj_value(b);
+  return bint_norm(mrb, bint_new(ctx, &z));
 }
 
 mrb_value

--- a/mrbgems/mruby-bigint/test/bigint.rb
+++ b/mrbgems/mruby-bigint/test/bigint.rb
@@ -192,6 +192,16 @@ assert 'Bigint pow' do
   n = 1<<65
   assert_equal n, n ** 1
   assert_equal 1, n ** 0
+
+  # `**` compares by value and passes either way; the result must also be
+  # demoted to a fixnum Integer, or `eql?` and `hash` disagree with it.
+  one = n ** 0
+  assert_true one.eql?(1)
+  assert_true 1.eql?(one)
+  assert_equal 1.hash, one.hash
+  h = {}
+  200.times { |i| h[i] = i }
+  assert_equal 1, h[one]
   assert_equal 1361129467683753853853498429727072845824, n ** 2
   # assert_equal 193128586, n.pow(n, 1234567890)
   # assert_equal(-1041439304, n.pow(n, -1234567890))


### PR DESCRIPTION
`Integer#**` can answer a bigint holding a value that fits `mrb_int`, and that object is not interchangeable with the fixnum of the same value. On today's master, `ci/gcc-clang`'s `full-debug` (any build carrying `mruby-bigint`), x86-64:

```console
$ build/full-debug/bin/mruby -e 'x = (2**70)**0; p x; p x.eql?(1); p 1.eql?(x); p x.hash == 1.hash'
1
true
false
false
```

CRuby prints `1`, `true`, `true`, `true`, on 3.2.3 and on 4.0.6.

## The path that skipped the demotion

Every arithmetic path in `bigint.c` that answers an Integer ends at `bint_norm()`, which hands the result back as a fixnum Integer when it fits:

```c
static mrb_value
bint_norm(mrb_state *mrb, struct RBigint *b)
{
  mrb_int i;
  mpz_t a;

  bint_as_mpz(b, &a);
  if (mpz_get_int(&a, &i)) {
    return mrb_int_value(mrb, i);
  }
  return mrb_obj_value(b);
}
```

Add and sub, their fixnum fast paths, mul and its multiply-by-one shortcut, divmod, the shifts and the bit operations, and `mrb_bint_powm()` immediately below all return through it. `mrb_bint_pow()` returned what `bint_new()` made:

```c
  struct RBigint *b = bint_new(ctx, &z);
  return mrb_obj_value(b);
```

`mrb_bint_neg()` is the one function beside it that skips the demotion, and it does so on purpose: its callers are all in mruby-rational, which keeps the result as a bigint object. Nothing in Integer reaches it, since `-x` on a bigint goes through sub.

`mrb_int_pow()` in `src/numeric.c` reaches it two ways: the base is a bigint already, or a fixnum base overflowed mid-loop and the whole power is retried as a bigint. The overflow entry cannot carry exponent 0, since a fixnum to the 0th power is 1 and overflows nothing, so the one reachable result that fits is `bigint ** 0`: 1 in an `MRB_TT_BIGINT`.

## What the object breaks

`==` compares by value and agrees either way. `eql?` and `hash` are the two that read the type, and they disagree with each other.

`num_eql()` value-compares when the receiver is a bigint, and demands `mrb_integer_p()` when it is a fixnum, so the pair is asymmetric:

```c
#ifdef MRB_USE_BIGINT
  if (mrb_bigint_p(x)) {
    /* `eql?` compares class as well as value, and `mrb_bint_cmp()` compares a
       Float argument numerically, so reject non-Integer arguments up front. */
    if (!mrb_bigint_p(y) && !mrb_integer_p(y)) return mrb_false_value();
    return mrb_bool_value(mrb_bint_cmp(mrb, x, y) == 0);
  }
#endif
```

`mrb_obj_hash_code()` hashes a fixnum as its value and a bigint through `mrb_bint_hash()`, which reads the limb array, so the two never land in the same bucket:

```c
  case MRB_TT_INTEGER:
    if (mrb_fixnum_p(key)) {
      hash_code = U32(mrb_fixnum(key));
    }
    else {
#ifdef MRB_USE_BIGINT
      hash_code = U32(mrb_integer(mrb_bint_hash(mrb, key)));
```

A Hash therefore misses the key, but only once the table is large enough to be indexed by hash code. Below that, the linear scan reaches `obj_eql()`, whose `default` arm calls `mrb_eql()` with the bigint on the left, which is the half of `eql?` that answers true, and the lookup succeeds:

```console
$ build/full-debug/bin/mruby -e 'h = {}; 200.times { |i| h[i] = i }; p h[(2**70)**0]; p h[1]'
nil
1
$ build/full-debug/bin/mruby -e 'h = {}; 4.times { |i| h[i] = i }; p h[(2**70)**0]; p h[1]'
1
1
```

## The change

`mrb_bint_pow()` returns through `bint_norm()` like the rest of the file, one line:

```c
  return bint_norm(mrb, bint_new(ctx, &z));
```

## Tests

`assert 'Bigint pow'` already asked `assert_equal 1, n ** 0`, and `==` is the one comparison that agrees either way, so that row passed before this commit and after it. The rows added beside it ask `eql?` in both directions, `hash`, and a Hash filled past the point where it is indexed by hash code. On master they fail 3 of 4; `one.eql?(1)` is the one that passes, for the reason above.

## Verification

`rake -m test` over `ci/gcc-clang`, every build green, 0 KO, 0 crash, no new warnings, and the counts are master's to the test: the new rows sit inside an `assert` block that already existed.

| build | master | with this commit |
| --- | --- | --- |
| full-debug | 2312 tests, 3 skip | 2312 tests, 3 skip |
| bintest | 2312 tests, 11 skip, plus 117 bintests | 2312 tests, 11 skip, plus 117 bintests |
| cxx_abi | 2312 tests, 11 skip | 2312 tests, 11 skip |
| byte-string | 2243 tests, 48 skip | 2243 tests, 48 skip |
| ascii-case | 2309 tests, 13 skip | 2309 tests, 13 skip |

`build_config/asan.rb` (clang, `address,undefined`) is green as well, 2312 tests and 3 skip plus 79 bintests, with no sanitizer report.

### Environment

<details>
<summary>Versions</summary>

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS, Linux 7.0.0-28-generic x86_64 |
| CPU | AMD Ryzen 9 5950X, 16 cores |
| C compiler | gcc 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1), and clang 22.1.8 for the asan build |
| Linker | GNU ld 2.47.20260726, and `g++` for `cxx_abi` |
| CRuby | 4.0.6 (2026-07-14) +PRISM, running rake; 3.2.3 and 4.0.6 for the answers quoted above |

</details>

<details>
<summary>Compile lines for bigint.c</summary>

`-MMD -c`, `-I` and `-o` dropped.

```console
# ci/gcc-clang full-debug, -O0 because enable_debug appends -g3 -O0
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRBGEM_MRUBY_BIGINT_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-bigint/core/bigint.c

# ci/gcc-clang bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_BIGINT_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK mrbgems/mruby-bigint/core/bigint.c

# ci/gcc-clang cxx_abi, gcc -x c++ rather than g++, which only links
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_BIGINT_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-bigint/core/bigint.c

# ci/gcc-clang byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_BIGINT_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-bigint/core/bigint.c

# ci/gcc-clang ascii-case
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CASE -DMRBGEM_MRUBY_BIGINT_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-bigint/core/bigint.c

# build_config/asan.rb, -O0 for the same reason as full-debug
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -fsanitize=address,undefined -g3 -O0 -DMRBGEM_MRUBY_BIGINT_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-bigint/core/bigint.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved exponentiation results so values that fit standard integers are returned as integers instead of bigint objects.
  - Exponentiation by zero now consistently returns a canonical `1`, including matching equality, hashing, and hash lookup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->