### PR TITLE
mruby-io: name the errors these tests are about

### DIFF
--- a/mrbgems/mruby-io/mrbgem.rake
+++ b/mrbgems/mruby-io/mrbgem.rake
@@ -5,6 +5,7 @@ MRuby::Gem::Specification.new('mruby-io') do |spec|
 
   spec.build.defines << "HAVE_MRUBY_IO_GEM"
   spec.add_test_dependency 'mruby-time', core: 'mruby-time'
+  spec.add_test_dependency 'mruby-errno', core: 'mruby-errno'
 
   if spec.for_windows?
     spec.linker.libraries << "ws2_32"

--- a/mrbgems/mruby-io/test/file.rb
+++ b/mrbgems/mruby-io/test/file.rb
@@ -279,14 +279,9 @@ assert("File.readlink fails with non-symlink") do
   skip "readlink is not supported on this platform" if MRubyIOTestUtil.win?
   begin
     e2 = nil
-    assert_raise(RuntimeError) {
+    assert_raise(Errno::EINVAL) {
       begin
         File.readlink($mrbtest_io_rfname)
-      rescue => e
-        if Object.const_defined?(:SystemCallError) and e.kind_of?(SystemCallError)
-          raise RuntimeError, "SystemCallError converted to RuntimeError"
-        end
-        raise e
       rescue NotImplementedError => e
         e2 = e
       end
@@ -425,7 +420,7 @@ assert('File.open with "x" mode') do
   assert_nothing_raised do
     File.open($mrbtest_io_wfname, "wx") {}
   end
-  assert_raise(RuntimeError) do
+  assert_raise(Errno::EEXIST) do
     File.open($mrbtest_io_wfname, "wx") {}
   end
 
@@ -433,7 +428,7 @@ assert('File.open with "x" mode') do
   assert_nothing_raised do
     File.open($mrbtest_io_wfname, "w+x") {}
   end
-  assert_raise(RuntimeError) do
+  assert_raise(Errno::EEXIST) do
     File.open($mrbtest_io_wfname, "w+x") {}
   end
 

--- a/mrbgems/mruby-io/test/io.rb
+++ b/mrbgems/mruby-io/test/io.rb
@@ -26,8 +26,8 @@ def assert_io_open(meth)
       end
     end
 
-    assert_raise(RuntimeError) { IO.__send__(meth, 1023) } # For Windows
-    assert_raise(RuntimeError) { IO.__send__(meth, 1 << 26) }
+    assert_raise(Errno::EBADF) { IO.__send__(meth, 1023) } # For Windows
+    assert_raise(Errno::EBADF) { IO.__send__(meth, 1 << 26) }
   end
 end
 
@@ -295,12 +295,7 @@ assert('IO gc check') do
 end
 
 assert('IO.sysopen("./nonexistent")') do
-  if Object.const_defined? :Errno
-    eclass = Errno::ENOENT
-  else
-    eclass = RuntimeError
-  end
-  assert_raise eclass do
+  assert_raise Errno::ENOENT do
     fd = IO.sysopen "./nonexistent"
     IO._sysclose fd
   end
@@ -391,7 +386,7 @@ assert('IO#isatty') do
   skip "isatty is not supported on this platform" if MRubyIOTestUtil.win?
   begin
     f = File.open("/dev/tty")
-  rescue RuntimeError => e
+  rescue SystemCallError => e
     skip e.message
   else
     assert_true f.isatty
@@ -732,7 +727,7 @@ assert('IO#pread') do
     assert_equal 0, io.pos
     assert_equal $mrbtest_io_msg.byteslice(1, 5), io.pread(5, 1)
     assert_equal 0, io.pos
-    assert_raise(RuntimeError) { io.pread(20, -9) }
+    assert_raise(Errno::EINVAL) { io.pread(20, -9) }
   end
 end
 


### PR DESCRIPTION
## Summary

A gem's tests run in a state holding its dependency closure and nothing else, and mruby-io's has never held mruby-errno. Without that gem there is no `SystemCallError` class for `mrb_sys_fail()` to reach, so it raises `RuntimeError` instead, and eight places in these tests were written to accept whichever turned up. `RuntimeError` is also what the gem raises when something else goes wrong, so each of them passes whether the call answered the error the test is about or fell over on the way there.

## Changes

| File | What |
|---|---|
| `mrbgems/mruby-io/mrbgem.rake` | `mruby-errno` becomes a test dependency |
| `mrbgems/mruby-io/test/io.rb` | five places name the error they are about |
| `mrbgems/mruby-io/test/file.rb` | three more, and the dance that turned a `SystemCallError` back into a `RuntimeError` goes |

### What a failed system call raises depends on what is in the build

`mrb_sys_fail()` asks, as it runs, whether the class is there:

```c
  if (mrb_class_defined_id(mrb, MRB_SYM(SystemCallError))) {
    /* ... raises the Errno subclass ... */
  }
  mrb_exc_raise(mrb, mrb_exc_new_str(mrb, E_RUNTIME_ERROR, ...));
```

mruby-errno is what defines that class, and a gem's tests see only that gem's own dependency closure, so in mruby-io's tests it was never defined. It is now asked for, by the tests that mean to name what it defines.

### The eight places

| Test | was | now |
| --- | --- | --- |
| `IO.new` and `IO.open` on a descriptor that is not open (twice) | `RuntimeError` | `Errno::EBADF` |
| `IO.sysopen("./nonexistent")` | `Errno::ENOENT` or `RuntimeError`, chosen as it ran from `Object.const_defined?(:Errno)` | `Errno::ENOENT` |
| `IO#isatty`, opening `/dev/tty` to decide whether it can run | `rescue RuntimeError` | `rescue SystemCallError` |
| `IO#pread` with a negative offset | `RuntimeError` | `Errno::EINVAL` |
| `File.readlink` on something that is not a symlink | `RuntimeError`, reached by catching a `SystemCallError` and raising it again as one | `Errno::EINVAL` |
| `File.open` with `"x"` on a file that exists (twice) | `RuntimeError` | `Errno::EEXIST` |

The `/dev/tty` one is a `rescue` rather than an assertion: it decides whether the test runs at all, and a `RuntimeError` from anywhere else in that open was being read as "no terminal here".

### Nothing that ships changes

A test dependency is added to a build only when its tests are, so no binary grows a gem it did not have. The builds that run these tests all held mruby-errno already, through their gembox rather than through mruby-io, which is why the tightened assertions pass as they stand: what was missing was the requirement, not the gem.

## Testing

`rake -m test` on this branch, on the default `host` build, on all five `build_config/ci/gcc-clang.rb` builds and on `build_config/cross-mingw-winetest.rb` under Wine:

| Build | Total | OK | KO | Crash | Skip |
| --- | --- | --- | --- | --- | --- |
| `host` (default config) | 2,283 | 2,229 | 0 | 0 | 54 |
| `bintest` | 2,515 | 2,501 | 0 | 0 | 14 |
| `ascii-ctype` | 2,508 | 2,493 | 0 | 0 | 15 |
| `byte-string` | 2,441 | 2,387 | 0 | 0 | 54 |
| `cxx_abi` | 2,515 | 2,501 | 0 | 0 | 14 |
| `full-debug` | 2,515 | 2,509 | 0 | 0 | 6 |
| `cross-mingw-winetest` (Wine 11.0) | 1,698 | 1,657 | 0 | 0 | 41 |

`bintest` also ran its own 124 bin tests (123 OK, 1 skip), and the Wine build its own 84 (79 OK, 5 skip).

No count moves: this changes what the tests accept, not how many there are. Every row above is what master at `9ef4b16e2` reports.

## Environment

<details>
<summary>Machine, toolchain and the compile line of each build</summary>

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-30-generic x86_64 |
| CPU | AMD Ryzen 9 5950X (16 cores, 32 threads) |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0 |
| Cross compiler | x86_64-w64-mingw32-gcc-posix (GCC) 13-posix |
| Linker | GNU ld (GNU Binutils) 2.47.20260726 |
| Wine | wine-11.0 |
| CRuby | 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |

The line each build actually compiles `mrbgems/mruby-io/src/io.c` with, taken from the `.o.flags` each build records, with `-MMD -c`, `-I` and `-o` dropped. `cxx_abi` is `gcc -x c++`, not `g++`; `g++` only links it.

```console
# host (default config)
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK mrbgems/mruby-io/src/io.c

# bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK mrbgems/mruby-io/src/io.c

# ascii-ctype
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-io/src/io.c

# byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-io/src/io.c

# cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-io/src/io.c

# full-debug (-O0)
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-io/src/io.c

# cross-mingw-winetest
x86_64-w64-mingw32-gcc-posix -static -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-io/src/io.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * File and I/O operations now report specific system error types for invalid descriptors, missing paths, unsupported TTY access, invalid offsets, non-symlink targets, and existing files during exclusive creation.
  * Improved consistency when handling operating system errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->