### PR TITLE
mruby-rational: guard the tests a narrow `mrb_int` cannot answer

### DIFF
--- a/mrbgems/mruby-rational/test/rational.rb
+++ b/mrbgems/mruby-rational/test/rational.rb
@@ -217,13 +217,17 @@ assert 'Rational#== when the cross product overflows mrb_int but neither side is
       next
     end
     begin
-      assert_equal_rational(false, Rational(h, 3), Rational(h, 5))
-      assert_equal_rational(false, Rational(h, 5), Rational(h, 3))
-    rescue RangeError
+      # Asked here rather than around the rows below, because a RangeError
+      # raised inside assert_equal_rational is caught by the assertion it
+      # wraps and recorded as a failure instead of reaching this rescue.
       # Neither a Float nor mruby-bigint to answer through: the fallback
       # correctly raises instead of guessing.
+      Rational(h, 3) == Rational(h, 5)
+    rescue RangeError
       next
     end
+    assert_equal_rational(false, Rational(h, 3), Rational(h, 5))
+    assert_equal_rational(false, Rational(h, 5), Rational(h, 3))
   end
 end
 

--- a/mrbgems/mruby-rational/test/rational.rb
+++ b/mrbgems/mruby-rational/test/rational.rb
@@ -75,7 +75,16 @@ assert 'Rational#to_i' do
   assert_equal(0, Rational(2, 3).to_i)
   assert_equal(3, Rational(3).to_i)
   if RATIONAL_FLOAT
-    assert_equal(300, Rational(300.6).to_i)
+    # The exact fraction of the double 300.6 is 2644105562475725/8796093022208,
+    # whose numerator is wider than a 32-bit mrb_int; a build that narrow with
+    # no mruby-bigint cannot name the Rational at all, so there is nothing for
+    # the truncation to be asked about rather than a truncation it gets wrong.
+    r = begin
+      Rational(300.6)
+    rescue RangeError
+      nil
+    end
+    assert_equal(300, r.to_i) if r
   end
   assert_equal(1, Rational(98, 71).to_i)
   assert_equal(-15, Rational(-30, 2).to_i)
@@ -337,8 +346,14 @@ assert 'Rational#<=> is exact' do
   # difference no double can hold is still seen, and there is an answer at all
   # in a build carrying no Float, where every one of these used to be nil.
   #
-  # 2**53 and 2**53 + 1 are the first pair a double cannot tell apart.
-  m = 1 << 53
+  # 2**53 and 2**53 + 1 are the first pair a double cannot tell apart, so a
+  # build whose integers stop short of that width has no such pair to ask
+  # about; the wider blocks below guard themselves the same way.
+  begin
+    m = 1 << 53
+  rescue RangeError
+    skip 'no integer this wide'
+  end
   assert_cmp(1,  Rational(m + 1, 1), Rational(m, 1))
   assert_cmp(-1, Rational(m, 1), Rational(m + 1, 1))
   assert_cmp(1,  Rational(m + 1, 3), Rational(m, 3))
@@ -568,7 +583,15 @@ assert 'Rational#** is exact for a whole exponent' do
   assert_rational(Rational(9, 49), Rational(3, 7) ** 2)
   assert_rational(Rational(27, 343), Rational(3, 7) ** 3)
   assert_rational(Rational(1024, 59049), Rational(2, 3) ** 10)
-  assert_rational(Rational(1048576, 3486784401), Rational(2, 3) ** 20)
+  # 3 ** 20 is 3486784401, which is wider than a 32-bit mrb_int, so both the
+  # power and the expected value it is compared against are out of reach of a
+  # build that narrow without mruby-bigint.
+  pow20 = begin
+    Rational(2, 3) ** 20
+  rescue RangeError
+    nil
+  end
+  assert_rational(Rational(1048576, 3486784401), pow20) if pow20
 
   # a negative exponent turns the fraction over
   assert_rational(Rational(7, 3), Rational(3, 7) ** -1)


### PR DESCRIPTION
## Summary

Four assertions in `mrbgems/mruby-rational/test/rational.rb` assume either a 64-bit `mrb_int` or a bigint to promote to. On a full-core build with `MRB_INT32` and `mruby-bigint` removed, three of them crash instead of skipping:

```
RangeError: Rational#to_i => integer overflow in rational
RangeError: Rational#<=> is exact => integer overflow in bit shift
RangeError: Rational#** is exact for a whole exponent => integer overflow
  Total: 2558  OK: 2526  KO: 0  Crash: 3
```

Adding `MRB_NO_FLOAT` to that build reaches a fourth, which fails rather than crashes because its guard is dead. None of these configurations is in the CI matrix: the `ci/gcc-clang` builds all have a 64-bit `mrb_int`, and full-core keeps `mruby-bigint`.

The fix is test-side throughout. Each width is guarded the way `Rational#<=> is exact` already guards its wider ones, so a build skips what it cannot name. No runtime source changes, so there is nothing to report for speed or size.

## Changes

| Assertion | Width it could not name | Guard |
| --- | --- | --- |
| `Rational#<=> is exact` | `1 << 53` | `skip 'no integer this wide'` |
| `Rational#to_i` | numerator of the exact `Rational(300.6)` | build the value first, assert only if it exists |
| `Rational#** is exact for a whole exponent` | `3486784401`, on both sides of the row | raise first, assert only if it succeeded |
| `Rational#== when the cross product overflows mrb_int but neither side is bigint-backed` | `(1 << 30) * 5` without a Float to fall back to | probe outside the assertion helper |

