### PR TITLE
mruby-io: let go of the write descriptor IO#close_write closed

### DIFF
--- a/mrbgems/mruby-io/src/io.c
+++ b/mrbgems/mruby-io/src/io.c
@@ -1210,7 +1210,11 @@ static mrb_value
 io_close_write(mrb_state *mrb, mrb_value io)
 {
   struct mrb_io *fptr = io_get_open_fptr(mrb, io);
-  if (mrb_hal_io_close(mrb, (int)fptr->fd2) == -1) {
+  int fd2 = fptr->fd2;
+  /* The write end is gone whatever close(2) answers, and leaving its number
+     behind would have #close try to close it a second time. */
+  fptr->fd2 = -1;
+  if (mrb_hal_io_close(mrb, fd2) == -1) {
     mrb_sys_fail(mrb, "close");
   }
   return mrb_nil_value();

--- a/mrbgems/mruby-io/test/io.rb
+++ b/mrbgems/mruby-io/test/io.rb
@@ -560,6 +560,20 @@ assert('IO.popen with err option') do
   end
 end
 
+assert('IO#close_write') do
+  begin
+    io = IO.popen("cat", "r+")
+    io.write "mruby-io\n"
+    io.close_write
+    assert_false io.closed?
+    assert_equal "mruby-io\n", io.read
+    io.close
+    assert_true io.closed?
+  rescue NotImplementedError => e
+    skip e.message
+  end
+end
+
 assert('IO.read') do
   # empty file
   fd = IO.sysopen $mrbtest_io_wfname, "w"


### PR DESCRIPTION
## Summary

`IO#close_write` closed the write end of a duplex stream and left its descriptor
number in the stream, so the `IO#close` that followed closed the number a second
time. Letting go of the number around the close is the whole fix.

## Changes

| File | What |
|---|---|
| `mrbgems/mruby-io/src/io.c` | `io_close_write()` clears `fd2` around the close |
| `mrbgems/mruby-io/test/io.rb` | `IO#close_write` gets its first test |

### The number stayed in the stream after the descriptor was gone

`io_close_write()` closed `fptr->fd2` and returned. `fptr_finalize()`, which
`IO#close` runs, closes whatever `fd2` still names:

```c
  if (fptr->fd2 >= limit) {
    if (fptr->close_fd2 && mrb_hal_io_close(mrb, fptr->fd2) == -1) {
      if (saved_errno == 0) {
        saved_errno = errno;
      }
    }
    fptr->fd2 = -1;
  }
```

so the second close ran on a number the process no longer owned. Here it
answered `EBADF` and `IO#close` raised; in a program that has opened anything in
between, it closes that instead.

The number is dropped before the close rather than after it. `close(2)` releases
the descriptor even when it answers `EINTR`, so an error return is not a reason
to keep the number, and `fptr_finalize()` above clears `fd` and `fd2` whatever
the close answers, for that reason.

A duplex stream is the only kind with an `fd2`, and `IO.popen(cmd, "r+")` is the
only way to get one, which is why nothing has run into this before:
`IO#close_write` has had no test, and no other test in the gem opens a duplex
stream. The gem's own `IO.popen` example
(`mrbgems/mruby-io/mrblib/io.rb:49-53`) is written on the pattern, and the block
form closes the stream on the way out:

```console
$ mruby -e 'IO.popen("cat", "r+") {|f| f.puts "5 2 *"; f.close_write; puts f.read }'
5 2 *
trace (most recent call last):
	[1] -e:1
-e:1:in close: Bad file descriptor - fptr_finalize failed (Errno::EBADF)
```

## Behaviour

`IO#close` after `IO#close_write` stops raising.

```console
$ mruby -e 'io = IO.popen("cat", "r+"); io.write "hello\n"; io.close_write; p io.read; p io.close'  # master
"hello\n"
trace (most recent call last):
	[1] -e:1
-e:1:in close: Bad file descriptor - fptr_finalize failed (Errno::EBADF)

$ mruby -e 'io = IO.popen("cat", "r+"); io.write "hello\n"; io.close_write; p io.read; p io.close'  # this PR
"hello\n"
nil

$ ruby -e 'io = IO.popen("cat", "r+"); io.write "hello\n"; io.close_write; p io.read; p io.close'   # CRuby 4.0.6
"hello\n"
nil
```

`fd2` is also read by `io_get_write_fd()`, `IO#select`, `IO#close_on_exec?`,
`IO#close_on_exec=` and `IO#dup`. In all but the first, `-1` already means "this
stream has no write end of its own", which is what the stream now is.
`io_get_write_fd()` falls back to `fptr->fd` on `-1`, so a write after
`close_write` now names the read end of the pipe rather than the closed write
end; `write(2)` refuses both with `EBADF`, so what Ruby sees does not change.
CRuby raises `IOError: not opened for writing` there, which mruby does not
either way, and which this PR does not try to settle.

## Size

`bin/mruby` `.text`, `build_config/ci/gcc-clang.rb`:

| build | master | this PR | delta |
|---|---:|---:|---:|
| `bintest` | 1,292,182 | 1,292,182 | 0 |
| `ascii-ctype` | 1,278,726 | 1,278,726 | 0 |
| `byte-string` | 1,259,718 | 1,259,718 | 0 |
| `cxx_abi` | 1,317,065 | 1,317,065 | 0 |
| `full-debug` (`-O0`) | 1,895,942 | 1,895,958 | +16 |

`full-debug` is the only build that pays for the store, and it is the only `-O0`
one. At `-O3` it costs nothing measurable: `mruby-io/src/io.o` `.text` is 20,094
in the default configuration both before and after.

## Testing

The new assertion writes through a duplex stream, closes the write end, reads
what came back, and closes the stream:

```ruby
assert('IO#close_write') do
  begin
    io = IO.popen("cat", "r+")
    io.write "mruby-io\n"
    io.close_write
    assert_false io.closed?
    assert_equal "mruby-io\n", io.read
    io.close
    assert_true io.closed?
  rescue NotImplementedError => e
    skip e.message
  end
end
```

On master it stops at `io.close` with `Errno::EBADF`; with the fix the whole
round trip passes. It is the gem's first test for `IO#close_write`.

**`rake test`**, `build_config/ci/gcc-clang.rb`, no compiler warning:

| build | total | KO | crash |
|---|---:|---:|---:|
| `full-debug` | 2,424 | 0 | 0 |
| `bintest` | 2,424 | 0 | 0 |
| `bintest` (bintest suite) | 124 | 0 | 0 |
| `cxx_abi` | 2,424 | 0 | 0 |
| `byte-string` | 2,350 | 0 | 0 |
| `ascii-ctype` | 2,417 | 0 | 0 |

The default configuration: 2,195 total, 0 KO, 0 crash, plus its 113 bintests.

## Environment

<details>

| | |
|---|---|
| OS | Ubuntu 24.04.4 LTS, Linux 7.0.0 x86_64, AMD Ryzen 9 5950X |
| gcc | 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1) |
| binutils | 2.47 |
| CRuby | 4.0.6, for the comparison in Behaviour |

Compile lines for `mrbgems/mruby-io/src/io.c` in the builds quoted above, paths
shortened:

```console
# ci/gcc-clang bintest
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK -I"include" -I"mrbgems/mruby-io/include" -I"mrbgems/mruby-time/include" -I"build/bintest/include" -o "build/bintest/mrbgems/mruby-io/src/io.o" "mrbgems/mruby-io/src/io.c"

# ci/gcc-clang full-debug
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -I"include" -I"mrbgems/mruby-io/include" -I"mrbgems/mruby-time/include" -I"build/full-debug/include" -o "build/full-debug/mrbgems/mruby-io/src/io.o" "mrbgems/mruby-io/src/io.c"

# ci/gcc-clang cxx_abi
gcc -MMD -c -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -I"include" -I"mrbgems/mruby-io/include" -I"mrbgems/mruby-time/include" -I"build/cxx_abi/include" -o "build/cxx_abi/mrbgems/mruby-io/src/io.o" "mrbgems/mruby-io/src/io.c"

# ci/gcc-clang byte-string
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -I"include" -I"mrbgems/mruby-io/include" -I"mrbgems/mruby-time/include" -I"build/byte-string/include" -o "build/byte-string/mrbgems/mruby-io/src/io.o" "mrbgems/mruby-io/src/io.c"

# ci/gcc-clang ascii-ctype
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -I"include" -I"mrbgems/mruby-io/include" -I"mrbgems/mruby-time/include" -I"build/ascii-ctype/include" -o "build/ascii-ctype/mrbgems/mruby-io/src/io.o" "mrbgems/mruby-io/src/io.c"
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where closing the write side of a bidirectional stream could leave a stale descriptor.
  * Reading remains available after the write side is closed, and the stream can be closed cleanly afterward.
  * Stream state now remains consistent even if the underlying close operation reports an error.

* **Tests**
  * Added coverage for bidirectional stream behavior, including preserving written data and handling unsupported configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->