### PR TITLE
string.c: let growth at the end of a shared string append in place

### DIFF
--- a/mrbgems/mruby-string-ext/src/string.c
+++ b/mrbgems/mruby-string-ext/src/string.c
@@ -2503,6 +2503,15 @@ str_insert(mrb_state *mrb, mrb_value self)
     mrb_raisef(mrb, E_INDEX_ERROR, "index %S out of string", mrb_int_value(mrb, idx));
   }
 
+  /* Inserting at the end is an append: it writes nothing any sharer of the
+     buffer can see, so mrb_str_cat() may grow the string inside that buffer
+     where mrb_str_modify() below would copy the whole of it first. */
+  if (idx == self_len) {
+    mrb_str_cat(mrb, self, RSTRING_PTR(str_to_insert), (size_t)insert_len);
+    str_mark_spliced_bytes(self, str_to_insert);
+    return self;
+  }
+
   mrb_str_modify(mrb, s);
   mrb_str_resize(mrb, self, self_len + insert_len);
 

--- a/mrbgems/mruby-string-ext/test/string.rb
+++ b/mrbgems/mruby-string-ext/test/string.rb
@@ -314,17 +314,24 @@ assert('String growth on a shared buffer') do
   assert_equal "1234" + "c" * 100 + "x" * 100, c
   assert_equal "c" * 100 + "x" * 50, c_slice
 
-  # The rest are contract rather than detection: what they write happens to
-  # land above the slice, or they take the buffer for reasons of their own.
-
-  # `insert` at the end writes above the slice, and moves only the length and
-  # the terminator of the buffer the slice reads.
+  # `insert` at the end appends, and an append writes only above what the
+  # slice reads, so it stays in the buffer instead of taking a copy of it.
   b = "b" * 100
   b << "y" * 100
   b_slice = b[0, 150]
   b.insert(-1, "1234")
   assert_equal "b" * 100 + "y" * 100 + "1234", b
   assert_equal "b" * 100 + "y" * 50, b_slice
+
+  # The loop that made growth at the end quadratic: the slice shares the
+  # buffer again on every turn, and the append past it stays in place.
+  f = ""
+  50.times { f.insert(-1, "0123456789012345678901234567890123456789"); f[0, 30] }
+  assert_equal 2000, f.length
+  assert_equal "0123456789012345678901234567890123456789", f[-40, 40]
+
+  # The rest are contract rather than detection: what they write happens to
+  # land above the slice, or they take the buffer for reasons of their own.
 
   # `succ!` writes a terminator over the string before it grows, so it has to
   # hold the buffer by then whatever the growth does.

