### PR TITLE
mruby-bin-mirb, mruby-bin-debugger: refuse a source file that cannot be read

### DIFF
--- a/include/mruby/compile.h
+++ b/include/mruby/compile.h
@@ -176,6 +176,25 @@ MRB_API mrb_value mrb_load_exec(mrb_state *mrb, struct mrb_parser_state *p, mrb_
 MRB_API mrb_value mrb_load_file(mrb_state*,FILE*);
 MRB_API mrb_value mrb_load_file_cxt(mrb_state*,FILE*, mrb_ccontext *cxt);
 MRB_API mrb_value mrb_load_detect_file_cxt(mrb_state *mrb, FILE *fp, mrb_ccontext *c);
+
+/**
+ * Tests whether a stream that opened can actually be read.
+ *
+ * A directory opens for reading on POSIX systems and then fails every read
+ * with EISDIR, so a successful fopen() says nothing about whether the caller
+ * will get any bytes.  Call this on a freshly opened stream before handing it
+ * to one of the loaders above, to tell a file that cannot be read from one
+ * that is merely empty.
+ *
+ * It reads one byte and pushes it back, so the stream is left where it was
+ * found, and it asks nothing about the kind of file: a character device or a
+ * pipe answers false, the way an ordinary file does.
+ *
+ * @param file an open stream, positioned at the start.
+ * @return TRUE if reading the stream fails, FALSE if it yields bytes or is
+ *         at end of input.
+ */
+MRB_API mrb_bool mrb_stream_is_unreadable(FILE *file);
 #endif
 MRB_API mrb_value mrb_load_string(mrb_state *mrb, const char *s);
 MRB_API mrb_value mrb_load_nstring(mrb_state *mrb, const char *s, size_t len);

--- a/mrbgems/mruby-bin-debugger/bintest/mrdb.rb
+++ b/mrbgems/mruby-bin-debugger/bintest/mrdb.rb
@@ -1,5 +1,6 @@
 require 'open3'
 require 'tempfile'
+require 'tmpdir'
 
 class BinTest_MRubyBinDebugger
   @debug1=false
@@ -280,4 +281,20 @@ SRC
 
   BinTest_MRubyBinDebugger.test(src, [{:cmd=>"ss",    :exp=>INVCMD}])
   BinTest_MRubyBinDebugger.test(src, [{:cmd=>"stepp", :exp=>INVCMD}])
+end
+
+assert('a directory as the program file is refused') do
+  # Only POSIX systems open a directory for reading; Windows refuses it at
+  # fopen() and reports that instead.
+  skip 'fopen() refuses a directory' if target_win?
+  # A directory opens for reading and then fails every read, and both loaders
+  # answer without raising, so without a check the debugger started on an
+  # empty program and exited 0.  Both arms take the same fopen().
+  Dir.mktmpdir do |dir|
+    [[dir], ["-b", dir]].each do |args|
+      o, s = Open3.capture2(*(cmd_list('mrdb') + args), :stdin_data => "")
+      assert_false s.success?
+      assert_include o, "Cannot read program file. (#{dir})"
+    end
+  end
 end

--- a/mrbgems/mruby-bin-debugger/bintest/mrdb.rb
+++ b/mrbgems/mruby-bin-debugger/bintest/mrdb.rb
@@ -350,3 +350,46 @@ assert('list reports a source it cannot read') do
     assert_include o, 'Invalid source file named'
   end
 end
+
+def mrdb_status(args, stdin_data)
+  _, _, s = Open3.capture3(*(cmd_list('mrdb') + args), :stdin_data => stdin_data)
+  s
+end
+
+assert('the exit status reports how the program ended') do
+  # The command loop decided the status by itself, with an unconditional 0, so
+  # `mrdb prog.rb` answered success for a program that raised and for one that
+  # would not even compile, where `mruby prog.rb` answers 1 for both.
+  script = Tempfile.new(['test', '.rb'])
+
+  File.write(script.path, "puts 'ok'\n")
+  assert_true mrdb_status([script.path], "r\nq\n").success?
+
+  File.write(script.path, "raise 'boom'\n")
+  assert_false mrdb_status([script.path], "r\nq\n").success?
+
+  # A program that does not compile never runs, and the failed load is still
+  # the program's outcome.
+  File.write(script.path, "def f(\n")
+  assert_false mrdb_status([script.path], "q\n").success?
+end
+
+assert('the exit status reports a compiled program too') do
+  script, bin = Tempfile.new(['test', '.rb']), Tempfile.new(['test', '.mrb'])
+
+  File.write(script.path, "raise 'boom'\n")
+  system(*(cmd_list('mrbc') + ['-g', '-o', bin.path, script.path]))
+  assert_false mrdb_status(['-b', bin.path], "r\nq\n").success?
+
+  File.write(script.path, "puts 'ok'\n")
+  system(*(cmd_list('mrbc') + ['-g', '-o', bin.path, script.path]))
+  assert_true mrdb_status(['-b', bin.path], "r\nq\n").success?
+end
+
+assert('quitting before the program runs is not a failure') do
+  # Leaving the debugger without running is the user's own exit, not the
+  # program's, and it returns through DebuggerExit rather than the path above.
+  script = Tempfile.new(['test', '.rb'])
+  File.write(script.path, "raise 'boom'\n")
+  assert_true mrdb_status([script.path], "q\n").success?
+end

--- a/mrbgems/mruby-bin-debugger/bintest/mrdb.rb
+++ b/mrbgems/mruby-bin-debugger/bintest/mrdb.rb
@@ -298,3 +298,55 @@ assert('a directory as the program file is refused') do
     end
   end
 end
+
+# Builds ROOT/src/prog.rb and ROOT/prog.mrb (compiled with -g, so its debug
+# info names ROOT/src/prog.rb), and yields the two paths.
+def with_debuggable_program
+  Dir.mktmpdir do |root|
+    src = File.join(root, 'src')
+    Dir.mkdir(src)
+    rb = File.join(src, 'prog.rb')
+    File.write(rb, "a = 1\nb = 2\n")
+    bin = File.join(root, 'prog.mrb')
+    system(*(cmd_list('mrbc') + ['-g', '-o', bin, rb]))
+    yield root, rb, bin
+  end
+end
+
+def mrdb_list(args)
+  o, _ = Open3.capture2(*(cmd_list('mrdb') + args), :stdin_data => "l\nq\n")
+  o
+end
+
+assert('the source search passes over a directory') do
+  # Only POSIX systems open a directory for reading; Windows refuses it at
+  # fopen() and never reaches the check this covers.
+  skip 'fopen() refuses a directory' if target_win?
+  # fopen() alone was the existence test, so a directory named like the source
+  # was a hit: the search stopped on a path `list` cannot show, and the
+  # readable file next in the search order was never reached.
+  with_debuggable_program do |root, rb, bin|
+    decoy = File.join(root, 'decoy')
+    Dir.mkdir(decoy)
+    Dir.mkdir(File.join(decoy, 'prog.rb'))
+
+    o = mrdb_list(['-d', decoy, '-b', bin])
+    assert_include o, 'a = 1'
+    assert_include o, 'b = 2'
+  end
+end
+
+assert('list reports a source it cannot read') do
+  skip 'fopen() refuses a directory' if target_win?
+  # With nothing readable anywhere in the search order, source_file_new()
+  # still answered a handle for the directory, show_lines() printed nothing
+  # and mrb_debug_list() answered OK, so `list` was silent instead of reaching
+  # its own message.
+  with_debuggable_program do |root, rb, bin|
+    File.delete(rb)
+    Dir.mkdir(rb)
+
+    o = mrdb_list(['-d', File.dirname(rb), '-b', bin])
+    assert_include o, 'Invalid source file named'
+  end
+end

--- a/mrbgems/mruby-bin-debugger/tools/mrdb/apilist.c
+++ b/mrbgems/mruby-bin-debugger/tools/mrdb/apilist.c
@@ -36,21 +36,6 @@ source_file_free(mrb_state *mrb, source_file *file)
   }
 }
 
