### PR TITLE
mruby-regexp: speed up String#sub and #gsub

### DIFF
--- a/mrbgems/mruby-regexp/mrblib/string_regexp.rb
+++ b/mrbgems/mruby-regexp/mrblib/string_regexp.rb
@@ -16,9 +16,9 @@
 # With the type established, each override reaches the engine through class
 # methods that take the pattern as an argument (`Regexp.__search`,
 # `__byte_search`, `__byte_rsearch`, `__search_p`, `__sub_str`, `__gsub_str`,
-# `__scan`), so
+# `__sub_lit`, `__gsub_lit`, `__gsub_block`, `__scan`), so
 # nothing rewritten on the pattern instance is consulted on the way: the C
-# side searches, and the loops and blocks stay here.  The MatchData those
+# side searches, and what loops and blocks remain stay here.  The MatchData those
 # searches answer is built in C too, so what the overrides read from it
 # (`[]`, `pre_match`, `begin` and the rest) cannot have been planted by an
 # argument.  What remains reachable is a class-wide redefinition of a
@@ -97,31 +97,40 @@ class String
 
   def sub(*args, &block)
     # CRuby accepts 1..2 arguments with a block, but demands exactly 2
-    # without one, and reports the expected count accordingly.
+    # without one, and reports the expected count accordingly.  The count is
+    # read once and compared, rather than asked of a Range built for the
+    # question: this is the first thing every call does, and a Range costs an
+    # object and a call to answer what two comparisons answer.
+    argc = args.length
     if block
-      unless (1..2).include?(args.length)
-        raise ArgumentError, "wrong number of arguments (given #{args.length}, expected 1..2)"
+      unless argc == 1 || argc == 2
+        raise ArgumentError, "wrong number of arguments (given #{argc}, expected 1..2)"
       end
-    elsif args.length != 2
-      raise ArgumentError, "wrong number of arguments (given #{args.length}, expected 2)"
+    elsif argc != 2
+      raise ArgumentError, "wrong number of arguments (given #{argc}, expected 2)"
     end
-    pattern, replacement = *args
-    pattern = Regexp.__check_pattern(pattern)
+    pattern = Regexp.__check_pattern(args[0])
     # Unlike `match`, a String pattern is quoted rather than compiled: it is a
     # literal here, the distinction CRuby draws between get_pat_quoted and
     # get_pat.  Only the quoting is taken from it: get_pat_quoted also accepts
     # anything answering `to_str`, where `__check_pattern` keeps to a real
     # String, as `match` already does.
     literal = String === pattern
+    # A replacement argument wins over the block, as in CRuby.  A literal goes
+    # to `__sub_lit`, which searches for its bytes without compiling anything
+    # to search with.  What a compiled pattern would be needed for is the
+    # Regexp the `$~` it publishes names, and `MatchData#regexp` quotes that
+    # one where CRuby quotes it: on the first call that asks for it.
+    if argc == 2
+      replacement = args[1].to_s
+      return Regexp.__sub_lit(pattern, self, replacement) if literal
+      return Regexp.__sub_str(pattern, self, replacement)
+    end
     # CRuby searches for a literal byte by byte and never reads the subject as
     # UTF-8 on the way, so quoting one into a Regexp here must not put the
     # subject through a check CRuby does not make: `"a\x80b".sub("b", "!")`
     # answers there, where the same call with `/b/` is refused.
     pattern = Regexp.new(Regexp.escape(pattern)) if literal
-    # A replacement argument wins over the block, as in CRuby.
-    if args.length == 2
-      return Regexp.__sub_str(pattern, self, replacement.to_s, literal)
-    end
     md = Regexp.__search(pattern, self, 0, literal)
     return self.dup unless md
     md.pre_match + block.call(md[0]).to_s + md.post_match
@@ -133,22 +142,33 @@ class String
     # `"abc".freeze.sub!(:b, "X")` TypeError, while the two-argument form on
     # the same receiver raises FrozenError.  `gsub!` orders it the other way,
     # also as CRuby does.
+    argc = args.length
     if block
-      unless (1..2).include?(args.length)
-        raise ArgumentError, "wrong number of arguments (given #{args.length}, expected 1..2)"
+      unless argc == 1 || argc == 2
+        raise ArgumentError, "wrong number of arguments (given #{argc}, expected 1..2)"
       end
-    elsif args.length != 2
-      raise ArgumentError, "wrong number of arguments (given #{args.length}, expected 2)"
+    elsif argc != 2
+      raise ArgumentError, "wrong number of arguments (given #{argc}, expected 2)"
     end
     # Resolved here rather than left to `sub` because the match below decides
     # the return value, and a String pattern is a literal on both paths.
     pattern = Regexp.__check_pattern(args[0])
     literal = String === pattern
-    pattern = Regexp.new(Regexp.escape(pattern)) if literal
+    # Quoting the literal below raises nothing, so asking here is the order the
+    # original had: after the argument checks, before any search.
     raise FrozenError, "can't modify frozen String" if frozen?
     # Whether a substitution happened is a question about the match, not about
     # the result: `"aaa".sub!(/a/, "a")` returns self even though the string is
-    # unchanged.  A full search and not `match?`, so a failed match clears $~.
+    # unchanged.  The `bang` argument is that question asked of the one search
+    # `__sub_lit` already makes, so the literal path does not walk the subject
+    # twice to answer it; a failed search clears $~ there as `__search` does.
+    if literal && argc == 2
+      str = Regexp.__sub_lit(pattern, self, args[1].to_s, true)
+      return nil unless str
+      return self.replace(str)
+    end
+    pattern = Regexp.new(Regexp.escape(pattern)) if literal
+    # A full search and not `match?`, so a failed match clears $~.
     return nil unless Regexp.__search(pattern, self, 0, literal)
     # `sub` matches again and publishes its own $~ over this one, leaving the
     # caller the match `sub` would have left, a block's own matches included.
@@ -159,71 +179,39 @@ class String
     # Overwriting `self` afterwards is safe: a MatchData snapshots its subject,
     # so $~ keeps describing the string as it was matched.
     down = literal ? args[0] : pattern
-    str = args.length == 2 ? self.sub(down, args[1], &block) : self.sub(down, &block)
+    str = argc == 2 ? self.sub(down, args[1], &block) : self.sub(down, &block)
     self.replace(str)
   end
 
   def gsub(*args, &block)
-    unless (1..2).include?(args.length)
-      raise ArgumentError, "wrong number of arguments (given #{args.length}, expected 1..2)"
+    argc = args.length
+    unless argc == 1 || argc == 2
+      raise ArgumentError, "wrong number of arguments (given #{argc}, expected 1..2)"
     end
     # Without mruby-enumerator this is core Kernel#to_enum, which raises
     # NotImplementedError; every other path here stays usable, so the gem does
     # not depend on Enumerator.
