### PR TITLE
mruby-regexp: keep a Regexp's source and compiled pattern in step

### DIFF
--- a/mrbgems/mruby-regexp/mrblib/regexp.rb
+++ b/mrbgems/mruby-regexp/mrblib/regexp.rb
@@ -7,6 +7,7 @@ class Regexp
   # @named_captures holds the internal name -> group_number table, so a fresh
   # Hash is derived on every call and the caller cannot corrupt the table.
   def named_captures
+    __check_initialized
     table = @named_captures
     return {} unless table
     result = {}
@@ -16,9 +17,16 @@ class Regexp
 
   # Return the capture names in group order
   def names
+    __check_initialized
     table = @named_captures
     table ? table.keys : []
   end
+
+  # The two readers above are readings of a compiled pattern, and an object
+  # from Regexp.allocate has none: no @source, no @flags, no capture table.
+  # An empty table there is indistinguishable from a pattern that named
+  # nothing, so they refuse it through the same guard the C readers use
+  # (re_check_initialized() in src/regexp.c, reached by __check_initialized).
 
   # options is implemented in C (internal flags -> Ruby constants conversion)
 

--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -89,39 +89,19 @@ parse_flags(mrb_state *mrb, mrb_value flags_val)
   return flags;
 }
 
-/*
- * Regexp.new(pattern, flags=nil)
- * Regexp.new(regexp)
- * Regexp.compile(pattern, flags=nil)
- */
+/* Compile `pattern` under `flags` into `self` and publish everything a Regexp
+   answers from. `Regexp.new` and `dup`/`clone` differ only in where the two
+   come from, so they share this and cannot drift apart in what they leave
+   behind. */
 static mrb_value
-regexp_init(mrb_state *mrb, mrb_value self)
+re_initialize(mrb_state *mrb, mrb_value self, mrb_value pattern, uint32_t flags)
 {
-  mrb_value pattern;
-  mrb_value flags_val = mrb_nil_value();
   mrb_regexp_pattern *pat;
-
-  mrb_get_args(mrb, "o|o", &pattern, &flags_val);
-
-  uint32_t flags;
-
-  /* If pattern is a Regexp, copy its source and flags */
-  if (mrb_obj_is_kind_of(mrb, pattern, mrb_class_get_id(mrb, MRB_SYM(Regexp)))) {
-    mrb_value iflags = mrb_iv_get(mrb, pattern, MRB_IVSYM(flags));
-    flags = mrb_nil_p(iflags) ? 0 : (uint32_t)mrb_integer(iflags);
-    pattern = mrb_iv_get(mrb, pattern, MRB_IVSYM(source));
-  }
-  else {
-    if (!mrb_string_p(pattern)) {
-      mrb_raise(mrb, E_TYPE_ERROR, "wrong argument type (expected String or Regexp)");
-    }
-    flags = parse_flags(mrb, flags_val);
-  }
 
   /* An object holds one pattern and owns it, so a second initialize cannot
      compile over the first: the pattern already there would be dropped with
      nothing left to free it. CRuby refuses the call for the same reason. The
-     check stands after the argument conversions above, which is the order
+     check stands after the caller's argument conversions, which is the order
      CRuby reports the two errors in. */
   if (DATA_PTR(self)) {
     mrb_raise(mrb, E_TYPE_ERROR, "already initialized regexp");
@@ -154,8 +134,79 @@ regexp_init(mrb_state *mrb, mrb_value self)
     }
     mrb_iv_set(mrb, self, MRB_IVSYM(named_captures), nc);
   }
+  else {
+    /* The table belongs to the pattern compiled just above, so a pattern that
+       names nothing has to leave nothing behind. A copy arrives here with the
+       original's table already on it, mrb_iv_copy() having run before
+       initialize_copy(), and an original whose @source was rewritten to a
+       pattern with no names would hand the copy names its own pattern cannot
+       resolve. Regexp.new reaches this on an object that has no table to
+       remove. */
+    mrb_iv_remove(mrb, self, MRB_IVSYM(named_captures));
+  }
 
   return self;
