### PR TITLE
build: let a build config declare `host` after a cross build

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -20,6 +20,11 @@ end
 MRUBY_CONFIG = MRuby::Build.mruby_config_path
 load MRUBY_CONFIG
 
+# Give every cross build the `mrbc` it compiles with. The whole config has been
+# read, so a `host` declared after a cross build is as visible as one declared
+# before it, and no gem has been set up yet, so nothing has asked for `mrbc`.
+MRuby.resolve_mrbc_hosts
+
 # define MRB_NO_GEMS and set up all gems
 MRuby.each_target do |build|
   unless enable_gems? && libmruby_enabled?

--- a/lib/mruby/build.rb
+++ b/lib/mruby/build.rb
@@ -22,6 +22,22 @@ module MRuby
         target.instance_eval(&block)
       end
     end
+
+    # Bind every cross build to the build it borrows `mrbc` from.
+    #
+    # A cross build cannot settle this as it is declared, because the `host`
+    # it would borrow from may be written after it, and `Build.new` reopens a
+    # name already taken rather than initialising it afresh: a build generated
+    # then to fill the gap would swallow the `host` the config goes on to
+    # declare. So the question is asked here instead, once from the Rakefile,
+    # where the config has been read whole and the set of targets is final.
+    # This still runs before the gems are set up, both because they ask for
+    # `mrbcfile` as they go and because the answer turns on defines, which the
+    # config alone has written this early.
+    def resolve_mrbc_hosts
+      mrbc_builds = {}
+      targets.values.grep(CrossBuild).each{|target| target.bind_mrbc_host(mrbc_builds)}
+    end
   end
 
   class Toolchain
@@ -615,11 +631,15 @@ EOS
     def initialize(name, build_dir=nil, &block)
       @test_runner = Command::CrossTestRunner.new(self)
       super
-      @mrbc_host = mrbcfile_external? ? nil : bind_mrbc_host
     end
 
     def mrbcfile
-      mrbcfile_external? ? super : MRuby::targets[@mrbc_host].mrbcfile
+      return super if mrbcfile_external?
+      unless @mrbc_host
+        fail "the `mrbc' for '#{@name}' is not bound yet; `MRuby.resolve_mrbc_hosts' " \
+             "binds it once the whole build config has been read"
+      end
+      MRuby::targets[@mrbc_host].mrbcfile
     end
 
     # The defines a target and the `mrbc` it borrows have to agree on.
@@ -628,9 +648,38 @@ EOS
     # `src/load.c` refuses a whole irep over a single pool entry the target
     # cannot represent: under `MRB_NO_FLOAT` a float literal is one. A define
     # that decides what a pool entry may hold belongs in this list, which is
-    # where the comparison in `bind_mrbc_host` and the defines a build
-    # generated there carries both read the question from.
+    # where the comparison below, the name of a generated build and the
+    # defines it carries all read the question from.
     MRBC_DEFINES = %w[MRB_NO_FLOAT].freeze
+
+    # Bind this target to the build it borrows `mrbc` from, generating one
+    # where none will do.
+    #
+    # A `host` the build config declares is borrowed as it is written. Where
+    # there is none, or where it answers otherwise, the target borrows a build
+    # generated here, named for the answer it carries rather than for the
+    # target that asked for it: targets that agree share one, and it belongs
+    # to none of them. `mrbc_builds` carries the ones this pass has generated,
+    # so a config with several cross targets builds `mrbc` once per answer.
+    #
+    # The name is one the build config does not write, so a build generated
+    # here cannot take a name the config wants, and `build/mrbc` is where
+    # `mrbc` built for its own sake goes, which is where `build_config/mrbc.rb`
+    # already puts it. `build/host` is left to a `host` the config declares.
+    def bind_mrbc_host(mrbc_builds)
+      return if mrbcfile_external?
+      needed = mrbc_defines(self)
+      host = MRuby.targets['host']
+      if host && mrbc_defines(host) == needed
+        @mrbc_host = 'host'
+      else
+        @mrbc_host = (mrbc_builds[needed] ||= generate_mrbc_build(needed))
+        # `tasks/presym.rake` reads this to leave the generated build's
+        # objects to it, which a target named `mrbc` would otherwise scan as
+        # its own.
+        @mrbc_build = MRuby.targets[@mrbc_host]
+      end
+    end
 
     def run_test
       @test_runner.runner_options << verbose_flag
