### PR TITLE
unify implementations of `mrb_ary_unshift*`

### DIFF
--- a/src/array.c
+++ b/src/array.c
@@ -997,7 +997,7 @@ ary_unshift_values(mrb_state *mrb, mrb_value self,
   mrb_value *ptr = NULL;
   if (ARY_SHARED_P(a)
       && a->as.heap.aux.shared->refcnt == 1 /* shared only referenced from this array */
-      && a->as.heap.ptr - a->as.heap.aux.shared->ptr >= argc) /* there's room for unshifted items */ { 
+      && a->as.heap.ptr - a->as.heap.aux.shared->ptr >= argc) /* there's room for unshifted items */ {
     ary_modify_check(mrb, a);
     a->as.heap.ptr -= argc;
     ptr = a->as.heap.ptr;

--- a/src/array.c
+++ b/src/array.c
@@ -978,6 +978,48 @@ mrb_ary_shift_m(mrb_state *mrb, mrb_value self)
   return val;
 }
 
+static mrb_value
+ary_unshift_values(mrb_state *mrb, mrb_value self,
+                   mrb_int argc, const mrb_value argv[])
+{
+  struct RArray *a = RARRAY(self);
+
+  if (argc == 0) {
+    ary_modify_check(mrb, a);
+    return self;
+  }
+
+  mrb_int len = ARY_LEN(a);
+  if (argc > ARY_MAX_SIZE - len) {
+    ary_too_big(mrb);
+  }
+
+  mrb_value *ptr = NULL;
+  if (ARY_SHARED_P(a)
+      && a->as.heap.aux.shared->refcnt == 1 /* shared only referenced from this array */
+      && a->as.heap.ptr - a->as.heap.aux.shared->ptr >= argc) /* there's room for unshifted items */ { 
+    ary_modify_check(mrb, a);
+    a->as.heap.ptr -= argc;
+    ptr = a->as.heap.ptr;
+  } else {
+    mrb_bool same = argv == ARY_PTR(a);
+    ary_modify(mrb, a);
+    if (ARY_CAPA(a) < len + argc)
+      ary_expand_capa(mrb, a, len + argc);
+    ptr = ARY_PTR(a);
+    value_move(ptr + argc, ptr, len);
+    if (same)
+      argv = ptr;
+  }
+  array_copy(ptr, argv, argc);
+  ARY_SET_LEN(a, len + argc);
+  while (argc--) {
+    mrb_field_write_barrier_value(mrb, (struct RBasic *)a, argv[argc]);
+  }
+
+  return self;
+}
+
 /* self = [1,2,3]
    item = 0
    self.unshift item
@@ -998,29 +1040,7 @@ mrb_ary_shift_m(mrb_state *mrb, mrb_value self)
 MRB_API mrb_value
 mrb_ary_unshift(mrb_state *mrb, mrb_value self, mrb_value item)
 {
-  struct RArray *a = mrb_ary_ptr(self);
-  mrb_int len = ARY_LEN(a);
-
-  if (ARY_SHARED_P(a)
-      && a->as.heap.aux.shared->refcnt == 1 /* shared only referenced from this array */
-      && a->as.heap.ptr - a->as.heap.aux.shared->ptr >= 1) /* there's room for unshifted item */ {
-    a->as.heap.ptr--;
-    a->as.heap.ptr[0] = item;
-  }
-  else {
-    mrb_value *ptr;
-
-    ary_modify(mrb, a);
-    if (ARY_CAPA(a) < len + 1)
-      ary_expand_capa(mrb, a, len + 1);
-    ptr = ARY_PTR(a);
-    value_move(ptr + 1, ptr, len);
-    ptr[0] = item;
-  }
-  ARY_SET_LEN(a, len+1);
-  mrb_field_write_barrier_value(mrb, (struct RBasic*)a, item);
-
-  return self;
+  return ary_unshift_values(mrb, self, 1, &item);
 }
 
 /*
@@ -1040,43 +1060,7 @@ mrb_ary_unshift(mrb_state *mrb, mrb_value self, mrb_value item)
 static mrb_value
 mrb_ary_unshift_m(mrb_state *mrb, mrb_value self)
 {
-  struct RArray *a = mrb_ary_ptr(self);
-  mrb_value *ptr;
-
-  mrb_int alen = mrb_get_argc(mrb);
-
-  if (alen == 0) {
-    ary_modify_check(mrb, a);
-    return self;
-  }
-  const mrb_value *vals = mrb_get_argv(mrb);
-  mrb_int len = ARY_LEN(a);
-  if (alen > ARY_MAX_SIZE - len) {
-    ary_too_big(mrb);
-  }
-  if (ARY_SHARED_P(a)
-      && a->as.heap.aux.shared->refcnt == 1 /* shared only referenced from this array */
-      && a->as.heap.ptr - a->as.heap.aux.shared->ptr >= alen) /* there's room for unshifted item */ {
-    ary_modify_check(mrb, a);
-    a->as.heap.ptr -= alen;
-    ptr = a->as.heap.ptr;
-  }
-  else {
-    mrb_bool same = vals == ARY_PTR(a);
-    ary_modify(mrb, a);
-    if (ARY_CAPA(a) < len + alen)
-      ary_expand_capa(mrb, a, len + alen);
-    ptr = ARY_PTR(a);
-    value_move(ptr + alen, ptr, len);
-    if (same) vals = ptr;
-  }
-  array_copy(ptr, vals, alen);
-  ARY_SET_LEN(a, len+alen);
-  while (alen--) {
-    mrb_field_write_barrier_value(mrb, (struct RBasic*)a, vals[alen]);
-  }
-
-  return self;
+  return ary_unshift_values(mrb, self, mrb_get_argc(mrb), mrb_get_argv(mrb));
 }
 
 /**

--- a/test/t/array.rb
+++ b/test/t/array.rb
@@ -486,6 +486,31 @@ assert('Array#unshift', '15.2.12.5.30') do
   assert_equal([0,1,2,3], d)
 end
 
+assert("Array#unshift with shared arrays") do
+  a = Array.new(16) { _1 }
+  a0 = Array.new(16) { _1 }
+  s = a.shift(4)
+  a.unshift(*s)
+  assert_equal a0, a
+
+  a = Array.new(16) { _1 }
+  exp = [-1, *a]
+  s = a.shift(4)
+  a.unshift(-1, *s) # unshift not in-place because of the extra element
+  assert_equal exp, a
+end
+
+assert("Array#unshift taking shared self") do
+  #define ARY_REPLACE_SHARED_MIN 20
+  a = Array.new(32) { _1 }
+  a0 = Array.new(32) { _1 }
+  a1 = a.dup
+  a.unshift(*a1)
+  assert_equal(a0 * 2, a)
+  assert_equal(a0, a1)
+end
+
+
 assert('Array#to_s', '15.2.12.5.31 / 15.2.12.5.32') do
   a = [2, 3,   4, 5]
   a[4] = a


### PR DESCRIPTION
this change unifies the implementations of `mrb_ary_unshift` and `mrb_ary_unshift_m`, we also propose elevating the unified function (`ary_unshift_values`) to `MRB_API`, it is not part of this patch though

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `Array#unshift` behavior for shared and duplicated arrays.
  * Preserved array contents correctly when reinserting shifted elements or adding multiple values.
  * Ensured source arrays remain unchanged when values are unshifted from duplicated arrays.

* **Tests**
  * Added coverage for shared-array unshift scenarios, including duplication and source preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->