### PR TITLE
build: build the Prism objects through the rules

### DIFF
--- a/lib/mruby/build/command.rb
+++ b/lib/mruby/build/command.rb
@@ -118,7 +118,18 @@ module MRuby
       File.write(flags_file(outfile), flags_record(opts, flags))
     end
 
-    def define_rules(build_dir, source_dir='', out_ext=build.exts.object)
+    # Define the rules that build the outputs under +build_dir+ from the
+    # sources under +source_dir+, and from the generated sources that sit
+    # beside the outputs.
+    #
+    # The rules compile with this compiler, or with the one the block returns
+    # when a block is given. The block is called when a rule is resolved, not
+    # here, so a compiler it derives from this one sees everything the build
+    # adds after the rules are defined: a gem's mrbgem.rake body runs before
+    # the gem's version define, the include paths of the gems it depends on
+    # and the presym include path reach the gem's compilers.
+    def define_rules(build_dir, source_dir='', out_ext=build.exts.object, &compiler_of)
+      compiler_of ||= proc { self }
       gemrake = File.join(source_dir, "mrbgem.rake")
       rakedep = File.exist?(gemrake) ? [ gemrake ] : []
 
@@ -138,9 +149,9 @@ module MRuby
           source_of = proc { |file| file.sub(generated_file_matcher, "#{dir}/\\1#{ext}") }
           rule generated_file_matcher => [
             source_of,
-            proc { |file| get_dependencies(file, source_of.call(file)) + rakedep }
+            proc { |file| compiler_of.call.get_dependencies(file, source_of.call(file)) + rakedep }
           ] do |t|
-            run t.name, t.prerequisites.first
+            compiler_of.call.run t.name, t.prerequisites.first
           end
         end
       end
@@ -152,8 +163,11 @@ module MRuby
       nil
     end
 
-    private
+    protected
 
+    # The prerequisites of an output besides its source: the config file and
+    # the headers the last compile of it read. Protected, not private, so the
+    # rules one compiler defines can ask the compiler they run.
     #
     # === Example of +.d+ file
     #
@@ -220,6 +234,8 @@ module MRuby
       end
       deps.concat(header_deps)
     end
+
+    private
 
     #
     # === Example of +.flags+ file

--- a/mrbgems/mruby-compiler/mrbgem.rake
+++ b/mrbgems/mruby-compiler/mrbgem.rake
@@ -97,19 +97,25 @@ MRuby::Gem::Specification.new('mruby-compiler') do |spec|
   # Route Prism's allocator to libc there too: the C++ core exports mrb_malloc
   # with C++ linkage, which the C-compiled Prism objects could not resolve, and
   # Prism's parse memory is transient and freed through the same libc path.
-  # The clone happens inside the file task (not here) so cc.flags is already
-  # fully populated with the build's generated-header include flags.
-  Dir.glob("#{prism_dir}/src/**/*.c").map do |src|
-    obj = objfile(src.pathmap("#{build_dir}/lib/%n"))
-    objs << obj
-    file obj => [src] do |f|
-      prism_cc = cc
-      if build.cxx_abi_enabled?
-        prism_cc = cc.clone
-        prism_cc.flags = cc.flags.flatten - [cc.cxx_compile_flag].flatten
-        prism_cc.defines = cc.defines + %w(MRC_ALLOC_LIBC)
+  # The compiler is derived when a rule is first resolved (not here) so cc is
+  # already fully populated with the build's generated-header include flags.
+  #
+  # The objects go through the rules like every other object of the gem, so
+  # that a change to a Prism header or to the compile flags rebuilds them.
+  prism_src_dir = "#{prism_dir}/src"
+  prism_obj_dir = "#{build_dir}/lib"
+  prism_cc = nil
+  cc.define_rules(prism_obj_dir, prism_src_dir) do
+    prism_cc ||= if build.cxx_abi_enabled?
+      cc.clone.tap do |c|
+        c.flags = cc.flags.flatten - [cc.cxx_compile_flag].flatten
+        c.defines = cc.defines + %w(MRC_ALLOC_LIBC)
       end
-      prism_cc.run f.name, f.prerequisites.first
+    else
+      cc
     end
+  end
+  Dir.glob("#{prism_src_dir}/**/*.c").each do |src|
+    objs << objfile(src.relative_path_from(prism_src_dir).pathmap("#{prism_obj_dir}/%X"))
   end
 end


### PR DESCRIPTION
mruby-compiler compiles the Prism sources with a `file` task of its own
instead of the rules every other object of a gem is built by. A `file` task
has the prerequisites it is written with, here the source alone, so nothing
reads the `.d` a compile of a Prism object writes and nothing compares the
flags the object was compiled with against the flags of now. The 21 Prism
objects of a build (42 with the `mrbc` build) are the only objects outside
both, and they stay as they are through a change to a Prism header and
through a change to the compile flags.

The flags case is visible from the outside. `PRISM_DEPTH_MAXIMUM` is the
nesting cap Prism refuses input at, and mruby-compiler's mrbgem.rake sets it
to 256 unless the config sets it first. Setting it in the config of a build
directory that was built once leaves the cap where it was:

```console
$ rake                                   # built once, cap 256
$ echo 'conf.cc.defines << "PRISM_DEPTH_MAXIMUM=64"' # added to the config
$ rake                                   # 165 CC, none of them Prism
$ bin/mruby -e "$(printf '[%.0s' {1..100})1$(printf ']%.0s' {1..100}); p 1"
1
$ grep -o 'PRISM_DEPTH_MAXIMUM=[0-9]*' build/host/mrbgems/mruby-compiler/lib/prism.o.flags
PRISM_DEPTH_MAXIMUM=256
```