### The three widths that were never guarded

`Rational#<=> is exact` shifts `1 << 53` to name the first pair a double cannot tell apart. The later widths in the same test, `w = 3 * (10 ** 18)` and `big = 1 << 70`, are already wrapped in `begin`/`rescue RangeError`, so the pattern the file uses simply did not reach its first width. A build whose integers stop short of 2**53 has no such pair to ask about, so the whole assertion skips.

`Rational#to_i` asks for `Rational(300.6)` under a build that has a Float. The exact fraction of that double is `2644105562475725/8796093022208`, whose numerator does not fit 32 bits, so the Rational cannot be built there at all. That is a value the build cannot name rather than a truncation it gets wrong, so the row is asked for only where the value exists; the other four rows of the assertion still run.

`Rational#** is exact for a whole exponent` asserts `Rational(2, 3) ** 20` against `Rational(1048576, 3486784401)`. `3 ** 20` is `3486784401`, wider than a 32-bit `mrb_int`, and the expected value spells that denominator out, so both sides of the row are out of reach. The power is raised first and the comparison is asked only if it succeeded, which keeps the row's neighbours (`** 0` through `** 10`, the negative exponents, the sign rows, the `Rational` exponent) running.

### A guard that never ran

`Rational#== when the cross product overflows mrb_int but neither side is bigint-backed` wraps its rows in `rescue RangeError` so that a build with neither a Float nor `mruby-bigint` to answer through moves on to the next width:

```ruby
begin
  assert_equal_rational(false, Rational(h, 3), Rational(h, 5))
  assert_equal_rational(false, Rational(h, 5), Rational(h, 3))
rescue RangeError
  next
end
```

The rows go through `assert_equal_rational`, which holds an `assert` block of its own, and that block catches the exception and records it as a failed assertion. The `rescue` around it never runs. The comparison is now asked once outside the helper, and the `RangeError` is taken from there.

This one is invisible wherever there is a Float, because the fallback answers through it; it needs `MRB_NO_FLOAT` on top of `MRB_INT32` without `mruby-bigint` to show up.

## Behaviour

No behaviour change in a build that can name these widths: every configuration with a 64-bit `mrb_int`, and every configuration carrying `mruby-bigint`, runs exactly the assertions it ran before. On `MRB_INT32` without `mruby-bigint`, one further assertion is reported as skipped (`Rational#<=> is exact`); the other three keep running with a single row each held back.

The test file is still loaded whole on those builds. The literals wider than an `mrb_int` all sit inside `assert` blocks, so they are a runtime `RangeError` rather than something the compiler refuses, and the guards added here keep every value they build inside a block as well. Confirmed by appending a marker assertion at the end of the file and watching it run on the `MRB_INT32` build.

## Testing

`rake -m test`, all green:

| Build | Result |
| --- | --- |
| `ci/gcc-clang` (`full-debug`, `bintest`, `cxx_abi`, `byte-string`, `ascii-ctype`) | KO 0, Crash 0 |
| full-core, 64-bit `mrb_int` | Total 2614, KO 0, Crash 0 |
| full-core, `MRB_INT32` | Total 2614, KO 0, Crash 0 |
| full-core minus `mruby-bigint`, `MRB_INT32` | Total 2568, KO 0, Crash 0 |
| stdlib + stdlib-ext + metaprog + `mruby-rational` + `mruby-bigint`, `MRB_NO_FLOAT` | Total 1930, KO 0, Crash 0 |
| stdlib + stdlib-ext + metaprog + `mruby-rational`, `MRB_NO_FLOAT` + `MRB_INT32` | Total 1882, KO 0, Crash 0 |

Before this branch the fourth row reported `Crash: 3` and the sixth `KO: 1, Crash: 2`. Both commits were run against the fourth row on their own.

## Environment

<details>

```
Ubuntu 24.04.4 LTS, Linux 7.0.0-30-generic x86_64
Homebrew clang version 22.1.8 (Target: x86_64-unknown-linux-gnu)
ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux]
```

Compile line for the `MRB_INT32` build without `mruby-bigint`, as recorded in `src/numeric.o.flags`:

```
clang -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration \
  -Wwrite-strings -Wzero-length-array -ffile-prefix-map=... \
  -DMRB_INT32 -DMRB_REVISION_HEADER -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM \
  -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM \
  -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -I include -I build/int32-nobigint/include \
  -o src/numeric.o src/numeric.c
```

Build config for that row:

```ruby
MRuby::Build.new('int32-nobigint') do |conf|
  conf.toolchain
  conf.gembox 'full-core'
  conf.gems.delete 'mruby-bigint'
  conf.compilers.each do |c|
    c.defines += %w(MRB_INT32)
  end
  conf.enable_test
end
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved rational-number tests for environments without extended integer support.
  * Added safeguards so tests involving values beyond 32-bit or large exponent calculations skip or conditionally validate when unsupported.
  * Preserved coverage for truncation, comparison, equality, and exponentiation behavior where the platform supports it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->