### PR TITLE
mruby-regexp: read an option group that names no letter

### DIFF
--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -1208,34 +1208,41 @@ compute_fixed_len(re_compiler *c, uint32_t start, uint32_t end, int *chars_out)
 }
 
 /* Parse the option letters of an inline (?...) group. The parser is
-   positioned just past the '?'; it reads a run of i/m/x, an optional '-',
-   and a further run of i/m/x to switch off, then stops at the terminator
-   (':' or ')'). `base` is the option set in effect on entry; the resulting
-   set is returned. Ruby's inline letters are i (IGNORECASE), m (DOTALL),
+   positioned just past the '?'; it reads i, m, x and '-' in any order until
+   the terminator (':' or ')'), a '-' switching the letters after it off.
+   `base` is the option set in effect on entry; the resulting set is
+   returned. Ruby's inline letters are i (IGNORECASE), m (DOTALL),
    x (EXTENDED). All three are scoped alike by the group they are read in:
    skip_extended_space() reads x from c->flags, which compile_atom() saves
    at every '(' and restores at its ')'. preprocess_pattern() tracks the
    same scopes over the pattern as written for the one thing it still does
-   under /x, removing `#` comments. */
+   under /x, removing `#` comments.
+
+   No letter has to come at all, and a second '-' is read like the first:
+   Onigmo's loop asks only that what it reads is one of these bytes and that
+   what stops it is the terminator, so `(?-)` is a toggle that changes
+   nothing, `(?-:a)` is `(?:a)` and `(?--i)` is `(?-i)`. A generator that
+   writes `(?#{on}-#{off}:...)` reaches the first two with both lists empty.
+   The caller reports what stops the loop when it is neither ':' nor ')',
+   which is where a letter that is not an option is refused, and `(?)` never
+   gets here at all: compile_atom() takes this arm only on i, m, x or '-'. */
 static uint32_t
 parse_inline_flags(re_compiler *c, uint32_t base)
 {
   uint32_t on = 0, off = 0;
-  mrb_bool negate = FALSE, seen = FALSE;
+  mrb_bool negate = FALSE;
   for (;;) {
     int oc = peek(c);
     uint32_t bit;
     if (oc == 'i') bit = RE_FLAG_IGNORECASE;
     else if (oc == 'm') bit = RE_FLAG_DOTALL;
     else if (oc == 'x') bit = RE_FLAG_EXTENDED;
-    else if (oc == '-' && !negate) { negate = TRUE; next_char(c); continue; }
+    else if (oc == '-') { negate = TRUE; next_char(c); continue; }
     else break;
     if (negate) off |= bit;
     else on |= bit;
-    seen = TRUE;
     next_char(c);
   }
-  if (!seen) compile_error(c, "undefined (?...) sequence");
   return (base | on) & ~off;
 }
 
@@ -2247,20 +2254,24 @@ skip_uninterpreted(const char *src, const char *end, mrb_bool *in_class, int *pa
    not name x. Returns the terminator's position, or NULL when the bytes
    are not an option group at all, which includes every malformed one: the
    parser reads those bytes too and reports them, and this pass has only to
-   agree with it about the well-formed ones. */
+   agree with it about the well-formed ones.
+
+   The letters are optional here as they are in parse_inline_flags(), so a
+   plain `(?:` is read as a scoped group carrying no options; that is what
+   it is, and the pass does the same with it either way, opening a scope
+   and leaving x as it stands. */
 static const char*
 scan_option_group(const char *src, const char *end, mrb_bool *toggle, mrb_bool *x_on)
 {
   if (end - src < 3 || src[1] != '?') return NULL;
   const char *q = src + 2;
-  mrb_bool negate = FALSE, seen = FALSE;
+  mrb_bool negate = FALSE;
   for (; q < end; q++) {
-    if (*q == 'x') { *x_on = !negate; seen = TRUE; }
-    else if (*q == 'i' || *q == 'm') seen = TRUE;
-    else if (*q == '-' && !negate) negate = TRUE;
-    else break;
+    if (*q == '-') negate = TRUE;
+    else if (*q == 'x') *x_on = !negate;
+    else if (*q != 'i' && *q != 'm') break;
   }
-  if (!seen || q >= end || (*q != ')' && *q != ':')) return NULL;
+  if (q >= end || (*q != ')' && *q != ':')) return NULL;
   *toggle = (*q == ')');
   return q;
 }

--- a/mrbgems/mruby-regexp/test/regexp_syntax.rb
+++ b/mrbgems/mruby-regexp/test/regexp_syntax.rb
@@ -672,6 +672,26 @@ b/ =~ "ab")
   assert_true Regexp.new("(?-x:a b)", Regexp::EXTENDED).match?("a b")
   assert_true Regexp.new("(?-x)a b", Regexp::EXTENDED).match?("a b")
   assert_true Regexp.new("(?x)a b", Regexp::EXTENDED).match?("ab")