+}
+
+/*
+ * Regexp.new(pattern, flags=nil)
+ * Regexp.new(regexp)
+ * Regexp.compile(pattern, flags=nil)
+ */
+static mrb_value
+regexp_init(mrb_state *mrb, mrb_value self)
+{
+  mrb_value pattern;
+  mrb_value flags_val = mrb_nil_value();
+  uint32_t flags;
+
+  mrb_get_args(mrb, "o|o", &pattern, &flags_val);
+
+  /* If pattern is a Regexp, copy its source and flags */
+  if (mrb_obj_is_kind_of(mrb, pattern, mrb_class_get_id(mrb, MRB_SYM(Regexp)))) {
+    flags = get_iflags(mrb, pattern);
+    pattern = mrb_iv_get(mrb, pattern, MRB_IVSYM(source));
+  }
+  else {
+    if (!mrb_string_p(pattern)) {
+      mrb_raise(mrb, E_TYPE_ERROR, "wrong argument type (expected String or Regexp)");
+    }
+    flags = parse_flags(mrb, flags_val);
+  }
+
+  return re_initialize(mrb, self, pattern, flags);
+}
+
+/*
+ * Regexp#initialize_copy - what dup and clone leave the copy holding
+ *
+ * The compiled pattern is not part of what mrb_iv_copy() carries over, and it
+ * cannot be: one pattern is owned by one object and freed with it, so a copy
+ * that took the original's pointer would hand regexp_free() the same block
+ * twice. Without this the copy kept the original's @source and @flags and
+ * nothing else, which made it a Regexp that answered source/options/to_s/==
+ * correctly and then refused every match on a NULL DATA_PTR. The copy compiles
+ * its own pattern from the same source and flags instead, which is what CRuby's
+ * rb_reg_init_copy() does.
+ */
+static mrb_value
+regexp_init_copy(mrb_state *mrb, mrb_value self)
+{
+  mrb_value orig = mrb_get_arg1(mrb);
+
+  if (mrb_obj_eq(mrb, self, orig)) return self;
+  if (mrb_type(self) != mrb_type(orig) || mrb_obj_class(mrb, self) != mrb_obj_class(mrb, orig)) {
+    mrb_raise(mrb, E_TYPE_ERROR, "initialize_copy should take same class object");
+  }
+
+  /* The copy is compiled from the original's source, so an original that
+     has none is refused here rather than handed to the compiler as a nil.
+     CRuby's rb_reg_init_copy() refuses Regexp.allocate.dup the same way. */
+  mrb_value src = mrb_iv_get(mrb, orig, MRB_IVSYM(source));
+  if (!mrb_string_p(src)) {
+    mrb_raise(mrb, E_TYPE_ERROR, "uninitialized Regexp");
+  }
+  return re_initialize(mrb, self, src, get_iflags(mrb, orig));
 }
 
 /* Pre-interned symbol for $~ (cached on first use). MRB_GVSYM() takes a
@@ -2178,6 +2229,7 @@ mrb_mruby_regexp_gem_init(mrb_state *mrb)
 
   /* Class methods */
   mrb_define_method(mrb, re, "initialize", regexp_init, MRB_ARGS_ARG(1, 2));
+  mrb_define_method(mrb, re, "initialize_copy", regexp_init_copy, MRB_ARGS_REQ(1));
   /* compile is defined in Ruby (mrblib) as alias for new */
   mrb_define_class_method(mrb, re, "escape", regexp_escape, MRB_ARGS_REQ(1));
   mrb_define_class_method(mrb, re, "quote", regexp_escape, MRB_ARGS_REQ(1));

--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -36,6 +36,41 @@ re_uninitialized_p(const mrb_regexp_pattern *pat)
   return !pat || pat->code_len == 0;
 }
 
