### PR TITLE
build: write a compile_commands.json from the records of the compiles

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -2,7 +2,7 @@
 # no include paths, so the force-includes below resolve nothing and every
 # `#include <mruby/...>` is a file-not-found. compile_flags.txt next to this
 # file supplies those paths; a compile_commands.json, when the tree has one,
-# still wins over it, so generating one (e.g. `bear -- rake`) still gives the
+# still wins over it, so the one this tree writes for itself gives the
 # per-file flags of a real build. The paths have to live there rather than
 # here, because a relative path added from this file resolves against the
 # directory of the file being edited, not against the project root.

--- a/Rakefile
+++ b/Rakefile
@@ -60,6 +60,7 @@ load "#{MRUBY_ROOT}/tasks/benchmark.rake"
 load "#{MRUBY_ROOT}/tasks/doc.rake"
 load "#{MRUBY_ROOT}/tasks/install.rake"
 load "#{MRUBY_ROOT}/tasks/amalgam.rake"
+load "#{MRUBY_ROOT}/tasks/compile_commands.rake"
 load "#{MRUBY_ROOT}/tasks/unicode.rake"
 load "#{MRUBY_ROOT}/tasks/difftest.rake"
 

--- a/build_config/bench.rb
+++ b/build_config/bench.rb
@@ -8,4 +8,7 @@ MRuby::Build.new('bench') do |conf|
   end
 
   conf.gembox 'default'
+
+  # The compile_commands.json at the source root speaks for this build
+  conf.enable_compile_commands default: true
 end

--- a/build_config/boxing.rb
+++ b/build_config/boxing.rb
@@ -12,6 +12,11 @@ boxings.product(bits, ints) do |boxing, bit, int|
       c.flags << "-m#{bit}"
     end
     conf.linker.flags << "-m#{bit}"
+
+    # The compile_commands.json at the source root speaks for the plain build,
+    # word boxing being what mruby picks when nothing asks for another.
+    conf.enable_compile_commands default: true if [boxing, bit, int] == ['word', 64, 64]
+
     conf.enable_debug
     conf.enable_test
     conf.enable_bintest

--- a/build_config/ci/gcc-clang.rb
+++ b/build_config/ci/gcc-clang.rb
@@ -8,6 +8,11 @@ MRuby::Build.new('full-debug') do |conf|
   conf.gembox 'full-core'
   conf.cc.defines += %w(MRB_GC_STRESS MRB_USE_DEBUG_HOOK)
 
+  # The compile_commands.json at the source root speaks for this build: what it
+  # adds to a default build only turns code on, where every other build here
+  # turns some off and would have an editor grey out a path that is live.
+  conf.enable_compile_commands default: true
+
   conf.enable_test
 end
 

--- a/build_config/clang-asan.rb
+++ b/build_config/clang-asan.rb
@@ -5,6 +5,9 @@ MRuby::Build.new('clang-asan') do |conf|
   # include the GEM box
   conf.gembox 'full-core'
 
+  # The compile_commands.json at the source root speaks for this build
+  conf.enable_compile_commands default: true
+
   # Turn on `enable_debug` for better debugging
   conf.enable_sanitizer "address,undefined"
   conf.enable_debug

--- a/build_config/default.rb
+++ b/build_config/default.rb
@@ -78,6 +78,10 @@ MRuby::Build.new do |conf|
 
   # Turn on `enable_debug` for better debugging
   # conf.enable_debug
+
+  # The compile_commands.json at the source root speaks for this build
+  conf.enable_compile_commands default: true
+
   conf.enable_bintest
   conf.enable_test
 end

--- a/build_config/gcc-asan.rb
+++ b/build_config/gcc-asan.rb
@@ -7,6 +7,9 @@ MRuby::Build.new('gcc-asan') do |conf|
   # include the GEM box
   conf.gembox 'full-core'
 
+  # The compile_commands.json at the source root speaks for this build
+  conf.enable_compile_commands default: true
+
   # Turn on `enable_debug` for better debugging
   conf.enable_sanitizer "address,undefined"
   conf.enable_debug

--- a/build_config/host-cxx.rb
+++ b/build_config/host-cxx.rb
@@ -6,6 +6,10 @@ MRuby::Build.new('host-cxx') do |conf|
 
   # C compiler settings
   conf.cc.defines = %w(MRB_USE_DEBUG_HOOK)
+
+  # The compile_commands.json at the source root speaks for this build
+  conf.enable_compile_commands default: true
+
   conf.enable_debug
   conf.enable_cxx_abi
   conf.enable_test

