### PR TITLE
numeric.c: make `Numeric#eql?` require the same type

### DIFF
--- a/mrbgems/mruby-complex/test/complex.rb
+++ b/mrbgems/mruby-complex/test/complex.rb
@@ -88,6 +88,14 @@ assert 'Complex#==' do
   assert_true  0.0 == Complex(0)
 end
 
+assert 'Complex#eql?' do
+  assert_true  Complex(1, 2).eql?(Complex(1, 2))
+  assert_false Complex(1, 0).eql?(1)
+  assert_false Complex(0, 0).eql?(0.0)
+  assert_false 1.eql?(Complex(1, 0))
+  assert_false Complex(1, 0).eql?(nil)
+end
+
 assert 'Complex#abs' do
   assert_float Complex(-1).abs,        1
   assert_float Complex(3.0, -4.0).abs, 5.0

--- a/mrbgems/mruby-rational/test/rational.rb
+++ b/mrbgems/mruby-rational/test/rational.rb
@@ -137,6 +137,15 @@ assert 'Rational#==, Rational#!=' do
   assert_equal_rational(false, Rational(1), '')
 end
 
+assert 'Rational#eql?' do
+  assert_true  Rational(2,1).eql?(Rational(2,1))
+  assert_true  Rational(1,2).eql?(Rational(2,4))
+  assert_false Rational(2,1).eql?(2)
+  assert_false Rational(1,2).eql?(0.5)
+  assert_false 2.eql?(Rational(2,1))
+  assert_false Rational(2,1).eql?(nil)
+end
+
 assert 'Integer#==(Rational), Integer#!=(Rational)' do
   assert_equal_rational(true, 2, Rational(4,2))
   assert_equal_rational(true, -2, Rational(-4,2))

--- a/src/numeric.c
+++ b/src/numeric.c
@@ -654,6 +654,10 @@ num_eql(mrb_state *mrb, mrb_value x)
     if (!mrb_integer_p(y)) return mrb_false_value();
     return mrb_bool_value(mrb_integer(x) == mrb_integer(y));
   }
+  /* Numeric subclasses such as Rational and Complex land here. Their `==`
+     converts the argument, so `Rational(2,1) == 2` is true; `eql?` must not,
+     because `#hash` does not treat them as the same key either. */
+  if (mrb_type(x) != mrb_type(y)) return mrb_false_value();
   return mrb_bool_value(mrb_equal(mrb, x, y));
 }
 


### PR DESCRIPTION
`Rational` and `Complex` define no `eql?` of their own, so both inherit `Numeric#eql?`. That method tests the type of its argument for `Integer`, `Float` and big integers, then falls through to `mrb_equal()` for everything else. On those two classes `eql?` is therefore an alias of `==`:

```ruby
Rational(2, 1).eql?(2)    # mruby: true  CRuby: false
Complex(1, 0).eql?(1)     # mruby: true  CRuby: false
Rational(1, 2).eql?(0.5)  # mruby: true  CRuby: false
```

`==` converts its argument, which is why `Rational(2, 1) == 2` is true. `eql?` is defined not to, and CRuby's `num_eql()` opens with a type check that mruby's lacks.

### The hash invariant

`Object#hash` is documented in `src/kernel.c` as having "the property that `a.eql?(b)` implies `a.hash == b.hash`", and `Hash` looks keys up on exactly that pair. `Rational#hash` and `Complex#hash` hash the components, so neither class ever agrees with the `Integer` or `Float` it equals. The two answered `true` to `eql?` while landing in different buckets:

```ruby
h = { Rational(2, 1) => :rat }
h[2]                           # => nil
Rational(2, 1).hash == 2.hash  # => false
```

### The change

One arm, ahead of the fall-through:

```c
if (mrb_type(x) != mrb_type(y)) return mrb_false_value();
return mrb_bool_value(mrb_equal(mrb, x, y));
```

`MRB_TT_RATIONAL` and `MRB_TT_COMPLEX` are what reach it in a build carrying the two gems. The `Integer`, `Float` and big integer arms above it test the type themselves already and are untouched, so `1.eql?(1)`, `1.eql?(1.0)`, `1.0.eql?(1.0)` and `(2**70).eql?(2**70)` answer as before.

A `Numeric` subclass written in Ruby is `MRB_TT_OBJECT` on both sides of the test, so it still reaches `mrb_equal()`, which is what CRuby does with two `T_OBJECT` operands.

CRuby's `Complex` carries an `eql?` of its own that also requires the component classes to match, which is what makes `Complex(1, 0).eql?(Complex(1.0, 0.0))` false there. mruby holds both components of a `Complex` as `mrb_float`, so it has no such pair to tell apart and the type test is the whole of it.

### Generated code

