### PR TITLE
mruby-bin-mirb: drop the readline and linenoise completion adapters

### DIFF
--- a/build_config/IntelEdison.rb
+++ b/build_config/IntelEdison.rb
@@ -22,7 +22,6 @@ MRuby::CrossBuild.new('core2-32-poky-linux') do |conf|
     cc.flags << %w(-O2 -pipe -g -feliminate-unused-debug-types)
     cc.flags << "--sysroot=#{POKY_EDISON_SYSROOT}"
     cc.compile_options = %Q[%{flags} -o "%{outfile}" -c "%{infile}"]
-    cc.defines = %w(MRB_USE_READLINE)
   end
 
   conf.cxx do |cxx|

--- a/mrbgems/mruby-bin-mirb/README.md
+++ b/mrbgems/mruby-bin-mirb/README.md
@@ -13,7 +13,9 @@ mirb-prism (mruby interactive) is an interactive Ruby shell for mruby, using the
 
 ## Tab Completion
 
-mirb supports context-aware tab completion when built with a readline library.
+mirb supports context-aware tab completion in its built-in multi-line editor.
+The editor is used when standard input is a terminal; no external line-editing
+library is required or consulted.
 
 ### Supported Completions
 
@@ -53,30 +55,11 @@ mirb supports context-aware tab completion when built with a readline library.
   class
   ```
 
-### Readline Library Support
+### Behavior
 
-Tab completion works with:
-
-- **GNU readline** (default on Linux)
-- **libedit** (default on macOS/BSD)
-- **linenoise** (lightweight alternative)
-
-### Configuration
-
-The readline library can be configured via the `MRUBY_MIRB_READLINE` environment variable:
-
-```bash
-# Auto-detect (default)
-rake
-
-# Force specific library
-MRUBY_MIRB_READLINE=readline rake    # GNU readline
-MRUBY_MIRB_READLINE=libedit rake     # libedit
-MRUBY_MIRB_READLINE=linenoise rake   # linenoise
-
-# Disable readline (plain input mode)
-MRUBY_MIRB_READLINE=none rake
-```
+- A single match is inserted in place of the typed prefix
+- Multiple matches sharing a longer common prefix extend the input to that prefix
+- Otherwise the candidates are listed below the input line
 
 ### Notes
 

--- a/mrbgems/mruby-bin-mirb/tools/mirb/mirb_completion.c
+++ b/mrbgems/mruby-bin-mirb/tools/mirb/mirb_completion.c
@@ -40,16 +40,6 @@ strndup(const char *s, size_t n)
 }
 #endif
 
-#ifdef MRB_USE_READLINE
-#ifndef MRB_USE_LINENOISE
-#include MRB_READLINE_HEADER
-#endif
-#endif
-
-#ifdef MRB_USE_LINENOISE
-#include <linenoise.h>
-#endif
-
 /* ============================================================
  * Core Completion Engine
  * ============================================================ */
@@ -84,7 +74,6 @@ mirb_completion_free(mirb_completion_ctx *ctx)
 
   ctx->completion_count = 0;
   ctx->completion_alloc = 0;
-  ctx->current_index = 0;
 }
 
 /* ============================================================
@@ -585,117 +574,6 @@ mirb_cleanup_completion(void)
     g_ctx = NULL;
   }
 }
-
-/* ============================================================
- * Readline/Libedit Adapter
- * ============================================================ */
-
-#ifdef MRB_USE_READLINE
-#ifndef MRB_USE_LINENOISE
-
-static char *
-mirb_readline_generator(const char *text, int state)
-{
-  (void)text;  /* text is already in match_prefix */
-
-  /* state == 0: first call, generate completions */
-  if (state == 0) {
-    mirb_completion_free(g_ctx);
-
-    /* Generate completions based on full line */
-    mirb_generate_completions(g_ctx, rl_line_buffer, rl_point);
-
-    g_ctx->current_index = 0;
-  }
-
-  /* Return next completion or NULL when done */
-  if (g_ctx->current_index < g_ctx->completion_count) {
-    char *completion = g_ctx->completions[g_ctx->current_index];
-    g_ctx->current_index++;
-
-    /* readline will free this, so duplicate */
-    return strdup(completion);
-  }
-
-  return NULL;
-}
-
-static char **
-mirb_readline_completion(const char *text, int start, int end)
-{
-  (void)start;
-  (void)end;
-
-  /* Prevent default filename completion */
-  rl_attempted_completion_over = 1;
-
-  /* Use our generator */
-  return rl_completion_matches(text, mirb_readline_generator);
-}
-
-void
-mirb_setup_readline_completion(mrb_state *mrb, mrb_ccontext *cxt)
-{
-  if (!init_completion_ctx(mrb, cxt)) return;
-
-  /* Set completion function */
-  rl_attempted_completion_function = mirb_readline_completion;
-
-  /* Configure readline behavior - include . so "obj.method" are separate words */
-  rl_basic_word_break_characters = " \t\n\"\\'`@$><=;|&{(.";
-  rl_completer_word_break_characters = " \t\n\"\\'`@$><=;|&{(.";
-}
-
-#endif
-#endif
-
-/* ============================================================
- * Linenoise Adapter
- * ============================================================ */
-
-#ifdef MRB_USE_LINENOISE
-
-static void
-mirb_linenoise_completion(const char *buf, linenoiseCompletions *lc)
-{
-  int cursor_pos = (int)strlen(buf);  /* linenoise completes at end */
-  int i, prefix_start;
-  char completion_line[1024];
-
-  /* Clear previous completions */
-  mirb_completion_free(g_ctx);
-
-  /* Generate completions */
-  mirb_generate_completions(g_ctx, buf, cursor_pos);
-
-  /* Need to build full line with completion */
-  prefix_start = cursor_pos - g_ctx->prefix_len;
-  if (prefix_start < 0) return;
-
-  /* Add each completion to linenoise */
-  for (i = 0; i < g_ctx->completion_count; i++) {
-    size_t len = strlen(g_ctx->completions[i]);
-
-    if ((size_t)prefix_start + len + 1 > sizeof(completion_line)) continue;
-
-    /* Copy line up to prefix, then the completion */
-    memcpy(completion_line, buf, prefix_start);
-    memcpy(completion_line + prefix_start, g_ctx->completions[i], len+1);
-
-    linenoiseAddCompletion(lc, completion_line);
-  }
-}
-
-void
-mirb_setup_linenoise_completion(mrb_state *mrb, mrb_ccontext *cxt)
-{
-  if (!init_completion_ctx(mrb, cxt)) return;
-
-  /* Set completion callback */
-  linenoiseSetCompletionCallback(mirb_linenoise_completion);
-}
-
-#endif
 
 /* ============================================================
  * Custom Editor Adapter

--- a/mrbgems/mruby-bin-mirb/tools/mirb/mirb_completion.h
+++ b/mrbgems/mruby-bin-mirb/tools/mirb/mirb_completion.h
@@ -17,7 +17,7 @@
  *
  * Architecture:
  * - Core engine is library-agnostic
- * - Adapters for readline/libedit and linenoise
+ * - Adapter for the built-in multi-line editor
  * - Context detection based on input line analysis
  * - Safe evaluation of receiver expressions
  *
@@ -58,7 +58,6 @@ typedef struct mirb_completion_ctx {
   char **completions;       /* Array of completion strings */
   int completion_count;     /* Number of completions */
   int completion_alloc;     /* Allocated size */
-  int current_index;        /* For generator pattern (readline) */
 } mirb_completion_ctx;
 
 /* Core Completion Engine Interface */
