### PR TITLE
build: rebuild an output another configuration left in the build directory

### DIFF
--- a/lib/mruby/build.rb
+++ b/lib/mruby/build.rb
@@ -91,6 +91,10 @@ module MRuby
 
     Exts = Struct.new(:object, :executable, :library, :presym_preprocessed)
 
+    # `rake -m` resolves the dependencies of several outputs at once, and each
+    # of them compares its own record, so the report is guarded to print once.
+    FLAGS_CHANGE_LOCK = Mutex.new
+
     def initialize(name='host', build_dir=nil, internal: false, &block)
       @name = name.to_s
 
@@ -111,6 +115,7 @@ module MRuby
         @install_excludes = []
         @defines = []
         @defines_final = false
+        @flags_change_reported = false
         @cc = Command::Compiler.new(self, %w(.c), label: "CC")
         @cxx = Command::Compiler.new(self, %w(.cc .cxx .cpp), label: "CXX")
         @objc = Command::Compiler.new(self, %w(.m), label: "OBJC")
@@ -513,6 +518,34 @@ EOS
       env = {"BUILD_DIR" => @build_dir, "MRBCFILE" => mrbc}
       bintest = File.join(MRUBY_ROOT, "test/bintest.rb")
       sh env, "ruby #{bintest}#{verbose_flag} #{targets.join ' '}"
+    end
+
+    # Report that this build directory holds output produced by another
+    # configuration, once for the whole directory: the command line is
+    # recorded per output, so every output that follows carries the same
+    # change and would report it again.
+    #
+    # `recorded` is nil when there is no record at all, which is what a
+    # directory built before this check looks like.
+    def report_flags_change(recorded, current)
+      FLAGS_CHANGE_LOCK.synchronize do
+        return if @flags_change_reported
+        @flags_change_reported = true
+
+        unless recorded
+          warn "#{build_dir}: output here has no record of what built it, rebuilding it"
+          return
+        end
+
+        warn "#{build_dir}: output here was built by another configuration, rebuilding it"
+        recorded.lines.zip(current.lines).each do |before, after|
+          next if before == after
+          field = (after || before)[/\A[^:]+/]
+          before, after = [before, after].map {|line| line.to_s.split(": ", 2)[1].to_s.split}
+          warn "  #{field} added: #{(after - before).join(" ")}" unless (after - before).empty?
+          warn "  #{field} removed: #{(before - after).join(" ")}" unless (before - after).empty?
+        end
+      end
     end
 
     def print_build_summary

--- a/lib/mruby/build/command.rb
+++ b/lib/mruby/build/command.rb
@@ -130,26 +130,16 @@ module MRuby
         generated_file_matcher = Regexp.new("^#{Regexp.escape build_dir}/(?!mrbc/|mrbgems/.+/)(.*)#{Regexp.escape out_ext}$")
       end
       source_exts.each do |ext|
-        rule generated_file_matcher => [
-          proc { |file|
-            file.sub(generated_file_matcher, "#{source_dir}/\\1#{ext}")
-          },
-          proc { |file|
-            get_dependencies(file) + rakedep
-          }
-        ] do |t|
-          run t.name, t.prerequisites.first
-        end
-
-        rule generated_file_matcher => [
-          proc { |file|
-            file.sub(generated_file_matcher, "#{build_dir}/\\1#{ext}")
-          },
-          proc { |file|
-            get_dependencies(file) + rakedep
-          }
-        ] do |t|
-          run t.name, t.prerequisites.first
+        # The source is looked for beside the sources first and among the
+        # generated files second.
+        [source_dir, build_dir].each do |dir|
+          source_of = proc { |file| file.sub(generated_file_matcher, "#{dir}/\\1#{ext}") }
+          rule generated_file_matcher => [
+            source_of,
+            proc { |file| get_dependencies(file) + rakedep }
+          ] do |t|
+            run t.name, t.prerequisites.first
+          end
         end
       end
     end

--- a/lib/mruby/build/command.rb
+++ b/lib/mruby/build/command.rb
@@ -103,17 +103,19 @@ module MRuby
 
     def run(outfile, infile, _defines=[], _include_paths=[], _flags=[])
       mkdir_p File.dirname(outfile)
-      flags = all_flags(_defines, _include_paths, _flags)
+      flags = compile_flags(outfile, _defines, _include_paths, _flags)
       if object_ext?(outfile)
         label = @label
         opts = compile_options
       else
         label = "CPP"
         opts = preprocess_options
