### PR TITLE
mruby-bigint: count the limbs an mrb_int needs in mpz_set_int()

### DIFF
--- a/mrbgems/mruby-bigint/core/bigint.c
+++ b/mrbgems/mruby-bigint/core/bigint.c
@@ -231,6 +231,22 @@ mpz_init_set(mpz_ctx_t *ctx, mpz_t *s, mpz_t *t)
 }
 
 static void
+mpz_set_uint64(mpz_ctx_t *ctx, mpz_t *y, uint64_t u)
+{
+  size_t len = 0;
+
+  for (uint64_t u0=u; u0; u0>>=DIG_SIZE,len++)
+    ;
+  y->sn = (u != 0);
+  mpz_realloc(ctx, y, len);
+  y->sz = len;
+  for (size_t i=0; i<len; i++) {
+    y->p[i] = (mp_limb)LOW(u);
+    u >>= DIG_SIZE;
+  }
+}
+
+static void
 mpz_set_int(mpz_ctx_t *ctx, mpz_t *y, mrb_int v)
 {
   mrb_uint u;
@@ -251,33 +267,17 @@ mpz_set_int(mpz_ctx_t *ctx, mpz_t *y, mrb_int v)
   }
 #if MRB_INT_BIT > DIG_SIZE
   if ((u & ~DIG_MASK) != 0) {
-    mpz_realloc(ctx, y, 2);
-    y->p[1] = (mp_limb)HIGH(u);
-    y->p[0] = (mp_limb)LOW(u);
-    y->sz = 2;
+    /* An mrb_int can be wider than two limbs; mpz_set_uint64() counts them.
+       It derives the sign from the magnitude, so keep the one v gave. */
+    short sn = y->sn;
+    mpz_set_uint64(ctx, y, u);
+    y->sn = sn;
     return;
   }
 #endif
   mpz_realloc(ctx, y, 1);
   y->p[0] = (mp_limb)u;
   y->sz = 1;
-}
-
-
-static void
-mpz_set_uint64(mpz_ctx_t *ctx, mpz_t *y, uint64_t u)
-{
-  size_t len = 0;
-
-  for (uint64_t u0=u; u0; u0>>=DIG_SIZE,len++)
-    ;
-  y->sn = (u != 0);
-  mpz_realloc(ctx, y, len);
-  y->sz = len;
-  for (size_t i=0; i<len; i++) {
-    y->p[i] = (mp_limb)LOW(u);
-    u >>= DIG_SIZE;
-  }
 }
 
 #ifdef MRB_INT32

--- a/mrbgems/mruby-bigint/test/bigint.rb
+++ b/mrbgems/mruby-bigint/test/bigint.rb
@@ -432,3 +432,22 @@ assert('Integer - a Float too big for an mrb_int keeps every digit') do
     assert_equal f, f.to_i.to_f
   end
 end
+
+assert('Bigint an mrb_int operand keeps every bit') do
+  # An mrb_int was written into a fixed pair of limbs, which holds the whole
+  # value only while a limb is half an mrb_int wide.  Under MRB_NO_MPZ64BIT a
+  # limb is 16 bits, so every bit from 32 up was dropped on the way in.  This
+  # is the entry every fixnum overflow takes.
+  max = (1 << 62) - 1 + (1 << 62)  # MRB_INT_MAX where an mrb_int is 64 bits
+  assert_equal 9223372036854775808, max + 1
+  assert_equal 9223372036854775808, (1 << 62) * 2
+  assert_equal(-9223372036854775809, -max - 2)
+  assert_equal(-13835058055282163712, -(1 << 62) * 3)
+
+  # ...and the same conversion on the mrb_int operand of a big integer.  Every
+  # expected value is named outright, because writing one as an expression over
+  # (1 << 32) would take the same broken path and agree with the wrong answer.
+  assert_equal 18446744078004518913, (1 << 64) + ((1 << 32) + 1)
+  assert_equal 18446744069414584319, (1 << 64) - ((1 << 32) + 1)
+  assert_equal 79228162514264337593543950336, (1 << 64) * (1 << 32)
+end


### PR DESCRIPTION
`mpz_set_int()` writes an `mrb_int` into a fixed pair of limbs
(`mrbgems/mruby-bigint/core/bigint.c:252-261` on master):

```c
#if MRB_INT_BIT > DIG_SIZE
  if ((u & ~DIG_MASK) != 0) {
    mpz_realloc(ctx, y, 2);
    y->p[1] = (mp_limb)HIGH(u);
    y->p[0] = (mp_limb)LOW(u);
    y->sz = 2;
    return;
  }
#endif
```

