### PR TITLE
presym: skip the table of a build without libmruby

### DIFF
--- a/tasks/presym.rake
+++ b/tasks/presym.rake
@@ -16,7 +16,19 @@ MRuby.each_target do |build|
   build.gems.each{|gem| gem.compilers.each{|c| c.include_paths << include_dir}}
 end
 
+# `all` waits on `gensym` whether or not a build below adds a table to it.
+task :gensym
+
 MRuby.each_target do |build|
+  # `id.h` numbers the symbols in the order `table.h` lists them, and
+  # `symbol.c` compiles `table.h` in: the two headers are one artifact, and
+  # libmruby is its reader. A build with `disable_libmruby` builds no
+  # `symbol.c`; it builds `mrbc` from the compiler gem's objects, which are
+  # compiled without `mruby.h` (`MRB_NO_GEMS` keeps `MRC_TARGET_MRUBY` off), so
+  # a table written for it has no reader, and preprocessing every core source
+  # to write it is work for nothing.
+  next unless build.libmruby_enabled?
+
   presym = build.presym
 
   prereqs = {}
@@ -24,11 +36,6 @@ MRuby.each_target do |build|
   build_dir = "#{build.build_dir}/"
   mrbc_build_dir = "#{build.mrbc_build.build_dir}/" if build.mrbc_build
   build.products.each{|product| all_prerequisites.(product, prereqs)}
-  # The core objects are reachable through libmruby.a, but not in a build with
-  # disable_libmruby, where nothing links them and their symbols would drop out
-  # of the table. Seed the scan from the object list so both cases behave the
-  # same. Only the preprocessed files are built from these, not the objects.
-  build.libmruby_core_objs.flatten.each{|obj| prereqs[obj] = true}
   prereqs.each_key do |prereq|
     next unless File.extname(prereq) == build.exts.object
     next unless prereq.start_with?(build_dir)


### PR DESCRIPTION
A build with `disable_libmruby` (the `mrbc` build every host build creates
under `build/<name>/mrbc`, the one a cross build generates, and
`build_config/mrbc.rb`) goes through the whole presym pipeline: 45 core
sources are preprocessed into `.pi` files, scanned, and written out as
`presym`, `id.h` and `table.h`. Nothing there reads them. Of the 34 objects
under `build/host/mrbc`, not one `.d` names `presym/id.h`:

```console
$ rake                                                   # 208 CC, 198 CPP, 55 GEN
$ find build/host/mrbc -name '*.o' | wc -l
34
$ find build/host/mrbc -name '*.pi' | wc -l
45
$ grep -l presym/id.h $(find build/host/mrbc -name '*.d') | wc -l
0
$ wc -l build/host/mrbc/presym
284 build/host/mrbc/presym
```

## Why

`id.h` numbers the symbols in the order `table.h` lists them, and
`symbol.c` compiles `table.h` in: the two headers are one artifact, and
libmruby is its reader. A build without libmruby has no `symbol.c`. It
builds `mrbc` from the compiler gem's objects, and those are compiled
without `mruby.h`: `MRB_NO_GEMS` is on the command line of such a build,
so `mruby-compiler` leaves `MRC_TARGET_MRUBY` off and `mrc_common.h` does
not include it. The table `mrbc` itself works from is the static
`mrc_presym.inc` of the gem, and the `MRB_SYM()` names it writes into
`mrblib.c` and every `gem_init.c` are resolved by the `id.h` of the build
that compiles those files, not by one of its own.

The core objects were seeded into the scan by hand (2918d6703) so that a
build without `libmruby.a` would still reach them, and the table of the
`mrbc` build kept its 284 entries through that change. With such a build
out of the scan, `libmruby.a` reaches the core objects wherever the scan
runs, and the seed goes with the case it was for.

## What this does

- `tasks/presym.rake` skips a build without libmruby: no `.pi`, no scan,
  no `presym`, `id.h` or `table.h` for it. The scan of the other builds is
  seeded from their products alone.
- `gensym` is declared up front, so that `all` finds it in a config whose
  every build is one without libmruby (`build_config/mrbc.rb`).

The compile lines do not change: `build/<name>/mrbc/include` stays on the
include path of the `mrbc` build, so an existing build directory is not
recompiled by the switch.

## Verified

