### PR TITLE
build: give a cross build's `mrbc` the target's answer on floats

### DIFF
--- a/lib/mruby/build.rb
+++ b/lib/mruby/build.rb
@@ -615,18 +615,11 @@ EOS
     def initialize(name, build_dir=nil, &block)
       @test_runner = Command::CrossTestRunner.new(self)
       super
-      unless mrbcfile_external? || MRuby.targets['host']
-        # add minimal 'host'
-        MRuby::Build.new('host') do |conf|
-          conf.toolchain
-          conf.build_mrbc_exec
-          conf.disable_libmruby
-        end
-      end
+      @mrbc_host = mrbcfile_external? ? nil : bind_mrbc_host
     end
 
     def mrbcfile
-      mrbcfile_external? ? super : MRuby::targets['host'].mrbcfile
+      mrbcfile_external? ? super : MRuby::targets[@mrbc_host].mrbcfile
     end
 
     def run_test
@@ -657,5 +650,35 @@ EOS
     protected
 
     def create_mrbc_build; end
+
+    private
+
+    # Name the build this target borrows `mrbc` from.
+    #
+    # The bytecode `mrbc` emits has to be loadable here, and `src/load.c`
+    # refuses a whole irep over a single pool entry the target cannot
+    # represent: under `MRB_NO_FLOAT` a float literal is one. So a target can
+    # only borrow from a build that answers the float question the way it
+    # does, and where none is at hand it gets one that does. A `host` the
+    # build config declares itself is left as it is written; the build
+    # generated here is this code's own and carries the target's answer.
+    def bind_mrbc_host
+      no_float = cc.has_define?('MRB_NO_FLOAT')
+      host = MRuby.targets['host']
+      return 'host' if host && host.cc.has_define?('MRB_NO_FLOAT') == no_float
+
+      # Where there is no `host` the generated build takes that name, as it
+      # always has. Where there is one and it answers otherwise, the build
+      # config owns the name, so this target gets a private `mrbc` beside its
+      # own output instead, the way a native build gets one.
+      name, internal = host ? ["#{@name}/mrbc", true] : ['host', false]
+      MRuby::Build.new(name, internal: internal) do |conf|
+        conf.toolchain
+        conf.build_mrbc_exec
+        conf.disable_libmruby
+        conf.compilers.each {|c| c.defines << 'MRB_NO_FLOAT'} if no_float
+      end
+      name
+    end
   end # CrossBuild
 end # MRuby


### PR DESCRIPTION
A `MRuby::CrossBuild` that names no `mrbc` of its own takes one from the `host`
build, and where the build config declares none, `CrossBuild#initialize`
generates a minimal one (`lib/mruby/build.rb:618-625` on master): a bare
`toolchain` + `build_mrbc_exec` + `disable_libmruby`, carrying none of the
target's configuration.

`mrbc` and the target therefore need not agree about what a value is, and
`src/load.c` does not let that pass. A pool entry the target cannot represent
makes it refuse the whole irep:

```c
      case IREP_TT_FLOAT:
#ifndef MRB_NO_FLOAT
        if (src + sizeof(double) > end) return FALSE;
        pool[i].tt = tt;
        pool[i].u.f = str_to_double(mrb, (const char*)src);
        src += sizeof(double);
        break;
#else
        return FALSE;           /* MRB_NO_FLOAT */
#endif
```

So one float literal, however far it sits from the code being run, costs the
file it is written in:

```console
$ cat t.rb
p 1.5
$ build/host/bin/mrbc -o t.mrb t.rb        # the generated host mrbc, floats enabled
$ build/no-float/bin/mruby -b t.mrb        # the target, MRB_NO_FLOAT
(unknown):0: irep load error (ScriptError)
```

`build_config/no-float.rb` is such a build. Compiling each of `test/t/*.rb` with
its `mrbc` and loading the result on its own `bin/mruby` leaves twelve files
unloadable (`array`, `class`, `float`, `gc`, `hash`, `integer`, `kernel`,
`literals`, `numeric`, `range`, `string`, `vformat`), and `rake test` ends at
the first of them:

```console
$ rake test MRUBY_CONFIG=build_config/no-float.rb
...
TEST for no-float
mrbtest - Embeddable Ruby Test

.........trace (most recent call last):
test/t/argumenterror.rb:34: irep load error (ScriptError)
rake aborted!
```

The name in that trace is the frame that was running, not the file that failed
to load; the failure carries no information about where the literal is.

## Fix

Bind each cross target to an `mrbc` that answers the float question the way it
does, and let targets that answer alike share one:

- a `host` that agrees is borrowed, as before;
- where there is no `host`, the generated build takes that name, as before, and
  carries the target's answer;
