### PR TITLE
string.c: make each write answer for what the bytes it leaves read as

### DIFF
--- a/include/mruby/internal.h
+++ b/include/mruby/internal.h
@@ -237,6 +237,26 @@ mrb_bool mrb_str_beg_len(mrb_int str_len, mrb_int *begp, mrb_int *lenp);
 mrb_value mrb_str_byte_subseq(mrb_state *mrb, mrb_value str, mrb_int beg, mrb_int len);
 mrb_value mrb_str_aref(mrb_state *mrb, mrb_value str, mrb_value idx, mrb_value len);
 void mrb_str_aset(mrb_state *mrb, mrb_value str, mrb_value idx, mrb_value len, mrb_value replace);
+
+/* mrb_str_modify() for a caller whose write leaves what the bytes read as
+   standing: it puts ASCII where ASCII stood, or it cuts where a character
+   ends. The next asker is then spared the walk that would arrive at the
+   answer the string already carries. The promise cannot be checked from
+   inside, which is why this is here rather than in mruby/string.h: a caller
+   that cannot answer for its write wants mrb_str_modify(). */
+#ifdef MRB_UTF8_STRING
+/* See the definition in string.c for what a string read as broken is asked
+   again about. */
+void mrb_str_modify_keep_cr(mrb_state *mrb, struct RString *s);
+#else
+/* A build that indexes by byte records nothing about the bytes, so there is
+   nothing here to keep and this is mrb_str_modify() itself. Naming it rather
+   than compiling a second body of it leaves such a build the size it was,
+   while the callers that reach both builds go on spelling the promise they
+   make. */
+#define mrb_str_modify_keep_cr(mrb, s) mrb_str_modify(mrb, s)
+#endif
+
 mrb_bool mrb_strcasecmp_p(const char *s1, mrb_int len1, const char *s2, mrb_int len2);
 #define MRB_STR_CASECMP_P(str, lit) \
   mrb_strcasecmp_p(RSTRING_PTR(str), RSTRING_LEN(str), lit, sizeof(lit"")-1)

--- a/mrbgems/mruby-encoding/mrbgem.rake
+++ b/mrbgems/mruby-encoding/mrbgem.rake
@@ -5,4 +5,12 @@ MRuby::Gem::Specification.new('mruby-encoding') do |spec|
   spec.build.defines << "HAVE_MRUBY_ENCODING_GEM"
   spec.build.defines << "MRB_UTF8_STRING"
   spec.add_test_dependency 'mruby-string-ext'
+  # The tests ask String for the methods that change a receiver, so that a
+  # method the build carries and the coderange checklist does not name fails
+  # the suite rather than going unasked.
+  spec.add_test_dependency 'mruby-metaprog'
+  # String#bitwise_*! write arbitrary bytes over a receiver, so they belong in
+  # that checklist; without the gem the tests would ask a method that is not
+  # there and pass on the refusal.
+  spec.add_test_dependency 'mruby-string-bitops'
 end

--- a/mrbgems/mruby-encoding/test/string.rb
+++ b/mrbgems/mruby-encoding/test/string.rb
@@ -344,6 +344,70 @@ assert('String#swapcase! leaves what the bytes read as standing') do
   end
 end
 
+assert('the prefix and suffix cuts ask again about the bytes they break') do
+  # `delete_prefix!` and `delete_suffix!` match by their bytes with nothing
+  # asked about where characters end, so either can cut a character in two and
+  # leave its head or its tail standing on its own. Where the cut lands on a
+  # byte that begins a character it leaves whole characters on both sides and
+  # what the rest is read as still stands; where it lands inside one, the
+  # answer has to be asked again. Each string below is read once before the
+  # cut, so the answer asked for after it is the one the cut left behind.
+  if UTF8STRING
+    a = "あ"
+    assert_true a.valid_encoding?
+    a.delete_suffix!("\x82")   # cuts one byte off a three-byte character
+    assert_equal "\xE3\x81".b, a.b
+    assert_false a.valid_encoding?
+
+    b = "あ"
+    assert_true b.valid_encoding?
+    b.delete_prefix!("\xE3")
+    assert_equal "\x81\x82".b, b.b
+    assert_false b.valid_encoding?
+
+    # The same cut on the branch that slides the start of a shared buffer,
+    # which writes no byte and so reaches no write helper of its own.
+    base = "あ" * 100
+    c = base.dup
+    assert_true c.valid_encoding?
+    c.delete_prefix!("\xE3")
+    assert_false c.valid_encoding?
+    assert_true base.valid_encoding?
+
+    # A cut landing where a character begins leaves the answer standing, and
+    # the answer it leaves is the right one.
+    d = "あい"
+    assert_true d.valid_encoding?
+    d.delete_prefix!("あ")
+    assert_equal "い", d
+    assert_equal 1, d.length
+    assert_true d.valid_encoding?
+
+    e = "あ\n"
+    assert_true e.valid_encoding?
+    e.delete_suffix!("\n")
+    assert_equal "あ", e
+    assert_equal 1, e.length
+    assert_true e.valid_encoding?
+
+    # A string already read as broken is the one neither can answer for, since
+    # a cut is as likely to have mended it as to have left it broken.
+    f = "\xE3\x81あ"
+    assert_false f.valid_encoding?
+    f.delete_prefix!("\xE3\x81")
+    assert_equal "あ", f
+    assert_true f.valid_encoding?
+
+    # Nothing matched is nothing cut, so what the string reads as stands.
+    g = "あ"
+    assert_true g.valid_encoding?
+    assert_nil g.delete_prefix!("\x82")
+    assert_nil g.delete_suffix!("\xE3")
+    assert_equal 1, g.length
+    assert_true g.valid_encoding?
+  end
+end
+
 assert('String#encoding') do
   if UTF8STRING
     a = "あ"