-/* A directory opens for reading on POSIX systems and then fails every read
-   with EISDIR, so a stream that opened says nothing about whether it can be
-   read.  One byte tells the two apart without asking the platform what kind
-   of file this is: an empty file reports end-of-file and no error, while a
-   directory raises the error indicator.  The byte is pushed back, so the
-   stream is left where it was found.  (Same probe as `mruby`'s.) */
-static int
-stream_is_unreadable(FILE *file)
-{
-  int c = getc(file);
-  if (c == EOF) return ferror(file) != 0;
-  ungetc(c, file);
-  return 0;
-}
-
 static char*
 build_path(mrb_state *mrb, const char *dir, const char *base)
 {
@@ -105,7 +90,7 @@ source_file_new(mrb_state *mrb, mrb_debug_context *dbg, char *filename)
     source_file_free(mrb, file);
     return NULL;
   }
-  if (stream_is_unreadable(file->fp)) {
+  if (mrb_stream_is_unreadable(file->fp)) {
     /* A directory answers fopen() and then no read, so show_lines() printed
        nothing and mrb_debug_list() answered OK: `list` was silent where it
        has a message for a file it cannot show.  Refusing it here reaches
@@ -219,7 +204,7 @@ mrb_debug_get_source(mrb_state *mrb, mrdb_state *mrdb, const char *srcpath, cons
       path = NULL;
       continue;
     }
-    if (stream_is_unreadable(fp)) {
+    if (mrb_stream_is_unreadable(fp)) {
       /* fopen() alone is the existence test here, and a directory passes it.
          Taking one for a hit ended the search on a path the lister cannot
          show, hiding a readable source further down the search order. */

--- a/mrbgems/mruby-bin-debugger/tools/mrdb/apilist.c
+++ b/mrbgems/mruby-bin-debugger/tools/mrdb/apilist.c
@@ -36,6 +36,21 @@ source_file_free(mrb_state *mrb, source_file *file)
   }
 }
 
