### PR TITLE
build_config: give the cosmopolitan config a name of its own

### DIFF
--- a/build_config/cosmopolitan.rb
+++ b/build_config/cosmopolitan.rb
@@ -15,8 +15,8 @@
 # Usage:
 #   COSMO_ROOT=/path/to/cosmocc rake MRUBY_CONFIG=cosmopolitan
 #
-# The resulting binaries in bin/ will have .com extension and run on all
-# supported platforms without recompilation.
+# The resulting binaries in build/cosmopolitan/bin/ will have .com extension
+# and run on all supported platforms without recompilation.
 
 COSMO_ROOT = ENV['COSMO_ROOT']
 
@@ -37,7 +37,7 @@ unless COSMO_ROOT && File.directory?(COSMO_ROOT)
   raise msg
 end
 
-MRuby::Build.new do |conf|
+MRuby::Build.new('cosmopolitan') do |conf|
   # C compiler
   conf.cc do |cc|
     cc.command = "#{COSMO_ROOT}/bin/cosmocc"


### PR DESCRIPTION
`build_config/cosmopolitan.rb` opens an anonymous `MRuby::Build`, and an unnamed build is called `host` (`lib/mruby/build.rb:114`). The build tree is keyed by that name (`:127`), so `MRUBY_CONFIG=cosmopolitan` aims a cosmocc build at `build/host`, on top of whatever a default build has left there, and never creates a directory of its own. This is the same shape as #7195, #7197, #7199 and #7200, on a config none of them touches.

All of the transcripts below are from today's master (76bf448), gcc 13.3.0 for the default build and cosmocc 14.1.0 for this one, each sequence starting from one clean default build.

### Run after a default build, it does not get as far as a library

The `.flags` record beside each object notices the compiler changed and rebuilds what the rules own, but the Prism objects are built by a `file` task of their own (`mrbgems/mruby-compiler/mrbgem.rake:105`), which the record does not cover. The gcc objects stay, and cosmocc refuses them at the first link:

```console
$ rake -j16                              # exit 0, default build
$ COSMO_ROOT=~/cosmo MRUBY_CONFIG=cosmopolitan rake -j16
build/host: output here was built by another configuration, rebuilding it
  command added: /home/.../cosmo/bin/cosmocc
  command removed: gcc
...
LD    build/host/mrbc/bin/mrbc.com
cosmocc: fatal error: build/host/mrbc/mrbgems/mruby-compiler/lib/diagnostic.o: linker input missing concomitant build/host/mrbc/mrbgems/mruby-compiler/lib/.aarch64/diagnostic.o file
rake aborted!
Tasks: TOP => default => all => gensym => build/host/presym => ... => build/host/mrbc/bin/mrbc.com
```

By then it has preprocessed the core sources with cosmocc, so the next default build finds its own tree foreign and does it over again. It exits 0 and what it links is byte for byte what it linked before, but it preprocesses 198 sources and compiles 165 objects to get there:

```console
$ rake -j16 2>&1 | tee rake.log          # exit 0
build/host/mrbc: output here was built by another configuration, rebuilding it
build/host: output here was built by another configuration, rebuilding it
...
$ grep -c '^CPP ' rake.log
198
$ grep -c '^CC ' rake.log
165
```

### Naming it

The build is named after its config, which is what `build_config/mrbc.rb`, `build_config/clang-asan.rb` and `build_config/gctest.rb` already do. The rename is all this config needs: it carries `mruby-bin-mrbc` itself, so its internal mrbc build is created either way (`:174`).

### Verified

Through the same sequence that broke it. An existing host build is left byte-identical, and the default build afterwards compiles nothing:

```console
$ rake -j16                              # exit 0, default build
$ md5sum build/host/bin/mruby build/host/lib/libmruby.a
7a52da8807433dc3812c042d46e633fd  build/host/bin/mruby
7492434aab8a47f72c1cbd48d1f7d093  build/host/lib/libmruby.a
$ COSMO_ROOT=~/cosmo MRUBY_CONFIG=cosmopolitan rake -j16   # exit 0
...
      Config Name: cosmopolitan
 Output Directory: build/cosmopolitan
$ ls build/
cosmopolitan  host
$ md5sum build/host/bin/mruby build/host/lib/libmruby.a
7a52da8807433dc3812c042d46e633fd  build/host/bin/mruby
7492434aab8a47f72c1cbd48d1f7d093  build/host/lib/libmruby.a
$ rake -j16 | grep -c '^CC '            # exit 0
0
```

The binaries it produces are the APE ones it was producing before:

```console
$ ls build/cosmopolitan/bin/*.com
build/cosmopolitan/bin/mirb.com  build/cosmopolitan/bin/mrbc.com  build/cosmopolitan/bin/mrdb.com
build/cosmopolitan/bin/mruby-strip.com  build/cosmopolitan/bin/mruby.com
$ build/cosmopolitan/bin/mruby.com -e 'p [1,2,3].map { |x| x.to_s }'
["1", "2", "3"]
```

and the command `.github/workflows/build.yml` runs for this config passes from a clean tree, touching nothing else:

```console
$ COSMO_ROOT=~/cosmo rake -m test:run:serial MRUBY_CONFIG=cosmopolitan   # exit 0
$ ls build/
cosmopolitan
```

### One thing changes for whoever runs this config

`bin/` symlinks are installed for a `host?` build (`:482`), so on master this config also pointed `bin/mruby` and the rest at the `.com` files it built. A named build does not, and they are under `build/cosmopolitan/bin/` instead; the header comment that said `bin/` now says so.

### Environment

<details>

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-29-generic x86_64 |
| CPU | AMD Ryzen 9 5950X, 16 cores / 32 threads |
| C compiler (default) | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0 |
| C compiler (cosmopolitan) | cosmocc (GCC) 14.1.0, from https://cosmo.zip/pub/cosmocc/cosmocc.zip |
| binutils | GNU ld (GNU Binutils) 2.47.20260726 |
| CRuby running rake | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM |

The line each build gives `src/string.c`, read off the `.flags` record beside the object, the `-I` list and `-o` dropped. Neither build calls `enable_debug`; the default build takes the gcc toolchain's own `-g -O3`, and this config sets `-Os -fno-omit-frame-pointer` itself:

```console
# default
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK -MMD -c src/string.c

# cosmopolitan
cosmocc -Os -fno-omit-frame-pointer -D"HAVE_MRUBY_REGEXP_GEM" -D"MRB_USE_SET" -D"HAVE_MRUBY_IO_GEM" -D"MRB_USE_RATIONAL" -D"MRB_USE_COMPLEX" -D"MRB_USE_BIGINT" -D"MRB_USE_DEBUG_HOOK" -c src/string.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Cosmopolitan build documentation to reference binaries in the correct build output directory.
  * Clarified the name of the Cosmopolitan build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->