### PR TITLE
numeric.rb: negate through a product so `-x` can reach a `-0.0`

### DIFF
--- a/mrblib/numeric.rb
+++ b/mrblib/numeric.rb
@@ -17,7 +17,7 @@ class Numeric
   #
   # ISO 15.2.7.4.2
   def -@
-    0 - self
+    -1 * self
   end
 
   ##

--- a/test/t/numeric.rb
+++ b/test/t/numeric.rb
@@ -24,6 +24,14 @@ end
 
 assert('Numeric#-@', '15.2.7.4.2') do
   assert_equal(-1, -1)
+
+  skip unless Object.const_defined?(:Float)
+  pzero = 0.0
+  nzero = -0.0
+  assert_float(-Float::INFINITY, 1.0 / -pzero)
+  assert_float(Float::INFINITY, 1.0 / -nzero)
+  assert_equal("-0.0", (-pzero).to_s)
+  assert_equal("0.0", (-nzero).to_s)
 end
 
 assert('Numeric#abs', '15.2.7.4.3') do


### PR DESCRIPTION
## Summary

`-x` could not answer a `-0.0`. `Numeric#-@` negated by subtracting from zero, and IEEE 754 gives `0.0 - 0.0` the sign `+` under round to nearest, so a `+0.0` came back unchanged. The one operand the operator could not negate was the one whose negation is the only way to reach a `-0.0` at run time.

```ruby
z = [0.0][0]
-z         # CRuby: -0.0,      mruby: 0.0
1.0 / -z   # CRuby: -Infinity, mruby: Infinity
(-z).to_s  # CRuby: "-0.0",    mruby: "0.0"

-0.0       # CRuby: -0.0,      mruby: -0.0  (a literal, negated by the parser)
```

## Changes

| File | What |
|---|---|
| `mrblib/numeric.rb` | `Numeric#-@` negates by `-1 * self` |
| `test/t/numeric.rb` | both zeros negated in both directions, read back by reciprocal and by `to_s` |

### Subtraction cannot make a zero negative

Every operand other than `+0.0` was already right. Subtracting a nonzero float from zero negates it exactly, and `0.0 - (-0.0)` is `+0.0`, which is what negating a `-0.0` should give. Only `0.0 - 0.0` is the case the standard hands back with the sign `+`, and that is the one case where the sign is the whole answer.

So the same expression answered differently depending on whether the operand was spelled or held. `-0.0` is `-0.0`, the parser having negated the literal; `-z` where `z` holds `0.0` was `0.0`, `Numeric#-@` having run. Nothing in the language says those two should differ.

The tree keeps the two zeros apart everywhere else it stores or prints one. Word boxing gives each its own word, `WORDBOX_FLOAT_PZERO` and `WORDBOX_FLOAT_NZERO`, so they are two objects and not one; `Float#to_s` prints the sign; `1.0 / -0.0` is `-Infinity`. `-@` was the only place that dropped it, and it dropped it silently: the result was a Float equal to what was wanted, so nothing downstream could tell that the sign had gone missing.

Multiplication carries the sign of a zero where subtraction does not, and `-1` is exact in both float widths, so negate by a product instead.

### Why the `-1` is on the left

Written with `-1` on the left, the product costs exactly what the difference cost. The codegen emits `OP_MUL` where it emitted `OP_SUB`, over the same three instructions and the same 12 bytes of irep holding no symbol:

```
# 0 - self                       # -1 * self
000 ENTER  0:0:0:0:0:0:0:0       000 ENTER  0:0:0:0:0:0:0:0
004 LOADI_0   R2  (0)            004 LOADI__1  R2  (-1)
006 LOADSELF  R3  (R0)           006 LOADSELF  R3  (R0)
008 SUB       R2  (R3)           008 MUL       R2  (R3)
010 RETURN    R2                 010 RETURN    R2
```

A bare `self` as the receiver does not compile to `OP_MUL` at all. The codegen takes it for a self-send and emits `OP_SSEND :*`, which leaves the VM's arithmetic path and pays a method dispatch on every negation.

Keeping the receiver an Integer also keeps the dispatch the method already had, so nothing else in the class tree moves. The two classes that define their own `-@` are `Rational`, which negates out of `rational_minus()` and never reaches here, and `Complex`, whose `-@` is `Complex(-real, -imaginary)`: it reaches this method once per part and picks up the fix with them.

## Behaviour

Measured against CRuby 4.0.6. `z`, `n`, `f`, `i` and `m` are locals holding `0.0`, `-0.0`, `1.5`, `3` and `MRB_INT_MIN`, so that the parser negates nothing. Bold marks the answers that were wrong.

