### PR TITLE
headers: unify C linkage guards on MRB_BEGIN_DECL

### DIFF
--- a/mrbgems/hw-adc/include/mruby/adc.h
+++ b/mrbgems/hw-adc/include/mruby/adc.h
@@ -2,18 +2,15 @@
 #define MRUBY_ADC_H
 
 #include <stdint.h>
+#include <mruby/common.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+MRB_BEGIN_DECL
 
 /* HAL functions - implemented in ports/<platform>/adc.c */
 int      mrb_adc_init(uint8_t pin);
 uint32_t mrb_adc_read_raw(uint8_t input);
 float    mrb_adc_read_voltage(uint8_t input);
 
-#ifdef __cplusplus
-}
-#endif
+MRB_END_DECL
 
 #endif /* MRUBY_ADC_H */

--- a/mrbgems/hw-gpio/include/mruby/gpio.h
+++ b/mrbgems/hw-gpio/include/mruby/gpio.h
@@ -2,10 +2,9 @@
 #define MRUBY_GPIO_H
 
 #include <stdint.h>
+#include <mruby/common.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+MRB_BEGIN_DECL
 
 /* direction/mode flags (bitmask) */
 #define MRB_GPIO_IN         0x01
@@ -24,8 +23,6 @@ void mrb_gpio_open_drain(uint8_t pin);
 int  mrb_gpio_read(uint8_t pin);
 void mrb_gpio_write(uint8_t pin, uint8_t val);
 
-#ifdef __cplusplus
-}
-#endif
+MRB_END_DECL
 
 #endif /* MRUBY_GPIO_H */

--- a/mrbgems/hw-i2c/include/mruby/i2c.h
+++ b/mrbgems/hw-i2c/include/mruby/i2c.h
@@ -4,10 +4,9 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>
+#include <mruby/common.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+MRB_BEGIN_DECL
 
 typedef enum {
   MRB_I2C_OK             =  0,
@@ -24,8 +23,6 @@ int mrb_i2c_write_read(int unit, uint8_t addr, const uint8_t *src, size_t wlen,
                        uint8_t *dst, size_t rlen, uint32_t timeout_us);
 int mrb_i2c_unit_name_to_num(const char *name);
 
-#ifdef __cplusplus
-}
-#endif
+MRB_END_DECL
 
 #endif /* MRUBY_I2C_H */

--- a/mrbgems/hw-pwm/include/mruby/pwm.h
+++ b/mrbgems/hw-pwm/include/mruby/pwm.h
@@ -3,18 +3,15 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include <mruby/common.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+MRB_BEGIN_DECL
 
 /* HAL functions - implemented in ports/<platform>/pwm.c */
 void mrb_pwm_init(uint32_t pin);
 void mrb_pwm_set_freq_duty(uint32_t pin, float frequency, float duty);
 void mrb_pwm_set_enabled(uint32_t pin, bool enabled);
 
-#ifdef __cplusplus
-}
-#endif
+MRB_END_DECL
 
 #endif /* MRUBY_PWM_H */

--- a/mrbgems/hw-spi/include/mruby/spi.h
+++ b/mrbgems/hw-spi/include/mruby/spi.h
@@ -3,10 +3,9 @@
 
 #include <stdint.h>
 #include <stddef.h>
+#include <mruby/common.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+MRB_BEGIN_DECL
 
 #define MRB_SPI_MSB_FIRST 1
 #define MRB_SPI_LSB_FIRST 0
@@ -37,8 +36,6 @@ int mrb_spi_read(mrb_spi_info *info, uint8_t *dst, size_t len, uint8_t tx_val);
 int mrb_spi_write(mrb_spi_info *info, const uint8_t *src, size_t len);
 int mrb_spi_transfer(mrb_spi_info *info, const uint8_t *tx, uint8_t *rx, size_t len);
 
-#ifdef __cplusplus
-}
-#endif
+MRB_END_DECL
 
 #endif /* MRUBY_SPI_H */

--- a/mrbgems/hw-uart/include/mruby/uart.h
+++ b/mrbgems/hw-uart/include/mruby/uart.h
@@ -4,10 +4,9 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>
+#include <mruby/common.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+MRB_BEGIN_DECL
 
 #define MRB_UART_PARITY_NONE 0
 #define MRB_UART_PARITY_EVEN 1
@@ -53,8 +52,6 @@ void mrb_uart_send_break(int unit, uint32_t duration_ms);
 void mrb_uart_clear_rx(int unit);
 void mrb_uart_clear_tx(int unit);
 
