### PR TITLE
build_config: let the asan config use the compiler that is present

### DIFF
--- a/build_config/asan.rb
+++ b/build_config/asan.rb
@@ -1,8 +1,12 @@
 # Address/Undefined sanitizer build in a dedicated build directory (build/asan)
 # so it does not clobber a normal host build. Used by the pre-push hook to catch
 # memory-safety regressions (see issues #6905, #6906) before pushing.
+#
+# The toolchain is the guessed one, so this config runs wherever a sanitizer
+# runtime is installed: gcc with libasan, or clang with compiler-rt. Pin
+# build_config/clang-asan.rb instead to ask for clang specifically.
 MRuby::Build.new('asan') do |conf|
-  conf.toolchain :clang
+  conf.toolchain
 
   conf.gembox 'full-core'
 


### PR DESCRIPTION
`build_config/asan.rb` pins its toolchain (`build_config/asan.rb:4-5` on master):

```ruby
MRuby::Build.new('asan') do |conf|
  conf.toolchain :clang
```

so a machine with gcc and libasan but no clang sanitizer runtime cannot produce a
sanitizer build at all, and no other config in the tree offers one.

Nothing in the config is clang specific. `enable_sanitizer` is defined by the gcc
toolchain rules (`tasks/toolchains/gcc.rake:67-73`), which put `-fsanitize=` onto
`cc`, `cxx` and `linker`, and `tasks/toolchains/clang.rake:1-8` only re-enters
those rules with `default_command: 'clang'`. gcc answers
`-fsanitize=address,undefined` with its own runtime.

## Fix

Guess the toolchain, the way `build_config/default.rb` does. `MRuby::Toolchain.guess`
answers clang on darwin and the BSDs, clang wherever `CC` or `CXX` names it, and gcc
otherwise, so the config follows the machine. Asking for clang specifically is what
`build_config/clang-asan.rb` is for, and it is unchanged.

## Environment

Three `ubuntu:24.04` containers on Linux x86_64, gcc 13.3.0
(`Ubuntu 13.3.0-6ubuntu2~24.04.1`) in all three:

- **A**: no clang installed
- **B**: clang 18.1.3, no sanitizer runtime (`libclang-rt-18-dev` absent)
- **C**: clang 18.1.3 with `libclang-rt-18-dev`, built with `CC=clang CXX=clang++ LD=clang`

Run with the default seccomp profile relaxed (`--security-opt seccomp=unconfined`),
which ASan needs under Docker; unrelated to this change.

## Before

A stops at the first compile:

```console
$ MRUBY_CONFIG=build_config/asan.rb rake
sh: 1: clang: not found
Command failed with status (127): [clang -E -P -std=gnu99 ...]
```

B gets as far as the first link:

```console
$ MRUBY_CONFIG=build_config/asan.rb rake
/usr/bin/ld: cannot find /usr/lib/llvm-18/lib/clang/18/lib/linux/libclang_rt.asan_static-x86_64.a: No such file or directory
/usr/bin/ld: cannot find /usr/lib/llvm-18/lib/clang/18/lib/linux/libclang_rt.asan-x86_64.a: No such file or directory
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

## After

A and B both build, arm, and run clean:

```console
$ MRUBY_CONFIG=build_config/asan.rb rake            # exit 0
$ ldd build/asan/bin/mruby | grep san
	libasan.so.8 => /lib/x86_64-linux-gnu/libasan.so.8
	libubsan.so.1 => /lib/x86_64-linux-gnu/libubsan.so.1
$ build/asan/bin/mruby -e 'p [1,2].map{|x| x*2}'
[2, 4]
$ MRUBY_CONFIG=build_config/asan.rb rake test
  Total: 2334   KO: 0   Crash: 0   Skip: 3
  Total:   79   KO: 0   Crash: 0            # bintest
```

with no sanitizer report anywhere in either run.

C is unchanged by the patch: the guess honours `CC`, so clang is still what builds it,
and the sanitizer flags are still there.

```console
$ CC=clang CXX=clang++ LD=clang MRUBY_CONFIG=build_config/asan.rb rake   # exit 0
$ grep -E '^MRUBY_CC |^MRUBY_LDFLAGS ' build/asan/lib/libmruby.flags.mak
MRUBY_CC = clang
MRUBY_LDFLAGS = -fsanitize=address,undefined -L$(MRUBY_PACKAGE_DIR)/lib
$ nm build/asan/bin/mruby | grep -c __asan_
320
$ MRUBY_CONFIG=build_config/asan.rb rake test
  Total: 2334   KO: 0   Crash: 0   Skip: 3
  Total:   79   KO: 0   Crash: 0            # bintest
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y5jfesJKA4HG8ujqNwUKLV


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AddressSanitizer builds by supporting the available compiler toolchain, including GCC and Clang.
  * Preserved existing sanitizer, debugging, binary testing, and test settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->