### PR TITLE
mruby-regexp: align RegexpError message wording with CRuby

### DIFF
--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -1659,8 +1659,15 @@ compile_atom(re_compiler *c)
             }
             next_char(c);
           }
-          if (peek(c) != close) compile_error(c, "unterminated named capture");
+          /* A name the pattern ends before the delimiter of is the same
+             `invalid group name` as one a ')' ended, quoted the same way,
+             and an empty one is empty whether or not it was ever closed:
+             (?'  and (?<>x) answer alike, as they do in CRuby. */
           if (c->p == cap_name) compile_error(c, "group name is empty");
+          if (peek(c) != close) {
+            compile_error_str(c, mrb_format(c->mrb, "invalid group name <%l>",
+                                            cap_name, (size_t)(c->p - cap_name)));
+          }
           /* A definition names a group, it never numbers one: CRuby reads a
              leading digit or '-' as the number spelling, which only a
              reference may use, and refuses it here. Everything after the first
@@ -1898,8 +1905,13 @@ compile_atom(re_compiler *c)
         }
         next_char(c);
       }
-      if (peek(c) != close) compile_error(c, "unterminated backreference name");
+      /* The end of the pattern ends the name the way a ')' does; see the
+         definition side for the pair. */
       if (c->p == name) compile_error(c, "group name is empty");
+      if (peek(c) != close) {
+        compile_error_str(c, mrb_format(c->mrb, "invalid group name <%l>",
+                                        name, (size_t)(c->p - name)));
+      }
       if (!RE_NAME_LEN_FITS(c->p - name)) compile_error(c, "group name too long");
       uint32_t name_len = (uint32_t)(c->p - name);
       next_char(c);  /* skip the closing > or ' */

--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -1226,7 +1226,7 @@ parse_quantifier(re_compiler *c, int *min_out, int *max_out, mrb_bool *ranged)
   while (peek(c) >= '0' && peek(c) <= '9') {
     min = min * 10 + (next_char(c) - '0');
     has_digit = TRUE;
-    if (min > RE_MAX_REPEAT) compile_error(c, "quantifier too large");
+    if (min > RE_MAX_REPEAT) compile_error(c, "too big number for repeat range");
   }
   if (peek(c) == ',') {
     next_char(c);
@@ -1236,7 +1236,7 @@ parse_quantifier(re_compiler *c, int *min_out, int *max_out, mrb_bool *ranged)
       while (peek(c) >= '0' && peek(c) <= '9') {
         max = max * 10 + (next_char(c) - '0');
         has_digit = TRUE;
-        if (max > RE_MAX_REPEAT) compile_error(c, "quantifier too large");
+        if (max > RE_MAX_REPEAT) compile_error(c, "too big number for repeat range");
       }
     }
     /* else max = -1 (unlimited) */

--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -626,7 +626,7 @@ static int
 parse_escape(re_compiler *c)
 {
   int ch = next_char(c);
-  if (ch < 0) compile_error(c, "trailing backslash");
+  if (ch < 0) compile_error(c, "too short escape sequence");
   switch (ch) {
   case 'c':
     return parse_control_escape(c);

--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -1715,7 +1715,7 @@ compile_atom(re_compiler *c)
           }
           else {
             if (peek(c) < 0) compile_error(c, "end pattern in group");
-            compile_error(c, "undefined (?...) sequence");
+            compile_error(c, "undefined group option");
           }
         }
         else if (c->p[1] == '#') {
@@ -1740,7 +1740,7 @@ compile_atom(re_compiler *c)
                leaves open. */
             compile_error(c, "end pattern with unmatched parenthesis");
           }
-          compile_error(c, "undefined (?...) sequence");
+          compile_error(c, "undefined group option");
         }
       }
 