+/* A directory opens for reading on POSIX systems and then fails every read
+   with EISDIR, so a stream that opened says nothing about whether it can be
+   read.  One byte tells the two apart without asking the platform what kind
+   of file this is: an empty file reports end-of-file and no error, while a
+   directory raises the error indicator.  The byte is pushed back, so the
+   stream is left where it was found.  (Same probe as `mruby`'s.) */
+static int
+stream_is_unreadable(FILE *file)
+{
+  int c = getc(file);
+  if (c == EOF) return ferror(file) != 0;
+  ungetc(c, file);
+  return 0;
+}
+
 static char*
 build_path(mrb_state *mrb, const char *dir, const char *base)
 {
@@ -87,6 +102,14 @@ source_file_new(mrb_state *mrb, mrb_debug_context *dbg, char *filename)
   file->fp = fopen(filename, "rb");
 
   if (file->fp == NULL) {
+    source_file_free(mrb, file);
+    return NULL;
+  }
+  if (stream_is_unreadable(file->fp)) {
+    /* A directory answers fopen() and then no read, so show_lines() printed
+       nothing and mrb_debug_list() answered OK: `list` was silent where it
+       has a message for a file it cannot show.  Refusing it here reaches
+       that message. */
     source_file_free(mrb, file);
     return NULL;
   }
@@ -192,6 +215,15 @@ mrb_debug_get_source(mrb_state *mrb, mrdb_state *mrdb, const char *srcpath, cons
     }
 
     if ((fp = fopen(path, "rb")) == NULL) {
+      mrb_free(mrb, path);
+      path = NULL;
+      continue;
+    }
+    if (stream_is_unreadable(fp)) {
+      /* fopen() alone is the existence test here, and a directory passes it.
+         Taking one for a hit ended the search on a path the lister cannot
+         show, hiding a readable source further down the search order. */
+      fclose(fp);
       mrb_free(mrb, path);
       path = NULL;
       continue;

--- a/mrbgems/mruby-bin-debugger/tools/mrdb/mrdb.c
+++ b/mrbgems/mruby-bin-debugger/tools/mrdb/mrdb.c
@@ -8,6 +8,7 @@
 #include <ctype.h>
 
 #include <mruby.h>
+#include <mruby/compile.h>
 #include <mruby/dump.h>
 #include <mruby/debug.h>
 #include <mruby/error.h>
@@ -64,7 +65,6 @@ static const debug_command debug_command_list[] = {
   {NULL}
 };
 
-
 static void
 usage(const char *name)
 {
@@ -82,21 +82,6 @@ usage(const char *name)
   while (*p) {
     printf("  %s\n", *p++);
   }
-}
-
-/* A directory opens for reading on POSIX systems and then fails every read
-   with EISDIR, so a stream that opened says nothing about whether it can be
-   read.  One byte tells the two apart without asking the platform what kind
-   of file this is: an empty file reports end-of-file and no error, while a
-   directory raises the error indicator.  The byte is pushed back, so the
-   stream is left where it was found.  (Same probe as `mruby`'s.) */
-static int
-stream_is_unreadable(FILE *file)
-{
-  int c = getc(file);
-  if (c == EOF) return ferror(file) != 0;
-  ungetc(c, file);
-  return 0;
 }
 
 static int
@@ -174,7 +159,7 @@ append_srcpath:
         printf("%s: Cannot open program file. (%s)\n", *origargv, *argv);
         return EXIT_FAILURE;
       }
-      if (stream_is_unreadable(args->rfp)) {
+      if (mrb_stream_is_unreadable(args->rfp)) {
         /* Without this, the failed read is swallowed: mrb_load_file_cxt() and
            mrb_load_irep_file() both answer without raising, so a directory
            argument entered the debugger as an empty program.  The check

--- a/mrbgems/mruby-bin-debugger/tools/mrdb/mrdb.c
+++ b/mrbgems/mruby-bin-debugger/tools/mrdb/mrdb.c
@@ -10,6 +10,7 @@
 #include <mruby.h>
 #include <mruby/dump.h>
 #include <mruby/debug.h>
+#include <mruby/error.h>
 #include <mruby/class.h>
 #include <mruby/opcode.h>
 #include <mruby/variable.h>
@@ -710,6 +711,7 @@ main(int argc, char **argv)
 {
   mrb_state *mrb = mrb_open();
   int n = -1;
+  int ret = EXIT_SUCCESS;
   struct _args args;
   mrb_value v;
   mrdb_state *mrdb;
@@ -782,6 +784,19 @@ main(int argc, char **argv)
       goto l_restart;
     }
   }
+  /* How the program ended, taken before anything below can disturb it.  The
+     debugger's own command loop follows and used to decide the exit status by
+     itself, with an unconditional 0, so `mrdb prog.rb` answered success for a
+     program that raised, and for one that would not even compile, where
+     `mruby prog.rb` answers 1.  A later command cannot change this: what the
+     status reports is the program's run, not the debugging session.  Quitting
+     from inside the run is not a failure and returns 0 above, with
+     DebuggerExit. */
+  if (mrb->exc) {
+    ret = MRB_EXC_EXIT_P(mrb->exc)
+            ? MRB_EXC_EXIT_STATUS(mrb, mrb->exc) : EXIT_FAILURE;
+  }
+
   puts("mruby application exited.");
   mrdb->dbg->xphase = DBG_PHASE_AFTER_RUN;
   if (!mrb_undef_p(v)) {
@@ -810,5 +825,5 @@ main(int argc, char **argv)
 
   cleanup(mrb, &args);
 
-  return 0;
+  return ret;
 }

--- a/mrbgems/mruby-bin-debugger/tools/mrdb/mrdb.c
+++ b/mrbgems/mruby-bin-debugger/tools/mrdb/mrdb.c
@@ -83,6 +83,21 @@ usage(const char *name)
   }
 }
 
+/* A directory opens for reading on POSIX systems and then fails every read
+   with EISDIR, so a stream that opened says nothing about whether it can be
+   read.  One byte tells the two apart without asking the platform what kind
+   of file this is: an empty file reports end-of-file and no error, while a
+   directory raises the error indicator.  The byte is pushed back, so the
+   stream is left where it was found.  (Same probe as `mruby`'s.) */
+static int
+stream_is_unreadable(FILE *file)
+{
+  int c = getc(file);
+  if (c == EOF) return ferror(file) != 0;
+  ungetc(c, file);
+  return 0;
+}
+
 static int
 parse_args(mrb_state *mrb, int argc, char **argv, struct _args *args)
 {
@@ -156,6 +171,17 @@ append_srcpath:
       args->rfp = fopen(argv[0], args->mrbfile ? "rb" : "r");
       if (args->rfp == NULL) {
         printf("%s: Cannot open program file. (%s)\n", *origargv, *argv);
+        return EXIT_FAILURE;
+      }
+      if (stream_is_unreadable(args->rfp)) {
+        /* Without this, the failed read is swallowed: mrb_load_file_cxt() and
+           mrb_load_irep_file() both answer without raising, so a directory
+           argument entered the debugger as an empty program.  The check
+           belongs here rather than in main(), which ends with an
+           unconditional `return 0`; only parse_args()'s EXIT_FAILURE reaches
+           the exit status.  The stream is closed by cleanup() on the way
+           out. */
+        printf("%s: Cannot read program file. (%s)\n", *origargv, *argv);
         return EXIT_FAILURE;
       }
       args->fname = argv[0];

--- a/mrbgems/mruby-bin-mirb/bintest/mirb.rb
+++ b/mrbgems/mruby-bin-mirb/bintest/mirb.rb
@@ -1,5 +1,6 @@
 require 'open3'
 require 'tempfile'
+require 'tmpdir'
 
 MIRB_BIN = "mirb"
 
@@ -57,4 +58,29 @@ A.call
   TESTCODE
 
   assert_kind_of Integer, o =~ /\bundefined method 'a' .*\(NoMethodError\).*=> 5\b.*=> 1\b/m
+end
+
+assert('a directory as the program file is refused') do
+  # Only POSIX systems open a directory for reading; Windows refuses it at
+  # fopen() and reports that instead.
+  skip 'fopen() refuses a directory' if target_win?
+  # A directory opens for reading and then fails every read, and the REPL loop
+  # takes that failure for end of input, so without a check it ran as an empty
+  # program: no diagnostic and exit status 0.
+  Dir.mktmpdir do |dir|
+    o, s = Open3.capture2(*(cmd_list(MIRB_BIN) + [dir]), :stdin_data => "")
+    assert_false s.success?
+    assert_include o, "Cannot read program file. (#{dir})"
+  end
+end
+
+assert('a directory as a library file is refused') do
+  skip 'fopen() refuses a directory' if target_win?
+  # -r took the same swallowed read (mrb_load_file_cxt() sets no exception for
+  # it) and went on into the REPL.
+  Dir.mktmpdir do |dir|
+    o, s = Open3.capture2(*(cmd_list(MIRB_BIN) + ["-r", dir]), :stdin_data => "")
+    assert_false s.success?
+    assert_include o, "Cannot read library file. (#{dir})"
+  end
 end

--- a/mrbgems/mruby-bin-mirb/tools/mirb/mirb.c
+++ b/mrbgems/mruby-bin-mirb/tools/mirb/mirb.c
@@ -44,6 +44,21 @@ extern mrb_state *global_mrb; /* defined in mruby-compiler (ccontext.c) */
 # define MRB_NO_MIRB_UNDERSCORE
 #endif
 
+/* A directory opens for reading on POSIX systems and then fails every read
+   with EISDIR, so a stream that opened says nothing about whether it can be
+   read.  One byte tells the two apart without asking the platform what kind
+   of file this is: an empty file reports end-of-file and no error, while a
+   directory raises the error indicator.  The byte is pushed back, so the
+   stream is left where it was found.  (Same probe as `mruby`'s.) */
+static int
+stream_is_unreadable(FILE *file)
+{
+  int c = getc(file);
+  if (c == EOF) return ferror(file) != 0;
+  ungetc(c, file);
+  return 0;
+}
+
 static void
 p(mrb_state *mrb, mrb_value obj, mirb_highlighter *hl)
 {
@@ -309,6 +324,15 @@ parse_args(mrb_state *mrb, int argc, char **argv, struct _args *args)
         printf("Cannot open program file. (%s)\n", *argv);
         return EXIT_FAILURE;
       }
+      if (stream_is_unreadable(args->rfp)) {
+        /* Without this, the failed read is swallowed: the REPL loop takes the
+           first fgets() failure for end of input and falls through to its
+           `cleanup:` with the initial EXIT_SUCCESS, so a directory argument
+           ran as an empty program with no output, no diagnostic and exit
+           status 0.  The stream is closed by `cleanup:` on the way out. */
+        printf("Cannot read program file. (%s)\n", *argv);
+        return EXIT_FAILURE;
+      }
       argc--; argv++;
     }
   }
