### PR TITLE
mruby-regexp: give back what a refused search took, and stop the capture pool growing with the subject

### DIFF
--- a/mrbgems/mruby-regexp/src/re_exec.c
+++ b/mrbgems/mruby-regexp/src/re_exec.c
@@ -487,8 +487,16 @@ pike_vm(mrb_state *mrb, const mrb_regexp_pattern *pat,
       }
       memcpy(&s.cap_pool[0], &s.cap_pool[base * ncap],
              sizeof(int) * ncap * curr.count);
-      s.pool_next = curr.count;
     }
+    /* Every live slot is a thread's, and a match keeps what it found in
+       result_caps rather than in the pool (see RE_MATCH in add_thread), so a
+       step with no threads left holds no slot either and the pool goes back
+       to the front. Reclaiming only where there was something to renumber
+       would leave the slot each dead attempt took: a run of positions where
+       nothing survives climbs the pool by one a position, and a search over
+       a long enough subject asks the allocator for memory in proportion to
+       the subject rather than to the pattern. */
+    if (!match_only) s.pool_next = curr.count;
 
     advance_gen(&s);
     s.cut = FALSE;

--- a/mrbgems/mruby-regexp/src/re_exec.c
+++ b/mrbgems/mruby-regexp/src/re_exec.c
@@ -136,6 +136,8 @@ typedef struct {
   mrb_bool binary;        /* true: subject is byte-indexed ASCII-8BIT */
   mrb_bool cut;           /* a higher-priority thread matched this step:
                              stop adding/processing lower-priority threads */
+  mrb_bool nomem;         /* the allocator refused the search a buffer it
+                             needed: it stops and answers RE_NOMEM */
   int *result_caps;       /* best match (ncap ints) */
 } pike_state;
 
