### PR TITLE
mruby-regexp: fold a byte-indexed subject by ASCII under a `/i` backreference

### DIFF
--- a/mrbgems/mruby-regexp/src/re_exec.c
+++ b/mrbgems/mruby-regexp/src/re_exec.c
@@ -62,6 +62,18 @@ class_match(const re_charclass *cc, uint32_t cp, mrb_bool raw)
   return cc->utf8_any;
 }
 
+/* The fold of one unit of the subject. A byte-indexed subject hands out
+   bytes, and a byte above 127 is not the codepoint of the same value: 0xC0 is
+   not U+00C0, so folding it to 0xE0 would pair two bytes that spell no letter
+   in common. The letters a byte can spell are the ASCII ones, and those fold
+   as they do everywhere. */
+static inline uint32_t
+subject_fold(uint32_t c, mrb_bool binary)
+{
+  if (binary && c >= 128) return c;
+  return mrb_re_case_fold(c);
+}
+
 /* Compare two spans ignoring case. Returns how many bytes of `a` were
    consumed, or -1 when they differ. The count is not always the length of
    `b`: with Unicode folding a counterpart can be a different width (U+212A
@@ -77,7 +89,7 @@ memcmp_ci(const char *a, const char *a_end, const char *b, const char *b_end,
     int alen = 0, blen = 0;
     uint32_t ca = mrb_re_decode_char(a, a_end, &alen, binary);
     uint32_t cb = mrb_re_decode_char(b, b_end, &blen, binary);
-    if (mrb_re_case_fold(ca) != mrb_re_case_fold(cb)) return -1;
+    if (subject_fold(ca, binary) != subject_fold(cb, binary)) return -1;
     a += alen;
     b += blen;
   }

--- a/mrbgems/mruby-regexp/test/regexp_utf8.rb
+++ b/mrbgems/mruby-regexp/test/regexp_utf8.rb
@@ -85,6 +85,27 @@ assert("Regexp - /i does not read a byte above 127 as a character") do
   assert_equal 0, (Regexp.new(lead, Regexp::IGNORECASE) =~ lead.b)
 end
 
+assert("Regexp - a backreference under /i folds a byte-indexed subject by ASCII") do
+  # A byte-indexed subject hands the folded comparison bytes, and a byte above
+  # 127 is not the codepoint of the same value: 0xC0 is not U+00C0. The
+  # comparison folded it as if it were, so a build with the Unicode table
+  # paired 0xC0 with 0xE0 the way it pairs "À" with "à". The letters a byte
+  # can spell are the ASCII ones, and those still fold.
+  assert_nil ("\xC0\xE0".b =~ /(.)\1/i)
+  assert_nil ("\xC0a\xE0A".b =~ /(..)\1/i)
+  assert_equal 0, ("\xC0\xC0".b =~ /(.)\1/i)
+  assert_equal 0, ("\xC0a\xC0A".b =~ /(..)\1/i)
+  assert_equal 0, ("aA".b =~ /(.)\1/i)
+  # Nor does a byte take the fold of the character it is part of. Read as
+  # characters "s" and "ſ" fold alike (U+017F to 's', which every build
+  # carries), and the same bytes read one at a time have no character to fold.
+  # A skip here would drop the assertions above, so this is a branch.
+  if __ENCODING__ == "UTF-8"
+    assert_equal 0, ("sſ" =~ /(.)\1/i)
+    assert_nil ("sſ".b =~ /(.)\1/i)
+  end
+end
+
 assert("Regexp - quantifier on a multibyte literal") do
   # The bytes of a multibyte literal used to be separate atoms, so a
   # quantifier bound to the last one: /Ā+/ was \xC4(\x80)+ and stopped after


### PR DESCRIPTION
A backreference under `/i` folded a byte-indexed subject (`String#b`) as if each byte were the codepoint of the same value. On a build with the Unicode case table 0xC0 folded to 0xE0 the way U+00C0 folds to U+00E0, so two bytes that spell no letter in common compared equal:

```ruby
"\xC0\xE0".b =~ /(.)\1/i      # CRuby: nil, mruby before: 0, mruby after: nil
"\xC0a\xE0A".b =~ /(..)\1/i   # CRuby: nil, mruby before: 0, mruby after: nil
"\xC0\xC0".b =~ /(.)\1/i      # CRuby: 0,   mruby before: 0, mruby after: 0
"aA".b =~ /(.)\1/i            # CRuby: 0,   mruby before: 0, mruby after: 0
"sſ" =~ /(.)\1/i              # CRuby: 0,   mruby before: 0, mruby after: 0
"ſs".b =~ /(.)\1/i            # CRuby: nil, mruby before: nil, mruby after: nil
```

`memcmp_ci` in `re_exec.c` compares the captured span and the text at the cursor by folding both sides with `mrb_re_case_fold`. `mrb_re_decode_char` hands out the raw byte for a byte-indexed subject, and the fold took that byte for a codepoint. The class side of the same report (`"\xE5".b =~ /[\xC5]/i`) was already answered by `class_match`, which keeps a byte member apart from the codepoint of the same number; the backreference was the one path that still folded a subject at match time.

## Fix

`memcmp_ci` folds through a new `subject_fold(c, binary)`, which returns a byte above 127 unchanged when the subject is byte-indexed and folds everything else as before. The letters a byte can spell are the ASCII ones, and those still fold; a subject read as characters is untouched. Builds without the Unicode table were never affected (their fold leaves 0xC0 alone), so the fix changes nothing there.

## Testing

New test `Regexp - a backreference under /i folds a byte-indexed subject by ASCII` in `mrbgems/mruby-regexp/test/regexp_utf8.rb`. The byte-indexed lines hold on every build and run unconditionally; the contrast with a subject read as characters (`"sſ" =~ /(.)\1/i` folds U+017F to `s`, `"sſ".b` does not) sits in an `if __ENCODING__ == "UTF-8"` branch rather than behind a `skip`, so a failure in the lines before it is not swallowed on the byte build. The test fails on `master` (`Expected 0 to be nil`) and passes with the fix.

Full suite green at every commit (one commit).

| Build (`MRUBY_CONFIG=ci/gcc-clang`) | Total | KO | Crash |
| --- | --- | --- | --- |
| full-debug | 2351 | 0 | 0 |
| bintest | 2351 | 0 | 0 |
| cxx_abi | 2351 | 0 | 0 |
| byte-string | 2281 | 0 | 0 |
| ascii-case | 2348 | 0 | 0 |
| default (`rake -m test`, no `MRUBY_CONFIG`) | 2127 | 0 | 0 |

One divergence from CRuby is left alone, since it is not about byte-indexed subjects: CRuby answers `"ſs" =~ /(.)\1/i` with `nil` while `"sſ" =~ /(.)\1/i` is `0`, because Onigmo requires the remaining subject to hold at least the captured span's byte length before it folds. mruby answers `0` for both orders.

### Environment

<details>
<summary>Machine, toolchain, and the compile line of every build</summary>

| Item | Value |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS |
| Kernel | 7.0.0-29-generic |
| CPU | AMD Ryzen 9 5950X 16-Core Processor |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0 |
| binutils | GNU ld (GNU Binutils) 2.47.20260726 |
| rake | rake, version 13.3.1 |
| CRuby (reference) | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |

Actual compile line of `src/string.c` in each `build_config/ci/gcc-clang.rb` build (`-MMD -c`, `-I`, and `-o` dropped). `full-debug` is `-O0` because `enable_debug` appends `-g3 -O0` after the toolchain's `-g -O3`; `cxx_abi` compiles C as C++ with `gcc -x c++ -std=gnu++03`, g++ only links.

```console
# full-debug
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
# bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK src/string.c
# cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
# byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
# ascii-case
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CASE -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
```

</details>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved case-insensitive regular expression matching for binary data.
  * ASCII byte values are folded correctly without incorrectly applying Unicode mappings to non-ASCII bytes.
  * Case-insensitive backreferences now behave consistently for byte-indexed subjects and valid UTF-8 text.

* **Tests**
  * Added regression coverage for binary and UTF-8 case-insensitive matching scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->