--- a/build_config/host-debug.rb
+++ b/build_config/host-debug.rb
@@ -16,6 +16,9 @@ MRuby::Build.new('host') do |conf|
 
   # Regexp is included via stdlib.gembox
 
+  # The compile_commands.json at the source root speaks for this build
+  conf.enable_compile_commands default: true
+
   # test
   conf.enable_test
   # bintest

--- a/build_config/host-f32.rb
+++ b/build_config/host-f32.rb
@@ -9,6 +9,9 @@ MRuby::Build.new('host-f32') do |conf|
 
   conf.cc.defines << 'MRB_USE_FLOAT32'
 
+  # The compile_commands.json at the source root speaks for this build
+  conf.enable_compile_commands default: true
+
   # Turn on `enable_debug` for better debugging
   conf.enable_debug
   conf.enable_test

--- a/build_config/host-gprof.rb
+++ b/build_config/host-gprof.rb
@@ -10,6 +10,9 @@ MRuby::Build.new('host-gprof') do |conf|
   conf.cc.flags << '-pg'
   conf.linker.flags << '-pg'
 
+  # The compile_commands.json at the source root speaks for this build
+  conf.enable_compile_commands default: true
+
   # Turn on `enable_debug` for better debugging
   conf.enable_debug
   conf.enable_test

--- a/build_config/host-m32-f32.rb
+++ b/build_config/host-m32-f32.rb
@@ -11,6 +11,9 @@ MRuby::Build.new('host-m32-f32') do |conf|
   conf.cc.defines << 'MRB_USE_FLOAT32'
   conf.linker.flags << '-m32'
 
+  # The compile_commands.json at the source root speaks for this build
+  conf.enable_compile_commands default: true
+
   # Turn on `enable_debug` for better debugging
   conf.enable_debug
   conf.enable_test

--- a/build_config/host-m32.rb
+++ b/build_config/host-m32.rb
@@ -10,6 +10,9 @@ MRuby::Build.new('host-m32') do |conf|
   conf.cc.flags << '-m32'
   conf.linker.flags << '-m32'
 
+  # The compile_commands.json at the source root speaks for this build
+  conf.enable_compile_commands default: true
+
   # Turn on `enable_debug` for better debugging
   conf.enable_debug
   conf.enable_test

--- a/build_config/host-nofloat.rb
+++ b/build_config/host-nofloat.rb
@@ -21,6 +21,9 @@ MRuby::Build.new('host-nofloat') do |conf|
     c.defines << "MRB_NO_FLOAT"
   end
 
+  # The compile_commands.json at the source root speaks for this build
+  conf.enable_compile_commands default: true
+
   conf.enable_debug
   conf.enable_test
   conf.enable_bintest

--- a/build_config/host-shared.rb
+++ b/build_config/host-shared.rb
@@ -35,6 +35,9 @@ MRuby::Build.new('host-shared') do |conf|
     cc.flags << '-fPIC'
   end
 
+  # The compile_commands.json at the source root speaks for this build
+  conf.enable_compile_commands default: true
+
   # Turn on `enable_debug` for better debugging
   conf.enable_debug
   conf.enable_bintest

--- a/build_config/no-float.rb
+++ b/build_config/no-float.rb
@@ -11,6 +11,9 @@ MRuby::CrossBuild.new('no-float') do |conf|
 
   conf.test_runner.command = 'env'
 
+  # The compile_commands.json at the source root speaks for this build
+  conf.enable_compile_commands default: true
+
   conf.enable_debug
 #  conf.enable_bintest
   conf.enable_test

--- a/doc/guides/compile.md
+++ b/doc/guides/compile.md
@@ -33,16 +33,24 @@ inside of the mruby source root. To generate and execute the test tools call
 `rake test`. To clean all build files call `rake clean`. To see full command
 line on build, call `rake -v`.
 
-`rake compile_commands.json` writes a `compile_commands.json` at the source
-root, for editors and clang tools, out of the command lines the build records
-beside its own objects. No tracer such as `bear` is involved.
+Every target ends its build by writing a `compile_commands.json` of its own
+compiles into its build directory, for editors and clang tools, out of the
+command lines it records beside its objects. No tracer such as `bear` is
+involved. `rake compile_commands.json` is that same build, asked for by the
+name of the file it leaves behind. A target says
+`conf.disable_compile_commands` to keep none.
 
