### PR TITLE
numeric.c: answer a comparison against a NaN as unordered

### DIFF
--- a/mrbgems/mruby-compar-ext/test/compar.rb
+++ b/mrbgems/mruby-compar-ext/test/compar.rb
@@ -19,3 +19,16 @@ assert("Comparable#clamp") do
     100.clamp(0...100)
   }
 end
+
+assert("Comparable#clamp with a NaN for a bound") do
+  # A NaN stands in no order with anything, so it bounds nothing: `min <=> max`
+  # has no answer to give and clamp refuses the pair, as it does for any two
+  # bounds it cannot put in order.
+  skip unless Object.const_defined?(:Float)
+  nan = Float::NAN
+
+  assert_raise(ArgumentError) { 1.clamp(nan, 2) }
+  assert_raise(ArgumentError) { 1.clamp(0, nan) }
+  assert_raise(ArgumentError) { 1.0.clamp(nan, 2) }
+  assert_raise(ArgumentError) { 1.clamp(nan..2) }
+end

--- a/mrbgems/mruby-range-ext/test/range.rb
+++ b/mrbgems/mruby-range-ext/test/range.rb
@@ -24,6 +24,19 @@ assert('Range#cover?') do
   assert_false (.."c").cover?("d"..)
 end
 
+assert('Range#cover? with a NaN') do
+  # `cover?` reads the same comparison `===` does, and an endless range answers
+  # a covered range by testing that comparison for the pair it cannot compare,
+  # which a NaN now is.
+  skip unless Object.const_defined?(:Float)
+  nan = Float::NAN
+
+  assert_false (1..2).cover?(nan)
+  assert_false (1..).cover?(nan)
+  assert_false (..2).cover?(nan)
+  assert_false (1..).cover?(nan..)
+end
+
 assert('Range#first') do
   assert_equal 10, (10..20).first
   assert_equal [10, 11, 12], (10..20).first(3)

--- a/src/array.c
+++ b/src/array.c
@@ -2287,7 +2287,14 @@ sort_cmp(mrb_state *mrb, mrb_value ary, mrb_value a_val, mrb_value b_val, mrb_va
         break;
 #ifndef MRB_NO_FLOAT
       case MRB_TT_FLOAT:
-        cmp = (mrb_float(a_val) > mrb_float(b_val)) ? 1 : (mrb_float(a_val) < mrb_float(b_val)) ? -1 : 0;
+        {
+          /* A NaN is greater than, less than and equal to nothing at all, so
+             the pair is reported as one that cannot be compared. Falling out
+             of the two tests below would call it a tie and leave the NaN
+             wherever the sort happened to put it. */
+          mrb_float a_flo = mrb_float(a_val), b_flo = mrb_float(b_val);
+          cmp = (a_flo > b_flo) ? 1 : (a_flo < b_flo) ? -1 : (a_flo == b_flo) ? 0 : -2;
+        }
         break;
 #endif
       case MRB_TT_STRING:

--- a/src/numeric.c
+++ b/src/numeric.c
@@ -2125,23 +2125,49 @@ int_to_s(mrb_state *mrb, mrb_value self)
   return mrb_integer_to_str(mrb, self, base);
 }
 
