### PR TITLE
etc.c: give every NaN an identity of its own

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -355,6 +355,15 @@ struct mrb_state {
 
   mrb_gc gc;
 
+#if !defined(MRB_NO_FLOAT) && !defined(MRB_WORD_BOXING)
+  /* Counts the NaNs made so far. A NaN is equal to nothing at all, its own
+     operand included, so a container searching for one has only the object to
+     go by; where a Float is a value and not an object, the count is what tells
+     two of them apart. See the comment above `MRB_NAN_SERIAL_MAX` in
+     `mruby/value.h`. */
+  uint64_t nan_serial;
+#endif
+
   mrb_bool bootstrapping;
 
 #ifndef MRB_NO_METHOD_CACHE

--- a/include/mruby/boxing_nan.h
+++ b/include/mruby/boxing_nan.h
@@ -62,7 +62,14 @@ mrb_nan_boxing_value_float(mrb_value v)
     uint64_t uval; \
   } float_uint_union; \
   if ((v) != (v)) { /* NaN */ \
-    float_uint_union.uval = 0x7ff8000000000000UL; \
+    /* A NaN is equal to nothing at all, its own operand included, so `==`
+       can never find one and a container searching for the NaN it holds has
+       only the object to go by. Each NaN takes a count of its own in the
+       payload, which the tag space leaves free: the tag saying which value
+       this is begins at bit 48, and everything below is the NaN's to spend.
+       `mrb_float()` reads any of these back as a NaN. */ \
+    float_uint_union.uval = 0x7ff8000000000000UL | \
+      (uint64_t)(mrb_nan_serial_next(mrb) & MRB_NAN_SERIAL_MAX); \
   } \
   else { \
     float_uint_union.fval = (v); \

--- a/include/mruby/boxing_no.h
+++ b/include/mruby/boxing_no.h
@@ -49,7 +49,17 @@ typedef struct mrb_value {
 #define SET_INT_VALUE(mrb,r,n) BOXNO_SET_VALUE(r, MRB_TT_INTEGER, value.i, (n))
 #define SET_FIXNUM_VALUE(r,n) BOXNO_SET_VALUE(r, MRB_TT_INTEGER, value.i, (n))
 #ifndef MRB_NO_FLOAT
-#define SET_FLOAT_VALUE(mrb,r,v) BOXNO_SET_VALUE(r, MRB_TT_FLOAT, value.f, (v))
+/* A NaN is equal to nothing at all, its own operand included, so `==` can
+   never find one and a container searching for the NaN it holds has only the
+   object to go by. There is no object here, a Float being a value, so each NaN
+   takes a count of its own in the payload, which no arithmetic reads;
+   `mrb_obj_eq()` compares what a Float holds bit for bit so that a NaN is the
+   same object as itself and no other. */
+#define SET_FLOAT_VALUE(mrb,r,v) do { \
+  mrb_float boxno_f = (v); \
+  if (boxno_f != boxno_f) boxno_f = mrb_nan_serialize(boxno_f, mrb_nan_serial_next(mrb)); \
+  BOXNO_SET_VALUE(r, MRB_TT_FLOAT, value.f, boxno_f); \
+} while (0)
 #endif
 #define SET_SYM_VALUE(r,v) BOXNO_SET_VALUE(r, MRB_TT_SYMBOL, value.sym, (v))
 #define SET_OBJ_VALUE(r,v) BOXNO_SET_VALUE(r, (((struct RObject*)(v))->tt), value.p, (v))

--- a/include/mruby/boxing_word.h
+++ b/include/mruby/boxing_word.h
@@ -129,7 +129,7 @@ enum mrb_special_consts {
  *
  * 64-bit word with inline float32 (MRB_USE_FLOAT32):
  *   float : ...FFFF FF10 (float32 shifted left by 2)
- *   (other values same as above)
+ *   (other values same as above; a NaN is heap-allocated as RFloat)
  *
  * word boxing without inline float (MRB_WORDBOX_NO_INLINE_FLOAT):
  *   nil   : ...0000 0000 (all bits are 0)
@@ -211,10 +211,9 @@ mrb_integer_func(mrb_value o) {
 #ifndef MRB_NO_FLOAT
 #ifdef MRB_WORDBOX_NO_INLINE_FLOAT
 #define mrb_float_p(o) WORDBOX_OBJ_TYPE_P(o, FLOAT)
-#elif defined(MRB_USE_FLOAT32) && defined(MRB_64BIT)
-#define mrb_float_p(o) WORDBOX_SHIFT_VALUE_P(o, FLOAT)
 #else
-/* rotation encoding: most floats inline, edge cases on heap */
+/* most floats inline; a NaN is always on the heap, and the rotation encoding
+   sends its edge cases there too */
 #define mrb_float_p(o) (WORDBOX_SHIFT_VALUE_P(o, FLOAT) || WORDBOX_OBJ_TYPE_P(o, FLOAT))
 #endif
 #else

--- a/include/mruby/value.h
+++ b/include/mruby/value.h
@@ -113,7 +113,62 @@ MRB_API double mrb_float_read(const char *p, char **endp);
 #else
   typedef double mrb_float;
 #endif
+
+#ifndef MRB_WORD_BOXING
+/* A NaN is equal to nothing at all, its own operand included, so `==` can
+   never find one and a container searching for the NaN it holds has only the
+   object to go by. Where a Float is a value and not an object, which is every
+   boxing but `boxing_word.h`, there is no object to be had: what tells one NaN
+   from another has to be carried by the NaN itself, and the only room for it
+   is the payload, which no arithmetic reads. Each NaN made takes a count
+   there.
+
+   The count is given every bit the payload can spare, which is what puts a
+   wrap out of reach: 51 bits where the boxing leaves that many, 48 where the
+   nan-boxing tag begins. Two NaNs made that far apart do hold the same bits.
+   `MRB_USE_FLOAT32` is the one build where the bound is a near one, its
+   payload being 22 bits and nothing more. `boxing_word.h` needs no count at
+   all: a NaN is an object there, and two objects are never one. */
+#ifdef MRB_NAN_BOXING
+/* bit 48 is where the tag saying which nan-boxed value this is begins */
+# define MRB_NAN_SERIAL_MAX UINT64_C(0xffffffffffff)
+#elif defined(MRB_USE_FLOAT32)
+  typedef uint32_t mrb_float_bits;
+# define MRB_NAN_SERIAL_MAX 0x3fffff  /* the whole payload under the quiet bit */
+# define MRB_NAN_QUIET_BIT  0x400000
+#else
+  typedef uint64_t mrb_float_bits;
+# define MRB_NAN_SERIAL_MAX UINT64_C(0x7ffffffffffff)
+# define MRB_NAN_QUIET_BIT  UINT64_C(0x8000000000000)
 #endif
+
+/* The count lives in `mrb_state`, whose layout is not known here: this header
+   is where `mrb_float_value()` expands the boxing's own float macro, and that
+   is above the definition of the struct. */
+MRB_API uint64_t mrb_nan_serial_next(mrb_state *mrb);
+
+#ifndef MRB_NAN_BOXING
+/* `boxing_nan.h` writes the count into a pattern it builds itself, so what
+   follows is for the boxing that has a whole Float to put it in. */
+static inline mrb_float
+mrb_nan_serialize(mrb_float f, uint64_t n)
+{
+  union { mrb_float f; mrb_float_bits u; } x;
+
+  x.f = f;
+  /* The quiet bit is set as well because that is what keeps the pattern a
+     NaN. A signaling NaN can carry every bit it has inside the field the
+     count takes, and clearing those for a count of zero would leave the
+     exponent alone, which is an infinity. Quieting is what arithmetic reading
+     such a NaN does with it anyway. */
+  x.u = (x.u & ~(mrb_float_bits)MRB_NAN_SERIAL_MAX) |
+        (mrb_float_bits)MRB_NAN_QUIET_BIT |
+        (mrb_float_bits)(n & MRB_NAN_SERIAL_MAX);
+  return x.f;
+}
+#endif  /* MRB_NAN_BOXING */
+#endif  /* MRB_WORD_BOXING */
+#endif  /* MRB_NO_FLOAT */
 
 #if defined _MSC_VER && _MSC_VER < 1900
 MRB_API int mrb_msvc_vsnprintf(char *s, size_t n, const char *format, va_list arg);

--- a/mrbgems/mruby-array-ext/test/array.rb
+++ b/mrbgems/mruby-array-ext/test/array.rb
@@ -86,6 +86,31 @@ assert("Array#uniq") do
   assert_equal [["student", "sam"], ["teacher", "matz"]], b.uniq { |s| s.first }
 end
 
+assert("Array#uniq, Array#- and Array#include? with a NaN") do
+  # A NaN is equal to no value, its own included, so none of these can find one
+  # by what it is equal to; they search for the object instead, and every NaN
+  # made is one of its own, so that two made apart are two objects.
+  skip unless Object.const_defined?(:Float)
+  z = [0.0][0]
+  a = z / z
+  b = z / z
+
+  assert_equal 1, [a, a].uniq.size
+  assert_equal 2, [a, b].uniq.size
+  assert_equal 0, ([a] - [a]).size
+  assert_equal 1, ([a] - [b]).size
+  assert_equal 1, ([a] & [a]).size
+  assert_equal 0, ([a] & [b]).size
+  assert_true [a].include?(a)
+  assert_false [a].include?(b)
+  assert_true [a].member?(a)
+
+  # a Float that is equal to itself is found by what it is equal to
+  x = z + 1.5
+  y = z + 1.5
+  assert_true [x].include?(y)
+end
+
 assert("Array#-") do
   # Test basic functionality
   a = [1, 2, 3, 1]

--- a/mrbgems/mruby-enum-ext/test/enum.rb
+++ b/mrbgems/mruby-enum-ext/test/enum.rb
@@ -343,3 +343,17 @@ assert('Enumerable#count - an argument decides over a block') do
   end.new
   assert_equal 1, one.count(never)
 end
+
+assert("Array#count with a NaN") do
+  # A NaN is equal to no value, its own included, so `count` cannot find one by
+  # what it is equal to; it searches for the object, and every NaN made is one
+  # of its own, so that two made apart are two objects.
+  skip unless Object.const_defined?(:Float)
+  z = [0.0][0]
+  a = z / z
+  b = z / z
+
+  assert_equal 1, [a].count(a)
+  assert_equal 0, [a].count(b)
+  assert_equal 2, [a, a].count(a)
+end

--- a/mrbgems/mruby-pack/test/pack.rb
+++ b/mrbgems/mruby-pack/test/pack.rb
@@ -162,6 +162,22 @@ assert 'pack double' do
   end
 end
 
+assert 'unpack a NaN that signals' do
+  skip unless Object.const_defined?(:Float)
+  # A NaN that signals has every bit it is set in the low payload, which is
+  # where a build that keeps no object for a NaN writes what tells one from
+  # another. Reading one back has to leave a NaN rather than the infinity an
+  # empty payload under that exponent would be, and two reads have to leave
+  # two objects, as they do for a NaN made any other way.
+  s = "\x01\x00\x00\x00\x00\x00\xf0\x7f"
+  a = s.unpack1("E")
+  b = s.unpack1("E")
+
+  assert_predicate(a, :nan?)
+  assert_predicate(b, :nan?)
+  assert_false(a.equal?(b))
+end
+
 assert 'pack/unpack "i"' do
   int_size = [0].pack('i').size
   raise "pack('i').size is too small (#{int_size})" if int_size < 2

--- a/src/etc.c
+++ b/src/etc.c
@@ -95,6 +95,18 @@ mrb_obj_to_sym(mrb_state *mrb, mrb_value name)
   return 0;  /* not reached */
 }
 
+#if !defined(MRB_NO_FLOAT) && !defined(MRB_WORD_BOXING)
+/*
+ * Hands out the count that tells one NaN from the next. See the comment above
+ * `MRB_NAN_SERIAL_MAX` in `mruby/value.h`.
+ */
+MRB_API uint64_t
+mrb_nan_serial_next(mrb_state *mrb)
+{
+  return mrb->nan_serial++;
+}
+#endif
+
 #if !defined(MRB_NO_FLOAT) && !defined(MRB_NAN_BOXING)
 static mrb_int
 mrb_float_id(mrb_float f)
@@ -125,7 +137,13 @@ mrb_obj_id(mrb_value obj)
     if (mrb_integer_p(obj)) return mrb_integer(obj);
 #ifndef MRB_NO_FLOAT
     if (mrb_float_p(obj)) {
-      return mrb_float_id(mrb_float(obj));
+      mrb_float f = mrb_float(obj);
+      /* A NaN is an object of its own here, and two of them hold the same
+         bits, so what the bits hash to is one id for objects that `equal?`
+         has already told apart. The object answers for a NaN instead, which
+         is what the line below does for everything that is not a Float. */
+      if (f != f) return (mrb_int)obj.w;
+      return mrb_float_id(f);
     }
 #endif
   }
@@ -185,6 +203,8 @@ mrb_obj_id(mrb_value obj)
  * - 64-bit float64: rotation encoding, lossless for exponents [-255, +256].
  * - 32-bit float32: rotation encoding, lossless for exponents [-32, +31].
  *   Floats outside the inline range are heap-allocated as RFloat.
+ * A NaN is heap-allocated whatever the width, being the one float that has to
+ * be told from another of the same value.
  */
 
 #if !defined(MRB_WORDBOX_NO_INLINE_FLOAT) && \
@@ -197,7 +217,7 @@ mrb_obj_id(mrb_value obj)
  *         2 bits == 10 (WORDBOX_FLOAT_FLAG).
  * Decode: rotl(tagged_value, N-3) + ADDEND recovers the original bits.
  *
- * Special values (0.0, -0.0, +Inf, -Inf, NaN) are encoded as small
+ * Special values (0.0, -0.0, +Inf, -Inf) are encoded as small
  * sentinel constants that also have bottom 2 bits == 10.  This avoids
  * heap allocation for these common values.
  */
@@ -208,8 +228,13 @@ mrb_obj_id(mrb_value obj)
 #define WORDBOX_FLOAT_NZERO       0x06  /* -0.0 */
 #define WORDBOX_FLOAT_PINF        0x0a  /* +Infinity */
 #define WORDBOX_FLOAT_NINF        0x0e  /* -Infinity */
-#define WORDBOX_FLOAT_NAN         0x12  /* NaN (all NaN bit patterns normalize to this) */
-#define WORDBOX_FLOAT_SENTINEL_MAX  WORDBOX_FLOAT_NAN
+/* A NaN gets no sentinel of its own. It is equal to nothing at all, its own
+   operand included, so `==` can never find one and a container searching for
+   the NaN it holds has only the object to go by. A NaN therefore takes the
+   heap, where the object it is answers for it and two of them are never one.
+   Every float a sentinel does stand for is equal to itself, so one word does
+   for all the copies of it there will ever be. */
+#define WORDBOX_FLOAT_SENTINEL_MAX WORDBOX_FLOAT_NINF
 
 #if defined(MRB_USE_FLOAT32) && !defined(MRB_64BIT)
 /*
@@ -291,9 +316,18 @@ mrb_word_boxing_float_value(mrb_state *mrb, mrb_float f)
   mrb_rfloat_set(v.fp, f);
   v.bp->frozen = 1;
 #elif defined(MRB_64BIT) && defined(MRB_USE_FLOAT32)
-  v.w = 0;
-  v.f = f;
-  v.w = (v.w<<2) | 2;
+  if (f != f) {
+    /* a NaN is the object it is, and a word holding the whole float has
+       nothing left to tell one from another with */
+    v.p = mrb_obj_alloc(mrb, MRB_TT_FLOAT, mrb->float_class);
+    mrb_rfloat_set(v.fp, f);
+    v.bp->frozen = 1;
+  }
+  else {
+    v.w = 0;
+    v.f = f;
+    v.w = (v.w<<2) | 2;
+  }
 #elif defined(MRB_64BIT)
   {
     uint64_t bits = wordbox_float64_to_u64((double)f);
@@ -313,7 +347,7 @@ mrb_word_boxing_float_value(mrb_state *mrb, mrb_float f)
       else if (bits == UINT64_C(0xFFF0000000000000))
         v.w = WORDBOX_FLOAT_NINF;
       else
-        v.w = WORDBOX_FLOAT_NAN;
+        goto float_heap;  /* a NaN is the object it is; see the sentinels */
     }
     else if (exp >= WORDBOX_FLOAT_EXP_MIN && exp <= WORDBOX_FLOAT_EXP_MAX) {
       uintptr_t w = (uintptr_t)wordbox_rotl64(bits - WORDBOX_FLOAT_ADDEND, WORDBOX_FLOAT_ROTATE);
@@ -347,7 +381,7 @@ mrb_word_boxing_float_value(mrb_state *mrb, mrb_float f)
       else if (bits == 0xFF800000u)
         v.w = WORDBOX_FLOAT_NINF;
       else
-        v.w = WORDBOX_FLOAT_NAN;
+        goto float_heap;  /* a NaN is the object it is; see the sentinels */
     }
     else if (exp >= WORDBOX_FLOAT32_EXP_MIN && exp <= WORDBOX_FLOAT32_EXP_MAX) {
       uintptr_t w = (uintptr_t)wordbox_rotl32(bits - WORDBOX_FLOAT32_ADDEND, WORDBOX_FLOAT_ROTATE);
@@ -379,8 +413,11 @@ mrb_word_boxing_value_float(mrb_value v)
 #if defined(MRB_64BIT) && defined(MRB_USE_FLOAT32)
   union mrb_value_ u;
   u.value = v;
-  u.w >>= 2;
-  return u.f;
+  if ((v.w & WORDBOX_FLOAT_MASK) == WORDBOX_FLOAT_FLAG) {
+    u.w >>= 2;
+    return u.f;
+  }
+  return mrb_rfloat_value(u.fp);
 #elif defined(MRB_64BIT)
   if ((v.w & WORDBOX_FLOAT_MASK) == WORDBOX_FLOAT_FLAG) {
     if (v.w <= WORDBOX_FLOAT_SENTINEL_MAX) {
@@ -389,7 +426,6 @@ mrb_word_boxing_value_float(mrb_value v)
       case WORDBOX_FLOAT_NZERO: return (mrb_float)(-0.0);
       case WORDBOX_FLOAT_PINF:  return (mrb_float)( INFINITY);
       case WORDBOX_FLOAT_NINF:  return (mrb_float)(-INFINITY);
-      case WORDBOX_FLOAT_NAN:   return (mrb_float)  NAN;
       default: break;  /* not reached */
       }
     }
@@ -410,7 +446,6 @@ mrb_word_boxing_value_float(mrb_value v)
       case WORDBOX_FLOAT_NZERO: return (mrb_float)(-0.0f);
       case WORDBOX_FLOAT_PINF:  return (mrb_float)( INFINITY);
       case WORDBOX_FLOAT_NINF:  return (mrb_float)(-INFINITY);
-      case WORDBOX_FLOAT_NAN:   return (mrb_float)  NAN;
       default: break;  /* not reached */
       }
     }

