### PR TITLE
mruby-process: wait for a child under the names Ruby has for it

### DIFF
--- a/mrbgems/mruby-process/README.md
+++ b/mrbgems/mruby-process/README.md
@@ -40,7 +40,7 @@ already include it.
 | Process.spawn              |               | separate change                          |
 | Process.exec               |               | separate change                          |
 | Process.exit, .exit!       |               | see mruby-exit                           |
-| Process.wait, .wait2       |               | separate change                          |
+| Process.wait, .wait2       | o             | `.waitpid2` too; not `.waitall`          |
 | Process.uid, .gid, ...     |               | separate change                          |
 | Process.getpgrp, ...       |               | separate change                          |
 

--- a/mrbgems/mruby-process/src/process.c
+++ b/mrbgems/mruby-process/src/process.c
@@ -10,6 +10,7 @@
 */
 
 #include <mruby.h>
+#include <mruby/array.h>
 #include <mruby/error.h>
 #include <mruby/string.h>
 #include <mruby/variable.h>
@@ -210,27 +211,11 @@ process_kill(mrb_state *mrb, mrb_value self)
   return mrb_int_value(mrb, argc);
 }
 
-/*
- * call-seq:
- *   Process.waitpid(pid = -1, flags = 0) -> integer or nil
- *
- * Waits for a child process to finish and returns its process ID, setting
- * <code>$?</code> to the Process::Status it finished with.  Which children
- * are waited for is what +pid+ chooses: a positive number names one child,
- * 0 any child in the caller's process group, -1 (the default) any child at
- * all, and a number below -1 any child in the process group whose ID is
- * -pid.
- *
- * With Process::WNOHANG among +flags+, returns nil and sets <code>$?</code>
- * to nil when no child is ready.  With Process::WUNTRACED, a stopped child
- * is reported too, where the platform has such a thing.
- *
- * Raises Errno::ECHILD when there is no child to wait for, Errno::EINVAL
- * when +flags+ holds a bit that is not one of the two, and RangeError when
- * +pid+ is too large for the platform to carry.
- */
+/* The wait itself.  Two module functions differ only in whether the status
+   is handed back beside the pid, so the wait is done here and both of them
+   publish it through `$?`. */
 static mrb_value
-process_waitpid(mrb_state *mrb, mrb_value self)
+wait_for_child(mrb_state *mrb, mrb_value *statusp)
 {
   mrb_int pid = MRB_PROCESS_WAIT_ANY;
   mrb_int flags = 0;
@@ -253,11 +238,63 @@ process_waitpid(mrb_state *mrb, mrb_value self)
   }
   if (result_pid == 0) {
     /* MRB_PROCESS_WAIT_NOHANG and nothing had finished */
+    *statusp = mrb_nil_value();
     set_last_status(mrb, mrb_nil_value());
     return mrb_nil_value();
   }
-  set_last_status(mrb, mrb_process_status_new(mrb, result_pid, raw_status));
+  *statusp = mrb_process_status_new(mrb, result_pid, raw_status);
+  set_last_status(mrb, *statusp);
   return mrb_int_value(mrb, result_pid);
