### PR TITLE
build_config: name the Windows port in the MinGW config

### DIFF
--- a/build_config/cross-mingw.rb
+++ b/build_config/cross-mingw.rb
@@ -10,5 +10,12 @@ MRuby::CrossBuild.new("cross-mingw") do |conf|
   conf.linker.command = conf.cc.command
   conf.archiver.command = "#{conf.host_target}-gcc-ar"
   conf.exts.executable = ".exe"
+
+  # A cross build detects no host to pick a port from, so the Windows HAL
+  # has to be named here; without it every `mrb_hal_*` the gems sitting on
+  # it call is undefined at link time.  This has to precede the gembox: a
+  # gem picks its port when it is added.
+  conf.ports :win
+
   conf.gembox "default"
 end


### PR DESCRIPTION
## Summary

`build_config/cross-mingw.rb` has not linked since the gems grew ports. A cross build detects no host, so it uses the port its config names, and this config names none: every `mrb_hal_*` function mruby-io, mruby-socket and mruby-process call is left undefined at link time.

## Changes

| File | What |
|---|---|
| `build_config/cross-mingw.rb` | `conf.ports :win`, before the gembox |

### Where the line goes

A gem picks its port when it is added to the build, so naming the port after the gembox would be naming it too late. `build_config/cross-mingw-winetest.rb` beside it carries the same line in the same place; this is the config that was left behind.

## Testing

On master, `MRUBY_CONFIG=build_config/cross-mingw.rb rake -m` ends in

```console
collect2: error: ld returned 1 exit status
```

with 620 undefined references over 112 distinct `mrb_hal_*` symbols. The only binary it produces is `mrbc.exe`, which is the compiler sub-build and holds none of the gems that sit on a port.

On this branch the same command completes, and `build/cross-mingw/bin` holds

```console
mirb.exe  mrbc.exe  mrdb.exe  mruby-strip.exe  mruby.exe
```

and the `mruby.exe` it produced runs. This config links against the MinGW runtime rather than statically, so the DLLs have to be reachable:

```console
$ WINEPATH='Z:\usr\lib\gcc\x86_64-w64-mingw32\13-posix' \
    wine build/cross-mingw/bin/mruby.exe -e 'puts "hello"'
hello
```

The config sets no `enable_test`, so there is no test suite here to run. `build_config/cross-mingw-winetest.rb`, which does have one, is unaffected and still reports `KO: 0`.

## Environment

<details>
<summary>Machine and toolchain</summary>

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-30-generic x86_64 |
| CPU | AMD Ryzen 9 5950X (16 cores, 32 threads) |
| Cross compiler | x86_64-w64-mingw32-gcc-posix (GCC) 13-posix |
| Wine | wine-11.0 |
| CRuby | 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |

The line this config compiles `mrbgems/mruby-io/src/io.c` with, taken from the `.o.flags` the build records, with `-MMD -c`, `-I` and `-o` dropped:

```console
x86_64-w64-mingw32-gcc-posix -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK mrbgems/mruby-io/src/io.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build Improvements**
  * Improved cross-platform Windows build configuration to ensure the Windows target is enabled correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->