### PR TITLE
build: build the test objects through the rules

### DIFF
--- a/mrbgems/mruby-test/mrbgem.rake
+++ b/mrbgems/mruby-test/mrbgem.rake
@@ -22,7 +22,6 @@ MRuby::Gem::Specification.new('mruby-test') do |spec|
     spec.cc.defines << "MRBTEST_COMPILER_PRISM"
   end
 
-  file assert_lib => assert_c
   file assert_c => [assert_rb, build.mrbcfile] do |t|
     _pp "GEN", t.name.relative_path
     mkdir_p File.dirname(t.name)
@@ -50,7 +49,6 @@ MRuby::Gem::Specification.new('mruby-test') do |spec|
     gem_rakefiles = [g, *dep_list].map {|d| File.join(d.dir, "mrbgem.rake") }
                                   .select {|f| File.exist?(f) }.uniq
 
-    file test_rbobj => g.test_rbireps
     # __FILE__ holds the generator itself, as in the mrbtest.c rule below.
     file g.test_rbireps => [g.test_rbfiles, build.mrbcfile, gem_rakefiles, __FILE__].flatten do |t|
       _pp "GEN", t.name.relative_path
@@ -160,7 +158,6 @@ MRuby::Gem::Specification.new('mruby-test') do |spec|
     end
   end
 
-  file mlib => clib
   file clib => ["#{build.build_dir}/mrbgems/active_gems.txt", build.mrbcfile, __FILE__] do |_t|
     _pp "GEN", clib.relative_path
     mkdir_p File.dirname(clib)


### PR DESCRIPTION
`mrbtest.o`, `assert.o` and the `gem_test.o` of every gem, the objects
`mrbtest` is made of, are declared by hand in
`mrbgems/mruby-test/mrbgem.rake`: `file` tasks without an action, with the
generated source as their only prerequisite. Rake finds the rule for such
a task, but only when the task runs, after it has already answered
`needed?` from that one file. The `.d` the compile writes and the flags
record beside the object are read by the prerequisite procs of the rule,
and for these objects those never ran. A header the object includes
changing, or a define reaching the build by a way that leaves the
generated source alone, left the old object in `mrbtest`. It is the same
gap #7250 closed for `mrbgems/gem_init.o`.

`mrbtest.c` reads `mrb->gc.arena_idx` around every gem's tests
(`mrb_gc_arena_save`, `mrb_gc_arena_restore`). Add a field at the top of
`struct mrb_state` and run `rake test`:

```console
$ rake test                   # built once, all green
$ sed -i 's/^  struct mrb_jmpbuf \*jmp;$/&\n  void *probe_pad;/' include/mruby.h
$ rake test                   # 185 CC, none of the 52 test objects among them
mrbtest - Embeddable Ruby Test

.rake aborted!
Command failed with status (1): [build/host/bin/mrbtest]
$ rake test                   # nothing to build, the same failure
```

Every other object of the build is compiled again; `mrbtest.o` keeps the
old offset of `gc.arena_idx`, and `mrbtest` exits after the first test.

## Why

The three tasks came with the test rakefiles (2014, 7201404ee; 2015,
c7d0f8ebc). Rake's `Task#execute` runs `enhance_with_matching_rule` for a
task without an action, so the rule's action does compile the object and
its prerequisite procs do run then; but that is after `invoke` decided
from the written prerequisite whether to execute at all. The rule from
`Compiler#define_rules` has paired an object under the build directory
with the generated source beside it since 2013 (ced80d2b4); `mrblib.o`
is built by it alone, and `mrbgems/gem_init.o` since #7250. It reads the
`.d` and discards an output whose recorded flags differ (#7236).

## What this does

`mrbgems/mruby-test/mrbgem.rake` no longer declares the three kinds of
object. The rule of the compiler pairs each with its generated source,
and its `.d` and flags record take effect. The compile lines do not
change: the flags record of every one of the 271 objects of a `rake test`
build is the same as on `master`.

## Verified

`rake -m -j16 test`, `CCACHE_DISABLE=1`, gcc; `default` gembox with
`enable_bintest` and `enable_test`; the build directory built once on
`master` (364d6dd8f) before each row, and the run after each row does
nothing in both columns.

| change | master | this PR |
|---|---|---|
| a field added to `struct mrb_state` in `include/mruby.h` | 185 `CC`, none of the 52 test objects among them; `mrbtest` prints one dot and exits with 1, and still does after another `rake test` | 236 `CC`, 51 test objects among them (`assert.o` includes no header); bintest OK 111, mrbtest OK 2073 |
| the field removed again | as above | 236 `CC`, 51 test objects; bintest OK 111, mrbtest OK 2073 |
| `touch include/mruby.h` | 185 `CC`, none of the test objects | 236 `CC`, 51 test objects |
| `rake -m -j16 test` from an empty build directory | bintest OK 111, mrbtest OK 2073 | bintest OK 111, mrbtest OK 2073, 0 KO, 0 crash; the flags record of every object the same as on `master` |
| `rake -m -j16 test MRUBY_CONFIG=ci/gcc-clang` from an empty build directory | | every target 0 KO, 0 crash |

## Environment

<details>

| | |
|---|---|
| OS | Linux 7.0.0-29-generic, x86_64 |
| Compiler | gcc 13.3.0 |
| binutils | 2.47 |
| Ruby | 4.0.6 |
| rake | 13.3.1 |

The compile line of `mrbtest.o` in the default build, unchanged by this
PR (the record beside the object):

```console
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBTEST_COMPILER_PRISM -DMRBGEM_MRUBY_TEST_VERSION=0.0.0 -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK -I"include" -I"build/host/include" -o "build/host/mrbgems/mruby-test/mrbtest.o" "build/host/mrbgems/mruby-test/mrbtest.c"
```

</details>

No C source changes and the compile lines are the same, so `.text` is
unaffected in every build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build Improvements**
  * Streamlined test build dependency tracking by removing unnecessary generated-file dependencies.
  * Existing code-generation steps remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->