### PR TITLE
mruby-io: leave the stream not open for writing after IO#close_write

### DIFF
--- a/mrbgems/mruby-io/src/io.c
+++ b/mrbgems/mruby-io/src/io.c
@@ -1214,6 +1214,12 @@ io_close_write(mrb_state *mrb, mrb_value io)
   /* The write end is gone whatever close(2) answers, and leaving its number
      behind would have #close try to close it a second time. */
   fptr->fd2 = -1;
+  if (fd2 != -1) {
+    /* A stream that has an fd2 writes to it and reads from fd, so closing the
+       write end leaves nowhere to write to: the flag every writer is gated on
+       has to fall with the descriptor. */
+    fptr->writable = 0;
+  }
   if (mrb_hal_io_close(mrb, fd2) == -1) {
     mrb_sys_fail(mrb, "close");
   }

--- a/mrbgems/mruby-io/test/io.rb
+++ b/mrbgems/mruby-io/test/io.rb
@@ -575,6 +575,28 @@ assert('IO#close_write') do
   end
 end
 
+assert('IO#close_write closes the stream for writing') do
+  skip "no `cat` to talk to on this platform" if MRubyIOTestUtil.win?
+  begin
+    io = IO.popen("cat", "r+")
+    io.write "mruby-io\n"
+    io.close_write
+    assert_raise(IOError) { io.write "again" }
+    assert_raise(IOError) { io.syswrite "again" }
+    assert_raise(IOError) { io.print "again" }
+    assert_raise(IOError) { io.puts "again" }
+    assert_raise(IOError) { io.putc "a" }
+    assert_raise(IOError) { io << "again" }
+    if MRubyIOTestUtil::MRB_USE_IO_PREAD_PWRITE
+      assert_raise(IOError) { io.pwrite("again", 0) }
+    end
+    assert_equal "mruby-io\n", io.read
+    io.close
+  rescue NotImplementedError => e
+    skip e.message
+  end
+end
+
 assert('IO.read') do
   # empty file
   fd = IO.sysopen $mrbtest_io_wfname, "w"


### PR DESCRIPTION
## Summary

`IO#close_write` closes the write end of a duplex stream and leaves the stream saying it is still open for writing, so the next write goes looking for a descriptor the caller never asked to write to and answers `Errno::EBADF` where CRuby answers `IOError`.

## Changes

| File | What |
|---|---|
| `mrbgems/mruby-io/src/io.c` | `io_close_write()` clears `fptr->writable` with `fptr->fd2` |
| `mrbgems/mruby-io/test/io.rb` | adds `IO#close_write closes the stream for writing`, covering all seven writers |

### The flag is the gate, and the write end is gone

`io_get_write_fptr()` is what `IO#write`, `IO#syswrite`, `IO#print`, `IO#puts`, `IO#putc`, `IO#<<` and `IO#pwrite` all pass through, and the one place in the gem that produces the message CRuby produces here:

```c
  if (!fptr->writable) {
    mrb_raise(mrb, E_IO_ERROR, "not opened for writing");
  }
```

`io_close_write()` never touched the flag, so the gate stayed open on a stream whose write end it had just closed. Past the gate, `io_get_write_fd()` falls back to `fptr->fd` when the stream has no `fd2`:

```c
  if (fptr->fd2 == -1) {
    return fptr->fd;
  }
```

`IO.popen(cmd, "r+")` is the only thing in the gem that opens an `fd2`, and there `fptr->fd` is the **read** end of the other pipe. So every writer ends up on a descriptor that has nothing to do with the request: six of them are refused with `EBADF`, and `IO#pwrite` gets as far as `ESPIPE`, because a pipe cannot be seeked.

### The flag falls only where a write end was let go

`fptr->writable` says whether the stream has somewhere to write. A stream that has an `fd2` writes to it and reads from `fd`, so closing the write end leaves nowhere, and the flag has to fall with the descriptor. A stream with no `fd2` writes through `fd`, which `close_write` does not close, so it stays as writable as it was and the guard leaves it alone.

