### PR TITLE
vm.c: answer `str[i] = x` from `OP_SETIDX`

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -302,6 +302,7 @@ enum mrb_idx_op_slot {
   MRB_IDX_OP_STR_AREF,          /* String#[] */
   MRB_IDX_OP_ARY_ASET,          /* Array#[]= */
   MRB_IDX_OP_HASH_ASET,         /* Hash#[]=  */
+  MRB_IDX_OP_STR_ASET,          /* String#[]= */
   MRB_IDX_OP_SLOT_COUNT
 };
 

--- a/include/mruby/internal.h
+++ b/include/mruby/internal.h
@@ -235,6 +235,7 @@ mrb_value mrb_str_inspect(mrb_state *mrb, mrb_value str);
 mrb_bool mrb_str_beg_len(mrb_int str_len, mrb_int *begp, mrb_int *lenp);
 mrb_value mrb_str_byte_subseq(mrb_state *mrb, mrb_value str, mrb_int beg, mrb_int len);
 mrb_value mrb_str_aref(mrb_state *mrb, mrb_value str, mrb_value idx, mrb_value len);
+void mrb_str_aset(mrb_state *mrb, mrb_value str, mrb_value idx, mrb_value len, mrb_value replace);
 mrb_bool mrb_strcasecmp_p(const char *s1, mrb_int len1, const char *s2, mrb_int len2);
 #define MRB_STR_CASECMP_P(str, lit) \
   mrb_strcasecmp_p(RSTRING_PTR(str), RSTRING_LEN(str), lit, sizeof(lit"")-1)

--- a/mrbgems/mruby-regexp/mrblib/string_regexp.rb
+++ b/mrbgems/mruby-regexp/mrblib/string_regexp.rb
@@ -6,9 +6,10 @@
 # is no Ruby-side helper for a subclass to redefine; an accepted String is
 # compiled or quoted into a Regexp here before anything is searched.  `split`
 # leaves a nil or String pattern to the built-in it aliased and uses the same
-# check to reject everything that is not a Regexp.  `[]`, `[]=` and `slice!`
-# read the real class with `Regexp === pattern` and leave anything else to the
-# built-in method they aliased.  `=~` rejects a String, which would recurse
+# check to reject everything that is not a Regexp.  `slice!` reads the real
+# class with `Regexp === pattern` and leaves anything else to the built-in
+# method it aliased; `[]` and `[]=` are `str_aref()` and `str_aset()` in
+# src/regexp.c, where the same test is the argument's own type.  `=~` rejects a String, which would recurse
 # back into this method, and hands anything that is not a Regexp to the
 # argument's own `=~`, as CRuby does.
 #
@@ -36,10 +37,10 @@ class String
   # back to the core implementation.
   alias __split split
 
-  # The write side of the same pair, overridden at the end of this file too.
-  # `[]=` has a single method table entry, and `slice!` comes from
-  # mruby-string-ext, which this gem depends on, so it needs its own capture.
-  alias __aset []=
+  # `slice!` comes from mruby-string-ext, which this gem depends on, and is
+  # overridden at the end of this file.  The core `[]=` it also reaches is
+  # captured as `__aset` in src/regexp.c, before the override defined there
+  # takes the name.
   alias __slice_bang slice!
 
   # The four search methods of src/string.c whose regexp form is overridden at
@@ -379,60 +380,10 @@ class String
     result
   end
 
