### PR TITLE
numeric.c: compare an Integer with a Float without rounding either one

### DIFF
--- a/include/mruby/internal.h
+++ b/include/mruby/internal.h
@@ -115,6 +115,7 @@ mrb_noreturn void mrb_int_zerodiv(mrb_state *mrb);
 mrb_noreturn void mrb_int_overflow(mrb_state *mrb, const char *reason);
 #ifndef MRB_NO_FLOAT
 void mrb_check_num_exact(mrb_state *mrb, mrb_float num);
+mrb_int mrb_int_float_cmp(mrb_int x, mrb_float y);
 #endif
 
 #ifdef MRB_USE_COMPLEX

--- a/src/numeric.c
+++ b/src/numeric.c
@@ -53,6 +53,45 @@ mrb_int_noconv(mrb_state *mrb, mrb_value y)
   mrb_raisef(mrb, E_TYPE_ERROR, "can't convert %Y into Integer", y);
 }
 
+#ifndef MRB_NO_FLOAT
+/**
+ * Compares an integer with a Float without rounding either operand.
+ *
+ * The usual arithmetic conversions turn the integer into an `mrb_float`, and a
+ * Float holds fewer significant bits than an `mrb_int` does. Every integer past
+ * the significand lands on a neighbouring Float, so it answers equal to a Float
+ * it is not equal to. Compare the integer parts as integers instead, and let
+ * what the Float carries below them break the tie.
+ *
+ * @param x The integer operand.
+ * @param y The Float operand.
+ * @return 1, 0 or -1 as `x` is greater than, equal to or less than `y`, and -2
+ *         when `y` is NaN, which stands in no order with anything.
+ */
+mrb_int
+mrb_int_float_cmp(mrb_int x, mrb_float y)
+{
+  if (isnan(y)) return -2;
+  /* Outside the `mrb_int` range the sign of `y` settles the comparison, and
+     the infinities are answered here as well. Both bounds are built from
+     `MRB_INT_MIN`, whose magnitude is a power of two and so is exact as a
+     Float; `MRB_INT_MAX` cast to a Float would have been rounded up to a value
+     no `mrb_int` reaches. */
+  if (y < (mrb_float)MRB_INT_MIN) return 1;
+  if (y >= -(mrb_float)MRB_INT_MIN) return -1;
+
+  mrb_int yi = (mrb_int)y;      /* truncates toward zero, and exactly */
+  if (x > yi) return 1;
+  if (x < yi) return -1;
+  /* The integer parts are equal, so what the truncation dropped decides.
+     `(mrb_float)yi` is exact: either `yi` fits the significand, or `y` was too
+     large to carry a fraction and `yi` is the value of `y` itself. */
+  if (y > (mrb_float)yi) return -1;
+  if (y < (mrb_float)yi) return 1;
+  return 0;
+}
+#endif
+
 /**
  * Calculates x raised to the power of y, where x is an integer.
  * y can be an integer or float. The result type can be Integer,
@@ -682,7 +721,7 @@ flo_eq(mrb_state *mrb, mrb_value x)
 
   switch (mrb_type(y)) {
   case MRB_TT_INTEGER:
-    return mrb_bool_value(mrb_float(x) == (mrb_float)mrb_integer(y));
+    return mrb_bool_value(mrb_int_float_cmp(mrb_integer(y), mrb_float(x)) == 0);
   case MRB_TT_FLOAT:
     return mrb_bool_value(mrb_float(x) == mrb_float(y));
 #ifdef MRB_USE_BIGINT
@@ -1331,7 +1370,7 @@ int_equal(mrb_state *mrb, mrb_value x)
     return mrb_bool_value(mrb_integer(x) == mrb_integer(y));
 #ifndef MRB_NO_FLOAT
   case MRB_TT_FLOAT:
-    return mrb_bool_value((mrb_float)mrb_integer(x) == mrb_float(y));
+    return mrb_bool_value(mrb_int_float_cmp(mrb_integer(x), mrb_float(y)) == 0);
 #endif
 #ifdef MRB_USE_BIGINT
   case MRB_TT_BIGINT:
@@ -2086,6 +2125,22 @@ int_to_s(mrb_state *mrb, mrb_value self)
   return mrb_integer_to_str(mrb, self, base);
 }
 
+#ifndef MRB_NO_FLOAT
+/* An integer wider than the significand rounds when it is cast to `mrb_float`,
+   so a mixed pair is compared exactly rather than as two Floats further down.
+   `mrb_int_float_cmp()` answers -2 for a NaN operand; keep the 0 that
+   comparing the two as Floats produced, because -2 is what `num_lt()` and its
+   neighbours raise on while a Float comparison against NaN is false rather
+   than an error. The 0 also leaves the answer safe to negate, which is how the
+   caller that holds the Float first reads it. */
+static mrb_int
+cmpnum_int_float(mrb_int x, mrb_float y)
+{
+  mrb_int c = mrb_int_float_cmp(x, y);
+  return c == -2 ? 0 : c;
+}
+#endif
+
 /* compare two numbers: (1:0:-1; -2 for error) */
 static mrb_int
 cmpnum(mrb_state *mrb, mrb_value v1, mrb_value v2)
