### PR TITLE
mruby-enum-ext: count an Array in C

### DIFF
--- a/mrbgems/mruby-enum-ext/mrblib/array.rb
+++ b/mrbgems/mruby-enum-ext/mrblib/array.rb
@@ -16,4 +16,31 @@ class Array
   def minmax(&block)
     block ? super : __minmax
   end
+
+  ##
+  # call-seq:
+  #   array.count                 -> int
+  #   array.count(obj)            -> int
+  #   array.count {|element| ... } -> int
+  #
+  # Returns the number of elements, of those equal to `obj`, or of those the
+  # block answers true for.
+  #
+  # This is an optimized version of Enumerable#count for arrays: the length is
+  # read off the array, and an argument is counted by a walk made in C, where
+  # the pair is compared with `mrb_equal()` as Array#index compares one. An
+  # argument decides even where a block came with it, as in CRuby, where
+  # Enumerable#count took the block.
+  #
+  #    [1, 2, 4, 2].count       #=> 4
+  #    [1, 2, 4, 2].count(2)    #=> 2
+  #    [1, 2, 4, 2].count {|x| x.even? }  #=> 3
+  #
+  def count(v = Enumerable::NONE, &block)
+    if Enumerable::NONE.equal?(v)
+      block ? super : size
+    else
+      __count(v)
+    end
+  end
 end

--- a/mrbgems/mruby-enum-ext/src/enum.c
+++ b/mrbgems/mruby-enum-ext/src/enum.c
@@ -46,10 +46,36 @@ ary_minmax(mrb_state *mrb, mrb_value self)
   return pair;
 }
 
+/* `Enumerable#count` with an argument reaches an element the same way and
+   compares it with `==`. An Array is walked in place instead, and the pair is
+   compared with `mrb_equal()`, which is what `Array#index` and `#delete`
+   search with and what `OP_EQ` tests before it dispatches `==`.
+
+   `==` can run Ruby that grows or shrinks the array under us, so the length
+   and the pointer are read afresh each turn, and whatever that Ruby built on
+   the way is dropped from the arena before the next turn adds to it. A count
+   walks every element, so without the restore an `==` answering with a fresh
+   object each time fills a fixed arena. What `mrb_equal()` returns is a C
+   value and outlives the restore. */
+static mrb_value
+ary_count(mrb_state *mrb, mrb_value self)
+{
+  mrb_value obj = mrb_get_arg1(mrb);
+  mrb_int n = 0;
+
+  int ai = mrb_gc_arena_save(mrb);
+  for (mrb_int i = 0; i < RARRAY_LEN(self); i++) {
+    if (mrb_equal(mrb, RARRAY_PTR(self)[i], obj)) n++;
+    mrb_gc_arena_restore(mrb, ai);
+  }
+  return mrb_int_value(mrb, n);
+}
+
 void
 mrb_mruby_enum_ext_gem_init(mrb_state *mrb)
 {
   mrb_define_method_id(mrb, mrb->array_class, MRB_SYM(__minmax), ary_minmax, MRB_ARGS_NONE());
+  mrb_define_method_id(mrb, mrb->array_class, MRB_SYM(__count), ary_count, MRB_ARGS_REQ(1));
 }
 
 void

--- a/mrbgems/mruby-enum-ext/test/enum.rb
+++ b/mrbgems/mruby-enum-ext/test/enum.rb
@@ -272,3 +272,48 @@ assert('Array#minmax - the walk made in C') do
   3.times {|i| a << cls.new(i, a) }
   assert_equal 2, a.minmax.size
 end
