### PR TITLE
mruby-array-ext: compare with `eql?` on the linear set-operation paths

### DIFF
--- a/mrbgems/mruby-array-ext/src/array.c
+++ b/mrbgems/mruby-array-ext/src/array.c
@@ -513,11 +513,11 @@ ary_subtract_internal(mrb_state *mrb, mrb_value self, mrb_int argc, const mrb_va
     int ai = mrb_gc_arena_save(mrb);
     for (mrb_int i = 0; i < RARRAY_LEN(self); i++) {
       mrb_value p = RARRAY_PTR(self)[i];
-      mrb_gc_protect(mrb, p); // p may be removed from self by mrb_equal()
+      mrb_gc_protect(mrb, p); // p may be removed from self by mrb_eql()
       mrb_bool found = FALSE;
       for (mrb_int j = 0; j < argc; j++) {
         for (mrb_int k = 0; k < RARRAY_LEN(argv[j]); k++) {
-          if (mrb_equal(mrb, p, RARRAY_PTR(argv[j])[k])) {
+          if (mrb_eql(mrb, p, RARRAY_PTR(argv[j])[k])) {
             found = TRUE;
             break;
           }
@@ -778,13 +778,13 @@ ary_intersection_internal(mrb_state *mrb, mrb_value self, mrb_int argc, const mr
     int ai = mrb_gc_arena_save(mrb);
     for (mrb_int i = 0; i < RARRAY_LEN(self); i++) {
       mrb_value p = RARRAY_PTR(self)[i];
-      mrb_gc_protect(mrb, p); // p may be removed from self by mrb_equal()
+      mrb_gc_protect(mrb, p); // p may be removed from self by mrb_eql()
       mrb_bool found_in_all = TRUE;
 
       for (mrb_int j = 0; j < argc; j++) {
         mrb_bool found_in_current_other = FALSE;
         for (mrb_int k = 0; k < RARRAY_LEN(argv[j]); k++) {
-          if (mrb_equal(mrb, p, RARRAY_PTR(argv[j])[k])) {
+          if (mrb_eql(mrb, p, RARRAY_PTR(argv[j])[k])) {
             found_in_current_other = TRUE;
             break;
           }
@@ -798,7 +798,7 @@ ary_intersection_internal(mrb_state *mrb, mrb_value self, mrb_int argc, const mr
       if (found_in_all) {
         mrb_bool already_added = FALSE;
         for (mrb_int j = 0; j < RARRAY_LEN(result); j++) {
-          if (mrb_equal(mrb, p, RARRAY_PTR(result)[j])) {
+          if (mrb_eql(mrb, p, RARRAY_PTR(result)[j])) {
             already_added = TRUE;
             break;
           }
@@ -936,9 +936,9 @@ ary_intersect_p(mrb_state *mrb, mrb_value self)
     int ai = mrb_gc_arena_save(mrb);
     for (mrb_int i = 0; i < RARRAY_LEN(longer_ary); i++) {
       mrb_value p = RARRAY_PTR(longer_ary)[i];
-      mrb_gc_protect(mrb, p); // p may be removed from longer_ary by mrb_equal()
+      mrb_gc_protect(mrb, p); // p may be removed from longer_ary by mrb_eql()
       for (mrb_int j = 0; j < RARRAY_LEN(shorter_ary); j++) {
-        if (mrb_equal(mrb, p, RARRAY_PTR(shorter_ary)[j])) {
+        if (mrb_eql(mrb, p, RARRAY_PTR(shorter_ary)[j])) {
           return mrb_true_value();
         }
       }
@@ -1168,10 +1168,10 @@ ary_uniq_bang(mrb_state *mrb, mrb_value self)
     int ai = mrb_gc_arena_save(mrb);
     for (mrb_int read_pos = 0; read_pos < RARRAY_LEN(self); read_pos++) {
       mrb_value elem = RARRAY_PTR(self)[read_pos];
-      mrb_gc_protect(mrb, elem); // elem may be removed from self by mrb_equal()
+      mrb_gc_protect(mrb, elem); // elem may be removed from self by mrb_eql()
       mrb_bool found = FALSE;
       for (mrb_int j = 0; j < write_pos && j < RARRAY_LEN(self); j++) {
-        if (mrb_equal(mrb, elem, RARRAY_PTR(self)[j])) {
+        if (mrb_eql(mrb, elem, RARRAY_PTR(self)[j])) {
           found = TRUE;
           break;
         }

--- a/mrbgems/mruby-array-ext/test/array.rb
+++ b/mrbgems/mruby-array-ext/test/array.rb
@@ -912,3 +912,57 @@ assert('mrb_ary_unshift respects a frozen receiver') do
   d = [1, 2]
   assert_equal [0, 1, 2], d.__unshift_from_c(0)
 end
+
+assert('Array set operations compare with eql? on both sides of the hash threshold') do
+  # Each of these operations has two implementations, picked by a length
+  # threshold of 32: a hash path whose equality callback is eql?, and a linear
+  # walk that used to compare with ==. 1 == 1.0 is true where 1.eql?(1.0) is
+  # false, so the same pair of elements was one element or two depending only
+  # on how long the array was. The linear walks now compare with eql? too.
+  pad = (2..40).to_a  # enough to carry any of these arrays past the threshold
+  long_receiver = [1] + pad
+  long_floats = pad.map { |i| i + 0.0 } + [1.0]
+
+  # uniq/uniq! take the threshold from the receiver
+  assert_equal [1, 1.0], [1, 1.0].uniq
+  assert_equal [1, 1.0] + pad, ([1, 1.0] + pad).uniq
+  # nothing to remove any more, so uniq! reports no change on either path
+  assert_nil [1, 1.0].uniq!
+  big = [1, 1.0] + pad
+  assert_nil big.uniq!
+  # and it still reports a change, and removes the right element, when the
+  # duplicate really is eql?
+  small_dup = [1, 1.0, 1]
+  assert_equal [1, 1.0], small_dup.uniq!
+
+  # `-` and `&` take it from the argument arrays alone, so a long receiver is
+  # no guarantee of the hash path
+  assert_equal [1], [1] - [1.0]
+  assert_equal [1] + pad, long_receiver - [1.0]
+  assert_equal [1], [1] - [1.0, 2.0]
+  assert_equal [1], [1] - long_floats
+
+  assert_equal [], [1] & [1.0]
+  assert_equal [], long_receiver & [1.0]
+  assert_equal [], [1] & long_floats
+  # the result dedup inside `&` is the same comparison
+  assert_equal [1, 1.0], ([1, 1.0] & [1, 1.0])
+
+  # intersect? takes it from the shorter of the two
+  assert_false [1].intersect?([1.0])
+  assert_false long_receiver.intersect?([1.0])
+  assert_false long_floats.intersect?([1])
+
+  # `|` already compared with eql? on both paths, and so did the block form of
+  # uniq, which is written over a Hash; they have to keep agreeing with the
+  # operations above rather than contradicting them
+  assert_equal [1, 1.0], [1] | [1.0]
+  assert_equal [1] + pad + [1.0], long_receiver | [1.0]
+  assert_equal [1, 1.0], [1, 1.0].uniq { |x| x }
+
+  # and elements that really are eql? still collapse on the linear paths
+  assert_equal [1.0], [1.0, 1.0].uniq
+  assert_equal [], [1.0] - [1.0]
+  assert_equal [1.0], [1.0] & [1.0]
+  assert_true [1.0].intersect?([1.0])
+end


### PR DESCRIPTION
## Summary

`Array#uniq`, `#-`, `#&` and `#intersect?` each have two implementations picked by the length of the array, and the two did not agree on what makes two elements the same one. Which of them ran decided whether `[1, 1.0]` held one element or two.

## Changes

| File | What |
|---|---|
| `mrbgems/mruby-array-ext/src/array.c` | `ary_subtract_internal()`, `ary_intersection_internal()` (two sites), `ary_intersect_p()` and `ary_uniq_bang()` compare with `mrb_eql()` on their linear paths |
| `mrbgems/mruby-array-ext/test/array.rb` | one block pinning the five operations on both sides of the threshold |

### The threshold decided the comparison

Each of `uniq`/`uniq!`, `-`, `&` and `intersect?` is written twice: past a length threshold of 32 it builds a khash set whose equality callback is `ary_set_equal_func()`, which calls `mrb_eql()`, and below it walks the array comparing with `mrb_equal()`, that is `==`. `1 == 1.0` is true where `1.eql?(1.0)` is false, so the length of the array decided the answer:

```ruby
[1, 1.0].uniq                        #=> [1], where CRuby answers [1, 1.0]
([1, 1.0] + (2..40).to_a).uniq.size  #=> 41, the same pair kept apart
```

The threshold is not even read off the same array everywhere. `-` and `&` measure their argument arrays alone, so a forty element receiver still took the linear path against a one element argument:

```ruby
([1] + (2..40).to_a) - [1.0]         #=> the 1 is gone; CRuby keeps it
```

And the operations disagreed with their own neighbours. `|` reaches `mrb_eql()` through `add_uniq()` on its linear path, and the block form of `uniq` is written in Ruby over a `Hash`, so both compared by `eql?` at every length. In the same two element world, `&` called `1` and `1.0` the same element while `|` and `uniq { |x| x }` called them different.

The five remaining `mrb_equal()` call sites in those linear walks become `mrb_eql()`. Each now agrees with its own khash branch, with `|`, with the block form of `uniq`, and with CRuby, and the answer no longer depends on where the array falls relative to the threshold.

`assoc` and `rassoc` keep `mrb_equal()`. They are defined in terms of `==`, and they are not set operations.

## Behaviour

Measured against CRuby 4.0.6.

| expression | master | this PR | CRuby |
| --- | --- | --- | --- |
| `[1, 1.0].uniq` | **[1]** | [1, 1.0] | [1, 1.0] |
| `[1, 1.0].uniq!` | **[1]** | nil | nil |
| `([1, 1.0] + (2..40).to_a).uniq.size` | 41 | 41 | 41 |
| `[1] - [1.0]` | **[]** | [1] | [1] |
| `[1, 1.0] - [1.0]` | **[]** | [1] | [1] |
| `(([1] + (2..40).to_a) - [1.0]).size` | **39** | 40 | 40 |
| `[1] & [1.0]` | **[1]** | [] | [] |
| `([1] + (2..40).to_a) & [1.0]` | **[1]** | [] | [] |
| `[1, 1.0] & [1, 1.0]` | **[1]** | [1, 1.0] | [1, 1.0] |
| `[1].intersect?([1.0])` | **true** | false | false |
| `((2..40).to_a + [1]).intersect?([1.0])` | **true** | false | false |
| <code>[1] &#124; [1.0]</code> | [1, 1.0] | [1, 1.0] | [1, 1.0] |
| <code>[1, 1.0].uniq { &#124;x&#124; x }</code> | [1, 1.0] | [1, 1.0] | [1, 1.0] |

The last four rows are the ones that already agreed with CRuby and had to keep agreeing: the khash path of `uniq`, `|`, and `uniq` with a block.

A NaN is untouched. Both comparisons answer identity first, so what a NaN does in these operations is decided by the boxing mode rather than by the comparison: a boxed build answers `[nan, nan].uniq` with one element, `[nan] & [nan]` with `[NaN]` and `[nan].intersect?([nan])` with true, and `MRB_NO_BOXING` answers all three the other way. Each of them answers the same before and after, in all three modes. That an `mrb_value` holding a NaN is its own identity at all is the separate question left open by mruby/mruby#7349.

## Speed

Callgrind `Ir` at 20,000 turns, with the same measurement run against an empty loop of the same length and subtracted. Every array here is 8 elements, which is the linear path. Default build config.

| | master `Ir` | this PR `Ir` | ratio |
|---|---|---|---|
| `syms - [:xx]` | 69,378,721 | 98,979,194 | 1.43x |
| `objs - [obj]` | 72,101,557 | 101,860,975 | 1.41x |
| `syms.uniq` | 108,592,815 | 212,193,288 | 1.95x |
| `syms.intersect?([:xx])` | 36,370,959 | 65,971,420 | 1.81x |
| `strs - ["xx"]` | 125,859,194 | 110,659,815 | 0.88x |
| `strs.uniq` | 289,233,937 | 236,034,558 | 0.82x |
| `ints - [9]` | 122,180,596 | 102,340,775 | 0.84x |
| `ints & [9]` | 100,510,637 | 80,670,816 | 0.80x |

The two halves of that table are one fact. `mrb_equal()` refuses to send `==` when the receiver still has the default one, and `mrb_eql()` sends `eql?` unconditionally, so an element that never redefined `eql?` (a Symbol, a plain Object) went from no send to one send a comparison. An element that redefines both (a String, an Integer) is sent to either way, and `eql?` is the cheaper of the two because it does not carry `mrb_equal()`'s Integer against Float and bigint arms.

That asymmetry is `mrb_eql()`'s, not this change's, and mruby/mruby#7351 gives `mrb_eql()` the same refusal. With it applied, no row is above master:

| | master `Ir` | this PR `Ir` | with mruby/mruby#7351 | ratio to master |
|---|---|---|---|---|
| `syms - [:xx]` | 69,378,721 | 98,979,194 | 66,339,194 | 0.96x |
| `objs - [obj]` | 72,101,557 | 101,860,975 | 69,700,975 | 0.97x |
| `syms.uniq` | 108,592,815 | 212,193,288 | 97,953,288 | 0.90x |
| `syms.intersect?([:xx])` | 36,370,959 | 65,971,420 | 33,331,432 | 0.92x |
| `strs - ["xx"]` | 125,859,194 | 110,659,815 | 123,939,815 | 0.98x |
| `strs.uniq` | 289,233,937 | 236,034,558 | 282,514,558 | 0.98x |
| `ints - [9]` | 122,180,596 | 102,340,775 | 117,060,775 | 0.96x |
| `ints & [9]` | 100,510,637 | 80,670,816 | 95,390,816 | 0.95x |

The two are independent and either can be merged alone. This one is the correctness fix and stands on its own; the other one is worth having whether or not this lands.

## Size

`bin/mruby` `.text`, `size -A`, each build made from an empty build directory at the same path:

| Build | master | this PR | delta |
|---|---|---|---|
| `full-debug` (-O0) | 1,911,686 | 1,911,686 | 0 |
| `bintest` | 1,306,246 | 1,306,246 | 0 |
| `cxx_abi` | 1,333,161 | 1,333,161 | 0 |
| `byte-string` | 1,270,630 | 1,270,630 | 0 |
| `ascii-ctype` | 1,292,854 | 1,292,854 | 0 |

One call is exchanged for another of the same shape at five sites, and no build's `.text` moves by a byte. The default config, where the Speed numbers were taken, is 1,217,342 either way.

## Testing

`build_config/ci/gcc-clang.rb`, all five builds plus the bintests, built from an empty build directory:

| Commit | full-debug | bintest | bintest (bin) | cxx_abi | byte-string | ascii-ctype |
|---|---|---|---|---|---|---|
| master (`a220a2bf9`) | 2562 OK | 2554 OK | 144 OK | 2554 OK | 2432 OK | 2543 OK |
| compare with `eql?` on the linear paths | 2563 OK | 2555 OK | 144 OK | 2555 OK | 2433 OK | 2544 OK |

0 KO, 0 crashes, no new compiler warnings anywhere.

The one added block is in `mrbgems/mruby-array-ext/test/array.rb`. It pins `[1, 1.0]` on both sides of the threshold for all five operations, including the argument side threshold that `-` and `&` read and the result dedup inside `&`, and it checks that elements that really are `eql?` still collapse, so the change is not just never equal. `|` and the block form of `uniq` are asserted alongside as the anchors they were.

Every expected value in it was read off CRuby 4.0.6 rather than written from memory. Building the block against master's `array.c` fails it on 12 assertions, which is the list in `## Behaviour` above.

`rake test` also passes under `MRB_NO_BOXING` and `MRB_NAN_BOXING`, where the identity that both comparisons answer first is a different question, and the new block asserts the same answers in all three.

## Environment

<details>
<summary>Host</summary>

| | |
|---|---|
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-30-generic x86_64 |
| CPU | AMD Ryzen 9 5950X (16C/32T) |
| Memory | 64 GiB |
| C compiler | gcc 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1) |
| binutils | GNU Binutils 2.47.20260726 |
| CRuby | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |
| rake | 13.3.1 |
| valgrind | 3.27.1 |

</details>

<details>
<summary>Compile lines, one per build</summary>

`mrbgems/mruby-array-ext/src/array.c` as each build actually compiles it, with `-MMD -c`, `-I` and `-o` dropped. `cxx_abi` is `gcc -x c++`, not `g++`; `g++` only links there. `enable_debug()` puts `-g3 -O0` after the toolchain's `-g -O3`, so `full-debug` is the one build at `-O0`.

```console
# full-debug
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRBGEM_MRUBY_ARRAY_EXT_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-array-ext/src/array.c

# bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_ARRAY_EXT_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK mrbgems/mruby-array-ext/src/array.c

# cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_ARRAY_EXT_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-array-ext/src/array.c

# byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_ARRAY_EXT_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-array-ext/src/array.c

# ascii-ctype
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRBGEM_MRUBY_ARRAY_EXT_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-array-ext/src/array.c

# default config, where the Speed numbers and the last Size line were measured
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_ARRAY_EXT_VERSION=0.0.0 -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK mrbgems/mruby-array-ext/src/array.c
```

</details>
