### PR TITLE
build: keep the paths of the build out of what it compiles

### DIFF
--- a/doc/guides/compile.md
+++ b/doc/guides/compile.md
@@ -386,6 +386,49 @@ When debugging mode is enabled
   - Because `-g` flag would be added to `mrbc` runner.
     - You can have better backtrace of mruby scripts with this.
 
+### File prefix map
+
+The compiler is given absolute paths, so where the mruby tree and the build
+directory sit reaches what it compiles: `__FILE__`, which is what `mrb_assert`
+reports through `assert`, and the debug information that the `-g` of the `gcc`
+and `clang` toolchains writes. To keep them out of it add the following:
+
+```ruby
+conf.enable_file_prefix_map
+```
+
+which compiles with `-ffile-prefix-map` for the two directories the sources of
+a build come from: the mruby tree, written as `.`, and the build directory,
+written as `./build`. The build directory is written as the place it takes when
+nothing moves it, so that a build with `MRUBY_BUILD_DIR` pointing outside the
+tree compiles what a build inside the tree compiles.
+
+To write the two names yourself:
+
+```ruby
+conf.enable_file_prefix_map source: "mruby", build: "mruby/build"
+```
+
+Any other directory is mapped one at a time, which is how the path of a
+toolchain or of a gem outside the tree is written:
+
+```ruby
+conf.file_prefix_map "/opt/toolchain", "toolchain"
+```
+
+Note that
+
+- A compiler that does not take `-ffile-prefix-map`, which `cl` and every
+  compiler older than GCC 8 or clang 10 are, is compiled with as it always was.
+  The build asks the compiler before it maps anything, and leaves the paths
+  alone where the answer is no.
+- The flags a build exports in `libmruby.flags.mak` carry no map: the
+  directories a map names are the ones of the machine that built the package,
+  and nothing compiled against the package from there sits under them.
+- The file names `mrbc` records under `enable_debug`, which the backtrace of an
+  mruby script reports, are written by `mrbc` and not by the compiler, so no
+  map reaches them.
+
 ## Cross-Compilation
 
 mruby can also be cross-compiled from one platform to another. To achieve

--- a/doc/guides/compile.md
+++ b/doc/guides/compile.md
@@ -389,19 +389,14 @@ When debugging mode is enabled
 ### File prefix map
 
 The compiler is given absolute paths, so where the mruby tree and the build
-directory sit reaches what it compiles: `__FILE__`, which is what `mrb_assert`
-reports through `assert`, and the debug information that the `-g` of the `gcc`
-and `clang` toolchains writes. To keep them out of it add the following:
-
-```ruby
-conf.enable_file_prefix_map
-```
-
-which compiles with `-ffile-prefix-map` for the two directories the sources of
-a build come from: the mruby tree, written as `.`, and the build directory,
-written as `./build`. The build directory is written as the place it takes when
-nothing moves it, so that a build with `MRUBY_BUILD_DIR` pointing outside the
-tree compiles what a build inside the tree compiles.
+directory sit would reach what it compiles: `__FILE__`, which is what
+`mrb_assert` reports through `assert`, and the debug information that the `-g`
+of the `gcc` and `clang` toolchains writes. Every build keeps them out of it on
+its own, compiling with `-ffile-prefix-map` for the two directories its sources
+come from: the mruby tree, written as `.`, and the build directory, written as
+`./build`. The build directory is written as the place it takes when nothing
+moves it, so that a build with `MRUBY_BUILD_DIR` pointing outside the tree
+compiles what a build inside the tree compiles.
 
 To write the two names yourself:
 
@@ -415,6 +410,18 @@ toolchain or of a gem outside the tree is written:
 ```ruby
 conf.file_prefix_map "/opt/toolchain", "toolchain"
 ```
