### PR TITLE
vm.c: move `$~` into the owning scope

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -182,6 +182,11 @@ typedef struct {
   struct RProc *blk;
   mrb_value *stack;
   const mrb_code *pc;           /* current address on iseq of this proc */
+  struct RBasic *svar;          /* special variables of this frame's scope (CRuby's svar): a keyed
+                                   container (struct RSvar), NULL until a first non-nil write allocates
+                                   it. The core stores and marks it; each key's meaning belongs to
+                                   whoever registers the matching virtual global (see
+                                   mrb_vm_svar_get()) */
   union {
     struct REnv *env;
     struct RClass *target_class;

--- a/include/mruby.h
+++ b/include/mruby.h
@@ -186,7 +186,10 @@ typedef struct {
                                    container (struct RSvar), NULL until a first non-nil write allocates
                                    it. The core stores and marks it; each key's meaning belongs to
                                    whoever registers the matching virtual global (see
-                                   mrb_vm_svar_get()) */
+                                   mrb_vm_svar_get()). A frame with no scope of its own holds instead
+                                   the env of the scope it resolves to, the forward the same slot of an
+                                   escaped env carries (see mrb_svar_frame_container() in vm.c), which
+                                   is why the field is typed by what both are rather than by one */
   union {
     struct REnv *env;
     struct RClass *target_class;

--- a/include/mruby/internal.h
+++ b/include/mruby/internal.h
@@ -160,10 +160,62 @@ void mrb_gc_free_set(mrb_state *mrb, struct RBasic *set);
 size_t mrb_set_memsize(mrb_value);
 #endif
 
+/* One Ruby scope's special variables (CRuby's `struct vm_svar`): a plain
+ * container of MRB_SVAR_MAX slots, one per key of `enum mrb_svar_index`
+ * below, each holding any mrb_value. The container is an internal GC
+ * object so a frame and the env the scope escapes into can hold the same
+ * one, and it is allocated lazily, on the first non-nil write into a
+ * scope (svar_new() in vm.c), so a scope that never touches a special
+ * variable never carries one. The slots live outside the object because
+ * sizeof(mrb_value) varies with the boxing and RVALUE is sized tightly;
+ * gc.c marks them through the object and frees them with it. */
+struct RSvar {
+  MRB_OBJECT_HEADER;
+  mrb_value *slots;
+};
+
+/* The keys of a Ruby scope's special variables, CRuby's `enum
+ * vm_svar_index` with CRuby's numbering. Each scope holds one container of
+ * MRB_SVAR_MAX slots (allocated lazily, see mrb_vm_svar_set()), and each
+ * key names one slot in it. The namespace is owned by the core: a new
+ * special variable takes a new enumerator here, never a key minted at
+ * runtime, so a key means the same slot in every build and gem load order.
+ *
+ * This enum and the accessor pair below are core-internal rather than
+ * MRB_API: the namespace they index is not open to a key minted outside
+ * this file, so exposing them would freeze the container's representation
+ * and the scope-resolution rule without giving an out-of-tree caller
+ * anything a new key could not already do from `mrb_gv_define_virtual()`.
+ * A gem publishes a special variable by registering a virtual global whose
+ * get/set pair closes over its own key here, the way mruby-regexp keeps
+ * `$~`'s MatchData under MRB_SVAR_BACKREF. */
+enum mrb_svar_index {
+  MRB_SVAR_LASTLINE = 0,        /* $_ */
+  MRB_SVAR_BACKREF,             /* $~ */
+  MRB_SVAR_MAX
+};
+
+/* Reads one special-variable slot of the owning Ruby scope, resolved like
+ * CRuby's svar (a C frame reads through to the Ruby frame below it, a block
+ * shares its defining method's container, and a scope that returned keeps
+ * its container in its env, so a proc outliving it still reads the value).
+ * The core stores and marks the slots but gives them no meaning: a key's
+ * semantics belong to whoever pairs these accessors with a virtual global,
+ * the way mruby-regexp keeps `$~`'s MatchData under MRB_SVAR_BACKREF. */
+mrb_value mrb_vm_svar_get(mrb_state *mrb, enum mrb_svar_index key);
+
+/* Writes one special-variable slot of the owning Ruby scope. The slot holds
+ * any mrb_value, immediates included. Any richer contract, like
+ * mruby-regexp's TypeError for `$~ = <not a MatchData>`, belongs to the
+ * caller. The scope's container is allocated on the first non-nil write; a
+ * nil write into a scope that has none is dropped, nil being what a missing
+ * slot already reads as. */
+void mrb_vm_svar_set(mrb_state *mrb, enum mrb_svar_index key, mrb_value v);
+
 #ifdef MRUBY_PROC_H
-/* A closed env may carry one slot past its locals: the ground the special
- * variables of the scope the env escapes from live on, once the frame
- * that held them is gone.
+/* A closed env may carry one slot past its locals: the special-variable
+ * container of the scope the env escapes from, which mrb_env_detach()
+ * moves there and svar_owner() reads back.
  *
  * Whether the slot is there is not implied by the env being closed. struct
  * REnv, MRB_ENV_CLOSE() and MRB_ENV_SET_LEN() are public, and out-of-tree
@@ -179,10 +231,10 @@ size_t mrb_set_memsize(mrb_value);
  * The middle state is what out-of-tree code makes, and what the core's own
  * envs fall back to when there is no stack left to size (mrb_env_unshare()
  * out of memory, error.c's fault-time rewind). It reads as a scope holding
- * no special variables, and the first write that needs the slot grows
- * such an env into the third. So: every path that allocates or resizes a
- * stack with the slot goes through MRB_ENV_SVAR_STACK_SIZE() and sets the
- * flag, every path that reads or writes the slot goes through
+ * no container, and svar_slot_ensure() in vm.c grows it into the third on
+ * the first write that needs one. So: every path that allocates or resizes
+ * a stack with the slot goes through MRB_ENV_SVAR_STACK_SIZE() and sets
+ * the flag, every path that reads or writes the slot goes through
  * MRB_ENV_SVAR_SLOT() under MRB_ENV_SVAR_P(), and every path that drops
  * the stack clears the flag. All three take the number of locals, which is
  * MRB_ENV_LEN() once the env carries it.
@@ -201,6 +253,7 @@ struct RProc *mrb_closure_new(mrb_state*, const mrb_irep*);
 void mrb_proc_copy(mrb_state *mrb, struct RProc *a, const struct RProc *b);
 mrb_int mrb_proc_arity(const struct RProc *p);
 struct REnv *mrb_env_new(mrb_state *mrb, struct mrb_context *c, mrb_callinfo *ci, int nstacks, mrb_value *stack, struct RClass *tc);
+mrb_bool mrb_env_detach(mrb_state *mrb, struct REnv *e, struct RBasic *sv, mrb_bool noraise);
 void mrb_env_detach_all(mrb_state *mrb, struct mrb_context *c);
 void mrb_proc_merge_lvar(mrb_state *mrb, mrb_irep *irep, struct REnv *env, int num, const mrb_sym *lv, const mrb_value *stack);
 mrb_value mrb_proc_local_variables(mrb_state *mrb, const struct RProc *proc);

--- a/include/mruby/internal.h
+++ b/include/mruby/internal.h
@@ -237,11 +237,13 @@ void mrb_vm_svar_set(mrb_state *mrb, enum mrb_svar_index key, mrb_value v);
  * what out-of-tree code makes, and what the core's own envs fall back to
  * when there is no stack left to size (mrb_env_unshare() out of memory,
  * error.c's fault-time rewind). It reads as a scope holding no container,
- * and svar_slot_ensure() in vm.c grows it into the third state on the one
- * write that needs it: mrb_env_detach() installing a container or forward
- * at close time, svar_env_adopt_owner() adopting one just after, or
- * mrb_vm_svar_set()'s first non-nil write into a scope that outlived its
- * frame. So: every path that grows a stack into the slot goes through
+ * and grows into the third state on the one write that needs it:
+ * mrb_env_detach() sizes the closing allocation for the slot up front
+ * (env_unshare_with_svar() in vm.c) when it has a container or forward to
+ * install at close time; svar_env_adopt_owner() adopting one just after,
+ * or mrb_vm_svar_set()'s first non-nil write into a scope that outlived
+ * its frame, instead grow an already-closed env into it (svar_slot_ensure()
+ * in vm.c). So: every path that grows a stack into the slot goes through
  * MRB_ENV_SVAR_STACK_SIZE() and sets the flag, every path that reads or
  * writes the slot goes through MRB_ENV_SVAR_SLOT() under MRB_ENV_SVAR_P(),
  * and every path that drops the stack clears the flag. All three take the

--- a/include/mruby/internal.h
+++ b/include/mruby/internal.h
@@ -215,7 +215,10 @@ void mrb_vm_svar_set(mrb_state *mrb, enum mrb_svar_index key, mrb_value v);
 #ifdef MRUBY_PROC_H
 /* A closed env may carry one slot past its locals: the special-variable
  * container of the scope the env escapes from, which mrb_env_detach()
- * moves there and svar_owner() reads back.
+ * moves there and svar_owner() reads back, or, for a scope that holds no
+ * container of its own, the env of the scope below whose special variables
+ * it shares, which the same walk follows one hop further (CRuby's ep
+ * chain, and its own svar slot is polymorphic the same way).
  *
  * Whether the slot is there is not implied by the env being closed. struct
  * REnv, MRB_ENV_CLOSE() and MRB_ENV_SET_LEN() are public, and out-of-tree
@@ -254,7 +257,8 @@ void mrb_proc_copy(mrb_state *mrb, struct RProc *a, const struct RProc *b);
 mrb_int mrb_proc_arity(const struct RProc *p);
 struct REnv *mrb_env_new(mrb_state *mrb, struct mrb_context *c, mrb_callinfo *ci, int nstacks, mrb_value *stack, struct RClass *tc);
 mrb_bool mrb_env_detach(mrb_state *mrb, struct REnv *e, struct RBasic *sv, mrb_bool noraise);
-void mrb_env_detach_all(mrb_state *mrb, struct mrb_context *c);
+void mrb_env_detach_all(mrb_state *mrb, struct mrb_context *c, mrb_bool resolve);
+struct RBasic *mrb_svar_frame_container(struct mrb_context *c, mrb_callinfo *ci);
 void mrb_proc_merge_lvar(mrb_state *mrb, mrb_irep *irep, struct REnv *env, int num, const mrb_sym *lv, const mrb_value *stack);
 mrb_value mrb_proc_local_variables(mrb_state *mrb, const struct RProc *proc);
 const struct RProc *mrb_proc_get_caller(mrb_state *mrb, struct REnv **env);

--- a/include/mruby/internal.h
+++ b/include/mruby/internal.h
@@ -161,6 +161,42 @@ size_t mrb_set_memsize(mrb_value);
 #endif
 
 #ifdef MRUBY_PROC_H
+/* A closed env may carry one slot past its locals: the ground the special
+ * variables of the scope the env escapes from live on, once the frame
+ * that held them is gone.
+ *
+ * Whether the slot is there is not implied by the env being closed. struct
+ * REnv, MRB_ENV_CLOSE() and MRB_ENV_SET_LEN() are public, and out-of-tree
+ * code builds closed envs over a stack of exactly MRB_ENV_LEN() values, so
+ * reading one past the locals of any closed env runs off such an
+ * allocation. The flag below says it for the env instead, leaving three
+ * states:
+ *
+ *   on-stack                 ONSTACK_P, never SVAR_P; the stack is the VM's
+ *   closed, no slot         !ONSTACK_P, !SVAR_P; len values, or none at all
+ *   closed, with the slot   !ONSTACK_P,  SVAR_P; len + 1 values
+ *
+ * The middle state is what out-of-tree code makes, and what the core's own
+ * envs fall back to when there is no stack left to size (mrb_env_unshare()
+ * out of memory, error.c's fault-time rewind). It reads as a scope holding
+ * no special variables, and the first write that needs the slot grows
+ * such an env into the third. So: every path that allocates or resizes a
+ * stack with the slot goes through MRB_ENV_SVAR_STACK_SIZE() and sets the
+ * flag, every path that reads or writes the slot goes through
+ * MRB_ENV_SVAR_SLOT() under MRB_ENV_SVAR_P(), and every path that drops
+ * the stack clears the flag. All three take the number of locals, which is
+ * MRB_ENV_LEN() once the env carries it.
+ *
+ * Invariant, asserted where the core reads the slot: MRB_ENV_SVAR_P(e)
+ * implies e is closed, e->stack is non-NULL, and its allocation holds
+ * MRB_ENV_LEN(e) + 1 values. */
+#define MRB_ENV_SVAR_BIT 15
+#define MRB_ENV_SVAR_P(e) MRB_FLAG_CHECK((e)->flags, MRB_ENV_SVAR_BIT)
+#define MRB_ENV_SET_SVAR(e) MRB_FLAG_ON((e)->flags, MRB_ENV_SVAR_BIT)
+#define MRB_ENV_CLEAR_SVAR(e) MRB_FLAG_OFF((e)->flags, MRB_ENV_SVAR_BIT)
+#define MRB_ENV_SVAR_STACK_SIZE(len) (sizeof(mrb_value) * ((size_t)(len) + 1))
+#define MRB_ENV_SVAR_SLOT(stack, len) ((stack)[(len)])
+
 struct RProc *mrb_closure_new(mrb_state*, const mrb_irep*);
 void mrb_proc_copy(mrb_state *mrb, struct RProc *a, const struct RProc *b);
 mrb_int mrb_proc_arity(const struct RProc *p);

--- a/include/mruby/internal.h
+++ b/include/mruby/internal.h
@@ -231,16 +231,21 @@ void mrb_vm_svar_set(mrb_state *mrb, enum mrb_svar_index key, mrb_value v);
  *   closed, no slot         !ONSTACK_P, !SVAR_P; len values, or none at all
  *   closed, with the slot   !ONSTACK_P,  SVAR_P; len + 1 values
  *
- * The middle state is what out-of-tree code makes, and what the core's own
- * envs fall back to when there is no stack left to size (mrb_env_unshare()
- * out of memory, error.c's fault-time rewind). It reads as a scope holding
- * no container, and svar_slot_ensure() in vm.c grows it into the third on
- * the first write that needs one. So: every path that allocates or resizes
- * a stack with the slot goes through MRB_ENV_SVAR_STACK_SIZE() and sets
- * the flag, every path that reads or writes the slot goes through
- * MRB_ENV_SVAR_SLOT() under MRB_ENV_SVAR_P(), and every path that drops
- * the stack clears the flag. All three take the number of locals, which is
- * MRB_ENV_LEN() once the env carries it.
+ * The middle state is the ordinary way every scope closes: mrb_env_unshare()
+ * never asks for the extra value, so a closure escaping a scope that never
+ * held a container or a forward to install pays nothing for it. It is also
+ * what out-of-tree code makes, and what the core's own envs fall back to
+ * when there is no stack left to size (mrb_env_unshare() out of memory,
+ * error.c's fault-time rewind). It reads as a scope holding no container,
+ * and svar_slot_ensure() in vm.c grows it into the third state on the one
+ * write that needs it: mrb_env_detach() installing a container or forward
+ * at close time, svar_env_adopt_owner() adopting one just after, or
+ * mrb_vm_svar_set()'s first non-nil write into a scope that outlived its
+ * frame. So: every path that grows a stack into the slot goes through
+ * MRB_ENV_SVAR_STACK_SIZE() and sets the flag, every path that reads or
+ * writes the slot goes through MRB_ENV_SVAR_SLOT() under MRB_ENV_SVAR_P(),
+ * and every path that drops the stack clears the flag. All three take the
+ * number of locals, which is MRB_ENV_LEN() once the env carries it.
  *
  * Invariant, asserted where the core reads the slot: MRB_ENV_SVAR_P(e)
  * implies e is closed, e->stack is non-NULL, and its allocation holds

--- a/include/mruby/proc.h
+++ b/include/mruby/proc.h
@@ -30,13 +30,23 @@ struct REnv {
   mrb_sym mid;
 };
 
-/* flags (20bits): 1(ZERO):1(separate module):2(visibility):8(cioff/bidx):8(stack_len) */
+/* flags (20bits): 1(ZERO):1(separate module):2(visibility):1(unused):7(bidx):8(stack_len)
+ * The block argument index needs seven bits at most: it counts one for the
+ * receiver, at most 14 positional arguments (15 meaning a packed array,
+ * worth one) and at most 28 for 14 keyword pairs (15 meaning a packed
+ * hash, worth one), so 43. */
 #define MRB_ENV_SET_LEN(e,len) ((e)->flags = (((e)->flags & ~0xff)|((unsigned int)(len) & 0xff)))
 #define MRB_ENV_LEN(e) ((mrb_int)((e)->flags & 0xff))
 #define MRB_ENV_CLOSE(e) ((e)->cxt = NULL)
 #define MRB_ENV_ONSTACK_P(e) ((e)->cxt != NULL)
-#define MRB_ENV_BIDX(e) (((e)->flags >> 8) & 0xff)
-#define MRB_ENV_SET_BIDX(e,idx) ((e)->flags = (((e)->flags & ~(0xff<<8))|((unsigned int)(idx) & 0xff)<<8))
+#define MRB_ENV_BIDX(e) MRB_FLAGS_GET((e)->flags, 8, 7)
+/* MRB_FLAGS_SET() masks to the width, so an index that does not fit is
+   stored truncated rather than reaching the bit above it. That is silent,
+   and this macro is public and was eight bits wide before, so a debug build
+   says so instead. The tighter bound the VM itself works to, 43, is
+   asserted where the VM computes the index (mrb_env_new()). */
+#define MRB_ENV_SET_BIDX(e,idx) \
+  (mrb_assert((unsigned int)(idx) < 128), MRB_FLAGS_SET((e)->flags, 8, 7, (unsigned int)(idx)))
 #define MRB_ENV_SET_VISIBILITY(e, vis) MRB_FLAGS_SET((e)->flags, 16, 2, vis)
 #define MRB_ENV_VISIBILITY(e) MRB_FLAGS_GET((e)->flags, 16, 2)
 #define MRB_ENV_VISIBILITY_BREAK_P(e) MRB_FLAG_CHECK((e)->flags, 18)

--- a/include/mruby/proc.h
+++ b/include/mruby/proc.h
@@ -30,18 +30,21 @@ struct REnv {
   mrb_sym mid;
 };
 
-/* flags (20bits): 1(ZERO):1(separate module):2(visibility):1(unused):7(bidx):8(stack_len)
- * The block argument index needs seven bits at most: it counts one for the
- * receiver, at most 14 positional arguments (15 meaning a packed array,
- * worth one) and at most 28 for 14 keyword pairs (15 meaning a packed
- * hash, worth one), so 43. */
+/* flags (20bits): 1(module_function):1(visibility break):2(visibility):1(svar):7(bidx):8(stack_len)
+ * The bit above the block argument index says whether the heap stack of a
+ * closed env carries the special-variable slot past its locals; it is an
+ * implementation detail of the core, so its accessors live in
+ * mruby/internal.h (MRB_ENV_SVAR_P) rather than here. The index below it
+ * needs seven bits at most: it counts one for the receiver, at most 14
+ * positional arguments (15 meaning a packed array, worth one) and at most
+ * 28 for 14 keyword pairs (15 meaning a packed hash, worth one), so 43. */
 #define MRB_ENV_SET_LEN(e,len) ((e)->flags = (((e)->flags & ~0xff)|((unsigned int)(len) & 0xff)))
 #define MRB_ENV_LEN(e) ((mrb_int)((e)->flags & 0xff))
 #define MRB_ENV_CLOSE(e) ((e)->cxt = NULL)
 #define MRB_ENV_ONSTACK_P(e) ((e)->cxt != NULL)
 #define MRB_ENV_BIDX(e) MRB_FLAGS_GET((e)->flags, 8, 7)
 /* MRB_FLAGS_SET() masks to the width, so an index that does not fit is
-   stored truncated rather than reaching the bit above it. That is silent,
+   stored truncated rather than reaching the flag above it. That is silent,
    and this macro is public and was eight bits wide before, so a debug build
    says so instead. The tighter bound the VM itself works to, 43, is
    asserted where the VM computes the index (mrb_env_new()). */

--- a/include/mruby/proc.h
+++ b/include/mruby/proc.h
@@ -47,9 +47,18 @@ struct REnv {
    stored truncated rather than reaching the flag above it. That is silent,
    and this macro is public and was eight bits wide before, so a debug build
    says so instead. The tighter bound the VM itself works to, 43, is
-   asserted where the VM computes the index (mrb_env_new()). */
-#define MRB_ENV_SET_BIDX(e,idx) \
-  (mrb_assert((unsigned int)(idx) < 128), MRB_FLAGS_SET((e)->flags, 8, 7, (unsigned int)(idx)))
+   asserted where the VM computes the index (mrb_env_new()).
+   A static inline function rather than a bare macro: mrb_assert() expands
+   to nothing under release, so a macro body using it evaluates idx once in
+   release and twice under MRB_DEBUG, which a public macro cannot ask a
+   caller to plan around. */
+static inline void
+mrb_env_set_bidx(struct REnv *e, unsigned int idx)
+{
+  mrb_assert(idx < 128);
+  MRB_FLAGS_SET(e->flags, 8, 7, idx);
+}
+#define MRB_ENV_SET_BIDX(e, idx) mrb_env_set_bidx((e), (unsigned int)(idx))
 #define MRB_ENV_SET_VISIBILITY(e, vis) MRB_FLAGS_SET((e)->flags, 16, 2, vis)
 #define MRB_ENV_VISIBILITY(e) MRB_FLAGS_GET((e)->flags, 16, 2)
 #define MRB_ENV_VISIBILITY_BREAK_P(e) MRB_FLAG_CHECK((e)->flags, 18)

--- a/include/mruby/value.h
+++ b/include/mruby/value.h
@@ -217,7 +217,8 @@ static const unsigned int IEEE754_INFINITY_BITS_SINGLE = 0x7F800000;
   f(MRB_TT_RATIONAL,    struct RRational,   "Rational") \
   f(MRB_TT_BIGINT,      struct RBigint,     "Integer") \
   f(MRB_TT_BACKTRACE,   struct RBacktrace,  "backtrace") \
-  f(MRB_TT_SET,         struct RSet,        "Set")
+  f(MRB_TT_SET,         struct RSet,        "Set") \
+  f(MRB_TT_SVAR,        struct RSvar,       "svar")
 
 enum mrb_vtype {
 #define MRB_VTYPE_DEFINE(tt, type, name) tt,

--- a/include/mruby/variable.h
+++ b/include/mruby/variable.h
@@ -94,6 +94,23 @@ MRB_API void mrb_gv_set(mrb_state *mrb, mrb_sym sym, mrb_value val);
  */
 MRB_API void mrb_gv_remove(mrb_state *mrb, mrb_sym sym);
 
+/**
+ * Turn a global variable name into a virtual one: `mrb_gv_get()` and
+ * `mrb_gv_set()` on `sym` call `get` and `set` instead of touching the
+ * stored value, so a name whose semantics are not "one process-wide slot"
+ * (CRuby's `$~` is per method scope) can keep its global spelling. The
+ * dispatch lives behind a sentinel stored in the globals table itself, so
+ * the name stays defined and listed in `global_variables`, and an ordinary
+ * global pays one type test on access. `set` may raise; removing the name
+ * with `mrb_gv_remove()` removes the hook with it.
+ *
+ * @param mrb The mruby state reference
+ * @param sym The name of the global variable
+ * @param get Called to produce the variable's value
+ * @param set Called with the value assigned to the variable
+ */
+MRB_API void mrb_gv_define_virtual(mrb_state *mrb, mrb_sym sym, mrb_value (*get)(mrb_state*), void (*set)(mrb_state*, mrb_value));
+
 MRB_API mrb_value mrb_cv_get(mrb_state *mrb, mrb_value mod, mrb_sym sym);
 MRB_API void mrb_mod_cv_set(mrb_state *mrb, struct RClass * c, mrb_sym sym, mrb_value v);
 MRB_API void mrb_cv_set(mrb_state *mrb, mrb_value mod, mrb_sym sym, mrb_value v);

--- a/mrbgems/mruby-bin-mruby/bintest/mruby.rb
+++ b/mrbgems/mruby-bin-mruby/bintest/mruby.rb
@@ -128,6 +128,32 @@ EOS
   assert_equal 0, status.exitstatus
 end
 
+assert('mruby -r option gives each chunk its own special-variable scope') do
+  # per-scope $~ comes with mruby-regexp; probe the binary rather than
+  # skip forever on a fixed gem list
+  probe, = Open3.capture2(*(cmd_list(MRUBY_BIN) + %w[-e print(Object.const_defined?(:Regexp))]))
+  skip unless probe == "true"
+
+  lib = Tempfile.new('lib.rb')
+  lib.write <<EOS
+"fromlib" =~ /fromlib/
+$pr = -> { $~ && $~[0] }
+EOS
+  lib.flush
+
+  script = Tempfile.new('test.rb')
+  script.write <<EOS
+p [$~ && $~[0], $pr.call]
+"inmain" =~ /inmain/
+p [$~ && $~[0], $pr.call]
+EOS
+  script.flush
+  # the main program starts with $~ unset, as a file `ruby -r` loads does,
+  # while a proc the library left behind keeps reading its own scope, in
+  # both directions
+  assert_mruby(%{[nil, "fromlib"]\n["inmain", "fromlib"]\n}, "", true, ['-r', lib.path, script.path])
+end
+
 assert('mruby -r option (no library specified)') do
   assert_mruby("", /\A.*: No library specified for -r\n\z/, false, %w[-r])
 end

--- a/mrbgems/mruby-binding/src/binding.c
+++ b/mrbgems/mruby-binding/src/binding.c
@@ -90,7 +90,10 @@ static struct REnv *
 binding_env_new_lvspace(mrb_state *mrb, const struct REnv *e)
 {
   struct REnv *env = MRB_OBJ_ALLOC(mrb, MRB_TT_ENV, NULL);
-  mrb_value *stacks = (mrb_value*)mrb_calloc(mrb, 1, sizeof(mrb_value));
+  /* Born closed and off the stack, standing in for a Ruby scope, so it
+     carries the special-variable slot past its one local from the start
+     (MRB_ENV_SET_SVAR below; see internal.h). */
+  mrb_value *stacks = (mrb_value*)mrb_malloc(mrb, MRB_ENV_SVAR_STACK_SIZE(1));
   env->mid = 0;
   env->stack = stacks;
   if (e && e->stack && MRB_ENV_LEN(e) > 0) {
@@ -99,7 +102,10 @@ binding_env_new_lvspace(mrb_state *mrb, const struct REnv *e)
   else {
     env->stack[0] = mrb_nil_value();
   }
+  SET_NIL_VALUE(MRB_ENV_SVAR_SLOT(env->stack, 1));
   MRB_ENV_SET_LEN(env, 1);
+  MRB_ENV_CLOSE(env);
+  MRB_ENV_SET_SVAR(env);
   return env;
 }
 

--- a/mrbgems/mruby-binding/test/binding.c
+++ b/mrbgems/mruby-binding/test/binding.c
@@ -1,4 +1,7 @@
 #include <mruby.h>
+#include <mruby/proc.h>
+#include <mruby/internal.h>
+#include <mruby/variable.h>
 
 static mrb_value
 binding_in_c(mrb_state *mrb, mrb_value self)
@@ -6,8 +9,84 @@ binding_in_c(mrb_state *mrb, mrb_value self)
   return mrb_funcall_argv(mrb, mrb_obj_value(mrb->object_class), MRB_SYM(binding), 0, NULL);
 }
 
+/* The local-variable space a binding holds (binding_env_new_lvspace() in
+   src/binding.c): a closed env born with the special-variable slot past
+   its locals, and the env Binding#local_variable_set grows through
+   mrb_proc_merge_lvar(). The four helpers below are what the shape of that
+   stack can be asked about with; there is no Ruby-visible face for it. */
+static struct REnv*
+binding_env(mrb_state *mrb, mrb_value binding)
+{
+  mrb_value obj = mrb_iv_get(mrb, binding, MRB_SYM(env));
+
+  mrb_check_type(mrb, obj, MRB_TT_ENV);
+  return (struct REnv*)mrb_obj_ptr(obj);
+}
+
+static mrb_value
+binding_env_svar_p(mrb_state *mrb, mrb_value self)
+{
+  return mrb_bool_value(MRB_ENV_SVAR_P(binding_env(mrb, mrb_get_arg1(mrb))));
+}
+
+static mrb_value
+binding_env_len(mrb_state *mrb, mrb_value self)
+{
+  return mrb_int_value(mrb, MRB_ENV_LEN(binding_env(mrb, mrb_get_arg1(mrb))));
+}
+
+/* Rewrites the env into what out-of-tree code builds by hand: a closed env
+   over a heap stack of exactly its locals, carrying no slot. The stack
+   shrinks for real, so a later read one past the locals is an
+   out-of-bounds access a sanitizer build reports. */
+static mrb_value
+binding_env_drop_svar(mrb_state *mrb, mrb_value self)
+{
+  struct REnv *e = binding_env(mrb, mrb_get_arg1(mrb));
+
+  if (MRB_ENV_ONSTACK_P(e) || !MRB_ENV_SVAR_P(e)) return mrb_false_value();
+  size_t len = (size_t)MRB_ENV_LEN(e);
+  if (len == 0) return mrb_false_value();
+
+  e->stack = (mrb_value*)mrb_realloc(mrb, e->stack, sizeof(mrb_value) * len);
+  MRB_ENV_CLEAR_SVAR(e);
+  return mrb_true_value();
+}
+
+/* Puts a marker in the slot and reads it back. What the core keeps there
+   has no Ruby face of its own; any marked value stands in for it here,
+   which is all the merge below moves. */
+static mrb_value
+binding_env_slot_set(mrb_state *mrb, mrb_value self)
+{
+  mrb_value binding, v;
+  mrb_get_args(mrb, "oo", &binding, &v);
+
+  struct REnv *e = binding_env(mrb, binding);
+  if (!MRB_ENV_SVAR_P(e)) return mrb_false_value();
+  MRB_ENV_SVAR_SLOT(e->stack, MRB_ENV_LEN(e)) = v;
+  mrb_write_barrier(mrb, (struct RBasic*)e);
+  return mrb_true_value();
+}
+
+static mrb_value
+binding_env_slot_get(mrb_state *mrb, mrb_value self)
+{
+  struct REnv *e = binding_env(mrb, mrb_get_arg1(mrb));
+
+  if (!MRB_ENV_SVAR_P(e)) return mrb_nil_value();
+  return MRB_ENV_SVAR_SLOT(e->stack, MRB_ENV_LEN(e));
+}
+
 void
 mrb_mruby_binding_gem_test(mrb_state *mrb)
 {
-  mrb_define_method(mrb, mrb->object_class, "binding_in_c", binding_in_c, MRB_ARGS_NONE());
+  struct RClass *o = mrb->object_class;
+
+  mrb_define_method(mrb, o, "binding_in_c", binding_in_c, MRB_ARGS_NONE());
+  mrb_define_method(mrb, o, "__binding_env_svar?", binding_env_svar_p, MRB_ARGS_REQ(1));
+  mrb_define_method(mrb, o, "__binding_env_len", binding_env_len, MRB_ARGS_REQ(1));
+  mrb_define_method(mrb, o, "__binding_env_drop_svar", binding_env_drop_svar, MRB_ARGS_REQ(1));
+  mrb_define_method(mrb, o, "__binding_env_slot_set", binding_env_slot_set, MRB_ARGS_REQ(2));
+  mrb_define_method(mrb, o, "__binding_env_slot_get", binding_env_slot_get, MRB_ARGS_REQ(1));
 }

--- a/mrbgems/mruby-binding/test/binding.c
+++ b/mrbgems/mruby-binding/test/binding.c
@@ -53,9 +53,10 @@ binding_env_drop_svar(mrb_state *mrb, mrb_value self)
   return mrb_true_value();
 }
 
-/* Puts a marker in the slot and reads it back. What the core keeps there
-   has no Ruby face of its own; any marked value stands in for it here,
-   which is all the merge below moves. */
+/* Puts a marker in the slot and reads it back. What lives there in a
+   running VM is a special-variable container or a forwarded env, neither
+   of which has a Ruby face; any marked value stands in for one here, which
+   is all the merge below moves. */
 static mrb_value
 binding_env_slot_set(mrb_state *mrb, mrb_value self)
 {

--- a/mrbgems/mruby-binding/test/binding.rb
+++ b/mrbgems/mruby-binding/test/binding.rb
@@ -62,3 +62,41 @@ end
 assert "Kernel#binding and .eval from C" do
   assert_raise(RuntimeError) { binding_in_c }
 end
+
+# The local-variable space a binding holds is a closed env carrying the
+# special-variable slot past its locals (mruby/internal.h), and
+# `local_variable_set` on a name the scope has not seen grows that stack
+# through mrb_proc_merge_lvar(). The new locals take the ground the slot
+# stood on, so the merge has to move it; an env sized without the slot,
+# which out-of-tree code builds by hand, must not be read past its locals
+# at all. The C helpers are in test/binding.c.
+assert "Binding#local_variable_set moves the special-variable slot" do
+  b = binding
+  assert_true __binding_env_svar?(b)
+  len = __binding_env_len(b)
+  marker = "slot marker"
+  assert_true __binding_env_slot_set(b, marker)
+
+  b.local_variable_set(:merged_lvar, 42)
+  assert_true __binding_env_svar?(b)
+  assert_equal len + 1, __binding_env_len(b)
+  assert_equal marker, __binding_env_slot_get(b)
+
+  GC.start
+  assert_equal 42, b.local_variable_get(:merged_lvar)
+  assert_equal marker, __binding_env_slot_get(b)
+end
+
+assert "Binding#local_variable_set over an env without the slot" do
+  b = binding
+  len = __binding_env_len(b)
+  assert_true __binding_env_drop_svar(b)
+  assert_false __binding_env_svar?(b)
+
+  b.local_variable_set(:merged_lvar, 42)
+  assert_false __binding_env_svar?(b)
+  assert_equal len + 1, __binding_env_len(b)
+
+  GC.start
+  assert_equal 42, b.local_variable_get(:merged_lvar)
+end

--- a/mrbgems/mruby-os-memsize/src/memsize.c
+++ b/mrbgems/mruby-os-memsize/src/memsize.c
@@ -113,8 +113,8 @@ os_memsize_of_object(mrb_state* mrb, mrb_value obj)
       const struct REnv *env = MRB_PROC_ENV(proc);
       size += mrb_objspace_page_slot_size();
       if (env) {
-        /* the locals, plus the slot past them where the env carries its
-           scope's special variables (see internal.h) */
+        /* the locals, plus the slot past them where the env carries the
+           special-variable container (see internal.h) */
         size += MRB_ENV_LEN(env) * sizeof(mrb_value);
         if (MRB_ENV_SVAR_P(env)) size += sizeof(mrb_value);
       }
@@ -178,6 +178,11 @@ os_memsize_of_object(mrb_state* mrb, mrb_value obj)
       break;
     case MRB_TT_BACKTRACE:
       size += ((struct RBacktrace*)mrb_obj_ptr(obj))->len * sizeof(struct mrb_backtrace_location);
+      break;
+    case MRB_TT_SVAR:
+      if (((struct RSvar*)mrb_obj_ptr(obj))->slots) {
+        size += MRB_SVAR_MAX * sizeof(mrb_value);
+      }
       break;
     /*  zero heap size types.
      *  immediate VM stack values, contained within mrb_state, or on C stack */

--- a/mrbgems/mruby-os-memsize/src/memsize.c
+++ b/mrbgems/mruby-os-memsize/src/memsize.c
@@ -110,8 +110,14 @@ os_memsize_of_object(mrb_state* mrb, mrb_value obj)
     }
     case MRB_TT_PROC: {
       struct RProc* proc = mrb_proc_ptr(obj);
+      const struct REnv *env = MRB_PROC_ENV(proc);
       size += mrb_objspace_page_slot_size();
-      size += MRB_ENV_LEN(proc->e.env) * sizeof(mrb_value);
+      if (env) {
+        /* the locals, plus the slot past them where the env carries its
+           scope's special variables (see internal.h) */
+        size += MRB_ENV_LEN(env) * sizeof(mrb_value);
+        if (MRB_ENV_SVAR_P(env)) size += sizeof(mrb_value);
+      }
       if (!MRB_PROC_CFUNC_P(proc))
         size += os_memsize_of_irep(mrb, proc->body.irep);
       break;

--- a/mrbgems/mruby-os-memsize/src/memsize.c
+++ b/mrbgems/mruby-os-memsize/src/memsize.c
@@ -180,6 +180,7 @@ os_memsize_of_object(mrb_state* mrb, mrb_value obj)
       size += ((struct RBacktrace*)mrb_obj_ptr(obj))->len * sizeof(struct mrb_backtrace_location);
       break;
     case MRB_TT_SVAR:
+      size += mrb_objspace_page_slot_size();
       if (((struct RSvar*)mrb_obj_ptr(obj))->slots) {
         size += MRB_SVAR_MAX * sizeof(mrb_value);
       }

--- a/mrbgems/mruby-regexp/mrbgem.rake
+++ b/mrbgems/mruby-regexp/mrbgem.rake
@@ -41,6 +41,30 @@ MRuby::Gem::Specification.new('mruby-regexp') do |spec|
     spec.add_dependency 'mruby-symbol-ext', :core => 'mruby-symbol-ext'
   end
 
+  # Same deal for `$~` being per execution context (the slot lives on each
+  # context's ci stack): the test pinning that can only run where the build
+  # has mruby-fiber anyway; the test skips itself where Fiber is missing.
+  if build.gems.any? {|g| g.name == 'mruby-fiber'}
+    spec.add_test_dependency 'mruby-fiber', :core => 'mruby-fiber'
+  end
+
+  # The nested-load tests drive `$~` the way an embedding host does: a C
+  # function calling mrb_load_string() mid-execution. The helper is C
+  # (test/backref_scope.c) and needs the compiler in the test state, the
+  # way mruby-proc-binding's proc_in_c helper does.
+  spec.add_test_dependency 'mruby-compiler', :core => 'mruby-compiler'
+
+  # Same deal for the `eval` family, which lands on the calling scope as the
+  # nested loads do, by another rule: an `eval` proc captures its caller's
+  # env, so it resolves as a block. `instance_eval` given a String is that
+  # shape too, and `Binding#eval` takes the bound scope instead. mruby-eval
+  # carries all three (`Binding#eval` is defined there) and pulls in
+  # mruby-binding, so this one dependency covers the set; the tests skip
+  # themselves where the build has no `eval`.
+  if build.gems.any? {|g| g.name == 'mruby-eval'}
+    spec.add_test_dependency 'mruby-eval', :core => 'mruby-eval'
+  end
+
   # Same deal for taking a method back off a class. The test that pins `$&`
   # and `$1` reading the match rather than `MatchData#[]` redefines `[]` and
   # parks the original under another name, and dropping that name afterwards

--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -245,30 +245,49 @@ regexp_init_copy(mrb_state *mrb, mrb_value self)
   return re_initialize(mrb, self, src, get_iflags(mrb, orig));
 }
 
-/* Pre-interned symbol for $~ (cached on first use). MRB_GVSYM() takes a
-   word after the `$`, which `~` is not, so this one is looked up once here. */
-static mrb_sym match_sym;
-
-static mrb_sym
-ensure_match_sym(mrb_state *mrb)
-{
-  if (!match_sym) match_sym = mrb_intern_lit(mrb, "$~");
-  return match_sym;
-}
-
 /* $~ is the one name a match publishes. `$&`, `` $` ``, `$'`, `$+` and `$1`
    onward are readings of it that the compiler derives when they are read,
-   so publishing and clearing are each one write of `$~`. */
+   so publishing and clearing are each one write of `$~`.
+
+   The value lives in the owning scope's MRB_SVAR_BACKREF slot, not in the
+   globals table, which is what keeps a method's match out of its caller's
+   `$~`. The engine reaches that slot directly, the way CRuby's re.c and
+   string.c reach rb_backref_set(): the global name is how Ruby code spells
+   the slot, not the route a match publishes through. The pair below is
+   what that spelling needs, and nothing more. */
 static void
 set_match_globals(mrb_state *mrb, mrb_value obj)
 {
-  mrb_gv_set(mrb, ensure_match_sym(mrb), obj);
+  mrb_vm_svar_set(mrb, MRB_SVAR_BACKREF, obj);
 }
 
 static void
 clear_match_globals(mrb_state *mrb)
 {
   set_match_globals(mrb, mrb_nil_value());
+}
+
+/* The virtual-global pair `$~` dispatches to, registered in gem init, so
+   that Ruby code reading or assigning the name lands on the same slot the
+   engine publishes into. The slot is opaque to the core; that it holds a
+   MatchData is this gem's contract, and every value the engine stores is
+   one by construction, which leaves the setter, the only path an arbitrary
+   value arrives by, as the home of CRuby's TypeError for
+   `$~ = <not a MatchData>` (CRuby's match_setter()). */
+static mrb_value
+backref_gv_get(mrb_state *mrb)
+{
+  return mrb_vm_svar_get(mrb, MRB_SVAR_BACKREF);
+}
+
+static void
+backref_gv_set(mrb_state *mrb, mrb_value v)
+{
+  if (!mrb_nil_p(v) && !(mrb_data_p(v) && DATA_TYPE(v) == &matchdata_type)) {
+    mrb_raisef(mrb, E_TYPE_ERROR, "wrong argument type %s (expected MatchData)",
+               mrb_obj_classname(mrb, v));
+  }
+  mrb_vm_svar_set(mrb, MRB_SVAR_BACKREF, v);
 }
 
 /* Byte-based substring extraction. The regexp engine records all capture
@@ -2229,8 +2248,10 @@ str_aset(mrb_state *mrb, mrb_value str)
 
 /* --- The regexp-aware String methods --- */
 
-/* Each stands where CRuby implements the same method in C, a C frame in
-   place of the Ruby frame the mrblib override pushed.
+/* Each stands where CRuby implements the same method in C. Being C frames
+   they are transparent to `$~` owner resolution, so a match inside publishes
+   into the calling scope the way rb_str_sub_bang()'s does, with nothing
+   having to say so.
 
    Every entry point settles its pattern argument up front, so the argument
    cannot steer the decision: check_pattern() reads the real type, an accepted
@@ -3180,12 +3201,14 @@ sym_match_op_m(mrb_state *mrb, mrb_value self)
 /*
  * Regexp.last_match / Regexp.last_match(n)
  *
- * Reads `$~` and indexes it the way MatchData#[] does: CRuby's
- * rb_reg_s_last_match() reaches rb_reg_nth_match() directly rather than
- * dispatching `[]`, so a program redefining `MatchData#[]` moves `md[n]`
- * and leaves this reader alone. The whole MatchData answers only an
- * omitted argument, told apart by arity: an explicit nil goes on to the
- * integer conversion and fails it, as it does in CRuby.
+ * Reads the caller's `$~`, which this C frame is transparent to, and indexes
+ * it the way MatchData#[] does: CRuby's rb_reg_s_last_match() reaches
+ * rb_reg_nth_match() directly rather than dispatching `[]`, so a program
+ * redefining `MatchData#[]` moves `md[n]` and leaves this reader alone. The
+ * whole MatchData answers only an omitted argument, told apart by arity: an
+ * explicit nil goes on to the integer conversion and fails it, as it does
+ * in CRuby. Being the engine, it reads the slot rather than the global
+ * name, as CRuby's rb_reg_s_last_match() reads rb_backref_get().
  */
 static mrb_value
 regexp_s_last_match(mrb_state *mrb, mrb_value klass)
@@ -3193,7 +3216,7 @@ regexp_s_last_match(mrb_state *mrb, mrb_value klass)
   mrb_value n;
 
   mrb_int argc = mrb_get_args(mrb, "|o", &n);
-  mrb_value md = mrb_gv_get(mrb, ensure_match_sym(mrb));
+  mrb_value md = mrb_vm_svar_get(mrb, MRB_SVAR_BACKREF);
   if (argc == 0) return md;
   if (mrb_nil_p(md)) return mrb_nil_value();
   return md_aref(mrb, md, n);
@@ -3206,6 +3229,12 @@ mrb_mruby_regexp_gem_init(mrb_state *mrb)
 {
   struct RClass *re = mrb_define_class(mrb, "Regexp", mrb->object_class);
   MRB_SET_INSTANCE_TT(re, MRB_TT_CDATA);
+
+  /* `$~` is a global name whose value is per method scope. This is the one
+     place the name is needed, so it is interned here rather than cached:
+     MRB_GVSYM() takes a word after the `$`, which `~` is not, and a cache
+     outside `mrb` would hand a second mrb_state the first one's numbering. */
+  mrb_gv_define_virtual(mrb, mrb_intern_lit(mrb, "$~"), backref_gv_get, backref_gv_set);
 
   /* Constants */
   mrb_define_const(mrb, re, "IGNORECASE", mrb_fixnum_value(1));

--- a/mrbgems/mruby-regexp/test/backref_scope.c
+++ b/mrbgems/mruby-regexp/test/backref_scope.c
@@ -1,0 +1,66 @@
+#include <mruby.h>
+#include <mruby/compile.h>
+#include <mruby/proc.h>
+#include <mruby/variable.h>
+#include <mruby/internal.h>
+
+/* Runs a script through mrb_load_string() while the VM is mid-execution,
+   the way an embedding host does from a C function it defines: mrb_top_run()
+   pushes a fresh frame whose proc captured no scope, the frame that is
+   transparent to `$~` owner resolution in svar_owner() (see vm.c). The
+   Ruby-visible shape is pinned by test/backref_scope.rb. */
+static mrb_value
+backref_nested_load(mrb_state *mrb, mrb_value self)
+{
+  const char *s;
+  mrb_get_args(mrb, "z", &s);
+  return mrb_load_string(mrb, s);
+}
+
+/* The two below drive MRB_SVAR_LASTLINE, the container key no global is
+   registered for yet, straight through the public accessors. Each is a C
+   frame, so a call lands on the calling Ruby scope the way a `$_` built on
+   them would; what they pin is that the second key shares `$~`'s container
+   without either key disturbing the other. */
+static mrb_value
+svar_lastline_get(mrb_state *mrb, mrb_value self)
+{
+  return mrb_vm_svar_get(mrb, MRB_SVAR_LASTLINE);
+}
+
+static mrb_value
+svar_lastline_set(mrb_state *mrb, mrb_value self)
+{
+  mrb_value v;
+  mrb_get_args(mrb, "o", &v);
+  mrb_vm_svar_set(mrb, MRB_SVAR_LASTLINE, v);
+  return v;
+}
+
+/* Whether the calling Ruby frame carries a special-variable container,
+   which is how the lazy allocation contract (a nil write allocates
+   nothing) is observable at all: the container's existence has no other
+   Ruby-visible face. The walk stops at the nearest non-C frame, so this
+   reports on a method that calls it directly, not on the owner a block's
+   resolution would reach. */
+static mrb_value
+svar_container_p(mrb_state *mrb, mrb_value self)
+{
+  mrb_callinfo *ci = mrb->c->ci;
+
+  while (ci > mrb->c->cibase) {
+    const struct RProc *p = ci->proc;
+    if (p && !MRB_PROC_CFUNC_P(p)) break;
+    ci--;
+  }
+  return mrb_bool_value(ci->svar != NULL);
+}
+
+void
+mrb_mruby_regexp_gem_test(mrb_state *mrb)
+{
+  mrb_define_method(mrb, mrb->object_class, "__backref_nested_load", backref_nested_load, MRB_ARGS_REQ(1));
+  mrb_define_method(mrb, mrb->object_class, "__svar_lastline", svar_lastline_get, MRB_ARGS_NONE());
+  mrb_define_method(mrb, mrb->object_class, "__svar_lastline_set", svar_lastline_set, MRB_ARGS_REQ(1));
+  mrb_define_method(mrb, mrb->object_class, "__svar_container?", svar_container_p, MRB_ARGS_NONE());
+}

--- a/mrbgems/mruby-regexp/test/backref_scope.rb
+++ b/mrbgems/mruby-regexp/test/backref_scope.rb
@@ -808,3 +808,23 @@ assert("svar - a fiber's container stays its own, both keys") do
   skip unless Object.const_defined?(:Fiber)
   assert_equal [["fiber", "fiber"], "main", "main"], svar_container_fiber
 end
+
+def svar_container_fiber_root
+  Fiber.new do
+    local = :fiber_held
+    -> { [local, __svar_lastline] }
+  end.resume
+end
+
+assert("svar - a terminated fiber's root env carries no slot until needed") do
+  # fiber_terminate() (src/vm.c) closes the fiber's own root env by hand
+  # rather than through mrb_env_unshare(), so it needs the same no-slot
+  # default a plain method's escaping env gets (test/t/env.rb).
+  skip unless Object.const_defined?(:Fiber)
+  pr = svar_container_fiber_root
+  assert_false __env_svar?(pr)
+  assert_equal :none, __env_svar_slot(pr)
+
+  GC.start
+  assert_equal [:fiber_held, nil], pr.call
+end

--- a/mrbgems/mruby-regexp/test/backref_scope.rb
+++ b/mrbgems/mruby-regexp/test/backref_scope.rb
@@ -1,0 +1,810 @@
+# Where `$~` lives. CRuby's match state belongs to a method scope: a C
+# frame has no slot of its own and writes through to the Ruby frame below
+# it, and a block shares its defining method's slot. Every expectation here
+# is CRuby's measured answer.
+
+def backref_scope_match
+  "zz" =~ /zz/
+end
+
+def backref_scope_no_match
+  "zz" =~ /q/
+end
+
+def backref_scope_reads
+  $~
+end
+
+def backref_scope_own
+  "own" =~ /(ow)n/
+  [$~ && $~[0], $&, $1]
+end
+
+def backref_scope_sub
+  "hello".sub(/l/, "L")
+  $~ && $~[0]
+end
+
+def backref_scope_block_share
+  "before" =~ /before/
+  [1].each { "inner" =~ /inner/ }
+  $~ && $~[0]
+end
+
+def backref_scope_mk
+  -> { "leak" =~ /leak/ }
+end
+
+def backref_scope_run(pr)
+  pr.call
+  $~
+end
+
+def backref_scope_escape
+  "esc" =~ /esc/
+  -> { $~ }
+end
+
+def backref_scope_pair
+  wr = -> { "pair" =~ /(pa)ir/ }
+  rd = -> { $~ && $~[0] }
+  [wr, rd]
+end
+
+def backref_scope_nested_escape
+  "nest" =~ /nest/
+  [1].map { -> { $~ } }.first
+end
+
+def backref_scope_deep_pair
+  wr = rd = nil
+  [1].each do
+    wr = -> { "deep" =~ /(de)ep/ }
+    rd = -> { $~ && $~[0] }
+  end
+  [wr, rd]
+end
+
+def backref_scope_three_deep
+  "m3" =~ /m3/
+  [[1]].map { |a| a.map { -> { $~ } } }.first.first
+end
+
+def backref_scope_block_writes
+  [1].each { "wb" =~ /wb/ }
+  -> { $~ && $~[0] }
+end
+
+def backref_scope_last_match
+  "helper" =~ /helper/
+  Regexp.last_match
+end
+
+def backref_scope_dead_fiber
+  "df" =~ /df/
+  f = Fiber.new { -> { $~ && $~[0] } }
+  f.resume
+end
+
+def backref_scope_dead_fiber_pair
+  f = Fiber.new { [-> { "dw" =~ /dw/ }, -> { $~ && $~[0] }] }
+  f.resume
+end
+
+def backref_scope_fiber_escape
+  "lf" =~ /lf/
+  f = Fiber.new { Fiber.yield(-> { $~ && $~[0] }); :done }
+  [f, f.resume]
+end
+
+def backref_scope_fiber_live
+  "lm" =~ /lm/
+  f = Fiber.new { Fiber.yield(-> { $~ && $~[0] }); :done }
+  pr = f.resume
+  r = yield pr
+  f.resume
+  r
+end
+
+def backref_scope_fiber_carried(pr)
+  f = Fiber.new { Fiber.yield; pr.call }
+  f.resume
+  f
+end
+
+def backref_scope_fiber_same_scope
+  "main" =~ /main/
+  rd = -> { $~ && $~[0] }
+  wr = -> { "fiber" =~ /fiber/; $~ && $~[0] }
+  inside = Fiber.new { [rd.call, wr.call] }.resume
+  [inside, $~ && $~[0]]
+end
+
+def backref_scope_collected_fiber
+  "cf" =~ /cf/
+  Fiber.yield(-> { $~ && $~[0] })
+end
+
+def backref_scope_collected_fiber_pair
+  wr = -> { "gw" =~ /gw/ }
+  rd = -> { $~ && $~[0] }
+  Fiber.yield([wr, rd])
+end
+
+def backref_scope_fiber_suspended_write
+  wr = -> { "xf" =~ /xf/ }
+  Fiber.yield(wr)
+  $~ && $~[0]
+end
+
+def backref_scope_fiber_suspended_read
+  "rf" =~ /rf/
+  Fiber.yield(-> { $~ && $~[0] })
+end
+
+assert("$~ - a match inside a method is invisible to its caller") do
+  "outer" =~ /outer/
+  backref_scope_match
+  assert_equal "outer", $~ && $~[0]
+end
+
+assert("$~ - a failed match inside a method does not clear the caller") do
+  "outer" =~ /outer/
+  backref_scope_no_match
+  assert_equal "outer", $~ && $~[0]
+end
+
+assert("$~ - a method reads its own scope, not its caller's") do
+  "outer" =~ /outer/
+  assert_nil backref_scope_reads
+end
+
+assert("$~ - a method sees its own match, and the derived names follow") do
+  assert_equal ["own", "own", "ow"], backref_scope_own
+end
+
+assert("$~ - a failed match in the same scope publishes nil") do
+  "keep" =~ /keep/
+  "keep" =~ /q/
+  assert_nil $~
+end
+
+assert("$~ - match? neither publishes nor clears") do
+  "keep" =~ /keep/
+  assert_true(/ke/.match?("keep"))
+  assert_false "keep".match?(/q/)
+  assert_equal "keep", $~ && $~[0]
+end
+
+assert("$~ - String#sub publishes into its caller") do
+  # under this frame sit only C frames, `String#sub` included, all
+  # transparent, so the publish lands here, as `rb_str_sub_bang()`'s does
+  "hello".sub(/l/, "L")
+  assert_equal "l", $~ && $~[0]
+  assert_equal "l", backref_scope_sub
+end
+
+assert("$~ - Kernel#!~ publishes into its caller") do
+  # `!~` is answered from C, so the `=~` it dispatches writes through to
+  # this frame rather than into a Ruby frame of its own, as CRuby's
+  # `rb_obj_not_match()` does
+  assert_false("abc" !~ /(b)/)
+  assert_equal "b", $~ && $~[0]
+  assert_equal "b", $1
+  assert_true("abc" !~ /(z)/)
+  assert_nil $~
+end
+
+assert("$~ - a block shares its defining method's slot") do
+  assert_equal "inner", backref_scope_block_share
+end
+
+assert("$~ - a method called from a block leaves the block's scope alone") do
+  "outer" =~ /outer/
+  [1].each do
+    "blk" =~ /blk/
+    backref_scope_match
+    assert_equal "blk", $~ && $~[0]
+  end
+  assert_equal "blk", $~ && $~[0]
+end
+
+assert("$~ - a gsub block reads the match being replaced") do
+  seen = []
+  "ab".gsub(/[ab]/) { seen << ($~ && $~[0]); "x" }
+  assert_equal ["a", "b"], seen
+  assert_equal "b", $~ && $~[0]
+end
+
+assert("$~ - a proc called elsewhere writes its defining scope, not its caller") do
+  # `backref_scope_run` calls a proc whose defining frame has returned: the
+  # write lands nowhere `run` can see, so `run` answers its own untouched
+  # slot, which is CRuby's nil too.
+  "outer" =~ /outer/
+  assert_nil backref_scope_run(backref_scope_mk)
+  assert_equal "outer", $~ && $~[0]
+end
+
+assert("$~ - a proc outliving its scope still reads its match") do
+  # The frame's slot moves into the env when the frame returns, the way
+  # CRuby's svar lives on the lep and survives with it.
+  pr = backref_scope_escape
+  assert_equal "esc", pr.call && pr.call[0]
+end
+
+assert("$~ - two procs from one dead scope share its slot") do
+  wr, rd = backref_scope_pair
+  assert_nil rd.call
+  wr.call
+  assert_equal "pair", rd.call
+end
+
+assert("$~ - a proc born in a block of a dead scope reads the method's match") do
+  # The lexical chain stands in for CRuby's lep walk: the proc's env is the
+  # block frame's, and the walk crosses it into the method's, where the
+  # slot moved when the frame returned.
+  pr = backref_scope_nested_escape
+  assert_equal "nest", pr.call && pr.call[0]
+  pr3 = backref_scope_three_deep
+  assert_equal "m3", pr3.call && pr3.call[0]
+end
+
+assert("$~ - block-born procs of one dead scope share the method's slot") do
+  wr, rd = backref_scope_deep_pair
+  assert_nil rd.call
+  wr.call
+  assert_equal "deep", rd.call
+end
+
+assert("$~ - a match made in a block survives the method's escape") do
+  # the block published into the method's frame (its defining scope), and
+  # the frame's slot moved into the env on return
+  assert_equal "wb", backref_scope_block_writes.call
+end
+
+assert("$~ - accepts a MatchData and nil, refuses the rest") do
+  m = /a/.match("a")
+  $~ = m
+  assert_equal "a", $~[0]
+  $~ = nil
+  assert_nil $~
+  assert_raise(TypeError) { $~ = 1 }
+  assert_raise(TypeError) { $~ = "str" }
+  assert_raise(TypeError) { $~ = Object.new }
+end
+
+assert("$~ - stays a global name") do
+  assert_equal "global-variable", defined?($~)
+end
+
+assert("Regexp.last_match reads the calling scope") do
+  "top" =~ /(t)op/
+  assert_equal "top", Regexp.last_match[0]
+  assert_equal "top", Regexp.last_match(0)
+  assert_equal "t", Regexp.last_match(1)
+  helper_md = backref_scope_last_match
+  assert_equal "helper", helper_md && helper_md[0]
+  assert_equal "top", $~ && $~[0]
+end
+
+assert("$~ - a match on a Symbol publishes into the caller") do
+  :symbol_subject =~ /sym(bol)/
+  assert_equal "symbol", $~ && $~[0]
+  assert_equal "bol", $1
+end
+
+assert("$~ - a slice of a Symbol publishes into the caller") do
+  # `Symbol#slice`, and the `[]` aliased to it, are answered from C, so the
+  # `String#slice` they send records into this frame, as CRuby's
+  # `sym_aref()` does. They live in mruby-symbol-ext, so ask only where
+  # the build has it, as symbol_regexp.rb does.
+  skip unless :hello.respond_to?(:slice)
+  assert_equal "symbol", :symbol_subject.slice(/sym(bol)/)
+  assert_equal "symbol", $~ && $~[0]
+  assert_equal "bol", $1
+  assert_nil :symbol_subject[/(zz)/]
+  assert_nil $~
+end
+
+assert("$~ - fibers do not share the slot") do
+  skip unless Object.const_defined?(:Fiber)
+  inner = nil
+  f = Fiber.new { "fib" =~ /fib/; inner = ($~ && $~[0]) }
+  "main" =~ /main/
+  f.resume
+  assert_equal "fib", inner
+  assert_equal "main", $~ && $~[0]
+end
+
+assert("$~ - a proc sharing the fiber root scope is redirected to the fiber") do
+  skip unless Object.const_defined?(:Fiber)
+  # the root-lep redirect pinned from a non-root frame: rd and wr resolve
+  # to the very scope the running fiber's root block was defined in, and
+  # running on the fiber they are handed its root slot instead, so the
+  # defining scope's match is neither read nor disturbed
+  assert_equal [[nil, "fiber"], "main"], backref_scope_fiber_same_scope
+end
+
+assert("$~ - a proc born in a dead fiber reads its lexical method scope") do
+  skip unless Object.const_defined?(:Fiber)
+  # the chain crosses the fiber's root block into the defining method,
+  # whose slot escaped with its env; the fiber's death does not reroute it
+  pr = backref_scope_dead_fiber
+  assert_equal "df", pr.call
+end
+
+assert("$~ - procs born in a dead fiber share the method's escaped slot") do
+  skip unless Object.const_defined?(:Fiber)
+  wr, rd = backref_scope_dead_fiber_pair
+  assert_nil rd.call
+  wr.call
+  assert_equal "dw", rd.call
+end
+
+assert("$~ - a fiber's own matches are unreachable once it dies") do
+  skip unless Object.const_defined?(:Fiber)
+  # the fiber-local slot is its root frame's, and nothing chains to it,
+  # so it dies with the fiber the way CRuby's per-context root svar does
+  pr = nil
+  f = Fiber.new { "fl" =~ /fl/; pr = -> { $~ && $~[0] } }
+  "base" =~ /base/
+  f.resume
+  assert_equal "base", pr.call
+end
+
+assert("$~ - a scope escaping a collected fiber keeps its match") do
+  skip unless Object.const_defined?(:Fiber)
+  # the fiber is garbage while the method frame is still suspended on it;
+  # the GC detaches the frame's env, and the container rides along the way
+  # it does on an ordinary return
+  f = Fiber.new { backref_scope_collected_fiber }
+  pr = f.resume
+  f = nil
+  GC.start
+  assert_equal "cf", pr.call
+end
+
+assert("$~ - procs from a collected fiber share the escaped slot") do
+  skip unless Object.const_defined?(:Fiber)
+  f = Fiber.new { backref_scope_collected_fiber_pair }
+  wr, rd = f.resume
+  f = nil
+  GC.start
+  assert_nil rd.call
+  wr.call
+  assert_equal "gw", rd.call
+end
+
+assert("$~ - a collected fiber's own matches die with it") do
+  skip unless Object.const_defined?(:Fiber)
+  # the root frame's slot is the fiber's own, exactly as when it terminates;
+  # the proc's lexical chain passes the root block into this scope
+  pr = nil
+  f = Fiber.new { "fg" =~ /fg/; pr = -> { $~ && $~[0] }; Fiber.yield }
+  "hold" =~ /hold/
+  f.resume
+  f = nil
+  GC.start
+  assert_equal "hold", pr.call
+end
+
+def backref_scope_suspended_match_writer
+  Fiber.yield(-> { "uw" =~ /u(w)/; $1 })
+end
+
+assert("$~ - a write can collect the fiber it resolves into") do
+  skip unless Object.const_defined?(:Fiber)
+  # no GC.start here: the method frame the write resolves to is suspended
+  # on a fiber nothing references any more, and the write's own
+  # allocations may be what sweep it; the write must land in what
+  # survives
+  f = Fiber.new { backref_scope_suspended_match_writer }
+  wr = f.resume
+  f = nil
+  assert_equal "w", wr.call
+end
+
+def backref_scope_suspended_slot_writer(md)
+  Fiber.yield(-> { $~ = md; $~ && $~[0] })
+end
+
+def backref_scope_fiber_write_window(md)
+  f = Fiber.new { backref_scope_suspended_slot_writer(md) }
+  wr = f.resume
+  f = nil
+  wr.call
+end
+
+assert("$~ - the container allocation itself can collect the owner's fiber") do
+  skip unless Object.const_defined?(:Fiber)
+  # the MatchData is made in advance, so the first allocation after the
+  # fiber's last reference drops is the scope's container: under
+  # MRB_GC_STRESS the fiber is swept inside that very allocation, and the
+  # owner has to be resolved again before the store
+  "vw" =~ /v(w)/
+  assert_equal "vw", backref_scope_fiber_write_window($~)
+end
+
+assert("$~ - a proc escaping a live fiber reads its dead method scope") do
+  skip unless Object.const_defined?(:Fiber)
+  f, pr = backref_scope_fiber_escape
+  assert_equal "lf", pr.call
+  f.resume
+end
+
+assert("$~ - a fiber-born proc reads its live method scope from outside") do
+  skip unless Object.const_defined?(:Fiber)
+  assert_equal "lm", backref_scope_fiber_live { |pr| pr.call }
+end
+
+assert("$~ - a carried proc reads its defining scope from inside a fiber") do
+  skip unless Object.const_defined?(:Fiber)
+  "car" =~ /car/
+  rd = -> { $~ && $~[0] }
+  f = backref_scope_fiber_carried(rd)
+  assert_equal "car", f.resume
+end
+
+assert("$~ - a carried proc writes its defining scope from inside a fiber") do
+  skip unless Object.const_defined?(:Fiber)
+  wr = -> { "cw" =~ /cw/ }
+  "pre" =~ /pre/
+  f = backref_scope_fiber_carried(wr)
+  f.resume
+  assert_equal "cw", $~ && $~[0]
+end
+
+assert("$~ - a proc reaches a scope suspended on another fiber") do
+  skip unless Object.const_defined?(:Fiber)
+  # the write lands on a frame owned by neither the running nor the root
+  # context, the arm that marks through the owning fiber
+  f1 = Fiber.new { backref_scope_fiber_suspended_write }
+  wr = f1.resume
+  f2 = Fiber.new { wr.call }
+  f2.resume
+  assert_equal "xf", f1.resume
+  f3 = Fiber.new { backref_scope_fiber_suspended_read }
+  rd = f3.resume
+  f4 = Fiber.new { rd.call }
+  assert_equal "rf", f4.resume
+  f3.resume
+end
+
+def backref_scope_nested_load
+  "before" =~ /before/
+  inner = __backref_nested_load("'ab' =~ /a(b)/; [$~ && $~[0], $1]")
+  [inner, $~ && $~[0], $1]
+end
+
+assert("$~ - a nested load is transparent to the scope below") do
+  # A C function calling mrb_load_string() mid-execution (the helper in
+  # test/backref_scope.c) runs the loaded top proc on a frame with no
+  # scope of its own: reads and writes pass through to the Ruby scope
+  # below, the way rb_eval_string()'s do.
+  assert_equal [["ab", "b"], "ab", "b"], backref_scope_nested_load
+end
+
+assert("$~ - consecutive nested loads share the scope below") do
+  "keep" =~ /keep/
+  assert_equal "keep", __backref_nested_load("$~ && $~[0]")
+  __backref_nested_load("'x1' =~ /x(1)/")
+  assert_equal "x1", __backref_nested_load("$~ && $~[0]")
+  assert_equal ["x1", "1"], [$~ && $~[0], $1]
+end
+
+def backref_scope_nested_load_block
+  "before" =~ /before/
+  inner = __backref_nested_load("[1].each { 'ab' =~ /a(b)/ }; [$~ && $~[0], $1]")
+  [inner, $~ && $~[0], $1]
+end
+
+assert("$~ - a block inside a nested load shares the scope below too") do
+  # The block was written inside the loaded top proc, so the scope it was
+  # defined in is that scopeless frame, which owns no slot either: the
+  # match belongs to the same scope a match outside the block reaches.
+  assert_equal [["ab", "b"], "ab", "b"], backref_scope_nested_load_block
+end
+
+assert("$~ - a block inside a nested load reaches the loads that follow") do
+  "hold" =~ /hold/
+  __backref_nested_load("[1].each { 'y2' =~ /y(2)/ }")
+  assert_equal "y2", __backref_nested_load("$~ && $~[0]")
+  assert_equal ["y2", "2"], [$~ && $~[0], $1]
+end
+
+def backref_scope_nested_load_escape_read
+  'keep' =~ /keep/
+  pr = __backref_nested_load("-> { $~ && $~[0] }")
+  pr.call
+end
+
+assert("$~ - a proc escaping a nested load still reads the caller scope") do
+  # The transparency of the load frame outlives the frame: the escaped
+  # env adopts the caller scope's container when the load returns.
+  assert_equal "keep", backref_scope_nested_load_escape_read
+end
+
+def backref_scope_nested_load_escape_late
+  pr = __backref_nested_load("-> { $~ && $~[0] }")
+  'late' =~ /late/
+  pr.call
+end
+
+assert("$~ - a proc escaping a nested load sees a match made after it") do
+  # Neither side has written when the load returns, so the container the
+  # adoption makes is shared before it holds anything.
+  assert_equal "late", backref_scope_nested_load_escape_late
+end
+
+def backref_scope_nested_load_escape_write
+  "before" =~ /before/
+  pr = __backref_nested_load("-> { 'inner' =~ /inner/ }")
+  pr.call
+  $~ && $~[0]
+end
+
+assert("$~ - a proc escaping a nested load writes the caller scope") do
+  assert_equal "inner", backref_scope_nested_load_escape_write
+end
+
+def backref_scope_fiber_run(pr)
+  Fiber.new { pr.call }.resume
+end
+
+def backref_scope_nested_load_fiber_write
+  __backref_nested_load("pr = -> { 'x' =~ /(x)/ }; backref_scope_fiber_run(pr); $~ && $~[0]")
+end
+
+assert("$~ - a proc from a live nested load writes the scope below from a fiber") do
+  skip unless Object.const_defined?(:Fiber)
+  # the block's defining scope is the load frame, transparent from
+  # wherever resolution starts: the walk crosses the fiber onto the
+  # frame's context and keeps descending to the scope the load runs
+  # against
+  assert_equal "x", backref_scope_nested_load_fiber_write
+end
+
+def backref_scope_nested_load_escape_fiber_write
+  pr = __backref_nested_load("-> { 'y' =~ /(y)/ }")
+  backref_scope_fiber_run(pr)
+  [$~ && $~[0], $1]
+end
+
+assert("$~ - a proc escaping a nested load writes the caller scope from a fiber") do
+  skip unless Object.const_defined?(:Fiber)
+  assert_equal ["y", "y"], backref_scope_nested_load_escape_fiber_write
+end
+
+def backref_scope_nested_load_marked_scope
+  outer = -> { $~ && $~[0] }
+  pr = __backref_nested_load("inner = -> { $~ && $~[0] }; GC.start; inner")
+  "late" =~ /late/
+  [outer.call, pr.call]
+end
+
+assert("$~ - a nested load marked mid-run stays transparent after it returns") do
+  skip unless Object.const_defined?(:Fiber)
+  # A collection while the load runs records what the load frame's env will
+  # carry into escape, the scope below holding no container yet: a forward
+  # to that scope's env, still on the stack. The return then carries the
+  # forward rather than adopting a container, and resolution crosses it to
+  # the same scope either way.
+  assert_equal ["late", "late"], Fiber.new { backref_scope_nested_load_marked_scope }.resume
+end
+
+def backref_scope_nested_load_marked_write
+  outer = -> { $~ && $~[0] }
+  pr = __backref_nested_load("inner = -> { 'w' =~ /(w)/ }; GC.start; inner")
+  pr.call
+  [outer.call, $~ && $~[0], $1]
+end
+
+assert("$~ - a proc escaping a marked nested load writes the scope below") do
+  skip unless Object.const_defined?(:Fiber)
+  assert_equal ["w", "w", "w"], Fiber.new { backref_scope_nested_load_marked_write }.resume
+end
+
+def backref_scope_eval
+  "before" =~ /before/
+  inner = eval("'ab' =~ /a(b)/; [$~ && $~[0], $1]")
+  [inner, $~ && $~[0], $1]
+end
+
+assert("$~ - eval shares the scope it is called from") do
+  skip unless respond_to?(:eval, true)
+  # The proc `eval` compiles takes its caller's env as upper, so owner
+  # resolution reads it as a block and lands on the calling scope: the
+  # match is the caller's, the way CRuby's `eval` shares its caller's svar.
+  assert_equal [["ab", "b"], "ab", "b"], backref_scope_eval
+end
+
+def backref_scope_eval_reads_caller
+  "seen" =~ /seen/
+  eval("$~ && $~[0]")
+end
+
+assert("$~ - eval reads the match its caller already made") do
+  skip unless respond_to?(:eval, true)
+  assert_equal "seen", backref_scope_eval_reads_caller
+end
+
+def backref_scope_eval_clears
+  "keep" =~ /keep/
+  eval("'aa' =~ /zzz/")
+  [$~, $1]
+end
+
+assert("$~ - a failed match inside eval clears the calling scope") do
+  skip unless respond_to?(:eval, true)
+  # sharing the scope means the failure publishes nil into it, rather than
+  # leaving the caller's own match standing
+  assert_equal [nil, nil], backref_scope_eval_clears
+end
+
+def backref_scope_eval_in_block
+  "before" =~ /before/
+  [1].each { eval("'cd' =~ /c(d)/") }
+  [$~ && $~[0], $1]
+end
+
+assert("$~ - eval called inside a block reaches the method's scope") do
+  skip unless respond_to?(:eval, true)
+  # two links: the eval proc's scope is the block, and the block's is the
+  # method, which is where the slot is
+  assert_equal ["cd", "d"], backref_scope_eval_in_block
+end
+
+def backref_scope_eval_in_eval
+  "top" =~ /top/
+  eval("eval(\"'nn' =~ /n(n)/\")")
+  [$~ && $~[0], $1]
+end
+
+assert("$~ - eval nested in eval reaches the same scope") do
+  skip unless respond_to?(:eval, true)
+  assert_equal ["nn", "n"], backref_scope_eval_in_eval
+end
+
+def backref_scope_instance_eval
+  "before" =~ /before/
+  Object.new.instance_eval("'ef' =~ /e(f)/")
+  [$~ && $~[0], $1]
+end
+
+assert("$~ - instance_eval on a string shares the calling scope") do
+  skip unless respond_to?(:eval, true)
+  # the receiver changes, the scope does not
+  assert_equal ["ef", "f"], backref_scope_instance_eval
+end
+
+def backref_scope_binding_source
+  "src" =~ /src/
+  binding
+end
+
+def backref_scope_binding_write
+  "here" =~ /here/
+  backref_scope_binding_source.eval("'zz' =~ /z(z)/")
+  [$~ && $~[0], $1]
+end
+
+assert("$~ - Binding#eval writes the bound scope, not the calling one") do
+  skip unless respond_to?(:eval, true)
+  # the binding hands eval a scope of its own, so this is the one eval
+  # shape where the calling scope is not the owner: it keeps its own match
+  assert_equal ["here", nil], backref_scope_binding_write
+end
+
+def backref_scope_binding_read
+  "here" =~ /here/
+  backref_scope_binding_source.eval("$~ && $~[0]")
+end
+
+assert("$~ - Binding#eval reads the bound scope after it has returned") do
+  skip unless respond_to?(:eval, true)
+  # the bound method returned before the eval runs, so what is read is the
+  # match cipop() moved into its closed env
+  assert_equal "src", backref_scope_binding_read
+end
+
+# --- the special-variable container -------------------------------------
+#
+# `$~` is one key of a per-scope container (CRuby's svar), and the shapes
+# below pin what a single-value slot could not carry: a second key living
+# in the same scope. No global is registered for MRB_SVAR_LASTLINE yet, so
+# the C helpers above drive it through the public accessors; each helper is
+# a C frame, transparent to owner resolution, so a call lands on the
+# calling Ruby scope the way a `$_` built on them would. The expectations
+# mirror CRuby's `$_`/`$~` behaviour.
+
+def svar_container_coexist
+  __svar_lastline_set(123)
+  "outer" =~ /outer/
+  [__svar_lastline, $~ && $~[0]]
+end
+
+assert("svar - two keys coexist in one scope") do
+  assert_equal [123, "outer"], svar_container_coexist
+end
+
+def svar_container_no_clobber
+  __svar_lastline_set(123)
+  "foo" =~ /foo/
+  __svar_lastline_set(456)
+  [__svar_lastline, $~ && $~[0]]
+end
+
+assert("svar - writing one key leaves the other key's value") do
+  assert_equal [456, "foo"], svar_container_no_clobber
+end
+
+def svar_container_inner
+  __svar_lastline_set("inner")
+  "inner" =~ /inner/
+  [__svar_lastline, $~ && $~[0]]
+end
+
+def svar_container_isolation
+  __svar_lastline_set("outer")
+  "outer" =~ /outer/
+  [svar_container_inner, __svar_lastline, $~ && $~[0]]
+end
+
+assert("svar - a method's container is invisible to its caller") do
+  assert_equal [["inner", "inner"], "outer", "outer"], svar_container_isolation
+end
+
+def svar_container_escape
+  __svar_lastline_set("captured")
+  "captured" =~ /captured/
+  -> { [__svar_lastline, $~ && $~[0]] }
+end
+
+assert("svar - an escaped proc reads both keys of its dead scope") do
+  assert_equal ["captured", "captured"], svar_container_escape.call
+end
+
+def svar_container_immediates
+  __svar_lastline_set(123)
+  a = __svar_lastline
+  __svar_lastline_set(:sym)
+  b = __svar_lastline
+  __svar_lastline_set(nil)
+  c = __svar_lastline
+  [a, b, c]
+end
+
+assert("svar - a slot holds immediates, and nil clears it") do
+  assert_equal [123, :sym, nil], svar_container_immediates
+end
+
+def svar_container_lazy_nil
+  __svar_lastline_set(nil)
+  __svar_container?
+end
+
+def svar_container_lazy_write
+  __svar_lastline_set(1)
+  __svar_container?
+end
+
+assert("svar - a nil write into an empty scope allocates no container") do
+  assert_false svar_container_lazy_nil
+  assert_true svar_container_lazy_write
+end
+
+def svar_container_fiber
+  __svar_lastline_set("main")
+  "main" =~ /main/
+  f = Fiber.new do
+    __svar_lastline_set("fiber")
+    "fiber" =~ /fiber/
+    [__svar_lastline, $~ && $~[0]]
+  end
+  [f.resume, __svar_lastline, $~ && $~[0]]
+end
+
+assert("svar - a fiber's container stays its own, both keys") do
+  skip unless Object.const_defined?(:Fiber)
+  assert_equal [["fiber", "fiber"], "main", "main"], svar_container_fiber
+end

--- a/mrbgems/mruby-regexp/test/match_data.rb
+++ b/mrbgems/mruby-regexp/test/match_data.rb
@@ -383,12 +383,10 @@ assert("the five names read the match, not the methods that read it") do
 end
 
 assert("the five names read whatever answers the private names") do
-  # They are sends, so they read what the `$~` in hand answers, MatchData or
-  # not. CRuby's setter refuses a `$~` that is not a MatchData and mruby has
-  # no hook on a global write to refuse from, so the private names buy one
-  # thing only: an accident (a `$~` holding an Array, a redefined
-  # `MatchData#[]`) is not read as a match. Rewriting the readings themselves
-  # is still asking for what comes back.
+  # They are sends, so they read what the `$~` in hand answers. The setter
+  # refuses anything that is not a MatchData (below), so the private names
+  # buy one thing: a redefined `MatchData#[]` is not read as a match.
+  # Rewriting the readings themselves is still asking for what comes back.
   /(b)(c)?/ =~ "abz"
   md = $~
   def md.__group(n)
@@ -398,41 +396,17 @@ assert("the five names read whatever answers the private names") do
   assert_equal "PWNED1", $1
   assert_equal "a", $`
   assert_equal "b", $+
-
-  # a stand-in that never was a match reads the same way
-  begin
-    fake = Object.new
-    def fake.__group(n)
-      "FAKE#{n}"
-    end
-    def fake.__pre_match
-      "FAKEPRE"
-    end
-    $~ = fake
-    assert_equal "FAKE0", $&
-    assert_equal "FAKE1", $1
-    assert_equal "FAKEPRE", $`
-  ensure
-    $~ = nil
-  end
 end
 
-assert("$& and $1 onward refuse a $~ that is not a MatchData") do
-  # `$~` is a plain global and takes any value, where CRuby's setter raises
-  # TypeError. A value that answers `[]` would answer `$1` as well were the
-  # names derived with `[]`, so they ask for the group by a name a MatchData
-  # alone carries and a wrong `$~` is a NoMethodError rather than an answer.
+assert("$& and $1 onward cannot see a $~ that is not a MatchData") do
+  # The names are derived from `$~`, and the setter is what stands between
+  # them and a wrong value: like CRuby's, it refuses anything but a
+  # MatchData or nil with TypeError at the write, so a `$~` holding an Array
+  # is a state the readers never see, and the refused write changes nothing.
   /(b)(c)?/ =~ "abz"
-  begin
-    $~ = [10, 20, 30]
-    assert_raise(NoMethodError) { $& }
-    assert_raise(NoMethodError) { $1 }
-    assert_raise(NoMethodError) { $+ }
-    assert_raise(NoMethodError) { $` }
-    assert_raise(NoMethodError) { $' }
-  ensure
-    $~ = nil
-  end
+  assert_raise(TypeError) { $~ = [10, 20, 30] }
+  assert_equal "b", $&
+  assert_equal "b", $1
 end
 
 assert("a piece cut from a subject is its own string") do

--- a/mrbgems/mruby-task/src/task.c
+++ b/mrbgems/mruby-task/src/task.c
@@ -39,8 +39,11 @@
  * An escaped closure keeps its REnv alive after the task is gone; if the
  * env still points into the freed stack, the next GC marks garbage and
  * crashes in mrb_gc_mark. mruby does the same for fibers in gc.c's
- * MRB_TT_FIBER free path; the walk both come through is
- * mrb_env_detach_all() (vm.c).
+ * MRB_TT_FIBER free path; the shared walk and the carrying policy for
+ * each frame's special-variable container live in mrb_env_detach_all()
+ * (vm.c). TRUE because this teardown runs outside a collection, so a
+ * scopeless frame's owner is resolved here, on this side of the C
+ * boundary a preempted nested load stopped at.
  *
  * Only called while the VM is alive. A task stays GC-registered for its
  * whole life, so the GC frees one only while tearing the heap down, and
@@ -49,7 +52,7 @@
 static void
 task_unshare_envs(mrb_state *mrb, struct mrb_context *c)
 {
-  mrb_env_detach_all(mrb, c);
+  mrb_env_detach_all(mrb, c, TRUE);
 }
 
 /*

--- a/mrbgems/mruby-task/src/task.c
+++ b/mrbgems/mruby-task/src/task.c
@@ -161,6 +161,14 @@ mrb_task_mark_all(mrb_state *mrb)
           if (ci->proc) {
             mrb_gc_mark(mrb, (struct RBasic*)ci->proc);
           }
+          if (ci->svar) {
+            /* the frame's special-variable slot, which mark_context() in
+               gc.c marks for every context this walk does not reach. A task
+               context has no fiber to be marked through, and a write to the
+               slot takes no barrier, so this walk is also its atomic
+               re-scan, like the value stack's above. */
+            mrb_gc_mark(mrb, (struct RBasic*)ci->svar);
+          }
           if (ci->u.target_class) {
             mrb_gc_mark(mrb, (struct RBasic*)ci->u.target_class);
           }
@@ -1752,6 +1760,9 @@ mrb_task_reset_context(mrb_state *mrb, mrb_value task)
   c->status = MRB_TASK_CREATED;
   if (c->ci) {
     mrb_vm_ci_target_class_set(c->ci, mrb->object_class);
+    /* the special variables of the previous run die with it: the next
+       body starts with `$~` unset, as a fresh task's does */
+    c->ci->svar = NULL;
   }
 }
 

--- a/mrbgems/mruby-test/driver.c
+++ b/mrbgems/mruby-test/driver.c
@@ -28,6 +28,7 @@ void mrbgemtest_init(mrb_state* mrb);
 void mrb_init_test_vformat(mrb_state* mrb);
 void mrb_init_test_notimplement(mrb_state* mrb);
 void mrb_init_test_sysfail(mrb_state* mrb);
+void mrb_init_test_env(mrb_state* mrb);
 
 /* Print a short remark for the user */
 static void
@@ -266,6 +267,7 @@ mrb_init_test_driver(mrb_state *mrb, mrb_bool verbose)
   mrb_init_test_vformat(mrb);
   mrb_init_test_notimplement(mrb);
   mrb_init_test_sysfail(mrb);
+  mrb_init_test_env(mrb);
 
   if (verbose) {
     mrb_gv_set(mrb, mrb_intern_lit(mrb, "$mrbtest_verbose"), mrb_true_value());

--- a/mrbgems/mruby-test/env.c
+++ b/mrbgems/mruby-test/env.c
@@ -1,0 +1,144 @@
+/*
+** env.c - helpers for test/t/env.rb
+**
+** The shape of a closed env's heap stack has no Ruby-visible face, so the
+** invariants of mruby/internal.h are asked about from here: only an env
+** flagged as carrying the special-variable slot has one, and a closed env
+** sized without it grows into one on the first write that needs it.
+*/
+
+#include <stdlib.h>
+#include <mruby.h>
+#include <mruby/proc.h>
+#include <mruby/internal.h>
+#include <mruby/variable.h>
+
+void mrb_init_test_env(mrb_state *mrb);
+
+/* The env a proc closed over, or NULL where it holds none. */
+static struct REnv*
+env_of_proc(mrb_state *mrb, mrb_value proc)
+{
+  mrb_check_type(mrb, proc, MRB_TT_PROC);
+  return MRB_PROC_ENV(mrb_proc_ptr(proc));
+}
+
+/* Whether the proc's env carries the slot past its locals; nil where the
+   proc closed over no env at all. */
+static mrb_value
+env_svar_p(mrb_state *mrb, mrb_value self)
+{
+  mrb_value proc = mrb_get_arg1(mrb);
+  struct REnv *e = env_of_proc(mrb, proc);
+
+  if (!e) return mrb_nil_value();
+  return mrb_bool_value(MRB_ENV_SVAR_P(e));
+}
+
+/* The number of locals the env holds, which is where the slot sits when
+   the env carries one. */
+static mrb_value
+env_len(mrb_state *mrb, mrb_value self)
+{
+  mrb_value proc = mrb_get_arg1(mrb);
+  struct REnv *e = env_of_proc(mrb, proc);
+
+  if (!e) return mrb_nil_value();
+  return mrb_int_value(mrb, MRB_ENV_LEN(e));
+}
+
+/* What the slot holds, named rather than returned: the container is an
+   internal object with no Ruby face. :none where the env carries no
+   slot. */
+static mrb_value
+env_svar_slot(mrb_state *mrb, mrb_value self)
+{
+  mrb_value proc = mrb_get_arg1(mrb);
+  struct REnv *e = env_of_proc(mrb, proc);
+
+  if (!e || !MRB_ENV_SVAR_P(e)) return mrb_symbol_value(mrb_intern_lit(mrb, "none"));
+
+  mrb_value v = MRB_ENV_SVAR_SLOT(e->stack, MRB_ENV_LEN(e));
+  switch (mrb_type(v)) {
+  case MRB_TT_FALSE:
+    if (mrb_nil_p(v)) return mrb_symbol_value(mrb_intern_lit(mrb, "nil"));
+    break;
+  case MRB_TT_SVAR:
+    return mrb_symbol_value(mrb_intern_lit(mrb, "svar"));
+  default:
+    break;
+  }
+  return mrb_symbol_value(mrb_intern_lit(mrb, "other"));
+}
+
+/* Rewrites the proc's env into what out-of-tree code builds by hand: a
+   closed env over a heap stack of exactly its locals, carrying no slot.
+   The stack shrinks for real, so a later read one past the locals is an
+   out-of-bounds access a sanitizer build reports. FALSE where the env is
+   not one this can be done to (on the stack, already without the slot, or
+   holding no locals to keep the allocation non-empty). */
+static mrb_value
+env_make_legacy(mrb_state *mrb, mrb_value self)
+{
+  mrb_value proc = mrb_get_arg1(mrb);
+  struct REnv *e = env_of_proc(mrb, proc);
+
+  if (!e || MRB_ENV_ONSTACK_P(e) || !MRB_ENV_SVAR_P(e)) return mrb_false_value();
+  size_t len = (size_t)MRB_ENV_LEN(e);
+  if (len == 0) return mrb_false_value();
+
+  e->stack = (mrb_value*)mrb_realloc(mrb, e->stack, sizeof(mrb_value) * len);
+  MRB_ENV_CLEAR_SVAR(e);
+  return mrb_true_value();
+}
+
+/* A special-variable read and write from a C frame, which owns no scope of
+   its own, so both land on the calling Ruby scope. MRB_SVAR_LASTLINE is
+   the key no global is registered for in core, so what these drive is the
+   container itself rather than any one variable's semantics. */
+static mrb_value
+env_svar_read(mrb_state *mrb, mrb_value self)
+{
+  return mrb_vm_svar_get(mrb, MRB_SVAR_LASTLINE);
+}
+
+static mrb_value
+env_svar_write(mrb_state *mrb, mrb_value self)
+{
+  mrb_value v = mrb_get_arg1(mrb);
+
+  mrb_vm_svar_set(mrb, MRB_SVAR_LASTLINE, v);
+  return v;
+}
+
+/* A proc over an env core itself builds without the slot: a C closure owns
+   no Ruby scope, so mrb_proc_new_cfunc_with_env() sizes its stack at
+   exactly the values handed to it. Calling the proc answers value 0 back,
+   which is what a GC that walked the env correctly leaves behind. */
+static mrb_value
+env_cfunc_value(mrb_state *mrb, mrb_value self)
+{
+  return mrb_cfunc_env_get(mrb, 0);
+}
+
+static mrb_value
+env_cfunc_proc_new(mrb_state *mrb, mrb_value self)
+{
+  mrb_value v = mrb_get_arg1(mrb);
+
+  return mrb_obj_value(mrb_proc_new_cfunc_with_env(mrb, env_cfunc_value, 1, &v));
+}
+
+void
+mrb_init_test_env(mrb_state *mrb)
+{
+  struct RClass *o = mrb->object_class;
+
+  mrb_define_method(mrb, o, "__env_svar?", env_svar_p, MRB_ARGS_REQ(1));
+  mrb_define_method(mrb, o, "__env_len", env_len, MRB_ARGS_REQ(1));
+  mrb_define_method(mrb, o, "__env_svar_slot", env_svar_slot, MRB_ARGS_REQ(1));
+  mrb_define_method(mrb, o, "__env_make_legacy", env_make_legacy, MRB_ARGS_REQ(1));
+  mrb_define_method(mrb, o, "__env_svar_read", env_svar_read, MRB_ARGS_NONE());
+  mrb_define_method(mrb, o, "__env_svar_write", env_svar_write, MRB_ARGS_REQ(1));
+  mrb_define_method(mrb, o, "__env_cfunc_proc", env_cfunc_proc_new, MRB_ARGS_REQ(1));
+}

--- a/mrbgems/mruby-test/env.c
+++ b/mrbgems/mruby-test/env.c
@@ -8,6 +8,11 @@
 **
 ** The shutdown probe at the bottom asks the same about the teardown
 ** mrb_close() runs, which no Ruby frame outlives.
+**
+** A second, unrelated probe lives here too: mruby/proc.h documents
+** MRB_ENV_SET_BIDX() as public, so its idx argument must be safe to pass
+** an expression with a side effect, which env_set_bidx_eval_count() below
+** checks by counting.
 */
 
 #include <stdlib.h>
@@ -24,6 +29,22 @@ env_of_proc(mrb_state *mrb, mrb_value proc)
 {
   mrb_check_type(mrb, proc, MRB_TT_PROC);
   return MRB_PROC_ENV(mrb_proc_ptr(proc));
+}
+
+/* MRB_ENV_SET_BIDX() is documented public (mruby/proc.h), so an idx
+   argument with a side effect must be evaluated exactly once: mrb_assert()
+   used to make the macro's own body evaluate idx a second time under
+   MRB_DEBUG. The fake env never reaches the GC; only its flags word is
+   touched. */
+static mrb_value
+env_set_bidx_eval_count(mrb_state *mrb, mrb_value self)
+{
+  struct REnv fake;
+  int count = 0;
+
+  fake.flags = 0;
+  MRB_ENV_SET_BIDX(&fake, count++);
+  return mrb_int_value(mrb, count);
 }
 
 /* Whether the proc's env carries the slot past its locals; nil where the
@@ -238,6 +259,7 @@ mrb_init_test_env(mrb_state *mrb)
   mrb_define_method(mrb, o, "__env_len", env_len, MRB_ARGS_REQ(1));
   mrb_define_method(mrb, o, "__env_svar_slot", env_svar_slot, MRB_ARGS_REQ(1));
   mrb_define_method(mrb, o, "__env_make_legacy", env_make_legacy, MRB_ARGS_REQ(1));
+  mrb_define_method(mrb, o, "__env_set_bidx_eval_count", env_set_bidx_eval_count, MRB_ARGS_NONE());
   mrb_define_method(mrb, o, "__env_svar_read", env_svar_read, MRB_ARGS_NONE());
   mrb_define_method(mrb, o, "__env_svar_write", env_svar_write, MRB_ARGS_REQ(1));
   mrb_define_method(mrb, o, "__env_cfunc_proc", env_cfunc_proc_new, MRB_ARGS_REQ(1));

--- a/mrbgems/mruby-test/env.c
+++ b/mrbgems/mruby-test/env.c
@@ -97,27 +97,6 @@ env_svar_slot(mrb_state *mrb, mrb_value self)
   return mrb_symbol_value(mrb_intern_lit(mrb, "other"));
 }
 
-/* Rewrites the proc's env into what out-of-tree code builds by hand: a
-   closed env over a heap stack of exactly its locals, carrying no slot.
-   The stack shrinks for real, so a later read one past the locals is an
-   out-of-bounds access a sanitizer build reports. FALSE where the env is
-   not one this can be done to (on the stack, already without the slot, or
-   holding no locals to keep the allocation non-empty). */
-static mrb_value
-env_make_legacy(mrb_state *mrb, mrb_value self)
-{
-  mrb_value proc = mrb_get_arg1(mrb);
-  struct REnv *e = env_of_proc(mrb, proc);
-
-  if (!e || MRB_ENV_ONSTACK_P(e) || !MRB_ENV_SVAR_P(e)) return mrb_false_value();
-  size_t len = (size_t)MRB_ENV_LEN(e);
-  if (len == 0) return mrb_false_value();
-
-  e->stack = (mrb_value*)mrb_realloc(mrb, e->stack, sizeof(mrb_value) * len);
-  MRB_ENV_CLEAR_SVAR(e);
-  return mrb_true_value();
-}
-
 /* A special-variable read and write from a C frame, which owns no scope of
    its own, so both land on the calling Ruby scope. MRB_SVAR_LASTLINE is
    the key no global is registered for in core, so what these drive is the
@@ -258,7 +237,6 @@ mrb_init_test_env(mrb_state *mrb)
   mrb_define_method(mrb, o, "__env_svar?", env_svar_p, MRB_ARGS_REQ(1));
   mrb_define_method(mrb, o, "__env_len", env_len, MRB_ARGS_REQ(1));
   mrb_define_method(mrb, o, "__env_svar_slot", env_svar_slot, MRB_ARGS_REQ(1));
-  mrb_define_method(mrb, o, "__env_make_legacy", env_make_legacy, MRB_ARGS_REQ(1));
   mrb_define_method(mrb, o, "__env_set_bidx_eval_count", env_set_bidx_eval_count, MRB_ARGS_NONE());
   mrb_define_method(mrb, o, "__env_svar_read", env_svar_read, MRB_ARGS_NONE());
   mrb_define_method(mrb, o, "__env_svar_write", env_svar_write, MRB_ARGS_REQ(1));

--- a/mrbgems/mruby-test/env.c
+++ b/mrbgems/mruby-test/env.c
@@ -5,6 +5,9 @@
 ** invariants of mruby/internal.h are asked about from here: only an env
 ** flagged as carrying the special-variable slot has one, and a closed env
 ** sized without it grows into one on the first write that needs it.
+**
+** The shutdown probe at the bottom asks the same about the teardown
+** mrb_close() runs, which no Ruby frame outlives.
 */
 
 #include <stdlib.h>
@@ -48,8 +51,8 @@ env_len(mrb_state *mrb, mrb_value self)
 }
 
 /* What the slot holds, named rather than returned: the container is an
-   internal object with no Ruby face. :none where the env carries no
-   slot. */
+   internal object with no Ruby face, and neither is a forwarded env.
+   :none where the env carries no slot. */
 static mrb_value
 env_svar_slot(mrb_state *mrb, mrb_value self)
 {
@@ -65,6 +68,8 @@ env_svar_slot(mrb_state *mrb, mrb_value self)
     break;
   case MRB_TT_SVAR:
     return mrb_symbol_value(mrb_intern_lit(mrb, "svar"));
+  case MRB_TT_ENV:
+    return mrb_symbol_value(mrb_intern_lit(mrb, "env"));
   default:
     break;
   }
@@ -129,6 +134,101 @@ env_cfunc_proc_new(mrb_state *mrb, mrb_value self)
   return mrb_obj_value(mrb_proc_new_cfunc_with_env(mrb, env_cfunc_value, 1, &v));
 }
 
+/* What mrb_close() does before it runs the atexit callbacks
+   (mrb_protect_atexit() in error.c): the top-level frame's env is detached
+   and the frame's special-variable container follows it into the escaped
+   env, so a proc an atexit callback calls still reads what the top level
+   could see. The arena is already restored there, which leaves the frame
+   the container's only root until mrb_env_detach() stores it, and
+   mrb_env_unshare() allocates in between; a collection in that window and
+   the slot is handed a swept object.
+
+   Asking about that window takes a state of its own, the answer being
+   there only once mrb_close() has run, and an atexit callback to read it
+   from, nothing Ruby-side outliving the teardown. What makes the window
+   fire is the collection MRB_GC_STRESS puts in every allocation: the
+   unshare's is a plain mrb_malloc_simple(), which no other build collects
+   in short of running out of memory. So the probe answers nil where the
+   build cannot discriminate, and the test skips rather than passing on a
+   window that never opened. */
+#if defined(MRBTEST_COMPILER_PRISM) && defined(MRB_GC_STRESS) && defined(MRB_DEBUG)
+/* MRBTEST_COMPILER_PRISM (mrbgem.rake) says mruby-compiler is in this
+   build, which is what mrb_load_string() below needs, and `global_mrb` is
+   that gem's allocator hook: mrc_ccontext_new() points it at whatever
+   state compiles, so the caller's has to be put back. */
+#include <mruby/compile.h>
+
+extern mrb_state *global_mrb;
+
+struct shutdown_probe {
+  mrb_bool ran;         /* the callback was reached at all */
+  mrb_bool shaped;      /* the escaped env is the one the probe asks about */
+  mrb_bool kept;        /* and its slot still holds the container */
+};
+
+/* Registered last, so it runs first of the state's atexit callbacks and
+   sees what the detach published rather than what a later callback left. */
+static void
+shutdown_probe_run(mrb_state *mrb)
+{
+  struct shutdown_probe *probe = (struct shutdown_probe*)mrb->ud;
+  mrb_value pr = mrb_gv_get(mrb, mrb_intern_lit(mrb, "$mrbtest_env_escape"));
+
+  probe->ran = TRUE;
+  if (mrb_type(pr) != MRB_TT_PROC) return;
+
+  struct REnv *e = MRB_PROC_ENV(mrb_proc_ptr(pr));
+  if (!e || MRB_ENV_ONSTACK_P(e) || !MRB_ENV_SVAR_P(e)) return;
+
+  /* The slot holds the container the top-level scope wrote. A sweep in the
+     window leaves a freed object there instead, which reads as neither a
+     container nor anything else the write could have put in the slot. */
+  probe->shaped = TRUE;
+  probe->kept = mrb_type(MRB_ENV_SVAR_SLOT(e->stack, MRB_ENV_LEN(e))) == MRB_TT_SVAR;
+}
+
+static mrb_value
+env_shutdown_svar(mrb_state *mrb, mrb_value self)
+{
+  struct shutdown_probe probe = { FALSE, FALSE, FALSE };
+  mrb_state *caller = global_mrb;
+  /* core alone: the teardown under test is core's, and the gems would only
+     make the state the probe throws away costlier to build */
+  mrb_state *sub = mrb_open_core();
+
+  if (sub) {
+    sub->ud = &probe;
+    mrb_init_test_env(sub);
+    /* Building the state is setup, not the window under test, and under
+       MRB_GC_STRESS every allocation of it would collect; the teardown is
+       what has to. */
+    sub->gc.disabled = TRUE;
+    /* a block over the top-level frame, kept by a global so the env
+       outlives the teardown, and a container on the scope that block
+       resolves to */
+    mrb_load_string(sub,
+                    "def __mrbtest_env_keep(&b); b; end\n"
+                    "$mrbtest_env_escape = __mrbtest_env_keep { }\n"
+                    "__env_svar_write(true)\n");
+    sub->gc.disabled = FALSE;
+    if (!sub->exc) {
+      mrb_state_atexit(sub, shutdown_probe_run);
+    }
+    mrb_close(sub);
+  }
+  global_mrb = caller;
+
+  if (!probe.ran || !probe.shaped) return mrb_nil_value();
+  return mrb_bool_value(probe.kept);
+}
+#else
+static mrb_value
+env_shutdown_svar(mrb_state *mrb, mrb_value self)
+{
+  return mrb_nil_value();
+}
+#endif
+
 void
 mrb_init_test_env(mrb_state *mrb)
 {
@@ -141,4 +241,5 @@ mrb_init_test_env(mrb_state *mrb)
   mrb_define_method(mrb, o, "__env_svar_read", env_svar_read, MRB_ARGS_NONE());
   mrb_define_method(mrb, o, "__env_svar_write", env_svar_write, MRB_ARGS_REQ(1));
   mrb_define_method(mrb, o, "__env_cfunc_proc", env_cfunc_proc_new, MRB_ARGS_REQ(1));
+  mrb_define_method(mrb, o, "__env_shutdown_svar", env_shutdown_svar, MRB_ARGS_NONE());
 }

--- a/src/error.c
+++ b/src/error.c
@@ -781,12 +781,18 @@ mrb_protect_atexit(mrb_state *mrb)
       if (c->ci == c->cibase) {
         // Since there is no problem with the ci, the env object is detached normally.
         struct REnv *e = mrb_vm_ci_env(c->ci);
-        *c->ci = zero;
-        c->ci->stack = c->stbase;
+        struct RBasic *sv = c->ci->svar;
         if (e) {
           c->ci->u.env = NULL;
-          mrb_env_unshare(mrb, e, TRUE);
+          /* carrying the top-level scope's special-variable container, so a
+             proc an atexit callback runs still reads the last match. The
+             frame is zeroed after the detach, not before: ci->svar is the
+             container's only root here, the arena having just been
+             restored, and mrb_env_unshare() allocates. */
+          mrb_env_detach(mrb, e, sv, TRUE);
         }
+        *c->ci = zero;
+        c->ci->stack = c->stbase;
       }
       else {
         // Any env objects on the ci that are in the process of being executed are destroyed.

--- a/src/error.c
+++ b/src/error.c
@@ -797,6 +797,8 @@ mrb_protect_atexit(mrb_state *mrb)
             MRB_ENV_SET_LEN(e, 0);
             MRB_ENV_SET_BIDX(e, 0);
             MRB_ENV_CLOSE(e);
+            /* the stack is gone, so the slot past it is too (internal.h) */
+            MRB_ENV_CLEAR_SVAR(e);
           }
         } while (c->ci-- > c->cibase);
         c->ci = c->cibase;

--- a/src/gc.c
+++ b/src/gc.c
@@ -1010,6 +1010,44 @@ gc_mark_children(mrb_state *mrb, mrb_gc *gc, struct RBasic *obj)
         mrb_assert(e->stack != NULL);
         mrb_gc_mark_value(mrb, MRB_ENV_SVAR_SLOT(e->stack, len));
       }
+      else if (MRB_ENV_ONSTACK_P(e) && e->cxt && e->cxt != mrb->root_c && e->cxt->cibase) {
+        /* The owning frame's special-variable container is kept alive
+           through the env, not only through the context: a suspended fiber
+           dead to the GC no longer marks its ci stack, while this env, held
+           by an escaped proc, still marks the locals; the container has to
+           survive the same way for the detach in the fiber's free to move
+           it into the heap copy (see mrb_env_detach() in vm.c). What is
+           marked is what that detach will carry: for a scopeless frame what
+           the scope further down has, resolved by
+           mrb_svar_frame_container() in vm.c and stashed in the frame's own
+           slot, because the free runs inside the sweep, where this
+           resolution's walk could chase objects already swept and recycled:
+           what it can trust is what this mark, running on intact memory,
+           left in ci->svar. The root frame is left out of the stash: its
+           container dies with the context, so the detach never reads it,
+           and a slot resolution can end on is one no forward may occupy.
+           Envs on the root context skip all of it: that context is never
+           torn down and root_scan_phase() marks its frames' containers, and
+           the owner a scopeless resolution would find is reached through
+           the marked proc chain. */
+        struct mrb_context *c = e->cxt;
+        /* Stop AT cibase rather than decrementing past it: forming a
+           pointer one element before the start of an array is undefined
+           behavior. */
+        for (mrb_callinfo *ci = c->ci; ; ci--) {
+          if (ci->u.env == e) {
+            struct RBasic *sv = ci->svar;
+            if (!sv && ci != c->cibase) {
+              sv = mrb_svar_frame_container(c, ci);
+              if (sv) ci->svar = sv;
+            }
+            mrb_gc_mark(mrb, sv);
+            children++;
+            break;
+          }
+          if (ci == c->cibase) break;
+        }
+      }
       children += len;
     }
     break;
@@ -1209,7 +1247,13 @@ obj_free(mrb_state *mrb, struct RBasic *obj, mrb_bool end)
 
       if (c && c != mrb->root_c) {
         if (!end && c->status != MRB_FIBER_TERMINATED) {
-          mrb_env_detach_all(mrb, c);
+          /* Every surviving env escapes with its frame's container (see
+             mrb_env_detach_all() in vm.c for the carrying policy); FALSE
+             because this runs inside the sweep, where resolving an owner
+             would chase objects already swept, so a scopeless frame's
+             carrier is what gc_mark_children() stashed in its ci->svar,
+             which is a container or a forward to the scope below's env. */
+          mrb_env_detach_all(mrb, c, FALSE);
         }
         mrb_free_context(mrb, c);
       }

--- a/src/gc.c
+++ b/src/gc.c
@@ -931,6 +931,7 @@ mark_context(mrb_state *mrb, struct mrb_context *c)
   if (c->cibase) {
     for (ci = c->cibase; ci <= c->ci; ci++) {
       mrb_gc_mark(mrb, (struct RBasic*)ci->proc);
+      mrb_gc_mark(mrb, ci->svar);
       mrb_gc_mark(mrb, (struct RBasic*)ci->u.target_class);
     }
   }
@@ -1000,15 +1001,31 @@ gc_mark_children(mrb_state *mrb, mrb_gc *gc, struct RBasic *obj)
         mrb_gc_mark_value(mrb, e->stack[i]);
       }
       if (MRB_ENV_SVAR_P(e)) {
-        /* the escaped scope's special variables, one slot past the locals
-           (see internal.h). Only an env whose flag says it carries the slot
-           has one: a closed env sized without it, which out-of-tree code
-           builds by hand, ends its allocation at the locals. */
+        /* the escaped scope's special-variable container, one slot past the
+           locals (see mrb_env_detach() in vm.c). Only an env whose flag says
+           it carries the slot has one: a closed env sized without it, which
+           out-of-tree code builds by hand, ends its allocation at the
+           locals (see internal.h). */
         mrb_assert(!MRB_ENV_ONSTACK_P(e));
         mrb_assert(e->stack != NULL);
         mrb_gc_mark_value(mrb, MRB_ENV_SVAR_SLOT(e->stack, len));
       }
       children += len;
+    }
+    break;
+
+  case MRB_TT_SVAR:
+    {
+      struct RSvar *sv = (struct RSvar*)obj;
+
+      /* slots is NULL only in the window svar_new() (vm.c) leaves between
+         allocating the object and its slot array */
+      if (sv->slots) {
+        for (int i = 0; i < MRB_SVAR_MAX; i++) {
+          mrb_gc_mark_value(mrb, sv->slots[i]);
+        }
+        children += MRB_SVAR_MAX;
+      }
     }
     break;
 
@@ -1180,6 +1197,10 @@ obj_free(mrb_state *mrb, struct RBasic *obj, mrb_bool end)
         mrb_free(mrb, e->stack);
       }
     }
+    break;
+
+  case MRB_TT_SVAR:
+    mrb_free(mrb, ((struct RSvar*)obj)->slots);
     break;
 
   case MRB_TT_FIBER:

--- a/src/gc.c
+++ b/src/gc.c
@@ -999,6 +999,15 @@ gc_mark_children(mrb_state *mrb, mrb_gc *gc, struct RBasic *obj)
       for (mrb_int i=0; i<len; i++) {
         mrb_gc_mark_value(mrb, e->stack[i]);
       }
+      if (MRB_ENV_SVAR_P(e)) {
+        /* the escaped scope's special variables, one slot past the locals
+           (see internal.h). Only an env whose flag says it carries the slot
+           has one: a closed env sized without it, which out-of-tree code
+           builds by hand, ends its allocation at the locals. */
+        mrb_assert(!MRB_ENV_ONSTACK_P(e));
+        mrb_assert(e->stack != NULL);
+        mrb_gc_mark_value(mrb, MRB_ENV_SVAR_SLOT(e->stack, len));
+      }
       children += len;
     }
     break;

--- a/src/proc.c
+++ b/src/proc.c
@@ -178,6 +178,9 @@ mrb_proc_new_cfunc_with_env(mrb_state *mrb, mrb_func_t func, mrb_int argc, const
   mrb_field_write_barrier(mrb, (struct RBasic*)p, (struct RBasic*)e);
   MRB_ENV_CLOSE(e);
 
+  /* A C frame owns no Ruby scope, so this env never carries the
+     special-variable slot (MRB_ENV_SVAR_P stays off; see internal.h) and
+     its stack is exactly the locals. */
   e->stack = (mrb_value*)mrb_malloc(mrb, sizeof(mrb_value) * argc);
   MRB_ENV_SET_LEN(e, argc);
 
@@ -551,8 +554,21 @@ mrb_proc_merge_lvar(mrb_state *mrb, mrb_irep *irep, struct REnv *env, int num, c
     mrb_raise(mrb, E_RUNTIME_ERROR, "unavailable local variable names");
   }
 
+  /* Only an env carrying the special-variable slot (see internal.h) has one
+     to keep: the new locals take the ground it stood on, so it is read off
+     the old stack and put back past the new ones. An env sized without it
+     grows by the locals alone and stays without it. */
+  mrb_bool has_svar = MRB_ENV_SVAR_P(env);
+  size_t old_len = (size_t)irep->nlocals;
+  size_t new_len = old_len + (size_t)num;
+  mrb_value svar = mrb_nil_value();
+
+  if (has_svar) svar = MRB_ENV_SVAR_SLOT(env->stack, old_len);
   irep->lv = (mrb_sym*)mrb_realloc(mrb, (mrb_sym*)irep->lv, sizeof(mrb_sym) * (irep->nlocals - 1 /* self */ + num));
-  env->stack = (mrb_value*)mrb_realloc(mrb, env->stack, sizeof(mrb_value) * (irep->nlocals + num));
+  env->stack = (mrb_value*)mrb_realloc(mrb, env->stack,
+                                       has_svar ? MRB_ENV_SVAR_STACK_SIZE(new_len)
+                                                : sizeof(mrb_value) * new_len);
+  if (has_svar) MRB_ENV_SVAR_SLOT(env->stack, new_len) = svar;
 
   mrb_sym *destlv = (mrb_sym*)irep->lv + irep->nlocals - 1 /* self */;
   mrb_value *destst = env->stack + irep->nlocals;

--- a/src/proc.c
+++ b/src/proc.c
@@ -81,6 +81,10 @@ mrb_env_new(mrb_state *mrb, struct mrb_context *c, mrb_callinfo *ci, int nstacks
   MRB_ENV_SET_LEN(e, nstacks);
   bidx += (n == 15) ? 1 : n;
   bidx += (nk == 15) ? 1 : (2*nk);
+  /* This is the only index the VM computes, and the field holding it is
+     seven bits wide (proc.h), which the widest call fits in: one for the
+     receiver, 14 positional arguments and 28 for 14 keyword pairs. */
+  mrb_assert(bidx <= 43);
   MRB_ENV_SET_BIDX(e, bidx);
   e->mid = ci->mid;
   e->stack = stack;

--- a/src/variable.c
+++ b/src/variable.c
@@ -7,6 +7,7 @@
 #include <mruby.h>
 #include <mruby/array.h>
 #include <mruby/class.h>
+#include <mruby/data.h>
 #include <mruby/proc.h>
 #include <mruby/string.h>
 #include <mruby/variable.h>
@@ -1596,6 +1597,57 @@ mrb_mod_constants(mrb_state *mrb, mrb_value mod)
   return ary;
 }
 
+/* A virtual global's dispatch table, held behind a sentinel stored in the
+ * globals table itself: the name stays defined and listed, marking is the
+ * table's ordinary marking, and an ordinary global pays one type test on
+ * access. What the sentinel must never do is leak into Ruby as the
+ * variable's value, which is what the dispatch in mrb_gv_get()/mrb_gv_set()
+ * guarantees. */
+struct gv_virtual {
+  mrb_value (*get)(mrb_state *mrb);
+  void (*set)(mrb_state *mrb, mrb_value v);
+};
+
+static void
+gv_virtual_free(mrb_state *mrb, void *p)
+{
+  mrb_free(mrb, p);
+}
+
+static const mrb_data_type gv_virtual_type = { "gv_virtual", gv_virtual_free };
+
+static const struct gv_virtual*
+gv_virtual_check(mrb_value v)
+{
+  if (mrb_data_p(v) && DATA_TYPE(v) == &gv_virtual_type) {
+    return (const struct gv_virtual*)DATA_PTR(v);
+  }
+  return NULL;
+}
+
+/*
+ * Registers `sym` as a virtual global variable dispatching to `get` and
+ * `set`. See <mruby/variable.h>.
+ */
+MRB_API void
+mrb_gv_define_virtual(mrb_state *mrb, mrb_sym sym, mrb_value (*get)(mrb_state*), void (*set)(mrb_state*, mrb_value))
+{
+  /* classless, the way struct RSvar is: an internal object with no class
+     is what mruby-objectspace's each_object filter hides, so the sentinel
+     cannot be fished out of the heap and stored where the dispatch below
+     would mistake it for a second virtual variable */
+  struct RData *d = mrb_data_object_alloc(mrb, NULL, NULL, &gv_virtual_type);
+  struct gv_virtual *vt = (struct gv_virtual*)mrb_malloc(mrb, sizeof(struct gv_virtual));
+
+  vt->get = get;
+  vt->set = set;
+  d->data = vt;
+  if (!mrb->globals) {
+    mrb->globals = iv_new(mrb);
+  }
+  iv_put(mrb, mrb->globals, sym, mrb_obj_value(d));
+}
+
 /*
  * Retrieves a global variable.
  *
@@ -1612,8 +1664,11 @@ mrb_gv_get(mrb_state *mrb, mrb_sym sym)
 {
   mrb_value v;
 
-  if (iv_get(mrb, mrb->globals, sym, &v))
+  if (iv_get(mrb, mrb->globals, sym, &v)) {
+    const struct gv_virtual *vt = gv_virtual_check(v);
+    if (vt) return vt->get(mrb);
     return v;
+  }
   return mrb_nil_value();
 }
 
@@ -1623,6 +1678,31 @@ mrb_gv_defined(mrb_state *mrb, mrb_sym sym)
 {
   mrb_value v;
   return iv_get(mrb, mrb->globals, sym, &v) != 0;
+}
+
+/* iv_put() for the globals table: an ordinary name already present is
+ * stored in place off the one search above, a fresh name falls through
+ * to iv_put(), and a virtual name is never overwritten, its dispatch
+ * pair handed back instead for the caller to route the value through. */
+static const struct gv_virtual*
+gv_put(mrb_state *mrb, iv_tbl *t, mrb_sym sym, mrb_value val)
+{
+  if (t->alloc == 0) {
+    iv_rehash(mrb, t);
+  }
+
+  mrb_sym   *keys = (mrb_sym*)&t->ptr[t->alloc];
+  mrb_value *vals =  t->ptr;
+  int lo = iv_bsearch_idx(keys, t->size, sym);
+
+  if (lo < t->size && keys[lo] == sym) {
+    const struct gv_virtual *vt = gv_virtual_check(vals[lo]);
+    if (vt) return vt;
+    vals[lo] = val;
+    return NULL;
+  }
+  iv_put(mrb, t, sym, val);
+  return NULL;
 }
 
 /*
@@ -1638,13 +1718,13 @@ mrb_gv_defined(mrb_state *mrb, mrb_sym sym)
 MRB_API void
 mrb_gv_set(mrb_state *mrb, mrb_sym sym, mrb_value v)
 {
-  iv_tbl *t;
-
   if (!mrb->globals) {
     mrb->globals = iv_new(mrb);
   }
-  t = mrb->globals;
-  iv_put(mrb, t, sym, v);
+  const struct gv_virtual *vt = gv_put(mrb, mrb->globals, sym, v);
+  if (vt) {
+    vt->set(mrb, v);
+  }
 }
 
 /*

--- a/src/vm.c
+++ b/src/vm.c
@@ -436,16 +436,17 @@ svar_scopeless_frame_p(const mrb_callinfo *ci)
 }
 
 /* An escaped scope's slot (MRB_ENV_SVAR_SLOT in internal.h):
- * mrb_env_detach() sizes the stack for it and fills it, through
- * svar_slot_ensure(), only when it actually has a container or forward to
- * install; mrb_env_unshare() on its own never asks for the extra value.
- * NULL where the env carries none, which only the flag can say: a closed
- * env whose stack stops at its locals is the ordinary result of
- * mrb_env_unshare() itself, what out-of-tree code builds by hand, and what
- * error.c's fault-time rewind and the out-of-memory arm of
+ * mrb_env_detach() sizes the closing allocation for it and fills it,
+ * through env_unshare_with_svar(), only when it actually has a container
+ * or forward to install; mrb_env_unshare() on its own never asks for the
+ * extra value. NULL where the env carries none, which only the flag can
+ * say: a closed env whose stack stops at its locals is the ordinary result
+ * of mrb_env_unshare() itself, what out-of-tree code builds by hand, and
+ * what error.c's fault-time rewind and the out-of-memory arm of
  * mrb_env_unshare() leave behind, all three with no room past the locals.
- * Reads take it for a scope holding no container; the one write that
- * cannot grows the env into the slot first (svar_slot_ensure()).
+ * Reads take it for a scope holding no container; the one later write that
+ * cannot, a live scope's first, grows the already-closed env into the slot
+ * instead (svar_slot_ensure()).
  *
  * An env still on the stack carries no slot either, its locals being the
  * VM's own stack. That test comes first because it is also what a swept
@@ -937,6 +938,60 @@ mrb_env_unshare(mrb_state *mrb, struct REnv *e, mrb_bool noraise)
   }
 }
 
+/* mrb_env_unshare(), sized and filled for the special-variable slot up
+ * front instead of leaving mrb_env_detach() to grow the closed env by a
+ * second, separate allocation (svar_slot_ensure()) once the first has
+ * already succeeded. That second allocation used to run outside every
+ * noraise contract, raising NoMemoryError straight out of the closing
+ * detach: a caller relying on FALSE to decrement its own callinfo first
+ * (cipop(), for the #3087 invariant) never got the chance. Folding the
+ * slot into the one allocation removes the intermediate state that bug
+ * needed, a scope whose locals had already detached while its slot's own
+ * growth could still fail on its own: here, either both close in the same
+ * allocation or neither does.
+ * Structured exactly like mrb_env_unshare() above, with a slot's width
+ * added to the size throughout and no len == 0 fast path: a slot is owed
+ * here even where there are no locals to copy. Called only where sv is
+ * known non-NULL; mrb_env_detach() takes mrb_env_unshare()'s plain path
+ * itself where there is no container to carry. */
+static mrb_bool
+env_unshare_with_svar(mrb_state *mrb, struct REnv *e, struct RBasic *sv, mrb_bool noraise)
+{
+  mrb_assert(e != NULL);
+  mrb_assert(MRB_ENV_ONSTACK_P(e));
+  mrb_assert(sv != NULL);
+
+  size_t len = (size_t)MRB_ENV_LEN(e);
+  size_t live = mrb->gc.live;
+  mrb_value *p = (mrb_value*)mrb_malloc_simple(mrb, MRB_ENV_SVAR_STACK_SIZE(len));
+  if (live != mrb->gc.live && mrb_object_dead_p(mrb, (struct RBasic*)e)) {
+    // See mrb_env_unshare(): e is already gone, so an allocation failure
+    // here needs no handling either.
+    mrb_free(mrb, p);
+    return TRUE;
+  }
+  else if (p) {
+    stack_copy(p, e->stack, len);
+    e->stack = p;
+    MRB_ENV_CLOSE(e);
+    MRB_ENV_SET_SVAR(e);
+    MRB_ENV_SVAR_SLOT(p, len) = mrb_obj_value(sv);
+    mrb_write_barrier(mrb, (struct RBasic*)e);
+    return TRUE;
+  }
+  else {
+    e->stack = NULL;
+    MRB_ENV_CLOSE(e);
+    MRB_ENV_CLEAR_SVAR(e);
+    MRB_ENV_SET_LEN(e, 0);
+    MRB_ENV_SET_BIDX(e, 0);
+    if (!noraise) {
+      mrb_exc_raise(mrb, mrb_obj_value(mrb->nomem_err));
+    }
+    return FALSE;
+  }
+}
+
 /* Detaches a live env from the frame that owns it: mrb_env_unshare() moves
  * the locals into a heap copy, and the frame's special-variable container
  * follows them into the slot past the locals, so a proc that outlives the
@@ -949,19 +1004,16 @@ mrb_env_unshare(mrb_state *mrb, struct REnv *e, mrb_bool noraise)
  * NULL; a scopeless frame owns none to pass, and its callers hand the
  * slot what the scope below has instead (svar_env_adopt_owner() on a
  * return, mrb_svar_frame_container() on a teardown), which is that
- * scope's container or, where it holds none, its env as a forward. */
+ * scope's container or, where it holds none, its env as a forward.
+ * The two arms close the env in exactly one allocation either way (see
+ * env_unshare_with_svar()), so noraise's FALSE always comes back with the
+ * env's own state settled and c->ci still pointing at the frame being
+ * torn down, never mid-close. */
 mrb_bool
 mrb_env_detach(mrb_state *mrb, struct REnv *e, struct RBasic *sv, mrb_bool noraise)
 {
-  if (!mrb_env_unshare(mrb, e, noraise)) return FALSE;
-  /* MRB_ENV_ONSTACK_P(e) here means unshare's allocation collected e out
-     from under itself and left it untouched (see above): nothing to grow. */
-  if (sv && !MRB_ENV_ONSTACK_P(e)) {
-    mrb_value *slot = svar_slot_ensure(mrb, e);
-    *slot = mrb_obj_value(sv);
-    mrb_write_barrier(mrb, (struct RBasic*)e);
-  }
-  return TRUE;
+  if (!sv) return mrb_env_unshare(mrb, e, noraise);
+  return env_unshare_with_svar(mrb, e, sv, noraise);
 }
 
 /* A scopeless frame is transparent while it runs: svar_owner() walks past

--- a/src/vm.c
+++ b/src/vm.c
@@ -499,7 +499,12 @@ svar_slot_ensure(mrb_state *mrb, struct REnv *e)
  * its context in *ocp), in the env of a scope that escaped the stack
  * (*envp, holding the container mrb_env_detach() moved off it, or the
  * owner's a scopeless frame adopted), or in neither, when the scope left
- * nothing behind: then a read answers nil and a write is dropped.
+ * nothing behind: then a read answers nil and a write is dropped. A
+ * scopeless frame's escaped env may instead hold the env of the scope
+ * below it (what mrb_svar_frame_container() hands on where that scope
+ * holds no container to share): the walk follows it, one hop per nested
+ * load, the way CRuby's ep chain crosses an eval frame's ep into the scope
+ * below's.
  * What resolution costs, and why it is linear: an env does not record
  * which frame it belongs to, so a defining scope still on a stack is
  * found by the downward scan below, one CI_ENV test per ci entry between
@@ -510,13 +515,16 @@ svar_slot_ensure(mrb_state *mrb, struct REnv *e)
  * reserved it in every method's locals, which no compiled irep has, so
  * the scan is what keeps existing bytecode running. The term stretches
  * past a handful of entries only when a proc is carried to the bottom of
- * a deep call chain and reads its special variables there. */
+ * a deep call chain and reads its special variables there.
+ * The walk starts at `top`, which is c->ci for a read or write and a
+ * mid-stack frame for mrb_svar_frame_container() resolving a torn-down
+ * context. */
 static void
-svar_owner(struct mrb_context *c, mrb_callinfo **cip, struct mrb_context **ocp, struct REnv **envp)
+svar_owner_from(struct mrb_context *c, mrb_callinfo *top, mrb_callinfo **cip, struct mrb_context **ocp, struct REnv **envp)
 {
   struct mrb_context *wc = c;   /* the context being walked; the redirect
                                    below stays the caller's */
-  mrb_callinfo *ci = c->ci;
+  mrb_callinfo *ci = top;
 
   *cip = NULL;
   *ocp = c;
@@ -538,22 +546,33 @@ svar_owner(struct mrb_context *c, mrb_callinfo **cip, struct mrb_context **ocp, 
         ci--;
         continue;
       }
-      const struct RProc *rp = c->cibase->proc;
-      if (rp && !MRB_PROC_CFUNC_P(rp) && !MRB_PROC_SCOPE_P(rp) &&
-          svar_scope_env(rp) == e) {
-        *cip = c->cibase;
-        *ocp = c;
-        return;
-      }
-      if (!MRB_ENV_ONSTACK_P(e)) {
-        /* The scope returned: what it left behind is this env, holding
-           the container mrb_env_detach() moved off the frame, or none
-           yet, in which case a read answers nil off the missing slot and
-           the first write grows the env into one (svar_slot_ensure()).
-           An env with no stack at all kept nothing to hold either. */
+      for (;;) {
+        const struct RProc *rp = c->cibase->proc;
+        if (rp && !MRB_PROC_CFUNC_P(rp) && !MRB_PROC_SCOPE_P(rp) &&
+            svar_scope_env(rp) == e) {
+          *cip = c->cibase;
+          *ocp = c;
+          return;
+        }
+        if (MRB_ENV_ONSTACK_P(e)) break;
         if (!e->stack) return;
-        *envp = e;
-        return;
+        mrb_value *slot = env_svar_slot(e);
+        if (!slot) {
+          /* A closed env whose stack was sized without the slot (see
+             internal.h): it can hold no forward, so it is the owner
+             itself, with no container yet. A read answers nil off it and
+             the first write grows it into one (svar_slot_ensure()). */
+          *envp = e;
+          return;
+        }
+        mrb_value fwd = *slot;
+        if (mrb_type(fwd) != MRB_TT_ENV) {
+          *envp = e;
+          return;
+        }
+        /* A scopeless frame's env, forwarded on teardown to the env of
+           the scope below the load: follow it there. */
+        e = (struct REnv*)mrb_obj_ptr(fwd);
       }
       struct mrb_context *oc = e->cxt;
       mrb_callinfo *s = (oc == wc) ? ci - 1 : oc->ci;
@@ -582,6 +601,12 @@ svar_owner(struct mrb_context *c, mrb_callinfo **cip, struct mrb_context **ocp, 
   *ocp = wc;
 }
 
+static void
+svar_owner(struct mrb_context *c, mrb_callinfo **cip, struct mrb_context **ocp, struct REnv **envp)
+{
+  svar_owner_from(c, c->ci, cip, ocp, envp);
+}
+
 /* A scope's special-variable container (struct RSvar in internal.h), made
  * on the first non-nil write into the scope. The object is allocated
  * first and reaches the GC arena with slots == NULL, so the collector a
@@ -603,7 +628,11 @@ svar_new(mrb_state *mrb)
 
 /* The container of the owner svar_owner() resolved to: on a live frame
  * the frame's pointer, on an escaped scope the object its env slot holds,
- * NULL where the scope has never written one (or left nothing behind). */
+ * NULL where the scope has never written one (or left nothing behind).
+ * Both places may instead hold a forward to the env of the scope below
+ * (mrb_svar_frame_container()), but only on a frame with no scope of its
+ * own, and resolution walks past those rather than ending on one, so what
+ * a resolved frame holds is a container or nothing. */
 static struct RSvar*
 svar_owner_container(mrb_callinfo *ci, struct REnv *e)
 {
@@ -672,6 +701,38 @@ svar_owner_force(mrb_state *mrb)
     return sv;
   }
   return NULL;
+}
+
+/* What a frame's env carries into escape when its context is torn down
+ * around it or marked through it: the frame's own container, or for a
+ * scopeless frame the one the owner it resolved to while it ran already
+ * holds. Where that owner holds none, the answer is the owner's env
+ * itself, the forward svar_owner_from() follows one hop further, so that
+ * the transparency of a scopeless frame survives its context by the same
+ * representation an escaped scopeless env uses: neither caller may make a
+ * container here, gc_mark_children() (gc.c) running mid-collection and
+ * mrb_env_detach_all() mid-teardown, where cipop() materializes one
+ * instead (svar_env_adopt_owner()). NULL where there is nothing to carry,
+ * and for an owner that is the context's own root frame, whose container
+ * dies with the context the way the root frame's own does. */
+struct RBasic*
+mrb_svar_frame_container(struct mrb_context *c, mrb_callinfo *ci)
+{
+  if (ci->svar || !svar_scopeless_frame_p(ci)) return ci->svar;
+
+  mrb_callinfo *oci;
+  struct mrb_context *oc;
+  struct REnv *oe;
+  svar_owner_from(c, ci, &oci, &oc, &oe);
+  if (oc == c && oci == c->cibase) return NULL;
+  struct RSvar *sv = svar_owner_container(oci, oe);
+  if (sv) return (struct RBasic*)sv;
+  struct REnv *fwd = oci ? CI_ENV(oci) : oe;
+  /* Nothing to forward to when the owner scope left no env behind: no proc
+     can be holding it, so nothing can look. A frame forwarding to its own
+     env would close the walk into a loop rather than a hop. */
+  if (fwd == NULL || fwd == CI_ENV(ci)) return NULL;
+  return (struct RBasic*)fwd;
 }
 
 /*
@@ -880,10 +941,13 @@ mrb_env_unshare(mrb_state *mrb, struct REnv *e, mrb_bool noraise)
  * scope still reads what the scope could see (CRuby's svar lives on the
  * lep and survives its escape the same way). This is the one invariant of
  * every path that closes an env over a live frame: cipop() on an ordinary
- * return and mrb_vm_ci_env_clear() below. Callers on a frame whose
- * container must die with its context pass sv as NULL; a scopeless frame
- * owns none to pass, and its caller hands the slot what the scope below
- * has instead (svar_env_adopt_owner() on a return). */
+ * return, the GC freeing a suspended fiber (gc.c), mruby-task tearing a
+ * context down, and mrb_vm_ci_env_clear() below. Callers on a frame whose
+ * container must die with its context, a fiber or task root, pass sv as
+ * NULL; a scopeless frame owns none to pass, and its callers hand the
+ * slot what the scope below has instead (svar_env_adopt_owner() on a
+ * return, mrb_svar_frame_container() on a teardown), which is that
+ * scope's container or, where it holds none, its env as a forward. */
 mrb_bool
 mrb_env_detach(mrb_state *mrb, struct REnv *e, struct RBasic *sv, mrb_bool noraise)
 {
@@ -929,28 +993,62 @@ svar_env_adopt_owner(mrb_state *mrb, struct REnv *e)
 
 /* Detaches every live on-stack env of a context being torn down around it:
  * the GC freeing a suspended fiber (gc.c) and mruby-task ending a task both
- * come through here. An escaped closure keeps its REnv alive after the
- * stack it stands on is gone, and an env still pointing into that freed
- * stack makes the next marking chase whatever now sits there, so the
- * locals move into a heap copy while the stack is still intact. */
+ * come through here, so the carrying policy is stated once: each frame's
+ * env escapes with the frame's own container, the root frame's dies with
+ * the context (CRuby's ec->root_svar), and a scopeless frame hands on the
+ * scope below's: its container where the owner holds one, else the owner's
+ * own env, forwarded into the slot for the walk in svar_owner_from() to
+ * follow, so two procs that shared one scope on the stack still share it
+ * escaped, and the first write through either makes the one container both
+ * see. `resolve` distinguishes the callers: mruby-task tears down outside a
+ * collection and resolves the owner here, with the GC held off across the
+ * loop because the resolution chases procs and envs of a stack nothing
+ * marks any more, which a detach allocation could otherwise sweep or
+ * recycle mid-loop, and because a container whose only holder is this
+ * dying stack must survive to the detach that roots it in the escaping
+ * env. The gc.c caller runs inside the sweep, where the walk could chase
+ * objects already swept and recycled and the GC cannot be held off, so it
+ * passes FALSE and relies on the frame's ci->svar alone, where
+ * gc_mark_children() stashed the same answer at mark time, on memory the
+ * sweep had not yet touched. */
 void
-mrb_env_detach_all(mrb_state *mrb, struct mrb_context *c)
+mrb_env_detach_all(mrb_state *mrb, struct mrb_context *c, mrb_bool resolve)
 {
   if (!c->cibase || !c->ci) return;
 
+  mrb_bool gc_was = FALSE;
+  if (resolve) {
+    gc_was = mrb->gc.disabled;
+    mrb->gc.disabled = TRUE;
+  }
   /* Stop AT cibase rather than decrementing past it: forming a pointer
    * one element before the start of an array is undefined behavior. */
   for (mrb_callinfo *ci = c->ci; ; ci--) {
     struct REnv *e = ci->u.env;
-    /* mrb_env_unshare() allocates and can therefore run a GC cycle. In
+    /* mrb_env_detach() allocates and can therefore run a GC cycle (with
+     * `resolve` the GC is off and the sweep is merely deferred). In
      * teardown paths the context may already be unlinked, so an env that
      * no other object refers to may be swept before the walk reaches it;
      * check liveness first. */
     if (e && !mrb_object_dead_p(mrb, (struct RBasic*)e) &&
         e->tt == MRB_TT_ENV && MRB_ENV_ONSTACK_P(e)) {
-      mrb_env_unshare(mrb, e, TRUE);
+      struct RBasic *sv = NULL;
+      if (ci != c->cibase) {
+        sv = ci->svar;
+        if (resolve && !sv) {
+          sv = mrb_svar_frame_container(c, ci);
+          /* A forward is only worth carrying to an env that survives the
+             teardown; the GC is off across the loop, so this answer still
+             holds at the detach below. */
+          if (sv && sv->tt == MRB_TT_ENV && mrb_object_dead_p(mrb, sv)) sv = NULL;
+        }
+      }
+      mrb_env_detach(mrb, e, sv, TRUE);
     }
     if (ci == c->cibase) break;
+  }
+  if (resolve) {
+    mrb->gc.disabled = gc_was;
   }
 }
 

--- a/src/vm.c
+++ b/src/vm.c
@@ -380,7 +380,357 @@ mrb_vm_ci_env_clear(mrb_state *mrb, mrb_callinfo *ci)
   struct REnv *e = ci->u.env;
   if (e && e->tt == MRB_TT_ENV) {
     ci->u.target_class = e->c;
-    mrb_env_unshare(mrb, e, FALSE);
+    /* The escaping env carries the container, so a proc from the earlier
+       top-level chunk keeps reading the scope it was written in. */
+    mrb_env_detach(mrb, e, ci->svar, FALSE);
+  }
+  /* The frame itself starts the next chunk in a fresh scope, the way each
+     file `ruby -r` loads gets one of its own; a caller that wants a single
+     scope across its chunks (mirb's interactive lines) does not call this,
+     which is also how it keeps the top-level locals. */
+  ci->svar = NULL;
+}
+
+/* The local scope of a block or lambda: following p->upper toward the
+ * scope proc, MRB_PROC_ENV() of each step is the env of the frame the
+ * proc was defined in, instance by instance, so the env in hand when the
+ * next proc up turns out to be a scope (or is missing) belongs to the
+ * method scope, the way CRuby's lep walk crosses block eps into the
+ * method's. NULL for a proc that captured no env. Pointer identity only:
+ * the env may be closed, or live on another context's stack. */
+static struct REnv*
+svar_scope_env(const struct RProc *p)
+{
+  struct REnv *e = MRB_PROC_ENV(p);
+
+  if (!e) return NULL;
+  for (;;) {
+    const struct RProc *up = p->upper;
+    if (!up || MRB_PROC_CFUNC_P(up) || MRB_PROC_SCOPE_P(up)) return e;
+    struct REnv *upenv = MRB_PROC_ENV(up);
+    if (!upenv) return e;
+    p = up;
+    e = upenv;
+  }
+}
+
+/* A frame with no scope of its own: an irep proc that neither is a scope
+ * nor captured one. What reaches here is the top proc of a nested
+ * `mrb_top_run()`, which is `mrb_load_string()` called from a C function
+ * mid-execution, and an eval compiled against no Ruby scope, which is the
+ * same call with no Ruby frame under it. An ordinary `eval` is not one of
+ * these: its proc captures the calling frame's env, so it answers FALSE
+ * and resolves as a block does, onto the scope that called it. Holding no
+ * slot, a scopeless frame is as transparent to the special variables as
+ * the C function that pushed it, the way CRuby's `rb_eval_string()` shares
+ * the scope below; when its env escapes, the transparency outlives the
+ * frame by adoption (svar_env_adopt_owner()). Blocks and lambdas always
+ * capture, so they never answer TRUE. */
+static mrb_bool
+svar_scopeless_frame_p(const mrb_callinfo *ci)
+{
+  const struct RProc *p = ci->proc;
+
+  return p && !MRB_PROC_CFUNC_P(p) &&
+         !MRB_PROC_SCOPE_P(p) && svar_scope_env(p) == NULL;
+}
+
+/* An escaped scope's slot (MRB_ENV_SVAR_SLOT in internal.h):
+ * mrb_env_detach() fills it, mrb_env_unshare() sizes the stack for it.
+ * NULL where the env carries none, which only the flag can say: a closed
+ * env whose stack stops at its locals is what out-of-tree code builds by
+ * hand, and what error.c's fault-time rewind and the out-of-memory arm of
+ * mrb_env_unshare() leave behind, those two with no stack at all. Reads
+ * take it for a scope holding no container; the one write that cannot
+ * grows the env into the slot first (svar_slot_ensure()).
+ *
+ * An env still on the stack carries no slot either, its locals being the
+ * VM's own stack. That test comes first because it is also what a swept
+ * env looks like: mrb_env_unshare() answers TRUE without touching an env
+ * the collection inside its allocation freed, and a freed cell's flags say
+ * nothing, so the callers that close an env and then read its slot,
+ * cipop() and mrb_env_detach(), still find such an env on the stack. */
+static mrb_value*
+env_svar_slot(struct REnv *e)
+{
+  if (MRB_ENV_ONSTACK_P(e) || !MRB_ENV_SVAR_P(e)) return NULL;
+  mrb_assert(e->stack != NULL);
+  return &MRB_ENV_SVAR_SLOT(e->stack, MRB_ENV_LEN(e));
+}
+
+/* The same slot, made if the env has none yet: a closed env whose stack
+ * holds exactly its locals grows by one and starts carrying the flag. Only
+ * the first write into such a scope comes here (svar_owner_force()); reads
+ * answer nil off the missing slot and leave the env alone, so an env that
+ * never owns special variables never pays the extra mrb_value.
+ * The env is reachable from the roots the caller resolved it through, so a
+ * collection inside the resize cannot sweep it and free the stack under
+ * the realloc. Out of memory raises, as the container allocation just
+ * above it does, leaving the env exactly as it was. */
+static mrb_value*
+svar_slot_ensure(mrb_state *mrb, struct REnv *e)
+{
+  mrb_value *slot = env_svar_slot(e);
+  if (slot) return slot;
+
+  mrb_assert(!MRB_ENV_ONSTACK_P(e));
+  size_t len = (size_t)MRB_ENV_LEN(e);
+  mrb_value *stack = (mrb_value*)mrb_realloc(mrb, e->stack, MRB_ENV_SVAR_STACK_SIZE(len));
+
+  e->stack = stack;
+  SET_NIL_VALUE(MRB_ENV_SVAR_SLOT(stack, len));
+  MRB_ENV_SET_SVAR(e);
+  return &MRB_ENV_SVAR_SLOT(stack, len);
+}
+
+/* The owner of the frame-scoped special variables, resolved the way CRuby
+ * resolves its svar: walking down from the top, a C frame has no slot of
+ * its own, a scope frame owns its own slot, a frame with no
+ * scope of its own is as transparent as a C frame (see
+ * `svar_scopeless_frame_p()`), and a block or lambda frame resolves to the
+ * scope it was defined in, wherever that scope now is: a live frame on
+ * this or on another context's stack, or the env the scope left behind. A
+ * block written inside a scopeless frame resolves to that frame, which
+ * owns no slot either, so the walk goes on below it.
+ * One exception, CRuby's root-lep redirect: a resolution landing on the
+ * very scope the running context's own root block was defined in is handed
+ * the context's root slot instead (`cibase`), which is how a fiber keeps
+ * its special variables to itself. Resolution ends in a live frame (*cip,
+ * its context in *ocp), in the env of a scope that escaped the stack
+ * (*envp, holding the container mrb_env_detach() moved off it, or the
+ * owner's a scopeless frame adopted), or in neither, when the scope left
+ * nothing behind: then a read answers nil and a write is dropped.
+ * What resolution costs, and why it is linear: an env does not record
+ * which frame it belongs to, so a defining scope still on a stack is
+ * found by the downward scan below, one CI_ENV test per ci entry between
+ * the reader and the scope (eight instructions each, measured), and the
+ * lexical chase of svar_scope_env() adds a step per block-nesting level.
+ * CRuby resolves in constant time at any call depth, its svar living on
+ * the ep itself; the slot could live that way here only if the compiler
+ * reserved it in every method's locals, which no compiled irep has, so
+ * the scan is what keeps existing bytecode running. The term stretches
+ * past a handful of entries only when a proc is carried to the bottom of
+ * a deep call chain and reads its special variables there. */
+static void
+svar_owner(struct mrb_context *c, mrb_callinfo **cip, struct mrb_context **ocp, struct REnv **envp)
+{
+  struct mrb_context *wc = c;   /* the context being walked; the redirect
+                                   below stays the caller's */
+  mrb_callinfo *ci = c->ci;
+
+  *cip = NULL;
+  *ocp = c;
+  *envp = NULL;
+  while (ci > wc->cibase) {
+    const struct RProc *p = ci->proc;
+
+    if (p && !MRB_PROC_CFUNC_P(p)) {
+      if (MRB_PROC_SCOPE_P(p)) {
+        *cip = ci;
+        *ocp = wc;
+        return;
+      }
+
+      struct REnv *e = svar_scope_env(p);
+      if (!e) {
+        /* A scopeless frame: reads and writes pass through to the scope
+           below, the way `rb_eval_string()`'s do. */
+        ci--;
+        continue;
+      }
+      const struct RProc *rp = c->cibase->proc;
+      if (rp && !MRB_PROC_CFUNC_P(rp) && !MRB_PROC_SCOPE_P(rp) &&
+          svar_scope_env(rp) == e) {
+        *cip = c->cibase;
+        *ocp = c;
+        return;
+      }
+      if (!MRB_ENV_ONSTACK_P(e)) {
+        /* The scope returned: what it left behind is this env, holding
+           the container mrb_env_detach() moved off the frame, or none
+           yet, in which case a read answers nil off the missing slot and
+           the first write grows the env into one (svar_slot_ensure()).
+           An env with no stack at all kept nothing to hold either. */
+        if (!e->stack) return;
+        *envp = e;
+        return;
+      }
+      struct mrb_context *oc = e->cxt;
+      mrb_callinfo *s = (oc == wc) ? ci - 1 : oc->ci;
+      /* Stop AT cibase rather than decrementing past it: forming a pointer
+         one element before the start of an array is undefined behavior. */
+      while (CI_ENV(s) != e) {
+        if (s == oc->cibase) return;
+        s--;
+      }
+      if (s > oc->cibase && svar_scopeless_frame_p(s)) {
+        /* The scope the block was defined in is itself scopeless: the block
+           was written inside a nested load, so its special variables belong
+           to the scope that load runs against, further down, on whichever
+           context that load's frame still stands. */
+        wc = oc;
+        ci = s - 1;
+        continue;
+      }
+      *cip = s;
+      *ocp = oc;
+      return;
+    }
+    ci--;
+  }
+  *cip = wc->cibase;
+  *ocp = wc;
+}
+
+/* A scope's special-variable container (struct RSvar in internal.h), made
+ * on the first non-nil write into the scope. The object is allocated
+ * first and reaches the GC arena with slots == NULL, so the collector a
+ * slot allocation may run sees the window; gc_mark_children() guards on
+ * it. A raise out of the slot allocation leaves that empty shell to the
+ * GC and no owner ever holds it. */
+static struct RSvar*
+svar_new(mrb_state *mrb)
+{
+  struct RSvar *sv = MRB_OBJ_ALLOC(mrb, MRB_TT_SVAR, NULL);
+  mrb_value *slots = (mrb_value*)mrb_malloc(mrb, sizeof(mrb_value) * MRB_SVAR_MAX);
+
+  for (int i = 0; i < MRB_SVAR_MAX; i++) {
+    SET_NIL_VALUE(slots[i]);
+  }
+  sv->slots = slots;
+  return sv;
+}
+
+/* The container of the owner svar_owner() resolved to: on a live frame
+ * the frame's pointer, on an escaped scope the object its env slot holds,
+ * NULL where the scope has never written one (or left nothing behind). */
+static struct RSvar*
+svar_owner_container(mrb_callinfo *ci, struct REnv *e)
+{
+  if (ci) {
+    mrb_assert(ci->svar == NULL || ci->svar->tt == MRB_TT_SVAR);
+    return (struct RSvar*)ci->svar;
+  }
+  if (e) {
+    mrb_value *slot = env_svar_slot(e);
+    if (slot && mrb_type(*slot) == MRB_TT_SVAR) return (struct RSvar*)mrb_obj_ptr(*slot);
+  }
+  return NULL;
+}
+
+/* Resolves the current owner and answers its container, making one on the
+ * spot when the scope holds none yet: the first non-nil write does this
+ * (mrb_vm_svar_set()), and so does a scopeless frame whose env escapes
+ * (svar_env_adopt_owner()), so the adopted slot and the scope share one
+ * object before either side has written. NULL when resolution found no
+ * scope that could hold one.
+ * Installing a fresh container into a frame needs no barrier of its own
+ * on the running or the root context, those two ci stacks being
+ * unbarriered roots that final_marking_phase() re-scans atomically like
+ * the value stack; a frame on any other context is marked through that
+ * context's fiber, so the fiber pays one; a task context has no fiber and
+ * needs none, its stack being re-scanned atomically by
+ * mrb_task_mark_all(), which final_marking_phase() calls for exactly
+ * that. An env slot is ordinary GC-owned storage and pays the env's own. */
+static struct RSvar*
+svar_owner_force(mrb_state *mrb)
+{
+  mrb_callinfo *ci;
+  struct mrb_context *oc;
+  struct REnv *e;
+
+  svar_owner(mrb->c, &ci, &oc, &e);
+  struct RSvar *sv = svar_owner_container(ci, e);
+  if (sv) return sv;
+  sv = svar_new(mrb);
+  /* The allocation may have run a collection, and the owner may have stood
+     on a stack nothing else kept alive, a suspended fiber whose last
+     reference was dropped: its sweep detached its envs and freed its
+     callinfo array, so the frame resolved above is gone. Whether one ran
+     cannot be read off mrb->gc.live, which counts objects rather than
+     cycles and comes back unchanged from a sweep that freed as many as
+     this allocation makes, so resolve again either way; the walk then ends
+     in the closed env the sweep left behind, holding whatever container
+     the detach carried. */
+  svar_owner(mrb->c, &ci, &oc, &e);
+  struct RSvar *moved = svar_owner_container(ci, e);
+  if (moved) return moved;
+  if (ci) {
+    ci->svar = (struct RBasic*)sv;
+    if (oc != mrb->c && oc != mrb->root_c && oc->fib) {
+      mrb_write_barrier(mrb, (struct RBasic*)oc->fib);
+    }
+    return sv;
+  }
+  if (e) {
+    /* Grows a closed env sized without the slot into one (see internal.h);
+       the resize may raise out of memory, leaving the fresh container to
+       the GC the way a raise out of svar_new() does. */
+    mrb_value *slot = svar_slot_ensure(mrb, e);
+    *slot = mrb_obj_value(sv);
+    mrb_write_barrier(mrb, (struct RBasic*)e);
+    return sv;
+  }
+  return NULL;
+}
+
+/*
+ * Reads one special-variable slot of the scope owning it, on a live frame
+ * or in the env of a scope that returned, nil where that scope holds no
+ * container.
+ */
+mrb_value
+mrb_vm_svar_get(mrb_state *mrb, enum mrb_svar_index key)
+{
+  mrb_callinfo *ci;
+  struct mrb_context *oc;
+  struct REnv *e;
+
+  mrb_assert(key >= 0 && key < MRB_SVAR_MAX);
+  svar_owner(mrb->c, &ci, &oc, &e);
+  struct RSvar *sv = svar_owner_container(ci, e);
+  if (!sv) return mrb_nil_value();
+  return sv->slots[key];
+}
+
+/*
+ * Writes one special-variable slot of the owning scope. The slot holds any
+ * mrb_value; any richer contract, like the TypeError mruby-regexp's
+ * virtual-global setter raises for `$~ = <not a MatchData>`, belongs to
+ * the caller. The scope's container is made on the first non-nil write; a
+ * nil write into a scope that has none is dropped, nil being what a
+ * missing slot already reads as, so `def foo; 1 + 2; end` never allocates
+ * one, and an immediate write pays no barrier, making no edge a black
+ * container would have to re-scan for. A heap-value write pays the
+ * backward barrier: a black container is
+ * re-grayed so the final marking re-reads its slots, and until then the
+ * barrier is a no-op. The forward barrier (marking the value on the spot)
+ * would be wrong here, not just slower: a publish-heavy loop hands the
+ * slot a fresh object every pass, and marking each one resurrects garbage
+ * into the next cycle wholesale, where a re-grayed container marks only
+ * what it still holds when the cycle closes.
+ */
+void
+mrb_vm_svar_set(mrb_state *mrb, enum mrb_svar_index key, mrb_value v)
+{
+  struct RSvar *sv;
+
+  mrb_assert(key >= 0 && key < MRB_SVAR_MAX);
+  if (mrb_nil_p(v)) {
+    mrb_callinfo *ci;
+    struct mrb_context *oc;
+    struct REnv *e;
+    svar_owner(mrb->c, &ci, &oc, &e);
+    sv = svar_owner_container(ci, e);
+    if (!sv) return;
+  }
+  else {
+    sv = svar_owner_force(mrb);
+    if (!sv) return;
+  }
+  sv->slots[key] = v;
+  if (!mrb_immediate_p(v)) {
+    mrb_write_barrier(mrb, (struct RBasic*)sv);
   }
 }
 
@@ -419,6 +769,7 @@ cipush(mrb_state *mrb, mrb_int push_stacks, uint8_t cci, struct RClass *target_c
   ci->nk = (argc>>4) & 0xf;
   ci->cci = cci;
   ci->vis = MRB_METHOD_PUBLIC_FL;
+  ci->svar = NULL;
   ci->u.target_class = target_class;
 
   return ci;
@@ -462,6 +813,8 @@ fiber_terminate(mrb_state *mrb, struct mrb_context *c, mrb_callinfo *ci)
         mrb_free(mrb, stack);
       }
       else {
+        /* nil, not the root frame's container: that one is the fiber's own
+           (CRuby's ec->root_svar) and dies with the fiber */
         SET_NIL_VALUE(MRB_ENV_SVAR_SLOT(stack, len));
         env->stack = stack;
         MRB_ENV_CLOSE(env);
@@ -521,6 +874,59 @@ mrb_env_unshare(mrb_state *mrb, struct REnv *e, mrb_bool noraise)
   }
 }
 
+/* Detaches a live env from the frame that owns it: mrb_env_unshare() moves
+ * the locals into a heap copy, and the frame's special-variable container
+ * follows them into the slot past the locals, so a proc that outlives the
+ * scope still reads what the scope could see (CRuby's svar lives on the
+ * lep and survives its escape the same way). This is the one invariant of
+ * every path that closes an env over a live frame: cipop() on an ordinary
+ * return and mrb_vm_ci_env_clear() below. Callers on a frame whose
+ * container must die with its context pass sv as NULL; a scopeless frame
+ * owns none to pass, and its caller hands the slot what the scope below
+ * has instead (svar_env_adopt_owner() on a return). */
+mrb_bool
+mrb_env_detach(mrb_state *mrb, struct REnv *e, struct RBasic *sv, mrb_bool noraise)
+{
+  if (!mrb_env_unshare(mrb, e, noraise)) return FALSE;
+  mrb_value *slot = sv ? env_svar_slot(e) : NULL;
+  if (slot) {
+    *slot = mrb_obj_value(sv);
+    mrb_write_barrier(mrb, (struct RBasic*)e);
+  }
+  return TRUE;
+}
+
+/* A scopeless frame is transparent while it runs: svar_owner() walks past
+ * it to the scope below. When its env escapes, that relation would die
+ * with the frame, the frame's own container being the NULL it never
+ * needed, so the freshly closed env adopts the owner's container instead,
+ * made on the spot when the owner holds none yet: a proc the load left
+ * behind keeps reading and writing the scope below, and a match made on
+ * either side after the return is seen on the other, the way CRuby's ep
+ * chain crosses an eval frame after its escape. Runs after cipop()
+ * decrements: resolution then starts at the scope below, and an
+ * allocation failure raises out of a consistent stack, leaving the slot
+ * empty. The env may already be garbage, nothing but an unreachable proc
+ * holding it, and the allocation the owner may need can collect it, so
+ * liveness is re-checked before the write. */
+static void
+svar_env_adopt_owner(mrb_state *mrb, struct REnv *e)
+{
+  if (env_svar_slot(e) == NULL) return;
+  struct RSvar *sv = svar_owner_force(mrb);
+  if (!sv) return;
+  /* Whether the container allocation ran a collection cannot be read off
+     mrb->gc.live (see svar_owner_force()), so re-check either way. The
+     collection may even have recycled the garbage env's own slot as the
+     new container: mrb_object_dead_p() would then inspect the live RSvar
+     and answer alive, so test the type tag first. Nothing else is
+     allocated in the window, so a reused slot can hold nothing but it. */
+  struct RBasic *b = (struct RBasic*)e;
+  if (b->tt != MRB_TT_ENV || mrb_object_dead_p(mrb, b)) return;
+  *env_svar_slot(e) = mrb_obj_value(sv);
+  mrb_write_barrier(mrb, (struct RBasic*)e);
+}
+
 /* Detaches every live on-stack env of a context being torn down around it:
  * the GC freeing a suspended fiber (gc.c) and mruby-task ending a task both
  * come through here. An escaped closure keeps its REnv alive after the
@@ -566,9 +972,19 @@ cipop(mrb_state *mrb)
   if (b && !MRB_PROC_STRICT_P(b) && MRB_PROC_ENV(b) == CI_ENV(&ci[-1])) {
     b->flags |= MRB_PROC_ORPHAN;
   }
-  if (env && !mrb_env_unshare(mrb, env, TRUE)) {
-    c->ci--; // exceptions are handled at the method caller; see #3087
-    mrb_exc_raise(mrb, mrb_obj_value(mrb->nomem_err));
+  if (env) {
+    /* The container escapes with the locals (see mrb_env_detach()); a
+       frame without an env leaves no proc behind that could look. */
+    mrb_bool transparent = (ci->svar == NULL && svar_scopeless_frame_p(ci));
+    if (!mrb_env_detach(mrb, env, ci->svar, TRUE)) {
+      c->ci--; // exceptions are handled at the method caller; see #3087
+      mrb_exc_raise(mrb, mrb_obj_value(mrb->nomem_err));
+    }
+    if (transparent) {
+      c->ci--;
+      svar_env_adopt_owner(mrb, env);
+      return c->ci;
+    }
   }
   c->ci--;
   return c->ci;
@@ -1802,7 +2218,7 @@ mrb_vm_run(mrb_state *mrb, const struct RProc *proc, mrb_value self, mrb_int sta
     struct REnv *e = CI_ENV(mrb->c->ci);
     if (e && (stack_keep == 0 || irep->nlocals < MRB_ENV_LEN(e))) {
       ci_env_set(mrb->c->ci, NULL);
-      mrb_env_unshare(mrb, e, FALSE);
+      mrb_env_detach(mrb, e, mrb->c->ci->svar, FALSE);
     }
   }
   stack_extend(mrb, nregs);

--- a/src/vm.c
+++ b/src/vm.c
@@ -436,13 +436,16 @@ svar_scopeless_frame_p(const mrb_callinfo *ci)
 }
 
 /* An escaped scope's slot (MRB_ENV_SVAR_SLOT in internal.h):
- * mrb_env_detach() fills it, mrb_env_unshare() sizes the stack for it.
+ * mrb_env_detach() sizes the stack for it and fills it, through
+ * svar_slot_ensure(), only when it actually has a container or forward to
+ * install; mrb_env_unshare() on its own never asks for the extra value.
  * NULL where the env carries none, which only the flag can say: a closed
- * env whose stack stops at its locals is what out-of-tree code builds by
- * hand, and what error.c's fault-time rewind and the out-of-memory arm of
- * mrb_env_unshare() leave behind, those two with no stack at all. Reads
- * take it for a scope holding no container; the one write that cannot
- * grows the env into the slot first (svar_slot_ensure()).
+ * env whose stack stops at its locals is the ordinary result of
+ * mrb_env_unshare() itself, what out-of-tree code builds by hand, and what
+ * error.c's fault-time rewind and the out-of-memory arm of
+ * mrb_env_unshare() leave behind, all three with no room past the locals.
+ * Reads take it for a scope holding no container; the one write that
+ * cannot grows the env into the slot first (svar_slot_ensure()).
  *
  * An env still on the stack carries no slot either, its locals being the
  * VM's own stack. That test comes first because it is also what a swept
@@ -869,17 +872,17 @@ fiber_terminate(mrb_state *mrb, struct mrb_context *c, mrb_callinfo *ci)
       // the reason is that env->stack may be freed by mrb_realloc() if MRB_DEBUG + MRB_GC_STRESS are enabled.
       // realloc() on a freed heap will cause double-free.
 
-      stack = (mrb_value*)mrb_realloc(mrb, stack, MRB_ENV_SVAR_STACK_SIZE(len));
+      stack = (mrb_value*)mrb_realloc(mrb, stack, sizeof(mrb_value)*len);
       if (mrb_object_dead_p(mrb, (struct RBasic*)env)) {
         mrb_free(mrb, stack);
       }
       else {
-        /* nil, not the root frame's container: that one is the fiber's own
-           (CRuby's ec->root_svar) and dies with the fiber */
-        SET_NIL_VALUE(MRB_ENV_SVAR_SLOT(stack, len));
+        /* No slot: the fiber's root container (CRuby's ec->root_svar) dies
+           here rather than being carried, and a later write from a
+           surviving closure grows one fresh (svar_slot_ensure()). */
         env->stack = stack;
         MRB_ENV_CLOSE(env);
-        MRB_ENV_SET_SVAR(env);
+        MRB_ENV_CLEAR_SVAR(env);
       }
     }
   }
@@ -906,7 +909,7 @@ mrb_env_unshare(mrb_state *mrb, struct REnv *e, mrb_bool noraise)
   }
 
   size_t live = mrb->gc.live;
-  mrb_value *p = (mrb_value*)mrb_malloc_simple(mrb, MRB_ENV_SVAR_STACK_SIZE(len));
+  mrb_value *p = (mrb_value*)mrb_malloc_simple(mrb, sizeof(mrb_value)*len);
   if (live != mrb->gc.live && mrb_object_dead_p(mrb, (struct RBasic*)e)) {
     // The e object is now subject to GC inside mrb_malloc_simple().
     // Moreover, if NULL is returned due to mrb_malloc_simple() failure, simply ignore it.
@@ -915,10 +918,9 @@ mrb_env_unshare(mrb_state *mrb, struct REnv *e, mrb_bool noraise)
   }
   else if (p) {
     stack_copy(p, e->stack, len);
-    SET_NIL_VALUE(MRB_ENV_SVAR_SLOT(p, len));
     e->stack = p;
     MRB_ENV_CLOSE(e);
-    MRB_ENV_SET_SVAR(e);
+    MRB_ENV_CLEAR_SVAR(e);
     mrb_write_barrier(mrb, (struct RBasic*)e);
     return TRUE;
   }
@@ -952,8 +954,10 @@ mrb_bool
 mrb_env_detach(mrb_state *mrb, struct REnv *e, struct RBasic *sv, mrb_bool noraise)
 {
   if (!mrb_env_unshare(mrb, e, noraise)) return FALSE;
-  mrb_value *slot = sv ? env_svar_slot(e) : NULL;
-  if (slot) {
+  /* MRB_ENV_ONSTACK_P(e) here means unshare's allocation collected e out
+     from under itself and left it untouched (see above): nothing to grow. */
+  if (sv && !MRB_ENV_ONSTACK_P(e)) {
+    mrb_value *slot = svar_slot_ensure(mrb, e);
     *slot = mrb_obj_value(sv);
     mrb_write_barrier(mrb, (struct RBasic*)e);
   }
@@ -976,7 +980,9 @@ mrb_env_detach(mrb_state *mrb, struct REnv *e, struct RBasic *sv, mrb_bool norai
 static void
 svar_env_adopt_owner(mrb_state *mrb, struct REnv *e)
 {
-  if (env_svar_slot(e) == NULL) return;
+  /* MRB_ENV_ONSTACK_P(e) here is the same collected-out-from-under-unshare
+     case mrb_env_detach() skips: no closed env, nothing to grow. */
+  if (MRB_ENV_ONSTACK_P(e)) return;
   struct RSvar *sv = svar_owner_force(mrb);
   if (!sv) return;
   /* Whether the container allocation ran a collection cannot be read off
@@ -987,7 +993,13 @@ svar_env_adopt_owner(mrb_state *mrb, struct REnv *e)
      allocated in the window, so a reused slot can hold nothing but it. */
   struct RBasic *b = (struct RBasic*)e;
   if (b->tt != MRB_TT_ENV || mrb_object_dead_p(mrb, b)) return;
-  *env_svar_slot(e) = mrb_obj_value(sv);
+  /* Grows a closed env sized without the slot into one (see internal.h).
+     No allocation has run since the dead-check just above passed, so the
+     resize's own allocation still finds the object that check vouched
+     for, the same one-allocation tolerance svar_owner_force()'s own
+     grow relies on, immediately after its own fresh resolution. */
+  mrb_value *slot = svar_slot_ensure(mrb, e);
+  *slot = mrb_obj_value(sv);
   mrb_write_barrier(mrb, (struct RBasic*)e);
 }
 

--- a/src/vm.c
+++ b/src/vm.c
@@ -446,6 +446,7 @@ fiber_terminate(mrb_state *mrb, struct mrb_context *c, mrb_callinfo *ci)
     if (len == 0) {
       env->stack = NULL;
       MRB_ENV_CLOSE(env);
+      MRB_ENV_CLEAR_SVAR(env);
       mrb_free(mrb, stack);
     }
     else {
@@ -456,13 +457,15 @@ fiber_terminate(mrb_state *mrb, struct mrb_context *c, mrb_callinfo *ci)
       // the reason is that env->stack may be freed by mrb_realloc() if MRB_DEBUG + MRB_GC_STRESS are enabled.
       // realloc() on a freed heap will cause double-free.
 
-      stack = (mrb_value*)mrb_realloc(mrb, stack, len * sizeof(mrb_value));
+      stack = (mrb_value*)mrb_realloc(mrb, stack, MRB_ENV_SVAR_STACK_SIZE(len));
       if (mrb_object_dead_p(mrb, (struct RBasic*)env)) {
         mrb_free(mrb, stack);
       }
       else {
+        SET_NIL_VALUE(MRB_ENV_SVAR_SLOT(stack, len));
         env->stack = stack;
         MRB_ENV_CLOSE(env);
+        MRB_ENV_SET_SVAR(env);
       }
     }
   }
@@ -484,11 +487,12 @@ mrb_env_unshare(mrb_state *mrb, struct REnv *e, mrb_bool noraise)
   if (len == 0) {
     e->stack = NULL;
     MRB_ENV_CLOSE(e);
+    MRB_ENV_CLEAR_SVAR(e);
     return TRUE;
   }
 
   size_t live = mrb->gc.live;
-  mrb_value *p = (mrb_value*)mrb_malloc_simple(mrb, sizeof(mrb_value)*len);
+  mrb_value *p = (mrb_value*)mrb_malloc_simple(mrb, MRB_ENV_SVAR_STACK_SIZE(len));
   if (live != mrb->gc.live && mrb_object_dead_p(mrb, (struct RBasic*)e)) {
     // The e object is now subject to GC inside mrb_malloc_simple().
     // Moreover, if NULL is returned due to mrb_malloc_simple() failure, simply ignore it.
@@ -497,14 +501,17 @@ mrb_env_unshare(mrb_state *mrb, struct REnv *e, mrb_bool noraise)
   }
   else if (p) {
     stack_copy(p, e->stack, len);
+    SET_NIL_VALUE(MRB_ENV_SVAR_SLOT(p, len));
     e->stack = p;
     MRB_ENV_CLOSE(e);
+    MRB_ENV_SET_SVAR(e);
     mrb_write_barrier(mrb, (struct RBasic*)e);
     return TRUE;
   }
   else {
     e->stack = NULL;
     MRB_ENV_CLOSE(e);
+    MRB_ENV_CLEAR_SVAR(e);
     MRB_ENV_SET_LEN(e, 0);
     MRB_ENV_SET_BIDX(e, 0);
     if (!noraise) {

--- a/test/t/env.rb
+++ b/test/t/env.rb
@@ -108,3 +108,10 @@ assert('REnv, the shutdown detach keeps the top-level container') do
   skip 'the teardown window opens under MRB_GC_STRESS with a compiler' if kept.nil?
   assert_true kept
 end
+
+assert('REnv, MRB_ENV_SET_BIDX() evaluates its index exactly once') do
+  # Unrelated to the slot above: mruby/proc.h documents the macro as
+  # public, so an idx argument with a side effect must run exactly once
+  # regardless of MRB_DEBUG (mrbgems/mruby-test/env.c).
+  assert_equal 1, __env_set_bidx_eval_count
+end

--- a/test/t/env.rb
+++ b/test/t/env.rb
@@ -95,3 +95,16 @@ assert('REnv, a grown env is the one scope both its procs see') do
   GC.start
   assert_equal "shared", reader.call
 end
+
+assert('REnv, the shutdown detach keeps the top-level container') do
+  # `mrb_close()` detaches the top-level frame's env before it runs the
+  # atexit callbacks, and carries the frame's special-variable container
+  # into the escaped env. The frame is the container's only root until that
+  # store, and the detach allocates on the way. The probe in
+  # mrbgems/mruby-test/env.c runs that teardown in a state of its own and
+  # answers what the escaped env's slot ended up holding; it answers nil
+  # where this build puts no collection in the window.
+  kept = __env_shutdown_svar
+  skip 'the teardown window opens under MRB_GC_STRESS with a compiler' if kept.nil?
+  assert_true kept
+end

--- a/test/t/env.rb
+++ b/test/t/env.rb
@@ -1,0 +1,97 @@
+# The shape of a closed env's heap stack (mruby/internal.h).
+#
+# A closed env carries the special-variable slot past its locals only when
+# its flag says so. `struct REnv`, `MRB_ENV_CLOSE()` and
+# `MRB_ENV_SET_LEN()` are public, so out-of-tree code builds closed envs
+# over a stack of exactly `MRB_ENV_LEN()` values; reading one past the
+# locals of such an env runs off the allocation. The C helpers are in
+# mrbgems/mruby-test/env.c: `__env_make_legacy` shrinks a real closed env
+# into that shape for the tests below, and the reads and writes go through
+# `mrb_vm_svar_get()` / `mrb_vm_svar_set()`, which resolve the owning scope
+# the way `$~` does.
+
+def env_capture(&blk)
+  blk
+end
+
+# A block written in a method closes over that method's env, and the env is
+# closed on the return, so what comes back is a proc over a closed env that
+# carries the slot.
+def env_closed_proc
+  local = :held
+  env_capture { [local, __env_svar_read] }
+end
+
+def env_closed_writer(v)
+  local = :held
+  env_capture { __env_svar_write(v); __env_svar_read }
+end
+
+# Two blocks over one env: what one writes, the other reads, because both
+# resolve to the scope they were written in.
+def env_closed_pair
+  local = :held
+  [env_capture { __env_svar_write("shared") }, env_capture { __env_svar_read }]
+end
+
+assert('REnv, closed env without the special-variable slot') do
+  pr = env_closed_proc
+  assert_true __env_svar?(pr)
+  assert_equal :nil, __env_svar_slot(pr)
+
+  assert_true __env_make_legacy(pr)
+  assert_false __env_svar?(pr)
+  assert_equal :none, __env_svar_slot(pr)
+
+  # A collection over the shrunken env must not read past its locals.
+  GC.start
+  assert_equal [:held, nil], pr.call
+end
+
+assert('REnv, C closure env carries no slot') do
+  pr = __env_cfunc_proc("cfunc")
+  assert_false __env_svar?(pr)
+  assert_equal :none, __env_svar_slot(pr)
+
+  GC.start
+  assert_equal "cfunc", pr.call
+end
+
+assert('REnv, reading special variables leaves a slotless env alone') do
+  pr = env_closed_proc
+  assert_true __env_make_legacy(pr)
+
+  assert_equal [:held, nil], pr.call
+  assert_false __env_svar?(pr)
+  assert_equal :none, __env_svar_slot(pr)
+end
+
+assert('REnv, the first write grows a slotless env into the slot') do
+  pr = env_closed_writer("written")
+  len = __env_len(pr)
+  assert_true __env_make_legacy(pr)
+
+  assert_equal "written", pr.call
+  assert_true __env_svar?(pr)
+  assert_equal :svar, __env_svar_slot(pr)
+  # the locals are still there, and the slot went past them
+  assert_equal len, __env_len(pr)
+  assert_equal "written", pr.call
+
+  # The container is reachable through the env alone; a collection must
+  # find it in the slot the write made.
+  GC.start
+  assert_equal "written", pr.call
+  assert_equal :svar, __env_svar_slot(pr)
+end
+
+assert('REnv, a grown env is the one scope both its procs see') do
+  writer, reader = env_closed_pair
+  assert_true __env_make_legacy(writer)
+  assert_false __env_svar?(reader)
+
+  writer.call
+  assert_true __env_svar?(reader)
+  GC.start
+  assert_equal "shared", reader.call
+end

--- a/test/t/env.rb
+++ b/test/t/env.rb
@@ -1,12 +1,15 @@
 # The shape of a closed env's heap stack (mruby/internal.h).
 #
 # A closed env carries the special-variable slot past its locals only when
-# its flag says so. `struct REnv`, `MRB_ENV_CLOSE()` and
-# `MRB_ENV_SET_LEN()` are public, so out-of-tree code builds closed envs
-# over a stack of exactly `MRB_ENV_LEN()` values; reading one past the
-# locals of such an env runs off the allocation. The C helpers are in
-# mrbgems/mruby-test/env.c: `__env_make_legacy` shrinks a real closed env
-# into that shape for the tests below, and the reads and writes go through
+# its flag says so, and mrb_env_unshare() never asks for that extra value on
+# its own: an ordinary escaping closure whose scope never became an owner or
+# a forward target closes over exactly its locals, the same shape
+# `struct REnv`, `MRB_ENV_CLOSE()` and `MRB_ENV_SET_LEN()` let out-of-tree
+# code build by hand. The slot appears only where mrb_env_detach() installs
+# a container or forward at close time, svar_env_adopt_owner() adopts one
+# right after, or the first non-nil write grows it in
+# (svar_slot_ensure(), mruby/internal.h). The C helpers are in
+# mrbgems/mruby-test/env.c, and the reads and writes go through
 # `mrb_vm_svar_get()` / `mrb_vm_svar_set()`, which resolve the owning scope
 # the way `$~` does.
 
@@ -15,8 +18,8 @@ def env_capture(&blk)
 end
 
 # A block written in a method closes over that method's env, and the env is
-# closed on the return, so what comes back is a proc over a closed env that
-# carries the slot.
+# closed on the return; the scope never became an owner, so what comes back
+# is a proc over a closed env with no slot at all.
 def env_closed_proc
   local = :held
   env_capture { [local, __env_svar_read] }
@@ -27,6 +30,15 @@ def env_closed_writer(v)
   env_capture { __env_svar_write(v); __env_svar_read }
 end
 
+# The write lands on the method's own live frame, before the block (and the
+# env it closes over) ever escapes: mrb_env_detach() closes this env with a
+# container already in hand, rather than growing an empty one later.
+def env_owner_before_escape(v)
+  local = :held
+  __env_svar_write(v)
+  env_capture { [local, __env_svar_read] }
+end
+
 # Two blocks over one env: what one writes, the other reads, because both
 # resolve to the scope they were written in.
 def env_closed_pair
@@ -34,18 +46,24 @@ def env_closed_pair
   [env_capture { __env_svar_write("shared") }, env_capture { __env_svar_read }]
 end
 
-assert('REnv, closed env without the special-variable slot') do
+assert('REnv, closed env carries no slot until a scope needs one') do
   pr = env_closed_proc
-  assert_true __env_svar?(pr)
-  assert_equal :nil, __env_svar_slot(pr)
-
-  assert_true __env_make_legacy(pr)
   assert_false __env_svar?(pr)
   assert_equal :none, __env_svar_slot(pr)
 
-  # A collection over the shrunken env must not read past its locals.
+  # A collection over the slotless env must not read past its locals.
   GC.start
   assert_equal [:held, nil], pr.call
+end
+
+assert('REnv, a live write closes with the slot already made') do
+  pr = env_owner_before_escape("owned")
+  assert_true __env_svar?(pr)
+  assert_equal :svar, __env_svar_slot(pr)
+
+  GC.start
+  assert_equal [:held, "owned"], pr.call
+  assert_equal :svar, __env_svar_slot(pr)
 end
 
 assert('REnv, C closure env carries no slot') do
@@ -59,7 +77,6 @@ end
 
 assert('REnv, reading special variables leaves a slotless env alone') do
   pr = env_closed_proc
-  assert_true __env_make_legacy(pr)
 
   assert_equal [:held, nil], pr.call
   assert_false __env_svar?(pr)
@@ -69,7 +86,7 @@ end
 assert('REnv, the first write grows a slotless env into the slot') do
   pr = env_closed_writer("written")
   len = __env_len(pr)
-  assert_true __env_make_legacy(pr)
+  assert_false __env_svar?(pr)
 
   assert_equal "written", pr.call
   assert_true __env_svar?(pr)
@@ -87,7 +104,7 @@ end
 
 assert('REnv, a grown env is the one scope both its procs see') do
   writer, reader = env_closed_pair
-  assert_true __env_make_legacy(writer)
+  assert_false __env_svar?(writer)
   assert_false __env_svar?(reader)
 
   writer.call


### PR DESCRIPTION
## Summary

Today `$~` and every name derived from it (`$&`, `` $` ``, `$'`, `$1`..., `Regexp.last_match`) share one process-wide global slot, while CRuby gives each Ruby local scope its own:

* a match inside a method leaks into its caller, and a failed match inside a helper erases the caller's match
* fibers overwrite each other's state
* `$~ =` accepts any object, and the derived readers fail on it later
* the last MatchData of a program, with the subject string it pins, is retained until `mrb_close()`

This PR moves the value into the owning scope while keeping the global name. `$~` becomes a virtual name in the globals table, dispatching into a per-scope special-variable container in the VM: CRuby's svar, with `$~` as one key of it. The compiler's lowering of `$&` and friends and an embedder's `mrb_gv_get(mrb, "$~")` keep working unchanged, the latter now answering the right scope's match instead of a stale global. The gem publishes into the slot directly, as CRuby's re.c calls `rb_backref_set()` rather than the name it registered with `rb_define_virtual_variable("~", ...)`.

Every behavioural cell below was measured against CRuby (ruby 4.0.6), including the escape, fiber, and cross-fiber shapes, and the new test file runs green under CRuby itself through an mrbtest-compatible assert shim.

## Changes

| commit | area | change |
|---|---|---|
| 1 | `src/variable.c`, `include/mruby/variable.h` | virtual global names: `mrb_gv_define_virtual()`, dispatch in `mrb_gv_get()`/`mrb_gv_set()` |
| 2 | `include/mruby/proc.h`, `src/proc.c` | the block argument index narrowed to the seven bits it needs, which frees the flag bit commit 3 uses to say that a closed env carries the slot |
| 3 | `src/vm.c`, `src/gc.c`, `src/proc.c`, `src/error.c`, `include/mruby/internal.h`, `include/mruby/proc.h`, `mrbgems/mruby-os-memsize`, `mrbgems/mruby-binding` | the one slot a closed env carries past its locals, under bit 15 of `REnv.flags`: sized where an env closes over a live stack, moved by `mrb_proc_merge_lvar()`, marked only where the flag says it is there |
| 4 | `src/vm.c`, `src/gc.c`, `include/mruby.h`, `include/mruby/value.h`, `include/mruby/internal.h`, `mrbgems/mruby-os-memsize`, `mrbgems/mruby-task`, `mrbgems/mruby-test`, `test/t/env.rb` | a special-variable container (`struct RSvar`, CRuby's svar) per call frame, keyed accessors, owner resolution, marking, and the escape into the slot above on an ordinary return |
| 5 | `src/vm.c`, `src/gc.c`, `src/error.c`, `include/mruby.h`, `include/mruby/internal.h`, `mrbgems/mruby-task`, `mrbgems/mruby-test`, `test/t/env.rb` | what each frame carries out of a stack being torn down around it, through `mrb_env_detach_all()` (#7410, already on master): a GC-freed suspended fiber, mruby-task, and the clean-shutdown arm |
| 6 | `mrbgems/mruby-regexp`, `mrbgems/mruby-bin-mruby` (bintest) | `$~` becomes the virtual global under `MRB_SVAR_BACKREF`, `$~ =` raises CRuby's `TypeError`, tests for the scope rules, the `eval` family and both container keys |
| 7 | `include/mruby/proc.h`, `mrbgems/mruby-test`, `test/t/env.rb` | `MRB_ENV_SET_BIDX()` evaluated its index twice under `MRB_DEBUG`; moved into a `static inline` function so a caller's side-effecting argument runs once in either build |
| 8 | `src/vm.c`, `include/mruby/internal.h`, `mrbgems/mruby-regexp/test`, `mrbgems/mruby-test`, `test/t/env.rb` | the slot past an env's locals is grown only where a scope ends up needing one, through `svar_slot_ensure()`, instead of sized up front by every closing env and every terminating fiber |
| 9 | `src/vm.c`, `include/mruby/internal.h` | closes an env's special-variable slot in the one allocation `mrb_env_unshare()` already makes for its locals, instead of growing it by a second, raising allocation afterward that could raise `NoMemoryError` out from under the two callers relying on `mrb_env_detach()`'s FALSE |

### variable.c: a global name that dispatches

`mrb_gv_define_virtual()` registers a getter/setter pair behind a sentinel stored in the globals table itself, so `$~` stays visible to `defined?`/`global_variables`, is marked like any other global, and costs one extra type test per access, no second table search.

### REnv: which closed envs carry the slot

`REnv` sits at the five-word object-cell bound, so the slot a scope leaves behind has to ride in the env's own heap stack, one past the locals. Being closed cannot say the slot is there by itself, since out-of-tree code builds closed envs sized to exactly their locals, so a flag bit in `REnv.flags` says it instead, reclaimed from the block argument index by narrowing that field to the width mruby's own argument limits need; nothing in tree writes the field beyond that bound, and the macro still asserts to catch code that does (commit 7 moves the assert into a `static inline` function, since the macro form evaluated its index argument twice under `MRB_DEBUG`). An env is on-stack, closed over exactly its locals, or closed with the slot appended:

* the middle (no-slot) state is the ordinary way every scope closes: `mrb_env_unshare()` never asks for the extra value on its own, so a closure escaping a scope that never became an owner or a forward target pays nothing for it. It is also what out-of-tree code and C closures make, and what the core's own envs fall back to when there is no stack left to size (`mrb_env_unshare()` out of memory, `error.c`'s fault-time rewind). A read there answers nil off the missing slot, and `svar_slot_ensure()` in vm.c grows it into the third state on the one write that needs it: `mrb_env_detach()` installing a container or forward at close time, `svar_env_adopt_owner()` adopting one just after, or the first non-nil write into a scope that already outlived its frame
* `mrb_proc_merge_lvar()` moves the slot rather than duplicating it, since appended locals take the ground it stood on
* the shape has no Ruby-visible face, so `test/t/env.rb` drives C helpers the way `test/t/vformat.rb` drives vformat.c, and mruby-binding tests drive their own for `Binding#local_variable_set`

Cost: `proc.o` is +32 bytes at `-O3` across commits 2, 3 and 7 together.

### Compatibility: `MRB_ENV_SET_BIDX()`'s narrower range

`MRB_ENV_SET_BIDX()` is public, so narrowing the field it writes from eight bits to seven technically narrows its representable range from 0..255 to 0..127. mruby itself never asks for more than 43: one for the receiver, at most 14 positional arguments (15 meaning a packed array, worth one), and at most 28 for 14 keyword pairs (15 meaning a packed hash, worth one), the bound `mrb_env_new()` computes to and asserts against. A debug build now asserts on any caller passing a wider index instead of silently truncating it into the flag bit above, the eight-bit field's old behavior; nothing in this tree, core or gems, is that caller.

### vm.c: the container and owner resolution

`mrb_callinfo` gains an `svar` pointer to a `struct RSvar` (`MRB_TT_SVAR`), a small keyed array mirroring CRuby's svar (sized for more than one key, e.g. `$_`, though only `$~`'s is registered here), allocated lazily on the first non-nil write into a scope so a method that never touches a special variable stays NULL. The core owns the container and its key namespace; what a key means belongs to the gem that registers the matching virtual global, the same split CRuby keeps between vm.c and re.c.

`mrb_vm_svar_get()`/`mrb_vm_svar_set()` resolve the owning scope the way CRuby resolves svar: C frames and nested `mrb_top_run()` calls are transparent, blocks and lambdas resolve over the lexical chain to their defining scope, `eval` inherits its caller's scope by construction (`Binding#eval` is the one exception, resolving to the bound scope instead), and one redirect mirrors CRuby's `ec->root_lep` to keep a fiber's matches its own. The Behaviour section below is the measured effect of each rule.

### vm.c: escape and teardown

A scope whose env escapes keeps its container: `mrb_env_detach()` grows the env into the slot past the locals, through `svar_slot_ensure()`, whenever a frame's env closes while the VM runs on and its `sv` argument is non-NULL, i.e. the frame already owns a container or was handed one to forward; an ordinary return, `mrb_vm_ci_env_clear()` between `mruby -r` files, or a fresh top-level chunk in `mrb_vm_run()` all reach it this way, so a proc outliving its scope keeps reading it. A scopeless frame's escaping env adopts the owner's container instead, through `svar_env_adopt_owner()` right after `cipop()`, made on the spot if that scope holds none yet. A frame with nothing to carry closes over exactly its locals and pays for none of this: `mrb_env_unshare()` and `fiber_terminate()` (a fiber's own root svar is CRuby's `ec->root_svar`, dying with the fiber by design) stopped sizing every closing env for the slot up front, so a method that never touches a special variable, in a build that never loads a gem that registers one, no longer pays one `mrb_value` per escaping closure.

Stack teardown shares `mrb_env_detach_all()` (#7410, already on master), but the two callers resolve owners differently for the same reason: GC freeing a suspended fiber runs inside the sweep, where resolving an owner would chase already-recycled objects, so it reads only what mark-time stashed in `ci->svar`; mruby-task tears down outside a collection, so it resolves owners live with GC held off across the loop. Either way, a scopeless frame with no container yet records its env, and resolution follows the forward.

GC safety: the write paths re-resolve the owner after their own allocation, since that allocation can itself collect the stack the owner stood on (`svar_owner_force()`); the clean-shutdown arm orders the top-level rewind after the detach for the same reason; a heap-value write pays a backward write barrier, an immediate write (nil after a failed match, the common case) pays none.

### vm.c: closing the slot in one allocation

Commit 8's lazy growth left `mrb_env_detach()` making two separate allocations whenever the closing env has a container or forward to carry: `mrb_env_unshare()`'s own allocation for the locals, which honors its `noraise` argument, followed by `svar_slot_ensure()`'s `mrb_realloc()` to grow by the one slot, a raising API called unconditionally regardless of `noraise`.

If the first allocation succeeds and the second fails, `mrb_realloc()` raises `NoMemoryError` directly, from inside a call `mrb_env_detach()` never gets the chance to turn into its own FALSE return. Two callers depend on that return value rather than a raise reaching them there: `cipop()`, which decrements its own callinfo before raising, the invariant mruby's own #3087 fix established so exception unwind never re-enters the frame that just returned; and `mrb_env_detach_all()`'s `resolve` callers (`mruby-task` tearing a context down), which hold `mrb->gc.disabled` across their whole detach loop and restore it only once the loop returns normally.

The second case demonstrates the sharper consequence. A counting allocator standing in for `mrb_basic_alloc_func()` (an intentional override point per `src/allocf.c`) failing exactly the slot-growing `mrb_realloc()` call, once, mid-`Task#close`: the `NoMemoryError` gets rescued cleanly by ordinary Ruby code, and `mrb->gc.disabled` is left stuck at TRUE anyway, since the raise skips the restore. Every later `mrb_full_gc()` becomes a no-op, invisibly, for the rest of the process's life. An ordinary call and return raising the same way self-heals instead, since the VM's generic exception unwind walks `c->ci` back down regardless of whether `cipop()` itself decremented it first, so it took the scopeless-frame teardown path to show the bug's real reach.

`env_unshare_with_svar()` folds both allocations into one, sized for `len + (sv ? 1 : 0)` up front and structured like `mrb_env_unshare()` itself: on failure it answers FALSE through the same `noraise` contract instead of raising out from underneath its caller, and there is no longer a window where the locals have detached but the slot's own growth can still fail on its own.

### mruby-regexp: the switch

`$~` becomes the virtual global under `MRB_SVAR_BACKREF`. The gem bypasses the name it registers: `set_match_globals()` and `Regexp.last_match` call `mrb_vm_svar_set()`/`mrb_vm_svar_get()` directly, as CRuby's re.c and string.c reach `rb_backref_set()`/`rb_backref_get()` beside their own `rb_define_virtual_variable("~", ...)`. Every value the gem publishes is a MatchData by construction, so the setter is where `$~ = <not a MatchData, not nil>` raises CRuby's `TypeError`, matching `match_setter()`.

#7397 / #7398 already moved `Kernel#!~` and `Symbol#slice`/`#[]` to C on master, the way #7393 did the String/Symbol overrides, so both are transparent here without change.

## Behaviour

Each row is measured on both engines; the PR column equals CRuby's answer everywhere.

```ruby
def m
  "inner" =~ /inner/
end
"outer" =~ /outer/
m
$~[0]   # master: "inner"   PR and CRuby: "outer"
```

| shape | master | this PR and CRuby |
|---|---|---|
| match inside a method, seen from the caller | leaks | invisible, the caller keeps its own |
| failed match inside a method | erases the caller's `$~` | the caller is untouched |
| failed match in the same scope | publishes nil | publishes nil |
| `match?` | preserves | preserves |
| a block | shares the one global | shares exactly its defining method's slot, wherever the block travels |
| fibers | one shared slot | per execution context |
| `eval` and `instance_eval` on a String | shares the one global | shares the scope it is called from |
| `Binding#eval` | shares the one global | writes the bound scope, the caller keeping its own |
| `$~ = 1` | stored, readers fail later | `TypeError` at the write |
| `defined?($~)` | `"global-variable"` | `"global-variable"` |

A proc outliving its scope keeps reading that scope's match, and two procs cut from one dead scope share its slot, the way CRuby's svar lives on the lep and survives with it:

```ruby
def mk
  "esc" =~ /esc/
  -> { $~ }
end
mk.call[0]   # "esc" on both engines
```

The same lexical rule runs across fiber boundaries (a proc born inside a fiber and read outside, a proc carried into a fiber, a fiber's own root matches dying with it, a fiber collected mid-resolution, the root-lep redirect), every cross-boundary shape measured equal on both engines. `mruby -r` starts each new file with `$~` unset while a proc the previous file left behind keeps reading that file's scope in both directions (`ruby -r` measured the same; a bintest pins the pair); mirb does not isolate between interactive lines, which keep one scope the way their top-level locals already persist.

## Speed

Callgrind Ir on the host build (clang, `-O3`, word boxing), each bench run at N and 2N iterations so the per-iteration cost is `(Ir(2N) - Ir(N)) / N` and startup cancels exactly; runs are bit-identical and linear in N. The base column is master at the branch point, `79b08d227`. Wall clock on the `=~` hit bench at 2M iterations medians 2.12s on master and 2.17s on this PR, five interleaved runs each on one pinned core.

| bench, one iteration | master | PR | delta |
|---|---|---|---|
| method call + `=~` hit + `$1` | 15,256.6 | 15,547.4 | +290.8 (+1.9%) |
| method call + `=~` miss | 11,689.7 | 11,685.0 | -4.7 (-0.0%) |
| `gsub`, 2 hits + block | 18,919.4 | 18,842.9 | -76.5 (-0.4%) |
| 12 `=~` inside an `each` block | 181,652.7 | 181,717.7 | +65.0 (+0.0%) |
| `=~` hit + 10 `$~` reads | 15,085.2 | 15,690.1 | +604.9 (+4.0%) |
| unrelated global, read + write | 529.0 | 525.0 | -4.0 |
| unrelated global, write only | 427.0 | 415.0 | -12.0 |
| unrelated global, read only | 375.0 | 383.0 | +8.0 |
| `fib(15)`, 1,973 calls, no regexp | 1,212,573.7 | 1,222,433.7 | +9,860.0 |
| startup, once per process | 2,424,719 | 2,427,514 | +2,795 |

* a publish or read pays the owner walk, and the first non-nil publish into a scope pays the container allocation, which is what the hit row shows against the top-scope benches' single allocation
* a publish or clear no longer searches the globals table, the gem writing the slot directly, which is what puts the miss and `gsub` rows under master despite every frame paying the new pair; the `each` row sits flat against master (+65.0, +0.04%), too small a gap to attribute to either cost
* a read written in Ruby still goes through the name, so the ten-read row keeps a search and a type test on top of the walk
* the `fib` row is the same per-frame pair on a program with no regexp at all: 5.0 Ir per method call, no slot allocated, no walk run

Owner resolution is linear where CRuby's is constant, since CRuby's svar lives on the ep and here the env does not record its frame: `svar_owner()` scans the ci stack downward from the reader (one `CI_ENV` test per intervening entry) and `svar_scope_env()`'s `p->upper` chase adds a step per lexical nesting level. A `$~` read under d nested `1.times` blocks costs 29.0 Ir more per level (master's own slope on the pair is 0.1); a lambda reading `$~` at the bottom of a d-frame recursion spends 9.0 Ir more inside `svar_owner()` per frame (master's slope on that pair is 35.0 Ir, the arena protect in `L_RETURN` any frame returning a heap value already pays). At the nesting depths real code runs, the term disappears into the read's constant cost; a comment on `svar_owner()` records the rule.

## Size

`.text` of `bin/mruby`, `build_config/ci/gcc-clang.rb`, this PR against master at the branch point (`79b08d227`), clean build directories, same tree path:

| build | master | PR | delta |
|---|---|---|---|
| bintest | 1,102,438 | 1,104,038 | +1,600 |
| ascii-ctype | 1,097,558 | 1,102,214 | +4,656 |
| byte-string | 1,076,598 | 1,081,190 | +4,592 |
| cxx_abi | 1,091,277 | 1,094,845 | +3,568 |
| full-debug (-O0) | 1,900,038 | 1,907,542 | +7,504 |

Attribution (bintest objects): `vm.o` +208 (the container, accessors, owner resolution, escape and teardown, net of commit 8 dropping `mrb_env_unshare()`'s and `fiber_terminate()`'s up-front slot sizing in favour of growing through `svar_slot_ensure()` at the point a scope actually needs it); `variable.o` +507 (virtual-name dispatch); `regexp.o` +469 (pair registration, `TypeError` setter, and an `-O3`-only inlining move: a direct slot write brings `create_matchdata()` under the inliner's threshold, so its bytes go into publishing callers while read/clear-only sites lose some back); `gc.o` +280 (marking/freeing the container, the fiber teardown loop having moved into vm.o); `proc.o` +32 (the two `mrb_proc_merge_lvar()` stack shapes plus commit 7's `static inline` replacement for `MRB_ENV_SET_BIDX()`); `memsize.o` +64 (`MRB_TT_SVAR` case); `binding.o` +16, `object.o` +16, `fiber.o` +16 (each pulls in one more call through `svar_slot_ensure()`'s inlined body); `task.o` +48 (its teardown loop moved into vm.o, net of `fiber_terminate()` no longer sizing for a slot the fiber's root scope never carries); `backtrace.o` -16, `mruby_objectspace.o` -16, netting zero (`MRB_TT_SVAR` joins `enum mrb_vtype`, switches and tables laid out afresh); `error.o` unchanged (the clean-shutdown arm carries the top-level container into the escaping env for the cost of the rewind it already did). The list sums to +1,624 against a measured `.text` delta of +1,600; the gap is link-time alignment padding, not a missing object.

## Testing

* every commit of the branch: `build_config/ci/gcc-clang.rb`, all five builds including full-debug's `MRB_GC_STRESS` and cxx_abi's C++ compile, `rake -m test` green with KO 0 and Crash 0 throughout, each commit built from an empty build directory and also green on the host build
* head: host build (clang, word boxing) green including bintest; six boxing configurations green over `full-core` (word / `MRB_NO_BOXING` / `MRB_NAN_BOXING` crossed with `MRB_INT64` / `MRB_INT32`); `MRB_GC_STRESS` on the full suite is full-debug above
* head: AddressSanitizer + UndefinedBehaviorSanitizer (clang, debug, full-core), full suite, zero reports. The ASan + `MRB_GC_STRESS` combination replays the fiber-collection window deterministically: with the owner re-resolution removed it reports a heap-use-after-free WRITE in `svar_owner_force()`, clean with it in place
* the shutdown window has its own test, `__env_shutdown_svar`, which builds a state, leaves a block over its top level and a container on the scope it resolves to, closes it with an atexit callback, and reads what the escaped env's slot held. With the rewind moved back before the detach it fails under full-debug (the slot reads as the swept object the sweep left there); the helper answers nil elsewhere and the test skips rather than passing on a window that never opened. The same shape outside mrbtest, under ASan with `MRB_GC_STRESS`, aborts in `mrb_gc_mark()` on `MRB_TT_FREE` reached from the escaped env's slot, clean with the ordering in place
* the env-shape tests close over the real slotless shape an ordinary escaping closure now reaches on its own (the same shape out-of-tree code builds by hand), so a read past the locals is a genuine out-of-bounds access: with the marking guard reverted, `gc_mark_children()` reports a heap-buffer-overflow (reached even from a C closure's own slotless env, e.g. `attr_accessor`'s writer); with the merge reverted, `Binding#local_variable_set` over the stripped env overflows in `mrb_proc_merge_lvar()`; with both in place the full suite runs clean
* `MRB_ENV_SET_BIDX()`'s index is pinned to a single evaluation by a counting helper in `mrbgems/mruby-test/env.c`: `test/t/env.rb` asserts the count is exactly one, red (`Expected: 1 / Actual: 2`) under `MRB_DEBUG` against the old comma-expression macro and green against the `static inline` replacement, checked in both build modes directly
* the lazy slot growth is checked by reverting each of its four sites in turn: `mrb_env_unshare()` alone turns four `test/t/env.rb` assertions red, all built around the no-slot default; `mrb_env_detach()`'s grow alone reddens most of `backref_scope.rb`'s fiber- and nested-load-related assertions, a `mruby -r` bintest checking that each loaded chunk keeps its own special variables, and a new live-write assertion (`env_owner_before_escape`); `svar_env_adopt_owner()`'s alone reddens the four nested-load-escape assertions in the same file; `fiber_terminate()`'s alone breaks nothing existing, which is why `backref_scope.rb` gained an assertion exercising a fiber's own root scope, the one file that already declares both `Fiber` and the env-shape introspection helpers. Restoring each fix turns the matching assertion green again
* mruby-task rides in all five builds above and is green there; the teardown shapes a scheduler alone reaches were driven by hand in a task+regexp build, plain and under `MRB_GC_STRESS`: a suspended scope keeping its match through `Task#terminate` and a following `GC.start`; a returning scope keeping its match through task completion; a task preempted inside a nested `mrb_load_string()` handing the load's escaped proc the scope below's match, in both write directions through the forwarded slot; a reset-and-reused context starting unset
* the mark-time record is driven from both ends: a nested load on a fiber with a `GC.start` inside the loaded source, so marking resolves and records the forward mid-run, then read and write through the escaped proc after the load returns
* `mrbgems/mruby-regexp/test/backref_scope.rb` passes under ruby 4.0.6 through an mrbtest-compatible assert shim, the eight `eval`-family shapes included, so every expectation is CRuby's measured answer; the nested-load and container-key tests drive C helpers with no CRuby counterpart and skip there, measured separately on CRuby with `$_` standing in for the helpers

## Environment

<details>

* Linux 7.0.0-30-generic x86_64, Ubuntu 24.04
* Homebrew clang 22.1.8, gcc (Ubuntu) 13.3.0
* valgrind 3.27.1, ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM
* host compile line as recorded by the build (`-ffile-prefix-map` and `-I` paths elided):

```
clang -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK
```

</details>





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
* Added virtual global variables with customizable getter and setter behavior.
* Improved special-variable scope handling across methods, blocks, fibers, bindings, and nested evaluations.
* Preserved regular-expression match state within its owning scope.

## Bug Fixes
* `$~` and related match handling now consistently reject invalid assignments with `TypeError`.
* Improved preservation of match state and scoped variables during garbage collection and environment changes.

## Tests
* Expanded coverage for backreferences, bindings, fibers, nested loads, and environment behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