--- a/mrbgems/mruby-encoding/test/string.rb
+++ b/mrbgems/mruby-encoding/test/string.rb
@@ -45,6 +45,104 @@ assert('String#valid_encoding? survives what the string goes through') do
   end
 end
 
+assert('every mutating method leaves an answer the string can stand behind') do
+  # The one rule underneath all of this: after a write, what the string says
+  # about its own bytes is either true of them or UNKNOWN. A write that keeps a
+  # true answer spares the next asker a walk; a write that cannot answer for
+  # what it did has to drop the answer instead. Neither is checkable from
+  # inside the write, so it is checked here, against every method that can
+  # change a receiver: the list is the checklist, and a method missing from it
+  # is a method nothing is asking this of.
+  #
+  # Each case runs the same write twice: once on a string that was read before
+  # it, and once on one that was not. The two have to agree afterwards. Where
+  # the write raises it has to raise on both, and the two are left as they were.
+  if UTF8STRING
+    ops = {
+      "<<"             => ->(s) { s << "\x80" },
+      "concat"         => ->(s) { s.concat("\xC0") },
+      "replace"        => ->(s) { s.replace("\xED\xA0\x80") },
+      "insert"         => ->(s) { s.insert(0, "\xFE") },
+      "prepend"        => ->(s) { s.prepend("\x81") },
+      "[]="            => ->(s) { s[0] = "\xF5" },
+      "sub!"           => ->(s) { s.sub!("あ", "\xE0\x80") },
+      "gsub!"          => ->(s) { s.gsub!("あ", "\xF5") },
+      "chop!"          => ->(s) { s.chop! },
+      "chomp!"         => ->(s) { s.chomp! },
+      "lstrip!"        => ->(s) { s.lstrip! },
+      "rstrip!"        => ->(s) { s.rstrip! },
+      "strip!"         => ->(s) { s.strip! },
+      "upcase!"        => ->(s) { s.upcase! },
+      "downcase!"      => ->(s) { s.downcase! },
+      "capitalize!"    => ->(s) { s.capitalize! },
+      "swapcase!"      => ->(s) { s.swapcase! },
+      "reverse!"       => ->(s) { s.reverse! },
+      "succ!"          => ->(s) { s.succ! },
+      "next!"          => ->(s) { s.next! },
+      "tr!"            => ->(s) { s.tr!("a", "\xE3") },
+      "tr_s!"          => ->(s) { s.tr_s!("a", "\xE3") },
+      "squeeze!"       => ->(s) { s.squeeze! },
+      "delete!"        => ->(s) { s.delete!("a") },
+      "slice!"         => ->(s) { s.slice!(0) },
+      "clear"          => ->(s) { s.clear },
+      # Both cut one byte off an end, which is where a character can be left
+      # standing without its head or its tail.
+      "delete_prefix!" => ->(s) { b = s.bytes.first; s.delete_prefix!(b.chr) if b },
+      "delete_suffix!" => ->(s) { b = s.bytes.last;  s.delete_suffix!(b.chr) if b },
+      # Writes that reach past the core gem. The bitwise pair takes an operand
+      # of the receiver's own width, so it has something to do on every base.
+      "setbyte"        => ->(s) { s.setbyte(0, 0x80) },
+      "bytesplice"     => ->(s) { s.bytesplice(0, 1, "\x80") },
+      "bitwise_and!"   => ->(s) { s.bitwise_and!("\x7f" * s.bytesize) },
+      "bitwise_or!"    => ->(s) { s.bitwise_or!("\x80" * s.bytesize) },
+      "bitwise_xor!"   => ->(s) { s.bitwise_xor!("\xff" * s.bytesize) },
+      "bitwise_not!"   => ->(s) { s.bitwise_not! },
+      # Not a write at all, but it changes what the bytes are read as, which is
+      # the same answer by another route. The round trip is the direction that
+      # can turn a string nothing was wrong with into a broken one.
+      "force_encoding" => ->(s) { s.force_encoding("BINARY") },
+      "force_encoding back" =>
+                          ->(s) { s.force_encoding("BINARY"); s.force_encoding("UTF-8") },
+    }
+    # Valid and broken, ASCII and not, with the whitespace and the repetition
+    # that make each write above find something to do.
+    bases = ["あ", "あa", "aあ", "  あ  ", "\tあ\n", "\0あ\0", "あ" * 40,
+             "abc", "a" * 40, "  abc  ", "",
+             "\x80", "a\x80b", "\xE3\x81", "\xED\xA0\x80"]
+    # Two readings, because they leave different answers behind: the walk
+    # settles on VALID or BROKEN, while counting marks only 7BIT.
+    reads = [->(s) { s.valid_encoding? }, ->(s) { s.length }]
+
+    # The list above is only a checklist while something keeps it honest. A
+    # method whose name ends in `!` changes its receiver, so one the build
+    # carries and the list does not name is one nothing is asking this of,
+    # which is how `delete_prefix!` and `delete_suffix!` stayed broken. The
+    # writes that do not announce themselves in their name (`<<`, `setbyte`,
+    # `force_encoding` and the rest above) still have to be added by hand.
+    untested = String.instance_methods.map { |m| m.to_s }
+                     .select { |m| m.end_with?("!") && m != "!" && !ops[m] }
+    assert_equal [], untested.sort, "String methods that change a receiver with no case here"
+
+    ops.each do |name, op|
+      bases.each do |base|
+        reads.each do |read|
+          warm = base.dup
+          read.call(warm)                       # remember an answer first
+          wraised = (begin; op.call(warm); nil; rescue => e; e.class; end)
+          cold = base.dup
+          craised = (begin; op.call(cold); nil; rescue => e; e.class; end)
+          where = "#{name} on #{base.inspect}"
+          assert_equal craised, wraised, where
+          next if wraised
+          assert_equal cold.bytes, warm.bytes, where
+          assert_equal cold.valid_encoding?, warm.valid_encoding?, where
+          assert_equal cold.length, warm.length, where
+        end
+      end
+    end
+  end
+end
+
 assert('String#valid_encoding? after an append inside a shared buffer') do
   # An append to a string sharing a buffer with room to spare writes in place
   # rather than detaching, and that path forgets the remembered answer on its

