### PR TITLE
build: pass over a `host` that has no `mrbc` to lend

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -20,6 +20,11 @@ end
 MRUBY_CONFIG = MRuby::Build.mruby_config_path
 load MRUBY_CONFIG
 
+# Give every cross build the `mrbc` it compiles with. The whole config has been
+# read, so a `host` declared after a cross build is as visible as one declared
+# before it, and no gem has been set up yet, so nothing has asked for `mrbc`.
+MRuby.resolve_mrbc_hosts
+
 # define MRB_NO_GEMS and set up all gems
 MRuby.each_target do |build|
   unless enable_gems? && libmruby_enabled?

--- a/lib/mruby/build.rb
+++ b/lib/mruby/build.rb
@@ -22,6 +22,22 @@ module MRuby
         target.instance_eval(&block)
       end
     end
+
+    # Bind every cross build to the build it borrows `mrbc` from.
+    #
+    # A cross build cannot settle this as it is declared, because the `host`
+    # it would borrow from may be written after it, and `Build.new` reopens a
+    # name already taken rather than initialising it afresh: a build generated
+    # then to fill the gap would swallow the `host` the config goes on to
+    # declare. So the question is asked here instead, once from the Rakefile,
+    # where the config has been read whole and the set of targets is final.
+    # This still runs before the gems are set up, both because they ask for
+    # `mrbcfile` as they go and because the answer turns on defines, which the
+    # config alone has written this early.
+    def resolve_mrbc_hosts
+      mrbc_builds = {}
+      targets.values.grep(CrossBuild).each{|target| target.bind_mrbc_host(mrbc_builds)}
+    end
   end
 
   class Toolchain
@@ -615,11 +631,15 @@ EOS
     def initialize(name, build_dir=nil, &block)
       @test_runner = Command::CrossTestRunner.new(self)
       super
-      @mrbc_host = mrbcfile_external? ? nil : bind_mrbc_host
     end
 
     def mrbcfile
-      mrbcfile_external? ? super : MRuby::targets[@mrbc_host].mrbcfile
+      return super if mrbcfile_external?
+      unless @mrbc_host
+        fail "the `mrbc' for '#{@name}' is not bound yet; `MRuby.resolve_mrbc_hosts' " \
+             "binds it once the whole build config has been read"
+      end
+      MRuby::targets[@mrbc_host].mrbcfile
     end
 
     # The defines a target and the `mrbc` it borrows have to agree on.
@@ -628,9 +648,38 @@ EOS
     # `src/load.c` refuses a whole irep over a single pool entry the target
     # cannot represent: under `MRB_NO_FLOAT` a float literal is one. A define
     # that decides what a pool entry may hold belongs in this list, which is
-    # where the comparison in `bind_mrbc_host` and the defines a build
-    # generated there carries both read the question from.
+    # where the comparison below, the name of a generated build and the
+    # defines it carries all read the question from.
     MRBC_DEFINES = %w[MRB_NO_FLOAT].freeze
+
+    # Bind this target to the build it borrows `mrbc` from, generating one
+    # where none will do.
+    #
+    # A `host` the build config declares is borrowed as it is written. Where
+    # there is none, or where it answers otherwise, the target borrows a build
+    # generated here, named for the answer it carries rather than for the
+    # target that asked for it: targets that agree share one, and it belongs
+    # to none of them. `mrbc_builds` carries the ones this pass has generated,
+    # so a config with several cross targets builds `mrbc` once per answer.
+    #
+    # The name is one the build config does not write, so a build generated
+    # here cannot take a name the config wants, and `build/mrbc` is where
+    # `mrbc` built for its own sake goes, which is where `build_config/mrbc.rb`
+    # already puts it. `build/host` is left to a `host` the config declares.
+    def bind_mrbc_host(mrbc_builds)
+      return if mrbcfile_external?
+      needed = mrbc_defines(self)
+      host = MRuby.targets['host']
+      if host && mrbc_defines(host) == needed
+        @mrbc_host = 'host'
+      else
+        @mrbc_host = (mrbc_builds[needed] ||= generate_mrbc_build(needed))
+        # `tasks/presym.rake` reads this to leave the generated build's
+        # objects to it, which a target named `mrbc` would otherwise scan as
+        # its own.
+        @mrbc_build = MRuby.targets[@mrbc_host]
+      end
+    end
 
     def run_test
       @test_runner.runner_options << verbose_flag
@@ -663,23 +712,13 @@ EOS
 
     private
 
