### PR TITLE
build: give the presym preprocess the header dependencies of its object

### DIFF
--- a/lib/mruby/build/command.rb
+++ b/lib/mruby/build/command.rb
@@ -191,6 +191,20 @@ module MRuby
         #    []
         #    []
       end.flatten.uniq
+      # A header the +.d+ file names but that no longer exists is not a
+      # dependency Rake can resolve: `Rake::TaskManager#attempt_rule` gives up
+      # on the rule when a source neither exists nor has a task, and the
+      # output is left as it is, with nothing to rebuild it (the object keeps
+      # only the presym proxy from `tasks/presym.rake`). The +.d+ describes a
+      # compile that read that header, so the output is stale by its own
+      # record: it is removed here, so that the rule, with the header left
+      # out, builds it again and writes a +.d+ that matches the sources of
+      # now.
+      missing = header_deps.reject {|dep| File.exist?(dep) || Rake::Task.task_defined?(dep) }
+      unless missing.empty?
+        header_deps -= missing
+        rm_f file if rule_applies?(source)
+      end
       deps.concat(header_deps)
     end
 

--- a/lib/mruby/build/command.rb
+++ b/lib/mruby/build/command.rb
@@ -175,11 +175,20 @@ module MRuby
     #
     #   /src/value_array.h:
     #
+    # The compile of the object writes the +.d+ file, and the presym
+    # preprocess of the same source reads it too: both run the preprocessor
+    # over the same source with the same include paths, so a header that
+    # changes what one sees changes what the other sees. Only the presym
+    # headers are left out of the preprocess: they are made from the
+    # preprocessed files, so depending on them would preprocess every source
+    # again on the run after the symbol table changed. The scan does not
+    # include them anyway (see +MRB_PRESYM_SCANNING+ in +mruby/presym.h+).
+    #
     def get_dependencies(file, source)
       discard_foreign_output(file) if rule_applies?(source)
       deps = [MRUBY_CONFIG]
       dep_file = file.ext(".d")
-      return deps unless object_ext?(file) && File.exist?(dep_file)
+      return deps unless File.exist?(dep_file)
 
       header_deps = File.read(dep_file).gsub("\\\n ", "").split("\n").map do |dep_line|
         # dep_line:
@@ -191,15 +200,19 @@ module MRuby
         #    []
         #    []
       end.flatten.uniq
+      unless object_ext?(file)
+        presym_dir = "#{build.presym.header_dir}/"
+        header_deps.reject! {|dep| dep.start_with?(presym_dir) }
+      end
       # A header the +.d+ file names but that no longer exists is not a
       # dependency Rake can resolve: `Rake::TaskManager#attempt_rule` gives up
       # on the rule when a source neither exists nor has a task, and the
       # output is left as it is, with nothing to rebuild it (the object keeps
-      # only the presym proxy from `tasks/presym.rake`). The +.d+ describes a
-      # compile that read that header, so the output is stale by its own
-      # record: it is removed here, so that the rule, with the header left
-      # out, builds it again and writes a +.d+ that matches the sources of
-      # now.
+      # only the presym proxy from `tasks/presym.rake`, the preprocess drops
+      # out of the scan). The +.d+ describes a compile that read that header,
+      # so the output is stale by its own record: it is removed here, so that
+      # the rule, with the header left out, builds it again and writes a
+      # +.d+ that matches the sources of now.
       missing = header_deps.reject {|dep| File.exist?(dep) || Rake::Task.task_defined?(dep) }
       unless missing.empty?
         header_deps -= missing

--- a/lib/mruby/presym.rb
+++ b/lib/mruby/presym.rb
@@ -142,6 +142,10 @@ module MRuby
       @table_header_path ||= "#{header_dir}/table.h".freeze
     end
 
+    def headers_exist?
+      File.exist?(id_header_path) && File.exist?(table_header_path)
+    end
+
     private
 
     def read_preprocessed(presym_hash, path)

--- a/tasks/presym.rake
+++ b/tasks/presym.rake
@@ -49,7 +49,25 @@ MRuby.each_target do |build|
         presym.send("write_#{type}_header", presyms)
       end
       presym.write_list(presyms)