-        flags << " -DMRB_PRESYM_SCANNING"
       end
       _pp label, infile.relative_path, outfile.relative_path
       _run opts, flags: flags, infile: filename(infile), outfile: filename(outfile)
+      # Recorded after the compile, so that a compile that failed leaves
+      # nothing claiming a configuration its output was not built with.
+      File.write(flags_file(outfile), flags_record(opts, flags))
     end
 
     def define_rules(build_dir, source_dir='', out_ext=build.exts.object)
@@ -136,7 +138,7 @@ module MRuby
           source_of = proc { |file| file.sub(generated_file_matcher, "#{dir}/\\1#{ext}") }
           rule generated_file_matcher => [
             source_of,
-            proc { |file| get_dependencies(file) + rakedep }
+            proc { |file| get_dependencies(file, source_of.call(file)) + rakedep }
           ] do |t|
             run t.name, t.prerequisites.first
           end
@@ -173,11 +175,13 @@ module MRuby
     #
     #   /src/value_array.h:
     #
-    def get_dependencies(file)
+    def get_dependencies(file, source)
+      discard_foreign_output(file) if rule_applies?(source)
+      deps = [MRUBY_CONFIG]
       dep_file = file.ext(".d")
-      return [MRUBY_CONFIG] unless object_ext?(file) && File.exist?(dep_file)
+      return deps unless object_ext?(file) && File.exist?(dep_file)
 
-      deps = File.read(dep_file).gsub("\\\n ", "").split("\n").map do |dep_line|
+      header_deps = File.read(dep_file).gsub("\\\n ", "").split("\n").map do |dep_line|
         # dep_line:
         # - "/build/host/src/array.o:   /src/array.c   /include/mruby/common.h ..."
         # - ""
@@ -187,7 +191,73 @@ module MRuby
         #    []
         #    []
       end.flatten.uniq
-      deps << MRUBY_CONFIG
+      deps.concat(header_deps)
+    end
+
+    #
+    # === Example of +.flags+ file
+    #
+    #   command: gcc
+    #   options: -MMD -c %{flags} -o "%{outfile}" "%{infile}"
+    #   flags: -std=gnu99 -g -O3 -Wall -DMRB_NO_FLOAT -I"/mruby/include"
+    #
+    def flags_record(options, flags)
+      "command: #{build.filename(command)}\noptions: #{options}\nflags: #{flags}\n"
+    end
+
+    # The record sits beside the output under the output's own name, so that
+    # the object and the presym preprocess of one source keep a record each.
+    def flags_file(outfile)
+      "#{outfile}.flags"
+    end
+
+    # Whether the rule this source belongs to is the one that builds the
+    # output. Rake asks the same of a rule before it applies it, and it asks
+    # every rule that matches the name: the compilers of a build define a rule
+    # each for the same output, differing in the extension of the source they
+    # look for. Only the one that finds its source speaks for the output; the
+    # others would compare it against flags no compile of it ever used.
+    #
+    # Rake accepts one source more than this, one another rule can produce:
+    # `Rake::TaskManager#attempt_rule` falls back to
+    # `enhance_with_matching_rule` for a source that is neither a file nor a
+    # task. The rules here are the only ones in the tree and they match object
+    # names, so nothing answers that fallback; a generated source is a `file`
+    # task, which `Rake::Task.task_defined?` already finds.
+    def rule_applies?(source)
+      File.exist?(source) || Rake::Task.task_defined?(source)
+    end
+
+    # Remove an output that the command line beside it does not answer for,
+    # so that the rule that would have found it up to date builds it again.
+    #
+    # Nothing else in the build tells the two apart. A +.d+ file lists header
+    # dependencies only, and the config file is a dependency by path, so its
+    # mtime does not move when another config takes over the same build
+    # directory. Left uncompared, the output stays up to date against every
+    # dependency it has, and the build silently keeps the flags of whichever
+    # config wrote it first, its defines above all.
+    #
+    # An output with no record at all counts as foreign too, since what
+    # produced it is unknown.
+    def discard_foreign_output(file)
+      return unless File.exist?(file)
+      path = flags_file(file)
+      options = object_ext?(file) ? compile_options : preprocess_options
+      record = flags_record(options, compile_flags(file))
+      recorded = File.read(path) if File.exist?(path)
+      return if recorded == record
+      build.report_flags_change(recorded, record)
+      rm_f file
+    end
+
+    # The flags a compile of `outfile` runs with. The preprocess that feeds
+    # the presym scan is this compiler with one define more, so the define
+    # belongs to the flags and to what is recorded of them.
+    def compile_flags(outfile, _defines=[], _include_paths=[], _flags=[])
+      flags = all_flags(_defines, _include_paths, _flags)
+      flags += " -DMRB_PRESYM_SCANNING" unless object_ext?(outfile)
+      flags
     end
 
     def object_ext?(path)

