### PR TITLE
mruby-regexp: cover the interval whose braces hold free-spacing whitespace

### DIFF
--- a/mrbgems/mruby-regexp/test/regexp_syntax.rb
+++ b/mrbgems/mruby-regexp/test/regexp_syntax.rb
@@ -847,6 +847,23 @@ assert("Regexp - free-spacing whitespace stands between tokens only") do
   assert_equal ["a{1,2}"], Regexp.new("a{1, 2}", x).match("a{1,2}").to_a
   assert_equal ["a{2}"], Regexp.new("a{ 2}", x).match("a{2}").to_a
   assert_equal ["a{2}"], Regexp.new("a{2 }", x).match("a{2}").to_a
+  # the whitespace breaks the interval wherever /x is on, and the inline
+  # forms turn it on for their own scope as the flag does for the pattern
+  assert_nil Regexp.new("(?x)a{1, 2}").match("aa")
+  assert_nil Regexp.new("(?x:a{1, 2})").match("aa")
+  assert_equal ["a{1,2}"], Regexp.new("(?x)a{1, 2}").match("a{1,2}").to_a
+  # with /x off there is no free-spacing for the braces to lose, and the
+  # literal is the whole of `{1, 2}`, its blank included
+  assert_equal ["a{1, 2}"], Regexp.new("a{1, 2}").match("a{1, 2}").to_a
+  # a comment is gone before the parser reads the interval, so one written
+  # inside the braces does not break it the way whitespace does
+  assert_equal ["aa"], Regexp.new("a{1,#c\n2}", x).match("aa").to_a
+  assert_nil Regexp.new("a{1,#c\n 2}", x).match("aa")
+  assert_equal ["aa"], Regexp.new("a{1,(?#c)2}", x).match("aa").to_a
+  # a `{` the whitespace makes a literal carries no count at all, so a
+  # number too large to repeat by is not one to report
+  assert_equal ["a{99999999999}"],
+               Regexp.new("a{ 99999999999}", x).match("a{99999999999}").to_a
   # the `?` that makes a quantifier non-greedy is read right after it, so a
   # `?` a space away is a repeat of the repeat, which this engine refuses
   # as it refuses `a**`


### PR DESCRIPTION
## Summary

Under `/x`, whitespace among an interval's digits does not make an interval in CRuby. Onigmo's `fetch_range_quantifier()` reads the number straight from the source rather than through the tokenizer that skips free-spacing, so the space ends the scan, the `{` falls back to a literal, and the tokenizer then skips that space like any other:

```ruby
/a{1, 2}/x =~ "aa"             # nil
/a{1, 2}/x.match("a{1,2}")[0]  # "a{1,2}"
```

The engine reads it that way already. #7272 moved the free-spacing skip out of `preprocess_pattern()` and into the parser, at the two places a token can end, so `parse_quantifier()` now meets the space itself, fails on it, and leaves the `{` a literal. The four rows that PR added pin the `/x` flag form of it. This adds the rows that reach the rest of the shape.

## Changes

| File | What |
|---|---|
| `mrbgems/mruby-regexp/test/regexp_syntax.rb` | eight rows added to `Regexp - free-spacing whitespace stands between tokens only` |

Nothing outside `mrbgems/mruby-regexp/test/` is touched, so no compiled source changes.

### The inline forms

The flag is not the only way to turn free-spacing on: `(?x)` turns it on for the rest of its group, `(?x:...)` for its own. What decides whether the space inside the braces is skipped is the scope the parser gives the mode, not how the mode was written, so both forms belong in the pinned set.

```ruby
Regexp.new("(?x)a{1, 2}").match("aa")           # nil
Regexp.new("(?x:a{1, 2})").match("aa")          # nil
Regexp.new("(?x)a{1, 2}").match("a{1,2}").to_a  # ["a{1,2}"]
```

### The mode off

With free-spacing off the braces have nothing to lose, so `{1, 2}` is a literal whole, its blank included, and the subject that matches carries the blank too:

```ruby
Regexp.new("a{1, 2}").match("a{1, 2}").to_a  # ["a{1, 2}"]
```

That is the control for the rows above: the same pattern, and the mode is the whole of the difference.

### A comment among the digits

`preprocess_pattern()` removes both spellings of a comment before the parser reads the interval, so one written among the digits does not break it the way whitespace does. The pair below says which of the two does the breaking in `a{1,#c\n 2}`: the space after the newline, not the comment.

```ruby
Regexp.new("a{1,#c\n2}", x).match("aa").to_a   # ["aa"]
Regexp.new("a{1,#c\n 2}", x).match("aa")       # nil
Regexp.new("a{1,(?#c)2}", x).match("aa").to_a  # ["aa"]
```

`x` is the case's `Regexp::EXTENDED`, since a literal cannot carry the newline these rows need.

### A count too large to repeat by

A `{` the whitespace has made a literal carries no count at all, so a number that would be refused as a repeat is never read as one:

```ruby
Regexp.new("a{ 99999999999}", x).match("a{99999999999}").to_a  # ["a{99999999999}"]
```

Without the space the same number raises `quantifier too large`. The row says the refusal sits behind the scan rather than in front of it.

Every expected value is CRuby's, taken from 3.2.3 and 4.0.6, which agree on all eight rows.

## Testing

`rake test` with `build_config/ci/gcc-clang.rb`, the builds run in sequence so the summaries do not interleave:

| Build | Total | OK | KO | Crash | Skip |
|---|---|---|---|---|---|
| `full-debug` | 2,423 | 2,417 | 0 | 0 | 6 |
| `bintest` | 2,423 | 2,409 | 0 | 0 | 14 |
| `bintest` (bintest cases) | 124 | 123 | 0 | 0 | 1 |
| `cxx_abi` | 2,423 | 2,409 | 0 | 0 | 14 |
| `byte-string` | 2,349 | 2,296 | 0 | 0 | 53 |
| `ascii-ctype` | 2,416 | 2,402 | 0 | 0 | 14 |

`master` at `2f2a4710e` gives the same six rows on the same machine, totals and skips included. The counts do not move because the new assertions land inside an existing case rather than opening a new one, and the skips are the ones this environment always takes: no `/dev/tty`, no backtrace, and the case-folding and encoding files each build leaves out.

The added assertions were confirmed to run by flipping `(?x:a{1, 2})` to expect a match, which turns `bintest` into `KO: 1`.

## Environment

<details>

| | |
|---|---|
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-30-generic |
| CPU | AMD Ryzen 9 5950X (16 cores, 32 threads) |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0 |
| Linker, archiver | GNU Binutils 2.47.20260726 |
| CRuby (rake) | 4.0.6 |
| CRuby (expected values) | 3.2.3 and 4.0.6 |

`cxx_abi` compiles the C sources as C++ with `gcc -x c++ -std=gnu++03`; `g++` only links.

The compile line each build gives `src/string.c`, with `-MMD -c`, `-I` and `-o` dropped:

```console
# full-debug (-O0)
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK

# cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ascii-ctype
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

`full-debug` puts `-g3 -O0` after the toolchain default `-g -O3`, so it builds at `-O0`.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage for extended-mode regular expression syntax involving whitespace, comments, and scoped options.
  - Verified invalid or oversized repetition intervals are handled safely and treated as literals when appropriate.
  - Confirmed behavior when extended mode is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->