### PR TITLE
compar.rb: order through `<=>` in `between?` and the `_by` family

### DIFF
--- a/mrbgems/mruby-enum-ext/mrblib/enum.rb
+++ b/mrbgems/mruby-enum-ext/mrblib/enum.rb
@@ -310,9 +310,15 @@ module Enumerable
         max_cmp = block.call(*val)
         first = false
       else
-        if (cmp = block.call(*val)) > max_cmp
+        value = block.call(*val)
+        # A comparison with no answer is not an ordering, the same as in
+        # Enumerable#max: without this the operator below would place a pair
+        # that stands in none.
+        cmp = (value <=> max_cmp)
+        raise ArgumentError, "comparison of #{value.class} with #{max_cmp.class} failed" if cmp.nil?
+        if cmp > 0
           max = val.__svalue
-          max_cmp = cmp
+          max_cmp = value
         end
       end
     end
@@ -344,9 +350,14 @@ module Enumerable
         min_cmp = block.call(*val)
         first = false
       else
-        if (cmp = block.call(*val)) < min_cmp
+        value = block.call(*val)
+        # A comparison with no answer is not an ordering, the same as in
+        # Enumerable#min.
+        cmp = (value <=> min_cmp)
+        raise ArgumentError, "comparison of #{value.class} with #{min_cmp.class} failed" if cmp.nil?
+        if cmp < 0
           min = val.__svalue
-          min_cmp = cmp
+          min_cmp = value
         end
       end
     end
@@ -441,13 +452,24 @@ module Enumerable
         max_cmp = min_cmp = block.call(*val)
         first = false
       else
-        if (cmp = block.call(*val)) > max_cmp
+        # The block is asked once an element and its value held, as it is in
+        # Enumerable#max_by and #min_by: the two bounds are both placed against
+        # the one value, where asking again would let a block that answers
+        # differently each time place the element in two orders.
+        value = block.call(*val)
+        # A comparison with no answer is not an ordering, the same as in
+        # Enumerable#minmax, which this walks by the block's values.
+        cmp = (value <=> max_cmp)
+        raise ArgumentError, "comparison of #{value.class} with #{max_cmp.class} failed" if cmp.nil?
+        if cmp > 0
           max = val.__svalue
-          max_cmp = cmp
+          max_cmp = value
         end
-        if (cmp = block.call(*val)) < min_cmp
+        cmp = (value <=> min_cmp)
+        raise ArgumentError, "comparison of #{value.class} with #{min_cmp.class} failed" if cmp.nil?
+        if cmp < 0
           min = val.__svalue
-          min_cmp = cmp
+          min_cmp = value
         end
       end
     end

--- a/mrbgems/mruby-enum-ext/test/enum.rb
+++ b/mrbgems/mruby-enum-ext/test/enum.rb
@@ -252,6 +252,49 @@ assert('Enumerable#minmax - a comparison with no answer') do
   assert_equal [nil, nil], [].minmax
 end
 
+assert('Enumerable#max_by, #min_by and #minmax_by - a comparison with no answer') do
+  # The same rule as Enumerable#max, #min and #minmax, walked by the block's
+  # values rather than by the elements.
+  if Object.const_defined?(:Float)
+    nan = Float::NAN
+    assert_raise(ArgumentError) { [1.0, nan].max_by { |x| x } }
+    assert_raise(ArgumentError) { [nan, 1.0].max_by { |x| x } }
+    assert_raise(ArgumentError) { [1.0, nan].min_by { |x| x } }
+    assert_raise(ArgumentError) { [nan, 1.0].min_by { |x| x } }
+    assert_raise(ArgumentError) { [1.0, nan].minmax_by { |x| x } }
+    assert_raise(ArgumentError) { [nan, 1.0].minmax_by { |x| x } }
+  end
+
+  # A pair of different kinds stands in no order either.
+  assert_raise(ArgumentError) { ['a', 1].max_by { |x| x } }
+  assert_raise(ArgumentError) { ['a', 1].min_by { |x| x } }
+  assert_raise(ArgumentError) { ['a', 1].minmax_by { |x| x } }
+
+  # A block answering nil orders nothing and moves nothing: `nil <=> nil` is 0,
+  # so the first element stands.
+  assert_equal 1, [1, 2].max_by { nil }
+  assert_equal 1, [1, 2].min_by { nil }
+  assert_equal [1, 1], [1, 2].minmax_by { nil }
+
+  assert_equal 3, [2, 1, 3].max_by { |x| x }
+  assert_equal 1, [2, 1, 3].min_by { |x| x }
+  assert_equal [1, 3], [2, 1, 3].minmax_by { |x| x }
+
+  # The first element's value is never compared, and an empty collection has
+  # no element at all.
+  assert_equal 'a', ['a'].max_by { |x| x }
+  assert_nil [].max_by { |x| x }
+  assert_equal [nil, nil], [].minmax_by { |x| x }
+end
+
+assert('Enumerable#minmax_by - the block is asked once an element') do
+  # Both bounds are placed against the one value the block gave, so the count
+  # is the count #max_by and #min_by make rather than twice it.
+  calls = 0
+  assert_equal [1, 3], [2, 1, 3].minmax_by { |x| calls += 1; x }
+  assert_equal 3, calls
+end
+
 assert('Array#minmax - the walk made in C') do
   # The same move as Array#max and #min: without a block the walk is in C.
   assert_equal [nil, nil], [].minmax

