### PR TITLE
vm.c: answer `==` against a NaN by value, not by representation

### DIFF
--- a/src/kernel.c
+++ b/src/kernel.c
@@ -128,6 +128,13 @@ mrb_eqq_m(mrb_state *mrb, mrb_value self)
 {
   mrb_value arg = mrb_get_arg1(mrb);
 
+#ifndef MRB_NO_FLOAT
+  /* Case equality is `==` for an Object, and a NaN is equal to nothing at all,
+     itself included. `mrb_equal()` answers a value that holds what the other
+     one holds before it asks `==` anything, which is the answer a container
+     searching for the object it was handed wants, and the wrong one here. */
+  if (mrb_float_p(self) && isnan(mrb_float(self))) return mrb_false_value();
+#endif
   return mrb_bool_value(mrb_equal(mrb, self, arg));
 }
 

--- a/src/vm.c
+++ b/src/vm.c
@@ -3559,6 +3559,7 @@ RETRY_TRY_BLOCK:
 #define OP_CMP_BODY(op,v1,v2) (v1(regs[a]) op v2(regs[a+1]))
 
 #ifdef MRB_NO_FLOAT
+#define value_nan_p(v) FALSE
 #define OP_CMP(op,sym) do {\
   int result;\
   /* need to check if op is overridden */\
@@ -3578,6 +3579,7 @@ RETRY_TRY_BLOCK:
   }\
 } while(0)
 #else
