### PR TITLE
mruby-regexp: let a refused capture block be `backtrack_exec()`'s answer

### DIFF
--- a/mrbgems/mruby-regexp/src/re_exec.c
+++ b/mrbgems/mruby-regexp/src/re_exec.c
@@ -1359,8 +1359,17 @@ backtrack_exec(mrb_state *mrb, const mrb_regexp_pattern *pat,
      hold by the undo log unwinding between start positions (see there): an
      iteration's record is written on the log now, which a match does not
      unwind, so a record left by the attempt before would otherwise be read
-     as this attempt's and stop a repetition that had not gone round yet. */
-  int *caps = (int*)mrb_malloc(mrb, sizeof(int) * (ncap + 2 * pat->code_len));
+     as this attempt's and stop a repetition that had not gone round yet.
+
+     Taken with mrb_malloc_simple() rather than mrb_malloc(), so that a
+     refusal is answered where the growth reallocs below already answer one.
+     Nothing is held here yet, so raising from this one line would strand
+     nothing; what it would cost is the engine's own answer. Every other
+     refusal inside a search reaches the caller as RE_NOMEM, which
+     re_check_exec_error() turns into the raise, and a search that raised
+     from here instead would be one the caller never saw stop. */
+  int *caps = (int*)mrb_malloc_simple(mrb, sizeof(int) * (ncap + 2 * pat->code_len));
+  if (!caps) return RE_NOMEM;
   int ret = 0;
   bt_state m;
   m.mrb = mrb;


### PR DESCRIPTION
## Summary

`backtrack_exec()` held the one allocation inside a search that raised where it could not answer. Every other one is a value the search hands back, and this line now hands the same one back.

## Changes

| File | What |
|---|---|
| `mrbgems/mruby-regexp/src/re_exec.c` | `backtrack_exec()` takes its capture block with `mrb_malloc_simple()` and answers `RE_NOMEM` where the allocator refuses it |

### One refusal reported from inside the engine, where every other is returned

A refused allocation inside a search reaches the caller as `RE_NOMEM`, which `re_check_exec_error()` in `regexp.c` turns into `NoMemoryError`. `pike_vm()`'s pools, `pool_alloc()`'s growth and `bt_push()`'s two stacks all take their memory with `mrb_malloc_simple()` or `mrb_realloc_simple()` for the reason the comments over them give: a raising allocator longjmps past the epilogue that frees what the search is holding by then, so a refusal has to be an answer rather than a raise.

`backtrack_exec()`'s own block was the exception, taken with `mrb_malloc()`. Nothing was leaked by it. The block is the first thing that frame takes, so an unwind from that line stranded nothing, and the growth reallocs under it already answer. What the exception cost is the shape of the answer: a caller reading `mrb_re_exec()`'s return value is told of every refusal but this one, and the frames below it already carry the reporting this line was skipping.

The line now takes the block with `mrb_malloc_simple()` and returns `RE_NOMEM` where it comes back NULL. The comment over it says which of the two the site keeps and why, as the sites below it do.

## Size

`.text` of `bin/mruby`, from `size -A`, for each build in `build_config/ci/gcc-clang.rb`.

| Build | master | this PR | delta |
|---|---|---|---|
| `bintest` | 1,306,022 | 1,305,910 | -112 |
| `ascii-ctype` | 1,292,582 | 1,292,486 | -96 |
| `byte-string` | 1,271,190 | 1,271,398 | +208 |
| `cxx_abi` | 1,330,537 | 1,330,585 | +48 |
| `full-debug` (-O0) | 1,908,342 | 1,908,374 | +32 |

Every delta is one function in `re_exec.o`, and no symbol appears or disappears. In the optimised builds that function is `exec_range()`, which `backtrack_exec()` is inlined into: its `.text` moves by -105 (`bintest`), -101 (`ascii-ctype`), +195 (`byte-string`) and +55 (`cxx_abi`), which is each build's whole delta up to the alignment of what follows it. What the source adds is a NULL test and a return, so the direction is the compiler scheduling a function it inlines as a whole rather than the amount of code asked of it. `full-debug` inlines nothing and shows what the source asks for: `backtrack_exec()` alone, 1,282 to 1,302.

## Testing

`rake -m test`, green on every build:

| Build | OK | KO | Crash | Skip |
|---|---|---|---|---|
| `full-debug` | 2522 | 0 | 0 | 6 |
| `bintest` | 2514 (+124 bintest) | 0 | 0 | 14 (+1 bintest) |
| `cxx_abi` | 2514 | 0 | 0 | 14 |
| `byte-string` | 2400 | 0 | 0 | 54 |
| `ascii-ctype` | 2506 | 0 | 0 | 15 |
| default (no `MRUBY_CONFIG`) | 2242 | 0 | 0 | 54 |

No test is added. The refusal this line answers is not reachable from Ruby: on a hosted OS `malloc()` does not return NULL under pressure, and the allocator behind `mrb_malloc_simple()` is the one the whole suite runs on.

What was checked instead is that the answer travels. With the block freed and NULLed at that line, so that the site behaves as a refusal every time, `/(a)\1/ =~ "aab aa"` reports `Out of memory (NoMemoryError)`, which is `re_check_exec_error()` raising from `RE_NOMEM`, the path `pool_alloc()` and `bt_push()` already take. A pattern with a backreference is what reaches the site at all, since `exec_range()` sends only `has_backref` or `needs_backtrack` patterns to this engine.

## Environment

<details>
<summary>Machine, toolchain, and the compile line of every build</summary>

| Item | Value |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS |
| Kernel | 7.0.0-30-generic |
| CPU | AMD Ryzen 9 5950X 16-Core Processor |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0 |
| binutils | GNU ld (GNU Binutils) 2.47.20260726 |

Actual compile line of `mrbgems/mruby-regexp/src/re_exec.c` in each build (`-MMD -c`, `-I` and `-o` dropped). `full-debug` is `-O0` because `enable_debug` appends `-g3 -O0` after the toolchain's `-g -O3`; `cxx_abi` compiles C as C++ with `gcc -x c++ -std=gnu++03`, g++ only links.

```console
# full-debug
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-regexp/src/re_exec.c
# bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK mrbgems/mruby-regexp/src/re_exec.c
# cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-regexp/src/re_exec.c
# byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-regexp/src/re_exec.c
# ascii-ctype
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-regexp/src/re_exec.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved regular expression handling when memory allocation fails.
  * The operation now reports an appropriate memory error instead of terminating unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->