### PR TITLE
gc.c: schedule collection on malloc growth by default

### DIFF
--- a/doc/guides/mrbconf.md
+++ b/doc/guides/mrbconf.md
@@ -128,6 +128,24 @@ end
 - Default value is `1024`.
 - Specifies number of `RBasic` per each heap page.
 
+`MRB_GC_MALLOC_THRESHOLD`
+
+- Default value is `16777216` (16MiB), the figure CRuby gives `malloc_limit`,
+  or `SIZE_MAX/4` on a target whose `size_t` cannot represent that.
+- Bytes of `mrb_realloc()` growth that schedule a collection, independent of
+  how many objects those bytes belong to.
+- Sets the initial value of `GC.malloc_threshold`, which can be changed at
+  run time; `0` disables byte-driven collection.
+- The counter behind it is cleared at the end of every collection cycle, so it
+  only accumulates while object-count scheduling is idle. A workload made of
+  ordinary objects never gets near the default: two million small allocations
+  peak at 188KB of accumulated growth, `benchmark/bm_ao_render.rb` at 710KB.
+  What reaches it is large buffers, which is what it exists to catch.
+- Lower it on a target whose memory budget is smaller than the default, or the
+  byte axis will never fire there. A figure on the order of the budget is the
+  right scale: on the two million allocation workload above, `65536` leaves
+  the collection count unchanged and `32768` adds 3% more minor collections.
+
 ## Memory pool configuration
 
 `POOL_ALIGNMENT`

--- a/doc/internal/gc.md
+++ b/doc/internal/gc.md
@@ -331,13 +331,19 @@ allocations can occur before the next GC cycle begins.
 
 ### Malloc Pressure
 
-When `gc->malloc_threshold` is set (non-zero), the GC also
-tracks bytes allocated through `mrb_realloc_simple()` in
-`gc->malloc_increase`. When `malloc_increase` exceeds
-`malloc_threshold`, the counter resets and an incremental GC
-step runs. This captures memory pressure from large buffers
-(e.g., long strings) that would otherwise be invisible to the
-object-count-based debt model.
+When `gc->malloc_threshold` is non-zero (it is `MRB_GC_MALLOC_THRESHOLD`
+by default), the GC also tracks bytes allocated through
+`mrb_realloc_simple()` in `gc->malloc_increase`. When
+`malloc_increase` reaches `malloc_threshold`, the counter resets
+and an incremental GC step runs. This captures memory pressure
+from large buffers (e.g., long strings) that would otherwise be
+invisible to the object-count-based debt model.
+
+Only a fresh allocation may step the collector here; a `realloc`
+has already freed the caller's old block and the caller has not
+yet stored the new pointer, so marking in that window would walk
+freed memory. Byte pressure from reallocs is not lost, it fires
+at the next fresh allocation.
 
 ### Manual
 
@@ -371,7 +377,7 @@ From Ruby code:
 GC.interval_ratio = 200     # controls debt credit after GC cycle
 GC.step_ratio = 200         # objects per incremental step
 GC.step_limit = 0           # 0=unlimited, >0=absolute step cap
-GC.malloc_threshold = 0     # 0=disabled, >0=bytes to trigger GC
+GC.malloc_threshold = 16777216 # 0=disabled, >0=bytes to trigger GC
 GC.generational_mode = true
 GC.start                     # force full GC
 GC.enable                    # re-enable GC
@@ -392,7 +398,7 @@ GC.stat
 #   :full => false,             # major GC in progress
 #   :step_limit => 0,           # current step limit setting
 #   :malloc_increase => 8192,   # malloc bytes since last cycle