-    # Name the build this target borrows `mrbc` from.
-    #
-    # A target can only borrow from a build that answers `MRBC_DEFINES` the
-    # way it does, and where none is at hand it gets one that does. A `host`
-    # the build config declares itself is left as it is written; the build
-    # generated here is this code's own and carries the target's answer.
-    def bind_mrbc_host
-      needed = mrbc_defines(self)
-      host = MRuby.targets['host']
-      return 'host' if host && mrbc_defines(host) == needed
-
-      # Where there is no `host` the generated build takes that name, as it
-      # always has. Where there is one and it answers otherwise, the build
-      # config owns the name, so this target gets a private `mrbc` beside its
-      # own output instead, the way a native build gets one.
-      name, internal = host ? ["#{@name}/mrbc", true] : ['host', false]
-      MRuby::Build.new(name, internal: internal) do |conf|
+    def generate_mrbc_build(needed)
+      name = mrbc_build_name(needed)
+      if MRuby.targets[name]
+        fail "cannot generate the `mrbc' build for '#{@name}': " \
+             "the build config already declares a build named '#{name}'"
+      end
+      MRuby::Build.new(name, internal: true) do |conf|
         conf.toolchain
         conf.build_mrbc_exec
         conf.disable_libmruby
@@ -694,13 +733,22 @@ EOS
     # Both lists a build config writes answer, the way `Build#has_define?`
     # reads them, because `Command::Compiler#all_flags` puts `build.defines`
     # on the same command line as a compiler's own. `Build#has_define?` itself
-    # cannot be asked here: it refuses until the gems are set up, and a cross
-    # build binds its `mrbc` as it is declared.
+    # cannot be asked here: it refuses until the gems are set up, and every
+    # `mrbc` is bound before that.
     def mrbc_defines(build)
       own = build.defines.flatten.map {|d| d.to_s.split('=', 2).first}
       MRBC_DEFINES.select do |d|
         own.include?(d) || build.compilers.any? {|c| c.has_define?(d)}
       end
+    end
+
+    # Name a generated build after the defines it carries, so that the name
+    # says which targets can borrow it. A build that carries none is the one a
+    # plain `host` would have been.
+    def mrbc_build_name(defines)
+      answer = defines.empty? ? 'default' :
+               defines.map {|d| d.delete_prefix('MRB_').downcase.tr('_', '-')}.join('+')
+      "mrbc/#{answer}"
     end
   end # CrossBuild
 end # MRuby

--- a/lib/mruby/build.rb
+++ b/lib/mruby/build.rb
@@ -622,6 +622,16 @@ EOS
       mrbcfile_external? ? super : MRuby::targets[@mrbc_host].mrbcfile
     end
 
+    # The defines a target and the `mrbc` it borrows have to agree on.
+    #
+    # The bytecode `mrbc` emits has to be loadable on the target, and
+    # `src/load.c` refuses a whole irep over a single pool entry the target
+    # cannot represent: under `MRB_NO_FLOAT` a float literal is one. A define
+    # that decides what a pool entry may hold belongs in this list, which is
+    # where the comparison in `bind_mrbc_host` and the defines a build
+    # generated there carries both read the question from.
+    MRBC_DEFINES = %w[MRB_NO_FLOAT].freeze
+
     def run_test
       @test_runner.runner_options << verbose_flag
       mrbtest = exefile("#{build_dir}/bin/mrbtest")
@@ -655,17 +665,14 @@ EOS
 
     # Name the build this target borrows `mrbc` from.
     #
-    # The bytecode `mrbc` emits has to be loadable here, and `src/load.c`
-    # refuses a whole irep over a single pool entry the target cannot
-    # represent: under `MRB_NO_FLOAT` a float literal is one. So a target can
-    # only borrow from a build that answers the float question the way it
-    # does, and where none is at hand it gets one that does. A `host` the
-    # build config declares itself is left as it is written; the build
+    # A target can only borrow from a build that answers `MRBC_DEFINES` the
+    # way it does, and where none is at hand it gets one that does. A `host`
+    # the build config declares itself is left as it is written; the build
     # generated here is this code's own and carries the target's answer.
     def bind_mrbc_host
-      no_float = cc.has_define?('MRB_NO_FLOAT')
+      needed = mrbc_defines(self)
       host = MRuby.targets['host']
-      return 'host' if host && host.cc.has_define?('MRB_NO_FLOAT') == no_float
+      return 'host' if host && mrbc_defines(host) == needed
 
       # Where there is no `host` the generated build takes that name, as it
       # always has. Where there is one and it answers otherwise, the build
@@ -676,9 +683,24 @@ EOS
         conf.toolchain
         conf.build_mrbc_exec
         conf.disable_libmruby
