### PR TITLE
mruby-complex: take the `to_s` separator from the rendered part

### DIFF
--- a/mrbgems/mruby-complex/mrblib/complex.rb
+++ b/mrbgems/mruby-complex/mrblib/complex.rb
@@ -39,7 +39,8 @@ class Complex < Numeric
   #   Complex(1, -2).to_s  #=> "1-2i"
   #
   def to_s
-    "#{real}#{'+' unless imaginary < 0}#{imaginary}#{'*' unless imaginary.finite?}i"
+    i = imaginary.to_s
+    "#{real}#{'+' unless i[0] == '-'}#{i}#{'*' unless imaginary.finite?}i"
   end
 
   #

--- a/mrbgems/mruby-complex/test/complex.rb
+++ b/mrbgems/mruby-complex/test/complex.rb
@@ -166,6 +166,18 @@ assert 'Complex::to_i' do
   end
 end
 
+assert 'Complex#to_s' do
+  assert_equal "1.0+2.0i", Complex(1.0, 2.0).to_s
+  assert_equal "1.0-2.0i", Complex(1.0, -2.0).to_s
+  assert_equal "1.0+0.0i", Complex(1.0, 0.0).to_s
+  assert_equal "1.0-0.0i", Complex(1.0, -0.0).to_s
+  assert_equal "-0.0-0.0i", Complex(-0.0, -0.0).to_s
+  assert_equal "(1.0-0.0i)", Complex(1.0, -0.0).inspect
+  assert_equal "1.0+Infinity*i", Complex(1.0, 1.0 / 0).to_s
+  assert_equal "1.0-Infinity*i", Complex(1.0, -1.0 / 0).to_s
+  assert_equal "0.0+NaN*i", Complex(0.0, 0.0 / 0).to_s
+end
+
 assert 'Complex#frozen?' do
   assert_predicate(1i, :frozen?)
   assert_predicate(Complex(2,3), :frozen?)


### PR DESCRIPTION
## Summary

`Complex#to_s` decides whether to write a `+` separator by asking the imaginary part whether it is negative, and `-0.0` is the one value that answers no while still rendering a sign, so a `-0.0` imaginary part was written `+-0.0i`.

## Changes

| File | What |
|---|---|
| `mrbgems/mruby-complex/mrblib/complex.rb` | `Complex#to_s` renders the imaginary part first and takes the separator decision from the rendered string |
| `mrbgems/mruby-complex/test/complex.rb` | `Complex#to_s` |

### `<` cannot see the sign bit of a zero

The method wrote `'+' unless imaginary < 0` and then interpolated the part whole, sign and all. That works because the two arms are exclusive: a part that takes the `< 0` arm carries its own `-`, and a part that does not carries no sign, so exactly one of the two is written. `-0.0` breaks the pairing: `-0.0 < 0` is false, so the `+` arm is taken, while `Float#to_s` still writes the sign the part carries, leaving the two side by side.

CRuby answers `"1.0-0.0i"` here, so the sign it writes and the magnitude it writes come from two different places: the sign bit, which a `-0.0` has, and the magnitude, which carries no sign for a zero. Rendering the part first and reading the sign off the rendered string asks the same question with what the class already has, since the string is needed for the interpolation anyway. `String#start_with?` lives in mruby-string-ext, which this gem does not depend on, so the first character is read with `String#[]`.

A NaN part renders without a sign in both engines and so keeps the `+` it has today, as do both infinities and every ordinary value.

## Behaviour

Rows measured on master (`8b659a782`), this branch, and CRuby 4.0.6 (`03b6d3f889`):

| Expression | before | after | CRuby |
|---|---|---|---|
| `Complex(1.0, -0.0).to_s` | `"1.0+-0.0i"` | `"1.0-0.0i"` | `"1.0-0.0i"` |
| `Complex(-0.0, -0.0).to_s` | `"-0.0+-0.0i"` | `"-0.0-0.0i"` | `"-0.0-0.0i"` |
| `Complex(1.0, -0.0).inspect` | `"(1.0+-0.0i)"` | `"(1.0-0.0i)"` | `"(1.0-0.0i)"` |

`inspect` is `"(#{to_s})"` and moves with it. The rows that were already right stay right, all three engines' columns identical: `Complex(1.0, 0.0).to_s`, `Complex(1.0, -2.0).to_s`, `Complex(1.0, 1.0 / 0).to_s`, `Complex(1.0, -1.0 / 0).to_s` and `Complex(0.0, 0.0 / 0).to_s`.

## Size

`.text` of `bin/mruby` for the five `build_config/ci/gcc-clang.rb` builds, `size -A`, master and this branch built at the same path from empty build directories:

| Build | master | this PR | delta |
|---|---|---|---|
| `bintest` | 1,076,166 | 1,076,166 | ±0 |
| `ascii-ctype` | 1,071,238 | 1,071,238 | ±0 |
| `byte-string` | 1,051,782 | 1,051,782 | ±0 |
| `cxx_abi` | 1,064,245 | 1,064,245 | ±0 |
| `full-debug` (-O0) | 1,865,846 | 1,865,846 | ±0 |

Nothing is compiled that was not compiled before, so the whole cost is bytecode: `mrbgems/mruby-complex/gem_init.o` `.rodata` +32 (`full-debug`). The one local the method gains is `i` and every method it sends (`to_s`, `[]`, `==`) is in the presym table already, so no symbol is added and no `.text` moves in any build.

## Testing

- `rake -m test` green with `build_config/ci/gcc-clang.rb` (`full-debug`, `bintest`, `cxx_abi`, `byte-string`, `ascii-ctype`), with the default config, and with `build_config/host-f32.rb`, where a 32-bit float renders the same `-0.0`, `Infinity` and `NaN` strings
- every row of the Behaviour table run on the master binary (`8b659a782`), the branch binary, and CRuby 4.0.6
- the new `Complex#to_s` test pins all eight strings and the three rows above are the only expressions whose answer differs between the two binaries

## Environment

<details>

| | |
|---|---|
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-30-generic x86_64 |
| CPU | AMD Ryzen 9 5950X (16C/32T) |
| C compiler | Homebrew clang 22.1.8 |
| binutils | GNU ld 2.47.20260726 |
| CRuby | 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM |
| base | `8b659a782` |

Compile lines as run for `mrbgems/mruby-complex/src/complex.c`, with `-MMD -c`, `-I`, `-o` and `-ffile-prefix-map` dropped:

```console
# bintest
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_COMPLEX_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK

# ascii-ctype
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -DMRB_USE_ASCII_CTYPE -DMRB_REGEXP_PARSE_DEPTH_LIMIT=512 -DMRBGEM_MRUBY_COMPLEX_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# byte-string
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -DMRBGEM_MRUBY_COMPLEX_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# cxx_abi
clang -g -O3 -Wall -Wundef -Wwrite-strings -Wzero-length-array -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_COMPLEX_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# full-debug
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRBGEM_MRUBY_COMPLEX_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved complex number string formatting for negative, signed-zero, infinite, and NaN imaginary components.
  * Ensured plus signs appear correctly based on the displayed imaginary value.

* **Tests**
  * Added coverage for complex number formatting across positive, negative, zero, infinity, and NaN values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->