### PR TITLE
test: invoke the tools in the bintests without a shell, and report one that does not run

### DIFF
--- a/mrbgems/mruby-bin-debugger/bintest/mrdb.rb
+++ b/mrbgems/mruby-bin-debugger/bintest/mrdb.rb
@@ -14,7 +14,7 @@ class BinTest_MRubyBinDebugger
     script.flush
 
     # compile
-    system(*(cmd_list('mrbc') + ['-g', '-o', bin.path, script.path]))
+    assert_run('mrbc', '-g', '-o', bin.path, script.path)
 
     # add mrdb quit
     testcase << {:cmd=>"quit"}
@@ -309,7 +309,7 @@ def with_debuggable_program
     rb = File.join(src, 'prog.rb')
     File.write(rb, "a = 1\nb = 2\n")
     bin = File.join(root, 'prog.mrb')
-    system(*(cmd_list('mrbc') + ['-g', '-o', bin, rb]))
+    assert_run('mrbc', '-g', '-o', bin, rb)
     yield root, rb, bin
   end
 end
@@ -379,11 +379,11 @@ assert('the exit status reports a compiled program too') do
   script, bin = Tempfile.new(['test', '.rb']), Tempfile.new(['test', '.mrb'])
 
   File.write(script.path, "raise 'boom'\n")
-  system(*(cmd_list('mrbc') + ['-g', '-o', bin.path, script.path]))
+  assert_run('mrbc', '-g', '-o', bin.path, script.path)
   assert_false mrdb_status(['-b', bin.path], "r\nq\n").success?
 
   File.write(script.path, "puts 'ok'\n")
-  system(*(cmd_list('mrbc') + ['-g', '-o', bin.path, script.path]))
+  assert_run('mrbc', '-g', '-o', bin.path, script.path)
   assert_true mrdb_status(['-b', bin.path], "r\nq\n").success?
 end
 

--- a/mrbgems/mruby-bin-debugger/bintest/mrdb.rb
+++ b/mrbgems/mruby-bin-debugger/bintest/mrdb.rb
@@ -14,15 +14,16 @@ class BinTest_MRubyBinDebugger
     script.flush
 
     # compile
-    `#{cmd("mrbc")} -g -o "#{bin.path}" "#{script.path}"`
+    system(*(cmd_list('mrbc') + ['-g', '-o', bin.path, script.path]))
 
     # add mrdb quit
     testcase << {:cmd=>"quit"}
 
     stdin_data = testcase.map{|t| t[:cmd]}.join("\n") << "\n"
 
-    ["#{cmd('mrdb')} #{script.path}", "#{cmd('mrdb')} -b #{bin.path}"].each do |cmd|
-      o, s = Open3.capture2(cmd, :stdin_data => stdin_data)
+    # Both arms of the same program: the source, and the compiled form of it.
+    [[script.path], ['-b', bin.path]].each do |args|
+      o, s = Open3.capture2(*(cmd_list('mrdb') + args), :stdin_data => stdin_data)
 
       exp_vals = testcase.map{|t| t.fetch(:exp, nil)}
       unexp_vals = testcase.map{|t| t.fetch(:unexp, nil)}

--- a/mrbgems/mruby-bin-debugger/bintest/print.rb
+++ b/mrbgems/mruby-bin-debugger/bintest/print.rb
@@ -13,7 +13,7 @@ class BinTest_MRubyBinDebugger
     script.flush
 
     # compile
-    `#{cmd("mrbc")} -g -o "#{bin.path}" "#{script.path}"`
+    system(*(cmd_list('mrbc') + ['-g', '-o', bin.path, script.path]))
 
     # add mrdb quit
     testcase << {:cmd=>"quit"}