+/* `cmpnum()` answers this for a pair that stands in no order, which is what a
+   NaN operand makes of every comparison. It is neither 0, which would say the
+   two are equal, nor -2, which says they cannot be compared at all: `num_cmp()`
+   answers nil for both, but `num_lt()` and its neighbours raise on -2 while a
+   comparison against NaN is false rather than an error. */
+#define CMP_UNORDERED (-3)
+
 #ifndef MRB_NO_FLOAT
 /* An integer wider than the significand rounds when it is cast to `mrb_float`,
    so a mixed pair is compared exactly rather than as two Floats further down.
-   `mrb_int_float_cmp()` answers -2 for a NaN operand; keep the 0 that
-   comparing the two as Floats produced, because -2 is what `num_lt()` and its
-   neighbours raise on while a Float comparison against NaN is false rather
-   than an error. The 0 also leaves the answer safe to negate, which is how the
-   caller that holds the Float first reads it. */
+   `mrb_int_float_cmp()` reports a NaN as -2, the only answer it has for a pair
+   it cannot place; report it here as unordered instead, which is the one the
+   callers of `cmpnum()` can tell apart from a type mismatch. */
 static mrb_int
 cmpnum_int_float(mrb_int x, mrb_float y)
 {
   mrb_int c = mrb_int_float_cmp(x, y);
-  return c == -2 ? 0 : c;
+  return c == -2 ? CMP_UNORDERED : c;
+}
+
+/* Only 1, 0 and -1 flip when the operands are read the other way round: a pair
+   that cannot be compared, or that stands in no order, is the same pair either
+   way round and its answer has no opposite. */
+static mrb_int
+cmpnum_rev(mrb_int c)
+{
+  return (c == -2 || c == CMP_UNORDERED) ? c : -c;
+}
+
+#ifdef MRB_USE_BIGINT
+/* `mrb_bint_cmp()` answers -2 both for a NaN on the right and for a value it
+   cannot compare with at all. Every call below has settled the types first, so
+   the only -2 left to answer is the NaN. */
+static mrb_int
+cmpnum_bint(mrb_state *mrb, mrb_value x, mrb_value y)
+{
+  mrb_int c = mrb_bint_cmp(mrb, x, y);
+  return c == -2 ? CMP_UNORDERED : c;
 }
 #endif
+#endif
 
-/* compare two numbers: (1:0:-1; -2 for error) */
+/* compare two numbers: (1:0:-1; -2 for error, -3 for an unordered pair) */
 static mrb_int
 cmpnum(mrb_state *mrb, mrb_value v1, mrb_value v2)
 {
@@ -2179,7 +2205,7 @@ cmpnum(mrb_state *mrb, mrb_value v1, mrb_value v2)
     return cmpnum_int_float(mrb_integer(v1), mrb_float(v2));
   }
   if (mrb_float_p(v1) && mrb_integer_p(v2)) {
-    return -cmpnum_int_float(mrb_integer(v2), mrb_float(v1));
+    return cmpnum_rev(cmpnum_int_float(mrb_integer(v2), mrb_float(v1)));
   }
 
   if (mrb_fixnum_p(v1)) {
@@ -2201,7 +2227,7 @@ cmpnum(mrb_state *mrb, mrb_value v1, mrb_value v2)
 #ifdef MRB_USE_BIGINT
   else if (mrb_bigint_p(v1)) {
     if (mrb_integer_p(v2) || mrb_bigint_p(v2) || mrb_float_p(v2)) {
-      return mrb_bint_cmp(mrb, v1, v2);
+      return cmpnum_bint(mrb, v1, v2);
     }
     x = mrb_as_float(mrb, v1);
   }
@@ -2213,11 +2239,10 @@ cmpnum(mrb_state *mrb, mrb_value v1, mrb_value v2)
 #ifdef MRB_USE_BIGINT
   if (mrb_bigint_p(v2)) {
     /* The switch below would convert `v2` with `mrb_as_float()` and lose the
-       low bits of a big integer. `mrb_bint_cmp()` keeps it exact. Negate the
-       result rather than the operands; -2 means incomparable, which has no
-       opposite. */
-    mrb_int c = mrb_bint_cmp(mrb, v2, mrb_float_value(mrb, x));
-    return c == -2 ? -2 : -c;
+       low bits of a big integer. `mrb_bint_cmp()` keeps it exact. The operands
+       are read the other way round here, so the answer is reversed rather than
+       the pair. */
+    return cmpnum_rev(cmpnum_bint(mrb, v2, mrb_float_value(mrb, x)));
   }
 #endif
 
@@ -2248,6 +2273,10 @@ cmpnum(mrb_state *mrb, mrb_value v1, mrb_value v2)
     }
     return -2;
   }
