### PR TITLE
build_config: drop the host build from the IntelEdison config

### DIFF
--- a/build_config/IntelEdison.rb
+++ b/build_config/IntelEdison.rb
@@ -2,17 +2,6 @@
 # Get SDK from here: https://software.intel.com/en-us/iot/hardware/edison/downloads
 # REMEMBER to check and update the SDK root in the constant POKY_EDISON_PATH
 
-MRuby::Build.new do |conf|
-  toolchain :gcc
-  conf.gembox 'default'
-  conf.cc.defines = %w(MRB_USE_READLINE)
-  conf.gembox 'default'
-
-  #lightweight regular expression
-  conf.gem :github => "pbosetti/mruby-hs-regexp", :branch => "master"
-
-end
-
 # Define cross build settings
 MRuby::CrossBuild.new('core2-32-poky-linux') do |conf|
   toolchain :gcc


### PR DESCRIPTION
`build_config/IntelEdison.rb` opens an anonymous `MRuby::Build` ahead of its `CrossBuild`, and an unnamed build is called `host` (`lib/mruby/build.rb:114`). The build tree is keyed by that name (`:127`), so `MRUBY_CONFIG=IntelEdison` aims a build carrying `MRB_USE_READLINE` and mruby-hs-regexp at `build/host`, on top of whatever a default build has left there. This is the same shape as #7195, #7197, #7199 and #7200, on a config none of them touches, and the last of the cross configs to have it.

### Where the block comes from

It dates from a27426a (2016), when a cross build took its mrbc from `MRuby.targets['host']` and nowhere else, so every cross config declared a host build to have one. 1520c97 (2020) made that unnecessary and deleted the block from the eight other cross configs of the time (ArduinoDue, IntelGalileo, RX630, three android configs, chipKITMax32, dreamcast_shelf); this one, the only one with a comment header above the block rather than the block at line 1, kept it. Nothing here has needed it since: the cross build carries `default.gembox`, and with `mruby-bin-mrbc` in it, `CrossBuild#bind_mrbc_host` generates an mrbc build of its own where the config declares no host (`:712`). Every other cross config in `build_config/` is written that way.

So rather than naming a host build that has nothing left to do, this deletes it, as 1520c97 did.

### What the block does on master

Run from a clean tree, the config does not get past it. The host build defines `MRB_USE_READLINE`, which mirb has not taken since 527018c, and aborts before the cross target is reached:

```console
$ MRUBY_CONFIG=IntelEdison rake -j16
...
CPP   mrbgems/mruby-bin-mirb/tools/mirb/mirb_completion.c -> build/host/mrbgems/mruby-bin-mirb/tools/mirb/mirb_completion.pi
mrbgems/mruby-bin-mirb/tools/mirb/mirb_completion.c:45:10: error: #include expects "FILENAME" or <FILENAME>
   45 | #include MRB_READLINE_HEADER
      |          ^~~~~~~~~~~~~~~~~~~
rake aborted!
$ ls build/
core2-32-poky-linux  host  repos
```

### Verified

Without it, the same run reaches the cross target and stops where a machine without the Edison SDK has to stop, on the cross compiler, and `build/host` is not created:

```console
$ MRUBY_CONFIG=IntelEdison rake -j16
GIT   https://github.com/pbosetti/mruby-hs-regexp.git -> build/repos/core2-32-poky-linux/mruby-hs-regexp
CPP   mrbgems/mruby-bigint/core/bigint.c -> build/core2-32-poky-linux/mrbgems/mruby-bigint/core/bigint.pi
sh: 1: /opt/poky-edison/1.7.2/sysroots/i386-pokysdk-darwin/usr/bin/i586-poky-linux/i586-poky-linux-gcc: not found
rake aborted!
$ ls build/
core2-32-poky-linux  repos
```

The mrbc the cross target compiles its Ruby with is the generated one, built with the host gcc into the directory that mechanism names:

```console
$ MRUBY_CONFIG=IntelEdison rake -j16 "$PWD/build/mrbc/default/bin/mrbc"   # exit 0
...
LD    build/mrbc/default/bin/mrbc
$ ls build/
core2-32-poky-linux  mrbc  repos
```

The cross target itself still carries `MRB_USE_READLINE`, and will fail on the same mirb line once the SDK is present; that is the target's own define, and out of the scope of removing a host build that duplicated it.

### Environment

<details>

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-29-generic x86_64 |
| CPU | AMD Ryzen 9 5950X, 16 cores / 32 threads |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0 |
| binutils | GNU ld (GNU Binutils) 2.47.20260726 |
| CRuby running rake | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM |

The one build that compiles here is the generated `mrbc/default`; the line it gives `mrbgems/mruby-compiler/src/codegen.c`, read off the `.flags` record beside the object, the `-I` list and `-o` dropped:

```console
# mrbc/default
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_GEMS -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -MMD -c mrbgems/mruby-compiler/src/codegen.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the standalone default GCC build configuration.
  * Retained support for Intel Edison cross-builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->