### PR TITLE
mruby-regexp: fail a backreference to a group that has not closed

### DIFF
--- a/mrbgems/mruby-regexp/src/re_exec.c
+++ b/mrbgems/mruby-regexp/src/re_exec.c
@@ -900,13 +900,27 @@ bt_match(bt_state *m, const char *sp, uint32_t pc, int depth)
           return BT_FAIL;
         }
         if (slot < ncap) {
+          /* An even slot opens its group, and the pair it heads is a span
+             only while the group is closed: clear the end slot with the
+             start, so that RE_BACKREF reads a group a repetition has just
+             re-entered the way it reads one never entered, instead of
+             pairing this iteration's start with the end of the one before:
+             an empty span where the two coincide, and a negative one where
+             the start is past it, which no closed group holds. CRuby
+             reads an open group as unmatched the same way (Onigmo's
+             STACK_PUSH_MEM_START invalidates the end with the start). The
+             end slot exists whenever the start does, ncap being even. */
+          mrb_bool opens = (slot & 1) == 0;
           int old = captures[slot];
+          int old_end = opens ? captures[slot + 1] : 0;
           captures[slot] = (int)(sp - str);
+          if (opens) captures[slot + 1] = -1;
           int r = bt_match(m, sp, pc + 1, depth + 1);
           if (r == BT_MATCH) return r;
           /* undone for a cut as for a failure: the group the cut fails may
              be the one this slot was written inside */
           captures[slot] = old;
+          if (opens) captures[slot + 1] = old_end;
           return r;
         }
         return BT_FAIL;

