### PR TITLE
mruby-array-ext: write `uniq!`, `|` and `&` once against `ary_memb`, with the threshold at 8

### DIFF
--- a/mrbgems/mruby-array-ext/src/array.c
+++ b/mrbgems/mruby-array-ext/src/array.c
@@ -412,7 +412,13 @@ ary_rotate_bang(mrb_state *mrb, mrb_value self)
   return self;
 }
 
-#define SET_OP_HASH_THRESHOLD 32
+/* Above this many deciding elements the khash set repays building it; at and
+   below, the linear walk wins and allocates nothing. Driving the deciding
+   length directly against a build that always walks and one that always
+   builds the set, the walk stops winning at 6 elements for `uniq`, 4 for `|`
+   and 8 for `&`, and the set is ahead from 8, 6 and 12; 8 takes the whole of
+   the set's win without giving any operation's small sizes away. */
+#define SET_OP_HASH_THRESHOLD 8
 
 /* Helper functions for temporary khash sets */
 static void

--- a/mrbgems/mruby-array-ext/src/array.c
+++ b/mrbgems/mruby-array-ext/src/array.c
@@ -461,18 +461,23 @@ ary_get_array_args(mrb_state *mrb, mrb_int argc, const mrb_value **argv_ptr)
   return total_len;
 }
 
-/* Answers one question, "is this value one of the elements I hold?", and
-   hides which of two strategies answered it. A khash set when there are
-   enough elements to repay building one, a walk over the arrays themselves
-   when there are not.
+/* Remembers elements and answers questions about them, hiding which of two
+   strategies did the remembering. A khash set when there are enough elements
+   to repay building one, a linear scan of an array the caller can already
+   see when there are not.
 
    Choosing between those two is what makes this file fast and is worth
    keeping. Writing the surrounding operation twice, once per strategy, is
    what made it wrong: the two copies compared elements with different
    functions until #7352, and `Array#intersection` narrowed by the union of
    its arguments on one side and by each argument on the other until #7368.
-   A caller states its algorithm once, against ary_memb_has(), and never
-   learns which strategy replied. */
+   A caller states its algorithm once, against one of three questions, and
+   never learns which strategy replied:
+
+     ary_memb_has()    is this value one of the elements I hold?
+     ary_memb_take()   the same, but each distinct element is handed out at
+                       most once; asking spends it
+     ary_memb_first()  is this the first time the caller meets this value? */
 typedef struct ary_memb {
   mrb_bool use_set;
   ary_set_t set;
@@ -489,21 +494,25 @@ ary_memb_init(mrb_state *mrb, ary_memb *m, const mrb_value *arys, mrb_int n_arys
   m->use_set = use_set;
   m->n_arys = n_arys;
   m->total_len = total_len;
+  m->arys = arys;
 
   if (!use_set) {
     /* The walk reads the caller's arrays in place. It allocates nothing, which
        is most of why it is worth choosing at all. */
-    m->arys = arys;
     return;
   }
 
-  /* Shared copies hold the elements while kh_put() runs `hash`, which is Ruby
-     code and free to empty the caller's arrays. */
-  mrb_value *copies = (mrb_value *)mrb_alloca(mrb, sizeof(mrb_value) * n_arys);
-  for (mrb_int i = 0; i < n_arys; i++) {
-    copies[i] = mrb_ary_make_shared_copy(mrb, arys[i]);
+  if (n_arys > 0) {
+    /* Shared copies hold the elements while kh_put() runs `hash`, which is
+       Ruby code and free to empty the caller's arrays. A caller that hands
+       over no arrays has to pin the set's keys some other way; `|` holds
+       every key in its result. */
+    mrb_value *copies = (mrb_value *)mrb_alloca(mrb, sizeof(mrb_value) * n_arys);
+    for (mrb_int i = 0; i < n_arys; i++) {
+      copies[i] = mrb_ary_make_shared_copy(mrb, arys[i]);
+    }
+    m->arys = copies;
   }
-  m->arys = copies;
   ary_init_temp_set(mrb, &m->set, total_len);
 }
 
@@ -541,6 +550,74 @@ ary_memb_has(mrb_state *mrb, ary_memb *m, mrb_value v)
     }
   }
   return FALSE;
