### PR TITLE
mruby-regexp: close a class range at the first codepoint of a `\u{...}` list

### DIFF
--- a/mrbgems/mruby-regexp/README.md
+++ b/mrbgems/mruby-regexp/README.md
@@ -41,8 +41,11 @@ simulation) with backtracking fallback.
 Outside a character class the list form is a sequence rather than one
 atom, so a quantifier after it repeats the last codepoint only:
 `/\u{61 62}+/` is `ab+`. Inside a class every codepoint is a member of
-its own, and the last one can still open a range: `/[\u{61 62}-z]/` is
-`a` plus `b-z`.
+its own, and the one next to a `-` still opens or closes a range: the
+last of the list before it and the first after it, so `/[\u{61 62}-z]/`
+is `a` plus `b-z` and `/[a-\u{63 7a}]/` is `a-c` plus `z`. A range
+written backwards, `[b-a]` or `[b-\u{61 63}]`, raises `RegexpError` as
+in CRuby.
 
 ### Anchors
 

--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -672,6 +672,9 @@ class_named_cp(re_compiler *c, re_charclass *cc, uint32_t cp, mrb_bool *is_byte)
    advances c->p. *is_byte says which of the two the value is: TRUE for a
    byte at or above 0x80 that starts no whole character, FALSE for ASCII, for
    a decoded codepoint and for `\u`, which names a codepoint outright.
+   closes_range says the atom follows a `-`, which matters to a `\u{...}`
+   list alone: the codepoint next to the `-` is the range end, and the rest
+   of the list are members.
 
    The question is the one the literal path already answers: emit_char_folded()
    decodes and stands aside when the decode consumed one byte, so `\xB5` and a
@@ -680,7 +683,7 @@ class_named_cp(re_compiler *c, re_charclass *cc, uint32_t cp, mrb_bool *is_byte)
    the pattern holds. A byte and a codepoint of the same number are different
    members, which is what the tag on the stored value records. */
 static uint32_t
