### PR TITLE
class.c: check frozen before mrb_define_method_raw() walks to the origin

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -1034,10 +1034,14 @@ MRB_API void
 mrb_define_method_raw(mrb_state *mrb, struct RClass *c, mrb_sym mid, mrb_method_t m)
 {
   union mrb_mt_ptr ptr;
+  /* The class the caller named, kept before the origin walk below moves `c`
+     past it: the origin ICLASS never carries the frozen flag, so a frozen
+     check made after the walk is a check nothing can fail. */
+  struct RClass *named = c;
 
   MRB_CLASS_ORIGIN(c);
 
-  mrb_mt_tbl *h = mt_writable(mrb, c, c);
+  mrb_mt_tbl *h = mt_writable(mrb, named, c);
   if (MRB_METHOD_PROC_P(m)) {
     struct RProc *p = (struct RProc*)MRB_METHOD_PROC(m);
 

--- a/test/t/module.rb
+++ b/test/t/module.rb
@@ -684,6 +684,19 @@ end
     assert_raise(FrozenError) { Class.new.freeze.prepend Module.new }
   end
 
+  assert 'Module#prepend leaves a frozen class frozen' do
+    c = Class.new { def bar; :own; end; prepend Module.new }
+    c.freeze
+
+    assert_raise(FrozenError, 'def') { c.class_eval { def baz; :new; end } }
+    assert_raise(FrozenError, 'define_method') { c.class_eval { define_method(:baz) { :new } } }
+    assert_raise(FrozenError, 'alias_method') { c.class_eval { alias_method :baz, :bar } }
+    assert_raise(FrozenError, 'undef_method') { c.class_eval { undef_method :bar } }
+
+    assert_false c.new.respond_to?(:baz), 'no definition may have got through'
+    assert_true c.new.respond_to?(:bar), 'no removal may have got through'
+  end
+
   assert 'Module#private on a method a prepended module also defines' do
     m = Module.new { def foo; :prepended; end }
     c = Class.new { def foo; :own; end; prepend m }


### PR DESCRIPTION
## Summary

`mrb_define_method_raw()` resolves `MRB_CLASS_ORIGIN()` before it asks `mt_writable()` whether the class is frozen. On a class with a prepended module those are two different objects, and the one left in `c` after the walk is the origin ICLASS, which never carries the frozen flag. The check therefore runs against an object that cannot fail it, and `def`, `define_method`, `alias_method` and `undef_method` all change a frozen class in silence.

## Changes

| File | What |
|---|---|
| `src/class.c` | `mrb_define_method_raw()` keeps the class the caller named and hands that to `mt_writable()` as the object to check; the table it writes to is still the origin's |
| `test/t/module.rb` | regression test for the four ways to reach the method table of a frozen class with a prepended module |

### Checking the class the caller named

`mrb_prepend_module()` creates the origin as a plain ICLASS to hold the class's own methods, and moves the class's method table into it. `MRB_FL_CLASS_IS_FROZEN` stays on the class the user called `freeze` on; nothing ever sets it on that ICLASS, and nothing should, since it is not an object anyone can name. `MRB_CLASS_ORIGIN(c)` reassigns `c`, so by the time `mt_writable()` looks at it the class the caller named is gone.

Keeping it in a local before the walk is enough. `mt_writable()` already takes the two apart, so the frozen check runs on the class the caller named and the table preparation on the origin, which is what the write needs. Everything the function does after the walk still sees the origin, unchanged: the write barrier, `MRB_PROC_SET_TARGET_CLASS()`, and the singleton test that decides visibility.

`find_origin()` performs the same reassignment but is only ever used for reads, so it has never had this problem, and `mrb_remove_method()` has no frozen check of its own to lose, `mrb_mod_remove_method()` running `mrb_check_frozen()` before it calls in. `mrb_define_method_raw()` is the one writer that carries the check itself.

## Behaviour

```ruby
module M; def x; end; end
class C; def w; :orig; end; prepend M; end
C.freeze

class C; def y; :new; end; end            # CRuby: FrozenError, before: defines y
class C; define_method(:y) { :new }; end  # CRuby: FrozenError, before: defines y
class C; alias_method :z, :w; end         # CRuby: FrozenError, before: defines z
class C; undef_method :w; end             # CRuby: FrozenError, before: undefines w
```

All four now raise `FrozenError`, as they already did on a class with nothing prepended. A class with no prepended module is untouched: `MRB_CLASS_ORIGIN()` leaves `c` alone there, so the local and the walked value are the same object and the check sees exactly what it saw before.

## Size

`.text` of `bin/mruby` for each `build_config/ci/gcc-clang.rb` build (`size -A`), both columns built from an empty directory at the same path:

| Build | master | this PR | delta |
|---|---:|---:|---:|
| `full-debug` (-O0) | 1,908,790 | 1,908,806 | +16 |
| `bintest` | 1,306,438 | 1,306,390 | -48 |
| `cxx_abi` | 1,330,953 | 1,330,905 | -48 |
| `byte-string` | 1,271,606 | 1,271,558 | -48 |
| `ascii-ctype` | 1,292,998 | 1,292,950 | -48 |

`src/class.c` is the only file that changes, and `class.o` accounts for the whole delta. Compiled on its own with each build's recorded flags, its `.text` goes 39,275 to 39,227 under `bintest` and 43,815 to 43,823 under `full-debug`, the latter rounding to +16 once the linker pads it. The two directions are the same edit seen at two optimisation levels: at `-O0` the extra local is an extra stack slot written and read, and at `-O3` there is no extra local, only a frozen check that now reads the incoming argument instead of the value the walk leaves behind. The only symbols that move are `mrb_define_method_raw()` and the constant propagated clone gcc emits beside it.

## Testing

`rake test`, default configuration: 2,301 total, 2,247 OK, 0 KO, 0 crash, 54 skip; `bintest` 114 total, 113 OK, 0 KO, 1 skip.

`rake -m test`, `build_config/ci/gcc-clang.rb`, no compiler warning in any build:

| Build | total | OK | KO | crash | skip |
|---|---:|---:|---:|---:|---:|
| `full-debug` | 2,533 | 2,527 | 0 | 0 | 6 |
| `bintest` | 2,533 | 2,519 | 0 | 0 | 14 |
| `cxx_abi` | 2,533 | 2,519 | 0 | 0 | 14 |
| `byte-string` | 2,459 | 2,405 | 0 | 0 | 54 |
| `ascii-ctype` | 2,526 | 2,511 | 0 | 0 | 15 |

The `bintest` suite: 125 total, 124 OK, 0 KO, 1 skip.

The new test asserts `FrozenError` from all four entry points and then checks, through `respond_to?`, that no definition and no removal got through. Against master's `src/class.c` it fails as `KO: 1`. `remove_method` is not among the four: `mrb_mod_remove_method()` checks the receiver itself, so it already raised.

## Environment

<details>
<summary>details</summary>

| | |
| --- | --- |
| OS | Ubuntu, Linux 7.0.0-30-generic, x86_64 |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0 |
| C++ compiler | `cxx_abi` compiles `src/class.c` as C++ with `gcc -x c++ -std=gnu++03`; g++ only links |
| binutils | GNU ld (GNU Binutils) 2.47.20260726 |
| CRuby | 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |

`src/class.c`'s actual compile line in each `build_config/ci/gcc-clang.rb` build, include paths dropped:

```
# full-debug (-O0)
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/class.c

# bintest
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK src/class.c

# cxx_abi
gcc -c -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/class.c

# byte-string
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/class.c

# ascii-ctype
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/class.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where frozen classes with prepended modules could be modified unexpectedly.
  - Method definitions, aliases, and removals now correctly raise a frozen-state error.
  - Existing methods remain available, and no new methods are added when modification is rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->