### PR TITLE
mruby-regexp: follow a block that changes the receiver in `gsub`, `sub!` and `scan`

### DIFF
--- a/mrbgems/mruby-regexp/mrblib/string_regexp.rb
+++ b/mrbgems/mruby-regexp/mrblib/string_regexp.rb
@@ -169,18 +169,29 @@ class String
     end
     pattern = Regexp.new(Regexp.escape(pattern)) if literal
     # A full search and not `match?`, so a failed match clears $~.
-    return nil unless Regexp.__search(pattern, self, 0, literal)
-    # `sub` matches again and publishes its own $~ over this one, leaving the
-    # caller the match `sub` would have left, a block's own matches included.
-    # The resolved pattern takes the place of the original argument so that a
-    # String is not quoted and compiled a second time; a literal goes down as
-    # the String it was instead, since that is what tells `sub` to leave the
-    # subject unread, and quoting it twice is the price of saying so.
-    # Overwriting `self` afterwards is safe: a MatchData snapshots its subject,
-    # so $~ keeps describing the string as it was matched.
-    down = literal ? args[0] : pattern
-    str = argc == 2 ? self.sub(down, args[1], &block) : self.sub(down, &block)
-    self.replace(str)
+    md = Regexp.__search(pattern, self, 0, literal)
+    return nil unless md
+    if argc == 2
+      # `sub` matches again and publishes its own $~ over this one, leaving
+      # the caller the match `sub` would have left.  The resolved pattern
+      # goes down so that it is not compiled a second time; a literal with a
+      # replacement never reaches here, having been answered by `__sub_lit`
+      # above.  Overwriting `self` afterwards is safe: a MatchData snapshots
+      # its subject, so $~ keeps describing the string as it was matched.
+      return self.replace(self.sub(pattern, args[1]))
+    end
+    # The block form does not go down to `sub`, which builds its answer from
+    # the snapshot the MatchData holds, because CRuby's `rb_str_sub_bang`
+    # builds it from the receiver as the block left it: `s = "hello";
+    # s.sub!(/l/) { s.upcase!; "X" }` is "HEXLO" there, where `sub` on the
+    # same receiver is "heXlo".  It refuses a block that changed the length
+    # first, as `gsub` does, so the offsets of the match still name the bytes
+    # they named.  $~ stays what the search above published, or whatever the
+    # block put there.
+    len = self.bytesize
+    val = block.call(md[0]).to_s
+    raise RuntimeError, "string modified" if self.bytesize != len
+    self.replace(self.byteslice(0, md.__byte_begin(0)) + val + self.byteslice(md.__byte_end(0)..-1))
   end
 
   def gsub(*args, &block)

--- a/mrbgems/mruby-regexp/mrblib/string_regexp.rb
+++ b/mrbgems/mruby-regexp/mrblib/string_regexp.rb
@@ -272,20 +272,30 @@ class String
     # a character on its own.
     pos = 0
     len = self.bytesize
-    # The loop ends on a failed search, which clears the globals. CRuby leaves
-    # the last match behind, so keep it and republish it below, the way `gsub`
-    # does. A scan that matched nothing keeps the cleared state.
+    # A block that changes the receiver is answered for as `rb_str_scan`
+    # answers for it, which is the way `__gsub_block` does: one that changed
+    # the length is refused with `RuntimeError` by the next search, which takes
+    # `len` for that, the next match is searched for in the string it left,
+    # and the match left in $~ is a search once more from the offset the last
+    # match was found from, on the string as it stands at the end. That search
+    # also republishes what the failed one that ends the loop clears; a scan
+    # that matched nothing keeps the cleared state. And as in `gsub`, a
+    # receiver that still reads as it did when the last match was made gets
+    # that match republished, and the search runs only where `__republish`
+    # finds it reading differently.
     last = nil
+    last_md = nil
     while pos <= len
-      md = Regexp.__byte_search(pattern, self, pos)
+      md = Regexp.__byte_search(pattern, self, pos, len)
       break unless md
-      last = md
+      last = pos
+      last_md = md
       yield(md.size == 1 ? md[0] : md.captures)
       match_start = md.__byte_begin(0)
       match_end = md.__byte_end(0)
       pos = match_start == match_end ? match_end + 1 : match_end
     end
-    last.__set_globals if last
+    Regexp.__byte_search(pattern, self, last, len) if last && !last_md.__republish(self)
     self
   end
 

