### PR TITLE
build_config: give the msvc build a name of its own

### DIFF
--- a/build_config/ci/msvc.rb
+++ b/build_config/ci/msvc.rb
@@ -6,7 +6,7 @@ def setup_option(conf)
   conf.linker.flags << "/DEBUG:NONE" unless ENV['LDFLAGS']
 end
 
-MRuby::Build.new do |conf|
+MRuby::Build.new('msvc') do |conf|
   conf.toolchain :visualcpp
 
   # include all core GEMs


### PR DESCRIPTION
`build_config/ci/msvc.rb` opens an anonymous `MRuby::Build`, and an unnamed build is called `host` (`lib/mruby/build.rb:114`). The build tree is keyed by that name (`:127`), so `MRUBY_CONFIG=ci/msvc` aims a full-core build with `MRB_GC_FIXED_ARENA` at `build/host`, the directory a default build on the same machine uses. The Windows-VC job never sees that, since it builds a fresh checkout, but a developer who points `MRUBY_CONFIG` at this config on a tree the default config has built shares one directory between two gem sets, which is the shape #7195, #7197, #7199 and #7200 took out of the other configs that had it.

14d6e42 named the bintest build in `ci/gcc-clang` and left this one alone, on the ground that a single build has no sibling for a name to tell it apart from. That was a reason about telling builds apart; the build directory is decided by the name whether or not there is a sibling, and that is the reason here.

### Naming it

The build is named after its config, as `build_config/mrbc.rb`, `clang-asan.rb` and `cosmopolitan.rb` (#7245) are. Nothing in the file needs the build to be called `host`. It is an `MRuby::Build`, and it pulls `mruby-bin-mrbc` in through full-core, so it lends no mrbc to any cross target and creates its own internal one either way (`:174`). The name reaches three other places: `install_prefix` (`:625`), the `bin/*.bat` wrappers that `define_installer_if_needed` writes only when `host?` answers true (`:461`, `:482`), and the mrbtest that `rake clean` removes from `MRUBY_ROOT/bin` (`tasks/test.rake:82`). The job runs `rake -m test:run:serial` (`.github/workflows/build.yml:89`), which installs nothing and cleans nothing, so none of the three fires. `enable_bintest` has not required the name `host` since fd113da, and `test/bintest.rb` resolves every binary it runs from `BUILD_DIR` rather than from `bin/`; the `bintest` build in `ci/gcc-clang` is this same shape under a name, in the same workflow.

### Verified

There is no MSVC here to run the job with, so the Windows-VC job on this PR is the run. What can be checked on Linux is that the config still loads and that the tree it names is its own:

```console
$ MRUBY_CONFIG=ci/msvc rake -T | grep amalgam
rake amalgam    # Generate amalgamated mruby.h and mruby.c in .../build/msvc/amalgam
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build Configuration**
  * Updated the MSVC build target naming for clearer build identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->