### PR TITLE
mruby-process: separate two sentences with a single space

### DIFF
--- a/mrbgems/mruby-process/README.md
+++ b/mrbgems/mruby-process/README.md
@@ -68,7 +68,7 @@ other to provide its own feature set:
 `mruby-io`'s own private spawn/wait primitives rather than by anything here.
 There is no dependency in either direction; `mrbgem.rake` names `mruby-io` only
 as a _test_ dependency, because waiting on a child process is only testable
-with a child, and `IO.popen` is how this build makes one.  `mruby-errno` is a
+with a child, and `IO.popen` is how this build makes one. `mruby-errno` is a
 test dependency for the same kind of reason: a gem's tests run in a state
 holding its dependency closure and nothing else, so naming an `Errno` class in
 an assertion means asking for the gem that defines them.


### PR DESCRIPTION
## Summary

`mrbgems/mruby-process/README.md` puts two spaces between one pair of
sentences. Every other sentence boundary in the same file uses a single
space, and this is the only double space left in any markdown file in the
tree, so it reads as a slip rather than a deliberate style.

## Changes

| File | Change |
| --- | --- |
| `mrbgems/mruby-process/README.md` | Collapse the double space in the `Architecture` section to one |

## Testing

Documentation only; no source, build file, or test is touched. The
rendered output is unchanged, since Markdown collapses runs of spaces
inside a paragraph either way.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected spacing in the Architecture section of the `mruby-process` documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->