| expression | master | this PR | CRuby |
| --- | --- | --- | --- |
| `-z` | **0.0** | -0.0 | -0.0 |
| `1.0 / -z` | **Infinity** | -Infinity | -Infinity |
| `(-z).to_s` | **"0.0"** | "-0.0" | "-0.0" |
| `-Complex(0.0, 0.0)` | **(0.0+0.0i)** | (-0.0+-0.0i) | (-0.0-0.0i) |
| `-n` | 0.0 | 0.0 | 0.0 |
| `1.0 / -n` | Infinity | Infinity | Infinity |
| `-0.0` | -0.0 | -0.0 | -0.0 |
| `-f` | -1.5 | -1.5 | -1.5 |
| `-i` | -3 | -3 | -3 |
| `-m` | 9223372036854775808 | 9223372036854775808 | 9223372036854775808 |
| `-Float::INFINITY` | -Infinity | -Infinity | -Infinity |
| `(-Float::NAN).to_s` | "NaN" | "NaN" | "NaN" |
| `-Complex(1.0, 2.0)` | (-1.0-2.0i) | (-1.0-2.0i) | (-1.0-2.0i) |
| `-Rational(1, 2)` | (-1/2) | (-1/2) | (-1/2) |

The rows below the first four are the ones that already agreed and had to keep agreeing: the other zero, the literal the parser negates, an ordinary Float and Integer, `MRB_INT_MIN` overflowing into a Bigint, an infinity and a NaN, a Complex whose parts are not zeros, and `Rational`, which negates out of `rational_minus()`.

The Complex row follows from `Complex#-@` negating each part through this method: it now holds the two zeros CRuby's holds, `1.0 / c.real` and `1.0 / c.imaginary` both being `-Infinity` in this column and both `Infinity` on master. What remains is `Complex#to_s`, which writes a `-0.0` imaginary part as `+-0.0i` because it tests `imag < 0`. That is reachable without `-@` at all, `Complex(1.0, -0.0).to_s` being `"1.0+-0.0i"` on master too, and is left alone here.

## Speed

Callgrind `Ir` at 1,000,000 negations, with the same measurement run against a loop of the same length assigning the operand unnegated and subtracted. Default build config, `clang -O3`.

| | master `Ir` | this PR `Ir` | per call |
|---|---:|---:|---|
| `-f`, `f` a Float | 531,002,510 | 529,002,510 | 531.0 -> 529.0 |
| `-i`, `i` an Integer | 502,002,522 | 502,002,522 | 502.0 -> 502.0 |

The Integer row is bit-identical, as are both empty loops the columns are measured against. The Float row is 2 `Ir` a call cheaper, which is the two opcodes' inline float paths and not anything the method does differently.

Written `self * -1` the same two rows are 753,002,608 and 700,002,741, which is the `OP_SSEND` above.

## Size

`bin/mruby` `.text`, `size -A`, for the five builds of `build_config/ci/gcc-clang.rb`, each made from an empty build directory at the same path.

| Build | master | this PR | delta |
| --- | ---: | ---: | ---: |
| `ascii-ctype` | 1,071,686 | 1,071,686 | 0 |
| `bintest` | 1,076,822 | 1,076,822 | 0 |
| `byte-string` | 1,051,670 | 1,051,670 | 0 |
| `cxx_abi` | 1,064,917 | 1,064,917 | 0 |
| `full-debug` (-O0) | 1,865,526 | 1,865,526 | 0 |

`mrblib.c` comes out the same 90,042 bytes in both columns and `mrblib.o` matches section for section, the two opcodes being the same width.

## Testing

`rake test` on the five builds of `build_config/ci/gcc-clang.rb`, no failures and no crashes:

| Build | assertions |
| --- | ---: |
| `full-debug` | 2,614 |
| `bintest` | 2,614, plus 145 bintests |
| `cxx_abi` | 2,614 |
| `byte-string` | 2,533 |
| `ascii-ctype` | 2,605 |

Six further builds of the default config, one per axis this method can be compiled along, all green: `MRB_USE_FLOAT32`, `MRB_INT32`, `MRB_NAN_BOXING`, `MRB_NO_BOXING`, `MRB_NO_FLOAT`, and a gembox without `mruby-bigint`. The repro above answers as CRuby does in every build that has a Float, and without `mruby-bigint` `-MRB_INT_MIN` raises the same `RangeError`, `integer overflow`, that it raised before.

## Environment

<details>

- mruby `a1fa9e7f1`, CRuby 4.0.6 (`03b6d3f889`), Linux 7.0.0 x86_64
- Homebrew clang 22.1.8, valgrind 3.27.1
- default config core compile line, paths elided:

  ```
  clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration
        -Wwrite-strings -Wzero-length-array -DMRB_REVISION_HEADER
        -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM
        -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT
        -DMRB_USE_DEBUG_HOOK -MMD -c
  ```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved unary negation for numeric values, including correct handling of positive and negative zero.

* **Tests**
  * Added coverage to verify signed-zero behavior through division results and string representations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->