-    return to_enum(:gsub, *args) if args.length == 1 && !block
-    pattern, replacement = *args
+    return to_enum(:gsub, *args) if argc == 1 && !block
+    pattern = args[0]
     # After the to_enum return above, so that `"abc".gsub(:b)` yields an
     # Enumerator and raises on the first iteration, as CRuby does.
     pattern = Regexp.__check_pattern(pattern)
     # A String pattern is a literal, as in `sub`, and reaches the subject the
     # way CRuby reaches it: byte by byte, with no reading of it as UTF-8.
     literal = String === pattern
+    # A replacement argument wins over the block, as in CRuby.  A literal is
+    # searched for as bytes and compiles nothing, as in `sub` above.
+    if argc == 2
+      replacement = args[1].to_s
+      return Regexp.__gsub_lit(pattern, self, replacement) if literal
+      return Regexp.__gsub_str(pattern, self, replacement)
+    end
     pattern = Regexp.new(Regexp.escape(pattern)) if literal
-    # A replacement argument wins over the block, as in CRuby.
-    if args.length == 2
-      return Regexp.__gsub_str(pattern, self, replacement.to_s, literal)
-    end
-    # block case: keep in Ruby to avoid VM callback from C
-    parts = []
-    pos = 0
-    len = self.bytesize
-    binary = Regexp.__binary_string?(self)
-    # The loop normally ends on a failed __byte_search, which clears $~ and
-    # the thirteen names that go with it. CRuby leaves the last match behind,
-    # so keep it and republish it below. A gsub that matched nothing has
-    # nothing to restore and keeps the cleared state, as CRuby does.
-    last = nil
-    while pos <= len
-      md = Regexp.__byte_search(pattern, self, pos, literal)
-      break unless md
-      last = md
-      # gsub works in byte space (match pos, byteslice). begin/end report
-      # character offsets (CRuby-compatible), so use the byte accessors.
-      match_start = md.__byte_begin(0)
-      match_end = md.__byte_end(0)
-      parts << self.byteslice(pos, match_start - pos)
-      parts << block.call(md[0]).to_s
-      if match_start == match_end
-        if match_end < len
-          if binary
-            parts << self.byteslice(match_end, 1)
-            pos = match_end + 1
-          else
-            rest = self.byteslice(match_end..-1)
-            char = rest[0]
-            parts << char
-            pos = match_end + char.bytesize
-          end
-        else
-          pos = match_end + 1
-        end
-      else
-        pos = match_end
-      end
-    end
-    parts << self.byteslice(pos..-1)
-    last.__set_globals if last
-    parts.join
+    # The walk and the block call are both in `__gsub_block`.  What the loop
+    # was written here for, the block reading the globals of the match it was
+    # handed, a C loop publishes just as well, and it pays neither the frame
+    # per search nor the array of pieces the mrblib one collected.
+    Regexp.__gsub_block(pattern, self, literal, &block)
   end
 
   def gsub!(*args, &block)
@@ -231,20 +219,28 @@ class String
     # `"abc".freeze.gsub!(/a/)` raises FrozenError rather than handing back an
     # Enumerator that fails later.
     raise FrozenError, "can't modify frozen String" if frozen?
-    unless (1..2).include?(args.length)
-      raise ArgumentError, "wrong number of arguments (given #{args.length}, expected 1..2)"
+    argc = args.length
+    unless argc == 1 || argc == 2
+      raise ArgumentError, "wrong number of arguments (given #{argc}, expected 1..2)"
     end
-    return to_enum(:gsub!, *args) if args.length == 1 && !block
+    return to_enum(:gsub!, *args) if argc == 1 && !block
     pattern = Regexp.__check_pattern(args[0])
     literal = String === pattern
-    pattern = Regexp.new(Regexp.escape(pattern)) if literal
     # As in `sub!`: the match decides the return value, and a failed search
     # clears $~.  What it publishes on success is replaced right away by the
     # last match of the `gsub` below, which is the one CRuby leaves behind.
-    # A literal goes down as the String it was, for the reason `sub!` gives.
+    # A literal goes down as the String it was, for the reason `sub!` gives,
+    # and a literal with a replacement asks the question of `__gsub_lit`
+    # itself rather than searching once to ask and again to substitute.
+    if literal && argc == 2
+      str = Regexp.__gsub_lit(pattern, self, args[1].to_s, true)
+      return nil unless str
+      return self.replace(str)
+    end
+    pattern = Regexp.new(Regexp.escape(pattern)) if literal
     return nil unless Regexp.__search(pattern, self, 0, literal)
     down = literal ? args[0] : pattern
-    str = args.length == 2 ? self.gsub(down, args[1], &block) : self.gsub(down, &block)
+    str = argc == 2 ? self.gsub(down, args[1], &block) : self.gsub(down, &block)
     self.replace(str)
   end
 

--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -278,8 +278,9 @@ re_binary_string_p(mrb_value str)
    bytes make no claim that could be broken. A quoted String pattern is exempt
    for a narrower reason: CRuby searches for a literal byte by byte and reads
    the subject as UTF-8 nowhere along the way, so `"a\x80b".sub("b", "!")`
-   answers there while the same call with `/b/` is refused. The searches a
-   literal reaches take a `checked` argument to say so.
+   answers there while the same call with `/b/` is refused. `__sub_lit` and
+   `__gsub_lit` never ask, having no compiled pattern to ask on behalf of, and
+   the searches a literal reaches with one take a `checked` argument to say so.
 
    The check walks the whole subject, so every entry point below runs it on the
    subject it is handed and the C loops over a subject run it before the first
@@ -506,9 +507,9 @@ check_regexp_arg(mrb_state *mrb, mrb_value re)
  * overrides use to report a miss.
  *
  * `checked` says the caller has settled the encoding question for the subject
- * and this search must not ask it again. `sub`, `sub!`, `gsub` and `gsub!` set
- * it when their pattern is a quoted String, which CRuby searches for without
- * reading the subject as UTF-8 at all.
+ * and this search must not ask it again. `sub`, `sub!` and `gsub!` set it when
+ * their pattern is a quoted String, which CRuby searches for without reading
+ * the subject as UTF-8 at all.
  */
 static mrb_value
 re_search(mrb_state *mrb, mrb_value re, mrb_value str, mrb_int pos, mrb_bool checked)
@@ -540,15 +541,15 @@ regexp_s_search(mrb_state *mrb, mrb_value klass)
 }
 
 /*
- * Regexp.__byte_search(re, str, pos = 0, checked = false)
+ * Regexp.__byte_search(re, str, pos = 0)
  *
- * Internal: the byte-offset search the mrblib loops of `gsub`, `split` and
+ * Internal: the byte-offset search the mrblib loops of `scan`, `split` and
  * `byteindex` drive themselves. No position normalization, because the
  * callers already work in byte space, and no operand conversion, because
  * they always pass a String. The subject is the one the loop holds fixed, so
- * the check reads the flag core left on it after the first turn. `checked`
- * carries the same meaning as in `__search`: `gsub` sets it for a block over
- * a quoted String pattern.
+ * the check reads the flag core left on it after the first turn. Nor is there
+ * a `checked` any more: `gsub` was the caller that set it, and its loop is
+ * `__gsub_block` now, which takes the flag itself.
  */
 static mrb_value
 regexp_s_byte_search(mrb_state *mrb, mrb_value klass)