-#   :malloc_threshold => 0,     # current malloc threshold setting
+#   :malloc_threshold => 16777216, # current malloc threshold setting
 # }
 ```
 
@@ -420,11 +426,14 @@ per incremental step regardless of `step_ratio`. Useful for
 real-time applications that need bounded pause times. The
 effective step size is `min(step_ratio calculation, step_limit)`.
 
-**`malloc_threshold`** (default 0, disabled): Triggers GC when
-cumulative `malloc`/`realloc` bytes exceed this threshold. Useful
-when applications allocate large buffers (strings, data objects)
-that create memory pressure without proportional object count
-increase.
+**`malloc_threshold`** (default `MRB_GC_MALLOC_THRESHOLD`, 16MiB,
+or `SIZE_MAX/4` where `size_t` is too narrow to hold that; 0
+disables it): Triggers GC when cumulative `malloc`/`realloc`
+bytes reach this threshold. This is what collects large buffers
+(strings, data objects) that create memory pressure without a
+proportional object count increase; without it a workload that
+churns buffers has no debt to pay and the collector never runs.
+Lower it to react sooner on a small memory budget.
 
 ### Practical Tuning Examples
 
@@ -456,12 +465,24 @@ This makes GC pauses more predictable but increases total GC
 overhead (more steps needed per cycle).
 
 **Large buffer workloads** (reading files, building long strings):
-Set `malloc_threshold` to trigger GC when buffer allocations
-accumulate, even if object count is low:
+`malloc_threshold` already collects these at its 16MiB default.
+Lower it to react sooner, at the cost of more collections:
 
 ```ruby
 GC.malloc_threshold = 1024 * 1024  # trigger GC per ~1MB allocated
 ```
+
+**Small memory budgets** (a target with a few hundred KiB of RAM):
+the default is inert there, because the counter is cleared at the end
+of every collection cycle and a small heap collects often enough that
+it never accumulates 16MiB. Measured high-water marks of
+`malloc_increase` on a host build: 188KB over two million small
+allocations, 710KB for `benchmark/bm_ao_render.rb`, and a small heap
+collects more often than either. To make the byte axis fire on such a
+target, set `MRB_GC_MALLOC_THRESHOLD` to something on the order of the
+memory budget. On the two million allocation workload, `65536` leaves
+the collection count unchanged and `32768` adds 3% more minor
+collections.
 
 ### Diagnosing GC Overhead
 

--- a/src/gc.c
+++ b/src/gc.c
@@ -530,8 +530,39 @@ mrb_gc_add_region(mrb_state *mrb, void *start, size_t size)
 
 #define DEFAULT_GC_INTERVAL_RATIO 200
 #define DEFAULT_GC_STEP_RATIO 200
+
 #define MAJOR_GC_INC_RATIO 120
 #define MAJOR_GC_TOOMANY 10000
+
+/* Bytes of malloc growth that schedule a collection, the byte counterpart of
+   the object count that gc_debt schedules on. A collection is worth running
+   when the process has churned this much through mrb_realloc(), however few
+   objects those bytes belong to. 16MiB is CRuby's malloc_limit. A port whose
+   memory budget is smaller than the figure it wants to react at overrides it;
+   a heap that never allocates this much simply never reaches the trigger and
+   is scheduled by object count alone, as before.
+
+   A target whose size_t cannot hold 16MiB gets a quarter of what it can hold
+   rather than a truncated constant; it should still name its own figure.
+
+   An override has to land in both types this value is seen through: size_t,
+   which holds it, and mrb_int, which GC.malloc_threshold and GC.stat report
+   it as. One too large for mrb_int would come back from those as a negative
+   number, so refuse it here rather than let it read back as something nobody
+   set. A negative one needs saying separately: it converts to size_t for the
+   SIZE_MAX comparison and passes it, then gets stored as the largest threshold
+   there is. Neither figure above can reach any of the three limits. */
+#ifndef MRB_GC_MALLOC_THRESHOLD
+# if SIZE_MAX < 16*1024*1024
+#  define MRB_GC_MALLOC_THRESHOLD (SIZE_MAX/4)
+# else
+#  define MRB_GC_MALLOC_THRESHOLD (16*1024*1024)
+# endif
+#endif
+mrb_static_assert((intmax_t)(MRB_GC_MALLOC_THRESHOLD) >= 0
+                  && MRB_GC_MALLOC_THRESHOLD <= SIZE_MAX
+                  && MRB_GC_MALLOC_THRESHOLD <= MRB_INT_MAX);
+
 #define is_generational(gc) ((gc)->generational)
 #define is_major_gc(gc) (is_generational(gc) && (gc)->full)
 #define is_minor_gc(gc) (is_generational(gc) && !(gc)->full)
@@ -551,6 +582,7 @@ mrb_gc_init(mrb_state *mrb, mrb_gc *gc)
   add_heap(mrb, gc);
   gc->interval_ratio = DEFAULT_GC_INTERVAL_RATIO;
   gc->step_ratio = DEFAULT_GC_STEP_RATIO;
+  gc->malloc_threshold = MRB_GC_MALLOC_THRESHOLD;
   gc->auto_step = TRUE;
   gc->sched_driven = FALSE;
 #ifndef MRB_GC_TURN_OFF_GENERATIONAL
@@ -1785,6 +1817,13 @@ mrb_full_gc(mrb_state *mrb)
   }
 
   incremental_gc_finish(mrb, gc);
+  /* Both axes start over: this collection has accounted for everything either
+     of them was counting. incremental_gc_run() clears malloc_increase when a
+     cycle it drove reaches MRB_GC_STATE_ROOT; the cycles here do not go
+     through it, so without this a full collection would leave the bytes it
+     just reclaimed still charged, and the next fresh allocation could cross
+     the threshold on pressure that no longer exists. */
+  gc->malloc_increase = 0;
   {
     mrb_int credit = (mrb_int)((gc->live_after_mark/100) * gc->interval_ratio)
                    - (mrb_int)gc->live_after_mark;
@@ -2036,13 +2075,15 @@ gc_step_limit_set(mrb_state *mrb, mrb_value obj)
  *     GC.malloc_threshold -> int
  *
  *  Returns the malloc-backed byte-growth threshold that triggers an
- *  incremental GC cycle (0 = disabled). Unlike GC.debt (which counts
- *  objects), this catches workloads that allocate few but large
- *  malloc-backed payloads (long String/Array buffers). It fires in two
- *  places: the ordinary allocation path triggers GC.start's incremental
- *  counterpart once malloc growth crosses this threshold even in stock
- *  auto_step mode, and mruby-task's GC.scheduler_driven also treats crossing
- *  it as a reason to step.
+ *  incremental GC cycle (0 = disabled, default MRB_GC_MALLOC_THRESHOLD).
+ *  Unlike GC.debt (which counts objects), this catches workloads that
+ *  allocate few but large malloc-backed payloads (long String/Array
+ *  buffers). The ordinary allocation path triggers GC.start's incremental
+ *  counterpart once malloc growth reaches this threshold, even in stock
+ *  auto_step mode. mruby-task's GC.scheduler_driven does not read the
+ *  threshold at all: any byte growth is reason enough to spend idle time
+ *  stepping, so 0 stops byte growth from driving collection here but not
+ *  there.
  */
 static mrb_value
 gc_malloc_threshold_get(mrb_state *mrb, mrb_value obj)

--- a/test/t/gc.rb
+++ b/test/t/gc.rb
@@ -62,7 +62,8 @@ end
 assert('GC.malloc_threshold=') do
   origin = GC.malloc_threshold
   begin
-    assert_equal 0, origin           # default: disabled
+    # No assertion on `origin`: the initial value is MRB_GC_MALLOC_THRESHOLD,
+    # which a build may set to anything including 0.
     assert_equal 65536, (GC.malloc_threshold = 65536)
     assert_equal 65536, GC.malloc_threshold
     assert_equal 0, (GC.malloc_threshold = 0)  # back to disabled


### PR DESCRIPTION
## Summary

`GC.malloc_threshold` defaults to 0, so nothing schedules a collection out of
the box except the per-object `gc_debt`. A buffer is one object however many
bytes it holds, so a workload that churns large `String` or `Array` payloads
pays almost no debt and the collector barely runs.

The 200 iteration slice-then-append loop below moves 630MB through
`mrb_realloc()`, drives one collection over the whole loop, and peaks at
135MB. CRuby 4.0.6 peaks at 52MB on it. With a default it peaks at 42MB.

```ruby
src = "x" * (1024 * 1024)
200.times do
  t = src[0, src.size]
  t << "y"
