### PR TITLE
mruby-regexp: raise RegexpError where a search gives up at a limit

### DIFF
--- a/mrbgems/mruby-regexp/README.md
+++ b/mrbgems/mruby-regexp/README.md
@@ -172,9 +172,11 @@ ReDoS attacks.
 **Backtracking engine**: Used when patterns contain `\1`-`\9`
 backreferences, non-greedy quantifiers (`*?`, `+?`, `??`),
 lookaround assertions (`(?=...)`, `(?!...)`, `(?<=...)`, `(?<!...)`)
-or atomic groups (`(?>...)`). Protected by a
-configurable step limit (`MRB_REGEXP_STEP_LIMIT`, default 1M) to
-prevent excessive backtracking.
+or atomic groups (`(?>...)`). Bounded by a configurable step limit
+(`MRB_REGEXP_STEP_LIMIT`, default 1M) against excessive backtracking and
+by a recursion limit (`MRB_REGEXP_RECURSION_LIMIT`, default 1000) on
+the C stack. A search that reaches either raises `RegexpError` naming
+the limit, since what it had found by then is not the answer.
 
 The engine is selected automatically at compile time based on
 pattern analysis.
@@ -255,7 +257,23 @@ there.
 #ifndef MRB_REGEXP_STEP_LIMIT
 #define MRB_REGEXP_STEP_LIMIT 1000000
 #endif
