### PR TITLE
vm.c: make stack_extend_alloc cover the frame offset

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -190,7 +190,10 @@ stack_extend_alloc(mrb_state *mrb, mrb_int room)
   mrb_value *oldbase = mrb->c->stbase;
   size_t oldsize = mrb->c->stend - mrb->c->stbase;
   size_t size = oldsize;
-  size_t off = mrb->c->ci->stack ? mrb->c->stend - mrb->c->ci->stack : 0;
+  /* ci->stack can sit past stend when an embedder enters the VM with an
+     undersized stack, since cipush places the frame before the stack is
+     extended. The base size must cover the frame offset. */
+  size_t off = mrb->c->ci->stack ? mrb->c->ci->stack - oldbase : 0;
 
   if (off > size) size = off;
 #ifdef MRB_STACK_EXTEND_DOUBLING


### PR DESCRIPTION
# Problem

In `stack_extend_alloc()`, commit 16baea067 changed the stack size floor calculation from the frame base offset to the remaining capacity:

```c
// Current calculation
size_t off = mrb->c->ci->stack ? mrb->c->stend - mrb->c->ci->stack : 0;
if (off > size) size = off;
```

### Impact

This reversal causes two issues depending on `ci->stack`:

1. As long as `ci->stack` is within `stbase..stend`, the calculated value never exceeds the old size, rendering the floor calculation useless.
2. If `ci->stack` sits past `stend` (e.g., when an embedder enters the VM with an undersized context, as previously seen in #7279), the unsigned subtraction wraps around to a huge value. This poisons the growth math, raising a `NoMemoryError` instead of properly growing the stack.

## Fix

Restore the pre-refactor logic. The floor must be the frame base offset from the stack bottom (`mrb->c->ci->stack - oldbase`).

An assertion on `ci->stack <= stend` would not be a substitute. Asserts compile out in release builds and the wrap-around would remain there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed stack growth in certain call-frame scenarios, improving runtime stability when additional stack space is required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->