-  # The regexp-aware `[]` and `slice` are `str_aref()` in src/regexp.c, where
-  # the indexes the core method answers reach it without a Ruby frame in
-  # between.  Everything below stays here, where a block or a loop needs the
-  # VM anyway.
-
-  # Regexp-aware element assignment.  Falls back to the C-defined `[]=`
-  # (aliased as `__aset` above) for every other argument form, and handles a
-  # regexp here.
-  #
-  # `vm_op_setidx()` optimizes Array and Hash only and sends `[]=` for every
-  # other receiver, so the ordinary `str[i] = repl` has always arrived here and
-  # paid a Ruby frame on its way to `__aset`.  That is why the delegation guard
-  # is a single `Regexp ===`, before any other work.
-  def []=(*args)
-    return __aset(*args) unless Regexp === args[0]
-    unless args.length == 2 || args.length == 3
-      raise ArgumentError, "wrong number of arguments (given #{args.length}, expected 2..3)"
-    end
-    # A full search and not `match?`, so that the match globals are published
-    # here including the clearing a failed match does.  CRuby searches before
-    # it checks the receiver for modification, which makes the order
-    # observable: a frozen receiver still leaves the match behind, and a
-    # pattern that does not match raises IndexError rather than FrozenError.
-    # Letting the mutation below be what raises reproduces both.
-    md = Regexp.__search(args[0], self)
-    raise IndexError, "regexp not matched" unless md
-    group = args.length > 2 ? args[1] : 0
-    if Integer === group
-      # An index out of range is an error here, not a missing group, and
-      # CRuby reports it before normalizing a negative one, so the message
-      # names the index as given, and group 0 is out of the negative end's
-      # reach.  `MatchData#begin` has its own wording for this and rejects
-      # every negative index, so the check cannot be left to it.
-      size = md.size
-      if group >= size || -group >= size
-        raise IndexError, "index #{group} out of regexp"
-      end
-      group += size if group < 0
-    end
-    # A String or Symbol reaches `MatchData#begin` as it stands: it resolves
-    # the name to its group and raises the IndexError CRuby raises for a name
-    # that resolves to none, with the same message.
-    beg = md.begin(group)
-    # A group that exists but did not take part in the match has nothing to
-    # replace.  CRuby names the group's number even when the argument was a
-    # name; the number is not reachable from Ruby, so the message repeats the
-    # argument as it was given.
-    raise IndexError, "regexp group #{group} not matched" unless beg
-    # `begin` and `end` report character offsets, which is the space the
-    # two-integer form of `[]=` works in, so a multibyte subject needs no
-    # further conversion.  The replacement is handed over unchecked: the type
-    # check belongs to the core method, as it does for `sub`.
-    __aset(beg, md.end(group) - beg, args[-1])
-  end
+  # The regexp-aware `[]`, `slice` and `[]=` are `str_aref()` and `str_aset()`
+  # in src/regexp.c, where the indexes the core methods answer reach them
+  # without a Ruby frame in between.  Everything below stays here, where a
+  # block or a loop needs the VM anyway.
 
   # Regexp-aware `slice!`.  Falls back to the C-defined `slice!` (aliased as
   # `__slice_bang` above) for every other argument form.

--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -1523,6 +1523,97 @@ str_aref(mrb_state *mrb, mrb_value str)
   return md_aref(mrb, md, argc == 1 ? mrb_fixnum_value(0) : a2);
 }
 