+}
+
+/*
+ * call-seq:
+ *   Process.waitpid(pid = -1, flags = 0) -> integer or nil
+ *   Process.wait(pid = -1, flags = 0)    -> integer or nil
+ *
+ * Waits for a child process to finish and returns its process ID, setting
+ * <code>$?</code> to the Process::Status it finished with.  Which children
+ * are waited for is what +pid+ chooses: a positive number names one child,
+ * 0 any child in the caller's process group, -1 (the default) any child at
+ * all, and a number below -1 any child in the process group whose ID is
+ * -pid.
+ *
+ * With Process::WNOHANG among +flags+, returns nil and sets <code>$?</code>
+ * to nil when no child is ready.  With Process::WUNTRACED, a stopped child
+ * is reported too, where the platform has such a thing.
+ *
+ * Raises Errno::ECHILD when there is no child to wait for, Errno::EINVAL
+ * when +flags+ holds a bit that is not one of the two, and RangeError when
+ * +pid+ is too large for the platform to carry.
+ */
+static mrb_value
+process_waitpid(mrb_state *mrb, mrb_value self)
+{
+  mrb_value status;
+
+  return wait_for_child(mrb, &status);
+}
+
+/*
+ * call-seq:
+ *   Process.waitpid2(pid = -1, flags = 0) -> [pid, status] or nil
+ *   Process.wait2(pid = -1, flags = 0)    -> [pid, status] or nil
+ *
+ * Waits as Process.waitpid does and returns the process ID and the
+ * Process::Status together, rather than leaving the status to be read from
+ * <code>$?</code>, which is set either way.  With Process::WNOHANG among
+ * +flags+ and no child ready, returns nil.
+ *
+ *   pid, status = Process.wait2
+ *   status.exitstatus   #=> 0
+ */
+static mrb_value
+process_waitpid2(mrb_state *mrb, mrb_value self)
+{
+  mrb_value status, pid = wait_for_child(mrb, &status);
+
+  if (mrb_nil_p(pid)) return mrb_nil_value();
+  return mrb_assoc_new(mrb, pid, status);
 }
 
 void
@@ -280,7 +317,10 @@ mrb_mruby_process_gem_init(mrb_state *mrb)
   mrb_define_module_function_id(mrb, process, MRB_SYM(pid),     process_pid,     MRB_ARGS_NONE());
   mrb_define_module_function_id(mrb, process, MRB_SYM(ppid),    process_ppid,    MRB_ARGS_NONE());
   mrb_define_module_function_id(mrb, process, MRB_SYM(kill),    process_kill,    MRB_ARGS_REQ(2)|MRB_ARGS_REST());
-  mrb_define_module_function_id(mrb, process, MRB_SYM(waitpid), process_waitpid, MRB_ARGS_OPT(2));
+  mrb_define_module_function_id(mrb, process, MRB_SYM(waitpid),  process_waitpid,  MRB_ARGS_OPT(2));
+  mrb_define_module_function_id(mrb, process, MRB_SYM(wait),     process_waitpid,  MRB_ARGS_OPT(2));
+  mrb_define_module_function_id(mrb, process, MRB_SYM(waitpid2), process_waitpid2, MRB_ARGS_OPT(2));
+  mrb_define_module_function_id(mrb, process, MRB_SYM(wait2),    process_waitpid2, MRB_ARGS_OPT(2));
 
   mrb_process_status_init(mrb, process);
 

--- a/mrbgems/mruby-process/test/process.rb
+++ b/mrbgems/mruby-process/test/process.rb
@@ -309,6 +309,64 @@ assert('Process.waitpid with no child to wait for') do
   io.close
 end
 