--- a/mrbgems/mruby-regexp/test/regexp_syntax.rb
+++ b/mrbgems/mruby-regexp/test/regexp_syntax.rb
@@ -215,6 +215,51 @@ assert("Regexp - a repetition of a lookaround or a backreference stops the same 
   assert_equal "abbc", /(?:(a)b|a(b)|\2)+c/.match("abbc")[0]
 end
 
+assert("Regexp - a backreference reads no group the running iteration reopened") do
+  # A group's pair in captures[] is a span only while the group is closed:
+  # its end slot used to keep the previous iteration's end after a repetition
+  # re-entered the group, so a backreference read the running iteration's
+  # start against it: an empty span where the two coincided, and a negative
+  # one where the start was past it. CRuby reads a group that has not closed
+  # as one that has not matched, so the backreference fails and the branch
+  # holding it is not taken.
+  assert_equal ["x", "x", "x"], /((x|\2b))*/.match("xb").to_a  # was ["xb", "b", "b"]
+  assert_equal ["a", "a", "a"], /((\2|a))*/.match("a").to_a    # was ["a", "", ""]
+  # The negative span left a MatchData whose capture sat outside the match,
+  # and where the repetition had no upper bound it walked the position back
+  # as far as the iteration had come, so the loop made no progress and the
+  # search died at the recursion limit.
+  md = /(?:(.)(\2?)){2}/.match("ab")                # answered ["a", "b", nil]
+  assert_equal ["ab", "b", ""], md.to_a
+  assert_equal [0, 2, 1, 2, 2, 2],
+               [md.begin(0), md.end(0), md.begin(1), md.end(1), md.begin(2), md.end(2)]
+  assert_equal ["xx", ""], /(?:x(\1?))+/.match("xx").to_a          # raised at the limit
+  assert_equal ["abc", "c", ""], /(?:(.)(\2?))+/.match("abc").to_a # raised at the limit
+  assert_equal ["ab", "b", ""], /(?>(.)(\2?))+/.match("ab").to_a   # raised at the limit
+  assert_equal ["xX", ""], /(?:x(\1?))+/i.match("xX").to_a
+  # With text between the group's start and the backreference the two sides
+  # of the negative span part company, and the compare read past the subject
+  # (a negative length as memcmp's size).
+  assert_equal ["xyxy", "y"], /(?:x(y\1?))+/.match("xyxy").to_a
+  assert_equal ["xx", "x"], /(?<g>x(\k<g>?))+/.match("xx").to_a
+  assert_equal ["xxx", ""], /(?:x(\1{0,2}))+/.match("xxx").to_a
+  # A group that never closes is a group that never matches, so a pattern
+  # whose only path runs the backreference inside its own group has no match
+  # at all, not an empty one.
+  assert_nil /(\1)/.match("aa")
+  assert_nil /(a\1)/.match("aa")
+  assert_equal ["", nil, nil], /((\1))*/.match("a").to_a
+  # What the guard now refuses is the open group alone: a closed group that
+  # captured empty still reads, and one closed by an earlier iteration still
+  # reads from a branch that does not reopen it.
+  assert_equal ["", ""], /()\1/.match("x").to_a
+  assert_equal ["y", ""], /(x?)y\1/.match("y").to_a
+  assert_equal ["aba", "a"], /(?:(a)|b\1)+/.match("aba").to_a
+  # Backtracking out of a reopened group restores the pair, so the failed
+  # iteration leaves the previous capture readable rather than half its own.
+  assert_equal ["x", "", "x"], /((x|\2b)?)*/.match("xb").to_a
+end
+
 assert("Regexp - the backtracking engine raises at a limit rather than answer short") do
   # A frame gives up at MRB_REGEXP_RECURSION_LIMIT or MRB_REGEXP_STEP_LIMIT,
   # and the frames above it used to read that as the branch having failed and


### PR DESCRIPTION
## Summary

`RE_BACKREF` reads a group's start and end out of `captures[]` and takes the two for a span, but the pair is a span only while the group is closed. A group a repetition has just re-entered holds the running iteration's start against the previous iteration's end, and the backtracking engine read it anyway: the backreference matched empty where CRuby fails the branch, walked the match position backwards, or reached `memcmp` with a negative length.

## Changes

| File | What |
|---|---|
| `mrbgems/mruby-regexp/src/re_exec.c` | `bt_match()`'s `RE_SAVE` clears the end slot beside the start it writes when the slot opens a group, and restores the pair, not the one integer, when the frame fails |
| `mrbgems/mruby-regexp/test/regexp_syntax.rb` | one assertion block over reopened groups, closed-empty groups and a group that never closes |

### The slot pair is a span only while the group is closed

`RE_SAVE` writes the start slot where a group opens and the end slot where it closes, so `captures[2g]` and `captures[2g+1]` bound a capture only between the two. Once a repetition re-enters the group, the start belongs to the iteration now running and the end to the one before. Neither is negative, so `RE_BACKREF`'s unmatched-group guard (`gs < 0 || ge < 0`, `re_exec.c:981`) passes the pair through and `blen = ge - gs` comes out zero or negative.

The zero span matched the empty string, which let an alternative that should never be reached decide the match. The negative span went two ways, by whether text stood between the group's start and the backreference. With text between, the pointers differ and `blen` reaches `memcmp` as its size, where it widens to a huge `size_t`; on master AddressSanitizer reports it from four characters of Ruby:

```console
$ mruby -e 'p /(?:x(y\1?))+/.match("xyxy")'
==387784==ERROR: AddressSanitizer: negative-size-param: (size=-1)
    #2 bt_match mrbgems/mruby-regexp/src/re_exec.c:978
```

With nothing between them the two pointers coincide, and the libc here answers 0 without reading, so `sp += blen` walked the position backwards: behind the match it was inside of, or, under an unbounded repetition, back by as much as the iteration had advanced, so the loop made no progress and the search gave up at `MRB_REGEXP_RECURSION_LIMIT`.

### Open-ness is knowable only where the group opens

A zero span is also what a closed group that captured empty holds, and `/()\1/` matching empty is correct, so `RE_BACKREF` cannot tell an open group from that one by the pair alone. The slot's parity already says which end it is (`group*2` and `group*2+1` is the compiler's slot contract), so the opening `RE_SAVE` clears the end slot beside the start it writes, and the guard that was already there covers the case it was missing. No new state, no new opcode, nothing added at the read.