-The database describes one build: the target named `host` where there is one
-and the first target the configuration declares otherwise, or the target
-`MRUBY_CDB_TARGET` names. A source no build in the tree compiled, one of a
-gem the configuration leaves out for instance, has no entry;
-`compile_flags.txt` and `.clangd` at the source root are what answer for
-those.
+A database in a build directory is what `clangd --compile-commands-dir` and
+its like are pointed at, so reading the tree as a cross target is one option
+away. What a tool finds without being pointed anywhere is the copy at the
+source root, and that one describes a single target: the one whose
+configuration says `conf.enable_compile_commands default: true`, or failing
+that the target named `host`, or failing that the first target the
+configuration declares. `MRUBY_CDB_TARGET` names another for one run.
+
+A source no build in the tree compiled, one of a gem the configuration leaves
+out for instance, has no entry; `compile_flags.txt` and `.clangd` at the
+source root are what answer for those.
 
 You can specify your own configuration file by the `MRUBY_CONFIG` environment
 variable (you can use `CONFIG` for shorthand for `MRUBY_CONFIG`). If the path

--- a/doc/guides/compile.md
+++ b/doc/guides/compile.md
@@ -33,6 +33,17 @@ inside of the mruby source root. To generate and execute the test tools call
 `rake test`. To clean all build files call `rake clean`. To see full command
 line on build, call `rake -v`.
 
+`rake compile_commands.json` writes a `compile_commands.json` at the source
+root, for editors and clang tools, out of the command lines the build records
+beside its own objects. No tracer such as `bear` is involved.
+
+The database describes one build: the target named `host` where there is one
+and the first target the configuration declares otherwise, or the target
+`MRUBY_CDB_TARGET` names. A source no build in the tree compiled, one of a
+gem the configuration leaves out for instance, has no entry;
+`compile_flags.txt` and `.clangd` at the source root are what answer for
+those.
+
 You can specify your own configuration file by the `MRUBY_CONFIG` environment
 variable (you can use `CONFIG` for shorthand for `MRUBY_CONFIG`). If the path
 doesn't exist, `build_config/${MRUBY_CONFIG}.rb` is used. The default

--- a/lib/mruby/build.rb
+++ b/lib/mruby/build.rb
@@ -163,6 +163,8 @@ module MRuby
         @enable_test = false
         @enable_lock = true
         @enable_benchmark = true
+        @enable_compile_commands = true
+        @compile_commands_default = false
         @mrbcfile_external = false
         @file_prefix_map = nil
         @internal = internal
@@ -283,6 +285,39 @@ module MRuby
 
     def lock_enabled?
       Lockfile.enabled? && @enable_lock
+    end
+
+    # Whether this build writes a `compile_commands.json` of its own compiles
+    # into its build directory.
+    def compile_commands_enabled?
+      @enable_compile_commands
+    end
+
+    # Whether this build is the one the tree's own `compile_commands.json`
+    # is written from. A tool opening a source without being told which build
+    # to read it as wants one answer, and a config with several builds is the
+    # only thing that knows which of them a reader of this tree means.
+    def compile_commands_default?
+      @compile_commands_default
+    end
+
+    # +default:+ makes this build the one the tree's `compile_commands.json`
+    # is written from. Two builds claiming it would leave the answer to
+    # declaration order, so the second to claim it says so.
+    def enable_compile_commands(default: false)
+      @enable_compile_commands = true
+      return unless default
+
+      claimed = MRuby.targets.each_value.find do |build|
+        !build.equal?(self) && !build.internal? && build.compile_commands_default?
+      end
+      fail "compile_commands default is already '#{claimed.name}'" if claimed
+      @compile_commands_default = true
+    end
+
+    def disable_compile_commands
+      @enable_compile_commands = false
+      @compile_commands_default = false
     end
 
     def disable_cxx_exception

