### PR TITLE
mruby-regexp: let an empty group take a quantifier

### DIFF
--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -1333,8 +1333,12 @@ emit_codepoint(re_compiler *c, uint32_t cp)
    number/name` for one within it that names no group. */
 #define RE_MAX_BACKREF_NUM 2147483647
 
-/* Compile a single atom (character, class, group, etc.) */
-static void
+/* Compile a single atom (character, class, group, etc.). Returns whether one
+   was read: FALSE when what stands at the parse point is not an atom, either a
+   quantifier metacharacter or the end of the sequence, neither of them
+   consumed, or an option toggle `(?i)`, consumed but nothing a quantifier can
+   repeat. An empty group `(?:)` emits nothing and is still an atom. */
+static mrb_bool
 compile_atom(re_compiler *c)
 {
   int ch = peek(c);
@@ -1449,7 +1453,7 @@ compile_atom(re_compiler *c)
           if (peek(c) == ')') {
             next_char(c);
             c->flags = new_flags;  /* rest of the group; restored at its ')' */
-            return;                /* consumed the token; no atom emitted */
+            return FALSE;          /* consumed the token; no atom emitted */
           }
           else if (peek(c) == ':') {
             next_char(c);
@@ -1458,7 +1462,7 @@ compile_atom(re_compiler *c)
             c->flags = saved_flags;
             if (peek(c) != ')') compile_error(c, "unmatched '('");
             next_char(c);
-            return;
+            return TRUE;
           }
           else {
             compile_error(c, "undefined (?...) sequence");
@@ -1741,7 +1745,7 @@ compile_atom(re_compiler *c)
 
   default:
     if (ch < 0 || ch == ')' || ch == '|' || ch == '*' || ch == '+' || ch == '?') {
-      return;  /* not an atom */
+      return FALSE;  /* not an atom */
     }
     next_char(c);
     if (ch >= 128) {
@@ -1751,6 +1755,7 @@ compile_atom(re_compiler *c)
     emit_char(c, (uint8_t)ch);
     break;
   }
+  return TRUE;
 }
 
 /* Append a copy of the atom bytecode in [start, start+size) at the current
@@ -1776,11 +1781,10 @@ emit_atom_copy(re_compiler *c, uint32_t start, uint32_t size)
   }
 }
 
-/* Compile atom with quantifiers (*, +, ?, {n,m}) */
 /* Read the quantifiers that follow a body which matches empty and emit
-   nothing for them: `a{0}` leaves no code, and repeating what matches empty
-   any number of times still matches empty, so `a{0}*` and `a{0}{2}?` are the
-   empty match CRuby gives. */
+   nothing for them: `a{0}` and `(?:)` leave no code, and repeating what
+   matches empty any number of times still matches empty, so `a{0}*`,
+   `a{0}{2}?` and `(?:)+` are the empty match CRuby gives. */
 static void
 skip_quantifiers(re_compiler *c)
 {
@@ -1805,6 +1809,7 @@ skip_quantifiers(re_compiler *c)
   }
 }
 
+/* Compile atom with quantifiers (*, +, ?, {n,m}) */
 static void
 compile_quantified(re_compiler *c)
 {
@@ -1815,10 +1820,19 @@ compile_quantified(re_compiler *c)
      leaving its own atom behind for this one. */
   uint32_t saved_atom_start = c->atom_start;
   c->atom_start = begin;
-  compile_atom(c);
+  mrb_bool atom = compile_atom(c);
   uint32_t start = c->atom_start;
   c->atom_start = saved_atom_start;
-  if (c->code_len == begin) return;  /* no atom emitted */
+  if (c->code_len == begin) {
+    /* Nothing emitted. An empty group `(?:)` is an atom all the same, and
+       one that matches empty matches empty however it is repeated, so its
+       quantifiers are read and emit nothing, as those of `a{0}` are; CRuby
+       compiles `(?:)*` the same way. What is not an atom, an option toggle
+       `(?i)` or a stray metacharacter, leaves a quantifier after it for
+       compile_seq() to refuse, as CRuby refuses `(?i)*`. */
+    if (atom) skip_quantifiers(c);
+    return;
+  }
 
   /* Under /x the quantifier may stand apart from its atom, `a +` being `a+`.
      A `?` making it non-greedy is read right after it, though, as CRuby
@@ -1978,7 +1992,7 @@ compile_seq(re_compiler *c)
     if (c->code_len == code_before && c->p == p_before) {
       /* compile_quantified neither consumed input nor emitted code: the
          current character is a quantifier metacharacter with no atom to
-         repeat (a leading `*`, `+`, `?`, or the trailing `*`s in `a***`).
+         repeat (a leading `*`, `+`, `?`, or one after the toggle `(?i)`).
          CRuby raises RegexpError here; without this guard peek() never
          advances and the loop spins forever (A1). */
       compile_error(c, "target of repeat operator is not specified");

--- a/mrbgems/mruby-regexp/test/regexp_syntax.rb
+++ b/mrbgems/mruby-regexp/test/regexp_syntax.rb
@@ -949,6 +949,34 @@ assert("Regexp - non-capturing group") do
   assert_nil md[2]
 end
 
+assert("Regexp - an empty group takes a quantifier") do
+  # `(?:)` emits no code, but it is an atom, and a repeat of what matches
+  # empty matches empty, as CRuby compiles it. The scoped-option and demoted
+  # plain spellings of an empty group are the same atom.
+  assert_equal [""], /(?:)*/.match("").to_a
+  assert_equal [""], /(?:)+/.match("").to_a
+  assert_equal [""], /(?:){2}/.match("").to_a
+  assert_equal [""], /(?:){0}/.match("").to_a
+  assert_equal [""], /(?:)*?/.match("").to_a
+  assert_equal [""], /(?:)*+/.match("").to_a
+  assert_equal [""], /(?:)**/.match("").to_a
+  assert_equal [""], /(?:(?:))*/.match("").to_a
+  assert_equal [""], /(?:a{0})*/.match("aa").to_a
+  assert_equal ["ab"], /a(?:)*b/.match("ab").to_a
+  assert_equal ["b", ""], /((?:)*)b/.match("b").to_a
+  assert_equal [""], /(?i:)*/.match("").to_a
+  assert_equal ["a", "a"], /(?<n>a)()*/.match("a").to_a
+  assert_equal [""], /(?:) * /x.match("").to_a
+  # A `{` after it that spells no quantifier is a literal, as after any atom.
+  assert_equal ["{a}"], /(?:){a}/.match("{a}").to_a
+  # An option toggle is not an atom: the quantifier after `(?i)` has no target.
+  assert_raise_with_message(RegexpError,
+                            "target of repeat operator is not specified: /(?i)*/") do
+    Regexp.new("(?i)*")
+  end
+  assert_raise(RegexpError) { Regexp.new("(?:(?i))*(?i)+") }
+end
+
 assert("Regexp - atomic group (?>...)") do
   # The body's first match is its only one: what follows cannot make it
   # give text back or take another branch, where a plain group can.


### PR DESCRIPTION
An empty non-capturing group takes no quantifier: `(?:)` followed by `*`,
`+`, `?` or an interval raises `target of repeat operator is not specified`,
where CRuby compiles the group as an empty match and the quantifier as one of
it. The scoped-option spelling `(?i:)` and a plain `()` demoted by a named
group are refused the same way, while `()`, `(?:|)` and `(?=)` take the
quantifier on both sides:

```ruby
/(?:)*/ =~ ""          # CRuby: 0,   mruby: RegexpError, target of repeat operator is not specified
/(?:)+/ =~ ""          # CRuby: 0,   mruby: RegexpError
/(?:){2}/ =~ ""        # CRuby: 0,   mruby: RegexpError
/(?:(?:))*/ =~ ""      # CRuby: 0,   mruby: RegexpError
/a(?:)*b/ =~ "ab"      # CRuby: 0,   mruby: RegexpError
/(?i:)*/ =~ ""         # CRuby: 0,   mruby: RegexpError
/(?<n>a)()*/ =~ "a"    # CRuby: 0,   mruby: RegexpError
/()*/ =~ ""            # 0 in both
/(?:|)*/ =~ ""         # 0 in both
/(?=)*/ =~ ""          # 0 in both
```

`compile_atom()` emits nothing for the empty group, so `compile_quantified()`
sees no atom and returns, and the quantifier is left to `compile_seq()`, whose
guard for a quantifier with no atom refuses it. `()` emits its two `RE_SAVE`s
and `(?:|)` its `RE_SPLIT`, so those have an atom.

## The fix

`compile_atom()` returns whether it read an atom, which an empty group is and
an option toggle `(?i)` is not, and `compile_quantified()` reads the
quantifiers of an atom that emitted nothing the way it already reads those of
`a{0}`, with `skip_quantifiers()`: a repeat of what matches empty matches
empty, so they emit nothing. `(?i)*` and a stray metacharacter still reach the
guard and are refused, as CRuby refuses them:

```ruby
/(?i)*/     # RegexpError in both
/(?#c)*/    # RegexpError in both
/(?:){a}/   # matches "{a}" in both: a `{` that spells no quantifier is a literal
```

## Size

`.text` of `bin/mruby`, `build_config/ci/gcc-clang.rb`, each side from a clean
build directory. `re_compile.o` is the only object that changes: by 41 bytes
at `-O0`, and at `-O3` `skip_quantifiers()` has two callers now and gcc stops
inlining it into `compile_seq()` (298 bytes in `bintest`), the rest being the
layout of `compile_seq()`, into which the parser is inlined.

| build | master | this PR | delta |
|---|---:|---:|---:|
| `bintest` | 1,281,398 | 1,281,846 | +448 |
| `ascii-ctype` | 1,269,286 | 1,269,766 | +480 |
| `byte-string` | 1,251,142 | 1,251,958 | +816 |
| `cxx_abi` | 1,306,873 | 1,307,097 | +224 |
| `full-debug` (`-O0`) | 1,881,126 | 1,881,174 | +48 |

## Verification

The tests go in `regexp_syntax.rb` beside the non-capturing group test: the
quantifiers above on `(?:)`, `(?i:)` and a demoted `()`, the lazy, possessive
and stacked spellings, `(?:) *` under `/x`, a `{` that spells no quantifier,
and `(?i)*` still refused. On master the block fails at its first assertion,
the literal being refused when it is compiled.

**Differential against CRuby 4.0.6**, the harness of #7269 and #7273 with
master and this PR against the same cases: 10,000 random patterns (seed 2,
the default features, over `a` and `b`), each matched against one subject and
compared as `MatchData#to_a`. Master refuses 1,657 of them, every one for
this reason, and CRuby cannot finish 1 under the memory cap. This PR refuses
none. Of the 1,657, 1,631 answer as CRuby does; 21 read a capture written
inside a lookaround, which is #7273 (with its fix stacked on this PR all 21
answer as CRuby does); and 5 are standing differences of the engine that the
empty group has no part in: each of the 5 answers the same, on master as
here, with its empty group and quantifier removed. The 8,342 cases both sides
compile answer the same on master and this PR, 100 of them differing from
CRuby on both.

**`rake test`**, `build_config/ci/gcc-clang.rb`, no compiler warning:

| build | total | KO | crash |
|---|---:|---:|---:|
| `full-debug` | 2,366 | 0 | 0 |
| `bintest` | 2,366 | 0 | 0 |
| `bintest` (bintest suite) | 123 | 0 | 0 |
| `cxx_abi` | 2,366 | 0 | 0 |
| `byte-string` | 2,295 | 0 | 0 |
| `ascii-ctype` | 2,362 | 0 | 0 |

The default configuration: 2,141 total, 0 KO, 0 crash, plus its 112 bintests.

### Environment

<details>

| | |
|---|---|
| OS | Ubuntu 24.04, Linux 7.0.0 x86_64, AMD Ryzen 9 5950X |
| gcc | 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1) |
| binutils | 2.47 |
| CRuby | 4.0.6, for the differential |

Compile lines for `mrbgems/mruby-regexp/src/re_compile.c` in the builds
quoted above, paths shortened:

```
# ci/gcc-clang full-debug
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -I"include" -I"mrbgems/mruby-regexp/include" -I"build/full-debug/include" -o "build/full-debug/mrbgems/mruby-regexp/src/re_compile.o" "mrbgems/mruby-regexp/src/re_compile.c"

# ci/gcc-clang bintest
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK -I"include" -I"mrbgems/mruby-regexp/include" -I"build/bintest/include" -o "build/bintest/mrbgems/mruby-regexp/src/re_compile.o" "mrbgems/mruby-regexp/src/re_compile.c"

# ci/gcc-clang cxx_abi
gcc -MMD -c -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -I"include" -I"mrbgems/mruby-regexp/include" -I"build/cxx_abi/include" -o "build/cxx_abi/mrbgems/mruby-regexp/src/re_compile.o" "mrbgems/mruby-regexp/src/re_compile.c"

# ci/gcc-clang byte-string
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -I"include" -I"mrbgems/mruby-regexp/include" -I"build/byte-string/include" -o "build/byte-string/mrbgems/mruby-regexp/src/re_compile.o" "mrbgems/mruby-regexp/src/re_compile.c"

# ci/gcc-clang ascii-ctype
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -I"include" -I"mrbgems/mruby-regexp/include" -I"build/ascii-ctype/include" -o "build/ascii-ctype/mrbgems/mruby-regexp/src/re_compile.o" "mrbgems/mruby-regexp/src/re_compile.c"
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed regular expression handling for quantifiers applied to empty groups.
  * Improved support for greedy, lazy, possessive, nested, scoped-option, and bounded repetitions.
  * Preserved existing errors for invalid quantifier targets and option-toggle patterns.
  * Corrected handling of literal braces that are not valid quantifiers.

* **Tests**
  * Added regression coverage for empty-group quantification and related syntax edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->