### PR TITLE
mruby-regexp: refuse a group name that is a number or holds a `)`

### DIFF
--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -1496,9 +1496,32 @@ compile_atom(re_compiler *c)
           int close = (c->p[1] == '<') ? '>' : '\'';
           next_char(c); next_char(c);  /* skip ?< or ?' */
           cap_name = c->p;
-          while (peek(c) != close && peek(c) >= 0) next_char(c);
+          while (peek(c) != close && peek(c) >= 0) {
+            /* CRuby's fetch_name() ends the scan at a ')' instead of taking it
+               into the name, and a name no delimiter ended is `invalid group
+               name`. The first byte is exempt, the test starting one byte
+               in, so (?<)>x) names ")" in both engines. The message quotes
+               to the end of the pattern, as CRuby does when the scan never
+               reached a delimiter. */
+            if (peek(c) == ')' && c->p > cap_name) {
+              compile_error_str(c, mrb_format(c->mrb, "invalid group name <%l>",
+                                              cap_name, (size_t)(c->src_end - cap_name)));
+            }
+            next_char(c);
+          }
           if (peek(c) != close) compile_error(c, "unterminated named capture");
           if (c->p == cap_name) compile_error(c, "group name is empty");
+          /* A definition names a group, it never numbers one: CRuby reads a
+             leading digit or '-' as the number spelling, which only a
+             reference may use, and refuses it here. Everything after the first
+             byte is a name to both engines, `-` and spaces included, so this
+             is not a restriction to word characters. Without it, (?<1>x)
+             defined a group that no \k could reach, the reference side
+             reading digits as a number. */
+          if (*cap_name == '-' || (*cap_name >= '0' && *cap_name <= '9')) {
+            compile_error_str(c, mrb_format(c->mrb, "invalid group name <%l>",
+                                            cap_name, (size_t)(c->p - cap_name)));
+          }
           if (!RE_NAME_LEN_FITS(c->p - cap_name)) compile_error(c, "group name too long");
           cap_name_len = (uint32_t)(c->p - cap_name);
           next_char(c);  /* skip the closing > or ' */
@@ -1689,7 +1712,16 @@ compile_atom(re_compiler *c)
       int close = (peek(c) == '<') ? '>' : '\'';
       next_char(c);  /* skip < or ' */
       const char *name = c->p;
-      while (peek(c) != close && peek(c) >= 0) next_char(c);
+      while (peek(c) != close && peek(c) >= 0) {
+        /* The reference reads a name the same way a definition does, and stops
+           at a ')' the same way too, from the second byte on: \k<)> reaches the
+           group (?<)>x) opened, while \k<a)b> is `invalid group name`. */
+        if (peek(c) == ')' && c->p > name) {
+          compile_error_str(c, mrb_format(c->mrb, "invalid group name <%l>",
+                                          name, (size_t)(c->src_end - name)));
+        }
+        next_char(c);
+      }
       if (peek(c) != close) compile_error(c, "unterminated backreference name");
       if (c->p == name) compile_error(c, "group name is empty");
       if (!RE_NAME_LEN_FITS(c->p - name)) compile_error(c, "group name too long");

--- a/mrbgems/mruby-regexp/test/regexp_syntax.rb
+++ b/mrbgems/mruby-regexp/test/regexp_syntax.rb
@@ -1561,6 +1561,73 @@ assert("Regexp - \\k group reference errors say which failure it was") do
   end
 end
 
