### PR TITLE
mruby-regexp: skip free-spacing whitespace in the parser and leave the pre-pass with comments and escape widths

### DIFF
--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -1989,6 +1989,33 @@ skip_posix_bracket(const char *src, const char *end)
  * A class spans several calls, with *in_class carrying the state between
  * them, so the caller keeps one flag and starts it FALSE.
  *
+ * An escape is stepped over at the width CRuby's pre-pass (re.c) reads it,
+ * because preprocess_pattern() copies what is stepped over and removes
+ * comments from what is not, and a comment removed from inside an escape
+ * leaves the parser a different escape: `\u12(?#c)34` would reach it as the
+ * valid `\u1234`, where CRuby has read `\u12(?` and rejected it before the
+ * comment is removed. So the escapes spelled with digits take their digits
+ * here:
+ *
+ * - `\u{...}` runs through its '}' (an unterminated list to the end): a `#`
+ *   inside it is a malformed list for the parser to reject, not a comment
+ *   for the pass to remove, and a "(?<" inside it declares nothing.
+ * - `\uXXXX` takes the next four bytes whatever they are, so that a byte
+ *   that is not a hex digit reaches the parser and is rejected there rather
+ *   than replaced by whatever a removed comment brings next.
+ * - `\x` takes up to two hex digits, and with none of them the one byte
+ *   after, which the parser rejects. `\0` takes up to two more octal digits.
+ *   Both stop short of their full width at the first byte that is not a
+ *   digit, and a digit a removed comment brings next would lengthen them:
+ *   `\x6(?#c)1` is `\x06` and `1` in CRuby, whose pre-pass has read `\x6`
+ *   whole and written it at full width before it reaches the comment. *pad
+ *   says how many '0' bytes bring the escape to full width, for the pass to
+ *   write after the letter; a full-width or non-numeric escape sets it to 0.
+ *
+ * `\1`-`\9` are the backslash and the digit, and the digits after them are
+ * plain bytes, as they are to CRuby's pre-pass: a removed comment does join
+ * them, and `\1(?#c)0` is `\10` there and here.
+ *
  * preprocess_pattern() and has_named_group() both walk the pattern hunting
  * for a "(?" opener, and both have to agree with the parser on when a '(' is
  * an opener rather than an escaped or bracketed byte. The rules for that live
@@ -1996,21 +2023,34 @@ skip_posix_bracket(const char *src, const char *end)
  * in the other.
  */
 static const char*
