### PR TITLE
string, array, hash: check a frozen receiver where a destructive call writes nothing

### DIFF
--- a/mrbgems/mruby-array-ext/mrblib/array.rb
+++ b/mrbgems/mruby-array-ext/mrblib/array.rb
@@ -16,6 +16,10 @@ class Array
   #    c.uniq! { |s| s.first } # => [["student", "sam"], ["teacher", "matz"]]
   #
   def uniq!(&block)
+    # The block form below answers nil without touching the array when it
+    # holds no duplicate, and __uniq! returns early for one element or none.
+    raise FrozenError, "can't modify frozen #{self.class}" if frozen?
+
     if block
       hash = {}
       result = []
@@ -155,6 +159,11 @@ class Array
     start, length = __fill_parse_arg(arg0, arg1, arg2, &block)
 
     if block
+      # A run of zero elements assigns nothing below, so nothing on this path
+      # asks whether the receiver may be written to. __fill_exec answers for
+      # the value form. Asked before the block runs, as CRuby does.
+      raise FrozenError, "can't modify frozen #{self.class}" if frozen?
+
       # Block-based filling in Ruby
       i = start
       while i < start + length
@@ -218,6 +227,9 @@ class Array
 
   def reject!(&block)
     return to_enum(:reject!) unless block
+    # Rejecting nothing skips the `replace` below, which is what would
+    # otherwise refuse a frozen receiver.
+    raise FrozenError, "can't modify frozen #{self.class}" if frozen?
 
     result = []
     idx = 0
@@ -390,6 +402,9 @@ class Array
 
   def select!(&block)
     return to_enum(:select!) unless block
+    # Keeping every element skips the `replace` below, which is what would
+    # otherwise refuse a frozen receiver.
+    raise FrozenError, "can't modify frozen #{self.class}" if frozen?
 
     result = []
     idx = 0

--- a/mrbgems/mruby-array-ext/src/array.c
+++ b/mrbgems/mruby-array-ext/src/array.c
@@ -1072,7 +1072,13 @@ ary_fill_exec(mrb_state *mrb, mrb_value self)
   }
 
   /* Ensure we don't go beyond array bounds */
-  if (start >= ARY_LEN(ary) || length <= 0) return self;
+  if (start >= ARY_LEN(ary) || length <= 0) {
+    /* Nothing to fill, so this returns ahead of the mrb_ary_modify() below
+       that turns a frozen receiver away. The fill is a destructive call
+       whatever the run comes to, so it is asked here. */
+    mrb_check_frozen(mrb, ary);
+    return self;
+  }
   if (end > ARY_LEN(ary)) {
     length = ARY_LEN(ary) - start;
   }
@@ -1134,6 +1140,10 @@ ary_uniq_bang(mrb_state *mrb, mrb_value self)
   mrb_int len = RARRAY_LEN(self);
 
   if (len <= 1) {
+    /* No room for a duplicate, so this returns without reaching the
+       mrb_ary_modify() below that turns a frozen receiver away. The call is
+       destructive at any length, so it is asked here. */
+    mrb_check_frozen(mrb, mrb_ary_ptr(self));
     return mrb_nil_value();
   }
 
@@ -1394,6 +1404,9 @@ ary_insert(mrb_state *mrb, mrb_value self)
   mrb_get_args(mrb, "i*", &idx, &argv, &argc);
 
   if (argc == 0) {
+    /* Inserting nothing is still an insert, and this returns ahead of the
+       mrb_ary_modify() below that a frozen receiver would have met. */
+    mrb_check_frozen(mrb, mrb_ary_ptr(self));
     return self;
   }
 

--- a/mrbgems/mruby-array-ext/test/array.rb
+++ b/mrbgems/mruby-array-ext/test/array.rb
@@ -64,6 +64,19 @@ assert("Array#uniq!") do
   assert_nil d.uniq! { |s| s.first }
 end
 
