### PR TITLE
mruby-regexp: share one class per codepoint for /i literals

### DIFF
--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -12,6 +12,14 @@
 #include <mruby/internal.h>
 #include <string.h>
 
+/* Class IDs are stored in re_inst.a (uint8_t), so at most 256 distinct
+   character classes can be encoded.  Without this cap, class_capa
+   (uint16_t) overflows on doubling past 32768 (8 -> 16 -> ... -> 32768
+   -> 0), mrb_realloc with size 0 returns NULL, and the next memset
+   crashes; even before that, the (uint8_t)id cast at emit sites would
+   silently alias different classes. */
+#define RE_MAX_CLASSES 256
+
 /* Compiler state.
 
    Everything the compile allocates and the finished pattern goes on owning
@@ -46,6 +54,9 @@ typedef struct {
                                before the atom, and a `\u{...}` list moves it
                                forward so the quantifier repeats the last
                                codepoint alone */
+  uint32_t literal_cp[RE_MAX_CLASSES];  /* by class id: the codepoint whose
+                               /i literal the class stands for, 0 for a class
+                               made by anything else; see literal_class() */
 } re_compiler;
 
 static void compile_alt(re_compiler *c);  /* forward */
@@ -177,14 +188,6 @@ next_char(re_compiler *c)
   return (uint8_t)*c->p++;
 }
 
-/* Class IDs are stored in re_inst.a (uint8_t), so at most 256 distinct
-   character classes can be encoded.  Without this cap, class_capa
-   (uint16_t) overflows on doubling past 32768 (8 -> 16 -> ... -> 32768
-   -> 0), mrb_realloc with size 0 returns NULL, and the next memset
-   crashes; even before that, the (uint8_t)id cast at emit sites would
-   silently alias different classes. */
-#define RE_MAX_CLASSES 256
-
 static uint16_t
 add_class(re_compiler *c)
 {
@@ -200,6 +203,40 @@ add_class(re_compiler *c)
   uint16_t id = c->pat->num_classes;
   memset(&c->pat->classes[id], 0, sizeof(re_charclass));
   c->pat->num_classes = id + 1;
+  return id;
+}
+
+/* The class a /i literal for `cp` compiles to, whether it exists yet or not.
+
+   The class holds `cp` and its case counterparts, and nothing else reaches it:
+   not the flags in force, not the pattern around it, and no writer once the
+   emitter that made it has returned. What it holds is a function of `cp`, so
+   the second occurrence of a codepoint can name the class the first one made
+   rather than make another. Each occurrence used to make its own, and a class
+   id is a uint8_t, so a phrase of a few hundred letters under /i ran out of
+   ids and was refused as having too many character classes, where the
+   classes it needed were as many as its distinct letters.
+
+   Every class is recorded by id, which keeps the record the size of the id
+   space and lets it be searched to `num_classes` alone. It sits in the
+   compiler's own frame rather than behind `pat`, since nothing outlives the
+   compile that would want it. Zero marks a class that stands for no literal:
+   it cannot be mistaken for one, since U+0000 has no case and neither caller
+   folds it. Only the id is handed back, and it is for the caller to fill a
+   class that is new, so that a class this function made is never taken for
+   one it found. */
+static uint16_t
+literal_class(re_compiler *c, uint32_t cp, mrb_bool *found)
+{
+  for (uint16_t id = 0; id < c->pat->num_classes; id++) {
+    if (c->literal_cp[id] == cp) {
+      *found = TRUE;
+      return id;
+    }
+  }
+  uint16_t id = add_class(c);
+  c->literal_cp[id] = cp;
+  *found = FALSE;
   return id;
 }
 
