### PR TITLE
object.c: compare what a Float holds bit for bit under `MRB_NO_BOXING`

### DIFF
--- a/src/object.c
+++ b/src/object.c
@@ -10,6 +10,7 @@
 #include <mruby/string.h>
 #include <mruby/class.h>
 #include <mruby/internal.h>
+#include <string.h>
 
 /*
  * Checks if two mruby values, `v1` and `v2`, are identical.
@@ -45,7 +46,12 @@ mrb_obj_eq(mrb_state *mrb, mrb_value v1, mrb_value v2)
 
 #ifndef MRB_NO_FLOAT
   case MRB_TT_FLOAT:
-    return (mrb_float(v1) == mrb_float(v2));
+    /* What a Float holds is compared bit for bit rather than as a number, so
+       that a NaN, which is equal to no number at all, is still the same object
+       as itself and no other. The two forms part only over a NaN and over
+       -0.0, which holds what 0.0 does not; a boxed build, where this reads the
+       representation, answers both the same way. */
+    return memcmp(&v1.value.f, &v2.value.f, sizeof(mrb_float)) == 0;
 #endif
 
   default:

--- a/test/t/float.rb
+++ b/test/t/float.rb
@@ -136,9 +136,9 @@ assert('a NaN is equal to nothing at all, itself included') do
   # expression answered true or false depending on how the build stores a
   # Float.
   #
-  # `equal?` is left out below for that reason: it is the one caller of the
-  # shortcut that asks for exactly what the shortcut reads, and what it reads
-  # still differs between those builds.
+  # `equal?` is left out below because it is not equality: it is the one
+  # caller of the shortcut that asks for exactly what the shortcut reads.
+  # What it answers is pinned below, in every boxing.
   nan = Float::NAN
 
   assert_false(nan == nan)
@@ -156,6 +156,33 @@ assert('a NaN is equal to nothing at all, itself included') do
   assert_true(0.0 == -0.0)
   assert_true(Float::INFINITY == Float::INFINITY)
   assert_equal(:hit, case 1.0 when 1.0 then :hit else :miss end)
+end
+
+assert('a Float is the object that holds what it holds') do
+  # `equal?` asks what a value holds rather than what it is equal to, and what
+  # a Float holds is compared bit for bit. A -0.0 holds what a 0.0 does not, so
+  # the two are two objects; the boxed builds answered that all along, reading
+  # the representation, and `MRB_NO_BOXING` used to read the number instead and
+  # answer the other way. Equal is what they still are.
+  #
+  # The two below are built at run time from a variable so that nothing folds
+  # them into a single literal.
+  z = [0.0][0]
+  pzero = z + 0.0
+  nzero = z * -1.0
+
+  assert_true(pzero.equal?(pzero))
+  assert_false(pzero.equal?(nzero))
+  assert_true(pzero == nzero)
+
+  # A NaN holds what it holds as well, so it is the same object as itself
+  # however far it is passed around, which reading the number could not say:
+  # a NaN is equal to nothing at all, its own operand included.
+  nan = z / z
+  same = nan
+  assert_true(nan.equal?(nan))
+  assert_true(nan.equal?(same))
+  assert_false(nan == nan)
 end
 
 assert('Float comparison with an Integer it cannot hold') do


### PR DESCRIPTION
## Summary

`mrb_obj_eq()` asks whether two values hold the same thing, and `equal?` is the one caller that asks for exactly that. For a Float it asked whether they were equal as numbers instead, which is a different question, and it asked it only under `MRB_NO_BOXING`: the boxed builds compare the `mrb_value` and so read the representation. The same expression answered one way there and the other way here.

## Changes

| File | What |
| --- | --- |
| `src/object.c` | `mrb_obj_eq()` compares two Floats with `memcmp()` under `MRB_NO_BOXING`; `<string.h>` for it |
| `test/t/float.rb` | `equal?` over `0.0` and `-0.0`, and over a NaN |

### Where the two questions part

A Float holds two kinds of pair that tell the questions apart. `0.0` and `-0.0` are equal as numbers and hold different bits; a NaN holds a NaN and is equal to no number at all, its own operand included. Reading them as numbers, `MRB_NO_BOXING` called `0.0` and `-0.0` one object and said a NaN was not the same object as itself, while the boxings that keep a Float in the value read the bits and answered both the other way.

`memcmp()` over `sizeof(mrb_float)` asks the question the boxed builds answer, so `equal?` reads alike whatever the build stores a Float in. `Float#==` is untouched, and what a Float is equal to does not move with it: `0.0 == -0.0` is still true, and a NaN is still equal to nothing.

## Behaviour

