### PR TITLE
build_config: let the program under test have the runner's stdin

### DIFF
--- a/build_config/helpers/wine_runner.rb
+++ b/build_config/helpers/wine_runner.rb
@@ -51,14 +51,18 @@ end
 # program: the wrapper hangs, holding a pipe no one will write to again, long
 # after the program it ran has exited.  A file ends where its contents do,
 # whoever else still holds it open.
-def capture(argv, input)
+#
+# Only the streams the wrapper has to read need that treatment.  Input is the
+# program's own business, so it is handed the wrapper's stdin as it stands:
+# whether anything ever arrives on it, and whether it is ever read, is then
+# between the program and whoever called the wrapper, which is how it reads
+# on the platform the tests are written for.
+def capture(argv)
   Dir.mktmpdir('wine-runner') do |dir|
-    stdin  = File.join(dir, 'stdin')
     stdout = File.join(dir, 'stdout')
     stderr = File.join(dir, 'stderr')
-    File.write(stdin, input)
 
-    pid = Process.spawn('wine', *argv, in: stdin, out: stdout, err: stderr)
+    pid = Process.spawn('wine', *argv, out: stdout, err: stderr)
     _, status = Process.waitpid2(pid)
 
     [File.read(stdout), File.read(stderr), status]
@@ -72,20 +76,11 @@ def main
     exit 0
   end
 
-  # For simplicity, just read all of stdin into memory and pass that
-  # as an argument when invoking wine. (Skipped if STDIN was not
-  # redirected.)
-  if !STDIN.tty?
-    input = STDIN.read
-  else
-    input = ""
-  end
-
   # Disable all Wine messages so they don't interfere with the output
   ENV['WINEDEBUG'] = 'err-all,warn-all,fixme-all,trace-all'
 
   # Run the program in wine and capture the output
-  output, errormsg, status = capture(ARGV, input)
+  output, errormsg, status = capture(ARGV)
 
   # Clean and print the results.
   STDOUT.write clean(output)


### PR DESCRIPTION
## Summary

The Wine runner reads all of its own stdin before it runs anything, so a run can stop before the program under test has been started. The read is guarded by `!STDIN.tty?`, which says fd 0 is not a terminal and nothing more; whether the end of that fd ever arrives is a separate question, and the guard cannot ask it. A caller that redirects nothing hands the runner whatever fd 0 `rake` was started with, and if that is a pipe whose writer outlives the run, the read never returns.

This is not the hang mruby/mruby#7319 fixed. That one was in `capture`, on the output side, and this read sits above it and is reached first.

## Changes

| File | What |
|---|---|
| `build_config/helpers/wine_runner.rb` | the runner no longer reads its own stdin; the program inherits fd 0 |

### Why the read is there

`Open3.capture3` takes its input as a string and would take it no other way, so the runner had to have the whole of stdin in memory before it could start. `capture` stopped using `Open3.capture3` in mruby/mruby#7319: it spawns `wine` itself and redirects to files the streams it has to collect. The string is no longer wanted by anything, and the read that produced it stayed behind.

### Which callers hand over a pipe

`Open3.capture3` and `Open3.capture2` open a pipe of their own and close it after writing, with or without `stdin_data:`, so the runner sees the end of it at once. Those are safe, and they cover every bintest that means to send input.

The callers that hang are the ones that redirect nothing, `` `#{cmd('mrb')} ...` `` and `system("#{cmd('mrbc')} ...")` in `mrbgems/mruby-bin-mrb/bintest/mrb.rb` among them. They pass on the fd 0 that `rake` was given, which is a shell's or a job runner's, and the runner blocks on it however little the program wanted to read.

### Output and input are not the same problem

Output goes through files because the runner reads it, and Wine hands the streams it was given to the services it starts, which hold the write ends after the program is gone. Input is the other way round. Whether anything arrives on stdin, and whether it is read, is between the program and whoever called the runner, and neither of those is the runner. So fd 0 is left as it stands:

```ruby
def capture(argv)
  Dir.mktmpdir('wine-runner') do |dir|
    stdout = File.join(dir, 'stdout')
    stderr = File.join(dir, 'stderr')

    pid = Process.spawn('wine', *argv, out: stdout, err: stderr)
    _, status = Process.waitpid2(pid)

    [File.read(stdout), File.read(stderr), status]
  end
end
```

## Behaviour

A program run through the runner now reads the stdin its caller gave it, which is what it reads when the same test runs natively. Nothing else about what the runner hands back has moved: the three values, the rewriting done to them, and the exit status are as they were.

## Testing

`rake -m test` on `build_config/cross-mingw-winetest.rb` under Wine:

| Suite | Total | OK | KO | Crash | Skip | Time |
| --- | --- | --- | --- | --- | --- | --- |
| `mrbtest` | 2,511 | 2,474 | 0 | 0 | 37 | 2.93s |
| `bintest` | 85 | 80 | 0 | 0 | 5 | 30.72s |

`mruby-bin-mirb`'s and `mruby-bin-debugger`'s bintests are in that count, and they are the ones that actually send input, so the passthrough is exercised with real data going to a real program.

The hang, with the runner's inherited stdin held open by a writer that sends nothing:

```sh
mkfifo hangfifo
( exec 3>hangfifo; sleep 300; exec 3>&- ) &
timeout 90 rake test:run:bin < hangfifo
```

Same build, same machine, the file put back to master's for the first row:

| Runner | OK | KO | Crash | Time |
| --- | --- | --- | --- | --- |
| master | 78 | 1 | 1 | 116.66s |
| this branch | 80 | 0 | 0 | 25.29s |

master's run is cut off by the `timeout`, inside the first `Kernel#system` that `mrbgems/mruby-bin-mrb/bintest/mrb.rb` reaches. This branch's run does not notice the fifo, and finishes in the time an ordinary run takes.

The mechanism on its own, with a stand-in for the runner that does the one thing the guard did:

```sh
$ cat runner.rb
input = STDIN.tty? ? "" : STDIN.read
$stderr.puts "read #{input.bytesize} bytes"
$ timeout 5 ruby runner.rb < hangfifo; echo "exit=$?"
exit=124
```

Nothing is printed. The read is where the run ends, before a program would have been started.

## Environment

<details>
<summary>Machine and toolchain</summary>

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-30-generic x86_64 |
| CPU | AMD Ryzen 9 5950X (16 cores, 32 threads) |
| Cross compiler | x86_64-w64-mingw32-gcc-posix (GCC) 13-posix |
| Wine | wine-11.0 |
| CRuby | 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Wine-based command execution by passing standard input directly through.
  * Preserved capture of standard output and error output while avoiding unnecessary input buffering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->