+    elsif !presym.headers_exist?
+      # The headers are made from the list, so a header that is gone is
+      # written again from the list as it stands. The list itself is left
+      # alone: its timestamp is what every object depends on, and nothing
+      # about the symbols changed. Only the header that is gone is written,
+      # since a new `id.h` recompiles every object that includes it.
+      mkdir_p presym.header_dir
+      %w[id table].each do |type|
+        next if File.exist?(presym.send("#{type}_header_path"))
+        presym.send("write_#{type}_header", presyms)
+      end
     end
+  end
+
+  # The list is the file of the task above, so Rake runs it only when a
+  # preprocessed file is newer than the list. The headers are made from the
+  # list, so a header that is gone needs the task too, with the list as it is.
+  presym_task.define_singleton_method :needed? do
+    super() || !presym.headers_exist?
   end
 
   # Don't directly write dependency tasks in the "task" arguments.


### PR DESCRIPTION
The presym preprocess of a source, the `.pi` file the symbol table is scanned
from, depends on the source and the build config only. A header that changes
which symbols a source uses leaves its `.pi` as it was, and the table misses
the change. Switching to a branch that renames the symbol
`MRB_EXC_EXIT_STATUS` reads in `include/mruby/error.h`:

```diff
-#define MRB_EXC_EXIT_STATUS(mrb,e) ((int)mrb_as_int((mrb),mrb_obj_iv_get((mrb),(e),MRB_IVSYM(status))))
+#define MRB_EXC_EXIT_STATUS(mrb,e) ((int)mrb_as_int((mrb),mrb_obj_iv_get((mrb),(e),MRB_IVSYM(status_probe))))
```

and running `rake` in a build directory that was built before the switch:

```console
$ rake
include/mruby/presym.h:38:25: error: ‘MRB_IVSYM__status_probe’ undeclared (first use in this function); did you mean ‘MRB_IVSYM__status’?
include/mruby/error.h:29:84: note: in expansion of macro ‘MRB_IVSYM’
include/mruby/error.h:31:67: note: in expansion of macro ‘MRB_EXC_EXIT_STATUS’
rake aborted!
Command failed with status (1): [gcc -MMD -c ... mrbgems/mruby-bin-mirb/tools/mirb/mirb.c]
```

Switching back fails the same way, with `MRB_IVSYM__status` undeclared, until
the `.pi` files are deleted by hand. A header that only drops a use of a
symbol does not fail; it leaves the entry in the table, so the table and
`presym/id.h` differ from a clean build's until one is made.

## Why

`Compiler#get_dependencies` reads the `.d` file the compile writes only for
the object:

```ruby
      dep_file = file.ext(".d")
      return deps unless object_ext?(file) && File.exist?(dep_file)
```

so a `.pi` depends on its `.c`, `MRUBY_CONFIG` and the gem's `mrbgem.rake`,
and on no header. The object does depend on the header, through the same
`.d`, so it is recompiled against a table that was scanned from a stale
`.pi`.

The `.pi` used to have header dependencies of its own: 456878ba0 wrote a
`.i.d` beside the `.o.d`, on the reasoning that sharing the `.d` would make
the `.i` depend on the presym include and circulate. d95ffb036 stopped
writing the `.pi.d`, and d90abc648 folded the `.o.d` back into `.d` with the
`object_ext?` guard that is there now.

## What this does

The compile of the object and the presym preprocess of the same source run
the preprocessor over the same source with the same include paths, so the
`.d` the compile writes lists the headers the preprocess reads too. The
guard is dropped and both read it.

The presym headers under `build/<name>/include/mruby/presym` are left out
of the preprocess's dependencies. They are made from the preprocessed
files, and the scan does not include them (`mruby/presym.h` skips them
under `MRB_PRESYM_SCANNING`), so keeping them would only preprocess every
source once more on the run after the table changed: with them in, adding
one `MRB_SYM()` to `src/array.c` and running `rake` twice does 154 `CPP` on
the first run and 153 on the second; with them out, the second run does
nothing.

On a clean build no `.d` exists when the `.pi` rules are resolved, so the
first build is unchanged; the dependency takes effect from the second run.

### A `.d` that names a header that no longer exists

Reading the `.d` for the `.pi` meets a case the object already had. When
a header the `.d` names is deleted or renamed afterwards,
`Rake::TaskManager#attempt_rule` gives up on the rule, since the source
neither exists nor has a task, and says nothing: the object keeps only the
plain file task `tasks/presym.rake` defines for it, whose one dependency is
the presym proxy, so its `.c` changing does not rebuild it either, and the
object of the previous build is linked for as long as the `.d` stays. With
the `.pi` reading the same `.d`, its rule gives up too and the `.pi` drops
out of the scan: the table loses the symbols only that source uses, while
the stale object keeps the numbers of the old table.