@@ -663,23 +712,13 @@ EOS
 
     private
 
-    # Name the build this target borrows `mrbc` from.
-    #
-    # A target can only borrow from a build that answers `MRBC_DEFINES` the
-    # way it does, and where none is at hand it gets one that does. A `host`
-    # the build config declares itself is left as it is written; the build
-    # generated here is this code's own and carries the target's answer.
-    def bind_mrbc_host
-      needed = mrbc_defines(self)
-      host = MRuby.targets['host']
-      return 'host' if host && mrbc_defines(host) == needed
-
-      # Where there is no `host` the generated build takes that name, as it
-      # always has. Where there is one and it answers otherwise, the build
-      # config owns the name, so this target gets a private `mrbc` beside its
-      # own output instead, the way a native build gets one.
-      name, internal = host ? ["#{@name}/mrbc", true] : ['host', false]
-      MRuby::Build.new(name, internal: internal) do |conf|
+    def generate_mrbc_build(needed)
+      name = mrbc_build_name(needed)
+      if MRuby.targets[name]
+        fail "cannot generate the `mrbc' build for '#{@name}': " \
+             "the build config already declares a build named '#{name}'"
+      end
+      MRuby::Build.new(name, internal: true) do |conf|
         conf.toolchain
         conf.build_mrbc_exec
         conf.disable_libmruby
@@ -694,13 +733,22 @@ EOS
     # Both lists a build config writes answer, the way `Build#has_define?`
     # reads them, because `Command::Compiler#all_flags` puts `build.defines`
     # on the same command line as a compiler's own. `Build#has_define?` itself
-    # cannot be asked here: it refuses until the gems are set up, and a cross
-    # build binds its `mrbc` as it is declared.
+    # cannot be asked here: it refuses until the gems are set up, and every
+    # `mrbc` is bound before that.
     def mrbc_defines(build)
       own = build.defines.flatten.map {|d| d.to_s.split('=', 2).first}
       MRBC_DEFINES.select do |d|
         own.include?(d) || build.compilers.any? {|c| c.has_define?(d)}
       end
+    end
+
+    # Name a generated build after the defines it carries, so that the name
+    # says which targets can borrow it. A build that carries none is the one a
+    # plain `host` would have been.
+    def mrbc_build_name(defines)
+      answer = defines.empty? ? 'default' :
+               defines.map {|d| d.delete_prefix('MRB_').downcase.tr('_', '-')}.join('+')
+      "mrbc/#{answer}"
     end
   end # CrossBuild
 end # MRuby

--- a/lib/mruby/build.rb
+++ b/lib/mruby/build.rb
@@ -622,6 +622,16 @@ EOS
       mrbcfile_external? ? super : MRuby::targets[@mrbc_host].mrbcfile
     end
 
+    # The defines a target and the `mrbc` it borrows have to agree on.
+    #
+    # The bytecode `mrbc` emits has to be loadable on the target, and
+    # `src/load.c` refuses a whole irep over a single pool entry the target
+    # cannot represent: under `MRB_NO_FLOAT` a float literal is one. A define
+    # that decides what a pool entry may hold belongs in this list, which is
+    # where the comparison in `bind_mrbc_host` and the defines a build
+    # generated there carries both read the question from.
+    MRBC_DEFINES = %w[MRB_NO_FLOAT].freeze
+
     def run_test
       @test_runner.runner_options << verbose_flag
       mrbtest = exefile("#{build_dir}/bin/mrbtest")
@@ -655,17 +665,14 @@ EOS
 
     # Name the build this target borrows `mrbc` from.
     #
-    # The bytecode `mrbc` emits has to be loadable here, and `src/load.c`
-    # refuses a whole irep over a single pool entry the target cannot
-    # represent: under `MRB_NO_FLOAT` a float literal is one. So a target can
-    # only borrow from a build that answers the float question the way it
-    # does, and where none is at hand it gets one that does. A `host` the
-    # build config declares itself is left as it is written; the build
+    # A target can only borrow from a build that answers `MRBC_DEFINES` the
+    # way it does, and where none is at hand it gets one that does. A `host`
+    # the build config declares itself is left as it is written; the build
     # generated here is this code's own and carries the target's answer.
     def bind_mrbc_host
-      no_float = cc.has_define?('MRB_NO_FLOAT')
+      needed = mrbc_defines(self)
       host = MRuby.targets['host']
