### PR TITLE
object.c: gate only the Float arm of `mrb_ensure_integer_type()` behind `MRB_NO_FLOAT`

### DIFF
--- a/src/object.c
+++ b/src/object.c
@@ -629,25 +629,23 @@ mrb_ensure_integer_type(mrb_state *mrb, mrb_value val)
     if (mrb_float_p(val)) {
       return mrb_float_to_integer(mrb, val);
     }
-    else {
-      switch (mrb_type(val)) {
+#endif
+    switch (mrb_type(val)) {
 #ifdef MRB_USE_BIGINT
-      case MRB_TT_BIGINT:
-        return val;
+    case MRB_TT_BIGINT:
+      return val;
 #endif
 #ifdef MRB_USE_RATIONAL
-      case MRB_TT_RATIONAL:
-        return mrb_rational_to_i(mrb, val);
+    case MRB_TT_RATIONAL:
+      return mrb_rational_to_i(mrb, val);
 #endif
 #ifdef MRB_USE_COMPLEX
-      case MRB_TT_COMPLEX:
-        return mrb_complex_to_i(mrb, val);
+    case MRB_TT_COMPLEX:
+      return mrb_complex_to_i(mrb, val);
 #endif
-      default:
-        break;
-      }
+    default:
+      break;
     }
-#endif
     mrb_raisef(mrb, E_TYPE_ERROR, "%Y cannot be converted to Integer", val);
   }
   return val;


### PR DESCRIPTION
## Summary

`mrb_ensure_integer_type()` kept its Bigint, Rational and Complex arms inside the same `#ifndef MRB_NO_FLOAT` block as the Float arm, so an `MRB_NO_FLOAT` build raised the wrong exception for those three types instead of converting or refusing them on their own terms.

## Changes

| File | What |
|---|---|
| `object.c` | Closes the `#ifndef MRB_NO_FLOAT` after the Float arm of `mrb_ensure_integer_type()`, so the Bigint/Rational/Complex `switch` runs under its own defines regardless of `MRB_NO_FLOAT` |

### The three module arms answered a wrong exception under `MRB_NO_FLOAT`

The comment on `mrb_ensure_integer_type()` gates each conversion on that conversion's own define, and names `MRB_NO_FLOAT` for the Float arm only. The code did not match: the `switch` over `MRB_TT_BIGINT`/`MRB_TT_RATIONAL`/`MRB_TT_COMPLEX` sat in the `else` of the Float arm, so the whole thing preprocessed away under `MRB_NO_FLOAT` and every non-`MRB_TT_INTEGER` argument fell straight to the final `mrb_raisef()`. A Bigint's class is `Integer`, so the message read `Integer cannot be converted to Integer`:

```ruby
k = 70; [10, 20, 30][1 << k]
#=> before: TypeError: Integer cannot be converted to Integer
#=>  after: RangeError: integer out of range
```

The fix closes the `#ifndef` right after `return mrb_float_to_integer(mrb, val)` instead of after the `switch`, so the three module arms keep running behind their own `MRB_USE_BIGINT`/`MRB_USE_RATIONAL`/`MRB_USE_COMPLEX` guards whether or not `MRB_NO_FLOAT` is defined. Nothing inside the `switch` changes.

## Behaviour

Under `MRB_NO_FLOAT` with `MRB_USE_BIGINT`, a Bigint that does not fit `mrb_int` now raises `RangeError: integer out of range`, matching what the same build answers with Float enabled and what CRuby answers for the same expression. A value that still is not convertible (a String, an Array) is unaffected: it still falls through to the same `TypeError`.

No shipped gembox reaches this combination today (`math.gembox` is the only one carrying `mruby-bigint`, and it also carries `mruby-math`/`mruby-complex`, which each refuse `MRB_NO_FLOAT` on their own with `#error`), so no build this repository ships changes behaviour. This fix reaches only a hand-written config that pairs `MRB_NO_FLOAT` with `mruby-bigint` directly.

## Size

`size -A <bin> | awk '$1==".text"{print $2}'` on `bin/mruby` (`bintest` on `bin/mrbc`, `full-debug` is `-O0`), same worktree path, master and this branch each built clean:

| Build | master | this PR | delta |
|---|---:|---:|---:|
| `full-debug` (-O0) | 1,907,254 | 1,907,254 | 0 |
| `bintest` | 1,304,758 | 1,304,758 | 0 |
| `cxx_abi` | 1,329,273 | 1,329,273 | 0 |
| `byte-string` | 1,269,926 | 1,269,926 | 0 |
| `ascii-ctype` | 1,291,318 | 1,291,318 | 0 |

None of the five `ci/gcc-clang` builds defines `MRB_NO_FLOAT`, and the change only moves where a preprocessor guard closes; it does not touch what any arm does. `object.o` is byte-identical in every build above, so the zero delta is exact, not rounding.

## Testing

- Hand-written `MRuby::Build` config: `MRB_NO_FLOAT` plus `mruby-bigint`, `mruby-io`, `mruby-sprintf`, `mruby-bin-mrbc`, `mruby-bin-mruby`. `rake -m test`: 913 assertions, 0 KO, 0 crash.
- `MRUBY_CONFIG=ci/gcc-clang rake -m test` (`full-debug`, `bintest`, `cxx_abi`, `byte-string`, `ascii-ctype`): 0 KO, 0 crash on every build.

## Environment

<details>
<summary>Toolchain and compile lines</summary>

| | |
|---|---|
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-30-generic x86_64 |
| CPU | AMD Ryzen 9 5950X |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0 |
| C++ compiler | g++ (link only; `cxx_abi` compiles as `gcc -x c++`) |
| binutils | GNU ld (GNU Binutils) 2.47.20260726 |
| CRuby (rake) | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |

Actual `src/object.c` compile line per `ci/gcc-clang` build (`-MMD -c`, `-I`, `-o` dropped):

```console
$ # full-debug (-O0)
$ gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/object.c

$ # bintest
$ gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK src/object.c

$ # cxx_abi
$ gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/object.c

$ # byte-string
$ gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/object.c

$ # ascii-ctype
$ gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/object.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved numeric type conversion behavior when floating-point support is disabled.
  * BigInt, Rational, and Complex values are now handled consistently; unsupported conversions continue to report a type error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->