--- a/mrblib/compar.rb
+++ b/mrblib/compar.rb
@@ -97,6 +97,22 @@ module Comparable
   #
   # ISO 15.3.3.2.6
   def between?(min, max)
-    self >= min and self <= max
+    # Asked of `<=>` rather than through `>=` and `<=`: an operator answers
+    # false for a pair that stands in no order, which is right written out but
+    # wrong as the whole of a method whose job is to place the receiver. The
+    # operators above refuse such a pair, yet a Float receiver never reaches
+    # them, because Float defines its own in C.
+    cmp = self <=> min
+    if cmp.nil?
+      raise ArgumentError, "comparison of #{self.class} with #{min.class} failed"
+    end
+    # The max bound is left unasked once the receiver is below the min, as it
+    # is when `>=` short-circuits the `and`.
+    return false if cmp < 0
+    cmp = self <=> max
+    if cmp.nil?
+      raise ArgumentError, "comparison of #{self.class} with #{max.class} failed"
+    end
+    cmp <= 0
   end
 end

--- a/test/t/comparable.rb
+++ b/test/t/comparable.rb
@@ -77,3 +77,31 @@ assert('Comparable#between?', '15.3.3.2.6') do
   assert_true(c.between?( 1, -1))
   assert_true(c.between?(0, 0))
 end
+
+assert('Comparable#between? - a comparison with no answer') do
+  # #between? places the receiver against both bounds, so a pair that stands in
+  # no order is refused rather than placed, as in Comparable#clamp.
+  unordered = Class.new {
+    include Comparable
+    def <=>(other)
+      nil
+    end
+  }.new
+  assert_raise(ArgumentError) { unordered.between?(1, 2) }
+
+  if Object.const_defined?(:Float)
+    assert_raise(ArgumentError) { Float::NAN.between?(1, 2) }
+    assert_raise(ArgumentError) { 1.between?(Float::NAN, 2) }
+    assert_raise(ArgumentError) { 1.0.between?(0.0, Float::NAN) }
+  end
+
+  # A pair of different kinds stands in no order either.
+  assert_raise(ArgumentError) { 1.between?('a', 2) }
+  assert_raise(ArgumentError) { 3.between?(1, 'a') }
+
+  # The max bound is not asked for once the receiver is below the min.
+  assert_false(1.between?(2, 'a'))
+
+  assert_true(2.between?(1, 3))
+  assert_false(4.between?(1, 3))
+end


### PR DESCRIPTION
## Summary

`Comparable#between?` and `Enumerable#max_by` / `#min_by` / `#minmax_by` placed a pair that stands in no order, because they compared with `>=`, `>` and `<` where their siblings ask `<=>` and refuse a pair the comparison has no answer for.

## Changes

| File | What |
|---|---|
| `mrblib/compar.rb` | `Comparable#between?` asks `<=>` for each bound and raises `ArgumentError` on a nil |
| `mrbgems/mruby-enum-ext/mrblib/enum.rb` | `Enumerable#max_by` / `#min_by` / `#minmax_by` compare the block's values with `<=>` and raise on a nil; `#minmax_by` holds the block's value once an element |
| `test/t/comparable.rb` | `Comparable#between? - a comparison with no answer` |
| `mrbgems/mruby-enum-ext/test/enum.rb` | `Enumerable#max_by, #min_by and #minmax_by - a comparison with no answer`, `Enumerable#minmax_by - the block is asked once an element` |