+
+  /* Neither test below holds when either side is NaN, and falling out of them
+     would answer 0, which says the two are equal. */
+  if (isnan(x) || isnan(y)) return CMP_UNORDERED;
 #endif
   if (x > y)
     return 1;
@@ -2287,7 +2316,7 @@ num_cmp(mrb_state *mrb, mrb_value self)
   mrb_value other = mrb_get_arg1(mrb);
   mrb_int n = cmpnum(mrb, self, other);
 
-  if (n == -2) return mrb_nil_value();
+  if (n == -2 || n == CMP_UNORDERED) return mrb_nil_value();
   return mrb_fixnum_value(n);
 }
 
@@ -2303,6 +2332,9 @@ num_lt(mrb_state *mrb, mrb_value self)
   mrb_value other = mrb_get_arg1(mrb);
   mrb_int n = cmpnum(mrb, self, other);
 
+  /* A NaN stands in no order with anything, so every comparison against one is
+     false; an exception is not an answer CRuby gives here either. */
+  if (n == CMP_UNORDERED) return mrb_false_value();
   if (n == -2) cmperr(mrb, self, other);
   if (n < 0) return mrb_true_value();
   return mrb_false_value();
@@ -2314,6 +2346,7 @@ num_le(mrb_state *mrb, mrb_value self)
   mrb_value other = mrb_get_arg1(mrb);
   mrb_int n = cmpnum(mrb, self, other);
 
+  if (n == CMP_UNORDERED) return mrb_false_value();
   if (n == -2) cmperr(mrb, self, other);
   if (n <= 0) return mrb_true_value();
   return mrb_false_value();
@@ -2325,6 +2358,7 @@ num_gt(mrb_state *mrb, mrb_value self)
   mrb_value other = mrb_get_arg1(mrb);
   mrb_int n = cmpnum(mrb, self, other);
 
+  if (n == CMP_UNORDERED) return mrb_false_value();
   if (n == -2) cmperr(mrb, self, other);
   if (n > 0) return mrb_true_value();
   return mrb_false_value();
@@ -2336,9 +2370,21 @@ num_ge(mrb_state *mrb, mrb_value self)
   mrb_value other = mrb_get_arg1(mrb);
   mrb_int n = cmpnum(mrb, self, other);
 
+  if (n == CMP_UNORDERED) return mrb_false_value();
   if (n == -2) cmperr(mrb, self, other);
   if (n >= 0) return mrb_true_value();
   return mrb_false_value();
