### PR TITLE
mruby-regexp: answer the backward search from the end of the subject

### DIFF
--- a/mrbgems/mruby-regexp/include/re_internal.h
+++ b/mrbgems/mruby-regexp/include/re_internal.h
@@ -264,4 +264,11 @@ int mrb_re_exec(mrb_state *mrb, const mrb_regexp_pattern *pat,
             const char *str, mrb_int len, mrb_int start,
             int *captures, int captures_size, mrb_bool binary);
 
+/* Execute a match backward: the last match that starts at or before `limit`.
+   Answers as mrb_re_exec() does, and clears the capture buffer itself before
+   each of the searches it makes, having to make more than one. */
+int mrb_re_rexec(mrb_state *mrb, const mrb_regexp_pattern *pat,
+            const char *str, mrb_int len, mrb_int limit,
+            int *captures, int captures_size, mrb_bool binary);
+
 #endif /* MRB_RE_INTERNAL_H */

--- a/mrbgems/mruby-regexp/mrblib/string_regexp.rb
+++ b/mrbgems/mruby-regexp/mrblib/string_regexp.rb
@@ -15,7 +15,8 @@
 #
 # With the type established, each override reaches the engine through class
 # methods that take the pattern as an argument (`Regexp.__search`,
-# `__byte_search`, `__search_p`, `__sub_str`, `__gsub_str`, `__scan`), so
+# `__byte_search`, `__byte_rsearch`, `__search_p`, `__sub_str`, `__gsub_str`,
+# `__scan`), so
 # nothing rewritten on the pattern instance is consulted on the way: the C
 # side searches, and the loops and blocks stay here.  The MatchData those
 # searches answer is built in C too, so what the overrides read from it
@@ -444,53 +445,6 @@ class String
     md && md.begin(0)
   end
 
-  # The last match that starts at or before `limit`, a byte offset, or nil,
-  # with the match globals left describing it.
-  #
-  # The engine searches forward only, so this walks the subject from the
-  # start and keeps the last match that qualifies: linear in the number of
-  # positions a match starts at, where the backward search CRuby hands to
-  # Onig is not.  Each step resumes one byte past the match start and not at
-  # the match end, which is what keeps overlapping matches in view:
-  # `"aaa".rindex(/aa/)` is 1, where resuming at the end would answer 0.
-  #
-  # The walk is in byte space so that its length is what it looks like.  A
-  # character offset is not a place the subject can be read from: every one
-  # handed to `Regexp.__search` is counted out from the start of the subject
-  # again, and every one read back off a match with `begin` is counted the
-  # same way, so a walk that speaks characters pays for the whole subject on
-  # every turn and takes quadratic time on a multibyte one.  Nothing is given
-  # up by leaving them: a byte inside a character is not a position a match
-  # can start at, and the engine steps over one on its own rather than seed a
-  # match attempt there, so `+ 1` reaches the next character by itself.
-  #
-  # `Regexp.__byte_search` does not range check its position, so the walk
-  # stops itself at the end of the subject.  An empty match there is the one
-  # that reaches it: it leaves `pos` one past the last byte.
-  #
-  # The walk publishes none of what it passes over.  A search that publishes
-  # cuts the whole subject into the pre match and post match globals, and
-  # every match here but the last is one this method already means to
-  # replace, so publishing them costs the subject once per match and leaves
-  # behind nothing anything reads.  The answer is published below instead,
-  # which is where it was published from before.
-  def __regexp_rsearch(pattern, limit)
-    found = nil
-    pos = 0
-    size = self.bytesize
-    while pos <= size && (md = Regexp.__byte_search(pattern, self, pos, false, false))
-      start = md.__byte_begin(0)
-      break if start > limit
-      found = md
-      pos = start + 1
-    end
-    # The globals still describe whatever they described before the call, the
-    # walk having said nothing to them, so the answer is published here and a
-    # search that found none clears them itself.
-    found ? found.__set_globals : Regexp.__search(pattern, nil)
-    found
-  end
-
   # Regexp-aware `rindex`.  Falls back to the C-defined `rindex` (aliased as
   # `__rindex` above) for every other argument form.
   def rindex(*args)
@@ -518,14 +472,12 @@ class String
         pos = len
       end
     end
-    # The walk reads the subject by byte, so the character position it is to
-    # stop at has to be read as one here.  A position at the end of the
+    # The search reads the subject by byte, so the character position it is
+    # to stop at has to be read as one here.  A position at the end of the
     # subject is the end of its bytes and needs no reading, which is the form
-    # `rindex` is called in when it is called with one argument at all; only
-    # a position named by the caller is measured, once, where the walk would
-    # otherwise have measured one on every turn.
+    # `rindex` is called in when it is called with one argument at all.
     byte_pos = pos == len ? self.bytesize : self[0, pos].bytesize
-    md = __regexp_rsearch(args[0], byte_pos)
+    md = Regexp.__byte_rsearch(args[0], self, byte_pos)
     md && md.begin(0)
   end
 
@@ -576,7 +528,7 @@ class String
     # As in `byteindex` above, and after the same clamp: a position past the
     # end of the subject has already been read as its end, which is a boundary.
     Regexp.__check_byte_pos(self, pos)
-    md = __regexp_rsearch(args[0], pos)
+    md = Regexp.__byte_rsearch(args[0], self, pos)
     md && md.__byte_begin(0)
   end
 
@@ -597,8 +549,8 @@ class String
   def rpartition(sep)
     return __rpartition(sep) unless Regexp === sep
     # The last match anywhere in the subject, so the limit is its end and the