### An operator answers false where a method has to refuse

#7348 gave an unordered pair a state of its own in `src/numeric.c` and made `<=>`, `Array#sort`, `Enumerable#max` / `#min` / `#minmax`, `Comparable#clamp` and `Range#===` answer for a NaN the way CRuby does. Two families were left comparing with the operators, and the operators are exactly the paths that answer `false` for an unordered pair. Written out that answer is right, `1 >= Float::NAN` is false in CRuby too, but as the whole of a method whose job is to place a value it orders a pair that stands in no order.

`Comparable#between?` was `self >= min and self <= max`. Comparable's own `>=` and `<=` refuse a nil `<=>` already, yet a Float receiver never reaches them, because Float defines the operators in C. `Enumerable#max_by`, `#min_by` and `#minmax_by` compared the block's values with `>` and `<` on the values themselves.

The fix is the shape `Comparable#clamp` carries and `ad20a74` gave `Enumerable#minmax`: ask `<=>`, raise `ArgumentError` on a nil, and read the answer's sign. `#between?` keeps the short-circuit the `and` gave it, leaving the max bound unasked once the receiver is below the min.

### `minmax_by` asked the block twice an element

`#minmax_by` called the block once for the max comparison and again for the min, five times for a three-element array where CRuby calls it three. Holding the value once and placing both bounds against it settles the count, and it keeps a block that answers differently each time from putting one element in two orders.

## Behaviour

`ArgumentError` where an unordered pair was placed. Rows measured against CRuby 4.0.6 (`03b6d3f889`):

| Expression | before | after | CRuby |
|---|---|---|---|
| `Float::NAN.between?(1, 2)` | `false` | `ArgumentError` | `ArgumentError` |
| `1.between?(Float::NAN, 2)` | `false` | `ArgumentError` | `ArgumentError` |
| `1.0.between?(0.0, Float::NAN)` | `false` | `ArgumentError` | `ArgumentError` |
| `[1.0, Float::NAN].max_by {\|x\| x}` | `1.0` | `ArgumentError` | `ArgumentError` |
| `[Float::NAN, 1.0].max_by {\|x\| x}` | `NaN` | `ArgumentError` | `ArgumentError` |
| `[1.0, Float::NAN].min_by {\|x\| x}` | `1.0` | `ArgumentError` | `ArgumentError` |
| `[1.0, Float::NAN].minmax_by {\|x\| x}` | `[1.0, 1.0]` | `ArgumentError` | `ArgumentError` |

The two `max_by` rows also answered from the order of the array, which is what placing a pair that stands in no order looks like from the outside.

Two more rows move with the comparison, both toward CRuby:

| Expression | before | after | CRuby |
|---|---|---|---|
| `[1, 2].max_by { nil }` | `NoMethodError` | `1` | `1` |
| `[1, 2].minmax_by { nil }` | `NoMethodError` | `[1, 1]` | `[1, 1]` |

`nil <=> nil` is 0, so a block that answers nil orders nothing and moves nothing; `nil > nil` was `undefined method '>' for NilClass`. A block whose values are of different kinds keeps raising `ArgumentError`, reaching `<=>` as a nil where it reached `>` as a raise.

The sibling forms are unchanged: `[1.0, Float::NAN].max`, `.min`, `.minmax`, `.sort`, `.sort_by {|x| x}` and `1.clamp(Float::NAN, 2)` raised `ArgumentError` before this branch and raise it after.

## Speed

`perf` is unavailable on this host (`perf_event_paranoid` = 4) and its wall clock swings far past the differences here, so the instruction counts are callgrind's `Ir`, taken as `Ir(2N) - Ir(N)` over `N = 100,000` so that start-up and parsing cancel. Each case is one call on the eight-element array `[3, 1, 4, 1, 5, 9, 2, 6]`, seven comparisons.

```ruby
a = [3, 1, 4, 1, 5, 9, 2, 6]
i = 0
while i < 100000   # and again at 200000
  a.max_by { |x| x }
  i += 1
end
```

| Case | master | this PR | delta |
|---|---|---|---|
| `a.max_by {\|x\| x}` | 26,607.5 | 29,861.5 | +3,254.0 (+12.2%) |
| `a.min_by {\|x\| x}` | 25,833.5 | 29,087.5 | +3,254.0 (+12.6%) |
| `a.minmax_by {\|x\| x}` | 36,240.7 | 34,980.3 | -1,260.4 (-3.5%) |
| `5.between?(1, 10)` | 1,383.0 | 1,813.0 | +430.0 (+31.1%) |
| `a.max` (control) | 1,625.0 | 1,625.0 | ±0 |
| `a.map {\|x\| x}` (control) | 27,285.3 | 27,285.3 | ±0 |