-read_class_atom(re_compiler *c, re_charclass *cc, mrb_bool *is_byte)
+read_class_atom(re_compiler *c, re_charclass *cc, mrb_bool *is_byte, mrb_bool closes_range)
 {
   *is_byte = FALSE;
   if (peek(c) == '\\') {
@@ -690,9 +693,20 @@ read_class_atom(re_compiler *c, re_charclass *cc, mrb_bool *is_byte)
       mrb_bool more;
       uint32_t cp = unicode_escape_first(c, &more);
       uint32_t nx;
-      /* Every codepoint of a `\u{...}` list is a member of its own. All but
-         the last join the class here; the last is returned, so it can open a
-         range as any other atom would: `[\u{61 62}-z]` is `a` plus `b-z`. */
+      /* Every codepoint of a `\u{...}` list is a member of its own, apart
+         from the one next to a `-`, which is a range end as any other atom
+         would be. That is the last of the list before the `-` and the first
+         after it: `[\u{61 62}-z]` is `a` plus `b-z`, and `[a-\u{63 7a}]` is
+         `a-c` plus `z`. The rest join the class here. */
+      if (closes_range) {
+        uint32_t end = class_named_cp(c, cc, cp, is_byte);
+        while (unicode_escape_next(c, &more, &nx)) {
+          mrb_bool member_byte = FALSE;
+          uint32_t member = class_named_cp(c, cc, nx, &member_byte);
+          class_add_member(c, cc, member, member_byte);
+        }
+        return end;
+      }
       while (unicode_escape_next(c, &more, &nx)) {
         mrb_bool member_byte = FALSE;
         uint32_t member = class_named_cp(c, cc, cp, &member_byte);
@@ -787,13 +801,13 @@ compile_charclass(re_compiler *c)
     }
 
     mrb_bool cp_byte;
-    uint32_t cp = read_class_atom(c, cc, &cp_byte);
+    uint32_t cp = read_class_atom(c, cc, &cp_byte, FALSE);
 
     /* check for range a-z (or U+xxxx-U+yyyy) */
     if (peek(c) == '-' && c->p + 1 < c->src_end && c->p[1] != ']') {
       next_char(c);  /* skip '-' */
       mrb_bool hi_byte;
-      uint32_t hi = read_class_atom(c, cc, &hi_byte);
+      uint32_t hi = read_class_atom(c, cc, &hi_byte, TRUE);
       /* An endpoint at or above 128 is a byte or a character, and a span from
          one to the other names neither: [\x80-µ] would run from a byte to a
          codepoint. ASCII belongs to both, so it pairs with either. */

--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -800,17 +800,21 @@ compile_charclass(re_compiler *c)
       if (cp >= 128 && hi >= 128 && cp_byte != hi_byte) {
         compile_error(c, "character class range mixes a byte and a character");
       }
+      /* A range written backwards holds nothing, and CRuby reports it rather
+         than compiling a class that silently lacks the span, or in the
+         negated form admits everything: [b-a] and [^b-a] both raise. The
+         numbers compare, since the check above leaves no byte paired with a
+         character and ASCII sits below either. */
+      if (cp > hi) compile_error(c, "empty range in char class");
       /* A range that straddles the ASCII boundary is split in two: the
          bitmap takes the half below 128 and the codepoint list the rest.
          Neither half can hold the other, and class_match() picks the side
          to read from the codepoint alone, so a span left whole in the
          codepoint list is unreachable below 128. */
-      if (cp <= hi) {
-        if (cp < 128) class_set_range(cc, (uint8_t)cp, (uint8_t)(hi < 128 ? hi : 127));
-        if (hi >= 128) {
-          uint32_t tag = hi_byte ? RE_CLASS_BYTE : 0;
-          class_add_range(c, cc, tag | (cp < 128 ? 128 : cp), tag | hi);
-        }
+      if (cp < 128) class_set_range(cc, (uint8_t)cp, (uint8_t)(hi < 128 ? hi : 127));
+      if (hi >= 128) {
+        uint32_t tag = hi_byte ? RE_CLASS_BYTE : 0;
+        class_add_range(c, cc, tag | (cp < 128 ? 128 : cp), tag | hi);
       }
     }
     else {

--- a/mrbgems/mruby-regexp/test/regexp_syntax.rb
+++ b/mrbgems/mruby-regexp/test/regexp_syntax.rb
@@ -4,6 +4,24 @@ assert("Regexp - character class") do
   assert_equal "abc", md[0]
 end
 
+assert("Regexp - reversed character class range") do
+  # A range written backwards holds nothing. It used to compile to a class
+  # that silently lacked the span, or in the negated form admitted every
+  # character; CRuby raises for either.
+  assert_raise_with_message(RegexpError, "empty range in char class: /[b-a]/") do
+    Regexp.new("[b-a]")
+  end
+  assert_raise_with_message(RegexpError, "empty range in char class: /[^b-a]/") do
+    Regexp.new("[^b-a]")
+  end
+  assert_raise(RegexpError) { Regexp.new("[xz-ay]") }
+  # a range of one is not empty
+  assert_equal ["a"], "abc".scan(/[a-a]/)
+  # a '-' at either edge is a member, not a range
+  assert_equal ["-", "a"], "-ab".scan(/[-a]/)
+  assert_equal ["a", "-"], "abc-".scan(/[a-]/)
+end
+
 assert("Regexp - POSIX bracket classes") do
   # ASCII semantics, like this gem's \w/\d shorthands.
   assert_equal "abc", "123abc456".match(/[[:alpha:]]+/)[0]

--- a/mrbgems/mruby-regexp/test/regexp_utf8.rb
+++ b/mrbgems/mruby-regexp/test/regexp_utf8.rb
@@ -432,6 +432,30 @@ assert("Regexp - \\u escapes in a character class") do
   assert_equal ["c"], "abc".scan(/[^\u{61 62}]/)
 end
 
+assert("Regexp - reversed character class range through \\u") do
+  # `\u` can write a range backwards without the letters showing it. Such a
+  # range holds nothing, and it used to be dropped without a word: a positive
+  # class lacked the span and a negated one admitted everything.
+  assert_raise_with_message(RegexpError, "empty range in char class: /[\\u{62}-\\u{61}]/") do
+    Regexp.new("[\\u{62}-\\u{61}]")
+  end
+  assert_raise(RegexpError) { Regexp.new("[^\\u{62}-\\u{61}]") }
+  # the last codepoint of a list opens the range, so it is the one compared
+  assert_raise(RegexpError) { Regexp.new("[\\u{62 63}-a]") }
+  assert_equal ["a", "b"], "abc".scan(/[\u{62 61}-a]/)
+  # a range of one codepoint is not empty
+  assert_equal ["a"], "abc".scan(/[\u{61}-\u{61}]/)
+  assert_equal ["a"], "abc".scan(/[a-\u{61}]/)
+  # A range between two characters above ASCII compares their codepoints. On
+  # a build reading a String by byte the ends are the last bytes of their
+  # spellings, whose order is not the codepoints' order.
+  if __ENCODING__ == "UTF-8"
+    assert_raise(RegexpError) { Regexp.new("[\\u{3044}-\\u{3042}]") }
+    assert_raise(RegexpError) { Regexp.new("[\\u{100}-\\u{FF}]") }
+    assert_equal 0, (/[\u{3042}-\u{3042}]/ =~ "あ")
+  end
+end
+
 assert("Regexp - a \\u escape in a class names what spelling it out names") do
   # A class member is one character, and on a build whose characters are single
   # bytes a character above ASCII is not one: `[Ā]` holds the two bytes that

--- a/mrbgems/mruby-regexp/test/regexp_utf8.rb
+++ b/mrbgems/mruby-regexp/test/regexp_utf8.rb
@@ -425,11 +425,32 @@ assert("Regexp - \\u escapes in a character class") do
   assert_nil (/[\u{3042}-\u{3044}]/ =~ "\xe3\x81\x85")
   assert_equal 0, (/[a-\u{7a}]/ =~ "q")
 
-  # every codepoint of a list is a member of its own, and the last one can
-  # still open a range
+  # every codepoint of a list is a member of its own, and the one next to a
+  # '-' still opens or closes a range: the last before it, the first after it
   assert_equal ["a", "b"], "abc".scan(/[\u{61 62}]/)
   assert_equal ["a", "b", "c"], "abc-".scan(/[\u{61 62}-z]/)
+  assert_equal ["a", "b", "c", "z"], "abcdz-".scan(/[a-\u{63 7a}]/)
   assert_equal ["c"], "abc".scan(/[^\u{61 62}]/)
+end
+
+assert("Regexp - a \\u list closing a character class range") do
+  # The codepoint next to the '-' is the range end and the rest of the list
+  # are members. The end used to be the last codepoint of the list, so the
+  # class held a different set from CRuby's in either direction: `a-z` plus
+  # `c` for /[a-\u{63 7a}]/, and `z` alone for /[a-\u{7a 41}]/, whose range
+  # ran from `a` down to `A` and was dropped.
+  assert_equal ["a", "b", "c", "z"], "abcdz".scan(/[a-\u{63 7a}]/)
+  assert_equal ["a", "A", "z"], "aAzB".scan(/[a-\u{7a 41}]/)
+  assert_equal ["a", "b", "c", "d"], "abcde".scan(/[\u{61 62}-\u{63 64}]/)
+  # which is also the codepoint a reversed range is reported for
+  assert_raise_with_message(RegexpError, "empty range in char class: /[b-\\u{61 63}]/") do
+    Regexp.new("[b-\\u{61 63}]")
+  end
+  if __ENCODING__ == "UTF-8"
+    assert_equal ["あ", "ぃ", "う"], "あぃぅう".scan(/[\u{3042}-\u{3044 3046}]/)
+    assert_equal ["あ", "ぅ"], "あぃぅ".scan(/[\u{3044}-\u{3046 3042}]/)
+    assert_raise(RegexpError) { Regexp.new("[\\u{3044}-\\u{3042 3046}]") }
+  end
 end
 
 assert("Regexp - reversed character class range through \\u") do
@@ -472,9 +493,11 @@ assert("Regexp - a \\u escape in a class names what spelling it out names") do
   # is what the written out spelling answers too.
   assert_true named.match?("\u{100}")
   # An ASCII codepoint is a member of its own on either build, and a list still
-  # gives every codepoint a membership with the last one able to open a range.
+  # gives every codepoint a membership with the one next to a '-' able to open
+  # or close a range.
   assert_equal ["a", "b"], "abc".scan(/[\u{61 62}]/)
   assert_equal ["a", "b", "c"], "abc-".scan(/[\u{61 62}-z]/)
+  assert_equal ["a", "b", "c", "z"], "abcdz-".scan(/[a-\u{63 7a}]/)
 end
 
 assert("Regexp - malformed \\u escapes") do


### PR DESCRIPTION
Two defects at the range step of `compile_charclass` in `mrbgems/mruby-regexp/src/re_compile.c`, fixed together because the second is not fully observable without the first: with the range end read from the wrong codepoint, `[b-\u{61 63}]` compiles to `b-c` and no reversed range is ever seen there.

**A reversed range was dropped without a word.** The emission was guarded by `cp <= hi` with no `else`, so a positive class silently lacked the span and a negated one admitted every character. CRuby raises for either.

```ruby
Regexp.new("[b-a]")            # CRuby: RegexpError (empty range in char class), mruby before: compiles and matches nothing, after: RegexpError
Regexp.new("[^b-a]") =~ "x"    # CRuby: RegexpError, mruby before: 0, after: RegexpError
Regexp.new("[\\u{62}-\\u{61}]")  # CRuby: RegexpError, mruby before: compiles, after: RegexpError
Regexp.new("[\\u{62 63}-a]")     # CRuby: RegexpError, mruby before: compiles to `b`, after: RegexpError
```

**A `\u{...}` list closing a range was bound at its last codepoint.** `read_class_atom` handed every list over the same way, all but the last codepoint as members and the last returned, which is right before a `-` (`[\u{61 62}-z]` is `a` plus `b-z`) and wrong after one, where CRuby closes the range with the codepoint next to the `-` and takes the rest as members. The class held a different set in either direction.

```ruby
/[a-\u{63 7a}]/ =~ "m"   # CRuby: nil, mruby before: 0 (`a-z` plus `c`), after: nil (`a-c` plus `z`)
/[a-\u{7a 41}]/ =~ "a"   # CRuby: 0, mruby before: nil (`a` down to `A`, dropped, and `z` alone), after: 0 (`a-z` plus `A`)
/[\u{3042}-\u{3044 3046}]/ =~ "ぅ"   # CRuby: nil, mruby before: 0, after: nil
Regexp.new("[b-\\u{61 63}]")   # CRuby: RegexpError (empty range in char class), mruby before: `a-c`, after: RegexpError
```

## Fix

- After the byte-versus-character check on the two ends, `cp > hi` raises `RegexpError` with CRuby's wording, `empty range in char class: /.../`. The comparison is sound where it runs: that check leaves no pair of a byte and a character above ASCII, and ASCII sits below either kind.
- `read_class_atom` takes a `closes_range` flag. For a `\u{...}` list that closes a range the first codepoint is returned as the end and the rest join the class as members; a list that does not keeps the old order (last codepoint returned). On a build reading a String by byte the end is still the last byte of that codepoint's spelling, as for any `\u` in a class there.
- README: the class paragraph on `\u{...}` lists now states both sides of the `-` and that a reversed range raises.

Both `[a-\u{61}]` and `[\u{61}-\u{61}]` (a range of one) still compile, `[-a]` and `[a-]` still take `-` as a member, and the byte-versus-character rule for `\x` ends is untouched.

## Testing

- `regexp_syntax.rb`: new block `reversed character class range` (`[b-a]`, `[^b-a]` with the exact message, `[xz-ay]`, and the non-cases `[a-a]`, `[-a]`, `[a-]`).
- `regexp_utf8.rb`: new blocks `reversed character class range through \u` and `a \u list closing a character class range`; the ASCII `\u` rows run on every build, the rows with codepoints above ASCII (`[\u{3044}-\u{3042}]`, `[\u{100}-\u{FF}]`, `[\u{3042}-\u{3044 3046}]`, `[\u{3044}-\u{3046 3042}]`) under `__ENCODING__ == "UTF-8"`, since on a byte-read build the ends are the last bytes of the spellings and their order is not the codepoints' order. The two existing list blocks gain a HI-side row `[a-\u{63 7a}]`.
- Every value in the tests and above was checked against CRuby 4.0.6; a probe of 41 class-range patterns gives byte-identical output (including error messages) from `bin/mruby` and `ruby`.

Full suite green at every commit (`MRUBY_CONFIG=ci/gcc-clang rake -m test` at both commits, default `rake -m test` at the tip after `rm -rf build/host`):

| Build | Total | KO | Crash |
| --- | --- | --- | --- |
| full-debug | 2353 | 0 | 0 |
| bintest | 2353 (+123 bintest) | 0 | 0 |
| cxx_abi | 2353 | 0 | 0 |
| byte-string | 2283 | 0 | 0 |
| ascii-case | 2350 | 0 | 0 |
| default (`rake -m test`) | 2129 (+112 bintest) | 0 | 0 |

At the first commit the totals are one lower on each of the five builds (2352 / 2352 / 2352 / 2282 / 2349), KO 0, Crash 0.

### Environment

<details>
<summary>Machine, toolchain, and the compile line of every build</summary>

| Item | Value |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS |
| Kernel | 7.0.0-29-generic |
| CPU | AMD Ryzen 9 5950X 16-Core Processor |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0 |
| binutils | GNU ld (GNU Binutils) 2.47.20260726 |
| rake | rake, version 13.3.1 |
| CRuby (reference) | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |

Actual compile line of `src/string.c` in each `build_config/ci/gcc-clang.rb` build (`-MMD -c`, `-I`, and `-o` dropped). `full-debug` is `-O0` because `enable_debug` appends `-g3 -O0` after the toolchain's `-g -O3`; `cxx_abi` compiles C as C++ with `gcc -x c++ -std=gnu++03`, g++ only links.

```console
# full-debug
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
# bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK src/string.c
# cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
# byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
# ascii-case
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CASE -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
```

</details>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved regular expression character classes using `\u{...}` codepoint lists.
  * Reversed ranges now correctly raise `RegexpError` instead of being silently ignored.
  * Valid ranges and mixed codepoint-list patterns now produce the expected matches, including negated classes.

* **Documentation**
  * Clarified how codepoint lists and range boundaries are interpreted in character classes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->