+}
+
+/* Narrows take() to one of the init arrays. Arguments are selected in order,
+   each at most once: the set forgets the previous argument's elements and
+   holds this one's, the walk just reads the array named by `sel` when asked.
+   Replaces ary_memb_fill() for a caller that takes; fill() answers for all
+   the arrays at once and select() for one at a time. */
+static void
+ary_memb_select(mrb_state *mrb, ary_memb *m, mrb_int sel)
+{
+  if (!m->use_set) return;
+  if (sel > 0) {
+    kh_clear(ary_set, mrb, &m->set);
+  }
+  ary_populate_temp_set(mrb, &m->set, m->arys[sel]);
+}
+
+/* Membership in the selected array, spending each distinct element as it is
+   taken so that a duplicate no longer finds it. The set spends by deleting
+   the key. The walk cannot cross an element off an array it only reads, so
+   it consults the caller's record of what was already taken, the first
+   `kept_len` slots of `kept`; a caller whose source holds no duplicates
+   passes 0 and skips that scan. */
+static inline mrb_bool
+ary_memb_take(mrb_state *mrb, ary_memb *m, mrb_int sel, mrb_value v,
+              mrb_value kept, mrb_int kept_len)
+{
+  if (m->use_set) {
+    khiter_t k = kh_get(ary_set, mrb, &m->set, v);
+    if (kh_is_end(&m->set, k)) return FALSE;
+    kh_del(ary_set, mrb, &m->set, k);
+    return TRUE;
+  }
+  mrb_value ary = m->arys[sel];
+  mrb_bool found = FALSE;
+  for (mrb_int i = 0; i < RARRAY_LEN(ary); i++) {
+    if (ary_elem_eql(mrb, v, RARRAY_PTR(ary)[i])) {
+      found = TRUE;
+      break;
+    }
+  }
+  if (!found) return FALSE;
+  for (mrb_int i = 0; i < kept_len && i < RARRAY_LEN(kept); i++) {
+    if (ary_elem_eql(mrb, v, RARRAY_PTR(kept)[i])) return FALSE;
+  }
+  return TRUE;
+}
+
+/* Is this the first time the caller meets this value? The set remembers every
+   value it is asked about. The walk remembers nothing and reads the caller's
+   record of what it kept, the first `kept_len` slots of `kept`; bounding the
+   scan by the caller's own count is what lets `uniq!` ask about the array it
+   is still compacting. A caller of first() never calls fill(): the record
+   starts empty and grows one answer at a time. */
+static inline mrb_bool
+ary_memb_first(mrb_state *mrb, ary_memb *m, mrb_value v,
+               mrb_value kept, mrb_int kept_len)
+{
+  if (m->use_set) {
+    khiter_t k = kh_get(ary_set, mrb, &m->set, v);
+    if (!kh_is_end(&m->set, k)) return FALSE;
+    kh_put(ary_set, mrb, &m->set, v);
+    return TRUE;
+  }
+  for (mrb_int i = 0; i < kept_len && i < RARRAY_LEN(kept); i++) {
+    if (ary_elem_eql(mrb, v, RARRAY_PTR(kept)[i])) return FALSE;
+  }
+  return TRUE;
 }
 
 /* Runs `body` with the set destroyed even if it raises. The walk owns nothing
@@ -648,56 +725,36 @@ ary_difference(mrb_state *mrb, mrb_value self)
   return ary_subtract_internal(mrb, self, argc, argv);
 }
 
-static void
-add_uniq(mrb_state *mrb, mrb_value item, mrb_value result)
-{
-  for (mrb_int i = 0; i < RARRAY_LEN(result); i++) {
-    if (mrb_eql(mrb, item, RARRAY_PTR(result)[i])) {
-      return;
-    }
-  }
-  mrb_ary_push(mrb, result, item);
-}
-
 struct ary_union_ctx {
-  ary_set_t *set;
-  mrb_value self_copy;
+  ary_memb *memb;
+  mrb_value self;
   mrb_value result;
   const mrb_value *argv;
   mrb_int argc;
 };
 
+static void
+ary_union_add(mrb_state *mrb, ary_memb *memb, mrb_value src, mrb_value result)
+{
+  int ai = mrb_gc_arena_save(mrb);
+  for (mrb_int i = 0; i < RARRAY_LEN(src); i++) {
+    mrb_value elem = RARRAY_PTR(src)[i];
+    mrb_gc_protect(mrb, elem); // elem may be removed from src by ary_memb_first()
+    if (ary_memb_first(mrb, memb, elem, result, RARRAY_LEN(result))) {
+      mrb_ary_push(mrb, result, elem);
+    }
+    mrb_gc_arena_restore(mrb, ai);
+  }
+}
+
 static mrb_value
 ary_union_body(mrb_state *mrb, void *data)
 {
   struct ary_union_ctx *ctx = (struct ary_union_ctx *)data;
-  int ai = mrb_gc_arena_save(mrb);
 
-  /* Add unique elements from self */
-  for (mrb_int i = 0; i < RARRAY_LEN(ctx->self_copy); i++) {
-    mrb_value elem = RARRAY_PTR(ctx->self_copy)[i];
-    mrb_gc_protect(mrb, elem); // elem may be removed from self_copy by kh_get(ary_set, ...)
-    khiter_t k = kh_get(ary_set, mrb, ctx->set, elem);
-    if (kh_is_end(ctx->set, k)) {
-      kh_put(ary_set, mrb, ctx->set, elem);
-      mrb_ary_push(mrb, ctx->result, elem);
-    }
-    mrb_gc_arena_restore(mrb, ai);
-  }
-
-  /* Add unique elements from others */
+  ary_union_add(mrb, ctx->memb, ctx->self, ctx->result);
   for (mrb_int i = 0; i < ctx->argc; i++) {
-    mrb_value other = ctx->argv[i];
-    for (mrb_int j = 0; j < RARRAY_LEN(other); j++) {
-      mrb_value elem = RARRAY_PTR(other)[j];
-      mrb_gc_protect(mrb, elem); // elem may be removed from other by kh_get(ary_set, ...)
-      khiter_t k = kh_get(ary_set, mrb, ctx->set, elem);
-      if (kh_is_end(ctx->set, k)) {
-        kh_put(ary_set, mrb, ctx->set, elem);
-        mrb_ary_push(mrb, ctx->result, elem);
-      }
-      mrb_gc_arena_restore(mrb, ai);
-    }
+    ary_union_add(mrb, ctx->memb, ctx->argv[i], ctx->result);
   }
 
   return ctx->result;
