### PR TITLE
mruby-regexp: look the match up in a Hash replacement

### DIFF
--- a/mrbgems/mruby-regexp/mrblib/string_regexp.rb
+++ b/mrbgems/mruby-regexp/mrblib/string_regexp.rb
@@ -121,10 +121,22 @@ class String
     # to search with.  What a compiled pattern would be needed for is the
     # Regexp the `$~` it publishes names, and `MatchData#regexp` quotes that
     # one where CRuby quotes it: on the first call that asks for it.
+    # A Hash replacement is not text to substitute but a table to look the
+    # match up in, which is the block form with the lookup where the call
+    # would be: CRuby runs the two down the same tail, so a `\1` in what comes
+    # back stands for itself rather than naming a group, and a key the Hash
+    # does not hold answers nil, which `to_s` spells as the empty string.  The
+    # Hash has to be one, as `__check_pattern` demands a real String: mruby
+    # converts nothing with `to_hash` anywhere.
+    hash = nil
     if argc == 2
-      replacement = args[1].to_s
-      return Regexp.__sub_lit(pattern, self, replacement) if literal
-      return Regexp.__sub_str(pattern, self, replacement)
+      if Hash === args[1]
+        hash = args[1]
+      else
+        replacement = args[1].to_s
+        return Regexp.__sub_lit(pattern, self, replacement) if literal
+        return Regexp.__sub_str(pattern, self, replacement)
+      end
     end
     # CRuby searches for a literal byte by byte and never reads the subject as
     # UTF-8 on the way, so quoting one into a Regexp here must not put the
@@ -133,7 +145,7 @@ class String
     pattern = Regexp.new(Regexp.escape(pattern)) if literal
     md = Regexp.__search(pattern, self, 0, literal)
     return self.dup unless md
-    md.pre_match + block.call(md[0]).to_s + md.post_match
+    md.pre_match + (hash ? hash[md[0]] : block.call(md[0])).to_s + md.post_match
   end
 
   def sub!(*args, &block)
@@ -154,6 +166,10 @@ class String
     # the return value, and a String pattern is a literal on both paths.
     pattern = Regexp.__check_pattern(args[0])
     literal = String === pattern
+    # A table to look the match up in rather than text to substitute, as in
+    # `sub`; the tail below is where the lookup happens, so both of the paths
+    # a replacement takes have to let it past.
+    hash = args[1] if argc == 2 && Hash === args[1]
     # Quoting the literal below raises nothing, so asking here is the order the
     # original had: after the argument checks, before any search.
     raise FrozenError, "can't modify frozen String" if frozen?
@@ -162,7 +178,7 @@ class String
     # unchanged.  The `bang` argument is that question asked of the one search
     # `__sub_lit` already makes, so the literal path does not walk the subject
     # twice to answer it; a failed search clears $~ there as `__search` does.
-    if literal && argc == 2
+    if literal && argc == 2 && !hash
       str = Regexp.__sub_lit(pattern, self, args[1].to_s, true)
       return nil unless str
       return self.replace(str)
@@ -171,7 +187,7 @@ class String
     # A full search and not `match?`, so a failed match clears $~.
     md = Regexp.__search(pattern, self, 0, literal)
     return nil unless md
-    if argc == 2
+    if argc == 2 && !hash
       # `sub` matches again and publishes its own $~ over this one, leaving
       # the caller the match `sub` would have left.  The resolved pattern
       # goes down so that it is not compiled a second time; a literal with a
@@ -187,9 +203,11 @@ class String
     # same receiver is "heXlo".  It refuses a block that changed the length
     # first, as `gsub` does, so the offsets of the match still name the bytes
     # they named.  $~ stays what the search above published, or whatever the
-    # block put there.
+    # block put there.  A Hash replacement is here rather than above for the
+    # same reason: its default proc is free to reach the receiver, and CRuby
+    # answers a lookup that did with the receiver it left.
     len = self.bytesize