-skip_uninterpreted(const char *src, const char *end, mrb_bool *in_class)
+skip_uninterpreted(const char *src, const char *end, mrb_bool *in_class, int *pad)
 {
   char ch = *src;
 
+  *pad = 0;
   if (ch == '\\' && src + 1 < end) {
-    mrb_bool unicode = (src[1] == 'u');
+    char kind = src[1];
     src += 2;
-    /* A `\u{...}` list is a single escape rather than `\u` followed by a
-       brace group: a `#` inside it is a malformed list for the parser to
-       reject, not a comment for the pass to remove, and a "(?<" inside it
-       declares nothing. An unterminated list runs to the end. */
-    if (unicode && src < end && *src == '{') {
-      while (src < end) {
-        if (*src++ == '}') break;
+    if (kind == 'u') {
+      if (src < end && *src == '{') {
+        while (src < end) {
+          if (*src++ == '}') break;
+        }
       }
+      else {
+        src += (end - src < 4) ? end - src : 4;
+      }
+    }
+    else if (kind == 'x') {
+      int n = 0;
+      while (n < 2 && src < end && hex_value(*src) >= 0) { src++; n++; }
+      if (n == 0) { if (src < end) src++; }
+      else *pad = 2 - n;
+    }
+    else if (kind == '0') {
+      int n = 0;
+      while (n < 2 && src < end && *src >= '0' && *src <= '7') { src++; n++; }
+      *pad = 2 - n;
     }
     return src;
   }
@@ -2100,21 +2140,25 @@ scope_get(const uint8_t *scope, mrb_int depth)
  * here because the bytes they cover are gone before the parser reads them.
  * A `#` inside [...] is a member of the class, and so is a (?# written
  * there. Escaped characters (\ followed by anything) are preserved.
- * skip_uninterpreted() decides which bytes those are.
+ * skip_uninterpreted() decides which bytes those are, and it also says when
+ * a numeric escape is to be written at full width, `\x6` as `\x06`, so that
+ * a digit a removed comment brings next cannot lengthen it.
  *
  * The buffer comes from the GC arena, which holds it until the caller's frame
  * is gone: the parser reads it from beginning to end, and every raise in
  * between leaves this function nothing to be reached through. The scope
  * stack lives behind the rewritten pattern in the same allocation: a group
  * opener is one byte of source, so len bits is room for every group. The
- * pass only removes bytes, so the pattern part is the size of the source.
+ * pattern part is twice the source: writing an escape at full width
+ * lengthens it by two bytes at most, `\0` to `\000`, and nothing else the
+ * pass writes is longer than what it read.
  */
 static char*
 preprocess_pattern(mrb_state *mrb, const char *src, mrb_int len,
                    mrb_bool extended, mrb_int *out_len)
 {
-  char *buf = (char*)mrb_temp_alloc(mrb, (size_t)len + ((size_t)len + 7) / 8);
-  uint8_t *scope = (uint8_t*)buf + len;
+  char *buf = (char*)mrb_temp_alloc(mrb, (size_t)len * 2 + ((size_t)len + 7) / 8);
+  uint8_t *scope = (uint8_t*)buf + len * 2;
   mrb_int depth = 0;
   mrb_int o = 0;
   mrb_bool in_class = FALSE;
@@ -2123,9 +2167,16 @@ preprocess_pattern(mrb_state *mrb, const char *src, mrb_int len,
   while (src < end) {
     char ch = *src;
     /* An escape or a character class is copied through untouched: neither
-       holds a comment. */
-    const char *skip = skip_uninterpreted(src, end, &in_class);
+       holds a comment. A numeric escape short of its full width is padded
+       with zeros after its letter, `\x6` to `\x06`. */
+    int pad;
+    const char *skip = skip_uninterpreted(src, end, &in_class, &pad);
     if (skip) {
+      if (pad) {
+        buf[o++] = *src++;
+        buf[o++] = *src++;
+        while (pad-- > 0) buf[o++] = '0';
+      }
       while (src < skip) buf[o++] = *src++;
       continue;
     }
@@ -2218,7 +2269,8 @@ has_named_group(const char *src, mrb_int len)
 
   while (src < end) {
     char ch = *src;
-    const char *skip = skip_uninterpreted(src, end, &in_class);
+    int pad;
+    const char *skip = skip_uninterpreted(src, end, &in_class, &pad);
     if (skip) {
       src = skip;
       continue;

--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -73,10 +73,9 @@ compile_error_str(re_compiler *c, mrb_value msg)
 {
   /* Quote c->orig, the pattern as written: when the pattern is preprocessed
      c->src points at the buffer preprocess_pattern() returned, so quoting it
-     would drop the free-spacing, the comments and the (?#...) groups from the
-     message. c->orig is the caller's buffer, which outlives the compile. It
-     is not NUL-terminated, so use %l with the explicit length from
-     c->orig_end. */
+     would drop the comments and the (?#...) groups from the message. c->orig
+     is the caller's buffer, which outlives the compile. It is not
+     NUL-terminated, so use %l with the explicit length from c->orig_end. */
   mrb_value emsg = mrb_format(c->mrb, "%v: /%l/",
                               msg, c->orig, (size_t)(c->orig_end - c->orig));
 
@@ -189,6 +188,30 @@ next_char(re_compiler *c)
 {
   if (c->p >= c->src_end) return -1;
   return (uint8_t)*c->p++;
+}
+
+/* Under /x, step over the whitespace between two tokens. Called where one
+   token ends and the next may begin, in compile_seq() and before the
+   quantifier in compile_quantified(), and nowhere else: whitespace inside a
+   token is the token's own, so `a{1, 2}` is not an interval and `(?<a b>x)`
+   names the group "a b", as in CRuby, whose tokenizer skips whitespace only
+   where it fetches a token. The bytes are the five Onigmo skips; a vertical
+   tab is a literal under /x there, and here.
+
+   `#` comments are not skipped here: preprocess_pattern() removes them, as
+   CRuby's own pre-pass does before it tokenizes, which is what lets a removed
+   comment join `\1` to the `0` after it. */
+static mrb_bool
+extended_space(int ch)
+{
+  return ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r' || ch == '\f';
+}
+
+static void
+skip_extended_space(re_compiler *c)
+{
+  if (!(c->flags & RE_FLAG_EXTENDED)) return;
+  while (extended_space(peek(c))) next_char(c);
 }
 
 static uint16_t
@@ -1136,11 +1159,11 @@ compute_fixed_len(re_compiler *c, uint32_t start, uint32_t end, int *chars_out)
    and a further run of i/m/x to switch off, then stops at the terminator
    (':' or ')'). `base` is the option set in effect on entry; the resulting
    set is returned. Ruby's inline letters are i (IGNORECASE), m (DOTALL),
-   x (EXTENDED). The x bit is carried like the other two but nothing in the
-   parser reads it: free-spacing is applied by preprocess_pattern() before
-   the parser runs, and that pass tracks the same (?x) and (?-x) scopes over
-   the pattern as written, so by the time the letter is read here the
-   whitespace it governed is already gone or already kept. */
+   x (EXTENDED). All three are scoped alike by the group they are read in:
+   skip_extended_space() reads x from c->flags, which compile_atom() saves
+   at every '(' and restores at its ')'. preprocess_pattern() tracks the
+   same scopes over the pattern as written for the one thing it still does
+   under /x, removing `#` comments. */
 static uint32_t
 parse_inline_flags(re_compiler *c, uint32_t base)
 {
@@ -1758,6 +1781,10 @@ compile_quantified(re_compiler *c)
   c->atom_start = saved_atom_start;
   if (c->code_len == begin) return;  /* no atom emitted */
 
+  /* Under /x the quantifier may stand apart from its atom, `a +` being `a+`.
+     A `?` making it non-greedy is read right after it, though, as CRuby
+     reads it: `a* ?` is `a*` and then a `?` of its own. */
+  skip_extended_space(c);
   int ch = peek(c);
   if (ch == '*' || ch == '+' || ch == '?') {
     next_char(c);
@@ -1849,7 +1876,13 @@ compile_quantified(re_compiler *c)
 static void
 compile_seq(re_compiler *c)
 {
-  while (peek(c) >= 0 && peek(c) != ')' && peek(c) != '|') {
+  for (;;) {
+    /* One token ends here and the next may begin, so under /x this is where
+       the whitespace between them goes: `a b` is `ab`, and the blanks before
+       a '|' or a ')' are gone by the time compile_alt() looks for one. */
+    skip_extended_space(c);
+    int ch = peek(c);
+    if (ch < 0 || ch == ')' || ch == '|') return;
     uint32_t code_before = c->code_len;
     const char *p_before = c->p;
     compile_quantified(c);
@@ -1929,31 +1962,6 @@ compile_alt(re_compiler *c)
   }
 }
 
-/*
- * Does the pattern hold a group preprocess_pattern() rewrites: a (?#
- * comment group, or an inline option group that turns x on, as in (?x),
- * (?x:...) or (?ix-m:...)? Cheap pre-check so an ordinary pattern without
- * one skips the pass and its malloc. An escaped or bracketed "(?" is a
- * false positive here, which costs the pass and nothing else: the pass
- * itself steps over escapes and classes.
- */
-static mrb_bool
-has_rewritten_group(const char *src, mrb_int len)
-{
-  const char *p = src, *end = src + len;
-  while (p < end && (p = (const char*)memchr(p, '(', (size_t)(end - p))) != NULL) {
-    if (end - p >= 3 && p[1] == '?') {
-      if (p[2] == '#') return TRUE;
-      /* The letters before a '-' are the ones switched on. */
-      for (const char *q = p + 2; q < end && (*q == 'i' || *q == 'm' || *q == 'x'); q++) {
-        if (*q == 'x') return TRUE;
-      }
-    }
-    p++;
-  }
-  return FALSE;
-}
-
 /* Inside a character class, is `src` the start of a POSIX bracket [:name:]?
    Returns the position just past its closing "]", or NULL if it is not one.
    compile_charclass() consumes such a bracket as a unit, so its ']' does not
@@ -1996,9 +2004,9 @@ skip_uninterpreted(const char *src, const char *end, mrb_bool *in_class)
     mrb_bool unicode = (src[1] == 'u');
     src += 2;
     /* A `\u{...}` list is a single escape rather than `\u` followed by a
-       brace group: it separates its codepoints with spaces, which the
-       free-spacing pass would otherwise remove, joining `\u{61 62}` into the
-       one codepoint `\u{6162}`. An unterminated list runs to the end. */
+       brace group: a `#` inside it is a malformed list for the parser to
+       reject, not a comment for the pass to remove, and a "(?<" inside it
+       declares nothing. An unterminated list runs to the end. */
     if (unicode && src < end && *src == '{') {
       while (src < end) {
         if (*src++ == '}') break;
@@ -2030,7 +2038,7 @@ skip_uninterpreted(const char *src, const char *end, mrb_bool *in_class)
 }
 
 /* Read the letters of an inline option group whose "(?" starts at `src`,
-   as far as the free-spacing pass needs them: whether the group is one,
+   as far as the comment pass needs them: whether the group is one,
    whether it is the toggle form (?imx) rather than the scoped (?imx:...),
    and what it makes of x. `*x_on` is left as it was when the letters do
    not name x. Returns the terminator's position, or NULL when the bytes
@@ -2054,8 +2062,8 @@ scan_option_group(const char *src, const char *end, mrb_bool *toggle, mrb_bool *
   return q;
 }
 
-/* The free-spacing pass's scope stack: one bit per open group, holding
-   what extended mode was outside it. */
+/* The comment pass's scope stack: one bit per open group, holding what
+   extended mode was outside it. */
 static void
 scope_set(uint8_t *scope, mrb_int depth, mrb_bool extended)
 {
@@ -2071,69 +2079,54 @@ scope_get(const uint8_t *scope, mrb_int depth)
 }
 
 /*
- * Rewrite the pattern before the parser sees it.
- * Removes (?#...) comment groups always, and wherever extended mode is in
- * effect also whitespace and #comments. Extended mode is in effect from the
- * start when the Regexp carries /x, and it is switched inside the pattern
- * by the inline option groups: (?x) and (?-x) for the rest of the enclosing
- * group, (?x:...) and (?-x:...) for their own body. So this pass keeps a
- * stack of one bit per open group, pushed at every '(' it interprets and
- * popped at every ')', which is what lets a toggle end where its group does.
- * That is the same scoping the parser gives i and m; x has to be resolved
- * here because the bytes it governs are gone before the parser reads them.
- * Whitespace inside [...] character classes is preserved, and so is a (?#
- * written there, which is a literal member rather than a comment group.
- * Escaped characters (\ followed by anything) are preserved.
- * skip_uninterpreted() decides which bytes those are.
+ * Rewrite the pattern before the parser sees it: remove the (?#...) comment
+ * groups, under any flags, and wherever extended mode is in effect the `#`
+ * comments too. That is what CRuby's own pre-pass (re.c) removes before its
+ * tokenizer reads the pattern, and it is why the removal is done here rather
+ * than by the parser: taking a comment out of the source joins the bytes on
+ * either side of it, and CRuby has `\1(?#c)0` and `\1#c`, a newline and `0`
+ * both as `\10`. The whitespace of free-spacing mode is another matter. It
+ * separates tokens and never joins anything, so the parser skips it between
+ * tokens (skip_extended_space()) and reads every token, escapes and group
+ * names included, with the whitespace still in place.
  *
- * Removing whitespace must not join what it kept apart. An escape spelled
- * with digits (`\1`, `\01`, `\x1`) takes the digits that follow it, so
- * `\x1 2` copied as `\x12` would be one byte where CRuby, whose tokenizer
- * stops at the space, reads two. So when whitespace went out between such
- * an escape and a hex digit, an empty group `(?:)` goes in: it emits no
- * instruction and keeps the digit an atom of its own. A removed comment,
- * `#...` to the end of its line or `(?#...)`, does join the two: CRuby
- * strips those before it tokenizes, and `\1(?#c)0` is `\10` there.
+ * Extended mode is in effect from the start when the Regexp carries /x, and
+ * it is switched inside the pattern by the inline option groups: (?x) and
+ * (?-x) for the rest of the enclosing group, (?x:...) and (?-x:...) for
+ * their own body. So this pass keeps a stack of one bit per open group,
+ * pushed at every '(' it interprets and popped at every ')', which is what
+ * lets a toggle end where its group does. That is the same scoping the
+ * parser gives x for the whitespace; the `#` comments have to be resolved
+ * here because the bytes they cover are gone before the parser reads them.
+ * A `#` inside [...] is a member of the class, and so is a (?# written
+ * there. Escaped characters (\ followed by anything) are preserved.
+ * skip_uninterpreted() decides which bytes those are.
  *
  * The buffer comes from the GC arena, which holds it until the caller's frame
  * is gone: the parser reads it from beginning to end, and every raise in
  * between leaves this function nothing to be reached through. The scope
  * stack lives behind the rewritten pattern in the same allocation: a group
  * opener is one byte of source, so len bits is room for every group. The
- * pattern part is twice the source: each separator adds four bytes and
- * takes an escape, a blank and a digit, at least four bytes, to occur.
+ * pass only removes bytes, so the pattern part is the size of the source.
  */
 static char*
 preprocess_pattern(mrb_state *mrb, const char *src, mrb_int len,
                    mrb_bool extended, mrb_int *out_len)
 {
-  char *buf = (char*)mrb_temp_alloc(mrb, (size_t)len * 2 + ((size_t)len + 7) / 8);
-  uint8_t *scope = (uint8_t*)buf + len * 2;
+  char *buf = (char*)mrb_temp_alloc(mrb, (size_t)len + ((size_t)len + 7) / 8);
+  uint8_t *scope = (uint8_t*)buf + len;
   mrb_int depth = 0;
   mrb_int o = 0;
-  mrb_int esc_end = -1;         /* where the last digit escape ended in buf */
-  mrb_bool blank_out = FALSE;   /* whitespace was removed since */
   mrb_bool in_class = FALSE;
   const char *end = src + len;
 
   while (src < end) {
     char ch = *src;
     /* An escape or a character class is copied through untouched: neither
-       holds a comment group, and inside a class the free-spacing rules do
-       not apply. */
+       holds a comment. */
     const char *skip = skip_uninterpreted(src, end, &in_class);
     if (skip) {
-      /* An escape spelled with digits: `\N`, `\x`, or `\u` outside the
-         `\u{...}` list form, whose brace closes it. What is copied here is
-         the backslash and the byte after it; the digits beyond are literals
-         to this pass, and the loop below keeps track of them. */
-      mrb_bool digits = (ch == '\\' && skip - src == 2 &&
-                         (ISDIGIT(src[1]) || src[1] == 'x' || src[1] == 'u'));
       while (src < skip) buf[o++] = *src++;
-      if (digits) {
-        esc_end = o;
-        blank_out = FALSE;
-      }
       continue;
     }
     if (ch == ')') {
@@ -2171,7 +2164,8 @@ preprocess_pattern(mrb_state *mrb, const char *src, mrb_int len,
       if (term && toggle) {
         /* (?imx) changes the rest of the enclosing group and opens none of
            its own, so the stack is left alone. The group is copied through
-           for the parser, which applies i and m from the same letters. */
+           for the parser, which applies all three letters from the same
+           bytes. */
         while (src <= term) buf[o++] = *src++;
         extended = x_on;
         continue;
@@ -2188,28 +2182,13 @@ preprocess_pattern(mrb_state *mrb, const char *src, mrb_int len,
       buf[o++] = *src++;
       continue;
     }
-    if (extended) {
-      if (ch == '#') {
-        /* Skip to the end of the line, newline included: the comment is
-           one removed span, not a comment and then a blank. */
-        while (src < end && *src != '\n') src++;
-        if (src < end) src++;
-        continue;
-      }
-      if (ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r' || ch == '\f' || ch == '\v') {
-        src++;
-        blank_out = TRUE;
-        continue;
-      }
-    }
-    if (o == esc_end && hex_value((unsigned char)ch) >= 0) {
-      if (blank_out) {
-        memcpy(buf + o, "(?:)", 4);  /* the digit is an atom of its own */
-        o += 4;
-      }
-      else {
-        esc_end = o + 1;  /* the digit extends the escape */
-      }
+    if (extended && ch == '#') {
+      /* Skip to the end of the line, newline included: the comment is one
+         removed span, and the newline is not left for the parser to read
+         as whitespace where the comment stood inside a token. */
+      while (src < end && *src != '\n') src++;
+      if (src < end) src++;
+      continue;
     }
     buf[o++] = *src++;
   }
@@ -2442,7 +2421,11 @@ mrb_re_compile(mrb_state *mrb, mrb_regexp_pattern *pat,
   c.orig = pattern;
   c.orig_end = pattern + len;
 
-  if ((flags & RE_FLAG_EXTENDED) || has_rewritten_group(pattern, len)) {
+  /* Both things the pre-pass removes, a (?#...) group and a `#` comment,
+     are spelled with a '#', so a pattern without one is parsed as written.
+     A '#' that is escaped or a class member is a false positive here, which
+     costs the pass and nothing else: the pass steps over both. */
+  if (memchr(pattern, '#', (size_t)len)) {
     mrb_int slen;
     pattern = preprocess_pattern(mrb, pattern, len,
                                  (flags & RE_FLAG_EXTENDED) != 0, &slen);
@@ -2454,8 +2437,7 @@ mrb_re_compile(mrb_state *mrb, mrb_regexp_pattern *pat,
   c.flags = flags;
   c.num_captures = 1;  /* group 0 = whole match */
   /* Scan the same bytes the parser is about to read: preprocess_pattern() has
-     already taken out the /x free-spacing, the #comments and the (?#...)
-     groups. */
+     already taken out the #comments and the (?#...) groups. */
   c.dont_capture = has_named_group(pattern, len);
 
   pat->flags = flags;

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -289,6 +289,9 @@ assert("Regexp#to_s") do
   assert_equal "(?x-mi:a b)", Regexp.new("a b", Regexp::EXTENDED).to_s
   assert_true Regexp.new(Regexp.new("a b", Regexp::EXTENDED).to_s).match?("ab")
   assert_false Regexp.new(Regexp.new("a b", Regexp::EXTENDED).to_s).match?("a b")
+  # a `#` comment in the source rides along and is still a comment inside the
+  # "(?x-mi:", so its newline has to come before the closing ")"
+  assert_true Regexp.new(Regexp.new("a # c\nb", Regexp::EXTENDED).to_s).match?("ab")
   assert_true(/#{Regexp.new("a b", Regexp::EXTENDED)}c d/.match?("abc d"))
 end
 

--- a/mrbgems/mruby-regexp/test/regexp_syntax.rb
+++ b/mrbgems/mruby-regexp/test/regexp_syntax.rb
@@ -791,6 +791,67 @@ assert("Regexp - free-spacing whitespace stands between tokens only") do
   assert_equal [" "], Regexp.new("[\\k<a b>]", x).match(" ").to_a
 end
 
+assert("Regexp - a removed comment does not reach into an escape") do
+  # The pass that removes (?#...) groups and, under /x, `#` comments runs
+  # before the parser, so bytes it removes from inside an escape would leave
+  # the parser a different escape. CRuby's own pre-pass reads each escape
+  # whole before it reaches the comment, and so does this one: `\u12(?#c)34`
+  # is rejected as `\u12(?` rather than read as `\u1234`.
+  x = Regexp::EXTENDED
+
+  # \uXXXX is exactly four bytes after the u, whatever they are
+  ["\\u12(?#c)34", "\\u(?#c){61}", "\\u006(?#c)1"].each do |pat|
+    assert_raise_with_message(RegexpError, "invalid Unicode escape: /#{pat}/") do
+      Regexp.new(pat)
+    end
+  end
+  ["\\u12#c\n34", "\\u#c\n{61}"].each do |pat|
+    assert_raise_with_message(RegexpError, "invalid Unicode escape: /#{pat}/") do
+      Regexp.new(pat, x)
+    end
+  end
+  assert_equal ["ab"], Regexp.new("\\u0061(?#c)\\u0062").match("ab").to_a
+  assert_equal ["ab"], Regexp.new("\\u{61}(?#c)\\u{62}").match("ab").to_a
+  # a `\u{...}` list is one escape through its brace, and holds no comment
+  assert_raise_with_message(RegexpError, "invalid Unicode list: /\\u{61(?#c)62}/") do
+    Regexp.new("\\u{61(?#c)62}")
+  end
+  assert_raise_with_message(RegexpError, "invalid Unicode list: /\\u{61 #c\n62}/") do
+    Regexp.new("\\u{61 #c\n62}", x)
+  end
+
+  # \x is one or two hex digits and needs the one; a one-digit escape is
+  # written at full width so that a digit the comment kept apart cannot
+  # join it: `\x6(?#c)1` is `\x06` and `1`
+  assert_raise_with_message(RegexpError, "invalid hex escape: /\\x(?#c)61/") do
+    Regexp.new("\\x(?#c)61")
+  end
+  assert_raise_with_message(RegexpError, "invalid hex escape: /\\x#c\n61/") do
+    Regexp.new("\\x#c\n61", x)
+  end
+  assert_equal ["\x061"], Regexp.new("\\x6(?#c)1").match("\x061").to_a
+  assert_nil Regexp.new("\\x6(?#c)1").match("a")
+  assert_equal ["\x061"], Regexp.new("\\x6#c\n1", x).match("\x061").to_a
+  assert_nil Regexp.new("\\x6#c\n1", x).match("a")
+  assert_equal ["\x06"], Regexp.new("\\x6(?#c)").match("\x06").to_a
+  assert_equal ["a1"], Regexp.new("\\x61(?#c)1").match("a1").to_a
+
+  # \0 is up to two more octal digits, written at full width the same way
+  assert_equal ["\x0061"], Regexp.new("\\0(?#c)61").match("\x0061").to_a
+  assert_nil Regexp.new("\\0(?#c)61").match("1")
+  assert_equal ["\x0061"], Regexp.new("\\0#c\n61", x).match("\x0061").to_a
+  assert_equal ["\x061"], Regexp.new("\\06(?#c)1").match("\x061").to_a
+  assert_equal ["\x061"], Regexp.new("\\06#c\n1", x).match("\x061").to_a
+  assert_equal ["\x00"], Regexp.new("\\0(?#c)").match("\x00").to_a
+  assert_equal ["\x001"], Regexp.new("\\000(?#c)1").match("\x001").to_a
+
+  # inside a class the pass removes nothing, so `(?#c)` is five members and
+  # `#c` two, and the escape is read as written
+  assert_equal ["\x06"], Regexp.new("[\\x6(?#c)1]").match("\x06").to_a
+  assert_equal ["("], Regexp.new("[\\x6(?#c)1]").match("(").to_a
+  assert_equal ["#"], Regexp.new("[\\x6#c\n1]", x).match("#").to_a
+end
+
 assert("Regexp - empty pattern") do
   assert_true //.match?("")
   assert_true //.match?("abc")

--- a/mrbgems/mruby-regexp/test/regexp_syntax.rb
+++ b/mrbgems/mruby-regexp/test/regexp_syntax.rb
@@ -673,13 +673,122 @@ assert("Regexp extended mode (x flag)") do
   # to_s shows x flag
   assert_equal "(?x-mi:abc)", Regexp.new("abc", Regexp::EXTENDED).to_s
 
-  # errors quote the pattern as written, not the stripped text
+  # errors quote the pattern as written, not the text with the comment removed
   assert_raise_with_message(RegexpError, "unterminated character class: /a # c\n[/") do
     Regexp.new("a # c\n[", Regexp::EXTENDED)
   end
   assert_raise_with_message(RegexpError, "unmatched '(': /a b(/") do
     Regexp.new("a b(", Regexp::EXTENDED)
   end
+end
+
+assert("Regexp - free-spacing whitespace stands between tokens only") do
+  # Under /x the parser skips whitespace where one token ends and the next
+  # begins, as CRuby's tokenizer does, and reads every token with the
+  # whitespace inside it in place. So a space cannot split a token that
+  # is not one, and taking a space out cannot join two into one.
+  x = Regexp::EXTENDED
+
+  # between tokens: literals, groups, alternatives, anchors, quantifiers
+  assert_equal ["ab"], Regexp.new("a b", x).match("ab").to_a
+  assert_equal ["a", "a"], Regexp.new("( a )", x).match("a").to_a
+  assert_equal ["b"], Regexp.new("(?: a | b )", x).match("b").to_a
+  assert_equal ["b"], Regexp.new("a | b", x).match("b").to_a
+  assert_equal ["a"], Regexp.new("^ a $", x).match("a").to_a
+  assert_equal ["axb"], Regexp.new("a . b", x).match("axb").to_a
+  assert_equal ["aaa"], Regexp.new("a +", x).match("aaa").to_a
+  assert_equal ["aa"], Regexp.new("a {2}", x).match("aa").to_a
+  assert_equal ["aa", "a"], Regexp.new("(a) {2}", x).match("aa").to_a
+  assert_equal ["b"], Regexp.new("a ?b", x).match("b").to_a
+  assert_equal ["a"], Regexp.new("(?= a)a", x).match("a").to_a
+  assert_equal ["b"], Regexp.new("(?<= a)b", x).match("ab").to_a
+  assert_equal ["b"], Regexp.new("(?! a)b", x).match("b").to_a
+  assert_equal ["a"], Regexp.new("(?> a )", x).match("a").to_a
+  assert_equal ["A"], Regexp.new("(?i: a )", x).match("A").to_a
+  assert_equal ["aa", "a"], Regexp.new("(?<n> a)\\k<n>", x).match("aa").to_a
+  assert_equal ["aa", "a"], Regexp.new("(a) \\1", x).match("aa").to_a
+
+  # the five bytes CRuby skips; a vertical tab is a literal
+  assert_equal ["ab"], Regexp.new("a \t\n\r\fb", x).match("ab").to_a
+  assert_nil Regexp.new("a\vb", x).match("ab")
+  assert_equal ["a\vb"], Regexp.new("a\vb", x).match("a\vb").to_a
+
+  # an escaped blank is the blank
+  assert_equal ["a b"], Regexp.new("a\\ b", x).match("a b").to_a
+  assert_equal ["a\nb"], Regexp.new("a\\\nb", x).match("a\nb").to_a
+  assert_equal ["#"], Regexp.new("\\#", x).match("#").to_a
+
+  # inside a token the whitespace is the token's own: `(?` and `{n,m}` are
+  # read whole, so a space breaks them rather than being removed from them
+  assert_raise_with_message(RegexpError,
+                            "target of repeat operator is not specified: /( ?i)A/") do
+    Regexp.new("( ?i)A", x)
+  end
+  assert_raise(RegexpError) { Regexp.new("(?i )a", x) }
+  assert_nil Regexp.new("a{1, 2}", x).match("aa")
+  assert_equal ["a{1,2}"], Regexp.new("a{1, 2}", x).match("a{1,2}").to_a
+  assert_equal ["a{2}"], Regexp.new("a{ 2}", x).match("a{2}").to_a
+  assert_equal ["a{2}"], Regexp.new("a{2 }", x).match("a{2}").to_a
+  # the `?` that makes a quantifier non-greedy is read right after it, so a
+  # `?` a space away is a repeat of the repeat, which this engine refuses
+  # as it refuses `a**`
+  assert_equal [""], Regexp.new("a*?", x).match("aaa").to_a
+  assert_raise(RegexpError) { Regexp.new("a* ?", x) }
+
+  # a numeric escape is read whole too: the whitespace that CRuby rejects
+  # inside one is rejected here, and the whitespace that ends one short of
+  # its full width ends it, so `\x6 1` is `\x06` and `1`
+  ["\\u {61 62}", "\\u1 234", "\\u12 34", "\\u00 61", "\\u\t{61 62}",
+   "\\u 0061", "[\\u12 34]"].each do |pat|
+    assert_raise_with_message(RegexpError, "invalid Unicode escape: /#{pat}/") do
+      Regexp.new(pat, x)
+    end
+  end
+  # nothing after \u is "too short", a wrong byte after it "invalid"; the
+  # blank is a byte the parser sees, and reports
+  assert_raise_with_message(RegexpError, "invalid Unicode escape: /\\u /") do
+    Regexp.new("\\u ", x)
+  end
+  assert_raise_with_message(RegexpError, "too short escape sequence: /\\u/") do
+    Regexp.new("\\u", x)
+  end
+  assert_equal ["ab"], Regexp.new("\\u0061 \\u0062", x).match("ab").to_a
+  assert_equal ["ab"], Regexp.new("\\u{ 61  62 }", x).match("ab").to_a
+  assert_raise_with_message(RegexpError, "invalid hex escape: /\\x 61/") do
+    Regexp.new("\\x 61", x)
+  end
+  assert_equal ["\x061"], Regexp.new("\\x6 1", x).match("\x061").to_a
+  assert_nil Regexp.new("\\x6 1", x).match("a")
+  assert_equal ["\x0061"], Regexp.new("\\0 61", x).match("\x0061").to_a
+  assert_equal ["\x061"], Regexp.new("\\06 1", x).match("\x061").to_a
+  assert_nil Regexp.new("\\0 61", x).match("1")
+
+  # a group name is the raw bytes up to its terminator, whitespace included,
+  # whether it is declared or referenced: the name is "a b"
+  assert_equal ["a b"], Regexp.new("(?<a b>x)", x).names
+  assert_equal ["a b"], Regexp.new("(?'a b'x)", x).names
+  assert_equal "xx", Regexp.new("(?<a b>x)\\k<a b>", x).match("xx")[0]
+  assert_equal "xx", Regexp.new("(?'a b'x)\\k'a b'", x).match("xx")[0]
+  assert_raise_with_message(RegexpError,
+                            "undefined name <a b> reference: /(?<ab>x)\\k<a b>/") do
+    Regexp.new("(?<ab>x)\\k<a b>", x)
+  end
+  assert_raise_with_message(RegexpError,
+                            "undefined name <ab> reference: /(?<a b>x)\\k<ab>/") do
+    Regexp.new("(?<a b>x)\\k<ab>", x)
+  end
+  # a `\k` that whitespace follows is the letter k, with the `<ab>` after
+  # the whitespace a literal of its own; a comment between the two is gone
+  # before the parser reads either, as in CRuby, so that `\k` is a reference
+  assert_equal "xk<ab>", Regexp.new("(?<ab>x)\\k <ab>", x).match("xk<ab>")[0]
+  assert_equal "xk<ab>", Regexp.new("(?<ab>x)\\k\n<ab>", x).match("xk<ab>")[0]
+  assert_equal "xx", Regexp.new("(?<ab>x)\\k#c\n<ab>", x).match("xx")[0]
+  assert_equal "xx", Regexp.new("(?<ab>x)\\k(?#c)<ab>").match("xx")[0]
+  # a comment inside a name is removed the same way, and takes its newline
+  assert_equal ["ab"], Regexp.new("(?<ab#c\n>x)\\k<ab#c\n>", x).names
+  assert_equal "xx", Regexp.new("(?<ab#c\n>x)\\k<ab#c\n>", x).match("xx")[0]
+  # inside a class the escape is the letter and the space is a member
+  assert_equal [" "], Regexp.new("[\\k<a b>]", x).match(" ").to_a
 end
 
 assert("Regexp - empty pattern") do
@@ -830,33 +939,40 @@ assert("Regexp - a named group makes plain groups non-capturing") do
   end
 end
 
-assert("Regexp - the /x pass and the named-group scan skip the same constructs") do
-  # Two walks read the pattern before the parser does: the /x free-spacing
-  # pass and the named-group pre-scan. Both have to step over the same
-  # escapes, character classes and POSIX brackets, so each row below is read
-  # by both at once. A rule lost from the free-spacing pass strips a space it
-  # should have kept; the same rule lost from the pre-scan turns a bracketed
-  # "(?<" into a phantom named group, which demotes the plain (b) that
-  # follows and shortens the match. Either way the row fails.
+assert("Regexp - the comment pass, the named-group scan and the parser skip the same constructs") do
+  # Three readers step over the pattern's escapes, character classes and
+  # POSIX brackets: the comment pass, which runs when the pattern holds a
+  # `#`; the named-group pre-scan; and the parser, which under /x skips
+  # whitespace between tokens and none inside those constructs. Every row
+  # below is read by the pre-scan and the parser, and the rows with a `#`
+  # by the pass as well. A rule lost from the pass takes a `#` inside a
+  # class for a comment and eats the rest of the pattern; the same rule
+  # lost from the pre-scan turns a bracketed "(?<" into a phantom named
+  # group, which demotes the plain (b) that follows and shortens the match;
+  # lost from the parser it strips a space that is a member. Either way the
+  # row fails.
   x = Regexp::EXTENDED
 
-  # an escape pair hides the '(' from both
+  # an escape pair hides the '(' from the pre-scan and the parser
   assert_equal ["(<a>b", "b"],
                Regexp.new('\(?<a> (b)', x).match("(<a>b").to_a
 
-  # a character class hides "(?<" and keeps its own spaces
-  assert_equal ["(?< b", "b"],
-               Regexp.new('[(?< a>]+ (b)', x).match("(?< b").to_a
+  # a character class hides "(?<" and keeps its own spaces and its `#`
+  assert_equal ["(?< #b", "b"],
+               Regexp.new('[(?< a>#]+ (b)', x).match("(?< #b").to_a
 
-  # a ']' written first is a member, so the class runs past it
+  # a ']' written first is a member, so the class runs past it; no `#` in
+  # these two, since CRuby's own pre-pass does not know this rule and takes
+  # a `#` after `[]` for a comment, so it cannot settle what the pass makes
+  # of one
   assert_equal ["] (?<b", "b"],
                Regexp.new('[] (?<a>]+(b)', x).match("] (?<b").to_a
   assert_equal ["zzb", "b"],
                Regexp.new('[^] (?<a>]+(b)', x).match("zzb").to_a
 
   # a POSIX bracket's ']' does not close the class either
-  assert_equal ["a (?<b", "b"],
-               Regexp.new('[[:alpha:] (?<a>]+(b)', x).match("a (?<b").to_a
+  assert_equal ["a #(?<b", "b"],
+               Regexp.new('[[:alpha:] #(?<a>]+(b)', x).match("a #(?<b").to_a
 
   # a `\u{...}` list is one escape, so its separating space survives /x and
   # its bytes are not read as pattern syntax
@@ -868,11 +984,10 @@ assert("Regexp - the /x pass and the named-group scan skip the same constructs")
   assert_equal ["abcd", "c", "d"],
                Regexp.new('[\u{61 62}]+(c)(d)', x).match("abcd").to_a
 
-  # With no whitespace, no #comment and no (?#...) to remove, /x rewrites
-  # nothing, so both compiles must agree; they do not take the same road,
-  # though: without /x the pre-scan reads the pattern as written, while with
-  # /x it reads what the free-spacing pass emitted. The two walks disagreeing
-  # about where a class or an escape ends is exactly what shows up here.
+  # With no `#` the pass does not run, and with no whitespace /x gives the
+  # parser nothing to skip, so both compiles read the same bytes and must
+  # agree: /x by itself changes nothing about where a class or an escape
+  # ends.
   [
     ['\(?<a>(b)',            "(<a>b"],
     ['[(?<a>]+(b)',          "(?<b"],
@@ -1224,7 +1339,7 @@ assert("Regexp - \\k group reference errors say which failure it was") do
 end
 
 assert("Regexp - named captures survive /x preprocessing") do
-  # Regression: with /x, mrb_re_compile freed the stripped buffer that
+  # Regression: with /x, mrb_re_compile freed the rewritten buffer that
   # named_captures[i].name pointed into.
   re = /(?<n>\d+) # comment
        \s* (?<u>\w+) /x

--- a/mrbgems/mruby-regexp/test/regexp_utf8.rb
+++ b/mrbgems/mruby-regexp/test/regexp_utf8.rb
@@ -430,8 +430,8 @@ assert("Regexp - \\u escapes") do
   assert_equal "abbb", "abbb"[/\u{61 62}+/]
   assert_nil ("b" =~ /\u{61 62}/)
 
-  # /x strips whitespace before the pattern is parsed, but not the spaces
-  # that separate the codepoints of a list
+  # under /x whitespace is skipped between tokens, and a list is one token,
+  # so the spaces that separate its codepoints stay
   assert_equal 0, (Regexp.new("\\u{61 62}", Regexp::EXTENDED) =~ "ab")
 
   # /i folds an ASCII letter reached through `\u`, like a literal one


### PR DESCRIPTION
`preprocess_pattern()` in mruby-regexp does three things before the parser reads the pattern: it removes `(?#...)` groups, it removes `#` comments under `/x`, and it removes whitespace under `/x`. CRuby does the first two in a pre-pass (`re.c`) and the third in the tokenizer, which skips whitespace only where it fetches a token and reads every token, an escape, a group name, an interval `{n,m}`, a `(?` opener, with the whitespace inside it in place. Doing all three by deleting bytes from the source means that whatever the deletion brings together is what the parser reads, and each kind of token boundary has needed a rule of its own: #7252 (inline `x` scoping) and #7268 (the `(?:)` written between a digit escape and a digit) each added one, and master still reads differently at every boundary without one:

```ruby
Regexp.new("( ?i)A", Regexp::EXTENDED) =~ "a"
# CRuby: RegexpError (target of repeat operator is not specified), mruby: 0
Regexp.new("a{1, 2}", Regexp::EXTENDED) =~ "aa"
# CRuby: nil (`{1, 2}` is not an interval), mruby: 0
Regexp.new("(?<a b>x)", Regexp::EXTENDED).names
# CRuby: ["a b"], mruby: ["ab"]
Regexp.new("(?<ab>x)\\k <ab>", Regexp::EXTENDED) =~ "xk<ab>"
# CRuby: 0 (`\k` is the letter and `<ab>` a literal), mruby: nil (it reads `\k<ab>`)
Regexp.new("a\vb", Regexp::EXTENDED) =~ "ab"
# CRuby: nil (a vertical tab is not free-spacing whitespace), mruby: 0
```

The comment rule from #7268, that a removed comment does join the bytes on either side of it, is right for `\1`-`\9` and wrong for the escapes CRuby's pre-pass has already read whole, and rewritten at a fixed width, by the time it reaches the comment:

```ruby
Regexp.new("\\1(?#c)0") =~ "\x08"      # CRuby: 0 (`\10`), mruby: 0
Regexp.new("\\u12(?#c)34") =~ "ሴ"
# CRuby: RegexpError (invalid Unicode escape), mruby: 0 (it reads `\u1234`)
Regexp.new("\\u#c\n{61}", Regexp::EXTENDED) =~ "a"
# CRuby: RegexpError (invalid Unicode escape), mruby: 0 (it reads `\u{61}`)
Regexp.new("\\x(?#c)61") =~ "a"
# CRuby: RegexpError (invalid hex escape), mruby: 0 (it reads `\x61`)
Regexp.new("\\x6(?#c)1") =~ "a"
# CRuby: nil (`\x06` then `1`), mruby: 0 (it reads `\x61`)
Regexp.new("\\0(?#c)61") =~ "1"
# CRuby: nil (`\0` then `61`), mruby: 0 (it reads `\061`)
```

## The two layers

Each of mruby's two layers gets one of CRuby's two, so that no rule has to be added per boundary. Two commits, and a third with one test line.

**Whitespace moves into the parser.** `RE_FLAG_EXTENDED` was already carried in `c->flags` and scoped by the save and restore every group does for `(?i)` and `(?m)`; `skip_extended_space()` reads it at the two places a token can end: at the top of `compile_seq()`, before each atom and before the `|` or `)` that ends the sequence, and in `compile_quantified()` between the atom and its quantifier. Nowhere else, so `{1, 2}` is not an interval, `( ?` is a group and then a `?`, a group name keeps its blanks, and a numeric escape reads what stands after it: `\x6 1` is `\x06` and `1` because the hex digits stop at the space, with nothing written between them. The bytes skipped are the five Onigmo skips; the vertical tab the pass also removed is a literal under `/x` in CRuby and now here. The `(?:)` insertion goes with its `esc_end` and `blank_out` bookkeeping (the #7268 tests stay as they are and hold through the parser), and `has_rewritten_group()`, which decided whether the pass runs at all, is replaced by a `memchr()` for `#`: both things the pass still removes are spelled with one, and neither the `/x` flag nor a `(?x)` needs the pass any more.

**The pre-pass keeps what `re.c` does**, `(?#...)` under any flags and `#...` under `/x`, with the scope stack from #7252 saying where `/x` is on. Both stay in the pre-pass rather than moving to the parser because CRuby removes both before it reads escapes: `\1#c`, a newline and `0` is `\10` there just as `\1(?#c)0` is. `skip_uninterpreted()` steps over an escape at the width CRuby's pre-pass reads it: `\u{...}` to its brace, `\uXXXX` and the next four bytes whatever they are, `\x` and its hex digits (with none, the one byte after, for the parser to reject), `\0` and its octal digits, written at full width (`\x6` as `\x06`, `\0` as `\000`) so that a removed comment cannot lengthen them; the rewrite buffer is twice the source for that. `\1`-`\9` are the backslash and one digit, and the digits after them are plain bytes, so a removed comment joins them into `\10` as it does in CRuby.

One shape of pattern that compiled on master is refused now. `a* ?` under `/x` was read as the non-greedy `a*?` once the blank was gone, and `a{2} ?` the same way; CRuby reads a `?` a blank away from the quantifier as a repeat of the repeat, `(?:a*)?`, and this engine refuses a repeat of a repeat wherever it is written, `a**` included, so it refuses these too rather than give them a meaning CRuby does not.

## Time

Wall clock, minimum of 9 alternating runs, `-O3`, `default` gembox plus `mruby-benchmark`: the path this PR changes, a `Regexp.new` under `/x` with and without a `#` and a `/x` literal, which is compiled on every turn.

```ruby
x = Regexp::EXTENDED
xpat = "(?<n>\\d+) # the number\n\\s* (?<u>\\w+) # the unit\n"
100000.times { Regexp.new("a b c", x) }                 # new_x_nocomment
100000.times { Regexp.new("a # c\nb # d\nc", x) }       # new_x_comment
100000.times { Regexp.new(xpat, x) }                    # new_x_named
100000.times { Regexp.new("abc") }                      # new_plain
100000.times { Regexp.new("a(?#c)bc") }                 # new_comment_group
100000.times { "abc" =~ /a b c/x }                      # match_x_literal
100000.times { "42 px" =~ /(?<n>\d+) # the number
                           \s* (?<u>\w+) # the unit
                          /x }                          # match_x_comment
```

| case | master | this PR |
| --- | --- | --- |
| new_x_nocomment | 75ms | 63ms (-16%) |
| new_x_comment | 77ms | 77ms (+0%) |
| new_x_named | 111ms | 113ms (+2%) |
| new_plain | 61ms | 61ms (+0%) |
| new_comment_group | 74ms | 74ms (+0%) |
| match_x_literal | 144ms | 139ms (-3%) |
| match_x_comment | 296ms | 305ms (+3%) |

A `/x` pattern without a `#` no longer runs the pass or takes its allocation, which is the -16%. With a `#` the pass still runs and now copies the whitespace through for the parser to skip, so the pattern's whitespace is walked twice instead of once; `match_x_comment`, whose literal carries about a hundred bytes of indentation, pays that second walk, +3%.

## Size

`.text` of `bin/mruby`, `build_config/ci/gcc-clang.rb`, each side from a clean build directory at the same path. `re_compile.o` is the only object that changes and accounts for the whole delta.

| build | master | this PR | delta |
|---|---:|---:|---:|
| `full-debug` (`-O0`) | 1,880,918 | 1,880,886 | -32 |
| `bintest` | 1,280,246 | 1,280,230 | -16 |
| `cxx_abi` | 1,305,897 | 1,305,753 | -144 |
| `byte-string` | 1,249,654 | 1,249,494 | -160 |
| `ascii-ctype` | 1,268,102 | 1,268,038 | -64 |

## Verification

Two new blocks in `mrbgems/mruby-regexp/test/regexp_syntax.rb`, one per commit. The first covers whitespace between tokens (literals, groups, alternatives, anchors, quantifiers, lookarounds, an atomic group, a named group and its `\k`, a numbered backreference), the five bytes skipped and the vertical tab that is not, escaped blanks, and whitespace inside a token: `( ?i)`, `(?i )`, `{1, 2}`, `{ 2}`, `{2 }`, `a* ?` against `a*?`, the `\u`, `\x` and `\0` spellings CRuby rejects or reads short, and group names with a blank inside, declared and referenced, with `\k <ab>` as the letter and `\k#c\n<ab>` and `\k(?#c)<ab>` as references. The second covers a comment removed from inside `\uXXXX`, `\u{...}`, `\x` and `\0`, with and without `/x`, the short escapes written at full width (`\x6(?#c)1`, `\0(?#c)61`), and a class keeping the bytes of `(?#c)` as members. The block that checks that the pass and the named-group scan step over the same constructs now names the three readers (the pass, the scan, the parser) and says which rows each reads, with a `#` added to two of its class rows so that the pass still runs there. Every expected value was checked against CRuby 4.0.6 first. The third commit adds one line to the `Regexp#to_s` block in `regexp.rb`: a `/x` pattern with a `#` comment printed as `(?x-mi:...)` and read back through `Regexp.new`, the one spelling that goes through the comment pass and the inline `x` scope on a single compile.

**Differential against CRuby 4.0.6**, `bintest` build (`MRB_UTF8_STRING`) of master and of this PR. 100,000 random patterns of one to six tokens drawn from `a`, `b`, digits, the five whitespace bytes and a vertical tab, `#c` with and without a newline, `(?#c)`, `\x`, `\x6`, `\x61`, `\0`, `\06`, `\1`, `\10`, `\u`, `\u00`, `\u0061`, `\u{61}`, `\u{61 62}`, `\u{`, `\u{61`, `\k`, `\k<a>`, `\k<a b>`, `\k'a'`, `(?<a>`, `(?<a b>`, `(?'a'`, `(?'a b'`, `(a)`, `(`, `)`, `(?:`, `(?x)`, `(?-x)`, `(?x:`, `(?i)`, `(?xi:`, `(?=`, `(?<=`, `(?>`, `[`, `]`, `[a b]`, `[#]`, `[\x6 1]`, `{`, `}`, `{2}`, `{1, 2}`, `{1,2}`, `*`, `+`, `?`, `|`, `\ `, `\\`, `^`, `$`, `.`, `\b`, `\d`, `<`, `>`, `-`, `'`, `e`, `f`; each compiled with or without `Regexp::EXTENDED` and matched against one of 35 subjects, compared as `MatchData#to_a` and `Regexp#names`. A pattern both sides refuse compares as equal whatever the message.

| | patterns |
|---|---:|
| same on master and here | 97,317 |
| master differs from CRuby, this PR agrees | 782 |
| both differ from CRuby | 1,889 |
| master agrees with CRuby, this PR differs | 12 |

Of the 782, 481 are patterns master refused as a quantifier with no target, having made an interval of a `{1, 2}` with nothing before it or removed a vertical tab before a quantifier, 293 are answers that change (a blank inside a name, `\k <`, a vertical tab, `( ?`), and 8 are `\u#c` and `\x#c` under `/x`. Of the 1,889, 1,533 are a `\1` that names no group, which this engine accepts and CRuby rejects, 160 are a repeat of a repeat, which this engine refuses and CRuby accepts, 151 are a `[` inside a class, and 42 are answers that differ on master as well (an inline toggle before a `|`, `a(?i)|b`, which Onigmo scopes over the alternation and this engine does not; `\b` at a non-ASCII word character; `{n}?`, which Onigmo reads as an optional repeat); none is new. All 12 where only this PR differs are `{1, 2}` before a `\1` with no group: master stopped at the interval, this PR reads it as CRuby does and reaches the `\1`.

**`rake test`**, `build_config/ci/gcc-clang.rb`, no compiler warning:

| build | total | KO | crash |
|---|---:|---:|---:|
| `full-debug` | 2,363 | 0 | 0 |
| `bintest` | 2,363 | 0 | 0 |
| `bintest` (bintest suite) | 123 | 0 | 0 |
| `cxx_abi` | 2,363 | 0 | 0 |
| `byte-string` | 2,292 | 0 | 0 |
| `ascii-ctype` | 2,359 | 0 | 0 |

The default configuration: 2,138 total, 0 KO, 0 crash, plus its 112 bintests.

### Environment

<details>
<summary>Machine, toolchain, and the compile line of every build</summary>

| Item | Value |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS |
| Kernel | 7.0.0-29-generic |
| CPU | AMD Ryzen 9 5950X 16-Core Processor |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0 |
| binutils | GNU ld (GNU Binutils) 2.47.20260726 |
| rake | rake, version 13.3.1 |
| CRuby (reference) | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |

Actual compile line of `mrbgems/mruby-regexp/src/re_compile.c` in each `build_config/ci/gcc-clang.rb` build (`-MMD -c`, `-I`, and `-o` dropped). `full-debug` is `-O0` because `enable_debug` appends `-g3 -O0` after the toolchain's `-g -O3`; `cxx_abi` compiles C as C++ with `gcc -x c++ -std=gnu++03`, g++ only links.

```console
# full-debug
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-regexp/src/re_compile.c
# bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK mrbgems/mruby-regexp/src/re_compile.c
# cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-regexp/src/re_compile.c
# byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-regexp/src/re_compile.c
# ascii-ctype
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-regexp/src/re_compile.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved extended-mode regular expressions so whitespace is handled correctly between tokens without altering spaces inside intervals, group names, or Unicode codepoint lists.
  - Improved handling of comments, escapes, quantifiers, character classes, named groups, and scoped options.
  - Corrected jump and lookaround positioning after pattern processing.
  - Improved error messages to reference the original regular expression accurately.
  - Preserved source comments and newlines when recompiling extended regular expressions.

- **Tests**
  - Added regression coverage for extended-mode parsing, escapes, Unicode patterns, POSIX brackets, character classes, and error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