-#ifdef __cplusplus
-}
-#endif
+MRB_END_DECL
 
 #endif /* MRUBY_UART_H */

--- a/mrbgems/mruby-dir/include/dir_hal.h
+++ b/mrbgems/mruby-dir/include/dir_hal.h
@@ -13,6 +13,8 @@
 
 #include <mruby.h>
 
+MRB_BEGIN_DECL
+
 /*
  * Platform-independent directory handle
  * Each HAL implementation defines this structure internally
@@ -76,5 +78,7 @@ void mrb_hal_dir_init(mrb_state *mrb);
 
 /* Cleanup HAL (called once at gem finalization) */
 void mrb_hal_dir_final(mrb_state *mrb);
+
+MRB_END_DECL
 
 #endif /* MRUBY_DIR_HAL_H */

--- a/mrbgems/mruby-io/include/io_hal.h
+++ b/mrbgems/mruby-io/include/io_hal.h
@@ -13,6 +13,8 @@
 
 #include <mruby.h>
 
+MRB_BEGIN_DECL
+
 /*
  * Platform-independent type definitions
  */
@@ -446,5 +448,7 @@ void mrb_hal_io_init(mrb_state *mrb);
  * @param mrb mruby state
  */
 void mrb_hal_io_final(mrb_state *mrb);
+
+MRB_END_DECL
 
 #endif /* MRUBY_IO_HAL_H */

--- a/mrbgems/mruby-io/include/mruby/io.h
+++ b/mrbgems/mruby-io/include/mruby/io.h
@@ -11,9 +11,7 @@
 # error IO and File conflicts 'MRB_NO_STDIO' in your build configuration
 #endif
 
-#if defined(__cplusplus)
-extern "C" {
-#endif
+MRB_BEGIN_DECL
 
 /* IO#pread / IO#pwrite are backed directly by POSIX pread(2)/pwrite(2),
    so enable them only where those calls are actually available.
@@ -82,7 +80,5 @@ struct mrb_io {
 
 int mrb_io_fileno(mrb_state *mrb, mrb_value io);
 
-#if defined(__cplusplus)
-} /* extern "C" { */
-#endif
+MRB_END_DECL
 #endif /* MRUBY_IO_H */

--- a/mrbgems/mruby-process/include/process_hal.h
+++ b/mrbgems/mruby-process/include/process_hal.h
@@ -22,6 +22,8 @@
 
 #include <mruby.h>
 
+MRB_BEGIN_DECL
+
 /*
  * Decoded wait status
  */
@@ -140,5 +142,7 @@ void mrb_hal_process_init(mrb_state *mrb);
 
 /* Cleanup HAL (called once at gem finalization) */
 void mrb_hal_process_final(mrb_state *mrb);
+
+MRB_END_DECL
 
 #endif /* MRUBY_PROCESS_HAL_H */

--- a/mrbgems/mruby-process/include/process_internal.h
+++ b/mrbgems/mruby-process/include/process_internal.h
@@ -12,6 +12,8 @@
 
 #include <mruby.h>
 
+MRB_BEGIN_DECL
+
 /* Refuse `v` with a RangeError naming `what` unless it fits the `int` a port
    has to narrow it to.  A no-op where mruby's own Integer is no wider. */
 mrb_int mrb_process_int_arg(mrb_state *mrb, mrb_int v, const char *what);
@@ -22,5 +24,7 @@ void mrb_process_status_init(mrb_state *mrb, struct RClass *process);
 /* Build a Process::Status for a pid and the platform status it was reaped
    with.  The status decodes itself through the HAL as it is asked questions. */
 mrb_value mrb_process_status_new(mrb_state *mrb, mrb_int pid, mrb_int raw_status);
+
+MRB_END_DECL
 
 #endif /* MRUBY_PROCESS_INTERNAL_H */

--- a/mrbgems/mruby-regexp/include/re_internal.h
+++ b/mrbgems/mruby-regexp/include/re_internal.h
@@ -11,6 +11,8 @@
 #include <mruby/internal.h>
 #include <stdint.h>
 
+MRB_BEGIN_DECL
+
 /* The Unicode foldings /i reads are core's table, which only a build reading
    its strings as characters and classifying them by Unicode carries. /i
    therefore folds the way that build's own case conversion does and no other
@@ -479,5 +481,7 @@ int mrb_re_exec(mrb_state *mrb, const mrb_regexp_pattern *pat,
 int mrb_re_rexec(mrb_state *mrb, const mrb_regexp_pattern *pat,
             const char *str, mrb_int len, mrb_int limit,
             int *captures, int captures_size, mrb_bool binary);
+
+MRB_END_DECL
 
 #endif /* MRB_RE_INTERNAL_H */

--- a/mrbgems/mruby-socket/include/socket_hal.h
+++ b/mrbgems/mruby-socket/include/socket_hal.h
@@ -14,9 +14,7 @@
 
 #include <mruby.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+MRB_BEGIN_DECL
 
 /*
  * Socket HAL Initialization/Finalization
@@ -95,8 +93,6 @@ mrb_value mrb_hal_socket_unix_path(mrb_state *mrb, const char *sockaddr, size_t 
  * (getifaddrs / GetAdaptersAddresses). */
 mrb_value mrb_hal_socket_ip_address_list(mrb_state *mrb);
 
-#ifdef __cplusplus
-}
-#endif
+MRB_END_DECL
 
 #endif /* MRUBY_SOCKET_HAL_H */