+/* The pattern text a reader answers from, or TypeError when there is none.
+   Regexp.allocate is on every class and hands out an object that never went
+   through re_initialize(): no @source, no @flags, a NULL DATA_PTR. The
+   matchers already refuse it through DATA_GET_PTR(), and the readers below
+   refuse it here, as CRuby's rb_reg_check() does at the top of each of its
+   own.
+
+   Both fields are tested because they answer different questions and each is
+   reachable without the other:
+
+   - DATA_PTR says whether the object was ever initialized. It is the one
+     field only re_initialize() writes: mrb_iv_copy() does not carry it to a
+     copy and no instance_variable_set() can forge it, so a NULL there is an
+     object that never went through re_initialize() however it was made:
+     Regexp.allocate's, or a copy from a subclass that overrode
+     initialize_copy without calling super. It is set before the compile
+     starts, so a Regexp whose compile raised still passes here and goes on
+     answering hash/eql?/inspect from the source it does have (see the
+     comment in re_initialize()).
+
+   - @source is what the readers below hand to mrb_str_cat_str() and
+     RSTRING_PTR(), which take an RString and dereference it as one. It is an
+     ordinary IV, so instance_variable_set() can put anything behind it, and
+     checking the type here is what keeps that a TypeError rather than a
+     read through whatever was stored. */
+static mrb_value
+re_check_initialized(mrb_state *mrb, mrb_value re)
+{
+  mrb_value src = mrb_iv_get(mrb, re, MRB_IVSYM(source));
+  if (!DATA_PTR(re) || !mrb_string_p(src)) {
+    mrb_raise(mrb, E_TYPE_ERROR, "uninitialized Regexp");
+  }
+  return src;
+}
+
 /* MatchData */
 typedef struct {
   mrb_value source;        /* source string */
@@ -165,7 +200,9 @@ regexp_init(mrb_state *mrb, mrb_value self)
   /* If pattern is a Regexp, copy its source and flags */
   if (mrb_obj_is_kind_of(mrb, pattern, mrb_class_get_id(mrb, MRB_SYM(Regexp)))) {
     flags = get_iflags(mrb, pattern);
-    pattern = mrb_iv_get(mrb, pattern, MRB_IVSYM(source));
+    /* Copying is a reading of the argument's source, so an argument that has
+       none is refused here rather than compiled from a nil below. */
+    pattern = re_check_initialized(mrb, pattern);
   }
   else {
     if (!mrb_string_p(pattern)) {
@@ -199,13 +236,9 @@ regexp_init_copy(mrb_state *mrb, mrb_value self)
     mrb_raise(mrb, E_TYPE_ERROR, "initialize_copy should take same class object");
   }
 
-  /* The copy is compiled from the original's source, so an original that
-     has none is refused here rather than handed to the compiler as a nil.
-     CRuby's rb_reg_init_copy() refuses Regexp.allocate.dup the same way. */
-  mrb_value src = mrb_iv_get(mrb, orig, MRB_IVSYM(source));
-  if (!mrb_string_p(src)) {
-    mrb_raise(mrb, E_TYPE_ERROR, "uninitialized Regexp");
-  }
+  /* Copying is a reading of the original's source, so an original that has
+     none is refused here as it is in regexp_init(). */
+  mrb_value src = re_check_initialized(mrb, orig);
   return re_initialize(mrb, self, src, get_iflags(mrb, orig));
 }
 
@@ -747,12 +780,26 @@ regexp_case_match(mrb_state *mrb, mrb_value self)
 }
 
 /*
+ * Regexp#__check_initialized - the guard above, for the readers in mrblib
+ *
+ * `names` and `named_captures` are readings of a compiled pattern too, and
+ * only this side can see DATA_PTR, so they raise through here rather than
+ * testing @source from Ruby and missing what an IV cannot show.
+ */
+static mrb_value
+regexp_check_initialized(mrb_state *mrb, mrb_value self)
+{
+  re_check_initialized(mrb, self);
+  return self;
+}
+
+/*
  * Regexp#source
  */
 static mrb_value
 regexp_source(mrb_state *mrb, mrb_value self)
 {
-  return mrb_iv_get(mrb, self, MRB_IVSYM(source));
+  return re_check_initialized(mrb, self);
 }
 
 /*
@@ -763,6 +810,7 @@ regexp_source(mrb_state *mrb, mrb_value self)
 static mrb_value
 regexp_options(mrb_state *mrb, mrb_value self)
 {
+  re_check_initialized(mrb, self);
   uint32_t iflags = get_iflags(mrb, self);
   mrb_int opts = 0;
   if (iflags & RE_FLAG_IGNORECASE) opts |= 1;  /* Regexp::IGNORECASE */
@@ -777,6 +825,7 @@ regexp_options(mrb_state *mrb, mrb_value self)
 static mrb_value
 regexp_casefold_p(mrb_state *mrb, mrb_value self)
 {
+  re_check_initialized(mrb, self);
   return mrb_bool_value((get_iflags(mrb, self) & RE_FLAG_IGNORECASE) != 0);
 }
 
