### PR TITLE
string.c: name the ASCII option for what it narrows

### DIFF
--- a/build_config/ci/gcc-clang.rb
+++ b/build_config/ci/gcc-clang.rb
@@ -59,7 +59,7 @@ MRuby::Build.new('byte-string') do |conf|
   conf.enable_test
 end
 
-MRuby::Build.new('ascii-case') do |conf|
+MRuby::Build.new('ascii-ctype') do |conf|
   conf.toolchain
 
   # The one build here that indexes by character and converts case by ASCII.
@@ -70,7 +70,7 @@ MRuby::Build.new('ascii-case') do |conf|
   # mruby-regexp/test/ascii_case.rb skips its assertions there.
   # Tests only, for the reason byte-string gives above.
   conf.gembox 'full-core'
-  conf.cc.defines << 'MRB_USE_ASCII_CASE'
+  conf.cc.defines << 'MRB_USE_ASCII_CTYPE'
 
   conf.enable_test
 end

--- a/doc/guides/language.md
+++ b/doc/guides/language.md
@@ -416,16 +416,16 @@ differently on 32-bit or NaN boxing configurations.
 
 Key compile-time macros that affect language behavior:
 
-| Macro                | Effect                             |
-| -------------------- | ---------------------------------- |
-| `MRB_NO_FLOAT`       | Remove all float support           |
-| `MRB_USE_FLOAT32`    | Use 32-bit float instead of double |
-| `MRB_UTF8_STRING`    | UTF-8 strings and Unicode case     |
-| `MRB_USE_ASCII_CASE` | Keep UTF-8, convert case by ASCII  |
-| `MRB_INT32`          | Force 32-bit integer               |
-| `MRB_INT64`          | Force 64-bit integer               |
-| `MRB_STR_LENGTH_MAX` | Max string length (default 1MB)    |
-| `MRB_ARY_LENGTH_MAX` | Max array length (default 2^17)    |
+| Macro                 | Effect                             |
+| --------------------- | ---------------------------------- |
+| `MRB_NO_FLOAT`        | Remove all float support           |
+| `MRB_USE_FLOAT32`     | Use 32-bit float instead of double |
+| `MRB_UTF8_STRING`     | UTF-8 strings and Unicode case     |
+| `MRB_USE_ASCII_CTYPE` | Keep UTF-8, convert case by ASCII  |
+| `MRB_INT32`           | Force 32-bit integer               |
+| `MRB_INT64`           | Force 64-bit integer               |
+| `MRB_STR_LENGTH_MAX`  | Max string length (default 1MB)    |
+| `MRB_ARY_LENGTH_MAX`  | Max array length (default 2^17)    |
 
 See [mrbconf.md](mrbconf.md) for the complete list of configuration
 macros.

--- a/doc/guides/mrbconf.md
+++ b/doc/guides/mrbconf.md
@@ -226,18 +226,19 @@ end
   pairs with one other. Without this macro it folds ASCII letters, and a
   pattern holding a character that needs one of the Unicode foldings raises
   `RegexpError` rather than answering as if the character had no case.
-- `MRB_USE_ASCII_CASE` narrows the case half back to ASCII, taking the refusal
+- `MRB_USE_ASCII_CTYPE` narrows the case half back to ASCII, taking the refusal
   with it and leaving the indexing.
 - If it isn't defined, they only support the US-ASCII encoding.
 
-`MRB_USE_ASCII_CASE`
+`MRB_USE_ASCII_CTYPE`
 
-- Narrows case conversion back to ASCII, so `String#downcase`, `#upcase`,
-  `#capitalize`, `#swapcase` and `#casecmp?` answer for `'A'` to `'Z'` and hand
-  every other character back as it stands.
-- Drops the Unicode case table the build would otherwise carry. That is what
-  the option is for: a target counting its bytes buys the UTF-8 indexing of
-  `MRB_UTF8_STRING` without the table beside it.
+- Narrows the character classification of `MRB_UTF8_STRING` back to ASCII
+  while keeping its indexing. What is classified today is case, so
+  `String#downcase`, `#upcase`, `#capitalize`, `#swapcase` and `#casecmp?`
+  answer for `'A'` to `'Z'` and hand every other character back as it stands.
+- Drops the Unicode tables the build would otherwise carry. That is what the
+  option is for: a target counting its bytes buys the UTF-8 indexing of
+  `MRB_UTF8_STRING` without the tables beside it.
 - Bytes that spell no character are handed back as they stand rather than
   refused with `ArgumentError`. That refusal belongs to the walk over
   characters, which is the walk this narrows away: what converts instead reads

--- a/doc/limitations.md
+++ b/doc/limitations.md
@@ -280,7 +280,7 @@ Module refinements (`refine`, `using`) are not supported in mruby.
 mruby does not have an `Encoding` class. Strings are treated as
 byte sequences by default. UTF-8 aware string operations can be
 enabled with the `MRB_UTF8_STRING` compile flag, which is also what
