### PR TITLE
build: keep a generated source that a new `mrbc` writes the same

### DIFF
--- a/lib/mruby/core_ext.rb
+++ b/lib/mruby/core_ext.rb
@@ -59,3 +59,34 @@ def _pp(cmd, src, tgt=nil, indent: nil)
   template = indent ? "%#{width * indent}s %s %s" : "%-#{width}s %s %s"
   puts template % [cmd, src, tgt ? "-> #{tgt}" : nil]
 end
+
+# A file task like `file`, for a source that is generated: the block writes
+# the text to the IO it is given. The file is written only when the text
+# differs from what is there, so the object built from it stays when a
+# newer `mrbc` makes the same bytecode.
+#
+# Rake holds an output out of date when anything behind its prerequisites
+# is newer, so a source with `mrbc` among its prerequisites would take its
+# object with it whether the text changed or not. The source task has no
+# prerequisites of its own: it runs every time and invokes the stamp
+# beside it, which has the prerequisites and holds the time of the last
+# generation.
+def generated_file(name, prerequisites, &block)
+  stamp = file "#{name}.stamp" => prerequisites do |t|
+    mkdir_p File.dirname(name)
+    fresh = "#{name}.tmp"
+    File.open(fresh, "w", &block)
+    if File.exist?(name) && FileUtils.identical?(fresh, name)
+      rm_f fresh
+    else
+      mv fresh, name
+    end
+    touch t.name
+  end
+  stamp.define_singleton_method(:needed?) { super() || !File.exist?(name) }
+  source = file name do
+    stamp.invoke
+  end
+  source.define_singleton_method(:needed?) { true }
+  source
+end

--- a/lib/mruby/gem.rb
+++ b/lib/mruby/gem.rb
@@ -240,43 +240,41 @@ module MRuby
       end
 
       def define_gem_init_builder
-        file "#{build_dir}/gem_init.c" => [build.mrbcfile, __FILE__] + [rbfiles].flatten do |t|
-          mkdir_p build_dir
-          generate_gem_init("#{build_dir}/gem_init.c")
+        fname = "#{build_dir}/gem_init.c"
+        generated_file fname, [build.mrbcfile, __FILE__] + [rbfiles].flatten do |f|
+          _pp "GEN", fname.relative_path
+          generate_gem_init(f)
         end
       end
 
-      def generate_gem_init(fname)
-        _pp "GEN", fname.relative_path
-        open(fname, 'w') do |f|
-          print_gem_init_header f
-          unless rbfiles.empty?
-            opts = {cdump: cdump?, static: true}
-            if cdump?
-              build.mrbc.run f, rbfiles, "gem_mrblib_#{funcname}_proc", **opts
-            else
-              build.mrbc.run f, rbfiles, "gem_mrblib_irep_#{funcname}", **opts
-            end
+      def generate_gem_init(f)
+        print_gem_init_header f
+        unless rbfiles.empty?
+          opts = {cdump: cdump?, static: true}
+          if cdump?
+            build.mrbc.run f, rbfiles, "gem_mrblib_#{funcname}_proc", **opts
+          else
+            build.mrbc.run f, rbfiles, "gem_mrblib_irep_#{funcname}", **opts
           end
