### PR TITLE
mruby-regexp: read `\k<name>` in a sub or gsub replacement

### DIFF
--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -911,6 +911,27 @@ regexp_escape(mrb_state *mrb, mrb_value self)
   return re_escape_str(mrb, str);
 }
 
+/* Answer the group a pattern gives a name to, or -1 for a name it gives to
+   no group. The name is compared as the bytes the pattern spelled it with.
+   A NULL pattern names nothing, which is the answer for a match made
+   without a pattern to compile: a literal String one. */
+static int
+re_name_to_group(mrb_regexp_pattern *pat, const char *name, mrb_int name_len)
+{
+  /* A stored name never exceeds RE_MAX_NAME_LEN, so a longer request can
+     name no group. Rejecting it here keeps the cast in the loop lossless;
+     without it the length test truncates while the memcmp() next to it does
+     not. */
+  if (!pat || !RE_NAME_LEN_FITS(name_len)) return -1;
+  for (uint16_t i = 0; i < pat->num_named; i++) {
+    if (pat->named_captures[i].name_len == (uint32_t)name_len &&
+        memcmp(pat->named_captures[i].name, name, name_len) == 0) {
+      return pat->named_captures[i].group;
+    }
+  }
+  return -1;
+}
+
 /* --- MatchData methods --- */
 
 /* Resolve a String or Symbol to the group it names. Shared by MatchData#[],
@@ -929,23 +950,12 @@ matchdata_name_to_group(mrb_state *mrb, mrb_match_data *md, mrb_value arg)
     name = RSTRING_PTR(arg);
     name_len = RSTRING_LEN(arg);
   }
-  /* look up name in regexp's named captures */
   mrb_regexp_pattern *pat = NULL;
   if (!mrb_nil_p(md->regexp)) {
     pat = DATA_GET_PTR(mrb, md->regexp, &regexp_type, mrb_regexp_pattern);
   }
-  /* A stored name never exceeds RE_MAX_NAME_LEN, so a longer request can
-     name no group. Rejecting it here keeps the cast in the loop lossless;
-     without it the length test truncates while the memcmp() next to it does
-     not. */
-  if (pat && RE_NAME_LEN_FITS(name_len)) {
-    for (uint16_t i = 0; i < pat->num_named; i++) {
-      if (pat->named_captures[i].name_len == (uint32_t)name_len &&
-          memcmp(pat->named_captures[i].name, name, name_len) == 0) {
-        return pat->named_captures[i].group;
-      }
-    }
-  }
+  int group = re_name_to_group(pat, name, name_len);
+  if (group >= 0) return group;
   /* A name that resolves to no group is a mistake at the point of the call,
      not a failed match. CRuby raises here even when the pattern has no
      named group at all. */
@@ -1302,11 +1312,15 @@ matchdata_to_s(mrb_state *mrb, mrb_value self)
 
 /* --- C-level gsub/sub/scan core --- */
 