+assert("Regexp - a group name may not be a number") do
+  # A definition names a group, it never numbers one: the number spelling
+  # belongs to a reference, and CRuby refuses a leading digit or `-` where a
+  # group is declared. (?<1>x) used to be accepted and left the group
+  # unreachable, since \k<1> reads digits as a number and a named pattern
+  # refuses a numbered backreference.
+  msg = "invalid group name"
+  assert_raise_with_message(RegexpError, "#{msg} <1>: /(?<1>c)/") do
+    Regexp.new("(?<1>c)")
+  end
+  assert_raise_with_message(RegexpError, "#{msg} <1a>: /(?<1a>c)/") do
+    Regexp.new("(?<1a>c)")
+  end
+  assert_raise_with_message(RegexpError, "#{msg} <-a>: /(?<-a>c)/") do
+    Regexp.new("(?<-a>c)")
+  end
+  # both spellings declare, so both refuse, and the message quotes in <>
+  # whichever delimiter wrote the name
+  assert_raise_with_message(RegexpError, "#{msg} <1a>: /(?'1a'c)/") do
+    Regexp.new("(?'1a'c)")
+  end
+  assert_raise_with_message(RegexpError, "#{msg} <-1>: /(?'-1'c)/") do
+    Regexp.new("(?'-1'c)")
+  end
+
+  # only the first byte carries the number spelling: a digit or a `-` further
+  # in is a name character like any other, as a space is
+  assert_equal ["a1"], Regexp.new("(?<a1>c)").names
+  assert_equal ["a-b"], Regexp.new("(?<a-b>c)").names
+  assert_equal ["a b"], Regexp.new("(?<a b>c)").names
+  assert_equal "cc", "cc".match(Regexp.new("(?<a b>c)\\k<a b>"))[0]
+end
+
+assert("Regexp - a group name may not hold a ')'") do
+  # CRuby's fetch_name() ends the name at a ')' and reports a name no
+  # delimiter ended as invalid. mruby took every byte up to the delimiter, so
+  # patterns CRuby rejects compiled here, with a ')' held as a name character
+  # no other engine reads as one.
+  msg = "invalid group name"
+  assert_raise_with_message(RegexpError, "#{msg} <a)b>c)>: /(?<a)b>c)/") do
+    Regexp.new("(?<a)b>c)")
+  end
+  assert_raise_with_message(RegexpError, "#{msg} <a)b'c)>: /(?'a)b'c)/") do
+    Regexp.new("(?'a)b'c)")
+  end
+  # the scan stops at the ')', so the name is quoted to the end of the
+  # pattern and an unterminated one is refused for the ')' rather than for
+  # its missing delimiter
+  assert_raise_with_message(RegexpError, "#{msg} <a)b>: /(?<a)b/") do
+    Regexp.new("(?<a)b")
+  end
+
+  # the reference arm reads a name the same way and stops the same way
+  assert_raise_with_message(RegexpError, "#{msg} <a)b>>: /(?<a>c)\\k<a)b>/") do
+    Regexp.new("(?<a>c)\\k<a)b>")
+  end
+  assert_raise_with_message(RegexpError, "#{msg} <a)b'>: /(?<a>c)\\k'a)b'/") do
+    Regexp.new("(?<a>c)\\k'a)b'")
+  end
+
+  # the first byte is exempt in both arms, as it is in CRuby: a lone ')' is a
+  # name a group can carry and a reference can reach
+  assert_equal [")"], Regexp.new("(?<)>c)").names
+  assert_equal "cc", "cc".match(Regexp.new("(?<)>c)\\k<)>"))[0]
+  assert_equal "cc", "cc".match(Regexp.new("(?')'c)\\k')'"))[0]
+end
+
 assert("Regexp - named captures survive /x preprocessing") do
   # Regression: with /x, mrb_re_compile freed the rewritten buffer that
   # named_captures[i].name pointed into.


### PR DESCRIPTION
## Summary

A group definition took every byte up to its delimiter as the name, so `(?<1>c)` and `(?<a)b>c)` compiled where CRuby raises `invalid group name`, and a `\k<...>` reference read its name the same way. This validates the name where it is read, in both arms, following CRuby's `fetch_name()`.

## Changes

| File | What |
|---|---|
| `mrbgems/mruby-regexp/src/re_compile.c` | the definition arm of `compile_atom()` refuses a leading digit or `-`; both name scans end at a `)` from the second byte on |
| `mrbgems/mruby-regexp/test/regexp_syntax.rb` | two cases added: `a group name may not be a number`, `a group name may not hold a ')'` |

