### PR TITLE
mruby-regexp: ask the backward search about a long multibyte subject

### DIFF
--- a/mrbgems/mruby-regexp/test/string_index.rb
+++ b/mrbgems/mruby-regexp/test/string_index.rb
@@ -436,6 +436,39 @@ assert("a backward search answers a match far from the end of the subject") do
   assert_nil Regexp.last_match(0)
 end
 
+assert("a backward search answers a long multibyte subject") do
+  # The subject above is single-byte, so the two paths of the search were
+  # asked about characters only on a short one. A search reads the subject by
+  # byte wherever it starts from, so a place it starts from falls inside a
+  # character as often as not, and the path that reaches the front of a long
+  # subject is not the path that answers from the end of it.
+  skip unless __ENCODING__ == "UTF-8"
+  mb = "あい" + "うえ" * 2000    # 4,002 characters, 12,006 bytes
+
+  # near the end, where the search settles without crossing the subject
+  assert_equal 4001, mb.rindex(/え/)
+  assert_equal 12003, mb.byterindex(/え/)
+  assert_equal 4000, mb.rindex(/うえ/)
+  assert_equal 12000, mb.byterindex(/うえ/)
+
+  # at the front, which is the far end of the same subject
+  assert_equal 0, mb.rindex(/あい/)
+  assert_equal 0, mb.byterindex(/あい/)
+  assert_nil mb.rindex(/お/)
+  assert_equal ["", "あい", "うえ" * 2000], mb.rpartition(/あい/)
+
+  # overlapping matches stay in view at that end too
+  assert_equal 1, ("あああ" + "い" * 3000).rindex(/ああ/)
+
+  # and the position is still a character offset for one of the pair and a
+  # byte offset for the other
+  assert_equal 0, mb.rindex(/あい/, 0)
+  assert_nil mb.rindex(/うえ/, 1)
+  assert_equal 2, mb.rindex(/うえ/, 2)
+  assert_equal 6, mb.byterindex(/うえ/, 6)
+  assert_nil mb.byterindex(/うえ/, 3)
+end
+
 assert("String#index and String#rindex with regexp set the match globals") do
   assert_equal 1, "abc".index(/(b)/)
   assert_equal "b", $1


### PR DESCRIPTION
Follow-up to #7233, test only.

The backward search that landed there has two paths. A window at the end of the
subject answers a match near the end; a match further in is left to a forward
search over the whole range, which the window falls through to once it would
read more than a fixed span. The tests that came with it ask each path on the
subjects it takes to reach it, but the subjects are ASCII. The multibyte tests
beside them use a few characters each, which one window covers whole, so the
second path has never been asked about a character.

This adds a subject that reaches it. `"あい" + "うえ" * 2000` is 4,002
characters and 12,006 bytes:

- `え` and `うえ` are at the end, inside the first windows, and are asked in
  both spaces: `mb.rindex(/うえ/)` is 4,000 and `mb.byterindex(/うえ/)` is
  12,000.
- the one `あい` is at the front, past the reach of any window, so it is the
  forward search that answers: `mb.rindex(/あい/)` and `mb.byterindex(/あい/)`
  are both 0, `mb.rpartition(/あい/)` splits there, and `mb.rindex(/お/)` is
  the miss.
- `("あああ" + "い" * 3000).rindex(/ああ/)` is 1, the later of the two
  overlapping matches at that same end.
- the positions each of the pair reads: `mb.rindex(/うえ/, 1)` is nil where
  `mb.rindex(/うえ/, 2)` is 2, and `mb.byterindex(/うえ/, 3)` is nil where
  `mb.byterindex(/うえ/, 6)` is 6.

The subject is also what puts a window start inside a character. The window is
measured in bytes and widened by doubling, so on a subject of three-byte
characters most of the starts it takes are interior ones; the engines step over
those rather than seed an attempt at them, and this is the first test where the
window does it more than a couple of times.

The block carries the `__ENCODING__` guard the character-bounds test beside it
carries, and sits in its own `assert` so that the guard does not swallow
assertions that hold on every build.

## Verification

Every answer above matches CRuby 4.0.6.

`rake test`, `build_config/ci/gcc-clang.rb`:

| build | total | KO | crash |
|---|---:|---:|---:|
| `full-debug` | 2,347 | 0 | 0 |
| `bintest` | 2,347 | 0 | 0 |
| `bintest` (bintest suite) | 122 | 0 | 0 |
| `cxx_abi` | 2,347 | 0 | 0 |
| `byte-string` | 2,277 | 0 | 0 |
| `ascii-case` | 2,344 | 0 | 0 |

`byte-string` is the build that skips it, having no `MRB_UTF8_STRING`.

Green also with `RE_RSEARCH_PROBE_SPAN` compiled as `0`, which sends every one
of these through the forward search, and as `100000000`, which sends every one
of them through the window: what the two paths answer on this subject is the
same.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added UTF-8 regression coverage for backward regular-expression searches on long multibyte strings.
  * Verified character and byte offsets, boundary behavior, unmatched patterns, partitioning, overlapping matches, and position offsets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