-/* Process replacement string: expand \0-\9, \&, \`, \', \+, \\ */
+/* Process replacement string: expand \0-\9, \&, \`, \', \+, \k<name>, \\.
+   `pat` is the pattern the match was made with, which is what a name is
+   resolved against; a literal String pattern hands in NULL, and every name
+   asked of it is then a name no group carries. */
 static void
 apply_replacement(mrb_state *mrb, mrb_value result,
                   const char *rep, mrb_int rep_len,
-                  const char *str, mrb_int str_len, int *captures, int ncap)
+                  const char *str, mrb_int str_len, int *captures, int ncap,
+                  mrb_regexp_pattern *pat)
 {
   mrb_int i = 0;
   while (i < rep_len) {
@@ -1317,11 +1331,33 @@ apply_replacement(mrb_state *mrb, mrb_value result,
          or one that took no part in the match stands for nothing. */
       int g = -1;
       mrb_bool ref = TRUE;
+      /* Every escape but `\k<name>` is the two bytes it opened with. */
+      mrb_int next = i + 2;
       if (c >= '0' && c <= '9') {
         g = c - '0';
       }
       else if (c == '&') {
         g = 0;
+      }
+      else if (c == 'k' && i + 2 < rep_len && rep[i + 2] == '<') {
+        /* A group named where `\1` numbers one. The name is the bytes up to
+           the first `>`, with no escape among them, and only this spelling
+           opens a reference: `\k'name'`, which the pattern side does read as
+           a backreference, is left to the literal branch below. */
+        const char *name = rep + i + 3;
+        const char *close = (const char*)memchr(name, '>', (size_t)(rep_len - (i + 3)));
+        if (close == NULL) {
+          mrb_raise(mrb, E_RUNTIME_ERROR, "invalid group name reference format");
+        }
+        mrb_int name_len = close - name;
+        /* What the name is asked of is the pattern, not the offsets, so a
+           name no group carries raises where a group that took no part in
+           the match would only have stood for nothing. */
+        g = re_name_to_group(pat, name, name_len);
+        if (g < 0) {
+          mrb_raisef(mrb, E_INDEX_ERROR, "undefined group name reference: %l", name, (size_t)name_len);
+        }
+        next = (close - rep) + 1;
       }
       else if (c == '+') {
         /* last successful capture */
@@ -1361,7 +1397,7 @@ apply_replacement(mrb_state *mrb, mrb_value result,
       else {
         mrb_str_cat(mrb, result, rep + i, 2);  /* \x as-is */
       }
-      i += 2;
+      i = next;
     }
     else {
       /* find next backslash or end for batch copy */
@@ -1451,7 +1487,7 @@ regexp_s_gsub_str(mrb_state *mrb, mrb_value klass)
 
     /* append replacement */
     if (need_expand) {
-      apply_replacement(mrb, result, rep, rep_len, s, slen, captures, ncap);
+      apply_replacement(mrb, result, rep, rep_len, s, slen, captures, ncap, pat);
     }
     else {
       mrb_str_cat(mrb, result, rep, rep_len);
@@ -1534,7 +1570,7 @@ regexp_s_sub_str(mrb_state *mrb, mrb_value klass)
 
   /* replacement */
   if (has_backslash(rep, rep_len)) {
-    apply_replacement(mrb, result, rep, rep_len, s, slen, captures, pat->num_captures);
+    apply_replacement(mrb, result, rep, rep_len, s, slen, captures, pat->num_captures, pat);
   }
   else {
     mrb_str_cat(mrb, result, rep, rep_len);
@@ -1656,7 +1692,7 @@ regexp_s_gsub_lit(mrb_state *mrb, mrb_value klass)
 
     if (beg > pos) re_cat_bytes(mrb, result, s + pos, beg - pos, binary);
     if (need_expand) {
-      apply_replacement(mrb, result, rep, rep_len, s, slen, captures, 1);
+      apply_replacement(mrb, result, rep, rep_len, s, slen, captures, 1, NULL);
     }
     else {
       mrb_str_cat(mrb, result, rep, rep_len);
@@ -1718,7 +1754,7 @@ regexp_s_sub_lit(mrb_state *mrb, mrb_value klass)
     int captures[2];
     captures[0] = (int)beg;
     captures[1] = (int)end;
-    apply_replacement(mrb, result, rep, rep_len, s, slen, captures, 1);
+    apply_replacement(mrb, result, rep, rep_len, s, slen, captures, 1, NULL);
   }
   else {
     mrb_str_cat(mrb, result, rep, rep_len);

--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -1420,7 +1420,7 @@ regexp_s_gsub_str(mrb_state *mrb, mrb_value klass)
 
   int ncap = pat->num_captures;
   int cap_size = ncap * 2;
-  int *captures = (int*)mrb_malloc(mrb, sizeof(int) * cap_size);
+  int captures[RE_MAX_CAPTURES * 2];
   mrb_value result = mrb_str_new_capa(mrb, slen);
   int ai = mrb_gc_arena_save(mrb);
 
@@ -1475,8 +1475,6 @@ regexp_s_gsub_str(mrb_state *mrb, mrb_value klass)
     mrb_str_cat(mrb, result, s + pos, slen - pos);
   }
 
-  mrb_free(mrb, captures);
-
   /* set $~ from last match */
   if (last_ncap > 0) {
     create_matchdata(mrb, re, str, last_captures, last_ncap);
@@ -1511,12 +1509,11 @@ regexp_s_sub_str(mrb_state *mrb, mrb_value klass)
   mrb_int rep_len = RSTRING_LEN(replacement);
 
   int cap_size = pat->num_captures * 2;
-  int *captures = (int*)mrb_malloc(mrb, sizeof(int) * cap_size);
+  int captures[RE_MAX_CAPTURES * 2];
   memset(captures, -1, sizeof(int) * cap_size);
 
   int n = mrb_re_exec(mrb, pat, s, slen, 0, captures, cap_size, re_binary_string_p(str));
   if (n == 0) {
-    mrb_free(mrb, captures);
     clear_match_globals(mrb);
     return mrb_str_dup(mrb, str);
   }
@@ -1542,7 +1539,6 @@ regexp_s_sub_str(mrb_state *mrb, mrb_value klass)
   }
 
   create_matchdata(mrb, re, str, captures, cap_size);
-  mrb_free(mrb, captures);
   re_mark_spliced(result, str, replacement, TRUE);
   return result;
 }

--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -1312,16 +1312,33 @@ apply_replacement(mrb_state *mrb, mrb_value result,
   while (i < rep_len) {
     if (rep[i] == '\\' && i + 1 < rep_len) {
       char c = rep[i + 1];
+      /* The escapes that stand for a group settle on one here, and the append
+         below is the only one that spends it: a group the escape reaches past
+         or one that took no part in the match stands for nothing. */
+      int g = -1;
+      mrb_bool ref = TRUE;
       if (c >= '0' && c <= '9') {
-        int g = c - '0';
-        if (g < ncap && captures[g * 2] >= 0) {
-          int s = captures[g * 2], e = captures[g * 2 + 1];
-          mrb_str_cat(mrb, result, str + s, e - s);
-        }
+        g = c - '0';
       }
       else if (c == '&') {
-        if (captures[0] >= 0) {
-          mrb_str_cat(mrb, result, str + captures[0], captures[1] - captures[0]);
+        g = 0;
+      }
+      else if (c == '+') {
+        /* last successful capture */
+        for (int j = ncap - 1; j >= 1; j--) {
+          if (captures[j * 2] >= 0) {
+            g = j;
+            break;
+          }
+        }
+      }
+      else {
+        ref = FALSE;
+      }
+      if (ref) {
+        if (g >= 0 && g < ncap && captures[g * 2] >= 0) {
+          int s = captures[g * 2], e = captures[g * 2 + 1];
+          mrb_str_cat(mrb, result, str + s, e - s);
         }
       }
       else if (c == '`') {
@@ -1336,16 +1353,6 @@ apply_replacement(mrb_state *mrb, mrb_value result,
              NUL bytes or be a non-NUL-terminated shared substring, in which
              case strlen() underflows the length (issue #6892). */
           mrb_str_cat(mrb, result, str + captures[1], str_len - captures[1]);
-        }
-      }
-      else if (c == '+') {
-        /* last successful capture */
-        for (int g = ncap - 1; g >= 1; g--) {
-          if (captures[g * 2] >= 0) {
-            int s = captures[g * 2], e = captures[g * 2 + 1];
-            mrb_str_cat(mrb, result, str + s, e - s);
-            break;
-          }
         }
       }
       else if (c == '\\') {

--- a/mrbgems/mruby-regexp/test/string_regexp.rb
+++ b/mrbgems/mruby-regexp/test/string_regexp.rb
@@ -641,6 +641,58 @@ assert("String#gsub with \\& special") do
   assert_equal "[a][b][c]", "abc".gsub(/./, '[\\&]')
 end
 
+assert("String#sub / #gsub expand \\k<name> in the replacement") do
+  assert_equal "ab!", "ab".sub(/(?<x>b)/, '\k<x>!')
+  assert_equal "acb", "abc".sub(/(?<x>b)(?<y>c)/, '\k<y>\k<x>')
+  assert_equal "abb", "ab".sub(/(?<x>b)/, '\k<x>\k<x>')
+  assert_equal "a<b>a<b>", "abab".gsub(/(?<x>b)/, '<\k<x>>')
+  assert_equal "aBb", "ab".dup.sub!(/(?<x>b)/, 'B\k<x>')
+  # A group that took no part in the match stands for nothing, the way a
+  # numbered reference to one does.
+  assert_equal "a[]", "ab".sub(/(?<x>c)?b/, '[\k<x>]')
+  # The name is the bytes between the angles, so a multibyte one reaches its
+  # group without the replacement being read as characters.
+  assert_equal "ab!", "ab".sub(/(?<あ>b)/, '\k<あ>!')
+  # Only `\k<` opens a reference: every other spelling is the literal it was,
+  # `\k'name'` among them, which the pattern side does accept as a backref.
+  assert_equal "a\\kx", "ab".sub(/(?<x>b)/, '\kx')
+  assert_equal "az\\k", "ab".sub(/(?<x>b)/, 'z\k')
+  assert_equal "a\\k'x'", "ab".sub(/(?<x>b)/, "\\k'x'")
+  assert_equal "a\\k<x>", "ab".sub(/(?<x>b)/, '\\\\k<x>')
+end
+
+assert("String#sub / #gsub raise for a replacement that names no group") do
+  msg = "undefined group name reference: y"
+  assert_raise_with_message(IndexError, msg) { "ab".sub(/(?<x>b)/, '\k<y>') }
+  assert_raise_with_message(IndexError, msg) { "abab".gsub(/(?<x>b)/, '\k<y>') }
+  assert_raise_with_message(IndexError, msg) { "ab".dup.sub!(/(?<x>b)/, '\k<y>') }
+  # A pattern that names no group at all, and a literal String pattern, which
+  # has no groups to name.
+  assert_raise_with_message(IndexError, msg) { "ab".sub(/b/, '\k<y>') }
+  assert_raise_with_message(IndexError, msg) { "ab".sub("b", '\k<y>') }
+  assert_raise_with_message(IndexError, msg) { "abab".gsub("b", '\k<y>') }
+  # Group 0 is a number, and no name at all is no name.
+  assert_raise_with_message(IndexError, "undefined group name reference: 0") do
+    "ab".sub(/(?<x>b)/, '\k<0>')
+  end
+  assert_raise_with_message(IndexError, "undefined group name reference: ") do
+    "ab".sub(/(?<x>b)/, '\k<>')
+  end
+  # Nothing matched, so nothing expanded the replacement and nothing asked
+  # the pattern for the name.
+  assert_equal "zz", "zz".sub(/(?<x>b)/, '\k<y>')
+  assert_equal "zz", "zz".gsub("b", '\k<y>')
+end
+
+assert("String#sub / #gsub raise for a replacement whose \\k< is unclosed") do
+  msg = "invalid group name reference format"
+  assert_raise_with_message(RuntimeError, msg) { "ab".sub(/(?<x>b)/, '\k<x') }
+  assert_raise_with_message(RuntimeError, msg) { "ab".sub(/(?<x>b)/, '\k<') }
+  assert_raise_with_message(RuntimeError, msg) { "abab".gsub(/(?<x>b)/, '\k<x') }
+  assert_raise_with_message(RuntimeError, msg) { "ab".sub("b", '\k<x') }
+  assert_equal "zz", "zz".sub(/(?<x>b)/, '\k<x')
+end
+
 assert("String#scan") do
   assert_equal ["1", "2", "3"], "a1b2c3".scan(Regexp.new("\\d"))
 end


### PR DESCRIPTION
A replacement string reads `\1` through `\9` for a group the pattern numbered,
and `\&` for the whole match, but nothing read `\k<name>` for a group the
pattern named. The reference is copied out as the text it was spelled with, a
wrong answer that nothing reports:

```ruby
"ab".sub(/(?<x>b)/, '\k<x>!')               # CRuby: "ab!",       mruby: "a\\k<x>!"
"abc".sub(/(?<x>b)(?<y>c)/, '\k<y>\k<x>')   # CRuby: "acb",       mruby: "a\\k<y>\\k<x>"
"abab".gsub(/(?<x>b)/, '<\k<x>>')           # CRuby: "a<b>a<b>",  mruby: "a<\\k<x>>a<\\k<x>>"
"ab".sub(/(?<x>b)/, '\k<y>')                # CRuby: IndexError,  mruby: "a\\k<y>"
"ab".sub(/(?<x>b)/, '\k<x')                 # CRuby: RuntimeError, mruby: "a\\k<x"
```

The pattern side reads the same spelling as a backreference, so a pattern can
name a group and refer to it within itself; the replacement is the one place
where the name says nothing.

## The fix

`apply_replacement()` is handed the pattern the match was made with, and `\k<`
opens a reference to a group that pattern names:

- The name is the bytes up to the first `>`, with no escape among them, which
  is where CRuby ends it. Only this spelling opens a reference, so `\k'name'`,
  which the pattern side does read as a backreference, stays the literal it was
  here as it does in CRuby, and so does a `\k` that no `<` follows.
- The group is asked of the pattern, not of the offsets the match left, so a
  name no group carries raises `IndexError` where a group of that name would
  only have stood for nothing. A pattern that names no group at all is asked
  the same question, and so is a literal String pattern, which has no group to
  name:

```ruby
"ab".sub(/(?<x>c)?b/, '[\k<x>]')   # "a[]": the group took no part in the match
"ab".sub(/b/, '\k<y>')             # IndexError: undefined group name reference: y
"ab".sub("b", '\k<y>')             # IndexError: undefined group name reference: y
```

- An unclosed `\k<` is a mistake of a different kind and raises `RuntimeError`
  (`invalid group name reference format`), as CRuby has it.
- Nothing is asked of the pattern when nothing matched, a replacement being
  expanded once per match: `"zz".sub(/(?<x>b)/, '\k<y>')` answers `"zz"` on
  both sides.

The lookup itself is the one `MatchData#[]` makes for a String or Symbol name,
extracted so that both sides read a name the same way.

Two commits come before it. The capture buffer of `__sub_str` and `__gsub_str`
moves to the stack, where the block core beside them already keeps its own and
where `__gsub_str`'s copy of the last match already stands, so that the raise
above leaves nothing behind; `RE_MAX_CAPTURES` bounds it at 256 bytes whatever
the pattern. Then the escapes that stand for a group (`\0` to `\9`, `\&`, `\+`)
fold onto a single append, so that the new reference is one more way to say
which group is meant rather than a fourth copy of the copy-out.

## Size

`.text` of `bin/mruby`, `build_config/ci/gcc-clang.rb`, each side from a clean
build directory at the same path. `regexp.o` is the only object that changes.

| build | master | this PR | delta |
|---|---:|---:|---:|
| `bintest` | 1,284,790 | 1,285,094 | +304 |
| `ascii-ctype` | 1,272,742 | 1,273,046 | +304 |
| `byte-string` | 1,254,262 | 1,254,614 | +352 |
| `cxx_abi` | 1,309,545 | 1,309,977 | +432 |
| `full-debug` (`-O0`) | 1,888,262 | 1,888,566 | +304 |

The two commits ahead of the reference are worth -80 to -384 of that on their
own: the fold is -48 in every build but `full-debug`, where it is -144, and the
buffer the rest. The reference costs +416 to +688 on top of them, and +560 to
+848 without the fold ahead of it, `apply_replacement()` being inlined into a
second, constant-propagated copy for the two literal cores, so that both copies
carry whatever the branch weighs.

## Verification

The tests go in `string_regexp.rb`, beside the block for `\&`, `` \` `` and
`\'`: what a name reaches, in `sub`, `sub!` and `gsub`, over two names, a
repeated name, a group that took no part in the match, and a multibyte name;
the four spellings that are not a reference; the names that reach no group,
through a named pattern, an unnamed one and a literal String pattern, with
group `0` and the empty name among them; and the unclosed `\k<`, including the
one at the very end of the replacement. Each case that raises has a companion
that matched nothing and so does not raise. 19 of the 26 assertions fail on
master.

Every case above was run against CRuby 4.0.6 first, and this branch answers all
26 as CRuby does.

**`rake test`**, `build_config/ci/gcc-clang.rb`, no compiler warning:

| build | total | KO | crash |
|---|---:|---:|---:|
| `full-debug` | 2,382 | 0 | 0 |
| `bintest` | 2,382 | 0 | 0 |
| `bintest` (bintest suite) | 123 | 0 | 0 |
| `cxx_abi` | 2,382 | 0 | 0 |
| `byte-string` | 2,311 | 0 | 0 |
| `ascii-ctype` | 2,378 | 0 | 0 |

The default configuration: 2,157 total, 0 KO, 0 crash, plus its 112 bintests.

### Environment

<details>

| | |
|---|---|
| OS | Ubuntu 24.04, Linux 7.0.0 x86_64, AMD Ryzen 9 5950X |
| gcc | 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1) |
| binutils | 2.47 |
| CRuby | 4.0.6, for the comparison |

Compile lines for `mrbgems/mruby-regexp/src/regexp.c` in the builds quoted
above, paths shortened:

```
# ci/gcc-clang full-debug
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -I"include" -I"mrbgems/mruby-regexp/include" -I"build/full-debug/include" -o "build/full-debug/mrbgems/mruby-regexp/src/regexp.o" "mrbgems/mruby-regexp/src/regexp.c"

# ci/gcc-clang bintest
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK -I"include" -I"mrbgems/mruby-regexp/include" -I"build/bintest/include" -o "build/bintest/mrbgems/mruby-regexp/src/regexp.o" "mrbgems/mruby-regexp/src/regexp.c"

# ci/gcc-clang cxx_abi
gcc -MMD -c -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -I"include" -I"mrbgems/mruby-regexp/include" -I"build/cxx_abi/include" -o "build/cxx_abi/mrbgems/mruby-regexp/src/regexp.o" "mrbgems/mruby-regexp/src/regexp.c"

# ci/gcc-clang byte-string
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -I"include" -I"mrbgems/mruby-regexp/include" -I"build/byte-string/include" -o "build/byte-string/mrbgems/mruby-regexp/src/regexp.o" "mrbgems/mruby-regexp/src/regexp.c"

# ci/gcc-clang ascii-ctype
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -I"include" -I"mrbgems/mruby-regexp/include" -I"build/ascii-ctype/include" -o "build/ascii-ctype/mrbgems/mruby-regexp/src/regexp.o" "mrbgems/mruby-regexp/src/regexp.c"
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Replacement strings now support named capture references using `\k<name>` with `String#sub`, `String#gsub`, `String#sub!`, and `String#gsub!`.
  - Named references expand to the corresponding captured text, including multibyte names and repeated references.

- **Bug Fixes**
  - Invalid or undefined named references now produce clear errors.
  - Unmatched patterns leave replacement text unexpanded without raising errors.
  - Literal string substitutions correctly reject named capture references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->