--- a/src/string.c
+++ b/src/string.c
@@ -4311,6 +4311,16 @@ str_bytesplice(mrb_state *mrb, mrb_value str, mrb_int idx1, mrb_int len1, mrb_va
   if (mrb_int_add_overflow(idx2, len2, &n) || RSTRING_LEN(replace) < n) {
     len2 = RSTRING_LEN(replace) - idx2;
   }
+  /* Splicing the empty range at the end is an append: it writes nothing any
+     sharer of the buffer can see, so mrb_str_cat() may grow the string inside
+     that buffer where mrb_str_modify() below would copy the whole of it first.
+     The frozen check mrb_str_modify() would make has to be made here as well,
+     since mrb_str_cat() makes none when handed nothing to append. */
+  if (idx1 == RSTR_LEN(s)) {
+    mrb_check_frozen(mrb, s);
+    return mrb_str_cat(mrb, str, RSTRING_PTR(replace) + idx2, (size_t)len2);
+  }
+
   mrb_str_modify(mrb, s);
   if (len1 >= len2) {
     memmove(RSTR_PTR(s)+idx1, RSTRING_PTR(replace)+idx2, len2);

--- a/src/string.c
+++ b/src/string.c
@@ -2009,6 +2009,18 @@ str_replace_partial(mrb_state *mrb, mrb_value src, mrb_int pos, mrb_int end, mrb
     mrb_raise(mrb, E_RUNTIME_ERROR, "string size too big");
   }
 
+  /* Replacing the empty range at the end is an append: it writes nothing any
+     sharer of the buffer can see, so mrb_str_cat() may grow the string inside
+     that buffer where mrb_str_modify() below would copy the whole of it first.
+     The frozen check mrb_str_modify() would make has to be made here as well,
+     since mrb_str_cat() makes none when handed nothing to append. */
+  if (pos == end && end == len && !mrb_nil_p(rep)) {
+    mrb_check_frozen(mrb, str);
+    mrb_str_cat(mrb, src, RSTRING_PTR(rep), (size_t)replen);
+    str_mark_spliced_binary(str, mrb_str_ptr(rep));
+    return src;
+  }
+
   mrb_str_modify(mrb, str);
 
   if (len < newlen) {

--- a/src/string.c
+++ b/src/string.c
@@ -1978,6 +1978,17 @@ str_out_of_index(mrb_state *mrb, mrb_value index)
   mrb_raisef(mrb, E_INDEX_ERROR, "index %v out of string", index);
 }
 
+/* Bytes spliced in mark the string they land in the way appended ones do:
+   byte-read bytes above ASCII spell no character here and hand their reading
+   over, ASCII bytes move nothing. */
+static void
+str_mark_spliced_binary(struct RString *str, struct RString *rep)
+{
+  if (!RSTR_BINARY_P(str) && RSTR_BINARY_P(rep) && !str_ascii_p(rep)) {
+    RSTR_ENCODING_SET(str, MRB_STR_ENCODING_BINARY);
+  }
+}
+
 static mrb_value
 str_replace_partial(mrb_state *mrb, mrb_value src, mrb_int pos, mrb_int end, mrb_value rep)
 {
@@ -2009,13 +2020,7 @@ str_replace_partial(mrb_state *mrb, mrb_value src, mrb_int pos, mrb_int end, mrb
   memmove(strp + newlen - (len - end), strp + end, len - end);
   if (!mrb_nil_p(rep)) {
     memmove(strp + pos, RSTRING_PTR(rep), replen);
-    /* bytes spliced in mark the string they land in the way appended ones
-       do: byte-read bytes above ASCII spell no character here and hand
-       their reading over, ASCII bytes move nothing */
-    struct RString *repp = mrb_str_ptr(rep);
-    if (!RSTR_BINARY_P(str) && RSTR_BINARY_P(repp) && !str_ascii_p(repp)) {
-      RSTR_ENCODING_SET(str, MRB_STR_ENCODING_BINARY);
-    }
+    str_mark_spliced_binary(str, mrb_str_ptr(rep));
   }
   RSTR_SET_LEN(str, newlen);
   strp[newlen] = '\0';

--- a/test/t/string.rb
+++ b/test/t/string.rb
@@ -400,6 +400,37 @@ assert('String[]=(UTF-8)') do
   assert_equal "➀➁➂➃➄", m
 end if UTF8STRING
 
+assert('String#[]= on a shared buffer') do
+  # Assigning to the empty range at the end appends, and an append writes
+  # only above what every other sharer of the buffer reads, so it stays in
+  # the buffer instead of taking a copy of it. The sharer must not see the
+  # bytes the string gained. Each string is shortened before it is shared, to
+  # leave spare capacity behind: one that has none cannot be grown in place
+  # anyway, so it would not tell the two behaviours apart.
+  a = "a" * 100 + "z" * 100
+  a[100, 100] = ""
+  a_slice = a[0, 60]
+  a[a.length, 0] = "1234567890"
+  assert_equal "a" * 100 + "1234567890", a
+  assert_equal "a" * 60, a_slice
+
+  # Assigning below the end writes where the sharer reads, so the buffer has
+  # to be taken away from it first.
+  b = "b" * 100 + "y" * 100
+  b[100, 100] = ""
+  b_slice = b[0, 60]
+  b[0, 1] = "1234567890"
+  assert_equal "1234567890" + "b" * 99, b
+  assert_equal "b" * 60, b_slice
+
+  # The loop that made growth at the end quadratic: the slice shares the
+  # buffer again on every turn, and the append past it stays in place.
+  c = ""
+  50.times { c[c.length, 0] = "0123456789012345678901234567890123456789"; c[0, 30] }
+  assert_equal 2000, c.length
+  assert_equal "0123456789012345678901234567890123456789", c[-40, 40]
+end
+
 assert('String#capitalize', '15.2.10.5.7') do
   a = 'abc'
   a.capitalize

--- a/test/t/string.rb
+++ b/test/t/string.rb
@@ -1445,4 +1445,20 @@ assert('String#bytesplice on a shared buffer') do
   b_slice.bytesplice(0, 1, "1234567890")
   assert_equal "1234567890" + "b" * 59, b_slice
   assert_equal "b" * 100, b
+
+  # Splicing the empty range at the end appends, and an append writes only
+  # above what the sharer reads, so it stays in the buffer.
+  c = "c" * 100 + "x" * 100
+  c.bytesplice(100, 100, "")
+  c_slice = c[0, 60]
+  c.bytesplice(c.bytesize, 0, "1234567890")
+  assert_equal "c" * 100 + "1234567890", c
+  assert_equal "c" * 60, c_slice
+
+  # The loop that made growth at the end quadratic: the slice shares the
+  # buffer again on every turn, and the append past it stays in place.
+  d = ""
+  50.times { d.bytesplice(d.bytesize, 0, "0123456789012345678901234567890123456789"); d[0, 30] }
+  assert_equal 2000, d.bytesize
+  assert_equal "0123456789012345678901234567890123456789", d.byteslice(-40, 40)
 end


### PR DESCRIPTION
## Summary

A string that shares its buffer with another string has to be unshared before it is written to, and `mrb_str_modify()` unshares by copying the whole buffer. `mrb_str_cat()` already exempts an append from that copy: an append writes only the bytes above the length every sharer of the buffer can see, so it may write inside the shared allocation, and the capacity it grows there is geometric.

Three more ways of growing a string at its end are appends by the same argument and were not treated as one. `String#insert` at the end, `String#bytesplice` of the empty range at the end and `String#[]=` to the empty range at the end each reached the generic `mrb_str_modify()` and took a copy of the whole string per call. In a loop where the buffer is shared again on every turn, growing this way is quadratic: at n=80000 the three took 25 to 30 seconds where `<<` took 0.011.

Each of the three now recognises the append it is about to make and hands it to `mrb_str_cat()`.

## Changes

| File | Change |
| --- | --- |
| `mrbgems/mruby-string-ext/src/string.c` | `str_insert()` hands an insert at the end to `mrb_str_cat()` |
| `src/string.c` | `str_bytesplice()` and `str_replace_partial()` do the same for the empty range at the end; the mark spliced-in bytes leave on the encoding gets a name, so both arms of `str_replace_partial()` can ask it |
| `test/t/string.rb` | `String#bytesplice` and `String#[]=` growing at the end against a live sharer |
| `mrbgems/mruby-string-ext/test/string.rb` | `String#insert` growing at the end against a live sharer |

### The three entry points

Each takes the branch only where the write starts at the end of the string, which is where no sharer of the buffer can see what is written:

- `str_insert()`, where the index is the length. The index is already normalised and range-checked by then, so `insert(-1, ...)` reaches it as well.
- `str_bytesplice()`, where `idx1` is the length. The clamping above it leaves `len1` at 0 there, so the branch covers exactly the empty range at the end.
- `str_replace_partial()`, where the replaced range is empty and sits at the length.

An insert or a splice anywhere below the end writes bytes a sharer still reads, so it keeps the copy: that is the copy earning its keep, not the one this removes.

### The frozen check

`mrb_str_cat()` returns a receiver it is handed nothing to append to untouched, frozen or not. `str_bytesplice()` and `str_replace_partial()` therefore ask `mrb_check_frozen()` in the branch, to keep the check `mrb_str_modify()` was making for them. `str_insert()` already checks before it normalises the index.

## Behaviour

The result, the bytes the sharer keeps reading, the errors raised and the encoding a spliced-in byte-read string moves the receiver to are all as before. What changes is that the receiver keeps sharing the buffer instead of taking it, and that the capacity it grows into is now geometric rather than exact, the same as for `<<`.

One answer gets sharper rather than staying the same: `mrb_str_cat()` carries a 7BIT receiver across an append of ASCII bytes, where `mrb_str_modify()` marked the code range unknown and left the next asker to walk the string. The three keep whatever `mrb_str_cat()` concludes.

## Speed

`build_config/default.rb`, `-g -O3`, gcc 13.3.0, the loop that shares the buffer again on every turn:

```ruby
n = ARGV[0].to_i
chunk = "abcdefghijabcdefghij"
s = ""
t0 = Time.now
case ARGV[1]
when "cat"        then n.times { s << chunk; s[0, 30] }
when "insert"     then n.times { s.insert(-1, chunk); s[0, 30] }
when "bytesplice" then n.times { s.bytesplice(s.bytesize, 0, chunk); s[0, 30] }
when "aset"       then n.times { s[s.length, 0] = chunk; s[0, 30] }
end
printf("mode=%s n=%d len=%d %.3fs\n", ARGV[1], n, s.bytesize, Time.now - t0)
```

| n | `<<` master | `<<` PR | `insert` master | `insert` PR | `bytesplice` master | `bytesplice` PR | `[]=` master | `[]=` PR |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 10000 | 0.002 s | 0.001 s | 0.195 s | 0.002 s | 0.437 s | 0.004 s | 0.143 s | 0.002 s |
| 20000 | 0.003 s | 0.003 s | 1.208 s | 0.003 s | 2.379 s | 0.003 s | 1.065 s | 0.004 s |
| 40000 | 0.005 s | 0.005 s | 5.730 s | 0.006 s | 8.553 s | 0.007 s | 6.323 s | 0.008 s |
| 80000 | 0.011 s | 0.010 s | 24.900 s | 0.027 s | 30.295 s | 0.015 s | 24.667 s | 0.015 s |

The three quadruple per doubling of n on master and double on this branch, which is where `<<` already was.

The paths that keep the copy are unchanged, and growing a string nobody shares is a little cheaper for the geometric capacity. n=40000, same loop with the slice dropped for the first three and with the write moved away from the end for the last three:

| loop body | master | PR |
| --- | ---: | ---: |
| `s.insert(-1, chunk)` | 0.005 s | 0.003 s |
| `s.bytesplice(s.bytesize, 0, chunk)` | 0.007 s | 0.004 s |
| `s[s.length, 0] = chunk` | 0.005 s | 0.005 s |
| `s.insert(0, chunk)` | 0.195 s | 0.195 s |
| `s.bytesplice(0, 1, chunk)` | 0.184 s | 0.188 s |
| `s[0, 1] = chunk` | 0.186 s | 0.188 s |

## Size

`.text` summed over the members of `libmruby.a`, `build_config/ci/gcc-clang.rb`, clean build directories at the same path:

| build | master | PR | delta |
| --- | ---: | ---: | ---: |
| full-debug | 1,926,227 | 1,926,692 | +465 |
| bintest | 1,318,446 | 1,318,878 | +432 |
| cxx_abi | 1,344,617 | 1,345,049 | +432 |
| byte-string | 1,283,951 | 1,284,271 | +320 |
| ascii-ctype | 1,305,021 | 1,305,453 | +432 |

## Testing

`rake -m test` over the five builds of `build_config/ci/gcc-clang.rb` at the branch tip, and over `build_config/default.rb` at every commit of this branch. All green, no compiler warnings.

The tests added are contract rather than detection: writing in place and copying the buffer answer alike, and only the time taken tells them apart. They pin what the sharer must keep reading across a growth at the end, and run the loop shape that was quadratic.

## Environment

- Linux x86\_64, gcc 13.3.0, clang 22.1.8
- `build_config/default.rb` for the timings, `build_config/ci/gcc-clang.rb` for the tests and the sizes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved performance for appending text or bytes to strings, reducing unnecessary copying and resizing.
  - Repeated append operations on shared or sliced strings are handled more efficiently.

- **Bug Fixes**
  - Preserved string encoding information during splice and append operations.
  - Improved handling of overlapping writes and shared string buffers while maintaining correct contents and lengths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->