## Behaviour

```ruby
io = IO.popen("cat", "r+")
io.write "hello\n"
io.close_write
io.read           #=> "hello\n"
io.write "again"  # one of the rows below
```

| last line | master | this PR | CRuby 4.0.6 |
| --- | --- | --- | --- |
| `io.write "again"` | `Errno::EBADF` | `IOError: not opened for writing` | `IOError: not opened for writing` |
| `io.syswrite "again"` | `Errno::EBADF` | `IOError: not opened for writing` | `IOError: not opened for writing` |
| `io.print "again"` | `Errno::EBADF` | `IOError: not opened for writing` | `IOError: not opened for writing` |
| `io.puts "again"` | `Errno::EBADF` | `IOError: not opened for writing` | `IOError: not opened for writing` |
| `io.putc "a"` | `Errno::EBADF` | `IOError: not opened for writing` | `IOError: not opened for writing` |
| `io << "again"` | `Errno::EBADF` | `IOError: not opened for writing` | `IOError: not opened for writing` |
| `io.pwrite("again", 0)` | `Errno::ESPIPE` | `IOError: not opened for writing` | `IOError: not opened for writing` |

Nothing else changes. Reading a stream whose write end has been closed works as before, and `close_write` on a stream that has no write end answers what it answered before.

## Size

`.text` of `bin/mruby` for the five `build_config/ci/gcc-clang.rb` builds, master and this branch built from the same path into empty directories:

| Build | master | this PR | delta |
| --- | --- | --- | --- |
| `bintest` | 1,304,694 | 1,304,710 | +16 |
| `ascii-ctype` | 1,291,254 | 1,291,270 | +16 |
| `byte-string` | 1,269,862 | 1,269,878 | +16 |
| `cxx_abi` | 1,329,209 | 1,329,225 | +16 |
| `full-debug` (-O0) | 1,907,142 | 1,907,158 | +16 |

All of it is `io_close_write()` itself, which grows from 112 to 121 bytes (`nm -S`, `bintest`); `io.o` `.text` goes 20,670 → 20,686.

## Testing

`rake -m test` on this branch, on the default `host` build and on all five `build_config/ci/gcc-clang.rb` builds:

| Build | Total | OK | KO | Crash | Skip |
| --- | --- | --- | --- | --- | --- |
| `host` (default config) | 2,280 | 2,226 | 0 | 0 | 54 |
| `bintest` | 2,512 | 2,498 | 0 | 0 | 14 |
| `ascii-ctype` | 2,505 | 2,490 | 0 | 0 | 15 |
| `byte-string` | 2,438 | 2,384 | 0 | 0 | 54 |
| `cxx_abi` | 2,512 | 2,498 | 0 | 0 | 14 |
| `full-debug` | 2,512 | 2,506 | 0 | 0 | 6 |

`bintest` also ran its own 124 bin tests (123 OK, 1 skip).

With the same test but without the change to `io.c`, the new test is the only failure (`KO: 1` on the default `host` build).

## Environment

<details>
<summary>Machine, toolchain and the compile line of each build</summary>

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-30-generic x86_64 |
| CPU | AMD Ryzen 9 5950X (16 cores, 32 threads) |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0 |
| Linker | GNU ld (GNU Binutils) 2.47.20260726 |
| CRuby | 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |

The line each build actually compiles `src/string.c` with, taken from `rake --verbose` with `-MMD -c`, `-I` and `-o` dropped. `cxx_abi` is `gcc -x c++`, not `g++`; `g++` only links it.

```console
# host (default config)
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK src/string.c

# bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK src/string.c

# ascii-ctype
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c

# byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c

# cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c

# full-debug (-O0)
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplex streams so closing the write side prevents any further write operations.
  * Reading from the stream remains available after the write side is closed.
* **Tests**
  * Added coverage for write-related methods to ensure they correctly raise an error after `close_write`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->