### PR TITLE
build_config: make the MinGW wine test config build and pass its tests

### DIFF
--- a/build_config/cross-mingw-winetest.rb
+++ b/build_config/cross-mingw-winetest.rb
@@ -83,6 +83,12 @@ MRuby::CrossBuild.new("cross-mingw-winetest") do |conf|
     t.command = File.join(thisdir, * %w{ helpers wine_runner.rb})
   end
 
+  # Cross builds have no port auto-detection, so the Windows HAL has to
+  # be named here; without it the gems that sit on it (mruby-io and
+  # friends) leave every 'mrb_hal_*' symbol undefined at link time.
+  # This has to precede the gembox: a gem picks its port when it is added.
+  conf.ports :win
+
   conf.gembox "full-core"
 
   conf.enable_bintest

--- a/build_config/helpers/wine_runner.rb
+++ b/build_config/helpers/wine_runner.rb
@@ -8,15 +8,15 @@ DOSROOT = 'z:'
 
 # Rewrite test output to replace DOS-isms with Unix-isms.
 def clean(output, stderr = false)
-  ends_with_newline = !!(output =~ /\n$/)
-
   # Fix line-ends
   output = output.gsub(/\r\n/, "\n")
 
   # Strip out Wine messages
 
 
-  results = output.split(/\n/).map do |line|
+  # A limit of -1 keeps the trailing empty fields, so a blank line at the end
+  # of the output survives the round trip; a disassembly ends with one.
+  results = output.split(/\n/, -1).map do |line|
     # Fix file paths
     if line =~ /#{DOSROOT}\\/i
       line.gsub!(/#{DOSROOT}([^:]*)/i) { |path|
@@ -29,9 +29,7 @@ def clean(output, stderr = false)
     line
   end
 
-  result_text = results.join("\n")
-  result_text += "\n" if ends_with_newline
-  result_text
+  results.join("\n")
 end
 
 

--- a/build_config/helpers/wine_runner.rb
+++ b/build_config/helpers/wine_runner.rb
@@ -11,8 +11,15 @@ def clean(output, stderr = false)
   # Fix line-ends
   output = output.gsub(/\r\n/, "\n")
 
-  # Strip out Wine messages
-
+  # Strip out Wine messages.  Wine writes its own diagnostics to the same
+  # stderr the program under test uses, and it does so on its way out, so
+  # they arrive appended to whatever the program said; a test that asks for
+  # an exact stderr fails at random when one turns up.  Taking the newline
+  # with the line keeps the rest of the text as it stood.
+  if stderr
+    output = output.gsub(/^wine client error:[0-9a-f]+:.*(?:\n|\z)/, '')
+    output = output.gsub(/^[0-9a-f]+:(?:err|warn|fixme|trace):.*(?:\n|\z)/, '')
+  end
 
   # A limit of -1 keeps the trailing empty fields, so a blank line at the end
   # of the output survives the round trip; a disassembly ends with one.
@@ -56,7 +63,7 @@ def main
 
   # Clean and print the results.
   STDOUT.write clean(output)
-  STDERR.write clean(errormsg)
+  STDERR.write clean(errormsg, true)
 
   exit(status.exitstatus)
 end

--- a/build_config/helpers/wine_runner.rb
+++ b/build_config/helpers/wine_runner.rb
@@ -9,7 +9,6 @@ DOSROOT = 'z:'
 # Rewrite test output to replace DOS-isms with Unix-isms.
 def clean(output, stderr = false)
   ends_with_newline = !!(output =~ /\n$/)
-  executable = ARGV[0].gsub(/\.exe\z/i, '')
 
   # Fix line-ends
   output = output.gsub(/\r\n/, "\n")
@@ -26,9 +25,6 @@ def clean(output, stderr = false)
         path
       }
     end