@@ -818,7 +867,7 @@ mrb_re_flags_cat(mrb_state *mrb, mrb_value str, uint32_t flags)
 static mrb_value
 regexp_to_s(mrb_state *mrb, mrb_value self)
 {
-  mrb_value src = mrb_iv_get(mrb, self, MRB_IVSYM(source));
+  mrb_value src = re_check_initialized(mrb, self);
   uint32_t flags = get_iflags(mrb, self);
   char off[RE_FLAG_LETTER_COUNT];
   mrb_int noff = 0;
@@ -846,7 +895,22 @@ static mrb_value
 regexp_inspect(mrb_state *mrb, mrb_value self)
 {
   mrb_value src = mrb_iv_get(mrb, self, MRB_IVSYM(source));
-  uint32_t flags = get_iflags(mrb, self);
+  uint32_t flags;
+
+  /* The one reader that answers for an uninitialized Regexp instead of
+     raising: an inspect that raises would leave the object undisplayable in
+     a backtrace or a debugger, which is where it is most likely to be met.
+     CRuby's rb_reg_inspect falls back to the default form for the same
+     reason, and this prints that same `#<Regexp:0x...>`.
+
+     What it falls back on is the pair re_check_initialized() raises on, so
+     the same objects are refused here and displayed rather than read: a
+     written or inherited @source without a pattern behind it prints the
+     default form, as it does in CRuby, where @source is not an IV at all and
+     rb_reg_inspect tests the pattern for itself. */
+  if (!DATA_PTR(self) || !mrb_string_p(src)) return mrb_any_to_s(mrb, self);
+
+  flags = get_iflags(mrb, self);
 
   mrb_value result = mrb_str_new_lit(mrb, "/");
   mrb_str_cat_str(mrb, result, src);
@@ -863,14 +927,14 @@ regexp_eql(mrb_state *mrb, mrb_value self)
 {
   mrb_value other;
   mrb_get_args(mrb, "o", &other);
+  /* The one object equal to an uninitialized Regexp is itself: identity holds
+     without reading either source, which is what CRuby answers first too. */
+  if (mrb_obj_eq(mrb, self, other)) return mrb_true_value();
   if (!mrb_obj_is_kind_of(mrb, other, mrb_class_get_id(mrb, MRB_SYM(Regexp)))) {
     return mrb_false_value();
   }
-  mrb_value src1 = mrb_iv_get(mrb, self, MRB_IVSYM(source));
-  mrb_value src2 = mrb_iv_get(mrb, other, MRB_IVSYM(source));
-  if (!mrb_string_p(src1) || !mrb_string_p(src2)) {
-    return mrb_bool_value(mrb_obj_eq(mrb, self, other));
-  }
+  mrb_value src1 = re_check_initialized(mrb, self);
+  mrb_value src2 = re_check_initialized(mrb, other);
   if (!mrb_str_equal(mrb, src1, src2)) return mrb_false_value();
   return mrb_bool_value(get_iflags(mrb, self) == get_iflags(mrb, other));
 }
@@ -881,8 +945,8 @@ regexp_eql(mrb_state *mrb, mrb_value self)
 static mrb_value
 regexp_hash(mrb_state *mrb, mrb_value self)
 {
-  mrb_value src = mrb_iv_get(mrb, self, MRB_IVSYM(source));
-  uint32_t h = mrb_string_p(src) ? mrb_str_hash(mrb, src) : 0;
+  mrb_value src = re_check_initialized(mrb, self);
+  uint32_t h = mrb_str_hash(mrb, src);
   h ^= get_iflags(mrb, self) * 0x9e3779b9;  /* mix flags into hash */
   return mrb_int_value(mrb, (mrb_int)h);
 }
@@ -2230,6 +2294,7 @@ mrb_mruby_regexp_gem_init(mrb_state *mrb)
   /* Class methods */
   mrb_define_method(mrb, re, "initialize", regexp_init, MRB_ARGS_ARG(1, 2));
   mrb_define_method(mrb, re, "initialize_copy", regexp_init_copy, MRB_ARGS_REQ(1));
+  mrb_define_private_method(mrb, re, "__check_initialized", regexp_check_initialized, MRB_ARGS_NONE());
   /* compile is defined in Ruby (mrblib) as alias for new */
   mrb_define_class_method(mrb, re, "escape", regexp_escape, MRB_ARGS_REQ(1));
   mrb_define_class_method(mrb, re, "quote", regexp_escape, MRB_ARGS_REQ(1));

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -324,15 +324,54 @@ assert("Regexp#hash") do
   assert_not_equal r1.hash, r3.hash
 end
 
-assert("Regexp#hash/== on uninitialized regexp") do
-  # Regexp.allocate yields an object with no @source IV; hash/== must
-  # not crash (regression: ObjectSpace.each_object could expose a
-  # half-initialized Regexp after Regexp.new raised a compile error).
+assert("Regexp readers on an uninitialized regexp") do
+  # Regexp.allocate hands out an object with no @source, no @flags and no
+  # compiled pattern; every reader is a reading of that missing state and
+  # raises TypeError rather than crashing on it or answering from nothing.
   r = Regexp.allocate
-  assert_kind_of Integer, r.hash
+  assert_raise(TypeError) { r.source }
+  assert_raise(TypeError) { r.options }
+  assert_raise(TypeError) { r.casefold? }
+  assert_raise(TypeError) { r.names }
+  assert_raise(TypeError) { r.named_captures }
+  assert_raise(TypeError) { r.hash }
+  assert_raise(TypeError) { r.to_s }
+  assert_raise(TypeError) { r == Regexp.allocate }
+  assert_raise(TypeError) { r == Regexp.new("abc") }
+  assert_raise(TypeError) { Regexp.new(r) }
+  # identity answers without reading either source
   assert_true r == r
-  assert_false r == Regexp.allocate
+  # and a non-Regexp is unequal before the source is looked at
+  assert_false r == "abc"
+  # inspect is the one reader that answers, so the object stays displayable
+  assert_kind_of String, r.inspect
+  assert_not_equal "//", r.inspect
+end
+
+class RegexpFailedCompile < Regexp
+  def initialize
+    super("(")
+  rescue RegexpError
+  end
+end
+
+assert("Regexp readers on a regexp whose compile raised") do
+  # regexp_init() sets @source and @flags before it compiles, so this object
+  # has a source to answer from where the allocated one has none; it must
+  # keep answering the readers that do not need the compiled pattern.
+  r = RegexpFailedCompile.new
+  assert_equal "(", r.source
+  assert_equal 0, r.options
+  assert_false r.casefold?
+  assert_equal [], r.names
+  assert_equal({}, r.named_captures)
+  assert_kind_of Integer, r.hash
+  assert_equal "/(/", r.inspect
+  assert_equal "(?-mix:()", r.to_s
+  assert_true r == RegexpFailedCompile.new
   assert_false r == Regexp.new("abc")
+  # but matching against it is still refused
+  assert_raise(ArgumentError) { r =~ "(" }
 end
 
 assert("Regexp#dup and Regexp#clone") do
@@ -376,6 +415,49 @@ assert("Regexp#dup and Regexp#clone") do
   assert_true frozen.clone.frozen?
   assert_true frozen.clone.match?("A")
   assert_false frozen.dup.frozen?
+end
+
+assert("Regexp readers on a copy that never reached initialize_copy") do
+  # A subclass can override initialize_copy and never call super, which leaves
+  # the copy holding the original's @source and @flags and no pattern at all.
+  # The readers answer from the compiled pattern, so they refuse it the way
+  # they refuse Regexp.allocate: what says the object was initialized is
+  # DATA_PTR, which no IV copy carries over, not the source it inherited.
+  c = Class.new(Regexp) do
+    def initialize_copy(other)
+      self
+    end
+  end
+  d = c.new("(?<n>a)").dup
+  assert_raise(TypeError) { d.source }
+  assert_raise(TypeError) { d.options }
+  assert_raise(TypeError) { d.casefold? }
+  assert_raise(TypeError) { d.to_s }
+  assert_raise(TypeError) { d.hash }
+  assert_raise(TypeError) { d.names }
+  assert_raise(TypeError) { d.named_captures }
+  assert_raise(TypeError) { d == Regexp.new("a") }
+  assert_raise(TypeError) { d.match?("a") }
+  # inspect answers rather than raising, but it answers about the object it
+  # has, not about the source it inherited
+  assert_true d.inspect.start_with?("#<")
+
+  # nor can an IV write alone make an uninitialized Regexp answer
+  a = Regexp.allocate
+  a.instance_variable_set(:@source, "a")
+  a.instance_variable_set(:@flags, 0)
+  assert_raise(TypeError) { a.to_s }
+  assert_raise(TypeError) { a.source }
+  assert_raise(TypeError) { a.hash }
+  assert_true a.inspect.start_with?("#<")
+
+  # and an initialized Regexp whose @source was replaced raises rather than
+  # reading whatever was put there as a String
+  r = Regexp.new("a")
+  r.instance_variable_set(:@source, nil)
+  assert_raise(TypeError) { r.to_s }
+  assert_raise(TypeError) { r.source }
+  assert_kind_of String, r.inspect
 end
 
 assert("Regexp#initialize_copy") do

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -335,6 +335,61 @@ assert("Regexp#hash/== on uninitialized regexp") do
   assert_false r == Regexp.new("abc")
 end
 
+assert("Regexp#dup and Regexp#clone") do
+  # The compiled pattern cannot be shared with the copy, since one pattern is
+  # owned by one object, so the copy compiles its own from the same source and
+  # flags. Without that it answered the readers and refused every match.
+  r = Regexp.new("ab(?<n>c)", Regexp::IGNORECASE)
+  [r.dup, r.clone].each do |c|
+    assert_equal r.source, c.source
+    assert_equal r.options, c.options
+    assert_equal r.to_s, c.to_s
+    assert_equal r.names, c.names
+    assert_equal r.named_captures, c.named_captures
+    assert_true c == r
+    assert_equal r.hash, c.hash
+    assert_true c.match?("xABCy")
+    assert_equal 1, c =~ "xABCy"
+    assert_equal "C", c.match("xABCy")[:n]
+    assert_equal "x-y", "xABCy".gsub(c, "-")
+  end
+  # the copy owns its own pattern, so the original outlives it and vice versa
+  c = r.dup
+  100.times { r.dup }
+  GC.start
+  assert_true c.match?("ABC")
+  assert_true r.match?("ABC")
+  # a copy of a subclass instance is compiled the same way
+  sub = Class.new(Regexp).new("a+")
+  assert_true sub.dup.match?("aaa")
+  # the capture names belong to the pattern the copy compiled, not to the
+  # table it inherited, so a source that names nothing leaves it none
+  n = Regexp.new("(?<n>a)")
+  n.instance_variable_set(:@source, "b")
+  assert_equal [], n.dup.names
+  assert_equal({}, n.dup.named_captures)
+  m = Regexp.new("(?<n>a)")
+  m.instance_variable_set(:@source, "(?<z>b)")
+  assert_equal ["z"], m.dup.names
+  # clone carries the frozen state, and a frozen original still copies
+  frozen = Regexp.new("a", Regexp::IGNORECASE).freeze
+  assert_true frozen.clone.frozen?
+  assert_true frozen.clone.match?("A")
+  assert_false frozen.dup.frozen?
+end
+
+assert("Regexp#initialize_copy") do
+  # an original with no source has nothing to compile the copy from
+  assert_raise(TypeError) { Regexp.allocate.dup }
+  assert_raise(TypeError) { Regexp.allocate.clone }
+  # reachable directly, so it refuses what dup and clone cannot hand it
+  assert_raise(TypeError) { Regexp.new("a").dup.send(:initialize_copy, Regexp.new("b")) }
+  assert_raise(TypeError) { Regexp.new("a").dup.send(:initialize_copy, "b") }
+  # copying onto itself is a no-op, not a second compile
+  r = Regexp.new("a")
+  assert_true r.send(:initialize_copy, r).match?("a")
+end
+
 assert("Regexp#options") do
   assert_equal 0, Regexp.new("abc").options
   assert_equal Regexp::IGNORECASE, Regexp.new("abc", Regexp::IGNORECASE).options


### PR DESCRIPTION
## Summary

A Regexp keeps its state in two independent places: the `@source`/`@flags` IVs, and the compiled pattern behind `DATA_PTR`. Only `Regexp.new` set both, so every other way of producing a Regexp left the pair out of step. `dup` and `clone` gave back a Regexp that answered every reader correctly and matched nothing, and `Regexp.allocate` gave the readers a nil `@source` that `mrb_str_cat_str()` dereferenced as an `RString`.

## Changes

| File | What |
| --- | --- |
| `mrbgems/mruby-regexp/src/regexp.c` | adds `re_initialize()`, the compile `regexp_init()` used to hold, and `Regexp#initialize_copy` on top of it; adds `re_check_initialized()`, the guard, and the private `Regexp#__check_initialized`; `source`, `options`, `casefold?`, `to_s`, `==`/`eql?` and `hash` read through the guard, and `inspect` falls back to `mrb_any_to_s()` on the same pair; `re_initialize()` takes away a capture-name table the copy inherited when the pattern it compiled names nothing |
| `mrbgems/mruby-regexp/mrblib/regexp.rb` | `names` and `named_captures` call `__check_initialized` first |
| `mrbgems/mruby-regexp/test/regexp.rb` | adds `dup`/`clone` and `initialize_copy`, and replaces `Regexp#hash/== on uninitialized regexp` with the allocated Regexp, one whose compile raised, and the copies an IV can forge |

### `dup` and `clone`

`Regexp` defined no `initialize_copy`, and the compiled pattern is not part of what `mrb_iv_copy()` carries over. It cannot be: one `mrb_regexp_pattern` is owned by one object and freed with it, so a copy holding the original's pointer would hand `regexp_free()` the same block twice. The copy therefore kept `@source` and `@flags` and nothing else:

```ruby
r = /ab(c)/i
r.dup.source         # => "ab(c)"          (correct)
r.dup.to_s           # => "(?i-mx:ab(c))"  (correct)
r.dup == r           # => true             (correct)
r.dup.match?("ABC")  # mruby: TypeError    CRuby: true
```

Every matcher raised `TypeError` on the NULL `DATA_PTR`. A valid Regexp became unusable, and silently: every reader kept answering correctly, so nothing but an actual match told you.

`Regexp#initialize_copy` compiles the copy's own pattern from the same source and flags, which is what CRuby's `rb_reg_init_copy()` does. The body `regexp_init()` already had is factored out as `re_initialize()` so the two entry points cannot drift apart in what they leave behind, and an original with no source is refused where the copy would be compiled from it, as CRuby refuses `Regexp.allocate.dup`.

The capture-name table is part of what the compile leaves behind, and `mrb_iv_copy()` runs before `initialize_copy()`, so a pattern that names nothing takes away the table the copy arrived holding. Without that, a copy of an original whose `@source` was replaced with a pattern naming nothing would answer `names` and `named_captures` with names its own pattern cannot resolve, which `MatchData#[]` then refuses.

### The readers on an uninitialized Regexp

`Regexp.allocate` is on every class and hands out an object that never went through the initializer: no `@source`, no `@flags`, a NULL `DATA_PTR`. The matchers already refused it through `DATA_GET_PTR()`, but the readers did not. `to_s` and `inspect` passed the nil `@source` to `mrb_str_cat_str()` and `Regexp.new(re)` passed it to `RSTRING_PTR()`, both of which take an `RString` and dereference it as one; all three segfaulted. `source`, `options`, `casefold?`, `names`, `named_captures`, `hash` and `==` answered from state that was never set.

A single `re_check_initialized()` raises `TypeError, "uninitialized Regexp"`, which is where CRuby's `rb_reg_check()` sits and what it raises. Two readers answer instead of raising, as CRuby does: `inspect` prints the default `#<Regexp:0x...>` form, so the object stays displayable in a backtrace or a debugger, which is where it is most likely to be met, and it falls back on the same pair the guard raises on, so a written or inherited `@source` with no pattern behind it prints that form too, as `rb_reg_inspect()` does by testing the pattern for itself; and `==` answers identity, and a non-Regexp, before either source is read.

The guard tests `DATA_PTR` and the type of `@source`, and the two halves answer different questions. `DATA_PTR` is what says the object was initialized: only `re_initialize()` writes it, no copy carries it, and no IV write can forge it. `@source` on its own would not say that, being an ordinary IV, and two objects that never reached the initializer would still answer through it: a copy from a subclass that overrides `initialize_copy` without calling `super`, which inherits the source and no pattern, and an allocated Regexp with a source written onto it. The `@source` type check is the other half, covering the value that `mrb_str_cat_str()` and `RSTRING_PTR()` dereference as an `RString`, which `DATA_PTR` says nothing about; dropping it would put `r.instance_variable_set(:@source, nil); r.to_s` back on the crashing path.

`names` and `named_captures` live in mrblib, where `DATA_PTR` cannot be seen, so they reach the same guard through a private `__check_initialized` rather than testing `@source` from Ruby.

## Behaviour

| how the Regexp was made | `@source` | `DATA_PTR` | before | after |
| --- | --- | --- | --- | --- |
| `Regexp.new`, and a literal (which compiles to `Regexp.compile`) | ✓ | ✓ | fine | unchanged |
| `dup` / `clone` | ✓ | **NULL** | **a valid Regexp that cannot match** | compiles its own pattern, as CRuby |
| `Regexp.allocate` | — | NULL | **SIGSEGV** in `to_s`/`inspect`/`Regexp.new(re)`; `source`/`options`/`hash`/… answered from nothing | `TypeError`, as CRuby (`inspect` prints the default form) |
| copy from a subclass overriding `initialize_copy` without `super`; `allocate` plus an `instance_variable_set(:@source, …)` | ✓ | NULL | readers answered from an inherited or written source | `TypeError`, as CRuby (`inspect` prints the default form) |
| compile raised, reachable through a rescued `Regexp.new` | ✓ | empty pattern | readers answer, matchers refuse | unchanged |

Every row was run against CRuby 4.0.6, and the after column matches it except the last. There `Regexp.new` sets the IVs before it compiles, so the object keeps a source and goes on answering `source`, `options`, `casefold?`, `names`, `named_captures`, `hash`, `inspect`, `to_s` and `==` from it while the matchers refuse it; CRuby raises `TypeError` from all of them, because it never gets as far as writing anything onto the object. That is what the initializer's own comment already describes, it is not one of the out-of-step paths this closes, and changing it is a separate question, so it is left as it is and pinned by a test.

Two divergences from CRuby remain, both pre-existing and outside this change. The matchers report `uninitialized Regexp (expected Regexp)` where CRuby says `uninitialized Regexp`; the class and the reason are the same and only the wording differs, since the text comes from `DATA_GET_PTR()`. And `{Regexp.allocate => 1}` succeeds because mruby's small-hash linear scan never calls `hash` for any object, which is not Regexp-specific.

## Size

`bin/mruby` `.text` under `build_config/ci/gcc-clang.rb`, both sides built at the same path from an empty build directory. The figures predate the `mrb_iv_remove()` in `re_initialize()` and the `DATA_PTR` test in `inspect`, which are not in them.

| build | master | this PR | delta |
| --- | --- | --- | --- |
| `bintest` | 1,307,110 | 1,308,342 | +1,232 |
| `ascii-ctype` | 1,293,718 | 1,294,950 | +1,232 |
| `byte-string` | 1,271,494 | 1,272,726 | +1,232 |
| `cxx_abi` | 1,334,041 | 1,335,289 | +1,248 |
| `full-debug` (-O0) | 1,913,478 | 1,913,974 | +496 |

All of it is `regexp.o`'s `.text` (27,413 → 28,645 in the `bintest` build). By function: `regexp_init_copy()` is +497 and the `re_initialize()` split is +352 against `regexp_init()`'s -278, which is the code actually added; the seven C readers take +23 to +79 each for the guard, which `-O3` inlines at every call site and `-O0` does not, and that is the gap between the two figures above. `gem_init.o`'s `.rodata` grows 16 bytes for the two `__check_initialized` calls compiled into mrblib, which is outside `.text`.

## Testing

- `rake -m test` on each of the two commits (host, default gembox, clang): 2336 and 2338 tests, 0 KO, 0 crash, 0 warning; bintest 128, 0 KO.
- `MRUBY_CONFIG=clang-asan rake -m test` (ASan + UBSan, `full-core` gembox): 2577 tests, 0 KO, 0 crash, 0 warning; bintest 101, 0 KO.
- Under that same ASan build with `detect_leaks=1`, three scripts, all clean and none reporting:
  - every Regexp method against `Regexp.allocate`, 50 methods across 30 argument shapes, plus 36 external entry points (`String#gsub`/`sub`/`split`/`scan`/`index`/`match`/`[]`/`partition`, `Symbol#match`, `Array#grep`, `case`/`when`, interpolation, Hash keys, `dup`/`clone`);
  - 2000 `dup`/`clone` copies with interleaved `GC.start`, each copy matching through its own pattern, the originals outliving the copies and the copies outliving the originals;
  - 702 calls against a valid Regexp whose `@source`, `@flags` or `@named_captures` was overwritten with nil, integers, symbols, arrays, hashes, floats, booleans and plain objects, running the readers, the matchers and the copies against the result.
- The before column of the table above reproduced on master: `Regexp.allocate.to_s`, `.inspect` and `Regexp.new(Regexp.allocate)` each exit 139, and `/ab(c)/i.dup` answers `source` with `"ab(c)"` while `match?` raises.

## Environment

<details>

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-30-generic x86_64 |
| CPU | AMD Ryzen 9 5950X (16C/32T) |
| C compiler | gcc 13.3.0 (`## Size`), clang 22.1.8 (`## Testing`) |
| binutils | GNU ld 2.47.20260726 |
| CRuby | 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM |

The `## Size` builds, as `src/string.o.flags` recorded them (`-MMD -c`, `-I` and `-o` dropped):

```console
# bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK

# ascii-ctype
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# full-debug
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Regular expression objects that were not properly initialized now consistently raise a clear error when accessed.
  * Duplication and cloning now produce fully functional, independent regular expression objects.
  * Comparisons, hashing, pattern inspection, and matching behave reliably for invalid or partially initialized expressions.
  * Inspection of uninitialized expressions now safely displays a default representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
