### PR TITLE
mruby-bin-mrb, mruby-bin-mruby: fail when a -r library does not load

### DIFF
--- a/mrbgems/mruby-bin-mrb/bintest/mrb.rb
+++ b/mrbgems/mruby-bin-mrb/bintest/mrb.rb
@@ -1,5 +1,6 @@
 require 'tempfile'
 require 'open3'
+require 'tmpdir'
 
 def assert_mrb(exp_out, exp_err, exp_success, args)
   out, err, stat = Open3.capture3(*(cmd_list("mrb") + args))
@@ -70,4 +71,43 @@ end
 
 assert('mrb nonexistent file') do
   assert_mrb("", /Cannot open/, false, %w[nonexistent.mrb])
+end
+
+# Every case below needs a program to run, and an empty file is one the tool
+# refuses for a reason of its own, so a failed compile has to be reported here
+# rather than left to surface as whatever the case asserts.
+def mrb_program
+  script = Tempfile.new(['test', '.rb'])
+  bin = Tempfile.new(['test', '.mrb'])
+  File.write(script.path, 'print "prog"')
+  assert_true system(*(cmd_list('mrbc') + ['-o', bin.path, script.path])),
+              "mrbc could not compile #{script.path}"
+  bin
+end
+
+assert('a -r library that does not load is fatal') do
+  # The library's exception was left on the state and nowhere else, and the
+  # program's first successful run overwrote it, so `mrb -r junk prog.mrb`
+  # printed the program's output and exited 0 as if the library had loaded.
+  # The irep loader has always raised here; only the check was missing.
+  bin = mrb_program
+  junk = Tempfile.new(['junk', '.mrb'])
+  File.write(junk.path, "not an irep\n")
+  assert_mrb("", /irep load error/, false, ["-r", junk.path, bin.path])
+end
+
+assert('a directory as a -r library is fatal') do
+  # Only POSIX systems open a directory for reading; Windows refuses it at
+  # fopen() and reports that instead.
+  skip 'fopen() refuses a directory' if target_win?
+  bin = mrb_program
+  Dir.mktmpdir do |dir|
+    assert_mrb("", /irep load error/, false, ["-r", dir, bin.path])
+  end
+end
+
+assert('a -r library that loads still runs the program') do
+  bin = mrb_program
+  lib = mrb_program
+  assert_mrb("progprog", "", true, ["-r", lib.path, bin.path])
 end

--- a/mrbgems/mruby-bin-mrb/tools/mrb/mrb.c
+++ b/mrbgems/mruby-bin-mrb/tools/mrb/mrb.c
@@ -290,8 +290,23 @@ main(int argc, char **argv)
       cleanup(mrb, &args);
       return EXIT_FAILURE;
     }
-    mrb_load_irep_file(mrb, lfp);
+    v = mrb_load_irep_file(mrb, lfp);
     fclose(lfp);
+    if (mrb->exc) {
+      /* A library that does not load leaves the exception here and nothing
+         else: the program below overwrites it on its first successful run, so
+         without this the failure vanished and the program ran as if the
+         library had been there.  A directory, a truncated file and an
+         ordinary non-irep file all reach this the same way.  Reported the way
+         the program's own failure is below, then fatal: a program whose
+         library is missing is not one to run. */
+      MRB_EXC_CHECK_EXIT(mrb, mrb->exc);
+      if (!mrb_undef_p(v)) {
+        mrb_print_error(mrb);
+      }
+      cleanup(mrb, &args);
+      return EXIT_FAILURE;
+    }
   }
 
   /* Load and execute program (.mrb only) */

--- a/mrbgems/mruby-bin-mruby/bintest/mruby.rb
+++ b/mrbgems/mruby-bin-mruby/bintest/mruby.rb
@@ -262,3 +262,30 @@ assert('symbol GC keeps a symbol its bytecode has not loaded yet') do
     "mruby_symbol_gc_a,mruby_symbol_gc_b"
   EXP
 end
+
+assert('a -r library that does not load is fatal') do
+  # The library's exception was left on the state and nowhere else, and the
+  # program's first successful run overwrote it, so the failure vanished: a
+  # syntax error printed its diagnostic and carried on, a library that raised
+  # said nothing at all, and both exited 0 with the program's output.  `ruby
+  # -r` exits 1 for each of these.
+  lib = Tempfile.new(['lib', '.rb'])
+
+  File.write(lib.path, "def f(\n")
+  assert_mruby("", /syntax error/, false, ["-r", lib.path, "-e", "puts 1"])
+
+  File.write(lib.path, "raise 'lib boom'\n")
+  assert_mruby("", /lib boom/, false, ["-r", lib.path, "-e", "puts 1"])
+
+  # An .mrb library takes the irep loader instead, which has always raised
+  # for this; only the check that reads the exception was missing.
+  bin = Tempfile.new(['lib', '.mrb'])
+  File.write(bin.path, "not an irep\n")
+  assert_mruby("", /irep load error/, false, ["-r", bin.path, "-e", "puts 1"])
+end
+
+assert('a -r library that loads still runs the program') do
+  lib = Tempfile.new(['lib', '.rb'])
+  File.write(lib.path, "def libfn; 42; end\n")
+  assert_mruby("42\n", "", true, ["-r", lib.path, "-e", "puts libfn"])
+end

