### PR TITLE
mruby-compiler, mruby-bin-mruby: refuse a program file that cannot be read

### DIFF
--- a/mrbgems/mruby-bin-mrbc/bintest/mrbc.rb
+++ b/mrbgems/mruby-bin-mrbc/bintest/mrbc.rb
@@ -1,4 +1,5 @@
 require 'tempfile'
+require 'tmpdir'
 
 assert('Compiling multiple files without new line in last line. #2361') do
   a, b, out = Tempfile.new('a.rb'), Tempfile.new('b.rb'), Tempfile.new('out.mrb')
@@ -105,4 +106,21 @@ assert('non-seekable input file is rejected by size, not blamed on the read') do
   assert_equal 1, $?.exitstatus
   assert_include result, 'compile.c: cannot get size of program file. (/dev/stdin)'
   assert_not_include result, 'cannot read program file'
+end
+
+assert('a directory as an input file is refused') do
+  # Only POSIX systems open a directory for reading; Windows refuses it at
+  # fopen() and never reaches the reader this guards.
+  skip 'fopen() refuses a directory' if /mswin(?!ce)|mingw|bccwin/ =~ RbConfig::CONFIG['host_os']
+  # ftell() answers LONG_MAX for a directory stream on ext4 and 0 on tmpfs,
+  # and the size check accepts both: the first overflows the length
+  # arithmetic that sizes the buffer, the second compiles as an empty
+  # program.  The fread() failure below reports the LONG_MAX case in wording
+  # of its own, so pin which message arrives, not merely that one did.
+  Dir.mktmpdir do |dir|
+    result = `#{cmd('mrbc')} -c #{shellquote(dir)} 2>&1`
+    assert_include result, 'compile.c: cannot read from program file.'
+    assert_not_include result, 'compile.c: cannot read program file.'
+    assert_equal 1, $?.exitstatus
+  end
 end

--- a/mrbgems/mruby-bin-mruby/bintest/mruby.rb
+++ b/mrbgems/mruby-bin-mruby/bintest/mruby.rb
@@ -1,5 +1,6 @@
 require 'tempfile'
 require 'open3'
+require 'tmpdir'
 
 MRUBY_BIN = "mruby"
 
@@ -202,4 +203,24 @@ assert('String#split still works when mruby-regexp is loaded') do
                ["-e", 'p "abc abc abc".split'])
   assert_mruby(%Q(["hello", "world"]\n), "", true,
                ["-e", 'p "hello world".split(/\s+/)'])
+end
+
+assert('a directory as the program file is refused') do
+  # Only POSIX systems open a directory for reading; Windows refuses it at
+  # fopen() and reports that instead.
+  skip 'fopen() refuses a directory' if /mswin(?!ce)|mingw|bccwin/ =~ RbConfig::CONFIG['host_os']
+  # A directory opens for reading and then fails every read, and the loader
+  # answers nil for that without raising, so without a check it ran as an
+  # empty program: no output, no diagnostic, exit 0.
+  Dir.mktmpdir do |dir|
+    assert_mruby("", /Cannot read program file/, false, [dir])
+  end
+end
+
+assert('a directory as a library file is refused') do
+  skip 'fopen() refuses a directory' if /mswin(?!ce)|mingw|bccwin/ =~ RbConfig::CONFIG['host_os']
+  # -r took the same swallowed read, and went on to run the program.
+  Dir.mktmpdir do |dir|
+    assert_mruby("", /Cannot read library file/, false, ["-r", dir, "-e", "puts 1"])
+  end
 end

--- a/mrbgems/mruby-bin-mruby/tools/mruby/mruby.c
+++ b/mrbgems/mruby-bin-mruby/tools/mruby/mruby.c
@@ -143,6 +143,21 @@ dup_arg_item(mrb_state *mrb, const char *item)
   return buf;
 }
 
+/* A directory opens for reading on POSIX systems and then fails every read
+   with EISDIR, so a stream that opened says nothing about whether it can be
+   read.  One byte tells the two apart without asking the platform what kind
+   of file this is: an empty file reports end-of-file and no error, while a
+   directory raises the error indicator.  The byte is pushed back, so the
+   stream is left where it was found. */
+static int
+stream_is_unreadable(FILE *file)
+{
+  int c = getc(file);
+  if (c == EOF) return ferror(file) != 0;
+  ungetc(c, file);
+  return 0;
+}
+
 static int
 parse_args(mrb_state *mrb, int argc, char **argv, struct _args *args)
 {
@@ -240,6 +255,14 @@ parse_args(mrb_state *mrb, int argc, char **argv, struct _args *args)
         fprintf(stderr, "%s: Cannot open program file: %s\n", opts->program, argv[0]);
         return EXIT_FAILURE;
       }
+      if (args->rfp != stdin && stream_is_unreadable(args->rfp)) {
+        /* Without this, the failed read is swallowed: the loader returns nil
+           without raising, so a directory argument ran as an empty program
+           with no output, no diagnostic and exit status 0.  The stream is
+           closed by cleanup() on the way out. */
+        fprintf(stderr, "%s: Cannot read program file: %s\n", opts->program, argv[0]);
+        return EXIT_FAILURE;
+      }
       args->fname = TRUE;
       args->cmdline = argv[0];
       argc--; argv++;
