### PR TITLE
mruby-regexp: support the atomic group `(?>...)`

### DIFF
--- a/mrbgems/mruby-regexp/README.md
+++ b/mrbgems/mruby-regexp/README.md
@@ -25,6 +25,7 @@ simulation) with backtracking fallback.
 - `(?!...)` negative lookahead
 - `(?<=...)` positive lookbehind (fixed-length only)
 - `(?<!...)` negative lookbehind (fixed-length only)
+- `(?>...)` atomic group
 - `(?imx-imx)` options for the rest of the enclosing group,
   `(?imx-imx:...)` options for the group's own body
 
@@ -145,13 +146,14 @@ $~                                # last MatchData
 The gem uses two execution engines:
 
 **Pike VM (NFA simulation)**: Used for patterns without
-backreferences, non-greedy quantifiers, or lookahead. Guarantees
-O(pattern x text) time complexity, making it immune to ReDoS
-attacks.
+backreferences, non-greedy quantifiers, lookaround or atomic groups.
+Guarantees O(pattern x text) time complexity, making it immune to
+ReDoS attacks.
 
 **Backtracking engine**: Used when patterns contain `\1`-`\9`
-backreferences, non-greedy quantifiers (`*?`, `+?`, `??`), or
-lookahead assertions (`(?=...)`, `(?!...)`). Protected by a
+backreferences, non-greedy quantifiers (`*?`, `+?`, `??`),
+lookaround assertions (`(?=...)`, `(?!...)`, `(?<=...)`, `(?<!...)`)
+or atomic groups (`(?>...)`). Protected by a
 configurable step limit (`MRB_REGEXP_STEP_LIMIT`, default 1M) to
 prevent excessive backtracking.
 

--- a/mrbgems/mruby-regexp/include/re_internal.h
+++ b/mrbgems/mruby-regexp/include/re_internal.h
@@ -39,6 +39,13 @@ enum re_opcode {
                         The executor rewinds by bytes against a binary subject
                         and by characters otherwise, and the sub-pattern body
                         starts past this instruction, at pc + 2. */
+  RE_ATOMIC,         /* atomic group (?>...): offset = nesting depth of the
+                        group, 1 for an outermost one. The body follows and
+                        ends at the RE_ATOMIC_END with the same depth; once
+                        the body has matched, a failure after it fails the
+                        whole group rather than backtracking into it. */
+  RE_ATOMIC_END,     /* end of an atomic group's body: offset = the depth of
+                        the RE_ATOMIC it closes */
 };
 
 /* Bytecode instruction (4 bytes each for alignment) */

