### PR TITLE
mruby-task: mark the main task's values during GC

### DIFF
--- a/mrbgems/mruby-task/src/task.c
+++ b/mrbgems/mruby-task/src/task.c
@@ -106,6 +106,17 @@ mrb_task_mark_all(mrb_state *mrb)
 {
   int qi;
 
+  /* The main task is created lazily by Task.current and never queued, so
+     the queue walk below cannot reach it. mrb_gc_register() pins only its
+     wrapper object, while the values inside the mrb_task struct are
+     reachable through this mark alone. It can exist while every queue is
+     empty, so mark it before the early return. */
+  if (mrb->task.main_task) {
+    mrb_gc_mark_value(mrb, mrb->task.main_task->self);
+    mrb_gc_mark_value(mrb, mrb->task.main_task->result);
+    mrb_gc_mark_value(mrb, mrb->task.main_task->name);
+  }
+
   /* GC can run before mruby-task's gem init (allocations during
      earlier gem inits trigger it, deterministically so under GC
      stress). At that point the queues are necessarily empty AND the

--- a/mrbgems/mruby-task/test/gc_task.rb
+++ b/mrbgems/mruby-task/test/gc_task.rb
@@ -120,3 +120,20 @@ assert("GC.scheduler_driven collects during scheduler idle") do
     GC.start
   end
 end
+
+# Regression: Task.current.name must still answer "main" after a GC. The
+# main task is created lazily by Task.current and never queued, so the
+# queue walk in mrb_task_mark_all() cannot reach it, and mrb_gc_register()
+# pins only the wrapper object. The name (and result) held in the mrb_task
+# C struct had no GC root. The "main" string was swept on the next GC, and
+# Task.current.name returned a wrong name, whatever object had reused the
+# slot.
+assert("Task.current.name still answers \"main\" after GC") do
+  t = Task.current
+  GC.start
+  # Churn allocations so a swept slot gets reused rather than merely freed.
+  churn = nil
+  200.times { |i| churn = "churn#{i}" }
+  GC.start
+  assert_equal "main", t.name
+end


### PR DESCRIPTION
## Problem

`mrb_task_mark_all()` walks the four scheduler queues, and the main task is never queued. Task.current creates it lazily as a wrapper that is not scheduled, and `mrb_gc_register()` pins only the wrapper object. The name and result values live in the `mrb_task` C struct, which has no mark hook, so the marker never sees them.

As a result, the "main" name string is swept on the next GC. Once its slot is reused, `Task.current.name` returns a wrong name, an unrelated object:

```ruby
t = Task.current
GC.start
200.times { |i| "churn#{i}" }
GC.start
t.name  # => [false, "main", [...], nil] (a recycled Array)
```

## Fix

Mark the main task's values in `mrb_task_mark_all()`, ahead of the queue walk and of the empty-queues early return, since the main task can exist while every queue is empty.

## Testing

Added a regression test. Without the fix it fails with the recycled object shown above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where the main task’s name and related values could be lost during garbage collection when no tasks were queued.
  - `Task.current.name` now remains reliably available after garbage collection and allocation activity.

- **Tests**
  - Added regression coverage for preserving the main task name through garbage collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->