### PR TITLE
Remove unused functions from mruby-eval

### DIFF
--- a/mrbgems/mruby-eval/src/eval.c
+++ b/mrbgems/mruby-eval/src/eval.c
@@ -423,15 +423,3 @@ void
 mrb_mruby_eval_gem_final(mrb_state* mrb)
 {
 }
-
-void
-mrb_mruby_eval_prism_gem_init(mrb_state* mrb)
-{
-  mrb_mruby_eval_gem_init(mrb);
-}
-
-void
-mrb_mruby_eval_prism_gem_final(mrb_state* mrb)
-{
-  mrb_mruby_eval_gem_final(mrb);
-}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the evaluation component by removing obsolete Prism-specific lifecycle handling.
  * Existing evaluation functionality and lifecycle behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->