--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -541,23 +541,32 @@ regexp_s_search(mrb_state *mrb, mrb_value klass)
 }
 
 /*
- * Regexp.__byte_search(re, str, pos = 0)
+ * Regexp.__byte_search(re, str, pos = 0, len = -1)
  *
  * Internal: the byte-offset search the mrblib loops of `scan`, `split` and
  * `byteindex` drive themselves. No position normalization, because the
  * callers already work in byte space, and no operand conversion, because
- * they always pass a String. The subject is the one the loop holds fixed, so
- * the check reads the flag core left on it after the first turn. Nor is there
- * a `checked` any more: `gsub` was the caller that set it, and its loop is
- * `__gsub_block` now, which takes the flag itself.
+ * they always pass a String. The subject is the one the loop holds, so the
+ * check reads the flag core left on it after the first turn, and walks it
+ * again only where a block has written to it in between. Nor is there a
+ * `checked` any more: `gsub` was the caller that set it, and its loop is
+ * `__gsub_block` now, which takes the flag itself. `len`, where the caller
+ * gives one, is the byte length its loop began with, and a subject that no
+ * longer has it is refused before the search: this is `str_mod_check` for
+ * the block loop of `scan`, asked here so that the loop pays one argument
+ * per search rather than one `bytesize` call per match.
  */
 static mrb_value
 regexp_s_byte_search(mrb_state *mrb, mrb_value klass)
 {
   mrb_value re, str;
   mrb_int pos = 0;
+  mrb_int len = -1;
 
-  mrb_get_args(mrb, "oS|i", &re, &str, &pos);
+  mrb_get_args(mrb, "oS|ii", &re, &str, &pos, &len);
+  if (len >= 0 && RSTRING_LEN(str) != len) {
+    mrb_raise(mrb, E_RUNTIME_ERROR, "string modified");
+  }
   check_regexp_arg(mrb, re);
   /* Every mrblib loop enters at zero or at an offset a match answered with,
      so a position before the subject reaches here only from a direct call.
@@ -1098,12 +1107,12 @@ matchdata_byte_end(mrb_state *mrb, mrb_value self)
   return mrb_int_value(mrb, pos);
 }
 
-/* Whether `str` still reads as the subject `md` was made on. The block loop
-   of `gsub` ends on a search from the offset its last match was found from,
-   on the receiver as the block left it, the way CRuby's `str_gsub` does; on a
-   receiver that reads as it did when that match was made, the search can only
-   find that match again, and the loop republishes it instead. What a search
-   reads of a subject is its bytes
+/* Whether `str` still reads as the subject `md` was made on. The block loops
+   of `gsub` and `scan` end on a search from the offset their last match was
+   found from, on the receiver as the block left it, the way CRuby's
+   `str_gsub` and `rb_str_scan` do; on a receiver that reads as it did when
+   that match was made, the search can only find that match again, and the
+   loops republish it instead. What a search reads of a subject is its bytes
    and whether they are read by byte, and `source` is a frozen copy of both as
    they stood at match time, so comparing the two is the whole of the test:
    where CRuby's `str_mod_check` reads the buffer pointer and the length, this
@@ -1122,18 +1131,24 @@ re_subject_reads_as(mrb_state *mrb, mrb_value str, mrb_value mdv)
   return p == q || memcmp(p, q, (size_t)len) == 0;
 }
 
-/* Private: republish $~ and the thirteen names derived from it. Used by the
-   mrblib loops that drive Regexp.__byte_search themselves, where the failing
-   call that ends the loop clears the match the loop is supposed to leave behind.
-   The names other than $~ are not assignable from Ruby, so restoring them
-   has to come from here. */
+/* Private: publish this match once more, if `str` still reads as the subject
+   it was made on, and say whether it did. The mrblib loop of `scan` ends on
+   a search from the offset its last match was found from, on the receiver as
+   the block left it, the way `rb_str_scan` does; `re_subject_reads_as()`
+   above is the test that spares that search, and this is it asked from
+   mrblib. The names other than $~ are not assignable from Ruby, so publishing
+   them again has to come from here. Returns false where `str` reads
+   differently, and the caller searches. */
 static mrb_value
-matchdata_set_globals(mrb_state *mrb, mrb_value self)
+matchdata_republish(mrb_state *mrb, mrb_value self)
 {
+  mrb_value str;
+  mrb_get_args(mrb, "S", &str);
   mrb_match_data *md = DATA_GET_PTR(mrb, self, &matchdata_type, mrb_match_data);
-  if (!md) return mrb_nil_value();
+  if (!md) return mrb_false_value();
+  if (!re_subject_reads_as(mrb, str, self)) return mrb_false_value();
   set_match_globals(mrb, self, md->source, md->captures, md->num_captures);
-  return self;
+  return mrb_true_value();
 }
 
 /*
@@ -2108,7 +2123,7 @@ mrb_mruby_regexp_gem_init(mrb_state *mrb)
   mrb_define_class_method(mrb, re, "__check_pattern", regexp_check_pattern, MRB_ARGS_REQ(1));
   mrb_define_class_method(mrb, re, "__check_byte_pos", regexp_check_byte_pos, MRB_ARGS_REQ(2));
   mrb_define_class_method(mrb, re, "__search", regexp_s_search, MRB_ARGS_ARG(2, 2));
-  mrb_define_class_method(mrb, re, "__byte_search", regexp_s_byte_search, MRB_ARGS_ARG(2, 1));
+  mrb_define_class_method(mrb, re, "__byte_search", regexp_s_byte_search, MRB_ARGS_ARG(2, 2));
   mrb_define_class_method(mrb, re, "__byte_rsearch", regexp_s_byte_rsearch, MRB_ARGS_REQ(3));
   mrb_define_class_method(mrb, re, "__search_p", regexp_s_search_p, MRB_ARGS_ARG(2, 1));
 
@@ -2177,7 +2192,7 @@ mrb_mruby_regexp_gem_init(mrb_state *mrb)
   mrb_define_method(mrb, md, "end", matchdata_end, MRB_ARGS_REQ(1));
   mrb_define_method(mrb, md, "__byte_begin", matchdata_byte_begin, MRB_ARGS_REQ(1));
   mrb_define_method(mrb, md, "__byte_end", matchdata_byte_end, MRB_ARGS_REQ(1));
-  mrb_define_method(mrb, md, "__set_globals", matchdata_set_globals, MRB_ARGS_NONE());
+  mrb_define_method(mrb, md, "__republish", matchdata_republish, MRB_ARGS_REQ(1));
   mrb_define_method(mrb, md, "pre_match", matchdata_pre, MRB_ARGS_NONE());
   mrb_define_method(mrb, md, "post_match", matchdata_post, MRB_ARGS_NONE());
   mrb_define_method(mrb, md, "named_captures", matchdata_named_captures, MRB_ARGS_NONE());

--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -1098,6 +1098,30 @@ matchdata_byte_end(mrb_state *mrb, mrb_value self)
   return mrb_int_value(mrb, pos);
 }
 
+/* Whether `str` still reads as the subject `md` was made on. The block loop
+   of `gsub` ends on a search from the offset its last match was found from,
+   on the receiver as the block left it, the way CRuby's `str_gsub` does; on a
+   receiver that reads as it did when that match was made, the search can only
+   find that match again, and the loop republishes it instead. What a search
+   reads of a subject is its bytes
+   and whether they are read by byte, and `source` is a frozen copy of both as
+   they stood at match time, so comparing the two is the whole of the test:
+   where CRuby's `str_mod_check` reads the buffer pointer and the length, this
+   reads the bytes themselves, and a change of length, of contents or of
+   reading each fail it. A receiver that still shares its buffer with the copy
+   is told apart by the pointer alone. */
+static mrb_bool
+re_subject_reads_as(mrb_state *mrb, mrb_value str, mrb_value mdv)
+{
+  mrb_match_data *md = DATA_GET_PTR(mrb, mdv, &matchdata_type, mrb_match_data);
+  mrb_value src = md->source;
+  mrb_int len = RSTRING_LEN(src);
+  if (RSTRING_LEN(str) != len) return FALSE;
+  if (re_binary_string_p(str) != re_binary_string_p(src)) return FALSE;
+  const char *p = RSTRING_PTR(str), *q = RSTRING_PTR(src);
+  return p == q || memcmp(p, q, (size_t)len) == 0;
+}
+
 /* Private: republish $~ and the thirteen names derived from it. Used by the
    mrblib loops that drive Regexp.__byte_search themselves, where the failing
    call that ends the loop clears the match the loop is supposed to leave behind.
@@ -1701,6 +1725,21 @@ regexp_s_sub_lit(mrb_state *mrb, mrb_value klass)
  * them, all around one `mrb_yield` that C can make directly.  The block still
  * reads what it read there: every match is published before the block sees it,
  * which is why a MatchData is built per turn here as it was there.
+ *
+ * The block can reach the receiver, and CRuby's `str_gsub` answers for a
+ * block that changes it in three ways this loop follows.  It refuses one that
+ * changed the length, as `str_mod_check` does, so the offsets a match answered
+ * with still name the bytes they named; the buffer pointer `str_mod_check`
+ * compares as well is no test here, since mruby answers a write into a shared
+ * string with a buffer of its own.  It reads the stretch before a match, the
+ * next match and the step over an empty one from the receiver as the block
+ * left it, so `s = "hello"; s.gsub(/l/) { s.tr!("h", "H"); "X" }` is "HeXXo"
+ * and not "heXXo".  And it searches once more from `last`, the offset the
+ * final match was found from, on the receiver as it stands at the end: that
+ * is the match it leaves in `$~`, or nil where the block wrote the match
+ * away.  On a receiver that still reads as it did when the last match was
+ * made, that search can only find the match the loop already has, so the loop
+ * republishes that one and searches only where the receiver reads differently.
  */
 static mrb_value
 regexp_s_gsub_block(mrb_state *mrb, mrb_value klass)
@@ -1721,38 +1760,45 @@ regexp_s_gsub_block(mrb_state *mrb, mrb_value klass)
   int cap_size = pat->num_captures * 2;
   int captures[RE_MAX_CAPTURES * 2];
   mrb_value result = mrb_str_new_capa(mrb, RSTRING_LEN(str));
-  /* The match the block was given last, kept so that it can be published
-     again below: CRuby leaves a gsub's own last match behind, over anything
-     the block matched on its way. */
+  /* The match the block was given last, and the offset it was found from:
+     what the closing search below starts from, or stands in for. */
   mrb_value last_md = mrb_nil_value();
+  mrb_int last = 0;
   mrb_int pos = 0;
-  /* The subject's length as the walk started, which is where the walk ends.
-     The mrblib loop this replaced took its bound before the first block call
-     and kept it, so a block that grows the subject it is walking cannot keep
-     the walk going for ever; reading the length afresh for the bound as well
-     as for the bytes would let it. */
-  mrb_int limit = RSTRING_LEN(str);
+  /* The subject the walk is bounded by. Every turn checks its length against
+     the receiver the block hands back, so it holds for the whole walk; the
+     bytes and their reading are taken afresh after every block call. */
+  const char *s = RSTRING_PTR(str);
+  mrb_int slen = RSTRING_LEN(str);
   int ai = mrb_gc_arena_save(mrb);
 
-  while (pos <= limit) {
-    /* The bytes, unlike the bound, are read afresh each turn: the block runs
-       between two of them and can replace them under the walk, which the
-       mrblib loop allowed by asking `self` again for every piece it took. */
-    const char *s = RSTRING_PTR(str);
-    mrb_int slen = RSTRING_LEN(str);
-    if (pos > slen) break;
-
+  while (pos <= slen) {
     memset(captures, -1, sizeof(int) * cap_size);
     if (mrb_re_exec(mrb, pat, s, slen, pos, captures, cap_size, binary) == 0) break;
     mrb_int beg = captures[0], end = captures[1];
 
-    if (beg > pos) re_cat_bytes(mrb, result, s + pos, beg - pos, binary);
     mrb_value matched = re_byte_substr(mrb, str, beg, end - beg);
     last_md = create_matchdata(mrb, re, str, captures, cap_size);
-    mrb_str_cat_str(mrb, result, mrb_obj_as_string(mrb, mrb_yield(mrb, block, matched)));
-
+    last = pos;
+    mrb_value piece = mrb_obj_as_string(mrb, mrb_yield(mrb, block, matched));
+    /* What the block did to the receiver while it had it. A change of length
+       moved every offset the walk holds, and the walk stops there. Bytes it
+       rewrote in place are read from where they are now, since the write can
+       have moved the buffer; whether they are read by byte can have changed
+       with them (`s.replace(s.b)`), and so can whether they spell characters
+       at all, which the next search asks as `__byte_search` would. */
+    if (RSTRING_LEN(str) != slen) {
+      mrb_raise(mrb, E_RUNTIME_ERROR, "string modified");
+    }
+    if (!checked) re_check_encoding(mrb, str);
     s = RSTRING_PTR(str);
-    slen = RSTRING_LEN(str);
+    binary = re_binary_string_p(str);
+
+    /* After the block and not before it, as in CRuby: the bytes before the
+       match are taken from the receiver as the block left it. */
+    if (beg > pos) re_cat_bytes(mrb, result, s + pos, beg - pos, binary);
+    mrb_str_cat_str(mrb, result, piece);
+
     /* A zero-width match carries the character it stood before, so that the
        next search starts past a place the pattern would answer at again. */
     if (beg == end) {
@@ -1776,8 +1822,8 @@ regexp_s_gsub_block(mrb_state *mrb, mrb_value klass)
     mrb_gc_protect(mrb, last_md);
   }
 
-  if (pos < RSTRING_LEN(str)) {
-    re_cat_bytes(mrb, result, RSTRING_PTR(str) + pos, RSTRING_LEN(str) - pos, binary);
+  if (pos < slen) {
+    re_cat_bytes(mrb, result, s + pos, slen - pos, binary);
   }
 
   if (mrb_nil_p(last_md)) {
@@ -1786,9 +1832,14 @@ regexp_s_gsub_block(mrb_state *mrb, mrb_value klass)
        CRuby does. */
     clear_match_globals(mrb);
   }
-  else {
+  else if (re_subject_reads_as(mrb, str, last_md)) {
     mrb_match_data *md = DATA_GET_PTR(mrb, last_md, &matchdata_type, mrb_match_data);
     set_match_globals(mrb, last_md, md->source, md->captures, md->num_captures);
+  }
+  else {
+    /* The closing search of `str_gsub`, on the receiver as the block left it,
+       which publishes what it finds or clears the globals for a miss. */
+    exec_match(mrb, re, str, last);
   }
   return result;
 }

--- a/mrbgems/mruby-regexp/test/match_data.rb
+++ b/mrbgems/mruby-regexp/test/match_data.rb
@@ -65,16 +65,43 @@ assert("MatchData - subject is snapshotted at match time") do
   assert_equal "hello", $~.string
 end
 
-assert("MatchData - match globals survive subject mutation in a gsub block") do
-  # Regression: the mrblib gsub loop republishes $&, $` and $' from the
-  # MatchData after the block runs, so a block that mutates the subject used
-  # to make them describe the mutated string.
+assert("MatchData - the match a gsub block leaves behind is a fresh search") do
+  # CRuby's `str_gsub` searches once more when the loop is over, from the
+  # offset the last match was found at and on the subject as it stands then,
+  # and that search is what $~ and the names derived from it describe.  A
+  # block that changes the subject in place can therefore leave nil behind,
+  # where the loop used to republish the MatchData of the last match it had.
   t = "hello"
   n = 0
   t.gsub(/l/) { n += 1; t.upcase! if n == 2; "X" }
+  assert_nil $~
+  assert_nil $&
+  assert_nil $`
+  assert_nil $'
+
+  # A change that leaves the last match where it was leaves a match behind,
+  # and its subject is the changed string, not the one that was matched.
+  t = "hello"
+  t.gsub(/l/) { t.tr!("h", "H"); "X" }
   assert_equal "l", $&
-  assert_equal "hel", $`
+  assert_equal "Hel", $`
   assert_equal "o", $'
+  assert_equal "Hello", $~.string
+  assert_true $~.string.frozen?
+
+  # The search runs from the offset the last match was found from, so a
+  # match the block writes in before that offset goes unseen, and one at or
+  # after it is the match left behind.
+  s = "abcbd"
+  n = 0
+  s.gsub(/b/) { n += 1; s[0] = "b" if n == 2; "!" }
+  assert_equal 3, $~.begin(0)
+  assert_equal "bbc", $`
+  s = "abcd"
+  s.gsub(/b/) { s[0] = "b"; "!" }
+  assert_equal 0, $~.begin(0)
+  assert_equal "bcd", $'
+  assert_equal "bbcd", $~.string
 end
 
 assert("MatchData#regexp") do

--- a/mrbgems/mruby-regexp/test/regexp_utf8.rb
+++ b/mrbgems/mruby-regexp/test/regexp_utf8.rb
@@ -830,3 +830,22 @@ assert("Regexp - what sub and gsub build out of a byte-read subject") do
   # a byte-read subject is read as bytes whether anything was spliced or not
   assert_equal Encoding::BINARY, subject.gsub(/x/, "-").encoding
 end
+
+assert("Regexp - the match a gsub block leaves behind reads as the receiver does") do
+  # The search that ends the block form of `gsub` runs on the receiver as
+  # the block left it, and it is spared where the receiver still reads as it
+  # did when the last match was made. A block that changed how the receiver
+  # is read without changing a byte has changed what a search reads of it:
+  # `s.replace(s.b)` keeps every byte and makes them byte-read, so the match
+  # left behind counts its offsets in bytes, where the match the loop had
+  # counted characters. Bytes alone would take that receiver for unchanged.
+  skip unless __ENCODING__ == "UTF-8"
+  s = "héllo"
+  s.gsub(/l/) { s.replace(s.b); "L" }
+  assert_equal 4, $~.begin(0)
+  assert_equal 6, $~.string.size
+  s = "héllo"
+  s.gsub(/l/) { "L" }
+  assert_equal 3, $~.begin(0)
+  assert_equal 5, $~.string.size
+end

--- a/mrbgems/mruby-regexp/test/string_regexp.rb
+++ b/mrbgems/mruby-regexp/test/string_regexp.rb
@@ -914,15 +914,35 @@ assert("String#sub! / #gsub! with a String pattern answer the one search they ma
   assert_equal 3, $~.begin(0)
 end
 
-assert("String#gsub with a block whose block replaces the subject") do
-  # The loop is in C and reads the subject afresh every turn, so a block that
-  # replaces it under the walk cannot leave the search reading bytes that were
-  # freed.
-  s = "aaaa".dup
-  assert_kind_of String, s.gsub(/a/) { s.replace("b"); "-" }
-  s = "aaaa".dup
-  assert_kind_of String, s.gsub(/a/) { s << "aaaa"; "-" }
-
+assert("String#gsub with a block that changes the receiver") do
+  # CRuby's `str_gsub` reads the stretch before each match, the next match
+  # and the step over an empty match from the receiver as the block left it,
+  # so a change the block makes in place shows in the answer from the first
+  # match on.  The stretch before a match used to be copied before the block
+  # ran, so a change there was lost.
+  s = "hello"
+  assert_equal "HeXXo", s.gsub(/l/) { s.tr!("h", "H"); "X" }
+  s = "hello"
+  assert_equal "HEXLO", s.gsub(/l/) { s.upcase!; "X" }
+  # long enough not to sit inside the string object, so that the write moves
+  # the receiver off the buffer the match was made on
+  s = "abcb" * 20
+  assert_equal "A-CB" + ("ABCB" * 19), s.gsub(/b/) { s.upcase!; "-" }
+  s = "hello"
+  n = 0
+  assert_equal "heXXO", s.gsub(/l/) { n += 1; s.upcase! if n == 2; "X" }
+  s = "abc"
+  assert_equal "x!z", s.gsub(/b/) { s.replace("xyz"); "!" }
+  s = "abcb"
+  assert_equal "Z!c!", s.gsub(/b/) { s[0] = "Z"; "!" }
+  # the next match is searched for in the changed string, so a match the block
+  # writes in after the current one is found, and one it writes away is not
+  s = "abcd"
+  assert_equal "a!c!", s.gsub(/b/) { s[3] = "b"; "!" }
+  s = "abcb"
+  assert_equal "a!cz", s.gsub(/b/) { s[3] = "z"; "!" }
+  s = "abc"
+  assert_equal "-A-B-C-", s.gsub(//) { s.upcase!; "-" }
   # What the walk takes after the block is what the block left, which needs
   # the bytes read again rather than the pointer the search was made with. A
   # replacement of the same length moves the buffer without changing the
@@ -930,6 +950,79 @@ assert("String#gsub with a block whose block replaces the subject") do
   # the old pointer keeps one byte of the subject as it was.
   s = "a" * 200
   assert_equal "-" + "b" * 200, s.gsub(/(?=a)/) { s.replace("b" * 200); "-" }
+  # a quoted String pattern goes the same way
+  s = "hello"
+  assert_equal "HeXXo", s.gsub("l") { s.tr!("h", "H"); "X" }
+  # `gsub!` replaces the receiver with the same answer
+  s = "hello"
+  assert_equal "HeXXo", s.gsub!(/l/) { s.tr!("h", "H"); "X" }
+  assert_equal "HeXXo", s
+
+  # A block that changes the length is refused, as `str_mod_check` refuses
+  # it, since the offsets of the match no longer name the bytes they named.
+  # The length is compared in bytes, and against the receiver as it was when
+  # the loop began, so a change undone before the block returns passes.
+  s = "abc"
+  assert_raise_with_message(RuntimeError, "string modified") { s.gsub(/b/) { s << "zz"; "!" } }
+  s = "abc"
+  assert_raise_with_message(RuntimeError, "string modified") { s.gsub(/b/) { s.replace("xy"); "!" } }
+  s = "abc"
+  assert_raise_with_message(RuntimeError, "string modified") { s.gsub(/b/) { s.clear; "!" } }
+  s = "aébé"
+  assert_raise_with_message(RuntimeError, "string modified") { s.gsub(/é/) { s.replace("aebe"); "!" } }
+  s = "hello"
+  assert_raise_with_message(RuntimeError, "string modified") { s.gsub("l") { s << "z"; "X" } }
+  # an empty match reads the receiver for the character it steps over
+  # before the next search, so a block that shrank it is refused there too
+  s = "ab"
+  assert_raise_with_message(RuntimeError, "string modified") { s.gsub(/x*/) { s.clear; "!" } }
+  s = "ab"
+  assert_raise_with_message(RuntimeError, "string modified") { s.gsub(/x*/) { s.chop!; "!" } }
+  s = "abc"
+  assert_equal "a!c", s.gsub(/b/) { s << "z"; s.chop!; "!" }
+  # the receiver keeps what the block did to it, and the last match stays
+  # published, since the loop ends on the raise and not on a failed search
+  s = "abc"
+  assert_raise(RuntimeError) { s.gsub!(/b/) { s << "zz"; "!" } }
+  assert_equal "abczz", s
+  assert_equal "b", $&
+  assert_equal "abc", $~.string
+
+  # `sub` builds its answer from a copy of the receiver, as `rb_str_sub`
+  # does, so the block reaches nothing it reads and no length is checked.
+  s = "hello"
+  assert_equal "heXlo", s.sub(/l/) { s.upcase!; "X" }
+  s = "abc"
+  assert_equal "a!c", s.sub(/b/) { s << "zz"; "!" }
+end
+
+assert("String#sub! with a block that changes the receiver") do
+  # `rb_str_sub_bang` splices the replacement into the receiver as the block
+  # left it, where `sub` reads the copy it made before the block ran.
+  s = "hello"
+  assert_equal "HEXLO", s.sub!(/l/) { s.upcase!; "X" }
+  assert_equal "HEXLO", s
+  s = "hello"
+  assert_equal "HeXlo", s.sub!(/l/) { s.tr!("h", "H"); "X" }
+  s = "abc"
+  assert_equal "x!z", s.sub!(/b/) { s.replace("xyz"); "!" }
+  # $~ is the match the replacement was made for, on the subject as matched
+  assert_equal "b", $&
+  assert_equal "abc", $~.string
+  # a change of length is refused here too, and the receiver keeps it
+  s = "abc"
+  assert_raise_with_message(RuntimeError, "string modified") { s.sub!(/b/) { s << "zz"; "!" } }
+  assert_equal "abczz", s
+  s = "abc"
+  assert_raise_with_message(RuntimeError, "string modified") { s.sub!(/b/) { s.replace("ab"); "!" } }
+  assert_equal "ab", s
+  # a receiver the block freezes cannot take the replacement
+  s = "abc"
+  assert_raise(FrozenError) { s.sub!(/b/) { s.freeze; "!" } }
+  assert_equal "abc", s
+  s = "abc"
+  assert_raise(FrozenError) { s.gsub!(/b/) { s.freeze; "!" } }
+  assert_equal "abc", s
 end
 
 assert("MatchData#regexp compiles a literal pattern only when asked for one") do

--- a/mrbgems/mruby-regexp/test/string_regexp.rb
+++ b/mrbgems/mruby-regexp/test/string_regexp.rb
@@ -45,6 +45,59 @@ assert("String#scan of a multibyte subject reports byte-correct globals") do
   assert_equal [[1, "あ", "いXう"], [3, "あXい", "う"]], seen
 end
 
+assert("String#scan with a block that changes the receiver") do
+  # `rb_str_scan` searches for the next match in the receiver as the block
+  # left it, and the match it leaves behind is a search once more from the
+  # offset the last match was found from, so a block that writes the match
+  # away leaves nil where the loop used to republish the match it had.
+  s = "hello"
+  seen = []
+  s.scan(/l/) { |m| seen << m; s.upcase! }
+  assert_equal ["l"], seen
+  assert_equal "HELLO", s
+  assert_nil $~
+  s = "hello"
+  n = 0
+  seen = []
+  s.scan(/l/) { |m| seen << m; n += 1; s.upcase! if n == 2 }
+  assert_equal ["l", "l"], seen
+  assert_nil $~
+  # a change that leaves the match where it was leaves it behind, on the
+  # changed string
+  s = "hello"
+  s.scan(/(l)/) { s.tr!("h", "H") }
+  assert_equal "l", $&
+  assert_equal "l", $1
+  assert_equal "Hel", $`
+  assert_equal "o", $'
+  assert_equal "Hello", $~.string
+  # a match the block writes in after the current one is found
+  s = "abcd"
+  seen = []
+  s.scan(/b/) { |m| seen << m; s[3] = "b" }
+  assert_equal ["b", "b"], seen
+  assert_equal "abc", $`
+  s = "abc"
+  seen = []
+  s.scan(//) { |m| seen << m; s.upcase! }
+  assert_equal ["", "", "", ""], seen
+  assert_equal "ABC", $`
+  # a quoted String pattern goes the same way
+  s = "hello"
+  seen = []
+  s.scan("l") { |m| seen << m; s.upcase! }
+  assert_equal ["l"], seen
+  assert_nil $~
+  # a block that changes the length is refused, as in `gsub`
+  s = "hello"
+  assert_raise_with_message(RuntimeError, "string modified") { s.scan(/l/) { s << "z" } }
+  assert_equal "helloz", s
+  s = "hello"
+  assert_raise_with_message(RuntimeError, "string modified") { s.scan("l") { s << "z" } }
+  s = "ab"
+  assert_raise_with_message(RuntimeError, "string modified") { s.scan(/x*/) { s.clear } }
+end
+
 assert("String#gsub - regexp search position is byte-based internally") do
   skip unless __ENCODING__ == "UTF-8"
   assert_equal "あ-い-う", "あ,い,う".gsub(/,/, "-")


### PR DESCRIPTION
Rebased onto master now that #7274, which moves the block walk of `gsub` into C, is merged: the two commits here are all this PR is. The semantics, the tests and the differential run are the ones reviewed above, with the `gsub` part living in the C loop, where the cost question of that review does not arise. Every figure below is measured against master as it stands after that merge.

The block forms of `String#gsub`, `gsub!`, `sub!` and `scan` in mruby-regexp did not answer for a block that writes to the receiver the way CRuby's `str_gsub`, `rb_str_sub_bang` and `rb_str_scan` do. Measured against CRuby 4.0.6:

```ruby
s = "hello"; s.gsub(/l/) { s.tr!("h", "H"); "X" }
# CRuby: "HeXXo"   mruby before: "heXXo"   mruby after: "HeXXo"

s = "abc"; s.gsub(/b/) { s.replace("xyz"); "!" }
# CRuby: "x!z"     mruby before: "a!z"     mruby after: "x!z"

t = "hello"; n = 0
t.gsub(/l/) { n += 1; t.upcase! if n == 2; "X" }
[$&, $`, $']
# CRuby: [nil, nil, nil]   mruby before: ["l", "hel", "o"]   mruby after: [nil, nil, nil]

s = "abc"; s.gsub(/b/) { s << "zz"; "!" }
# CRuby: RuntimeError (string modified)   mruby before: "a!czz"   mruby after: RuntimeError (string modified)

s = "hello"; s.sub!(/l/) { s.upcase!; "X" }
# CRuby: "HEXLO"   mruby before: "heXlo"   mruby after: "HEXLO"

s = "hello"; s.scan(/l/) { s.upcase! }; $~ && $~[0]
# CRuby: nil       mruby before: "l"       mruby after: nil
```

Three things were off in what the loops read and when. The `gsub` loop copied the stretch before each match before the block ran, so a change the block made there was lost from the answer while the next match was already searched for in the changed string. A block that changed the length was let through in every loop, and the offsets of the match then named other bytes than the ones it matched; CRuby refuses one in `str_mod_check` right after the block returns. And the match left in `$~` was the MatchData of the last match the loop had, published again; CRuby searches once more when the loop is over, from the offset the last match was found from and on the receiver as it stands then, which is nil where the block wrote the match away and a fresh match on the changed string otherwise. `sub!` went down to `sub`, which builds the answer from the snapshot the MatchData holds, where `rb_str_sub_bang` splices the replacement into the receiver as the block left it.

## Fix

Two commits.

The first takes `gsub` and `sub!`. `Regexp.__gsub_block`, the C loop #7274 put on master, calls the block first and copies the stretch before the match afterwards, compares the receiver's byte length after each call against what it was when the loop began and raises `RuntimeError` where it differs (`str_mod_check` compares the buffer pointer too, which is no test here: mruby answers a write into a shared string with a buffer of its own, which is also why the bytes, their reading and the encoding check are taken afresh from the receiver the block left rather than through the pointer the search was given), keeps the offset each match was found from and the match itself, and ends on a search from that offset where the receiver no longer reads as it did when that match was made. Where it still does, the search could only find that match again, so the loop publishes it again: a MatchData holds a frozen copy of its subject, and what a search reads of a subject is its bytes and whether they are read by byte, so the receiver is compared against that copy on both counts. A change of length fails the comparison, so do `tr!` and `upcase!`, which keep the length and change the bytes, and so does `s.replace(s.b)`, which keeps every byte and changes the reading; where the receiver still shares its buffer with the copy, the pointer settles it. In C the length check is one comparison per turn and the copy test a pointer compare or a `memcmp` in the same function. `gsub!` inherits all of it. The block form of `sub!` runs the block itself in mrblib, applies the same length check, and splices the replacement into the receiver by the byte offsets of the match. `sub` is unchanged: CRuby's `rb_str_sub` works on a copy, so the block reaches nothing it reads.

The second takes `scan`, whose block loop stays in mrblib. It hands the length it began with to every search it makes after the block, and `Regexp.__byte_search` takes it as a fourth argument and raises `RuntimeError` before it looks where the receiver no longer has it, so the loop pays one argument per search rather than one `bytesize` call per match; it keeps the offset each match was found from and the match itself, and ends on a search from that offset unless `MatchData#__republish(str)`, the copy test above asked from mrblib, publishes the match again. `MatchData#__set_globals`, which republished the last match whatever the block had done to the receiver, loses its last caller there and goes.

## Testing

- `mrbgems/mruby-regexp/test/match_data.rb`: the test that pinned the republished MatchData after a `gsub` block mutated the subject now pins CRuby's answer (`$~` nil where the match was written away, a match on the changed string where it was left in place, and the closing search running from the offset the last match was found from).
- `mrbgems/mruby-regexp/test/string_regexp.rb`: return values of `gsub` / `gsub!` / `sub!` / `scan` under a block that changes the receiver in place, `RuntimeError` for a change of length (in bytes, and against the length at the start of the loop, so a change undone inside the block passes), the receiver keeping what the block did to it, `sub` unaffected, `FrozenError` for a receiver the block freezes, a receiver long enough that the write moves it off the buffer the match was made on, and, for the empty-match step, `s.clear` and `s.chop!` under `gsub(/x*/)` and `s.clear` under `scan(/x*/)`, which raise `RuntimeError` on CRuby. The assertion master gained in ba8a7c82d, a `replace` of the same length under `gsub(/(?=a)/)` that tells reading the receiver's bytes again from reading the pointer the search was made with, stands inside this rewritten test as it was written.
- `mrbgems/mruby-regexp/test/regexp_utf8.rb`: the match left behind after a block that changed the reading of the receiver without changing a byte (`s.replace(s.b)`) counts its offsets in bytes, as CRuby's does after a `force_encoding` in the block; a comparison of bytes alone would take that receiver for unchanged.

Every value in the tests was measured on CRuby 4.0.6 first. The differential run from the earlier review, the four block forms over 7 subjects, 8 patterns and 16 kinds of in-block change, 3584 cases printed the same way on both sides and diffed against CRuby 4.0.6: master differs on 992, the first commit here on 223 (all of them `scan`), the tip on 0.

Full suite green at every commit: `rake -m test` on the default configuration at each commit, and `MRUBY_CONFIG=build_config/ci/gcc-clang.rb rake -m test` and `MRUBY_CONFIG=build_config/gcc-asan.rb rake -m test` at the tip, no sanitizer report.

| Build | Total | KO | Crash |
| --- | --- | --- | --- |
| full-debug | 2377 | 0 | 0 |
| bintest | 2377 (+122 bintest) | 0 | 0 |
| cxx_abi | 2377 | 0 | 0 |
| byte-string | 2306 | 0 | 0 |
| ascii-ctype | 2373 | 0 | 0 |
| gcc-asan | 2377 (+84 bintest) | 0 | 0 |
| default | 2152 | 0 | 0 |

## Cost

Wall clock, the cases of the earlier review plus the String pattern block forms and a `scan` over the long subject, minimum of 5 alternating runs, `-O3`, default configuration. master has the C walk of #7274, so the block rows start from where that PR left them; the percentages are against master.

```ruby
s480 = "hello world foo bar " * 24
30000.times { s480.gsub(/o/) { } }        # gsub480_blk
100000.times { "abc".gsub(/b/) { } }      # gsub_abc_blk
100000.times { "abc".scan(/b/) { } }      # scan_abc_blk
100000.times { "abc".sub!(/b/) { } }      # sub!_abc_blk
30000.times { s480.gsub(/o/, "0") }       # gsub480_str
100000.times { "abc".scan(/b/) }          # scan_abc
100000.times { "abc".sub!(/b/, "0") }     # sub!_abc_str
30000.times { s480.gsub(/z/) { } }        # gsub480_none
30000.times { s480.scan(/o/) { } }        # scan480_blk
30000.times { s480.gsub("o") { } }        # lit_gsub480_blk
100000.times { "abc".gsub("b") { } }      # lit_gsub_abc_blk
100000.times { "abc".sub!("b") { } }      # lit_sub!_abc_blk
100000.times { s = "hello"; s.gsub(/l/) { s.tr!("h", "H"); "X" } }        # gsub_tr
30000.times { s = s480.dup; s.gsub(/o/) { s.tr!("h", "H"); "0" } }        # gsub480_tr
100000.times { s = "hello"; s.scan(/l/) { s.tr!("h", "H") } }             # scan_tr
```

| case | master | commit 1 | this PR |
| --- | --- | --- | --- |
| gsub480_blk | 1207ms | 1231ms (+2%) | 1207ms |
| gsub_abc_blk | 160ms | 164ms (+3%) | 164ms (+3%) |
| scan_abc_blk | 174ms | 172ms (-1%) | 182ms (+5%) |
| sub!_abc_blk | 212ms | 172ms (-19%) | 170ms (-20%) |
| gsub480_str | 118ms | 118ms | 118ms |
| scan_abc | 117ms | 118ms (+1%) | 117ms |
| sub!_abc_str | 193ms | 190ms (-2%) | 192ms (-1%) |
| gsub480_none | 37ms | 38ms (+3%) | 38ms (+3%) |
| scan480_blk | 1592ms | 1580ms (-1%) | 1612ms (+1%) |
| lit_gsub480_blk | 1189ms | 1216ms (+2%) | 1201ms (+1%) |
| lit_gsub_abc_blk | 157ms | 158ms (+1%) | 157ms |
| lit_sub!_abc_blk | 266ms | 168ms (-37%) | 167ms (-37%) |
| gsub_tr | 222ms | 221ms | 223ms |
| gsub480_tr | 4286ms | 4293ms | 4318ms (+1%) |
| scan_tr | 260ms | 257ms (-1%) | 266ms (+2%) |

The `gsub` rows: the length comparison, the reading and the encoding flag read per turn cost about 2% on the 480 byte subject in the first commit (24ms over 2.16 million turns), a spread the tip's run of the same code lands inside, and 3% at most on the short ones; the closing test is the pointer alone there, since the receiver still shares its buffer with the snapshot. `sub!` with a block no longer goes down to `sub`, which is the -20% and -37% on its two rows. The `scan` rows carry the argument the search now parses and the `__republish` call, 1% on the long subject and 5% on the short one, and `scan` on `"abc"` without a block, `gsub(/o/, "0")` and `sub!(/b/, "0")` are unchanged. The mutating rows (`gsub_tr`, `gsub480_tr`, `scan_tr`) are where the closing search runs, and they sit on master to within 2%.

## Size

`.text` of `bin/mruby`, `build_config/ci/gcc-clang.rb`, each side from a clean
build directory. `regexp.o` is the object that changes, and it accounts for the
whole delta in every build (to within 5 bytes of alignment in `full-debug`):
the copy test and the closing search in `__gsub_block`, `__republish` and the
length argument of `__byte_search`. The mrblib side, the block form of `sub!`
and the closing search of `scan`, is bytecode in `mruby-regexp/gem_init.o`'s
`.rodata`, which grows by 128 (160 in `full-debug`).

| build | master | commit 1 | this PR | delta |
|---|---:|---:|---:|---:|
| `bintest` | 1,287,414 | 1,287,718 | 1,288,134 | +720 |
| `ascii-ctype` | 1,275,302 | 1,275,606 | 1,276,022 | +720 |
| `byte-string` | 1,257,014 | 1,257,318 | 1,257,734 | +720 |
| `cxx_abi` | 1,313,017 | 1,313,353 | 1,313,593 | +576 |
| `full-debug` (`-O0`) | 1,886,710 | 1,887,062 | 1,887,318 | +608 |

On the default configuration, the one the wall clock was measured on, `.text` is
1,204,174 on master, 1,204,478 after the first commit and 1,204,894 at the tip
(+720).

### Environment

<details>
<summary>Machine, toolchain, and the compile line of every build</summary>

| Item | Value |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS |
| Kernel | 7.0.0-29-generic |
| CPU | AMD Ryzen 9 5950X 16-Core Processor |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0 |
| binutils | GNU ld (GNU Binutils) 2.47.20260726 |
| CRuby (reference) | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |

Actual compile line of `mrbgems/mruby-regexp/src/regexp.c` in each build (`-MMD -c`, `-I`, and `-o` dropped). `full-debug` and `gcc-asan` are `-O0` because `enable_debug` appends `-g3 -O0` after the toolchain's `-g -O3`; `cxx_abi` compiles C as C++ with `gcc -x c++ -std=gnu++03`, g++ only links.

```console
# full-debug
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-regexp/src/regexp.c
# bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK mrbgems/mruby-regexp/src/regexp.c
# cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-regexp/src/regexp.c
# byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-regexp/src/regexp.c
# ascii-ctype
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-regexp/src/regexp.c
# gcc-asan
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -fsanitize=address,undefined -g3 -O0 -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-regexp/src/regexp.c
# default (no MRUBY_CONFIG), the build every figure above was measured on
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK mrbgems/mruby-regexp/src/regexp.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `String#sub`, `gsub`, `scan`, and bang variants when the source string is modified during processing.
  * Added validation to detect source-length changes and prevent inconsistent results.
  * Preserved match information more reliably after substitutions and callbacks.
  * Improved handling of literal string patterns, replacement expansions, empty patterns, frozen strings, and invalid byte sequences.
  * Corrected UTF-8 and byte-based match indexing after block substitutions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