@@ -556,9 +557,7 @@ regexp_s_byte_search(mrb_state *mrb, mrb_value klass)
   mrb_value re, str;
   mrb_int pos = 0;
 
-  mrb_bool checked = FALSE;
-
-  mrb_get_args(mrb, "oS|ib", &re, &str, &pos, &checked);
+  mrb_get_args(mrb, "oS|i", &re, &str, &pos);
   check_regexp_arg(mrb, re);
   /* Every mrblib loop enters at zero or at an offset a match answered with,
      so a position before the subject reaches here only from a direct call.
@@ -571,7 +570,7 @@ regexp_s_byte_search(mrb_state *mrb, mrb_value klass)
     clear_match_globals(mrb);
     return mrb_nil_value();
   }
-  if (!checked) re_check_encoding(mrb, str);
+  re_check_encoding(mrb, str);
   return exec_match(mrb, re, str, pos);
 }
 
@@ -855,15 +854,12 @@ regexp_hash(mrb_state *mrb, mrb_value self)
   return mrb_int_value(mrb, (mrb_int)h);
 }
 
-/*
- * Regexp.escape(str)
- */
+/* The bytes of `str` with everything a pattern reads as syntax escaped, which
+   is what `Regexp.escape` answers and what a quoted String pattern is compiled
+   from where one is needed. */
 static mrb_value
-regexp_escape(mrb_state *mrb, mrb_value self)
+re_escape_str(mrb_state *mrb, mrb_value str)
 {
-  mrb_value str;
-  mrb_get_args(mrb, "S", &str);
-
   const char *s = RSTRING_PTR(str);
   mrb_int len = RSTRING_LEN(str);
   mrb_value result = mrb_str_new_capa(mrb, len + len / 4);
@@ -893,6 +889,17 @@ regexp_escape(mrb_state *mrb, mrb_value self)
     }
   }
   return result;
+}
+
+/*
+ * Regexp.escape(str)
+ */
+static mrb_value
+regexp_escape(mrb_state *mrb, mrb_value self)
+{
+  mrb_value str;
+  mrb_get_args(mrb, "S", &str);
+  return re_escape_str(mrb, str);
 }
 
 /* --- MatchData methods --- */
@@ -1177,14 +1184,67 @@ matchdata_string(mrb_state *mrb, mrb_value self)
   return md->source;
 }
 
+/* The Regexp a match against a literal String pattern reports itself as. The
+   searches such a pattern reaches need no compiled pattern and build none, so
+   the one asked for here is compiled on the spot, and the last one compiled is
+   kept: CRuby keeps exactly one too, in `rb_reg_regcomp`, which is the cache
+   `MatchData#regexp` reaches there for the same quoted pattern. Two entries
+   would answer where CRuby compiles afresh, so the count is the compatible
+   part and not an accident of sizing.
+
+   The pair hangs off the `Regexp` class, so the GC reaches both, under names
+   `instance_variables` does not report. The literal is stored frozen, so a
+   caller that goes on to modify the string it passed cannot turn the entry it
+   left behind into a hit for something else. */
+static mrb_value
+re_quoted_regexp(mrb_state *mrb, mrb_value lit)
+{
+  struct RClass *re_class = mrb_class_get_id(mrb, MRB_SYM(Regexp));
+  mrb_value klass = mrb_obj_value(re_class);
+  mrb_value key = mrb_iv_get(mrb, klass, MRB_SYM(__quoted_literal));
+  mrb_value hit = mrb_iv_get(mrb, klass, MRB_SYM(__quoted_regexp));
+
+  if (mrb_string_p(key) && !mrb_nil_p(hit) && mrb_str_equal(mrb, key, lit)) {
+    return hit;
+  }
+
+  /* Everything that can raise happens before either half of the pair is
+     stored, so a failure leaves the old pair whole rather than the new Regexp
+     under the old literal. */
+  mrb_value frozen = mrb_str_dup_frozen(mrb, lit);
+  mrb_value source = re_escape_str(mrb, lit);
+  mrb_value re = mrb_obj_new(mrb, re_class, 1, &source);
+  mrb_iv_set(mrb, klass, MRB_SYM(__quoted_regexp), re);
+  mrb_iv_set(mrb, klass, MRB_SYM(__quoted_literal), frozen);
+  return re;
+}
+
 /*
  * MatchData#regexp - the Regexp used
+ *
+ * A literal String pattern leaves none behind: `__sub_lit` and `__gsub_lit`
+ * search for its bytes without compiling anything to search with, so the
+ * Regexp it names is built here, out of the bytes the match reports, the first
+ * time something asks for one. That is what CRuby does with a match against a
+ * String pattern, down to the memo the answer is kept in. A call that never
+ * asks pays for no compile at all.
  */
 static mrb_value
 matchdata_regexp(mrb_state *mrb, mrb_value self)
 {
   mrb_match_data *md = DATA_GET_PTR(mrb, self, &matchdata_type, mrb_match_data);
   if (!md) return mrb_nil_value();
+  if (mrb_nil_p(md->regexp)) {
+    /* Group 0 of a literal match spans the pattern itself, and a literal
+       match is the only thing that arrives here without a Regexp. */
+    mrb_value lit = re_byte_substr(mrb, md->source, md->captures[0],
+                                   md->captures[1] - md->captures[0]);
+    mrb_value re = re_quoted_regexp(mrb, lit);
+    /* The instance variable is what keeps it reachable: the struct beside it
+       is C-allocated and the GC does not scan it. */
+    mrb_iv_set(mrb, self, MRB_SYM(regexp), re);
+    md->regexp = re;
+  }
   return md->regexp;
 }
 