-    # walk below never stops early.
-    md = __regexp_rsearch(sep, self.bytesize)
+    # search below never stops early.
+    md = Regexp.__byte_rsearch(sep, self, self.bytesize)
     # No match puts the whole subject in the tail, which is the row this
     # method is most often got wrong on.
     return ["", "", self.byteslice(0, self.bytesize)] unless md

--- a/mrbgems/mruby-regexp/src/re_exec.c
+++ b/mrbgems/mruby-regexp/src/re_exec.c
@@ -918,3 +918,77 @@ mrb_re_exec(mrb_state *mrb, const mrb_regexp_pattern *pat,
      the forward search is the unbounded case of the above. */
   return exec_range(mrb, pat, str, len, start, len, captures, captures_size, binary);
 }
+
+/* How far the backward probe below may read before it stops being the cheap
+   question. A search bounded to a window still reads from where the window
+   starts to the end of the subject, so the bound is on that span and not on
+   the window's own width: a narrow window at the end of a long subject is
+   cheap, the same window asked about a position far from the end is the
+   whole search over again. */
+#define RE_RSEARCH_PROBE_SPAN 256
+
+/* The last match that starts at or before `limit`, which is what `rindex`,
+   `byterindex` and `rpartition` ask for.
+
+   A forward walk answers this by stepping every match from the front and
+   keeping the last, which costs a search per match: on a subject a pattern
+   matches everywhere that is a search per position, and where one search is
+   itself linear in the subject -- a greedy `/a+b?/` and the like -- the walk
+   is quadratic in it.
+
+   The last match is usually near the end, so ask about the end first: widen
+   a window there until a match starts inside it. A window that catches one
+   costs the window rather than the subject, and the walk that follows has
+   only the window to cross. Widening stops at the span above rather than at
+   the front, so a subject with no match near the end falls through to the
+   single forward search this cost before, instead of paying for the
+   widening as well. */
+int
+mrb_re_rexec(mrb_state *mrb, const mrb_regexp_pattern *pat,
+             const char *str, mrb_int len, mrb_int limit,
+             int *captures, int captures_size, mrb_bool binary)
+{
+  if (limit > len) limit = len;
+  if (limit < 0) return 0;
+
+  int last[RE_MAX_CAPTURES * 2];
+  int last_n = 0;
+
+  for (mrb_int k = 1; ; k *= 2) {
+    mrb_int lo = limit - k + 1;
+    if (lo < 0) lo = 0;
+    if (len - lo > RE_RSEARCH_PROBE_SPAN) break;
+    memset(captures, -1, sizeof(int) * captures_size);
+    last_n = exec_range(mrb, pat, str, len, lo, limit, captures, captures_size, binary);
+    if (last_n) break;
+    /* The window had grown to the whole range, so there is no match to find
+       and the search below would only ask again. */
+    if (lo == 0) return 0;
+  }
+
+  if (last_n == 0) {
+    memset(captures, -1, sizeof(int) * captures_size);
+    last_n = exec_range(mrb, pat, str, len, 0, limit, captures, captures_size, binary);
+    if (last_n == 0) return 0;
+  }
+
+  /* Whichever range answered gave its leftmost match; the last one is found
+     by walking forward from it. Each step resumes one byte past the match
+     start and not at the match end, which is what keeps overlapping matches
+     in view: `"aaa"` against `/aa/` answers 1, where resuming at the end
+     would answer 0. A byte inside a character is not a position a match can
+     start at, and the engine steps over one rather than seed an attempt
+     there, so `+ 1` reaches the next character by itself. */
+  memcpy(last, captures, sizeof(int) * captures_size);
+  mrb_int pos = captures[0] + 1;
+  while (pos <= limit) {
+    memset(captures, -1, sizeof(int) * captures_size);
+    int n = exec_range(mrb, pat, str, len, pos, limit, captures, captures_size, binary);
+    if (n == 0) break;
+    last_n = n;
+    memcpy(last, captures, sizeof(int) * captures_size);
+    pos = captures[0] + 1;
+  }
+  memcpy(captures, last, sizeof(int) * captures_size);
+  return last_n;
+}

