### PR TITLE
enum.rb: ask for the block once rather than once an element

### DIFF
--- a/mrbgems/mruby-enum-ext/mrblib/enum.rb
+++ b/mrbgems/mruby-enum-ext/mrblib/enum.rb
@@ -369,22 +369,42 @@ module Enumerable
     min = nil
     first = true
 
-    self.each do |*val|
-      if first
+    # The block is asked for out here rather than once an element, as in
+    # `Enumerable#max`; the loop body is the same either way but for what it
+    # compares with.
+    if block
+      self.each do |*val|
         val = val.__svalue
-        max = val
-        min = val
-        first = false
-      else
+        if first
+          max = val
+          min = val
+          first = false
+        else
+          # A comparison with no answer is not an ordering, the same as in
+          # Enumerable#max and #min.
+          cmp = block.call(val, max)
+          raise ArgumentError, "comparison of #{val.class} with #{max.class} failed" if cmp.nil?
+          max = val if cmp > 0
+          cmp = block.call(val, min)
+          raise ArgumentError, "comparison of #{val.class} with #{min.class} failed" if cmp.nil?
+          min = val if cmp < 0
+        end
+      end
+    else
+      self.each do |*val|
         val = val.__svalue
-        # A comparison with no answer is not an ordering, the same as in
-        # Enumerable#max and #min.
-        cmp = block ? block.call(val, max) : (val <=> max)
-        raise ArgumentError, "comparison of #{val.class} with #{max.class} failed" if cmp.nil?
-        max = val if cmp > 0
-        cmp = block ? block.call(val, min) : (val <=> min)
-        raise ArgumentError, "comparison of #{val.class} with #{min.class} failed" if cmp.nil?
-        min = val if cmp < 0
+        if first
+          max = val
+          min = val
+          first = false
+        else
+          cmp = (val <=> max)
+          raise ArgumentError, "comparison of #{val.class} with #{max.class} failed" if cmp.nil?
+          max = val if cmp > 0
+          cmp = (val <=> min)
+          raise ArgumentError, "comparison of #{val.class} with #{min.class} failed" if cmp.nil?
+          min = val if cmp < 0
+        end
       end
     end
     [min, max]

--- a/mrbgems/mruby-enum-ext/test/enum.rb
+++ b/mrbgems/mruby-enum-ext/test/enum.rb
@@ -241,6 +241,13 @@ assert('Enumerable#minmax - a comparison with no answer') do
     assert_raise(ArgumentError) { [1.0, Float::NAN, 2.0].minmax }
   end
 
+  # A pair of different kinds stands in no order either.
+  assert_raise(ArgumentError) { [1, 'a'].minmax }
+
   assert_equal [1, 3], [3, 1, 2].minmax
   assert_equal [1, 3], [3, 1, 2].minmax { |a, b| a <=> b }
+
+  # The first element is never compared, and an empty collection has none.
+  assert_equal ['a', 'a'], ['a'].minmax
+  assert_equal [nil, nil], [].minmax
 end

--- a/mrblib/enum.rb
+++ b/mrblib/enum.rb
@@ -223,20 +223,37 @@ module Enumerable
   def max(&block)
     flag = true  # 1st element?
     result = nil
-    self.each {|*val|
-      val = val.__svalue
-      if flag
-        # 1st element
-        result = val
-        flag = false
-      else
-        cmp = block ? yield(val, result) : (val <=> result)
-        # A comparison with no answer is not an ordering: without this the line
-        # below would ask nil whether it is positive.
-        raise ArgumentError, "comparison of #{val.class} with #{result.class} failed" if cmp.nil?
-        result = val if cmp > 0
-      end
-    }
+    # The block is asked for out here rather than once an element: what the
+    # loop does with a pair is the same either way, and the test is worth more
+    # outside the loop than the second copy of the body costs.
+    if block
+      self.each {|*val|
+        val = val.__svalue
+        if flag
+          # 1st element
+          result = val
+          flag = false
+        else
+          cmp = yield(val, result)
+          # A comparison with no answer is not an ordering: without this the
+          # line below would ask nil whether it is positive.
+          raise ArgumentError, "comparison of #{val.class} with #{result.class} failed" if cmp.nil?
+          result = val if cmp > 0
+        end
+      }
+    else
+      self.each {|*val|
+        val = val.__svalue
+        if flag
+          result = val
+          flag = false
+        else
+          cmp = (val <=> result)
+          raise ArgumentError, "comparison of #{val.class} with #{result.class} failed" if cmp.nil?
+          result = val if cmp > 0
+        end
+      }
+    end
     result
   end
 
@@ -250,18 +267,33 @@ module Enumerable
   def min(&block)
     flag = true  # 1st element?
     result = nil
-    self.each {|*val|
-      val = val.__svalue
-      if flag
-        # 1st element
-        result = val
-        flag = false
-      else
-        cmp = block ? yield(val, result) : (val <=> result)
-        raise ArgumentError, "comparison of #{val.class} with #{result.class} failed" if cmp.nil?
-        result = val if cmp < 0
-      end
-    }
+    # see `max` above for why the block is asked for out here
+    if block
+      self.each {|*val|
+        val = val.__svalue
+        if flag
+          # 1st element
+          result = val
+          flag = false
+        else
+          cmp = yield(val, result)
+          raise ArgumentError, "comparison of #{val.class} with #{result.class} failed" if cmp.nil?
+          result = val if cmp < 0
+        end
+      }
+    else
+      self.each {|*val|
+        val = val.__svalue
+        if flag
+          result = val
+          flag = false
+        else
+          cmp = (val <=> result)
+          raise ArgumentError, "comparison of #{val.class} with #{result.class} failed" if cmp.nil?
+          result = val if cmp < 0
+        end
+      }
+    end
     result
   end
 

