### PR TITLE
symbol.c: mark the globals, a fiber's stack and a Range's ends

### DIFF
--- a/include/mruby/internal.h
+++ b/include/mruby/internal.h
@@ -481,6 +481,9 @@ mrb_bool mrb_vm_const_defined_p(mrb_state *mrb, const struct RProc *proc, mrb_sy
 mrb_value mrb_vm_const_get_noraise(mrb_state *mrb, const struct RProc *proc, mrb_sym sym);
 mrb_bool mrb_vm_cv_defined_p(mrb_state *mrb, const struct RProc *proc, mrb_sym sym);
 mrb_bool mrb_gv_defined(mrb_state *mrb, mrb_sym sym);
+#ifdef MRUBY_VARIABLE_H
+void mrb_gv_foreach(mrb_state *mrb, mrb_iv_foreach_func *func, void *p);
+#endif
 size_t mrb_obj_iv_tbl_memsize(mrb_value);
 void mrb_obj_iv_set_force(mrb_state *mrb, struct RObject *obj, mrb_sym sym, mrb_value v);
 mrb_value mrb_mod_constants(mrb_state *mrb, mrb_value mod);

--- a/include/mruby/range.h
+++ b/include/mruby/range.h
@@ -50,6 +50,13 @@ struct RRange {
 #define mrb_range_value(p) mrb_obj_value((void*)(p))
 #define RANGE_EXCL(p) ((p)->excl)
 
+/* A range is born uninitialized: `Range.allocate` hands one out before
+   `initialize` has set its ends, and reading them before that flag is on
+   reads whatever the allocation left behind. */
+#define RANGE_INITIALIZED_FLAG 1
+#define RANGE_INITIALIZED(p) ((p)->flags |= RANGE_INITIALIZED_FLAG)
+#define RANGE_INITIALIZED_P(p) ((p)->flags & RANGE_INITIALIZED_FLAG)
+
 MRB_API struct RRange* mrb_range_ptr(mrb_state *mrb, mrb_value range);
 
 /*

--- a/mrbgems/mruby-eval/test/eval.rb
+++ b/mrbgems/mruby-eval/test/eval.rb
@@ -237,3 +237,16 @@ assert('alias and undef reject a dynamic symbol') do
   assert_raise(SyntaxError) { eval 'alias :"#{1}" p' }
   assert_raise(SyntaxError) { eval 'undef :"#{}"' }
 end
+
+assert('symbol GC keeps the names of live global variables') do
+  # The global outlives the code that set it: once that code is collected its
+  # name is reachable from the global variable table alone, which is a root
+  # the sweep has to walk in its own right.
+  eval("$symbol_gc_eval_global = 99")
+  GC.start
+
+  6000.times { |i| "gc-filler-global-name-#{i}".to_sym }
+  GC.start
+
+  assert_true global_variables.include?("$symbol_gc_eval_global".to_sym)
+end

--- a/src/range.c
+++ b/src/range.c
@@ -12,10 +12,6 @@
 #include <mruby/numeric.h>
 #include <mruby/internal.h>
 
-#define RANGE_INITIALIZED_FLAG 1
-#define RANGE_INITIALIZED(p) ((p)->flags |= RANGE_INITIALIZED_FLAG)
-#define RANGE_INITIALIZED_P(p) ((p)->flags & RANGE_INITIALIZED_FLAG)
-
 static void
 r_check(mrb_state *mrb, mrb_value a, mrb_value b)
 {

--- a/src/symbol.c
+++ b/src/symbol.c
@@ -14,6 +14,8 @@
 #include <mruby/proc.h>
 #include <mruby/variable.h>
 #include <mruby/gc.h>
+#include <mruby/range.h>
+#include <mruby/error.h>
 #include <mruby/internal.h>
 
 #ifndef MRB_PRESYM_SCANNING
@@ -742,6 +744,9 @@ sym_gc_mark_hash_entry(mrb_state *mrb, mrb_value key, mrb_value val, void *p)
   return 0;
 }
 
+/* `sym_gc_mark_object` reaches a suspended fiber, whose stack this walks. */
+static void sym_gc_mark_context(mrb_state *mrb, struct mrb_context *c);
+
 /* Mark the symbols an irep holds: the pool the bytecode loads them from, the
    local variable names, and the same for every irep nested inside it.  An
    irep is not an object, so the sweep below never reaches one on its own, and
@@ -827,6 +832,32 @@ sym_gc_mark_object(mrb_state *mrb, struct RBasic *obj, void *data)
       }
     }
     break;
+  case MRB_TT_FIBER:
+    {
+      /* A suspended fiber's stack is a root of its own; `mrb_symbol_gc`
+         reaches only the current and the root context. */
+      struct mrb_context *c = ((struct RFiber*)obj)->cxt;
+      if (c && c != mrb->root_c && c != mrb->c &&
+          c->status != MRB_FIBER_TERMINATED) {
+        sym_gc_mark_context(mrb, c);
+      }
+    }
+    break;
+  case MRB_TT_RANGE:
+    {
+      struct RRange *r = (struct RRange*)obj;
+      if (RANGE_INITIALIZED_P(r)) {
+        if (mrb_symbol_p(RANGE_BEG(r))) sym_gc_mark(mrb, mrb_symbol(RANGE_BEG(r)));
+        if (mrb_symbol_p(RANGE_END(r))) sym_gc_mark(mrb, mrb_symbol(RANGE_END(r)));
+      }
+    }
+    break;
+  case MRB_TT_BREAK:
+    {
+      mrb_value v = mrb_break_value_get((struct RBreak*)obj);
+      if (mrb_symbol_p(v)) sym_gc_mark(mrb, mrb_symbol(v));
+    }
+    break;
   default:
     break;
   }
