### PR TITLE
mruby-regexp: fold a leading option group into what `Regexp#to_s` prints

### DIFF
--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -855,6 +855,138 @@ mrb_re_flags_cat(mrb_state *mrb, mrb_value str, uint32_t flags)
   }
 }
 
+/* The options one letter of an inline group names, which is the reading
+   parse_flags() gives the same letter in Regexp.new's flags argument: `m` is
+   both halves of Ruby's multiline, and i/m/x are the only options. Zero for
+   anything else, which is what ends a run of letters.
+
+   re_flag_letters[] above is the other direction and cannot serve here: it
+   holds one bit of the multiline pair, enough to decide a letter to print,
+   where a group being folded has to carry the pair into a compile. */
+static uint32_t
+re_option_letter_bits(char c)
+{
+  switch (c) {
+  case 'i': return RE_FLAG_IGNORECASE;
+  case 'm': return RE_FLAG_MULTILINE | RE_FLAG_DOTALL;
+  case 'x': return RE_FLAG_EXTENDED;
+  default:  return 0;
+  }
+}
+
+struct re_trial_compile {
+  mrb_regexp_pattern *pat;
+  const char *ptr;
+  mrb_int len;
+  uint32_t flags;
+};
+
+static mrb_value
+re_trial_compile_body(mrb_state *mrb, void *ud)
+{
+  struct re_trial_compile *t = (struct re_trial_compile*)ud;
+  mrb_re_compile(mrb, t->pat, t->ptr, t->len, t->flags);
+  return mrb_nil_value();
+}
+
+/* Whether `ptr`/`len` is a pattern in its own right under `flags`.
+   mrb_re_compile() reports a bad pattern by raising, so the trial runs under
+   mrb_protect_error(), which returns here however the compile ended and
+   leaves neither the exception nor the arena behind. The pattern is held by
+   the caller's frame rather than the body's, since a compile that raises
+   abandons the body's: what it allocated hangs off `pat`, and mrb_re_free()
+   is what reaches it either way. */
+static mrb_bool
+re_compiles_alone(mrb_state *mrb, const char *ptr, mrb_int len, uint32_t flags)
+{
+  struct re_trial_compile t;
+  mrb_bool error;
+
+  t.pat = (mrb_regexp_pattern*)mrb_calloc(mrb, 1, sizeof(mrb_regexp_pattern));
+  t.ptr = ptr;
+  t.len = len;
+  t.flags = flags;
+  mrb_protect_error(mrb, re_trial_compile_body, &t, &error);
+  mrb_re_free(mrb, t.pat);
+  return !error;
+}
+
+/* Fold a leading option group of `src` into the flags to print, leaving the
+   text that is left in `*ptrp`/`*lenp` and the flags in `*flagsp`. This is
+   what makes /(?i)a/ and /a/i print alike, as they do in CRuby
+   (rb_reg_str_with_term(), re.c).
+
+   Two shapes fold, and only at the very start of the source:
+
+   - a toggle, "(?imx-imx)", governs everything after it, so its letters are
+     the flags of the whole and the group itself is gone. Several in a row
+     fold in turn.
+   - a scoped group, "(?imx-imx:...)", governs only what it encloses, so it
+     folds only when what it encloses is the whole source. Its ")" being the
+     last byte does not say that: in "(?i:a)(b)" the last byte closes another
+     group. What settles it is whether the text between them is a pattern on
+     its own, which is one trial compile, the same question and the same
+     price CRuby pays through onig_new().
+
+   A group that folds neither way is not the only thing left as written: the
+   toggles already peeled ahead of it go back too, which is why /(?i)(?=a)/
+   prints its "(?i)" where /(?i)(?m:a)/ does not. */
+static void
+re_fold_leading_group(mrb_state *mrb, mrb_value src, const char **ptrp, mrb_int *lenp, uint32_t *flagsp)
+{
+  const char *ptr = RSTRING_PTR(src);
+  mrb_int len = RSTRING_LEN(src);
+  uint32_t flags = *flagsp;
+
+  /* "(?" and the shortest thing that can close a group: below that there is
+     no group to read. */
+  while (len >= 4 && ptr[0] == '(' && ptr[1] == '?') {
+    const char *p = ptr + 2;
+    mrb_int n = len - 2;
+    uint32_t on = flags;
+    uint32_t bits;
+
+    while (n > 0 && (bits = re_option_letter_bits(*p)) != 0) {
+      on |= bits;
+      p++; n--;
+    }
+    /* A '-' with nothing after it names no letter to turn off, and reading
+       past it would run off the end. */
+    if (n > 1 && *p == '-') {
+      p++; n--;
+      while (n > 0 && (bits = re_option_letter_bits(*p)) != 0) {
+        on &= ~bits;
+        p++; n--;
+      }
+    }
+
+    if (n > 0 && *p == ')') {
+      flags = on;
+      ptr = p + 1;
+      len = n - 1;
+      continue;
+    }
+
+    /* n counts ':' and ')' as well as what lies between, which may be empty:
+       "(?:)" is a group around nothing. */
+    if (n >= 2 && *p == ':' && p[n-1] == ')' && re_compiles_alone(mrb, p + 1, n - 2, on)) {
+      flags = on;
+      ptr = p + 1;
+      len = n - 2;
+    }
+    else {
+      ptr = RSTRING_PTR(src);
+      len = RSTRING_LEN(src);
+      flags = *flagsp;
+    }
+    break;
+  }
+
+  *ptrp = ptr;
+  *lenp = len;
+  *flagsp = flags;
+}
+
 /*
  * Regexp#to_s - (?on-off:source) format
  *
@@ -863,14 +995,23 @@ mrb_re_flags_cat(mrb_state *mrb, mrb_value str, uint32_t flags)
  * meaningful once it is interpolated into another pattern: written as
  * "(?i:a)", the embedded source in /#{/a/i}b/m would pick up the
  * enclosing pattern's flags instead of carrying only its own.
+ *
+ * A source that already opens with an option group has it folded into those
+ * flags rather than printed inside them, so the printed form names each
+ * option once. Regexp#inspect prints the source as written and is not
+ * touched; CRuby draws the same line.
  */
 static mrb_value
 regexp_to_s(mrb_state *mrb, mrb_value self)
 {
   mrb_value src = re_check_initialized(mrb, self);
   uint32_t flags = get_iflags(mrb, self);
+  const char *ptr;
+  mrb_int len;
   char off[RE_FLAG_LETTER_COUNT];
   mrb_int noff = 0;
+
+  re_fold_leading_group(mrb, src, &ptr, &len, &flags);
 
   mrb_value result = mrb_str_new_lit(mrb, "(?");
   for (size_t i = 0; i < RE_FLAG_LETTER_COUNT; i++) {
@@ -886,7 +1027,7 @@ regexp_to_s(mrb_state *mrb, mrb_value self)
     mrb_str_cat(mrb, result, off, noff);
   }
   mrb_str_cat_lit(mrb, result, ":");
-  mrb_str_cat_str(mrb, result, src);
+  mrb_str_cat(mrb, result, ptr, len);
   mrb_str_cat_lit(mrb, result, ")");
   return result;
 }

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -295,6 +295,62 @@ assert("Regexp#to_s") do
   assert_true(/#{Regexp.new("a b", Regexp::EXTENDED)}c d/.match?("abc d"))
 end
 
+assert("Regexp#to_s - a leading option group folds into the printed flags") do
+  # a toggle governs everything after it, so its letters are the flags of the
+  # whole and the group is gone: the two spellings of /a/i print alike
+  assert_equal "(?i-mx:a)", Regexp.new("(?i)a").to_s
+  assert_equal Regexp.new("a", Regexp::IGNORECASE).to_s, Regexp.new("(?i)a").to_s
+  assert_equal "(?x-mi:a b)", Regexp.new("(?x)a b").to_s
+  assert_equal "(?mi-x:a)", Regexp.new("(?i)(?m)a").to_s
+  # a '-' run turns letters off, including one the object carries
+  assert_equal "(?-mix:a)", Regexp.new("(?-i)a", Regexp::IGNORECASE).to_s
+  assert_equal "(?i-mx:)", Regexp.new("(?i)").to_s
+
+  # a scoped group governs only what it encloses, so it folds only when that
+  # is the whole source
+  assert_equal "(?i-mx:a)", Regexp.new("(?i:a)").to_s
+  assert_equal "(?i-mx:a)", Regexp.new("(?i-m:a)").to_s
+  assert_equal "(?-mix:)", Regexp.new("(?:)").to_s
+  assert_equal "(?mi-x:a)", Regexp.new("(?i:a)", Regexp::MULTILINE).to_s
+  # one level only: the group inside is text like any other
+  assert_equal "(?i-mx:(?m:a))", Regexp.new("(?i:(?m:a))").to_s
+  # a toggle ahead of it folds first, and then it does
+  assert_equal "(?mi-x:a)", Regexp.new("(?i)(?m:a)").to_s
+
+  # what the group does not enclose stays outside it, so nothing folds
+  assert_equal "(?-mix:(?i:a)b)", Regexp.new("(?i:a)b").to_s
+  # the ')' at the end closes the second group, not the first: only trying
+  # the text between them as a pattern of its own tells the two apart
+  assert_equal "(?-mix:(?i:a)(b))", Regexp.new("(?i:a)(b)").to_s
+  assert_equal "(?-mix:a(?i:b))", Regexp.new("a(?i:b)").to_s
+
+  # a group that is not an option group is not one to fold, and the toggles
+  # already peeled ahead of it are printed again with it
+  assert_equal "(?-mix:(?=a))", Regexp.new("(?=a)").to_s
+  assert_equal "(?-mix:(?i)(?=a))", Regexp.new("(?i)(?=a)").to_s
+  assert_equal "(?-mix:(?#c)a)", Regexp.new("(?#c)a").to_s
+  assert_equal "(?-mix:(?<n>a))", Regexp.new("(?<n>a)").to_s
+
+  # inspect prints the source as written either way
+  assert_equal "/(?i)a/", Regexp.new("(?i)a").inspect
+  assert_equal "/(?i:a)/m", Regexp.new("(?i:a)", Regexp::MULTILINE).inspect
+  # and == compares source and options, which the fold does not touch
+  assert_false Regexp.new("(?i)a") == Regexp.new("a", Regexp::IGNORECASE)
+end
+
+assert("Regexp#to_s - a folded form matches what it was folded from") do
+  ["(?i)a", "(?i:a)", "(?i:a)b", "(?i:a)(b)", "(?x)a b", "(?i)(?m)a",
+   "(?i:a|b)", "(?i:a)|b", "(?m)a.b", "(?i:(?m:a))"].each do |src|
+    re = Regexp.new(src)
+    round = Regexp.new(re.to_s)
+    ["a", "A", "ab", "AB", "a b", "a\nb", "b", "a.b"].each do |input|
+      assert_equal re.match?(input), round.match?(input), "#{src.inspect} on #{input.inspect}"
+      # and carries only its own flags into a pattern that has others
+      assert_equal re.match?(input), /#{re}/m.match?(input), "#{src.inspect} nested, on #{input.inspect}"
+    end
+  end
+end
+
 assert("Regexp#to_s - interpolation") do
   inner = Regexp.new("abc", Regexp::IGNORECASE)
   # the inner Regexp keeps its own flags where the outer has none


### PR DESCRIPTION
## Summary

`Regexp#to_s` printed the flags the object carries and then the source as written, so a source that already opens with an option group carried that group twice over: once as the `(?-mix:` it was wrapped in, and once inside it. Two spellings of the same matcher printed as two different strings, where CRuby prints one.

```ruby
/(?i)a/.to_s                # mruby: "(?-mix:(?i)a)",  CRuby: "(?i-mx:a)"
/(?i:a)/.to_s               # mruby: "(?-mix:(?i:a))", CRuby: "(?i-mx:a)"
/(?i)a/.to_s == /a/i.to_s   # mruby: false,            CRuby: true
```

Both forms recompile to the same matcher, so nothing matched differently. What saw it was code that normalises a Regexp through `to_s`, and `/#{re}/` interpolation, which is a reading of the same printed form.

## Changes

| File | What |
| --- | --- |
| `mrbgems/mruby-regexp/src/regexp.c` | `regexp_to_s()` folds a leading option group into the flags it prints, through the new `re_fold_leading_group()`; adds `re_option_letter_bits()`, the letter-to-bit mapping the fold shares with `parse_flags()`, and `re_compiles_alone()`, one trial compile under `mrb_protect_error()` |
| `mrbgems/mruby-regexp/test/regexp.rb` | adds the shapes that fold and the ones that must not, and a round trip pinning that a folded form matches what it was folded from |

### What folds

CRuby's `rb_reg_str_with_term()` (`re.c`) reads the head of the source before printing, and `regexp_to_s()` now reads it the same way. Two shapes fold, and only at the very start of the source.

A toggle, `(?imx-imx)`, governs everything after it, so its letters become the flags of the whole and the group itself is gone. Several in a row fold in turn, so `/(?i)(?m)a/` prints `(?mi-x:a)`.

A scoped group, `(?imx-imx:...)`, governs only what it encloses, so it folds only when what it encloses is the whole source. Its `)` being the last byte of the source does not say that: in `(?i:a)(b)` the last byte closes a different group, and in `(?i:a)b` there is no `)` at the end at all. What settles the first case is whether the text between the `:` and that last `)` is a pattern in its own right, which is one trial compile of `a)(b`, and it fails.

A scoped group folds one level only. `(?i:(?m:a))` prints `(?i-mx:(?m:a))`: what the outer group encloses is the whole source, and the inner group is then text like any other.

### The trial compile

`mrb_re_compile()` reports a bad pattern by raising, where CRuby's `onig_new()` returns an error code, so the trial runs under `mrb_protect_error()`, which returns however the compile ended and leaves neither the exception nor the arena behind. The pattern being compiled into is held by `re_compiles_alone()`'s own frame rather than the protected body's: a compile that raises abandons the body's frame, and every buffer it allocated hangs off that pattern, so `mrb_re_free()` is what reaches them either way. That is the ownership `mrb_re_compile()` already documents and `re_initialize()` already relies on.

The letters are read into bits through `re_option_letter_bits()` rather than the `re_flag_letters[]` table beside it. That table is the printing direction, where one bit of the multiline pair stands for the letter `m`; a group being folded has to carry `RE_FLAG_MULTILINE | RE_FLAG_DOTALL` into the trial, which is what `parse_flags()` gives the same letter in `Regexp.new`'s flags argument. The printed letters would be the same either way; what the trial compiles under would not.

### What does not fold

A group that is neither shape leaves the source printed as written, and takes the toggles already peeled ahead of it back with it. That is why `/(?i)(?=a)/` prints its `(?i)` where `/(?i)(?m:a)/` does not: the lookahead is not an option group, so the whole source goes back, `(?i)` included. CRuby restores the same two things from the same place, and the row is in the table below.

`Regexp#inspect` prints the source as written throughout and is untouched, as it is in CRuby: `/(?i)a/.inspect` is `"/(?i)a/"` in both. `Regexp#==` compares source and options and is unaffected, so `/(?i)a/ == /a/i` stays false in both engines.

## Behaviour

Every row was run against CRuby 4.0.6 and against both sides of this change.

| source | master | this PR, and CRuby |
| --- | --- | --- |
| `(?i)a` | `(?-mix:(?i)a)` | `(?i-mx:a)` |
| `(?i:a)` | `(?-mix:(?i:a))` | `(?i-mx:a)` |
| `(?i-m:a)` | `(?-mix:(?i-m:a))` | `(?i-mx:a)` |
| `(?x)a b` | `(?-mix:(?x)a b)` | `(?x-mi:a b)` |
| `(?x: a )` | `(?-mix:(?x: a ))` | `(?x-mi: a )` |
| `(?:a)` | `(?-mix:(?:a))` | `(?-mix:a)` |
| `(?:)` | `(?-mix:(?:))` | `(?-mix:)` |
| `(?i)` | `(?-mix:(?i))` | `(?i-mx:)` |
| `(?i)(?m)a` | `(?-mix:(?i)(?m)a)` | `(?mi-x:a)` |
| `(?i)(?m:a)` | `(?-mix:(?i)(?m:a))` | `(?mi-x:a)` |
| `(?i:(?m:a))` | `(?-mix:(?i:(?m:a)))` | `(?i-mx:(?m:a))` |
| `(?-i)a`, the object under `/i` | `(?i-mx:(?-i)a)` | `(?-mix:a)` |
| `(?i-)a` | `(?-mix:(?i-)a)` | `(?i-mx:a)` |
| `(?i:a)`, the object under `/m` | `(?m-ix:(?i:a))` | `(?mi-x:a)` |
| `(?i:a)b` | `(?-mix:(?i:a)b)` | unchanged |
| `(?i:a)(b)` | `(?-mix:(?i:a)(b))` | unchanged |
| `a(?i:b)` | `(?-mix:a(?i:b))` | unchanged |
| `(?=a)` | `(?-mix:(?=a))` | unchanged |
| `(?i)(?=a)` | `(?-mix:(?i)(?=a))` | unchanged |
| `(?#c)a` | `(?-mix:(?#c)a)` | unchanged |
| `(?<n>a)` | `(?-mix:(?<n>a))` | unchanged |

The printed form still recompiles to the same matcher, which is what the `to_s` tests already pin and what the round trip added here pins for the folded shapes: for ten sources with a leading group, over eight inputs, `Regexp.new(re.to_s)` and `/#{re}/m` answer `match?` exactly as `re` does.

## Speed

Callgrind `Ir` for 20,000 `Regexp#to_s` calls on one Regexp, `bintest` build, the difference between the two binaries divided by the call count.

| source | Ir per call |
| --- | --- |
| `abc`, no group to read | -24 |
| `(?i:abc)b`, read and not folded | +17 |
| `(?i)abc`, one toggle folded | +153 |
| `(?i)(?m)(?x)abc`, three toggles folded | +215 |
| `(?i:abc)`, scoped group folded, trial compiles | +3,994 |
| `(?i:abc)(d)`, scoped group refused, trial raises | +5,012 |

A source with no leading `(?` is two byte tests cheaper than before, the printed source now going through `mrb_str_cat()` rather than `mrb_str_cat_str()`. The trial compile is the whole of the rest, and it is paid only by a source that both opens with `(?...:` and ends with `)`; the refused case pays for the `RegexpError` object and message on top, which is what mruby raises where `onig_new()` returns a code. CRuby pays one compile per `to_s` on the same sources.

## Size

`bin/mruby` `.text` under `build_config/ci/gcc-clang.rb`, both sides built at the same path from an empty build directory.

| build | master | this PR | delta |
| --- | --- | --- | --- |
| `bintest` | 1,309,222 | 1,309,718 | +496 |
| `ascii-ctype` | 1,295,670 | 1,296,166 | +496 |
| `byte-string` | 1,273,430 | 1,273,926 | +496 |
| `cxx_abi` | 1,336,121 | 1,336,617 | +496 |
| `full-debug` (-O0) | 1,915,078 | 1,916,166 | +1,088 |

All of it is `regexp.o`'s `.text` (28,725 to 29,221 in the `bintest` build). By function, `regexp_to_s()` is +448, `-O3` having inlined `re_fold_leading_group()`, `re_option_letter_bits()` and `re_compiles_alone()` into it, and the protected body `re_trial_compile_body()` is the +38 that stays a function because its address is taken. `-O0` inlines none of it, which is the gap between the two figures above.

## Testing

- `rake test` on `build_config/ci/gcc-clang.rb`, clang, all five builds: `full-debug` 2,596, `bintest` 2,596, `cxx_abi` 2,596, `byte-string` 2,515, `ascii-ctype` 2,587, plus bintest 145. 0 KO, 0 crash, 0 warning throughout.
- `full-core` gembox with `MRB_UTF8_STRING` under ASan and UBSan with `detect_leaks=1`: 2,596 tests, 0 KO, 0 crash, 0 warning, and nothing reported by either sanitizer.
- A differential run against CRuby 4.0.6 over 8,420 cases, every leading option group spelling (19 option strings by 11 bodies by 4 tails, in both the toggle and the scoped form) by five flag arguments: `to_s` agrees on every one, including the sources both engines refuse to compile. The same corpus under the ASan build reports no leak, which is the trial compile's pattern being freed on both the success and the failure path.
- The round trip and the nesting check from the Behaviour section, run under both engines and under ASan.

## Environment

<details>

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-30-generic x86_64 |
| CPU | AMD Ryzen 9 5950X (16C/32T) |
| C compiler | gcc 13.3.0 (`## Size`, `## Speed`), clang 22.1.8 (`## Testing`) |
| binutils | GNU ld 2.47.20260726 |
| valgrind | callgrind, `## Speed` |
| CRuby | 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM |

The `## Size` builds, as `src/string.o.flags` recorded them (`-MMD -c`, `-I` and `-o` dropped):

```console
# bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK

# ascii-ctype
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_REGEXP_PARSE_DEPTH_LIMIT=512 -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# full-debug
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `Regexp#to_s` output by folding supported leading and whole-pattern inline options into the displayed flags.
  * Preserved scoped and unsupported option groups when they cannot be safely folded.
  * Maintained matching behavior, equality, inspection output, and nested regular-expression semantics.

* **Tests**
  * Added coverage for option folding, nested groups, interpolation, and round-trip behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->