+
+To compile with the paths as they are:
+
+```ruby
+conf.disable_file_prefix_map
+```
+
+which is what a build to be debugged from outside the mruby tree wants: a
+debugger looks for the sources of a mapped build under the names they were
+mapped to, and finds them only from the directory those names are relative to.
+Either tell the debugger where they are (`set substitute-path . /path/to/mruby`
+in gdb) or take the map off this way.
 
 Note that
 

--- a/lib/mruby/build.rb
+++ b/lib/mruby/build.rb
@@ -164,6 +164,7 @@ module MRuby
         @enable_lock = true
         @enable_benchmark = true
         @mrbcfile_external = false
+        @file_prefix_map = nil
         @internal = internal
         @toolchains = []
         @port_names = nil
@@ -176,6 +177,9 @@ module MRuby
       begin
         current.instance_eval(&block)
       ensure
+        # Before the compilers are copied: `create_mrbc_build` below takes a
+        # copy of them, and so does every gem when it is set up.
+        current.apply_default_file_prefix_map
         if current.libmruby_enabled? && !current.mrbcfile_external?
           current.create_mrbc_build if current.host? || current.gems["mruby-bin-mrbc"]
         end
@@ -217,6 +221,10 @@ module MRuby
     # directories its sources come from: the mruby tree, and the build
     # directory, where the generated sources and the presym headers are.
     #
+    # Every build does this much on its own, so a config calls this only to
+    # write the two names itself, and by calling it says that the build has
+    # no say: the names a config writes are the only ones its output carries.
+    #
     # The build directory is written as `build` under the name of the tree,
     # the place it takes when nothing moves it, so that a build with
     # `MRUBY_BUILD_DIR` pointing outside the tree compiles what a build inside
@@ -234,6 +242,15 @@ module MRuby
     def enable_file_prefix_map(source: ".", build: "#{source}/build")
       file_prefix_map(MRUBY_ROOT, source)
       file_prefix_map(@build_root, build)
+      @file_prefix_map = true
+    end
+
+    # Compile with the paths of this build as they are, which a build that
+    # is meant to be debugged from outside the tree wants: a debugger looks
+    # for the sources of a mapped build under the mapped names, and finds
+    # them only from the directory they were mapped against.
+    def disable_file_prefix_map
+      @file_prefix_map = false
     end
 
     # Set target port names for this build.
@@ -672,6 +689,12 @@ EOS
     protected
 
     attr_writer :presym
+
+    # Map the directories of this build unless the config has spoken for
+    # itself, either way.
+    def apply_default_file_prefix_map
+      enable_file_prefix_map if @file_prefix_map.nil?
+    end
 
     def create_mrbc_build
       exclusions = %i[@name @build_dir @gems @enable_test @enable_bintest @internal @install_excludes]

--- a/lib/mruby/build.rb
+++ b/lib/mruby/build.rb
@@ -97,6 +97,7 @@ module MRuby
     include LoadGems
     attr_accessor :name, :bins, :exts, :file_separator, :build_dir, :gem_clone_dir, :defines, :libdir_name
     attr_reader :products, :libmruby_core_objs, :libmruby_objs, :gems, :toolchains, :presym, :mrbc_build, :gem_dir_to_repo_url
+    attr_reader :build_root
     attr_reader :install_excludes, :port_names
 
     alias libmruby libmruby_objs
@@ -124,6 +125,11 @@ module MRuby
         build_dir = build_dir || ENV['MRUBY_BUILD_DIR'] || "#{MRUBY_ROOT}/build"
 
         @file_separator = '/'
+        # The directory every target of this config builds under. `@build_dir`
+        # is this target's share of it, and the clones of remote gems sit
+        # beside that. `MRUBY_BUILD_DIR` may put it anywhere, so this is the
+        # one a build maps to keep its own paths out of what it compiles.
+        @build_root = build_dir
         @build_dir = "#{build_dir}/#{@name}"
         @gem_clone_dir = "#{build_dir}/repos/#{@name}"
         @libdir_name = (self.kind_of?(MRuby::CrossBuild) ? nil : ENV["MRUBY_SYSTEM_LIBDIR_NAME"]) || "lib"