--- a/mrbgems/mruby-task/include/task.h
+++ b/mrbgems/mruby-task/include/task.h
@@ -9,6 +9,8 @@
 
 #include <mruby.h>
 
+MRB_BEGIN_DECL
+
 /*
  * Task status values (bit-mapped)
  */
@@ -244,5 +246,7 @@ mrb_task_excl_exit(mrb_state *mrb)
 
 /* GC.scheduler_driven family - defined in gc.c */
 void mrb_init_task_gc(mrb_state *mrb);
+
+MRB_END_DECL
 
 #endif /* MRUBY_TASK_H */

--- a/mrbgems/mruby-task/include/task_hal.h
+++ b/mrbgems/mruby-task/include/task_hal.h
@@ -13,6 +13,8 @@
 
 #include <mruby.h>
 
+MRB_BEGIN_DECL
+
 /*
  * Configuration - can be overridden in platform-specific build configs
  */
@@ -166,5 +168,7 @@ void mrb_hal_task_sleep_us(mrb_state *mrb, mrb_int usec);
  * @param mrb The mruby state to tick
  */
 void mrb_tick(mrb_state *mrb);
+
+MRB_END_DECL
 
 #endif /* MRUBY_TASK_HAL_H */


### PR DESCRIPTION
## Summary

Gem headers spelled the boundary between a declaration and its same-language definition three different ways; unify all fifteen on `MRB_BEGIN_DECL`/`MRB_END_DECL`, the spelling `include/mruby/` and `mruby-compiler`'s `MRC_BEGIN_DECL` already use.

## Changes

| File | What |
|---|---|
| `mruby-socket/include/socket_hal.h` | bare `extern "C"` → `MRB_BEGIN_DECL`/`MRB_END_DECL` |
| `mruby-io/include/mruby/io.h` | bare `extern "C"` → `MRB_BEGIN_DECL`/`MRB_END_DECL` |
| `hw-adc/include/mruby/adc.h` | bare `extern "C"` → `MRB_BEGIN_DECL`; adds `#include <mruby/common.h>` |
| `hw-gpio/include/mruby/gpio.h` | bare `extern "C"` → `MRB_BEGIN_DECL`; adds `#include <mruby/common.h>` |
| `hw-spi/include/mruby/spi.h` | bare `extern "C"` → `MRB_BEGIN_DECL`; adds `#include <mruby/common.h>` |
| `hw-uart/include/mruby/uart.h` | bare `extern "C"` → `MRB_BEGIN_DECL`; adds `#include <mruby/common.h>` |
| `hw-i2c/include/mruby/i2c.h` | bare `extern "C"` → `MRB_BEGIN_DECL`; adds `#include <mruby/common.h>` |
| `hw-pwm/include/mruby/pwm.h` | bare `extern "C"` → `MRB_BEGIN_DECL`; adds `#include <mruby/common.h>` |
| `mruby-io/include/io_hal.h` | no guard → `MRB_BEGIN_DECL`/`MRB_END_DECL` |
| `mruby-task/include/task.h` | no guard → `MRB_BEGIN_DECL`/`MRB_END_DECL` |
| `mruby-task/include/task_hal.h` | no guard → `MRB_BEGIN_DECL`/`MRB_END_DECL` |
| `mruby-dir/include/dir_hal.h` | no guard → `MRB_BEGIN_DECL`/`MRB_END_DECL` |
| `mruby-regexp/include/re_internal.h` | no guard → `MRB_BEGIN_DECL`/`MRB_END_DECL` |
| `mruby-process/include/process_hal.h` | no guard → `MRB_BEGIN_DECL`/`MRB_END_DECL` |
| `mruby-process/include/process_internal.h` | no guard → `MRB_BEGIN_DECL`/`MRB_END_DECL` |

