### PR TITLE
mruby-regexp: refuse the nest level a `\k` reference may carry

### DIFF
--- a/mrbgems/mruby-regexp/README.md
+++ b/mrbgems/mruby-regexp/README.md
@@ -226,6 +226,14 @@ pattern analysis.
   call all raise `RegexpError` rather than standing for their own letter.
   Inside a character class CRuby reads each as the letter, and so does this;
   a bare `\g` is the letter either way.
+- **No nest level on a backreference**: `\k<name+n>` and `\k<name-n>` read the
+  group as the enclosing recursion left it `n` levels up, which goes with the
+  subexpression call above, so they raise `RegexpError` too. The level starts
+  at the first `+` or `-` past the name's first byte, in CRuby as here, which
+  leaves a group whose name holds one out of every reference's reach:
+  `(?<a-1>x)` names a group in both, and `\k<a-1>` reaches it in neither. The
+  first byte is the relative form's sign, so `\k<-1>` is still the group one
+  back.
 - **No character class intersection**: `[a&&b]` narrows a class to what both
   sides hold in CRuby, and raises `RegexpError` here. A lone `&` is a member
   of the class, as it is in CRuby, and so is an escaped one: `[\&&]` holds

--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -1886,8 +1886,39 @@ compile_atom(re_compiler *c)
       }
       if (peek(c) != close) compile_error(c, "unterminated backreference name");
       if (c->p == name) compile_error(c, "group name is empty");
-      if (!RE_NAME_LEN_FITS(c->p - name)) compile_error(c, "group name too long");
       uint32_t name_len = (uint32_t)(c->p - name);
+
+      /* A `+` or `-` past the first byte ends a \k name and opens a nest
+         level: `\k<name+n>` reads the group as the enclosing recursion left
+         it n levels up, which is a feature of the subexpression calls this
+         engine refuses (see `\g` below), so the reference is refused with it.
+         The first byte is exempt because that is where the relative form's
+         sign stands: `\k<-1>` is the group one back, and `\k<-1-1>` is that
+         group at a level. Reading the sign as part of the name instead let a
+         reference reach a group CRuby's own numbering puts out of reach, since
+         a definition takes the sign into the name where a reference never
+         does: `(?<a-1>x)\k<a-1>` matched here and is `undefined name <a>`
+         there. Only digits stand behind the sign, so a level CRuby itself
+         refuses is a malformed name here as it is there, `\k<a+>` and
+         `\k<a+1x>` reaching the message the rest of this arm gives one. The
+         name is quoted as it was read; CRuby quotes it to the end of the
+         pattern instead, the way it does for every name its own scan ended.
+         The whole check comes before the length one below because the sign is
+         where the name ends, so a name long enough to fail that one is a
+         level first. */
+      uint32_t sign = 1;
+      while (sign < name_len && name[sign] != '+' && name[sign] != '-') sign++;
+      if (sign < name_len) {
+        mrb_bool numeric = (sign + 1 < name_len);
+        for (uint32_t i = sign + 1; numeric && i < name_len; i++) {
+          if (name[i] < '0' || name[i] > '9') numeric = FALSE;
+        }
+        if (numeric) compile_error(c, "backreference with nest level is not supported");
+        compile_error_str(c, mrb_format(c->mrb, "invalid group name <%l>",
+                                        name, (size_t)name_len));
+      }
+
+      if (!RE_NAME_LEN_FITS(name_len)) compile_error(c, "group name too long");
       next_char(c);  /* skip the closing > or ' */
 
       int group = -1;

--- a/mrbgems/mruby-regexp/test/regexp_syntax.rb
+++ b/mrbgems/mruby-regexp/test/regexp_syntax.rb
@@ -2109,6 +2109,77 @@ assert("Regexp - a \\k reference reads leading zeros as digits") do
   assert_equal "aa", "aa".match(Regexp.new("(a)\\k<-01>"))[0]
 end
 