@@ -1295,21 +1355,22 @@ re_mark_spliced(mrb_value result, mrb_value subject, mrb_value replacement,
 }
 
 /*
- * Regexp.__gsub_str(re, str, replacement, checked = false) - gsub core without block
+ * Regexp.__gsub_str(re, str, replacement) - gsub core without block
  *
- * `checked` carries the same meaning as in `__search`.
+ * A compiled pattern only: a String pattern is a literal and reaches
+ * `__gsub_lit` instead, which is why there is no `checked` here to say that
+ * the subject was left unread.
  */
 static mrb_value
 regexp_s_gsub_str(mrb_state *mrb, mrb_value klass)
 {
   mrb_value re, str, replacement;
-  mrb_bool checked = FALSE;
-  mrb_get_args(mrb, "oSS|b", &re, &str, &replacement, &checked);
+  mrb_get_args(mrb, "oSS", &re, &str, &replacement);
   check_regexp_arg(mrb, re);
 
   mrb_regexp_pattern *pat = DATA_GET_PTR(mrb, re, &regexp_type, mrb_regexp_pattern);
   if (re_uninitialized_p(pat)) mrb_raise(mrb, E_ARGUMENT_ERROR, "uninitialized Regexp");
-  if (!checked) re_check_encoding(mrb, str);
+  re_check_encoding(mrb, str);
 
   const char *s = RSTRING_PTR(str);
   mrb_int slen = RSTRING_LEN(str);
@@ -1390,21 +1451,20 @@ regexp_s_gsub_str(mrb_state *mrb, mrb_value klass)
 }
 
 /*
- * Regexp.__sub_str(re, str, replacement, checked = false) - sub core without block
+ * Regexp.__sub_str(re, str, replacement) - sub core without block
  *
- * `checked` carries the same meaning as in `__search`.
+ * A compiled pattern only, as `__gsub_str` above.
  */
 static mrb_value
 regexp_s_sub_str(mrb_state *mrb, mrb_value klass)
 {
   mrb_value re, str, replacement;
-  mrb_bool checked = FALSE;
-  mrb_get_args(mrb, "oSS|b", &re, &str, &replacement, &checked);
+  mrb_get_args(mrb, "oSS", &re, &str, &replacement);
   check_regexp_arg(mrb, re);
 
   mrb_regexp_pattern *pat = DATA_GET_PTR(mrb, re, &regexp_type, mrb_regexp_pattern);
   if (re_uninitialized_p(pat)) mrb_raise(mrb, E_ARGUMENT_ERROR, "uninitialized Regexp");
-  if (!checked) re_check_encoding(mrb, str);
+  re_check_encoding(mrb, str);
 
   const char *s = RSTRING_PTR(str);
   mrb_int slen = RSTRING_LEN(str);
@@ -1445,6 +1505,291 @@ regexp_s_sub_str(mrb_state *mrb, mrb_value klass)
   create_matchdata(mrb, re, str, captures, cap_size);
   mrb_free(mrb, captures);
   re_mark_spliced(result, str, replacement, TRUE);
+  return result;
+}
+
+/* --- literal (quoted String) pattern core --- */
+
+/* Forward search for the bytes of a literal pattern. A String pattern is
+   searched for byte by byte, which is the search CRuby makes for one: the
+   subject is never read as UTF-8 on the way, and no pattern is compiled to
+   walk it with. Answers the byte offset of the first match at or after `pos`,
+   or -1 for none. An empty pattern matches at `pos` itself, which is what
+   leaves the callers below stepping a character at a time over it. */
+static mrb_int
+re_lit_search(const char *s, mrb_int slen, const char *p, mrb_int plen, mrb_int pos)
+{
+  if (pos > slen) return -1;
+  if (plen == 0) return pos;
+  if (plen > slen - pos) return -1;
+  /* The last offset a match can start at, so that the tail comparison never
+     reads past the subject; a pattern longer than what is left was answered
+     above, so this never points before it. */
+  const char *last = s + slen - plen;
+  const char *q = s + pos;
+  while (q <= last) {
+    q = (const char*)memchr(q, *p, (size_t)(last - q) + 1);
+    if (q == NULL) break;
+    if (memcmp(q + 1, p + 1, (size_t)(plen - 1)) == 0) return (mrb_int)(q - s);
+    q++;
+  }
+  return -1;
+}
+
+/* Append `len` bytes of the subject to `result`, carrying the byte reading the
+   way `mrb_str_cat_str()` carries it for a piece that arrives as a String:
+   bytes read as bytes that go above ASCII spell no character where they land
+   and hand their reading over, and all-ASCII bytes say nothing. The pieces a
+   substitution splices in come from a subject that was read one way or the
+   other, so the result has to be read the way the pieces are; going through a
+   String for each of them only to have it read the flag would allocate one
+   per match for an answer these few bytes already carry. */
+static void
+re_cat_bytes(mrb_state *mrb, mrb_value result, const char *p, mrb_int len, mrb_bool binary)
+{
+  mrb_str_cat(mrb, result, p, len);
+  if (!binary || RSTR_BINARY_P(mrb_str_ptr(result))) return;
+  for (mrb_int i = 0; i < len; i++) {
+    if (p[i] & 0x80) {
+      RSTR_ENCODING_SET(mrb_str_ptr(result), MRB_STR_ENCODING_BINARY);
+      return;
+    }
+  }
+}
+
+/* Publish the one match a literal substitution leaves behind. The offsets are
+   the whole of it: a literal has no groups, so group 0 is the only one there
+   is to report. No Regexp goes with it, because nothing here compiled one:
+   `MatchData#regexp` builds it out of these offsets if anything ever asks. */
+static void
+re_lit_matchdata(mrb_state *mrb, mrb_value str, mrb_int beg, mrb_int end)
+{
+  int captures[2];
+  captures[0] = (int)beg;
+  captures[1] = (int)end;
+  create_matchdata(mrb, mrb_nil_value(), str, captures, 2);
+}
+
+/*
+ * Regexp.__gsub_lit(pattern, str, replacement, bang = false) - the gsub of a
+ * literal String pattern and a String replacement, without a pattern compiled
+ * to search with.
+ *
+ * `bang` answers nil rather than a result when nothing matched, so that
+ * `gsub!` reads the question it asks, whether a substitution happened, off
+ * this search instead of making a second one ahead of it.
+ */
+static mrb_value
+regexp_s_gsub_lit(mrb_state *mrb, mrb_value klass)
+{
+  mrb_value lit, str, replacement;
+  mrb_bool bang = FALSE;
+  mrb_get_args(mrb, "SSS|b", &lit, &str, &replacement, &bang);
+
+  const char *s = RSTRING_PTR(str);
+  mrb_int slen = RSTRING_LEN(str);
+  const char *p = RSTRING_PTR(lit);
+  mrb_int plen = RSTRING_LEN(lit);
+  const char *rep = RSTRING_PTR(replacement);
+  mrb_int rep_len = RSTRING_LEN(replacement);
+  mrb_bool need_expand = has_backslash(rep, rep_len);
+  mrb_bool binary = re_binary_string_p(str);
+
+  mrb_int beg = re_lit_search(s, slen, p, plen, 0);
+  if (beg < 0) {
+    clear_match_globals(mrb);
+    return bang ? mrb_nil_value() : mrb_str_dup(mrb, str);
+  }
+
+  mrb_value result = mrb_str_new_capa(mrb, slen);
+  mrb_int pos = 0;
+  /* The loop leaves the last match's offsets here, which is the match `$~`
+     reports below: nothing writes them after the search that ends the loop
+     fails. */
+  int captures[2];
+
+  do {
+    captures[0] = (int)beg;
+    captures[1] = (int)(beg + plen);
+
+    if (beg > pos) re_cat_bytes(mrb, result, s + pos, beg - pos, binary);
+    if (need_expand) {
+      apply_replacement(mrb, result, rep, rep_len, s, slen, captures, 1);
+    }
+    else {
+      mrb_str_cat(mrb, result, rep, rep_len);
+    }
+
+    /* An empty pattern matches at every position without consuming anything,
+       so the step past it carries the character it stood before, the way the
+       compiled-pattern loop steps a zero-width match. */
+    if (plen == 0) {
+      if (beg < slen) {
+        int clen = mrb_re_charlen(s + beg, s + slen, binary);
+        re_cat_bytes(mrb, result, s + beg, clen, binary);
+        pos = beg + clen;
+      }
+      else {
+        pos = beg + 1;
+      }
+    }
+    else {
+      pos = beg + plen;
+    }
+    beg = re_lit_search(s, slen, p, plen, pos);
+  } while (beg >= 0);
+
+  if (pos < slen) re_cat_bytes(mrb, result, s + pos, slen - pos, binary);
+
+  re_lit_matchdata(mrb, str, captures[0], captures[1]);
+  re_mark_spliced(result, str, replacement, TRUE);
+  return result;
+}
+
+/*
+ * Regexp.__sub_lit(pattern, str, replacement, bang = false) - `__gsub_lit` for
+ * the first match alone.
+ */
+static mrb_value
+regexp_s_sub_lit(mrb_state *mrb, mrb_value klass)
+{
+  mrb_value lit, str, replacement;
+  mrb_bool bang = FALSE;
+  mrb_get_args(mrb, "SSS|b", &lit, &str, &replacement, &bang);
+
+  const char *s = RSTRING_PTR(str);
+  mrb_int slen = RSTRING_LEN(str);
+  const char *rep = RSTRING_PTR(replacement);
+  mrb_int rep_len = RSTRING_LEN(replacement);
+  mrb_bool binary = re_binary_string_p(str);
+
+  mrb_int beg = re_lit_search(s, slen, RSTRING_PTR(lit), RSTRING_LEN(lit), 0);
+  if (beg < 0) {
+    clear_match_globals(mrb);
+    return bang ? mrb_nil_value() : mrb_str_dup(mrb, str);
+  }
+  mrb_int end = beg + RSTRING_LEN(lit);
+
+  mrb_value result = mrb_str_new_capa(mrb, slen);
+  if (beg > 0) re_cat_bytes(mrb, result, s, beg, binary);
+  if (has_backslash(rep, rep_len)) {
+    int captures[2];
+    captures[0] = (int)beg;
+    captures[1] = (int)end;
+    apply_replacement(mrb, result, rep, rep_len, s, slen, captures, 1);
+  }
+  else {
+    mrb_str_cat(mrb, result, rep, rep_len);
+  }
+  if (end < slen) re_cat_bytes(mrb, result, s + end, slen - end, binary);
+
+  re_lit_matchdata(mrb, str, beg, end);
+  re_mark_spliced(result, str, replacement, TRUE);
+  return result;
+}
+
+/*
+ * Regexp.__gsub_block(re, str, checked = false, &block) - gsub core with a
+ * block.
+ *
+ * `checked` carries the same meaning as in `__search`.
+ *
+ * The walk this replaced was written in mrblib to keep the block call out of
+ * C.  What it cost was paid per match rather than per call: a `__byte_search`
+ * frame, two `byteslice` frames and their strings, the `__byte_begin` and
+ * `__byte_end` pair, an array to collect the pieces in and a `join` to spend
+ * them, all around one `mrb_yield` that C can make directly.  The block still
+ * reads what it read there: every match is published before the block sees it,
+ * which is why a MatchData is built per turn here as it was there.
+ */
+static mrb_value
+regexp_s_gsub_block(mrb_state *mrb, mrb_value klass)
+{
+  mrb_value re, str, block = mrb_nil_value();
+  mrb_bool checked = FALSE;
+  mrb_get_args(mrb, "oS|b&", &re, &str, &checked, &block);
+  check_regexp_arg(mrb, re);
+  /* A backstop, as check_regexp_arg() is: the one caller reaches here only
+     with a block, having handed the blockless forms to an enumerator. */
+  if (mrb_nil_p(block)) mrb_raise(mrb, E_ARGUMENT_ERROR, "no block given");
+
+  mrb_regexp_pattern *pat = DATA_GET_PTR(mrb, re, &regexp_type, mrb_regexp_pattern);
+  if (re_uninitialized_p(pat)) mrb_raise(mrb, E_ARGUMENT_ERROR, "uninitialized Regexp");
+  if (!checked) re_check_encoding(mrb, str);
+
+  mrb_bool binary = re_binary_string_p(str);
+  int cap_size = pat->num_captures * 2;
+  int captures[RE_MAX_CAPTURES * 2];
+  mrb_value result = mrb_str_new_capa(mrb, RSTRING_LEN(str));
+  /* The match the block was given last, kept so that it can be published
+     again below: CRuby leaves a gsub's own last match behind, over anything
+     the block matched on its way. */
+  mrb_value last_md = mrb_nil_value();
+  mrb_int pos = 0;
+  /* The subject's length as the walk started, which is where the walk ends.
+     The mrblib loop this replaced took its bound before the first block call
+     and kept it, so a block that grows the subject it is walking cannot keep
+     the walk going for ever; reading the length afresh for the bound as well
+     as for the bytes would let it. */
+  mrb_int limit = RSTRING_LEN(str);
+  int ai = mrb_gc_arena_save(mrb);
+
+  while (pos <= limit) {
+    /* The bytes, unlike the bound, are read afresh each turn: the block runs
+       between two of them and can replace them under the walk, which the
+       mrblib loop allowed by asking `self` again for every piece it took. */
+    const char *s = RSTRING_PTR(str);
+    mrb_int slen = RSTRING_LEN(str);
+    if (pos > slen) break;
+
+    memset(captures, -1, sizeof(int) * cap_size);
+    if (mrb_re_exec(mrb, pat, s, slen, pos, captures, cap_size, binary) == 0) break;
+    mrb_int beg = captures[0], end = captures[1];
+
+    if (beg > pos) re_cat_bytes(mrb, result, s + pos, beg - pos, binary);
+    mrb_value matched = re_byte_substr(mrb, str, beg, end - beg);
+    last_md = create_matchdata(mrb, re, str, captures, cap_size);
+    mrb_str_cat_str(mrb, result, mrb_obj_as_string(mrb, mrb_yield(mrb, block, matched)));
+
+    s = RSTRING_PTR(str);
+    slen = RSTRING_LEN(str);
+    /* A zero-width match carries the character it stood before, so that the
+       next search starts past a place the pattern would answer at again. */
+    if (beg == end) {
+      if (end < slen) {
+        int clen = mrb_re_charlen(s + end, s + slen, binary);
+        re_cat_bytes(mrb, result, s + end, clen, binary);
+        pos = end + clen;
+      }
+      else {
+        pos = end + 1;
+      }
+    }
+    else {
+      pos = end;
+    }
+
+    mrb_gc_arena_restore(mrb, ai);
+    /* Nothing allocates between the restore and this, so the match spends one
+       arena slot for the whole loop rather than one per turn. It cannot be
+       left to `$~` alone: the block is free to publish a match of its own. */
+    mrb_gc_protect(mrb, last_md);
+  }
+
+  if (pos < RSTRING_LEN(str)) {
+    re_cat_bytes(mrb, result, RSTRING_PTR(str) + pos, RSTRING_LEN(str) - pos, binary);
+  }
+
+  if (mrb_nil_p(last_md)) {
+    /* The loop ends on a failed search, which clears the globals. A gsub that
+       matched nothing has nothing to restore and keeps the cleared state, as
+       CRuby does. */
+    clear_match_globals(mrb);
+  }
+  else {
+    mrb_match_data *md = DATA_GET_PTR(mrb, last_md, &matchdata_type, mrb_match_data);
+    set_match_globals(mrb, last_md, md->source, md->captures, md->num_captures);
+  }
   return result;
 }
 