--- a/mrbgems/mruby-encoding/test/string.rb
+++ b/mrbgems/mruby-encoding/test/string.rb
@@ -251,6 +251,99 @@ assert('String#reverse! leaves what the bytes read as standing') do
   end
 end
 
+assert('the strip family leaves what the bytes read as standing') do
+  # Whitespace is ASCII, so a cut off either end lands where a character ends,
+  # and what the rest is read as is still the answer. The three keep it rather
+  # than dropping it for the next asker to walk to again; a string already read
+  # as broken is the one they cannot answer for, since a cut is as likely to
+  # have mended it as to have left it broken. Each string below is read once
+  # before the cut, so the answer asked for after it is the kept one.
+  if UTF8STRING
+    a = "  あい  "
+    assert_equal 6, a.length
+    a.strip!
+    assert_equal "あい", a
+    assert_equal 2, a.length
+    assert_true a.valid_encoding?
+
+    b = "\tあ\n"
+    assert_true b.valid_encoding?
+    b.lstrip!
+    assert_equal "あ\n", b
+    assert_equal 2, b.length
+    b.rstrip!
+    assert_equal "あ", b
+    assert_equal 1, b.length
+    assert_true b.valid_encoding?
+
+    # A NUL is whitespace to these three, and an ASCII byte like the rest.
+    c = "\0あ\0"
+    assert_equal 3, c.length
+    c.strip!
+    assert_equal "あ", c
+    assert_equal 1, c.length
+    assert_true c.valid_encoding?
+
+    # Broken before the cut and broken after it: the answer is asked again
+    # rather than kept, and comes back the same.
+    d = " a\xE3\x81 "
+    assert_false d.valid_encoding?
+    d.strip!
+    assert_equal "a\xE3\x81".b, d.b
+    assert_false d.valid_encoding?
+
+    # Nothing to cut is nothing changed, so what the string reads as stands.
+    e = "あ"
+    assert_true e.valid_encoding?
+    assert_nil e.strip!
+    assert_nil e.lstrip!
+    assert_nil e.rstrip!
+    assert_equal 1, e.length
+    assert_true e.valid_encoding?
+  end
+end
+
+assert('String#swapcase! leaves what the bytes read as standing') do
+  # The ASCII loop `swapcase!` falls back to is reached for a string that holds
+  # nothing but ASCII or is read as bytes, and it puts ASCII where ASCII stood.
+  # Where the build has no case tables the loop is the whole of the method, and
+  # a byte above ASCII is no letter to it, so it is left alone there too.
+  if UTF8STRING
+    a = "aB"
+    assert_equal 2, a.length
+    a.swapcase!
+    assert_equal "Ab", a
+    assert_equal 2, a.length
+    assert_true a.valid_encoding?
+
+    b = "\xC3\x84B".b   # the bytes of "Ä", read as bytes
+    b.swapcase!
+    assert_equal [195, 132, 98], b.bytes
+    assert_equal Encoding::BINARY, b.encoding
+    assert_true b.valid_encoding?
+
+    c = "Äb"
+    assert_true c.valid_encoding?
+    c.swapcase!
+    assert_equal 2, c.length
+    assert_true c.valid_encoding?
+    assert_equal(UNICODECASE ? "äB" : "ÄB", c)
+
+    # Bytes that spell no character are the walk's to refuse where it runs at
+    # all; where it does not, the loop finds no letter among them and leaves
+    # the string whole.
+    d = "\xE3\x81"
+    assert_false d.valid_encoding?
+    if UNICODECASE
+      assert_raise(ArgumentError) { d.swapcase! }
+    else
+      assert_nil d.swapcase!
+    end
+    assert_equal "\xE3\x81".b, d.b
+    assert_false d.valid_encoding?
+  end
+end
+
 assert('String#encoding') do
   if UTF8STRING
     a = "あ"

--- a/mrbgems/mruby-string-ext/src/string.c
+++ b/mrbgems/mruby-string-ext/src/string.c
@@ -1443,6 +1443,49 @@ str_scrub_chunks(mrb_state *mrb, mrb_value self)
 }
 #endif
 