## Why

`Dir.glob` over the Prism sources registers each object with
`file obj => [src] do prism_cc.run ... end`. Rake takes the task as it is
written, so the object is up to date whenever it is newer than its `.c`;
the `-MMD` output beside it is written and never read, and
`Compiler#get_dependencies`, which reads the `.d` and discards an output
whose recorded flags differ (#7236), runs from the rules only. Everything
else a gem builds, its own sources and its generated `gem_init.c`, goes
through `Compiler#define_rules`.

The `file` task was where the compiler for the C++ ABI build was made: a
clone of the gem's `cc` with the C++ compile flag stripped and
`MRC_ALLOC_LIBC` added, cloned inside the action because `Compiler#clone`
is a deep copy and the mrbgem.rake body runs before the gem's version
define, the include paths of the gems it depends on and the presym include
path reach `cc`. A rule defined in the body would have had to name its
compiler in the body.

## What this does

- `Compiler#define_rules` takes a block that names the compiler to run
  with. The block is called when a rule is resolved, not when the rules
  are defined, so a compiler it derives from the receiver sees everything
  the build added to the receiver since. Without a block the rules run
  with the receiver, as before. `get_dependencies` becomes protected so
  the rules one compiler defines can ask the compiler they run.
- mruby-compiler registers the Prism objects with `define_rules` and
  derives the C++ ABI compiler in the block, once. The objects mirror the
  Prism source tree (`lib/util/pm_buffer.o` for `src/util/pm_buffer.c`),
  since a rule maps an output to its source by path; the `file` task
  flattened them into `lib/`.

The compile lines do not change: every Prism object is byte-identical to
the one `master` builds at the same path, in the default and in the C++
ABI build, and so is `bin/mrbc`; `bin/mruby` differs only in the debug
line strings that spell the build directory.

## Verified

`rake -m -j16`, `CCACHE_DISABLE=1`, gcc; the build directory built once on
`master` (0122b457d) before each row, and the run after each row does
nothing in the "this PR" column.

| change | master | this PR |
|---|---|---|
| `touch lib/prism/include/prism/defines.h` | 70 `CC`: the compiler glue and the regenerated `gem_init.c` / `mrblib.c`, 0 of the 42 Prism objects | 112 `CC`: the same 70 and the 42 Prism objects |
| `conf.cc.defines << "PRISM_DEPTH_MAXIMUM=64"` in the config | 165 `CC`, 0 Prism; `bin/mruby` accepts the expression nested 100 deep, `prism.o.flags` says 256 | 207 `CC`, 42 Prism; `bin/mruby` refuses it with `nesting too deep`, `prism.o.flags` says 64 |
| `conf.cc.defines << "PROBE_FLAG"` in the config, C++ ABI build (`enable_cxx_abi`) | 165 `CC`, 0 Prism | 207 `CC`, 42 Prism; the Prism record has `-DMRC_ALLOC_LIBC` and the presym include path and no `-x c++`, the glue record has `-x c++` |
| `rake -m -j16 test` from an empty build directory, `default.rb` with `enable_bintest` | bintest OK 111, mrbtest OK 2073 | bintest OK 111, mrbtest OK 2073, 0 KO, 0 crash |
| the same, C++ ABI build (`default` gembox, `enable_cxx_abi`) | mrbtest OK 2073 | mrbtest OK 2073, 0 KO, 0 crash |

The 207 is 208 objects less `build/host/mrbgems/gem_init.o`, whose `file`
task in `tasks/mrbgems.rake` has no action and takes the rule's at execute
time, after Rake has decided it is up to date; that one is outside this PR.

## Environment

<details>

| | |
|---|---|
| OS | Linux 7.0.0-29-generic, x86_64 |
| Compiler | gcc 13.3.0 |
| binutils | 2.47 |
| Ruby | 4.0.6 |
| rake | 13.3.1 |

The compile line of `lib/prism.o` in the default build, unchanged by this
PR (the record beside the object; `%{flags}` is the `flags:` line):

```console
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK -I"include" -I"mrbgems/mruby-compiler/include" -I"mrbgems/mruby-compiler/lib/prism/include" -I"mrbgems/mruby-compiler/include" -I"build/host/include" -o "build/host/mrbgems/mruby-compiler/lib/prism.o" "mrbgems/mruby-compiler/lib/prism/src/prism.c"
```

The same object in the C++ ABI build, next to the glue that is built as
C++:

```console
gcc -MMD -c -g -O3 -Wall -Wundef -Wwrite-strings -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRC_ALLOC_LIBC -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI ... -I"build/host-cxx/include" -o "build/host-cxx/mrbgems/mruby-compiler/lib/prism.o" "mrbgems/mruby-compiler/lib/prism/src/prism.c"
gcc -MMD -c -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI ... -I"build/host-cxx/include" -o "build/host-cxx/mrbgems/mruby-compiler/src/ccontext.o" "mrbgems/mruby-compiler/src/ccontext.c"
```

</details>

No C source changes and the compile lines are the same, so `.text` is
unaffected in every build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Build Improvements**
  - Improved compilation of Prism C sources with more consistent compiler settings.
  - Enhanced dependency tracking for Prism source files and headers.
  - Streamlined build rule handling to improve reliability across compiler configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->