### PR TITLE
build: write a generated source again when the list of its inputs changes

### DIFF
--- a/lib/mruby/core_ext.rb
+++ b/lib/mruby/core_ext.rb
@@ -71,7 +71,13 @@ end
 # prerequisites of its own: it runs every time and invokes the stamp
 # beside it, which has the prerequisites and holds the time of the last
 # generation.
-def generated_file(name, prerequisites, &block)
+#
+# The stamp also holds the list of the prerequisites and `inputs`, the
+# values the text depends on that are not files. A prerequisite that is
+# gone leaves the ones that remain older than the stamp, and a changed
+# input touches no file at all; the list catches both.
+def generated_file(name, prerequisites, inputs: [], &block)
+  record = (prerequisites + inputs).map { |v| "#{v}\n" }.join
   stamp = file "#{name}.stamp" => prerequisites do |t|
     mkdir_p File.dirname(name)
     fresh = "#{name}.tmp"
@@ -81,9 +87,11 @@ def generated_file(name, prerequisites, &block)
     else
       mv fresh, name
     end
-    touch t.name
+    File.write(t.name, record)
   end
-  stamp.define_singleton_method(:needed?) { super() || !File.exist?(name) }
+  stamp.define_singleton_method(:needed?) do
+    super() || !File.exist?(name) || File.read(self.name) != record
+  end
   source = file name do
     stamp.invoke
   end

--- a/lib/mruby/gem.rb
+++ b/lib/mruby/gem.rb
@@ -241,7 +241,7 @@ module MRuby
 
       def define_gem_init_builder
         fname = "#{build_dir}/gem_init.c"
-        generated_file fname, [build.mrbcfile, __FILE__] + [rbfiles].flatten do |f|
+        generated_file fname, [build.mrbcfile, __FILE__] + [rbfiles].flatten, inputs: [cdump?, *objs] do |f|
           _pp "GEN", fname.relative_path
           generate_gem_init(f)
         end


### PR DESCRIPTION
`mrblib.c`, the `gem_init.c` of every gem and the sources of `mrbtest`
are written from a list of files, and the list itself is not among the
things Rake compares. A file that is gone is not a prerequisite any more,
so the ones that remain are all older than the last generation, and
nothing runs:

```console
$ rake                                  # built once
$ printf 'class Integer; def zip; 42; end; end\n' > mrblib/zz_probe.rb
$ rake                                  # 1 GEN, 1 CC
$ bin/mruby -e 'p 1.zip'
42
$ rm mrblib/zz_probe.rb
$ rake                                  # nothing
$ bin/mruby -e 'p 1.zip'
42                                      # and after every rake from here on
```

The same for a test file removed from a gem: `rake test` keeps running
it. The `gem_init.c` of a gem also depends on two values that are not
files at all: whether the gem has native objects, which decides whether
the generated `mrb_<gem>_gem_init` call is written, and whether `cdump`
is on. Adding a `src/probe.c` to a gem that had only Ruby files compiles
and archives it, and its `mrb_..._gem_init` is never called; removing the
last one leaves the call in place, and the link fails at the next archive
and stays failed. `spec.disable_cdump` in an `mrbgem.rake` is not seen
either. Each of these takes a clean build, or a deleted stamp, to get
out of.

## Why

