### PR TITLE
mruby-regexp: reject a hex escape with no digit

### DIFF
--- a/mrbgems/mruby-regexp/README.md
+++ b/mrbgems/mruby-regexp/README.md
@@ -33,7 +33,7 @@ simulation) with backtracking fallback.
 
 - `\n`, `\t`, `\r`, `\f`, `\v`, `\a`, `\e` control characters
 - `\NNN` octal, one to three digits
-- `\xHH` hex, one or two digits
+- `\xHH` hex, one or two digits; `\x` with no digit raises `RegexpError`
 - `\uXXXX` Unicode codepoint, exactly four hex digits
 - `\u{...}` Unicode codepoints, one to six hex digits each, several of
   them separated by spaces: `/\u{61 62}/` is `ab`
@@ -175,7 +175,8 @@ pattern analysis.
 - **No Unicode properties**: `\p{Alpha}`, `\p{L}`, etc. are not
   supported.
 - **No `\x{...}` hex escape**: the hex escape is `\xHH`, so it reaches
-  `0xff` at most. Write `\u{...}` for a codepoint above that.
+  `0xff` at most, and `\x{...}` raises `RegexpError` as CRuby does, since
+  the brace is not a hex digit. Write `\u{...}` for a codepoint above that.
 - **No encodings**: a pattern is a byte string read the way the build reads a
   String, and there is no encoding to consult about a byte that starts no
   whole character. Such a byte is that byte, inside a character class as much

--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -525,7 +525,10 @@ parse_escape(re_compiler *c)
     return val & 0xff;
   }
   /* Hex escape `\xHH` (1-2 hex digits, value 0-255). The `\x{HHHH}` form
-     for codepoints above 0xff is not implemented. */
+     for codepoints above 0xff is not implemented, and it is not read as
+     `\x` either: a `\x` that no hex digit follows used to come out as
+     `\x00`, so `\x{41}` compiled to a NUL and a quantifier. CRuby rejects
+     it, as it rejects a bare `\x` and `\xZ`. */
   case 'x': {
     int val = 0;
     int n = 0;
@@ -536,6 +539,7 @@ parse_escape(re_compiler *c)
       next_char(c);
       n++;
     }
+    if (n == 0) compile_error(c, "invalid hex escape");
     return val & 0xff;
   }
   default: return ch;  /* literal: \., \\, \/, \(, etc. */

--- a/mrbgems/mruby-regexp/test/regexp_syntax.rb
+++ b/mrbgems/mruby-regexp/test/regexp_syntax.rb
@@ -1297,6 +1297,35 @@ assert("Regexp - octal and hex escapes") do
   assert_equal 0, (/\x7/ =~ "\a")
 end
 
+assert("Regexp - a hex escape needs at least one digit") do
+  # `\x` followed by no hex digit used to read as `\x00`, so `\x{41}` was a
+  # NUL and a quantifier, and matched 41 NUL bytes. A regexp literal never
+  # gets this far (the parser refuses it), so the pattern has to be a string.
+  assert_raise_with_message(RegexpError, "invalid hex escape: /\\x{41}/") do
+    Regexp.new("\\x{41}")
+  end
+  assert_raise_with_message(RegexpError, "invalid hex escape: /\\x/") do
+    Regexp.new("\\x")
+  end
+  assert_raise(RegexpError) { Regexp.new("\\xZ") }
+  assert_raise(RegexpError) { Regexp.new("a\\x") }
+  assert_raise(RegexpError) { Regexp.new("\\x{}") }
+
+  # inside a character class the escape reads the same way
+  assert_raise_with_message(RegexpError, "invalid hex escape: /[\\x]/") do
+    Regexp.new("[\\x]")
+  end
+  assert_raise(RegexpError) { Regexp.new("[\\xZ]") }
+  assert_raise(RegexpError) { Regexp.new("[\\x{41}]") }
+  assert_raise(RegexpError) { Regexp.new("[a-\\x]") }
+  assert_raise(RegexpError) { Regexp.new("[\\x-z]") }
+
+  # one digit is enough, and a second non-digit ends the escape
+  assert_equal 0, (Regexp.new("\\x4") =~ "\x04")
+  assert_equal 0, (Regexp.new("\\x4Z") =~ "\x04Z")
+  assert_equal 0, (Regexp.new("[\\x4]") =~ "\x04")
+end
+
 assert("Regexp - \\h and \\H hex-digit shorthands") do
   assert_equal 0, (/\h/ =~ "f")
   assert_nil (/\h/ =~ "g")


