### PR TITLE
test: cover three untested behaviours of Unicode case conversion

### DIFF
--- a/mrbgems/mruby-encoding/test/string.rb
+++ b/mrbgems/mruby-encoding/test/string.rb
@@ -525,6 +525,10 @@ assert('a byte-read string converted case') do
     assert_equal [195, 132, 66], s.upcase.bytes
     assert_equal [195, 132, 98], s.capitalize.bytes
     assert_equal Encoding::BINARY, s.downcase.encoding
+    # swapcase and casecmp? reach the same byte-read arm through their own
+    # readers, one by the walk and the other by mrb_str_single_byte_p.
+    assert_equal [195, 132, 98], s.swapcase.bytes
+    assert_true s.casecmp?("\xC3\x84b".b)
     if UNICODECASE
       assert_equal [195, 164, 98], "\xC3\x84B".downcase.bytes
     else

--- a/mrbgems/mruby-string-ext/test/string.rb
+++ b/mrbgems/mruby-string-ext/test/string.rb
@@ -197,6 +197,14 @@ assert('String#swapcase - ASCII only') do
   assert_nil "Ä".swapcase!
 end
 
+assert('String#swapcase! - a frozen receiver') do
+  skip unless UNICODECASE
+  # The Unicode walk raises from inside str_modify_keep_cr(), the same site
+  # String#downcase! raises from, before the ASCII loop str_swapcase_bang
+  # otherwise runs.
+  assert_raise(FrozenError) { "Ä".freeze.swapcase! }
+end
+
 assert('String#concat') do
   assert_equal "Hello World!", "Hello " << "World" << 33
   assert_equal "Hello World!", "Hello ".concat("World").concat(33)

--- a/test/t/string.rb
+++ b/test/t/string.rb
@@ -506,6 +506,13 @@ assert('String#downcase - a receiver above the embedded buffer') do
   assert_equal "äöü" * 20, long.downcase
 end if UNICODECASE
 
+assert('String case conversion - a frozen receiver') do
+  # The Unicode walk raises from inside str_modify_keep_cr(), before the
+  # ASCII loop each bang method otherwise runs, whether or not the
+  # conversion would have changed anything.
+  assert_raise(FrozenError) { 'Ä'.freeze.downcase! }
+end if UNICODECASE
+
 assert('String case conversion - ASCII only') do
   # The other reading of case: a build that converts by ASCII, whether by
   # MRB_USE_ASCII_CTYPE or by reading its strings as bytes, has no mapping above

--- a/test/t/string.rb
+++ b/test/t/string.rb
@@ -496,6 +496,16 @@ assert('String#upcase - an answer that outgrows an embedded buffer') do
   end
 end if UNICODECASE
 
+assert('String#downcase - a receiver above the embedded buffer') do
+  # A receiver too long to live inside its own object holds its bytes in a
+  # heap (or shared) buffer that str_replace() has to release rather than
+  # overwrite, and the coderange the walk sets has to survive the copy that
+  # hands the converted buffer to the receiver.
+  long = "ÄÖÜ" * 20
+  assert_equal 60, long.downcase.length
+  assert_equal "äöü" * 20, long.downcase
+end if UNICODECASE
+
 assert('String case conversion - ASCII only') do
   # The other reading of case: a build that converts by ASCII, whether by
   # MRB_USE_ASCII_CTYPE or by reading its strings as bytes, has no mapping above


### PR DESCRIPTION
## Summary

`mruby/mruby#7182` (`f0d1afd`) taught `String#downcase`, `#upcase`, `#capitalize`, `#swapcase` and `#casecmp?` to convert case by Unicode. Three of the distinct code paths that decision opened were never asked: `swapcase` and `casecmp?` on a byte-read string, a frozen receiver, and a receiver too long to live inside its own object. All three already answer correctly on master; this adds the assertions that pin them.

## Changes

| File | What |
|---|---|
| `mrbgems/mruby-encoding/test/string.rb` | `swapcase` and `casecmp?` added beside the existing `downcase`/`upcase`/`capitalize` byte-read assertions |
| `test/t/string.rb` | new blocks: a `downcase` receiver above the embedded buffer, and `downcase!` on a frozen receiver |
| `mrbgems/mruby-string-ext/test/string.rb` | new block: `swapcase!` on a frozen receiver |

### A byte-read string, for the two methods left out

`mrbgems/mruby-encoding/test/string.rb` already covered `downcase`, `upcase` and `capitalize` on a `String#b` receiver. `swapcase` and `casecmp?` are the other two callers of `mrb_str_case_convert_unicode()`'s `RSTR_BINARY_P(s)` arm, and neither was asked. `casecmp?` reaches that arm through `mrb_str_single_byte_p()` in `str_folds_beyond_ascii()` rather than through the walk:

```ruby
s = "\xC3\x84B".b
s.swapcase.bytes        #=> [195, 132, 98]
s.casecmp?("\xC3\x84b".b)  #=> true
```

### A frozen receiver

```ruby
"Ä".freeze.downcase!   #=> FrozenError
"Ä".freeze.swapcase!   #=> FrozenError
```

The Unicode walk raises this from inside `str_modify_keep_cr()`, before the ASCII loop each caller keeps is ever reached, a different site from the one the ASCII path raises at. Nothing asserted either half.

`String#swapcase!` lives in `mruby-string-ext`, not core, so its assertion goes in that gem's own test file rather than beside `downcase!`'s in `test/t/string.rb`. `mrbtest` runs each gem's tests in a fresh `mrb_state`, seeded only with that gem's own `add_dependency` list (`mrbgems/mruby-test/mrbgem.rake`); `mruby-test`, which owns `test/t/`, declares none. A call to `swapcase!` from `test/t/string.rb` raises `NoMethodError` in every build configuration, UNICODECASE included, since it is a gem boundary rather than a build flag.

### A string above the embed limit

On 64-bit, `RSTRING_EMBED_LEN_MAX` is 27, and every existing case-conversion assertion used a string short enough to take the `str_init_embed()` arm of `str_replace()`. The `str_share()` arm below it, where the converted buffer is handed to the receiver rather than copied into it, never ran for the receiver side, and neither did the coderange set at the end of the walk surviving `RSTR_ENC_CR_COPY()` there:

```ruby
long = "ÄÖÜ" * 20      # 120 bytes
long.downcase.length   #=> 60
long.downcase == "äöü" * 20   #=> true
```

## Testing

`rake test:run:serial` with `build_config/ci/gcc-clang.rb`, each build run to completion before the next so the summaries do not interleave, on `master` at `64361b5f8` and on this branch:

| Build | Total (master → PR) | OK (master → PR) | KO | Crash | Skip (master → PR) |
|---|---|---|---|---|---|
| `full-debug` | 2,528 → 2,531 | 2,522 → 2,525 | 0 | 0 | 6 → 6 |
| `bintest` | 2,528 → 2,531 | 2,514 → 2,517 | 0 | 0 | 14 → 14 |
| `bintest` (bintest cases) | 124 → 124 | 123 → 123 | 0 | 0 | 1 → 1 |
| `cxx_abi` | 2,528 → 2,531 | 2,514 → 2,517 | 0 | 0 | 14 → 14 |
| `byte-string` | 2,454 → 2,455 | 2,400 → 2,400 | 0 | 0 | 54 → 55 |
| `ascii-ctype` | 2,521 → 2,522 | 2,506 → 2,506 | 0 | 0 | 15 → 16 |

`KO` and `Crash` are 0 in every column, both before and after. `full-debug`, `bintest` and `cxx_abi` convert case by Unicode: all three new blocks run there and pass, +3 Total and +3 OK apiece. `byte-string` and `ascii-ctype` convert case by ASCII, so `UNICODECASE` is false: the two blocks in `test/t/string.rb` are gated by `end if UNICODECASE` and are not defined at all, while the one in `mruby-string-ext` is gated by `skip unless UNICODECASE` and runs as a new Skip, +1 Total and +1 Skip apiece. `mrbgems/mruby-encoding/test/string.rb`'s two new lines land inside an existing `assert` block rather than opening one, so they move no Total or OK count anywhere they run, `byte-string` (which drops `mruby-encoding` entirely) included.

## Environment

<details>

| | |
|---|---|
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-30-generic, x86_64 |
| CPU | AMD Ryzen 9 5950X (16 cores, 32 threads) |
| C compiler | gcc 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1) |
| binutils | GNU ld 2.47.20260726 |
| CRuby (build host) | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM |

`cxx_abi` compiles with `gcc -x c++ -std=gnu++03`; `g++` only links. The compile line each build gives `src/string.c`, with `-MMD -c`, `-I` and `-o` dropped, is unchanged by this PR since it touches no compiled source, shown here for completeness:

```console
# full-debug
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK

# cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ascii-ctype
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of case conversion and comparison for byte-oriented strings.
  * Corrected behavior when modifying frozen strings, consistently raising `FrozenError`.
  * Verified Unicode case conversion for heap-backed and frozen strings.

* **Tests**
  * Added regression coverage for Unicode and binary-compatible string operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->