### PR TITLE
unicase.c: unfold an ASCII character without reading a table

### DIFF
--- a/src/unicase.c
+++ b/src/unicase.c
@@ -249,8 +249,19 @@ mrb_uni_case_unfold(uint32_t cp, uint32_t *out, int max)
     out[n++] = folded - 32;
   }
 
-  /* A non-ASCII source folding into ASCII (U+017F into 's') is in a table and
-     is found by these scans like any other. */
+  /* A non-ASCII source folding into ASCII (U+017F into 's') is the only thing
+     an ASCII source can find in a table, and the generator lists those beside
+     the tables, so the list is the whole answer for one. What that saves is
+     the two full scans below, which an ASCII source would otherwise make to
+     collect the entries the list already holds. Most patterns are ASCII and
+     nothing else, and this is what /i costs them. */
+  if (cp < 128) {
+#define X(src, to) if (folded == (to) && n < max) out[n++] = (src);
+    UNI_FOLD_TO_ASCII
+#undef X
+    return n;
+  }
+
   n = unfold_from(&case_tables[MRB_CASE_KIND_FOLD], cp, folded, out, max, n);
   n = unfold_from(&case_tables[MRB_CASE_KIND_LOWER], cp, folded, out, max, n);
   return n;
@@ -359,6 +370,17 @@ void
 mrb_uni_case_unfold_range(uint32_t lo, uint32_t hi,
                           void (*add)(void *, uint32_t, uint32_t), void *user)
 {
+  /* An ASCII fold has the listed sources and no others, for the reason
+     mrb_uni_case_unfold() gives, so the ASCII part of the span is answered
+     from the list and the walks below are handed what is left of it. A class
+     of nothing but ASCII, which is most classes, reaches neither walk. */
+  if (lo < 128) {
+#define X(src, to) if (lo <= (to) && (to) <= hi) add(user, (src), (src));
+    UNI_FOLD_TO_ASCII
+#undef X
+    if (hi < 128) return;
+    lo = 128;
+  }
   unfold_range_of(&case_tables[MRB_CASE_KIND_FOLD], FALSE, lo, hi, add, user);
   unfold_range_of(&case_tables[MRB_CASE_KIND_LOWER], TRUE, lo, hi, add, user);
 }