@@ -710,46 +767,17 @@ ary_union_internal(mrb_state *mrb, mrb_value self, mrb_int argc, const mrb_value
 
   mrb_value result = mrb_ary_new(mrb);
 
-  if (total_len > SET_OP_HASH_THRESHOLD) {
-    /* Create shared copies to protect elements during khash operations */
-    mrb_value self_copy = mrb_ary_make_shared_copy(mrb, self);
-    mrb_value *argv_copies = (mrb_value *)mrb_alloca(mrb, sizeof(mrb_value) * argc);
-    for (mrb_int i = 0; i < argc; i++) {
-      argv_copies[i] = mrb_ary_make_shared_copy(mrb, argv[i]);
-    }
+  /* The record of what has been kept is the result itself, and the result is
+     also what keeps the set's keys alive: every element the set remembers
+     was pushed there in the same turn. So the membership object is handed no
+     arrays, and the sources are walked in place, each element kept in
+     encounter order the first time it is met. */
+  ary_memb memb;
+  ary_memb_init(mrb, &memb, NULL, 0, total_len,
+                total_len > SET_OP_HASH_THRESHOLD);
 
-    ary_set_t set_struct;
-    ary_set_t *set = &set_struct;
-    ary_init_temp_set(mrb, set, total_len);
-
-    struct ary_union_ctx ctx = { set, self_copy, result, argv_copies, argc };
-    MRB_ENSURE(mrb, result, ary_union_body, &ctx) {
-      ary_destroy_temp_set(mrb, set);
-    }
-  }
-  else {
-    int ai = mrb_gc_arena_save(mrb);
-
-    /* Use linear search for small arrays */
-    /* Add unique elements from self */
-    for (mrb_int i = 0; i < RARRAY_LEN(self); i++) {
-      mrb_value p = RARRAY_PTR(self)[i];
-      mrb_gc_protect(mrb, p); // p may be removed from self by add_uniq()
-      add_uniq(mrb, p, result);
-      mrb_gc_arena_restore(mrb, ai);
-    }
-
-    /* Add unique elements from others */
-    for (mrb_int i = 0; i < argc; i++) {
-      mrb_value other = argv[i];
-      for (mrb_int j = 0; j < RARRAY_LEN(other); j++) {
-        mrb_value p = RARRAY_PTR(other)[j];
-        mrb_gc_protect(mrb, p); // p may be removed from other by add_uniq()
-        add_uniq(mrb, p, result);
-        mrb_gc_arena_restore(mrb, ai);
-      }
-    }
-  }
+  struct ary_union_ctx ctx = { &memb, self, result, argv, argc };
+  ARY_MEMB_RUN(mrb, result, ary_union_body, &ctx, &memb);
 
   return result;
 }
