### PR TITLE
mruby-process: add a Process module over a process HAL

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -90,6 +90,7 @@ mruby-symbol-ext, mruby-range-ext, mruby-object-ext.
 - **mruby-task**: Cooperative multitasking with preemptive scheduling ([ae0d7a0](https://github.com/mruby/mruby/commit/ae0d7a0))
 - **mruby-benchmark**: Benchmarking gem ([2f40f3d](https://github.com/mruby/mruby/commit/2f40f3d))
 - **mruby-strftime**: Time#strftime implementation ([b31e22f](https://github.com/mruby/mruby/commit/b31e22f))
+- **mruby-process**: `Process` module and `Process::Status` class, over a process HAL with POSIX and Windows ports
 
 ## mruby-bin-mirb Improvements
 

--- a/doc/guides/language.md
+++ b/doc/guides/language.md
@@ -285,6 +285,7 @@ gembox provides the class or feature you need:
 | Socket                | stdlib-io  | mruby-socket      |
 | Dir                   | stdlib-io  | mruby-dir         |
 | Errno                 | stdlib-io  | mruby-errno       |
+| Process               | stdlib-io  | mruby-process     |
 | Math                  | math       | mruby-math        |
 | Rational              | math       | mruby-rational    |
 | Complex               | math       | mruby-complex     |
@@ -330,7 +331,7 @@ methods. These are included by default:
 | ------------ | --------------------------------------------- | -------------------------------------------- |
 | `stdlib`     | Core class extensions, Fiber, Enumerator, Set | Works with `MRB_NO_STDIO` and `MRB_NO_FLOAT` |
 | `stdlib-ext` | Time, Struct, Data, Random, sprintf, pack     | Works with `MRB_NO_STDIO` and `MRB_NO_FLOAT` |
-| `stdlib-io`  | IO, File, Dir, Socket, Errno                  | Requires stdio                               |
+| `stdlib-io`  | IO, File, Dir, Socket, Errno, Process         | Requires stdio                               |
 | `math`       | Math, Rational, Complex, Bigint               | Works with `MRB_NO_STDIO`                    |
 | `metaprog`   | eval, binding, Method, compiler               | Works with `MRB_NO_STDIO` and `MRB_NO_FLOAT` |
 | `default`    | All of the above + CLI tools                  | Full installation                            |

--- a/mrbgems/mruby-process/README.md
+++ b/mrbgems/mruby-process/README.md
@@ -1,0 +1,196 @@
+# mruby-process
+
+`Process` module and `Process::Status` class for mruby.
+
+## Installation
+
+Add the line below to your build configuration.
+
+```ruby
+  conf.gem core: 'mruby-process'
+```
+
+It is part of the `stdlib-io` gembox, so `default.gembox` and `full-core.gembox`
+already include it.
+
+## Implemented methods
+
+| method                     | mruby-process | memo                                     |
+| -------------------------- | ------------- | ---------------------------------------- |
+| Process.pid                | o             | also `$$`                                |
+| Process.ppid               | o             |                                          |
+| Process.kill               | o             | no negative-signal form yet, see below   |
+| Process.waitpid            | o             | sets `$?`; POSIX only, see below         |
+| Process::WNOHANG           | o             | mruby's own value, not the platform's    |
+| Process::WUNTRACED         | o             | mruby's own value, not the platform's    |
+| Process::Status#pid        | o             |                                          |
+| Process::Status#to_i       | o             | also `#to_int`                           |
+| Process::Status#exited?    | o             |                                          |
+| Process::Status#exitstatus | o             |                                          |
+| Process::Status#signaled?  | o             |                                          |
+| Process::Status#termsig    | o             |                                          |
+| Process::Status#stopped?   | o             |                                          |
+| Process::Status#stopsig    | o             |                                          |
+| Process::Status#coredump?  | o             |                                          |
+| Process::Status#success?   | o             |                                          |
+| Process::Status#to_s       | o             |                                          |
+| Process::Status#inspect    | o             |                                          |
+| Process::Status#==         | o             | the raw status decides, not the pid      |
+| Process.fork               |               | inherently non-portable; separate change |
+| Process.spawn              |               | separate change                          |
+| Process.exec               |               | separate change                          |
+| Process.exit, .exit!       |               | see mruby-exit                           |
+| Process.wait, .wait2       |               | separate change                          |
+| Process.uid, .gid, ...     |               | separate change                          |
+| Process.getpgrp, ...       |               | separate change                          |
+
+## Architecture
+
+`mruby-process` and `mruby-io` are independent sibling gems. Neither needs the
+other to provide its own feature set:
+
+```text
+             mruby
+               |
+       +-------+-------+
+       |               |
+       v               v
+   mruby-io       mruby-process
+       |               |
+       v               v
+    io_hal         process_hal
+       |               |
+   +---+---+       +---+---+
+ posix   win     posix   win
+```
+
+`IO.popen` is the one place the two capabilities meet, and it is served by
+`mruby-io`'s own private spawn/wait primitives rather than by anything here.
+There is no dependency in either direction; `mrbgem.rake` names `mruby-io` only
+as a _test_ dependency, because waiting on a child process is only testable
+with a child, and `IO.popen` is how this build makes one.
+
+### The HAL boundary
+
+`include/process_hal.h` declares platform-neutral primitives. The port under
+`ports/<name>/` implements them; a gem named `hal-process-<conf>` may supply
+them instead, in which case the bundled ports are dropped from the build.
+
+The HAL answers OS-level facts and performs OS-level operations:
+
+- `mrb_hal_process_pid()`, `mrb_hal_process_ppid()` — the native process
+  identity, widened to `mrb_int`.
+- `mrb_hal_process_waitpid()` — translates the `MRB_PROCESS_WAIT_*` bits into
+  native wait options and waits.
+- `mrb_hal_process_kill()` — delivers a signal.
+- `mrb_hal_process_signal_number()` / `_signal_name()` — map between a bare
+  name such as `TERM` and the number this platform gives it.
+- `mrb_hal_process_status_decode()` — reads a native wait status into
+  `mrb_process_status`.
+
+The common sources under `src/` implement everything Ruby promises: the module
+and class definitions, argument shapes and conversions, `Process.waitpid`
+return semantics, `$?` and `$$`, the `Process::WNOHANG` / `Process::WUNTRACED`
+constants, and every `Process::Status` method.
+
+No POSIX type or macro — `pid_t`, `WIFEXITED`, `WEXITSTATUS`, `SIGTERM`,
+`WNOHANG` — appears above the HAL, and the HAL knows nothing of `$?`, `$$`,
+blocks or `Process::Status`.
+
+### Process::Status and mruby-io
+
+`mruby-io` sets `$?` after an `IO.popen` stream closes by calling
+`Process::Status.new(pid, raw_status)` when the class happens to be defined,
+and falling back to a plain Integer when it is not. That soft integration keeps
+working unchanged: `Process::Status.new(pid, raw_status)` is a supported way to
+build a status, and the status decodes itself through the same HAL that
+`Process.waitpid` uses, so a status `mruby-io` produced reads exactly like one
+this gem reaped.
+
+A `Process::Status` stores only the pid and the raw platform status, and asks
+the HAL afresh for every question about it. Nothing above the HAL ever holds a
+decoded copy that could disagree with the platform.
+
+The tests exercise that seam on POSIX only. On Windows, `mruby-io` hands out a
+process **handle** as `IO#pid` rather than a process ID, and its `IO.popen`
+sets `$?` through a branch that never fires, so there is nothing there to give
+`Process.waitpid` yet. Both are `mruby-io`'s to fix, and that cleanup is
+kept separate from adding this gem.
+
+### Design decisions
+
+- **`mrb_hal_process_waitpid()` returns a raw status, decoded separately.**
+  `Process.waitpid` itself returns the pid it reaped and publishes the status
+  through `$?`. The decoding is a step of its own because `Process::Status`
+  must be able to decode a status that arrived from somewhere else — that is
+  what the `mruby-io` integration is — so it has to stand alone either way.
+  Having the wait return a decoded struct as well would be a second path to
+  keep in step with the first.
+- **`raw_status` is permanent, not a compatibility detail.** It is what
+  `Process::Status#to_i` returns, and it is the only thing a status needs to
+  store to answer everything else.
+- **Windows exposes the signals it can honour.** `KILL` and `TERM` are
+  delivered as `TerminateProcess()`, and signal 0 asks whether the process can
+  be opened. Other names resolve to a number (so `Process::Status#to_s` can
+  spell them) but fail with `ENOSYS` when sent.
+- **Unsupported operations fail through `errno`.** A port sets `ENOSYS` and the
+  common layer raises through `mrb_sys_fail()`, which becomes `Errno::ENOSYS`
+  when `mruby-errno` is in the build. Methods are never conditionally absent,
+  so a program can be written once and told at the call site what this platform
+  will not do.
+- **`Process::Status.new(pid, raw_status)` stays public.** Making it private
+  would break the `mruby-io` path it exists for.
+- **A wait flag no port stands for is refused before a port sees it.** The
+  flags are mruby's own bits, and a port reads the ones it knows and can say
+  nothing about the rest, so `MRB_PROCESS_WAIT_FLAGS` names every bit a wait
+  may carry and anything else is `EINVAL` in the common layer. Leaving the
+  check to the ports would leave the answer to each of them.
+- **A pid or a signal too large for the platform is refused in the common
+  layer.** What is wrong with such a value is its size, and size is not
+  something a port can report: the HAL answers with an `errno`, which has no
+  spelling for "that was never a pid" and would have to borrow one that means
+  something else, leaving `Errno::ESRCH` to stand both for "no process there"
+  and for "that was never a process id". So the value is refused where
+  `RangeError` can be said, which is also what CRuby raises for it and how
+  `mruby-socket` checks the `int` fields of a getaddrinfo hint. The ports keep
+  their own range guards, so that each is correct on its own.
+- **The POSIX signal list is Ruby's own, not a selection.** Every name Ruby
+  knows is there, in Ruby's order, behind the guard that says whether the host
+  has it. Taking the list rather than picking one keeps a name the host defines
+  from being reported as unsupported, and keeping the order is what makes the
+  reverse lookup answer `ABRT` rather than `IOT` where a host spells one signal
+  two ways. `EXIT` is the one name left out, for the reason below.
+
+## Deviations from CRuby
+
+- `Process.kill` does not name a process group through the signal yet. A
+  negative signal number, or a name written with a leading `-`, asks CRuby for
+  the group of each pid given; here it raises `ArgumentError` rather than
+  quietly signalling the process instead. The `pid` selectors are untouched by
+  that: a positive number names one process, and 0, -1, and numbers below -1
+  reach the platform as they are written, which on POSIX is `kill(2)`'s
+  caller's process group, every process the caller may signal, and the group
+  whose ID is `-pid`.
+- `Process::Status._signame` and `Process::Status._signal_description` are
+  internal helpers `Process::Status#to_s` uses to spell a signal number out.
+  They are not a general signal API; `Signal` and `Signal.signame` are not
+  implemented. `_signame(0)` is nil rather than `"EXIT"`, since a status never
+  carries 0 as a signal and `Process.kill` does not take the name either.
+- On Windows a wait status is the child's exit code and nothing more, so a
+  status there always reads as exited — even for a process this gem terminated.
+- On Windows, `Process.waitpid` fails for every process: `ENOSYS` for a pid of
+  -1, which no handle stands for, and `ECHILD` for a specific one. Win32 names
+  a process to wait on by handle, and a handle comes from opening a process ID,
+  which succeeds for any process the caller may open rather than only for its
+  own children. Waiting on such a handle would report a stranger's exit code as
+  a child's and publish it as `$?`, so the wait says it has no such child
+  instead. A port learns which processes are its children by creating them, so
+  this becomes answerable when `Process.spawn` is added and not before.
+
+## Adding a port
+
+Create `ports/<name>/process_hal.c` implementing every function in
+`include/process_hal.h`, then build with `conf.ports :<name>, :posix` so gems
+without a `<name>` port fall back. A port that cannot do something should set
+`errno` to `ENOSYS` and return the documented failure value rather than
+pretending to succeed.

--- a/mrbgems/mruby-process/include/process_hal.h
+++ b/mrbgems/mruby-process/include/process_hal.h
@@ -1,0 +1,144 @@
+/*
+** process_hal.h - Process Hardware Abstraction Layer (HAL)
+**
+** See Copyright Notice in mruby.h
+**
+** This header defines the HAL interface for platform-specific process
+** operations.  A port under mruby-process/ports/<port_name>/, or an
+** external provider gem named hal-process-<conf>, supplies every function
+** declared here.
+**
+** The HAL answers OS-level facts and performs OS-level operations.  It knows
+** nothing about `Process::Status`, `$?`, `$$`, blocks or any other Ruby
+** notion: those belong to the common sources under src/.  In the other
+** direction, no platform type or macro (`pid_t`, `WIFEXITED`, `SIGTERM`,
+** `WNOHANG`, ...) crosses into the common layer: process and signal
+** numbers travel as `mrb_int`, wait options as the MRB_PROCESS_WAIT_* bits
+** below, and a decoded wait status as `mrb_process_status`.
+*/
+
+#ifndef MRUBY_PROCESS_HAL_H
+#define MRUBY_PROCESS_HAL_H
+
+#include <mruby.h>
+
+/*
+ * Decoded wait status
+ */
+
+/* What a decoded status says about how the process left the CPU.  A port sets
+   the flags it can tell apart; a platform that only reports an exit code sets
+   MRB_PROCESS_STATUS_EXITED alone. */
+typedef enum mrb_process_status_flags {
+  MRB_PROCESS_STATUS_EXITED    = 1 << 0,  /* ran to completion; exitstatus is set */
+  MRB_PROCESS_STATUS_SIGNALED  = 1 << 1,  /* killed by a signal; termsig is set */
+  MRB_PROCESS_STATUS_STOPPED   = 1 << 2,  /* stopped, not reaped; stopsig is set */
+  MRB_PROCESS_STATUS_COREDUMP  = 1 << 3,  /* a core dump accompanied the signal */
+} mrb_process_status_flags;
+
+/* A wait status in platform-neutral form.  Fields not selected by `flags`
+   hold 0.  `raw_status` is the platform value the status was decoded from,
+   kept so that `Process::Status#to_i` can hand it back unchanged. */
+typedef struct mrb_process_status {
+  mrb_int pid;
+  mrb_int raw_status;
+  mrb_int exitstatus;
+  mrb_int termsig;
+  mrb_int stopsig;
+  unsigned int flags;
+} mrb_process_status;
+
+/*
+ * Wait options
+ *
+ * These are the values `Process::WNOHANG` and `Process::WUNTRACED` carry, so
+ * they are mruby's own; a port translates them to whatever its platform
+ * spells them as.
+ */
+#define MRB_PROCESS_WAIT_NOHANG   (1u << 0)  /* return at once if nothing is ready */
+#define MRB_PROCESS_WAIT_UNTRACED (1u << 1)  /* report stopped children too */
+
+/* Every bit a wait may carry.  The common layer refuses anything else, so a
+   port is handed only bits it knows and does not have to say what it would
+   do with the others. */
+#define MRB_PROCESS_WAIT_FLAGS (MRB_PROCESS_WAIT_NOHANG | MRB_PROCESS_WAIT_UNTRACED)
+
+/* Wait for any child, whichever finishes first.  Other non-positive pids keep
+   their platform meaning (on POSIX, a process group selector); a port that
+   cannot express them fails with ENOSYS. */
+#define MRB_PROCESS_WAIT_ANY ((mrb_int)-1)
+
+/*
+ * HAL Interface Functions
+ */
+
+/* Process ID of the calling process.  Returns -1 with errno set on failure. */
+mrb_int mrb_hal_process_pid(mrb_state *mrb);
+
+/* Process ID of the parent.  Returns -1 with errno set where the platform
+   cannot name a parent (errno ENOSYS when it has no such notion at all). */
+mrb_int mrb_hal_process_ppid(mrb_state *mrb);
+
+/*
+ * Wait for a child process to change state.
+ *
+ * @param pid         child to wait for, or MRB_PROCESS_WAIT_ANY
+ * @param flags       zero or more MRB_PROCESS_WAIT_* bits
+ * @param result_pid  out: the child that changed state, or 0 when
+ *                    MRB_PROCESS_WAIT_NOHANG found none ready
+ * @param raw_status  out: the platform status, to be read back through
+ *                    mrb_hal_process_status_decode()
+ * @return 0 on success, -1 on error (sets errno)
+ */
+int mrb_hal_process_waitpid(mrb_state *mrb, mrb_int pid, unsigned int flags,
+                            mrb_int *result_pid, mrb_int *raw_status);
+
+/*
+ * Send a signal to a process.
+ *
+ * Signal 0 sends nothing and only reports whether the process may be
+ * signalled, as POSIX `kill(2)` does.
+ *
+ * @return 0 on success, -1 on error (sets errno; ENOSYS where the platform
+ *         cannot deliver this signal at all)
+ */
+int mrb_hal_process_kill(mrb_state *mrb, mrb_int pid, mrb_int signo);
+
+/*
+ * Resolve a signal name to its number on this platform.
+ *
+ * @param name  a bare name such as "TERM", without the "SIG" prefix, which
+ *              the common layer has already stripped
+ * @return 0 with *signo set, or -1 when the platform has no such signal
+ */
+int mrb_hal_process_signal_number(mrb_state *mrb, const char *name, mrb_int *signo);
+
+/*
+ * Name the signal `signo` stands for on this platform.
+ *
+ * @return a static bare name such as "TERM", or NULL when the number names
+ *         no signal here.  The caller must not free it.
+ */
+const char *mrb_hal_process_signal_name(mrb_state *mrb, mrb_int signo);
+
+/*
+ * Read a platform wait status into its neutral form.
+ *
+ * Every field of `status` is written, including `pid` and `raw_status`, which
+ * are copied from the arguments.  Decoding cannot fail: a status the platform
+ * does not recognize decodes to flags of 0.
+ */
+void mrb_hal_process_status_decode(mrb_state *mrb, mrb_int pid, mrb_int raw_status,
+                                   mrb_process_status *status);
+
+/*
+ * HAL Initialization/Finalization
+ */
+
+/* Initialize HAL (called once at gem initialization) */
+void mrb_hal_process_init(mrb_state *mrb);
+
+/* Cleanup HAL (called once at gem finalization) */
+void mrb_hal_process_final(mrb_state *mrb);
+
+#endif /* MRUBY_PROCESS_HAL_H */

--- a/mrbgems/mruby-process/include/process_internal.h
+++ b/mrbgems/mruby-process/include/process_internal.h
@@ -1,0 +1,22 @@
+/*
+** process_internal.h - shared declarations within mruby-process
+**
+** See Copyright Notice in mruby.h
+**
+** Not part of the HAL and not for other gems: these are the handful of
+** things process.c and status.c say to each other.
+*/
+
+#ifndef MRUBY_PROCESS_INTERNAL_H
+#define MRUBY_PROCESS_INTERNAL_H
+
+#include <mruby.h>
+
+/* Define Process::Status under `process`.  Called once from gem init. */
+void mrb_process_status_init(mrb_state *mrb, struct RClass *process);
+
+/* Build a Process::Status for a pid and the platform status it was reaped
+   with.  The status decodes itself through the HAL as it is asked questions. */
+mrb_value mrb_process_status_new(mrb_state *mrb, mrb_int pid, mrb_int raw_status);
+
+#endif /* MRUBY_PROCESS_INTERNAL_H */

--- a/mrbgems/mruby-process/mrbgem.rake
+++ b/mrbgems/mruby-process/mrbgem.rake
@@ -1,0 +1,10 @@
+MRuby::Gem::Specification.new('mruby-process') do |spec|
+  spec.license = 'MIT'
+  spec.authors = 'mruby developers'
+  spec.summary = 'Process module and Process::Status class'
+
+  # mruby-process needs no I/O of its own.  The tests do: waiting on a child
+  # is only testable with a child, and IO.popen is how one is made.  The
+  # dependency stops at the tests; see README.md.
+  spec.add_test_dependency 'mruby-io', core: 'mruby-io'
+end

--- a/mrbgems/mruby-process/mrblib/status.rb
+++ b/mrbgems/mruby-process/mrblib/status.rb
@@ -1,0 +1,47 @@
+module Process
+  # The way a process finished, as reported by Process.waitpid and left in
+  # <code>$?</code>.
+  #
+  # The questions a status answers (#exited?, #exitstatus, #termsig and the
+  # rest) are decoded from the platform value by the process HAL. What is
+  # here is the part that reads the same everywhere.
+  class Status
+    # Whether the process exited with a status of zero.
+    #
+    # Returns nil rather than false when the process did not exit at all,
+    # because "did it succeed?" has no answer for one that was signalled.
+    def success?
+      exitstatus == 0 if exited?
+    end
+
+    # A description of how the process finished, in the shape CRuby uses:
+    #
+    #   pid 1234 exit 0
+    #   pid 1234 SIGKILL (signal 9)
+    #   pid 1234 SIGSEGV (signal 11) (core dumped)
+    #   pid 1234 stopped SIGSTOP (signal 19)
+    def to_s
+      if exited?
+        "pid #{pid} exit #{exitstatus}"
+      elsif signaled?
+        desc = "pid #{pid} #{Status._signal_description(termsig)}"
+        coredump? ? "#{desc} (core dumped)" : desc
+      elsif stopped?
+        "pid #{pid} stopped #{Status._signal_description(stopsig)}"
+      else
+        "pid #{pid}"
+      end
+    end
+
+    def inspect
+      "#<Process::Status: #{self}>"
+    end
+
+    # Spell a signal number out for #to_s. A platform that does not name the
+    # number gets the bare number rather than a guess.
+    def self._signal_description(signo)
+      name = _signame(signo)
+      name ? "SIG#{name} (signal #{signo})" : "signal #{signo}"
+    end
+  end
+end

--- a/mrbgems/mruby-process/ports/posix/process_hal.c
+++ b/mrbgems/mruby-process/ports/posix/process_hal.c
@@ -1,0 +1,340 @@
+/*
+** process_hal.c - POSIX HAL implementation for mruby-process
+**
+** See Copyright Notice in mruby.h
+**
+** POSIX implementation of the process HAL using getpid(2), getppid(2),
+** waitpid(2) and kill(2).
+** Supported platforms: Linux, macOS, BSD, Unix
+*/
+
+#include <mruby.h>
+#include "process_hal.h"
+
+#include <sys/types.h>
+#include <sys/wait.h>
+
+#include <errno.h>
+#include <limits.h>
+#include <signal.h>
+#include <string.h>
+#include <unistd.h>
+
+/* An mrb_int is wider than a pid_t where mrb_int is 64-bit, so a pid from
+   Ruby is range-checked rather than truncated into one. */
+#define PID_FITS(pid) ((pid) >= (mrb_int)INT_MIN && (pid) <= (mrb_int)INT_MAX)
+
+/*
+ * Signal table
+ *
+ * The names Ruby knows a signal by, in the order Ruby lists them, each one
+ * behind the guard that says whether this host has it.  Taking the list from
+ * Ruby rather than picking one keeps a name the host defines from being
+ * reported as unsupported merely because it was left out here.
+ *
+ * `EXIT` is not among them: it names signal 0 only where a handler is being
+ * set, which this gem does not do, and `Process.kill` refuses it in Ruby too.
+ *
+ * The order carries a second meaning.  Where a host gives one signal two
+ * names, the alias follows the name Ruby answers with, so the reverse lookup
+ * that `Process::Status#to_s` goes through finds `ABRT` before `IOT`, `CHLD`
+ * before `CLD` and `IO` before `POLL`.
+ */
+
+struct signal_entry {
+  const char *name;
+  int signo;
+};
+
+static const struct signal_entry signal_table[] = {
+#define SIGNAL_ENTRY(name) { #name, SIG##name },
+#ifdef SIGHUP
+  SIGNAL_ENTRY(HUP)
+#endif
+#ifdef SIGINT
+  SIGNAL_ENTRY(INT)
+#endif
+#ifdef SIGQUIT
+  SIGNAL_ENTRY(QUIT)
+#endif
+#ifdef SIGILL
+  SIGNAL_ENTRY(ILL)
+#endif
+#ifdef SIGTRAP
+  SIGNAL_ENTRY(TRAP)
+#endif
+#ifdef SIGABRT
+  SIGNAL_ENTRY(ABRT)
+#endif
+#ifdef SIGIOT
+  SIGNAL_ENTRY(IOT)
+#endif
+#ifdef SIGEMT
+  SIGNAL_ENTRY(EMT)
+#endif
+#ifdef SIGFPE
+  SIGNAL_ENTRY(FPE)
+#endif
+#ifdef SIGKILL
+  SIGNAL_ENTRY(KILL)
+#endif
+#ifdef SIGBUS
+  SIGNAL_ENTRY(BUS)
+#endif
+#ifdef SIGSEGV
+  SIGNAL_ENTRY(SEGV)
+#endif
+#ifdef SIGSYS
+  SIGNAL_ENTRY(SYS)
+#endif
+#ifdef SIGPIPE
+  SIGNAL_ENTRY(PIPE)
+#endif
+#ifdef SIGALRM
+  SIGNAL_ENTRY(ALRM)
+#endif
+#ifdef SIGTERM
+  SIGNAL_ENTRY(TERM)
+#endif
+#ifdef SIGURG
+  SIGNAL_ENTRY(URG)
+#endif
+#ifdef SIGSTOP
+  SIGNAL_ENTRY(STOP)
+#endif
+#ifdef SIGTSTP
+  SIGNAL_ENTRY(TSTP)
+#endif
+#ifdef SIGCONT
+  SIGNAL_ENTRY(CONT)
+#endif
+#ifdef SIGCHLD
+  SIGNAL_ENTRY(CHLD)
+#endif
+#ifdef SIGCLD
+  SIGNAL_ENTRY(CLD)
+#endif
+#ifdef SIGTTIN
+  SIGNAL_ENTRY(TTIN)
+#endif
+#ifdef SIGTTOU
+  SIGNAL_ENTRY(TTOU)
+#endif
+#ifdef SIGIO
+  SIGNAL_ENTRY(IO)
+#endif
+#ifdef SIGXCPU
+  SIGNAL_ENTRY(XCPU)
+#endif
+#ifdef SIGXFSZ
+  SIGNAL_ENTRY(XFSZ)
+#endif
+#ifdef SIGVTALRM
+  SIGNAL_ENTRY(VTALRM)
+#endif
+#ifdef SIGPROF
+  SIGNAL_ENTRY(PROF)
+#endif
+#ifdef SIGWINCH
+  SIGNAL_ENTRY(WINCH)
+#endif
+#ifdef SIGUSR1
+  SIGNAL_ENTRY(USR1)
+#endif
+#ifdef SIGUSR2
+  SIGNAL_ENTRY(USR2)
+#endif
+#ifdef SIGLOST
+  SIGNAL_ENTRY(LOST)
+#endif
+#ifdef SIGMSG
+  SIGNAL_ENTRY(MSG)
+#endif
+#ifdef SIGPWR
+  SIGNAL_ENTRY(PWR)
+#endif
+#ifdef SIGPOLL
+  SIGNAL_ENTRY(POLL)
+#endif
+#ifdef SIGDANGER
+  SIGNAL_ENTRY(DANGER)
+#endif
+#ifdef SIGMIGRATE
+  SIGNAL_ENTRY(MIGRATE)
+#endif
+#ifdef SIGPRE
+  SIGNAL_ENTRY(PRE)
+#endif
+#ifdef SIGGRANT
+  SIGNAL_ENTRY(GRANT)
+#endif
+#ifdef SIGRETRACT
+  SIGNAL_ENTRY(RETRACT)
+#endif
+#ifdef SIGSOUND
+  SIGNAL_ENTRY(SOUND)
+#endif
+#ifdef SIGINFO
+  SIGNAL_ENTRY(INFO)
+#endif
+#undef SIGNAL_ENTRY
+};
+
+#define SIGNAL_TABLE_LEN (sizeof(signal_table) / sizeof(signal_table[0]))
+
+/*
+ * Process Identity
+ */
+
+mrb_int
+mrb_hal_process_pid(mrb_state *mrb)
+{
+  (void)mrb;
+  return (mrb_int)getpid();
+}
+
+mrb_int
+mrb_hal_process_ppid(mrb_state *mrb)
+{
+  (void)mrb;
+  return (mrb_int)getppid();
+}
+
+/*
+ * Waiting
+ */
+
+int
+mrb_hal_process_waitpid(mrb_state *mrb, mrb_int pid, unsigned int flags,
+                        mrb_int *result_pid, mrb_int *raw_status)
+{
+  pid_t result;
+  int status = 0;
+  int options = 0;
+  (void)mrb;
+
+  if (!PID_FITS(pid)) {
+    errno = ECHILD;
+    return -1;
+  }
+  if (flags & MRB_PROCESS_WAIT_NOHANG) options |= WNOHANG;
+  if (flags & MRB_PROCESS_WAIT_UNTRACED) options |= WUNTRACED;
+
+  do {
+    result = waitpid((pid_t)pid, &status, options);
+  } while (result == -1 && errno == EINTR);
+
+  if (result == -1) return -1;
+
+  /* result is 0 when WNOHANG found nothing ready; status is untouched then */
+  *result_pid = (mrb_int)result;
+  *raw_status = (result == 0) ? 0 : (mrb_int)status;
+  return 0;
+}
+
+/*
+ * Signalling
+ */
+
+int
+mrb_hal_process_kill(mrb_state *mrb, mrb_int pid, mrb_int signo)
+{
+  (void)mrb;
+
+  /* Which numbers name a signal is kill(2)'s to say, and it answers EINVAL
+     for the ones this host does not have, so the range asked for here is only
+     the one an int can carry. */
+  if (signo < 0 || signo > (mrb_int)INT_MAX) {
+    errno = EINVAL;
+    return -1;
+  }
+  if (!PID_FITS(pid)) {
+    errno = ESRCH;
+    return -1;
+  }
+  return kill((pid_t)pid, (int)signo);
+}
+
+int
+mrb_hal_process_signal_number(mrb_state *mrb, const char *name, mrb_int *signo)
+{
+  size_t i;
+  (void)mrb;
+
+  for (i = 0; i < SIGNAL_TABLE_LEN; i++) {
+    if (strcmp(signal_table[i].name, name) == 0) {
+      *signo = (mrb_int)signal_table[i].signo;
+      return 0;
+    }
+  }
+  return -1;
+}
+
+const char*
+mrb_hal_process_signal_name(mrb_state *mrb, mrb_int signo)
+{
+  size_t i;
+  (void)mrb;
+
+  for (i = 0; i < SIGNAL_TABLE_LEN; i++) {
+    if ((mrb_int)signal_table[i].signo == signo) {
+      return signal_table[i].name;
+    }
+  }
+  return NULL;
+}
+
+/*
+ * Status Decoding
+ */
+
+void
+mrb_hal_process_status_decode(mrb_state *mrb, mrb_int pid, mrb_int raw_status,
+                              mrb_process_status *status)
+{
+  int raw = (int)raw_status;
+  (void)mrb;
+
+  status->pid = pid;
+  status->raw_status = raw_status;
+  status->exitstatus = 0;
+  status->termsig = 0;
+  status->stopsig = 0;
+  status->flags = 0;
+
+  /* WIFSTOPPED comes first: a stopped status can also satisfy WIFSIGNALED on
+     some platforms, and stopping is the more specific answer. */
+  if (WIFSTOPPED(raw)) {
+    status->flags |= MRB_PROCESS_STATUS_STOPPED;
+    status->stopsig = (mrb_int)WSTOPSIG(raw);
+  }
+  else if (WIFEXITED(raw)) {
+    status->flags |= MRB_PROCESS_STATUS_EXITED;
+    status->exitstatus = (mrb_int)WEXITSTATUS(raw);
+  }
+  else if (WIFSIGNALED(raw)) {
+    status->flags |= MRB_PROCESS_STATUS_SIGNALED;
+    status->termsig = (mrb_int)WTERMSIG(raw);
+#ifdef WCOREDUMP
+    if (WCOREDUMP(raw)) {
+      status->flags |= MRB_PROCESS_STATUS_COREDUMP;
+    }
+#endif
+  }
+}
+
+/*
+ * HAL Initialization/Finalization
+ */
+
+void
+mrb_hal_process_init(mrb_state *mrb)
+{
+  (void)mrb;
+}
+
+void
+mrb_hal_process_final(mrb_state *mrb)
+{
+  (void)mrb;
+}

--- a/mrbgems/mruby-process/ports/win/process_hal.c
+++ b/mrbgems/mruby-process/ports/win/process_hal.c
@@ -1,0 +1,305 @@
+/*
+** process_hal.c - Windows HAL implementation for mruby-process
+**
+** See Copyright Notice in mruby.h
+**
+** Windows implementation of the process HAL.  Windows has no signals between
+** processes and no wait status beyond an exit code, so this port covers the
+** part of the interface Win32 can answer honestly and fails, rather than
+** guesses, at the rest:
+**
+**   - a wait cannot be answered at all.  Win32 identifies a process to wait
+**     on by handle, and a handle is obtained by opening a process ID, which
+**     succeeds for any process this one may open rather than only for its
+**     own children.  Waiting on it would report a stranger's exit code as a
+**     child's, so every wait fails instead: ECHILD for a specific process,
+**     since this port can name no child, and ENOSYS for MRB_PROCESS_WAIT_ANY,
+**     which has no handle standing for it.  A port learns of its children
+**     when it creates them, so this is answerable once spawn exists and not
+**     before.  No process is ever reported as stopped either;
+**   - a raw status is the child's exit code, which is what mruby-io's
+**     `IO.popen` already hands to `Process::Status.new` on this platform, so
+**     a decoded status always reads as exited;
+**   - only `KILL` and `TERM` can be delivered, both as TerminateProcess(),
+**     and signal 0 asks whether the process can be opened at all.
+*/
+
+#include <mruby.h>
+#include "process_hal.h"
+
+#include <windows.h>
+#include <tlhelp32.h>
+
+#include <errno.h>
+#include <stdint.h>
+#include <string.h>
+
+/* Vista and later; fall back to the access right every Windows has. */
+#ifndef PROCESS_QUERY_LIMITED_INFORMATION
+#define PROCESS_QUERY_LIMITED_INFORMATION PROCESS_QUERY_INFORMATION
+#endif
+
+/*
+ * Signal table
+ *
+ * The numbers Windows' <signal.h> uses, plus KILL at its conventional POSIX
+ * value so that `Process.kill(:KILL, pid)` names something here.  Being in
+ * the table only makes a name resolvable; mrb_hal_process_kill() decides
+ * which of them can actually be delivered.
+ */
+
+struct signal_entry {
+  const char *name;
+  int signo;
+};
+
+static const struct signal_entry signal_table[] = {
+  { "INT",   2 },
+  { "ILL",   4 },
+  { "FPE",   8 },
+  { "KILL",  9 },
+  { "SEGV",  11 },
+  { "TERM",  15 },
+  { "BREAK", 21 },
+  { "ABRT",  22 },
+};
+
+#define SIGNAL_TABLE_LEN (sizeof(signal_table) / sizeof(signal_table[0]))
+
+#define SIGNAL_KILL 9
+#define SIGNAL_TERM 15
+
+/* Exit code TerminateProcess() stamps on the victim.  128+SIGTERM is the
+   shell's convention for "died on a signal", which is the closest a Windows
+   exit code gets to saying so. */
+#define TERMINATED_EXIT_CODE (128 + SIGNAL_TERM)
+
+/*
+ * Helper Functions
+ */
+
+static void
+set_errno_from_win32(DWORD err)
+{
+  switch (err) {
+  case ERROR_INVALID_PARAMETER:
+    errno = EINVAL;
+    break;
+  case ERROR_ACCESS_DENIED:
+    errno = EPERM;
+    break;
+  case ERROR_INVALID_HANDLE:
+  case ERROR_NOT_FOUND:
+    errno = ESRCH;
+    break;
+  default:
+    errno = EINVAL;
+    break;
+  }
+}
+
+/* Open a process by pid.  A pid Windows will not open is "no such process"
+   here, whatever it says: OpenProcess reports a pid that names nothing as
+   ERROR_INVALID_PARAMETER rather than as a missing process. */
+static HANDLE
+open_process(mrb_int pid, DWORD access)
+{
+  HANDLE h;
+  DWORD err;
+
+  if (pid <= 0 || (uint64_t)pid > 0xFFFFFFFFu) {
+    errno = ESRCH;
+    return NULL;
+  }
+  h = OpenProcess(access, FALSE, (DWORD)pid);
+  if (h == NULL) {
+    err = GetLastError();
+    switch (err) {
+    case ERROR_INVALID_PARAMETER:
+    case ERROR_INVALID_HANDLE:
+    case ERROR_NOT_FOUND:
+      errno = ESRCH;
+      break;
+    default:
+      set_errno_from_win32(err);
+      break;
+    }
+  }
+  return h;
+}
+
+/*
+ * Process Identity
+ */
+
+mrb_int
+mrb_hal_process_pid(mrb_state *mrb)
+{
+  (void)mrb;
+  return (mrb_int)GetCurrentProcessId();
+}
+
+mrb_int
+mrb_hal_process_ppid(mrb_state *mrb)
+{
+  HANDLE snapshot;
+  PROCESSENTRY32W entry;
+  DWORD self = GetCurrentProcessId();
+  mrb_int ppid = -1;
+  (void)mrb;
+
+  snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+  if (snapshot == INVALID_HANDLE_VALUE) {
+    set_errno_from_win32(GetLastError());
+    return -1;
+  }
+
+  entry.dwSize = sizeof(entry);
+  if (Process32FirstW(snapshot, &entry)) {
+    do {
+      if (entry.th32ProcessID == self) {
+        ppid = (mrb_int)entry.th32ParentProcessID;
+        break;
+      }
+    } while (Process32NextW(snapshot, &entry));
+  }
+  CloseHandle(snapshot);
+
+  if (ppid < 0) errno = ESRCH;
+  return ppid;
+}
+
+/*
+ * Waiting
+ */
+
+int
+mrb_hal_process_waitpid(mrb_state *mrb, mrb_int pid, unsigned int flags,
+                        mrb_int *result_pid, mrb_int *raw_status)
+{
+  (void)mrb;
+  (void)flags;
+  (void)result_pid;
+  (void)raw_status;
+
+  /* A wait needs a handle, and there is no handle standing for "any child". */
+  if (pid <= 0) {
+    errno = ENOSYS;
+    return -1;
+  }
+
+  /* OpenProcess() opens any process this one is allowed to open, and asks
+     nothing about parentage, so a handle got that way is no evidence that
+     the process is a child.  Waiting on it would answer Process.waitpid with
+     an unrelated process's exit code and publish it as `$?`.  ECHILD is both
+     the honest answer and the same one a real child gets from a wait that
+     has already reaped it: this port knows of no children, because a port
+     learns of its children by creating them, and creating them is spawn's
+     to add. */
+  errno = ECHILD;
+  return -1;
+}
+
+/*
+ * Signalling
+ */
+
+int
+mrb_hal_process_kill(mrb_state *mrb, mrb_int pid, mrb_int signo)
+{
+  HANDLE h;
+  (void)mrb;
+
+  if (signo == 0) {
+    h = open_process(pid, PROCESS_QUERY_LIMITED_INFORMATION);
+    if (h == NULL) return -1;
+    CloseHandle(h);
+    return 0;
+  }
+
+  if (signo != SIGNAL_KILL && signo != SIGNAL_TERM) {
+    errno = ENOSYS;
+    return -1;
+  }
+
+  h = open_process(pid, PROCESS_TERMINATE);
+  if (h == NULL) return -1;
+  if (!TerminateProcess(h, TERMINATED_EXIT_CODE)) {
+    set_errno_from_win32(GetLastError());
+    CloseHandle(h);
+    return -1;
+  }
+  CloseHandle(h);
+  return 0;
+}
+
+int
+mrb_hal_process_signal_number(mrb_state *mrb, const char *name, mrb_int *signo)
+{
+  size_t i;
+  (void)mrb;
+
+  for (i = 0; i < SIGNAL_TABLE_LEN; i++) {
+    if (strcmp(signal_table[i].name, name) == 0) {
+      *signo = (mrb_int)signal_table[i].signo;
+      return 0;
+    }
+  }
+  return -1;
+}
+
+const char*
+mrb_hal_process_signal_name(mrb_state *mrb, mrb_int signo)
+{
+  size_t i;
+  (void)mrb;
+
+  for (i = 0; i < SIGNAL_TABLE_LEN; i++) {
+    if ((mrb_int)signal_table[i].signo == signo) {
+      return signal_table[i].name;
+    }
+  }
+  return NULL;
+}
+
+/*
+ * Status Decoding
+ */
+
+void
+mrb_hal_process_status_decode(mrb_state *mrb, mrb_int pid, mrb_int raw_status,
+                              mrb_process_status *status)
+{
+  (void)mrb;
+
+  /* A Windows raw status is an exit code and nothing else: a process killed
+     with TerminateProcess() is indistinguishable from one that exited with
+     the same code, so every status reads as exited.  Nothing in this port
+     produces one, since it performs no wait; a status reaching here came
+     from a caller of Process::Status.new, which is how mruby-io's IO.popen
+     reports a child on this platform.  An exit code such as 0xC0000005 does
+     not fit a 32-bit mrb_int unsigned and reads back negative, which is what
+     Process::Status#to_i then shows. */
+  status->pid = pid;
+  status->raw_status = raw_status;
+  status->exitstatus = raw_status;
+  status->termsig = 0;
+  status->stopsig = 0;
+  status->flags = MRB_PROCESS_STATUS_EXITED;
+}
+
+/*
+ * HAL Initialization/Finalization
+ */
+
+void
+mrb_hal_process_init(mrb_state *mrb)
+{
+  (void)mrb;
+}
+
+void
+mrb_hal_process_final(mrb_state *mrb)
+{
+  (void)mrb;
+}

--- a/mrbgems/mruby-process/src/process.c
+++ b/mrbgems/mruby-process/src/process.c
@@ -1,0 +1,292 @@
+/*
+** process.c - Process module
+**
+** See Copyright Notice in mruby.h
+**
+** The common half of mruby-process: everything Ruby promises about a
+** process, expressed over the platform-neutral primitives in process_hal.h.
+** Argument shapes, return conventions, `$?` and `$$` live here; what a pid
+** or a signal or a wait status *is* stays behind the HAL.
+*/
+
+#include <mruby.h>
+#include <mruby/error.h>
+#include <mruby/string.h>
+#include <mruby/variable.h>
+#include "process_hal.h"
+#include "process_internal.h"
+
+#include <errno.h>
+#include <limits.h>
+#include <string.h>
+
+/* `$?` and `$$` are not word names, so MRB_GVSYM() cannot spell them and
+   they are interned where they are used. */
+static void
+set_last_status(mrb_state *mrb, mrb_value status)
+{
+  mrb_gv_set(mrb, mrb_intern_lit(mrb, "$?"), status);
+}
+
+/*
+ * Refuse a pid or a signal number that would not survive the narrowing a port
+ * has to do with it.
+ *
+ * What is wrong with such a value is its size, and size is not something a
+ * port can report: the HAL answers with an `errno`, which has no spelling for
+ * "that was never a pid" and would have to borrow one that also means
+ * something else.  So the value is refused here, where `RangeError` can be
+ * said, and a port keeps `errno` for what the platform actually answered.
+ * mruby-socket checks the `int` fields of a getaddrinfo hint the same way.
+ */
+static mrb_int
+int_arg(mrb_state *mrb, mrb_int v, const char *what)
+{
+#if MRB_INT_MAX > INT_MAX
+  if (v < (mrb_int)INT_MIN || v > (mrb_int)INT_MAX) {
+    mrb_raisef(mrb, E_RANGE_ERROR, "%s out of range: %i", what, v);
+  }
+#else
+  (void)mrb;
+  (void)what;
+#endif
+  return v;
+}
+
+/*
+ * Read a signal argument into a number.
+ *
+ * Ruby lets a signal be an Integer, or a name as a String or Symbol, with or
+ * without the "SIG" prefix.  Deciding that much is common-layer work; which
+ * number a name stands for is the port's.
+ */
+static mrb_int
+signal_to_number(mrb_state *mrb, mrb_value sig)
+{
+  const char *name;
+  mrb_int len, signo;
+  char bare[32];
+
+  /* A bigint is an Integer that no signal number can be, and `mrb_integer_p`
+     is false for one, so it has to be turned away before the branches below
+     read it as a name and report it as the wrong type. */
+  if (mrb_bigint_p(sig)) {
+    mrb_raisef(mrb, E_RANGE_ERROR, "signal number out of range: %v", sig);
+  }
+
+  if (mrb_integer_p(sig)) {
+    signo = mrb_integer(sig);
+    if (signo < 0) {
+      mrb_raise(mrb, E_ARGUMENT_ERROR, "signalling a process group is not supported");
+    }
+    return int_arg(mrb, signo, "signal number");
+  }
+
+  if (mrb_symbol_p(sig)) {
+    name = mrb_sym_name_len(mrb, mrb_symbol(sig), &len);
+  }
+  else {
+    sig = mrb_ensure_string_type(mrb, sig);
+    name = RSTRING_PTR(sig);
+    len = RSTRING_LEN(sig);
+  }
+  if (name == NULL) {
+    mrb_raise(mrb, E_ARGUMENT_ERROR, "bad signal name");
+  }
+
+  /* The HAL is asked in C strings, so a name holding a NUL would be read as
+     the part before it and would signal something that was never asked for.
+     Checked before the name is taken apart, as CRuby checks it. */
+  if (memchr(name, '\0', (size_t)len) != NULL) {
+    mrb_raise(mrb, E_ARGUMENT_ERROR, "signal name with null byte");
+  }
+
+  /* A leading "-" asks for the process group, which this gem does not do
+     yet; say so rather than quietly signalling the process instead. */
+  if (len > 0 && name[0] == '-') {
+    mrb_raise(mrb, E_ARGUMENT_ERROR, "signalling a process group is not supported");
+  }
+  if (len > 3 && memcmp(name, "SIG", 3) == 0) {
+    name += 3;
+    len -= 3;
+  }
+  if (len <= 0 || (size_t)len >= sizeof(bare)) {
+    mrb_raise(mrb, E_ARGUMENT_ERROR, "bad signal name");
+  }
+  /* The HAL takes a C string, and `name` is a slice of a longer one. */
+  memcpy(bare, name, (size_t)len);
+  bare[len] = '\0';
+
+  if (mrb_hal_process_signal_number(mrb, bare, &signo) != 0) {
+    mrb_raisef(mrb, E_ARGUMENT_ERROR, "unsupported signal 'SIG%s'", bare);
+  }
+  return signo;
+}
+
+/*
+ * call-seq:
+ *   Process.pid -> integer
+ *
+ * The process ID of the running process.  Also available as <code>$$</code>.
+ */
+static mrb_value
+process_pid(mrb_state *mrb, mrb_value self)
+{
+  mrb_int pid = mrb_hal_process_pid(mrb);
+
+  if (pid < 0) mrb_sys_fail(mrb, "getpid");
+  return mrb_int_value(mrb, pid);
+}
+
+/*
+ * call-seq:
+ *   Process.ppid -> integer
+ *
+ * The process ID of the parent of the running process.
+ */
+static mrb_value
+process_ppid(mrb_state *mrb, mrb_value self)
+{
+  mrb_int ppid = mrb_hal_process_ppid(mrb);
+
+  if (ppid < 0) mrb_sys_fail(mrb, "getppid");
+  return mrb_int_value(mrb, ppid);
+}
+
+/*
+ * call-seq:
+ *   Process.kill(signal, pid, ...) -> integer
+ *
+ * Sends +signal+ to each process, and returns how many it was sent to.
+ * At least one process must be named.  +signal+ is a number, or a name as a
+ * String or Symbol with or without the "SIG" prefix.  Signal 0 sends nothing
+ * and only checks that the process is there to be signalled; it is spelled
+ * as the number, since "EXIT" names it only where a handler is being set.
+ *
+ *   Process.kill(:TERM, pid)
+ *   Process.kill("SIGTERM", pid)
+ *   Process.kill(0, pid)          # => 1 if pid exists, Errno::ESRCH if not
+ *
+ * Which processes a +pid+ names is what its sign says, and what a sign says
+ * is the platform's to answer.  A positive number names the process with that
+ * ID everywhere; where the platform reads the rest as POSIX does, 0 names
+ * every process in the caller's process group, -1 every process the caller
+ * has permission to signal, and a number below -1 every process in the
+ * process group whose ID is -pid.  Windows has no such selectors and answers
+ * Errno::ESRCH for every one of them.
+ *
+ * Naming a process group through the signal instead, which is a negative
+ * signal number or a name written with a leading "-" and asks for the group
+ * of each +pid+ given, is not supported yet and raises ArgumentError.  A
+ * signal number or a pid too large for the platform to carry raises
+ * RangeError.
+ */
+static mrb_value
+process_kill(mrb_state *mrb, mrb_value self)
+{
+  mrb_value sig, *pids;
+  mrb_int argc, i, signo;
+
+  mrb_get_args(mrb, "o*", &sig, &pids, &argc);
+  /* The rest is what names the processes, so an empty one leaves nothing to
+     signal.  Counting the signal back in makes the message read as the call
+     was written. */
+  if (argc == 0) {
+    mrb_argnum_error(mrb, 1, 2, -1);
+  }
+  signo = signal_to_number(mrb, sig);
+
+  for (i = 0; i < argc; i++) {
+    mrb_int pid = int_arg(mrb, mrb_as_int(mrb, pids[i]), "pid");
+    if (mrb_hal_process_kill(mrb, pid, signo) != 0) {
+      mrb_sys_fail(mrb, "kill");
+    }
+  }
+  return mrb_int_value(mrb, argc);
+}
+
+/*
+ * call-seq:
+ *   Process.waitpid(pid = -1, flags = 0) -> integer or nil
+ *
+ * Waits for a child process to finish and returns its process ID, setting
+ * <code>$?</code> to the Process::Status it finished with.  Which children
+ * are waited for is what +pid+ chooses: a positive number names one child,
+ * 0 any child in the caller's process group, -1 (the default) any child at
+ * all, and a number below -1 any child in the process group whose ID is
+ * -pid.
+ *
+ * With Process::WNOHANG among +flags+, returns nil and sets <code>$?</code>
+ * to nil when no child is ready.  With Process::WUNTRACED, a stopped child
+ * is reported too, where the platform has such a thing.
+ *
+ * Raises Errno::ECHILD when there is no child to wait for, Errno::EINVAL
+ * when +flags+ holds a bit that is not one of the two, and RangeError when
+ * +pid+ is too large for the platform to carry.
+ */
+static mrb_value
+process_waitpid(mrb_state *mrb, mrb_value self)
+{
+  mrb_int pid = MRB_PROCESS_WAIT_ANY;
+  mrb_int flags = 0;
+  mrb_int result_pid = 0, raw_status = 0;
+
+  mrb_get_args(mrb, "|ii", &pid, &flags);
+  pid = int_arg(mrb, pid, "pid");
+
+  /* A port is told what a wait means in mruby's own bits and answers only for
+     the ones it was given, so a bit that stands for nothing has to be refused
+     before it reaches one.  Checked here rather than in each port, so that
+     every port refuses the same values. */
+  if (flags < 0 || (flags & ~(mrb_int)MRB_PROCESS_WAIT_FLAGS) != 0) {
+    errno = EINVAL;
+    mrb_sys_fail(mrb, "waitpid");
+  }
+
+  if (mrb_hal_process_waitpid(mrb, pid, (unsigned int)flags, &result_pid, &raw_status) != 0) {
+    mrb_sys_fail(mrb, "waitpid");
+  }
+  if (result_pid == 0) {
+    /* MRB_PROCESS_WAIT_NOHANG and nothing had finished */
+    set_last_status(mrb, mrb_nil_value());
+    return mrb_nil_value();
+  }
+  set_last_status(mrb, mrb_process_status_new(mrb, result_pid, raw_status));
+  return mrb_int_value(mrb, result_pid);
+}
+
+void
+mrb_mruby_process_gem_init(mrb_state *mrb)
+{
+  struct RClass *process;
+  mrb_int pid;
+
+  mrb_hal_process_init(mrb);
+
+  process = mrb_define_module_id(mrb, MRB_SYM(Process));
+
+  /* The wait flags are mruby's own bits, not the host's: a program that
+     passes Process::WNOHANG means the same thing on every port. */
+  mrb_define_const_id(mrb, process, MRB_SYM(WNOHANG),
+                      mrb_fixnum_value(MRB_PROCESS_WAIT_NOHANG));
+  mrb_define_const_id(mrb, process, MRB_SYM(WUNTRACED),
+                      mrb_fixnum_value(MRB_PROCESS_WAIT_UNTRACED));
+
+  mrb_define_module_function_id(mrb, process, MRB_SYM(pid),     process_pid,     MRB_ARGS_NONE());
+  mrb_define_module_function_id(mrb, process, MRB_SYM(ppid),    process_ppid,    MRB_ARGS_NONE());
+  mrb_define_module_function_id(mrb, process, MRB_SYM(kill),    process_kill,    MRB_ARGS_REQ(2)|MRB_ARGS_REST());
+  mrb_define_module_function_id(mrb, process, MRB_SYM(waitpid), process_waitpid, MRB_ARGS_OPT(2));
+
+  mrb_process_status_init(mrb, process);
+
+  pid = mrb_hal_process_pid(mrb);
+  if (pid >= 0) {
+    mrb_gv_set(mrb, mrb_intern_lit(mrb, "$$"), mrb_int_value(mrb, pid));
+  }
+}
+
+void
+mrb_mruby_process_gem_final(mrb_state *mrb)
+{
+  mrb_hal_process_final(mrb);
+}

--- a/mrbgems/mruby-process/src/status.c
+++ b/mrbgems/mruby-process/src/status.c
@@ -1,0 +1,277 @@
+/*
+** status.c - Process::Status
+**
+** See Copyright Notice in mruby.h
+**
+** A Process::Status keeps only what the platform gave it: the pid and the
+** raw wait status.  Every question about that status (exited?, termsig,
+** coredump?) is answered by handing the raw value back to the HAL, so the
+** Ruby side never grows its own idea of what the bits mean and a status
+** built elsewhere reads exactly as one this gem reaped.
+**
+** That "built elsewhere" is the point of keeping `Process::Status.new(pid,
+** raw_status)` a working construction path: mruby-io's `IO.popen` sets `$?`
+** that way when this gem happens to be present, and it must keep working
+** without either gem depending on the other.
+*/
+
+#include <mruby.h>
+#include <mruby/class.h>
+#include <mruby/variable.h>
+#include <mruby/string.h>
+#include "process_hal.h"
+#include "process_internal.h"
+
+/* Read one of the two integers a status is made of.  An instance that never
+   reached #initialize has neither, and asking it anything is a mistake worth
+   naming rather than reading past. */
+static mrb_int
+status_ivar(mrb_state *mrb, mrb_value self, mrb_sym name)
+{
+  mrb_value v = mrb_iv_get(mrb, self, name);
+
+  if (!mrb_integer_p(v)) {
+    mrb_raise(mrb, E_RUNTIME_ERROR, "uninitialized Process::Status");
+  }
+  return mrb_integer(v);
+}
+
+static void
+status_decode(mrb_state *mrb, mrb_value self, mrb_process_status *st)
+{
+  mrb_int pid = status_ivar(mrb, self, MRB_IVSYM(pid));
+  mrb_int raw = status_ivar(mrb, self, MRB_IVSYM(status));
+
+  mrb_hal_process_status_decode(mrb, pid, raw, st);
+}
+
+static mrb_value
+status_flag(mrb_state *mrb, mrb_value self, unsigned int flag)
+{
+  mrb_process_status st;
+
+  status_decode(mrb, self, &st);
+  return mrb_bool_value((st.flags & flag) != 0);
+}
+
+/*
+ * call-seq:
+ *   Process::Status.new(pid, raw_status) -> status
+ *
+ * Wraps a platform wait status for the process +pid+.  +raw_status+ is the
+ * value the platform reported the process with, as Process.waitpid passes
+ * on and as Process::Status#to_i gives back.
+ */
+static mrb_value
+status_initialize(mrb_state *mrb, mrb_value self)
+{
+  mrb_int pid, raw_status;
+
+  mrb_get_args(mrb, "ii", &pid, &raw_status);
+  mrb_iv_set(mrb, self, MRB_IVSYM(pid), mrb_int_value(mrb, pid));
+  mrb_iv_set(mrb, self, MRB_IVSYM(status), mrb_int_value(mrb, raw_status));
+  return self;
+}
+
+/*
+ * call-seq:
+ *   status.pid -> integer
+ *
+ * The process ID this status came from.
+ */
+static mrb_value
+status_pid(mrb_state *mrb, mrb_value self)
+{
+  return mrb_int_value(mrb, status_ivar(mrb, self, MRB_IVSYM(pid)));
+}
+
+/*
+ * call-seq:
+ *   status.to_i -> integer
+ *
+ * The platform status as it was reported, unread.  Its layout is the
+ * platform's business, which is why nothing but the HAL takes it apart.
+ */
+static mrb_value
+status_to_i(mrb_state *mrb, mrb_value self)
+{
+  return mrb_int_value(mrb, status_ivar(mrb, self, MRB_IVSYM(status)));
+}
+
+/*
+ * call-seq:
+ *   status.exited? -> true or false
+ *
+ * Whether the process ran to completion rather than being signalled.
+ */
+static mrb_value
+status_exited_p(mrb_state *mrb, mrb_value self)
+{
+  return status_flag(mrb, self, MRB_PROCESS_STATUS_EXITED);
+}
+
+/*
+ * call-seq:
+ *   status.exitstatus -> integer or nil
+ *
+ * The status the process exited with, or nil if it did not exit.
+ */
+static mrb_value
+status_exitstatus(mrb_state *mrb, mrb_value self)
+{
+  mrb_process_status st;
+
+  status_decode(mrb, self, &st);
+  if (!(st.flags & MRB_PROCESS_STATUS_EXITED)) return mrb_nil_value();
+  return mrb_int_value(mrb, st.exitstatus);
+}
+
+/*
+ * call-seq:
+ *   status.signaled? -> true or false
+ *
+ * Whether an uncaught signal ended the process.
+ */
+static mrb_value
+status_signaled_p(mrb_state *mrb, mrb_value self)
+{
+  return status_flag(mrb, self, MRB_PROCESS_STATUS_SIGNALED);
+}
+
+/*
+ * call-seq:
+ *   status.termsig -> integer or nil
+ *
+ * The signal that ended the process, or nil if none did.
+ */
+static mrb_value
+status_termsig(mrb_state *mrb, mrb_value self)
+{
+  mrb_process_status st;
+
+  status_decode(mrb, self, &st);
+  if (!(st.flags & MRB_PROCESS_STATUS_SIGNALED)) return mrb_nil_value();
+  return mrb_int_value(mrb, st.termsig);
+}
+
+/*
+ * call-seq:
+ *   status.stopped? -> true or false
+ *
+ * Whether the process is stopped rather than finished.  Only a wait made
+ * with Process::WUNTRACED reports one.
+ */
+static mrb_value
+status_stopped_p(mrb_state *mrb, mrb_value self)
+{
+  return status_flag(mrb, self, MRB_PROCESS_STATUS_STOPPED);
+}
+
+/*
+ * call-seq:
+ *   status.stopsig -> integer or nil
+ *
+ * The signal that stopped the process, or nil if it is not stopped.
+ */
+static mrb_value
+status_stopsig(mrb_state *mrb, mrb_value self)
+{
+  mrb_process_status st;
+
+  status_decode(mrb, self, &st);
+  if (!(st.flags & MRB_PROCESS_STATUS_STOPPED)) return mrb_nil_value();
+  return mrb_int_value(mrb, st.stopsig);
+}
+
+/*
+ * call-seq:
+ *   status.coredump? -> true or false
+ *
+ * Whether the signal that ended the process also dumped core.  Platforms
+ * that cannot tell answer false.
+ */
+static mrb_value
+status_coredump_p(mrb_state *mrb, mrb_value self)
+{
+  return status_flag(mrb, self, MRB_PROCESS_STATUS_COREDUMP);
+}
+
+/*
+ * call-seq:
+ *   status == other -> true or false
+ *
+ * Whether +other+ equals the raw status, which is what #to_i gives back.
+ * The pid takes no part: two statuses holding the same platform value are
+ * equal whichever processes they came from.
+ */
+static mrb_value
+status_eq(mrb_state *mrb, mrb_value self)
+{
+  mrb_value raw = mrb_int_value(mrb, status_ivar(mrb, self, MRB_IVSYM(status)));
+  mrb_value other;
+
+  mrb_get_args(mrb, "o", &other);
+  /* Ruby answers this question as `to_i == other`, and reaches a status on
+     the right through Integer#== asking it back.  mrb_equal() answers false
+     for anything that is not a number instead of asking, so a status is
+     unwrapped here rather than left to it. */
+  if (mrb_obj_class(mrb, self) == mrb_obj_class(mrb, other)) {
+    other = mrb_int_value(mrb, status_ivar(mrb, other, MRB_IVSYM(status)));
+  }
+  return mrb_bool_value(mrb_equal(mrb, raw, other));
+}
+
+/*
+ * call-seq:
+ *   Process::Status._signame(signo) -> string or nil
+ *
+ * The bare name this platform gives signal +signo+, without the "SIG"
+ * prefix, or nil where the number names no signal.  Process::Status#to_s
+ * uses it to spell a signal out; it is not a signal API of its own.
+ */
+static mrb_value
+status_s_signame(mrb_state *mrb, mrb_value self)
+{
+  mrb_int signo;
+  const char *name;
+
+  mrb_get_args(mrb, "i", &signo);
+  name = mrb_hal_process_signal_name(mrb, signo);
+  if (name == NULL) return mrb_nil_value();
+  return mrb_str_new_cstr(mrb, name);
+}
+
+mrb_value
+mrb_process_status_new(mrb_state *mrb, mrb_int pid, mrb_int raw_status)
+{
+  struct RClass *process = mrb_module_get_id(mrb, MRB_SYM(Process));
+  struct RClass *status = mrb_class_get_under_id(mrb, process, MRB_SYM(Status));
+  mrb_value argv[2];
+
+  argv[0] = mrb_int_value(mrb, pid);
+  argv[1] = mrb_int_value(mrb, raw_status);
+  return mrb_obj_new(mrb, status, 2, argv);
+}
+
+void
+mrb_process_status_init(mrb_state *mrb, struct RClass *process)
+{
+  struct RClass *status;
+
+  status = mrb_define_class_under_id(mrb, process, MRB_SYM(Status), mrb->object_class);
+
+  mrb_define_class_method_id(mrb, status, MRB_SYM(_signame), status_s_signame, MRB_ARGS_REQ(1));
+
+  mrb_define_method_id(mrb, status, MRB_SYM(initialize), status_initialize, MRB_ARGS_REQ(2));
+  mrb_define_method_id(mrb, status, MRB_SYM(pid),        status_pid,        MRB_ARGS_NONE());
+  mrb_define_method_id(mrb, status, MRB_SYM(to_i),       status_to_i,       MRB_ARGS_NONE());
+  mrb_define_method_id(mrb, status, MRB_SYM(to_int),     status_to_i,       MRB_ARGS_NONE());
+  mrb_define_method_id(mrb, status, MRB_SYM_Q(exited),   status_exited_p,   MRB_ARGS_NONE());
+  mrb_define_method_id(mrb, status, MRB_SYM(exitstatus), status_exitstatus, MRB_ARGS_NONE());
+  mrb_define_method_id(mrb, status, MRB_SYM_Q(signaled), status_signaled_p, MRB_ARGS_NONE());
+  mrb_define_method_id(mrb, status, MRB_SYM(termsig),    status_termsig,    MRB_ARGS_NONE());
+  mrb_define_method_id(mrb, status, MRB_SYM_Q(stopped),  status_stopped_p,  MRB_ARGS_NONE());
+  mrb_define_method_id(mrb, status, MRB_SYM(stopsig),    status_stopsig,    MRB_ARGS_NONE());
+  mrb_define_method_id(mrb, status, MRB_SYM_Q(coredump), status_coredump_p, MRB_ARGS_NONE());
+  mrb_define_method_id(mrb, status, MRB_OPSYM(eq),       status_eq,         MRB_ARGS_REQ(1));
+}

--- a/mrbgems/mruby-process/test/process.rb
+++ b/mrbgems/mruby-process/test/process.rb
@@ -1,0 +1,281 @@
+##
+# Process ISO Test
+
+module ProcessTestUtil
+  # mruby-io is a test-only dependency: mruby-process itself never needs it,
+  # but a child process is the only honest way to test waiting on one, and
+  # IO.popen is how this build makes children.
+  def self.popen?
+    Object.const_defined?(:IO) && IO.respond_to?(:popen)
+  end
+
+  def self.windows?
+    Object.const_defined?(:File) && !File::ALT_SEPARATOR.nil?
+  end
+
+  # Why the tests that need a child are POSIX-only for now.  On Windows
+  # mruby-io hands out a process HANDLE as IO#pid, not a process ID, so
+  # there is nothing there to give Process.waitpid or Process.kill, and its
+  # IO.popen sets $? through a path that never fires; both are mruby-io's to
+  # fix, and neither is what this gem is being tested for.  The Windows port
+  # would refuse the wait in any case: it cannot tell a child from any other
+  # process it may open, so it reports ECHILD rather than a stranger's exit
+  # code.  See the README.
+  def self.child_reason
+    return "IO.popen is not available" unless popen?
+    return "IO#pid is a process handle, not a pid, on this platform" if windows?
+    nil
+  end
+
+  # Whether Process.kill turned +pid+ down rather than passing it on.  What a
+  # non-positive pid selects is the platform's to say, so its answer cannot be
+  # asserted here; that it was asked at all can be.
+  def self.kill_refused?(pid)
+    Process.kill(0, pid)
+    false
+  rescue ArgumentError
+    true
+  rescue StandardError
+    false
+  end
+
+  # Start a child running +cmd+ through a shell, or return nil where this
+  # build has no child to give.
+  def self.spawn(cmd)
+    return nil if child_reason
+    IO.popen(cmd)
+  rescue NotImplementedError
+    nil
+  end
+end
+
+assert('Process.pid') do
+  pid = Process.pid
+  assert_kind_of Integer, pid
+  assert_true pid > 0
+  assert_equal pid, Process.pid
+  assert_equal pid, $$
+end
+
+assert('Process.ppid') do
+  ppid = Process.ppid
+  assert_kind_of Integer, ppid
+  assert_true ppid >= 0
+end
+
+assert('Process::WNOHANG, Process::WUNTRACED') do
+  # Portable bits of mruby's own, not the host's, so they are simply two
+  # distinct flags that can be combined.
+  assert_kind_of Integer, Process::WNOHANG
+  assert_kind_of Integer, Process::WUNTRACED
+  assert_not_equal Process::WNOHANG, Process::WUNTRACED
+  assert_equal 0, Process::WNOHANG & Process::WUNTRACED
+end
+
+assert('Process.waitpid with a flag it does not define') do
+  # A port answers for the bits it is given and says nothing about the rest,
+  # so a bit that stands for nothing is refused before it reaches one.  A
+  # negative value is refused for the same reason: read as the unsigned value
+  # a port takes, it would turn both of the known bits on.
+  [4, -1, Process::WNOHANG | Process::WUNTRACED | 4].each do |flags|
+    # Errno is mruby-errno's, which this gem does not depend on; without it
+    # mrb_sys_fail() falls back to RuntimeError.
+    if Object.const_defined?(:Errno)
+      assert_raise(Errno::EINVAL) { Process.waitpid(-1, flags) }
+    else
+      assert_raise(StandardError) { Process.waitpid(-1, flags) }
+    end
+  end
+end
+
+assert('Process.kill with signal 0') do
+  # Signal 0 sends nothing; it only asks whether the process can be signalled.
+  assert_equal 1, Process.kill(0, Process.pid)
+  assert_equal 2, Process.kill(0, Process.pid, Process.pid)
+end
+
+assert('Process.kill does not take "EXIT" for signal 0') do
+  # "EXIT" names signal 0 only where a handler is being set, which is not
+  # something this gem does; as a signal to send, Ruby refuses the name and
+  # leaves the number as the portable way to ask for the null signal.
+  assert_raise(ArgumentError) { Process.kill("EXIT", Process.pid) }
+  assert_raise(ArgumentError) { Process.kill(:EXIT, Process.pid) }
+  assert_raise(ArgumentError) { Process.kill("SIGEXIT", Process.pid) }
+end
+
+assert('Process.kill with no process to signal') do
+  # A signal on its own names nothing to send it to, which CRuby reports as
+  # a missing argument rather than as a call that signalled nobody.
+  assert_raise(ArgumentError) { Process.kill(0) }
+  assert_raise(ArgumentError) { Process.kill(:TERM) }
+end
+
+assert('Process.kill with an unknown signal name') do
+  assert_raise(ArgumentError) { Process.kill("NO_SUCH_SIGNAL", Process.pid) }
+  assert_raise(ArgumentError) { Process.kill(:NO_SUCH_SIGNAL, Process.pid) }
+end
+
+assert('Process.kill with a signal name holding a NUL') do
+  # The name reaches the port as a C string, so a NUL in it would name the
+  # part before it.  "TERM\0suffix" must not be a way to spell TERM.
+  assert_raise(ArgumentError) { Process.kill("TERM\0suffix", Process.pid) }
+  assert_raise(ArgumentError) { Process.kill(:"TERM\0suffix", Process.pid) }
+end
+
+assert('Process.kill rejects the process-group signal forms') do
+  # Naming a process group through the signal is out of this gem's scope for
+  # now, and saying so beats signalling the process instead.
+  assert_raise(ArgumentError) { Process.kill(-15, Process.pid) }
+  assert_raise(ArgumentError) { Process.kill("-TERM", Process.pid) }
+end
+
+assert('Process.kill passes the pid selectors on') do
+  # A pid selects processes the way kill(2) reads it, and reading it is the
+  # platform's job: POSIX takes 0 for the caller's process group, -1 for every
+  # process the caller may signal, and a number below -1 for the group whose
+  # ID is -pid, while Windows has no such selectors and answers ESRCH.  Both
+  # are answers rather than refusals, and it is the refusal that is pinned
+  # here, since what the selectors reach depends on the host: whether the test
+  # runner leads its own process group, and whether there is any other process
+  # it may signal.  Signal 0 throughout, so nothing is signalled.
+  assert_false ProcessTestUtil.kill_refused?(0), "a pid of 0"
+  assert_false ProcessTestUtil.kill_refused?(-1), "a pid of -1"
+  # Not -Process.pid: where this runs as process 1, that is -1 again and the
+  # third selector would never be asked about.
+  assert_false ProcessTestUtil.kill_refused?(-(Process.pid + 1)), "a pid below -1"
+
+  # The caller's own process group is one the caller is always in, so where
+  # the platform reads the selectors as POSIX does, this one selects.
+  assert_equal 1, Process.kill(0, 0) unless ProcessTestUtil.windows?
+end
+
+assert('a pid or a signal number too large for the platform') do
+  # What is wrong with these is their size, so RangeError is the answer, not
+  # the errno a port would have to borrow to report one.  Where the build's
+  # Integer is no wider than the platform's own, `big` is a Float and there
+  # is nothing here to ask.
+  big = 2**31
+  skip "this build has no Integer wider than a pid" unless big.is_a?(Integer)
+
+  assert_raise(RangeError) { Process.kill(0, big) }
+  assert_raise(RangeError) { Process.kill(big, Process.pid) }
+  assert_raise(RangeError) { Process.waitpid(big) }
+end
+
+assert('Process::Status.new') do
+  # A raw status of 0 means "exited with 0" on every port, which is what lets
+  # this be asserted without knowing the platform's status layout.
+  st = Process::Status.new(1234, 0)
+  assert_equal 1234, st.pid
+  assert_equal 0, st.to_i
+  assert_true st.exited?
+  assert_equal 0, st.exitstatus
+  assert_true st.success?
+  assert_false st.signaled?
+  assert_nil st.termsig
+  assert_false st.stopped?
+  assert_nil st.stopsig
+  assert_false st.coredump?
+end
+
+assert('Process::Status#==') do
+  st = Process::Status.new(1234, 0)
+  assert_operator st, :==, Process::Status.new(1234, 0)
+  # The raw status alone decides, so the pid does not have to match.
+  assert_operator st, :==, Process::Status.new(1235, 0)
+  assert_not_operator st, :==, Process::Status.new(1234, 1)
+  assert_operator st, :==, 0
+  assert_not_operator st, :==, 1
+  assert_not_operator st, :==, "0"
+end
+
+assert('Process::Status#to_s, #inspect') do
+  st = Process::Status.new(1234, 0)
+  assert_equal "pid 1234 exit 0", st.to_s
+  assert_equal "#<Process::Status: pid 1234 exit 0>", st.inspect
+end
+
+assert('Process::Status._signame answers with the name Ruby answers with') do
+  # A host that spells one signal two ways gives both names the same number,
+  # and the table is ordered so that the reverse lookup finds the name Ruby
+  # reports: ABRT rather than IOT, CHLD rather than CLD, IO rather than POLL.
+  aliases = %w[IOT CLD POLL]
+  0.upto(64) do |signo|
+    name = Process::Status._signame(signo)
+    assert_not_include aliases, name if name
+  end
+end
+
+assert('Process.waitpid') do
+  skip ProcessTestUtil.child_reason if ProcessTestUtil.child_reason
+  io = ProcessTestUtil.spawn("exit 3")
+  skip "IO.popen is not available" unless io
+
+  io.read
+  pid = io.pid
+  assert_equal pid, Process.waitpid(pid)
+
+  # waitpid publishes what it reaped through $?
+  assert_kind_of Process::Status, $?
+  assert_equal pid, $?.pid
+  assert_true $?.exited?
+  assert_equal 3, $?.exitstatus
+  assert_false $?.success?
+  io.close
+end
+
+assert('Process.waitpid with Process::WNOHANG') do
+  skip ProcessTestUtil.child_reason if ProcessTestUtil.child_reason
+  # `exec` so that the pid this knows is the one that sleeps.  IO.popen runs
+  # the command under /bin/sh, and a shell that forks it rather than replacing
+  # itself with it leaves the sleep running once the shell has been killed.
+  io = ProcessTestUtil.spawn("exec sleep 30")
+  skip "IO.popen is not available" unless io
+
+  # Nothing has finished, so the wait returns at once with nothing to report.
+  assert_nil Process.waitpid(io.pid, Process::WNOHANG)
+  assert_nil $?
+
+  Process.kill(:KILL, io.pid)
+  assert_equal io.pid, Process.waitpid(io.pid)
+  assert_true $?.signaled?
+  assert_false $?.exited?
+  assert_nil $?.exitstatus
+  assert_nil $?.success?
+  assert_equal "KILL", Process::Status._signame($?.termsig)
+  io.close
+end
+
+assert('Process.waitpid with no child to wait for') do
+  # A pid reaped once is gone; waiting on it again has nothing to find.
+  skip ProcessTestUtil.child_reason if ProcessTestUtil.child_reason
+  io = ProcessTestUtil.spawn("exit 0")
+  skip "IO.popen is not available" unless io
+
+  io.read
+  pid = io.pid
+  Process.waitpid(pid)
+  # ECHILD is the documented answer.  Errno is mruby-errno's, which this gem
+  # does not depend on; without it mrb_sys_fail() falls back to RuntimeError.
+  if Object.const_defined?(:Errno)
+    assert_raise(Errno::ECHILD) { Process.waitpid(pid) }
+  else
+    assert_raise(StandardError) { Process.waitpid(pid) }
+  end
+  io.close
+end
+
+assert('$? after IO.popen') do
+  # mruby-io sets $? through Process::Status.new(pid, raw_status) when this
+  # gem is present.  Neither gem depends on the other; this is the seam.
+  skip ProcessTestUtil.child_reason if ProcessTestUtil.child_reason
+  io = ProcessTestUtil.spawn("exit 0")
+  skip "IO.popen is not available" unless io
+
+  io.read
+  pid = io.pid
+  io.close
+  assert_kind_of Process::Status, $?
+  assert_equal pid, $?.pid
+  assert_true $?.success?
+end

--- a/mrbgems/stdlib-io.gembox
+++ b/mrbgems/stdlib-io.gembox
@@ -15,4 +15,7 @@ MRuby::GemBox.new do |conf|
 
   # Use ENV object
   conf.gem :core => "mruby-env"
+
+  # Use Process module
+  conf.gem :core => "mruby-process"
 end


### PR DESCRIPTION
## Summary

mruby has no `Process`, so a build that can already start a child through
`IO.popen` cannot ask its pid, wait for it, signal it, or read how it
finished. This adds `mruby-process`, a `Process` module and a
`Process::Status` class drawn on the same `ports/<name>/` HAL line
`mruby-io` and `mruby-dir` use.

## Changes

| File | What |
|---|---|
| `mrbgems/mruby-process/include/process_hal.h` | new; `mrb_hal_process_pid()` `_ppid()` `_waitpid()` `_kill()` `_signal_number()` `_signal_name()` `_status_decode()` `_init()` `_final()`, the `mrb_process_status` struct, the `MRB_PROCESS_STATUS_*` flags and the `MRB_PROCESS_WAIT_*` bits |
| `mrbgems/mruby-process/include/process_internal.h` | new; `mrb_process_status_init()` and `mrb_process_status_new()`, the two things the common sources say to each other |
| `mrbgems/mruby-process/src/process.c` | new; `Process.pid`, `.ppid`, `.kill`, `.waitpid`, `Process::WNOHANG`, `Process::WUNTRACED`, `$?`, `$$` |
| `mrbgems/mruby-process/src/status.c` | new; `Process::Status.new`, `#pid`, `#to_i`, `#to_int`, `#exited?`, `#exitstatus`, `#signaled?`, `#termsig`, `#stopped?`, `#stopsig`, `#coredump?`, `#==`, `Process::Status._signame` |
| `mrbgems/mruby-process/mrblib/status.rb` | new; `Process::Status#success?`, `#to_s`, `#inspect`, `Process::Status._signal_description` |
| `mrbgems/mruby-process/ports/posix/process_hal.c` | new; the HAL over `getpid(2)`, `getppid(2)`, `waitpid(2)`, `kill(2)` and the `W*` macros |
| `mrbgems/mruby-process/ports/win/process_hal.c` | new; the HAL over `GetCurrentProcessId()`, a `Toolhelp32` walk for the parent, and `TerminateProcess()`; the wait fails, see below |
| `mrbgems/mruby-process/mrbgem.rake` | new; names `mruby-io` as a test dependency and nothing else |
| `mrbgems/mruby-process/test/process.rb` | new; 20 assertions |
| `mrbgems/mruby-process/README.md` | new |
| `mrbgems/stdlib-io.gembox` | adds `mruby-process` beside `mruby-io`, `mruby-dir` and `mruby-errno` |
| `doc/guides/language.md` | names `Process` in the "which gembox" table |
| `NEWS.md` | names the gem among the ones added this cycle |

### Where the HAL line falls

`process_hal.h` declares OS-level primitives only. No platform type or macro
crosses it: `pid_t`, `WIFEXITED`, `SIGTERM` and `WNOHANG` all stay in the
port. A pid or a signal travels as an `mrb_int`, wait options travel as
`MRB_PROCESS_WAIT_NOHANG` / `_UNTRACED`, which are mruby's own bits that the
port translates, and a wait status is read into `mrb_process_status` by the
port that produced it.

In the other direction the HAL knows nothing of `$?`, `$$`, blocks or
`Process::Status`. Everything Ruby promises lives in `src/`: the module and
class, the argument shapes, `Process.waitpid`'s return convention, the two
global variables and the constants.

A pid and a signal number cross as an `mrb_int` and narrow inside the port, so
a value too large to survive that narrowing is refused in `src/process.c`
rather than by the port that would have done the narrowing. What is wrong with
such a value is its size, and size is not something a port can report: the HAL
answers with an `errno`, which has no spelling for "that was never a pid" and
would have to borrow one that means something else, leaving `Errno::ESRCH` to
stand both for "no process there" and for "that was never a process id".
Refusing it above the line is what lets the answer be `RangeError`, which is
what CRuby raises for it and how `mruby-socket` checks the `int` fields of a
getaddrinfo hint. The ports keep their own range guards, so each is correct on
its own.

Signal names are the one thing split across the line. Which number a name
stands for is the platform's, so it is a HAL question; that a name may be
written `:TERM`, `"TERM"`, `"SIGTERM"` or `:SIGTERM` is Ruby's, so
`src/process.c` strips the prefix and hands the port a bare name.

The POSIX port's table is Ruby's own list, in Ruby's order, each name behind
the guard that says whether the host has it. Taking the list rather than
picking one keeps a name the host defines from being reported as unsupported,
and keeping the order is what makes the reverse lookup answer `ABRT` rather
than `IOT` where a host spells one signal two ways. `EXIT` is the one name
left out: it names signal 0 only where a handler is being set, which this gem
does not do, and Ruby refuses it as a signal to send as well.

### Process::Status keeps only what the platform gave it

A `Process::Status` stores the pid and the raw platform status, and asks the
HAL again for every question about it. Nothing above the HAL ever holds a
decoded copy that could disagree with the platform, and
`Process::Status.new(pid, raw_status)` therefore works for a status that
arrived from somewhere else.

That matters because it already does arrive from somewhere else.
`mruby-io`'s `io_set_process_status()` calls `Process::Status.new(pid,
raw_status)` when the class happens to be defined and falls back to an
Integer when it is not. That path keeps working unchanged, in a build with
this gem and in a build without it, with no dependency in either direction.

### mruby-io keeps its own spawn and wait

`IO.popen` still spawns and reaps through `io_hal.h`. Nothing in `mruby-io`
is touched here, and the two gems remain siblings: neither is required for
the other to provide its own feature set. `mrbgem.rake` names `mruby-io`
only as a *test* dependency, because waiting on a child needs a child and
`IO.popen` is how this build makes one. The gem compiles and runs with no
I/O gem in the build at all.

### What is left out

`fork`, `spawn`, `exec`, `system`, credentials and the process group calls,
each its own change. Naming a process group through the *signal* is left out
with them: a negative signal number, or a name written with a leading `-`,
asks for the group of every pid given, and `Process.kill` says so rather
than signalling the processes instead. The pid selectors are a separate
thing and are passed on: what a pid's sign selects is the platform's to
read, and both ports already read it, POSIX as `kill(2)` does and Windows
as `ESRCH`, since it has no such selectors.

A port that cannot do something sets `errno` to `ENOSYS` and returns the
documented failure value, which the common layer raises through
`mrb_sys_fail()`. Methods are never conditionally absent, so a program can
be written once and told at the call site what this platform will not do.

## Behaviour

`$?` after an `IO.popen` stream closes changes shape in any build that
includes this gem, which after the gembox commit is every build using
`default.gembox` or `full-core.gembox`. `mruby-io` has always preferred
`Process::Status` there and only fell back to an Integer because no build
had the class:

```console
# master
$ mruby -e 'io = IO.popen("exit 3"); io.read; io.close; p $?; p $?.to_i'
3
3

# this PR
$ mruby -e 'io = IO.popen("exit 3"); io.read; io.close; p $?; p $?.to_i'
#<Process::Status: pid 431903 exit 3>
768
```

The new shape is CRuby's, byte for byte. Against CRuby 4.0.6 on the same
child, `$?.inspect`, `$?.to_s`, `$?.to_i`, `$?.exitstatus` and `$? == 3`
agree, for an exited child and for a signalled one:

```console
$ ruby  -e 'io = IO.popen("exit 3"); io.read; io.close; p $?'
#<Process::Status: pid 431968 exit 3>
$ mruby -e 'io = IO.popen("exit 3"); io.read; io.close; p $?'
#<Process::Status: pid 431970 exit 3>

$ ruby  -e 'io = IO.popen("sleep 30"); Process.kill(:KILL, io.pid); Process.waitpid(io.pid); p $?'
#<Process::Status: pid 431973 SIGKILL (signal 9)>
$ mruby -e 'io = IO.popen("sleep 30"); Process.kill(:KILL, io.pid); Process.waitpid(io.pid); p $?'
#<Process::Status: pid 431975 SIGKILL (signal 9)>
```

Code reading `$?` as a number is affected in the way it is on CRuby:
`$?.to_i` is the raw wait status, not the exit status, so `$? == 3` becomes
false and `$?.exitstatus == 3` is the question that was meant. A build
without the gem keeps the Integer.

Three places deviate from CRuby on purpose, all recorded in the README.
`Process.kill` refuses the process-group signal forms rather than accepting
them with a different meaning; on Windows a wait status is the child's exit code
and nothing more, so a status there always reads as exited; and on Windows
`Process.waitpid` fails rather than answering.

That last one is the interesting one. Win32 names a process to wait on by
handle, and a handle comes from opening a process ID, which succeeds for any
process the caller may open rather than only for its own children. Waiting on
such a handle would report an unrelated process's exit code as a child's and
publish it as `$?`, so the port answers `ECHILD` for a specific pid and
`ENOSYS` for a pid of -1, which no handle stands for. A port learns which
processes are its children by creating them, so this is answerable once
`Process.spawn` exists and not before, and the answer a stranger's pid gets
does not change when it is: `ECHILD` either way. POSIX needs none of this,
because `waitpid(2)` already refuses a process that is not a child.

## Size

`.text` of `bin/mruby`, `build_config/ci/gcc-clang.rb`, each side from a
clean build directory at the same path. The whole gem is new code, so the
delta is its cost when a build includes it.

| build | master | this PR | delta |
|---|---:|---:|---:|
| `bintest` | 1,293,574 | 1,299,286 | +5,712 |
| `ascii-ctype` | 1,280,054 | 1,285,766 | +5,712 |
| `byte-string` | 1,260,918 | 1,266,630 | +5,712 |
| `cxx_abi` | 1,318,489 | 1,324,521 | +6,032 |
| `full-debug` (`-O0`) | 1,896,918 | 1,903,462 | +6,544 |

The default configuration, which the second commit puts the gem into, moves
the same way: 1,207,822 to 1,213,534, +5,712.

## Testing

The gem's own file is `mrbgems/mruby-process/test/process.rb`, 20
assertions: `Process.pid` against `$$`, `Process.ppid`, the two wait
constants as distinct portable bits, a wait flag the gem does not define and
a negative one, signal 0 by number over one and two pids, `"EXIT"` and
`:EXIT` refused as signal names, an unknown signal name as a String and as a
Symbol, a name holding a NUL, a signal with no process named after it, the
two process-group signal forms, the three pid selectors a non-positive
number spells, a pid and a signal number too large for the
platform to carry, `Process::Status.new` and every question it
answers, `#==` against a status with a different pid, a status with a
different raw value and an Integer, `#to_s` and `#inspect`, the reverse
signal lookup answering with the name Ruby answers with rather than with an
alias, a `waitpid` of a child that exited 3 and what it leaves in `$?`, a
`waitpid` with `Process::WNOHANG` that finds nothing and then reaps a killed
child, a `waitpid` of a pid already reaped, and `$?` after `IO.popen`
closes, which is the `mruby-io` seam.

The four assertions that need a real child skip on Windows and say why: there
`mruby-io` hands out a process handle as `IO#pid` rather than a process ID,
and its `IO.popen` sets `$?` through a branch that never fires. Both are
`mruby-io`'s to fix, and the port would refuse the wait regardless, for the
reason given under Behaviour.

The pid selector assertions ask whether the value was passed on, not what it
reached: what a non-positive pid selects is the platform's answer, and both
whether the suite leads its own process group and whether anything else is
there for -1 to select vary with where it runs. Where the platform reads
them as POSIX does, the caller's own process group is one it is always in,
so `Process.kill(0, 0)` returning 1 is asserted there too.

**`rake test`**, `build_config/ci/gcc-clang.rb`, no compiler warning:

| build | total | KO | crash |
|---|---:|---:|---:|
| `full-debug` | 2,467 | 0 | 0 |
| `bintest` | 2,467 | 0 | 0 |
| `bintest` (bintest suite) | 124 | 0 | 0 |
| `cxx_abi` | 2,467 | 0 | 0 |
| `byte-string` | 2,393 | 0 | 0 |
| `ascii-ctype` | 2,460 | 0 | 0 |

The default configuration: 2,238 total, 0 KO, 0 crash, plus its 113
bintests. The first commit alone, before the gem is in a gembox: 2,218
total, 0 KO, 0 crash, and a `.text` unchanged from master, since no gembox
builds the gem yet.

`full-core` plus `MRB_INT32`, where an `mrb_int` is no wider than the `int` a
port narrows to, so the common layer's range check compiles out and a value
past the width arrives as a bigint instead: 2,467 total, 0 KO, 0 crash, and no
`-Wtype-limits` warning from the gem under `-Wextra`.

A build of `mruby-compiler`, `mruby-bin-mrbc`, `mruby-bin-mruby` and
`mruby-process` and nothing else compiles and runs, which is the claim that
the gem needs no I/O gem:

```console
$ mruby -e 'p Process.pid, $$, Process.ppid, Process.kill(0, Process.pid)'
1236056
1236056
1235048
1
$ mruby -e 's = Process::Status.new(4321, 0); p s.to_s, s.success?, Process::WNOHANG'
"pid 4321 exit 0"
true
1
$ mruby -e 'begin; Process.kill(15, 2**31); rescue => e; p e.class, e.message; end'
RangeError
"pid out of range: 2147483648"
```

There `mruby-errno` is absent too, so `mrb_sys_fail()` falls back to
`RuntimeError`, which is why the test asks for `Errno::ECHILD` and
`Errno::EINVAL` only where `Errno` is defined.

The Windows port is written against the same HAL contract but is not
exercised here; this machine has no Windows toolchain.

## Environment

<details>

| | |
|---|---|
| OS | Ubuntu 24.04.4 LTS, Linux 7.0.0 x86_64, AMD Ryzen 9 5950X |
| gcc | 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1) |
| binutils | 2.47 |
| CRuby | 4.0.6, for the comparison in Behaviour |

Compile lines for `mrbgems/mruby-process/src/process.c` in the builds quoted
above, paths shortened:

```console
# ci/gcc-clang bintest
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_PROCESS_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK -I"include" -I"mrbgems/mruby-process/include" -I"mrbgems/mruby-io/include" -I"build/bintest/include" -o "build/bintest/mrbgems/mruby-process/src/process.o" "mrbgems/mruby-process/src/process.c"

# ci/gcc-clang full-debug
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRBGEM_MRUBY_PROCESS_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -I"include" -I"mrbgems/mruby-process/include" -I"mrbgems/mruby-io/include" -I"build/full-debug/include" -o "build/full-debug/mrbgems/mruby-process/src/process.o" "mrbgems/mruby-process/src/process.c"

# ci/gcc-clang cxx_abi
gcc -MMD -c -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_PROCESS_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -I"include" -I"mrbgems/mruby-process/include" -I"mrbgems/mruby-io/include" -I"build/cxx_abi/include" -o "build/cxx_abi/mrbgems/mruby-process/src/process.o" "mrbgems/mruby-process/src/process.c"

# ci/gcc-clang byte-string
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_PROCESS_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -I"include" -I"mrbgems/mruby-process/include" -I"mrbgems/mruby-io/include" -I"build/byte-string/include" -o "build/byte-string/mrbgems/mruby-process/src/process.o" "mrbgems/mruby-process/src/process.c"

# ci/gcc-clang ascii-ctype
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRBGEM_MRUBY_PROCESS_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -I"include" -I"mrbgems/mruby-process/include" -I"mrbgems/mruby-io/include" -I"build/ascii-ctype/include" -o "build/ascii-ctype/mrbgems/mruby-process/src/process.o" "mrbgems/mruby-process/src/process.c"
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `mruby-process` gem to the standard I/O bundle.
  * Added APIs for process IDs, signaling, waiting, and wait-status handling.
  * Added `Process::Status` to inspect exits, signals, stops, core dumps, and related details.
  * Added POSIX and Windows support with platform-specific behavior and limitations.

* **Documentation**
  * Added installation, API, platform, and integration documentation for process management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