-makes case conversion follow Unicode rather than ASCII; `MRB_USE_ASCII_CASE`
+makes case conversion follow Unicode rather than ASCII; `MRB_USE_ASCII_CTYPE`
 narrows that half back without giving up the indexing. A Unicode conversion
 refuses bytes that spell no character with `ArgumentError`; one narrowed to
 ASCII reads no characters and hands those bytes back untouched.

--- a/include/mruby/internal.h
+++ b/include/mruby/internal.h
@@ -400,13 +400,13 @@ enum mrb_case_mode {
    which is what every build without the tables answers to every string.
    `swapcase` lives in mruby-string-ext and reaches the tables through this, so
    they are asked about in one place. */
-#if defined(MRB_UTF8_STRING) && !defined(MRB_USE_ASCII_CASE)
+#if defined(MRB_UTF8_STRING) && !defined(MRB_USE_ASCII_CTYPE)
 int mrb_str_case_convert_unicode(mrb_state *mrb, mrb_value str, enum mrb_case_mode mode);
 #else
 #define mrb_str_case_convert_unicode(mrb, str, mode) (-1)
 #endif
 
-#if defined(MRB_UTF8_STRING) && !defined(MRB_USE_ASCII_CASE)
+#if defined(MRB_UTF8_STRING) && !defined(MRB_USE_ASCII_CTYPE)
 /* What case a character has, from the tables in unicase.c. A string is
    converted through mrb_str_case_convert_unicode() above; these are for a
    caller holding a codepoint rather than a string, which is mruby-regexp
@@ -464,7 +464,7 @@ void mrb_uni_case_fold_range(uint32_t lo, uint32_t hi,
 void mrb_uni_case_unfold_range(uint32_t lo, uint32_t hi,
                                void (*add)(void *, uint32_t, uint32_t), void *user);
 #endif  /* HAVE_MRUBY_REGEXP_GEM */
-#endif  /* MRB_UTF8_STRING && !MRB_USE_ASCII_CASE */
+#endif  /* MRB_UTF8_STRING && !MRB_USE_ASCII_CTYPE */
 
 /* attr accessor bodies (class.c); the VM compares function pointers against
    these to run attr calls without a full method-call frame */

--- a/mrbgems/mruby-regexp/README.md
+++ b/mrbgems/mruby-regexp/README.md
@@ -242,7 +242,7 @@ there.
 
 Case folding beyond ASCII is not this gem's to configure. The table is
 core's, carried by any build that defines `MRB_UTF8_STRING` without
-`MRB_USE_ASCII_CASE`, and is what `String#downcase` and the four case methods
+`MRB_USE_ASCII_CTYPE`, and is what `String#downcase` and the four case methods
 beside it read; `/i` reads the two directions it needs over that same table.
 So `/i` folds what the build's own case conversion folds, and a build
 converting case by ASCII has nothing for it to fold beyond ASCII either,

--- a/mrbgems/mruby-regexp/include/re_internal.h
+++ b/mrbgems/mruby-regexp/include/re_internal.h
@@ -203,7 +203,7 @@ mrb_bool mrb_re_is_word_char(uint32_t c);
    therefore folds the way that build's own case conversion does and no other
    way, a pattern read as bytes having no character to fold in the first
    place. */
-#if defined(MRB_UTF8_STRING) && !defined(MRB_USE_ASCII_CASE)
+#if defined(MRB_UTF8_STRING) && !defined(MRB_USE_ASCII_CTYPE)
 # define RE_UNICODE_CASE
 #endif
 

--- a/mrbgems/mruby-regexp/mrbgem.rake
+++ b/mrbgems/mruby-regexp/mrbgem.rake
@@ -54,7 +54,7 @@ MRuby::Gem::Specification.new('mruby-regexp') do |spec|
   # characters carries, and only where it converts their case by Unicode.
   spec.build_settings do
     if build.has_define?('MRB_UTF8_STRING') &&
-       !build.has_define?('MRB_USE_ASCII_CASE')
+       !build.has_define?('MRB_USE_ASCII_CTYPE')
       spec.test_rbfiles -= ["#{spec.dir}/test/ascii_case.rb"]
     else
       spec.test_rbfiles -= ["#{spec.dir}/test/unicode_case.rb"]

--- a/mrbgems/mruby-regexp/test/ascii_case.rb
+++ b/mrbgems/mruby-regexp/test/ascii_case.rb
@@ -1,5 +1,5 @@
 # Only compiled into mrbtest when the build converts case by ASCII, whether by
-# MRB_USE_ASCII_CASE or by reading its strings as bytes; see the gem's
+# MRB_USE_ASCII_CTYPE or by reading its strings as bytes; see the gem's
 # mrbgem.rake. Where it converts by Unicode, every pattern refused here
 # compiles and matches instead.
 assert("Regexp - /i refuses what ASCII folding cannot answer") do

--- a/mrbgems/mruby-string-ext/README.md
+++ b/mrbgems/mruby-string-ext/README.md
@@ -809,14 +809,22 @@ Example:
 "aBcDeF".casecmp?("abcdeg")    #=> false
 ```
 
-On a build defining `MRB_UTF8_STRING`, folding follows Unicode, and one folding may spell a character as several. `MRB_USE_ASCII_CTYPE` narrows it back to ASCII:
+On a build defining `MRB_UTF8_STRING`, folding follows Unicode, and one folding may spell a character as several:
 
 ```ruby
 "ä".casecmp?("Ä")     #=> true
 "ß".casecmp?("ss")    #=> true
 ```
 
-A string holding bytes that spell no character is refused with `ArgumentError`, since bytes that spell nothing have no folding. One read as bytes folds ASCII alone, having no characters to fold.
+There, a string holding bytes that spell no character is refused with `ArgumentError`, since bytes that spell nothing have no folding. One read as bytes folds ASCII alone, having no characters to fold.
+
+`MRB_USE_ASCII_CTYPE` narrows the folding of such a build back to ASCII, and the refusal goes with it, since what folds no longer reads characters:
+
+```ruby
+"ä".casecmp?("Ä")         #=> false
+"ß".casecmp?("ss")        #=> false
+"\xff".casecmp?("\xff")   #=> true
+```
 
 ### `String#+@` (Unary Plus)
 

--- a/mrbgems/mruby-string-ext/README.md
+++ b/mrbgems/mruby-string-ext/README.md
@@ -809,7 +809,7 @@ Example:
 "aBcDeF".casecmp?("abcdeg")    #=> false
 ```
 
-On a build defining `MRB_UTF8_STRING`, folding follows Unicode, and one folding may spell a character as several. `MRB_USE_ASCII_CASE` narrows it back to ASCII:
+On a build defining `MRB_UTF8_STRING`, folding follows Unicode, and one folding may spell a character as several. `MRB_USE_ASCII_CTYPE` narrows it back to ASCII:
 
 ```ruby
 "ä".casecmp?("Ä")     #=> true

--- a/src/string.c
+++ b/src/string.c
@@ -2192,7 +2192,7 @@ mrb_str_aset_m(mrb_state *mrb, mrb_value str)
   return replace;
 }
 
