### PR TITLE
mruby-regexp: give an inline toggle the alternatives after it

### DIFF
--- a/build_config/ci/gcc-clang.rb
+++ b/build_config/ci/gcc-clang.rb
@@ -73,5 +73,17 @@ MRuby::Build.new('ascii-ctype') do |conf|
   conf.gembox 'full-core'
   conf.cc.defines << 'MRB_USE_ASCII_CTYPE'
 
+  # A second mruby-regexp refusal that needs a build of its own: the parse
+  # depth limit. Reaching a limit costs the C stack that limit stands for,
+  # about 600 bytes a level, so no build can be asked to reach the default
+  # 4096, whose 2.4 MiB is more than a Windows thread's whole stack, and the
+  # test skips above 512 for that reason. This build sets a limit a test may
+  # reach anywhere in the matrix, some 300 KiB, which is what gives
+  # `parse depth limit over` a home; the arithmetic that refuses is the same
+  # at any limit. It rides along here rather than in a build of its own so
+  # that the matrix runs no extra pass, and it costs this build nothing: the
+  # depth a pattern may nest is not what ASCII classification is about.
+  conf.cc.defines << 'MRB_REGEXP_PARSE_DEPTH_LIMIT=512'
+
   conf.enable_test
 end

--- a/mrbgems/mruby-regexp/README.md
+++ b/mrbgems/mruby-regexp/README.md
@@ -294,6 +294,11 @@ there.
 #ifndef MRB_REGEXP_STACK_LIMIT
 #define MRB_REGEXP_STACK_LIMIT 2048
 #endif
+
+/* How deep a pattern may nest (the parser's own C stack) */
+#ifndef MRB_REGEXP_PARSE_DEPTH_LIMIT
+#define MRB_REGEXP_PARSE_DEPTH_LIMIT 4096
+#endif
 ```
 
 A search that reaches either limit raises `RegexpError`, `step limit over
@@ -357,6 +362,45 @@ The macro was called `MRB_REGEXP_RECURSION_LIMIT` while the engine recursed
 once per fork and the limit counted C frames. A build that still defines that
 name fails to compile: the two limits count different things, so an old value
 does not carry over and the build has to choose a new one.
+
+`MRB_REGEXP_PARSE_DEPTH_LIMIT` is the third limit and the odd one out: it
+bounds the compiler rather than a search, and what it guards is the C stack
+rather than memory or work. A pattern past it raises `RegexpError`, `parse
+depth limit over`, which is CRuby's message for the same refusal.
+
+Every construct that opens a level costs one: a group of any kind, a
+lookaround, an atomic group, and an inline option toggle, which encloses the
+rest of the group it stands in and so is a level of its own. A pattern of 4096
+nested `(?:` and one of 4096 nested `(?i)` are refused alike, at the same
+depth CRuby refuses them: the default is Onigmo's `ONIG_MAX_PARSE_DEPTH`.
+
+**A build on a stack smaller than about 3 MiB has to lower it.** The parser
+recurses once per level, so the ceiling is a property of the build's stack
+rather than of the engine, and the default is chosen for the refusal point
+rather than for the stack. A level costs about 600 bytes on a 64-bit build, so
+the deepest pattern the default accepts spends some 2.4 MiB, and so does a
+deeper one before being refused, since the count is reached at the bottom of
+the recursion. Where the stack cannot pay that, the crash the limit exists to
+prevent comes back. The compiler is not the only thing standing on that stack
+either, so a third of it is the share to size the limit from:
+
+| Stack   | A limit that fits           |
+| ------- | --------------------------- |
+| 8 MiB   | 4096 (default, CRuby-exact) |
+| 1 MiB   | 512                         |
+| 256 KiB | 128                         |
+| 64 KiB  | 32                          |
+
+Divide the build's own figure, not this one: `-Os` and a 32-bit ABI both make
+a level cheaper, and `-fstack-usage` over `re_compile.c` names it, the frames
+of `compile_alt` and `compile_seq` summed and the rest inlining into them (560
+bytes on a 64-bit gcc `-O2` build, 528 at `-Os`, 592 on a clang `-O3` one).
+
+Lowering it costs little. Nesting this deep is not what a written pattern
+does, a handful of levels being ordinary and dozens unusual, so a build that
+sets 128 still takes every pattern anyone writes, and gives up only the
+CRuby-exact refusal point. The limit stands between 1 and 1,048,576, and a
+build that sets it outside that fails to compile.
 
 Case folding beyond ASCII is not this gem's to configure. The table is
 core's, carried by any build that defines `MRB_UTF8_STRING` without