--- a/src/hash.c
+++ b/src/hash.c
@@ -410,9 +410,17 @@ obj_eql(mrb_state *mrb, mrb_value a, mrb_value b, struct RHash *h)
     return mrb_integer(a) == mrb_integer(b);
 
 #ifndef MRB_NO_FLOAT
-  case MRB_TT_FLOAT:
+  case MRB_TT_FLOAT: {
     if (!mrb_float_p(b)) return FALSE;
-    return mrb_float(a) == mrb_float(b);
+    mrb_float fa = mrb_float(a);
+    if (fa == mrb_float(b)) return TRUE;
+    /* A NaN is equal to no value, its own key included, so a Hash handed the
+       very key it stored would not find it again. The key it holds is that
+       object, and an object is the same key as itself. Only a key that is not
+       equal to itself asks, so what an ordinary key pays is the comparison
+       against the value already in hand. */
+    return fa != fa && mrb_obj_eq(mrb, a, b);
+  }
 #endif
 
   default:

--- a/test/t/float.rb
+++ b/test/t/float.rb
@@ -185,6 +185,51 @@ assert('a Float is the object that holds what it holds') do
   assert_false(nan == nan)
 end
 
+assert('a NaN is the object it is and no other') do
+  # A NaN is equal to no value, its own included, so `==` can never find one.
+  # A container searching for the NaN it holds has nothing but the object to go
+  # by, so every NaN made is one of its own: two NaNs made apart are two
+  # objects, and one copied around stays one.
+  #
+  # The two below are built at run time from a variable so that nothing folds
+  # them into a single literal, and every answer here is the same whichever
+  # boxing the build uses, which is what a NaN having an identity is for.
+  z = [0.0][0]
+  a = z / z
+  b = z / z
+  c = a
+
+  assert_predicate(a, :nan?)
+  assert_predicate(b, :nan?)
+
+  assert_true(a.equal?(a))
+  assert_true(a.equal?(c))          # the same object, passed around
+  assert_false(a.equal?(b))         # two NaNs, made apart
+  assert_false(a.equal?(Float::NAN))
+
+  # `object_id` names what `equal?` compares, so the two answer alike. Where a
+  # NaN is a heap object its id comes off the object, the bits every NaN holds
+  # being the same ones.
+  assert_equal(a.object_id, c.object_id)
+  assert_not_equal(a.object_id, b.object_id)
+
+  # The searches asked here are the ones core answers. `Array#include?` and
+  # `#count` are answered by mruby-array-ext and mruby-enum-ext, and are asked
+  # in the tests those gems carry.
+  assert_equal(0, [a].index(a))
+  assert_nil([a].index(b))
+  assert_true([1.0, a] == [1.0, a])
+  assert_false([1.0, a] == [1.0, b])
+  assert_equal(1, ({a => 1})[a])
+  assert_nil(({a => 1})[b])
+
+  # a Float that is equal to itself is found by what it is equal to
+  x = z + 1.5
+  y = z + 1.5
+  assert_equal(0, [x].index(y))
+  assert_equal(1, ({x => 1})[y])
+end
+
 assert('Float comparison with an Integer it cannot hold') do
   # A Float keeps fewer significant bits than an mrb_int, so an integer past
   # the significand rounds onto a neighbouring Float when the two are compared


