### PR TITLE
mruby-io: run these Windows-skipped tests on Windows

### DIFF
--- a/mrbgems/mruby-io/test/file.rb
+++ b/mrbgems/mruby-io/test/file.rb
@@ -276,7 +276,6 @@ assert("File.readlink") do
 end
 
 assert("File.readlink fails with non-symlink") do
-  skip "readlink is not supported on this platform" if MRubyIOTestUtil.win?
   begin
     e2 = nil
     assert_raise(Errno::EINVAL) {

--- a/mrbgems/mruby-io/test/io.rb
+++ b/mrbgems/mruby-io/test/io.rb
@@ -3,6 +3,7 @@
 
 MRubyIOTestUtil.io_test_setup
 $cr, $cmd = MRubyIOTestUtil.win? ? [1, "cmd /c "] : [0, ""]
+$cat = MRubyIOTestUtil.win? ? 'findstr "^"' : 'cat'
 
 def assert_io_open(meth)
   assert "assert_io_open" do
@@ -171,13 +172,15 @@ end
 
 assert "IO#read(n) with n > IO::BUF_SIZE" do
   buf_size = 4096  # copied from io.c
-  # The whole write has to fit in the pipe, since nothing reads from it until
-  # the writer is done, and Windows gives a pipe less room than this.
-  skip "the pipe buffer here is smaller than this write" if MRubyIOTestUtil.win?
-  IO.pipe do |r,w|
-    n = buf_size+1
-    w.write 'a'*n
-    assert_equal 'a'*n, r.read(n)
+  n = buf_size+1
+  dir = MRubyIOTestUtil.mkdtemp("mruby-io-test.XXXXXX")
+  path = "#{dir}/bufsize"
+  begin
+    File.open(path, "w") { |f| f.write('a'*n) }
+    File.open(path, "r") { |f| assert_equal 'a'*n, f.read(n) }
+  ensure
+    File.delete(path) rescue nil
+    MRubyIOTestUtil.rmdir dir
   end
 end
 
@@ -395,15 +398,16 @@ assert('IO#ungetc after grow and partial read') do
 end
 
 assert('IO#isatty') do
-  skip "isatty is not supported on this platform" if MRubyIOTestUtil.win?
-  begin
-    f = File.open("/dev/tty")
-  rescue SystemCallError => e
-    skip e.message
-  else
-    assert_true f.isatty
-  ensure
-    f&.close
+  unless MRubyIOTestUtil.win?
+    begin
+      f = File.open("/dev/tty")
+    rescue SystemCallError => e
+      skip e.message
+    else
+      assert_true f.isatty
+    ensure
+      f&.close
+    end
   end
   begin
     f = File.open($mrbtest_io_rfname)
@@ -530,12 +534,11 @@ assert('IO.popen') do
 end
 
 assert('IO.popen with in option') do
-  skip "no POSIX shell or `cat` to talk to here" if MRubyIOTestUtil.win?
   begin
     IO.pipe do |r, w|
-      w.write 'hello'
+      w.write "hello\n"
       w.close
-      assert_equal "hello", IO.popen("cat", "r", in: r) { |i| i.read }
+      assert_equal "hello\n", IO.popen($cat, "r", in: r) { |i| i.read }
       assert_equal "", r.read
     end
     assert_raise(ArgumentError) { IO.popen("hello", "r", in: Object.new) }
@@ -545,12 +548,11 @@ assert('IO.popen with in option') do
 end
 
 assert('IO.popen with out option') do
-  skip "no POSIX shell or `cat` to talk to here" if MRubyIOTestUtil.win?
   begin
     IO.pipe do |r, w|
-      IO.popen("echo 'hello'", "w", out: w) {}
+      IO.popen(MRubyIOTestUtil.win? ? "echo hello" : "echo 'hello'", "w", out: w) {}
       w.close
-      assert_equal "hello\n", r.read
+      assert_equal MRubyIOTestUtil.win? ? "hello\r\n" : "hello\n", r.read
     end
   rescue NotImplementedError => e
     skip e.message
@@ -558,12 +560,14 @@ assert('IO.popen with out option') do
 end
 
 assert('IO.popen with err option') do
-  skip "no POSIX shell or `cat` to talk to here" if MRubyIOTestUtil.win?
   begin
     IO.pipe do |r, w|
-      assert_equal "", IO.popen("echo 'hello' 1>&2", "r", err: w) { |i| i.read }
+      cmd = MRubyIOTestUtil.win? ? "echo hello 1>&2" : "echo 'hello' 1>&2"
+      assert_equal "", IO.popen(cmd, "r", err: w) { |i| i.read }
       w.close
-      assert_equal "hello\n", r.read
+      # cmd.exe's `echo` includes the space before the redirection operator
+      # in what it prints, so the Windows side carries a trailing space.
+      assert_equal MRubyIOTestUtil.win? ? "hello \r\n" : "hello\n", r.read
     end
   rescue NotImplementedError => e
     skip e.message
@@ -571,9 +575,8 @@ assert('IO.popen with err option') do
 end
 
 assert('IO#close_write') do
-  skip "no `cat` to talk to on this platform" if MRubyIOTestUtil.win?
   begin
-    io = IO.popen("cat", "r+")
+    io = IO.popen($cat, "r+")
     io.write "mruby-io\n"
     io.close_write
     assert_false io.closed?
@@ -586,9 +589,8 @@ assert('IO#close_write') do
 end
 
 assert('IO#close_write closes the stream for writing') do
-  skip "no `cat` to talk to on this platform" if MRubyIOTestUtil.win?
   begin
-    io = IO.popen("cat", "r+")
+    io = IO.popen($cat, "r+")
     io.write "mruby-io\n"
     io.close_write
     assert_raise(IOError) { io.write "again" }
@@ -643,9 +645,8 @@ assert('IO#close_write on a pipe end') do
 end
 
 assert('IO#close_write twice') do
-  skip "no `cat` to talk to on this platform" if MRubyIOTestUtil.win?
   begin
-    io = IO.popen("cat", "r+")
+    io = IO.popen($cat, "r+")
     io.close_write
     # the write end is already gone, and the stream is still read from
     assert_raise(IOError) { io.close_write }


### PR DESCRIPTION
## Summary

Nine mruby-io tests carried an explicit `skip ... if MRubyIOTestUtil.win?`, turning them into POSIX-only tests. Eight of them were leaning on a POSIX-specific detail rather than a real Windows capability gap; this PR adjusts them so they run, and pass, on Windows too.

## Changes

| File | What |
|---|---|
| `mrbgems/mruby-io/test/io.rb` | Seven tests stop skipping on Windows; a shared `$cat` is added |
| `mrbgems/mruby-io/test/file.rb` | A redundant Windows skip is dropped |

### `IO#read(n) with n > IO::BUF_SIZE`

The test wrote through a pipe without a concurrent reader, and Windows gives a pipe less room than the write needs, so it deadlocks there. Reading the data back from a temp file instead sidesteps pipe capacity entirely; it was never what the test meant to exercise.

### `IO#isatty`

Only the half that opens `/dev/tty` is POSIX-specific. The other half, asserting a regular file's `isatty` is false, does not touch a POSIX path and already passes on Windows, since `isatty` itself is implemented in the Windows HAL (`ports/win/io_hal.c`). The skip is narrowed to just the `/dev/tty` part.

### `IO.popen` with `in:`/`out:`/`err:`, and `IO#close_write` (three tests)

These talked to a POSIX shell and `cat`. `cmd.exe` has neither, but `findstr "^"` is a working `cat` substitute there; verified byte-exact against both pipe input (`in:`) and popen's `r+` mode (`close_write`). `echo` needed only its quoting adjusted, since `cmd.exe` does not strip shell-style quotes. One assertion keeps a platform-conditional expected value: `echo hello 1>&2` on `cmd.exe` echoes the space before the redirection operator, so that side of the pipe carries a trailing space the POSIX side does not.

### `File.readlink fails with non-symlink`

This one stays out of reach: `ports/win/io_hal.c`'s `mrb_hal_io_readlink` unconditionally raises `E_NOTIMP_ERROR`, and nothing here adds Windows symlink support. The test already had its own `rescue NotImplementedError => e; skip e.message` around the assertion it cares about, the same fallback `File.readlink` right above it relies on, so the explicit Windows skip was redundant rather than the thing keeping the test off Windows. It still skips there, just without the dead guard.

## Testing

`rake -m test` on this branch, on the default `host` build, on all five `build_config/ci/gcc-clang.rb` builds, and on `build_config/cross-mingw-winetest.rb` under Wine:

| Build | Total | OK | KO | Crash | Skip |
| --- | --- | --- | --- | --- | --- |
| `host` (default config) | 2,284 | 2,230 | 0 | 0 | 54 |
| `bintest` (host) | 113 | 112 | 0 | 0 | 1 |
| `full-debug` | 2,516 | 2,510 | 0 | 0 | 6 |
| `bintest` (ci build) | 2,516 | 2,502 | 0 | 0 | 14 |
| `bintest`'s own bin tests | 124 | 123 | 0 | 0 | 1 |
| `cxx_abi` | 2,516 | 2,502 | 0 | 0 | 14 |
| `byte-string` | 2,442 | 2,388 | 0 | 0 | 54 |
| `ascii-ctype` | 2,509 | 2,494 | 0 | 0 | 15 |
| `cross-mingw-winetest` (Wine 11.0) | 1,699 | 1,668 | 0 | 0 | 31 |
| `cross-mingw-winetest`'s own bin tests | 84 | 79 | 0 | 0 | 5 |

The eight retargeted tests run, and pass, on both the POSIX-side builds and under Wine; `File.readlink fails with non-symlink` still shows as a skip on Wine, now reached through `rescue NotImplementedError` instead of the removed explicit guard.

## Environment

<details>
<summary>Machine and toolchain</summary>

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-30-generic x86_64 |
| CPU | AMD Ryzen 9 5950X (16 cores, 32 threads) |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0 |
| Cross compiler | x86_64-w64-mingw32-gcc-posix (GCC) 13-posix |
| Linker | GNU ld (GNU Binutils) 2.47.20260726 |
| Wine | wine-11.0 |
| CRuby | 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows compatibility for file and stream I/O tests.
  * Enabled additional `IO.popen` and `IO#close_write` validation on Windows.
  * Updated command handling and expected line endings for platform differences.
  * Reworked buffer-size validation to use temporary files where pipe limitations affected Windows.
  * Preserved appropriate handling for unsupported symbolic-link and terminal operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->