### PR TITLE
range.c: refuse a range bounded by a NaN

### DIFF
--- a/src/range.c
+++ b/src/range.c
@@ -23,7 +23,18 @@ r_check(mrb_state *mrb, mrb_value a, mrb_value b)
 #else
   if ((ta == MRB_TT_INTEGER || ta == MRB_TT_FLOAT) &&
       (tb == MRB_TT_INTEGER || tb == MRB_TT_FLOAT)) {
-    return;
+    /* Two numbers stand in some order, and which one needs no comparison to
+       tell, unless one of them is a NaN, which stands in no order with
+       anything. A range bounded by one holds nothing and covers nothing, so
+       the pair is refused here, as a pair that cannot be compared is below.
+       An end left out is nil rather than a number and does not reach this
+       branch, which is why `(Float::NAN..)` is still a range: with one end
+       there is no pair to put in order. */
+    if ((ta != MRB_TT_FLOAT || !isnan(mrb_float(a))) &&
+        (tb != MRB_TT_FLOAT || !isnan(mrb_float(b)))) {
+      return;
+    }
+    mrb_raise(mrb, E_ARGUMENT_ERROR, "bad value for range");
   }
 #endif
 

--- a/test/t/range.rb
+++ b/test/t/range.rb
@@ -109,6 +109,31 @@ assert('Range#initialize', '15.2.14.4.9') do
   assert_false d.exclude_end?
 end
 
+assert('Range with a NaN for an end') do
+  # A NaN stands in no order with anything, so a range bounded by one holds
+  # nothing and covers nothing. The pair is refused the way a pair that cannot
+  # be compared at all is, rather than built and left to answer nothing.
+  #
+  # One end alone is no pair, and an end left out is nil rather than a number,
+  # so an endless or beginless range bounded by a NaN is still a range. CRuby
+  # draws the line in the same place.
+  skip unless Object.const_defined?(:Float)
+  nan = Float::NAN
+
+  assert_raise(ArgumentError) { (nan..2) }
+  assert_raise(ArgumentError) { (1..nan) }
+  assert_raise(ArgumentError) { (nan..nan) }
+  assert_raise(ArgumentError) { (nan...2) }
+  assert_raise(ArgumentError) { (1.0..nan) }
+  assert_raise(ArgumentError) { Range.new(nan, 2) }
+
+  assert_predicate((nan..).begin, :nan?)
+  assert_nil((nan..).end)
+  assert_predicate((..nan).end, :nan?)
+  assert_nil((..nan).begin)
+  assert_equal(1.0, (1.0..2.0).begin)      # an ordinary pair is untouched
+end
+
 assert('Range#last', '15.2.14.4.10') do
   assert_equal 10, (1..10).last
   assert_nil (1..).last


### PR DESCRIPTION
## Summary

`r_check()` lets a pair of numbers through without comparing them, because two numbers always stand in some order. A NaN is the one number that stands in no order with anything, and the range built around it held nothing and covered nothing.

## Changes

| File | What |
|---|---|
| `src/range.c` | `r_check()` refuses a numeric pair with a NaN in it, where the arm used to return at once |
| `test/t/range.rb` | the refusals, both one-ended ranges, and an ordinary pair |

### The numeric arm is the one place a NaN got through

`r_check()` has two arms. A pair of numbers returns at once, because which order two numbers stand in needs no comparison to tell; anything else is handed to `mrb_cmp()` and refused where the comparison has no answer. A NaN belongs on the second side and was taken by the first, so `(Float::NAN..2)` was built and then answered nothing: every value fell outside it, and iterating it raised on the first step. The refusal it gets now is the one the arm below already gives, and the one CRuby gives.

The question is asked of the operands themselves rather than through a comparison, so an ordinary pair still returns without one.

### One end is not a pair

An end left out is nil rather than a number and never reaches the numeric arm, so `(Float::NAN..)` and `(..Float::NAN)` are still ranges. With one end there is no pair to put in order, which is where CRuby draws the line too.

## Behaviour

Every row below matches CRuby 4.0.6 after the change.