--- a/lib/mruby/compile_commands.rb
+++ b/lib/mruby/compile_commands.rb
@@ -1,0 +1,172 @@
+require "json"
+
+module MRuby
+  # The compilation database (+compile_commands.json+) of a build, made from
+  # what the build already writes about itself.
+  #
+  # Every compile leaves two files beside its output: +<output>.flags+, the
+  # command line it ran with (see +MRuby::Command::Compiler#run+), and
+  # +<output>.d+, the files it read, whose first name is the source it
+  # compiled. The two together are an entry of the database, so nothing has
+  # to watch the build run to write one. A tool that traces the compiles
+  # instead, +bear+ or +compiledb+ or an +strace+ wrapper, is not needed and
+  # is not asked for.
+  #
+  # What the database holds is what the build compiled. A source that no
+  # build in this directory has reached, a gem the config leaves out or a
+  # port for another platform, has no record and so no entry; the +.clangd+
+  # and +compile_flags.txt+ of the tree are what answer for those.
+  class CompileCommands
+    # The keys of a +.flags+ record, in the order it writes them.
+    RECORD_KEYS = %w[command options flags].freeze
+
+    # Where the database goes. clangd and the clang tools look for it beside
+    # the file they are asked about and in the directories above it, so the
+    # source root is where it answers for the whole tree.
+    def self.path
+      "#{MRUBY_ROOT}/compile_commands.json"
+    end
+
+    # Write the database of the tree and say so.
+    def self.write
+      build = target
+      count = new(build).write(path)
+      _pp "GEN", path.relative_path, "#{count} entries from '#{build.name}'"
+    end
+
+    # The build the database describes.
+    #
+    # A tree builds several targets and a tool that opens one source wants
+    # one answer for it, so one target speaks for the tree: the one named
+    # +host+ where there is one, and the first the config declares
+    # otherwise. +MRUBY_CDB_TARGET+ names another.
+    #
+    # The builds a build makes for itself are left out. The +mrbc+ donor
+    # compiles the same sources as its owner with the defines of a
+    # bootstrap compiler, and it is no target the config asked for.
+    def self.target(name = ENV["MRUBY_CDB_TARGET"])
+      if name
+        MRuby.targets[name] or fail "unknown build target: #{name}"
+      else
+        builds = MRuby.targets.each_value.reject(&:internal?)
+        builds.find { |build| build.name == "host" } || builds.first
+      end
+    end
+
+    def initialize(build)
+      @build = build
+    end
+
+    # Write the database to +path+ and answer the number of entries in it.
+    #
+    # A file that already holds these entries is left alone, mtime and all,
+    # so that a language server watching it does not reindex the tree after
+    # a build that compiled nothing.
+    def write(path)
+      entries = self.entries
+      json = JSON.pretty_generate(entries) << "\n"
+      File.write(path, json) unless File.exist?(path) && File.read(path) == json
+      entries.size
+    end
+
+    # The entries for the objects this build has compiled, ordered by the
+    # source they compile so that two runs over the same build directory
+    # write the same file.
+    def entries
+      list = records.map { |outfile| entry(outfile) }.compact
+      list.sort_by! { |e| [e["file"], e["output"]] }
+      # One source is compiled once here, but a build directory that holds a
+      # nested build keeps a record for each. The first is the one the sort
+      # settled on, and a database with two answers for a file has none.
+      list.uniq! { |e| e["file"] }
+      list
+    end
+
+    private
+
+    # The objects this build directory holds, named by the record beside
+    # them.
+    #
+    # Every one of them is walked, and not only those the build has just
+    # compiled or still declares. An entry earns its place by being true, not
+    # by having been built a moment ago: an object whose flags no longer match
+    # what its build would compile it with is removed and made again (see
+    # +Command::Compiler#discard_foreign_output+), so every object a build
+    # declares carries a record of how that build compiles it, and an object
+    # left behind by a gem the config has since dropped carries the last true
+    # account of how this tree compiled that source. The second is worth more
+    # to a language server than the nothing that dropping it would leave.
+    #
+    # An object that is gone answers for nothing, so its record is passed
+    # over rather than believed.
+    #
+    # The walk stops at the build directory of the +mrbc+ this build makes
+    # for itself, which sits inside this one.
+    def records
+      paths = Dir.glob("#{@build.build_dir}/**/*#{@build.exts.object}.flags").sort
+      donor = @build.mrbc_build
+      if donor && donor.build_dir.start_with?("#{@build.build_dir}/")
+        paths.reject! { |path| path.start_with?("#{donor.build_dir}/") }
+      end
+      paths.map { |path| path.sub(/\.flags\z/, "") }.select { |o| File.exist?(o) }
+    end
+
+    # The entry for an object, or nothing where the record cannot be read or
+    # no longer describes a compile that could be run. A source that has been
+    # renamed or deleted is still named by the records of the object it used
+    # to be compiled to, and answering for a file that is not there helps
+    # nobody.
+    def entry(outfile)
+      record = read_record("#{outfile}.flags")
+      return nil unless record
+      infile = source_of(outfile)
+      return nil unless infile && File.exist?(infile)
+
+      {
+        "directory" => MRUBY_ROOT,
+        "file" => infile,
+        "command" => command_line(record, infile, outfile),
+        "output" => outfile,
+      }
+    end
+
+    # The command line of the compile, put back together the way
+    # +MRuby::Command#_run+ builds it. The record keeps the options apart
+    # from the flags they carry, and names neither file, so the two names
+    # come from the output the record sits beside and the source it read.
+    def command_line(record, infile, outfile)
+      params = {
+        :flags => record["flags"],
+        :infile => @build.filename(infile),
+        :outfile => @build.filename(outfile),
+      }
+      "#{record["command"]} #{record["options"] % params}"
+    end
+
+    def read_record(path)
+      return nil unless File.exist?(path)
+      record = {}
+      File.foreach(path) do |line|
+        key, value = line.chomp.split(": ", 2)
+        record[key] = value if value && RECORD_KEYS.include?(key)
+      end
+      RECORD_KEYS.all? { |key| record.key?(key) } ? record : nil
+    end
+
+    # The source the last compile of +outfile+ read, which the compiler
+    # names first in the dependency file it wrote:
+    #
+    #   /build/host/src/array.o: \
+    #     /src/array.c \
+    #     /include/mruby.h ...
+    #
+    # A toolchain that writes no dependency file leaves its objects out of
+    # the database, rather than have the database guess at a source and
+    # answer for a file with the flags of another.
+    def source_of(outfile)
+      dep = outfile.ext(".d")
+      return nil unless File.exist?(dep)
+      File.read(dep).gsub("\\\n ", "").lines.first.to_s[/\A\S+:\s+(\S+)/, 1]
+    end
+  end
+end

