### PR TITLE
mruby-regexp: take a MatchData in one block, into an object that owns it

### DIFF
--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -46,10 +46,9 @@ typedef struct {
 
 static void matchdata_free(mrb_state *mrb, void *ptr) {
   mrb_match_data *md = (mrb_match_data*)ptr;
-  if (md) {
-    mrb_free(mrb, md->captures);
-    mrb_free(mrb, md);
-  }
+  /* One block holds the struct and the positions it points into, so this is
+     the whole of what a MatchData took. */
+  mrb_free(mrb, md);
 }
 
 static const struct mrb_data_type matchdata_type = { "MatchData", matchdata_free };
@@ -341,14 +340,22 @@ create_matchdata(mrb_state *mrb, mrb_value regexp, mrb_value str, int *captures,
   str = mrb_str_dup_frozen(mrb, str);
 
   struct RClass *md_class = mrb_class_get_id(mrb, MRB_SYM(MatchData));
-  mrb_match_data *md = (mrb_match_data*)mrb_malloc(mrb, sizeof(mrb_match_data));
+  /* The object comes first and one block holds the rest, so nothing this takes
+     is ever owned by this frame alone. Both of the calls below raise where they
+     cannot answer, mrb_malloc() through mrb_raise_nomemory() and
+     mrb_data_object_alloc() through the page add_heap() takes when the object
+     heap has no free slot, and either longjmps past this frame with nothing
+     left to unwind it. The object is empty when it is made, which
+     matchdata_free() takes, and after that what the object holds is everything
+     the match asked for. */
+  mrb_value obj = mrb_obj_value(mrb_data_object_alloc(mrb, md_class, NULL, &matchdata_type));
+  mrb_match_data *md = (mrb_match_data*)mrb_malloc(mrb, sizeof(mrb_match_data) + sizeof(int) * ncap);
+  DATA_PTR(obj) = md;
   md->source = str;
   md->regexp = regexp;
   md->num_captures = ncap / 2;
-  md->captures = (int*)mrb_malloc(mrb, sizeof(int) * ncap);
+  md->captures = (int*)(md + 1);
   memcpy(md->captures, captures, sizeof(int) * ncap);
-
-  mrb_value obj = mrb_obj_value(mrb_data_object_alloc(mrb, md_class, md, &matchdata_type));
   /* Keep `source` and `regexp` GC-reachable via instance variables.
    * The mrb_values are also held in mrb_match_data, but C-allocated
    * structs are not scanned by the GC. */


### PR DESCRIPTION
## Summary

`create_matchdata()` allocated the `mrb_match_data` and its capture array itself and handed the pair to an RData afterwards, so between the first allocation and that hand-over nothing owned them. Both of the calls standing in that gap raise rather than answer when they cannot allocate, and a raise longjmps past the only frame that could free what had been taken: the struct leaks, and after the second allocation the capture array with it. The object is now made first, over nothing at all, and one block holds the struct and the positions it points into, which is the shape the rest of the gem already uses. Dropping the second allocation makes every `MatchData` cheaper and the gem smaller.

## Changes

| File | What |
| --- | --- |
| `mrbgems/mruby-regexp/src/regexp.c` | `create_matchdata()` makes the RData before it allocates and takes struct and positions in one block; `matchdata_free()` gives back that one block |

### What raised in the gap

`mrb_malloc()` (`src/gc.c:366`) reaches `mrb_raise_nomemory()` through `mrb_realloc()`. `mrb_data_object_alloc()` (`src/etc.c:19`) allocates an object slot, and where the free slots have run out that reaches `add_heap()` (`src/gc.c:473`), which takes a whole page with `mrb_calloc()`. So the old order had two raising calls between an allocation and an owner:

```c
  mrb_match_data *md = (mrb_match_data*)mrb_malloc(mrb, sizeof(mrb_match_data));
  ...
  md->captures = (int*)mrb_malloc(mrb, sizeof(int) * ncap);   /* leaks md */
  ...
  mrb_value obj = mrb_obj_value(mrb_data_object_alloc(mrb, md_class, md, &matchdata_type));  /* leaks both */
```

`NoMemoryError` is an ordinary rescuable exception, so the program goes on without what it left behind, and nothing about the state stops the next search from reaching the same place.

### The order the gem already uses

`regexp_init()` hands the pattern to the object before the compile starts, so the allocations the compiler makes are made into something `regexp_free()` reaches however the compile ends. `mark_empty_loops()` takes one block for the two arrays it needs, so there is no raising call between an allocation and an owner. Both say so in a comment; `create_matchdata()` was the site that did neither, and it now does both:

```c
  mrb_value obj = mrb_obj_value(mrb_data_object_alloc(mrb, md_class, NULL, &matchdata_type));
  mrb_match_data *md = (mrb_match_data*)mrb_malloc(mrb, sizeof(mrb_match_data) + sizeof(int) * ncap);
  DATA_PTR(obj) = md;
```

The RData is made over no struct at all, which `matchdata_free()` takes, and the one block that follows holds everything a `MatchData` has. What the object holds is either nothing or the whole match, and there is no second allocation left to raise in between.

Every reader goes on reading `md->captures`, which now points just past the struct rather than at a block of its own. Nothing else allocated or freed that array, so it has no other owner to disagree with, and `matchdata_free()` gives back the one block.

## Behaviour

No answer changes. The difference shows only where an allocation is refused, and it is what the process holds afterwards rather than what it answers.

A harness that refuses every allocation from the nth after a warmed `'abc' =~ /b(c)/`, and rescues what follows, puts that under valgrind. The search after the arming point takes six allocations on master and five here. Refusing each in turn:

| refusal point | master | this PR |
| --- | --- | --- |
| 3rd (the struct on master, struct and positions here) | nothing lost | nothing lost |
| 4th (the capture array) | 32 bytes definitely lost | no such allocation |
| every one of 80 points swept | the 32 bytes above, nothing else | nothing lost |

The 32 bytes are the struct `create_matchdata()` had taken one allocation earlier, and they are what goes.

The remaining raise, the one from `mrb_data_object_alloc()` where the object heap has to take a page, is not reached by this harness, since that call only allocates when the free slots are gone. It is the likelier of the two refusals in a real program, being a page rather than a handful of bytes, and it is the one that leaked both the struct and the array on master.

## Speed

Callgrind, default configuration (`-O3`), `Ir(400 iterations) - Ir(200 iterations)` so that start-up cancels, per iteration:

```ruby
s480  = "hello world foo bar " * 24
words = (["alpha1", "beta", "gamma22", "delta", "eps3"] * 20).join(" ")

n.times { "abc".match(/b/) }             # match_abc
n.times { "abc".match(/z/) }             # match_none
n.times { "abc" =~ /b/ }                 # eq_abc
n.times { "abc".match(/(a)(b)(c)/) }     # match_caps
n.times { s480.gsub(/o/) { } }           # gsub480_blk
n.times { s480.gsub(/o/, "0") }          # gsub480_str
n.times { words.scan(/[a-z]+[0-9]/) }    # scan_words
```

| case | master | this PR | delta |
| --- | --- | --- | --- |
| match_abc | 14,058 | 13,798 | -1.8% |
| match_none | 12,003 | 12,003 | 0.0% |
| eq_abc | 14,063 | 13,803 | -1.8% |
| match_caps | 20,380 | 19,306 | -5.3% |
| gsub480_blk | 401,784 | 376,203 | -6.4% |
| gsub480_str | 55,479 | 55,248 | -0.4% |
| scan_words | 504,229 | 503,940 | -0.1% |

One allocation is roughly 260 instructions, and what each row saves is that times the number of `MatchData` it publishes: one for `match_abc`, none for `match_none`, which is unchanged to the instruction, and 96 for `gsub480_blk`, whose block form publishes a match per replacement. `match_caps` saves more than `match_abc` because the array it no longer allocates separately is larger. `gsub480_str` and `scan_words` answer without publishing a match per position, so what they save is the one they do publish.

Wall clock, minimum of 15 alternating runs, same build, the eight cases of the review on #7267:

```ruby
s480 = "hello world foo bar " * 24

30000.times  { s480.gsub(/o/) { } }        # gsub480_blk
100000.times { "abc".gsub(/b/) { } }       # gsub_abc_blk
100000.times { "abc".scan(/b/) { } }       # scan_abc_blk
100000.times { x = "abc".dup; x.sub!(/b/) { } }   # sub!_abc_blk
30000.times  { s480.gsub(/o/, "0") }       # gsub480_str
100000.times { "abc".scan(/b/) }           # scan_abc
100000.times { x = "abc".dup; x.sub!(/b/, "0") }  # sub!_abc_str
30000.times  { s480.gsub(/z/) { } }        # gsub480_none
```

| case | master | this PR | ratio |
| --- | --- | --- | --- |
| gsub480_blk | 744ms | 693ms | 0.93x |
| gsub_abc_blk | 132ms | 132ms | 1.00x |
| scan_abc_blk | 144ms | 140ms | 0.97x |
| sub!_abc_blk | 163ms | 159ms | 0.98x |
| gsub480_str | 108ms | 109ms | 1.01x |
| scan_abc | 100ms | 97ms | 0.97x |
| sub!_abc_str | 167ms | 162ms | 0.97x |
| gsub480_none | 34ms | 34ms | 1.00x |

`gsub480_none` matches nothing, publishes nothing, and is where the clock says the same as the instruction count. `gsub480_str` is the one row where the two disagree in sign, by a millisecond on a hundred and by 0.4% in instructions; the instruction count is the exact figure and the clock is a shared machine's.

## Size

`.text` of `bin/mruby`, `size -A`:

| Build | master | this PR | delta |
| --- | --- | --- | --- |
| full-debug (-O0) | 1,907,174 | 1,907,158 | -16 |
| bintest | 1,304,758 | 1,304,710 | -48 |
| cxx_abi | 1,329,273 | 1,329,225 | -48 |
| byte-string | 1,269,926 | 1,269,878 | -48 |
| ascii-ctype | 1,291,318 | 1,291,270 | -48 |
| default | 1,216,686 | 1,216,638 | -48 |

All of it is the one call that goes: `regexp.o` `.text` in the default build goes 27,157 to 27,109, which is the whole of that build's -48, and `re_exec.o` (12,546) and `re_compile.o` (27,025) are unchanged. The `-O0` build saves 8 bytes in `regexp.o` (30,236 to 30,228), where nothing around the call is inlined, and its binary moves by 16; the difference between the two is alignment rather than code.

## Testing

`rake test` and `rake MRUBY_CONFIG=ci/gcc-clang test` pass:

| Build | Total | KO | Crash | Skip |
| --- | --- | --- | --- | --- |
| full-debug | 2511 | 0 | 0 | 6 |
| bintest | 2511 (+124 bintest) | 0 | 0 | 14 |
| cxx_abi | 2511 | 0 | 0 | 14 |
| byte-string | 2437 | 0 | 0 | 54 |
| ascii-ctype | 2504 | 0 | 0 | 15 |
| default | 2279 (+113 bintest) | 0 | 0 | 54 |

No test is added. What changes is what a refused allocation leaves behind, and mrbtest has no way to refuse one: the harness above replaces `mrb_basic_alloc_func()` in a program of its own, which is where a build can decide what the allocator answers. Its result is in Behaviour.

## Environment

<details>
<summary>Machine, toolchain, and the compile line of every build</summary>

| Item | Value |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS |
| Kernel | 7.0.0-30-generic |
| CPU | AMD Ryzen 9 5950X 16-Core Processor |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0 |
| binutils | GNU ld (GNU Binutils) 2.47.20260726 |
| valgrind | valgrind-3.27.1 |

Actual compile line of `mrbgems/mruby-regexp/src/regexp.c` in each build (`-MMD -c`, `-I`, and `-o` dropped). `full-debug` is `-O0` because `enable_debug` appends `-g3 -O0` after the toolchain's `-g -O3`; `cxx_abi` compiles C as C++ with `gcc -x c++ -std=gnu++03`, g++ only links.

```console
# full-debug
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-regexp/src/regexp.c
# bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK mrbgems/mruby-regexp/src/regexp.c
# cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-regexp/src/regexp.c
# byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-regexp/src/regexp.c
# ascii-ctype
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-regexp/src/regexp.c
# default (no MRUBY_CONFIG), the build every figure above was measured on
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK mrbgems/mruby-regexp/src/regexp.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved memory handling for regular-expression match results.
  * Reduced allocation overhead during pattern matching while preserving existing matching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->