### PR TITLE
mruby-array-ext: narrow `Array#intersection` by every argument

### DIFF
--- a/mrbgems/mruby-array-ext/src/array.c
+++ b/mrbgems/mruby-array-ext/src/array.c
@@ -728,20 +728,50 @@ ary_intersection_body(mrb_state *mrb, void *data)
 {
   struct ary_intersection_ctx *ctx = (struct ary_intersection_ctx *)data;
 
-  for (mrb_int i = 0; i < ctx->argc; i++) {
-    ary_populate_temp_set(mrb, ctx->set, ctx->argv[i]);
-  }
-
-  int ai = mrb_gc_arena_save(mrb);
-  for (mrb_int i = 0; i < RARRAY_LEN(ctx->self); i++) {
-    mrb_value p = RARRAY_PTR(ctx->self)[i];
-    mrb_gc_protect(mrb, p); // p may be removed from self by kh_get(ary_set, ...)
-    khiter_t k = kh_get(ary_set, mrb, ctx->set, p);
-    if (!kh_is_end(ctx->set, k)) {
-      mrb_ary_push(mrb, ctx->result, p);
-      kh_del(ary_set, mrb, ctx->set, k);
+  /* An element belongs in the result only if every argument holds it, so the
+     arguments have to narrow the result one at a time. Pouring them all into
+     one set instead answers `self & (a | b | ...)`, which let an element
+     missing from one argument survive because another argument carried it. */
+  for (mrb_int j = 0; j < ctx->argc; j++) {
+    if (j > 0) {
+      kh_clear(ary_set, mrb, ctx->set);
     }
-    mrb_gc_arena_restore(mrb, ai);
+    ary_populate_temp_set(mrb, ctx->set, ctx->argv[j]);
+
+    /* The first argument selects out of `self` into the still empty result;
+       every later one narrows that result, which is ours alone and can be
+       compacted in place since the write position never runs ahead of the
+       read position. The set gives up an element the first time it is taken,
+       so a duplicate no longer finds it and the result keeps one of each. */
+    mrb_value src = ctx->self;
+    if (j > 0) {
+      src = ctx->result;
+      mrb_ary_modify(mrb, mrb_ary_ptr(ctx->result));
+    }
+
+    mrb_int write_pos = 0;
+    int ai = mrb_gc_arena_save(mrb);
+    for (mrb_int i = 0; i < RARRAY_LEN(src); i++) {
+      mrb_value p = RARRAY_PTR(src)[i];
+      mrb_gc_protect(mrb, p); // p may be removed from src by kh_get(ary_set, ...)
+      khiter_t k = kh_get(ary_set, mrb, ctx->set, p);
+      if (!kh_is_end(ctx->set, k)) {
+        kh_del(ary_set, mrb, ctx->set, k);
+        if (j == 0) {
+          mrb_ary_push(mrb, ctx->result, p);
+        }
+        else {
+          RARRAY_PTR(ctx->result)[write_pos] = p;
+        }
+        write_pos++;
+      }
+      mrb_gc_arena_restore(mrb, ai);
+    }
+    if (j > 0) {
+      mrb_ary_resize(mrb, ctx->result, write_pos);
+    }
+
+    if (write_pos == 0) break;
   }
 
   return ctx->result;

--- a/mrbgems/mruby-array-ext/test/array.rb
+++ b/mrbgems/mruby-array-ext/test/array.rb
@@ -1076,3 +1076,40 @@ assert('Array#include? - a comparison that runs Ruby') do
   assert_false a.include?(:missing)
   assert_equal 0, a.size
 end
+
+assert('Array#intersection narrows by every argument, not by their union') do
+  # The hash path used to pour every argument into one set and then keep the
+  # elements of `self` found in it, which answers `self & (a | b | ...)`: an
+  # element missing from one argument survived because another one carried it.
+  # The linear path always looped over the arguments and got this right, so
+  # the answer depended on whether the arguments totalled more than 32.
+  a = [1, 2]
+  b = (1..20).to_a    # holds 1 and 2
+  c = (10..30).to_a   # holds neither; 41 elements in all, so the hash path
+  assert_equal [], a.intersection(b, c)
+
+  # the same shape below the threshold, which was already correct
+  assert_equal [], a.intersection([1, 2, 3], [10, 11])
+
+  # a narrowing that keeps something; each pair below is the same question
+  # asked once above and once below the threshold, so both must answer alike
+  d = [1, 2, 3, 4]
+  assert_equal [2, 3, 4], d.intersection((1..20).to_a, (2..30).to_a)
+  assert_equal [2, 3, 4], d.intersection([1, 2, 3, 4], [2, 3, 4])
+
+  # duplicates in the receiver still collapse to one, on both paths
+  assert_equal [2, 5], [2, 2, 5].intersection((1..20).to_a, (2..30).to_a)
+  assert_equal [2, 5], [2, 2, 5].intersection([2, 5], [2, 5])
+
+  # an argument holding nothing empties the answer whatever the others hold
+  assert_equal [], [1, 2, 3].intersection((1..40).to_a, [])
+  assert_equal [], [1, 2, 3].intersection([1, 2, 3], [])
+
+  # three arguments narrow in turn, and the receiver still decides the order
+  assert_equal [3, 1], [3, 1, 2, 1].intersection((1..40).to_a, (1..40).to_a, [1, 3])
+  assert_equal [3, 1], [3, 1, 2, 1].intersection([1, 2, 3, 4], [1, 2, 3, 4], [1, 3])
+
+  # a single argument is the `&` case and must not regress
+  assert_equal [1, 2], a.intersection((1..40).to_a)
+  assert_equal [1, 2], a.intersection([1, 2, 3])
+end


### PR DESCRIPTION
## Summary

`Array#intersection` has two implementations picked by how long its arguments are, and past the threshold it answered `self & (a | b | ...)` instead of `self & a & b & ...`. An element missing from one argument survived because a different argument carried it.

## Changes

| File | What |
|---|---|
| `mrbgems/mruby-array-ext/src/array.c` | `ary_intersection_body()` lets the arguments narrow the result one at a time, reusing the one set |
| `mrbgems/mruby-array-ext/test/array.rb` | one block asking the same questions on both sides of the threshold |

### The threshold decided the answer

`ary_intersection_internal()` measures the arguments together and, past `SET_OP_HASH_THRESHOLD` (32), builds a khash set instead of walking them. The hash path poured **every** argument into that one set and then kept the elements of `self` the set held:

```ruby
[1, 2].intersection((1..20).to_a, (10..30).to_a)  #=> [1, 2], where CRuby answers []
```

`1` and `2` are in the first argument and in neither the second, so the answer is `[]`. The linear path loops over the arguments and requires a hit in each, so it was right all along, and the same question got opposite answers on either side of the threshold:

```ruby
[1, 2].intersection([1, 2, 3], [10, 11])  #=> [], five argument elements, the linear path
```

An argument holding nothing did not even empty the answer:

```ruby
[1, 2, 3].intersection((1..40).to_a, [])  #=> [1, 2, 3], where CRuby answers []
```

`&` takes a single argument and was never affected, and neither was `intersect?`, which walks the arguments itself.

### Narrowing one argument at a time

The fix keeps the one set and reuses it, `kh_clear()` between arguments:

- the **first** argument selects out of `self` into the still empty result, and by giving up each element the first time it is taken (`kh_del`) it also collapses duplicates in the receiver, which is what the code already did;
- every **later** argument narrows that result in place. The result is a fresh array nothing else can reach, and the write position never runs ahead of the read position, so no intermediate array is allocated;
- an empty result stops the walk.

Total work is the same insertions into the set as before, plus one lookup per surviving element per argument after the first. The single-argument case does exactly what it did.

## Behaviour

Measured against CRuby 4.0.6. Bold marks the answers that were wrong.

| expression | master | this PR | CRuby |
| --- | --- | --- | --- |
| `[1, 2].intersection((1..20).to_a, (10..30).to_a)` | **[1, 2]** | [] | [] |
| `[1, 2, 3, 4].intersection((1..20).to_a, (2..30).to_a)` | **[1, 2, 3, 4]** | [2, 3, 4] | [2, 3, 4] |
| `[1, 2, 3].intersection((1..40).to_a, [])` | **[1, 2, 3]** | [] | [] |
| `[3, 1, 2, 1].intersection((1..40).to_a, (1..40).to_a, [1, 3])` | **[3, 1, 2]** | [3, 1] | [3, 1] |
| `[2, 2, 5].intersection((1..20).to_a, (2..30).to_a)` | [2, 5] | [2, 5] | [2, 5] |
| `[1, 2].intersection([1, 2, 3], [10, 11])` | [] | [] | [] |
| `[1, 2].intersection((1..40).to_a)` | [1, 2] | [1, 2] | [1, 2] |
| `[].intersection((1..40).to_a, (1..40).to_a)` | [] | [] | [] |

The last four rows are the ones that already agreed with CRuby and had to keep agreeing: the linear path, the receiver's duplicates, the single argument that `&` is, and an empty receiver.

`intersection` with no argument at all answers `[]` in both columns where CRuby answers a copy of the receiver. That is `argc == 0` returning early, not the arguments narrowing anything, so it is left alone here.

## Speed

Callgrind `Ir` at 20,000 turns, with the same measurement run against an empty loop of the same length and subtracted. `a` is `(1..20).to_a`, `b` is `(1..40).to_a`, `s` is `[1, 2, 3]`. Default build config. Every argument is the same array in the multi-argument rows so that both columns answer alike and the counts compare like with like.

| | master `Ir` | this PR `Ir` | ratio |
|---|---|---|---|
| `a.intersection(b)` | 637,925,291 | 638,225,291 | 1.00x |
| `a.intersection(b, b)` | 733,634,479 | 788,685,681 | 1.08x |
| `a.intersection(b, b, b)` | 1,016,815,983 | 1,126,611,726 | 1.11x |
| `a.intersection(s, s)` | 578,389,560 | 578,389,560 | 1.00x |

The last row is the linear path, which is untouched and comes out bit-identical, as does the empty loop both columns are measured against. The single argument row is 15 `Ir` a call apart, which is the loop the one argument now runs in.

Each argument after the first costs one `kh_clear()` of the set and one lookup per element still standing: 2,753 `Ir` a call here for the second argument, 2,737 for the third, against a receiver of 20 elements. That is what answering the question actually asks for; the old cost was the cost of answering a different one.

## Size

`bin/mruby` `.text`, `size -A`, each build made from an empty build directory at the same path:

| Build | master | this PR | delta |
|---|---|---|---|
| `full-debug` (-O0) | 1,915,078 | 1,915,302 | +224 |
| `bintest` | 1,309,222 | 1,309,526 | +304 |
| `cxx_abi` | 1,336,121 | 1,336,409 | +288 |
| `byte-string` | 1,273,430 | 1,273,734 | +304 |
| `ascii-ctype` | 1,295,670 | 1,295,974 | +304 |

The default config, where the Speed numbers were taken, is 1,220,142 against 1,220,446, the same +304. All of it is `mruby-array-ext/src/array.o`, whose `.text` goes 21,461 to 21,765 there: the second loop body the narrowing walk needs.

## Testing

`build_config/ci/gcc-clang.rb`, all five builds plus the bintests, built from an empty build directory:

| Commit | full-debug | bintest | bintest (bin) | cxx_abi | byte-string | ascii-ctype |
|---|---|---|---|---|---|---|
| master (`72ff8d312`) | 2587 OK | 2579 OK | 145 OK | 2579 OK | 2457 OK | 2569 OK |
| narrow by every argument | 2588 OK | 2580 OK | 145 OK | 2580 OK | 2458 OK | 2570 OK |

0 KO, 0 crashes, no new compiler warnings anywhere.

The one added block is in `mrbgems/mruby-array-ext/test/array.rb`. Each question in it is asked twice, once with arguments long enough for the hash path and once short enough for the linear one, and the two must answer alike: the empty narrowing, a narrowing that keeps elements, an argument that holds nothing, three arguments in turn, the receiver's duplicates collapsing, and the single-argument shape that `&` is as a no-regression check.

Every expected value was read off CRuby 4.0.6 rather than written from memory. Building the block against master's `array.c` fails it on four assertions, which are the four bold rows above.

## Environment

<details>
<summary>Host</summary>

| | |
|---|---|
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-30-generic x86_64 |
| CPU | AMD Ryzen 9 5950X (16C/32T) |
| Memory | 64 GiB |
| C compiler | gcc 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1) |
| binutils | GNU Binutils 2.47.20260726 |
| CRuby | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |
| rake | 13.3.1 |
| valgrind | 3.27.1 |

</details>

<details>
<summary>Compile lines, one per build</summary>

`mrbgems/mruby-array-ext/src/array.c` as each build actually compiles it, with `-MMD -c`, `-I` and `-o` dropped. `cxx_abi` is `gcc -x c++`, not `g++`; `g++` only links there. `enable_debug()` puts `-g3 -O0` after the toolchain's `-g -O3`, so `full-debug` is the one build at `-O0`.

```console
# full-debug
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRBGEM_MRUBY_ARRAY_EXT_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-array-ext/src/array.c

# bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_ARRAY_EXT_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK mrbgems/mruby-array-ext/src/array.c

# cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_ARRAY_EXT_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-array-ext/src/array.c

# byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_ARRAY_EXT_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-array-ext/src/array.c

# ascii-ctype
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_REGEXP_PARSE_DEPTH_LIMIT=512 -DMRBGEM_MRUBY_ARRAY_EXT_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-array-ext/src/array.c

# default config, where the Speed numbers and the extra Size line were measured
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_ARRAY_EXT_VERSION=0.0.0 -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK mrbgems/mruby-array-ext/src/array.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected multi-array intersections to retain only values present in every provided array.
  * Ensured duplicate values are removed and result ordering remains consistent.
  * Improved handling of empty arrays and three-or-more array intersections.

* **Tests**
  * Added regression coverage for multi-argument intersections and single-argument equivalence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->