+/* Whether cutting the `cutlen` bytes at `cut` off an end of `s` leaves what
+   the rest of it is read as standing. A byte below 0x80 stands for a character
+   of its own and is never part of one that began earlier, so a cut of nothing
+   but ASCII lands exactly where a character ends; and it cannot have taken the
+   last non-ASCII byte with it either, so a string that was read as UTF-8 with
+   characters in it still is. Cutting a byte at or above 0x80 can do both, and
+   what is left has to be asked about again. This is the question `chomp!` in
+   src/string.c asks of the bytes it cuts.
+
+   Asked before the cut, of a string that has an answer to keep: one carrying
+   nothing has none, and one holding a character per byte is cutting ASCII
+   whatever it cuts, so neither is worth reading a byte for. */
+static mrb_bool
+str_cut_keeps_cr(struct RString *s, const char *cut, mrb_int cutlen)
+{
+#ifdef MRB_UTF8_STRING
+  if (RSTR_CODERANGE(s) == MRB_STR_CODERANGE_UNKNOWN) return FALSE;
+  if (RSTR_CODERANGE(s) == MRB_STR_CODERANGE_7BIT) return TRUE;
+  for (mrb_int i = 0; i < cutlen; i++) {
+    if ((uint8_t)cut[i] & 0x80) return FALSE;
+  }
+  return TRUE;
+#else
+  (void)s; (void)cut; (void)cutlen;
+  return FALSE;
+#endif
+}
+
+/* mrb_str_modify_keep_cr()'s rule without the unsharing, which a cut that
+   writes no byte has no use for. A build that records nothing has nothing to
+   say here, down to the arguments. */
+static void
+str_cut_coderange(struct RString *s, mrb_bool keep_cr)
+{
+#ifdef MRB_UTF8_STRING
+  if (!keep_cr || RSTR_CODERANGE(s) == MRB_STR_CODERANGE_BROKEN) {
+    RSTR_CODERANGE_SET(s, MRB_STR_CODERANGE_UNKNOWN);
+  }
+#else
+  (void)s; (void)keep_cr;
+#endif
+}
+
 static mrb_bool
 str_prefix_p(mrb_state *mrb, mrb_value str, const char *prefix_ptr, mrb_int prefix_len)
 {
@@ -1473,15 +1516,21 @@ str_del_prefix_bang(mrb_state *mrb, mrb_value self)
   if (plen > slen) return mrb_nil_value();
   char *s = RSTR_PTR(str);
   if (!str_prefix_p(mrb, self, ptr, plen)) return mrb_nil_value();
+  /* The prefix matched, so its bytes are the ones being cut. */
+  mrb_bool keep_cr = str_cut_keeps_cr(str, ptr, plen);
   if (!mrb_frozen_p(str) && (RSTR_SHARED_P(str) || RSTR_FSHARED_P(str))) {
+    /* Sliding the start of a shared buffer writes no byte, so there is nothing
+       to unshare, and nothing here drops the answer the string was carrying,
+       which is what the branch below gets from its modify. */
     str->as.heap.ptr += plen;
   }
   else {
-    mrb_str_modify(mrb, str);
+    mrb_str_modify_keep_cr(mrb, str);
     s = RSTR_PTR(str);
     memmove(s, s+plen, slen-plen);
   }
   RSTR_SET_LEN(str, slen-plen);
+  str_cut_coderange(str, keep_cr);
   return self;
 }
 
@@ -1538,7 +1587,11 @@ str_del_suffix_bang(mrb_state *mrb, mrb_value self)
   mrb_int slen = RSTR_LEN(str);
   if (plen > slen) return mrb_nil_value();
   if (!str_suffix_p(mrb, self, ptr, plen)) return mrb_nil_value();
+  /* Cutting the end back writes no byte, so there is nothing to unshare. The
+     suffix matched, so its bytes are the ones being cut. */
+  mrb_bool keep_cr = str_cut_keeps_cr(str, ptr, plen);
   RSTR_SET_LEN(str, slen-plen);
+  str_cut_coderange(str, keep_cr);
   return self;
 }
 

--- a/mrbgems/mruby-string-ext/src/string.c
+++ b/mrbgems/mruby-string-ext/src/string.c
@@ -75,7 +75,11 @@ str_swapcase_bang(mrb_state *mrb, mrb_value str)
   int modify = 0;
   struct RString *s = mrb_str_ptr(str);
 