The two commits before it close that:

- The presym task writes `presym/id.h` or `presym/table.h` again when it
  is gone and the list did not change. The list is the file of the task,
  so Rake runs it only when a `.pi` is newer than the list; a header that
  is gone marks the task as needed too, and the list itself is not
  touched, since its timestamp is what every object depends on. Only the
  header that is gone is written, since a new `id.h` recompiles every
  object that includes it. Deleting the generated headers used to leave
  every object with a dependency Rake could not resolve, and the link went
  through with the objects of the previous build; with the next commit
  alone it would fail the compile instead, on the missing `id.h`.
- `get_dependencies` removes an output whose `.d` names a header that no
  longer exists, and leaves that header out of the dependencies, so the
  rule builds the output again and writes a `.d` that matches the sources
  of now. The `.d` describes a compile that read that header, so the
  output is stale by its own record.

## Verified

`build_config/default.rb`, `rake -m -j16`, `CCACHE_DISABLE=1`, the build
directory built once on `master` and then switched between the two states.

| change | master | this PR |
|---|---|---|
| `include/mruby/error.h`, rename the symbol above | `rake aborted!` in `mirb.o`, both directions | builds: 34 `CPP`, table updated, 174 `CC`; back again, `presym/id.h` identical to the clean build |
| `include/mruby/error.h`, drop the use of `MRB_IVSYM(status)` | builds, `@status` stays in the table (1577 lines) | builds, 1576 lines; back again, 1577 |
| `src/array.c`, add one `MRB_SYM()` | 208 `CC`, 45 `CPP` | unchanged; the run after it does nothing |
| `src/version.c` includes a header, built, then header and include deleted | 2 `CPP`, 0 `CC`; `version.o` is not compiled and its `.d` keeps naming the header | 2 `CPP`, 1 `CC`; `version.o` compiled again, its `.d` clean, the table 1577 lines as before, the run after it does nothing |
| `rm -rf build/host/include/mruby/presym`, right after a clean build | builds; nothing is compiled, the objects of the previous build are linked, on this run and every run after | 2 `GEN` (the headers), 152 `CC` (every object of `host` that includes `id.h`), no `CPP`; `id.h` identical to before; the run after it does nothing |
| `rm build/host/include/mruby/presym/table.h` | the same | 1 `GEN`, 1 `CC` (`symbol.o`) |
| `rake -m -j16 test` | | 0 KO, 0 crash |

Build time, wall / user seconds, two runs each where a range is given:

| change | master | this PR |
|---|---|---|
| touch `include/mruby/value.h` (152 objects) | 3.96 to 4.10 / 27.9 to 28.6 | 4.25 / 30.3 to 30.6 (152 `CC` and 153 `CPP`) |
| the same, serial `rake` | 29.3 / 25.8 | 31.8 / 27.1 |
| touch `mrbgems/mruby-io/include/mruby/io.h` (4 objects) | 1.23 | 1.34 |
| touch `src/array.c` | 1.33 | 1.42 |
| clean build | 17.9 | 17.8 |
| no-op | 0.69 | 0.76 |

The cost is one `-E -P` per source that includes the touched header, about
16 ms each in serial, in the run that recompiles that source's object
anyway.

## Environment

<details>

| | |
|---|---|
| OS | Linux 7.0.0-29-generic, x86_64 |
| Compiler | gcc 13.3.0 |
| binutils | 2.47 |
| Ruby | 4.0.6 |
| rake | 13.3.1 |

The compile line and the presym preprocess line of `src/array.c` in the
`host` build:

```console
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK src/array.c
gcc -E -P -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK -DMRB_PRESYM_SCANNING src/array.c
```

</details>

No C source changes, so `.text` is unaffected in every build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved dependency tracking for generated build outputs.
  - Automatically removes stale or missing dependencies and rebuilds affected outputs.
  - Correctly excludes internal pre-symbol header dependencies from preprocessing results.

- **Build Improvements**
  - Missing generated headers are now recreated automatically, even when the pre-symbol list is unchanged.
  - Only missing headers are regenerated, avoiding unnecessary updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->