--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -40,6 +40,7 @@ typedef struct {
   mrb_bool has_backref;
   mrb_bool needs_backtrack;
   mrb_bool dont_capture;    /* pattern declares a named group: plain (...) does not capture */
+  uint32_t atomic_depth;    /* how many (?>...) groups enclose the parse point */
   uint32_t atom_start;      /* where the atom a quantifier binds to begins;
                                compile_quantified sets it to the position
                                before the atom, and a `\u{...}` list moves it
@@ -1272,6 +1273,25 @@ compile_atom(re_compiler *c)
           c->flags = saved_flags;
           break;
         }
+        else if (c->p[1] == '>') {
+          /* atomic group (?>...): the body is a non-capturing group whose
+             first match is its only one. The two instructions bracketing it
+             carry the group's nesting depth, which is how the executor pairs
+             the end of a body with the group it closes when a failure after
+             the body has to fail the group; see bt_match(). The depth counts
+             instructions the pattern holds, so it fits the field. */
+          next_char(c); next_char(c);  /* skip ?> */
+          c->atomic_depth++;
+          emit(c, RE_ATOMIC, 0, (uint16_t)c->atomic_depth);
+          compile_alt(c);
+          emit(c, RE_ATOMIC_END, 0, (uint16_t)c->atomic_depth);
+          c->atomic_depth--;
+          if (peek(c) != ')') compile_error(c, "unmatched '('");
+          next_char(c);
+          c->needs_backtrack = TRUE;  /* the Pike VM cannot cut a thread */
+          c->flags = saved_flags;
+          break;
+        }
         else if (c->p[1] == '\'' ||
                  (c->p[1] == '<' && c->p + 2 < c->src_end &&
                   c->p[2] != '=' && c->p[2] != '!')) {
@@ -1322,7 +1342,7 @@ compile_atom(re_compiler *c)
         }
         else {
           /* (?X) with an unsupported X: not one of the recognized (?: (?= (?!
-             (?<= (?<! (?<name> (?'name' (?imx forms. Comment groups (?#...)
+             (?<= (?<! (?<name> (?'name' (?> (?imx forms. Comment groups (?#...)
              never get here either, having been removed by
              preprocess_pattern(). The absent operator (?~...) and
              conditionals (?(...)) are not implemented. Raise here rather
@@ -2097,6 +2117,7 @@ first_set_walk(const re_inst *code, uint32_t code_len,
     case RE_SAVE:
     case RE_BOL: case RE_EOL: case RE_BOT: case RE_EOT: case RE_EOTNL:
     case RE_WBOUND: case RE_NWBOUND:
+    case RE_ATOMIC: case RE_ATOMIC_END:
       pc++;
       continue;  /* zero-width, keep walking */
     case RE_JMP:
@@ -2158,6 +2179,7 @@ epsilon_path(const re_inst *code, uint32_t pc, uint32_t goal,
     case RE_SAVE:
     case RE_BOL: case RE_EOL: case RE_BOT: case RE_EOT: case RE_EOTNL:
     case RE_WBOUND: case RE_NWBOUND:
+    case RE_ATOMIC: case RE_ATOMIC_END:
       pc++;
       break;
     case RE_JMP:

--- a/mrbgems/mruby-regexp/src/re_exec.c
+++ b/mrbgems/mruby-regexp/src/re_exec.c
@@ -612,74 +612,105 @@ lookbehind_start(const mrb_regexp_pattern *pat, const char *str,
   return sp;
 }
 
+/* What one bt_match() frame answers. The frame that reaches RE_MATCH answers
+   BT_MATCH, and every frame under it hands that up unchanged. A frame whose
+   alternatives are exhausted answers BT_FAIL, and its caller tries the next
+   alternative of its own. The third answer is the cut of an atomic group:
+   the text after an RE_ATOMIC_END has failed, and no alternative inside the
+   group's body may be tried for it, so the frames between that end and the
+   RE_ATOMIC that opened the group hand BT_CUT of the group's depth up
+   unchanged, undoing their captures as they go, and the frame that ran that
+   RE_ATOMIC turns it into BT_FAIL. A cut never reaches a lookaround from
+   inside its sub-pattern: the RE_ATOMIC that absorbs it is in there too.
+   The fourth answer, BT_LIMIT, is a frame giving up at the recursion or step
+   limit. A frame that gets it hands it up; a SPLIT takes it as that branch
+   failing and answers with its other branch, as it would with a failure.
+   What no frame does is turn it into a cut or into a lookaround's answer,
+   since a limit says nothing about the text. That matters because the
+   recursion limit is what stops a repetition whose body can match empty
+   under this engine (see MRB_REGEXP_RECURSION_LIMIT), and the repetition
+   being stopped may be inside an atomic group's body, where a cut would keep
+   its exit from being taken, or inside a negative lookaround, where reading
+   the limit as "no match" would make the assertion hold. */
+#define BT_FAIL 0
+#define BT_MATCH 1
+#define BT_LIMIT 2
+#define BT_CUT(atomic_depth) (-(int)(atomic_depth))
+
 /*
  * Backtracking engine for patterns with backreferences.
  * Step-limited to prevent ReDoS.
  */
-static mrb_bool
+static int
 bt_match(const mrb_regexp_pattern *pat, const char *str, const char *str_end,
          const char *sp, uint32_t pc, int *captures, int ncap, int *steps,
          int depth, mrb_bool binary)
 {
-  if (depth > MRB_REGEXP_RECURSION_LIMIT) return FALSE;
+  if (depth > MRB_REGEXP_RECURSION_LIMIT) return BT_LIMIT;
   while (pc < pat->code_len) {
-    if (++(*steps) > MRB_REGEXP_STEP_LIMIT) return FALSE;
+    if (++(*steps) > MRB_REGEXP_STEP_LIMIT) return BT_LIMIT;
 
     re_inst inst = pat->code[pc];
     switch (inst.op) {
     case RE_CHAR:
-      if (sp >= str_end || (uint8_t)*sp != inst.a) return FALSE;
+      if (sp >= str_end || (uint8_t)*sp != inst.a) return BT_FAIL;
       sp++; pc++;
       break;
 
     case RE_ANY:
-      if (sp >= str_end || *sp == '\n') return FALSE;
+      if (sp >= str_end || *sp == '\n') return BT_FAIL;
       sp += mrb_re_charlen(sp, str_end, binary); pc++;
       break;
 
     case RE_ANY_NL:
-      if (sp >= str_end) return FALSE;
+      if (sp >= str_end) return BT_FAIL;
       sp += mrb_re_charlen(sp, str_end, binary); pc++;
       break;
 
     case RE_CLASS:
-      if (sp >= str_end) return FALSE;
+      if (sp >= str_end) return BT_FAIL;
       {
         int dlen = 0;
         uint32_t cp_ = mrb_re_decode_char(sp, str_end, &dlen, binary);
         mrb_bool raw = (dlen == 1 && (uint8_t)*sp >= 0x80);
-        if (!class_match(&pat->classes[inst.a], cp_, raw)) return FALSE;
+        if (!class_match(&pat->classes[inst.a], cp_, raw)) return BT_FAIL;
         sp += mrb_re_charlen(sp, str_end, binary);
       }
       pc++;
       break;
 
     case RE_NCLASS:
-      if (sp >= str_end) return FALSE;
+      if (sp >= str_end) return BT_FAIL;
       {
         int dlen = 0;
         uint32_t cp_ = mrb_re_decode_char(sp, str_end, &dlen, binary);
         mrb_bool raw = (dlen == 1 && (uint8_t)*sp >= 0x80);
-        if (class_match(&pat->classes[inst.a], cp_, raw)) return FALSE;
+        if (class_match(&pat->classes[inst.a], cp_, raw)) return BT_FAIL;
         sp += mrb_re_charlen(sp, str_end, binary);
       }
       pc++;
       break;
 
     case RE_MATCH:
-      return TRUE;
+      return BT_MATCH;
 
     case RE_JMP:
       pc = inst.offset;
       break;
 
     case RE_SPLIT:
-      if (bt_match(pat, str, str_end, sp, pc + 1, captures, ncap, steps, depth + 1, binary)) return TRUE;
+      {
+        int r = bt_match(pat, str, str_end, sp, pc + 1, captures, ncap, steps, depth + 1, binary);
+        if (r != BT_FAIL && r != BT_LIMIT) return r;
+      }
       pc = inst.offset;
       break;
 
     case RE_SPLITNG:
-      if (bt_match(pat, str, str_end, sp, inst.offset, captures, ncap, steps, depth + 1, binary)) return TRUE;
+      {
+        int r = bt_match(pat, str, str_end, sp, inst.offset, captures, ncap, steps, depth + 1, binary);
+        if (r != BT_FAIL && r != BT_LIMIT) return r;
+      }
       pc++;
       break;
 
@@ -691,37 +722,41 @@ bt_match(const mrb_regexp_pattern *pat, const char *str, const char *str_end,
            branches, so a longer one can still match. */
         if (slot == 1 && !binary && sp < str_end &&
             mrb_re_char_interior_p(str, sp, str_end)) {
-          return FALSE;
+          return BT_FAIL;
         }
         if (slot < ncap) {
           int old = captures[slot];
           captures[slot] = (int)(sp - str);
-          if (bt_match(pat, str, str_end, sp, pc + 1, captures, ncap, steps, depth + 1, binary)) return TRUE;
+          int r = bt_match(pat, str, str_end, sp, pc + 1, captures, ncap, steps, depth + 1, binary);
+          if (r == BT_MATCH) return r;
+          /* undone for a cut as for a failure: the group the cut fails may
+             be the one this slot was written inside */
           captures[slot] = old;
+          return r;
         }
-        return FALSE;
+        return BT_FAIL;
       }
 
     case RE_BOL:
       /* ^ always matches at a line start (see the Pike VM case); /m only
          affects `.`. \A is RE_BOT. A trailing \n opens no final line. */
-      if (sp != str && (sp == str_end || sp[-1] != '\n')) return FALSE;
+      if (sp != str && (sp == str_end || sp[-1] != '\n')) return BT_FAIL;
       pc++;
       break;
 
     case RE_EOL:
       /* $ always matches at a line end. */
-      if (sp != str_end && *sp != '\n') return FALSE;
+      if (sp != str_end && *sp != '\n') return BT_FAIL;
       pc++;
       break;
 
     case RE_BOT:
-      if (sp != str) return FALSE;
+      if (sp != str) return BT_FAIL;
       pc++;
       break;
 
     case RE_EOT:
-      if (sp != str_end) return FALSE;
+      if (sp != str_end) return BT_FAIL;
       pc++;
       break;
 
@@ -729,7 +764,7 @@ bt_match(const mrb_regexp_pattern *pat, const char *str, const char *str_end,
       {
         mrb_bool before = (sp > str) && mrb_re_is_word_char((uint8_t)sp[-1]);
         mrb_bool after = (sp < str_end) && mrb_re_is_word_char((uint8_t)*sp);
-        if (before == after) return FALSE;
+        if (before == after) return BT_FAIL;
       }
       pc++;
       break;
@@ -738,7 +773,7 @@ bt_match(const mrb_regexp_pattern *pat, const char *str, const char *str_end,
       {
         mrb_bool before = (sp > str) && mrb_re_is_word_char((uint8_t)sp[-1]);
         mrb_bool after = (sp < str_end) && mrb_re_is_word_char((uint8_t)*sp);
-        if (before != after) return FALSE;
+        if (before != after) return BT_FAIL;
       }
       pc++;
       break;
@@ -746,21 +781,21 @@ bt_match(const mrb_regexp_pattern *pat, const char *str, const char *str_end,
     case RE_BACKREF:
       {
         int group = inst.a;
-        if (group * 2 + 1 >= ncap) return FALSE;
+        if (group * 2 + 1 >= ncap) return BT_FAIL;
         int gs = captures[group * 2];
         int ge = captures[group * 2 + 1];
-        if (gs < 0 || ge < 0) return FALSE;
+        if (gs < 0 || ge < 0) return BT_FAIL;
         int blen = ge - gs;
         if (inst.offset) {
           /* A folded comparison can consume a different number of bytes than
              the captured text holds, so the span is measured, not assumed. */
           int used = memcmp_ci(sp, str_end, str + gs, str + ge, binary);
-          if (used < 0) return FALSE;
+          if (used < 0) return BT_FAIL;
           sp += used;
         }
         else {
-          if (sp + blen > str_end) return FALSE;
-          if (memcmp(sp, str + gs, blen) != 0) return FALSE;
+          if (sp + blen > str_end) return BT_FAIL;
+          if (memcmp(sp, str + gs, blen) != 0) return BT_FAIL;
           sp += blen;
         }
         pc++;
@@ -768,23 +803,31 @@ bt_match(const mrb_regexp_pattern *pat, const char *str, const char *str_end,
       break;
 
     case RE_LOOKAHEAD:
-      if (!bt_match(pat, str, str_end, sp, pc + 1, captures, ncap, steps, depth + 1, binary))
-        return FALSE;
-      pc = inst.offset;
+      {
+        /* A sub-pattern answers BT_MATCH, BT_FAIL or BT_LIMIT, never a cut.
+           The two failures go up as they are; the four lookarounds only
+           differ in what a match means. */
+        int r = bt_match(pat, str, str_end, sp, pc + 1, captures, ncap, steps, depth + 1, binary);
+        if (r != BT_MATCH) return r;
+        pc = inst.offset;
+      }
       break;
 
     case RE_NEG_LOOKAHEAD:
-      if (bt_match(pat, str, str_end, sp, pc + 1, captures, ncap, steps, depth + 1, binary))
-        return FALSE;
-      pc = inst.offset;
+      {
+        int r = bt_match(pat, str, str_end, sp, pc + 1, captures, ncap, steps, depth + 1, binary);
+        if (r == BT_MATCH) return BT_FAIL;
+        if (r == BT_LIMIT) return r;
+        pc = inst.offset;
+      }
       break;
 
     case RE_LOOKBEHIND:
       {
         const char *back = lookbehind_start(pat, str, str_end, sp, pc, binary);
-        if (!back) return FALSE;  /* not enough text before */
-        if (!bt_match(pat, str, str_end, back, pc + 2, captures, ncap, steps, depth + 1, binary))
-          return FALSE;
+        if (!back) return BT_FAIL;  /* not enough text before */
+        int r = bt_match(pat, str, str_end, back, pc + 2, captures, ncap, steps, depth + 1, binary);
+        if (r != BT_MATCH) return r;
         pc = inst.offset;
       }
       break;
@@ -792,19 +835,42 @@ bt_match(const mrb_regexp_pattern *pat, const char *str, const char *str_end,
     case RE_NEG_LOOKBEHIND:
       {
         const char *back = lookbehind_start(pat, str, str_end, sp, pc, binary);
-        if (back &&
-            bt_match(pat, str, str_end, back, pc + 2, captures, ncap, steps, depth + 1, binary))
-          return FALSE;
+        if (back) {
+          int r = bt_match(pat, str, str_end, back, pc + 2, captures, ncap, steps, depth + 1, binary);
+          if (r == BT_MATCH) return BT_FAIL;
+          if (r == BT_LIMIT) return r;
+        }
         /* if not enough text before, negative lookbehind succeeds */
         pc = inst.offset;
       }
       break;
 
+    case RE_ATOMIC:
+      {
+        /* The body runs on through its RE_ATOMIC_END to the end of the
+           pattern inside this call, so there is nothing to continue with
+           here: the answer is passed up, except that a cut aimed at this
+           group is this group failing, which the caller backtracks over the
+           way it would any other failed atom. */
+        int r = bt_match(pat, str, str_end, sp, pc + 1, captures, ncap, steps, depth + 1, binary);
+        return (r == BT_CUT(inst.offset)) ? BT_FAIL : r;
+      }
+
+    case RE_ATOMIC_END:
+      {
+        /* The body has matched once, and that is the only way it matches:
+           when what follows fails, the failure is a cut, so that the SPLITs
+           inside the body do not get to try their other branches. A limit
+           is not the text failing and goes up as it is. */
+        int r = bt_match(pat, str, str_end, sp, pc + 1, captures, ncap, steps, depth + 1, binary);
+        return (r == BT_FAIL) ? BT_CUT(inst.offset) : r;
+      }
+
     default:
-      return FALSE;
+      return BT_FAIL;
     }
   }
-  return FALSE;
+  return BT_FAIL;
 }
 
 static int
@@ -837,7 +903,7 @@ backtrack_exec(mrb_state *mrb, const mrb_regexp_pattern *pat,
     memset(caps, -1, sizeof(int) * ncap);
     int steps = 0;
 
-    if (bt_match(pat, str, str_end, sp, 0, caps, ncap, &steps, 0, binary)) {
+    if (bt_match(pat, str, str_end, sp, 0, caps, ncap, &steps, 0, binary) == BT_MATCH) {
       if (captures) {
         int copy = ncap < captures_size ? ncap : captures_size;
         memcpy(captures, caps, sizeof(int) * copy);

--- a/mrbgems/mruby-regexp/test/regexp_syntax.rb
+++ b/mrbgems/mruby-regexp/test/regexp_syntax.rb
@@ -521,6 +521,66 @@ assert("Regexp - non-capturing group") do
   assert_nil md[2]
 end
 
+assert("Regexp - atomic group (?>...)") do
+  # The body's first match is its only one: what follows cannot make it
+  # give text back or take another branch, where a plain group can.
+  assert_equal 0, /(?>a)+b/ =~ "aab"
+  assert_equal 0, /(?:a+)ab/ =~ "aaab"
+  assert_nil /(?>a+)ab/ =~ "aaab"
+  assert_equal 0, /(?>a+)b/ =~ "aaab"
+  assert_equal 0, /(?:a|ab)c/ =~ "abc"
+  assert_nil /(?>a|ab)c/ =~ "abc"
+  assert_equal 0, /(?>ab|a)c/ =~ "abc"
+
+  # A repeated atomic group still gives back whole iterations: only the
+  # inside of each one is closed to backtracking.
+  assert_equal 0, /(?>a)+a/ =~ "aa"
+  assert_equal 0, /(?>ab)+c/ =~ "ababc"
+  assert_nil /(?>ab)+c/ =~ "abbc"
+  assert_equal 0, /(?>a){2}b/ =~ "aab"
+  assert_equal 1, /(?>ab)*?b/ =~ "abab"
+  assert_equal 0, /(?>ab)|x/ =~ "x"
+
+  # Once a group is closed, a failure after it fails the group as a whole,
+  # even an alternation at the top of its body.
+  assert_nil /(?>a(?>b|bc)|abcd)d/ =~ "abcd"
+  # Before it is closed, its body backtracks as any other does, past an
+  # inner atomic group that already closed.
+  assert_equal "xy", /(?>(x|xy)(?>a)b)/.match("xyab")[1]
+  # Sequential atomic groups at the same depth cut independently.
+  assert_nil /(?>x(?>a)(?>b)y)/.match("xabz")
+  assert_equal 0, /(?>x(?>a)(?>b)y)/ =~ "xaby"
+
+  # A repetition whose body can match empty runs until the engine's recursion
+  # limit stops it. Reached inside the body, that stop is not a cut.
+  assert_equal 0, /(?>(?:b*)+)/ =~ ""
+  assert_equal 0, /(?>(?:a*)*)b/ =~ "aab"
+
+  # Captures written inside the body stay when the group matches, and are
+  # unset again when a cut fails the group.
+  assert_equal "a", /(?>(a)+)b/.match("aab")[1]
+  assert_nil /(?:(?>(a))x|a)b/.match("ab")[1]
+  assert_equal "a", /(?>(a)|ab)b/.match("ab")[1]
+
+  # Inside a lookaround, the cut stays inside it.
+  assert_equal 0, /(?=(?>a+)b)a/ =~ "aab"
+  assert_nil /(?=(?>a+)ab)a/ =~ "aab"
+  assert_equal 0, /(?!(?>a)b)a/ =~ "aac"
+
+  # Options toggled in the body end with it, as in any group.
+  assert_equal 0, /(?>a(?i)x)b/ =~ "aXb"
+  assert_nil /(?>a(?i)x)B/ =~ "aXb"
+
+  # It reads back through to_s, and free-spacing applies to its body.
+  assert_equal 0, Regexp.new(/(?>a)+b/.to_s) =~ "aab"
+  assert_equal 0, Regexp.new("(?> a b )c", Regexp::EXTENDED) =~ "abc"
+
+  assert_raise(RegexpError) { Regexp.new("(?>a") }
+  assert_raise(RegexpError) { Regexp.new("(?>") }
+  # not a fixed-length construct, so not allowed in a lookbehind
+  assert_raise(RegexpError) { Regexp.new("(?<=(?>a))b") }
+end
+
 assert("Regexp - a named group makes plain groups non-capturing") do
   # Onigmo's ONIG_OPTION_DONT_CAPTURE_GROUP, which CRuby turns on once the
   # pattern declares a named group: (...) then groups without capturing.


### PR DESCRIPTION
An atomic group commits to the first match of its body: once the body has
matched, what follows may fail the group as a whole but cannot make the body
give text back or take another branch. The parser refused the form, so a
pattern that uses it to keep a quantifier from backtracking could not be
compiled:

```ruby
/(?>a+)ab/ =~ "aaab"   # CRuby: nil
                       # mruby: RegexpError, undefined (?...) sequence
/(?>a|ab)c/ =~ "abc"   # CRuby: nil
/(?>a)+b/ =~ "aab"     # CRuby: 0
```

## Compiling the group

The compiler brackets the body with two zero-width instructions, `RE_ATOMIC`
and `RE_ATOMIC_END`. Both carry the group's nesting depth, 1 for an outermost
group, which is how the executor pairs the end of a body with the group it
closes when the groups nest. The parser counts the depth in `atomic_depth`
while it is inside the body, and the group forces the backtracking engine,
since the Pike VM has no way to cut a thread. Both zero-width walkers in the
compiler step over the two instructions, and `compute_fixed_len()` still
rejects them, so an atomic group is not accepted inside a lookbehind, as in
Onigmo.

## The cut

`bt_match()` now answers one of four things instead of a bool. `BT_MATCH` and
`BT_FAIL` are the two it had. The third, `BT_CUT(depth)`, is what an
`RE_ATOMIC_END` answers when the text after it fails: the frames between that
end and the `RE_ATOMIC` that opened the group hand it up unchanged, so none of
the `RE_SPLIT`s inside the body get to try their other branch, and the frame
that ran the `RE_ATOMIC` turns it into `BT_FAIL`, which its caller backtracks
over the way it would any other failed atom. `RE_SAVE` undoes its capture for
a cut as for a failure, since the group the cut fails may be the one the slot
was written inside. A cut never escapes a lookaround, because the `RE_ATOMIC`
that absorbs it is inside the sub-pattern too.

The depth is what makes nested and sequential groups come out right. In
`/(?>a(?>b|bc)|abcd)d/`, a `d` failing after the outer group is a cut of
depth 1: it passes through the inner group's end and start unchanged, and the
`|` in the outer body may not try `abcd`. In `/(?>x(?>a)(?>b)y)/`, the two
inner groups have the same depth 2, and each cut is absorbed by the
`RE_ATOMIC` frame nearest to it, which is its own.

The fourth answer, `BT_LIMIT`, is what a frame answers when it gives up at
the recursion or step limit. A frame that gets it hands it up; a `RE_SPLIT`
takes it as that branch failing and answers with its other branch, as it
would with a failure. What no frame does is turn it into a cut, or into a
lookaround's answer, since a limit says nothing about the text. That matters
because the recursion limit is what stops a repetition whose body can match
empty under this engine, and the repetition being stopped may be inside the
group's body, where a cut would keep its exit from being taken:

```ruby
/(?>(?:b*)+)/ =~ ""     # CRuby: 0
```

The four lookarounds hand a limit up for the same reason: read as "no match",
it would make a negative assertion hold. In practice the `RE_SPLIT` nearest
the limit answers with its exit branch and the limit rarely reaches the
sub-pattern's frame at all, so no differential run told the two apart; the
rule is there so that no frame invents an answer.

The README lists the group and names it among the constructs that pick the
backtracking engine, alongside the lookbehinds it had left out.

## Size

`.text` of `bin/mruby`, `build_config/ci/gcc-clang.rb`, each side from a clean
build directory. `re_compile.o` and `re_exec.o` are the objects that change;
in `bintest` they account for +528 and +1,104 of the delta.

| build | master | this PR | delta |
|---|---:|---:|---:|
| `bintest` | 1,280,870 | 1,282,502 | +1,632 |
| `ascii-case` | 1,268,614 | 1,270,214 | +1,600 |
| `byte-string` | 1,248,790 | 1,250,214 | +1,424 |
| `cxx_abi` | 1,305,897 | 1,307,177 | +1,280 |
| `full-debug` (`-O0`) | 1,877,478 | 1,878,502 | +1,024 |

## Verification

The tests go in `regexp_syntax.rb` beside the other group forms. They cover
the cut against a plain group, a repeated atomic group giving back whole
iterations, nested and sequential groups at the same depth, the recursion
limit reached inside the body, captures kept and unset, the cut staying inside
a lookaround, options ending with the body, `to_s` round-tripping and
free-spacing, and the three rejected forms.

**Differential against CRuby 4.0.6.** Random patterns over `a`, `b`, `c`,
`.`, `[ab]`, plain, non-capturing and atomic groups, alternation and all the
quantifiers including the lazy and interval forms, nested up to four deep,
each with at least one atomic group, run with `match` against 30 subjects and
compared as `MatchData#to_a`:

| generator | patterns | lines | differ |
|---|---:|---:|---:|
| no quantifier on an atom that can match empty | 6,000 | 180,000 | 0 |
| plus lookahead, no capture inside it | 3,000 | 90,000 | 0 |
| plus lookahead with captures, and backreferences | 3,000 | 90,000 | 276 |
| plus backreferences alone | 3,000 | 90,000 | 18 |
| quantifiers anywhere | 3,000 | 90,000 | 480 |

The 294 lines with lookaround captures and backreferences are each a capture
written inside a lookaround or a backreference to the group that contains it,
two things this engine already answers differently from Onigmo; at 288 of
them, master gives the same answer as here for the pattern with its atomic
groups made plain. The 480 lines with quantifiers anywhere are repetitions
whose body can match empty: this engine has no empty-iteration stop and runs
such a repetition to the recursion limit, on master as here, and at 373 of
the 480, master's answer for the pattern with the atomic groups made plain
differs from CRuby as well.

**`rake test`**, `build_config/ci/gcc-clang.rb`, no compiler warning:

| build | total | KO | crash |
|---|---:|---:|---:|
| `full-debug` | 2,349 | 0 | 0 |
| `bintest` | 2,349 | 0 | 0 |
| `bintest` (bintest suite) | 123 | 0 | 0 |
| `cxx_abi` | 2,349 | 0 | 0 |
| `byte-string` | 2,279 | 0 | 0 |
| `ascii-case` | 2,346 | 0 | 0 |

The default configuration: 2,125 total, 0 KO, 0 crash, plus its 112 bintests.

### Environment

<details>

| | |
|---|---|
| OS | Ubuntu 24.04, Linux 7.0.0 x86_64 |
| gcc | 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1) |
| binutils | 2.47 |
| CRuby | 4.0.6, for the differential |

Compile lines for `mrbgems/mruby-regexp/src/re_exec.c` in the builds quoted
above, paths shortened:

```
# ci/gcc-clang bintest
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK -I"include" -I"mrbgems/mruby-regexp/include" -I"build/bintest/include" -o "build/bintest/mrbgems/mruby-regexp/src/re_exec.o" "mrbgems/mruby-regexp/src/re_exec.c"

# ci/gcc-clang full-debug
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -I"include" -I"mrbgems/mruby-regexp/include" -I"build/full-debug/include" -o "build/full-debug/mrbgems/mruby-regexp/src/re_exec.o" "mrbgems/mruby-regexp/src/re_exec.c"

# ci/gcc-clang cxx_abi
gcc -MMD -c -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -I"include" -I"mrbgems/mruby-regexp/include" -I"build/cxx_abi/include" -o "build/cxx_abi/mrbgems/mruby-regexp/src/re_exec.o" "mrbgems/mruby-regexp/src/re_exec.c"

# ci/gcc-clang byte-string
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -I"include" -I"mrbgems/mruby-regexp/include" -I"build/byte-string/include" -o "build/byte-string/mrbgems/mruby-regexp/src/re_exec.o" "mrbgems/mruby-regexp/src/re_exec.c"

# ci/gcc-clang ascii-case
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CASE -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -I"include" -I"mrbgems/mruby-regexp/include" -I"build/ascii-case/include" -o "build/ascii-case/mrbgems/mruby-regexp/src/re_exec.o" "mrbgems/mruby-regexp/src/re_exec.c"
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for atomic groups using `(?>...)` in regular expressions.
  - Atomic groups now prevent backtracking into completed group matches, enabling more precise matching behavior.
  - Patterns using atomic groups automatically use the compatible backtracking engine.

- **Bug Fixes**
  - Improved handling of nested groups, captures, lookarounds, repetition, and empty matches involving atomic groups.
  - Invalid atomic-group syntax now raises `RegexpError` consistently.

- **Documentation**
  - Documented atomic-group syntax and engine-selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->