### PR TITLE
mruby-regexp: relocate the lookaround offsets with the code they name

### DIFF
--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -106,8 +106,33 @@ patch(re_compiler *c, uint32_t pos, uint16_t offset)
   c->code[pos].offset = offset;
 }
 
+/* True for the opcodes whose `offset` field holds an absolute code index, so
+   that relocating code has to carry it along. The jumps are the obvious ones;
+   the four lookarounds hold the end of their sub-pattern there
+   (re_internal.h), which is a code index just as much as a jump target and is
+   just as wrong when the code it names moves. Every relocator asks this one
+   question, because the two that used to carry their own list disagreed with
+   each other and with the opcode set: both relocated the jumps alone, and a
+   lookaround inside a quantified, repeated or alternated group kept an offset
+   pointing at whatever the shift left in its place.
+   RE_LB_WIDTH is not here: it carries a character count in `a`, and RE_SAVE
+   and RE_BACKREF put a slot number and a case-fold flag in `offset` rather
+   than an index. */
+static mrb_bool
+op_holds_code_index(uint8_t op)
+{
+  switch (op) {
+  case RE_JMP: case RE_SPLIT: case RE_SPLITNG:
+  case RE_LOOKAHEAD: case RE_NEG_LOOKAHEAD:
+  case RE_LOOKBEHIND: case RE_NEG_LOOKBEHIND:
+    return TRUE;
+  default:
+    return FALSE;
+  }
+}
+
 /* Insert an instruction at position `pos` by shifting code.
-   Adjusts jump targets so they still point at the same instructions. */
+   Adjusts code indices so they still point at the same instructions. */
 static void
 insert_inst(re_compiler *c, uint32_t pos, uint8_t op, uint8_t a, uint16_t offset)
 {
@@ -118,23 +143,22 @@ insert_inst(re_compiler *c, uint32_t pos, uint8_t op, uint8_t a, uint16_t offset
   c->code[pos].a = a;
   c->code[pos].offset = offset;
 
-  /* Fix jump targets across the insertion. A target past `pos` shifts down by
-     one. A target equal to `pos` is ambiguous:
+  /* Fix code indices across the insertion. An index past `pos` shifts down by
+     one. An index equal to `pos` is ambiguous:
      - code that moved (i > pos) is a backward jump -- e.g. the SPLIT that
        loops `\d+` back to its class -- and meant the instruction now at
        pos+1, so it must follow.
      - code before the insertion (i < pos) is a forward "skip to here"
-       reference that should stay on the newly inserted instruction. */
+       reference that should stay on the newly inserted instruction. A
+       lookaround is always that second case, since the end of its sub-pattern
+       lies ahead of it: leaving the end at `pos` puts the inserted
+       instruction after the sub-pattern rather than inside it, which is what
+       the quantifier wrapping the whole group wants. */
   for (uint32_t i = 0; i < c->code_len; i++) {
     if (i == pos) continue;
-    switch (c->code[i].op) {
-    case RE_JMP: case RE_SPLIT: case RE_SPLITNG:
-      if (c->code[i].offset > pos || (c->code[i].offset == pos && i > pos)) {
-        c->code[i].offset++;
-      }
-      break;
-    default:
-      break;
+    if (op_holds_code_index(c->code[i].op) &&
+        (c->code[i].offset > pos || (c->code[i].offset == pos && i > pos))) {
+      c->code[i].offset++;
     }
   }
 }
@@ -1526,11 +1550,14 @@ compile_atom(re_compiler *c)
 }
 
 /* Append a copy of the atom bytecode in [start, start+size) at the current
-   position. Internal jump/split targets are relocated to the copy, so a
-   repeated group like (a{2,3}){2} keeps each iteration self-contained instead
-   of jumping back into the first copy (which corrupted its captures). Capture
-   slots (RE_SAVE) are shared across copies on purpose: a repeated group keeps
-   only its last iteration, like CRuby. */
+   position. Internal code indices are relocated to the copy, so a repeated
+   group like (a{2,3}){2} keeps each iteration self-contained instead of
+   jumping back into the first copy (which corrupted its captures). A
+   lookaround's sub-pattern end is one of those indices: left pointing into
+   the original, the copy runs its assertion against the first iteration's
+   code and ends the outer match early. Capture slots (RE_SAVE) are shared
+   across copies on purpose: a repeated group keeps only its last iteration,
+   like CRuby. */
 static void
 emit_atom_copy(re_compiler *c, uint32_t start, uint32_t size)
 {
@@ -1538,14 +1565,8 @@ emit_atom_copy(re_compiler *c, uint32_t start, uint32_t size)
   uint32_t atom_end = start + size;
   for (uint32_t j = 0; j < size; j++) {
     re_inst in = c->code[start + j];
-    switch (in.op) {
-    case RE_JMP: case RE_SPLIT: case RE_SPLITNG:
-      if (in.offset >= start && in.offset <= atom_end) {
-        in.offset = (uint16_t)((int32_t)in.offset + delta);
-      }
-      break;
-    default:
-      break;
+    if (op_holds_code_index(in.op) && in.offset >= start && in.offset <= atom_end) {
+      in.offset = (uint16_t)((int32_t)in.offset + delta);
     }
     emit(c, in.op, in.a, in.offset);
   }

--- a/mrbgems/mruby-regexp/test/regexp_syntax.rb
+++ b/mrbgems/mruby-regexp/test/regexp_syntax.rb
@@ -937,6 +937,32 @@ assert("Regexp - consecutive optional quantifiers (#6853)") do
   assert_equal [""], /a?b?c?d?/.match("").to_a
 end
 
+assert("Regexp - a relocated lookaround keeps the end of its sub-pattern") do
+  # A lookaround holds the end of its sub-pattern as an absolute code index,
+  # so every relocation has to carry it the way it carries a jump target.
+  # Neither relocator did: the stale index landed on the sub-pattern's own
+  # RE_MATCH, which ends the outer match early, so the answers below flipped
+  # in both directions and the MatchData of an apparent success held nil.
+  # Three shapes reach a relocator, one each.
+
+  # insert_inst, via the SPLIT a quantifier puts in front of the group
+  assert_nil /(?:(?=a)b)*x/.match("a")
+  assert_equal "x", /(?:(?!b)b)*x/.match("ax")[0]
+
+  # emit_atom_copy, via the copies {n,m} makes of the group
+  assert_equal "aa", /(?:(?=a)a){2}/.match("aa")[0]
+  assert_nil /(?:(?=a)a){2}/.match("ab")
+
+  # insert_inst again, via the SPLIT compile_alt puts in front of branch 0
+  # once every branch is compiled
+  md = /(?=a)a|z/.match("ax")
+  assert_equal 0, md.begin(0)
+  assert_equal "a", md[0]
+
+  # the same group without a relocation, which always answered correctly
+  assert_equal "ab", /(?:(?=a)ab)+/.match("ab")[0]
+end
+
 assert("Regexp - empty-matchable patterns find earliest match position") do
   # When a regex can match zero characters via epsilon transitions, the
   # first-byte skip-ahead optimization is unsafe: skipping past bytes


### PR DESCRIPTION
`enum re_opcode` gives four opcodes an absolute code index in `offset`: the lookarounds hold the end of their sub-pattern there, the same way `RE_JMP`, `RE_SPLIT` and `RE_SPLITNG` hold a jump target. Two places in `re_compile.c` move compiled code and have to carry those indices along, and each carried its own list of which opcodes to fix. Both lists named the three jumps and stopped.

### The defect

A lookaround that goes through either relocator keeps an index into where its sub-pattern used to be. The stale index lands on the sub-pattern's own `RE_MATCH`, which ends the outer match at that point, so the pattern answers about a match it never made.

Three shapes reach a relocator:

* `*` or `?` around a group, where `insert_inst()` puts a `SPLIT` in front of it and shifts the rest down
* `{n,m}`, where `emit_atom_copy()` copies the group and re-points the copy at itself
* alternation, where `compile_alt()` inserts a `SPLIT` at the first branch once every branch is compiled

The answers flip in both directions, and a `MatchData` survives the failure looking successful: the match reports a position while `m[0]` is `nil`. Each line is `begin(0)` and `m[0]`, against CRuby 4.0.6:

```ruby
/(?:(?=a)b)*x/.match("a")    # CRuby: nil      mruby: 0, nil
/(?:(?=a)a){2}/.match("aa")  # CRuby: 0, "aa"  mruby: nil
/(?=a)a|z/.match("ax")       # CRuby: 0, "a"   mruby: 0, nil
/(?:(?!b)b)*x/.match("ax")   # CRuby: 1, "x"   mruby: 0, nil
/(?:(?=a)ab)+/.match("ab")   # CRuby: 0, "ab"  mruby: 0, "ab"
```

The last line is the same group with nothing to relocate, and it has always agreed.

### The fix

Ask one function, `op_holds_code_index()`, which opcodes hold a code index, rather than keeping the question answered separately in each relocator. The two lists disagreeing with the opcode set is the defect, and a list per relocator invites it back the next time an opcode gains an index.

`RE_LB_WIDTH` stays out, since it carries a character count in `a`, as do `RE_SAVE` and `RE_BACKREF`, whose `offset` is a slot number and a case-fold flag.

The ambiguity `insert_inst()` already resolves for a target equal to the insertion point needs no new arm. A lookaround's sub-pattern ends ahead of it, so it is always the forward-reference case, and leaving the end where it is puts the inserted instruction after the sub-pattern rather than inside it, which is what the quantifier wrapping the whole group is asking for.

### Tests

`mrbgems/mruby-regexp/test/regexp_syntax.rb` gains one assertion block covering the three relocation shapes, one case each, plus the group with nothing to relocate as the control.

| build | config | total | OK | KO | crash | skip |
| --- | --- | ---: | ---: | ---: | ---: | ---: |
| `host` | `build_config/default.rb` | 2103 | 2054 | 0 | 0 | 49 |
| `host` bintest | `build_config/default.rb` | 106 | 106 | 0 | 0 | 0 |
| `full-debug` | `build_config/ci/gcc-clang.rb` | 2327 | 2324 | 0 | 0 | 3 |
| `bintest` | `build_config/ci/gcc-clang.rb` | 2327 | 2316 | 0 | 0 | 11 |
| `bintest` bintest | `build_config/ci/gcc-clang.rb` | 117 | 117 | 0 | 0 | 0 |
| `cxx_abi` | `build_config/ci/gcc-clang.rb` | 2327 | 2316 | 0 | 0 | 11 |
| `byte-string` | `build_config/ci/gcc-clang.rb` | 2257 | 2208 | 0 | 0 | 49 |
| `ascii-case` | `build_config/ci/gcc-clang.rb` | 2323 | 2310 | 0 | 0 | 13 |
| `asan` | `build_config/asan.rb` | 2327 | 2324 | 0 | 0 | 3 |
| `asan` bintest | `build_config/asan.rb` | 79 | 79 | 0 | 0 | 0 |

The `asan` build reports no `AddressSanitizer` or UBSan diagnostic.

### Environment

<details>

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-28-generic x86_64 |
| CPU | AMD Ryzen 9 5950X 16-Core Processor |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0 |
| C compiler (asan) | Homebrew clang version 22.1.8 |
| binutils | GNU ld (GNU Binutils) 2.47.20260726 |
| CRuby | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |

Compile lines for `mrbgems/mruby-regexp/src/re_compile.c`, taken from `rake --verbose` with `-MMD -c`, `-I` and `-o` removed. `full-debug` and `asan` are `-O0`, since `enable_debug()` appends `-g3 -O0` after the toolchain default of `-g -O3`.

```console
# host (build_config/default.rb)
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK

# full-debug (build_config/ci/gcc-clang.rb)
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# bintest (build_config/ci/gcc-clang.rb)
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK

# cxx_abi (build_config/ci/gcc-clang.rb), compiled by gcc -x c++, g++ only links
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# byte-string (build_config/ci/gcc-clang.rb)
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ascii-case (build_config/ci/gcc-clang.rb)
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CASE -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# asan (build_config/asan.rb)
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -fsanitize=address,undefined -g3 -O0 -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved regular expression handling for lookaround patterns, alternations, and repeated groups.
  * Fixed cases where inserting or copying pattern instructions could produce incorrect matches or match boundaries.

* **Tests**
  * Added regression coverage for lookaround endpoint preservation and related matching scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->