@@ -197,6 +203,37 @@ module MRuby
       @mrbc.compile_options += ' -g'
 
       @enable_debug = true
+    end
+
+    # Have the compilers write +to+ in place of +from+ wherever they write a
+    # path of their own: in `__FILE__`, which `mrb_assert` reaches through
+    # `assert`, and in the debug information `-g` writes. A compiler that
+    # cannot map a path is left alone.
+    def file_prefix_map(from, to)
+      compilers.each {|c| c.file_prefix_maps[from] = to}
+    end
+
+    # Keep the paths of this build out of what it compiles, by mapping the two
+    # directories its sources come from: the mruby tree, and the build
+    # directory, where the generated sources and the presym headers are.
+    #
+    # The build directory is written as `build` under the name of the tree,
+    # the place it takes when nothing moves it, so that a build with
+    # `MRUBY_BUILD_DIR` pointing outside the tree compiles what a build inside
+    # the tree compiles.
+    #
+    # The two maps overlap where the build directory is inside the tree, and
+    # both `gcc` and `clang` answer a path both cover with the longer prefix,
+    # which is the build directory. Under the names above that is the answer
+    # either map gives; a caller that names the two apart is asking for the
+    # longer one to win.
+    #
+    # This says nothing of the paths `mrbc` writes: the file names it records
+    # for a backtrace under `enable_debug` are the ones the build passes it,
+    # and no compiler flag reaches them.
+    def enable_file_prefix_map(source: ".", build: "#{source}/build")
+      file_prefix_map(MRUBY_ROOT, source)
+      file_prefix_map(@build_root, build)
     end
 
     # Set target port names for this build.

--- a/lib/mruby/build/command.rb
+++ b/lib/mruby/build/command.rb
@@ -35,6 +35,10 @@ module MRuby
   end
 
   class Command::Compiler < Command
+    # The answers `file_prefix_map?` has had from the commands it asked,
+    # which are the same from one compiler to the next.
+    FILE_PREFIX_MAP_SUPPORT = {}
+
     attr_accessor :label, :flags, :include_paths, :defines, :source_exts
     # Defines are held in two lists, split by who asked for them. `defines` is
     # what the build config and the gems write. `internal_defines` is what the
@@ -44,6 +48,11 @@ module MRuby
     # the config already wrote, and lets a caller ask for one list alone.
     attr_accessor :internal_defines
     attr_accessor :compile_options, :option_define, :option_include_path, :out_ext
+    # The directories the compiler writes another name for, as `from => to`,
+    # and the option that spells that to it. They are kept out of `flags`
+    # because they name directories of the machine the build runs on, which
+    # the flags a package exports are asked not to carry.
+    attr_accessor :file_prefix_maps, :option_file_prefix_map
     attr_accessor :cxx_compile_flag, :cxx_exception_flag, :cxx_invalid_flags
     attr_writer :preprocess_options
 
@@ -58,6 +67,8 @@ module MRuby
       @internal_defines = []
       @option_include_path = %q[-I"%s"]
       @option_define = %q[-D"%s"]
+      @file_prefix_maps = {}
+      @option_file_prefix_map = %q[-ffile-prefix-map="%s=%s"]
       @compile_options = %q[%{flags} -o "%{outfile}" -c "%{infile}"]
       @cxx_invalid_flags = []
       @out_ext = build.exts.object
@@ -81,6 +92,36 @@ module MRuby
         .any? {|d| d.to_s.split('=', 2).first == name}
     end
 