-    val = block.call(md[0]).to_s
+    val = (hash ? hash[md[0]] : block.call(md[0])).to_s
     raise RuntimeError, "string modified" if self.bytesize != len
     self.replace(self.byteslice(0, md.__byte_begin(0)) + val + self.byteslice(md.__byte_end(0)..-1))
   end
@@ -212,12 +230,24 @@ class String
     literal = String === pattern
     # A replacement argument wins over the block, as in CRuby.  A literal is
     # searched for as bytes and compiles nothing, as in `sub` above.
+    hash = nil
     if argc == 2
-      replacement = args[1].to_s
-      return Regexp.__gsub_lit(pattern, self, replacement) if literal
-      return Regexp.__gsub_str(pattern, self, replacement)
+      if Hash === args[1]
+        hash = args[1]
+      else
+        replacement = args[1].to_s
+        return Regexp.__gsub_lit(pattern, self, replacement) if literal
+        return Regexp.__gsub_str(pattern, self, replacement)
+      end
     end
     pattern = Regexp.new(Regexp.escape(pattern)) if literal
+    # A Hash replacement is a table the match is looked up in, as in `sub`,
+    # and CRuby's `str_gsub` walks it with the very loop it walks a block
+    # with: what the receiver looks like to each turn, the refusal of a
+    # lookup that changed its length and the `$~` left behind are the ones
+    # `__gsub_block` already answers for, so the lookup goes down as the
+    # block it stands in for.
+    return Regexp.__gsub_block(pattern, self, literal) { |m| hash[m] } if hash
     # The walk and the block call are both in `__gsub_block`.  What the loop
     # was written here for, the block reading the globals of the match it was
     # handed, a C loop publishes just as well, and it pays neither the frame
@@ -242,8 +272,10 @@ class String
     # last match of the `gsub` below, which is the one CRuby leaves behind.
     # A literal goes down as the String it was, for the reason `sub!` gives,
     # and a literal with a replacement asks the question of `__gsub_lit`
-    # itself rather than searching once to ask and again to substitute.
-    if literal && argc == 2
+    # itself rather than searching once to ask and again to substitute.  A
+    # Hash is no replacement to hand it: it goes to the `gsub` below, which
+    # looks the match up in it.
+    if literal && argc == 2 && !(Hash === args[1])
       str = Regexp.__gsub_lit(pattern, self, args[1].to_s, true)
       return nil unless str
       return self.replace(str)

--- a/mrbgems/mruby-regexp/test/string_regexp.rb
+++ b/mrbgems/mruby-regexp/test/string_regexp.rb
@@ -324,6 +324,39 @@ assert("String#sub/#gsub - replacement string takes precedence over the block") 
   assert_equal "aYcY", "abcb".gsub(/b/) { "Y" }
 end
 
+assert("String#sub/#gsub with a Hash replacement") do
+  # A Hash is a table the match is looked up in, not text to substitute.
+  assert_equal "aB", "ab".sub(/b/, "b" => "B")
+  assert_equal "aBcB", "abcb".gsub(/b/, "b" => "B")
+  # A String pattern is looked up the same way.
+  assert_equal "aBc", "abc".sub("b", "b" => "B")
+  assert_equal "aBcB", "abcb".gsub("b", "b" => "B")
+  # A key the Hash does not hold answers nil, which `to_s` spells as the empty
+  # string, and a value that is no String is asked for its `to_s` too.
+  assert_equal "B", "abc".gsub(/[abc]/, "b" => "B")
+  assert_equal "a1c", "abc".gsub(/b/, "b" => 1)
+  # A default is the answer where there is no key, as for any other lookup.
+  h = Hash.new("?")
+  h["b"] = "B"
+  assert_equal "?B?", "abc".gsub(/[abc]/, h)
+  # `\1` in the value stands for itself: only a String replacement names
+  # groups.
+  assert_equal "a<\\1>c", "abc".gsub(/(b)/, "b" => '<\1>')
+  # A Hash wins over the block, as a String replacement does.
+  assert_equal "aB", "ab".sub(/b/, {"b" => "B"}) { "Z" }
+  assert_equal "aB", "ab".gsub(/b/, {"b" => "B"}) { "Z" }
+  # The whole match is the key, groups or no groups.
+  assert_equal "aX", "abc".gsub(/(b)(c)/, "bc" => "X")
+  # A zero-width match looks the empty string up.
+  assert_equal "-a-b-", "ab".gsub(/x*/, "" => "-")
+  # Nothing matched, nothing looked up.
+  assert_equal "abc", "abc".sub(/z/, "z" => "Z")
+  assert_equal "abc", "abc".gsub(/z/, "z" => "Z")
+  # The match left behind is the last one, as with any other replacement.
+  "abcb".gsub(/b/, "b" => "B")
+  assert_equal 3, $~.begin(0)
+end
+
 assert("String#sub - wrong number of arguments") do
   # Without a block CRuby demands exactly 2 arguments, and says so.
   assert_raise_with_message(ArgumentError, "wrong number of arguments (given 0, expected 2)") do