@@ -383,10 +385,12 @@ pike_vm(mrb_state *mrb, const mrb_regexp_pattern *pat,
 
   mrb_bool match_only = (captures == NULL || captures_size == 0);
 
-  /* Use cached VM state if available (avoids malloc per call) */
+  /* Use cached VM state if available (avoids malloc per call). Whether this
+     search may have it is decided here, since it decides what there is left
+     to allocate; the claim itself is made below, once nothing is left to
+     ask for. */
   mrb_regexp_pattern *mpat = (mrb_regexp_pattern*)pat;  /* for cache_in_use flag */
   mrb_bool use_cache = !mpat->cache_in_use && mpat->cached_visited != NULL;
-  if (use_cache) mpat->cache_in_use = TRUE;
 
   pike_state s;
   s.mrb = mrb;
@@ -398,40 +402,72 @@ pike_vm(mrb_state *mrb, const mrb_regexp_pattern *pat,
   s.match_only = match_only;
   s.binary = binary;
   s.cut = FALSE;
+  s.nomem = FALSE;
   s.pass_span = RE_PASS_SPAN(pat->loop_depth);
   s.gen = 0;
   s.key_max = s.pass_span - 1;
+
+  /* Everything this search holds is given back by one epilogue below, which
+     an allocator that raises would jump past: what had been taken by then
+     would be leaked, and the cache claim made after it would stand for the
+     rest of the pattern's life, since nothing but that epilogue clears it.
+     The allocator that answers NULL is what lets a refusal be the search's
+     own answer (RE_NOMEM) and leave by the same exit as every other one.
+     What was not taken is left NULL, which the epilogue frees as readily. */
+  size_t vsize = sizeof(uint32_t) * ((size_t)pat->code_len + 1);
+  s.pool_next = 0;
+  s.result_caps = NULL;
   if (match_only) {
     s.pool_capa = 1;
-    s.pool_next = 0;
-    s.cap_pool = (int*)mrb_malloc(mrb, sizeof(int) * ncap);
-    s.result_caps = NULL;
+    s.cap_pool = (int*)mrb_malloc_simple(mrb, sizeof(int) * ncap);
+    if (!s.cap_pool) s.nomem = TRUE;
   }
   else {
     s.pool_capa = list_capa * 2;
-    s.pool_next = 0;
-    s.cap_pool = (int*)mrb_malloc(mrb, sizeof(int) * s.pool_capa * ncap);
-    s.result_caps = (int*)mrb_malloc(mrb, sizeof(int) * ncap);
-    memset(s.result_caps, -1, sizeof(int) * ncap);
+    s.cap_pool = (int*)mrb_malloc_simple(mrb, sizeof(int) * s.pool_capa * ncap);
+    s.result_caps = (int*)mrb_malloc_simple(mrb, sizeof(int) * ncap);
+    if (!s.cap_pool || !s.result_caps) s.nomem = TRUE;
+    else memset(s.result_caps, -1, sizeof(int) * ncap);
   }
 
   re_threadlist curr, next;
-  if (use_cache) {
+  s.visited = NULL;
+  curr.threads = next.threads = NULL;
+  curr.capa = next.capa = 0;
+  curr.count = next.count = 0;
+  if (s.nomem) {
+    /* The search is over before it starts; there is nothing left to take. */
+  }
+  else if (use_cache) {
     s.visited = mpat->cached_visited;
-    memset(s.visited, 0, sizeof(uint32_t) * (pat->code_len + 1));
+    memset(s.visited, 0, vsize);
     curr.threads = (re_thread*)mpat->cached_threads[0];
     next.threads = (re_thread*)mpat->cached_threads[1];
     curr.capa = next.capa = mpat->cached_list_capa;
   }
   else {
-    s.visited = (uint32_t*)mrb_calloc(mrb, pat->code_len + 1, sizeof(uint32_t));
-    curr.threads = (re_thread*)mrb_malloc(mrb, sizeof(re_thread) * list_capa);
-    next.threads = (re_thread*)mrb_malloc(mrb, sizeof(re_thread) * list_capa);
-    curr.capa = next.capa = list_capa;
+    s.visited = (uint32_t*)mrb_malloc_simple(mrb, vsize);
+    curr.threads = (re_thread*)mrb_malloc_simple(mrb, sizeof(re_thread) * list_capa);
+    next.threads = (re_thread*)mrb_malloc_simple(mrb, sizeof(re_thread) * list_capa);
+    if (!s.visited || !curr.threads || !next.threads) {
+      s.nomem = TRUE;
+    }
+    else {
+      memset(s.visited, 0, vsize);
+      curr.capa = next.capa = list_capa;
+    }
   }
-  curr.count = next.count = 0;
 
-  for (; sp <= str_end; sp++) {
+  /* Claim the cache last. The claim is on the pattern, which outlives the
+     search, so it may not be made where something between it and the
+     epilogue could leave without reaching the epilogue, which is what every
+     allocation above could do until it stopped raising. A search that
+     was refused the memory to run never claims it and never used it, so it
+     is not the one to release it either. */
+  if (s.nomem) use_cache = FALSE;
+  else if (use_cache) mpat->cache_in_use = TRUE;
+
+  for (; !s.nomem && sp <= str_end; sp++) {
     /* Past the last position a match may start at, only the threads already
        running can still answer; once they are gone nothing can. */
     if (!s.matched && sp > start_cap && curr.count == 0) break;
@@ -587,7 +623,13 @@ pike_vm(mrb_state *mrb, const mrb_regexp_pattern *pat,
   }
 
   int ret = 0;
-  if (s.matched) {
+  if (s.nomem) {
+    /* The allocator had nothing left for a buffer this search needed. It is
+       told apart from a limit all the way out to the caller for the reason
+       backtrack_exec() gives: what it asks for is not a knob turned up. */
+    ret = RE_NOMEM;
+  }
+  else if (s.matched) {
     if (captures && s.result_caps) {
       int copy = ncap < captures_size ? ncap : captures_size;
       memcpy(captures, s.result_caps, sizeof(int) * copy);

--- a/mrbgems/mruby-regexp/src/re_exec.c
+++ b/mrbgems/mruby-regexp/src/re_exec.c
@@ -141,26 +141,47 @@ typedef struct {
   int *result_caps;       /* best match (ncap ints) */
 } pike_state;
 
-static int
-pool_alloc(pike_state *s)
+/* Hand out a capture slot, growing the pool where it has none left. TRUE is
+   a slot having been handed out, and FALSE is the allocator having refused
+   the growth, which is the search stopping: there is no slot to answer with,
+   and an index that is not one would be read as a slot all the same. The
+   refusal is recorded on the state as well, since the walk that asked for it
+   is several frames deep and hands nothing back (see add_thread()).
+
+   Growing with mrb_realloc_simple() rather than mrb_realloc() is what lets
+   the refusal be an answer at all, for the reason pike_vm() gives: a raising
+   allocator here jumps past the epilogue that frees the pool and releases
+   the cache, and by this point the search holds all of both. */
+static mrb_bool
+pool_alloc(pike_state *s, int *slot)
 {
   if (s->pool_next >= s->pool_capa) {
     int new_capa = s->pool_capa * 2;
-    s->cap_pool = (int*)mrb_realloc(s->mrb, s->cap_pool,
-                                     sizeof(int) * new_capa * s->ncap);
+    int *p = (int*)mrb_realloc_simple(s->mrb, s->cap_pool,
+                                      sizeof(int) * new_capa * s->ncap);
+    if (!p) {
+      s->nomem = TRUE;
+      return FALSE;
+    }
+    s->cap_pool = p;
     s->pool_capa = new_capa;
   }
-  return s->pool_next++;
+  *slot = s->pool_next++;
+  return TRUE;
 }
 
-static int
-pool_copy(pike_state *s, int src_slot)
+/* A fresh slot holding what `src_slot` holds. Answers as pool_alloc() does,
+   and for the same reason. */
+static mrb_bool
+pool_copy(pike_state *s, int src_slot, int *slot)
 {
-  int dst = pool_alloc(s);
+  int dst;
+  if (!pool_alloc(s, &dst)) return FALSE;
   memcpy(&s->cap_pool[dst * s->ncap],
          &s->cap_pool[src_slot * s->ncap],
          sizeof(int) * s->ncap);
-  return dst;
+  *slot = dst;
+  return TRUE;
 }
 
 #define CAP(s, slot) (&(s)->cap_pool[(slot) * (s)->ncap])
@@ -218,7 +239,10 @@ add_thread(pike_state *s, re_threadlist *list,
            uint32_t pc, int cap_slot, const char *sp, uint32_t key)
 {
   for (;;) {
-    if (s->cut) return;
+    /* Both of these end the walk without an answer to hand back: a cut is
+       this step having been settled by a higher-priority thread, and a
+       refused allocation is the search stopping (see pool_alloc()). */
+    if (s->cut || s->nomem) return;
     if (pc >= s->pat->code_len) return;
     if (s->visited[pc] >= key) return;
     s->visited[pc] = key;
@@ -262,9 +286,10 @@ add_thread(pike_state *s, re_threadlist *list,
       {
         uint32_t back = re_loop_back(s, inst, pc, key);
         if (back == RE_LOOP_STOP) { pc++; continue; }
-        int cp = s->match_only ? 0 : pool_copy(s, cap_slot);
+        int cp = 0;
+        if (!s->match_only && !pool_copy(s, cap_slot, &cp)) return;
         add_thread(s, list, pc + 1, cap_slot, sp, key);
-        if (s->cut) return;
+        if (s->cut || s->nomem) return;
         pc = inst.offset;
         cap_slot = cp;
         key = back;
@@ -276,9 +301,10 @@ add_thread(pike_state *s, re_threadlist *list,
       {
         uint32_t back = re_loop_back(s, inst, pc, key);
         if (back == RE_LOOP_STOP) { pc++; continue; }
-        int cp = s->match_only ? 0 : pool_copy(s, cap_slot);
+        int cp = 0;
+        if (!s->match_only && !pool_copy(s, cap_slot, &cp)) return;
         add_thread(s, list, inst.offset, cap_slot, sp, back);
-        if (s->cut) return;
+        if (s->cut || s->nomem) return;
         pc = pc + 1;
         cap_slot = cp;
       }
@@ -494,11 +520,15 @@ pike_vm(mrb_state *mrb, const mrb_regexp_pattern *pat,
          test guards the seeding alone and never skips the iteration. */
       if (s.binary || sp >= str_end ||
           !mrb_re_char_interior_p(str, sp, str_end)) {
-        int slot = match_only ? 0 : pool_alloc(&s);
-        if (!match_only) memset(CAP(&s, slot), -1, sizeof(int) * ncap);
+        int slot = 0;
+        if (!match_only) {
+          if (!pool_alloc(&s, &slot)) break;
+          memset(CAP(&s, slot), -1, sizeof(int) * ncap);
+        }
         advance_gen(&s);
         s.cut = FALSE;
         add_thread(&s, &curr, 0, slot, sp, s.gen);
+        if (s.nomem) break;
         if (s.matched && curr.count == 0) break;
       }
     }
@@ -516,11 +546,16 @@ pike_vm(mrb_state *mrb, const mrb_regexp_pattern *pat,
          final block copy to the front is disjoint because pool_next >= count. */
       int base = s.pool_next;
       for (int i = 0; i < curr.count; i++) {
-        int dst = pool_alloc(&s);
+        int dst;
+        if (!pool_alloc(&s, &dst)) break;
         memcpy(CAP(&s, dst), CAP(&s, curr.threads[i].cap_slot),
                sizeof(int) * ncap);
         curr.threads[i].cap_slot = i;
       }
+      /* Leave before the block copy rather than after it: the staging slots
+         it reads from are the ones the loop above was refused, and `base` is
+         past the end of the pool without them. */
+      if (s.nomem) break;
       memcpy(&s.cap_pool[0], &s.cap_pool[base * ncap],
              sizeof(int) * ncap * curr.count);
     }
@@ -570,35 +605,40 @@ pike_vm(mrb_state *mrb, const mrb_regexp_pattern *pat,
       switch (inst.op) {
       case RE_CHAR:
         if (ch == inst.a) {
-          int cp = match_only ? 0 : pool_copy(&s, th->cap_slot);
+          int cp = 0;
+          if (!match_only && !pool_copy(&s, th->cap_slot, &cp)) break;
           add_thread(&s, &next, th->pc + 1, cp, sp + 1, s.gen);
         }
         break;
 
       case RE_ANY:
         if (ch != '\n') {
-          int cp = match_only ? 0 : pool_copy(&s, th->cap_slot);
+          int cp = 0;
+          if (!match_only && !pool_copy(&s, th->cap_slot, &cp)) break;
           add_thread(&s, &next, th->pc + 1, cp, sp + advance, s.gen);
         }
         break;
 
       case RE_ANY_NL:
         {
-          int cp = match_only ? 0 : pool_copy(&s, th->cap_slot);
+          int cp = 0;
+          if (!match_only && !pool_copy(&s, th->cap_slot, &cp)) break;
           add_thread(&s, &next, th->pc + 1, cp, sp + advance, s.gen);
         }
         break;
 
       case RE_CLASS:
         if (class_match(&pat->classes[inst.a], curr_cp, curr_raw)) {
-          int cp = match_only ? 0 : pool_copy(&s, th->cap_slot);
+          int cp = 0;
+          if (!match_only && !pool_copy(&s, th->cap_slot, &cp)) break;
           add_thread(&s, &next, th->pc + 1, cp, sp + advance, s.gen);
         }
         break;
 
       case RE_NCLASS:
         if (!class_match(&pat->classes[inst.a], curr_cp, curr_raw)) {
-          int cp = match_only ? 0 : pool_copy(&s, th->cap_slot);
+          int cp = 0;
+          if (!match_only && !pool_copy(&s, th->cap_slot, &cp)) break;
           add_thread(&s, &next, th->pc + 1, cp, sp + advance, s.gen);
         }
         break;
@@ -608,8 +648,10 @@ pike_vm(mrb_state *mrb, const mrb_regexp_pattern *pat,
       }
 
       /* A higher-priority thread reached a match while building `next`; the
-         remaining (lower-priority) threads in `curr` are cut for this step. */
-      if (s.cut) break;
+         remaining (lower-priority) threads in `curr` are cut for this step.
+         A refused allocation stops the whole search rather than this step,
+         and the loop above reads it as its own end. */
+      if (s.cut || s.nomem) break;
     }
 
     /* swap curr and next */


### PR DESCRIPTION
## Summary

`pike_vm()` takes up to five buffers and the pattern's VM state cache, and gives all six back in one epilogue. Every allocator it used raised when it could not answer, and a raise longjmps past that epilogue: what had been taken by then was leaked, and the cache claim, which nothing but that epilogue clears, stood for the rest of the pattern's life. `NoMemoryError` is an ordinary rescuable exception, so a program that rescues one goes on with a pattern that allocates its VM state afresh on every later search and cannot take the claim back, which nothing reachable from Ruby can repair. Under a capped address space, one refused search leaves the same 2,000 searches 12 to 15 times slower, and 40 refused searches lose 1,273 KiB that never comes back.

A refusal becomes the search's own answer, `RE_NOMEM`, where the backtracking engine already puts one and where `re_check_exec_error()` already raises `NoMemoryError` for it. The claim moves below the last allocation, so nothing between it and the epilogue asks the allocator at all.

One allocator is in the middle of the search rather than at its setup, and most of what it was doing there was work of its own making: a capture slot was reclaimed only on a step that had a live thread, so a run of positions where nothing survives climbed the pool by a slot a position, and a search asked for memory in proportion to the subject rather than to the pattern. `/\B(a)/` over 6,400 bytes held 3,201 slots to use one. That comes first.

## Changes

| File | What |
| --- | --- |
| `mrbgems/mruby-regexp/src/re_exec.c` | the capture pool goes back to the front on every step rather than only where there was something to renumber; `pike_state` gains `nomem`; the setup allocations go to `mrb_malloc_simple()` and answer `RE_NOMEM`; the cache claim moves below the last of them; `pool_alloc()` and `pool_copy()` answer whether they handed out a slot and write it through a pointer |

### The pool gave slots back only where there was something to renumber

A step renumbers each live thread's capture slot to its list index and resets the pool to the number of threads, which is how a slot is reclaimed. That reset sat inside the block doing the renumbering, and that block runs only where there is a thread to renumber, so a step that ended with none kept every slot the attempts at that position had taken.

The slots are not needed. A live slot is a thread's, and a thread that a step's closure killed has none; a match keeps what it found in `result_caps` rather than in the pool. So the pool can go back to the front, and the reset moves out of the block.

What that cost was in proportion to the subject, since the pool grows by doubling. `/\B(a)/` needs one slot at a time:

| subject | slots the search used | master held | this PR holds |
| --- | --- | --- | --- |
| 200 B | 1 | 101 | 1 |
| 800 B | 1 | 401 | 1 |
| 3,200 B | 1 | 1,601 | 1 |
| 6,400 B | 1 | 3,201 | 1 |

At 6,400 bytes that is 61,440 bytes of capture pool for a search whose high-water mark is 16 of them, and all six of those searches grew the pool. Over a corpus of 14,530 searches master grows the pool 28 times and this PR none, and over 438 searches written to push the pool as high as it will go neither grows it.

### A refused buffer is an answer, not a jump

`mrb_malloc_simple()` answers NULL where `mrb_malloc()` raises, which is what lets the refusal leave by the same exit as every other answer: the search stops, the epilogue frees what it holds and releases the claim, and `RE_NOMEM` goes up to `mrb_re_exec()`. `mrb_calloc()` goes with them, since it raises `ArgumentError` on an overflow its caller here cannot reach, and a plain allocation with the `memset` written out says what it does without the second exit. What was not taken is left NULL, which the epilogue frees as readily.

The exception a caller sees is the one it saw before. `re_check_exec_error()` already turns `RE_NOMEM` into `NoMemoryError`, so what changes is not the class raised but what the process is left holding when it is.

### The claim is made after the last allocation

`cache_in_use` is on the pattern, which outlives the search, and only the epilogue clears it, so the claim may not stand over anything that can leave without reaching the epilogue. It was made before all five allocations; it is made after them. A search that was refused the memory to run never claims the cache and is not the one to release it either.

With the allocations no longer raising, this is not what makes the flag safe. What it does is keep the region the claim covers to the region it has to cover, so that the next thing added to the setup does not silently fall inside it.

### `pool_alloc()` answers a slot, or says it has none

The pool's own allocator could not simply stop raising. It answers a slot index, and an index that is not a slot would be read as one, so the refusal needed somewhere to go first. It goes in the answer: `pool_alloc()` and `pool_copy()` hand back whether they handed out a slot and write the slot through a pointer, so no caller can use what it was not given. The refusal is recorded on the state as well, since the epsilon closure that asks for most of the slots is several frames deep and hands nothing back; `add_thread()` reads it where it already reads `s->cut`, which stops a walk for the other reason a walk stops.

One place needs care. The renumbering block leaves before its block copy rather than after it, since the staging slots that copy reads are the ones a refusal did not hand out, and `base` is past the end of the pool without them.

## Behaviour

A search that is not refused anything answers exactly as it did. What a refused one costs the program is what changes, and both halves of it are measurable.

**The pattern goes back to its cache.** A pattern that lost the claim allocates `visited` and both thread lists on every later search. Under `ulimit -v 20000`, 2,000 searches timed before and after one search the allocator refused:

```ruby
re   = Regexp.new("zzzz" + ("(?:a|b)?" * 4000))   # a prefix the subject has not
subj = "q" * 64                                   # got, so a search is its setup
2000.times { re =~ subj }                         # before
begin; hog = "x" * (12 * 1024 * 1024); re =~ subj; rescue NoMemoryError; end
hog = nil; GC.start
2000.times { re =~ subj }                         # after
```


| | before | after | ratio |
| --- | --- | --- | --- |
| master | 1.5 ms | 18.1 / 18.2 / 22.1 ms | 12.1 / 12.1 / 14.7 |
| this PR | 1.5 ms | 1.5 ms | 1.00 |

**The buffers come back.** Under a cap, with the address space squeezed to a window that fits some of a search's buffers and not all of them, 40 refused searches and then a measurement of what is left:

| `ulimit -v` | master lost | this PR lost | of the 40, refused |
| --- | --- | --- | --- |
| 12,000 KiB | 1,273 KiB | 0 | master 40, this PR 0 |
| 14,000 KiB | 1,273 KiB | 0 | master 40, this PR 0 |
| 16,000 KiB | 1,273 KiB | 0 | master 40, this PR 0 |

The last column is where the two halves meet: master lost the cache on the first refusal, so each later search asks for about three times as much and none of the 40 fits the window, where this PR is still on the cached path and all 40 match.

## Speed

Callgrind, default configuration (`-O3`), `Ir(400 iterations) - Ir(200 iterations)` so that start-up cancels, per iteration. The last three cases reach the backtracking engine, which no commit here touches; they are in the table to say what the measurement itself does.

```ruby
s480  = "hello world foo bar " * 24
words = (["alpha1", "beta", "gamma22", "delta", "eps3"] * 20).join(" ")
seeds = "a " * 200

n.times { s480.gsub(/o/) { } }                        # gsub480_blk, the Pike VM with no captures
n.times { s480.gsub(/(\w+) (\w+)/) { } }              # gsub480_caps
n.times { words.scan(/(\w+?)(\d)/) }                  # scan_caps
n.times { s480.match(/(o)(r)?(l?)d/) }                # match480_caps
n.times { seeds.scan(/\B(a)/) }                       # scan_dead_seeds, every seeded thread dies
n.times { "aaaaaaaaaaaaaaaaaaaab".match(/(a+)+b/) }   # match_nested
n.times { words.scan(/(\w)\1/) }                      # scan_backref
n.times { words.scan(/(?>\w+)\d/) }                   # scan_atomic
```

| case | engine | master | commit 1 | commit 2 | this PR |
| --- | --- | --- | --- | --- | --- |
| gsub480_blk | Pike VM | 402,757 | 402,757 | 402,853 | 402,757 |
| gsub480_caps | Pike VM | 601,481 | 601,481 | 601,799 | 633,105 |
| scan_caps | Pike VM | 447,421 | 447,421 | 446,043 | 451,860 |
| match480_caps | Pike VM | 23,195 | 23,195 | 23,195 | 23,558 |
| scan_dead_seeds | Pike VM | 68,067 | 66,641 | 66,671 | 68,082 |
| match_nested | backtracking | 37,748 | 37,748 | 37,689 | 40,125 |
| scan_backref | backtracking | 258,393 | 258,393 | 258,953 | 259,753 |
| scan_atomic | backtracking | 331,448 | 331,448 | 329,250 | 336,884 |

The first commit is instruction-identical to master on every case but the one shaped like what it fixes, where it is 2.1% cheaper: `/\B(a)/` seeds a thread at every `a` and the closure kills it, so master grows the pool over that subject and this does not.

After that the counts move on cases no commit can reach. `match_nested` runs the backtracking engine and is 6.3% above master at the tip, where `gsub480_caps` runs the Pike VM and is 5.3% above it. Both engines are inlined into `exec_range`, so a change in one moves the code of the other, and what the two figures have in common is where gcc put the code.

Wall clock says the same thing more plainly. Minimum of 7 alternating runs of 20,000 iterations:

| case | engine | master | commit 1 | commit 2 | this PR |
| --- | --- | --- | --- | --- | --- |
| gsub480_caps | Pike VM | 776 ms | 772 ms | 774 ms | 792 ms |
| match_nested | backtracking | 49 ms | 49 ms | 49 ms | 51 ms |
| scan_backref | backtracking | 284 ms | 284 ms | 308 ms | 297 ms |
| scan_atomic | backtracking | 318 ms | 310 ms | 388 ms | 354 ms |

`scan_atomic` reaches no line any of these commits changed, and it stands 22% above master after the second commit and 11% above it after the third. The path that did change, `gsub480_caps`, moves 2.1%. Building master with `-falign-functions=64` and nothing else moves the same cases by up to 2.4%.

So the honest reading of the tables is that they bound what this costs rather than measure it: the figure of interest is smaller than the floor the measurement has on this compiler. What is added is a NULL test per pool growth, a test of the refusal where the walk already tests for a cut, and one store a step; what is removed is the pool growth itself on every subject that used to cause one.

## Size

`.text` of `bin/mruby`, `size -A`, both revisions built from the same worktree path:

| Build | master | this PR | delta |
| --- | --- | --- | --- |
| full-debug (-O0) | 1,906,550 | 1,907,174 | +624 |
| bintest | 1,304,534 | 1,304,758 | +224 |
| cxx_abi | 1,329,257 | 1,329,273 | +16 |
| byte-string | 1,269,958 | 1,269,926 | -32 |
| ascii-ctype | 1,290,422 | 1,291,318 | +896 |
| default | 1,216,718 | 1,216,686 | -32 |

`re_exec.o` is the only object that changes, and in the default build its `.text` goes 12,578 to 12,546, which is that build's -32. The spread between the builds is inlining: the same source change is -32 in two of them and +896 in another, and `-O0`, which inlines nothing, is +624 for the code that is actually added. By commit in the default build: 1,216,718 after the first (unchanged), 1,216,990 after the second, 1,216,686 at the tip.

## Testing

`rake test` is KO 0 and Crash 0 at each of the three commits: 2,511 assertions, 14 skips, on the default configuration.

There is no assertion for what this fixes. A build has no way to refuse an allocation from Ruby, so the path that answers `RE_NOMEM` cannot be reached from a test, and neither the claim nor the pool's high-water mark is readable from Ruby. The figures under Behaviour are what stands in for it, and they need a capped address space to reproduce. The backtracking engine's `BT_NOMEM` has no test for the same reason.

What can be tested is that nothing else moved:

- 29 patterns against 13 subjects, taken through `=~`, `match`, `scan`, `gsub`, `split` and `rindex`, print 1,886 identical lines on master and on this branch.
- Differential runs against CRuby 4.0.6, each pattern run under CRuby, under master and under this branch, the answers compared as `MatchData#to_a` inspected. Master standing beside the branch is what separates a difference this branch introduced from one the gem already had.

| cases | features | subjects | same as CRuby | already differed | at a limit |
| --- | --- | --- | --- | --- | --- |
| 1,000 | all | up to 4 characters | 995 | 4 | 1 |
| 4,000 | the Pike VM's | up to 4, plus runs of 32, 128 and 512 | 3,965 | 9 | 20 |
| 4,000 | all, nesting 3 | up to 4 characters | 3,980 | 16 | 4 |
| 800 | the Pike VM's | runs of 2,048 | 791 | 2 | 7 |

The second run generated 4,000 cases and 3,994 were compared: CRuby answered `Regexp::TimeoutError` to six of them, which the harness records rather than compares.

Every difference and every limit in those cases is one master and this branch share. There is no case the two answer differently.

## Environment

<details>
<summary>Machine, toolchain, and the compile line of every build</summary>

| Item | Value |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS |
| Kernel | 7.0.0-30-generic |
| CPU | AMD Ryzen 9 5950X 16-Core Processor |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0 |
| binutils | GNU ld (GNU Binutils) 2.47.20260726 |
| valgrind | valgrind-3.27.1 |
| CRuby (reference) | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |

Actual compile line of `mrbgems/mruby-regexp/src/re_exec.c` in each build (`-MMD -c`, `-I`, and `-o` dropped). `full-debug` is `-O0` because `enable_debug` appends `-g3 -O0` after the toolchain's `-g -O3`; `cxx_abi` compiles C as C++ with `gcc -x c++ -std=gnu++03`, g++ only links.

```console
# full-debug
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-regexp/src/re_exec.c
# bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK mrbgems/mruby-regexp/src/re_exec.c
# cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-regexp/src/re_exec.c
# byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-regexp/src/re_exec.c
# ascii-ctype
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-regexp/src/re_exec.c
# default (no MRUBY_CONFIG), the build the Speed and Behaviour figures were measured on
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK mrbgems/mruby-regexp/src/re_exec.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability when the regular expression engine cannot allocate memory.
  * Prevented invalid capture and matching state during allocation failures.
  * Ensured temporary matching resources are safely released during interrupted or unsuccessful matches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->