-        conf.compilers.each {|c| c.defines << 'MRB_NO_FLOAT'} if no_float
+        conf.compilers.each {|c| c.defines.concat(needed)}
       end
       name
+    end
+
+    # The answer `build` gives to every question in `MRBC_DEFINES`, as the
+    # defines it says yes to.
+    #
+    # Both lists a build config writes answer, the way `Build#has_define?`
+    # reads them, because `Command::Compiler#all_flags` puts `build.defines`
+    # on the same command line as a compiler's own. `Build#has_define?` itself
+    # cannot be asked here: it refuses until the gems are set up, and a cross
+    # build binds its `mrbc` as it is declared.
+    def mrbc_defines(build)
+      own = build.defines.flatten.map {|d| d.to_s.split('=', 2).first}
+      MRBC_DEFINES.select do |d|
+        own.include?(d) || build.compilers.any? {|c| c.has_define?(d)}
+      end
     end
   end # CrossBuild
 end # MRuby

--- a/lib/mruby/build.rb
+++ b/lib/mruby/build.rb
@@ -385,6 +385,15 @@ EOS
       @mrbcfile_external = true
     end
 
+    # Whether this build has a `mrbc` to lend: one it was given, one it
+    # generated for itself (`create_mrbc_build` hands that one over through
+    # `mrbcfile=`), or one it builds from the gem. This is the question
+    # `mrbcfile` asks of `host` on behalf of a native build; a build with
+    # `disable_libmruby` and no `mruby-bin-mrbc` answers no.
+    def supplies_mrbc?
+      mrbcfile_external? || !@gems['mruby-bin-mrbc'].nil?
+    end
+
     def mrbcfile_external?
       @mrbcfile_external
     end
@@ -656,11 +665,12 @@ EOS
     # where none will do.
     #
     # A `host` the build config declares is borrowed as it is written. Where
-    # there is none, or where it answers otherwise, the target borrows a build
-    # generated here, named for the answer it carries rather than for the
-    # target that asked for it: targets that agree share one, and it belongs
-    # to none of them. `mrbc_builds` carries the ones this pass has generated,
-    # so a config with several cross targets builds `mrbc` once per answer.
+    # there is none, where it has no `mrbc` to lend, or where it answers
+    # otherwise, the target borrows a build generated here, named for the
+    # answer it carries rather than for the target that asked for it: targets
+    # that agree share one, and it belongs to none of them. `mrbc_builds`
+    # carries the ones this pass has generated, so a config with several
+    # cross targets builds `mrbc` once per answer.
     #
     # The name is one the build config does not write, so a build generated
     # here cannot take a name the config wants, and `build/mrbc` is where
@@ -670,7 +680,7 @@ EOS
       return if mrbcfile_external?
       needed = mrbc_defines(self)
       host = MRuby.targets['host']
-      if host && mrbc_defines(host) == needed
+      if host && host.supplies_mrbc? && mrbc_defines(host) == needed
         @mrbc_host = 'host'
       else
         @mrbc_host = (mrbc_builds[needed] ||= generate_mrbc_build(needed))

--- a/tasks/install.rake
+++ b/tasks/install.rake
@@ -1,8 +1,13 @@
+# A build config of cross builds alone declares no `host`, and the `mrbc` its
+# targets borrow is internal and installs nothing. There is no host build to
+# install, so these fall back to every target the config did declare.
+host_build = MRuby.targets["host"]
+
 desc "install compiled products (on host)"
-task :install => "install:full:host"
+task :install => (host_build ? "install:full:host" : "install:full")
 
 desc "install compiled executable (on host)"
-task :install_bin => "install:bin:host"
+task :install_bin => (host_build ? "install:bin:host" : "install:bin")
 
 desc "install compiled products (all build targets)"
 task "install:full"

--- a/tasks/presym.rake
+++ b/tasks/presym.rake
@@ -65,7 +65,7 @@ MRuby.each_target do |build|
   # This is critical when a build's .o files are compiled during another
   # build's presym scanning chain (before :gensym completes), e.g.:
   #   - internal sub-builds (mrbc) triggered by their parent build
-  #   - the implicit host build triggered by a cross build needing mrbc
+  #   - the mrbc build generated for a cross build that has none to borrow
   prereqs.each_key do |prereq|
     next unless File.extname(prereq) == build.exts.object
     next unless prereq.start_with?(build_dir)


### PR DESCRIPTION
Stacked on #7239, which binds every cross build to its `mrbc` once the whole
config has been read and names the generated build for the defines it carries,
and through it on #7238. Their two commits are the first here and are not part
of this change.