--- a/mrbgems/mruby-regexp/include/re_internal.h
+++ b/mrbgems/mruby-regexp/include/re_internal.h
@@ -254,6 +254,49 @@ typedef struct mrb_regexp_pattern {
 #error MRB_REGEXP_STACK_LIMIT must stand between 1 and 16777216
 #endif
 
+/* How deep a pattern may nest. Every construct that opens a level costs one:
+   a group of any kind, a lookaround, an atomic group, and an inline option
+   toggle, which encloses the rest of the group it stands in and so is a level
+   of its own (see compile_alt() in re_compile.c). A pattern past this is
+   `parse depth limit over`, which is CRuby's message for the same refusal.
+
+   Unlike the two limits above, what this one guards is the C stack: the
+   parser recurses per level, so without it a deep enough pattern reaches the
+   end of the stack, which is a crash rather than an error.
+
+   The default is Onigmo's ONIG_MAX_PARSE_DEPTH, so a pattern is refused
+   exactly where CRuby refuses it. What that costs is stack, and a build has
+   to know the price: a level takes about 600 bytes on a 64-bit build, so the
+   deepest pattern the default accepts spends around 2.4 MiB, and a pattern
+   deeper than that spends the same before being refused, the count being
+   reached at the bottom of the recursion. A build whose stack is smaller
+   than that -- the 1 MiB a Windows thread is given by default is, and an
+   RTOS task is by far -- has to set this to what it can pay for or keep the
+   crash the limit is here to prevent: a third of the stack is the share to
+   size it from, the compiler not being the only thing standing on that
+   stack, so about 512 for 1 MiB, 128 for 256 KiB, 32 for 64 KiB. The figure
+   to divide is the build's own: -Os and a 32-bit ABI both make a level
+   cheaper, and `-fstack-usage` over re_compile.c names it (the frames of
+   compile_alt and compile_seq, the rest inlining into them: 560 bytes on a
+   64-bit gcc -O2 build, 528 at -Os, 592 on a clang -O3 one).
+
+   Lowering it costs little in practice. Nesting this deep is not what a
+   written pattern does -- a handful of levels is ordinary and dozens are
+   unusual -- so a build that sets 128 still takes every pattern anyone
+   writes, and trades only the CRuby-exact refusal point for a crash it
+   cannot otherwise avoid.
+
+   The floor is 1, a build that takes no nesting at all; the ceiling is where
+   the limit stops being one, every stack this engine runs on having ended
+   long before. */
+#ifndef MRB_REGEXP_PARSE_DEPTH_LIMIT
+#define MRB_REGEXP_PARSE_DEPTH_LIMIT 4096
+#endif
+
+#if MRB_REGEXP_PARSE_DEPTH_LIMIT < 1 || MRB_REGEXP_PARSE_DEPTH_LIMIT > (1 << 20)
+#error MRB_REGEXP_PARSE_DEPTH_LIMIT must stand between 1 and 1048576
+#endif
+
 /* What a search answers when the backtracking engine stopped before it had
    an answer (see mrb_re_exec()). The caller raises on it: what the search had
    found by then is not a shorter or a later match, and reading it as one was

--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -1533,8 +1533,9 @@ compile_look_body(re_compiler *c, mrb_bool negative)
 /* Compile a single atom (character, class, group, etc.). Returns whether one
    was read: FALSE when what stands at the parse point is not an atom, either a
    quantifier metacharacter or the end of the sequence, neither of them
-   consumed, or an option toggle `(?i)`, consumed but nothing a quantifier can
-   repeat. An empty group `(?:)` emits nothing and is still an atom. */
+   consumed. An empty group `(?:)` emits nothing and is still an atom, and so
+   does an option toggle `(?i)` whose scope, the rest of the enclosing group,
+   is empty. */
 static mrb_bool
 compile_atom(re_compiler *c)
 {
@@ -1674,9 +1675,25 @@ compile_atom(re_compiler *c)
           next_char(c);  /* skip '?' */
           uint32_t new_flags = parse_inline_flags(c, c->flags);
           if (peek(c) == ')') {
+            /* The rest of the enclosing group, alternatives and all, is the
+               toggle's scope: `a(?i)b|c` is `a(?i:b|c)`, as Onigmo builds it
+               (parse_exp() hands its "option only" remainder to
+               parse_subexp(), the alternation level). So compile that
+               remainder here rather than returning to the sequence the
+               toggle was read in, where the `|` would split at the level the
+               toggle was written at and `c` would match with no `a` before
+               it. compile_alt() consumes every `|` and stops at the group's
+               ')' or the end of the pattern, which is where the caller
+               expects the parse point, so what follows is unchanged: the
+               enclosing compile_seq() finds its terminator, a stray ')' at
+               top level is still refused by mrb_re_compile(), and a
+               quantifier with nothing before it is refused by the
+               compile_seq() called from here. */
             next_char(c);
-            c->flags = new_flags;  /* rest of the group; restored at its ')' */
-            return FALSE;          /* consumed the token; no atom emitted */
+            c->flags = new_flags;
+            compile_alt(c);
+            c->flags = saved_flags;
+            return TRUE;
           }
           else if (peek(c) == ':') {
             next_char(c);
@@ -1744,7 +1761,7 @@ compile_atom(re_compiler *c)
       if (capturing) {
         emit(c, RE_SAVE, 0, group * 2 + 1);
       }
-      c->flags = saved_flags;  /* inline toggles inside the group end here */
+      c->flags = saved_flags;  /* the options this group opened with */
     }
     break;
 
@@ -2086,9 +2103,10 @@ compile_quantified(re_compiler *c)
     /* Nothing emitted. An empty group `(?:)` is an atom all the same, and
        one that matches empty matches empty however it is repeated, so its
        quantifiers are read and emit nothing, as those of `a{0}` are; CRuby
-       compiles `(?:)*` the same way. What is not an atom, an option toggle
-       `(?i)` or a stray metacharacter, leaves a quantifier after it for
-       compile_seq() to refuse, as CRuby refuses `(?i)*`. */
+       compiles `(?:)*` the same way. A stray metacharacter is no atom and
+       leaves the quantifier for compile_seq() to refuse; `(?i)*` is refused
+       there too, as CRuby refuses it, by the compile_seq() that reads the
+       toggle's scope. */
     if (atom) skip_quantifiers(c);
     return;
   }

--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -72,6 +72,9 @@ typedef struct {
   uint32_t literal_cp[RE_MAX_CLASSES];  /* by class id: the codepoint whose
                                /i literal the class stands for, 0 for a class
                                made by anything else; see literal_class() */
+  uint32_t depth;           /* nesting levels open at the parse point, one per
+                               compile_alt() frame on the C stack; bounded by
+                               MRB_REGEXP_PARSE_DEPTH_LIMIT */
 } re_compiler;
 
 static void compile_alt(re_compiler *c);  /* forward */
@@ -2279,7 +2282,7 @@ compile_seq(re_compiler *c)
 
 /* Compile alternation: seq | seq | ... */
 static void
-compile_alt(re_compiler *c)
+compile_alt_body(re_compiler *c)
 {
   uint32_t alt_start = c->code_len;
   compile_seq(c);
@@ -2340,6 +2343,23 @@ compile_alt(re_compiler *c)
     c->pat->code[jmp_pos].op = RE_JMP;
     c->pat->code[jmp_pos].offset = (uint16_t)end;
   }
+}
+
+/* Bound the parser's own recursion. Every nesting level it descends into is
+   one compile_alt() frame -- compile_alt -> compile_seq -> compile_quantified
+   -> compile_atom, whose group, lookaround, atomic and inline-option arms
+   call compile_alt again -- so the count stands here, at the one entry the
+   recursion passes through, and a pattern that nests deeper is refused rather
+   than run off the C stack. The message is CRuby's for the same refusal; see
+   MRB_REGEXP_PARSE_DEPTH_LIMIT for what the number is and what it costs. */
+static void
+compile_alt(re_compiler *c)
+{
+  if (++c->depth > (uint32_t)MRB_REGEXP_PARSE_DEPTH_LIMIT) {
+    compile_error(c, "parse depth limit over");
+  }
+  compile_alt_body(c);
+  c->depth--;
 }
 
 /* Inside a character class, is `src` the start of a POSIX bracket [:name:]?

--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -2175,6 +2175,11 @@ mrb_mruby_regexp_gem_init(mrb_state *mrb)
      whoever has to size a subject or a pattern to the build it runs on. */
   mrb_define_const(mrb, re, "STACK_LIMIT", mrb_int_value(mrb, MRB_REGEXP_STACK_LIMIT));
   mrb_define_const(mrb, re, "STEP_LIMIT", mrb_int_value(mrb, MRB_REGEXP_STEP_LIMIT));