-#if defined(MRB_UTF8_STRING) && !defined(MRB_USE_ASCII_CASE)
+#if defined(MRB_UTF8_STRING) && !defined(MRB_USE_ASCII_CTYPE)
 
 /* What the walk below makes of an ASCII character. Each method keeps its own
    loop over a string that holds nothing but ASCII, so this is reached only for
@@ -2363,7 +2363,7 @@ mrb_str_case_convert_unicode(mrb_state *mrb, mrb_value str, enum mrb_case_mode m
   return str_case_convert_utf8(mrb, str, mode) ? 1 : 0;
 }
 
-#endif  /* MRB_UTF8_STRING && !MRB_USE_ASCII_CASE */
+#endif  /* MRB_UTF8_STRING && !MRB_USE_ASCII_CTYPE */
 
 /* 15.2.10.5.8  */
 /*

--- a/src/unicase.c
+++ b/src/unicase.c
@@ -11,7 +11,7 @@
 #include <string.h>
 #include <mruby.h>
 
-#if defined(MRB_UTF8_STRING) && !defined(MRB_USE_ASCII_CASE)
+#if defined(MRB_UTF8_STRING) && !defined(MRB_USE_ASCII_CTYPE)
 
 #include <mruby/internal.h>
 #include "unicase.h"
@@ -387,4 +387,4 @@ mrb_uni_case_unfold_range(uint32_t lo, uint32_t hi,
 
 #endif  /* HAVE_MRUBY_REGEXP_GEM */
 
-#endif  /* MRB_UTF8_STRING && !MRB_USE_ASCII_CASE */
+#endif  /* MRB_UTF8_STRING && !MRB_USE_ASCII_CTYPE */

--- a/test/t/string.rb
+++ b/test/t/string.rb
@@ -498,7 +498,7 @@ end if UNICODECASE
 
 assert('String case conversion - ASCII only') do
   # The other reading of case: a build that converts by ASCII, whether by
-  # MRB_USE_ASCII_CASE or by reading its strings as bytes, has no mapping above
+  # MRB_USE_ASCII_CTYPE or by reading its strings as bytes, has no mapping above
   # ASCII, so a character that has one on the Unicode side stands as it was
   # while the ASCII beside it still converts.
   assert_equal 'Ä', 'Ä'.downcase