+assert('Process.wait') do
+  # The same wait under Ruby's other name for it.
+  skip ProcessTestUtil.child_reason if ProcessTestUtil.child_reason
+  io = ProcessTestUtil.spawn("exit 4")
+  skip "IO.popen is not available" unless io
+
+  io.read
+  pid = io.pid
+  assert_equal pid, Process.wait(pid)
+  assert_kind_of Process::Status, $?
+  assert_equal pid, $?.pid
+  assert_equal 4, $?.exitstatus
+  io.close
+end
+
+assert('Process.waitpid2, Process.wait2') do
+  # The pid and the status of one wait, returned together.  $? is set to the
+  # same status, so the pair is a second way to reach it and not a second
+  # wait: asking twice would find nothing to wait for the second time.
+  skip ProcessTestUtil.child_reason if ProcessTestUtil.child_reason
+  io = ProcessTestUtil.spawn("exit 4")
+  skip "IO.popen is not available" unless io
+
+  io.read
+  pid = io.pid
+  result = Process.waitpid2(pid)
+  assert_kind_of Array, result
+  assert_equal 2, result.size
+  assert_equal pid, result[0]
+  assert_kind_of Process::Status, result[1]
+  assert_equal 4, result[1].exitstatus
+  assert_equal pid, result[1].pid
+  # The same object, not merely a status that reads the same: one wait
+  # happened, and both ways of reaching it reach that one.
+  assert_true result[1].equal?($?)
+  io.close
+end
+
+assert('Process.wait2 with Process::WNOHANG') do
+  skip ProcessTestUtil.child_reason if ProcessTestUtil.child_reason
+  # `exec` so that the pid this knows is the one that sleeps; see
+  # Process.waitpid with Process::WNOHANG above.
+  io = ProcessTestUtil.spawn("exec sleep 30")
+  skip "IO.popen is not available" unless io
+
+  # Nothing has finished, so there is no pair to hand back.
+  assert_nil Process.wait2(io.pid, Process::WNOHANG)
+  assert_nil $?
+
+  Process.kill(:KILL, io.pid)
+  pid, status = Process.wait2(io.pid)
+  assert_equal io.pid, pid
+  assert_true status.signaled?
+  assert_nil status.exitstatus
+  assert_equal "KILL", Process::Status._signame(status.termsig)
+  io.close
+end
+
 assert('$? after IO.popen') do
   # mruby-io sets $? through Process::Status.new(pid, raw_status) when this
   # gem is present.  Neither gem depends on the other; this is the seam.


### PR DESCRIPTION
## Summary

`Process.waitpid` was the only way to wait for a child. Ruby has three more names for that wait: `Process.wait`, whose answer is the pid, and `Process.waitpid2` and `Process.wait2`, whose answer is the pid and the status together. The README has listed the missing ones as a separate change since the gem arrived, and this is that change.

## Changes

| File | What |
|---|---|
| `mrbgems/mruby-process/src/process.c` | the wait moves into `wait_for_child()`; `Process.wait`, `.waitpid2` and `.wait2` are defined beside `.waitpid` |
| `mrbgems/mruby-process/test/process.rb` | three tests: the other name, the pair, and the pair under `Process::WNOHANG` |
| `mrbgems/mruby-process/README.md` | the row for `Process.wait, .wait2` |

### One wait, two answers

`process_waitpid()` did the wait and then let half of its result go: it built the `Process::Status`, set `$?` to it, and returned the pid alone. The pair-returning form wants both, so the wait is now `wait_for_child()`, which hands the status back through an out parameter, and the two module functions differ only in what they do with it.

```c
static mrb_value
process_waitpid2(mrb_state *mrb, mrb_value self)
{
  mrb_value status, pid = wait_for_child(mrb, &status);

  if (mrb_nil_p(pid)) return mrb_nil_value();
  return mrb_assoc_new(mrb, pid, status);
}
```

That is what makes the pair a second reading of one wait rather than a second wait. `$?` is set to the same object, so the two ways of reaching the status cannot disagree, and nothing has to wait again to learn what it was. The test says that with `equal?` rather than `==`: what is asserted is one object, not two statuses that read alike.

### `Process::WNOHANG` has nothing to pair

A wait that returns because nothing was ready has neither a pid nor a status. `Process.waitpid` answers `nil` there and sets `$?` to `nil`; the pair-returning form answers `nil` too, rather than a pair with `nil` in it, which is what Ruby does.

### What is still missing

`Process.waitall` is not here. It waits for every child the process has, which is a set rather than a selector, and a gem that creates no children has no set to keep. The README row says so.

## Behaviour

```ruby
io = IO.popen("exit 4")
io.read
```

| | master | this PR | CRuby 4.0.6 |
| --- | --- | --- | --- |
| `Process.wait(io.pid)` | `NoMethodError` | the pid | the pid |
| `Process.wait2(io.pid)` | `NoMethodError` | `[pid, #<Process::Status: pid N exit 4>]` | `[pid, #<Process::Status: pid N exit 4>]` |
| `Process.waitpid2(io.pid)` | `NoMethodError` | the same pair | the same pair |
| `Process.wait2(io.pid, Process::WNOHANG)`, still running | `NoMethodError` | `nil` | `nil` |
| `Process.waitpid(io.pid)` | the pid | the pid | the pid |

