### PR TITLE
mruby-io: let a closed stream be closed again

### DIFF
--- a/mrbgems/mruby-io/src/io.c
+++ b/mrbgems/mruby-io/src/io.c
@@ -79,13 +79,22 @@ static int io_modestr_to_flags(mrb_state *mrb, const char *modestr);
 static int io_mode_to_flags(mrb_state *mrb, mrb_value mode);
 static void fptr_finalize(mrb_state *mrb, struct mrb_io *fptr, int quiet);
 
+/* Every method that touches the stream starts here; only the ones that give a
+   descriptor up rather than use it go on to accept a closed one. */
 static struct mrb_io*
-io_get_open_fptr(mrb_state *mrb, mrb_value io)
+io_get_fptr(mrb_state *mrb, mrb_value io)
 {
   struct mrb_io *fptr = (struct mrb_io*)mrb_data_get_ptr(mrb, io, &mrb_io_type);
   if (fptr == NULL) {
     mrb_raise(mrb, E_IO_ERROR, "uninitialized stream");
   }
+  return fptr;
+}
+
+static struct mrb_io*
+io_get_open_fptr(mrb_state *mrb, mrb_value io)
+{
+  struct mrb_io *fptr = io_get_fptr(mrb, io);
   if (fptr->fd < 0) {
     mrb_raise(mrb, E_IO_ERROR, "closed stream");
   }
@@ -1186,11 +1195,26 @@ io_lshift(mrb_state *mrb, mrb_value io)
   return io;
 }
 
+/*
+ * call-seq:
+ *   ios.close -> nil
+ *
+ * Closes the stream. A stream that is already closed is left as it is.
+ *
+ *   f = File.new("testfile")
+ *   f.close         #=> nil
+ *   f.close         #=> nil
+ */
 static mrb_value
 io_close(mrb_state *mrb, mrb_value io)
 {
-  struct mrb_io *fptr;
-  fptr = io_get_open_fptr(mrb, io);
+  struct mrb_io *fptr = io_get_fptr(mrb, io);
+
+  /* Closing what is closed asks for nothing, and the stream already answers
+     #closed? with true, so there is nothing for a raise to tell. */
+  if (fptr->fd < 0) {
+    return mrb_nil_value();
+  }
   fptr_finalize(mrb, fptr, FALSE);
   return mrb_nil_value();
 }
@@ -1204,7 +1228,7 @@ io_close(mrb_state *mrb, mrb_value io)
  * A stream that is not duplex has no write end of its own. If it cannot be
  * read from, or it was opened to a child process, its only end is the one
  * being closed and the whole stream is closed; otherwise an `IOError` is
- * raised.
+ * raised. A stream that is already closed is left as it is.
  *
  *   r, w = IO.pipe
  *   w.close_write
