### PR TITLE
mruby-array-ext: write `-` and `intersect?` once, against a membership oracle

### DIFF
--- a/mrbgems/mruby-array-ext/src/array.c
+++ b/mrbgems/mruby-array-ext/src/array.c
@@ -18,10 +18,20 @@ ary_set_hash_func(mrb_state *mrb, mrb_value key)
   return (khint_t)mrb_obj_hash_code(mrb, key);
 }
 
+/* The one definition of "the same element" for the operations written against
+   ary_memb below. The khash callback and the walk both come through here, so
+   the two kinds of path cannot drift apart the way they did when one compared
+   with `==` and the other with `eql?`. */
+static inline mrb_bool
+ary_elem_eql(mrb_state *mrb, mrb_value a, mrb_value b)
+{
+  return mrb_eql(mrb, a, b);
+}
+
 static inline mrb_bool
 ary_set_equal_func(mrb_state *mrb, mrb_value a, mrb_value b)
 {
-  return mrb_eql(mrb, a, b);
+  return ary_elem_eql(mrb, a, b);
 }
 
 KHASH_DECLARE(ary_set, mrb_value, char, 0)
@@ -451,12 +461,108 @@ ary_get_array_args(mrb_state *mrb, mrb_int argc, const mrb_value **argv_ptr)
   return total_len;
 }
 
+/* Answers one question, "is this value one of the elements I hold?", and
+   hides which of two strategies answered it. A khash set when there are
+   enough elements to repay building one, a walk over the arrays themselves
+   when there are not.
+
+   Choosing between those two is what makes this file fast and is worth
+   keeping. Writing the surrounding operation twice, once per strategy, is
+   what made it wrong: the two copies compared elements with different
+   functions until #7352, and `Array#intersection` narrowed by the union of
+   its arguments on one side and by each argument on the other until #7368.
+   A caller states its algorithm once, against ary_memb_has(), and never
+   learns which strategy replied. */
+typedef struct ary_memb {
+  mrb_bool use_set;
+  ary_set_t set;
+  mrb_int total_len;
+  const mrb_value *arys;  /* shared copies under the set, the caller's own
+                             arrays under the walk */
+  mrb_int n_arys;
+} ary_memb;
+
+static void
+ary_memb_init(mrb_state *mrb, ary_memb *m, const mrb_value *arys, mrb_int n_arys,
+              mrb_int total_len, mrb_bool use_set)
+{
+  m->use_set = use_set;
+  m->n_arys = n_arys;
+  m->total_len = total_len;
+
+  if (!use_set) {
+    /* The walk reads the caller's arrays in place. It allocates nothing, which
+       is most of why it is worth choosing at all. */
+    m->arys = arys;
+    return;
+  }
+
+  /* Shared copies hold the elements while kh_put() runs `hash`, which is Ruby
+     code and free to empty the caller's arrays. */
+  mrb_value *copies = (mrb_value *)mrb_alloca(mrb, sizeof(mrb_value) * n_arys);
+  for (mrb_int i = 0; i < n_arys; i++) {
+    copies[i] = mrb_ary_make_shared_copy(mrb, arys[i]);
+  }
+  m->arys = copies;
+  ary_init_temp_set(mrb, &m->set, total_len);
+}
+
+/* Filling is separate from init because `hash` can raise, and the set has to
+   already be under an ensure when it does. A no-op for the walk. */
+static inline void
+ary_memb_fill(mrb_state *mrb, ary_memb *m)
+{
+  if (!m->use_set) return;
+  for (mrb_int i = 0; i < m->n_arys; i++) {
+    ary_populate_temp_set(mrb, &m->set, m->arys[i]);
+  }
+}
+
+static void
+ary_memb_destroy(mrb_state *mrb, ary_memb *m)
+{
+  if (m->use_set) {
+    ary_destroy_temp_set(mrb, &m->set);
+  }
+}
+
+static inline mrb_bool
+ary_memb_has(mrb_state *mrb, ary_memb *m, mrb_value v)
+{
+  if (m->use_set) {
+    return !kh_is_end(&m->set, kh_get(ary_set, mrb, &m->set, v));
+  }
+  for (mrb_int i = 0; i < m->n_arys; i++) {
+    mrb_value ary = m->arys[i];
+    for (mrb_int j = 0; j < RARRAY_LEN(ary); j++) {
+      if (ary_elem_eql(mrb, v, RARRAY_PTR(ary)[j])) {
+        return TRUE;
+      }
+    }
+  }
+  return FALSE;
+}
+
+/* Runs `body` with the set destroyed even if it raises. The walk owns nothing
+   to destroy, so it calls straight through rather than paying for the setjmp
+   that mrb_protect_error() sets up; the walk is picked exactly when the work
+   is too small to absorb that. */
+#define ARY_MEMB_RUN(mrb, result_var, body, ctx, memb)  \
+  do {                                                  \
+    if ((memb)->use_set) {                              \
+      MRB_ENSURE(mrb, result_var, body, ctx) {          \
+        ary_memb_destroy(mrb, memb);                    \
+      }                                                 \
+    }                                                   \
+    else {                                              \
+      (result_var) = body(mrb, ctx);                    \
+    }                                                   \
+  } while (0)
+
 struct ary_subtract_ctx {
-  ary_set_t *set;
+  ary_memb *memb;
   mrb_value self;
   mrb_value result;
-  const mrb_value *argv;
-  mrb_int argc;
 };
 
 static mrb_value
