### PR TITLE
mruby-regexp: stop looking up `MatchData`, `$~` and the `Regexp` ivars by string on every match

### DIFF
--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -159,6 +159,10 @@ regexp_init(mrb_state *mrb, mrb_value self)
   return self;
 }
 
+/* Pre-interned symbol for $~ (cached on first use). MRB_GVSYM() takes a
+   word after the `$`, which `~` is not, so this one is looked up once here. */
+static mrb_sym match_sym;
+
 /* Pre-interned symbols for $1-$9 (cached on first use) */
 static mrb_sym nth_syms[9];
 
@@ -170,6 +174,7 @@ static void
 ensure_match_syms(mrb_state *mrb)
 {
   if (nth_syms[0]) return;
+  match_sym = mrb_intern_lit(mrb, "$~");
   nth_syms[0] = mrb_intern_lit(mrb, "$1");
   nth_syms[1] = mrb_intern_lit(mrb, "$2");
   nth_syms[2] = mrb_intern_lit(mrb, "$3");
@@ -189,7 +194,7 @@ static void
 clear_match_globals(mrb_state *mrb)
 {
   ensure_match_syms(mrb);
-  mrb_gv_set(mrb, mrb_intern_lit(mrb, "$~"), mrb_nil_value());
+  mrb_gv_set(mrb, match_sym, mrb_nil_value());
   for (int i = 0; i < 9; i++) {
     mrb_gv_set(mrb, nth_syms[i], mrb_nil_value());
   }
@@ -351,7 +356,7 @@ set_match_globals(mrb_state *mrb, mrb_value obj, mrb_value str, int *captures, i
 {
   ensure_match_syms(mrb);
 
-  mrb_gv_set(mrb, mrb_intern_lit(mrb, "$~"), obj);
+  mrb_gv_set(mrb, match_sym, obj);
 
   /* set $1-$9 from captures */
   for (int i = 0; i < 9; i++) {
@@ -392,7 +397,7 @@ create_matchdata(mrb_state *mrb, mrb_value regexp, mrb_value str, int *captures,
      time, so later in-place changes to it must not be visible here. */
   str = mrb_str_dup_frozen(mrb, str);
 
-  struct RClass *md_class = mrb_class_get(mrb, "MatchData");
+  struct RClass *md_class = mrb_class_get_id(mrb, MRB_SYM(MatchData));
   mrb_match_data *md = (mrb_match_data*)mrb_malloc(mrb, sizeof(mrb_match_data));
   md->source = str;
   md->regexp = regexp;
@@ -404,8 +409,8 @@ create_matchdata(mrb_state *mrb, mrb_value regexp, mrb_value str, int *captures,
   /* Keep `source` and `regexp` GC-reachable via instance variables.
    * The mrb_values are also held in mrb_match_data, but C-allocated
    * structs are not scanned by the GC. */
-  mrb_iv_set(mrb, obj, mrb_intern_lit(mrb, "source"), str);
-  mrb_iv_set(mrb, obj, mrb_intern_lit(mrb, "regexp"), regexp);
+  mrb_iv_set(mrb, obj, MRB_SYM(source), str);
+  mrb_iv_set(mrb, obj, MRB_SYM(regexp), regexp);
 
   set_match_globals(mrb, obj, str, captures, md->num_captures);
 

--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -58,7 +58,7 @@ static const struct mrb_data_type matchdata_type = { "MatchData", matchdata_free
 static uint32_t
 get_iflags(mrb_state *mrb, mrb_value self)
 {
-  mrb_value v = mrb_iv_get(mrb, self, mrb_intern_lit(mrb, "@flags"));
+  mrb_value v = mrb_iv_get(mrb, self, MRB_IVSYM(flags));
   return mrb_nil_p(v) ? 0 : (uint32_t)mrb_integer(v);
 }
 
@@ -107,10 +107,10 @@ regexp_init(mrb_state *mrb, mrb_value self)
   uint32_t flags;
 
   /* If pattern is a Regexp, copy its source and flags */
-  if (mrb_obj_is_kind_of(mrb, pattern, mrb_class_get(mrb, "Regexp"))) {
-    mrb_value iflags = mrb_iv_get(mrb, pattern, mrb_intern_lit(mrb, "@flags"));
+  if (mrb_obj_is_kind_of(mrb, pattern, mrb_class_get_id(mrb, MRB_SYM(Regexp)))) {
+    mrb_value iflags = mrb_iv_get(mrb, pattern, MRB_IVSYM(flags));
     flags = mrb_nil_p(iflags) ? 0 : (uint32_t)mrb_integer(iflags);
-    pattern = mrb_iv_get(mrb, pattern, mrb_intern_lit(mrb, "@source"));
+    pattern = mrb_iv_get(mrb, pattern, MRB_IVSYM(source));
   }
   else {
     if (!mrb_string_p(pattern)) {
@@ -131,8 +131,8 @@ regexp_init(mrb_state *mrb, mrb_value self)
   /* Set @source and @flags before mrb_re_compile() so a Regexp that survives
      a compile-time exception (e.g. picked up by ObjectSpace.each_object)
      still has usable IVs for hash/eql?/inspect. */
-  mrb_iv_set(mrb, self, mrb_intern_lit(mrb, "@source"), pattern);
-  mrb_iv_set(mrb, self, mrb_intern_lit(mrb, "@flags"), mrb_int_value(mrb, (mrb_int)flags));
+  mrb_iv_set(mrb, self, MRB_IVSYM(source), pattern);
+  mrb_iv_set(mrb, self, MRB_IVSYM(flags), mrb_int_value(mrb, (mrb_int)flags));
 
   /* Hand the pattern over before the compile starts. mrb_re_compile() raises
      to report a bad pattern and mrb_realloc() raises to report an allocation
@@ -153,7 +153,7 @@ regexp_init(mrb_state *mrb, mrb_value self)
       mrb_value name = mrb_str_new(mrb, pat->named_captures[i].name, pat->named_captures[i].name_len);
       mrb_hash_set(mrb, nc, name, mrb_fixnum_value(pat->named_captures[i].group));
     }
-    mrb_iv_set(mrb, self, mrb_intern_lit(mrb, "@named_captures"), nc);
+    mrb_iv_set(mrb, self, MRB_IVSYM(named_captures), nc);
   }
 
   return self;
@@ -726,7 +726,7 @@ regexp_case_match(mrb_state *mrb, mrb_value self)
 static mrb_value
 regexp_source(mrb_state *mrb, mrb_value self)
 {
-  return mrb_iv_get(mrb, self, mrb_intern_lit(mrb, "@source"));
+  return mrb_iv_get(mrb, self, MRB_IVSYM(source));
 }
 
 /*
@@ -782,7 +782,7 @@ static const struct {
 static mrb_value
 regexp_to_s(mrb_state *mrb, mrb_value self)
 {
-  mrb_value src = mrb_iv_get(mrb, self, mrb_intern_lit(mrb, "@source"));
+  mrb_value src = mrb_iv_get(mrb, self, MRB_IVSYM(source));
   uint32_t flags = get_iflags(mrb, self);
   char off[RE_FLAG_LETTER_COUNT];
   mrb_int noff = 0;
@@ -809,7 +809,7 @@ regexp_to_s(mrb_state *mrb, mrb_value self)
 static mrb_value
 regexp_inspect(mrb_state *mrb, mrb_value self)
 {
-  mrb_value src = mrb_iv_get(mrb, self, mrb_intern_lit(mrb, "@source"));
+  mrb_value src = mrb_iv_get(mrb, self, MRB_IVSYM(source));
   uint32_t flags = get_iflags(mrb, self);
 
   mrb_value result = mrb_str_new_lit(mrb, "/");
@@ -831,11 +831,11 @@ regexp_eql(mrb_state *mrb, mrb_value self)
 {
   mrb_value other;
   mrb_get_args(mrb, "o", &other);
-  if (!mrb_obj_is_kind_of(mrb, other, mrb_class_get(mrb, "Regexp"))) {
+  if (!mrb_obj_is_kind_of(mrb, other, mrb_class_get_id(mrb, MRB_SYM(Regexp)))) {
     return mrb_false_value();
   }
-  mrb_value src1 = mrb_iv_get(mrb, self, mrb_intern_lit(mrb, "@source"));
-  mrb_value src2 = mrb_iv_get(mrb, other, mrb_intern_lit(mrb, "@source"));
+  mrb_value src1 = mrb_iv_get(mrb, self, MRB_IVSYM(source));
+  mrb_value src2 = mrb_iv_get(mrb, other, MRB_IVSYM(source));
   if (!mrb_string_p(src1) || !mrb_string_p(src2)) {
     return mrb_bool_value(mrb_obj_eq(mrb, self, other));
   }
@@ -849,7 +849,7 @@ regexp_eql(mrb_state *mrb, mrb_value self)
 static mrb_value
 regexp_hash(mrb_state *mrb, mrb_value self)
 {
-  mrb_value src = mrb_iv_get(mrb, self, mrb_intern_lit(mrb, "@source"));
+  mrb_value src = mrb_iv_get(mrb, self, MRB_IVSYM(source));
   uint32_t h = mrb_string_p(src) ? mrb_str_hash(mrb, src) : 0;
   h ^= get_iflags(mrb, self) * 0x9e3779b9;  /* mix flags into hash */
   return mrb_int_value(mrb, (mrb_int)h);


### PR DESCRIPTION
Every successful search in mruby-regexp goes through `create_matchdata()`, and that function looked its names up by string on every call: `mrb_class_get(mrb, "MatchData")`, which interns the name and then reads the constant; `mrb_intern_lit()` of `source` and `regexp` for the two ivars that keep the snapshot and the pattern reachable; and `mrb_intern_lit()` of `$~` in `set_match_globals()` and `clear_match_globals()`. Each of those is a binary search over the presym table with a `memcmp` per probe. The thirteen names derived from the match were already cached in `nth_syms[]` and `last_match_syms[]` by `ensure_match_syms()`; `$~` was the one left out. Outside the match, `regexp_init()` read the `Regexp` class by `mrb_class_get(mrb, "Regexp")` and `@source` and `@flags` by `mrb_intern_lit()`, and since a regexp literal is compiled every time it is evaluated, that ran once per turn of a loop over `/o/` as well.

Under callgrind, `Regexp.__byte_search` with `/o/` on a 480 byte subject cost 8,254 Ir per search, 7,166 of them in `create_matchdata()`; `find_symbol()` alone was 17% of the whole program and `memcmp` under it another 6%. The match itself (`mrb_re_exec`) was below 1%.

## Fix

Two commits, both mechanical, neither changing behaviour.

The first takes the four lookups on the match path: `mrb_class_get_id(mrb, MRB_SYM(MatchData))`, `MRB_SYM(source)` and `MRB_SYM(regexp)` for the ivar names, and `$~` cached in `ensure_match_syms()` next to the other match symbols (`MRB_GVSYM()` takes a word after the `$`, which `~` is not, so it cannot name it directly). The ivar names stay the same symbols, so `source` and `regexp` remain hidden from `instance_variables` as before.

The second takes the rest of the file: `mrb_class_get_id(mrb, MRB_SYM(Regexp))`, which `regexp.c` already used in four other places, and `MRB_IVSYM(source)`, `MRB_IVSYM(flags)` and `MRB_IVSYM(named_captures)` in `regexp_init()`, the accessors, `to_s`, `inspect`, `eql?`, `hash` and `casefold?`. Again the same symbols, so the mrblib side that reads `@named_captures` sees what it did.

## Cost

Callgrind, default configuration (`-O3`), `1000.times { pos = 0; 72.times { md = Regexp.__byte_search(/o/, s480, pos); pos += 6 } }` with `s480 = "hello world foo bar " * 24`; per-search figures are inclusive Ir over 108,000 searches, the loop turn is `Ir(1500 iterations) - Ir(500 iterations)` over 72,000 turns so that start-up cancels.

| what | master | commit 1 | commit 2 |
| --- | --- | --- | --- |
| `Regexp.__byte_search`, per search | 8,254 | 6,344 (-23%) | 6,344 (-23%) |
| `create_matchdata()`, per search | 7,166 | 5,254 (-27%) | 5,254 (-27%) |
| `regexp_init()`, per literal evaluation | 5,556 | 5,556 | 4,048 (-27%) |
| one loop turn (search + literal + VM) | 19,051 | 17,141 (-10%) | 15,633 (-18%) |
| `find_symbol()`, share of the program | 17.0% | 8.3% | 0.01% |

Wall clock, the cases of the review on #7267, minimum of 5 alternating runs, `-O3`, default configuration:

```ruby
s480 = "hello world foo bar " * 24
30000.times { s480.gsub(/o/) { } }        # gsub480_blk
100000.times { "abc".gsub(/b/) { } }      # gsub_abc_blk
100000.times { "abc".scan(/b/) { } }      # scan_abc_blk
100000.times { "abc".sub!(/b/) { } }      # sub!_abc_blk
30000.times { s480.gsub(/o/, "0") }       # gsub480_str
100000.times { "abc".scan(/b/) }          # scan_abc
100000.times { "abc".sub!(/b/, "0") }     # sub!_abc_str
30000.times { s480.gsub(/z/) { } }        # gsub480_none
```

| case | master | commit 1 | commit 2 |
| --- | --- | --- | --- |
| gsub480_blk | 2846ms | 2411ms (-15%) | 2387ms (-16%) |
| gsub_abc_blk | 269ms | 243ms (-10%) | 234ms (-13%) |
| scan_abc_blk | 206ms | 188ms (-9%) | 174ms (-16%) |
| sub!_abc_blk | 269ms | 243ms (-10%) | 235ms (-13%) |
| gsub480_str | 127ms | 121ms (-5%) | 119ms (-6%) |
| scan_abc | 140ms | 127ms (-9%) | 116ms (-17%) |
| sub!_abc_str | 237ms | 212ms (-11%) | 202ms (-15%) |
| gsub480_none | 50ms | 50ms | 46ms (-8%) |

The block forms publish a MatchData per match, and that is where the first commit lands. The string and blockless forms run in C (`__gsub_str`, `__scan`, `__sub_str`) and publish one MatchData at the end of the call, so the first commit reaches them once per call; `sub!` searches once to decide its return value and once more in `sub`, so both of its rows publish twice. The literal is compiled on every turn in all eight cases, so the second commit reaches each of them, and on the three byte subject a call is mostly the literal, which is why `scan_abc` and `sub!_abc_str` move as much as the block forms. `gsub480_none` matches nothing, publishes nothing, and shows the literal alone.

`.text` of `bin/mruby` is 1196814 on master, 1198190 after the first commit and 1197774 at the tip (+960). None of it is the change: `regexp.o` shows `clear_match_globals()` (130 bytes on master) at 0 and each of its twelve call sites about 100 bytes larger, so gcc inlined it once it lost the `$~` intern; `create_matchdata()`, `regexp_init()` and the accessors are all smaller.

## Testing

No test is added: nothing observable changes. Full suite green at both commits; `MRUBY_CONFIG=ci/gcc-clang rake -m test` at the tip and the default configuration (`rake -m test`, no `MRUBY_CONFIG`, fresh build directory) at each commit.

| Build | Total | KO | Crash |
| --- | --- | --- | --- |
| full-debug | 2361 | 0 | 0 |
| bintest | 2361 (+123 bintest) | 0 | 0 |
| cxx_abi | 2361 | 0 | 0 |
| byte-string | 2290 | 0 | 0 |
| ascii-case | 2357 | 0 | 0 |
| default | 2136 | 0 | 0 |

### Environment

<details>
<summary>Machine, toolchain, and the compile line of every build</summary>

| Item | Value |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS |
| Kernel | 7.0.0-29-generic |
| CPU | AMD Ryzen 9 5950X 16-Core Processor |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0 |
| binutils | GNU ld (GNU Binutils) 2.47.20260726 |
| valgrind | valgrind-3.27.1 |
| CRuby (reference) | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |

Actual compile line of `mrbgems/mruby-regexp/src/regexp.c` in each build (`-MMD -c`, `-I`, and `-o` dropped). `full-debug` is `-O0` because `enable_debug` appends `-g3 -O0` after the toolchain's `-g -O3`; `cxx_abi` compiles C as C++ with `gcc -x c++ -std=gnu++03`, g++ only links.

```console
# full-debug
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-regexp/src/regexp.c
# bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK mrbgems/mruby-regexp/src/regexp.c
# cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-regexp/src/regexp.c
# byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-regexp/src/regexp.c
# ascii-case
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CASE -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-regexp/src/regexp.c
# default (no MRUBY_CONFIG), the build every figure above was measured on
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK mrbgems/mruby-regexp/src/regexp.c
```

</details>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved regular expression processing by reusing cached identifiers and class references.
  * Reduced overhead when handling match results and named captures.
* **Reliability**
  * Improved management of regular-expression match data during cleanup and garbage collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->