+/*
+ * String#[]=(index, replace) / String#[]=(index, length, replace)
+ * String#[]=(regexp, replace) / String#[]=(regexp, capture, replace)
+ *
+ * The write side of `str_aref()` above, and C for the same reason: the core
+ * `[]=` answers every argument form but a Regexp, so an override written in
+ * Ruby made every `str[i] = x` in the program pay a Ruby frame and the two
+ * splat arrays a `*args` method builds on its way back to the core one.
+ *
+ * The arguments are read raw rather than with the core method's `"oo|S!"`,
+ * because the regexp form has to search before it looks at the replacement:
+ * CRuby's `rb_str_subpat_set()` raises IndexError for a pattern that did not
+ * match whatever the replacement is, and `$~` is left describing the failure.
+ * The delegation below therefore repeats what `"oo|S!"` does, in its order:
+ * the replacement's type is checked before the argument count, which is what
+ * makes `str[1, 2, 3] = "X"` a TypeError rather than an ArgumentError.
+ */
+static mrb_value
+str_aset(mrb_state *mrb, mrb_value str)
+{
+  const mrb_value *argv;
+  mrb_int argc;
+  mrb_get_args(mrb, "*", &argv, &argc);
+
+  /* The real type, not `argv[0].is_a?`; see str_aref() above. */
+  if (argc < 1 || mrb_type(argv[0]) != MRB_TT_CDATA ||
+      !mrb_obj_is_kind_of(mrb, argv[0], mrb_class_get_id(mrb, MRB_SYM(Regexp)))) {
+    if (argc >= 3 && !mrb_nil_p(argv[2])) mrb_ensure_string_type(mrb, argv[2]);
+    if (argc < 2 || argc > 3) mrb_argnum_error(mrb, argc, 2, 3);
+    mrb_value replace = argv[argc-1];
+    mrb_str_aset(mrb, str, argv[0], argc == 2 ? mrb_undef_value() : argv[1], replace);
+    return replace;
+  }
+
+  if (argc < 2 || argc > 3) mrb_argnum_error(mrb, argc, 2, 3);
+  /* Read out of `argv`, which points into the VM stack, before anything else
+     runs. */
+  mrb_value pattern = argv[0];
+  mrb_value group = argc > 2 ? argv[1] : mrb_fixnum_value(0);
+  mrb_value replace = argv[argc-1];
+
+  /* A full search and not a match test, so that the match globals are
+     published here including the clearing a failed match does. CRuby searches
+     before it checks the receiver for modification, which makes the order
+     observable: a frozen receiver still leaves the match behind, and a pattern
+     that does not match raises IndexError rather than FrozenError. Letting the
+     store below be what raises reproduces both. */
+  mrb_value match = re_search(mrb, pattern, str, 0, FALSE);
+  if (mrb_nil_p(match)) mrb_raise(mrb, E_INDEX_ERROR, "regexp not matched");
+  mrb_match_data *md = DATA_GET_PTR(mrb, match, &matchdata_type, mrb_match_data);
+
+  mrb_int idx;
+  if (mrb_obj_is_kind_of(mrb, group, mrb->integer_class)) {
+    /* An index out of range is an error here, not a missing group, and CRuby
+       reports it before normalizing a negative one, so the message names the
+       index as given. Group 0 is out of the negative end's reach. An index
+       that does not even fit an `mrb_int` reaches no group either. */
+    mrb_int size = md->num_captures;
+    if (!mrb_integer_p(group) ||
+        mrb_integer(group) >= size || mrb_integer(group) <= -size) {
+      mrb_raisef(mrb, E_INDEX_ERROR, "index %v out of regexp", group);
+    }
+    idx = mrb_integer(group);
+    if (idx < 0) idx += size;
+    group = mrb_int_value(mrb, idx);
+  }
+  else {
+    /* A String or Symbol resolves to the group it names, and everything else
+       is read as an index, both the way `MatchData#begin` reads its argument:
+       a name that resolves to no group raises the IndexError CRuby raises for
+       it, with the same message. */
+    idx = matchdata_group_arg(mrb, md, group);
+  }
+
+  /* A group that exists but did not take part in the match has nothing to
+     replace. CRuby names the group's number even when the argument was a
+     name; the number is not reachable from Ruby, so the message repeats the
+     argument as it was given. */
+  int beg = md->captures[idx * 2];
+  if (beg < 0) mrb_raisef(mrb, E_INDEX_ERROR, "regexp group %v not matched", group);
+
+  /* Character offsets, which is the space the two-integer form of `[]=` works
+     in, so a multibyte subject needs no further conversion. The replacement is
+     handed over unchecked: the type check belongs to the core method, as it
+     does for `sub`. */
+  mrb_int cbeg = re_byte_to_char(mrb, md->source, beg);
+  mrb_int clen = re_byte_to_char(mrb, md->source, md->captures[idx * 2 + 1]) - cbeg;
+  mrb_str_aset(mrb, str, mrb_int_value(mrb, cbeg), mrb_int_value(mrb, clen), replace);
+  return replace;
+}
+
 /* --- Gem init --- */
 
 void
@@ -1581,6 +1672,15 @@ mrb_mruby_regexp_gem_init(mrb_state *mrb)
      it arrives above.  Widen `str_aref()` past a Regexp and this call has to
      go; test/string_index.rb asks both ways round and would catch it. */
   mrb_idx_op_rearm(mrb, MRB_IDX_OP_STR_AREF);