+assert("Regexp - a nest level on a \\k reference is refused") do
+  need_backtracking_stack
+  # `\k<name+n>` reads the group as the enclosing recursion left it n levels
+  # up, which goes with the `\g` subexpression call this engine refuses. Taking
+  # the sign into the name made each a name no group carried, so
+  # /(?<a>c)\k<a+0>/ raised `undefined name <a+0> reference` where CRuby
+  # matched "cc".
+  msg = "backreference with nest level is not supported"
+  assert_raise_with_message(RegexpError, "#{msg}: /(?<a>c)\\k<a+0>/") do
+    Regexp.new("(?<a>c)\\k<a+0>")
+  end
+  ["(?<a>c)\\k<a-1>", "(?<a>c)\\k'a+0'", "(c)\\k<1+0>", "(c)\\k<1-1>",
+   "(?<a>c)\\k<a+007>"].each do |src|
+    assert_raise(RegexpError, src) { Regexp.new(src) }
+  end
+
+  # The first byte is exempt: that is where the relative form's sign stands,
+  # and the level of a relative reference comes after its digits
+  assert_equal "aa", "aa".match(Regexp.new("(a)\\k<-1>"))[0]
+  assert_raise_with_message(RegexpError, "#{msg}: /(a)\\k<-1-1>/") do
+    Regexp.new("(a)\\k<-1-1>")
+  end
+
+  # A definition takes the sign into the name where a reference never does, so
+  # a group whose name holds one is out of every reference's reach, here as in
+  # CRuby. Reading it as a name let /(?<a-1>c)\k<a-1>/ match where CRuby
+  # raised.
+  assert_equal "a-1", Regexp.new("(?<a-1>c)").names[0]
+  assert_raise_with_message(RegexpError, "#{msg}: /(?<a-1>c)\\k<a-1>/") do
+    Regexp.new("(?<a-1>c)\\k<a-1>")
+  end
+
+  # Only digits stand behind the sign, so a level CRuby itself refuses is a
+  # malformed name here as it is there. The name is quoted as it was read,
+  # where CRuby quotes it to the end of the pattern.
+  bad = "invalid group name"
+  assert_raise_with_message(RegexpError,
+                            "#{bad} <a-b>: /(?<a-b>c)\\k<a-b>/") do
+    Regexp.new("(?<a-b>c)\\k<a-b>")
+  end
+  assert_raise_with_message(RegexpError,
+                            "#{bad} <a+>: /(?<a>c)\\k<a+>x/") do
+    Regexp.new("(?<a>c)\\k<a+>x")
+  end
+  assert_raise_with_message(RegexpError,
+                            "#{bad} <a+0+0>: /(?<a>c)\\k<a+0+0>/") do
+    Regexp.new("(?<a>c)\\k<a+0+0>")
+  end
+  # quoted in <> whichever delimiter wrote it, as the rest of this arm is
+  assert_raise_with_message(RegexpError,
+                            "#{bad} <a+>: /(?<a>c)\\k'a+'/") do
+    Regexp.new("(?<a>c)\\k'a+'")
+  end
+
+  # A `)` still ends the name first, whichever side of the sign it falls
+  assert_raise_with_message(RegexpError,
+                            "invalid group name <a)b+0>>: /(?<a>c)\\k<a)b+0>/") do
+    Regexp.new("(?<a>c)\\k<a)b+0>")
+  end
+  assert_raise_with_message(RegexpError,
+                            "invalid group name <a+0)>>: /(?<a>c)\\k<a+0)>/") do
+    Regexp.new("(?<a>c)\\k<a+0)>")
+  end
+
+  # An unterminated name is still that, and not a level with nothing behind it
+  assert_raise_with_message(RegexpError,
+                            "unterminated backreference name: /(?<a>c)\\k<a+/") do
+    Regexp.new("(?<a>c)\\k<a+")
+  end
+end
+
 assert("Regexp - a group name may not be a number") do
   # A definition names a group, it never numbers one: the number spelling
   # belongs to a reference, and CRuby refuses a leading digit or `-` where a


### PR DESCRIPTION
## Summary

`\k<name+n>` and `\k<name-n>` read a group as the enclosing recursion left it `n` levels up. This engine has no recursion to read, `\g<name>` already raising `RegexpError`, but the reference arm took the `+` or `-` into the name instead of refusing the construct. Most spellings then failed as a name no group carried, and a few reached a group CRuby's own numbering puts out of every reference's reach and matched there.

## Changes

| File | What |
|---|---|
| `mrbgems/mruby-regexp/src/re_compile.c` | the `\k` arm ends the name at the first `+` or `-` past its first byte and reads what stands behind it: a level is refused by name, anything else is the malformed name it is |
| `mrbgems/mruby-regexp/README.md` | a limitation beside the `\g<name>` one |
| `mrbgems/mruby-regexp/test/regexp_syntax.rb` | a block next to the `\k` reference tests |

### The sign ends the name

`fetch_name_with_level()` stops a `\k` name at a `+` or `-` and reads the rest as a level, so in CRuby the sign is never a name character in a reference. It is one in a definition, which reads the name whole: `(?<a-1>x)` names a group `a-1` there, and no `\k` can reach it, `\k<a-1>` being group `a` at level -1.

The reference arm here read the name whole too, so the two sides agreed with each other and not with CRuby. Where the pattern opened no group by that name the reference failed as a missing one, which is a message about the wrong thing; where it did, the pattern compiled and matched where CRuby raises.