end
```

## Changes

| Change                                    | Where                  |
| ----------------------------------------- | ---------------------- |
| `GC.malloc_threshold` starts at 16MiB     | `mrb_gc_init()`        |
| A full collection clears the byte counter | `mrb_full_gc()`        |
| Build-time override, and its scale        | `doc/`, `test/t/gc.rb` |

`GC.malloc_threshold` starts at `MRB_GC_MALLOC_THRESHOLD`, 16MiB, the figure
CRuby gives `malloc_limit`. It stays settable at run time and `0` still
disables byte-driven collection. The macro scales itself to `SIZE_MAX/4`
where `size_t` cannot hold 16MiB, so a target that small gets a figure it can
represent rather than a truncated constant.

### `mrb_full_gc()` has to clear `malloc_increase`

`incremental_gc_run()` clears the counter when a cycle it drove reaches
`MRB_GC_STATE_ROOT`, but the cycles `mrb_full_gc()` finishes do not go through
it, so a full collection left the bytes it had just reclaimed still charged.
On master:

```
before GC.start: 1450876
after  GC.start: 1451244
```

Nothing observed that while the default was 0. With a default in place it
means `GC.start` can be followed immediately by a collection driven by
pressure that no longer exists, so this clears it. The comment on the test
below it, `GC.start # reset malloc_increase`, now describes what happens
rather than what was meant.

### Nothing made of ordinary objects reaches the threshold

`malloc_increase` only accumulates while object-count scheduling is idle.
High-water marks below come from a throwaway patch that records the largest
value the counter ever holds, run with the trigger disabled so nothing resets
it early:

| Workload                        | peak `malloc_increase` |
| ------------------------------- | ---------------------- |
| two million small allocations   | 188KB                  |
| `benchmark/bm_so_mandelbrot.rb` | 196KB                  |
| `benchmark/bm_ao_render.rb`     | 710KB                  |
| `benchmark/bm_so_lists.rb`      | 16.9MB                 |
| the loop above                  | 630MB                  |

Only the last two reach 16MiB. `bm_so_mandelbrot.rb` runs 215 minor and 10
major collections with the default in place, and the same 215 and 10 with it
at 0.

### Small memory budgets

The same property makes the default inert on a target with a few hundred KiB
of RAM: a small heap has a small live set, so `gc_debt` hands out small
credits, so cycles complete often and the counter never builds up. The 188KB
above is a host build with a live set in the thousands; a 256KiB target sits
below it.

Such a target sets the macro to something on the order of its budget, which
is cheap. On the two million allocation workload, by the value the macro
would install:

| threshold    | minor GC | major GC | wall  |
| ------------ | -------- | -------- | ----- |
| 0 (disabled) | 5828     | 50       | 0.60s |
| 256KiB       | 5828     | 50       | 0.57s |
| 128KiB       | 5828     | 50       | 0.52s |
| 64KiB        | 5828     | 50       | 0.52s |
| 32KiB        | 6007     | 52       | 0.53s |

`doc/guides/mrbconf.md` and `doc/internal/gc.md` carry these figures.

### Scheduler-driven builds are untouched

The trigger condition includes `gc.auto_step`, so a build that hands GC to the
task scheduler (`GC.scheduler_driven`) or turns auto stepping off does not
gain a synchronous collection from this. Byte pressure reaches those builds
the way it already did, through `mrb_gc_scheduler_pending()`.

## Behaviour

Peak RSS, `/usr/bin/time -f %M`:

| Workload                        | master   | PR      |
| ------------------------------- | -------- | ------- |
| the loop above                  | 134992kB | 42032kB |
| `benchmark/bm_so_lists.rb`      | 53636kB  | 13484kB |
| `benchmark/bm_ao_render.rb`     | 3604kB   | 3860kB  |
| `benchmark/bm_so_mandelbrot.rb` | 3352kB   | 3600kB  |
| `benchmark/bm_fib.rb`           | 3268kB   | 2992kB  |

The last three never reach the threshold; their spread is run to run noise on
a 3.5MB footprint.

## Speed

Best of seven, wall clock:

| Workload                        | master | PR    |
| ------------------------------- | ------ | ----- |
| the loop above                  | 0.15s  | 0.04s |
| `benchmark/bm_so_lists.rb`      | 0.39s  | 0.36s |
| `benchmark/bm_so_mandelbrot.rb` | 1.02s  | 1.08s |

`bm_so_mandelbrot.rb` is 6% slower here and the threshold is not what does
it. Within one binary the benchmark takes 1.08 to 1.11s whether the default
is in place or set to 0, on the same 215 minor and 10 major collections
either way. Across the two binaries the gap survives setting the threshold to
0 in both, 1.03s against 1.09s, which leaves code layout: this patch adds two
stores and moves everything after them.

## Size

`.text` of `libmruby.a`, `ci/gcc-clang`:

| Build       | master  | PR      | delta |
| ----------- | ------- | ------- | ----- |
| full-debug  | 1926710 | 1926740 | +30   |
| bintest     | 1318556 | 1318604 | +48   |
| cxx_abi     | 1342253 | 1342269 | +16   |
| byte-string | 1283933 | 1283981 | +48   |
| ascii-ctype | 1305115 | 1305163 | +48   |

## Testing

`MRUBY_CONFIG=ci/gcc-clang rake -m test`: all five builds green, including
`full-debug` with `MRB_GC_STRESS`. Also green on a 32-bit build
(`i686-linux-gnu-gcc`), where `size_t` is half as wide.

`GC.malloc_threshold=` asserted the default was 0. It asserts nothing about
the initial value now: that value is `MRB_GC_MALLOC_THRESHOLD`, which a build
may set to anything, 0 included, so a test cannot pin it.

## Environment

- AMD Ryzen 9 5950X, Linux 7.0.0-30-generic x86_64
- gcc 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1), i686-linux-gnu-gcc 13.3.0
- ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Garbage collection now uses a configurable default allocation threshold of 16 MiB, with size-appropriate defaults on smaller systems.
  - The threshold can be adjusted at runtime.
  - Full collections reset accumulated allocation growth, improving scheduling consistency.

- **Documentation**
  - Added guidance on threshold behavior, large allocations, reallocation, configuration, and memory-constrained workloads.
  - Updated runtime examples and garbage-collection statistics to reflect the new default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->