--- a/lib/mruby/compile_commands.rb
+++ b/lib/mruby/compile_commands.rb
@@ -20,52 +20,106 @@ module MRuby
     # The keys of a +.flags+ record, in the order it writes them.
     RECORD_KEYS = %w[command options flags].freeze
 
-    # Where the database goes. clangd and the clang tools look for it beside
-    # the file they are asked about and in the directories above it, so the
-    # source root is where it answers for the whole tree.
-    def self.path
+    # Where the tree's own database goes. clangd and the clang tools look
+    # for one beside the file they are asked about and in the directories
+    # above it, and a source of this tree has the source root above it and
+    # no build directory, so the source root is where a database answers
+    # for the tree.
+    def self.tree_path
       "#{MRUBY_ROOT}/compile_commands.json"
     end
 
-    # Write the database of the tree and say so.
+    # Write a database for every build that keeps one, and the tree's from
+    # the build that speaks for it.
+    #
+    # A build's own database sits in its build directory, where a tool told
+    # to read that build finds it: what clangd's +compile-commands-dir+
+    # option names is a directory, so a cross build's flags are one option
+    # away without the config or the environment being changed at all.
+    #
+    # A build that has compiled nothing is passed over rather than handed an
+    # empty database, since its build directory may not even be there yet.
     def self.write
-      build = target
-      count = new(build).write(path)
-      _pp "GEN", path.relative_path, "#{count} entries from '#{build.name}'"
+      speaks_for_tree = target
+      keepers.each do |build|
+        database = new(build)
+        next if database.count.zero?
+
+        write_one(database, database.path, "#{database.count} entries")
+        next unless build.equal?(speaks_for_tree)
+
+        write_one(database, tree_path, "from '#{build.name}'")
+      end
     end
 
-    # The build the database describes.
+    # Write one database, and report where the file cannot be written rather
+    # than raise.
     #
-    # A tree builds several targets and a tool that opens one source wants
-    # one answer for it, so one target speaks for the tree: the one named
-    # +host+ where there is one, and the first the config declares
-    # otherwise. +MRUBY_CDB_TARGET+ names another.
+    # A file that cannot be written is not a build that has gone wrong: mruby
+    # is built from a read-only checkout as a dependency of something else,
+    # and the database is no part of what that build is for. Each file is
+    # answered for on its own, so a source root that refuses the tree's copy
+    # leaves the builds after it their own.
+    def self.write_one(database, path, note)
+      database.write(path)
+      _pp "GEN", path.relative_path, note
+    rescue SystemCallError => e
+      warn "#{path.relative_path} not written: #{e.message}"
+    end
+
+    # The builds that keep a database: those a config declared, and that it
+    # has not told to keep none.
     #
     # The builds a build makes for itself are left out. The +mrbc+ donor
     # compiles the same sources as its owner with the defines of a
     # bootstrap compiler, and it is no target the config asked for.