### PR DESCRIPTION
## Summary

A NaN is equal to no value, its own operand included, so `==` can never find one. A container searching for the NaN it holds has nothing left but the object, and mruby gave it nothing to hold on to: every NaN was normalized to one representation, so a NaN was either the same object as every other NaN or, under `MRB_NO_BOXING`, not even the same object as itself.

```ruby
z = [0.0][0]; a = z / z; b = z / z   # two NaNs, made apart
```

## Changes

Five commits, each green on its own. The first four are the PRs this one is built on, and this PR shrinks to its last commit once they land:

| commit | PR |
| --- | --- |
| `array.c: take an Array element for equal to itself in #==` | #7359 |
| `mruby-array-ext: walk an Array in C for include? and member?` | #7360 |
| `mruby-enum-ext: count an Array in C` | #7361 |
| `object.c: compare what a Float holds bit for bit under MRB_NO_BOXING` | #7362 |
| `etc.c: give every NaN an identity of its own` | this one |

The four below it are what a NaN needs before an identity is worth giving it: the searches an array makes asking for the object, and an `equal?` that reads the same thing in every boxing. Each is worth having on its own and none of them mentions a NaN in its own right.

| File | What |
| --- | --- |
| `include/mruby/value.h` | adds `MRB_NAN_SERIAL_MAX`, `MRB_NAN_QUIET_BIT`, `mrb_float_bits` and `mrb_nan_serialize()`, for the boxings that put the count in the Float |
| `include/mruby.h` | adds `mrb_state.nan_serial` |
| `include/mruby/boxing_nan.h` | the count goes in the payload where a Float is made |
| `include/mruby/boxing_no.h` | the same, in `SET_FLOAT_VALUE` |
| `include/mruby/boxing_word.h` | a heap Float is a Float at every width now, the one exception having gone |
| `src/etc.c` | adds `mrb_nan_serial_next()`; word boxing hands every NaN to the heap and drops the sentinel it kept for one; `mrb_obj_id()` gives a heap NaN the id of the object it is |
| `src/hash.c` | a key that is not equal to itself is asked for the object |
| `test/t/float.rb` | `equal?`, `object_id`, `index`, `Array#==` and Hash lookup, for one NaN and for two made apart |
| `mrbgems/mruby-array-ext/test/array.rb` | `uniq`, `-`, `&` and `include?` with a NaN |
| `mrbgems/mruby-enum-ext/test/enum.rb` | `count` with a NaN |
| `mrbgems/mruby-pack/test/pack.rb` | a NaN that signals is read back as a NaN, and two reads are two objects |