@@ -329,6 +352,15 @@ main(int argc, char **argv)
       FILE *lfp = fopen(args.libv[i], "rb");
       if (lfp == NULL) {
         fprintf(stderr, "%s: Cannot open library file: %s\n", *argv, args.libv[i]);
+        mrb_ccontext_free(mrb, c);
+        cleanup(mrb, &args);
+        return EXIT_FAILURE;
+      }
+      if (stream_is_unreadable(lfp)) {
+        /* Same swallowed read as the program file above: -r on a directory
+           loaded nothing and said nothing. */
+        fprintf(stderr, "%s: Cannot read library file: %s\n", *argv, args.libv[i]);
+        fclose(lfp);
         mrb_ccontext_free(mrb, c);
         cleanup(mrb, &args);
         return EXIT_FAILURE;

--- a/mrbgems/mruby-compiler/src/compile.c
+++ b/mrbgems/mruby-compiler/src/compile.c
@@ -233,6 +233,21 @@ append_from_stdin(mrc_ccontext *c, uint8_t **source, size_t source_length)
   }
 }
 
+/* A directory opens for reading on POSIX systems and then fails every read
+   with EISDIR, so a stream that opened says nothing about whether it can be
+   read.  One byte tells the two apart without asking the platform what kind
+   of file this is: an empty file reports end-of-file and no error, while a
+   directory raises the error indicator.  The byte is pushed back, so the
+   stream is left where it was found. */
+static int
+stream_is_unreadable(FILE *file)
+{
+  int c = getc(file);
+  if (c == EOF) return ferror(file) != 0;
+  ungetc(c, file);
+  return 0;
+}
+
 static intptr_t
 read_input_files(mrc_ccontext *c, const char **filenames, uint8_t **source, mrc_filename_table *filename_table)
 {
@@ -284,6 +299,17 @@ read_input_files(mrc_ccontext *c, const char **filenames, uint8_t **source, mrc_
            determined up front, so the read-it-all-at-once path below does not
            apply. */
         fprintf(stderr, "compile.c: cannot get size of program file. (%s)\n", filename);
+        fclose(file);
+        return -1;
+      }
+      if (stream_is_unreadable(file)) {
+        /* The size above is not trustworthy for a stream that cannot be read:
+           a directory answers LONG_MAX to ftell() on ext4 and 0 on tmpfs, so
+           it either overflows the length arithmetic below before the
+           allocation is attempted, or compiles as an empty program.  The
+           wording differs from the fread() failure below so that the two
+           cannot be mistaken for each other. */
+        fprintf(stderr, "compile.c: cannot read from program file. (%s)\n", filename);
         fclose(file);
         return -1;
       }


### PR DESCRIPTION
```console
$ mruby /home/user; echo "RC=$?"    # a directory
RC=0
```

A directory opens for reading on POSIX systems, and every read of it then fails with `EISDIR`. Neither reader asks, and they fail differently for it.

The mruby CLI opens the program file itself and hands the stream to `mrb_load_detect_file_cxt()`, which stops on the stream's error indicator and answers nil without raising. Nothing on that path inspects the answer, so a directory ran as an empty program: no output, no diagnostic, exit status 0. `-r` loads its libraries through the same call and had the same hole, then went on to run the program.

`read_input_files()` sizes its buffer from `ftell()`, and what a directory stream answers there is the filesystem's business:

```
ext4     ftell=9223372036854775807  getc=-1 ferror=1 errno=21
tmpfs    ftell=0                    getc=-1 ferror=1 errno=21
```

Both are positive, so the existing check for an unseekable stream passes them, and neither is a size. `LONG_MAX` overflows `length + 1` before the allocation is attempted; 0 compiles the directory as an empty program and reports `Syntax OK`. Measured on master with gcc `-fsanitize=address,undefined`:

```
compile.c:292:30: runtime error: signed integer overflow: 9223372036854775807 + 1
  cannot be represented in type 'long int'
ERROR: AddressSanitizer: requested allocation size 0x8000000000000000 ... exceeds maximum
    #2 in read_input_files .../mrbgems/mruby-compiler/src/compile.c:292
```

The honest "cannot read program file" that mrbc goes on to print on ext4 comes from the `fread()` count check, several statements after the overflow has already happened.

One byte answers the question all three readers should have asked, without asking the platform what kind of file this is: an empty file reports end-of-file and no error, a directory raises the error indicator. The byte is pushed back, so the stream is left where it was found, and an unseekable stream is still rejected earlier by the `ftell()` check, before anything is read from it.

The compiler's new message is worded apart from the `fread()` failure it now precedes, so a test can say which of the two arrived rather than only that one did.

After: all three arms report and exit 1, and the sanitizer build is clean on the same input. A bintest covers each arm, and each fails on master whichever filesystem the temporary directory lands on. Windows refuses a directory at `fopen()` and never reaches either reader, so the three skip there the way the neighbouring `/dev/stdin` test does.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of directory paths supplied where program files or libraries are expected.
  * Added clear read errors and unsuccessful termination instead of attempting to process unreadable inputs.
  * Preserved correct handling of readable empty files.

* **Tests**
  * Added regression coverage for invalid directory inputs across compiler and runtime command-line tools.
  * Platform-specific test behavior now accounts for environments where directories cannot be opened as files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->