`pzero` and `nzero` are built at run time as `z + 0.0` and `z * -1.0`, and `nan` as `z / z`, from `z = [0.0][0]`, so that nothing folds them into a single literal. Bold marks where a build differs from CRuby today.

| expression | word / nan boxing | `MRB_NO_BOXING` | this PR | CRuby |
| --- | --- | --- | --- | --- |
| `pzero.equal?(pzero)` | true | true | true | true |
| `pzero.equal?(nzero)` | false | **true** | false | false |
| `pzero == nzero` | true | true | true | true |
| `nan.equal?(nan)` | true | **false** | true | true |
| `nan == nan` | false | false | false | false |

The `this PR` column is what all three boxings answer after the change. Measured against CRuby 4.0.6.

## Speed

`MRB_NO_BOXING` is the only build the change reaches, so the counts below are from a `MRB_NO_BOXING` build of the full-core gembox:

```ruby
z = [0.0][0]
a = z + 1.5
b = z + 1.5
i = 0
while i < 1000000 do a == b; i += 1 end                 # the shortcut, over two Floats

t = 0.0; i = 0
while i < 1000000 do t += i * 0.5; i += 1 end           # Float arithmetic

h = {}; i = 0
while i < 100000 do h[i * 0.5] = i; i += 1 end          # Float-keyed Hash
i = 0
while i < 100000 do h[i * 0.5]; i += 1 end
```

Instruction counts as callgrind reads them, taken as `Ir(2N) - Ir(N)` so that startup cancels:

| benchmark | master | this PR |
| --- | --- | --- |
| `a == b` over two Floats, 1M turns | 302,004,732 | **298,004,732 (-1.3%)** |
| `t += i * 0.5`, 1M turns | 377,005,412 | 377,005,412 |
| Float-keyed Hash, 100k insert + 100k lookup | 228,251,313 | 228,251,415 |

`memcmp()` over eight bytes is four instructions fewer per comparison than loading the two Floats and comparing them, so the path `equal?` and the `==` shortcut take is slightly shorter than it was. The other two rows are the same code either way.

## Size

`bin/mruby` `.text` for every build in `build_config/ci/gcc-clang.rb`:

| build | master | this PR | delta |
| --- | --- | --- | --- |
| `ascii-ctype` | 1,293,718 | 1,293,718 | 0 |
| `bintest` | 1,307,110 | 1,307,110 | 0 |
| `byte-string` | 1,271,494 | 1,271,494 | 0 |
| `cxx_abi` | 1,334,041 | 1,334,041 | 0 |
| `full-debug` (-O0) | 1,913,478 | 1,913,478 | 0 |

None of the five defines `MRB_NO_BOXING`, so none of them compiles the edit. The build that does is 96 bytes smaller: `object.o` `.text` reads 5,288 against master and 5,192 here, and `bin/mruby` the same 96 less.

## Testing

`rake test` passes for the default build, for `build_config/host-nofloat.rb`, for every build in `build_config/ci/gcc-clang.rb` including the C++ ABI one, and for a `MRB_NO_BOXING` build of the full-core gembox, with no compiler warnings beyond the one `-Wmaybe-uninitialized` about `eq` in `hash.c` that master already emits in a `MRB_NO_BOXING` build.

## Environment

<details>
<summary>Machine, toolchain and the compile lines these numbers were taken with</summary>

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-30-generic x86_64 |
| CPU | AMD Ryzen 9 5950X (16 cores) |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0 |
| binutils | GNU ld (GNU Binutils) 2.47.20260726 |
| valgrind | valgrind-3.27.1 (callgrind) |
| CRuby | 4.0.6 (2026-07-14 revision 03b6d3f889) |

The instruction counts were taken with a full-core gembox build at `MRB_NO_BOXING`:

```console
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_BOXING -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

The `## Size` table was taken with `build_config/ci/gcc-clang.rb`:

```console
bintest      gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK
ascii-ctype  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
byte-string  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
cxx_abi      gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
full-debug   gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

`cxx_abi` compiles mruby as C++ with `gcc -x c++ -std=gnu++03`; g++ only links. `full-debug` is the one build at `-O0`, `enable_debug` putting `-g3 -O0` after the toolchain default of `-g -O3`.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Float `equal?` behavior to compare exact object representations.
  * NaN values now preserve identity when aliased.
  * Positive and negative zero are correctly distinguished.
  * Float `equal?` remains distinct from numeric `==` comparisons.

* **Documentation**
  * Clarified that `equal?` checks object representation rather than numeric equality.

* **Tests**
  * Added coverage for NaN identity, signed zero, and differences between `equal?` and `==`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->