@@ -21,8 +21,9 @@ class BinTest_MRubyBinDebugger
     stdin_data = testcase.map{|t| t[:cmd]}.join("\n") << "\n"
 
     prompt = /^\(#{Regexp.escape(script.path)}:\d+\) /
-    ["#{cmd('mrdb')} #{script.path}", "#{cmd('mrdb')} -b #{bin.path}"].each do |cmd|
-      o, s = Open3.capture2(cmd, :stdin_data => stdin_data)
+    # Both arms of the same program: the source, and the compiled form of it.
+    [[script.path], ['-b', bin.path]].each do |args|
+      o, s = Open3.capture2(*(cmd_list('mrdb') + args), :stdin_data => stdin_data)
       scanner = StringScanner.new(o)
       scanner.skip_until(prompt)
       testcase.each do |tc|

--- a/mrbgems/mruby-bin-debugger/bintest/print.rb
+++ b/mrbgems/mruby-bin-debugger/bintest/print.rb
@@ -13,7 +13,7 @@ class BinTest_MRubyBinDebugger
     script.flush
 
     # compile
-    system(*(cmd_list('mrbc') + ['-g', '-o', bin.path, script.path]))
+    assert_run('mrbc', '-g', '-o', bin.path, script.path)
 
     # add mrdb quit
     testcase << {:cmd=>"quit"}

--- a/mrbgems/mruby-bin-mirb/bintest/mirb.rb
+++ b/mrbgems/mruby-bin-mirb/bintest/mirb.rb
@@ -5,26 +5,26 @@ require 'tmpdir'
 MIRB_BIN = "mirb"
 
 assert('mirb normal operations') do
-  o, s = Open3.capture2(cmd(MIRB_BIN), :stdin_data => "a=1\nb=2\na+b\n")
+  o, s = Open3.capture2(*cmd_list(MIRB_BIN), :stdin_data => "a=1\nb=2\na+b\n")
   assert_true o.include?('=> 3')
   assert_true o.include?('=> 2')
 end
 
 assert('mirb multi-line') do
-  o, s = Open3.capture2(cmd(MIRB_BIN), :stdin_data => "def a(b)\n return b\n end\na(1)\n")
+  o, s = Open3.capture2(*cmd_list(MIRB_BIN), :stdin_data => "def a(b)\n return b\n end\na(1)\n")
   assert_true o.include?('=> :a')
   assert_true o.include?('=> 1')
 end
 
 assert('regression for #1563') do
-  o, s = Open3.capture2(cmd(MIRB_BIN), :stdin_data => "a=1;b=2;c=3\nb\nc")
+  o, s = Open3.capture2(*cmd_list(MIRB_BIN), :stdin_data => "a=1;b=2;c=3\nb\nc")
   assert_true o.include?('=> 3')
 end
 
 assert('mirb -d option') do
-  o, _ = Open3.capture2(cmd(MIRB_BIN), :stdin_data => "$DEBUG\n")
+  o, _ = Open3.capture2(*cmd_list(MIRB_BIN), :stdin_data => "$DEBUG\n")
   assert_true o.include?('=> false')
-  o, _ = Open3.capture2("#{cmd(MIRB_BIN)} -d", :stdin_data => "$DEBUG\n")
+  o, _ = Open3.capture2(*(cmd_list(MIRB_BIN) + ['-d']), :stdin_data => "$DEBUG\n")
   assert_true o.include?('=> true')
 end
 
@@ -39,7 +39,7 @@ end
 EOS
   lib.flush
 
-  o, _ = Open3.capture2("#{cmd(MIRB_BIN)} -r #{lib.path}", :stdin_data => "Hoge.new.hoge\n")
+  o, _ = Open3.capture2(*(cmd_list(MIRB_BIN) + ['-r', lib.path]), :stdin_data => "Hoge.new.hoge\n")
   assert_true o.include?('=> :hoge')
 end
 
@@ -51,7 +51,7 @@ A = -> { a }
   TESTLIB
   lib.flush
 
-  o, _ = Open3.capture2("#{cmd(MIRB_BIN)} -r #{lib.path}", :stdin_data => <<-TESTCODE)
+  o, _ = Open3.capture2(*(cmd_list(MIRB_BIN) + ['-r', lib.path]), :stdin_data => <<-TESTCODE)
 a
 a = 5
 A.call

--- a/mrbgems/mruby-bin-mrb/bintest/mrb.rb
+++ b/mrbgems/mruby-bin-mrb/bintest/mrb.rb
@@ -14,27 +14,27 @@ assert('mrb can execute .mrb files') do
   script = Tempfile.new(['test', '.rb'])
   bin = Tempfile.new(['test', '.mrb'])
   File.write(script.path, 'print "hello from mrb"')
-  system("#{cmd('mrbc')} -o #{bin.path} #{script.path}")
-  o = `#{cmd('mrb')} #{bin.path}`.strip
-  assert_equal 'hello from mrb', o
+  system(*(cmd_list('mrbc') + ['-o', bin.path, script.path]))
+  o, = Open3.capture2(*(cmd_list('mrb') + [bin.path]))
+  assert_equal 'hello from mrb', o.strip
 end
 
 assert('mrb $0 value') do
   script = Tempfile.new(['test', '.rb'])
   bin = Tempfile.new(['test', '.mrb'])
   File.write(script.path, 'print $0')
-  system("#{cmd('mrbc')} -o #{bin.path} #{script.path}")
-  o = `#{cmd('mrb')} #{bin.path}`.strip
-  assert_equal bin.path, o
+  system(*(cmd_list('mrbc') + ['-o', bin.path, script.path]))
+  o, = Open3.capture2(*(cmd_list('mrb') + [bin.path]))
+  assert_equal bin.path, o.strip
 end
 
 assert('mrb ARGV value') do
   script = Tempfile.new(['test', '.rb'])
   bin = Tempfile.new(['test', '.mrb'])
   File.write(script.path, 'p ARGV')
-  system("#{cmd('mrbc')} -o #{bin.path} #{script.path}")
-  o = `#{cmd('mrb')} #{bin.path} foo bar`.strip
-  assert_equal '["foo", "bar"]', o
+  system(*(cmd_list('mrbc') + ['-o', bin.path, script.path]))
+  o, = Open3.capture2(*(cmd_list('mrb') + [bin.path, 'foo', 'bar']))
+  assert_equal '["foo", "bar"]', o.strip
 end
 
 assert('mrb with no arguments prints error') do
@@ -53,19 +53,19 @@ assert('mrb -r option loads library') do
 
   File.write(lib.path, '$lib_loaded = true')
   File.write(main.path, 'print $lib_loaded')
-  system("#{cmd('mrbc')} -o #{lib_mrb.path} #{lib.path}")
-  system("#{cmd('mrbc')} -o #{main_mrb.path} #{main.path}")
-  o = `#{cmd('mrb')} -r #{lib_mrb.path} #{main_mrb.path}`.strip
-  assert_equal 'true', o
+  system(*(cmd_list('mrbc') + ['-o', lib_mrb.path, lib.path]))
+  system(*(cmd_list('mrbc') + ['-o', main_mrb.path, main.path]))
+  o, = Open3.capture2(*(cmd_list('mrb') + ['-r', lib_mrb.path, main_mrb.path]))
+  assert_equal 'true', o.strip
 end
 
 assert('mrb -d sets $DEBUG') do
   script = Tempfile.new(['test', '.rb'])
   bin = Tempfile.new(['test', '.mrb'])
   File.write(script.path, 'print $DEBUG')
-  system("#{cmd('mrbc')} -o #{bin.path} #{script.path}")
-  o = `#{cmd('mrb')} -d #{bin.path}`.strip
-  assert_equal 'true', o
+  system(*(cmd_list('mrbc') + ['-o', bin.path, script.path]))
+  o, = Open3.capture2(*(cmd_list('mrb') + ['-d', bin.path]))
+  assert_equal 'true', o.strip
 end
 
 assert('mrb nonexistent file') do

--- a/mrbgems/mruby-bin-mrb/bintest/mrb.rb
+++ b/mrbgems/mruby-bin-mrb/bintest/mrb.rb
@@ -14,7 +14,7 @@ assert('mrb can execute .mrb files') do
   script = Tempfile.new(['test', '.rb'])
   bin = Tempfile.new(['test', '.mrb'])
   File.write(script.path, 'print "hello from mrb"')
-  system(*(cmd_list('mrbc') + ['-o', bin.path, script.path]))
+  assert_run('mrbc', '-o', bin.path, script.path)
   o, = Open3.capture2(*(cmd_list('mrb') + [bin.path]))
   assert_equal 'hello from mrb', o.strip
 end
@@ -23,7 +23,7 @@ assert('mrb $0 value') do
   script = Tempfile.new(['test', '.rb'])
   bin = Tempfile.new(['test', '.mrb'])
   File.write(script.path, 'print $0')
-  system(*(cmd_list('mrbc') + ['-o', bin.path, script.path]))
+  assert_run('mrbc', '-o', bin.path, script.path)
   o, = Open3.capture2(*(cmd_list('mrb') + [bin.path]))
   assert_equal bin.path, o.strip
 end
@@ -32,7 +32,7 @@ assert('mrb ARGV value') do
   script = Tempfile.new(['test', '.rb'])
   bin = Tempfile.new(['test', '.mrb'])
   File.write(script.path, 'p ARGV')
-  system(*(cmd_list('mrbc') + ['-o', bin.path, script.path]))
+  assert_run('mrbc', '-o', bin.path, script.path)
   o, = Open3.capture2(*(cmd_list('mrb') + [bin.path, 'foo', 'bar']))
   assert_equal '["foo", "bar"]', o.strip
 end
@@ -53,8 +53,8 @@ assert('mrb -r option loads library') do
 
   File.write(lib.path, '$lib_loaded = true')
   File.write(main.path, 'print $lib_loaded')
-  system(*(cmd_list('mrbc') + ['-o', lib_mrb.path, lib.path]))
-  system(*(cmd_list('mrbc') + ['-o', main_mrb.path, main.path]))
+  assert_run('mrbc', '-o', lib_mrb.path, lib.path)
+  assert_run('mrbc', '-o', main_mrb.path, main.path)
   o, = Open3.capture2(*(cmd_list('mrb') + ['-r', lib_mrb.path, main_mrb.path]))
   assert_equal 'true', o.strip
 end
@@ -63,7 +63,7 @@ assert('mrb -d sets $DEBUG') do
   script = Tempfile.new(['test', '.rb'])
   bin = Tempfile.new(['test', '.mrb'])
   File.write(script.path, 'print $DEBUG')
-  system(*(cmd_list('mrbc') + ['-o', bin.path, script.path]))
+  assert_run('mrbc', '-o', bin.path, script.path)
   o, = Open3.capture2(*(cmd_list('mrb') + ['-d', bin.path]))
   assert_equal 'true', o.strip
 end

--- a/mrbgems/mruby-bin-mrbc/bintest/mrbc.rb
+++ b/mrbgems/mruby-bin-mrbc/bintest/mrbc.rb
@@ -1,3 +1,4 @@
+require 'open3'
 require 'tempfile'
 require 'tmpdir'
 
@@ -7,43 +8,44 @@ assert('Compiling multiple files without new line in last line. #2361') do
   a.flush
   b.write('module B; end')
   b.flush
-  result = `#{cmd('mrbc')} -c -o #{out.path} #{a.path} #{b.path} 2>&1`
+  result, status = Open3.capture2e(*(cmd_list('mrbc') + ['-c', '-o', out.path, a.path, b.path]))
   assert_equal "#{cmd_bin('mrbc')}:#{a.path}:Syntax OK", result.chomp
-  assert_equal 0, $?.exitstatus
+  assert_equal 0, status.exitstatus
 end
 
 assert('parsing function with void argument') do
   a, out = Tempfile.new('a.rb'), Tempfile.new('out.mrb')
   a.write('f ()')
   a.flush
-  result = `#{cmd('mrbc')} -c -o #{out.path} #{a.path} 2>&1`
+  result, status = Open3.capture2e(*(cmd_list('mrbc') + ['-c', '-o', out.path, a.path]))
   assert_equal "#{cmd_bin('mrbc')}:#{a.path}:Syntax OK", result.chomp
-  assert_equal 0, $?.exitstatus
+  assert_equal 0, status.exitstatus
 end
 
 assert('embedded document with invalid terminator') do
   a, out = Tempfile.new('a.rb'), Tempfile.new('out.mrb')
   a.write("=begin\n=endx\n")
   a.flush
-  result = `#{cmd('mrbc')} -c -o #{out.path} #{a.path} 2>&1`
+  result, status = Open3.capture2e(*(cmd_list('mrbc') + ['-c', '-o', out.path, a.path]))
   assert_equal "#{a.path}:2:1: syntax error, embedded document meets end of file", result.chomp
-  assert_equal 1, $?.exitstatus
+  assert_equal 1, status.exitstatus
 end
 
 assert('a float literal under MRB_NO_FLOAT is read as 0 with a warning') do
   # Only a build without Float takes this path.  Whether this is one is asked
   # of its mruby, when there is one; mrbc itself cannot be asked.
   skip 'no mruby to probe the build with' unless File.exist?(cmd_bin('mruby'))
-  system("#{cmd('mruby')} -e Float", out: File::NULL, err: File::NULL)
+  system(*(cmd_list('mruby') + ['-e', 'Float']), out: File::NULL, err: File::NULL)
   skip 'this build has Float' if $?.success?
 
   a, out = Tempfile.new('a.rb'), Tempfile.new('out.mrb')
   a.write("x = 1\np 1.5\n")
   a.flush
-  result = `#{cmd('mrbc')} -v -o #{out.path} #{a.path} 2>&1`
-  assert_equal 0, $?.exitstatus
+  result, status = Open3.capture2e(*(cmd_list('mrbc') + ['-v', '-o', out.path, a.path]))
+  assert_equal 0, status.exitstatus
   assert_include result, "#{a.path}:2:3: generator warning, floating-point numbers are not supported"
-  assert_equal "0\n", `#{cmd('mruby')} -b #{out.path}`
+  compiled, = Open3.capture2(*(cmd_list('mruby') + ['-b', out.path]))
+  assert_equal "0\n", compiled
 end
 
 assert('mrbc -v disassembles like mruby -v') do
@@ -96,10 +98,9 @@ assert('mrbc -v disassembles like mruby -v') do
      .lines.reject { |l| l.start_with?('Syntax OK') }.join
   end
 
-  # Backticks capture stdout only, which is where both write the disassembly.
-  # Do not redirect stderr: `2>/dev/null` is not portable to cmd.exe.
-  from_mrbc = clean.call(`#{cmd('mrbc')} -v -o #{out.path} #{a.path}`)
-  from_mruby = clean.call(`#{cmd('mruby')} -v -c #{a.path}`)
+  # capture2 takes stdout only, which is where both write the disassembly.
+  from_mrbc = clean.call(Open3.capture2(*(cmd_list('mrbc') + ['-v', '-o', out.path, a.path]))[0])
+  from_mruby = clean.call(Open3.capture2(*(cmd_list('mruby') + ['-v', '-c', a.path]))[0])
 
   assert_false from_mrbc.empty?, 'mrbc -v produced no disassembly'
   assert_equal from_mruby, from_mrbc
@@ -118,6 +119,9 @@ assert('non-seekable input file is rejected by size, not blamed on the read') do
   a.write("puts 1\n")
   a.flush
 
+  # The one command here that a shell has to read: what is under test is what
+  # arrives through a pipe, and the pipeline is the shell's to build.  The
+  # path is quoted for it.
   result = `cat #{shellquote(a.path)} | #{cmd('mrbc')} -c /dev/stdin 2>&1`
   assert_equal 1, $?.exitstatus
   assert_include result, 'compile.c: cannot get size of program file. (/dev/stdin)'
@@ -134,10 +138,10 @@ assert('a directory as an input file is refused') do
   # program.  The fread() failure below reports the LONG_MAX case in wording
   # of its own, so pin which message arrives, not merely that one did.
   Dir.mktmpdir do |dir|
-    result = `#{cmd('mrbc')} -c #{shellquote(dir)} 2>&1`
+    result, status = Open3.capture2e(*(cmd_list('mrbc') + ['-c', dir]))
     assert_include result, 'compile.c: cannot read from program file.'
     assert_not_include result, 'compile.c: cannot read program file.'
-    assert_equal 1, $?.exitstatus
+    assert_equal 1, status.exitstatus
   end
 end
 
@@ -157,8 +161,8 @@ assert('a super outside a method forwards no block') do
   a, out = Tempfile.new('a.rb'), Tempfile.new('out.mrb')
   a.write(src)
   a.flush
-  result = `#{cmd('mrbc')} -v -o #{out.path} #{a.path} 2>&1`
-  assert_equal 0, $?.exitstatus
+  result, status = Open3.capture2e(*(cmd_list('mrbc') + ['-v', '-o', out.path, a.path]))
+  assert_equal 0, status.exitstatus
   assert_include result, 'SUPER'
   assert_not_include result, 'GETUPVAR'
 end

--- a/mrbgems/mruby-bin-mrbc/bintest/mrbc.rb
+++ b/mrbgems/mruby-bin-mrbc/bintest/mrbc.rb
@@ -33,7 +33,9 @@ end
 
 assert('a float literal under MRB_NO_FLOAT is read as 0 with a warning') do
   # Only a build without Float takes this path.  Whether this is one is asked
-  # of its mruby, when there is one; mrbc itself cannot be asked.
+  # of its mruby, when there is one; mrbc itself cannot be asked.  The run
+  # below is the one here that is not assert_run's: what it fails with is the
+  # answer, not a broken fixture.
   skip 'no mruby to probe the build with' unless File.exist?(cmd_bin('mruby'))
   system(*(cmd_list('mruby') + ['-e', 'Float']), out: File::NULL, err: File::NULL)
   skip 'this build has Float' if $?.success?

--- a/mrbgems/mruby-bin-mrbc/bintest/mrbc.rb
+++ b/mrbgems/mruby-bin-mrbc/bintest/mrbc.rb
@@ -46,7 +46,8 @@ assert('a float literal under MRB_NO_FLOAT is read as 0 with a warning') do
   result, status = Open3.capture2e(*(cmd_list('mrbc') + ['-v', '-o', out.path, a.path]))
   assert_equal 0, status.exitstatus
   assert_include result, "#{a.path}:2:3: generator warning, floating-point numbers are not supported"
-  compiled, = Open3.capture2(*(cmd_list('mruby') + ['-b', out.path]))
+  compiled, status = Open3.capture2(*(cmd_list('mruby') + ['-b', out.path]))
+  assert_true status.success?, 'mruby did not run the compiled program'
   assert_equal "0\n", compiled
 end
 
@@ -101,8 +102,12 @@ assert('mrbc -v disassembles like mruby -v') do
   end
 
   # capture2 takes stdout only, which is where both write the disassembly.
-  from_mrbc = clean.call(Open3.capture2(*(cmd_list('mrbc') + ['-v', '-o', out.path, a.path]))[0])
-  from_mruby = clean.call(Open3.capture2(*(cmd_list('mruby') + ['-v', '-c', a.path]))[0])
+  mrbc_out, mrbc_status = Open3.capture2(*(cmd_list('mrbc') + ['-v', '-o', out.path, a.path]))
+  mruby_out, mruby_status = Open3.capture2(*(cmd_list('mruby') + ['-v', '-c', a.path]))
+  assert_true mrbc_status.success?, 'mrbc -v did not run'
+  assert_true mruby_status.success?, 'mruby -v -c did not run'
+  from_mrbc = clean.call(mrbc_out)
+  from_mruby = clean.call(mruby_out)
 
   assert_false from_mrbc.empty?, 'mrbc -v produced no disassembly'
   assert_equal from_mruby, from_mrbc

--- a/mrbgems/mruby-bin-mrbc/bintest/mrbc.rb
+++ b/mrbgems/mruby-bin-mrbc/bintest/mrbc.rb
@@ -122,9 +122,12 @@ assert('non-seekable input file is rejected by size, not blamed on the read') do
   a.flush
 
   # The one command here that a shell has to read: what is under test is what
-  # arrives through a pipe, and the pipeline is the shell's to build.  The
-  # path is quoted for it.
-  result = `cat #{shellquote(a.path)} | #{cmd('mrbc')} -c /dev/stdin 2>&1`
+  # arrives through a pipe, and the pipeline is the shell's to build.  Both
+  # halves are quoted for it, the command included: `cmd_list()` can hold a
+  # build directory or an emulator argument with a space in it, and joining
+  # that with spaces is what hands the shell the wrong words.
+  mrbc = Shellwords.join(cmd_list('mrbc'))
+  result = `cat #{shellquote(a.path)} | #{mrbc} -c /dev/stdin 2>&1`
   assert_equal 1, $?.exitstatus
   assert_include result, 'compile.c: cannot get size of program file. (/dev/stdin)'
   assert_not_include result, 'cannot read program file'

--- a/mrbgems/mruby-bin-mruby/bintest/mruby.rb
+++ b/mrbgems/mruby-bin-mruby/bintest/mruby.rb
@@ -24,9 +24,9 @@ end
 assert('regression for #1572') do
   script, bin = Tempfile.new('test.rb'), Tempfile.new('test.mrb')
   File.write script.path, 'p "ok"'
-  system "#{cmd('mrbc')} -g -o #{bin.path} #{script.path}"
-  o = `#{cmd(MRUBY_BIN)} #{bin.path}`.strip
-  assert_equal '"ok"', o
+  system(*(cmd_list('mrbc') + ['-g', '-o', bin.path, script.path]))
+  o, = Open3.capture2(*(cmd_list(MRUBY_BIN) + [bin.path]))
+  assert_equal '"ok"', o.strip
 end
 
 assert '$0 value' do
@@ -35,14 +35,17 @@ assert '$0 value' do
   # .rb script
   script.write "p $0\n"
   script.flush
-  assert_equal "\"#{script.path}\"", `#{cmd(MRUBY_BIN)} "#{script.path}"`.chomp
+  o, = Open3.capture2(*(cmd_list(MRUBY_BIN) + [script.path]))
+  assert_equal "\"#{script.path}\"", o.chomp
 
   # .mrb file
-  `#{cmd('mrbc')} -o "#{bin.path}" "#{script.path}"`
-  assert_equal "\"#{bin.path}\"", `#{cmd(MRUBY_BIN)} "#{bin.path}"`.chomp
+  system(*(cmd_list('mrbc') + ['-o', bin.path, script.path]))
+  o, = Open3.capture2(*(cmd_list(MRUBY_BIN) + [bin.path]))
+  assert_equal "\"#{bin.path}\"", o.chomp
 
   # one liner
-  assert_equal '"-e"', `#{cmd(MRUBY_BIN)} -e #{shellquote('p $0')}`.chomp
+  o, = Open3.capture2(*(cmd_list(MRUBY_BIN) + ['-e', 'p $0']))
+  assert_equal '"-e"', o.chomp
 end
 
 assert 'ARGV value' do
@@ -61,7 +64,8 @@ __END__
 p 'legend'
 EOS
   script.flush
-  assert_equal "\"test\"\n\"fin\"\n", `#{cmd(MRUBY_BIN)} #{script.path}`
+  o, = Open3.capture2(*(cmd_list(MRUBY_BIN) + [script.path]))
+  assert_equal "\"test\"\n\"fin\"\n", o
 end
 
 assert('garbage collecting built-in classes') do
@@ -74,8 +78,9 @@ Array.dup
 print nil.class.to_s
 RUBY
   script.flush
-  assert_equal "NilClass", `#{cmd(MRUBY_BIN)} #{script.path}`
-  assert_equal 0, $?.exitstatus
+  o, status = Open3.capture2(*(cmd_list(MRUBY_BIN) + [script.path]))
+  assert_equal "NilClass", o
+  assert_equal 0, status.exitstatus
 end
 
 assert('mruby -c option') do
@@ -113,11 +118,14 @@ EOS
 print Hoge.new.hoge
 EOS
   script.flush
-  assert_equal 'hoge', `#{cmd(MRUBY_BIN)} -r #{lib.path} #{script.path}`
-  assert_equal 0, $?.exitstatus
+  o, status = Open3.capture2(*(cmd_list(MRUBY_BIN) + ['-r', lib.path, script.path]))
+  assert_equal 'hoge', o
+  assert_equal 0, status.exitstatus
 
-  assert_equal 'hogeClass', `#{cmd(MRUBY_BIN)} -r #{lib.path} -r #{script.path} -e #{shellquote('print Hoge.class')}`
-  assert_equal 0, $?.exitstatus
+  o, status = Open3.capture2(*(cmd_list(MRUBY_BIN) +
+                               ['-r', lib.path, '-r', script.path, '-e', 'print Hoge.class']))
+  assert_equal 'hogeClass', o
+  assert_equal 0, status.exitstatus
 end
 
 assert('mruby -r option (no library specified)') do
@@ -173,16 +181,16 @@ assert('top level local variables are in file scope') do
   drb, dmrb = Tempfile.new('d.rb'), Tempfile.new('d.mrb')
 
   File.write arb.path, 'a = 1'
-  system "#{cmd('mrbc')} -g -o #{amrb.path} #{arb.path}"
+  system(*(cmd_list('mrbc') + ['-g', '-o', amrb.path, arb.path]))
   File.write brb.path, 'p a'
-  system "#{cmd('mrbc')} -g -o #{bmrb.path} #{brb.path}"
+  system(*(cmd_list('mrbc') + ['-g', '-o', bmrb.path, brb.path]))
   assert_mruby("", /:1: undefined method 'a' .*\(NoMethodError\)\n\z/, false, ["-r", arb.path, brb.path])
   assert_mruby("", /:1: undefined method 'a' .*\(NoMethodError\)\n\z/, false, ["-b", "-r", amrb.path, bmrb.path])
 
   File.write crb.path, 'a, b, c = 1, 2, 3; A = -> { b = -2; [a, b, c] }'
-  system "#{cmd('mrbc')} -g -o #{cmrb.path} #{crb.path}"
+  system(*(cmd_list('mrbc') + ['-g', '-o', cmrb.path, crb.path]))
   File.write drb.path, 'a, b = 5, 6; p A.call; p a, b'
-  system "#{cmd('mrbc')} -g -o #{dmrb.path} #{drb.path}"
+  system(*(cmd_list('mrbc') + ['-g', '-o', dmrb.path, drb.path]))
   assert_mruby("[1, -2, 3]\n5\n6\n", "", true, ["-r", crb.path, drb.path])
   assert_mruby("[1, -2, 3]\n5\n6\n", "", true, ["-b", "-r", cmrb.path, dmrb.path])
 end

--- a/mrbgems/mruby-bin-mruby/bintest/mruby.rb
+++ b/mrbgems/mruby-bin-mruby/bintest/mruby.rb
@@ -24,7 +24,7 @@ end
 assert('regression for #1572') do
   script, bin = Tempfile.new('test.rb'), Tempfile.new('test.mrb')
   File.write script.path, 'p "ok"'
-  system(*(cmd_list('mrbc') + ['-g', '-o', bin.path, script.path]))
+  assert_run('mrbc', '-g', '-o', bin.path, script.path)
   o, = Open3.capture2(*(cmd_list(MRUBY_BIN) + [bin.path]))
   assert_equal '"ok"', o.strip
 end
@@ -39,7 +39,7 @@ assert '$0 value' do
   assert_equal "\"#{script.path}\"", o.chomp
 
   # .mrb file
-  system(*(cmd_list('mrbc') + ['-o', bin.path, script.path]))
+  assert_run('mrbc', '-o', bin.path, script.path)
   o, = Open3.capture2(*(cmd_list(MRUBY_BIN) + [bin.path]))
   assert_equal "\"#{bin.path}\"", o.chomp
 
@@ -181,16 +181,16 @@ assert('top level local variables are in file scope') do
   drb, dmrb = Tempfile.new('d.rb'), Tempfile.new('d.mrb')
 
   File.write arb.path, 'a = 1'
-  system(*(cmd_list('mrbc') + ['-g', '-o', amrb.path, arb.path]))
+  assert_run('mrbc', '-g', '-o', amrb.path, arb.path)
   File.write brb.path, 'p a'
-  system(*(cmd_list('mrbc') + ['-g', '-o', bmrb.path, brb.path]))
+  assert_run('mrbc', '-g', '-o', bmrb.path, brb.path)
   assert_mruby("", /:1: undefined method 'a' .*\(NoMethodError\)\n\z/, false, ["-r", arb.path, brb.path])
   assert_mruby("", /:1: undefined method 'a' .*\(NoMethodError\)\n\z/, false, ["-b", "-r", amrb.path, bmrb.path])
 
   File.write crb.path, 'a, b, c = 1, 2, 3; A = -> { b = -2; [a, b, c] }'
-  system(*(cmd_list('mrbc') + ['-g', '-o', cmrb.path, crb.path]))
+  assert_run('mrbc', '-g', '-o', cmrb.path, crb.path)
   File.write drb.path, 'a, b = 5, 6; p A.call; p a, b'
-  system(*(cmd_list('mrbc') + ['-g', '-o', dmrb.path, drb.path]))
+  assert_run('mrbc', '-g', '-o', dmrb.path, drb.path)
   assert_mruby("[1, -2, 3]\n5\n6\n", "", true, ["-r", crb.path, drb.path])
   assert_mruby("[1, -2, 3]\n5\n6\n", "", true, ["-b", "-r", cmrb.path, dmrb.path])
 end

--- a/mrbgems/mruby-bin-strip/bintest/mruby_strip.rb
+++ b/mrbgems/mruby-bin-strip/bintest/mruby_strip.rb
@@ -27,8 +27,8 @@ assert('success') do
     Tempfile.new('script.rb'), Tempfile.new('c1.mrb'), Tempfile.new('c2.mrb')
   script_file.write "p 'test'\n"
   script_file.flush
-  system(*(cmd_list('mrbc') + ['-g', '-o', compiled1.path, script_file.path]))
-  system(*(cmd_list('mrbc') + ['-g', '-o', compiled2.path, script_file.path]))
+  assert_run('mrbc', '-g', '-o', compiled1.path, script_file.path)
+  assert_run('mrbc', '-g', '-o', compiled2.path, script_file.path)
 
   o, s = Open3.capture2(*(cmd_list('mruby-strip') + [compiled1.path]))
   assert_equal 0, s.exitstatus
@@ -47,12 +47,12 @@ assert('check debug section') do
     Tempfile.new('script.rb'), Tempfile.new('c1.mrb'), Tempfile.new('c2.mrb')
   script_file.write "p 'test'\n"
   script_file.flush
-  system(*(cmd_list('mrbc') + ['-o', without_debug.path, script_file.path]))
-  system(*(cmd_list('mrbc') + ['-g', '-o', with_debug.path, script_file.path]))
+  assert_run('mrbc', '-o', without_debug.path, script_file.path)
+  assert_run('mrbc', '-g', '-o', with_debug.path, script_file.path)
 
   assert_true with_debug.size >= without_debug.size
 
-  system(*(cmd_list('mruby-strip') + [with_debug.path]))
+  assert_run('mruby-strip', with_debug.path)
   assert_equal without_debug.size, with_debug.size
 end
 
@@ -65,10 +65,10 @@ a += b
 p Kernel.local_variables
 EOS
   script_file.flush
-  system(*(cmd_list('mrbc') + ['-o', with_lv.path, script_file.path]))
-  system(*(cmd_list('mrbc') + ['-o', without_lv.path, script_file.path]))
+  assert_run('mrbc', '-o', with_lv.path, script_file.path)
+  assert_run('mrbc', '-o', without_lv.path, script_file.path)
 
-  system(*(cmd_list('mruby-strip') + ['-l', without_lv.path]))
+  assert_run('mruby-strip', '-l', without_lv.path)
   assert_true without_lv.size < with_lv.size
 #
 #  assert_equal '[:a, :b]', Open3.capture2(*(cmd_list('mruby') + ['-b', with_lv.path]))[0].chomp

--- a/mrbgems/mruby-bin-strip/bintest/mruby_strip.rb
+++ b/mrbgems/mruby-bin-strip/bintest/mruby_strip.rb
@@ -1,14 +1,15 @@
+require 'open3'
 require 'tempfile'
 
 assert('no files') do
-  o = `#{cmd('mruby-strip')} 2>&1`
-  assert_equal 1, $?.exitstatus
+  o, s = Open3.capture2e(*cmd_list('mruby-strip'))
+  assert_equal 1, s.exitstatus
   assert_equal "no files to strip", o.split("\n")[0]
 end
 
 assert('file not found') do
-  o = `#{cmd('mruby-strip')} not_found.mrb 2>&1`
-  assert_equal 1, $?.exitstatus
+  o, s = Open3.capture2e(*(cmd_list('mruby-strip') + ['not_found.mrb']))
+  assert_equal 1, s.exitstatus
   assert_equal "can't open file for reading not_found.mrb\n", o
 end
 
@@ -16,8 +17,8 @@ assert('not irep file') do
   t = Tempfile.new('script.rb')
   t.write 'p test\n'
   t.flush
-  o = `#{cmd('mruby-strip')} #{t.path} 2>&1`
-  assert_equal 1, $?.exitstatus
+  o, s = Open3.capture2e(*(cmd_list('mruby-strip') + [t.path]))
+  assert_equal 1, s.exitstatus
   assert_equal "can't read irep file #{t.path}\n", o
 end
 
@@ -26,16 +27,18 @@ assert('success') do
     Tempfile.new('script.rb'), Tempfile.new('c1.mrb'), Tempfile.new('c2.mrb')
   script_file.write "p 'test'\n"
   script_file.flush
-  `#{cmd('mrbc')} -g -o #{compiled1.path} #{script_file.path}`
-  `#{cmd('mrbc')} -g -o #{compiled2.path} #{script_file.path}`
+  system(*(cmd_list('mrbc') + ['-g', '-o', compiled1.path, script_file.path]))
+  system(*(cmd_list('mrbc') + ['-g', '-o', compiled2.path, script_file.path]))
 
-  o = `#{cmd('mruby-strip')} #{compiled1.path}`
-  assert_equal 0, $?.exitstatus
+  o, s = Open3.capture2(*(cmd_list('mruby-strip') + [compiled1.path]))
+  assert_equal 0, s.exitstatus
   assert_equal "", o
-  assert_equal `#{cmd('mruby')} #{script_file.path}`, `#{cmd('mruby')} #{compiled1.path}`
+  from_source, = Open3.capture2(*(cmd_list('mruby') + [script_file.path]))
+  from_stripped, = Open3.capture2(*(cmd_list('mruby') + [compiled1.path]))
+  assert_equal from_source, from_stripped
 
-  o = `#{cmd('mruby-strip')} #{compiled1.path} #{compiled2.path}`
-  assert_equal 0, $?.exitstatus
+  o, s = Open3.capture2(*(cmd_list('mruby-strip') + [compiled1.path, compiled2.path]))
+  assert_equal 0, s.exitstatus
   assert_equal "", o
 end
 
@@ -44,12 +47,12 @@ assert('check debug section') do
     Tempfile.new('script.rb'), Tempfile.new('c1.mrb'), Tempfile.new('c2.mrb')
   script_file.write "p 'test'\n"
   script_file.flush
-  `#{cmd('mrbc')} -o #{without_debug.path} #{script_file.path}`
-  `#{cmd('mrbc')} -g -o #{with_debug.path} #{script_file.path}`
+  system(*(cmd_list('mrbc') + ['-o', without_debug.path, script_file.path]))
+  system(*(cmd_list('mrbc') + ['-g', '-o', with_debug.path, script_file.path]))
 
   assert_true with_debug.size >= without_debug.size
 
-  `#{cmd('mruby-strip')} #{with_debug.path}`
+  system(*(cmd_list('mruby-strip') + [with_debug.path]))
   assert_equal without_debug.size, with_debug.size
 end
 
@@ -62,12 +65,12 @@ a += b
 p Kernel.local_variables
 EOS
   script_file.flush
-  `#{cmd('mrbc')} -o #{with_lv.path} #{script_file.path}`
-  `#{cmd('mrbc')} -o #{without_lv.path} #{script_file.path}`
+  system(*(cmd_list('mrbc') + ['-o', with_lv.path, script_file.path]))
+  system(*(cmd_list('mrbc') + ['-o', without_lv.path, script_file.path]))
 
-  `#{cmd('mruby-strip')} -l #{without_lv.path}`
+  system(*(cmd_list('mruby-strip') + ['-l', without_lv.path]))
   assert_true without_lv.size < with_lv.size
 #
-#  assert_equal '[:a, :b]', `#{cmd('mruby')} -b #{with_lv.path}`.chomp
-#  assert_equal '[]', `#{cmd('mruby')} -b #{without_lv.path}`.chomp
+#  assert_equal '[:a, :b]', Open3.capture2(*(cmd_list('mruby') + ['-b', with_lv.path]))[0].chomp
+#  assert_equal '[]', Open3.capture2(*(cmd_list('mruby') + ['-b', without_lv.path]))[0].chomp
 end

--- a/test/bintest.rb
+++ b/test/bintest.rb
@@ -44,6 +44,15 @@ def cmd(s)
   cmd_list(s).join(' ')
 end
 
+# Runs a tool the test needs to have succeeded, usually the `mrbc` that builds
+# its fixture, and reports it here when it did not.  Without this the failure
+# arrives as whatever the case asserts about the tool under test: an empty
+# fixture is a file the tool refuses for a reason of its own, and the case
+# blames the tool rather than the build of its input.
+def assert_run(s, *args)
+  assert_true system(*(cmd_list(s) + args)), "#{s} #{args.join(' ')} did not run"
+end
+
 def shellquote(s)
   case RbConfig::CONFIG['host_os']
   when /mswin(?!ce)|mingw|bccwin/


### PR DESCRIPTION
## Summary

Two things the bintests did with the tools they run. Every call built one command string and handed it to a shell, with the paths of its temporary files interpolated unquoted, so the suite silently depends on the temporary directory having no space in its name: with one, 60 of the 133 bintests fail. And every fixture build threw away the result of the `mrbc` that produced it, so a failed build surfaced as whatever the case asserts about the tool under test.

## Changes

| File | What |
|---|---|
| `test/bintest.rb` | add `assert_run()`, which runs a tool through `cmd_list()` and asserts that it ran |
| `mrbgems/mruby-bin-mruby/bintest/mruby.rb` | backticks and `system("...")` become `Open3.capture2` and `assert_run` over the argument list |
| `mrbgems/mruby-bin-mrb/bintest/mrb.rb` | the same for `mrb` and for the `mrbc` calls that build its fixtures |
| `mrbgems/mruby-bin-mrbc/bintest/mrbc.rb` | the same, with `2>&1` becoming `Open3.capture2e`; the one command that keeps a shell is quoted with `Shellwords.join()`, and the three runs asked for output assert their status |
| `mrbgems/mruby-bin-mirb/bintest/mirb.rb` | `Open3.capture2("#{cmd(MIRB_BIN)} -r #{lib.path}", ...)` becomes the argument list |
| `mrbgems/mruby-bin-strip/bintest/mruby_strip.rb` | the same, and `$?.exitstatus` becomes the status the call answers |
| `mrbgems/mruby-bin-debugger/bintest/mrdb.rb`, `print.rb` | the same, and the block over the two arms of the program stops shadowing `cmd` |

Four commits, each green on its own.

### The suite depended on the shape of the temporary directory's name

```console
$ TMPDIR='/tmp/dir with space' rake test:bin        # on master
compile.c: cannot open program file. (with)
Cannot open files: with space/test.mrb /tmp/dir with space/test.rb
...
  Total: 133
     KO: 60
```

Nothing is at fault beyond the quoting: `mrbc -o /tmp/dir with space/test.mrb ...` is four arguments once a shell has read it. A path holding a character the shell takes for syntax has the same problem, and there the outcome is not a failed test but a command the test did not write.

### `cmd_list()` is the form the harness already had

`test/bintest.rb` answers the command three ways: `cmd_bin()` for the path, `cmd_list()` for the whole command as a list of words, emulator prefix included, and `cmd()` for that list joined with spaces so a shell can take it apart again. The assertion helpers already used the list, `Open3.capture3(*(cmd_list("mrb") + args))`, while the calls around them used the string. They now use the same list:

- a backtick call becomes `Open3.capture2`, or `Open3.capture2e` where the command ended in `2>&1`, and the `$?` beside it becomes the status the call answers;
- `system("...")` becomes `assert_run(...)`, below;
- `shellquote()` goes with the shell that needed it.

### A fixture that did not build said nothing about `mrbc`

The 25 fixture builds threw the result away, and a build that fails leaves an empty file, which is one the tool under test refuses for a reason of its own. Pointing `MRBCFILE` at a path that is not there, on master:

```
Fail: mrb can execute .mrb files (mrbgems: mruby-bin-mrb)
 - Assertion[1]
    Expected: "hello from mrb"
      Actual: ""
```

and with `assert_run()`:

```
Fail: mrb can execute .mrb files (mrbgems: mruby-bin-mrb)
 - Assertion[1] mrbc -o /tmp/test.mrb /tmp/test.rb did not run.
```

`system` answers false for a tool that ran and failed and nil for one that could not be run at all, and neither is a fixture to go on with. The two `mruby-strip` runs whose effect the test measures afterwards take the same assertion, and in `mruby-bin-mrbc` the three runs asked for their output rather than for success assert their status beside it.

### The one command that keeps a shell is quoted whole

In `mruby-bin-mrbc`, the test for a non-seekable input runs `cat FILE | mrbc -c /dev/stdin`. What it tests is what arrives through a pipe, and the pipeline is the shell's to build, so it stays a shell command. Both halves are quoted for that shell now: the path through `shellquote()` as before, and the command through `Shellwords.join(cmd_list('mrbc'))`, since a build directory or an emulator argument can hold a space just as a temporary path can.

`cmd()` has no caller left in the tree and `shellquote()` has one. Both stay, for that call and for the bintests of gems outside this tree.

The same file asks the build whether it has Float by running `mruby -e Float` and reading the status. That run stays a plain `system`: what it fails with is the answer, not a broken fixture. A comment says so.

No test changes what it asserts, and the suite is the same size.

## Testing

`build_config/ci/gcc-clang.rb`, five builds: bintest 133 total, 0 KO, 0 crash, and mrbtest unchanged from master in every build (`full-debug` 2,551, `bintest` 2,551, `cxx_abi` 2,551, `byte-string` 2,474, `ascii-ctype` 2,542), 0 KO throughout. `build_config/default.rb`: 122 bintests and 2,316 tests, 0 KO. Each of the four commits was checked out and run through the suite on its own: 133 bintests and 2,551 tests, 0 KO, every time. No C source is touched, so no binary changes.

Each commit was measured against what it is for, with the same build both times:

| | master | this PR |
| --- | ---: | ---: |
| `rake test:bin` with `TMPDIR` holding a space | 133 total, 60 KO | 133 total, 0 KO |
| the same with an ordinary `TMPDIR` | 133 total, 0 KO | 133 total, 0 KO |
| the suite with `MRBCFILE` pointing at a path that is not there | fails on the tool under test | fails naming the command that did not run |
| `mruby-bin-mrbc`'s bintest with `mrbc` in a directory holding a space | 8 total, 1 KO | 8 total, 0 KO |

## Environment

<details>
<summary>host and compilers</summary>

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS |
| kernel | Linux 7.0.0-30-generic x86_64 |
| CPU | AMD Ryzen 9 5950X 16-Core Processor |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0 |
| Ruby running the bintests | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command execution reliability across debugger, interpreter, compiler, and stripping tool tests.
  * Added coverage confirming directories are rejected when supplied as program or library files, with clear error messages.

* **Tests**
  * Standardized subprocess status and output validation.
  * Improved handling of command arguments and platform-specific execution scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->