### PR TITLE
mruby-regexp: stop a repetition on an empty iteration in the backtracker

### DIFF
--- a/mrbgems/mruby-regexp/include/re_internal.h
+++ b/mrbgems/mruby-regexp/include/re_internal.h
@@ -135,8 +135,8 @@ typedef struct mrb_regexp_pattern {
 #define MRB_REGEXP_STEP_LIMIT 1000000
 #endif
 
-/* Recursion-depth limit for bt_match: bounds C stack growth on
-   patterns like `(?=)+` that recurse without consuming input. */
+/* Recursion-depth limit for bt_match, which recurses at every fork and
+   every capture: bounds C stack growth on a long subject or a deep pattern. */
 #ifndef MRB_REGEXP_RECURSION_LIMIT
 #define MRB_REGEXP_RECURSION_LIMIT 1000
 #endif

--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -2165,9 +2165,12 @@ first_set_walk(const re_inst *code, uint32_t code_len,
   return FALSE;
 }
 
-/* TRUE when an epsilon-only path runs from pc to goal, so the repetition that
-   goal closes can complete an iteration without consuming. seen[] is marked
-   with `mark` rather than cleared, so one buffer serves every edge. */
+/* TRUE when a path that need not consume runs from pc to goal, so the
+   repetition that goal closes can complete an iteration without consuming.
+   A lookaround is zero-width whatever its sub-pattern does, so the walk
+   steps over the sub-pattern; a backreference to a group that captured
+   empty consumes nothing, so it can be on such a path. seen[] is marked with
+   `mark` rather than cleared, so one buffer serves every edge. */
 static mrb_bool
 epsilon_path(const re_inst *code, uint32_t pc, uint32_t goal,
              uint32_t *seen, uint32_t mark)
@@ -2180,9 +2183,12 @@ epsilon_path(const re_inst *code, uint32_t pc, uint32_t goal,
     case RE_BOL: case RE_EOL: case RE_BOT: case RE_EOT: case RE_EOTNL:
     case RE_WBOUND: case RE_NWBOUND:
     case RE_ATOMIC: case RE_ATOMIC_END:
+    case RE_BACKREF:
       pc++;
       break;
     case RE_JMP:
+    case RE_LOOKAHEAD: case RE_NEG_LOOKAHEAD:
+    case RE_LOOKBEHIND: case RE_NEG_LOOKBEHIND:
       pc = code[pc].offset;
       break;
     case RE_SPLIT:
@@ -2191,7 +2197,7 @@ epsilon_path(const re_inst *code, uint32_t pc, uint32_t goal,
       pc++;
       break;
     default:
-      return FALSE;  /* consumes input, or is an assertion this walk cannot judge */
+      return FALSE;  /* consumes input */
     }
   }
   return TRUE;

--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -2198,10 +2198,15 @@ epsilon_path(const re_inst *code, uint32_t pc, uint32_t goal,
 }
 
 /* Find the repetitions whose body can match empty and mark the backward edge
-   that closes each one, so the Pike VM knows which loops need the empty-
-   iteration handling in add_thread() and which can stay on the cheap path.
-   Returns how deeply those loops nest, which bounds the VM's epsilon passes
-   and the thread lists sized from them; see RE_MAX_PASS and RE_LIST_CAPA. */
+   that closes each one, so that both engines know which loops need the
+   empty-iteration handling (add_thread() and bt_match()) and which can stay
+   on the cheap path. A repetition laid out as e* is closed by a jump back to
+   its SPLIT/SPLITNG head, and that head is marked too: it is where an
+   iteration begins, which the backtracker has to record; see bt_iter(). The
+   head is a forward edge, and a forward edge's mark means nothing else.
+   Returns how deeply the marked loops nest, which bounds the VM's epsilon
+   passes and the thread lists sized from them; see RE_MAX_PASS and
+   RE_LIST_CAPA. */
 static uint8_t
 mark_empty_loops(mrb_state *mrb, re_inst *code, uint32_t code_len)
 {
@@ -2222,6 +2227,11 @@ mark_empty_loops(mrb_state *mrb, re_inst *code, uint32_t code_len)
     if (in.offset > pc) continue;  /* forward edge: alternation, not a loop */
     if (!epsilon_path(code, in.offset, pc, seen, ++mark)) continue;
     code[pc].a = 1;
+    if (in.op == RE_JMP) {
+      /* The head was passed earlier in this scan, so its mark stays. */
+      mrb_assert(code[in.offset].op == RE_SPLIT || code[in.offset].op == RE_SPLITNG);
+      code[in.offset].a = 1;
+    }
     delta[in.offset]++;
     delta[pc + 1]--;  /* the closing edge itself still sits inside the loop */
   }

--- a/mrbgems/mruby-regexp/src/re_exec.c
+++ b/mrbgems/mruby-regexp/src/re_exec.c
@@ -637,18 +637,36 @@ lookbehind_start(const mrb_regexp_pattern *pat, const char *str,
 #define BT_LIMIT 2
 #define BT_CUT(atomic_depth) (-(int)(atomic_depth))
 
+/* What one backtrack_exec() call shares between its bt_match() frames: the
+   pattern, the subject, the capture slots being written and the step count.
+   A frame's own state is its position, its pc and its depth. */
+typedef struct {
+  const mrb_regexp_pattern *pat;
+  const char *str;
+  const char *str_end;
+  int *captures;
+  int ncap;
+  int steps;
+  mrb_bool binary;
+} bt_state;
+
 /*
  * Backtracking engine for patterns with backreferences.
  * Step-limited to prevent ReDoS.
  */
 static int
-bt_match(const mrb_regexp_pattern *pat, const char *str, const char *str_end,
-         const char *sp, uint32_t pc, int *captures, int ncap, int *steps,
-         int depth, mrb_bool binary)
+bt_match(bt_state *m, const char *sp, uint32_t pc, int depth)
 {
+  const mrb_regexp_pattern *pat = m->pat;
+  const char *str = m->str;
+  const char *str_end = m->str_end;
+  int *captures = m->captures;
+  int ncap = m->ncap;
+  mrb_bool binary = m->binary;
+
   if (depth > MRB_REGEXP_RECURSION_LIMIT) return BT_LIMIT;
   while (pc < pat->code_len) {
-    if (++(*steps) > MRB_REGEXP_STEP_LIMIT) return BT_LIMIT;
+    if (++m->steps > MRB_REGEXP_STEP_LIMIT) return BT_LIMIT;
 
     re_inst inst = pat->code[pc];
     switch (inst.op) {
@@ -700,7 +718,7 @@ bt_match(const mrb_regexp_pattern *pat, const char *str, const char *str_end,
 
     case RE_SPLIT:
       {
-        int r = bt_match(pat, str, str_end, sp, pc + 1, captures, ncap, steps, depth + 1, binary);
+        int r = bt_match(m, sp, pc + 1, depth + 1);
         if (r != BT_FAIL && r != BT_LIMIT) return r;
       }
       pc = inst.offset;
@@ -708,7 +726,7 @@ bt_match(const mrb_regexp_pattern *pat, const char *str, const char *str_end,
 
     case RE_SPLITNG:
       {
-        int r = bt_match(pat, str, str_end, sp, inst.offset, captures, ncap, steps, depth + 1, binary);
+        int r = bt_match(m, sp, inst.offset, depth + 1);
         if (r != BT_FAIL && r != BT_LIMIT) return r;
       }
       pc++;
@@ -727,7 +745,7 @@ bt_match(const mrb_regexp_pattern *pat, const char *str, const char *str_end,
         if (slot < ncap) {
           int old = captures[slot];
           captures[slot] = (int)(sp - str);
-          int r = bt_match(pat, str, str_end, sp, pc + 1, captures, ncap, steps, depth + 1, binary);
+          int r = bt_match(m, sp, pc + 1, depth + 1);
           if (r == BT_MATCH) return r;
           /* undone for a cut as for a failure: the group the cut fails may
              be the one this slot was written inside */
@@ -812,7 +830,7 @@ bt_match(const mrb_regexp_pattern *pat, const char *str, const char *str_end,
         /* A sub-pattern answers BT_MATCH, BT_FAIL or BT_LIMIT, never a cut.
            The two failures go up as they are; the four lookarounds only
            differ in what a match means. */
-        int r = bt_match(pat, str, str_end, sp, pc + 1, captures, ncap, steps, depth + 1, binary);
+        int r = bt_match(m, sp, pc + 1, depth + 1);
         if (r != BT_MATCH) return r;
         pc = inst.offset;
       }
@@ -820,7 +838,7 @@ bt_match(const mrb_regexp_pattern *pat, const char *str, const char *str_end,
 
     case RE_NEG_LOOKAHEAD:
       {
-        int r = bt_match(pat, str, str_end, sp, pc + 1, captures, ncap, steps, depth + 1, binary);
+        int r = bt_match(m, sp, pc + 1, depth + 1);
         if (r == BT_MATCH) return BT_FAIL;
         if (r == BT_LIMIT) return r;
         pc = inst.offset;
@@ -831,7 +849,7 @@ bt_match(const mrb_regexp_pattern *pat, const char *str, const char *str_end,
       {
         const char *back = lookbehind_start(pat, str, str_end, sp, pc, binary);
         if (!back) return BT_FAIL;  /* not enough text before */
-        int r = bt_match(pat, str, str_end, back, pc + 2, captures, ncap, steps, depth + 1, binary);
+        int r = bt_match(m, back, pc + 2, depth + 1);
         if (r != BT_MATCH) return r;
         pc = inst.offset;
       }
@@ -841,7 +859,7 @@ bt_match(const mrb_regexp_pattern *pat, const char *str, const char *str_end,
       {
         const char *back = lookbehind_start(pat, str, str_end, sp, pc, binary);
         if (back) {
-          int r = bt_match(pat, str, str_end, back, pc + 2, captures, ncap, steps, depth + 1, binary);
+          int r = bt_match(m, back, pc + 2, depth + 1);
           if (r == BT_MATCH) return BT_FAIL;
           if (r == BT_LIMIT) return r;
         }
@@ -857,7 +875,7 @@ bt_match(const mrb_regexp_pattern *pat, const char *str, const char *str_end,
            here: the answer is passed up, except that a cut aimed at this
            group is this group failing, which the caller backtracks over the
            way it would any other failed atom. */
-        int r = bt_match(pat, str, str_end, sp, pc + 1, captures, ncap, steps, depth + 1, binary);
+        int r = bt_match(m, sp, pc + 1, depth + 1);
         return (r == BT_CUT(inst.offset)) ? BT_FAIL : r;
       }
 
@@ -867,7 +885,7 @@ bt_match(const mrb_regexp_pattern *pat, const char *str, const char *str_end,
            when what follows fails, the failure is a cut, so that the SPLITs
            inside the body do not get to try their other branches. A limit
            is not the text failing and goes up as it is. */
-        int r = bt_match(pat, str, str_end, sp, pc + 1, captures, ncap, steps, depth + 1, binary);
+        int r = bt_match(m, sp, pc + 1, depth + 1);
         return (r == BT_FAIL) ? BT_CUT(inst.offset) : r;
       }
 
@@ -889,6 +907,13 @@ backtrack_exec(mrb_state *mrb, const mrb_regexp_pattern *pat,
   if (ncap == 0) ncap = 2;
 
   int *caps = (int*)mrb_malloc(mrb, sizeof(int) * ncap);
+  bt_state m;
+  m.pat = pat;
+  m.str = str;
+  m.str_end = str_end;
+  m.captures = caps;
+  m.ncap = ncap;
+  m.binary = binary;
 
   for (const char *sp = str + start; sp <= str_end && sp <= start_cap; sp++) {
     /* Skip ahead using literal prefix or first-byte bitmap */
@@ -906,9 +931,9 @@ backtrack_exec(mrb_state *mrb, const mrb_regexp_pattern *pat,
       continue;
     }
     memset(caps, -1, sizeof(int) * ncap);
-    int steps = 0;
+    m.steps = 0;
 
-    if (bt_match(pat, str, str_end, sp, 0, caps, ncap, &steps, 0, binary) == BT_MATCH) {
+    if (bt_match(&m, sp, 0, 0) == BT_MATCH) {
       if (captures) {
         int copy = ncap < captures_size ? ncap : captures_size;
         memcpy(captures, caps, sizeof(int) * copy);

--- a/mrbgems/mruby-regexp/src/re_exec.c
+++ b/mrbgems/mruby-regexp/src/re_exec.c
@@ -626,20 +626,19 @@ lookbehind_start(const mrb_regexp_pattern *pat, const char *str,
    limit. A frame that gets it hands it up; a SPLIT takes it as that branch
    failing and answers with its other branch, as it would with a failure.
    What no frame does is turn it into a cut or into a lookaround's answer,
-   since a limit says nothing about the text. That matters because the
-   recursion limit is what stops a repetition whose body can match empty
-   under this engine (see MRB_REGEXP_RECURSION_LIMIT), and the repetition
-   being stopped may be inside an atomic group's body, where a cut would keep
-   its exit from being taken, or inside a negative lookaround, where reading
-   the limit as "no match" would make the assertion hold. */
+   since a limit says nothing about the text: the frame giving up may be
+   inside an atomic group's body, where a cut would keep the group's exit
+   from being taken, or inside a negative lookaround, where reading the limit
+   as "no match" would make the assertion hold. */
 #define BT_FAIL 0
 #define BT_MATCH 1
 #define BT_LIMIT 2
 #define BT_CUT(atomic_depth) (-(int)(atomic_depth))
 
 /* What one backtrack_exec() call shares between its bt_match() frames: the
-   pattern, the subject, the capture slots being written and the step count.
-   A frame's own state is its position, its pc and its depth. */
+   pattern, the subject, the capture slots being written, the step count and
+   the iteration records. A frame's own state is its position, its pc and its
+   depth. */
 typedef struct {
   const mrb_regexp_pattern *pat;
   const char *str;
@@ -647,8 +646,38 @@ typedef struct {
   int *captures;
   int ncap;
   int steps;
+  /* Per pc, the offset the running iteration of the loop that pc keys began
+     at, or -1 while none is running. A repetition whose body can match empty
+     has to stop once an iteration ends where it began, or it would go round
+     at the same position until a limit refused it and answer with whatever
+     the alternatives left inside the limit produce. Onigmo stops it with a
+     null check around the body; this array is that check's memory. The pc
+     that keys a loop is its marked head for e* (the SPLIT/SPLITNG whose
+     offset is the exit; the JMP closing the body reads the record) and its
+     marked back edge for e+ (the SPLIT/SPLITNG at the end of the body, which
+     both writes and reads it); see mark_empty_loops(). */
+  int *iter_at;
   mrb_bool binary;
 } bt_state;
+
+static int bt_match(bt_state *m, const char *sp, uint32_t pc, int depth);
+
+/* Run the frame at pc as the start of an iteration of the loop `key` keys,
+   recording where it begins so that the edge closing the body can tell an
+   empty iteration. The record lasts exactly as long as the frame: the frame
+   that ran the edge into the body is the one that undoes it, so backtracking
+   out of an iteration finds the record of the one it lands in, and the
+   branch that begins an iteration is run this way rather than in place even
+   when it is the frame's last, so that there is one place to undo it. */
+static int
+bt_iter(bt_state *m, const char *sp, uint32_t pc, uint32_t key, int depth)
+{
+  int old = m->iter_at[key];
+  m->iter_at[key] = (int)(sp - m->str);
+  int r = bt_match(m, sp, pc, depth);
+  m->iter_at[key] = old;
+  return r;
+}
 
 /*
  * Backtracking engine for patterns with backreferences.
@@ -713,10 +742,37 @@ bt_match(bt_state *m, const char *sp, uint32_t pc, int depth)
       return BT_MATCH;
 
     case RE_JMP:
+      /* A backward jump closes e* and returns to its head. When the head is
+         marked, the body can match empty and iter_at[head] holds where the
+         iteration that just ended began (see bt_iter()): an iteration that
+         ended where it began matched empty, and the repetition stops here,
+         taking the head's exit and keeping what the iteration captured, as
+         Onigmo's null check does. */
+      if (inst.a && m->iter_at[inst.offset] == (int)(sp - str)) {
+        pc = pat->code[inst.offset].offset;
+        break;
+      }
       pc = inst.offset;
       break;
 
     case RE_SPLIT:
+      /* Greedy fork: pc+1 first, then the jump target. A marked one is an
+         edge of a repetition whose body can match empty. Forward, it heads
+         e*, and pc+1 begins an iteration. Backward, it closes e+?, and its
+         target begins the next iteration, unless the one that just ended was
+         empty: then there is only the exit, as at a marked RE_JMP. */
+      if (inst.a) {
+        if (inst.offset > pc) {
+          int r = bt_iter(m, sp, pc + 1, pc, depth + 1);
+          if (r != BT_FAIL && r != BT_LIMIT) return r;
+          pc = inst.offset;
+          break;
+        }
+        if (m->iter_at[pc] == (int)(sp - str)) { pc++; break; }
+        int r = bt_match(m, sp, pc + 1, depth + 1);
+        if (r != BT_FAIL && r != BT_LIMIT) return r;
+        return bt_iter(m, sp, inst.offset, pc, depth + 1);
+      }
       {
         int r = bt_match(m, sp, pc + 1, depth + 1);
         if (r != BT_FAIL && r != BT_LIMIT) return r;
@@ -725,6 +781,22 @@ bt_match(bt_state *m, const char *sp, uint32_t pc, int depth)
       break;
 
     case RE_SPLITNG:
+      /* Non-greedy fork: the jump target first, then pc+1. Marked, forward
+         it heads e*? and backward it closes e+; the iteration-starting branch
+         is the other one from RE_SPLIT's, and the empty-iteration stop is the
+         same. */
+      if (inst.a) {
+        if (inst.offset > pc) {
+          int r = bt_match(m, sp, inst.offset, depth + 1);
+          if (r != BT_FAIL && r != BT_LIMIT) return r;
+          return bt_iter(m, sp, pc + 1, pc, depth + 1);
+        }
+        if (m->iter_at[pc] == (int)(sp - str)) { pc++; break; }
+        int r = bt_iter(m, sp, inst.offset, pc, depth + 1);
+        if (r != BT_FAIL && r != BT_LIMIT) return r;
+        pc++;
+        break;
+      }
       {
         int r = bt_match(m, sp, inst.offset, depth + 1);
         if (r != BT_FAIL && r != BT_LIMIT) return r;
@@ -906,14 +978,19 @@ backtrack_exec(mrb_state *mrb, const mrb_regexp_pattern *pat,
   int ncap = pat->num_captures * 2;
   if (ncap == 0) ncap = 2;
 
-  int *caps = (int*)mrb_malloc(mrb, sizeof(int) * ncap);
+  /* One block: the capture slots, then an iteration record per pc. Every
+     record a search writes it undoes before returning (see bt_iter()), so
+     the array is filled once for all start positions. */
+  int *caps = (int*)mrb_malloc(mrb, sizeof(int) * (ncap + pat->code_len));
   bt_state m;
   m.pat = pat;
   m.str = str;
   m.str_end = str_end;
   m.captures = caps;
   m.ncap = ncap;
+  m.iter_at = caps + ncap;
   m.binary = binary;
+  memset(m.iter_at, -1, sizeof(int) * pat->code_len);
 
   for (const char *sp = str + start; sp <= str_end && sp <= start_cap; sp++) {
     /* Skip ahead using literal prefix or first-byte bitmap */

--- a/mrbgems/mruby-regexp/test/regexp_syntax.rb
+++ b/mrbgems/mruby-regexp/test/regexp_syntax.rb
@@ -127,6 +127,43 @@ assert("String#split and String#scan see the empty iteration's capture") do
   assert_equal [[""], [""], [""]], "ab".scan(/(a?)*/)
 end
 
+assert("Regexp - the backtracking engine stops a repetition on an empty iteration") do
+  # The same rule under the engine a lazy quantifier routes a pattern to. It
+  # used to run such a loop until its recursion limit refused the next frame,
+  # and answer with whatever the alternatives left inside the limit produced:
+  # nothing here, since the outer loop went round again in the frame at the
+  # limit until the step budget was gone.
+  assert_equal 0, /(?:(?:b*)+)+?/ =~ ""
+  assert_equal 0, /(?:(?:b*)+)+?/ =~ "b"
+  assert_equal 0, /(?:(?:b?)+)+?/ =~ ""
+  assert_equal 0, /(?:(?:b*)+)+?/ =~ "abcdefghij"
+  # The loop stops with its lazy body still empty, rather than unwinding into
+  # the body's other branches once the limit is reached.
+  assert_equal "ca", /ca(?:b??b??)+a*?/.match("cab")[0]
+  assert_equal "aa", /(?:a?)*b??/.match("aab")[0]
+  assert_equal "aa", /(?:a?){2,}b??/.match("aab")[0]
+  assert_equal "", /(?:a??)+/.match("aa")[0]
+  assert_equal "a", /(?:a?|b)+c??/.match("ababab")[0]
+  # Each layout of a repetition stops on its own, greedy or lazy: e* jumps
+  # back to its head, e+ forks at the end of its body, e{n,} is copies of the
+  # body before an e*.
+  assert_equal "aab", /(?:a?)*?b/.match("aab")[0]
+  assert_equal "aab", /(?:a??)+b/.match("aab")[0]
+  assert_equal "aab", /(?:a??)+?b/.match("aab")[0]
+  assert_equal "aab", /(?:a?){2,}?b/.match("aab")[0]
+  assert_equal "aab", /(?:(?:a?)*)*?b/.match("aab")[0]
+  assert_equal "", /(?:(?:a?)*?)*b??/.match("aab")[0]
+  assert_equal "aab", /(?:(?:a??)+?)+?b/.match("aab")[0]
+  # The empty iteration's capture is kept, as under the linear-time engine.
+  md = /(a?)*b??/.match("a")
+  assert_equal "", md[1]
+  assert_equal 1, md.begin(1)
+  assert_equal 1, /(a??)+b/.match("ab").begin(1)
+  assert_equal 2, /(a*?)*b/.match("aab").begin(1)
+  assert_equal 1, /(a*?)*?b/.match("aab").begin(1)
+  assert_equal "", /((c*)*)a??/.match("c")[2]
+end
+
 assert("Regexp - quantified first alternative does not leak into the next") do
   # A quantifier loops back to its own atom. When the atom starts the first
   # alternative, the alternation SPLIT is inserted in front of it; the
@@ -566,10 +603,14 @@ assert("Regexp - atomic group (?>...)") do
   assert_nil /(?>x(?>a)(?>b)y)/.match("xabz")
   assert_equal 0, /(?>x(?>a)(?>b)y)/ =~ "xaby"
 
-  # A repetition whose body can match empty runs until the engine's recursion
-  # limit stops it. Reached inside the body, that stop is not a cut.
+  # A repetition whose body can match empty stops on its empty iteration
+  # inside the group as anywhere else, and takes the group's exit; a
+  # repetition of the group stops the same way, its lazy body still empty.
   assert_equal 0, /(?>(?:b*)+)/ =~ ""
   assert_equal 0, /(?>(?:a*)*)b/ =~ "aab"
+  assert_equal "aab", /(?>(?:a*)*)b?/.match("aab")[0]
+  assert_equal "aab", /(?:(?>a*))*b?/.match("aab")[0]
+  assert_equal "ca", /ca(?>b??)+/.match("cab")[0]
 
   # Captures written inside the body stay when the group matches, and are
   # unset again when a cut fails the group.

--- a/mrbgems/mruby-regexp/test/regexp_syntax.rb
+++ b/mrbgems/mruby-regexp/test/regexp_syntax.rb
@@ -164,6 +164,33 @@ assert("Regexp - the backtracking engine stops a repetition on an empty iteratio
   assert_equal "", /((c*)*)a??/.match("c")[2]
 end
 
+assert("Regexp - a repetition of a lookaround or a backreference stops the same way") do
+  # A lookaround is zero-width, and a backreference to a group that
+  # captured empty consumes nothing, so a repetition of either can run an
+  # empty iteration and stops on it. It used to run to the recursion limit,
+  # where the frame at the limit could not open the branch of a `?` that
+  # follows and answered with the branch that skips it.
+  assert_equal 0, /(?=)+/ =~ "a"
+  assert_equal "a", /(?=a)+a/.match("a")[0]
+  assert_equal "b", /(?:(?!a))*b?/.match("b")[0]
+  assert_equal "ab", /a(?:(?<=a))*b?/.match("ab")[0]
+  assert_equal 1, /(?:(?<!x))+b/ =~ "ab"
+  assert_equal "aab", /(?:a|(?!b))+?b/.match("aab")[0]
+  assert_equal "a", /(?>(?:(?=a))*)a/.match("a")[0]
+  assert_equal "aa", /(a*)\1*/.match("aa")[0]
+  assert_equal "b", /(a?)\1*b/.match("b")[0]
+  assert_equal "aab", /(?:(a)|\1)*b/.match("aab")[0]
+  assert_equal 1, /(?:(?=(a))\1?)*?b/.match("aab").begin(1)
+  # An iteration's record is undone when the iteration is backtracked out
+  # of, so an alternative of the earlier iteration that ends at the same
+  # position is not taken for an empty one: the loop goes round again from
+  # there, and the backreference sees what that alternative captured.
+  md = /(?:(a)b|a(b)|\2)*?c/.match("abbc")
+  assert_equal "abbc", md[0]
+  assert_equal "b", md[2]
+  assert_equal "abbc", /(?:(a)b|a(b)|\2)+c/.match("abbc")[0]
+end
+
 assert("Regexp - quantified first alternative does not leak into the next") do
   # A quantifier loops back to its own atom. When the atom starts the first
   # alternative, the alternation SPLIT is inserted in front of it; the


### PR DESCRIPTION
The Pike VM stops a repetition once its body has run without consuming;
`bt_match()` had no such stop. A repetition whose body can match empty went
round at the same position until `MRB_REGEXP_RECURSION_LIMIT` refused the
next frame, and what the engine then answered was whatever the alternatives
left inside the limit produced. That was CRuby's answer often, and not always:

```ruby
/(?:(?:b*)+)+?/ =~ ""                 # CRuby: 0,     mruby: nil
/(?:(?:b*)+)+?/ =~ "b"                # CRuby: 0,     mruby: nil
/(?:(?:b?)+)+?/ =~ ""                 # CRuby: 0,     mruby: nil
/ca(?:b??b??)+a*?/.match("cab")[0]    # CRuby: "ca",  mruby: "cab"
/(?:a?)*b??/.match("aab")[0]          # CRuby: "aa",  mruby: "aab"
/(?>(?:a*)*)b?/.match("aab")[0]       # CRuby: "aab", mruby: "aa"
/(a*?)*b/.match("aab").begin(1)       # CRuby: 2,     mruby: 0
/(?:(?!a))*b?/.match("b")[0]          # CRuby: "b",   mruby: ""
/a(?:(?<=a))*b?/.match("ab")[0]       # CRuby: "ab",  mruby: "a"
```

In the first three the limit is reached inside the inner `+`, and the outer
`+?` then loops in the frame at the limit until the step budget is gone. In
the fourth the empty iterations run to the limit, and the lazy `b??` in the
frames being unwound is then allowed its `b`. In the last two the frame at
the limit cannot open the branch of the `?` that follows and answers with the
branch that skips it. The cost was there even when the answer was right: each
such loop climbed 1000 frames per start position, and a nested one spent the
whole step budget per start position, 7 ms for `/(?:(?:b*)+)+?/ =~ ""` and
80 ms against `"abcdefghij"`.

## The stop

The backtracker gets Onigmo's null check. `mark_empty_loops()` already finds
every back edge whose loop body can match empty and marks it for the Pike VM;
it now marks the head of a jump-closed loop as well, since that is where an
iteration of `e*` begins. `bt_state` gains a record per pc: the offset the
running iteration of the loop that pc keys began at. The frame that runs an
edge into an iteration writes the record and undoes it when the iteration's
frame returns (`bt_iter()`), so the record follows the backtracking, and the
branch that begins an iteration is run by recursion rather than in place so
that there is one place to undo it. The edge closing the body compares: an
iteration that ends where it began matched empty, and the loop takes its exit
instead of going round again, keeping what the iteration captured, as the
Pike VM does. `e*` is keyed by its head (the head writes, the closing jump
reads) and `e+` by its closing fork (which writes and reads). Only loops
whose body can match empty pay the record and, for a lazy one, the extra
frame; every other fork runs as before.

The recursion limit no longer stops any loop, and its comment says what it
bounds now. The rule from #7256 that a limit is not a cut and not a
lookaround's answer stays: a frame giving up at the limit may still be inside
an atomic group's body or a negative lookaround.

`bt_match()` took ten arguments, seven of which are the same in every frame
of one search. The first commit moves the shared seven into `bt_state`, which
`backtrack_exec()` fills once and each frame reads through a pointer, so that
a frame carries only what is its own: the position, the pc and the depth. The
iteration records then have a place to live.

## Lookarounds and backreferences

`epsilon_path()` answered FALSE at a lookaround and at a backreference, so a
repetition whose body was one of them was not marked, and the stop did not
apply: `(?=)+`, `(?:(?!a))*` and `(a?)\1*` still ran to the recursion limit.
A lookaround is zero-width whatever its sub-pattern does, so the walk steps
over the sub-pattern to the end the instruction records; a backreference to a
group that captured empty consumes nothing, so it can lie on a path that need
not consume. Neither reaches the Pike VM, which runs neither construct, so
this part is the backtracker's alone.

## Time

The `default` gembox plus `mruby-benchmark`, `-O3`, `Benchmark.realtime` over
`n` matches after three warm-up calls, mean of two runs each, master and this
PR alternated:

```ruby
CASES = [
  ["/(?:(?:b*)+)+?/ =~ ''",            2000,  -> { /(?:(?:b*)+)+?/ =~ "" }],
  ["/(?:(?:b*)+)+?/ =~ 'abcdefghij'",  200,   -> { /(?:(?:b*)+)+?/ =~ "abcdefghij" }],
  ["/(?:a*)*b+?/ =~ 'b'",              20000, -> { /(?:a*)*b+?/ =~ "b" }],
  # ...
]
CASES.each do |label, n, blk|
  3.times { blk.call }
  t = Benchmark.realtime { n.times { blk.call } }
  puts "%-38s %10.3f us/iter" % [label, t / n * 1e6]
end
```

| match | master | this PR | |
|---|---:|---:|---:|
| `/(?:(?:b*)+)+?/ =~ ""` | 7,418 us | 1.47 us | 5,000x |
| `/(?:(?:b*)+)+?/ =~ "abcdefghij"` | 78,570 us | 1.36 us | 57,800x |
| `/(?:a*)*b+?/ =~ "b"` | 11.14 us | 1.45 us | 7.7x |
| `/(?:x?)*y??/ =~ "x" * 10` | 11.11 us | 1.51 us | 7.4x |
| `/(a?)\1*b/ =~ "b"` | 10.89 us | 1.41 us | 7.7x |
| `/(?:(?!x))*b/ =~ "b"` | 11.31 us | 1.33 us | 8.5x |
| `/(?=)+b/ =~ "b"` | 10.37 us | 1.30 us | 8.0x |
| `/(?:a*)*b/ =~ "b"` (Pike VM) | 1.45 us | 1.43 us | 1.0x |
| `/(?:x?)+?y/ =~ "x" * 10 + "y"` | 1.49 us | 1.48 us | 1.0x |
| `/(a*)\1*b/ =~ "aab"` | 1.43 us | 1.43 us | 1.0x |
| `/(a\|b)*?c/ =~ "ab" * 50 + "c"` | 3.85 us | 3.93 us | 0.98x |
| `/(?:a\|b)*?c/ =~ "ab" * 50 + "c"` | 2.77 us | 2.80 us | 0.99x |
| `/a.*?b/ =~ "a" + "x" * 100 + "b"` | 2.22 us | 2.23 us | 1.0x |
| `/(?<=a)b+?/ =~ "ab" * 50` | 1.37 us | 1.38 us | 0.99x |

The first seven rows are repetitions that used to run to the limit; the
first two are the nested case that used to spend the step budget. The rows
after them are loops that consume on every iteration, or the Pike VM, and
stay where they were; 1.4 us is what such a match costs on the Pike VM too.

## Size

`.text` of `bin/mruby`, `build_config/ci/gcc-clang.rb`, each side from a clean
build directory. `re_compile.o` and `re_exec.o` are the objects that change;
in `bintest` they account for -1,280 and -1,744 of the delta; -1,328 of the
second is the first commit alone, the ten-argument recursive calls becoming
four-argument ones.

| build | master | this PR | delta |
|---|---:|---:|---:|
| `bintest` | 1,282,582 | 1,279,558 | -3,024 |
| `ascii-case` | 1,270,294 | 1,267,270 | -3,024 |
| `byte-string` | 1,250,374 | 1,248,038 | -2,336 |
| `cxx_abi` | 1,307,353 | 1,304,665 | -2,688 |
| `full-debug` (`-O0`) | 1,878,566 | 1,879,382 | +816 |

## Verification

The tests go in `regexp_syntax.rb` beside the Pike VM's empty-iteration
tests. They cover the nested loops that used to answer nil, the lazy body
that stays empty when the loop stops, each layout of a repetition stopping on
its own (`e*`, `e+`, `e*?`, `e+?`, `e{n,}`, `e{n,}?`, and nested), the empty
iteration's capture being kept as under the Pike VM, a repetition of each of
the four lookarounds and of a backreference, the record being undone when an
iteration is backtracked out of, and the stop inside and around an atomic
group.

**Differential against CRuby 4.0.6.** 10,000 random patterns over `a`, `b`,
`a?`, `b?`, `[ab]?`, `\w?`, `(?:)`, `(a|)`, `(|b)`, `(?:a|)`, the four
lookarounds, the two lookaheads also with a capture inside, backreferences,
plain, non-capturing and atomic groups and alternation, groups nested up to
two deep, every atom quantified with probability 0.7 by one of `*`, `+`, `*?`, `+?`,
`?`, `??`, `{0,}`, `{1,}`, `{2,}`, `{0,}?`, `{1,}?`, half of them with a lazy
`x??` appended to keep the pattern on the backtracking engine, each run with
`match` against one of 18 subjects over `a` and `b` and compared as
`MatchData#to_a`. 5,404 of the patterns mruby refuses to compile (a quantifier
on a quantifier, which CRuby accepts with a warning) and 85 CRuby cannot
finish under a memory or time cap; the rest compare:

| | lines |
|---|---:|
| compared | 4,568 |
| same on master and here | 3,973 |
| master differs from CRuby, this PR agrees | 474 |
| both differ from CRuby | 111 |
| master agrees with CRuby, this PR differs | 10 |

Of the 111 lines where both differ, 108 have a capture group inside a
lookaround, and so do all 10 where only this PR differs. That is one thing
this engine already answers differently from Onigmo: a lookaround's body runs
as a sub-pattern call, so a capture written inside it stays written when the
text after the lookaround fails and the engine backtracks past it, where
Onigmo undoes it. On master those patterns ran to the recursion limit and
failed outright; here the loop stops, the match goes on, and the leaked
capture is what gets read. The remaining 3 lines differ on master as well.

**`rake test`**, `build_config/ci/gcc-clang.rb`, no compiler warning:

| build | total | KO | crash |
|---|---:|---:|---:|
| `full-debug` | 2,352 | 0 | 0 |
| `bintest` | 2,352 | 0 | 0 |
| `bintest` (bintest suite) | 123 | 0 | 0 |
| `cxx_abi` | 2,352 | 0 | 0 |
| `byte-string` | 2,282 | 0 | 0 |
| `ascii-case` | 2,349 | 0 | 0 |

The default configuration: 2,128 total, 0 KO, 0 crash, plus its 112 bintests.

### Environment

<details>

| | |
|---|---|
| OS | Ubuntu 24.04, Linux 7.0.0 x86_64 |
| gcc | 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1) |
| binutils | 2.47 |
| CRuby | 4.0.6, for the differential |

Compile lines for `mrbgems/mruby-regexp/src/re_exec.c` in the builds quoted
above, paths shortened:

```
# ci/gcc-clang bintest
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK -I"include" -I"mrbgems/mruby-regexp/include" -I"build/bintest/include" -o "build/bintest/mrbgems/mruby-regexp/src/re_exec.o" "mrbgems/mruby-regexp/src/re_exec.c"

# ci/gcc-clang full-debug
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -I"include" -I"mrbgems/mruby-regexp/include" -I"build/full-debug/include" -o "build/full-debug/mrbgems/mruby-regexp/src/re_exec.o" "mrbgems/mruby-regexp/src/re_exec.c"

# ci/gcc-clang cxx_abi
gcc -MMD -c -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -I"include" -I"mrbgems/mruby-regexp/include" -I"build/cxx_abi/include" -o "build/cxx_abi/mrbgems/mruby-regexp/src/re_exec.o" "mrbgems/mruby-regexp/src/re_exec.c"

# ci/gcc-clang byte-string
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -I"include" -I"mrbgems/mruby-regexp/include" -I"build/byte-string/include" -o "build/byte-string/mrbgems/mruby-regexp/src/re_exec.o" "mrbgems/mruby-regexp/src/re_exec.c"

# ci/gcc-clang ascii-case
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CASE -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -I"include" -I"mrbgems/mruby-regexp/include" -I"build/ascii-case/include" -o "build/ascii-case/mrbgems/mruby-regexp/src/re_exec.o" "mrbgems/mruby-regexp/src/re_exec.c"
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved regular expression handling for repetitions that consume no input.
  * Prevented potential hangs or excessive backtracking with empty patterns, lookarounds, backreferences, nested repetitions, and atomic groups.
  * Improved matching consistency for greedy and lazy quantifiers.

* **Tests**
  * Added regression coverage for empty-iteration behavior and capture preservation across complex regular expression patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->