```ruby
Regexp.new("(?<a>c)\\k<a+0>")    # CRuby: compiles, matches "cc"
                                 # master: undefined name <a+0> reference
Regexp.new("(c)\\k<1-1>")        # CRuby: compiles
                                 # master: invalid group name <1-1>
Regexp.new("(?<a-1>c)\\k<a-1>")  # CRuby: undefined name <a> reference
                                 # master: compiles, matches "cc"
```

The first byte stays exempt, because that is where the relative form's sign stands. `\k<-1>` is the group one back and keeps working; `\k<-1-1>` is that group at a level and is refused. `\k<+1>` is a name and fails as one, as it does in CRuby, since only `-` leads a number.

### What stands behind the sign

Digits and nothing else is a level, and raises `backreference with nest level is not supported`, the spelling `\g<name>` already uses one arm below. Anything else is a malformed name in CRuby too, and reaches the `invalid group name` the rest of this arm gives one; the name is quoted as it was read, where CRuby quotes it to the end of the pattern.

The refusal comes before the name length check, since the sign is where the name ends and a name long enough to fail that check is a level first. It also comes before the group is resolved, so a pattern that would fail some later check reports the construct rather than that check: `(?<n>a)\k<1+0>` is the level here and `numbered backref/call is not allowed. (use name)` in CRuby.

## Behaviour

Every row run against CRuby 4.0.6 and both sides of this change, subject `"cc"`.

| source | master | this PR | CRuby 4.0.6 |
| --- | --- | --- | --- |
| `(?<a>c)\k<a+0>` | `RegexpError: undefined name <a+0> reference` | `RegexpError: backreference with nest level is not supported` | `["cc", "c"]` |
| `(?<a>c)\k'a+0'` | `RegexpError: undefined name <a+0> reference` | `RegexpError: backreference with nest level is not supported` | `["cc", "c"]` |
| `(?<a>c)\k<a-1>` | `RegexpError: undefined name <a-1> reference` | `RegexpError: backreference with nest level is not supported` | `nil` |
| `(c)\k<1+0>` | `RegexpError: invalid group name <1+0>` | `RegexpError: backreference with nest level is not supported` | `["cc", "c"]` |
| `(c)\k<1-1>` | `RegexpError: invalid group name <1-1>` | `RegexpError: backreference with nest level is not supported` | `nil` |
| `(c)\k<-1-1>` | `RegexpError: invalid group name <-1-1>` | `RegexpError: backreference with nest level is not supported` | `nil` |
| `(?<a-1>c)\k<a-1>` | `["cc", "c"]` | `RegexpError: backreference with nest level is not supported` | `RegexpError: undefined name <a> reference` |
| `(?<a+1>c)\k<a+1>` | `["cc", "c"]` | `RegexpError: backreference with nest level is not supported` | `RegexpError: undefined name <a> reference` |
| `(?<a-b>c)\k<a-b>` | `["cc", "c"]` | `RegexpError: invalid group name <a-b>` | `RegexpError: invalid group name <a-b>>` |
| `(?<a>c)\k<a+>` | `RegexpError: undefined name <a+> reference` | `RegexpError: invalid group name <a+>` | `RegexpError: invalid group name <a+>>` |
| `(?<a>c)\k<a+1x>` | `RegexpError: undefined name <a+1x> reference` | `RegexpError: invalid group name <a+1x>` | `RegexpError: invalid group name <a+1x>>` |
| `(?<a>c)\k<a++1>` | `RegexpError: undefined name <a++1> reference` | `RegexpError: invalid group name <a++1>` | `RegexpError: invalid group name <a++1>>` |
| `(?<a>c)\k<a)b+0>` | `RegexpError: invalid group name <a)b+0>>` | unchanged | `RegexpError: invalid group name <a)b+0>>` |
| `(?<a>c)\k<a+0)>` | `RegexpError: invalid group name <a+0)>>` | unchanged | `RegexpError: invalid group name <a+0)>>` |
| `(?<a>c)\k<a+` | `RegexpError: unterminated backreference name` | unchanged | `RegexpError: invalid char in group name <a>` |
| `(c)\k<-1>` | `["cc", "c"]` | unchanged | `["cc", "c"]` |
| `(c)\k<01>` | `["cc", "c"]` | unchanged | `["cc", "c"]` |
| `(?<a>c)\k<a>` | `["cc", "c"]` | unchanged | `["cc", "c"]` |
| `(a)\k<+1>` | `RegexpError: undefined name <+1> reference` | unchanged | `RegexpError: undefined name <+1> reference` |
| `(a)\k<->` | `RegexpError: invalid group name <->` | unchanged | `RegexpError: invalid group name <->` |

