### PR TITLE
mruby-regexp: raise when a repeat range's upper bound is below its lower

### DIFF
--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -1127,6 +1127,16 @@ parse_quantifier(re_compiler *c, int *min_out, int *max_out, mrb_bool *ranged)
     return FALSE;
   }
   next_char(c);  /* skip '}' */
+  /* A range written backwards names no repeat count, and CRuby reports it
+     rather than compiling a repeat that silently drops the upper bound:
+     compile_quantified() would lay out `min` mandatory copies and then a
+     `max - min` loop that runs zero times, which is `{min}`. The check sits
+     here, once the `}` is consumed, so that a `{...}` which is no quantifier
+     at all is still restored as a literal brace above, and it lets the
+     unlimited upper bound through, which is spelled -1. */
+  if (max >= 0 && max < min) {
+    compile_error(c, "upper is smaller than lower in repeat range");
+  }
   *min_out = min;
   *max_out = max;
   return TRUE;

--- a/mrbgems/mruby-regexp/test/regexp_syntax.rb
+++ b/mrbgems/mruby-regexp/test/regexp_syntax.rb
@@ -484,6 +484,36 @@ assert("Regexp - repetition {n,m}") do
   assert_equal "aaa", Regexp.new("a{2,3}").match("aaaa")[0]
 end
 