+
+assert('Array#count - the walk made in C') do
+  # `Enumerable#count` reaches an element through a call to `each`, a block
+  # call and a `__svalue` send, then compares it with `==`. An Array reads its
+  # length off itself, and an argument is counted by a walk made in C where
+  # the pair is compared with `mrb_equal()`, as `Array#index` compares one.
+  a = [1, 2, 4, 2]
+  assert_equal 4, a.count
+  assert_equal 0, [].count
+  assert_equal 2, a.count(2)
+  assert_equal 0, a.count(3)
+  assert_equal 3, a.count {|x| x % 2 == 0}     # the block form, through super
+
+  # an argument decides even where a block came with it, as in CRuby, where
+  # `Enumerable#count` took the block
+  assert_equal 2, a.count(2) {|x| true}
+
+  # an element is taken for equal to itself before `==` is asked anything
+  never = Class.new { def ==(other); false; end }.new
+  assert_equal 1, [never].count(never)
+end
+
+assert('Array#count - a comparison that runs Ruby') do
+  # `==` can run Ruby, which can empty the array being walked. The C walk
+  # reads the length and the pointer afresh each time round.
+  cls = Class.new do
+    def initialize(a); @a = a; end
+    def ==(o); @a.clear; false; end
+  end
+  a = [1, 2]
+  a << cls.new(a)
+  assert_equal 0, a.count(:missing)
+  assert_equal 0, a.size
+end
+
+assert("Array#count - a comparison that answers with a fresh object") do
+  # What a call leaves behind in the GC arena is its return value, and a count
+  # walks every element rather than returning at the first true one, so an `==`
+  # answering with a fresh object each time would pile them up. The walk drops
+  # what a turn left before the next one adds to it, which is what keeps a
+  # fixed arena from filling with the length of the array.
+  cls = Class.new { def ==(o); "truthy"; end }
+  a = Array.new(300) { cls.new }
+  assert_equal 300, a.count(:x)
+end


### PR DESCRIPTION
## Summary

`Enumerable#count` reaches an element through a call to `each`, a block call and a `__svalue` send, then compares it with `==` where an argument was given, and counts every element the same way where none was. An Array reads its length off itself, and an argument is counted by a walk made in C where the pair is compared with `mrb_equal()`, as `Array#index` and `#delete` already compare one. This is the move `Array#minmax` made in 7c0c643, applied to the other `Enumerable` method this gem lends an Array.

## Changes

| File | What |
| --- | --- |
| `mrbgems/mruby-enum-ext/src/enum.c` | adds `ary_count()`, registered as `Array#__count` |
| `mrbgems/mruby-enum-ext/mrblib/array.rb` | `Array#count` reads `size`, walks in C, or reaches the block form through `super` |
| `mrbgems/mruby-enum-ext/test/enum.rb` | the three forms, an argument with a block, and a comparison that empties the array |

### The three forms

```ruby
def count(v = Enumerable::NONE, &block)
  if Enumerable::NONE.equal?(v)
    block ? super : size
  else
    __count(v)
  end
end
```

With no argument the answer is the length, which an Array already knows. With an argument it is a walk in C. The block form is left where it is written and reached through `super`, as `Array#minmax` leaves its own.

`mrb_equal()` takes two values for equal where they are the same object and asks `==` only after, which is the test `OP_EQ` makes for `a == b` before it dispatches anything, and the one `Enumerable#count` reached `==` through. The answers are the ones the array gave before.

The walk reads the length and the pointer afresh each turn, because `==` may run Ruby that grows or shrinks the array under it, and it restores the GC arena at the end of each turn. What a call leaves in the arena is its return value, and a count goes past a true answer rather than returning at it, so an `==` answering with a fresh object every time would pile up one per element; a fixed arena fills at a few hundred. `Array#include?` needs no such restore, returning at the first true answer, and `Array#index` has none for the same reason.

## Behaviour

`a` and `b` are two NaNs built at run time as `z / z` from `z = [0.0][0]`, so that nothing folds them into a single literal. Bold marks a row that differs from CRuby.

| expression | master | this PR | CRuby |
| --- | --- | --- | --- |
| `[1, 2, 2].count(2) { \|v\| true }` | 3 | 2 | 2 |
| `[a].count(a)` | 0 | 1 | 1 |
| `[a].count(b)` | 0 | **1** | 0 |
| `[a].index(b)` | **0** | **0** | nil |

