### PR TITLE
mruby-regexp: declare a named group as `(?'name'...)` too

### DIFF
--- a/mrbgems/mruby-regexp/README.md
+++ b/mrbgems/mruby-regexp/README.md
@@ -17,7 +17,7 @@ simulation) with backtracking fallback.
 - `(...)` capture group
 - `(?:...)` non-capturing group
 - `(?#...)` comment group
-- `(?<name>...)` named capture group
+- `(?<name>...)`, `(?'name'...)` named capture group
 - `|` alternation
 - `\1`-`\9` backreferences
 - `\k<name>`, `\k'name'` named backreferences

--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -1278,15 +1278,23 @@ compile_atom(re_compiler *c)
           c->flags = saved_flags;
           break;
         }
-        else if (c->p[1] == '<' && c->p + 2 < c->src_end && c->p[2] != '=' && c->p[2] != '!') {
-          next_char(c); next_char(c);  /* skip ?< */
+        else if (c->p[1] == '\'' ||
+                 (c->p[1] == '<' && c->p + 2 < c->src_end &&
+                  c->p[2] != '=' && c->p[2] != '!')) {
+          /* A named capture, in either spelling: (?<name>...) or (?'name'...).
+             The quoted one needs none of the ruling out the angled one does
+             above, since no lookbehind is spelled with a quote. The name runs
+             to its own terminator, so a '>' inside quotes and a quote inside
+             angles are both members of the name. */
+          int close = (c->p[1] == '<') ? '>' : '\'';
+          next_char(c); next_char(c);  /* skip ?< or ?' */
           cap_name = c->p;
-          while (peek(c) != '>' && peek(c) >= 0) next_char(c);
-          if (peek(c) != '>') compile_error(c, "unterminated named capture");
+          while (peek(c) != close && peek(c) >= 0) next_char(c);
+          if (peek(c) != close) compile_error(c, "unterminated named capture");
           if (c->p == cap_name) compile_error(c, "group name is empty");
           if (!RE_NAME_LEN_FITS(c->p - cap_name)) compile_error(c, "group name too long");
           cap_name_len = (uint32_t)(c->p - cap_name);
-          next_char(c);  /* skip > */
+          next_char(c);  /* skip the closing > or ' */
         }
         else if (c->p[1] == 'i' || c->p[1] == 'm' || c->p[1] == 'x' || c->p[1] == '-') {
           /* Inline options: the toggle form (?imx) / (?-imx) changes the
@@ -1320,12 +1328,12 @@ compile_atom(re_compiler *c)
         }
         else {
           /* (?X) with an unsupported X: not one of the recognized (?: (?= (?!
-             (?<= (?<! (?<name> (?imx forms. Comment groups (?#...) never get
-             here either, having been removed by preprocess_pattern(). The
-             absent operator (?~...) and conditionals (?(...)) are not
-             implemented. Raise here rather than falling through to the
-             capturing-group path, which would leave the stray `?` for
-             compile_seq to spin on forever (A1). */
+             (?<= (?<! (?<name> (?'name' (?imx forms. Comment groups (?#...)
+             never get here either, having been removed by
+             preprocess_pattern(). The absent operator (?~...) and
+             conditionals (?(...)) are not implemented. Raise here rather
+             than falling through to the capturing-group path, which would
+             leave the stray `?` for compile_seq to spin on forever (A1). */
           compile_error(c, "undefined (?...) sequence");
         }
       }
@@ -1922,14 +1930,14 @@ preprocess_pattern(mrb_state *mrb, const char *src, mrb_int len,
  * parser starts is what lets compile_atom() demote a plain (...) that comes
  * before the named group that causes the demotion.
  *
- * (?<name>...) is the only spelling of a definition this gem accepts; the
- * (?'name'...) form raises "undefined (?...) sequence", so the scan looks for
- * "(?<" alone. It excludes (?<= and (?<!, which are lookbehind rather than a
- * definition, and it steps over escapes and character classes with
- * skip_uninterpreted(), so that /\(?/ and /[(?<]/ are not false positives.
+ * A definition has two spellings, so the scan looks for "(?<" and "(?'" both.
+ * It excludes (?<= and (?<!, which are lookbehind rather than a definition,
+ * and it steps over escapes and character classes with skip_uninterpreted(),
+ * so that /\(?/ and /[(?<]/ are not false positives.
  *
- * A truncated "(?<" at the end of the pattern is counted as a named group,
- * which is harmless: the parser reaches the same bytes and raises there.
+ * A truncated "(?<" or "(?'" at the end of the pattern is counted as a named
+ * group, which is harmless: the parser reaches the same bytes and raises
+ * there.
  */
 static mrb_bool
 has_named_group(const char *src, mrb_int len)
@@ -1944,13 +1952,16 @@ has_named_group(const char *src, mrb_int len)
       src = skip;
       continue;
     }
-    if (ch == '(' && end - src >= 3 && src[1] == '?' && src[2] == '<') {
-      /* src + 3 is at most end here, since the test above leaves three bytes
-         to read, so the one-past-the-end pointer it can form is a position C
-         allows. */
-      if (src + 3 >= end || (src[3] != '=' && src[3] != '!')) return TRUE;
-      src += 3;
-      continue;
+    if (ch == '(' && end - src >= 3 && src[1] == '?') {
+      if (src[2] == '\'') return TRUE;
+      if (src[2] == '<') {
+        /* src + 3 is at most end here, since the test above leaves three
+           bytes to read, so the one-past-the-end pointer it can form is a
+           position C allows. */
+        if (src + 3 >= end || (src[3] != '=' && src[3] != '!')) return TRUE;
+        src += 3;
+        continue;
+      }
     }
     src++;
   }

--- a/mrbgems/mruby-regexp/test/regexp_syntax.rb
+++ b/mrbgems/mruby-regexp/test/regexp_syntax.rb
@@ -607,6 +607,8 @@ assert("Regexp - the /x pass and the named-group scan skip the same constructs")
     ['\u{61}(?<n>b)(c)',     "abc"],
     ['[\u{61}]+(?<n>b)(c)',  "abc"],
     ['(a)(?<b>b)',           "ab"],
+    ["\\(?'a'(b)",           "('a'b"],
+    ["[(?'a]+(b)",           "(?'b"],
   ].each do |pat, subject|
     assert_equal Regexp.new(pat).match(subject).to_a,
                  Regexp.new(pat, x).match(subject).to_a
@@ -658,6 +660,72 @@ assert("Regexp - named captures") do
   assert_equal "03", md[:month]
   assert_equal "21", md[:day]
   assert_equal "2026", md["year"]
+end
+
+assert("Regexp - a named group can be written (?'name'...)") do
+  # A definition has two spellings, and \k already read both, so the parser
+  # used to accept a reference to a name it refused to introduce.
+  md = /(?'x'a)/.match("a")
+  assert_equal ["a", "a"], md.to_a
+  assert_equal "a", md[:x]
+  assert_equal ["year", "month"], /(?'year'\d+)-(?'month'\d+)/.names
+  assert_equal({"year" => [1], "month" => [2]},
+               /(?'year'\d+)-(?'month'\d+)/.named_captures)
+
+  # either spelling of \k reaches a group written in either spelling
+  assert_equal "aa", "aa".match(/(?'n'\w)\k<n>/)[0]
+  assert_equal "aa", "aa".match(/(?<n>\w)\k'n'/)[0]
+  assert_equal "aa", "aa".match(/(?'n'\w)\k'n'/)[0]
+
+  # the two spellings write into one registry: a name given twice is reported
+  # once however each of them was spelled
+  assert_equal ["t"], /(?<t>\w)(?'t'\w)/.names
+  assert_equal ["xy", "x", "y"], /(?<a>x)(?'b'y)/.match("xy").to_a
+
+  # a name runs to its own terminator, so the other spelling's terminator is
+  # a member of it rather than the end
+  assert_equal ["a>b"], /(?'a>b'x)/.names
+  assert_equal ["a'b"], /(?<a'b>x)/.names
+
+  # nesting, quantifiers and /i are the group's own business either way
+  assert_equal ["ab", "ab", "b"], /(?'o'a(?'i'b))/.match("ab").to_a
+  assert_equal ["abab", "ab"], /(?'a'ab)+/.match("abab").to_a
+  assert_equal ["AB", "AB"], /(?'a'ab)/i.match("AB").to_a
+
+  # a name is still required, and still has to be terminated
+  assert_raise(RegexpError) { Regexp.new("(?''x)") }
+  assert_raise(RegexpError) { Regexp.new("(?'x") }
+  assert_raise(RegexpError) { Regexp.new("(?'") }
+end
+
+assert("Regexp - a (?'name'...) group demotes plain groups too") do
+  # The pre-scan settles the demotion before the parser runs, so it has to
+  # know both spellings: reading "(?<" alone left /(a)(?'b'b)/ numbering the
+  # plain group that the declaration demotes.
+  md = /(?'a'a)(b)/.match("ab")
+  assert_equal 2, md.size
+  assert_equal ["ab", "a"], md.to_a
+  assert_nil md[2]
+
+  md = /(a)(?'b'b)/.match("ab")
+  assert_equal ["ab", "b"], md.to_a
+  assert_equal "b", md[:b]
+
+  assert_equal "[]", "ab".sub(/(?'a'a)(b)/, '[\2]')
+
+  # and the numbers the declaration took away cannot be referred to
+  msg = "numbered backref/call is not allowed. (use name)"
+  assert_raise_with_message(RegexpError, "#{msg}: /(a)(?'b'b)\\1/") do
+    Regexp.new("(a)(?'b'b)\\1")
+  end
+  assert_raise_with_message(RegexpError, "#{msg}: /(a)(?'b'b)\\k<1>/") do
+    Regexp.new("(a)(?'b'b)\\k<1>")
+  end
+
+  # an escaped or bracketed "(?'" declares nothing, so the plain group that
+  # follows keeps its number
+  assert_equal ["('a'b", "b"], /\(?'a'(b)/.match("('a'b").to_a
+  assert_equal ["(?'b", "b"], /[(?'a]+(b)/.match("(?'b").to_a
 end
 
 assert("Regexp#named_captures") do


### PR DESCRIPTION
```ruby
Regexp.new("(?'x'a)") =~ "a"          # CRuby: 0, mruby: RegexpError
Regexp.new("(?<x>a)\k'x'") =~ "aa"    # both: 0
```

A named group has two spellings, and this gem reads both of them in `\k` while accepting only one of them in a declaration. The pattern language could therefore refer to a name in a spelling it had no way to introduce.

Two places read the spelling.

`compile_atom()` parses the declaration, where the forms differ only in which byte closes the name. The angled one has to be told apart from the lookbehind `(?<=` and `(?<!` first; the quoted one has no such neighbour, so its name simply runs to its own terminator. That is what settles the two crossed spellings, and both agree with CRuby:

```ruby
/(?'a>b'x)/.names   # => ["a>b"]
/(?<a'b>x)/.names   # => ["a'b"]
```

`has_named_group()` scans for a declaration before the parser runs, because whether a plain `(...)` captures is settled by whether the pattern declares a name anywhere, including after that group. So the scan has to learn the spelling alongside the parser. Taught to the parser alone, the pattern compiles and then numbers the plain group that the declaration is supposed to demote:

```ruby
/(a)(?'b'b)/.match("ab").to_a
# CRuby: ["ab", "b"], with the parser half alone: ["ab", "a", "b"]
```

The scan steps over escapes and character classes through the helper it shares with the free-spacing pass, so `/\(?'a'(b)/` and `/[(?'a]+(b)/` declare nothing in the new spelling either. The table that pins those rules against both walks gains a row for each.

The two new tests separate the halves. The first raises `RegexpError` on the declaration itself, so it fails whenever the parser has not been taught; the second misnumbers whenever the scan has not been. Each was run against a build carrying only the other half.

Nothing else about the group changes with the spelling, and the tests say so: nesting, quantifiers and `/i`, either `\k` spelling reaching a group declared in either one, one name registry across the two so a name written twice is reported once, the empty and unterminated names still refused, and the numbered-backreference refusal that any declaration brings with it.

Verified with `rake -m test` on the default configuration and on `ci/gcc-clang`, whose six builds report no failure and no warning. Twenty-three patterns covering the new spelling were also compared against CRuby 4.0.6 one by one; they agree except that an unterminated name reports `unterminated named capture`, which is the wording this gem already gives the angled form.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Regular expressions now support named capture groups using both `(?<name>...)` and `(?'name'...)` syntax.
  * Named captures work consistently with nesting, references, quantifiers, duplicate names, and case-insensitive matching.

* **Bug Fixes**
  * Improved handling prevents escaped text and character-class contents from being incorrectly interpreted as named-group declarations.
  * Clearer diagnostics are provided for unsupported group syntax.

* **Documentation**
  * Updated regexp syntax documentation to describe both supported named-capture formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->