### PR TITLE
mruby-array-ext: build `-` a set only when both sides can repay it

### DIFF
--- a/mrbgems/mruby-array-ext/src/array.c
+++ b/mrbgems/mruby-array-ext/src/array.c
@@ -493,7 +493,12 @@ ary_subtract_internal(mrb_state *mrb, mrb_value self, mrb_int argc, const mrb_va
 
   mrb_value result = mrb_ary_new(mrb);
 
-  if (total_len > SET_OP_HASH_THRESHOLD) {
+  /* Both sides have to be worth a set: it costs O(total_len) to build and is
+     then asked RARRAY_LEN(self) questions. A short receiver cannot repay a
+     long set, one lookup into a thousand entries losing to one linear scan of
+     them, so, as CRuby does, either side being small picks the walk. */
+  if (total_len > SET_OP_HASH_THRESHOLD &&
+      RARRAY_LEN(self) > SET_OP_HASH_THRESHOLD) {
     /* Create shared copies to protect elements during khash operations */
     mrb_value *argv_copies = (mrb_value *)mrb_alloca(mrb, sizeof(mrb_value) * argc);
     for (mrb_int i = 0; i < argc; i++) {

--- a/mrbgems/mruby-array-ext/test/array.rb
+++ b/mrbgems/mruby-array-ext/test/array.rb
@@ -960,12 +960,13 @@ assert('Array set operations compare with eql? on both sides of the hash thresho
   small_dup = [1, 1.0, 1]
   assert_equal [1, 1.0], small_dup.uniq!
 
-  # `-` and `&` take it from the argument arrays alone, so a long receiver is
-  # no guarantee of the hash path
+  # `-` takes the set only when both sides are long enough to pay for it, so
+  # it needs a row for each way of being short as well as one for neither
   assert_equal [1], [1] - [1.0]
   assert_equal [1] + pad, long_receiver - [1.0]
   assert_equal [1], [1] - [1.0, 2.0]
   assert_equal [1], [1] - long_floats
+  assert_equal [1] + pad, long_receiver - long_floats
 
   assert_equal [], [1] & [1.0]
   assert_equal [], long_receiver & [1.0]


### PR DESCRIPTION
## Summary

`Array#-` chose between its khash set and its linear walk from the argument arrays alone, so a one-element receiver still built a set over a thousand-element argument in order to ask it a single question. Both sides now have to be worth a set, which is CRuby's rule.

## Changes

| File | What |
|---|---|
| `mrbgems/mruby-array-ext/src/array.c` | `ary_subtract_internal()` takes the set only when the receiver is past `SET_OP_HASH_THRESHOLD` as well as the arguments |
| `mrbgems/mruby-array-ext/test/array.rb` | one row where both sides are long, so the set path keeps a case with a `Float` in it |

### The receiver was never part of the decision

The set costs `O(total_len)` to build and is then asked `RARRAY_LEN(self)` questions, so what it is worth depends on both numbers. `ary_subtract_internal()` looked only at the first:

```c
if (total_len > SET_OP_HASH_THRESHOLD) {
```

where `total_len` is the sum of the argument lengths. A one-element receiver against a thousand-element argument therefore built a thousand-entry hash table, hashed every element into it, asked it a single question and threw it away, where one linear scan of the argument would have answered. That is not an unusual shape to write: `[x] - big_list` is how a caller asks whether `big_list` holds `x` when they want an array back.

Requiring both sides to be long enough leaves the set exactly where it repays itself, and it is the rule CRuby follows. Against the same 1,000-element argument CRuby answers `[1] - big` in 2 ms where it takes 196 ms over `(1..64).to_a - big`, 120x apart over 10,000 calls, which is a short receiver declining to build the table rather than a table being asked fewer questions.

## Speed

```ruby
a = (1..N).to_a
b = (1..1000).to_a
i = 0
while i < 10000 do a - b; i += 1 end
```

Best of 11 interleaved runs against master, with a master-against-master control to read the noise by, and the instruction counts callgrind reads beside them:

| receiver | master | this PR | control | Ir per call |
| ---: | ---: | ---: | ---: | ---: |
| 1 | 940 ms | **&lt;10 ms** | ±0% | 1,617,482 → **1,474** |
| 4 | 940 ms | **&lt;10 ms** | ±0% | |
| 16 | 940 ms | **30 ms** | ±0% | |
| 33 | 950 ms | 940 ms | -1% | |
| 64 | 940 ms | 940 ms | ±0% | 1,627,256 → 1,627,261 |

From 33 elements up both sides are long, the set is still what runs, and the two bottom rows are the run-to-run spread: callgrind puts that case at five instructions in 1.6 million, which is the `RARRAY_LEN(self)` comparison this PR adds.

## Size

`.text` of `bin/mruby`, `size -A`, for the five builds of `build_config/ci/gcc-clang.rb`, master and this branch built at the same path in an empty build directory:

| Build | master | this PR | delta |
| --- | ---: | ---: | ---: |
| `ascii-ctype` | 1,071,270 | 1,071,302 | +32 |
| `bintest` | 1,076,390 | 1,076,422 | +32 |
| `byte-string` | 1,051,270 | 1,051,302 | +32 |
| `cxx_abi` | 1,064,469 | 1,064,501 | +32 |
| `full-debug` (-O0) | 1,867,686 | 1,867,830 | +144 |

All of it is `mrbgems/mruby-array-ext/src/array.o`, which grows by the same 32 bytes for the added comparison. No other object moves.

## Testing

`rake test` is green: 2,362 tests, 0 KO, 0 crash, 0 warning, plus 128 bintest cases with 0 KO.

The answers do not change, so no test that passed before fails now. The row this PR adds is needed for a different reason: `[1] - long_floats`, immediately above it, was the only case that reached the set path with a `Float` in it, and under the new rule its one-element receiver takes the walk. A receiver long enough to keep the set has to stand beside it, or the set path loses its coverage of `1.eql?(1.0)` being false. Expected values were checked against CRuby 3.2.3 and 4.0.6.

## Environment

<details>

| | |
|---|---|
| OS | Ubuntu 24.04, Linux 7.0.0-30-generic x86_64 |
| CPU | AMD Ryzen 9 5950X |
| C compiler | Homebrew clang 22.1.8 (`CC`, `CXX` and `LD` all clang) |
| binutils | GNU ld 2.47.20260726 |
| valgrind | 3.27.1 (callgrind) |
| CRuby | 3.2.3 and 4.0.6, for the expected values |

Benchmarks were built with `build_config/default.rb` and run one core at a time under `taskset -c 7`. Wall clock has 10 ms of resolution here, so the instruction counts are the ones to read for small differences; they are `Ir(2N) - Ir(N)` divided by `N`, which cancels out start-up and parsing.

The compile line for the benchmarked build, with `-MMD -c`, `-I` and `-o` dropped:

```console
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration
      -Wwrite-strings -Wzero-length-array -DMRBGEM_MRUBY_ARRAY_EXT_VERSION=0.0.0
      -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL
      -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK
```

And for the five builds the `Size` table comes from:

```console
# ascii-ctype
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration
      -Wwrite-strings -Wzero-length-array -DMRB_USE_ASCII_CTYPE
      -DMRB_REGEXP_PARSE_DEPTH_LIMIT=512 -DMRBGEM_MRUBY_ARRAY_EXT_VERSION=0.0.0
      -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING
      -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET
      -DMRB_USE_TASK_SCHEDULER

# bintest
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration
      -Wwrite-strings -Wzero-length-array -DMRB_GC_FIXED_ARENA
      -DMRBGEM_MRUBY_ARRAY_EXT_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX
      -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM
      -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET
      -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK

# byte-string
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration
      -Wwrite-strings -Wzero-length-array -DMRBGEM_MRUBY_ARRAY_EXT_VERSION=0.0.0
      -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL
      -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# cxx_abi, the one build compiled as C++
clang -g -O3 -Wall -Wundef -Wwrite-strings -Wzero-length-array -x c++ -std=gnu++03
      -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_ARRAY_EXT_VERSION=0.0.0
      -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX
      -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM
      -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET
      -DMRB_USE_TASK_SCHEDULER

# full-debug, the only -O0 build
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration
      -Wwrite-strings -Wzero-length-array -g3 -O0 -DMRB_GC_STRESS
      -DMRB_USE_DEBUG_HOOK -DMRBGEM_MRUBY_ARRAY_EXT_VERSION=0.0.0 -DMRB_DEBUG
      -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING
      -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET
      -DMRB_USE_TASK_SCHEDULER
```

`full-debug` puts `-g3 -O0` after the toolchain's own `-g -O3`, so it is the one row measured at `-O0`.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `Array#-` behavior by selecting the most efficient processing method based on the sizes of both arrays.
  * Preserved expected results for short arrays while supporting optimized handling for larger arrays.

* **Tests**
  * Expanded coverage for different receiver and argument array-size combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->