### PR TITLE
build: let a build config declare `host` after a cross build

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -20,6 +20,11 @@ end
 MRUBY_CONFIG = MRuby::Build.mruby_config_path
 load MRUBY_CONFIG
 
+# Give every cross build the `mrbc` it compiles with. The whole config has been
+# read, so a `host` declared after a cross build is as visible as one declared
+# before it, and no gem has been set up yet, so nothing has asked for `mrbc`.
+MRuby.resolve_mrbc_hosts
+
 # define MRB_NO_GEMS and set up all gems
 MRuby.each_target do |build|
   unless enable_gems? && libmruby_enabled?

--- a/lib/mruby/build.rb
+++ b/lib/mruby/build.rb
@@ -22,6 +22,22 @@ module MRuby
         target.instance_eval(&block)
       end
     end
+
+    # Bind every cross build to the build it borrows `mrbc` from.
+    #
+    # A cross build cannot settle this as it is declared, because the `host`
+    # it would borrow from may be written after it, and `Build.new` reopens a
+    # name already taken rather than initialising it afresh: a build generated
+    # then to fill the gap would swallow the `host` the config goes on to
+    # declare. So the question is asked here instead, once from the Rakefile,
+    # where the config has been read whole and the set of targets is final.
+    # This still runs before the gems are set up, both because they ask for
+    # `mrbcfile` as they go and because the answer turns on defines, which the
+    # config alone has written this early.
+    def resolve_mrbc_hosts
+      mrbc_builds = {}
+      targets.values.grep(CrossBuild).each{|target| target.bind_mrbc_host(mrbc_builds)}
+    end
   end
 
   class Toolchain
@@ -75,6 +91,11 @@ module MRuby
       def install_dir
         @install_dir ||= ENV['INSTALL_DIR'] || "#{MRUBY_ROOT}/bin"
       end
+
+      # The directory the builds write into, each under a directory of its own.
+      def build_root
+        ENV['MRUBY_BUILD_DIR'] || "#{MRUBY_ROOT}/build"
+      end
     end
 
     include Rake::DSL
@@ -101,7 +122,7 @@ module MRuby
           @exts = Exts.new('.o', '', '.a', '.pi')
         end
 
-        build_dir = build_dir || ENV['MRUBY_BUILD_DIR'] || "#{MRUBY_ROOT}/build"
+        build_dir ||= MRuby::Build.build_root
 
         @file_separator = '/'
         @build_dir = "#{build_dir}/#{@name}"
@@ -615,11 +636,53 @@ EOS
     def initialize(name, build_dir=nil, &block)
       @test_runner = Command::CrossTestRunner.new(self)
       super
-      @mrbc_host = mrbcfile_external? ? nil : bind_mrbc_host
     end
 
     def mrbcfile
-      mrbcfile_external? ? super : MRuby::targets[@mrbc_host].mrbcfile
+      return super if mrbcfile_external?
+      unless @mrbc_host
+        fail "the `mrbc' for '#{@name}' is not bound yet; `MRuby.resolve_mrbc_hosts' " \
+             "binds it once the whole build config has been read"
+      end
+      MRuby::targets[@mrbc_host].mrbcfile
+    end
+
+    # Bind this target to the build it borrows `mrbc` from, generating one
+    # where none will do.
+    #
+    # The bytecode `mrbc` emits has to be loadable here, and `src/load.c`
+    # refuses a whole irep over a single pool entry the target cannot
+    # represent: under `MRB_NO_FLOAT` a float literal is one. So a target can
+    # only borrow from a build that answers the float question the way it
+    # does.
+    #
+    # A `host` the build config declares is borrowed as it is written. Where
+    # there is none, or where it answers otherwise, the target gets a `mrbc`
+    # of its own, the way a native build does. That build is internal and
+    # named after the target that asked for it, so a build generated here can
+    # never take a name the build config wants. `mrbc_builds` carries the ones
+    # generated in this pass, keyed by the answer they give, so a config with
+    # several cross targets builds `mrbc` once.
+    def bind_mrbc_host(mrbc_builds)
+      return if mrbcfile_external?
+      no_float = cc.has_define?('MRB_NO_FLOAT')
+      host = MRuby.targets['host']
+      if host && host.cc.has_define?('MRB_NO_FLOAT') == no_float
+        @mrbc_host = 'host'
+      else
+        # `build/host` is where a generated `mrbc` has always been written, and
+        # where the build config declares no `host` it is free to go on being
+        # that: the build belongs to the machine doing the building and to no
+        # one cross target, several of which may share it. The second one
+        # generated, which a config that disagrees with itself on
+        # `MRB_NO_FLOAT` needs, writes beside the target that asked for it.
+        in_host_dir = host.nil? && mrbc_builds.empty?
+        @mrbc_host = (mrbc_builds[no_float] ||= generate_mrbc_build(no_float, in_host_dir))
+        # `tasks/presym.rake` reads this to leave the mrbc build's objects to
+        # it: they sit under this target's own build directory when this is
+        # the target that generated it and `build/host` was taken.
+        @mrbc_build = MRuby.targets[@mrbc_host]
+      end
     end
 
     def run_test