@@ -390,6 +423,62 @@ assert("String#sub! / #gsub! with a Regexp pattern") do
   # A replacement argument wins over the block, as in `sub`/`gsub`.
   assert_equal "aYc", "abc".sub!(/b/, "Y") { "X" }
   assert_equal "aYcY", "abcb".gsub!(/b/, "Y") { "X" }
+end
+
+assert("String#sub! / #gsub! with a Hash replacement") do
+  s = "ab"
+  assert_same s, s.sub!(/b/, "b" => "B")
+  assert_equal "aB", s
+  s = "abab"
+  assert_same s, s.gsub!(/b/, "b" => "B")
+  assert_equal "aBaB", s
+  # A String pattern carries the Hash down the same way: the literal
+  # replacement path is no place for a table.
+  s = "abc"
+  assert_equal "aBc", s.sub!("b", "b" => "B")
+  s = "abcb"
+  assert_equal "aBcB", s.gsub!("b", "b" => "B")
+  # A key the Hash does not hold is still a match, and still a substitution.
+  s = "abc"
+  assert_same s, s.sub!("b", "x" => "B")
+  assert_equal "ac", s
+  # Nothing matched, nothing replaced.
+  s = "abc"
+  assert_nil s.sub!(/z/, "z" => "Z")
+  assert_nil s.gsub!(/z/, "z" => "Z")
+  assert_nil s.sub!("z", "z" => "Z")
+  assert_nil s.gsub!("z", "z" => "Z")
+  assert_equal "abc", s
+  # A match is a match even where the lookup leaves the string as it was.
+  s = "aaa"
+  assert_same s, s.sub!(/a/, "a" => "a")
+  assert_same s, s.gsub!(/a/, "a" => "a")
+  assert_equal "aaa", s
+  # A frozen receiver is refused before anything is looked up.
+  message = "can't modify frozen String"
+  assert_raise_with_message(FrozenError, message) { "abc".freeze.sub!(/a/, "a" => "X") }
+  assert_raise_with_message(FrozenError, message) { "abc".freeze.gsub!(/a/, "a" => "X") }
+end
+
+assert("String#sub / #sub! / #gsub! with a Hash default proc that reaches the receiver") do
+  # A Hash replacement goes down the tail the block form goes down, so a
+  # default proc that reaches the receiver is answered the way a block is:
+  # `sub!` builds its result from the receiver as the lookup left it, where
+  # `sub` builds from the string it matched.
+  s = "hello"
+  h = Hash.new { |_h, _k| s.upcase!; "X" }
+  assert_equal "heXlo", s.sub(/l/, h)
+  assert_equal "HELLO", s
+  s = "hello"
+  assert_equal "HEXLO", s.sub!(/l/, h)
+  s = "hello"
+  assert_equal "HEXLO", s.gsub!(/l/, h)
+  # One that changed the length is refused, as a block that did is.
+  s = "hello"
+  grow = Hash.new { |_h, _k| s << "!"; "X" }
+  assert_raise_with_message(RuntimeError, "string modified") { s.sub!(/l/, grow) }
+  s = "hello"
+  assert_raise_with_message(RuntimeError, "string modified") { s.gsub(/l/, grow) }
 end
 
 assert("String#sub! / #gsub! return nil only when nothing matched") do


