### PR TITLE
string.c: ask a broken string again after `String#reverse!`

### DIFF
--- a/mrbgems/mruby-encoding/test/string.rb
+++ b/mrbgems/mruby-encoding/test/string.rb
@@ -217,12 +217,18 @@ end
 
 assert('String#reverse! leaves what the bytes read as standing') do
   # Reversing puts the same bytes back with every character whole, so a string
-  # that read as UTF-8 still does, and one that did not still does not. The
-  # reversal is where that is decided; asking afterwards is how it is seen.
+  # that read as UTF-8 still does. A string that did not is the one case the
+  # reversal can settle either way, since bytes that spell nothing where they
+  # stood can spell a character once they are turned around. The reversal is
+  # where all of that is decided; asking afterwards is how it is seen.
   if UTF8STRING
     a = "あいうz"
     a.reverse!
     assert_equal "zういあ", a
+    assert_equal 4, a.length
+    assert_true a.valid_encoding?
+    a.reverse!
+    assert_equal "あいうz", a
     assert_equal 4, a.length
     assert_true a.valid_encoding?
 
@@ -235,6 +241,13 @@ assert('String#reverse! leaves what the bytes read as standing') do
     c.reverse!
     assert_equal "\x81\xE3a".b, c.b
     assert_false c.valid_encoding?
+
+    d = "\x80\xC2"   # a trailing byte and then a lead byte, spelling nothing
+    assert_false d.valid_encoding?   # asked here, so the answer is on the string
+    d.reverse!                       # and the same bytes now spell U+0080
+    assert_equal "\xC2\x80".b, d.b
+    assert_equal 1, d.length
+    assert_true d.valid_encoding?
   end
 end
 

--- a/src/string.c
+++ b/src/string.c
@@ -2954,8 +2954,11 @@ mrb_str_reverse_bang(mrb_state *mrb, mrb_value str)
   char *p, *e;
 
   /* Reversing writes the string's own bytes back in another order, and both
-     paths below leave every character whole, so what the bytes read as is
-     still what they read as: both write through str_modify_keep_cr(). */
+     paths below leave every character whole, so a string that read as UTF-8
+     still does: both write through str_modify_keep_cr(). A string already
+     read as broken is the one this cannot answer for, since bytes that spell
+     nothing where they stand can spell a character turned around, and that is
+     the string the helper asks again on its own. */
 
 #ifdef MRB_UTF8_STRING
   /* mrb_str_char_len() walks the string and records what it finds. The


### PR DESCRIPTION
Follow-up to #7224, which put `mrb_str_reverse_bang()` on `str_modify_keep_cr()`.
That helper keeps what the string is read as and asks a string read as broken
again:

```c
/* src/string.c */
static void
str_modify_keep_cr(mrb_state *mrb, struct RString *s)
{
  mrb_check_frozen(mrb, s);
  str_unshare_buffer(mrb, s);
  if (RSTR_CODERANGE(s) == MRB_STR_CODERANGE_BROKEN) {
    RSTR_CODERANGE_SET(s, MRB_STR_CODERANGE_UNKNOWN);
  }
}
```

The test that came with #7224 reverses a broken string and finds it broken
after, which is the same answer whether the helper asks again or not. Nothing
there says why the asking again is needed, and a `reverse!` that kept a broken
answer passes it.

### The case that shows it

Reversal is the write that can mend as well as break. Bytes that spell nothing
where they stand can spell a character once they are turned around:

```ruby
d = "\x80\xC2"        # a trailing byte, then a lead byte
d.valid_encoding?     #=> false
d.reverse!            # the same two bytes, now U+0080
d.valid_encoding?     #=> true
```

The first `valid_encoding?` is what the case turns on. It is what puts the
broken answer on the string, so a `reverse!` keeping it answers `false` for a
string that is now valid. Without that question the string reaches the reversal
with nothing recorded, the helper walks it afterwards either way, and both
readings agree.

Reversing the multi-byte string a second time comes with it, so the record is
carried across two writes rather than one, which is the loop #7224 was measured
on.

Against a `mrb_str_reverse_bang()` that prepares its write without the broken
check, both new assertions turn red in every build that indexes by character:

```console
Fail: String#reverse! leaves what the bytes read as standing (mrbgems: mruby-encoding)
```

### The comment

The comment at the top of the function said what the bytes read as is still
what they read as. That is the promise `str_modify_keep_cr()` asks of a caller,
not the whole of what happens here, since the broken string is the one it
cannot promise for. It now names that string and why reversing is what can
settle it either way.

### Testing

`build_config/ci/gcc-clang.rb` and `build_config/gcc-asan.rb`, run per build so
the counts are attributable:

| build | tests | OK | KO | skip |
| --- | ---: | ---: | ---: | ---: |
| `full-debug` | 2339 | 2334 | 0 | 5 |
| `bintest` | 2339 | 2326 | 0 | 13 |
| `cxx_abi` | 2339 | 2326 | 0 | 13 |
| `byte-string` | 2269 | 2220 | 0 | 49 |
| `ascii-case` | 2336 | 2323 | 0 | 13 |
| `gcc-asan` | 2339 | 2334 | 0 | 5 |

The binary tests pass 117 of 117 under `ci/gcc-clang` and 84 of 84 under
`gcc-asan`. `src/string.c` changes only in a comment, so no build moves by a
byte.

### Environment

<details>

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-28-generic x86_64 |
| CPU | AMD Ryzen 9 5950X (16 cores, 32 threads) |
| C compiler | gcc 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1) |
| binutils | GNU ld 2.47.20260726 |
| CRuby (build host) | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM |

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `String#reverse!` handling for invalid byte sequences.
  * Ensured reversing strings preserves complete UTF-8 characters and correctly restores validity when possible.
  * Added validation for reversed string bytes, length, and encoding status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->