### PR TITLE
mruby-compiler: read a float literal as Integer 0 under `MRB_NO_FLOAT`

### DIFF
--- a/doc/guides/mrbconf.md
+++ b/doc/guides/mrbconf.md
@@ -85,6 +85,7 @@ end
 
 - When defined removes floating-point numbers from mruby.
 - It makes mruby easier to handle in "Micro-controller without FPU" and "Kernel Space".
+- A floating-point literal in Ruby source is read as the Integer `0`, with a compiler warning.
 
 `MRB_INT32`
 

--- a/mrbgems/mruby-bin-mrbc/bintest/mrbc.rb
+++ b/mrbgems/mruby-bin-mrbc/bintest/mrbc.rb
@@ -30,6 +30,22 @@ assert('embedded document with invalid terminator') do
   assert_equal 1, $?.exitstatus
 end
 
+assert('a float literal under MRB_NO_FLOAT is read as 0 with a warning') do
+  # Only a build without Float takes this path.  Whether this is one is asked
+  # of its mruby, when there is one; mrbc itself cannot be asked.
+  skip 'no mruby to probe the build with' unless File.exist?(cmd_bin('mruby'))
+  system("#{cmd('mruby')} -e Float", out: File::NULL, err: File::NULL)
+  skip 'this build has Float' if $?.success?
+
+  a, out = Tempfile.new('a.rb'), Tempfile.new('out.mrb')
+  a.write("x = 1\np 1.5\n")
+  a.flush
+  result = `#{cmd('mrbc')} -v -o #{out.path} #{a.path} 2>&1`
+  assert_equal 0, $?.exitstatus
+  assert_include result, "#{a.path}:2:3: generator warning, floating-point numbers are not supported"
+  assert_equal "0\n", `#{cmd('mruby')} -b #{out.path}`
+end
+
 assert('mrbc -v disassembles like mruby -v') do
   # mruby-compiler carries its own copy of the disassembler, because it has to
   # build for mruby/c as well and cannot share src/codedump.c. The copy has

--- a/mrbgems/mruby-compiler/src/codegen.c
+++ b/mrbgems/mruby-compiler/src/codegen.c
@@ -4690,18 +4690,29 @@ codegen(mrc_codegen_scope *s, mrc_node *tree, int val)
       }
       break;
     }
-#ifndef MRC_NO_FLOAT
   case PM_FLOAT_NODE:
   {
+#ifndef MRC_NO_FLOAT
     if (val) {
       CAST(float);
       int off = new_lit_float(s, (mrc_float)cast->value);
       genop_2(s, OP_LOADL, cursp(), off);
       push();
     }
+#else
+    /* A build without Float still has to compile source that spells a
+       float literal, so the literal is warned about and read as Integer 0,
+       as the lrama parser did under MRB_NO_FLOAT. */
+    mrc_diagnostic_list_append(s->c, tree->location.start,
+                               "floating-point numbers are not supported",
+                               MRC_GENERATOR_WARNING);
+    if (val) {
+      gen_int(s, cursp(), 0);
+      push();
+    }
+#endif
     break;
   }
