### PR TITLE
string.c: answer an ASCII-case build from the header's fallback

### DIFF
--- a/include/mruby/internal.h
+++ b/include/mruby/internal.h
@@ -388,7 +388,7 @@ enum mrb_case_mode {
    which is what every build without the tables answers to every string.
    `swapcase` lives in mruby-string-ext and reaches the tables through this, so
    they are asked about in one place. */
-#ifdef MRB_UTF8_STRING
+#if defined(MRB_UTF8_STRING) && !defined(MRB_USE_ASCII_CASE)
 int mrb_str_case_convert_unicode(mrb_state *mrb, mrb_value str, enum mrb_case_mode mode);
 #else
 #define mrb_str_case_convert_unicode(mrb, str, mode) (-1)

--- a/src/string.c
+++ b/src/string.c
@@ -2248,23 +2248,7 @@ mrb_str_case_convert_unicode(mrb_state *mrb, mrb_value str, enum mrb_case_mode m
   return str_case_convert_utf8(mrb, str, mode) ? 1 : 0;
 }
 
-#elif defined(MRB_UTF8_STRING)
-
-/* The walk above is what a build asking for ASCII case gives up, and this is
-   where it says so: every caller of it converts the ASCII of a string in a
-   loop of its own and reaches for the walk only where the string holds more.
-   Answering that there was nothing to walk sends each of them back to that
-   loop, which is the conversion such a build asked for. */
-int
-mrb_str_case_convert_unicode(mrb_state *mrb, mrb_value str, enum mrb_case_mode mode)
-{
-  (void)mrb;
-  (void)str;
-  (void)mode;
-  return -1;
-}
-
-#endif  /* MRB_UTF8_STRING */
+#endif  /* MRB_UTF8_STRING && !MRB_USE_ASCII_CASE */
 
 /* 15.2.10.5.8  */
 /*


### PR DESCRIPTION
`include/mruby/internal.h` already answers `-1` for a build that compiles no
case tables:

```c
/* include/mruby/internal.h */
#ifdef MRB_UTF8_STRING
int mrb_str_case_convert_unicode(mrb_state *mrb, mrb_value str, enum mrb_case_mode mode);
#else
#define mrb_str_case_convert_unicode(mrb, str, mode) (-1)
#endif
```

The guard asks only about `MRB_UTF8_STRING`, but that is not the condition the
tables are compiled under. `MRB_USE_ASCII_CASE` keeps `MRB_UTF8_STRING` and
drops the tables, so such a build takes the declared side of the guard, and
`src/string.c` has to supply a body for the promise:

```c
/* src/string.c */
#elif defined(MRB_UTF8_STRING)
int
mrb_str_case_convert_unicode(mrb_state *mrb, mrb_value str, enum mrb_case_mode mode)
{
  (void)mrb;
  (void)str;
  (void)mode;
  return -1;
}
#endif  /* MRB_UTF8_STRING */
```

Two spellings of one answer, and the one costing a call and a return is the one
that build takes.

### The change

Widen the guard to the condition the tables are actually compiled under, and
the `#elif` arm goes away whole:

```c
#if defined(MRB_UTF8_STRING) && !defined(MRB_USE_ASCII_CASE)
int mrb_str_case_convert_unicode(mrb_state *mrb, mrb_value str, enum mrb_case_mode mode);
#else
#define mrb_str_case_convert_unicode(mrb, str, mode) (-1)
#endif
```

That condition is the one `src/string.c` opens the walk with and the one
`include/mruby/internal.h` already uses a few lines below for the codepoint
accessors, so the header now names the tables the same way in both places.

All seven call sites pass plain locals, so a macro evaluating none of its
arguments answers each of them as before:

| file | caller |
| --- | --- |
| `src/string.c` | `mrb_str_capitalize_bang()`, `mrb_str_downcase_bang()`, `mrb_str_upcase_bang()` |
| `mrbgems/mruby-string-ext/src/string.c` | `String#swapcase!`, and both operands of `String#casecmp?` |

Each already reads the result as `int uc = ...; if (uc >= 0)` or as `... < 0`,
which `(-1)` satisfies. A build without `MRB_UTF8_STRING` has taken the macro
for as long as it has existed, so this is the path those five methods are
already compiled from where the tables are absent; what changes is which builds
count as absent.

The stale `#endif  /* MRB_UTF8_STRING */` comment, which closed a chain whose
first arm is `MRB_UTF8_STRING && !MRB_USE_ASCII_CASE`, is carried off by the
same change.

### Size

`.text` summed over every `.o`, each side built from an empty build directory:

| build | master | this PR | delta |
| --- | ---: | ---: | ---: |
| `full-debug` (`-O0`) | 2,842,151 | 2,842,151 | 0 |
| `bintest` | 1,829,550 | 1,829,550 | 0 |
| `cxx_abi` | 1,839,166 | 1,839,166 | 0 |
| `byte-string` | 1,778,920 | 1,778,920 | 0 |
| `ascii-case` | 1,800,224 | 1,799,984 | -240 |
| `asan` (`-O0`) | 12,375,935 | 12,375,935 | 0 |

`ascii-case` is the only build whose guard moves, and every other one is
unchanged to the byte, which is what a change that only redraws a `#if` should
show.

### Testing

`build_config/ci/gcc-clang.rb` and `build_config/asan.rb`, run per build so the
counts are attributable:

| build | tests | OK | KO | skip |
| --- | ---: | ---: | ---: | ---: |
| `full-debug` | 2336 | 2333 | 0 | 3 |
| `bintest` | 2336 | 2325 | 0 | 11 |
| `cxx_abi` | 2336 | 2325 | 0 | 11 |
| `byte-string` | 2266 | 2217 | 0 | 49 |
| `ascii-case` | 2332 | 2319 | 0 | 13 |
| `asan` | 2336 | 2333 | 0 | 3 |

Identical to master, build for build. `bintest` (the binary tests) passes 117
of 117 under `ci/gcc-clang` and 79 of 79 under `asan`.

No new tests come with this. `ascii-case` already asks all five methods for the
`-1` answer: `mrbgems/mruby-string-ext/test/string.rb` skips only the Unicode
assertions of `String#swapcase` and `String#casecmp?` there and keeps the ASCII
ones, and `test/t/string.rb` asserts `downcase`, `upcase` and `capitalize` on
strings the walk would have refused either way.

### Environment

<details>

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-28-generic x86_64 |
| CPU | AMD Ryzen 9 5950X (16 cores, 32 threads) |
| C compiler | gcc 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1) |
| binutils | GNU ld 2.47.20260726 |
| CRuby (build host) | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM |

The optimization level is not the same in every build, so these are the lines
that actually compiled `src/string.c`, with `-MMD -c`, `-I` and `-o` dropped.
`cxx_abi` compiles with `gcc -x c++`, not with `g++`; `g++` only links.

```console
# ci/gcc-clang, full-debug
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c

# ci/gcc-clang, bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK src/string.c

# ci/gcc-clang, cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c

# ci/gcc-clang, byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c

# ci/gcc-clang, ascii-case
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CASE -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c

# build_config/asan.rb
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -fsanitize=address,undefined -g3 -O0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Unicode string case conversion behavior for configurations using ASCII case conversion.
  * Prevented unavailable Unicode case-conversion functionality from being exposed in those configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->