### A number is a spelling only a reference may use

`(?<1>c)` compiled and named the group `1`. Nothing in the pattern could then reach it: every reference syntax reads a leading digit as a number rather than as a name, so both spellings refuse the group the definition had just created.

```ruby
Regexp.new("(?<1>c)").names  # CRuby: RegexpError, mruby: ["1"]
Regexp.new('(?<1>c)\k<1>')   # CRuby: invalid group name, mruby: numbered backref
Regexp.new('(?<1>c)\1')      # CRuby: invalid group name, mruby: numbered backref
```

CRuby closes that gap where the name is read: `fetch_name()` takes a leading digit or `-` as the number spelling and, in a definition, refuses it. The test is on the first byte alone, so `a1` and `a-b` stay names in both engines, as `a b` does.

### A `)` ends the scan, from the second byte on

CRuby stops the name scan at a `)` rather than taking it into the name, and a name that no delimiter ended is `invalid group name`, quoted to the end of the pattern. mruby read on to the delimiter, so `(?<a)b>c)` compiled with `a)b` as the name and `(?<a)b` was refused for the missing delimiter instead.

The first byte is exempt in CRuby, and this keeps that exemption: `(?<)>c)` still names `)`, and `\k<)>` still reaches it. Every other byte remains a name character, `-` and spaces included, so this is not a restriction to word characters.

The reference arm reads a name the same way, so it takes the same stop. `has_named_group()` and `preprocess_pattern()` are untouched: the former answers on `(?<` and `(?'` alone, and the `)` case now closes through the parser.

Two neighbouring divergences are left as they are. An unterminated `(?<a` still says `unterminated named capture` where CRuby says `invalid group name <a>`, which is a message the definition arm reports after this scan rather than during it. And `\k<a-b>` still resolves the group `(?<a-b>c)` defines, where CRuby reads the `-` as the start of a nesting level and raises; reading that suffix is a separate feature, not a name-validation question.

## Behaviour

| pattern | master | this PR (= CRuby 3.2.3 and 4.0.6) |
|---|---|---|
| `(?<1>c)` | names `["1"]` | `invalid group name <1>` |
| `(?<1a>c)`, `(?'1a'c)` | names `["1a"]` | `invalid group name <1a>` |
| `(?<-a>c)` | names `["-a"]` | `invalid group name <-a>` |
| `(?'-1'c)` | names `["-1"]` | `invalid group name <-1>` |
| `(?<a)b>c)` | names `["a)b"]` | `invalid group name <a)b>c)>` |
| `(?'a)b'c)` | names `["a)b"]` | `invalid group name <a)b'c)>` |
| `(?<a)b` | `unterminated named capture` | `invalid group name <a)b>` |
| `(?<a>c)\k<a)b>` | `undefined name <a)b> reference` | `invalid group name <a)b>>` |
| `(?<a>c)\k'a)b'` | `undefined name <a)b> reference` | `invalid group name <a)b'>` |
| `(?<)>c)`, `(?<)>c)\k<)>` | names `[")"]`, matches | unchanged |
| `(?')'c)\k')'` | names `[")"]`, matches | unchanged |
| `(?<a1>c)`, `(?<a-b>c)`, `(?<a b>c)` | names as written | unchanged |

Each `this PR` cell is the message CRuby prints for the same pattern, taken from 3.2.3 and 4.0.6, which agree on every row.

## Size

`bin/mruby` `.text`, from `size -A`, for the five builds of `build_config/ci/gcc-clang.rb`:

| Build | master | this PR | delta |
|---|---|---|---|
| `bintest` | 1,292,182 | 1,292,262 | +80 |
| `ascii-ctype` | 1,278,726 | 1,278,790 | +64 |
| `byte-string` | 1,259,718 | 1,259,686 | -32 |
| `cxx_abi` | 1,317,065 | 1,317,257 | +192 |
| `full-debug` (-O0) | 1,895,942 | 1,896,278 | +336 |