Two limbs carry the whole value only while a limb is half an `mrb_int` wide.
`MRB_NO_MPZ64BIT` makes `mp_limb` a `uint16_t` and `MPZ_DIG_SIZE` 16
(`mrbgems/mruby-bigint/core/bigint.h:33-37`) while `mrb_int` stays 64 bits, so those two
limbs hold 32 of the 64 bits. `HIGH(u)` keeps bits 16 to 31 and everything from
bit 32 up is dropped. The `MRB_INT_BIT > DIG_SIZE` guard is true for this build,
so it takes the branch and there is no wider one behind it.

```ruby
9223372036854775807 + 1    # CRuby: 9223372036854775808, mruby: 4294967296
4611686018427387904 * 2    # CRuby: 9223372036854775808, mruby: 0
-9223372036854775807 - 2   # CRuby: -9223372036854775809, mruby: -4294967297
```

This is the entry every fixnum overflow takes: `mrb_bint_add_ii()`,
`mrb_bint_sub_ii()` and `mrb_bint_mul_ii()` each reach it through
`mpz_init_set_int()`, which is why the three lines above are wrong in three
different ways rather than one. It is also how an `mrb_int` operand of an
existing big integer is converted, so `(1<<64) + ((1<<32) + 1)` loses its `2**32`
as well.

Two tests fail on master because of it, `Bigint Integer#pow(e, m) - Montgomery
path` and `Bigint gcd`, both downstream of the same truncation rather than
defects of their own.

## Fix

Hand the wide case to `mpz_set_uint64()`, the loop right below that already
counts the limbs a magnitude needs. It derives the sign from the magnitude, so
the sign `v` gave is kept across the call. `mpz_set_uint64()` moves above
`mpz_set_int()` to be visible there; its body is unchanged.

The single-limb path is untouched, so a value that fits one limb costs exactly
what it did.

## Tests

`Bigint an mrb_int operand keeps every bit` pins all seven expressions. Every
expected value is named outright rather than written as an expression over
`(1 << 32)`, because such an expression takes the same broken path and agrees
with the wrong answer: on master `-(1 << 63) - 1` answers `-1`, not
`-9223372036854775809`. With the fix reverted, all seven assertions fail.

## Size

`.text` of `bigint.o`, and the `text` column of `bin/mruby`, from a clean build
directory. Both configurations are the `default` gembox.

| build | master | this PR | delta |
|---|---|---|---|
| `bigint.o`, default | 93,434 | 92,842 | **-592** |
| `bigint.o`, `MRB_NO_MPZ64BIT` | 97,419 | 97,643 | +224 |
| `bin/mruby`, default | 1,725,391 | 1,724,759 | **-632** |
| `bin/mruby`, `MRB_NO_MPZ64BIT` | 1,729,247 | 1,729,495 | +248 |

## Instruction count

callgrind, `Ir(2N) - Ir(N)` to cancel startup, over a loop of nothing but
big-integer arithmetic:

```ruby
n = ARGV[0].to_i
a = (1 << 62) - 1 + (1 << 62)
b = (1 << 64)
i = 0
while i < n
  x = a + 1        # fixnum overflow, mrb_bint_add_ii
  y = a * 2        # fixnum overflow, mrb_bint_mul_ii
  z = b + 12345    # mrb_int operand of a big integer
  i += 1
end
```

| build | master | this PR | delta |
|---|---|---|---|
| default | 1,205,076,368 | 1,210,676,368 | +0.46% |
| `MRB_NO_MPZ64BIT` | 1,055,730,208 | 1,087,076,368 | +2.97% |

The default build pays 0.46% on a loop that is entirely big-integer arithmetic,
for a `bigint.o` that is 592 bytes smaller. The `MRB_NO_MPZ64BIT` figure is the
cost of writing four limbs where master wrote two: master was cheaper because it
was answering with half the value.

## Verification

26 configurations, `rake test` in each. On master the failures land on exactly
the seven that pair `MRB_INT64` with a 16-bit limb; every one of them passes
here, and no configuration regresses.