+    # The flags that have this compiler write the names in `file_prefix_maps`
+    # in place of the directories they stand for, wherever it writes a path of
+    # its own: in `__FILE__`, and in the debug information. Empty where this
+    # compiler cannot map a path at all, and the paths it writes stand as they
+    # are.
+    def file_prefix_map_flags
+      return [] if file_prefix_maps.empty? || !file_prefix_map?
+      file_prefix_maps.map {|from, to| option_file_prefix_map % [filename(from), to]}
+    end
+
+    # Whether this compiler can map a path, which is two questions: whether
+    # the toolchain spells such an option at all, and whether the command it
+    # names knows the one it spells. The second is asked of the command,
+    # since a toolchain stands for a family of compilers and the flag is not
+    # in the older ones: `-ffile-prefix-map` arrived in GCC 8 and in clang
+    # 10. A command that answers no is compiled with as it always was, so a
+    # build that used to work is not broken by a map it never asked for.
+    #
+    # The answer is kept per command line, since a build has four compilers
+    # and a config has several builds, and they name few commands between
+    # them.
+    def file_prefix_map?
+      return false unless option_file_prefix_map
+      probe = "#{build.filename(command)} #{option_file_prefix_map % ['/mruby', '.']}"
+      FILE_PREFIX_MAP_SUPPORT.fetch(probe) do
+        `echo | #{probe} -E - 2>&1`
+        FILE_PREFIX_MAP_SUPPORT[probe] = $?.exitstatus == 0
+      end
+    end
+
     def search_header_path(name)
       header_search_paths.find do |v|
         File.exist? build.filename("#{v}/#{name}").sub(/^"(.*)"$/, '\1')
@@ -98,7 +139,7 @@ module MRuby
       include_path_flags = [include_paths, _include_paths].flatten.map do |f|
         option_include_path % filename(f)
       end
-      [flags, define_flags, include_path_flags, _flags].flatten.join(' ')
+      [flags, file_prefix_map_flags, define_flags, include_path_flags, _flags].flatten.join(' ')
     end
 
     def run(outfile, infile, _defines=[], _include_paths=[], _flags=[])

--- a/tasks/libmruby.rake
+++ b/tasks/libmruby.rake
@@ -57,6 +57,10 @@ MRuby.each_target do
         end
         modcc = cc.clone
         modcc.include_paths = incpaths.replace_prefix_by(dirmaps).uniq
+        # The file prefix maps name directories of the machine that built the
+        # package, and nothing the package is compiled with from here sits
+        # under them.
+        modcc.file_prefix_maps = {}
 
         f.puts "#{cmd} = #{cc.command}"
         f.puts "#{flags} = #{modcc.all_flags}"

--- a/tasks/toolchains/visualcpp.rake
+++ b/tasks/toolchains/visualcpp.rake
@@ -12,6 +12,9 @@ MRuby::Toolchain.new(:visualcpp) do |conf, _params|
     compiler.internal_defines |= %w(MRB_STACK_EXTEND_DOUBLING)
     compiler.option_include_path = %q[/I"%s"]
     compiler.option_define = '/D%s'
+    # `cl` has no counterpart of `-ffile-prefix-map`: it writes the path it
+    # is given, and `/d1trimfile` only takes a prefix off `__FILE__`.
+    compiler.option_file_prefix_map = nil
     compiler.compile_options = %Q[/Zi /c /Fo"%{outfile}" %{flags} "%{infile}"]
     compiler.preprocess_options = %Q[/EP %{flags} "%{infile}" > "%{outfile}"]
     compiler.cxx_compile_flag = '/TP'


### PR DESCRIPTION
## Summary

What a build compiles carries the directories it was built in, and nothing in mruby asked for it to: `bin/mruby` of the `bintest` build names the tree it was built from and the directory it was built in 308 times. This maps both out with `-ffile-prefix-map`, so that one tree compiled from two directories answers with the same bytes.

## Changes

| File | What |
| --- | --- |
| `lib/mruby/build/command.rb` | adds `Command::Compiler#file_prefix_maps`, `#option_file_prefix_map`, `#file_prefix_map_flags` and `#file_prefix_map?`; `#all_flags` puts the maps after `flags` |
| `lib/mruby/build.rb` | adds `Build#build_root`, `#file_prefix_map`, `#enable_file_prefix_map`, `#disable_file_prefix_map` and `#apply_default_file_prefix_map`, the last called at the end of the config block |
| `tasks/toolchains/visualcpp.rake` | sets `option_file_prefix_map` to nil |
| `tasks/libmruby.rake` | clears the maps out of the flags `libmruby.flags.mak` exports |
| `doc/guides/compile.md` | a `File prefix map` section under `Build Configuration` |

