### PR TITLE
build: write the archive from the objects of now

### DIFF
--- a/lib/mruby/build/command.rb
+++ b/lib/mruby/build/command.rb
@@ -315,11 +315,18 @@ module MRuby
     def initialize(build)
       super
       @command = ENV['AR'] || 'ar'
-      @archive_options = 'rs "%{outfile}" %{objs}'
+      @archive_options = 'rcs "%{outfile}" %{objs}'
     end
 
+    # The archive is written from the objects of now. `ar r` adds to an
+    # archive that exists and never takes a member out, so an object whose
+    # source was renamed or removed stays in it, ahead of the one that
+    # replaced it, and the linker resolves a symbol both define through the
+    # member it meets first: the old one. Only a build directory that starts
+    # empty avoids that, so the archive that exists is removed here first.
     def run(outfile, objfiles)
       mkdir_p File.dirname(outfile)
+      rm_f outfile
       _pp "AR", outfile.relative_path
       _run archive_options, { :outfile => filename(outfile), :objs => filename(objfiles).map{|f| %Q["#{f}"]}.join(' ') }
     end

--- a/tasks/toolchains/openwrt.rake
+++ b/tasks/toolchains/openwrt.rake
@@ -27,6 +27,6 @@ MRuby::Toolchain.new(:openwrt) do |conf|
 
   conf.archiver do |archiver|
     archiver.command = ENV['TARGET_AR']
-    archiver.archive_options = 'rs "%{outfile}" %{objs}'
+    archiver.archive_options = 'rcs "%{outfile}" %{objs}'
   end
 end

--- a/tasks/toolchains/wasi.rake
+++ b/tasks/toolchains/wasi.rake
@@ -18,5 +18,5 @@ MRuby::Toolchain.new(:wasi) do |conf, params|
   conf.linker.libraries << 'setjmp'
 
   # llvm-ar defaults to the Darwin format on macOS hosts, which overflows on long member paths
-  conf.archiver.archive_options = '--format=gnu rs "%{outfile}" %{objs}'
+  conf.archiver.archive_options = '--format=gnu rcs "%{outfile}" %{objs}'
 end


### PR DESCRIPTION
`ar r` adds to an archive that exists and never takes a member out, so
`libmruby.a` keeps every object it was ever given. An object whose source was
renamed or removed stays in it, ahead of the one that replaced it, and the
linker resolves a symbol both define through the member it meets first: the
old one. `rake` reports the compile, the archive and the links, and every test
passes on the code that was replaced.

Renaming `src/version.c` in a build directory that was built once shows it.
The new object is compiled and archived, and the binary still runs the old
one, on the next `rake` too:

```console
$ git mv src/version.c src/version_r.c   # and change the engine name in it
$ rake
CC    src/version_r.c -> build/host/src/version_r.o
AR    build/host/lib/libmruby.a
LD    build/host/bin/mruby
$ ar t build/host/lib/libmruby.a | grep version
version.o
version_r.o
$ bin/mruby -e 'p RUBY_ENGINE'
"mruby"
```

## Why

`Command::Archiver#run` passes every object of the task to `ar rs` and lets
`ar` merge them into the archive that is there. `r` replaces a member by
name and appends the rest; a member no object on the command line is named
after is left in place. Nothing in the build removes an object whose source
went away either, so the member and the object both outlive the source.

The same rule of `ar r` is what breaks the switch from a config with more
gems to one with fewer in the same directory, `build_config/host-debug.rb`
and then `build_config/default.rb`, both of which build under the name
`host`. Every gem's init object is called `gem_init.o`, so `ar r` replaces
the n-th `gem_init.o` on the command line with the n-th `gem_init.o` member,
the eight members past the end of the shorter list stay, and the link picks
up a `gem_init.o` whose symbol numbers came from the other config:

```console
$ rake MRUBY_CONFIG=host-debug
$ rake test
mrbgems/mruby-symbol-ext/mrblib/symbol.rb:2: uninitialized constant divide::other_excl (NameError)
```

## What this does

The archive is removed before it is written, so that it holds the objects of
the task's prerequisites and nothing else. The task passes every object each
time it runs, and `ar r` writes the archive out again in full whether a
member is new or not, so nothing more is spent. Since the archive is now
created on every run, `c` is added to the options wherever the default `rs`
is written out (`tasks/toolchains/openwrt.rake`, `tasks/toolchains/wasi.rake`),
which keeps `ar` from reporting each creation.

## Verified

`build_config/default.rb`, `rake -m -j16`, `CCACHE_DISABLE=1`, the build
directory built once on `master` before each row.

| change | master | this PR |
|---|---|---|
| `src/version.c` renamed to `src/version_r.c`, `RUBY_ENGINE` changed in it | 1 `CC`, `AR`, 4 `LD`; `bin/mruby` prints `"mruby"`, `version.o` and `version_r.o` both in the archive; the run after it does nothing and prints `"mruby"` | 1 `CC`, `AR`, 4 `LD`; prints `"probe-engine"`, `version_r.o` alone in the archive |
| the rename undone | `version.o` and `version_r.o` stay in the archive | `version.o` alone |
| `rake MRUBY_CONFIG=host-debug`, then `rake test` with `default.rb` | 51 `gem_init.o` members after both; bintest OK 11, KO 59, Crash 24, and `rake` stops there | 51, then 43; bintest OK 111, KO 0; mrbtest OK 2073, KO 0 |
| `rake -m -j16 test` from an empty build directory | | bintest OK 111, mrbtest OK 2073, 0 KO, 0 crash; no `ar: creating` line |

The stale object stays on disk in both columns (`build/host/src/version.o`
here); nothing links it once it is out of the archive.

## Environment

<details>

| | |
|---|---|
| OS | Linux 7.0.0-29-generic, x86_64 |
| Compiler | gcc 13.3.0 |
| binutils | 2.47 (`ar`, `ld`) |
| Ruby | 4.0.6 |
| rake | 13.3.1 |

The archive line of the `host` build, before and after:

```console
ar rs "build/host/lib/libmruby.a" "build/host/src/array.o" ...
ar rcs "build/host/lib/libmruby.a" "build/host/src/array.o" ...
```

</details>

No C source changes, so `.text` is unaffected in every build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved archive creation to ensure outdated or stale entries are removed.
  * Updated OpenWrt and WASI toolchain archives for more reliable results.
  * Prevented existing archive contents from persisting unexpectedly during rebuilds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->