### PR TITLE
string.c: keep what the bytes read as across `String#reverse!`

### DIFF
--- a/mrbgems/mruby-encoding/test/string.rb
+++ b/mrbgems/mruby-encoding/test/string.rb
@@ -215,6 +215,29 @@ assert('String#reverse! on a binary string reverses bytes') do
   end
 end
 
+assert('String#reverse! leaves what the bytes read as standing') do
+  # Reversing puts the same bytes back with every character whole, so a string
+  # that read as UTF-8 still does, and one that did not still does not. The
+  # reversal is where that is decided; asking afterwards is how it is seen.
+  if UTF8STRING
+    a = "あいうz"
+    a.reverse!
+    assert_equal "zういあ", a
+    assert_equal 4, a.length
+    assert_true a.valid_encoding?
+
+    b = "abc"
+    b.reverse!
+    assert_equal 3, b.length
+    assert_true b.valid_encoding?
+
+    c = "a\xE3\x81"
+    c.reverse!
+    assert_equal "\x81\xE3a".b, c.b
+    assert_false c.valid_encoding?
+  end
+end
+
 assert('String#encoding') do
   if UTF8STRING
     a = "あ"

--- a/src/string.c
+++ b/src/string.c
@@ -2969,13 +2969,22 @@ mrb_str_reverse_bang(mrb_state *mrb, mrb_value str)
   struct RString *s = mrb_str_ptr(str);
   char *p, *e;
 
+  /* Reversing writes the string's own bytes back in another order, and both
+     paths below leave every character whole, so what the bytes read as is
+     still what they read as: both write through str_modify_keep_cr(). */
+
 #ifdef MRB_UTF8_STRING