+  /* How deep a pattern may nest, which the compiler refuses past rather than
+     recurse off the C stack: read back like the two above, by whoever has to
+     size a pattern to the build it runs on. */
+  mrb_define_const(mrb, re, "PARSE_DEPTH_LIMIT",
+                   mrb_int_value(mrb, MRB_REGEXP_PARSE_DEPTH_LIMIT));
 
   /* Class methods */
   mrb_define_method(mrb, re, "initialize", regexp_init, MRB_ARGS_ARG(1, 2));

--- a/mrbgems/mruby-regexp/test/regexp_syntax.rb
+++ b/mrbgems/mruby-regexp/test/regexp_syntax.rb
@@ -934,6 +934,29 @@ assert("Regexp - inline options (?i) / (?i:...)") do
   assert_equal 0, (/(a(?i)b)c/ =~ "aBc")
   assert_nil (/(a(?i)b)c/ =~ "aBC")       # trailing `c` is case-sensitive again
 
+  # The rest of the group is the toggle's scope alternatives and all, so
+  # `a(?i)b|c` is `a(?i:b|c)`: the `|` splits inside the scope, not at the
+  # level the toggle was written at, and the `c` still wants the `a` before
+  # it. Without that, an alternative after a toggle matched on its own.
+  assert_nil (/a(?i)b|c/ =~ "c")
+  assert_nil (/a(?i)b|c/ =~ "C")
+  assert_equal 0, (/a(?i)b|c/ =~ "ac")
+  assert_equal 0, (/a(?i)b|c/ =~ "aC")    # and the option reaches that `c`
+  assert_nil (/a(?i)|b/ =~ "b")           # an empty first alternative too
+  assert_nil (/x|a(?i)b|c/ =~ "c")        # a toggle in the second alternative
+  assert_nil (/(a(?i)b|c)d/ =~ "cd")
+  assert_equal 0, (/x(a(?i)b|c)d/ =~ "xacd")
+  assert_equal ["acd", "ac", "d"], /(a(?i)b|c)(d)/.match("acd").to_a
+  assert_equal 0, (/a(?i)b(?m).|c/ =~ "aB\n")  # a toggle within that scope
+  assert_equal 0, (/a(?x) b|c/ =~ "ac")   # x is scoped the same way
+  assert_nil (/a(?x) b|c/ =~ "c")
+
+  # Turning an option off is scoped alike, so the alternative after `(?-i)`
+  # is case-sensitive whether or not the pattern is /i.
+  assert_equal 0, (/a(?-i)b|c/i =~ "ac")
+  assert_nil (/a(?-i)b|c/i =~ "aC")
+  assert_nil (/a(?-i)b|c/i =~ "C")
+
   # m enables dot-matches-newline for its scope.
   assert_equal 0, (/(?m:a.b)/ =~ "a\nb")
   assert_nil (/a.b/ =~ "a\nb")