+    def self.keepers
+      MRuby.targets.each_value.reject(&:internal?).select(&:compile_commands_enabled?)
+    end
+
+    # The build the tree's own database is written from.
+    #
+    # The config settles it where it says so, since a config with several
+    # builds is the only thing that knows which of them a reader of this
+    # tree means. Failing that it is the build named +host+, the one that
+    # runs on the machine the sources are being read on, and failing that
+    # the first the config declares. +MRUBY_CDB_TARGET+ names another for a
+    # single run, and has to name one that keeps a database: a build told to
+    # keep none has none to copy, and saying so beats writing nothing and
+    # leaving the reader to wonder which build answered.
     def self.target(name = ENV["MRUBY_CDB_TARGET"])
+      builds = keepers
       if name
-        MRuby.targets[name] or fail "unknown build target: #{name}"
-      else
-        builds = MRuby.targets.each_value.reject(&:internal?)
-        builds.find { |build| build.name == "host" } || builds.first
+        return builds.find { |build| build.name == name } ||
+          fail("MRUBY_CDB_TARGET names no build that keeps a compile_commands.json: #{name}")
       end
+
+      builds.find(&:compile_commands_default?) ||
+        builds.find { |build| build.name == "host" } ||
+        builds.first
     end
 
     def initialize(build)
       @build = build
     end
 
-    # Write the database to +path+ and answer the number of entries in it.
+    # Where this build's own database goes.
+    def path
+      "#{@build.build_dir}/compile_commands.json"
+    end
+
+    # Write the database to +path+.
     #
     # A file that already holds these entries is left alone, mtime and all,
     # so that a language server watching it does not reindex the tree after
-    # a build that compiled nothing.
+    # a build that compiled nothing. The same database is written to more
+    # than one path, so what it holds is worked out once.
     def write(path)
-      entries = self.entries
-      json = JSON.pretty_generate(entries) << "\n"
       File.write(path, json) unless File.exist?(path) && File.read(path) == json
+    end
+
+    # How many entries the database holds.
+    def count
       entries.size
     end
 
@@ -73,16 +127,23 @@ module MRuby
     # source they compile so that two runs over the same build directory
     # write the same file.
     def entries
-      list = records.map { |outfile| entry(outfile) }.compact
-      list.sort_by! { |e| [e["file"], e["output"]] }
-      # One source is compiled once here, but a build directory that holds a
-      # nested build keeps a record for each. The first is the one the sort
-      # settled on, and a database with two answers for a file has none.
-      list.uniq! { |e| e["file"] }
-      list
+      @entries ||= begin
+        list = records.map { |outfile| entry(outfile) }.compact
+        list.sort_by! { |e| [e["file"], e["output"]] }
+        # One source is compiled once here, but a build directory that holds
+        # a nested build keeps a record for each. The first is the one the
+        # sort settled on, and a database with two answers for a file has
+        # none.
+        list.uniq! { |e| e["file"] }
+        list
+      end
     end
 
     private
+
+    def json
+      @json ||= JSON.pretty_generate(entries) << "\n"
+    end
 
     # The objects this build directory holds, named by the record beside
     # them.

--- a/tasks/compile_commands.rake
+++ b/tasks/compile_commands.rake
@@ -1,0 +1,11 @@
+require_relative '../lib/mruby/compile_commands'
+
+# The database answers for the compiles that ran, so the build runs first.
+# It is incremental, so asking for the database again after a build costs
+# the walk and nothing more.
+desc "generate compile_commands.json from the records the build writes"
+task "compile_commands.json" => :all do
+  MRuby::CompileCommands.write
+end
+
+task :compile_commands => "compile_commands.json"

--- a/tasks/compile_commands.rake
+++ b/tasks/compile_commands.rake
@@ -1,11 +1,22 @@
 require_relative '../lib/mruby/compile_commands'
 
-# The database answers for the compiles that ran, so the build runs first.
-# It is incremental, so asking for the database again after a build costs
-# the walk and nothing more.
-desc "generate compile_commands.json from the records the build writes"
-task "compile_commands.json" => :all do
+# The database says what the compiles of the build were, so it is written
+# where the build ends. `:build` has prerequisites and no action of its own,
+# and Rake runs the prerequisites of a task before its actions, so this runs
+# once every product is up to date, whatever order the task files load in.
+task :build do
   MRuby::CompileCommands.write
 end
 
+# Asking for the database by name is asking for the build that writes it.
+desc "build, and write the compile_commands.json of the build"
+task "compile_commands.json" => :all
+
 task :compile_commands => "compile_commands.json"
+
+# The database is one of the things the build leaves behind, and it answers
+# for objects that are about to be gone. The one each build keeps of its own
+# goes with the build directory that holds it.
+task :clean do
+  rm_f MRuby::CompileCommands.tree_path
+end


### PR DESCRIPTION
## Summary

