### PR TITLE
mruby-io: close the child's stream where IO#close_write has no write end

### DIFF
--- a/mrbgems/mruby-io/src/io.c
+++ b/mrbgems/mruby-io/src/io.c
@@ -1202,8 +1202,9 @@ io_close(mrb_state *mrb, mrb_value io)
  * Closes the write end of a duplex I/O stream (i.e., a pipe).
  *
  * A stream that is not duplex has no write end of its own. If it cannot be
- * read from, its only end is the one being closed and the whole stream is
- * closed; otherwise an `IOError` is raised.
+ * read from, or it was opened to a child process, its only end is the one
+ * being closed and the whole stream is closed; otherwise an `IOError` is
+ * raised.
  *
  *   r, w = IO.pipe
  *   w.close_write
@@ -1218,8 +1219,10 @@ io_close_write(mrb_state *mrb, mrb_value io)
   if (fd2 == -1) {
     /* No second descriptor, so writing goes through fd, which is also what
        reading goes through. There is a write end to give up only where
-       nothing reads from the stream, and then it is the whole stream. */
-    if (fptr->readable) {
+       nothing reads from the stream for the caller's own sake, and then it is
+       the whole stream: what a stream opened to a child process reads is the
+       child, which ends with the pipe. */
+    if (fptr->readable && fptr->pid == 0) {
       mrb_raise(mrb, E_IO_ERROR, "closing non-duplex IO for writing");
     }
     fptr_finalize(mrb, fptr, FALSE);

--- a/mrbgems/mruby-io/test/io.rb
+++ b/mrbgems/mruby-io/test/io.rb
@@ -647,11 +647,22 @@ end
 assert('IO#close_write twice') do
   begin
     io = IO.popen($cat, "r+")
+    io.write "mruby-io\n"
     io.close_write
-    # the write end is already gone, and the stream is still read from
-    assert_raise(IOError) { io.close_write }
-    assert_false io.closed?
-    io.close
+    assert_equal "mruby-io\n", io.read
+    # the write end is already gone, and what is left of the stream is the child
+    assert_nil io.close_write
+    assert_true io.closed?
+  rescue NotImplementedError => e
+    skip e.message
+  end
+end
+
+assert('IO#close_write on a stream opened to a child') do
+  begin
+    io = IO.popen("#{$cmd}echo mruby-io", "r")
+    assert_nil io.close_write
+    assert_true io.closed?
   rescue NotImplementedError => e
     skip e.message
   end


### PR DESCRIPTION
## Summary

`IO#close_write` on a stream with no `fd2` decides whether it may close the whole stream from `fptr->readable` alone, and that flag is set the same way on a stream the caller opened for itself and on one opened to a child process. Two `IO.popen` receivers land on the raising side where CRuby closes the stream and answers `nil`.

## Changes

| File | What |
|---|---|
| `mrbgems/mruby-io/src/io.c` | `io_close_write()` adds `&& fptr->pid == 0` to the guard that raises `IOError` |
| `mrbgems/mruby-io/test/io.rb` | rewrites `IO#close_write twice` for the new answer, adds `IO#close_write on a stream opened to a child` |

### `pid` is what tells the two readers apart

`fptr->readable` cannot say who the stream is read for. A stream of the caller's own loses its contents when `close_write` closes it, which is what the `IOError` protects; a stream opened to a child reads the child, and the child ends with the pipe, so there is nothing left for the caller to lose. `io_alloc()` (`io.c:286-302`) leaves `fptr->pid` at 0 for everything but `IO.popen` (`io.c:445`) and an `IO#dup` of such a stream (`io.c:486`), which is exactly the distinction the guard was missing:

```c
  if (fd2 == -1) {
    /* No second descriptor, so writing goes through fd, which is also what
       reading goes through. There is a write end to give up only where
       nothing reads from the stream for the caller's own sake, and then it is
       the whole stream: what a stream opened to a child process reads is the
       child, which ends with the pipe. */
    if (fptr->readable && fptr->pid == 0) {
      mrb_raise(mrb, E_IO_ERROR, "closing non-duplex IO for writing");
    }
    fptr_finalize(mrb, fptr, FALSE);
    return mrb_nil_value();
  }
```

The message the first row read out was also the wrong shape: a stream that has just lost its `fd2` is the one duplex stream mruby-io builds, and it was told `closing non-duplex IO for writing`.

## Behaviour

```ruby
io = IO.popen("cat", "r+")
io.close_write
io.read
io.close_write            # first row below

IO.popen("cat f", "r").close_write
                           # second row below
```

| receiver | master | this PR | CRuby 4.0.6 |
| --- | --- | --- | --- |
| `IO.popen(cmd, "r+")`, `close_write` a second time | `IOError` | `nil`, stream closed | `nil`, stream closed |
| `IO.popen(cmd, "r")` | `IOError` | `nil`, stream closed | `nil`, stream closed |

The other seven receivers mruby-io can build `close_write` on (a stream with no write end that is not readable, one that is, `IO.pipe`'s two ends, `File.open` in `"w"`/`"r"`/`"r+"`) already matched CRuby and are unaffected.

## Size

`.text` of `bin/mruby` for the five `build_config/ci/gcc-clang.rb` builds, master and this branch built from the same path into empty directories:

| Build | master | this PR | delta |
| --- | --- | --- | --- |
| `full-debug` (-O0) | 1,907,990 | 1,908,006 | +16 |
| `bintest` | 1,305,622 | 1,305,654 | +32 |
| `cxx_abi` | 1,330,137 | 1,330,169 | +32 |
| `byte-string` | 1,270,790 | 1,270,822 | +32 |
| `ascii-ctype` | 1,292,182 | 1,292,214 | +32 |

All of it is `io_close_write()` itself, which grows from 175 to 199 bytes (`nm -S`, default `host` build); `io.o` `.text` goes 20,158 → 20,190 there.

## Testing

`rake test:run:serial` on this branch, on the default `host` build and on all five `build_config/ci/gcc-clang.rb` builds:

| Build | Total | OK | KO | Crash | Skip |
| --- | --- | --- | --- | --- | --- |
| `host` (default config) | 2,297 | 2,243 | 0 | 0 | 54 |
| `full-debug` | 2,529 | 2,523 | 0 | 0 | 6 |
| `bintest` | 2,529 | 2,515 | 0 | 0 | 14 |
| `cxx_abi` | 2,529 | 2,515 | 0 | 0 | 14 |
| `byte-string` | 2,455 | 2,401 | 0 | 0 | 54 |
| `ascii-ctype` | 2,522 | 2,507 | 0 | 0 | 15 |

`bintest` also ran its own 124 bin tests (123 OK, 1 skip). `host` also ran 113 bin tests (112 OK, 1 skip).

With the same tests but `io.c` reverted to master, the two new assertions are the only failures (`IO#close_write twice` and `IO#close_write on a stream opened to a child`, both raising `IOError`).

## Environment

<details>
<summary>Machine, toolchain and the compile line of each build</summary>

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-30-generic x86_64 |
| CPU | AMD Ryzen 9 5950X (16 cores, 32 threads) |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0 |
| Linker | GNU ld (GNU Binutils) 2.47.20260726 |
| CRuby | 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |

The line each build actually compiles `src/string.c` with, taken from `rake --verbose` with `-MMD -c`, `-I` and `-o` dropped. `cxx_abi` is `gcc -x c++`, not `g++`; `g++` only links it.

```console
# full-debug (-O0)
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c

# bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK src/string.c

# cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c

# byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c

# ascii-ctype
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved `IO#close_write` behavior for streams connected to child processes.
  - Read-only child-process streams now close cleanly instead of raising an error.
  - Repeated calls after writing has ended now return `nil` and close the remaining stream.
  - Ordinary read-only streams continue to report an error when no write channel exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->