@@ -1080,10 +1117,13 @@ emit_char(re_compiler *c, uint8_t ch)
 {
   if ((c->flags & RE_FLAG_IGNORECASE) &&
       ((ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z'))) {
-    uint16_t id = add_class(c);
-    class_set_bit(&c->pat->classes[id], ch);
-    class_set_bit(&c->pat->classes[id], (uint8_t)(ch ^ 0x20));  /* the other case */
-    class_add_fold_counterparts(c, id, ch);
+    mrb_bool found;
+    uint16_t id = literal_class(c, ch, &found);
+    if (!found) {
+      class_set_bit(&c->pat->classes[id], ch);
+      class_set_bit(&c->pat->classes[id], (uint8_t)(ch ^ 0x20));  /* the other case */
+      class_add_fold_counterparts(c, id, ch);
+    }
     emit(c, RE_CLASS, (uint8_t)id, 0);
     return;
   }
@@ -1136,10 +1176,13 @@ emit_cp_folded(re_compiler *c, uint32_t cp)
   if (f != cp) { alt[n++] = f; alt[n++] = f - 32; }
 #endif
   if (n == 0) return FALSE;
-  uint16_t id = add_class(c);
-  class_add_codepoint(c, &c->pat->classes[id], cp);
-  for (int i = 0; i < n; i++) {
-    class_add_member(c, &c->pat->classes[id], alt[i], FALSE);
+  mrb_bool found;
+  uint16_t id = literal_class(c, cp, &found);
+  if (!found) {
+    class_add_codepoint(c, &c->pat->classes[id], cp);
+    for (int i = 0; i < n; i++) {
+      class_add_member(c, &c->pat->classes[id], alt[i], FALSE);
+    }
   }
   emit(c, RE_CLASS, (uint8_t)id, 0);
   return TRUE;

--- a/mrbgems/mruby-regexp/test/regexp_syntax.rb
+++ b/mrbgems/mruby-regexp/test/regexp_syntax.rb
@@ -212,6 +212,26 @@ assert("Regexp - case insensitive") do
   assert_true re.match?("Abc")
 end
 
+assert("Regexp - /i literals share one class per letter") do
+  # Under /i a letter compiles to a class of its cases, and a class id is a
+  # byte, so a pattern holds at most 256 of them. Every occurrence used to take
+  # one, and a phrase of a few hundred letters was refused as too many
+  # character classes; the second occurrence of a letter now names the class
+  # the first one made.
+  re = Regexp.new("a" * 300, Regexp::IGNORECASE)
+  assert_true re.match?("A" * 300)
+  assert_true re.match?("a" * 300)
+  assert_false re.match?("A" * 299)
+  re = Regexp.new("aA" * 150, Regexp::IGNORECASE)
+  assert_true re.match?("AA" * 150)
+  assert_true re.match?("aa" * 150)
+  # The class is consulted only where /i is on: outside it the same letter
+  # matches its own case alone.
+  re = Regexp.new("(?i:a)a")
+  assert_true re.match?("Aa")
+  assert_false re.match?("AA")
+end
+
 assert("Regexp - case insensitive character class") do
   # /i used to be folded in only where a single literal was emitted, so a
   # character class ignored it entirely.

--- a/mrbgems/mruby-regexp/test/unicode_case.rb
+++ b/mrbgems/mruby-regexp/test/unicode_case.rb
@@ -66,3 +66,45 @@ assert("Regexp - Unicode case folding under /i") do
   assert_nil "ss".match(/ß/i)
   assert_nil "ff".match(/ﬀ/i)
 end
+
+assert("Regexp - /i literals share one class per codepoint") do
+  skip unless __ENCODING__ == "UTF-8"
+  # A folded literal compiles to a class, and a class id is a byte, so a
+  # pattern holds at most 256 of them. Every occurrence used to take one, and a
+  # phrase of a few hundred letters was refused as too many character
+  # classes; the second occurrence of a codepoint now names the class the
+  # first one made.
+  re = Regexp.new("д" * 300, Regexp::IGNORECASE)
+  assert_true re.match?("Д" * 300)
+  assert_true re.match?("д" * 300)
+  assert_false re.match?("Д" * 299)
+  # Both cases of a letter, and a run of one letter next to a run of another,
+  # each cost as many classes as they have distinct codepoints.
+  re = Regexp.new("дД" * 150, Regexp::IGNORECASE)
+  assert_true re.match?("ДД" * 150)
+  assert_true re.match?("дд" * 150)
+  re = Regexp.new("д" * 256 + "a" * 256, Regexp::IGNORECASE)
+  assert_true re.match?("Д" * 256 + "A" * 256)
+  # A `\u` escape and a spelled out character name the same codepoint, so
+  # they share the class as well.
+  re = Regexp.new("\\u{434}" * 150 + "д" * 150, Regexp::IGNORECASE)
+  assert_true re.match?("Д" * 300)
+  # The class is consulted only where /i is on: outside it the same codepoint
+  # is its bytes and matches its own case alone.
+  re = Regexp.new("(?i:д)д")
+  assert_true re.match?("Дд")
+  assert_false re.match?("ДД")
+  # What the cap counts now is distinct codepoints. Cyrillic, Latin-1, Greek
+  # and Armenian letters below come to 281 of them, past what the id can hold,
+  # so the pattern is still refused; CRuby has no such cap.
+  cyr = (0x400..0x45f).map {|c| c.chr("UTF-8") }.join
+  lat = ((0xc0..0xd6).to_a + (0xd8..0xde).to_a + (0xe0..0xf6).to_a +
+         (0xf8..0xfe).to_a).map {|c| c.chr("UTF-8") }.join
+  grk = ((0x391..0x3a1).to_a + (0x3a3..0x3a9).to_a +
+         (0x3b1..0x3c9).to_a).map {|c| c.chr("UTF-8") }.join
+  arm = ((0x531..0x556).to_a + (0x561..0x586).to_a).map {|c| c.chr("UTF-8") }.join
+  assert_equal 281, (cyr + lat + grk + arm).length
+  re = Regexp.new(cyr + lat + grk, Regexp::IGNORECASE)
+  assert_true re.match?((cyr + lat + grk).upcase)
+  assert_raise(RegexpError) { Regexp.new(cyr + lat + grk + arm, Regexp::IGNORECASE) }
+end


### PR DESCRIPTION
Under /i a literal with case counterparts compiles to a character class holding it and them, and every occurrence made a class of its own. A class id is a `uint8_t`, so a pattern holds 256 at most, and a phrase of a few hundred letters ran out of them and was refused. CRuby compiles and matches it.

```ruby
Regexp.new("д" * 300, Regexp::IGNORECASE) =~ "Д" * 300
# CRuby:        0
# mruby before: RegexpError (too many character classes: /ддд.../)
# mruby after:  0
Regexp.new("a" * 300, Regexp::IGNORECASE) =~ "A" * 300
# CRuby:        0
# mruby before: RegexpError (too many character classes: /aaa.../)
# mruby after:  0
```

The class such a literal needs holds the codepoint and its case counterparts and nothing else: neither the flags in force nor the pattern around it reach it, and nothing writes to it once `emit_char()` or `emit_cp_folded()` has returned. What it holds is a function of the codepoint, so the second occurrence of a codepoint can name the class the first one made rather than make another.

## Fix

The compiler records, by class id, the codepoint each /i literal class stands for (`literal_cp[RE_MAX_CLASSES]` in `re_compiler`), and `literal_class()` looks a codepoint up there before adding a class. The record sits in the compiler's frame and dies with it; zero marks a class made by anything else, which U+0000 cannot be confused with, since it has no case. Both literal paths, the ASCII letter in `emit_char()` and the folded codepoint in `emit_cp_folded()`, fill the class only when it is new. `add_class()` is unchanged: the slot is still zero cleared before `num_classes` counts it.

The cap now counts distinct codepoints. A pattern that folds more than 256 different ones is still refused, which CRuby does not do; that is out of scope here and the test pins the present meaning of the cap. Bracket classes (`[k]`) and the shorthands (`\d`) keep taking a class per occurrence, so `"\\d" * 300` still hits the cap; that is a separate defect of the same shape and not touched here.

## Testing

- `mrbgems/mruby-regexp/test/unicode_case.rb` (runs where `RE_UNICODE_CASE` is on): `"д" * 300` under /i compiles and matches both cases; `"дД" * 150`, `"д" * 256 + "a" * 256`, and a `\u{434}` escape mixed with the spelled character all compile; the same codepoint outside `(?i:...)` still matches its own case alone; 281 distinct cased codepoints (Cyrillic, Latin-1, Greek, Armenian) are still refused, 207 of them compile and match their upcase.
- `mrbgems/mruby-regexp/test/regexp_syntax.rb` (every build): `"a" * 300` and `"aA" * 150` under /i compile and match; `(?i:a)a` matches `"Aa"` and not `"AA"`.
- Both new tests fail on master with `RegexpError: too many character classes` and pass at the tip.

Full suite green at every commit (single commit).

| Build | Total | KO | Crash |
| --- | --- | --- | --- |
| ci/gcc-clang full-debug | 2352 | 0 | 0 |
| ci/gcc-clang bintest | 2352 | 0 | 0 |
| ci/gcc-clang cxx_abi | 2352 | 0 | 0 |
| ci/gcc-clang byte-string | 2281 | 0 | 0 |
| ci/gcc-clang ascii-case | 2348 | 0 | 0 |
| default (`rake -m test`) | 2127 | 0 | 0 |

### Environment

<details>
<summary>Machine, toolchain, and the compile line of every build</summary>

| Item | Value |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS |
| Kernel | 7.0.0-29-generic |
| CPU | AMD Ryzen 9 5950X 16-Core Processor |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0 |
| binutils | GNU ld (GNU Binutils) 2.47.20260726 |
| rake | rake, version 13.3.1 |
| CRuby (reference) | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |

Actual compile line of `src/string.c` in each `build_config/ci/gcc-clang.rb` build (`-MMD -c`, `-I`, and `-o` dropped). `full-debug` is `-O0` because `enable_debug` appends `-g3 -O0` after the toolchain's `-g -O3`; `cxx_abi` compiles C as C++ with `gcc -x c++ -std=gnu++03`, g++ only links.

```console
# full-debug
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
# bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK src/string.c
# cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
# byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
# ascii-case
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CASE -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
```

</details>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved case-insensitive regular expressions with many repeated characters.
  * Preserved matching behavior for ASCII and Unicode characters, including scoped `/i` patterns.
  * Added clear errors when regular expressions exceed the supported character-class limit.
* **Tests**
  * Expanded coverage for repeated literals, mixed Unicode spellings, case matching, and class-limit behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->