### PR TITLE
mruby-compiler: report a source file that cannot be read

### DIFF
--- a/mrbgems/mruby-compiler/src/mruby_compat.c
+++ b/mrbgems/mruby-compiler/src/mruby_compat.c
@@ -9,6 +9,7 @@
 #include <mruby/internal.h>
 #include <mruby/opcode.h>
 #include <mruby/proc.h>
+#include <mruby/string.h>
 #include <string.h>
 
 #include "../include/mrc_ccontext.h"
@@ -244,6 +245,29 @@ read_file_content(mrb_state *mrb, FILE *f, size_t *lenp)
   *lenp = len;
   return buf;
 }
+
+/* A stream that opened can still fail every read: a directory does exactly
+   that on POSIX, failing with EISDIR rather than reporting end of input.
+   read_file_content() answers NULL for that, and without an exception here
+   the failure is indistinguishable from an empty file one layer up
+   (mrb_parse_file() passes the NULL on and mrb_load_exec() answers an
+   undefined value), so the caller ran nothing and was told nothing.  The
+   binary loader already raises for its own read failures (`irep load error`
+   in load.c); this is the source loader's counterpart. */
+static void
+set_read_error(mrb_state *mrb, mrb_ccontext *c)
+{
+  mrb_value mesg;
+
+  if (mrb->exc) return;
+  if (c && c->filename) {
+    mesg = mrb_format(mrb, "cannot read file: %s", c->filename);
+  }
+  else {
+    mesg = mrb_str_new_lit(mrb, "cannot read file");
+  }
+  mrb->exc = mrb_obj_ptr(mrb_exc_new_str(mrb, E_SCRIPT_ERROR, mesg));
+}
 #endif
 
 MRB_API mrb_ccontext*
@@ -387,7 +411,10 @@ mrb_parse_file(mrb_state *mrb, FILE *f, mrb_ccontext *c)
 
   if (!f) return NULL;
   buf = read_file_content(mrb, f, &len);
-  if (!buf) return NULL;
+  if (!buf) {
+    set_read_error(mrb, c);
+    return NULL;
+  }
   p = parse_source(mrb, buf, len, c);
   mrb_free(mrb, buf);
   return p;