@@ -1004,6 +1027,10 @@ assert("Regexp - an inline option reaches a lookaround and a backreference") do
   assert_equal 0, (/(a)(?i:\1)/ =~ "aA")
   assert_nil (/(?-i:(a)\1)/i =~ "aA")
   assert_equal 0, (/(?=(?x)a b)ab c/ =~ "ab c")
+  # The sub-pattern is where a toggle inside it ends, so the alternation it
+  # takes in ends there too: this is `(?=a(?i:b|c))`.
+  assert_nil (/(?=a(?i)b|c)/ =~ "c")
+  assert_equal 0, (/(?=a(?i)b|c)/ =~ "aC")
 end
 
 assert("Regexp - comment groups (?#...)") do
@@ -1411,7 +1438,9 @@ assert("Regexp - an empty group takes a quantifier") do
   assert_equal [""], /(?:) * /x.match("").to_a
   # A `{` after it that spells no quantifier is a literal, as after any atom.
   assert_equal ["{a}"], /(?:){a}/.match("{a}").to_a
-  # An option toggle is not an atom: the quantifier after `(?i)` has no target.
+  # A quantifier after `(?i)` has no target: what follows the toggle is its
+  # scope, and the quantifier stands at the beginning of it with no atom
+  # before it.
   assert_raise_with_message(RegexpError,
                             "target of repeat operator is not specified: /(?i)*/") do
     Regexp.new("(?i)*")