-#endif
     case PM_CALL_NODE:
     {
       CAST(call);

--- a/mrbgems/mruby-regexp/test/string_regexp.rb
+++ b/mrbgems/mruby-regexp/test/string_regexp.rb
@@ -647,7 +647,7 @@ assert("String#split with regexp limit") do
   assert_equal ["a", ""], "a,".split(/,/, 2)
   assert_equal ["a,b,"], "a,b,".split(/,/, 1)
   assert_raise(TypeError) { "a,b".split(/,/, nil) }
-  assert_equal ["a,b"], "a,b".split(/,/, 1.5)
+  assert_equal ["a,b"], "a,b".split(/,/, 1.5) if Object.const_defined?(:Float)
 
   # mruby has no implicit conversion protocol, so an object defining `to_int`
   # is rejected here exactly as `Array.new(obj)` and `ary[obj]` reject it. The

--- a/mrbgems/mruby-string-bitops/test/string_bitops.rb
+++ b/mrbgems/mruby-string-bitops/test/string_bitops.rb
@@ -15,13 +15,13 @@ assert('String#bit_get') do
   # CRuby raises ArgumentError for offsets too large to represent.
   # mruby has no Bignum bit offsets and raises RangeError instead:
   # without mruby-bigint the power itself overflows, with it the
-  # offset conversion rejects the Bigint.  Either way this compiles
-  # in every build configuration (a float literal like 1e30 would
-  # not compile under MRB_NO_FLOAT).
+  # offset conversion rejects the Bigint.  Either way this raises
+  # in every build configuration (a float literal like 1e30 reads
+  # as 0 under MRB_NO_FLOAT).
   assert_raise(RangeError) { s.bit_get(2 ** 100) }
 
   # The Float path of the offset conversion, built without a float
-  # literal so MRB_NO_FLOAT builds can still compile this file.
+  # literal, which MRB_NO_FLOAT builds would read as 0.
   if 1.respond_to?(:to_f)
     huge = (1 << 30).to_f
     huge = huge * huge * 16  # 2.0**64, beyond mrb_int in any build

--- a/test/t/gc.rb
+++ b/test/t/gc.rb
@@ -349,6 +349,7 @@ end
 # retain nothing and the assertions hold trivially.
 
 assert('OP_MATH does not retain a boxed Float in the GC arena') do
+  skip unless Object.const_defined?(:Float)
   [1.0e100, 5.0e-324].each do |x|
     zero = 0.0
     one = 1.0
@@ -369,6 +370,7 @@ assert('OP_MATH does not retain a boxed Float in the GC arena') do
 end
 
 assert('OP_DIV does not retain a boxed Float in the GC arena') do
+  skip unless Object.const_defined?(:Float)
   # OP_DIV boxes from a helper outside the interpreter loop, so it restores to
   # its own saved arena index rather than to the frame's.
   [1.0e100, 5.0e-324].each do |x|
@@ -388,6 +390,7 @@ assert('OP_DIV does not retain a boxed Float in the GC arena') do
 end
 
 assert('OP_ADDI does not retain a boxed Float in the GC arena') do
+  skip unless Object.const_defined?(:Float)
   x = 1.0e100
   y = nil
   GC.start
@@ -407,6 +410,7 @@ assert('OP_ADDI does not retain a boxed Float in the GC arena') do
 end
 
 assert('OP_LOADL does not retain a boxed Float in the GC arena') do
+  skip unless Object.const_defined?(:Float)
   y = nil
   GC.start
   base = GC.stat[:live]

--- a/test/t/integer.rb
+++ b/test/t/integer.rb
@@ -343,7 +343,7 @@ assert('Integer.__ensure converts its argument without dispatching') do
   assert_raise(TypeError) { Integer.__ensure(Class.new { def to_int; 2; end }.new) }
 
   assert_equal 2, Integer.__ensure(2)
-  assert_equal 1, Integer.__ensure(1.9)
+  assert_equal 1, Integer.__ensure(1.9) if Object.const_defined?(:Float)
   assert_raise(TypeError) { Integer.__ensure("2") }
   assert_raise(TypeError) { Integer.__ensure(nil) }
 end

--- a/test/t/literals.rb
+++ b/test/t/literals.rb
@@ -35,6 +35,17 @@ assert('Literals Numerical', '8.7.6.2') do
   assert_equal 10.0, 1.0e+1
 end
 
+assert('Literals Numerical without Float') do
+  # A build without Float (MRB_NO_FLOAT) reads a float literal as the Integer
+  # 0, with a compiler warning, so a shared test file still compiles and its
+  # Float rows can be skipped at run time.
+  skip 'Float is defined' if Object.const_defined?(:Float)
+  assert_equal 0, 1.5
+  assert_equal 0, -1.5
+  assert_equal 0, 1e10
+  assert_equal Integer, 1.5.class
+end
+
 assert('Literals Numerical wider than mrb_int') do
   # None of these fit mrb_int on MRB_INT32, so the compiler has to hand them
   # to the VM as big integer literals.  A shift is written on the other side

--- a/test/t/syntax.rb
+++ b/test/t/syntax.rb
@@ -1629,7 +1629,7 @@ assert('defined? on constant paths (A::B)') do
   assert_equal 'constant', defined?(DefinedPathChild::Sub)
 
   # a builtin nested constant
-  assert_equal 'constant', defined?(Float::INFINITY)
+  assert_equal 'constant', defined?(Float::INFINITY) if Object.const_defined?(:Float)
 end
 
 # NOTE: `&nil` block-forbidding parameters live in syntax_block_forbid.rb,


### PR DESCRIPTION
The Prism codegen compiles `case PM_FLOAT_NODE` out under `MRC_NO_FLOAT` (which
`mrc_common.h` derives from `MRB_NO_FLOAT`), so a float literal falls through to
the default arm of `codegen()` and the compile dies with the arm's internal
message:

```console
$ MRUBY_CONFIG=host-nofloat rake test
...
      MRBC mrbgems/mruby-compar-ext/test/compar.rb
mrbgems/mruby-compar-ext/test/compar.rb:4: Not implemented: PM_FLOAT_NODE
mrbgems/mruby-compar-ext/test/compar.rb:0:0: generator error, Not implemented: PM_FLOAT_NODE
rake aborted!
```

The lrama parser read the same literal as the Integer 0 and warned
`floating-point numbers are not supported` (parse.y, since acdc2d1f2 added
`MRB_WITHOUT_FLOAT`), and the shared test files are written against that: 73
`Object.const_defined?(:Float)` guards in `test/t` and the gem tests skip the
Float rows at run time, which only helps once the file has compiled. Counted
with the fixed `mrbc -v`, 13 of the 43 files in `test/t` hold a float literal
(374 of them, 226 in `float.rb` alone) and 21 gem test files do, so with the arm
missing no `MRB_NO_FLOAT` build can run the suite at all; the compile stops at
the first such file, `compar.rb:4` for `build_config/host-nofloat.rb` and
`test/t/array.rb:65` for `build_config/no-float.rb` (since #7230 gave that cross
build an `mrbc` that answers the float question the way its target does).

## Fix

Give `PM_FLOAT_NODE` a `MRC_NO_FLOAT` arm that appends a generator warning at
the literal and emits the Integer 0, what the lrama parser produced. The warning
goes through the diagnostic list like the Prism parser warnings, so `mrbc -v`
and mirb report it, with the file, line and column of the literal:

```console
$ printf 'p 1.5\n' > f.rb
$ build/host-nofloat/bin/mrbc -v -o f.mrb f.rb
...
f.rb:1:3: generator warning, floating-point numbers are not supported
$ build/host-nofloat/bin/mruby -b f.mrb
0
$ echo 'p 1.5' | build/host-nofloat/bin/mirb
mirb - Embeddable Interactive Ruby Shell

1> 0
warning: line 1: generator warning, floating-point numbers are not supported
 => 0
```

With the suite compiling again, five rows fail at run time because their Float
is now 0 instead of the row being skipped: the four Float arena tests in
`test/t/gc.rb` (`OP_DIV` divides by zero, `OP_ADDI` sees -1),
`Integer.__ensure(1.9)`, `defined?(Float::INFINITY)` and
`"a,b".split(/,/, 1.5)`. They are guarded the way the rows around them are.

The comment in `mruby-string-bitops/test/string_bitops.rb` that described a
float literal as not compiling under `MRB_NO_FLOAT` is updated, and
`doc/guides/mrbconf.md` gains the sentence.

Two tests pin the new arm: `test/t/literals.rb` asserts the Integer 0
in-process, so every `MRB_NO_FLOAT` build that runs mrbtest checks it, and the
mrbc bintest compiles `p 1.5` with `mrbc -v`, asserts the warning with the
literal's file, line and column, and runs the bytecode on the build's mruby for
the `0`. Both skip in a Float build.

## Scope

Float builds compile the same arm as before; the `#ifndef` moved inside the
`case`. `codegen.o` of the default build disassembles identically apart from
the `__LINE__` immediates in the assertions.

## Verification

`rake test` per config, master and this PR:

| config | master | this PR |
|---|---|---|
| `build_config/host-nofloat.rb` (`MRB_NO_FLOAT`, bintest on) | rake aborted at `compar.rb:4` | 1739 OK, 0 KO, 0 Crash, 94 Skip; bintest 68 OK |
| `build_config/no-float.rb` (`MRB_NO_FLOAT` cross build, native runner) | rake aborted at `test/t/array.rb:65` | 675 OK, 0 KO, 0 Crash, 25 Skip |
| default (`build_config/default.rb`) | 2073 OK, 0 KO, 0 Crash, 50 Skip; bintest 111 OK | 2073 OK, 0 KO, 0 Crash, 51 Skip; bintest 111 OK, 1 Skip |

`rake test`, `build_config/ci/gcc-clang.rb`, all five builds plus bintest, this
PR (the guards are no-ops in a Float build, and the codegen arm they compile is
the one they compiled before):

| build | Total | OK | KO | Crash | Skip |
|---|---:|---:|---:|---:|---:|
| `full-debug` | 2347 | 2342 | 0 | 0 | 5 |
| `bintest` | 2347 | 2334 | 0 | 0 | 13 |
| `cxx_abi` | 2347 | 2334 | 0 | 0 | 13 |
| `byte-string` | 2277 | 2227 | 0 | 0 | 50 |
| `ascii-case` | 2344 | 2331 | 0 | 0 | 13 |
| `bintest` (bintest) | 122 | 122 | 0 | 0 | 0 |

`.text` of `mrbgems/mruby-compiler/src/codegen.o`, master vs this PR:

| build | flags | master | this PR |
|---|---|---:|---:|
| default (`build/host`) | `-O3` | 87081 | 87081 (±0) |
| `no-float.rb`, its `mrbc` (`build/mrbc/no-float`) | `-O3 -DMRB_NO_FLOAT` | 87337 | 87401 (+64) |
| `host-nofloat.rb` (`build/host-nofloat`) | `-O0 -DMRB_NO_FLOAT -DMRB_DEBUG` | 111037 | 111162 (+125) |

The shared test files were what #7230 named as the remaining distance between
an `MRB_NO_FLOAT` build and a running suite; this closes it.

### Environment

<details>

| | |
|---|---|
| OS | Ubuntu 24.04.4 LTS, Linux 7.0.0-28-generic x86_64 |
| CPU | AMD Ryzen 9 5950X 16-Core Processor |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0 |
| binutils | GNU ld (GNU Binutils) 2.47.20260726 |
| CRuby | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |
| rake | 13.3.1 |

The compile line of `mrbgems/mruby-compiler/src/codegen.c` in each build
(`-I`, `-MMD -c` and `-o` dropped):

```console
# default, build/host
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK mrbgems/mruby-compiler/src/codegen.c
# host-nofloat.rb, build/host-nofloat (enable_debug appends -g3 -O0)
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_NO_FLOAT -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DMRC_DEBUG -DMRC_DUMP_PRETTY -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_DEBUG -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM mrbgems/mruby-compiler/src/codegen.c
# no-float.rb, build/no-float (target) and build/mrbc/no-float (its mrbc)
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_NO_FLOAT -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DMRC_DEBUG -DMRC_DUMP_PRETTY -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_DEBUG mrbgems/mruby-compiler/src/codegen.c
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_FLOAT -DMRB_NO_GEMS -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 mrbgems/mruby-compiler/src/codegen.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ruby builds without floating-point support now compile floating-point literals as integer `0` and emit a compiler warning.
  * Builds with floating-point support continue to preserve floating-point literal behavior.

* **Documentation**
  * Added documentation describing floating-point behavior when `MRB_NO_FLOAT` is enabled.

* **Tests**
  * Updated tests to run conditionally when floating-point support is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->