| group | axes | master | this PR |
|---|---|---|---|
| x86_64 gcc, `full-core`, `MRB_DEBUG` | boxing {no, word, nan} x int {64, 32} x limb {32, 16} | 3 KO in the three `i64`/`l16` builds | 12/12 pass |
| i686 gcc, `full-core`, `MRB_DEBUG` | no boxing x int {64, 32} x limb {32, 16}; word/nan x `MRB_INT32` x limb {32, 16} | 3 KO in `no`/`i64`/`l16` | 8/8 pass |
| clang, ASan + UBSan, `full-core` | limb {32, 16} | 3 KO in `l16` | 2/2 pass |
| clang, `full-core` | limb {32, 16} | 3 KO in `l16` | 2/2 pass |
| gcc `enable_cxx_abi`, `default` | limb {32, 16} | 3 KO in `l16` | 2/2 pass |

`MRB_INT64` with word or nan boxing on 32-bit is not in the matrix:
`include/mrbconf.h:99` refuses it with `#error "MRB_INT64 on 32-bit requires
MRB_NO_BOXING"`.

ASan and UBSan on a 16-bit-limb build matter here specifically: the fix writes
four limbs where two were written before, and the run is clean.

`bigint.c` compiles with the same one warning before and after on a 16-bit-limb
build (`inv3 = 0xAAAAAAAAAAAAAAABULL`, `-Woverflow`, pre-existing).

`rake test` on the `default` config also runs `bintest`: 106/106.

`grep -rn 'MPZ64BIT' .github/workflows/` is empty, so no CI job builds
`MRB_NO_MPZ64BIT`, which is why the two failing tests have gone unnoticed.

### Environment

<details>

| | |
|---|---|
| OS | Ubuntu 24.04, Linux x86_64 |
| gcc | 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1) |
| clang | Homebrew clang 22.1.8 |
| i686 | `i686-linux-gnu-gcc` 13.3.0 |
| valgrind | callgrind, for the instruction counts |
| CRuby | 4.0.6, for the expected values |

Compile lines for the builds quoted above, paths shortened:

```
# default (size and Ir rows)
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_BIGINT_VERSION=0.0.0 -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK -I"include" -I"build/size-def/include" -o "build/size-def/mrbgems/mruby-bigint/core/bigint.o" "mrbgems/mruby-bigint/core/bigint.c"

# MRB_NO_MPZ64BIT (size and Ir rows)
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_MPZ64BIT -DMRBGEM_MRUBY_BIGINT_VERSION=0.0.0 -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK -I"include" -I"build/size-16/include" -o "build/size-16/mrbgems/mruby-bigint/core/bigint.o" "mrbgems/mruby-bigint/core/bigint.c"

# nan boxing, MRB_INT64, MRB_NO_MPZ64BIT (one of the seven that fail on master)
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_NAN_BOXING -DMRB_INT64 -DMRB_NO_MPZ64BIT -DMRBGEM_MRUBY_BIGINT_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -I"include" -I"build/n-nan-i64-l16/include" -o "build/n-nan-i64-l16/mrbgems/mruby-bigint/core/bigint.o" "mrbgems/mruby-bigint/core/bigint.c"

# clang, ASan + UBSan, MRB_NO_MPZ64BIT
clang -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -fsanitize=address,undefined -g3 -O0 -DMRB_NO_MPZ64BIT -DMRBGEM_MRUBY_BIGINT_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -I"include" -I"build/asan-l16/include" -o "build/asan-l16/mrbgems/mruby-bigint/core/bigint.o" "mrbgems/mruby-bigint/core/bigint.c"

# C++ ABI, MRB_NO_MPZ64BIT
gcc -MMD -c -g -O3 -Wall -Wundef -Wwrite-strings -g3 -O0 -x c++ -std=gnu++03 -DMRB_NO_MPZ64BIT -DMRBGEM_MRUBY_BIGINT_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK -I"include" -I"build/cxx-l16/include" -o "build/cxx-l16/mrbgems/mruby-bigint/core/bigint.o" "mrbgems/mruby-bigint/core/bigint.c"

# i686, MRB_NO_BOXING, MRB_INT64, MRB_NO_MPZ64BIT
i686-linux-gnu-gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_NO_BOXING -DMRB_INT64 -DMRB_NO_MPZ64BIT -DMRBGEM_MRUBY_BIGINT_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -I"include" -I"build/x86-no-i64-l16/include" -o "build/x86-no-i64-l16/mrbgems/mruby-bigint/core/bigint.o" "mrbgems/mruby-bigint/core/bigint.c"
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VTnLSJEtJMAHG5B3GfrxXF


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversion of large integer values to Bigint, preserving high and low bits for positive and negative numbers.
  * Corrected arithmetic behavior for overflow, addition, subtraction, and multiplication involving large integers.

* **Tests**
  * Added regression coverage for large integer conversion and arithmetic scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