@@ -100,20 +99,8 @@ mrb_value mirb_eval_receiver(mrb_state *mrb, const char *receiver_expr, mrb_ccon
 /* Check if in file completion context */
 mrb_bool mirb_in_file_context(const char *line, int quote_pos);
 
-/* Cleanup completion context (shared by all adapters) */
+/* Cleanup completion context */
 void mirb_cleanup_completion(void);
-
-/* Readline/Libedit adapter setup */
-#ifdef MRB_USE_READLINE
-#ifndef MRB_USE_LINENOISE
-void mirb_setup_readline_completion(mrb_state *mrb, mrb_ccontext *cxt);
-#endif
-#endif
-
-/* Linenoise adapter setup */
-#ifdef MRB_USE_LINENOISE
-void mirb_setup_linenoise_completion(mrb_state *mrb, mrb_ccontext *cxt);
-#endif
 
 /* Custom editor adapter */
 void mirb_setup_editor_completion(mrb_state *mrb, mrb_ccontext *cxt);


### PR DESCRIPTION
527018c replaced readline, libedit and linenoise in mirb with the built-in multi-line editor and took their detection out of `mrbgem.rake`. That rake file was also what defined `MRB_READLINE_HEADER` next to `MRB_USE_READLINE`, so a config that still defines `MRB_USE_READLINE` on its own, as the IntelEdison cross target does (`build_config/IntelEdison.rb:25`), now reaches an `#include` with nothing to include:

```console
$ MRUBY_CONFIG=IntelEdison rake -j16
...
CPP   mrbgems/mruby-bin-mirb/tools/mirb/mirb_completion.c -> build/host/mrbgems/mruby-bin-mirb/tools/mirb/mirb_completion.pi
mrbgems/mruby-bin-mirb/tools/mirb/mirb_completion.c:45:10: error: #include expects "FILENAME" or <FILENAME>
   45 | #include MRB_READLINE_HEADER
      |          ^~~~~~~~~~~~~~~~~~~
rake aborted!
```

### What is left in the source

Three guarded blocks survived 527018c, none of them reachable:

| Where | What |
| --- | --- |
| `mirb_completion.c:43-51` | `#ifdef MRB_USE_READLINE` → `#include MRB_READLINE_HEADER`, `#ifdef MRB_USE_LINENOISE` → `#include <linenoise.h>` |
| `mirb_completion.c:593-698` | the readline/libedit adapter (`mirb_readline_generator`, `mirb_readline_completion`, `mirb_setup_readline_completion`) and the linenoise adapter (`mirb_linenoise_completion`, `mirb_setup_linenoise_completion`) |
| `mirb_completion.h:107-116` | the declarations of the two setup functions |

`mirb.c` only calls `mirb_setup_editor_completion` and `mirb_get_completions`; neither setup function has a caller. The first commit removes the three blocks together with the `current_index` field that only the readline generator used, so defining `MRB_USE_READLINE` or `MRB_USE_LINENOISE` is a no-op, which is what 527018c's message already says ("readline integration has been completely removed").

The second commit brings `mrbgems/mruby-bin-mirb/README.md` up to date: it still said completion needs "a readline library", listed the three backends, and documented a `MRUBY_MIRB_READLINE` environment variable that nothing reads. The Tab Completion section now describes the built-in editor.

The third commit removes the define from `IntelEdison.rb:25` itself. It selected mirb's readline backend when the config was written; with the last guarded block gone, `cc.defines = %w(MRB_USE_READLINE)` only replaces the toolchain's default define list with a stale name. With the config loaded, `MRuby.targets['core2-32-poky-linux'].cc.defines` is `[]` where it was `["MRB_USE_READLINE"]`.

### Verified

Three builds of the same config (`default.gembox`, `enable_debug`, `enable_test`) into separate build directories: master, this branch, and this branch with `conf.cc.defines << 'MRB_USE_READLINE'` added. The third one fails on master at the line above and builds here; `mirb_completion.o.flags` confirms `-DMRB_USE_READLINE` reached the compiler.

`size` on the results, master versus branch and branch with the define:

| | `mirb` text | `mirb_completion.o` text |
| --- | --- | --- |
| master | 2585455 | 6540 |
| branch | 2585439 | 6529 |
| branch + `MRB_USE_READLINE` | 2585439 | 6529 |

The 11 bytes are the `ctx->current_index = 0` store in `mirb_completion_free` (this config is `-O0`); the guarded blocks were never compiled without the define, so nothing else moves. Master and the branch with the define are not comparable, since master does not build.

Tab completion was driven through a pty on all three binaries with the same key sequence per case (constant `Stri`, method `String.ne`, listing `String.n`, keyword `whi`, global `$std`, local `my_var`), and the three terminal transcripts are byte-identical (`md5sum` b80fb4d6…). Excerpts:

```console
1> String          # Stri<Tab>
1> String.new      # String.ne<Tab>
1> String.n
new  name  nil?    # String.n<Tab>
1> while           # whi<Tab>
1> $std
$stdin  $stderr  $stdout
1> my_var          # my_<Tab> after my_var = 1
```

`rake -m test` on the branch build: KO 0, Crash 0.

### Environment

<details>

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-29-generic x86_64 |
| CPU | AMD Ryzen 9 5950X, 16 cores / 32 threads |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0 |
| binutils | GNU ld (GNU Binutils) 2.47.20260726 |
| CRuby running rake | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM |

The line each build gives `mrbgems/mruby-bin-mirb/tools/mirb/mirb_completion.c`, read off the `.flags` record beside the object, the `-I` list and `-o` dropped:

```console
# master, branch
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRBGEM_MRUBY_BIN_MIRB_VERSION=0.0.0 -DMRB_DEBUG -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK -MMD -c mrbgems/mruby-bin-mirb/tools/mirb/mirb_completion.c
# branch + MRB_USE_READLINE
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_USE_READLINE -DMRBGEM_MRUBY_BIN_MIRB_VERSION=0.0.0 -DMRB_DEBUG -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK -MMD -c mrbgems/mruby-bin-mirb/tools/mirb/mirb_completion.c
```

</details>