@@ -2108,6 +2163,13 @@ cmpnum(mrb_state *mrb, mrb_value v1, mrb_value v2)
 #else                           /* float version */
 
   mrb_float x, y;
+
+  if (mrb_integer_p(v1) && mrb_float_p(v2)) {
+    return cmpnum_int_float(mrb_integer(v1), mrb_float(v2));
+  }
+  if (mrb_float_p(v1) && mrb_integer_p(v2)) {
+    return -cmpnum_int_float(mrb_integer(v2), mrb_float(v1));
+  }
 
   if (mrb_fixnum_p(v1)) {
     if (mrb_fixnum_p(v2)) {

--- a/src/object.c
+++ b/src/object.c
@@ -82,11 +82,11 @@ mrb_equal(mrb_state *mrb, mrb_value obj1, mrb_value obj2)
 #ifndef MRB_NO_FLOAT
   /* value mixing with integer and float */
   else if (mrb_integer_p(obj1) && mrb_float_p(obj2)) {
-    if ((mrb_float)mrb_integer(obj1) == mrb_float(obj2))
+    if (mrb_int_float_cmp(mrb_integer(obj1), mrb_float(obj2)) == 0)
       return TRUE;
   }
   else if (mrb_float_p(obj1) && mrb_integer_p(obj2)) {
-    if (mrb_float(obj1) == (mrb_float)mrb_integer(obj2))
+    if (mrb_int_float_cmp(mrb_integer(obj2), mrb_float(obj1)) == 0)
       return TRUE;
   }
 #endif

--- a/src/vm.c
+++ b/src/vm.c
@@ -3508,6 +3508,19 @@ RETRY_TRY_BLOCK:
   }\
 } while(0)
 #else
+/* The usual arithmetic conversions would round an `mrb_int` wider than the
+   significand onto a neighbouring Float, so a mixed pair asks
+   `mrb_int_float_cmp()` for the order of the two values themselves. It answers
+   -2 for a NaN operand, which stands in no order with anything: every operator
+   is false against it, as comparing the two as Floats would have been. */
+#define OP_CMP_INT_FLOAT(op) do {\
+  mrb_int c = mrb_int_float_cmp(mrb_integer(regs[a]), mrb_float(regs[a+1]));\
+  result = c != -2 && (c op 0);\
+} while (0)
+#define OP_CMP_FLOAT_INT(op) do {\
+  mrb_int c = mrb_int_float_cmp(mrb_integer(regs[a+1]), mrb_float(regs[a]));\
+  result = c != -2 && (0 op c);\
+} while (0)
 #define OP_CMP(op, sym) do {\
   int result;\
   /* need to check if op is overridden */\
