### PR TITLE
mruby-regexp: range-check `\k<-n>` before refusing it as numbered

### DIFF
--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -1918,23 +1918,33 @@ compile_atom(re_compiler *c)
                                           name, (size_t)name_len));
         }
 
-        /* CRuby rejects a numbered backreference in a named pattern whatever
-           its spelling, and it has to be rejected here too: once plain groups
-           stop consuming numbers, both the check after the parse, which
-           counts the demoted groups, and the relative form's `num_captures -
-           n` below would silently resolve to a different group instead of
-           erroring. */
-        if (c->dont_capture) {
-          compile_error(c, "numbered backref/call is not allowed. (use name)");
-        }
         if (relative) {
           /* `\k<-n>` counts back from where it stands, so the groups it can
              name are the ones already open; Onigmo resolves it the same way
-             (BACKREF_REL_TO_ABS) and refuses a relative forward reference. */
-          group = (int)c->num_captures - n;
+             (BACKREF_REL_TO_ABS) and refuses a relative forward reference.
+             The count is `num_groups` rather than `num_captures` because the
+             groups a named pattern demotes still count here, as they do
+             everywhere else the parse numbers a group; where nothing is
+             demoted the two agree, `num_groups` standing one below
+             `num_captures`, which counts group 0. The resolution comes before
+             the refusal below because CRuby reaches that refusal only once
+             the reference has resolved to a group the pattern has:
+             `(?<n>a)\k<-1>` is refused for being numbered, `(?<n>a)\k<-2>`
+             is out of range instead. */
+          group = (int)c->num_groups + 1 - n;
           if (group < 1) compile_error(c, "invalid backref number/name");
         }
