### PR TITLE
class.c: fix mrb_mod_visibility()'s copy into a prepended class's method table

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -2505,7 +2505,15 @@ mrb_mod_visibility(mrb_state *mrb, mrb_value mod, int vis)
       MRB_METHOD_SET_VISIBILITY(m, vis);
       union mrb_mt_ptr ptr;
       if (MRB_METHOD_PROC_P(m)) {
-        ptr.proc = MRB_METHOD_PROC(m);
+        struct RProc *p = (struct RProc*)MRB_METHOD_PROC(m);
+
+        /* A method table entry is a GC field: mrb_gc_mark_mt() marks every
+           non-MRB_MT_FUNC entry as a child of the class. mrb_define_method_raw()
+           barriers the same kind of store; this one did not. */
+        ptr.proc = p;
+        if (p) {
+          mrb_field_write_barrier(mrb, (struct RBasic*)c, (struct RBasic*)p);
+        }
       }
       else {
         ptr.func = MRB_METHOD_FUNC(m);

--- a/src/class.c
+++ b/src/class.c
@@ -992,27 +992,31 @@ find_visibility_scope(mrb_state *mrb, const struct RClass *c, int n, mrb_callinf
  *             If the method visibility is default, it's determined by the current scope.
  * @raise TypeError if the class/module or its attached object (for singleton classes) is frozen.
  */
-/* The method table of `c`, ready to be written to: created where there is
+/* The method table of `table`, ready to be written to: created where there is
    none, thawed where it was frozen, and given a mutable layer of its own
    where what it has is read-only. Whoever changes a method table has to come
-   through here, or writes into a table that is not theirs to write. */
-static mrb_mt_tbl*
-mt_writable(mrb_state *mrb, struct RClass *c)
-{
-  mrb_mt_tbl *h = c->mt;
+   through here, or writes into a table that is not theirs to write.
 
-  if (c->tt == MRB_TT_SCLASS && mrb_frozen_p(c)) {
-    mrb_value v = mrb_iv_get(mrb, mrb_obj_value(c), MRB_SYM(__attached__));
+   The frozen check runs on `frozen`, not `table`: on a prepended class the two
+   differ, the origin ICLASS never carries the frozen flag, and the class the
+   caller named is the one CRuby raises FrozenError on. */
+static mrb_mt_tbl*
+mt_writable(mrb_state *mrb, struct RClass *frozen, struct RClass *table)
+{
+  mrb_mt_tbl *h = table->mt;
+
+  if (frozen->tt == MRB_TT_SCLASS && mrb_frozen_p(frozen)) {
+    mrb_value v = mrb_iv_get(mrb, mrb_obj_value(frozen), MRB_SYM(__attached__));
     mrb_check_frozen_value(mrb, v);
   }
   else {
-    mrb_check_frozen(mrb, c);
+    mrb_check_frozen(mrb, frozen);
   }
   if (!h) {
-    return c->mt = mt_new(mrb);
+    return table->mt = mt_new(mrb);
   }
   if (mt_frozen_p(h)) {
-    /* unfreeze heap-allocated frozen layer to preserve c->mt pointer
+    /* unfreeze heap-allocated frozen layer to preserve table->mt pointer
      * (iclasses hold a copy of the mt pointer for included modules) */
     h->alloc &= ~MRB_MT_FROZEN_BIT;
     return h;
@@ -1021,7 +1025,7 @@ mt_writable(mrb_state *mrb, struct RClass *c)
     /* COW: create mutable top layer, chain to ROM */
     mrb_mt_tbl *top = mt_new(mrb);
     top->next = h;
-    return c->mt = top;
+    return table->mt = top;
   }
   return h;
 }
@@ -1033,7 +1037,7 @@ mrb_define_method_raw(mrb_state *mrb, struct RClass *c, mrb_sym mid, mrb_method_
 
   MRB_CLASS_ORIGIN(c);
 
-  mrb_mt_tbl *h = mt_writable(mrb, c);
+  mrb_mt_tbl *h = mt_writable(mrb, c, c);
   if (MRB_METHOD_PROC_P(m)) {
     struct RProc *p = (struct RProc*)MRB_METHOD_PROC(m);
 
@@ -2492,12 +2496,22 @@ mrb_mod_visibility(mrb_state *mrb, mrb_value mod, int vis)
     }
   }
   else {
-    /* A visibility change writes a copy of the method into this class, so the
-       table it writes to has to be prepared the way defining one prepares it:
-       `class << self; class << self; protected :p; end; end` reached mt_put()
-       with none at all (#7293), and a frozen class took the change in
-       silence. */
-    mrb_mt_tbl *h = mt_writable(mrb, c);
+    /* A visibility change writes a copy of the method into a class's own
+       table, so the table it writes to has to be prepared the way defining
+       one prepares it: `class << self; class << self; protected :p; end;
+       end` reached mt_put() with none at all (#7293), and a frozen class
+       took the change in silence.
+
+       On a prepended class that table is the origin's, not `c`'s: `c` only
+       has the prepended module in front of it, and a copy written to `c`
+       would outrank the module instead of falling behind it. The frozen
+       check still runs on `c`, the class the caller named and the one
+       `mrb_check_frozen()` can see the flag on; `mrb_method_search()` still
+       starts its walk from `c` too, exactly as it would without this
+       change. */
+    struct RClass *t = c;
+    MRB_CLASS_ORIGIN(t);
+    mrb_mt_tbl *h = mt_writable(mrb, c, t);
     for (int i=0; i<argc; i++) {
       mrb_check_type(mrb, argv[i], MRB_TT_SYMBOL);
       mrb_sym mid = mrb_symbol(argv[i]);
@@ -2512,7 +2526,7 @@ mrb_mod_visibility(mrb_state *mrb, mrb_value mod, int vis)
            barriers the same kind of store; this one did not. */
         ptr.proc = p;
         if (p) {
-          mrb_field_write_barrier(mrb, (struct RBasic*)c, (struct RBasic*)p);
+          mrb_field_write_barrier(mrb, (struct RBasic*)t, (struct RBasic*)p);
         }
       }
       else {

--- a/test/t/module.rb
+++ b/test/t/module.rb
@@ -683,6 +683,36 @@ end
   assert 'Module#prepend to frozen class' do
     assert_raise(FrozenError) { Class.new.freeze.prepend Module.new }
   end
+
+  assert 'Module#private on a method a prepended module also defines' do
+    m = Module.new { def foo; :prepended; end }
+    c = Class.new { def foo; :own; end; prepend m }
+
+    assert_equal :prepended, c.new.foo
+
+    c.class_eval { private :foo }
+    assert_equal :prepended, c.new.foo, 'private on the origin must not shadow the module ahead of it'
+
+    c.class_eval { public :foo }
+    assert_equal :prepended, c.new.foo
+
+    m.module_eval { def foo; :prepended2; end }
+    assert_equal :prepended2, c.new.foo, 'the origin copy must not freeze what foo answers'
+
+    c.class_eval { def foo; :own2; end }
+    assert_equal :prepended2, c.new.foo
+
+    d = c.dup
+    assert_equal :prepended2, d.new.foo
+
+    # `remove_method` comes from mruby-metaprog, which the core test build
+    # does not have.
+    if c.respond_to?(:remove_method, true)
+      c.class_eval { remove_method :foo }
+      m.module_eval { remove_method :foo }
+      assert_raise(NoMethodError) { c.new.foo }
+    end
+  end
 # @!endgroup prepend
 
 assert('Module#to_s') do


### PR DESCRIPTION
## Summary

`mrb_mod_visibility()` (`private`/`public`/`protected`) copies the resolved method into the receiver's own method table without resolving `MRB_CLASS_ORIGIN()` first, so on a class with a prepended module the copy lands in front of the module instead of behind it and freezes what the method answers from then on; the same copy is also missing the write barrier `mrb_define_method_raw()` runs for the identical kind of store.

## Changes

| File | What |
|---|---|
| `src/class.c` | `mt_writable()` takes separate `frozen` and `table` classes; `mrb_mod_visibility()` writes the visibility copy into a prepended class's origin table and barriers it |
| `test/t/module.rb` | regression test for `private`/`public` on a method a prepended module also defines |

### Writing into the origin

`mrb_mod_visibility()` copied the resolved method straight into `c`'s own table. `mrb_define_method_raw()` and `mrb_remove_method()` both resolve `MRB_CLASS_ORIGIN()` first, because on a class with a prepended module `c`'s own table sits in front of the prepended module in the ancestor chain; a plain class has no such table until one is prepended, at which point the class's original methods move to a new origin ICLASS behind it. Writing to `c` instead of the origin put the copy ahead of the module, so it answered instead of the module from that point on, regardless of what the module or the class itself did afterward.

`mt_writable()` prepares a table and checks whether writing to it is allowed; both of those used to run against the same class. Splitting them into a `frozen` argument and a `table` argument lets `mrb_mod_visibility()` check `c` (the class the caller named, the one `mrb_check_frozen()` can see the frozen flag on) while writing into `c`'s origin. `mrb_method_search()` still starts its walk from `c`, unchanged, so a method the prepended module still defines keeps winning the lookup exactly as before any visibility change.

### Missing write barrier

A method table entry is a GC field: `mrb_gc_mark_mt()` marks every non-`MRB_MT_FUNC` entry as a child of the class. The proc `mrb_mod_visibility()` copies was stored with no `mrb_field_write_barrier()`, unlike the same kind of store in `mrb_define_method_raw()`. The window this can bite in is narrow (live only while the class is black and the proc still white), so no test accompanies this half; the commit message explains why a reproduction could not be constructed.

## Behaviour

```ruby
module M; def m; "M"; end; end
class C; def m; "C"; end; prepend M; end

C.new.m                        # CRuby: "M",  mruby before: "M",            mruby after: "M"
class C; private :m; end
C.new.m                        # CRuby: "M",  mruby before: NoMethodError,  mruby after: "M"
class C; public :m; end
C.new.m                        # CRuby: "M",  mruby before: "M" (stuck),    mruby after: "M"
module M; def m; "M2"; end; end
C.new.m                        # CRuby: "M2", mruby before: "M" (stuck),    mruby after: "M2"
class C; def m; "C2"; end; end
C.new.m                        # CRuby: "M2", mruby before: "M" (stuck),    mruby after: "M2"
C.dup.new.m                    # CRuby: "M2", mruby before: "M" (stuck),    mruby after: "M2"
```

Before this change, a class with a prepended module answered whatever the module held at the moment `private`/`public`/`protected` first ran on it, no matter what happened afterward. After, it tracks the module the same way CRuby does.

## Size

`.text` of `bin/mruby` for each `build_config/ci/gcc-clang.rb` build (`size -A`), built from an empty directory:

| Build | master | this PR | delta |
|---|---:|---:|---:|
| `full-debug` (-O0) | 1,908,342 | 1,908,470 | +128 |
| `bintest` | 1,306,022 | 1,306,134 | +112 |
| `cxx_abi` | 1,330,537 | 1,330,649 | +112 |
| `byte-string` | 1,271,190 | 1,271,302 | +112 |
| `ascii-ctype` | 1,292,582 | 1,292,694 | +112 |

The +112 (+128 under `-O0`, where nothing is inlined away) is `mrb_mod_visibility()`'s `class.o` growing by the added `mrb_field_write_barrier()` call, the `struct RClass *t` origin resolution, and the split `mt_writable()` signature; none of it touches float, encoding, or C++-specific code, so the delta is uniform across all four `-O3` builds.

## Testing

```console
$ rake test
```

All core assertions pass (2243 OK, 0 KO, 0 Crash, 54 Skip) and all bintest assertions pass (113 OK, 0 KO, 1 Skip), including the new regression test.

## Environment

<details>
<summary>details</summary>

| | |
| --- | --- |
| OS | Ubuntu, Linux 7.0.0-30-generic, x86_64 |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0 |
| C++ compiler | `cxx_abi` compiles `src/class.c` as C++ with `gcc -x c++ -std=gnu++03`; g++ only links |
| binutils | GNU ld (GNU Binutils) 2.47.20260726 |
| CRuby | 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |

`src/class.c`'s actual compile line in each `build_config/ci/gcc-clang.rb` build:

```console
$ touch src/class.c && MRUBY_CONFIG=build_config/ci/gcc-clang.rb rake --verbose
```

```
# full-debug (-O0)
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/class.c

# bintest
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK src/class.c

# cxx_abi
gcc -c -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/class.c

# byte-string
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/class.c

# ascii-ctype
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/class.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed method visibility changes involving prepended modules and classes.
  * Preserved correct method lookup when methods are redefined, classes are duplicated, or methods are removed.

* **Tests**
  * Added regression coverage for visibility changes and method removal with prepended modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->