### PR TITLE
array.c: take an `Array` element for equal to itself in `#==`

### DIFF
--- a/src/array.c
+++ b/src/array.c
@@ -1970,8 +1970,14 @@ mrb_ary_eq(mrb_state *mrb, mrb_value ary1)
 
   int ai = mrb_gc_arena_save(mrb);
   for (mrb_int i=0; i<RARRAY_LEN(ary1); i++) {
-    mrb_value eq = mrb_funcall_argv1(mrb, mrb_ary_entry(ary1, i), MRB_OPSYM(eq), mrb_ary_entry(ary2, i));
-    if (!mrb_test(eq)) return mrb_false_value();
+    /* `OP_EQ` takes two values for equal where they are the same object and
+       dispatches `==` only after; `mrb_equal()` is that same test made from C,
+       and it is what `#index` and `#delete` search a pair with. Dispatching
+       `==` here went around it, so an element was equal to itself only where
+       its own `==` said so. CRuby compares elements here the same way. */
+    if (!mrb_equal(mrb, mrb_ary_entry(ary1, i), mrb_ary_entry(ary2, i))) {
+      return mrb_false_value();
+    }
     mrb_gc_arena_restore(mrb, ai);
   }
   return mrb_true_value();

--- a/test/t/array.rb
+++ b/test/t/array.rb
@@ -527,6 +527,26 @@ assert('Array#==', '15.2.12.5.33') do
   assert_false(["a", "c", 7] == ["a", "d", "f"])
 end
 
+assert('Array#== takes an element for equal to itself') do
+  # `a == b` is answered by `OP_EQ`, which takes two values for equal where
+  # they are the same object and dispatches `==` only after. Comparing the
+  # elements here with `==` went around that, so an object whose `==` answers
+  # false to everything was not equal to itself inside an array while it was
+  # outside one. `#index` searches with the first of the two.
+  class ArrayEqNever
+    def ==(other)
+      false
+    end
+  end
+  never = ArrayEqNever.new
+
+  # `never == never` reads true whatever the definition says, `OP_EQ` having
+  # answered it from the object; the definition is reached by name.
+  assert_false(never.__send__(:==, never))
+  assert_true([never] == [never])
+  assert_equal(0, [never].index(never))
+end
+
 assert('Array#eql?', '15.2.12.5.34') do
   a1 = [ 1, 2, 3 ]
   a2 = [ 1, 2, 3 ]


### PR DESCRIPTION
## Summary

`a == b` is answered by `OP_EQ`, which takes two values for equal where they are the same object and dispatches `==` only after. `mrb_equal()` is that same test made from C, and it is what `Array#index` and `#delete` search a pair with. `Array#==` dispatched `==` at each element instead, going around it, so an object was equal to itself outside an array and not inside one.

## Changes

| File | What |
| --- | --- |
| `src/array.c` | `mrb_ary_eq()` compares its elements with `mrb_equal()` rather than dispatching `==` at each one |
| `test/t/array.rb` | `Array#==` over an object whose `==` answers false to everything |

### The one comparison that asks nothing of the object

`mrb_equal()` looks for the object first and asks `==` after. Every other search an array makes reads a pair that way, and `OP_EQ` reads one that way before it dispatches anything; `mrb_ary_eq()` was the exception.

```ruby
class Never
  def ==(other); false; end
end
n = Never.new

n == n         # true, OP_EQ having answered it from the object
[n].index(n)   # 0
[n] == [n]     # before false, CRuby true
```

CRuby compares elements here the same way it compares them in `#index`, and so does this now. An element whose `==` answers as `==` should is found by `==` as before, one comparison earlier.

## Behaviour

`n` is an object whose `==` answers false to everything; `a` and `b` are two NaNs built at run time as `z / z` from `z = [0.0][0]`, so that nothing folds them into a single literal. Bold marks a row that differs from CRuby.

| expression | master | this PR | CRuby |
| --- | --- | --- | --- |
| `[n] == [n]` | false | true | true |
| `[1.0, a] == [1.0, a]` | false | true | true |
| `[1.0, a] == [1.0, b]` | false | **true** | false |
| `[a].index(b)` | **0** | **0** | nil |

The last two rows are one answer. A NaN is equal to no value, its own operand included, so `==` can never find one and only the object is left to go by; where a boxing keeps a Float in the value, every NaN is normalized to one representation, so two NaNs made apart are one object. `#index` has been saying so on master all along, and `#==` says it now too. Making a NaN an object of its own is a change to what a Float is rather than to how an array compares, and it is not in this PR.

## Speed

```ruby
x = (1..200).to_a
y = (1..200).to_a
i = 0
while i < 20000 do x == y; i += 1 end
```

Best of 11 interleaved runs against master, with a master-vs-master control to read the noise by, and the instruction counts callgrind reads beside them:

| benchmark | master | this PR | control | Ir |
| --- | --- | --- | --- | --- |
| `Array#==` over 200 elements, 20000 times | 85.6 ms | **11.0 ms (0.13x)** | +0.4% | 1,441,020,104 -> 180,820,104 |

`mrb_equal()` in place of a method dispatch at each of the 200 elements is what `#index` already paid for the same walk.

## Size

`bin/mruby` `.text` for every build in `build_config/ci/gcc-clang.rb`:

| build | master | this PR | delta |
| --- | --- | --- | --- |
| `ascii-ctype` | 1,293,718 | 1,293,638 | -80 |
| `bintest` | 1,307,110 | 1,307,030 | -80 |
| `byte-string` | 1,271,494 | 1,271,414 | -80 |
| `cxx_abi` | 1,334,041 | 1,333,993 | -48 |
| `full-debug` (-O0) | 1,913,478 | 1,913,462 | -16 |

The whole of it is `src/array.o`, which **shrinks** by 80 bytes: a call to `mrb_funcall_argv1()` with a symbol and an argument array goes away, and `mrb_equal()` takes its place.

## Testing

`rake test` passes for the default build, for `build_config/host-nofloat.rb`, for every build in `build_config/ci/gcc-clang.rb` including the C++ ABI one, and for a `MRB_NO_BOXING` build of the full-core gembox, with no compiler warnings beyond the one `-Wmaybe-uninitialized` about `eq` in `hash.c` that master already emits in a `MRB_NO_BOXING` build. The last of those is there because the rows about a NaN in the table above are ones a boxing decides.

## Environment

<details>
<summary>Machine, toolchain and the compile lines these numbers were taken with</summary>

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-30-generic x86_64 |
| CPU | AMD Ryzen 9 5950X (16 cores) |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0 |
| binutils | GNU ld (GNU Binutils) 2.47.20260726 |
| valgrind | valgrind-3.27.1 (callgrind) |
| CRuby | 4.0.6 (2026-07-14 revision 03b6d3f889) |

The wall clock and instruction counts were taken with the default build:

```console
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK
```

The `## Size` table was taken with `build_config/ci/gcc-clang.rb`:

```console
bintest      gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK
ascii-ctype  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
byte-string  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
cxx_abi      gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
full-debug   gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

`cxx_abi` compiles mruby as C++ with `gcc -x c++ -std=gnu++03`; g++ only links. `full-debug` is the one build at `-O0`, `enable_debug` putting `-g3 -O0` after the toolchain default of `-g -O3`.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated array equality to consistently recognize an object as equal to itself, even when its custom equality method returns false.
  * Aligned `Array#==` behavior with standard Ruby behavior and related array operations.

* **Tests**
  * Added regression coverage for array comparisons involving custom equality methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->