`rake -m -j16`, `CCACHE_DISABLE=1`, gcc; `default` gembox with
`enable_bintest` and `enable_test` unless a config is named. Where the
two columns are compared byte for byte, both were built from the same
source tree path into the same build directory path.

| change | master | this PR |
|---|---|---|
| clean build | 208 `CC`, 198 `CPP`, 55 `GEN`; `build/host/mrbc`: 34 `.o`, 45 `.pi`, `presym` with 284 entries, `id.h`, `table.h` | 208 `CC`, 153 `CPP`, 52 `GEN`; `build/host/mrbc`: 34 `.o`, no `.pi`, no `presym`, no `include/` |
| the 34 objects and `bin/mrbc` of the `mrbc` build; `presym`, `id.h`, `bin/mrbc`, `bin/mruby`, `libmruby.a` of the host build | | byte-identical to master, all 38 files |
| `host/presym` | 1577 entries | 1577 entries, byte-identical |
| `rake` over a build directory built by master, then again | | nothing to do, both times |
| `touch include/mruby.h`, then `rake` | 174 `CC`, 153 `CPP`, nothing under `build/host/mrbc` | the same |
| `rake -m -j16 test` from an empty build directory | | bintest OK 111, mrbtest OK 2073, 0 KO, 0 crash |
| `MRUBY_CONFIG=ci/gcc-clang` (5 targets) from an empty build directory | 1097 `CC`, 1047 `CPP`, 289 `GEN`; 45 `.pi` under each target's `mrbc/` | 1097 `CC`, 822 `CPP`, 274 `GEN`; no `.pi` and no `id.h` under any target's `mrbc/`; every target's `presym` byte-identical to master's; with `test`: every target 0 KO, 0 crash |
| `MRUBY_CONFIG=build_config/mrbc.rb` (a config whose only build has `disable_libmruby`) | 34 `CC`, 45 `CPP`, 3 `GEN`; `build/mrbc` has `src/`, `presym`, `include/` | 34 `CC`, 0 `CPP`, 0 `GEN`; `build/mrbc` has `bin/` and `mrbgems/`; `bin/mrbc` compiles a file |
| a `CrossBuild` with no `host` declared (`mruby-bin-mruby`, `mruby-bigint`) | generated `build/mrbc/default`: 45 `.pi`; the cross build: 52 `.pi`, `presym` with 413 entries | generated build: no `.pi`; the cross build: 52 `.pi`, 413 entries |
| clean `build_config/mrbc.rb` build, alternating 4 rounds | `-j16`: 5.5s wall, 12.2 CPU s; `-j1`: 11.4s | `-j16`: 5.35s wall, 11.0 CPU s; `-j1`: 10.4s |
| clean default build, alternating 3 rounds | `-j16`: 17.7s wall, 53.3 CPU s; `-j1`: 50.3s | `-j16`: 17.6s wall, 52.2 CPU s; `-j1`: 49.1s |

The 174 in the header row is 208 less the 34 objects of the `mrbc`
build, none of which includes `mruby.h`; it is the same in both columns
because the `.pi` files of the `mrbc` build carried no header
dependencies to begin with, so the waste was in every clean build and
never in an incremental one.

## Environment

<details>

| | |
|---|---|
| OS | Linux 7.0.0-29-generic, x86_64 |
| Compiler | gcc 13.3.0 |
| binutils | 2.47 |
| Ruby | 4.0.6 |
| rake | 13.3.1 |

The compile line of `compile.o` in the `mrbc` build, unchanged by this PR
(the record beside the object; `%{flags}` is the `flags:` line). `-DMRB_NO_GEMS`
is what keeps `MRC_TARGET_MRUBY` off, and `build/host/mrbc/include` stays
on the include path:

```console
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_GEMS -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -I"include" -I"mrbgems/mruby-compiler/include" -I"mrbgems/mruby-compiler/lib/prism/include" -I"mrbgems/mruby-compiler/include" -I"build/host/mrbc/include" -o "build/host/mrbc/mrbgems/mruby-compiler/src/compile.o" "mrbgems/mruby-compiler/src/compile.c"
```

</details>

No C source changes and no compile line changes, so `.text` is unaffected
in every build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved build consistency by ensuring required symbol information remains available across build configurations.
  - Presymbol generation now runs only for builds that include the relevant runtime library.
  - Removed unnecessary symbol scanning for configurations that exclude that library.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->