### PR TITLE
mruby-process: refuse a non-signal by its class

### DIFF
--- a/mrbgems/mruby-process/src/process.c
+++ b/mrbgems/mruby-process/src/process.c
@@ -69,13 +69,6 @@ signal_to_number(mrb_state *mrb, mrb_value sig)
   mrb_int len, signo;
   char bare[32];
 
-  /* A bigint is an Integer that no signal number can be, and `mrb_integer_p`
-     is false for one, so it has to be turned away before the branches below
-     read it as a name and report it as the wrong type. */
-  if (mrb_bigint_p(sig)) {
-    mrb_raisef(mrb, E_RANGE_ERROR, "signal number out of range: %v", sig);
-  }
-
   if (mrb_integer_p(sig)) {
     signo = mrb_integer(sig);
     if (signo < 0) {
@@ -87,10 +80,16 @@ signal_to_number(mrb_state *mrb, mrb_value sig)
   if (mrb_symbol_p(sig)) {
     name = mrb_sym_name_len(mrb, mrb_symbol(sig), &len);
   }
-  else {
-    sig = mrb_ensure_string_type(mrb, sig);
+  else if (mrb_string_p(sig)) {
     name = RSTRING_PTR(sig);
     len = RSTRING_LEN(sig);
+  }
+  else {
+    /* Anything else is refused by its class, as Ruby reports it.  A bigint
+       lands here too: it is an Integer that no signal number can be, and
+       `mrb_integer_p` is false for one, which is also how CRuby comes to
+       report a value like 2**70 by class rather than by size. */
+    mrb_raisef(mrb, E_ARGUMENT_ERROR, "bad signal type %C", mrb_obj_class(mrb, sig));
   }
   if (name == NULL) {
     mrb_raise(mrb, E_ARGUMENT_ERROR, "bad signal name");
@@ -185,8 +184,9 @@ process_ppid(mrb_state *mrb, mrb_value self)
  * Naming a process group through the signal instead, which is a negative
  * signal number or a name written with a leading "-" and asks for the group
  * of each +pid+ given, is not supported yet and raises ArgumentError.  A
- * signal number or a pid too large for the platform to carry raises
- * RangeError.
+ * signal of any other class, a big integer included, raises ArgumentError
+ * naming that class.  A signal number or a pid too large for the platform
+ * to carry raises RangeError.
  */
 static mrb_value
 process_kill(mrb_state *mrb, mrb_value self)

--- a/mrbgems/mruby-process/test/process.rb
+++ b/mrbgems/mruby-process/test/process.rb
@@ -133,6 +133,32 @@ assert('Process.kill with a name that is nothing but the prefix') do
   end
 end
 
+assert('Process.kill with a signal of no signal type') do
+  # What cannot be a signal at all is refused by its class, which Ruby
+  # reports as ArgumentError: the call is not converting the argument, it is
+  # naming the kinds it takes.
+  assert_raise_with_message(ArgumentError, "bad signal type Float") do
+    Process.kill(15.0, Process.pid)
+  end
+  assert_raise_with_message(ArgumentError, "bad signal type NilClass") do
+    Process.kill(nil, Process.pid)
+  end
+  assert_raise_with_message(ArgumentError, "bad signal type Array") do
+    Process.kill([], Process.pid)
+  end
+
+  # A big integer is an Integer, but not the Integer the signal branch reads,
+  # so it is refused the same way, as CRuby refuses it.  Worked out rather
+  # than written down: a literal this wide would drop the whole file from a
+  # build that cannot parse it.
+  huge = ((2**35) * (2**35) rescue nil)
+  if huge
+    assert_raise_with_message(ArgumentError, "bad signal type Integer") do
+      Process.kill(huge, Process.pid)
+    end
+  end
+end
+
 assert('Process.kill with a signal name holding a NUL') do
   # The name reaches the port as a C string, so a NUL in it would name the
   # part before it.  "TERM\0suffix" must not be a way to spell TERM.
@@ -180,8 +206,15 @@ assert('a pid or a signal number too large for the platform') do
   skip "this build cannot name a number wider than a pid" unless big
 
   assert_raise(RangeError) { Process.kill(0, big) }
-  assert_raise(RangeError) { Process.kill(big, Process.pid) }
   assert_raise(RangeError) { Process.waitpid(big) }
+
+  # As a signal, its size is only what is wrong with it where the build's own
+  # Integer carries it: a build that promoted it to a big integer refuses it
+  # as no signal type instead, tested above.  The builds are told apart by
+  # identity, which every Integer has and no big integer object does.
+  if big.equal?(2**31)
+    assert_raise(RangeError) { Process.kill(big, Process.pid) }
+  end
 end
 
 assert('Process::Status.new') do


### PR DESCRIPTION
## Summary

`Process.kill` refused a signal argument that can never name a signal with three different spellings where CRuby has one. An object that is not an Integer, String, or Symbol fell into the String conversion and was reported as a `TypeError` about that conversion, and a big integer was singled out early as a `RangeError` about its size. CRuby reports every one of them alike, as an `ArgumentError` naming the class of the argument, and this PR makes mruby say the same.

## Changes

| File | Change |
| --- | --- |
| `mrbgems/mruby-process/src/process.c` | `signal_to_number()` refuses what is no signal type as `ArgumentError: bad signal type <Class>` |
| `mrbgems/mruby-process/test/process.rb` | Assertions for the refused classes; the `2**31` signal case follows the builds that promote it |

### `signal_to_number()` takes the signal's classes apart explicitly

The Integer and Symbol branches stay as they are, the String case becomes an explicit branch, and everything that matches none of them is refused by its class. A big integer lands in that refusal too: `mrb_integer_p` is false for one, which is also how CRuby comes to report `2**70` by class rather than by size, since the value stopped being the Integer the numeric branch reads before it stopped fitting a signal.

### The size test tells promoted Integers from carried ones

On a build whose `mrb_int` carries `2**31`, the value is an Integer wider than the `int` a signal must fit, and its size stays the answer: `RangeError`. A build that promoted it to a big integer now refuses it as no signal type instead, as a 32-bit CRuby does. The test tells the two apart by identity, which every immediate Integer has and no big integer object does.

## Behaviour

```ruby
# CRuby 4.0.6, and mruby with this PR
Process.kill(15.0, pid)   # ArgumentError: bad signal type Float
Process.kill(nil, pid)    # ArgumentError: bad signal type NilClass
Process.kill([], pid)     # ArgumentError: bad signal type Array
Process.kill(2**70, pid)  # ArgumentError: bad signal type Integer

# mruby before
Process.kill(15.0, pid)   # TypeError: Float cannot be converted to String
Process.kill(nil, pid)    # TypeError: nil cannot be converted to String
Process.kill([], pid)     # TypeError: Array cannot be converted to String
Process.kill(2**70, pid)  # RangeError: signal number out of range: 1180591620717411303424
```

Everything that named a signal before still does: numbers in range, names as String or Symbol with or without the `SIG` prefix. An Integer wider than an `int` but within `mrb_int` still raises `RangeError`, as it does in CRuby.

## Speed

Nothing to time: the change is confined to refusal paths, and no call that sends a signal compiles differently.

## Size

`.text` of `libmruby.a`, `build_config/ci/gcc-clang.rb` builds compiled with clang, master and PR measured at the same worktree path in clean build directories, master detached at `upstream/master` (a1fa9e7f1).

| build | master | PR | delta |
| --- | ---: | ---: | ---: |
| full-debug | 2,420,910 | 2,420,770 | -140 |
| bintest | 1,533,458 | 1,533,382 | -76 |
| cxx_abi | 1,524,434 | 1,524,358 | -76 |
| byte-string | 1,478,777 | 1,478,701 | -76 |
| ascii-ctype | 1,501,722 | 1,501,646 | -76 |

## Testing

- `rake -m test` on a clang full-core build: 2615 assertions, 2600 OK, 0 KO, 15 skip.
- The same with `MRB_INT32`, so `2**31` promotes to a big integer and the new identity branch runs: 2615 assertions, 2599 OK, 0 KO, 16 skip.
- A 29-case differential script running the same `Process.kill` calls on CRuby 4.0.6 and on this branch agrees on the exception class for every refusal, and on the message for every case above.

## Environment

<details>

- Linux 7.0.0-30-generic x86_64
- Homebrew clang version 22.1.8
- Compile line as recorded for `mruby-process/src/process.o` in the `bintest` build:

```
clang -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -ffile-prefix-map="<worktree>=." -ffile-prefix-map="<build dir>=./build" -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_PROCESS_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK -I"<worktree>/include" -I"<worktree>/mrbgems/mruby-process/include" -I"<worktree>/mrbgems/mruby-signal/include" -I"<worktree>/mrbgems/mruby-io/include" -I"<build dir>/bintest/include" -o process.o process.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `Process.kill` handling for invalid signal arguments.
  * Unsupported signal types, including big integers and other objects, now consistently raise `ArgumentError`.
  * Preserved `RangeError` behavior for oversized native-width integer values.
  * Updated documentation to clarify errors for unsupported signal classes.

* **Tests**
  * Added coverage for invalid signal types and oversized values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->