### The two directories a build has of its own

The sources of a build come from two places: the tree, and the build directory, where the generated sources and the presym headers are. Mapping the tree alone leaves the second behind, and `MRUBY_BUILD_DIR` may put it anywhere, so both are mapped: the tree as `.`, and the build directory as `./build`, the place it takes when nothing moves it. That second name is what makes a build in `/tmp` compile what a build in the tree compiles, rather than merely compiling something with no absolute path in it.

`-ffile-prefix-map` and not `-fdebug-prefix-map`, because the paths reach the output twice: through the debug information, and through `__FILE__`, which is where `assert` gets the name it reports and `mrb_assert` is `assert`.

Where the build directory is inside the tree the two maps overlap. Both gcc and clang answer a path both cover with the longer prefix, which is the build directory, whichever order the options are given in; under these two names that is the answer either map gives.

### The compiler is asked before anything is mapped

`-ffile-prefix-map` arrived in GCC 8 and in clang 10, and `cl` has no counterpart of it. A toolchain stands for a family of compilers rather than for a version of one, so the toolchain's word is not enough: the build asks the command itself, once per command line, and leaves the paths alone where the answer is no. A build that used to work is not broken by a map it never asked for. The Visual C++ toolchain declares a nil `option_file_prefix_map` and is not asked at all.

### The maps are not flags

They are held in `Command::Compiler#file_prefix_maps` rather than in `flags`, which settles two things. `toolchain` writes `flags` whole, so a config that mapped before calling it would lose the map; held apart, a map may be written on either side of `toolchain`. And `libmruby.flags.mak` exports `all_flags` to whoever compiles against the installed package, where a map would name directories of the machine that built it and nothing there sits under them; `tasks/libmruby.rake` clears them for that file alone.

### What no map reaches

`mrbc` writes the file names it records under `enable_debug`, and Ruby's own `__FILE__` is one of them. No compiler flag reaches those: they are the 96 the `full-debug` row below still counts. In a build without `enable_debug` they show up in `mrbtest` alone, in the eight test files that write `__FILE__`.

## Behaviour

- `bin/mruby` named the tree and the build directory 308 times in the `bintest` build, and names them 0 times now. What is left in it is the toolchain's own: `/usr/include`, and the include directory of the compiler.
- Two builds of one tree, one with `MRUBY_BUILD_DIR` inside it and one outside, now produce a byte-identical `bin/mruby`, `bin/mrbc`, `bin/mirb`, `bin/mrdb` and `lib/libmruby.a`.
- `assert` names `./src/array.c` where it named the absolute path, and so does the debug information, whose `DW_AT_comp_dir` becomes `.`.
- A debugger reading a mapped build from outside the tree has to be told where the sources are (`set substitute-path . <tree>` in gdb). A config that would rather keep the paths says `conf.disable_file_prefix_map`.
- A build whose compiler cannot take the flag compiles exactly as it did.

## Size

`.text` of `bin/mruby`, `build_config/ci/gcc-clang.rb`, both sides built with gcc from an empty directory at the same path:

| Build | master | this PR | delta |
| --- | ---: | ---: | ---: |
| `bintest` | 1,310,310 | 1,310,310 | 0 |
| `byte-string` | 1,274,518 | 1,274,518 | 0 |
| `ascii-ctype` | 1,296,758 | 1,296,758 | 0 |
| `cxx_abi` | 1,337,241 | 1,337,241 | 0 |
| `full-debug` (-O0) | 1,916,838 | 1,916,838 | 0 |