An editor reading this tree gets one set of flags for the whole of it from
`compile_flags.txt`, unless something outside the build writes a compilation
database. The build already records the command line of every compile it runs,
beside the object that compile produced. This turns those records into a
`compile_commands.json` as each build ends, so the flags a tool reads a file
with are the flags that file was built with, and no tracer such as `bear` is
involved.

## Changes

| File | What |
|---|---|
| `lib/mruby/compile_commands.rb` | new: `MRuby::CompileCommands`, which reads a build's records and writes its database |
| `tasks/compile_commands.rake` | new: the write at the end of `:build`, the `compile_commands.json` task, the `:clean` hook |
| `lib/mruby/build.rb` | `enable_compile_commands` / `disable_compile_commands`, `compile_commands_enabled?` / `compile_commands_default?` |
| `Rakefile` | load the new task file |
| `build_config/` (15 files) | `conf.enable_compile_commands default: true` |
| `doc/guides/compile.md` | the database, in the `Build` section |
| `.clangd` | the comment no longer sends the reader to `bear` |

### The records an entry is made of

Every compile leaves two files beside its output. `<output>.flags` holds the
command, the options template and the flags it ran with, written by
`MRuby::Command::Compiler#run`; `<output>.d` holds the files it read, the first
of which is the source it compiled. The two together are one entry of the
database, so nothing has to watch the build run to write one.

`discard_foreign_output` removes and remakes any object whose flags no longer
match what its build would compile it with, so the record beside a declared
object always describes how that build compiles that source now.

### Which records count

The walk is over the objects the build directory holds, not over the ones the
build has just compiled or still declares. An entry earns its place by being
true rather than by being fresh: a record left by a gem the configuration has
since dropped is still the last true account of how this tree compiled that
source, which is worth more to a language server than the nothing dropping it
would leave. What is dropped is the entry whose object or source is gone, since
that one answers for nothing.

The `mrbc` a build makes for itself compiles the same sources with the defines
of a bootstrap compiler, and its build directory sits inside its owner's, so
the walk goes around it. Without that a host-only build has two entries for
every core source.

A file already holding the entries about to be written is left alone, mtime and
all, so that a build which compiled nothing does not send a language server
through the tree again.

### Where the files go, and which target the root copy is

Each target writes its own database into its build directory, the flags of one
target answering for no other. What `clangd --compile-commands-dir` and its like
name is a directory, so reading the tree as a cross target is one option away.

What a tool finds without being pointed anywhere is the copy at the source root,
and that one describes a single target: the one whose configuration says
`conf.enable_compile_commands default: true`, or failing that the target named
`host`, the one that runs on the machine the sources are being read on, or
failing that the first target the configuration declares. `MRUBY_CDB_TARGET`
names another for a single run. Two targets claiming the default would leave the
answer to declaration order, so the second to claim it is refused.

The 15 configurations that now carry a declaration name the build a reader of
those sources means. Twelve of them build a single target, where the declaration
changes no answer but keeps it off the order the file happens to be written in.
`ci/gcc-clang` names `full-debug`, whose defines only turn code on where every
other build in that set turns some off. `boxing` names `boxing-word-m64-i64`,
first declared having picked a boxing no build gets without asking for it.

A target that wants no database says `conf.disable_compile_commands`. A tree
that cannot be written to reports the failure and carries on, since mruby is
built from a read-only checkout as a dependency of something else and the
database is no part of what that build is for.

## Behaviour

- Every target writes `<build_dir>/compile_commands.json` as its build ends, and
  one of them also writes the copy at the source root.
  `rake compile_commands.json` is that same build, asked for by the name of the
  file it leaves behind.
- `rake clean` takes the copy at the source root with it, since it answers for
  objects the clean is about to remove. The one a target keeps goes with the
  build directory that holds it.
- No compile, link or product changes. `compile_commands.json` is already in
  `.gitignore` with no leading slash, so the copies inside build directories are
  ignored as well.

## Size

`.text` of `bin/mruby` by `size -A`, `build_config/ci/gcc-clang.rb`, master
(73e880bf5) and this branch built in the same empty build directory.

| Build | master | this PR | delta |
|---|---:|---:|---:|
| `full-debug` (-O0) | 1,896,966 | 1,896,966 | 0 |
| `bintest` | 1,100,374 | 1,100,374 | 0 |
| `cxx_abi` | 1,088,485 | 1,088,485 | 0 |
| `byte-string` | 1,075,830 | 1,075,830 | 0 |
| `ascii-ctype` | 1,095,670 | 1,095,670 | 0 |