The undo on failure is the one the start slot already gets, widened to the pair, so an iteration that reopened a group and then failed leaves the previous iteration's capture readable rather than half of its own: `/((x|\2b)?)*/` on `"xb"` keeps answering `["x", "", "x"]`.

CRuby records it the same way. Onigmo's `STACK_PUSH_MEM_START` saves both fields into the stack entry and sets `mem_end_stk[mnum]` to `INVALID_STACK_INDEX` beside the start it writes, and `OP_BACKREF` fails on the invalid end. `bt_match()`'s recursive `RE_SAVE` frame is this engine's stack entry, so the save and the restore land there.

### The Pike VM needs no change

A pattern holding a backreference is routed to the backtracking engine, and nothing else reads a group's slots before `RE_MATCH`, by which point every group on the thread's path has closed: the closing `RE_SAVE` lies on every path out of a group's body.

## Behaviour

A backreference to a group that has not closed fails, and the branch holding it is not taken. Every case below now answers what CRuby answers.

| pattern on subject | CRuby 4.0.6 | master | this PR |
|---|---|---|---|
| `/((x\|\2b))*/` on `"xb"` | `["x", "x", "x"]` | `["xb", "b", "b"]` | CRuby's |
| `/((\2\|a))*/` on `"a"` | `["a", "a", "a"]` | `["a", "", ""]` | CRuby's |
| `/(\1\|a)+/` on `"aaa"` | `["aaa", "a"]` | `["a", ""]` | CRuby's |
| `/((x\|\2b)?)*/` on `"xb"` | `["x", "", "x"]` | `["xb", "", "b"]` | CRuby's |
| `/(?:(.)(\2?)){2}/` on `"ab"` | `["ab", "b", ""]` | `["a", "b", nil]` | CRuby's |
| `/(?:x(\1?))+/` on `"xx"` | `["xx", ""]` | `RegexpError` at the limit | CRuby's |
| `/(?:(.)(\2?))+/` on `"abc"` | `["abc", "c", ""]` | `RegexpError` at the limit | CRuby's |
| `/(?>(.)(\2?))+/` on `"ab"` | `["ab", "b", ""]` | `RegexpError` at the limit | CRuby's |
| `/(?:x(\1{0,2}))+/` on `"xxx"` | `["xxx", ""]` | `RegexpError` at the limit | CRuby's |

What master answers for `/(?:(.)(\2?)){2}/` is a `MatchData` that contradicts itself, its capture sitting outside the match it belongs to. `/(?:x(y\1?))+/` on `"xyxy"` answers `["xyxy", "y"]` on both sides; that is the case the sanitizer catches, where the answer happens to survive the negative `memcmp`.

A closed group still reads as it did. `/()\1/` and `/(x?)y\1/` still match empty, and `/(?:(a)|b\1)+/` on `"aba"` still reads the group an earlier iteration closed. A group that never closes never matches, so `/(\1)/` and `/(a\1)/` have no match at all rather than an empty one.

## Speed

Instruction counts from callgrind, `Ir(2N) - Ir(N)` so process startup cancels, per call, on the `bintest` build of `build_config/ci/gcc-clang.rb`:

```ruby
n = ARGV[0].to_i
subject = "The quick brown fox jumps over the lazy dog. " * 20   # 900 bytes
n.times { subject =~ /(\w+) \1/ }                                # and the other three
```

| call | master | this PR | delta |
|---|---:|---:|---:|
| `/(\w+) \1/`, no match | 840,968 | 849,062 | +8,094 (+0.96%) |
| `/(\w+) \1/`, matching at the end | 845,426 | 853,508 | +8,082 (+0.96%) |
| `/(?>(\w+))o(\w*)/` | 768,649 | 775,661 | +7,012 (+0.91%) |
| `/(?:(\w)(\w?))+z/` | 62,409 | 62,410 | +1 (+0.00%) |

