### PR TITLE
mruby-compiler: give an assignment to a captured local its value

### DIFF
--- a/mrbgems/mruby-compiler/src/codegen.c
+++ b/mrbgems/mruby-compiler/src/codegen.c
@@ -1151,12 +1151,16 @@ gen_getupvar(mrc_codegen_scope *s, uint16_t dst, mrc_sym id)
 }
 
 static void
-gen_setupvar(mrc_codegen_scope *s, uint16_t dst, mrc_sym id)
+gen_setupvar(mrc_codegen_scope *s, uint16_t dst, mrc_sym id, int val)
 {
   int idx;
   int lv = search_upvar(s, id, &idx);
 
-  if (!no_peephole(s)) {
+  /* Folding the preceding `OP_MOVE dst, src` into `OP_SETUPVAR src` leaves
+     `dst` unwritten, so it is only sound where the assignment is a statement.
+     As an expression the value belongs in `dst`, and the store is the only
+     thing that would have put it there. */
+  if (!val && !no_peephole(s)) {
     struct mrc_insn_data data = mrc_last_insn(s);
     if (data.insn == OP_MOVE && data.a == dst) {
       dst = data.b;
@@ -1980,7 +1984,7 @@ gen_assignment_lvar(mrc_codegen_scope *s, int sp, mrc_sym name, int depth, int v
     }
   }
   else {
-    gen_setupvar(s, sp, name);
+    gen_setupvar(s, sp, name, val);
   }
 }
 

--- a/test/t/codegen.rb
+++ b/test/t/codegen.rb
@@ -267,3 +267,39 @@ assert('block inside a for body sees its own locals') do
   end
   assert_equal 3, x
 end
+
+assert('assignment to a captured local is worth its value') do
+  # `a = v` inside a block stores through OP_SETUPVAR, which unlike OP_MOVE
+  # leaves no value behind. Folding the preceding move into it used to happen
+  # even where the assignment is an expression, so the register the value
+  # belonged in was never written and the block answered whatever it held.
+  a = nil
+  assert_equal [7], [7].map {|v| a = v }
+  assert_equal 7, a
+
+  assert_equal [7], [7].select {|v| a = v }
+
+  # every name of a chain gets the value, not just the last
+  b = nil
+  [7].each {|v| a = b = v }
+  assert_equal [7, 7], [a, b]
+
+  # the register is not merely nil: `f` below is what it held
+  a = nil; b = nil; f = true
+  [7].each {|v| if f; a = b = v; f = false; end }
+  assert_equal [7, 7], [a, b]
+
+  a = nil
+  assert_equal [7], [7].map {|v| a ||= v }
+
+  # a block nested in another block, and one reached through `yield`
+  a = nil
+  assert_equal [[7]], [[7]].map {|arr| arr.map {|v| a = v } }
+  def give7; yield 7; end
+  assert_equal 7, give7 {|v| a = v }
+
+  # as a statement the value is unused, and the store still lands
+  a = nil
+  [7].each {|v| a = v }
+  assert_equal 7, a
+end


### PR DESCRIPTION
## Summary

```ruby
a = nil
p([7].map {|v| a = v })      # master: [nil], CRuby: [7]
p([7].select {|v| a = v })   # master: [],    CRuby: [7]
```

`a` holds 7 after either line, so the store lands. It is the value of the assignment that is wrong, and anything reading it gets whatever the register happened to hold: nil where nothing wrote it, and the value of a neighbouring name where something did. Nothing raises, so `select` quietly drops an element it should keep and a block whose last statement is such an assignment quietly answers something unrelated.

## Changes

| File | What |
|---|---|
| `mrbgems/mruby-compiler/src/codegen.c` | `gen_setupvar()` takes `val` and folds the preceding `OP_MOVE` only where the value is unused |
| `test/t/codegen.rb` | the value of the assignment, a chain, `\|\|=`, a nested block, `yield`, and the statement form |

### `OP_SETUPVAR` leaves nothing behind, and the fold took away what did

A local of the block's own scope is assigned with `OP_MOVE Rdst, Rsrc`, which leaves the value in `Rdst` as a side effect of the store. A captured one goes through `OP_SETUPVAR`, which writes only the upvar. `gen_setupvar()` folded the `OP_MOVE` that put the value in `Rdst` into the store's source operand, so nothing wrote `Rdst` at all:

```console
$ cat bug.rb
a = nil
[7].each {|v| p(a = v) }

$ mrbc -v bug.rb          # master
    2 000 ENTER      1:0:0:0:0:0:0:0
    2 004 SETUPVAR   R1  1  0    ; R1:v
    2 008 SSEND      R3  :p  n=1
    2 012 RETURN     R3

$ mrbc -v bug.rb          # this PR
    2 000 ENTER      1:0:0:0:0:0:0:0
    2 004 MOVE       R4  R1      ; R1:v
    2 007 SETUPVAR   R4  1  0
    2 011 SSEND      R3  :p  n=1
    2 015 RETURN     R3
```

`SSEND R3 :p n=1` reads its one argument from R4, which on master no instruction ever writes.

### The guard is the one the neighbouring stores already carry

`gen_setxv()`, which emits `OP_SETIV`, `OP_SETCV`, `OP_SETGV` and `OP_SETCONST`, holds the same peephole behind `!val`, and so does `genjmp2()`. `gen_setupvar()` was the one store that folded unconditionally. Giving it the same parameter and the same guard is the whole change; `gen_assignment_lvar()` already had `val` in hand to pass, and its `depth == 0` arm already threads it into `gen_move()`.

Where the assignment is a statement the fold still happens, and the bytecode is byte for byte what master emits.

### The right-hand side has to be a plain local of the block

Anything that computes into a fresh register leaves the value where the expression expects it, and never reached the fold. That is why the shape is easy to miss in review: `a = v` is wrong and `a = v.to_i` is right.

Nine sites in the tree write the wrong half, in `Enumerable#inject`, `#max` and `#min` (`mrblib/enum.rb`), `#max_by`, `#min_by`, `#minmax` and `#minmax_by` (`mrbgems/mruby-enum-ext/mrblib/enum.rb`), `Enumerator#chunk_while` (`mrbgems/mruby-enumerator/mrblib/enumerator.rb`) and `TCPSocket#initialize` (`mrbgems/mruby-socket/mrblib/socket.rb`). Every one of them is the last expression of a block passed to `each` or `foreach`, whose value the caller throws away, so no method in the tree answers differently today. What each gains is the three bytes of the restored `OP_MOVE`.

## Behaviour

Each row is the value the block answers, from `[7].map {|v| ... }`. Every row matches CRuby 4.0.6 after the change.

| written inside the block | master | this PR | CRuby |
| --- | --- | --- | --- |
| `a = v` | `[nil]` | `[7]` | `[7]` |
| `a = b = v` | `[nil]` | `[7]` | `[7]` |
| `a = nil; a \|\|= v` | `[nil]` | `[7]` | `[7]` |
| `a = v.to_i` | `[7]` | `[7]` | `[7]` |
| `a = v + 0` | `[7]` | `[7]` | `[7]` |
| `a = 7` | `[7]` | `[7]` | `[7]` |
| `a = c` (`c` captured) | `[5]` | `[5]` | `[5]` |
| `a, b = v, v` | `[[7, 7]]` | `[[7, 7]]` | `[[7, 7]]` |
| `a = 0; a += v` | `[7]` | `[7]` | `[7]` |
| `@a = v` | `[7]` | `[7]` | `[7]` |
| `$g = v` | `[7]` | `[7]` | `[7]` |
| `x = y = v` (both block-locals) | `[7]` | `[7]` | `[7]` |

And two shapes where the wrong value is read rather than returned:

| | master | this PR | CRuby |
| --- | --- | --- | --- |
| `[7].select {\|v\| a = v }` | `[]` | `[7]` | `[7]` |
| `a = b = v` in a chain, then `[a, b]` | `[true, 7]` | `[7, 7]` | `[7, 7]` |

The `true` in the last row is what the register held from the line before, which is `f = false` in the loop this was reduced from.

## Speed

The restored `OP_MOVE` is one instruction per assignment, executed only where the assignment is an expression.

```ruby
arr = [7]
i = 0; while i < N; arr.each {|v| a = v; v };        i += 1; end   # statement
i = 0; while i < N; arr.each {|v| a = v };           i += 1; end   # block's value
i = 0; while i < N; arr.each {|v| x = (a = v) };     i += 1; end   # assigned on
i = 0; while i < N; arr.map  {|v| a = v };           i += 1; end
```

Callgrind `Ir` at 300,000 turns, whole process, with an empty loop of the same length measured the same way as a control:

| script | master `Ir` | this PR `Ir` | delta | per turn |
|---|---|---|---|---|
| control: empty `while` loop | 83,256,881 | 83,256,874 | -7 | |
| `arr.each {\|v\| a = v; v }` | 752,716,108 | 752,716,108 | 0 | 0 |
| `arr.each {\|v\| a = v }` | 753,314,309 | 760,214,305 | +6,899,996 | +23 |
| `arr.each {\|v\| x = (a = v) }` | 767,120,952 | 774,020,978 | +6,900,026 | +23 |
| `arr.map {\|v\| a = v }` | 1,655,298,040 | 1,661,595,838 | +6,297,798 | +21 |

Net of the control that is 1.0% on `each` and 0.4% on `map`. The statement row is bit identical before subtraction, which is the fold still doing its job and also says the measurement is clean.

Wall clock, best of 11, 20,000,000 turns for the `each` rows and 6,000,000 for `map`, is inside this host's noise:

| script | master | this PR |
|---|---|---|
| `arr.each {\|v\| a = v; v }` | 2.86 s | 2.84 s |
| `arr.each {\|v\| a = v }` | 2.90 s | 2.92 s |
| `arr.each {\|v\| x = (a = v) }` | 3.10 s | 3.04 s |
| `arr.map {\|v\| a = v }` | 2.09 s | 2.08 s |

Compile time carries one more branch per captured-local assignment, which is the -7 `Ir` on the control: below what the layout of the surrounding functions moves by.

## Size

`bin/mruby` `.text`, `size -A`, each build made from an empty build directory at the same path:

| Build | master | this PR | delta |
|---|---|---|---|
| `full-debug` (-O0) | 1,911,686 | 1,911,686 | 0 |
| `bintest` | 1,306,246 | 1,306,214 | -32 |
| `cxx_abi` | 1,333,161 | 1,333,145 | -16 |
| `byte-string` | 1,270,630 | 1,270,598 | -32 |
| `ascii-ctype` | 1,292,854 | 1,292,822 | -32 |

The guard itself costs 5 bytes: at -O3 `gen_setupvar()` inlines into `gen_assignment_lvar()`, which goes 330 -> 335. The negative total is the optimizer re-laying out the rest of the object around it, `genjmp.constprop.0` 578 -> 537 and `genop_2S` 443 -> 457, for `codegen.o` `.text` 87,609 -> 87,577. At -O0 the function is not inlined and grows 9 bytes, with 1 more in its caller, and the linked `.text` does not move because function alignment absorbs it.

`.rodata` grows 32 in the same build, 258,352 -> 258,384, holding the 27 bytes the nine `mrblib` sites gain.

## Testing

`build_config/ci/gcc-clang.rb`, all five builds plus the bintests, built from an empty build directory:

| Commit | full-debug | bintest | bintest (bin) | cxx_abi | byte-string | ascii-ctype |
|---|---|---|---|---|---|---|
| master (`a220a2bf9`) | 2562 OK | 2554 OK | 144 OK | 2554 OK | 2432 OK | 2543 OK |
| give an assignment to a captured local its value | 2563 OK | 2555 OK | 144 OK | 2555 OK | 2433 OK | 2544 OK |

0 KO, 0 crashes, no new compiler warnings anywhere. The behaviour table above also reproduces under `mruby -d`, where `no_peephole()` is on and neither the fold nor the guard runs.

The one block is in `test/t/codegen.rb`. It pins the value of the assignment, a chain, `||=`, a block nested in a block, a block reached through `yield`, the register holding a neighbouring name's value rather than nil, and the statement form whose store still lands.

## Environment

<details>
<summary>Host</summary>

| | |
|---|---|
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-30-generic x86_64 |
| CPU | AMD Ryzen 9 5950X (16C/32T) |
| Memory | 64 GiB |
| C compiler | gcc 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1) |
| binutils | GNU Binutils 2.47.20260726 |
| CRuby | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |
| rake | 13.3.1 |
| valgrind | 3.27.1 |

</details>

<details>
<summary>Compile lines, one per build</summary>

`mrbgems/mruby-compiler/src/codegen.c` as each build actually compiles it, with `-MMD -c`, `-I` and `-o` dropped. `cxx_abi` is `gcc -x c++`, not `g++`; `g++` only links there. `enable_debug()` puts `-g3 -O0` after the toolchain's `-g -O3`, so `full-debug` is the one build at `-O0`.

```console
# full-debug
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DMRC_DEBUG -DMRC_DUMP_PRETTY -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-compiler/src/codegen.c

# bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK mrbgems/mruby-compiler/src/codegen.c

# cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-compiler/src/codegen.c

# byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-compiler/src/codegen.c

# ascii-ctype
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-compiler/src/codegen.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed assignments to captured local variables so expressions return the correct assigned value.
  * Preserved expected behavior for chained, conditional, nested-block, and yielded-block assignments.
  * Ensured statement-only assignments continue to update captured variables correctly.

* **Tests**
  * Added regression coverage for captured-local assignment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->