--- a/test/t/enumerable.rb
+++ b/test/t/enumerable.rb
@@ -147,8 +147,19 @@ assert('Enumerable#max, #min - a comparison with no answer') do
     assert_raise(ArgumentError) { [1, nan].max }
   end
 
+  # A pair of different kinds stands in no order either.
+  assert_raise(ArgumentError) { [1, 'a'].max }
+  assert_raise(ArgumentError) { [1, 'a'].min }
+
   # An ordering that holds is left alone.
   assert_equal 3, [3, 1, 2].max
   assert_equal 1, [3, 1, 2].min
   assert_equal 3, [3, 1, 2].max { |a, b| a <=> b }
+  assert_equal 1, [3, 1, 2].min { |a, b| a <=> b }
+
+  # The first element is never compared, and an empty collection has none.
+  assert_equal 'a', ['a'].max
+  assert_equal 'a', ['a'].min
+  assert_nil [].max
+  assert_nil [].min
 end


### PR DESCRIPTION
## Summary

`Enumerable#max`, `#min` and `#minmax` decide per element whether they were handed a block, and what the answer is was settled before the walk began. Taking that test out of the loop is worth 2.5% to `max` and 3.9% to `minmax`, and changes nothing about what they answer.

## Changes

| File | What |
| --- | --- |
| `mrblib/enum.rb` | `#max`, `#min`: the walk is written once for each way of comparing |
| `mrbgems/mruby-enum-ext/mrblib/enum.rb` | `#minmax`: the same |
| `test/t/enumerable.rb` | a pair of different kinds, one element, none |
| `mrbgems/mruby-enum-ext/test/enum.rb` | the same for `#minmax` |

### What the block is was settled before the walk began

`block ? yield(val, result) : (val <=> result)` is a test the loop carries and never changes its mind about. The walk is written twice instead, once for each way of comparing, and the test is made once before either runs:

```ruby
if block
  self.each {|*val| ... cmp = yield(val, result) ... }
else
  self.each {|*val| ... cmp = (val <=> result) ... }
end
```

`#minmax` gains the most from it, having asked twice per element.

## Behaviour

None. What is compared, in what order, and what is raised are what they were: a probe of 114 expressions over `#max`, `#min`, `#minmax`, `#clamp` and their neighbours answers identically to master, row for row, including the ones that raise.

The tests added pin what the rewrite must not lose: a pair of different kinds (`[1, 'a'].max`), an ordering that holds with and without a block, a single element (never compared) and an empty collection.

## Speed

```ruby
a = (1..300).to_a
20000.times { a.max }        # and 10000.times { a.minmax }
```

Best of 11 interleaved runs against master, with a master-vs-master control to read the noise by, and the instruction counts callgrind reads beside them:

| benchmark | master | this PR | control | Ir |
| --- | --- | --- | --- | --- |
| `(1..300).to_a.max` x 20000 | 729 ms | **706 ms (0.97x)** | +0.5% | -2.5% |
| `(1..300).to_a.minmax` x 10000 | 465 ms | **447 ms (0.96x)** | +0.5% | -3.9% |

## Size

`bin/mruby` `.text` for every build in `build_config/ci/gcc-clang.rb`:

| build | master | this PR | delta |
| --- | --- | --- | --- |
| `ascii-ctype` | 1,292,854 | 1,292,854 | 0 |
| `bintest` | 1,306,246 | 1,306,246 | 0 |
| `byte-string` | 1,270,630 | 1,270,630 | 0 |
| `cxx_abi` | 1,333,161 | 1,333,161 | 0 |
| `full-debug` (-O0) | 1,911,686 | 1,911,782 | +96 |

No C changed, so the second copy of the three walks is paid in bytecode: `.rodata` reads +544 bytes in the first four builds and +704 in `full-debug`.

## Testing

`rake test` passes for the default build, `build_config/host-nofloat.rb`, and every build in `build_config/ci/gcc-clang.rb` including the C++ ABI one.

## Environment

<details>
<summary>Machine, toolchain and the compile lines these numbers were taken with</summary>

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-30-generic x86_64 |
| CPU | AMD Ryzen 9 5950X (16 cores) |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0 |
| binutils | GNU ld (GNU Binutils) 2.47.20260726 |
| valgrind | valgrind-3.27.1 (callgrind) |
| CRuby | 4.0.6 (2026-07-14 revision 03b6d3f889) |

The wall clock and instruction counts were taken with the default build:

```console
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK
```

The `## Size` table was taken with `build_config/ci/gcc-clang.rb`:

```console
bintest      gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK
ascii-ctype  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
byte-string  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
cxx_abi      gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
full-debug   gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

`cxx_abi` compiles mruby as C++ with `gcc -x c++ -std=gnu++03`; g++ only links. `full-debug` is the one build at `-O0`, `enable_debug` putting `-g3 -O0` after the toolchain default of `-g -O3`.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `Enumerable#minmax` handling for incomparable elements and invalid comparison results, with clearer `ArgumentError` reporting.
  * Updated `Enumerable#min` and `Enumerable#max` behavior for mixed-type collections, explicit ordering blocks, single-element collections, and empty collections.
  * Preserved expected results for valid comparisons while returning `nil` for empty collections.

* **Tests**
  * Added coverage for edge cases involving ordering, comparison failures, singleton collections, and empty collections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->