@@ -523,6 +547,15 @@ main(int argc, char **argv)
     FILE *lfp = fopen(args.libv[i], "r");
     if (lfp == NULL) {
       printf("Cannot open library file. (%s)\n", args.libv[i]);
+      ret = EXIT_FAILURE;
+      goto cleanup;
+    }
+    if (stream_is_unreadable(lfp)) {
+      /* -r took the same swallowed read: mrb_load_file_cxt() answers an
+         undefined value without setting mrb->exc, and the result is
+         discarded, so the library loaded nothing and said nothing. */
+      printf("Cannot read library file. (%s)\n", args.libv[i]);
+      fclose(lfp);
       ret = EXIT_FAILURE;
       goto cleanup;
     }

--- a/mrbgems/mruby-bin-mirb/tools/mirb/mirb.c
+++ b/mrbgems/mruby-bin-mirb/tools/mirb/mirb.c
@@ -44,21 +44,6 @@ extern mrb_state *global_mrb; /* defined in mruby-compiler (ccontext.c) */
 # define MRB_NO_MIRB_UNDERSCORE
 #endif
 
-/* A directory opens for reading on POSIX systems and then fails every read
-   with EISDIR, so a stream that opened says nothing about whether it can be
-   read.  One byte tells the two apart without asking the platform what kind
-   of file this is: an empty file reports end-of-file and no error, while a
-   directory raises the error indicator.  The byte is pushed back, so the
-   stream is left where it was found.  (Same probe as `mruby`'s.) */
-static int
-stream_is_unreadable(FILE *file)
-{
-  int c = getc(file);
-  if (c == EOF) return ferror(file) != 0;
-  ungetc(c, file);
-  return 0;
-}
-
 static void
 p(mrb_state *mrb, mrb_value obj, mirb_highlighter *hl)
 {
@@ -324,7 +309,7 @@ parse_args(mrb_state *mrb, int argc, char **argv, struct _args *args)
         printf("Cannot open program file. (%s)\n", *argv);
         return EXIT_FAILURE;
       }
