### PR TITLE
mruby-task: fix VM stack overflow when a larger proc is set on an existing task

### DIFF
--- a/mrbgems/mruby-task/src/task.c
+++ b/mrbgems/mruby-task/src/task.c
@@ -1769,6 +1769,23 @@ mrb_task_proc_set(mrb_state *mrb, mrb_value task, struct RProc *proc)
   mrb_task *t = (mrb_task*)mrb_data_check_get_ptr(mrb, task, &mrb_task_type);
   if (!t) return;
 
+  struct mrb_context *c = &t->c;
+
+  /* Grow the task's stack to fit the proc being set. It may need more
+   * registers than the original proc the stack was sized for.
+   * mrb_stack_extend() works on mrb->c, so point mrb->c at the task context
+   * across the call. */
+  if (c->stbase && !MRB_PROC_CFUNC_P(proc) && proc->body.irep) {
+    size_t cur = (size_t)(c->stend - c->stbase);
+    size_t need = (size_t)proc->body.irep->nregs;
+    if (need > cur) {
+      struct mrb_context *prev_c = mrb->c;
+      mrb->c = c;
+      mrb_stack_extend(mrb, (mrb_int)need);
+      mrb->c = prev_c;
+    }
+  }
+
   /* Handle environment resize if needed */
   if (t->c.cibase && t->c.cibase->u.env) {
     struct REnv *e = mrb_vm_ci_env(t->c.cibase);

--- a/mrbgems/mruby-task/test/proc_set_stack.rb
+++ b/mrbgems/mruby-task/test/proc_set_stack.rb
@@ -1,0 +1,21 @@
+# Regression: a task's stack is sized for the proc it is created with. When a
+# larger proc is installed on the same context afterwards (mrb_task_proc_set,
+# as picoruby-sandbox's Sandbox#execute does), the stack must grow to cover the
+# new proc's nregs. Otherwise mrb_vm_exec()/OP_ENTER clears registers past the
+# stack allocation (heap-buffer-overflow; the crash surfaces as a bogus realloc
+# in stack_extend_alloc on 32-bit targets).
+if Object.const_defined?(:TaskTest) && TaskTest.respond_to?(:proc_set_stack)
+  assert('mruby-task: proc_set grows the task stack for a larger proc') do
+    small = Proc.new { }
+    # ~80 locals -> nregs well past TASK_STACK_INIT_SIZE (64).
+    big = Proc.new {
+      a0=0;a1=0;a2=0;a3=0;a4=0;a5=0;a6=0;a7=0;a8=0;a9=0;a10=0;a11=0;a12=0;a13=0;a14=0;a15=0;a16=0;a17=0;a18=0;a19=0;
+      a20=0;a21=0;a22=0;a23=0;a24=0;a25=0;a26=0;a27=0;a28=0;a29=0;a30=0;a31=0;a32=0;a33=0;a34=0;a35=0;a36=0;a37=0;a38=0;a39=0;
+      a40=0;a41=0;a42=0;a43=0;a44=0;a45=0;a46=0;a47=0;a48=0;a49=0;a50=0;a51=0;a52=0;a53=0;a54=0;a55=0;a56=0;a57=0;a58=0;a59=0;
+      a60=0;a61=0;a62=0;a63=0;a64=0;a65=0;a66=0;a67=0;a68=0;a69=0;a70=0;a71=0;a72=0;a73=0;a74=0;a75=0;a76=0;a77=0;a78=0;a79=0
+    }
+    slots, nregs = TaskTest.proc_set_stack(small, big)
+    assert_true nregs > 64, "test proc should exceed TASK_STACK_INIT_SIZE (got nregs=#{nregs})"
+    assert_true slots >= nregs, "task stack (#{slots}) must cover replacement proc nregs (#{nregs})"
+  end
+end

--- a/mrbgems/mruby-task/test/tasktest.c
+++ b/mrbgems/mruby-task/test/tasktest.c
@@ -2,6 +2,8 @@
 #include <mruby.h>
 #include <mruby/class.h>
 #include <mruby/proc.h>
+#include <mruby/data.h>
+#include <mruby/array.h>
 #include "task.h"
 
 /* Burn CPU until `ms` milliseconds of CPU time have elapsed, then raise.
@@ -127,6 +129,34 @@ tasktest_run_sync(mrb_state *mrb, mrb_value self)
   return mrb_execute_proc_synchronously(mrb, blk, 0, NULL);
 }
 
+/* Regression for the undersized-stack overflow: creating a task sizes its
+   stack for the INITIAL proc only. Setting a larger proc afterwards (the
+   picoruby-sandbox reset_context + proc_set path) must grow the stack to
+   cover the new proc's nregs, otherwise mrb_vm_exec()/OP_ENTER writes past
+   the stack. Returns [stack_slots, replacement_nregs]. */
+static mrb_value
+tasktest_proc_set_stack(mrb_state *mrb, mrb_value self)
+{
+  mrb_value small_blk, big_blk;
+  mrb_get_args(mrb, "oo", &small_blk, &big_blk);
+  struct RProc *small = mrb_proc_ptr(small_blk);
+  struct RProc *big = mrb_proc_ptr(big_blk);
+
+  mrb_value task = mrb_create_task(mrb, small, mrb_nil_value(),
+                                   mrb_nil_value(), mrb_obj_value(mrb->top_self));
+  mrb_task_reset_context(mrb, task);
+  mrb_task_proc_set(mrb, task, big);
+
+  mrb_task *t = (mrb_task*)DATA_PTR(task);
+  mrb_value r[2];
+  r[0] = mrb_fixnum_value((mrb_int)(t->c.stend - t->c.stbase));
+  r[1] = mrb_fixnum_value((mrb_int)big->body.irep->nregs);
+  /* Never run this probe task: unschedule it so a deliberately undersized
+     stack (unfixed build) fails as a clean assertion, not a later crash. */
+  mrb_terminate_task(mrb, task);
+  return mrb_ary_new_from_values(mrb, 2, r);
+}
+
 void
 mrb_mruby_task_gem_test(mrb_state* mrb)
 {
@@ -139,4 +169,5 @@ mrb_mruby_task_gem_test(mrb_state* mrb)
   mrb_define_module_function(mrb, tasktest, "run_once", tasktest_run_once, MRB_ARGS_NONE());
   mrb_define_module_function(mrb, tasktest, "reinit_context", tasktest_reinit_context, MRB_ARGS_REQ(1) | MRB_ARGS_BLOCK());
   mrb_define_module_function(mrb, tasktest, "run_sync", tasktest_run_sync, MRB_ARGS_BLOCK());
+  mrb_define_module_function(mrb, tasktest, "proc_set_stack", tasktest_proc_set_stack, MRB_ARGS_REQ(2));
 }


### PR DESCRIPTION
## Problem

When a task is created, `task_init_context()` sizes its VM stack once and only for the initial proc: `TASK_STACK_INIT_SIZE` slots, extended by the proc's `nregs` when that is larger. `mrb_task_reset_context()` and `mrb_task_proc_set()` then let a different proc run on the same context, but `mrb_task_proc_set()` never grew the stack.

So if the replacement proc needs more registers than the proc the task was created with, it runs on an undersized stack. `mrb_vm_exec()` does not `stack_extend()` for the entry proc. It relies on the caller having done so, as `exec_irep()` does on the normal `OP_SEND` path. `OP_ENTER` then clears the new proc's locals up to `irep->nregs` and writes past the stack allocation, causing a heap-buffer-overflow.

This path is reached in practice by picoruby-sandbox. Its [`Sandbox#execute`](https://github.com/picoruby/picoruby/blob/a9857ed46632135abd4668e581c3a13e314093be/mrbgems/picoruby-sandbox/src/mruby/sandbox.c#L171-L174) creates the task with a tiny placeholder proc and swaps in the compiled user program via exactly this `reset_context` + `proc_set` sequence.

On 64-bit targets this is a heap-buffer-overflow, a memory-unsafe write. On 32-bit targets such as RP2350 it becomes a deterministic crash, because the same undersizing later makes `stack_extend_alloc()` compute a bogus realloc size and raise `NoMemoryError`.

## Reproduction on a 64-bit host with ASan

Build config:

```ruby
MRuby::Build.new do |conf|
  conf.toolchain :clang
  conf.enable_sanitizer "address,undefined"
  conf.cc.defines << 'MRB_INT64'
  conf.cc.defines << 'MRB_NO_BOXING'
  conf.gem core: 'mruby-compiler'
  conf.gem core: 'mruby-bin-mrbc'
  conf.gem core: 'mruby-task'
end
```

Reproduction code, the same sequence as `Sandbox#execute`:

```c
/* create a initial proc: nregs ~3 */
struct RProc *small = mrb_proc_ptr(mrb_load_string(mrb, "Proc.new { }"));
mrb_value task = mrb_create_task(mrb, small, mrb_nil_value(),
                                 mrb_nil_value(), mrb_obj_value(mrb->top_self));

/* replacement proc with ~80 locals, nregs ~83, past TASK_STACK_INIT_SIZE (64) */
struct RProc *big = mrb_proc_ptr(mrb_load_string(mrb,
  "Proc.new { a0=0;a1=0; ... (define 80 local variables) ... ;a79=0 }"));

mrb_task_reset_context(mrb, task);
mrb_task_proc_set(mrb, task, big);   /* stack NOT grown */
mrb_resume_task(mrb, task);
mrb_task_run(mrb);                    /* OP_ENTER overflows the stack here */
```

ASan report:

```
==ERROR: AddressSanitizer: heap-buffer-overflow WRITE ... 8 bytes after a 1024-byte region
    #0 stack_clear            src/vm.c
    #1 vm_op_enter (OP_ENTER) src/vm.c
    #2 mrb_vm_exec
  1024-byte region allocated by task_init_context <- mrb_create_task
```

The overflowed region is 1024 bytes, which is 64 slots of 16 bytes. The stack was sized for the initial proc, not for the replacement.

## Fix

Grow the task stack in `mrb_task_proc_set()` to cover the replacement proc's `nregs`, the same way `task_init_context()` and mruby-fiber size a context's stack for its proc. `mrb_stack_extend()` operates on `mrb->c`, so point `mrb->c` at the task context across the call and reuse the vetted `stack_extend_alloc()` / `envadjust()` path.

Adds a regression test, `TaskTest.proc_set_stack`, that installs a larger proc on a freshly created task and asserts the task stack was grown to cover the replacement proc's `nregs`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved task replacement behavior so task stacks automatically accommodate procedures with higher register requirements.
  - Prevented potential stack sizing issues when replacing a task’s procedure.

- **Tests**
  - Added regression coverage verifying that task stacks expand sufficiently for larger replacement procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->