### PR TITLE
mruby-regexp: let `\k<n>` name a group written after it

### DIFF
--- a/mrbgems/mruby-regexp/README.md
+++ b/mrbgems/mruby-regexp/README.md
@@ -34,6 +34,8 @@ simulation) with backtracking fallback.
   raises `RegexpError`, counting the groups of the whole pattern, so `\1(a)`
   is valid
 - `\k<name>`, `\k'name'` named backreferences
+- `\k<n>`, `\k'n'` numbered backreferences
+- `\k<-n>`, `\k'-n'` relative backreferences
 - `(?=...)` positive lookahead
 - `(?!...)` negative lookahead
 - `(?<=...)` positive lookbehind (fixed-length only)

--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -51,12 +51,14 @@ typedef struct {
   mrb_bool has_backref;
   mrb_bool needs_backtrack;
   mrb_bool dont_capture;    /* pattern declares a named group: plain (...) does not capture */
-  uint16_t max_backref;     /* the largest `\NN` the pattern refers back to,
-                               checked against the group count once the whole
-                               pattern is read: CRuby takes a reference to a
-                               group written later, `\1(a)`, so the count it
-                               compares with is the pattern's, not the one
-                               standing where the reference is */
+  uint16_t max_backref;     /* the largest group number the pattern refers
+                               back to, whichever of `\NN` and `\k<n>` spelled
+                               it, checked against the group count once the
+                               whole pattern is read: CRuby takes a reference
+                               to a group written later, `\1(a)` and
+                               `\k<1>(a)` alike, so the count it compares with
+                               is the pattern's, not the one standing where
+                               the reference is */
   uint16_t num_groups;      /* groups opened so far, counting the plain ones a
                                named pattern demotes: what decides whether
                                `\NN` is a backreference or an octal escape */
@@ -1918,15 +1920,31 @@ compile_atom(re_compiler *c)
 
         /* CRuby rejects a numbered backreference in a named pattern whatever
            its spelling, and it has to be rejected here too: once plain groups
-           stop consuming numbers, both the absolute bound and the relative
-           form's `num_captures - n` below would silently resolve to a
-           different group instead of erroring. */
+           stop consuming numbers, both the check after the parse, which
+           counts the demoted groups, and the relative form's `num_captures -
+           n` below would silently resolve to a different group instead of
+           erroring. */
         if (c->dont_capture) {
           compile_error(c, "numbered backref/call is not allowed. (use name)");
         }
-        group = relative ? (int)c->num_captures - n : n;
-        if (group < 1 || group >= (int)c->num_captures) {
-          compile_error(c, "invalid backref number/name");
+        if (relative) {
+          /* `\k<-n>` counts back from where it stands, so the groups it can
+             name are the ones already open; Onigmo resolves it the same way
+             (BACKREF_REL_TO_ABS) and refuses a relative forward reference. */
+          group = (int)c->num_captures - n;
+          if (group < 1) compile_error(c, "invalid backref number/name");
+        }
+        else {
+          /* The absolute form may name a group written later, `\k<1>(a)`
+             being as valid in CRuby as `\1(a)` is, so the number is only
+             recorded here and mrb_re_compile() checks it against the
+             pattern's group count once the parse is done. A number above
+             RE_MAX_CAPTURES names no group whatever the pattern goes on to
+             open, and is kept at that bound so the check still refuses it
+             while the number stays one a group field can hold. */
+          if (n > RE_MAX_CAPTURES) n = RE_MAX_CAPTURES;
+          if (n > (int)c->max_backref) c->max_backref = (uint16_t)n;
+          group = n;
         }
       }
       else {
@@ -2908,9 +2926,11 @@ mrb_re_compile(mrb_state *mrb, mrb_regexp_pattern *pat,
     compile_error(&c, "unmatched ')'");
   }
 
-  /* A `\NN` names a group the pattern does not have. The count is taken here
-     rather than where the reference stands because a reference may be written
-     before the group it names, `\1(a)` being valid in CRuby. */
+  /* A backreference names a group the pattern does not have. The count is
+     taken here rather than where the reference stands because a reference may
+     be written before the group it names, `\1(a)` being valid in CRuby, and
+     it is taken once for both spellings so `\1` and `\k<1>` agree on which
+     references a pattern accepts. */
   if (c.max_backref > c.num_groups) {
     compile_error(&c, "invalid backref number/name");
   }

--- a/mrbgems/mruby-regexp/test/regexp_syntax.rb
+++ b/mrbgems/mruby-regexp/test/regexp_syntax.rb
@@ -930,6 +930,12 @@ assert("Regexp - a backreference names a group the pattern has") do
   assert_raise(RegexpError) { Regexp.new("(a)\\2") }
   assert_raise(RegexpError) { Regexp.new("(a)(b)\\3") }
   assert_raise(RegexpError) { Regexp.new("\\9") }
+  # Both spellings ask the same count, so both refuse the same references.
+  assert_raise(RegexpError) { Regexp.new("\\k<1>") }
+  assert_raise(RegexpError) { Regexp.new("(a)\\k<2>") }
+  assert_raise(RegexpError) { Regexp.new("(a)(b)\\k<3>") }
+  # A number above the capture limit names no group whatever follows it.
+  assert_raise(RegexpError) { Regexp.new("\\k<32>(a)") }
   # A named pattern refuses a numbered reference before it counts.
   assert_raise(RegexpError) { Regexp.new("(?<n>a)\\1") }
   assert_raise(RegexpError) { Regexp.new("(?<n>a)\\2") }
@@ -943,6 +949,25 @@ assert("Regexp - a backreference reaches a group written after it") do
   assert_equal ["aa", "a"], /(a)\1/.match("aa").to_a
   assert_nil(/\1(a)/ =~ "a")
   assert_equal 0, Regexp.new("(a)" * 9 + "\\9") =~ "aaaaaaaaaa"
+
+  # The `\k<n>` spelling of the same reference reaches the same group: it used
+  # to be checked where it stood while `\1` was checked after the parse, so
+  # the two spellings of one forward reference disagreed.
+  assert_nil(Regexp.new("\\k<1>(a)") =~ "a")
+  assert_equal ["aa", "a"], Regexp.new("(a)\\k<1>").match("aa").to_a
+  assert_nil(Regexp.new("\\k<2>(a)(b)") =~ "ab")
+  assert_nil(Regexp.new("(a)\\k<2>(b)") =~ "ab")
+
+  # What the forward reference is for: the group has captured by the second
+  # iteration, so the reference matches there.
+  assert_equal ["aa", "a"], Regexp.new("(?:\\1|(a))+").match("aa").to_a
+  assert_equal ["cc", "c"], Regexp.new("(?:\\k<1>|(c))+").match("cc").to_a
+
+  # The relative form stays as it was: `\k<-n>` counts back from where it
+  # stands, so it names one of the groups already open and never a later one.
+  assert_equal "abba", "abba".match(Regexp.new("(.)(.)\\k<-1>\\k<-2>"))[0]
+  assert_raise(RegexpError) { Regexp.new("\\k<-1>(a)") }
+  assert_raise(RegexpError) { Regexp.new("(?:\\k<-1>|(c))+") }
 end
 
 assert("Regexp - patterns that used to hang the compiler now raise (A1)") do


### PR DESCRIPTION
## Summary

`\1` and `\k<1>` spell one backreference, and the two disagreed about a group the pattern writes later. The digit form records its number and `mrb_re_compile()` checks it against the pattern's group count once the parse is done, so `\1(a)` compiles; the `\k` form was checked against the groups seen so far, so `\k<1>(a)` raised.

```ruby
Regexp.new("\\k<1>(a)") =~ "a"             # mruby: RegexpError, CRuby: nil
Regexp.new("(?:\\k<1>|(c))+").match("cc")  # mruby: RegexpError, CRuby: #<MatchData "cc" 1:"c">
Regexp.new("(?:\\1|(a))+").match("aa")     # both: #<MatchData "aa" 1:"a">
```

Onigmo validates a numbered backreference after the parse, in `setup_tree()`, against the pattern's total group count, and `ONIG_SYN_STRICT_CHECK_BACKREF`, which would refuse a forward reference where it stands, is not in `OnigSyntaxRuby`. So the reference compiles whichever spelling wrote it, and matches nothing until the group has captured, which is what a repetition such as `(?:\1|(a))+` is written for.

## Changes

| File | What |
| --- | --- |
| `mrbgems/mruby-regexp/src/re_compile.c` | the absolute `\k<n>` records its number in `max_backref` instead of refusing it where it stands, so `mrb_re_compile()`'s check after the parse is the one check both spellings ask; the relative `\k<-n>` keeps resolving against the groups already open |
| `mrbgems/mruby-regexp/test/regexp_syntax.rb` | adds the `\k` rows to the block pinning a reference to a group written later, and to the block pinning which references a pattern refuses |
| `mrbgems/mruby-regexp/README.md` | names the numbered and relative `\k` spellings in the syntax list |

### One check for both spellings

`max_backref` was already the list the digit arm records into and `mrb_re_compile()` already compares it with `c.num_groups` once the pattern is read. The `\k` arm now records into the same field rather than comparing with `c->num_captures` on the spot, which is what made the same reference legal in one spelling and not in the other. Nothing else moves: `dont_capture` is still checked first, since a named pattern refuses a numbered reference whatever its spelling and the count `num_groups` holds includes the plain groups such a pattern demotes.

### What the relative form keeps

`\k<-n>` counts back from where it stands, so the groups it can name are the ones already open, and Onigmo resolves it the same way before it checks anything (`BACKREF_REL_TO_ABS`). A relative forward reference is an error in CRuby and stays one here, `\k<-1>(a)` and `(?:\k<-1>|(c))+` both raising as before. Only the half of the old test that could never fire is gone: with `group` resolved as `num_captures - n` and `n` at least 1, the `group >= num_captures` arm was unreachable.

### A number above the capture limit

`\k<n>` is bounded by its brackets rather than by digits, so it can spell a number no group can carry. A number above `RE_MAX_CAPTURES` names no group whatever the pattern goes on to open, since a pattern that tried would stop at `too many capture groups` first, and it is recorded at that bound: the check after the parse still refuses it, and the number written into the opcode stays one the group field can hold. `too big number`, which parts the two CRuby messages at 2147483647, is unchanged and still reported before this point.

## Behaviour

Every row was run against CRuby 4.0.6 and against both sides of this change.

| source | subject | master | this PR, and CRuby |
| --- | --- | --- | --- |
| `\k<1>(a)` | `"a"` | `RegexpError: invalid backref number/name` | `nil` |
| `(?:\k<1>\|(c))+` | `"cc"` | `RegexpError: invalid backref number/name` | `["cc", "c"]` |
| `\k<2>(a)(b)` | `"ab"` | `RegexpError: invalid backref number/name` | `nil` |
| `(a)\k<2>(b)` | `"ab"` | `RegexpError: invalid backref number/name` | `nil` |
| `(a)\k<1>` | `"aa"` | `["aa", "a"]` | unchanged |
| `\1(a)` | `"a"` | `nil` | unchanged |
| `(?:\1\|(a))+` | `"aa"` | `["aa", "a"]` | unchanged |
| `(a)(b)\k<-1>` | `"abb"` | `["abb", "a", "b"]` | unchanged |
| `\k<1>` | `"a"` | `RegexpError: invalid backref number/name` | unchanged |
| `(a)\k<2>` | `"aa"` | `RegexpError: invalid backref number/name` | unchanged |
| `(a)\2` | `"a"` | `RegexpError: invalid backref number/name` | unchanged |
| `\k<32>(a)` | `"a"` | `RegexpError: invalid backref number/name` | unchanged |
| `\k<2147483647>(a)` | `"a"` | `RegexpError: invalid backref number/name` | unchanged |
| `\k<2147483648>(a)` | `"a"` | `RegexpError: too big number` | unchanged |
| `\k<-1>(a)` | `"a"` | `RegexpError: invalid backref number/name` | unchanged |
| `(?:\k<-1>\|(c))+` | `"cc"` | `RegexpError: invalid backref number/name` | unchanged |
| `(a)(?<b>b)\k<1>` | `"ab"` | `RegexpError: numbered backref/call is not allowed. (use name)` | unchanged |

A reference that now compiles matches nothing until its group has captured, which is the same thing `\1` has always done: `\k<1>(a)` answers `nil` for `"a"`, and `(?:\k<1>|(c))+` matches `"cc"` because the second iteration reads what the first captured.

## Speed

Callgrind `Ir` for one `Regexp.new`, as `Ir(2N) - Ir(N)` over `N` with `N` = 20,000, `bintest` build.

| source | master | this PR | delta |
| --- | --- | --- | --- |
| `abc` | 7,792 | 7,792 | 0 |
| `(a)\1` | 7,922 | 7,922 | 0 |
| `(a)\k<1>` | 8,029 | 8,031 | +2 |
| `(a)(b)(c)\k<3>` | 8,811 | 8,813 | +2 |
| `(a)(b)\k<-1>` | 8,383 | 8,378 | -5 |
| `(?<n>a)\k<n>` | 10,121 | 10,121 | 0 |

A pattern with no numbered `\k` in it compiles through the same instructions as before. The absolute form pays two for the bound and the record where it paid two for the comparison it no longer makes; the relative form saves the comparison that could never fire. The check after the parse is one the compile already ran.

## Size

`bin/mruby` `.text` under `build_config/ci/gcc-clang.rb`, both sides built at the same path from an empty build directory.

| build | master | this PR | delta |
| --- | --- | --- | --- |
| `bintest` | 1,310,358 | 1,310,390 | +32 |
| `ascii-ctype` | 1,296,806 | 1,296,822 | +16 |
| `byte-string` | 1,274,566 | 1,274,598 | +32 |
| `cxx_abi` | 1,337,289 | 1,337,305 | +16 |
| `full-debug` (-O0) | 1,916,902 | 1,916,934 | +32 |

All of it is `re_compile.o`'s `.text`, 27,969 to 28,001 in the `bintest` build.

## Testing

- `rake test` on `build_config/ci/gcc-clang.rb`, clang, all five builds: `full-debug` 2,603, `bintest` 2,603, `cxx_abi` 2,603, `byte-string` 2,522, `ascii-ctype` 2,594, plus bintest 145. 0 KO, 0 crash, 0 warning throughout.
- `build_config/clang-asan.rb` (`full-core`, address and undefined, `detect_leaks=1`): 2,603 tests and 101 bintest, 0 KO, 0 crash, 0 warning, and nothing reported by either sanitizer.
- A differential run against CRuby 4.0.6 over 41,744 backreference cases: 23 spellings of a reference by 36 shapes that place one against a group, by every string over `ab` of at most four characters, plus 2,000 random patterns. CRuby answers 9,486 of them and this PR agrees on every one, where master parts on 2,598; CRuby refuses the other 32,258 and this PR refuses exactly those, no more and no fewer.
- A second differential run of 20,000 generated patterns drawing every `\k` spelling, forward references and named patterns among them: 19,996 compared, of which 1,156 are cases master refuses and this PR answers as CRuby does, 46 are cases both answer differently from CRuby, which are the engine's standing differences, and 6 are cases master refused and this PR answers differently from CRuby. Master answers each of those 6 the same way once its `\k<n>` is written `\1`, so they are standing differences the refusal was hiding rather than new ones.

## Environment

<details>

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-30-generic x86_64 |
| C compiler | gcc 13.3.0 (`## Size`, `## Speed`), clang 22.1.8 (`## Testing`) |
| binutils | GNU ld 2.47.20260726 |
| valgrind | callgrind, `## Speed` |
| CRuby | 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM |

The `## Size` builds, as `src/string.o.flags` recorded them (`-MMD -c`, `-I` and `-o` dropped):

```console
# bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK

# ascii-ctype
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_REGEXP_PARSE_DEPTH_LIMIT=512 -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# full-debug
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for numeric `\k<n>` regular-expression backreferences, including forward references.
  - Documented absolute numbered and backward-relative backreference syntax.

- **Bug Fixes**
  - Improved validation for undefined and out-of-range numeric backreferences.
  - Preserved correct behavior for relative backreferences such as `\k<-n>`.

- **Tests**
  - Expanded coverage for valid, invalid, forward, relative, and equivalent backreference syntax.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->