### PR TITLE
load.c: bounds-check length fields in debug/lv section readers

### DIFF
--- a/src/load.c
+++ b/src/load.c
@@ -529,12 +529,16 @@ read_section_debug(mrb_state *mrb, const uint8_t *start, size_t size, mrb_irep *
   struct rite_section_debug_header *header = (struct rite_section_debug_header*)bin;
   bin += sizeof(struct rite_section_debug_header);
 
+  if ((size_t)(end - bin) < sizeof(uint16_t)) return MRB_DUMP_GENERAL_FAILURE;
   uint16_t filenames_len = bin_to_uint16(bin);
   bin += sizeof(uint16_t);
-  if (bin > end) return MRB_DUMP_GENERAL_FAILURE;
   mrb_value filenames_obj = mrb_str_new(mrb, NULL, sizeof(mrb_sym) * (size_t)filenames_len);
   mrb_sym *filenames = (mrb_sym*)RSTRING_PTR(filenames_obj);
   for (uint16_t i = 0; i < filenames_len; i++) {
+    if ((size_t)(end - bin) < sizeof(uint16_t)) {
+      result = MRB_DUMP_GENERAL_FAILURE;
+      goto debug_exit;
+    }
     uint16_t f_len = bin_to_uint16(bin);
     bin += sizeof(uint16_t);
     if (bin + f_len > end) {
@@ -625,13 +629,14 @@ read_section_lv(mrb_state *mrb, const uint8_t *start, size_t size, mrb_irep *ire
   header = (struct rite_section_lv_header const*)bin;
   bin += sizeof(struct rite_section_lv_header);
 
+  if ((size_t)(end - bin) < sizeof(uint32_t)) return MRB_DUMP_READ_FAULT;
   syms_len = bin_to_uint32(bin);
   bin += sizeof(uint32_t);
-  if (bin > end) return MRB_DUMP_READ_FAULT;
   if (SIZE_ERROR_MUL(syms_len, sizeof(mrb_sym))) return MRB_DUMP_GENERAL_FAILURE;
   syms_obj = mrb_str_new(mrb, NULL, sizeof(mrb_sym) * (size_t)syms_len);
   syms = (mrb_sym*)RSTRING_PTR(syms_obj);
   for (i = 0; i < syms_len; i++) {
+    if ((size_t)(end - bin) < sizeof(uint16_t)) return MRB_DUMP_READ_FAULT;
     uint16_t const str_len = bin_to_uint16(bin);
     bin += sizeof(uint16_t);
     if (bin + str_len > end) return MRB_DUMP_READ_FAULT;


### PR DESCRIPTION
The debug and local-variable section readers in the .mrb loader take a 16- or 32-bit length or count field from the section and use it before checking the bytes are still inside the buffer. read_section_debug reads filenames_len and then each entry's f_len, and read_section_lv reads syms_len and each name's str_len, in every case advancing bin first and only testing it against end afterward. A crafted .mrb whose debug or lv section ends right where one of those fields begins makes bin_to_uint16/bin_to_uint32 read a couple of bytes past the declared binary. I ran into it feeding a truncated section to mruby -b, where ASan reports a heap-buffer-overflow read in read_section_debug (load.c:538) and read_section_lv (load.c:628). The existing symbol-length check here guards the bytes a length points at, not the read of the length field itself, so this adds the missing check right before each field read, using the same form read_debug_record already applies. Valid .mrb files are unaffected because a real section always carries these fields.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation when reading debug information and local-variable metadata.
  * Prevented invalid or incomplete filename and symbol data from being processed.
  * Preserved existing error reporting for malformed input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->