### PR DESCRIPTION
`parse_escape` in `re_compile.c` reads `\x` by taking up to two hex digits and returning whatever it has, so `\x` followed by no digit came out as `\x00`. A pattern handed to `Regexp.new` then compiled quietly to a NUL (a regexp literal never gets this far, since the parser refuses `/\x/` as a syntax error, as CRuby's does): `\x{41}` was a NUL and a `{41}` quantifier and matched 41 NUL bytes, `\x` and `\xZ` were a NUL, and `[\x]` held a NUL because the class reads its escapes through the same function. This is the spelling the README's "No `\x{...}` hex escape" note steers a reader away from, and it did not fail, it matched something else.

```ruby
Regexp.new("\\x{41}") =~ "\0" * 41
# CRuby:        RegexpError (invalid hex escape: /\x{41}/)
# mruby before: 0
# mruby after:  RegexpError (invalid hex escape: /\x{41}/)

Regexp.new("\\x") =~ "\0"
# CRuby:        RegexpError (invalid hex escape: /\x/)
# mruby before: 0
# mruby after:  RegexpError (invalid hex escape: /\x/)

Regexp.new("[\\x]") =~ "\0"
# CRuby:        RegexpError (invalid hex escape: /[\x]/)
# mruby before: 0
# mruby after:  RegexpError (invalid hex escape: /[\x]/)

Regexp.new("\\x4Z") =~ "\x04Z"
# CRuby / mruby before / mruby after: 0
```

## Fix

`parse_escape` raises `RegexpError` with CRuby's message, `invalid hex escape`, when the digit loop read nothing. One digit is still enough (`\x4`, `\x4Z`), as before, and the check sits in the shared function, so a class atom (`[\x]`, `[\xZ]`, `[a-\x]`) is refused by the same line. The README's limitation note now says `\x{...}` raises, since the brace is not a hex digit, and the escape list says `\x` with no digit raises.

The `\x{...}` form itself is still not implemented; this only makes the missing form an error rather than a silent NUL, which is what CRuby does with it too.

## Testing

`mrbgems/mruby-regexp/test/regexp_syntax.rb` gains "a hex escape needs at least one digit": the message for `\x{41}`, `\x`, and `[\x]`, plus `\xZ`, `a\x`, `\x{}`, `[\xZ]`, `[\x{41}]`, `[a-\x]`, `[\x-z]` raising, and `\x4`, `\x4Z`, `[\x4]` still matching `"\x04"`. Every pattern in the block was run against CRuby 4.0.6 first and behaves the same there.

Full suite green at every commit (one commit).

| Build (`MRUBY_CONFIG`) | Total | KO | Crash |
| --- | --- | --- | --- |
| `ci/gcc-clang` full-debug | 2351 | 0 | 0 |
| `ci/gcc-clang` bintest | 2351 (+123 bintest) | 0 | 0 |
| `ci/gcc-clang` cxx_abi | 2351 | 0 | 0 |
| `ci/gcc-clang` byte-string | 2281 | 0 | 0 |
| `ci/gcc-clang` ascii-case | 2348 | 0 | 0 |
| default (unset) | 2127 (+112 bintest) | 0 | 0 |

### Environment

<details>
<summary>Machine, toolchain, and the compile line of every build</summary>

| Item | Value |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS |
| Kernel | 7.0.0-29-generic |
| CPU | AMD Ryzen 9 5950X 16-Core Processor |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0 |
| binutils | GNU ld (GNU Binutils) 2.47.20260726 |
| rake | rake, version 13.3.1 |
| CRuby (reference) | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |

Actual compile line of `src/string.c` in each `build_config/ci/gcc-clang.rb` build (`-MMD -c`, `-I`, and `-o` dropped). `full-debug` is `-O0` because `enable_debug` appends `-g3 -O0` after the toolchain's `-g -O3`; `cxx_abi` compiles C as C++ with `gcc -x c++ -std=gnu++03`, g++ only links.

```console
# full-debug
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
# bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK src/string.c
# cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
# byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
# ascii-case
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CASE -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
```

</details>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved regular expression validation for hexadecimal escapes.
  * Invalid forms such as bare `\x`, `\xZ`, and `\x{...}` now raise `RegexpError`.
  * Valid one- and two-digit hexadecimal escapes continue to work as expected.

* **Documentation**
  * Clarified supported hexadecimal and Unicode escape syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->