### PR TITLE
mruby-regexp: implement `\g` subexpression calls

### DIFF
--- a/mrbgems/mruby-regexp/README.md
+++ b/mrbgems/mruby-regexp/README.md
@@ -36,6 +36,13 @@ simulation) with backtracking fallback.
 - `\k<name>`, `\k'name'` named backreferences
 - `\k<n>`, `\k'n'` numbered backreferences
 - `\k<-n>`, `\k'-n'` relative backreferences
+- `\g<name>`, `\g'name'` subexpression calls: the group's sub-pattern runs
+  again where the call stands, recursively when the call stands inside it,
+  so `(?<p>\((?:[^()]|\g<p>)*\))` matches balanced parentheses. `\g<n>` is
+  absolute, `\g<-n>` counts back over the groups already opened, `\g<+n>`
+  counts forward, and `\g<0>` is the whole pattern. The recursion depth is
+  bounded at match time by `MRB_REGEXP_STACK_LIMIT`, the call frames living
+  on the backtracking stack it counts
 - `(?=...)` positive lookahead
 - `(?!...)` negative lookahead
 - `(?<=...)` positive lookbehind (fixed-length only)
@@ -171,14 +178,16 @@ $&, $`, $', $+, $1, $2, ...       # read from $~ at the moment they are read
 The gem uses two execution engines:
 
 **Pike VM (NFA simulation)**: Used for patterns without
-backreferences, non-greedy quantifiers, lookaround or atomic groups.
-Guarantees O(pattern x text) time complexity, making it immune to
-ReDoS attacks.
+backreferences, non-greedy quantifiers, lookaround, atomic groups or
+subexpression calls. Guarantees O(pattern x text) time complexity, making it
+immune to ReDoS attacks.
 
 **Backtracking engine**: Used when patterns contain `\1`-`\9`
 backreferences, non-greedy quantifiers (`*?`, `+?`, `??`),
-lookaround assertions (`(?=...)`, `(?!...)`, `(?<=...)`, `(?<!...)`)
-or atomic groups (`(?>...)`). It backtracks on a stack of its own on the
+lookaround assertions (`(?=...)`, `(?!...)`, `(?<=...)`, `(?<!...)`),
+atomic groups (`(?>...)`) or subexpression calls (`\g<name>`), whose call
+frames the Pike VM's threads have no stack to hold -- a call declines the
+Pike path the way a backreference does. It backtracks on a stack of its own on the
 heap, so a search spends a constant amount of C stack however long the
 subject is. Bounded by a configurable step limit (`MRB_REGEXP_STEP_LIMIT`,
 default 1M) against excessive backtracking and by a stack limit
@@ -221,19 +230,37 @@ pattern analysis.
   A collating element (`[[.a.]]`), an equivalence class (`[[=a=]]`) and a
   class nested in this one (`[[a][b]]`) each raise `RegexpError`. Write
   `[\[]` for the bracket itself, which is the spelling CRuby wants too.
-- **No `\G`, `\K`, `\R`, `\X` or `\g<name>`**: the search-start anchor, the
-  match-start reset, the linebreak, the grapheme cluster and the subexpression
-  call all raise `RegexpError` rather than standing for their own letter.
-  Inside a character class CRuby reads each as the letter, and so does this;
-  a bare `\g` is the letter either way.
+- **No `\G`, `\K`, `\R` or `\X`**: the search-start anchor, the match-start
+  reset, the linebreak and the grapheme cluster all raise `RegexpError`
+  rather than standing for their own letter. Inside a character class CRuby
+  reads each as the letter, and so does this; a bare `\g`, which calls a
+  group only with a `<name>` or `'name'` after it, is the letter either way.
 - **No nest level on a backreference**: `\k<name+n>` and `\k<name-n>` read the
-  group as the enclosing recursion left it `n` levels up, which goes with the
-  subexpression call above, so they raise `RegexpError` too. The level starts
-  at the first `+` or `-` past the name's first byte, in CRuby as here, which
-  leaves a group whose name holds one out of every reference's reach:
-  `(?<a-1>x)` names a group in both, and `\k<a-1>` reaches it in neither. The
-  first byte is the relative form's sign, so `\k<-1>` is still the group one
-  back.
+  group as the enclosing recursion left it `n` levels up, which asks for a
+  capture memory per call level where this engine keeps one flat slot per
+  group, so they raise `RegexpError`. A plain `\k<name>` still works inside a
+  recursion: it reads the pair the innermost completed invocation left, and
+  reads the group as unmatched inside an invocation no inner one has
+  completed within, which are CRuby's answers for the same shapes. The level
+  starts at the first `+`
+  or `-` past the name's first byte, in CRuby as here, which leaves a group
+  whose name holds one out of a backreference's reach: `(?<a-1>x)` names a
+  group in both, and `\k<a-1>` reaches it in neither, though `\g<a-1>`, a
+  call taking no level, reaches it in both. The first byte is the relative
+  form's sign, so `\k<-1>` is still the group one back.
+- **A call in a lookbehind must still be fixed-length**: `(?<=\g<a>)` runs
+  where the group's body is fixed-length, and raises the lookbehind's own
+  `lookbehind must be fixed length` where it is not -- recursion included --
+  where CRuby says `invalid pattern in look-behind`.
+- **An empty iteration ends a repeat around a call too**: an iteration that
+  matched empty ends the repetition and keeps what it captured, which is the
+  rule every inline repeat here follows, and a repeat whose body runs
+  through a called group follows it unchanged. Onigmo switches such repeats
+  to a capture-tracking empty check that can lose matches its own inline
+  rule finds: `/((?<g1>|){2}b){2}\g<g1>{0}/` answers nil in CRuby although
+  the dead call never runs, and `/(?<g1>)b\g<g1>{1,3}?/` answers nil where
+  its greedy spelling matches `"b"`. This engine answers every such pattern
+  as the call-free spelling does.
 - **No character class intersection**: `[a&&b]` narrows a class to what both
   sides hold in CRuby, and raises `RegexpError` here. A lone `&` is a member
   of the class, as it is in CRuby, and so is an escaped one: `[\&&]` holds

--- a/mrbgems/mruby-regexp/README.md
+++ b/mrbgems/mruby-regexp/README.md
@@ -40,9 +40,11 @@ simulation) with backtracking fallback.
   again where the call stands, recursively when the call stands inside it,
   so `(?<p>\((?:[^()]|\g<p>)*\))` matches balanced parentheses. `\g<n>` is
   absolute, `\g<-n>` counts back over the groups already opened, `\g<+n>`
-  counts forward, and `\g<0>` is the whole pattern. The recursion depth is
-  bounded at match time by `MRB_REGEXP_STACK_LIMIT`, the call frames living
-  on the backtracking stack it counts
+  counts forward, and `\g<0>` is the whole pattern. A recursion no input
+  could end (`(?<a>\g<a>)`, `(?<a>x\g<a>)`) raises `RegexpError` at compile
+  time, as in CRuby; the depth of one that can end is bounded at match time
+  by `MRB_REGEXP_STACK_LIMIT`, the call frames living on the backtracking
+  stack it counts
 - `(?=...)` positive lookahead
 - `(?!...)` negative lookahead
 - `(?<=...)` positive lookbehind (fixed-length only)

--- a/mrbgems/mruby-regexp/README.md
+++ b/mrbgems/mruby-regexp/README.md
@@ -42,9 +42,11 @@ simulation) with backtracking fallback.
   absolute, `\g<-n>` counts back over the groups already opened, `\g<+n>`
   counts forward, and `\g<0>` is the whole pattern. A recursion no input
   could end (`(?<a>\g<a>)`, `(?<a>x\g<a>)`) raises `RegexpError` at compile
-  time, as in CRuby; the depth of one that can end is bounded at match time
-  by `MRB_REGEXP_STACK_LIMIT`, the call frames living on the backtracking
-  stack it counts
+  time, as in CRuby; one that can end is bounded at match time by
+  `MRB_REGEXP_STACK_LIMIT`, which counts the calls open or completed along
+  the current path -- a completed call's frame and return marker stay on
+  the backtracking stack until backtracking removes them -- so a long flat
+  repetition of a call reaches the limit as a deep recursion does
 - `(?=...)` positive lookahead
 - `(?!...)` negative lookahead
 - `(?<=...)` positive lookbehind (fixed-length only)
@@ -251,9 +253,9 @@ pattern analysis.
   call taking no level, reaches it in both. The first byte is the relative
   form's sign, so `\k<-1>` is still the group one back.
 - **A call in a lookbehind must still be fixed-length**: `(?<=\g<a>)` runs
-  where the group's body is fixed-length, and raises the lookbehind's own
-  `lookbehind must be fixed length` where it is not -- recursion included --
-  where CRuby says `invalid pattern in look-behind`.
+  where the group's body is fixed-length, and where it is not -- recursion
+  included -- raises `invalid pattern in look-behind`, which is CRuby's
+  message for the same refusal.
 - **An empty iteration ends a repeat around a call too**: an iteration that
   matched empty ends the repetition and keeps what it captured, which is the
   rule every inline repeat here follows, and a repeat whose body runs

--- a/mrbgems/mruby-regexp/include/re_internal.h
+++ b/mrbgems/mruby-regexp/include/re_internal.h
@@ -68,6 +68,28 @@ enum re_opcode {
                         the text after the lookaround, which is where the
                         opener's `offset` points, so the opener finds its end
                         at offset - 1. */
+  RE_CALL,           /* run the body of group `a` again (\g<name>): offset =
+                        where the body starts. The executor pushes a frame
+                        holding where to go on when the body completes (pc + 1)
+                        and where the input stood, clears the group's end slot
+                        so the group reads as unmatched while the invocation
+                        is open, and jumps. The frame lives on the choice
+                        point stack, so backtracking past the call unwinds it
+                        with everything else and MRB_REGEXP_STACK_LIMIT is
+                        what bounds the call depth. Every entry into a called
+                        group's body is one of these, the inline occurrence
+                        included: resolve_calls() reroutes it through a
+                        trampoline appended after the pattern, so the body has
+                        one entry and one exit however it is reached. Until
+                        that pass runs, `offset` is not a code index but the
+                        parser's own bookkeeping, which is why this opcode is
+                        not in op_holds_code_index(). */
+  RE_RETURN          /* end of a called group's body: a = the group. Finds
+                        the topmost frame no return has answered yet, writes
+                        the group's capture pair from it -- the invocation
+                        that completes last is the one the pair names, as in
+                        CRuby -- leaves a marker in the frame's place and
+                        goes on where the frame says. */
 };
 
 /* Bytecode instruction (4 bytes each for alignment) */

--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -3229,7 +3229,195 @@ compute_first_set(const re_inst *code, uint32_t code_len,
    The parse leaves a pattern with \g in it unfinished in three ways: an
    RE_CALL may still carry a parked reference, no RE_CALL has anywhere to
    jump, and a lookbehind holding one is unmeasured. resolve_calls() finishes
-   all three. */
+   all three, and refuses the recursions no input could end. */
+
+/* One reachability walk over the finished code, from `start` down every
+   branch. The answer is the set of groups the walk reached a RE_CALL to, as
+   bits; with `reached_ret` given, whether it reached the RE_RETURN closing
+   `ret_group`'s body is answered there too. Three questions share the walk:
+
+   - consuming_stops on: which calls stand where no input need be consumed
+     first. What a call itself consumes is its body's minimum, so the walk
+     steps over one only when `pass_mask` holds the group -- the groups whose
+     body can complete consuming nothing, computed by fixpoint below. CRuby
+     counts the same way: `(?<g1>b\g<g1>??)$\g<0>?` compiles there because
+     the call to g1 consumes a `b` and \g<0> is never at the head, while
+     `(?<e>)(?<a>\g<e>\g<a>)` is refused because e's body is empty.
+   - consuming_stops off, look_forks on: which calls can run at all inside an
+     invocation, wherever they stand -- inside either branch of a fork, and
+     inside a lookaround of either polarity, whose sub-pattern runs whatever
+     its answer is used for.
+   - consuming_stops off, look_forks off, wall_mask set: whether an
+     invocation can complete without recursing. A lookaround is walked
+     through its sub-pattern alone, since the text after it is reached only
+     once the sub-pattern has run; a call into the recursion under test is a
+     wall, and reaching the body's own RE_RETURN is the escape.
+
+   A RE_RETURN ends every path: the walk has no call stack, and what follows
+   one belongs to whoever called. seen[] is marked with `mark` so one buffer
+   serves every walk; `stack` is the worklist, and code_len entries bound it
+   because a fork is pushed at most once. */
+static uint32_t
+call_walk(const re_inst *code, uint32_t code_len, uint32_t start,
+          uint32_t *seen, uint32_t mark, uint32_t *stack,
+          mrb_bool consuming_stops, mrb_bool look_forks, uint32_t wall_mask,
+          uint32_t pass_mask, uint16_t ret_group, mrb_bool *reached_ret)
+{
+  uint32_t mask = 0;
+  uint32_t top = 0;
+
+  if (reached_ret) *reached_ret = FALSE;
+  stack[top++] = start;
+  while (top > 0) {
+    uint32_t pc = stack[--top];
+    for (;;) {
+      if (pc >= code_len || seen[pc] == mark) break;
+      seen[pc] = mark;
+      re_inst in = code[pc];
+      switch (in.op) {
+      case RE_CHAR: case RE_CLASS: case RE_NCLASS: case RE_ANY: case RE_ANY_NL:
+        if (consuming_stops) break;
+        pc++;
+        continue;
+      case RE_SAVE:
+      case RE_BOL: case RE_EOL: case RE_BOT: case RE_EOT: case RE_EOTNL:
+      case RE_WBOUND: case RE_NWBOUND:
+      case RE_ATOMIC: case RE_ATOMIC_END:
+      case RE_BACKREF: case RE_LOOK_END:
+        pc++;
+        continue;
+      case RE_JMP:
+        pc = in.offset;
+        continue;
+      case RE_SPLIT: case RE_SPLITNG:
+        stack[top++] = in.offset;
+        pc++;
+        continue;
+      case RE_LOOKAHEAD: case RE_NEG_LOOKAHEAD:
+        if (look_forks) stack[top++] = in.offset;
+        pc++;
+        continue;
+      case RE_LOOKBEHIND: case RE_NEG_LOOKBEHIND:
+        if (look_forks) stack[top++] = in.offset;
+        pc += 2;  /* over the RE_LB_WIDTH carrier, into the sub-pattern */
+        continue;
+      case RE_CALL:
+        if ((wall_mask >> in.a) & 1) break;
+        mask |= (uint32_t)1 << in.a;
+        /* What stands after the call is reached only through what its body
+           consumes; a body that cannot complete at zero width ends this
+           path where a literal would. */
+        if (!((pass_mask >> in.a) & 1)) break;
+        pc++;
+        continue;
+      case RE_RETURN:
+        if (reached_ret && in.a == ret_group) *reached_ret = TRUE;
+        break;
+      default:  /* RE_MATCH */
+        break;
+      }
+      break;
+    }
+  }
+  return mask;
+}
+
+/* Close a 32-node call graph under reachability, in place. */
+static void
+call_closure(uint32_t *adj)
+{
+  for (;;) {
+    mrb_bool changed = FALSE;
+    for (int k = 0; k < RE_MAX_CAPTURES; k++) {
+      uint32_t reach = adj[k];
+      for (int m = 0; m < RE_MAX_CAPTURES; m++) {
+        if ((adj[k] >> m) & 1) reach |= adj[m];
+      }
+      if (reach != adj[k]) { adj[k] = reach; changed = TRUE; }
+    }
+    if (!changed) return;
+  }
+}
+
+/* Refuse the recursions no input could end, with CRuby's message and, as far
+   as the probes reach, CRuby's line. Two shapes are refused:
+
+   - a call cycle a walk reaches with nothing consumed on the way, wherever
+     the calls stand: `(?<a>\g<a>?x)` and `(?<a>x|\g<a>)` alike, since an
+     engine that takes them re-enters the body at the position it left.
+   - a group no invocation can complete without re-entering its own
+     recursion: `(?<a>x\g<a>)` must recurse to match at all, and so must
+     `x(?=\g<0>)`, whose lookahead is not an alternative but a requirement.
+
+   What escapes both is a call every path can decline: `(?<a>x\g<a>?)` and
+   the balanced-parentheses pattern this feature exists for. */
+static void
+never_ending_check(re_compiler *c, uint32_t called, const uint32_t *entry)
+{
+  uint32_t code_len = c->code_len;
+  const re_inst *code = c->pat->code;
+  uint32_t eps[RE_MAX_CAPTURES];   /* calls reached consuming nothing */
+  uint32_t any[RE_MAX_CAPTURES];   /* calls reached at all */
+  uint32_t mark = 0;
+  mrb_bool bad = FALSE;
+
+  /* One block: the seen marks and the walk's worklist. Freed before the
+     raise below, this frame being its only owner. */
+  uint32_t *buf = (uint32_t*)mrb_calloc(c->mrb, 2 * (size_t)code_len + 2,
+                                        sizeof(uint32_t));
+  uint32_t *seen = buf;
+  uint32_t *stack = buf + code_len + 1;
+
+  /* Which called bodies can complete consuming nothing, to fixpoint: a body
+     completing through a call needs that call's body to have completed the
+     same way, so the set starts empty and grows until it holds. This is what
+     prices a call in the head walk below at its body's minimum rather than
+     at zero. */
+  uint32_t eps_done = 0;
+  for (;;) {
+    uint32_t before = eps_done;
+    for (int k = 0; k < RE_MAX_CAPTURES; k++) {
+      if (!((called >> k) & 1) || ((eps_done >> k) & 1)) continue;
+      mrb_bool done;
+      call_walk(code, code_len, entry[k], seen, ++mark, stack,
+                TRUE, TRUE, 0, eps_done, (uint16_t)k, &done);
+      if (done) eps_done |= (uint32_t)1 << k;
+    }
+    if (eps_done == before) break;
+  }
+
+  memset(eps, 0, sizeof(eps));
+  memset(any, 0, sizeof(any));
+  for (int k = 0; k < RE_MAX_CAPTURES; k++) {
+    if (!((called >> k) & 1)) continue;
+    eps[k] = call_walk(code, code_len, entry[k], seen, ++mark, stack,
+                       TRUE, TRUE, 0, eps_done, (uint16_t)k, NULL);
+    any[k] = call_walk(code, code_len, entry[k], seen, ++mark, stack,
+                       FALSE, TRUE, 0, ~(uint32_t)0, (uint16_t)k, NULL);
+  }
+  call_closure(eps);
+  call_closure(any);
+
+  for (int k = 0; !bad && k < RE_MAX_CAPTURES; k++) {
+    if (((called >> k) & 1) && ((eps[k] >> k) & 1)) bad = TRUE;
+  }
+  for (int k = 0; !bad && k < RE_MAX_CAPTURES; k++) {
+    if (!((called >> k) & 1)) continue;
+    /* The walls are this group and everything a call chain leads back from:
+       a path that reaches one has re-entered the recursion under test. */
+    uint32_t wall = (uint32_t)1 << k;
+    for (int m = 0; m < RE_MAX_CAPTURES; m++) {
+      if ((any[m] >> k) & 1) wall |= (uint32_t)1 << m;
+    }
+    mrb_bool escapes;
+    call_walk(code, code_len, entry[k], seen, ++mark, stack,
+              FALSE, FALSE, wall, ~(uint32_t)0, (uint16_t)k, &escapes);
+    if (!escapes) bad = TRUE;
+  }
+
+  mrb_free(c->mrb, buf);
+  if (bad) compile_error(c, "never ending recursion");
+}
 
 /* Measure the lookbehinds whose sub-pattern holds a call, which the parse
    marked and left; see the lookbehind arm in compile_atom(). The walk is the
@@ -3257,8 +3445,8 @@ measure_deferred_lookbehinds(re_compiler *c)
 
 /* Finish what the \g arm left: resolve the parked references, give every
    called group's body its one entry and one exit, point every call at the
-   body it names, and measure the lookbehinds that waited. Runs once, after
-   the last instruction is emitted;
+   body it names, refuse the recursions no input could end, and measure the
+   lookbehinds that waited. Runs once, after the last instruction is emitted;
    nothing moves code after it, which is what lets RE_CALL carry a code index
    from here on (see op_holds_code_index()). */
 static void
@@ -3366,6 +3554,7 @@ resolve_calls(re_compiler *c)
     c->pat->code[pc].offset = (uint16_t)entry[c->pat->code[pc].a];
   }
 
+  never_ending_check(c, called, entry);
   measure_deferred_lookbehinds(c);
 }
 

--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -1580,7 +1580,8 @@ enum re_pending_kind {
 typedef struct {
   uint32_t src_off;   /* where the name, or the number's digits, start */
   uint32_t len;
-  uint32_t resolved;  /* RE_PENDING_NUM: the group number it spelled */
+  uint32_t resolved;  /* the group number it spelled (RE_PENDING_NUM) or the
+                         name resolved to (filled in by resolve_calls()) */
   uint8_t kind;
 } re_pending_call;
 
@@ -3452,39 +3453,38 @@ measure_deferred_lookbehinds(re_compiler *c)
 static void
 resolve_calls(re_compiler *c)
 {
-  const re_pending_call *pend = c->num_pending
-    ? (const re_pending_call*)RSTRING_PTR(c->pending_calls) : NULL;
+  re_pending_call *pend = c->num_pending
+    ? (re_pending_call*)RSTRING_PTR(c->pending_calls) : NULL;
   uint32_t entry[RE_MAX_CAPTURES];
   uint32_t called = 0;
   uint32_t parsed_len = c->code_len;
 
-  /* Resolve the parked references. A name is read against the whole
-     pattern's definitions: a group written after the call is reachable, a
-     name two groups carry is refused where the call reads it, as CRuby
-     refuses it, and a number past the groups open at the call is checked
-     against the count the finished pattern reached. Every group number here
-     is under RE_MAX_CAPTURES: the numeric forms are refused in a pattern
-     that demotes plain groups, so the count they were checked against is
-     the capture count. */
-  for (uint32_t pc = 0; pc < parsed_len; pc++) {
-    re_inst *in = &c->pat->code[pc];
-    if (in->op != RE_CALL || in->a != RE_CALL_PENDING) continue;
-    const re_pending_call *r = &pend[in->offset];
+  /* Resolve the parked references, every record and not only those an
+     instruction still carries: `{0}` drops a callless atom's code but not
+     its records, and CRuby refuses `(?:\g<nope>){0}` all the same. A name
+     is read against the whole pattern's definitions: a group written after
+     the call is reachable, a name two groups carry is refused where the
+     call reads it, as CRuby refuses it, and a number past the groups open
+     at the call is checked against the count the finished pattern reached.
+     Every group number here is under RE_MAX_CAPTURES: the numeric forms are
+     refused in a pattern that demotes plain groups, so the count they were
+     checked against is the capture count. */
+  for (uint16_t i = 0; i < c->num_pending; i++) {
+    re_pending_call *r = &pend[i];
     const char *at = c->src + r->src_off;
     if (r->kind == RE_PENDING_NUM) {
       if (r->resolved > c->num_groups) {
         compile_error_str(c, mrb_format(c->mrb, "undefined group <%l> reference",
                                         at, (size_t)r->len));
       }
-      in->a = (uint8_t)r->resolved;
     }
     else {
       int group = -1;
       int defs = 0;
-      for (uint16_t i = 0; i < c->num_named; i++) {
-        if (c->pat->named_captures[i].name_len == r->len &&
-            memcmp(c->pat->named_captures[i].name, at, r->len) == 0) {
-          group = c->pat->named_captures[i].group;
+      for (uint16_t n = 0; n < c->num_named; n++) {
+        if (c->pat->named_captures[n].name_len == r->len &&
+            memcmp(c->pat->named_captures[n].name, at, r->len) == 0) {
+          group = c->pat->named_captures[n].group;
           defs++;
         }
       }
@@ -3496,8 +3496,13 @@ resolve_calls(re_compiler *c)
         compile_error_str(c, mrb_format(c->mrb, "multiplex definition name <%l> call",
                                         at, (size_t)r->len));
       }
-      in->a = (uint8_t)group;
+      r->resolved = (uint32_t)group;
     }
+  }
+  for (uint32_t pc = 0; pc < parsed_len; pc++) {
+    re_inst *in = &c->pat->code[pc];
+    if (in->op != RE_CALL || in->a != RE_CALL_PENDING) continue;
+    in->a = (uint8_t)pend[in->offset].resolved;
     in->offset = 0;
   }
 

--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -10,6 +10,7 @@
 #include "re_internal.h"
 #include <mruby/error.h>
 #include <mruby/internal.h>
+#include <mruby/string.h>
 #include <string.h>
 
 /* Class IDs are stored in re_inst.a (uint8_t), so at most 256 distinct
@@ -77,6 +78,12 @@ typedef struct {
   uint32_t depth;           /* nesting levels open at the parse point, one per
                                compile_alt() frame on the C stack; bounded by
                                MRB_REGEXP_PARSE_DEPTH_LIMIT */
+  mrb_bool has_call;        /* a \g call was emitted: resolve_calls() runs */
+  mrb_value pending_calls;  /* the \g references the parse could not resolve,
+                               as re_pending_call records in a String the GC
+                               arena keeps for the compile; nil until the
+                               first one */
+  uint16_t num_pending;
 } re_compiler;
 
 static void compile_alt(re_compiler *c);  /* forward */
@@ -152,7 +159,10 @@ patch(re_compiler *c, uint32_t pos, uint16_t offset)
    pointing at whatever the shift left in its place.
    RE_LB_WIDTH is not here: it carries a character count in `a`, and RE_SAVE
    and RE_BACKREF put a slot number and a case-fold flag in `offset` rather
-   than an index. */
+   than an index. RE_CALL is not here either, deliberately: while the parse
+   runs, its `offset` is a pending-reference index that relocation would
+   corrupt, and by the time resolve_calls() writes a code index into it, the
+   last insertion has already happened. */
 static mrb_bool
 op_holds_code_index(uint8_t op)
 {
@@ -1274,13 +1284,19 @@ parse_quantifier(re_compiler *c, int *min_out, int *max_out, mrb_bool *ranged)
  * has no fixed width (quantifiers, alternation, etc.).
  */
 static int
-compute_fixed_len(re_compiler *c, uint32_t start, uint32_t end, int *chars_out)
+fixed_len_walk(re_compiler *c, uint32_t start, uint32_t end, int *chars_out, int depth)
 {
   int len = 0;
   int chars = 0;
   uint32_t pc = start;
 
-  while (pc < end) {
+  /* The walk runs to `end` rather than while it is below it, because a call
+     steps outside the span: an inline occurrence of a called group is a jump
+     to the trampoline after the pattern and a jump back. The bound below is
+     what keeps a walk that misses `end` finite; a cycle without RE_SPLIT does
+     not exist, and RE_SPLIT answers -1. */
+  while (pc != end) {
+    if (pc >= c->code_len) return -1;
     re_inst inst = c->pat->code[pc];
     switch (inst.op) {
     case RE_CHAR: {
@@ -1332,12 +1348,41 @@ compute_fixed_len(re_compiler *c, uint32_t start, uint32_t end, int *chars_out)
     case RE_LOOK_END:
       *chars_out = chars;
       return len;
+    case RE_CALL: {
+      /* The call runs the body it points at, so the body's measure is this
+         instruction's. The depth bound is what answers a recursive call:
+         distinct groups nest no deeper than there are groups, so a walk
+         past that is going round a cycle, which no fixed length fits --
+         CRuby refuses recursion in a lookbehind the same way. */
+      if (depth > RE_MAX_CAPTURES) return -1;
+      uint32_t body = inst.offset;
+      uint32_t close = body;
+      while (close < c->code_len &&
+             !(c->pat->code[close].op == RE_RETURN &&
+               c->pat->code[close].a == inst.a)) {
+        close++;
+      }
+      if (close >= c->code_len) return -1;
+      int sub_chars = 0;
+      int sub_len = fixed_len_walk(c, body, close, &sub_chars, depth + 1);
+      if (sub_len < 0) return -1;
+      len += sub_len;
+      chars += sub_chars;
+      pc++;
+      break;
+    }
     default:
       return -1;  /* unknown/variable-length instruction */
     }
   }
   *chars_out = chars;
   return len;
+}
+
+static int
+compute_fixed_len(re_compiler *c, uint32_t start, uint32_t end, int *chars_out)
+{
+  return fixed_len_walk(c, start, end, chars_out, 0);
 }
 
 /* Parse the option letters of an inline (?...) group. The parser is
@@ -1517,6 +1562,49 @@ emit_codepoint(re_compiler *c, uint32_t cp)
    number/name` for one within it that names no group. */
 #define RE_MAX_BACKREF_NUM 2147483647
 
+/* A \g reference the parse could not finish resolving: a name, which has to
+   wait for the definitions still to come, or a number past the groups open so
+   far, which CRuby takes when the pattern goes on to open enough. The
+   RE_CALL emitted for one carries RE_CALL_PENDING in `a` and this record's
+   index in `offset` until resolve_calls() rewrites it; RE_MAX_CAPTURES is 32,
+   so no resolved group ever wears the sentinel. What the record points into
+   is c->src, which outlives the parse, so a name is an offset and a length
+   rather than a copy. */
+#define RE_CALL_PENDING 255
+
+enum re_pending_kind {
+  RE_PENDING_NAME,  /* resolved against the named-capture table */
+  RE_PENDING_NUM    /* already a group number; checked against the count */
+};
+
+typedef struct {
+  uint32_t src_off;   /* where the name, or the number's digits, start */
+  uint32_t len;
+  uint32_t resolved;  /* RE_PENDING_NUM: the group number it spelled */
+  uint8_t kind;
+} re_pending_call;
+
+/* Park one reference. The records live in a String rather than a buffer this
+   frame owns, because the parse raises through longjmp and a raise must not
+   strand them: the GC arena holds the String for the length of the compile
+   and no longer, which is exactly the records' life. The count is bounded by
+   the instructions emitted, so it fits the uint16_t field that carries it. */
+static uint16_t
+add_pending_call(re_compiler *c, uint8_t kind, const char *at, uint32_t len,
+                 uint32_t resolved)
+{
+  re_pending_call rec;
+  if (mrb_nil_p(c->pending_calls)) {
+    c->pending_calls = mrb_str_new(c->mrb, NULL, 0);
+  }
+  rec.src_off = (uint32_t)(at - c->src);
+  rec.len = len;
+  rec.resolved = resolved;
+  rec.kind = kind;
+  mrb_str_cat(c->mrb, c->pending_calls, (const char*)&rec, sizeof(rec));
+  return c->num_pending++;
+}
+
 /* Compile the sub-pattern of a lookaround, whose opener has just been
    emitted, up to and including the RE_LOOK_END that closes it. The end
    carries the lookaround's number, from the count the atomic groups use, so
@@ -1592,18 +1680,32 @@ compile_atom(re_compiler *c)
           compile_look_body(c, negative);
           c->pat->code[lb_pos].offset = (uint16_t)c->code_len;
 
-          /* measure the sub-pattern for both rewind units */
-          int fixed_chars;
-          int fixed_len = compute_fixed_len(c, sub_start, c->code_len, &fixed_chars);
-          if (fixed_len < 0) {
-            compile_error(c, "invalid pattern in look-behind");
+          /* A sub-pattern holding a \g call cannot be measured yet: where
+             the call jumps is not decided until resolve_calls(), and the
+             body it runs may not be written yet. The RE_LB_WIDTH's spare
+             field marks the lookbehind for measure_deferred_lookbehinds(),
+             which runs the same walk once the calls are wired. */
+          mrb_bool deferred = FALSE;
+          for (uint32_t i = sub_start; i < c->code_len; i++) {
+            if (c->pat->code[i].op == RE_CALL) { deferred = TRUE; break; }
           }
-          if (fixed_len > 255) {
-            compile_error(c, "lookbehind too long (max 255 bytes)");
+          if (deferred) {
+            c->pat->code[lb_pos + 1].offset = 1;
           }
-          c->pat->code[lb_pos].a = (uint8_t)fixed_len;
-          /* the character count never exceeds the byte count, so it fits */
-          c->pat->code[lb_pos + 1].a = (uint8_t)fixed_chars;
+          else {
+            /* measure the sub-pattern for both rewind units */
+            int fixed_chars;
+            int fixed_len = compute_fixed_len(c, sub_start, c->code_len, &fixed_chars);
+            if (fixed_len < 0) {
+              compile_error(c, "invalid pattern in look-behind");
+            }
+            if (fixed_len > 255) {
+              compile_error(c, "lookbehind too long (max 255 bytes)");
+            }
+            c->pat->code[lb_pos].a = (uint8_t)fixed_len;
+            /* the character count never exceeds the byte count, so it fits */
+            c->pat->code[lb_pos + 1].a = (uint8_t)fixed_chars;
+          }
 
           if (peek(c) != ')') compile_error(c, "end pattern with unmatched parenthesis");
           next_char(c);
@@ -2036,11 +2138,138 @@ compile_atom(re_compiler *c)
     }
     else if (ch == 'g' && c->p + 1 < c->src_end &&
              (c->p[1] == '<' || c->p[1] == '\'')) {
-      /* `\g<name>` calls a group's sub-pattern again, which this engine does
-         not do. Left to the fall-through it was the letter `g` and the name
-         was literal text, so /(a)\g<1>/ matched "ag<1>" rather than "aa".
-         A bare `\g` is the letter in CRuby too, and stays one. */
-      compile_error(c, "subexpression call is not supported");
+      /* \g<name> / \g'name': run a group's sub-pattern again, from wherever
+         the call stands -- recursion when the call stands inside the group it
+         names. The numeric forms follow the \k family: \g<2> is absolute,
+         \g<-1> counts back over the groups already open, and \g<+1>, a form
+         \k has no use for, counts forward over the groups still to come.
+         \g<0> is the whole pattern. The name is read as a definition reads
+         one, signs included: there is no nest level on a call, so `\g<a-1>`
+         reaches the group `(?<a-1>x)` names, which the sign-cutting \k arm
+         above can never reach.
+
+         What is emitted here is one RE_CALL. Where it jumps to is not
+         decided now: the group it names may not be written yet, a name may
+         turn out to name two groups, and the body it runs has to be given
+         its one entry and one exit once the whole pattern is laid out. All
+         of that is resolve_calls(), after the parse; a reference it must
+         finish resolving is parked in c->pending_calls and the instruction
+         carries the parking slot until then. */
+      next_char(c);  /* skip g */
+      {
+        int close = (peek(c) == '<') ? '>' : '\'';
+        next_char(c);  /* skip < or ' */
+        const char *name = c->p;
+        while (peek(c) != close && peek(c) >= 0) {
+          /* The scan stops at a ')' from the second byte on, as every name
+             scan here does; the message quotes to the end of the pattern,
+             as CRuby does when its own scan never reached a delimiter. */
+          if (peek(c) == ')' && c->p > name) {
+            compile_error_str(c, mrb_format(c->mrb, "invalid group name <%l>",
+                                            name, (size_t)(c->src_end - name)));
+          }
+          next_char(c);
+        }
+        /* The end of the pattern ends the name the way a ')' does, and the
+           two failures are reported as the \k arm above reports them: a name
+           that never began is the empty one whether or not it was closed,
+           and one the pattern ends inside is quoted back as the malformed
+           name it is. */
+        if (c->p == name) compile_error(c, "group name is empty");
+        if (peek(c) != close) {
+          compile_error_str(c, mrb_format(c->mrb, "invalid group name <%l>",
+                                          name, (size_t)(c->p - name)));
+        }
+        uint32_t name_len = (uint32_t)(c->p - name);
+        if (!RE_NAME_LEN_FITS(name_len)) compile_error(c, "group name too long");
+        next_char(c);  /* skip the closing > or ' */
+
+        int group = -1;
+        uint16_t pend = 0;
+        mrb_bool pended = FALSE;
+        if (name[0] == '-' || name[0] == '+' ||
+            (name[0] >= '0' && name[0] <= '9')) {
+          mrb_bool back = (name[0] == '-');
+          uint32_t first = (back || name[0] == '+') ? 1 : 0;
+
+          /* As at \k: the whole name is read before it is converted, and a
+             lone sign is malformed. The message is CRuby's own for a call,
+             which differs from the one its backreferences get. */
+          mrb_bool numeric = (first < name_len);
+          for (uint32_t i = first; numeric && i < name_len; i++) {
+            if (name[i] < '0' || name[i] > '9') numeric = FALSE;
+          }
+          if (!numeric) {
+            compile_error_str(c, mrb_format(c->mrb, "invalid char in group name <%l>",
+                                            name, (size_t)name_len));
+          }
+
+          int n = 0;
+          for (uint32_t i = first; i < name_len; i++) {
+            int digit = name[i] - '0';
+            if (n > (RE_MAX_BACKREF_NUM - digit) / 10) compile_error(c, "too big number");
+            n = n * 10 + digit;
+          }
+
+          if (n == 0) {
+            /* `\g<0>` is the whole pattern, group 0, which even a named
+               pattern numbers; a signed zero names no group either way.
+               CRuby quotes `-0` as written and `+0` without its sign. */
+            if (first) {
+              compile_error_str(c, mrb_format(c->mrb, "invalid group name <%l>",
+                                              name + (back ? 0 : 1),
+                                              (size_t)(name_len - (back ? 0 : 1))));
+            }
+            group = 0;
+          }
+          else if (back) {
+            /* Backward-relative resolves against the groups already open,
+               exactly as \k<-n> does above, and for the same CRuby order:
+               the range is checked before a named pattern refuses the
+               numbered spelling. */
+            group = (int)c->num_groups + 1 - n;
+            if (group < 1) compile_error(c, "invalid backref number/name");
+            if (c->dont_capture) {
+              compile_error(c, "numbered backref/call is not allowed. (use name)");
+            }
+          }
+          else {
+            if (c->dont_capture) {
+              compile_error(c, "numbered backref/call is not allowed. (use name)");
+            }
+            /* Forward-relative counts on from the groups already open; the
+               absolute form is the number itself. Either may name a group
+               written later, so a number past the count so far is checked
+               against the whole pattern's count once the parse is done. The
+               digits are kept for that check's message, which quotes them
+               as written, sign dropped, as CRuby quotes a call's number. */
+            group = first ? (int)c->num_groups + n : n;
+            if (group > (int)c->num_groups) {
+              pend = add_pending_call(c, RE_PENDING_NUM, name + first,
+                                      name_len - first, (uint32_t)group);
+              pended = TRUE;
+            }
+          }
+        }
+        else {
+          /* A name resolves once the whole pattern is read: CRuby takes a
+             call to a group defined later, and a name two groups carry is
+             refused only where a call reads it, so even a name already
+             defined here has to wait for the definitions still to come. */
+          pend = add_pending_call(c, RE_PENDING_NAME, name, name_len, 0);
+          pended = TRUE;
+        }
+
+        if (pended) {
+          emit(c, RE_CALL, RE_CALL_PENDING, pend);
+        }
+        else {
+          /* group 0, or a group already open: 32 at most, so it fits `a` */
+          emit(c, RE_CALL, (uint8_t)group, 0);
+        }
+        c->has_call = TRUE;
+        c->needs_backtrack = TRUE;  /* the Pike VM has no call stack */
+      }
     }
     else if (ch == 'G' || ch == 'K' || ch == 'R' || ch == 'X') {
       /* Each of these means something in CRuby that this engine does not do:
@@ -2297,8 +2526,23 @@ compile_quantified(re_compiler *c)
     uint32_t atom_size = atom_end - start;
 
     if (min == 0 && max == 0) {
-      /* {0}: the atom matches zero times, so drop the copy we emitted. */
-      c->code_len = start;
+      /* {0}: the atom matches zero times. The copy we emitted is dropped --
+         except where it defines a capture group. CRuby erases only the
+         inline occurrence there: the group stays callable by \g, and \k
+         still reads it as a group that never matched rather than one that
+         does not exist, so the body is kept behind a jump instead. Nothing
+         inline reaches it; a call may. */
+      mrb_bool has_group = FALSE;
+      for (uint32_t i = start; i < atom_end; i++) {
+        if (c->pat->code[i].op == RE_SAVE) { has_group = TRUE; break; }
+      }
+      if (has_group) {
+        insert_inst(c, start, RE_JMP, 0, 0);
+        patch(c, start, (uint16_t)c->code_len);
+      }
+      else {
+        c->code_len = start;
+      }
     }
     else {
       /* {0,m} and {0,} compile as {1,m}/{1,} wrapped in an optional, so the
@@ -2807,6 +3051,13 @@ first_set_walk(const re_inst *code, uint32_t code_len,
     case RE_JMP:
       pc = code[pc].offset;
       continue;
+    case RE_CALL:
+      /* The body runs where the call stands, so its first bytes are the
+         call's. What follows a body that can complete without consuming is
+         unknown to this walk, which has no call stack; that path ends at
+         the body's RE_RETURN, whose default below answers FALSE. */
+      pc = code[pc].offset;
+      continue;
     case RE_SPLIT:
       /* both branches: pc+1 and offset */
       if (!first_set_walk(code, code_len, classes, code[pc].offset, bm, seen))
@@ -2853,14 +3104,23 @@ first_set_walk(const re_inst *code, uint32_t code_len,
    repetition that goal closes can complete an iteration without consuming.
    A lookaround is zero-width whatever its sub-pattern does, so the walk
    steps over the sub-pattern; a backreference to a group that captured
-   empty consumes nothing, so it can be on such a path. seen[] is marked with
-   `mark` rather than cleared, so one buffer serves every edge. */
+   empty consumes nothing, so it can be on such a path, and so can a call,
+   whose body may match empty. seen[] is marked with `mark` rather than
+   cleared, so one buffer serves every edge.
+
+   The walk is not bounded to [pc, goal]: an inline occurrence of a called
+   group jumps out to the trampoline after the pattern and back in, so a path
+   may stand past `goal` and still reach it. seen[] is what makes the walk
+   finite, and the answer stays conservative: what a stray path can add is a
+   mark on a loop whose body cannot in fact match empty, and a marked loop
+   whose iterations all consume never triggers the handling the mark turns
+   on. */
 static mrb_bool
-epsilon_path(const re_inst *code, uint32_t pc, uint32_t goal,
+epsilon_path(const re_inst *code, uint32_t code_len, uint32_t pc, uint32_t goal,
              uint32_t *seen, uint32_t mark)
 {
   while (pc != goal) {
-    if (pc > goal || seen[pc] == mark) return FALSE;
+    if (pc >= code_len || seen[pc] == mark) return FALSE;
     seen[pc] = mark;
     switch (code[pc].op) {
     case RE_SAVE:
@@ -2868,6 +3128,7 @@ epsilon_path(const re_inst *code, uint32_t pc, uint32_t goal,
     case RE_WBOUND: case RE_NWBOUND:
     case RE_ATOMIC: case RE_ATOMIC_END:
     case RE_BACKREF:
+    case RE_CALL:
       pc++;
       break;
     case RE_JMP:
@@ -2877,7 +3138,7 @@ epsilon_path(const re_inst *code, uint32_t pc, uint32_t goal,
       break;
     case RE_SPLIT:
     case RE_SPLITNG:
-      if (epsilon_path(code, code[pc].offset, goal, seen, mark)) return TRUE;
+      if (epsilon_path(code, code_len, code[pc].offset, goal, seen, mark)) return TRUE;
       pc++;
       break;
     default:
@@ -2912,10 +3173,20 @@ mark_empty_loops(mrb_state *mrb, re_inst *code, uint32_t code_len)
 
   for (uint32_t pc = 0; pc < code_len; pc++) {
     re_inst in = code[pc];
+    /* The parsed pattern ends at its RE_MATCH; what follows are the
+       trampolines resolve_calls() appended, whose jump back into a called
+       body is a backward edge but not a loop. Reading one as a loop close
+       was two defects in one: its "head" is whatever instruction the body
+       resumes after, whose fields mean something else entirely, so marking
+       it clobbered them, and the empty-iteration stop then resumed at that
+       instruction's `offset`, which for a backward SPLITNG is the body --
+       the repetition that was to stop re-entered instead, and grew the
+       stack to the limit. */
+    if (in.op == RE_MATCH) break;
     if (in.op != RE_JMP && in.op != RE_SPLIT && in.op != RE_SPLITNG) continue;
     code[pc].a = 0;                /* this pass owns `a` on the edge opcodes */
     if (in.offset > pc) continue;  /* forward edge: alternation, not a loop */
-    if (!epsilon_path(code, in.offset, pc, seen, ++mark)) continue;
+    if (!epsilon_path(code, code_len, in.offset, pc, seen, ++mark)) continue;
     code[pc].a = 1;
     if (in.op == RE_JMP) {
       /* The head was passed earlier in this scan, so its mark stays. */
@@ -2954,6 +3225,150 @@ compute_first_set(const re_inst *code, uint32_t code_len,
   return set_bits < 96;  /* useful only if fewer than 75% of bytes match */
 }
 
+/* ---- subexpression calls -------------------------------------------------
+   The parse leaves a pattern with \g in it unfinished in three ways: an
+   RE_CALL may still carry a parked reference, no RE_CALL has anywhere to
+   jump, and a lookbehind holding one is unmeasured. resolve_calls() finishes
+   all three. */
+
+/* Measure the lookbehinds whose sub-pattern holds a call, which the parse
+   marked and left; see the lookbehind arm in compile_atom(). The walk is the
+   parse's own, now able to follow a call. */
+static void
+measure_deferred_lookbehinds(re_compiler *c)
+{
+  for (uint32_t pc = 0; pc + 1 < c->code_len; pc++) {
+    re_inst in = c->pat->code[pc];
+    if (in.op != RE_LOOKBEHIND && in.op != RE_NEG_LOOKBEHIND) continue;
+    if (c->pat->code[pc + 1].offset != 1) continue;
+    int fixed_chars = 0;
+    int fixed_len = compute_fixed_len(c, pc + 2, in.offset, &fixed_chars);
+    if (fixed_len < 0) {
+      compile_error(c, "invalid pattern in look-behind");
+    }
+    if (fixed_len > 255) {
+      compile_error(c, "lookbehind too long (max 255 bytes)");
+    }
+    c->pat->code[pc].a = (uint8_t)fixed_len;
+    c->pat->code[pc + 1].a = (uint8_t)fixed_chars;
+    c->pat->code[pc + 1].offset = 0;
+  }
+}
+
+/* Finish what the \g arm left: resolve the parked references, give every
+   called group's body its one entry and one exit, point every call at the
+   body it names, and measure the lookbehinds that waited. Runs once, after
+   the last instruction is emitted;
+   nothing moves code after it, which is what lets RE_CALL carry a code index
+   from here on (see op_holds_code_index()). */
+static void
+resolve_calls(re_compiler *c)
+{
+  const re_pending_call *pend = c->num_pending
+    ? (const re_pending_call*)RSTRING_PTR(c->pending_calls) : NULL;
+  uint32_t entry[RE_MAX_CAPTURES];
+  uint32_t called = 0;
+  uint32_t parsed_len = c->code_len;
+
+  /* Resolve the parked references. A name is read against the whole
+     pattern's definitions: a group written after the call is reachable, a
+     name two groups carry is refused where the call reads it, as CRuby
+     refuses it, and a number past the groups open at the call is checked
+     against the count the finished pattern reached. Every group number here
+     is under RE_MAX_CAPTURES: the numeric forms are refused in a pattern
+     that demotes plain groups, so the count they were checked against is
+     the capture count. */
+  for (uint32_t pc = 0; pc < parsed_len; pc++) {
+    re_inst *in = &c->pat->code[pc];
+    if (in->op != RE_CALL || in->a != RE_CALL_PENDING) continue;
+    const re_pending_call *r = &pend[in->offset];
+    const char *at = c->src + r->src_off;
+    if (r->kind == RE_PENDING_NUM) {
+      if (r->resolved > c->num_groups) {
+        compile_error_str(c, mrb_format(c->mrb, "undefined group <%l> reference",
+                                        at, (size_t)r->len));
+      }
+      in->a = (uint8_t)r->resolved;
+    }
+    else {
+      int group = -1;
+      int defs = 0;
+      for (uint16_t i = 0; i < c->num_named; i++) {
+        if (c->pat->named_captures[i].name_len == r->len &&
+            memcmp(c->pat->named_captures[i].name, at, r->len) == 0) {
+          group = c->pat->named_captures[i].group;
+          defs++;
+        }
+      }
+      if (defs == 0) {
+        compile_error_str(c, mrb_format(c->mrb, "undefined name <%l> reference",
+                                        at, (size_t)r->len));
+      }
+      if (defs > 1) {
+        compile_error_str(c, mrb_format(c->mrb, "multiplex definition name <%l> call",
+                                        at, (size_t)r->len));
+      }
+      in->a = (uint8_t)group;
+    }
+    in->offset = 0;
+  }
+
+  for (uint32_t pc = 0; pc < parsed_len; pc++) {
+    if (c->pat->code[pc].op == RE_CALL) {
+      called |= (uint32_t)1 << c->pat->code[pc].a;
+    }
+  }
+
+  /* Reroute every copy of every called group's body through the call
+     machinery, so the body has one entry and one exit however it is reached.
+     The inline SAVE pair becomes a jump out to a trampoline appended after
+     the pattern and the RE_RETURN that jumps back, so nothing here moves an
+     instruction and no jump into or around the group needs relocating: a
+     repetition's back edge still lands where the group begins, which is now
+     the jump out, and takes the same path the first iteration took. A
+     quantifier that copied the body leaves several pairs; each copy gets its
+     own trampoline, and the calls all run the first, the slots being shared
+     among the copies anyway. */
+  memset(entry, 0, sizeof(entry));
+  for (uint32_t pc = 0; pc < parsed_len; pc++) {
+    re_inst in = c->pat->code[pc];
+    uint16_t k;
+    if (in.op != RE_SAVE || (in.offset & 1)) continue;
+    k = in.offset / 2;
+    if (!((called >> k) & 1)) continue;
+    /* This copy's close: spans of one group never nest, so the next close
+       slot of the same group is this copy's. */
+    uint32_t close = pc + 1;
+    while (close < parsed_len &&
+           !(c->pat->code[close].op == RE_SAVE &&
+             c->pat->code[close].offset == (uint16_t)(k * 2 + 1))) {
+      close++;
+    }
+    mrb_assert(close < parsed_len);
+    {
+      uint32_t tramp = c->code_len;
+      emit(c, RE_CALL, (uint8_t)k, 0);  /* the entry index lands below */
+      emit(c, RE_JMP, 0, (uint16_t)(close + 1));
+      c->pat->code[pc].op = RE_JMP;
+      c->pat->code[pc].a = 0;
+      c->pat->code[pc].offset = (uint16_t)tramp;
+      c->pat->code[close].op = RE_RETURN;
+      c->pat->code[close].a = (uint8_t)k;
+      c->pat->code[close].offset = 0;
+      if (entry[k] == 0) entry[k] = pc + 1;  /* never 0: pc 0 is group 0's open */
+    }
+  }
+
+  /* Point every call, the trampolines' own included, at the body it runs. */
+  for (uint32_t pc = 0; pc < c->code_len; pc++) {
+    if (c->pat->code[pc].op != RE_CALL) continue;
+    mrb_assert(entry[c->pat->code[pc].a] != 0);
+    c->pat->code[pc].offset = (uint16_t)entry[c->pat->code[pc].a];
+  }
+
+  measure_deferred_lookbehinds(c);
+}
+
 void
 mrb_re_compile(mrb_state *mrb, mrb_regexp_pattern *pat,
                const char *pattern, mrb_int len, uint32_t flags)
@@ -2965,6 +3380,7 @@ mrb_re_compile(mrb_state *mrb, mrb_regexp_pattern *pat,
   c.pat = pat;
   c.orig = pattern;
   c.orig_end = pattern + len;
+  c.pending_calls = mrb_nil_value();  /* a zero fill is not a nil mrb_value */
 
   /* Both things the pre-pass removes, a (?#...) group and a `#` comment,
      are spelled with a '#', so a pattern without one is parsed as written.
@@ -3009,6 +3425,10 @@ mrb_re_compile(mrb_state *mrb, mrb_regexp_pattern *pat,
   /* group 0 end */
   emit(&c, RE_SAVE, 0, 1);
   emit(&c, RE_MATCH, 0, 0);
+
+  /* A pattern with \g in it is finished by resolve_calls(), which appends
+     the trampolines after the RE_MATCH just emitted; see there. */
+  if (c.has_call) resolve_calls(&c);
 
   /* code_len is the last field written, at the end of this function: the
      Regexp has been holding this pattern since before the compile started,

--- a/mrbgems/mruby-regexp/src/re_exec.c
+++ b/mrbgems/mruby-regexp/src/re_exec.c
@@ -754,10 +754,25 @@ enum re_cp_kind {
                    popping; its end drops it and everything above it, which is
                    how an atomic group and a positive lookaround cut (see
                    RE_ATOMIC_END and RE_LOOK_END). */
-  RE_CP_NEG     /* the barrier of a negative lookaround, which is both: its
+  RE_CP_NEG,    /* the barrier of a negative lookaround, which is both: its
                    sub-pattern running out of alternatives is the assertion
                    holding, so reaching it resumes the text after the
                    lookaround, at the sp and pc it holds. */
+  RE_CP_CALL,   /* not a branch: a call frame, pushed where RE_CALL entered a
+                   group's body. `pc` is where the body's RE_RETURN goes on
+                   and `sp` is where the input stood, which is where the
+                   invocation's capture opens; `group` is the group, for the
+                   assert alone. Living on this stack is what makes a call
+                   backtrack-safe with no bookkeeping: a failure that goes
+                   back past the call pops the frame with everything above
+                   it, and MRB_REGEXP_STACK_LIMIT bounds the call depth by
+                   bounding the frames. */
+  RE_CP_RET     /* not a branch either: the mark RE_RETURN leaves in place of
+                   popping the frame it answered, which backtracking may
+                   still need. The next RE_RETURN's downward scan counts
+                   these against the frames it passes, so each return pairs
+                   with the innermost frame no return has answered yet, as
+                   Onigmo's STACK_RETURN counts its STK_RETURN marks. */
 };
 
 /* A choice point: an alternative the search has not tried yet, as where the
@@ -1313,6 +1328,68 @@ bt_match(bt_state *m, const char *sp, uint32_t pc)
       }
       break;
 
+    case RE_CALL:
+      {
+        /* The group's body is entered: a frame holds where its RE_RETURN
+           goes on and where the input stands, and the group's end slot is
+           cleared so the group reads as unmatched while the invocation is
+           open -- the same invalidation entering a group inline makes at
+           RE_SAVE, and what makes `(?<a>x|\k<a>y)\g<a>` read \k<a> as
+           unmatched inside the second invocation rather than as the first
+           invocation's text, which is CRuby's answer. The clear is logged,
+           so backtracking out of the call puts back what an earlier
+           invocation captured. */
+        int slot = inst.a * 2 + 1;
+        if (slot < ncap && (r = bt_log(m, &captures[slot], -1)) != BT_OK) return r;
+        if ((r = bt_push(m, sp, pc + 1, RE_CP_CALL, inst.a)) != BT_OK) return r;
+        pc = inst.offset;
+      }
+      break;
+
+    case RE_RETURN:
+      {
+        /* The invocation completed: find its frame -- the innermost one no
+           return has answered yet, the returns already made counting
+           against the frames they answered -- write the group's capture
+           pair from it, leave the mark, and go on where the frame says.
+           The pair is written whole here rather than half at entry: the
+           invocation that completes last is the one the capture names, as
+           in CRuby, where `(?<a>x)\g<a>` leaves the call's text and the
+           recursion this feature exists for leaves the outermost span. */
+        uint32_t i = m->cp_top;
+        uint32_t level = 0;
+        uint32_t idx = 0;
+        mrb_bool found = FALSE;
+        while (i > 0) {
+          i--;
+          if (m->cp[i].kind == RE_CP_RET) level++;
+          else if (m->cp[i].kind == RE_CP_CALL) {
+            if (level == 0) { idx = i; found = TRUE; break; }
+            level--;
+          }
+        }
+        if (!found) goto fail;  /* a compiled pattern always has the frame */
+        mrb_assert(m->cp[idx].group == inst.a);
+        /* Group 0 is the whole match, which may not close inside a
+           character; the same rule RE_SAVE applies to slot 1. */
+        if (inst.a == 0 && !binary && sp < str_end &&
+            mrb_re_char_interior_p(str, sp, str_end)) {
+          goto fail;
+        }
+        {
+          int slot = inst.a * 2;
+          if (slot + 1 >= ncap) goto fail;
+          if ((r = bt_log(m, &captures[slot], (int)(m->cp[idx].sp - str))) != BT_OK) return r;
+          if ((r = bt_log(m, &captures[slot + 1], (int)(sp - str))) != BT_OK) return r;
+        }
+        {
+          uint32_t ret = m->cp[idx].pc;
+          if ((r = bt_push(m, sp, 0, RE_CP_RET, inst.a)) != BT_OK) return r;
+          pc = ret;
+        }
+      }
+      break;
+
     default:
       goto fail;
     }
@@ -1334,8 +1411,10 @@ bt_match(bt_state *m, const char *sp, uint32_t pc)
          that group failing, and what is left to try is below it. A negative
          lookaround's is the exception: its sub-pattern having no match
          left is the assertion holding, and what it resumes is the text after
-         the lookaround. */
-      if (c.kind == RE_CP_BARRIER) continue;
+         the lookaround. A call frame and a return's mark are not branches
+         either: backtracking past a call is just the call unwinding, and
+         what is left to try is below them. */
+      if (c.kind == RE_CP_BARRIER || c.kind == RE_CP_CALL || c.kind == RE_CP_RET) continue;
       sp = c.sp;
       pc = c.pc;
       if (c.kind == RE_CP_ITER && (r = bt_iter_begin(m, c.group, sp)) != BT_OK) return r;

--- a/mrbgems/mruby-regexp/test/regexp_call.rb
+++ b/mrbgems/mruby-regexp/test/regexp_call.rb
@@ -248,9 +248,39 @@ assert("Regexp - the references a call refuses") do
   end
 end
 
+assert("Regexp - a recursion no input could end is refused") do
+  # the check is CRuby's, message and line: a call cycle reachable with
+  # nothing consumed, or a group no invocation completes without re-entering
+  msg = "never ending recursion"
+  assert_raise_with_message(RegexpError, "#{msg}: /(?<a>\\g<a>)/") do
+    Regexp.new("(?<a>\\g<a>)")
+  end
+  ["(?<a>x\\g<a>)",             # must recurse to match at all
+   "(?<a>x|\\g<a>)",            # reachable with nothing consumed
+   "(?<a>\\g<a>?x)",            # optional, but still at the head
+   "(?<a>x\\g<a>{1,2})",        # a lower bound of one is mandatory
+   "(?:(?<a>x\\g<a>))?",        # optional outside the group saves nothing
+   "(?<a>(?:\\g<a>)*)",         # the loop re-enters at the position it left
+   "(?<a>(?<b>\\g<a>)?)",       # through a nested group, still at the head
+   "(?<a>(?=\\g<a>)x)",         # a lookaround's sub-pattern runs at its head
+   "(?<a>(?!\\g<a>)x)",
+   "(?<a>x(?=\\g<a>))",         # and a positive one is not an alternative
+   "(?<a>x(?!\\g<a>))",
+   "(?<a>(?>\\g<a>))",
+   "(?<e>z)(?<a>\\g<e>\\g<a>)", # every path recurses, \g<e> escaping nothing
+   "(?<b>x?)(?<a>\\k<b>\\g<a>)", # a backreference's minimum is zero
+   "(?<a>^\\g<a>)",
+   "(?<a>\\g<b>)(?<b>\\g<a>)",  # mutual recursion counts the same
+   "\\g<0>",
+   "x(?=\\g<0>)",
+   "(?<a>x)\\g<0>"].each do |src|
+    assert_raise(RegexpError, src) { Regexp.new(src) }
+  end
+end
+
 assert("Regexp - the recursions an input can end compile") do
   need_backtracking_stack
-  # a call every path can decline ends when the input does
+  # a call every path can decline escapes both refusals
   assert_equal "xxx", "xxx".match(Regexp.new("(?<a>x\\g<a>?)"))[0]
   assert_equal "xxx", "xxx".match(Regexp.new("(?<a>x\\g<a>*)"))[0]
   assert_equal "x", "xx".match(Regexp.new("(?<a>x\\g<a>??)"))[0]
@@ -260,6 +290,13 @@ assert("Regexp - the recursions an input can end compile") do
   assert_equal "xx", "xx".match(Regexp.new("x\\g<0>*"))[0]
   assert_equal "xy", "xy".match(Regexp.new("(?<a>x(?:(?=\\g<a>)|y))"))[0]
   assert_equal "xx", "xx".match(Regexp.new("(?<a>(?>x)\\g<a>?)"))[0]
+
+  # a call on the way to a recursion prices in its body's minimum, so a call
+  # to a group that always consumes keeps what follows off the head:
+  # \g<0> here stands behind a's `b` and compiles, where a call to an
+  # empty-bodied group leaves the head reachable and is refused above
+  assert_nil Regexp.new("(?<a>b\\g<a>??)$\\g<0>?").match("bbaa")
+  assert_equal "b", "b".match(Regexp.new("(?<a>b\\g<a>??)\\g<0>?"))[0]
 end
 
 assert("Regexp - recursion depth is bounded by the stack limit") do

--- a/mrbgems/mruby-regexp/test/regexp_call.rb
+++ b/mrbgems/mruby-regexp/test/regexp_call.rb
@@ -131,6 +131,31 @@ assert("Regexp - {0} erases the inline occurrence and keeps the group") do
   assert_equal "x", "x".match(Regexp.new("(?:(?<a>x)){0}\\g<a>"))[0]
 end
 
+assert("Regexp - {0} erases a call's code but not its reference checks") do
+  # The reference a {0}-erased call spelled is still read against the whole
+  # pattern: CRuby refuses each of these, erased or not. No call survives to
+  # run, so no backtracking stack is asked for.
+  assert_raise_with_message(RegexpError,
+                            "undefined name <nope> reference: /(?:\\g<nope>){0}/") do
+    Regexp.new("(?:\\g<nope>){0}")
+  end
+  assert_raise_with_message(RegexpError,
+                            "undefined group <9> reference: /(?:\\g<+9>){0}/") do
+    Regexp.new("(?:\\g<+9>){0}")
+  end
+  assert_raise_with_message(RegexpError,
+                            "undefined group <2> reference: /(?:\\g<2>){0}(x)/") do
+    Regexp.new("(?:\\g<2>){0}(x)")
+  end
+  assert_raise_with_message(RegexpError,
+                            "multiplex definition name <a> call: /(?:\\g<a>){0}(?<a>x)(?<a>y)/") do
+    Regexp.new("(?:\\g<a>){0}(?<a>x)(?<a>y)")
+  end
+
+  # a reference the pattern does define stays fine erased
+  assert_equal "x", "x".match(Regexp.new("(?:\\g<a>){0}(?<a>x)"))[0]
+end
+
 assert("Regexp - {0} keeps a group \\k reads as never matched") do
   # No call machinery runs here, so no stack is asked for: the erased group
   # never matches, and a backreference to it fails, as in CRuby.

--- a/mrbgems/mruby-regexp/test/regexp_call.rb
+++ b/mrbgems/mruby-regexp/test/regexp_call.rb
@@ -1,0 +1,276 @@
+# Subexpression calls: \g<name>, \g'name', \g<n>, \g<-n>, \g<+n>, \g<0>.
+#
+# A call runs a group's sub-pattern again where the call stands, recursively
+# when the call stands inside the group it names. Every expectation here is
+# CRuby's answer (ruby 4.0.6) for the same pattern and subject; where a
+# message deliberately differs, the assertion says so.
+
+assert("Regexp - a call runs the group's sub-pattern again") do
+  need_backtracking_stack
+  assert_equal "cc", "cc".match(Regexp.new("(?<a>c)\\g<a>"))[0]
+  assert_equal "cc", "cc".match(Regexp.new("(?<a>c)\\g'a'"))[0]
+  assert_equal "cc", "cc".match(Regexp.new("(c)\\g<1>"))[0]
+  assert_equal "cc", "cc".match(Regexp.new("(c)\\g'1'"))[0]
+
+  # the relative forms count over the groups: -n back over those already
+  # opened, +n forward over those still to come
+  assert_equal "cc", "cc".match(Regexp.new("(c)\\g<-1>"))[0]
+  assert_equal "cc", "cc".match(Regexp.new("\\g<+1>(c)"))[0]
+  assert_equal "abb", "abb".match(Regexp.new("(a)\\g<+1>(b)"))[0]
+
+  # a call may name a group written later, as \1(a) may
+  assert_equal "cc", "cc".match(Regexp.new("\\g<1>(c)"))[0]
+  assert_equal "cc", "cc".match(Regexp.new("\\g<a>(?<a>c)"))[0]
+
+  # \g<0> is the whole pattern
+  assert_equal "aaa", "aaa".match(Regexp.new("a\\g<0>?"))[0]
+  assert_equal "aa", "aa".match(Regexp.new("a\\g'0'?"))[0]
+
+  # the body runs as compiled: an option scoped to it travels with it, and
+  # one in force at the call site does not reach into it
+  assert_equal "abAB", "abAB".match(Regexp.new("(?i:(?<a>ab))\\g<a>"))[0]
+  assert_nil Regexp.new("(?<a>ab)\\g<a>").match("abAB")
+  assert_equal "abAB", "abAB".match(Regexp.new("(?<a>ab)\\g<a>", "i"))[0]
+end
+
+assert("Regexp - recursion matches balanced text") do
+  need_backtracking_stack
+  re = Regexp.new("(?<p>\\((?:[^()]|\\g<p>)*\\))")
+  md = re.match("x(a(b))y")
+  assert_equal "(a(b))", md[0]
+  assert_equal "(a(b))", md[:p]
+  assert_equal "(a)", re.match("((a)")[0]
+  assert_nil re.match("((((")
+  assert_equal "(a)", re.match("))(a)((")[0]
+
+  # a multibyte body recurses like any other
+  assert_equal "ああ", "ああ".match(Regexp.new("(?<a>あ)\\g<a>"))[0]
+end
+
+assert("Regexp - the invocation that completes last names the capture") do
+  need_backtracking_stack
+  # a call's invocation completes after the inline one, so the capture is the
+  # call's text
+  md = Regexp.new("(?<a>x)\\g<a>").match("xx")
+  assert_equal "x", md[:a]
+  assert_equal 1, md.begin(:a)
+
+  # a recursion's outermost invocation completes last of all
+  md = Regexp.new("(?<p>\\((?:[^()]|\\g<p>)*\\))").match("(a(b))")
+  assert_equal "(a(b))", md[:p]
+  assert_equal 0, md.begin(:p)
+
+  # two sibling recursions: the second completes later
+  md = Regexp.new("(?<p>\\(\\g<p>?\\))\\g<p>").match("(())()")
+  assert_equal "()", md[:p]
+  assert_equal 4, md.begin(:p)
+
+  # a call that does not run leaves the capture the inline occurrence wrote
+  md = Regexp.new("(?<a>x)\\g<a>?y").match("xy")
+  assert_equal "x", md[:a]
+  assert_equal 0, md.begin(:a)
+
+  # a plain group inside the body captures per invocation, last write winning
+  md = Regexp.new("(?<p>\\((?<q>[a-z])?\\g<p>?\\))").match("((a))")
+  assert_equal "a", md[:q]
+  assert_equal 2, md.begin(:q)
+
+  # \g<0>'s outermost invocation is the whole match
+  md = Regexp.new("a\\g<0>?").match("aaa")
+  assert_equal "aaa", md[0]
+  assert_equal 0, md.begin(0)
+end
+
+assert("Regexp - what a backreference reads while an invocation is open") do
+  need_backtracking_stack
+  # entering an invocation invalidates the group, so \k inside the second
+  # invocation does not read what the first captured: the first branch fails
+  # and the second matches, as in CRuby
+  md = Regexp.new("(?<a>\\k<a>y|ab)z\\g<a>").match("abzaby")
+  assert_equal "abzab", md[0]
+  assert_equal 3, md.begin(:a)
+
+  # a completed inner invocation is readable inside the still-open outer one
+  md = Regexp.new("(?<p>\\(\\g<p>?\\k<p>?\\))").match("(()())")
+  assert_equal "(()())", md[0]
+
+  # and after the invocation closes, \k reads what it captured
+  assert_equal "xyy", "xyy".match(Regexp.new("(?<a>x|y)\\g<a>\\k<a>"))[0]
+end
+
+assert("Regexp - calls under quantifiers and copies of the body") do
+  need_backtracking_stack
+  # a quantified call re-enters the body per iteration
+  assert_equal "xxxy", "xxxy".match(Regexp.new("(?<a>x)(?:\\g<a>)*y"))[0]
+  assert_equal "xxx", "xxx".match(Regexp.new("(?<a>x)\\g<a>+"))[0]
+  assert_equal "xxxx", "xxxx".match(Regexp.new("(?<a>x)\\g<a>{2,3}"))[0]
+
+  # a body that can match empty ends the repetition rather than spinning
+  assert_equal "y", "y".match(Regexp.new("(?<a>x?)(?:\\g<a>)*y"))[0]
+
+  # a greedy repeat over the called group itself stops the same way: its
+  # back edge lands on the body's rerouted entry, and the trampoline's jump
+  # back must not be read as a loop of its own, which once re-entered the
+  # repetition on every empty iteration until the stack limit refused it
+  assert_equal "b", "b".match(Regexp.new("(?<a>|)+b\\g<a>"))[0]
+  assert_equal "b", "b".match(Regexp.new("(?<a>x?)+b\\g<a>"))[0]
+
+  # an interval copies the body; the copies stay one callable group
+  assert_equal "xxx", "xxx".match(Regexp.new("(?:(?<a>x)){2}\\g<a>"))[0]
+  assert_equal "(())", "(())".match(Regexp.new("(?<p>\\(\\g<p>{0,2}\\))"))[0]
+
+  # a possessive call cuts like any possessive atom
+  assert_nil Regexp.new("(?<a>x)\\g<a>*+x").match("xxx")
+  assert_nil Regexp.new("(?<a>x+)(?>\\g<a>)x").match("xxx")
+end
+
+assert("Regexp - {0} erases the inline occurrence and keeps the group") do
+  need_backtracking_stack
+  # CRuby keeps the body callable when {0} drops its inline occurrence
+  assert_equal "x", "x".match(Regexp.new("(?<a>x){0}\\g<a>"))[0]
+  assert_equal "x", "x".match(Regexp.new("(?:(?<a>x)){0}\\g<a>"))[0]
+end
+
+assert("Regexp - {0} keeps a group \\k reads as never matched") do
+  # No call machinery runs here, so no stack is asked for: the erased group
+  # never matches, and a backreference to it fails, as in CRuby.
+  assert_nil Regexp.new("(?<a>x){0}\\k<a>y").match("y")
+end
+
+assert("Regexp - calls and lookarounds") do
+  need_backtracking_stack
+  # a call inside a lookaround runs there
+  assert_equal "xx", "xx".match(Regexp.new("(?<a>x)(?=\\g<a>)x"))[0]
+  assert_equal "x", "xx".match(Regexp.new("(?<a>x)(?<=\\g<a>)"))[0]
+  assert_equal "x", "xy".match(Regexp.new("(?<a>x)(?!\\g<a>)"))[0]
+
+  # a group defined inside a lookaround is callable from outside it
+  assert_equal "x", "xx".match(Regexp.new("(?=(?<a>x))\\g<a>"))[0]
+  assert_equal "y", "yq".match(Regexp.new("(?!(?<a>y)z)\\g<a>"))[0]
+
+  # an anchor inside the body asserts against the real position
+  assert_equal "xy", "xy".match(Regexp.new("(?<a>^x)y\\g<a>?"))[0]
+end
+
+assert("Regexp - a call in a lookbehind must measure fixed") do
+  need_backtracking_stack
+  assert_equal "xy", "xy".match(Regexp.new("(?<a>xy)(?<=\\g<a>)"))[0]
+
+  # a variable-length or recursive body does not measure, and is refused as
+  # every unfixed lookbehind is, message and all as in CRuby
+  msg = "invalid pattern in look-behind"
+  assert_raise_with_message(RegexpError, "#{msg}: /(?<a>x+)(?<=\\g<a>)/") do
+    Regexp.new("(?<a>x+)(?<=\\g<a>)")
+  end
+  assert_raise_with_message(RegexpError, "#{msg}: /(?<p>\\(\\g<p>?\\))(?<=\\g<p>)/") do
+    Regexp.new("(?<p>\\(\\g<p>?\\))(?<=\\g<p>)")
+  end
+end
+
+assert("Regexp - the group numbering calls use") do
+  need_backtracking_stack
+  # a pattern that names a group demotes the plain ones from capturing, and
+  # the numbered call spellings are refused with them, \g<0> excepted
+  assert_equal "xyx", "xyx".match(Regexp.new("(?<a>x)(y)\\g<a>"))[0]
+  assert_equal "xyxy", "xyxy".match(Regexp.new("(?<a>x)y\\g<0>?"))[0]
+  msg = "numbered backref/call is not allowed. (use name)"
+  assert_raise_with_message(RegexpError, "#{msg}: /(?<a>x)(y)\\g<1>/") do
+    Regexp.new("(?<a>x)(y)\\g<1>")
+  end
+  ["(?<a>x)\\g<-1>", "(?<a>x)\\g<+1>(y)"].each do |src|
+    assert_raise(RegexpError, src) { Regexp.new(src) }
+  end
+
+  # a call does not open a group, so the numbers after it are unmoved
+  assert_equal "xxyy", "xxyy".match(Regexp.new("(x)\\g<1>(y)\\2"))[0]
+
+  # a call's name is read whole, signs included: a group whose name holds one
+  # is reachable by \g where \k's level cut puts it out of reach
+  assert_equal "xx", "xx".match(Regexp.new("(?<a-1>x)\\g<a-1>"))[0]
+end
+
+assert("Regexp - the references a call refuses") do
+  # every one of these is the parser or the resolver answering, so no
+  # backtracking stack is asked for
+  assert_raise_with_message(RegexpError, "undefined group <3> reference: /(a)\\g<3>/") do
+    Regexp.new("(a)\\g<3>")
+  end
+  assert_raise_with_message(RegexpError, "undefined group <5> reference: /(a)\\g<+5>/") do
+    Regexp.new("(a)\\g<+5>")
+  end
+  assert_raise_with_message(RegexpError, "undefined name <b> reference: /(?<a>x)\\g<b>/") do
+    Regexp.new("(?<a>x)\\g<b>")
+  end
+  assert_raise_with_message(RegexpError, "invalid backref number/name: /(a)\\g<-3>/") do
+    Regexp.new("(a)\\g<-3>")
+  end
+  assert_raise_with_message(RegexpError, "group name is empty: /(a)\\g<>/") do
+    Regexp.new("(a)\\g<>")
+  end
+  assert_raise_with_message(RegexpError, "too big number: /(a)\\g<99999999999999999999>/") do
+    Regexp.new("(a)\\g<99999999999999999999>")
+  end
+
+  # a number holding another character is CRuby's `invalid char in group
+  # name`, quoted as read where CRuby quotes to the end of the pattern
+  assert_raise_with_message(RegexpError, "invalid char in group name <1x>: /(a)\\g<1x>/") do
+    Regexp.new("(a)\\g<1x>")
+  end
+
+  # a signed zero names no group; CRuby quotes -0 as written and +0 without
+  # its sign
+  assert_raise_with_message(RegexpError, "invalid group name <-0>: /(a)\\g<-0>/") do
+    Regexp.new("(a)\\g<-0>")
+  end
+  assert_raise_with_message(RegexpError, "invalid group name <0>: /(a)\\g<+0>/") do
+    Regexp.new("(a)\\g<+0>")
+  end
+
+  # a name two groups carry is refused where a call reads it, and only there
+  assert_raise_with_message(RegexpError,
+                            "multiplex definition name <a> call: /(?<a>x)(?<a>y)\\g<a>/") do
+    Regexp.new("(?<a>x)(?<a>y)\\g<a>")
+  end
+  assert_equal "xy", "xy".match(Regexp.new("(?<a>x)(?<a>y)"))[0]
+
+  # the name scan is every other one's: a ')' past the first byte ends it
+  # with the name quoted to the end of the pattern, `>` included, which is
+  # CRuby's quote for a scan its delimiter never closed, and the end of the
+  # pattern ends the name the same way, quoted as read as the \k arm quotes
+  # one
+  assert_raise_with_message(RegexpError,
+                            "invalid group name <a)b>>: /(?<a>x)\\g<a)b>/") do
+    Regexp.new("(?<a>x)\\g<a)b>")
+  end
+  assert_raise_with_message(RegexpError,
+                            "invalid group name <a>: /(?<a>x)\\g<a/") do
+    Regexp.new("(?<a>x)\\g<a")
+  end
+end
+
+assert("Regexp - the recursions an input can end compile") do
+  need_backtracking_stack
+  # a call every path can decline ends when the input does
+  assert_equal "xxx", "xxx".match(Regexp.new("(?<a>x\\g<a>?)"))[0]
+  assert_equal "xxx", "xxx".match(Regexp.new("(?<a>x\\g<a>*)"))[0]
+  assert_equal "x", "xx".match(Regexp.new("(?<a>x\\g<a>??)"))[0]
+  assert_equal "xxy", "xxy".match(Regexp.new("(?<a>x\\g<a>|y)"))[0]
+  assert_equal "xx", "xx".match(Regexp.new("(?<a>(?:x\\g<a>)?)"))[0]
+  assert_equal "xyxy", "xyxy".match(Regexp.new("(?<a>x\\g<b>?)(?<b>y\\g<a>?)"))[0]
+  assert_equal "xx", "xx".match(Regexp.new("x\\g<0>*"))[0]
+  assert_equal "xy", "xy".match(Regexp.new("(?<a>x(?:(?=\\g<a>)|y))"))[0]
+  assert_equal "xx", "xx".match(Regexp.new("(?<a>(?>x)\\g<a>?)"))[0]
+end
+
+assert("Regexp - recursion depth is bounded by the stack limit") do
+  # every call frame is an entry on the backtracking stack, so a recursion
+  # deeper than MRB_REGEXP_STACK_LIMIT admits stops at the limit rather than
+  # running away; the test sizes its subject from the limit, and steps aside
+  # where that subject would be unreasonable to build
+  skip "stack limit too high to exercise" if Regexp::STACK_LIMIT > 100_000
+  depth = Regexp::STACK_LIMIT + 1
+  subject = ("(" * depth) + (")" * depth)
+  assert_raise(RegexpError) do
+    Regexp.new("(?<p>\\(\\g<p>?\\))").match(subject)
+  end
+end

--- a/mrbgems/mruby-regexp/test/regexp_syntax.rb
+++ b/mrbgems/mruby-regexp/test/regexp_syntax.rb
@@ -2224,10 +2224,10 @@ end
 assert("Regexp - a nest level on a \\k reference is refused") do
   need_backtracking_stack
   # `\k<name+n>` reads the group as the enclosing recursion left it n levels
-  # up, which goes with the `\g` subexpression call this engine refuses. Taking
-  # the sign into the name made each a name no group carried, so
-  # /(?<a>c)\k<a+0>/ raised `undefined name <a+0> reference` where CRuby
-  # matched "cc".
+  # up, which asks for a capture memory per call level that this engine's flat
+  # slots do not carry, `\g` calls themselves being supported. Taking the sign
+  # into the name made each a name no group carried, so /(?<a>c)\k<a+0>/
+  # raised `undefined name <a+0> reference` where CRuby matched "cc".
   msg = "backreference with nest level is not supported"
   assert_raise_with_message(RegexpError, "#{msg}: /(?<a>c)\\k<a+0>/") do
     Regexp.new("(?<a>c)\\k<a+0>")
@@ -2912,17 +2912,10 @@ end
 assert("Regexp - the escapes this engine does not carry are refused") do
   # Each means something in CRuby that this engine does not do, and as an
   # unknown escape each was simply its own letter: /\R/ matched an R rather
-  # than a newline, and /(a)\g<1>/ matched "ag<1>" rather than "aa".
+  # than a newline.
   assert_raise_with_message(RegexpError, "\\G is not supported: /\\G/") { Regexp.new("\\G") }
   assert_raise_with_message(RegexpError, "\\K is not supported: /a\\Kb/") { Regexp.new("a\\Kb") }
   ["\\R", "\\X", "x\\G", "\\K"].each do |src|
-    assert_raise(RegexpError, src) { Regexp.new(src) }
-  end
-  assert_raise_with_message(RegexpError,
-                            "subexpression call is not supported: /(a)\\g<1>/") do
-    Regexp.new("(a)\\g<1>")
-  end
-  ["(?<n>a)\\g<n>", "(a)\\g'1'", "\\g<0>"].each do |src|
     assert_raise(RegexpError, src) { Regexp.new(src) }
   end
 
@@ -2932,7 +2925,8 @@ assert("Regexp - the escapes this engine does not carry are refused") do
   assert_equal "X", "X"[/[\X]/]
   assert_equal "g", "g"[/[\g]/]
 
-  # and a bare `\g` is the letter outside one too
+  # and a bare `\g`, which calls a group only with a <name> or 'name' after
+  # it, is the letter outside one too
   assert_equal "g", "g"[/\g/]
 end
 


### PR DESCRIPTION
## Summary

`\g<name>` runs a group's sub-pattern again where the call stands, recursively when the call stands inside the group it names, which is what makes `(?<p>\((?:[^()]|\g<p>)*\))` match balanced parentheses. This engine has refused the escape since 2e7e38a80 closed the silent `g<name>`-as-text reading; this implements it, in every spelling CRuby takes: `\g<name>`, `\g'name'`, absolute `\g<n>`, relative `\g<-n>` and `\g<+n>`, and `\g<0>` for the whole pattern. A recursion no input could end is refused at compile time with CRuby's `never ending recursion`, and the depth of one that can end is bounded at match time by `MRB_REGEXP_STACK_LIMIT`.

## Changes

| File | What |
|---|---|
| `mrbgems/mruby-regexp/include/re_internal.h` | two opcodes: `RE_CALL` and `RE_RETURN` |
| `mrbgems/mruby-regexp/src/re_compile.c` | a `\g` arm beside the `\k` one; `resolve_calls()`, which finishes a pattern with calls in it after the parse; the never-ending check; `{0}` keeps a group's body; call-aware lookbehind measurement |
| `mrbgems/mruby-regexp/src/re_exec.c` | call frames and return marks on the backtracking engine's choice point stack |
| `mrbgems/mruby-regexp/test/regexp_call.rb` | the feature's tests, every expectation CRuby 4.0.6's answer |
| `mrbgems/mruby-regexp/test/regexp_syntax.rb` | the `\g` refusal rows come out of the refused-escapes block |
| `mrbgems/mruby-regexp/README.md` | `\g` moves from Limitations to Pattern Syntax |

### One entry, one exit

The parser emits one `RE_CALL` per reference and parks what it cannot resolve yet -- a name, which waits for the definitions still to come since CRuby takes `\g<a>(?<a>c)`, or a number past the groups open so far. After the parse, `resolve_calls()` resolves the parked references against the whole pattern (`undefined group <n> reference`, `undefined name <x> reference`, and `multiplex definition name <x> call` where two groups carry the name, as in CRuby), and then reroutes every copy of every called group's body through the call machinery: the inline `RE_SAVE` pair becomes a jump out to a trampoline appended after the pattern (`RE_CALL` plus a jump back) and the `RE_RETURN` that ends the body.

The rewiring moves no instruction, which is what makes it safe under everything the parser has already laid out: every jump into or around the group still lands where it did, and a repetition's back edge, which lands on the group's first instruction, takes the same path through the call machinery that the first iteration took. A quantifier that copied the body (`(?:(?<a>x)){2}`) leaves several pairs; each copy is rewired, and every call runs the first, the capture slots being shared among copies anyway.

### Frames on the stack the engine already has

At match time `RE_CALL` pushes a frame on the choice point stack, holding where the body's `RE_RETURN` goes on and where the input stood. Living there is what makes calls backtrack-safe with no bookkeeping of their own: a failure that goes back past the call pops the frame with everything above it, an atomic group's or lookaround's cut drops frames and their marks together, and `MRB_REGEXP_STACK_LIMIT` bounds the recursion depth by bounding the frames. `RE_RETURN` pairs with the innermost frame no return has answered yet, counting the marks earlier returns left, as Onigmo's `STACK_RETURN` counts its `STK_RETURN` entries.

The Pike VM declines patterns with calls the way it declines backreferences: its threads have no stack to hold a frame, so `RE_CALL` sets `needs_backtrack`.

### Captures and what `\k` sees

Both follow CRuby's observable answers. Entering an invocation clears the group's end slot, logged like every write, so a backreference inside the invocation reads the group as unmatched rather than as the previous invocation's text: `/(?<a>\k<a>y|ab)z\g<a>/` matches `"abzab"` out of `"abzaby"`, the `\k` branch failing in the second invocation. The pair is written whole at `RE_RETURN`, from the frame's position to the current one, so the invocation that completes last is the one the capture names: the call's text in `/(?<a>x)\g<a>/`, the outermost span in a recursion, and a completed inner invocation is readable inside the still-open outer one, `/(?<p>\(\g<p>?\k<p>?\))/` matching `"(()())"`.

### The recursions no input could end

`never_ending_check()` refuses two shapes on the compiled code, which between them reproduce CRuby's line on every pattern probed and on the fuzz corpora below: a call cycle reachable from a group's entry with nothing consumed on the way (`(?<a>\g<a>?x)`, `(?<a>x|\g<a>)` -- with a call on the way priced at its body's minimum, computed to fixpoint, so `(?<g1>b\g<g1>??)$\g<0>?` compiles as it does in CRuby while `(?<e>)(?<a>\g<e>\g<a>)` is refused), and a group no invocation can complete without re-entering its own recursion (`(?<a>x\g<a>)`, `(?<e>z)(?<a>\g<e>\g<a>)`, and `x(?=\g<0>)`, whose lookahead is a requirement rather than an alternative). What escapes both is a call every path can decline: `(?<a>x\g<a>?)`, `(?<a>x\g<a>|y)`, the balanced-parentheses pattern.

### Two edges that go with the feature

`{0}` used to drop the repeated atom's code; where that code defines a capture group the body is now kept behind a jump, since CRuby erases only the inline occurrence: `/(?<a>x){0}\g<a>/` matches `"x"` there, and `\k` still reads the group as one that never matched. And a lookbehind whose sub-pattern holds a call cannot be measured while the call is unresolved, so its measurement is deferred to after `resolve_calls()` and the walk follows calls into their bodies: `(?<a>xy)(?<=\g<a>)` measures and matches, a variable-length or recursive body is `invalid pattern in look-behind` as it is in CRuby.

## Behaviour

Every row run against CRuby 4.0.6 and both sides of this change.

| source | subject | master | this PR | CRuby 4.0.6 |
| --- | --- | --- | --- | --- |
| `(?<p>\((?:[^()]\|\g<p>)*\))` | `"x(a(b))y"` | `RegexpError: subexpression call is not supported` | `["(a(b))", "(a(b))"]` | same |
| `(?<a>c)\g<a>` | `"cc"` | same refusal | `["cc", "c"]`, `begin(:a)` 1 | same |
| `\g<a>(?<a>c)` | `"cc"` | same refusal | `["cc", "c"]` | same |
| `(c)\g<-1>` / `\g<+1>(c)` / `a\g<0>?` | `"cc"` / `"cc"` / `"aaa"` | same refusal | match | same |
| `(?<a>x){0}\g<a>` | `"x"` | same refusal | `["x", "x"]` | same |
| `(?<a>\k<a>y\|ab)z\g<a>` | `"abzaby"` | same refusal | `["abzab", "ab"]` | same |
| `(?<p>\(\g<p>?\k<p>?\))` | `"(()())"` | same refusal | `["(()())", "(()())"]` | same |
| `(?<a>xy)(?<=\g<a>)` | `"xy"` | same refusal | `["xy", "xy"]` | same |
| `(?<a>x+)(?<=\g<a>)` | -- | same refusal | `RegexpError: invalid pattern in look-behind` | same |
| `(?<a>\g<a>)` | -- | same refusal | `RegexpError: never ending recursion` | same |
| `(?<a>x)(y)\g<1>` | -- | same refusal | `RegexpError: numbered backref/call is not allowed. (use name)` | same |
| `(?<a>x)(?<a>y)\g<a>` | -- | same refusal | `RegexpError: multiplex definition name <a> call` | same |
| `(?<a>x)\g<a+1>` | -- | same refusal | `RegexpError: undefined name <a+1> reference` | same |
| `(a)\g<1x>` | -- | same refusal | `RegexpError: invalid char in group name <1x>` | `... name <1x>>` |
| `(?<p>\(\g<p>?\))` | 3,000 nested | same refusal | `RegexpError: stack limit over (MRB_REGEXP_STACK_LIMIT)` | matches |

The last two rows are deliberate differences. The malformed number quotes the name as read, where CRuby quotes to the end of the pattern, the quoting this engine already uses everywhere a name is quoted. And the recursion depth is the backtracking stack's: every call frame is an entry `MRB_REGEXP_STACK_LIMIT` counts, so the default 2048 answers about 340 nesting levels of the pattern above (300 in the tests' margin) and refuses deeper input with the limit's own error, where CRuby recurses on the machine stack. A build that wants deeper recursion raises the one knob that already bounds this engine's matching state.

One more difference is deliberate and is CRuby's own artifact rather than a rule of the feature. Onigmo switches its empty-iteration bookkeeping to a capture-tracking variant for any repeat whose body touches a called group, and that machinery loses matches its inline rule finds:

```ruby
/((?<g1>|){2}b){2}/ =~ "bb"            # both engines: "bb"
/((?<g1>|){2}b){2}\g<g1>{0}/ =~ "bb"   # CRuby: nil -- the dead call alone
                                       # this PR: "bb"
/(?<g1>)b\g<g1>{1,3}/ =~ "b"           # both: "b"
/(?<g1>)b\g<g1>{1,3}?/ =~ "b"          # CRuby: nil; this PR: "b"
```

A `\g<g1>{0}` that never runs changes what CRuby's `{2}` matches, and the lazy spelling of a satisfiable interval answers nil where the greedy one matches. This engine keeps the one empty-iteration rule it has always applied to inline repeats -- an iteration that matched empty ends the repetition and keeps what it captured -- for called bodies too, so every row above answers as the call-free spelling does. The fuzz runs below part from CRuby almost only on this family.

`\k<name+n>` nest levels stay refused: they ask for a capture memory per call level where this engine keeps one flat slot per group, and a plain `\k<name>` inside a recursion answers as CRuby's level 0 does.

## Speed

Patterns without calls compile and run through the same paths as before; the additions are two switch cases the old opcodes never reach and one flag test after the parse. Callgrind over a workload of eight call-free patterns (Pike and backtracker, literal, classes, captures, backreference, lookahead, `{0}`), 200 iterations each with the compile inside the loop, both runs per binary bit-identical:

| binary | Ir |
|---|---|
| master | 6,935,747 |
| this PR | 6,941,651 (+5,904, +0.09%) |

The delta is compile-time only -- under 4 instructions per compile across the 1,600 compiles the workload makes.

## Size

`.text` of `bin/mruby` for the five builds of `build_config/ci/gcc-clang.rb`, measured with `size -A` in a clean build directory at the same path.

| Build | master | This PR | Delta |
|---|---|---|---|
| `bintest` | 1,076,198 | 1,083,718 | +7,520 |
| `ascii-ctype` | 1,071,238 | 1,079,014 | +7,776 |
| `byte-string` | 1,051,286 | 1,059,286 | +8,000 |
| `cxx_abi` | 1,064,277 | 1,071,797 | +7,520 |
| `full-debug` (-O0) | 1,866,070 | 1,873,734 | +7,664 |

Every delta is `re_compile.o` plus `re_exec.o` to within alignment: the parse arm, the resolution and the analyses are about 6.6-6.9 KiB of `re_compile.o`, the two executor cases 0.7-1.3 KiB of `re_exec.o`.

## Testing

`rake -m test` green on the default build and over `build_config/ci/gcc-clang.rb`, all five builds:

```console
$ MRUBY_CONFIG=build_config/ci/gcc-clang.rb rake -m test
>>> Test full-debug <<<  Total: 2643  OK: 2636  KO: 0  Crash: 0  Skip: 7
>>> Test bintest <<<     Total: 2643  OK: 2628  KO: 0  Crash: 0  Skip: 15
>>> Test cxx_abi <<<     Total: 2643  OK: 2628  KO: 0  Crash: 0  Skip: 15
>>> Test byte-string <<< Total: 2562  OK: 2506  KO: 0  Crash: 0  Skip: 56
>>> Test ascii-ctype <<< Total: 2634  OK: 2618  KO: 0  Crash: 0  Skip: 16
```

Beside the test file, the change was checked against CRuby 4.0.6 differentially, three ways.

Two systematic corpora -- 100 patterns over the call forms, capture attribution, backreference visibility, quantified and copied bodies, lookarounds, possessive cuts and anchors crossed with 346 subjects, and 31 mutual-recursion and alternation shapes crossed with 1,108 subjects, about 68,000 (pattern, subject) pairs -- answered identically on every compile decision and every capture.

The reference corpus of this gem's differential harness (takumin/mruby's `regexp-differential-tool`, taught to draw calls for this), 21,222 cases pairing every group-sequence shape with every reference spelling, `-e` comparing the refusal messages: the feature moves 10,637 rows onto CRuby's answer, no row moves off it, and what remains apart is what was apart on master (the known quoting quirks) plus the rows the 31-capture ceiling refuses by design.

Randomized differential fuzzing over the harness's full feature mix, five configurations, about 130,000 (pattern, subject) pairs with master run alongside: no row where master agreed with CRuby moved off that agreement. The rows where this PR and CRuby part are the empty-iteration family documented above, recursion deeper than the stack limit, and patterns whose divergence master shows equally once their `\g` no longer stops the compile (`(((?<g2>)(\k<g2>b*+))\b)` parts from CRuby the same way on master today). Two engine defects this fuzzing caught were fixed and folded in: the trampoline's jump back read as a loop edge, and the head walk pricing every call at zero.

## Environment

<details>

- mruby `regexp-subexpression-call` on c47c5a3eb, `full-core` gembox
- clang 22.1.8, gcc 13.3.0 (cxx_abi link via `--gcc-install-dir`), Linux x86_64
- oracle: ruby 4.0.6 (2026-07-14 revision 03b6d3f889)
- compile line (bintest): `clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -ffile-prefix-map=... -DMRB_GC_FIXED_ARENA -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK -I include -I mrbgems/mruby-regexp/include`

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added recursive subexpression calls in regular expressions using named, numbered, relative, and whole-pattern references.
  - Added support for recursion across captures, backreferences, quantifiers, lookarounds, and multibyte input.
  - Preserved callable groups and references in additional repetition scenarios.

- **Bug Fixes**
  - Improved validation for malformed references, invalid recursion, lookbehind widths, and excessive recursion depth.
  - Updated non-fixed-length lookbehind errors to match CRuby behavior.

- **Documentation**
  - Clarified supported syntax, recursion behavior, stack limits, and unsupported nested capture references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->