+}
+
+/* `mrb_cmp()` reports an unordered pair as one it cannot compare. Its callers
+   sort, search and test ranges with the answer, and a NaN belongs at neither
+   end of an order; -2 is the answer they already refuse, which is what CRuby
+   does with a NaN in `Array#sort`. */
+static mrb_int
+cmpnum_total(mrb_state *mrb, mrb_value v1, mrb_value v2)
+{
+  mrb_int n = cmpnum(mrb, v1, v2);
+  return n == CMP_UNORDERED ? -2 : n;
 }
 
 /**
@@ -2362,13 +2408,13 @@ mrb_cmp(mrb_state *mrb, mrb_value obj1, mrb_value obj2)
   mrb_value v;
 
   if (mrb_fixnum_p(obj1) || mrb_float_p(obj1)) {
-    return cmpnum(mrb, obj1, obj2);
+    return cmpnum_total(mrb, obj1, obj2);
   }
   switch (mrb_type(obj1)) {
   case MRB_TT_INTEGER:
   case MRB_TT_FLOAT:
   case MRB_TT_BIGINT:
-    return cmpnum(mrb, obj1, obj2);
+    return cmpnum_total(mrb, obj1, obj2);
   case MRB_TT_STRING:
     if (!mrb_string_p(obj2))
       return -2;

--- a/test/t/array.rb
+++ b/test/t/array.rb
@@ -580,6 +580,21 @@ assert('Array#sort!') do
   assert_equal [1, 2, 3], a    # it is sorted.
 end
 
+assert('Array#sort with a NaN in it') do
+  # A NaN stands in no order with anything, so there is no sorted order for an
+  # array holding one and the comparison is refused rather than answered. The
+  # all-Float array takes a comparison of its own inside the sort, so it is
+  # pinned alongside the mixed one, and a longer array is sorted as well
+  # because a short one takes a different route through the sort.
+  skip unless Object.const_defined?(:Float)
+  nan = Float::NAN
+
+  assert_raise(ArgumentError) { [1.0, nan].sort }
+  assert_raise(ArgumentError) { [1, nan].sort }
+  assert_raise(ArgumentError) { [nan, 1.0].sort }
+  assert_raise(ArgumentError) { ([1.0] * 40 + [nan]).sort }
+end
+
 assert('Array#freeze') do
   a = [].freeze
   assert_raise(FrozenError) do

--- a/test/t/float.rb
+++ b/test/t/float.rb
@@ -157,6 +157,30 @@ assert('Float comparison with an Integer it cannot hold') do
   assert_false([f] == [n])        # Array#== reads the same comparison
 end
 
+assert('Float comparison with a NaN') do
+  # A NaN stands in no order with anything, itself included, so `<=>` has no
+  # answer to give and every comparison against one is false rather than an
+  # error.
+  #
+  # The four operators are written as method calls because `OP_LT` and its
+  # neighbours compare the pair as C values themselves whenever both sides are
+  # numbers, and the methods under test here are never reached that way.
+  nan = Float::NAN
+
+  assert_nil(1.0 <=> nan)
+  assert_nil(nan <=> 1.0)
+  assert_nil(nan <=> nan)
+  assert_nil(nan <=> 1)
+  assert_false(1.0.__send__(:<, nan))
+  assert_false(1.0.__send__(:<=, nan))
+  assert_false(1.0.__send__(:>, nan))
+  assert_false(1.0.__send__(:>=, nan))
+  assert_false(nan.__send__(:<, 1.0))
+  assert_false(nan.__send__(:<=, nan))
+  assert_false(nan.__send__(:>=, 1))
+  assert_false(nan < 1.0)         # the opcode, which already answered this
+end
+
 assert('Float#ceil', '15.2.9.3.8') do
   a = 3.123456789.ceil
   b = 3.0.ceil

--- a/test/t/integer.rb
+++ b/test/t/integer.rb
@@ -133,6 +133,41 @@ assert('Integer comparison with a Float that stands for another number') do
   assert_false([n] == [f])        # Array#== reads the same comparison
 end
 
+assert('Integer comparison with a NaN') do
+  # The mixed pair is compared exactly rather than as two Floats, and that
+  # comparison reports a NaN apart; the answer it stands for is the one a pair
+  # of Floats gets, no order at all. See the Float file for what that means.
+  skip unless Object.const_defined?(:Float)
+  nan = Float::NAN
+
+  assert_nil(1 <=> nan)
+  assert_false(1.__send__(:<, nan))
+  assert_false(1.__send__(:<=, nan))
+  assert_false(1.__send__(:>, nan))
+  assert_false(1.__send__(:>=, nan))
+  assert_false(1 < nan)           # the opcode, which already answered this
+end
+
+assert('Integer wider than an mrb_int compared with a NaN') do
+  # A big integer is compared by a path of its own, which reported the NaN as a
+  # pair it could not compare at all: `<=>` was already nil, but the four
+  # operators raised where the ones above answered false.
+  skip unless Object.const_defined?(:Float)
+  begin
+    big = 1 << 70
+  rescue RangeError
+    skip 'no integer here is wider than an mrb_int'
+  end
+  nan = Float::NAN
+
+  assert_nil(big <=> nan)
+  assert_nil(nan <=> big)
+  assert_false(big.__send__(:<, nan))
+  assert_false(big.__send__(:>=, nan))
+  assert_false(nan.__send__(:<, big))
+  assert_false(nan.__send__(:>=, big))
+end
+
 assert('Integer comparison with a Float at the ends of the mrb_int range') do
   # The far ends are where the neighbouring Floats stand furthest apart, and
   # where the bounds the comparison tests against are themselves built. Both

--- a/test/t/range.rb
+++ b/test/t/range.rb
@@ -37,6 +37,19 @@ assert('Range#===', '15.2.14.4.2') do
   assert_true c === 0
 end
 
+assert('Range#=== with a NaN') do
+  # A NaN stands in no order with either end, so it falls in no range at all.
+  # `Range` tests the comparison for the answers that hold and takes anything
+  # else for a miss, so this follows from what the comparison itself reports.
+  skip unless Object.const_defined?(:Float)
+  nan = Float::NAN
+
+  assert_false((1..2) === nan)
+  assert_false((1..) === nan)
+  assert_false((..2) === nan)
+  assert_false((1.0..2.0) === nan)
+end
+
 assert('Range#begin', '15.2.14.4.3') do
   assert_equal 1, (1..10).begin
   assert_equal 1, (1..).begin


### PR DESCRIPTION
## Summary

`cmpnum()` ends by comparing its two operands as C values, and neither `x > y` nor `x < y` holds against a NaN, so it fell out with 0: the answer that says the two are equal. Everything reading it inherited that, from `1 <=> Float::NAN` through `Array#sort` and `Range#===`.

## Changes

| File | What |
|---|---|
| `src/numeric.c` | `CMP_UNORDERED` as a third answer from `cmpnum()`; `cmpnum_rev()`, `cmpnum_bint()` and `cmpnum_total()` added; `cmpnum_int_float()`, `num_cmp()`, `num_lt()`, `num_le()`, `num_gt()`, `num_ge()` and `mrb_cmp()` read it |
| `src/array.c` | `sort_cmp()` reports a Float pair holding a NaN as one it cannot compare |
| `test/t/float.rb`, `test/t/integer.rb` | `<=>` and the four operators against a NaN, for an `mrb_int` and for an integer wider than one |
| `test/t/array.rb` | `Array#sort` refusing |
| `test/t/range.rb`, `mrbgems/mruby-range-ext/test/range.rb` | `Range#===` and `Range#cover?` |
| `mrbgems/mruby-compar-ext/test/compar.rb` | `Comparable#clamp` refusing |

### An unordered pair is not the pair `cmpnum()` cannot compare

`cmpnum()` already had -2, for a pair whose types put them in no order at all, and that is not this answer. `num_cmp()` answers nil for -2, which suits a NaN as well, but `num_lt()` and its three neighbours raise on it, and `1 < Float::NAN` is false in CRuby rather than an error. Reusing -2 would trade four wrong answers for four wrong exceptions.

`CMP_UNORDERED` is a third state:

- `num_cmp()` answers nil for it, as it does for -2
- `num_lt()`, `num_le()`, `num_gt()` and `num_ge()` answer false for it, where they raise for -2
- `mrb_cmp()` reports it as -2, so its own callers refuse the pair

Reversing the operands is the other thing the third state touches. Only 1, 0 and -1 have an opposite; a pair that stands in no order is the same pair read either way round, and so is a pair that cannot be compared. `cmpnum_rev()` leaves both alone and negates the rest, where the old code negated a 0 that happened to be safe to negate.

### `Array#sort` reads a Float pair itself

`sort_cmp()` does not ask `mrb_cmp()` for a pair of Floats; it compares them in place, and it read them the way `cmpnum()` used to. `[1.0, Float::NAN].sort` came back in whatever order the sort left it, while the mixed `[1, Float::NAN].sort` went through `mrb_cmp()` and raised. `a == b` tells a genuine tie from a NaN there, and -2 is the answer the caller above already raises on.

### A big integer already answered differently

`mrb_bint_cmp()` reports a NaN as -2 and `cmpnum()` passed it straight through, so `2**70 <=> Float::NAN` was already nil while `1 <=> Float::NAN` was 0, and `(2**70) < Float::NAN` raised where `1 < Float::NAN` answered false. `cmpnum_bint()` puts both pairs on the same answer.

### `Range` needs nothing of its own

`r_le()` and its neighbours test `mrb_cmp()` for the answers that hold and take anything else for a miss, so `(1..2) === Float::NAN` and `(1..2).cover?(Float::NAN)` are false as soon as `mrb_cmp()` reports -2. They are in the table below because the behaviour is what this is for, not because the file changed.

## Behaviour

Measured against CRuby 4.0.6.

| expression | master | this PR | CRuby |
| --- | --- | --- | --- |
| `1 <=> Float::NAN` | 0 | nil | nil |
| `Float::NAN <=> Float::NAN` | 0 | nil | nil |
| `1.__send__(:<=, Float::NAN)` | true | false | false |
| `1.__send__(:>=, Float::NAN)` | true | false | false |
| `[1.0, Float::NAN].sort` | `[1.0, NaN]` | ArgumentError | ArgumentError |
| `[1, Float::NAN].sort` | `[1, NaN]` | ArgumentError | ArgumentError |
| `1.clamp(Float::NAN, 2)` | 1 | ArgumentError | ArgumentError |
| `(1..2) === Float::NAN` | true | false | false |
| `(1..2).cover?(Float::NAN)` | true | false | false |
| `2**70 <=> Float::NAN` | nil | nil | nil |
| `(2**70).__send__(:<, Float::NAN)` | ArgumentError | false | false |

The last two rows are the split the third state also closes. `mrb_bint_cmp()` already reported a NaN as -2 and `cmpnum()` passed it through, so a big integer answered nil for `<=>` and raised for `<` where an `mrb_int` answered 0 and true. Both pairs now answer alike.

### Left as they are

- `Float::NAN.between?(1, 2)` is false, where CRuby raises ArgumentError. `Comparable#between?` is written as `self >= min and self <= max`, and both halves are false now.
- `[1.0, Float::NAN].max` and `Float::NAN.clamp(1, 2)` raise NoMethodError on the nil that `<=>` now answers, where CRuby raises ArgumentError. `Enumerable#max`, `#min`, `#minmax` and `Comparable#clamp` read `<=>` from Ruby and already answer that way for every pair they cannot order: `[1, 'a'].max` raises the same NoMethodError on master. That is about how those methods read a comparison with no answer, not about what the comparison reports.

The opcodes were already right and stay so. `OP_LT` and its neighbours compare a pair of numbers as C values themselves, which is why the rows above are written with `__send__`.

## Speed

`cmpnum()` gains a test on the path every ordered comparison takes, and `sort_cmp()` reads its Float pair through two locals rather than four calls to `mrb_float()`.

```ruby
a = 1; b = 2.0
i = 0; while i < N; a.__send__(:<=>, b); i += 1; end
i = 0; while i < N; a.__send__(:<, b);   i += 1; end

base = []                                    # 1,000 Floats, scrambled
k = 0; while k < 1000; base << (k * 7919 % 1000) + 0.5; k += 1; end
i = 0; while i < N; base.sort; i += 1; end
```

Callgrind `Ir`, with the same measurement run against an empty loop of the same length and subtracted, at 300,000 turns (300 for the sort); and wall clock at 20,000,000 turns (5,000 for the sort), interleaved, best of 11.

| | master `Ir` | this PR `Ir` | ratio | master | this PR | ratio |
|---|---|---|---|---|---|---|
| `1 <=> 2.0` | 163,502,183 | 163,802,183 | 1.002x | 0.75 s | 0.72 s | 0.96x |
| `1 < 2.0` | 163,803,044 | 164,403,044 | 1.004x | 0.75 s | 0.71 s | 0.95x |
| `Array#sort`, 1,000 Floats | 473,548,213 | 414,683,113 | **0.876x** | 0.57 s | 0.48 s | **0.84x** |

The comparison pays one or two instructions a call, which is below what this host's wall clock can read; the wall clock columns for those two rows are the measurement floor rather than a speedup. The sort gets more back than the test costs, because `sort_cmp()` used to decode each operand of the pair twice.

## Size

`bin/mruby` `.text`, `size -A`, each build made from an empty build directory at the same path:

| Build | master | this PR | delta |
|---|---|---|---|
| `full-debug` (-O0) | 1,911,030 | 1,911,318 | +288 |
| `bintest` | 1,305,670 | 1,305,846 | +176 |
| `cxx_abi` | 1,332,681 | 1,332,793 | +112 |
| `byte-string` | 1,270,006 | 1,270,182 | +176 |
| `ascii-ctype` | 1,292,230 | 1,292,406 | +176 |

The default build, where the symbols can be read one by one, accounts for +159 of it: `cmpnum` 1,803 -> 1,844 for the third state and the helpers that fold into it, `mrb_cmp` 265 -> 289 for `cmpnum_total()`, and 4 to 26 each for `num_cmp` and the four operators. `sort_cmp` is one byte smaller.

## Testing

`build_config/ci/gcc-clang.rb`, all five builds plus the bintests, each commit built from an empty build directory:

| Commit | full-debug | bintest | bintest (bin) | cxx_abi | byte-string | ascii-ctype |
|---|---|---|---|---|---|---|
| master (`91cf562f6`) | 2556 OK | 2556 OK | 145 OK | 2556 OK | 2475 OK | 2547 OK |
| answer a comparison against a NaN as unordered | 2562 OK | 2562 OK | 145 OK | 2562 OK | 2481 OK | 2553 OK |
| refuse to sort an array holding a NaN | 2563 OK | 2563 OK | 145 OK | 2563 OK | 2482 OK | 2554 OK |

0 KO, 0 crashes, no new compiler warnings anywhere. `rake test` also passes under `build_config/host-nofloat.rb`, where all seven new blocks skip, and in all three boxing modes (`MRB_NO_BOXING`, `MRB_WORD_BOXING`, `MRB_NAN_BOXING`).

Seven blocks, all float-only and under the guard their file already uses: `test/t/float.rb` and `test/t/integer.rb` for `<=>` and the four operators, with a block of its own for an integer wider than an `mrb_int`; `test/t/array.rb` for `sort` refusing; `test/t/range.rb` and `mrbgems/mruby-range-ext/test/range.rb` for `===` and `cover?`; and `mrbgems/mruby-compar-ext/test/compar.rb` for `clamp`.

## Environment

<details>
<summary>Host</summary>

| | |
|---|---|
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-30-generic x86_64 |
| CPU | AMD Ryzen 9 5950X (16C/32T) |
| Memory | 64 GiB |
| C compiler | gcc 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1) |
| binutils | GNU Binutils 2.47.20260726 |
| CRuby | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |
| rake | 13.3.1 |
| valgrind | 3.27.1 |

</details>

<details>
<summary>Compile lines, one per build</summary>

`src/numeric.c` as each build actually compiles it, with `-MMD -c`, `-I` and `-o` dropped. `cxx_abi` is `gcc -x c++`, not `g++`; `g++` only links there. `enable_debug()` puts `-g3 -O0` after the toolchain's `-g -O3`, so `full-debug` is the one build at `-O0`.

```console
# full-debug
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/numeric.c

# bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK src/numeric.c

# cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/numeric.c

# byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/numeric.c

# ascii-ctype
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/numeric.c
```

</details>