-      return 'host' if host && host.cc.has_define?('MRB_NO_FLOAT') == no_float
+      return 'host' if host && mrbc_defines(host) == needed
 
       # Where there is no `host` the generated build takes that name, as it
       # always has. Where there is one and it answers otherwise, the build
@@ -676,9 +683,24 @@ EOS
         conf.toolchain
         conf.build_mrbc_exec
         conf.disable_libmruby
-        conf.compilers.each {|c| c.defines << 'MRB_NO_FLOAT'} if no_float
+        conf.compilers.each {|c| c.defines.concat(needed)}
       end
       name
+    end
+
+    # The answer `build` gives to every question in `MRBC_DEFINES`, as the
+    # defines it says yes to.
+    #
+    # Both lists a build config writes answer, the way `Build#has_define?`
+    # reads them, because `Command::Compiler#all_flags` puts `build.defines`
+    # on the same command line as a compiler's own. `Build#has_define?` itself
+    # cannot be asked here: it refuses until the gems are set up, and a cross
+    # build binds its `mrbc` as it is declared.
+    def mrbc_defines(build)
+      own = build.defines.flatten.map {|d| d.to_s.split('=', 2).first}
+      MRBC_DEFINES.select do |d|
+        own.include?(d) || build.compilers.any? {|c| c.has_define?(d)}
+      end
     end
   end # CrossBuild
 end # MRuby

--- a/tasks/install.rake
+++ b/tasks/install.rake
@@ -1,8 +1,13 @@
+# A build config of cross builds alone declares no `host`, and the `mrbc` its
+# targets borrow is internal and installs nothing. There is no host build to
+# install, so these fall back to every target the config did declare.
+host_build = MRuby.targets["host"]
+
 desc "install compiled products (on host)"
-task :install => "install:full:host"
+task :install => (host_build ? "install:full:host" : "install:full")
 
 desc "install compiled executable (on host)"
-task :install_bin => "install:bin:host"
+task :install_bin => (host_build ? "install:bin:host" : "install:bin")
 
 desc "install compiled products (all build targets)"
 task "install:full"

--- a/tasks/presym.rake
+++ b/tasks/presym.rake
@@ -65,7 +65,7 @@ MRuby.each_target do |build|
   # This is critical when a build's .o files are compiled during another
   # build's presym scanning chain (before :gensym completes), e.g.:
   #   - internal sub-builds (mrbc) triggered by their parent build
-  #   - the implicit host build triggered by a cross build needing mrbc
+  #   - the mrbc build generated for a cross build that has none to borrow
   prereqs.each_key do |prereq|
     next unless File.extname(prereq) == build.exts.object
     next unless prereq.start_with?(build_dir)


### PR DESCRIPTION
Stacked on #7238, which reads the defines a cross target and its `mrbc` have to
agree on from the build as well as from the compiler, and keeps them in
`MRBC_DEFINES`. Its commit is the first here and is not part of this change.

A build config that declares an `MRuby::CrossBuild` before its own
`MRuby::Build.new('host')` cannot be built. No defines, no toolchain settings,
nothing but the order:

```ruby
MRuby::CrossBuild.new('cross') do |conf|
  conf.toolchain
  conf.gem :core => "mruby-bin-mruby"
  conf.test_runner.command = 'env'
end

MRuby::Build.new('host') do |conf|
  conf.toolchain
  conf.gem :core => 'mruby-bin-mrbc'
  conf.gem :core => 'mruby-bin-mruby'
end
```

```console
$ rake
rake aborted!
Don't know how to build task 'build/host/lib/libmruby.a' (See the list of available tasks with `rake --tasks`)
Did you mean?  build/host/bin/mruby
               build/cross/lib/libmruby.a
tasks/presym.rake:5:in 'block (2 levels) in <top (required)>'
```

Swapping the two declarations builds fine.

## Why

`CrossBuild#initialize` settles the build it borrows `mrbc` from as the target
is declared, and where the config has written no `host` yet it generates one
under that name, deliberately crippled:

```ruby
        MRuby::Build.new('host') do |conf|
          conf.toolchain
          conf.build_mrbc_exec
          conf.disable_libmruby
        end
```

`Build#initialize` initialises a target only when the name is free, and reopens
it otherwise. Every instance variable, `@enable_libmruby` included, sits inside
that `unless`:

