### PR TITLE
doc: say what a build converting case by ASCII stops refusing

### DIFF
--- a/doc/guides/mrbconf.md
+++ b/doc/guides/mrbconf.md
@@ -225,8 +225,8 @@ end
   pairs with one other. Without this macro it folds ASCII letters, and a
   pattern holding a character that needs one of the Unicode foldings raises
   `RegexpError` rather than answering as if the character had no case.
-- `MRB_USE_ASCII_CASE` narrows the case half back to ASCII, leaving the
-  indexing.
+- `MRB_USE_ASCII_CASE` narrows the case half back to ASCII, taking the refusal
+  with it and leaving the indexing.
 - If it isn't defined, they only support the US-ASCII encoding.
 
 `MRB_USE_ASCII_CASE`
@@ -237,6 +237,10 @@ end
 - Drops the Unicode case table the build would otherwise carry. That is what
   the option is for: a target counting its bytes buys the UTF-8 indexing of
   `MRB_UTF8_STRING` without the table beside it.
+- Bytes that spell no character are handed back as they stand rather than
+  refused with `ArgumentError`. That refusal belongs to the walk over
+  characters, which is the walk this narrows away: what converts instead reads
+  bytes, and reading bytes asks nothing about what they spell.
 - The regexp `i` flag reads that table too, so it narrows with the rest: it
   folds ASCII letters, and a pattern holding a character that needs one of the
   Unicode foldings raises `RegexpError` rather than answering as if the

--- a/doc/limitations.md
+++ b/doc/limitations.md
@@ -281,7 +281,9 @@ mruby does not have an `Encoding` class. Strings are treated as
 byte sequences by default. UTF-8 aware string operations can be
 enabled with the `MRB_UTF8_STRING` compile flag, which is also what
 makes case conversion follow Unicode rather than ASCII; `MRB_USE_ASCII_CASE`
-narrows that half back without giving up the indexing.
+narrows that half back without giving up the indexing. A Unicode conversion
+refuses bytes that spell no character with `ArgumentError`; one narrowed to
+ASCII reads no characters and hands those bytes back untouched.
 
 ## Integer Precision Varies by Boxing Mode
 


### PR DESCRIPTION
`doc/guides/mrbconf.md`, under `MRB_UTF8_STRING`:

> - A string read as bytes (`String#b`) converts and folds ASCII alone, and one
>   holding bytes that spell no character is refused with `ArgumentError`.

and, two bullets down, what the option beside it takes away:

> - `MRB_USE_ASCII_CASE` narrows the case half back to ASCII, leaving the
>   indexing.

The `MRB_USE_ASCII_CASE` section says the same at greater length: it narrows which
characters convert, and names the case table and the regexp `i` flag as what goes with
them. Neither place says the refusal goes too, so a reader carries the promise across.

## What happens

It goes too. The refusal is raised inside the walk over characters, `src/string.c:2197`,
and the whole walk sits inside `#if defined(MRB_UTF8_STRING) && !defined(MRB_USE_ASCII_CASE)`,
`src/string.c:2080-2251`. Compiled out, every method falls to its own ASCII loop, and
that loop asks nothing about what the bytes spell.

`"abc\x80"`, on three of the `build_config/ci/gcc-clang.rb` builds:

| | `bintest` | `ascii-case` | `byte-string` |
| --- | --- | --- | --- |
| `downcase` | `ArgumentError` | `"abc\x80"` | `"abc\x80"` |
| `upcase` | `ArgumentError` | `"ABC\x80"` | `"ABC\x80"` |
| `capitalize` | `ArgumentError` | `"Abc\x80"` | `"Abc\x80"` |
| `swapcase` | `ArgumentError` | `"ABC\x80"` | `"ABC\x80"` |
| `casecmp?("ABC\x80")` | `ArgumentError` | `true` | `true` |

Every `ArgumentError` above carries the message `input string invalid`.

## Why this changes the documents and not the code

The refusal is there because answering as though a stray byte were the character it
starts with hands back a string nobody asked for. A build that converts nothing above
ASCII writes nothing over those bytes, so there is no wrong answer left to refuse, and
reading the string through to find them would buy only the exception. The `ascii-case`
column above is also the `byte-string` column, which is the shape the last bullet of the
section already promises: a build reading its strings as bytes converts ASCII alone
whatever the option says.

Both readings are pinned already:

- `test/t/string.rb:452` asks for the `ArgumentError` from `#downcase`, `#upcase`,
  `#capitalize` and `#downcase!`, gated `if UNICODECASE`.
- `test/t/string.rb:498` asks the same bytes back untouched from `#downcase` and
  `#upcase`, gated `unless UNICODECASE`.
- `mrbgems/mruby-string-ext/test/string.rb:360-362` asks for it from `#casecmp?` and
  `#swapcase`, gated `skip unless UNICODECASE`, and `:376` asks `#casecmp?` for `false`
  instead, gated `skip if UNICODECASE`.

So what is missing is the sentence.

## Fix

Three sentences, no code.

- The `MRB_USE_ASCII_CASE` section gains a bullet: bytes that spell no character are
  handed back as they stand rather than refused, the refusal belonging to the walk the
  option narrows away.
- The `MRB_UTF8_STRING` bullet that sends the reader to that option names the refusal
  as part of what it takes, so the promise two bullets above is not carried across.
- `doc/limitations.md`, which said only that the option "narrows that half back without
  giving up the indexing", gains the same qualification.

## Verification

No build output changes: the diff is two Markdown files. The table above was measured on
this branch, and `rake -m test` on `build_config/ci/gcc-clang.rb` reports `KO 0` and
`Crash 0` in all five builds, unchanged from `03daa666`.

## Environment

<details>

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-28-generic x86_64 |
| CPU | AMD Ryzen 9 5950X (16 cores, 32 threads) |
| C compiler | gcc 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1) |
| binutils | GNU ld 2.47.20260726 |
| CRuby (build host) | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM |

The lines that actually compiled `src/string.c` in the three builds the table reads,
with `-MMD -c`, `-I` and `-o` dropped:

```console
# ci/gcc-clang, bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK src/string.c

# ci/gcc-clang, ascii-case
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CASE -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c

# ci/gcc-clang, byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F57Qh8PB4NJRGZPbg9QvHU


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that ASCII narrowing returns invalid UTF-8 byte sequences unchanged instead of raising an `ArgumentError`.
  - Expanded encoding limitation guidance to explain behavior under Unicode conversion and ASCII narrowing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->