### PR TITLE
mruby-regexp: tell an omitted `last_match` argument from an explicit nil

### DIFF
--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -3175,16 +3175,18 @@ sym_match_op_m(mrb_state *mrb, mrb_value self)
  * Reads `$~` and indexes it the way MatchData#[] does: CRuby's
  * rb_reg_s_last_match() reaches rb_reg_nth_match() directly rather than
  * dispatching `[]`, so a program redefining `MatchData#[]` moves `md[n]`
- * and leaves this reader alone.
+ * and leaves this reader alone. The whole MatchData answers only an
+ * omitted argument, told apart by arity: an explicit nil goes on to the
+ * integer conversion and fails it, as it does in CRuby.
  */
 static mrb_value
 regexp_s_last_match(mrb_state *mrb, mrb_value klass)
 {
-  mrb_value n = mrb_nil_value();
+  mrb_value n;
 
-  mrb_get_args(mrb, "|o", &n);
+  mrb_int argc = mrb_get_args(mrb, "|o", &n);
   mrb_value md = mrb_gv_get(mrb, ensure_match_sym(mrb));
-  if (mrb_nil_p(n)) return md;
+  if (argc == 0) return md;
   if (mrb_nil_p(md)) return mrb_nil_value();
   return md_aref(mrb, md, n);
 }

--- a/mrbgems/mruby-regexp/test/match_data.rb
+++ b/mrbgems/mruby-regexp/test/match_data.rb
@@ -166,6 +166,14 @@ assert("Regexp.last_match") do
   assert_equal "123", Regexp.last_match(0)
 end
 
+assert("Regexp.last_match - an explicit nil is not an omitted argument") do
+  "lm" =~ /lm/
+  assert_equal "lm", Regexp.last_match[0]
+  assert_raise(TypeError) { Regexp.last_match(nil) }
+  "lm" =~ /nomatch/
+  assert_nil Regexp.last_match(nil)
+end
+
 assert("MatchData#[] - negative index") do
   md = /(a)(b)/.match("ab")
   assert_equal "b", md[-1]


### PR DESCRIPTION

## Summary

`Regexp.last_match` reads its optional argument into a nil default and tests the value, so an explicit nil answers the full MatchData the way an omitted argument does. CRuby short-circuits on the arity instead: `rb_reg_s_last_match()` answers the backref for zero arguments and otherwise numbers the group, where nil fails the integer conversion.

```ruby
"a" =~ /a/
Regexp.last_match       # => #<MatchData "a">
Regexp.last_match(nil)  # CRuby: TypeError; mruby: #<MatchData "a">
```

## Changes

The omission test becomes the argument count `mrb_get_args()` returns. An explicit nil now falls through to `md_aref()` and fails its integer conversion with CRuby's `TypeError`; with no current match the method answers nil ahead of the conversion, as CRuby answers nil before numbering the group.

## Behaviour

| shape | master | this PR and CRuby |
|---|---|---|
| `Regexp.last_match(nil)`, a match standing | the full MatchData | `TypeError` |
| `Regexp.last_match(nil)`, no match | nil | nil |

The `TypeError` is `mrb_as_int()`'s ("nil cannot be converted to Integer"); CRuby spells it "no implicit conversion from nil to integer", a wording difference the message-alignment policy of #7385 leaves alone since the raise sites already agree.

## Size

`.text` of `bin/mruby`, `build_config/ci/gcc-clang.rb`, this PR against master, clean build directories, same tree path; the four optimized builds compile the arity test to the byte-identical size:

| build | master | PR | delta |
|---|---|---|---|
| bintest | 1,100,374 | 1,100,374 | 0 |
| ascii-ctype | 1,095,670 | 1,095,670 | 0 |
| byte-string | 1,075,830 | 1,075,830 | 0 |
| cxx_abi | 1,088,485 | 1,088,485 | 0 |
| full-debug (-O0) | 1,896,982 | 1,896,966 | -16 |

## Testing

* `build_config/ci/gcc-clang.rb`, all five builds, `rake -m test` green (cxx_abi linked with `LDFLAGS=--gcc-install-dir=...`)
* host build (clang, word boxing): `rake -m test` green
* a new test pins both rows of the table above, the omitted form beside them

## Environment

<details>

* Linux 7.0.0-30-generic x86_64, Ubuntu 24.04
* Homebrew clang 22.1.8

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated `Regexp.last_match` to distinguish between an omitted argument and an explicitly provided `nil`, matching CRuby behavior.
  * Explicit `nil` now raises a `TypeError` when a match is available and returns `nil` when no match exists.

* **Tests**
  * Added coverage for the updated `Regexp.last_match(nil)` behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->