+
+  /* `String#[]=` the same way, and on the same terms: `str_aset()` answers an
+     Integer, String or Range index through the same `mrb_str_aset()` the
+     opcode calls. `slice!` stays in mrblib and reaches the core method under
+     `__aset`, captured here rather than in mrblib so that it is the core one
+     and not the override defined next. */
+  mrb_alias_method(mrb, mrb->string_class, MRB_SYM(__aset), MRB_OPSYM(aset));
+  mrb_define_method(mrb, mrb->string_class, "[]=", str_aset, MRB_ARGS_ANY());
+  mrb_idx_op_rearm(mrb, MRB_IDX_OP_STR_ASET);
 
   /* MatchData class */
   struct RClass *md = mrb_define_class(mrb, "MatchData", mrb->object_class);

--- a/mrbgems/mruby-regexp/test/string_index.rb
+++ b/mrbgems/mruby-regexp/test/string_index.rb
@@ -872,3 +872,62 @@ assert("String#[] answers the same through the opcode and through a send") do
     [0..2, 1...4, -2..-1].each { |r| assert_equal u.slice(r), u[r], "u[#{r.inspect}]" }
   end
 end
+
+assert("String#[]= answers the same through the opcode and through a send") do
+  # `s[x] = repl` is answered by `OP_SETIDX` in C, without a method lookup,
+  # while `s.[]=(x, repl)` reaches `str_aset()` itself.  The two are only
+  # allowed to be different code while they cannot be told apart, which is the
+  # promise `mrb_idx_op_rearm()` takes from this gem for `[]=` as it does for
+  # `[]`: `str_aset()` takes the name to reach a Regexp index, and re-arms the
+  # opcode because it hands every other argument form to the same
+  # `mrb_str_aset()` the opcode calls.  Widening it to another argument type
+  # the opcode answers would not show up in `s[x] = repl` at all, so ask both
+  # ways, and compare what each store left behind rather than the replacement
+  # both forms answer with.
+  [0, 1, 5, -1, -11, 10].each do |i|
+    a = "hello world"
+    b = "hello world"
+    a[i] = "X"
+    b.[]=(i, "X")
+    assert_equal b, a, "s[#{i}] = 'X'"
+  end
+  ["h", "lo w", "hello world", "", "d"].each do |sub|
+    a = "hello world"
+    b = "hello world"
+    a[sub] = "X"
+    b.[]=(sub, "X")
+    assert_equal b, a, "s[#{sub.inspect}] = 'X'"
+  end
+  [0..3, 1...3, -3..-1, 0..-1, 5..99, 3..1].each do |r|
+    a = "hello world"
+    b = "hello world"
+    a[r] = "X"
+    b.[]=(r, "X")
+    assert_equal b, a, "s[#{r.inspect}] = 'X'"
+  end
+  # The forms neither answers from the opcode: a Regexp index reaches
+  # `str_aset()` through the send the opcode falls back to, and an index that
+  # matches nothing raises the same error either way.
+  a = "hello world"
+  b = "hello world"
+  a[/o.w/] = "X"
+  b.[]=(/o.w/, "X")
+  assert_equal b, a
+  assert_raise(IndexError) { "hello world"[99] = "X" }
+  assert_raise(IndexError) { "hello world".[]=(99, "X") }
+  assert_raise(IndexError) { "hello world"["zz"] = "X" }
+  assert_raise(IndexError) { "hello world".[]=("zz", "X") }
+  # A receiver whose characters are not one byte each.
+  if "あ".length == 1
+    a = "こんにちは"
+    b = "こんにちは"
+    a[1] = "X"
+    b.[]=(1, "X")
+    assert_equal b, a
+    a = "こんにちは"
+    b = "こんにちは"
+    a[1..3] = "X"
+    b.[]=(1..3, "X")
+    assert_equal b, a
+  end
+end