@@ -1213,9 +1237,15 @@ io_close(mrb_state *mrb, mrb_value io)
 static mrb_value
 io_close_write(mrb_state *mrb, mrb_value io)
 {
-  struct mrb_io *fptr = io_get_open_fptr(mrb, io);
-  int fd2 = fptr->fd2;
+  struct mrb_io *fptr = io_get_fptr(mrb, io);
 
+  /* A closed stream has no write end left to give up, duplex or not, so the
+     answer is the one #close gives and nothing below it applies. */
+  if (fptr->fd < 0) {
+    return mrb_nil_value();
+  }
+
+  int fd2 = fptr->fd2;
   if (fd2 == -1) {
     /* No second descriptor, so writing goes through fd, which is also what
        reading goes through. There is a write end to give up only where

--- a/mrbgems/mruby-io/test/file.rb
+++ b/mrbgems/mruby-io/test/file.rb
@@ -23,9 +23,7 @@ end
 assert('File#initialize', '15.2.21.4.1') do
   io = File.open($mrbtest_io_rfname, "r")
   assert_nil io.close
-  assert_raise IOError do
-    io.close
-  end
+  assert_nil io.close
 end
 
 assert('File#path', '15.2.21.4.2') do

--- a/mrbgems/mruby-io/test/io.rb
+++ b/mrbgems/mruby-io/test/io.rb
@@ -53,6 +53,13 @@ assert('IO#close', '15.2.20.5.1') do
   assert_nil io.close
 end
 
+assert('IO#close on a closed stream') do
+  io = IO.new(IO.sysopen($mrbtest_io_rfname))
+  io.close
+  assert_nil io.close
+  assert_true io.closed?
+end
+
 assert('IO#closed?', '15.2.20.5.2') do
   io = IO.new(IO.sysopen($mrbtest_io_rfname))
   assert_false io.closed?
@@ -661,6 +668,23 @@ end
 assert('IO#close_write on a stream opened to a child') do
   begin
     io = IO.popen("#{$cmd}echo mruby-io", "r")
+    assert_nil io.close_write
+    assert_true io.closed?
+  rescue NotImplementedError => e
+    skip e.message
+  end
+end
+
+assert('IO#close_write on a closed stream') do
+  # The whole stream is gone, so there is no write end left to give up.
+  io = IO.new(IO.sysopen($mrbtest_io_rfname))
+  io.close
+  assert_nil io.close_write
+  assert_true io.closed?
+
+  begin
+    io = IO.popen($cat, "r+")
+    io.close
     assert_nil io.close_write
     assert_true io.closed?
   rescue NotImplementedError => e


### PR DESCRIPTION
## Summary

`IO#close` and `IO#close_write` raise `IOError: closed stream` on a stream that is already closed, where CRuby answers `nil` to both. This lets a closed stream be closed again.

## Changes

| File | What |
|---|---|
| `mrbgems/mruby-io/src/io.c` | add `io_get_fptr()`, build `io_get_open_fptr()` on it, and take the former in `io_close()` and `io_close_write()` |
| `mrbgems/mruby-io/test/io.rb` | add `IO#close on a closed stream` and `IO#close_write on a closed stream` |
| `mrbgems/mruby-io/test/file.rb` | `File#initialize` pinned the raise a second `close` gave |

### Both closers start from the getter every reader and writer starts from

`io_get_open_fptr()` is where every method that needs a live descriptor starts, and it refuses two things: a stream that was never initialized, and one whose descriptor is gone.

```c
  if (fptr->fd < 0) {
    mrb_raise(mrb, E_IO_ERROR, "closed stream");
  }
```

That is the right answer for the readers and the writers, which are asked for a descriptor there is none of. `io_close()` and `io_close_write()` take it only because they share the getter, and they are not asking for a descriptor to use, they are giving one up. Closing what is already closed asks for nothing, and the stream already answers `closed?` with `true`, so the raise tells the caller nothing the receiver does not already say.

The two are one rule, so the getter is split in two rather than the check being written twice: `io_get_fptr()` refuses only an uninitialized stream, and `io_get_open_fptr()` is that plus the `fd < 0` raise. Its 22 call sites are untouched. The two closers take `io_get_fptr()` and answer `nil` where the descriptor is gone.

An uninitialized stream is a separate matter and is left where it is: `IO.allocate.close` raises `TypeError: uninitialized IO (expected IO)` from `mrb_data_get_ptr()`, before the getter's own `IOError: uninitialized stream` can be reached.

### In `IO#close_write` the check goes before the `fd2` arms

A closed stream has no write end left to give up, duplex or not, so the answer is the one `IO#close` gives and nothing below needs to run. Placing the check first also means a closed non-duplex readable stream answers `nil` rather than `closing non-duplex IO for writing`, which is the order CRuby takes as well:

```console
$ ruby -e 'r, w = IO.pipe; r.close; p r.close_write'
nil
```

Below it stand the arms #7325 added, which close the whole stream where a non-duplex stream is not readable or was opened to a child process. The two guards read in the order they have to: a closed stream has already given its only end up, so it never reaches the question of which end this one is, and `IO.popen("cat", "r").close_write` closes the stream on the first call and answers `nil` on the second. CRuby answers the same both times.

`IO#close` is 15.2.20.5.1 in the ISO table. The standard says the method closes the stream and says nothing about a second call, so neither answer is ruled out there.

## Behaviour

| receiver | before | after | CRuby 4.0.6 |
| --- | --- | --- | --- |
| `IO#close` on a closed stream | `IOError: closed stream` | `nil` | `nil` |
| `IO#close_write` on a closed stream | `IOError: closed stream` | `nil` | `nil` |
| `IO#close_write` on an open non-duplex readable stream | `IOError: closing non-duplex IO for writing` | unchanged | same `IOError` |
| `IO#close_write` twice on `IO.popen("cat", "r")` | `IOError: closed stream` | `nil` | `nil` |
| `IO#close_write` twice on `IO.popen("cat", "r+")` | closes the stream | unchanged | closes the stream |
| `IO#read`, `IO#write` and the rest on a closed stream | `IOError: closed stream` | unchanged | same `IOError` |
| `IO.allocate.close` | `TypeError: uninitialized IO (expected IO)` | unchanged | `IOError: uninitialized stream` |

```console
$ cat closed.rb
f = File.open("/etc/hostname")
f.close
p f.close
p f.close_write
p f.closed?
$ build/host/bin/mruby closed.rb
nil
nil
true
```

## Size

`.text` of `bin/mruby` for the five builds of `build_config/ci/gcc-clang.rb`, measured with `size -A`, both sides built in the same worktree path from an empty build directory.

| build | master | this PR | delta |
| --- | ---: | ---: | ---: |
| `bintest` | 1,306,454 | 1,305,574 | -880 |
| `cxx_abi` | 1,331,113 | 1,330,233 | -880 |
| `byte-string` | 1,271,942 | 1,271,046 | -896 |
| `ascii-ctype` | 1,293,030 | 1,292,150 | -880 |
| `full-debug` (-O0) | 1,908,918 | 1,908,998 | +80 |

`mrbgems/mruby-io/src/io.o` is the only object whose `.text` moves (bintest 20,766 -> 19,886). At `-O3` gcc keeps `io_get_fptr()` as an outlined `io_get_fptr.part.0` and folds the shared prologue there, so all 22 callers of `io_get_open_fptr()` shrink a little each: `io_fileno` 0x4e -> 0x37, `io_isatty` 0x5b -> 0x44, `io_getbyte` 0xe6 -> 0xc7 and so on. At `-O0` nothing is inlined and the new function body is the whole `+80`.

## Testing

```console
$ MRUBY_BUILD_DIR=$PWD/build rake -m test
  Total: 2305
     OK: 2250
     KO: 0
  Crash: 0
Warning: 0
   Skip: 55

$ MRUBY_BUILD_DIR=$PWD/build-ci MRUBY_CONFIG=build_config/ci/gcc-clang.rb rake -m test
```

All five builds green, `KO: 0` and `Crash: 0` in each.

`File#initialize` (15.2.21.4.1) asserted that a second `close` raises `IOError`; it now expects `nil`. That assertion is not part of what the ISO entry describes. The existing `IO#close_write` tests all close an open stream and are unchanged.

## Environment

<details>
<summary>host, compilers and compile lines</summary>

| | |
| --- | --- |
| OS | Ubuntu 24.04 |
| kernel | Linux 7.0.0-30-generic x86_64 |
| CPU | AMD Ryzen 9 5950X 16-Core Processor |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0 |
| | Homebrew clang version 22.1.8 |
| binutils | GNU ld (GNU Binutils) 2.47.20260726 |
| CRuby | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |

The compile line of `mrbgems/mruby-io/src/io.c` in each of the five builds, with `-MMD -c`, the `-I` flags and `-o` dropped:

```console
bintest      gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK

cxx_abi      gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

byte-string  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

ascii-ctype  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

full-debug   gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

`full-debug` carries `-g -O3` from the gcc toolchain default and `-g3 -O0` after it from `enable_debug`, so it builds at `-O0`. `cxx_abi` compiles with `gcc -x c++ -std=gnu++03`; `g++` only links.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Repeated calls to `IO#close` now safely return `nil` instead of raising an error.
  * Calling `IO#close_write` on an already closed stream now returns `nil`.
  * Stream closure state remains consistent after repeated close operations.
  * `IO#close_write` now properly closes single-ended child-process streams.

* **Tests**
  * Added coverage for repeated close operations on regular and popen streams.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