The `_by` family pays 465 `Ir` a comparison, which is the `<=>` send that `#max`, `#min` and `#minmax` were already making for the same refusal. Walking the same eight elements through an `Enumerable` that is not an `Array`, so that the mrblib forms are the ones running:

| Case | master | this PR | delta |
|---|---|---|---|
| `e.max` | 22,142.2 | 22,142.2 | ±0 |
| `e.min` | 21,992.2 | 21,992.2 | ±0 |
| `e.minmax` | 26,844.2 | 26,844.2 | ±0 |
| `e.max_by {\|x\| x}` | 27,146.4 | 30,400.5 | +3,254.1 (+12.0%) |

After the change `#max_by` costs `#max` plus the block call an element (30,400.5 - 22,142.2 = 8,258.3 over eight calls), which is what it should cost once both make the same comparison. `#minmax_by` comes out ahead because seven block calls leave while fourteen operators become `<=>` sends.

## Size

`.text` of `bin/mruby` for the five `build_config/ci/gcc-clang.rb` builds, `size -A`, master and this branch built at the same path from empty build directories:

| Build | master | this PR | delta |
|---|---|---|---|
| `bintest` | 1,076,822 | 1,076,822 | ±0 |
| `ascii-ctype` | 1,071,686 | 1,071,686 | ±0 |
| `byte-string` | 1,051,670 | 1,051,670 | ±0 |
| `cxx_abi` | 1,064,917 | 1,064,917 | ±0 |
| `full-debug` (-O0) | 1,865,526 | 1,865,526 | ±0 |

Nothing is compiled that was not compiled before, so the whole cost is bytecode in `.rodata`: `mrbgems/mruby-enum-ext/gem_init.o` +336 (`full-debug` +352) for the three `_by` methods, and `mrblib/mrblib.o` +128 (`full-debug` +144) for `#between?`. No other object moves in any build.

The one local the three `_by` methods gain is named `value`, which the presym table already holds, so no symbol is added and `src/symbol.o` does not move either.

## Testing

- `rake -m test` green with `build_config/ci/gcc-clang.rb` (`full-debug`, `bintest`, `cxx_abi`, `byte-string`, `ascii-ctype`), with the default config, and with `build_config/host-nofloat.rb`, which is what walks the `Object.const_defined?(:Float)` guard on the far side
- every row of the tables above run on the branch binary and on CRuby 4.0.6, including the message texts; mruby names the two classes where CRuby prints the value of a special constant (`comparison of Float with Float failed` against `comparison of Float with NaN failed`), which is the convention `Comparable#>=` and `Enumerable#max` already follow
- both commits build and test green on their own

## Environment

<details>

| | |
|---|---|
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-30-generic x86_64 |
| CPU | AMD Ryzen 9 5950X (16C/32T) |
| C compiler | Homebrew clang 22.1.8 |
| binutils | GNU ld 2.47.20260726 |
| CRuby | 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM |
| valgrind | 3.27.1 |
| base | `a1fa9e7f1` |

Compile lines as run, with `-MMD -c`, `-I`, `-o` and `-ffile-prefix-map` dropped:

```console
# bintest
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -DMRB_GC_FIXED_ARENA -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK

# ascii-ctype
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -DMRB_USE_ASCII_CTYPE -DMRB_REGEXP_PARSE_DEPTH_LIMIT=512 -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# byte-string
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# cxx_abi
clang -g -O3 -Wall -Wundef -Wwrite-strings -Wzero-length-array -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# full-debug
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# host, the default config the Ir tables were taken on
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -DMRB_REVISION_HEADER -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved `Enumerable#max_by`, `#min_by`, and `#minmax_by` handling for unordered comparisons, including `nil`, NaN, and incompatible values.
  - `minmax_by` now evaluates its block once per element, improving consistency and avoiding duplicate work.
  - `Comparable#between?` now raises `ArgumentError` when bounds cannot be ordered and avoids unnecessary bound evaluation when the value is below the minimum.
- **Tests**
  - Added coverage for unordered comparisons, edge cases, and block evaluation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->