### PR TITLE
mruby-complex: hold the exact parts the numeric tower hands over

### DIFF
--- a/include/mruby/internal.h
+++ b/include/mruby/internal.h
@@ -133,6 +133,9 @@ mrb_value mrb_rational_sub(mrb_state *mrb, mrb_value x, mrb_value y);
 mrb_value mrb_rational_mul(mrb_state *mrb, mrb_value x, mrb_value y);
 mrb_value mrb_rational_div(mrb_state *mrb, mrb_value x, mrb_value y);
 mrb_value mrb_as_rational(mrb_state *mrb, mrb_value x);
+mrb_value mrb_rational_canonicalize(mrb_state *mrb, mrb_value x);
+mrb_bool mrb_rational_eq(mrb_state *mrb, mrb_value x, mrb_value y);
+mrb_value mrb_rational_hash(mrb_state *mrb, mrb_value rat);
 void mrb_rational_copy(mrb_state *mrb, mrb_value x, mrb_value y);
 int mrb_rational_mark(mrb_state *mrb, struct RBasic *rat);
 #endif

--- a/include/mruby/internal.h
+++ b/include/mruby/internal.h
@@ -119,12 +119,27 @@ mrb_int mrb_int_float_cmp(mrb_int x, mrb_float y);
 #endif
 
 #ifdef MRB_USE_COMPLEX
+/* struct mrb_complex sits beside the object header where it fits in the
+   slot, and behind one pointer where it does not.  Which of the two a build
+   gets is also what obj_free() must know to free that pointer, so the
+   condition lives here, visible to both gc.c and the gem.  Without
+   MRB_COMPLEX_FLOAT_ONLY a part is an mrb_value, which is wider than an
+   mrb_float wherever a value carries its type tag beside the payload, so
+   an unboxed build overflows the slot that its two floats used to fit. */
+#if (defined(MRB_32BIT) && !defined(MRB_USE_FLOAT32)) || \
+    (!defined(MRB_COMPLEX_FLOAT_ONLY) && defined(MRB_NO_BOXING))
+#define MRB_COMPLEX_INDIRECT
+#endif
 mrb_value mrb_complex_new(mrb_state *mrb, mrb_float x, mrb_float y);
 mrb_value mrb_complex_add(mrb_state *mrb, mrb_value x, mrb_value y);
 mrb_value mrb_complex_sub(mrb_state *mrb, mrb_value x, mrb_value y);
 mrb_value mrb_complex_mul(mrb_state *mrb, mrb_value x, mrb_value y);
 mrb_value mrb_complex_div(mrb_state *mrb, mrb_value x, mrb_value y);
 void mrb_complex_copy(mrb_state *mrb, mrb_value x, mrb_value y);
+#ifndef MRB_COMPLEX_FLOAT_ONLY
+mrb_value mrb_complex_new_value(mrb_state *mrb, mrb_value real, mrb_value imaginary);
+int mrb_complex_mark(mrb_state *mrb, struct RBasic *comp);
+#endif
 #endif
 #ifdef MRB_USE_RATIONAL
 mrb_value mrb_rational_new(mrb_state *mrb, mrb_int x, mrb_int y);

--- a/mrbgems/mruby-complex/README.md
+++ b/mrbgems/mruby-complex/README.md
@@ -29,7 +29,7 @@ c3 = Complex.polar(5, Math::PI/2) # => (0.0+5.0i) (approximately)
 puts c1 + c2  # => (4+6i)
 puts c1 - c2  # => (-2-2i)
 puts c1 * c2  # => (-5+10i)
-puts c1 / c2  # => (0.44+0.08i)
+puts c1 / c2  # => ((11/25)+(2/25)*i) with mruby-rational, (0.44+0.08i) without
 
 # Accessing parts
 puts c1.real      # => 1