- a `host` the build config declares itself is left as it is written, so a
  target that disagrees with it gets a private `mrbc` beside its own output, at
  `<target>/mrbc`, the way a native build gets one from `create_mrbc_build`.

`mrbc` then refuses a float literal where it is written, naming the file and the
line, instead of emitting bytecode that fails at load:

```console
$ rake test MRUBY_CONFIG=build_config/no-float.rb
...
test/t/array.rb:65: Not implemented: PM_FLOAT_NODE
test/t/array.rb:0:0: generator error, Not implemented: PM_FLOAT_NODE
```

which is what `build_config/host-nofloat.rb` has always done, its `mrbc` being
its own because it is not a cross build. The remaining distance to a suite that
runs is the float literals in the shared test files, which this does not touch;
it only moves the report to the line that causes it.

`Command::Compiler#has_define?` is the reader that answers here: `MRB_NO_FLOAT`
is a build-config define, and `Build#has_define?` refuses to answer this early
because the gems have not contributed theirs yet.

## Scope

Only `MRB_NO_FLOAT`, and only where the target and the `mrbc` it would borrow
disagree about it. A cross build that names its own `mrbc` (`conf.mrbcfile =`)
is untouched, as is one that agrees with the `host` it borrows from.

## Verification

Two cross builds in one config, one `MRB_NO_FLOAT` and one not, built in both
declaration orders. Each target's `mrbc` compiles `p 1.5`, and the result is
loaded on that target's own `bin/mruby`:

| declared first | target | `mrbc` it binds to | `mrbc` on `p 1.5` | target on the bytecode |
|---|---|---|---|---|
| `nf` | `fl` | `fl/mrbc` | accepted | `1.5` |
| `nf` | `nf` | `host` | `PM_FLOAT_NODE` | n/a |
| `fl` | `fl` | `host` | accepted | `1.5` |
| `fl` | `nf` | `nf/mrbc` | `PM_FLOAT_NODE` | n/a |

The two orders agree, and neither target is served an `mrbc` that disagrees
with it.

A build config that declares its own float-enabled `host` next to an
`MRB_NO_FLOAT` cross build keeps that `host` and gets a separate `mrbc` for the
cross target:

```console
float OK    host/bin/mrbc
float OK    host/mrbc/bin/mrbc      # the native build's own, from create_mrbc_build
float DENY  nf/mrbc/bin/mrbc
```

`rake test`, `build_config/ci/gcc-clang.rb`, all five builds plus bintest:

| build | Total | OK | KO | Crash | Skip |
|---|---:|---:|---:|---:|---:|
| `full-debug` | 2339 | 2334 | 0 | 0 | 5 |
| `bintest` | 2339 | 2326 | 0 | 0 | 13 |
| `cxx_abi` | 2339 | 2326 | 0 | 0 | 13 |
| `byte-string` | 2269 | 2220 | 0 | 0 | 49 |
| `ascii-case` | 2336 | 2323 | 0 | 0 | 13 |
| `bintest` (bintest) | 122 | 122 | 0 | 0 | 0 |

No CI config declares a `MRuby::CrossBuild` (`ci/gcc-clang`, `ci/msvc` and
`cosmopolitan` are all `MRuby::Build`), so nothing there reaches this code.

The path that does is checked directly, with `build_config/no-float.rb` minus
the define, so its suite runs natively and the `mrbc` selection is the only
thing under test:

```ruby
MRuby::CrossBuild.new('cross-float') do |conf|
  conf.toolchain
  conf.gem :core => "mruby-bin-mruby"
  conf.test_runner.command = 'env'
  conf.enable_debug
  conf.enable_test
end
```

| | Total | OK | KO | Crash | Skip |
|---|---:|---:|---:|---:|---:|
| master | 771 | 769 | 0 | 0 | 2 |
| this PR | 771 | 769 | 0 | 0 | 2 |

And `build_config/no-float.rb` itself, which builds and runs as before:

```console
$ rake MRUBY_CONFIG=build_config/no-float.rb          # exit 0
$ build/no-float/bin/mruby -e 'p :sym, 1+2, "s".upcase, [1,2].map{|x|x*2}'
:sym
3
"S"
[2, 4]
```

## Environment

| | |
|---|---|
| OS | Linux 7.0.0-28-generic, x86_64 |
| Compiler | gcc 13.3.0 |
| Ruby | 4.0.6 |
| rake | 13.3.1 |

No C source changes, so `.text` is unaffected in every build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DRc6K8kwzLzvs4W6GiLRaz


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cross-compilation reliability when builds use different floating-point configurations.
  * Automatically selects a compatible build tool or creates one with matching settings, preventing configuration conflicts.
  * Ensures generated tools use the correct target configuration for more consistent build results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->