--- a/src/unicase.h
+++ b/src/unicase.h
@@ -890,4 +890,12 @@ static const uint8_t uni_fold_multi[] = {
 #define UNI_FOLD_MIN 0x000B5
 #define UNI_FOLD_MAX 0x0FB17
 
+/* The sources above ASCII whose simple folding is an ASCII character, as
+   a list the caller expands with an X of its own. ASCII itself is in no
+   table, so unfolding an ASCII character is these and the ASCII rules,
+   and no table is read at all. */
+#define UNI_FOLD_TO_ASCII \
+  X(0x0017F, 0x00073)  /* to 's' */ \
+  X(0x0212A, 0x0006B)  /* to 'k' */
+
 #endif /* MRB_UNICASE_H */

--- a/tools/gen_unicase.rb
+++ b/tools/gen_unicase.rb
@@ -155,6 +155,18 @@ end
 # to TABLES and left out here would be one the buffer is too small for.
 widest = TABLES.flat_map { |_, map, _| map.values.map(&:bytesize) }.max
 
+# The sources above ASCII whose simple folding is an ASCII character, read the
+# way the lookup reads folding: the difference first, and the lowercase mapping
+# under it for the sources the difference passes over. ASCII is in no table, so
+# these are the whole of what unfolding an ASCII character can find there, and
+# emitting them lets that answer be given without a table at all. Measured over
+# the tables rather than listed beside them for the reason `widest` is.
+fold_to_ascii = (fold_diff.keys | lower.keys).sort.map do |cp|
+  to = (fold_diff[cp] || lower[cp]).unpack("U*")
+  next nil unless to.size == 1 && to[0] < 0x80
+  [cp, to[0]]
+end.compact
+
 # ------------------------------------------------------------------- emit
 
 def hex(cp)
@@ -272,6 +284,16 @@ File.open(File.join(outdir, 'unicase.h'), 'w') do |out|
     out.puts "#define UNI_#{up}_MIN #{hex(lo)}"
     out.puts "#define UNI_#{up}_MAX #{hex(hi)}"
   end
+
+  out.puts
+  out.puts "/* The sources above ASCII whose simple folding is an ASCII character, as"
+  out.puts "   a list the caller expands with an X of its own. ASCII itself is in no"
+  out.puts "   table, so unfolding an ASCII character is these and the ASCII rules,"
+  out.puts "   and no table is read at all. */"
+  out.puts "#define UNI_FOLD_TO_ASCII" +
+           fold_to_ascii.map { |cp, to|
+             " \\\n  X(#{hex(cp)}, #{hex(to)})  /* to '#{to.chr}' */"
+           }.join
 
   out.puts
   out.puts "#endif /* MRB_UNICASE_H */"


### PR DESCRIPTION
Compiling a pattern under `/i` walks the Unicode case tables once per
character and once per character class span, and a pattern of nothing but
ASCII, which is most patterns, walks them for an answer that is not in them.

`mrb_uni_case_unfold()` (`src/unicase.c:238` on master) answers the case
counterparts of one character. It reads ASCII inline from two rules and then
scans both tables anyway:

```c
  /* The folded form is itself a member of the class. */
  if (folded != cp && n < max) out[n++] = folded;

  /* ASCII sources are in no table, so the upper case letter that folds into a
     lower case one is added here. */
  if (folded >= 'a' && folded <= 'z' && folded - 32 != cp && n < max) {
    out[n++] = folded - 32;
  }

  n = unfold_from(&case_tables[MRB_CASE_KIND_FOLD], cp, folded, out, max, n);
  n = unfold_from(&case_tables[MRB_CASE_KIND_LOWER], cp, folded, out, max, n);
```

That is 24 + 184 runs, each unpacked from six packed bytes by the loop in
`case_run_at()`, and each surviving candidate re-checked through
`mrb_uni_case_fold()`, which is two more binary searches.
`mrb_uni_case_unfold_range()` (`src/unicase.c:359`) ends the same way over a
span.

Both are on the `/i` compile path for ASCII. `emit_char()`
(`mrbgems/mruby-regexp/src/re_compile.c:1097`) asks for the counterparts of
every ASCII letter a pattern spells, and the closure `compile_charclass()`
runs over a finished class asks for the counterparts of every run of set bits
in its ASCII bitmap.

## Why the answer is not in the tables

The generator drops every source below `0x80`: ASCII is what the tables are the
rest of, and the callers fold it inline from the two rules above. What the
scans can still find for an ASCII source is a source above ASCII that folds
*down* into it, and over the Unicode 17 database there are two, `U+017F` into
`'s'` and `U+212A` into `'k'`. Nothing else in either table folds below `0x80`.
They are the same two `re_internal.h` already spells out as `RE_FOLD_LONG_S`
and `RE_FOLD_KELVIN` for a build with no table at all.

## Fix

`tools/gen_unicase.rb` emits that list as `UNI_FOLD_TO_ASCII`, an X-macro over
the same two maps the tables themselves are built from:

```c
#define UNI_FOLD_TO_ASCII \
  X(0x0017F, 0x00073)  /* to 's' */ \
  X(0x0212A, 0x0006B)  /* to 'k' */
```

Measured over the maps rather than written out beside them for the reason
`UNI_CASE_MAX_BYTES` is measured rather than declared: a Unicode version that
adds a third source gets a third entry here without anyone having to notice
that it had to, and `rake unicode:verify` fails if the committed header and the
database disagree.

`mrb_uni_case_unfold()` then answers an ASCII source from the list and returns,
and `mrb_uni_case_unfold_range()` answers the ASCII part of its span from the
list and hands the walks only what is left above `0x80`.

`mrb_uni_case_fold_range()` keeps both of its walks. It reports the folds *of*
the sources in a span, and an ASCII source is in no table, so there is no list
for it to read; the gem folds its ASCII bitmap inline already and never asks
that function about a span below `0x80`.

## Instruction count

callgrind, `Ir(2N) - Ir(N)` to cancel interpreter start-up. gcc 13.3.0 at
`-O3`, `full-core`.

| | master | this PR | ratio | `MRB_USE_ASCII_CASE` |
|---|---:|---:|---:|---:|
| `Regexp.new("[a-z0-9_]", //i)` x20,000 | 1,056,511,426 | 461,287,040 | **2.29x** | 410,565,952 |
| `Regexp.new("hello world", //i)` x20,000 | 1,797,022,034 | 447,367,788 | **4.02x** | 433,127,448 |
| `/[a-z0-9_]/i =~ "hello"` x100,000 | 5,385,099,698 | 2,408,977,326 | **2.24x** | 2,154,671,750 |
| `Regexp.new("[\u{80}-\u{2FFF}]", //i)` x2,000 | 881,046,557 | 841,504,178 | 1.05x | `RegexpError` |

The last column is a build that drops the Unicode case tables altogether, as
the floor an ASCII-only pattern could reach. The three ASCII rows land within
3% to 12% of it; what remains is the closure the gem runs over a finished
class, not the tables. Under callgrind, `mrb_uni_case_unfold_range()` and
everything below it is 1.88% of the first row after this change.

Matching itself is untouched. The third row is a plain literal in a loop, which
mruby recompiles on every pass, which is why it moves with the other two.

## Size

`.text` of `bin/mruby`, `build_config/ci/gcc-clang.rb`, from a clean build
directory.

| build | master | this PR | delta |
|---|---:|---:|---:|
| `byte-string` | 1,245,750 | 1,245,750 | 0 |
| `ascii-case` | 1,266,102 | 1,266,102 | 0 |
| `bintest` | 1,277,446 | 1,277,398 | **-48** |
| `cxx_abi` | 1,302,025 | 1,302,105 | +80 |
| `full-debug` (`-O0`) | 1,873,206 | 1,873,398 | +192 |

The first two compile none of this: `byte-string` has no `MRB_UTF8_STRING` and
`ascii-case` defines `MRB_USE_ASCII_CASE`, and the whole file is behind that
pair. `bintest` is the build that pays for the tables, and it shrinks: the two
scans lose a call site each. The `cxx_abi` and `full-debug` figures are the two
new branches not being folded away, at `-O0` for the latter.

## Verification

No test is added. What the fast path has to preserve is already pinned, on
every build, by `Regexp - /i folds an ASCII letter's class whole`
(`mrbgems/mruby-regexp/test/regexp_syntax.rb:218`), which asserts that
`[a-z]`, `[j-l]` and `[k]` under `/i` all reach `U+212A` and that `[^k]` does
not, and by `Regexp - Unicode case folding under /i`
(`mrbgems/mruby-regexp/test/unicode_case.rb:5`), which pins the
single-character forms. Both pass.

Beyond that, two differential checks:

**Against the two functions themselves.** A harness carrying master's
`mrb_uni_case_unfold()` and `mrb_uni_case_unfold_range()` verbatim, linked
against the patched `libmruby.a`, comparing the two as sets, since the walks
may report the same source twice and in spans of a different shape:

- every codepoint from `U+0000` to `U+10FFFF`, 1,114,112 of them: 0 differences
- 221,125 spans: every `[lo, hi]` inside `U+0000..U+0250`, every table entry
  and its neighbourhood, and 20,000 random spans over the whole range: 0
  differences
- the same run under ASan + UBSan: clean, 0 differences

**Against the binary.** 15,277 patterns, each compiled under `/i` and run
against 118 subjects chosen to cover ASCII, both fold-to-ASCII sources, the
three-way sigma class, dotted and dotless i, and the `U+10400` and `U+1E900`
blocks. Single characters and their positive and negated classes over
`U+0000..U+02FF` and a stride through the rest, 34 ranges, the ASCII-only
classes the fast path answers whole, and mixed classes. Output of the master
binary and the patched one is byte-identical.

`rake test` on `build_config/ci/gcc-clang.rb`, all five builds plus bintest:

| build | total | KO | crash |
|---|---:|---:|---:|
| `bintest` (bintest suite) | 117 | 0 | 0 |
| `full-debug` | 2,266 | 0 | 0 |
| `bintest` | 2,336 | 0 | 0 |
| `cxx_abi` | 2,336 | 0 | 0 |
| `byte-string` | 2,332 | 0 | 0 |
| `ascii-case` | 2,336 | 0 | 0 |

`rake test` on `build_config/asan.rb`: 2,336 total, 0 KO, 0 crash, plus its 79
bintests, with no sanitizer report.

`rake unicode:verify` against the Unicode 17.0.0 database: the committed
tables, including the new list, are what the database generates.

### Environment

<details>

| | |
|---|---|
| OS | Ubuntu 24.04, Linux x86_64 |
| gcc | 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1) |
| valgrind | callgrind 3.27.1, for the instruction counts |
| CRuby | 4.0.6, for `tools/gen_unicase.rb` |

