### PR TITLE
mruby-io: define IO.pipe where the port has one

### DIFF
--- a/mrbgems/mruby-io/src/io.c
+++ b/mrbgems/mruby-io/src/io.c
@@ -1340,7 +1340,7 @@ time2timeval(mrb_state *mrb, mrb_value time)
  *   f.puts "hello"
  */
 
-#if !defined(_WIN32) && !(defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE)
+#if !(defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE)
 static mrb_value
 io_s_pipe(mrb_state *mrb, mrb_value klass)
 {
@@ -2367,7 +2367,7 @@ mrb_init_io(mrb_state *mrb)
   mrb_define_class_method_id(mrb, io, MRB_SYM(for_fd),  io_s_for_fd,   MRB_ARGS_ARG(1,2));
   mrb_define_class_method_id(mrb, io, MRB_SYM(select),  io_s_select,  MRB_ARGS_ARG(1,3));
   mrb_define_class_method_id(mrb, io, MRB_SYM(sysopen), io_s_sysopen, MRB_ARGS_ARG(1,2));
-#if !defined(_WIN32) && !(defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE)
+#if !(defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE)
   mrb_define_class_method_id(mrb, io, MRB_SYM(_pipe), io_s_pipe, MRB_ARGS_NONE());
 #endif
 

--- a/mrbgems/mruby-io/test/io.rb
+++ b/mrbgems/mruby-io/test/io.rb
@@ -158,9 +158,22 @@ assert('IO#read', '15.2.20.5.14') do
   end
 end
 
+assert('IO.pipe carries what is written to it') do
+  # The test named `IO.pipe` below stops at `FileTest.pipe?`, which Windows
+  # has no answer for, so the one thing a pipe is for goes unasserted on the
+  # platform that has only just been given one.
+  IO.pipe do |r, w|
+    w.write "hello"
+    w.close
+    assert_equal "hello", r.read
+  end
+end
+
 assert "IO#read(n) with n > IO::BUF_SIZE" do
   buf_size = 4096  # copied from io.c
-  skip "pipe is not supported on this platform" if MRubyIOTestUtil.win?
+  # The whole write has to fit in the pipe, since nothing reads from it until
+  # the writer is done, and Windows gives a pipe less room than this.
+  skip "the pipe buffer here is smaller than this write" if MRubyIOTestUtil.win?
   IO.pipe do |r,w|
     n = buf_size+1
     w.write 'a'*n
@@ -376,7 +389,6 @@ assert('IO#ungetc') do
 end
 
 assert('IO#ungetc after grow and partial read') do
-  skip "pipe is not supported on this platform" if MRubyIOTestUtil.win?
   # ungetc grows the buffer past MRB_IO_BUF_SIZE, a partial read advances
   # start, then a second ungetc must not read past the reallocated block (#6964)
   IO.pipe do |r, w|
@@ -523,6 +535,7 @@ assert('IO.popen') do
 end
 
 assert('IO.popen with in option') do
+  skip "no POSIX shell or `cat` to talk to here" if MRubyIOTestUtil.win?
   begin
     IO.pipe do |r, w|
       w.write 'hello'
@@ -537,6 +550,7 @@ assert('IO.popen with in option') do
 end
 
 assert('IO.popen with out option') do
+  skip "no POSIX shell or `cat` to talk to here" if MRubyIOTestUtil.win?
   begin
     IO.pipe do |r, w|
       IO.popen("echo 'hello'", "w", out: w) {}
@@ -549,6 +563,7 @@ assert('IO.popen with out option') do
 end
 
 assert('IO.popen with err option') do
+  skip "no POSIX shell or `cat` to talk to here" if MRubyIOTestUtil.win?
   begin
     IO.pipe do |r, w|
       assert_equal "", IO.popen("echo 'hello' 1>&2", "r", err: w) { |i| i.read }


### PR DESCRIPTION
## Summary

`IO.pipe` answered `NotImplementedError: pipe is not supported on this platform` on Windows, while `mrb_hal_io_pipe()` sat implemented in the Windows port, opening a pipe with `_pipe()` and clearing `HANDLE_FLAG_INHERIT` on both ends. What was missing was not the pipe but the method: `io_s_pipe()` and the `IO._pipe` that reaches it were compiled out of a Windows build.

Seven tests skip on a Windows build for want of that pipe, `9ef4b16e2` having just moved one of them into a test of its own so that it could. Two of them need nothing else and run here; the rest skip for reasons of their own, which they now give.

## Changes

| File | What |
|---|---|
| `mrbgems/mruby-io/src/io.c` | `io_s_pipe()` and `IO._pipe` are compiled for Windows too |
| `mrbgems/mruby-io/test/io.rb` | the three `IO.popen` option tests say what they need; one skip goes, one is given its real reason; a new test asserts that a pipe carries bytes |

### The port had a pipe; the class did not

Both the definition and the registration were behind the same guard:

```c
#if !defined(_WIN32) && !(defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE)
```

`_WIN32` is the half that has not been true since the ports arrived. `mrbgems/mruby-io/ports/win/io_hal.c` implements `mrb_hal_io_pipe()`, `IO.popen`, which is a pipe plus a child, is built for Windows and works there, and the README table has listed `IO.pipe` as provided all along. The guard now names the platform it was about: iOS, where there is no `pipe(2)` for a port to call.

### Three tests were skipping without saying so

On master, under Wine:

```
Skip: IO.popen with in option => pipe is not supported on this platform
Skip: IO.popen with out option => pipe is not supported on this platform
Skip: IO.popen with err option => pipe is not supported on this platform
```

That message is not theirs. Each opens a pipe with `IO.pipe` before it gets to `IO.popen`, the `NotImplementedError` landed in the `rescue NotImplementedError` written for `IO.popen`, and the test skipped. With a pipe there they run, under `cmd.exe`, and fail on the POSIX quoting and the `cat` they are written for. They now skip on the question they are actually about.

### What a pipe still cannot do on Windows

`IO#read(n) with n > IO::BUF_SIZE` writes 4097 bytes and only then reads them, and `_pipe(fds, 4096, _O_BINARY)` gives the pipe 4096 bytes of room, so the writer waits for a reader that has not started yet. Confirmed under Wine: 100 bytes through a pipe returns, 4097 bytes does not. It stays skipped, with the reason rewritten from a claim about the platform to a fact about the write.

`IO#ungetc after grow and partial read` opens a pipe and never writes to it, so its skip goes.

The test named `IO.pipe` runs on Windows now, but not far: `FileTest.pipe?` is among the first things it asks and the Windows port refuses it, so the write and the read at the end of the test are never reached. A separate test asserts that much on its own, and runs wherever there is a pipe.

## Behaviour

```ruby
IO.pipe { |r, w| w.write "hello"; w.close; r.read }
```

| platform | master | this PR | CRuby 4.0.6 |
| --- | --- | --- | --- |
| Windows | `NotImplementedError: pipe is not supported on this platform` | `"hello"` | `"hello"` |
| everything else | `"hello"` | `"hello"` | `"hello"` |

Nothing else changes. On a platform that is not Windows the preprocessed `io.c` is byte for byte what it was.

## Size

Windows is where the code changes, so that is where it is measured: `.text` of `bin/mruby.exe` from `build_config/cross-mingw-winetest.rb`, master and this branch built from the same path into empty directories.

| Build | master | this PR | delta |
| --- | --- | --- | --- |
| `cross-mingw-winetest` | 1,585,832 | 1,586,264 | +432 |

All of it is `io_s_pipe()`, 395 bytes by `nm -S`, and what registering it costs; `io.o` `.text` goes 21,296 → 21,728.

The five `build_config/ci/gcc-clang.rb` builds do not move by a byte, and not because the delta rounds to zero: with `_WIN32` undefined, `gcc -E` on this branch's `io.c` gives a file identical to master's, so there is nothing for the compiler to see.

## Testing

`rake -m test` on this branch, on the default `host` build, on all five `build_config/ci/gcc-clang.rb` builds and on `build_config/cross-mingw-winetest.rb` under Wine:

| Build | Total | OK | KO | Crash | Skip |
| --- | --- | --- | --- | --- | --- |
| `host` (default config) | 2,284 | 2,230 | 0 | 0 | 54 |
| `bintest` | 2,516 | 2,502 | 0 | 0 | 14 |
| `ascii-ctype` | 2,509 | 2,494 | 0 | 0 | 15 |
| `byte-string` | 2,442 | 2,388 | 0 | 0 | 54 |
| `cxx_abi` | 2,516 | 2,502 | 0 | 0 | 14 |
| `full-debug` | 2,516 | 2,510 | 0 | 0 | 6 |
| `cross-mingw-winetest` (Wine 11.0) | 1,699 | 1,660 | 0 | 0 | 39 |

`bintest` also ran its own 124 bin tests (123 OK, 1 skip), and the Wine build its own 84 (79 OK, 5 skip).

Master at `9ef4b16e2` on the same Wine build reports 1,698 / 1,657 / 0 / 0 / 41, and the difference is exactly this change: the extra test is the new one, and the two skips that turned into passes are `IO#ungetc after grow and partial read` and `IO#close_write on a pipe end`.

## Environment

<details>
<summary>Machine, toolchain and the compile line of each build</summary>

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-30-generic x86_64 |
| CPU | AMD Ryzen 9 5950X (16 cores, 32 threads) |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0 |
| Cross compiler | x86_64-w64-mingw32-gcc-posix (GCC) 13-posix |
| Linker | GNU ld (GNU Binutils) 2.47.20260726 |
| Wine | wine-11.0 |
| CRuby | 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |

The line each build actually compiles `mrbgems/mruby-io/src/io.c` with, taken from the `.o.flags` each build records, with `-MMD -c`, `-I` and `-o` dropped. `cxx_abi` is `gcc -x c++`, not `g++`; `g++` only links it.

```console
# host (default config)
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK mrbgems/mruby-io/src/io.c

# bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK mrbgems/mruby-io/src/io.c

# ascii-ctype
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-io/src/io.c

# byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-io/src/io.c

# cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-io/src/io.c

# full-debug (-O0)
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-io/src/io.c

# cross-mingw-winetest
x86_64-w64-mingw32-gcc-posix -static -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-io/src/io.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled `IO.pipe` on Windows, allowing data transfer through pipes across supported platforms.

* **Bug Fixes**
  * Improved Windows coverage for pipe reading and character pushback.
  * Refined platform-specific handling for pipe buffer limits and process-related I/O tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->