### PR TITLE
object.c: skip the send when `eql?` is the identity

### DIFF
--- a/src/object.c
+++ b/src/object.c
@@ -870,6 +870,8 @@ mrb_inspect(mrb_state *mrb, mrb_value obj)
  *
  * Otherwise, it calls the `eql?` method on `obj1`, passing `obj2` as
  * an argument. The symbol for the `eql?` method is `MRB_SYM_Q(eql)`.
+ * A receiver that still has the default `eql?` skips that call: the
+ * default is `mrb_obj_equal_m`, the identity just tested.
  *
  * The function returns `TRUE` if the `eql?` method call returns a truthy
  * value (any value other than `false` or `nil`). Otherwise, it returns
@@ -880,6 +882,7 @@ MRB_API mrb_bool
 mrb_eql(mrb_state *mrb, mrb_value obj1, mrb_value obj2)
 {
   if (mrb_obj_eq(mrb, obj1, obj2)) return TRUE;
+  if (mrb_func_basic_p(mrb, obj1, MRB_SYM_Q(eql), mrb_obj_equal_m)) return FALSE;
   return mrb_test(mrb_funcall_argv(mrb, obj1, MRB_SYM_Q(eql), 1, &obj2));
 }
 


### PR DESCRIPTION
## Summary

`mrb_eql()` sends `eql?` even when the receiver has never redefined it, and the send walks into `Object#eql?` for the identity that was tested a line earlier. `mrb_equal()`, in the same file, already refuses that send for `==`.

## Changes

| File | What |
|---|---|
| `src/object.c` | `mrb_eql()` answers false without the send when the receiver's `eql?` is still `mrb_obj_equal_m()` |

### The question `mrb_equal()` already asks

`mrb_equal()` does not send `==` unconditionally. It asks whether the receiver still has the default `==`, which is `mrb_obj_equal_m()`, and answers false without the send when it does, because the identity that method would test has already been tested at the top of the function:

```c
  if (mrb_obj_eq(mrb, obj1, obj2)) return TRUE;
  ...
  else if (!mrb_func_basic_p(mrb, obj1, MRB_OPSYM(eq), mrb_obj_equal_m)) {
```

`Object#eql?` is that same `mrb_obj_equal_m()` (`src/kernel.c`, 15.3.1.3.10), so the reasoning carries over to `mrb_eql()`, which asked nothing and sent anyway. A Symbol, a plain Object, a Class, an Exception: anything that has not given itself an `eql?` paid a full send to be told what `mrb_obj_eq()` had just said.

Ask the question there too. A receiver whose `eql?` is still the default answers false at once; every other receiver reaches the send as before, and so does a receiver with no `eql?` at all, along with the `NoMethodError` raised there. Nothing observable changes, which is why there is no `## Behaviour` section below.

### Who reaches this

`mrb_eql()` is what the containers that compare by hash and equality use: `Hash` key lookup for a key that is not a String, Symbol, Integer or Float, since `obj_eql()` in `src/hash.c` answers those four itself; the khash set that `Array#uniq`, `#-`, `#&` and `#intersect?` build once they are past their length threshold; `Set`; `Range#eql?`; `Struct#eql?`; and `Data#eql?`.

## Speed

Callgrind `Ir`, with the same measurement run against an empty loop of the same length and subtracted. Default build config.

At 20,000 turns:

| | master `Ir` | this PR `Ir` | ratio |
|---|---|---|---|
| `h[obj]`, a `Hash` of 8 `Object` keys | 62,021,142 | 28,581,142 | 0.46x |
| `h["zz"]`, a `Hash` of 8 String keys | 21,702,049 | 21,702,049 | 1.00x |

At 2,000 turns, since one call is two orders of magnitude dearer:

| | master `Ir` | this PR `Ir` | ratio |
|---|---|---|---|
| `a.uniq`, 41 Symbols, over the threshold | 585,819,028 | 267,907,028 | 0.46x |
| `a.uniq`, 41 Strings, over the threshold | 59,109,947 | 62,923,947 | 1.06x |

The String rows are the two shapes of not benefiting. `Hash` never reaches `mrb_eql()` for a String key, so that row does not move at all. `Array#uniq` does reach it, and `String#eql?` is a real method, so the send happens anyway and the new question is paid for and answered no: one method lookup per comparison, 6% of a `uniq` that is already the cheap case here.

The `Object` and Symbol rows are receivers that never had an `eql?` of their own. Both cost a little under half what they did.

## Size

`bin/mruby` `.text`, `size -A`, each build made from an empty build directory at the same path:

| Build | master | this PR | delta |
|---|---|---|---|
| `full-debug` (-O0) | 1,911,686 | 1,911,718 | +32 |
| `bintest` | 1,306,246 | 1,306,294 | +48 |
| `cxx_abi` | 1,333,161 | 1,333,209 | +48 |
| `byte-string` | 1,270,630 | 1,270,678 | +48 |
| `ascii-ctype` | 1,292,854 | 1,292,902 | +48 |

The measurements above were taken in the default config, whose `.text` goes 1,217,342 to 1,217,390, +48.

## Testing

`build_config/ci/gcc-clang.rb`, all five builds plus the bintests, built from an empty build directory:

| Commit | full-debug | bintest | bintest (bin) | cxx_abi | byte-string | ascii-ctype |
|---|---|---|---|---|---|---|
| master (`a220a2bf9`) | 2562 OK | 2554 OK | 144 OK | 2554 OK | 2432 OK | 2543 OK |
| skip the send when `eql?` is the identity | 2562 OK | 2554 OK | 144 OK | 2554 OK | 2432 OK | 2543 OK |

0 KO, 0 crashes, no new compiler warnings anywhere.

`rake test` also passes under `MRB_NO_BOXING` and `MRB_NAN_BOXING`, since the identity tested above the new question is what boxing decides.

No test is added: nothing observable changes, and the counts above say so. What guards the change is the existing suite, which already fails if the send is skipped for a receiver that does have an `eql?`. Replacing the new question with an unconditional `return FALSE` and running `rake test` gives 5 failures, in `mruby-array-ext`, `mruby-set` (two), `mruby-rational` and `test/t/hash.rb`, which is a redefined `eql?` no longer being reached where it answers true.

## Environment

<details>
<summary>Host</summary>

| | |
|---|---|
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-30-generic x86_64 |
| CPU | AMD Ryzen 9 5950X (16C/32T) |
| Memory | 64 GiB |
| C compiler | gcc 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1) |
| binutils | GNU Binutils 2.47.20260726 |
| rake | 13.3.1 |
| valgrind | 3.27.1 |

</details>

<details>
<summary>Compile lines, one per build</summary>

`src/object.c` as each build actually compiles it, with `-MMD -c`, `-I` and `-o` dropped. `cxx_abi` is `gcc -x c++`, not `g++`; `g++` only links there. `enable_debug()` puts `-g3 -O0` after the toolchain's `-g -O3`, so `full-debug` is the one build at `-O0`.

```console
# full-debug
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/object.c

# bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK src/object.c

# cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/object.c

# byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/object.c

# ascii-ctype
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/object.c

# default config, where the Speed and the last Size line were measured
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK src/object.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved equality checks to return `false` consistently when the default equality behavior is used.

* **Documentation**
  * Clarified the documented behavior of equality comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->