+  /* mrb_str_char_len() walks the string and records what it finds. The
+     multi-byte path turns each character's bytes around where they stand and
+     then turns the whole buffer around, which puts the characters back in the
+     reverse order with each one whole, so that record still holds and the
+     next asker is spared the same walk. */
   mrb_int utf8_len = mrb_str_char_len(mrb, str);
   mrb_int len = RSTR_LEN(s);
 
   if (utf8_len < 2) return str;
   if (utf8_len < len) {
-    mrb_str_modify(mrb, s);
+    str_modify_keep_cr(mrb, s);
     p = RSTR_PTR(s);
     e = p + RSTR_LEN(s);
     while (p<e) {
@@ -2987,8 +2996,10 @@ mrb_str_reverse_bang(mrb_state *mrb, mrb_value str)
   }
 #endif
 
+  /* Reached with one character per byte, where the reversal below is a byte
+     reversal that cuts no character in two. */
   if (RSTR_LEN(s) > 1) {
-    mrb_str_modify(mrb, s);
+    str_modify_keep_cr(mrb, s);
     goto bytes;
   }
   return str;


### PR DESCRIPTION
`mrb_str_reverse_bang()` opens by asking for the character count, and that
question walks the string:

```c
/* src/string.c */
#ifdef MRB_UTF8_STRING
  mrb_int utf8_len = mrb_str_char_len(mrb, str);   /* walks, and records 7BIT */
  mrb_int len = RSTR_LEN(s);

  if (utf8_len < 2) return str;
  if (utf8_len < len) {
    mrb_str_modify(mrb, s);                        /* sets the record to UNKNOWN */
    ...
  }
#endif

  if (RSTR_LEN(s) > 1) {
    mrb_str_modify(mrb, s);                        /* same, on the single-byte path */
    goto bytes;
  }
```

`mrb_str_char_len()` scans with `search_nonascii()` and records 7BIT on the
string where the scan meets nothing else. `mrb_str_modify()` sets that record
back to UNKNOWN one line later, because a write in general can turn a sound
string unsound. So the walk is paid for, thrown away, and paid for again at the
next question about the string. In a loop that is once per `reverse!`, either
inside `reverse!` on the next iteration or in whatever asks first.

### The change

Both calls become `str_modify_keep_cr()`, the in-file helper for a write that
leaves what the bytes read as standing:

```c
/* src/string.c */
static void
str_modify_keep_cr(mrb_state *mrb, struct RString *s)
{
  mrb_check_frozen(mrb, s);
  str_unshare_buffer(mrb, s);
  if (RSTR_CODERANGE(s) == MRB_STR_CODERANGE_BROKEN) {
    RSTR_CODERANGE_SET(s, MRB_STR_CODERANGE_UNKNOWN);
  }
}
```

Reversing is such a write. The multi-byte path turns each character's bytes
around where they stand and then turns the whole buffer around, which puts the
characters back in the reverse order with each one whole; the single-byte path
is a byte reversal of a string holding one character per byte. Neither can turn
a sound string unsound, so the record the walk arrived at is still the answer,
and the helper asks a string already read as broken again on its own.

### Performance

Instructions per call, callgrind on `bin/mruby` from the `bintest` build, as
`Ir(2N) - Ir(N)` so the startup cancels:

| receiver of `reverse!` | master | this PR | delta |
| --- | ---: | ---: | ---: |
| 1 MB of ASCII | 4,654,190 | 4,195,421 | -9.9% |
| 40 bytes of ASCII | 1,236 | 1,160 | -6.1% |
| 200,000 characters above ASCII | 20,276,906 | 20,276,832 | 0.0% |

The ASCII string is where the walk was the cost. A string holding characters
above ASCII is counted by walking it either way, since the count is not kept on
the string, so keeping the record buys it nothing and costs it nothing.

### Size

`.text` summed over every `.o`, each side built from an empty build directory:

| build | master | this PR | delta |
| --- | ---: | ---: | ---: |
| `full-debug` (`-O0`) | 2,784,978 | 2,784,978 | 0 |
| `bintest` | 1,776,429 | 1,776,461 | +32 |
| `cxx_abi` | 1,784,836 | 1,784,836 | 0 |
| `byte-string` | 1,727,817 | 1,727,817 | 0 |
| `ascii-case` | 1,748,571 | 1,747,803 | -768 |
| `asan` (`-O0`) | 12,171,024 | 12,171,024 | 0 |

`src/string.o` is the only object that moves in any of the six, and
`mrb_str_reverse_bang()` itself is 368 bytes on both sides of every one of
them. What moves is where gcc puts the two helpers, since the change takes two
callers off `mrb_str_modify()` and puts them on `str_modify_keep_cr()`:

| build | symbol | master | this PR |
| --- | --- | ---: | ---: |
| `bintest` | `mrb_str_setbyte()` | 262 | 302 |
| `ascii-case` | `str_modify_keep_cr()` | inlined | 926 |
| `ascii-case` | `str_replace()` | inlined | 467 |
| `ascii-case` | `mrb_str_chomp_bang()` | 2,305 | 1,374 |
| `ascii-case` | `mrb_str_to_s()` | 513 | 110 |
| `ascii-case` | `mrb_str_upcase()`, `mrb_str_downcase()` | 539 | 186 |

In `bintest`, `mrb_str_modify()` is down to a caller count gcc will inline it
at, so `mrb_str_setbyte()` now calls `str_unshare_buffer()` directly and carries
the rest of the body itself. In `ascii-case` it goes the other way: eight
callers is past where gcc keeps inlining `str_modify_keep_cr()`, so it is
emitted once and called, and the callers it had been inlined into give back
more than the 926 bytes that costs.

A build whose strings index by byte compiles `RSTR_CODERANGE_SET()` to nothing,
which makes the two helpers the same code, and `byte-string` is unchanged to
the byte.

### Testing

`build_config/ci/gcc-clang.rb` and `build_config/asan.rb`, run per build so the
counts are attributable:

| build | tests | OK | KO | skip |
| --- | ---: | ---: | ---: | ---: |
| `full-debug` | 2337 | 2334 | 0 | 3 |
| `bintest` | 2337 | 2326 | 0 | 11 |
| `cxx_abi` | 2337 | 2326 | 0 | 11 |
| `byte-string` | 2266 | 2217 | 0 | 49 |
| `ascii-case` | 2333 | 2320 | 0 | 13 |
| `asan` | 2337 | 2334 | 0 | 3 |

One more test than master everywhere the string is indexed by character;
`byte-string` drops `mruby-encoding` and with it the file the test lives in.
The binary tests pass 117 of 117 under `ci/gcc-clang` and 79 of 79 under
`asan`.

Beside the suite, 100,000 random strings built from ASCII, characters above
it, and stray bytes were reversed under both builds, comparing the bytes, the
length and `valid_encoding?` of the result and of the result reversed again.
Every line is identical.

The test that comes with this is for the record the change keeps. What a
reversed string answers for its own length and validity was asserted nowhere:
the existing `reverse!` tests read the result as a string and stop there, so a
reversal that kept a record it had unmade would have passed them. Dropping the
per-character reversal from the multi-byte path, which is what would leave such
a record wrong, turns the new assertions red.

### Environment

<details>

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-28-generic x86_64 |
| CPU | AMD Ryzen 9 5950X (16 cores, 32 threads) |
| C compiler | gcc 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1) |
| binutils | GNU ld 2.47.20260726 |
| valgrind | 3.27.1 |
| CRuby (build host) | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM |

The optimization level is not the same in every build, so these are the lines
that actually compiled `src/string.c`, with `-MMD -c`, `-I` and `-o` dropped.
`cxx_abi` compiles with `gcc -x c++`, not with `g++`; `g++` only links.

```console
# ci/gcc-clang, full-debug
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c

# ci/gcc-clang, bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK src/string.c

# ci/gcc-clang, cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c

# ci/gcc-clang, byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c

# ci/gcc-clang, ascii-case
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CASE -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c

# build_config/asan.rb
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -fsanitize=address,undefined -g3 -O0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `String#reverse!` handling for UTF-8 strings.
  * Valid UTF-8 strings now reverse without breaking character boundaries or changing their character length.
  * Incomplete UTF-8 byte sequences are reversed correctly while retaining their invalid status.

* **Tests**
  * Added coverage for reversing both valid and incomplete UTF-8 strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->