### PR TITLE
mruby-regexp: cover `a{n}?` as an optional wrapper around the interval

### DIFF
--- a/mrbgems/mruby-regexp/test/regexp_syntax.rb
+++ b/mrbgems/mruby-regexp/test/regexp_syntax.rb
@@ -546,6 +546,20 @@ assert("Regexp - a quantifier after a quantifier repeats the repeat") do
   assert_equal ["aaa"], /a{3,3}?/.match("aaa").to_a
   assert_equal [""], /a{0,2}?/.match("aa").to_a
 
+  # The optional wraps the copies of `{n}` alone, so the rest of the pattern
+  # still has to match: `xa{2}?y` takes "xy" and "xaay" but nothing between,
+  # and inside a group the capture is what the wrapper let through. Written
+  # with a comma the `?` is the non-greedy marker again and the copies are
+  # required.
+  assert_equal ["xy"], /xa{2}?y/.match("xy").to_a
+  assert_equal ["xaay"], /xa{2}?y/.match("xaay").to_a
+  assert_nil /xa{2}?y/.match("xay")
+  assert_equal ["xy"], /xa{1}?y/.match("xy").to_a
+  assert_equal [""], /^a{2}?$/.match("").to_a
+  assert_equal ["xy", ""], /x(a{2}?)y/.match("xy").to_a
+  assert_equal ["xaay", "aa"], /x(a{2}?)y/.match("xaay").to_a
+  assert_nil /xa{2,2}?y/.match("xy")
+
   # `+` right after a greedy `*`, `+` or `?` is possessive, `a*+` being
   # `(?>a*)`: `a?+` takes one `a` out of "aa" where `(?:a?)+` takes two. After
   # a lazy repeat, a possessive one or a `{...}` it is a quantifier again.


### PR DESCRIPTION
## Summary

`{n}` names one width, so a `?` written after it is not the non-greedy marker: it is a second quantifier, and `a{2}?` is `(?:a{2})?`. The compiler has read it that way since the quantifier loop landed, but the tests only ask it of a bare `/a{3}?/`, which passes by matching empty wherever the wrapper sits. This adds the rows that pin the wrapper to the copies alone.

## Changes

| File | What |
|---|---|
| `mrbgems/mruby-regexp/test/regexp_syntax.rb` | eight rows added to `Regexp - a quantifier after a quantifier repeats the repeat` |

Nothing outside `mrbgems/mruby-regexp/test/` is touched, so no compiled source changes.

### What a bare pattern leaves open

The suite already asks `/a{3}?/.match("")` and `/a{3}?/.match("aa")` for `[""]`, with `/a{3,3}?/` as the control that keeps its copies. Those rows do say the `?` is a quantifier rather than the non-greedy marker. They cannot say what it wraps. A pattern that is nothing but the quantified atom matches empty at position 0 under every reading of where the optional sits, so `[""]` is not evidence for one of them.

### What the added rows pin

Put the quantifier between two literals and the readings separate. The optional covers the copies and the rest of the pattern still has to match, so `xa{2}?y` takes `"xy"` and `"xaay"` and nothing between:

```ruby
/xa{2}?y/.match("xy").to_a      # ["xy"]
/xa{2}?y/.match("xaay").to_a    # ["xaay"]
/xa{2}?y/.match("xay")          # nil
/xa{1}?y/.match("xy").to_a      # ["xy"]
/^a{2}?$/.match("").to_a        # [""]
/x(a{2}?)y/.match("xy").to_a    # ["xy", ""]
/x(a{2}?)y/.match("xaay").to_a  # ["xaay", "aa"]
/xa{2,2}?y/.match("xy")         # nil
```

The anchored row asks the same of a pattern that cannot slide to an easier position. The two group rows read the wrapper out of the capture, which is `""` when it takes the empty branch and `"aa"` when it takes the copies. The last row carries the existing comma control into the embedded shape: `{2,2}` has a range, so its `?` is the non-greedy marker again and the copies stay required.

Every expected value is CRuby's, taken from 3.2.3 and 4.0.6, which agree on all eight rows.

## Testing

`rake test` with `build_config/ci/gcc-clang.rb`, each build run on its own so the summaries do not interleave:

| Build | Total | OK | KO | Crash | Skip |
|---|---|---|---|---|---|
| `bintest` | 2,423 | 2,409 | 0 | 0 | 14 |
| `bintest` (bintest cases) | 124 | 123 | 0 | 0 | 1 |
| `ascii-ctype` | 2,416 | 2,402 | 0 | 0 | 14 |
| `byte-string` | 2,349 | 2,296 | 0 | 0 | 53 |
| `cxx_abi` | 2,423 | 2,409 | 0 | 0 | 14 |
| `full-debug` | 2,423 | 2,417 | 0 | 0 | 6 |

`master` at `2f2a4710e` gives the same six rows on the same machine, totals and skips included. The counts do not move because the new assertions land inside an existing case rather than opening a new one, and the skips are the ones this environment always takes: no `/dev/tty`, no backtrace, and the case-folding and encoding files each build leaves out.

## Environment

<details>

| | |
|---|---|
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-30-generic |
| CPU | AMD Ryzen 9 5950X (16 cores, 32 threads) |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0 |
| Linker, archiver | GNU Binutils 2.47.20260726 |
| CRuby (rake) | 4.0.6 |
| CRuby (expected values) | 3.2.3 and 4.0.6 |

`cxx_abi` compiles the C sources as C++ with `gcc -x c++ -std=gnu++03`; `g++` only links.

The compile line each build gives `src/string.c`, with `-MMD -c`, `-I` and `-o` dropped:

```console
# bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK

# ascii-ctype
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# full-debug (-O0)
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

`full-debug` puts `-g3 -O0` after the toolchain default `-g -O3`, so it builds at `-O0`.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected handling of optional exact-count regular-expression quantifiers.
  * Preserved lazy behavior for ranged quantifiers while maintaining expected capture and anchored matching results.

* **Tests**
  * Added regression coverage for exact-count and ranged quantifier syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->