### PR TITLE
test: state the sprintf and bigint float expectations for the build's own width

### DIFF
--- a/mrbgems/mruby-bigint/test/bigint.rb
+++ b/mrbgems/mruby-bigint/test/bigint.rb
@@ -448,17 +448,31 @@ assert('Integer - a Float too big for an mrb_int keeps every digit') do
   # The conversion took the highest base-2**DIG_SIZE digit and read zero for
   # every digit below it, because the fraction left behind was never scaled
   # back up: 1e20 answered 92233720368547758080, which is 5 * 2**64.
-  assert_equal 100000000000000000000, 1e20.to_i
-  assert_equal(-100000000000000000000, -1e20.to_i)
-  assert_equal 10000000000000000000, 1e19.to_i
-  assert_equal 150000000000000000000, 1.5e20.to_i
-  assert_equal 1000000000000000019884624838656, 1e30.to_i
-  assert_equal 30000000000000000570425344, 3.0e25.to_i
+  if 1e39.infinite? then
+    # MRB_USE_FLOAT32 in effect: every one of these literals rounds to a Float
+    # of its own, and the widest entry has to stay under the 3.4e38 a Float
+    # tops out at, 1e100 being Infinity there.
+    assert_equal 100000002004087734272, 1e20.to_i
+    assert_equal(-100000002004087734272, -1e20.to_i)
+    assert_equal 9999999980506447872, 1e19.to_i
+    assert_equal 150000003006131601408, 1.5e20.to_i
+    assert_equal 1000000015047466219876688855040, 1e30.to_i
+    assert_equal 29999999838992083349143552, 3.0e25.to_i
+    widest = 1e38
+  else
+    assert_equal 100000000000000000000, 1e20.to_i
+    assert_equal(-100000000000000000000, -1e20.to_i)
+    assert_equal 10000000000000000000, 1e19.to_i
+    assert_equal 150000000000000000000, 1.5e20.to_i
+    assert_equal 1000000000000000019884624838656, 1e30.to_i
+    assert_equal 30000000000000000570425344, 3.0e25.to_i
+    widest = 1e100
+  end
   # A power of two answered correctly all along, its lower digits being zero.
   assert_equal 18446744073709551616, (2.0**64).to_i
   assert_equal 1180591620717411303424, (2.0**70).to_i
   # Every one of them names the Float it came from.
-  [1e19, 1e20, 1.5e20, 1e30, 3.0e25, 1e100, 2.0**70].each do |f|
+  [1e19, 1e20, 1.5e20, 1e30, 3.0e25, widest, 2.0**70].each do |f|
     assert_equal f, f.to_i.to_f
   end
 end

--- a/mrbgems/mruby-sprintf/test/sprintf.rb
+++ b/mrbgems/mruby-sprintf/test/sprintf.rb
@@ -112,7 +112,13 @@ assert("sprintf rejects an oversized float precision/width") do
   assert_raise(ArgumentError) { sprintf("%.2147483647f", 1.0) }
   # ordinary precision/width still work
   assert_equal "1.31072e+05", sprintf("%.5e", 131072.0)
-  assert_equal "3.1400000000", sprintf("%.10f", 3.14)
+  if 1e39.infinite? then
+    # MRB_USE_FLOAT32 in effect: the nearest Float to 3.14 is
+    # 3.1400001049041748046875, and ten fixed digits of it are its own.
+    assert_equal "3.1400001049", sprintf("%.10f", 3.14)
+  else
+    assert_equal "3.1400000000", sprintf("%.10f", 3.14)
+  end
 end
 
 assert("sprintf with to_s mutating format string") do


### PR DESCRIPTION
## Summary

`sprintf`'s fixed-precision case and `mruby-bigint`'s Float to Integer case both state their expected digits as a `double` writes them. An `MRB_USE_FLOAT32` build gets the right answer out of both and fails anyway: one assertion reports a formatter that was correct, and the other walks a literal that is `Infinity` at that width and raises out of its assert block, which is counted as a crash rather than a failure. Together they are 1 KO and the 1 Crash such a build ends its suite with.

Nothing outside `test/` changes.

## Changes

| File | What |
|---|---|
| `mrbgems/mruby-sprintf/test/sprintf.rb` | the ten fixed digits of 3.14, stated for each Float width |
| `mrbgems/mruby-bigint/test/bigint.rb` | the digits of six Floats too large for an `mrb_int`, stated for each width, and a round-trip entry the narrower width can hold |

Both blocks tell the widths apart the way `test/t/float.rb` and `mruby-complex`'s tests already do, by asking a literal past the top of a `float` whether it is infinite.

### `sprintf("%.10f", 3.14)` prints the digits the value has