Compile lines for `src/unicase.c` in the builds quoted above, paths shortened:

```
# -O3 full-core, the Ir rows
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -I"include" -I"build/perf/include" -o "build/perf/src/unicase.o" "src/unicase.c"

# -O3 full-core, MRB_USE_ASCII_CASE, the last Ir column
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CASE -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -I"include" -I"build/perf-ascii/include" -o "build/perf-ascii/src/unicase.o" "src/unicase.c"

# ci/gcc-clang bintest
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK -I"include" -I"build/bintest/include" -o "build/bintest/src/unicase.o" "src/unicase.c"

# ci/gcc-clang full-debug
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -I"include" -I"build/full-debug/include" -o "build/full-debug/src/unicase.o" "src/unicase.c"

# ci/gcc-clang cxx_abi
gcc -MMD -c -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -I"include" -I"build/cxx_abi/include" -o "build/cxx_abi/src/unicase.o" "src/unicase.c"

# ci/gcc-clang byte-string
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -I"include" -I"build/byte-string/include" -o "build/byte-string/src/unicase.o" "src/unicase.c"

# ci/gcc-clang ascii-case
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CASE -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -I"include" -I"build/ascii-case/include" -o "build/ascii-case/src/unicase.o" "src/unicase.c"

# asan
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -fsanitize=address,undefined -g3 -O0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -I"include" -I"build/asan/include" -o "build/asan/src/unicase.o" "src/unicase.c"
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dhp4MAkemDdpxUSPQWZHZ3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved Unicode case folding for ASCII inputs and ranges, reducing unnecessary processing.
  * Accelerated handling of non-ASCII characters that fold to ASCII equivalents.

* **Compatibility**
  * Added support for additional Unicode characters folding to ASCII “s” and “k” equivalents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->