-
-    # strip '.exe' off the end of the executable's name if needed
-    line.gsub!(/(#{Regexp.escape executable})\.exe/i, '\1')
 
     line
   end

--- a/lib/mruby/build.rb
+++ b/lib/mruby/build.rb
@@ -540,7 +540,8 @@ EOS
       puts ">>> Bintest #{name} <<<"
       targets = @gems.select { |v| File.directory? "#{v.dir}/bintest" }.map { |v| filename v.dir }
       mrbc = @gems["mruby-bin-mrbc"] ? exefile("#{@build_dir}/bin/mrbc") : mrbcfile
-      env = {"BUILD_DIR" => @build_dir, "MRBCFILE" => mrbc}
+      env = {"BUILD_DIR" => @build_dir, "MRBCFILE" => mrbc,
+             "EXECUTABLE_EXT" => @exts.executable}
       bintest = File.join(MRUBY_ROOT, "test/bintest.rb")
       sh env, "ruby #{bintest}#{verbose_flag} #{targets.join ' '}"
     end
@@ -744,6 +745,7 @@ EOS
         "BUILD_DIR" => @build_dir,
         "MRBCFILE" => mrbc,
         "EMULATOR" => @test_runner.emulator,
+        "EXECUTABLE_EXT" => @exts.executable,
       }
       bintest = File.join(MRUBY_ROOT, "test/bintest.rb")
       sh env, "ruby #{bintest}#{verbose_flag} #{targets.join ' '}"

--- a/mrbgems/mruby-bin-mrbc/bintest/mrbc.rb
+++ b/mrbgems/mruby-bin-mrbc/bintest/mrbc.rb
@@ -111,7 +111,7 @@ assert('non-seekable input file is rejected by size, not blamed on the read') do
   # allocation and the fread() count, surfacing as the misleading "cannot read
   # program file"; the file opens and reads fine, only its size is unknown.
   # Needs a genuinely unseekable path: `< file` would still be seekable.
-  skip 'no /dev/stdin' if /mswin(?!ce)|mingw|bccwin/ =~ RbConfig::CONFIG['host_os']
+  skip 'no /dev/stdin' if target_win?
   skip 'no /dev/stdin' unless File.exist?('/dev/stdin')
 
   a = Tempfile.new('a.rb')
@@ -127,7 +127,7 @@ end
 assert('a directory as an input file is refused') do
   # Only POSIX systems open a directory for reading; Windows refuses it at
   # fopen() and never reaches the reader this guards.
-  skip 'fopen() refuses a directory' if /mswin(?!ce)|mingw|bccwin/ =~ RbConfig::CONFIG['host_os']
+  skip 'fopen() refuses a directory' if target_win?
   # ftell() answers LONG_MAX for a directory stream on ext4 and 0 on tmpfs,
   # and the size check accepts both: the first overflows the length
   # arithmetic that sizes the buffer, the second compiles as an empty

--- a/mrbgems/mruby-bin-mruby/bintest/mruby.rb
+++ b/mrbgems/mruby-bin-mruby/bintest/mruby.rb
@@ -208,7 +208,7 @@ end
 assert('a directory as the program file is refused') do
   # Only POSIX systems open a directory for reading; Windows refuses it at
   # fopen() and reports that instead.
-  skip 'fopen() refuses a directory' if /mswin(?!ce)|mingw|bccwin/ =~ RbConfig::CONFIG['host_os']
+  skip 'fopen() refuses a directory' if target_win?
   # A directory opens for reading and then fails every read, and the loader
   # answers nil for that without raising, so without a check it ran as an
   # empty program: no output, no diagnostic, exit 0.
@@ -218,7 +218,7 @@ assert('a directory as the program file is refused') do
 end
 
 assert('a directory as a library file is refused') do
-  skip 'fopen() refuses a directory' if /mswin(?!ce)|mingw|bccwin/ =~ RbConfig::CONFIG['host_os']
+  skip 'fopen() refuses a directory' if target_win?
   # -r took the same swallowed read, and went on to run the program.
   Dir.mktmpdir do |dir|
     assert_mruby("", /Cannot read library file/, false, ["-r", dir, "-e", "puts 1"])

--- a/mrbgems/mruby-io/test/io.rb
+++ b/mrbgems/mruby-io/test/io.rb
@@ -561,6 +561,7 @@ assert('IO.popen with err option') do
 end
 
 assert('IO#close_write') do
+  skip "no `cat` to talk to on this platform" if MRubyIOTestUtil.win?
   begin
     io = IO.popen("cat", "r+")
     io.write "mruby-io\n"

--- a/test/bintest.rb
+++ b/test/bintest.rb
@@ -15,6 +15,13 @@ def exe_ext
   ENV['EXECUTABLE_EXT'] || (host_win? ? ".exe" : "")
 end
 
+# Which platform the binaries under test run on.  A test that turns on the
+# platform has to ask this and not the host: under an emulator the two differ,
+# and it is the binary that meets the directory or the '/dev' entry.
+def target_win?
+  exe_ext == ".exe"
+end
+
 # MRBCFILE is a whole path the build hands over, extension and all, and the
 # build that produced it need not be this one: a cross build can borrow the
 # host's `mrbc`.  Only the names spelled out here take this build's suffix.

--- a/test/bintest.rb
+++ b/test/bintest.rb
@@ -4,12 +4,23 @@ require 'test/assert.rb'
 
 GEMNAME = ""
 
+def host_win?
+  !!(/mswin(?!ce)|mingw|bccwin/ =~ RbConfig::CONFIG['host_os'])
+end
+
+# The suffix comes from the build rather than from this host: a cross build
+# hands its executables to an emulator, so what the name needs is the suffix
+# the target produced.  Without the build to ask, the host's own is the answer.
+def exe_ext
+  ENV['EXECUTABLE_EXT'] || (host_win? ? ".exe" : "")
+end
+
+# MRBCFILE is a whole path the build hands over, extension and all, and the
+# build that produced it need not be this one: a cross build can borrow the
+# host's `mrbc`.  Only the names spelled out here take this build's suffix.
 def cmd_bin(s)
-  path = s == "mrbc" ? ENV['MRBCFILE'] : "#{ENV['BUILD_DIR']}/bin/#{s}"
-  path = path.sub(/\.exe\z/, "")
-  if /mswin(?!ce)|mingw|bccwin/ =~ RbConfig::CONFIG['host_os']
-    path = "#{path}.exe".tr("/", "\\")
-  end
+  path = s == "mrbc" ? ENV['MRBCFILE'] : "#{ENV['BUILD_DIR']}/bin/#{s}#{exe_ext}"
+  path = path.tr("/", "\\") if host_win?
   path
 end
 


### PR DESCRIPTION
## Summary

`build_config/cross-mingw-winetest.rb` builds a Windows target on a POSIX host and runs the suite under Wine, and the comment at its head documents the steps for doing so. Following them does not work today. The link of every executable fails, and once that is answered, all but three of the command tests fail.

Six commits take the config from there to a green run. The unit tests and the command tests both pass, and the two fixes that reach beyond this config, the executable suffix and the host versus target question in `test/bintest.rb`, leave the host build as it was.

| | unit tests | command tests |
| --- | --- | --- |
| master | does not link | does not link |
| master plus the port named | 1,661, 1 failing | 83, 78 failing |
| this branch | 1,661, none failing | 84, none failing |

## Changes

| Commit | What it answers |
| --- | --- |
| `build_config: name the Windows port in the MinGW wine config` | `undefined reference to 'mrb_hal_io_read'` at every link |
| ``mruby-io: skip `IO#close_write` where the platform has no `cat` `` | the one failing unit test |
| `bintest: take the executable suffix from the build under test` | `wine: failed to open ".../bin/mruby"`, on every command test |
| `bintest: ask the target, not the host, whether it is Windows` | four tests that skip on Windows and ran anyway |
| `build_config: keep the empty line at the end of the wine output` | the disassembly `mrbc -v` and `mruby -v` are compared through |
| `build_config: drop Wine's own diagnostics from the test output` | a failure that lands on a different test each run |

### The port the config never named

`MRuby::CrossBuild` answers `effective_ports` with an empty list, because the platform of a cross target cannot be read off the host that builds it. A config that wants a port has to name it, as `cosmopolitan.rb` and `glib_hal_test.rb` do. This one never did, so `mruby-io`, `mruby-dir`, `mruby-socket`, `mruby-task` and `mruby-process` compiled no port at all and `libmruby.a` was archived with every `mrb_hal_*` call unresolved.

The call has to precede the gembox: a gem picks its port when it is added, in `Gem#initialize`.

### The suffix the tests never carried

`cmd_bin` stripped `.exe` from the name it built and put it back only when this host is Windows. For a build that runs where it was built the two always agree. A cross build hands its executables to an emulator, and then the host says nothing about what the target produced, so every command was named without its suffix and Wine refused all of them.

The build knows the answer, so it now passes `exts.executable` to `bintest.rb` in the environment and `cmd_bin` appends that. Where the variable is absent, as when `test/bintest.rb` is run by hand, the host's own suffix remains the guess. `MRBCFILE` still arrives whole, because the `mrbc` it names need not come from this build.

The wine runner used to erase `.exe` from the output so that the names in a diagnostic would match the names the tests built without one. Both sides now spell the suffix, so that erasing goes.

### The side the platform tests asked

Four tests skip themselves on Windows, because it is Windows that has no `/dev/stdin` and refuses a directory at `fopen()`. They read the host's own name for the platform, which answers the question only while the binary runs where it was built. Under an emulator the host is a POSIX system and the binary is not, so all four ran and failed on what the target does. The suffix the build reports answers the question they meant to ask, and `target_win?` names it. The two places that do mean this host, quoting for its shell and spelling its path separator, keep asking for the host.

### What the wine runner did to the output

`clean` split the output on newlines and joined it back, and such a split drops the trailing empty fields. A final newline was restored afterwards but a blank line before it was not, so output ending in one came back a line short. A disassembly does, and the test that reads `mrbc -v` against `mruby -v` compares the two texts whole.

Separately, Wine writes lines of its own to the stderr the program under test writes to, and it writes them on its way out, so they arrive appended to whatever the program said. `WINEDEBUG` silences the channel messages but not `wine client error:`, which turned up on roughly every other run of the suite, on no particular test, and failed whichever one pins its stderr exactly. `clean` already takes the argument that says which stream it is reading, so it now has a caller that sets it, and those lines are dropped there. A message from the launcher itself, `wine: failed to open ...`, says the run never happened and stays.

## Testing

Both builds were run from the same worktree at the tip of this branch.

The cross config, `rake -m test` with `MRUBY_CONFIG=build_config/cross-mingw-winetest.rb`:

```
mrbtest   Total: 1661   OK: 1623   KO: 0   Crash: 0   Skip: 38
bintest   Total:   84   OK:   79   KO: 0   Crash: 0   Skip:  5
```

The command tests were then run five more times on their own, because the failure the last commit answers appears on a different test each time. All five reported `KO: 0`. Before that commit, two of three runs were red.

The host build, `rake -m test` with the default config, covers the changes to `lib/mruby/build.rb` and `test/bintest.rb` on a build that is not cross compiled:

```
mrbtest   Total: 2249   OK: 2196   KO: 0   Crash: 0   Skip: 53
bintest   Total:  113   OK:  112   KO: 0   Crash: 0   Skip:  1
```

The skips under Wine are what the platform does not carry: `symlink`, `pipe`, `isatty`, `cat`, AF_UNIX addresses, and name resolution for `localhost`.

## Environment

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS, kernel 7.0.0-30-generic, x86_64 |
| Target | `x86_64-w64-mingw32`, gcc 13.2.0 (`gcc-mingw-w64-x86-64-posix` 13.2.0-6ubuntu1+26.1) |
| Emulator | wine 11.0 |
| Ruby | ruby 4.0.6, rake 13.3.1 |

```
MRUBY_CONFIG=build_config/cross-mingw-winetest.rb rake -m test
rake -m test
```

The two runs shared one `MRUBY_BUILD_DIR`, under which each config writes a directory of its own. `TMPDIR` was set to a short path outside the checkout, because `mruby-io` binds an AF_UNIX address under it and the family caps the whole path at 108 bytes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows and MinGW/Wine compatibility for executable discovery and test execution.
  - Preserved Wine error output more accurately, including trailing blank lines and executable names.
  - Added platform-aware handling for executable file extensions and Windows path conversion.
  - Corrected platform-specific test behavior and skips, including tests requiring unavailable Windows commands.

- **Tests**
  - Improved cross-platform validation for native, Windows, and emulated builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->