+
+/* Maximum recursion depth of the backtracking engine (C stack) */
+#ifndef MRB_REGEXP_RECURSION_LIMIT
+#define MRB_REGEXP_RECURSION_LIMIT 1000
+#endif
 ```
+
+A search that reaches either limit raises `RegexpError`, `step limit over
+(MRB_REGEXP_STEP_LIMIT)` or `recursion limit over
+(MRB_REGEXP_RECURSION_LIMIT)`, rather than answer with what it had found
+by then. The recursion limit is spent per fork and per capture, so a
+repetition of an atomic group or a lookaround spends a few frames per
+iteration, and a long enough run of one reaches it on a pattern that is
+not pathological; a build with the stack for it can set it higher. The
+values a build chose are `Regexp::RECURSION_LIMIT` and `Regexp::STEP_LIMIT`,
+for a program that has to size a subject or a pattern to the build it runs
+on; CRuby has no counterpart, its guard being `Regexp.timeout`.
 
 Case folding beyond ASCII is not this gem's to configure. The table is
 core's, carried by any build that defines `MRB_UTF8_STRING` without

--- a/mrbgems/mruby-regexp/include/re_internal.h
+++ b/mrbgems/mruby-regexp/include/re_internal.h
@@ -179,6 +179,14 @@ typedef struct mrb_regexp_pattern {
 #define MRB_REGEXP_RECURSION_LIMIT 1000
 #endif
 
+/* What a search answers when the backtracking engine gave up at one of the
+   two limits before it had an answer (see mrb_re_exec()). The caller raises
+   on it: what the search had found by then is not a shorter or a later
+   match, and reading it as one was the defect. Which of the two it was
+   names the knob to turn. */
+#define RE_OVER_RECURSION_LIMIT (-1)
+#define RE_OVER_STEP_LIMIT (-2)
+
 /* Maximum captures */
 #define RE_MAX_CAPTURES 32
 
@@ -332,7 +340,8 @@ mrb_re_char_interior_p(const char *str, const char *s, const char *end)
 }
 
 /* Execute a match.
-   Returns number of captures filled (0 = no match).
+   Returns number of captures filled (0 = no match), or RE_OVER_*_LIMIT with
+   nothing in `captures` to read.
    captures[2*n] = start, captures[2*n+1] = end for group n. */
 int mrb_re_exec(mrb_state *mrb, const mrb_regexp_pattern *pat,
             const char *str, mrb_int len, mrb_int start,

--- a/mrbgems/mruby-regexp/src/re_exec.c
+++ b/mrbgems/mruby-regexp/src/re_exec.c
@@ -641,13 +641,13 @@ lookbehind_start(const mrb_regexp_pattern *pat, const char *str,
    the RE_LOOK_END (see there), so a cut can pass through one; the opener
    absorbs its own number like an RE_ATOMIC and hands any other up.
    The fourth answer, BT_LIMIT, is a frame giving up at the recursion or step
-   limit. A frame that gets it hands it up; a SPLIT takes it as that branch
-   failing and answers with its other branch, as it would with a failure.
-   What no frame does is turn it into a cut or into a lookaround's answer,
-   since a limit says nothing about the text: the frame giving up may be
-   inside an atomic group's body, where a cut would keep the group's exit
-   from being taken, or inside a negative lookaround, where reading the limit
-   as "no match" would make the assertion hold. */
+   limit, and it is the search's answer rather than the frame's: every frame
+   hands it up unchanged, as it does a cut, and backtrack_exec() stops at it
+   (see there). A limit says nothing about the text, so no frame may read it
+   as its branch having failed and answer with its other branch, which would
+   be answering a smaller question with whatever the alternatives inside the
+   limit produce: a shorter, a later or no match, told from the real answer
+   by nothing. */
 #define BT_FAIL 0
 #define BT_MATCH 1
 #define BT_LIMIT 2
@@ -849,18 +849,18 @@ bt_match(bt_state *m, const char *sp, uint32_t pc, int depth)
       if (inst.a) {
         if (inst.offset > pc) {
           int r = bt_iter(m, sp, pc + 1, pc, depth + 1);
-          if (r != BT_FAIL && r != BT_LIMIT) return r;
+          if (r != BT_FAIL) return r;
           pc = inst.offset;
           break;
         }
         if (ITER_EMPTY(m, pc, sp)) { pc++; break; }
         int r = bt_match(m, sp, pc + 1, depth + 1);
-        if (r != BT_FAIL && r != BT_LIMIT) return r;
+        if (r != BT_FAIL) return r;
         return bt_iter(m, sp, inst.offset, pc, depth + 1);
       }
       {
         int r = bt_match(m, sp, pc + 1, depth + 1);
-        if (r != BT_FAIL && r != BT_LIMIT) return r;
+        if (r != BT_FAIL) return r;
       }
       pc = inst.offset;
       break;
@@ -873,18 +873,18 @@ bt_match(bt_state *m, const char *sp, uint32_t pc, int depth)
       if (inst.a) {
         if (inst.offset > pc) {
           int r = bt_match(m, sp, inst.offset, depth + 1);
-          if (r != BT_FAIL && r != BT_LIMIT) return r;
+          if (r != BT_FAIL) return r;
           return bt_iter(m, sp, pc + 1, pc, depth + 1);
         }
         if (ITER_EMPTY(m, pc, sp)) { pc++; break; }
         int r = bt_iter(m, sp, inst.offset, pc, depth + 1);
-        if (r != BT_FAIL && r != BT_LIMIT) return r;
+        if (r != BT_FAIL) return r;
         pc++;
         break;
       }
       {
         int r = bt_match(m, sp, inst.offset, depth + 1);
-        if (r != BT_FAIL && r != BT_LIMIT) return r;
+        if (r != BT_FAIL) return r;
       }
       pc++;
       break;
@@ -1116,13 +1116,24 @@ backtrack_exec(mrb_state *mrb, const mrb_regexp_pattern *pat,
     memset(caps, -1, sizeof(int) * ncap);
     m.steps = 0;
 
-    if (bt_match(&m, sp, 0, 0) == BT_MATCH) {
+    int r = bt_match(&m, sp, 0, 0);
+    if (r == BT_MATCH) {
       if (captures) {
         int copy = ncap < captures_size ? ncap : captures_size;
         memcpy(captures, caps, sizeof(int) * copy);
       }
       mrb_free(mrb, caps);
       return ncap > 0 ? ncap : 1;
+    }
+    if (r == BT_LIMIT) {
+      /* The search ends here, not this start position's attempt: the
+         positions after it answer where the first match is only once this
+         one has none, which is what the limit left unanswered. Which limit
+         is read off the step count: the depth check runs before a frame
+         counts its step, so the count is over the step limit exactly when
+         the step check gave up. */
+      mrb_free(mrb, caps);
+      return m.steps > MRB_REGEXP_STEP_LIMIT ? RE_OVER_STEP_LIMIT : RE_OVER_RECURSION_LIMIT;
     }
   }
   mrb_free(mrb, caps);
@@ -1239,6 +1250,10 @@ mrb_re_rexec(mrb_state *mrb, const mrb_regexp_pattern *pat,
     if (len - lo > RE_RSEARCH_PROBE_SPAN) break;
     memset(captures, -1, sizeof(int) * captures_size);
     last_n = exec_range(mrb, pat, str, len, lo, limit, captures, captures_size, binary);
+    /* A match or a limit ends the probe. A limit is the answer to the whole
+       question and not to this window's: a window that gave up is not one
+       with no match in it, and widening would only ask the same search
+       again a size up. */
     if (last_n) break;
     /* The window had grown to the whole range, so there is no match to find
        and the search below would only ask again. */
@@ -1250,6 +1265,7 @@ mrb_re_rexec(mrb_state *mrb, const mrb_regexp_pattern *pat,
     last_n = exec_range(mrb, pat, str, len, 0, limit, captures, captures_size, binary);
     if (last_n == 0) return 0;
   }
+  if (last_n < 0) return last_n;
 
   /* Whichever range answered gave its leftmost match; the last one is found
      by walking forward from it. Each step resumes one byte past the match
@@ -1264,6 +1280,7 @@ mrb_re_rexec(mrb_state *mrb, const mrb_regexp_pattern *pat,
     memset(captures, -1, sizeof(int) * captures_size);
     int n = exec_range(mrb, pat, str, len, pos, limit, captures, captures_size, binary);
     if (n == 0) break;
+    if (n < 0) return n;
     last_n = n;
     memcpy(last, captures, sizeof(int) * captures_size);
     pos = captures[0] + 1;

--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -427,6 +427,22 @@ match_operand(mrb_state *mrb, mrb_value obj)
   return mrb_ensure_string_type(mrb, obj);
 }
 
+/* Raise if the search answered RE_OVER_*_LIMIT (see mrb_re_exec()): it gave
+   up at a limit, and what it had found by then is not a shorter or a later
+   match, so the caller raises rather than read it as one. A caller that
+   holds its capture buffer on the heap hands it over to be freed first,
+   nothing after the raise being there to free it; NULL where the caller
+   holds none or holds it on the stack. */
+static void
+re_check_over_limit(mrb_state *mrb, int n, int *captures)
+{
+  if (n >= 0) return;
+  mrb_free(mrb, captures);
+  mrb_raise(mrb, E_REGEXP_ERROR, n == RE_OVER_STEP_LIMIT
+            ? "step limit over (MRB_REGEXP_STEP_LIMIT)"
+            : "recursion limit over (MRB_REGEXP_RECURSION_LIMIT)");
+}
+
 /* Internal: execute match and create MatchData.
    Returns MatchData on match, nil on no match.
    Sets $~ and $1-$9 globals, and clears them on a miss. */
@@ -441,6 +457,7 @@ exec_match(mrb_state *mrb, mrb_value self, mrb_value str, mrb_int pos)
   memset(captures, -1, sizeof(int) * cap_size);
   int ncap = mrb_re_exec(mrb, pat, RSTRING_PTR(str), RSTRING_LEN(str), pos,
                      captures, cap_size, re_binary_string_p(str));
+  re_check_over_limit(mrb, ncap, captures);
 
   if (ncap == 0) {
     mrb_free(mrb, captures);
@@ -626,6 +643,7 @@ regexp_s_byte_rsearch(mrb_state *mrb, mrb_value klass)
   int *captures = (int*)mrb_malloc(mrb, sizeof(int) * cap_size);
   int ncap = mrb_re_rexec(mrb, pat, RSTRING_PTR(str), RSTRING_LEN(str), limit,
                           captures, cap_size, re_binary_string_p(str));
+  re_check_over_limit(mrb, ncap, captures);
   if (ncap == 0) {
     mrb_free(mrb, captures);
     clear_match_globals(mrb);
@@ -653,6 +671,7 @@ exec_match_p(mrb_state *mrb, mrb_value re, mrb_value str, mrb_int pos)
 
   int ncap = mrb_re_exec(mrb, pat, RSTRING_PTR(str), RSTRING_LEN(str), pos, NULL, 0,
                          re_binary_string_p(str));
+  re_check_over_limit(mrb, ncap, NULL);
   return mrb_bool_value(ncap > 0);
 }
 
@@ -1481,6 +1500,7 @@ regexp_s_gsub_str(mrb_state *mrb, mrb_value klass)
   while (pos <= slen) {
     memset(captures, -1, sizeof(int) * cap_size);
     int n = mrb_re_exec(mrb, pat, s, slen, pos, captures, cap_size, binary);
+    re_check_over_limit(mrb, n, NULL);
     if (n == 0) break;
 
     /* save last match for $~ */
@@ -1563,6 +1583,7 @@ regexp_s_sub_str(mrb_state *mrb, mrb_value klass)
   memset(captures, -1, sizeof(int) * cap_size);
 
   int n = mrb_re_exec(mrb, pat, s, slen, 0, captures, cap_size, re_binary_string_p(str));
+  re_check_over_limit(mrb, n, NULL);
   if (n == 0) {
     clear_match_globals(mrb);
     return mrb_str_dup(mrb, str);
@@ -1835,7 +1856,9 @@ regexp_s_gsub_block(mrb_state *mrb, mrb_value klass)
 
   while (pos <= slen) {
     memset(captures, -1, sizeof(int) * cap_size);
-    if (mrb_re_exec(mrb, pat, s, slen, pos, captures, cap_size, binary) == 0) break;
+    int n = mrb_re_exec(mrb, pat, s, slen, pos, captures, cap_size, binary);
+    re_check_over_limit(mrb, n, NULL);
+    if (n == 0) break;
     mrb_int beg = captures[0], end = captures[1];
 
     mrb_value matched = re_byte_substr(mrb, str, beg, end - beg);
@@ -1935,6 +1958,7 @@ regexp_s_scan(mrb_state *mrb, mrb_value klass)
   while (pos <= slen) {
     memset(captures, -1, sizeof(int) * cap_size);
     int n = mrb_re_exec(mrb, pat, s, slen, pos, captures, cap_size, binary);
+    re_check_over_limit(mrb, n, captures);
     if (n == 0) break;
 
     last_ncap = cap_size;
@@ -2158,6 +2182,11 @@ mrb_mruby_regexp_gem_init(mrb_state *mrb)
   mrb_define_const(mrb, re, "IGNORECASE", mrb_fixnum_value(1));
   mrb_define_const(mrb, re, "EXTENDED", mrb_fixnum_value(2));
   mrb_define_const(mrb, re, "MULTILINE", mrb_fixnum_value(4));
+  /* The two limits of the backtracking engine, which a build sets (see
+     re_internal.h) and a `RegexpError` names: the value behind the name, for
+     whoever has to size a subject or a pattern to the build it runs on. */
+  mrb_define_const(mrb, re, "RECURSION_LIMIT", mrb_int_value(mrb, MRB_REGEXP_RECURSION_LIMIT));
+  mrb_define_const(mrb, re, "STEP_LIMIT", mrb_int_value(mrb, MRB_REGEXP_STEP_LIMIT));
 
   /* Class methods */
   mrb_define_method(mrb, re, "initialize", regexp_init, MRB_ARGS_ARG(1, 2));

--- a/mrbgems/mruby-regexp/test/regexp_syntax.rb
+++ b/mrbgems/mruby-regexp/test/regexp_syntax.rb
@@ -215,6 +215,59 @@ assert("Regexp - a repetition of a lookaround or a backreference stops the same 
   assert_equal "abbc", /(?:(a)b|a(b)|\2)+c/.match("abbc")[0]
 end
 
+assert("Regexp - the backtracking engine raises at a limit rather than answer short") do
+  # A frame gives up at MRB_REGEXP_RECURSION_LIMIT or MRB_REGEXP_STEP_LIMIT,
+  # and the frames above it used to read that as the branch having failed and
+  # go on with their other branches: the search answered with a shorter match,
+  # a later one or none, told from the real answer by nothing. A limit is the
+  # search's answer now, and the caller raises on it; the same patterns match
+  # whole on a subject inside the limits, as in CRuby.
+  #
+  # The subjects are sized from the limits, which the build sets and the two
+  # constants read back. A repetition of an atomic group or a lookaround
+  # spends two or three frames per iteration, so a run of `a` as long as the
+  # recursion limit is past it for every pattern here and a quarter of that
+  # run is inside it; a chain of `(?=a)` or `(?>a)` spends two frames per
+  # link; `(a+)+\1b` spends about 2^n steps on a run of n. The n that reaches
+  # the step limit is counted by shifting the limit down rather than 1 up to
+  # it, so that a build setting the limit near the width of `mrb_int` has no
+  # shift of its own to overflow.
+  limit = Regexp::RECURSION_LIMIT
+  over = "a" * limit
+  fits = "a" * (limit / 4)
+  n = 0
+  n += 1 while (Regexp::STEP_LIMIT - 1) >> n > 0
+  steps = "a" * (n + 10)
+  assert_raise(RegexpError) { over.match(/(?:(?>a))*/) }       # answered a third of the run
+  assert_raise(RegexpError) { over.match(/(?:(?=a)a)*/) }      # a third of the run
+  assert_raise(RegexpError) { (over + "b").match(/(a)*?b/) }   # began past the middle
+  assert_raise(RegexpError) { over.match(/(?:(?>a))*\z/) }    # began past the middle
+  assert_raise(RegexpError) { "a".match(Regexp.new("(?=a)" * (limit / 2 + 1) + "a")) }   # was nil
+  assert_raise(RegexpError) { over.match(Regexp.new("(?>a)" * (limit / 2 + 1) + "a")) }  # was nil
+  assert_equal fits, fits.match(/(?:(?>a))*/)[0]
+  assert_equal fits, fits.match(/(?:(?=a)a)*/)[0]
+  assert_equal 0, (fits + "b").match(/(a)*?b/).begin(0)
+  assert_equal 0, fits.match(/(?:(?>a))*\z/).begin(0)
+  assert_equal "a", "a".match(Regexp.new("(?=a)" * (limit / 4) + "a"))[0]
+  assert_equal fits, fits.match(Regexp.new("(?>a)" * (limit / 4 - 1) + "a"))[0]
+  # The message names the limit, so that whoever hits one on a legitimate
+  # subject knows which knob to turn, and the constant says where it stands.
+  assert_raise_with_message(RegexpError, "recursion limit over (MRB_REGEXP_RECURSION_LIMIT)") do
+    over.match(/(?:(?>a))*/)
+  end
+  assert_raise_with_message(RegexpError, "step limit over (MRB_REGEXP_STEP_LIMIT)") do
+    steps.match(/(a+)+\1b/)
+  end
+  assert_kind_of Integer, Regexp::RECURSION_LIMIT
+  assert_kind_of Integer, Regexp::STEP_LIMIT
+  # A limit ends the search at the start position it was hit at: the
+  # positions after it would say where the first match is only once this one
+  # has none. The search that reads no captures raises the same.
+  assert_raise(RegexpError) { ("b" + over + "c").match(/b(?:(?>a))*c|a/) }   # began at 1
+  assert_raise(RegexpError) { over.match?(/(?:(?>a))*\z/) }
+  assert_raise(RegexpError) { /(?:(?>a))*\z/ === over }
+end
+
 assert("Regexp - quantified first alternative does not leak into the next") do
   # A quantifier loops back to its own atom. When the atom starts the first
   # alternative, the alternation SPLIT is inserted in front of it; the

--- a/mrbgems/mruby-regexp/test/string_index.rb
+++ b/mrbgems/mruby-regexp/test/string_index.rb
@@ -469,6 +469,44 @@ assert("a backward search answers a long multibyte subject") do
   assert_nil mb.byterindex(/うえ/, 3)
 end
 
+assert("a backward search raises where one of its searches hits a limit") do
+  # The search makes up to three searches: a window at the end that widens,
+  # the whole range when no window answers, and a walk forward from the match
+  # it found. A limit in any of them is the answer to the whole question, so
+  # each raises rather than read it as a window with no match in it, which
+  # would widen, or as the walk having run out of matches, which would answer
+  # the one before.
+  #
+  # The subjects are sized from the recursion limit, which the build sets and
+  # `Regexp::RECURSION_LIMIT` reads back. An atomic group nested d deep spends
+  # 2d frames per copy and one more per iteration of a repetition, and d is
+  # chosen so that a run inside the 256 bytes the window reads spends the
+  # limit; a build with a limit the window cannot reach sends the first and
+  # third cases through the whole-range search instead, where they raise the
+  # same.
+  limit = Regexp::RECURSION_LIMIT
+  d = limit / 600 + 1
+  atom = "a"
+  d.times { atom = "(?>#{atom})" }
+  # the window, grown to the whole subject: the lookbehind lets only position
+  # 0 try, and that one gives up
+  n = limit / (2 * d + 1) + 1
+  assert_raise(RegexpError) { ("a" * n + "b").rindex(/(?<!a)(?:#{atom})*b/) }   # was nil, CRuby 0
+  # the whole range, once no window within 256 bytes of the end has answered
+  assert_raise(RegexpError) { ("a" * limit + "b" + "c" * 300).rindex(/\A(?:(?>a))*b/) }  # was nil, CRuby 0
+  # the walk from the window's match at position 1 to position 2, which has
+  # the run the second alternative asks for and gives up on; the windows
+  # before the one that reaches position 1 have less than that run
+  n = limit / (2 * d) + 1
+  assert_raise(RegexpError) { ("x" + "a" * (n + 1) + "c").rindex(/(?<=x)a|(?:#{atom}){#{n}}c/) }  # was 1, CRuby 2
+  # Inside the limits the same three searches answer, as in CRuby.
+  n = limit / (2 * (2 * d + 1))
+  assert_equal 0, ("a" * n + "b").rindex(/(?<!a)(?:#{atom})*b/)
+  assert_equal 0, ("a" * (limit / 4) + "b" + "c" * 300).rindex(/\A(?:(?>a))*b/)
+  n = limit / (4 * d)
+  assert_equal 2, ("x" + "a" * (n + 1) + "c").rindex(/(?<=x)a|(?:#{atom}){#{n}}c/)
+end
+
 assert("String#index and String#rindex with regexp set the match globals") do
   assert_equal 1, "abc".index(/(b)/)
   assert_equal "b", $1

--- a/mrbgems/mruby-regexp/test/string_regexp.rb
+++ b/mrbgems/mruby-regexp/test/string_regexp.rb
@@ -1214,3 +1214,28 @@ assert("MatchData#regexp compiles a literal pattern only when asked for one") do
   "abc".sub("", "-")
   assert_equal "", $~.regexp.source
 end
+
+assert("String#sub / #gsub / #scan / #split raise where a search hits a limit") do
+  # A walk over the subject raises from the middle of it rather than hand
+  # back what it had: the matches before the limit are no more the answer
+  # than the shorter match a search itself used to settle for. The first
+  # search here matches the `b`; the second gives up on the run of `a`, three
+  # frames an iteration and as long as the recursion limit, and the walk used
+  # to go on past it to the tail of the run that fit before the `c`.
+  over = "a" * Regexp::RECURSION_LIMIT
+  fits = "a" * (Regexp::RECURSION_LIMIT / 4)
+  s = "b" + over + "c"
+  re = /b|(?:(?>a))*c/
+  assert_raise(RegexpError) { s.gsub(re, "x") }    # was "x" + most of the run + "x", CRuby "xx"
+  assert_raise(RegexpError) { s.scan(re) }         # was ["b", the tail of the run + "c"]
+  assert_raise(RegexpError) { s.split(re) }        # was ["", most of the run], CRuby []
+  assert_raise(RegexpError) { s.sub(/(?:(?>a))*c/, "x") }
+  n = 0
+  assert_raise(RegexpError) { s.gsub(re) { n += 1; "x" } }
+  assert_equal 1, n
+  # Inside the limits the walk goes through, as in CRuby.
+  t = "b" + fits + "c"
+  assert_equal "xx", t.gsub(re, "x")
+  assert_equal ["b", fits + "c"], t.scan(re)
+  assert_equal [], t.split(re)
+end


### PR DESCRIPTION
`bt_match()` answers `BT_LIMIT` when a frame would pass `MRB_REGEXP_RECURSION_LIMIT`
(1,000) or the search has spent `MRB_REGEXP_STEP_LIMIT` (1,000,000) steps, and
everything above it reads that as the branch having failed: the six forks in
`bt_match()` go on with their other branch, and `backtrack_exec()` moves on to the
next start position. Nothing raises, so a search that was cut short reports a
shorter match, a later one or none, and the caller cannot tell it from the real
answer:

```ruby
s = "a" * 2000
s.match(/(?:(?>a))*/)[0].size                       # CRuby: 2000,  mruby: 332
s.match(/(?:(?=a)a)*/)[0].size                      # CRuby: 2000,  mruby: 332
(s + "b").match(/(a)*?b/).begin(0)                  # CRuby: 0,     mruby: 1502
s.match(/(?:(?>a))*\z/).begin(0)                    # CRuby: 0,     mruby: 1668
"a".match(Regexp.new("(?=a)" * 500 + "a"))          # CRuby: match, mruby: nil
("b" + s + "c").match(/b(?:(?>a))*c|a/).begin(0)    # CRuby: 0,     mruby: 1
("b" + s + "c").scan(/b|(?:(?>a))*c/).last.size     # CRuby: 2001,  mruby: 333
("b" + s + "c").gsub(/b|(?:(?>a))*c/, "x")          # CRuby: "xx",  mruby: "x" + "a" * 1668 + "x"
```

The limits themselves stay: the recursion limit is what keeps a long subject off
the end of the C stack, and the step limit is the ReDoS guard. What is wrong is
what a limit means to the frames above it. #7256 settled that a limit is not a
cut and not a lookaround's answer, and left it as "the frame gives up and its
caller tries the next branch", which is what turns a limit into a partial answer.

## The fix

A limit says nothing about the text, so it is the search's answer and not a
branch's:

- every frame hands `BT_LIMIT` up unchanged, as it does a cut, so no frame
  answers with its other branch after one below it gave up (the six forks lose
  a comparison each);
- `backtrack_exec()` stops at the start position that answers it, the positions
  after it saying where the first match is only once this one has none;
- `mrb_re_exec()` and `mrb_re_rexec()` answer `RE_OVER_RECURSION_LIMIT` or
  `RE_OVER_STEP_LIMIT`, which limit it was being read off the step count;
  `mrb_re_rexec()` stops at a limit in any of its three searches, since a window
  that gave up is not one with no match in it, and a walk that gave up has no
  last match to answer with;
- the seven callers in `regexp.c` raise `RegexpError` on either through one
  helper, which frees the caller's capture buffer first where that buffer is on
  the heap, nothing after the raise being there to free it, and takes `NULL`
  from the four holding theirs on the stack or holding none. The message names
  the limit, so that whoever hits one on a legitimate subject knows which knob
  to turn:

```ruby
("a" * 2000).match(/(?:(?>a))*/)   # RegexpError: recursion limit over (MRB_REGEXP_RECURSION_LIMIT)
("a" * 30).match(/(a+)+\1b/)       # RegexpError: step limit over (MRB_REGEXP_STEP_LIMIT)
("a" * 300).match(/(?:(?>a))*/)[0].size   # 300, as before
```

CRuby's own guards answer the same way: `Regexp.timeout` raises
`Regexp::TimeoutError`, and Onigmo's match-stack limit, where set, raises
`RegexpError` (`match-stack limit over`), rather than answer with what the
search had by then.

The values a build chose for the two limits are read back as
`Regexp::RECURSION_LIMIT` and `Regexp::STEP_LIMIT`, for a program that has to
size a subject or a pattern to the build it runs on, as `Float::MANT_DIG` reads
back `MRB_FLT_MANT_DIG`; CRuby has no counterpart, its guard being
`Regexp.timeout`. The tests size their subjects from the two.

This does not make the subjects above match; that takes the per-iteration
recursion off the C stack, and once this is in, that change's effect is
measurable as raises that become matches. The README names both limits, the
two constants and what reaching a limit does.

## Size

`.text` of `bin/mruby`, `build_config/ci/gcc-clang.rb`, each side from a clean
build directory at the same path. Two objects change: `re_exec.o` for the stop
in `backtrack_exec()` and the three checks in `mrb_re_rexec()` (+32 in
`bintest`, the six comparisons it loses paying for most of those), and
`regexp.o` for the helper with its seven calls and the two constants (+160 in
`bintest`).

| build | master | this PR | delta |
|---|---:|---:|---:|
| `bintest` | 1,286,550 | 1,286,742 | +192 |
| `ascii-ctype` | 1,273,398 | 1,273,702 | +304 |
| `byte-string` | 1,254,982 | 1,255,526 | +544 |
| `cxx_abi` | 1,311,417 | 1,312,025 | +608 |
| `full-debug` (`-O0`) | 1,889,910 | 1,890,390 | +480 |

## Verification

The tests go in three files by subject, and size their subjects from the two
constants: a repetition of an atomic group or a lookaround spends two or three
frames per iteration, so a run as long as `RECURSION_LIMIT` is past the limit
and a quarter of it inside; `(a+)+\1b` spends about 2^n steps on a run of n,
so a run of `log2(STEP_LIMIT) + 10` is past the step limit. `regexp_syntax.rb`,
beside the empty-iteration tests: the subjects above raise, the same patterns
match whole inside the limits, each message names its limit, a limit at the
first start position is not answered by the second, and `match?` and `===`
raise the same. `string_regexp.rb`: `sub`, `gsub` (with and without a block),
`scan` and `split` raise from the middle of a subject rather than return what
they had, the block having run once. `string_index.rb`: `rindex` raises from
each of the three searches of `mrb_re_rexec()` on a subject CRuby answers and
master answers wrongly, and answers from each inside the limits; the atomic
group there is nested as deep as the limit asks, so that the run fits the 256
bytes the window reads. On master every `assert_raise` in the three blocks
fails, and the `rindex` walk case loops without the check in the walk. The
suite is also green on two builds with other limits, `RECURSION_LIMIT=3000`
with `STEP_LIMIT=100000` and `RECURSION_LIMIT=500` with
`STEP_LIMIT=20000000`.

**Differential against CRuby 4.0.6**, the harness of #7269 and #7273 with
master and this PR against the same cases: 10,000 random patterns (seed 2, the
default features, over `a` and `b`), each matched against one subject and
compared as `MatchData#to_a`. 9,967 answer the same everywhere. 27 differ from
CRuby on master and on this PR alike, the standing differences of the engine.
4 raise the step limit on this PR where master answered `nil`, as CRuby does:
each is a pattern of nested empty-matching repetitions and backreferences over
a subject of two to four bytes, where master read the limit as no match at that
start position and went on to answer `nil` for the rest. CRuby cannot finish 2
under its timeout and memory cap; both sides answer those `nil` on master and
here.

