### PR TITLE
Added the internal function `mrb_args_pack_positional()`

### DIFF
--- a/include/mruby/internal.h
+++ b/include/mruby/internal.h
@@ -592,6 +592,7 @@ mrb_value mrb_object_exec(mrb_state *mrb, mrb_value self, struct RClass *target_
 mrb_value mrb_mod_module_eval(mrb_state*, mrb_value);
 mrb_value mrb_f_send(mrb_state *mrb, mrb_value self);
 mrb_value mrb_f_public_send(mrb_state *mrb, mrb_value self);
+mrb_value mrb_args_pack_positional(mrb_state *mrb);
 
 #ifdef MRB_USE_BIGINT
 mrb_value mrb_bint_new_int(mrb_state *mrb, mrb_int x);

--- a/mrbgems/mruby-eval/src/eval.c
+++ b/mrbgems/mruby-eval/src/eval.c
@@ -394,16 +394,8 @@ f_class_eval(mrb_state *mrb, mrb_value self)
 static mrb_value
 mrb_binding_eval(mrb_state *mrb, mrb_value binding)
 {
-  mrb_callinfo *ci = mrb->c->ci;
-  int argc = ci->n;
-  mrb_value *argv = ci->stack + 1;
-
-  if (argc < 15) {
-    argv[0] = mrb_ary_new_from_values(mrb, argc, argv);
-    argv[1] = argv[argc];       /* copy block */
-    ci->n = 15;
-  }
-  mrb_ary_splice(mrb, argv[0], 1, 0, binding); /* insert binding as 2nd argument */
+  mrb_value args = mrb_args_pack_positional(mrb);
+  mrb_ary_splice(mrb, args, 1, 0, binding); /* insert binding as 2nd argument */
   return f_eval(mrb, binding);
 }
 

--- a/mrbgems/mruby-method/src/method.c
+++ b/mrbgems/mruby-method/src/method.c
@@ -38,28 +38,8 @@ args_shift(mrb_state *mrb)
 static void
 args_unshift(mrb_state *mrb, mrb_value obj)
 {
-  mrb_callinfo *ci = mrb->c->ci;
-  mrb_value *argv = ci->stack + 1;
-
-  if (ci->n < 15) {
-    mrb_assert(ci->nk == 0 || ci->nk == 15);
-    mrb_value args = mrb_ary_new_from_values(mrb, ci->n, argv);
-    if (ci->nk == 0) {
-      mrb_value block = argv[ci->n];
-      argv[0] = args;
-      argv[1] = block;
-    }
-    else {
-      mrb_value keyword = argv[ci->n];
-      mrb_value block = argv[ci->n + 1];
-      argv[0] = args;
-      argv[1] = keyword;
-      argv[2] = block;
-    }
-    ci->n = 15;
-  }
-
-  mrb_ary_unshift(mrb, *argv, obj);
+  mrb_value args = mrb_args_pack_positional(mrb);
+  mrb_ary_unshift(mrb, args, obj);
 }
 
 static const struct RProc*

--- a/src/vm.c
+++ b/src/vm.c
@@ -762,6 +762,33 @@ prepare_missing(mrb_state *mrb, mrb_callinfo *ci, mrb_value recv, mrb_sym mid, m
   return m;
 }
 
+mrb_value
+mrb_args_pack_positional(mrb_state *mrb)
+{
+  mrb_callinfo *ci = mrb->c->ci;
+  int argc = ci->n;
+  mrb_value *argv = ci->stack + 1;
+
+  if (argc < CALL_MAXARGS) {
+    mrb_value args = mrb_ary_new_from_values(mrb, argc, argv);
+    if (ci->nk == 0) {
+      mrb_value block = argv[argc];
+      argv[1] = block;
+    }
+    else {
+      mrb_assert(ci->nk == CALL_MAXARGS);
+      mrb_value keyword = argv[argc];
+      mrb_value block = argv[argc + 1];
+      argv[1] = keyword;
+      argv[2] = block;
+    }
+    argv[0] = args;
+    ci->n = CALL_MAXARGS;
+  }
+
+  return *argv;
+}
+
 static void
 funcall_args_capture(mrb_state *mrb, int stoff, mrb_int argc, const mrb_value *argv, mrb_value block, mrb_callinfo *ci)
 {


### PR DESCRIPTION
This function converts positional arguments in the current call frame from flat form to splat form.

`mrb_binding_eval()` (mruby-eval) and `args_unshift()` (mruby-method) have been modified to use the new internal function.

In particular, this resolves two issues that were not apparent in `mrb_binding_eval()`:
  - When positional arguments were not specified, block arguments were being overwritten by the splat array. This was not an issue because the block argument was not used in subsequent processing.
  - When keyword arguments were specified, the keyword arguments were shifted in place of the block arguments.
    However, the block arguments were not updated and continued to use the previous positional arguments (or keyword arguments or undefined values).
    In the case of undefined values, the GC might recognize them as objects, potentially causing memory-related errors (though this could not be verified).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved argument handling for binding evaluation and method argument manipulation.
  * Preserved keyword arguments and blocks when positional arguments are repacked.
  * Ensured consistent behavior for calls with varying numbers of positional arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->