### PR TITLE
mruby-rational: cross-multiply exactly in rational_eq()'s overflow fallback

### DIFF
--- a/mrbgems/mruby-rational/src/rational.c
+++ b/mrbgems/mruby-rational/src/rational.c
@@ -717,10 +717,21 @@ rational_eq(mrb_state *mrb, mrb_value x)
       }
       if (mrb_int_mul_overflow(p1->numerator, p2->denominator, &a) ||
           mrb_int_mul_overflow(p2->numerator, p1->denominator, &b)) {
-#ifdef MRB_NO_FLOAT
+        /* Cross-multiply exactly instead of falling to Float: the products
+           are what mrb_bint_mul_n() already holds for the bigint-backed
+           arm above, and a double can round two unequal Rationals equal
+           near its precision limit. */
+#ifdef RAT_BIGINT
+        mrb_value na = mrb_bint_mul_n(mrb, mrb_as_bint(mrb, mrb_int_value(mrb, p1->numerator)),
+                                       mrb_int_value(mrb, p2->denominator));
+        mrb_value nb = mrb_bint_mul_n(mrb, mrb_as_bint(mrb, mrb_int_value(mrb, p2->numerator)),
+                                       mrb_int_value(mrb, p1->denominator));
+        result = mrb_bint_cmp(mrb, na, nb) == 0;
+        break;
+#elif defined(MRB_NO_FLOAT)
         rat_overflow(mrb);
 #else
-        result = (double)p1->numerator*p2->denominator == (double)p2->numerator*p2->denominator;
+        result = (double)p1->numerator*p2->denominator == (double)p2->numerator*p1->denominator;
         break;
 #endif
       }

--- a/mrbgems/mruby-rational/test/rational.rb
+++ b/mrbgems/mruby-rational/test/rational.rb
@@ -194,6 +194,50 @@ assert 'Rational#== between bigint-backed rationals' do
   assert_equal_rational(false, Rational(1, 2), Rational(big, 3))
 end
 
+assert 'Rational#== when the cross product overflows mrb_int but neither side is bigint-backed' do
+  # rational_eq()'s fallback cross-multiplies num1*den2 against num2*den1
+  # once the exact product overflows mrb_int; 1 << 30 overflows once
+  # multiplied by 3 or 5 on MRB_INT32, and 1 << 62 does the same on
+  # MRB_INT64 (same width-portable technique as test/t/gc.rb), so whichever
+  # width this build has, one of the two shifts below reaches the fallback
+  # while h itself stays under mrb_int and is not promoted to a Bigint.
+  [30, 62].each do |k|
+    h = begin
+      1 << k
+    rescue RangeError
+      next
+    end
+    begin
+      assert_equal_rational(false, Rational(h, 3), Rational(h, 5))
+      assert_equal_rational(false, Rational(h, 5), Rational(h, 3))
+    rescue RangeError
+      # Neither a Float nor mruby-bigint to answer through: the fallback
+      # correctly raises instead of guessing.
+      next
+    end
+  end
+end
+
+assert 'Rational#== is exact across the overflow, not rounded through Float' do
+  # Rational(h, 3) and Rational(h + 1, 3) differ by 1/3 in the numerator,
+  # which is inside a double's rounding error once h is large enough that
+  # h*3 overflows mrb_int; only exact (bigint) arithmetic tells them apart.
+  # The shift count is a variable because a constant shift wider than
+  # mrb_int is folded at compile time, which fails the build instead of
+  # raising.
+  k = 70
+  begin
+    probe = 1 << k
+    probe + probe
+  rescue RangeError
+    skip 'requires mruby-bigint'
+  end
+  [30, 62].each do |shift|
+    h = 1 << shift
+    assert_equal_rational(false, Rational(h, 3), Rational(h + 1, 3))
+  end
+end
+
 assert 'Rational#eql?' do
   assert_true  Rational(2,1).eql?(Rational(2,1))
   assert_true  Rational(1,2).eql?(Rational(2,4))