@@ -49,6 +49,23 @@ puts 2.3.to_c     # => (2.3+0i)
 puts 5i           # => (0+5i)
 puts 2.3i         # => (0+2.3i)
 ```
+
+## Exact parts
+
+A `Complex` answers with the parts it was given: `Complex(1, 2).real` is the
+Integer `1`, a Rational or Bigint part stays what it is, and only a Float
+part is a Float. Arithmetic follows the parts, so `Complex(1, 2) ** 2` is
+exactly `(-3+4i)`, and division without a Float anywhere is exact where the
+build has mruby-rational: `Complex(1, 2) / 2` is `((1/2)+1i)`. With a Float
+in the operands, arithmetic is the usual floating-point kind.
+
+### `MRB_COMPLEX_FLOAT_ONLY`
+
+- When defined, every part is coerced through `Float` on the way in and the
+  two parts are stored as two `mrb_float`, which is this gem's historical
+  representation.
+- For builds that want the smaller arithmetic paths and have no use for
+  exact parts.
 
 ## Note
 

--- a/mrbgems/mruby-complex/mrbgem.rake
+++ b/mrbgems/mruby-complex/mrbgem.rake
@@ -4,4 +4,10 @@ MRuby::Gem::Specification.new('mruby-complex') do |spec|
   spec.summary = 'Complex class'
   spec.build.defines << "MRB_USE_COMPLEX"
   spec.add_dependency 'mruby-math', core: 'mruby-math'
+
+  # The exact-division path needs mruby-rational, but a test dependency on
+  # it here would close a cycle: mruby-rational already test-depends on this
+  # gem, and test dependencies sort with the regular ones. The tests for
+  # that path live in mruby-rational's test directory instead, where both
+  # gems are in the state.
 end

--- a/mrbgems/mruby-complex/mrblib/complex.rb
+++ b/mrbgems/mruby-complex/mrblib/complex.rb
@@ -6,11 +6,23 @@ class Complex < Numeric
   # Returns a complex number in terms of its polar coordinates.
   # abs is the absolute value (magnitude) and arg is the argument (angle).
   #
-  #   Complex.polar(3, 0)            #=> (3+0i)
-  #   Complex.polar(3, Math::PI/2)   #=> (1.836909530733566e-16+3.0i)
-  #   Complex.polar(3, Math::PI)     #=> (-3.0+3.673819061467132e-16i)
+  #   Complex.polar(3, 0)            #=> (3+0.0i)
+  #   Complex.polar(3, Math::PI/2)   #=> (0.0+3i)
+  #   Complex.polar(3, Math::PI)     #=> (-3+0.0i)
   #
   def self.polar(abs, arg = 0)
+    # the four angles the sine and cosine answer exactly keep the magnitude
+    # exact, the way CRuby's f_complex_polar_real does
+    return Complex(abs, 0.0) if abs == 0 || arg == 0
+    if arg.is_a?(Float)
+      if arg == Math::PI
+        return Complex(-abs, 0.0)
+      elsif arg == Math::PI / 2
+        return Complex(0.0, abs)
+      elsif arg == Math::PI / 2 + Math::PI
+        return Complex(0.0, -abs)
+      end
+    end
     Complex(abs * Math.cos(arg), abs * Math.sin(arg))
   end
 
@@ -25,7 +37,18 @@ class Complex < Numeric
   #   Complex(1, 2).inspect   #=> "(1+2i)"
   #
   def inspect
-    "(#{to_s})"
+    s = imaginary.to_s
+    i = imaginary.inspect
+    if s[0] == '-'
+      sep = '-'
+      # the sign character sits at the front, or just inside a Rational's
+      # opening parenthesis; drop it rather than negate the part
+      i = i[0] == '-' ? i[1..-1] : i[0, 1] + i[2..-1]
+    else
+      sep = '+'
+    end
+    d = i[-1]
+    "(#{real.inspect}#{sep}#{i}#{'*' unless d >= '0' && d <= '9'}i)"
   end
 
   #
@@ -39,8 +62,20 @@ class Complex < Numeric
   #   Complex(1, -2).to_s  #=> "1-2i"
   #
   def to_s
+    # The sign comes off the rendered part and becomes the separator: the
+    # rendering carries the sign bit `<` cannot see on -0.0, and stripping
+    # it needs no negation, which an Integer part of INT_MIN has no room for
+    # without bigint. The `*` marks a part whose rendering does not end in a
+    # digit, such as Infinity or NaN.
     i = imaginary.to_s
-    "#{real}#{'+' unless i[0] == '-'}#{i}#{'*' unless imaginary.finite?}i"
+    if i[0] == '-'
+      sep = '-'
+      i = i[1..-1]
+    else
+      sep = '+'
+    end
+    d = i[-1]
+    "#{real}#{sep}#{i}#{'*' unless d >= '0' && d <= '9'}i"
   end
 
   #
@@ -76,9 +111,9 @@ class Complex < Numeric
   # or greater than numeric. This is the basis for the tests in the Comparable module.
   # Returns nil if the two values are incomparable.
   #
-  #   Complex(2, 3) <=> Complex(2, 3)  #=> 0
-  #   Complex(5) <=> 5                 #=> 0
-  #   Complex(2, 3) <=> 1              #=> 1
+  #   Complex(5) <=> 5     #=> 0
+  #   Complex(2) <=> 1     #=> 1
+  #   Complex(2, 3) <=> 1  #=> nil
   #
   def <=>(other)
     return nil unless Numeric === other
@@ -154,7 +189,7 @@ class Complex < Numeric
   #   Complex(11, 22).fdiv(3)  #=> (3.6666666666666665+7.333333333333333i)
   #
   def fdiv(numeric)
-    Complex(real / numeric, imaginary / numeric)
+    Complex(real.to_f, imaginary.to_f) / numeric
   end
 
   #
@@ -219,7 +254,7 @@ class Complex < Numeric
   #   Complex(1, 2).to_r    #=> RangeError
   #
   def to_r
-    raise RangeError.new "can't convert #{to_s} into Rational" unless imaginary.zero?
+    raise RangeError.new "can't convert #{to_s} into Rational" unless imaginary == 0
     Rational(real, 1)
   end
 

--- a/mrbgems/mruby-complex/src/complex.c
+++ b/mrbgems/mruby-complex/src/complex.c
@@ -14,12 +14,39 @@
 #define F(x) x
 #endif
 
+#ifdef MRB_USE_RATIONAL
+mrb_value mrb_rational_to_i(mrb_state *mrb, mrb_value self);
+#endif
+
+/* A Complex answers with the parts it was given.  Two Floats stay the two
+   mrb_float they always were; any other pair from the numeric tower is held
+   as two mrb_value, with COMP_VALUE on the object saying which half of the
+   union is live.  MRB_COMPLEX_FLOAT_ONLY compiles the value half away and
+   coerces every part through Float on the way in, which is this gem's
+   historical behavior. */
 struct mrb_complex {
-  mrb_float real;
-  mrb_float imaginary;
+  union {
+    struct {
+      mrb_float real;
+      mrb_float imaginary;
+    } f;
+#ifndef MRB_COMPLEX_FLOAT_ONLY
+    struct {
+      mrb_value real;
+      mrb_value imaginary;
+    } v;
+#endif
+  };
 };
 
-#if defined(MRB_32BIT) && !defined(MRB_USE_FLOAT32)
+#ifndef MRB_COMPLEX_FLOAT_ONLY
+#define COMP_VALUE 1
+#define COMP_VALUE_P(cpx) (mrb_obj_ptr(cpx)->flags & COMP_VALUE)
+#else
+#define COMP_VALUE_P(cpx) FALSE
+#endif
+
+#ifdef MRB_COMPLEX_INDIRECT
 
 struct RComplex {
   MRB_OBJECT_HEADER;
@@ -61,13 +88,53 @@ complex_alloc(mrb_state *mrb, struct RClass *c, struct mrb_complex **p)
   return (struct RBasic*)s;
 }
 
+/* Both parts as floats, whichever half of the union is live. */
+static mrb_float
+comp_float_real(mrb_state *mrb, mrb_value cpx)
+{
+  struct mrb_complex *p = complex_ptr(mrb, cpx);
+#ifndef MRB_COMPLEX_FLOAT_ONLY
+  if (COMP_VALUE_P(cpx)) return mrb_as_float(mrb, p->v.real);
+#endif
+  return p->f.real;
+}
+
+static mrb_float
+comp_float_imaginary(mrb_state *mrb, mrb_value cpx)
+{
+  struct mrb_complex *p = complex_ptr(mrb, cpx);
+#ifndef MRB_COMPLEX_FLOAT_ONLY
+  if (COMP_VALUE_P(cpx)) return mrb_as_float(mrb, p->v.imaginary);
+#endif
+  return p->f.imaginary;
+}
+
+/* Both parts as values: what #real and #imaginary answer. */
+static mrb_value
+part_real(mrb_state *mrb, mrb_value cpx)
+{
+  struct mrb_complex *p = complex_ptr(mrb, cpx);
+#ifndef MRB_COMPLEX_FLOAT_ONLY
+  if (COMP_VALUE_P(cpx)) return p->v.real;
+#endif
+  return mrb_float_value(mrb, p->f.real);
+}
+
+static mrb_value
+part_imaginary(mrb_state *mrb, mrb_value cpx)
+{
+  struct mrb_complex *p = complex_ptr(mrb, cpx);
+#ifndef MRB_COMPLEX_FLOAT_ONLY
+  if (COMP_VALUE_P(cpx)) return p->v.imaginary;
+#endif
+  return mrb_float_value(mrb, p->f.imaginary);
+}
+
 void
 mrb_complex_get(mrb_state *mrb, mrb_value cpx, mrb_float *r, mrb_float *i)
 {
-  struct mrb_complex *c = complex_ptr(mrb, cpx);
-
-  *r = c->real;
-  *i = c->imaginary;
+  *r = comp_float_real(mrb, cpx);
+  *i = comp_float_imaginary(mrb, cpx);
 }
 
 mrb_value
@@ -76,8 +143,8 @@ mrb_complex_new(mrb_state *mrb, mrb_float real, mrb_float imaginary)
   struct RClass *c = mrb_class_get_id(mrb, MRB_SYM(Complex));
   struct mrb_complex *p;
   struct RBasic *comp = complex_alloc(mrb, c, &p);
-  p->real = real;
-  p->imaginary = imaginary;
+  p->f.real = real;
+  p->f.imaginary = imaginary;
   comp->frozen = 1;
 
   return mrb_obj_value(comp);
@@ -85,46 +152,154 @@ mrb_complex_new(mrb_state *mrb, mrb_float real, mrb_float imaginary)
 
 #define complex_new(mrb, real, imag) mrb_complex_new(mrb, real, imag)
 
+#ifndef MRB_COMPLEX_FLOAT_ONLY
+
+/* The set a part can be: the numeric tower as this build has it, minus
+   Complex itself and Float, which has its own storage. */
+static mrb_bool
+part_exact_type_p(mrb_value v)
+{
+  switch (mrb_type(v)) {
+  case MRB_TT_INTEGER:
+#ifdef MRB_USE_BIGINT
+  case MRB_TT_BIGINT:
+#endif
+#ifdef MRB_USE_RATIONAL
+  case MRB_TT_RATIONAL:
+#endif
+    return TRUE;
+  default:
+    return FALSE;
+  }
+}
+
+/* A member of the tower passes through as itself; everything else keeps its
+   old answer, a coercion through Float.  For a Complex argument that is its
+   real part when the imaginary part is zero and a RangeError otherwise. */
+static mrb_value
+part_coerce(mrb_state *mrb, mrb_value v)
+{
+  if (part_exact_type_p(v) || mrb_float_p(v)) return v;
+  return mrb_float_value(mrb, mrb_as_float(mrb, v));
+}
+
+mrb_value
+mrb_complex_new_value(mrb_state *mrb, mrb_value real, mrb_value imaginary)
+{
+  if (mrb_float_p(real) && mrb_float_p(imaginary)) {
+    return mrb_complex_new(mrb, mrb_float(real), mrb_float(imaginary));
+  }
+
+  struct RClass *c = mrb_class_get_id(mrb, MRB_SYM(Complex));
+  struct mrb_complex *p;
+  struct RBasic *comp = complex_alloc(mrb, c, &p);
+  comp->flags |= COMP_VALUE;
+  p->v.real = real;
+  p->v.imaginary = imaginary;
+  comp->frozen = 1;
+
+  return mrb_obj_value(comp);
+}
+
+int
+mrb_complex_mark(mrb_state *mrb, struct RBasic *comp)
+{
+  if (!(comp->flags & COMP_VALUE)) return 0;
+
+  struct mrb_complex *p;
+#ifdef COMPLEX_INLINE
+  p = &((struct RComplex*)comp)->r;
+#else
+  p = ((struct RComplex*)comp)->p;
+  if (!p) return 0;
+#endif
+  int children = 0;
+  if (!mrb_immediate_p(p->v.real)) {
+    mrb_gc_mark(mrb, mrb_basic_ptr(p->v.real));
+    children++;
+  }
+  if (!mrb_immediate_p(p->v.imaginary)) {
+    mrb_gc_mark(mrb, mrb_basic_ptr(p->v.imaginary));
+    children++;
+  }
+  return children;
+}
+
+/* Equality on the closed set a part can be.  Every pair lands on an exact
+   C comparison; nothing here calls back into Ruby. */
+static mrb_bool
+part_eq(mrb_state *mrb, mrb_value a, mrb_value b)
+{
+#ifdef MRB_USE_RATIONAL
+  if (mrb_type(a) == MRB_TT_RATIONAL) return mrb_rational_eq(mrb, a, b);
+  if (mrb_type(b) == MRB_TT_RATIONAL) return mrb_rational_eq(mrb, b, a);
+#endif
+#ifdef MRB_USE_BIGINT
+  if (mrb_bigint_p(a)) return mrb_bint_cmp(mrb, a, b) == 0;
+  if (mrb_bigint_p(b)) return mrb_bint_cmp(mrb, b, a) == 0;
+#endif
+  if (mrb_float_p(a)) {
+    if (mrb_float_p(b)) return mrb_float(a) == mrb_float(b);
+    return mrb_int_float_cmp(mrb_integer(b), mrb_float(a)) == 0;
+  }
+  if (mrb_float_p(b)) return mrb_int_float_cmp(mrb_integer(a), mrb_float(b)) == 0;
+  return mrb_integer(a) == mrb_integer(b);
+}
+
+#define part_zero_p(mrb, v) part_eq(mrb, v, mrb_fixnum_value(0))
+
+#endif /* MRB_COMPLEX_FLOAT_ONLY */
+
 void
 mrb_complex_copy(mrb_state *mrb, mrb_value x, mrb_value y)
 {
   struct mrb_complex *p1 = complex_ptr(mrb, x);
   struct mrb_complex *p2 = complex_ptr(mrb, y);
-  p1->real = p2->real;
-  p1->imaginary = p2->imaginary;
+#ifndef MRB_COMPLEX_FLOAT_ONLY
+  struct RBasic *b1 = (struct RBasic*)mrb_obj_ptr(x);
+  if (COMP_VALUE_P(y)) {
+    p1->v.real = p2->v.real;
+    p1->v.imaginary = p2->v.imaginary;
+    b1->flags |= COMP_VALUE;
+    return;
+  }
+  b1->flags &= ~COMP_VALUE;
+#endif
+  p1->f.real = p2->f.real;
+  p1->f.imaginary = p2->f.imaginary;
 }
 
 /*
  * call-seq:
- *   complex.real -> float
+ *   complex.real -> numeric
  *
- * Returns the real part of the complex number.
+ * Returns the real part of the complex number, in the class it was
+ * given as.
  *
- *   Complex(3, 4).real  #=> 3.0
- *   Complex(-1).real    #=> -1.0
+ *   Complex(3, 4).real    #=> 3
+ *   Complex(-1.5).real    #=> -1.5
  */
 static mrb_value
 complex_real(mrb_state *mrb, mrb_value self)
 {
-  struct mrb_complex *p = complex_ptr(mrb, self);
-  return mrb_float_value(mrb, p->real);
+  return part_real(mrb, self);
 }
 
 /*
  * call-seq:
- *   complex.imaginary -> float
- *   complex.imag      -> float
+ *   complex.imaginary -> numeric
+ *   complex.imag      -> numeric
  *
- * Returns the imaginary part of the complex number.
+ * Returns the imaginary part of the complex number, in the class it was
+ * given as.
  *
- *   Complex(3, 4).imaginary  #=> 4.0
- *   Complex(5).imag          #=> 0.0
+ *   Complex(3, 4).imaginary  #=> 4
+ *   Complex(5).imag          #=> 0
  */
 static mrb_value
 complex_imaginary(mrb_state *mrb, mrb_value self)
 {
-  struct mrb_complex *p = complex_ptr(mrb, self);
-  return mrb_float_value(mrb, p->imaginary);
+  return part_imaginary(mrb, self);
 }
 
 /*
@@ -143,10 +318,35 @@ complex_imaginary(mrb_state *mrb, mrb_value self)
 static mrb_value
 complex_s_rect(mrb_state *mrb, mrb_value self)
 {
+#ifdef MRB_COMPLEX_FLOAT_ONLY
   mrb_float real, imaginary = 0.0;
 
   mrb_get_args(mrb, "f|f", &real, &imaginary);
   return complex_new(mrb, real, imaginary);
+#else
+  mrb_value real, imaginary = mrb_fixnum_value(0);
+
+  mrb_get_args(mrb, "o|o", &real, &imaginary);
+  real = part_coerce(mrb, real);
+  imaginary = part_coerce(mrb, imaginary);
+  return mrb_complex_new_value(mrb, real, imaginary);
+#endif
+}
+
+/* The Integer this float is, by the rules #to_i has always used. */
+static mrb_value
+complex_float_to_i(mrb_state *mrb, mrb_value self, mrb_float f)
+{
+#ifdef MRB_USE_BIGINT
+  if (!FIXABLE_FLOAT(f)) {
+    return mrb_bint_new_float(mrb, f);
+  }
+#else
+  if (!FIXABLE_FLOAT(f)) {
+    mrb_raisef(mrb, E_RANGE_ERROR, "can't convert %v into Integer", self);
+  }
+#endif
+  return mrb_int_value(mrb, (mrb_int)f);
 }
 
 /*
@@ -162,13 +362,23 @@ complex_s_rect(mrb_state *mrb, mrb_value self)
 mrb_value
 mrb_complex_to_f(mrb_state *mrb, mrb_value self)
 {
+#ifndef MRB_COMPLEX_FLOAT_ONLY
+  if (COMP_VALUE_P(self)) {
+    struct mrb_complex *p = complex_ptr(mrb, self);
+
+    if (!part_zero_p(mrb, p->v.imaginary)) {
+      mrb_raisef(mrb, E_RANGE_ERROR, "can't convert %v into Float", self);
+    }
+    return mrb_float_value(mrb, mrb_as_float(mrb, p->v.real));
+  }
+#endif
   struct mrb_complex *p = complex_ptr(mrb, self);
 
-  if (p->imaginary != 0) {
+  if (p->f.imaginary != 0) {
     mrb_raisef(mrb, E_RANGE_ERROR, "can't convert %v into Float", self);
   }
 
-  return mrb_float_value(mrb, p->real);
+  return mrb_float_value(mrb, p->f.real);
 }
 
 /*
@@ -184,26 +394,60 @@ mrb_complex_to_f(mrb_state *mrb, mrb_value self)
 mrb_value
 mrb_complex_to_i(mrb_state *mrb, mrb_value self)
 {
-  struct mrb_complex *p = complex_ptr(mrb, self);
+#ifndef MRB_COMPLEX_FLOAT_ONLY
+  if (COMP_VALUE_P(self)) {
+    struct mrb_complex *p = complex_ptr(mrb, self);
 
+    if (!part_zero_p(mrb, p->v.imaginary)) {
+      mrb_raisef(mrb, E_RANGE_ERROR, "can't convert %v into Integer", self);
+    }
+    switch (mrb_type(p->v.real)) {
+    case MRB_TT_INTEGER:
 #ifdef MRB_USE_BIGINT
-  if (p->imaginary != 0) {
-    mrb_raisef(mrb, E_RANGE_ERROR, "can't convert %v into Integer", self);
-  }
-  if (!FIXABLE_FLOAT(p->real)) {
-    return mrb_bint_new_float(mrb, p->real);
-  }
-#else
-  if (p->imaginary != 0 || !FIXABLE_FLOAT(p->real)) {
-    mrb_raisef(mrb, E_RANGE_ERROR, "can't convert %v into Integer", self);
+    case MRB_TT_BIGINT:
+#endif
+      return p->v.real;
+#ifdef MRB_USE_RATIONAL
+    case MRB_TT_RATIONAL:
+      return mrb_rational_to_i(mrb, p->v.real);
+#endif
+    default:
+      return complex_float_to_i(mrb, self, mrb_float(p->v.real));
+    }
   }
 #endif
-  return mrb_int_value(mrb, (mrb_int)p->real);
+  struct mrb_complex *p = complex_ptr(mrb, self);
+
+  if (p->f.imaginary != 0) {
+    mrb_raisef(mrb, E_RANGE_ERROR, "can't convert %v into Integer", self);
+  }
+  return complex_float_to_i(mrb, self, p->f.real);
 }
 
 mrb_bool
 mrb_complex_eq(mrb_state *mrb, mrb_value x, mrb_value y)
 {
+#ifndef MRB_COMPLEX_FLOAT_ONLY
+  if (COMP_VALUE_P(x) || (mrb_type(y) == MRB_TT_COMPLEX && COMP_VALUE_P(y))) {
+    switch (mrb_type(y)) {
+    case MRB_TT_COMPLEX:
+      return part_eq(mrb, part_real(mrb, x), part_real(mrb, y)) &&
+             part_eq(mrb, part_imaginary(mrb, x), part_imaginary(mrb, y));
+    case MRB_TT_INTEGER:
+    case MRB_TT_FLOAT:
+#ifdef MRB_USE_BIGINT
+    case MRB_TT_BIGINT:
+#endif
+#ifdef MRB_USE_RATIONAL
+    case MRB_TT_RATIONAL:
+#endif
+      return part_zero_p(mrb, part_imaginary(mrb, x)) &&
+             part_eq(mrb, part_real(mrb, x), y);
+    default:
+      return mrb_equal(mrb, y, x);
+    }
+  }
+#endif
   struct mrb_complex *p1 = complex_ptr(mrb, x);
 
   switch (mrb_type(y)) {
@@ -211,17 +455,17 @@ mrb_complex_eq(mrb_state *mrb, mrb_value x, mrb_value y)
     {
       struct mrb_complex *p2 = complex_ptr(mrb, y);
 
-      if (p1->real == p2->real && p1->imaginary == p2->imaginary) {
+      if (p1->f.real == p2->f.real && p1->f.imaginary == p2->f.imaginary) {
         return TRUE;
       }
       return FALSE;
     }
   case MRB_TT_INTEGER:
-    if (p1->imaginary != 0) return FALSE;
-    return p1->real == mrb_integer(y);
+    if (p1->f.imaginary != 0) return FALSE;
+    return p1->f.real == mrb_integer(y);
   case MRB_TT_FLOAT:
-    if (p1->imaginary != 0) return FALSE;
-    return p1->real == mrb_float(y);
+    if (p1->f.imaginary != 0) return FALSE;
+    return p1->f.real == mrb_float(y);
 
   default:
     return mrb_equal(mrb, y, x);
@@ -246,17 +490,96 @@ complex_eq(mrb_state *mrb, mrb_value x)
   return mrb_bool_value(mrb_complex_eq(mrb, x, y));
 }
 
+#ifndef MRB_COMPLEX_FLOAT_ONLY
+static mrb_bool
+part_eql(mrb_state *mrb, mrb_value a, mrb_value b)
+{
+  if (mrb_type(a) != mrb_type(b)) return FALSE;
+  return part_eq(mrb, a, b);
+}
+
+/*
+ * call-seq:
+ *   complex.eql?(object) -> true or false
+ *
+ * Returns true if object is a Complex whose parts are of the same classes
+ * and equal.  `==` converts across part classes; `eql?` must not, because
+ * #hash keys each part by its class as well as its value.
+ *
+ *   Complex(1, 2).eql?(Complex(1, 2))      #=> true
+ *   Complex(1, 2).eql?(Complex(1.0, 2.0))  #=> false
+ */
+static mrb_value
+complex_eql(mrb_state *mrb, mrb_value x)
+{
+  mrb_value y = mrb_get_arg1(mrb);
+
+  if (mrb_type(y) != MRB_TT_COMPLEX) return mrb_false_value();
+  return mrb_bool_value(part_eql(mrb, part_real(mrb, x), part_real(mrb, y)) &&
+                        part_eql(mrb, part_imaginary(mrb, x), part_imaginary(mrb, y)));
+}
+
+static mrb_value
+complex_op_value(mrb_state *mrb, mrb_value x, mrb_value y, char op)
+{
+  mrb_value ar = part_real(mrb, x);
+  mrb_value ai = part_imaginary(mrb, x);
+
+  if (mrb_type(y) != MRB_TT_COMPLEX) {
+    /* part-wise, not the four-product formula with a zero imaginary part:
+       multiplying an Integer part by that zero would answer in whatever
+       class the other side's arithmetic returns, not the part's own */
+    mrb_value s = part_coerce(mrb, y);
+
+    switch (op) {
+    case '+':
+      return mrb_complex_new_value(mrb, mrb_num_add(mrb, ar, s), ai);
+    case '-':
+      return mrb_complex_new_value(mrb, mrb_num_sub(mrb, ar, s), ai);
+    default: /* '*' */
+      return mrb_complex_new_value(mrb, mrb_num_mul(mrb, ar, s), mrb_num_mul(mrb, ai, s));
+    }
+  }
+
+  mrb_value br = part_real(mrb, y);
+  mrb_value bi = part_imaginary(mrb, y);
+
+  switch (op) {
+  case '+':
+    return mrb_complex_new_value(mrb, mrb_num_add(mrb, ar, br), mrb_num_add(mrb, ai, bi));
+  case '-':
+    return mrb_complex_new_value(mrb, mrb_num_sub(mrb, ar, br), mrb_num_sub(mrb, ai, bi));
+  default: /* '*' */
+    {
+      mrb_value r = mrb_num_sub(mrb, mrb_num_mul(mrb, ar, br), mrb_num_mul(mrb, ai, bi));
+      mrb_value i = mrb_num_add(mrb, mrb_num_mul(mrb, ar, bi), mrb_num_mul(mrb, ai, br));
+      return mrb_complex_new_value(mrb, r, i);
+    }
+  }
+}
+
+/* A pair of float-form operands takes the float arms below; anything
+   holding a value form goes part-wise through the tower's own dispatch. */
+#define COMP_OP_VALUE_P(x, y) \
+  (COMP_VALUE_P(x) || (mrb_type(y) == MRB_TT_COMPLEX && COMP_VALUE_P(y)))
+#endif /* MRB_COMPLEX_FLOAT_ONLY */
+
 static mrb_value
 complex_op(mrb_state *mrb, mrb_value x, mrb_value y, char op)
 {
+#ifndef MRB_COMPLEX_FLOAT_ONLY
+  if (COMP_OP_VALUE_P(x, y)) {
+    return complex_op_value(mrb, x, y, op);
+  }
+#endif
   struct mrb_complex *p1 = complex_ptr(mrb, x);
   mrb_float r, i;
 
   switch (mrb_type(y)) {
   case MRB_TT_COMPLEX: {
     struct mrb_complex *p2 = complex_ptr(mrb, y);
-    r = p2->real;
-    i = p2->imaginary;
+    r = p2->f.real;
+    i = p2->f.imaginary;
     break;
   }
   default: {
@@ -268,11 +591,11 @@ complex_op(mrb_state *mrb, mrb_value x, mrb_value y, char op)
 
   switch (op) {
   case '+':
-    return mrb_complex_new(mrb, p1->real + r, p1->imaginary + i);
+    return mrb_complex_new(mrb, p1->f.real + r, p1->f.imaginary + i);
   case '-':
-    return mrb_complex_new(mrb, p1->real - r, p1->imaginary - i);
+    return mrb_complex_new(mrb, p1->f.real - r, p1->f.imaginary - i);
   case '*':
-    return mrb_complex_new(mrb, p1->real * r - p1->imaginary * i, p1->real * i + p1->imaginary * r);
+    return mrb_complex_new(mrb, p1->f.real * r - p1->f.imaginary * i, p1->f.real * i + p1->f.imaginary * r);
   }
   return mrb_nil_value(); /* should not happen */
 }
@@ -391,13 +714,88 @@ div_pair(struct float_pair *q, struct float_pair const *a,
   q->x = a->x - b->x;
 }
 
+#if !defined(MRB_COMPLEX_FLOAT_ONLY) && defined(MRB_USE_RATIONAL)
+/* Exact division of two parts: what Integer#quo answers, folded back to an
+   Integer when the quotient has denominator 1, the way every part of an
+   exact quotient reads in CRuby. */
+static mrb_value
+part_quo(mrb_state *mrb, mrb_value a, mrb_value b)
+{
+  return mrb_rational_canonicalize(mrb, mrb_rational_div(mrb, mrb_as_rational(mrb, a), b));
+}
+
+/* One part divided by an exact real scalar: a Float part divides as a
+   float, an exact part quotients exactly, the way CRuby's f_divide runs
+   quo over each part and canonicalizes its scalar arm. */
+static mrb_value
+part_quo_scalar(mrb_state *mrb, mrb_value part, mrb_value rhs)
+{
+  if (mrb_float_p(part)) {
+    return mrb_float_value(mrb, mrb_div_float(mrb_float(part), mrb_as_float(mrb, rhs)));
+  }
+  return part_quo(mrb, part, rhs);
+}
+
+static mrb_bool
+comp_no_float_parts_p(mrb_state *mrb, mrb_value cpx)
+{
+  if (!COMP_VALUE_P(cpx)) return FALSE;
+  struct mrb_complex *p = complex_ptr(mrb, cpx);
+  return !mrb_float_p(p->v.real) && !mrb_float_p(p->v.imaginary);
+}
+
+/* A complex divisor stays exact only while no float is anywhere in it, the
+   same condition CRuby's f_divide asks before it skips canonicalization. */
+static mrb_bool
+comp_div_exact_p(mrb_state *mrb, mrb_value x, mrb_value rhs)
+{
+  return comp_no_float_parts_p(mrb, x) && comp_no_float_parts_p(mrb, rhs);
+}
+
+static mrb_value
+complex_div_exact(mrb_state *mrb, mrb_value x, mrb_value rhs)
+{
+  mrb_value ar = part_real(mrb, x);
+  mrb_value ai = part_imaginary(mrb, x);
+
+  mrb_value br = part_real(mrb, rhs);
+  mrb_value bi = part_imaginary(mrb, rhs);
+  /* multiply through by the conjugate; with exact parts there is no
+     rounding for the float arm's r-scaling to save */
+  mrb_value n = mrb_num_add(mrb, mrb_num_mul(mrb, br, br), mrb_num_mul(mrb, bi, bi));
+  if (part_zero_p(mrb, n)) mrb_int_zerodiv(mrb);
+  mrb_value zr = mrb_num_add(mrb, mrb_num_mul(mrb, ar, br), mrb_num_mul(mrb, ai, bi));
+  mrb_value zi = mrb_num_sub(mrb, mrb_num_mul(mrb, ai, br), mrb_num_mul(mrb, ar, bi));
+  return mrb_complex_new_value(mrb, part_quo(mrb, zr, n), part_quo(mrb, zi, n));
+}
+#endif /* !MRB_COMPLEX_FLOAT_ONLY && MRB_USE_RATIONAL */
+
 mrb_value
 mrb_complex_div(mrb_state *mrb, mrb_value self, mrb_value rhs)
 {
-  struct mrb_complex *a, *b;
+#if !defined(MRB_COMPLEX_FLOAT_ONLY) && defined(MRB_USE_RATIONAL)
+  /* The class check is runtime, not compile-time, because mrbtest runs each
+     gem's tests in a state that initializes only its declared dependencies;
+     without Rational the quotient falls to the float arms, the same answer
+     Integer#quo gives there. */
+  if (mrb_type(rhs) != MRB_TT_COMPLEX) {
+    if (COMP_VALUE_P(self) && part_exact_type_p(rhs) &&
+        mrb_class_defined_id(mrb, MRB_SYM(Rational))) {
+      if (part_zero_p(mrb, rhs)) mrb_int_zerodiv(mrb);
+      return mrb_complex_new_value(mrb,
+                                   part_quo_scalar(mrb, part_real(mrb, self), rhs),
+                                   part_quo_scalar(mrb, part_imaginary(mrb, self), rhs));
+    }
+  }
+  else if (comp_div_exact_p(mrb, self, rhs) &&
+           mrb_class_defined_id(mrb, MRB_SYM(Rational))) {
+    return complex_div_exact(mrb, self, rhs);
+  }
+#endif
+  mrb_float ar = comp_float_real(mrb, self);
+  mrb_float ai = comp_float_imaginary(mrb, self);
   mrb_float r, den;
 
-  a = complex_ptr(mrb, self);
   if (mrb_type(rhs) != MRB_TT_COMPLEX) {
     if (mrb_integer_p(rhs) && mrb_integer(rhs) == 0) {
       mrb_int_zerodiv(mrb);
@@ -406,16 +804,14 @@ mrb_complex_div(mrb_state *mrb, mrb_value self, mrb_value rhs)
     if (f == 0.0) {
       mrb_int_zerodiv(mrb);
     }
-    return complex_new(mrb, mrb_div_float(a->real, f), mrb_div_float(a->imaginary, f));
+    return complex_new(mrb, mrb_div_float(ar, f), mrb_div_float(ai, f));
   }
 
-  b = complex_ptr(mrb, rhs);
-  if (b->real == 0 && b->imaginary == 0) {
+  mrb_float br = comp_float_real(mrb, rhs);
+  mrb_float bi = comp_float_imaginary(mrb, rhs);
+  if (br == 0 && bi == 0) {
     mrb_int_zerodiv(mrb);
   }
-
-  mrb_float br = b->real;
-  mrb_float bi = b->imaginary;
 
   if (F(fabs)(br) < DBL_MIN * F(fabs)(bi) && F(fabs)(bi) < DBL_MIN * F(fabs)(br)) {
     /* Fallback to frexp/ldexp for extreme values */
@@ -426,8 +822,8 @@ mrb_complex_div(mrb_state *mrb, mrb_value self, mrb_value rhs)
     struct float_pair ai_br_p, ar_bi_p;
     struct float_pair zr_p, zi_p;
 
-    ar_p.s = F(frexp)(a->real, &ar_p.x);
-    ai_p.s = F(frexp)(a->imaginary, &ai_p.x);
+    ar_p.s = F(frexp)(ar, &ar_p.x);
+    ai_p.s = F(frexp)(ai, &ai_p.x);
     br_p.s = F(frexp)(br, &br_p.x);
     bi_p.s = F(frexp)(bi, &bi_p.x);
 
@@ -452,12 +848,12 @@ mrb_complex_div(mrb_state *mrb, mrb_value self, mrb_value rhs)
     if (F(fabs)(br) > F(fabs)(bi)) {
       r = bi / br;
       den = br + r * bi;
-      return complex_new(mrb, (a->real + a->imaginary * r) / den, (a->imaginary - a->real * r) / den);
+      return complex_new(mrb, (ar + ai * r) / den, (ai - ar * r) / den);
     }
     else {
       r = br / bi;
       den = bi + r * br;
-      return complex_new(mrb, (a->real * r + a->imaginary) / den, (a->imaginary * r - a->real) / den);
+      return complex_new(mrb, (ar * r + ai) / den, (ai * r - ar) / den);
     }
   }
 }
@@ -467,8 +863,9 @@ mrb_complex_div(mrb_state *mrb, mrb_value self, mrb_value rhs)
  *   complex / numeric -> complex
  *   complex.quo(numeric) -> complex
  *
- * Returns the quotient of complex divided by numeric. Uses the standard
- * complex division formula by multiplying by the conjugate.
+ * Returns the quotient of complex divided by numeric. With no Float
+ * anywhere in it the quotient is exact; otherwise it divides with the
+ * standard float algorithm.
  *
  *   Complex(10, 5) / Complex(2, 1)  #=> (5+0i)
  *   Complex(6, 4) / 2               #=> (3+2i)
@@ -480,21 +877,68 @@ complex_div(mrb_state *mrb, mrb_value x)
   return mrb_complex_div(mrb, x, y);
 }
 
+#ifndef MRB_COMPLEX_FLOAT_ONLY
+/* One part's contribution to #hash.  Keyed by class as well as value, the
+   same distinction #eql? draws; both float zeros hash as one key because
+   0.0 and -0.0 are eql?. */
+static uint32_t
+part_hash32(mrb_state *mrb, mrb_value v)
+{
+  switch (mrb_type(v)) {
+  case MRB_TT_INTEGER:
+    {
+      mrb_int i = mrb_integer(v);
+      return mrb_byte_hash((uint8_t*)&i, sizeof(i));
+    }
+#ifdef MRB_USE_BIGINT
+  case MRB_TT_BIGINT:
+    return (uint32_t)mrb_integer(mrb_bint_hash(mrb, v));
+#endif
+#ifdef MRB_USE_RATIONAL
+  case MRB_TT_RATIONAL:
+    return (uint32_t)mrb_integer(mrb_rational_hash(mrb, v));
+#endif
+  default:
+    {
+      mrb_float f = mrb_float(v);
+      if (f == 0.0) f = 0.0;
+      return mrb_byte_hash((uint8_t*)&f, sizeof(f));
+    }
+  }
+}
+#endif
+
 /*
  * call-seq:
  *   complex.hash -> integer
  *
  * Returns a hash value for the complex number. Two complex numbers with
- * the same real and imaginary parts will have the same hash value.
+ * eql? parts will have the same hash value.
  *
  *   Complex(1, 2).hash == Complex(1, 2).hash  #=> true
  */
 static mrb_value
 complex_hash(mrb_state *mrb, mrb_value cpx)
 {
+  uint32_t hash;
+#ifndef MRB_COMPLEX_FLOAT_ONLY
+  if (COMP_VALUE_P(cpx)) {
+    struct mrb_complex *c = complex_ptr(mrb, cpx);
+    uint32_t hr = part_hash32(mrb, c->v.real);
+    uint32_t hi = part_hash32(mrb, c->v.imaginary);
+    hash = mrb_byte_hash((uint8_t*)&hr, sizeof(hr));
+    hash = mrb_byte_hash_step((uint8_t*)&hi, sizeof(hi), hash);
+    return mrb_int_value(mrb, hash);
+  }
+#endif
   struct mrb_complex *c = complex_ptr(mrb, cpx);
-  uint32_t hash = mrb_byte_hash((uint8_t*)&c->real, sizeof(mrb_float));
-  hash = mrb_byte_hash_step((uint8_t*)&c->imaginary, sizeof(mrb_float), hash);
+  /* -0.0 == 0.0, and Float#eql? agrees, so the two must hash alike */
+  mrb_float fr = c->f.real;
+  mrb_float fi = c->f.imaginary;
+  if (fr == 0.0) fr = 0.0;
+  if (fi == 0.0) fi = 0.0;
+  hash = mrb_byte_hash((uint8_t*)&fr, sizeof(mrb_float));
+  hash = mrb_byte_hash_step((uint8_t*)&fi, sizeof(mrb_float), hash);
   return mrb_int_value(mrb, hash);
 }
 
@@ -509,7 +953,42 @@ complex_hash(mrb_state *mrb, mrb_value cpx)
 static mrb_value
 nil_to_c(mrb_state *mrb, mrb_value self)
 {
+#ifdef MRB_COMPLEX_FLOAT_ONLY
   return complex_new(mrb, 0, 0);
+#else
+  return mrb_complex_new_value(mrb, mrb_fixnum_value(0), mrb_fixnum_value(0));
+#endif
+}
+
+static mrb_value
+complex_one(mrb_state *mrb)
+{
+#ifdef MRB_COMPLEX_FLOAT_ONLY
+  return complex_new(mrb, 1, 0);
+#else
+  return mrb_complex_new_value(mrb, mrb_fixnum_value(1), mrb_fixnum_value(0));
+#endif
+}
+
+/* Square-and-multiply, n >= 0.  Exact parts stay exact; float parts repeat
+   the same float multiply, which still beats the polar arm's transcendental
+   round trip: (1+2i)**2 is (-3+4i), not (-3+4.000000000000002i). */
+static mrb_value
+complex_pow_int(mrb_state *mrb, mrb_value x, mrb_int n)
+{
+  mrb_value r = complex_one(mrb);
+  mrb_value z = x;
+  int ai = mrb_gc_arena_save(mrb);
+
+  while (n > 0) {
+    if (n & 1) r = mrb_complex_mul(mrb, r, z);
+    n >>= 1;
+    if (n) z = mrb_complex_mul(mrb, z, z);
+    mrb_gc_arena_restore(mrb, ai);
+    mrb_gc_protect(mrb, r);
+    mrb_gc_protect(mrb, z);
+  }
+  return r;
 }
 
 /*
@@ -525,14 +1004,23 @@ static mrb_value
 complex_pow(mrb_state *mrb, mrb_value self)
 {
   mrb_value other = mrb_get_arg1(mrb);
-  struct mrb_complex *c_self = complex_ptr(mrb, self);
-  mrb_float self_real = c_self->real;
-  mrb_float self_imaginary = c_self->imaginary;
+
+  if (mrb_integer_p(other)) {
+    mrb_int n = mrb_integer(other);
+    if (n >= 0) return complex_pow_int(mrb, self, n);
+    /* -MRB_INT_MIN has no mrb_int negation; that one exponent answers its
+       magnitude-zero-or-infinity question in the polar arm below */
+    if (n != MRB_INT_MIN) {
+      return mrb_complex_div(mrb, complex_one(mrb), complex_pow_int(mrb, self, -n));
+    }
+  }
+
+  mrb_float self_real = comp_float_real(mrb, self);
+  mrb_float self_imaginary = comp_float_imaginary(mrb, self);
 
   if (mrb_type(other) == MRB_TT_COMPLEX) {
-    struct mrb_complex *c_other = complex_ptr(mrb, other);
-    mrb_float x = c_other->real;
-    mrb_float y = c_other->imaginary;
+    mrb_float x = comp_float_real(mrb, other);
+    mrb_float y = comp_float_imaginary(mrb, other);
 
     mrb_float log_abs_self = F(log)(F(hypot)(self_real, self_imaginary));
     mrb_float arg_self = F(atan2)(self_imaginary, self_real);
@@ -569,6 +1057,9 @@ static const mrb_mt_entry complex_rom_entries[] = {
   MRB_MT_ENTRY(complex_div,       MRB_OPSYM(div), MRB_ARGS_REQ(1)),
   MRB_MT_ENTRY(complex_div,       MRB_SYM(quo), MRB_ARGS_REQ(1)),
   MRB_MT_ENTRY(complex_eq,        MRB_OPSYM(eq), MRB_ARGS_REQ(1)),
+#ifndef MRB_COMPLEX_FLOAT_ONLY
+  MRB_MT_ENTRY(complex_eql,       MRB_SYM_Q(eql), MRB_ARGS_REQ(1)),
+#endif
   MRB_MT_ENTRY(complex_hash,      MRB_SYM(hash),   MRB_ARGS_NONE()),
   MRB_MT_ENTRY(complex_pow,       MRB_OPSYM(pow), MRB_ARGS_REQ(1)),
 };

--- a/mrbgems/mruby-complex/test/complex.rb
+++ b/mrbgems/mruby-complex/test/complex.rb
@@ -192,3 +192,134 @@ assert 'Complex#**' do
   assert_complex Complex(0, 1) ** 2, Complex(-1, 0)
   assert_complex Complex(0, 1) ** Complex(0, 1), Complex(Math::E ** (-Math::PI / 2), 0)
 end
+
+# An MRB_COMPLEX_FLOAT_ONLY build coerces every part through Float; the
+# tests below ask about exact parts, so each skips itself there. The probe
+# sits outside the assert helpers, as does the bigint one further down, so
+# no rescue inside a helper can swallow what it asks.
+complex_exact = Complex(1, 0).real.class == Integer
+
+assert 'Complex parts keep their class' do
+  skip "float-only build" unless complex_exact
+  assert_equal Integer, Complex(1, 2).real.class
+  assert_equal Integer, Complex(1, 2).imaginary.class
+  assert_equal [1, 2], Complex(1, 2).rectangular
+  assert_equal Float, Complex(1.5, 2).real.class
+  assert_equal Integer, Complex(1.5, 2).imaginary.class
+  assert_equal [1.5, 2.5], Complex(1.5, 2.5).rectangular
+  assert_equal [0, 0], nil.to_c.rectangular
+  assert_equal Integer, nil.to_c.real.class
+  assert_equal Integer, 1.to_c.real.class
+  assert_equal Integer, (-42.i).imaginary.class
+end
+
+assert 'Complex#to_s with exact parts' do
+  skip "float-only build" unless complex_exact
+  assert_equal "2+0i", Complex(2).to_s
+  assert_equal "-8+6i", Complex(-8, 6).to_s
+  assert_equal "1-2i", Complex(1, -2).to_s
+  assert_equal "0-42i", (-42.i).to_s
+  assert_equal "(2+0i)", Complex(2).inspect
+  assert_equal "(1-2i)", Complex(1, -2).inspect
+  assert_equal "2.0+2i", (Complex(1, 2) + 1.0).to_s
+end
+
+assert 'exact arithmetic keeps exact parts' do
+  skip "float-only build" unless complex_exact
+  c = Complex(1, 2) * Complex(3, 4)
+  assert_equal [-5, 10], c.rectangular
+  assert_equal Integer, c.real.class
+  c = Complex(1, 2) + Complex(3, 4)
+  assert_equal [4, 6], c.rectangular
+  assert_equal Integer, c.real.class
+  c = 2 - Complex(1, 2)
+  assert_equal [1, -2], c.rectangular
+  assert_equal Integer, c.real.class
+  c = 3 * Complex(1, 2)
+  assert_equal [3, 6], c.rectangular
+  assert_equal Integer, c.real.class
+end
+
+assert 'a real scalar touches only the part it lands on' do
+  skip "float-only build" unless complex_exact
+  c = Complex(1, 2) + 1.0
+  assert_equal Float, c.real.class
+  assert_equal Integer, c.imaginary.class
+  assert_equal [2.0, 2], c.rectangular
+  c = Complex(1, 2) - 1.0
+  assert_equal Integer, c.imaginary.class
+  c = Complex(1, 2) * 2.0
+  assert_equal Float, c.imaginary.class
+end
+
+assert 'Complex#** with an integer exponent is exact' do
+  skip "float-only build" unless complex_exact
+  c = Complex(1, 2) ** 2
+  assert_equal [-3, 4], c.rectangular
+  assert_equal Integer, c.real.class
+  c = Complex(1, 2) ** 0
+  assert_equal [1, 0], c.rectangular
+  assert_equal Integer, c.real.class
+end
+
+assert 'Complex#** with an integer exponent multiplies float parts exactly' do
+  c = Complex(1.0, 2.0) ** 2
+  assert_equal [-3.0, 4.0], c.rectangular
+  assert_equal Float, c.real.class
+end
+
+assert 'Complex#== converts across part classes' do
+  assert_true Complex(1, 2) == Complex(1.0, 2.0)
+  assert_true Complex(2, 0) == 2
+  assert_true Complex(2, 0) == 2.0
+  assert_false Complex(2, 1) == 2
+  assert_false Complex(1, 2) == Complex(2, 1)
+end
+
+assert 'Complex#eql? and #hash key by part class' do
+  skip "float-only build" unless complex_exact
+  assert_true Complex(1, 2).eql?(Complex(1, 2))
+  assert_false Complex(1, 2).eql?(Complex(1.0, 2.0))
+  assert_false Complex(1, 2).eql?(1)
+  assert_equal Complex(1, 2).hash, Complex(1, 2).hash
+  assert_equal Complex(1.0, 2.0).hash, Complex(1.0, 2.0).hash
+  assert_not_equal Complex(1, 2).hash, Complex(1.0, 2.0).hash
+end
+
+assert 'the two float zeros are one hash key' do
+  assert_equal Complex(1.0, 0.0).hash, Complex(1.0, -0.0).hash
+  assert_true Complex(1.0, 0.0).eql?(Complex(1.0, -0.0))
+end
+
+assert 'Complex#to_i and #to_f with exact parts' do
+  assert_equal 3, Complex(3, 0).to_i
+  assert_equal Integer, Complex(3, 0).to_i.class
+  assert_float 3.0, Complex(3, 0).to_f
+  assert_raise(RangeError) { Complex(3, 4).to_i }
+  assert_raise(RangeError) { Complex(3, 4).to_f }
+end
+
+assert 'Complex#abs2 with exact parts' do
+  skip "float-only build" unless complex_exact
+  assert_equal 1, Complex(-1).abs2
+  assert_equal Integer, Complex(-1).abs2.class
+  assert_float 25.0, Complex(3.0, -4.0).abs2
+end
+
+complex_test_bigint = begin
+  10 ** 20
+rescue RangeError
+  nil
+end
+
+assert 'Complex holds a Bigint part' do
+  skip "float-only build" unless complex_exact
+  skip "no bigint in this build" unless complex_test_bigint
+  big = complex_test_bigint
+  c = Complex(big, 0)
+  assert_equal big, c.real
+  assert_equal big * 2, (c * 2).real
+  assert_equal big + 1, (c + 1).real
+  assert_true c == big
+  assert_equal big, c.to_i
+end

--- a/mrbgems/mruby-rational/src/rational.c
+++ b/mrbgems/mruby-rational/src/rational.c
@@ -324,6 +324,30 @@ mrb_rational_new(mrb_state *mrb, mrb_int nume, mrb_int deno)
 
 #define rational_new_i(mrb,n,d) mrb_rational_new(mrb, n, d)
 
+/* (n/1) is the Integer n to the callers that hand a Rational back to the
+   rest of the tower, such as an exact Complex division; every other value
+   passes through untouched.  The denominator is 1 and not -1 or 0 here,
+   because both constructors move the sign onto the numerator and refuse a
+   zero denominator. */
+mrb_value
+mrb_rational_canonicalize(mrb_state *mrb, mrb_value x)
+{
+  if (mrb_type(x) != MRB_TT_RATIONAL) return x;
+  struct mrb_rational *p = rat_ptr(mrb, x);
+#ifdef RAT_BIGINT
+  if (RAT_BIGINT_P(x)) {
+    if (mrb_bint_cmp(mrb, mrb_obj_value(p->b.den), mrb_int_value(mrb, 1)) != 0) {
+      return x;
+    }
+    /* rational_new_b() demotes a half that fits an mrb_int, so a bigint
+       numerator beside a denominator of 1 is a value only a Bigint holds */
+    return mrb_obj_value(p->b.num);
+  }
+#endif
+  if (p->denominator != 1) return x;
+  return mrb_int_value(mrb, p->numerator);
+}
+
 #ifndef MRB_NO_FLOAT
 
 #if defined(MRB_INT32) || defined(MRB_USE_FLOAT32)
@@ -692,18 +716,17 @@ rational_eq_b(mrb_state *mrb, mrb_value x, mrb_value y)
  *   Rational(1, 2) == 0.5             #=> true
  *   Rational(1, 2) == Rational(1, 3)  #=> false
  */
-static mrb_value
-rational_eq(mrb_state *mrb, mrb_value x)
+mrb_bool
+mrb_rational_eq(mrb_state *mrb, mrb_value x, mrb_value y)
 {
-  mrb_value y = mrb_get_arg1(mrb);
 #ifdef RAT_BIGINT
-  if (RAT_BIGINT_P(x)) return rational_eq_b(mrb, x, y);
+  if (RAT_BIGINT_P(x)) return mrb_test(rational_eq_b(mrb, x, y));
   /* rational_eq_b() reads the bigint half of the union from its left operand
      only, so a bigint-backed right-hand side is answered by swapping the two.
      Equality is symmetric, and without the swap the MRB_TT_RATIONAL arm below
      reads y's `struct RBasic*` fields through the mrb_int half. */
   if (mrb_type(y) == MRB_TT_RATIONAL && RAT_BIGINT_P(y)) {
-    return rational_eq_b(mrb, y, x);
+    return mrb_test(rational_eq_b(mrb, y, x));
   }
 #endif
   struct mrb_rational *p1 = rat_ptr(mrb, x);
@@ -711,13 +734,13 @@ rational_eq(mrb_state *mrb, mrb_value x)
 
   switch (mrb_type(y)) {
   case MRB_TT_INTEGER:
-    if (p1->denominator != 1) return mrb_false_value();
+    if (p1->denominator != 1) return FALSE;
     result = p1->numerator == mrb_integer(y);
     break;
 #ifdef MRB_USE_BIGINT
   case MRB_TT_BIGINT:
     /* Non-bigint rational comparing with bigint */
-    if (p1->denominator != 1) return mrb_false_value();
+    if (p1->denominator != 1) return FALSE;
     result = mrb_bint_cmp(mrb, y, mrb_int_value(mrb, p1->numerator)) == 0;
     break;
 #endif
@@ -732,7 +755,7 @@ rational_eq(mrb_state *mrb, mrb_value x)
       mrb_int a, b;
 
       if (p1->numerator == p2->numerator && p1->denominator == p2->denominator) {
-        return mrb_true_value();
+        return TRUE;
       }
       if (mrb_int_mul_overflow(p1->numerator, p2->denominator, &a) ||
           mrb_int_mul_overflow(p2->numerator, p1->denominator, &b)) {
@@ -769,7 +792,13 @@ rational_eq(mrb_state *mrb, mrb_value x)
     result = mrb_equal(mrb, y, x);
     break;
   }
-  return mrb_bool_value(result);
+  return result;
+}
+
+static mrb_value
+rational_eq(mrb_state *mrb, mrb_value x)
+{
+  return mrb_bool_value(mrb_rational_eq(mrb, x, mrb_get_arg1(mrb)));
 }
 
 /*
@@ -1310,8 +1339,8 @@ rational_pow(mrb_state *mrb, mrb_value x)
  *
  *   Rational(1, 2).hash == Rational(2, 4).hash  #=> true
  */
-static mrb_value
-rational_hash(mrb_state *mrb, mrb_value rat)
+mrb_value
+mrb_rational_hash(mrb_state *mrb, mrb_value rat)
 {
   struct mrb_rational *r = rat_ptr(mrb, rat);
   uint32_t hash;
@@ -1460,7 +1489,7 @@ static const mrb_mt_entry rational_rom_entries[] = {
   MRB_MT_ENTRY(rational_div,         MRB_OPSYM(div), MRB_ARGS_REQ(1)),
   MRB_MT_ENTRY(rational_div,         MRB_SYM(quo), MRB_ARGS_REQ(1)),
   MRB_MT_ENTRY(rational_pow,         MRB_OPSYM(pow), MRB_ARGS_REQ(1)),
-  MRB_MT_ENTRY(rational_hash,        MRB_SYM(hash),     MRB_ARGS_NONE()),
+  MRB_MT_ENTRY(mrb_rational_hash,    MRB_SYM(hash),     MRB_ARGS_NONE()),
 #ifndef MRB_NO_FLOAT
   MRB_MT_ENTRY(mrb_rational_to_f,   MRB_SYM(to_f),     MRB_ARGS_NONE()),
 #endif

--- a/mrbgems/mruby-rational/src/rational.c
+++ b/mrbgems/mruby-rational/src/rational.c
@@ -912,7 +912,11 @@ mrb_rational_add(mrb_state *mrb, mrb_value x, mrb_value y)
 
 #if defined(MRB_USE_COMPLEX)
   case MRB_TT_COMPLEX:
+#ifdef MRB_COMPLEX_FLOAT_ONLY
     return mrb_complex_add(mrb, mrb_complex_new(mrb, rat_float(mrb, x), 0), y);
+#else
+    return mrb_complex_add(mrb, mrb_complex_new_value(mrb, x, mrb_fixnum_value(0)), y);
+#endif
 #endif
 
   default:
@@ -1008,7 +1012,11 @@ mrb_rational_sub(mrb_state *mrb, mrb_value x, mrb_value y)
 
 #if defined(MRB_USE_COMPLEX)
   case MRB_TT_COMPLEX:
+#ifdef MRB_COMPLEX_FLOAT_ONLY
     return mrb_complex_sub(mrb, mrb_complex_new(mrb, rat_float(mrb, x), 0), y);
+#else
+    return mrb_complex_sub(mrb, mrb_complex_new_value(mrb, x, mrb_fixnum_value(0)), y);
+#endif
 #endif
 
 #ifndef MRB_NO_FLOAT
@@ -1115,7 +1123,11 @@ mrb_rational_mul(mrb_state *mrb, mrb_value x, mrb_value y)
 
 #if defined(MRB_USE_COMPLEX)
   case MRB_TT_COMPLEX:
+#ifdef MRB_COMPLEX_FLOAT_ONLY
     return mrb_complex_mul(mrb, mrb_complex_new(mrb, rat_float(mrb, x), 0), y);
+#else
+    return mrb_complex_mul(mrb, mrb_complex_new_value(mrb, x, mrb_fixnum_value(0)), y);
+#endif
 #endif
 
   default:
@@ -1206,7 +1218,11 @@ mrb_rational_div(mrb_state *mrb, mrb_value x, mrb_value y)
 
 #ifdef MRB_USE_COMPLEX
   case MRB_TT_COMPLEX:
+#ifdef MRB_COMPLEX_FLOAT_ONLY
     return mrb_complex_div(mrb, mrb_complex_new(mrb, rat_float(mrb, x), 0), y);
+#else
+    return mrb_complex_div(mrb, mrb_complex_new_value(mrb, x, mrb_fixnum_value(0)), y);
+#endif
 #endif
 
 #ifndef MRB_NO_FLOAT

--- a/mrbgems/mruby-rational/src/rational.c
+++ b/mrbgems/mruby-rational/src/rational.c
@@ -551,6 +551,13 @@ rational_new(mrb_state *mrb, mrb_value a, mrb_value b)
     return rational_new_b(mrb, mrb_as_bint(mrb, a), b);
   }
 #endif
+  else if ((mrb_type(a) == MRB_TT_RATIONAL || mrb_type(b) == MRB_TT_RATIONAL) &&
+           !mrb_float_p(a) && !mrb_float_p(b)) {
+    /* Rational(a, b) is a/b, and with a Rational among exact operands the
+       quotient is exact; the Float arm below would round it through a
+       division of two doubles. */
+    return mrb_rational_div(mrb, mrb_as_rational(mrb, a), b);
+  }
   else {
     mrb_float x = mrb_as_float(mrb, a);
     mrb_float y = mrb_as_float(mrb, b);

--- a/mrbgems/mruby-rational/test/complex.rb
+++ b/mrbgems/mruby-rational/test/complex.rb
@@ -1,0 +1,88 @@
+# The exact-division path of mruby-complex answers in Rationals, so its
+# tests need both gems in the state. This gem test-depends on mruby-complex
+# wherever the build has a Float, which is the state these run in; the
+# complex gem cannot declare the mirror dependency without closing a cycle.
+# An MRB_COMPLEX_FLOAT_ONLY build has no exact parts to ask about, which is
+# what the second question detects.
+
+if Object.const_defined?(:Complex) && Complex(1, 0).real.class == Integer
+  assert 'Complex#/ is exact without a Float part' do
+    c = Complex(1, 2) / 2
+    assert_equal Rational(1, 2), c.real
+    assert_equal Rational, c.real.class
+    assert_equal 1, c.imaginary
+    assert_equal Integer, c.imaginary.class
+
+    c = Complex(9, 8) / 4
+    assert_equal Rational(9, 4), c.real
+    assert_equal 2, c.imaginary
+
+    c = Complex(1, 2) / Complex(3, 4)
+    assert_equal Rational(11, 25), c.real
+    assert_equal Rational(2, 25), c.imaginary
+
+    c = 1 / Complex(1, 2)
+    assert_equal Rational(1, 5), c.real
+    assert_equal Rational(-2, 5), c.imaginary
+
+    assert_raise(ZeroDivisionError) { Complex(1, 2) / 0 }
+    assert_raise(ZeroDivisionError) { Complex(1, 2) / Complex(0, 0) }
+  end
+
+  assert 'Complex#/ with a Float anywhere divides that part as a float' do
+    c = Complex(2.0, 2) / 2
+    assert_float 1.0, c.real
+    assert_equal Float, c.real.class
+    assert_equal 1, c.imaginary
+    assert_equal Integer, c.imaginary.class
+
+    c = Complex(1, 2) / 2.0
+    assert_equal Float, c.real.class
+    assert_float 0.5, c.real
+  end
+
+  assert 'Complex#** with a negative exponent is exact' do
+    c = Complex(1, 2) ** -2
+    assert_equal Rational(-3, 25), c.real
+    assert_equal Rational(-4, 25), c.imaginary
+  end
+
+  assert 'Complex holds a Rational part' do
+    c = Complex(Rational(1, 3), 0)
+    assert_equal Rational(1, 3), c.real
+    assert_equal "1/3+0i", c.to_s
+    assert_equal "((1/3)+0i)", c.inspect
+    assert_equal "(0+(1/2)*i)", Complex(0, Rational(1, 2)).inspect
+    assert_equal "(0-(1/2)*i)", Complex(0, Rational(-1, 2)).inspect
+    assert_equal "0-1/2i", Complex(0, Rational(-1, 2)).to_s
+  end
+
+  assert 'Complex#to_r keeps a Rational real part' do
+    assert_equal Rational(1, 3), Complex(Rational(1, 3), 0).to_r
+    assert_equal Rational(1, 1), Complex(1, 0).to_r
+  end
+
+  assert 'Complex#to_i truncates a Rational real part' do
+    assert_equal 3, Complex(Rational(7, 2), 0).to_i
+    assert_equal(-3, Complex(Rational(-7, 2), 0).to_i)
+  end
+
+  assert 'a Rational scalar touches only the part it lands on' do
+    c = Rational(1, 2) + Complex(1, 2)
+    assert_equal Rational(3, 2), c.real
+    assert_equal 2, c.imaginary
+    assert_equal Integer, c.imaginary.class
+
+    c = Complex(Rational(1, 2), 3) * 2
+    assert_equal Rational(1, 1), c.real
+    assert_equal 6, c.imaginary
+    assert_equal Integer, c.imaginary.class
+  end
+
+  assert 'Complex#== reaches a Rational part' do
+    assert_true Complex(Rational(1, 2), 0) == Rational(1, 2)
+    assert_true Complex(Rational(4, 2), 0) == 2
+    assert_true Complex(Rational(1, 2), 0) == 0.5
+    assert_false Complex(Rational(1, 2), 1) == Rational(1, 2)
+  end
+end

--- a/mrbgems/mruby-rational/test/rational.rb
+++ b/mrbgems/mruby-rational/test/rational.rb
@@ -629,3 +629,10 @@ assert 'Integer#quo' do
   a = 6.quo(5)
   assert_equal 6/5r, a
 end
+
+assert 'Kernel#Rational with a Rational operand stays exact' do
+  assert_equal Rational(1, 3), Rational(Rational(1, 3), 1)
+  assert_equal Rational(3, 2), Rational(Rational(1, 2), Rational(1, 3))
+  assert_equal Rational(3, 1), Rational(1, Rational(1, 3))
+  assert_equal Rational(1, 6), Rational(Rational(1, 3), 2)
+end

--- a/src/gc.c
+++ b/src/gc.c
@@ -1083,6 +1083,11 @@ gc_mark_children(mrb_state *mrb, mrb_gc *gc, struct RBasic *obj)
     children += mrb_rational_mark(mrb, obj);
     break;
 #endif
+#if defined(MRB_USE_COMPLEX) && !defined(MRB_COMPLEX_FLOAT_ONLY)
+  case MRB_TT_COMPLEX:
+    children += mrb_complex_mark(mrb, obj);
+    break;
+#endif
 #ifdef MRB_USE_SET
   case MRB_TT_SET:
     children += mrb_gc_mark_set(mrb, obj);
@@ -1117,7 +1122,8 @@ mrb_gc_mark(mrb_state *mrb, struct RBasic *obj)
 #ifdef MRB_USE_BIGINT
   case MRB_TT_BIGINT:
 #endif
-#ifdef MRB_USE_COMPLEX
+#if defined(MRB_USE_COMPLEX) && defined(MRB_COMPLEX_FLOAT_ONLY)
+  /* only a float-only complex is a leaf; otherwise a part may be an object */
   case MRB_TT_COMPLEX:
 #endif
     /* leaf types: no children besides class */
@@ -1250,7 +1256,7 @@ obj_free(mrb_state *mrb, struct RBasic *obj, mrb_bool end)
     break;
 #endif
 
-#if defined(MRB_USE_COMPLEX) && defined(MRB_32BIT) && !defined(MRB_USE_FLOAT32)
+#if defined(MRB_USE_COMPLEX) && defined(MRB_COMPLEX_INDIRECT)
   case MRB_TT_COMPLEX:
     {
       struct RData *o = (struct RData*)obj;

--- a/src/numeric.c
+++ b/src/numeric.c
@@ -265,7 +265,11 @@ int_div(mrb_state *mrb, mrb_value x)
 #endif
 #ifdef MRB_USE_COMPLEX
   case MRB_TT_COMPLEX:
+#ifdef MRB_COMPLEX_FLOAT_ONLY
     x = mrb_complex_new(mrb, mrb_as_float(mrb, x), 0);
+#else
+    x = mrb_complex_new_value(mrb, x, mrb_fixnum_value(0));
+#endif
     return mrb_complex_div(mrb, x, y);
 #endif
 #ifndef MRB_NO_FLOAT
@@ -1989,7 +1993,11 @@ mrb_int_sub(mrb_state *mrb, mrb_value x, mrb_value y)
 #endif
 #ifdef MRB_USE_COMPLEX
   case MRB_TT_COMPLEX:
+#ifdef MRB_COMPLEX_FLOAT_ONLY
     return mrb_complex_sub(mrb, mrb_complex_new(mrb, (mrb_float)a, 0), y);
+#else
+    return mrb_complex_sub(mrb, mrb_complex_new_value(mrb, mrb_int_value(mrb, a), mrb_fixnum_value(0)), y);
+#endif
 #endif
   default:
 #ifdef MRB_NO_FLOAT


### PR DESCRIPTION
## Summary

`struct mrb_complex` held two `mrb_float`, so whatever a part was on the way in, it was a double once stored. `Complex` was the one member of the numeric tower whose parts could not be a member of it: an Integer plus an Integer is an Integer, a Rational's numerator is an Integer, but there was no argument `a` for which `Complex(a, 0).real` answered in `a`'s class unless `a` was already a Float, and the gem's own documentation was written for the mapping it did not have. A `Complex` now holds the parts it was given; two Floats keep the exact layout and arithmetic they had, and `MRB_COMPLEX_FLOAT_ONLY` compiles the gem back to the old representation for builds that want it.

## Changes

| File | What |
|---|---|
| `mrbgems/mruby-complex/src/complex.c` | two-form storage, part-wise arithmetic over `mrb_num_*`, exact division, square-and-multiply `**`, `#eql?` and a class-keyed `#hash` |
| `mrbgems/mruby-complex/mrblib/complex.rb` | `#to_s` / `#inspect` strip the part's sign into the separator, `.polar` keeps the magnitude exact at the exact angles, `#fdiv` / `#to_r` follow the parts; the `#=>` examples now hold |
| `include/mruby/internal.h` | `MRB_COMPLEX_INDIRECT` as the one statement of where the parts live; declarations for the new entry points |
| `src/gc.c` | a value-form `Complex` marks its parts; the leaf case remains for `MRB_COMPLEX_FLOAT_ONLY` |
| `src/numeric.c` | Integer's Complex arms construct the exact form |
| `mrbgems/mruby-rational/src/rational.c` | `Kernel#Rational` keeps a Rational operand exact; `mrb_rational_eq()` / `mrb_rational_hash()` / `mrb_rational_canonicalize()` exported; Rational's Complex arms construct the exact form |
| `mrbgems/mruby-complex/test/complex.rb` | exact parts, part-wise scalars, exact `**`, `#eql?` / `#hash`, Bigint parts; each skips itself under `MRB_COMPLEX_FLOAT_ONLY` |
| `mrbgems/mruby-rational/test/complex.rb` | exact division, Rational parts, `#to_r`; the state that holds both gems |
| `mrbgems/mruby-rational/test/rational.rb` | `Kernel#Rational` with a Rational operand |
| `mrbgems/mruby-complex/README.md` | the exact-parts contract and the `MRB_COMPLEX_FLOAT_ONLY` switch |
| `mrbgems/mruby-complex/mrbgem.rake` | a note on where the rational-dependent tests live and why |

