### PR TITLE
version.c: name the target platform as `MRUBY_PLATFORM`

### DIFF
--- a/doc/guides/mrbconf.md
+++ b/doc/guides/mrbconf.md
@@ -343,6 +343,30 @@ conf.defines << 'MRUBY_REVISION=\"0123456789\"'
 conf.defines << 'MRUBY_FULL_REVISION=\"0123456789abcdef0123456789abcdef01234567\"'
 ```
 
+## Platform name
+
+`MRUBY_PLATFORM`
+
+- The name of the platform the built binary runs on, in the `cpu-os` form
+  CRuby's `RUBY_PLATFORM` uses: `x86_64-linux`, `arm64-darwin`,
+  `x64-mingw-ucrt`. It is what the `MRUBY_PLATFORM` global constant carries.
+- The default is read from the compiler's own predefined macros, so a cross
+  build names its target rather than the machine that ran the build. A target
+  the detection does not know reports `unknown` for the CPU half; one with no
+  operating system under it (bare metal, or an RTOS the compiler does not
+  announce) reports `none`, as a triple would (`arm-none`, `xtensa-none`).
+- Define this to name the platform outright. The value is a C string literal,
+  so its quotes have to reach the compiler:
+
+```ruby
+conf.defines << 'MRUBY_PLATFORM=\"esp32-freertos\"'
+```
+
+`MRUBY_PLATFORM_CPU`, `MRUBY_PLATFORM_OS`
+
+- The two halves `MRUBY_PLATFORM` is built from. Define either one, the same
+  way, to correct one half and leave the other to the detection.
+
 ## Tuning profiles
 
 Predefined profiles adjust several macros together for specific

--- a/include/mruby/platform.h
+++ b/include/mruby/platform.h
@@ -1,0 +1,173 @@
+/**
+** @file mruby/platform.h - target platform identification
+**
+** See Copyright Notice in mruby.h
+*/
+
+#ifndef MRUBY_PLATFORM_H
+#define MRUBY_PLATFORM_H
+
+#include "common.h"
+
+/**
+ * Target platform definition macros
+ *
+ * `MRUBY_PLATFORM` names the machine the built binary runs on, in the
+ * `cpu-os` form CRuby's `RUBY_PLATFORM` uses: `"x86_64-linux"`,
+ * `"arm64-darwin"`, `"x64-mingw-ucrt"`.  It is what the `MRUBY_PLATFORM`
+ * global constant carries.
+ *
+ * The name is spelled the way the platform itself spells it rather than the
+ * way any one canonical-triple scheme would: the same 64-bit ARM core is
+ * `arm64` on darwin and under MSVC but `aarch64` elsewhere, and the same
+ * x86_64 is `x64` on Windows.  Code that reads this constant matches it
+ * against a pattern (`/mingw|mswin/`, `/darwin/`), so agreeing with the
+ * spelling in use beats being internally consistent.
+ *
+ * Everything here is decided by the compiler's own predefined macros, since
+ * mruby is cross compiled far more often than not and the machine running
+ * the build says nothing about the machine the result runs on.  A target the
+ * detection below does not know reports `"unknown"` for that half; a target
+ * with no operating system under it (bare metal, or an RTOS the compiler
+ * does not announce) reports `"none"`, as a triple would.
+ *
+ * Three overrides, in the order they are consulted: define `MRUBY_PLATFORM`
+ * to name the platform outright, or define `MRUBY_PLATFORM_CPU` and/or
+ * `MRUBY_PLATFORM_OS` to correct one half and let the other be detected.
+ * A build that wants a name of its own (`"esp32-freertos"`) takes the first.
+ */
+MRB_BEGIN_DECL
+
+/*
+ * The operating system half of `MRUBY_PLATFORM`.
+ *
+ * The WebAssembly hosts and Android come before the systems whose macros
+ * they also define: `__EMSCRIPTEN__` and `__wasi__` sit on a Unix-ish
+ * environment, and Android is a Linux.  The more specific name is the one
+ * worth reporting, so it is tested first.
+ */
+#ifndef MRUBY_PLATFORM_OS
+# if defined(__EMSCRIPTEN__)
+#  define MRUBY_PLATFORM_OS "emscripten"
+# elif defined(__wasi__)
+#  define MRUBY_PLATFORM_OS "wasi"
+# elif defined(__ANDROID__)
+#  define MRUBY_PLATFORM_OS "linux-android"
+# elif defined(__linux__)
+#  define MRUBY_PLATFORM_OS "linux"
+# elif defined(__APPLE__)
+#  define MRUBY_PLATFORM_OS "darwin"
+# elif defined(__FreeBSD__)
+#  define MRUBY_PLATFORM_OS "freebsd"
+# elif defined(__NetBSD__)
+#  define MRUBY_PLATFORM_OS "netbsd"
+# elif defined(__OpenBSD__)
+#  define MRUBY_PLATFORM_OS "openbsd"
+# elif defined(__DragonFly__)
+#  define MRUBY_PLATFORM_OS "dragonfly"
+# elif defined(__sun)
+#  define MRUBY_PLATFORM_OS "solaris"
+# elif defined(__HAIKU__)
+#  define MRUBY_PLATFORM_OS "haiku"
+# elif defined(__CYGWIN__)
+#  define MRUBY_PLATFORM_OS "cygwin"
+# elif defined(__MINGW32__)
+   /* mingw-w64 defines `__MINGW32__` on both widths; `_UCRT` is what tells
+      the UCRT toolchain from the msvcrt one, the way CRuby's `mingw-ucrt`
+      and `mingw32` names do. */
+#  if defined(_UCRT)
+#   define MRUBY_PLATFORM_OS "mingw-ucrt"
+#  else
+#   define MRUBY_PLATFORM_OS "mingw32"
+#  endif
+# elif defined(_WIN32)
+   /* CRuby spells the MSVC runtime version into the name (`mswin64_140`).
+      That version is a property of the runtime the binary links against,
+      not of the compiler, so it is left out rather than guessed from
+      `_MSC_VER`. */
+#  if defined(_WIN64)
+#   define MRUBY_PLATFORM_OS "mswin64"
+#  else
+#   define MRUBY_PLATFORM_OS "mswin32"
+#  endif
+# elif defined(__unix__) || defined(__unix)
+#  define MRUBY_PLATFORM_OS "unix"
+# else
+#  define MRUBY_PLATFORM_OS "none"
+# endif
+#endif
+
+/*
+ * The CPU half of `MRUBY_PLATFORM`.
+ *
+ * Windows and darwin spell the two widest architectures their own way, so
+ * the spelling is chosen per system rather than per architecture.
+ */
+#ifndef MRUBY_PLATFORM_CPU
+# if defined(__wasm64__)
+#  define MRUBY_PLATFORM_CPU "wasm64"
+# elif defined(__wasm32__) || defined(__wasm__)
+#  define MRUBY_PLATFORM_CPU "wasm32"
+# elif defined(__x86_64__) || defined(__amd64__) || defined(_M_X64) || defined(_M_AMD64)
+#  if defined(_WIN32)
+#   define MRUBY_PLATFORM_CPU "x64"
+#  else
+#   define MRUBY_PLATFORM_CPU "x86_64"
+#  endif
+# elif defined(__i386__) || defined(_M_IX86)
+#  define MRUBY_PLATFORM_CPU "i386"
+# elif defined(__aarch64__) || defined(_M_ARM64)
+   /* Windows spells 64-bit ARM `arm64` only in the MSVC toolchain, which is
+      where CRuby's name for it comes from; the mingw one keeps `aarch64`
+      (`aarch64-mingw-ucrt`) even though the same width of x86 is `x64` on
+      both.  `_MSC_VER` is what tells the two apart. */
+#  if defined(__APPLE__) || defined(_MSC_VER)
+#   define MRUBY_PLATFORM_CPU "arm64"
+#  else
+#   define MRUBY_PLATFORM_CPU "aarch64"
+#  endif
+# elif defined(__arm__) || defined(_M_ARM)
+#  define MRUBY_PLATFORM_CPU "arm"
+# elif defined(__riscv)
+#  if __riscv_xlen == 64
+#   define MRUBY_PLATFORM_CPU "riscv64"
+#  else
+#   define MRUBY_PLATFORM_CPU "riscv32"
+#  endif
+# elif defined(__powerpc64__) || defined(__ppc64__)
+#  if defined(__LITTLE_ENDIAN__) || (defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
+#   define MRUBY_PLATFORM_CPU "powerpc64le"
+#  else
+#   define MRUBY_PLATFORM_CPU "powerpc64"
+#  endif
+# elif defined(__powerpc__) || defined(__ppc__)
+#  define MRUBY_PLATFORM_CPU "powerpc"
+# elif defined(__mips64) || defined(__mips64__)
+#  define MRUBY_PLATFORM_CPU "mips64"
+# elif defined(__mips__) || defined(__mips)
+#  define MRUBY_PLATFORM_CPU "mips"
+# elif defined(__s390x__)
+#  define MRUBY_PLATFORM_CPU "s390x"
+# elif defined(__sparc64__) || defined(__sparcv9) || defined(__sparc_v9__)
+#  define MRUBY_PLATFORM_CPU "sparc64"
+# elif defined(__sparc__) || defined(__sparc)
+#  define MRUBY_PLATFORM_CPU "sparc"
+# elif defined(__XTENSA__)
+#  define MRUBY_PLATFORM_CPU "xtensa"
+# elif defined(__AVR__)
+#  define MRUBY_PLATFORM_CPU "avr"
+# else
+#  define MRUBY_PLATFORM_CPU "unknown"
+# endif
+#endif
+
+/*
+ * The platform mruby was built for.
+ */
+#ifndef MRUBY_PLATFORM
+#define MRUBY_PLATFORM MRUBY_PLATFORM_CPU "-" MRUBY_PLATFORM_OS
+#endif
+
+MRB_END_DECL
+
+#endif  /* MRUBY_PLATFORM_H */

--- a/include/mruby/version.h
+++ b/include/mruby/version.h
@@ -8,6 +8,7 @@
 #define MRUBY_VERSION_H
 
 #include "common.h"
+#include "platform.h"
 
 /**
  * mruby version definition macros

--- a/src/version.c
+++ b/src/version.c
@@ -29,6 +29,7 @@ mrb_init_version(mrb_state* mrb)
   mrb_define_global_const(mrb, "RUBY_ENGINE", mrb_str_new_lit(mrb, MRUBY_RUBY_ENGINE));
   mrb_define_global_const(mrb, "RUBY_ENGINE_VERSION", mruby_version);
   mrb_define_global_const(mrb, "MRUBY_VERSION", mruby_version);
+  mrb_define_global_const(mrb, "MRUBY_PLATFORM", mrb_str_new_lit_frozen(mrb, MRUBY_PLATFORM));
   mrb_define_global_const(mrb, "MRUBY_RELEASE_NO", mrb_fixnum_value(MRUBY_RELEASE_NO));
   mrb_define_global_const(mrb, "MRUBY_RELEASE_DATE", mrb_str_new_lit(mrb, MRUBY_RELEASE_DATE));
   mrb_define_global_const(mrb, "MRUBY_REVISION", mrb_str_new_lit_frozen(mrb, MRUBY_FULL_REVISION));

--- a/test/t/platform.rb
+++ b/test/t/platform.rb
@@ -1,0 +1,17 @@
+##
+# MRUBY_PLATFORM Test
+
+assert('MRUBY_PLATFORM') do
+  assert_kind_of String, MRUBY_PLATFORM
+  assert_predicate MRUBY_PLATFORM, :frozen?
+end
+
+assert('MRUBY_PLATFORM is a cpu-os pair') do
+  # The constant is read by matching a pattern against it, so what it has to
+  # promise is the shape: a non-empty cpu name, a separator, a non-empty rest.
+  sep = MRUBY_PLATFORM.index('-')
+  assert_not_nil sep, "MRUBY_PLATFORM #{MRUBY_PLATFORM.inspect} has no separator"
+  assert_operator sep, :>, 0
+  assert_operator sep, :<, MRUBY_PLATFORM.size - 1
+  assert_not_include MRUBY_PLATFORM, ' '
+end


### PR DESCRIPTION
## Summary

mruby says what version it is (`MRUBY_VERSION`) and what engine it is (`RUBY_ENGINE`), but never what machine it runs on. Code that has to tell one target from another, in a script or in the Ruby half of a gem, has nothing to read.

This adds a `MRUBY_PLATFORM` global constant naming the target in the `cpu-os` form CRuby's `RUBY_PLATFORM` uses, and the `include/mruby/platform.h` that decides it.

```console
$ ./build/host/bin/mruby -e 'p MRUBY_PLATFORM, MRUBY_PLATFORM.frozen?'
"x86_64-linux"
true
```

## Changes

| File | What |
|---|---|
| `include/mruby/platform.h` | new. `MRUBY_PLATFORM_CPU` and `MRUBY_PLATFORM_OS` decided from the compiler's own predefined macros, and `MRUBY_PLATFORM` as the two joined by `-`. All three are overridable |
| `include/mruby/version.h` | includes it, so anything reading the version macros reads this one too |
| `src/version.c` | registers `MRUBY_PLATFORM` as a frozen `String`, beside the constants already there |
| `test/t/platform.rb` | new. Asserts the shape the constant is read through |
| `doc/guides/mrbconf.md` | documents the three defines |

### What decides the name

The compiler's own predefined macros, rather than anything the build script knows: mruby is cross compiled far more often than not, and the machine running the build says nothing about the machine the result runs on. `build_config/` never has to be told the answer, and a cross build names its target on its own.

A target with no operating system under it, bare metal or an RTOS the compiler does not announce, reports `none`, as a triple would (`arm-none`, `xtensa-none`). A target the detection does not know reports `unknown` for that half.

### Spelling

The name follows what each platform calls itself rather than one canonical-triple scheme, which is what CRuby does: the same 64-bit ARM core is `arm64` on darwin and under MSVC but `aarch64` everywhere else, mingw included (`aarch64-mingw-ucrt`), while the same x86_64 is `x64` under both Windows toolchains. Such a constant is read by matching a pattern against it (`/mingw|mswin/`, `/darwin/`), so agreeing with the spelling already in use beats being internally consistent.

Two things CRuby derives from configure are left out, because a compiler cannot answer them: the darwin release number (`arm64-darwin`, not `arm64-darwin24`) and the MSVC runtime version (`x64-mswin64`, not `x64-mswin64_140`). Both remain matchable by the patterns that read them.

### Overrides

`MRUBY_PLATFORM` names the platform outright; `MRUBY_PLATFORM_CPU` and `MRUBY_PLATFORM_OS` each correct one half and leave the other detected. The value is a C string literal, so the quotes have to reach the compiler:

```ruby
conf.defines << 'MRUBY_PLATFORM=\"esp32-freertos\"'
```

### `RUBY_PLATFORM` is deliberately not defined

mruby has neither `Gem::Platform` nor native extension loading to read one, so the name would promise a compatibility that has nothing behind it. A constant is easy to add later and breaking to take away.

## Behaviour

One new global constant. Nothing else changes: no existing constant, no method, and no `RUBY_PLATFORM`.

What the macros expand to, checked by running the preprocessor over `platform.h` with each target's macros forced (`cc -E -undef -nostdinc`):

| target | value |
| --- | --- |
| linux x86_64 / i386 | `x86_64-linux` / `i386-linux` |
| linux aarch64 / arm | `aarch64-linux` / `arm-linux` |
| android | `aarch64-linux-android` |
| macOS arm64 / x86_64 | `arm64-darwin` / `x86_64-darwin` |
| FreeBSD / NetBSD / OpenBSD / DragonFly | `x86_64-freebsd` / `x86_64-netbsd` / `x86_64-openbsd` / `x86_64-dragonfly` |
| mingw-w64 UCRT / msvcrt | `x64-mingw-ucrt` / `x64-mingw32` |
| mingw-w64 arm64 | `aarch64-mingw-ucrt` |
| MSVC x64 / x86 / arm64 | `x64-mswin64` / `i386-mswin32` / `arm64-mswin64` |
| cygwin | `x86_64-cygwin` |
| wasi / emscripten | `wasm32-wasi` / `wasm32-emscripten` |
| ppc64 LE / BE | `powerpc64le-linux` / `powerpc64-linux` |
| s390x / mips64 / riscv64 | `s390x-linux` / `mips64-linux` / `riscv64-linux` |
| solaris sparc64 / haiku | `sparc64-solaris` / `x86_64-haiku` |
| bare metal | `xtensa-none`, `arm-none`, `riscv64-none`, `avr-none` |
| nothing the detection knows | `unknown-none` |
| `MRUBY_PLATFORM_CPU="esp32"` on linux x86_64 | `esp32-linux` |
| `MRUBY_PLATFORM_OS="freertos"` on linux x86_64 | `x86_64-freertos` |

The Windows row is not only preprocessed: `build_config/cross-mingw-winetest.rb` answers `"x64-mingw32"` under wine, which is what that toolchain's msvcrt target should say.

## Speed

The cost is one `mrb_define_global_const()` at startup and nothing after it, so what there is to measure is `mrb_open()`. Instructions retired by `mruby -e ''` under callgrind, `build_config/default.rb`, `-g -O3`, gcc 13.3.0, three runs each, bit-identical across runs:

| | master | PR | delta |
|---|---:|---:|---:|
| `mruby -e ''` | 3,071,522 | 3,073,969 | +2,447 |

+0.08% of startup, paid once. No path after startup is touched.

## Size

`.text` and `.rodata` of `bin/mruby` for each `build_config/ci/gcc-clang.rb` build (`size -A`), both columns built from an empty directory at the same path:

| build | `.text` master | `.text` PR | delta | `.rodata` master | `.rodata` PR | delta |
|---|---:|---:|---:|---:|---:|---:|
| `full-debug` | 1,913,478 | 1,913,542 | +64 | 362,040 | 362,104 | +64 |
| `bintest` | 1,307,110 | 1,307,158 | +48 | 259,152 | 259,184 | +32 |
| `cxx_abi` | 1,334,041 | 1,334,089 | +48 | 259,120 | 259,152 | +32 |
| `byte-string` | 1,271,494 | 1,271,542 | +48 | 231,296 | 231,328 | +32 |
| `ascii-ctype` | 1,293,718 | 1,293,766 | +48 | 234,432 | 234,464 | +32 |

The `.text` growth is the one added call and the freeze around it; `.rodata` carries the two string literals, `"MRUBY_PLATFORM"` and the name itself. Both are flat across the builds, since neither half of what was added depends on how strings are indexed.

## Testing

`rake -m test` over the five builds of `build_config/ci/gcc-clang.rb`, no compiler warning in any build:

| build | total | OK | KO | crash | skip |
|---|---:|---:|---:|---:|---:|
| `full-debug` | 2,575 | 2,569 | 0 | 0 | 6 |
| `bintest` | 2,575 | 2,561 | 0 | 0 | 14 |
| `cxx_abi` | 2,575 | 2,561 | 0 | 0 | 14 |
| `byte-string` | 2,494 | 2,439 | 0 | 0 | 55 |
| `ascii-ctype` | 2,566 | 2,550 | 0 | 0 | 16 |

The `bintest` suite: 145 total, 144 OK, 0 KO, 1 skip. `build_config/default.rb` and `build_config/host-cxx.rb`: 2,336 total, 0 KO, 0 crash each.

`build_config/cross-mingw-winetest.rb` covers the one non-host target that can be run here: 2,558 total, 0 KO, 0 crash under wine, and its bintest 98 total, 0 KO. That is also where the `x64-mingw32` above comes from.

`test/t/platform.rb` asserts the contract the constant is read through: a frozen `String` holding a non-empty cpu name, a separator, and a non-empty rest, with no spaces. It stops short of asserting that neither half is `unknown` or `none`, which would make a legitimate port's first build fail a core test.

## Environment

<details>
<summary>details</summary>

| | |
| --- | --- |
| OS | Ubuntu, Linux 7.0.0-30-generic, x86_64 |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0 |
| C++ compiler | `cxx_abi` compiles the core sources as C++ with `gcc -x c++ -std=gnu++03`; g++ only links |
| mingw | x86_64-w64-mingw32-gcc (GCC) 13-win32 |
| wine | wine-11.0 |
| valgrind | valgrind-3.27.1 |

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added platform identification through CPU and operating system names.
  - Platform information is available in a consistent `cpu-os` format and supports cross-compilation targets.
  - Build configurations can override the detected platform, CPU, or operating system values.
  - Exposed the platform name as a frozen `MRUBY_PLATFORM` constant.

- **Documentation**
  - Added guidance explaining platform detection, naming, and customization.

- **Tests**
  - Added validation for platform format and immutable platform values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->