### PR TITLE
gc.c (gc_mark_children): drop the duplicate method table mark

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -921,7 +921,6 @@ gc_mark_children(mrb_state *mrb, mrb_gc *gc, struct RBasic *obj)
     {
       struct RClass *c = (struct RClass*)obj;
 
-      mrb_gc_mark_mt(mrb, c);
       mrb_gc_mark(mrb, (struct RBasic*)c->super);
       children += mrb_gc_mark_mt(mrb, c);
       children++;


### PR DESCRIPTION
`gc_mark_children()` marks a class's method table twice. Marking is idempotent, so the bare `mrb_gc_mark_mt(mrb, c)` is redundant work.

It is a leftover from f13daee2f, which folded the equivalent bare call in the `MRB_TT_ICLASS` branch into `children +=` but left this one behind.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved garbage collection marking for classes and modules by eliminating redundant processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->