--- a/src/class.c
+++ b/src/class.c
@@ -2919,6 +2919,7 @@ mrb_idx_op_update(mrb_state *mrb, mrb_sym mid)
   if (mid == 0 || mid == MRB_OPSYM(aset)) {
     idx_op_refresh(mrb, MRB_IDX_OP_ARY_ASET);
     idx_op_refresh(mrb, MRB_IDX_OP_HASH_ASET);
+    idx_op_refresh(mrb, MRB_IDX_OP_STR_ASET);
   }
 }
 

--- a/src/string.c
+++ b/src/string.c
@@ -2009,7 +2009,17 @@ str_escape(mrb_state *mrb, mrb_value str, mrb_bool inspect)
   return result;
 }
 
-static void
+/*
+ * @param mrb The mruby state.
+ * @param str The receiver, modified in place.
+ * @param idx The index or range, read as `mrb_str_aref()` reads it.
+ * @param alen An optional length (if `idx` is an integer), or undef.
+ * @param replace The replacement, which has to be a String already: anything
+ *                else raises TypeError, before the range is looked at.
+ *
+ * Implements string element assignment (e.g. `str[idx] = replace`).
+ */
+void
 mrb_str_aset(mrb_state *mrb, mrb_value str, mrb_value idx, mrb_value alen, mrb_value replace)
 {
   mrb_int beg, len, charlen;

--- a/src/vm.c
+++ b/src/vm.c
@@ -2192,6 +2192,33 @@ vm_op_setidx(mrb_state *mrb, uint32_t a, mrb_sym *midp)
       mrb_gc_arena_restore(mrb, ai);
     }
     return VM_NEXT;
+  case MRB_TT_STRING:
+    /* optimize only for String itself; see vm_op_getidx() */
+    if (mrb_obj_ptr(va)->c != mrb->idx_class[MRB_IDX_OP_STR_ASET]) goto setidx_fallback;
+    /* A replacement that is not a String is a TypeError rather than a store,
+       and the method is where it is raised: leaving it to the send keeps the
+       `String#[]=` frame the backtrace has always shown for it. */
+    if (!mrb_string_p(vc)) goto setidx_fallback;
+    switch (mrb_type(vb)) {
+    case MRB_TT_INTEGER:
+    case MRB_TT_STRING:
+    case MRB_TT_RANGE:
+      {
+        /* mrb_str_aset() allocates, and an inline opcode never runs the cfunc
+           epilogue that would shrink the arena, so save and restore it here.
+           As in the String branch of vm_op_getidx(), `ci` needs no refresh:
+           none of the three index types reaches a conversion that runs Ruby
+           code, so the call cannot move the stack. */
+        int ai = mrb_gc_arena_save(mrb);
+        mrb_str_aset(mrb, va, vb, mrb_undef_value(), vc);
+        regs[a] = vc;
+        mrb_gc_arena_restore(mrb, ai);
+      }
+      return VM_NEXT;
+    default:
+      break;
+    }
+    goto setidx_fallback;
   default:
   setidx_fallback:
     SET_NIL_VALUE(regs[a+3]);

--- a/test/t/string.rb
+++ b/test/t/string.rb
@@ -187,6 +187,86 @@ assert('String#[] redefined on String itself reaches the redefinition') do
   assert_equal 'e', 'hello'[1]
 end
 
