### PR TITLE
array.c: take a comparison block's answer in every form it has

### DIFF
--- a/src/array.c
+++ b/src/array.c
@@ -2276,6 +2276,35 @@ insertion_sort_str(mrb_state *mrb, mrb_value *a, mrb_int size)
   }
 }
 
+/* A comparison block answers with whatever object stands for the ordering it
+   found, and only one of those answers is an error. An Integer is its own
+   sign, big or small; `nil` is the block saying the pair has no order at all;
+   anything else is asked `> 0` and then `< 0`, and is a tie when neither
+   holds. That last arm is what lets a Float, or any object carrying the two
+   operators, order a sort, and it is the map `Enumerable#max` and `#min`
+   already read their own block through. It calls back into the VM, which is
+   the price of ordering by an object that answers only to sends; the Integer
+   arm ahead of it takes every block that returns `a <=> b`. */
+static mrb_int
+cmpint(mrb_state *mrb, mrb_value c, mrb_value a, mrb_value b)
+{
+  if (mrb_fixnum_p(c)) {
+    return mrb_fixnum(c);
+  }
+  if (mrb_nil_p(c)) {
+    mrb_raisef(mrb, E_ARGUMENT_ERROR, "comparison of %T with %T failed", a, b);
+  }
+#ifdef MRB_USE_BIGINT
+  if (mrb_bigint_p(c)) {
+    return mrb_bint_cmp(mrb, c, mrb_fixnum_value(0));
+  }
+#endif
+  mrb_value zero = mrb_fixnum_value(0);
+  if (mrb_test(mrb_funcall_argv1(mrb, c, MRB_OPSYM(gt), zero))) return 1;
+  if (mrb_test(mrb_funcall_argv1(mrb, c, MRB_OPSYM(lt), zero))) return -1;
+  return 0;
+}
+
 static mrb_bool
 sort_cmp(mrb_state *mrb, mrb_value ary, mrb_value a_val, mrb_value b_val, mrb_value blk)
 {
@@ -2317,21 +2346,25 @@ sort_cmp(mrb_state *mrb, mrb_value ary, mrb_value a_val, mrb_value b_val, mrb_va
     else {
       cmp = mrb_cmp(mrb, a_val, b_val);
     }
+    /* -2 is how the comparisons above report a pair they cannot order. It is
+       a value a block may answer with, so the test for it stays on this side
+       of the branch, where the answers are the ones written here. */
+    if (cmp == -2) {
+      mrb_gc_arena_restore(mrb, ai);
+      mrb_raise(mrb, E_ARGUMENT_ERROR, "comparison failed");
+    }
   }
   else {
     mrb_value args[2] = {a_val, b_val};
     mrb_value c = mrb_yield_argv(mrb, blk, 2, args);
-    if (mrb_nil_p(c) || !mrb_fixnum_p(c)) {
-      cmp = -2;
-    }
-    else {
-      cmp = mrb_fixnum(c);
-    }
+    /* The pair goes to `cmpint()` out of `args`, which the yield leaves as it
+       found it, rather than out of the parameters: one arm of the map calls
+       Ruby, and holding the two in registers across the yield so that arm can
+       reach them costs every comparison the sort makes, Integer answers
+       included. */
+    cmp = cmpint(mrb, c, args[0], args[1]);
   }
   mrb_gc_arena_restore(mrb, ai);
-  if (cmp == -2) {
-    mrb_raise(mrb, E_ARGUMENT_ERROR, "comparison failed");
-  }
   if (RARRAY_PTR(ary) != p || RARRAY_LEN(ary) != n) {
     mrb_raise(mrb, E_RUNTIME_ERROR, "array modified during sort");
   }

--- a/test/t/array.rb
+++ b/test/t/array.rb
@@ -615,6 +615,77 @@ assert('Array#sort with a NaN in it') do
   assert_raise(ArgumentError) { ([1.0] * 40 + [nan]).sort }
 end
 
+assert('Array#sort with a block that answers with something other than an Integer') do
+  # The block's answer stands for an ordering, and an Integer is one of the
+  # forms it takes rather than the only one: anything else is asked `> 0` and
+  # then `< 0`, and is a tie when neither holds. `nil` is the one answer with
+  # no order in it. This is the map `Enumerable#max` and `#min` already read
+  # their own block through, so an object that orders one orders the other.
+  class SortSign
+    def initialize(n)
+      @n = n
+    end
+
+    def >(other)
+      @n > other
+    end
+
+    def <(other)
+      @n < other
+    end
+  end
+
+  # A short array and a long one take different routes through the sort, so
+  # both are ordered here.
+  descending = Array.new(40) { |i| 40 - i }
+  ascending = Array.new(40) { |i| i + 1 }
+
+  assert_equal [1, 2, 3], [3, 1, 2].sort { |a, b| SortSign.new(a - b) }
+  assert_equal ascending, descending.sort { |a, b| SortSign.new(a - b) }
+  assert_equal [1, 2, 3], [3, 1, 2].sort! { |a, b| SortSign.new(a - b) }
+  assert_equal 3, [3, 1, 2].max { |a, b| SortSign.new(a - b) }
+
+  # An Integer answer is read for its sign alone. -2 is the value the sort
+  # keeps for a pair it cannot order, and a block that answered with it used to
+  # be taken for one.
+  assert_equal [1, 2, 3], [3, 1, 2].sort { |a, b| (a <=> b) * 2 }
+
+  # The wording is the one the rest of the tree gives a pair with no order,
+  # `Comparable` and `Enumerable#max` included.
+  assert_raise_with_message(ArgumentError, "comparison of Integer with Integer failed") {
+    [3, 1, 2].sort { |a, b| nil }
+  }
+end
+
+assert('Array#sort with a block that answers with a Float') do
+  skip unless Object.const_defined?(:Float)
+
+  assert_equal [1, 2, 3], [3, 1, 2].sort { |a, b| (a - b).to_f }
+  assert_equal Array.new(40) { |i| i + 1 },
+               Array.new(40) { |i| 40 - i }.sort { |a, b| (a - b).to_f }
+
+  # A NaN is greater than and less than nothing at all, so every pair it
+  # answers for is a tie and the sort has nothing to order by. Which order it
+  # leaves is its own business; that it answers at all is what is asserted.
+  assert_equal [1, 2, 3], [3, 1, 2].sort { |a, b| Float::NAN }.sort
+end
+
+assert('Array#sort with a block that answers with a big integer') do
+  # A big integer is read for its sign, which is the one thing it can say about
+  # an ordering. The shift count is a variable because a constant shift out of
+  # mrb_int range makes the build fail rather than raise.
+  begin
+    k = 100
+    big = 1 << k
+  rescue RangeError
+    skip 'requires mruby-bigint'
+  end
+
+  assert_equal [1, 2, 3], [3, 1, 2].sort { |a, b| a > b ? big : -big }
+  assert_equal Array.new(40) { |i| i + 1 },
+               Array.new(40) { |i| 40 - i }.sort { |a, b| a > b ? big : -big }
+end
+
 assert('Array#freeze') do
   a = [].freeze
   assert_raise(FrozenError) do


### PR DESCRIPTION
## Summary

`sort_cmp()` reads a comparison block's return value with `mrb_fixnum_p()` and folds every other answer into a single `ArgumentError, "comparison failed"` (`src/array.c`). CRuby reads the same value through `rb_cmpint()` (`compar.c`), a four-way map: `nil` goes to `rb_cmperr()`, a Fixnum is its own value, a Bignum is its sign, and anything else is asked `> 0` and then `< 0`, answering 0 when both are false. Only the first arm is an error, and the last arm is what lets a Float, a big integer and any object with the two operators order a sort.

`Enumerable#max` and `#min` already read their own block through that map (`mrblib/enum.rb`, `mrbgems/mruby-enum-ext/mrblib/enum.rb`): they guard `nil` and then send `> 0` or `< 0` to whatever came back. So one engine has two contracts for the same kind of block, and `max` takes what `sort` will not:

```ruby
class Sign
  def initialize(n); @n = n; end
  def >(o); @n > o; end
  def <(o); @n < o; end
end

[3, 1, 2].max  {|a, b| Sign.new(a - b) }   # 3 on master
[3, 1, 2].sort {|a, b| Sign.new(a - b) }   # ArgumentError (comparison failed) on master
```

That is the case for the change, rather than any single row of the table below. It reaches `Array#sort`, `Array#sort!` and `Enumerable#sort`, which delegate to it (`mrblib/array.rb`, `mrblib/enum.rb`).

## Changes

| File | What |
|---|---|
| `src/array.c` | `cmpint()` holds the whole map and `sort_cmp()` reads the block through it; the `-2` the sort keeps for a pair it cannot order moves into the branch that produces it |
| `test/t/array.rb` | three assert blocks: the map itself, the Float arm, the big integer arm |

### `cmpint()`

The four arms in the order `rb_cmpint()` has them: an Integer is its own value, `nil` raises `ArgumentError`, a big integer is its sign through `mrb_bint_cmp()`, and anything else is sent `> 0` and then `< 0` and is a tie when neither holds. The Integer arm stays the fast path it is today and takes every block that returns `a <=> b`.

The last arm calls back into the VM, which is worth stating plainly: it is off the Integer path, it is the arm CRuby also spends a `rb_funcall()` on, and there is no way to order by an arbitrary object without asking it. The `Speed` section below measures what it costs a sort that never reaches it.

### The `-2` sentinel

`sort_cmp()` used `-2` for a pair it cannot order and raised on it after both branches had run. `-2` is also a value a block can answer with, so `sort {|a, b| (a <=> b) * 2 }` raised instead of sorting. It is produced only by the comparisons written in the no-block branch (the NaN arm and `mrb_cmp()`), so the test for it moves there with them, and the block's answer is read for its sign alone.

### Where the pair comes from

`cmpint()` takes the two elements for the `nil` arm's message, and it gets them out of `args`, which `mrb_yield_argv()` leaves as it found it, rather than out of `sort_cmp()`'s parameters. Holding the two in registers across the yield so an arm that calls Ruby can reach them costs every comparison the sort makes, Integer answers included: 16,985,373 Ir in `sort_cmp()` against master's 14,601,461 on the benchmark below, about 8 Ir on each of its 297,989 calls. Read back out of `args` the figure is 14,303,472.

## Behaviour

| | master | this PR | CRuby 4.0.6 |
|---|---|---|---|
| `[3, 1, 2].sort {\|a, b\| (a - b).to_f }` | `ArgumentError: comparison failed` | `[1, 2, 3]` | `[1, 2, 3]` |
| `[3, 1, 2].sort {\|a, b\| a > b ? 2**100 : -(2**100) }` | `ArgumentError: comparison failed` | `[1, 2, 3]` | `[1, 2, 3]` |
| `[3, 1, 2].sort {\|a, b\| Sign.new(a - b) }` | `ArgumentError: comparison failed` | `[1, 2, 3]` | `[1, 2, 3]` |
| `[3, 1, 2].sort {\|a, b\| (a <=> b) * 2 }` | `ArgumentError: comparison failed` | `[1, 2, 3]` | `[1, 2, 3]` |
| `[3, 1, 2].sort {\|a, b\| Float::NAN }` | `ArgumentError: comparison failed` | `[3, 1, 2]` | `[3, 1, 2]` |
| `[3, 1, 2].sort {\|a, b\| nil }` | `ArgumentError: comparison failed` | `ArgumentError: comparison of Integer with Integer failed` | `ArgumentError: comparison of Integer with 2 failed` |
| `[3, 1, 2].sort {\|a, b\| "x" }` | `ArgumentError: comparison failed` | `ArgumentError: comparison of String with Integer failed` | `ArgumentError: comparison of String with 0 failed` |
| `[3, 1, 2].sort {\|a, b\| false }` | `ArgumentError: comparison failed` | `NoMethodError: undefined method '>' for FalseClass` | `NoMethodError: undefined method '>' for false` |

The last three rows raise the class CRuby raises. The operands are spelled the way the rest of this tree spells them: `rb_cmperr()` inspects a special constant or a Float and names the class of anything else, while `mrb_raisef()`'s `%T` and `Comparable`'s `#{other.class}` always name the class. Following that is what the `nil` arm does here; a second rendering of an operand is not this PR's to introduce.

`Float::NAN` is greater than and less than nothing at all, so every pair it answers for is a tie and the sort has nothing to order by, in CRuby too.

## Speed

Callgrind `Ir`, `bintest` build, 20,000 pseudo-random integers built without `Random` so both sides see the same array. Each figure is the run minus a control that builds the array and does not sort it, so the numbers are the sort alone. The control is 32,213,383 on master and 32,213,432 here.

| | master | this PR | delta |
|---|---:|---:|---:|
| `a.sort {\|p, q\| p <=> q }` | 321,990,758 | 321,692,766 | -297,992 (-0.09%) |
| `a.sort` | 9,111,262 | 9,111,262 | 0 |

The block sort makes 297,989 calls into `sort_cmp()` on both sides, and `sort_cmp()` itself goes from 14,601,461 Ir to 14,303,472, which is one instruction less on each of them: the `cmp $-2` and its branch leave the tail the two branches shared, and the Integer arm gains a `mov` where the answer now comes back through `cmpint()`. The no-block sort is where that test moved to and is unmoved to the instruction.

## Size

`bin/mruby` `.text`, `size -A`, in the five `build_config/ci/gcc-clang.rb` builds, each side built from an empty build directory at the same path:

| Build | master | this PR | delta |
|---|---:|---:|---:|
| `full-debug` | 1,865,366 | 1,865,670 | +304 |
| `bintest` | 1,075,254 | 1,075,542 | +288 |
| `cxx_abi` | 1,063,333 | 1,063,621 | +288 |
| `byte-string` | 1,050,134 | 1,050,422 | +288 |
| `ascii-ctype` | 1,070,134 | 1,070,422 | +288 |

The growth is the three arms `sort_cmp()` did not have.

## Testing

`rake -m test`, `build_config/ci/gcc-clang.rb`, both sides built from an empty build directory:

| Build | master (`72ff8d312`) | this PR |
|---|---|---|
| `full-debug` | 2587 OK, 0 KO, 0 Crash, 7 skip | 2590 OK, 0 KO, 0 Crash, 7 skip |
| `bintest` | 2579 OK, 0 KO, 0 Crash, 15 skip | 2582 OK, 0 KO, 0 Crash, 15 skip |
| `cxx_abi` | 2579 OK, 0 KO, 0 Crash, 15 skip | 2582 OK, 0 KO, 0 Crash, 15 skip |
| `byte-string` | 2457 OK, 0 KO, 0 Crash, 56 skip | 2460 OK, 0 KO, 0 Crash, 56 skip |
| `ascii-ctype` | 2569 OK, 0 KO, 0 Crash, 16 skip | 2572 OK, 0 KO, 0 Crash, 16 skip |

The `bintest` build's bintests are 144 OK, 0 KO, 1 skip on both sides. No compiler warnings on either side.

`mrb_fixnum_p()`, `mrb_nil_p()`, `mrb_bigint_p()` and `mrb_test()` are all boxing macros, so `build_config/boxing.rb`'s three boxings are run at both integer widths as well. The three new blocks run, none of them skipping, in all six:

| Build | master (`72ff8d312`) | this PR |
|---|---|---|
| `boxing-no-i64` | 2587 OK, 0 KO, 0 Crash, 7 skip | 2590 OK, 0 KO, 0 Crash, 7 skip |
| `boxing-no-i32` | 2586 OK, 0 KO, 0 Crash, 8 skip | 2589 OK, 0 KO, 0 Crash, 8 skip |
| `boxing-word-i64` | 2587 OK, 0 KO, 0 Crash, 7 skip | 2590 OK, 0 KO, 0 Crash, 7 skip |
| `boxing-word-i32` | 2586 OK, 0 KO, 0 Crash, 8 skip | 2589 OK, 0 KO, 0 Crash, 8 skip |
| `boxing-nan-i64` | 2587 OK, 0 KO, 0 Crash, 7 skip | 2590 OK, 0 KO, 0 Crash, 7 skip |
| `boxing-nan-i32` | 2586 OK, 0 KO, 0 Crash, 8 skip | 2589 OK, 0 KO, 0 Crash, 8 skip |

The three new assert blocks are the three arms. The general one covers an object with `>` and `<`, the `-2` answer and `nil` with its message, in a three-element array (insertion sort) and a forty-element one (heap sort), and through `sort`, `sort!` and `max`. The other two guard on what the build has, and `build_config/host-nofloat.rb`, which has neither `Float` nor `mruby-bigint`, is where both guards are exercised:

| Build | master (`72ff8d312`) | this PR |
|---|---|---|
| `host-nofloat` | 1905 OK, 0 KO, 0 Crash, 110 skip | 1906 OK, 0 KO, 0 Crash, 112 skip |

Each of the three fails on master: with `src/array.c` reverted and `test/t/array.rb` kept, all three raise `ArgumentError: comparison failed`.

## Environment

<details>
<summary>Host</summary>

| | |
|---|---|
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-30-generic x86_64 |
| CPU | AMD Ryzen 9 5950X (16C/32T) |
| Memory | 64 GiB |
| C compiler | Homebrew clang 22.1.8 |
| binutils | GNU Binutils 2.47.20260726 |
| valgrind | valgrind 3.27.1 |
| CRuby | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |
| rake | 13.3.1 |

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved array sorting with custom comparison blocks.
  * Comparison blocks can now return non-integer ordering objects, floating-point values, and large integers.
  * Added clearer handling for `nil`, unordered values, and special numeric cases.
  * Updated related behavior for array maximum calculations.

* **Tests**
  * Expanded coverage for short and long arrays, in-place sorting, sign-based ordering, and edge cases such as `NaN`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->