### PR TITLE
mruby-regexp: undo what a lookaround captured when the match backtracks past it

### DIFF
--- a/mrbgems/mruby-regexp/include/re_internal.h
+++ b/mrbgems/mruby-regexp/include/re_internal.h
@@ -47,6 +47,12 @@ enum re_opcode {
                         backtracking into it. */
   RE_ATOMIC_END,     /* end of an atomic group's body: offset = the number of
                         the RE_ATOMIC it closes */
+  RE_LOOK_END,       /* end of a lookaround's sub-pattern: offset = the
+                        lookaround's number, from the same count as RE_ATOMIC;
+                        a = 1 for a negative one. The instruction after it is
+                        the text after the lookaround, which is where the
+                        opener's `offset` points, so the opener finds its end
+                        at offset - 1. */
 };
 
 /* Bytecode instruction (4 bytes each for alignment) */

--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -57,9 +57,10 @@ typedef struct {
   uint16_t num_groups;      /* groups opened so far, counting the plain ones a
                                named pattern demotes: what decides whether
                                `\NN` is a backreference or an octal escape */
-  uint32_t num_cuts;        /* atomic groups numbered so far, the possessive
-                               repeats among them: each takes the next number,
-                               so no two that nest share one; see RE_ATOMIC */
+  uint32_t num_cuts;        /* atomic groups and lookarounds numbered so far,
+                               the possessive repeats among them: each takes
+                               the next number, so no two that nest share one;
+                               see RE_ATOMIC and RE_LOOK_END */
   uint32_t atom_start;      /* where the atom a quantifier binds to begins;
                                compile_quantified sets it to the position
                                before the atom, and a `\u{...}` list moves it
@@ -1154,7 +1155,7 @@ compute_fixed_len(re_compiler *c, uint32_t start, uint32_t end, int *chars_out)
       /* For simplicity, reject alternation in lookbehind */
       return -1;
     }
-    case RE_MATCH:
+    case RE_LOOK_END:
       *chars_out = chars;
       return len;
     default:
@@ -1335,6 +1336,19 @@ emit_codepoint(re_compiler *c, uint32_t cp)
    number/name` for one within it that names no group. */
 #define RE_MAX_BACKREF_NUM 2147483647
 
+/* Compile the sub-pattern of a lookaround, whose opener has just been
+   emitted, up to and including the RE_LOOK_END that closes it. The end
+   carries the lookaround's number, from the count the atomic groups use, so
+   that a cut aimed at this lookaround is told from one aimed at a group
+   around or inside it; see bt_match(). */
+static void
+compile_look_body(re_compiler *c, mrb_bool negative)
+{
+  uint16_t cut = (uint16_t)++c->num_cuts;
+  compile_alt(c);
+  emit(c, RE_LOOK_END, negative, cut);
+}
+
 /* Compile a single atom (character, class, group, etc.) */
 static void
 compile_atom(re_compiler *c)
@@ -1365,8 +1379,7 @@ compile_atom(re_compiler *c)
           mrb_bool negative = (c->p[1] == '!');
           next_char(c); next_char(c);  /* skip ?= or ?! */
           uint32_t la_pos = emit(c, negative ? RE_NEG_LOOKAHEAD : RE_LOOKAHEAD, 0, 0);
-          compile_alt(c);
-          emit(c, RE_MATCH, 0, 0);  /* end of lookahead sub-pattern */
+          compile_look_body(c, negative);
           c->pat->code[la_pos].offset = (uint16_t)c->code_len;  /* patch: skip past sub-pattern */
           if (peek(c) != ')') compile_error(c, "unmatched '('");
           next_char(c);
@@ -1381,8 +1394,7 @@ compile_atom(re_compiler *c)
           uint32_t lb_pos = emit(c, negative ? RE_NEG_LOOKBEHIND : RE_LOOKBEHIND, 0, 0);
           emit(c, RE_LB_WIDTH, 0, 0);
           uint32_t sub_start = c->code_len;
-          compile_alt(c);
-          emit(c, RE_MATCH, 0, 0);
+          compile_look_body(c, negative);
           c->pat->code[lb_pos].offset = (uint16_t)c->code_len;
 
           /* measure the sub-pattern for both rewind units */

--- a/mrbgems/mruby-regexp/src/re_exec.c
+++ b/mrbgems/mruby-regexp/src/re_exec.c
@@ -632,8 +632,10 @@ lookbehind_start(const mrb_regexp_pattern *pat, const char *str,
    group's body may be tried for it, so the frames between that end and the
    RE_ATOMIC that opened the group hand BT_CUT of the group's number up
    unchanged, undoing their captures as they go, and the frame that ran that
-   RE_ATOMIC turns it into BT_FAIL. A cut never reaches a lookaround from
-   inside its sub-pattern: the RE_ATOMIC that absorbs it is in there too.
+   RE_ATOMIC turns it into BT_FAIL. A lookaround runs its sub-pattern the
+   same way, the text after it going on inside the sub-pattern's frames from
+   the RE_LOOK_END (see there), so a cut can pass through one; the opener
+   absorbs its own number like an RE_ATOMIC and hands any other up.
    The fourth answer, BT_LIMIT, is a frame giving up at the recursion or step
    limit. A frame that gets it hands it up; a SPLIT takes it as that branch
    failing and answers with its other branch, as it would with a failure.
@@ -658,19 +660,45 @@ typedef struct {
   int *captures;
   int ncap;
   int steps;
-  /* Per pc, the offset the running iteration of the loop that pc keys began
-     at, or -1 while none is running. A repetition whose body can match empty
-     has to stop once an iteration ends where it began, or it would go round
-     at the same position until a limit refused it and answer with whatever
-     the alternatives left inside the limit produce. Onigmo stops it with a
-     null check around the body; this array is that check's memory. The pc
-     that keys a loop is its marked head for e* (the SPLIT/SPLITNG whose
-     offset is the exit; the JMP closing the body reads the record) and its
-     marked back edge for e+ (the SPLIT/SPLITNG at the end of the body, which
-     both writes and reads it); see mark_empty_loops(). */
-  int *iter_at;
+  /* Per pc, the offset the frame that pc keys was entered at, or -1 while
+     none is running; what a record means is what its pc is. For the edge of
+     a repetition whose body can match empty it is where the running
+     iteration began: such a repetition has to stop once an iteration ends
+     where it began, or it would go round at the same position until a limit
+     refused it and answer with whatever the alternatives left inside the
+     limit produce. Onigmo stops it with a null check around the body; this
+     array is that check's memory. The pc that keys a loop is its marked head
+     for e* (the SPLIT/SPLITNG whose offset is the exit; the JMP closing the
+     body reads the record) and its marked back edge for e+ (the
+     SPLIT/SPLITNG at the end of the body, which both writes and reads it);
+     see mark_empty_loops(). For the RE_LOOK_END of a lookaround it is where
+     the lookaround was entered, which is where the text after it goes on
+     from; see bt_look(). */
+  int *entered_at;
+  /* Per pc, the pass that wrote entered_at[pc]. A pass is one run of a
+     lookaround's sub-pattern, told by the depth of the bt_look() frame
+     running it, and 0 is the pattern outside every lookaround; `pass` is the
+     one the frames now running are in. A record is read as the running
+     iteration's only by the pass that wrote it: the text after a positive
+     lookaround runs inside its sub-pattern's frames (see RE_LOOK_END), so a
+     repetition around the lookaround re-enters the sub-pattern while the
+     records of the loops inside it from the pass before are still live, and
+     the first iteration of an e+, which reads its record without having
+     written it, would take one of those for its own where the positions
+     coincide: `(?=(b|)+)+` on "b" re-enters at 0 while the pass before left
+     1 for `(b|)+`, and its first iteration, ending at 1, would stop there
+     with "b" captured, where a fresh pass goes round once more and leaves
+     "". For the RE_LOOK_END the record is the pass the lookaround was entered
+     from, which the text after it runs in. */
+  int *entered_in;
+  int pass;
   mrb_bool binary;
 } bt_state;
+
+/* Whether the loop `key` keys is at the end of an iteration that began at
+   sp: the record is this pass's and names sp. */
+#define ITER_EMPTY(m, key, sp) \
+  ((m)->entered_at[key] == (int)((sp) - (m)->str) && (m)->entered_in[key] == (m)->pass)
 
 static int bt_match(bt_state *m, const char *sp, uint32_t pc, int depth);
 
@@ -684,11 +712,52 @@ static int bt_match(bt_state *m, const char *sp, uint32_t pc, int depth);
 static int
 bt_iter(bt_state *m, const char *sp, uint32_t pc, uint32_t key, int depth)
 {
-  int old = m->iter_at[key];
-  m->iter_at[key] = (int)(sp - m->str);
+  int old_at = m->entered_at[key], old_in = m->entered_in[key];
+  m->entered_at[key] = (int)(sp - m->str);
+  m->entered_in[key] = m->pass;
   int r = bt_match(m, sp, pc, depth);
-  m->iter_at[key] = old;
+  m->entered_at[key] = old_at;
+  m->entered_in[key] = old_in;
   return r;
+}
+
+/* Run the sub-pattern of the lookaround whose opener is at pc: it begins at
+   `body` and matches from `from`, which is sp for a lookahead and the
+   rewound start for a lookbehind. The record of sp, and of the pass the
+   lookaround is entered from, lasts as long as the frame, as an iteration's
+   does in bt_iter(); the RE_LOOK_END closing the sub-pattern reads it (see
+   there). The sub-pattern runs as a pass of its own, this frame's depth,
+   which no pass still live has, so the records of the loops inside it that
+   another run of the same sub-pattern may have left live are not taken for
+   this run's (see bt_state).
+
+   The answer is the sub-pattern's, and the cut of this lookaround's number
+   is what the sub-pattern matching comes back as: for a negative lookaround
+   from the RE_LOOK_END itself, and the answer is BT_MATCH, with every
+   capture the sub-pattern wrote undone on the way up; for a positive one
+   from the text after the lookaround failing, which the RE_LOOK_END ran
+   inside the sub-pattern's frames, so the sub-pattern matched once and that
+   was its only match: BT_FAIL, the captures undone the same way. BT_MATCH
+   from a positive one is the whole pattern having matched through that
+   text. Everything else, a failure, a limit or another group's cut, goes up
+   as it is. */
+static int
+bt_look(bt_state *m, const char *sp, const char *from, uint32_t pc,
+        uint32_t body, int depth)
+{
+  uint32_t end = m->pat->code[pc].offset - 1;
+  re_inst end_inst = m->pat->code[end];
+  int old_at = m->entered_at[end], old_in = m->entered_in[end];
+  int old_pass = m->pass;
+  m->entered_at[end] = (int)(sp - m->str);
+  m->entered_in[end] = old_pass;
+  m->pass = depth;
+  int r = bt_match(m, from, body, depth);
+  m->pass = old_pass;
+  m->entered_at[end] = old_at;
+  m->entered_in[end] = old_in;
+  if (r != BT_CUT(end_inst.offset)) return r;
+  return end_inst.a ? BT_MATCH : BT_FAIL;
 }
 
 /*
@@ -755,12 +824,12 @@ bt_match(bt_state *m, const char *sp, uint32_t pc, int depth)
 
     case RE_JMP:
       /* A backward jump closes e* and returns to its head. When the head is
-         marked, the body can match empty and iter_at[head] holds where the
+         marked, the body can match empty and entered_at[head] holds where the
          iteration that just ended began (see bt_iter()): an iteration that
          ended where it began matched empty, and the repetition stops here,
          taking the head's exit and keeping what the iteration captured, as
          Onigmo's null check does. */
-      if (inst.a && m->iter_at[inst.offset] == (int)(sp - str)) {
+      if (inst.a && ITER_EMPTY(m, inst.offset, sp)) {
         pc = pat->code[inst.offset].offset;
         break;
       }
@@ -780,7 +849,7 @@ bt_match(bt_state *m, const char *sp, uint32_t pc, int depth)
           pc = inst.offset;
           break;
         }
-        if (m->iter_at[pc] == (int)(sp - str)) { pc++; break; }
+        if (ITER_EMPTY(m, pc, sp)) { pc++; break; }
         int r = bt_match(m, sp, pc + 1, depth + 1);
         if (r != BT_FAIL && r != BT_LIMIT) return r;
         return bt_iter(m, sp, inst.offset, pc, depth + 1);
@@ -803,7 +872,7 @@ bt_match(bt_state *m, const char *sp, uint32_t pc, int depth)
           if (r != BT_FAIL && r != BT_LIMIT) return r;
           return bt_iter(m, sp, pc + 1, pc, depth + 1);
         }
-        if (m->iter_at[pc] == (int)(sp - str)) { pc++; break; }
+        if (ITER_EMPTY(m, pc, sp)) { pc++; break; }
         int r = bt_iter(m, sp, inst.offset, pc, depth + 1);
         if (r != BT_FAIL && r != BT_LIMIT) return r;
         pc++;
@@ -910,21 +979,19 @@ bt_match(bt_state *m, const char *sp, uint32_t pc, int depth)
       break;
 
     case RE_LOOKAHEAD:
-      {
-        /* A sub-pattern answers BT_MATCH, BT_FAIL or BT_LIMIT, never a cut.
-           The two failures go up as they are; the four lookarounds only
-           differ in what a match means. */
-        int r = bt_match(m, sp, pc + 1, depth + 1);
-        if (r != BT_MATCH) return r;
-        pc = inst.offset;
-      }
-      break;
+      /* A positive lookaround never goes on in this frame: its RE_LOOK_END
+         has run the text after it, so the sub-pattern's answer is the
+         frame's, whichever it is. */
+      return bt_look(m, sp, sp, pc, pc + 1, depth + 1);
 
     case RE_NEG_LOOKAHEAD:
       {
-        int r = bt_match(m, sp, pc + 1, depth + 1);
+        /* The sub-pattern matching is the assertion failing; the sub-pattern
+           running out of alternatives is the assertion holding, and the text
+           after it goes on here. A limit goes up as it is. */
+        int r = bt_look(m, sp, sp, pc, pc + 1, depth + 1);
         if (r == BT_MATCH) return BT_FAIL;
-        if (r == BT_LIMIT) return r;
+        if (r != BT_FAIL) return r;
         pc = inst.offset;
       }
       break;
@@ -933,24 +1000,43 @@ bt_match(bt_state *m, const char *sp, uint32_t pc, int depth)
       {
         const char *back = lookbehind_start(pat, str, str_end, sp, pc, binary);
         if (!back) return BT_FAIL;  /* not enough text before */
-        int r = bt_match(m, back, pc + 2, depth + 1);
-        if (r != BT_MATCH) return r;
-        pc = inst.offset;
+        return bt_look(m, sp, back, pc, pc + 2, depth + 1);
       }
-      break;
 
     case RE_NEG_LOOKBEHIND:
       {
         const char *back = lookbehind_start(pat, str, str_end, sp, pc, binary);
         if (back) {
-          int r = bt_match(m, back, pc + 2, depth + 1);
+          int r = bt_look(m, sp, back, pc, pc + 2, depth + 1);
           if (r == BT_MATCH) return BT_FAIL;
-          if (r == BT_LIMIT) return r;
+          if (r != BT_FAIL) return r;
         }
         /* if not enough text before, negative lookbehind succeeds */
         pc = inst.offset;
       }
       break;
+
+    case RE_LOOK_END:
+      {
+        /* The sub-pattern has matched. For a negative lookaround that is
+           the whole of its answer, and it goes up as a cut so that the
+           frames of the sub-pattern undo their captures and try no other
+           branch on the way; bt_look() reads it back as the match it is.
+           For a positive one the text after the lookaround goes on from
+           where the lookaround was entered, inside the sub-pattern's frames
+           as the text after an atomic group does (RE_ATOMIC_END): a failure
+           there is a cut, undone for and not backtracked into, since the
+           sub-pattern matching once is its only match. A limit goes up as
+           it is. The text after runs in the pass the lookaround was entered
+           from, which is what its loops' records are keyed by; the pass of
+           this sub-pattern comes back for the frames above on the way up. */
+        if (inst.a) return BT_CUT(inst.offset);
+        int pass = m->pass;
+        m->pass = m->entered_in[pc];
+        int r = bt_match(m, str + m->entered_at[pc], pc + 1, depth + 1);
+        m->pass = pass;
+        return (r == BT_FAIL) ? BT_CUT(inst.offset) : r;
+      }
 
     case RE_ATOMIC:
       {
@@ -990,19 +1076,23 @@ backtrack_exec(mrb_state *mrb, const mrb_regexp_pattern *pat,
   int ncap = pat->num_captures * 2;
   if (ncap == 0) ncap = 2;
 
-  /* One block: the capture slots, then an iteration record per pc. Every
-     record a search writes it undoes before returning (see bt_iter()), so
-     the array is filled once for all start positions. */
-  int *caps = (int*)mrb_malloc(mrb, sizeof(int) * (ncap + pat->code_len));
+  /* One block: the capture slots, then an entry record per pc and the pass
+     that wrote it. Every record a search writes it undoes before returning
+     (see bt_iter() and bt_look()), so the arrays are filled once for all
+     start positions. */
+  int *caps = (int*)mrb_malloc(mrb, sizeof(int) * (ncap + 2 * pat->code_len));
   bt_state m;
   m.pat = pat;
   m.str = str;
   m.str_end = str_end;
   m.captures = caps;
   m.ncap = ncap;
-  m.iter_at = caps + ncap;
+  m.entered_at = caps + ncap;
+  m.entered_in = m.entered_at + pat->code_len;
+  m.pass = 0;
   m.binary = binary;
-  memset(m.iter_at, -1, sizeof(int) * pat->code_len);
+  memset(m.entered_at, -1, sizeof(int) * pat->code_len);
+  memset(m.entered_in, 0, sizeof(int) * pat->code_len);
 
   for (const char *sp = str + start; sp <= str_end && sp <= start_cap; sp++) {
     /* Skip ahead using literal prefix or first-byte bitmap */

--- a/mrbgems/mruby-regexp/test/regexp_syntax.rb
+++ b/mrbgems/mruby-regexp/test/regexp_syntax.rb
@@ -1548,6 +1548,63 @@ assert("Regexp - negative lookbehind at string start") do
   assert_equal "a", md[0]
 end
 
+assert("Regexp - a capture inside a lookaround is undone with the lookaround") do
+  # A lookaround's sub-pattern used to run in a call of its own, so once it
+  # had matched, the frames that could undo what it captured were gone, and
+  # backtracking past the lookaround left the capture written. A plain
+  # group's frames stay while the text after it runs, and undo.
+  assert_nil /(?:(a)b|)/.match("a")[1]
+  assert_nil /(?:(?=(a))b|)/.match("a")[1]
+  assert_nil /(?=(a))b|/.match("a")[1]
+  assert_nil /(?:(?=(a))b)?/.match("a")[1]
+  assert_nil /(?:(?=(a))b)*/.match("a")[1]
+  assert_nil /(?:(?<=(a))b|)c/.match("ac")[1]
+  # A negative lookaround's sub-pattern matching is the assertion failing,
+  # and what it captured on the way is undone with it.
+  assert_nil /(?!(a))|/.match("a")[1]
+  assert_nil /(?!(a))*/.match("a")[1]
+  assert_nil /(?!(a))?/.match("a")[1]
+  assert_equal ["a", nil], /(?!(a)b)a\1?/.match("ac").to_a
+  # A backreference to the leaked group consumed text, and the match itself
+  # changed.
+  assert_nil /(?:(?=(a))b|)\1/ =~ "aa"
+  assert_nil /(?:(?!(a))|a)\1/ =~ "aa"
+  assert_equal "ab", /(?:(?!(a))|a)\1?b/.match("aab")[0]
+  assert_nil /(?:(?=(a))a|b)\1/ =~ "ba"
+  # What a lookaround that holds captured stays, as before.
+  assert_equal "a", /(?=(a))a/.match("a")[1]
+  assert_equal ["b", "a"], /(?<=(a))b/.match("ab").to_a
+  assert_equal ["ab", "a"], /(?=(a|ab))\1b/.match("abb").to_a
+  # A positive lookaround's sub-pattern matches once: the text after it
+  # failing does not send it back for another branch, as in Onigmo.
+  assert_nil /(?=(a|ab))\1c/ =~ "abc"
+  assert_equal ["abc", nil], /(?:(?=(a|ab))\1c|abc)/.match("abc").to_a
+  # The text after a lookaround runs inside its sub-pattern's frames, so
+  # an atomic group's cut from that text passes through the lookaround on
+  # its way to the group, and the lookaround does not absorb it as its own.
+  assert_nil /(?>(?=a)ab|a)b/ =~ "ab"
+  assert_nil /(?>(?!x)ab|a)b/ =~ "ab"
+  assert_equal 0, /(?>(?=a)ab|a)c/ =~ "abc"
+  # A possessive repeat wrapped around a lookaround is numbered apart from
+  # it, as from an atomic group, so its cut is not read as the lookaround's.
+  assert_nil /(?:(?=a)a)?+a/.match("a")
+  assert_nil /(?:(?=a)a)*+a/.match("aa")
+  assert_nil /(?:a(?<=a))?+a/.match("a")
+  assert_nil /(?:(?!b)a)?+a/.match("a")
+  assert_equal 0, /(?:(?=a)a)?+b/ =~ "ab"
+  # A repeat around a positive lookaround re-enters its sub-pattern while
+  # the frames of the run before are still up, so a loop inside it starts
+  # over with the record of where the run before left off still live; the
+  # first iteration of an e+ reads that record without having written it,
+  # and must not take it for its own: `(b|)+` on "b" goes round twice, and
+  # the empty second time is what it leaves in the group.
+  assert_equal ["", ""], /(?=(b|)+)+/.match("b").to_a
+  assert_equal ["", ""], /(?=(b|)+a)+/.match("ba").to_a
+  assert_equal ["", ""], /(?=(b|)+)+\1/.match("b").to_a
+  assert_equal ["", "", ""], /(?=(b|)+(?=(a|)+))+/.match("ba").to_a
+  assert_equal ["", ""], /(?=(a|)+)++/.match("abab").to_a
+end
+
 assert("Regexp - lookbehind over a class that can match a multibyte character") do
   # A class consumes exactly one character whatever its members are, so the
   # rewind steps back that many characters rather than assuming a byte each.


### PR DESCRIPTION
Stacked on #7276, which numbers atomic groups instead of giving them a nesting depth: the first commit here is that PR's, and the second is this one. The review of the first version found that a possessive repeat wrapped around a lookaround shared the lookaround's depth, and #7276 is what tells them apart, for a lookaround here as for an atomic group on master. The second revision adds one thing to the fix: a repeat around a positive lookaround re-enters its sub-pattern while the frames of the run before are still up, and a loop inside the sub-pattern could take the run before's record for its own (`/(?=(b|)+)+/` on `"b"` answered `["", "b"]`); the entry records now name the pass that wrote them (the last bullet of the fix). The tests and the differential section cover it, the latter with #7275 merged as well, since the shape mostly sits behind master's refusal of a quantified empty group. The rest is as reviewed.

`bt_match()` runs a lookaround's sub-pattern in a call of its own. The
sub-pattern ends in `RE_MATCH` and answers `BT_MATCH`, so every `RE_SAVE`
frame on that path returns with its write kept (a write is undone for any
answer other than `BT_MATCH`), and the frame that ran the opener goes on with
`pc = inst.offset` in place. From then on the frames that could undo the
sub-pattern's writes are gone: when the text after the lookaround fails and
the engine backtracks past it, nothing undoes what the sub-pattern captured.
A plain group undoes, because its `RE_SAVE` frames are still on the stack
while the text after it runs:

```ruby
/(?:(a)b|)/.match("a")[1]         # nil in both
/(?:(?=(a))b|)/.match("a")[1]     # CRuby: nil,   mruby: "a"
/(?=(a))b|/.match("a")[1]         # CRuby: nil,   mruby: "a"
/(?:(?=(a))b)?/.match("a")[1]     # CRuby: nil,   mruby: "a"
/(?:(?=(a))b)*/.match("a")[1]     # CRuby: nil,   mruby: "a"
```

A negative lookaround leaks the same way one step earlier: `RE_NEG_LOOKAHEAD`
and `RE_NEG_LOOKBEHIND` turn the sub-pattern's `BT_MATCH` into `BT_FAIL` and
return, and the writes stay:

```ruby
/(?!(a))|/.match("a")[1]          # CRuby: nil,   mruby: "a"
/(?!(a))*/.match("a")[1]          # CRuby: nil,   mruby: "a"
/(?!(a))?/.match("a")[1]          # CRuby: nil,   mruby: "a"
```

A backreference to the leaked group then consumes text, and the match itself
changes:

```ruby
/(?:(?=(a))b|)\1/ =~ "aa"                # CRuby: nil,   mruby: 0
/(?:(?!(a))|a)\1/ =~ "aa"                # CRuby: nil,   mruby: 0
/(?:(?!(a))|a)\1?b/.match("aab")[0]      # CRuby: "ab",  mruby: "aab"
```

The sub-pattern failing was handled: `/(?:(?=(a)b)|)\1/ =~ "ac"` is nil in
both, since there the `RE_SAVE` frames undid on the way up. The leak surfaced
in the differential run for #7269: on master a repetition of such a
lookaround ran to the recursion limit and failed outright, and with the
empty-iteration stop the loop stops, the match goes on, and the leaked
capture is what gets read. The engine was already wrong on master for the
shapes above; #7269 reaches more of them.

## The fix

Run the text after the lookaround while the sub-pattern's frames are still on
the stack, which is what `RE_ATOMIC` and `RE_ATOMIC_END` already do for
`(?>...)` (#7256): the body runs on through its end into the text after the
group inside the same call chain, and a failure there comes back as
`BT_CUT(number)`, which every `RE_SAVE` on the way undoes for, every `RE_SPLIT`
passes up without trying its other branch, and the `RE_ATOMIC` of that number
turns into `BT_FAIL`. A lookaround is that group with two differences, where
the text after it starts from and what the sub-pattern reaching its end
means, so it reuses the machinery rather than adding a second way to undo:

- `compile_look_body()` ends the sub-pattern with `RE_LOOK_END` instead of
  `RE_MATCH`. The end carries the lookaround's number from the count
  `(?>...)` takes its numbers from, `num_cuts`, so that a cut is keyed to the
  one construct that absorbs it however groups and lookarounds nest, and
  `a = 1` for a negative one. The opener's `offset` is patched to the instruction
  after the end as before, so the opener finds its end at `offset - 1` and
  the end needs no operand for the text after it.
- Every opener runs its sub-pattern through `bt_look()`, which records the
  position the lookaround was entered at (for a lookbehind that is `sp`, not
  the rewound start) in the entry record of the `RE_LOOK_END`, kept for as
  long as the frame runs the way `bt_iter()` keeps an iteration's start. The
  per-pc array is the one `bt_iter()` writes, renamed from `iter_at` to
  `entered_at`: what a record means is now which pc keys it, a loop edge's
  being where the running iteration began and a lookaround end's where the
  lookaround was entered.
- The end of a positive sub-pattern reads that record and runs the text after
  the lookaround from there in a sub-call. `BT_MATCH` goes up with the
  captures kept (`/(?=(a))a/.match("a")[1]` is `"a"` in CRuby too);
  `BT_FAIL` becomes `BT_CUT(number)`, so the sub-pattern's `RE_SAVE` frames
  undo on the way up and no alternative inside it is retried, which is the
  atomic answer the separate call gave before; a limit and another group's
  cut go up as they are.
- The end of a negative sub-pattern answers `BT_CUT(number)` outright: the
  frames above undo their writes and try no other branch, and `bt_look()`
  hands the opener the `BT_MATCH` the sub-pattern's match is, its captures
  unset by then, which is what CRuby reports for a group inside a negative
  lookaround. The sub-pattern running out of alternatives is `BT_FAIL`, the
  assertion holding, and the opener goes on with `pc = inst.offset` in place
  as before.
- Each record also names the pass that wrote it, in a second per-pc array,
  `entered_in`. A pass is one run of a lookaround's sub-pattern, told by the
  depth of the `bt_look()` frame running it, which no other frame on the
  stack has since every call goes a level deeper, and 0 is the pattern
  outside every lookaround. `bt_iter()` writes the running pass beside the
  position, and a loop edge reads a record as its iteration's only when the
  pass is its own. What this is for: the text after a positive lookaround
  runs inside the sub-pattern's frames, so a repeat around the lookaround
  re-enters the sub-pattern while the records of the loops inside it from
  the run before are still live, and the first iteration of an `e+`, which
  reads its record without having written it, would take one of those for
  its own where the positions coincide. `/(?=(b|)+)+/` on `"b"` re-enters at
  0 while the run before left 1 for `(b|)+`, and its first iteration, ending
  at 1, would stop there with `"b"` in the group, where CRuby goes round once
  more and leaves `""`. The `RE_LOOK_END` runs the text after the lookaround
  in the pass the lookaround was entered from, kept in the end's record too,
  so the loops around a lookaround key their records by one pass throughout.
  Master is not open to this: its opener runs the sub-pattern to `RE_MATCH`
  and returns, so the records inside are restored before the repeat comes
  round; and a negative lookaround here is not either, its end cutting the
  sub-pattern's frames at once.

The comment above the `BT_*` codes said a cut never reaches a lookaround from
inside its sub-pattern. With the text after the lookaround running inside the
sub-pattern's frames it does: `/(?>(?=a)ab|a)b/` on `"ab"` sends the atomic
group's cut up through the lookaround's end, its sub-pattern's frames and its
opener, and the opener has to pass it up because the number is not its own,
or the group's other branch would be tried after the cut. That is why the
number is one count with `(?>...)`, and a possessive repeat wrapped around a
lookaround takes a number of its own from it, as it does around an atomic
group (#7276): `/(?:(?=a)a)?+a/ =~ "a"` is nil, as in CRuby. `compute_fixed_len()` looked for
`RE_MATCH` as the end of a lookbehind's sub-pattern and looks for
`RE_LOOK_END` now; the `RE_MATCH` ending the whole pattern is untouched, and
the Pike VM runs no pattern with a lookaround in it.

The text after a positive lookaround now runs as many frames deeper as the
sub-pattern took plus two, where before it ran in the opener's frame, so a
repetition of a lookaround reaches `MRB_REGEXP_RECURSION_LIMIT` in fewer
iterations: `/(?:(?=a)a)*/` against 2,000 `a`s stops at 332 iterations, where
it stopped at 998 before and `(?:(?>a))*` already stopped at 332; CRuby
matches all 2,000. What the engine answers at the limit is the same question
as before, and not this one.

## Time

The `default` gembox at `-O3`, `Time.now` over `n` matches after three
warm-up calls, pinned to one core, mean of three runs each, master and this
PR alternated:

```ruby
CASES = [
  ["/\\d+(?!%)/ =~ '100%'",           200000, -> { /\d+(?!%)/ =~ "100%" }],
  ["/(?=(a|ab))\\1c/ =~ 'ab' * 50",   50000,  -> { /(?=(a|ab))\1c/ =~ "ab" * 50 }],
  # ...
]
CASES.each do |label, n, blk|
  3.times { blk.call }
  t0 = Time.now
  n.times { blk.call }
  puts "%-42s %10.3f us/iter" % [label, (Time.now - t0) / n * 1e6]