### A bare `extern "C"` answers a different question than `MRB_BEGIN_DECL`

`MRB_BEGIN_DECL` expands to nothing under `MRB_USE_CXX_ABI`, because that build compiles mruby itself as C++ and means its own declarations to carry C++ linkage. A bare `extern "C" { ... }` forces C linkage regardless, which is the one distinction the macro exists to make. Eight headers — `socket_hal.h`, `mruby/io.h`, and the six `hw-*/include/mruby/*.h` peripheral headers — used the bare form. `mruby/io.h` is the one of the eight that already crosses a gem boundary today (`mruby-socket/src/socket.c` includes it), but the fix applies uniformly rather than only where a boundary happens to be crossed today.

The six `hw-*` headers (`adc.h`, `gpio.h`, `spi.h`, `uart.h`, `i2c.h`, `pwm.h`) previously depended on nothing from `mruby.h`, so each gains `#include <mruby/common.h>` — the header `MRB_BEGIN_DECL` itself lives in — rather than pulling in all of `mruby.h` for a macro.

`mruby-compiler/include/mrc_common.h` keeps its own bare `extern "C"` unchanged: that one wraps the vendored `prism.h` include to force C linkage on Prism's C-only declarations so they match Prism's C-compiled objects, a different job than guarding a declaration of its own, and is out of scope here.

### Seven headers declared external functions with no guard at all

`include/mruby/`'s own rule guards every header that declares an externally-linked function, whether or not another gem happens to include it today — 23 of its 34 headers cross no gem boundary and still carry `MRB_BEGIN_DECL`. Seven gem headers didn't follow that rule: `io_hal.h`, `task.h`, `dir_hal.h`, `re_internal.h`, `process_hal.h`, `task_hal.h`, `process_internal.h`. `process_internal.h` and `re_internal.h` read as internal to their gem by name, but each declares functions with external linkage compiled in another translation unit of the same gem, which is exactly the case the guard exists for.

## Size

`.text` of `bin/mruby`, `size -A`, `build_config/ci/gcc-clang.rb`'s five builds, clean build directory, same worktree path, no test objects:

| Build | master | this PR | delta |
|---|---:|---:|---:|
| `full-debug` (-O0) | 1,907,254 | 1,907,254 | 0 |
| `bintest` | 1,304,758 | 1,304,758 | 0 |
| `cxx_abi` | 1,329,273 | 1,329,273 | 0 |
| `byte-string` | 1,269,926 | 1,269,926 | 0 |
| `ascii-ctype` | 1,291,318 | 1,291,318 | 0 |

No build's `.text` moved. `MRB_BEGIN_DECL` and a bare `extern "C" { ... }` expand to the same thing everywhere except under `MRB_USE_CXX_ABI`, and none of the affected declarations is overloaded there, so the change is symbol-linkage only.

## Testing

`rake -m test MRUBY_CONFIG=ci/gcc-clang` — all five builds (`full-debug`, `bintest`, `cxx_abi`, `byte-string`, `ascii-ctype`): 0 KO, 0 Crash.

The six `hw-*` headers aren't reachable from any host build (`full-core` only globs `mruby-*`), so each was also syntax-checked standalone against `-Iinclude` with `gcc -x c -fsyntax-only`, `g++ -x c++ -fsyntax-only`, and `g++ -x c++ -DMRB_USE_CXX_ABI -fsyntax-only`.

## Environment

<details>
<summary>OS, toolchain, CRuby</summary>

| | |
|---|---|
| OS | Ubuntu 24.04.4 LTS |
| Kernel | 7.0.0-30-generic |
| CPU | AMD Ryzen 9 5950X 16-Core Processor |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0 |
| C++ compiler (link only) | g++ (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0 |
| binutils | GNU Binutils 2.47.20260726 |
| CRuby (mrbgems fetch/tools) | ruby 4.0.6 (2026-07-14) +PRISM [x86_64-linux] |

`cxx_abi` compiles through `gcc -x c++ -std=gnu++03`, not `g++` directly — `g++` only links. Compile lines actually run (`mrbgems/mruby-io/src/io.c`, one representative TU touching the changed headers):

```console
# full-debug (enable_debug appends -g3 -O0 after the default -g -O3)
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# bintest
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK

# cxx_abi
gcc -c -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# byte-string
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ascii-ctype
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Compatibility Improvements**
  * Standardized C and C++ linkage handling across hardware, I/O, process, networking, regular expression, and task interfaces.
  * Improved consistency when including these interfaces from C++ code.
  * No public function signatures or runtime behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->