### PR TITLE
mruby-regexp: number atomic groups so a possessive repeat cuts as its own

### DIFF
--- a/mrbgems/mruby-regexp/include/re_internal.h
+++ b/mrbgems/mruby-regexp/include/re_internal.h
@@ -39,12 +39,13 @@ enum re_opcode {
                         The executor rewinds by bytes against a binary subject
                         and by characters otherwise, and the sub-pattern body
                         starts past this instruction, at pc + 2. */
-  RE_ATOMIC,         /* atomic group (?>...): offset = nesting depth of the
-                        group, 1 for an outermost one. The body follows and
-                        ends at the RE_ATOMIC_END with the same depth; once
-                        the body has matched, a failure after it fails the
-                        whole group rather than backtracking into it. */
-  RE_ATOMIC_END,     /* end of an atomic group's body: offset = the depth of
+  RE_ATOMIC,         /* atomic group (?>...): offset = the group's number,
+                        1 for the first one the pattern opens and no two the
+                        same. The body follows and ends at the RE_ATOMIC_END
+                        with the same number; once the body has matched, a
+                        failure after it fails the whole group rather than
+                        backtracking into it. */
+  RE_ATOMIC_END,     /* end of an atomic group's body: offset = the number of
                         the RE_ATOMIC it closes */
 };
 