end
```

| match | master | this PR | |
|---|---:|---:|---:|
| `/\d+(?!%)/ =~ "100%"` | 1.22 us | 1.21 us | 1.01x |
| `/foo(?=bar)/ =~ "foobar"` | 1.18 us | 1.19 us | 0.99x |
| `/(?<=a)b+?/ =~ "ab" * 50` | 1.24 us | 1.24 us | 1.00x |
| `/(?<!x)a/ =~ "ab" * 50` | 1.20 us | 1.20 us | 1.00x |
| `/(?=(a))\1/ =~ "ab" * 50` | 1.27 us | 1.27 us | 1.00x |
| `/(?=a+b)a+/ =~ "a" * 20 + "b"` | 1.48 us | 1.56 us | 0.95x |
| `/(?!a+c)a+b/ =~ "a" * 20 + "b"` | 1.52 us | 1.55 us | 0.98x |
| `/(?:(?!b)a)*b/ =~ "a" * 20 + "b"` | 1.58 us | 1.60 us | 0.99x |
| `/(?:(?=a)a)*b/ =~ "a" * 20 + "b"` | 1.60 us | 1.75 us | 0.91x |
| `/(?=(a\|ab))\1c/ =~ "ab" * 50` | 3.39 us | 3.83 us | 0.89x |
| `/(?:(?=(a))b\|)\1/ =~ "aa"` | 1.23 us | 1.03 us | 1.19x |
| `/(a*)\1*b/ =~ "aab"` | 1.25 us | 1.24 us | 1.00x |
| `/(a\|b)*?c\1/ =~ "ab" * 50 + "cb"` | 4.02 us | 3.80 us | 1.06x |
| `/(?>a+)b/ =~ "a" * 20 + "b"` | 1.37 us | 1.38 us | 0.99x |
| `/(?:x?)*y??/ =~ "x" * 10` | 1.38 us | 1.37 us | 1.01x |
| `/a.*?b/ =~ "a" + "x" * 100 + "b"` (Pike VM) | 2.22 us | 2.25 us | 0.99x |

A lookaround that holds once and is followed by text that matches costs what
it did. The two rows that slow down are the ones the fix is about: a
lookaround whose sub-pattern matches and whose text after fails, once per
position for `/(?=(a|ab))\1c/` and once per iteration for `/(?:(?=a)a)*b/`
(the loop nests a frame deeper per iteration), where the failure now unwinds
through the sub-pattern's frames instead of returning from the opener's. The
`/(?:(?=(a))b|)\1/` row is faster because the backreference no longer finds a
leaked `"a"` to compare against. `/(?=a+b)a+/` pays for the second record
`bt_iter()` writes per iteration of the loop inside its sub-pattern. `/(a|b)*?c\1/`
runs no lookaround; its wall clock moves with code layout from build to build
(0.92x in the first revision's measurement, 1.06x here), and it executed 0.5%
fewer instructions under callgrind on the first revision.

## Size

`.text` of `bin/mruby`, `build_config/ci/gcc-clang.rb`, each side from a clean
build directory; the `#7276` column is the base this stacks on. `re_exec.o`
and `re_compile.o` are the objects that change. `re_exec.o` shrinks by 4,208
in `bintest`: on master gcc emits `bt_match()` twice, once as a `constprop`
clone for the top-level call with `pc` and `depth` 0, and here it emits it
once with `bt_iter()` and `bt_look()` inlined into it; `re_compile.o` grows
by 128 over #7276 for `compile_look_body()`.

