### PR TITLE
mruby-compiler: avoid pushing discarded local assignment values

### DIFF
--- a/mrbgems/mruby-compiler/src/codegen.c
+++ b/mrbgems/mruby-compiler/src/codegen.c
@@ -4675,7 +4675,7 @@ codegen(mrc_codegen_scope *s, mrc_node *tree, int val)
              expression yields nothing and every later register is off by
              one, which shows up as `bidx < irep->nregs` in the VM. */
           gen_assignment_lvar(s, cursp(), name, depth, val);
-          push();
+          if (val) push();
           break;
         case PM_GLOBAL_VARIABLE_OR_WRITE_NODE:
         case PM_GLOBAL_VARIABLE_AND_WRITE_NODE:

--- a/test/t/ensure.rb
+++ b/test/t/ensure.rb
@@ -34,3 +34,13 @@ assert('ensure - context - yield and return') do
   end.call
   assert_equal yielder, yielder.ensure_context
 end
+
+assert('ensure with local ||= preserves return value') do
+  result = lambda do
+    value = []
+    :result
+  ensure
+    value ||= []
+  end.call
+  assert_equal :result, result
+end


### PR DESCRIPTION
## Problem

The following code returns `2` instead of `"success"`:

```ruby
def result
  value = [1, 2, 3]
  "success"
ensure
  value ||= []
  value.each { |v| p v }
end

p result
```

`mrbc -v` emits the following irep for `result`:

```text
irep nregs=9 nlocals=3 pools=1 syms=1 reps=1 ilen=43
local variable names:
  R2:value
catch type: ensure   begin: 0004 end: 0020 target: 0020
catch type: rescue   begin: 0004 end: 0017 target: 0020
    1 000 ENTER        0:0:0:0:0:0:0:0 (0x0)
    2 004 LOADI_1      R3      (1)
    2 006 LOADI_2      R4      (2)
    2 008 LOADI_3      R5      (3)
    2 010 ARRAY        R2      R3      3
    3 014 STRING       R3      L[0]    ; success
    3 017 JMP          020
    3 020 EXCEPT       R5
    5 022 JMPIF        R2      029
    5 026 ARRAY        R2      0
    6 029 MOVE         R7      R2
    6 032 BLOCK        R8      I[0]
    6 035 SENDB        R7      :each  n=0
    6 039 RAISEIF      R5
    6 041 RETURN       R4
```

The return value is stored in `R3`, but the final instruction reads `R4`.

## Fix

`gen_ensure()` compiles the ensure statements with `NOVAL`. However, the local OR/AND-assignment branch unconditionally called `push()`, advancing the compiler's register stack even when the expression result was discarded.

This left the register stack offset by one, so the later `gen_return()` emitted `RETURN R4` instead of `RETURN R3`.

Only call `push()` when `val` is requested. A minimal regression test was also added.

## Verification

- `./minirake all`
- `./minirake test:build`
- Confirmed that the regression test fails with the unconditional `push()`
- Confirmed that the regression test passes with `if (val) push()`
- The reproduction returns `"success"`
- `mrbc -v` emits `RETURN R3`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where local variable assignments in `ensure` blocks could incorrectly affect the return value.
  * Assignments now preserve expected expression results when their value is not needed.

* **Tests**
  * Added coverage confirming that `ensure` blocks using local variable assignment preserve the original return value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->