--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -57,7 +57,9 @@ typedef struct {
   uint16_t num_groups;      /* groups opened so far, counting the plain ones a
                                named pattern demotes: what decides whether
                                `\NN` is a backreference or an octal escape */
-  uint32_t atomic_depth;    /* how many (?>...) groups enclose the parse point */
+  uint32_t num_cuts;        /* atomic groups numbered so far, the possessive
+                               repeats among them: each takes the next number,
+                               so no two that nest share one; see RE_ATOMIC */
   uint32_t atom_start;      /* where the atom a quantifier binds to begins;
                                compile_quantified sets it to the position
                                before the atom, and a `\u{...}` list moves it
@@ -1405,16 +1407,21 @@ compile_atom(re_compiler *c)
         else if (c->p[1] == '>') {
           /* atomic group (?>...): the body is a non-capturing group whose
              first match is its only one. The two instructions bracketing it
-             carry the group's nesting depth, which is how the executor pairs
-             the end of a body with the group it closes when a failure after
-             the body has to fail the group; see bt_match(). The depth counts
-             instructions the pattern holds, so it fits the field. */
+             carry a number of the group's own, which is how the executor
+             pairs the end of a body with the group it closes when a failure
+             after the body has to fail the group; see bt_match(). The number
+             is the count of groups numbered before it rather than the
+             nesting depth: a possessive repeat wraps a group around code
+             already emitted, and with depths that wrapper and a group inside
+             it, compiled with the same groups open around them, shared a
+             depth, so a cut of the wrapper was read as the inner group's.
+             Every numbered group emits two instructions, so the number fits
+             the field. */
           next_char(c); next_char(c);  /* skip ?> */
-          c->atomic_depth++;
-          emit(c, RE_ATOMIC, 0, (uint16_t)c->atomic_depth);
+          uint16_t cut = (uint16_t)++c->num_cuts;
+          emit(c, RE_ATOMIC, 0, cut);
           compile_alt(c);
-          emit(c, RE_ATOMIC_END, 0, (uint16_t)c->atomic_depth);
-          c->atomic_depth--;
+          emit(c, RE_ATOMIC_END, 0, cut);
           if (peek(c) != ')') compile_error(c, "unmatched '('");
           next_char(c);
           c->needs_backtrack = TRUE;  /* the Pike VM cannot cut a thread */
@@ -1848,12 +1855,12 @@ compile_quantified(re_compiler *c)
     int ch = peek(c);
 
     if (greedy_rep && ch == '+') {
-      /* Possessive: what stands emitted becomes an atomic group of its own. */
+      /* Possessive: what stands emitted becomes an atomic group of its own,
+         numbered after every group inside it, since those are emitted. */
       next_char(c);
-      c->atomic_depth++;
-      insert_inst(c, begin, RE_ATOMIC, 0, (uint16_t)c->atomic_depth);
-      emit(c, RE_ATOMIC_END, 0, (uint16_t)c->atomic_depth);
-      c->atomic_depth--;
+      uint16_t cut = (uint16_t)++c->num_cuts;
+      insert_inst(c, begin, RE_ATOMIC, 0, cut);
+      emit(c, RE_ATOMIC_END, 0, cut);
       c->needs_backtrack = TRUE;  /* the Pike VM cannot cut a thread */
       greedy_rep = FALSE;
       start = begin;

--- a/mrbgems/mruby-regexp/src/re_exec.c
+++ b/mrbgems/mruby-regexp/src/re_exec.c
@@ -630,7 +630,7 @@ lookbehind_start(const mrb_regexp_pattern *pat, const char *str,
    alternative of its own. The third answer is the cut of an atomic group:
    the text after an RE_ATOMIC_END has failed, and no alternative inside the
    group's body may be tried for it, so the frames between that end and the
-   RE_ATOMIC that opened the group hand BT_CUT of the group's depth up
+   RE_ATOMIC that opened the group hand BT_CUT of the group's number up
    unchanged, undoing their captures as they go, and the frame that ran that
    RE_ATOMIC turns it into BT_FAIL. A cut never reaches a lookaround from
    inside its sub-pattern: the RE_ATOMIC that absorbs it is in there too.
@@ -645,7 +645,7 @@ lookbehind_start(const mrb_regexp_pattern *pat, const char *str,
 #define BT_FAIL 0
 #define BT_MATCH 1
 #define BT_LIMIT 2
-#define BT_CUT(atomic_depth) (-(int)(atomic_depth))
+#define BT_CUT(cut) (-(int)(cut))
 
 /* What one backtrack_exec() call shares between its bt_match() frames: the
    pattern, the subject, the capture slots being written, the step count and

--- a/mrbgems/mruby-regexp/test/regexp_syntax.rb
+++ b/mrbgems/mruby-regexp/test/regexp_syntax.rb
@@ -979,6 +979,19 @@ assert("Regexp - atomic group (?>...)") do
   assert_nil /(?>x(?>a)(?>b)y)/.match("xabz")
   assert_equal 0, /(?>x(?>a)(?>b)y)/ =~ "xaby"
 
+  # A possessive repeat is an atomic group wrapped around what it repeats,
+  # and it cuts as a group of its own: a failure after it does not open the
+  # repeat to being skipped, whatever groups the repeated code holds.
+  assert_nil /(?>a)?+a/.match("a")
+  assert_nil /(?>a)*+a/.match("aa")
+  assert_nil /(?:(?>a)b?)?+a/.match("a")
+  assert_nil /(?:(?>a)?+)?+a/.match("a")
+  assert_equal 0, /(?>a)?+b/ =~ "ab"
+  assert_equal 0, /(?:(?>a)b?)?+c/ =~ "abc"
+  # A failure inside the repeat, before its end, still fails only the inner
+  # group, and the repeat is skipped as its `?` allows.
+  assert_equal 1, /(?:(?>a)b)?+c/ =~ "ac"
+
   # A repetition whose body can match empty stops on its empty iteration
   # inside the group as anywhere else, and takes the group's exit; a
   # repetition of the group stops the same way, its lazy body still empty.


### PR DESCRIPTION
A possessive repeat (`a*+`, `a?+`, `a++`) wraps an atomic group around the
code it repeats after that code is emitted, and it takes the group's depth
from the count of groups open around it, which is the count the groups inside
that code took theirs from. So the wrapper and a group inside it share a
depth, and a failure after the wrapper, which is meant to fail the wrapper
without opening the repeat to being skipped, is read by the inner group as
its own cut: the inner group fails, the `?` or `*` skips the repeat, and the
text after the wrapper is tried once more where CRuby has already failed:

```ruby
/(?>a)?+a/ =~ "a"          # CRuby: nil, mruby: 0
/(?>a)*+a/ =~ "aa"         # CRuby: nil, mruby: 0
/(?:(?>a)b?)?+a/ =~ "a"    # CRuby: nil, mruby: 0
/(?>(?:(?>a))?)a/ =~ "a"   # nil in both: the group form nests its depths
```

The written-out group nests because its depth is taken before its body is
compiled; the wrapper is the one construct that is put around code already
emitted, so a depth is not what tells it apart from what it holds.

## The fix

The two instructions of an atomic group carry the count of groups numbered
before it, one more for each `(?>...)` the pattern opens and for each
possessive repeat, instead of the nesting depth. A cut is still keyed by that
number (`BT_CUT`), and it is unique in the pattern, so a wrapper and any group
inside it never share one. Every numbered group emits two instructions, so the
number fits the field as the depth did. `emit_atom_copy()` copies a group's
number with the group, and the copies are sequential, never one inside the
other, so they cut independently as before.

## Size

`.text` of `bin/mruby`, `build_config/ci/gcc-clang.rb`, each side from a clean
build directory. `re_compile.o` is the only object that changes; `re_exec.o`, whose
change is a comment and the name of a macro parameter, keeps its size.

| build | master | this PR | delta |
|---|---:|---:|---:|
| `bintest` | 1,281,398 | 1,281,318 | -80 |
| `ascii-ctype` | 1,269,286 | 1,269,158 | -128 |
| `byte-string` | 1,251,142 | 1,251,094 | -48 |
| `cxx_abi` | 1,306,873 | 1,306,841 | -32 |
| `full-debug` (`-O0`) | 1,881,126 | 1,881,094 | -32 |

## Verification

The tests go in `regexp_syntax.rb`, in the atomic group block: the examples
above, a possessive repeat around a possessive repeat, a repeat that matches
with the text after it, and a failure inside the repeat before its end, which
still fails only the inner group and lets the `?` skip the repeat
(`/(?:(?>a)b)?+c/ =~ "ac"` is 1 in both). Four of the assertions fail on
master.

**Differential against CRuby 4.0.6**, the harness of #7269 with a possessive
form added to the quantifiers it draws, master and this PR against the same
cases, compared as `MatchData#to_a`. 10,000 random patterns over the default
features (seed 2), 3,081 of them with a possessive quantifier: 8,406 compared
(master and this PR both refuse 1,592, an empty group under a quantifier,
which is #7275), 8,294 the same everywhere, 111 differing from CRuby on both
sides, 1 that master answers differently and this PR as CRuby does
(`/(?:(?<!aa)(?:b|)??(?>a{2}?))?+\B/` on `"baba"`), 0 that only this PR
answers differently. A second 10,000 (seed 3) drawn from atomic groups,
possessive and lazy quantifiers, intervals, empty-matching atoms, classes and
backreferences: 8,247 compared, 5 that master answers differently and this PR
as CRuby does, every one a possessive repeat around an atomic group, 11 that
both differ on (none with a possessive repeat around a group), 0 only this PR.

**`rake test`**, `build_config/ci/gcc-clang.rb`, no compiler warning:

| build | total | KO | crash |
|---|---:|---:|---:|
| `full-debug` | 2,365 | 0 | 0 |
| `bintest` | 2,365 | 0 | 0 |
| `bintest` (bintest suite) | 123 | 0 | 0 |
| `cxx_abi` | 2,365 | 0 | 0 |
| `byte-string` | 2,294 | 0 | 0 |
| `ascii-ctype` | 2,361 | 0 | 0 |

The default configuration: 2,140 total, 0 KO, 0 crash, plus its 112 bintests.

### Environment

<details>

| | |
|---|---|
| OS | Ubuntu 24.04, Linux 7.0.0 x86_64, AMD Ryzen 9 5950X |
| gcc | 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1) |
| binutils | 2.47 |
| CRuby | 4.0.6, for the differential |

Compile lines for `mrbgems/mruby-regexp/src/re_compile.c` in the builds
quoted above, paths shortened:

```
# ci/gcc-clang full-debug
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -I"include" -I"mrbgems/mruby-regexp/include" -I"build/full-debug/include" -o "build/full-debug/mrbgems/mruby-regexp/src/re_compile.o" "mrbgems/mruby-regexp/src/re_compile.c"

# ci/gcc-clang bintest
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK -I"include" -I"mrbgems/mruby-regexp/include" -I"build/bintest/include" -o "build/bintest/mrbgems/mruby-regexp/src/re_compile.o" "mrbgems/mruby-regexp/src/re_compile.c"

# ci/gcc-clang cxx_abi
gcc -MMD -c -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -I"include" -I"mrbgems/mruby-regexp/include" -I"build/cxx_abi/include" -o "build/cxx_abi/mrbgems/mruby-regexp/src/re_compile.o" "mrbgems/mruby-regexp/src/re_compile.c"

# ci/gcc-clang byte-string
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -I"include" -I"mrbgems/mruby-regexp/include" -I"build/byte-string/include" -o "build/byte-string/mrbgems/mruby-regexp/src/re_compile.o" "mrbgems/mruby-regexp/src/re_compile.c"

# ci/gcc-clang ascii-ctype
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -I"include" -I"mrbgems/mruby-regexp/include" -I"build/ascii-ctype/include" -o "build/ascii-ctype/mrbgems/mruby-regexp/src/re_compile.o" "mrbgems/mruby-regexp/src/re_compile.c"
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved regular expression handling for possessive repeats and atomic groups.
  * Prevented backtracking from incorrectly reopening protected patterns after a match failure.
  * Preserved valid matches involving nested atomic groups and possessive quantifiers.

* **Tests**
  * Added coverage for optional, repeated, and grouped possessive patterns, including nested failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->