Nothing that gets compiled is touched, so the zeroes are what the change
predicts rather than a result to read into.

## Testing

`rake -m test` on each of the three commits, `build_config/default.rb`:
2428 assertions, 0 KO, 0 crash, 57 skip.

`MRUBY_CONFIG=ci/gcc-clang rake -m test`: all five builds and the bintest run
green, 0 KO and 0 crash throughout (145 / 2586 / 2658 / 2667 / 2667 / 2667).

The five builds write five databases plus the copy at the source root, and that
copy is byte for byte the one `build/full-debug` keeps:

```console
GEN   build/full-debug/compile_commands.json -> 192 entries
GEN   compile_commands.json -> from 'full-debug'
GEN   build/bintest/compile_commands.json -> 201 entries
GEN   build/cxx_abi/compile_commands.json -> 192 entries
GEN   build/byte-string/compile_commands.json -> 190 entries
GEN   build/ascii-ctype/compile_commands.json -> 192 entries
```

All 15 declaring configurations were loaded and asked which target speaks for
the tree: `default` and `host-debug` answer `host`, the other eleven single
target configurations answer with themselves, `ci/gcc-clang` answers
`full-debug` and `boxing` answers `boxing-word-m64-i64`.
`MRUBY_CDB_TARGET=byte-string` moves the answer to `byte-string`, and a second
target claiming the default fails the configuration with
`compile_commands default is already 'alpha'`.

clangd reads it. For a gem source it now answers from the database rather than
from the tree-wide flags:

```console
$ clangd --check=mrbgems/mruby-regexp/src/regexp.c
Compile command from CDB is: ... -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 ...

$ mv compile_commands.json /tmp && clangd --check=mrbgems/mruby-regexp/src/regexp.c
Loaded compilation database from .../compile_flags.txt
```

All 177 tracked `.c` files outside `oss-fuzz/` were run through
`clangd --check`: 0 files with diagnostics, with the database and without it
alike. `compile_flags.txt` and `.clangd` already covered the tree, so this is a
check that the database does not take that away, not a count it improves. A
source no build compiled, one of a gem the configuration leaves out, has no
entry, and clangd infers its flags from a neighbouring one.

Writing twice over an unchanged build directory leaves the file's contents and
its mtime alone.

## Environment

<details>
<summary>Machine, toolchain and the compile line of each build</summary>

| Item | Value |
|---|---|
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-30-generic x86_64 |
| CPU | AMD Ryzen 9 5950X, 16 cores / 32 threads |
| C compiler | Homebrew clang 22.1.8, through ccache 4.14 |
| Linker | GNU ld 2.47.20260726 |
| Archiver | GNU ar 2.47.20260726 |
| CRuby | 4.0.6 |
| Rake | 13.3.1 |
| clangd | Homebrew clangd 22.1.8 |

The compile line of each build, as `rake --verbose` printed it after
`touch src/string.c`, with `-MMD -c`, the include paths and the output name
dropped and the source root written `$MRUBY_ROOT`. `cxx_abi` is `clang -x c++`
rather than `clang++`.

```console
full-debug   clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -g3 -O0 -ffile-prefix-map="$MRUBY_ROOT=." -ffile-prefix-map="$MRUBY_ROOT/build=./build" -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

bintest      clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -ffile-prefix-map="$MRUBY_ROOT=." -ffile-prefix-map="$MRUBY_ROOT/build=./build" -DMRB_GC_FIXED_ARENA -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK

cxx_abi      clang -g -O3 -Wall -Wundef -Wwrite-strings -Wzero-length-array -x c++ -std=gnu++03 -ffile-prefix-map="$MRUBY_ROOT=." -ffile-prefix-map="$MRUBY_ROOT/build=./build" -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

byte-string  clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -ffile-prefix-map="$MRUBY_ROOT=." -ffile-prefix-map="$MRUBY_ROOT/build=./build" -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

ascii-ctype  clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -ffile-prefix-map="$MRUBY_ROOT=." -ffile-prefix-map="$MRUBY_ROOT/build=./build" -DMRB_USE_ASCII_CTYPE -DMRB_REGEXP_PARSE_DEPTH_LIMIT=512 -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Builds now generate `compile_commands.json` databases by default for improved editor and tooling support.
  * Added commands to generate, select, and clean compilation databases.
  * Each build target can provide its own database, while the source-root database can represent a selected target.
  * Added options to disable generation or override the selected target for a single build.

* **Documentation**
  * Documented database generation, target selection, overrides, and fallback compiler flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->