--- a/tasks/presym.rake
+++ b/tasks/presym.rake
@@ -6,12 +6,18 @@ all_prerequisites = ->(task_name, prereqs) do
   end
 end
 
+# Every target first, before the walk below resolves a rule: the products of
+# one target reach the objects of another (a build reaches the mrbc build it
+# generated), and a rule resolved for those objects must see the same include
+# paths as the compile that follows it.
 MRuby.each_target do |build|
-  presym = build.presym
-
   include_dir = "#{build.build_dir}/include"
   build.compilers.each{|c| c.include_paths << include_dir}
   build.gems.each{|gem| gem.compilers.each{|c| c.include_paths << include_dir}}
+end
+
+MRuby.each_target do |build|
+  presym = build.presym
 
   prereqs = {}
   ppps = []


### PR DESCRIPTION
A build directory records what was built, not what it was built with, so two
configs that share a build directory and a build name share the objects, and the
second one silently gets the first one's compiler flags.

`MRuby::Command::Compiler#all_flags` (`lib/mruby/build/command.rb:95-101` on
master) assembles the defines at the moment of the call and writes them nowhere
`rake` will read again. The `.d` file beside an object records header
dependencies only, and `MRUBY_CONFIG` is a dependency by path, whose mtime does
not move when another config takes the directory over. Every dependency the
object has says it is up to date, so nothing is compiled, and the binary carries
the defines of whichever config came first.

The name is what brings two configs together: `CrossBuild#initialize` generates
its minimal build under the name `host`, which is the name
`build_config/default.rb` uses too. Two runs of the same build name from
different build configs collide the same way.

## Before

The same tree and the same command twice,
`rake test MRUBY_CONFIG=build_config/no-float.rb`, differing only in what was in
the build directory beforehand: nothing, or a default `rake` build.

| | own | shared |
|---|---|---|
| compile lines for `host` | 79 | 0 |
| the `mrbc` it uses | `MRB_NO_FLOAT` | floats enabled |
| stops at | the float literal | `irep load error` |
| which is | what #7230 merged | what #7230 removed |

With a directory of its own, the generated `host` build carries `MRB_NO_FLOAT`,
and its `mrbc` refuses the float literal where it is written:

```console
$ MRUBY_BUILD_DIR=/tmp/nofloat-build rake -m test MRUBY_CONFIG=build_config/no-float.rb
...
        (79 compile lines for the generated `host` build)
...
test/t/array.rb:65: Not implemented: PM_FLOAT_NODE
test/t/array.rb:0:0: generator error, Not implemented: PM_FLOAT_NODE
rake aborted!
```

Over a directory a plain `rake` has populated, not one compile line for `host`.
The float-enabled `mrbc` of the earlier build is reused, writes `IREP_TT_FLOAT`
pool entries, and `src/load.c` refuses them on the `MRB_NO_FLOAT` target: the
pre-#7230 failure, on a tree that carries #7230.

```console
$ rake -m                                          # populates build/host
$ rake test MRUBY_CONFIG=build_config/no-float.rb
...
 Output Directory: build/host                      # the only mention of build/host in the run
...
TEST for no-float
mrbtest - Embeddable Ruby Test

.........trace (most recent call last):
test/t/argumenterror.rb:34: irep load error (ScriptError)
rake aborted!
```

`MRB_NO_FLOAT` is the loud case, because the answer changes shape. `MRB_INT32` /
`MRB_INT64`, `MRB_GC_FIXED_ARENA` and the boxing modes are the quiet ones, and a
measurement taken in a shared directory can report that a merged fix did not
land.

## After

Every compile records the command line it ran with, beside its output, the way
the `.d` file records the headers it read:

```console
$ cat build/host/src/array.o.flags
command: gcc
options: -MMD -c %{flags} -o "%{outfile}" "%{infile}"
flags: -std=gnu99 -g -O3 -Wall ... -DMRB_USE_BIGINT ... -I"/mruby/include"
```