The two `)` rows are the name scan's own rule, which ends a name at a `)` from the second byte on: it reaches the sign check on neither side, and its quoting is the one spelling here that matches CRuby's. `\k<a+` keeps the message an unterminated name has always had.

## Size

`.text` of `bin/mruby` for the five builds of `build_config/ci/gcc-clang.rb`, measured with `size -A` in a clean build directory at the same path.

| Build | master | This PR | Delta |
|---|---|---|---|
| `bintest` | 1,076,822 | 1,076,198 | -624 |
| `ascii-ctype` | 1,071,686 | 1,071,270 | -416 |
| `byte-string` | 1,051,670 | 1,051,814 | +144 |
| `cxx_abi` | 1,064,917 | 1,064,277 | -640 |
| `full-debug` (-O0) | 1,865,526 | 1,865,910 | +384 |

Every delta is `re_compile.o`, to the byte, and the check itself is two loops and a call. The `-O3` rows move both ways because it lands inside `compile_atom()`, which is large enough that clang's inlining decisions move with it; `full-debug` is `-O0` and shows what the code costs on its own, +384.

## Testing

`rake -m test` over `build_config/ci/gcc-clang.rb`, all five builds green:

```console
$ MRUBY_CONFIG=build_config/ci/gcc-clang.rb rake -m test
>>> Test bintest <<<     Total: 2615  OK: 2600  KO: 0  Crash: 0  Skip: 15
>>> Test ascii-ctype <<< Total: 2606  OK: 2590  KO: 0  Crash: 0  Skip: 16
>>> Test byte-string <<< Total: 2534  OK: 2478  KO: 0  Crash: 0  Skip: 56
>>> Test cxx_abi <<<     Total: 2615  OK: 2600  KO: 0  Crash: 0  Skip: 15
>>> Test full-debug <<<  Total: 2615  OK: 2608  KO: 0  Crash: 0  Skip: 7
```

Beside the block added next to the `\k` tests, the change was checked against CRuby over a corpus of 980 reference cases: ten group prefixes, drawn over plain, non-capturing and named groups and including the four definitions whose own name holds a sign, paired with 49 name spellings in both the `<>` and the `''` delimiter, each run over four subjects.

master answers 8 of them where CRuby raises, which is those four definitions and the two spellings of the reference to each. This PR raises on all 8, and there is no case master agreed with CRuby on that it now parts on.

64 cases are the level references themselves, which CRuby compiles and this engine refuses before and after. What moves is the reason: master reported 40 of them as a name no group carried and 24 as a malformed name, and all 64 now name the construct.

## Environment

<details>

| | |
|---|---|
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-30-generic |
| CPU | AMD Ryzen 9 5950X, 32 threads |
| C compiler | Homebrew clang 22.1.8 (`CC`, `LD`) |
| binutils | GNU Binutils 2.47.20260726 (`size`, `ld`) |
| CRuby | 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM, x86_64-linux |
| rake | 13.3.1 |

The compile line each build actually ran, from `touch src/string.c && rake --verbose`, with `-MMD -c`, the include paths and the output path dropped. `cxx_abi` compiles with `clang -x c++ -std=gnu++03` rather than a C++ driver; `full-debug` is `-O0` because `enable_debug` appends `-g3 -O0` after the toolchain's `-g -O3`.

```console
# bintest
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -ffile-prefix-map="$PWD=." -ffile-prefix-map="$MRUBY_BUILD_DIR=./build" -DMRB_GC_FIXED_ARENA -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK src/string.c

# ascii-ctype
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -ffile-prefix-map="$PWD=." -ffile-prefix-map="$MRUBY_BUILD_DIR=./build" -DMRB_USE_ASCII_CTYPE -DMRB_REGEXP_PARSE_DEPTH_LIMIT=512 -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c

# byte-string
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -ffile-prefix-map="$PWD=." -ffile-prefix-map="$MRUBY_BUILD_DIR=./build" -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c

# cxx_abi
clang -g -O3 -Wall -Wundef -Wwrite-strings -Wzero-length-array -x c++ -std=gnu++03 -ffile-prefix-map="$PWD=." -ffile-prefix-map="$MRUBY_BUILD_DIR=./build" -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c

# full-debug
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -g3 -O0 -ffile-prefix-map="$PWD=." -ffile-prefix-map="$MRUBY_BUILD_DIR=./build" -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of named regular-expression backreferences with `+` or `-` suffixes.
  * Unsupported nest-level references now raise a clear error.
  * Malformed backreference names produce more accurate validation errors.
  * Preserved support for relative backreferences and valid group names containing signs.

* **Documentation**
  * Documented the limitations and parsing behavior of nest-level backreferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->