### PR TITLE
build_config: collect Wine output through files

### DIFF
--- a/build_config/helpers/wine_runner.rb
+++ b/build_config/helpers/wine_runner.rb
@@ -2,7 +2,7 @@
 
 # Wrapper for running tests for cross-compiled Windows builds in Wine.
 
-require 'open3'
+require 'tmpdir'
 
 DOSROOT = 'z:'
 
@@ -40,6 +40,31 @@ def clean(output, stderr = false)
 end
 
 
+# Run a Windows program under Wine and hand back what it wrote and how it
+# ended, the way `Open3.capture3` would.
+#
+# Not the way it would, though.  Wine starts background services on its way
+# up and gives each of them the standard streams it was handed itself, and
+# they outlive the program.  A pipe is at an end when the last writer lets go
+# of it, so reading one here is waiting on those services and not on the
+# program: the wrapper hangs, holding a pipe no one will write to again, long
+# after the program it ran has exited.  A file ends where its contents do,
+# whoever else still holds it open.
+def capture(argv, input)
+  Dir.mktmpdir('wine-runner') do |dir|
+    stdin  = File.join(dir, 'stdin')
+    stdout = File.join(dir, 'stdout')
+    stderr = File.join(dir, 'stderr')
+    File.write(stdin, input)
+
+    pid = Process.spawn('wine', *argv, in: stdin, out: stdout, err: stderr)
+    _, status = Process.waitpid2(pid)
+
+    [File.read(stdout), File.read(stderr), status]
+  end
+end
+
+
 def main
   if ARGV.empty? || ARGV[0] =~ /^- (-?) (\?|help|h) $/x
     puts "#{$0} <command-line>"
@@ -59,7 +84,7 @@ def main
   ENV['WINEDEBUG'] = 'err-all,warn-all,fixme-all,trace-all'
 
   # Run the program in wine and capture the output
-  output, errormsg, status = Open3.capture3('wine', *ARGV, :stdin_data => input)
+  output, errormsg, status = capture(ARGV, input)
 
   # Clean and print the results.
   STDOUT.write clean(output)


### PR DESCRIPTION
## Summary

The Wine runner reads what a program wrote from two pipes, and a pipe is at an end when the last writer lets go of it. Wine gives the standard streams it was handed itself to the services it starts on its way up, and those outlive the program, so the read is waiting on them and not on it. The runner sits on a pipe no one will write to again, and the test run stops there, after the program it ran has exited.

## Changes

| File | What |
|---|---|
| `build_config/helpers/wine_runner.rb` | the program's output is collected through files instead of pipes, and the process waited for is the one that was started |

### What was seen

The run this was caught in had `mrbtest.exe` already gone and the runner blocked in `read`. Its stderr was pipe `784664`, and walking `/proc/*/fd` for that pipe found the write end still open in seven processes, none of them the program: `wineserver`, `services.exe`, `plugplay.exe`, `svchost.exe`, `rpcss.exe`, and two `winedevice.exe`.

Which services are up, and which of them a run starts rather than inherits from an earlier one, is what decides whether it finishes; that is why only some do not. Three runs hung this way.

### Files instead of pipes

```ruby
def capture(argv, input)
  Dir.mktmpdir('wine-runner') do |dir|
    stdin  = File.join(dir, 'stdin')
    stdout = File.join(dir, 'stdout')
    stderr = File.join(dir, 'stderr')
    File.write(stdin, input)

    pid = Process.spawn('wine', *argv, in: stdin, out: stdout, err: stderr)
    _, status = Process.waitpid2(pid)

    [File.read(stdout), File.read(stderr), status]
  end
end
```

A file ends where its contents do, whoever else still holds it open. The three values `Open3.capture3` handed back are what this hands back, and what the runner then does to them is untouched.

## Testing

The mechanism, with a stand-in for the launcher that does the one thing Wine does here, and nothing else Wine does:

```sh
$ cat fake/wine
#!/bin/sh
sleep 30 &            # a service that keeps the streams and outlives us
echo "$@"
echo "diagnostic" 1>&2
exit 3
```

| Runner | Result |
| --- | --- |
| master | killed by `timeout 10`, exit 124, nothing printed |
| this branch | `a.exe` on stdout, `diagnostic` on stderr, exit 3, elapsed 0s |

Seven shapes through master's runner and this one, against a real `mruby.exe` and `mrbc.exe` under Wine, byte for byte identical on both: a plain `puts`; a `raise`, for stderr and a non-zero exit; stdin delivered and read back; UTF-8 out and back; an empty stdin; a DOS path in a diagnostic, to show the rewriting still reaches it; and `mrbc -o -`, whose 82 bytes of `.mrb` come back with the same digest.

`rake -m test` on `build_config/cross-mingw-winetest.rb` under Wine:

| Suite | Total | OK | KO | Crash | Skip |
| --- | --- | --- | --- | --- | --- |
| `mrbtest` | 1,698 | 1,657 | 0 | 0 | 41 |
| `bintest` | 84 | 79 | 0 | 0 | 5 |

Both are what master reports on a run that does finish.

## Environment

<details>
<summary>Machine and toolchain</summary>

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-30-generic x86_64 |
| CPU | AMD Ryzen 9 5950X (16 cores, 32 threads) |
| Cross compiler | x86_64-w64-mingw32-gcc-posix (GCC) 13-posix |
| Wine | wine-11.0 |
| CRuby | 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Wine command execution reliability by capturing input, output, and errors through temporary files.
  * Preserved process completion and exit-status reporting for build operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->