### Storage: the float pair stays, the value pair is the other half of a union

Two Float parts keep the two `mrb_float` of the old layout, bit for bit; any other pair from the tower is held as two `mrb_value` in the other half of a union, with one flag on the object saying which half is live. A float-only program allocates nothing it did not allocate before, on any boxing. Where the union no longer fits the object slot, which the two words of an unboxed `mrb_value` do not, the parts move behind the one pointer the gem already uses for doubles on 32-bit; that condition is `MRB_COMPLEX_INDIRECT` in internal.h, where `obj_free()` reads it too. A value-form `Complex` is no longer a collector leaf and marks its parts the way `mruby-rational` marks its Bigint halves.

### Arithmetic follows the parts

The dispatch already exists: `mrb_num_add()` and friends walk the tower as this build has it, so the four-product forms are four calls, an Integer overflow promotes or raises exactly as bare Integers do in that build, and no path calls back into Ruby. A real scalar is applied part-wise, so the part it does not land on keeps its class, the shape CRuby's `f_divide` and scalar arms have. Division quotients each part through `mrb_rational_div()` and `mrb_rational_canonicalize()` folds a `(n/1)` back to its Integer, only while no Float is anywhere in the operands; with one, or without mruby-rational in the state, the float arms answer as before. The mruby-rational check is a runtime class lookup rather than the compile-time define because mrbtest runs each gem's tests in a state that initializes only its declared dependencies.

