### PR TITLE
mruby-regexp: turn `\1` through `\9` off in a replacement that names a group

### DIFF
--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -1335,6 +1335,13 @@ apply_replacement(mrb_state *mrb, mrb_value result,
       mrb_int next = i + 2;
       if (c >= '0' && c <= '9') {
         g = c - '0';
+        /* A pattern that names a group turns `\1` through `\9` off, the same
+           rule that stops a plain `(...)` from taking a number there: the
+           number a named group answers to for `md[1]` is not one a
+           replacement may spend, and `\k<name>` is what reaches it. `\0` is
+           the whole match, which naming a group does not touch, and neither
+           do `\&` and `\+` below. */
+        if (g > 0 && pat && pat->num_named > 0) g = -1;
       }
       else if (c == '&') {
         g = 0;

--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -911,6 +911,27 @@ regexp_escape(mrb_state *mrb, mrb_value self)
   return re_escape_str(mrb, str);
 }
 
+/* Answer the group a pattern gives a name to, or -1 for a name it gives to
+   no group. The name is compared as the bytes the pattern spelled it with.
+   A NULL pattern names nothing, which is the answer for a match made
+   without a pattern to compile: a literal String one. */
+static int
+re_name_to_group(mrb_regexp_pattern *pat, const char *name, mrb_int name_len)
+{
+  /* A stored name never exceeds RE_MAX_NAME_LEN, so a longer request can
+     name no group. Rejecting it here keeps the cast in the loop lossless;
+     without it the length test truncates while the memcmp() next to it does
+     not. */
+  if (!pat || !RE_NAME_LEN_FITS(name_len)) return -1;
+  for (uint16_t i = 0; i < pat->num_named; i++) {
+    if (pat->named_captures[i].name_len == (uint32_t)name_len &&
+        memcmp(pat->named_captures[i].name, name, name_len) == 0) {
+      return pat->named_captures[i].group;
+    }
+  }
+  return -1;
+}
+
 /* --- MatchData methods --- */
 
 /* Resolve a String or Symbol to the group it names. Shared by MatchData#[],
@@ -929,23 +950,12 @@ matchdata_name_to_group(mrb_state *mrb, mrb_match_data *md, mrb_value arg)
     name = RSTRING_PTR(arg);
     name_len = RSTRING_LEN(arg);
   }
-  /* look up name in regexp's named captures */
   mrb_regexp_pattern *pat = NULL;
   if (!mrb_nil_p(md->regexp)) {
     pat = DATA_GET_PTR(mrb, md->regexp, &regexp_type, mrb_regexp_pattern);
   }
-  /* A stored name never exceeds RE_MAX_NAME_LEN, so a longer request can
-     name no group. Rejecting it here keeps the cast in the loop lossless;
-     without it the length test truncates while the memcmp() next to it does
-     not. */
-  if (pat && RE_NAME_LEN_FITS(name_len)) {
-    for (uint16_t i = 0; i < pat->num_named; i++) {
-      if (pat->named_captures[i].name_len == (uint32_t)name_len &&
-          memcmp(pat->named_captures[i].name, name, name_len) == 0) {
-        return pat->named_captures[i].group;
-      }
-    }
-  }
+  int group = re_name_to_group(pat, name, name_len);
+  if (group >= 0) return group;
   /* A name that resolves to no group is a mistake at the point of the call,
      not a failed match. CRuby raises here even when the pattern has no
      named group at all. */
@@ -1302,11 +1312,15 @@ matchdata_to_s(mrb_state *mrb, mrb_value self)
 
 /* --- C-level gsub/sub/scan core --- */
 
-/* Process replacement string: expand \0-\9, \&, \`, \', \+, \\ */
+/* Process replacement string: expand \0-\9, \&, \`, \', \+, \k<name>, \\.
+   `pat` is the pattern the match was made with, which is what a name is
+   resolved against; a literal String pattern hands in NULL, and every name
+   asked of it is then a name no group carries. */
 static void
 apply_replacement(mrb_state *mrb, mrb_value result,
                   const char *rep, mrb_int rep_len,
-                  const char *str, mrb_int str_len, int *captures, int ncap)
+                  const char *str, mrb_int str_len, int *captures, int ncap,
+                  mrb_regexp_pattern *pat)
 {
   mrb_int i = 0;
   while (i < rep_len) {
@@ -1317,11 +1331,33 @@ apply_replacement(mrb_state *mrb, mrb_value result,
          or one that took no part in the match stands for nothing. */
       int g = -1;
       mrb_bool ref = TRUE;
+      /* Every escape but `\k<name>` is the two bytes it opened with. */
+      mrb_int next = i + 2;
       if (c >= '0' && c <= '9') {
         g = c - '0';
       }
       else if (c == '&') {
         g = 0;
+      }
+      else if (c == 'k' && i + 2 < rep_len && rep[i + 2] == '<') {
+        /* A group named where `\1` numbers one. The name is the bytes up to
+           the first `>`, with no escape among them, and only this spelling
+           opens a reference: `\k'name'`, which the pattern side does read as
+           a backreference, is left to the literal branch below. */
+        const char *name = rep + i + 3;
+        const char *close = (const char*)memchr(name, '>', (size_t)(rep_len - (i + 3)));
+        if (close == NULL) {
+          mrb_raise(mrb, E_RUNTIME_ERROR, "invalid group name reference format");
+        }
+        mrb_int name_len = close - name;
+        /* What the name is asked of is the pattern, not the offsets, so a
+           name no group carries raises where a group that took no part in
+           the match would only have stood for nothing. */
+        g = re_name_to_group(pat, name, name_len);
+        if (g < 0) {
+          mrb_raisef(mrb, E_INDEX_ERROR, "undefined group name reference: %l", name, (size_t)name_len);
+        }
+        next = (close - rep) + 1;
       }
       else if (c == '+') {
         /* last successful capture */
@@ -1361,7 +1397,7 @@ apply_replacement(mrb_state *mrb, mrb_value result,
       else {
         mrb_str_cat(mrb, result, rep + i, 2);  /* \x as-is */
       }
-      i += 2;
+      i = next;
     }
     else {
       /* find next backslash or end for batch copy */
@@ -1451,7 +1487,7 @@ regexp_s_gsub_str(mrb_state *mrb, mrb_value klass)
 
     /* append replacement */
     if (need_expand) {
-      apply_replacement(mrb, result, rep, rep_len, s, slen, captures, ncap);
+      apply_replacement(mrb, result, rep, rep_len, s, slen, captures, ncap, pat);
     }
     else {
       mrb_str_cat(mrb, result, rep, rep_len);
@@ -1534,7 +1570,7 @@ regexp_s_sub_str(mrb_state *mrb, mrb_value klass)
 
   /* replacement */
   if (has_backslash(rep, rep_len)) {
-    apply_replacement(mrb, result, rep, rep_len, s, slen, captures, pat->num_captures);
+    apply_replacement(mrb, result, rep, rep_len, s, slen, captures, pat->num_captures, pat);
   }
   else {
     mrb_str_cat(mrb, result, rep, rep_len);
@@ -1656,7 +1692,7 @@ regexp_s_gsub_lit(mrb_state *mrb, mrb_value klass)
 
     if (beg > pos) re_cat_bytes(mrb, result, s + pos, beg - pos, binary);
     if (need_expand) {
-      apply_replacement(mrb, result, rep, rep_len, s, slen, captures, 1);
+      apply_replacement(mrb, result, rep, rep_len, s, slen, captures, 1, NULL);
     }
     else {
       mrb_str_cat(mrb, result, rep, rep_len);
@@ -1718,7 +1754,7 @@ regexp_s_sub_lit(mrb_state *mrb, mrb_value klass)
     int captures[2];
     captures[0] = (int)beg;
     captures[1] = (int)end;
-    apply_replacement(mrb, result, rep, rep_len, s, slen, captures, 1);
+    apply_replacement(mrb, result, rep, rep_len, s, slen, captures, 1, NULL);
   }
   else {
     mrb_str_cat(mrb, result, rep, rep_len);

--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -1420,7 +1420,7 @@ regexp_s_gsub_str(mrb_state *mrb, mrb_value klass)
 
   int ncap = pat->num_captures;
   int cap_size = ncap * 2;
-  int *captures = (int*)mrb_malloc(mrb, sizeof(int) * cap_size);
+  int captures[RE_MAX_CAPTURES * 2];
   mrb_value result = mrb_str_new_capa(mrb, slen);
   int ai = mrb_gc_arena_save(mrb);
 
@@ -1475,8 +1475,6 @@ regexp_s_gsub_str(mrb_state *mrb, mrb_value klass)
     mrb_str_cat(mrb, result, s + pos, slen - pos);
   }
 
-  mrb_free(mrb, captures);
-
   /* set $~ from last match */
   if (last_ncap > 0) {
     create_matchdata(mrb, re, str, last_captures, last_ncap);
@@ -1511,12 +1509,11 @@ regexp_s_sub_str(mrb_state *mrb, mrb_value klass)
   mrb_int rep_len = RSTRING_LEN(replacement);
 
   int cap_size = pat->num_captures * 2;
-  int *captures = (int*)mrb_malloc(mrb, sizeof(int) * cap_size);
+  int captures[RE_MAX_CAPTURES * 2];
   memset(captures, -1, sizeof(int) * cap_size);
 
   int n = mrb_re_exec(mrb, pat, s, slen, 0, captures, cap_size, re_binary_string_p(str));
   if (n == 0) {
-    mrb_free(mrb, captures);
     clear_match_globals(mrb);
     return mrb_str_dup(mrb, str);
   }
@@ -1542,7 +1539,6 @@ regexp_s_sub_str(mrb_state *mrb, mrb_value klass)
   }
 
   create_matchdata(mrb, re, str, captures, cap_size);
-  mrb_free(mrb, captures);
   re_mark_spliced(result, str, replacement, TRUE);
   return result;
 }

--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -1312,16 +1312,33 @@ apply_replacement(mrb_state *mrb, mrb_value result,
   while (i < rep_len) {
     if (rep[i] == '\\' && i + 1 < rep_len) {
       char c = rep[i + 1];
+      /* The escapes that stand for a group settle on one here, and the append
+         below is the only one that spends it: a group the escape reaches past
+         or one that took no part in the match stands for nothing. */
+      int g = -1;
+      mrb_bool ref = TRUE;
       if (c >= '0' && c <= '9') {
-        int g = c - '0';
-        if (g < ncap && captures[g * 2] >= 0) {
-          int s = captures[g * 2], e = captures[g * 2 + 1];
-          mrb_str_cat(mrb, result, str + s, e - s);
-        }
+        g = c - '0';
       }
       else if (c == '&') {
-        if (captures[0] >= 0) {
-          mrb_str_cat(mrb, result, str + captures[0], captures[1] - captures[0]);
+        g = 0;
+      }
+      else if (c == '+') {
+        /* last successful capture */
+        for (int j = ncap - 1; j >= 1; j--) {
+          if (captures[j * 2] >= 0) {
+            g = j;
+            break;
+          }
+        }
+      }
+      else {
+        ref = FALSE;
+      }
+      if (ref) {
+        if (g >= 0 && g < ncap && captures[g * 2] >= 0) {
+          int s = captures[g * 2], e = captures[g * 2 + 1];
+          mrb_str_cat(mrb, result, str + s, e - s);
         }
       }
       else if (c == '`') {
@@ -1336,16 +1353,6 @@ apply_replacement(mrb_state *mrb, mrb_value result,
              NUL bytes or be a non-NUL-terminated shared substring, in which
              case strlen() underflows the length (issue #6892). */
           mrb_str_cat(mrb, result, str + captures[1], str_len - captures[1]);
-        }
-      }
-      else if (c == '+') {
-        /* last successful capture */
-        for (int g = ncap - 1; g >= 1; g--) {
-          if (captures[g * 2] >= 0) {
-            int s = captures[g * 2], e = captures[g * 2 + 1];
-            mrb_str_cat(mrb, result, str + s, e - s);
-            break;
-          }
         }
       }
       else if (c == '\\') {

--- a/mrbgems/mruby-regexp/test/string_regexp.rb
+++ b/mrbgems/mruby-regexp/test/string_regexp.rb
@@ -693,6 +693,38 @@ assert("String#sub / #gsub raise for a replacement whose \\k< is unclosed") do
   assert_equal "zz", "zz".sub(/(?<x>b)/, '\k<x')
 end
 
+assert("String#sub / #gsub turn \\1-\\9 off where the pattern names a group") do
+  # Naming a group is what stops a plain `(...)` from taking a number, and it
+  # stops a replacement from spending one too: the escape stands for nothing,
+  # not for the named group that carries that number.
+  assert_equal "a[]", "ab".sub(/(?<x>b)/, '[\1]')
+  assert_equal "a[]a[]", "abab".gsub(/(?<x>b)/, '[\1]')
+  assert_equal "[]", "ab".sub(/(?<a>a)(?<b>b)/, '[\1\2]')
+  assert_equal "a[]", "ab".dup.sub!(/(?<x>b)/, '[\1]')
+  # The number is still the group's own, so `md[1]` and `\k<x>` reach what
+  # `\1` no longer does.
+  assert_equal "b", /(?<x>b)/.match("ab")[1]
+  assert_equal "a[b]", "ab".sub(/(?<x>b)/, '[\k<x>]')
+  # A plain group beside a named one has no number left to reach either, and
+  # the named one's number reaches nothing.
+  assert_equal "[]", "ab".sub(/(?<a>a)(b)/, '[\2]')
+  assert_equal "[]", "ab".sub(/(?<a>a)(b)/, '[\1]')
+  # The escapes that name no group are untouched: `\0` and `\&` are the whole
+  # match, `\+` the last group that took part, and `` \` `` and `\'` the text
+  # around the match.
+  assert_equal "a[b]", "ab".sub(/(?<x>b)/, '[\0]')
+  assert_equal "a[b]", "ab".sub(/(?<x>b)/, '[\&]')
+  assert_equal "a[b]", "ab".sub(/(?<x>b)/, '[\+]')
+  assert_equal "a[a]", "ab".sub(/(?<x>b)/, '[\`]')
+  assert_equal "a[]", "ab".sub(/(?<x>b)/, "[\\']")
+  # A pattern that names nothing keeps every number it hands out.
+  assert_equal "a[b]", "ab".sub(/(b)/, '[\1]')
+  assert_equal "a[b]a[b]", "abab".gsub(/(b)/, '[\1]')
+  # A literal String pattern has no group for a number to reach, named or not.
+  assert_equal "a[]", "ab".sub("b", '[\1]')
+  assert_equal "a[]a[]", "abab".gsub("b", '[\1]')
+end
+
 assert("String#scan") do
   assert_equal ["1", "2", "3"], "a1b2c3".scan(Regexp.new("\\d"))
 end

--- a/mrbgems/mruby-regexp/test/string_regexp.rb
+++ b/mrbgems/mruby-regexp/test/string_regexp.rb
@@ -641,6 +641,58 @@ assert("String#gsub with \\& special") do
   assert_equal "[a][b][c]", "abc".gsub(/./, '[\\&]')
 end
 
+assert("String#sub / #gsub expand \\k<name> in the replacement") do
+  assert_equal "ab!", "ab".sub(/(?<x>b)/, '\k<x>!')
+  assert_equal "acb", "abc".sub(/(?<x>b)(?<y>c)/, '\k<y>\k<x>')
+  assert_equal "abb", "ab".sub(/(?<x>b)/, '\k<x>\k<x>')
+  assert_equal "a<b>a<b>", "abab".gsub(/(?<x>b)/, '<\k<x>>')
+  assert_equal "aBb", "ab".dup.sub!(/(?<x>b)/, 'B\k<x>')
+  # A group that took no part in the match stands for nothing, the way a
+  # numbered reference to one does.
+  assert_equal "a[]", "ab".sub(/(?<x>c)?b/, '[\k<x>]')
+  # The name is the bytes between the angles, so a multibyte one reaches its
+  # group without the replacement being read as characters.
+  assert_equal "ab!", "ab".sub(/(?<あ>b)/, '\k<あ>!')
+  # Only `\k<` opens a reference: every other spelling is the literal it was,
+  # `\k'name'` among them, which the pattern side does accept as a backref.
+  assert_equal "a\\kx", "ab".sub(/(?<x>b)/, '\kx')
+  assert_equal "az\\k", "ab".sub(/(?<x>b)/, 'z\k')
+  assert_equal "a\\k'x'", "ab".sub(/(?<x>b)/, "\\k'x'")
+  assert_equal "a\\k<x>", "ab".sub(/(?<x>b)/, '\\\\k<x>')
+end
+
+assert("String#sub / #gsub raise for a replacement that names no group") do
+  msg = "undefined group name reference: y"
+  assert_raise_with_message(IndexError, msg) { "ab".sub(/(?<x>b)/, '\k<y>') }
+  assert_raise_with_message(IndexError, msg) { "abab".gsub(/(?<x>b)/, '\k<y>') }
+  assert_raise_with_message(IndexError, msg) { "ab".dup.sub!(/(?<x>b)/, '\k<y>') }
+  # A pattern that names no group at all, and a literal String pattern, which
+  # has no groups to name.
+  assert_raise_with_message(IndexError, msg) { "ab".sub(/b/, '\k<y>') }
+  assert_raise_with_message(IndexError, msg) { "ab".sub("b", '\k<y>') }
+  assert_raise_with_message(IndexError, msg) { "abab".gsub("b", '\k<y>') }
+  # Group 0 is a number, and no name at all is no name.
+  assert_raise_with_message(IndexError, "undefined group name reference: 0") do
+    "ab".sub(/(?<x>b)/, '\k<0>')
+  end
+  assert_raise_with_message(IndexError, "undefined group name reference: ") do
+    "ab".sub(/(?<x>b)/, '\k<>')
+  end
+  # Nothing matched, so nothing expanded the replacement and nothing asked
+  # the pattern for the name.
+  assert_equal "zz", "zz".sub(/(?<x>b)/, '\k<y>')
+  assert_equal "zz", "zz".gsub("b", '\k<y>')
+end
+
+assert("String#sub / #gsub raise for a replacement whose \\k< is unclosed") do
+  msg = "invalid group name reference format"
+  assert_raise_with_message(RuntimeError, msg) { "ab".sub(/(?<x>b)/, '\k<x') }
+  assert_raise_with_message(RuntimeError, msg) { "ab".sub(/(?<x>b)/, '\k<') }
+  assert_raise_with_message(RuntimeError, msg) { "abab".gsub(/(?<x>b)/, '\k<x') }
+  assert_raise_with_message(RuntimeError, msg) { "ab".sub("b", '\k<x') }
+  assert_equal "zz", "zz".sub(/(?<x>b)/, '\k<x')
+end
+
 assert("String#scan") do
   assert_equal ["1", "2", "3"], "a1b2c3".scan(Regexp.new("\\d"))
 end


### PR DESCRIPTION
*Stacked on #7282, which is what hands `apply_replacement()` the pattern. The
last commit is the whole of this change.*

A replacement string reads `\1` through `\9` as whatever group the number
reaches, a group the pattern gave a name to among them. CRuby turns those
escapes off as soon as the pattern declares a named group, so mruby answers
with the group's text where CRuby answers with nothing:

```ruby
"ab".sub(/(?<x>b)/, '[\1]')           # CRuby: "a[]",    mruby: "a[b]"
"abab".gsub(/(?<x>b)/, '[\1]')        # CRuby: "a[]a[]", mruby: "a[b]a[b]"
"ab".sub(/(?<a>a)(?<b>b)/, '[\1\2]')  # CRuby: "[]",     mruby: "[ab]"
"ab".dup.sub!(/(?<x>b)/, '[\1]')      # CRuby: "a[]",    mruby: "a[b]"
```

It is the `ONIG_OPTION_DONT_CAPTURE_GROUP` rule that stops a plain `(...)` from
taking a number in a pattern that names a group, reaching the replacement:
`rb_reg_regsub()` reads a digit escape as a group only where
`onig_noname_group_capture_is_active()` holds, and drops the reference where it
does not, so the escape stands for nothing. `\0`, `\&` and `\+` sit in a
separate case of the same switch and are not guarded, so the whole match and
the last participating group keep working there.

The replacement string is the one place left that differs. Every other numbered
accessor already agrees, ea0b2f907 having demoted the plain groups:

```ruby
md = /(?<x>b)/.match("ab")
md.size                              # 2 in both
md[1]                                # "b" in both
"ab" =~ /(?<x>b)/; $1                # "b" in both
"ab".sub(/(?<x>b)/) { "[#{$1}]" }    # "a[b]" in both
"ab".sub(/(?<a>a)(b)/, '[\2]')       # "[]" in both
"ab".sub("b", '[\1]')                # "a[]" in both: a literal has no groups
```

The `\2` row is what that demotion fixed: a plain group in a named pattern has
no number for `\2` to reach. What remains is the named group's own number,
which the same rule governs and which no demotion can take away, the group
being still numbered for `md[1]` and `$1`.

## The fix

`apply_replacement()` is handed the pattern the match was made with, so the
question is one the pattern answers: a named group registers its name, and
`pat->num_named > 0` is what the compiler asked `has_named_group()` for when it
set `dont_capture`. A digit above `0` stands for nothing there. `\0` is the
whole match, which naming a group does not touch, and neither do `\&` and `\+`,
which CRuby keeps outside the guard. A literal String pattern hands in no
pattern and has no group for a number to reach either way.

## Size

`.text` of `bin/mruby`, `build_config/ci/gcc-clang.rb`, each side from a clean
build directory at the same path; the `#7282` column is the base this stacks
on. `regexp.o` is the only object that changes.

| build | master | #7282 | this PR | delta over #7282 |
|---|---:|---:|---:|---:|
| `bintest` | 1,284,790 | 1,285,094 | 1,285,190 | +96 |
| `ascii-ctype` | 1,272,742 | 1,273,046 | 1,273,142 | +96 |
| `byte-string` | 1,254,262 | 1,254,614 | 1,254,710 | +96 |
| `cxx_abi` | 1,309,545 | 1,309,977 | 1,310,073 | +96 |
| `full-debug` (`-O0`) | 1,888,262 | 1,888,566 | 1,888,614 | +48 |

The condition weighs 48 bytes, which `full-debug` pays once and the optimised
builds twice: `apply_replacement()` is inlined into a second,
constant-propagated copy for the two literal cores, and both copies carry it.

## Verification

The tests go in `string_regexp.rb`, after the `\k<name>` blocks the base adds:
the four cases above, in `sub`, `sub!` and `gsub`, over one named group and
two; the number read where it still reaches, `md[1]` and `\k<name>`; a plain
group beside a named one, which has no number of its own left either; the
escapes the rule leaves alone, `\0`, `\&`, `\+`, `` \` `` and `\'`; a pattern
that names nothing, which keeps every number it hands out; and a literal String
pattern, which has no group for a number to reach. 5 of the 17 assertions fail
on #7282, 6 on master.

**Differential against CRuby 4.0.6**, master, #7282 and this branch against the
same cases. 16 patterns (one and two plain groups, one and two named ones, a
named group beside a plain one and beside a non-capturing one, a named group
nested either way, optional and repeated named groups, alternation, a pattern
with no group at all, a backreference) crossed with 11 replacements (`\0`
through `\9`, `\&`, `\+`, `` \` `` and `\'`, two digits at once, an escaped
backslash, `\k<name>`), 4 subjects and `sub` and `gsub`: 1,408 cases. This
branch answers all 1,408 as CRuby does; #7282 differs on 112 of them, master on
202, the other 90 being the `\k<name>` the base adds.

**`rake test`**, `build_config/ci/gcc-clang.rb`, no compiler warning:

| build | total | KO | crash |
|---|---:|---:|---:|
| `full-debug` | 2,383 | 0 | 0 |
| `bintest` | 2,383 | 0 | 0 |
| `bintest` (bintest suite) | 123 | 0 | 0 |
| `cxx_abi` | 2,383 | 0 | 0 |
| `byte-string` | 2,312 | 0 | 0 |
| `ascii-ctype` | 2,379 | 0 | 0 |

The default configuration: 2,158 total, 0 KO, 0 crash.

### Environment

<details>

| | |
|---|---|
| OS | Ubuntu 24.04, Linux 7.0.0 x86_64, AMD Ryzen 9 5950X |
| gcc | 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1) |
| binutils | 2.47 |
| CRuby | 4.0.6, for the comparison |

Compile lines for `mrbgems/mruby-regexp/src/regexp.c` in the builds quoted
above, paths shortened:

```console
# ci/gcc-clang full-debug
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -I"include" -I"mrbgems/mruby-regexp/include" -I"build/full-debug/include" -o "build/full-debug/mrbgems/mruby-regexp/src/regexp.o" "mrbgems/mruby-regexp/src/regexp.c"

# ci/gcc-clang bintest
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK -I"include" -I"mrbgems/mruby-regexp/include" -I"build/bintest/include" -o "build/bintest/mrbgems/mruby-regexp/src/regexp.o" "mrbgems/mruby-regexp/src/regexp.c"

# ci/gcc-clang cxx_abi
gcc -MMD -c -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -I"include" -I"mrbgems/mruby-regexp/include" -I"build/cxx_abi/include" -o "build/cxx_abi/mrbgems/mruby-regexp/src/regexp.o" "mrbgems/mruby-regexp/src/regexp.c"

# ci/gcc-clang byte-string
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -I"include" -I"mrbgems/mruby-regexp/include" -I"build/byte-string/include" -o "build/byte-string/mrbgems/mruby-regexp/src/regexp.o" "mrbgems/mruby-regexp/src/regexp.c"

# ci/gcc-clang ascii-ctype
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -I"include" -I"mrbgems/mruby-regexp/include" -I"build/ascii-ctype/include" -o "build/ascii-ctype/mrbgems/mruby-regexp/src/regexp.o" "mrbgems/mruby-regexp/src/regexp.c"
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for named replacement backreferences using `\k<name>`.
  * Added validation for undefined and malformed named references.
  * Numeric backreferences are suppressed when patterns contain named groups.

* **Bug Fixes**
  * Improved replacement handling for unmatched groups, multibyte names, literal escapes, and whole-match references.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->