@@ -1712,7 +2057,7 @@ mrb_mruby_regexp_gem_init(mrb_state *mrb)
   mrb_define_class_method(mrb, re, "__check_pattern", regexp_check_pattern, MRB_ARGS_REQ(1));
   mrb_define_class_method(mrb, re, "__check_byte_pos", regexp_check_byte_pos, MRB_ARGS_REQ(2));
   mrb_define_class_method(mrb, re, "__search", regexp_s_search, MRB_ARGS_ARG(2, 2));
-  mrb_define_class_method(mrb, re, "__byte_search", regexp_s_byte_search, MRB_ARGS_ARG(2, 3));
+  mrb_define_class_method(mrb, re, "__byte_search", regexp_s_byte_search, MRB_ARGS_ARG(2, 1));
   mrb_define_class_method(mrb, re, "__byte_rsearch", regexp_s_byte_rsearch, MRB_ARGS_REQ(3));
   mrb_define_class_method(mrb, re, "__search_p", regexp_s_search_p, MRB_ARGS_ARG(2, 1));
 
@@ -1729,8 +2074,11 @@ mrb_mruby_regexp_gem_init(mrb_state *mrb)
   mrb_define_method(mrb, re, "hash", regexp_hash, MRB_ARGS_NONE());
   mrb_define_method(mrb, re, "options", regexp_options, MRB_ARGS_NONE());
   mrb_define_method(mrb, re, "casefold?", regexp_casefold_p, MRB_ARGS_NONE());
