### PR TITLE
mruby-regexp: append the flag suffix to a RegexpError message

### DIFF
--- a/mrbgems/mruby-regexp/include/re_internal.h
+++ b/mrbgems/mruby-regexp/include/re_internal.h
@@ -312,6 +312,13 @@ void mrb_re_compile(mrb_state *mrb, mrb_regexp_pattern *pat, const char *pattern
 /* Free a compiled pattern */
 void mrb_re_free(mrb_state *mrb, mrb_regexp_pattern *pat);
 
+/* Append the set flags among RE_FLAG_MULTILINE/IGNORECASE/EXTENDED to `str`
+   as letters, in the order Regexp#to_s and Regexp#inspect write them
+   (m, i, x). Shared so a compile error can quote a pattern the way
+   Regexp#inspect would, `/pattern/flags`, without duplicating the table
+   `regexp_to_s()` walks in regexp.c. */
+void mrb_re_flags_cat(mrb_state *mrb, mrb_value str, uint32_t flags);
+
 /* Word character (\w) test */
 mrb_bool mrb_re_is_word_char(uint32_t c);
 

--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -44,6 +44,9 @@ typedef struct {
   uint16_t class_capa;
   uint16_t num_captures;
   uint32_t flags;
+  uint32_t orig_flags;  /* flags as passed to mrb_re_compile(), for error
+                            messages: unlike `flags`, an inline option such as
+                            `(?i)` does not change this (re_compile.c:1667) */
   uint16_t num_named;
   mrb_bool has_backref;
   mrb_bool needs_backtrack;
@@ -84,9 +87,14 @@ compile_error_str(re_compiler *c, mrb_value msg)
      c->src points at the buffer preprocess_pattern() returned, so quoting it
      would drop the comments and the (?#...) groups from the message. c->orig
      is the caller's buffer, which outlives the compile. It is not
-     NUL-terminated, so use %l with the explicit length from c->orig_end. */
+     NUL-terminated, so use %l with the explicit length from c->orig_end. The
+     flag suffix uses c->orig_flags, not c->flags: an inline option such as
+     `(?i)` mutates the latter partway through the parse, where CRuby's
+     message (and Regexp#inspect) reports the flags the pattern was compiled
+     with. */
   mrb_value emsg = mrb_format(c->mrb, "%v: /%l/",
                               msg, c->orig, (size_t)(c->orig_end - c->orig));
+  mrb_re_flags_cat(c->mrb, emsg, c->orig_flags);
 
   mrb_exc_raise(c->mrb,
     mrb_exc_new_str(c->mrb, mrb_exc_get_id(c->mrb, MRB_SYM(RegexpError)), emsg));
@@ -2845,6 +2853,7 @@ mrb_re_compile(mrb_state *mrb, mrb_regexp_pattern *pat,
   c.src_end = pattern + len;
   c.p = pattern;
   c.flags = flags;
+  c.orig_flags = flags;
   c.num_captures = 1;  /* group 0 = whole match */
   /* Scan the same bytes the parser is about to read: preprocess_pattern() has
      already taken out the #comments and the (?#...) groups. */

--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -745,6 +745,16 @@ static const struct {
 
 #define RE_FLAG_LETTER_COUNT (sizeof(re_flag_letters) / sizeof(re_flag_letters[0]))
 
+void
+mrb_re_flags_cat(mrb_state *mrb, mrb_value str, uint32_t flags)
+{
+  for (size_t i = 0; i < RE_FLAG_LETTER_COUNT; i++) {
+    if (flags & re_flag_letters[i].bit) {
+      mrb_str_cat(mrb, str, &re_flag_letters[i].letter, 1);
+    }
+  }
+}
+
 /*
  * Regexp#to_s - (?on-off:source) format
  *
@@ -790,11 +800,7 @@ regexp_inspect(mrb_state *mrb, mrb_value self)
   mrb_value result = mrb_str_new_lit(mrb, "/");
   mrb_str_cat_str(mrb, result, src);
   mrb_str_cat_lit(mrb, result, "/");
-  for (size_t i = 0; i < RE_FLAG_LETTER_COUNT; i++) {
-    if (flags & re_flag_letters[i].bit) {
-      mrb_str_cat(mrb, result, &re_flag_letters[i].letter, 1);
-    }
-  }
+  mrb_re_flags_cat(mrb, result, flags);
   return result;
 }
 

--- a/mrbgems/mruby-regexp/test/ascii_case.rb
+++ b/mrbgems/mruby-regexp/test/ascii_case.rb
@@ -31,7 +31,7 @@ assert("Regexp - /i refuses what ASCII folding cannot answer") do
   # The message names what is missing rather than the option that would have
   # supplied it, there being two ways to reach it and no one name for both.
   refused = "/i needs Unicode case folding for this character"
-  assert_raise_with_message(RegexpError, "#{refused}: /Ā/") do
+  assert_raise_with_message(RegexpError, "#{refused}: /Ā/i") do
     Regexp.new("Ā", Regexp::IGNORECASE)
   end
   # A `\u` escape names a character rather than spelling it out, and naming one
@@ -41,12 +41,12 @@ assert("Regexp - /i refuses what ASCII folding cannot answer") do
   # has reasons of its own to raise `RegexpError` and a complaint about the
   # escape's own spelling would otherwise pass for this refusal.
   ["\\u0100", "\\u{100}"].each do |src|
-    assert_raise_with_message(RegexpError, "#{refused}: /#{src}/") do
+    assert_raise_with_message(RegexpError, "#{refused}: /#{src}/i") do
       Regexp.new(src, Regexp::IGNORECASE)
     end
   end
   ["[\\u{100}]", "[^\\u{100}]", "[\\u{100}-\\u{102}]"].each do |src|
-    assert_raise_with_message(RegexpError, "#{refused} class: /#{src}/") do
+    assert_raise_with_message(RegexpError, "#{refused} class: /#{src}/i") do
       Regexp.new(src, Regexp::IGNORECASE)
     end
   end

--- a/mrbgems/mruby-regexp/test/regexp_syntax.rb
+++ b/mrbgems/mruby-regexp/test/regexp_syntax.rb
@@ -1069,10 +1069,10 @@ assert("Regexp extended mode (x flag)") do
 
   # a bracket the pattern truncates leaves the scan with nothing after the
   # name, and the class is still the parser's error to report
-  assert_raise_with_message(RegexpError, "unterminated character class: /[[:alpha/") do
+  assert_raise_with_message(RegexpError, "unterminated character class: /[[:alpha/x") do
     Regexp.new("[[:alpha", Regexp::EXTENDED)
   end
-  assert_raise_with_message(RegexpError, "unterminated character class: /[[:alpha:/") do
+  assert_raise_with_message(RegexpError, "unterminated character class: /[[:alpha:/x") do
     Regexp.new("[[:alpha:", Regexp::EXTENDED)
   end
 
@@ -1096,7 +1096,7 @@ assert("Regexp extended mode (x flag)") do
   assert_nil Regexp.new('\x1 2', Regexp::EXTENDED) =~ "\x12"
   assert_equal 0, (Regexp.new('\x1 a', Regexp::EXTENDED) =~ "\x01a")
   assert_equal 0, (Regexp.new('\01 2', Regexp::EXTENDED) =~ "\x012")
-  assert_raise_with_message(RegexpError, "unmatched '(': /\\x1 2(/") do
+  assert_raise_with_message(RegexpError, "unmatched '(': /\\x1 2(/x") do
     Regexp.new('\x1 2(', Regexp::EXTENDED)
   end
 
@@ -1108,7 +1108,7 @@ assert("Regexp extended mode (x flag)") do
   re = Regexp.new("a (?#note) b # tail\nc", Regexp::EXTENDED)
   assert_true re.match?("abc")
 
-  assert_raise_with_message(RegexpError, "unterminated comment group: /a (?#note/") do
+  assert_raise_with_message(RegexpError, "unterminated comment group: /a (?#note/x") do
     Regexp.new("a (?#note", Regexp::EXTENDED)
   end
 
@@ -1119,11 +1119,28 @@ assert("Regexp extended mode (x flag)") do
   assert_equal "(?x-mi:abc)", Regexp.new("abc", Regexp::EXTENDED).to_s
 
   # errors quote the pattern as written, not the text with the comment removed
-  assert_raise_with_message(RegexpError, "unterminated character class: /a # c\n[/") do
+  assert_raise_with_message(RegexpError, "unterminated character class: /a # c\n[/x") do
     Regexp.new("a # c\n[", Regexp::EXTENDED)
   end
-  assert_raise_with_message(RegexpError, "unmatched '(': /a b(/") do
+  assert_raise_with_message(RegexpError, "unmatched '(': /a b(/x") do
     Regexp.new("a b(", Regexp::EXTENDED)
+  end
+
+  # The suffix names the flags mrb_re_compile() was entered with, not
+  # whatever an inline (?x)/(?-x) leaves c->flags holding by the time the
+  # error is raised: turning /x off inline still reports the entry's /x,
+  # and turning it on where entry carried none reports no suffix at all.
+  # CRuby matches this on both patterns.
+  assert_raise_with_message(RegexpError, "unterminated character class: /(?-x)a # c[/x") do
+    Regexp.new("(?-x)a # c[", Regexp::EXTENDED)
+  end
+  assert_raise_with_message(RegexpError, "unterminated character class: /(?x)a # c\n[/") do
+    Regexp.new("(?x)a # c\n[")
+  end
+
+  # Multiple entry flags are named in Regexp#to_s/#inspect's m, i, x order.
+  assert_raise_with_message(RegexpError, "unterminated character class: /[a/ix") do
+    Regexp.new("[a", Regexp::EXTENDED | Regexp::IGNORECASE)
   end
 end
 
@@ -1171,7 +1188,7 @@ assert("Regexp - free-spacing whitespace stands between tokens only") do
   # inside a token the whitespace is the token's own: `(?` and `{n,m}` are
   # read whole, so a space breaks them rather than being removed from them
   assert_raise_with_message(RegexpError,
-                            "target of repeat operator is not specified: /( ?i)A/") do
+                            "target of repeat operator is not specified: /( ?i)A/x") do
     Regexp.new("( ?i)A", x)
   end
   assert_raise(RegexpError) { Regexp.new("(?i )a", x) }
@@ -1202,21 +1219,21 @@ assert("Regexp - free-spacing whitespace stands between tokens only") do
   # its full width ends it, so `\x6 1` is `\x06` and `1`
   ["\\u {61 62}", "\\u1 234", "\\u12 34", "\\u00 61", "\\u\t{61 62}",
    "\\u 0061", "[\\u12 34]"].each do |pat|
-    assert_raise_with_message(RegexpError, "invalid Unicode escape: /#{pat}/") do
+    assert_raise_with_message(RegexpError, "invalid Unicode escape: /#{pat}/x") do
       Regexp.new(pat, x)
     end
   end
   # nothing after \u is "too short", a wrong byte after it "invalid"; the
   # blank is a byte the parser sees, and reports
-  assert_raise_with_message(RegexpError, "invalid Unicode escape: /\\u /") do
+  assert_raise_with_message(RegexpError, "invalid Unicode escape: /\\u /x") do
     Regexp.new("\\u ", x)
   end
-  assert_raise_with_message(RegexpError, "too short escape sequence: /\\u/") do
+  assert_raise_with_message(RegexpError, "too short escape sequence: /\\u/x") do
     Regexp.new("\\u", x)
   end
   assert_equal ["ab"], Regexp.new("\\u0061 \\u0062", x).match("ab").to_a
   assert_equal ["ab"], Regexp.new("\\u{ 61  62 }", x).match("ab").to_a
-  assert_raise_with_message(RegexpError, "invalid hex escape: /\\x 61/") do
+  assert_raise_with_message(RegexpError, "invalid hex escape: /\\x 61/x") do
     Regexp.new("\\x 61", x)
   end
   assert_equal ["\x061"], Regexp.new("\\x6 1", x).match("\x061").to_a
@@ -1230,11 +1247,11 @@ assert("Regexp - free-spacing whitespace stands between tokens only") do
   assert_equal ["a b"], Regexp.new("(?<a b>x)", x).names
   assert_equal ["a b"], Regexp.new("(?'a b'x)", x).names
   assert_raise_with_message(RegexpError,
-                            "undefined name <a b> reference: /(?<ab>x)\\k<a b>/") do
+                            "undefined name <a b> reference: /(?<ab>x)\\k<a b>/x") do
     Regexp.new("(?<ab>x)\\k<a b>", x)
   end
   assert_raise_with_message(RegexpError,
-                            "undefined name <ab> reference: /(?<a b>x)\\k<ab>/") do
+                            "undefined name <ab> reference: /(?<a b>x)\\k<ab>/x") do
     Regexp.new("(?<a b>x)\\k<ab>", x)
   end
   # a `\k` that whitespace follows is the letter k, with the `<ab>` after
@@ -1296,7 +1313,7 @@ assert("Regexp - a removed comment does not reach into an escape") do
     end
   end
   ["\\u12#c\n34", "\\u#c\n{61}"].each do |pat|
-    assert_raise_with_message(RegexpError, "invalid Unicode escape: /#{pat}/") do
+    assert_raise_with_message(RegexpError, "invalid Unicode escape: /#{pat}/x") do
       Regexp.new(pat, x)
     end
   end
@@ -1306,7 +1323,7 @@ assert("Regexp - a removed comment does not reach into an escape") do
   assert_raise_with_message(RegexpError, "invalid Unicode list: /\\u{61(?#c)62}/") do
     Regexp.new("\\u{61(?#c)62}")
   end
-  assert_raise_with_message(RegexpError, "invalid Unicode list: /\\u{61 #c\n62}/") do
+  assert_raise_with_message(RegexpError, "invalid Unicode list: /\\u{61 #c\n62}/x") do
     Regexp.new("\\u{61 #c\n62}", x)
   end
 
@@ -1316,7 +1333,7 @@ assert("Regexp - a removed comment does not reach into an escape") do
   assert_raise_with_message(RegexpError, "invalid hex escape: /\\x(?#c)61/") do
     Regexp.new("\\x(?#c)61")
   end
-  assert_raise_with_message(RegexpError, "invalid hex escape: /\\x#c\n61/") do
+  assert_raise_with_message(RegexpError, "invalid hex escape: /\\x#c\n61/x") do
     Regexp.new("\\x#c\n61", x)
   end
   assert_equal ["\x061"], Regexp.new("\\x6(?#c)1").match("\x061").to_a


### PR DESCRIPTION
## Summary

CRuby quotes a pattern that failed to compile with the flags it was given,
`/pattern/x`; mruby-regexp's `RegexpError` carried no such suffix, so a
message pasted back into `Regexp.new` did not reproduce the failure. This
adds the suffix, sourced from the same rendering `Regexp#inspect` uses.

## Changes

| File | What |
|---|---|
| `include/re_internal.h` | Declares `mrb_re_flags_cat()` |
| `src/regexp.c` | Extracts the flag-letter loop out of `regexp_inspect()` into `mrb_re_flags_cat()`, so `re_compile.c` can reuse it |
| `src/re_compile.c` | Adds `re_compiler::orig_flags`; `compile_error_str()` appends the suffix |
| `test/regexp_syntax.rb` | Updates existing `RegexpError` message expectations that carry `/x`; adds coverage for the entry-vs-inline-flag case and multi-flag ordering |
| `test/ascii_case.rb` | Updates existing `RegexpError` message expectations that carry `/i` |

### Why `orig_flags` rather than `c->flags`

`re_flag_letters[]` and the loop over it were static to `src/regexp.c`,
invisible to `re_compile.c`, so the two files needed a shared entry point
rather than a duplicated table.

`c->flags` is not that entry point either: an inline `(?i)` or `(?x)`
mutates it partway through the parse, and a `RegexpError` still needs to
report the flags `mrb_re_compile()` was called with, not whatever the
parse has toggled by the time it raises. `orig_flags` is a copy of the
argument taken before the parse can touch it.

Verified against CRuby 4.0.6 that the suffix tracks the entry flags in
both directions, independent of what an inline option leaves active:

```ruby
Regexp.new("(?-x)a # c[", Regexp::EXTENDED)
# => still "premature end of char-class: /(?-x)a # c[/x"
Regexp.new("(?x)a # c\n[", 0)
# => "premature end of char-class: /(?x)a # c\n[/", no suffix
```

## Behaviour

```ruby
begin
  Regexp.new("a # c\n[", Regexp::EXTENDED)
rescue RegexpError => e
  e.message
end
# before: "unterminated character class: /a # c\n[/"
# after:  "unterminated character class: /a # c\n[/x"
```

## Size

`.text` of `bin/mruby`, `build_config/ci/gcc-clang.rb`'s five builds:

| Build | master | this PR | delta |
|---|---:|---:|---:|
| `full-debug` (-O0) | 1,908,342 | 1,908,438 | +96 |
| `bintest` | 1,306,022 | 1,306,166 | +144 |
| `cxx_abi` | 1,330,537 | 1,330,665 | +128 |
| `byte-string` | 1,271,190 | 1,271,334 | +144 |
| `ascii-ctype` | 1,292,582 | 1,292,726 | +144 |

## Testing

- `rake -m test` (default `host` build): green.
- `MRUBY_CONFIG=ci/gcc-clang rake -m test` (`full-debug`, `bintest`, `cxx_abi`,
  `byte-string`, `ascii-ctype`): all five green. `ascii-ctype` is the build
  that compiles `test/ascii_case.rb` in; confirmed its updated assertions
  run rather than skip.
- Both commits on this branch build and test green independently.

## Environment

<details>
<summary>OS, toolchain, CRuby</summary>

| | |
|---|---|
| OS | Ubuntu 24.04 (kernel 7.0.0-30-generic) |
| CPU | AMD Ryzen 9 5950X |
| C/C++ compiler | gcc/g++ 13.3.0 |
| binutils | 2.47.20260726 |
| CRuby (oracle) | 4.0.6 |

Actual `re_compile.c` compile line per build (`-MMD -c`, `-I...`, and `-o ...`
dropped for width):

```console
$ # full-debug (effectively -O0: -g3 -O0 follows -g -O3 on the same line)
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER re_compile.c

$ # bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK re_compile.c

$ # cxx_abi (gcc as the C++ front end; g++ only links)
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER re_compile.c

$ # byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER re_compile.c

$ # ascii-ctype
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER re_compile.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved regular expression error messages to preserve and display the flags supplied during compilation.
  * Error messages now correctly include `/i`, `/x`, and combined flags, including when inline options alter matching behavior.
  * Standardized flag formatting across regular expression inspection and error reporting.

* **Tests**
  * Updated and expanded coverage for flag-aware errors involving Unicode, escapes, named references, and comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->