+
+  # A group that names no letter is still a group: `-` may stand alone or
+  # come twice, so a generator emitting `(?#{on}-#{off}:...)` with both
+  # lists empty is read rather than refused.
+  assert_equal 0, (Regexp.new("(?-)a") =~ "a")
+  assert_equal 0, (Regexp.new("(?-:a)") =~ "a")
+  assert_equal 0, (Regexp.new("(?--i)a") =~ "a")
+  assert_equal 0, (Regexp.new("(?i-)a") =~ "A")
+  assert_nil (Regexp.new("(?--i)a") =~ "A")   # the second `-` switches off
+  assert_nil (Regexp.new("(?i)a(?--i)b") =~ "aB")
+  assert_true Regexp.new("(?-)a b", Regexp::EXTENDED).match?("ab")
+  assert_true Regexp.new("(?--x)a b", Regexp::EXTENDED).match?("a b")
+  assert_true Regexp.new("(?--x:a b)", Regexp::EXTENDED).match?("a b")
+
+  # What stops the letters is still checked, so a letter that is not an
+  # option and an unterminated group raise as before. `(?)` names no option
+  # byte at all, not even a `-`, and is not an option group to begin with.
+  assert_raise(RegexpError) { Regexp.new("(?-a)b") }
+  assert_raise(RegexpError) { Regexp.new("(?-") }
+  assert_raise(RegexpError) { Regexp.new("(?)") }
 end
 
 assert("Regexp - comment groups (?#...)") do


### PR DESCRIPTION
## Summary

An inline option group that names no option letter was refused where CRuby compiles it: `(?-)`, `(?-:a)` and `(?--i)` all raised `RegexpError`. Onigmo's option loop never asks that a letter was seen, and it takes a `-` whenever one comes, so all three are well formed.

## Changes

| File | What |
|---|---|
| `mrbgems/mruby-regexp/src/re_compile.c` | `parse_inline_flags()` drops its "a letter was seen" requirement and reads a second `-`; `scan_option_group()` loses the same two rules |
| `mrbgems/mruby-regexp/test/regexp_syntax.rb` | 12 assertions in the existing `Regexp - inline options (?i) / (?i:...)` block |

### The option loop asks only what stops it

Onigmo reads the letters in `parse_enclose()` (`regparse.c`), and the loop there has three properties:

```c
case '-':  neg = 1; break;
case 'x':  ONOFF(option, ONIG_OPTION_EXTEND,     neg); break;
case 'i':  ONOFF(option, ONIG_OPTION_IGNORECASE, neg); break;
...
default:
  return ONIGERR_UNDEFINED_GROUP_OPTION;
```

Nothing counts the letters; `-` is taken unconditionally, so a second one sets `neg` again; and the only way out is `:` or `)`, everything else falling to `default`. So `(?-)` is a toggle that changes nothing, `(?-:a)` is `(?:a)` and `(?--i)` is `(?-i)`.

Nobody writes these by hand, but a generator emitting `(?#{on}-#{off}:...)` produces the first two whenever both lists are empty.

`parse_inline_flags()` carried both extra rules: a `seen` flag whose absence raised, and `oc == '-' && !negate`, which stopped reading at the second `-` and left it to be reported. Dropping them is the whole fix. What stops the letters is still checked by the caller, so the malformed forms raise exactly as before:

* `(?-a)b` and an unterminated `(?-` reach `compile_atom()` with the loop stopped on something that is neither `:` nor `)`, and it raises there.
* `(?)` never reaches the letters at all: `compile_atom()` takes the option arm only on `i`, `m`, `x` or `-`. CRuby raises on it too.

### The free-spacing pre-pass has to agree

`scan_option_group()` reads the same letters ahead of the parser, for the one thing `preprocess_pattern()` still does under `/x`, so it loses both rules too. Two forms change how the pass classifies them, and neither changes what it emits:

* A plain `(?:` is now reported as an option group carrying no options, which is what it is. The option-group path copies the bytes through, pushes the scope and sets `x` to what it already was; the fall-through path it used to take did the same three things.
* `(?)` is now reported as a toggle group, so the pass no longer pushes a scope for it and no longer pops that scope at the `)`. The bytes are copied either way and `x` is left as it stands, so the pattern handed to the parser is unchanged, and the parser still raises on it.