The first three are searches the backtracking engine runs, and they pay for the extra store and the wider undo once per group entry, which under a failing repetition over a 900 byte subject is the innermost loop there is. The fourth pattern has no backreference, atomic group or lookbehind, so it runs on the Pike VM, where nothing changed.

## Size

`.text` of `bin/mruby`, from `size -A`, for the five builds of `build_config/ci/gcc-clang.rb`:

| build | master | this PR | delta |
|---|---:|---:|---:|
| `bintest` | 1,292,182 | 1,292,294 | +112 |
| `ascii-ctype` | 1,278,726 | 1,278,838 | +112 |
| `byte-string` | 1,259,718 | 1,259,798 | +80 |
| `cxx_abi` | 1,317,065 | 1,317,161 | +96 |
| `full-debug` (-O0) | 1,895,942 | 1,896,086 | +144 |

All of it is `re_exec.o` (`bintest`: 11,858 to 11,970, +112); `re_compile.o` and `regexp.o` are byte for byte what they were.

## Testing

`rake test`, `build_config/ci/gcc-clang.rb`, no compiler warning in any of the five builds the size table was taken from:

| build | total | KO | crash |
|---|---:|---:|---:|
| `full-debug` | 2,424 | 0 | 0 |
| `bintest` | 2,424 | 0 | 0 |
| `bintest` (bintest suite) | 124 | 0 | 0 |
| `cxx_abi` | 2,424 | 0 | 0 |
| `byte-string` | 2,350 | 0 | 0 |
| `ascii-ctype` | 2,417 | 0 | 0 |

The default configuration: 2,195 total, 0 KO, 0 crash, and 113 bintests. `build_config/clang-asan.rb` (address and undefined, `-O0`): 2,424 total, 0 KO, 0 crash, and no sanitizer report anywhere in the run.

Beyond the suite:

- A 32 case differential battery against CRuby 4.0.6, covering the patterns in the table above plus self-reference (`/(\1)/`), forward reference, `\k<name>` self-reference, `/i` through both open and closed groups, `{n,m}` atom copies, nested optionals, closed-empty groups, a group closed by an earlier iteration, and backreferences inside lookahead. Every line of the branch's output is what CRuby prints, `to_a` and every `begin`/`end` alike, under the sanitizer build as well; master differs from CRuby on nine of the 32. CRuby 3.2.3 prints the same file as 4.0.6.
- 70,000 generated cases (a random pattern generator over `"ab"` with every feature on, seven seeds of 10,000, each case run under CRuby and under both mruby binaries with a 1 GB address-space cap). The branch's output is byte-identical to master's on all 70,000, so nothing the generator reaches moves; the reopened-group shapes above are what it does not build, since its backreferences point at groups closed earlier in the pattern.

## Environment

<details>

| | |
|---|---|
| OS | Ubuntu 24.04.4, Linux 7.0.0 x86_64, AMD Ryzen 9 5950X |
| gcc | 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1) |
| clang | 22.1.8 (Homebrew), for the sanitizer build |
| binutils | 2.47 |
| valgrind | 3.27.1, for the instruction counts |
| CRuby | 4.0.6 and 3.2.3, for the differential runs |

Compile lines for `mrbgems/mruby-regexp/src/re_exec.c` in the builds quoted above, with `-MMD -c`, the `-I` and the `-o` dropped:

```console
# ci/gcc-clang full-debug
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK

# ci/gcc-clang cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang ascii-ctype
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# default configuration
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK

# clang-asan
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -fsanitize=address,undefined -g3 -O0 -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect backreference behavior when capture groups are reopened during repeated matching.
  * Prevented stale captures from being reused after backtracking.
  * Improved handling of unmatched groups and capture boundaries.

* **Tests**
  * Added regression coverage for backreferences, repeated groups, self-referential patterns, and backtracking scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->