@@ -881,10 +912,10 @@ mrb_symbol_gc(mrb_state *mrb)
     sym_gc_mark_context(mrb, mrb->c);
   }
 
-  /* Mark symbols from global variable table */
-  if (mrb->globals) {
-    mrb_iv_foreach(mrb, mrb_obj_value(mrb->object_class), sym_gc_mark_iv, NULL);
-  }
+  /* Mark symbols from global variable table.
+     `mrb->globals` is a table of its own, not the instance variables of
+     `Object`; walking the latter reaches none of the global names. */
+  mrb_gv_foreach(mrb, sym_gc_mark_iv, NULL);
 
   /* Phase 3: sweep unmarked dynamic symbols */
   mrb_sym freed = 0;

--- a/src/variable.c
+++ b/src/variable.c
@@ -1668,6 +1668,19 @@ gv_i(mrb_state *mrb, mrb_sym sym, mrb_value v, void *p)
   return 0;
 }
 
+/* Iterate over the global variable table.
+ *
+ * `mrb_iv_foreach` only reaches the instance variables of an object; the
+ * globals live in `mrb->globals`, a table of their own that nothing outside
+ * this file can name. Symbol GC needs to walk it to keep the names of live
+ * globals from being swept.
+ */
+void
+mrb_gv_foreach(mrb_state *mrb, mrb_iv_foreach_func *func, void *p)
+{
+  iv_foreach(mrb, mrb->globals, func, p);
+}
+
 /* 15.3.1.2.4  */
 /* 15.3.1.3.14 */
 /*


### PR DESCRIPTION
## Summary

`38d4283` gave the symbol GC sweep the symbols an irep holds. Three more roots of the same kind go unwalked, so a name whose only holder is one of them is freed under code that is still going to ask for it.

## Changes

| File | What |
|---|---|
| `src/symbol.c` | Walk `mrb->globals` via `mrb_gv_foreach`; walk a suspended fiber's context; mark a Range's ends and an `RBreak`'s value |
| `src/variable.c`, `include/mruby/internal.h` | Add `mrb_gv_foreach`, since `iv_foreach` over an arbitrary `iv_tbl` is private to `variable.c` |
| `include/mruby/range.h`, `src/range.c` | Move `RANGE_INITIALIZED_P` beside `RANGE_BEG`/`RANGE_END` |
| `mrbgems/mruby-eval/test/eval.rb` | Add the global-variable regression test |

### The three remaining roots

**The global variable table.** The block commented "Mark symbols from global variable table" runs `mrb_iv_foreach` over `Object`, which reaches that class's *instance* variables and not one global name. `mrb->globals` is a table of its own, so walking it needs an entry point of its own, `mrb_gv_foreach`.

**A suspended fiber's stack.** `sym_gc_mark_context` is called for the running context and the root one. A fiber that is not currently running is neither.

**A Range's ends.** Its sibling containers, Array and Hash, were already walked for the symbols they hold; a Range was not. An `RBreak`'s value goes the same way.

### Why the global still bites after 38d4283

The code that sets a global holds the name in its irep, so `38d4283` covers it, but only for as long as that code is alive. Once it is collected the table is the sole holder, and nothing marks the table. Interning the name afresh then answers a different symbol than the one the table is keyed by, so the global is no longer reachable under its own name:

```ruby
eval("$g = 99")
GC.start                                        # the eval'd code goes away
6000.times { |i| "gc-filler-#{i}".to_sym }      # sweep runs
GC.start
global_variables.include?("$g".to_sym)          #=> false
```

That is the added test, and it fails on `38d4283` without this change:

```
Fail: symbol GC keeps the names of live global variables (mrbgems: mruby-eval)
  Total: 2529   KO: 1
```

The fiber and Range roots have no comparable pure-Ruby probe, since reaching them means arranging for a name to have no other holder, so they are fixed but not covered by a test here.

The irep test this PR previously carried is dropped: `38d4283` added `mrbgems/mruby-bin-mruby/bintest/mruby.rb` coverage for that root.

## Behaviour

A global variable, a value held only on a suspended fiber's stack, or a value held only as a Range's endpoint or a caught `break` value could have its name's symbol swept out from under it once nothing else referenced that symbol, making the name unreachable again under `to_sym`/`intern` even though the value was still live. All three are now marked.

## Size

`.text` of `bin/mruby` for each `ci/gcc-clang` build, master (`38d4283`) vs this PR (`78e9c2a32`):

| build | master | this PR | delta |
|---|---|---|---|
| bintest | 1,306,022 | 1,306,326 | +304 |
| ascii-ctype | 1,292,582 | 1,292,886 | +304 |
| byte-string | 1,271,190 | 1,271,494 | +304 |
| cxx_abi | 1,330,537 | 1,330,841 | +304 |
| full-debug (-O0) | 1,908,342 | 1,908,662 | +320 |

`src/symbol.o` accounts for +176 and `src/variable.o` for +128 (`src/range.o` is ±0), a `nm -S --size-sort` diff on the bintest build. `sym_gc_mark_object` grows from 624 to 816 bytes for the three added `case` arms (fiber stack, Range ends, `RBreak`); the new `mrb_gv_foreach` adds its own 117 bytes. `full-debug` moves 16 bytes further because at `-O0` there is no inlining to absorb part of the growth the way the optimized builds do.

## Testing

`MRUBY_CONFIG=ci/gcc-clang rake -m test:run:serial` on `78e9c2a32`:

| build | Total | OK | KO | Crash |
|---|---|---|---|---|
| full-debug | 2529 | 2522 | 0 | 0 |
| bintest | 2529 | 2514 | 0 | 0 |
| Bintest bintest | 125 | 124 | 0 | 0 |
| cxx_abi | 2529 | 2514 | 0 | 0 |
| byte-string | 2455 | 2400 | 0 | 0 |
| ascii-ctype | 2522 | 2506 | 0 | 0 |

`cross-mingw-winetest` under Wine 9.0 (mingw-w64 13.2, x86_64): Total 2512, OK 2471, Crash 0. The count itself is not this PR's doing; `38d4283` is what restored it, from 1711 on `bc1c81a` to the 2500s.

Seen on Wine, not from this change (both reproduce on master without this patch):

- Three `mruby-io` failures, `IO.popen with in option`, `IO#close_write`, `IO#close_write closes the stream for writing`. These are tests the recent `mruby-io` work newly runs on Windows, failing under Wine 9.0.
- `rake test:run:bin` for this config hangs. `build_config/helpers/wine_runner.rb` still does `STDIN.read` whenever stdin is not a tty, so a bintest that inherits rake's stdin blocks on an EOF that never comes (`mrbgems/mruby-bin-mrb/bintest/mrb.rb` hits it first). A different hang from the output-pipe one fixed in c23d534.

## Environment

<details>
<summary>OS, compiler, toolchain</summary>

| | |
|---|---|
| OS | Ubuntu 24.04 |
| Kernel | Linux 7.0.0-30-generic #30~24.04.1-Ubuntu SMP PREEMPT_DYNAMIC Fri Aug 7 13:27:52 UTC 2, x86_64 |
| CPU | AMD Ryzen 9 5950X 16-Core Processor |
| gcc | 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1) |
| g++ | 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1); `cxx_abi` compiles with `gcc -x c++`, g++ only links |
| binutils (`ld`/`size`) | GNU Binutils 2.47.20260726 |
| CRuby | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |

Actual compile line for `src/symbol.c`, per build (`-MMD -c`, `-I`, `-o` omitted):

```console
$ # full-debug
gcc -c -std=gnu99 -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings src/symbol.c

$ # bintest
gcc -c -std=gnu99 -g -O3 -DMRB_GC_FIXED_ARENA -DMRB_USE_DEBUG_HOOK -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings src/symbol.c

$ # cxx_abi (C++ compiler is gcc, not g++; g++ only links)
gcc -c -g -O3 -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -Wall -Wundef -Wwrite-strings src/symbol.c

$ # byte-string
gcc -c -std=gnu99 -g -O3 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings src/symbol.c

$ # ascii-ctype
gcc -c -std=gnu99 -g -O3 -DMRB_USE_ASCII_CTYPE -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings src/symbol.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved garbage collection so symbols used by global variables, ranges, fibers, and control-flow values remain available when needed.
  - Fixed an issue where global-variable names could become unavailable after evaluated code was collected.
  - Improved handling of newly allocated ranges before their endpoints are initialized.

- **Refactor**
  - Centralized range initialization tracking for more consistent runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->