-  mrb_str_modify(mrb, s);
+  /* The loop below swaps ASCII letters and passes every other byte through, so
+     it puts ASCII where ASCII stood and leaves what the bytes read as standing.
+     That holds both where the walk above declined the string and where the
+     build carries no tables for it to walk with. */
+  mrb_str_modify_keep_cr(mrb, s);
   char *p = RSTRING_PTR(str);
   char *pend = p + RSTRING_LEN(str);
   while (p < pend) {
@@ -1892,7 +1896,9 @@ str_lstrip_bang(mrb_state *mrb, mrb_value self)
   mrb_int start = 0;
 
   mrb_check_frozen(mrb, mrb_obj_ptr(self));
-  mrb_str_modify(mrb, s);
+  /* Whitespace is ASCII, so the cut below lands where a character ends and
+     what the rest is read as stands. */
+  mrb_str_modify_keep_cr(mrb, s);
   char *ptr = RSTR_PTR(s);
 
   /* Find first non-whitespace character */
@@ -1937,7 +1943,9 @@ str_rstrip_bang(mrb_state *mrb, mrb_value self)
   mrb_int end = len;
 
   mrb_check_frozen(mrb, mrb_obj_ptr(self));
-  mrb_str_modify(mrb, s);
+  /* Whitespace is ASCII, so the cut below lands where a character ends and
+     what the rest is read as stands. */
+  mrb_str_modify_keep_cr(mrb, s);
   char *ptr = RSTR_PTR(s);
 
   /* Find last non-whitespace character */
@@ -1976,7 +1984,9 @@ str_strip_bang(mrb_state *mrb, mrb_value self)
   mrb_bool changed = FALSE;
 
   mrb_check_frozen(mrb, mrb_obj_ptr(self));
-  mrb_str_modify(mrb, s);
+  /* Whitespace is ASCII, so the cuts below land where a character ends and
+     what the rest is read as stands. */
+  mrb_str_modify_keep_cr(mrb, s);
   char *ptr = RSTR_PTR(s);
 
   /* Find first non-whitespace character */

--- a/mrbgems/mruby-string-ext/test/string.rb
+++ b/mrbgems/mruby-string-ext/test/string.rb
@@ -199,7 +199,7 @@ end
 
 assert('String#swapcase! - a frozen receiver') do
   skip unless UNICODECASE
-  # The Unicode walk raises from inside str_modify_keep_cr(), the same site
+  # The Unicode walk raises from inside mrb_str_modify_keep_cr(), the same site
   # String#downcase! raises from, before the ASCII loop str_swapcase_bang
   # otherwise runs.
   assert_raise(FrozenError) { "Ä".freeze.swapcase! }

--- a/src/string.c
+++ b/src/string.c
@@ -1440,6 +1440,7 @@ mrb_str_modify(mrb_state *mrb, struct RString *s)
   RSTR_CODERANGE_SET(s, MRB_STR_CODERANGE_UNKNOWN);
 }
 
+#ifdef MRB_UTF8_STRING
 /* mrb_str_modify() for a caller whose write leaves what the bytes read as
    standing: it puts ASCII where ASCII stood, or it cuts where a character
    ends. Such a write cannot turn a sound string unsound, so the answer the
@@ -1453,9 +1454,11 @@ mrb_str_modify(mrb_state *mrb, struct RString *s)
    one, and finding the truth is the walk this is here to skip.
 
    The promise this asks of its caller cannot be checked here, which is why
-   it is not offered outside the library. */
-static void
-str_modify_keep_cr(mrb_state *mrb, struct RString *s)
+   it is declared in mruby/internal.h rather than a public header: it is for
+   a caller inside the library, who can answer for the write, and not for
+   whoever includes mruby/string.h. */
+void
+mrb_str_modify_keep_cr(mrb_state *mrb, struct RString *s)
 {
   mrb_check_frozen(mrb, s);
   str_unshare_buffer(mrb, s);
@@ -1463,6 +1466,7 @@ str_modify_keep_cr(mrb_state *mrb, struct RString *s)
     RSTR_CODERANGE_SET(s, MRB_STR_CODERANGE_UNKNOWN);
   }
 }
+#endif
 
 /*
  * @param mrb The mruby state.
@@ -2374,7 +2378,7 @@ mrb_str_case_convert_unicode(mrb_state *mrb, mrb_value str, enum mrb_case_mode m
      not be recorded as holding one character per byte. */
   if (RSTR_BINARY_P(s) || str_ascii_p(s)) return -1;
 
-  str_modify_keep_cr(mrb, s);
+  mrb_str_modify_keep_cr(mrb, s);
 
   return str_case_convert_utf8(mrb, str, mode) ? 1 : 0;
 }
@@ -2404,7 +2408,7 @@ mrb_str_capitalize_bang(mrb_state *mrb, mrb_value str)
   struct RString *s = mrb_str_ptr(str);
   mrb_int len = RSTR_LEN(s);
 
-  str_modify_keep_cr(mrb, s);
+  mrb_str_modify_keep_cr(mrb, s);
   char *p = RSTR_PTR(s);
   char *pend = RSTR_PTR(s) + len;
   if (len == 0 || p == NULL) return mrb_nil_value();
@@ -2458,7 +2462,7 @@ mrb_str_chomp_bang(mrb_state *mrb, mrb_value str)
   mrb_int argc = mrb_get_args(mrb, "|S", &rs);
   struct RString *s = mrb_str_ptr(str);
 