@@ -464,16 +570,13 @@ ary_subtract_body(mrb_state *mrb, void *data)
 {
   struct ary_subtract_ctx *ctx = (struct ary_subtract_ctx *)data;
 
-  for (mrb_int i = 0; i < ctx->argc; i++) {
-    ary_populate_temp_set(mrb, ctx->set, ctx->argv[i]);
-  }
+  ary_memb_fill(mrb, ctx->memb);
 
   int ai = mrb_gc_arena_save(mrb);
   for (mrb_int i = 0; i < RARRAY_LEN(ctx->self); i++) {
     mrb_value p = RARRAY_PTR(ctx->self)[i];
-    mrb_gc_protect(mrb, p); // p may be removed from self by kh_get(ary_set, ...)
-    khiter_t k = kh_get(ary_set, mrb, ctx->set, p);
-    if (kh_is_end(ctx->set, k)) {  /* key doesn't exist in any ary */
+    mrb_gc_protect(mrb, p); // p may be removed from self by ary_memb_has()
+    if (!ary_memb_has(mrb, ctx->memb, p)) {  /* held by none of the arguments */
       mrb_ary_push(mrb, ctx->result, p);
     }
     mrb_gc_arena_restore(mrb, ai);
@@ -497,44 +600,13 @@ ary_subtract_internal(mrb_state *mrb, mrb_value self, mrb_int argc, const mrb_va
      then asked RARRAY_LEN(self) questions. A short receiver cannot repay a
      long set, one lookup into a thousand entries losing to one linear scan of
      them, so, as CRuby does, either side being small picks the walk. */
-  if (total_len > SET_OP_HASH_THRESHOLD &&
-      RARRAY_LEN(self) > SET_OP_HASH_THRESHOLD) {
-    /* Create shared copies to protect elements during khash operations */
-    mrb_value *argv_copies = (mrb_value *)mrb_alloca(mrb, sizeof(mrb_value) * argc);
-    for (mrb_int i = 0; i < argc; i++) {
-      argv_copies[i] = mrb_ary_make_shared_copy(mrb, argv[i]);
-    }
+  ary_memb memb;
+  ary_memb_init(mrb, &memb, argv, argc, total_len,
+                total_len > SET_OP_HASH_THRESHOLD &&
+                RARRAY_LEN(self) > SET_OP_HASH_THRESHOLD);
 
-    ary_set_t set_struct;
-    ary_set_t *set = &set_struct;
-    ary_init_temp_set(mrb, set, total_len);
-
-    struct ary_subtract_ctx ctx = { set, self, result, argv_copies, argc };
-    MRB_ENSURE(mrb, result, ary_subtract_body, &ctx) {
-      ary_destroy_temp_set(mrb, set);
-    }
-  }
-  else {
-    int ai = mrb_gc_arena_save(mrb);
-    for (mrb_int i = 0; i < RARRAY_LEN(self); i++) {
-      mrb_value p = RARRAY_PTR(self)[i];
-      mrb_gc_protect(mrb, p); // p may be removed from self by mrb_eql()
-      mrb_bool found = FALSE;
-      for (mrb_int j = 0; j < argc; j++) {
-        for (mrb_int k = 0; k < RARRAY_LEN(argv[j]); k++) {
-          if (mrb_eql(mrb, p, RARRAY_PTR(argv[j])[k])) {
-            found = TRUE;
-            break;
-          }
-        }
-        if (found) break;
-      }
-      if (!found) {
-        mrb_ary_push(mrb, result, p);
-      }
-      mrb_gc_arena_restore(mrb, ai);
-    }
-  }
+  struct ary_subtract_ctx ctx = { &memb, self, result };
+  ARY_MEMB_RUN(mrb, result, ary_subtract_body, &ctx, &memb);
 
   return result;
 }
@@ -903,8 +975,7 @@ ary_intersection_multi(mrb_state *mrb, mrb_value self)
  */
 
 struct ary_intersect_p_ctx {
-  ary_set_t *set;
-  mrb_value shorter_ary_copy;
+  ary_memb *memb;
   mrb_value longer_ary;
   mrb_bool *found;
 };
@@ -914,15 +985,15 @@ ary_intersect_p_body(mrb_state *mrb, void *data)
 {
   struct ary_intersect_p_ctx *ctx = (struct ary_intersect_p_ctx *)data;
 
-  ary_populate_temp_set(mrb, ctx->set, ctx->shorter_ary_copy);
+  ary_memb_fill(mrb, ctx->memb);
 
   int ai = mrb_gc_arena_save(mrb);
   for (mrb_int i = 0; i < RARRAY_LEN(ctx->longer_ary); i++) {
     mrb_value p = RARRAY_PTR(ctx->longer_ary)[i];
-    mrb_gc_protect(mrb, p); // p may be removed from longer_ary by kh_get(ary_set, ...)
-    khiter_t k = kh_get(ary_set, mrb, ctx->set, p);
+    mrb_gc_protect(mrb, p); // p may be removed from longer_ary by ary_memb_has()
+    mrb_bool hit = ary_memb_has(mrb, ctx->memb, p);
     mrb_gc_arena_restore(mrb, ai);
-    if (!kh_is_end(ctx->set, k)) {
+    if (hit) {
       *ctx->found = TRUE;
       break;
     }
@@ -951,40 +1022,18 @@ ary_intersect_p(mrb_state *mrb, mrb_value self)
     return mrb_false_value();
   }
 
-  if (RARRAY_LEN(shorter_ary) > SET_OP_HASH_THRESHOLD) {
-    mrb_value shorter_ary_copy = mrb_ary_make_shared_copy(mrb, shorter_ary);
+  /* The shorter side is the one that would become the set, so it is the one
+     that has to be long enough to be worth building. */
+  ary_memb memb;
+  ary_memb_init(mrb, &memb, &shorter_ary, 1, RARRAY_LEN(shorter_ary),
+                RARRAY_LEN(shorter_ary) > SET_OP_HASH_THRESHOLD);
 
-    ary_set_t set_struct;
-    ary_set_t *set = &set_struct;
-    ary_init_temp_set(mrb, set, RARRAY_LEN(shorter_ary_copy));
+  mrb_bool found = FALSE;
+  struct ary_intersect_p_ctx ctx = { &memb, longer_ary, &found };
+  mrb_value result;
+  ARY_MEMB_RUN(mrb, result, ary_intersect_p_body, &ctx, &memb);
 
-    mrb_bool found = FALSE;
-
-    struct ary_intersect_p_ctx ctx = { set, shorter_ary_copy, longer_ary, &found };
-    mrb_value result;
-    MRB_ENSURE(mrb, result, ary_intersect_p_body, &ctx) {
-      ary_destroy_temp_set(mrb, set);
-    }
-
-    if (found) {
-      return mrb_true_value();
-    }
-  }
-  else {
-    int ai = mrb_gc_arena_save(mrb);
-    for (mrb_int i = 0; i < RARRAY_LEN(longer_ary); i++) {
-      mrb_value p = RARRAY_PTR(longer_ary)[i];
-      mrb_gc_protect(mrb, p); // p may be removed from longer_ary by mrb_eql()
-      for (mrb_int j = 0; j < RARRAY_LEN(shorter_ary); j++) {
-        if (mrb_eql(mrb, p, RARRAY_PTR(shorter_ary)[j])) {
-          return mrb_true_value();
-        }
-      }
-      mrb_gc_arena_restore(mrb, ai);
-    }
-  }
-
-  return mrb_false_value();
+  return found ? mrb_true_value() : mrb_false_value();
 }
 
 /*

--- a/mrbgems/mruby-array-ext/src/array.c
+++ b/mrbgems/mruby-array-ext/src/array.c
@@ -493,7 +493,12 @@ ary_subtract_internal(mrb_state *mrb, mrb_value self, mrb_int argc, const mrb_va
 
   mrb_value result = mrb_ary_new(mrb);
 
-  if (total_len > SET_OP_HASH_THRESHOLD) {
+  /* Both sides have to be worth a set: it costs O(total_len) to build and is
+     then asked RARRAY_LEN(self) questions. A short receiver cannot repay a
+     long set, one lookup into a thousand entries losing to one linear scan of
+     them, so, as CRuby does, either side being small picks the walk. */
+  if (total_len > SET_OP_HASH_THRESHOLD &&
+      RARRAY_LEN(self) > SET_OP_HASH_THRESHOLD) {
     /* Create shared copies to protect elements during khash operations */
     mrb_value *argv_copies = (mrb_value *)mrb_alloca(mrb, sizeof(mrb_value) * argc);
     for (mrb_int i = 0; i < argc; i++) {

--- a/mrbgems/mruby-array-ext/test/array.rb
+++ b/mrbgems/mruby-array-ext/test/array.rb
@@ -220,6 +220,22 @@ assert("Array#difference") do
   assert_equal [2, 3], a.difference(b,c)
 end
 
+assert("Array#difference drops an element found in any argument, on either path") do
+  # `-` keeps a set path and a walk, and several arguments mean "drop what any
+  # one of them holds". Only the walk was ever asked that with more than one
+  # argument: every case above is small enough to take it. The set path had
+  # the same gap when `Array#intersection` answered `self & (a | b)` there and
+  # nothing caught it, so ask this one on both sides and require agreement.
+  pad = (100..140).to_a
+  a = [1, 2, 3] + pad             # 44 elements, long enough for the set path
+  b = [1] + (200..220).to_a       # holds 1 but not 2
+  c = [2] + (300..320).to_a       # holds 2 but not 1; 44 argument elements
+  assert_equal [3] + pad, a.difference(b, c)
+
+  # the same question below the threshold, where the walk answers it
+  assert_equal [3], [1, 2, 3].difference([1], [2])
+end
+
 assert("Array#&") do
   a = [1, 2, 3, 1]
   b = [1, 4]

--- a/mrbgems/mruby-array-ext/test/array.rb
+++ b/mrbgems/mruby-array-ext/test/array.rb
@@ -960,12 +960,13 @@ assert('Array set operations compare with eql? on both sides of the hash thresho
   small_dup = [1, 1.0, 1]
   assert_equal [1, 1.0], small_dup.uniq!
 
-  # `-` and `&` take it from the argument arrays alone, so a long receiver is
-  # no guarantee of the hash path
+  # `-` takes the set only when both sides are long enough to pay for it, so
+  # it needs a row for each way of being short as well as one for neither
   assert_equal [1], [1] - [1.0]
   assert_equal [1] + pad, long_receiver - [1.0]
   assert_equal [1], [1] - [1.0, 2.0]
   assert_equal [1], [1] - long_floats
+  assert_equal [1] + pad, long_receiver - long_floats
 
   assert_equal [], [1] & [1.0]
   assert_equal [], long_receiver & [1.0]


### PR DESCRIPTION
> **Stacked on #7371**, which this needs: the path-selection rule that PR adds is what `ary_memb_init()` is handed here. Until #7371 lands, the diff below carries its one commit as well; the second commit is this PR's own work, and every figure in `Speed` and `Size` is measured against #7371's tip rather than against master, so that what is attributed here is only what this commit does.

## Summary

`Array#-` and `#intersect?` each keep a khash set and a linear walk, picked by a length threshold, and both strategies earn their place. What does not earn its place is writing the operation twice, once per strategy. This puts the strategy behind an oracle that answers one question, so each operation is written once and never learns which strategy replied.

## Changes

| File | What |
|---|---|
| `mrbgems/mruby-array-ext/src/array.c` | adds `ary_elem_eql()` and the `ary_memb` oracle (`_init`, `_fill`, `_has`, `_destroy`, `ARY_MEMB_RUN`); rewrites `ary_subtract_internal()` and `ary_intersect_p()` against it |
| `mrbgems/mruby-array-ext/test/array.rb` | asks `-` about several arguments on both sides of the threshold |

### Two copies, and nothing making them agree

Two defects have already come out of this structure, and they are not the same kind of defect.

- **#7352.** The two copies compared elements with different functions, `mrb_equal()` on the walk against `mrb_eql()` in the khash callback. Giving both paths one comparator fixed it.
- **#7368.** One copy of `Array#intersection` narrowed by each argument where the other narrowed by their union. The copies did not disagree about equality; they disagreed about the algorithm, and no shared comparator would have caught it.

A shared comparator closes the first kind and not the second. What closes both is not having a second copy of the operation at all.

### The oracle

`ary_memb` answers *"is this value one of the elements I hold?"* and nothing else. A khash set answers it when there are enough elements to repay building one, a walk over the caller's arrays when there are not. The caller states its algorithm once, against `ary_memb_has()`:

- `-` is a single loop over the receiver, keeping what the oracle does not hold.
- `intersect?` is a single loop over the longer side, stopping at the first thing it does.

Neither can drift from a copy of itself, because there is no copy.

### Keeping the walk free

The walk is chosen precisely when the work is too small to absorb any setup, so three things had to stay true of it:

- **it allocates nothing and is not protected.** Only the set backend takes shared copies and runs under `MRB_ENSURE`; the walk reads the caller's arrays in place and is called straight through, so it never pays for the `setjmp` in `mrb_protect_error()`. That is what `ARY_MEMB_RUN` is for.
- **filling is separate from init.** `kh_put()` runs `hash`, which is Ruby and free to raise, so the set has to already be under the ensure before it is filled. `ary_memb_fill()` is a no-op for the walk.
- **`ary_memb_has()` is inline**, so the set path still reaches `kh_get()` without a call per element.

The `Speed` table below is the check on that: the two walk paths and the two set paths, none of which should move.

## Speed

```ruby
a = (1..32).to_a; b = (33..64).to_a
                        i = 0; while i < 100000 do a - b;           i += 1 end
a = (1..32).to_a; b = (33..64).to_a
                        i = 0; while i < 100000 do a.intersect?(b); i += 1 end
a = (1..64).to_a; b = (1..1000).to_a
                        i = 0; while i <  10000 do a - b;           i += 1 end
a = (1..64).to_a; b = (65..128).to_a
                        i = 0; while i < 100000 do a.intersect?(b); i += 1 end
```

Best of 11 interleaved runs against #7371, with a #7371-against-#7371 control to read the noise by, and the instruction counts callgrind reads beside them:

| benchmark | #7371 | this PR | control | Ir per call |
| --- | ---: | ---: | ---: | ---: |
| `-`, 32 each, walk path | 2,500 ms | 2,550 ms | ±0% | 458,332 → 457,688 (-0.14%) |
| `intersect?`, 32 each, walk path | 2,530 ms | 2,500 ms | +2% | 452,551 → 453,129 (+0.13%) |
| `-`, receiver 64, argument 1,000, set path | 940 ms | 940 ms | ±0% | 1,627,261 → 1,626,715 (-0.03%) |
| `intersect?`, 64 with 64, set path | 750 ms | 760 ms | +3% | 133,129 → 133,817 (+0.52%) |

Three of the four are inside 0.14% by instruction count, which is below what this machine's wall clock can resolve. The fourth, `intersect?` on its set path, costs 688 instructions more per call over a 64-element walk of the longer side, about ten per element: that is `ary_memb_has()` reading `use_set` out of the struct where the old code had the branch hoisted out of the loop by construction. It is the one place the indirection is visible, and its wall clock stays inside the control.

## Size

`.text` of `bin/mruby`, `size -A`, for the five builds of `build_config/ci/gcc-clang.rb`, #7371's tip and this branch built at the same path in an empty build directory:

| Build | #7371 | this PR | delta |
| --- | ---: | ---: | ---: |
| `ascii-ctype` | 1,071,302 | 1,071,478 | +176 |
| `bintest` | 1,076,422 | 1,076,598 | +176 |
| `byte-string` | 1,051,302 | 1,051,478 | +176 |
| `cxx_abi` | 1,064,501 | 1,064,677 | +176 |
| `full-debug` (-O0) | 1,867,830 | 1,866,902 | -928 |

All of it is `mrbgems/mruby-array-ext/src/array.o`, whose `.text` goes from 18,887 to 19,063. The optimised builds grow because `ary_memb_has()` is inlined into both callers; `full-debug` shrinks because at `-O0` nothing is inlined and what is left is one walk where there were two.

## Testing

`rake test` is green: 2,363 tests, 0 KO, 0 crash, 0 warning, plus 128 bintest cases with 0 KO.

The test this adds asks `-` about several arguments on both sides of the threshold. Only the walk was ever asked that: every existing case is small enough to take it, so the set path went untested with more than one argument, which is exactly the gap #7368 fell through. Expected values were checked against CRuby 3.2.3 and 4.0.6.

## Environment

<details>

| | |
|---|---|
| OS | Ubuntu 24.04, Linux 7.0.0-30-generic x86_64 |
| CPU | AMD Ryzen 9 5950X |
| C compiler | Homebrew clang 22.1.8 (`CC`, `CXX` and `LD` all clang) |
| binutils | GNU ld 2.47.20260726 |
| valgrind | 3.27.1 (callgrind) |
| CRuby | 3.2.3 and 4.0.6, for the expected values |

Benchmarks were built with `build_config/default.rb` and run one core at a time under `taskset -c 7`. Wall clock has 10 ms of resolution here, so the instruction counts are the ones to read for small differences; they are `Ir(2N) - Ir(N)` divided by `N`, which cancels out start-up and parsing.

The compile line for the benchmarked build, with `-MMD -c`, `-I` and `-o` dropped:

```console
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration
      -Wwrite-strings -Wzero-length-array -DMRBGEM_MRUBY_ARRAY_EXT_VERSION=0.0.0
      -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL
      -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK
```

And for the five builds the `Size` table comes from:

```console
# ascii-ctype
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration
      -Wwrite-strings -Wzero-length-array -DMRB_USE_ASCII_CTYPE
      -DMRB_REGEXP_PARSE_DEPTH_LIMIT=512 -DMRBGEM_MRUBY_ARRAY_EXT_VERSION=0.0.0
      -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING
      -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET
      -DMRB_USE_TASK_SCHEDULER

# bintest
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration
      -Wwrite-strings -Wzero-length-array -DMRB_GC_FIXED_ARENA
      -DMRBGEM_MRUBY_ARRAY_EXT_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX
      -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM
      -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET
      -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK

# byte-string
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration
      -Wwrite-strings -Wzero-length-array -DMRBGEM_MRUBY_ARRAY_EXT_VERSION=0.0.0
      -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL
      -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# cxx_abi, the one build compiled as C++
clang -g -O3 -Wall -Wundef -Wwrite-strings -Wzero-length-array -x c++ -std=gnu++03
      -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_ARRAY_EXT_VERSION=0.0.0
      -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX
      -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM
      -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET
      -DMRB_USE_TASK_SCHEDULER

# full-debug, the only -O0 build
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration
      -Wwrite-strings -Wzero-length-array -g3 -O0 -DMRB_GC_STRESS
      -DMRB_USE_DEBUG_HOOK -DMRBGEM_MRUBY_ARRAY_EXT_VERSION=0.0.0 -DMRB_DEBUG
      -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING
      -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET
      -DMRB_USE_TASK_SCHEDULER
```

`full-debug` puts `-g3 -O0` after the toolchain's own `-g -O3`, so it is the one row measured at `-O0`.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved `Array#difference` and intersection-related operations for consistent `eql?` comparisons.
  - Fixed behavior when removing elements across multiple arrays, including large and small collections.
  - Improved handling of duplicate and matching elements across different execution paths.

- **Tests**
  - Added regression coverage for multiple-argument differences and threshold-sized arrays.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->