### PR TITLE
vm.c: end `mrb_vm_exec()` with a return the retry loop never reaches

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -4070,6 +4070,8 @@ RETRY_TRY_BLOCK:
     goto RETRY_TRY_BLOCK;
   }
   MRB_END_EXC(&c_jmp);
+  /* not reached */
+  return mrb_nil_value();
 }
 
 static mrb_value


### PR DESCRIPTION
`mrb_vm_exec()` is one `MRB_TRY` block. Every path through the dispatch loop inside it returns, and the `MRB_CATCH` arm ends with `goto RETRY_TRY_BLOCK`, so nothing falls out of the block; the function ends right after `MRB_END_EXC` with no `return` of its own. Whether a compiler sees that depends on how far it follows the flow. gcc 13 at `-O0` with `-fsanitize=address` does not, and every `build_config/gcc-asan.rb` build compiles `src/vm.c` with

```
src/vm.c:4073:1: warning: control reaches end of non-void function [-Wreturn-type]
```

the one warning of that build. The same source at `-O0` without a sanitizer (`ci/gcc-clang` `full-debug`), with `-fsanitize=undefined` alone, at `-O3`, as C++ under `MRB_USE_CXX_ABI`, and under clang compiles clean, so the warning is not about a real path.

### Change

Add `return mrb_nil_value();` after `MRB_END_EXC`, marked `/* not reached */`, the way `INIT_DISPATCH` in the same file follows its own `JUMP`, and the way `mrb_mod_cv_get`, `mrb_str_len_to_integer` and `mrb_f_raise` end after a raise.

### Verification

| build | warnings in `src/vm.c` (master) | warnings (this PR) |
| --- | --- | --- |
| `build_config/gcc-asan.rb` | 1 (`-Wreturn-type`) | 0 |
| default (`build_config/default.rb`) | 0 | 0 |

`.text` of the default build, master vs this PR:

| object | master | this PR |
| --- | --- | --- |
| `build/host/src/vm.o` | 66758 | 66758 |

`vm.o` is the only object the change touches, so `libmruby.a` and `bin/mruby` are byte-for-byte the same size as on master.

`rake -m test` (mrbtest and bintest) is green on both the default and the `gcc-asan` build.

### Environment

<details>

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS, Linux 7.0.0-29-generic x86_64 |
| CPU | AMD Ryzen 9 5950X |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0 |
| binutils | GNU ld (GNU Binutils) 2.47.20260726 |
| CRuby | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM |

Compile lines for `src/vm.c` (`-MMD -c`, `-I` and `-o` dropped):

```console
# default
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK src/vm.c
# gcc-asan
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -fsanitize=address,undefined -g3 -O0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/vm.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a safe fallback for an unreachable execution path in the virtual machine, improving runtime stability in exceptional cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->