+assert("Array - a frozen receiver of a call that writes nothing") do
+  # Each of these leaves the array as it was and used to return before the
+  # write that carries the frozen check.
+  assert_raise(FrozenError) { [].freeze.uniq! }
+  assert_raise(FrozenError) { [1].freeze.uniq! }
+  assert_raise(FrozenError) { [1, 2].freeze.uniq! { |e| e } }
+  assert_raise(FrozenError) { [1, 2].freeze.insert(0) }
+  assert_raise(FrozenError) { [1, 2].freeze.fill(9, 0, 0) }
+  assert_raise(FrozenError) { [1, 2].freeze.fill(0, 0) { |i| i } }
+  assert_raise(FrozenError) { [1, 2].freeze.reject! { false } }
+  assert_raise(FrozenError) { [1, 2].freeze.select! { true } }
+end
+
 assert("Array#uniq") do
   a = [1, 2, 3, 1]
   assert_equal [1, 2, 3], a.uniq

--- a/mrbgems/mruby-hash-ext/mrblib/hash.rb
+++ b/mrbgems/mruby-hash-ext/mrblib/hash.rb
@@ -28,6 +28,9 @@ class Hash
   def merge!(*others, &block)
     i = 0; len=others.size
     return self.__merge(*others) unless block
+    # With a block, an empty `others` (or empty hashes in it) assigns nothing
+    # below, so nothing on that path asks about a frozen receiver.
+    raise FrozenError, "can't modify frozen #{self.class}" if frozen?
     while i<len
       other = others[i]
       i += 1
@@ -130,6 +133,9 @@ class Hash
 
   def delete_if(&block)
     return to_enum(:delete_if) unless block
+    # An empty hash, or a block that keeps every pair, never reaches the
+    # `delete` below that would refuse a frozen receiver.
+    raise FrozenError, "can't modify frozen #{self.class}" if frozen?
 
     self.each do |k, v|
       self.delete(k) if block.call(k, v)
@@ -187,6 +193,9 @@ class Hash
 
   def keep_if(&block)
     return to_enum(:keep_if) unless block
+    # An empty hash, or a block that keeps every pair, never reaches the
+    # `delete` below that would refuse a frozen receiver.
+    raise FrozenError, "can't modify frozen #{self.class}" if frozen?
 
     self.each do |k, v|
       unless block.call([k, v])
@@ -372,6 +381,9 @@ class Hash
   #
   def transform_values!(&b)
     return to_enum(:transform_values!) unless block_given?
+    # An empty hash assigns nothing below, so no `[]=` asks about a frozen
+    # receiver.
+    raise FrozenError, "can't modify frozen #{self.class}" if frozen?
     self.keys.each do |k|
       self[k] = yield(self[k])
     end

--- a/mrbgems/mruby-hash-ext/test/hash.rb
+++ b/mrbgems/mruby-hash-ext/test/hash.rb
@@ -104,6 +104,17 @@ assert('Hash#fetch') do
   end
 end
 
+assert("Hash - a frozen receiver of a call that writes nothing") do
+  # Each of these leaves the hash as it was and used to return before the
+  # write that carries the frozen check.
+  assert_raise(FrozenError) { {a: 1}.freeze.merge!({}) { |*x| x } }
+  assert_raise(FrozenError) { {}.freeze.delete_if { true } }
+  assert_raise(FrozenError) { {}.freeze.keep_if { true } }
+  assert_raise(FrozenError) { {a: 1}.freeze.delete_if { false } }
+  assert_raise(FrozenError) { {a: 1}.freeze.keep_if { true } }
+  assert_raise(FrozenError) { {}.freeze.transform_values! { |v| v } }
+end
+
 assert("Hash#delete_if") do
   base = { 1 => 'one', 2 => false, true => 'true', 'cat' => 99 }
   h1   = { 1 => 'one', 2 => false, true => 'true' }