--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -1596,7 +1596,7 @@ compile_atom(re_compiler *c)
           int fixed_chars;
           int fixed_len = compute_fixed_len(c, sub_start, c->code_len, &fixed_chars);
           if (fixed_len < 0) {
-            compile_error(c, "lookbehind must be fixed length");
+            compile_error(c, "invalid pattern in look-behind");
           }
           if (fixed_len > 255) {
             compile_error(c, "lookbehind too long (max 255 bytes)");

--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -940,7 +940,7 @@ compile_charclass(re_compiler *c)
 
   mrb_bool first = TRUE;
   while (peek(c) != ']' || first) {
-    if (peek(c) < 0) compile_error(c, "unterminated character class");
+    if (peek(c) < 0) compile_error(c, "premature end of char-class");
     first = FALSE;
 
     /* `&&` takes the intersection of what is written either side of it, which
@@ -976,7 +976,6 @@ compile_charclass(re_compiler *c)
       if (peek(c) == '^') { neg = TRUE; next_char(c); }
       const char *name = c->p;
       while (peek(c) >= 0 && peek(c) != ':' && peek(c) != ']') next_char(c);
-      mrb_bool stopped_at_bracket_end = (peek(c) == ']');
       if (peek(c) == ':' && c->p + 1 < c->src_end && c->p[1] == ']') {
         uint8_t bits[16] = {0};
         mrb_bool by_ascii;
@@ -1010,15 +1009,11 @@ compile_charclass(re_compiler *c)
       }
       /* The '[' opened a bracket, so a name that does not close is the
          bracket ending early rather than a literal '[', as it is to CRuby.
-         Which of the two things went wrong depends on where the scan
-         stopped: at a ']' the class does close and only the bracket ended
-         early, and anywhere else (a ':' with nothing after it, or the end of
-         the pattern) the class never closes either, which is the older and
-         more particular complaint of the two. */
+         Where the scan stopped makes no difference to what is said: the
+         complaint is the class's own either way, as it is in CRuby, where
+         /[[:al]/ and /[[:al/ raise the one message between them. */
       c->p = save;
-      compile_error(c, stopped_at_bracket_end
-                    ? "premature end of char-class"
-                    : "unterminated character class");
+      compile_error(c, "premature end of char-class");
     }
 
     /* Shorthand classes (\d, \D, \w, \W, \s, \S, \h, \H) are handled

--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -1567,7 +1567,7 @@ compile_atom(re_compiler *c)
           uint32_t la_pos = emit(c, negative ? RE_NEG_LOOKAHEAD : RE_LOOKAHEAD, 0, 0);
           compile_look_body(c, negative);
           c->pat->code[la_pos].offset = (uint16_t)c->code_len;  /* patch: skip past sub-pattern */
-          if (peek(c) != ')') compile_error(c, "unmatched '('");
+          if (peek(c) != ')') compile_error(c, "end pattern with unmatched parenthesis");
           next_char(c);
           c->needs_backtrack = TRUE;  /* needs backtracking engine */
           c->flags = saved_flags;
@@ -1596,7 +1596,7 @@ compile_atom(re_compiler *c)
           /* the character count never exceeds the byte count, so it fits */
           c->pat->code[lb_pos + 1].a = (uint8_t)fixed_chars;
 
-          if (peek(c) != ')') compile_error(c, "unmatched '('");
+          if (peek(c) != ')') compile_error(c, "end pattern with unmatched parenthesis");
           next_char(c);
           c->needs_backtrack = TRUE;  /* needs backtracking engine */
           c->flags = saved_flags;
@@ -1620,7 +1620,7 @@ compile_atom(re_compiler *c)
           emit(c, RE_ATOMIC, 0, cut);
           compile_alt(c);
           emit(c, RE_ATOMIC_END, 0, cut);
-          if (peek(c) != ')') compile_error(c, "unmatched '('");
+          if (peek(c) != ')') compile_error(c, "end pattern with unmatched parenthesis");
           next_char(c);
           c->needs_backtrack = TRUE;  /* the Pike VM cannot cut a thread */
           c->flags = saved_flags;
@@ -1700,7 +1700,7 @@ compile_atom(re_compiler *c)
             c->flags = new_flags;
             compile_alt(c);
             c->flags = saved_flags;
-            if (peek(c) != ')') compile_error(c, "unmatched '('");
+            if (peek(c) != ')') compile_error(c, "end pattern with unmatched parenthesis");
             next_char(c);
             return TRUE;
           }
@@ -1755,7 +1755,7 @@ compile_atom(re_compiler *c)
 
       compile_alt(c);
 
-      if (peek(c) != ')') compile_error(c, "unmatched '('");
+      if (peek(c) != ')') compile_error(c, "end pattern with unmatched parenthesis");
       next_char(c);
 
       if (capturing) {

--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -1764,7 +1764,7 @@ compile_atom(re_compiler *c)
       uint16_t group = 0;
       if (capturing) {
         if (c->num_captures >= RE_MAX_CAPTURES) {
-          compile_error(c, "too many capture groups");
+          compile_error(c, "too many capture groups are specified");
         }
         group = c->num_captures++;
         emit(c, RE_SAVE, 0, group * 2);

--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -1555,6 +1555,15 @@ compile_atom(re_compiler *c)
       const char *cap_name = NULL;
       uint32_t cap_name_len = 0;
 
+      /* `(?` and nothing more: the prefix that names which group this is
+         runs off the end of the pattern. It is reported here because what
+         the parser would otherwise be left with is a `?` standing where no
+         atom is, which compile_seq() reads as a quantifier with nothing to
+         repeat. */
+      if (peek(c) == '?' && c->p + 1 >= c->src_end) {
+        compile_error(c, "end pattern in group");
+      }
+
       if (peek(c) == '?' && c->p + 1 < c->src_end) {
         if (c->p[1] == ':') {
           next_char(c); next_char(c);  /* skip ?: */
@@ -1705,13 +1714,15 @@ compile_atom(re_compiler *c)
             return TRUE;
           }
           else {
+            if (peek(c) < 0) compile_error(c, "end pattern in group");
             compile_error(c, "undefined (?...) sequence");
           }
         }
         else if (c->p[1] == '#') {
           /* preprocess_pattern() removes a terminated comment group before
-             the parser runs, so one reaching here was never closed. */
-          compile_error(c, "unterminated comment group");
+             the parser runs, so one reaching here was never closed, which
+             is the pattern ending inside the prefix like any other. */
+          compile_error(c, "end pattern in group");
         }
         else {
           /* (?X) with an unsupported X: not one of the recognized (?: (?= (?!
@@ -1721,6 +1732,14 @@ compile_atom(re_compiler *c)
              conditionals (?(...)) are not implemented. Raise here rather
              than falling through to the capturing-group path, which would
              leave the stray `?` for compile_seq to spin on forever (A1). */
+          if (c->p[1] == '<') {
+            /* `(?<` and nothing more, the only way a '<' reaches here: the
+               pattern ends before the character that tells a lookbehind
+               from a named group. CRuby answers for the group that never
+               closes rather than for the prefix, which either reading
+               leaves open. */
+            compile_error(c, "end pattern with unmatched parenthesis");
+          }
           compile_error(c, "undefined (?...) sequence");
         }
       }

--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -2928,7 +2928,7 @@ mrb_re_compile(mrb_state *mrb, mrb_regexp_pattern *pat,
   compile_alt(&c);
 
   if (c.p < c.src_end) {
-    compile_error(&c, "unmatched ')'");
+    compile_error(&c, "unmatched close parenthesis");
   }
 
   /* A backreference names a group the pattern does not have. The count is

--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -981,7 +981,7 @@ compile_charclass(re_compiler *c)
         mrb_bool by_ascii;
         uint16_t ctype;
         if (!posix_class_bits(bits, name, (size_t)(c->p - name), &by_ascii, &ctype)) {
-          compile_error(c, "invalid POSIX bracket class");
+          compile_error(c, "invalid POSIX bracket type");
         }
         next_char(c);  /* ':' */
         next_char(c);  /* ']' */

--- a/mrbgems/mruby-regexp/test/regexp_syntax.rb
+++ b/mrbgems/mruby-regexp/test/regexp_syntax.rb
@@ -52,8 +52,15 @@ assert("Regexp - POSIX bracket classes") do
   # negated forms
   assert_equal "abc", "abc123".match(/[[:^digit:]]+/)[0]
   assert_equal "x", " x".match(/[^[:space:]]/)[0]
-  # an unknown class name is an error
-  assert_raise(RegexpError) { Regexp.new("[[:bogus:]]") }
+  # an unknown class name is an error, named as CRuby names it
+  assert_raise_with_message(RegexpError,
+                            "invalid POSIX bracket type: /[[:bogus:]]/") do
+    Regexp.new("[[:bogus:]]")
+  end
+  assert_raise_with_message(RegexpError,
+                            "invalid POSIX bracket type: /[[:^bogus:]]/") do
+    Regexp.new("[[:^bogus:]]")
+  end
   # The name length used to be truncated with a (uint16_t) cast, so a name
   # 65536 bytes longer than "alpha" compared equal to "alpha" and compiled
   # as [[:alpha:]] instead of raising.

--- a/mrbgems/mruby-regexp/test/regexp_syntax.rb
+++ b/mrbgems/mruby-regexp/test/regexp_syntax.rb
@@ -1677,6 +1677,19 @@ assert("Regexp - an atomic group the parser refuses") do
   assert_raise(RegexpError) { Regexp.new("(?<=(?>a))b") }
 end
 
+assert("Regexp - a lookbehind body of no fixed width says which it was") do
+  # This engine rewinds a lookbehind by a width it measures at compile
+  # time, so a body that has none is refused. CRuby refuses the same
+  # bodies, and what it says of them is `invalid pattern in look-behind`.
+  ["(?<=a+)b", "(?<=a*)b", "(?<=a?)b", "(?<=a{1,2})b", "(?<!a+)b",
+   "(?<=(?>a))b"].each do |src|
+    assert_raise_with_message(RegexpError,
+                              "invalid pattern in look-behind: /#{src}/", src) do
+      Regexp.new(src)
+    end
+  end
+end
+
 assert("Regexp - a named group makes plain groups non-capturing") do
   # Onigmo's ONIG_OPTION_DONT_CAPTURE_GROUP, which CRuby turns on once the
   # pattern declares a named group: (...) then groups without capturing.

--- a/mrbgems/mruby-regexp/test/regexp_syntax.rb
+++ b/mrbgems/mruby-regexp/test/regexp_syntax.rb
@@ -4,6 +4,18 @@ assert("Regexp - character class") do
   assert_equal "abc", md[0]
 end
 
+assert("Regexp - a class the pattern ends inside says which it was") do
+  # A class no ']' closes is `premature end of char-class` in CRuby, whatever
+  # stands unfinished inside it: a member, a range, or a POSIX bracket that
+  # ends early enough to leave the class open as well.
+  ["[", "[a", "[a-", "[^a", "[[:alpha", "[[:alpha:", "[[:alpha:]",
+   "[a[:alpha:]", "[[:word:]x"].each do |src|
+    assert_raise_with_message(RegexpError, "premature end of char-class: /#{src}/", src) do
+      Regexp.new(src)
+    end
+  end
+end
+
 assert("Regexp - reversed character class range") do
   # A range written backwards holds nothing. It used to compile to a class
   # that silently lacked the span, or in the negated form admitted every
@@ -1174,10 +1186,10 @@ assert("Regexp extended mode (x flag)") do
 
   # a bracket the pattern truncates leaves the scan with nothing after the
   # name, and the class is still the parser's error to report
-  assert_raise_with_message(RegexpError, "unterminated character class: /[[:alpha/x") do
+  assert_raise_with_message(RegexpError, "premature end of char-class: /[[:alpha/x") do
     Regexp.new("[[:alpha", Regexp::EXTENDED)
   end
-  assert_raise_with_message(RegexpError, "unterminated character class: /[[:alpha:/x") do
+  assert_raise_with_message(RegexpError, "premature end of char-class: /[[:alpha:/x") do
     Regexp.new("[[:alpha:", Regexp::EXTENDED)
   end
 
@@ -1224,7 +1236,7 @@ assert("Regexp extended mode (x flag)") do
   assert_equal "(?x-mi:abc)", Regexp.new("abc", Regexp::EXTENDED).to_s
 
   # errors quote the pattern as written, not the text with the comment removed
-  assert_raise_with_message(RegexpError, "unterminated character class: /a # c\n[/x") do
+  assert_raise_with_message(RegexpError, "premature end of char-class: /a # c\n[/x") do
     Regexp.new("a # c\n[", Regexp::EXTENDED)
   end
   assert_raise_with_message(RegexpError, "unmatched '(': /a b(/x") do
@@ -1236,15 +1248,15 @@ assert("Regexp extended mode (x flag)") do
   # error is raised: turning /x off inline still reports the entry's /x,
   # and turning it on where entry carried none reports no suffix at all.
   # CRuby matches this on both patterns.
-  assert_raise_with_message(RegexpError, "unterminated character class: /(?-x)a # c[/x") do
+  assert_raise_with_message(RegexpError, "premature end of char-class: /(?-x)a # c[/x") do
     Regexp.new("(?-x)a # c[", Regexp::EXTENDED)
   end
-  assert_raise_with_message(RegexpError, "unterminated character class: /(?x)a # c\n[/") do
+  assert_raise_with_message(RegexpError, "premature end of char-class: /(?x)a # c\n[/") do
     Regexp.new("(?x)a # c\n[")
   end
 
   # Multiple entry flags are named in Regexp#to_s/#inspect's m, i, x order.
-  assert_raise_with_message(RegexpError, "unterminated character class: /[a/ix") do
+  assert_raise_with_message(RegexpError, "premature end of char-class: /[a/ix") do
     Regexp.new("[a", Regexp::EXTENDED | Regexp::IGNORECASE)
   end
 end
@@ -1652,7 +1664,7 @@ assert("Regexp - a named group makes plain groups non-capturing") do
 
   # the scan runs on every pattern, so a truncated POSIX bracket reaches
   # skip_posix_bracket() without /x too, and is still the parser's error
-  assert_raise_with_message(RegexpError, "unterminated character class: /[[:alpha/") do
+  assert_raise_with_message(RegexpError, "premature end of char-class: /[[:alpha/") do
     Regexp.new("[[:alpha")
   end
 end

--- a/mrbgems/mruby-regexp/test/regexp_syntax.rb
+++ b/mrbgems/mruby-regexp/test/regexp_syntax.rb
@@ -802,6 +802,22 @@ assert("Regexp - repetition {n,m}") do
   assert_equal "aaa", Regexp.new("a{2,3}").match("aaaa")[0]
 end
 
+assert("Regexp - a repeat count above what the engine takes") do
+  # The ceiling here is 32768 and CRuby's is 100000, so between them stand
+  # counts this engine refuses and CRuby compiles. Above both the two
+  # refuse the same pattern, and what they say of it is the same.
+  ["a{100001}", "a{1,100001}", "a{100001,}", "a{10000000000}"].each do |src|
+    assert_raise_with_message(RegexpError,
+                              "too big number for repeat range: /#{src}/", src) do
+      Regexp.new(src)
+    end
+  end
+  assert_raise_with_message(RegexpError,
+                            "too big number for repeat range: /a{32769}/") do
+    Regexp.new("a{32769}")
+  end
+end
+
 assert("Regexp - an upper bound below the lower one is an error") do
   # `{n,m}` with m < n names no repeat count, and CRuby raises rather than
   # compiling it; it used to compile as `{n}` and match exactly n repeats.

--- a/mrbgems/mruby-regexp/test/regexp_syntax.rb
+++ b/mrbgems/mruby-regexp/test/regexp_syntax.rb
@@ -1544,9 +1544,10 @@ assert("Regexp - a (?...) prefix the pattern ends inside says which it was") do
     end
   end
   # A character that names no group is that failure rather than this one,
-  # whether or not the pattern goes on.
-  ["(?z", "(?z)"].each do |src|
-    assert_raise_with_message(RegexpError, "undefined (?...) sequence: /#{src}/", src) do
+  # whether or not the pattern goes on. `(?P<name>x)` is Python's spelling
+  # of a named group and no group of Ruby's, so it is one of these too.
+  ["(?z", "(?z)", "(?P", "(?P<a>x)"].each do |src|
+    assert_raise_with_message(RegexpError, "undefined group option: /#{src}/", src) do
       Regexp.new(src)
     end
   end

--- a/mrbgems/mruby-regexp/test/regexp_syntax.rb
+++ b/mrbgems/mruby-regexp/test/regexp_syntax.rb
@@ -1488,6 +1488,18 @@ assert("Regexp - empty pattern") do
   assert_true //.match?("abc")
 end
 
+assert("Regexp - more capture groups than the engine holds") do
+  # This engine holds 31 of them, group 0 taking the last of the 32 slots,
+  # where CRuby holds thousands. The pattern that reaches the limit is not
+  # the same one, so what is shared is the wording, which is CRuby's.
+  src = "(a)" * 32
+  assert_raise_with_message(RegexpError,
+                            "too many capture groups are specified: /#{src}/") do
+    Regexp.new(src)
+  end
+  assert_equal 32, Regexp.new("(a)" * 31).match("a" * 31).size
+end
+
 assert("Regexp - nested captures") do
   md = /((a)(b))c/.match("abc")
   assert_equal "abc", md[0]

--- a/mrbgems/mruby-regexp/test/regexp_syntax.rb
+++ b/mrbgems/mruby-regexp/test/regexp_syntax.rb
@@ -1522,6 +1522,18 @@ assert("Regexp - a group the pattern ends inside says which it was") do
   end
 end
 
+assert("Regexp - a ')' that closes no group says which it was") do
+  # The counterpart of the group that never closes: a ')' with no group
+  # open is `unmatched close parenthesis` in CRuby. A comment group does
+  # not nest, so the second ')' of (?#a(?#b)) is one of these.
+  [")", "a)", "(a))", "(?#a(?#b))"].each do |src|
+    assert_raise_with_message(RegexpError,
+                              "unmatched close parenthesis: /#{src}/", src) do
+      Regexp.new(src)
+    end
+  end
+end
+
 assert("Regexp - non-capturing group") do
   md = /(?:a)(b)/.match("ab")
   assert_equal "ab", md[0]

--- a/mrbgems/mruby-regexp/test/regexp_syntax.rb
+++ b/mrbgems/mruby-regexp/test/regexp_syntax.rb
@@ -1154,7 +1154,7 @@ assert("Regexp - comment groups (?#...)") do
   assert_raise(RegexpError) { Regexp.new("x(?#a(?#b))y") }
 
   # An unterminated group raises rather than swallowing the rest.
-  assert_raise_with_message(RegexpError, "unterminated comment group: /a(?#note/") do
+  assert_raise_with_message(RegexpError, "end pattern in group: /a(?#note/") do
     Regexp.new("a(?#note")
   end
 
@@ -1232,7 +1232,7 @@ assert("Regexp extended mode (x flag)") do
   re = Regexp.new("a (?#note) b # tail\nc", Regexp::EXTENDED)
   assert_true re.match?("abc")
 
-  assert_raise_with_message(RegexpError, "unterminated comment group: /a (?#note/x") do
+  assert_raise_with_message(RegexpError, "end pattern in group: /a (?#note/x") do
     Regexp.new("a (?#note", Regexp::EXTENDED)
   end
 
@@ -1531,6 +1531,31 @@ assert("Regexp - a ')' that closes no group says which it was") do
                               "unmatched close parenthesis: /#{src}/", src) do
       Regexp.new(src)
     end
+  end
+end
+
+assert("Regexp - a (?...) prefix the pattern ends inside says which it was") do
+  # `(?` opens a group the characters after it name. A pattern that ends
+  # before they do is `end pattern in group` in CRuby, whether what stands
+  # there is nothing at all, an option letter, or a comment group.
+  ["(?", "(?i", "(?im", "(?i-", "(?-", "(?#", "(?#note"].each do |src|
+    assert_raise_with_message(RegexpError, "end pattern in group: /#{src}/", src) do
+      Regexp.new(src)
+    end
+  end
+  # A character that names no group is that failure rather than this one,
+  # whether or not the pattern goes on.
+  ["(?z", "(?z)"].each do |src|
+    assert_raise_with_message(RegexpError, "undefined (?...) sequence: /#{src}/", src) do
+      Regexp.new(src)
+    end
+  end
+  # `(?<` is the prefix CRuby answers for with the group instead: it ends
+  # before the character that tells a lookbehind from a named group, and
+  # both of those are a group that never closes.
+  assert_raise_with_message(RegexpError,
+                            "end pattern with unmatched parenthesis: /(?</") do
+    Regexp.new("(?<")
   end
 end
 

--- a/mrbgems/mruby-regexp/test/regexp_syntax.rb
+++ b/mrbgems/mruby-regexp/test/regexp_syntax.rb
@@ -1220,7 +1220,7 @@ assert("Regexp extended mode (x flag)") do
   assert_nil Regexp.new('\x1 2', Regexp::EXTENDED) =~ "\x12"
   assert_equal 0, (Regexp.new('\x1 a', Regexp::EXTENDED) =~ "\x01a")
   assert_equal 0, (Regexp.new('\01 2', Regexp::EXTENDED) =~ "\x012")
-  assert_raise_with_message(RegexpError, "unmatched '(': /\\x1 2(/x") do
+  assert_raise_with_message(RegexpError, "end pattern with unmatched parenthesis: /\\x1 2(/x") do
     Regexp.new('\x1 2(', Regexp::EXTENDED)
   end
 
@@ -1246,7 +1246,7 @@ assert("Regexp extended mode (x flag)") do
   assert_raise_with_message(RegexpError, "premature end of char-class: /a # c\n[/x") do
     Regexp.new("a # c\n[", Regexp::EXTENDED)
   end
-  assert_raise_with_message(RegexpError, "unmatched '(': /a b(/x") do
+  assert_raise_with_message(RegexpError, "end pattern with unmatched parenthesis: /a b(/x") do
     Regexp.new("a b(", Regexp::EXTENDED)
   end
 
@@ -1506,6 +1506,20 @@ end
 assert("Regexp - word boundary") do
   assert_equal "cat", /\bcat\b/.match("the cat sat")[0]
   assert_nil /\bcat\b/.match("concatenate")
+end
+
+assert("Regexp - a group the pattern ends inside says which it was") do
+  # A group no ')' closes is `end pattern with unmatched parenthesis` in
+  # CRuby, whichever of the (?...) forms opened it, and the plain one as
+  # well.
+  ["(", "(a", "(?:a", "(?=a", "(?!a", "(?<=a", "(?<!a", "(?>a", "(?i:a",
+   "(?<a>x", "(?'a'x"].each do |src|
+    assert_raise_with_message(RegexpError,
+                              "end pattern with unmatched parenthesis: /#{src}/",
+                              src) do
+      Regexp.new(src)
+    end
+  end
 end
 
 assert("Regexp - non-capturing group") do

--- a/mrbgems/mruby-regexp/test/regexp_syntax.rb
+++ b/mrbgems/mruby-regexp/test/regexp_syntax.rb
@@ -2193,6 +2193,27 @@ assert("Regexp - a \\k reference reads leading zeros as digits") do
   assert_equal "aa", "aa".match(Regexp.new("(a)\\k<-01>"))[0]
 end
 
+assert("Regexp - a name the pattern ends inside says which it was") do
+  # A name the pattern ends before the delimiter of is `invalid group name`
+  # in CRuby, quoted as far as the scan got, and a name that never began is
+  # the empty one. Both spellings of a definition and both of a reference
+  # read the name the same way.
+  {
+    "(?<a" => "invalid group name <a>",
+    "(?'a" => "invalid group name <a>",
+    "(?<ab" => "invalid group name <ab>",
+    "(?'" => "group name is empty",
+    "(a)\\k<b" => "invalid group name <b>",
+    "(a)\\k'b" => "invalid group name <b>",
+    "(a)\\k<" => "group name is empty",
+    "(a)\\k'" => "group name is empty",
+  }.each do |src, msg|
+    assert_raise_with_message(RegexpError, "#{msg}: /#{src}/", src) do
+      Regexp.new(src)
+    end
+  end
+end
+
 assert("Regexp - a group name may not be a number") do
   # A definition names a group, it never numbers one: the number spelling
   # belongs to a reference, and CRuby refuses a leading digit or `-` where a

--- a/mrbgems/mruby-regexp/test/regexp_syntax.rb
+++ b/mrbgems/mruby-regexp/test/regexp_syntax.rb
@@ -2602,6 +2602,18 @@ assert("Regexp - octal and hex escapes") do
   end
 end
 
+assert("Regexp - a backslash the pattern ends after says which it was") do
+  # A `\\` with nothing after it is an escape that ends early, which is what
+  # CRuby calls it, and the same one it calls a `\\u` with no digits after
+  # it. Inside a class as well: the member reads its escape the same way.
+  ["a\\", "\\", "[a\\", "(?:a\\"].each do |src|
+    assert_raise_with_message(RegexpError,
+                              "too short escape sequence: /#{src}/", src) do
+      Regexp.new(src)
+    end
+  end
+end
+
 assert("Regexp - a hex escape needs at least one digit") do
   # `\x` followed by no hex digit used to read as `\x00`, so `\x{41}` was a
   # NUL and a quantifier, and matched 41 NUL bytes. A regexp literal never


### PR DESCRIPTION
## Summary

`mruby-regexp` refuses the patterns Onigmo refuses, and until now it said so in
words of its own. Thirteen messages are aligned with CRuby's here, so a test
written against CRuby's message text ports unchanged.

```ruby
Regexp.new("[a")
# before: unterminated character class: /[a/
# after:  premature end of char-class: /[a/
```

The set of patterns this engine accepts is not touched. Every pattern that
raised before raises now, and none that compiled has stopped: what changed is
the text, and in two rows the text was reporting the wrong thing entirely.

## Changes

| pattern | before | after (CRuby's wording) |
| --- | --- | --- |
| `[a` | `unterminated character class` | `premature end of char-class` |
| `[[:foo:]]` | `invalid POSIX bracket class` | `invalid POSIX bracket type` |
| `(a` | `unmatched '('` | `end pattern with unmatched parenthesis` |
| `a)` | `unmatched ')'` | `unmatched close parenthesis` |
| `(?#note` | `unterminated comment group` | `end pattern in group` |
| `(?i` | `undefined (?...) sequence` | `end pattern in group` |
| `(?` | `target of repeat operator is not specified` | `end pattern in group` |
| `(?<` | `undefined (?...) sequence` | `end pattern with unmatched parenthesis` |
| `(?z)` | `undefined (?...) sequence` | `undefined group option` |
| `(?<=a+)b` | `lookbehind must be fixed length` | `invalid pattern in look-behind` |
| `a\` | `trailing backslash` | `too short escape sequence` |
| `(?<a` | `unterminated named capture` | `invalid group name <a>` |
| `(?'` | `unterminated named capture` | `group name is empty` |
| `(a)\k<b` | `unterminated backreference name` | `invalid group name <b>` |
| `(a)\k<` | `unterminated backreference name` | `group name is empty` |
| `(a)` × 32 | `too many capture groups` | `too many capture groups are specified` |
| `a{10000000000}` | `quantifier too large` | `too big number for repeat range` |

### A class or a bracket that ends early

The bracket arm already carried CRuby's wording for a POSIX bracket whose name
stops at a `]`, and the class loop carried a different one for a class that
never closes, so the two ways of ending early inside one class answered
differently. CRuby has a single message between them, which leaves
`stopped_at_bracket_end` with nothing to decide.

### A group that never closes, and a `)` that closes nothing

Five sites look for their own `)`, one per group form, and the parser reaches
them only at the end of the pattern: `compile_alt()` stops at a `)` or there,
so a `)` that is not the one is never what they find. The stray `)` at the
other end had no test at all before this.

### A `(?` prefix the pattern ends inside

`(?` opens a group whose kind the characters after it name, and a pattern that
ends among them answered with three different things. One of them was not a
report of the prefix at all: `(?` with nothing after it never entered the
prefix arm, so what raised was `compile_seq()` finding a `?` with no atom
before it, under the message for a quantifier with nothing to repeat.

`(?<` is the one prefix CRuby answers for with the group rather than with the
prefix, since the pattern ends before the character that tells a lookbehind
from a named group and either reading leaves a group open.

### A group name the pattern ends inside

The end of the pattern ends a name the way a `)` does, and CRuby reports the
name it got rather than the fact that no delimiter arrived. A name that never
began is the empty one whether or not it was closed, so the emptiness test goes
first and `(?'` answers as `(?<>x)` does. Both spellings of a definition and
both of a reference read the name through the same two lines each.

### Two limits, and the wording they report under

The limits themselves are unchanged and are not CRuby's: 31 capture groups
against thousands, a repeat count of 32768 against Onigmo's 100000. The pattern
that reaches one reaches neither, so the wording is what the two can share, and
above both ceilings the same pattern is now refused in the same words.

## Behaviour

Nothing but the message text. No pattern changed from refused to accepted or
back, and the flag suffix, the quoting of the pattern, and the exception class
are as they were.

Rows that stay divergent are divergences of another kind, and none is a
wording: constructs this engine does not carry (`\p{...}`, `[[a]]`, `&&`,
`(?~`, `(?(n)`, `\g<>`, `\M-`, the `a`/`d`/`u` encoding options), the two
limits above, a lookbehind over alternation, and three Onigmo artifacts
(`/[]/` reporting `empty char-class`, `/[[:word:]/` reporting a bracket type,
and the `<0>>` in `\k<0>`'s message).

## Speed

Not measured, and nothing to measure: every line touched is on a path that ends
in `mrb_exc_raise()`, and the one comparison added runs once per `(` at compile
time. The match path is untouched.

## Size

`.text` of `lib/libmruby.a`, clang 22.1.8, `-O3`, each build made in a clean
build directory at the same worktree path.

| build | master | PR | delta |
| --- | ---: | ---: | ---: |
| full-debug | 1879868 | 1880092 | +224 |
| bintest | 1082734 | 1082030 | -704 |
| cxx_abi | 1072058 | 1071338 | -720 |
| byte-string | 1057617 | 1057137 | -480 |
| ascii-ctype | 1077620 | 1077076 | -544 |

Four builds shrink: two messages that were distinct strings are one now, and
the ternary that chose between them is gone. `full-debug` grows by inlining
around the two new arms.

## Testing

`rake -m test` with `build_config/ci/gcc-clang.rb`, all five builds and the
bintest pass, 0 KO. Every one of the thirteen messages is now pinned by
`assert_raise_with_message`, where seven of the sites asserted the old text and
the rest asserted nothing about the message at all.

Each row was measured against a CRuby of its own before and after: ruby 3.2.3
and ruby 4.0.6 agree on every row quoted here.

## Environment

<details>

```
Homebrew clang version 22.1.8
Linux 7.0.0-30-generic x86_64
ruby 3.2.3 (2024-01-18 revision 52bb2ac0a6) [x86_64-linux-gnu]
ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux]
```

Compile line for `re_compile.c` in the `byte-string` build:

```
clang -MMD -c -std=gnu99 -g -O3 -Wall -Wundef \
  -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array \
  -ffile-prefix-map=... -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT \
  -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL \
  -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER \
  -Iinclude -Imrbgems/mruby-regexp/include -Ibuild/byte-string/include \
  -o build/byte-string/mrbgems/mruby-regexp/src/re_compile.o \
  mrbgems/mruby-regexp/src/re_compile.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved regular expression syntax validation and error reporting.
  * Added clearer diagnostics for malformed escapes, character classes, groups, quantifiers, lookarounds, named captures, references, and unmatched parentheses.
  * Improved handling of incomplete and invalid regular expression constructs.

* **Tests**
  * Expanded syntax coverage for invalid and truncated patterns.
  * Added compatibility checks for expected parsing behavior and diagnostic messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->