## Behaviour

| | master | this PR | CRuby 4.0.6 |
|---|---|---|---|
| `Regexp.new("(?-)a") =~ "a"` | `RegexpError` | `0` | `0` |
| `Regexp.new("(?-:a)") =~ "a"` | `RegexpError` | `0` | `0` |
| `Regexp.new("(?--i)a") =~ "a"` | `RegexpError` | `0` | `0` |
| `Regexp.new("(?--i)a") =~ "A"` | `RegexpError` | `nil` | `nil` |
| `Regexp.new("(?i)a(?--i)b") =~ "aB"` | `RegexpError` | `nil` | `nil` |
| `Regexp.new("(?-)a b", Regexp::EXTENDED).match?("ab")` | `RegexpError` | `true` | `true` |
| `Regexp.new("(?--x:a b)", Regexp::EXTENDED).match?("a b")` | `RegexpError` | `true` | `true` |
| `Regexp.new("(?-a)b")` | `RegexpError` | `RegexpError` | `RegexpError` |
| `Regexp.new("(?-")` | `RegexpError` | `RegexpError` | `RegexpError` |
| `Regexp.new("(?)")` | `RegexpError` | `RegexpError` | `RegexpError` |

## Size

`bin/mruby` `.text`, from `size -A`, for the five builds of `build_config/ci/gcc-clang.rb`:

| Build | master | this PR | delta |
|---|---:|---:|---:|
| `bintest` | 1,292,182 | 1,292,214 | +32 |
| `ascii-ctype` | 1,278,726 | 1,278,710 | -16 |
| `byte-string` | 1,259,718 | 1,259,734 | +16 |
| `cxx_abi` | 1,317,065 | 1,317,033 | -32 |
| `full-debug` (-O0) | 1,895,942 | 1,895,862 | -80 |

Two predicates leave two loops, so the sign is whichever way the surrounding code lands. All of it is `re_compile.o`, whose `.text` moves by +32, -16, +16, -32 and -85 in the same order; `re_exec.o` and `regexp.o` are unchanged in every build.

## Testing

`rake test` is green in the default `host` build and in all five builds of `build_config/ci/gcc-clang.rb`:

| Build | Total | OK | KO | Warning | Skip |
|---|---:|---:|---:|---:|---:|
| `host` | 2,194 | 2,141 | 0 | 0 | 53 |
| `host` bintest | 113 | 112 | 0 | 0 | 1 |
| `bintest` | 2,423 | 2,409 | 0 | 0 | 14 |
| `bintest` bintest | 124 | 123 | 0 | 0 | 1 |
| `ascii-ctype` | 2,416 | 2,402 | 0 | 0 | 14 |
| `byte-string` | 2,349 | 2,296 | 0 | 0 | 53 |
| `cxx_abi` | 2,423 | 2,409 | 0 | 0 | 14 |
| `full-debug` | 2,423 | 2,417 | 0 | 0 | 6 |

Beyond the new assertions, every string of length 1 to 5 over the alphabet `()?-imx:a #` was compiled by both binaries, in the default mode and under `Regexp::EXTENDED`, and matched against `"a"`, `"A"`, `"a b"`, `"ab"`, `"a\nb"` and `""`. That is 354,310 rows. 37 of them differ, and all 37 are a pattern containing `(?-)`, `(?--)` or `(?-:)`: master raises, this PR compiles. Running the same 37 rows under CRuby 4.0.6 reproduces this PR's output byte for byte.

## Environment

<details>
<summary>Machine and toolchain</summary>

| | |
|---|---|
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-30-generic, x86_64 |
| CPU | AMD Ryzen 9 5950X, 16C/32T |
| C compiler | gcc 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1) |
| binutils | GNU Binutils 2.47.20260726 (`size -A`) |
| CRuby | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM |

`cxx_abi` compiles with `gcc -x c++ -std=gnu++03`; `g++` is the linker only.

</details>

<details>
<summary>Compile lines, as printed by <code>rake --verbose</code> (<code>-MMD -c</code>, <code>-I</code> and <code>-o</code> removed)</summary>

```console
# bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK

# ascii-ctype
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# full-debug
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Regular expressions now support empty and hyphen-only inline option groups, including scoped forms and repeated hyphen toggles.
  * Improved handling of interactions with case-insensitive and extended-mode options.

* **Bug Fixes**
  * Invalid, unterminated, or improperly empty option groups continue to raise appropriate regular expression errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->