+assert('String#[]= redefined on String itself reaches the redefinition') do
+  # `OP_SETIDX` answers `s[0] = 'X'` from C whenever the receiver's class is
+  # exactly `String`, on the same terms as the `[]` test above: it tests the
+  # receiver against `mrb->idx_class[]`, which the method table drops the
+  # moment `String#[]=` is replaced. A redefinition that stores nothing makes
+  # the difference visible in the receiver as well as in the return value.
+  String.class_eval do
+    alias_method :__aset_before_test, :[]=
+    def []=(*args)
+      $string_aset_redefinition_args = args
+    end
+  end
+  begin
+    s = 'hello'
+    s[0] = 'X'
+    seen = $string_aset_redefinition_args
+    untouched = s.dup
+    sub = Class.new(String).new('hello')
+    sub[0] = 'X'
+    seen_sub = $string_aset_redefinition_args
+  ensure
+    String.class_eval do
+      alias_method :[]=, :__aset_before_test
+      # `remove_method` comes from mruby-metaprog, which the core test build
+      # does not have; the saved alias is harmless where it is missing.
+      remove_method :__aset_before_test if respond_to?(:remove_method, true)
+    end
+    $string_aset_redefinition_args = nil
+  end
+  assert_equal [0, 'X'], seen
+  assert_equal 'hello', untouched
+  assert_equal [0, 'X'], seen_sub
+  # Aliasing the original implementation back re-arms the opcode.
+  s = 'hello'
+  s[0] = 'X'
+  assert_equal 'Xello', s
+end
+
+assert('String#[]= answers the same through the opcode and through a send') do
+  # `s[x] = repl` is answered by `OP_SETIDX` in C, without a method lookup,
+  # while `s.[]=(x, repl)` reaches `String#[]=` itself. The opcode
+  # answers an Integer, String or Range index and a String replacement, and
+  # leaves every other form to the method, so ask both ways and compare the
+  # receiver each left behind.
+  [0, 1, 4, -1, -5].each do |i|
+    a = 'hello'; b = 'hello'
+    a[i] = 'X'
+    b.[]=(i, 'X')
+    assert_equal b, a, "s[#{i}] = 'X'"
+  end
+  ['h', 'll', 'hello', ''].each do |sub|
+    a = 'hello'; b = 'hello'
+    a[sub] = 'X'
+    b.[]=(sub, 'X')
+    assert_equal b, a, "s[#{sub.inspect}] = 'X'"
+  end
+  [0..2, 1...3, -3..-1, 0..-1, 2..99, 3..1].each do |r|
+    a = 'hello'; b = 'hello'
+    a[r] = 'X'
+    b.[]=(r, 'X')
+    assert_equal b, a, "s[#{r.inspect}] = 'X'"
+  end
+  # Each loop above compares the two forms with each other, so anchor one case
+  # of every index type to the result itself: a defect that made both forms
+  # store nothing would agree with itself.
+  a = 'hello'; a[1] = 'X'
+  assert_equal 'hXllo', a
+  a = 'hello'; a['ll'] = 'X'
+  assert_equal 'heXo', a
+  a = 'hello'; a[1..3] = 'X'
+  assert_equal 'hXo', a
+  # The forms the opcode leaves to the method raise what the method raises.
+  assert_raise(IndexError) { 'hello'[99] = 'X' }
+  assert_raise(IndexError) { 'hello'['zz'] = 'X' }
+  assert_raise(IndexError) { 'hello'[99..100] = 'X' }
+  assert_raise(TypeError) { 'hello'[0] = :sym }
+  assert_raise(TypeError) { 'hello'[nil] = 'X' }
+  assert_raise(FrozenError) { 'hello'.freeze[0] = 'X' }
+end
+
 assert('String#[]=') do
   # length of args is 1
   a = 'abc'


### PR DESCRIPTION
`OP_SETIDX` implements `[]=` in C for an Array and a Hash receiver and sends the operator for every other one, so a String store pays a method lookup and a call frame where the read side has answered `str[i]` from C since `OP_GETIDX` learned its String branch. This adds the write side, and then removes what would keep it switched off in a default build: mruby-regexp takes the `[]=` name for a Regexp index, and a taken name disarms the slot the opcode compares against.

## 1. vm.c: answer `str[i] = x` from `OP_SETIDX`

A String branch mirroring the one in `vm_op_getidx()`: the same three index types (Integer, String and Range), the same test of the receiver's class against `mrb->idx_class[]`, and the same arena save around a call that allocates where no cfunc epilogue will shrink the arena. `mrb_str_aset()` loses its `static` for it, as `mrb_str_aref()` did for the read side, and `MRB_IDX_OP_STR_ASET` joins the slots `mrb_idx_op_update()` rechecks.

A replacement that is not a String is a TypeError rather than a store, and is left to the send so that it is still raised with a `String#[]=` frame on the backtrace.