@@ -653,26 +716,14 @@ EOS
 
     private
 
-    # Name the build this target borrows `mrbc` from.
-    #
-    # The bytecode `mrbc` emits has to be loadable here, and `src/load.c`
-    # refuses a whole irep over a single pool entry the target cannot
-    # represent: under `MRB_NO_FLOAT` a float literal is one. So a target can
-    # only borrow from a build that answers the float question the way it
-    # does, and where none is at hand it gets one that does. A `host` the
-    # build config declares itself is left as it is written; the build
-    # generated here is this code's own and carries the target's answer.
-    def bind_mrbc_host
-      no_float = cc.has_define?('MRB_NO_FLOAT')
-      host = MRuby.targets['host']
-      return 'host' if host && host.cc.has_define?('MRB_NO_FLOAT') == no_float
-
-      # Where there is no `host` the generated build takes that name, as it
-      # always has. Where there is one and it answers otherwise, the build
-      # config owns the name, so this target gets a private `mrbc` beside its
-      # own output instead, the way a native build gets one.
-      name, internal = host ? ["#{@name}/mrbc", true] : ['host', false]
-      MRuby::Build.new(name, internal: internal) do |conf|
+    def generate_mrbc_build(no_float, in_host_dir)
+      name = "#{@name}/mrbc"
+      if MRuby.targets[name]
+        fail "cannot generate the `mrbc' build for '#{@name}': " \
+             "the build config already declares a build named '#{name}'"
+      end
+      MRuby::Build.new(name, internal: true) do |conf|
+        conf.build_dir = "#{MRuby::Build.build_root}/host" if in_host_dir
         conf.toolchain
         conf.build_mrbc_exec
         conf.disable_libmruby

--- a/tasks/install.rake
+++ b/tasks/install.rake
@@ -1,8 +1,13 @@
+# A build config of cross builds alone declares no `host`, and the `mrbc` its
+# targets borrow is internal and installs nothing. There is no host build to
+# install, so these fall back to every target the config did declare.
+host_build = MRuby.targets["host"]
+
 desc "install compiled products (on host)"
-task :install => "install:full:host"
+task :install => (host_build ? "install:full:host" : "install:full")
 
 desc "install compiled executable (on host)"
-task :install_bin => "install:bin:host"
+task :install_bin => (host_build ? "install:bin:host" : "install:bin")
 
 desc "install compiled products (all build targets)"
 task "install:full"

--- a/tasks/presym.rake
+++ b/tasks/presym.rake
@@ -65,7 +65,7 @@ MRuby.each_target do |build|
   # This is critical when a build's .o files are compiled during another
   # build's presym scanning chain (before :gensym completes), e.g.:
   #   - internal sub-builds (mrbc) triggered by their parent build
-  #   - the implicit host build triggered by a cross build needing mrbc
+  #   - the mrbc build generated for a cross build that has none to borrow
   prereqs.each_key do |prereq|
     next unless File.extname(prereq) == build.exts.object
     next unless prereq.start_with?(build_dir)


### PR DESCRIPTION
A build config that declares an `MRuby::CrossBuild` before its own
`MRuby::Build.new('host')` cannot be built. No defines, no toolchain settings,
nothing but the order:

```ruby
MRuby::CrossBuild.new('cross') do |conf|
  conf.toolchain
  conf.gem :core => "mruby-bin-mruby"
  conf.test_runner.command = 'env'
end

MRuby::Build.new('host') do |conf|
  conf.toolchain
  conf.gem :core => 'mruby-bin-mrbc'
  conf.gem :core => 'mruby-bin-mruby'
end
```

```console
$ rake
rake aborted!
Don't know how to build task 'build/host/lib/libmruby.a' (See the list of available tasks with `rake --tasks`)
Did you mean?  build/host/bin/mruby
               build/cross/lib/libmruby.a
tasks/presym.rake:5:in 'block (2 levels) in <top (required)>'
```

Swapping the two declarations builds fine.

## Why

`CrossBuild#initialize` settles the build it borrows `mrbc` from as the target
is declared, and where the config has written no `host` yet it generates one
under that name, deliberately crippled:

```ruby
        MRuby::Build.new('host') do |conf|
          conf.toolchain
          conf.build_mrbc_exec
          conf.disable_libmruby
        end
```