@@ -3517,10 +3530,10 @@ RETRY_TRY_BLOCK:
   }\
   else switch (tt) {\
   case TYPES2(MRB_TT_INTEGER,MRB_TT_FLOAT):\
-    result = OP_CMP_BODY(op,mrb_integer,mrb_float);\
+    OP_CMP_INT_FLOAT(op);\
     break;\
   case TYPES2(MRB_TT_FLOAT,MRB_TT_INTEGER):\
-    result = OP_CMP_BODY(op,mrb_float,mrb_integer);\
+    OP_CMP_FLOAT_INT(op);\
     break;\
   case TYPES2(MRB_TT_FLOAT,MRB_TT_FLOAT):\
     result = OP_CMP_BODY(op,mrb_float,mrb_float);\

--- a/test/t/float.rb
+++ b/test/t/float.rb
@@ -124,6 +124,39 @@ assert('Float#==', '15.2.9.3.7') do
   assert_false 3.1 == 3.2
 end
 
+assert('Float comparison with an Integer it cannot hold') do
+  # A Float keeps fewer significant bits than an mrb_int, so an integer past
+  # the significand rounds onto a neighbouring Float when the two are compared
+  # as Floats, and the Float answers equal to an integer it is not equal to.
+  #
+  # The pair is derived rather than written out. 2 ** p, for the p significant
+  # bits this build's Float holds, is the first Float that cannot be told from
+  # the integer above it, so the pair stays right where mrb_float is narrower
+  # than the usual 53 bits. A literal that wide cannot be built where mrb_int
+  # is narrow either, and failing to build one drops every test in this file.
+  #
+  # Where mrb_int cannot hold the integer, mruby-bigint answers the assertions
+  # below through mrb_bint_cmp() instead, which is exact for its own reasons;
+  # without that gem the build has no such integer at all and this skips.
+  f = 2.0
+  f *= 2 while f + 1.0 != f
+  begin
+    n = f.to_i + 1
+  rescue RangeError
+    skip 'no mrb_int here is wider than the significand of an mrb_float'
+  end
+
+  assert_false(f == n)
+  assert_false(f.__send__(:==, n))    # the method, where the line above is an opcode
+  assert_equal(-1, f <=> n)
+  assert_true(f < n)
+  assert_true(f.__send__(:<, n))
+  assert_true(f <= n)
+  assert_false(f > n)
+  assert_false(f >= n)
+  assert_false([f] == [n])        # Array#== reads the same comparison
+end
+
 assert('Float#ceil', '15.2.9.3.8') do
   a = 3.123456789.ceil
   b = 3.0.ceil

--- a/test/t/integer.rb
+++ b/test/t/integer.rb
@@ -99,6 +99,72 @@ assert('Integer#==', '15.2.8.3.7') do
   assert_true b
 end
 
+assert('Integer comparison with a Float that stands for another number') do
+  # An mrb_float keeps fewer significant bits than an mrb_int, so an integer
+  # past the significand rounds onto a neighbouring Float when the two are
+  # compared as Floats, and answers equal to a Float it is not equal to.
+  #
+  # The pair is derived rather than written out. 2 ** p, for the p significant
+  # bits this build's Float holds, is the first Float that cannot be told from
+  # the integer above it, so the pair stays right where mrb_float is narrower
+  # than the usual 53 bits. A literal that wide cannot be built where mrb_int
+  # is narrow either, and failing to build one drops every test in this file.
+  #
+  # Where mrb_int cannot hold the integer, mruby-bigint answers the assertions
+  # below through mrb_bint_cmp() instead, which is exact for its own reasons;
+  # without that gem the build has no such integer at all and this skips.
+  skip unless Object.const_defined?(:Float)
+  f = 2.0
+  f *= 2 while f + 1.0 != f
+  begin
+    n = f.to_i + 1
+  rescue RangeError
+    skip 'no mrb_int here is wider than the significand of an mrb_float'
+  end
+
+  assert_false(n == f)
+  assert_false(n.__send__(:==, f))    # the method, where the line above is an opcode
+  assert_equal(1, n <=> f)
+  assert_true(n > f)
+  assert_true(n.__send__(:>, f))
+  assert_true(n >= f)
+  assert_false(n < f)
+  assert_false(n <= f)
+  assert_false([n] == [f])        # Array#== reads the same comparison
+end
+
+assert('Integer comparison with a Float at the ends of the mrb_int range') do
+  # The far ends are where the neighbouring Floats stand furthest apart, and
+  # where the bounds the comparison tests against are themselves built. Both
+  # ends come from arithmetic for the reason the pair above does.
+  #
+  # A narrower mrb_int leaves the shift outside the range these name, and the
+  # two cases part the same way as above: with mruby-bigint the assertions
+  # still hold, answered by mrb_bint_cmp() rather than by the bounds, and
+  # without it the shift raises and this skips.
+  skip unless Object.const_defined?(:Float)
+  begin
+    half = 1 << 62
+  rescue RangeError
+    skip 'an mrb_int here is narrower than 64 bits'
+  end
+  imin = -half - half             # the least mrb_int, which is exact as a Float
+  imax = half - 1 + half          # the greatest, which is not
+  fmin = -(2.0 ** 63)
+  fmax = 2.0 ** 63
+  inf = 1.0 / 0.0
+
+  assert_true(imin == fmin)
+  assert_equal(0, imin <=> fmin)
+  assert_equal(1, (imin + 3) <=> fmin)
+  assert_true((imin + 3) > fmin)
+  assert_false(imax == fmax)
+  assert_equal(-1, imax <=> fmax)
+  assert_true(imax < fmax)
+  assert_true(imax < inf)
+  assert_true(imin > -inf)
+end
+
 assert('Integer#~', '15.2.8.3.8') do
   # Complement
   assert_equal(-1, ~0)


### PR DESCRIPTION
An `mrb_int` is cast to `mrb_float` to be compared against a Float, and a Float carries fewer significant bits than an `mrb_int` does. Every integer past the significand lands on a neighbouring Float, so it answers equal to a Float it is not equal to:

```ruby
(2 ** 53 + 1) == (2.0 ** 53)    # CRuby: false, mruby: true
(2 ** 53 + 1) <=> (2.0 ** 53)   # CRuby: 1,     mruby: 0
(2 ** 53 + 1) >   (2.0 ** 53)   # CRuby: true,  mruby: false
(2.0 ** 53)   ==  (2 ** 53 + 1) # CRuby: false, mruby: true
```

On a 64-bit `mrb_int` that is the whole range from 2\*\*53 to 2\*\*63, all of it reachable without mruby-bigint being built at all. The top of the range is where it is easiest to see, because there the gap between neighbouring Floats is 2048:

```console
$ bin/mruby -e 'p(-9223372036854775805 <=> -9223372036854775808.0)'
0
$ ruby -e 'p(-9223372036854775805 <=> -9223372036854775808.0)'
1
```

CRuby answers all of these as though neither side had been rounded, which is the behaviour matched here.

### Where a mixed pair is answered

Five places hold one, and each rounded:

| | |
| --- | --- |
| `src/numeric.c` `flo_eq()` | `Float#==` with an Integer |
| `src/numeric.c` `int_equal()` | `Integer#==` with a Float |
| `src/numeric.c` `cmpnum()` | `<=>`, and the `Comparable` operators built on it |
| `src/object.c` `mrb_equal()` | what `Array#==` and its callers read |
| `src/vm.c` `OP_CMP` | `OP_EQ`, `OP_LT`, `OP_LE`, `OP_GT`, `OP_GE` |

The last of those is where the first, third and fourth rows above are actually answered: in compiled code `==`, `<` and their neighbours are opcodes, and `OP_CMP` compares the pair itself for `INTEGER`/`FLOAT` rather than sending. Only `<=>` reaches `cmpnum()` there.

A big integer operand already goes through `mrb_bint_cmp()` at each of these and is untouched.

### The change

`mrb_int_float_cmp()` in `src/numeric.c`, declared in `mruby/internal.h`, which every one of the five now asks:

```c
mrb_int
mrb_int_float_cmp(mrb_int x, mrb_float y)
{
  if (isnan(y)) return -2;
  if (y < (mrb_float)MRB_INT_MIN) return 1;
  if (y >= -(mrb_float)MRB_INT_MIN) return -1;

  mrb_int yi = (mrb_int)y;
  if (x > yi) return 1;
  if (x < yi) return -1;
  if (y > (mrb_float)yi) return -1;
  if (y < (mrb_float)yi) return 1;
  return 0;
}
```

The two bounds are built from `MRB_INT_MIN` alone. Its magnitude is a power of two, so both are exact as Floats, where `MRB_INT_MAX` cast to a Float rounds up to a value no `mrb_int` reaches and would let one through.

Inside them the cast to `mrb_int` truncates toward zero and loses nothing, and `(mrb_float)yi` is exact for the same reason in either direction: below the significand `yi` is representable outright, and above it `y` had no fraction to truncate, so `yi` carries the value of `y` itself. What is left to decide is therefore the integer comparison, and then the sign of the fraction the truncation dropped.

`cmpnum()` tests `mrb_integer_p()` rather than `mrb_fixnum_p()`. Under word boxing on a 64-bit host `MRB_FIXNUM_MAX` is `INT64_MAX>>1`, so the Integers from 2\*\*62 up are heap `RInteger` objects; `mrb_fixnum_p()` is false for exactly the range where the rounding is widest, which is the range the `bin/mruby` line above stands in.

### NaN

`mrb_int_float_cmp()` reports a NaN operand apart, as -2, because the readers want different answers for it.

Equality is false, and the opcodes are false for every operator, which is what comparing the pair as two Floats gave. `cmpnum()` folds -2 back to the 0 it produced before, because -2 is what `num_lt()` and its neighbours raise on, while CRuby answers `1 < Float::NAN` with false rather than an error. Nothing about NaN changes here.

### Generated code

`.text` over every `.o`, against the same objects built from master, for each of the five builds `ci/gcc-clang` makes. Their compile lines are under Environment at the end: `full-debug` is `-O0`, the other four are `-O3`.

| build | master | this PR |
| --- | --- | --- |
| full-debug | 2782721 | 2783453 (+732) |
| bintest | 1774541 | 1775309 (+768) |
| cxx_abi | 1782420 | 1783444 (+1024) |
| byte-string | 1725897 | 1726729 (+832) |
| ascii-case | 1746651 | 1747483 (+832) |

Three objects move, and they account for the whole of each total:

| | master | this PR |
| --- | --- | --- |
| full-debug src/numeric.o | 22037 | 22595 (+558) |
| full-debug src/vm.o | 138320 | 138533 (+213) |
| full-debug src/object.o | 6466 | 6427 (-39) |
| bintest src/numeric.o | 26860 | 27884 (+1024) |
| bintest src/vm.o | 72641 | 72401 (-240) |
| bintest src/object.o | 6200 | 6184 (-16) |
| cxx_abi src/numeric.o | 26812 | 27868 (+1056) |
| cxx_abi src/vm.o | 83089 | 83105 (+16) |
| cxx_abi src/object.o | 6136 | 6088 (-48) |
| byte-string src/numeric.o | 26812 | 27836 (+1024) |
| byte-string src/vm.o | 69889 | 69713 (-176) |
| byte-string src/object.o | 6136 | 6120 (-16) |
| ascii-case src/numeric.o | 26860 | 27884 (+1024) |
| ascii-case src/vm.o | 69889 | 69713 (-176) |
| ascii-case src/object.o | 6200 | 6184 (-16) |

`src/numeric.o` carries all of the growth. In the `bintest` build `mrb_int_float_cmp` is 96 bytes of it, `flo_eq` gains 75 and `int_equal` 48, and `cmpnum` gains 795 because the compiler inlines the function into both of its arms. `src/vm.o` and `src/object.o` give bytes back in the four `-O3` builds: the opcode no longer holds an inline Float comparison, and under word boxing that comparison had to unbox the Float through a call. `full-debug` is the `-O0` build, where nothing is inlined and `src/vm.o` grows by the two call sites instead.

### Speed

Callgrind `Ir`, from the `bintest` build, taken as `Ir(2N) - Ir(N)` with N = 1,000,000 so that interpreter start-up cancels. Each loop compares once per iteration.

| loop | master | this PR | per comparison |
| --- | --- | --- | --- |
| `i < lim` with a Float `lim` | 412007304 | 422007886 | +10 |
| `i <=> lim` with a Float `lim` | 740013603 | 706012890 | -34 |
| `i < lim` with an Integer `lim` | 391006155 | 391006119 | 0 |

The opcode pays 10 instructions for the exact answer, +2.4% over the loop as a whole. `Integer#<=>` gets 34 back, because the new arm returns before the switch it stands in front of, which under word boxing had been unboxing both operands into Floats. An Integer against an Integer is untouched.

### Testing

`rake -m test` over `ci/gcc-clang`, all five builds green, 0 KO, 0 crash, and the compiler emits no warnings on either side.

| build | master | this PR |
| --- | --- | --- |
| full-debug | 2328 tests, 2325 OK, 3 skip | 2331 tests, 2328 OK, 3 skip |
| bintest | 2328 tests, 2317 OK, 11 skip | 2331 tests, 2320 OK, 11 skip |
| cxx_abi | 2328 tests, 2317 OK, 11 skip | 2331 tests, 2320 OK, 11 skip |
| byte-string | 2258 tests, 2209 OK, 49 skip | 2261 tests, 2212 OK, 49 skip |
| ascii-case | 2324 tests, 2311 OK, 13 skip | 2327 tests, 2314 OK, 13 skip |

`bintest` runs 117 bintests, all OK, on both. The three tests added here are the whole of the difference in every column.

`rake -m test` over `build_config/asan.rb` is green as well, address and undefined sanitizers both: 2331 tests, 2328 OK, 3 skip, plus 79 bintests, and no sanitizer report. The undefined sanitizer is what covers the cast to `mrb_int` above, which is undefined for a value the type cannot hold.

Three tests are added. `test/t/integer.rb` pins an Integer against the Float it used to equal, through the opcode and through `__send__` for the method behind it, for `==`, `<=>`, the four operators and `Array#==`; a second pins both ends of the `mrb_int` range, where the bounds in the function above are built, along with the infinities. `test/t/float.rb` pins the mirror of the first with the Float as the receiver. All three build their operands from a shifted variable rather than a literal, so that a build whose `mrb_int` cannot hold them skips rather than failing to compile the file, which would drop every test in it.

Beyond the suite, mruby was compared against CRuby 4.0.6 row by row:

* 625 fixed pairs, drawn from the significand boundary, the ends of the `mrb_int` range, the neighbours of 2\*\*63, the infinities and NaN, each asked 26 ways. Master answers 595 rows as CRuby does; this PR answers all 600 of the non-NaN ones. The 25 NaN rows are the ones described above and are unchanged.
* 30,000 random pairs, weighted toward the same boundaries, each asked 17 ways, run under the sanitizers. Master differs from CRuby on 19 of them, every one a pair the cast lands exactly on its Float; this PR agrees on all 30,000, with no sanitizer report.

The skip path was exercised on an `MRB_INT32` build without mruby-bigint, where `1 << 53` raises and the three tests skip with the file otherwise intact. Behaviour was also confirmed on `MRB_WORD_BOXING`, `MRB_NAN_BOXING`, `MRB_INT32` with mruby-bigint, and `MRB_USE_FLOAT32`, whose 24-bit significand puts the boundary far below 2\*\*53; the `MRB_USE_FLOAT32` builds carry three failures in `Float#to_s`, `mrb_vformat` and `sprintf` that master carries too and that are unrelated to this change.

`byte-string` builds without `MRB_UTF8_STRING` and `ascii-case` with `MRB_USE_ASCII_CASE`; nothing touched here reads how strings are indexed or what case table is compiled in, which is why those two builds move by the same amounts as `bintest`.

### Environment

<details>
<summary>Versions, and the compile line of every build named above</summary>

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS, Linux 7.0.0-28-generic x86_64 |
| CPU | AMD Ryzen 9 5950X, 16 cores |
| C compiler | gcc 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1) |
| Sanitizer compiler | clang 22.1.8 (Homebrew), which is what `build_config/asan.rb` picks |
| Linker | GNU ld 2.47.20260726, and `g++` for `cxx_abi` |
| Profiler | valgrind 3.27.1, `--tool=callgrind` |
| CRuby | 4.0.6 (2026-07-14) +PRISM, running rake and answering the comparisons above |

What each build actually compiles `src/numeric.c` with, `-MMD -c`, the `-I` paths and `-o` stripped:

```console
# ci/gcc-clang, full-debug
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang, bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK

# ci/gcc-clang, cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang, byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang, ascii-case
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CASE -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# build_config/asan.rb
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -fsanitize=address,undefined -g3 -O0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

`-g -O3` is what the `gcc` toolchain sets. `full-debug` and the sanitizer build then append `-g3 -O0` through `enable_debug()`, so those two are `-O0`, not `-O3`. `cxx_abi` is the C compiler driven as C++ with `-x c++ -std=gnu++03`, and `g++` links it.

The `.text` figures were taken from a build dir holding no test objects, `rake` without `test`, on both sides. The `Ir` figures come from the `bintest` binaries of those same two dirs.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved comparisons between integers and floating-point values without losing precision for large integers.
  - Corrected equality and ordering behavior involving values beyond floating-point precision.
  - Preserved expected behavior for infinities and unordered NaN comparisons across comparison operators and collection equality.

- **Tests**
  - Added coverage for mixed integer/Float operators, method calls, array equality, precision boundaries, and special values across supported numeric configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->