Nothing else changes hands: a subclass receiver, a singleton, a Float index and the three-argument form all reach the method exactly as before.

## 2. mruby-regexp: define the regexp-aware `String#[]=` in C

The override was `def []=(*args)` in mrblib. A Regexp was the first thing it ruled out, so every ordinary `str[i] = x` paid a Ruby frame and the two splat arrays a `*args` method builds to reach the `mrb_str_aset()` the core method reaches directly, and taking the name disarmed the branch added above.

`str_aset()` in `src/regexp.c` is the write side of the `str_aref()` that already lives there. It hands an Integer, String or Range index to the same `mrb_str_aset()` the opcode calls, which is the promise `mrb_idx_op_rearm()` asks for, so it re-arms `MRB_IDX_OP_STR_ASET`. A Regexp is none of the three: the opcode sends it, and it arrives at the search.

The arguments are read raw rather than with the core method's `"oo|S!"`, because the regexp form has to search before it looks at the replacement: as in CRuby's `rb_str_subpat_set()`, a pattern that did not match raises IndexError whatever the replacement is, and leaves `$~` describing the failure. The delegation repeats what `"oo|S!"` does, in its order, so every other form keeps the errors it raised, including `str[1, 2, 3] = "X"` being a TypeError for the third argument rather than an ArgumentError for the count.

`slice!` stays in mrblib and still reaches the core method under `__aset`, captured in C now, before the override takes the name.

## Benchmark

```ruby
# str[i] = x, 3M iterations
n = 3000000
s = "hello world"
i = 0
while i < n
  s[3] = "X"
  i += 1
end
```

```ruby
# str[i, len] = repl, 3M iterations; str[re] = repl, 1M
s[1, 3] = "ell"
s[re] = "ll"     # re = /l+/
```

Wall clock is the best of 7 runs taken alternately from the two binaries (running one binary five times in a row and then the other reversed the result on this machine). `Ir` is `Ir(2N) - Ir(N)` per iteration under callgrind, which cancels startup.

Default gembox (byte indexed), `gcc -g -O3`:

| benchmark | master | this PR | ratio |
|---|---|---|---|
| `str[3] = "X"` 3M | 451 ms, 2644 Ir | 125 ms, 762 Ir | 3.6x, 3.5x |
| `str[1, 3] = "ell"` 3M | 498 ms, 2799 Ir | 249 ms, 1489 Ir | 2.0x, 1.9x |
| `str[/l+/] = "ll"` 1M | 1030 ms, 15543 Ir | 656 ms, 10879 Ir | 1.6x, 1.4x |

The same gembox with mruby-regexp removed, which is what the first commit buys on its own, since there the core `[]=` keeps the name and the slot stays armed:

| benchmark | master | this PR | ratio |
|---|---|---|---|
| `str[3] = "X"` 3M | 216 ms, 1330 Ir | 120 ms, 758 Ir | 1.8x, 1.8x |

## Size

`.text` of `libmruby.a`, built in a clean directory per column.

Default gembox, byte indexed:

| object | master | this PR | delta |
|---|---|---|---|
| `src/vm.o` | 65,896 | 66,136 | +240 |
| `src/string.o` | 41,162 | 41,266 | +104 |
| `src/class.o` | 49,118 | 49,213 | +95 |
| `mruby-regexp/src/regexp.o` | 22,392 | 23,980 | +1,588 |
| `mruby-regexp/gem_init.o` | 7,695 | 7,194 | -501 |
| **`libmruby.a` total** | **1,584,654** | **1,586,180** | **+1,526** |

`full-core` gembox, `MRB_UTF8_STRING`:

| object | master | this PR | delta |
|---|---|---|---|
| `src/vm.o` | 74,795 | 74,971 | +176 |
| `src/string.o` | 63,167 | 63,271 | +104 |
| `src/class.o` | 49,118 | 49,214 | +96 |
| `mruby-regexp/src/regexp.o` | 22,800 | 24,388 | +1,588 |
| `mruby-regexp/gem_init.o` | 7,695 | 7,194 | -501 |
| **`libmruby.a` total** | **1,689,391** | **1,690,854** | **+1,463** |

