### PR TITLE
mruby-array-ext: walk an Array in C for `include?` and `member?`

### DIFF
--- a/mrbgems/mruby-array-ext/src/array.c
+++ b/mrbgems/mruby-array-ext/src/array.c
@@ -1777,6 +1777,43 @@ ary_min(mrb_state *mrb, mrb_value self)
   return ary_max_min(mrb, self, -1);
 }
 
+/*
+ *  call-seq:
+ *     array.include?(obj) -> true or false
+ *     array.member?(obj)  -> true or false
+ *
+ *  Returns `true` if the array holds an element equal to `obj`.
+ *
+ *  This is an optimized version of `Enumerable#include?` for arrays: the walk
+ *  is made in C, and the pair is compared with `mrb_equal()`, which is what
+ *  `Array#index` and `#delete` search with and what `a == b` reaches through
+ *  `OP_EQ`.
+ *
+ *     [1, 2, 3].include?(2)   #=> true
+ *     [1, 2, 3].include?(4)   #=> false
+ *
+ *  ISO 15.3.2.2.10, 15.3.2.2.15
+ */
+static mrb_value
+ary_include(mrb_state *mrb, mrb_value self)
+{
+  mrb_value obj = mrb_get_arg1(mrb);
+
+  /* `==` may run Ruby that grows or shrinks the array under us, so the length
+     and the pointer are read afresh each turn.
+
+     Nothing accumulates in the GC arena over the walk, which is why there is
+     no arena restore in it, as there is none in `Array#index`: what a call
+     leaves behind is its return value, and this walk returns at the first one
+     that is true. The answers it walks past are false, which is immediate. */
+  for (mrb_int i = 0; i < RARRAY_LEN(self); i++) {
+    if (mrb_equal(mrb, RARRAY_PTR(self)[i], obj)) {
+      return mrb_true_value();
+    }
+  }
+  return mrb_false_value();
+}
+
 static const mrb_mt_entry array_ext_rom_entries[] = {
   MRB_MT_ENTRY(ary_assoc,              MRB_SYM(assoc),              MRB_ARGS_REQ(1)),
   MRB_MT_ENTRY(ary_at,                 MRB_SYM(at),                 MRB_ARGS_REQ(1)),
@@ -1810,6 +1847,8 @@ static const mrb_mt_entry array_ext_rom_entries[] = {
   MRB_MT_ENTRY(ary_combination_next,   MRB_SYM(__combination_next), MRB_ARGS_REQ(1)),
   MRB_MT_ENTRY(ary_max,                MRB_SYM(__max),              MRB_ARGS_NONE()),
   MRB_MT_ENTRY(ary_min,                MRB_SYM(__min),              MRB_ARGS_NONE()),
+  MRB_MT_ENTRY(ary_include,            MRB_SYM_Q(include),          MRB_ARGS_REQ(1)),
+  MRB_MT_ENTRY(ary_include,            MRB_SYM_Q(member),           MRB_ARGS_REQ(1)),
 };
 
 void

--- a/mrbgems/mruby-array-ext/test/array.rb
+++ b/mrbgems/mruby-array-ext/test/array.rb
@@ -1014,3 +1014,40 @@ assert('Array#max, #min - a comparison that runs Ruby') do
   assert_kind_of cls, a.max
   assert_equal 0, a.size
 end
+
+assert('Array#include?, #member? - the walk made in C') do
+  # `Enumerable#include?` reaches an element through a call to `each`, a block
+  # call and a `__svalue` send, then compares it with `==`. An Array is walked
+  # in place instead, and the pair is compared with `mrb_equal()`, which is
+  # what `Array#index` and `#delete` search with.
+  assert_false [].include?(1)
+  assert_true [1, 2, 3].include?(1)      # the first element is reached
+  assert_true [1, 2, 3].include?(3)      # and so is the last
+  assert_false [1, 2, 3].include?(4)
+  assert_true [1, 2, 3].member?(2)
+  assert_false [1, 2, 3].member?(4)
+
+  assert_true ["a", "b"].include?("a")   # found by what it is equal to
+  assert_true [nil].include?(nil)
+  assert_true [false].include?(false)
+  assert_false [nil].include?(false)
+
+  # an element is taken for equal to itself before `==` is asked anything,
+  # which is how `#index` reads a pair
+  never = Class.new { def ==(other); false; end }.new
+  assert_true [never].include?(never)
+  assert_equal 0, [never].index(never)
+end
+
+assert('Array#include? - a comparison that runs Ruby') do
+  # `==` can run Ruby, which can empty the array being walked. The C walk
+  # reads the length and the pointer afresh each time round.
+  cls = Class.new do
+    def initialize(a); @a = a; end
+    def ==(o); @a.clear; false; end
+  end
+  a = [1, 2]
+  a << cls.new(a)
+  assert_false a.include?(:missing)
+  assert_equal 0, a.size
+end


### PR DESCRIPTION
## Summary

`Enumerable#include?` reaches an element through a call to `each`, a block call and a `__svalue` send, then compares it with `==`. An Array can be walked in place, and the pair compared with `mrb_equal()`, as `Array#index` and `#delete` already compare one. This is the same move `Array#max` and `#min` made in 6722d35, applied to the other search `Enumerable` lends an Array.

## Changes

| File | What |
| --- | --- |
| `mrbgems/mruby-array-ext/src/array.c` | adds `ary_include()`, registered as `include?` and `member?` |
| `mrbgems/mruby-array-ext/test/array.rb` | the walk, an element whose `==` answers false, and a comparison that empties the array |

### Where the walk goes

`mrb_equal()` takes two values for equal where they are the same object and asks `==` only after, which is the test `OP_EQ` makes for `a == b` before it dispatches anything. `Enumerable#include?` reaches `==` through `OP_EQ` too, so the answers are the ones the array gave before, arrived at without a block call per element.

There is no block form to leave behind, so the two names reach the C walk directly rather than through `super`, which is where `Array#max` and `#min` leave theirs.

The walk reads the length and the pointer afresh each turn, because `==` may run Ruby that grows or shrinks the array under it.

There is no GC arena restore in the loop, and none is needed: what a call leaves in the arena is its return value, and this walk returns at the first one that is true. The answers it walks past are false, which is immediate. `Array#index` searches without one for the same reason. `Array#count` is the walk that does need one, since it goes past a true answer, and it has one.

## Behaviour

Nothing an array answers moves, apart from a NaN. `a` and `b` are two NaNs built at run time as `z / z` from `z = [0.0][0]`, so that nothing folds them into a single literal. Bold marks a row that differs from CRuby.

| expression | master | this PR | CRuby |
| --- | --- | --- | --- |
| `[a].include?(a)` | false | true | true |
| `[a].include?(b)` | false | **true** | false |
| `[a].index(b)` | **0** | **0** | nil |

A NaN is equal to no value, its own operand included, so `==` can never find one: `Enumerable#include?` found nothing, while `#index` looked for the object and found the NaN the array holds. The two give one answer now, and it is `#index`'s. That answer is right about the NaN an array holds and wrong about a second one, because a boxing that keeps a Float in the value normalizes every NaN to one representation, which is what the last row shows `#index` saying on master and saying still. Making a NaN an object of its own is a change to what a Float is rather than to how an array searches, and it is not in this PR.

## Speed

```ruby
a = (1..200).to_a
i = 0
while i < 20000 do a.include?(200); i += 1 end
```

Best of 11 interleaved runs against master, with a master-vs-master control to read the noise by, and the instruction counts callgrind reads beside them:

| benchmark | master | this PR | control | Ir |
| --- | --- | --- | --- | --- |
| `#include?` over 200 elements, 20000 times | 342 ms | **105 ms (0.31x)** | +0.2% | 6,524,727,384 -> 1,865,200,104 |

## Size

`bin/mruby` `.text` for every build in `build_config/ci/gcc-clang.rb`:

| build | master | this PR | delta |
| --- | --- | --- | --- |
| `ascii-ctype` | 1,293,718 | 1,293,862 | +144 |
| `bintest` | 1,307,110 | 1,307,254 | +144 |
| `byte-string` | 1,271,494 | 1,271,638 | +144 |
| `cxx_abi` | 1,334,041 | 1,334,185 | +144 |
| `full-debug` (-O0) | 1,913,478 | 1,913,718 | +240 |

The whole of it is `mrbgems/mruby-array-ext/src/array.o`, which grows by exactly 144 for the one function; no other object moves.

## Testing

`rake test` passes for the default build, for `build_config/host-nofloat.rb`, for every build in `build_config/ci/gcc-clang.rb` including the C++ ABI one, and for a `MRB_NO_BOXING` build of the full-core gembox, with no compiler warnings beyond the one `-Wmaybe-uninitialized` about `eq` in `hash.c` that master already emits in a `MRB_NO_BOXING` build. The last of those is there because the rows about a NaN in the table above are ones a boxing decides.

One thing this does not test, and could not before either: the ISO assertions for `Enumerable#include?` and `#member?` (15.3.2.2.10 and 15.3.2.2.15) in `test/t/enumerable.rb` are written with an Array receiver, so in a build carrying this gem they now reach the C walk rather than the `Enumerable` one. `Enumerable#max` and `#min` are in the same position after 6722d35. Giving those assertions a receiver that is not an Array is worth doing and is not in this PR.

## Environment

<details>
<summary>Machine, toolchain and the compile lines these numbers were taken with</summary>

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-30-generic x86_64 |
| CPU | AMD Ryzen 9 5950X (16 cores) |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0 |
| binutils | GNU ld (GNU Binutils) 2.47.20260726 |
| valgrind | valgrind-3.27.1 (callgrind) |
| CRuby | 4.0.6 (2026-07-14 revision 03b6d3f889) |

The wall clock and instruction counts were taken with the default build:

```console
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK
```

The `## Size` table was taken with `build_config/ci/gcc-clang.rb`:

```console
bintest      gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK
ascii-ctype  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
byte-string  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
cxx_abi      gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
full-debug   gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

`cxx_abi` compiles mruby as C++ with `gcc -x c++ -std=gnu++03`; g++ only links. `full-debug` is the one build at `-O0`, `enable_debug` putting `-g3 -O0` after the toolchain default of `-g -O3`.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `Array#include?` and `Array#member?` for checking whether an array contains a matching element.
  - Matching follows Ruby equality semantics, including support for `nil`, `false`, and custom comparisons.
  - Searches remain safe when comparisons modify the array during traversal.

- **Tests**
  - Added coverage for empty arrays, successful and unsuccessful matches, identity, equality behavior, and mutation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->