| build | master | #7276 | this PR | delta over #7276 |
|---|---:|---:|---:|---:|
| `bintest` | 1,281,398 | 1,281,318 | 1,277,238 | -4,080 |
| `ascii-ctype` | 1,269,286 | 1,269,158 | 1,265,062 | -4,096 |
| `byte-string` | 1,251,142 | 1,251,094 | 1,246,342 | -4,752 |
| `cxx_abi` | 1,306,873 | 1,306,841 | 1,302,473 | -4,368 |
| `full-debug` (`-O0`) | 1,881,126 | 1,881,094 | 1,882,022 | +928 |

## Verification

The tests go in `regexp_syntax.rb` beside the lookaround tests: the examples
above for each of the four lookarounds, a backreference reading the leaked
group, the captures a lookaround that holds keeps, the atomic answer of a
positive lookaround (`/(?=(a|ab))\1c/ =~ "abc"` is nil in both), and the cut
of an atomic group passing through a lookaround on its way to the group,
a possessive repeat wrapped around each kind of lookaround, which cuts as a
group of its own, and a repeat re-entering a positive lookaround whose
sub-pattern holds a loop (`/(?=(b|)+)+/` and four more shapes, with text
after the loop, a backreference, a nested lookahead and a possessive repeat).
Twelve of the assertions fail on master, the possessive ones on the first
revision of this PR, and the re-entering ones on the second.