The record is compared when the rule for that output is resolved. An output the
record does not answer for is removed, so `rake` builds it again. The shared
directory of the second run above:

| | master | this PR |
|---|---|---|
| compile lines for `host` | 0 | 79 |
| says what changed | nothing | once per directory |
| stops at | `irep load error` | the float literal |
| the default config after it | keeps the `MRB_NO_FLOAT` objects | rebuilds them |

```console
$ rake -m                                          # populates build/host
$ rake test MRUBY_CONFIG=build_config/no-float.rb
/mruby/build/host: output here was built by another configuration, rebuilding it
  flags added: -DMRB_NO_FLOAT -DMRB_NO_GEMS
  flags removed: -DMRC_TARGET_MRUBY -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET ...
...
        (79 compile lines for `host`)
...
test/t/array.rb:65: Not implemented: PM_FLOAT_NODE
test/t/array.rb:0:0: generator error, Not implemented: PM_FLOAT_NODE
rake aborted!
```

Only a compile that succeeded writes a record, so a build that stops halfway
leaves nothing claiming a configuration its output was not built with: what it
did not reach is still the earlier output, still without a record that answers
for it, and the next run removes that too.

Two things this rests on:

- The record is compared only through the rule that finds its source, which is
  the test `rake` itself applies before it uses a rule. Every compiler of a
  build defines a rule for the object names, differing in the extension of the
  source it looks for, and a compiler that does not build the output would
  otherwise judge it against flags no compile of it ever used.
- `tasks/presym.rake` now hands every target its generated header directory
  before the walk that resolves rules begins. That walk reaches past the target
  it runs for, since a build's products lead to the objects of the `mrbc` build
  it generated, and a rule resolved for those objects has to see the include
  paths the compile will use.

## What it costs

One directory, the default gembox:

| | master | this PR |
|---|---:|---:|
| `rake -m` with nothing to do | 0.60 s | 0.62 s |
| records written | 0 | 594 files, 335 KiB |
| build directory | 184 MiB | 184 MiB |

The first `rake` in a directory built before this change rebuilds it once, there
being no record to compare it against, and says so:
`output here has no record of what built it, rebuilding it`.

An object built by a `file` task written by hand rather than by a rule is not
compared, the check hanging off the rule. `mrbgems/mruby-compiler` is the only
such place in the tree: its Prism objects choose their flags inside the task
body, and they carry no dependency on `MRUBY_CONFIG` either.

## Verification

Under `build_config/`, each run twice:

| config | run | again |
|---|---|---|
| `default.rb` | 2123 assertions, 0 KO; bintest 111, 0 KO | nothing compiled |
| `ci/gcc-clang.rb` | 6 suites, 0 KO, 0 crash | nothing compiled |
| `host-cxx.rb` | builds | nothing compiled |
| `host-debug.rb` | builds | nothing compiled |
| `no-float.rb` | builds | nothing compiled |
| `minimal.rb` | builds | nothing compiled |
| the config below | builds | nothing compiled |

The last row is a config for the rules a build can define for one object name:
`enable_cxx_exception`, so that the `cxx` compiler defines rules for the object
names too, and two gems from `examples/mrbgems`, which are outside `mrbgems/`
and so use all four compilers. Overwriting the record of one core object and one
gem object in that build rebuilds those two and nothing else.

One directory, in this order:

| | outcome |
|---|---|
| `rake -m test` | 2123 assertions, 0 KO; bintest 111, 0 KO |
| `rake test` with `no-float.rb` | reports, rebuilds `host`, stops at the literal |
| `rake -m test` | reports, rebuilds `host`, 2123 assertions, 0 KO |
| `rake -m test` | nothing compiled |

## Environment

| | |
|---|---|
| OS | Linux 7.0.0-28-generic, x86_64 |
| Compiler | gcc 13.3.0 |
| Ruby | 4.0.6 |
| rake | 13.3.1 |

No C source changes, so `.text` is unaffected in every build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ArcdfvwWWVJiJr1sWW4EQf


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved build reliability by detecting when generated outputs use missing or outdated compiler settings.
  - Prevented stale or incompatible build artifacts from being reused.
  - Added clearer warnings showing which configuration fields were added or removed.
  - Improved dependency handling and presymbol processing across build targets and bundled components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->