### PR TITLE
mruby-rational: demote a reduced Rational's halves that fit `mrb_int`

### DIFF
--- a/mrbgems/mruby-rational/src/rational.c
+++ b/mrbgems/mruby-rational/src/rational.c
@@ -266,12 +266,24 @@ rational_new_b(mrb_state *mrb, mrb_value n, mrb_value d)
   }
   /* normalize (n/gcd, d/gcd) */
   mrb_bint_reduce(mrb, &n, &d);
+  /* demote halves that now fit mrb_int, the same way bint_norm() would;
+     mrb_bint_reduce() itself hands back bigint objects unconditionally */
+  n = mrb_bint_mul(mrb, n, ONE);
+  d = mrb_bint_mul(mrb, d, ONE);
   struct RClass *c = mrb_class_get_id(mrb, MRB_SYM(Rational));
   struct RBasic *rat;
   struct mrb_rational *p = rat_alloc(mrb, c, &rat);
+  if (!mrb_bigint_p(n) && !mrb_bigint_p(d)) {
+    /* both halves fit mrb_int: store the same layout mrb_rational_new()
+       would, so this value hashes the same as one built from fixnums */
+    p->numerator = mrb_integer(n);
+    p->denominator = mrb_integer(d);
+    rat->frozen = 1;
+    return mrb_obj_value(rat);
+  }
   rat->flags |= RAT_BIGINT;
-  p->b.num = (struct RBasic*)mrb_obj_ptr(n);
-  p->b.den = (struct RBasic*)mrb_obj_ptr(d);
+  p->b.num = (struct RBasic*)mrb_obj_ptr(mrb_as_bint(mrb, n));
+  p->b.den = (struct RBasic*)mrb_obj_ptr(mrb_as_bint(mrb, d));
   rat->frozen = 1;
   return mrb_obj_value(rat);
 }
@@ -1300,9 +1312,13 @@ rational_hash(mrb_state *mrb, mrb_value rat)
 #ifdef RAT_BIGINT
   if (RAT_BIGINT_P(rat)) {
     mrb_value tmp = mrb_bint_hash(mrb, mrb_obj_value(r->b.num));
-    hash = (uint32_t)mrb_integer(tmp);
+    uint32_t num_hash = (uint32_t)mrb_integer(tmp);
     tmp = mrb_bint_hash(mrb, mrb_obj_value(r->b.den));
-    hash ^= (uint32_t)mrb_integer(tmp);
+    uint32_t den_hash = (uint32_t)mrb_integer(tmp);
+    /* chain rather than XOR, so swapping the halves changes the hash the
+       same way the mrb_int path below does */
+    hash = mrb_byte_hash((uint8_t*)&num_hash, sizeof(num_hash));
+    hash = mrb_byte_hash_step((uint8_t*)&den_hash, sizeof(den_hash), hash);
     return mrb_int_value(mrb, hash);
   }
 #endif

--- a/mrbgems/mruby-rational/test/rational.rb
+++ b/mrbgems/mruby-rational/test/rational.rb
@@ -238,6 +238,49 @@ assert 'Rational#== is exact across the overflow, not rounded through Float' do
   end
 end
 
