### PR TITLE
test: ask what case conversion answers where it follows ASCII

### DIFF
--- a/mrbgems/mruby-encoding/test/string.rb
+++ b/mrbgems/mruby-encoding/test/string.rb
@@ -480,14 +480,20 @@ end
 assert('a byte-read string converted case') do
   # Bytes read as bytes spell no characters, so a case conversion has nothing
   # above ASCII to map and hands back the bytes it was given, still read as
-  # bytes. The same bytes read as UTF-8 spell "Ä", which does map.
+  # bytes. The same bytes read as UTF-8 spell "Ä", which maps where the
+  # build holds a table for it; where case follows ASCII there is nothing to
+  # map and the two readings answer alike.
   if UTF8STRING
     s = "\xC3\x84B".b
     assert_equal [195, 132, 98], s.downcase.bytes
     assert_equal [195, 132, 66], s.upcase.bytes
     assert_equal [195, 132, 98], s.capitalize.bytes
     assert_equal Encoding::BINARY, s.downcase.encoding
-    assert_equal [195, 164, 98], "\xC3\x84B".downcase.bytes if UNICODECASE
+    if UNICODECASE
+      assert_equal [195, 164, 98], "\xC3\x84B".downcase.bytes
+    else
+      assert_equal [195, 132, 98], "\xC3\x84B".downcase.bytes
+    end
   end
 end
 

--- a/mrbgems/mruby-string-ext/test/string.rb
+++ b/mrbgems/mruby-string-ext/test/string.rb
@@ -166,6 +166,14 @@ assert('String#swapcase - Unicode') do
   assert_nil "日本".swapcase!
 end
 
+assert('String#swapcase - ASCII only') do
+  skip if UNICODECASE
+  # Where case follows ASCII, a character above it has no case to swap and
+  # stands between the ASCII that does.
+  assert_equal "abÄCD", "ABÄcd".swapcase
+  assert_nil "Ä".swapcase!
+end
+
 assert('String#concat') do
   assert_equal "Hello World!", "Hello " << "World" << 33
   assert_equal "Hello World!", "Hello ".concat("World").concat(33)
@@ -352,6 +360,21 @@ assert('String#casecmp? - Unicode') do
   assert_raise(ArgumentError) { "\xC3ABC".casecmp?("a") }
   assert_equal 0, "\xC3ABC".casecmp("\xC3abc")
   assert_raise(ArgumentError) { "\xC3ABC".swapcase }
+end
+
+assert('String#casecmp? - ASCII only') do
+  skip if UNICODECASE
+  # Narrowed to ASCII, folding sees no further than `casecmp` does, so two
+  # spellings that differ above ASCII stay apart however they would fold.
+  assert_equal 1, "ä".casecmp("Ä")
+  assert_false "ä".casecmp?("Ä")
+  assert_false "ß".casecmp?("ss")
+  assert_false "ﬁ".casecmp?("fi")
+  # What is left of the folding is the ASCII half, and a folding that reads
+  # nothing above ASCII has no bytes it must refuse.
+  assert_true "äB".casecmp?("äb")
+  assert_false "\xC3ABC".casecmp?("a")
+  assert_equal 0, "\xC3ABC".casecmp("\xC3abc")
 end
 
 assert('String#count') do

--- a/test/t/string.rb
+++ b/test/t/string.rb
@@ -496,6 +496,27 @@ assert('String#upcase - an answer that outgrows an embedded buffer') do
   end
 end if UNICODECASE
 
+assert('String case conversion - ASCII only') do
+  # The other reading of case: a build that converts by ASCII, whether by
+  # MRB_USE_ASCII_CASE or by reading its strings as bytes, has no mapping above
+  # ASCII, so a character that has one on the Unicode side stands as it was
+  # while the ASCII beside it still converts.
+  assert_equal 'Ä', 'Ä'.downcase
+  assert_equal 'ä', 'ä'.upcase
+  assert_equal 'Ä', 'Ä'.capitalize
+  assert_equal 'äb', 'äB'.downcase
+  assert_equal 'ÄB', 'Äb'.upcase
+  assert_equal 'Äb', 'ÄB'.capitalize
+  # A conversion that maps nothing is one that changed nothing.
+  assert_nil 'Ä'.downcase!
+  assert_nil 'ä'.upcase!
+  assert_nil 'Ä'.capitalize!
+  # Refusing a run of bytes that spells no character belongs to the walk over
+  # characters; a walk that only knows ASCII hands the bytes back untouched.
+  assert_equal [195, 97, 98, 99], "\xC3ABC".downcase.bytes
+  assert_equal [195, 65, 66, 67], "\xC3ABC".upcase.bytes
+end unless UNICODECASE
+
 assert('String#chomp', '15.2.10.5.9') do
   a = 'abc'.chomp
   b = ''.chomp


