### PR TITLE
mruby-regexp: give the pattern its buffers before the compile starts

### DIFF
--- a/mrbgems/mruby-regexp/include/re_internal.h
+++ b/mrbgems/mruby-regexp/include/re_internal.h
@@ -167,8 +167,15 @@ typedef struct {
 #define RE_LIST_CAPA(code_len, depth) \
   ((int)(code_len) * (int)(RE_PASS_SPAN(depth) + 1) + 16)
 
-/* Compile a pattern string into bytecode */
-mrb_regexp_pattern* mrb_re_compile(mrb_state *mrb, const char *pattern, mrb_int len, uint32_t flags);
+/* Compile a pattern string into `pat`, which the caller passes zero filled
+   and keeps reachable from a GC object for the whole call. Every buffer the
+   compile allocates hangs off `pat` from the moment it is allocated, so a
+   compile that raises, over a bad pattern or a refused allocation, leaves
+   them to mrb_re_free() rather than to the frame the longjmp abandons: the
+   zero fill is what lets mrb_re_free() read a pattern that got that far.
+   `pat->code_len` is written last and stays zero until the pattern is
+   complete. */
+void mrb_re_compile(mrb_state *mrb, mrb_regexp_pattern *pat, const char *pattern, mrb_int len, uint32_t flags);
 
 /* Free a compiled pattern */
 void mrb_re_free(mrb_state *mrb, mrb_regexp_pattern *pat);

--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -2060,8 +2060,14 @@ epsilon_path(const re_inst *code, uint32_t pc, uint32_t goal,
 static uint8_t
 mark_empty_loops(mrb_state *mrb, re_inst *code, uint32_t code_len)
 {
-  int32_t *delta = (int32_t*)mrb_calloc(mrb, code_len + 1, sizeof(int32_t));
-  uint32_t *seen = (uint32_t*)mrb_calloc(mrb, code_len + 1, sizeof(uint32_t));
+  /* One block holds both arrays. Asking twice puts a raising call between the
+     first allocation and anything that could free it: mrb_calloc() raises
+     when it cannot answer, and this frame is the only owner `delta` has.
+     code_len is capped at RE_MAX_CODE_LEN, so the doubled element count stays
+     well inside the overflow check mrb_calloc() makes. */
+  uint32_t n = code_len + 1;
+  int32_t *delta = (int32_t*)mrb_calloc(mrb, 2 * (size_t)n, sizeof(int32_t));
+  uint32_t *seen = (uint32_t*)(delta + n);
   uint32_t mark = 0;
 
   for (uint32_t pc = 0; pc < code_len; pc++) {
@@ -2080,7 +2086,6 @@ mark_empty_loops(mrb_state *mrb, re_inst *code, uint32_t code_len)
     depth += delta[pc];
     if (depth > max) max = depth;
   }
-  mrb_free(mrb, seen);
   mrb_free(mrb, delta);
   return max > UINT8_MAX ? UINT8_MAX : (uint8_t)max;
 }

--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -12,23 +12,30 @@
 #include <mruby/internal.h>
 #include <string.h>
 
-/* Compiler state */
+/* Compiler state.
+
+   Everything the compile allocates and the finished pattern goes on owning
+   hangs off `pat`, which mrb_re_compile()'s caller has already handed to a
+   Regexp. That is what makes the buffers survivable: raising is how this
+   compiler reports a bad pattern and how mrb_realloc() reports a refused
+   allocation, and either longjmps past this frame, which nothing then
+   unwinds. Held here instead, the buffers would go with the frame.
+
+   What is left here is the parse's own state: the cursor, the capacities the
+   pattern does not record, and the counts that reach `pat` at the end. */
 typedef struct {
   mrb_state *mrb;
+  mrb_regexp_pattern *pat;  /* the pattern being built; owns code/classes/names */
   const char *src;     /* pattern source, preprocessed (see preprocess_pattern) */
   const char *src_end;
   const char *orig;    /* pattern as written, for error messages */
   const char *orig_end;
   const char *p;       /* current position */
-  re_inst *code;       /* instruction array */
   uint32_t code_len;
   uint32_t code_capa;
-  re_charclass *classes;
-  uint16_t num_classes;
   uint16_t class_capa;
   uint16_t num_captures;
   uint32_t flags;
-  re_named_capture *named_captures;
   uint16_t num_named;
   mrb_bool has_backref;
   mrb_bool needs_backtrack;
@@ -38,7 +45,6 @@ typedef struct {
                                before the atom, and a `\u{...}` list moves it
                                forward so the quantifier repeats the last
                                codepoint alone */
-  char *stripped;           /* allocated buffer for pattern preprocessing */
 } re_compiler;
 
 static void compile_alt(re_compiler *c);  /* forward */
@@ -54,23 +60,6 @@ compile_error(re_compiler *c, const char *msg)
      c->orig_end. */
   mrb_value emsg = mrb_format(c->mrb, "%s: /%l/",
                               msg, c->orig, (size_t)(c->orig_end - c->orig));
-
-  /* Free compile buffers before raising, since mrb_exc_raise longjmps out
-     and the stack-local re_compiler is abandoned without a chance to clean
-     up. mrb_free doesn't trigger GC, so emsg stays valid across these. */
-  mrb_free(c->mrb, c->code);
-  c->code = NULL;
-  if (c->classes) {
-    for (uint16_t i = 0; i < c->num_classes; i++) {
-      mrb_free(c->mrb, c->classes[i].ranges);
-    }
-    mrb_free(c->mrb, c->classes);
-    c->classes = NULL;
-  }
-  mrb_free(c->mrb, c->named_captures);
-  c->named_captures = NULL;
-  if (c->stripped) mrb_free(c->mrb, c->stripped);
-  c->stripped = NULL;
 
   mrb_exc_raise(c->mrb,
     mrb_exc_new_str(c->mrb, mrb_exc_get_id(c->mrb, MRB_SYM(RegexpError)), emsg));
@@ -91,19 +80,19 @@ emit(re_compiler *c, uint8_t op, uint8_t a, uint16_t offset)
   if (c->code_len >= RE_MAX_CODE_LEN) compile_error(c, "regexp too large");
   if (c->code_len >= c->code_capa) {
     c->code_capa = c->code_capa ? c->code_capa * 2 : 64;
-    c->code = (re_inst*)mrb_realloc(c->mrb, c->code, sizeof(re_inst) * c->code_capa);
+    c->pat->code = (re_inst*)mrb_realloc(c->mrb, c->pat->code, sizeof(re_inst) * c->code_capa);
   }
   uint32_t pos = c->code_len++;
-  c->code[pos].op = op;
-  c->code[pos].a = a;
-  c->code[pos].offset = offset;
+  c->pat->code[pos].op = op;
+  c->pat->code[pos].a = a;
+  c->pat->code[pos].offset = offset;
   return pos;
 }
 
 static void
 patch(re_compiler *c, uint32_t pos, uint16_t offset)
 {
-  c->code[pos].offset = offset;
+  c->pat->code[pos].offset = offset;
 }
 
 /* True for the opcodes whose `offset` field holds an absolute code index, so
@@ -138,10 +127,10 @@ insert_inst(re_compiler *c, uint32_t pos, uint8_t op, uint8_t a, uint16_t offset
 {
   emit(c, RE_JMP, 0, 0);  /* grow array */
   uint32_t len = c->code_len - 1 - pos;
-  memmove(&c->code[pos + 1], &c->code[pos], sizeof(re_inst) * len);
-  c->code[pos].op = op;
-  c->code[pos].a = a;
-  c->code[pos].offset = offset;
+  memmove(&c->pat->code[pos + 1], &c->pat->code[pos], sizeof(re_inst) * len);
+  c->pat->code[pos].op = op;
+  c->pat->code[pos].a = a;
+  c->pat->code[pos].offset = offset;
 
   /* Fix code indices across the insertion. An index past `pos` shifts down by
      one. An index equal to `pos` is ambiguous:
@@ -156,9 +145,9 @@ insert_inst(re_compiler *c, uint32_t pos, uint8_t op, uint8_t a, uint16_t offset
        the quantifier wrapping the whole group wants. */
   for (uint32_t i = 0; i < c->code_len; i++) {
     if (i == pos) continue;
-    if (op_holds_code_index(c->code[i].op) &&
-        (c->code[i].offset > pos || (c->code[i].offset == pos && i > pos))) {
-      c->code[i].offset++;
+    if (op_holds_code_index(c->pat->code[i].op) &&
+        (c->pat->code[i].offset > pos || (c->pat->code[i].offset == pos && i > pos))) {
+      c->pat->code[i].offset++;
     }
   }
 }
@@ -188,15 +177,18 @@ next_char(re_compiler *c)
 static uint16_t
 add_class(re_compiler *c)
 {
-  if (c->num_classes >= RE_MAX_CLASSES) {
+  if (c->pat->num_classes >= RE_MAX_CLASSES) {
     compile_error(c, "too many character classes");
   }
-  if (c->num_classes >= c->class_capa) {
+  if (c->pat->num_classes >= c->class_capa) {
     c->class_capa = c->class_capa ? c->class_capa * 2 : 8;
-    c->classes = (re_charclass*)mrb_realloc(c->mrb, c->classes, sizeof(re_charclass) * c->class_capa);
+    c->pat->classes = (re_charclass*)mrb_realloc(c->mrb, c->pat->classes, sizeof(re_charclass) * c->class_capa);
   }
-  uint16_t id = c->num_classes++;
-  memset(&c->classes[id], 0, sizeof(re_charclass));
+  /* num_classes counts the entries mrb_re_free() reads a `ranges` pointer
+     out of, so the slot is cleared before it is counted rather than after. */
+  uint16_t id = c->pat->num_classes;
+  memset(&c->pat->classes[id], 0, sizeof(re_charclass));
+  c->pat->num_classes = id + 1;
   return id;
 }
 
@@ -319,12 +311,12 @@ class_add_fold_counterparts(re_compiler *c, uint16_t id, uint32_t cp)
   uint32_t alt[MRB_UNI_MAX_UNFOLD];
   int n = mrb_uni_case_unfold(cp, alt, MRB_UNI_MAX_UNFOLD);
   for (int i = 0; i < n; i++) {
-    if (alt[i] < 128) class_set_bit(&c->classes[id], (uint8_t)alt[i]);
-    else class_add_codepoint(c, &c->classes[id], alt[i]);
+    if (alt[i] < 128) class_set_bit(&c->pat->classes[id], (uint8_t)alt[i]);
+    else class_add_codepoint(c, &c->pat->classes[id], alt[i]);
   }
 #else
-  if (cp == 'k' || cp == 'K') class_add_codepoint(c, &c->classes[id], RE_FOLD_KELVIN);
-  else if (cp == 's' || cp == 'S') class_add_codepoint(c, &c->classes[id], RE_FOLD_LONG_S);
+  if (cp == 'k' || cp == 'K') class_add_codepoint(c, &c->pat->classes[id], RE_FOLD_KELVIN);
+  else if (cp == 's' || cp == 'S') class_add_codepoint(c, &c->pat->classes[id], RE_FOLD_LONG_S);
 #endif
 }
 
@@ -730,7 +722,7 @@ static void
 compile_charclass(re_compiler *c)
 {
   uint16_t id = add_class(c);
-  re_charclass *cc = &c->classes[id];
+  re_charclass *cc = &c->pat->classes[id];
   mrb_bool negated = FALSE;
 
   if (peek(c) == '^') {
@@ -978,7 +970,7 @@ compute_fixed_len(re_compiler *c, uint32_t start, uint32_t end, int *chars_out)
   uint32_t pc = start;
 
   while (pc < end) {
-    re_inst inst = c->code[pc];
+    re_inst inst = c->pat->code[pc];
     switch (inst.op) {
     case RE_CHAR: {
       /* A multibyte literal is a run of one-byte RE_CHAR instructions, and
@@ -989,8 +981,8 @@ compute_fixed_len(re_compiler *c, uint32_t start, uint32_t end, int *chars_out)
          and a run never splits one. */
       char buf[4];
       int n = 0;
-      while (n < 4 && pc + (uint32_t)n < end && c->code[pc + n].op == RE_CHAR) {
-        buf[n] = (char)c->code[pc + n].a;
+      while (n < 4 && pc + (uint32_t)n < end && c->pat->code[pc + n].op == RE_CHAR) {
+        buf[n] = (char)c->pat->code[pc + n].a;
         n++;
       }
       int clen = mrb_re_charlen(buf, buf + n, FALSE);
@@ -1092,8 +1084,8 @@ emit_char(re_compiler *c, uint8_t ch)
   if ((c->flags & RE_FLAG_IGNORECASE) &&
       ((ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z'))) {
     uint16_t id = add_class(c);
-    class_set_bit(&c->classes[id], ch);
-    class_set_bit(&c->classes[id], (uint8_t)(ch ^ 0x20));  /* the other case */
+    class_set_bit(&c->pat->classes[id], ch);
+    class_set_bit(&c->pat->classes[id], (uint8_t)(ch ^ 0x20));  /* the other case */
     class_add_fold_counterparts(c, id, ch);
     emit(c, RE_CLASS, (uint8_t)id, 0);
     return;
@@ -1148,9 +1140,9 @@ emit_cp_folded(re_compiler *c, uint32_t cp)
 #endif
   if (n == 0) return FALSE;
   uint16_t id = add_class(c);
-  class_add_codepoint(c, &c->classes[id], cp);
+  class_add_codepoint(c, &c->pat->classes[id], cp);
   for (int i = 0; i < n; i++) {
-    class_add_member(c, &c->classes[id], alt[i], FALSE);
+    class_add_member(c, &c->pat->classes[id], alt[i], FALSE);
   }
   emit(c, RE_CLASS, (uint8_t)id, 0);
   return TRUE;
@@ -1241,7 +1233,7 @@ compile_atom(re_compiler *c)
           uint32_t la_pos = emit(c, negative ? RE_NEG_LOOKAHEAD : RE_LOOKAHEAD, 0, 0);
           compile_alt(c);
           emit(c, RE_MATCH, 0, 0);  /* end of lookahead sub-pattern */
-          c->code[la_pos].offset = (uint16_t)c->code_len;  /* patch: skip past sub-pattern */
+          c->pat->code[la_pos].offset = (uint16_t)c->code_len;  /* patch: skip past sub-pattern */
           if (peek(c) != ')') compile_error(c, "unmatched '('");
           next_char(c);
           c->needs_backtrack = TRUE;  /* needs backtracking engine */
@@ -1257,7 +1249,7 @@ compile_atom(re_compiler *c)
           uint32_t sub_start = c->code_len;
           compile_alt(c);
           emit(c, RE_MATCH, 0, 0);
-          c->code[lb_pos].offset = (uint16_t)c->code_len;
+          c->pat->code[lb_pos].offset = (uint16_t)c->code_len;
 
           /* measure the sub-pattern for both rewind units */
           int fixed_chars;
@@ -1268,9 +1260,9 @@ compile_atom(re_compiler *c)
           if (fixed_len > 255) {
             compile_error(c, "lookbehind too long (max 255 bytes)");
           }
-          c->code[lb_pos].a = (uint8_t)fixed_len;
+          c->pat->code[lb_pos].a = (uint8_t)fixed_len;
           /* the character count never exceeds the byte count, so it fits */
-          c->code[lb_pos + 1].a = (uint8_t)fixed_chars;
+          c->pat->code[lb_pos + 1].a = (uint8_t)fixed_chars;
 
           if (peek(c) != ')') compile_error(c, "unmatched '('");
           next_char(c);
@@ -1345,11 +1337,11 @@ compile_atom(re_compiler *c)
         emit(c, RE_SAVE, 0, group * 2);
         if (cap_name) {
           /* register named capture */
-          c->named_captures = (re_named_capture*)mrb_realloc(c->mrb, c->named_captures,
+          c->pat->named_captures = (re_named_capture*)mrb_realloc(c->mrb, c->pat->named_captures,
             sizeof(re_named_capture) * (c->num_named + 1));
-          c->named_captures[c->num_named].name = cap_name;
-          c->named_captures[c->num_named].name_len = cap_name_len;
-          c->named_captures[c->num_named].group = group;
+          c->pat->named_captures[c->num_named].name = cap_name;
+          c->pat->named_captures[c->num_named].name_len = cap_name_len;
+          c->pat->named_captures[c->num_named].group = group;
           c->num_named++;
         }
       }
@@ -1400,7 +1392,7 @@ compile_atom(re_compiler *c)
     else if (ch == 'd' || ch == 'D' || ch == 'w' || ch == 'W' || ch == 's' || ch == 'S') {
       next_char(c);
       uint16_t id = add_class(c);
-      class_add_shorthand(&c->classes[id], ch);
+      class_add_shorthand(&c->pat->classes[id], ch);
       /* class_add_shorthand already builds the complemented set for the
          uppercase forms (\D, \W, \S include utf8_any), so always emit
          RE_CLASS. Emitting RE_NCLASS here would negate a second time and
@@ -1413,7 +1405,7 @@ compile_atom(re_compiler *c)
          \H through an RE_NCLASS path that would double-negate. */
       next_char(c);
       uint16_t id = add_class(c);
-      class_add_shorthand(&c->classes[id], ch);
+      class_add_shorthand(&c->pat->classes[id], ch);
       emit(c, RE_CLASS, (uint8_t)id, 0);
     }
     else if (ch == 'A') {
@@ -1473,9 +1465,9 @@ compile_atom(re_compiler *c)
       }
       else {
         for (uint16_t i = 0; i < c->num_named; i++) {
-          if (c->named_captures[i].name_len == name_len &&
-              memcmp(c->named_captures[i].name, name, name_len) == 0) {
-            group = c->named_captures[i].group;
+          if (c->pat->named_captures[i].name_len == name_len &&
+              memcmp(c->pat->named_captures[i].name, name, name_len) == 0) {
+            group = c->pat->named_captures[i].group;
             break;
           }
         }
@@ -1564,7 +1556,7 @@ emit_atom_copy(re_compiler *c, uint32_t start, uint32_t size)
   int32_t delta = (int32_t)c->code_len - (int32_t)start;
   uint32_t atom_end = start + size;
   for (uint32_t j = 0; j < size; j++) {
-    re_inst in = c->code[start + j];
+    re_inst in = c->pat->code[start + j];
     if (op_holds_code_index(in.op) && in.offset >= start && in.offset <= atom_end) {
       in.offset = (uint16_t)((int32_t)in.offset + delta);
     }
@@ -1603,7 +1595,7 @@ compile_quantified(re_compiler *c)
          SPLIT offset = end (after JMP), patched after JMP is emitted */
       insert_inst(c, start, nongreedy ? RE_SPLITNG : RE_SPLIT, 0, 0);
       emit(c, RE_JMP, 0, start);
-      c->code[start].offset = (uint16_t)c->code_len;  /* patch: skip to end */
+      c->pat->code[start].offset = (uint16_t)c->code_len;  /* patch: skip to end */
     }
     else if (ch == '+') {
       /* e+ → body; SPLIT/SPLITNG(start)
@@ -1614,7 +1606,7 @@ compile_quantified(re_compiler *c)
     else { /* ? */
       /* e? → SPLIT(body, end); body; end: */
       insert_inst(c, start, nongreedy ? RE_SPLITNG : RE_SPLIT, 0, 0);
-      c->code[start].offset = (uint16_t)c->code_len;  /* patch: skip to end */
+      c->pat->code[start].offset = (uint16_t)c->code_len;  /* patch: skip to end */
     }
   }
   else if (ch == '{') {
@@ -1669,7 +1661,7 @@ compile_quantified(re_compiler *c)
       if (wrap_optional) {
         /* Make the whole {1,m}/{1,} body skippable so it matches zero times. */
         insert_inst(c, start, nongreedy ? RE_SPLITNG : RE_SPLIT, 0, 0);
-        c->code[start].offset = (uint16_t)c->code_len;
+        c->pat->code[start].offset = (uint16_t)c->code_len;
       }
     }
   }
@@ -1745,17 +1737,17 @@ compile_alt(re_compiler *c)
      source order -- i.e. leftmost-first across three or more branches. */
   for (uint32_t i = 0; i < split_count; i++) {
     uint32_t pos = alt_starts[0] - split_count + i;
-    c->code[pos].op = RE_SPLIT;
-    c->code[pos].a = 0;
-    c->code[pos].offset = (uint16_t)alt_starts[split_count - i];
+    c->pat->code[pos].op = RE_SPLIT;
+    c->pat->code[pos].a = 0;
+    c->pat->code[pos].offset = (uint16_t)alt_starts[split_count - i];
   }
 
   /* Patch JMPs (they are right before each alt_starts[1..n-1]) to point to end */
   uint32_t end = c->code_len;
   for (int i = 1; i < num_alts; i++) {
     uint32_t jmp_pos = alt_starts[i] - 1;
-    c->code[jmp_pos].op = RE_JMP;
-    c->code[jmp_pos].offset = (uint16_t)end;
+    c->pat->code[jmp_pos].op = RE_JMP;
+    c->pat->code[jmp_pos].offset = (uint16_t)end;
   }
 }
 
@@ -1857,12 +1849,16 @@ skip_uninterpreted(const char *src, const char *end, mrb_bool *in_class)
  * written there, which is a literal member rather than a comment group.
  * Escaped characters (\ followed by anything) are preserved.
  * skip_uninterpreted() decides which bytes those are.
+ *
+ * The buffer comes from the GC arena, which holds it until the caller's frame
+ * is gone: the parser reads it from beginning to end, and every raise in
+ * between leaves this function nothing to be reached through.
  */
 static char*
 preprocess_pattern(mrb_state *mrb, const char *src, mrb_int len,
                    mrb_bool extended, mrb_int *out_len)
 {
-  char *buf = (char*)mrb_malloc(mrb, len);
+  char *buf = (char*)mrb_temp_alloc(mrb, len);
   mrb_int o = 0;
   mrb_bool in_class = FALSE;
   const char *end = src + len;
@@ -2109,23 +2105,24 @@ compute_first_set(const re_inst *code, uint32_t code_len,
   return set_bits < 96;  /* useful only if fewer than 75% of bytes match */
 }
 
-mrb_regexp_pattern*
-mrb_re_compile(mrb_state *mrb, const char *pattern, mrb_int len, uint32_t flags)
+void
+mrb_re_compile(mrb_state *mrb, mrb_regexp_pattern *pat,
+               const char *pattern, mrb_int len, uint32_t flags)
 {
   re_compiler c;
   memset(&c, 0, sizeof(c));
 
+  c.mrb = mrb;
+  c.pat = pat;
   c.orig = pattern;
   c.orig_end = pattern + len;
 
   if ((flags & RE_FLAG_EXTENDED) || has_comment_group(pattern, len)) {
     mrb_int slen;
-    c.stripped = preprocess_pattern(mrb, pattern, len,
-                                    (flags & RE_FLAG_EXTENDED) != 0, &slen);
-    pattern = c.stripped;
+    pattern = preprocess_pattern(mrb, pattern, len,
+                                 (flags & RE_FLAG_EXTENDED) != 0, &slen);
     len = slen;
   }
-  c.mrb = mrb;
   c.src = pattern;
   c.src_end = pattern + len;
   c.p = pattern;
@@ -2135,6 +2132,8 @@ mrb_re_compile(mrb_state *mrb, const char *pattern, mrb_int len, uint32_t flags)
      already taken out the /x free-spacing, the #comments and the (?#...)
      groups. */
   c.dont_capture = has_named_group(pattern, len);
+
+  pat->flags = flags;
 
   /* group 0 start */
   emit(&c, RE_SAVE, 0, 0);
@@ -2149,35 +2148,33 @@ mrb_re_compile(mrb_state *mrb, const char *pattern, mrb_int len, uint32_t flags)
   emit(&c, RE_SAVE, 0, 1);
   emit(&c, RE_MATCH, 0, 0);
 
-  mrb_regexp_pattern *pat = (mrb_regexp_pattern*)mrb_malloc(mrb, sizeof(mrb_regexp_pattern));
-  pat->code = c.code;
-  pat->code_len = c.code_len;
-  pat->classes = c.classes;
-  pat->num_classes = c.num_classes;
+  /* code_len is the last field written, at the end of this function: the
+     Regexp has been holding this pattern since before the compile started,
+     and a non-zero code_len is what tells the rest of the gem that what it
+     holds can be run (see re_uninitialized_p()). Everything below reads the
+     local instead. */
+  uint32_t code_len = c.code_len;
   pat->num_captures = c.num_captures;
-  pat->flags = flags;
-  pat->named_captures = c.named_captures;
-  pat->named_arena = NULL;
   pat->num_named = c.num_named;
 
-  /* Copy capture names into an owned arena. Until this point the names
-     point into the pattern source (or into c.stripped, which gets freed
-     below when the pattern was preprocessed). After this loop the regexp
-     owns its names. */
+  /* Copy capture names into an owned arena. Until this point the names point
+     into the pattern source, or into the preprocessed copy of it, which the
+     GC arena owns and drops once this frame is gone. After this loop the
+     regexp owns its names. */
   if (c.num_named > 0) {
     size_t total = 0;
-    for (uint16_t i = 0; i < c.num_named; i++) total += c.named_captures[i].name_len;
+    for (uint16_t i = 0; i < c.num_named; i++) total += pat->named_captures[i].name_len;
     /* total is zero only when every registered name is empty, which the
        parser rejects, so today the arena is always taken. Allocate a byte
        for that case anyway rather than skipping the copy: skipping it leaves
-       name borrowing memory this function is about to free, and nulling name
+       name borrowing memory the pattern does not own, and nulling name
        instead would hand a NULL to the memcmp() in matchdata_name_to_group(),
        which is declared nonnull even for a zero length. */
     pat->named_arena = (char*)mrb_malloc(mrb, total ? total : 1);
     size_t off = 0;
     for (uint16_t i = 0; i < c.num_named; i++) {
-      uint32_t n = c.named_captures[i].name_len;
-      memcpy(pat->named_arena + off, c.named_captures[i].name, n);
+      uint32_t n = pat->named_captures[i].name_len;
+      memcpy(pat->named_arena + off, pat->named_captures[i].name, n);
       pat->named_captures[i].name = pat->named_arena + off;
       off += n;
     }
@@ -2190,7 +2187,7 @@ mrb_re_compile(mrb_state *mrb, const char *pattern, mrb_int len, uint32_t flags)
   {
     uint8_t pbuf[256];
     int plen = 0;
-    for (uint32_t i = 0; i < pat->code_len && plen < 255; i++) {
+    for (uint32_t i = 0; i < code_len && plen < 255; i++) {
       if (pat->code[i].op == RE_SAVE) continue;
       if (pat->code[i].op == RE_CHAR) {
         pbuf[plen++] = pat->code[i].a;
@@ -2216,10 +2213,10 @@ mrb_re_compile(mrb_state *mrb, const char *pattern, mrb_int len, uint32_t flags)
     /* bytecode should be: SAVE(0), CHAR*N, SAVE(1), MATCH
        = 2 + prefix_len + 2 = prefix_len + 2 instructions
        (SAVE(0) at 0, CHARs at 1..N, SAVE(1) at N+1, MATCH at N+2) */
-    if (pat->code_len == (uint32_t)(pat->prefix_len + 3) &&
+    if (code_len == (uint32_t)(pat->prefix_len + 3) &&
         pat->code[0].op == RE_SAVE &&
-        pat->code[pat->code_len - 2].op == RE_SAVE &&
-        pat->code[pat->code_len - 1].op == RE_MATCH) {
+        pat->code[code_len - 2].op == RE_SAVE &&
+        pat->code[code_len - 1].op == RE_MATCH) {
       pat->is_literal = TRUE;
     }
   }
@@ -2229,26 +2226,27 @@ mrb_re_compile(mrb_state *mrb, const char *pattern, mrb_int len, uint32_t flags)
   {
     uint8_t bm[16];
     memset(bm, 0, sizeof(bm));
-    pat->has_first_bytes = compute_first_set(pat->code, pat->code_len, pat->classes, bm);
+    pat->has_first_bytes = compute_first_set(pat->code, code_len, pat->classes, bm);
     if (pat->has_first_bytes) {
       memcpy(pat->first_bytes, bm, 16);
     }
   }
 
-  pat->loop_depth = mark_empty_loops(mrb, pat->code, pat->code_len);
+  pat->loop_depth = mark_empty_loops(mrb, pat->code, code_len);
 
   /* Pre-allocate VM state cache for pike_vm */
   {
-    int list_capa = RE_LIST_CAPA(pat->code_len, pat->loop_depth);
-    pat->cached_visited = (uint32_t*)mrb_calloc(mrb, pat->code_len + 1, sizeof(uint32_t));
+    int list_capa = RE_LIST_CAPA(code_len, pat->loop_depth);
+    pat->cached_visited = (uint32_t*)mrb_calloc(mrb, code_len + 1, sizeof(uint32_t));
     pat->cached_threads[0] = mrb_malloc(mrb, sizeof(re_thread_cache) * list_capa);
     pat->cached_threads[1] = mrb_malloc(mrb, sizeof(re_thread_cache) * list_capa);
     pat->cached_list_capa = list_capa;
     pat->cache_in_use = FALSE;
   }
 
-  if (c.stripped) mrb_free(mrb, c.stripped);
-  return pat;
+  /* Nothing above allocates any more, so the pattern is complete: publish
+     the length that says so. */
+  pat->code_len = code_len;
 }
 
 void

--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -107,6 +107,15 @@ regexp_init(mrb_state *mrb, mrb_value self)
     flags = parse_flags(mrb, flags_val);
   }
 
+  /* An object holds one pattern and owns it, so a second initialize cannot
+     compile over the first: the pattern already there would be dropped with
+     nothing left to free it. CRuby refuses the call for the same reason. The
+     check stands after the argument conversions above, which is the order
+     CRuby reports the two errors in. */
+  if (DATA_PTR(self)) {
+    mrb_raise(mrb, E_TYPE_ERROR, "already initialized regexp");
+  }
+
   /* Set @source and @flags before mrb_re_compile() so a Regexp that survives
      a compile-time exception (e.g. picked up by ObjectSpace.each_object)
      still has usable IVs for hash/eql?/inspect. */

--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -24,6 +24,18 @@ static void regexp_free(mrb_state *mrb, void *ptr) {
 
 static const struct mrb_data_type regexp_type = { "Regexp", regexp_free };
 
+/* True while the object holds nothing that can be matched against. A Regexp
+   owns its pattern from before mrb_re_compile() fills it (see regexp_init()),
+   so a compile that raised leaves one behind, and it is reachable: the
+   exception can be rescued while ObjectSpace still hands the object out.
+   mrb_re_compile() writes code_len last, and no pattern compiles to nothing,
+   so a zero there says the compile did not finish. */
+static mrb_bool
+re_uninitialized_p(const mrb_regexp_pattern *pat)
+{
+  return !pat || pat->code_len == 0;
+}
+
 /* MatchData */
 typedef struct {
   mrb_value source;        /* source string */
@@ -122,10 +134,17 @@ regexp_init(mrb_state *mrb, mrb_value self)
   mrb_iv_set(mrb, self, mrb_intern_lit(mrb, "@source"), pattern);
   mrb_iv_set(mrb, self, mrb_intern_lit(mrb, "@flags"), mrb_int_value(mrb, (mrb_int)flags));
 
-  pat = mrb_re_compile(mrb, RSTRING_PTR(pattern), RSTRING_LEN(pattern), flags);
-
+  /* Hand the pattern over before the compile starts. mrb_re_compile() raises
+     to report a bad pattern and mrb_realloc() raises to report an allocation
+     it cannot make, and either longjmps past the compiler's frame with
+     nothing left to unwind it; what the object holds, regexp_free() reaches
+     however the compile ends. Until the compile finishes, code_len is zero
+     and re_uninitialized_p() refuses what it holds. */
+  pat = (mrb_regexp_pattern*)mrb_calloc(mrb, 1, sizeof(mrb_regexp_pattern));
   DATA_TYPE(self) = &regexp_type;
   DATA_PTR(self) = pat;
+
+  mrb_re_compile(mrb, pat, RSTRING_PTR(pattern), RSTRING_LEN(pattern), flags);
 
   /* store named captures as hash */
   if (pat->num_named > 0) {
@@ -413,7 +432,7 @@ static mrb_value
 exec_match(mrb_state *mrb, mrb_value self, mrb_value str, mrb_int pos, mrb_bool publish)
 {
   mrb_regexp_pattern *pat = DATA_GET_PTR(mrb, self, &regexp_type, mrb_regexp_pattern);
-  if (!pat) mrb_raise(mrb, E_ARGUMENT_ERROR, "uninitialized Regexp");
+  if (re_uninitialized_p(pat)) mrb_raise(mrb, E_ARGUMENT_ERROR, "uninitialized Regexp");
 
   int cap_size = pat->num_captures * 2;
   int *captures = (int*)mrb_malloc(mrb, sizeof(int) * cap_size);
@@ -574,7 +593,7 @@ exec_match_p(mrb_state *mrb, mrb_value re, mrb_value str, mrb_int pos)
   if (pos < 0) return mrb_false_value();
 
   mrb_regexp_pattern *pat = DATA_GET_PTR(mrb, re, &regexp_type, mrb_regexp_pattern);
-  if (!pat) mrb_raise(mrb, E_ARGUMENT_ERROR, "uninitialized Regexp");
+  if (re_uninitialized_p(pat)) mrb_raise(mrb, E_ARGUMENT_ERROR, "uninitialized Regexp");
   re_check_encoding(mrb, str);
 
   int ncap = mrb_re_exec(mrb, pat, RSTRING_PTR(str), RSTRING_LEN(str), pos, NULL, 0,
@@ -647,7 +666,7 @@ regexp_case_match(mrb_state *mrb, mrb_value self)
   str = match_operand(mrb, str);
 
   pat = DATA_GET_PTR(mrb, self, &regexp_type, mrb_regexp_pattern);
-  if (!pat) return mrb_false_value();
+  if (re_uninitialized_p(pat)) return mrb_false_value();
   re_check_encoding(mrb, str);
 
   md = exec_match(mrb, self, str, 0, TRUE);
@@ -1242,7 +1261,7 @@ regexp_s_gsub_str(mrb_state *mrb, mrb_value klass)
   check_regexp_arg(mrb, re);
 
   mrb_regexp_pattern *pat = DATA_GET_PTR(mrb, re, &regexp_type, mrb_regexp_pattern);
-  if (!pat) mrb_raise(mrb, E_ARGUMENT_ERROR, "uninitialized Regexp");
+  if (re_uninitialized_p(pat)) mrb_raise(mrb, E_ARGUMENT_ERROR, "uninitialized Regexp");
   if (!checked) re_check_encoding(mrb, str);
 
   const char *s = RSTRING_PTR(str);
@@ -1337,7 +1356,7 @@ regexp_s_sub_str(mrb_state *mrb, mrb_value klass)
   check_regexp_arg(mrb, re);
 
   mrb_regexp_pattern *pat = DATA_GET_PTR(mrb, re, &regexp_type, mrb_regexp_pattern);
-  if (!pat) mrb_raise(mrb, E_ARGUMENT_ERROR, "uninitialized Regexp");
+  if (re_uninitialized_p(pat)) mrb_raise(mrb, E_ARGUMENT_ERROR, "uninitialized Regexp");
   if (!checked) re_check_encoding(mrb, str);
 
   const char *s = RSTRING_PTR(str);
@@ -1393,7 +1412,7 @@ regexp_s_scan(mrb_state *mrb, mrb_value klass)
   check_regexp_arg(mrb, re);
 
   mrb_regexp_pattern *pat = DATA_GET_PTR(mrb, re, &regexp_type, mrb_regexp_pattern);
-  if (!pat) mrb_raise(mrb, E_ARGUMENT_ERROR, "uninitialized Regexp");
+  if (re_uninitialized_p(pat)) mrb_raise(mrb, E_ARGUMENT_ERROR, "uninitialized Regexp");
   re_check_encoding(mrb, str);
 
   const char *s = RSTRING_PTR(str);

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -11,6 +11,17 @@ assert("Regexp.new with regexp") do
   assert_true r2.match?("ABC")
 end
 
+class RegexpInitializedTwice < Regexp
+  def initialize(first, second)
+    super(first)
+    super(second)
+  end
+end
+
+assert("Regexp#initialize - second call") do
+  assert_raise(TypeError) { RegexpInitializedTwice.new("abc", "xyz") }
+end
+
 assert("Regexp#match - simple") do
   re = Regexp.new("abc")
   md = re.match("xabcy")


### PR DESCRIPTION
Replaces #7229, which closed one of the exits below.

`mrb_re_compile()` grew the pattern in a `re_compiler` on its own stack and copied the result into a `mrb_regexp_pattern` once the parse was through:

```c
  re_compiler c;
  memset(&c, 0, sizeof(c));
  ...
  mrb_regexp_pattern *pat = (mrb_regexp_pattern*)mrb_malloc(mrb, sizeof(mrb_regexp_pattern));
  pat->code = c.code;
```

Nothing outside that frame could reach `c.code`, `c.classes`, `c.named_captures` or `c.stripped` while the compile ran, and a compile leaves in two ways that never arrive at the copy: `compile_error()` raises `RegexpError` for a pattern it cannot parse, and `mrb_realloc()` raises `NoMemoryError` for an allocation it cannot make. Both longjmp past the frame, and nothing unwinds it.

`compile_error()` answered its own exit with a block of `mrb_free()` calls. A refused allocation had no answer at all, and neither did the allocations made after the parse: `pat` itself, `named_arena`, `prefix`, `cached_visited` and the two `cached_threads` are asked for one at a time, and a failure among them loses the pattern along with everything already handed to it. On a `MRB_GC_FIXED_ARENA` build, which `build_config/ci/gcc-clang.rb` and `build_config/ci/msvc.rb` both are, an arena overflow opens the same exits.

## The fix

`regexp_init()` allocates the pattern zero filled and hands it to the Regexp before asking for a compile:

```c
  pat = (mrb_regexp_pattern*)mrb_calloc(mrb, 1, sizeof(mrb_regexp_pattern));
  DATA_TYPE(self) = &regexp_type;
  DATA_PTR(self) = pat;

  mrb_re_compile(mrb, pat, RSTRING_PTR(pattern), RSTRING_LEN(pattern), flags);
```

Every buffer the compile allocates hangs off an object the GC reaches, from the moment it is allocated, so `regexp_free()` collects them however the compile ends. `re_compiler` keeps what belongs to the parse: the cursor, the capacities the pattern does not record, and the counts that reach it at the end.

A pattern that can be read before it is finished has to answer for that, in three places:

- `add_class()` clears a class before counting it. `num_classes` is what `mrb_re_free()` reads `ranges` pointers out of, so the count grows last rather than first.
- `pat->code_len` is written last, after the final allocation. No pattern compiles to no instructions, so a zero there marks a compile that did not finish, and `re_uninitialized_p()` reads it. It takes over from the `!pat` tests already standing at those call sites: the object is reachable in that state, since the exception can be rescued while `ObjectSpace` still hands it out.
- A second `Regexp#initialize` is refused with `TypeError: already initialized regexp`, which is CRuby's answer to it. Compiling in place would drop the pattern the object already owns with nothing left to free it, which the old code did.

That leaves `compile_error()` with nothing to free. The preprocessed copy of the pattern is not the pattern's to own, so it comes from `mrb_temp_alloc()` and the GC arena holds it for as long as the parse reads it. `mark_empty_loops()` takes its two arrays from one allocation for the same reason: asking twice put a raising call between the first block and anything that could free it.

## Measurement

A driver that redefines `mrb_basic_alloc_func` to fail every allocation from the Nth on, counting only the allocations made inside a `Regexp.new` call, under ASan and LeakSanitizer. The `leaked` columns are what LeakSanitizer reports at exit; the `size` columns are the allocation that was refused, and they differ between the two builds because the order changes, the pattern struct now being the third rather than the twelfth.

A pattern that compiles through to the end, `Regexp.new("[a] (?<n>b) " + "z"*2000, Regexp::EXTENDED)`. Its compile asks 20 times on master and 19 times here, the two arrays `mark_empty_loops()` wants now coming from one allocation:

| refused | master size | master leaked | this branch size | this branch leaked |
| --- | --- | --- | --- | --- |
| `#1` | 16 | 0 | 16 | 0 |
| `#2` | 24 | 0 | 24 | 0 |
| `#3` | 2012 | 0 | 120 | 0 |
| `#4` | 256 | **2012** | 2012 | 0 |
| `#5` | 320 | **2268** | 256 | 0 |
| `#6` | 16 | **2588** | 320 | 0 |
| `#7` | 512 | **2604** | 16 | 0 |
| `#8` | 1024 | **2860** | 512 | 0 |
| `#9` | 2048 | **3372** | 1024 | 0 |
| `#10` | 4096 | **4396** | 2048 | 0 |
| `#11` | 8192 | **6444** | 4096 | 0 |
| `#12` | 120 | **10540** | 8192 | 0 |
| `#13` | 1 | **10660** | 1 | 0 |
| `#14` | 8032 | **10661** | 16064 | 0 |
| `#15` | 8032 | **18693** | 8032 | 0 |
| `#16` | 8032 | **10661** | 64480 | 0 |
| `#17` | 64480 | **18693** | 64480 | 0 |
| `#18` | 64480 | **83173** | 16 | 0 |
| `#19` | 16 | 0 | 48 | 0 |
| `#20` | 48 | 0 | | |

The same pattern with a `(` appended, so that `compile_error()` raises. Its compile asks 14 times on master and 15 times here, the extra one being the pattern struct, which master does not reach on this path:

| refused | master size | master leaked | this branch size | this branch leaked |
| --- | --- | --- | --- | --- |
| `#1` | 16 | 0 | 16 | 0 |
| `#2` | 24 | 0 | 24 | 0 |
| `#3` | 2013 | 0 | 120 | 0 |
| `#4` | 256 | **2013** | 2013 | 0 |
| `#5` | 320 | **2269** | 256 | 0 |
| `#6` | 16 | **2589** | 320 | 0 |
| `#7` | 512 | **2605** | 16 | 0 |
| `#8` | 1024 | **2861** | 512 | 0 |
| `#9` | 2048 | **3373** | 1024 | 0 |
| `#10` | 4096 | **4397** | 2048 | 0 |
| `#11` | 8192 | **6445** | 4096 | 0 |
| `#12` | 129 | **10541** | 8192 | 0 |
| `#13` | 2049 | **10541** | 129 | 0 |
| `#14` | 48 | 0 | 2049 | 0 |
| `#15` | | | 48 | 0 |

The rows master answers with a leak are the two kinds this changes. `#4` to `#11`, in both tables, are a refused allocation in the middle of the parse, where `compile_error()` is never reached and nothing frees anything. `#12` onward are a refused allocation after the parse: on the failing pattern those are the two `mrb_format()` makes for the message, and on the other they are the pattern struct and the arrays that follow it, where what is lost is the pattern together with everything already handed to it. On this branch every N reports nothing leaked, in both tables.

Nothing observable changes when the allocator answers, apart from the refusal a second `initialize` now gets, which `mrbgems/mruby-regexp/test/regexp.rb` covers. `rake -m test` on the default configuration and on `ci/gcc-clang`, whose six test runs report no failure and no warning, says so; the whole suite under the sanitizer build below is green as well, at 2340 assertions, with LeakSanitizer reporting nothing at exit.

## Size

`.text` over every object of a build, on a clean build directory, `ci/gcc-clang`:

| build | master | this branch | |
| --- | --- | --- | --- |
| `full-debug` | 3482762 | 3483441 | +679 |
| `bintest` | 2351588 | 2352527 | +939 |
| `cxx_abi` | 2356784 | 2357769 | +985 |
| `byte-string` | 2282704 | 2283147 | +443 |
| `ascii-case` | 2307431 | 2308378 | +947 |

The growth is one indirection: a buffer the parser reached through `c` it now reaches through `c->pat`, and `c->pat` has to be loaded again after every call the parser makes. `compile_seq`, where the parser is inlined, takes +288 of the `bintest` figure and `mrb_re_compile` +349; the rest is `re_uninitialized_p()` at its six call sites.

### Environment

<details>
<summary>Versions</summary>

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS, Linux 7.0.0-28-generic x86_64 |
| CPU | AMD Ryzen 9 5950X, 16 cores |
| C compiler | gcc 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1), clang 22.1.8 for the sanitizer build |
| CRuby | 4.0.6 (2026-07-14) +PRISM, running rake |

</details>

<details>
<summary>Builds</summary>

`ci/gcc-clang`, with `-MMD -c`, `-I` and `-o` dropped:

```console
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-regexp/src/re_compile.c
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK mrbgems/mruby-regexp/src/re_compile.c
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-regexp/src/re_compile.c
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-regexp/src/re_compile.c
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CASE -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-regexp/src/re_compile.c
```

The sanitizer build is `full-core` with `MRB_GC_FIXED_ARENA`, `enable_debug`, `enable_test` and `enable_sanitizer "address"`:

```ruby
MRuby::Build.new('regexp-leak-asan') do |conf|
  conf.toolchain :clang
  conf.gembox 'full-core'
  conf.enable_sanitizer "address"
  conf.enable_debug
  conf.enable_test
  conf.compilers.each do |c|
    c.defines += %w(MRB_GC_FIXED_ARENA)
  end
end
```

```console
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -fsanitize=address -g3 -O0 -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-regexp/src/re_compile.c
```

</details>

<details>
<summary>Driver</summary>

Linked against that `libmruby.a` with `clang -g -O0 -fsanitize=address`. Its `mrb_basic_alloc_func` replaces the one in `src/allocf.c`, and `__count_on` bounds the window so the counted allocations are the ones `Regexp.new` makes rather than the parser's. It fails every allocation from the Nth on, not the Nth alone, because `mrb_realloc()` runs the GC and asks once more before it gives up.

```c
#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <mruby.h>
#include <mruby/compile.h>

static int counting = 0;
static int alloc_seq = 0;
static int fail_at = 0;

void *
mrb_basic_alloc_func(void *p, size_t size)
{
  if (size == 0) {
    free(p);
    return NULL;
  }
  if (counting) {
    alloc_seq++;
    if (fail_at && alloc_seq >= fail_at) {
      fprintf(stderr, "alloc #%d size %zu -> FAIL\n", alloc_seq, size);
      return NULL;
    }
    fprintf(stderr, "alloc #%d size %zu\n", alloc_seq, size);
  }
  return realloc(p, size);
}

static mrb_value count_on(mrb_state *mrb, mrb_value self) { counting = 1; return self; }
static mrb_value count_off(mrb_state *mrb, mrb_value self) { counting = 0; return self; }

static const char SCRIPT_VALID[] =
  "pat = \"[a] (?<n>b) \" + \"z\"*2000\n"
  "__count_on\n"
  "begin\n"
  "  Regexp.new(pat, Regexp::EXTENDED)\n"
  "rescue Exception => e\n"
  "end\n"
  "__count_off\n";

static const char SCRIPT_BROKEN[] =
  "pat = \"[a] (?<n>b) \" + \"z\"*2000 + \"(\"\n"
  "__count_on\n"
  "begin\n"
  "  Regexp.new(pat, Regexp::EXTENDED)\n"
  "rescue Exception => e\n"
  "end\n"
  "__count_off\n";

int
main(int argc, char **argv)
{
  mrb_state *mrb;
  const char *script = SCRIPT_BROKEN;

  if (argc > 1) fail_at = atoi(argv[1]);
  if (argc > 2 && strcmp(argv[2], "valid") == 0) script = SCRIPT_VALID;

  mrb = mrb_open();
  mrb_define_method(mrb, mrb->object_class, "__count_on", count_on, MRB_ARGS_NONE());
  mrb_define_method(mrb, mrb->object_class, "__count_off", count_off, MRB_ARGS_NONE());
  mrb_load_string(mrb, script);
  counting = 0;
  fail_at = 0;
  fprintf(stderr, "allocations in window: %d\n", alloc_seq);
  mrb_close(mrb);
  return 0;
}
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved regular expression compilation reliability, including safer handling of incomplete or failed patterns.
  * Prevented regular expressions from being initialized more than once; repeated initialization now raises a `TypeError`.
  * Strengthened validation across matching and replacement operations to avoid using uninitialized patterns.

* **Tests**
  * Added coverage for repeated initialization of `Regexp` subclasses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->