--- a/mrbgems/mruby-bin-mruby/tools/mruby/mruby.c
+++ b/mrbgems/mruby-bin-mruby/tools/mruby/mruby.c
@@ -367,12 +367,30 @@ main(int argc, char **argv)
       }
       mrb_ccontext_filename(mrb, c, args.libv[i]);
       if (mrb_extension_p(args.libv[i])) {
-        mrb_load_irep_file_cxt(mrb, lfp, c);
+        v = mrb_load_irep_file_cxt(mrb, lfp, c);
       }
       else {
-        mrb_load_detect_file_cxt(mrb, lfp, c);
+        v = mrb_load_detect_file_cxt(mrb, lfp, c);
       }
       fclose(lfp);
+      if (mrb->exc) {
+        /* A library that does not load leaves the exception here and nothing
+           else: the program below overwrites it on its first successful run,
+           so without this the failure vanished and the program ran as if the
+           library had been there: a syntax error printed its diagnostic and
+           carried on, a library that raised said nothing at all, and both
+           exited 0.  Reported the way the program's own failure is below,
+           then fatal, matching `ruby -r`. */
+        MRB_EXC_CHECK_EXIT(mrb, mrb->exc);
+        if (!mrb_undef_p(v)) {
+          /* undef means the loader already reported it: a syntax error goes
+             to stderr as it is parsed. */
+          mrb_print_error(mrb);
+        }
+        mrb_ccontext_free(mrb, c);
+        cleanup(mrb, &args);
+        return EXIT_FAILURE;
+      }
       mrb_vm_ci_env_clear(mrb, mrb->c->cibase);
       mrb_ccontext_cleanup_local_variables(c);
     }


### PR DESCRIPTION
## Summary

`mruby -r lib` and `mrb -r lib` discard what the library load answered and never look at `mrb->exc`, so a library that does not load leaves no trace: the program runs as if the library had been there and the tool exits 0. `ruby -r` exits 1 for every one of these.

## Changes

| File | What |
|---|---|
| `mrbgems/mruby-bin-mruby/tools/mruby/mruby.c` | keep the loader's answer in `v` and check `mrb->exc` after each `-r` library |
| `mrbgems/mruby-bin-mrb/tools/mrb/mrb.c` | the same after `mrb_load_irep_file()` |
| `mrbgems/mruby-bin-mruby/bintest/mruby.rb` | `-r` on a library that does not parse, one that raises, and a corrupt `.mrb`; plus one that loads |
| `mrbgems/mruby-bin-mrb/bintest/mrb.rb` | `-r` on a corrupt `.mrb` and on a directory; plus one that loads |

### The exception was the only record, and the program overwrote it

Neither loader is at fault. The irep loader has raised `irep load error` since it was written (`load_irep()`, `src/load.c`), and the source loader prints its syntax errors to stderr as it parses. What was missing is the check that reads the result: between the library load and the program's own run nothing looks at `mrb->exc`, and the program's first successful call overwrites it.

```console
$ mruby -r junk.mrb  -e 'puts 1'    # 1                     RC=0
$ mruby -r syntax.rb -e 'puts 1'    # diagnostic, then 1    RC=0
$ mruby -r raises.rb -e 'puts 1'    # 1                     RC=0
$ mrb   -r junk.mrb  prog.mrb       # prog                  RC=0
$ mrb   -r DIR       prog.mrb       # prog                  RC=0
```

The failure was never specific to one kind of file: a truncated `.mrb`, an ordinary non-irep file, a directory, a library that raises and one that does not parse all reach it.

### The check is the one each tool already runs after the program

Each tool now does after every library what it already did after the program, in the same three steps: honour an exit through `MRB_EXC_CHECK_EXIT`, print the error unless the loader already printed it, and stop with `EXIT_FAILURE`. The middle one is the existing `!mrb_undef_p(v)` idiom, which is why the loader's answer is now kept: an undefined value is what a loader that has already reported to stderr leaves behind, and printing again would repeat the diagnostic. `mruby` frees the compile context on the way out, the way the arms around it do.

### `mruby`'s directory case is unchanged