+assert("Regexp - an upper bound below the lower one is an error") do
+  # `{n,m}` with m < n names no repeat count, and CRuby raises rather than
+  # compiling it; it used to compile as `{n}` and match exactly n repeats.
+  assert_raise(RegexpError) { Regexp.new("a{2,1}") }
+  assert_raise(RegexpError) { Regexp.new("^a{3,1}$") }
+  # The non-greedy marker comes after the `}`, so it does not save the range.
+  assert_raise(RegexpError) { Regexp.new("a{3,1}?") }
+  # Nor does a group, a class, or a lookaround.
+  assert_raise(RegexpError) { Regexp.new("(ab){2,1}") }
+  assert_raise(RegexpError) { Regexp.new("[a-z]{5,3}") }
+  assert_raise(RegexpError) { Regexp.new("(?=a{2,1})") }
+  # A body that matches empty reads its quantifiers and emits nothing for
+  # them, and the range is read there too.
+  assert_raise(RegexpError) { Regexp.new("a{0}{2,1}") }
+  assert_raise(RegexpError) { Regexp.new("(?:){2,1}") }
+  # Where there is no atom to repeat, the range is what CRuby reports, ahead
+  # of the missing target.
+  assert_raise(RegexpError) { Regexp.new("{2,1}") }
+  # Equal bounds are a repeat of exactly n, and an omitted upper bound is
+  # unlimited: neither is below the lower bound.
+  assert_equal "aa", Regexp.new("a{2,2}").match("aaa")[0]
+  assert_equal "aaa", Regexp.new("a{2,}").match("aaa")[0]
+  assert_equal "", Regexp.new("a{0,0}").match("aaa")[0]
+  # A `{...}` that is no quantifier is still a literal brace rather than a
+  # bad range, whether the `}` is missing or the braces are escaped.
+  assert_equal "a{2,1", "a{2,1".match(/a{2,1/)[0]
+  assert_equal "a{2,1}", "a{2,1}".match(/a\{2,1}/)[0]
+  assert_equal "{2,1}", "a{2,1}".match(/[{]2,1[}]/)[0]
+end
+
 assert("Regexp - repeated group keeps each iteration self-contained") do
   # Copying a grouped quantifier body must relocate its internal jumps, or a
   # later copy jumps back into the first and reports the wrong capture span.


### PR DESCRIPTION
## Summary

`{n,m}` with `m` below `n` names no repeat count, and CRuby refuses it, but mruby compiled it as `{n}` and matched exactly `n` repeats. `parse_quantifier()` read both bounds and never compared them.

## Changes

| File | What |
|---|---|
| `mrbgems/mruby-regexp/src/re_compile.c` | `parse_quantifier()` compares the two bounds once the `}` is consumed, and raises `RegexpError` where they are the wrong way round |
| `mrbgems/mruby-regexp/test/regexp_syntax.rb` | new `Regexp - an upper bound below the lower one is an error` block, 15 assertions |

### A backwards range compiled as the lower bound alone

`compile_quantified()` lays out `min` mandatory copies of the atom and then a loop of `max - min` optional ones. With `max` below `min` that count is negative, the loop emits nothing, and what is left is `{min}`. Nothing raised on the way there, so the pattern was accepted and matched:

```ruby
Regexp.new("a{2,1}")                 # CRuby: RegexpError, mruby: /a{2,1}/
Regexp.new("a{2,1}").match("aaa")[0] # CRuby: RegexpError, mruby: "aa"
Regexp.new("^a{3,1}$") =~ "aaa"      # CRuby: RegexpError, mruby: 0
Regexp.new("a{3,1}?")                # CRuby: RegexpError, mruby: /a{3,1}?/
```

Onigmo makes the comparison in `fetch_range_quantifier()` (`regparse.c`) and returns `ONIGERR_UPPER_SMALLER_THAN_LOWER_IN_REPEAT_RANGE`, whose text is the message this PR raises with.

### The comparison sits after the `}`, not where the bounds are read

`parse_quantifier()` reads the digits, and only at the `}` does it know it was reading a quantifier at all: a `{...}` that never closes, or that carries no digit, is restored and the `{` is emitted as a literal character. CRuby does the same, so `a{2,1` is five literal characters rather than a bad range. Judging the bounds where they are read would turn that into an error; judging them once the `}` is consumed leaves it alone. Onigmo's own check sits in the same place, after the `}` is fetched:

```c
  if (c != '}') goto invalid;

  if (!IS_REPEAT_INFINITE(up) && low > up) {
    return ONIGERR_UPPER_SMALLER_THAN_LOWER_IN_REPEAT_RANGE;
  }
```

The unlimited upper bound is spelled `-1` here, as `REPEAT_INFINITE` is there, and the same condition lets it through, so `{n,}` is untouched.

### Every spelling of the range reaches the one reader

`parse_quantifier()` has three callers, and the check covers all of them:

* `compile_quantified()`, the quantifier after an atom, which is the grouped, class and lookaround spellings as well as the plain one, and which reads the `?` making it non-greedy only after the `}`.
* `compile_atom()`'s trial parse for a `{` with no atom to repeat. `{2,1}` now reports the range where it used to report the missing target, which is what CRuby reports there too; `{2}` still reports the target.
* `skip_quantifiers()`, which reads the quantifiers of a body that matches empty and emits nothing for them, so `a{0}{2,1}` and `(?:){2,1}` raise as well.

## Behaviour

| | master | this PR | CRuby 4.0.6 |
|---|---|---|---|
| `Regexp.new("a{2,1}")` | `/a{2,1}/` | `RegexpError` | `RegexpError` |
| `Regexp.new("a{2,1}").match("aaa")[0]` | `"aa"` | `RegexpError` | `RegexpError` |
| `Regexp.new("^a{3,1}$") =~ "aaa"` | `0` | `RegexpError` | `RegexpError` |
| `Regexp.new("a{3,1}?")` | `/a{3,1}?/` | `RegexpError` | `RegexpError` |
| `Regexp.new("(ab){2,1}")` | `/(ab){2,1}/` | `RegexpError` | `RegexpError` |
| `Regexp.new("[a-z]{5,3}")` | `/[a-z]{5,3}/` | `RegexpError` | `RegexpError` |
| `Regexp.new("(?=a{2,1})")` | `/(?=a{2,1})/` | `RegexpError` | `RegexpError` |
| `Regexp.new("a{0}{2,1}")` | `/a{0}{2,1}/` | `RegexpError` | `RegexpError` |
| `Regexp.new("{2,1}")` | `RegexpError`, target of repeat operator | `RegexpError`, upper is smaller than lower | `RegexpError`, upper is smaller than lower |
| `Regexp.new("{2}")` | `RegexpError`, target of repeat operator | `RegexpError`, target of repeat operator | `RegexpError`, target of repeat operator |
| `Regexp.new("a{2,2}").match("aaa")[0]` | `"aa"` | `"aa"` | `"aa"` |
| `Regexp.new("a{2,}").match("aaa")[0]` | `"aaa"` | `"aaa"` | `"aaa"` |
| `Regexp.new("a{0,0}").match("aaa")[0]` | `""` | `""` | `""` |
| `"a{2,1".match(/a{2,1/)[0]` | `"a{2,1"` | `"a{2,1"` | `"a{2,1"` |

## Size

`bin/mruby` `.text`, from `size -A`, for the five builds of `build_config/ci/gcc-clang.rb`:

| Build | master | this PR | delta |
|---|---:|---:|---:|
| `bintest` | 1,292,182 | 1,292,198 | +16 |
| `ascii-ctype` | 1,278,726 | 1,278,742 | +16 |
| `byte-string` | 1,259,718 | 1,259,734 | +16 |
| `cxx_abi` | 1,317,065 | 1,317,081 | +16 |
| `full-debug` (-O0) | 1,895,942 | 1,895,974 | +32 |

All of it is `re_compile.o`, whose `.text` moves by +16 in each of the four `-O3` builds and by +36 at `-O0`; `re_exec.o` and `regexp.o` are unchanged in every build. The message is a 44-byte string, which lands in `.rodata` rather than `.text`: `re_compile.o` carries it padded to 48 bytes, and the linked `.rodata` grows by 32 bytes in four builds and by 64 in `cxx_abi`.

## Testing

`rake test` is green in the default `host` build and in all five builds of `build_config/ci/gcc-clang.rb`:

| Build | Total | OK | KO | Warning | Skip |
|---|---:|---:|---:|---:|---:|
| `host` | 2,195 | 2,142 | 0 | 0 | 53 |
| `host` bintest | 113 | 112 | 0 | 0 | 1 |
| `bintest` | 2,424 | 2,410 | 0 | 0 | 14 |
| `bintest` bintest | 124 | 123 | 0 | 0 | 1 |
| `ascii-ctype` | 2,417 | 2,403 | 0 | 0 | 14 |
| `byte-string` | 2,350 | 2,297 | 0 | 0 | 53 |
| `cxx_abi` | 2,424 | 2,410 | 0 | 0 | 14 |
| `full-debug` | 2,424 | 2,418 | 0 | 0 | 6 |

Beyond the new assertions, every pattern up to a bounded length was compiled and matched by master, by this PR and by CRuby 4.0.6, against the subjects `""`, `"a"` and `"aaa"`.

Over the alphabet `a { } , 1 2 ?` at lengths 1 to 6, which is where `a{2,1}` and the spellings around it live, that is 411,768 rows. Every row this PR answers is what CRuby answers, byte for byte, the refusal messages included. master parts from CRuby on 66 of them, which are 22 patterns: `a{2,1}` and five more that master compiled and matched (`{{2,1}`, `}{2,1}`, `,{2,1}`, `1{2,1}`, `2{2,1}`), and 16 with no atom to repeat, such as `{2,1}` and `{22,2}`, which master refused for the missing target rather than for the range.

Over the wider alphabet `a { } , 1 2 3 ? ( )` at lengths 1 to 5, which brings in groups, that is 333,330 rows. master and this PR part on 9 of them, the three no-atom ranges that fit in five characters (`{2,1}`, `{3,1}`, `{3,2}`), each now reporting the range as CRuby does; every other row is unchanged. The differences from CRuby that remain in both are the ones this PR does not touch: mruby's own wording for an unmatched parenthesis, and `(?a)`, which CRuby compiles and mruby refuses.

## Environment

<details>
<summary>Machine and toolchain</summary>

| | |
|---|---|
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-30-generic, x86_64 |
| CPU | AMD Ryzen 9 5950X, 16C/32T |
| C compiler | gcc 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1) |
| binutils | GNU Binutils 2.47.20260726 (`size -A`) |
| CRuby | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM |

`cxx_abi` compiles with `gcc -x c++ -std=gnu++03`; `g++` is the linker only.

</details>

<details>
<summary>Compile lines, as printed by <code>rake --verbose</code> (<code>-MMD -c</code>, <code>-I</code> and <code>-o</code> removed)</summary>

```console
# bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK

# ascii-ctype
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# full-debug
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid regular expression quantifier ranges now raise `RegexpError` when the upper bound is less than the lower bound.
  * Valid equal, unbounded, and zero-width ranges continue to work correctly.
  * Malformed non-quantifier braces remain supported as literal characters.

* **Tests**
  * Added coverage for invalid ranges across literals, groups, character classes, lookarounds, empty expressions, and missing targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->