3.14 is not a binary fraction, so ten fixed digits of it are whatever the stored value rounds to. As a `double` that is `3.1400000000`; the nearest `float` is 3.1400001049041748046875, and the build prints `3.1400001049`. The line is the last of a block about refusing an oversized precision or width, and it is there to show that an ordinary precision still works, which it did.

### `1e100` is not a Float at every width

The bigint block asserts the exact digits of `1e19`, `1e20`, `1.5e20`, `1e30` and `3.0e25`, then walks those five plus `1e100` and `2.0**70` and asks each to come back through `to_i`. As a `float` each of the five is a different number, `1e20` being 100000002004087734272, so six assertions reported a conversion that had kept every digit it was given.

`1e100` is not merely a different number there: it is `Infinity` where a Float tops out near 3.4e38, `Infinity.to_i` raises `FloatDomainError`, and the raise leaves the assert block, which is why the whole test counts as a crash. The round trip walks `1e38` at that width instead, a Float with digits below its top one. The two powers of two are exact at both widths and stay shared.

Every expected value is the one CRuby names for the `float` the literal rounds to:

```ruby
[1e19, 1e20, 1.5e20, 1e30, 3.0e25, 1e38].map { |f| [f].pack("f").unpack1("f").to_i }
sprintf("%.10f", [3.14].pack("f").unpack1("f"))
```

## Size

`bin/mruby` `.text`, `size -A`, in the five `build_config/ci/gcc-clang.rb` builds, each side built from an empty build directory at the same path:

| Build | master | this PR | delta |
|---|---|---|---|
| `full-debug` | 1,913,478 | 1,913,478 | 0 |
| `bintest` | 1,307,110 | 1,307,110 | 0 |
| `cxx_abi` | 1,334,041 | 1,334,041 | 0 |
| `byte-string` | 1,271,494 | 1,271,494 | 0 |
| `ascii-ctype` | 1,293,718 | 1,293,718 | 0 |

## Testing

`rake -m test` at each Float width:

| Build | master (`7c0c643eb`) | this PR |
|---|---|---|
| `host-f32` | 2563 OK, 3 KO, 1 Crash | 2565 OK, 2 KO, 0 Crash |
| `host-m32-f32`, built with `i686-linux-gnu-gcc` | 2562 OK, 3 KO, 1 Crash | 2564 OK, 2 KO, 0 Crash |
| `MRB_USE_FLOAT32` with `MRB_WORD_BOXING` | 2555 OK, 3 KO, 1 Crash | 2557 OK, 2 KO, 0 Crash |
| `host-nofloat` | 1890 OK, 0 KO, 0 Crash | 1890 OK, 0 KO, 0 Crash |

The 32-bit build wants `i686-linux-gnu-gcc` because this host has no multilib for `-m32`. It differs from the 64-bit one by a single skip, `Addrinfo.getaddrinfo rejects out-of-range integer hints`, which wants a 64-bit `mrb_int`. Under `host-nofloat` both blocks skip on `Object.const_defined?(:Float)` before they ask anything, and the count is unmoved. `MRB_NAN_BOXING` with `MRB_USE_FLOAT32` is refused by `include/mruby/boxing_nan.h`, so that pair is not a build to run.

The 2 KO left in every `MRB_USE_FLOAT32` build are `Float#to_s` and `mrb_vformat`, where the shortest-mode formatter spells a `float` with the digit count a `double` needs and `0.0125` comes out as `0.012500000186264515`. That one is the formatter's, not a test's, and this PR leaves it alone.

`build_config/ci/gcc-clang.rb`, all five builds plus the bintests, built from an empty build directory:

| Commit | full-debug | bintest | bintest (bin) | cxx_abi | byte-string | ascii-ctype |
|---|---|---|---|---|---|---|
| master (`7c0c643eb`) | 2567 OK | 2559 OK | 144 OK | 2559 OK | 2437 OK | 2548 OK |
| this PR | 2567 OK | 2559 OK | 144 OK | 2559 OK | 2437 OK | 2548 OK |

0 KO, 0 crashes, no new compiler warnings anywhere.

## Environment

<details>
<summary>Host</summary>

| | |
|---|---|
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-30-generic x86_64 |
| CPU | AMD Ryzen 9 5950X (16C/32T) |
| Memory | 64 GiB |
| C compiler | gcc 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1) |
| 32-bit C compiler | i686-linux-gnu-gcc 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1) |
| binutils | GNU Binutils 2.47.20260726 |
| CRuby | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |
| rake | 13.3.1 |

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated numeric conversion tests to account for differences between 32-bit and full-width floating-point builds.
  * Updated formatting tests to validate the expected precision of floating-point output across supported build configurations.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->