**Differential against CRuby 4.0.6**, master and this PR against the same
cases. 10,000 random patterns over `a`, `b`, `a?`, `b?`, `[ab]?`, `\w?`,
`(?:)`, `(a|)`, `(|b)`, `(?:a|)`, the four lookarounds, the two lookaheads
also with a capture inside, backreferences, plain, non-capturing and atomic
groups, possessive repeats and alternation, groups nested up to two deep,
every atom quantified with probability 0.5, each run with `match` against one
subject over `a` and `b` and compared as `MatchData#to_a`. 1,592 of the
patterns both sides refuse to compile (a quantifier on an empty group, which
#7275 lets through) and 2 CRuby cannot finish under a memory cap; the rest
compare:

| | lines |
|---|---:|
| compared | 8,406 |
| same on master and here | 8,293 |
| master differs from CRuby, this PR agrees | 89 |
| both differ from CRuby | 23 |
| master agrees with CRuby, this PR differs | 1 |

88 of the 89 have a capture inside a lookaround, and the 89th is
#7276's, a possessive repeat around an atomic group. The 1 line that only this
PR answers differently,
`/(?:((?:)(b|)++(?:)|\2??a)$??(?=[a](|a)\1*)??|(?:\2?+)[^a](?<=ab))+(?<=ab)(?<!bb)??/`
on `"baab"`, reduces to `/(?:((b|)++|a)(?=a(|a)\1*)??|b)+(?<=ab)/`: CRuby
reports group 3 as `""` at offset 2, written by the lazily optional lookahead
entered at 1, a position where the iteration matches empty; this engine stops
the repetition on that iteration and reports the match it goes on to find,
which never enters the lookahead, so the group is unset. Master agrees with
CRuby by leaking the group from an attempt it backtracked out of, and the
first revision answers as this one does. Of the 23 lines where both differ, 6
have a capture inside a lookaround, each in a pattern with a `{n}?` (which
this engine reads as a lazy `{n}`) or a repeat of a group that matches empty,
the standing differences the run for #7269 turned up.

A second run of 10,000 with the features narrowed to lookarounds, captures
inside them, backreferences, atomic groups and empty-matching atoms: 1,621
refused by both, 10 CRuby cannot finish, 8,369 compared, 162 lines master
differs on and this PR agrees, 7 both differ on (1 with a capture inside a
lookaround), 0 only this PR differs on. The first revision differs alone on 1
line of this run, `/(?=((?:b|)?(?:b|)+)+)+(?<!bb)/` on `"bbab"`, group 1
`"bb"` for CRuby's `""`, which is the re-entry the second revision fixes.

The re-entry mostly hides behind the refusals: a repeat around a positive
lookaround with a loop inside is what the generator draws with a `(?:)`
quantified, which master refuses, so the narrowed run above shows one line of
it and the full run none. With #7275 merged into both revisions, over the two
runs above and four more of 10,000 (seeds 4 to 7, the full feature set or the
narrowed one, one of them with possessive repeats), the first revision alone
differs from CRuby on 11 lines, `/(?=(a|)+)++/` on `"abab"` the shortest,
answering `["", "a"]` for `["", ""]`, and the second revision on none; the
lines where the merged builds of both revisions differ where master refuses
(3, 1, 3, 2, 3 and 18 per run) are the same on both and are #7275's reading
of a quantified empty group.

**`rake test`**, `build_config/ci/gcc-clang.rb`, no compiler warning:

| build | total | KO | crash |
|---|---:|---:|---:|
| `full-debug` | 2,366 | 0 | 0 |
| `bintest` | 2,366 | 0 | 0 |
| `bintest` (bintest suite) | 123 | 0 | 0 |
| `cxx_abi` | 2,366 | 0 | 0 |
| `byte-string` | 2,295 | 0 | 0 |
| `ascii-ctype` | 2,362 | 0 | 0 |

The default configuration: 2,141 total, 0 KO, 0 crash, plus its 112 bintests.

### Environment

<details>

| | |
|---|---|
| OS | Ubuntu 24.04, Linux 7.0.0 x86_64, AMD Ryzen 9 5950X |
| gcc | 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1) |
| binutils | 2.47 |
| CRuby | 4.0.6, for the differential |