--- a/mrbgems/mruby-regexp/src/re_exec.c
+++ b/mrbgems/mruby-regexp/src/re_exec.c
@@ -354,9 +354,10 @@ add_thread(pike_state *s, re_threadlist *list,
 
 static int
 pike_vm(mrb_state *mrb, const mrb_regexp_pattern *pat,
-        const char *str, mrb_int len, mrb_int start,
+        const char *str, mrb_int len, mrb_int start, mrb_int start_limit,
         int *captures, int captures_size, mrb_bool binary)
 {
+  const char *start_cap = str + start_limit;
   const char *sp = str + start;
   const char *str_end = str + len;
   int ncap = pat->num_captures * 2;
@@ -415,7 +416,10 @@ pike_vm(mrb_state *mrb, const mrb_regexp_pattern *pat,
   curr.count = next.count = 0;
 
   for (; sp <= str_end; sp++) {
-    if (!s.matched) {
+    /* Past the last position a match may start at, only the threads already
+       running can still answer; once they are gone nothing can. */
+    if (!s.matched && sp > start_cap && curr.count == 0) break;
+    if (!s.matched && sp <= start_cap) {
       /* Skip ahead when no active threads */
       if (curr.count == 0) {
         if (pat->prefix_len > 0) {
@@ -427,6 +431,7 @@ pike_vm(mrb_state *mrb, const mrb_regexp_pattern *pat,
           while (sp < str_end && !FIRST_BYTE_OK(pat, (uint8_t)*sp)) sp++;
           if (sp > str_end) break;
         }
+        if (sp > start_cap) break;
       }
       /* Don't seed a new match attempt inside a character. Its interior is
          not a char boundary, and starting a thread there mis-decodes the
@@ -804,16 +809,17 @@ bt_match(const mrb_regexp_pattern *pat, const char *str, const char *str_end,
 
 static int
 backtrack_exec(mrb_state *mrb, const mrb_regexp_pattern *pat,
-               const char *str, mrb_int len, mrb_int start,
+               const char *str, mrb_int len, mrb_int start, mrb_int start_limit,
                int *captures, int captures_size, mrb_bool binary)
 {
+  const char *start_cap = str + start_limit;
   const char *str_end = str + len;
   int ncap = pat->num_captures * 2;
   if (ncap == 0) ncap = 2;
 
   int *caps = (int*)mrb_malloc(mrb, sizeof(int) * ncap);
 
-  for (const char *sp = str + start; sp <= str_end; sp++) {
+  for (const char *sp = str + start; sp <= str_end && sp <= start_cap; sp++) {
     /* Skip ahead using literal prefix or first-byte bitmap */
     if (pat->prefix_len > 0) {
       const char *skip = skip_to_prefix(pat, sp, str_end);
@@ -824,6 +830,7 @@ backtrack_exec(mrb_state *mrb, const mrb_regexp_pattern *pat,
       while (sp < str_end && !FIRST_BYTE_OK(pat, (uint8_t)*sp)) sp++;
       if (sp > str_end) break;
     }
+    if (sp > start_cap) break;
     if (!binary && sp < str_end && mrb_re_char_interior_p(str, sp, str_end)) {
       continue;
     }
@@ -846,16 +853,17 @@ backtrack_exec(mrb_state *mrb, const mrb_regexp_pattern *pat,
 /* Fast path for pure literal patterns: use memchr+memcmp, no NFA needed */
 static int
 literal_exec(const mrb_regexp_pattern *pat,
-             const char *str, mrb_int len, mrb_int start,
+             const char *str, mrb_int len, mrb_int start, mrb_int start_limit,
              int *captures, int captures_size, mrb_bool binary)
 {
+  const char *start_cap = str + start_limit;
   const char *sp = str + start;
   const char *str_end = str + len;
   int plen = pat->prefix_len;
 
-  while (sp + plen <= str_end) {
+  while (sp + plen <= str_end && sp <= start_cap) {
     const char *found = (const char*)memchr(sp, pat->prefix[0], str_end - sp);
-    if (!found || found + plen > str_end) return 0;
+    if (!found || found + plen > str_end || found > start_cap) return 0;
     if (!binary && mrb_re_char_interior_p(str, found, str_end)) {
       sp = found + 1;  /* not a char boundary, same rule as the other engines */
       continue;
@@ -879,17 +887,34 @@ literal_exec(const mrb_regexp_pattern *pat,
   return 0;
 }
 
+/* The search the three engines make, with the last position a match may
+   start at named.  The bound is on where a match may begin and not on how
+   far the subject is read: a match that begins at `start_limit` runs to
+   wherever it ends, which is why this is a separate argument rather than a
+   shorter `len`.  Shortening the subject would answer a different question
+   -- `$` and `\z` would assert at the cut, and a match reaching past it
+   would be lost. */
+static int
+exec_range(mrb_state *mrb, const mrb_regexp_pattern *pat,
+           const char *str, mrb_int len, mrb_int start, mrb_int start_limit,
+           int *captures, int captures_size, mrb_bool binary)
+{
+  if (pat->is_literal) {
+    return literal_exec(pat, str, len, start, start_limit, captures, captures_size, binary);
+  }
+  if (pat->has_backref || pat->needs_backtrack) {
+    return backtrack_exec(mrb, pat, str, len, start, start_limit, captures, captures_size, binary);
+  }
+  return pike_vm(mrb, pat, str, len, start, start_limit, captures, captures_size, binary);
+}
+
 /* Public entry point */
 int
 mrb_re_exec(mrb_state *mrb, const mrb_regexp_pattern *pat,
         const char *str, mrb_int len, mrb_int start,
         int *captures, int captures_size, mrb_bool binary)
 {
-  if (pat->is_literal) {
-    return literal_exec(pat, str, len, start, captures, captures_size, binary);
-  }
-  if (pat->has_backref || pat->needs_backtrack) {
-    return backtrack_exec(mrb, pat, str, len, start, captures, captures_size, binary);
-  }
-  return pike_vm(mrb, pat, str, len, start, captures, captures_size, binary);
+  /* The end of the subject is the last position anything can start at, so
+     the forward search is the unbounded case of the above. */
+  return exec_range(mrb, pat, str, len, start, len, captures, captures_size, binary);
 }

--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -355,12 +355,10 @@ set_match_globals(mrb_state *mrb, mrb_value obj, mrb_value str, int *captures, i
   mrb_gv_set(mrb, last_match_syms[LAST_PAREN], last_paren);
 }
 
-/* Create MatchData from captures. `publish` says whether the match becomes the
-   one the match globals describe; a caller that will publish a match of its
-   own choosing passes FALSE and leaves them where they were. */
+/* Create MatchData from captures, and make it the match the globals
+   describe. */
 static mrb_value
-create_matchdata(mrb_state *mrb, mrb_value regexp, mrb_value str, int *captures, int ncap,
-                 mrb_bool publish)
+create_matchdata(mrb_state *mrb, mrb_value regexp, mrb_value str, int *captures, int ncap)
 {
   /* Snapshot the subject: MatchData reports the string as it was at match
      time, so later in-place changes to it must not be visible here. */
@@ -381,7 +379,7 @@ create_matchdata(mrb_state *mrb, mrb_value regexp, mrb_value str, int *captures,
   mrb_iv_set(mrb, obj, mrb_intern_lit(mrb, "source"), str);
   mrb_iv_set(mrb, obj, mrb_intern_lit(mrb, "regexp"), regexp);
 
-  if (publish) set_match_globals(mrb, obj, str, captures, md->num_captures);
+  set_match_globals(mrb, obj, str, captures, md->num_captures);
 
   return obj;
 }
@@ -397,11 +395,9 @@ match_operand(mrb_state *mrb, mrb_value obj)
 
 /* Internal: execute match and create MatchData.
    Returns MatchData on match, nil on no match.
-   Sets $~ and $1-$9 globals, unless `publish` says the caller owns them: a
-   search that publishes nothing clears nothing either, so the globals come
-   out of it exactly as they went in. */
+   Sets $~ and $1-$9 globals, and clears them on a miss. */
 static mrb_value
-exec_match(mrb_state *mrb, mrb_value self, mrb_value str, mrb_int pos, mrb_bool publish)
+exec_match(mrb_state *mrb, mrb_value self, mrb_value str, mrb_int pos)
 {
   mrb_regexp_pattern *pat = DATA_GET_PTR(mrb, self, &regexp_type, mrb_regexp_pattern);
   if (!pat) mrb_raise(mrb, E_ARGUMENT_ERROR, "uninitialized Regexp");
@@ -414,10 +410,10 @@ exec_match(mrb_state *mrb, mrb_value self, mrb_value str, mrb_int pos, mrb_bool 
 
   if (ncap == 0) {
     mrb_free(mrb, captures);
-    if (publish) clear_match_globals(mrb);
+    clear_match_globals(mrb);
     return mrb_nil_value();
   }
-  mrb_value md = create_matchdata(mrb, self, str, captures, cap_size, publish);
+  mrb_value md = create_matchdata(mrb, self, str, captures, cap_size);
   mrb_free(mrb, captures);
   return md;
 }
@@ -446,7 +442,7 @@ regexp_match(mrb_state *mrb, mrb_value self)
   }
 
   re_check_encoding(mrb, str);
-  md = exec_match(mrb, self, str, pos, TRUE);
+  md = exec_match(mrb, self, str, pos);
   if (!mrb_nil_p(md) && !mrb_nil_p(block)) {
     return mrb_yield(mrb, block, md);
   }
@@ -495,7 +491,7 @@ re_search(mrb_state *mrb, mrb_value re, mrb_value str, mrb_int pos, mrb_bool che
     return mrb_nil_value();
   }
   if (!checked) re_check_encoding(mrb, str);
-  return exec_match(mrb, re, str, pos, TRUE);
+  return exec_match(mrb, re, str, pos);
 }
 
 static mrb_value
@@ -511,7 +507,7 @@ regexp_s_search(mrb_state *mrb, mrb_value klass)
 }
 
 /*
- * Regexp.__byte_search(re, str, pos = 0, checked = false, publish = true)
+ * Regexp.__byte_search(re, str, pos = 0, checked = false)
  *
  * Internal: the byte-offset search the mrblib loops of `gsub`, `split` and
  * `byteindex` drive themselves. No position normalization, because the
@@ -520,12 +516,6 @@ regexp_s_search(mrb_state *mrb, mrb_value klass)
  * the check reads the flag core left on it after the first turn. `checked`
  * carries the same meaning as in `__search`: `gsub` sets it for a block over
  * a quoted String pattern.
- *
- * `publish` says whether the match becomes the one the match globals describe.
- * A loop that walks past a match on the way to the one it wants clears it:
- * `rindex` and its family pass FALSE and publish the match they settled on
- * with `MatchData#__set_globals`. `gsub` and `scan` cannot, since the block
- * they call reads the globals of the match it was handed.
  */
 static mrb_value
 regexp_s_byte_search(mrb_state *mrb, mrb_value klass)
@@ -534,9 +524,8 @@ regexp_s_byte_search(mrb_state *mrb, mrb_value klass)
   mrb_int pos = 0;
 
   mrb_bool checked = FALSE;
-  mrb_bool publish = TRUE;
 
-  mrb_get_args(mrb, "oS|ibb", &re, &str, &pos, &checked, &publish);
+  mrb_get_args(mrb, "oS|ib", &re, &str, &pos, &checked);
   check_regexp_arg(mrb, re);
   /* Every mrblib loop enters at zero or at an offset a match answered with,
      so a position before the subject reaches here only from a direct call.
@@ -546,11 +535,64 @@ regexp_s_byte_search(mrb_state *mrb, mrb_value klass)
      encoding is, as `__search` asks a position it cannot place, since a
      subject the position names nothing in is not read either way. */
   if (pos < 0) {
-    if (publish) clear_match_globals(mrb);
+    clear_match_globals(mrb);
     return mrb_nil_value();
   }
   if (!checked) re_check_encoding(mrb, str);
-  return exec_match(mrb, re, str, pos, publish);
+  return exec_match(mrb, re, str, pos);
+}
+
+/*
+ * Regexp.__byte_rsearch(re, str, limit)
+ *
+ * Internal: the backward search of `rindex`, `byterindex` and `rpartition`.
+ * `limit` is a byte offset and the answer is the last match that starts at or
+ * before it, or nil.
+ *
+ * The three callers work in byte space and always pass a String, as the
+ * callers of `__byte_search` do, so there is no position normalization and no
+ * operand conversion here either. Nor is there a `checked`: none of the three
+ * has a quoted String pattern to reach here with, a String argument being the
+ * form each of them leaves to the C method it aliased.
+ *
+ * The match this answers with is the one the globals describe, and a miss
+ * clears them, as in every other search. The walk that used to pass over
+ * matches on its way to this one is inside this call now, so there is no
+ * longer a caller that has to keep the globals off what it passes.
+ */
+static mrb_value
+regexp_s_byte_rsearch(mrb_state *mrb, mrb_value klass)
+{
+  mrb_value re, str;
+  mrb_int limit;
+
+  mrb_get_args(mrb, "oSi", &re, &str, &limit);
+  check_regexp_arg(mrb, re);
+  /* A backstop, as the one in `__byte_search` is: every caller clamps its
+     position into the subject first, so a negative offset reaches here only
+     from a direct call, and it is the miss it names rather than a read
+     behind RSTRING_PTR(str). */
+  if (limit < 0) {
+    clear_match_globals(mrb);
+    return mrb_nil_value();
+  }
+  re_check_encoding(mrb, str);
+
+  mrb_regexp_pattern *pat = DATA_GET_PTR(mrb, re, &regexp_type, mrb_regexp_pattern);
+  if (!pat) mrb_raise(mrb, E_ARGUMENT_ERROR, "uninitialized Regexp");
+
+  int cap_size = pat->num_captures * 2;
+  int *captures = (int*)mrb_malloc(mrb, sizeof(int) * cap_size);
+  int ncap = mrb_re_rexec(mrb, pat, RSTRING_PTR(str), RSTRING_LEN(str), limit,
+                          captures, cap_size, re_binary_string_p(str));
+  if (ncap == 0) {
+    mrb_free(mrb, captures);
+    clear_match_globals(mrb);
+    return mrb_nil_value();
+  }
+  mrb_value md = create_matchdata(mrb, re, str, captures, cap_size);
+  mrb_free(mrb, captures);
+  return md;
 }
 
 /* Internal: the search of `match?`, run with a NULL capture buffer so that
@@ -617,7 +659,7 @@ regexp_match_op(mrb_state *mrb, mrb_value self)
   str = match_operand(mrb, str);
   re_check_encoding(mrb, str);
 
-  mrb_value md = exec_match(mrb, self, str, 0, TRUE);
+  mrb_value md = exec_match(mrb, self, str, 0);
   if (mrb_nil_p(md)) return mrb_nil_value();
 
   mrb_match_data *m = DATA_GET_PTR(mrb, md, &matchdata_type, mrb_match_data);
@@ -641,7 +683,7 @@ regexp_case_match(mrb_state *mrb, mrb_value self)
   if (!pat) return mrb_false_value();
   re_check_encoding(mrb, str);
 
-  md = exec_match(mrb, self, str, 0, TRUE);
+  md = exec_match(mrb, self, str, 0);
   return mrb_bool_value(!mrb_nil_p(md));
 }
 
@@ -1304,7 +1346,7 @@ regexp_s_gsub_str(mrb_state *mrb, mrb_value klass)
 
   /* set $~ from last match */
   if (last_ncap > 0) {
-    create_matchdata(mrb, re, str, last_captures, last_ncap, TRUE);
+    create_matchdata(mrb, re, str, last_captures, last_ncap);
   }
   else {
     clear_match_globals(mrb);
@@ -1367,7 +1409,7 @@ regexp_s_sub_str(mrb_state *mrb, mrb_value klass)
     mrb_str_cat(mrb, result, s + captures[1], slen - captures[1]);
   }
 
-  create_matchdata(mrb, re, str, captures, cap_size, TRUE);
+  create_matchdata(mrb, re, str, captures, cap_size);
   mrb_free(mrb, captures);
   re_mark_spliced(result, str, replacement, TRUE);
   return result;
@@ -1447,7 +1489,7 @@ regexp_s_scan(mrb_state *mrb, mrb_value klass)
   mrb_free(mrb, captures);
 
   if (last_ncap > 0) {
-    create_matchdata(mrb, re, str, last_captures, last_ncap, TRUE);
+    create_matchdata(mrb, re, str, last_captures, last_ncap);
   }
   else {
     clear_match_globals(mrb);
@@ -1638,6 +1680,7 @@ mrb_mruby_regexp_gem_init(mrb_state *mrb)
   mrb_define_class_method(mrb, re, "__check_byte_pos", regexp_check_byte_pos, MRB_ARGS_REQ(2));
   mrb_define_class_method(mrb, re, "__search", regexp_s_search, MRB_ARGS_ARG(2, 2));
   mrb_define_class_method(mrb, re, "__byte_search", regexp_s_byte_search, MRB_ARGS_ARG(2, 3));
+  mrb_define_class_method(mrb, re, "__byte_rsearch", regexp_s_byte_rsearch, MRB_ARGS_REQ(3));
   mrb_define_class_method(mrb, re, "__search_p", regexp_s_search_p, MRB_ARGS_ARG(2, 1));
 
   /* Instance methods */

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -168,13 +168,6 @@ assert("Regexp.__byte_search answers a position before the subject with a miss")
   assert_nil Regexp.__byte_search(/b/, "abc", 1000000)
   assert_nil $~
 
-  # and a search that publishes nothing clears nothing either, at both ends
-  $~ = /b/.match("abc")
-  assert_nil Regexp.__byte_search(/b/, "abc", -1, false, false)
-  assert_equal "b", $~[0]
-  assert_nil Regexp.__byte_search(/b/, "abc", 1000000, false, false)
-  assert_equal "b", $~[0]
-
   # and it is answered before the subject is read, the way `__search` answers a
   # position it cannot place: a subject the position names nothing in is not
   # read either way
@@ -185,6 +178,28 @@ assert("Regexp.__byte_search answers a position before the subject with a miss")
   else
     assert_nil Regexp.__byte_search(/b/, bad, 0)
   end
+end
+
+assert("Regexp.__byte_rsearch reads its limit at both ends of the subject") do
+  # The limit is the last position a match may start at, so one past the end
+  # of the subject is every position in it and not the miss the forward
+  # search answers a position past the end with. `rindex` clamps for the same
+  # reason: `"abc".rindex(/b/, 10)` is 1.
+  assert_equal 1, Regexp.__byte_rsearch(/b/, "abc", 1000000).__byte_begin(0)
+  assert_equal 1, Regexp.__byte_rsearch(/b/, "abc", 3).__byte_begin(0)
+  assert_nil Regexp.__byte_rsearch(/b/, "abc", 0)
+
+  # A negative limit names no position and reaches here only from a direct
+  # call, as a negative position does in `__byte_search` above: it is the
+  # miss, and it clears the match globals.
+  $~ = /b/.match("abc")
+  assert_nil Regexp.__byte_rsearch(/b/, "abc", -1)
+  assert_nil $~
+
+  # and the answer is the one the globals describe
+  assert_equal 4, Regexp.__byte_rsearch(/b(c)/, "abcabc", 6).__byte_begin(0)
+  assert_equal "c", $1
+  assert_equal "bc", Regexp.last_match(0)
 end
 
 assert("Regexp.escape") do

--- a/mrbgems/mruby-regexp/test/string_index.rb
+++ b/mrbgems/mruby-regexp/test/string_index.rb
@@ -376,6 +376,64 @@ assert("String#rindex bounds the match start in characters") do
   assert_equal 3, "あああ".byterindex(/ああ/)
   assert_equal ["あ", "ああ", ""], "あああ".rpartition(/ああ/)
   assert_equal ["あい", "うあ", "いう"], str.rpartition(/うあ/)
+
+  # the position bounds where the match starts and not how far the subject is
+  # read: `$` still asserts at the end of the subject, and a match that
+  # reaches it is still found from a position well before it
+  assert_nil "あいうい".rindex(/い$/, 1)
+  assert_equal 3, "あいうい".rindex(/い$/)
+  assert_equal 1, str.rindex(/いうあいう/, 1)
+end
+
+assert("a backward search bounds where a match starts, not how far it reads") do
+  # `$` and `\z` assert at the end of the subject. A position that bounded
+  # how much of the subject was read would put that end at the bound instead,
+  # and the `b` at 1 would answer where it must not.
+  assert_nil "abcb".rindex(/b$/, 1)
+  assert_nil "abcb".rindex(/b\z/, 1)
+  assert_equal 3, "abcb".rindex(/b$/)
+
+  # and a match may reach past the bound, since what the bound names is where
+  # the match begins
+  assert_equal 1, "abcabc".rindex(/bcabc/, 1)
+  assert_equal 1, "abcabc".byterindex(/bcabc/, 1)
+end
+
+assert("a backward search answers a match far from the end of the subject") do
+  # A backward search asks about the end of the subject first, and only what
+  # it does not find there sends it over the whole subject. A subject long
+  # enough for those to be two different paths says that both answer what a
+  # short one answers.
+  str = "ab" + "c" * 4000
+
+  assert_equal 0, str.rindex(/ab/)
+  assert_equal 1, str.rindex(/b/)
+  assert_equal 4001, str.rindex(/c/)
+  assert_nil str.rindex(/z/)
+  assert_equal 0, str.byterindex(/ab/)
+  assert_equal 4001, str.byterindex(/c/)
+  assert_equal ["", "ab", "c" * 4000], str.rpartition(/ab/)
+
+  # a match at the end and further ones behind it: the last is still the
+  # answer when the search starts from the end rather than the front
+  tail = "c" * 4000 + "abab"
+  assert_equal 4002, tail.rindex(/ab/)
+  # overlapping matches stay in view there too, as they do on a short subject
+  assert_equal 4001, tail.rindex(/ba/)
+  assert_equal ["c" * 4000 + "ab", "ab", ""], tail.rpartition(/ab/)
+
+  # the bound is read the same way whichever path answers
+  assert_equal 0, str.rindex(/ab/, 0)
+  assert_nil str.rindex(/b/, 0)
+  assert_equal 4000, tail.rindex(/ab/, 4000)
+
+  # and the match it settles on is the one the globals describe
+  assert_equal 4002, tail.rindex(/a(b)/)
+  assert_equal "b", $1
+  assert_equal "ab", Regexp.last_match(0)
+  assert_nil str.rindex(/(z)/)
+  assert_nil $1
+  assert_nil Regexp.last_match(0)
 end
 
 assert("String#index and String#rindex with regexp set the match globals") do


### PR DESCRIPTION
`String#rindex`, `#byterindex` and `#rpartition` want the last match that
starts at or before a position. The engine has one entry point and it searches
forward, so the mrblib helper the three shared
(`__regexp_rsearch`, `mrbgems/mruby-regexp/mrblib/string_regexp.rb:477` on
master) walked the subject from the front and kept the last match that
qualified:

```ruby
    while pos <= size && (md = Regexp.__byte_search(pattern, self, pos, false, false))
      start = md.__byte_begin(0)
      break if start > limit
      found = md
      pos = start + 1
    end
```

That is one search per match. On a subject the pattern matches everywhere it is
one per position, and where a single search is itself linear in the subject the
walk is quadratic in it. `("a" * n).rindex(/a+b?/)`, `bintest` build:

| n | mruby | CRuby 4.0.6 |
|---:|---:|---:|
| 1,250 | 0.0322s | 0.0000s |
| 2,500 | 0.1202s | 0.0000s |
| 5,000 | 0.5232s | 0.0000s |
| 10,000 | 1.8207s | 0.0000s |

Four times the work for twice the subject. At n = 20,000 it is 7.2s.

This is what is left of #7148 and #7149, which took the walk into byte space and
stopped it publishing what it passed over. Both removed a factor from each turn;
neither could remove the turns.

## The bound is on where a match may begin

The three engines behind `mrb_re_exec()` each scan the subject for a place to
start from: `literal_exec()` walks the first byte with `memchr`,
`backtrack_exec()` tries every position in turn, `pike_vm()` seeds a thread at
each one. All three scan to the end of the subject, because the end of the
subject is the last place anything can begin.

The first commit gives each of them the position to stop seeding at, and reaches
them through `exec_range()`. `mrb_re_exec()` passes the end of the subject, so
every existing caller asks the question it asked and nothing answers
differently.

It has to be a separate argument and not a shorter `len`. A match that begins at
the bound runs to wherever it ends: cutting the subject would make `$` and `\z`
assert at the cut, and would lose a match that reaches past it. Threads already
running are not seeded either, so the Pike VM keeps stepping them past the bound
and stops only once they are gone.

## Asking about the end first

`mrb_re_rexec()` widens a window at the end of the range until a match starts
inside it, then walks that window forward for the last one. The last match is
usually near the end, and a window that catches it costs the window rather than
the subject.

A window search still reads from where the window starts to the end of the
subject, so the widening is bounded by that span and not by the window's own
width: a narrow window at the end of a long subject is cheap, the same window
asked about a position far from the end is the whole search over again. Past the
bound the function falls through to a single forward search over the whole
range, which is what this cost before.

That is what keeps a pattern matching nowhere at its old price. `/a+z/` against
`"a" * n` matches at no position, and its threads survive the whole subject at
every one, so no window can answer it; it pays for one forward search, as it did
before.

## Timings

`bintest` build of `build_config/ci/gcc-clang.rb`, best of five, n = 20,000, the
two binaries run alternately.

| | master | this PR |
|---|---:|---:|
| `("a"*n).rindex(/a+b?/)` | 7.2111s | **0.0000s** |
| `("ab "*n).rindex(/\w+/)` | 0.0198s | **0.0000s** |
| `("a"*n).rindex(/.a/)` | 0.0095s | **0.0000s** |
| `("a"*n).rindex(/(a)\1/)` | 0.0084s | **0.0000s** |
| `("a"*n).rindex(/a\|b/)` | 0.0093s | **0.0000s** |
| `("a"*n).rindex(/[ab]/)` | 0.0089s | **0.0000s** |
| `("a"*n).rindex(/b*/)` | 0.0090s | **0.0000s** |
| `("a"*n).rindex(/a/)` | 0.0073s | **0.0000s** |
| `("a"*n).rpartition(/a/)` | 0.0077s | **0.0000s** |
| `("あb"*n).byterindex(/b/)` | 0.0076s | **0.0000s** |
| `("あb"*n).rindex(/b/)` | 0.0076s | **0.0001s** |
| `("a"*n).rindex(/a$/)` | 0.0007s | **0.0000s** |
| `("a"*n).rindex(/a/, n / 10)` | 0.0008s | **0.0000s** |
| `("a"*n).rindex(/a+z/, n / 10)` | 0.0008s | 0.0006s |
| `("a"*n).rindex(/a+z/)` | 0.0009s | 0.0009s |
| `("a"*n).rindex(/a*z/)` | 0.0011s | 0.0011s |
| `("az" + "a"*n).rindex(/a+z/)` | 0.0009s | 0.0009s |
| `("a"*n).rindex(/zz/)` | 0.0000s | 0.0000s |
| `("a"*(n-1) + "z").rindex(/z/)` | 0.0000s | 0.0000s |
| `("z" + "a"*(n-1)).rindex(/z/)` | 0.0000s | 0.0000s |

The multibyte `rindex` row does not reach zero because `rindex` answers a
character offset: the one conversion of the answer walks the subject, where
before it was the walk that did. `byterindex` on the same subject does reach it.

The rows that do not move are the ones no window can answer. At n = 400,000,
where they are large enough to compare:

| | master | this PR |
|---|---:|---:|
| `("a"*n).rindex(/a+z/)` | 0.01619s | 0.01633s |
| `("a"*n).rindex(/a*z/)` | 0.02106s | 0.02137s |
| `("az" + "a"*n).rindex(/a+z/)` | 0.01623s | 0.01633s |

Under 2%, which is the run-to-run spread on this machine. No case measured is
slower.

The forward search is untouched, and measures untouched. n = 200,000 for the
searches, 10,000 for the rest:

| | master | this PR |
|---|---:|---:|
| `("a"*n).index(/a+z/)` | 0.00816s | 0.00814s |
| `("a"*n).index(/a*z/)` | 0.01036s | 0.01065s |
| `("a"*n).index(/[ab]z/)` | 0.00565s | 0.00564s |
| `("a"*n).match?(/a+z/)` | 0.00432s | 0.00434s |
| `("a"*n).gsub(/a/, "b")` | 0.00020s | 0.00020s |
| `("a"*n).scan(/a/)` | 0.00064s | 0.00064s |
| `("a"*n).split(/a/)` | 0.01084s | 0.01090s |

## Size

`.text` of `bin/mruby`, `build_config/ci/gcc-clang.rb`, each from a clean build
directory.

| build | master | this PR | delta |
|---|---:|---:|---:|
| `bintest` | 1,277,702 | 1,278,854 | +1,152 |
| `ascii-case` | 1,265,366 | 1,266,518 | +1,152 |
| `byte-string` | 1,246,022 | 1,247,238 | +1,216 |
| `cxx_abi` | 1,302,393 | 1,303,929 | +1,536 |
| `full-debug` (`-O0`) | 1,873,862 | 1,875,574 | +1,712 |

Against it, the mrblib walk leaves: on a byte build of the default gembox
`.rodata` falls 192 bytes, the bytecode of the method that is gone.

## Verification

Two tests are added, in `mrbgems/mruby-regexp/test/string_index.rb`. Both pass
on master, being about answers that do not change; each turns red against a
wrong implementation of the new spans.

- *a backward search bounds where a match starts, not how far it reads*.
  `"abcb".rindex(/b$/, 1)` is nil and `"abcb".rindex(/b$/)` is 3, so a bound
  cannot be a shorter subject; `"abcabc".rindex(/bcabc/, 1)` is 1, so a match
  may reach past it. The multibyte half sits in the existing character-bounds
  test, which already carries the `__ENCODING__` guard.
- *a backward search answers a match far from the end of the subject*, over a
  subject long enough that the window and the forward search are two different
  paths, asking it what a short subject is asked.

A third, in `test/regexp.rb`, says how `Regexp.__byte_rsearch` reads its limit at
both ends: a limit past the end of the subject is every position in it, where
the forward `__byte_search` answers a position past the end with a miss. Beside
it, the block that pinned `__byte_search`'s `publish = false` goes with the
argument.

Against a `mrb_re_rexec()` that bounded the subject instead of the start
position, six tests fail, four of them ones that were already there.

Both paths of the new function were also run over the whole suite on their own,
by compiling the span bound as `0` (never a window) and as `10**8` (always a
window): 0 KO either way.

**Differential against CRuby.** 80,000 random cases over two seeds: 41 pattern
sources x 4 flag sets x random subjects over an alphabet of ASCII, two
multibyte characters and whitespace, each asked one of `rindex(re)`,
`rindex(re, pos)`, `byterindex(re, pos)` and `rpartition(re)` with a random
position. Output byte-identical to CRuby 4.0.6.

`\b` and `\B` are excluded from that set: mruby and CRuby disagree about whether
a non-ASCII character is a word character, which shows on the forward path too
(`"亜a".index(/\ba/)` is 1 here and nil there) and is not this change.

**`rake test`**, `build_config/ci/gcc-clang.rb`:

| build | total | KO | crash |
|---|---:|---:|---:|
| `full-debug` | 2,342 | 0 | 0 |
| `bintest` | 2,342 | 0 | 0 |
| `bintest` (bintest suite) | 122 | 0 | 0 |
| `cxx_abi` | 2,342 | 0 | 0 |
| `byte-string` | 2,272 | 0 | 0 |
| `ascii-case` | 2,339 | 0 | 0 |

`build_config/clang-asan.rb`: 2,342 total, 0 KO, 0 crash, plus its 84 bintests,
with no sanitizer report.

The first commit was run through the same suite on its own, being the one that
answers nothing differently: 0 KO.

### Environment

<details>

| | |
|---|---|
| OS | Ubuntu 24.04, Linux x86_64 |
| gcc | 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1) |
| CRuby | 4.0.6, for the differential |

Compile lines for `mrbgems/mruby-regexp/src/re_exec.c` in the builds quoted
above, paths shortened:

```
# ci/gcc-clang bintest
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK -I"include" -I"mrbgems/mruby-regexp/include" -I"build/bintest/include" -o "build/bintest/mrbgems/mruby-regexp/src/re_exec.o" "mrbgems/mruby-regexp/src/re_exec.c"

# ci/gcc-clang full-debug
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -I"include" -I"mrbgems/mruby-regexp/include" -I"build/full-debug/include" -o "build/full-debug/mrbgems/mruby-regexp/src/re_exec.o" "mrbgems/mruby-regexp/src/re_exec.c"

# ci/gcc-clang cxx_abi
gcc -MMD -c -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -I"include" -I"mrbgems/mruby-regexp/include" -I"build/cxx_abi/include" -o "build/cxx_abi/mrbgems/mruby-regexp/src/re_exec.o" "mrbgems/mruby-regexp/src/re_exec.c"

# ci/gcc-clang byte-string
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -I"include" -I"mrbgems/mruby-regexp/include" -I"build/byte-string/include" -o "build/byte-string/mrbgems/mruby-regexp/src/re_exec.o" "mrbgems/mruby-regexp/src/re_exec.c"

# ci/gcc-clang ascii-case
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CASE -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -I"include" -I"mrbgems/mruby-regexp/include" -I"build/ascii-case/include" -o "build/ascii-case/mrbgems/mruby-regexp/src/re_exec.o" "mrbgems/mruby-regexp/src/re_exec.c"
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SxozX6Sq6LxbX1CeGgqg2U


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved backward regular-expression searches for `rindex`, `byterindex`, and `rpartition`.
  * Added support for overlapping matches and matches extending beyond the search boundary.
  * Match captures and related match variables now consistently reflect the selected result.

* **Bug Fixes**
  * Corrected backward searches on long strings, at boundaries, and with negative limits.
  * Match information is now cleared when a search fails.
  * Improved handling of anchors and encoding-related invalid positions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->