### PR TITLE
fp_uscale.c: measure the shortest round trip against `mrb_float`

### DIFF
--- a/src/fp_uscale.c
+++ b/src/fp_uscale.c
@@ -861,6 +861,48 @@ static void unpack64(double f, uint64_t *m, int *e)
   }
 }
 
+/*
+ * unpack_flo splits an mrb_float the same way, against the significand the
+ * build actually carries: 53 bits for a double, 24 for MRB_USE_FLOAT32.
+ * FLO_SHIFT is what that significand leaves over in the normalised 64-bit
+ * word, and FLO_MIN_EXP the exponent of the smallest subnormal in it.
+ */
+#ifdef MRB_USE_FLOAT32
+#define FLO_SHIFT 40
+#define FLO_MIN_EXP (-(149 + FLO_SHIFT))
+
+static void unpack32(float f, uint64_t *m, int *e)
+{
+  union { float f; uint32_t u; } u;
+  uint32_t bits;
+  int exp;
+
+  u.f = f;
+  bits = u.u;
+
+  *m = (1ULL << 63) | ((uint64_t)(bits & ((1UL << 23) - 1)) << FLO_SHIFT);
+  exp = (int)((bits >> 23) & 0xff);
+
+  if (exp == 0) {
+    int s;
+    *m &= ~(1ULL << 63);
+    *e = FLO_MIN_EXP;
+    s = clz64(*m);
+    *m <<= s;
+    *e -= s;
+  }
+  else {
+    *e = (exp - 1) + FLO_MIN_EXP;
+  }
+}
+
+#define unpack_flo(f, m, e) unpack32((float)(f), (m), (e))
+#else
+#define FLO_SHIFT 11
+#define FLO_MIN_EXP (-(1074 + FLO_SHIFT))
+#define unpack_flo(f, m, e) unpack64((double)(f), (m), (e))
+#endif
+
 static double pack64(uint64_t m, int e)
 {
   union { double d; uint64_t u; } u;
@@ -984,16 +1026,16 @@ static void trim_zeros(uint64_t *x, int *p)
  * shortest computes the shortest formatting of f
  * Returns d and p such that d * 10^p equals f when parsed
  */
-static void shortest(double f, uint64_t *d, int *p)
+static void shortest(mrb_float f, uint64_t *d, int *p)
 {
-  const int min_exp = -1085;
+  const int min_exp = FLO_MIN_EXP;
   uint64_t m, min, max;
   int e, z, odd, lp;
   scaler pre;
   uint64_t dmin, dmax;
 
-  unpack64(f, &m, &e);
-  z = 11;
+  unpack_flo(f, &m, &e);
+  z = FLO_SHIFT;
 
   if (m == (1ULL << 63) && e > min_exp) {
     *p = -skewed(e + z);
@@ -1001,7 +1043,7 @@ static void shortest(double f, uint64_t *d, int *p)
   }
   else {
     if (e < min_exp) {
-      z = 11 + (min_exp - e);
+      z = FLO_SHIFT + (min_exp - e);
     }
     *p = -log10_pow2(e + z);
     min = m - (1ULL << (z - 1));
@@ -1209,7 +1251,7 @@ mrb_format_float(mrb_float f, char *buf, size_t buf_size, char fmt, int prec, ch
     if (fmt == 'S') {
       /* shortest representation for to_s */
       int i;
-      shortest((double)f, &d, &p);
+      shortest(f, &d, &p);
       nd = count_digits(d);
       exp = p + nd - 1;
       format_base10(digs, nd, d);


### PR DESCRIPTION
## Summary

`shortest()` asks which decimal digits read back as the value it was handed, and it asks that question of a `double` whatever the build's `mrb_float` is. On an `MRB_USE_FLOAT32` build the answer is measured against 29 bits of significand the value does not carry, so `Float#to_s` printed `0.0125` as `0.012500000186264515`.

## Changes

| File | What |
|---|---|
| `src/fp_uscale.c` | `unpack32()` added, `FLO_SHIFT` / `FLO_MIN_EXP` / `unpack_flo()` added, `shortest()` takes `mrb_float` and measures at that width |

### The round trip was measured against a width the value does not carry

`flo_to_s()` reaches `mrb_float_to_str()`, which asks for shortest mode with `prec == -2`, and `mrb_format_float()` turns that into the `'S'` arm and calls `shortest((double)f, &d, &p)`.

`shortest()` unpacked its argument with `unpack64()` and derived the neighbourhood the printed decimal has to stay inside from `z = 11`, the bits a 53-bit significand leaves over in the normalised 64-bit word. Widening a `float` to `double` zeroes the low 29 bits of that significand but says nothing about where the value came from, so the shortest decimal that reads back as **that** `double` runs to 16 or 17 digits. Measured against the 24 bits the value actually carries, the answer is `0.0125`, and `"0.0125".to_f == 0.0125` is already true on the same build: the short form does read back.

The value now goes in as an `mrb_float` and is unpacked at the width the build carries. `FLO_SHIFT` is what the significand leaves over in the 64-bit word and `FLO_MIN_EXP` the exponent of the smallest subnormal in that encoding: 11 and `-1085` for a `double`, 40 and `-189` for a `float`. `unpack32()` is the `float` half of the existing `unpack64()`, and `unpack_flo()` selects one of the two, so a build without `MRB_USE_FLOAT32` compiles neither the new function nor a second copy of the old one.

The `MRB_USE_FLOAT32` arms already in `mrb_format_float()` shape the frame around the digits, the minimum buffer and the exponent at which the `e` form takes over, and are untouched.

### Fixed precision keeps asking about the `double`

`fixed_width()` still takes a `double`, because `%.10f` and its neighbours print the value that is there rather than the shortest decimal standing for it, and the exact expansion of a widened `float` is that value. Only `prec == -2` enters shortest mode, so no fixed precision output moves.

`mrb_vformat()`'s `%f` builds a Float value and falls into the `to_s` path, so it follows `Float#to_s` here: `vf.f('`f`: %f', 0.0125)` gave `` `f`: 0.012500000186264515 `` and now gives `` `f`: 0.0125 ``.

## Behaviour

`Float#to_s` on an `MRB_USE_FLOAT32` build. The last column is the shortest decimal that reads back as the same `float`, from numpy 2.5.2; the digits are what CRuby prints for these literals as well, and the `.0` and `e+NN` spellings are mruby's own.

| expression | master | this PR | shortest `float` |
|---|---|---|---|
| `0.0125` | `0.012500000186264515` | `0.0125` | `0.0125` |
| `-0.0125` | `-0.012500000186264515` | `-0.0125` | `-0.0125` |
| `0.0000000001` | `1.000000013351432e-10` | `1.0e-10` | `1e-10` |
| `1e20` | `1.0000000200408773e+20` | `1.0e+20` | `1e+20` |
| `3.14` | `3.140000104904175` | `3.14` | `3.14` |
| `0.1` | `0.10000000149011612` | `0.1` | `0.1` |
| `100000.0` | `100000.0` | `100000.0` | `100000.0` |
| `1.4e-45` | `1.401298464324817e-45` | `1.0e-45` | `1e-45` |
| `3.4028235e38` | `3.4028234663852886e+38` | `3.4028235e+38` | `3.4028235e+38` |
| `1.1754944e-38` | `1.1754943508222875e-38` | `1.1754944e-38` | `1.1754944e-38` |

Beyond the table, 4,215 values were put through `to_s` on the built `bin/mruby`: 4,000 random 32-bit patterns, every subnormal from the smallest up, the normal and subnormal boundaries, and the literals above. Every one reads back as the same `float`, none has a shorter decimal that also reads back, and where more than one decimal of that length reads back, the one printed is the nearest to the value. A build without `MRB_USE_FLOAT32` prints exactly what it printed before, which the Size section pins.

## Size

`bin/mruby` `.text`, `size -A`, each build made from an empty build directory at the same path:

| Build | master | this PR | delta |
|---|---|---|---|
| `full-debug` (-O0) | 1,911,686 | 1,911,686 | 0 |
| `bintest` | 1,306,214 | 1,306,214 | 0 |
| `cxx_abi` | 1,333,145 | 1,333,145 | 0 |
| `byte-string` | 1,270,598 | 1,270,598 | 0 |
| `ascii-ctype` | 1,292,822 | 1,292,822 | 0 |

Zero everywhere because the object a build without `MRB_USE_FLOAT32` compiles is byte identical to the one before this change: what the preprocessor leaves is the same code with the same two constants spelled as macros.

The build the change is for is not in `ci/gcc-clang.rb`. Adding `MRB_USE_FLOAT32` to its `bintest` build gives `bin/mruby` `.text` 1,304,005 -> 1,303,957, all of it in `src/fp_uscale.o` (17,077 -> 17,029): `unpack32()` reads a 32-bit word where `unpack64()` read a 64-bit one, and `shortest()` no longer widens.

## Testing

`build_config/ci/gcc-clang.rb`, all five builds plus the bintests, built from an empty build directory:

| Commit | full-debug | bintest | bintest (bin) | cxx_abi | byte-string | ascii-ctype |
|---|---|---|---|---|---|---|
| master (`163c4f112`) | 2563 OK | 2555 OK | 144 OK | 2555 OK | 2433 OK | 2544 OK |
| measure the shortest round trip against `mrb_float` | 2563 OK | 2555 OK | 144 OK | 2555 OK | 2433 OK | 2544 OK |

0 KO, 0 crashes, no new compiler warnings. Identical on both sides, as the Size section says it must be.

The suite already covers this, in `test/t/float.rb` next to `Float#to_s` and in `test/t/vformat.rb` next to `%f`, and both were KO on an `MRB_USE_FLOAT32` build:

| Build | master | this PR |
|---|---|---|
| `build_config/host-f32.rb` | 2559 OK, 3 KO, 1 crash | 2561 OK, 1 KO, 1 crash |
| `build_config/host-m32-f32.rb` | 2558 OK, 3 KO, 1 crash | 2560 OK, 1 KO, 1 crash |

The two KO that go away are `Float#to_s` and `mrb_vformat`. The KO and the crash that stay are on master too and are not in this path: `mruby-sprintf` rejecting an oversized float precision, and `mruby-bigint` reading `1e20.to_i` as `100000000000000000000` where a `float` holds `100000002004087734272`.

`rake test` also passes with `MRB_USE_FLOAT32` under `MRB_NO_BOXING` and `MRB_WORD_BOXING`, with the same one KO and one crash; `MRB_NAN_BOXING` and `MRB_USE_FLOAT32` refuse to be combined in `boxing_nan.h`.

## Environment

<details>
<summary>Host</summary>

| | |
|---|---|
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-30-generic x86_64 |
| CPU | AMD Ryzen 9 5950X (16C/32T) |
| Memory | 64 GiB |
| C compiler | gcc 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1) |
| 32-bit C compiler | i686-linux-gnu-gcc 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1) |
| binutils | GNU Binutils 2.47.20260726 |
| CRuby | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |
| rake | 13.3.1 |
| numpy | 2.5.2 |

`build_config/host-m32-f32.rb` was compiled with `i686-linux-gnu-gcc` in place of `gcc -m32` and without `enable_bintest`, because this host has no multilib. The two `MRB_USE_FLOAT32` builds print the same digits for all 4,215 values, so nothing here depends on the word size.

</details>

<details>
<summary>Compile lines, one per build</summary>

`src/fp_uscale.c` as each build actually compiles it, with `-MMD -c`, `-I` and `-o` dropped. `cxx_abi` is `gcc -x c++`, not `g++`; `g++` only links there. `enable_debug()` puts `-g3 -O0` after the toolchain's `-g -O3`, so `full-debug` is the one build at `-O0`.

```console
# full-debug
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/fp_uscale.c

# bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK src/fp_uscale.c

# cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/fp_uscale.c

# byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/fp_uscale.c

# ascii-ctype
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/fp_uscale.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved floating-point formatting and parsing when 32-bit floating-point mode is enabled.
  * Ensured shortest-value conversion uses the appropriate precision for the configured floating-point type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->