+#define value_nan_p(v) (mrb_float_p(v) && isnan(mrb_float(v)))
 /* The usual arithmetic conversions would round an `mrb_int` wider than the
    significand onto a neighbouring Float, so a mixed pair asks
    `mrb_int_float_cmp()` for the order of the two values themselves. It answers
@@ -3622,7 +3624,16 @@ RETRY_TRY_BLOCK:
 #endif
 
     CASE(OP_EQ, B) {
-      if (mrb_obj_eq(mrb, regs[a], regs[a+1])) {
+      /* Two values that hold the same thing are the same object, and an object
+         is equal to itself. A NaN is the one value that holds for neither: it
+         is equal to nothing at all, its own operand included. What
+         `mrb_obj_eq()` reads is the representation, and a boxing that carries
+         a Float in an `mrb_value` gives a NaN the same one every time, so
+         without the test below `Float::NAN == Float::NAN` answered true in a
+         boxed build and false in `MRB_NO_BOXING`. The pair falls through to
+         the comparison instead, which reads it as numbers and answers false
+         in either. */
+      if (mrb_obj_eq(mrb, regs[a], regs[a+1]) && !value_nan_p(regs[a])) {
         SET_TRUE_VALUE(regs[a]);
       }
       else if (mrb_symbol_p(regs[a])) {

--- a/test/t/float.rb
+++ b/test/t/float.rb
@@ -124,6 +124,40 @@ assert('Float#==', '15.2.9.3.7') do
   assert_false 3.1 == 3.2
 end
 
+assert('a NaN is equal to nothing at all, itself included') do
+  # `==` answers by value, and a NaN has no value: it is equal to no Float,
+  # its own operand included.
+  #
+  # `Float#==` said so all along. What answered true was the shortcut before
+  # it, which takes two values that hold the same thing for the same object
+  # and an object for equal to itself. How much of a Float an `mrb_value`
+  # holds is what boxing decides, so the shortcut used to answer this pair in
+  # a boxed build and leave it to `Float#==` under `MRB_NO_BOXING`: the same
+  # expression answered true or false depending on how the build stores a
+  # Float.
+  #
+  # `equal?` is left out below for that reason: it is the one caller of the
+  # shortcut that asks for exactly what the shortcut reads, and what it reads
+  # still differs between those builds.
+  nan = Float::NAN
+
+  assert_false(nan == nan)
+  assert_true(nan != nan)
+  assert_false((0.0 / 0.0) == (0.0 / 0.0))
+  assert_false(nan == 0.0 / 0.0)
+  assert_false(nan.__send__(:==, nan))
+  assert_false(nan.eql?(nan))
+  assert_false(nan === nan)                       # case equality is `==` here
+  assert_equal(:miss, case nan when nan then :hit else :miss end)
+
+  # every other pair answers as it did
+  assert_true(1.0 == 1.0)
+  assert_true(1.0 === 1.0)
+  assert_true(0.0 == -0.0)
+  assert_true(Float::INFINITY == Float::INFINITY)
+  assert_equal(:hit, case 1.0 when 1.0 then :hit else :miss end)
+end
+
 assert('Float comparison with an Integer it cannot hold') do
   # A Float keeps fewer significant bits than an mrb_int, so an integer past
   # the significand rounds onto a neighbouring Float when the two are compared


### PR DESCRIPTION
## Summary

A NaN is equal to nothing at all, its own operand included, but `==` answered otherwise, and answered differently depending on how the build stores a Float. What answered was the identity shortcut in `OP_EQ`, which reads the representation rather than the value.

## Changes

| File | What |
|---|---|
| `src/vm.c` | `value_nan_p()`, and `OP_EQ` leaves a NaN to the comparison below rather than answering it from the identity shortcut |
| `src/kernel.c` | `mrb_eqq_m()` answers false for a NaN receiver rather than reaching `mrb_equal()` |
| `test/t/float.rb` | `==`, `!=`, `===`, `case`/`when` and `eql?` against a NaN, and the ordinary pairs that answer as they did |

### The shortcut reads the representation, and boxing decides what that holds

`OP_EQ` takes two values that hold the same thing for the same object, and an object for equal to itself, and answers true before `Float#==` is asked anything. What `mrb_obj_eq()` reads is the representation, and how much of a Float an `mrb_value` carries is what boxing decides, so the same expression had two answers:

```ruby
Float::NAN == Float::NAN                        # word/nan boxing: true, MRB_NO_BOXING: false
case Float::NAN when Float::NAN then :hit end   # boxed: :hit
```

`Float#==` compares the two as Floats and was right in every build, which is why `Float::NAN.__send__(:==, Float::NAN)` was already false where the operator was true. Only the pairs the shortcut answered were wrong.

A NaN is the only value it reads wrong, so it is the only one turned away. The pair falls through to the comparison below, where `OP_CMP` handles Float/Float, Float/Integer and the send to `Float#==`: a Float's equality lives there, and it answered false all along.

`Object#===` is case equality, which is `==` for anything that does not redefine it, and it reached the same shortcut through `mrb_equal()`. It leaves a NaN to `Float#==` as well.

### What this does not change

`mrb_equal()` keeps the shortcut for its other callers. `Array#index`, `#delete`, `#-`, `#uniq` and their neighbours search for the object they were handed rather than for a value equal to it, which is what CRuby's own `rb_equal()` does, and none of them is `==`.

One consequence is worth naming. `Enumerable#include?` and `#count` are written in Ruby over `==`, which ISO 15.3.2.2.10 is the wording for, so a NaN is no longer found by them. CRuby's `true` there is object identity reaching a value predicate: it holds for the same object only, and `[Float::NAN].include?(0.0/0.0)` is false in CRuby. mruby cannot draw that line for a Float as it stands, because a boxed build normalizes every NaN to one representation, so both builds now give the same answer where they did not before. Giving a NaN an identity of its own is a change to the value representation and belongs in its own PR; that mruby's container searches answer by boxing mode at all is part of that same question and is untouched here.

## Behaviour

Measured against CRuby 4.0.6, and in both boxing modes.

| expression | master (boxed) | master (`MRB_NO_BOXING`) | this PR (both) | CRuby |
| --- | --- | --- | --- | --- |
| `Float::NAN == Float::NAN` | **true** | false | false | false |
| `Float::NAN != Float::NAN` | **false** | true | true | true |
| `(0.0/0.0) == (0.0/0.0)` | **true** | false | false | false |
| `Float::NAN === Float::NAN` | **true** | false | false | false |
| `case Float::NAN when Float::NAN` | **hit** | miss | miss | miss |
| `Float::NAN.eql?(Float::NAN)` | false | false | false | false |
| `1.0 == 1.0`, `0.0 == -0.0`, `1.0 === 1.0`, `1.0 == 1` | true | true | true | true |

Two rows follow from it and go the other way, for the reason given above:

| expression | master (boxed) | master (`MRB_NO_BOXING`) | this PR (both) | CRuby |
| --- | --- | --- | --- | --- |
| `[Float::NAN].include?(Float::NAN)` | true | **false** | false | true |
| `[Float::NAN].count(Float::NAN)` | 1 | **0** | 0 | 1 |

The container searches that read the object rather than the value are untouched and still answer by boxing mode, as they did: `[nan].index(nan)` is 0 in a boxed build and nil under `MRB_NO_BOXING`, and `[nan, nan].uniq` is one element or two. So is `equal?`, which is true in a boxed build and false without it.

## Speed

The shortcut asks one more question, and the question decodes the Float.

```ruby
t = 0.0; i = 0; while i < N; t += i * 0.5; i += 1; end   # no OP_EQ at all
a = 1.0; b = 1.0; i = 0; while i < N; a == b; i += 1; end
a = 1;   b = 1;   i = 0; while i < N; a == b; i += 1; end
a = "x";          i = 0; while i < N; a == a; i += 1; end
```

Callgrind `Ir`, with the same measurement run against an empty loop of the same length and subtracted, at 300,000 turns; and wall clock at 60,000,000 turns, interleaved, best of 11.

| | master `Ir` | this PR `Ir` | ratio | master | this PR | ratio |
|---|---|---|---|---|---|---|
| `t += i * 0.5` (no `OP_EQ`) | 91,500,937 | 91,500,948 | 1.000x | 1.92 s | 1.85 s | 0.96x |
| `1.0 == 1.0` | 21,901,828 | 29,401,850 | 1.34x | 0.94 s | 1.02 s | 1.09x |
| `1 == 1` | 21,902,704 | 23,702,737 | 1.08x | 0.93 s | 0.92 s | 0.99x |
| `s == s`, the same String | 21,903,750 | 24,903,794 | 1.14x | 0.92 s | 0.89 s | 0.97x |

A Float pays for the decode. Everything else pays for the test alone, a few instructions a call, which this host's wall clock cannot separate from its own noise.

The first row is a loop with no `OP_EQ` in it. It is there because the dispatch loop pays for its register allocation everywhere, not only in the opcode that changed, and the count says this predicate did not move it: the two builds differ by 11 instructions over 300,000 turns.

## Size

`bin/mruby` `.text`, `size -A`, each build made from an empty build directory at the same path:

| Build | master | this PR | delta |
|---|---|---|---|
| `full-debug` (-O0) | 1,911,030 | 1,911,302 | +272 |
| `bintest` | 1,305,670 | 1,305,766 | +96 |
| `cxx_abi` | 1,332,681 | 1,332,745 | +64 |
| `byte-string` | 1,270,006 | 1,270,150 | +144 |
| `ascii-ctype` | 1,292,230 | 1,292,374 | +144 |

## Testing

`build_config/ci/gcc-clang.rb`, all five builds plus the bintests, built from an empty build directory:

| Commit | full-debug | bintest | bintest (bin) | cxx_abi | byte-string | ascii-ctype |
|---|---|---|---|---|---|---|
| master (`91cf562f6`) | 2556 OK | 2556 OK | 145 OK | 2556 OK | 2475 OK | 2547 OK |
| answer `==` against a NaN by value | 2557 OK | 2557 OK | 145 OK | 2557 OK | 2476 OK | 2548 OK |

0 KO, 0 crashes, no new compiler warnings anywhere.

Boxing is what this is about, so `rake test` was run in all three modes (`MRB_NO_BOXING`, `MRB_WORD_BOXING`, `MRB_NAN_BOXING`): 2557 OK in each, and the new block asserts the same answers in all three. It also passes under `build_config/host-nofloat.rb`, where the block skips.

The one block is in `test/t/float.rb`, next to `Float#==`. It pins `==`, `!=`, `===`, `case`/`when`, `eql?` and a NaN built at run time, plus the ordinary pairs. `equal?` is deliberately not asserted: it is the one caller that asks for exactly what the shortcut reads, and what it reads still differs between builds.

## Environment

<details>
<summary>Host</summary>

| | |
|---|---|
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-30-generic x86_64 |
| CPU | AMD Ryzen 9 5950X (16C/32T) |
| Memory | 64 GiB |
| C compiler | gcc 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1) |
| binutils | GNU Binutils 2.47.20260726 |
| CRuby | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |
| rake | 13.3.1 |
| valgrind | 3.27.1 |

</details>

<details>
<summary>Compile lines, one per build</summary>

`src/vm.c` as each build actually compiles it, with `-MMD -c`, `-I` and `-o` dropped. `cxx_abi` is `gcc -x c++`, not `g++`; `g++` only links there. `enable_debug()` puts `-g3 -O0` after the toolchain's `-g -O3`, so `full-debug` is the one build at `-O0`.

```console
# full-debug
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/vm.c

# bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK src/vm.c

# cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/vm.c

# byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/vm.c

# ascii-ctype
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/vm.c
```

</details>