--- a/mrbgems/mruby-string-ext/src/string.c
+++ b/mrbgems/mruby-string-ext/src/string.c
@@ -2545,12 +2545,14 @@ str_prepend(mrb_state *mrb, mrb_value self)
   mrb_int argc;
   mrb_get_args(mrb, "*", &argv, &argc);
 
+  struct RString *s = mrb_str_ptr(self);
+  /* Ahead of the return for no arguments below: prepending nothing is still
+     a prepend, and a frozen receiver answers FrozenError either way. */
+  mrb_check_frozen(mrb, s);
+
   if (argc == 0) {
     return self;
   }
-
-  struct RString *s = mrb_str_ptr(self);
-  mrb_check_frozen(mrb, s);
 
   /* Calculate total length needed for all prepended strings */
   mrb_int total_prepend_len = 0;

--- a/mrbgems/mruby-string-ext/test/string.rb
+++ b/mrbgems/mruby-string-ext/test/string.rb
@@ -219,6 +219,23 @@ assert('String#concat') do
   end
 end
 
+assert('String#concat - a frozen receiver with nothing to append') do
+  # An append of no bytes writes nothing and used to return before reaching
+  # the frozen check, which sits with the write.
+  assert_raise(FrozenError) { "abc".freeze << "" }
+  assert_raise(FrozenError) { "abc".freeze.concat("") }
+  assert_raise(FrozenError) { "".freeze << "" }
+  assert_raise(FrozenError) { "abc".freeze.append_as_bytes("") }
+  # An append that has bytes to add answers the same way.
+  assert_raise(FrozenError) { "abc".freeze << "d" }
+end
+
+assert('String#prepend - a frozen receiver with nothing to prepend') do
+  assert_raise(FrozenError) { "abc".freeze.prepend() }
+  assert_raise(FrozenError) { "abc".freeze.prepend("") }
+  assert_raise(FrozenError) { "abc".freeze.prepend("d") }
+end
+
 assert('String#concat on a shared buffer') do
   # An append to a string that shares its buffer writes into the spare
   # capacity above what every other sharer can see, and each sharer has to

--- a/mrblib/array.rb
+++ b/mrblib/array.rb
@@ -55,6 +55,9 @@ class Array
   # ISO 15.2.12.5.7
   def collect!(&block)
     return to_enum(:collect!) unless block
+    # An empty array assigns no element below, so nothing else on this path
+    # asks whether the receiver may be written to.
+    raise FrozenError, "can't modify frozen #{self.class}" if frozen?
 
     idx = 0
     len = size

--- a/mrblib/hash.rb
+++ b/mrblib/hash.rb
@@ -166,6 +166,9 @@ class Hash
   #
   def reject!(&block)
     return to_enum(:reject!) unless block
+    # Nothing to reject means no `delete` below, and `delete` is what would
+    # otherwise refuse a frozen receiver.
+    raise FrozenError, "can't modify frozen #{self.class}" if frozen?
 
     keys = []
     self.each {|k,v|
@@ -219,6 +222,9 @@ class Hash
   #
   def select!(&block)
     return to_enum(:select!) unless block
+    # Keeping every pair means no `delete` below, and `delete` is what would
+    # otherwise refuse a frozen receiver.
+    raise FrozenError, "can't modify frozen #{self.class}" if frozen?
 
     keys = []
     self.each {|k,v|

--- a/src/array.c
+++ b/src/array.c
@@ -468,6 +468,13 @@ mrb_ary_init(mrb_state *mrb, mrb_value ary)
   mrb_int size = mrb_as_int(mrb, ss);
   struct RArray *a = mrb_ary_ptr(ary);
 
+  /* Rebuilding an array through `initialize` writes over whatever it held,
+     and nothing below this point asks whether that is allowed: a size of
+     zero writes nothing at all, and the loop that fills a larger one writes
+     through no helper that checks. The branch above goes through
+     ary_replace(), which opens with the same check. */
+  ary_modify_check(mrb, a);
+
   if (ARY_CAPA(a) < size) {
     ary_expand_capa(mrb, a, size);
   }
@@ -646,6 +653,12 @@ mrb_ary_replace(mrb_state *mrb, mrb_value self, mrb_value other)
   if (a1 != a2) {
     ary_replace(mrb, a1, a2);
   }
+  else {
+    /* Replacing an array with itself leaves it as it was, so ary_replace()
+       and the frozen check it opens with are skipped. The call still asks to
+       write, and a frozen receiver answers FrozenError for it. */
+    ary_modify_check(mrb, a1);
+  }
 }
 
 /*
@@ -747,6 +760,12 @@ mrb_ary_reverse_bang(mrb_state *mrb, mrb_value self)
       *p1++ = *p2;
       *p2-- = tmp;
     }
+  }
+  else {
+    /* One element or none reverses into itself, so the ary_modify() above,
+       which is where a frozen receiver is turned away, is never reached.
+       The call is destructive at any length, so it is asked here. */
+    ary_modify_check(mrb, a);
   }
   return self;
 }