-  str_modify_keep_cr(mrb, s);
+  mrb_str_modify_keep_cr(mrb, s);
   mrb_int len = RSTR_LEN(s);
   if (argc == 0) {
     if (len == 0) return mrb_nil_value();
@@ -2517,11 +2521,11 @@ mrb_str_chomp_bang(mrb_state *mrb, mrb_value str)
     if (!RSTR_SINGLE_BYTE_P(s) && mrb_utf8_char_head(p, pp, p + len) != pp) {
       return mrb_nil_value();
     }
-    /* Cutting bytes that are nothing but ASCII leaves what the rest is read as
-       standing, non-ASCII and all, so the coderange str_modify_keep_cr() kept
-       is still the answer. Cutting a non-ASCII byte can have taken the last of
-       them, and a string of nothing but ASCII stands at 7BIT rather than
-       VALID: what it is has to be asked again. */
+    /* Cutting bytes that are nothing but ASCII leaves what the rest is read
+       as standing, non-ASCII and all, so the coderange that
+       mrb_str_modify_keep_cr() kept is still the answer. Cutting a non-ASCII
+       byte can have taken the last of them, and a string of nothing but ASCII
+       stands at 7BIT rather than VALID: what it is has to be asked again. */
     if (search_nonascii(pp, pp + rslen) != pp + rslen) {
       RSTR_CODERANGE_SET(s, MRB_STR_CODERANGE_UNKNOWN);
     }
@@ -2573,7 +2577,7 @@ mrb_str_chop_bang(mrb_state *mrb, mrb_value str)
 {
   struct RString *s = mrb_str_ptr(str);
 
-  str_modify_keep_cr(mrb, s);
+  mrb_str_modify_keep_cr(mrb, s);
   if (RSTR_LEN(s) > 0) {
     /* The last position of a single-byte string is its last byte. */
     mrb_int len = RSTR_LEN(s) - 1;
@@ -2651,7 +2655,7 @@ mrb_str_downcase_bang(mrb_state *mrb, mrb_value str)
   mrb_bool modify = FALSE;
   struct RString *s = mrb_str_ptr(str);
 
-  str_modify_keep_cr(mrb, s);
+  mrb_str_modify_keep_cr(mrb, s);
   p = RSTR_PTR(s);
   pend = RSTR_PTR(s) + RSTR_LEN(s);
   while (p < pend) {
@@ -3086,7 +3090,7 @@ mrb_str_reverse_bang(mrb_state *mrb, mrb_value str)
 
   /* Reversing writes the string's own bytes back in another order, and both
      paths below leave every character whole, so a string that read as UTF-8
-     still does: both write through str_modify_keep_cr(). A string already
+     still does: both write through mrb_str_modify_keep_cr(). A string already
      read as broken is the one this cannot answer for, since bytes that spell
      nothing where they stand can spell a character turned around, and that is
      the string the helper asks again on its own. */
@@ -3108,7 +3112,7 @@ mrb_str_reverse_bang(mrb_state *mrb, mrb_value str)
     return str;
   }
   if (utf8_len < len) {
-    str_modify_keep_cr(mrb, s);
+    mrb_str_modify_keep_cr(mrb, s);
     p = RSTR_PTR(s);
     e = p + RSTR_LEN(s);
     while (p<e) {
@@ -3123,7 +3127,7 @@ mrb_str_reverse_bang(mrb_state *mrb, mrb_value str)
   /* Reached with one character per byte, where the reversal below is a byte
      reversal that cuts no character in two. */
   if (RSTR_LEN(s) > 1) {
-    str_modify_keep_cr(mrb, s);
+    mrb_str_modify_keep_cr(mrb, s);
     goto bytes;
   }
   /* As above, for a build that reads one character per byte. */
@@ -3855,7 +3859,7 @@ mrb_str_upcase_bang(mrb_state *mrb, mrb_value str)
   char *p, *pend;
   mrb_bool modify = FALSE;
 
-  str_modify_keep_cr(mrb, s);
+  mrb_str_modify_keep_cr(mrb, s);
   p = RSTRING_PTR(str);
   pend = RSTRING_END(str);
   while (p < pend) {


### PR DESCRIPTION
## Summary

After a write, what a string says about its own bytes is either true of them or UNKNOWN. Four writes were dropping an answer they could not have broken, so the next asker paid for a walk that arrives at what the string came in carrying; two were keeping an answer about bytes they had already cut in half.

## Changes

| File | What |
|---|---|
| `src/string.c` | `str_modify_keep_cr()` loses `static` and takes the published name `mrb_str_modify_keep_cr()` |
| `include/mruby/internal.h` | declares it, or names `mrb_str_modify()` where strings index by byte |
| `mrbgems/mruby-string-ext/src/string.c` | `swapcase!` / `lstrip!` / `rstrip!` / `strip!` write through it; `delete_prefix!` / `delete_suffix!` gain `str_cut_keeps_cr()` and `str_cut_coderange()` |
| `mrbgems/mruby-encoding/test/string.rb` | the six methods above, and the rule itself over every method that changes a receiver |
| `mrbgems/mruby-encoding/mrbgem.rake` | `mruby-metaprog` and `mruby-string-bitops` as test dependencies |

### The rule

A write that keeps a true answer spares the next asker a walk; a write that cannot answer for what it did has to drop the answer instead. Neither is checkable from inside the write: `mrb_str_modify_keep_cr()` takes the caller's word, and a write that reaches neither helper is taken at its word by nobody at all.

### The coderange-keeping write is offered under a published name

`str_modify_keep_cr()` was `static` in `src/string.c`, and the one thing outside that file that offered anything similar, `mrb_str_modify_keep_ascii()`, is gone; a gem was left with `mrb_str_modify()`, which always drops the answer. The helper takes the published name and is declared in `include/mruby/internal.h`, which is where a write a caller has to answer for belongs: inside the library rather than in a header whoever includes `mruby/string.h` reads.

A build that indexes its strings by byte records nothing about them, so there is nothing there for this to keep and it is `mrb_str_modify()` itself. It is named so rather than compiled as a second body of the same code, which is why the byte-indexed build in the table below does not move at all.

### Four writes keep an answer they cannot break

- `String#swapcase!`: the ASCII loop it falls back to swaps ASCII letters and passes every other byte through. That holds both where the Unicode walk declined the string and where the build carries no tables for it to walk with. `ISUPPER(c)` is `((unsigned)(c) - 'A') < 26` and `ISLOWER(c)` is `((unsigned)(c) - 'a') < 26`, false for every byte from 0x80 up, so a `MRB_USE_ASCII_CTYPE` build, where the walk is a `(-1)` macro and the loop sees multibyte strings too, still leaves non-ASCII bytes alone.
- `String#lstrip!` / `rstrip!` / `strip!`: each cuts ASCII whitespace off one or both ends, which is always where a character ends, the same reason `chomp!` and `chop!` were safe to convert.

`swapcase!` pays for this on its own account, not only through the next asker: with the answer dropped it rescanned the receiver to find out it was ASCII before reaching the loop.

`tr!`, `tr_s!`, `squeeze!`, `delete!`, `succ!`, `insert` and `prepend` are left as they are. Each is byte-oriented and each demonstrably turns a valid receiver into a broken one, so a write that drops the answer is what they need: `"あ".tr!("\x82","x")`, `"\u{A69A}".squeeze!("\x9A")`, `"あ".delete!("\x81")`, `"\xff".succ!`.

### Two writes ask again about the bytes they can break

The other half of the rule, and a wrong answer rather than a slow one. `delete_prefix!` and `delete_suffix!` match by their bytes with nothing asked about where characters end, so either can cut a character in two. `delete_suffix!` called no modify at all; `delete_prefix!` skipped `mrb_str_modify()` on the branch that slides the start of a shared buffer.

Which of the two things a write owes is decided by the bytes being cut, the question `chomp!` in `src/string.c` already asks of the bytes it cuts. A byte below 0x80 stands for a character of its own and is never part of one that began earlier, so a cut of nothing but ASCII lands exactly where a character ends; and it cannot have taken the last non-ASCII byte with it either, so a string that was read as UTF-8 with characters in it still is, at VALID rather than at the 7BIT it would have to move to. Cutting a byte at or above 0x80 can do both, and what is left has to be asked about again. `"\n"`, `"/"` and `".rb"` are what these two are usually given, so the common case keeps its answer.

The bytes asked are the argument's, which the method has already read through once to find that it matched, so nothing is walked here that was not walked before it; and a receiver already holding a character per byte is cutting ASCII whatever it cuts, so it is settled without reading them at all.

Neither method writes a byte, so neither needs the buffer copy `mrb_str_modify()` would make to unshare. The non-shared arm of `delete_prefix!` moves to `mrb_str_modify_keep_cr()` so that the unsharing copy does not drop what the line below is about to decide.

`String#slice!` takes both its cut points from `mrb_str_char_to_byte()`, so they are character-aligned and it would be safe to convert; the audit shows it is already correct, and that is an optimization rather than part of this rule.

### The rule is checked from outside, and the build says what the checklist is missing

Since neither half is checkable from inside a write, it is checked from outside, over every method that can change a receiver: 36 writes against 15 receivers (valid and broken, ASCII and not, with the whitespace and repetition that make each write find something to do) and two prior readings, since the walk settles VALID or BROKEN while counting marks only 7BIT. Each case runs the same write twice, once on a string read before it and once on one that was not; the two have to agree on their bytes, their validity and their length, and to raise alike where they raise.

A hand-written list is a checklist only while somebody remembers to add to it, so the list is checked too: a method whose name ends in `!` changes its receiver, so one the build carries that the list does not name fails the assert. `mruby-metaprog` and `mruby-string-bitops` join the test dependencies for the reflection and for `String#bitwise_*!`; asking a method that is not linked passes on the refusal, which is coverage that is not there either.

Still by hand: the writes that do not announce themselves in their name (`<<`, `setbyte`, `force_encoding`), and the check reaches only the gems these tests link.

## Behaviour

```ruby
s = "あ"
s.valid_encoding?          #=> true, and remembered
s.delete_suffix!("\x82")   # cuts one byte off a three-byte character
s.valid_encoding?          # master: true, of bytes that spell nothing; this PR: false

base = "あ" * 100
t = base.dup               # shares the buffer, so the cut below slides its start
t.valid_encoding?          #=> true, and remembered
t.delete_prefix!("\xE3")
t.valid_encoding?          # master: true; this PR: false
```

Nothing else observable changes. The four writes in the section above keep an answer that was already true of their result, so every method reading it after them answers as it did.

## Speed

1 MB pure-ASCII receiver, `full-core` (so `MRB_UTF8_STRING`), `gcc -O3`. Each cut below is O(1) on this receiver, so what is timed is whether the following `#length` re-walks the megabyte or reads the flag.

```ruby
MB = 1024 * 1024
N  = 100_000

def run(label, setup, body)
  t = nil
  3.times do
    s = setup.call
    t0 = Time.now
    body.call(s)
    e = (Time.now - t0) * 1000.0
    t = e if t.nil? || e < t
  end
  printf("%-26s %10.2f ms\n", label, t)
end

ascii = ->() { s = "a" * MB; s.length; s }
nl    = ->() { s = "a" * MB + "\n" * N; s.length; s }

run("chop! + length",       ascii, ->(s) { N.times { s.chop!;   s.length } })
run("rstrip! + length",     ascii, ->(s) { N.times { s.rstrip!; s.length } })
run("lstrip! + length",     ascii, ->(s) { N.times { s.lstrip!; s.length } })
run("strip! + length",      ascii, ->(s) { N.times { s.strip!;  s.length } })
run("del_suffix! + length", nl,    ->(s) { N.times { s.delete_suffix!("\n"); s.length } })
```

100,000 iterations, best of 3:

| | master | this PR | ratio |
|---|---|---|---|
| `chop!` + `#length` (already keep-cr, control) | 6.20 ms | 6.05 ms | 1.0x |
| `rstrip!` + `#length` | 2,626.25 ms | 6.21 ms | **423x** |
| `lstrip!` + `#length` | 2,629.74 ms | 6.19 ms | **425x** |
| `strip!` + `#length` | 2,610.32 ms | 6.30 ms | **414x** |
| `delete_suffix!("\n")` + `#length` | 8.46 ms | 8.50 ms | 1.0x |

`delete_suffix!` was already this fast on master, and wrong: it kept an answer it had not earned. It stays this fast and is now right.

The rest are differences of a few percent or less, where this host's wall clock is not steady enough to read, so they are counted instead. Callgrind `Ir`, with the same measurement run against an empty loop and subtracted, 2,000 iterations of the same 1 MB receiver:

| | master | this PR | ratio |
|---|---|---|---|
| `chop!` + `#length` (control) | 1,107,604 | 1,107,570 | 1.00x |
| `rstrip!` + `#length` | 918,762,387 | 1,154,325 | 796x |
| `lstrip!` + `#length` | 918,765,303 | 1,157,241 | 794x |
| `strip!` + `#length` | 918,784,712 | 1,176,140 | 781x |
| `delete_prefix!("\n")` + `#length` | 1,117,804,433 | 199,315,346 | 5.6x |
| `delete_suffix!("\n")` + `#length` | 2,311,212 | 2,337,213 | 0.99x |

`delete_suffix!` spends 13 instructions a call asking about the byte it cuts. `delete_prefix!` was dropping the answer through `mrb_str_modify()` on its copying branch, so what it gains is the walk it no longer forces; what is left is the `memmove` it has always done.

And the case conversions, three of them at call sites `mrb_str_modify_keep_cr()` already had, 20 iterations of the same receiver, base subtracted. Losing `static` costs those three nothing measurable, and `swapcase!`, which is the one moved onto it, gains the rescan it no longer does:

| | master | this PR | ratio |
|---|---|---|---|
| `swapcase!` | 281,357,256 | 272,640,014 | 1.03x |
| `downcase!` | 167,781,642 | 167,781,560 | 1.00x |
| `upcase!` | 170,928,403 | 170,928,457 | 1.00x |
| `capitalize!` | 167,783,621 | 167,783,641 | 1.00x |

## Size

`bin/mruby` `.text`, `size -A`, each build made from an empty build directory at the same path:

| Build | master | this PR | delta |
|---|---|---|---|
| `full-debug` (-O0) | 1,910,214 | 1,910,534 | +320 |
| `bintest` | 1,306,822 | 1,307,366 | +544 |
| `cxx_abi` | 1,330,313 | 1,330,825 | +512 |
| `byte-string` | 1,271,702 | 1,271,702 | ±0 |
| `ascii-ctype` | 1,293,382 | 1,293,926 | +544 |

`bintest` and `ascii-ctype` are `str_del_suffix_bang` 260 → 590 and `str_del_prefix_bang` 350 → 552, plus 16 for the out-of-line `mrb_str_modify_keep_cr()` over the `static` body it replaces (926 → 942). `cxx_abi` is the same three. Where strings index by byte, both cut helpers compile away and the name is `mrb_str_modify()` itself: not one symbol in that build changes size.

## Testing

`build_config/ci/gcc-clang.rb`, all five builds plus the bintests, each commit built from an empty build directory:

| Commit | full-debug | bintest | bintest (bin) | cxx_abi | byte-string | ascii-ctype |
|---|---|---|---|---|---|---|
| offer the write under a published name | 2551 OK | 2551 OK | 145 OK | 2551 OK | 2474 OK | 2542 OK |
| keep what the bytes read as | 2553 OK | 2553 OK | 145 OK | 2553 OK | 2474 OK | 2544 OK |
| ask again about the bytes a cut breaks | 2554 OK | 2554 OK | 145 OK | 2554 OK | 2474 OK | 2545 OK |
| ask every mutating method | 2555 OK | 2555 OK | 145 OK | 2555 OK | 2474 OK | 2546 OK |

0 KO, 0 crashes, no new compiler warnings anywhere. The new assert costs no measurable suite time.

Falsified in three directions, each failing both new asserts: letting `delete_prefix!` keep what it had, letting `delete_suffix!` keep what it had, and forcing the question about the bytes being cut to answer yes on every cut.

## Environment

<details>
<summary>Host</summary>

| | |
|---|---|
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-30-generic x86_64 |
| CPU | AMD Ryzen 9 5950X (16C/32T) |
| Memory | 64 GiB |
| C compiler | gcc 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1) |
| binutils | GNU Binutils 2.47.20260726 |
| CRuby | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |
| rake | 13.3.1 |
| valgrind | 3.27.1 |

</details>

<details>
<summary>Compile lines, one per build</summary>

`src/string.c` as each build actually compiles it, with `-MMD -c`, `-I` and `-o` dropped. `cxx_abi` is `gcc -x c++`, not `g++`; `g++` only links there. `enable_debug()` puts `-g3 -O0` after the toolchain's `-g -O3`, so `full-debug` is the one build at `-O0`.

```console
# full-debug
gcc -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c

# bintest
gcc -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK src/string.c

# cxx_abi
gcc -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c

# byte-string
gcc -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c

# ascii-ctype
gcc -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UTF-8 string mutation handling so encoding validity is preserved when edits do not alter character interpretation.
  * Corrected validity tracking for case changes, whitespace removal, prefix/suffix deletion, reversing, and related string operations.
  * Ensured validity is recalculated when removing bytes may split a character.

* **Tests**
  * Added comprehensive coverage for encoding behavior across mutating string methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->