`gem_init.o` shrinks because the mrblib `[]=` and its irep are gone; its `.data` drops 224 bytes in both builds, which the totals above do not include.

## Behaviour

A differential fuzz ran 4,967 `[]=` calls on master and on this branch, each case tried both through the `s[x] = repl` syntax and through `s.[]=(...)`, over empty, ASCII, multibyte and invalid-UTF-8 subjects, every index form (Integer, two Integers, Range, String, Regexp), every capture form (Integer, negative, out of range, Symbol, String, unknown name, nil, Float) and replacements including nil, a Symbol and an Integer. Each line records the receiver afterwards, the return value or the exception class and message, and `$~`. The output is identical in a byte build and in a `MRB_UTF8_STRING` build, and the same run is clean under ASan/UBSan and under `MRB_GC_STRESS`.

New tests: `test/t/string.rb` asks that a `String#[]=` redefined on `String` itself is reached (the Array and Hash equivalents are already there) and that the opcode and the method agree on every index form; `mrbgems/mruby-regexp/test/string_index.rb` asks the same both ways round for the re-armed opcode, which is what would catch `str_aset()` being widened to an argument type the opcode answers.

## Tests

| config | build | tests |
|---|---|---|
| `build_config/default.rb` | host | 2107 tests, 0 KO; bintest 106, 0 KO |
| `build_config/ci/gcc-clang.rb` | full-debug | 2331 tests, 0 KO |
| | bintest | 2331 tests, 0 KO; bintest 117, 0 KO |
| | cxx_abi | 2331 tests, 0 KO |
| | byte-string | 2261 tests, 0 KO |
| | ascii-case | 2327 tests, 0 KO |
| `build_config/clang-asan.rb` | clang-asan | 2331 tests, 0 KO; bintest 79, 0 KO |
| default gembox without mruby-regexp | noregexp | 1854 tests, 0 KO |

Both commits are green on their own: the first was run through `ci/gcc-clang` with the gem left as it is on master.

### Environment

<details>

| | |
|---|---|
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-28-generic x86_64 |
| CPU | AMD Ryzen 9 5950X (16 cores, 32 threads) |
| RAM | 62 GB |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0 |
| clang | Homebrew clang 22.1.8 (`clang-asan` only) |
| binutils | GNU ld (GNU Binutils) 2.47.20260726 |
| valgrind | valgrind-3.27.1 |
| CRuby (rake) | ruby 4.0.6 (2026-07-14) |

`cxx_abi` compiles with `gcc -x c++ -std=gnu++03`; `g++` only links.

The compile line each build actually used for `src/string.c`, with `-MMD -c`, `-I` and `-o` removed:

```console
# build_config/default.rb (host)
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK src/string.c

# ci/gcc-clang.rb (full-debug)
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c

# ci/gcc-clang.rb (bintest)
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK src/string.c

# ci/gcc-clang.rb (cxx_abi)
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c

# ci/gcc-clang.rb (byte-string)
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c

# ci/gcc-clang.rb (ascii-case)
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CASE -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c

# build_config/clang-asan.rb
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -fsanitize=address,undefined -g3 -O0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c

# benchmark and size columns, default gembox (conf.gembox 'default')
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK src/string.c

# size columns, full-core gembox (conf.gembox 'full-core')
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c

# benchmark without mruby-regexp (conf.gembox 'default'; conf.gems.delete('mruby-regexp'))
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK src/string.c
```

The gcc toolchain's default is `-g -O3`; `enable_debug` appends `-g3 -O0`, which is why `full-debug` and `clang-asan` are `-O0` builds.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded `String#[]=` support for integer, substring, range, regular expression, and capture-group assignments.
  * Added consistent assignment behavior for multibyte strings and replacement operations.

* **Bug Fixes**
  * Bracket assignment now honors method overrides and matches direct `[]=` calls.
  * Improved validation and error handling for invalid indexes, replacements, captures, and frozen strings.
  * Added optimized handling for common string assignment operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->