Compile lines for `mrbgems/mruby-regexp/src/re_exec.c` in the builds quoted
above, paths shortened:

```
# ci/gcc-clang bintest
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK -I"include" -I"mrbgems/mruby-regexp/include" -I"build/bintest/include" -o "build/bintest/mrbgems/mruby-regexp/src/re_exec.o" "mrbgems/mruby-regexp/src/re_exec.c"

# ci/gcc-clang full-debug
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -I"include" -I"mrbgems/mruby-regexp/include" -I"build/full-debug/include" -o "build/full-debug/mrbgems/mruby-regexp/src/re_exec.o" "mrbgems/mruby-regexp/src/re_exec.c"

# ci/gcc-clang cxx_abi
gcc -MMD -c -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -I"include" -I"mrbgems/mruby-regexp/include" -I"build/cxx_abi/include" -o "build/cxx_abi/mrbgems/mruby-regexp/src/re_exec.o" "mrbgems/mruby-regexp/src/re_exec.c"

# ci/gcc-clang byte-string
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -I"include" -I"mrbgems/mruby-regexp/include" -I"build/byte-string/include" -o "build/byte-string/mrbgems/mruby-regexp/src/re_exec.o" "mrbgems/mruby-regexp/src/re_exec.c"

# ci/gcc-clang ascii-ctype
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -I"include" -I"mrbgems/mruby-regexp/include" -I"build/ascii-ctype/include" -o "build/ascii-ctype/mrbgems/mruby-regexp/src/re_exec.o" "mrbgems/mruby-regexp/src/re_exec.c"
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved regular-expression lookahead and lookbehind behavior during backtracking.
  * Fixed capture handling so failed or backtracked assertions no longer leave incorrect captures.
  * Improved interactions between lookarounds, atomic groups, possessive repeats, and backreferences.
  * Ensured nested atomic constructs operate independently and preserve expected matching behavior.
  * Fixed handling of quantifiers applied to empty-matching expressions.

* **Tests**
  * Added regression coverage for lookarounds, capture rollback, alternate branches, and possessive-repeat atomicity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->