No instruction moves. What a shorter name saves is in the strings `assert` reports and in the debug information: for `bintest`, `.rodata` 259,760 → 258,704 and the `.debug_*` sections 8,772,618 → 8,743,992, which is the file on disk going 11,152,160 → 11,123,536. The saving is one prefix per occurrence, so it is as long as the path the tree is built at, which is 89 characters here and is written as one.

## Testing

Every job of the CI matrix that this machine can stand in for, and the answers the switches give:

- `rake -m test` with the default config, green at each of the two commits: 2,362 assertions and the 128 of `bintest`, 0 KO, 0 crashes.
- `MRUBY_CONFIG=build_config/ci/gcc-clang.rb rake -m test`, green compiled with clang and again compiled with gcc: 2,520 / 2,592 / 2,601 / 2,601 / 2,601 assertions over the five builds and 145 in `bintest`, 0 KO and 0 crashes in each.
- `MRUBY_CONFIG=build_config/cross-mingw-winetest.rb rake -m test`, the Windows binaries run under wine: 2,584 assertions and 98 in `bintest`, 0 KO. `bin/mruby.exe` carries no build path either.
- `MRUBY_CONFIG=cosmopolitan rake -m test:run:serial`, which is what the Cosmopolitan job runs: `cosmocc` is GCC 14.1.0 and takes the flag, and the APE it builds runs. The map changes nothing there: that config compiles without `-g`, and one object built with the maps and without them is byte-identical.
- A config on `toolchain :visualcpp` adds no map and asks its compiler nothing, which is what the Visual C++ job will see.
- A compiler that rejects `-ffile-prefix-map` (a wrapper standing in for one older than GCC 8), a compiler command that does not exist, and `conf.disable_file_prefix_map` each compile with no map and no error.
- A config that writes its own names with `enable_file_prefix_map` gets those and no others, whether it maps before or after `toolchain`.

Untested here: the ARM64 Linux and the macOS rows of the matrix, for want of the machines. Both are the gcc and clang the other rows run, and a compiler that does not answer for the flag is left alone rather than handed one.

## Environment

<details>

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-30-generic |
| CPU | AMD Ryzen 9 5950X, 32 threads |
| C compiler | gcc 13.3.0 (size table), clang 22.1.8 (the test runs above) |
| C++ compiler | `cxx_abi` compiles as `gcc -x c++ -std=gnu++03`; `g++` links |
| binutils | GNU Binutils 2.47.20260726 |
| CRuby | ruby 4.0.6 |
| Cross | x86_64-w64-mingw32-gcc 13 under wine 11.0; cosmocc (GCC) 14.1.0 |

The compile line of `src/string.c` in each build, as run, with `-MMD -c`, `-I` and `-o` dropped, and with the checkout written as `<tree>` (89 characters here) and what `MRUBY_BUILD_DIR` pointed at written as `<build dir>`:

```console
# bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="<tree>=." -ffile-prefix-map="<build dir>=./build" -DMRB_GC_FIXED_ARENA -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK "<tree>/src/string.c"

# byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="<tree>=." -ffile-prefix-map="<build dir>=./build" -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "<tree>/src/string.c"

# ascii-ctype
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="<tree>=." -ffile-prefix-map="<build dir>=./build" -DMRB_USE_ASCII_CTYPE -DMRB_REGEXP_PARSE_DEPTH_LIMIT=512 -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "<tree>/src/string.c"

# cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -ffile-prefix-map="<tree>=." -ffile-prefix-map="<build dir>=./build" -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "<tree>/src/string.c"

# full-debug
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -ffile-prefix-map="<tree>=." -ffile-prefix-map="<build dir>=./build" -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "<tree>/src/string.c"
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable file-prefix mapping for build paths in compiler output and debug information.
  * Added options to enable, customize, or disable path mapping.
  * Unsupported compilers automatically omit file-prefix mapping options.

* **Documentation**
  * Added compile guide documentation covering configuration, compiler support, and debugging considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->