`.text` over every `.o`, against the same objects built from master, for each of the five builds `ci/gcc-clang` makes. Their compile lines are under Environment at the end: `full-debug` is `-O0`, the other four are `-O3`.

| build | master | this PR |
| --- | --- | --- |
| full-debug | 2778363 | 2778400 (+37) |
| bintest | 1792734 | 1792910 (+176) |
| cxx_abi | 1802293 | 1802469 (+176) |
| byte-string | 1745089 | 1745265 (+176) |
| ascii-case | 1766339 | 1766515 (+176) |

`src/numeric.o` is the only object that moves, and it moves by the whole of each total:

| | master | this PR |
| --- | --- | --- |
| full-debug src/numeric.o | 21810 | 21847 (+37) |
| bintest src/numeric.o | 26540 | 26716 (+176) |
| cxx_abi src/numeric.o | 26508 | 26684 (+176) |
| byte-string src/numeric.o | 26492 | 26668 (+176) |
| ascii-case src/numeric.o | 26540 | 26716 (+176) |

All of it lands in `num_eql`, which is 567 bytes on master and 747 here in the `bintest` build. The added bytes are two inlined expansions of `mrb_type()`: under word boxing each is a tag lookup for an immediate plus a read of `RBasic.tt` for a heap value. `full-debug` gains 37 instead of 176 because it is the `-O0` build, where `mrb_type()` stays out of line as a single 131 byte local function and the new test costs two calls and a compare.

### Testing

`rake -m test` over `ci/gcc-clang`, all five builds green, 0 KO, 0 crash. The compiler emits the same four `-Wsign-compare` warnings in `mruby-compiler` as it does on master, and no others.

| build | master | this PR |
| --- | --- | --- |
| full-debug | 2312 tests, 2309 OK, 3 skip | 2314 tests, 2311 OK, 3 skip |
| bintest | 2312 tests, 2301 OK, 11 skip | 2314 tests, 2303 OK, 11 skip |
| cxx_abi | 2312 tests, 2301 OK, 11 skip | 2314 tests, 2303 OK, 11 skip |
| byte-string | 2243 tests, 2195 OK, 48 skip | 2245 tests, 2197 OK, 48 skip |
| ascii-case | 2309 tests, 2296 OK, 13 skip | 2311 tests, 2298 OK, 13 skip |

`bintest` runs 117 bintests, all OK, on both. The two tests added here are the whole of the difference in every column.

`rake -m test` over `build_config/asan.rb` is green as well, address and undefined sanitizers both: 2314 tests, 2311 OK, 3 skip, plus 79 bintests, and no sanitizer report.

The tests pin both directions of each pair: a receiver against its own class, a `Rational` against the `Integer` and the `Float` it equals, an `Integer` against the `Rational` and the `Complex` that equal it, a `Complex` against the `Integer` and the `Float`, and `nil` on the right. Master answers 7 of those 11 the way CRuby 4.0.6 does; this PR answers all 11.

`byte-string` builds without `MRB_UTF8_STRING` and `ascii-case` with `MRB_USE_ASCII_CASE`; neither `src/numeric.c` nor the two test files reads how strings are indexed or what case table is compiled in, which is why those two builds move by the same amounts as `bintest`.

### Environment

<details>
<summary>Versions, and the compile line of every build named above</summary>

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS, Linux 7.0.0-28-generic x86_64 |
| CPU | AMD Ryzen 9 5950X, 16 cores |
| C compiler | gcc 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1) |
| Sanitizer compiler | clang 22.1.8 (Homebrew), which is what `build_config/asan.rb` picks |
| Linker | GNU ld 2.47.20260726, and `g++` for `cxx_abi` |
| CRuby | 4.0.6 (2026-07-14) +PRISM, running rake and answering the comparison above |

What each build actually compiles `src/numeric.c` with, `-MMD -c`, the `-I` paths and `-o` stripped:

```console
# ci/gcc-clang, full-debug
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang, bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK

# ci/gcc-clang, cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang, byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang, ascii-case
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CASE -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# build_config/asan.rb
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -fsanitize=address,undefined -g3 -O0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

`-g -O3` is what the `gcc` toolchain sets. `full-debug` and the sanitizer build then append `-g3 -O0` through `enable_debug()`, so those two are `-O0`, not `-O3`. `cxx_abi` is the C compiler driven as C++ with `-x c++ -std=gnu++03`, and `g++` links it.

The `.text` figures were taken from a build dir holding no test objects, `rake` without `test`, on both sides.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected `eql?` behavior so numeric values must have matching types to be considered equal.
  * Prevented incorrect equality between different numeric types, including rational and complex values.
  * Ensured comparisons with integers, floats, reversed operands, and `nil` return the expected results.

* **Tests**
  * Added coverage for equality and inequality cases involving rational and complex numbers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->