### PR TITLE
mruby-regexp: move the backtracking stack off the C stack

### DIFF
--- a/mrbgems/mruby-regexp/README.md
+++ b/mrbgems/mruby-regexp/README.md
@@ -301,20 +301,22 @@ A search that reaches either limit raises `RegexpError`, `step limit over
 rather than answer with what it had found by then. The step limit bounds
 the work one search may do; the stack limit bounds the state it holds while
 doing it: the branches it has not taken yet and the writes it has not taken
-back, an entry each. What a repetition spends per iteration is what it
-holds: one choice point where it captures nothing, and undo records on top
-of that for a capture (two writes to open a group and one to close it) and
-for the record of an iteration that may match empty. A run longer than the
-limit reaches it on a pattern that is not pathological; a build with the
-memory for it can set it higher, and one that wants a smaller ceiling can
-set it lower.
+back, an entry each. A write of the value already in the slot leaves nothing
+to take back and is not counted. What a repetition spends per iteration is
+what it holds: one choice point where it captures nothing, and undo records
+on top of that for a capture (up to two writes to open a group and one to
+close it, an iteration that opens one the attempt has not closed yet paying
+for one of the two) and for the record of an iteration that may match empty.
+A run longer than the limit reaches it on a pattern that is not pathological;
+a build with the memory for it can set it higher, and one that wants a
+smaller ceiling can set it lower.
 
 The default is where the state moving off the C stack costs no pattern the
 subject it used to match, and no higher. The limit that preceded it counted
 C frames, and a frame is not an entry: a fork was one frame and is one
-choice point, while a capture was one frame and is three undo records. Of
-the shapes measured across that change the tightest is `(a)*?b`, which
-crossed 498 characters on the old 1,000 frames and crosses 681 on 2,048
+choice point, while a capture was one frame and is up to three undo records.
+Of the shapes measured across that change the tightest is `(a)*?b`, which
+crossed 498 characters on the old 1,000 frames and crosses 682 on 2,048
 entries; a chain of atomic groups or of lookarounds, which spent two frames
 a link and now spends none once each has closed, is bounded by the pattern
 rather than by this limit either way.
@@ -323,7 +325,7 @@ The limit stands between 1 and 16,777,216, and a build that sets it outside
 that fails to compile: at 0 no search could hold one entry, and above the
 ceiling the arithmetic that sizes the arrays stops holding on a 32-bit ABI.
 A low limit is a build's to choose, and what it buys is memory at the price
-of the patterns the engine will match: the gem's tests ask for 49, which is
+of the patterns the engine will match: the gem's tests ask for 48, which is
 where every pattern they take for granted matches, and the assertions that
 reach the engine skip below it while the rest go on running. The two limits
 are set apart from one another as well: a build that turns this one up far

--- a/mrbgems/mruby-regexp/README.md
+++ b/mrbgems/mruby-regexp/README.md
@@ -176,11 +176,15 @@ ReDoS attacks.
 **Backtracking engine**: Used when patterns contain `\1`-`\9`
 backreferences, non-greedy quantifiers (`*?`, `+?`, `??`),
 lookaround assertions (`(?=...)`, `(?!...)`, `(?<=...)`, `(?<!...)`)
-or atomic groups (`(?>...)`). Bounded by a configurable step limit
-(`MRB_REGEXP_STEP_LIMIT`, default 1M) against excessive backtracking and
-by a recursion limit (`MRB_REGEXP_RECURSION_LIMIT`, default 1000) on
-the C stack. A search that reaches either raises `RegexpError` naming
-the limit, since what it had found by then is not the answer.
+or atomic groups (`(?>...)`). It backtracks on a stack of its own on the
+heap, so a search spends a constant amount of C stack however long the
+subject is. Bounded by a configurable step limit (`MRB_REGEXP_STEP_LIMIT`,
+default 1M) against excessive backtracking and by a stack limit
+(`MRB_REGEXP_STACK_LIMIT`, default 2048) on how tall that stack may
+stand. A search that reaches either raises `RegexpError` naming the limit,
+since what it had found by then is not the answer; one whose stack the
+allocator refuses to grow raises `NoMemoryError` instead, that being a
+different thing to do something about.
 
 The engine is selected automatically at compile time based on
 pattern analysis.
@@ -286,22 +290,71 @@ there.
 #define MRB_REGEXP_STEP_LIMIT 1000000
 #endif
 
-/* Maximum recursion depth of the backtracking engine (C stack) */
-#ifndef MRB_REGEXP_RECURSION_LIMIT
-#define MRB_REGEXP_RECURSION_LIMIT 1000
+/* Maximum height of the backtracking engine's stack (heap) */
+#ifndef MRB_REGEXP_STACK_LIMIT
+#define MRB_REGEXP_STACK_LIMIT 2048
 #endif
 ```
 
 A search that reaches either limit raises `RegexpError`, `step limit over
-(MRB_REGEXP_STEP_LIMIT)` or `recursion limit over
-(MRB_REGEXP_RECURSION_LIMIT)`, rather than answer with what it had found
-by then. The recursion limit is spent per fork and per capture, so a
-repetition of an atomic group or a lookaround spends a few frames per
-iteration, and a long enough run of one reaches it on a pattern that is
-not pathological; a build with the stack for it can set it higher. The
-values a build chose are `Regexp::RECURSION_LIMIT` and `Regexp::STEP_LIMIT`,
-for a program that has to size a subject or a pattern to the build it runs
-on; CRuby has no counterpart, its guard being `Regexp.timeout`.
+(MRB_REGEXP_STEP_LIMIT)` or `stack limit over (MRB_REGEXP_STACK_LIMIT)`,
+rather than answer with what it had found by then. The step limit bounds
+the work one search may do; the stack limit bounds the state it holds while
+doing it: the branches it has not taken yet and the writes it has not taken
+back, an entry each. What a repetition spends per iteration is what it
+holds: one choice point where it captures nothing, and undo records on top
+of that for a capture (two writes to open a group and one to close it) and
+for the record of an iteration that may match empty. A run longer than the
+limit reaches it on a pattern that is not pathological; a build with the
+memory for it can set it higher, and one that wants a smaller ceiling can
+set it lower.
+
+The default is where the state moving off the C stack costs no pattern the
+subject it used to match, and no higher. The limit that preceded it counted
+C frames, and a frame is not an entry: a fork was one frame and is one
+choice point, while a capture was one frame and is three undo records. Of
+the shapes measured across that change the tightest is `(a)*?b`, which
+crossed 498 characters on the old 1,000 frames and crosses 681 on 2,048
+entries; a chain of atomic groups or of lookarounds, which spent two frames
+a link and now spends none once each has closed, is bounded by the pattern
+rather than by this limit either way.
+
+The limit stands between 1 and 16,777,216, and a build that sets it outside
+that fails to compile: at 0 no search could hold one entry, and above the
+ceiling the arithmetic that sizes the arrays stops holding on a 32-bit ABI.
+A low limit is a build's to choose, and what it buys is memory at the price
+of the patterns the engine will match: the gem's tests ask for 49, which is
+where every pattern they take for granted matches, and the assertions that
+reach the engine skip below it while the rest go on running. The two limits
+are set apart from one another as well: a build that turns this one up far
+enough puts it out of the step limit's reach, since filling the stack costs
+a handful of steps an entry, and the tests that pin the stack limit size
+their subjects from it are skipped there. The values a build chose are
+`Regexp::STACK_LIMIT` and `Regexp::STEP_LIMIT`, for a program that has to
+size a subject or a pattern to the build it runs on; CRuby has no
+counterpart, its guard being `Regexp.timeout`.
+
+What the stack limit counts is live entries and not bytes. Two arrays hold
+them, one for the branches and one for the writes, and they grow
+geometrically and keep their capacity for the rest of the search, so a search
+that fills one, backtracks, and then fills the other holds both high-water
+marks at once. Neither is grown past the limit, so the memory one search may
+ask for is bounded by it: at most `MRB_REGEXP_STACK_LIMIT` entries in each
+array, an entry being 32 and 16 bytes respectively on a 64-bit ABI and 24 and
+8 on a 32-bit one, so 96 KiB together at the default on a 64-bit build and
+64 KiB on a 32-bit one. Halving the limit halves that ceiling. The capture
+slots and the per-instruction iteration records a search also holds are sized
+by the pattern rather than by this limit.
+
+A search whose stack the allocator refuses to grow raises `NoMemoryError`
+rather than `RegexpError`. The two are worth telling apart: a limit names the
+knob to turn, where turning `MRB_REGEXP_STACK_LIMIT` up in answer to an
+allocator that had nothing left would only let the next search ask for more.
+
+The macro was called `MRB_REGEXP_RECURSION_LIMIT` while the engine recursed
+once per fork and the limit counted C frames. A build that still defines that
+name fails to compile: the two limits count different things, so an old value
+does not carry over and the build has to choose a new one.
 
 Case folding beyond ASCII is not this gem's to configure. The table is
 core's, carried by any build that defines `MRB_UTF8_STRING` without

--- a/mrbgems/mruby-regexp/include/re_internal.h
+++ b/mrbgems/mruby-regexp/include/re_internal.h
@@ -173,19 +173,95 @@ typedef struct mrb_regexp_pattern {
 #define MRB_REGEXP_STEP_LIMIT 1000000
 #endif
 
-/* Recursion-depth limit for bt_match, which recurses at every fork and
-   every capture: bounds C stack growth on a long subject or a deep pattern. */
-#ifndef MRB_REGEXP_RECURSION_LIMIT
-#define MRB_REGEXP_RECURSION_LIMIT 1000
+/* How tall the backtracking engine's stack may stand in one search: the
+   choice points it has not tried yet and the writes it has not taken back,
+   counted together (see bt_room() in re_exec.c). That stack is on the heap,
+   so a search spends a constant amount of C stack however long the subject
+   is, and what this bounds is what it holds instead. Where
+   MRB_REGEXP_STEP_LIMIT bounds the work one search may do, this bounds the
+   state it may hold while doing it.
+
+   What it counts is live entries, not bytes. The two arrays behind them grow
+   geometrically and keep their capacity for the rest of the search, so a
+   search that fills one, backtracks, and then fills the other holds both
+   high-water marks at once. Neither array is grown past this limit, though
+   (see bt_push()), so the memory one search may ask for is bounded by it:
+   at most this many entries in each array, an entry being 32 and 16 bytes
+   on a 64-bit ABI and 24 and 8 on a 32-bit one, so 96 KiB together at the
+   default on a 64-bit build and 64 KiB on a 32-bit one. The capture slots
+   and the iteration records (see backtrack_exec()) are sized by the pattern
+   and lie outside it.
+
+   The default is where the state moving off the C stack costs no pattern the
+   subject it used to match, and no higher: moving it is one change and
+   letting a search hold more of it is another, and a default above this one
+   would make the second silently. The old limit allowed 1,000 C frames, and
+   a frame is not an entry: a fork was one frame and is one choice point,
+   while a capture was one frame and is three undo records, so what a pattern
+   spends per iteration is what it holds. `(a)*?b` crossed 498 characters on
+   1,000 frames and crosses 681 on 2,048 entries, which is the tightest of
+   the shapes measured; a chain of atomic groups or of lookarounds, which
+   spent two frames a link and now spends none once each has closed, is
+   bounded by the pattern rather than by this limit either way. A build that
+   wants a longer subject to match, or a smaller ceiling on the memory a
+   search may ask for, sets it. */
+#ifdef MRB_REGEXP_RECURSION_LIMIT
+/* The engine no longer recurses per fork, so nothing counts C frames any more
+   and this knob is gone. Its replacement counts entries on a heap stack, and
+   the two measure different things: a value chosen for the old one does not
+   carry over, and a build that means to keep a restriction has to choose a
+   new one rather than have this header guess. */
+#error MRB_REGEXP_RECURSION_LIMIT was replaced by MRB_REGEXP_STACK_LIMIT
+#endif
+#ifndef MRB_REGEXP_STACK_LIMIT
+#define MRB_REGEXP_STACK_LIMIT 2048
 #endif
 
-/* What a search answers when the backtracking engine gave up at one of the
-   two limits before it had an answer (see mrb_re_exec()). The caller raises
-   on it: what the search had found by then is not a shorter or a later
-   match, and reading it as one was the defect. Which of the two it was
-   names the knob to turn. */
-#define RE_OVER_RECURSION_LIMIT (-1)
+/* What a build may set it to. Outside this it bounds nothing.
+
+   The floor is what the engine itself asks: at 0 no search could hold a
+   single entry and every pattern that reaches this engine would answer
+   RegexpError, which is a limit that has stopped being one. Any value from 1
+   up is a build's to choose. A low one is not a broken build but a smaller
+   ceiling on what one search may ask the allocator for, bought by refusing
+   more patterns: an ordinary one holds a handful of entries whatever the
+   subject (ten groups and a backreference hold thirty-three before the first
+   repetition adds any), so a build that sets the limit that low is choosing
+   memory over the patterns it can match. The gem's own tests ask for 49,
+   which is where every pattern they take for granted matches again, and skip
+   below it (see test/backtracking_stack.rb).
+
+   The two limits are set apart from one another as well. Filling the stack
+   costs a handful of steps an entry, so a build that turns this one up far
+   enough puts it out of MRB_REGEXP_STEP_LIMIT's reach: a search that was to
+   stop here stops there instead. Nothing in the engine reads that as an
+   error, the two limits being answers to different questions, but the tests
+   that pin this one size their subjects from it and are skipped there.
+
+   Above the ceiling the arithmetic that sizes the arrays stops holding: a
+   capacity is doubled in 32 bits and multiplied by an entry's width to ask
+   the allocator for bytes, which is 32 bits wide too on a 32-bit ABI, and a
+   limit this high has in any case stopped being one, the two arrays at it
+   standing at hundreds of megabytes.
+
+   A negative value is refused here rather than read as no limit at all: the
+   count it is compared against is unsigned (see bt_room() in re_exec.c), so
+   -1 would stand for the largest ceiling there is. */
+#if MRB_REGEXP_STACK_LIMIT < 1 || MRB_REGEXP_STACK_LIMIT > (1 << 24)
+#error MRB_REGEXP_STACK_LIMIT must stand between 1 and 16777216
+#endif
+
+/* What a search answers when the backtracking engine stopped before it had
+   an answer (see mrb_re_exec()). The caller raises on it: what the search had
+   found by then is not a shorter or a later match, and reading it as one was
+   the defect. Which one it was names what to do about it: a limit names the
+   knob to turn, where RE_NOMEM says the allocator refused and no knob will
+   help. Turning MRB_REGEXP_STACK_LIMIT up in answer to a refused allocation
+   would make the memory it failed to find scarcer still, so the two are kept
+   apart all the way out of the engine. */
+#define RE_OVER_STACK_LIMIT (-1)
 #define RE_OVER_STEP_LIMIT (-2)
+#define RE_NOMEM (-3)
 
 /* Maximum captures */
 #define RE_MAX_CAPTURES 32

--- a/mrbgems/mruby-regexp/include/re_internal.h
+++ b/mrbgems/mruby-regexp/include/re_internal.h
@@ -197,10 +197,10 @@ typedef struct mrb_regexp_pattern {
    letting a search hold more of it is another, and a default above this one
    would make the second silently. The old limit allowed 1,000 C frames, and
    a frame is not an entry: a fork was one frame and is one choice point,
-   while a capture was one frame and is three undo records, so what a pattern
-   spends per iteration is what it holds. `(a)*?b` crossed 498 characters on
-   1,000 frames and crosses 681 on 2,048 entries, which is the tightest of
-   the shapes measured; a chain of atomic groups or of lookarounds, which
+   while a capture was one frame and is up to three undo records, so what a
+   pattern spends per iteration is what it holds. `(a)*?b` crossed 498
+   characters on 1,000 frames and crosses 682 on 2,048 entries, the tightest
+   of the shapes measured; a chain of atomic groups or of lookarounds, which
    spent two frames a link and now spends none once each has closed, is
    bounded by the pattern rather than by this limit either way. A build that
    wants a longer subject to match, or a smaller ceiling on the memory a
@@ -225,11 +225,12 @@ typedef struct mrb_regexp_pattern {
    up is a build's to choose. A low one is not a broken build but a smaller
    ceiling on what one search may ask the allocator for, bought by refusing
    more patterns: an ordinary one holds a handful of entries whatever the
-   subject (ten groups and a backreference hold thirty-three before the first
-   repetition adds any), so a build that sets the limit that low is choosing
-   memory over the patterns it can match. The gem's own tests ask for 49,
-   which is where every pattern they take for granted matches again, and skip
-   below it (see test/backtracking_stack.rb).
+   subject (ten groups and a backreference hold twenty-two, two to a group
+   with the whole match's own pair among them, before the first repetition
+   adds any), so a build that sets the limit that low is choosing memory
+   over the patterns it can match. The gem's own tests ask for 48, which is
+   where every pattern they take for granted matches again, and skip below
+   it (see test/backtracking_stack.rb).
 
    The two limits are set apart from one another as well. Filling the stack
    costs a handful of steps an entry, so a build that turns this one up far

--- a/mrbgems/mruby-regexp/src/re_exec.c
+++ b/mrbgems/mruby-regexp/src/re_exec.c
@@ -819,12 +819,19 @@ bt_push(bt_state *m, const char *sp, uint32_t pc, uint8_t kind, uint32_t group)
 
 /* Write `val` into `slot`, logging what stood there so that backtracking
    past this point puts it back. The answer is bt_push()'s, and means what it
-   means there: BT_OK is the write having happened, and BT_LIMIT or BT_NOMEM
-   is the search stopping, for the same two reasons and told apart for the
-   same one. */
+   means there: BT_OK is the write having gone through, and BT_LIMIT or
+   BT_NOMEM is the search stopping, for the same two reasons and told apart
+   for the same one.
+
+   A write of the value already there leaves nothing to put back, so it is not
+   logged. What MRB_REGEXP_STACK_LIMIT counts is then the state a search would
+   have to restore rather than the calls it made, and a search at the limit
+   goes on through such a write rather than stopping at one that would have
+   restored nothing. */
 static int
 bt_log(bt_state *m, int *slot, int val)
 {
+  if (*slot == val) return BT_OK;
   if (!bt_room(m)) return BT_LIMIT;
   if (m->undo_top == m->undo_capa) {
     uint32_t capa = bt_grow_capa(m->undo_capa);
@@ -876,7 +883,9 @@ bt_barrier_find(const bt_state *m, uint32_t group, uint32_t *idx)
    records go on the undo log, so that backtracking out of an iteration puts
    back the record of the one it lands in; the branch that begins an
    iteration is written this way rather than in place when it is taken, so
-   that there is one place that writes them. */
+   that there is one place that writes them. They go through bt_log() like
+   any other write, so an iteration that begins where the record already
+   says, in the pass it already names, spends nothing on saying so again. */
 static int
 bt_iter_begin(bt_state *m, uint32_t key, const char *sp)
 {
@@ -1044,7 +1053,9 @@ bt_match(bt_state *m, const char *sp, uint32_t pc)
            STACK_PUSH_MEM_START invalidates the end with the start). The
            end slot exists whenever the start does, ncap being even. The
            clear is logged too, so backtracking puts back the end the
-           iteration before it left. */
+           iteration before it left; where there is no such end, the group
+           being one this attempt has not closed yet, the clear writes the
+           -1 that already stands there and bt_log() records nothing. */
         if ((slot & 1) == 0 && (r = bt_log(m, &captures[slot + 1], -1)) != BT_OK) return r;
         pc++;
       }

--- a/mrbgems/mruby-regexp/src/re_exec.c
+++ b/mrbgems/mruby-regexp/src/re_exec.c
@@ -672,9 +672,10 @@ enum re_cp_kind {
    input stood (`sp`), which instruction takes the alternative (`pc`) and how
    tall the undo log was when it was pushed (`undo_top`). Backtracking pops
    one, takes back every write logged above its `undo_top` and goes on from
-   its `sp` and `pc`. A fork costs one of these rather than the C frame it
-   used to recurse into, so the C stack a search spends stops growing with
-   the subject: the state that grows is this stack, on the heap.
+   its `sp` and `pc`. A fork costs one of these rather than the C frame the
+   engine used to recurse into, so the C stack a search spends is the one
+   bt_match() call it makes, whatever the subject: the state that grows is
+   this stack, on the heap.
 
    MRB_REGEXP_STACK_LIMIT is what bounds it (see there and bt_room()). */
 typedef struct {
@@ -703,11 +704,10 @@ typedef struct {
   int old;
 } re_undo;
 
-/* What one backtrack_exec() call shares between its bt_match() frames: the
-   pattern, the subject, the capture slots being written, the step count, the
-   iteration records and the two stacks the backtracking state stands on. A
-   frame's own state is its position, its pc and its depth, plus the heights
-   it found the stacks at. */
+/* Everything one backtrack_exec() call carries: the pattern, the subject,
+   the capture slots being written, the step count, the iteration records and
+   the two stacks the backtracking state stands on. What the search itself
+   holds between instructions is only its position and its pc. */
 typedef struct {
   mrb_state *mrb;
   const mrb_regexp_pattern *pat;
@@ -716,7 +716,7 @@ typedef struct {
   int *captures;
   int ncap;
   int steps;
-  /* Per pc, the offset the frame that pc keys was entered at, or -1 while
+  /* Per pc, the offset the loop that pc keys was entered at, or -1 while
      none is running; what a record means is what its pc is. For the edge of
      a repetition whose body can match empty it is where the running
      iteration began: such a repetition has to stop once an iteration ends
@@ -731,17 +731,18 @@ typedef struct {
   int *entered_at;
   /* Per pc, the pass that wrote entered_at[pc]. A pass is one run of a
      lookaround's sub-pattern, numbered from `pass_seq` so that no two runs
-     share one, and 0 is the pattern outside every lookaround; `pass` is the
-     one the search is in. A record is read as the running iteration's only
-     by the pass that wrote it: what a positive lookaround captured outlives
-     it, and so do the records of the loops inside it, the undo log not
-     unwinding at its end, so a repetition around the lookaround re-enters
-     the sub-pattern with the records of the run before still live. The first
-     iteration of an e+, which reads its record without having written it,
-     would take one of those for its own where the positions coincide:
-     `(?=(b|)+)+` on "b" re-enters at 0 while the run before left 1 for
-     `(b|)+`, and its first iteration, ending at 1, would stop there with "b"
-     captured, where a fresh pass goes round once more and leaves "". */
+     of one start position's attempt share one, and 0 is the pattern outside
+     every lookaround; `pass` is the one the search is in. A record is read
+     as the running iteration's only by the pass that wrote it: what a
+     positive lookaround captured outlives it, and so do the records of the
+     loops inside it, the undo log not unwinding at its end, so a repetition
+     around the lookaround re-enters the sub-pattern with the records of the
+     run before still live. The first iteration of an e+, which reads its
+     record without having written it, would take one of those for its own
+     where the positions coincide: `(?=(b|)+)+` on "b" re-enters at 0 while
+     the run before left 1 for `(b|)+`, and its first iteration, ending at
+     1, would stop there with "b" captured, where a fresh pass goes round
+     once more and leaves "". */
   int *entered_in;
   int pass;
   int pass_seq;
@@ -763,15 +764,6 @@ typedef struct {
    sp: the record is this pass's and names sp. */
 #define ITER_EMPTY(m, key, sp) \
   ((m)->entered_at[key] == (int)((sp) - (m)->str) && (m)->entered_in[key] == (m)->pass)
-
-/* What is left of the bound on the C stack while the backtracking state moves
-   onto the heap. The mechanisms that still recurse (a capture, the record of
-   an iteration, an atomic group, a lookaround) each spend a frame per
-   iteration the way a fork used to, and MRB_REGEXP_STACK_LIMIT no longer
-   counts frames, so the frames keep a bound of their own until the last of
-   them is gone. A frame that reaches it gives up as it did before and the
-   search names the same limit, there being one knob and not two. */
-#define RE_FRAME_LIMIT 1000
 
 /* Whether the search may hold one more entry of backtracking state.
    MRB_REGEXP_STACK_LIMIT counts the two stacks together: a choice point and
@@ -858,16 +850,6 @@ bt_undo_to(bt_state *m, uint32_t top)
   }
 }
 
-/* Drop the backtracking state above the heights a frame found: the choice
-   points it pushed and the writes it logged, none of which its caller may
-   backtrack into. */
-static void
-bt_truncate(bt_state *m, uint32_t cp_top, uint32_t undo_top)
-{
-  m->cp_top = cp_top;
-  bt_undo_to(m, undo_top);
-}
-
 /* Where the group `group` was entered, as an index into the choice point
    stack. Barriers nest and a group's end runs while its own is the innermost
    still standing, so the walk down from the top is over what that end is
@@ -875,10 +857,10 @@ bt_truncate(bt_state *m, uint32_t cp_top, uint32_t undo_top)
    opener, which a compiled pattern does not hold; the search reads it as a
    failure rather than trusting an index. */
 static mrb_bool
-bt_barrier_find(const bt_state *m, uint32_t group, uint32_t floor, uint32_t *idx)
+bt_barrier_find(const bt_state *m, uint32_t group, uint32_t *idx)
 {
   uint32_t i = m->cp_top;
-  while (i > floor) {
+  while (i > 0) {
     i--;
     if ((m->cp[i].kind == RE_CP_BARRIER || m->cp[i].kind == RE_CP_NEG) &&
         m->cp[i].group == group) {
@@ -907,17 +889,15 @@ bt_iter_begin(bt_state *m, uint32_t key, const char *sp)
  *
  * A fork pushes a choice point and goes on with its first branch; a failure
  * pops one and goes on with the alternative it holds, taking back the writes
- * logged since it was pushed. The frame therefore loops where it used to
- * recurse, and what it may pop is what it pushed: the heights the stacks
- * stood at on entry are the floor, since below them is the state of the
- * frame that called this one, whose iteration records that frame restores
- * itself. Every answer but BT_MATCH leaves the stacks as the frame found
- * them.
+ * logged since it was pushed. The whole of a search is this one loop, so what
+ * it costs the C stack is one call however long the subject is and however
+ * deep the pattern nests; what grows instead are the two stacks on the heap,
+ * which MRB_REGEXP_STACK_LIMIT bounds.
  *
  * Step-limited to prevent ReDoS.
  */
 static int
-bt_match(bt_state *m, const char *sp, uint32_t pc, int depth)
+bt_match(bt_state *m, const char *sp, uint32_t pc)
 {
   const mrb_regexp_pattern *pat = m->pat;
   const char *str = m->str;
@@ -925,17 +905,15 @@ bt_match(bt_state *m, const char *sp, uint32_t pc, int depth)
   int *captures = m->captures;
   int ncap = m->ncap;
   mrb_bool binary = m->binary;
-  const uint32_t cp_floor = m->cp_top;
-  const uint32_t undo_floor = m->undo_top;
+  /* What an operation on the stacks answers, which is this call's answer
+     wherever it is not BT_OK. Outside the loop so that no `goto fail`
+     crosses an initialization: a C++ build refuses a jump that does. */
   int r;
-  /* Outside the loop so that no `goto fail` crosses its initialization: a
-     C++ build refuses a jump that does. */
   re_inst inst;
 
-  if (depth > RE_FRAME_LIMIT) return BT_LIMIT;
   for (;;) {
     if (pc >= pat->code_len) goto fail;
-    if (++m->steps > MRB_REGEXP_STEP_LIMIT) { r = BT_LIMIT; goto done; }
+    if (++m->steps > MRB_REGEXP_STEP_LIMIT) return BT_LIMIT;
 
     inst = pat->code[pc];
     switch (inst.op) {
@@ -1004,16 +982,16 @@ bt_match(bt_state *m, const char *sp, uint32_t pc, int depth)
       if (inst.a) {
         if (inst.offset > pc) {
           if ((r = bt_push(m, sp, inst.offset, RE_CP_FORK, 0)) != BT_OK ||
-              (r = bt_iter_begin(m, pc, sp)) != BT_OK) goto done;
+              (r = bt_iter_begin(m, pc, sp)) != BT_OK) return r;
           pc++;
           break;
         }
         if (ITER_EMPTY(m, pc, sp)) { pc++; break; }
-        if ((r = bt_push(m, sp, inst.offset, RE_CP_ITER, pc)) != BT_OK) goto done;
+        if ((r = bt_push(m, sp, inst.offset, RE_CP_ITER, pc)) != BT_OK) return r;
         pc++;
         break;
       }
-      if ((r = bt_push(m, sp, inst.offset, RE_CP_FORK, 0)) != BT_OK) goto done;
+      if ((r = bt_push(m, sp, inst.offset, RE_CP_FORK, 0)) != BT_OK) return r;
       pc++;
       break;
 
@@ -1024,17 +1002,17 @@ bt_match(bt_state *m, const char *sp, uint32_t pc, int depth)
          same. */
       if (inst.a) {
         if (inst.offset > pc) {
-          if ((r = bt_push(m, sp, pc + 1, RE_CP_ITER, pc)) != BT_OK) goto done;
+          if ((r = bt_push(m, sp, pc + 1, RE_CP_ITER, pc)) != BT_OK) return r;
           pc = inst.offset;
           break;
         }
         if (ITER_EMPTY(m, pc, sp)) { pc++; break; }
         if ((r = bt_push(m, sp, pc + 1, RE_CP_FORK, 0)) != BT_OK ||
-            (r = bt_iter_begin(m, pc, sp)) != BT_OK) goto done;
+            (r = bt_iter_begin(m, pc, sp)) != BT_OK) return r;
         pc = inst.offset;
         break;
       }
-      if ((r = bt_push(m, sp, pc + 1, RE_CP_FORK, 0)) != BT_OK) goto done;
+      if ((r = bt_push(m, sp, pc + 1, RE_CP_FORK, 0)) != BT_OK) return r;
       pc = inst.offset;
       break;
 
@@ -1050,10 +1028,11 @@ bt_match(bt_state *m, const char *sp, uint32_t pc, int depth)
         }
         if (slot >= ncap) goto fail;
         /* The write is logged rather than recursed over: backtracking past
-           it puts the slot back, which is undone for a cut as for a failure
-           (the group a cut fails may be the one this slot was written
-           inside), and a match keeps it, the log unwinding for neither. */
-        if ((r = bt_log(m, &captures[slot], (int)(sp - str))) != BT_OK) goto done;
+           it puts the slot back, which is what undoes what a branch captured
+           before it was abandoned. What a match keeps, and what an atomic
+           group or a positive lookaround keeps once it has matched, is kept
+           by the log not unwinding at all there. */
+        if ((r = bt_log(m, &captures[slot], (int)(sp - str))) != BT_OK) return r;
         /* An even slot opens its group, and the pair it heads is a span
            only while the group is closed: clear the end slot with the
            start, so that RE_BACKREF reads a group a repetition has just
@@ -1066,7 +1045,7 @@ bt_match(bt_state *m, const char *sp, uint32_t pc, int depth)
            end slot exists whenever the start does, ncap being even. The
            clear is logged too, so backtracking puts back the end the
            iteration before it left. */
-        if ((slot & 1) == 0 && (r = bt_log(m, &captures[slot + 1], -1)) != BT_OK) goto done;
+        if ((slot & 1) == 0 && (r = bt_log(m, &captures[slot + 1], -1)) != BT_OK) return r;
         pc++;
       }
       break;
@@ -1172,7 +1151,7 @@ bt_match(bt_state *m, const char *sp, uint32_t pc, int depth)
         }
         if ((r = bt_push(m, sp, inst.offset, negated ? RE_CP_NEG : RE_CP_BARRIER,
                          pat->code[inst.offset - 1].offset)) != BT_OK) {
-          goto done;
+          return r;
         }
         m->pass = ++m->pass_seq;
         sp = from;
@@ -1195,7 +1174,7 @@ bt_match(bt_state *m, const char *sp, uint32_t pc, int depth)
            pass the lookaround was entered from comes back with the
            barrier. */
         uint32_t idx;
-        if (!bt_barrier_find(m, inst.offset, cp_floor, &idx)) goto fail;
+        if (!bt_barrier_find(m, inst.offset, &idx)) goto fail;
         re_cpoint c = m->cp[idx];
         m->cp_top = idx;
         m->pass = c.pass;
@@ -1211,8 +1190,8 @@ bt_match(bt_state *m, const char *sp, uint32_t pc, int depth)
     case RE_ATOMIC:
       /* The group is entered: a barrier stands where it began, so that a
          failure inside the body that reaches it is the group failing, and
-         the body goes on in this frame. */
-      if ((r = bt_push(m, sp, pc + 1, RE_CP_BARRIER, inst.offset)) != BT_OK) goto done;
+         the body goes on from here. */
+      if ((r = bt_push(m, sp, pc + 1, RE_CP_BARRIER, inst.offset)) != BT_OK) return r;
       pc++;
       break;
 
@@ -1225,7 +1204,7 @@ bt_match(bt_state *m, const char *sp, uint32_t pc, int depth)
            failure that goes back past where the group began takes it back
            along with everything else logged since. */
         uint32_t idx;
-        if (!bt_barrier_find(m, inst.offset, cp_floor, &idx)) goto fail;
+        if (!bt_barrier_find(m, inst.offset, &idx)) goto fail;
         m->cp_top = idx;
         pc++;
       }
@@ -1238,11 +1217,10 @@ bt_match(bt_state *m, const char *sp, uint32_t pc, int depth)
 
   fail:
     /* This branch is spent. The next alternative is the choice point on top,
-       with every write since it was pushed taken back; below the floor is the
-       caller's state and the caller's alternatives, so there this frame is
-       spent too. */
+       with every write since it was pushed taken back; with none left there
+       is nothing more to try from this start position. */
     for (;;) {
-      if (m->cp_top == cp_floor) { r = BT_FAIL; goto done; }
+      if (m->cp_top == 0) return BT_FAIL;
       re_cpoint c = m->cp[--m->cp_top];
       bt_undo_to(m, c.undo_top);
       /* The pass a branch was pushed in is the pass it runs in, and for a
@@ -1257,16 +1235,10 @@ bt_match(bt_state *m, const char *sp, uint32_t pc, int depth)
       if (c.kind == RE_CP_BARRIER) continue;
       sp = c.sp;
       pc = c.pc;
-      if (c.kind == RE_CP_ITER && (r = bt_iter_begin(m, c.group, sp)) != BT_OK) {
-        goto done;
-      }
+      if (c.kind == RE_CP_ITER && (r = bt_iter_begin(m, c.group, sp)) != BT_OK) return r;
       break;
     }
   }
-
-done:
-  if (r != BT_MATCH) bt_truncate(m, cp_floor, undo_floor);
-  return r;
 }
 
 static int
@@ -1326,11 +1298,18 @@ backtrack_exec(mrb_state *mrb, const mrb_regexp_pattern *pat,
     /* The state of the attempt before, which failed and left nothing to
        resume, is not this attempt's: the stacks start empty, and the writes
        still logged are taken back so that the records the arrays hold are
-       what a fresh search finds. */
+       what a fresh search finds. The pass numbering starts over with them.
+       Every record a pass wrote is on that log, so once it has unwound
+       there is nothing left for a number to be read against and the numbers
+       need only be unique within the attempt; a counter that ran on across
+       the start positions would climb with the length of the subject
+       instead, until a long enough search overflowed it. */
     m.cp_top = 0;
+    m.pass = 0;
+    m.pass_seq = 0;
     bt_undo_to(&m, 0);
 
-    int r = bt_match(&m, sp, 0, 0);
+    int r = bt_match(&m, sp, 0);
     if (r == BT_MATCH) {
       if (captures) {
         int copy = ncap < captures_size ? ncap : captures_size;
@@ -1352,9 +1331,9 @@ backtrack_exec(mrb_state *mrb, const mrb_regexp_pattern *pat,
       /* The search ends here, not this start position's attempt: the
          positions after it answer where the first match is only once this
          one has none, which is what the limit left unanswered. Which limit
-         is read off the step count: the state checks run before a frame
-         counts its step, so the count is over the step limit exactly when
-         the step check gave up. */
+         is read off the step count: nothing but the step check moves it, so
+         it is over the step limit exactly when that check is what gave
+         up. */
       ret = m.steps > MRB_REGEXP_STEP_LIMIT ? RE_OVER_STEP_LIMIT : RE_OVER_STACK_LIMIT;
       break;
     }

--- a/mrbgems/mruby-regexp/src/re_exec.c
+++ b/mrbgems/mruby-regexp/src/re_exec.c
@@ -668,9 +668,14 @@ lookbehind_start(const mrb_regexp_pattern *pat, const char *str,
 /* What taking a choice point does beyond resuming where it points. */
 enum re_cp_kind {
   RE_CP_FORK,   /* nothing: a branch the search has not tried yet */
-  RE_CP_ITER    /* the branch begins an iteration of the loop its `group`
+  RE_CP_ITER,   /* the branch begins an iteration of the loop its `group`
                    keys, whose record is written when the branch is taken
                    rather than when it was pushed (see bt_iter_begin()) */
+  RE_CP_BARRIER /* not a branch at all: where the group its `group` names was
+                 entered. Reaching it while backtracking is that group
+                 failing, so it resumes nothing and the search goes on
+                 popping; its end drops it and everything above it, which is
+                 how an atomic group cuts (see RE_ATOMIC_END). */
 };
 
 /* A choice point: an alternative the search has not tried yet, as where the
@@ -869,6 +874,40 @@ bt_truncate(bt_state *m, uint32_t cp_top, uint32_t undo_top)
 {
   m->cp_top = cp_top;
   bt_undo_to(m, undo_top);
+}
+
+/* Where the group `group` was entered, as an index into the choice point
+   stack, or FALSE when it was entered in a frame below `floor`: a group
+   whose body holds a lookaround, whose end runs inside the frames the
+   lookaround makes, and which the cut still reaches instead (see
+   bt_cut_absorb()). Barriers nest, so the walk down from the top is over
+   what the group's end is about to drop in any case. */
+static mrb_bool
+bt_barrier_find(const bt_state *m, uint32_t group, uint32_t floor, uint32_t *idx)
+{
+  uint32_t i = m->cp_top;
+  while (i > floor) {
+    i--;
+    if (m->cp[i].kind == RE_CP_BARRIER && m->cp[i].group == group) {
+      *idx = i;
+      return TRUE;
+    }
+  }
+  return FALSE;
+}
+
+/* Whether a nested call's answer is the cut of a group this frame opened,
+   which is that group failing here: everything the body left goes, the writes
+   it logged with it, which is what popping its barrier does. Any other answer
+   is not this frame's to read. */
+static mrb_bool
+bt_cut_absorb(bt_state *m, int r, uint32_t floor)
+{
+  uint32_t idx;
+  if (r >= 0 || !bt_barrier_find(m, (uint32_t)(-r), floor, &idx)) return FALSE;
+  m->cp_top = idx;
+  bt_undo_to(m, m->cp[idx].undo_top);
+  return TRUE;
 }
 
 static int bt_match(bt_state *m, const char *sp, uint32_t pc, int depth);
@@ -1170,7 +1209,7 @@ bt_match(bt_state *m, const char *sp, uint32_t pc, int depth)
          frame's, whichever it is. */
       {
         int rr = bt_look(m, sp, sp, pc, pc + 1, depth + 1);
-        if (rr == BT_FAIL) goto fail;
+        if (rr == BT_FAIL || bt_cut_absorb(m, rr, cp_floor)) goto fail;
         r = rr;
         goto done;
       }
@@ -1181,7 +1220,7 @@ bt_match(bt_state *m, const char *sp, uint32_t pc, int depth)
            running out of alternatives is the assertion holding, and the text
            after it goes on here. A limit goes up as it is. */
         int rr = bt_look(m, sp, sp, pc, pc + 1, depth + 1);
-        if (rr == BT_MATCH) goto fail;
+        if (rr == BT_MATCH || bt_cut_absorb(m, rr, cp_floor)) goto fail;
         if (rr != BT_FAIL) { r = rr; goto done; }
         pc = inst.offset;
       }
@@ -1192,7 +1231,7 @@ bt_match(bt_state *m, const char *sp, uint32_t pc, int depth)
         const char *back = lookbehind_start(pat, str, str_end, sp, pc, binary);
         if (!back) goto fail;  /* not enough text before */
         int rr = bt_look(m, sp, back, pc, pc + 2, depth + 1);
-        if (rr == BT_FAIL) goto fail;
+        if (rr == BT_FAIL || bt_cut_absorb(m, rr, cp_floor)) goto fail;
         r = rr;
         goto done;
       }
@@ -1202,7 +1241,7 @@ bt_match(bt_state *m, const char *sp, uint32_t pc, int depth)
         const char *back = lookbehind_start(pat, str, str_end, sp, pc, binary);
         if (back) {
           int rr = bt_look(m, sp, back, pc, pc + 2, depth + 1);
-          if (rr == BT_MATCH) goto fail;
+          if (rr == BT_MATCH || bt_cut_absorb(m, rr, cp_floor)) goto fail;
           if (rr != BT_FAIL) { r = rr; goto done; }
         }
         /* if not enough text before, negative lookbehind succeeds */
@@ -1229,29 +1268,39 @@ bt_match(bt_state *m, const char *sp, uint32_t pc, int depth)
         m->pass = m->entered_in[pc];
         int rr = bt_match(m, str + m->entered_at[pc], pc + 1, depth + 1);
         m->pass = pass;
+        if (bt_cut_absorb(m, rr, cp_floor)) goto fail;
         r = (rr == BT_FAIL) ? BT_CUT(inst.offset) : rr;
         goto done;
       }
 
     case RE_ATOMIC:
-      {
-        /* The body runs on through its RE_ATOMIC_END to the end of the
-           pattern inside this call, so there is nothing to continue with
-           here: the answer is passed up, except that a cut aimed at this
-           group is this group failing, which the caller backtracks over the
-           way it would any other failed atom. */
-        int rr = bt_match(m, sp, pc + 1, depth + 1);
-        if (rr == BT_CUT(inst.offset) || rr == BT_FAIL) goto fail;
-        r = rr;
-        goto done;
-      }
+      /* The group is entered: a barrier stands where it began, so that a
+         failure inside the body that reaches it is the group failing, and
+         the body goes on in this frame. */
+      if ((r = bt_push(m, sp, pc + 1, RE_CP_BARRIER, inst.offset)) != BT_OK) goto done;
+      pc++;
+      break;
 
     case RE_ATOMIC_END:
       {
         /* The body has matched once, and that is the only way it matches:
-           when what follows fails, the failure is a cut, so that the SPLITs
-           inside the body do not get to try their other branches. A limit
-           is not the text failing and goes up as it is. */
+           the alternatives it left are dropped, barrier and all, so that a
+           failure after the group is not answered from inside it. What the
+           body captured stays; the undo log is left as it is, and a
+           failure that goes back past where the group began takes it back
+           along with everything else logged since. */
+        uint32_t idx;
+        if (bt_barrier_find(m, inst.offset, cp_floor, &idx)) {
+          m->cp_top = idx;
+          pc++;
+          break;
+        }
+        /* The group was entered in a frame below this one, whose choice
+           points this one may not touch. The text after it runs inside this
+           frame instead, as it did before the barrier: a failure there is
+           the cut, which reaches the barrier through the frames between
+           (see bt_cut_absorb()), and a limit is not the text failing and
+           goes up as it is. */
         int rr = bt_match(m, sp, pc + 1, depth + 1);
         r = (rr == BT_FAIL) ? BT_CUT(inst.offset) : rr;
         goto done;
@@ -1267,15 +1316,19 @@ bt_match(bt_state *m, const char *sp, uint32_t pc, int depth)
        with every write since it was pushed taken back; below the floor is the
        caller's state and the caller's alternatives, so there this frame is
        spent too. */
-    if (m->cp_top == cp_floor) { r = BT_FAIL; goto done; }
-    {
+    for (;;) {
+      if (m->cp_top == cp_floor) { r = BT_FAIL; goto done; }
       re_cpoint c = m->cp[--m->cp_top];
       bt_undo_to(m, c.undo_top);
+      /* A barrier is where a group was entered, not a branch: reaching it
+         is that group failing, and what is left to try is below it. */
+      if (c.kind == RE_CP_BARRIER) continue;
       sp = c.sp;
       pc = c.pc;
       if (c.kind == RE_CP_ITER && (r = bt_iter_begin(m, c.group, sp)) != BT_OK) {
         goto done;
       }
+      break;
     }
   }
 

--- a/mrbgems/mruby-regexp/src/re_exec.c
+++ b/mrbgems/mruby-regexp/src/re_exec.c
@@ -630,34 +630,77 @@ lookbehind_start(const mrb_regexp_pattern *pat, const char *str,
 
 /* What one bt_match() frame answers. The frame that reaches RE_MATCH answers
    BT_MATCH, and every frame under it hands that up unchanged. A frame whose
-   alternatives are exhausted answers BT_FAIL, and its caller tries the next
-   alternative of its own. The third answer is the cut of an atomic group:
-   the text after an RE_ATOMIC_END has failed, and no alternative inside the
-   group's body may be tried for it, so the frames between that end and the
-   RE_ATOMIC that opened the group hand BT_CUT of the group's number up
-   unchanged, undoing their captures as they go, and the frame that ran that
-   RE_ATOMIC turns it into BT_FAIL. A lookaround runs its sub-pattern the
-   same way, the text after it going on inside the sub-pattern's frames from
-   the RE_LOOK_END (see there), so a cut can pass through one; the opener
-   absorbs its own number like an RE_ATOMIC and hands any other up.
-   The fourth answer, BT_LIMIT, is a frame giving up at the recursion or step
-   limit, and it is the search's answer rather than the frame's: every frame
-   hands it up unchanged, as it does a cut, and backtrack_exec() stops at it
-   (see there). A limit says nothing about the text, so no frame may read it
-   as its branch having failed and answer with its other branch, which would
-   be answering a smaller question with whatever the alternatives inside the
-   limit produce: a shorter, a later or no match, told from the real answer
-   by nothing. */
+   alternatives are exhausted answers BT_FAIL; its alternatives are the choice
+   points it pushed on the stack the search shares, which it backtracks into
+   itself, and the branches it still recurses into, whose failure it reads
+   here. The third answer is the cut of an atomic group: the text after an
+   RE_ATOMIC_END has failed, and no alternative inside the group's body may be
+   tried for it, so the frames between that end and the RE_ATOMIC that opened
+   the group hand BT_CUT of the group's number up unchanged, undoing their
+   captures as they go, and the frame that ran that RE_ATOMIC turns it into
+   BT_FAIL. A lookaround runs its sub-pattern the same way, the text after it
+   going on inside the sub-pattern's frames from the RE_LOOK_END (see there),
+   so a cut can pass through one; the opener absorbs its own number like an
+   RE_ATOMIC and hands any other up.
+   The fourth answer, BT_LIMIT, is a frame giving up at one of the limits, and
+   the fifth, BT_NOMEM, is the allocator having refused the state a frame
+   needed. Both are the search's answer rather than the frame's: every frame
+   hands them up unchanged, as it does a cut, and backtrack_exec() stops at
+   them (see there). Neither says anything about the text, so no frame may
+   read one as its branch having failed and answer with its other branch,
+   which would be answering a smaller question with whatever the alternatives
+   inside the limit produce: a shorter, a later or no match, told from the
+   real answer by nothing. They stay apart from each other for the same
+   reason they stay apart from a failure: what a limit asks of the build is
+   that MRB_REGEXP_STACK_LIMIT be turned up, which is the worst thing it
+   could do about an allocator that had nothing left to give.
+
+   BT_OK is not one of bt_match()'s answers. It is what bt_push() and the
+   other operations on the stacks answer when there is nothing to hand up,
+   so that what they answer otherwise is the frame's answer as it stands. */
 #define BT_FAIL 0
 #define BT_MATCH 1
 #define BT_LIMIT 2
+#define BT_NOMEM 3
+#define BT_OK 4
 #define BT_CUT(cut) (-(int)(cut))
 
-/* What one backtrack_exec() call shares between its bt_match() frames: the
-   pattern, the subject, the capture slots being written, the step count and
-   the iteration records. A frame's own state is its position, its pc and its
-   depth. */
+/* A choice point: an alternative the search has not tried yet, as where the
+   input stood (`sp`), which instruction takes the alternative (`pc`) and how
+   tall the undo log was when it was pushed (`undo_top`). Backtracking pops
+   one, takes back every write logged above its `undo_top` and goes on from
+   its `sp` and `pc`. A fork costs one of these rather than the C frame it
+   used to recurse into, so the C stack a search spends stops growing with
+   the subject: the state that grows is this stack, on the heap.
+
+   MRB_REGEXP_STACK_LIMIT is what bounds it (see there and bt_room()). */
 typedef struct {
+  const char *sp;
+  uint32_t pc;
+  uint32_t undo_top;
+} re_cpoint;
+
+/* An undo record: one write the search must be able to take back, as the slot
+   written and what stood in it. The records are a stack of their own beside
+   the choice points rather than a field in them, because what a cut does to
+   each differs: the captures a positive lookaround or an atomic group wrote
+   outlive it, so its cut drops the choice points above the barrier and leaves
+   the undo log alone, while a negative lookaround, whose captures do not
+   outlive it, unwinds both. One mixed stack could not truncate at all: it
+   would have to walk the region above the barrier and keep the undo records
+   while dropping the choice points. */
+typedef struct {
+  int *slot;
+  int old;
+} re_undo;
+
+/* What one backtrack_exec() call shares between its bt_match() frames: the
+   pattern, the subject, the capture slots being written, the step count, the
+   iteration records and the two stacks the backtracking state stands on. A
+   frame's own state is its position, its pc and its depth, plus the heights
+   it found the stacks at. */
+typedef struct {
+  mrb_state *mrb;
   const mrb_regexp_pattern *pat;
   const char *str;
   const char *str_end;
@@ -697,12 +740,101 @@ typedef struct {
   int *entered_in;
   int pass;
   mrb_bool binary;
+  /* The choice points not yet tried and the writes not yet taken back, both
+     grown lazily on the heap. A search starts with neither allocated and
+     pays only for the kind of state it holds: a fork is a choice point, a
+     capture or an iteration record is an undo record, and a pattern with
+     none of them in it asks the allocator for nothing. */
+  re_cpoint *cp;
+  uint32_t cp_top;
+  uint32_t cp_capa;
+  re_undo *undo;
+  uint32_t undo_top;
+  uint32_t undo_capa;
 } bt_state;
 
 /* Whether the loop `key` keys is at the end of an iteration that began at
    sp: the record is this pass's and names sp. */
 #define ITER_EMPTY(m, key, sp) \
   ((m)->entered_at[key] == (int)((sp) - (m)->str) && (m)->entered_in[key] == (m)->pass)
+
+/* What is left of the bound on the C stack while the backtracking state moves
+   onto the heap. The mechanisms that still recurse (a capture, the record of
+   an iteration, an atomic group, a lookaround) each spend a frame per
+   iteration the way a fork used to, and MRB_REGEXP_STACK_LIMIT no longer
+   counts frames, so the frames keep a bound of their own until the last of
+   them is gone. A frame that reaches it gives up as it did before and the
+   search names the same limit, there being one knob and not two. */
+#define RE_FRAME_LIMIT 1000
+
+/* Whether the search may hold one more entry of backtracking state.
+   MRB_REGEXP_STACK_LIMIT counts the two stacks together: a choice point and
+   an undo record each stand for a branch or a write the search is still able
+   to take back, and bounding their sum is what bounds the state one search
+   holds. */
+static mrb_bool
+bt_room(const bt_state *m)
+{
+  return m->cp_top + m->undo_top < (uint32_t)MRB_REGEXP_STACK_LIMIT;
+}
+
+/* What a full stack grows to. Doubling is what makes a push amortised
+   constant; the ceiling is what makes MRB_REGEXP_STACK_LIMIT a bound on the
+   memory a search asks for and not only on the entries it holds at once,
+   since a stack keeps its capacity for the rest of the search and the two of
+   them reach their high-water marks at different times. A stack is grown only
+   where bt_room() has just passed, so its height is below the limit and the
+   ceiling always leaves room for the entry being pushed. */
+static uint32_t
+bt_grow_capa(uint32_t capa)
+{
+  capa = capa ? capa * 2 : 16;
+  return capa < (uint32_t)MRB_REGEXP_STACK_LIMIT ? capa : (uint32_t)MRB_REGEXP_STACK_LIMIT;
+}
+
+/* Push a choice point. BT_OK is the push having happened, and anything else
+   is the search stopping, to be handed up as the frame's answer: BT_LIMIT
+   where the stack limit refuses the entry, BT_NOMEM where the allocator
+   refuses the memory for it. Growing with mrb_realloc_simple() rather than
+   mrb_realloc() is what lets a refusal be an answer at all, a raising
+   allocator longjmping past the mrb_free() in backtrack_exec(). */
+static int
+bt_push(bt_state *m, const char *sp, uint32_t pc)
+{
+  if (!bt_room(m)) return BT_LIMIT;
+  if (m->cp_top == m->cp_capa) {
+    uint32_t capa = bt_grow_capa(m->cp_capa);
+    re_cpoint *p = (re_cpoint*)mrb_realloc_simple(m->mrb, m->cp, sizeof(re_cpoint) * capa);
+    if (!p) return BT_NOMEM;
+    m->cp = p;
+    m->cp_capa = capa;
+  }
+  re_cpoint *c = &m->cp[m->cp_top++];
+  c->sp = sp;
+  c->pc = pc;
+  c->undo_top = m->undo_top;
+  return BT_OK;
+}
+
+/* Take back every write logged above `top`. */
+static void
+bt_undo_to(bt_state *m, uint32_t top)
+{
+  while (m->undo_top > top) {
+    re_undo *u = &m->undo[--m->undo_top];
+    *u->slot = u->old;
+  }
+}
+
+/* Drop the backtracking state above the heights a frame found: the choice
+   points it pushed and the writes it logged, none of which its caller may
+   backtrack into. */
+static void
+bt_truncate(bt_state *m, uint32_t cp_top, uint32_t undo_top)
+{
+  m->cp_top = cp_top;
+  bt_undo_to(m, undo_top);
+}
 
 static int bt_match(bt_state *m, const char *sp, uint32_t pc, int depth);
 
@@ -766,6 +898,15 @@ bt_look(bt_state *m, const char *sp, const char *from, uint32_t pc,
 
 /*
  * Backtracking engine for patterns with backreferences.
+ *
+ * A fork pushes a choice point and goes on with its first branch; a failure
+ * pops one and goes on with the alternative it holds. The frame therefore
+ * loops where it used to recurse, and what it may pop is what it pushed: the
+ * heights the stacks stood at on entry are the floor, since below them is the
+ * state of the frame that called this one, whose captures and iteration
+ * records that frame undoes itself. Every answer but BT_MATCH leaves the
+ * stacks as the frame found them.
+ *
  * Step-limited to prevent ReDoS.
  */
 static int
@@ -777,47 +918,54 @@ bt_match(bt_state *m, const char *sp, uint32_t pc, int depth)
   int *captures = m->captures;
   int ncap = m->ncap;
   mrb_bool binary = m->binary;
+  const uint32_t cp_floor = m->cp_top;
+  const uint32_t undo_floor = m->undo_top;
+  int r;
+  /* Outside the loop so that no `goto fail` crosses its initialization: a
+     C++ build refuses a jump that does. */
+  re_inst inst;
 
-  if (depth > MRB_REGEXP_RECURSION_LIMIT) return BT_LIMIT;
-  while (pc < pat->code_len) {
-    if (++m->steps > MRB_REGEXP_STEP_LIMIT) return BT_LIMIT;
+  if (depth > RE_FRAME_LIMIT) return BT_LIMIT;
+  for (;;) {
+    if (pc >= pat->code_len) goto fail;
+    if (++m->steps > MRB_REGEXP_STEP_LIMIT) { r = BT_LIMIT; goto done; }
 
-    re_inst inst = pat->code[pc];
+    inst = pat->code[pc];
     switch (inst.op) {
     case RE_CHAR:
-      if (sp >= str_end || (uint8_t)*sp != inst.a) return BT_FAIL;
+      if (sp >= str_end || (uint8_t)*sp != inst.a) goto fail;
       sp++; pc++;
       break;
 
     case RE_ANY:
-      if (sp >= str_end || *sp == '\n') return BT_FAIL;
+      if (sp >= str_end || *sp == '\n') goto fail;
       sp += mrb_re_charlen(sp, str_end, binary); pc++;
       break;
 
     case RE_ANY_NL:
-      if (sp >= str_end) return BT_FAIL;
+      if (sp >= str_end) goto fail;
       sp += mrb_re_charlen(sp, str_end, binary); pc++;
       break;
 
     case RE_CLASS:
-      if (sp >= str_end) return BT_FAIL;
+      if (sp >= str_end) goto fail;
       {
         int dlen = 0;
         uint32_t cp_ = mrb_re_decode_char(sp, str_end, &dlen, binary);
         mrb_bool raw = (dlen == 1 && (uint8_t)*sp >= 0x80);
-        if (!class_match(&pat->classes[inst.a], cp_, raw)) return BT_FAIL;
+        if (!class_match(&pat->classes[inst.a], cp_, raw)) goto fail;
         sp += mrb_re_charlen(sp, str_end, binary);
       }
       pc++;
       break;
 
     case RE_NCLASS:
-      if (sp >= str_end) return BT_FAIL;
+      if (sp >= str_end) goto fail;
       {
         int dlen = 0;
         uint32_t cp_ = mrb_re_decode_char(sp, str_end, &dlen, binary);
         mrb_bool raw = (dlen == 1 && (uint8_t)*sp >= 0x80);
-        if (class_match(&pat->classes[inst.a], cp_, raw)) return BT_FAIL;
+        if (class_match(&pat->classes[inst.a], cp_, raw)) goto fail;
         sp += mrb_re_charlen(sp, str_end, binary);
       }
       pc++;
@@ -848,21 +996,25 @@ bt_match(bt_state *m, const char *sp, uint32_t pc, int depth)
          empty: then there is only the exit, as at a marked RE_JMP. */
       if (inst.a) {
         if (inst.offset > pc) {
-          int r = bt_iter(m, sp, pc + 1, pc, depth + 1);
-          if (r != BT_FAIL) return r;
+          int rr = bt_iter(m, sp, pc + 1, pc, depth + 1);
+          if (rr != BT_FAIL) { r = rr; goto done; }
           pc = inst.offset;
           break;
         }
         if (ITER_EMPTY(m, pc, sp)) { pc++; break; }
-        int r = bt_match(m, sp, pc + 1, depth + 1);
-        if (r != BT_FAIL) return r;
-        return bt_iter(m, sp, inst.offset, pc, depth + 1);
+        {
+          int rr = bt_match(m, sp, pc + 1, depth + 1);
+          if (rr != BT_FAIL) { r = rr; goto done; }
+        }
+        {
+          int rr = bt_iter(m, sp, inst.offset, pc, depth + 1);
+          if (rr == BT_FAIL) goto fail;
+          r = rr;
+          goto done;
+        }
       }
-      {
-        int r = bt_match(m, sp, pc + 1, depth + 1);
-        if (r != BT_FAIL) return r;
-      }
-      pc = inst.offset;
+      if ((r = bt_push(m, sp, inst.offset)) != BT_OK) goto done;
+      pc++;
       break;
 
     case RE_SPLITNG:
@@ -872,21 +1024,25 @@ bt_match(bt_state *m, const char *sp, uint32_t pc, int depth)
          same. */
       if (inst.a) {
         if (inst.offset > pc) {
-          int r = bt_match(m, sp, inst.offset, depth + 1);
-          if (r != BT_FAIL) return r;
-          return bt_iter(m, sp, pc + 1, pc, depth + 1);
+          int rr = bt_match(m, sp, inst.offset, depth + 1);
+          if (rr != BT_FAIL) { r = rr; goto done; }
+          {
+            int rr2 = bt_iter(m, sp, pc + 1, pc, depth + 1);
+            if (rr2 == BT_FAIL) goto fail;
+            r = rr2;
+            goto done;
+          }
         }
         if (ITER_EMPTY(m, pc, sp)) { pc++; break; }
-        int r = bt_iter(m, sp, inst.offset, pc, depth + 1);
-        if (r != BT_FAIL) return r;
+        {
+          int rr = bt_iter(m, sp, inst.offset, pc, depth + 1);
+          if (rr != BT_FAIL) { r = rr; goto done; }
+        }
         pc++;
         break;
       }
-      {
-        int r = bt_match(m, sp, inst.offset, depth + 1);
-        if (r != BT_FAIL) return r;
-      }
-      pc++;
+      if ((r = bt_push(m, sp, pc + 1)) != BT_OK) goto done;
+      pc = inst.offset;
       break;
 
     case RE_SAVE:
@@ -897,7 +1053,7 @@ bt_match(bt_state *m, const char *sp, uint32_t pc, int depth)
            branches, so a longer one can still match. */
         if (slot == 1 && !binary && sp < str_end &&
             mrb_re_char_interior_p(str, sp, str_end)) {
-          return BT_FAIL;
+          goto fail;
         }
         if (slot < ncap) {
           /* An even slot opens its group, and the pair it heads is a span
@@ -915,42 +1071,44 @@ bt_match(bt_state *m, const char *sp, uint32_t pc, int depth)
           int old_end = opens ? captures[slot + 1] : 0;
           captures[slot] = (int)(sp - str);
           if (opens) captures[slot + 1] = -1;
-          int r = bt_match(m, sp, pc + 1, depth + 1);
-          if (r == BT_MATCH) return r;
+          int rr = bt_match(m, sp, pc + 1, depth + 1);
+          if (rr == BT_MATCH) return rr;
           /* undone for a cut as for a failure: the group the cut fails may
              be the one this slot was written inside */
           captures[slot] = old;
           if (opens) captures[slot + 1] = old_end;
-          return r;
+          if (rr == BT_FAIL) goto fail;
+          r = rr;
+          goto done;
         }
-        return BT_FAIL;
+        goto fail;
       }
 
     case RE_BOL:
       /* ^ always matches at a line start (see the Pike VM case); /m only
          affects `.`. \A is RE_BOT. A trailing \n opens no final line. */
-      if (sp != str && (sp == str_end || sp[-1] != '\n')) return BT_FAIL;
+      if (sp != str && (sp == str_end || sp[-1] != '\n')) goto fail;
       pc++;
       break;
 
     case RE_EOL:
       /* $ always matches at a line end. */
-      if (sp != str_end && *sp != '\n') return BT_FAIL;
+      if (sp != str_end && *sp != '\n') goto fail;
       pc++;
       break;
 
     case RE_BOT:
-      if (sp != str) return BT_FAIL;
+      if (sp != str) goto fail;
       pc++;
       break;
 
     case RE_EOT:
-      if (sp != str_end) return BT_FAIL;
+      if (sp != str_end) goto fail;
       pc++;
       break;
 
     case RE_EOTNL:
-      if (sp != str_end && !(sp + 1 == str_end && *sp == '\n')) return FALSE;
+      if (sp != str_end && !(sp + 1 == str_end && *sp == '\n')) goto fail;
       pc++;
       break;
 
@@ -958,7 +1116,7 @@ bt_match(bt_state *m, const char *sp, uint32_t pc, int depth)
       {
         mrb_bool before = (sp > str) && mrb_re_word_before(str, sp, str_end, binary);
         mrb_bool after = (sp < str_end) && mrb_re_word_at(sp, str_end, binary);
-        if (before == after) return BT_FAIL;
+        if (before == after) goto fail;
       }
       pc++;
       break;
@@ -967,7 +1125,7 @@ bt_match(bt_state *m, const char *sp, uint32_t pc, int depth)
       {
         mrb_bool before = (sp > str) && mrb_re_word_before(str, sp, str_end, binary);
         mrb_bool after = (sp < str_end) && mrb_re_word_at(sp, str_end, binary);
-        if (before != after) return BT_FAIL;
+        if (before != after) goto fail;
       }
       pc++;
       break;
@@ -975,21 +1133,21 @@ bt_match(bt_state *m, const char *sp, uint32_t pc, int depth)
     case RE_BACKREF:
       {
         int group = inst.a;
-        if (group * 2 + 1 >= ncap) return BT_FAIL;
+        if (group * 2 + 1 >= ncap) goto fail;
         int gs = captures[group * 2];
         int ge = captures[group * 2 + 1];
-        if (gs < 0 || ge < 0) return BT_FAIL;
+        if (gs < 0 || ge < 0) goto fail;
         int blen = ge - gs;
         if (inst.offset) {
           /* A folded comparison can consume a different number of bytes than
              the captured text holds, so the span is measured, not assumed. */
           int used = memcmp_ci(sp, str_end, str + gs, str + ge, binary);
-          if (used < 0) return BT_FAIL;
+          if (used < 0) goto fail;
           sp += used;
         }
         else {
-          if (sp + blen > str_end) return BT_FAIL;
-          if (memcmp(sp, str + gs, blen) != 0) return BT_FAIL;
+          if (sp + blen > str_end) goto fail;
+          if (memcmp(sp, str + gs, blen) != 0) goto fail;
           sp += blen;
         }
         pc++;
@@ -1000,16 +1158,21 @@ bt_match(bt_state *m, const char *sp, uint32_t pc, int depth)
       /* A positive lookaround never goes on in this frame: its RE_LOOK_END
          has run the text after it, so the sub-pattern's answer is the
          frame's, whichever it is. */
-      return bt_look(m, sp, sp, pc, pc + 1, depth + 1);
+      {
+        int rr = bt_look(m, sp, sp, pc, pc + 1, depth + 1);
+        if (rr == BT_FAIL) goto fail;
+        r = rr;
+        goto done;
+      }
 
     case RE_NEG_LOOKAHEAD:
       {
         /* The sub-pattern matching is the assertion failing; the sub-pattern
            running out of alternatives is the assertion holding, and the text
            after it goes on here. A limit goes up as it is. */
-        int r = bt_look(m, sp, sp, pc, pc + 1, depth + 1);
-        if (r == BT_MATCH) return BT_FAIL;
-        if (r != BT_FAIL) return r;
+        int rr = bt_look(m, sp, sp, pc, pc + 1, depth + 1);
+        if (rr == BT_MATCH) goto fail;
+        if (rr != BT_FAIL) { r = rr; goto done; }
         pc = inst.offset;
       }
       break;
@@ -1017,17 +1180,20 @@ bt_match(bt_state *m, const char *sp, uint32_t pc, int depth)
     case RE_LOOKBEHIND:
       {
         const char *back = lookbehind_start(pat, str, str_end, sp, pc, binary);
-        if (!back) return BT_FAIL;  /* not enough text before */
-        return bt_look(m, sp, back, pc, pc + 2, depth + 1);
+        if (!back) goto fail;  /* not enough text before */
+        int rr = bt_look(m, sp, back, pc, pc + 2, depth + 1);
+        if (rr == BT_FAIL) goto fail;
+        r = rr;
+        goto done;
       }
 
     case RE_NEG_LOOKBEHIND:
       {
         const char *back = lookbehind_start(pat, str, str_end, sp, pc, binary);
         if (back) {
-          int r = bt_look(m, sp, back, pc, pc + 2, depth + 1);
-          if (r == BT_MATCH) return BT_FAIL;
-          if (r != BT_FAIL) return r;
+          int rr = bt_look(m, sp, back, pc, pc + 2, depth + 1);
+          if (rr == BT_MATCH) goto fail;
+          if (rr != BT_FAIL) { r = rr; goto done; }
         }
         /* if not enough text before, negative lookbehind succeeds */
         pc = inst.offset;
@@ -1048,12 +1214,13 @@ bt_match(bt_state *m, const char *sp, uint32_t pc, int depth)
            it is. The text after runs in the pass the lookaround was entered
            from, which is what its loops' records are keyed by; the pass of
            this sub-pattern comes back for the frames above on the way up. */
-        if (inst.a) return BT_CUT(inst.offset);
+        if (inst.a) { r = BT_CUT(inst.offset); goto done; }
         int pass = m->pass;
         m->pass = m->entered_in[pc];
-        int r = bt_match(m, str + m->entered_at[pc], pc + 1, depth + 1);
+        int rr = bt_match(m, str + m->entered_at[pc], pc + 1, depth + 1);
         m->pass = pass;
-        return (r == BT_FAIL) ? BT_CUT(inst.offset) : r;
+        r = (rr == BT_FAIL) ? BT_CUT(inst.offset) : rr;
+        goto done;
       }
 
     case RE_ATOMIC:
@@ -1063,8 +1230,10 @@ bt_match(bt_state *m, const char *sp, uint32_t pc, int depth)
            here: the answer is passed up, except that a cut aimed at this
            group is this group failing, which the caller backtracks over the
            way it would any other failed atom. */
-        int r = bt_match(m, sp, pc + 1, depth + 1);
-        return (r == BT_CUT(inst.offset)) ? BT_FAIL : r;
+        int rr = bt_match(m, sp, pc + 1, depth + 1);
+        if (rr == BT_CUT(inst.offset) || rr == BT_FAIL) goto fail;
+        r = rr;
+        goto done;
       }
 
     case RE_ATOMIC_END:
@@ -1073,15 +1242,33 @@ bt_match(bt_state *m, const char *sp, uint32_t pc, int depth)
            when what follows fails, the failure is a cut, so that the SPLITs
            inside the body do not get to try their other branches. A limit
            is not the text failing and goes up as it is. */
-        int r = bt_match(m, sp, pc + 1, depth + 1);
-        return (r == BT_FAIL) ? BT_CUT(inst.offset) : r;
+        int rr = bt_match(m, sp, pc + 1, depth + 1);
+        r = (rr == BT_FAIL) ? BT_CUT(inst.offset) : rr;
+        goto done;
       }
 
     default:
-      return BT_FAIL;
+      goto fail;
+    }
+    continue;
+
+  fail:
+    /* This branch is spent. The next alternative is the choice point on top,
+       with every write since it was pushed taken back; below the floor is the
+       caller's state and the caller's alternatives, so there this frame is
+       spent too. */
+    if (m->cp_top == cp_floor) { r = BT_FAIL; goto done; }
+    {
+      re_cpoint c = m->cp[--m->cp_top];
+      bt_undo_to(m, c.undo_top);
+      sp = c.sp;
+      pc = c.pc;
     }
   }
-  return BT_FAIL;
+
+done:
+  if (r != BT_MATCH) bt_truncate(m, cp_floor, undo_floor);
+  return r;
 }
 
 static int
@@ -1099,7 +1286,9 @@ backtrack_exec(mrb_state *mrb, const mrb_regexp_pattern *pat,
      (see bt_iter() and bt_look()), so the arrays are filled once for all
      start positions. */
   int *caps = (int*)mrb_malloc(mrb, sizeof(int) * (ncap + 2 * pat->code_len));
+  int ret = 0;
   bt_state m;
+  m.mrb = mrb;
   m.pat = pat;
   m.str = str;
   m.str_end = str_end;
@@ -1109,6 +1298,10 @@ backtrack_exec(mrb_state *mrb, const mrb_regexp_pattern *pat,
   m.entered_in = m.entered_at + pat->code_len;
   m.pass = 0;
   m.binary = binary;
+  m.cp = NULL;
+  m.cp_top = m.cp_capa = 0;
+  m.undo = NULL;
+  m.undo_top = m.undo_capa = 0;
   memset(m.entered_at, -1, sizeof(int) * pat->code_len);
   memset(m.entered_in, 0, sizeof(int) * pat->code_len);
 
@@ -1129,6 +1322,12 @@ backtrack_exec(mrb_state *mrb, const mrb_regexp_pattern *pat,
     }
     memset(caps, -1, sizeof(int) * ncap);
     m.steps = 0;
+    /* The state of the attempt before, which failed and left nothing to
+       resume, is not this attempt's: the stacks start empty, and the writes
+       still logged are taken back so that the records the arrays hold are
+       what a fresh search finds. */
+    m.cp_top = 0;
+    bt_undo_to(&m, 0);
 
     int r = bt_match(&m, sp, 0, 0);
     if (r == BT_MATCH) {
@@ -1136,22 +1335,33 @@ backtrack_exec(mrb_state *mrb, const mrb_regexp_pattern *pat,
         int copy = ncap < captures_size ? ncap : captures_size;
         memcpy(captures, caps, sizeof(int) * copy);
       }
-      mrb_free(mrb, caps);
-      return ncap > 0 ? ncap : 1;
+      ret = ncap > 0 ? ncap : 1;
+      break;
+    }
+    if (r == BT_NOMEM) {
+      /* The allocator had nothing left for the state this search needed. The
+         search ends here as it does at a limit, and it is told apart from
+         one all the way out to the caller, since what it asks for is not a
+         knob turned up: raising MRB_REGEXP_STACK_LIMIT in answer to this
+         would only let the next search ask for more. */
+      ret = RE_NOMEM;
+      break;
     }
     if (r == BT_LIMIT) {
       /* The search ends here, not this start position's attempt: the
          positions after it answer where the first match is only once this
          one has none, which is what the limit left unanswered. Which limit
-         is read off the step count: the depth check runs before a frame
+         is read off the step count: the state checks run before a frame
          counts its step, so the count is over the step limit exactly when
          the step check gave up. */
-      mrb_free(mrb, caps);
-      return m.steps > MRB_REGEXP_STEP_LIMIT ? RE_OVER_STEP_LIMIT : RE_OVER_RECURSION_LIMIT;
+      ret = m.steps > MRB_REGEXP_STEP_LIMIT ? RE_OVER_STEP_LIMIT : RE_OVER_STACK_LIMIT;
+      break;
     }
   }
+  mrb_free(mrb, m.undo);
+  mrb_free(mrb, m.cp);
   mrb_free(mrb, caps);
-  return 0;
+  return ret;
 }
 
 /* Fast path for pure literal patterns: use memchr+memcmp, no NFA needed */
@@ -1264,10 +1474,11 @@ mrb_re_rexec(mrb_state *mrb, const mrb_regexp_pattern *pat,
     if (len - lo > RE_RSEARCH_PROBE_SPAN) break;
     memset(captures, -1, sizeof(int) * captures_size);
     last_n = exec_range(mrb, pat, str, len, lo, limit, captures, captures_size, binary);
-    /* A match or a limit ends the probe. A limit is the answer to the whole
-       question and not to this window's: a window that gave up is not one
-       with no match in it, and widening would only ask the same search
-       again a size up. */
+    /* A match or an execution error ends the probe. A limit, or an
+       allocation the engine was refused, is the answer to the whole question
+       and not to this window's: a window that gave up is not one with no
+       match in it, and widening would only ask the same search again a size
+       up. */
     if (last_n) break;
     /* The window had grown to the whole range, so there is no match to find
        and the search below would only ask again. */

--- a/mrbgems/mruby-regexp/src/re_exec.c
+++ b/mrbgems/mruby-regexp/src/re_exec.c
@@ -816,6 +816,29 @@ bt_push(bt_state *m, const char *sp, uint32_t pc)
   return BT_OK;
 }
 
+/* Write `val` into `slot`, logging what stood there so that backtracking
+   past this point puts it back. The answer is bt_push()'s, and means what it
+   means there: BT_OK is the write having happened, and BT_LIMIT or BT_NOMEM
+   is the search stopping, for the same two reasons and told apart for the
+   same one. */
+static int
+bt_log(bt_state *m, int *slot, int val)
+{
+  if (!bt_room(m)) return BT_LIMIT;
+  if (m->undo_top == m->undo_capa) {
+    uint32_t capa = bt_grow_capa(m->undo_capa);
+    re_undo *p = (re_undo*)mrb_realloc_simple(m->mrb, m->undo, sizeof(re_undo) * capa);
+    if (!p) return BT_NOMEM;
+    m->undo = p;
+    m->undo_capa = capa;
+  }
+  re_undo *u = &m->undo[m->undo_top++];
+  u->slot = slot;
+  u->old = *slot;
+  *slot = val;
+  return BT_OK;
+}
+
 /* Take back every write logged above `top`. */
 static void
 bt_undo_to(bt_state *m, uint32_t top)
@@ -900,12 +923,13 @@ bt_look(bt_state *m, const char *sp, const char *from, uint32_t pc,
  * Backtracking engine for patterns with backreferences.
  *
  * A fork pushes a choice point and goes on with its first branch; a failure
- * pops one and goes on with the alternative it holds. The frame therefore
- * loops where it used to recurse, and what it may pop is what it pushed: the
- * heights the stacks stood at on entry are the floor, since below them is the
- * state of the frame that called this one, whose captures and iteration
- * records that frame undoes itself. Every answer but BT_MATCH leaves the
- * stacks as the frame found them.
+ * pops one and goes on with the alternative it holds, taking back the writes
+ * logged since it was pushed. The frame therefore loops where it used to
+ * recurse, and what it may pop is what it pushed: the heights the stacks
+ * stood at on entry are the floor, since below them is the state of the
+ * frame that called this one, whose iteration records that frame restores
+ * itself. Every answer but BT_MATCH leaves the stacks as the frame found
+ * them.
  *
  * Step-limited to prevent ReDoS.
  */
@@ -1055,34 +1079,28 @@ bt_match(bt_state *m, const char *sp, uint32_t pc, int depth)
             mrb_re_char_interior_p(str, sp, str_end)) {
           goto fail;
         }
-        if (slot < ncap) {
-          /* An even slot opens its group, and the pair it heads is a span
-             only while the group is closed: clear the end slot with the
-             start, so that RE_BACKREF reads a group a repetition has just
-             re-entered the way it reads one never entered, instead of
-             pairing this iteration's start with the end of the one before:
-             an empty span where the two coincide, and a negative one where
-             the start is past it, which no closed group holds. CRuby
-             reads an open group as unmatched the same way (Onigmo's
-             STACK_PUSH_MEM_START invalidates the end with the start). The
-             end slot exists whenever the start does, ncap being even. */
-          mrb_bool opens = (slot & 1) == 0;
-          int old = captures[slot];
-          int old_end = opens ? captures[slot + 1] : 0;
-          captures[slot] = (int)(sp - str);
-          if (opens) captures[slot + 1] = -1;
-          int rr = bt_match(m, sp, pc + 1, depth + 1);
-          if (rr == BT_MATCH) return rr;
-          /* undone for a cut as for a failure: the group the cut fails may
-             be the one this slot was written inside */
-          captures[slot] = old;
-          if (opens) captures[slot + 1] = old_end;
-          if (rr == BT_FAIL) goto fail;
-          r = rr;
-          goto done;
-        }
-        goto fail;
+        if (slot >= ncap) goto fail;
+        /* The write is logged rather than recursed over: backtracking past
+           it puts the slot back, which is undone for a cut as for a failure
+           (the group a cut fails may be the one this slot was written
+           inside), and a match keeps it, the log unwinding for neither. */
+        if ((r = bt_log(m, &captures[slot], (int)(sp - str))) != BT_OK) goto done;
+        /* An even slot opens its group, and the pair it heads is a span
+           only while the group is closed: clear the end slot with the
+           start, so that RE_BACKREF reads a group a repetition has just
+           re-entered the way it reads one never entered, instead of
+           pairing this iteration's start with the end of the one before:
+           an empty span where the two coincide, and a negative one where
+           the start is past it, which no closed group holds. CRuby
+           reads an open group as unmatched the same way (Onigmo's
+           STACK_PUSH_MEM_START invalidates the end with the start). The
+           end slot exists whenever the start does, ncap being even. The
+           clear is logged too, so backtracking puts back the end the
+           iteration before it left. */
+        if ((slot & 1) == 0 && (r = bt_log(m, &captures[slot + 1], -1)) != BT_OK) goto done;
+        pc++;
       }
+      break;
 
     case RE_BOL:
       /* ^ always matches at a line start (see the Pike VM case); /m only

--- a/mrbgems/mruby-regexp/src/re_exec.c
+++ b/mrbgems/mruby-regexp/src/re_exec.c
@@ -628,42 +628,27 @@ lookbehind_start(const mrb_regexp_pattern *pat, const char *str,
   return sp;
 }
 
-/* What one bt_match() frame answers. The frame that reaches RE_MATCH answers
-   BT_MATCH, and every frame under it hands that up unchanged. A frame whose
-   alternatives are exhausted answers BT_FAIL; its alternatives are the choice
-   points it pushed on the stack the search shares, which it backtracks into
-   itself, and the branches it still recurses into, whose failure it reads
-   here. The third answer is the cut of an atomic group: the text after an
-   RE_ATOMIC_END has failed, and no alternative inside the group's body may be
-   tried for it, so the frames between that end and the RE_ATOMIC that opened
-   the group hand BT_CUT of the group's number up unchanged, undoing their
-   captures as they go, and the frame that ran that RE_ATOMIC turns it into
-   BT_FAIL. A lookaround runs its sub-pattern the same way, the text after it
-   going on inside the sub-pattern's frames from the RE_LOOK_END (see there),
-   so a cut can pass through one; the opener absorbs its own number like an
-   RE_ATOMIC and hands any other up.
-   The fourth answer, BT_LIMIT, is a frame giving up at one of the limits, and
-   the fifth, BT_NOMEM, is the allocator having refused the state a frame
-   needed. Both are the search's answer rather than the frame's: every frame
-   hands them up unchanged, as it does a cut, and backtrack_exec() stops at
-   them (see there). Neither says anything about the text, so no frame may
-   read one as its branch having failed and answer with its other branch,
-   which would be answering a smaller question with whatever the alternatives
-   inside the limit produce: a shorter, a later or no match, told from the
-   real answer by nothing. They stay apart from each other for the same
-   reason they stay apart from a failure: what a limit asks of the build is
-   that MRB_REGEXP_STACK_LIMIT be turned up, which is the worst thing it
-   could do about an allocator that had nothing left to give.
+/* What one bt_match() call answers. BT_MATCH is the search having reached
+   RE_MATCH, BT_FAIL is every alternative it held having been tried, BT_LIMIT
+   is the search giving up at one of the limits before it had either, and
+   BT_NOMEM is the allocator having refused the state it needed. Neither of
+   the last two says anything about the text, so neither is read as a branch
+   having failed and answered from the alternatives left: that would be
+   answering a smaller question with whatever they produce: a shorter match, a
+   later one or none, told from the real answer by nothing. backtrack_exec()
+   stops the whole search at either (see there), and tells the two apart
+   there, since what a limit asks of the build is that MRB_REGEXP_STACK_LIMIT
+   be turned up, which is the worst thing it could do about an allocator that
+   had nothing left to give.
 
-   BT_OK is not one of bt_match()'s answers. It is what bt_push() and the
-   other operations on the stacks answer when there is nothing to hand up,
-   so that what they answer otherwise is the frame's answer as it stands. */
+   BT_OK is not one of bt_match()'s answers. It is what bt_push(), bt_log()
+   and bt_iter_begin() answer when there is nothing to hand up, so that what
+   they answer otherwise is bt_match()'s answer as it stands. */
 #define BT_FAIL 0
 #define BT_MATCH 1
 #define BT_LIMIT 2
 #define BT_NOMEM 3
 #define BT_OK 4
-#define BT_CUT(cut) (-(int)(cut))
 
 /* What taking a choice point does beyond resuming where it points. */
 enum re_cp_kind {
@@ -671,11 +656,16 @@ enum re_cp_kind {
   RE_CP_ITER,   /* the branch begins an iteration of the loop its `group`
                    keys, whose record is written when the branch is taken
                    rather than when it was pushed (see bt_iter_begin()) */
-  RE_CP_BARRIER /* not a branch at all: where the group its `group` names was
-                 entered. Reaching it while backtracking is that group
-                 failing, so it resumes nothing and the search goes on
-                 popping; its end drops it and everything above it, which is
-                 how an atomic group cuts (see RE_ATOMIC_END). */
+  RE_CP_BARRIER,/* not a branch at all: where the group its `group` names was
+                   entered. Reaching it while backtracking is that group
+                   failing, so it resumes nothing and the search goes on
+                   popping; its end drops it and everything above it, which is
+                   how an atomic group and a positive lookaround cut (see
+                   RE_ATOMIC_END and RE_LOOK_END). */
+  RE_CP_NEG     /* the barrier of a negative lookaround, which is both: its
+                   sub-pattern running out of alternatives is the assertion
+                   holding, so reaching it resumes the text after the
+                   lookaround, at the sp and pc it holds. */
 };
 
 /* A choice point: an alternative the search has not tried yet, as where the
@@ -692,6 +682,10 @@ typedef struct {
   uint32_t pc;
   uint32_t undo_top;
   uint32_t group;   /* what `kind` names, where it names something */
+  int pass;         /* the pass it was pushed in, which is the pass the
+                       branch it holds runs in; for a lookaround's barrier
+                       that is the pass the lookaround was entered from, and
+                       the sub-pattern above it runs in one of its own */
   uint8_t kind;
 } re_cpoint;
 
@@ -733,27 +727,24 @@ typedef struct {
      for e* (the SPLIT/SPLITNG whose offset is the exit; the JMP closing the
      body reads the record) and its marked back edge for e+ (the
      SPLIT/SPLITNG at the end of the body, which both writes and reads it);
-     see mark_empty_loops(). For the RE_LOOK_END of a lookaround it is where
-     the lookaround was entered, which is where the text after it goes on
-     from; see bt_look(). */
+     see mark_empty_loops(). */
   int *entered_at;
   /* Per pc, the pass that wrote entered_at[pc]. A pass is one run of a
-     lookaround's sub-pattern, told by the depth of the bt_look() frame
-     running it, and 0 is the pattern outside every lookaround; `pass` is the
-     one the frames now running are in. A record is read as the running
-     iteration's only by the pass that wrote it: the text after a positive
-     lookaround runs inside its sub-pattern's frames (see RE_LOOK_END), so a
-     repetition around the lookaround re-enters the sub-pattern while the
-     records of the loops inside it from the pass before are still live, and
-     the first iteration of an e+, which reads its record without having
-     written it, would take one of those for its own where the positions
-     coincide: `(?=(b|)+)+` on "b" re-enters at 0 while the pass before left
-     1 for `(b|)+`, and its first iteration, ending at 1, would stop there
-     with "b" captured, where a fresh pass goes round once more and leaves
-     "". For the RE_LOOK_END the record is the pass the lookaround was entered
-     from, which the text after it runs in. */
+     lookaround's sub-pattern, numbered from `pass_seq` so that no two runs
+     share one, and 0 is the pattern outside every lookaround; `pass` is the
+     one the search is in. A record is read as the running iteration's only
+     by the pass that wrote it: what a positive lookaround captured outlives
+     it, and so do the records of the loops inside it, the undo log not
+     unwinding at its end, so a repetition around the lookaround re-enters
+     the sub-pattern with the records of the run before still live. The first
+     iteration of an e+, which reads its record without having written it,
+     would take one of those for its own where the positions coincide:
+     `(?=(b|)+)+` on "b" re-enters at 0 while the run before left 1 for
+     `(b|)+`, and its first iteration, ending at 1, would stop there with "b"
+     captured, where a fresh pass goes round once more and leaves "". */
   int *entered_in;
   int pass;
+  int pass_seq;
   mrb_bool binary;
   /* The choice points not yet tried and the writes not yet taken back, both
      grown lazily on the heap. A search starts with neither allocated and
@@ -829,6 +820,7 @@ bt_push(bt_state *m, const char *sp, uint32_t pc, uint8_t kind, uint32_t group)
   c->pc = pc;
   c->undo_top = m->undo_top;
   c->group = group;
+  c->pass = m->pass;
   c->kind = kind;
   return BT_OK;
 }
@@ -877,40 +869,25 @@ bt_truncate(bt_state *m, uint32_t cp_top, uint32_t undo_top)
 }
 
 /* Where the group `group` was entered, as an index into the choice point
-   stack, or FALSE when it was entered in a frame below `floor`: a group
-   whose body holds a lookaround, whose end runs inside the frames the
-   lookaround makes, and which the cut still reaches instead (see
-   bt_cut_absorb()). Barriers nest, so the walk down from the top is over
-   what the group's end is about to drop in any case. */
+   stack. Barriers nest and a group's end runs while its own is the innermost
+   still standing, so the walk down from the top is over what that end is
+   about to drop in any case. FALSE is a group's end reached without its
+   opener, which a compiled pattern does not hold; the search reads it as a
+   failure rather than trusting an index. */
 static mrb_bool
 bt_barrier_find(const bt_state *m, uint32_t group, uint32_t floor, uint32_t *idx)
 {
   uint32_t i = m->cp_top;
   while (i > floor) {
     i--;
-    if (m->cp[i].kind == RE_CP_BARRIER && m->cp[i].group == group) {
+    if ((m->cp[i].kind == RE_CP_BARRIER || m->cp[i].kind == RE_CP_NEG) &&
+        m->cp[i].group == group) {
       *idx = i;
       return TRUE;
     }
   }
   return FALSE;
 }
-
-/* Whether a nested call's answer is the cut of a group this frame opened,
-   which is that group failing here: everything the body left goes, the writes
-   it logged with it, which is what popping its barrier does. Any other answer
-   is not this frame's to read. */
-static mrb_bool
-bt_cut_absorb(bt_state *m, int r, uint32_t floor)
-{
-  uint32_t idx;
-  if (r >= 0 || !bt_barrier_find(m, (uint32_t)(-r), floor, &idx)) return FALSE;
-  m->cp_top = idx;
-  bt_undo_to(m, m->cp[idx].undo_top);
-  return TRUE;
-}
-
-static int bt_match(bt_state *m, const char *sp, uint32_t pc, int depth);
 
 /* Record that an iteration of the loop `key` keys begins at sp, so that the
    edge closing the body can tell an iteration that matched empty. The two
@@ -923,45 +900,6 @@ bt_iter_begin(bt_state *m, uint32_t key, const char *sp)
 {
   int r = bt_log(m, &m->entered_at[key], (int)(sp - m->str));
   return r != BT_OK ? r : bt_log(m, &m->entered_in[key], m->pass);
-}
-
-/* Run the sub-pattern of the lookaround whose opener is at pc: it begins at
-   `body` and matches from `from`, which is sp for a lookahead and the
-   rewound start for a lookbehind. The record of sp, and of the pass the
-   lookaround is entered from, lasts as long as the frame, as an iteration's
-   does in bt_iter_begin(); the RE_LOOK_END closing the sub-pattern reads it (see
-   there). The sub-pattern runs as a pass of its own, this frame's depth,
-   which no pass still live has, so the records of the loops inside it that
-   another run of the same sub-pattern may have left live are not taken for
-   this run's (see bt_state).
-
-   The answer is the sub-pattern's, and the cut of this lookaround's number
-   is what the sub-pattern matching comes back as: for a negative lookaround
-   from the RE_LOOK_END itself, and the answer is BT_MATCH, with every
-   capture the sub-pattern wrote undone on the way up; for a positive one
-   from the text after the lookaround failing, which the RE_LOOK_END ran
-   inside the sub-pattern's frames, so the sub-pattern matched once and that
-   was its only match: BT_FAIL, the captures undone the same way. BT_MATCH
-   from a positive one is the whole pattern having matched through that
-   text. Everything else, a failure, a limit or another group's cut, goes up
-   as it is. */
-static int
-bt_look(bt_state *m, const char *sp, const char *from, uint32_t pc,
-        uint32_t body, int depth)
-{
-  uint32_t end = m->pat->code[pc].offset - 1;
-  re_inst end_inst = m->pat->code[end];
-  int old_at = m->entered_at[end], old_in = m->entered_in[end];
-  int old_pass = m->pass;
-  m->entered_at[end] = (int)(sp - m->str);
-  m->entered_in[end] = old_pass;
-  m->pass = depth;
-  int r = bt_match(m, from, body, depth);
-  m->pass = old_pass;
-  m->entered_at[end] = old_at;
-  m->entered_in[end] = old_in;
-  if (r != BT_CUT(end_inst.offset)) return r;
-  return end_inst.a ? BT_MATCH : BT_FAIL;
 }
 
 /*
@@ -1204,74 +1142,71 @@ bt_match(bt_state *m, const char *sp, uint32_t pc, int depth)
       break;
 
     case RE_LOOKAHEAD:
-      /* A positive lookaround never goes on in this frame: its RE_LOOK_END
-         has run the text after it, so the sub-pattern's answer is the
-         frame's, whichever it is. */
-      {
-        int rr = bt_look(m, sp, sp, pc, pc + 1, depth + 1);
-        if (rr == BT_FAIL || bt_cut_absorb(m, rr, cp_floor)) goto fail;
-        r = rr;
-        goto done;
-      }
-
-    case RE_NEG_LOOKAHEAD:
-      {
-        /* The sub-pattern matching is the assertion failing; the sub-pattern
-           running out of alternatives is the assertion holding, and the text
-           after it goes on here. A limit goes up as it is. */
-        int rr = bt_look(m, sp, sp, pc, pc + 1, depth + 1);
-        if (rr == BT_MATCH || bt_cut_absorb(m, rr, cp_floor)) goto fail;
-        if (rr != BT_FAIL) { r = rr; goto done; }
-        pc = inst.offset;
-      }
-      break;
-
     case RE_LOOKBEHIND:
-      {
-        const char *back = lookbehind_start(pat, str, str_end, sp, pc, binary);
-        if (!back) goto fail;  /* not enough text before */
-        int rr = bt_look(m, sp, back, pc, pc + 2, depth + 1);
-        if (rr == BT_FAIL || bt_cut_absorb(m, rr, cp_floor)) goto fail;
-        r = rr;
-        goto done;
-      }
-
+    case RE_NEG_LOOKAHEAD:
     case RE_NEG_LOOKBEHIND:
       {
-        const char *back = lookbehind_start(pat, str, str_end, sp, pc, binary);
-        if (back) {
-          int rr = bt_look(m, sp, back, pc, pc + 2, depth + 1);
-          if (rr == BT_MATCH || bt_cut_absorb(m, rr, cp_floor)) goto fail;
-          if (rr != BT_FAIL) { r = rr; goto done; }
+        /* The lookaround is entered: a barrier stands where it began, and
+           the sub-pattern goes on from here, from sp for a lookahead, from
+           the rewound start for a lookbehind. What the barrier holds is
+           where the text after the lookaround goes on from and the pass to
+           go on in; for a negative one that is what taking the barrier
+           resumes, its sub-pattern running out of alternatives being the
+           assertion holding. The sub-pattern runs as a pass of its own, one
+           no run before it had, so the records of the loops inside it that
+           an earlier run may have left live are not taken for this run's
+           (see bt_state). */
+        mrb_bool negated = (inst.op == RE_NEG_LOOKAHEAD || inst.op == RE_NEG_LOOKBEHIND);
+        const char *from = sp;
+        uint32_t body = pc + 1;
+        if (inst.op == RE_LOOKBEHIND || inst.op == RE_NEG_LOOKBEHIND) {
+          from = lookbehind_start(pat, str, str_end, sp, pc, binary);
+          if (!from) {
+            /* not enough text before: a positive lookbehind cannot hold and
+               a negative one holds without a sub-pattern to run */
+            if (!negated) goto fail;
+            pc = inst.offset;
+            break;
+          }
+          body = pc + 2;
         }
-        /* if not enough text before, negative lookbehind succeeds */
-        pc = inst.offset;
+        if ((r = bt_push(m, sp, inst.offset, negated ? RE_CP_NEG : RE_CP_BARRIER,
+                         pat->code[inst.offset - 1].offset)) != BT_OK) {
+          goto done;
+        }
+        m->pass = ++m->pass_seq;
+        sp = from;
+        pc = body;
       }
       break;
 
     case RE_LOOK_END:
       {
-        /* The sub-pattern has matched. For a negative lookaround that is
-           the whole of its answer, and it goes up as a cut so that the
-           frames of the sub-pattern undo their captures and try no other
-           branch on the way; bt_look() reads it back as the match it is.
-           For a positive one the text after the lookaround goes on from
-           where the lookaround was entered, inside the sub-pattern's frames
-           as the text after an atomic group does (RE_ATOMIC_END): a failure
-           there is a cut, undone for and not backtracked into, since the
-           sub-pattern matching once is its only match. A limit goes up as
-           it is. The text after runs in the pass the lookaround was entered
-           from, which is what its loops' records are keyed by; the pass of
-           this sub-pattern comes back for the frames above on the way up. */
-        if (inst.a) { r = BT_CUT(inst.offset); goto done; }
-        int pass = m->pass;
-        m->pass = m->entered_in[pc];
-        int rr = bt_match(m, str + m->entered_at[pc], pc + 1, depth + 1);
-        m->pass = pass;
-        if (bt_cut_absorb(m, rr, cp_floor)) goto fail;
-        r = (rr == BT_FAIL) ? BT_CUT(inst.offset) : rr;
-        goto done;
+        /* The sub-pattern has matched, and that is the whole of what the
+           lookaround asks of it: no alternative inside it may be tried for
+           the text after, so its choice points go, barrier and all, as an
+           atomic group's do. A positive one goes on with the text after from
+           where it was entered, and what the sub-pattern captured stays --
+           the undo log is left alone, and a failure that goes back past
+           where the lookaround began takes it back with everything else
+           logged since. A negative one is the assertion failing: the log
+           unwinds to where the lookaround began, so what the sub-pattern
+           captured goes with it, and the search backtracks. Either way the
+           pass the lookaround was entered from comes back with the
+           barrier. */
+        uint32_t idx;
+        if (!bt_barrier_find(m, inst.offset, cp_floor, &idx)) goto fail;
+        re_cpoint c = m->cp[idx];
+        m->cp_top = idx;
+        m->pass = c.pass;
+        if (inst.a) {
+          bt_undo_to(m, c.undo_top);
+          goto fail;
+        }
+        sp = c.sp;
+        pc++;
       }
+      break;
 
     case RE_ATOMIC:
       /* The group is entered: a barrier stands where it began, so that a
@@ -1290,21 +1225,11 @@ bt_match(bt_state *m, const char *sp, uint32_t pc, int depth)
            failure that goes back past where the group began takes it back
            along with everything else logged since. */
         uint32_t idx;
-        if (bt_barrier_find(m, inst.offset, cp_floor, &idx)) {
-          m->cp_top = idx;
-          pc++;
-          break;
-        }
-        /* The group was entered in a frame below this one, whose choice
-           points this one may not touch. The text after it runs inside this
-           frame instead, as it did before the barrier: a failure there is
-           the cut, which reaches the barrier through the frames between
-           (see bt_cut_absorb()), and a limit is not the text failing and
-           goes up as it is. */
-        int rr = bt_match(m, sp, pc + 1, depth + 1);
-        r = (rr == BT_FAIL) ? BT_CUT(inst.offset) : rr;
-        goto done;
+        if (!bt_barrier_find(m, inst.offset, cp_floor, &idx)) goto fail;
+        m->cp_top = idx;
+        pc++;
       }
+      break;
 
     default:
       goto fail;
@@ -1320,8 +1245,15 @@ bt_match(bt_state *m, const char *sp, uint32_t pc, int depth)
       if (m->cp_top == cp_floor) { r = BT_FAIL; goto done; }
       re_cpoint c = m->cp[--m->cp_top];
       bt_undo_to(m, c.undo_top);
-      /* A barrier is where a group was entered, not a branch: reaching it
-         is that group failing, and what is left to try is below it. */
+      /* The pass a branch was pushed in is the pass it runs in, and for a
+         lookaround's barrier it is the pass the lookaround was entered
+         from, which is where the search is once the barrier is taken. */
+      m->pass = c.pass;
+      /* A barrier is where a group was entered, not a branch: reaching it is
+         that group failing, and what is left to try is below it. A negative
+         lookaround's is the exception: its sub-pattern having no match
+         left is the assertion holding, and what it resumes is the text after
+         the lookaround. */
       if (c.kind == RE_CP_BARRIER) continue;
       sp = c.sp;
       pc = c.pc;
@@ -1365,6 +1297,7 @@ backtrack_exec(mrb_state *mrb, const mrb_regexp_pattern *pat,
   m.entered_at = caps + ncap;
   m.entered_in = m.entered_at + pat->code_len;
   m.pass = 0;
+  m.pass_seq = 0;
   m.binary = binary;
   m.cp = NULL;
   m.cp_top = m.cp_capa = 0;

--- a/mrbgems/mruby-regexp/src/re_exec.c
+++ b/mrbgems/mruby-regexp/src/re_exec.c
@@ -665,6 +665,14 @@ lookbehind_start(const mrb_regexp_pattern *pat, const char *str,
 #define BT_OK 4
 #define BT_CUT(cut) (-(int)(cut))
 
+/* What taking a choice point does beyond resuming where it points. */
+enum re_cp_kind {
+  RE_CP_FORK,   /* nothing: a branch the search has not tried yet */
+  RE_CP_ITER    /* the branch begins an iteration of the loop its `group`
+                   keys, whose record is written when the branch is taken
+                   rather than when it was pushed (see bt_iter_begin()) */
+};
+
 /* A choice point: an alternative the search has not tried yet, as where the
    input stood (`sp`), which instruction takes the alternative (`pc`) and how
    tall the undo log was when it was pushed (`undo_top`). Backtracking pops
@@ -678,6 +686,8 @@ typedef struct {
   const char *sp;
   uint32_t pc;
   uint32_t undo_top;
+  uint32_t group;   /* what `kind` names, where it names something */
+  uint8_t kind;
 } re_cpoint;
 
 /* An undo record: one write the search must be able to take back, as the slot
@@ -799,7 +809,7 @@ bt_grow_capa(uint32_t capa)
    mrb_realloc() is what lets a refusal be an answer at all, a raising
    allocator longjmping past the mrb_free() in backtrack_exec(). */
 static int
-bt_push(bt_state *m, const char *sp, uint32_t pc)
+bt_push(bt_state *m, const char *sp, uint32_t pc, uint8_t kind, uint32_t group)
 {
   if (!bt_room(m)) return BT_LIMIT;
   if (m->cp_top == m->cp_capa) {
@@ -813,6 +823,8 @@ bt_push(bt_state *m, const char *sp, uint32_t pc)
   c->sp = sp;
   c->pc = pc;
   c->undo_top = m->undo_top;
+  c->group = group;
+  c->kind = kind;
   return BT_OK;
 }
 
@@ -861,30 +873,24 @@ bt_truncate(bt_state *m, uint32_t cp_top, uint32_t undo_top)
 
 static int bt_match(bt_state *m, const char *sp, uint32_t pc, int depth);
 
-/* Run the frame at pc as the start of an iteration of the loop `key` keys,
-   recording where it begins so that the edge closing the body can tell an
-   empty iteration. The record lasts exactly as long as the frame: the frame
-   that ran the edge into the body is the one that undoes it, so backtracking
-   out of an iteration finds the record of the one it lands in, and the
-   branch that begins an iteration is run this way rather than in place even
-   when it is the frame's last, so that there is one place to undo it. */
+/* Record that an iteration of the loop `key` keys begins at sp, so that the
+   edge closing the body can tell an iteration that matched empty. The two
+   records go on the undo log, so that backtracking out of an iteration puts
+   back the record of the one it lands in; the branch that begins an
+   iteration is written this way rather than in place when it is taken, so
+   that there is one place that writes them. */
 static int
-bt_iter(bt_state *m, const char *sp, uint32_t pc, uint32_t key, int depth)
+bt_iter_begin(bt_state *m, uint32_t key, const char *sp)
 {
-  int old_at = m->entered_at[key], old_in = m->entered_in[key];
-  m->entered_at[key] = (int)(sp - m->str);
-  m->entered_in[key] = m->pass;
-  int r = bt_match(m, sp, pc, depth);
-  m->entered_at[key] = old_at;
-  m->entered_in[key] = old_in;
-  return r;
+  int r = bt_log(m, &m->entered_at[key], (int)(sp - m->str));
+  return r != BT_OK ? r : bt_log(m, &m->entered_in[key], m->pass);
 }
 
 /* Run the sub-pattern of the lookaround whose opener is at pc: it begins at
    `body` and matches from `from`, which is sp for a lookahead and the
    rewound start for a lookbehind. The record of sp, and of the pass the
    lookaround is entered from, lasts as long as the frame, as an iteration's
-   does in bt_iter(); the RE_LOOK_END closing the sub-pattern reads it (see
+   does in bt_iter_begin(); the RE_LOOK_END closing the sub-pattern reads it (see
    there). The sub-pattern runs as a pass of its own, this frame's depth,
    which no pass still live has, so the records of the loops inside it that
    another run of the same sub-pattern may have left live are not taken for
@@ -1000,11 +1006,11 @@ bt_match(bt_state *m, const char *sp, uint32_t pc, int depth)
 
     case RE_JMP:
       /* A backward jump closes e* and returns to its head. When the head is
-         marked, the body can match empty and entered_at[head] holds where the
-         iteration that just ended began (see bt_iter()): an iteration that
-         ended where it began matched empty, and the repetition stops here,
-         taking the head's exit and keeping what the iteration captured, as
-         Onigmo's null check does. */
+         marked, the body can match empty and entered_at[head] holds where
+         the iteration that just ended began (see bt_iter_begin()): an
+         iteration that ended where it began matched empty, and the
+         repetition stops here, taking the head's exit and keeping what the
+         iteration captured, as Onigmo's null check does. */
       if (inst.a && ITER_EMPTY(m, inst.offset, sp)) {
         pc = pat->code[inst.offset].offset;
         break;
@@ -1020,24 +1026,17 @@ bt_match(bt_state *m, const char *sp, uint32_t pc, int depth)
          empty: then there is only the exit, as at a marked RE_JMP. */
       if (inst.a) {
         if (inst.offset > pc) {
-          int rr = bt_iter(m, sp, pc + 1, pc, depth + 1);
-          if (rr != BT_FAIL) { r = rr; goto done; }
-          pc = inst.offset;
+          if ((r = bt_push(m, sp, inst.offset, RE_CP_FORK, 0)) != BT_OK ||
+              (r = bt_iter_begin(m, pc, sp)) != BT_OK) goto done;
+          pc++;
           break;
         }
         if (ITER_EMPTY(m, pc, sp)) { pc++; break; }
-        {
-          int rr = bt_match(m, sp, pc + 1, depth + 1);
-          if (rr != BT_FAIL) { r = rr; goto done; }
-        }
-        {
-          int rr = bt_iter(m, sp, inst.offset, pc, depth + 1);
-          if (rr == BT_FAIL) goto fail;
-          r = rr;
-          goto done;
-        }
+        if ((r = bt_push(m, sp, inst.offset, RE_CP_ITER, pc)) != BT_OK) goto done;
+        pc++;
+        break;
       }
-      if ((r = bt_push(m, sp, inst.offset)) != BT_OK) goto done;
+      if ((r = bt_push(m, sp, inst.offset, RE_CP_FORK, 0)) != BT_OK) goto done;
       pc++;
       break;
 
@@ -1048,24 +1047,17 @@ bt_match(bt_state *m, const char *sp, uint32_t pc, int depth)
          same. */
       if (inst.a) {
         if (inst.offset > pc) {
-          int rr = bt_match(m, sp, inst.offset, depth + 1);
-          if (rr != BT_FAIL) { r = rr; goto done; }
-          {
-            int rr2 = bt_iter(m, sp, pc + 1, pc, depth + 1);
-            if (rr2 == BT_FAIL) goto fail;
-            r = rr2;
-            goto done;
-          }
+          if ((r = bt_push(m, sp, pc + 1, RE_CP_ITER, pc)) != BT_OK) goto done;
+          pc = inst.offset;
+          break;
         }
         if (ITER_EMPTY(m, pc, sp)) { pc++; break; }
-        {
-          int rr = bt_iter(m, sp, inst.offset, pc, depth + 1);
-          if (rr != BT_FAIL) { r = rr; goto done; }
-        }
-        pc++;
+        if ((r = bt_push(m, sp, pc + 1, RE_CP_FORK, 0)) != BT_OK ||
+            (r = bt_iter_begin(m, pc, sp)) != BT_OK) goto done;
+        pc = inst.offset;
         break;
       }
-      if ((r = bt_push(m, sp, pc + 1)) != BT_OK) goto done;
+      if ((r = bt_push(m, sp, pc + 1, RE_CP_FORK, 0)) != BT_OK) goto done;
       pc = inst.offset;
       break;
 
@@ -1281,6 +1273,9 @@ bt_match(bt_state *m, const char *sp, uint32_t pc, int depth)
       bt_undo_to(m, c.undo_top);
       sp = c.sp;
       pc = c.pc;
+      if (c.kind == RE_CP_ITER && (r = bt_iter_begin(m, c.group, sp)) != BT_OK) {
+        goto done;
+      }
     }
   }
 
@@ -1300,9 +1295,11 @@ backtrack_exec(mrb_state *mrb, const mrb_regexp_pattern *pat,
   if (ncap == 0) ncap = 2;
 
   /* One block: the capture slots, then an entry record per pc and the pass
-     that wrote it. Every record a search writes it undoes before returning
-     (see bt_iter() and bt_look()), so the arrays are filled once for all
-     start positions. */
+     that wrote it. The arrays are filled once here and put back to what they
+     hold by the undo log unwinding between start positions (see there): an
+     iteration's record is written on the log now, which a match does not
+     unwind, so a record left by the attempt before would otherwise be read
+     as this attempt's and stop a repetition that had not gone round yet. */
   int *caps = (int*)mrb_malloc(mrb, sizeof(int) * (ncap + 2 * pat->code_len));
   int ret = 0;
   bt_state m;

--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -369,17 +369,25 @@ match_operand(mrb_state *mrb, mrb_value obj)
   return mrb_ensure_string_type(mrb, obj);
 }
 
-/* Raise if the search answered RE_OVER_*_LIMIT (see mrb_re_exec()): it gave
-   up at a limit, and what it had found by then is not a shorter or a later
-   match, so the caller raises rather than read it as one. Every caller holds
-   its capture buffer on the stack, so the raise strands nothing. */
+/* Raise if the search stopped before it had an answer (see mrb_re_exec()):
+   what it had found by then is not a shorter or a later match, so the caller
+   raises rather than read it as one. Every caller holds its capture buffer on
+   the stack, so the raise strands nothing.
+
+   A limit and a refused allocation raise different classes, since what they
+   ask of the program differs: a build answers a limit by turning the knob the
+   message names, where turning MRB_REGEXP_STACK_LIMIT up in answer to an
+   allocator with nothing left would only let the next search ask for more.
+   NoMemoryError is thrown by the object mruby keeps for it, so the raise
+   itself asks for nothing. */
 static void
-re_check_over_limit(mrb_state *mrb, int n)
+re_check_exec_error(mrb_state *mrb, int n)
 {
   if (n >= 0) return;
+  if (n == RE_NOMEM) mrb_raise_nomemory(mrb);
   mrb_raise(mrb, E_REGEXP_ERROR, n == RE_OVER_STEP_LIMIT
             ? "step limit over (MRB_REGEXP_STEP_LIMIT)"
-            : "recursion limit over (MRB_REGEXP_RECURSION_LIMIT)");
+            : "stack limit over (MRB_REGEXP_STACK_LIMIT)");
 }
 
 /* Internal: execute match and create MatchData.
@@ -396,7 +404,7 @@ exec_match(mrb_state *mrb, mrb_value self, mrb_value str, mrb_int pos)
   memset(captures, -1, sizeof(int) * cap_size);
   int ncap = mrb_re_exec(mrb, pat, RSTRING_PTR(str), RSTRING_LEN(str), pos,
                      captures, cap_size, re_binary_string_p(str));
-  re_check_over_limit(mrb, ncap);
+  re_check_exec_error(mrb, ncap);
 
   if (ncap == 0) {
     clear_match_globals(mrb);
@@ -579,7 +587,7 @@ regexp_s_byte_rsearch(mrb_state *mrb, mrb_value klass)
   int captures[RE_MAX_CAPTURES * 2];
   int ncap = mrb_re_rexec(mrb, pat, RSTRING_PTR(str), RSTRING_LEN(str), limit,
                           captures, cap_size, re_binary_string_p(str));
-  re_check_over_limit(mrb, ncap);
+  re_check_exec_error(mrb, ncap);
   if (ncap == 0) {
     clear_match_globals(mrb);
     return mrb_nil_value();
@@ -604,7 +612,7 @@ exec_match_p(mrb_state *mrb, mrb_value re, mrb_value str, mrb_int pos)
 
   int ncap = mrb_re_exec(mrb, pat, RSTRING_PTR(str), RSTRING_LEN(str), pos, NULL, 0,
                          re_binary_string_p(str));
-  re_check_over_limit(mrb, ncap);
+  re_check_exec_error(mrb, ncap);
   return mrb_bool_value(ncap > 0);
 }
 
@@ -1470,7 +1478,7 @@ regexp_s_gsub_str(mrb_state *mrb, mrb_value klass)
   while (pos <= slen) {
     memset(captures, -1, sizeof(int) * cap_size);
     int n = mrb_re_exec(mrb, pat, s, slen, pos, captures, cap_size, binary);
-    re_check_over_limit(mrb, n);
+    re_check_exec_error(mrb, n);
     if (n == 0) break;
 
     /* save last match for $~ */
@@ -1553,7 +1561,7 @@ regexp_s_sub_str(mrb_state *mrb, mrb_value klass)
   memset(captures, -1, sizeof(int) * cap_size);
 
   int n = mrb_re_exec(mrb, pat, s, slen, 0, captures, cap_size, re_binary_string_p(str));
-  re_check_over_limit(mrb, n);
+  re_check_exec_error(mrb, n);
   if (n == 0) {
     clear_match_globals(mrb);
     return mrb_str_dup(mrb, str);
@@ -1827,7 +1835,7 @@ regexp_s_gsub_block(mrb_state *mrb, mrb_value klass)
   while (pos <= slen) {
     memset(captures, -1, sizeof(int) * cap_size);
     int n = mrb_re_exec(mrb, pat, s, slen, pos, captures, cap_size, binary);
-    re_check_over_limit(mrb, n);
+    re_check_exec_error(mrb, n);
     if (n == 0) break;
     mrb_int beg = captures[0], end = captures[1];
 
@@ -1927,7 +1935,7 @@ regexp_s_scan(mrb_state *mrb, mrb_value klass)
   while (pos <= slen) {
     memset(captures, -1, sizeof(int) * cap_size);
     int n = mrb_re_exec(mrb, pat, s, slen, pos, captures, cap_size, binary);
-    re_check_over_limit(mrb, n);
+    re_check_exec_error(mrb, n);
     if (n == 0) break;
 
     last_ncap = cap_size;
@@ -2152,7 +2160,7 @@ mrb_mruby_regexp_gem_init(mrb_state *mrb)
   /* The two limits of the backtracking engine, which a build sets (see
      re_internal.h) and a `RegexpError` names: the value behind the name, for
      whoever has to size a subject or a pattern to the build it runs on. */
-  mrb_define_const(mrb, re, "RECURSION_LIMIT", mrb_int_value(mrb, MRB_REGEXP_RECURSION_LIMIT));
+  mrb_define_const(mrb, re, "STACK_LIMIT", mrb_int_value(mrb, MRB_REGEXP_STACK_LIMIT));
   mrb_define_const(mrb, re, "STEP_LIMIT", mrb_int_value(mrb, MRB_REGEXP_STEP_LIMIT));
 
   /* Class methods */

--- a/mrbgems/mruby-regexp/test/backtracking_stack.rb
+++ b/mrbgems/mruby-regexp/test/backtracking_stack.rb
@@ -1,0 +1,29 @@
+# What a test that reaches the backtracking engine asks of the build.
+#
+# That engine holds its state on a heap stack, and MRB_REGEXP_STACK_LIMIT is
+# how many entries the build lets it hold at once. The macro takes any value
+# from 1 up, a build that would rather bound what one search may ask the
+# allocator for than match a complicated pattern being free to set it low, and
+# what such a build gets is an engine that refuses more: a backreference, an
+# atomic group or a lookaround sends a pattern here, and a handful of entries
+# go on the stack whatever the subject is, so below a certain limit a pattern
+# these tests take for granted answers RegexpError instead of matching.
+#
+# The engine is doing what the build asked there, and the assertions have
+# nothing to say about it. 49 is the limit at which every pattern in these
+# files matches again (at 48 one test is left, at 32 three, at 1 fifty-one),
+# so a test that reaches the engine asks for that much and skips below it.
+#
+# What asks for it is a test and not a subject: an assertion that reaches no
+# further than the parser, or one whose pattern the Pike VM runs, holds none
+# of this state and answers the same whatever the limit is. Such assertions
+# stand in an assert of their own rather than under this guard, so that a
+# build that sets the limit low still runs them; where a block mixed the two,
+# the split is what the two blocks' names say.
+RE_TESTS_NEED_STACK = 49
+
+def need_backtracking_stack
+  if Regexp::STACK_LIMIT < RE_TESTS_NEED_STACK
+    skip "MRB_REGEXP_STACK_LIMIT stands below what these patterns need"
+  end
+end

--- a/mrbgems/mruby-regexp/test/backtracking_stack.rb
+++ b/mrbgems/mruby-regexp/test/backtracking_stack.rb
@@ -10,8 +10,8 @@
 # these tests take for granted answers RegexpError instead of matching.
 #
 # The engine is doing what the build asked there, and the assertions have
-# nothing to say about it. 49 is the limit at which every pattern in these
-# files matches again (at 48 one test is left, at 32 three, at 1 fifty-one),
+# nothing to say about it. 48 is the limit at which every pattern in these
+# files matches again (at 44 one test is left, at 36 two, at 1 fifty-one),
 # so a test that reaches the engine asks for that much and skips below it.
 #
 # What asks for it is a test and not a subject: an assertion that reaches no
@@ -20,7 +20,7 @@
 # stand in an assert of their own rather than under this guard, so that a
 # build that sets the limit low still runs them; where a block mixed the two,
 # the split is what the two blocks' names say.
-RE_TESTS_NEED_STACK = 49
+RE_TESTS_NEED_STACK = 48
 
 def need_backtracking_stack
   if Regexp::STACK_LIMIT < RE_TESTS_NEED_STACK

--- a/mrbgems/mruby-regexp/test/regexp_syntax.rb
+++ b/mrbgems/mruby-regexp/test/regexp_syntax.rb
@@ -383,6 +383,33 @@ assert("Regexp - a greedy repetition costs the backtracking engine no C stack") 
   assert_equal s, s.match(/(?:a)*(b)\1/)[0]
 end
 
+assert("Regexp - a capture costs the backtracking engine no C stack") do
+  need_backtracking_stack
+  # A capture wrote its slot and recursed, so that the frame could put back
+  # what the slot held when the branch below it failed: a repetition of a
+  # capturing group spent two frames an iteration, and `(a)*?b`, which runs
+  # its iterations in one frame otherwise, reached the limit by the length
+  # of the run. The write is logged now, and taking it back is the log
+  # unwinding to where the branch was left.
+  if Regexp::STACK_LIMIT * 8 > Regexp::STEP_LIMIT
+    skip "the stack limit stands out of the step limit's reach here"
+  end
+  n = Regexp::STACK_LIMIT / 4
+  s = "a" * n + "b"
+  md = s.match(/(a)*?b/)
+  assert_equal 0, md.begin(0)
+  assert_equal s, md[0]
+  assert_equal "a", md[1]
+  assert_equal n - 1, md.begin(1)
+end
+
+assert("Regexp - what the undo log puts back is what the branch found") do
+  # A slot goes back to what stood in it when the branch that wrote it was
+  # taken, so a group that a later branch did not enter reads as it did
+  # before rather than as the failed branch left it.
+  assert_equal [nil, "b"], "ab".match(/(?:(x)|a)(b)/).captures
+end
+
 assert("Regexp - quantified first alternative does not leak into the next") do
   # A quantifier loops back to its own atom. When the atom starts the first
   # alternative, the alternation SPLIT is inserted in front of it; the

--- a/mrbgems/mruby-regexp/test/regexp_syntax.rb
+++ b/mrbgems/mruby-regexp/test/regexp_syntax.rb
@@ -307,13 +307,16 @@ assert("Regexp - the backtracking engine raises at a limit rather than answer sh
   assert_raise(RegexpError) { (over + "b").match(/(a)*?b/) }   # began later than it should
   assert_raise(RegexpError) { over.match(/(?:(?>a))*\z/) }    # began later than it should
   assert_raise(RegexpError) { "a".match(Regexp.new("(?=a)" * (limit / 2 + 1) + "a")) }   # was nil
-  assert_raise(RegexpError) { over.match(Regexp.new("(?>a)" * (limit / 2 + 1) + "a")) }  # was nil
   assert_equal fits, fits.match(/(?:(?>a))*/)[0]
   assert_equal fits, fits.match(/(?:(?=a)a)*/)[0]
   assert_equal 0, (fits + "b").match(/(a)*?b/).begin(0)
   assert_equal 0, fits.match(/(?:(?>a))*\z/).begin(0)
   assert_equal "a", "a".match(Regexp.new("(?=a)" * (limit / 32) + "a"))[0]
   assert_equal fits, fits.match(Regexp.new("(?>a)" * (limit / 32 - 1) + "a"))[0]
+  # A chain of atomic groups holds nothing per link once each has closed, so
+  # its length is bounded by the pattern and not by the limit.
+  chain = limit / 2 + 1
+  assert_equal "a" * (chain + 1), over.match(Regexp.new("(?>a)" * chain + "a"))[0]
   # The message names the limit, so that whoever hits one on a legitimate
   # subject knows which knob to turn, and the constant says where it stands.
   assert_raise_with_message(RegexpError, "stack limit over (MRB_REGEXP_STACK_LIMIT)") do
@@ -437,6 +440,38 @@ assert("Regexp - what a start position records is not read by the next one") do
       end
     end
   end
+end
+
+assert("Regexp - an atomic group costs the backtracking engine no C stack") do
+  need_backtracking_stack
+  # The group used to run its body, and then the text after it, in frames of
+  # its own, so that a failure after the group could unwind the frames the
+  # body left rather than backtrack into them: a repetition of one spent two
+  # frames an iteration and a chain of them two a link. Entering the group
+  # pushes a barrier onto the choice point stack instead, and its end drops
+  # the barrier and every alternative the body left above it: the cut, as
+  # a truncation.
+  if Regexp::STACK_LIMIT * 8 > Regexp::STEP_LIMIT
+    skip "the stack limit stands out of the step limit's reach here"
+  end
+  begin
+    Regexp.new("(?>a)" * (Regexp::STACK_LIMIT / 2 + 1))
+  rescue RegexpError
+    skip "a chain sized from the stack limit is more pattern than one may spell"
+  end
+  limit = Regexp::STACK_LIMIT
+  s = "a" * (limit / 4)
+  assert_equal s, s.match(/(?:(?>a))*/)[0]
+  assert_equal 0, s.match(/(?:(?>a))*\z/).begin(0)
+  n = limit / 2 + 1
+  assert_equal "a" * (n + 1), ("a" * (n + 1)).match(Regexp.new("(?>a)" * n + "a"))[0]
+  # What the truncation leaves is what the frames left: the body's captures
+  # stay once it has matched, and go when the search backtracks past where
+  # the group began.
+  assert_equal "a", /(?>(a))a/.match("aa")[1]
+  assert_nil /(?:(?>(a))b|a)/.match("a")[1]
+  assert_nil /(?>a*)a/ =~ "aaa"
+  assert_equal 0, /(?>a*)b/ =~ "aab"
 end
 
 assert("Regexp - quantified first alternative does not leak into the next") do

--- a/mrbgems/mruby-regexp/test/regexp_syntax.rb
+++ b/mrbgems/mruby-regexp/test/regexp_syntax.rb
@@ -306,17 +306,18 @@ assert("Regexp - the backtracking engine raises at a limit rather than answer sh
   assert_raise(RegexpError) { over.match(/(?:(?=a)a)*/) }      # a part of the run
   assert_raise(RegexpError) { (over + "b").match(/(a)*?b/) }   # began later than it should
   assert_raise(RegexpError) { over.match(/(?:(?>a))*\z/) }    # began later than it should
-  assert_raise(RegexpError) { "a".match(Regexp.new("(?=a)" * (limit / 2 + 1) + "a")) }   # was nil
   assert_equal fits, fits.match(/(?:(?>a))*/)[0]
   assert_equal fits, fits.match(/(?:(?=a)a)*/)[0]
   assert_equal 0, (fits + "b").match(/(a)*?b/).begin(0)
   assert_equal 0, fits.match(/(?:(?>a))*\z/).begin(0)
   assert_equal "a", "a".match(Regexp.new("(?=a)" * (limit / 32) + "a"))[0]
   assert_equal fits, fits.match(Regexp.new("(?>a)" * (limit / 32 - 1) + "a"))[0]
-  # A chain of atomic groups holds nothing per link once each has closed, so
-  # its length is bounded by the pattern and not by the limit.
+  # A chain of atomic groups or of lookarounds holds nothing per link once
+  # each has closed, so its length is bounded by the pattern and not by the
+  # limit.
   chain = limit / 2 + 1
   assert_equal "a" * (chain + 1), over.match(Regexp.new("(?>a)" * chain + "a"))[0]
+  assert_equal "a", "a".match(Regexp.new("(?=a)" * chain + "a"))[0]
   # The message names the limit, so that whoever hits one on a legitimate
   # subject knows which knob to turn, and the constant says where it stands.
   assert_raise_with_message(RegexpError, "stack limit over (MRB_REGEXP_STACK_LIMIT)") do
@@ -472,6 +473,40 @@ assert("Regexp - an atomic group costs the backtracking engine no C stack") do
   assert_nil /(?:(?>(a))b|a)/.match("a")[1]
   assert_nil /(?>a*)a/ =~ "aaa"
   assert_equal 0, /(?>a*)b/ =~ "aab"
+end
+
+assert("Regexp - a lookaround costs the backtracking engine no C stack") do
+  need_backtracking_stack
+  # A lookaround ran its sub-pattern in a call of its own, and a positive one
+  # ran the text after it inside that call as well, so that a failure there
+  # could come back as a cut and undo what the sub-pattern had captured: two
+  # frames a lookaround, and a repetition of one or a chain of them reached
+  # the limit by their length. Entering one pushes a barrier instead, and its
+  # end drops the barrier and the alternatives the sub-pattern left, going on
+  # with the text after from where the lookaround was entered.
+  if Regexp::STACK_LIMIT * 8 > Regexp::STEP_LIMIT
+    skip "the stack limit stands out of the step limit's reach here"
+  end
+  begin
+    Regexp.new("(?=a)" * (Regexp::STACK_LIMIT / 2 + 1))
+  rescue RegexpError
+    skip "a chain sized from the stack limit is more pattern than one may spell"
+  end
+  limit = Regexp::STACK_LIMIT
+  s = "a" * (limit / 4)
+  assert_equal s, s.match(/(?:(?=a)a)*/)[0]
+  assert_equal s, s.match(/(?:a(?<=a))*/)[0]
+  assert_equal s, s.match(/(?:(?!b)a)*/)[0]
+  n = limit / 2 + 1
+  assert_equal "a", "a".match(Regexp.new("(?=a)" * n + "a"))[0]
+  # What the barrier keeps and what it takes back is what the frames did: a
+  # positive lookaround's captures outlive it and a negative one's do not,
+  # and neither survives the search going back past where it was entered.
+  assert_equal "a", /(?=(a))a/.match("a")[1]
+  assert_equal ["b", "a"], /(?<=(a))b/.match("ab").to_a
+  assert_nil /(?!(a))|/.match("a")[1]
+  assert_nil /(?:(?=(a))b|)/.match("a")[1]
+  assert_nil /(?=(a|ab))\1c/ =~ "abc"
 end
 
 assert("Regexp - quantified first alternative does not leak into the next") do

--- a/mrbgems/mruby-regexp/test/regexp_syntax.rb
+++ b/mrbgems/mruby-regexp/test/regexp_syntax.rb
@@ -410,6 +410,35 @@ assert("Regexp - what the undo log puts back is what the branch found") do
   assert_equal [nil, "b"], "ab".match(/(?:(x)|a)(b)/).captures
 end
 
+assert("Regexp - what a start position records is not read by the next one") do
+  need_backtracking_stack
+  # Where the running iteration of an empty-matchable repetition began is
+  # recorded on the undo log, which a match does not unwind and a failure
+  # unwinds only as far as the branch it goes back to. A start position that
+  # has failed must leave none of it behind: the first iteration of an `e+`
+  # reads the record without having written it, and one left at the offset
+  # the next start position reaches would stop that repetition before it had
+  # gone round, which shows up as a capture the answer should not hold rather
+  # than as a crash. The search from a later position therefore has to answer
+  # what the same search over the tail alone answers.
+  ["(?:(a)|)+b", "(?:(a)|)+?b", "(?:(a)|)*b\\1", "((?:a|)+)b\\1",
+   "(?:(a*))+?b\\1", "(?:(?>a*)(b|))+?c"].each do |src|
+    re = Regexp.new(src)
+    ["ab", "aab", "b", "abb"].each do |tail|
+      # a head the patterns cannot reach into, so that the leftmost match of
+      # the whole is the tail's own
+      %w[x xx xyx].each do |head|
+        md = (head + tail).match(re)
+        want = tail.match(re)
+        if want
+          assert_equal want[0], md && md[0], "#{src} on #{head + tail}"
+          assert_equal want.captures, md && md.captures, "#{src} on #{head + tail}"
+        end
+      end
+    end
+  end
+end
+
 assert("Regexp - quantified first alternative does not leak into the next") do
   # A quantifier loops back to its own atom. When the atom starts the first
   # alternative, the alternation SPLIT is inserted in front of it; the

--- a/mrbgems/mruby-regexp/test/regexp_syntax.rb
+++ b/mrbgems/mruby-regexp/test/regexp_syntax.rb
@@ -126,7 +126,12 @@ assert("Regexp - a repetition keeps its last, empty iteration's capture") do
   assert_equal "", "b".match(/(a*)*b/)[1]
   # a nullable body nested in a repetition reaches the same answer
   assert_equal "", "a".match(/((a?)*)*/)[1]
-  # both engines agree: a lookaround routes the same pattern to the other one
+end
+
+assert("Regexp - both engines keep the last, empty iteration's capture") do
+  need_backtracking_stack
+  # The same patterns with a lookaround in front, which routes them to the
+  # other engine: what the two answer must not differ.
   assert_equal "", "a".match(/(?=a)(a?)*/)[1]
   assert_equal 1, "a".match(/(?=a)(a?)*/).begin(1)
   assert_equal "", "b".match(/(?=b)(a?)*/)[1]
@@ -146,6 +151,7 @@ assert("String#split and String#scan see the empty iteration's capture") do
 end
 
 assert("Regexp - the backtracking engine stops a repetition on an empty iteration") do
+  need_backtracking_stack
   # The same rule under the engine a lazy quantifier routes a pattern to. It
   # used to run such a loop until its recursion limit refused the next frame,
   # and answer with whatever the alternatives left inside the limit produced:
@@ -189,6 +195,7 @@ assert("Regexp - the backtracking engine stops a repetition on an empty iteratio
 end
 
 assert("Regexp - a repetition of a lookaround or a backreference stops the same way") do
+  need_backtracking_stack
   # A lookaround is zero-width, and a backreference to a group that
   # captured empty consumes nothing, so a repetition of either can run an
   # empty iteration and stops on it. It used to run to the recursion limit,
@@ -216,6 +223,7 @@ assert("Regexp - a repetition of a lookaround or a backreference stops the same 
 end
 
 assert("Regexp - a backreference reads no group the running iteration reopened") do
+  need_backtracking_stack
   # A group's pair in captures[] is a span only while the group is closed:
   # its end slot used to keep the previous iteration's end after a repetition
   # re-entered the group, so a backreference read the running iteration's
@@ -261,56 +269,118 @@ assert("Regexp - a backreference reads no group the running iteration reopened")
 end
 
 assert("Regexp - the backtracking engine raises at a limit rather than answer short") do
-  # A frame gives up at MRB_REGEXP_RECURSION_LIMIT or MRB_REGEXP_STEP_LIMIT,
-  # and the frames above it used to read that as the branch having failed and
-  # go on with their other branches: the search answered with a shorter match,
-  # a later one or none, told from the real answer by nothing. A limit is the
-  # search's answer now, and the caller raises on it; the same patterns match
-  # whole on a subject inside the limits, as in CRuby.
+  need_backtracking_stack
+  # A search gives up at MRB_REGEXP_STACK_LIMIT or MRB_REGEXP_STEP_LIMIT,
+  # and what was running above it used to read that as the branch having
+  # failed and go on with its other branches: the search answered with a
+  # shorter match, a later one or none, told from the real answer by nothing.
+  # A limit is the search's answer now, and the caller raises on it; the same
+  # patterns match whole on a subject inside the limits, as in CRuby.
   #
-  # The subjects are sized from the limits, which the build sets and the two
-  # constants read back. A repetition of an atomic group or a lookaround
-  # spends two or three frames per iteration, so a run of `a` as long as the
-  # recursion limit is past it for every pattern here and a quarter of that
-  # run is inside it; a chain of `(?=a)` or `(?>a)` spends two frames per
-  # link; `(a+)+\1b` spends about 2^n steps on a run of n. The n that reaches
-  # the step limit is counted by shifting the limit down rather than 1 up to
-  # it, so that a build setting the limit near the width of `mrb_int` has no
-  # shift of its own to overflow.
-  limit = Regexp::RECURSION_LIMIT
-  over = "a" * limit
-  fits = "a" * (limit / 4)
-  n = 0
-  n += 1 while (Regexp::STEP_LIMIT - 1) >> n > 0
-  steps = "a" * (n + 10)
-  assert_raise(RegexpError) { over.match(/(?:(?>a))*/) }       # answered a third of the run
-  assert_raise(RegexpError) { over.match(/(?:(?=a)a)*/) }      # a third of the run
-  assert_raise(RegexpError) { (over + "b").match(/(a)*?b/) }   # began past the middle
-  assert_raise(RegexpError) { over.match(/(?:(?>a))*\z/) }    # began past the middle
+  # The subjects and the patterns here are sized from the stack limit, which
+  # the build sets and `Regexp::STACK_LIMIT` reads back. What a pattern holds
+  # per iteration differs (a repetition holds at least the branch it has not
+  # taken, a capture or a group's opener costs on top of that), so the run
+  # that is past the limit is a multiple of it and the run that fits is a
+  # fraction, rather than either being the limit itself.
+  #
+  # A build may set the limit where neither is sized any more. Filling the
+  # stack costs a handful of steps an entry, so a limit high enough puts
+  # itself out of the step limit's reach and these searches stop at the step
+  # limit instead; and a chain sized from it is more pattern than one may
+  # spell. Such a build is left out rather than have the assertions read the
+  # wrong limit.
+  if Regexp::STACK_LIMIT * 8 > Regexp::STEP_LIMIT
+    skip "the stack limit stands out of the step limit's reach here"
+  end
+  begin
+    Regexp.new("(?>a)" * (Regexp::STACK_LIMIT / 2 + 1))
+    Regexp.new("(?=a)" * (Regexp::STACK_LIMIT / 2 + 1))
+  rescue RegexpError
+    skip "a chain sized from the stack limit is more pattern than one may spell"
+  end
+  limit = Regexp::STACK_LIMIT
+  over = "a" * (2 * limit)
+  fits = "a" * (limit / 32)
+  assert_raise(RegexpError) { over.match(/(?:(?>a))*/) }       # answered a part of the run
+  assert_raise(RegexpError) { over.match(/(?:(?=a)a)*/) }      # a part of the run
+  assert_raise(RegexpError) { (over + "b").match(/(a)*?b/) }   # began later than it should
+  assert_raise(RegexpError) { over.match(/(?:(?>a))*\z/) }    # began later than it should
   assert_raise(RegexpError) { "a".match(Regexp.new("(?=a)" * (limit / 2 + 1) + "a")) }   # was nil
   assert_raise(RegexpError) { over.match(Regexp.new("(?>a)" * (limit / 2 + 1) + "a")) }  # was nil
   assert_equal fits, fits.match(/(?:(?>a))*/)[0]
   assert_equal fits, fits.match(/(?:(?=a)a)*/)[0]
   assert_equal 0, (fits + "b").match(/(a)*?b/).begin(0)
   assert_equal 0, fits.match(/(?:(?>a))*\z/).begin(0)
-  assert_equal "a", "a".match(Regexp.new("(?=a)" * (limit / 4) + "a"))[0]
-  assert_equal fits, fits.match(Regexp.new("(?>a)" * (limit / 4 - 1) + "a"))[0]
+  assert_equal "a", "a".match(Regexp.new("(?=a)" * (limit / 32) + "a"))[0]
+  assert_equal fits, fits.match(Regexp.new("(?>a)" * (limit / 32 - 1) + "a"))[0]
   # The message names the limit, so that whoever hits one on a legitimate
   # subject knows which knob to turn, and the constant says where it stands.
-  assert_raise_with_message(RegexpError, "recursion limit over (MRB_REGEXP_RECURSION_LIMIT)") do
+  assert_raise_with_message(RegexpError, "stack limit over (MRB_REGEXP_STACK_LIMIT)") do
     over.match(/(?:(?>a))*/)
   end
-  assert_raise_with_message(RegexpError, "step limit over (MRB_REGEXP_STEP_LIMIT)") do
-    steps.match(/(a+)+\1b/)
-  end
-  assert_kind_of Integer, Regexp::RECURSION_LIMIT
-  assert_kind_of Integer, Regexp::STEP_LIMIT
   # A limit ends the search at the start position it was hit at: the
   # positions after it would say where the first match is only once this one
   # has none. The search that reads no captures raises the same.
   assert_raise(RegexpError) { ("b" + over + "c").match(/b(?:(?>a))*c|a/) }   # began at 1
   assert_raise(RegexpError) { over.match?(/(?:(?>a))*\z/) }
   assert_raise(RegexpError) { /(?:(?>a))*\z/ === over }
+end
+
+assert("Regexp - a search that runs too long raises at the step limit") do
+  need_backtracking_stack
+  # The step limit bounds the work one search may do, where the stack limit
+  # bounds the state it holds while doing it, and a search reaches this one
+  # holding almost nothing: `(?:a|a|a|a)+(z)\1` tries four branches per
+  # character of the run and holds about three entries per character, so
+  # 4**m steps stand against 3*m entries. Sizing the run from the step
+  # limit's width that way is what lets the assertion read the same on a
+  # build with a low stack limit, where a pattern that reaches the step
+  # limit by the length of its run alone would fill the stack first and pin
+  # the other limit.
+  #
+  # The width is counted by shifting the limit down rather than 1 up to it,
+  # so that a build setting the limit near the width of `mrb_int` has no
+  # shift of its own to overflow. `(?:a)+` alone never reaches this engine,
+  # the Pike VM running it in no stack at all, so the backreference is what
+  # sends the pattern here.
+  n = 0
+  n += 1 while (Regexp::STEP_LIMIT - 1) >> n > 0
+  steps = "a" * (n / 2 + 1)
+  assert_raise_with_message(RegexpError, "step limit over (MRB_REGEXP_STEP_LIMIT)") do
+    steps.match(/(?:a|a|a|a)+(z)\1/)
+  end
+end
+
+assert("Regexp - the two limits say where they stand") do
+  # Whichever engine a pattern reaches, the build's answer to both knobs is
+  # readable: a build that sets one low is where the constants matter most.
+  assert_kind_of Integer, Regexp::STACK_LIMIT
+  assert_kind_of Integer, Regexp::STEP_LIMIT
+  assert_true Regexp::STACK_LIMIT >= 1
+  assert_true Regexp::STEP_LIMIT >= 1
+end
+
+assert("Regexp - a greedy repetition costs the backtracking engine no C stack") do
+  need_backtracking_stack
+  # A greedy repetition tries its body first and keeps the exit for later,
+  # whatever the body holds, so the branch it has not taken used to be a C
+  # frame it recursed into and the frames accumulated one per iteration: the
+  # run a search could cross was what the C stack held, and `(?:a)*` reached
+  # the limit on a subject that is nothing out of the ordinary. The branch is
+  # a choice point on the heap now, and what bounds the run is how many of
+  # those MRB_REGEXP_STACK_LIMIT allows.
+  #
+  # `(?:a)*` alone never reaches this engine, the Pike VM running it in no
+  # stack at all, so the backreference is what sends the pattern here.
+  if Regexp::STACK_LIMIT * 8 > Regexp::STEP_LIMIT
+    skip "the stack limit stands out of the step limit's reach here"
+  end
+  s = "a" * (Regexp::STACK_LIMIT / 4) + "bb"
+  assert_equal 0, s.match(/(?:a)*(b)\1/).begin(0)
+  assert_equal 0, s.match(/(?:a)+(b)\1/).begin(0)
+  assert_equal 0, s.match(/(?:a)*?(b)\1/).begin(0)
+  assert_equal s, s.match(/(?:a)*(b)\1/)[0]
 end
 
 assert("Regexp - quantified first alternative does not leak into the next") do
@@ -377,14 +447,19 @@ assert("Regexp - ^ and $ always match at line boundaries") do
   assert_equal "bar", "foo\nbar".match(/bar\z/)[0]
 end
 
-assert("Regexp - \\Z matches before a trailing newline under both engines") do
-  # \Z is the string end or the position just before a final newline. The
-  # lazy quantifier routes the pattern to the backtracking engine, which had
-  # no case for the opcode and so failed every \Z it saw.
+assert("Regexp - \\Z matches before a trailing newline") do
+  # \Z is the string end or the position just before a final newline.
   assert_equal 0, "a" =~ /a\Z/
   assert_equal 0, "a\n" =~ /a\Z/
   assert_nil "a\n\n" =~ /a\Z/
   assert_nil "ab" =~ /a\Z/
+end
+
+assert("Regexp - \\Z matches before a trailing newline under the backtracking engine too") do
+  need_backtracking_stack
+  # The same four, with a lazy quantifier or a lookaround to route the
+  # pattern to the other engine, which had no case for the opcode and so
+  # failed every \Z it saw.
   assert_equal 0, "a" =~ /a\Za*?/
   assert_equal 0, "a\n" =~ /a\Z.*?/
   assert_nil "a\n\n" =~ /a\Z.*?/
@@ -600,7 +675,9 @@ end
 assert("Regexp - a quantifier after a quantifier repeats the repeat") do
   # CRuby reads a second quantifier as binding the repeat before it, not the
   # atom: `a**` is `(?:a*)*`. Two spellings are not that, and are read where
-  # the first quantifier is.
+  # the first quantifier is. Every repeat here is greedy, so the Pike VM
+  # runs them all; the two spellings that are not a quantifier at all, the
+  # non-greedy marker and the possessive one, are pinned below.
   assert_equal ["aaa"], /a**/.match("aaa").to_a
   assert_equal ["aaa"], /a+*/.match("aaa").to_a
   assert_equal ["aaa"], /a?*/.match("aaa").to_a
@@ -610,22 +687,15 @@ assert("Regexp - a quantifier after a quantifier repeats the repeat") do
   assert_equal ["aaa"], /a***/.match("aaa").to_a
   assert_equal ["aa"], /(?:a?){2}/.match("aaa").to_a
   assert_equal ["aa"], /a?{2}/.match("aaa").to_a
+  assert_equal ["aa"], /(?:a?)+/.match("aa").to_a
 
-  # `?` right after a greedy `*`, `+`, `?` or a `{n,m}` written with a comma
-  # is the non-greedy marker. `{n}` has no non-greedy form, so its `?` is a
-  # quantifier and `a{3}?` matches empty where the lazy `a{3,3}?` does not.
-  assert_equal [""], /a*?/.match("aaa").to_a
+  # `{n}` has no non-greedy form, so its `?` is a quantifier: `a{3}?` matches
+  # empty where the lazy `a{3,3}?` does not. The optional wraps the copies of
+  # `{n}` alone, so the rest of the pattern still has to match: `xa{2}?y`
+  # takes "xy" and "xaay" but nothing between, and inside a group the capture
+  # is what the wrapper let through.
   assert_equal [""], /a{3}?/.match("").to_a
   assert_equal [""], /a{3}?/.match("aa").to_a
-  assert_nil /a{3,3}?/.match("aa")
-  assert_equal ["aaa"], /a{3,3}?/.match("aaa").to_a
-  assert_equal [""], /a{0,2}?/.match("aa").to_a
-
-  # The optional wraps the copies of `{n}` alone, so the rest of the pattern
-  # still has to match: `xa{2}?y` takes "xy" and "xaay" but nothing between,
-  # and inside a group the capture is what the wrapper let through. Written
-  # with a comma the `?` is the non-greedy marker again and the copies are
-  # required.
   assert_equal ["xy"], /xa{2}?y/.match("xy").to_a
   assert_equal ["xaay"], /xa{2}?y/.match("xaay").to_a
   assert_nil /xa{2}?y/.match("xay")
@@ -633,6 +703,29 @@ assert("Regexp - a quantifier after a quantifier repeats the repeat") do
   assert_equal [""], /^a{2}?$/.match("").to_a
   assert_equal ["xy", ""], /x(a{2}?)y/.match("xy").to_a
   assert_equal ["xaay", "aa"], /x(a{2}?)y/.match("xaay").to_a
+
+  # A body that matches no times matches empty however it is repeated.
+  assert_equal [""], /a{0}*/.match("").to_a
+  assert_equal [""], /a{0}{2}?/.match("aa").to_a
+
+  # A repeat of a repeat is an empty-matching loop by construction; the null
+  # check of both engines stops it rather than the stack limit.
+  assert_equal ["aaa"], /(?:a?)**/.match("aaa").to_a
+  assert_equal ["b"], /(?:a?)**b/.match("b").to_a
+end
+
+assert("Regexp - the non-greedy and possessive markers are read where the quantifier is") do
+  need_backtracking_stack
+  # The two spellings the block above leaves out, both of which send the
+  # pattern to the backtracking engine.
+
+  # `?` right after a greedy `*`, `+`, `?` or a `{n,m}` written with a comma
+  # is the non-greedy marker; written without one it is the quantifier the
+  # block above pins.
+  assert_equal [""], /a*?/.match("aaa").to_a
+  assert_nil /a{3,3}?/.match("aa")
+  assert_equal ["aaa"], /a{3,3}?/.match("aaa").to_a
+  assert_equal [""], /a{0,2}?/.match("aa").to_a
   assert_nil /xa{2,2}?y/.match("xy")
 
   # `+` right after a greedy `*`, `+` or `?` is possessive, `a*+` being
@@ -641,36 +734,36 @@ assert("Regexp - a quantifier after a quantifier repeats the repeat") do
   assert_equal ["a"], /a?+/.match("aa").to_a
   assert_nil /a?+a/.match("a")
   assert_equal ["aa"], /a?+a/.match("aa").to_a
-  assert_equal ["aa"], /(?:a?)+/.match("aa").to_a
   assert_equal ["aaa"], /a*+/.match("aaa").to_a
   assert_equal ["aa"], /a+?+/.match("aa").to_a
   assert_equal ["a"], /a+?+?/.match("aa").to_a
   assert_equal ["aa"], /a?++/.match("aa").to_a
 
-  # A body that matches no times matches empty however it is repeated.
-  assert_equal [""], /a{0}*/.match("").to_a
-  assert_equal [""], /a{0}{2}?/.match("aa").to_a
-
   # A repeat of a repeat is an empty-matching loop by construction; the null
-  # check of both engines stops it rather than the recursion limit.
-  assert_equal ["aaa"], /(?:a?)**/.match("aaa").to_a
+  # check of both engines stops it rather than the stack limit.
   assert_equal ["aaa"], /(?:a*)*+/.match("aaa").to_a
-  assert_equal ["b"], /(?:a?)**b/.match("b").to_a
 end
 
 assert("Regexp - a backreference names a group the pattern has") do
   # The count is the pattern's, not the one standing where the reference is,
-  # so a reference to a group written later is valid.
-  assert_equal ["aa", "a"], /(a)\1/.match("aa").to_a
-  assert_nil(/\1(a)/ =~ "a")
+  # so a reference past it is refused where the pattern is read.
   assert_raise(RegexpError) { Regexp.new("\\1") }
   assert_raise(RegexpError) { Regexp.new("(a)\\2") }
   assert_raise(RegexpError) { Regexp.new("(a)(b)\\3") }
   assert_raise(RegexpError) { Regexp.new("\\9") }
-  assert_equal 0, Regexp.new("(a)" * 9 + "\\9") =~ "aaaaaaaaaa"
   # A named pattern refuses a numbered reference before it counts.
   assert_raise(RegexpError) { Regexp.new("(?<n>a)\\1") }
   assert_raise(RegexpError) { Regexp.new("(?<n>a)\\2") }
+end
+
+assert("Regexp - a backreference reaches a group written after it") do
+  need_backtracking_stack
+  # The count being the pattern's rather than the one standing where the
+  # reference is, a reference to a group written later is valid; the group
+  # has captured nothing where the reference is read, so it does not match.
+  assert_equal ["aa", "a"], /(a)\1/.match("aa").to_a
+  assert_nil(/\1(a)/ =~ "a")
+  assert_equal 0, Regexp.new("(a)" * 9 + "\\9") =~ "aaaaaaaaaa"
 end
 
 assert("Regexp - patterns that used to hang the compiler now raise (A1)") do
@@ -715,12 +808,6 @@ assert("Regexp - inline options (?i) / (?i:...)") do
   assert_equal 0, (/(a(?i)b)c/ =~ "aBc")
   assert_nil (/(a(?i)b)c/ =~ "aBC")       # trailing `c` is case-sensitive again
 
-  # A backreference takes the options in effect where it appears, not the
-  # pattern's own, so an inline toggle reaches it like any other atom.
-  assert_equal 0, (/(a)(?i)\1/ =~ "aA")
-  assert_equal 0, (/(a)(?i:\1)/ =~ "aA")
-  assert_nil (/(?-i:(a)\1)/i =~ "aA")
-
   # m enables dot-matches-newline for its scope.
   assert_equal 0, (/(?m:a.b)/ =~ "a\nb")
   assert_nil (/a.b/ =~ "a\nb")
@@ -732,7 +819,6 @@ assert("Regexp - inline options (?i) / (?i:...)") do
   assert_equal 0, (/(?x:a b)c d/ =~ "abc d")
   assert_equal 0, (/(a(?x)b c)d e/ =~ "abcd e")
   assert_equal 0, (/(?<n>(?x)a b)c d/ =~ "abc d")
-  assert_equal 0, (/(?=(?x)a b)ab c/ =~ "ab c")
   assert_equal 0, (/(?xi)a b/ =~ "AB")
   assert_equal 0, (/(?x)a b(?-x)c d/ =~ "abc d")
   assert_equal 0, (/(?x:a(?-x:b c)d)/ =~ "ab cd")
@@ -781,6 +867,17 @@ b/ =~ "ab")
   assert_raise(RegexpError) { Regexp.new("(?-a)b") }
   assert_raise(RegexpError) { Regexp.new("(?-") }
   assert_raise(RegexpError) { Regexp.new("(?)") }
+end
+
+assert("Regexp - an inline option reaches a lookaround and a backreference") do
+  need_backtracking_stack
+  # A backreference takes the options in effect where it appears, not the
+  # pattern's own, so an inline toggle reaches it like any other atom; a
+  # lookaround's sub-pattern is a scope of its own for the toggle inside it.
+  assert_equal 0, (/(a)(?i)\1/ =~ "aA")
+  assert_equal 0, (/(a)(?i:\1)/ =~ "aA")
+  assert_nil (/(?-i:(a)\1)/i =~ "aA")
+  assert_equal 0, (/(?=(?x)a b)ab c/ =~ "ab c")
 end
 
 assert("Regexp - comment groups (?#...)") do
@@ -873,11 +970,6 @@ assert("Regexp extended mode (x flag)") do
   assert_nil Regexp.new('\x1 2', Regexp::EXTENDED) =~ "\x12"
   assert_equal 0, (Regexp.new('\x1 a', Regexp::EXTENDED) =~ "\x01a")
   assert_equal 0, (Regexp.new('\01 2', Regexp::EXTENDED) =~ "\x012")
-  assert_equal 0, (Regexp.new('(a)\1 0', Regexp::EXTENDED) =~ "aa0")
-  # what keeps them apart is no atom: a quantifier after the digit repeats
-  # the digit, and a lookbehind still measures a fixed width
-  assert_equal "aa000", Regexp.new('(a)\1 0+', Regexp::EXTENDED).match("aa000")[0]
-  assert_equal 2, (Regexp.new('(?<=\x1 2)x', Regexp::EXTENDED) =~ "\x012x")
   assert_raise_with_message(RegexpError, "unmatched '(': /\\x1 2(/") do
     Regexp.new('\x1 2(', Regexp::EXTENDED)
   end
@@ -909,6 +1001,17 @@ assert("Regexp extended mode (x flag)") do
   end
 end
 
+assert("Regexp extended mode keeps a digit escape apart from what follows it") do
+  need_backtracking_stack
+  # The same rule as above, where what stands after the whitespace is a
+  # backreference's digit or a lookbehind: `\1 0` is group 1 and a `0`.
+  assert_equal 0, (Regexp.new('(a)\1 0', Regexp::EXTENDED) =~ "aa0")
+  # what keeps them apart is no atom: a quantifier after the digit repeats
+  # the digit, and a lookbehind still measures a fixed width
+  assert_equal "aa000", Regexp.new('(a)\1 0+', Regexp::EXTENDED).match("aa000")[0]
+  assert_equal 2, (Regexp.new('(?<=\x1 2)x', Regexp::EXTENDED) =~ "\x012x")
+end
+
 assert("Regexp - free-spacing whitespace stands between tokens only") do
   # Under /x the parser skips whitespace where one token ends and the next
   # begins, as CRuby's tokenizer does, and reads every token with the
@@ -927,13 +1030,7 @@ assert("Regexp - free-spacing whitespace stands between tokens only") do
   assert_equal ["aa"], Regexp.new("a {2}", x).match("aa").to_a
   assert_equal ["aa", "a"], Regexp.new("(a) {2}", x).match("aa").to_a
   assert_equal ["b"], Regexp.new("a ?b", x).match("b").to_a
-  assert_equal ["a"], Regexp.new("(?= a)a", x).match("a").to_a
-  assert_equal ["b"], Regexp.new("(?<= a)b", x).match("ab").to_a
-  assert_equal ["b"], Regexp.new("(?! a)b", x).match("b").to_a
-  assert_equal ["a"], Regexp.new("(?> a )", x).match("a").to_a
   assert_equal ["A"], Regexp.new("(?i: a )", x).match("A").to_a
-  assert_equal ["aa", "a"], Regexp.new("(?<n> a)\\k<n>", x).match("aa").to_a
-  assert_equal ["aa", "a"], Regexp.new("(a) \\1", x).match("aa").to_a
 
   # the five bytes CRuby skips; a vertical tab is a literal
   assert_equal ["ab"], Regexp.new("a \t\n\r\fb", x).match("ab").to_a
@@ -973,14 +1070,6 @@ assert("Regexp - free-spacing whitespace stands between tokens only") do
   # number too large to repeat by is not one to report
   assert_equal ["a{99999999999}"],
                Regexp.new("a{ 99999999999}", x).match("a{99999999999}").to_a
-  # the `?` that makes a quantifier non-greedy is read right after it, so a
-  # `?` a space away is a repeat of the repeat, which this engine refuses
-  # as it refuses `a**`
-  assert_equal [""], Regexp.new("a*?", x).match("aaa").to_a
-  # A `?` a blank away from the quantifier repeats the repeat, `(?:a*)?`, and
-  # is not the non-greedy marker, which is read where the quantifier is.
-  assert_equal ["aaa"], Regexp.new("a* ?", x).match("aaa").to_a
-  assert_equal ["aa"], Regexp.new("a{2} ?", x).match("aaa").to_a
 
   # a numeric escape is read whole too: the whitespace that CRuby rejects
   # inside one is rejected here, and the whitespace that ends one short of
@@ -1014,8 +1103,6 @@ assert("Regexp - free-spacing whitespace stands between tokens only") do
   # whether it is declared or referenced: the name is "a b"
   assert_equal ["a b"], Regexp.new("(?<a b>x)", x).names
   assert_equal ["a b"], Regexp.new("(?'a b'x)", x).names
-  assert_equal "xx", Regexp.new("(?<a b>x)\\k<a b>", x).match("xx")[0]
-  assert_equal "xx", Regexp.new("(?'a b'x)\\k'a b'", x).match("xx")[0]
   assert_raise_with_message(RegexpError,
                             "undefined name <a b> reference: /(?<ab>x)\\k<a b>/") do
     Regexp.new("(?<ab>x)\\k<a b>", x)
@@ -1025,17 +1112,47 @@ assert("Regexp - free-spacing whitespace stands between tokens only") do
     Regexp.new("(?<a b>x)\\k<ab>", x)
   end
   # a `\k` that whitespace follows is the letter k, with the `<ab>` after
-  # the whitespace a literal of its own; a comment between the two is gone
-  # before the parser reads either, as in CRuby, so that `\k` is a reference
+  # the whitespace a literal of its own
   assert_equal "xk<ab>", Regexp.new("(?<ab>x)\\k <ab>", x).match("xk<ab>")[0]
   assert_equal "xk<ab>", Regexp.new("(?<ab>x)\\k\n<ab>", x).match("xk<ab>")[0]
-  assert_equal "xx", Regexp.new("(?<ab>x)\\k#c\n<ab>", x).match("xx")[0]
-  assert_equal "xx", Regexp.new("(?<ab>x)\\k(?#c)<ab>").match("xx")[0]
-  # a comment inside a name is removed the same way, and takes its newline
+  # a comment inside a name is removed and takes its newline with it
   assert_equal ["ab"], Regexp.new("(?<ab#c\n>x)\\k<ab#c\n>", x).names
-  assert_equal "xx", Regexp.new("(?<ab#c\n>x)\\k<ab#c\n>", x).match("xx")[0]
   # inside a class the escape is the letter and the space is a member
   assert_equal [" "], Regexp.new("[\\k<a b>]", x).match(" ").to_a
+end
+
+assert("Regexp - free-spacing whitespace stands between the tokens the backtracking engine runs") do
+  need_backtracking_stack
+  # The same rule where the token is a lookaround's opener, an atomic
+  # group's, a non-greedy marker or a backreference's name: the whitespace
+  # between two tokens goes, and the whitespace inside one breaks it.
+  x = Regexp::EXTENDED
+
+  # between tokens
+  assert_equal ["a"], Regexp.new("(?= a)a", x).match("a").to_a
+  assert_equal ["b"], Regexp.new("(?<= a)b", x).match("ab").to_a
+  assert_equal ["b"], Regexp.new("(?! a)b", x).match("b").to_a
+  assert_equal ["a"], Regexp.new("(?> a )", x).match("a").to_a
+  assert_equal ["aa", "a"], Regexp.new("(?<n> a)\\k<n>", x).match("aa").to_a
+  assert_equal ["aa", "a"], Regexp.new("(a) \\1", x).match("aa").to_a
+
+  # the `?` that makes a quantifier non-greedy is read right after it, so a
+  # `?` a space away is a repeat of the repeat, `(?:a*)?`, and not the
+  # marker, which is read where the quantifier is
+  assert_equal [""], Regexp.new("a*?", x).match("aaa").to_a
+  assert_equal ["aaa"], Regexp.new("a* ?", x).match("aaa").to_a
+  assert_equal ["aa"], Regexp.new("a{2} ?", x).match("aaa").to_a
+
+  # a group name is the raw bytes up to its terminator, whitespace included,
+  # so the reference whose name holds the blank is the one that resolves
+  assert_equal "xx", Regexp.new("(?<a b>x)\\k<a b>", x).match("xx")[0]
+  assert_equal "xx", Regexp.new("(?'a b'x)\\k'a b'", x).match("xx")[0]
+  # a comment between `\k` and its name is gone before the parser reads
+  # either, as in CRuby, so that `\k` is a reference where whitespace would
+  # have left it the letter k
+  assert_equal "xx", Regexp.new("(?<ab>x)\\k#c\n<ab>", x).match("xx")[0]
+  assert_equal "xx", Regexp.new("(?<ab>x)\\k(?#c)<ab>").match("xx")[0]
+  assert_equal "xx", Regexp.new("(?<ab#c\n>x)\\k<ab#c\n>", x).match("xx")[0]
 end
 
 assert("Regexp - a removed comment does not reach into an escape") do
@@ -1113,6 +1230,7 @@ assert("Regexp - nested captures") do
 end
 
 assert("Regexp - non-greedy quantifiers") do
+  need_backtracking_stack
 
   assert_equal "a", /a+?/.match("aaa")[0]
   assert_equal "", /a*?/.match("aaa")[0]
@@ -1159,6 +1277,7 @@ assert("Regexp - an empty group takes a quantifier") do
 end
 
 assert("Regexp - atomic group (?>...)") do
+  need_backtracking_stack
   # The body's first match is its only one: what follows cannot make it
   # give text back or take another branch, where a plain group can.
   assert_equal 0, /(?>a)+b/ =~ "aab"
@@ -1228,7 +1347,9 @@ assert("Regexp - atomic group (?>...)") do
   # It reads back through to_s, and free-spacing applies to its body.
   assert_equal 0, Regexp.new(/(?>a)+b/.to_s) =~ "aab"
   assert_equal 0, Regexp.new("(?> a b )c", Regexp::EXTENDED) =~ "abc"
+end
 
+assert("Regexp - an atomic group the parser refuses") do
   assert_raise(RegexpError) { Regexp.new("(?>a") }
   assert_raise(RegexpError) { Regexp.new("(?>") }
   # not a fixed-length construct, so not allowed in a lookbehind
@@ -1262,10 +1383,8 @@ assert("Regexp - a named group makes plain groups non-capturing") do
   assert_equal "a", $+
   assert_equal "[]", "ab".sub(/(?<a>a)(b)/, '[\2]')
 
-  # (?<= and (?<! open a lookbehind, not a named group, so they demote nothing
-  assert_equal ["b", "b"], /(?<=a)(b)/.match("ab").to_a
-  assert_equal ["b", "b"], /(?<!x)(b)/.match("ab").to_a
-  # nor does a "(?<" that is escaped or sits inside a character class
+  # a "(?<" that is escaped or sits inside a character class opens no named
+  # group either
   assert_equal ["(<a>b", "b"], /\(?<a>(b)/.match("(<a>b").to_a
   assert_equal ["(?<b", "b"], /[(?<a>]+(b)/.match("(?<b").to_a
   assert_equal ["a(?<b", "b"], /[[:alpha:](?<]+(b)/.match("a(?<b").to_a
@@ -1286,6 +1405,14 @@ assert("Regexp - a named group makes plain groups non-capturing") do
   assert_raise_with_message(RegexpError, "unterminated character class: /[[:alpha/") do
     Regexp.new("[[:alpha")
   end
+end
+
+assert("Regexp - a lookbehind opener is no named group") do
+  need_backtracking_stack
+  # (?<= and (?<! open a lookbehind, not a named group, so they demote the
+  # plain group after them no more than the spellings above do.
+  assert_equal ["b", "b"], /(?<=a)(b)/.match("ab").to_a
+  assert_equal ["b", "b"], /(?<!x)(b)/.match("ab").to_a
 end
 
 assert("Regexp - the comment pass, the named-group scan and the parser skip the same constructs") do
@@ -1377,6 +1504,7 @@ assert("Regexp - case in when") do
 end
 
 assert("Regexp - backreference \\1") do
+  need_backtracking_stack
   # match repeated word
   md = /(\w+) \1/.match("hello hello world")
   assert_equal "hello hello", md[0]
@@ -1384,10 +1512,12 @@ assert("Regexp - backreference \\1") do
 end
 
 assert("Regexp - backreference no match") do
+  need_backtracking_stack
   assert_nil /(\w+) \1/.match("hello world")
 end
 
 assert("Regexp - backreference under /i") do
+  need_backtracking_stack
   # The comparison against the captured text has to fold case too, otherwise
   # `\1` stays case-sensitive while the rest of the pattern does not.
   assert_equal "aA", /(a)\1/i.match("aA")[0]
@@ -1413,11 +1543,6 @@ assert("Regexp - a named group can be written (?'name'...)") do
   assert_equal({"year" => [1], "month" => [2]},
                /(?'year'\d+)-(?'month'\d+)/.named_captures)
 
-  # either spelling of \k reaches a group written in either spelling
-  assert_equal "aa", "aa".match(/(?'n'\w)\k<n>/)[0]
-  assert_equal "aa", "aa".match(/(?<n>\w)\k'n'/)[0]
-  assert_equal "aa", "aa".match(/(?'n'\w)\k'n'/)[0]
-
   # the two spellings write into one registry: a name given twice is reported
   # once however each of them was spelled
   assert_equal ["t"], /(?<t>\w)(?'t'\w)/.names
@@ -1437,6 +1562,15 @@ assert("Regexp - a named group can be written (?'name'...)") do
   assert_raise(RegexpError) { Regexp.new("(?''x)") }
   assert_raise(RegexpError) { Regexp.new("(?'x") }
   assert_raise(RegexpError) { Regexp.new("(?'") }
+end
+
+assert("Regexp - either spelling of \\k reaches either spelling of a name") do
+  need_backtracking_stack
+  # The reference half of the block above, which the declaration alone
+  # cannot show: a group written in one spelling is reached by the other.
+  assert_equal "aa", "aa".match(/(?'n'\w)\k<n>/)[0]
+  assert_equal "aa", "aa".match(/(?<n>\w)\k'n'/)[0]
+  assert_equal "aa", "aa".match(/(?'n'\w)\k'n'/)[0]
 end
 
 assert("Regexp - a (?'name'...) group demotes plain groups too") do
@@ -1497,8 +1631,12 @@ assert("Regexp - empty group name") do
   assert_raise(RegexpError) { Regexp.new("(?<>x)\\k<>") }
   assert_raise(RegexpError) { Regexp.new("\\k<>") }
   assert_raise(RegexpError) { Regexp.new("\\k''") }
+end
 
-  # lookbehind is not a named group and is unaffected
+assert("Regexp - a lookbehind is no named group with an empty name") do
+  need_backtracking_stack
+  # `(?<` opens one only where `=` or `!` does not follow, so the refusal
+  # above reaches no lookbehind.
   assert_equal "b", Regexp.new("(?<=a)b").match("ab")[0]
   assert_nil Regexp.new("(?<!a)b").match("ab")
 end
@@ -1521,17 +1659,23 @@ assert("Regexp - group name longer than a uint16 length") do
   assert_equal "y", md[long]
   assert_equal({ "ab" => "x", long => "y" }, md.named_captures)
 
-  # \k binds to the group the name was written on
-  re = Regexp.new("(?<ab>x)(?<#{long}>y)\\k<#{long}>")
-  assert_nil re.match("xyx")
-  assert_equal "xyy", re.match("xyy")[0]
-
   # a name of exactly 65536 bytes is not the empty name
   z = "Z" * 65536
   assert_equal [z], Regexp.new("(?<#{z}>x)").named_captures.keys
 end
 
+assert("Regexp - \\k binds to the group a long name was written on") do
+  need_backtracking_stack
+  # The reference half of the truncation above: two names that shared a
+  # truncated length must not share a group here either.
+  long = "ab" + "A" * 65536
+  re = Regexp.new("(?<ab>x)(?<#{long}>y)\\k<#{long}>")
+  assert_nil re.match("xyx")
+  assert_equal "xyy", re.match("xyy")[0]
+end
+
 assert("Regexp - named backreference \\k") do
+  need_backtracking_stack
   assert_equal "aa", "aa".match(/(?<n>\w)\k<n>/)[0]
   assert_equal "abba", "abba".match(/(?<a>.)(?<b>.)\k<b>\k<a>/)[0]
   assert_equal "1212", "1212".match(/(?<x>\d+)\k'x'/)[0]
@@ -1542,6 +1686,9 @@ assert("Regexp - named backreference \\k") do
   # /i folds the comparison against the captured text
   assert_equal "aA", "aA".match(/(?<n>a)\k<n>/i)[0]
   assert_nil "ab".match(/(?<n>a)\k<n>/i)
+end
+
+assert("Regexp - a \\k reference names a group the pattern has") do
   # an unknown name is an error
   assert_raise(RegexpError) { Regexp.new("\\k<missing>") }
 
@@ -1670,10 +1817,6 @@ assert("Regexp - \\k group reference errors say which failure it was") do
     Regexp.new("(a)(?<b>b)\\k<5>")
   end
 
-  # leading zeros are digits like any other, not a malformed name
-  assert_equal "aa", "aa".match(Regexp.new("(a)\\k<01>"))[0]
-  assert_equal "aa", "aa".match(Regexp.new("(a)\\k<-01>"))[0]
-
   # The name is a length-counted slice of the pattern, so a name holding a NUL
   # is quoted whole. CRuby builds these messages through a C string and stops
   # at the NUL, reporting `undefined name <a` for the first of the two.
@@ -1685,6 +1828,15 @@ assert("Regexp - \\k group reference errors say which failure it was") do
                             "invalid group name <1\0>: /(a)\\k<1\0>/") do
     Regexp.new("(a)\\k<1\0>")
   end
+end
+
+assert("Regexp - a \\k reference reads leading zeros as digits") do
+  need_backtracking_stack
+  # Not a malformed name, which is the failure the block above pins: <01> is
+  # group 1 and <-01> is the group one back, and the reference matching is
+  # what says the name resolved.
+  assert_equal "aa", "aa".match(Regexp.new("(a)\\k<01>"))[0]
+  assert_equal "aa", "aa".match(Regexp.new("(a)\\k<-01>"))[0]
 end
 
 assert("Regexp - a group name may not be a number") do
@@ -1717,7 +1869,6 @@ assert("Regexp - a group name may not be a number") do
   assert_equal ["a1"], Regexp.new("(?<a1>c)").names
   assert_equal ["a-b"], Regexp.new("(?<a-b>c)").names
   assert_equal ["a b"], Regexp.new("(?<a b>c)").names
-  assert_equal "cc", "cc".match(Regexp.new("(?<a b>c)\\k<a b>"))[0]
 end
 
 assert("Regexp - a group name may not hold a ')'") do
@@ -1750,6 +1901,14 @@ assert("Regexp - a group name may not hold a ')'") do
   # the first byte is exempt in both arms, as it is in CRuby: a lone ')' is a
   # name a group can carry and a reference can reach
   assert_equal [")"], Regexp.new("(?<)>c)").names
+end
+
+assert("Regexp - a name a group carries is a name a reference reaches") do
+  need_backtracking_stack
+  # What the two blocks above leave to the parser, this one runs: \k resolves
+  # the name the group was declared with, whichever delimiter wrote either
+  # and whatever byte the name holds past its first.
+  assert_equal "cc", "cc".match(Regexp.new("(?<a b>c)\\k<a b>"))[0]
   assert_equal "cc", "cc".match(Regexp.new("(?<)>c)\\k<)>"))[0]
   assert_equal "cc", "cc".match(Regexp.new("(?')'c)\\k')'"))[0]
 end
@@ -1774,28 +1933,33 @@ assert("Regexp - named captures survive source string mutation") do
 end
 
 assert("Regexp - positive lookahead (?=...)") do
+  need_backtracking_stack
   md = /\w+(?=@)/.match("user@host")
   assert_equal "user", md[0]
 end
 
 assert("Regexp - negative lookahead (?!...)") do
+  need_backtracking_stack
   md = /\d+(?!%)/.match("100%")
   assert_equal "10", md[0]
 end
 
 assert("Regexp - lookahead does not consume") do
+  need_backtracking_stack
   md = /foo(?=bar)/.match("foobar")
   assert_equal "foo", md[0]
   assert_nil /foo(?=baz)/.match("foobar")
 end
 
 assert("Regexp - positive lookbehind (?<=...)") do
+  need_backtracking_stack
   md = Regexp.new("(?<=@)\\w+").match("user@host")
   assert_equal "host", md[0]
   assert_nil Regexp.new("(?<=@)\\w+").match("user_host")
 end
 
 assert("Regexp - negative lookbehind (?<!...)") do
+  need_backtracking_stack
   md = Regexp.new("(?<!\\d)px").match("12px auto")
   assert_nil md  # preceded by digit
   md = Regexp.new("(?<!\\d)em").match("12px 1.5em auto")
@@ -1805,12 +1969,14 @@ assert("Regexp - negative lookbehind (?<!...)") do
 end
 
 assert("Regexp - lookbehind with literal string") do
+  need_backtracking_stack
   md = Regexp.new("(?<=foo)bar").match("foobar")
   assert_equal "bar", md[0]
   assert_nil Regexp.new("(?<=foo)bar").match("bazbar")
 end
 
 assert("Regexp - lookbehind at string start") do
+  need_backtracking_stack
   # lookbehind should fail if not enough text before
   assert_nil Regexp.new("(?<=abc)d").match("d")
   # but should work at correct position
@@ -1819,12 +1985,14 @@ assert("Regexp - lookbehind at string start") do
 end
 
 assert("Regexp - negative lookbehind at string start") do
+  need_backtracking_stack
   # negative lookbehind succeeds when not enough text before
   md = Regexp.new("(?<!x)a").match("a")
   assert_equal "a", md[0]
 end
 
 assert("Regexp - a capture inside a lookaround is undone with the lookaround") do
+  need_backtracking_stack
   # A lookaround's sub-pattern used to run in a call of its own, so once it
   # had matched, the frames that could undo what it captured were gone, and
   # backtracking past the lookaround left the capture written. A plain
@@ -1929,6 +2097,7 @@ assert("Regexp - lookbehind against a binary subject rewinds by bytes") do
 end
 
 assert("Regexp - lookbehind measures bytes that spell no character") do
+  need_backtracking_stack
   # A byte no lead byte reaches is a character of its own, which is what the
   # rewind steps back over, so the width has to count it as one. Counting the
   # lead bytes of the run alone made such a byte part of the character before
@@ -1964,6 +2133,7 @@ assert("Regexp - lookbehind measures bytes that spell no character") do
 end
 
 assert("Regexp - lookbehind over a class holding a byte that spells no character") do
+  need_backtracking_stack
   # Two things meet here that were built apart: a character class may hold a
   # byte that starts no character, and the rewind steps back over characters.
   # They agree on the unit already: such a byte is a character of its own,
@@ -1993,6 +2163,7 @@ assert("Regexp - lookbehind over a class holding a byte that spells no character
 end
 
 assert("Regexp - lookbehind measures an ASCII-only class") do
+  need_backtracking_stack
   assert_equal "x", "ax".match(/(?<=[a-z])x/)[0]
   assert_nil "1x".match(/(?<=[a-z])x/)
   assert_equal "x", "1x".match(/(?<=\d)x/)[0]
@@ -2019,6 +2190,7 @@ assert("Regexp - consecutive optional quantifiers (#6853)") do
 end
 
 assert("Regexp - a relocated lookaround keeps the end of its sub-pattern") do
+  need_backtracking_stack
   # A lookaround holds the end of its sub-pattern as an absolute code index,
   # so every relocation has to carry it the way it carries a jump target.
   # Neither relocator did: the stale index landed on the sub-pattern's own
@@ -2105,11 +2277,13 @@ assert("Regexp - a hex escape needs at least one digit") do
   assert_equal 0, (Regexp.new("[\\x4]") =~ "\x04")
 end
 
-assert("Regexp - a digit escape is a backreference or an octal escape by the group count") do
+assert("Regexp - a digit escape no group answers to is an octal escape") do
   # Outside a class the digits after the backslash are read as one decimal
   # number: a backreference when it is at most 9 or at most the number of
   # groups opened before it, as CRuby reads it, and an octal escape of up
-  # to three digits otherwise. \0 is always octal.
+  # to three digits otherwise. \0 is always octal. An octal escape is a
+  # byte like any other, so none of these leaves the Pike VM; what the
+  # count does make a backreference is pinned below.
   assert_equal 0, (/\101/ =~ "A")
   assert_equal 0, (/\12/ =~ "\n")
   assert_equal 0, (/\100/ =~ "@")
@@ -2123,17 +2297,6 @@ assert("Regexp - a digit escape is a backreference or an octal escape by the gro
   # digit itself
   assert_equal 0, (/\81/ =~ "81")
   assert_equal 0, (/\99/ =~ "99")
-
-  # the count is taken where the escape stands, so the same \10 refers back
-  # after ten groups and is octal 010 before them
-  ten = "(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)"
-  assert_equal 0, (Regexp.new("#{ten}\\10") =~ "abcdefghijj")
-  assert_nil Regexp.new("#{ten}\\10") =~ "abcdefghij\b"
-  assert_equal 0, (Regexp.new("#{ten}\\10{2}") =~ "abcdefghijjj")
-  assert_equal 0, (Regexp.new("#{ten}\\11") =~ "abcdefghij\t")
-  assert_equal 0, (Regexp.new("#{ten}(k)\\11") =~ "abcdefghijkk")
-  assert_equal 0, (Regexp.new("\\10#{ten}") =~ "\babcdefghij")
-  assert_equal 0, (/(a)(b)(c)(d)(e)(f)(g)(h)(i)\10/ =~ "abcdefghi\b")
 
   # A named pattern counts its plain groups too, since CRuby demotes them
   # only once the parse is done: what the count makes a backreference is
@@ -2149,9 +2312,29 @@ assert("Regexp - a digit escape is a backreference or an octal escape by the gro
     Regexp.new("(?<n>a)(?<m>b)(c)(d)(e)(f)(g)(h)(i)(j)\\10")
   end
 
-  # Under /x whitespace ends the number and a comment does not, as in
-  # CRuby, whose tokenizer stops at whitespace but never sees a comment.
+  # Under /x whitespace ends the number, so `\10 1` is octal 010 and a `1`
   assert_equal 0, (Regexp.new("\\10 1", Regexp::EXTENDED) =~ "\b1")
+end
+
+assert("Regexp - a digit escape is a backreference or an octal escape by the group count") do
+  need_backtracking_stack
+  # The count is taken where the escape stands, so the same \10 refers back
+  # after ten groups and is octal 010 before them. Each pair here is the
+  # same spelling read both ways, which is why the octal half stands under
+  # this guard with the backreference half rather than beside the escapes
+  # above.
+  ten = "(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)"
+  assert_equal 0, (Regexp.new("#{ten}\\10") =~ "abcdefghijj")
+  assert_nil Regexp.new("#{ten}\\10") =~ "abcdefghij\b"
+  assert_equal 0, (Regexp.new("#{ten}\\10{2}") =~ "abcdefghijjj")
+  assert_equal 0, (Regexp.new("#{ten}\\11") =~ "abcdefghij\t")
+  assert_equal 0, (Regexp.new("#{ten}(k)\\11") =~ "abcdefghijkk")
+  assert_equal 0, (Regexp.new("\\10#{ten}") =~ "\babcdefghij")
+  assert_equal 0, (/(a)(b)(c)(d)(e)(f)(g)(h)(i)\10/ =~ "abcdefghi\b")
+
+  # Under /x whitespace ends the number and a comment does not, as in
+  # CRuby, whose tokenizer stops at whitespace but never sees a comment: the
+  # first is `\1` and a `0`, and the other two are octal 010.
   assert_equal 0, (Regexp.new("(a)\\1 0", Regexp::EXTENDED) =~ "aa0")
   assert_equal 0, (Regexp.new("(a)\\1#c\n0", Regexp::EXTENDED) =~ "a\b")
   assert_equal 0, (/(a)\1(?#c)0/ =~ "a\b")
@@ -2263,8 +2446,11 @@ assert("Regexp - the escapes this engine does not carry are refused") do
 
   # and a bare `\g` is the letter outside one too
   assert_equal "g", "g"[/\g/]
+end
 
-  # `\k<name>` is the backreference this engine does carry
+assert("Regexp - \\k<name> is the group reference this engine does carry") do
+  need_backtracking_stack
+  # `\g<name>` is refused above; the letter one apart from it is not.
   assert_equal "aa", "aa"[/(?<n>a)\k<n>/]
 end
 

--- a/mrbgems/mruby-regexp/test/regexp_utf8.rb
+++ b/mrbgems/mruby-regexp/test/regexp_utf8.rb
@@ -86,6 +86,7 @@ assert("Regexp - /i does not read a byte above 127 as a character") do
 end
 
 assert("Regexp - a backreference under /i folds a byte-indexed subject by ASCII") do
+  need_backtracking_stack
   # A byte-indexed subject hands the folded comparison bytes, and a byte above
   # 127 is not the codepoint of the same value: 0xC0 is not U+00C0. The
   # comparison folded it as if it were, so a build with the Unicode table

--- a/mrbgems/mruby-regexp/test/string_index.rb
+++ b/mrbgems/mruby-regexp/test/string_index.rb
@@ -470,6 +470,7 @@ assert("a backward search answers a long multibyte subject") do
 end
 
 assert("a backward search raises where one of its searches hits a limit") do
+  need_backtracking_stack
   # The search makes up to three searches: a window at the end that widens,
   # the whole range when no window answers, and a walk forward from the match
   # it found. A limit in any of them is the answer to the whole question, so
@@ -477,34 +478,35 @@ assert("a backward search raises where one of its searches hits a limit") do
   # would widen, or as the walk having run out of matches, which would answer
   # the one before.
   #
-  # The subjects are sized from the recursion limit, which the build sets and
-  # `Regexp::RECURSION_LIMIT` reads back. An atomic group nested d deep spends
-  # 2d frames per copy and one more per iteration of a repetition, and d is
-  # chosen so that a run inside the 256 bytes the window reads spends the
-  # limit; a build with a limit the window cannot reach sends the first and
-  # third cases through the whole-range search instead, where they raise the
-  # same.
-  limit = Regexp::RECURSION_LIMIT
-  d = limit / 600 + 1
-  atom = "a"
-  d.times { atom = "(?>#{atom})" }
-  # the window, grown to the whole subject: the lookbehind lets only position
-  # 0 try, and that one gives up
-  n = limit / (2 * d + 1) + 1
-  assert_raise(RegexpError) { ("a" * n + "b").rindex(/(?<!a)(?:#{atom})*b/) }   # was nil, CRuby 0
-  # the whole range, once no window within 256 bytes of the end has answered
-  assert_raise(RegexpError) { ("a" * limit + "b" + "c" * 300).rindex(/\A(?:(?>a))*b/) }  # was nil, CRuby 0
-  # the walk from the window's match at position 1 to position 2, which has
-  # the run the second alternative asks for and gives up on; the windows
-  # before the one that reaches position 1 have less than that run
-  n = limit / (2 * d) + 1
-  assert_raise(RegexpError) { ("x" + "a" * (n + 1) + "c").rindex(/(?<=x)a|(?:#{atom}){#{n}}c/) }  # was 1, CRuby 2
+  # The subjects are sized from the stack limit, which the build sets and
+  # `Regexp::STACK_LIMIT` reads back: a repetition of an atomic group
+  # holds an entry of backtracking state per iteration, so a run twice as
+  # long as the limit is past it and a run of a fraction of it is inside.
+  # A window reads 256 bytes at most, so a run that gives up is longer than
+  # one and none of the three reaches the limit inside a window: what each
+  # case names is the search that does. A build that puts the stack limit
+  # out of the step limit's reach is left out, as it is where the two limits
+  # are pinned (see regexp_syntax.rb).
+  if Regexp::STACK_LIMIT * 8 > Regexp::STEP_LIMIT
+    skip "the stack limit stands out of the step limit's reach here"
+  end
+  limit = Regexp::STACK_LIMIT
+  over = "a" * (2 * limit)
+  fits = "a" * (limit / 32)
+  # the whole range, no window holding a match: the lookbehind lets only
+  # position 0 try, and that one gives up
+  assert_raise(RegexpError) { (over + "b").rindex(/(?<!a)(?:(?>a))*b/) }   # was nil, CRuby 0
+  # the whole range again, once no window within 256 bytes of the end has
+  # answered
+  assert_raise(RegexpError) { (over + "b" + "c" * 300).rindex(/\A(?:(?>a))*b/) }  # was nil, CRuby 0
+  # the walk from the whole range's match at position 1 to position 2, which
+  # has the run the second alternative takes and gives up on; the tail of `d`
+  # is what keeps the windows from answering first
+  assert_raise(RegexpError) { ("x" + over + "c" + "d" * 300).rindex(/(?<=x)a|(?:(?>a))*c/) }  # was 1, CRuby 2
   # Inside the limits the same three searches answer, as in CRuby.
-  n = limit / (2 * (2 * d + 1))
-  assert_equal 0, ("a" * n + "b").rindex(/(?<!a)(?:#{atom})*b/)
-  assert_equal 0, ("a" * (limit / 4) + "b" + "c" * 300).rindex(/\A(?:(?>a))*b/)
-  n = limit / (4 * d)
-  assert_equal 2, ("x" + "a" * (n + 1) + "c").rindex(/(?<=x)a|(?:#{atom}){#{n}}c/)
+  assert_equal 0, (fits + "b").rindex(/(?<!a)(?:(?>a))*b/)
+  assert_equal 0, (fits + "b" + "c" * 300).rindex(/\A(?:(?>a))*b/)
+  assert_equal fits.size + 1, ("x" + fits + "c" + "d" * 300).rindex(/(?<=x)a|(?:(?>a))*c/)
 end
 
 assert("String#index and String#rindex with regexp set the match globals") do

--- a/mrbgems/mruby-regexp/test/string_regexp.rb
+++ b/mrbgems/mruby-regexp/test/string_regexp.rb
@@ -739,19 +739,29 @@ end
 
 assert("String#gsub with block and zero-width match") do
   assert_equal "!abc", "abc".gsub(/^/) { "!" }
-  assert_equal "a!bc", "abc".gsub(/(?=b)/) { "!" }
   assert_equal "!a!b!c!", "abc".gsub(//) { "!" }
   assert_equal "!\n", "\n".gsub(/^/m) { "!" }
   assert_equal "!a\n", "a\n".gsub(/^/m) { "!" }
   assert_equal "!a\n!b", "a\nb".gsub(/^/m) { "!" }
   if __ENCODING__ == "UTF-8"
     assert_equal "！いろは", "いろは".gsub(/^/) { "！" }
-    assert_equal "い！ろは", "いろは".gsub(/(?=ろ)/) { "！" }
     assert_equal "！い！ろ！は！", "いろは".gsub(//) { "！" }
   end
   bin = "\xC3\xA9x".b
   assert_equal [45, 195, 45, 169, 45, 120, 45], bin.gsub(//, "-").bytes
   assert_equal [45, 195, 45, 169, 45, 120, 45], bin.gsub(//) { "-" }.bytes
+end
+
+assert("String#gsub with a zero-width lookahead") do
+  need_backtracking_stack
+  # The same walk over empty matches, with a lookahead as the pattern: what
+  # is under test is the walk, and the lookahead is what routes the search
+  # to the backtracking engine.
+  assert_equal "a!bc", "abc".gsub(/(?=b)/) { "!" }
+  if __ENCODING__ == "UTF-8"
+    assert_equal "い！ろは", "いろは".gsub(/(?=ろ)/) { "！" }
+  end
+  bin = "\xC3\xA9x".b
   assert_equal [45, 195, 45, 169, 45, 120], bin.gsub(/(?=.)/, "-").bytes
   assert_equal [45, 195, 45, 169, 45, 120], bin.gsub(/(?=.)/) { "-" }.bytes
 end
@@ -891,7 +901,13 @@ assert("String#split with regexp captures") do
   assert_equal ["hell", ""], "hello".split(/(x)?o/, -1)
 end
 
+assert("String#split at a zero-width anchor") do
+  assert_equal ["abc"], "abc".split(/^/)
+  assert_equal ["abc", ""], "abc".split(/$/, -1)
+end
+
 assert("String#split with zero-width regexp") do
+  need_backtracking_stack
   assert_equal ["ab"], "ab".split(/(?=b)/, 1)
   assert_equal ["a", "b"], "ab".split(/(?=b)/, 2)
   assert_equal ["a", "b"], "ab".split(/(?=b)/, 3)
@@ -900,17 +916,19 @@ assert("String#split with zero-width regexp") do
   assert_equal ["abc"], "abc".split(/(?=a)/)
   assert_equal ["abc"], "abc".split(/(?=a)/, -1)
   assert_equal ["ab", "c"], "abc".split(/(?=c)/)
-  assert_equal ["abc"], "abc".split(/^/)
-  assert_equal ["abc", ""], "abc".split(/$/, -1)
   assert_equal ["a", "b", "bc"], "abc".split(/(?=(b))/)
 end
 
 assert("String#split with multibyte regexp") do
+  assert_equal ["", "あ", "い"], "あい".split(/(あ)/)
+  assert_equal ["", "あ", "い"], "あい".split(/(あ)/, -1)
+end
+
+assert("String#split with a multibyte zero-width regexp") do
+  need_backtracking_stack
   assert_equal ["あ", "い"], "あい".split(/(?=い)/)
   assert_equal ["あ", "い"], "あい".split(/(?=い)/, -1)
   assert_equal ["あ", "い", "い"], "あい".split(/(?=(い))/)
-  assert_equal ["", "あ", "い"], "あい".split(/(あ)/)
-  assert_equal ["", "あ", "い"], "あい".split(/(あ)/, -1)
 end
 
 assert("String#gsub with block leaves the last match behind") do
@@ -1080,13 +1098,6 @@ assert("String#gsub with a block that changes the receiver") do
   assert_equal "a!cz", s.gsub(/b/) { s[3] = "z"; "!" }
   s = "abc"
   assert_equal "-A-B-C-", s.gsub(//) { s.upcase!; "-" }
-  # What the walk takes after the block is what the block left, which needs
-  # the bytes read again rather than the pointer the search was made with. A
-  # replacement of the same length moves the buffer without changing the
-  # length, so this stands whatever a check on the length would say: reading
-  # the old pointer keeps one byte of the subject as it was.
-  s = "a" * 200
-  assert_equal "-" + "b" * 200, s.gsub(/(?=a)/) { s.replace("b" * 200); "-" }
   # a quoted String pattern goes the same way
   s = "hello"
   assert_equal "HeXXo", s.gsub("l") { s.tr!("h", "H"); "X" }
@@ -1131,6 +1142,19 @@ assert("String#gsub with a block that changes the receiver") do
   assert_equal "heXlo", s.sub(/l/) { s.upcase!; "X" }
   s = "abc"
   assert_equal "a!c", s.sub(/b/) { s << "zz"; "!" }
+end
+
+assert("String#gsub reads the receiver again after a block that moved it") do
+  need_backtracking_stack
+  # What the walk takes after the block is what the block left, which needs
+  # the bytes read again rather than the pointer the search was made with. A
+  # replacement of the same length moves the buffer without changing the
+  # length, so this stands whatever a check on the length would say: reading
+  # the old pointer keeps one byte of the subject as it was. The lookahead
+  # is what makes the match empty, so that the byte the walk steps over is
+  # read from the receiver rather than from the match.
+  s = "a" * 200
+  assert_equal "-" + "b" * 200, s.gsub(/(?=a)/) { s.replace("b" * 200); "-" }
 end
 
 assert("String#sub! with a block that changes the receiver") do
@@ -1216,14 +1240,21 @@ assert("MatchData#regexp compiles a literal pattern only when asked for one") do
 end
 
 assert("String#sub / #gsub / #scan / #split raise where a search hits a limit") do
+  need_backtracking_stack
   # A walk over the subject raises from the middle of it rather than hand
   # back what it had: the matches before the limit are no more the answer
   # than the shorter match a search itself used to settle for. The first
-  # search here matches the `b`; the second gives up on the run of `a`, three
-  # frames an iteration and as long as the recursion limit, and the walk used
-  # to go on past it to the tail of the run that fit before the `c`.
-  over = "a" * Regexp::RECURSION_LIMIT
-  fits = "a" * (Regexp::RECURSION_LIMIT / 4)
+  # search here matches the `b`; the second gives up on the run of `a`, an
+  # entry of backtracking state an iteration and longer than the stack limit
+  # allows entries, and the walk used to go on past it to the tail of
+  # the run that fit before the `c`. A build that puts the stack limit out of
+  # the step limit's reach is left out, as it is where the two limits are
+  # pinned (see regexp_syntax.rb).
+  if Regexp::STACK_LIMIT * 8 > Regexp::STEP_LIMIT
+    skip "the stack limit stands out of the step limit's reach here"
+  end
+  over = "a" * (2 * Regexp::STACK_LIMIT)
+  fits = "a" * (Regexp::STACK_LIMIT / 32)
   s = "b" + over + "c"
   re = /b|(?:(?>a))*c/
   assert_raise(RegexpError) { s.gsub(re, "x") }    # was "x" + most of the run + "x", CRuby "xx"


### PR DESCRIPTION
## Summary

`bt_match()` recursed at every fork, so the C stack *was* the backtracking stack and `MRB_REGEXP_RECURSION_LIMIT` was what kept a long subject from overflowing it. A greedy repetition forks once per iteration whatever its body holds, so what reached the limit was the length of the run and not the nesting of the pattern: `/(?:(?>a))*/` gave up after 332 iterations and `/(?:a)*(b)\1/` after 996. The state moves onto two stacks of the engine's own, on the heap; `bt_match()` becomes one loop, and a search spends one C frame however long the subject is. What the limit counts moves with it: entries a search would have to put back, rather than C frames or calls made.

## Changes

| File | What |
| --- | --- |
| `src/re_exec.c` | added `re_cpoint`, `re_undo`, `bt_room()`, `bt_grow_capa()`, `bt_push()`, `bt_log()`, `bt_undo_to()`, `bt_barrier_find()`, `bt_iter_begin()`; removed `bt_iter()`, `bt_look()`, `BT_CUT()` and `bt_match()`'s `depth` parameter; `bt_log()` records a write only where the slot changes |
| `include/re_internal.h` | `MRB_REGEXP_RECURSION_LIMIT` (1000) becomes `MRB_REGEXP_STACK_LIMIT` (2048), the old name an `#error`; `RE_OVER_RECURSION_LIMIT` becomes `RE_OVER_STACK_LIMIT`, and `RE_NOMEM` joins it; an `#error` bounds what the new macro may be set to |
| `src/regexp.c` | `Regexp::RECURSION_LIMIT` becomes `Regexp::STACK_LIMIT`; `re_check_over_limit()` becomes `re_check_exec_error()`, which raises `NoMemoryError` on `RE_NOMEM` and `RegexpError` naming the knob on either limit |
| `README.md` | the two limits described as the work a search may do and the state it may hold, with what the stack limit does and does not bound |
| `test/regexp_syntax.rb` | five asserts added for what no longer costs C stack; the limit asserts re-sized from the new constant, and skipped on a build whose two limits leave them nothing to pin; the step limit pinned by a pattern that holds little while spending much; the blocks that mixed parser checks with engine checks split so that only the latter carry the skip |
| `test/string_index.rb`, `test/string_regexp.rb` | the limit subjects re-sized from the new constant; the same split |
| `test/backtracking_stack.rb` | new: what a test that reaches the backtracking engine asks of the build's limit (48), and the skip where it stands below that |

### Two stacks rather than one

A choice point is a branch not taken: where the input stood (`sp`), which instruction takes the branch (`pc`), and how tall the undo log was when it was pushed. An undo record is one write to take back: the slot, and what stood in it. Backtracking pops a choice point, unwinds the log to its height, and goes on from there.

They are separate stacks because what a cut does to each differs. The captures a positive lookaround or an atomic group wrote outlive it, so its cut drops the choice points above its barrier and leaves the log alone, where a negative lookaround unwinds both. One mixed stack could not truncate at all: it would have to walk the region above the barrier and keep the undo records while dropping the choice points.

### A cut is a truncation

Entering an atomic group or a lookaround pushes a barrier onto the choice point stack. Reaching one while backtracking is that group failing, so it resumes nothing and the search goes on popping; its end drops the barrier and everything above it. A negative lookaround's barrier is the one that resumes rather than keeps being popped, its sub-pattern running out of alternatives being the assertion holding. That is what `BT_CUT` was, and it goes with the recursion.

Two things ride on the barrier rather than on the undo log. The pass a lookaround was entered from is one, since a positive lookaround has to come back to it without unwinding anything; and a pass is numbered from a counter, so that no two runs of a sub-pattern share one where the frame depth that numbered them could.

### The limit is renamed, and the old name is refused

What the limit counted was C frames. What a search may hold now is the height of a stack of the engine's own, on the heap, so the name says so:

| was | is |
| --- | --- |
| `MRB_REGEXP_RECURSION_LIMIT` (1000) | `MRB_REGEXP_STACK_LIMIT` (2048) |
| `Regexp::RECURSION_LIMIT` | `Regexp::STACK_LIMIT` |
| `recursion limit over (MRB_REGEXP_RECURSION_LIMIT)` | `stack limit over (MRB_REGEXP_STACK_LIMIT)` |

The old macro is not aliased to the new one. The two count different things, so a value chosen for C frames does not carry over, and a build that had `-DMRB_REGEXP_RECURSION_LIMIT=500` for a reason has to choose a new number rather than have the header guess one for it. It is not ignored either, which would leave that build running on the default under a restriction it believes it still has: defining it is an `#error` naming the replacement.

### What the limit bounds

An entry is a choice point or an undo record, and `MRB_REGEXP_STACK_LIMIT` counts the two stacks together. What a repetition spends per iteration is what it holds: one choice point where it captures nothing, and undo records on top of that for a capture (up to two writes to open a group, since the end slot is cleared with the start, and one to close it) and for the record of an iteration whose body can match empty. A write of the value already in the slot is not one of them (see the next section). A subject longer than the limit still raises.

Counting live entries does not on its own bound the memory, since the arrays behind them grow geometrically and keep their capacity for the rest of the search: a search that fills one, backtracks, and then fills the other holds both high-water marks, and doubling alone would let each of them stand at up to twice the limit. So neither array is grown past the limit. At most that many entries stand in each, an entry being 32 and 16 bytes on a 64-bit ABI and 24 and 8 on a 32-bit one, which is 98,304 bytes together at the default on a 64-bit build and 65,536 on a 32-bit one, and halving the limit halves the ceiling. The capture slots and the per-instruction iteration records are sized by the pattern and lie outside it.

What a build may set the macro to is bounded where it is defined, at 1 and 16777216, and a build outside that range is an `#error` naming it. The range is the engine's rather than the test suite's: the count the limit is compared against is unsigned, so `-1` would stand for the largest ceiling there is rather than be refused; a capacity is doubled in 32 bits and multiplied by an entry's width to ask the allocator for bytes, which is 32 bits wide as well on a 32-bit ABI, so a value near the top of that range stops sizing anything; and at 0 no search could hold a single entry, which is a limit that has stopped being one.

A low limit inside that range is a build's to choose, and nothing here reads it as a mistake: what it buys is a smaller ceiling on what one search may ask the allocator for, at the price of the patterns the engine will match. An ordinary pattern holds a handful of entries whatever its subject, ten groups and a backreference holding twenty-two of them before the first repetition adds any, so a limit below about 48 answers `RegexpError` to patterns the tests take for granted. That is the engine doing what the build asked, and the tests say so rather than fail (see Testing).

The two limits are set apart from one another as well, which no `#error` can do. Filling the stack costs a handful of steps an entry, so a build that turns this one up far enough puts it out of the step limit's reach: a search that was to stop here stops there. Nothing in the engine reads that as an error, the two being answers to different questions, but the tests that pin the stack limit size their subjects from it and have nothing to pin on such a build (see Testing).

### The limit counts what has to be put back

`bt_log()` took an entry off the budget for every write it was handed, whether or not the write changed anything. `RE_SAVE` is where that showed: opening a group logs the start and then clears the end slot with it, so that a backreference reads a group the repetition has just re-entered as unmatched, and the end slot already holds `-1` wherever the group has not matched in this attempt yet. That second call logged `-1` over `-1`: a record `bt_undo_to()` walks to write `-1` back over `-1`, and an entry `bt_room()` counted on the way in. So the limit bounded the writes a search recorded rather than the state that differs, and two builds with the same limit held different amounts of restorable state depending on how many of their writes were no-ops.

A write of the value already in the slot is not logged now. Backtracking unwinds to a height, and a slot the log does not name is a slot no record has moved, so the value the unwind leaves is the one that stood there; a search at the limit goes on through such a write rather than stopping at one that would have restored nothing. `bt_iter_begin()` is covered by the same line, going through the same function.

The clear is a no-op only on the group's first iteration in an attempt, so a repetition's per-iteration cost is what it was and the run a pattern crosses moves by a character or two. What moves is the constant a fresh attempt pays, one entry per group, and a walk that tries a start position per byte pays it at every one of them: that is where the instruction count falls (see Speed).

### The default is where the move costs no pattern its subject

Taking the state off the C stack is one change and letting a search hold more of it is another, so the default is set where the first costs nothing and stops there: no pattern crosses a shorter run than it did on 1,000 C frames, and none crosses much more than it has to.

The old number does not carry over, a frame not being an entry. A fork was one frame and is one choice point; a capture was one frame and is up to three undo records. So the ratio differs by shape, and the default is read off the tightest of them. The longest run each pattern crosses whole:

| pattern | on 1,000 frames (master) | on 1,024 entries | on 2,048 entries (this PR) |
| --- | --- | --- | --- |
| `/(a)*?b/` | 498 | 340 | 682 |
| `/(a)*(b)\2/` | 332 | 255 | 511 |
| `/(?<x>a)*\k<x>/` | 331 | 254 | 510 |
| `/(?:(a)(b))*(c)\3/` | 399 | 293 | 585 |
| `/((a)*)*(b)\3/` | 330 | 253 | 509 |
| `/(?:(a)b?)*(c)\2/` | 332 | 255 | 511 |
| `/(?:a)*(b)\1/` | 996 | 1,020 | 2,044 |
| `/(?:(?>a))*/` | 332 | 1,021 | 2,045 |
| `/(?:(?=a)a)*/` | 332 | 1,021 | 2,045 |
| `/(?:a(?<=a))*/` | 332 | 1,022 | 2,046 |
| `/(?:(?>(a)))*(b)\2/` | 199 | 255 | 511 |

2,048 is the smallest power of two that clears every row: at 1,024 the six capture-heavy shapes cross less than they did on 1,000 C frames. A chain of atomic groups or of lookarounds, which spent two frames a link, now spends none once each has closed and is bounded by the pattern rather than by this limit either way.

### A refused allocation is not a limit

`mrb_realloc_simple()` is what grows the arrays, a raising allocator longjmping past the `mrb_free()` that ends a search. Reading its NULL as the stack limit would answer `stack limit over (MRB_REGEXP_STACK_LIMIT)` for an allocator that had nothing left, and what a build does about that message is turn the limit up, which is the worst thing it could do about the actual problem.

So the two travel apart. `bt_push()`, `bt_log()` and `bt_iter_begin()` answer `BT_OK`, `BT_LIMIT` or `BT_NOMEM` rather than a truth value, `bt_match()` hands the last two up unchanged the way it hands up a match, and `backtrack_exec()` turns `BT_NOMEM` into `RE_NOMEM` once its buffers are freed. `re_check_exec_error()` raises `NoMemoryError` on it, thrown from the object mruby keeps for that, so the raise itself asks for no memory. There is no automatic test for it. A refused allocation is not reachable from Ruby, and `mrb_open_allocf()` hands an allocator to a state at its birth, so a refusal injected that way is the whole VM's: reaching this engine's two growths and nothing else would take either a hook in the engine that only a test build compiles, or an allocator that guesses at request sizes and the order they arrive in, and neither is worth what it would pin. It was exercised by hand instead, on a build whose two `mrb_realloc_simple()` calls go through an injection that refuses either the first k growths or every one of them, and that can narrow the refusal to one of the two stacks. Neither stack begins with a capacity, so a refusal that stands is met by the first search that needs one:

- refusing every growth, a search that needs either stack raises `NoMemoryError: Out of memory`, which `rescue Exception` catches (it is a direct subclass, as in CRuby), and one that needs neither answers as it did;
- refusing the choice points alone, `/(?:(?>a))*z/` raises where `/(a)\1/` answers, the latter writing an undo record and pushing no choice point; refusing the undo log alone, both raise, a repetition logging where its iteration began;
- refusing the first growth alone, the search that meets it raises and every search after it answers, the buffers of the failed one having been freed and nothing of it left behind.

### The seven commits

Each builds and passes the whole suite on its own at the default limit, as C and as C++, so the migration can be read one mechanism at a time. What a build reads from a limit set low is the tip's answer rather than each step's: the tests that pin the limit size their subjects from it, and a mechanism that has not moved yet is bounded by the C stack instead, so those subjects reach no limit until the sixth commit has landed.

| commit | what it moves off the C stack |
| --- | --- |
| `back the backtracking engine's forks with a heap stack` | the unmarked `RE_SPLIT` / `RE_SPLITNG`, the two stacks, the limit |
| `log a capture's write instead of recursing over it` | `RE_SAVE` |
| `log where an iteration began instead of recursing over it` | `bt_iter()`, `entered_at` / `entered_in` |
| `cut an atomic group by truncating the choice point stack` | `RE_ATOMIC` / `RE_ATOMIC_END` |
| `cut a lookaround by truncating the choice point stack` | `bt_look()`, `RE_LOOK_END`, and with it `BT_CUT` |
| `drop what the frame-per-fork engine left behind` | `depth`, the transitional C-stack bound, the comments |
| `log a write only where there is something to take back` | nothing further; it settles what the limit counts once the state is on the heap |

While the migration is under way the mechanisms that still recurse keep a bound of their own (`RE_FRAME_LIMIT`), which the sixth commit removes. The seventh moves nothing further and is separable from the six: what it settles is what an entry is, which only has an answer once the state is on the heap.

## Behaviour

The run a repetition can cross no longer depends on what its body holds. On the default build, the longest subject each pattern matches whole:

| pattern | master | this PR | CRuby |
| --- | --- | --- | --- |
| `/(?:(?>a))*/` | 332 | 2,045 | bounded by `Regexp.timeout` |
| `/(?:(?=a)a)*/` | 332 | 2,045 | bounded by `Regexp.timeout` |
| `/(?:a)*(b)\1/` | 996 | 2,044 | bounded by `Regexp.timeout` |
| `/(a)*?b/` | 498 | 682 | bounded by `Regexp.timeout` |

Master spent three C frames an iteration on the first two, one on the third and two on the fourth; this PR spends one entry an iteration on the first three and three on the fourth, with `MRB_REGEXP_STACK_LIMIT` at 2,048. The fourth is the tightest of the shapes measured, and is where the default is read off (see Changes). So subjects that raised `RegexpError` on master now answer as CRuby does:

```ruby
s = "a" * 2000
s.match(/(?:(?>a))*/)[0].size              # 2000
s.match(/(?:(?=a)a)*/)[0].size             # 2000
s.match(/(?:(?>a))*\z/).begin(0)           # 0
(s + "bb").match(/(?:a)*(b)\1/).begin(0)   # 0

t = "a" * 600                              # a capture costs three entries an iteration
(t + "b").match(/(a)*?b/).begin(0)         # 0
```

Each of the five raised `recursion limit over (MRB_REGEXP_RECURSION_LIMIT)` on master, and each answers here what CRuby 4.0.6 answers. A chain of groups is bounded by the pattern rather than by the limit now, since a group that has closed holds nothing: `Regexp.new("(?>a)" * 1001 + "a")` and `Regexp.new("(?=a)" * 1001 + "a")` both raised on master and both match here.

A search the allocator refuses raises `NoMemoryError` rather than `RegexpError`, which is new: there was no allocation on this path to refuse before.

What a search costs the process falls with the frames. On the longest runs both builds cross, `/(?:(?>a))*/` over 330 characters and `/(?:a)*(b)\1/` over 990, peak RSS is 3,616 KB on master and 3,348 KB here, taken with address-space randomisation off as the median of 21 runs. 3,348 KB is what this build holds before the search, so its peak is the interpreter's own, where master's stands 256 KB above its. Massif, counting the C stack, puts those two searches at 285,104 bytes against 165,608 and 286,776 against 177,032: the stack a search touches goes from about 146,000 bytes to 7,208, and the two arrays hold 16,508 at their widest on the longer run.

## Speed

Callgrind, default configuration (`-O3`), `Ir(400 iterations) - Ir(200 iterations)` so that start-up cancels, per iteration:

```ruby
s480  = "hello world foo bar " * 24
words = (["alpha1", "beta", "gamma22", "delta", "eps3"] * 20).join(" ")   # 20 words

n.times { s480.gsub(/o/) { } }          # gsub480_blk, the Pike VM
n.times { words.scan(/\w+(?=\d)/) }     # scan_lookahead
n.times { words.scan(/(?<=a)\d+/) }     # scan_lookbehind
n.times { words.scan(/(?>\w+)\d/) }     # scan_atomic
n.times { words.scan(/(\w)\1/) }        # scan_backref
n.times { words.scan(/\w+?\d/) }        # scan_nongreedy
n.times { "aaaaaaaaaaaaaaaaaaaab".match(/(a+)+b/) }   # match_nested
```

| case | master | this PR | delta |
| --- | --- | --- | --- |
| gsub480_blk | 402,530 | 402,617 | +0.0% |
| scan_lookahead | 323,621 | 331,930 | +2.6% |
| scan_lookbehind | 242,033 | 232,842 | -3.8% |
| scan_atomic | 382,387 | 331,449 | -13.3% |
| scan_backref | 278,824 | 260,100 | -6.7% |
| scan_nongreedy | 240,498 | 258,411 | +7.4% |
| match_nested | 37,495 | 37,744 | +0.7% |

An atomic group is where the frames were most expensive, two per iteration, and a barrier push is one write; a non-greedy repetition is where they were cheapest, its iterations sharing a frame, so the heap push is what it pays now. What moves the three `scan` rows the other way is the last commit: a walk tries a start position per byte, and every attempt used to spend an entry per group on clearing an end slot that already held `-1`. `gsub480_blk` is the Pike VM, which this does not touch, and the 87 instructions between the two builds are the layout of code neither of them ran.

The last commit on its own, measured against the six before it:

| case | six commits | with the last | delta |
| --- | --- | --- | --- |
| gsub480_blk | 402,617 | 402,617 | +0.0% |
| scan_lookahead | 338,663 | 331,930 | -2.0% |
| scan_lookbehind | 246,911 | 232,842 | -5.7% |
| scan_atomic | 343,942 | 331,449 | -3.6% |
| scan_backref | 282,927 | 260,100 | -8.1% |
| scan_nongreedy | 264,184 | 258,411 | -2.2% |
| match_nested | 37,744 | 37,744 | +0.0% |
| a scan over sixteen groups | 860,163 | 761,956 | -11.4% |

`match_nested` is one search from one start position, so it pays the constant once and reads the same either way.

Wall clock, minimum of 15 alternating runs, same build and the cases of the review on #7267 alongside the seven above:

```ruby
s480  = "hello world foo bar " * 24
words = (["alpha1", "beta", "gamma22", "delta", "eps3"] * 200).join(" ")  # 200 words

30000.times  { s480.gsub(/o/) { } }        # gsub480_blk
100000.times { "abc".gsub(/b/) { } }       # gsub_abc_blk
100000.times { "abc".scan(/b/) { } }       # scan_abc_blk
100000.times { "abc".sub!(/b/) { } }       # sub!_abc_blk
30000.times  { s480.gsub(/o/, "0") }       # gsub480_str
100000.times { "abc".scan(/b/) }           # scan_abc
100000.times { "abc".sub!(/b/, "0") }      # sub!_abc_str
30000.times  { s480.gsub(/z/) { } }        # gsub480_none
2000.times   { words.scan(/\w+(?=\d)/) }   # scan_lookahead
2000.times   { words.scan(/(?<=a)\d+/) }   # scan_lookbehind
2000.times   { words.scan(/(?>\w+)\d/) }   # scan_atomic
2000.times   { words.scan(/(\w)\1/) }      # scan_backref
2000.times   { words.scan(/\w+?\d/) }      # scan_nongreedy
20000.times  { "aaaaaaaaaaaaaaaaaaaab".match(/(a+)+b/) }   # match_nested
```

| case | master | this PR | ratio |
| --- | --- | --- | --- |
| gsub480_blk | 754ms | 748ms | 0.99x |
| gsub_abc_blk | 132ms | 133ms | 1.01x |
| scan_abc_blk | 141ms | 144ms | 1.02x |
| sub!_abc_blk | 155ms | 156ms | 1.01x |
| gsub480_str | 110ms | 111ms | 1.01x |
| scan_abc | 100ms | 101ms | 1.01x |
| sub!_abc_str | 156ms | 157ms | 1.01x |
| gsub480_none | 34ms | 34ms | 1.00x |
| scan_lookahead | 321ms | 307ms | 0.96x |
| scan_lookbehind | 245ms | 227ms | 0.93x |
| scan_atomic | 367ms | 293ms | 0.80x |
| scan_backref | 292ms | 266ms | 0.91x |
| scan_nongreedy | 237ms | 245ms | 1.03x |
| match_nested | 48ms | 48ms | 1.00x |

Each figure is a whole process, so a few milliseconds of start-up stand in every row.

The two tables agree on the rows that move by more than a couple of percent: the atomic group and the backreference gain, the non-greedy repetition pays, and the eight Pike VM cases stand still. `scan_lookahead` is where they part, +2.6% of the instruction count against 0.96x of the clock, and 14ms on 321ms is what a shared machine moves by between runs. Those are the counts to read rather than the milliseconds beside them.

## Size

`.text` of `bin/mruby`, `size -A`:

| Build | master | this PR | delta |
| --- | --- | --- | --- |
| full-debug (-O0) | 1,905,478 | 1,906,150 | +672 |
| bintest | 1,301,926 | 1,304,310 | +2,384 |
| cxx_abi | 1,326,969 | 1,329,033 | +2,064 |
| byte-string | 1,267,446 | 1,269,734 | +2,288 |
| ascii-ctype | 1,288,262 | 1,290,198 | +1,936 |
| default | 1,214,430 | 1,216,718 | +2,288 |

All of it is the gem: in the default build `re_exec.o` `.text` goes 10,514 to 12,578 and `regexp.o` 26,933 to 27,157, which is that build's +2,288 exactly. `re_compile.o` (27,025) is unchanged. The last commit is 32 of those bytes back, a comparison being cheaper than the push it skips.

## Testing

`rake test` and `rake MRUBY_CONFIG=ci/gcc-clang test` pass on every one of the seven commits. The totals below are the tip:

| Build | Total | KO | Crash | Skip |
| --- | --- | --- | --- | --- |
| full-debug | 2509 | 0 | 0 | 6 |
| bintest | 2509 (+124 bintest) | 0 | 0 | 14 |
| cxx_abi | 2509 | 0 | 0 | 14 |
| byte-string | 2435 | 0 | 0 | 54 |
| ascii-ctype | 2502 | 0 | 0 | 14 |
| default | 2279 (+113 bintest) | 0 | 0 | 54 |

`rake MRUBY_CONFIG=build_config/gcc-asan.rb test` and the clang counterpart pass on the tip as well, both `full-core` under `address,undefined`: 2509 assertions, no failure and no diagnostic from either sanitizer. The two stacks are grown with `mrb_realloc_simple()` and read through raw slot pointers and indices, so the arithmetic behind them is worth running under a sanitizer rather than only under the tests.

The `assert_raise(RegexpError)` assertions that pinned the limits either stay or become `assert_equal`; none goes the other way. The subjects behind them are re-sized once, in the first commit, since that is where the counting rule moves.

A block that pins the stack limit sizes its subjects from `Regexp::STACK_LIMIT`, and the chain of cuts it spells as well, so it asks two things of the build before it runs: that filling the stack cost fewer steps than `MRB_REGEXP_STEP_LIMIT` allows, and that a chain that long be a pattern one may spell. Where either fails it skips, the second by handing the chain to `Regexp.new` and reading the refusal rather than by writing the compiler's instruction count into a test. The step limit is pinned on its own, by `(?:a|a|a|a)+(z)\1`, which spends 4**m steps while holding about 3*m entries: that reads the same however low the stack limit stands, where the `(a+)+\1b` it replaces would fill the stack first and pin the wrong limit.

A test that reaches the backtracking engine without reading the limit asks for one of its own, `need_backtracking_stack` (see `test/backtracking_stack.rb`), and skips where the build stands below it. The engine refuses more patterns as the limit falls, so a build that set it low answers `RegexpError` to a backreference or a lookaround that these files take for granted, and 51 of them lose their subject that way. 48 is where every one matches again, counted down from there: 44 leaves one, 36 two, 1 fifty-one. The last commit is what brings that floor down from 49, an attempt no longer spending an entry per group on a write that restores nothing. The floor is the same on the boxes that run more of these files than `rake test` does: `full-core` and the byte-indexed box both leave one test at 47 and none at 48.

What asks for it is a test and not a file. An assertion that reaches no further than the parser, and one whose pattern the Pike VM runs, hold none of this state and answer the same whatever the limit is, so they stand in an assert of their own and a build with a low limit goes on running them; where a block held both kinds, it is split in two and the two names say which is which. That leaves the guard over 325 assertions rather than over the 640 a block-at-a-time reading of it would cover, and the split is checked the only way it can be: with `need_backtracking_stack` neutered, a build at 1 leaves exactly the 51 tests that carry it, and none of the rest.

There is no assertion for the accounting itself. What a build's limit buys is not readable from Ruby beyond `Regexp::STACK_LIMIT`, and the runs above move by less than a test sized from that constant can pin without writing down what an instruction costs. The floor coming down, and the suite staying green at every limit in the range, is what says the log still restores what it has to.

`rake test` was run at `MRB_REGEXP_STACK_LIMIT` of 1, 2, 8, 16, 32, 47, 48, 64, 1024, 2048, 125000, 125001 and 16777216, and is KO 0 and Crash 0 at every one: the two ends of the range, the default, the floor the tests ask for and the point below it, and the points on either side of where each skip begins. What moves is the skip count, 54 at the default and 105 below 48.

Each commit adds the tests for what it makes match, plus what its mechanism has to keep answering: captures surviving an atomic group's cut, a negative lookaround's captures not surviving, and a start position leaving no iteration record for the next one to read.

Differential runs against CRuby 4.0.6. Patterns are generated over the features this engine carries, each is run under CRuby, under master and under this branch, and what each answers is compared as `MatchData#to_a` inspected; a run whose address space or clock runs out is recorded rather than lost. Master standing beside the branch is what separates a difference this branch introduced from one the gem already had.

Over 10,000 patterns paired with a subject of at most four characters, CRuby answered 9,998: 9,967 of them both builds answer as CRuby does, 27 are cases both already answered differently, and 4 are cases both stop at a limit on. There is no case the two builds answer differently.

A subject of four characters reaches no limit either build sets, so a second run pairs 2,000 patterns with subjects that are runs of 100, 1,000 and 3,000 characters. CRuby answered 1,982: 1,843 both builds answer as CRuby does, 39 are cases master stops at its limit on and this branch answers as CRuby does, 6 are cases both already answered differently, and 94 are cases both stop at a limit on. Here too the two builds part on nothing, and nothing this branch refuses is something master answered: what a search gives up on goes from 148 cases to 109.

A corpus generated in the gem's own terms was run on the tip against master as well: five sets of 4,000 patterns over the 31 subjects over `ab` of length 4 or less, 187,670 lines counting the diagnostics of the patterns that do not compile, written identically by both.

## Environment

<details>
<summary>Machine, toolchain, and the compile line of every build</summary>

| Item | Value |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS |
| Kernel | 7.0.0-30-generic |
| CPU | AMD Ryzen 9 5950X 16-Core Processor |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0 |
| binutils | GNU ld (GNU Binutils) 2.47.20260726 |
| valgrind | valgrind-3.27.1 |
| CRuby (reference) | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |

Actual compile line of `mrbgems/mruby-regexp/src/re_exec.c` in each build (`-MMD -c`, `-I`, and `-o` dropped). `full-debug` is `-O0` because `enable_debug` appends `-g3 -O0` after the toolchain's `-g -O3`; `cxx_abi` compiles C as C++ with `gcc -x c++ -std=gnu++03`, g++ only links.

```console
# full-debug
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-regexp/src/re_exec.c
# bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK mrbgems/mruby-regexp/src/re_exec.c
# cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-regexp/src/re_exec.c
# byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-regexp/src/re_exec.c
# ascii-ctype
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-regexp/src/re_exec.c
# default (no MRUBY_CONFIG), the build every figure above was measured on
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK mrbgems/mruby-regexp/src/re_exec.c
```

</details>