### PR DESCRIPTION
`MRB_USE_ASCII_CASE` narrows case conversion back to ASCII on a build that keeps the character indexing of `MRB_UTF8_STRING`. Case is the one thing such a build knows of a character beyond its bytes today, so the name fit. It stops fitting with the next table: what a character *is*, the classification a regexp POSIX bracket like `[[:alpha:]]` asks for, drawn from `DerivedCoreProperties.txt` of the same Unicode database the case tables come from, sits under the same guard, since a target that dropped the case tables to count its bytes drops that one the same way. A define named for case would be the wrong name for a table that classifies.

This PR renames it `MRB_USE_ASCII_CTYPE`, and the CI build that defines it `ascii-ctype`. Nothing else moves: the same builds convert the same case and `/i` refuses the same patterns.

## What changes

- The guard `#if defined(MRB_UTF8_STRING) && !defined(MRB_USE_ASCII_CASE)` in `src/string.c`, `src/unicase.c`, `include/mruby/internal.h` and `mrbgems/mruby-regexp/include/re_internal.h` reads `MRB_USE_ASCII_CTYPE`, as does the test file selection in `mrbgems/mruby-regexp/mrbgem.rake`.
- `build_config/ci/gcc-clang.rb`: the build `ascii-case` becomes `ascii-ctype` and defines the new name.
- `doc/guides/mrbconf.md` describes the option as narrowing the character classification of `MRB_UTF8_STRING` back to ASCII while keeping its indexing, with case as what is classified so far; `doc/guides/language.md`, `doc/limitations.md` and the two gem READMEs (`mruby-regexp`, `mruby-string-ext`) name the new spelling. Comments in the tests that name the option follow.
- `mrbgems/mruby-regexp/test/ascii_case.rb` and `ascii_case_conv()` in `src/string.c` keep their names, being about case and nothing wider.

No compatibility shim for the old name: the option landed in #7190 on 2026-08-15 and has had no release.

## Size

`bin/mruby`, `full-core`, gcc 13.3.0 `-g -O3` (the toolchain default), `size -A`, master and this branch built at the same path:

| Build | `.text` master | `.text` this PR | `.rodata` master | `.rodata` this PR |
| --- | --- | --- | --- | --- |
| UTF-8, Unicode case | 1,280,102 | 1,280,102 | 235,560 | 235,560 |
| UTF-8, `MRB_USE_ASCII_CASE` / `MRB_USE_ASCII_CTYPE` | 1,270,550 | 1,270,550 | 231,296 | 231,296 |

A build reading its strings as bytes compiles nothing the option guards, and is not built again here.

## Testing

Full suite green (single commit).

| Build | Total | KO | Crash |
| --- | --- | --- | --- |
| `ci/gcc-clang` full-debug | 2358 | 0 | 0 |
| `ci/gcc-clang` bintest | 2358 (+ bintest 123) | 0 | 0 |
| `ci/gcc-clang` cxx_abi | 2358 | 0 | 0 |
| `ci/gcc-clang` byte-string | 2287 | 0 | 0 |
| `ci/gcc-clang` ascii-ctype | 2354 | 0 | 0 |
| default (`rake -m test`) | 2133 (+ bintest 112) | 0 | 0 |

The `ascii-ctype` build skips `String#swapcase - Unicode` and `String#casecmp? - Unicode` and runs the ASCII rows, as `ascii-case` did, and its `.flags` record shows `-DMRB_USE_ASCII_CTYPE` on every compile line. `grep -r MRB_USE_ASCII_CASE` over the tree finds nothing outside `build/`.

### Environment

<details>
<summary>Machine, toolchain, and the compile line of every build</summary>

| Item | Value |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS |
| Kernel | 7.0.0-29-generic |
| CPU | AMD Ryzen 9 5950X 16-Core Processor |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0 |
| binutils | GNU ld (GNU Binutils) 2.47.20260726 |
| rake | rake, version 13.3.1 |

Actual compile line of `src/string.c` in each `build_config/ci/gcc-clang.rb` build (`-MMD -c`, `-I`, and `-o` dropped). `full-debug` is `-O0` because `enable_debug` appends `-g3 -O0` after the toolchain's `-g -O3`; `cxx_abi` compiles C as C++ with `gcc -x c++ -std=gnu++03`, g++ only links.

```console
# full-debug
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
# bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK src/string.c
# cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
# byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
# ascii-ctype
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated configuration guidance and limitations to use the renamed ASCII character classification setting.
  * Clarified its interaction with UTF-8 indexing, Unicode case conversion, and regular expression behavior.

* **Build & Compatibility**
  * Updated build configurations and feature detection to consistently recognize the new setting name.
  * Preserved existing ASCII-only and Unicode behavior across string and regular expression features.

* **Tests**
  * Updated related test conditions to reflect the renamed configuration setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->