`Build#initialize` initialises a target only when the name is free, and reopens
it otherwise. Every instance variable, `@enable_libmruby` included, sits inside
that `unless`:

```ruby
      unless current = MRuby.targets[@name]
        ...
        @enable_libmruby = true
        ...
        MRuby.targets[@name] = current = self
      end

      MRuby::Build.current = current
      begin
        current.instance_eval(&block)
```

So the config's own `host` block does not run on a fresh build. It runs on the
generated one, which already carries `disable_libmruby` and a gem list of its
own. `libmruby_enabled?` stays false, no `libmruby.a` rule is defined for
`host`, and `tasks/presym.rake` asks for one.

The failure is loud, so nothing is silently miscompiled, but the message names
a missing rake task and points at `presym.rake`, which says nothing about
declaration order. No in-tree config is affected:
`build_config/IntelEdison.rb` is the only one that declares both, and it
declares `host` first.

## What this does

Ask the question once, from the Rakefile, where the config has been read whole.
`MRuby.resolve_mrbc_hosts` binds every cross build before any gem is set up, so
a `host` written after a cross build is as visible as one written before it,
and the defines the answer turns on are still the ones the config alone has
written, which is what #7230 rests on.

A build generated because no declared `host` will do is now internal and named
after the target that asked for it, so it can no longer take a name the build
config wants. Cross targets that agree on `MRB_NO_FLOAT` share one, so a config
with several of them still builds `mrbc` once.

The name is all that moves. `build/host` is still where a generated `mrbc` is
written, since a config that declares no `host` claims that directory for
nothing else:

| build config | master | this PR |
|---|---|---|
| a cross build before a `host` | fails | borrows the declared `host` |
| a cross build after a `host` | borrows it | unchanged |
| a cross build, no `host` | target `host`, in `build/host` | target `<cross>/mrbc`, internal, in `build/host` |
| two of them, no `host` | one generated build, shared | one generated build, shared |
| two of them differing on `MRB_NO_FLOAT`, no `host` | the second builds beside itself | unchanged |
| a cross build after a `host` that differs on `MRB_NO_FLOAT` | builds beside itself | unchanged |

Two things follow for a config of cross builds alone. No `host` target is left
for `rake install` and `rake install_bin` to name, so they fall back to every
target the config did declare. And where `build/host` is taken, by a declared
`host` or by a first generated build that answers otherwise on floats, the
generated build sits under the target that asked for it, so `tasks/presym.rake`
reads `mrbc_build` to leave those objects to the build that owns them: without
it the cross build scanned 13 files belonging to its own `mrbc` build, 62
against 49.

## Verified

| build config | outcome |
|---|---|
| a cross build before a `host`, the one above | `rake` builds, the cross build borrows the declared `host` |
| the same with `enable_test` | `rake -m test`, 771 assertions, 0 KO |
| a `host` before a cross build | unchanged, the cross build borrows it |
| two cross builds, no `host` | one `mrbc`, in `build/host` |
| two cross builds differing on `MRB_NO_FLOAT`, no `host` | the first in `build/host`, the second in `build/<cross>/mrbc` |
| a `MRB_NO_FLOAT` cross build declared before a float `host` | `build/<cross>/mrbc`, the behaviour #7230 merged, now whatever the order |
| `build_config/minimal.rb` | `build/host/bin/mrbc` beside `build/minimal`, as on master |
| `build_config/minimal.rb`, `rake install` | 38 files under `/usr/local/mruby/minimal` |
| `build_config/default.rb` | `rake -m test`, 2123 assertions, 0 KO |
| `build_config/no-float.rb` | stops at `test/t/array.rb:65`, the same output as master |

This also composes with #7236, which records what built an output so that a
build directory two configs share is rebuilt rather than reused. The two are
independent: one is about the name a build takes, the other about the directory
it writes into. Applied together they merge without conflict, the config above
builds, and a `build/host` written by a config of cross builds alone is
reported and rebuilt when an ordinary build comes back to it, 2123 assertions
and 0 KO in both directions.

## Environment

| | |
|---|---|
| OS | Linux 7.0.0-28-generic, x86_64 |
| Compiler | gcc 13.3.0 |
| Ruby | 4.0.6 |
| rake | 13.3.1 |

No C source changes, so `.text` is unaffected in every build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JJf1R2cytz2gAnJ2CgpGp1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved cross-build support by automatically selecting compatible `mrbc` tooling.
  * Added support for externally provided `mrbc` executables.
  * Reuses compatible generated build tools to streamline build setup.

* **Bug Fixes**
  * Installation now works when no host build is defined, falling back to available target artifacts.
  * Added safeguards against conflicting generated build-tool names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->