The assertions are asked where the method they ask about is answered: `include?` and `count` are `mruby-array-ext`'s and `mruby-enum-ext`'s, so a build without those gems is not asked about them.

### Where the identity comes from

Every NaN made is now one of its own, and what carries that is whatever the boxing has room for.

- **word boxing** gives a NaN the heap, where the object it is answers for it and two objects are never one. A word that is not an immediate already points at an object, so no reader is asked anything new, and this is what CRuby does as well: a NaN falls outside the flonum range and is allocated, as an infinity is. The 32-bit `MRB_USE_FLOAT32` build already took this path for want of room in its word; it is the rule at every width now, which leaves the sentinel range at the four floats that are equal to themselves and drops the count that range used to carry.
- **nan boxing** and **no boxing** keep a Float in the value, so there is no object to be had and the NaN has to carry what tells it from another. That goes in the payload, which no arithmetic reads: a count, `mrb_state.nan_serial`, given every bit the payload can spare. That is **51 bits** under `MRB_NO_BOXING` and **48** under `MRB_NAN_BOXING`, where the tag saying which value a word holds begins.
- The count is written with the quiet bit set, which is what keeps every pattern it makes a NaN. A NaN that signals can have every bit it is set inside the field the count takes, and clearing those for a count of zero would leave the exponent alone, which is an infinity.