+assert 'Rational#hash agrees with #==' do
+  # A bigint-backed Rational whose reduced halves both fit an mrb_int must
+  # hash the same as the equal value built straight from fixnums; otherwise
+  # equal Rationals disagree on #hash, which breaks Hash lookup and
+  # Array#uniq for them.
+  k = 70
+  begin
+    big = 1 << k
+  rescue RangeError
+    skip 'requires mruby-bigint'
+  end
+  one = Rational(1, 1)
+  assert_equal(one.hash, Rational(big, big).hash)
+  assert_equal(Rational(3, 4).hash, Rational(3 * big, 4 * big).hash)
+  assert_equal(one.hash, (Rational(big, 1) - Rational(big - 1, 1)).hash)
+
+  # Rational(big, 3) shares no common factor, so it stays bigint-backed
+  # after reduction, unlike the halves above, which all reduce down to the
+  # mrb_int layout; this is what actually reaches rational_hash()'s
+  # RAT_BIGINT_P branch.
+  bigint = Rational(big, 3)
+  assert_equal(bigint.hash, Rational(big * 5, 15).hash)
+
+  # Halves combine order-sensitively, on the bigint path as well as the
+  # mrb_int path, since CRuby's Rational#hash does too.
+  assert_not_equal(Rational(2, 3).hash, Rational(3, 2).hash)
+  assert_not_equal(bigint.hash, Rational(3, big).hash)
+
+  small = { one => :one }
+  assert_equal(:one, small[Rational(big, big)])
+
+  large = {}
+  32.times { |i| large[i] = i }
+  large[one] = :one
+  assert_equal(:one, large[Rational(big, big)])
+  large[bigint] = :bigint
+  assert_equal(:bigint, large[Rational(big * 5, 15)])
+
+  if [].respond_to?(:uniq)
+    assert_equal(41, (1..40).to_a.push(one, Rational(big, big)).uniq.size)
+  end
+end
+
 assert 'Rational#eql?' do
   assert_true  Rational(2,1).eql?(Rational(2,1))
   assert_true  Rational(1,2).eql?(Rational(2,4))


### PR DESCRIPTION
## Summary

A bigint-backed `Rational` whose reduced numerator and denominator both fit `mrb_int` kept the bigint layout instead of being demoted, so `Rational(2**70, 2**70)` hashed differently from the equal `Rational(1, 1)`; the bigint hash path also combined the two halves with `^`, which loses which half was which.

## Changes

| File | What |
|---|---|
| `mrbgems/mruby-rational/src/rational.c` | `rational_new_b()` demotes each half through `mrb_bint_mul(mrb, n, ONE)` after `mrb_bint_reduce()` and builds the `mrb_int` layout when both fit; `rational_hash()`'s bigint path chains the two halves with `mrb_byte_hash_step()` instead of `^` |
| `mrbgems/mruby-rational/test/rational.rb` | adds `Rational#hash agrees with #==` |

### `rational_new_b()` kept the bigint layout after reducing back into `mrb_int` range

Every other Bigint result in this codebase goes through `bint_norm()`, which demotes a value back to a fixnum `Integer` when it fits `mrb_int`. `rational_new_b()` is the one place that builds a Bigint-backed value without that step: it calls `mrb_bint_reduce()` and stores whatever comes back, even when the reduced numerator and denominator both fit `mrb_int`. `rational_numerator()` and `rational_denominator()` already work around this by normalizing on the way out through `mrb_bint_mul(mrb, n, ONE)`, which is why `Rational(2**70, 2**70).numerator.equal?(1)` was already `true`; `rational_hash()` reads the stored fields directly and had no such repair.

The fix reuses that same `mrb_bint_mul(mrb, n, ONE)` call right after the reduction and, when both halves come back as fixnums, builds the same layout `mrb_rational_new()` builds from two `mrb_int`s.

### `rational_hash()`'s bigint path combined the halves with `^`

`Rational(2*h, 3*h)` and `Rational(3*h, 2*h)` hashed alike, and any `Rational(n, n)` that kept the bigint layout hashed to `0`, because XOR does not see which half a bit came from. The `mrb_int` path just below it does not have this problem: it chains the denominator's bytes onto the numerator's through `mrb_byte_hash_step()`, so swapping numerator and denominator changes the hash. The bigint path now does the same.

## Behaviour

