### PR TITLE
mruby-numeric-ext: guard the bigint arm of `Integer#remainder` under `MRB_NO_FLOAT`

### DIFF
--- a/mrbgems/mruby-bigint/test/bigint.rb
+++ b/mrbgems/mruby-bigint/test/bigint.rb
@@ -328,6 +328,14 @@ assert 'Bigint Integer#remainder large operand' do
   assert_equal (2**400) % ((2**130) + 1), (2**400).remainder((2**130) + 1)
 end
 
+assert 'Bigint Integer#remainder with a non-numeric argument' do
+  # The bigint arm of int_remainder() has its own copy of the fallthrough
+  # the fixnum arm reaches: re-dispatch through Float where Float exists,
+  # TypeError where it does not. Either way the argument is refused.
+  assert_raise(TypeError) { (2**100).remainder("1") }
+  assert_raise(TypeError) { (2**100).remainder(nil) }
+end
+
 assert 'Bigint abs' do
   n = 1<<65
   assert_equal 36893488147419103232, n.abs

--- a/mrbgems/mruby-numeric-ext/src/numeric_ext.c
+++ b/mrbgems/mruby-numeric-ext/src/numeric_ext.c
@@ -62,7 +62,11 @@ int_remainder(mrb_state *mrb, mrb_value x)
     if (mrb_integer_p(y) || mrb_bigint_p(y)) {
       return mrb_bint_rem(mrb, x, y);
     }
+#ifdef MRB_NO_FLOAT
+    mrb_raise(mrb, E_TYPE_ERROR, "non integer remainder");
+#else
     return flo_remainder(mrb, mrb_float_value(mrb, mrb_as_float(mrb, x)));
+#endif
   }
 #endif
   a = mrb_integer(x);


### PR DESCRIPTION
`mrbgems/mruby-numeric-ext` does not compile when `MRB_NO_FLOAT` and `MRB_USE_BIGINT` are both on.

## What was wrong

`int_remainder()` reaches the "the argument is not an Integer" fallthrough twice, and only the second one was guarded. The first sits inside the `#ifdef MRB_USE_BIGINT` arm and names `flo_remainder()`, `mrb_float_value()` and `mrb_as_float()` behind no float guard at all, and all three exist only when `MRB_NO_FLOAT` is off:

```c
#ifdef MRB_USE_BIGINT
  if (mrb_bigint_p(x)) {
    if (mrb_integer_p(y) || mrb_bigint_p(y)) {
      return mrb_bint_rem(mrb, x, y);
    }
    return flo_remainder(mrb, mrb_float_value(mrb, mrb_as_float(mrb, x)));  /* :65 */
  }
#endif
  a = mrb_integer(x);
  ...
#ifdef MRB_NO_FLOAT
  mrb_raise(mrb, E_TYPE_ERROR, "non integer remainder");                    /* :76 */
#else
  return flo_remainder(mrb, mrb_float_value(mrb, mrb_as_float(mrb, x)));    /* :78 */
#endif
```

Neither define alone exposes it: without `MRB_USE_BIGINT` line 65 is preprocessed away, without `MRB_NO_FLOAT` everything it names exists. With both on, the gem stops the build:

```
numeric_ext.c:65:12: error: implicit declaration of function 'flo_remainder'
numeric_ext.c:65:31: error: implicit declaration of function 'mrb_float_value'
numeric_ext.c:65:52: error: implicit declaration of function 'mrb_as_float'
numeric_ext.c:65:12: error: incompatible types when returning type 'int' but 'mrb_value' was expected
```

`MRB_USE_BIGINT` comes from having `mruby-bigint`, and `math.gembox` is the only gembox that brings it in. That same gembox also carries `mruby-math` and `mruby-complex`, which stop an `MRB_NO_FLOAT` build outright with `#error Math conflicts with 'MRB_NO_FLOAT' configuration`. So the pair takes a hand-written config to reach, which is how line 65 stayed uncompiled.

## The change

Give that call site the same guard its identical twin twelve lines below already has: raise `E_TYPE_ERROR` with the existing "non integer remainder" message under `MRB_NO_FLOAT`, and keep the float re-dispatch otherwise. A build with Float compiles what it compiled before.

The re-dispatch itself is unchanged and remains correct: `flo_remainder()` reads the argument itself through `mrb_get_args(mrb, "f", &b)`, so passing the receiver widened to a Float as `self` is the intended hand-off, not a dropped argument.

The test asks the bigint arm to refuse an argument that is neither an Integer nor a Float, which nothing asked of it in either build shape. The answer is a `TypeError` on both sides of the guard, out of the Float conversion where Float exists and out of the new raise where it does not, so one assertion holds for both:

```ruby
(2**100).remainder("1")   # TypeError, either way
(2**100).remainder(nil)   # TypeError, either way
```

## Verification

A build with `MRB_NO_FLOAT`, `mruby-bigint` and `mruby-numeric-ext` fails on `master` with the four errors above and builds clean here. Adding the test gem to it runs the suite that build can hold, `mruby-bigint` tests included:

| | total | OK | KO | crash |
|---|---:|---:|---:|---:|
| `MRB_NO_FLOAT` + `mruby-bigint` | 738 | 709 | 0 | 2 |

The two crashes are `Bigint <=>` (`SystemStackError`) and `Bigint abs` (`TypeError: Integer cannot be converted to Integer`). Both are `MRB_NO_FLOAT` defects of `mruby-bigint` itself, neither goes through `Integer#remainder`, and neither could be seen before this commit because the build did not get that far. They are left for their own change.

`ci/gcc-clang`, all five builds:

| build | total | OK | KO | crash |
|---|---:|---:|---:|---:|
| `full-debug` | 2,385 | 2,379 | 0 | 0 |
| `bintest` | 2,385 | 2,371 | 0 | 0 |
| `bintest` (bintest suite) | 123 | 122 | 0 | 0 |
| `cxx_abi` | 2,385 | 2,371 | 0 | 0 |
| `byte-string` | 2,311 | 2,258 | 0 | 0 |
| `ascii-ctype` | 2,378 | 2,364 | 0 | 0 |

The default configuration: 2,156 total, 2,103 OK, 0 KO, 0 crash, plus its 112 bintests.

### Environment

<details>

| | |
|---|---|
| OS | Ubuntu 24.04.4, Linux 7.0.0 x86_64, AMD Ryzen 9 5950X |
| gcc | 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1) |
| binutils | 2.47 |

Compile lines for `mrbgems/mruby-numeric-ext/src/numeric_ext.c` in the builds quoted above, paths shortened:

```
# ci/gcc-clang full-debug
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRBGEM_MRUBY_NUMERIC_EXT_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -I"include" -I"build/full-debug/include" -o "build/full-debug/mrbgems/mruby-numeric-ext/src/numeric_ext.o" "mrbgems/mruby-numeric-ext/src/numeric_ext.c"

# ci/gcc-clang bintest
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_NUMERIC_EXT_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK -I"include" -I"build/bintest/include" -o "build/bintest/mrbgems/mruby-numeric-ext/src/numeric_ext.o" "mrbgems/mruby-numeric-ext/src/numeric_ext.c"

# ci/gcc-clang cxx_abi
gcc -MMD -c -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_NUMERIC_EXT_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -I"include" -I"build/cxx_abi/include" -o "build/cxx_abi/mrbgems/mruby-numeric-ext/src/numeric_ext.o" "mrbgems/mruby-numeric-ext/src/numeric_ext.c"

# ci/gcc-clang byte-string
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_NUMERIC_EXT_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -I"include" -I"build/byte-string/include" -o "build/byte-string/mrbgems/mruby-numeric-ext/src/numeric_ext.o" "mrbgems/mruby-numeric-ext/src/numeric_ext.c"

# ci/gcc-clang ascii-ctype
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRBGEM_MRUBY_NUMERIC_EXT_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -I"include" -I"build/ascii-ctype/include" -o "build/ascii-ctype/mrbgems/mruby-numeric-ext/src/numeric_ext.o" "mrbgems/mruby-numeric-ext/src/numeric_ext.c"

# MRB_NO_FLOAT + mruby-bigint + mruby-numeric-ext, the config the errors above come from
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_FLOAT -DMRBGEM_MRUBY_NUMERIC_EXT_VERSION=0.0.0 -DMRB_USE_BIGINT -I"include" -I"build/nf-numext/include" -o "build/nf-numext/mrbgems/mruby-numeric-ext/src/numeric_ext.o" "mrbgems/mruby-numeric-ext/src/numeric_ext.c"
```

That configuration is

```ruby
MRuby::Build.new('nf-numext') do |conf|
  conf.toolchain :gcc
  conf.compilers.each { |c| c.defines << "MRB_NO_FLOAT" }
  conf.gem :core => "mruby-bigint"
  conf.gem :core => "mruby-numeric-ext"
  conf.gem :core => "mruby-bin-mrbc"
end
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Big integer remainder operations now consistently raise a type error for invalid string and `nil` arguments.
  * Builds without floating-point support no longer attempt unintended floating-point conversion during remainder calculations.

* **Tests**
  * Added regression coverage for invalid arguments to big integer remainder operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->