A count is a bound and an object is not, so the two differ in what a long run can reach. Holding one NaN while 2^51 more are made leaves two that hold the same bits; at the 50M NaNs a second this machine manages, that is over a year of making nothing else. **`MRB_USE_FLOAT32` under `MRB_NO_BOXING` is the one build where the bound is a near one**: a binary32 NaN has 22 payload bits and no more, so 4,194,304 NaNs bring the count round. There is no object to fall back on there, a Float being the value itself, and no other build is affected: `MRB_NAN_BOXING` refuses `MRB_USE_FLOAT32`, and word boxing keeps no count at all.

### What had to stop asking `==` alone

A **Hash** asks for the object where a key is not equal to itself, which only a NaN is, so the key it stored is found again. What an ordinary key pays is that comparison, made against the value already in hand.

**`mrb_obj_id()`** names what `equal?` compares, so the two have to agree. Under word boxing a Float that is not immediate is an object, and its id came off the bits it holds; every NaN holds the same bits, so two that `equal?` now tells apart would have shared an id. A NaN is given the id of the object it is, which is what the same function returns for everything else on the heap. The other boxings need nothing here: the count is in the payload, so the bits already differ.

The other callers are the commits below this one: `mrb_obj_eq()` reading a Float bit for bit under `MRB_NO_BOXING`, and `Array#==`, `#include?`, `#member?` and `#count` comparing a pair with `mrb_equal()`, as `#index` and `#delete` already did. Each is worth having on its own, and together they are what makes a NaN's identity reach an answer once it has one.

