### PR TITLE
mruby-compiler: compare integers of the same signedness

### DIFF
--- a/mrbgems/mruby-compiler/src/ccontext.c
+++ b/mrbgems/mruby-compiler/src/ccontext.c
@@ -32,7 +32,7 @@ mrc_ccontext_cleanup_local_variables(mrc_ccontext *cc)
   cc->keep_lv = FALSE;
 
   if (cc->options && cc->options->scopes) {
-    for (int i = 0; i < cc->options->scopes[0].locals_count; i++) {
+    for (size_t i = 0; i < cc->options->scopes[0].locals_count; i++) {
       mrc_free(cc, (void *)cc->options->scopes[0].locals[i].source);
     }
     mrc_free(cc, cc->options);

--- a/mrbgems/mruby-compiler/src/cdump.c
+++ b/mrbgems/mruby-compiler/src/cdump.c
@@ -349,7 +349,7 @@ static int
 cdump_syms(mrc_ccontext *c, const char *name, const char *key, int n, int syms_len, const mrc_sym *syms, mrc_string *init_syms_code, FILE *fp)
 {
   int ai = mrc_gc_arena_save(c);
-  mrc_int code_len = MRC_STRING_LEN(init_syms_code);
+  size_t code_len = MRC_STRING_LEN(init_syms_code);
   mrc_string *var_name = sym_var_name_str(c, name, key, n);
 
   fprintf(fp, "mrb_DEFINE_SYMS_VAR(%s, %d, (", MRC_STRING_PTR(var_name), syms_len);

--- a/mrbgems/mruby-compiler/src/codegen.c
+++ b/mrbgems/mruby-compiler/src/codegen.c
@@ -1438,7 +1438,7 @@ gen_binop(mrc_codegen_scope *s, mrc_sym op, uint16_t dst)
   else if (op == MRC_OPSYM_2(aref)) {
     /* GETIDX0 fusion: MOVE dst arr; LOADI_0 dst+1 -> GETIDX0 dst arr */
     struct mrc_insn_data data = mrc_last_insn(s);
-    if (data.insn == OP_LOADI_0 && data.a == dst+1 && addr_pc(s, data.addr) != s->lastlabel) {
+    if (data.insn == OP_LOADI_0 && data.a == (uint32_t)(dst+1) && addr_pc(s, data.addr) != s->lastlabel) {
       struct mrc_insn_data data0 = mrc_decode_insn(mrc_prev_pc(s, data.addr));
       if (data0.insn == OP_MOVE && data0.a == dst && data0.b != dst) {
         s->pc = addr_pc(s, data0.addr);

--- a/mrbgems/mruby-compiler/src/compile.c
+++ b/mrbgems/mruby-compiler/src/compile.c
@@ -203,7 +203,7 @@ append_from_stdin(mrc_ccontext *c, uint8_t **source, size_t source_length)
   uint8_t *buffer = (uint8_t *)mrc_malloc(c, INITIAL_BUF_SIZE);
   if (buffer == NULL) return -1;
 
-  int capacity = INITIAL_BUF_SIZE;
+  size_t capacity = INITIAL_BUF_SIZE;
   size_t length = 0;
 
   while (1) {


### PR DESCRIPTION
## Problem

The `cxx_abi` build compiles the compiler sources as C++, and gcc's `-Wall` implies `-Wsign-compare` in C++ mode. The C builds would need `-Wextra` for the same check, so four comparisons in `mruby-compiler` warn in that build alone. Every gcc job on master prints each of them twice, once for the `mrbc` sub-build and once for the library ([ubuntu-22.04-gcc on bd41ddb](https://github.com/mruby/mruby/actions/runs/31981285134/job/95248386725), and the same 8 lines in `ubuntu-24.04-gcc`, `ubuntu-24.04-arm-gcc`, `windows-2025-mingw-gcc` and `windows-2022-mingw-gcc`). The clang jobs are quiet, since clang does not fold `-Wsign-compare` into `-Wall`.

```console
mrbgems/mruby-compiler/src/ccontext.c: In function ‘void mrc_ccontext_cleanup_local_variables(mrc_ccontext*)’:
mrbgems/mruby-compiler/src/ccontext.c:35:23: warning: comparison of integer expressions of different signedness: ‘int’ and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
   35 |     for (int i = 0; i < cc->options->scopes[0].locals_count; i++) {
      |                     ~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
mrbgems/mruby-compiler/src/cdump.c: In function ‘int cdump_syms(mrc_ccontext*, const char*, const char*, int, int, const mrc_sym*, mrc_string*, FILE*)’:
mrbgems/mruby-compiler/src/cdump.c:368:16: warning: comparison of integer expressions of different signedness: ‘mrc_int’ {aka ‘long int’} and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
  368 |   if (code_len == MRC_STRING_LEN(init_syms_code)) fputs("const", fp);
      |                ^
mrbgems/mruby-compiler/src/codegen.c: In function ‘mrc_bool gen_binop(mrc_codegen_scope*, mrc_sym, uint16_t)’:
mrbgems/mruby-compiler/src/codegen.c:1441:43: warning: comparison of integer expressions of different signedness: ‘uint32_t’ {aka ‘unsigned int’} and ‘int’ [-Wsign-compare]
 1441 |     if (data.insn == OP_LOADI_0 && data.a == dst+1 && addr_pc(s, data.addr) != s->lastlabel) {
      |                                    ~~~~~~~^~~~~~~~
mrbgems/mruby-compiler/src/compile.c: In function ‘intptr_t append_from_stdin(mrc_ccontext*, uint8_t**, size_t)’:
mrbgems/mruby-compiler/src/compile.c:224:18: warning: comparison of integer expressions of different signedness: ‘int’ and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
  224 |     if (capacity <= length) {
      |         ~~~~~~~~~^~~~~~~~~
```

## Changes

Each site takes the type its counterpart already has, so only the one comparison whose operand is an expression needs a cast.

| File | Before | After | Why this type |
| --- | --- | --- | --- |
| `ccontext.c:35` | `for (int i = 0; ...)` | `for (size_t i = 0; ...)` | `locals_count` is `size_t`, and the loop over the same field at line 69 already uses `size_t` |
| `compile.c:206` | `int capacity` | `size_t capacity` | `length` beside it is `size_t`, and `capacity` is passed as the `size_t` size argument of `mrc_realloc` |
| `cdump.c:352` | `mrc_int code_len` | `size_t code_len` | it only ever holds `MRC_STRING_LEN`, which is `size_t` |
| `codegen.c:1441` | `data.a == dst+1` | `data.a == (uint32_t)(dst+1)` | `data.a` is `uint32_t`; the `uint16_t` `dst` promotes to `int`, so the cast goes on the promoted expression |

## Effect on the generated code

Object files compared against master in the same build directory, with only these four files recompiled.

At `-O3` (`bintest`, `cxx_abi`, `byte-string`, `ascii-case`) `ccontext.o`, `cdump.o` and `codegen.o` disassemble identically. `compile.o` is the one that moves: in the inlined `append_from_stdin` the two `movslq` sign extensions of `capacity` are gone, and the freed byte goes back into alignment padding (`nopw` becomes `nopl`), so `.text` stays at 2901 bytes in `cxx_abi`.

```diff
  7d4:	lea    (%r15,%rbx,1),%rdx
  7d8:	cmp    $0xffffffff,%eax
  7db:	je     820
- 7dd:	mov    %al,(%rdx)
- 7df:	add    $0x1,%rbx
- 7e3:	movslq %ebp,%rax
- 7e6:	cmp    %rax,%rbx
- 7e9:	jb     7c8
- 7eb:	mov    0x10(%rsp),%rax
- 7f0:	add    %ebp,%ebp
- 7f2:	mov    %r15,%rsi
- 7f5:	movslq %ebp,%rdx
- 7f8:	mov    (%rax),%rdi
- 7fb:	call   800
- 800:	test   %rax,%rax
- 803:	je     880
- 805:	mov    %rax,%r15
- 808:	jmp    7c8
- 80a:	nopw   0x0(%rax,%rax,1)
+ 7dd:	add    $0x1,%rbx
+ 7e1:	mov    %al,(%rdx)
+ 7e3:	cmp    %rbp,%rbx
+ 7e6:	jb     7c8
+ 7e8:	mov    0x10(%rsp),%rax
+ 7ed:	add    %rbp,%rbp
+ 7f0:	mov    %r15,%rsi
+ 7f3:	mov    %rbp,%rdx
+ 7f6:	mov    (%rax),%rdi
+ 7f9:	call   7fe
+ 7fe:	test   %rax,%rax
+ 801:	je     880
+ 803:	mov    %rax,%r15
+ 806:	jmp    7c8
+ 808:	nopl   0x0(%rax,%rax,1)
  810:	mov    %rdx,%rsi
  813:	call   818
  818:	jmp    6eb
```

At `-O0` (`full-debug`) the same sign extensions simply disappear: `.text` of `ccontext.o` 1004 -> 999, `cdump.o` 8357 -> 8354, `compile.o` 4358 -> 4357, `codegen.o` unchanged.

## Verification

`rake -m test:run:serial` with `MRUBY_CONFIG=ci/gcc-clang CC=gcc CXX=g++ LD=gcc`, from an empty build directory.

| Build | Warnings | Tests |
| --- | --- | --- |
| `full-debug` | 0 | 2327 total, 2324 OK, 0 KO, 0 crash |
| `bintest` | 0 | 2327 total, 2316 OK, 0 KO, 0 crash; bintest 117 OK |
| `cxx_abi` | 0 | 2327 total, 2316 OK, 0 KO, 0 crash |
| `byte-string` | 0 | 2257 total, 2208 OK, 0 KO, 0 crash |
| `ascii-case` | 0 | 2323 total, 2310 OK, 0 KO, 0 crash |

The same command on master prints the 8 warning lines quoted above.

### Environment

<details>

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-28-generic x86_64 |
| CPU | AMD Ryzen 9 5950X |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0 |
| binutils | GNU ld (GNU Binutils) 2.47.20260726 |
| CRuby | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |

Compile lines per build as printed by `rake --verbose`, with `-MMD -c`, `-I` and `-o` dropped. `cxx_abi` reaches C++ through `gcc -x c++ -std=gnu++03`; `g++` only links there.

```console
# full-debug
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DMRC_DEBUG -DMRC_DUMP_PRETTY -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK

# cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ascii-case
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CASE -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compiler handling of large local-variable lists and dynamically sized input buffers.
  * Strengthened numeric comparisons during bytecode generation.
  * Improved reliability when processing generated symbol data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->