### PR TITLE
mruby-regexp: match `\Z` under the backtracking engine

### DIFF
--- a/mrbgems/mruby-regexp/src/re_exec.c
+++ b/mrbgems/mruby-regexp/src/re_exec.c
@@ -725,6 +725,11 @@ bt_match(const mrb_regexp_pattern *pat, const char *str, const char *str_end,
       pc++;
       break;
 
+    case RE_EOTNL:
+      if (sp != str_end && !(sp + 1 == str_end && *sp == '\n')) return FALSE;
+      pc++;
+      break;
+
     case RE_WBOUND:
       {
         mrb_bool before = (sp > str) && mrb_re_is_word_char((uint8_t)sp[-1]);

--- a/mrbgems/mruby-regexp/test/regexp_syntax.rb
+++ b/mrbgems/mruby-regexp/test/regexp_syntax.rb
@@ -191,6 +191,21 @@ assert("Regexp - ^ and $ always match at line boundaries") do
   assert_equal "bar", "foo\nbar".match(/bar\z/)[0]
 end
 
+assert("Regexp - \\Z matches before a trailing newline under both engines") do
+  # \Z is the string end or the position just before a final newline. The
+  # lazy quantifier routes the pattern to the backtracking engine, which had
+  # no case for the opcode and so failed every \Z it saw.
+  assert_equal 0, "a" =~ /a\Z/
+  assert_equal 0, "a\n" =~ /a\Z/
+  assert_nil "a\n\n" =~ /a\Z/
+  assert_nil "ab" =~ /a\Z/
+  assert_equal 0, "a" =~ /a\Za*?/
+  assert_equal 0, "a\n" =~ /a\Z.*?/
+  assert_nil "a\n\n" =~ /a\Z.*?/
+  assert_nil "ab" =~ /a\Zb*?/
+  assert_equal "aX\n", "ab\n".sub(/b\Z(?=)/, "X")
+end
+
 assert("Regexp - case insensitive") do
   re = Regexp.new("abc", Regexp::IGNORECASE)
   assert_true re.match?("ABC")


### PR DESCRIPTION
`\Z` compiles to `RE_EOTNL`, and only the Pike VM executed it. `bt_match()`
had no case for the opcode, so it fell to `default:` and failed, and `\Z`
never matched once anything in the pattern routed it to the backtracking
engine, whether or not the subject ended in a newline:

```ruby
"a"   =~ /a\Za*?/           # CRuby: 0,      mruby: nil
"a\n" =~ /a\Z.*?/           # CRuby: 0,      mruby: nil
"a\n" =~ /(a)\1*\Z/         # CRuby: 0,      mruby: nil
"ab\n".sub(/b\Z(?=)/, "X")  # CRuby: "aX\n", mruby: "ab\n"
"a\n" =~ /a\Z/              # 0 in both, the Pike VM has the case
```

A lazy quantifier, a backreference, or a lookaround is enough to get there,
and with #7256 an atomic group. It has been so since the backtracking engine
landed in 23b2d24cf, and no test in the gem used `\Z`, so nothing noticed.
`RE_EOTNL` was the one opcode the Pike VM handled that `bt_match()` did not;
the ones the other way round are the backreference and the lookarounds, which
only the backtracker runs.

### The fix

One case beside `RE_EOT` in `bt_match()`, testing what `add_thread()` tests:
the string end, or the position just before a newline that is the last byte.

The test exercises `\Z` under both engines, with the lazy quantifier as the
shortest way onto the backtracker, and pins the two positions it must not
match: before a newline that is not the last byte, and before any other byte.

### Testing

`build_config/ci/gcc-clang.rb` and `build_config/gcc-asan.rb`, run per build so
the counts are attributable:

| build | tests | OK | KO | skip |
| --- | ---: | ---: | ---: | ---: |
| `full-debug` | 2349 | 2343 | 0 | 6 |
| `bintest` | 2349 | 2335 | 0 | 14 |
| `cxx_abi` | 2349 | 2335 | 0 | 14 |
| `byte-string` | 2279 | 2228 | 0 | 51 |
| `ascii-case` | 2346 | 2332 | 0 | 14 |
| `gcc-asan` | 2349 | 2343 | 0 | 6 |

The binary tests pass 122 of 123 under `ci/gcc-clang` and 84 of 85 under
`gcc-asan`, one skip each. The only warning any build prints is the
`-Wreturn-type` line `gcc-asan` gives for `src/vm.c:4073` at `-O0`, and master
prints the same; this branch does not touch `src/vm.c`.

Against a `bt_match()` without the case, the test block turns red:

```console
Fail: Regexp - \Z matches before a trailing newline under both engines (mrbgems: mruby-regexp)
```

### Size

Summed `.text` over `libmruby.a`, `full-core` at `-O3`, each build from an
empty build directory:

| | master | this branch | delta |
| --- | ---: | ---: | ---: |
| `libmruby.a` `.text` | 1290173 | 1290285 | +112 |
| `re_exec.o` `.text` | 16242 | 16354 | +112 |

The whole of it is the new case in `bt_match()`. `mruby-regexp` is not in the
default gembox, so `build_config/default.rb` does not move.

### Environment

<details>

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-29-generic x86_64 |
| C compiler | gcc 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1) |
| binutils | GNU ld 2.47.20260726 |
| CRuby (oracle for the examples) | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM |

The size rows use a build config of their own, so that `full-core` at `-O3`
carries no test or debug options:

```ruby
MRuby::Build.new('size') do |conf|
  conf.toolchain
  conf.gembox 'full-core'
end
```

Compile lines for `mrbgems/mruby-regexp/src/re_exec.c` in the builds quoted
above, paths shortened:

```
# size, the -O3 full-core rows
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -I"include" -I"mrbgems/mruby-regexp/include" -I"build/size/include" -o "build/size/mrbgems/mruby-regexp/src/re_exec.o" "mrbgems/mruby-regexp/src/re_exec.c"

# ci/gcc-clang full-debug
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -I"include" -I"mrbgems/mruby-regexp/include" -I"build/full-debug/include" -o "build/full-debug/mrbgems/mruby-regexp/src/re_exec.o" "mrbgems/mruby-regexp/src/re_exec.c"

# ci/gcc-clang bintest
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK -I"include" -I"mrbgems/mruby-regexp/include" -I"build/bintest/include" -o "build/bintest/mrbgems/mruby-regexp/src/re_exec.o" "mrbgems/mruby-regexp/src/re_exec.c"

# ci/gcc-clang cxx_abi
gcc -MMD -c -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -I"include" -I"mrbgems/mruby-regexp/include" -I"build/cxx_abi/include" -o "build/cxx_abi/mrbgems/mruby-regexp/src/re_exec.o" "mrbgems/mruby-regexp/src/re_exec.c"

# ci/gcc-clang byte-string
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -I"include" -I"mrbgems/mruby-regexp/include" -I"build/byte-string/include" -o "build/byte-string/mrbgems/mruby-regexp/src/re_exec.o" "mrbgems/mruby-regexp/src/re_exec.c"

# ci/gcc-clang ascii-case
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CASE -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -I"include" -I"mrbgems/mruby-regexp/include" -I"build/ascii-case/include" -o "build/ascii-case/mrbgems/mruby-regexp/src/re_exec.o" "mrbgems/mruby-regexp/src/re_exec.c"

# gcc-asan
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -fsanitize=address,undefined -g3 -O0 -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -I"include" -I"mrbgems/mruby-regexp/include" -I"build/gcc-asan/include" -o "build/gcc-asan/mrbgems/mruby-regexp/src/re_exec.o" "mrbgems/mruby-regexp/src/re_exec.c"
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected `\Z` regular-expression matching so it recognizes both the true end of a string and the position immediately before a single trailing newline.
  - Prevented incorrect matches when strings contain multiple trailing newlines or unmatched suffixes.
  - Improved behavior with lazy quantifiers and substitutions using lookaheads.
- **Tests**
  - Added regression coverage across supported regular-expression engines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->