An integer exponent is square-and-multiply. For exact parts that is exact; for float parts every step is the same float multiply the polar arm rounds through transcendentals, so `(1.0+2.0i) ** 2` is `(-3.0+4.0i)` where it was `(-3.0+4.000000000000002i)`.

### Rendering

`#to_s` keeps taking its separator from the rendered part, which carries the sign bit `<` cannot see on `-0.0` (#7386), and now strips that sign from the rendering, so `#inspect` can write a negative Rational part the way CRuby does: `Complex(0, Rational(-1, 2)).inspect` is `"(0-(1/2)*i)"`. The `*` marks a part whose rendering does not end in a digit, which is CRuby's rule and covers Infinity, NaN and Rationals alike. Stripping a character instead of negating matters once a part can be an Integer: `-INT_MIN` has no `mrb_int` to land in without bigint, and `#inspect` is no place to raise.

`Complex.polar` keeps the magnitude exact at the four angles whose sine and cosine are exact, following CRuby's `f_complex_polar_real`.

### `#eql?` and `#hash` key by part class

`==` converts across part classes, so `Complex(1, 2) == Complex(1.0, 2.0)`; `#eql?` must not, because a Hash key holds its class. `#eql?` now exists and matches part classes as well as values, `#hash` folds each part in by its class and value, and the two float zeros hash as the one key `#eql?` says they are.

### `MRB_COMPLEX_FLOAT_ONLY`

Defining it compiles the value half of the union away and coerces every part through Float on the way in, which is this gem's historical behavior, for builds that want the smaller arithmetic paths and have no use for exact parts. The exact-parts tests skip themselves there.

### `Kernel#Rational` lost a Rational on the way in

Separately from Complex, `Kernel#Rational` sent any operand pair outside Integer and Bigint through a division of two doubles, so `Rational(Rational(1, 3), 1)` answered `(6004799503160661/18014398509481984)`. A Rational among exact operands now routes through `mrb_rational_div()`, which is also what `Complex#to_r` needs to keep a Rational real part.

The rational-dependent Complex tests live in mruby-rational's test directory: that gem already test-depends on mruby-complex, and the mirror dependency would close a cycle in the gem sort.

## Behaviour

Rows measured against CRuby 4.0.6 (`03b6d3f889`):

| Expression | before | after | CRuby |
|---|---|---|---|
| `Complex(1, 2).real.class` | `Float` | `Integer` | `Integer` |
| `Complex(1, 2).rectangular` | `[1.0, 2.0]` | `[1, 2]` | `[1, 2]` |
| `Complex(1, 2).to_s` | `"1.0+2.0i"` | `"1+2i"` | `"1+2i"` |
| `Complex(1, 2) ** 2` | `(-3.0+4.000000000000002i)` | `(-3+4i)` | `(-3+4i)` |
| `Complex(1, 2) / 2` | `(0.5+1.0i)` | `((1/2)+1i)` | `((1/2)+1i)` |
| `1 / Complex(1, 2)` | `(0.2-0.4i)` | `((1/5)-(2/5)*i)` | `((1/5)-(2/5)*i)` |
| `Complex(10 ** 20, 0).real` | `1.0e+20` | `100000000000000000000` | `100000000000000000000` |
| `Complex(Rational(1, 3), 0).real` | `0.3333333333333333` | `(1/3)` | `(1/3)` |
| `Complex(1, 2) + 1.0` | `(2.0+2.0i)` | `(2.0+2i)` | `(2.0+2i)` |
| `Complex(1, 2).eql?(Complex(1.0, 2.0))` | `true` | `false` | `false` |

A differential list of some sixty expressions covering construction, the four operations, `**`, `==` / `#eql?` / `#hash`, conversions and rendering now answers byte-identically to CRuby. One difference is left deliberately: `Complex.polar(3)` answers `(3+0i)` here, where CRuby's one-argument form alone answers `(3+0.0i)` against its own documentation (`Complex.polar(3) # => (3+0i)` in CRuby's complex.c); the two-argument forms agree.