### PR DESCRIPTION
## Summary

`String#sub` and `String#gsub` asked the replacement argument for its `to_s` whatever it was, so a Hash replacement reached the subject as its own `inspect` rather than as the table it is. This looks the match up in it, as CRuby does, in all four of `sub`, `sub!`, `gsub` and `gsub!`.

## Changes

| File | What |
|---|---|
| `mrbgems/mruby-regexp/mrblib/string_regexp.rb` | `sub` / `sub!` / `gsub` / `gsub!` take a Hash replacement to the block tail and look the match up in it |
| `mrbgems/mruby-regexp/test/string_regexp.rb` | three assertions: the lookup, the four bang and non-bang return values, and a default proc that reaches the receiver |

### A Hash replacement is a table, not text

```ruby
"ab".gsub(/b/, "b" => "B")   # CRuby: "aB", master: "a{\"b\" => \"B\"}"
```

The replacement went through `args[1].to_s` on the way to `__sub_str` and `__gsub_str`, and a Hash answers that with its `inspect`, so the wrong answer was substituted quietly rather than refused. `sub`, `sub!` and `gsub!` did the same.

### The lookup goes where the block call goes

CRuby's `rb_str_sub_bang` and `str_gsub` run a Hash down the tail they run a block down, with `rb_hash_aref` standing where the yield would be. Everything that follows from that is what the block form already answers for here, so the lookup takes the same route rather than a new one:

- a `\1` in what comes back names no group, since only `rb_reg_regsub` reads one and the block tail does not call it;
- a key the Hash does not hold answers nil, which `to_s` spells as the empty string, and a value that is no String is asked for its own `to_s`;
- the whole match is the key, groups or no groups;
- `$~` is left at the last match, as it is for any other replacement.

`sub` and `sub!` do the lookup at the line where they call the block. `gsub` hands `Regexp.__gsub_block` the lookup as the block it stands in for, so the walk, the step over a zero-width match and the refusal of a lookup that changed the subject's length come from the loop that already answers those questions for a block.

### The receiver a lookup left

A Hash default proc can reach the receiver, which is the one thing that tells the two tails apart, and CRuby answers it the way it answers a block that did:

```ruby
s = "hello"
h = Hash.new { |_h, _k| s.upcase!; "X" }
s.sub(/l/, h)    # "heXlo", built from the string that was matched
s.sub!(/l/, h)   # "HEXLO", built from the receiver as the lookup left it
```

So `sub!` and `gsub!` build from the receiver rather than delegating to `sub` and taking the match's snapshot, and one that changed the length raises `RuntimeError: string modified`, as a block that changed it does.

### The literal paths keep to the replacement they substitute

`Regexp.__sub_lit` and `Regexp.__gsub_lit` search for a String pattern's bytes and splice a replacement's bytes in; they have no lookup to make. A Hash is kept off them and the literal is quoted into a Regexp instead, which is what a literal with a block already does, so `"abc".sub("b", "b" => "B")` answers `"aBc"` without those two learning about tables.

The Hash has to be one, not something answering `to_hash`: mruby converts with `to_hash` nowhere, and `Regexp.__check_pattern` already demands a real String of the pattern.

## Behaviour

Every form below answered with the Hash's `inspect` before and answers CRuby's value now.