-          f.puts %Q[void mrb_#{funcname}_gem_init(mrb_state *mrb);]
-          f.puts %Q[void mrb_#{funcname}_gem_final(mrb_state *mrb);]
-          f.puts %Q[]
-          f.puts %Q[void GENERATED_TMP_mrb_#{funcname}_gem_init(mrb_state *mrb) {]
-          f.puts %Q[  gem_mrblib_#{funcname}_proc_init_syms(mrb);] if !rbfiles.empty? && cdump?
-          f.puts %Q[  mrb_#{funcname}_gem_init(mrb);] if objs != [objfile("#{build_dir}/gem_init")]
-          unless rbfiles.empty?
-            if cdump?
-              f.puts %Q[  mrb_load_proc(mrb, gem_mrblib_#{funcname}_proc);]
-            else
-              f.puts %Q[  mrb_load_irep(mrb, gem_mrblib_irep_#{funcname});]
-            end
-          end
-          f.puts %Q[}]
-          f.puts %Q[]
-          f.puts %Q[void GENERATED_TMP_mrb_#{funcname}_gem_final(mrb_state *mrb) {]
-          f.puts %Q[  mrb_#{funcname}_gem_final(mrb);] if objs != [objfile("#{build_dir}/gem_init")]
-          f.puts %Q[}]
         end
+        f.puts %Q[void mrb_#{funcname}_gem_init(mrb_state *mrb);]
+        f.puts %Q[void mrb_#{funcname}_gem_final(mrb_state *mrb);]
+        f.puts %Q[]
+        f.puts %Q[void GENERATED_TMP_mrb_#{funcname}_gem_init(mrb_state *mrb) {]
+        f.puts %Q[  gem_mrblib_#{funcname}_proc_init_syms(mrb);] if !rbfiles.empty? && cdump?
+        f.puts %Q[  mrb_#{funcname}_gem_init(mrb);] if objs != [objfile("#{build_dir}/gem_init")]
+        unless rbfiles.empty?
+          if cdump?
+            f.puts %Q[  mrb_load_proc(mrb, gem_mrblib_#{funcname}_proc);]
+          else
+            f.puts %Q[  mrb_load_irep(mrb, gem_mrblib_irep_#{funcname});]
+          end
+        end
+        f.puts %Q[}]
+        f.puts %Q[]
+        f.puts %Q[void GENERATED_TMP_mrb_#{funcname}_gem_final(mrb_state *mrb) {]
+        f.puts %Q[  mrb_#{funcname}_gem_final(mrb);] if objs != [objfile("#{build_dir}/gem_init")]
+        f.puts %Q[}]
       end # generate_gem_init
 
       def print_gem_comment(f)

--- a/mrbgems/mruby-test/mrbgem.rake
+++ b/mrbgems/mruby-test/mrbgem.rake
@@ -22,7 +22,6 @@ MRuby::Gem::Specification.new('mruby-test') do |spec|
     spec.cc.defines << "MRBTEST_COMPILER_PRISM"
   end
 
-  file assert_lib => assert_c
   file assert_c => [assert_rb, build.mrbcfile] do |t|
     _pp "GEN", t.name.relative_path
     mkdir_p File.dirname(t.name)
@@ -50,7 +49,6 @@ MRuby::Gem::Specification.new('mruby-test') do |spec|
     gem_rakefiles = [g, *dep_list].map {|d| File.join(d.dir, "mrbgem.rake") }
                                   .select {|f| File.exist?(f) }.uniq
 
-    file test_rbobj => g.test_rbireps
     # __FILE__ holds the generator itself, as in the mrbtest.c rule below.
     file g.test_rbireps => [g.test_rbfiles, build.mrbcfile, gem_rakefiles, __FILE__].flatten do |t|
       _pp "GEN", t.name.relative_path
@@ -160,7 +158,6 @@ MRuby::Gem::Specification.new('mruby-test') do |spec|
     end
   end
 
-  file mlib => clib
   file clib => ["#{build.build_dir}/mrbgems/active_gems.txt", build.mrbcfile, __FILE__] do |_t|
     _pp "GEN", clib.relative_path
     mkdir_p File.dirname(clib)

--- a/mrbgems/mruby-test/mrbgem.rake
+++ b/mrbgems/mruby-test/mrbgem.rake
@@ -22,14 +22,9 @@ MRuby::Gem::Specification.new('mruby-test') do |spec|
     spec.cc.defines << "MRBTEST_COMPILER_PRISM"
   end
 
-  file assert_c => [assert_rb, build.mrbcfile] do |t|
-    _pp "GEN", t.name.relative_path
-    mkdir_p File.dirname(t.name)
-    tmpfile = t.name + ".tmp"
-    open(tmpfile, 'w') do |f|
-      mrbc.run f, assert_rb, 'mrbtest_assert_irep', cdump: false
-    end
-    File.rename(tmpfile, t.name)
+  generated_file assert_c, [assert_rb, build.mrbcfile] do |f|
+    _pp "GEN", assert_c.relative_path
+    mrbc.run f, assert_rb, 'mrbtest_assert_irep', cdump: false
   end
 
   gem_table = build.gems.generate_gem_table build
@@ -50,101 +45,96 @@ MRuby::Gem::Specification.new('mruby-test') do |spec|
                                   .select {|f| File.exist?(f) }.uniq
 
     # __FILE__ holds the generator itself, as in the mrbtest.c rule below.
-    file g.test_rbireps => [g.test_rbfiles, build.mrbcfile, gem_rakefiles, __FILE__].flatten do |t|
-      _pp "GEN", t.name.relative_path
-      mkdir_p File.dirname(t.name)
-      tmpfile = t.name + ".tmp"
-      open(tmpfile, 'w') do |f|
-        g.print_gem_test_header(f)
-        test_preload = g.test_preload and [g.dir, MRUBY_ROOT].map {|dir|
-          File.expand_path(g.test_preload, dir)
-        }.find {|file| File.exist?(file) }
+    generated_file g.test_rbireps, [g.test_rbfiles, build.mrbcfile, gem_rakefiles, __FILE__].flatten do |f|
+      _pp "GEN", g.test_rbireps.relative_path
+      g.print_gem_test_header(f)
+      test_preload = g.test_preload and [g.dir, MRUBY_ROOT].map {|dir|
+        File.expand_path(g.test_preload, dir)
+      }.find {|file| File.exist?(file) }
 
-        f.puts %Q[/*]
-        f.puts %Q[ * This file contains a test code for #{g.name} gem.]
-        f.puts %Q[ *]
-        f.puts %Q[ * IMPORTANT:]
-        f.puts %Q[ *   This file was generated!]
-        f.puts %Q[ *   All manual changes will get lost.]
-        f.puts %Q[ */]
-        if test_preload.nil?
-          f.puts %Q[extern const uint8_t mrbtest_assert_irep[];]
-        else
-          g.build.mrbc.run f, test_preload, "gem_test_irep_#{g.funcname}_preload", cdump: false
+      f.puts %Q[/*]
+      f.puts %Q[ * This file contains a test code for #{g.name} gem.]
+      f.puts %Q[ *]
+      f.puts %Q[ * IMPORTANT:]
+      f.puts %Q[ *   This file was generated!]
+      f.puts %Q[ *   All manual changes will get lost.]
+      f.puts %Q[ */]
+      if test_preload.nil?
+        f.puts %Q[extern const uint8_t mrbtest_assert_irep[];]
+      else
+        g.build.mrbc.run f, test_preload, "gem_test_irep_#{g.funcname}_preload", cdump: false
+      end
+      g.test_rbfiles.flatten.each_with_index do |rbfile, i|
+        g.build.mrbc.run f, rbfile, "gem_test_irep_#{g.funcname}_#{i}", cdump: false, static: true
+      end
+      f.puts %Q[void mrb_#{g.funcname}_gem_test(mrb_state *mrb);] if g.custom_test_init?
+      dep_list.each do |d|
+        f.puts %Q[void GENERATED_TMP_mrb_#{d.funcname}_gem_init(mrb_state *mrb);]
+        f.puts %Q[void GENERATED_TMP_mrb_#{d.funcname}_gem_final(mrb_state *mrb);]
+      end
+      f.puts %Q[void mrb_init_test_driver(mrb_state *mrb, mrb_bool verbose);]
+      f.puts %Q[void mrb_t_pass_result(mrb_state *dst, mrb_state *src);]
+      f.puts %Q[#if defined(MRBTEST_COMPILER_PRISM)]
+      f.puts %Q[extern mrb_state *global_mrb;]
+      f.puts %Q[#endif]
+      f.puts %Q[void GENERATED_TMP_mrb_#{g.funcname}_gem_test(mrb_state *mrb) {]
+      unless g.test_rbfiles.empty?
+        unless g.test_args.empty?
+          f.puts %Q[  mrb_value test_args_hash;]
         end
-        g.test_rbfiles.flatten.each_with_index do |rbfile, i|
-          g.build.mrbc.run f, rbfile, "gem_test_irep_#{g.funcname}_#{i}", cdump: false, static: true
-        end
-        f.puts %Q[void mrb_#{g.funcname}_gem_test(mrb_state *mrb);] if g.custom_test_init?
-        dep_list.each do |d|
-          f.puts %Q[void GENERATED_TMP_mrb_#{d.funcname}_gem_init(mrb_state *mrb);]
-          f.puts %Q[void GENERATED_TMP_mrb_#{d.funcname}_gem_final(mrb_state *mrb);]
-        end
-        f.puts %Q[void mrb_init_test_driver(mrb_state *mrb, mrb_bool verbose);]
-        f.puts %Q[void mrb_t_pass_result(mrb_state *dst, mrb_state *src);]
+        f.puts %Q[  mrb_state *mrb2 = mrb_open_core();]
+        f.puts %Q[  if (mrb2 == NULL) {]
+        f.puts %Q[    fprintf(stderr, "Invalid mrb_state, exiting \%s", __func__);]
+        f.puts %Q[    exit(EXIT_FAILURE);]
+        f.puts %Q[  }]
         f.puts %Q[#if defined(MRBTEST_COMPILER_PRISM)]
-        f.puts %Q[extern mrb_state *global_mrb;]
+        f.puts %Q[  global_mrb = mrb2;]
         f.puts %Q[#endif]
-        f.puts %Q[void GENERATED_TMP_mrb_#{g.funcname}_gem_test(mrb_state *mrb) {]
-        unless g.test_rbfiles.empty?
+        f.puts %Q[  int ai = mrb_gc_arena_save(mrb2);]
+        f.puts %Q[  mrb_const_set(mrb2, mrb_obj_value(mrb2->object_class), mrb_intern_lit(mrb2, "GEMNAME"), mrb_str_new(mrb2, "#{g.name}", #{g.name.length}));]
+        f.puts %Q[  mrb_gc_arena_restore(mrb2, ai);]
+        if test_preload.nil?
+          f.puts %Q[  mrb_load_irep(mrb2, mrbtest_assert_irep);]
+        else
+          f.puts %Q[  mrb_load_irep(mrb2, gem_test_irep_#{g.funcname}_preload);]
+        end
+        dep_list.each do |d|
+          f.puts %Q[  GENERATED_TMP_mrb_#{d.funcname}_gem_init(mrb2);]
+          f.puts %Q[  mrb_state_atexit(mrb2, GENERATED_TMP_mrb_#{d.funcname}_gem_final);]
+          f.puts %Q[  mrb_gc_arena_restore(mrb2, ai);]
+        end
+        f.puts %Q[  mrb_init_test_driver(mrb2, mrb_test(mrb_gv_get(mrb, mrb_intern_lit(mrb, "$mrbtest_verbose"))));]
+        f.puts %Q[  mrb_gc_arena_restore(mrb2, ai);]
+        f.puts %Q[  ]
+        g.test_rbfiles.count.times do |i|
           unless g.test_args.empty?
-            f.puts %Q[  mrb_value test_args_hash;]
+            f.puts %Q[  test_args_hash = mrb_hash_new_capa(mrb2, #{g.test_args.length}); ]
+            g.test_args.each do |arg_name, arg_value|
+              escaped_arg_name = arg_name.gsub('\\', '\\\\\\\\').gsub('"', '\"')
+              escaped_arg_value = arg_value.gsub('\\', '\\\\\\\\').gsub('"', '\"')
+              f.puts %Q[  mrb_hash_set(mrb2, test_args_hash, mrb_str_new(mrb2, "#{escaped_arg_name.to_s}", #{escaped_arg_name.to_s.length}), mrb_str_new(mrb2, "#{escaped_arg_value.to_s}", #{escaped_arg_value.to_s.length})); ]
+            end
+            f.puts %Q[  mrb_const_set(mrb2, mrb_obj_value(mrb2->object_class), mrb_intern_lit(mrb2, "TEST_ARGS"), test_args_hash); ]
           end
-          f.puts %Q[  mrb_state *mrb2 = mrb_open_core();]
-          f.puts %Q[  if (mrb2 == NULL) {]
-          f.puts %Q[    fprintf(stderr, "Invalid mrb_state, exiting \%s", __func__);]
+          f.puts %Q[  mrb_gc_arena_restore(mrb2, ai);]
+
+          f.puts %Q[  mrb_#{g.funcname}_gem_test(mrb2);] if g.custom_test_init?
+          f.puts %Q[  mrb_gc_arena_restore(mrb2, ai);]
+          f.puts %Q[  mrb_load_irep(mrb2, gem_test_irep_#{g.funcname}_#{i});]
+          f.puts %Q[  if (mrb2->exc) {]
+          f.puts %Q[    mrb_print_error(mrb2);]
+          f.puts %Q[    mrb_close(mrb2);]
           f.puts %Q[    exit(EXIT_FAILURE);]
           f.puts %Q[  }]
-          f.puts %Q[#if defined(MRBTEST_COMPILER_PRISM)]
-          f.puts %Q[  global_mrb = mrb2;]
-          f.puts %Q[#endif]
-          f.puts %Q[  int ai = mrb_gc_arena_save(mrb2);]
-          f.puts %Q[  mrb_const_set(mrb2, mrb_obj_value(mrb2->object_class), mrb_intern_lit(mrb2, "GEMNAME"), mrb_str_new(mrb2, "#{g.name}", #{g.name.length}));]
-          f.puts %Q[  mrb_gc_arena_restore(mrb2, ai);]
-          if test_preload.nil?
-            f.puts %Q[  mrb_load_irep(mrb2, mrbtest_assert_irep);]
-          else
-            f.puts %Q[  mrb_load_irep(mrb2, gem_test_irep_#{g.funcname}_preload);]
-          end
-          dep_list.each do |d|
-            f.puts %Q[  GENERATED_TMP_mrb_#{d.funcname}_gem_init(mrb2);]
-            f.puts %Q[  mrb_state_atexit(mrb2, GENERATED_TMP_mrb_#{d.funcname}_gem_final);]
-            f.puts %Q[  mrb_gc_arena_restore(mrb2, ai);]
-          end
-          f.puts %Q[  mrb_init_test_driver(mrb2, mrb_test(mrb_gv_get(mrb, mrb_intern_lit(mrb, "$mrbtest_verbose"))));]
-          f.puts %Q[  mrb_gc_arena_restore(mrb2, ai);]
           f.puts %Q[  ]
-          g.test_rbfiles.count.times do |i|
-            unless g.test_args.empty?
-              f.puts %Q[  test_args_hash = mrb_hash_new_capa(mrb2, #{g.test_args.length}); ]
-              g.test_args.each do |arg_name, arg_value|
-                escaped_arg_name = arg_name.gsub('\\', '\\\\\\\\').gsub('"', '\"')
-                escaped_arg_value = arg_value.gsub('\\', '\\\\\\\\').gsub('"', '\"')
-                f.puts %Q[  mrb_hash_set(mrb2, test_args_hash, mrb_str_new(mrb2, "#{escaped_arg_name.to_s}", #{escaped_arg_name.to_s.length}), mrb_str_new(mrb2, "#{escaped_arg_value.to_s}", #{escaped_arg_value.to_s.length})); ]
-              end
-              f.puts %Q[  mrb_const_set(mrb2, mrb_obj_value(mrb2->object_class), mrb_intern_lit(mrb2, "TEST_ARGS"), test_args_hash); ]
-            end
-            f.puts %Q[  mrb_gc_arena_restore(mrb2, ai);]
-
-            f.puts %Q[  mrb_#{g.funcname}_gem_test(mrb2);] if g.custom_test_init?
-            f.puts %Q[  mrb_gc_arena_restore(mrb2, ai);]
-            f.puts %Q[  mrb_load_irep(mrb2, gem_test_irep_#{g.funcname}_#{i});]
-            f.puts %Q[  if (mrb2->exc) {]
-            f.puts %Q[    mrb_print_error(mrb2);]
-            f.puts %Q[    mrb_close(mrb2);]
-            f.puts %Q[    exit(EXIT_FAILURE);]
-            f.puts %Q[  }]
-            f.puts %Q[  ]
-          end
-          f.puts %Q[  mrb_t_pass_result(mrb, mrb2);]
-          f.puts %Q[#if defined(MRBTEST_COMPILER_PRISM)]
-          f.puts %Q[  global_mrb = mrb;]
-          f.puts %Q[#endif]
-          f.puts %Q[  mrb_close(mrb2);]
         end
-        f.puts %Q[}]
+        f.puts %Q[  mrb_t_pass_result(mrb, mrb2);]
+        f.puts %Q[#if defined(MRBTEST_COMPILER_PRISM)]
+        f.puts %Q[  global_mrb = mrb;]
+        f.puts %Q[#endif]
+        f.puts %Q[  mrb_close(mrb2);]
       end
-      File.rename(tmpfile, t.name)
+      f.puts %Q[}]
     end
   end
 
@@ -158,45 +148,40 @@ MRuby::Gem::Specification.new('mruby-test') do |spec|
     end
   end
 
-  file clib => ["#{build.build_dir}/mrbgems/active_gems.txt", build.mrbcfile, __FILE__] do |_t|
+  generated_file clib, ["#{build.build_dir}/mrbgems/active_gems.txt", build.mrbcfile, __FILE__] do |f|
     _pp "GEN", clib.relative_path
-    mkdir_p File.dirname(clib)
-    tmpfile = clib + ".tmp"
-    open(tmpfile, 'w') do |f|
-      f.puts %Q[/*]
-      f.puts %Q[ * This file contains a list of all]
-      f.puts %Q[ * test functions.]
-      f.puts %Q[ *]
-      f.puts %Q[ * IMPORTANT:]
-      f.puts %Q[ *   This file was generated!]
-      f.puts %Q[ *   All manual changes will get lost.]
-      f.puts %Q[ */]
-      f.puts %Q[]
-      f.puts %Q[#include <mruby.h>]
-      f.puts %Q[#include <mruby/variable.h>]
-      f.puts %Q[#include <mruby/array.h>]
-      f.puts %Q[]
-      build.gems.each do |g|
-        f.puts %Q[void GENERATED_TMP_mrb_#{g.funcname}_gem_test(mrb_state *mrb);]
-      end
-      f.puts %Q[void mrbgemtest_init(mrb_state* mrb) {]
-      f.puts %Q[  int ai = mrb_gc_arena_save(mrb);]
-      build.gems.each do |g|
-        if g.skip_test?
-          f.puts %Q[    do {]
-          f.puts %Q[      mrb_value asserts = mrb_gv_get(mrb, mrb_intern_lit(mrb, "$asserts"));]
-          f.puts %Q[      mrb_ary_push(mrb, asserts, mrb_str_new_lit(mrb, ]
-          f.puts %Q[                   "Warn: Skipping tests for gem (#{
-                                        g.name == 'mruby-test' ? 'core' : "mrbgems: #{g.name}"
-                                       })"));]
-          f.puts %Q[    } while (0);]
-        else
-          f.puts %Q[    GENERATED_TMP_mrb_#{g.funcname}_gem_test(mrb);]
-        end
-        f.puts %Q[    mrb_gc_arena_restore(mrb, ai);]
-      end
-      f.puts %Q[}]
+    f.puts %Q[/*]
+    f.puts %Q[ * This file contains a list of all]
+    f.puts %Q[ * test functions.]
+    f.puts %Q[ *]
+    f.puts %Q[ * IMPORTANT:]
+    f.puts %Q[ *   This file was generated!]
+    f.puts %Q[ *   All manual changes will get lost.]
+    f.puts %Q[ */]
+    f.puts %Q[]
+    f.puts %Q[#include <mruby.h>]
+    f.puts %Q[#include <mruby/variable.h>]
+    f.puts %Q[#include <mruby/array.h>]
+    f.puts %Q[]
+    build.gems.each do |g|
+      f.puts %Q[void GENERATED_TMP_mrb_#{g.funcname}_gem_test(mrb_state *mrb);]
     end
-    File.rename(tmpfile, clib)
+    f.puts %Q[void mrbgemtest_init(mrb_state* mrb) {]
+    f.puts %Q[  int ai = mrb_gc_arena_save(mrb);]
+    build.gems.each do |g|
+      if g.skip_test?
+        f.puts %Q[    do {]
+        f.puts %Q[      mrb_value asserts = mrb_gv_get(mrb, mrb_intern_lit(mrb, "$asserts"));]
+        f.puts %Q[      mrb_ary_push(mrb, asserts, mrb_str_new_lit(mrb, ]
+        f.puts %Q[                   "Warn: Skipping tests for gem (#{
+                                      g.name == 'mruby-test' ? 'core' : "mrbgems: #{g.name}"
+                                     })"));]
+        f.puts %Q[    } while (0);]
+      else
+        f.puts %Q[    GENERATED_TMP_mrb_#{g.funcname}_gem_test(mrb);]
+      end
+      f.puts %Q[    mrb_gc_arena_restore(mrb, ai);]
+    end
+    f.puts %Q[}]
   end
 end

--- a/tasks/mrblib.rake
+++ b/tasks/mrblib.rake
@@ -6,24 +6,21 @@ MRuby.each_target do
 
   self.libmruby_objs << objfile(src.ext)
 
-  file src => [mrbcfile, __FILE__, *rbfiles] do |t|
-    mkdir_p File.dirname(t.name)
-    File.open(t.name, 'w') do |f|
-      _pp "GEN", "mrblib/*.rb", "#{t.name.relative_path}"
-      f.puts %Q[/*]
-      f.puts %Q[ * This file is loading the mrblib]
-      f.puts %Q[ *]
-      f.puts %Q[ * IMPORTANT:]
-      f.puts %Q[ *   This file was generated!]
-      f.puts %Q[ *   All manual changes will get lost.]
-      f.puts %Q[ */]
-      mrbc.run f, rbfiles, "mrblib_proc", cdump: true, static: true
-      f.puts %Q[void]
-      f.puts %Q[mrb_init_mrblib(mrb_state *mrb)]
-      f.puts %Q[{]
-      f.puts %Q[  mrblib_proc_init_syms(mrb);]
-      f.puts %Q[  mrb_load_proc(mrb, mrblib_proc);]
-      f.puts %Q[}]
-    end
+  generated_file src, [mrbcfile, __FILE__, *rbfiles] do |f|
+    _pp "GEN", "mrblib/*.rb", "#{src.relative_path}"
+    f.puts %Q[/*]
+    f.puts %Q[ * This file is loading the mrblib]
+    f.puts %Q[ *]
+    f.puts %Q[ * IMPORTANT:]
+    f.puts %Q[ *   This file was generated!]
+    f.puts %Q[ *   All manual changes will get lost.]
+    f.puts %Q[ */]
+    mrbc.run f, rbfiles, "mrblib_proc", cdump: true, static: true
+    f.puts %Q[void]
+    f.puts %Q[mrb_init_mrblib(mrb_state *mrb)]
+    f.puts %Q[{]
+    f.puts %Q[  mrblib_proc_init_syms(mrb);]
+    f.puts %Q[  mrb_load_proc(mrb, mrblib_proc);]
+    f.puts %Q[}]
   end
 end


### PR DESCRIPTION
Stacked on #7253 (the test objects through the rules); the first commit is that PR.

`mrblib.c`, the `gem_init.c` of every gem and the three sources of
`mrbtest` (`assert.c`, `mrbtest.c`, the `gem_test.c` of every gem) are
written by `mrbc`, and each of them has `bin/mrbc` among its
prerequisites. Any compile of the compiler relinks `mrbc`, and every one
of them is then written again, preprocessed again for presym and compiled
again, whether the bytecode changed or not:

```console
$ rake                        # built once
$ touch mrbgems/mruby-compiler/src/diagnostic.c
$ rake                        # 43 GEN, 44 CPP, 45 CC: diagnostic.o twice, and 43 loaders
$ rake test                   # built once
$ touch mrbgems/mruby-compiler/src/diagnostic.c
$ rake test                   # 95 GEN, 44 CPP, 97 CC
```

The bytecode is the same in all of them; nothing about it changed.

## Why

Comparing the text before writing does not do it alone. Rake holds an
output out of date when anything behind its prerequisites is newer
(`Rake::FileTask#out_of_date?` walks `all_prerequisite_tasks`), so an
object whose source has `mrbc` behind it is compiled again the moment
`mrbc` is, whatever the source says. `tasks/presym.rake` meets the same
wall (#6721) and puts a task without prerequisites between the objects
and the presym list, with the list's timestamp; `active_gems.txt` is
written by a task that always runs and writes only when the text differs.

## What this does

`generated_file` in `lib/mruby/core_ext.rb` is a `file` task for a
generated source that takes both:

- The source task has no prerequisites of its own and runs every time. It
  invokes a stamp task, `<source>.stamp` beside the source, which has the
  prerequisites (`mrbc`, the Ruby files, the generator) and holds the time
  of the last generation.
- The stamp task writes the text to `<source>.tmp` and moves it over the
  source only when it differs from what is there. A source that is missing
  is written again whatever the stamp says.

The five generators go through it. `mrbtest`'s wrote to a `.tmp` and
renamed already, so a failed `mrbc` leaves the source as it was; the
others do now too. The compile lines do not change: the flags record of
every object is the same as on `master`.

`mrbc` still runs for every source when it changed; only the write, the
preprocess and the compile are skipped when the text is the same. A change
to what `mrbc` writes still reaches every object it reaches.

## Verified

`rake -m -j16` (`-j1` where noted), `CCACHE_DISABLE=1`, gcc; `default`
gembox with `enable_bintest` and `enable_test`; the build directory built
once (`rake`, or `rake test` where the row says so) before each row, and
the run after each row does nothing in both columns. Times are the median
of three alternating runs (two for `-j1`); the `rake test` rows include running the tests.

| change | master | this PR |
|---|---|---|
| `touch mrbgems/mruby-compiler/src/diagnostic.c`, `rake` | 43 `GEN`, 44 `CPP`, 45 `CC`; 1.16 s wall, 4.4 s CPU; `-j1` 4.0 s | 43 `GEN`, 1 `CPP`, 2 `CC`; 0.97 s wall, 1.5 s CPU; `-j1` 1.35 s |
| the same, `rake test` | 95 `GEN`, 44 `CPP`, 97 `CC`; 3.65 s wall, 10.1 s CPU; `-j1` 9.3 s | 95 `GEN`, 1 `CPP`, 2 `CC`; 3.23 s wall, 4.4 s CPU; `-j1` 4.2 s |
| one line more in the `-S` output of `mrbc` (`cdump.c`), `rake` | 43 `GEN`, 45 `CC` | 43 `GEN`, 31 `CC`: `cdump.o` twice and the 29 sources that carry the line; the 14 `gem_init.c` of gems without Ruby files stay |
| `touch mrblib/compar.rb` | 1 `GEN`, 1 `CC`, `AR`, 4 `LD` | 1 `GEN`, nothing else |
| a method added to `mrblib/compar.rb` | | 1 `GEN`, `mrblib.c` written; the presym table grows, 174 `CC`; `bin/mruby` has the method; removed again: the same |
| a generated source deleted | 1 `GEN`, 1 `CC` | 1 `GEN`, 1 `CC` |
| a stamp deleted | | 1 `GEN`, 0 `CC` |
| a syntax error in `mrbgems/mruby-catch/mrblib/catch.rb` | `rake` fails | `rake` fails, `gem_init.c` and its stamp as before, no `.tmp` left; the error undone: builds, 111 / 2073 OK |
| a build directory built on `master`, `rake test` | | 95 `GEN`, none of them compiled, 111 / 2073 OK; the run after that nothing; back to `master`: builds and tests, nothing stale |
| `rake -m -j16 test` from an empty build directory | 111 / 2073 OK | 111 / 2073 OK, 0 KO, 0 crash; the flags record of every object the same |
| `rake -m -j16 test MRUBY_CONFIG=ci/gcc-clang` from an empty build directory | | every target 0 KO, 0 crash |
| a `CrossBuild` with no host (`mruby-bin-mruby` + `mruby-bigint`), the generated `mrbc` build | | builds and runs; `touch` of a compiler source: 3 `GEN`, 2 `CC` |
| this change without #7253, `conf.cc.defines << "PROBE_FLAG=1"` from an environment variable, `rake test` | | 219 `CC` and none of the 52 test objects; `mrbtest.o`'s flags record has no `PROBE_FLAG`. With #7253: 271 `CC`, all 52 |

The last row is why this is stacked: once the sources stop being written,
the test objects have to answer to their `.d` and flags records themselves.

## Environment

<details>

| | |
|---|---|
| OS | Linux 7.0.0-29-generic, x86_64 |
| Compiler | gcc 13.3.0 |
| binutils | 2.47 |
| Ruby | 4.0.6 |
| rake | 13.3.1 |

The compile line of `mrblib.o` in the default build, unchanged by this
PR (the record beside the object):

```console
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK -I"include" -I"build/host/include" -o "build/host/mrblib/mrblib.o" "build/host/mrblib/mrblib.c"
```

</details>

No C source changes and the compile lines are the same, so `.text` is
unaffected in every build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved generated-file handling so build outputs are updated only when their contents change.
  * Ensured generated sources are consistently refreshed when their inputs change.
  * Preserved existing gem initialization, test generation, and compilation behavior.

* **Developer Experience**
  * Added clearer warnings to generated source files.
  * Improved reliability and efficiency of repeated builds by avoiding unnecessary file rewrites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->