## Behaviour

Every row answers as CRuby does after the change, and the three boxings answer alike, which they did not before. Bold marks where a build differs from CRuby today.

| expression | word / nan boxing | `MRB_NO_BOXING` | this PR | CRuby |
| --- | --- | --- | --- | --- |
| `a.equal?(a)` | true | **false** | true | true |
| `a.equal?(b)` | **true** | false | false | false |
| `a.object_id == c.object_id` | true | true | true | true |
| `a.object_id == b.object_id` | **true** | **true** | false | false |
| `[a].index(a)` | 0 | **nil** | 0 | 0 |
| `[a].index(b)` | **0** | nil | nil | nil |
| `[a].include?(a)` | **false** | **false** | true | true |
| `[a].include?(b)` | false | false | false | false |
| `[a].count(a)` | **0** | **0** | 1 | 1 |
| `[a].count(b)` | 0 | 0 | 0 | 0 |
| `[1.0, a] == [1.0, a]` | **false** | **false** | true | true |
| `[1.0, a] == [1.0, b]` | false | false | false | false |
| `[a, a].uniq.size` | 1 | **2** | 1 | 1 |
| `[a, b].uniq.size` | **1** | 2 | 2 | 2 |
| `{a => 1}[a]` | **nil** | **nil** | 1 | 1 |
| `{a => 1}[b]` | nil | nil | nil | nil |
| `([a] - [b]).size` | **0** | 1 | 1 | 1 |
| `([a] & [a]).size` | 1 | **0** | 1 | 1 |
| `pzero.equal?(nzero)` | false | **true** | false | false |

