### PR TITLE
promote `ary_unshift_values` to `MRB_API`

### DIFF
--- a/include/mruby/array.h
+++ b/include/mruby/array.h
@@ -229,6 +229,20 @@ MRB_API void mrb_ary_set(mrb_state *mrb, mrb_value ary, mrb_int n, mrb_value val
 MRB_API void mrb_ary_replace(mrb_state *mrb, mrb_value self, mrb_value other);
 
 /*
+ * Unshift many values into an array
+ *
+ * Equivalent to:
+ *
+ *      ary.unshift(*argv)
+ *
+ * @param mrb The mruby state reference.
+ * @param self The target array.
+ * @param argc The number of values to unshift.
+ * @param argv The values to unshift.
+ */
+MRB_API mrb_value mrb_ary_unshift_values(mrb_state *mrb, mrb_value self, mrb_int argc, const mrb_value argv[]);
+
+/*
  * Unshift an element into the array
  *
  * Equivalent to:

--- a/src/array.c
+++ b/src/array.c
@@ -978,9 +978,9 @@ mrb_ary_shift_m(mrb_state *mrb, mrb_value self)
   return val;
 }
 
-static mrb_value
-ary_unshift_values(mrb_state *mrb, mrb_value self,
-                   mrb_int argc, const mrb_value argv[])
+MRB_API mrb_value
+mrb_ary_unshift_values(mrb_state *mrb, mrb_value self,
+                       mrb_int argc, const mrb_value argv[])
 {
   struct RArray *a = RARRAY(self);
 
@@ -1041,7 +1041,7 @@ ary_unshift_values(mrb_state *mrb, mrb_value self,
 MRB_API mrb_value
 mrb_ary_unshift(mrb_state *mrb, mrb_value self, mrb_value item)
 {
-  return ary_unshift_values(mrb, self, 1, &item);
+  return mrb_ary_unshift_values(mrb, self, 1, &item);
 }
 
 /*
@@ -1061,7 +1061,7 @@ mrb_ary_unshift(mrb_state *mrb, mrb_value self, mrb_value item)
 static mrb_value
 mrb_ary_unshift_m(mrb_state *mrb, mrb_value self)
 {
-  return ary_unshift_values(mrb, self, mrb_get_argc(mrb), mrb_get_argv(mrb));
+  return mrb_ary_unshift_values(mrb, self, mrb_get_argc(mrb), mrb_get_argv(mrb));
 }
 
 /**


### PR DESCRIPTION
expose the `Array#unshift(...)` eqvl. primitive to `MRB_API` this *could* supersede the `mrb_ary_unshift` function, as it is just a special case of this function (`argv == 1`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a public API for inserting multiple values at the beginning of an array.
  * Supports behavior equivalent to adding several values with `unshift`, while preserving their order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->