### PR TITLE
boxing_word.h: let one flag answer whether floats are inlined

### DIFF
--- a/include/mruby/boxing_word.h
+++ b/include/mruby/boxing_word.h
@@ -7,7 +7,11 @@
 #ifndef MRUBY_BOXING_WORD_H
 #define MRUBY_BOXING_WORD_H
 
-#if defined(MRB_32BIT) && !defined(MRB_USE_FLOAT32) && !defined(MRB_WORDBOX_NO_INLINE_FLOAT)
+/* Floats are not inlined where a double does not fit beside the tag, nor where
+   there are no floats to inline. The tag layout below and mrb_type() both ask
+   that one question, so it is answered once, here. */
+#if !defined(MRB_WORDBOX_NO_INLINE_FLOAT) && \
+    (defined(MRB_NO_FLOAT) || (defined(MRB_32BIT) && !defined(MRB_USE_FLOAT32)))
 # define MRB_WORDBOX_NO_INLINE_FLOAT
 #endif
 
@@ -79,7 +83,7 @@ enum mrb_special_consts {
 #define WORDBOX_FIXNUM_FLAG     (1 << (WORDBOX_FIXNUM_BIT_POS - 1))
 #define WORDBOX_FIXNUM_MASK     ((1 << WORDBOX_FIXNUM_BIT_POS) - 1)
 
-#if defined(MRB_WORDBOX_NO_INLINE_FLOAT) || defined(MRB_NO_FLOAT)
+#ifdef MRB_WORDBOX_NO_INLINE_FLOAT
 /* floats are allocated in heaps */
 #define WORDBOX_IMMEDIATE_MASK  0x03
 #define WORDBOX_SYMBOL_BIT_POS  2


### PR DESCRIPTION
An `MRB_NO_FLOAT` build does not boot on 64-bit. It dies during mrblib initialization on an empty script, at `module_function def loop`, with a message that contradicts itself: the actual type prints as `Symbol` and the expected type prints as `Symbol`.

```console
$ mruby -e ''
mrblib/kernel.rb:27:in module_function: wrong argument type Symbol (expected Symbol) (TypeError)
```

Two guards in `include/mruby/boxing_word.h` disagree about the same question. The tag layout moves symbols to the heap-float scheme for either `MRB_WORDBOX_NO_INLINE_FLOAT` or `MRB_NO_FLOAT`, so a symbol carries low bits `0b10`. `mrb_type()` switches on `MRB_WORDBOX_NO_INLINE_FLOAT` alone, and that flag is auto-defined for 32-bit only, so on 64-bit it reads those same bits through the inline-float table and answers `MRB_TT_FLOAT`. `mrb_symbol_p()` is a raw tag test and still answers true, which is how `mrb_check_type()` comes to name the same type twice.

Both sites are asking whether floats are inlined, so ask it once: define `MRB_WORDBOX_NO_INLINE_FLOAT` under `MRB_NO_FLOAT` as well, and the tag layout no longer needs its own second condition.

For a build that has floats the new guard reduces to the one it replaces, and the second hunk keeps its meaning once `MRB_NO_FLOAT` implies the flag, so nothing outside a no-float build changes. Every block behind that flag which names a float type is already nested inside `#ifndef MRB_NO_FLOAT`: the `RFloat` definition, the `union mrb_value_` member, the `mrb_float()` and `mrb_float_p()` selections, `src/etc.c`, `mrbgems/mruby-test/driver.c`, and the one block in `src/gc.c`, which already excludes `MRB_NO_FLOAT` by hand.

## Reproduction without the VM

`mrbc` provenance is not involved. The contradiction is in the headers, so one translation unit shows it:

```c
#include <mruby.h>
#include <stdio.h>
int main(void) {
  mrb_value v = mrb_symbol_value((mrb_sym)0xfc);
  printf("mrb_symbol_p=%d mrb_type=%d (SYMBOL=%d FLOAT=%d)\n",
         (int)mrb_symbol_p(v), (int)mrb_type(v),
         (int)MRB_TT_SYMBOL, (int)MRB_TT_FLOAT);
  return 0;
}
```

| headers | defines | `mrb_symbol_p` | `mrb_type` |
| --- | --- | --- | --- |
| master | none | 1 | 2 (`MRB_TT_SYMBOL`) |
| master | `MRB_NO_FLOAT` | 1 | 5 (`MRB_TT_FLOAT`) |
| master | `MRB_NO_FLOAT`, `MRB_WORDBOX_NO_INLINE_FLOAT` | 1 | 2 (`MRB_TT_SYMBOL`) |
| this branch | none | 1 | 2 (`MRB_TT_SYMBOL`) |
| this branch | `MRB_NO_FLOAT` | 1 | 2 (`MRB_TT_SYMBOL`) |
| this branch | `MRB_NO_FLOAT`, `MRB_WORDBOX_NO_INLINE_FLOAT` | 1 | 2 (`MRB_TT_SYMBOL`) |

## Measured

Both in-tree configs that carry `MRB_NO_FLOAT` fail at the same site with the same message before, and boot after.

```console
# build_config/host-nofloat.rb, before / after
$ mruby -e ''                                     # exit 1 -> exit 0
$ mruby -e 'p :sym, 1+2, "s".upcase, [1,2].map{|x|x*2}'
:sym / 3 / "S" / [2, 4]                           # exit 0
$ mruby -e 'p 1.5'
-e:1: Not implemented: PM_FLOAT_NODE              # exit 1, which is what a no-float build should say

# build_config/no-float.rb, before / after
$ mruby -e ''                                     # exit 1 -> exit 0
$ mruby -e 'p :sym, 1+2, "s".upcase'
:sym / 3 / "S"                                    # exit 0
```

The default host build is untouched: `rake -m test` runs Total 2110, KO 0, Crash 0.

Nothing in CI builds `MRB_NO_FLOAT`, and no in-tree 64-bit config pairs it with `MRB_NO_BOXING` or an explicit `MRB_WORDBOX_NO_INLINE_FLOAT`, which is why this has sat.

`rake test` on a no-float build still stops earlier than the runner, at a float literal in a shared test file (`mrbgems/mruby-compar-ext/test/compar.rb:4`, `Not implemented: PM_FLOAT_NODE`). That is a separate defect in the test data and is left alone here.

## Environment

| | |
| --- | --- |
| Commit | `28a968c` on `71dd52d` |
| OS | Linux x86_64 |
| Compiler | gcc 13.3.0 |
| Boxing | default (word boxing) |

<details>
<summary>Compile lines</summary>

```
# build_config/host-nofloat.rb
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_NO_FLOAT -DMRB_DEBUG -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -I"include" -I"build/host-nofloat/include" -o "build/host-nofloat/src/etc.o" "src/etc.c"

# build_config/no-float.rb
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_NO_FLOAT -DMRB_DEBUG -I"include" -I"build/no-float/include" -o "build/no-float/src/etc.o" "src/etc.c"

# build_config/default.rb
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK -I"include" -I"build/host/include" -o "build/host/src/etc.o" "src/etc.c"

# header probe (each row of the table above)
gcc [-DMRB_NO_FLOAT] [-DMRB_WORDBOX_NO_INLINE_FLOAT] -I"include" -I"build/host-nofloat/include" probe.c -o probe
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011w5jhq8qcFeFVdfCC897dZ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for floating-point handling across supported build configurations.
  * Ensured immediate-value layouts are selected consistently when inline floating-point values are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->