### PR TITLE
mruby-process: file the `wait` row with the implemented methods

### DIFF
--- a/mrbgems/mruby-process/README.md
+++ b/mrbgems/mruby-process/README.md
@@ -20,6 +20,7 @@ already include it.
 | Process.pid                | o             | also `$$`                                |
 | Process.ppid               | o             |                                          |
 | Process.kill               | o             | no negative-signal form yet, see below   |
+| Process.wait, .wait2       | o             | `.waitpid2` too; not `.waitall`          |
 | Process.waitpid            | o             | sets `$?`; POSIX only, see below         |
 | Process::WNOHANG           | o             | mruby's own value, not the platform's    |
 | Process::WUNTRACED         | o             | mruby's own value, not the platform's    |
@@ -40,7 +41,6 @@ already include it.
 | Process.spawn              |               | separate change                          |
 | Process.exec               |               | separate change                          |
 | Process.exit, .exit!       |               | see mruby-exit                           |
-| Process.wait, .wait2       | o             | `.waitpid2` too; not `.waitall`          |
 | Process.uid, .gid, ...     |               | separate change                          |
 | Process.getpgrp, ...       |               | separate change                          |
 


### PR DESCRIPTION
## Summary

The README's method table lists `Process.wait` and `.wait2` with an implemented mark, but the row sits in the block of rows naming what the gem does not do yet, between `Process.exit` and `Process.uid`. This moves the row up next to `Process.waitpid`, with the other implemented wait entry. The row itself is unchanged.

## Testing

Documentation only; `prettier --check` passes on the file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the supported methods table to document `Process.wait`, `.wait2`, and `.waitpid2`.
  - Clarified that `.waitall` is not supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->