An argument decides even where a block came with it, which is what CRuby does, warning that the block goes unused; `Enumerable#count` took the block and dropped the argument. This is `Array#count` only: `Enumerable#count` is unchanged, and every other receiver still takes the block.

The last three rows are one answer. A NaN is equal to no value, its own operand included, so `==` can never find one and only the object is left to go by; `#index` looked for the object and found the NaN an array holds, and `#count` counts it now too. That is right about the NaN an array holds and wrong about a second one, because a boxing that keeps a Float in the value normalizes every NaN to one representation, which is what the last row shows `#index` saying on master and saying still. Making a NaN an object of its own is a change to what a Float is rather than to how an array counts, and it is not in this PR.

## Speed

```ruby
a = (1..200).to_a
i = 0
while i < 20000 do a.count(200); i += 1 end
```

Best of 11 interleaved runs against master, with a master-vs-master control to read the noise by, and the instruction counts callgrind reads beside them:

| benchmark | master | this PR | control | Ir |
| --- | --- | --- | --- | --- |
| `#count` over 200 elements, 20000 times | 348 ms | **106 ms (0.31x)** | -0.1% | 6,557,637,571 -> 1,886,640,104 |

## Size

`bin/mruby` `.text` for every build in `build_config/ci/gcc-clang.rb`:

| build | master | this PR | delta |
| --- | --- | --- | --- |
| `ascii-ctype` | 1,293,718 | 1,293,926 | +208 |
| `bintest` | 1,307,110 | 1,307,318 | +208 |
| `byte-string` | 1,271,494 | 1,271,702 | +208 |
| `cxx_abi` | 1,334,041 | 1,334,249 | +208 |
| `full-debug` (-O0) | 1,913,478 | 1,913,878 | +400 |

The whole of it is `mrbgems/mruby-enum-ext/src/enum.o`, which grows by exactly 208 for the one function and the arena save and restore around its loop; the Ruby that picks between the three forms is bytecode and lands in `.rodata`, not here.

## Testing

`rake test` passes for the default build, for `build_config/host-nofloat.rb`, for every build in `build_config/ci/gcc-clang.rb` including the C++ ABI one, and for a `MRB_NO_BOXING` build of the full-core gembox, with no compiler warnings beyond the one `-Wmaybe-uninitialized` about `eq` in `hash.c` that master already emits in a `MRB_NO_BOXING` build. The last of those is there because the rows about a NaN in the table above are ones a boxing decides.

The `Enumerable#count` assertions this gem already carries are written with an Array receiver, so they now reach the C walk. They are kept as they are and the new ones are asked beside them; `Enumerable#count` itself is reached by the block form through `super`.

## Environment

<details>
<summary>Machine, toolchain and the compile lines these numbers were taken with</summary>

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-30-generic x86_64 |
| CPU | AMD Ryzen 9 5950X (16 cores) |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0 |
| binutils | GNU ld (GNU Binutils) 2.47.20260726 |
| valgrind | valgrind-3.27.1 (callgrind) |
| CRuby | 4.0.6 (2026-07-14 revision 03b6d3f889) |

The wall clock and instruction counts were taken with the default build:

```console
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK
```

The `## Size` table was taken with `build_config/ci/gcc-clang.rb`:

```console
bintest      gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK
ascii-ctype  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
byte-string  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
cxx_abi      gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
full-debug   gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

`cxx_abi` compiles mruby as C++ with `gcc -x c++ -std=gnu++03`; g++ only links. `full-debug` is the one build at `-O0`, `enable_debug` putting `-g3 -O0` after the toolchain default of `-g -O3`.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `Array#count` for counting all elements, matching values, or elements meeting a block condition.
  - Supports Ruby-compatible behavior when both an argument and block are provided.

- **Bug Fixes**
  - Improved counting behavior for arrays modified during element comparison.

- **Tests**
  - Added coverage for empty arrays, value matching, block behavior, self-equality, and mutations during counting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->