@@ -2406,7 +2425,13 @@ mrb_ary_sort_bang(mrb_state *mrb, mrb_value ary)
   mrb_value blk;
 
   mrb_int n = RARRAY_LEN(ary);
-  if (n < 2) return ary;
+  if (n < 2) {
+    /* Already sorted, so this returns without reaching the ary_modify()
+       below, which is where a frozen receiver would have been turned away.
+       The sort is a destructive call at any length, so it is asked here. */
+    ary_modify_check(mrb, mrb_ary_ptr(ary));
+    return ary;
+  }
 
   ary_modify(mrb, mrb_ary_ptr(ary));
   mrb_get_args(mrb, "&", &blk);

--- a/src/string.c
+++ b/src/string.c
@@ -2012,10 +2012,9 @@ str_replace_partial(mrb_state *mrb, mrb_value src, mrb_int pos, mrb_int end, mrb
   /* Replacing the empty range at the end is an append: it writes nothing any
      sharer of the buffer can see, so mrb_str_cat() may grow the string inside
      that buffer where mrb_str_modify() below would copy the whole of it first.
-     The frozen check mrb_str_modify() would make has to be made here as well,
-     since mrb_str_cat() makes none when handed nothing to append. */
+     mrb_str_cat() checks the frozen receiver on every length, so the check
+     mrb_str_modify() would have made is not lost. */
   if (pos == end && end == len && !mrb_nil_p(rep)) {
-    mrb_check_frozen(mrb, str);
     mrb_str_cat(mrb, src, RSTRING_PTR(rep), (size_t)replen);
     str_mark_spliced_binary(str, mrb_str_ptr(rep));
     return src;
@@ -3101,7 +3100,13 @@ mrb_str_reverse_bang(mrb_state *mrb, mrb_value str)
   mrb_int utf8_len = mrb_str_char_len(mrb, str);
   mrb_int len = RSTR_LEN(s);
 
-  if (utf8_len < 2) return str;
+  if (utf8_len < 2) {
+    /* One character or none reverses into itself and returns here, ahead of
+       the str_modify_keep_cr() below that turns a frozen receiver away. The
+       call is destructive at any length, so it is asked here. */
+    mrb_check_frozen(mrb, s);
+    return str;
+  }
   if (utf8_len < len) {
     str_modify_keep_cr(mrb, s);
     p = RSTR_PTR(s);
@@ -3121,6 +3126,8 @@ mrb_str_reverse_bang(mrb_state *mrb, mrb_value str)
     str_modify_keep_cr(mrb, s);
     goto bytes;
   }
+  /* As above, for a build that reads one character per byte. */
+  mrb_check_frozen(mrb, s);
   return str;
 
  bytes:
@@ -3945,7 +3952,14 @@ mrb_str_cat(mrb_state *mrb, mrb_value str, const char *ptr, size_t len)
   struct RString *s = mrb_str_ptr(str);
   ptrdiff_t off = -1;
 
-  if (len == 0) return str;
+  /* An append of nothing writes nothing, but it is still an append, and the
+     only frozen check on this path is the one the modify below runs. Asking
+     here keeps `str << ""` answering FrozenError like an append that has
+     bytes to add, instead of passing over a frozen receiver in silence. */
+  if (len == 0) {
+    mrb_check_frozen(mrb, s);
+    return str;
+  }
   /* `len` has to be known to fit in an `mrb_int` before it is used as one:
      the conversion is otherwise free to make it negative, and the overflow
      check takes `mrb_int` parameters, so it would not see it. Checking ahead
@@ -4331,10 +4345,9 @@ str_bytesplice(mrb_state *mrb, mrb_value str, mrb_int idx1, mrb_int len1, mrb_va
   /* Splicing the empty range at the end is an append: it writes nothing any
      sharer of the buffer can see, so mrb_str_cat() may grow the string inside
      that buffer where mrb_str_modify() below would copy the whole of it first.
-     The frozen check mrb_str_modify() would make has to be made here as well,
-     since mrb_str_cat() makes none when handed nothing to append. */
+     mrb_str_cat() checks the frozen receiver on every length, so the check
+     mrb_str_modify() would have made is not lost. */
   if (idx1 == RSTR_LEN(s)) {
-    mrb_check_frozen(mrb, s);
     return mrb_str_cat(mrb, str, RSTRING_PTR(replace) + idx2, (size_t)len2);
   }
 

--- a/test/t/array.rb
+++ b/test/t/array.rb
@@ -587,6 +587,20 @@ assert('Array#freeze') do
   end
 end
 
+assert('Array - a frozen receiver of a call that writes nothing') do
+  # Each of these leaves the array as it was and used to return before the
+  # write that carries the frozen check.
+  assert_raise(FrozenError) { [].freeze.reverse! }
+  assert_raise(FrozenError) { [1].freeze.reverse! }
+  assert_raise(FrozenError) { [].freeze.sort! }
+  assert_raise(FrozenError) { [1].freeze.sort! }
+  assert_raise(FrozenError) { [].freeze.collect! { |e| e } }
+  assert_raise(FrozenError) { [].freeze.map! { |e| e } }
+  assert_raise(FrozenError) { [1, 2].freeze.__send__(:initialize) }
+  a = [1, 2].freeze
+  assert_raise(FrozenError) { a.replace(a) }
+end
+
 assert('Array#delete') do
   a = ["a", "b", "c"]
   assert_equal nil, a.delete("x")

--- a/test/t/hash.rb
+++ b/test/t/hash.rb
@@ -845,11 +845,15 @@ end
       assert_equal(pairs, h.to_a)
 
       assert_raise(FrozenError){h.freeze.__send__(meth, &filter)}
+      # A block that leaves every pair where it is never reaches the delete
+      # that carries the frozen check.
+      assert_raise(FrozenError){h.freeze.__send__(meth){meth == :select!}}
     end
 
     h = {}
     assert_nil(h.__send__(meth){})
     assert_predicate(h, :empty?)
+    assert_raise(FrozenError){{}.freeze.__send__(meth){}}
   end
 end
 

--- a/test/t/string.rb
+++ b/test/t/string.rb
@@ -908,6 +908,28 @@ assert('String#reverse!', '15.2.10.5.30') do
   assert_equal 'cba', 'abc'.reverse!
 end
 
+assert('String#reverse! - a frozen receiver') do
+  # A string of one character or none reverses into itself and returns
+  # without writing, which is where the frozen check used to sit.
+  assert_raise(FrozenError) { ''.freeze.reverse! }
+  assert_raise(FrozenError) { 'a'.freeze.reverse! }
+  assert_raise(FrozenError) { 'ab'.freeze.reverse! }
+end
+
+assert('String#reverse!(UTF-8) - a frozen receiver') do
+  # One character of several bytes is the same early return, reached by the
+  # character count rather than the byte count.
+  assert_raise(FrozenError) { 'あ'.freeze.reverse! }
+end if UTF8STRING
+
+assert('String - a frozen receiver of an empty splice at the end') do
+  # The empty splice at the end is handed to mrb_str_cat() as an append of
+  # no bytes, whose frozen check covers what the callers used to ask.
+  assert_raise(FrozenError) { 'abc'.freeze.bytesplice(3, 0, '') }
+  s = 'abc'.freeze
+  assert_raise(FrozenError) { s[3, 0] = '' }
+end
+
 assert('String#reverse!(UTF-8)', '15.2.10.5.30') do
   a = 'こんにちは世界!'
   a.reverse!


### PR DESCRIPTION
## Summary

`"abc".freeze << ""` returns the string and raises nothing, where CRuby raises `FrozenError`.

The cause is not that one early return. mruby keeps the frozen check inside the thing that writes: `mrb_str_modify()` and `str_modify_cat()` for a String, `ary_modify()` for an Array, and for a Hash the `delete` and `[]=` its Ruby-level methods call. So any path that finds it has nothing to write returns before reaching a check, and a frozen receiver is passed over in silence. CRuby asks at the entry of the method instead. `mrb_str_cat()`'s `if (len == 0) return str;` is one instance of a shape that repeats across String, Array and Hash.

Sweeping every destructive method against CRuby 4.0.6 turned up 22 of them across the three types, in 14 shapes:

| call | before | CRuby |
|---|---|---|
| `"abc".freeze << ""` / `.concat("")` / `.append_as_bytes("")` | no raise | FrozenError |
| `"".freeze.reverse!` / `"a".freeze.reverse!` | no raise | FrozenError |
| `"abc".freeze.prepend()` | no raise | FrozenError |
| `[].freeze.reverse!` / `[1].freeze.reverse!` | no raise | FrozenError |
| `[].freeze.sort!` / `[1].freeze.sort!` | no raise | FrozenError |
| `[1,2].freeze.uniq! { \|e\| e }` | no raise | FrozenError |
| `[1,2].freeze.insert(0)` | no raise | FrozenError |
| `[1,2].freeze.fill(9, 0, 0)` (and the block form) | no raise | FrozenError |
| `[].freeze.map!` / `.collect!` | no raise | FrozenError |
| `[1,2].freeze.reject! { false }` / `.select! { true }` | no raise | FrozenError |
| `a = [1,2].freeze; a.replace(a)` | no raise | FrozenError |
| `[1,2].freeze.__send__(:initialize)` | no raise | FrozenError |
| `{a: 1}.freeze.merge!({}) { }` | no raise | FrozenError |
| `{}.freeze.delete_if { }` / `.keep_if { }` / `.transform_values! { }` / `{a: 1}.freeze.reject! { false }` / `.select! { true }` | no raise | FrozenError |

`String#reverse!` widens in a `MRB_UTF8_STRING` build, where the early return is `utf8_len < 2`: any single character, multi-byte included.

The C API has the same hole through `mrb_str_cat(mrb, str, ptr, 0)`.

## Changes

| File | What |
|---|---|
| `src/string.c` | `mrb_str_cat()` and `mrb_str_reverse_bang()` ask on the path that writes nothing; the two checks `str_bytesplice()` and `str_replace_partial()` carried for this hole are dropped |
| `mrbgems/mruby-string-ext/src/string.c` | `str_prepend()` asks ahead of its return for no arguments |
| `src/array.c` | `mrb_ary_reverse_bang()`, `mrb_ary_sort_bang()`, `mrb_ary_replace()` and `mrb_ary_init()` ask where they leave without writing |
| `mrbgems/mruby-array-ext/src/array.c` | the same for `ary_fill_exec()`, `ary_uniq_bang()` and `ary_insert()` |
| `mrblib/array.rb`, `mrbgems/mruby-array-ext/mrblib/array.rb` | `collect!`, `uniq!`, `fill` with a block, `reject!` and `select!` ask before the block runs |
| `mrblib/hash.rb`, `mrbgems/mruby-hash-ext/mrblib/hash.rb` | the same for `reject!`, `select!`, `delete_if`, `keep_if`, `merge!` with a block and `transform_values!` |
| `test/t/{string,array,hash}.rb`, `mrbgems/mruby-{string,array,hash}-ext/test/*.rb` | regression tests beside the methods they cover |

### Where the check goes in C

Each of these paths asks about the receiver where it leaves, not at the top of the method, so a call that does write pays for no second check: the one the write helper already runs is still the only one it meets. `mrb_str_cat()` is the exception, since its early return is what the C API reaches for an append of no bytes, and that is the hole the C API has.

`mrb_ary_init()` is the one place the check is added ahead of the write rather than on a return: `initialize` rebuilds the array through `mrb_ary_set()`, which carries no frozen check, so no length of it was covered. Its `Array.new(ary)` branch goes through `ary_replace()`, which opens with the same check, and is left alone.

### Where the check goes in Ruby

`raise FrozenError, "can't modify frozen #{self.class}" if frozen?` at the entry of the method, which is the idiom `String#sub!` and `String#gsub!` already use in `mrblib/string.rb`. It sits after the `to_enum` guard, so a frozen receiver with no block still answers an `Enumerator` as CRuby does, and before the block runs, which is where CRuby asks.

### Left alone on purpose

- `Array#delete` for an element that is not there, and `Array#delete_at` for an index out of range. CRuby does not raise for either, and mruby already matched.
- `String#initialize` on a frozen receiver, where mruby raises and CRuby does not. Pre-existing, unrelated to the paths here.
- `Hash#merge!()` and `#update()` with neither argument nor block answer `ArgumentError` where CRuby answers `FrozenError`. That is an arity difference (`__merge` wants 1+), not a frozen one. Given a block the same call now answers `FrozenError`, since it no longer reaches `__merge`.
- `[1,2].freeze.insert("x")` and `[1,2].freeze.__send__(:initialize, "x")` answer `TypeError` where CRuby answers `FrozenError`, because `mrb_get_args()` converts before the body runs. Unchanged by this PR, and CRuby is not uniform here either: `[1,2].freeze.fill(9, "x")` answers `TypeError` in both.

Three commits, one per type, each green on its own.

## Behaviour

Every call in the sweep now answers `FrozenError`, matching CRuby 4.0.6 on all 31 of them. A call with something to write answers as before, and no unfrozen receiver changes.

Two answers move rather than appear:

- The Ruby-level methods ask before the block runs, so `[1,2,3].freeze.map! { }` raises before the first yield instead of after it, as in CRuby.
- `[1].freeze.uniq!` answered `nil`; it now raises.

## Speed

Wall clock could not separate these from the noise on this machine, so the cost is counted rather than timed: instructions retired per iteration under callgrind, taken as the difference between a 12,000 and a 2,000 iteration run so startup and the loop scaffold drop out. `build_config/default.rb`, `-g -O3`, gcc 13.3.0. The two controls come out bit-identical, which is what makes the small numbers readable.

| case | master | PR | delta |
|---|---:|---:|---:|
| `[1,2,3].reverse!` | 755.2 | 755.2 | 0 |
| `[1,2,3].insert(1, 9)` | 1,798.7 | 1,798.7 | 0 |
| `"abc" << "d"` | 1,085.3 | 1,085.3 | 0 |
| `"abc".reverse!` | 731.2 | 731.2 | 0 |
| `[1,2,3].fill(9)` | 3,203.7 | 3,202.7 | -1.0 |
| `[3,1,4,1,5].sort!` | 1,603.7 | 1,601.7 | -2.0 |
| `Array.new(3)` | 2,755.8 | 2,761.7 | +6.0 |
| `[1,2,3].map! { \|e\| e }` | 5,121.7 | 5,341.7 | +220.0 |
| `{a: 1, b: 2, c: 3}.select! { true }` | 10,327.0 | 10,548.1 | +221.2 |
| control: integer loop | 254.0 | 254.0 | 0 |
| control: `"abc".upcase` | 925.1 | 925.1 | 0 |

Every C path that writes is unchanged to the instruction, which is what putting the check on the return that writes nothing buys. `Array.new(3)` pays 6 instructions for the one check that had to go ahead of the write.

The Ruby-level methods pay one `frozen?` send, 220 instructions. That is 4.3% of a three-element `map!` whose block does nothing, and the share falls as the block does anything at all.

## Size

`.text` and `.rodata` of `bin/mruby` for each `build_config/ci/gcc-clang.rb` build (`size -A`), both columns built from an empty directory at the same path. The Ruby-level checks are bytecode, so they land in `.rodata` rather than `.text`.

| build | `.text` master | `.text` PR | delta | `.rodata` master | `.rodata` PR | delta |
|---|---:|---:|---:|---:|---:|---:|
| `full-debug` | 1,909,398 | 1,909,590 | +192 | 360,280 | 361,048 | +768 |
| `bintest` | 1,306,838 | 1,306,950 | +112 | 257,360 | 257,968 | +608 |
| `cxx_abi` | 1,331,513 | 1,330,617 | -896 | 257,424 | 257,968 | +544 |
| `byte-string` | 1,272,198 | 1,271,846 | -352 | 229,568 | 230,176 | +608 |
| `ascii-ctype` | 1,293,398 | 1,293,510 | +112 | 232,672 | 233,280 | +608 |

The two builds that shrink do so in `string.o`, and only there: compiled on its own with each build's recorded flags its `.text` goes 54,512 to 53,552 under `cxx_abi` and 35,424 to 34,960 under `byte-string`, while `bintest` and `ascii-ctype` come out unchanged to the byte. Those are the two builds where a `mrb_check_frozen()` call site is expensive enough for dropping two of them and adding one to net negative: `cxx_abi` gives every call that can throw its own landing pad, and `byte-string` folds `mrb_str_char_len()` to the byte length so the code around the check is smaller to begin with. `array.o` grows in every build, 16 to 91 bytes.

## Testing

`rake -m test` over the five builds of `build_config/ci/gcc-clang.rb`, no compiler warning in any build:

| build | total | OK | KO | crash | skip |
|---|---:|---:|---:|---:|---:|
| `full-debug` | 2,547 | 2,541 | 0 | 0 | 6 |
| `bintest` | 2,547 | 2,533 | 0 | 0 | 14 |
| `cxx_abi` | 2,547 | 2,533 | 0 | 0 | 14 |
| `byte-string` | 2,470 | 2,415 | 0 | 0 | 55 |
| `ascii-ctype` | 2,538 | 2,522 | 0 | 0 | 16 |

The `bintest` suite: 125 total, 124 OK, 0 KO, 1 skip. `build_config/default.rb`: 2,312 total, 0 KO, 0 crash, and 114 bintest, 0 KO.

`byte-string` and the UTF-8 builds cover both readings of `reverse!`: the early return is `utf8_len < 2` in one and the byte length in the other, and each has a test of its own.

Each of the three commits was checked out and run through `rake -m test` on `build_config/default.rb` on its own.

## Environment

<details>
<summary>details</summary>

| | |
| --- | --- |
| OS | Ubuntu, Linux 7.0.0-30-generic, x86_64 |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0 |
| C++ compiler | `cxx_abi` compiles the core sources as C++ with `gcc -x c++ -std=gnu++03`; g++ only links |
| binutils | GNU ld (GNU Binutils) 2.47.20260726 |
| valgrind | valgrind-3.27.1 |
| CRuby | 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |

</details>