-        else {
+
+        /* CRuby rejects a numbered backreference in a named pattern whatever
+           its spelling, and it has to be rejected here too: once plain groups
+           stop consuming numbers, the check after the parse, which counts the
+           demoted groups, would silently accept a number naming a group that
+           no longer carries it. */
+        if (c->dont_capture) {
+          compile_error(c, "numbered backref/call is not allowed. (use name)");
+        }
+
+        if (!relative) {
           /* The absolute form may name a group written later, `\k<1>(a)`
              being as valid in CRuby as `\1(a)` is, so the number is only
              recorded here and mrb_re_compile() checks it against the

--- a/mrbgems/mruby-regexp/test/regexp_syntax.rb
+++ b/mrbgems/mruby-regexp/test/regexp_syntax.rb
@@ -1954,6 +1954,12 @@ assert("Regexp - a \\k reference names a group the pattern has") do
   assert_raise_with_message(RegexpError, "#{msg}: /(a)(?<b>b)\\k<-1>/") do
     Regexp.new("(a)(?<b>b)\\k<-1>")
   end
+  # the relative form resolves against every group the pattern has opened, the
+  # plain ones it demotes included, so this one names group 1 and is refused
+  # for being numbered rather than for naming no group
+  assert_raise_with_message(RegexpError, "#{msg}: /(a)(?<b>b)\\k<-2>/") do
+    Regexp.new("(a)(?<b>b)\\k<-2>")
+  end
   assert_raise(RegexpError) { Regexp.new("(?<b>b)\\k'1'") }
 end
 
@@ -2033,6 +2039,10 @@ assert("Regexp - \\k group reference errors say which failure it was") do
   assert_raise_with_message(RegexpError, "#{msg}: /(a)(b)\\k<-3>/") do
     Regexp.new("(a)(b)\\k<-3>")
   end
+  # a pattern that has opened no group at all
+  assert_raise_with_message(RegexpError, "#{msg}: /\\k<-1>/") do
+    Regexp.new("\\k<-1>")
+  end
 
   # a name no group carries
   assert_raise_with_message(RegexpError,
@@ -2065,6 +2075,16 @@ assert("Regexp - \\k group reference errors say which failure it was") do
   assert_raise_with_message(RegexpError,
                             "numbered backref/call is not allowed. (use name): /(a)(?<b>b)\\k<5>/") do
     Regexp.new("(a)(?<b>b)\\k<5>")
+  end
+  # the relative form is resolved before that refusal, so one past the groups
+  # the pattern has is out of range where an absolute one is refused: where an
+  # absolute reference points is only settled once the parse is done, and a
+  # relative one is settled where it stands
+  assert_raise_with_message(RegexpError, "#{msg}: /(?<b>b)\\k<-2>/") do
+    Regexp.new("(?<b>b)\\k<-2>")
+  end
+  assert_raise_with_message(RegexpError, "#{msg}: /(a)(?<b>b)\\k<-3>/") do
+    Regexp.new("(a)(?<b>b)\\k<-3>")
   end
 
   # The name is a length-counted slice of the pattern, so a name holding a NUL


### PR DESCRIPTION
## Summary

A relative `\k<-n>` counting past the groups of a pattern that declares a named group reported the refusal a numbered reference gets, where CRuby reports the range the number is out of. The refusal is right for a reference that resolves; it was standing in for the range error on one that does not.

## Changes

| File | What |
|---|---|
| `mrbgems/mruby-regexp/src/re_compile.c` | `\k` numeric form: the relative spelling is resolved and range-checked before the `dont_capture` refusal, and it resolves against `num_groups` rather than `num_captures` |
| `mrbgems/mruby-regexp/test/regexp_syntax.rb` | five rows over the two `\k` error tests |

### The refusal comes after the resolution

A pattern that declares a named group refuses a numbered backreference whatever its spelling, and CRuby reaches that refusal only once it has resolved a relative reference to a group number. `-1` in `(?<n>a)\k<-1>` is group 1, which the pattern has, so the refusal is what it reports; `-2` is group 0, which no pattern has, and that is `invalid backref number/name` instead.

The parser refused on `dont_capture` before it resolved anything, so an out-of-range relative reference in a named pattern reported the named refusal and the resolution below it was never reached. Resolving first and falling through to the refusal as before is the whole fix.

The absolute form keeps the order it had. `(?<n>a)\k<5>` is the refusal rather than a range error in CRuby too, since where an absolute reference points is only settled once the parse is done: it may name a group the pattern opens later, and `mrb_re_compile()` already checks `max_backref` against the group count at the end.

### The count is the groups opened, not the groups that capture

The relative form resolved against `num_captures`, which counts group 0 and every group that captures. In a named pattern a plain `(...)` captures nothing, so it is not in that count, and CRuby's is: `(a)(?<n>b)\k<-2>` resolves to group 1 and reaches the refusal, while `(a)(?<n>b)\k<-3>` does not resolve at all. `num_groups`, which the `\NN` spelling already reads for the same reason, counts every group the parse has opened, so the resolution is `num_groups + 1 - n`. Where nothing is demoted the two agree, `num_groups` standing one below `num_captures`.

## Behaviour

Every row was run against CRuby 4.0.6 and against both sides of this change. Only the message moves, and only on patterns that were refused before.

| source | subject | master | this PR, and CRuby |
| --- | --- | --- | --- |
| `(?<n>a)\k<-1>` | `"aa"` | `RegexpError: numbered backref/call is not allowed. (use name)` | unchanged |
| `(?<n>a)\k<-2>` | `"aa"` | `RegexpError: numbered backref/call is not allowed. (use name)` | `RegexpError: invalid backref number/name` |
| `(a)(?<n>b)\k<-1>` | `"abb"` | `RegexpError: numbered backref/call is not allowed. (use name)` | unchanged |
| `(a)(?<n>b)\k<-2>` | `"aba"` | `RegexpError: numbered backref/call is not allowed. (use name)` | unchanged |
| `(a)(?<n>b)\k<-3>` | `"aba"` | `RegexpError: numbered backref/call is not allowed. (use name)` | `RegexpError: invalid backref number/name` |
| `(?<n>a)(?:x)\k<-2>` | `"axa"` | `RegexpError: numbered backref/call is not allowed. (use name)` | `RegexpError: invalid backref number/name` |
| `(?<n>a)(?=(b))\k<-2>` | `"ab"` | `RegexpError: numbered backref/call is not allowed. (use name)` | unchanged |
| `(?<n>a)(?=(b))\k<-3>` | `"ab"` | `RegexpError: numbered backref/call is not allowed. (use name)` | `RegexpError: invalid backref number/name` |
| `(?<n>a\k<-1>)` | `"aa"` | `RegexpError: numbered backref/call is not allowed. (use name)` | unchanged |
| `(?<n>a)\k<1>` | `"aa"` | `RegexpError: numbered backref/call is not allowed. (use name)` | unchanged |
| `(?<n>a)\k<5>` | `"a"` | `RegexpError: numbered backref/call is not allowed. (use name)` | unchanged |
| `(?<n>a)\k<2147483648>` | `"a"` | `RegexpError: too big number` | unchanged |
| `\k<-1>(?<n>a)` | `"a"` | `RegexpError: numbered backref/call is not allowed. (use name)` | `RegexpError: invalid backref number/name` |
| `(a)\k<-1>` | `"aa"` | `["aa", "a"]` | unchanged |
| `(a)(b)\k<-1>` | `"abb"` | `["abb", "a", "b"]` | unchanged |
| `(a)(b)\k<-2>` | `"aba"` | `["aba", "a", "b"]` | unchanged |
| `(a)(b)\k<-3>` | `"abb"` | `RegexpError: invalid backref number/name` | unchanged |
| `\k<-1>` | `"a"` | `RegexpError: invalid backref number/name` | unchanged |

`(?<n>a)(?:x)\k<-2>` and `(?<n>a)(?=(b))\k<-3>` are the two forms that show what the count is: `(?:...)` opens no group and so does not move a relative reference, while a capture inside a lookahead does.

## Size

`.text` of `bin/mruby` for the five builds of `build_config/ci/gcc-clang.rb`, measured with `size -A` in a clean build directory at the same path.

| Build | master | This PR | Delta |
|---|---|---|---|
| `bintest` | 1,076,822 | 1,076,870 | +48 |
| `ascii-ctype` | 1,071,686 | 1,071,734 | +48 |
| `byte-string` | 1,051,670 | 1,051,718 | +48 |
| `cxx_abi` | 1,064,917 | 1,064,965 | +48 |
| `full-debug` (-O0) | 1,867,046 | 1,867,062 | +16 |

The whole delta is the range check: `re_compile.o` `.text` moves by the same amount in each build, 22,492 to 22,540 in `bintest` and 28,633 to 28,649 in `full-debug`.

## Testing

`rake -m test` over `build_config/ci/gcc-clang.rb`, all five builds green:

```console
$ MRUBY_CONFIG=build_config/ci/gcc-clang.rb rake -m test
>>> Test bintest <<<     Total: 2606  OK: 2591  KO: 0  Crash: 0  Skip: 15
>>> Test ascii-ctype <<< Total: 2606  OK: 2591  KO: 0  Crash: 0  Skip: 15
>>> Test byte-string <<< Total: 2597  OK: 2581  KO: 0  Crash: 0  Skip: 16
>>> Test cxx_abi <<<     Total: 2606  OK: 2599  KO: 0  Crash: 0  Skip: 7
>>> Test full-debug <<<  Total: 2606  OK: 2469  KO: 0  Crash: 0  Skip: 56
```

Beside the rows added to the two `\k` error tests, the fix was checked against CRuby with a corpus of 8,096 backreference cases: every sequence of groups up to three, drawn over `(a)`, `(?:a)`, `(?<gN>a)` and `(?=(a))`, paired with every spelling of a numbered, relative and named reference, written after the groups, before them, and inside the last of them. CRuby refuses 7,098 of them. master parts from CRuby on 803, all of them this one shape; this PR parts on none of the 803.

The 1,012 cases both sides part on are a different thing, left alone here: for a reference to group 0, `(a)\k<0>`, the name CRuby quotes in `invalid group name` runs to the end of the pattern, `<0>>`, where this gem quotes the name alone.

## Environment

<details>

| | |
|---|---|
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-30-generic |
| CPU | AMD Ryzen 9 5950X, 32 threads |
| C compiler | Homebrew clang 22.1.8 (`CC`, `LD`) |
| binutils | GNU Binutils 2.47.20260726 (`size`, `ld`) |
| CRuby | 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM, x86_64-linux |
| rake | 13.3.1 |

The compile line each build actually ran, from `touch src/string.c && rake --verbose`, with `-MMD -c`, the include paths and the output path dropped. `cxx_abi` compiles with `clang -x c++ -std=gnu++03` rather than a C++ driver; `full-debug` is `-O0` because `enable_debug` appends `-g3 -O0` after the toolchain's `-g -O3`.

```console
# bintest
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -ffile-prefix-map="$PWD=." -ffile-prefix-map="$MRUBY_BUILD_DIR=./build" -DMRB_GC_FIXED_ARENA -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK src/string.c

# ascii-ctype
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -ffile-prefix-map="$PWD=." -ffile-prefix-map="$MRUBY_BUILD_DIR=./build" -DMRB_USE_ASCII_CTYPE -DMRB_REGEXP_PARSE_DEPTH_LIMIT=512 -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c

# byte-string
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -ffile-prefix-map="$PWD=." -ffile-prefix-map="$MRUBY_BUILD_DIR=./build" -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c

# cxx_abi
clang -g -O3 -Wall -Wundef -Wwrite-strings -Wzero-length-array -x c++ -std=gnu++03 -ffile-prefix-map="$PWD=." -ffile-prefix-map="$MRUBY_BUILD_DIR=./build" -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c

# full-debug
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -g3 -O0 -ffile-prefix-map="$PWD=." -ffile-prefix-map="$MRUBY_BUILD_DIR=./build" -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
```

</details>