--- a/mrbgems/mruby-regexp/test/regexp_syntax.rb
+++ b/mrbgems/mruby-regexp/test/regexp_syntax.rb
@@ -268,6 +268,57 @@ assert("Regexp - a backreference reads no group the running iteration reopened")
   assert_equal ["x", "", "x"], /((x|\2b)?)*/.match("xb").to_a
 end
 
+assert("Regexp - a pattern nested past the parse depth limit raises") do
+  # The parser recurses once per nesting level, so a deep enough pattern used
+  # to reach the end of the C stack, which is a crash and not an error:
+  # `(?:` x 50000 was a SIGSEGV. MRB_REGEXP_PARSE_DEPTH_LIMIT bounds it, and
+  # CRuby's message for the same refusal is the one raised here.
+  #
+  # A nesting the guard must not refuse: the count has to leave a pattern
+  # inside the limit alone, and a deep one it accepts has to still match. The
+  # depth comes from the build's own limit, since a build may set one below
+  # any figure written here.
+  limit = Regexp::PARSE_DEPTH_LIMIT
+  inside = limit > 200 ? 200 : limit - 1
+  if inside > 0
+    assert_equal 0, (Regexp.new("(?:" * inside + "a" + ")" * inside) =~ "a")
+    assert_equal 0, (Regexp.new("(?i)" * inside + "a") =~ "A")
+  end
+
+  # The refusal itself is sized from `Regexp::PARSE_DEPTH_LIMIT`, which reads
+  # back what the build set. Reaching it costs the stack the limit stands for:
+  # the count is checked at the bottom of the recursion, so a pattern past the
+  # limit descends to it before being refused, and asking a build with a high
+  # limit to do that here would spend a megabyte or more of C stack -- the
+  # very thing the limit exists to keep a pattern from doing. Such a build is
+  # left out rather than have the assertion crash it; the default is
+  # CRuby-exact and so is one of them, and a build that sets the limit to what
+  # a smaller stack can pay for is where this runs.
+  if limit > 512
+    skip "reaching this build's parse depth limit costs more C stack than a test may spend"
+  end
+
+  # Every construct that opens a level is asked, an inline toggle among them:
+  # it encloses the rest of the group it stands in, so it is a level of its
+  # own, and CRuby counts it as one too.
+  fits = limit - 1
+  assert_equal 0, (Regexp.new("(?:" * fits + "a" + ")" * fits) =~ "a")
+  assert_equal 0, (Regexp.new("(?i)" * fits + "a") =~ "A")
+
+  [
+    ["(?:" * limit + "a" + ")" * limit, "a plain group"],
+    ["(?i)" * limit + "a",              "an option toggle"],
+    ["(?i:" * limit + "a" + ")" * limit, "a scoped option group"],
+    ["(?=" * limit + "a" + ")" * limit, "a lookahead"],
+    ["(?>" * limit + "a" + ")" * limit, "an atomic group"],
+  ].each do |pattern, what|
+    assert_raise_with_message(RegexpError,
+                              "parse depth limit over: /#{pattern}/", what) do
+      Regexp.new(pattern)
+    end
+  end
+end
+
 assert("Regexp - the backtracking engine raises at a limit rather than answer short") do
   need_backtracking_stack
   # A search gives up at MRB_REGEXP_STACK_LIMIT or MRB_REGEXP_STEP_LIMIT,

--- a/mrbgems/mruby-regexp/test/regexp_syntax.rb
+++ b/mrbgems/mruby-regexp/test/regexp_syntax.rb
@@ -288,12 +288,14 @@ assert("Regexp - a pattern nested past the parse depth limit raises") do
   # The refusal itself is sized from `Regexp::PARSE_DEPTH_LIMIT`, which reads
   # back what the build set. Reaching it costs the stack the limit stands for:
   # the count is checked at the bottom of the recursion, so a pattern past the