@@ -469,6 +496,13 @@ mrb_load_exec(mrb_state *mrb, struct mrb_parser_state *p, mrb_ccontext *c)
   mrb_int keep = 0;
 
   if (!p) {
+    /* No parser state at all: the source could not be obtained.  The reader
+       that knows why (set_read_error() above) has already said so; anything
+       else reaching here (a NULL stream, a NULL string) gets a message
+       rather than the silent undefined value this used to answer. */
+    if (mrb->exc == NULL) {
+      mrb->exc = mrb_obj_ptr(mrb_exc_new_lit(mrb, E_SCRIPT_ERROR, "cannot load source"));
+    }
     return mrb_undef_value();
   }
   if (!p->tree || p->nerr) {
@@ -533,7 +567,10 @@ mrb_load_detect_file_cxt(mrb_state *mrb, FILE *fp, mrb_ccontext *c)
 
   if (!fp) return mrb_nil_value();
   buf = read_file_content(mrb, fp, &len);
-  if (!buf) return mrb_nil_value();
+  if (!buf) {
+    set_read_error(mrb, c);
+    return mrb_nil_value();
+  }
   if (len >= 4 && memcmp(buf, "RITE", 4) == 0) {
     result = mrb_load_irep_buf_cxt(mrb, buf, len, c);
   }

--- a/mrbgems/mruby-compiler/test/mruby_compat.c
+++ b/mrbgems/mruby-compiler/test/mruby_compat.c
@@ -1,0 +1,58 @@
+/*
+** Test helpers for the C-level load API.
+**
+** The read-failure path is only reachable from C: no core method hands a
+** FILE* to mrb_load_file_cxt(), so the Ruby suite needs a door onto it.
+*/
+
+#include <mruby.h>
+
+#ifndef MRB_NO_STDIO
+
+#include <mruby/compile.h>
+#include <mruby/string.h>
+#include <stdio.h>
+
+/*
+ * Opens `path`, loads it as source through mrb_load_file_cxt(), and answers
+ * the exception that was left behind, or false when none was.  Answers nil
+ * when the platform refuses to open `path` at all: Windows does that for a
+ * directory, and never reaches the reader under test.
+ *
+ * The exception is taken off the state rather than propagated, so the caller
+ * examines it as an object instead of rescuing it.
+ */
+static mrb_value
+load_file_exc(mrb_state *mrb, mrb_value self)
+{
+  const char *path;
+  FILE *f;
+  mrb_ccontext *c;
+  mrb_value exc = mrb_false_value();
+
+  mrb_get_args(mrb, "z", &path);
+  f = fopen(path, "r");
+  if (f == NULL) return mrb_nil_value();
+
+  c = mrb_ccontext_new(mrb);
+  mrb_ccontext_filename(mrb, c, path);
+  mrb_load_file_cxt(mrb, f, c);
+  fclose(f);
+  mrb_ccontext_free(mrb, c);
+
+  if (mrb->exc) {
+    exc = mrb_obj_value(mrb->exc);
+    mrb->exc = NULL;
+  }
+  return exc;
+}
+
+#endif /* MRB_NO_STDIO */
+
+void
+mrb_mruby_compiler_gem_test(mrb_state *mrb)
+{
+#ifndef MRB_NO_STDIO
+  mrb_define_method(mrb, mrb->object_class, "load_file_exc", load_file_exc, MRB_ARGS_REQ(1));
+#endif
+}

--- a/mrbgems/mruby-compiler/test/mruby_compat.rb
+++ b/mrbgems/mruby-compiler/test/mruby_compat.rb
@@ -1,0 +1,31 @@
+##
+# Loading a source file that cannot be read
+
+assert('mrb_load_file_cxt reports a stream it cannot read') do
+  skip 'no stdio' unless respond_to?(:load_file_exc)
+
+  # A directory opens for reading on POSIX and then fails every read with
+  # EISDIR.  The reader answered NULL for that and set no exception, so
+  # mrb_load_exec() returned an undefined value and the caller could not tell
+  # the failure from an empty file: `mirb DIR`, `mrdb DIR` and `mrb -r DIR`
+  # each ran nothing, said nothing and exited 0.  '.' is a directory wherever
+  # the suite runs.
+  exc = load_file_exc('.')
+  skip 'fopen() refuses a directory' if exc.nil?
+
+  assert_kind_of ScriptError, exc
+  # `to_s`, not `message`: on a tree without the fix `exc` is false, and this
+  # has to report a failed assertion rather than raise on the way there.
+  assert_include exc.to_s, '.'
+end
+
+assert('an empty source file is not a read failure') do
+  skip 'no stdio' unless respond_to?(:load_file_exc)
+
+  # The counterpart the guard must not catch: end of input with no error.
+  # `/dev/null` reads as an empty program, which is legal and silent.
+  exc = load_file_exc('/dev/null')
+  skip 'no /dev/null' if exc.nil?
+
+  assert_false exc
+end


### PR DESCRIPTION
## Summary

A stream that opened can still fail every read, which is what a directory does on POSIX, and the source loader destroys that error: `mrb_load_file_cxt()` answers an undefined value with `mrb->exc` left NULL, so no caller can tell a failed read from an empty file. The binary loader has raised for its own read failures since it was written; the source loader is now its counterpart.

## Changes

| File | What |
|---|---|
| `mrbgems/mruby-compiler/src/mruby_compat.c` | add `set_read_error()`, called by `mrb_parse_file()` and `mrb_load_detect_file_cxt()`; `mrb_load_exec()`'s `!p` arm sets a message instead of answering in silence |
| `mrbgems/mruby-compiler/test/mruby_compat.c` | new: `load_file_exc`, a helper that loads a path through the C API and answers the exception left behind |
| `mrbgems/mruby-compiler/test/mruby_compat.rb` | new: the two assertions over that helper |

### The error was destroyed two layers below the caller

`read_file_content()` answers NULL for a failed read and sets no exception, `mrb_parse_file()` passes the NULL on, and `mrb_load_exec()` opened with:

```c
if (!p) {
  return mrb_undef_value();
}
```

A C program that opens a path, hands the stream to `mrb_load_file_cxt()` and reports what came back, run against a directory on both trees:

```console
$ ./probe /tmp/d      # master
/tmp/d  fopen: ok   undef? yes   mrb->exc: NULL (silent)

$ ./probe /tmp/d      # this PR
/tmp/d  fopen: ok   undef? yes   mrb->exc: cannot read file: /tmp/d (ScriptError)
```

Nothing above could tell that from an empty file, so an embedder ran nothing, said nothing and answered success.

### Where the message comes from

`set_read_error()` names the file from the compiler context when one was set, which is the same source `parse_source()`'s existing error reporting takes it from, and says `cannot read file` when there is no context. It leaves an exception already on the state alone. Both readers that can fail this way call it: `mrb_parse_file()` and `mrb_load_detect_file_cxt()`.

`ScriptError` is the class the binary loader already answers with for `irep load error`, and a source that cannot be read is the same kind of failure.

### `mrb_load_exec()`'s `!p` arm

It still answers the undefined value, so no caller's control flow changes, but it no longer leaves silence behind: where the reader has not already set an exception, which is what a NULL stream or a NULL string reaches it as, it sets a generic one. That mirrors the syntax-error and codegen-error arms directly beside it, which have always set `mrb->exc` under the same `mrb->exc == NULL` guard.

### An empty file is not a read failure

`/dev/null` reports end of input with no error, so it still loads as an empty program and leaves no exception. That is the counterpart the guard must not catch, and it is one of the two assertions.

### The tools' own guards are not made redundant

`mruby` refuses a directory before the loader sees it, so its message is unchanged. `mirb` reads its program file with its own `fgets()` loop and never reaches the loader at all, and `mrdb`'s `main()` ends with an unconditional `return 0`, so an exception left on the state cannot reach its exit status. Each of those still has to refuse the file itself. What changes here is that an embedder calling `mrb_load_file_cxt()`, or any future caller, can detect the failure instead of re-implementing the probe.

### Relationship to the other two open PRs

#7342 makes `mruby` and `mrb` stop when a `-r` library fails to load, and #7343 gives `mirb` and `mrdb` the read guard they lack. Those two work on the callers, this one on the loader, and none of the three makes another redundant. All three branches merge onto each other with no conflict.

## Behaviour

Only the C API changes.

| call | before | after |
|---|---|---|
| `mrb_load_file_cxt()` on a directory | undefined value, `mrb->exc == NULL` | undefined value, `ScriptError: cannot read file: <path>` |
| `mrb_load_detect_file_cxt()` on a directory | `nil`, `mrb->exc == NULL` | `nil`, the same `ScriptError` |
| `mrb_load_exec(mrb, NULL, c)` | undefined value, `mrb->exc == NULL` | undefined value, `ScriptError: cannot load source` |
| `mrb_load_file_cxt()` on `/dev/null` or an ordinary file | a value, no exception | unchanged |
| `mrb_load_file_cxt()` on a file that does not parse | undefined value, `SyntaxError` | unchanged |

Every command line tool answers exactly as before. `mruby`, `mrb`, `mirb`, `mrdb` and `mrbc` were run over a directory as the program file, a directory and a corrupt file as a `-r` library, `/dev/null`, and an ordinary program, on both trees: same output, same exit status in every case.

## Size

`.text` of `bin/mruby` for the five builds of `build_config/ci/gcc-clang.rb`, measured with `size -A`, both sides built from an empty build directory in the same worktree path.

| build | master | this PR | delta |
| --- | ---: | ---: | ---: |
| `bintest` | 1,306,118 | 1,306,758 | +640 |
| `cxx_abi` | 1,329,753 | 1,330,265 | +512 |
| `byte-string` | 1,270,998 | 1,271,638 | +640 |
| `ascii-ctype` | 1,292,678 | 1,293,318 | +640 |
| `full-debug` (-O0) | 1,909,702 | 1,910,022 | +320 |

`bin/mirb`, `bin/mrb` and `bin/mrdb` move by the same amount in the optimised builds, and by +336 at `-O0`, since what grew is `mruby_compat.o` in the library they all link. `bin/mrbc` is unchanged to the byte in every build: it is built from the `mrc` layer in `compile.c`, which this does not touch.

## Testing

The read-failure path is reachable only from C, since no core method hands a `FILE*` to `mrb_load_file_cxt()`, so this adds `test/` to `mruby-compiler` with a helper that opens a path, loads it, and answers the exception left behind: `false` when none was, and `nil` when the platform refuses to open the path at all, which is what Windows does for a directory. Two assertions: a directory yields a `ScriptError` naming the path, and `/dev/null` yields none. The helper sits inside the file's existing `#ifndef MRB_NO_STDIO` block, and the test skips itself where the method is not defined.

With only the two test files applied to master, the directory assertion fails: 1 KO, 0 crash. With the C change, 0 KO.

`MRUBY_CONFIG=build_config/ci/gcc-clang.rb rake -m test`, five builds, no compiler warning in any of them:

| build | total | OK | KO | crash | skip |
|---|---:|---:|---:|---:|---:|
| `full-debug` | 2,551 | 2,545 | 0 | 0 | 6 |
| `bintest` | 2,551 | 2,537 | 0 | 0 | 14 |
| `cxx_abi` | 2,551 | 2,537 | 0 | 0 | 14 |
| `byte-string` | 2,474 | 2,419 | 0 | 0 | 55 |
| `ascii-ctype` | 2,542 | 2,526 | 0 | 0 | 16 |

Each is master's count plus the two new assertions. The `bintest` suite is unchanged at 125 total, 0 KO, since this adds no bintest.

`build_config/default.rb`: 2,314 → 2,316 tests, 0 KO, 0 crash; bintests unchanged at 114, 0 KO.

## Environment

<details>
<summary>host and compilers</summary>

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS |
| kernel | Linux 7.0.0-30-generic x86_64 |
| CPU | AMD Ryzen 9 5950X 16-Core Processor |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0 |
| binutils | GNU ld (GNU Binutils) 2.47.20260726 |
| CRuby | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting when source files cannot be read.
  * File-loading failures now produce script errors instead of silently returning an undefined result.
  * Error messages identify the affected source path.

* **Tests**
  * Added coverage for unreadable files and empty source files.
  * Confirmed empty sources load successfully without raising an exception.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->