-  mrb_define_class_method(mrb, re, "__gsub_str", regexp_s_gsub_str, MRB_ARGS_ARG(3, 1));
-  mrb_define_class_method(mrb, re, "__sub_str", regexp_s_sub_str, MRB_ARGS_ARG(3, 1));
+  mrb_define_class_method(mrb, re, "__gsub_str", regexp_s_gsub_str, MRB_ARGS_REQ(3));
+  mrb_define_class_method(mrb, re, "__sub_str", regexp_s_sub_str, MRB_ARGS_REQ(3));
+  mrb_define_class_method(mrb, re, "__gsub_lit", regexp_s_gsub_lit, MRB_ARGS_ARG(3, 1));
+  mrb_define_class_method(mrb, re, "__sub_lit", regexp_s_sub_lit, MRB_ARGS_ARG(3, 1));
+  mrb_define_class_method(mrb, re, "__gsub_block", regexp_s_gsub_block, MRB_ARGS_ARG(2, 1)|MRB_ARGS_BLOCK());
   mrb_define_class_method(mrb, re, "__scan", regexp_s_scan, MRB_ARGS_REQ(2));
 
   /* String#[] takes the name here rather than in mrblib, so that the indexes

--- a/mrbgems/mruby-regexp/test/string_index.rb
+++ b/mrbgems/mruby-regexp/test/string_index.rb
@@ -934,6 +934,23 @@ assert("String overrides run a pattern whose operation cores were rewritten") do
   assert_equal "heXo", s
 end
 
+assert("String overrides run a String pattern whose operation cores were rewritten") do
+  # The literal path reaches the same class methods on Regexp, so a pattern
+  # carrying its own `__sub_lit` or `__gsub_lit` is searched for, not asked.
+  p = "l".dup
+  def p.__sub_lit(*args); "PWNED"; end
+  def p.__gsub_lit(*args); "PWNED"; end
+  def p.__gsub_block(*args); "PWNED"; end
+
+  assert_equal "heXlo", "hello".sub(p, "X")
+  assert_equal "heXXo", "hello".gsub(p, "X")
+  assert_equal "heXXo", "hello".gsub(p) { "X" }
+  s = "hello".dup
+  assert_equal "heXlo", s.sub!(p, "X")
+  s = "hello".dup
+  assert_equal "heXXo", s.gsub!(p, "X")
+end
+
 assert("String#[] answers the same through the opcode and through a send") do
   # `s[x]` is answered by `OP_GETIDX` / `OP_GETIDX0` in C, without a method
   # lookup, while `slice` is a second method table entry for the same

--- a/mrbgems/mruby-regexp/test/string_regexp.rb
+++ b/mrbgems/mruby-regexp/test/string_regexp.rb
@@ -816,3 +816,164 @@ assert("String#gsub with block leaves the last match behind") do
   assert_nil $1
   assert_nil $+
 end
+
+assert("String#sub / #gsub search a String pattern without compiling one") do
+  # A String pattern is a literal, and the search for it walks the subject's
+  # bytes rather than a pattern compiled to walk them: `.` matches only `.`.
+  assert_equal "aXc.e", "a.c.e".sub(".", "X")
+  assert_equal "aXcXe", "a.c.e".gsub(".", "X")
+  assert_equal "a.c.e", "a.c.e".gsub("z", "X")
+  assert_equal "abcabc", "abcabc".gsub("abcabcabc", "X")
+  assert_equal "X", "abc".gsub("abc", "X")
+  assert_equal "--", "aaaa".gsub("aa", "-")
+
+  # What a compiled pattern is still asked for is the Regexp the match names,
+  # which is the quoted literal as CRuby's is.
+  "a.c".gsub(".", "X")
+  assert_equal "\\.", $~.regexp.source
+  assert_equal ".", $~[0]
+  assert_equal 1, $~.begin(0)
+  assert_equal "a", $`
+  assert_equal "c", $'
+  assert_equal ".", $&
+
+  # The last match, not the first, as everywhere else.
+  "a.c.e".gsub(".", "X")
+  assert_equal 3, $~.begin(0)
+
+  # Matching nothing clears, as it does everywhere else.
+  /b(c)/ =~ "abcd"
+  "abc".gsub("z", "X")
+  assert_nil $~
+  assert_nil $&
+  assert_nil $`
+  assert_nil $1
+end
+
+assert("String#sub / #gsub with a String pattern leave the subject unread") do
+  # CRuby searches for a literal byte by byte and reads the subject as UTF-8
+  # nowhere along the way, so a subject that spells no character is answered
+  # for here where the same call with a Regexp is refused.
+  s = "a\x80b"
+  assert_equal "a\x80!", s.sub("b", "!")
+  assert_equal "a\x80!", s.gsub("b", "!")
+  assert_equal "a\x80!", s.dup.sub!("b", "!")
+  assert_equal "a\x80!", s.dup.gsub!("b", "!")
+  if __ENCODING__ == "UTF-8"
+    assert_raise(ArgumentError) { s.sub(/b/, "!") }
+    assert_raise(ArgumentError) { s.gsub(/b/, "!") }
+    assert_raise(ArgumentError) { s.gsub(/b/) { "!" } }
+  end
+end
+
+assert("String#gsub with an empty String pattern steps one character") do
+  assert_equal "-a-b-", "ab".gsub("", "-")
+  assert_equal "-", "".gsub("", "-")
+  assert_equal "-a-", "a".sub("", "-") + "-"
+  # A character and not a byte, where the subject is read as characters, and a
+  # byte where it is read as bytes.
+  if "あ".length == 1
+    assert_equal "-a-あ-b-", "aあb".gsub("", "-")
+  end
+  assert_equal "-a-\xE3-\x81-\x82-b-", "aあb".b.gsub("", "-")
+end
+
+assert("String#sub / #gsub expand the replacement of a String pattern") do
+  assert_equal "a[b]c", "abc".sub("b", "[\\0]")
+  assert_equal "a[b]c", "abc".sub("b", "[\\&]")
+  assert_equal "a<a>c", "abc".sub("b", "<\\`>")
+  assert_equal "a<c>c", "abc".sub("b", "<\\'>")
+  assert_equal "a\\c", "abc".sub("b", "\\\\")
+  assert_equal "a[b]c[b]", "abcb".gsub("b", "[\\&]")
+  # A literal has no groups, so a group reference names nothing and stands for
+  # nothing, as in CRuby.
+  assert_equal "ac", "abc".sub("b", "\\1")
+  assert_equal "ac", "abc".sub("b", "\\+")
+end
+
+assert("String#sub! / #gsub! with a String pattern answer the one search they make") do
+  s = "a.c.e"
+  assert_equal "aXc.e", s.sub!(".", "X")
+  assert_equal "aXc.e", s
+  s = "a.c.e"
+  assert_equal "aXcXe", s.gsub!(".", "X")
+  assert_equal "aXcXe", s
+
+  # nil for nothing matched, and self even where the substitution changed no
+  # byte: the question is about the match, not the result.
+  assert_nil "abc".dup.sub!("z", "X")
+  assert_nil "abc".dup.gsub!("z", "X")
+  s = "aaa"
+  assert_equal "aaa", s.dup.gsub!("a", "a")
+
+  # A miss clears the globals, and a hit leaves the last match behind.
+  /b(c)/ =~ "abcd"
+  assert_nil "abc".dup.gsub!("z", "X")
+  assert_nil $~
+  "a.c.e".dup.gsub!(".", "X")
+  assert_equal 3, $~.begin(0)
+end
+
+assert("String#gsub with a block whose block replaces the subject") do
+  # The loop is in C and reads the subject afresh every turn, so a block that
+  # replaces it under the walk cannot leave the search reading bytes that were
+  # freed. What comes out of such a call is not worth pinning down; that it
+  # comes out at all is.
+  s = "aaaa".dup
+  assert_kind_of String, s.gsub(/a/) { s.replace("b"); "-" }
+  s = "aaaa".dup
+  assert_kind_of String, s.gsub(/a/) { s << "aaaa"; "-" }
+end
+
+assert("MatchData#regexp compiles a literal pattern only when asked for one") do
+  # Nothing compiled a pattern to search with, so the Regexp the match names is
+  # built out of the bytes it matched, the first time something asks. The same
+  # literal asked for twice running answers the same object, which is what
+  # CRuby's `rb_reg_regcomp` answers for the same quoted pattern.
+  "abc".gsub("b", "X")
+  first = $~.regexp
+  "zbz".gsub("b", "Y")
+  assert_true first.equal?($~.regexp)
+
+  # One entry, as CRuby keeps one: a literal asked for in between drops it.
+  "abc".gsub("b", "X")
+  first = $~.regexp
+  "abc".gsub("c", "Y")
+  $~.regexp
+  "zbz".gsub("b", "Z")
+  assert_false first.equal?($~.regexp)
+
+  # A call that never asks compiles nothing, so it cannot drop what the entry
+  # holds either.
+  "abc".gsub("b", "X")
+  first = $~.regexp
+  "abc".gsub("c", "Y")
+  "zbz".gsub("b", "Z")
+  assert_true first.equal?($~.regexp)
+
+  # A match answers the same Regexp however often it is asked, the entry
+  # behind it having moved on.
+  "abc".gsub("b", "X")
+  md = $~
+  first = md.regexp
+  "abc".gsub("c", "Y")
+  $~.regexp
+  assert_true first.equal?(md.regexp)
+
+  # The literal reaches the entry as it was matched, so a pattern modified
+  # afterwards cannot answer for what it used to spell.
+  pattern = "b".dup
+  "abc".gsub(pattern, "X")
+  first = $~.regexp
+  pattern << "c"
+  "zbz".gsub("b", "Y")
+  assert_true first.equal?($~.regexp)
+  assert_equal "b", first.source
+
+  # A literal has no groups, so a name reaches none, as in CRuby.
+  "a.c".sub(".", "-")
+  assert_equal({}, $~.named_captures)
+  assert_raise(IndexError) { $~[:x] }
+  "abc".sub("", "-")
+  assert_equal "", $~.regexp.source
+end


### PR DESCRIPTION
Three costs stood between a substitution and the bytes it moves, and none of them was the search.

## A String pattern was compiled on every call

`"hello world".gsub("o", "0")` spent most of its time in `Regexp.escape` and the compiler, and the rest of it in a compiled pattern the engine walked one character at a time. A literal now reaches `Regexp.__sub_lit` / `Regexp.__gsub_lit`, which search for its bytes with `memchr` and compile nothing.

What a compiled pattern is still needed for is the Regexp the match names in `$~`. `MatchData#regexp` quotes and compiles that one the first time something asks for it and keeps the last one compiled, which is what CRuby does for a match against a String pattern (`match_regexp` in re.c compiles on demand, and `rb_reg_regcomp` keeps one entry). A call that never looks at `$~.regexp` compiles nothing. The one entry hangs off the `Regexp` class under names `instance_variables` does not report, keyed by a frozen copy of the literal, so a caller that goes on to modify the pattern it passed cannot turn the entry into a hit for something else.

## The block form drove its walk from mrblib

It paid, per match, for a `__byte_search` frame, two `byteslice` frames and their strings, a `__byte_begin`/`__byte_end` pair and an array entry, then a `join` to spend the pieces. `Regexp.__gsub_block` does the walk in C around one `mrb_yield`. The block still reads the globals of the match it was handed, so a MatchData is built per turn as before, and the last one is republished when the walk ends, as the mrblib loop did. What the mrblib loop did with a block that changes the receiver under it, the C loop does too: the bound is the length the walk started with and the bytes are read afresh each turn, so nothing observable moves here. Following CRuby there (`str_mod_check`, and the closing search behind `$~`) is #7267, which is stacked on this loop.

## Everything else was per-call overhead

`sub!` and `gsub!` searched the subject once to decide whether to answer nil and again to substitute; the literal path answers both from the one search `__sub_lit` / `__gsub_lit` already makes. The argument counts are compared rather than asked of a `Range` built per call.

`__gsub_str`, `__sub_str` and `__byte_search` lose their `checked` argument along with the last caller that set it.

## Behaviour

One observable change, the identity of `$~.regexp` after a String pattern, which moves onto CRuby's answer:

```ruby
"abc".gsub("b", "X"); a = $~.regexp
"zbz".gsub("b", "Y"); a.equal?($~.regexp)   # was false, now true, as in CRuby
```

Otherwise nothing: a matrix of 13 subjects × 12 patterns × 11 replacements across `sub`, `gsub`, `sub!`, `gsub!` and both block forms, comparing the result, the receiver afterwards, `$~[0]`, `$~.begin(0)`, `` $` ``, `$'`, `$~.string` and `$~.regexp.source`, answers byte for byte on master and on this branch, in the byte-indexed default build and in a UTF-8 build (14,976 lines each, no diff).

## Cost

Wall clock, the cases of the review on #7267 and the same shapes with a String pattern, minimum of 5 alternating runs, `-O3`, default configuration:

```ruby
s480 = "hello world foo bar " * 24
30000.times { s480.gsub(/o/) { } }        # gsub480_blk
100000.times { "abc".gsub(/b/) { } }      # gsub_abc_blk
100000.times { "abc".scan(/b/) { } }      # scan_abc_blk
100000.times { "abc".sub!(/b/) { } }      # sub!_abc_blk
30000.times { s480.gsub(/o/, "0") }       # gsub480_str
100000.times { "abc".scan(/b/) }          # scan_abc
100000.times { "abc".sub!(/b/, "0") }     # sub!_abc_str
30000.times { s480.gsub(/z/) { } }        # gsub480_none
30000.times { s480.gsub("o") { } }        # lit_gsub480_blk
100000.times { "abc".gsub("b") { } }      # lit_gsub_abc_blk
100000.times { "abc".sub!("b") { } }      # lit_sub!_abc_blk
30000.times { s480.gsub("o", "0") }       # lit_gsub480_str
100000.times { "abc".gsub("b", "0") }     # lit_gsub_abc_str
100000.times { "abc".sub("b", "0") }      # lit_sub_abc_str
100000.times { "abc".sub!("b", "0") }     # lit_sub!_abc_str
100000.times { "abc".gsub!("b", "0") }    # lit_gsub!_abc_str
30000.times { s480.gsub("z", "0") }       # lit_gsub480_none
```

| case | master | this branch |
| --- | --- | --- |
| gsub480_blk | 2324ms | 1200ms (-48%) |
| gsub_abc_blk | 233ms | 162ms (-30%) |
| scan_abc_blk | 178ms | 177ms (-1%) |
| sub!_abc_blk | 232ms | 210ms (-9%) |
| gsub480_str | 117ms | 118ms (+1%) |
| scan_abc | 115ms | 116ms (+1%) |
| sub!_abc_str | 201ms | 193ms (-4%) |
| gsub480_none | 47ms | 38ms (-19%) |
| lit_gsub480_blk | 2363ms | 1203ms (-49%) |
| lit_gsub_abc_blk | 230ms | 159ms (-31%) |
| lit_sub!_abc_blk | 280ms | 263ms (-6%) |
| lit_gsub480_str | 117ms | 83ms (-29%) |
| lit_gsub_abc_str | 151ms | 70ms (-54%) |
| lit_sub_abc_str | 136ms | 65ms (-52%) |
| lit_sub!_abc_str | 251ms | 69ms (-73%) |
| lit_gsub!_abc_str | 263ms | 69ms (-74%) |
| lit_gsub480_none | 37ms | 13ms (-65%) |

The block rows are the walk moving into C, Regexp and String pattern alike. The String pattern rows without a block are the quoting and the compile coming out, and the two bang rows fall furthest because they also lose the second walk of the subject. `scan` and the blockless `gsub(/o/, "0")` were already in C and are unchanged; `sub!(/b/)` moves on the `Range` alone. `lit_sub!_abc_blk` still quotes and compiles the literal for `__search` and `sub`, which is why it moves the least of the String rows.

## Size

`.text` of `bin/mruby`, `build_config/ci/gcc-clang.rb`, each side from a clean
build directory. `regexp.o` is the object that changes, and it accounts for the
whole delta in every build (to within 2 bytes of alignment in `full-debug`):
the three C entry points, `__sub_lit`, `__gsub_lit` and `__gsub_block`. The
mrblib loop that left was bytecode in `mruby-regexp/gem_init.o`'s `.rodata`,
which shrinks by 192 (224 in `full-debug`).

| build | master | this PR | delta |
|---|---:|---:|---:|
| `bintest` | 1,281,190 | 1,287,222 | +6,032 |
| `ascii-ctype` | 1,268,998 | 1,275,030 | +6,032 |
| `byte-string` | 1,250,454 | 1,256,342 | +5,888 |
| `cxx_abi` | 1,306,681 | 1,312,825 | +6,144 |
| `full-debug` (`-O0`) | 1,880,502 | 1,886,086 | +5,584 |

On the default configuration, the one the wall clock was measured on, `.text` is
1,197,614 on master and 1,203,502 here (+5,888).

## Testing

Full suite green: `rake -m test` on the default configuration in a fresh build directory, `MRUBY_CONFIG=build_config/ci/gcc-clang.rb rake -m test` and `MRUBY_CONFIG=build_config/gcc-asan.rb rake -m test`, no sanitizer report.

| Build | Total | KO | Crash |
| --- | --- | --- | --- |
| full-debug | 2371 | 0 | 0 |
| bintest | 2371 (+123 bintest) | 0 | 0 |
| cxx_abi | 2371 | 0 | 0 |
| byte-string | 2300 | 0 | 0 |
| ascii-ctype | 2367 | 0 | 0 |
| gcc-asan | 2371 (+85 bintest) | 0 | 0 |
| default | 2146 | 0 | 0 |

New assertions cover the literal search and the match it publishes, a literal against a subject whose bytes spell no character, the empty-pattern step, replacement expansion under a literal, the one search the bang methods make, `MatchData#regexp` compiling on demand and keeping one entry, a block that replaces the subject under the walk, and a String pattern carrying its own `__sub_lit` / `__gsub_lit` / `__gsub_block` singletons.

### Environment

<details>
<summary>Machine, toolchain, and the compile line of every build</summary>

| Item | Value |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS |
| Kernel | 7.0.0-29-generic |
| CPU | AMD Ryzen 9 5950X 16-Core Processor |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0 |
| binutils | GNU ld (GNU Binutils) 2.47.20260726 |
| CRuby (reference) | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |

Actual compile line of `mrbgems/mruby-regexp/src/regexp.c` in each build (`-MMD -c`, `-I`, and `-o` dropped). `full-debug` and `gcc-asan` are `-O0` because `enable_debug` appends `-g3 -O0` after the toolchain's `-g -O3`; `cxx_abi` compiles C as C++ with `gcc -x c++ -std=gnu++03`, g++ only links.

```console
# full-debug
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-regexp/src/regexp.c
# bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK mrbgems/mruby-regexp/src/regexp.c
# cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-regexp/src/regexp.c
# byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-regexp/src/regexp.c
# ascii-ctype
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-regexp/src/regexp.c
# gcc-asan
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -fsanitize=address,undefined -g3 -O0 -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-regexp/src/regexp.c
# default (no MRUBY_CONFIG), the build every figure above was measured on
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK mrbgems/mruby-regexp/src/regexp.c
```

</details>

