### PR TITLE
ci: give the mingw jobs timeout headroom

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
   GCC-CLANG:
     name: "${{ matrix.os }}-${{ matrix.altname || matrix.cc }}"
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 10
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       max-parallel: 8


### PR DESCRIPTION
## Summary

`6e1a133` gave the `GCC-CLANG` matrix `timeout-minutes: 10` in March 2021 and the value has not been touched since. The build has grown into it: the two mingw jobs now spend three quarters of that budget on an ordinary green run, so an ordinary slow runner ends the job as a red X on a PR that has nothing wrong with it.

## Changes

| File | What |
|---|---|
| `.github/workflows/build.yml` | `GCC-CLANG` matrix `timeout-minutes`, 10 to 15 |

### Where the budget goes

Wall clock of every job in the `GCC-CLANG` matrix over this workflow's last 60 runs, from `started_at`/`completed_at` in the Actions API:

| job | n | p50 | p90 | max | runs over 8m |
|---|---|---|---|---|---|
| `windows-2022-mingw-gcc` | 58 | 7.6m | 8.0m | 10.1m (cancelled) | 4 |
| `windows-2025-mingw-gcc` | 59 | 7.9m | 8.4m | 8.9m | 25 |
| `macos-26-clang` | 60 | 2.7m | 3.4m | 4.6m | 0 |
| `ubuntu-24.04-gcc` | 60 | 3.4m | 3.6m | 3.7m | 0 |
| `ubuntu-22.04-gcc` | 60 | 3.2m | 3.4m | 3.5m | 0 |
| `ubuntu-22.04-clang` | 60 | 3.1m | 3.2m | 3.4m | 0 |
| `ubuntu-24.04-clang` | 60 | 2.9m | 3.1m | 3.2m | 0 |
| `macos-15-clang` | 60 | 2.6m | 3.0m | 3.2m | 0 |
| `ubuntu-24.04-arm-gcc` | 60 | 2.8m | 2.8m | 3.0m | 0 |

The seven non-mingw jobs finish inside 3 of the 10 minutes and are nowhere near the limit. The two mingw jobs run at 76% and 79% of it as their median, and `windows-2025-mingw-gcc` is over 8 minutes on 25 of its 59 runs. There is roughly two minutes of slack left on a job whose own spread is already wider than that.

It has already cost a run: in run `32722884774` on #7329, `windows-2022-mingw-gcc` was killed at 10m04s with the log still at `LD build/bintest/bin/mrbtest.exe`, before a single test had run. The commit before it on that branch had an identical tree, and the same job passed on it in 7m11s.

### Why 15, and why the whole matrix

15 is the value the `Cosmopolitan` job further down the same file already carries, so the file gains no new number.

Raising only the two mingw rows would need a per-entry key and a `${{ matrix.timeout || 10 }}` expression on the job. That is not worth it. A timeout only fires on a job that was never going to finish, and for those the change buys 5 more minutes of runner time before the kill. The ubuntu and macOS jobs keep a guard that is still five times their p90.

## Behaviour

No change to what is built or tested. A `GCC-CLANG` matrix job that runs long is now cancelled at 15 minutes instead of 10.

## Testing

Nothing to compile. The table above is the evidence.

## Environment

<details>
<summary>How the numbers were collected</summary>

| | |
|---|---|
| Source | GitHub Actions API, `repos/mruby/mruby/actions/runs/<id>/jobs` |
| Runs | the 60 most recent of `.github/workflows/build.yml` at collection time, `32723913127` (2026-08-24) back to `32579410724` (2026-08-22), `push` and `pull_request` events both |
| Metric | `completed_at - started_at` per job, which counts runner startup and checkout, the same clock `timeout-minutes` is measured against |
| Excluded | jobs with `conclusion: null`, still running when collected |
| gh | 2.97.0 |

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the build validation time limit to improve reliability for longer-running checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->