### PR DESCRIPTION
## Summary

`rational_eq()`'s `MRB_TT_RATIONAL` arm falls back once the cross product
`p1->numerator * p2->denominator` or `p2->numerator * p1->denominator`
overflows `mrb_int`. Two defects sat in that fallback: it compared the wrong
pair of products, and where `mruby-bigint` is present it went through
`Float` even though an exact bigint product was available.

## Changes

| File | Change |
|---|---|
| `mrbgems/mruby-rational/src/rational.c` | Fix `rational_eq()`'s overflow fallback |
| `mrbgems/mruby-rational/test/rational.rb` | Add regression tests, width-portable across `MRB_INT32`/`MRB_INT64` |

### The Float fallback compared `num1*den2` with `num2*den2`

The overflow check names the products the comparison wants —
`p1->numerator * p2->denominator` and `p2->numerator * p1->denominator` —
but the `Float` fallback two lines below read `p2->denominator` on both
sides, so the common factor cancelled and it actually asked
`num1 == num2`, with both denominators dropped. Corrected to
`p1->denominator` on the right-hand side.

### The fallback used `Float` even where `RAT_BIGINT` had an exact answer

The sibling arm for a bigint-backed receiver (`rational_eq_b()`) already
redoes its cross product with `mrb_bint_mul_n()` and compares it with
`mrb_bint_cmp()`. This arm now does the same under `RAT_BIGINT`, instead of
rounding through a `double` that has no bit left for the difference once
the operands are wide enough. This also answers under `MRB_NO_FLOAT` where
`RAT_BIGINT` is available, instead of raising through `rat_overflow()`
unconditionally. Without `RAT_BIGINT` there is no exact product to fall
back on, so the `Float` comparison remains there, with the operand
corrected.

## Behaviour

```ruby
h = 1 << 62
Rational(h, 3) == Rational(h, 5)     # master: true,  this PR: false (CRuby: false)
Rational(h, 5) == Rational(h, 3)     # master: true,  this PR: false (CRuby: false)
Rational(h, 3) == Rational(h + 1, 3) # master: true,  this PR: false (CRuby: false, with mruby-bigint)
```

```ruby
# MRB_NO_FLOAT with mruby-bigint
Rational(h, 3) == Rational(h, 5) # master: raises RangeError, this PR: false
```

## Size

`.text` of `bin/mruby` for each of `build_config/ci/gcc-clang.rb`'s 5 builds
(`size -A <bin> | awk '$1==".text"{print $2}'`, both sides built from a
clean `MRUBY_BUILD_DIR` at the same path):

| Build | master | this PR | delta |
|---|---:|---:|---:|
| full-debug (-O0) | 1,907,254 | 1,907,366 | +112 |
| bintest | 1,304,758 | 1,304,870 | +112 |
| cxx_abi | 1,329,273 | 1,329,369 | +96 |
| byte-string | 1,269,926 | 1,270,038 | +112 |
| ascii-ctype | 1,291,318 | 1,291,430 | +112 |

## Testing

```console
$ rake -m test                         # default (host) build
$ MRUBY_CONFIG=ci/gcc-clang rake -m test  # full-debug / bintest / cxx_abi / byte-string / ascii-ctype
```

All green (`KO: 0`, `Crash: 0`). Also verified against ad hoc build
configs, checked against CRuby 3.3.6:

- `MRB_INT64` and `MRB_INT32`, with `mruby-bigint` and Float
- `MRB_NO_FLOAT` with `mruby-bigint`
- Float without `mruby-bigint`

## Environment

- gcc 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1), Linux x86_64
- oracle: CRuby 3.3.6


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rational-number equality comparisons for very large values.
  * Prevented incorrect equality results caused by overflow or floating-point rounding.
  * Corrected comparisons involving rational values without bigint support.

* **Tests**
  * Added coverage for large rational values across 32-bit and 64-bit configurations.
  * Added tests for bigint and non-bigint comparison behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->