```ruby
      unless current = MRuby.targets[@name]
        ...
        @enable_libmruby = true
        ...
        MRuby.targets[@name] = current = self
      end

      MRuby::Build.current = current
      begin
        current.instance_eval(&block)
```

So the config's own `host` block does not run on a fresh build. It runs on the
generated one, which already carries `disable_libmruby` and a gem list of its
own. `libmruby_enabled?` stays false, no `libmruby.a` rule is defined for
`host`, and `tasks/presym.rake` asks for one.

The failure is loud, so nothing is silently miscompiled, but the message names
a missing rake task and points at `presym.rake`, which says nothing about
declaration order. No in-tree config is affected:
`build_config/IntelEdison.rb` is the only one that declares both, and it
declares `host` first.

## What this does

Ask the question once, from the Rakefile, where the config has been read whole.
`MRuby.resolve_mrbc_hosts` binds every cross build before any gem is set up, so
a `host` written after a cross build is as visible as one written before it,
and the defines the answer turns on are still the ones the config alone has
written.

A cross target that cannot borrow a declared `host` then borrows a build
generated under a name of this code's own, named for the `MRBC_DEFINES` it
carries rather than for the target that asked for it first:

| the generated build | master | this PR |
|---|---|---|
| name | `host`, or `<cross>/mrbc` where a `host` disagrees | `mrbc/default` or `mrbc/no-float` |
| directory | `build/host`, or `build/<cross>/mrbc` | `build/mrbc/default` or `build/mrbc/no-float` |
| shared by several cross targets | yes, through the `host` name | yes, by the answer they give |
| a `host` declared after a cross build | reopened, and the build fails | untouched |

The name is one a build config does not write, so nothing generated here takes
a name the config wants, and `build/mrbc` is where `mrbc` built for its own
sake goes, which is where `build_config/mrbc.rb` already puts it. `build/host`
is left to a `host` the config declares, so an ordinary `host` build no longer
meets a `MRB_NO_GEMS` object a config of cross builds alone left behind.

Two things follow for a config of cross builds alone. No `host` target is left
for `rake install` and `rake install_bin` to name, so they fall back to every
target the config did declare. And `tasks/presym.rake` reads `mrbc_build` to
leave the generated build's objects to it, which a cross target named `mrbc`
holds in its own directory and would otherwise scan as its own, 62 files
against 49.

## Verified

| build config | outcome |
|---|---|
| a cross build before a `host`, the one above | `rake` builds, the cross build borrows the declared `host` |
| the same with `enable_test` | `rake -m test`, 771 assertions, 0 KO |
| a `host` before a cross build | unchanged, borrows it |
| two cross builds, no `host` | one `mrbc/default`, shared |
| two cross builds differing on `MRB_NO_FLOAT`, no `host` | `mrbc/default` and `mrbc/no-float` |
| a `MRB_NO_FLOAT` cross build declared before a float `host` | `mrbc/no-float`, the behaviour #7230 merged, now whatever the order |
| a cross build named `mrbc` | builds, and keeps the generated build out of its own presym scan |
| `build_config/minimal.rb` | `build/minimal` and `build/mrbc/default` |
| `build_config/minimal.rb`, `rake install` | 38 files under `/usr/local/mruby/minimal` |
| `build_config/no-float.rb` | `mrbc/no-float`, stops where it does on master |
| `build_config/default.rb` | `rake -m test`, 2123 assertions, 0 KO |

One build directory, `build_config/default.rb` and then
`build_config/minimal.rb` and then `build_config/default.rb` again: 145
compiles for the cross build and its `mrbc`, and nothing recompiled when the
default config comes back to it, the two having no directory in common.

## Environment

| | |
|---|---|
| OS | Linux 7.0.0-28-generic, x86_64 |
| Compiler | gcc 13.3.0 |
| Ruby | 4.0.6 |
| rake | 13.3.1 |

No C source changes, so `.text` is unaffected in every build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JJf1R2cytz2gAnJ2CgpGp1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved cross-build compiler handling, including automatic compatibility checks and reuse of compatible generated builds.
  * Added support for installations when no dedicated host build is available.

* **Bug Fixes**
  * Prevented conflicts between generated and declared build names.
  * Ensured cross-build compiler assignments are resolved correctly after all targets are loaded.

* **Documentation**
  * Clarified build-generation behavior in installation-related documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->