Measured against CRuby 4.0.6, with `a` and `b` built at run time as `z / z` from `z = [0.0][0]`, and `pzero` and `nzero` as `z + 0.0` and `z * -1.0`. The `this PR` column is the same in every one of the twelve boxing builds listed under Testing.

## Speed

```ruby
t = 0.0; i = 0
while i < 1000000 do t += i * 0.5; i += 1 end           # Float arithmetic

h = {}; i = 0
while i < 100000 do h[i * 0.5] = i; i += 1 end          # Float-keyed Hash
i = 0
while i < 100000 do h[i * 0.5]; i += 1 end

z = [0.0][0]; i = 0
while i < 100000 do z / z; i += 1 end                   # NaNs made
```

Best of 11 interleaved runs against master, with a master-vs-master control to read the noise by, and the instruction counts callgrind reads beside them:

| benchmark | master | this PR | control | Ir |
| --- | --- | --- | --- | --- |
| `t += i * 0.5`, 1M turns | 377 ms | 394 ms (1.05x) | -0.1% | 523,999,972 -> 523,999,972 |
| Float-keyed Hash, 100k insert + 100k lookup | 42.5 ms | 43.0 ms (1.01x) | -0.2% | +0.43% |
| 100k NaNs made in a loop | 6.0 ms | **8.2 ms (1.37x)** | +1.7% | +45.8% |

The Float path is untouched and the first row says so: the same instruction count to the last one over a million turns, which is the same code either way; the wall clock difference beside it is layout, not work. What the Hash pays is the comparison a key now makes against itself, +0.43%.

The third row is what this costs. A NaN takes an object under word boxing now, and the loop pays about 174 instructions for each one it makes. That is the trade the design makes, and it is the one CRuby makes too: a NaN is not a flonum there either. Nothing pays it but a program making NaNs, which is a program on an error path.

