### PR TITLE
build: ask the build too whether a cross target compiles without floats

### DIFF
--- a/lib/mruby/build.rb
+++ b/lib/mruby/build.rb
@@ -622,6 +622,16 @@ EOS
       mrbcfile_external? ? super : MRuby::targets[@mrbc_host].mrbcfile
     end
 
+    # The defines a target and the `mrbc` it borrows have to agree on.
+    #
+    # The bytecode `mrbc` emits has to be loadable on the target, and
+    # `src/load.c` refuses a whole irep over a single pool entry the target
+    # cannot represent: under `MRB_NO_FLOAT` a float literal is one. A define
+    # that decides what a pool entry may hold belongs in this list, which is
+    # where the comparison in `bind_mrbc_host` and the defines a build
+    # generated there carries both read the question from.
+    MRBC_DEFINES = %w[MRB_NO_FLOAT].freeze
+
     def run_test
       @test_runner.runner_options << verbose_flag
       mrbtest = exefile("#{build_dir}/bin/mrbtest")
@@ -655,17 +665,14 @@ EOS
 
     # Name the build this target borrows `mrbc` from.
     #
-    # The bytecode `mrbc` emits has to be loadable here, and `src/load.c`
-    # refuses a whole irep over a single pool entry the target cannot
-    # represent: under `MRB_NO_FLOAT` a float literal is one. So a target can
-    # only borrow from a build that answers the float question the way it
-    # does, and where none is at hand it gets one that does. A `host` the
-    # build config declares itself is left as it is written; the build
+    # A target can only borrow from a build that answers `MRBC_DEFINES` the
+    # way it does, and where none is at hand it gets one that does. A `host`
+    # the build config declares itself is left as it is written; the build
     # generated here is this code's own and carries the target's answer.
     def bind_mrbc_host
-      no_float = cc.has_define?('MRB_NO_FLOAT')
+      needed = mrbc_defines(self)
       host = MRuby.targets['host']
-      return 'host' if host && host.cc.has_define?('MRB_NO_FLOAT') == no_float
+      return 'host' if host && mrbc_defines(host) == needed
 
       # Where there is no `host` the generated build takes that name, as it
       # always has. Where there is one and it answers otherwise, the build
@@ -676,9 +683,24 @@ EOS
         conf.toolchain
         conf.build_mrbc_exec
         conf.disable_libmruby
-        conf.compilers.each {|c| c.defines << 'MRB_NO_FLOAT'} if no_float
+        conf.compilers.each {|c| c.defines.concat(needed)}
       end
       name
+    end
+
+    # The answer `build` gives to every question in `MRBC_DEFINES`, as the
+    # defines it says yes to.
+    #
+    # Both lists a build config writes answer, the way `Build#has_define?`
+    # reads them, because `Command::Compiler#all_flags` puts `build.defines`
+    # on the same command line as a compiler's own. `Build#has_define?` itself
+    # cannot be asked here: it refuses until the gems are set up, and a cross
+    # build binds its `mrbc` as it is declared.
+    def mrbc_defines(build)
+      own = build.defines.flatten.map {|d| d.to_s.split('=', 2).first}
+      MRBC_DEFINES.select do |d|
+        own.include?(d) || build.compilers.any? {|c| c.has_define?(d)}
+      end
     end
   end # CrossBuild
 end # MRuby


### PR DESCRIPTION
Since #7230 a cross target borrows `mrbc` from a build that answers
`MRB_NO_FLOAT` the way it does, because `src/load.c` refuses a whole irep over
a single pool entry the target cannot represent. The question is asked of the
compiler alone, and a build config can write the define on the build instead:

```ruby
MRuby::Build.new('host') do |conf|
  conf.toolchain
  conf.gem :core => 'mruby-bin-mrbc'
end

MRuby::CrossBuild.new('nofloat-build-define') do |conf|
  conf.toolchain
  conf.defines << 'MRB_NO_FLOAT'
  conf.gem :core => 'mruby-bin-mruby'
  conf.test_runner.command = 'env'
  conf.enable_test
end
```

`Command::Compiler#all_flags` puts `build.defines` on every command line
(`lib/mruby/build/command.rb:96` on master):

```ruby
      define_flags = [defines, internal_defines, _defines, build.defines].flatten
```

so the target compiles without floats while `cc.has_define?('MRB_NO_FLOAT')`
says it does not. It borrows the `host`, whose `mrbc` has floats, and that
`mrbc` writes a pool entry the target refuses to load.

| `rake -m test` with the config above | master | this PR |
|---|---|---|
| the `mrbc` it compiles the tests with | the `host` build's, floats enabled | one generated for it, `MRB_NO_FLOAT` |
| where it stops | `irep load error`, at load | `test/t/array.rb:65`, at the literal |
| what that is | the failure #7230 removed | the behaviour #7230 merged |

On master the target builds, and refuses its own test suite the moment a float
literal reaches it:

```console
$ rake -m test
...
TEST for nofloat-build-define
mrbtest - Embeddable Ruby Test

.........(unknown):0: irep load error (ScriptError)
rake aborted!
```

With this patch the target gets a `mrbc` that answers as it does, which
refuses the float literal where it is written, the same place
`build_config/no-float.rb` stops:

```console
$ rake -m test
...
test/t/array.rb:65: Not implemented: PM_FLOAT_NODE
test/t/array.rb:0:0: generator error, Not implemented: PM_FLOAT_NODE
rake aborted!
```

## What this does

Read both lists a build config writes, the way `Build#has_define?` reads them.
`Build#has_define?` itself cannot be asked here: it refuses until the gems are
set up, and a cross build binds its `mrbc` as it is declared, which is why the
compiler was read directly in the first place.

The question moves into `MRBC_DEFINES` as well, which the comparison and the
defines a generated build carries now both read, so a second define that
decides what a pool entry may hold is one entry rather than three places.
`src/load.c` refusing `IREP_TT_INT64` on an `MRB_INT32` target is one candidate
and is left alone here: it is not a regression of this kind, and the `mrbc` a
cross target borrows follows the machine doing the building on integer width
today.

## Verified

| build config | outcome |
|---|---|
| the config above | the target gets `nofloat-build-define/mrbc`, and stops at the literal |
| a cross build and a `host` that agree | unchanged, borrows the `host` |
| `build_config/no-float.rb` | unchanged, stops at the same place |
| `build_config/default.rb` | `rake -m test`, 2123 assertions, 0 KO |

## Environment

| | |
|---|---|
| OS | Linux 7.0.0-28-generic, x86_64 |
| Compiler | gcc 13.3.0 |
| Ruby | 4.0.6 |
| rake | 13.3.1 |

No C source changes, so `.text` is unaffected in every build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JJf1R2cytz2gAnJ2CgpGp1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility checks for generated and host compilation tools.
  * Ensured builds consistently apply relevant target configuration settings, including floating-point support options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->