**`rake test`**, `build_config/ci/gcc-clang.rb`, no compiler warning:

| build | total | KO | crash |
|---|---:|---:|---:|
| `full-debug` | 2,391 | 0 | 0 |
| `bintest` | 2,391 | 0 | 0 |
| `bintest` (bintest suite) | 123 | 0 | 0 |
| `cxx_abi` | 2,391 | 0 | 0 |
| `byte-string` | 2,317 | 0 | 0 |
| `ascii-ctype` | 2,384 | 0 | 0 |

The default configuration: 2,162 total, 0 KO, 0 crash, plus its 112 bintests.
`build_config/gcc-asan.rb`, which the two `sub` and `gsub` call sites answer to
since #7282 stands their capture buffers on the stack: 2,391 total, 0 KO,
0 crash, no sanitizer report.

### Environment

<details>

| | |
|---|---|
| OS | Ubuntu 24.04, Linux 7.0.0 x86_64, AMD Ryzen 9 5950X |
| gcc | 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1) |
| binutils | 2.47 |
| CRuby | 4.0.6, for the differential |

Compile lines for `mrbgems/mruby-regexp/src/re_exec.c` in the builds quoted
above, paths shortened:

```
# ci/gcc-clang full-debug
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -I"include" -I"mrbgems/mruby-regexp/include" -I"build/full-debug/include" -o "build/full-debug/mrbgems/mruby-regexp/src/re_exec.o" "mrbgems/mruby-regexp/src/re_exec.c"

# ci/gcc-clang bintest
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK -I"include" -I"mrbgems/mruby-regexp/include" -I"build/bintest/include" -o "build/bintest/mrbgems/mruby-regexp/src/re_exec.o" "mrbgems/mruby-regexp/src/re_exec.c"

# ci/gcc-clang cxx_abi
gcc -MMD -c -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -I"include" -I"mrbgems/mruby-regexp/include" -I"build/cxx_abi/include" -o "build/cxx_abi/mrbgems/mruby-regexp/src/re_exec.o" "mrbgems/mruby-regexp/src/re_exec.c"

# ci/gcc-clang byte-string
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -I"include" -I"mrbgems/mruby-regexp/include" -I"build/byte-string/include" -o "build/byte-string/mrbgems/mruby-regexp/src/re_exec.o" "mrbgems/mruby-regexp/src/re_exec.c"

# ci/gcc-clang ascii-ctype
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -I"include" -I"mrbgems/mruby-regexp/include" -I"build/ascii-ctype/include" -o "build/ascii-ctype/mrbgems/mruby-regexp/src/re_exec.o" "mrbgems/mruby-regexp/src/re_exec.c"
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Unicode-aware POSIX character classes for regular expressions.
  - Exposed configurable recursion and step limits through `Regexp::RECURSION_LIMIT` and `Regexp::STEP_LIMIT`.
  - Searches exceeding either limit now raise `RegexpError` with a specific message.

- **Bug Fixes**
  - Corrected matching, reverse searches, substitutions, scanning, and splitting so limit errors are not treated as failed matches.

- **Documentation**
  - Documented POSIX syntax, limit configuration, capture behavior after limit errors, and compatibility details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