-      if (stream_is_unreadable(args->rfp)) {
+      if (mrb_stream_is_unreadable(args->rfp)) {
         /* Without this, the failed read is swallowed: the REPL loop takes the
            first fgets() failure for end of input and falls through to its
            `cleanup:` with the initial EXIT_SUCCESS, so a directory argument
@@ -550,7 +535,7 @@ main(int argc, char **argv)
       ret = EXIT_FAILURE;
       goto cleanup;
     }
-    if (stream_is_unreadable(lfp)) {
+    if (mrb_stream_is_unreadable(lfp)) {
       /* -r took the same swallowed read: mrb_load_file_cxt() answers an
          undefined value without setting mrb->exc, and the result is
          discarded, so the library loaded nothing and said nothing. */

--- a/mrbgems/mruby-bin-mruby/tools/mruby/mruby.c
+++ b/mrbgems/mruby-bin-mruby/tools/mruby/mruby.c
@@ -143,21 +143,6 @@ dup_arg_item(mrb_state *mrb, const char *item)
   return buf;
 }
 
-/* A directory opens for reading on POSIX systems and then fails every read
-   with EISDIR, so a stream that opened says nothing about whether it can be
-   read.  One byte tells the two apart without asking the platform what kind
-   of file this is: an empty file reports end-of-file and no error, while a
-   directory raises the error indicator.  The byte is pushed back, so the
-   stream is left where it was found. */
-static int
-stream_is_unreadable(FILE *file)
-{
-  int c = getc(file);
-  if (c == EOF) return ferror(file) != 0;
-  ungetc(c, file);
-  return 0;
-}
-
 static int
 parse_args(mrb_state *mrb, int argc, char **argv, struct _args *args)
 {
@@ -255,7 +240,7 @@ parse_args(mrb_state *mrb, int argc, char **argv, struct _args *args)
         fprintf(stderr, "%s: Cannot open program file: %s\n", opts->program, argv[0]);
         return EXIT_FAILURE;
       }
-      if (args->rfp != stdin && stream_is_unreadable(args->rfp)) {
+      if (args->rfp != stdin && mrb_stream_is_unreadable(args->rfp)) {
         /* Without this, the failed read is swallowed: the loader returns nil
            without raising, so a directory argument ran as an empty program
            with no output, no diagnostic and exit status 0.  The stream is
@@ -356,7 +341,7 @@ main(int argc, char **argv)
         cleanup(mrb, &args);
         return EXIT_FAILURE;
       }
-      if (stream_is_unreadable(lfp)) {
+      if (mrb_stream_is_unreadable(lfp)) {
         /* Same swallowed read as the program file above: -r on a directory
            loaded nothing and said nothing. */
         fprintf(stderr, "%s: Cannot read library file: %s\n", *argv, args.libv[i]);

--- a/mrbgems/mruby-compiler/src/compile.c
+++ b/mrbgems/mruby-compiler/src/compile.c
@@ -238,7 +238,12 @@ append_from_stdin(mrc_ccontext *c, uint8_t **source, size_t source_length)
    read.  One byte tells the two apart without asking the platform what kind
    of file this is: an empty file reports end-of-file and no error, while a
    directory raises the error indicator.  The byte is pushed back, so the
-   stream is left where it was found. */
+   stream is left where it was found.
+
+   The same probe is exported as mrb_stream_is_unreadable() for callers that
+   have mruby.h.  This file does not: it is the portable mrc layer, built for
+   targets with no mruby core, so it keeps its own copy rather than reach for
+   one. */
 static int
 stream_is_unreadable(FILE *file)
 {

--- a/mrbgems/mruby-compiler/src/mruby_compat.c
+++ b/mrbgems/mruby-compiler/src/mruby_compat.c
@@ -543,6 +543,25 @@ mrb_load_detect_file_cxt(mrb_state *mrb, FILE *fp, mrb_ccontext *c)
   mrb_free(mrb, buf);
   return result;
 }
+
+/* One byte tells a stream that cannot be read from one that is merely empty,
+   without asking the platform what kind of file it has: an empty file reports
+   end-of-file and no error, while a directory raises the error indicator.  The
+   byte is pushed back, so the stream is left where it was found.
+
+   This lives beside the loaders because it is their failure mode it detects,
+   and the command line tools each opened their own streams and needed their
+   own copy of it before it was exported.  `mruby-compiler`'s own
+   read_input_files() keeps a private copy: compile.c is the portable mrc
+   layer, built for targets that have no mruby.h to declare this. */
+MRB_API mrb_bool
+mrb_stream_is_unreadable(FILE *file)
+{
+  int c = getc(file);
+  if (c == EOF) return ferror(file) != 0;
+  ungetc(c, file);
+  return FALSE;
+}
 #endif
 
 MRB_API mrb_value


### PR DESCRIPTION
## Summary

`fopen()` succeeds on a directory on POSIX systems, and the read that follows fails with `EISDIR` rather than coming back empty. Nothing on `mirb`'s and `mrdb`'s paths inspects that, so a directory handed to either ran as an empty program and exited 0. Fixing it puts a fifth copy of the same four-line probe in the tree, so the last commit exports it and the copies become calls.

## Changes

| File | What |
|---|---|
| `mrbgems/mruby-bin-mirb/tools/mirb/mirb.c` | refuse an unreadable program file in `parse_args()` and an unreadable `-r` library in `main()` |
| `mrbgems/mruby-bin-debugger/tools/mrdb/mrdb.c` | the same for the program file in `parse_args()`; `main()` returns how the program ended instead of an unconditional 0 |
| `mrbgems/mruby-bin-debugger/tools/mrdb/apilist.c` | `mrb_debug_get_source()` walks past an unreadable candidate; `source_file_new()` refuses one |
| `include/mruby/compile.h` | declare `mrb_stream_is_unreadable()` beside the loaders |
| `mrbgems/mruby-compiler/src/mruby_compat.c` | implement it next to them |
| `mrbgems/mruby-compiler/src/compile.c` | say why `read_input_files()` keeps a private copy |
| `mrbgems/mruby-bin-mruby/tools/mruby/mruby.c` | drop its private copy for the exported one |
| `mrbgems/mruby-bin-mirb/bintest/mirb.rb`, `mrbgems/mruby-bin-debugger/bintest/mrdb.rb` | the seven cases below |

Four commits, each green on its own.

### What each tool did with a directory

```console
$ mkdir /tmp/d
$ mirb /tmp/d      # no output                        RC=0
$ mirb -r /tmp/d   # library ignored, REPL starts     RC=0
$ mrdb /tmp/d      # debugger on an empty program     RC=0
$ mrdb -b /tmp/d   #                                  RC=0
```

CRuby's answer for the same input is `ruby: Is a directory -- /tmp/d (LoadError)`, `RC=1`.

`mirb`'s REPL loop breaks on the first `fgets()` failure and falls through to `cleanup:` with `ret` still at its initial `EXIT_SUCCESS`; its `-r` discards the result of `mrb_load_file_cxt()`, which for a failed read answers an undefined value. `mrdb` opens the file itself and reaches neither `mruby`'s guard nor the compiler's.

`mrdb`'s check goes in `parse_args()`, not `main()`: `main()` ended with an unconditional `return 0`, so only `parse_args()`'s `EXIT_FAILURE` reached the exit status. One site there covers both the `.rb` and the `-b` arm, which share the `fopen()`.

### `list` took `fopen()` for the whole test

Both places `mrdb` opens a source hit the same thing. `mrb_debug_get_source()` walks three search paths and opens each candidate to decide whether it exists, so a directory named like the source counted as a hit and ended the walk on a path the lister cannot show, hiding the readable file behind it. `source_file_new()` only NULL-checks its `fopen()`, so a directory yielded a handle, `show_lines()` read nothing, and `mrb_debug_list()` answered `MRB_DEBUG_OK`: `list` printed nothing at all rather than the `Invalid source file named ...` it already has for a file it cannot show.

Measured with a program compiled `-g` from `src/prog.rb` and a directory of that name ahead of it in the search order: `list` printed nothing, where the source itself was two directories away and readable.

### The exit status is the program's, not the session's

`mrdb prog.rb` answered success for a program that raised, and for one that would not even compile, where `mruby prog.rb` answers 1. The outcome is now taken straight after the load, before the command loop can disturb it: an exception marked as an exit answers its own status, so `exit 3` under the debugger answers 3 the way `mruby` does; any other exception answers `EXIT_FAILURE`; a clean run answers `EXIT_SUCCESS`. A program that does not compile never runs, and its failed load is still the program's outcome, so it answers failure too.

Two things deliberately keep answering 0. Quitting before or during the run is the user leaving the debugger, not the program failing, and it returns earlier through `DebuggerExit`. And a debugger command that raises does not touch the status.

### Five copies of the probe become one

With the three commits above, the tree would carry five byte-identical copies of the probe: `mruby` and `mrbc` grew theirs when they were taught to refuse a directory, and `mirb`, `mrdb` and `apilist.c` add three more. The reason the earlier ones stayed private no longer holds, since the probe settled on plain `getc`/`ungetc`/`ferror` and needs no header a target might not have.

It is declared beside `mrb_load_file_cxt()` in `mruby/compile.h`, because the failure it detects is that loader's, and implemented next to the loaders in `mruby_compat.c`, which `mruby-bin-mirb` and `mruby-bin-mruby` reach directly and `mruby-bin-debugger` reaches through `mruby-eval`. `mruby-compiler`'s own `read_input_files()` keeps a private copy with a comment saying why: `compile.c` is the portable `mrc` layer, built for targets that have no `mruby.h` to declare this. Five copies become one exported function and one deliberate exception, with no behaviour change: the probe is byte-for-byte what each caller ran before.

### What is deliberately not changed

`S_ISDIR` is not used. The probe asks nothing about the kind of file, so the non-regular sources that work today keep working: `mirb /dev/stdin < ok.rb` still runs, and an empty `.rb` is still an empty program rather than an error.

### Relationship to the other two open PRs

#7341 makes the source loader report a read failure instead of destroying it, and #7342 makes `mruby` and `mrb` stop when a `-r` library fails to load. They are complementary rather than redundant: `mirb` reads its program file with its own `fgets()` loop and never reaches the loader, and `mrdb`'s exit status is decided here. All three branches merge onto each other with no conflict.

## Behaviour

| call | before | after | CRuby |
|---|---|---|---|
| `mirb DIR` | no output, RC=0 | `Cannot read program file. (DIR)`, RC=1 | `LoadError`, RC=1 |
| `mirb -r DIR` | library ignored, REPL runs, RC=0 | `Cannot read library file. (DIR)`, RC=1 | `LoadError`, RC=1 |
| `mrdb DIR` | debugger on an empty program, RC=0 | `Cannot read program file. (DIR)`, RC=1 | `LoadError`, RC=1 |
| `mrdb -b DIR` | `irep load error`, then the debugger, RC=0 | `Cannot read program file. (DIR)`, RC=1 | n/a |
| `mrdb prog.rb` where the program raises | diagnostic, RC=0 | diagnostic, RC=1 | RC=1 |
| `mrdb prog.rb` where the program does not compile | diagnostic, RC=0 | diagnostic, RC=1 | RC=1 |
| `mrdb -b prog.mrb` where the program raises | diagnostic, RC=0 | diagnostic, RC=1 | n/a |
| `mrdb prog.rb`, quit before running | RC=0 | unchanged | n/a |
| `list` with a directory ahead of the source in the search order | prints nothing | lists the source | n/a |
| `list` with nothing readable to show | prints nothing | `Invalid source file named ...` | n/a |
| `mirb /dev/stdin < ok.rb`, `mirb prog.rb`, `mruby` and `mrbc` on every input | unchanged | unchanged | |

## Size

`.text` for the five builds of `build_config/ci/gcc-clang.rb`, measured with `size -A`, both sides built from an empty build directory in the same worktree path. `bin/mrdb` exists only in the `bintest` build, which is the one build that carries `mruby-bin-debugger`.

| build | `bin/mirb` master | PR | delta | `bin/mruby` master | PR | delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| `bintest` | 1,335,718 | 1,335,862 | +144 | 1,306,118 | 1,306,102 | -16 |
| `cxx_abi` | 1,359,577 | 1,359,721 | +144 | 1,329,753 | 1,329,737 | -16 |
| `byte-string` | 1,300,182 | 1,300,326 | +144 | 1,270,998 | 1,270,982 | -16 |
| `ascii-ctype` | 1,322,278 | 1,322,422 | +144 | 1,292,678 | 1,292,662 | -16 |
| `full-debug` (-O0) | 1,946,950 | 1,947,206 | +256 | 1,909,702 | 1,909,702 | 0 |

`bin/mrdb` in the `bintest` build: 1,321,174 to 1,321,430, +256, its two new call sites and the exit-status arm.

`bin/mruby` shrinks by the 16 bytes its private copy cost it, since the probe it calls now lives in the library. `bin/mrb`, which calls nothing new, grows by 48 bytes in the optimised builds and 80 in `full-debug`: that is the exported function itself, linked in from `mruby_compat.o`. `bin/mrbc` is unchanged to the byte, since `compile.c` keeps its own copy.

## Testing

Seven bintests across `mruby-bin-mirb` and `mruby-bin-debugger`, following the directory tests `mruby-bin-mruby` and `mruby-bin-mrbc` already have, with the same `target_win?` skip: Windows refuses a directory at `fopen()` and never reaches these checks. They cover the program file and the `-r` library for `mirb`; the program file through both arms for `mrdb`; the source search and the `list` message; and the exit status for a source program, a compiled one, and quitting before the run.

With only the two bintest files applied to master, the suite answers 7 KO out of 133, each on the exit status and the missing diagnostic. With the C changes, 0 KO.

`MRUBY_CONFIG=build_config/ci/gcc-clang.rb rake -m test`, five builds, no compiler warning in any of them: mrbtest is unchanged from master in every build (`full-debug` 2,549, `bintest` 2,549, `cxx_abi` 2,549, `byte-string` 2,472, `ascii-ctype` 2,540), 0 KO and 0 crash throughout; the `bintest` suite goes 125 to 133, 0 KO.

`build_config/default.rb`: 2,314 tests, 0 KO, 0 crash; bintests 114 to 122, 0 KO.

Each of the four commits was checked out and run through `rake -m test` on a build carrying `mruby-bin-debugger`, on its own: all four green.

## Environment

<details>
<summary>host and compilers</summary>

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS |
| kernel | Linux 7.0.0-30-generic x86_64 |
| CPU | AMD Ryzen 9 5950X 16-Core Processor |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0 |
| binutils | GNU ld (GNU Binutils) 2.47.20260726 |
| CRuby | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unreadable program and library paths, including directories, with clear error messages instead of treating them as empty files.
  * Debugger source lookup now skips invalid paths and continues searching for readable source files.
  * Debugger commands now report accurate process exit statuses, including runtime and compilation failures.

* **Tests**
  * Added regression coverage for unreadable paths, source lookup, execution failures, and debugger exit behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->