@@ -793,33 +821,32 @@ ary_union_multi(mrb_state *mrb, mrb_value self)
 }
 
 struct ary_intersection_ctx {
-  ary_set_t *set;
+  ary_memb *memb;
   mrb_value self;
   mrb_value result;
-  const mrb_value *argv;
-  mrb_int argc;
 };
 
 static mrb_value
 ary_intersection_body(mrb_state *mrb, void *data)
 {
   struct ary_intersection_ctx *ctx = (struct ary_intersection_ctx *)data;
+  ary_memb *memb = ctx->memb;
 
   /* An element belongs in the result only if every argument holds it, so the
-     arguments have to narrow the result one at a time. Pouring them all into
-     one set instead answers `self & (a | b | ...)`, which let an element
-     missing from one argument survive because another argument carried it. */
-  for (mrb_int j = 0; j < ctx->argc; j++) {
-    if (j > 0) {
-      kh_clear(ary_set, mrb, ctx->set);
-    }
-    ary_populate_temp_set(mrb, ctx->set, ctx->argv[j]);
+     arguments have to narrow the result one at a time. Asking one membership
+     question over all of them instead answers `self & (a | b | ...)`, which
+     let an element missing from one argument survive because another
+     argument carried it. */
+  for (mrb_int j = 0; j < memb->n_arys; j++) {
+    ary_memb_select(mrb, memb, j);
 
     /* The first argument selects out of `self` into the still empty result;
        every later one narrows that result, which is ours alone and can be
        compacted in place since the write position never runs ahead of the
-       read position. The set gives up an element the first time it is taken,
-       so a duplicate no longer finds it and the result keeps one of each. */
+       read position. take() gives up an element the first time it is taken,
+       so a duplicate in `self` no longer finds it and the result keeps one
+       of each; from the second argument on the source is the result itself,
+       already duplicate-free, so its record of taken elements stays empty. */
     mrb_value src = ctx->self;
     if (j > 0) {
       src = ctx->result;
@@ -830,10 +857,8 @@ ary_intersection_body(mrb_state *mrb, void *data)
     int ai = mrb_gc_arena_save(mrb);
     for (mrb_int i = 0; i < RARRAY_LEN(src); i++) {
       mrb_value p = RARRAY_PTR(src)[i];
-      mrb_gc_protect(mrb, p); // p may be removed from src by kh_get(ary_set, ...)
-      khiter_t k = kh_get(ary_set, mrb, ctx->set, p);
-      if (!kh_is_end(ctx->set, k)) {
-        kh_del(ary_set, mrb, ctx->set, k);
+      mrb_gc_protect(mrb, p); // p may be removed from src by ary_memb_take()
+      if (ary_memb_take(mrb, memb, j, p, ctx->result, j == 0 ? write_pos : 0)) {
         if (j == 0) {
           mrb_ary_push(mrb, ctx->result, p);
         }
@@ -868,58 +893,13 @@ ary_intersection_internal(mrb_state *mrb, mrb_value self, mrb_int argc, const mr
 
   mrb_value result = mrb_ary_new(mrb);
 
-  if (total_len > SET_OP_HASH_THRESHOLD) {
-    /* Create shared copies to protect elements during khash operations */
-    mrb_value *argv_copies = (mrb_value *)mrb_alloca(mrb, sizeof(mrb_value) * argc);
-    for (mrb_int i = 0; i < argc; i++) {
-      argv_copies[i] = mrb_ary_make_shared_copy(mrb, argv[i]);
-    }
+  ary_memb memb;
+  ary_memb_init(mrb, &memb, argv, argc, total_len,
+                total_len > SET_OP_HASH_THRESHOLD);
 
-    ary_set_t set_struct;
-    ary_set_t *set = &set_struct;
-    ary_init_temp_set(mrb, set, total_len);
+  struct ary_intersection_ctx ctx = { &memb, self, result };
+  ARY_MEMB_RUN(mrb, result, ary_intersection_body, &ctx, &memb);
 
-    struct ary_intersection_ctx ctx = { set, self, result, argv_copies, argc };
-    MRB_ENSURE(mrb, result, ary_intersection_body, &ctx) {
-      ary_destroy_temp_set(mrb, set);
-    }
-  }
-  else {
-    int ai = mrb_gc_arena_save(mrb);
-    for (mrb_int i = 0; i < RARRAY_LEN(self); i++) {
-      mrb_value p = RARRAY_PTR(self)[i];
-      mrb_gc_protect(mrb, p); // p may be removed from self by mrb_eql()
-      mrb_bool found_in_all = TRUE;
-
-      for (mrb_int j = 0; j < argc; j++) {
-        mrb_bool found_in_current_other = FALSE;
-        for (mrb_int k = 0; k < RARRAY_LEN(argv[j]); k++) {
-          if (mrb_eql(mrb, p, RARRAY_PTR(argv[j])[k])) {
-            found_in_current_other = TRUE;
-            break;
-          }
-        }
-        if (!found_in_current_other) {
-          found_in_all = FALSE;
-          break;
-        }
-      }
-
-      if (found_in_all) {
-        mrb_bool already_added = FALSE;
-        for (mrb_int j = 0; j < RARRAY_LEN(result); j++) {
-          if (mrb_eql(mrb, p, RARRAY_PTR(result)[j])) {
-            already_added = TRUE;
-            break;
-          }
-        }
-        if (!already_added) {
-          mrb_ary_push(mrb, result, p);
-        }
-      }
-      mrb_gc_arena_restore(mrb, ai);
-    }
-  }
   return result;
 }
 
@@ -1185,8 +1165,7 @@ ary_fill_exec(mrb_state *mrb, mrb_value self)
  *  Modifies array in-place, returns nil if no changes.
  */
 struct ary_uniq_bang_ctx {
-  ary_set_t *set;
-  mrb_value self_copy;
+  ary_memb *memb;
   mrb_value self;
   mrb_int *write_pos;
 };
@@ -1195,21 +1174,18 @@ static mrb_value
 ary_uniq_bang_body(mrb_state *mrb, void *data)
 {
   struct ary_uniq_bang_ctx *ctx = (struct ary_uniq_bang_ctx *)data;
-
-  ary_populate_temp_set(mrb, ctx->set, ctx->self_copy);
+  mrb_value self = ctx->self;
 
   int ai = mrb_gc_arena_save(mrb);
-  for (mrb_int read_pos = 0; read_pos < RARRAY_LEN(ctx->self); read_pos++) {
-    mrb_value elem = RARRAY_PTR(ctx->self)[read_pos];
-    mrb_gc_protect(mrb, elem); // elem may be removed from self by kh_get(ary_set, ...)
-    khiter_t k = kh_get(ary_set, mrb, ctx->set, elem);
-    if (!kh_is_end(ctx->set, k)) {
-      if (*ctx->write_pos != read_pos && *ctx->write_pos < RARRAY_LEN(ctx->self)) {
-        mrb_ary_modify(mrb, mrb_ary_ptr(ctx->self));
-        RARRAY_PTR(ctx->self)[*ctx->write_pos] = elem;
+  for (mrb_int read_pos = 0; read_pos < RARRAY_LEN(self); read_pos++) {
+    mrb_value elem = RARRAY_PTR(self)[read_pos];
+    mrb_gc_protect(mrb, elem); // elem may be removed from self by ary_memb_first()
+    if (ary_memb_first(mrb, ctx->memb, elem, self, *ctx->write_pos)) {
+      if (*ctx->write_pos != read_pos && *ctx->write_pos < RARRAY_LEN(self)) {
+        mrb_ary_modify(mrb, mrb_ary_ptr(self));
+        RARRAY_PTR(self)[*ctx->write_pos] = elem;
       }
       (*ctx->write_pos)++;
-      kh_del(ary_set, mrb, ctx->set, k);
     }
     /* Every turn protects `elem`, so every turn has to give the slot back:
        an element already seen took the other branch and left its slot behind,
@@ -1235,44 +1211,19 @@ ary_uniq_bang(mrb_state *mrb, mrb_value self)
   }
 
   mrb_ary_modify(mrb, mrb_ary_ptr(self));
+
+  /* The kept prefix of `self` is the record of first occurrences, so the
+     membership object holds `self` itself: under the set as a shared copy
+     that keeps every element alive while `hash` runs, under the walk as the
+     array whose prefix first() reads. */
+  ary_memb memb;
+  ary_memb_init(mrb, &memb, &self, 1, len, len > SET_OP_HASH_THRESHOLD);
+
   mrb_int write_pos = 0;
-
-  if (len > SET_OP_HASH_THRESHOLD) {
-    /* Create shared copy to protect elements during khash operations */
-    mrb_value self_copy = mrb_ary_make_shared_copy(mrb, self);
-
-    ary_set_t set_struct;
-    ary_set_t *set = &set_struct;
-    ary_init_temp_set(mrb, set, len);
-
-    struct ary_uniq_bang_ctx ctx = { set, self_copy, self, &write_pos };
-    mrb_value result;
-    MRB_ENSURE(mrb, result, ary_uniq_bang_body, &ctx) {
-      ary_destroy_temp_set(mrb, set);
-    }
-  }
-  else {
-    int ai = mrb_gc_arena_save(mrb);
-    for (mrb_int read_pos = 0; read_pos < RARRAY_LEN(self); read_pos++) {
-      mrb_value elem = RARRAY_PTR(self)[read_pos];
-      mrb_gc_protect(mrb, elem); // elem may be removed from self by mrb_eql()
-      mrb_bool found = FALSE;
-      for (mrb_int j = 0; j < write_pos && j < RARRAY_LEN(self); j++) {
-        if (mrb_eql(mrb, elem, RARRAY_PTR(self)[j])) {
-          found = TRUE;
-          break;
-        }
-      }
-      if (!found) {
-        if (write_pos != read_pos && write_pos < RARRAY_LEN(self)) {
-          mrb_ary_modify(mrb, mrb_ary_ptr(self));
-          RARRAY_PTR(self)[write_pos] = elem;
-        }
-        write_pos++;
-      }
-      mrb_gc_arena_restore(mrb, ai);
-    }
-  }
+  struct ary_uniq_bang_ctx ctx = { &memb, self, &write_pos };
+  mrb_value discard;
+  ARY_MEMB_RUN(mrb, discard, ary_uniq_bang_body, &ctx, &memb);
+  (void)discard;
 
   if (write_pos == len) {
     return mrb_nil_value();

--- a/mrbgems/mruby-array-ext/test/array.rb
+++ b/mrbgems/mruby-array-ext/test/array.rb
@@ -121,9 +121,9 @@ assert("Array#-") do
   assert_equal [2, 3], (a - b)
   assert_equal [1, 2, 3, 1], a
 
-  # Test hash-based implementation (other_ary length > 32)
+  # Test hash-based implementation (other_ary length past the hash threshold)
   a = (1..50).to_a
-  b = (15..50).to_a  # 36 elements > 32, triggers hash approach
+  b = (15..50).to_a  # well past the hash threshold
   result = a - b
   expected = (1..14).to_a
 
@@ -132,7 +132,7 @@ assert("Array#-") do
 
   # Test with larger removal set
   a = (1..60).to_a
-  b = (20..55).to_a  # 36 elements > 32, triggers hash approach
+  b = (20..55).to_a  # well past the hash threshold
   result = a - b
   expected = (1..19).to_a + (56..60).to_a
 
@@ -150,7 +150,7 @@ assert("Array#-") do
 
   # Test removing no elements
   a = (1..20).to_a
-  b = (30..50).to_a  # 21 elements > 16, triggers hash approach
+  b = (30..50).to_a  # past the hash threshold
   result = a - b
   expected = (1..20).to_a
 
@@ -177,9 +177,9 @@ assert("Array#|") do
 end
 
 assert("Array#| with large arrays") do
-  # Test hash-based implementation (total length > 32)
+  # Test hash-based implementation (total length past the hash threshold)
   a = (1..25).to_a
-  b = (20..45).to_a  # total = 51 > 32, triggers hash approach
+  b = (20..45).to_a  # well past the hash threshold
   result = a | b
   expected = (1..45).to_a
 
@@ -188,7 +188,7 @@ assert("Array#| with large arrays") do
 
   # Test with overlapping ranges
   a = (1..20).to_a
-  b = (15..35).to_a  # total = 41 > 32, triggers hash approach
+  b = (15..35).to_a  # well past the hash threshold
   result = a | b
   expected = (1..35).to_a
 
@@ -247,9 +247,9 @@ assert("Array#&") do
 end
 
 assert("Array#& with large arrays") do
-  # Test hash-based implementation (other_ary length > 32)
+  # Test hash-based implementation (other_ary length past the hash threshold)
   a = (1..50).to_a
-  b = (20..55).to_a  # 36 elements > 32, triggers hash approach
+  b = (20..55).to_a  # well past the hash threshold
   result = a & b
   expected = (20..50).to_a
 
@@ -258,7 +258,7 @@ assert("Array#& with large arrays") do
 
   # Test with larger intersection set
   a = (1..60).to_a
-  b = (25..60).to_a  # 36 elements > 32, triggers hash approach
+  b = (25..60).to_a  # well past the hash threshold
   result = a & b
   expected = (25..60).to_a
 
@@ -267,7 +267,7 @@ assert("Array#& with large arrays") do
 
   # Test with duplicates in first array
   a = [1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10]
-  b = (5..25).to_a  # 21 elements > 16, triggers hash approach
+  b = (5..25).to_a  # past the hash threshold
   result = a & b
   expected = [5, 6, 7, 8, 9, 10]  # no duplicates in result
 
@@ -276,7 +276,7 @@ assert("Array#& with large arrays") do
 
   # Test no intersection
   a = (1..20).to_a
-  b = (30..50).to_a  # 21 elements > 16, triggers hash approach
+  b = (30..50).to_a  # past the hash threshold
   result = a & b
   expected = []
 
@@ -318,27 +318,27 @@ assert("Array#intersect?") do
 end
 
 assert("Array#intersect? with large arrays") do
-  # Test hash-based implementation (shorter array > 32)
+  # Test hash-based implementation (shorter array past the hash threshold)
   a = (1..50).to_a
-  b = (40..75).to_a  # 36 elements > 32, but a is longer so b is shorter
+  b = (40..75).to_a  # well past the threshold, but a is longer so b is shorter
   result = a.intersect?(b)
   assert_true(result)  # should find intersection at 40-50
 
   # Test with larger arrays, no intersection
   a = (1..30).to_a
-  b = (50..85).to_a  # 36 elements > 32, triggers hash approach
+  b = (50..85).to_a  # well past the hash threshold
   result = a.intersect?(b)
   assert_false(result)  # no intersection
 
   # Test with first element matching (early termination)
   a = (1..30).to_a
-  b = [1] + (50..70).to_a  # 22 elements > 16, first element matches
+  b = [1] + (50..70).to_a  # past the threshold, first element matches
   result = a.intersect?(b)
   assert_true(result)  # should terminate early on first element
 
   # Test with last element matching
   a = (1..30).to_a
-  b = (50..70).to_a + [30]  # 22 elements > 16, last element matches
+  b = (50..70).to_a + [30]  # past the threshold, last element matches
   result = a.intersect?(b)
   assert_true(result)  # should find match at the end
 
@@ -355,13 +355,13 @@ assert("Array#intersect? with large arrays") do
 
   # Test array size optimization (shorter array used for hash)
   a = (1..5).to_a  # shorter
-  b = (3..30).to_a  # longer, 28 elements > 16
+  b = (3..30).to_a  # longer, past the threshold
   result = a.intersect?(b)
   assert_true(result)  # should use a (shorter) for hash, find 3,4,5
 
   # Test with duplicates
   a = [1, 1, 2, 2, 3, 3] * 5  # 30 elements with duplicates
-  b = (25..50).to_a  # 26 elements > 16, no intersection
+  b = (25..50).to_a  # past the threshold, no intersection
   result = a.intersect?(b)
   assert_false(result)
 
@@ -961,7 +961,7 @@ assert('Array set operations compare with eql? on both sides of the hash thresho
   # `pad` itself, and the rows stop asking what they were written to ask.
   skip unless Object.const_defined?(:Float)
   # Each of these operations has two implementations, picked by a length
-  # threshold of 32: a hash path whose equality callback is eql?, and a linear
+  # threshold of 8: a hash path whose equality callback is eql?, and a linear
   # walk that used to compare with ==. 1 == 1.0 is true where 1.eql?(1.0) is
   # false, so the same pair of elements was one element or two depending only
   # on how long the array was. The linear walks now compare with eql? too.
@@ -1129,7 +1129,7 @@ assert('Array#intersection narrows by every argument, not by their union') do
 
   # three arguments narrow in turn, and the receiver still decides the order
   assert_equal [3, 1], [3, 1, 2, 1].intersection((1..40).to_a, (1..40).to_a, [1, 3])
-  assert_equal [3, 1], [3, 1, 2, 1].intersection([1, 2, 3, 4], [1, 2, 3, 4], [1, 3])
+  assert_equal [3, 1], [3, 1, 2, 1].intersection([1, 2, 3], [1, 2, 3], [1, 3])
 
   # a single argument is the `&` case and must not regress
   assert_equal [1, 2], a.intersection((1..40).to_a)


### PR DESCRIPTION
## Summary

Review of the first version of this PR measured below its table's first row and found the walk winning there, at a size the set cannot reach without paying an allocation that is constant in `n`. So the walk stays. What goes is the duplication: `uniq`/`uniq!`, `|` and `&` are now written once against `ary_memb`, the membership object #7373 introduced for `-` and `intersect?`, and the strategy choice moves out of the operations and into it. With one writing per operation the threshold is free to sit where the crossover is, and `SET_OP_HASH_THRESHOLD` moves from 32 to 8.

## Changes

| Commit | What |
|---|---|
| `mruby-array-ext: write uniq!, \| and & once against ary_memb` | two new question forms on the membership object; the three operations move onto it; no behavioural change for a contract-honouring type, threshold untouched |
| `mruby-array-ext: lower SET_OP_HASH_THRESHOLD from 32 to 8` | the number moves; every predicate that reads it keeps its shape |

### Two more question forms on the membership object

`ary_memb_has()` answers static membership, which is the question `-` and `intersect?` ask. These three ask two others, so the object learns them rather than each operation writing both strategies again:

- `ary_memb_first()` asks "is this the first time I meet this value?". The set remembers every value it is asked about; the walk remembers nothing and reads the caller's record of what it already kept, bounded by the caller's own count so `uniq!` can ask it about the array it is still compacting. `uniq!` asks it about the kept prefix, `|` about the result it is building. `add_uniq()`, the dedup `|` had written a second time, was this question and goes.
- `ary_memb_take()` is membership that hands each distinct element out at most once: asking spends it, and a duplicate no longer finds it. The set spends by deleting the key; the walk consults the caller's record of what was already taken. `ary_memb_select()` narrows it to one of the init arrays, which is the shape of `&`: each argument narrows the result in turn.

Three shapes move underneath, none observable for a type whose `hash` agrees with its `eql?`. The walk under `&` becomes argument-major, the same passes the set makes, instead of asking every argument about each element. The set under `uniq!` records first occurrences as it walks rather than pre-filling from the receiver and taking elements back out, which drops a full pass. The set under `|` stops copying its sources, since every key it remembers was pushed to the result in the same turn and the result is what keeps it alive; `|` now hands the membership object no arrays at all.

### The threshold moves to 8

Driving the deciding length directly against a build that always walks and one that always builds the set, the walk stops winning at 6 elements for `uniq`, 4 for `|` and 8 for `&`, and the set is ahead from 8, 6 and 12. 8 takes the whole of the set's win and is above `&`'s crossover, which 4 would not be. Below it the walk keeps the two things it is there for: at 2 elements it is 1.25x to 1.74x faster, and it allocates nothing where the set pays its `malloc` calls and table bytes at any size.

## Behaviour

For a type whose `hash` agrees with its `eql?` every answer is unchanged at every length, which the threshold block in the tests pins on both sides. A type that breaks that contract has no answer defined by Ruby, and reads back whichever strategy happened to answer; the lengths whose strategy changed are the deciding lengths 9 through 32, which now read the set's answer rather than the walk's.

## Speed

Instruction counts per call, callgrind `Ir(4,000 calls) - Ir(2,000 calls)` over 2,000, `build_config/default.rb`, master → this PR:

| deciding length | `uniq` | `&` | `\|` |
| --- | ---: | ---: | ---: |
| 2 | 1,525 → 1,567 (1.03x) | 2,440 → 2,523 (1.03x) | 1,556 → 1,618 (1.04x) |
| 4 | 2,961 → 3,020 (1.02x) | 6,140 → 6,234 (1.02x) | 3,566 → 3,640 (1.02x) |
| 8 | 7,590 → 7,683 (1.01x) | 21,886 → 21,992 (1.00x) | 11,687 → 11,815 (1.01x) |
| 16 | 27,496 → **9,987 (0.36x)** | 84,765 → **35,045 (0.41x)** | 42,917 → **15,928 (0.37x)** |
| 32 | 109,598 → **21,340 (0.19x)** | 337,305 → **64,346 (0.19x)** | 168,098 → **39,939 (0.24x)** |

At and below 8 both sides run the same walk, and the 1 to 4 percent there is the framing of the membership object. Above 8 the walk stops being asked, which is the whole win the first version of this PR measured, now without giving the small sizes away.

Wall clock agrees, best of 7 interleaved runs, 100,000 calls:

| benchmark | master | this PR |
| --- | ---: | ---: |
| `uniq`, 16 elements | 160 ms | **50 ms (0.31x)** |
| `uniq`, 32 elements | 650 ms | **120 ms (0.18x)** |
| `&`, 16-element argument | 510 ms | **190 ms (0.37x)** |
| `&`, 32-element argument | 2,020 ms | **360 ms (0.18x)** |
| `\|`, 8 with 8 elements | 260 ms | **90 ms (0.35x)** |
| `\|`, 16 with 16 elements | 1,000 ms | **230 ms (0.23x)** |

```ruby
a = (1..N/2).to_a * 2;                   i = 0; while i < 100000 do a.uniq; i += 1 end
a = (1..N).to_a;   b = (N/2+1..N+N/2).to_a
                                         i = 0; while i < 100000 do a & b;  i += 1 end
a = (1..N/2).to_a; b = (N/4+1..N/2+N/4).to_a
                                         i = 0; while i < 100000 do a | b;  i += 1 end
```

## Size

`.text` of `bin/mruby`, `size -A`, for the five builds of `build_config/ci/gcc-clang.rb`, master and this branch built at the same path in an empty build directory:

| Build | master | this PR | delta |
| --- | ---: | ---: | ---: |
| `ascii-ctype` | 1,071,686 | 1,070,646 | -1,040 |
| `bintest` | 1,076,822 | 1,075,782 | -1,040 |
| `byte-string` | 1,051,670 | 1,050,630 | -1,040 |
| `cxx_abi` | 1,064,917 | 1,063,877 | -1,040 |
| `full-debug` (-O0) | 1,867,046 | 1,864,214 | -2,832 |

All of it is `mrbgems/mruby-array-ext/src/array.o`, whose `.text` goes from 19,063 to 18,023, exactly the -1,040 of the four optimised rows. No other object moves.

## Testing

`rake test` is green on `build_config/default.rb` (2,367 tests, 0 KO, 0 crash, 0 warning) and across the five builds of `build_config/ci/gcc-clang.rb`, and `rake test:bin` passes its 145 bintest cases with 0 KO. Both commits were run separately; each is green on its own.

No test row is added or removed. The threshold block already asks each operation on both sides of the threshold and every answer survives; its comment now says 8. The blocks that quoted "36 elements > 32, triggers hash approach" and the like now say "past the hash threshold", so the next move of the number does not strand them. One row moved sides rather than being stranded: the below-threshold twin of the three-argument `intersection` narrowing put 10 elements into its arguments, which 8 reads as the hash side, so its arguments shrink to a total of 8 and it keeps asking the walk it was written for.

## Environment

<details>

| | |
|---|---|
| OS | Ubuntu 24.04, Linux 7.0.0-30-generic x86_64 |
| CPU | AMD Ryzen 9 5950X |
| C compiler | Homebrew clang 22.1.8 (`CC`, `CXX` and `LD` all clang) |
| binutils | GNU ld 2.47.20260726 |
| valgrind | 3.27.1 (callgrind) |

Benchmarks were run one core at a time under `taskset -c 7`. Wall clock has 10 ms of resolution here, so the instruction counts are the ones to read for small differences; they are `Ir(2N) - Ir(N)` divided by `N`, which cancels out start-up and parsing.

The compile line for the benchmarked build, with `-MMD -c`, `-ffile-prefix-map`, `-I` and `-o` dropped:

```console
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration
      -Wwrite-strings -Wzero-length-array -DMRBGEM_MRUBY_ARRAY_EXT_VERSION=0.0.0
      -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL
      -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK
```

And for the five builds the `Size` table comes from:

```console
# ascii-ctype
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration
      -Wwrite-strings -Wzero-length-array -DMRB_USE_ASCII_CTYPE
      -DMRB_REGEXP_PARSE_DEPTH_LIMIT=512 -DMRBGEM_MRUBY_ARRAY_EXT_VERSION=0.0.0
      -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING
      -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET
      -DMRB_USE_TASK_SCHEDULER

# bintest
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration
      -Wwrite-strings -Wzero-length-array -DMRB_GC_FIXED_ARENA
      -DMRBGEM_MRUBY_ARRAY_EXT_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX
      -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM
      -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET
      -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK

# byte-string
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration
      -Wwrite-strings -Wzero-length-array -DMRBGEM_MRUBY_ARRAY_EXT_VERSION=0.0.0
      -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL
      -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# cxx_abi, the one build compiled as C++
clang -g -O3 -Wall -Wundef -Wwrite-strings -Wzero-length-array -x c++ -std=gnu++03
      -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_ARRAY_EXT_VERSION=0.0.0
      -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX
      -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM
      -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET
      -DMRB_USE_TASK_SCHEDULER

# full-debug, the only -O0 build
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration
      -Wwrite-strings -Wzero-length-array -g3 -O0 -DMRB_GC_STRESS
      -DMRB_USE_DEBUG_HOOK -DMRBGEM_MRUBY_ARRAY_EXT_VERSION=0.0.0 -DMRB_DEBUG
      -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING
      -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET
      -DMRB_USE_TASK_SCHEDULER

# full-debug puts -g3 -O0 after the toolchain's own -g -O3, so it is the one
# row measured at -O0
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency across Array set operations, including union, intersection, difference, and uniqueness handling.
  * Array comparisons now consistently follow `eql?` semantics, regardless of array size.
  * Corrected difference results when values appear across multiple input arrays.
  * Ensured intersections include only elements present in every input array.
  * Ensured block-based uniqueness and related set operations produce consistent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->