### PR TITLE
mruby-regexp: say which `\k` reference failure it was

### DIFF
--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -43,8 +43,12 @@ typedef struct {
 
 static void compile_alt(re_compiler *c);  /* forward */
 
+/* Take the message as a String rather than as a C string, for the messages
+   that quote a group name: the name is a length-counted slice of the pattern
+   and may hold a NUL, which a C string would cut short. Callers with a fixed
+   message use compile_error() below. */
 static void
-compile_error(re_compiler *c, const char *msg)
+compile_error_str(re_compiler *c, mrb_value msg)
 {
   /* Quote c->orig, the pattern as written: when the pattern is preprocessed
      c->src points at the buffer preprocess_pattern() returned, so quoting it
@@ -52,7 +56,7 @@ compile_error(re_compiler *c, const char *msg)
      message. c->orig is the caller's buffer, which outlives the compile. It
      is not NUL-terminated, so use %l with the explicit length from
      c->orig_end. */
-  mrb_value emsg = mrb_format(c->mrb, "%s: /%l/",
+  mrb_value emsg = mrb_format(c->mrb, "%v: /%l/",
                               msg, c->orig, (size_t)(c->orig_end - c->orig));
 
   /* Free compile buffers before raising, since mrb_exc_raise longjmps out
@@ -74,6 +78,12 @@ compile_error(re_compiler *c, const char *msg)
 
   mrb_exc_raise(c->mrb,
     mrb_exc_new_str(c->mrb, mrb_exc_get_id(c->mrb, MRB_SYM(RegexpError)), emsg));
+}
+
+static void
+compile_error(re_compiler *c, const char *msg)
+{
+  compile_error_str(c, mrb_str_new_cstr(c->mrb, msg));
 }
 
 /* Maximum number of instructions in a compiled pattern. Every jump target

--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -1219,6 +1219,12 @@ emit_codepoint(re_compiler *c, uint32_t cp)
   }
 }
 
+/* Largest number a \k<n> / \k<-n> backreference may spell. The bound is far
+   above RE_MAX_CAPTURES because it is not a capacity: it separates two of
+   CRuby's messages, `too big number` for a number past it and `invalid backref
+   number/name` for one within it that names no group. */
+#define RE_MAX_BACKREF_NUM 2147483647
+
 /* Compile a single atom (character, class, group, etc.) */
 static void
 compile_atom(re_compiler *c)
@@ -1464,6 +1470,32 @@ compile_atom(re_compiler *c)
 
       int group = -1;
       if (name_len > 0 && (name[0] == '-' || (name[0] >= '0' && name[0] <= '9'))) {
+        mrb_bool relative = (name[0] == '-');
+        uint32_t first = relative ? 1 : 0;
+
+        /* CRuby reads the whole name before converting it, so a name that is
+           not `-`? followed by digits is a malformed name whatever the digits
+           it does hold would come to: \k<99999999999999999999x> is `invalid
+           group name`, not `too big number`. A lone `-` is malformed too. */
+        mrb_bool numeric = (first < name_len);
+        for (uint32_t i = first; numeric && i < name_len; i++) {
+          if (name[i] < '0' || name[i] > '9') numeric = FALSE;
+        }
+
+        int n = 0;
+        for (uint32_t i = first; numeric && i < name_len; i++) {
+          int digit = name[i] - '0';
+          /* CRuby's scanner stops at RE_MAX_BACKREF_NUM, and a number past it
+             is too big rather than a reference to a group that is missing. */
+          if (n > (RE_MAX_BACKREF_NUM - digit) / 10) compile_error(c, "too big number");
+          n = n * 10 + digit;
+        }
+        /* n == 0 names group 0, the whole match, which \k cannot reference */
+        if (!numeric || n == 0) {
+          compile_error_str(c, mrb_format(c->mrb, "invalid group name <%l>",
+                                          name, (size_t)name_len));
+        }
+
         /* CRuby rejects a numbered backreference in a named pattern whatever
            its spelling, and it has to be rejected here too: once plain groups
            stop consuming numbers, both the absolute bound and the relative
@@ -1472,14 +1504,10 @@ compile_atom(re_compiler *c)
         if (c->dont_capture) {
           compile_error(c, "numbered backref/call is not allowed. (use name)");
         }
-        mrb_bool relative = (name[0] == '-');
-        int n = 0;
-        for (uint32_t i = (relative ? 1 : 0); i < name_len; i++) {
-          if (name[i] < '0' || name[i] > '9') compile_error(c, "invalid backreference");
-          n = n * 10 + (name[i] - '0');
-          if (n > (int)c->num_captures - 1) compile_error(c, "undefined group name reference");
-        }
         group = relative ? (int)c->num_captures - n : n;
+        if (group < 1 || group >= (int)c->num_captures) {
+          compile_error(c, "invalid backref number/name");
+        }
       }
       else {
         for (uint16_t i = 0; i < c->num_named; i++) {
@@ -1489,9 +1517,10 @@ compile_atom(re_compiler *c)
             break;
           }
         }
-      }
-      if (group < 1 || group >= (int)c->num_captures) {
-        compile_error(c, "undefined group name reference");
+        if (group < 1) {
+          compile_error_str(c, mrb_format(c->mrb, "undefined name <%l> reference",
+                                          name, (size_t)name_len));
+        }
       }
       emit(c, RE_BACKREF, (uint8_t)group, (c->flags & RE_FLAG_IGNORECASE) ? 1 : 0);
       c->has_backref = TRUE;

--- a/mrbgems/mruby-regexp/test/regexp_syntax.rb
+++ b/mrbgems/mruby-regexp/test/regexp_syntax.rb
@@ -754,9 +754,128 @@ end
 assert("Regexp - numeric \\k backreference out of int range") do
   # The digit accumulator is an int with no bound, so 4294967297 used to wrap
   # to 1 and bind this backreference to group 1 instead of raising.
-  assert_raise(RegexpError) { Regexp.new("(a)\\k<4294967297>") }
-  assert_raise(RegexpError) { Regexp.new("(a)\\k<-4294967297>") }
-  assert_raise(RegexpError) { Regexp.new("(a)(b)\\k<4294967298>") }
+  msg = "too big number"
+  assert_raise_with_message(RegexpError, "#{msg}: /(a)\\k<4294967297>/") do
+    Regexp.new("(a)\\k<4294967297>")
+  end
+  assert_raise_with_message(RegexpError, "#{msg}: /(a)\\k<-4294967297>/") do
+    Regexp.new("(a)\\k<-4294967297>")
+  end
+  assert_raise_with_message(RegexpError, "#{msg}: /(a)(b)\\k<4294967298>/") do
+    Regexp.new("(a)(b)\\k<4294967298>")
+  end
+end
+
+assert("Regexp - \\k group reference errors say which failure it was") do
+  # A \k reference fails in four ways and CRuby gives each its own message.
+  # They used to collapse into one, so a pattern that misspelled a name and a
+  # pattern that named a group it never opened read the same.
+
+  # a name that is neither `-`? digits nor a name any group carries
+  assert_raise_with_message(RegexpError, "invalid group name <1x>: /(a)\\k<1x>/") do
+    Regexp.new("(a)\\k<1x>")
+  end
+  assert_raise_with_message(RegexpError, "invalid group name <-x>: /(a)\\k<-x>/") do
+    Regexp.new("(a)\\k<-x>")
+  end
+  # `-` with no digits behind it
+  assert_raise_with_message(RegexpError, "invalid group name <->: /(a)\\k<->/") do
+    Regexp.new("(a)\\k<->")
+  end
+  # group 0 is the whole match, which \k cannot name in either spelling.
+  # The message quotes the name in <> whichever delimiter wrote it.
+  assert_raise_with_message(RegexpError, "invalid group name <0>: /(a)\\k<0>/") do
+    Regexp.new("(a)\\k<0>")
+  end
+  assert_raise_with_message(RegexpError, "invalid group name <-0>: /(a)\\k<-0>/") do
+    Regexp.new("(a)\\k<-0>")
+  end
+  assert_raise_with_message(RegexpError, "invalid group name <0>: /(a)\\k'0'/") do
+    Regexp.new("(a)\\k'0'")
+  end
+
+  # the name is read whole before it is converted, so digits followed by
+  # anything else is a malformed name and never an oversized number
+  assert_raise_with_message(RegexpError,
+                            "invalid group name <99999999999999999999x>: /(a)\\k<99999999999999999999x>/") do
+    Regexp.new("(a)\\k<99999999999999999999x>")
+  end
+
+  # a number past the bound, either sign
+  assert_raise_with_message(RegexpError, "too big number: /(a)\\k<2147483648>/") do
+    Regexp.new("(a)\\k<2147483648>")
+  end
+  assert_raise_with_message(RegexpError, "too big number: /(a)\\k<-2147483648>/") do
+    Regexp.new("(a)\\k<-2147483648>")
+  end
+
+  # a number within the bound that names no group: a different message from
+  # the one above, and the bound is where they part
+  msg = "invalid backref number/name"
+  assert_raise_with_message(RegexpError, "#{msg}: /(a)\\k<2147483647>/") do
+    Regexp.new("(a)\\k<2147483647>")
+  end
+  assert_raise_with_message(RegexpError, "#{msg}: /(a)\\k<5>/") do
+    Regexp.new("(a)\\k<5>")
+  end
+  assert_raise_with_message(RegexpError, "#{msg}: /(a)\\k'5'/") do
+    Regexp.new("(a)\\k'5'")
+  end
+  assert_raise_with_message(RegexpError, "#{msg}: /(a)\\k<-5>/") do
+    Regexp.new("(a)\\k<-5>")
+  end
+  assert_raise_with_message(RegexpError, "#{msg}: /(a)(b)\\k<-3>/") do
+    Regexp.new("(a)(b)\\k<-3>")
+  end
+
+  # a name no group carries
+  assert_raise_with_message(RegexpError,
+                            "undefined name <_nope> reference: /(a)\\k<_nope>/") do
+    Regexp.new("(a)\\k<_nope>")
+  end
+  assert_raise_with_message(RegexpError,
+                            "undefined name <_nope> reference: /(a)\\k'_nope'/") do
+    Regexp.new("(a)\\k'_nope'")
+  end
+  # only `-` leads a number, so `+1` is a name and fails as one
+  assert_raise_with_message(RegexpError,
+                            "undefined name <+1> reference: /(a)\\k<+1>/") do
+    Regexp.new("(a)\\k<+1>")
+  end
+
+  # a named pattern refuses a numbered reference, but only once the name is
+  # read as a number at all: a malformed one and an oversized one are still
+  # reported for what they are
+  assert_raise_with_message(RegexpError, "invalid group name <1x>: /(a)(?<b>b)\\k<1x>/") do
+    Regexp.new("(a)(?<b>b)\\k<1x>")
+  end
+  assert_raise_with_message(RegexpError, "invalid group name <0>: /(a)(?<b>b)\\k<0>/") do
+    Regexp.new("(a)(?<b>b)\\k<0>")
+  end
+  assert_raise_with_message(RegexpError,
+                            "too big number: /(a)(?<b>b)\\k<99999999999999999999>/") do
+    Regexp.new("(a)(?<b>b)\\k<99999999999999999999>")
+  end
+  assert_raise_with_message(RegexpError,
+                            "numbered backref/call is not allowed. (use name): /(a)(?<b>b)\\k<5>/") do
+    Regexp.new("(a)(?<b>b)\\k<5>")
+  end
+
+  # leading zeros are digits like any other, not a malformed name
+  assert_equal "aa", "aa".match(Regexp.new("(a)\\k<01>"))[0]
+  assert_equal "aa", "aa".match(Regexp.new("(a)\\k<-01>"))[0]
+
+  # The name is a length-counted slice of the pattern, so a name holding a NUL
+  # is quoted whole. CRuby builds these messages through a C string and stops
+  # at the NUL, reporting `undefined name <a` for the first of the two.
+  assert_raise_with_message(RegexpError,
+                            "undefined name <a\0b> reference: /(a)\\k<a\0b>/") do
+    Regexp.new("(a)\\k<a\0b>")
+  end
+  assert_raise_with_message(RegexpError,
+                            "invalid group name <1\0>: /(a)\\k<1\0>/") do
+    Regexp.new("(a)\\k<1\0>")
+  end
 end
 
 assert("Regexp - named captures survive /x preprocessing") do


### PR DESCRIPTION
A `\k<...>` reference can fail in four ways, and CRuby names each one. mruby
answers the first three with a single message and the fourth with another, so
a pattern that misspelled a name and a pattern that named a group it never
opened read the same:

| pattern | mruby | CRuby 4.0.6 |
| --- | --- | --- |
| `(a)\k<99999999999999999999>` | `undefined group name reference` | `too big number` |
| `(a)\k<5>` | `undefined group name reference` | `invalid backref number/name` |
| `(a)\k<_nope>` | `undefined group name reference` | `undefined name <_nope> reference` |
| `(a)\k<1x>` | `invalid backreference` | `invalid group name <1x>` |

### Why the three collapse

The number was read and bounded in one loop:

```c
/* mrbgems/mruby-regexp/src/re_compile.c */
for (uint32_t i = (relative ? 1 : 0); i < name_len; i++) {
  if (name[i] < '0' || name[i] > '9') compile_error(c, "invalid backreference");
  n = n * 10 + (name[i] - '0');
  if (n > (int)c->num_captures - 1) compile_error(c, "undefined group name reference");
}
```

The bound on the partial value is what keeps the accumulator from wrapping, and
it is also the only thing that answers whether the group exists. So the loop
stops before the number is whole, and a number too large to be one at all
arrives at the same site as a number that simply names a group the pattern does
not have. The final `group < 1 || group >= num_captures` check outside the loop
carried the third case, an undefined name, to that same message.

### Reading the name in two passes

The first pass says whether the name is `-`? followed by digits; the second
converts it and stops at `RE_MAX_BACKREF_NUM`. Each failure then has its own
site: a name that is not a number, a number past the bound, and a number within
it that resolves to no group. The name lookup keeps its own.

Reading the name whole before converting it is what CRuby does, and it decides
one row on its own: `\k<99999999999999999999x>` is a malformed name, not an
oversized number, since the digits are never converted.

Two more rows fall out. `\k<0>` names the whole match, which no reference can
name, and `\k<->` has no digits at all; both are malformed names rather than
references to a missing group. And the refusal a named pattern gives a numbered
reference now comes after the name is read as a number at all, so
`(a)(?<b>b)\k<1x>` reports the malformed name rather than the refusal, which is
again CRuby's order.

`RE_MAX_BACKREF_NUM` is 2147483647, where CRuby's scanner stops. The bound is
not a capacity, it is where two messages part: `\k<2147483647>` is
`invalid backref number/name` and `\k<2147483648>` is `too big number`.

### Carrying the name in the message

Two of the four messages quote the name. `compile_error()` takes the message as
a C string and formats it with `%s`, which cannot carry one: the name is a
length-counted slice of the pattern, and a name holding a NUL would be cut
short. The first commit splits the function, leaving `compile_error_str()` to
take an `mrb_value` and `compile_error()` a wrapper over it. Every existing
caller keeps the message it already passes, so that commit changes no message.

### What still differs from CRuby

CRuby quotes one byte too many for the group-0 case, `invalid group name <0>>`
for `\k<0>` and `<0'>` for `\k'0'`. The name is quoted here without the
delimiter that closed it.

A name holding a NUL is quoted whole here. CRuby builds these messages through
a C string and stops at the NUL, so `(a)\k<a\0b>` is `undefined name <a` there
and `undefined name <a\0b> reference` here. This is the row the message carrier
above buys, and the tests pin it.

`\k<1-1>` is Onigmo's nesting-level backreference, which this engine does not
implement. It was `invalid backreference` and is now `invalid group name
<1-1>`; a spelling the engine cannot read is what both messages report.

### Testing

`build_config/ci/gcc-clang.rb` and `build_config/gcc-asan.rb`, run per build so
the counts are attributable:

| build | tests | OK | KO | skip |
| --- | ---: | ---: | ---: | ---: |
| `full-debug` | 2340 | 2335 | 0 | 5 |
| `bintest` | 2340 | 2327 | 0 | 13 |
| `cxx_abi` | 2340 | 2327 | 0 | 13 |
| `byte-string` | 2270 | 2221 | 0 | 49 |
| `ascii-case` | 2337 | 2324 | 0 | 13 |
| `gcc-asan` | 2340 | 2335 | 0 | 5 |

The binary tests pass 122 of 122 under `ci/gcc-clang` and 84 of 84 under
`gcc-asan`. No build warns.

Against a parser that still bounds the partial value, both test blocks turn
red:

```console
Fail: Regexp - numeric \k backreference out of int range (mrbgems: mruby-regexp)
Fail: Regexp - \k group reference errors say which failure it was (mrbgems: mruby-regexp)
```

### Size

Summed `.text` over `libmruby.a`, `full-core` at `-O3`, each build from an
empty build directory:

| | master | this branch | delta |
| --- | ---: | ---: | ---: |
| `libmruby.a` `.text` | 1287005 | 1287165 | +160 |
| `re_compile.o` `.text` | 23921 | 24081 | +160 |

The whole of it is the second pass over the name and the extra call sites. The
strings move by +43 bytes across `.rodata.str1.1` and `.rodata.str1.8`.
`mruby-regexp` is not in the default gembox, so `build_config/default.rb` does
not move.

### Environment

<details>

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-28-generic x86_64 |
| C compiler | gcc 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1) |
| binutils | GNU ld 2.47.20260726 |
| CRuby (oracle for the messages) | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM |

The size rows use a build config of their own, so that `full-core` at `-O3`
carries no test or debug options:

```ruby
MRuby::Build.new('size') do |conf|
  conf.toolchain
  conf.gembox 'full-core'
end
```

Compile lines for `mrbgems/mruby-regexp/src/re_compile.c` in the builds quoted
above, paths shortened:

```
# size, the -O3 full-core rows
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -I"include" -I"mrbgems/mruby-regexp/include" -I"build/size/include" -o "build/size/mrbgems/mruby-regexp/src/re_compile.o" "mrbgems/mruby-regexp/src/re_compile.c"

# ci/gcc-clang full-debug
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -I"include" -I"mrbgems/mruby-regexp/include" -I"build/full-debug/include" -o "build/full-debug/mrbgems/mruby-regexp/src/re_compile.o" "mrbgems/mruby-regexp/src/re_compile.c"

# ci/gcc-clang bintest
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK -I"include" -I"mrbgems/mruby-regexp/include" -I"build/bintest/include" -o "build/bintest/mrbgems/mruby-regexp/src/re_compile.o" "mrbgems/mruby-regexp/src/re_compile.c"

# ci/gcc-clang cxx_abi
gcc -MMD -c -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -I"include" -I"mrbgems/mruby-regexp/include" -I"build/cxx_abi/include" -o "build/cxx_abi/mrbgems/mruby-regexp/src/re_compile.o" "mrbgems/mruby-regexp/src/re_compile.c"

# ci/gcc-clang byte-string
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -I"include" -I"mrbgems/mruby-regexp/include" -I"build/byte-string/include" -o "build/byte-string/mrbgems/mruby-regexp/src/re_compile.o" "mrbgems/mruby-regexp/src/re_compile.c"

# ci/gcc-clang ascii-case
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CASE -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -I"include" -I"mrbgems/mruby-regexp/include" -I"build/ascii-case/include" -o "build/ascii-case/mrbgems/mruby-regexp/src/re_compile.o" "mrbgems/mruby-regexp/src/re_compile.c"

# gcc-asan
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -fsanitize=address,undefined -g3 -O0 -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -I"include" -I"mrbgems/mruby-regexp/include" -I"build/gcc-asan/include" -o "build/gcc-asan/mrbgems/mruby-regexp/src/re_compile.o" "mrbgems/mruby-regexp/src/re_compile.c"
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EtQ1ZeRkWXncrDed7qpJyY


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved regular expression error messages for invalid named and numeric backreferences.
  * Preserved embedded characters in group names and the original pattern text in diagnostics.
  * Clearly distinguishes malformed, undefined, unavailable, and oversized references.
  * Accepts valid references with leading zeros while detecting numeric overflow.

* **Tests**
  * Expanded coverage for backreference validation, embedded characters, overflow handling, and exact error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->