### PR TITLE
mruby-rational: build under MRB_NO_FLOAT with MRB_USE_BIGINT, and compare bigint-backed Rationals exactly

### DIFF
--- a/mrbgems/mruby-rational/src/rational.c
+++ b/mrbgems/mruby-rational/src/rational.c
@@ -520,6 +520,13 @@ static mrb_value
 rational_new(mrb_state *mrb, mrb_value a, mrb_value b)
 {
 #ifdef MRB_NO_FLOAT
+  /* The #if above admits this arm only when RAT_BIGINT is on, so a Bigint
+     operand is possible here and takes the same route as in the arm below:
+     mrb_ensure_int_type() narrows a Bigint to an mrb_int, which is what
+     rational_new_b() exists to avoid. */
+  if (mrb_bigint_p(a) || mrb_bigint_p(b)) {
+    return rational_new_b(mrb, mrb_as_bint(mrb, a), b);
+  }
   a = mrb_ensure_int_type(mrb, a);
   b = mrb_ensure_int_type(mrb, b);
   return rational_new_i(mrb, mrb_integer(a), mrb_integer(b));

--- a/mrbgems/mruby-rational/src/rational.c
+++ b/mrbgems/mruby-rational/src/rational.c
@@ -520,8 +520,8 @@ static mrb_value
 rational_new(mrb_state *mrb, mrb_value a, mrb_value b)
 {
 #ifdef MRB_NO_FLOAT
-  a = mrb_as_int(mrb, a);
-  b = mrb_as_int(mrb, b);
+  a = mrb_ensure_int_type(mrb, a);
+  b = mrb_ensure_int_type(mrb, b);
   return rational_new_i(mrb, mrb_integer(a), mrb_integer(b));
 #else
   if (mrb_integer_p(a) && mrb_integer_p(b)) {

--- a/mrbgems/mruby-rational/src/rational.c
+++ b/mrbgems/mruby-rational/src/rational.c
@@ -628,11 +628,15 @@ rational_eq_b(mrb_state *mrb, mrb_value x, mrb_value y)
 #endif
   case MRB_TT_RATIONAL:
     {
-      /* Compare by converting to float - less precise but safe */
-      mrb_float v1 = mrb_bint_as_float(mrb, mrb_obj_value(p1->b.num)) /
-                     mrb_bint_as_float(mrb, mrb_obj_value(p1->b.den));
-      mrb_float v2 = rat_float(mrb, y);
-      result = v1 == v2;
+      /* Cross-multiply instead of dividing: num1/den1 == num2/den2 becomes
+         num1*den2 == num2*den1, which is exact and needs no Float. Both
+         denominators are positive (rational_new_b() moves the sign onto the
+         numerator), so the direction of the equality is unaffected. */
+      mrb_value num2 = mrb_as_bint(mrb, rat_numerator(mrb, y));
+      mrb_value den2 = rat_denominator(mrb, y);
+      mrb_value a = mrb_bint_mul_n(mrb, mrb_obj_value(p1->b.num), den2);
+      mrb_value b = mrb_bint_mul_n(mrb, num2, mrb_obj_value(p1->b.den));
+      result = mrb_bint_cmp(mrb, a, b) == 0;
       break;
     }
 

--- a/mrbgems/mruby-rational/src/rational.c
+++ b/mrbgems/mruby-rational/src/rational.c
@@ -679,6 +679,13 @@ rational_eq(mrb_state *mrb, mrb_value x)
   mrb_value y = mrb_get_arg1(mrb);
 #ifdef RAT_BIGINT
   if (RAT_BIGINT_P(x)) return rational_eq_b(mrb, x, y);
+  /* rational_eq_b() reads the bigint half of the union from its left operand
+     only, so a bigint-backed right-hand side is answered by swapping the two.
+     Equality is symmetric, and without the swap the MRB_TT_RATIONAL arm below
+     reads y's `struct RBasic*` fields through the mrb_int half. */
+  if (mrb_type(y) == MRB_TT_RATIONAL && RAT_BIGINT_P(y)) {
+    return rational_eq_b(mrb, y, x);
+  }
 #endif
   struct mrb_rational *p1 = rat_ptr(mrb, x);
   mrb_bool result;

--- a/mrbgems/mruby-rational/test/rational.rb
+++ b/mrbgems/mruby-rational/test/rational.rb
@@ -137,6 +137,33 @@ assert 'Rational#==, Rational#!=' do
   assert_equal_rational(false, Rational(1), '')
 end
 
+assert 'Rational#== between bigint-backed rationals' do
+  # A bigint-backed Rational is compared by cross-multiplication, which is
+  # exact.  The rows below are the ones a comparison through Float gets wrong:
+  # at this magnitude a double has no bit left for the difference of 1, so
+  # both quotients round to the same value.  The shift count is a variable
+  # because a constant shift wider than mrb_int is folded at compile time,
+  # which fails the build instead of raising.
+  k = 70
+  begin
+    big = 1 << k
+  rescue RangeError
+    skip 'requires mruby-bigint'
+  end
+  assert_equal_rational(false, Rational(big + 1, 3), Rational(big, 3))
+  assert_equal_rational(false, Rational(3, big + 1), Rational(3, big))
+  assert_equal_rational(true,  Rational(big, 3), Rational(big * 2, 6))
+  assert_equal_rational(false, Rational(big, 3), Rational(big, 5))
+  assert_equal_rational(false, Rational(-big, 3), Rational(big, 3))
+  assert_equal_rational(true,  Rational(-big, 3), Rational(big, -3))
+  # One side bigint-backed, the other not: the reduced form of big/big is 1/1
+  # but it keeps the bigint representation, so this crosses the two layouts.
+  assert_equal_rational(true,  Rational(big, big), Rational(1, 1))
+  assert_equal_rational(false, Rational(big, 3), Rational(1, 2))
+  assert_equal_rational(true,  Rational(big, 1), big)
+  assert_equal_rational(false, Rational(big, 1), big + 1)
+end
+
 assert 'Rational#eql?' do
   assert_true  Rational(2,1).eql?(Rational(2,1))
   assert_true  Rational(1,2).eql?(Rational(2,4))

--- a/mrbgems/mruby-rational/test/rational.rb
+++ b/mrbgems/mruby-rational/test/rational.rb
@@ -162,6 +162,11 @@ assert 'Rational#== between bigint-backed rationals' do
   assert_equal_rational(false, Rational(big, 3), Rational(1, 2))
   assert_equal_rational(true,  Rational(big, 1), big)
   assert_equal_rational(false, Rational(big, 1), big + 1)
+  # The same crossing with the bigint-backed side on the right, which reaches
+  # the comparison the other way around.
+  assert_equal_rational(true,  Rational(1, 1), Rational(big, big))
+  assert_equal_rational(true,  Rational(1, 2), Rational(big, big * 2))
+  assert_equal_rational(false, Rational(1, 2), Rational(big, 3))
 end
 
 assert 'Rational#eql?' do


### PR DESCRIPTION
`mrbgems/mruby-rational/src/rational.c` does not compile when `MRB_NO_FLOAT` and
`MRB_USE_BIGINT` are both on. Two defects stop the build, both in code that only that pair
reaches, which is why neither had ever passed a compiler. Clearing them lets the file be run
for the first time, and two more defects come out from behind them. All four are here, one per
commit.

The pair takes a hand-written config to reach: `MRB_USE_BIGINT` comes from `mruby-bigint`, the
only gembox that carries it is `math.gembox`, and the `mruby-math` and `mruby-complex` in that
same box stop an `MRB_NO_FLOAT` build with `#error`, by design. No CI job builds
`MRB_NO_FLOAT` at all.

## `rational_new()` unwrapped twice

The `MRB_NO_FLOAT` arm assigned the result of `mrb_as_int()` back into the `mrb_value` it read
from, then called `mrb_integer()` on it again:

```c
a = mrb_as_int(mrb, a);      /* mrb_int -> mrb_value */
b = mrb_as_int(mrb, b);
return rational_new_i(mrb, mrb_integer(a), mrb_integer(b));
```

`mrb_as_int()` is `mrb_integer(mrb_ensure_int_type(mrb, val))`, so `mrb_ensure_int_type()`
alone is what these lines want: it raises for what is not an Integer and returns the
`mrb_value` the next line unwraps.

## `rational_eq_b()`'s `MRB_TT_RATIONAL` arm was float-only, unguarded, and inexact

The arm divided both sides into `mrb_float` and compared quotients, under a comment calling it
*"less precise but safe"*. Neither `mrb_float` nor `rat_float()` exists under `MRB_NO_FLOAT`
(`rat_float()` sits inside the `#ifndef MRB_NO_FLOAT` at `:315`), while the `MRB_TT_FLOAT` arm
directly above it is guarded.

Replaced with cross-multiplication, what the `MRB_TT_INTEGER` and `MRB_TT_BIGINT` arms of the
same switch already do. `num1/den1 == num2/den2` becomes `num1*den2 == num2*den1` through
`mrb_bint_mul_n()` (already declared in this file at `:15`) and `mrb_bint_cmp()`. Both
denominators are positive because `rational_new_b()` moves the sign onto the numerator, so the
direction of the equality is unaffected. The other side goes through
`rat_numerator()`/`rat_denominator()`, so a plain Rational compared against a bigint-backed one
needs no special case. Nothing in the arm needs Float now, so it needs no guard either.

This is a behaviour change on a float build too. Pairs whose quotients round to the same double
were reported equal and are now parted, and `eql?` stops contradicting `hash`: `Numeric#eql?`
on a Rational is `==` with a class check (`src/numeric.c:699-700`), so the first pair below was
`eql?` while hashing differently, and `{Rational((1<<70)+1, 3) => :a}` answered `:a` for the
key `Rational(1<<70, 3)`.

## `rational_new()` narrowed a Bigint operand

With the build fixed, the no-float arm turned out to be missing the branch its float sibling
has: it sent both operands to `mrb_ensure_int_type()`, which narrows a Bigint through
`mrb_bint_as_int()` and raises `RangeError: integer out of range` for anything an `mrb_int`
cannot hold. The `#if` around the function admits that arm only when `RAT_BIGINT` is on
(`:518`), so a Bigint operand is exactly what it has to expect, and `rational_new_b()` is
already in the file to hold one.

What a no-float build reports before the branch is a `TypeError`, not that `RangeError`:
`mrb_ensure_integer_type()` keeps its Bigint, Rational and Complex arms inside an
`#ifndef MRB_NO_FLOAT` that only its Float arm needs (`src/object.c:628-650`). That is a
separate defect in the core and stays out of scope; relaxing the guard by hand is what exposes
the `RangeError` behind it. With the branch, neither guard is on the path.

## `==` answered differently depending on which side held the Bigint

`rational_eq()` sent `x` to `rational_eq_b()` when `x` carried `RAT_BIGINT`, and otherwise read
both operands through the `mrb_int` half of the union. A bigint-backed `y` reaching that path
holds `struct RBasic*` in those fields, so the comparison read a pair of pointers as numerator
and denominator. Equality is symmetric and `rational_eq_b()` reads its bigint operand from the
left only, so swapping the two arguments is the whole fix.

## Before and after

| expression | before | after |
| --- | --- | --- |
| `Rational((1<<70)+1, 3) == Rational(1<<70, 3)` | `true` | `false` |
| `Rational(3, (1<<70)+1) == Rational(3, 1<<70)` | `true` | `false` |
| `Rational(1, 1) == Rational(1<<70, 1<<70)` | `false` | `true` |
| `Rational((1<<70)+1, 3).eql?(Rational(1<<70, 3))` | `true` | `false` |
| `{Rational((1<<70)+1, 3) => :a}[Rational(1<<70, 3)]` | `:a` | `nil` |
| `Rational(2**70, 3)` under `MRB_NO_FLOAT` | `TypeError` | `(1180591620717411303424/3)` |

All but the last row are a float build, where CRuby 4.0.6 answers `false`, `false`, `true`,
`false`, `nil`. The last row is the no-float build this PR opens up, taken at the second commit
where the file builds but the Bigint branch is not in yet.

## Size

`.text` of `bin/mruby`, `build_config/ci/gcc-clang.rb`, each side built from a clean build
directory at the same path.

| build | master | this PR | delta |
|---|---:|---:|---:|
| `bintest` | 1,286,150 | 1,286,342 | +192 |
| `ascii-ctype` | 1,272,998 | 1,273,190 | +192 |
| `byte-string` | 1,254,534 | 1,254,726 | +192 |
| `cxx_abi` | 1,310,889 | 1,311,113 | +224 |
| `full-debug` (`-O0`) | 1,889,558 | 1,889,638 | +80 |

`rational.o` is the only object that changes, and it accounts for the whole of it: 11,157 →
11,349 in the three C builds at `-O3`, 10,965 → 11,189 in `cxx_abi`, and 12,458 → 12,550 at
`-O0`, where the binary moves less than the object by the padding the linker drops.

## Verification

The two build errors fall one per commit, and the two defects behind them one per commit after
that. `MRB_NO_FLOAT` with `mruby-bigint` and `mruby-rational`, at each commit:

| at | what that build does |
|---|---|
| master | stops at `boxing_word.h:200:24: incompatible types when assigning to type 'mrb_value' from type 'mrb_int'` |
| 1st commit | gets past `rational_new()`, stops at `rational.c:632: unknown type name 'mrb_float'` |
| 2nd commit | builds; `Rational(2**70, 3)` raises `TypeError: Integer cannot be converted to Integer` |
| 3rd commit | `Rational(2**70, 3)` answers `(1180591620717411303424/3)`, but `Rational(1, 1) == Rational(2**70, 2**70)` is `false` |
| 4th commit | that pair is `true` |

Built and run in four shapes, all agreeing on the comparisons below:

| build | result |
| --- | --- |
| `MRB_NO_FLOAT` | builds, runs |
| `MRB_NO_FLOAT` + `MRB_NO_BOXING` | builds, runs |
| `MRB_NO_FLOAT` + `MRB_INT32` | builds, runs |
| `MRB_NO_FLOAT` + `MRB_NO_BOXING` + `MRB_INT32` | builds, runs |

The config carries `mruby-bigint`, `mruby-rational`, `mruby-io` and the two binaries. Adding
`mruby-numeric-ext` to it needs #7284 as well: `Integer#remainder` has the same shape of defect
in its bigint arm, and the two together are what stop an `MRB_NO_FLOAT` build that carries
`mruby-bigint`.

The new test rows cannot run under `MRB_NO_FLOAT` at all, whatever they assert: `mruby-rational`
declares `mruby-complex` as a test dependency, and `mruby-complex` stops an `MRB_NO_FLOAT`
build with `#error`. That build was exercised by hand instead:

```
Rational(2**70, 3) == Rational(2**70, 3): true
Rational(2**70, 3) == Rational(2*2**70, 6): true
Rational(2**70, 3) == Rational(2**70+3, 3): false
Rational(2**70, 3) == Rational(2**70, 5): false
Rational(1, 1) == Rational(2**70, 2**70): true
Rational(2**70, 3).inspect: (1180591620717411303424/3)
```

`rake test` at the tip:

| | total | OK | KO | crash |
|---|---:|---:|---:|---:|
| default gembox | 2169 | 2116 | 0 | 0 |
| default gembox, `MRB_INT32` | 2169 | 2115 | 0 | 0 |
| `stdlib` + `stdlib-ext` + `metaprog` + `mruby-rational`, no `mruby-bigint` | 1930 | 1874 | 0 | 0 |

The last row is the skip path:
`Skip: Rational#== between bigint-backed rationals => requires mruby-bigint`. The default
gembox suite was also run at each of the four commits (2155, 2166, 2166 and 2169 assertions,
against 2155 on master), no failures anywhere, so no commit is red.

## Left out of scope

- The core `mrb_ensure_integer_type()` guard above. This PR routes around it inside
  `rational_new()`, but the function still refuses a Bigint on any no-float build:
  `[10, 20, 30][1 << 70]` raises `TypeError: Integer cannot be converted to Integer` where a
  float build raises `RangeError`.
- The non-bigint `rational_eq()`'s `MRB_TT_RATIONAL` arm compares
  `(double)p1->numerator*p2->denominator == (double)p2->numerator*p2->denominator` on `mrb_int`
  overflow. The right-hand side reads `p2->denominator` where `p1->denominator` is meant, so
  `Rational(2**62, 3) == Rational(2**62, 5)` is `true` on an ordinary float build. Same file,
  same shape of fix, but a different function and a wrong answer rather than a build failure.
- `Rational#<=>` is `self.to_f <=> other.to_f` in `mrblib/rational.rb`. It stays as inexact as
  `==` used to be, so the two now disagree:
  `Rational((1<<70)+1, 3) <=> Rational(1<<70, 3)` is `0` while `==` is `false`. Worse on the
  build this PR opens up: `Rational#to_f` does not exist under `MRB_NO_FLOAT`, the `rescue nil`
  in `<=>` swallows the `NoMethodError`, and every pair compares as incomparable, so `<`, `<=`,
  `>` and `>=` all raise `ArgumentError`. Fixing it means a C `rational_cmp()` beside
  `rational_eq()`, which is its own change.

### Environment

<details>

| | |
|---|---|
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-29-generic x86_64 |
| CPU | AMD Ryzen 9 5950X, 16 cores / 32 threads |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0 |
| binutils | GNU ld / GNU ar 2.47.20260726 |
| CRuby | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |
| rake | 13.3.1 |

`cxx_abi` compiles with `gcc -x c++ -std=gnu++03`; g++ only links. The compile line of
`src/string.c` in each build, with `-MMD`, the include paths and the output path dropped:

```console
# bintest
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK src/string.c

# ascii-ctype
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c

# byte-string
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c

# cxx_abi
gcc -c -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c

# full-debug (enable_debug appends -g3 -O0 after the -g -O3 default)
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c

# default gembox, the rake test rows
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK src/string.c

# the MRB_NO_FLOAT verification build
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_FLOAT -DMRB_USE_BIGINT -DMRB_USE_RATIONAL -DHAVE_MRUBY_IO_GEM src/string.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of large-integer rational values when floating-point support is unavailable.
  * Fixed equality comparisons for large-integer fractions, including equivalent values, negative values, and mixed representations.
  * Ensured comparisons work correctly regardless of operand order.

* **Tests**
  * Added coverage for large-integer rational equality and inequality scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->