-  # limit descends to it before being refused, and asking a build with a high
-  # limit to do that here would spend a megabyte or more of C stack -- the
-  # very thing the limit exists to keep a pattern from doing. Such a build is
-  # left out rather than have the assertion crash it; the default is
-  # CRuby-exact and so is one of them, and a build that sets the limit to what
-  # a smaller stack can pay for is where this runs.
+  # limit descends to it before being refused, and at the CRuby-exact default
+  # that is some 2.4 MiB -- more C stack than a Windows thread has at all, and
+  # the very thing the limit exists to keep a pattern from spending. So a
+  # build whose limit stands above what a test may descend is left out rather
+  # than crashed, and the refusal is covered by a build that sets a limit a
+  # test can reach: the `ascii-ctype` build of build_config/ci/gcc-clang.rb
+  # sets 512, which runs on every entry of the CI matrix. The arithmetic that
+  # refuses is the same at any limit.
   if limit > 512
     skip "reaching this build's parse depth limit costs more C stack than a test may spend"
   end


### PR DESCRIPTION
## Summary

An inline toggle `(?imx)` encloses the rest of the group it stands in, alternatives and all, and this engine split its alternation one level too high, so an alternative written after a toggle matched on its own. Fixing that gives the parser a second way to recurse, so how deep a pattern may nest is bounded here too.

## Changes

| File | What |
| --- | --- |
| `mrbgems/mruby-regexp/src/re_compile.c` | the option-toggle arm of `compile_atom()` compiles the rest of the group through `compile_alt()`; `compile_alt()` becomes a depth-counting wrapper over `compile_alt_body()` |
| `mrbgems/mruby-regexp/include/re_internal.h` | adds `MRB_REGEXP_PARSE_DEPTH_LIMIT` (4096) and its range guard |
| `mrbgems/mruby-regexp/src/regexp.c` | adds `Regexp::PARSE_DEPTH_LIMIT` |
| `mrbgems/mruby-regexp/README.md` | what the third limit guards, and how a build sizes it to its own stack |
| `mrbgems/mruby-regexp/test/regexp_syntax.rb` | the alternation after a toggle, and the depth refusal |
| `build_config/ci/gcc-clang.rb` | `ascii-ctype` sets the limit to 512, so the refusal has a build that can reach it |

### An alternation after an inline toggle split one level too high

Onigmo wraps everything after the toggle, alternatives included, into one group under the new options, so `a(?i)b|c` is `a(?i:b|c)`: `parse_exp()`'s "option only" branch hands the remainder to `parse_subexp()`, which is the alternation level. `compile_atom()` set `c->flags` and returned to `compile_seq()`, so the `|` split at the level the toggle was written at, `a(?i)b|c` being `(?:a(?i)b)|c`, and the `c` matched with no `a` before it:

```ruby
/a(?i)b|c/ =~ "c"         # CRuby: nil, mruby: 0
/(a(?i)b|c)d/ =~ "acd"    # CRuby: 0,   mruby: 1
/x(a(?i)b|c)d/ =~ "xacd"  # CRuby: 0,   mruby: nil
```

The options themselves reached the right atoms either way, which is why the divergence showed only in the shape of the alternation. A toggle-off leaked alike, `/a(?-i)b|c/i` leaving the `c` case-sensitive, and so did `(?x)`, whose free-spacing side already agreed.

The toggle arm now compiles that remainder with `compile_alt()` under the new flags and restores them after. `compile_alt()` consumes every `|` and stops at the group's `)` or the end of the pattern, which is where the arm's caller already expects the parse point, so what follows is unchanged: the enclosing `compile_seq()` finds its terminator, `mrb_re_compile()` still refuses a stray `)` at top level, `(?i)*` is still `target of repeat operator is not specified`, and capture numbering does not move.

### The parser had no bound on its own recursion

`compile_alt()` calls `compile_seq()` calls `compile_quantified()` calls `compile_atom()`, whose group, lookaround, atomic and inline-option arms call `compile_alt()` again, so the parser recurses once per nesting level. Nothing counted the levels, and a deep enough pattern ran off the C stack: a pattern of 50000 nested `(?:` was a **SIGSEGV** rather than an error. That is pre-existing, but the change above gives the toggle a second way there, since `(?i)` now opens a level where before it set a flag and returned, so the bound belongs in this PR.

`compile_alt()`, the one entry the recursion passes through, now counts levels and refuses past `MRB_REGEXP_PARSE_DEPTH_LIMIT` with `parse depth limit over`, CRuby's message for the same refusal. Every construct that opens a level counts, the toggle among them, as Onigmo counts them: 4096 nested `(?:` and 4096 nested `(?i)` are refused alike there, which is independent confirmation of the tree this parser now builds.