| Call | master | this PR | CRuby 4.0.6 |
|---|---|---|---|
| `"ab".sub(/b/, "b" => "B")` | `"a{\"b\" => \"B\"}"` | `"aB"` | `"aB"` |
| `"abcb".gsub(/b/, "b" => "B")` | `"a{\"b\" => \"B\"}c{\"b\" => \"B\"}"` | `"aBcB"` | `"aBcB"` |
| `"abc".sub("b", "b" => "B")` | `"a{\"b\" => \"B\"}c"` | `"aBc"` | `"aBc"` |
| `"abc".gsub(/[abc]/, "b" => "B")` | `"{\"b\" => \"B\"}{\"b\" => \"B\"}{\"b\" => \"B\"}"` | `"B"` | `"B"` |
| `"abc".gsub(/(b)/, "b" => '<\1>')` | `"a{\"b\" => \"<\\1>\"}c"` | `"a<\\1>c"` | `"a<\\1>c"` |
| `s = "ab"; s.sub!(/b/, "b" => "B")` | `"a{\"b\" => \"B\"}"` | `"aB"` | `"aB"` |
| `s = "abab"; s.gsub!(/b/, "b" => "B")` | `"a{\"b\" => \"B\"}a{\"b\" => \"B\"}"` | `"aBaB"` | `"aBaB"` |

Nothing else changes: a String replacement, a block and the arity, type and frozen checks all take the paths they took.

## Size

`.text` of `bin/mruby`, `size -A`, `build_config/ci/gcc-clang.rb`, both sides built with `rake` from an empty build directory at the same path.

| Build | master | this PR | delta |
|---|---:|---:|---:|
| `bintest` | 1,072,934 | 1,072,934 | 0 |
| `ascii-ctype` | 1,067,926 | 1,067,926 | 0 |
| `byte-string` | 1,047,942 | 1,047,942 | 0 |
| `cxx_abi` | 1,061,029 | 1,061,029 | 0 |
| `full-debug` (-O0) | 1,863,558 | 1,863,590 | +32 |

The change is mrblib, so what grows is the irep in `.rodata`: +288 bytes in each of the four `-O3` builds and +320 in `full-debug`, all of it in `mrbgems/mruby-regexp/gem_init.o`.

## Testing

`MRUBY_CONFIG=build_config/ci/gcc-clang.rb rake -m test` on all five builds, plus `rake -m test` on the default configuration.

| Build | Total | OK | KO | Crash | Skip |
|---|---:|---:|---:|---:|---:|
| `full-debug` | 2,576 | 2,570 | 0 | 0 | 6 |
| `bintest` | 2,576 | 2,562 | 0 | 0 | 14 |
| `bintest` (binary tests) | 145 | 144 | 0 | 0 | 1 |
| `cxx_abi` | 2,576 | 2,562 | 0 | 0 | 14 |
| `byte-string` | 2,495 | 2,440 | 0 | 0 | 55 |
| `ascii-ctype` | 2,567 | 2,551 | 0 | 0 | 16 |
| `default` | 2,337 | 2,282 | 0 | 0 | 55 |

Every value in the Behaviour table above, and every case the new assertions cover, was read off CRuby 4.0.6 first.

## Environment

<details>
<summary>Machine, toolchain and the compile line of each build</summary>

| | |
|---|---|
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-30-generic x86_64 |
| CPU | AMD Ryzen 9 5950X (16 cores, 32 threads) |
| C compiler | Homebrew clang 22.1.8 (`CC=clang`) |
| C++ ABI build | `clang -x c++ -std=gnu++03`; `clang++` links |
| binutils | GNU size / ld 2.47.20260726 |
| CRuby | 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM |
| rake | 13.3.1 |

`src/string.c`, with `-MMD -c`, the `-I` flags and `-o` dropped:

```console
full-debug   clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
bintest      clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -DMRB_GC_FIXED_ARENA -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK
cxx_abi      clang -g -O3 -Wall -Wundef -Wwrite-strings -Wzero-length-array -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
byte-string  clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
ascii-ctype  clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -DMRB_USE_ASCII_CTYPE -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * String substitution methods now support Hash-based replacements for `sub`, `sub!`, `gsub`, and `gsub!`.
  * Replacements can use matched text and capture values, with appropriate handling for defaults and string conversion.

* **Bug Fixes**
  * Preserved existing replacement behavior, mutation semantics, frozen-string handling, and block precedence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->