| expression | master | this PR | CRuby |
| --- | --- | --- | --- |
| `(Float::NAN..2)` | `NaN..2` | ArgumentError | ArgumentError |
| `(1..Float::NAN)` | `1..NaN` | ArgumentError | ArgumentError |
| `(Float::NAN..Float::NAN)` | `NaN..NaN` | ArgumentError | ArgumentError |
| `(Float::NAN...2)` | `NaN...2` | ArgumentError | ArgumentError |
| `Range.new(Float::NAN, 2)` | `NaN..2` | ArgumentError | ArgumentError |
| `(Float::NAN..)` | `NaN..` | `NaN..` | `NaN..` |
| `(..Float::NAN)` | `..NaN` | `..NaN` | `..NaN` |
| `(1..'z')` | ArgumentError | ArgumentError | ArgumentError |
| `(1..2)`, `(1.0..2.0)`, `('a'..'z')` | built | built | built |

## Speed

`r_check()` asks about a pair it used to wave through.

```ruby
i = 0; while i < N; Range.new(1, 2);     i += 1; end
i = 0; while i < N; Range.new(1.0, 2.0); i += 1; end
i = 0; while i < N; Range.new("a", "z"); i += 1; end
```

Callgrind `Ir`, with the same measurement run against an empty loop of the same length and subtracted, at 300,000 turns; and wall clock at 5,000,000 turns, interleaved, best of 11.

| | master `Ir` | this PR `Ir` | ratio | master | this PR | ratio |
|---|---|---|---|---|---|---|
| `Range.new(1, 2)` | 605,129,990 | 606,929,990 | 1.003x | 0.62 s | 0.64 s | 1.03x |
| `Range.new(1.0, 2.0)` | 623,731,592 | 637,231,592 | 1.022x | 0.64 s | 0.67 s | 1.05x |
| `Range.new("a", "z")` | 766,943,193 | 767,543,193 | 1.001x | 0.78 s | 0.78 s | 1.00x |

Only a Float pair is asked `isnan()`, and a range with a Float for an end is where the whole of that 2% sits. A pair of Integers pays for the type test alone, and a pair that is not numeric never reaches this arm.

## Size

`bin/mruby` `.text`, `size -A`, each build made from an empty build directory at the same path:

| Build | master | this PR | delta |
|---|---|---|---|
| `full-debug` (-O0) | 1,911,030 | 1,911,126 | +96 |
| `bintest` | 1,305,670 | 1,305,974 | +304 |
| `cxx_abi` | 1,332,681 | 1,332,985 | +304 |
| `byte-string` | 1,270,006 | 1,270,310 | +304 |
| `ascii-ctype` | 1,292,230 | 1,292,534 | +304 |

`r_check()` is `static` and inlines into each of its three callers, so the test lands three times: in the default build, `mrb_range_new` 286 -> 377, `range_initialize` 540 -> 637 and `range_initialize_copy` 631 -> 740.

## Testing

`build_config/ci/gcc-clang.rb`, all five builds plus the bintests, built from an empty build directory:

| Commit | full-debug | bintest | bintest (bin) | cxx_abi | byte-string | ascii-ctype |
|---|---|---|---|---|---|---|
| master (`91cf562f6`) | 2556 OK | 2556 OK | 145 OK | 2556 OK | 2475 OK | 2547 OK |
| refuse a range bounded by a NaN | 2557 OK | 2557 OK | 145 OK | 2557 OK | 2476 OK | 2548 OK |

0 KO, 0 crashes, no new compiler warnings anywhere. `rake test` also passes under `build_config/host-nofloat.rb`, where the block skips, and in all three boxing modes (`MRB_NO_BOXING`, `MRB_WORD_BOXING`, `MRB_NAN_BOXING`).

The one block is in `test/t/range.rb`, next to `Range#initialize`. It pins the refusals, both one-ended ranges, and an ordinary pair.

## Environment

<details>
<summary>Host</summary>

| | |
|---|---|
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-30-generic x86_64 |
| CPU | AMD Ryzen 9 5950X (16C/32T) |
| Memory | 64 GiB |
| C compiler | gcc 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1) |
| binutils | GNU Binutils 2.47.20260726 |
| CRuby | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |
| rake | 13.3.1 |
| valgrind | 3.27.1 |

</details>

<details>
<summary>Compile lines, one per build</summary>

`src/range.c` as each build actually compiles it, with `-MMD -c`, `-I` and `-o` dropped. `cxx_abi` is `gcc -x c++`, not `g++`; `g++` only links there. `enable_debug()` puts `-g3 -O0` after the toolchain's `-g -O3`, so `full-debug` is the one build at `-O0`.

```console
# full-debug
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/range.c

# bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK src/range.c

# cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/range.c

# byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/range.c

# ascii-ctype
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/range.c
```

</details>
