### PR TITLE
build_config: drop the stale asan.rb reference from gcc-asan.rb

### DIFF
--- a/build_config/gcc-asan.rb
+++ b/build_config/gcc-asan.rb
@@ -1,7 +1,6 @@
 # Address/Undefined sanitizer build with gcc, in a dedicated build directory
 # (build/gcc-asan) so it does not clobber a normal host build. The counterpart
-# of build_config/clang-asan.rb; build_config/asan.rb follows whichever
-# compiler the machine has.
+# of build_config/clang-asan.rb.
 MRuby::Build.new('gcc-asan') do |conf|
   conf.toolchain :gcc
 


### PR DESCRIPTION
`build_config/gcc-asan.rb` opens by pointing at a file that the next commit deleted:

```ruby
# Address/Undefined sanitizer build with gcc, in a dedicated build directory
# (build/gcc-asan) so it does not clobber a normal host build. The counterpart
# of build_config/clang-asan.rb; build_config/asan.rb follows whichever
# compiler the machine has.
```

The config was added by `0ea59d94` and `asan.rb` was removed by `e784e62a`, the commit immediately after it, so the last sentence has never been true on any commit that has both files in their final state:

```console
$ git log --oneline --reverse 0ea59d94~1..e784e62a
0ea59d94f build_config: add a gcc-pinned sanitizer build
e784e62a8 build_config: drop asan.rb for the two pinned sanitizer configs

$ ls build_config/asan.rb
ls: cannot access 'build_config/asan.rb': No such file or directory
```

The sentence is also the only thing left in the tree that tells a reader what to reach for when they do not want to pin a compiler, and after `e784e62a` the answer is to name one of the two, which is what the deletion decided.

Drop the clause. `clang-asan.rb`'s own comment names no third config, so the two read as a pair once it is gone.

Comment only, no build changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected an internal build configuration comment to reference the appropriate AddressSanitizer compiler counterpart.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->