### PR TITLE
build_config: rewrite only the `z:` that is a path

### DIFF
--- a/build_config/helpers/wine_runner.rb
+++ b/build_config/helpers/wine_runner.rb
@@ -24,14 +24,15 @@ def clean(output, stderr = false)
   # A limit of -1 keeps the trailing empty fields, so a blank line at the end
   # of the output survives the round trip; a disassembly ends with one.
   results = output.split(/\n/, -1).map do |line|
-    # Fix file paths
-    if line =~ /#{DOSROOT}\\/i
-      line.gsub!(/#{DOSROOT}([^:]*)/i) { |path|
-        path.gsub!(/^#{DOSROOT}/i, '')
-        path.gsub!(%r{\\}, '/')
-        path
-      }
-    end
+    # Fix file paths.  A line that holds one is not all path, so what a path
+    # is has to be said on both ends: `z:` is a root only where a path
+    # follows it, which is what the backslash asks, and a path ends where the
+    # next root begins.  Without the first, a `z:` that is merely text is
+    # taken for a root and the words after it go with it; without the second,
+    # a path that follows another on the same line is swallowed by it.
+    line.gsub!(/#{DOSROOT}(\\(?:(?!#{DOSROOT})[^:])*)/i) { |path|
+      path.sub(/\A#{DOSROOT}/i, '').gsub(%r{\\}, '/')
+    }
 
     line
   end


### PR DESCRIPTION
## Summary

The Wine runner turns the DOS paths a Windows program prints back into the Unix ones the tests wrote, by matching `z:` and everything after it up to the next colon. A line that carries a path is not all path, and neither end of one was being said: a `z:` that is not a root is taken for one, and a path that is followed by another swallows it.

The first is what fails in CI. `Tempfile` draws the last characters of a name from thirty-six, and four bin test assertions echo such a name back, so about one run in ten fails, on whichever of them drew the name.

## Changes

| File | What |
|---|---|
| `build_config/helpers/wine_runner.rb` | a root is `z:` with a path after it, a path ends where the next root begins, and the separate guard that asked the line the first question goes |

### Both ends of a path

```ruby
    line.gsub!(/#{DOSROOT}(\\(?:(?!#{DOSROOT})[^:])*)/i) { |path|
      path.sub(/\A#{DOSROOT}/i, '').gsub(%r{\\}, '/')
    }
```

The backslash says where a path starts: `z:` is a root only where one follows. The lookahead says where it ends: a root cannot be inside a path, so the run stops when the next one begins. A colon still ends it as before.

The guard around all this, `if line =~ /#{DOSROOT}\\/i`, asked whether the line held a root before rewriting anything in it, and that is the shape of the bug: asked once for the whole line, it let everything else on a line that held one be rewritten too. The question now belongs to each match, so the guard has nothing left to do.

## Testing

The five shapes through the old rewriting and the new, `clean()` lifted out of the runner:

| raw | was | now |
| --- | --- | --- |
| `z:\home\t\bin\mrbc.exe:/home/t/tmp/a.rb...fpmp1z:Syntax OK` | `/home/t/bin/mrbc.exe:/home/t/tmp/a.rb...fpmp1Syntax OK` | `/home/t/bin/mrbc.exe:/home/t/tmp/a.rb...fpmp1z:Syntax OK` |
| `z:\home\t\bin\mrbc.exe:z:\home\t\tmp\a.rb:Syntax OK` | `/home/t/bin/mrbc.exe:/home/t/tmp/a.rb:Syntax OK` | unchanged |
| `z:\home\t\a.rb:1:2: syntax error` | `/home/t/a.rb:1:2: syntax error` | unchanged |
| `z:\home\a.rb z:\home\b.rb` | `/home/a.rb z:\home\b.rb` | `/home/a.rb /home/b.rb` |
| `nothing to rewrite here` | unchanged | unchanged |

The fourth row is the second end of the same question: master leaves the later path alone, since the earlier one ran over the `z` that begins it. The first row is the failure as it was seen, from `parsing function with void argument` in the mrbc bin tests: the temp file name ended in `z`, the colon after it made a second `z:`, and `Syntax OK` went with it. Three Wine runs failed this way while the change was being written, the other two on `Compiling multiple files without new line in last line. #2361` and on the same test again with a different name.

`rake -m test` on `build_config/cross-mingw-winetest.rb` under Wine:

| Suite | Total | OK | KO | Crash | Skip |
| --- | --- | --- | --- | --- | --- |
| `mrbtest` | 1,698 | 1,657 | 0 | 0 | 41 |
| `bintest` | 84 | 79 | 0 | 0 | 5 |

Both are what master reports. A green run proves little on its own here, since whether master fails
depends on the random tail of a temp file name; what it does show is that the narrower pattern still
rewrites every path these two suites print.

## Environment

<details>
<summary>Machine and toolchain</summary>

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-30-generic x86_64 |
| CPU | AMD Ryzen 9 5950X (16 cores, 32 threads) |
| Cross compiler | x86_64-w64-mingw32-gcc-posix (GCC) 13-posix |
| Wine | wine-11.0 |
| CRuby | 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows path handling during build operations.
  * Prevented incorrect rewriting of paths that contain additional colons or do not include a valid path segment.
  * Converted rewritten paths to consistent slash-based formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->