### PR TITLE
doc: list `ENV` in the standard library tables

### DIFF
--- a/doc/guides/language.md
+++ b/doc/guides/language.md
@@ -285,6 +285,7 @@ gembox provides the class or feature you need:
 | Socket                | stdlib-io  | mruby-socket      |
 | Dir                   | stdlib-io  | mruby-dir         |
 | Errno                 | stdlib-io  | mruby-errno       |
+| ENV                   | stdlib-io  | mruby-env         |
 | Process               | stdlib-io  | mruby-process     |
 | Signal                | stdlib-io  | mruby-signal      |
 | Math                  | math       | mruby-math        |
@@ -328,14 +329,14 @@ methods. These are included by default:
 
 ### Gembox Summary
 
-| Gembox       | Contents                                      | Notes                                        |
-| ------------ | --------------------------------------------- | -------------------------------------------- |
-| `stdlib`     | Core class extensions, Fiber, Enumerator, Set | Works with `MRB_NO_STDIO` and `MRB_NO_FLOAT` |
-| `stdlib-ext` | Time, Struct, Data, Random, sprintf, pack     | Works with `MRB_NO_STDIO` and `MRB_NO_FLOAT` |
-| `stdlib-io`  | IO, File, Dir, Socket, Errno, Process, Signal | Requires stdio                               |
-| `math`       | Math, Rational, Complex, Bigint               | Works with `MRB_NO_STDIO`                    |
-| `metaprog`   | eval, binding, Method, compiler               | Works with `MRB_NO_STDIO` and `MRB_NO_FLOAT` |
-| `default`    | All of the above + CLI tools                  | Full installation                            |
+| Gembox       | Contents                                           | Notes                                        |
+| ------------ | -------------------------------------------------- | -------------------------------------------- |
+| `stdlib`     | Core class extensions, Fiber, Enumerator, Set      | Works with `MRB_NO_STDIO` and `MRB_NO_FLOAT` |
+| `stdlib-ext` | Time, Struct, Data, Random, sprintf, pack          | Works with `MRB_NO_STDIO` and `MRB_NO_FLOAT` |
+| `stdlib-io`  | IO, File, Dir, Socket, Errno, ENV, Process, Signal | Requires stdio                               |
+| `math`       | Math, Rational, Complex, Bigint                    | Works with `MRB_NO_STDIO`                    |
+| `metaprog`   | eval, binding, Method, compiler                    | Works with `MRB_NO_STDIO` and `MRB_NO_FLOAT` |
+| `default`    | All of the above + CLI tools                       | Full installation                            |
 
 ## Key Differences from CRuby
 


### PR DESCRIPTION
## Summary

The stdlib-io gembox provides the `ENV` object through mruby-env, but the standard library tables in `doc/guides/language.md` did not mention it. This PR lists `ENV` in both tables.

## Changes

| File | Change |
| --- | --- |
| `doc/guides/language.md` | List `ENV` in the Classes and Modules table and in the Gembox Summary |

### Classes and Modules

A new row `ENV | stdlib-io | mruby-env` between `Errno` and `Process`, matching the order of the Gembox Summary.

### Gembox Summary

The stdlib-io row now reads `IO, File, Dir, Socket, Errno, ENV, Process, Signal`. The Contents column grew, so the table is re-aligned.

## Testing

```console
$ prettier --check doc/guides/language.md
Checking formatting...
All matched files use Prettier code style!
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the language guide to include `ENV` in the `stdlib-io` module and class listings.
  * Expanded the `stdlib-io` contents table with six additional entries while retaining its standard I/O requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->