### PR TITLE
build: write the same archive from the same objects

### DIFF
--- a/lib/mruby/build/command.rb
+++ b/lib/mruby/build/command.rb
@@ -358,7 +358,7 @@ module MRuby
     def initialize(build)
       super
       @command = ENV['AR'] || 'ar'
-      @archive_options = 'rcs "%{outfile}" %{objs}'
+      @archive_options = 'rcs%{deterministic} "%{outfile}" %{objs}'
     end
 
     # The archive is written from the objects of now. `ar r` adds to an
@@ -371,7 +371,35 @@ module MRuby
       mkdir_p File.dirname(outfile)
       rm_f outfile
       _pp "AR", outfile.relative_path
-      _run archive_options, { :outfile => filename(outfile), :objs => filename(objfiles).map{|f| %Q["#{f}"]}.join(' ') }
+      params = { :outfile => filename(outfile), :objs => filename(objfiles).map{|f| %Q["#{f}"]}.join(' ') }
+      params[:deterministic] = deterministic_modifier(File.dirname(outfile)) if
+        archive_options.include?("%{deterministic}")
+      _run archive_options, params
+    end
+
+    private
+
+    # `ar` copies the mtime, uid, gid and mode of every object into the member
+    # header it writes, so the same objects archived by another user, or a
+    # second later, make a different archive. The `D` modifier of GNU ar and
+    # llvm-ar writes zeros in those fields instead. Most binutils are built to
+    # do that unasked, but that is the choice of whoever built binutils and not
+    # one to rest on, and the `ar` of cctools takes no `D` at all. So ask this
+    # `ar` whether it takes one, once per build, with its complaint about an
+    # unknown modifier kept off the screen.
+    def deterministic_modifier(dir)
+      return @deterministic_modifier if defined?(@deterministic_modifier)
+      probe = "#{dir}/.ar-deterministic-probe"
+      rm_f probe
+      accepted = system(%Q[#{build.filename(command)} rcsD "#{filename(probe)}" > #{File::NULL} 2>&1])
+      rm_f probe
+      @deterministic_modifier = accepted ? "D" : ""
+    end
+
+    # The `ar` that takes no `D`, cctools', zeroes the timestamps when this is
+    # set instead. GNU ar and llvm-ar pay it no attention.
+    def _run(options, params={})
+      sh({"ZERO_AR_DATE" => "1"}, "#{build.filename(command)} #{options % params}")
     end
   end
 

--- a/lib/mruby/gem.rb
+++ b/lib/mruby/gem.rb
@@ -206,9 +206,14 @@ module MRuby
         end
       end
 
+      # The order of this list is the order of the members in `libmruby.a`.
+      # A glob of several extensions hands back one extension after another,
+      # and the sorting inside each of them is a default of `Dir` and not
+      # something asked for, so the order is settled here: the same sources
+      # then make the same archive, wherever it is built.
       def srcs_to_objs(src_dir_from_gem_dir)
         exts = compilers.flat_map{|c| c.source_exts} * ","
-        Dir["#{@dir}/#{src_dir_from_gem_dir}/*{#{exts}}"].map do |f|
+        Dir["#{@dir}/#{src_dir_from_gem_dir}/*{#{exts}}"].sort.map do |f|
           objfile(f.relative_path_from(@dir).to_s.pathmap("#{build_dir}/%X"))
         end
       end

--- a/tasks/bin.rake
+++ b/tasks/bin.rake
@@ -10,7 +10,7 @@ MRuby.each_target do |build|
     linker_attrs = build.gems.linker_attrs(gem)
     gem.bins.each do |bin|
       exe = build.exefile("#{build.build_dir}/bin/#{bin}")
-      objs = Dir["#{gem.dir}/tools/#{bin}/*.{c,cpp,cxx,cc}"].map do |f|
+      objs = Dir["#{gem.dir}/tools/#{bin}/*.{c,cpp,cxx,cc}"].sort.map do |f|
         build.objfile(f.pathmap("#{gem.build_dir}/tools/#{bin}/%n"))
       end
       file exe => objs.concat(build.libraries) do |t|

--- a/tasks/core.rake
+++ b/tasks/core.rake
@@ -1,7 +1,7 @@
 as_cxx_srcs = %w[vm error gc].map{|name| "#{MRUBY_ROOT}/src/#{name}.c"}
 
 MRuby.each_target do
-  objs = Dir.glob("#{MRUBY_ROOT}/src/*.c").map do |src|
+  objs = Dir.glob("#{MRUBY_ROOT}/src/*.c").sort.map do |src|
     if cxx_exception_enabled? && as_cxx_srcs.include?(src)
       compile_as_cxx(src)
     else

--- a/tasks/toolchains/openwrt.rake
+++ b/tasks/toolchains/openwrt.rake
@@ -27,6 +27,6 @@ MRuby::Toolchain.new(:openwrt) do |conf|
 
   conf.archiver do |archiver|
     archiver.command = ENV['TARGET_AR']
-    archiver.archive_options = 'rcs "%{outfile}" %{objs}'
+    archiver.archive_options = 'rcs%{deterministic} "%{outfile}" %{objs}'
   end
 end

--- a/tasks/toolchains/wasi.rake
+++ b/tasks/toolchains/wasi.rake
@@ -18,5 +18,5 @@ MRuby::Toolchain.new(:wasi) do |conf, params|
   conf.linker.libraries << 'setjmp'
 
   # llvm-ar defaults to the Darwin format on macOS hosts, which overflows on long member paths
-  conf.archiver.archive_options = '--format=gnu rcs "%{outfile}" %{objs}'
+  conf.archiver.archive_options = '--format=gnu rcs%{deterministic} "%{outfile}" %{objs}'
 end


### PR DESCRIPTION
## Summary

Two builds of the same sources do not give the same `libmruby.a`: the order of its members is the order a glob handed back, and every member header carries the mtime, uid, gid and mode of the object it was written from. Both are settled here, so the same objects give the same archive.

## Changes

| File | What |
|---|---|
| `lib/mruby/build/command.rb` | `Command::Archiver#run` asks `ar` whether it takes a `D` and runs it with `ZERO_AR_DATE` set; the default `archive_options` becomes `rcs%{deterministic}` |
| `tasks/toolchains/wasi.rake` | `archive_options` carries the modifier |
| `tasks/toolchains/openwrt.rake` | `archive_options` carries the modifier |
| `lib/mruby/gem.rb` | `srcs_to_objs` sorts the objects it answers with |
| `tasks/core.rake` | sorts the core objects |
| `tasks/bin.rake` | sorts a binary's own objects |

### The order of the members is the order a glob returned

The member order of `libmruby.a` is the order of the object lists the build collects, and each of those lists is whatever `Dir` handed back. `Dir.glob` has sorted its results by default only since Ruby 3.0, while `doc/guides/compile.md` asks for Ruby 2.5 or later, so on a supported Ruby the members can come out in directory order. A glob over several source extensions, as `srcs_to_objs` writes, returns one extension after another whatever the Ruby, and the sorting inside each of them is a default rather than something this build asked for.

The three lists that reach an archive or a link are sorted: a gem's own objects, the core objects of `src`, and a binary's objects under `tools`. With the gems in this tree and a Ruby that sorts, no member moves; the order simply stops resting on a default.

### The member headers carry a timestamp and an owner

`ar` copies the mtime, uid, gid and mode of every object into the member header it writes, so the same objects archived by another user, or after a rebuild, give a different `libmruby.a`. The `D` modifier of GNU ar and llvm-ar writes zeros in those fields instead. Many binutils are configured to do that without being asked, but that is the choice of whoever built binutils and not one this build can rest on.

The modifier is not assumed: the `ar` of cctools takes no `D`, and reads `ZERO_AR_DATE` from the environment instead. So `Command::Archiver` puts the question to the archiver once per build (`ar rcsD` on a probe file, with its complaint about an unknown modifier kept off the screen and the probe removed), uses a `D` only if it is taken, and sets `ZERO_AR_DATE` for every run, which the two that take a `D` pay no attention to. A configuration that writes its own `archive_options` without `%{deterministic}`, as `visualcpp` does, is left as it is and is not asked.

## Behaviour

Rebuilding one object and writing the archive from the same objects, with and without the modifier. This host's binutils zeroes the fields unasked, so `U`, the modifier that keeps the real values, stands in for an `ar` that does not.

```console
$ rake
$ ar rcsU u1.a <the objects of libmruby.a>
$ ar rcsD d1.a <the objects of libmruby.a>
$ touch src/string.c
$ rake
$ ar rcsU u2.a <the objects of libmruby.a>
$ ar rcsD d2.a <the objects of libmruby.a>
$ cmp u1.a u2.a
u1.a u2.a differ: byte 34, line 2
$ cmp d1.a d2.a
$ ar tvU u2.a | head -2
rw-rw-r-- 1000/1000 557992 Aug 26 14:03 2026 bigint.o
rw-rw-r-- 1000/1000   4056 Aug 26 14:03 2026 allocf.o
$ ar tvU d2.a | head -2
rw-r--r-- 0/0 557992 Jan  1 09:00 1970 bigint.o
rw-r--r-- 0/0   4056 Jan  1 09:00 1970 allocf.o
```

What the archive holds does not change, and neither does the linked `mruby`.

## Testing

`rake -m test` on each commit of the branch, run as `git rebase <base> --exec 'rake -m test'`:

| Commit | bintest | mrbtest | KO |
|---|---|---|---|
| `settle the order of the objects an archive is written from` | 128 | 2364 | 0 |
| `write archives with no timestamp and no owner in them` | 128 | 2364 | 0 |

Two further checks on the second commit:

- Removing `build/host/lib/libmruby.a` and letting `rake` write it again gives a file identical to the one it replaced (`cmp`).
- With `AR` pointing at a script that refuses a `D`, the archiver falls back to `ZERO_AR_DATE=1 <ar> rcs "…/libmruby.a" …`, the build completes, and the probe file does not survive.

## Environment

<details>
<summary>Host</summary>

| | |
|---|---|
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-30-generic x86_64 |
| CPU | AMD Ryzen 9 5950X |
| C compiler | Homebrew clang 22.1.8 |
| Linker | Homebrew LLD 22.1.8 |
| Archiver | GNU ar (GNU Binutils) 2.47.20260726 |
| CRuby | ruby 4.0.6 (2026-07-14) +PRISM |
| Build config | `build_config/default.rb` (`host`) |

The compile line of `src/string.c` in that build, with `-MMD -c`, `-I` and `-o` dropped:

```console
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings
      -Wzero-length-array -DMRB_REVISION_HEADER -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET
      -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT
      -DMRB_USE_DEBUG_HOOK
```

and the archiver line it now runs, with the objects dropped:

```console
ZERO_AR_DATE=1 ar rcsD "build/host/lib/libmruby.a" …
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Builds now produce deterministic archives when supported by the archiver.
  * Source and object files are processed in a consistent order, improving reproducibility across builds.
  * Existing output archives are safely replaced during rebuilding.
  * Archive timestamps are normalized to reduce unnecessary differences between builds.
  * Compatibility is preserved with archivers that do not support deterministic mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->