The wall clock times were taken with the default build, which carries all four commits; the two arriving from the PRs below do not touch any of these three loops, and their instruction counts against master are identical.

## Size

`bin/mruby` `.text` for every build in `build_config/ci/gcc-clang.rb`, for all five commits:

| build | master | this PR | delta |
| --- | --- | --- | --- |
| `ascii-ctype` | 1,293,718 | 1,294,198 | +480 |
| `bintest` | 1,307,110 | 1,307,590 | +480 |
| `byte-string` | 1,271,494 | 1,271,974 | +480 |
| `cxx_abi` | 1,334,041 | 1,334,601 | +560 |
| `full-debug` (-O0) | 1,913,478 | 1,914,182 | +704 |

In `bintest` five objects add up to the +480 exactly, and **208 of it is this commit**:

| object | delta | commit |
| --- | --- | --- |
| `src/array.o` | **-80** | `Array#==` |
| `mruby-array-ext/src/array.o` | +144 | `include?` / `member?` |
| `mruby-enum-ext/src/enum.o` | +208 | `count` |
| `src/hash.o` | +240 | this one |
| `src/etc.o` | **-32** | this one |

`etc.o` shrinks on balance: the sentinel range word boxing kept for a NaN and the count that range carried are gone, against the test `mrb_obj_id()` now makes. `object.o` is unchanged, its edit being under `MRB_NO_BOXING`.

## Testing

`rake test` passes for the default build, for `build_config/host-nofloat.rb`, and for every build in `build_config/ci/gcc-clang.rb` including the C++ ABI one, with no compiler warnings. The one `-Wmaybe-uninitialized` about `eq` in `hash.c` that a `MRB_NO_BOXING` build emits is master's, unmoved by the edit beside it.



Because the change is one the boxing decides, it was also run over twelve builds of the full-core gembox:

- 64-bit: `MRB_NO_BOXING`, `MRB_WORD_BOXING` and `MRB_NAN_BOXING`, and the first two again with `MRB_USE_FLOAT32` (which nan boxing refuses).
- 32-bit: the same three, `MRB_USE_FLOAT32` with `MRB_INT32` under the first two, and `MRB_WORDBOX_NO_INLINE_FLOAT` at both float widths, which covers the Float that never sits in a word.

Seven of the twelve pass outright. The five `MRB_USE_FLOAT32` builds fail exactly what they fail on master: three assertions about how many digits a binary32 prints (`Float#to_s`, `mrb_vformat` and one in mruby-sprintf) and one crash, none of them about a NaN, and the counts are the same before and after this change. Each of the five commits was built and run on its own, so none of them is red in the middle.

The tests added build their two NaNs at run time from a variable so that nothing folds them into a single literal, and assert the same answers in every boxing, which is the point of the change. The one in `mrbgems/mruby-pack/test/pack.rb` is there rather than in `test/t/` because a NaN that signals cannot be spelled without `unpack`: it reads such a pattern back and asks that it be a NaN and that two reads be two objects.

## Environment

<details>
<summary>Machine, toolchain and the compile lines these numbers were taken with</summary>

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-30-generic x86_64 |
| CPU | AMD Ryzen 9 5950X (16 cores) |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0 |
| 32-bit compiler | i686-linux-gnu-gcc 13.3.0 |
| binutils | GNU ld (GNU Binutils) 2.47.20260726 |
| valgrind | valgrind-3.27.1 (callgrind) |
| CRuby | 4.0.6 (2026-07-14 revision 03b6d3f889) |

The wall clock and instruction counts were taken with the default build:

```console
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK
```

The `## Size` table was taken with `build_config/ci/gcc-clang.rb`:

```console
bintest      gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK
ascii-ctype  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
byte-string  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
cxx_abi      gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
full-debug   gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

`cxx_abi` compiles mruby as C++ with `gcc -x c++ -std=gnu++03`; g++ only links. `full-debug` is the one build at `-O0`, `enable_debug` putting `-g3 -O0` after the toolchain default of `-g -O3`.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of `NaN` values so each independently created value maintains distinct object identity.
  * Updated array and hash operations to correctly recognize the exact `NaN` instance being searched for.
  * Preserved signaling `NaN` values when unpacking floating-point data.
  * Improved `NaN` recognition and behavior across supported floating-point formats.
* **Tests**
  * Added coverage for `NaN` comparisons, collection operations, identity-based lookups, and floating-point edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->