**The default is 4096, Onigmo's `ONIG_MAX_PARSE_DEPTH`, so a pattern is refused exactly where CRuby refuses it**, 4095 levels compiling and 4096 raising on both. What that costs is stack. A level takes 560 bytes on a 64-bit gcc `-O2` build, 528 at `-Os` and 592 on the clang `-O3` build measured here, which is `compile_alt()`'s frame plus `compile_seq()`'s as `-fstack-usage` reports them, the rest inlining into the two. Measured as the deepest nesting that survives a given `ulimit -s`, that is:

| Stack | Deepest that survives | A limit that fits |
| ----- | --------------------- | ----------------- |
| 8 MiB | 4095 (the limit, not the stack) | 4096 (default, CRuby-exact) |
| 1 MiB | 1660 | 512 |
| 256 KiB | 364 | 128 |
| 64 KiB | 42 | 32 |

So the deepest pattern the default accepts spends some 2.4 MiB, and so does a deeper one before being refused, since the count is reached at the bottom of the recursion. **A build on a smaller stack than that has to lower the limit or keep the crash it exists to prevent**; the header and the README both say so, with the `-fstack-usage` recipe for measuring a build's own per-level figure. The right-hand column is a third of the stack, the compiler not being the only thing standing on it. Nesting this deep is not what a written pattern does, a handful of levels being ordinary and dozens unusual, so a build that sets 128 still takes every pattern anyone writes and gives up only the CRuby-exact refusal point. `Regexp::PARSE_DEPTH_LIMIT` reads the value back, as `Regexp::STACK_LIMIT` and `Regexp::STEP_LIMIT` read theirs.

That trade, a CRuby-exact refusal point against a stack cost a small-stack build must opt out of, is the one choice in this PR a build can be asked to revisit.

### The refusal needs a build that can reach it

Reaching a limit costs the stack that limit stands for, so the test skips a build whose limit stands above 512: at the default a pattern descends some 2.4 MiB before being refused, which is more stack than a Windows thread has at all, and no test may spend what the limit exists to keep a pattern from spending.

Nothing else could lift that skip. Which platforms could pay 2.4 MiB is not a question the test can ask: mruby defines no `RUBY_PLATFORM`, the one signal it has tells Windows from the rest through `File::ALT_SEPARATOR`, and Cosmopolitan, which runs the suite and whose main stack is smaller than a POSIX host's, is not distinguishable from Linux by it. So a build sets a limit a test may reach instead, which is what the `ascii-ctype` build now does at 512, some 300 KiB. That build already exists to give an mruby-regexp refusal a home, what `/i` answers where the build has no folding table, and the depth a pattern may nest is not what ASCII classification is about, so the two do not tread on each other. It rides along there rather than in a build of its own so the matrix runs no extra pass.

## Behaviour

Three things an existing pattern can notice.

**An alternative after a toggle now wants what precedes the toggle**, which is the fix: the three rows above, and a toggle-off and an `(?x)` alike.

**A pattern nested past the limit raises `RegexpError` where it used to crash or compile.** At the default that is 4096 levels or more, where CRuby raises the same error; a build that lowers the limit moves the point.

**Three patterns in a 4000-pattern toggle fuzz now reach `step limit over (MRB_REGEXP_STEP_LIMIT)` where they used to answer.** All three are nested quantified alternations carrying a toggle in nearly every sequence; splitting inside the toggle's scope rather than at the level above changes what the search retries, so the same step limit is reached by a different walk. CRuby answers `nil` for all three, and two of them answered wrongly here before. A control run of 124,000 cases over patterns with no toggle in them answers identically before and after.

## Size

`.text` of `bin/mruby`, `size -A`, for the five builds of `build_config/ci/gcc-clang.rb`, master and this branch built at the same path in an empty build directory:

| Build | master | this PR | delta |
| --- | ---: | ---: | ---: |
| `bintest` | 1,072,934 | 1,073,526 | +592 |
| `ascii-ctype` | 1,067,926 | 1,068,406 | +480 |
| `byte-string` | 1,047,942 | 1,048,390 | +448 |
| `cxx_abi` | 1,061,029 | 1,061,621 | +592 |
| `full-debug` (-O0) | 1,863,558 | 1,863,750 | +192 |

Two objects account for it: `re_compile.o` `.text` grows by 560, 448, 432, 560 and 112 bytes down that column, and `regexp.o` by 48, 48, 48, 48 and 80 for the new constant. The `ascii-ctype` row also carries the `MRB_REGEXP_PARSE_DEPTH_LIMIT=512` this PR gives that build, which changes one constant.