A build config that declares a `host` which can supply no `mrbc` stops before
anything is built, and the message names the `host`:

```ruby
MRuby::Build.new('host') do |conf|
  conf.toolchain
  conf.disable_libmruby
end

MRuby::CrossBuild.new('cross') do |conf|
  conf.toolchain
  conf.gem :core => "mruby-bin-mruby"
  conf.test_runner.command = 'env'
end
```

```console
$ rake
rake aborted!
external mrbc or mruby-bin-mrbc gem in current('host') or 'host' build is required
lib/mruby/build.rb:364:in 'MRuby::Build#mrbcfile'
lib/mruby/build.rb:622:in 'MRuby::CrossBuild#mrbcfile'
tasks/mrblib.rake:9:in 'block in <top (required)>'
```

Dropping the cross build, or dropping `disable_libmruby`, builds fine. The
failure is the same on `master`, on #7238 and on #7239; only the line numbers
move.

## Why

`CrossBuild#bind_mrbc_host` picks a declared `host` on one question: whether it
answers the defines in `MRBC_DEFINES` the way the target does. It does not ask
whether that `host` can produce a `mrbc` at all.

A `host` with `disable_libmruby` never gets one. `Build#initialize` asks
`libmruby_enabled?` before it generates the `mrbc` sub-build:

```ruby
        if current.libmruby_enabled? && !current.mrbcfile_external?
          current.create_mrbc_build if current.host? || current.gems["mruby-bin-mrbc"]
        end
```

so the `host` above has no `@mrbcfile` and no `mruby-bin-mrbc` gem, and the
cross target reads it anyway. `Build#mrbcfile` then raises for the `host`,
during the cross target's own `mrblib` rule.

Everywhere else `bind_mrbc_host` generates a build when the declared `host`
will not do: where there is none, and where it answers otherwise on the
defines. Only "it has none to lend" falls through to a raise, and the raise is
loud but misdirected: the build that wanted a `mrbc` is `cross`, the message
names `host` twice and `cross` not at all, and the remedy it suggests is to add
`mruby-bin-mrbc` to a `host` the config deliberately stripped.

## What this does

Ask that question too. `Build#supplies_mrbc?` says whether a build has a `mrbc`
to hand out: one it was given through `mrbcfile=`, one `create_mrbc_build`
generated for it (which hands it over the same way), or one it builds from the
gem. It is the question `Build#mrbcfile` already puts to `host` on behalf of a
native build.

`bind_mrbc_host` asks it before the defines are compared:

```ruby
      if host && host.supplies_mrbc? && mrbc_defines(host) == needed
        @mrbc_host = 'host'
```

A `host` that answers no is passed over for the generated build the answer
names, `mrbc/default` for the config above, the way a `host` that answers
otherwise on the defines already is. The `host` itself is left as it is
written: nothing is added to it, it is only not borrowed from.

A native build that borrows from the same `host` still fails in
`Build#mrbcfile` as before; that path generates nothing and is not touched
here.

## Verified

| build config | #7239 | this PR |
|---|---|---|
| the one above | `rake aborted!` in `Build#mrbcfile` | `rake` builds; `cross` borrows `mrbc/default`, `build/cross/bin/mruby` runs |
| a full `host` | borrows `host` | unchanged |
| a `host` with `disable_libmruby` and `mruby-bin-mrbc` | borrows `host` | unchanged |
| a `host` with `disable_libmruby` and an external `mrbcfile` | borrows `host` | unchanged |
| no `host` | `mrbc/default` | unchanged |
| a `host` with `disable_libmruby`, a `MRB_NO_FLOAT` cross build | `mrbc/no-float`, the defines already disagree | unchanged |
| a cross build with its own external `mrbcfile` | asks nothing of `host` | unchanged |
| `build_config/default.rb` | | `rake -m test`, 2123 assertions, 0 KO |

## Environment

| | |
|---|---|
| OS | Linux 7.0.0-28-generic, x86_64 |
| Compiler | gcc 13.3.0 |
| Ruby | 4.0.6 |
| rake | 13.3.1 |

No C source changes, so `.text` is unaffected in every build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BCjntyYTPYqq5Nppjnm38


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cross-build configuration when compiling projects with different target settings.
  - Prevented failures caused by missing or conflicting host compiler configurations.
  - Installation tasks now work correctly whether a dedicated host build is available or not.

- **Improvements**
  - Reuses compatible compiler builds where possible, reducing redundant generated builds.
  - Ensures compiler selection is completed consistently before gems and targets are initialized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->