```ruby
h = 1 << 70
Rational(h, h) == Rational(1, 1)                    # CRuby: true,  mruby before: true,  mruby after: true
Rational(h, h).hash == Rational(1, 1).hash          # CRuby: true,  mruby before: false, mruby after: true
{ Rational(1, 1) => :one }[Rational(h, h)]          # CRuby: :one,  mruby before: :one,  mruby after: :one
large = {}; 32.times { |i| large[i] = i }; large[Rational(1,1)] = :one
large[Rational(h, h)]                               # CRuby: :one,  mruby before: nil,   mruby after: :one
Rational(2 * h, 3 * h).hash == Rational(3 * h, 2 * h).hash  # CRuby: false, mruby before: true, mruby after: false
```

A one-entry `Hash` still found the key before this change, since `h_get()` walks the entries and falls back to `eql?`; a `Hash` large enough to bucket by hash value, and `Array#uniq`'s khash path (`SET_OP_HASH_THRESHOLD`), did not.

## Size

`.text` of `bin/mruby` for each `build_config/ci/gcc-clang.rb` build, master vs this PR:

| Build | master | this PR | delta |
|---|---:|---:|---:|
| `bintest` | 1,304,758 | 1,305,270 | +512 |
| `ascii-ctype` | 1,291,318 | 1,291,830 | +512 |
| `byte-string` | 1,269,926 | 1,270,438 | +512 |
| `cxx_abi` | 1,329,273 | 1,329,801 | +528 |
| `full-debug` (-O0) | 1,907,254 | 1,907,542 | +288 |

The only object that changes is `mrbgems/mruby-rational/src/rational.o`; its `.text` moves from 13,413 to 13,925 bytes in the `bintest` build (+512, matching the binary-level delta there and in `ascii-ctype`/`byte-string`).

## Testing

Numbers below are Total/OK (the gap is `skip`, unrelated to this change); KO is 0 and Crash is 0 everywhere.

- `mrbgems/mruby-rational/test/rational.rb` (`default` gembox + `math` gembox + `mruby-array-ext`, `enable_test`): 2285/2231. Repeated with `MRB_INT32`: 2285/2230 (one more skip, an existing `mruby-socket` guard for 64-bit `mrb_int`, unrelated to this change).
- Full suite, all five `build_config/ci/gcc-clang.rb` builds: `full-debug` 2517/2511, `bintest` 2517/2503 (+ its own `enable_bintest` suite 124/123), `cxx_abi` 2517/2503, `byte-string` 2443/2389, `ascii-ctype` 2510/2495.
- The rows in Behaviour above, run under `build/host/bin/mruby` and under `ruby 4.0.6`, to confirm mruby now agrees with CRuby on each one.

## Environment

<details>
<summary>Details</summary>

| | |
|---|---|
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-30-generic x86_64 |
| CPU | x86_64 |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0 |
| Binutils | GNU ld (GNU Binutils) 2.47.20260726 |
| CRuby (oracle) | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |

Actual compile line for `rational.c` in each `ci/gcc-clang` build (`-MMD -c`, `-I`, and `-o` dropped):

```console
$ # full-debug (effectively -O0: enable_debug's `-g3 -O0` is appended after the toolchain's `-O3`)
$ gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 \
    -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX \
    -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL \
    -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER rational.c

$ # bintest
$ gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings \
    -DMRB_GC_FIXED_ARENA -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM \
    -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM \
    -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK rational.c

$ # cxx_abi (C++ compiler is gcc -x c++, not g++; g++ only links)
$ gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA \
    -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX \
    -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL \
    -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER rational.c

$ # byte-string
$ gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings \
    -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL \
    -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER rational.c

$ # ascii-ctype
$ gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings \
    -DMRB_USE_ASCII_CTYPE -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM \
    -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM \
    -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER rational.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved normalization of rational numbers involving large integer values.
  * Ensured exact equality comparisons when rational calculations exceed standard integer limits.
  * Ensured equivalent rational values produce consistent, order-sensitive hashes.
  * Improved handling of rational values in hash tables and duplicate removal.

* **Tests**
  * Added coverage for overflow-safe equality, hash consistency, hash-table lookups, and array deduplication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->