`$?` is set exactly as it was, by every one of them.

## Size

`.text` of `bin/mruby` for the five `build_config/ci/gcc-clang.rb` builds, master and this branch built from the same path into empty directories:

| Build | master | this PR | delta |
| --- | --- | --- | --- |
| `bintest` | 1,304,758 | 1,304,998 | +240 |
| `ascii-ctype` | 1,291,318 | 1,291,558 | +240 |
| `byte-string` | 1,269,926 | 1,270,166 | +240 |
| `cxx_abi` | 1,329,273 | 1,329,513 | +240 |
| `full-debug` (-O0) | 1,907,254 | 1,907,590 | +336 |

All of it is in `process.o`, whose `.text` goes 1,913 → 2,153. By `nm -S` on the `bintest` build, master's `process_waitpid` is 353 bytes; here `wait_for_child` is 361, and the two entry points that call it are 58 and 83.

## Testing

`rake -m test` on this branch, on the default `host` build, on all five `build_config/ci/gcc-clang.rb` builds and on `build_config/cross-mingw-winetest.rb` under Wine:

| Build | Total | OK | KO | Crash | Skip |
| --- | --- | --- | --- | --- | --- |
| `host` (default config) | 2,286 | 2,232 | 0 | 0 | 54 |
| `bintest` | 2,518 | 2,504 | 0 | 0 | 14 |
| `ascii-ctype` | 2,511 | 2,496 | 0 | 0 | 15 |
| `byte-string` | 2,444 | 2,390 | 0 | 0 | 54 |
| `cxx_abi` | 2,518 | 2,504 | 0 | 0 | 14 |
| `full-debug` | 2,518 | 2,512 | 0 | 0 | 6 |
| `cross-mingw-winetest` (Wine 11.0) | 1,701 | 1,657 | 0 | 0 | 44 |

`bintest` also ran its own 124 bin tests (123 OK, 1 skip), and the Wine build its own 84 (79 OK, 5 skip).

The three new tests need a child to wait for, and `IO#pid` is a process handle rather than a pid on Windows, so all three skip there: master at `9ef4b16e2` reports 1,698 / 1,657 / 0 / 0 / 41 on that build, and the +3 lands entirely in the total and the skips.

## Environment

<details>
<summary>Machine, toolchain and the compile line of each build</summary>

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-30-generic x86_64 |
| CPU | AMD Ryzen 9 5950X (16 cores, 32 threads) |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0 |
| Cross compiler | x86_64-w64-mingw32-gcc-posix (GCC) 13-posix |
| Linker | GNU ld (GNU Binutils) 2.47.20260726 |
| Wine | wine-11.0 |
| CRuby | 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |

The line each build actually compiles `mrbgems/mruby-process/src/process.c` with, taken from the `.o.flags` each build records, with `-MMD -c`, `-I` and `-o` dropped. `cxx_abi` is `gcc -x c++`, not `g++`; `g++` only links it.

```console
# host (default config)
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK mrbgems/mruby-process/src/process.c

# bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK mrbgems/mruby-process/src/process.c

# ascii-ctype
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-process/src/process.c

# byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-process/src/process.c

# cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-process/src/process.c

# full-debug (-O0)
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-process/src/process.c

# cross-mingw-winetest
x86_64-w64-mingw32-gcc-posix -static -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-process/src/process.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `Process.wait` as an alias for `Process.waitpid`.
  * Added `Process.waitpid2` and `Process.wait2`, returning both the child process ID and exit status.
  * Nonblocking waits now return no result when no child has finished.

* **Bug Fixes**
  * Improved process status reporting, including exit and signal-termination results.
  * Preserved consistent `$?` updates across wait methods.

* **Documentation**
  * Updated the supported-methods documentation for the new process-wait APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->