### PR DESCRIPTION
`build_config/ci/gcc-clang.rb:65-70` says what the `ascii-case` build is there for:

```ruby
  # The one build here that indexes by character and converts case by ASCII.
  # Both halves of that pair are what it covers: core's ASCII conversion, and
  # the refusal mruby-regexp answers a pattern with when /i is asked for a
  # folding the build has no table for.
```

The second half holds, and holds nowhere else. `mrbgems/mruby-regexp/test/ascii_case.rb:12`
opens with `skip unless __ENCODING__ == "UTF-8"`, so the `byte-string` build reaches
neither of its blocks and this build is their only home.

The first half asserts nothing. Every assertion that would show the narrowing is gated
off rather than mirrored:

| where | how it is gated | what runs where case follows ASCII |
| --- | --- | --- |
| `test/t/string.rb:433,450,468,482,497` | `end if UNICODECASE` | the blocks are not defined |
| `mrbgems/mruby-string-ext/test/string.rb:152,327` | `skip unless UNICODECASE` | reported as Skip |
| `mrbgems/mruby-encoding/test/string.rb:490` | `... if UNICODECASE` | the line is dropped |

So the conversion is held to "nothing raised" rather than to an answer. Counted against
the build beside it, `ascii-case` reports a Total of 2332 where `bintest` reports 2336,
and none of the four blocks that went missing came back as a mirror. Nothing in any
build configuration pins this:

```ruby
"Ä".downcase       #=> "Ä" where case follows ASCII, "ä" where it follows Unicode
"ä".upcase         #=> "ä"
"ä".casecmp?("Ä")  #=> false
```

## Fix

Gate the mirrors the other way. `UNICODECASE` is false both under `MRB_USE_ASCII_CASE`
and on a build reading its strings as bytes, so one addition covers both configurations,
and each block sits beside the Unicode block it answers.

Core holds `String#downcase`, `#upcase` and `#capitalize`, and asks for the bytes of a
run that spells no character handed back, the `ArgumentError` such a run draws elsewhere
belonging to the walk over characters. mruby-string-ext holds `String#swapcase` and
`#casecmp?`. mruby-encoding asks what the bytes of `"Ä"` read as UTF-8 answer, which is
what the same bytes read as bytes answer where there is nothing above ASCII to map.

## Verification

`rake -m test`, the mrbtest counts, on `e5517c30` and on this branch:

| build | before | after |
| --- | --- | --- |
| `ci/gcc-clang`, `full-debug` | 2336, OK 2333, Skip 3 | 2338, OK 2333, Skip 5 |
| `ci/gcc-clang`, `bintest` | 2336, OK 2325, Skip 11 | 2338, OK 2325, Skip 13 |
| `ci/gcc-clang`, `cxx_abi` | 2336, OK 2325, Skip 11 | 2338, OK 2325, Skip 13 |
| `ci/gcc-clang`, `byte-string` | 2266, OK 2217, Skip 49 | 2269, OK 2220, Skip 49 |
| `ci/gcc-clang`, `ascii-case` | 2332, OK 2319, Skip 13 | 2335, OK 2322, Skip 13 |
| `build_config/default.rb` | 2112, OK 2063, Skip 49 | 2115, OK 2066, Skip 49 |

`KO` and `Crash` are 0 in every column. The three builds that convert case by Unicode
gain the two blocks in mruby-string-ext as Skip; the three that convert by ASCII, which
`default.rb` is one of, gain three blocks that run. The bintests are unchanged, 106 OK
in `default.rb` and the same in the `bintest` build.

Thirteen of the twenty one new assertions answer differently on a build converting by
Unicode, which is the narrowing they are there to show. The other eight pin that the
ASCII half still converts, and answer alike either way.

## Environment

<details>

| | |
| --- | --- |
| OS | Ubuntu 24.04 |
| Kernel | Linux 7.0.0-28-generic x86_64 |
| CPU | AMD Ryzen 9 5950X (16 cores, 32 threads) |
| C compiler | gcc 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1) |
| binutils | GNU ld 2.47.20260726 |
| CRuby (build host) | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM |

The optimization level is not the same in every build, so these are the lines that
actually compiled `src/string.c`, with `-MMD -c`, `-I` and `-o` dropped. `cxx_abi`
compiles with `gcc -x c++`, not with `g++`; `g++` only links.

```console
# ci/gcc-clang, full-debug
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c

# ci/gcc-clang, bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK src/string.c

# ci/gcc-clang, cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c

# ci/gcc-clang, byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c

# ci/gcc-clang, ascii-case
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CASE -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c

# build_config/default.rb
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK src/string.c
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PiFpCR4tWrc5iWH8DRfNeQ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for string case conversion when Unicode support is unavailable.
  * Verified ASCII characters continue to convert correctly while non-ASCII and malformed byte sequences are handled consistently.
  * Added tests for `swapcase`, `casecmp?`, and bang methods, including unchanged-result behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->