### PR TITLE
mruby-regexp: test a lookbehind over a class that holds a stray byte

### DIFF
--- a/mrbgems/mruby-regexp/test/regexp_syntax.rb
+++ b/mrbgems/mruby-regexp/test/regexp_syntax.rb
@@ -911,6 +911,35 @@ assert("Regexp - lookbehind measures bytes that spell no character") do
   assert_nil "aab".match(/(?<=Āa)b/)
 end
 
+assert("Regexp - lookbehind over a class holding a byte that spells no character") do
+  # Two things meet here that were built apart: a character class may hold a
+  # byte that starts no character, and the rewind steps back over characters.
+  # They agree on the unit already: such a byte is a character of its own,
+  # which is the step the forward match takes for it too, so a class holding
+  # one is measured as one character wide, the same as any other class.
+  #
+  # A subject whose bytes spell no character is refused wherever an encoding
+  # reads them, so the stray byte is put to a binary subject, which rewinds by
+  # bytes in either build.
+  assert_equal "x", "\xB5x".b.match(/(?<=[\xB5])x/)[0]
+  assert_equal 1, ("\xB5x".b =~ /(?<=[\xB5])x/)
+  if __ENCODING__ == "UTF-8"
+    assert_raise(ArgumentError) { "\xB5x" =~ /(?<=[\xB5])x/ }
+    # the byte written into a class is still asked about a character: Ā is
+    # C4 80, and the rewind steps back over the whole of it, so the class is
+    # handed U+0100 rather than either of its bytes
+    assert_nil ("Āx" =~ /(?<=[\x80])x/)
+    assert_nil ("Āx" =~ /(?<=[\xC4])x/)
+    assert_equal 1, ("Āx" =~ /(?<=[Ā])x/)
+  else
+    # a build that reads its strings by byte has one character per byte, so
+    # the same class does see the continuation byte, and only that one
+    assert_equal 1, ("\xB5x" =~ /(?<=[\xB5])x/)
+    assert_equal 2, ("\xC4\x80x" =~ /(?<=[\x80])x/)
+    assert_nil ("\xC4\x80x" =~ /(?<=[\xC4])x/)
+  end
+end
+
 assert("Regexp - lookbehind measures an ASCII-only class") do
   assert_equal "x", "ax".match(/(?<=[a-z])x/)[0]
   assert_nil "1x".match(/(?<=[a-z])x/)


### PR DESCRIPTION
A character class may hold a byte that starts no character, and a lookbehind rewinds over characters rather than bytes. The two agree on the unit already: such a byte is a character of its own, which is the step the forward match takes for it, so a class holding one is one character wide like any other class. Nothing pinned that.

The class rows nearby all hold characters, and the stray-byte rows all write the byte into the pattern literally rather than into a class. The one existing crossing is a binary subject, which rewinds by bytes; the character reading of the same question has no row.

Three readings, because the answer depends on what reads the subject:

- A binary subject rewinds by bytes in either build, and it is where a stray byte can be put to a subject at all: a subject whose bytes spell no character is refused wherever an encoding reads them.
- Reading by character, the class is asked about a character even when it holds a byte. The rewind steps back over the whole of `Ā`, so the class is handed U+0100 and neither `C4` nor `80` matches it.
- Reading by byte, there is one character per byte, so the same class does see the continuation byte, and only that one.

Tests only. The block carries no `skip`, so it runs everywhere rather than skipping silently on the builds that read by byte: every build below reports one test more than `master` with its skip count unchanged, KO 0.

| build | `master` | this PR | skip |
| --- | --- | --- | --- |
| `build_config/default.rb` | 2110 | 2111 | 49 |
| `ci/gcc-clang`, `full-debug` | 2334 | 2335 | 3 |
| `ci/gcc-clang`, `bintest` | 2334 | 2335 | 11 |
| `ci/gcc-clang`, `cxx_abi` | 2334 | 2335 | 11 |
| `ci/gcc-clang`, `byte-string` | 2264 | 2265 | 49 |
| `ci/gcc-clang`, `ascii-case` | 2330 | 2331 | 13 |
| `build_config/asan.rb` | 2334 | 2335 | 3 |

### Environment

<details>

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-28-generic x86_64 |
| CPU | AMD Ryzen 9 5950X |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0 |
| C compiler (asan) | Homebrew clang 22.1.8 |
| binutils | GNU ld (GNU Binutils) 2.47.20260726 |
| CRuby | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |

The line each build actually compiles `src/string.c` with, taken from `rake --verbose` with `-MMD -c`, `-I` and `-o` dropped:

```console
# build_config/default.rb
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK

# ci/gcc-clang, full-debug
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang, bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK

# ci/gcc-clang, cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang, byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang, ascii-case
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CASE -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# build_config/asan.rb
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -fsanitize=address,undefined -g3 -O0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

`-g -O3` is what the `gcc` toolchain sets. `full-debug` and the sanitizer build then append `-g3 -O0` through `enable_debug()`, so those two are `-O0`, not `-O3`. `cxx_abi` is the C compiler driven as C++ with `-x c++ -std=gnu++03`, and `g++` links it.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added regression coverage for regular-expression lookbehind with character classes containing invalid byte sequences.
  - Added validation for binary subjects and UTF-8 inputs with invalid encoding.
  - Expanded coverage to distinguish matching individual continuation or leading bytes from matching complete multibyte characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->