`re_compile.o` carries it: its `.text` is 26,929 → 27,009 in `bintest` and 29,986 → 30,320 in `full-debug`. `regexp.o` and `re_exec.o` do not move in either build. The two arms hold one comparison and one call each, and `-O0` writes both out where `-O3` folds them into the loop it already had. `byte-string` losing 32 bytes is the inliner deciding differently around code that did not change; the object file it comes from is the same 80 bytes larger there as everywhere else.

## Testing

`rake test` with `build_config/ci/gcc-clang.rb`, each build run on its own so the summaries do not interleave:

| Build | Total | OK | KO | Crash | Skip |
|---|---|---|---|---|---|
| `bintest` | 2,425 | 2,411 | 0 | 0 | 14 |
| `bintest` (bintest cases) | 124 | 123 | 0 | 0 | 1 |
| `ascii-ctype` | 2,418 | 2,404 | 0 | 0 | 14 |
| `byte-string` | 2,351 | 2,298 | 0 | 0 | 53 |
| `cxx_abi` | 2,425 | 2,411 | 0 | 0 | 14 |
| `full-debug` | 2,425 | 2,419 | 0 | 0 | 6 |

`master` at `2f2a4710e` gives the same builds two rows lower, the two new cases being the whole difference, and 0 KO with 0 crashes throughout:

| Build | Total | OK | KO | Crash | Skip |
|---|---|---|---|---|---|
| `bintest` | 2,423 | 2,409 | 0 | 0 | 14 |
| `ascii-ctype` | 2,416 | 2,402 | 0 | 0 | 14 |
| `byte-string` | 2,349 | 2,296 | 0 | 0 | 53 |
| `cxx_abi` | 2,423 | 2,409 | 0 | 0 | 14 |
| `full-debug` | 2,423 | 2,417 | 0 | 0 | 6 |

The skips are the ones this environment always takes: no `/dev/tty`, no backtrace, and the case-folding and encoding files each build leaves out.

`rake test` on the default gembox is green as well: 2,196 tests, 2,143 OK, 0 KO, 0 crashes, 53 skips, with the 113 bintest cases at 112 OK and 1 skip.

The two new cases cover both arms, both delimiters, the exempt first byte, and the names that stay names.

For regressions outside them, 20,000 generated patterns were matched under CRuby 4.0.6, `master` and this branch, with each run's address space capped. The two mruby builds answer identically on every case: 19,933 agree with CRuby, 53 diverge from it on both, and 8 reach the cap on both. Nothing in that corpus separates this PR from `master`. The generator writes patterns out of `a`, `b` and the metacharacters, so it never reaches a group name; the run bounds the change rather than exercising it.

## Environment

<details>

| | |
|---|---|
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-30-generic |
| CPU | AMD Ryzen 9 5950X (16 cores, 32 threads) |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0 |
| Linker, archiver | GNU Binutils 2.47.20260726 |
| CRuby (rake) | 4.0.6 |
| CRuby (expected values) | 3.2.3 and 4.0.6 |

`cxx_abi` compiles the C sources as C++ with `gcc -x c++ -std=gnu++03`; `g++` only links.

The compile line each build gives `src/string.c`, with `-MMD -c`, `-I` and `-o` dropped:

```console
# bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK

# ascii-ctype
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# full-debug (-O0)
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

`full-debug` puts `-g3 -O0` after the toolchain default `-g -O3`, so it builds at `-O0`.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for named capture groups and named backreferences.
  * Invalid names beginning with a digit or hyphen are now rejected consistently.
  * Parentheses correctly terminate name parsing, producing clearer syntax errors for malformed patterns.

* **Tests**
  * Added coverage for invalid group names, both named-group syntaxes, and corresponding named backreference errors.
  * Added cases confirming correct handling of parentheses in group names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->