### PR TITLE
mruby-string-ext: strip leading NUL in `strip` and `lstrip`

### DIFF
--- a/mrbgems/mruby-string-ext/src/string.c
+++ b/mrbgems/mruby-string-ext/src/string.c
@@ -1591,19 +1591,12 @@ str_b(mrb_state *mrb, mrb_value self)
 }
 
 /*
- * Check if character is whitespace (space, tab, newline, carriage return, form feed, vertical tab)
+ * Check if character is whitespace for the strip family: space, tab, newline,
+ * carriage return, form feed, vertical tab, and NUL.  CRuby's `strip`,
+ * `lstrip` and `rstrip` all treat NUL as whitespace on both ends.
  */
 static inline mrb_bool
 is_whitespace(char c)
-{
-  return (c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f' || c == '\v');
-}
-
-/*
- * Check if character is whitespace or null (for rstrip)
- */
-static inline mrb_bool
-is_whitespace_or_null(char c)
 {
   return (c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f' || c == '\v' || c == '\0');
 }
@@ -1657,7 +1650,7 @@ str_rstrip(mrb_state *mrb, mrb_value self)
   mrb_int end = len;
 
   /* Find last non-whitespace character */
-  while (end > 0 && is_whitespace_or_null(ptr[end - 1])) {
+  while (end > 0 && is_whitespace(ptr[end - 1])) {
     end--;
   }
 
@@ -1694,7 +1687,7 @@ str_strip(mrb_state *mrb, mrb_value self)
   }
 
   /* Find last non-whitespace character */
-  while (end > start && is_whitespace_or_null(ptr[end - 1])) {
+  while (end > start && is_whitespace(ptr[end - 1])) {
     end--;
   }
 
@@ -1773,7 +1766,7 @@ str_rstrip_bang(mrb_state *mrb, mrb_value self)
   char *ptr = RSTR_PTR(s);
 
   /* Find last non-whitespace character */
-  while (end > 0 && is_whitespace_or_null(ptr[end - 1])) {
+  while (end > 0 && is_whitespace(ptr[end - 1])) {
     end--;
   }
 
@@ -1817,7 +1810,7 @@ str_strip_bang(mrb_state *mrb, mrb_value self)
   }
 
   /* Find last non-whitespace character */
-  while (end > start && is_whitespace_or_null(ptr[end - 1])) {
+  while (end > start && is_whitespace(ptr[end - 1])) {
     end--;
   }
 

--- a/mrbgems/mruby-string-ext/test/string.rb
+++ b/mrbgems/mruby-string-ext/test/string.rb
@@ -59,7 +59,9 @@ assert('String#strip') do
   assert_equal("  abc  ", s)
   assert_equal("", "".strip)
   assert_equal("", " \t\r\n\f\v".strip)
-  assert_equal("\0a", "\0a\0".strip)
+  assert_equal("a", "\0a\0".strip)
+  assert_equal("a", "\0 a \0".strip)
+  assert_equal("", "\0 \0".strip)
   assert_equal("abc", "abc".strip)
   assert_equal("abc", "  abc".strip)
   assert_equal("abc", "abc  ".strip)
@@ -71,7 +73,10 @@ assert('String#lstrip') do
   assert_equal("  abc  ", s)
   assert_equal("", "".lstrip)
   assert_equal("", " \t\r\n\f\v".lstrip)
-  assert_equal("\0a\0", "\0a\0".lstrip)
+  assert_equal("a\0", "\0a\0".lstrip)
+  assert_equal("a", "\0\0a".lstrip)
+  assert_equal("a \0", "\0 a \0".lstrip)
+  assert_equal("", "\0 \0".lstrip)
   assert_equal("abc", "abc".lstrip)
   assert_equal("abc", "  abc".lstrip)
   assert_equal("abc  ", "abc  ".lstrip)
@@ -84,6 +89,8 @@ assert('String#rstrip') do
   assert_equal("", "".rstrip)
   assert_equal("", " \t\r\n\f\v".rstrip)
   assert_equal("\0a", "\0a\0".rstrip)
+  assert_equal("\0 a", "\0 a \0".rstrip)
+  assert_equal("", "\0 \0".rstrip)
   assert_equal("abc", "abc".rstrip)
   assert_equal("  abc", "  abc".rstrip)
   assert_equal("abc", "abc  ".rstrip)
@@ -96,6 +103,12 @@ assert('String#strip!') do
   assert_equal("abc", s)
   assert_nil(t.strip!)
   assert_equal("abc", t)
+  u = "\0 a \0"
+  assert_equal("a", u.strip!)
+  assert_equal("a", u)
+  v = "\0 \0"
+  assert_equal("", v.strip!)
+  assert_equal("", v)
 end
 
 assert('String#lstrip!') do
@@ -105,6 +118,12 @@ assert('String#lstrip!') do
   assert_equal("abc  ", s)
   assert_nil(t.lstrip!)
   assert_equal("abc  ", t)
+  u = "\0 a \0"
+  assert_equal("a \0", u.lstrip!)
+  assert_equal("a \0", u)
+  v = "\0\0"
+  assert_equal("", v.lstrip!)
+  assert_equal("", v)
 end
 
 assert('String#rstrip!') do


### PR DESCRIPTION
`String#strip` and `String#lstrip` (and `strip!` / `lstrip!`) in mruby-string-ext left a leading NUL byte in place, while `String#rstrip` removed a trailing one. CRuby treats NUL as whitespace on both ends.

```ruby
"\0 a \0".strip   # CRuby: "a",      mruby before: "\x00 a",     mruby after: "a"
"\0\0a".lstrip    # CRuby: "a",      mruby before: "\x00\x00a",  mruby after: "a"
"\0a\0".lstrip    # CRuby: "a\x00",  mruby before: "\x00a\x00",  mruby after: "a\x00"
"\0a\0".rstrip    # CRuby: "\x00a",  mruby before: "\x00a",      mruby after: "\x00a"
s = "\0a\0"; s.lstrip!   # CRuby: "a\x00", mruby before: nil,  mruby after: "a\x00"
```

The strip family used two predicates in `mrbgems/mruby-string-ext/src/string.c`: `is_whitespace` (space, tab, newline, carriage return, form feed, vertical tab) for the left end and `is_whitespace_or_null` (the same plus NUL, commented "for rstrip") for the right end.

The asymmetric answer was pinned on purpose: `e3b339bec6` (2019, "Fix missing assertions in `mruby-string-ext` test") turned the existing `"\0a\0".strip == "\0a"` and `"\0a\0".lstrip == "\0a\0"` expressions into real assertions, and at that time CRuby gave the same answers. CRuby then changed: its documentation defines whitespace for these methods as null, horizontal tab, line feed, vertical tab, form feed, carriage return, and space, and https://github.com/ruby/ruby/pull/4164 (Ruby 3.0.2 / 3.1, "Make String#{strip,lstrip}{,!} strip leading NUL bytes") made `strip` and `lstrip` follow that definition. This PR moves mruby to the current CRuby answer, so it is a deliberate behavior change rather than a fix of an accidental slip.

## Fix

Fold the two predicates into a single `is_whitespace` that includes NUL, and use it on both ends in all six methods. `is_whitespace` had no callers outside the strip family (checked with `grep` over `mrbgems/`, `src/`, `include/`), so nothing else changes meaning. The README describes the methods as removing "whitespace" without listing the characters, so it needs no change.

## Testing

`mrbgems/mruby-string-ext/test/string.rb`:

- `String#strip` and `String#lstrip`: the two assertions that pinned the old answer now expect CRuby's (`"a"` and `"a\0"` for `"\0a\0"`), plus `"\0 a \0"`, `"\0\0a"`, and all-whitespace `"\0 \0"` cases.
- `String#rstrip`: `"\0 a \0"` and `"\0 \0"` added so the three siblings are covered by the same inputs.
- `String#strip!` and `String#lstrip!`: `"\0 a \0"` and all-NUL receivers, checking both the return value and the mutated receiver.

All expected values were confirmed against CRuby 4.0.6 before being written down. Full suite green at every commit (single commit).

| Build | Total | KO | Crash |
| --- | --- | --- | --- |
| `ci/gcc-clang` full-debug | 2350 | 0 | 0 |
| `ci/gcc-clang` bintest | 2350 | 0 | 0 |
| `ci/gcc-clang` cxx_abi | 2350 | 0 | 0 |
| `ci/gcc-clang` byte-string | 2280 | 0 | 0 |
| `ci/gcc-clang` ascii-case | 2347 | 0 | 0 |
| default (`rake -m test`) | 2126 | 0 | 0 |

The `ci/gcc-clang` bintest step (the Ruby-side `bintest`) also passed: 123 total, 0 KO, 0 Crash.

### Environment

<details>
<summary>Machine, toolchain, and the compile line of every build</summary>

| Item | Value |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS |
| Kernel | 7.0.0-29-generic |
| CPU | AMD Ryzen 9 5950X 16-Core Processor |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0 |
| binutils | GNU ld (GNU Binutils) 2.47.20260726 |
| rake | rake, version 13.3.1 |
| CRuby (reference) | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |

Actual compile line of `src/string.c` in each `build_config/ci/gcc-clang.rb` build (`-MMD -c`, `-I`, and `-o` dropped). `full-debug` is `-O0` because `enable_debug` appends `-g3 -O0` after the toolchain's `-g -O3`; `cxx_abi` compiles C as C++ with `gcc -x c++ -std=gnu++03`, g++ only links.

```console
# full-debug
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
# bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK src/string.c
# cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
# byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
# ascii-case
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CASE -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
```

</details>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated string stripping methods to consistently remove NUL characters as whitespace.
  * Improved handling for leading, trailing, embedded, repeated, and all-NUL content.
  * Ensured destructive stripping methods correctly report and apply changes.

* **Tests**
  * Expanded coverage for NUL-character stripping across standard and destructive methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->