`mruby` refuses a directory a few lines above, at the read guard on the opened stream, so the message for that one is what it was. What changes there is every other way a library can fail. `mrb` has no such guard, and a directory reaches its irep loader, which answers `irep load error`.

### Relationship to the other two open PRs

#7341 makes the source loader report a read failure instead of destroying it, and #7343 refuses an unreadable source in `mirb` and `mrdb`. Neither covers what this one does: most of the libraries that fail here open and read fine, and what was missing is the check that reads `mrb->exc` afterwards. All three branches merge onto each other with no conflict.

## Behaviour

| call | before | after | CRuby |
|---|---|---|---|
| `mruby -r junk.mrb -e 'puts 1'` | `1`, RC=0 | `irep load error (ScriptError)`, RC=1 | RC=1 |
| `mruby -r syntax.rb -e 'puts 1'` | diagnostic, then `1`, RC=0 | diagnostic, RC=1 | RC=1 |
| `mruby -r raises.rb -e 'puts 1'` | `1`, RC=0 | `boom (RuntimeError)` with its trace, RC=1 | RC=1 |
| `mrb -r junk.mrb prog.mrb` | `prog`, RC=0 | `irep load error (ScriptError)`, RC=1 | RC=1 |
| `mrb -r DIR prog.mrb` | `prog`, RC=0 | `irep load error (ScriptError)`, RC=1 | RC=1 |
| `mruby -r DIR -e 'puts 1'` | `Cannot read library file`, RC=1 | unchanged | RC=1 |
| `mruby -r ok.rb -e 'puts libfn'`, `mrb -r ok.mrb prog.mrb` | runs, RC=0 | unchanged | RC=0 |
| `mruby DIR`, `mrb DIR` as the program file | RC=1 | unchanged | RC=1 |

`mrb`'s directory case answers `irep load error` rather than a message about the directory, because that is what its loader reports for a stream it cannot read; what this changes is that the tool now stops instead of running the program.

## Size

`.text` of `bin/mruby` and `bin/mrb` for the five builds of `build_config/ci/gcc-clang.rb`, measured with `size -A`, both sides built from an empty build directory in the same worktree path.

| build | `bin/mruby` master | PR | delta | `bin/mrb` master | PR | delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| `bintest` | 1,306,118 | 1,306,198 | +80 | 1,304,998 | 1,305,046 | +48 |
| `cxx_abi` | 1,329,753 | 1,329,817 | +64 | 1,328,645 | 1,328,693 | +48 |
| `byte-string` | 1,270,998 | 1,271,078 | +80 | 1,269,878 | 1,269,926 | +48 |
| `ascii-ctype` | 1,292,678 | 1,292,758 | +80 | 1,291,558 | 1,291,606 | +48 |
| `full-debug` (-O0) | 1,909,702 | 1,909,894 | +192 | 1,908,374 | 1,908,534 | +160 |

`bin/mirb`, `bin/mrbc` and `bin/mrdb` are unchanged to the byte in every build.

## Testing

`mruby-bin-mruby`: a `-r` library that does not parse, one that raises, and a corrupt `.mrb`, each of which must exit non-zero with its diagnostic, plus a library that loads and lets the program run. `mruby-bin-mrb`: a corrupt `.mrb` library and a directory (with the usual `target_win?` skip, since Windows refuses a directory at `fopen()` and reports that instead), plus the same positive case.

With only the two bintest files applied to master, the suite answers 8 KO out of 137, each on the exit status and the missing diagnostic. With the C changes, 0 KO.

`MRUBY_CONFIG=build_config/ci/gcc-clang.rb rake -m test`, five builds, no compiler warning in any of them. `mrb` is built by the `full-core` gembox, so every build here carries it. mrbtest is unchanged from master in every build (`full-debug` 2,549, `bintest` 2,549, `cxx_abi` 2,549, `byte-string` 2,472, `ascii-ctype` 2,540), 0 KO and 0 crash throughout; the `bintest` suite goes 125 to 137, 0 KO.

`build_config/default.rb`: 2,314 tests, 0 KO, 0 crash; bintests 114 to 120, 0 KO. The default gembox has no `mruby-bin-mrb`, so the six `mrb` cases run only in the `full-core` builds above.

## Environment

<details>
<summary>host and compilers</summary>

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS |
| kernel | Linux 7.0.0-30-generic x86_64 |
| CPU | AMD Ryzen 9 5950X 16-Core Processor |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0 |
| binutils | GNU ld (GNU Binutils) 2.47.20260726 |
| CRuby | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Programs now stop with a nonzero exit status and display an error when a required library cannot be loaded.
  * Invalid, truncated, directory, and syntactically or runtime-invalid libraries no longer fail silently.
  * Successful library loading continues to work as expected.

* **Tests**
  * Added coverage for failed and successful library-loading scenarios in both command-line tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->