Rake compares times of files that are there. The set of inputs, and a
value read from a spec, leave no time behind. `active_gems.txt` in
`tasks/mrbgems.rake` is the in-tree answer to the same question for the
list of gems: a task that always runs writes the list only when it
differs, and the loader depends on the file. The flags record beside
every object (#7236) does the same for the compile line. The stamp of
`generated_file` (#7254) is the place for the list of a generated source.

## What this does

`generated_file` in `lib/mruby/core_ext.rb` writes the list of the
prerequisites and of `inputs`, the values the caller names, into the
stamp, one per line, and the stamp task is needed when the list on disk
differs from the list of this run. `gem_init.c` names `cdump?` and
`objs`; the other four generators pass no inputs, the prerequisite list
covers them. Nothing else changes: the same prerequisites, the same
write only when the text differs, the same compile lines.

## Verified

`rake -m -j16`, `CCACHE_DISABLE=1`, gcc; `default` gembox with
`enable_bintest` and `enable_test`; the build directory built once
before each row, and the run after each row does nothing in both columns
unless the row says otherwise. `mruby-compar-ext` is the gem with only
Ruby files used for the rows about native objects.

| change | master | this PR |
|---|---|---|
| `mrblib/zz_probe.rb` with `Integer#zip` added, `rake` | 1 `GEN`, 1 `CC`; `1.zip` is `42` | the same |
| the file removed, `rake` | nothing; `1.zip` is `42`, and after the next `rake` too | 1 `GEN`, 1 `CC`; `NoMethodError` |
| `src/probe.c` with a C `Integer#zip` added to `mruby-compar-ext`, `rake` | 1 `CC` (`probe.o`), `AR`, `LD`; `gem_init.c` not written, no `mrb_mruby_compar_ext_gem_init` call; `1.zip` is `NoMethodError` | 1 `GEN`, 2 `CC`; the call is there; `1.zip` is `43` |
| `touch` of the gem's `compar.rb` after that | 1 `GEN`, 1 `CC`; the call is there now; `43` | 1 `GEN`, 0 `CC` |
| `src/probe.c` removed, `rake` | nothing (`probe.o` stays in the archive); `touch src/version.c`, `rake`: the link fails, `undefined reference to mrb_mruby_compar_ext_gem_init`, and every `rake` after it | 1 `GEN`, 1 `CC`; the call is gone; `NoMethodError`; `touch src/version.c`: 1 `CC`, links |
| `test/zz_probe.rb` with one assertion added to the gem, `rake test`; then removed, `rake test` | 2074 OK; 2074 OK | 2074 OK; 1 `GEN`, 1 `CC`, 2073 OK |
| `spec.disable_cdump` added to the gem's `mrbgem.rake`, `rake`; then removed | `gem_init.c` not written (the build is already broken by the row above) | `gem_init.c` written with `mrb_load_irep`; the presym table changes, 174 `CC`; removed: written back, 174 `CC` |
| a build directory built on `master`, `rake test` | | 95 `GEN` (every stamp was empty), 0 `CC`, 111 / 2073 OK; the run after that nothing; back to `master`: 42 `GEN` (the `gem.rb` time), 0 `CC`, green |
| `rake` with nothing to do, 5 alternating runs | 0.62 to 0.93 s wall | 0.61 to 0.68 s wall |
| `rake -m -j16 test` from an empty build directory | 111 / 2073 OK | 111 / 2073 OK; 95 stamps, none empty |
| `rake -m -j16 test MRUBY_CONFIG=ci/gcc-clang` from an empty build directory | | every target 0 KO, 0 crash; the run after that compiles nothing |
| a `CrossBuild` with no host (`mruby-bin-mruby` + `mruby-bigint`), `rake test` | | builds and runs; the run after that nothing |

## Environment

<details>

| | |
|---|---|
| OS | Linux 7.0.0-29-generic, x86_64 |
| Compiler | gcc 13.3.0 |
| binutils | 2.47 |
| Ruby | 4.0.6 |
| rake | 13.3.1 |

The compile line of `mrblib.o` in the default build, unchanged by this
PR (the record beside the object):

```console
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK -I"include" -I"build/host/include" -o "build/host/mrblib/mrblib.o" "build/host/mrblib/mrblib.c"
```

</details>

No C source changes and the compile lines are the same, so `.text` is
unaffected in every build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Generated files are now refreshed when their prerequisites or input values change.
  * Missing generated files are correctly detected and rebuilt.
  * Gem initialization output now updates when relevant source files or build settings change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->