For a build that carries the gem on flash, `re_compile.o` `.text` at `-Os` grows by 50 bytes under gcc (13,863 to 13,913) and 56 under clang (15,638 to 15,694), against some 87 KiB for the whole gem. RAM is one `uint32_t` on `re_compiler`, which lives on the C stack for the duration of a compile; no heap allocation changes. The C stack per nesting level is what it was under gcc, 560 bytes at `-O2` and 528 at `-Os`, and under clang `-Os` (480); at clang `-O3` it goes from 376 to 592, clang no longer folding `compile_seq()` into the level. What changed everywhere is that `(?i)` now opens a level of its own.

## Testing

- `rake test` on the default config at each of the three commits: 0 KO, 0 crash.
- `MRUBY_CONFIG=build_config/ci/gcc-clang.rb rake test`, all five builds: 0 KO, 0 crash. The depth assertions run in `ascii-ctype` and skip in the other four.
- The same suite at `MRB_REGEXP_PARSE_DEPTH_LIMIT` of 48, 512, 1024 and 4096: green at each, the refusal asked at the first two and skipped at the last two, for a plain group, a scoped option group, a lookahead, an atomic group and a toggle. The range guard rejects 0, -1 and 2000000 at compile time.
- A differential run of 4000 toggle-heavy patterns against 15 subjects each, master and this branch against CRuby 4.0.6. Of the 14,760 answers that parted from CRuby, 14,750 agree now. The ten that still part part the same way when `(?i:` is written where the toggle stands, so they are not about the toggle's scope: `/[BA]*(?i:A)/ =~ "A"` is `nil` in CRuby and `0` here on master too, and `/((|b[ab])+[aB])+/ =~ "aB"` parts with no option anywhere in it.
- A control differential run of 124,000 cases over patterns with no toggle: master and this branch answer identically, byte for byte.
- The crash and its absence, on the binaries built above:

```console
$ master/bin/mruby -e 'Regexp.new("(?:" * 50000 + "a" + ")" * 50000)'
Segmentation fault (core dumped)

$ branch/bin/mruby -e 'Regexp.new("(?:" * 50000 + "a" + ")" * 50000)'
trace (most recent call last):
        [1] -e:1
-e:1:in initialize: parse depth limit over: /(?:(?:(?:...  (RegexpError)

$ (ulimit -s 1024; master/bin/mruby -e 'Regexp.new("(?:" * 5000 + "a" + ")" * 5000)')
Segmentation fault (core dumped)

$ (ulimit -s 1024; ascii-ctype/bin/mruby -e 'Regexp.new("(?:" * 5000 + "a" + ")" * 5000)')
-e:1:in initialize: parse depth limit over: /(?:(?:(?:...  (RegexpError)
```

(the `ascii-ctype` build is the one that sets the limit to 512; the error echoes the whole pattern, elided here.)

## Environment

<details>
<summary>Host, toolchain and the compile line of each build</summary>

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-30-generic x86_64 |
| CPU | AMD Ryzen 9 5950X (16 cores) |
| C compiler | Homebrew clang 22.1.8 (`CC=clang`) |
| Second compiler, for the `-fstack-usage` and `-Os` figures | gcc 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1) |
| binutils | GNU ld / size 2.47.20260726 |
| CRuby, for the differential runs | ruby 4.0.6 (2026-07-14) +PRISM |

`cxx_abi` links through `clang++`; the other four link through `clang`. The compile line of `re_compile.c` in each build, with `-MMD -c`, the `-I` paths and `-o` dropped:

```console
# bintest
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK

# ascii-ctype
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -DMRB_USE_ASCII_CTYPE -DMRB_REGEXP_PARSE_DEPTH_LIMIT=512 -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# byte-string
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# cxx_abi
clang -g -O3 -Wall -Wundef -Wwrite-strings -Wzero-length-array -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# full-debug
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable regular-expression parser depth limit, defaulting to 4096.
  * Exposed the limit through `Regexp::PARSE_DEPTH_LIMIT`.
  * Patterns exceeding the configured limit now raise `RegexpError`.

* **Bug Fixes**
  * Improved handling and scoping of inline regular-expression options across alternatives and nested expressions.

* **Documentation**
  * Documented configuration, supported values, counted constructs, and stack-sizing guidance.

* **Tests**
  * Added coverage for parser-depth limits, inline options, lookarounds, atomic groups, and invalid quantifier usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->