### PR TITLE
gc.c: let byte pressure advance an in-progress collection cycle

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -324,7 +324,7 @@ mrb_realloc_simple(mrb_state *mrb, void *p,  size_t len)
     if (p == NULL &&
         mrb->gc.malloc_threshold > 0 &&
         mrb->gc.malloc_increase >= mrb->gc.malloc_threshold &&
-        mrb->gc.state == MRB_GC_STATE_ROOT &&
+        !mrb->gc.collecting &&
         !mrb->gc.disabled && !mrb->gc.iterating && mrb->gc.auto_step) {
       /* Only a fresh allocation (p == NULL) may drive the collector here. A
          realloc (p != NULL) has just freed the caller's old block, but the
@@ -337,6 +337,21 @@ mrb_realloc_simple(mrb_state *mrb, void *p,  size_t len)
          references, so it is a safe point to step GC. Byte pressure from
          reallocs is not lost: malloc_increase keeps accumulating above and
          fires at the next fresh allocation.
+
+         The collector may be in any state here. A major cycle advances one
+         step per call, and those calls come from the object axis
+         (mrb_obj_alloc_core), so gating byte pressure on MRB_GC_STATE_ROOT
+         let it start a cycle it could never finish: a workload that allocates
+         bytes without allocating objects fired once, parked the cycle in
+         MARK, and locked the byte axis out for the rest of the run. Stepping
+         from MARK or SWEEP is what the object axis already does on every
+         allocation.
+
+         collecting takes the place of that state test: it is set exactly
+         while the mark/sweep engine is on the C stack, so an allocation made
+         from inside a collection (an RData dfree that allocates during sweep)
+         cannot re-enter the engine. The state test used to rule that case out
+         only as a side effect of sweeping never being at ROOT.
 
          auto_step is part of the condition (not just relied on inside
          mrb_incremental_gc) so malloc_increase is not cleared for a call

--- a/test/t/gc.rb
+++ b/test/t/gc.rb
@@ -85,6 +85,44 @@ assert('GC.malloc_threshold - triggers GC on large allocations') do
   end
 end
 
+# A cycle that runs incrementally needs one call per step, and outside this
+# path every one of those calls comes from an object allocation.  A workload
+# that allocates bytes without allocating objects therefore has to advance the
+# cycle on byte pressure alone; if it cannot, the first threshold crossing
+# starts a cycle that parks mid-mark and no later crossing is ever honoured.
+# `malloc_increase` is cleared on every crossing, so its value at the end
+# counts the bytes allocated since the last one: it stays near the threshold
+# while the axis keeps working and grows to the whole loop once it stops.
+#
+# The 40 buffers below are Strings, and an object allocation does step the
+# collector, so the loop has to stay far enough under that axis for the
+# reading to mean what it says.  It does, by construction: `GC.start` ends
+# with `gc_debt` at minus a credit that is floored at `GC_STEP_SIZE`, so the
+# object axis takes at least 1024 allocations to step even once.  40 is
+# twenty-five times under that floor, and the floor is the worst case, since
+# a build with a larger live set gets a proportionally larger credit.
+#
+# That floor is the one thing MRB_GC_STRESS takes away: it collects fully at
+# every object allocation, and with MRB_DEBUG at every heap allocation too, so
+# the assertion passes there whether or not byte pressure works.  It is not
+# weaker than it looks, it is measuring a build that cannot hold the state it
+# is about: a cycle can only park where something allocates without collecting,
+# which is exactly what those builds rule out.
+assert('GC.malloc_threshold - byte pressure advances an incremental cycle') do
+  origin = GC.malloc_threshold
+  origin_mode = GC.generational_mode
+  begin
+    GC.generational_mode = false   # every cycle is incremental in this mode
+    GC.start                       # start from MRB_GC_STATE_ROOT
+    GC.malloc_threshold = 1024
+    40.times { "x" * 65536 }       # 2.6MB of buffers, 40 objects
+    assert_true GC.stat[:malloc_increase] < 262144
+  ensure
+    GC.malloc_threshold = origin
+    GC.generational_mode = origin_mode
+  end
+end
+
 assert('GC.malloc_threshold - does not mark through stale realloc buffers') do
   origin = GC.malloc_threshold
   begin


### PR DESCRIPTION
## Summary

`GC.malloc_threshold` schedules collection on malloc-backed bytes, for the
workloads `gc_debt` cannot see: a buffer costs the object counter the same
whether it holds eight bytes or eight megabytes. As written the trigger can
start a collection cycle but never finish one, so on exactly those workloads
turning it on makes peak memory worse than leaving it off.

A 200 iteration slice-then-append loop over a 1MiB string moves 630MB through
`mrb_realloc()` while allocating a few hundred objects. It peaks at 135MB with
the knob off and 210MB with it set to 1MiB. With this fix the same setting
peaks at 86MB, and 16MiB peaks at 42MB.

## Changes

### The trigger required `MRB_GC_STATE_ROOT`

A cycle that runs incrementally advances one step per call, and every one of
those calls comes from an object allocation in `mrb_obj_alloc_core()`. So the
first threshold crossing started a cycle, the state left `MRB_GC_STATE_ROOT`,
and every later crossing was refused until the object axis walked the cycle
back to root.

A workload that allocates bytes without allocating objects has no object axis
to walk it back. The cycle parked in `MRB_GC_STATE_MARK` and the byte axis was
locked out for the rest of the run. `GC.stat` after the loop above with the
threshold at 1MiB: one minor collection, `state` 1, `malloc_increase` 628MB
unclaimed. That single cycle never reached its sweep, which is why opting in
was worse than staying out.

Stepping from `MRB_GC_STATE_MARK` or `MRB_GC_STATE_SWEEP` is what the object
axis already does on every allocation, so the state test is dropped.

### `collecting` takes over the guard the state test was providing

`gc->collecting` is set exactly while the mark/sweep engine is on the C stack.
An allocation made from inside a collection (an RData `dfree` that allocates
during sweep) therefore still cannot re-enter the engine, which the state test
was ruling out only as a side effect of sweeping never being at root.

The `p == NULL` guard is untouched: a `realloc` has already freed the caller's
old block before the caller stores the new pointer, so marking in that window
would walk freed memory.

## Behaviour

A default build is unaffected: `GC.malloc_threshold` is 0 there and the
trigger never runs. What changes is what the knob does once set.

Peak RSS on the loop below, `/usr/bin/time -f %M`:

| `GC.malloc_threshold` | master   | PR       |
| --------------------- | -------- | -------- |
| 0 (default)           | 135028kB | 135516kB |
| 1MiB                  | 209672kB | 86260kB  |
| 8MiB                  | 207220kB | 72996kB  |
| 16MiB                 | 204360kB | 41920kB  |
| 32MiB                 | 199028kB | 31624kB  |

```ruby
src = "x" * (1024 * 1024)
200.times do
  t = src[0, src.size]
  t << "y"
end
```

CRuby 4.0.6 peaks at 51728kB on the same loop.

## Speed

Best of seven, wall clock, same loop:

| `GC.malloc_threshold` | master | PR    |
| --------------------- | ------ | ----- |
| 0 (default)           | 0.10s  | 0.10s |
| 1MiB                  | 0.09s  | 0.08s |
| 16MiB                 | 0.09s  | 0.02s |

The collections the fix adds are minor ones, and they cost less than the page
faults the unbounded heap was paying for.

## Size

`.text` of `libmruby.a`, `ci/gcc-clang`:

| Build       | master  | PR      | delta |
| ----------- | ------- | ------- | ----- |
| full-debug  | 1926227 | 1926237 | +10   |
| bintest     | 1318268 | 1318172 | -96   |
| cxx_abi     | 1341949 | 1341869 | -80   |
| byte-string | 1283773 | 1283661 | -112  |
| ascii-ctype | 1304843 | 1304731 | -112  |

## Testing

`MRUBY_CONFIG=ci/gcc-clang rake -m test`: all five builds green, including
`full-debug` with `MRB_GC_STRESS`.

`test/t/gc.rb` gains `GC.malloc_threshold - byte pressure advances an
incremental cycle`. It runs in non-generational mode, where every cycle is
incremental, allocates 2.6MB of buffers over 40 objects, and reads
`GC.stat[:malloc_increase]`, which is cleared on each threshold crossing: it
stays near the threshold while the byte axis keeps working and grows to the
whole loop once it stops. The assertion fails on master and passes here.

## Environment

- AMD Ryzen 9 5950X, Linux 7.0.0-30-generic x86_64
- gcc 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1)
- ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved incremental garbage collection during memory-intensive allocations.
  * Memory-pressure-triggered collection can now continue progressing through more collection stages, helping prevent excessive memory growth.
  * Prevented collection from being re-entered while garbage collection callbacks are running.

* **Tests**
  * Added regression coverage confirming that allocation pressure advances incremental collection and that garbage-collection settings are restored correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->