All ten `#=>` examples in `mrblib/complex.rb` that documented answers the storage could not hold, `Complex(2).inspect #=> "(2+0i)"` among them, now hold as written; the thirty-five documented examples in the file were audited against the built binary.

## Speed

Callgrind `Ir` on the default host build (clang `-O3`), a million iterations of a three-operation loop, an identical loop without the operations subtracted from each side; every count below was bit-identical across two runs.

Two float-form operands, `x * y; x + y; x / y`:

| | master | this PR | delta |
|---|---|---|---|
| Ir net of the empty loop | 2,387,626,521 | 2,455,484,732 | +2.84% |

That is +22.6 Ir per operation: the live-half tests on the operands, on a microloop that does nothing but complex arithmetic. The float arithmetic itself is byte-for-byte the old code.

Two Integer-constructed operands, `x * y; x + y`, which master flattened to floats and this branch keeps exact:

| | master (floats) | this PR (exact) | delta |
|---|---|---|---|
| Ir per operation net of the empty loop | 787.2 | 1,061.7 | +34.9% |

That is the price of the answers being exact rather than rounded; a build that wants the old arithmetic back has `MRB_COMPLEX_FLOAT_ONLY`.

## Size

`.text` of `bin/mruby` for the five `build_config/ci/gcc-clang.rb` builds, `size -A`, master and this branch built at the same path from empty build directories:

| Build | master | this PR | delta |
|---|---|---|---|
| `bintest` | 1,076,198 | 1,083,078 | +6,880 |
| `ascii-ctype` | 1,071,238 | 1,078,118 | +6,880 |
| `byte-string` | 1,051,286 | 1,058,166 | +6,880 |
| `cxx_abi` | 1,064,277 | 1,071,157 | +6,880 |
| `full-debug` (-O0) | 1,866,070 | 1,876,070 | +10,000 |

The four optimized builds move by the same 6,880 bytes, which is the whole machinery once. On the default host build only three objects move: `mrbgems/mruby-complex/src/complex.o` +5,910 (the value-form storage, dispatch and rendering support), `mrbgems/mruby-rational/src/rational.o` +83 (the exported helpers and the `Kernel#Rational` arm), `src/numeric.o` -16; the remainder of the binary's delta is link-stage padding. `src/gc.o` and `src/symbol.o` do not move, and the mrblib rendering rework lives in `gem_init.o`'s `.rodata` (+460), outside `.text`. `MRB_COMPLEX_FLOAT_ONLY` compiles the value half away for builds that keep the old representation.

## Testing

`rake -m test` is green on eleven configurations: the default host build, `MRB_COMPLEX_FLOAT_ONLY`, `MRB_NO_BOXING`, `MRB_NAN_BOXING`, `MRB_USE_FLOAT32`, `MRB_INT32`, a build holding mruby-complex without mruby-rational and bigint, and i686 builds for word boxing with doubles (the indirect layout), word boxing with `MRB_USE_FLOAT32` (the inline union), `MRB_NAN_BOXING`, and `MRB_NO_BOXING` with `MRB_INT64`, plus `MRB_COMPLEX_FLOAT_ONLY` with `MRB_NO_BOXING`. Each of the three commits is green on the full suite by itself. A GC pass over five thousand Complexes holding Bigint and Rational parts survives `GC.start` on the inline, indirect and unboxed layouts.

## Environment

<details>

- mruby master `c47c5a3eb` as the measuring base, word boxing unless stated
- Homebrew clang 22.1.8, Linux x86_64 (kernel 7.0.0-30-generic)
- i686 builds: `i686-linux-gnu-gcc` (Ubuntu 13.3.0)
- CRuby 4.0.6 (`03b6d3f889`) for every CRuby column
- valgrind callgrind for the Ir counts
- compile line (default host build, as run):

```
clang -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -ffile-prefix-map="<worktree>=." -ffile-prefix-map="<build>=./build" -DMRBGEM_MRUBY_COMPLEX_VERSION=0.0.0 -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK -I"<worktree>/include" -I"<build>/host/include" -o "<build>/host/mrbgems/mruby-complex/src/complex.o" "<worktree>/mrbgems/mruby-complex/src/complex.c"
```

</details>
