### PR TITLE
string: snapshot shared append sources

### DIFF
--- a/mrbgems/mruby-string-ext/test/string.rb
+++ b/mrbgems/mruby-string-ext/test/string.rb
@@ -296,6 +296,15 @@ assert('String#concat on a shared buffer') do
   assert_equal "i" * 100 + "j" * 100 + "i" * 40, i
   assert_equal "i" * 40, k
 
+  # A source may start inside the receiver but extend beyond it. Detaching
+  # the receiver must not redirect that tail into its uninitialized capacity.
+  source = "abcdefghij" * 12
+  receiver = source[21, 39]
+  append = source[22, 111]
+  expected = receiver.dup + append
+  receiver.concat(append)
+  assert_equal expected, receiver
+
   # A frozen sharer still raises, and does not stop the others.
   l = "l" * 100
   l << "m" * 100

--- a/src/string.c
+++ b/src/string.c
@@ -3976,11 +3976,10 @@ mrb_str_cat(mrb_state *mrb, mrb_value str, const char *ptr, size_t len)
   }
   /* The overlap has to be recognized against the buffer `ptr` was taken
      from, which is the one `s` holds now. `str_modify_cat()` either appends
-     inside the shared allocation, where `ptr` stays valid and the offset is
-     the same answer reached another way, or detaches `s` onto a fresh buffer
-     and releases the old one, where `ptr` is neither inside the new buffer
-     nor safe to read. Recording the offset ahead of the call covers both
-     without having to know which path ran.
+     inside the shared allocation, where `ptr` stays valid, or detaches `s`
+     onto a fresh buffer. An offset can only be replayed after a detach when
+     the whole source range was copied with the visible bytes of `s`; save a
+     range that starts inside them but extends beyond them before modifying.
 
      `ptr` is allowed to come from anywhere, so it and `RSTR_PTR(s)` need not
      point into the same object, and relational comparison and subtraction
@@ -3988,8 +3987,14 @@ mrb_str_cat(mrb_state *mrb, mrb_value str, const char *ptr, size_t len)
      leaves both on integers, where the whole range is ordered. */
   uintptr_t ptr_addr = (uintptr_t)ptr;
   uintptr_t str_addr = (uintptr_t)RSTR_PTR(s);
-  if (ptr_addr >= str_addr && ptr_addr <= str_addr + (uintptr_t)RSTR_LEN(s)) {
-      off = (ptrdiff_t)(ptr_addr - str_addr);
+  if (ptr_addr >= str_addr && ptr_addr - str_addr <= (uintptr_t)RSTR_LEN(s)) {
+    off = (ptrdiff_t)(ptr_addr - str_addr);
+    if (len > (size_t)(RSTR_LEN(s) - off)) {
+      char *tmp = (char*)mrb_alloca(mrb, len);
+      memcpy(tmp, ptr, len);
+      ptr = tmp;
+      off = -1;
+    }
   }
   /* Read before the modify below, which forgets it. */
   uint32_t cr = RSTR_CODERANGE(s);
@@ -4005,7 +4010,7 @@ mrb_str_cat(mrb_state *mrb, mrb_value str, const char *ptr, size_t len)
   if (off != -1) {
       ptr = RSTR_PTR(s) + off;
   }
-  memcpy(RSTR_PTR(s) + RSTR_LEN(s), ptr, len);
+  memmove(RSTR_PTR(s) + RSTR_LEN(s), ptr, len);
   RSTR_SET_LEN(s, total);
   RSTR_PTR(s)[total] = '\0';   /* sentinel */
 #ifdef MRB_UTF8_STRING


### PR DESCRIPTION
## Summary

`mrb_str_cat()` records an offset when the source pointer starts inside the receiver, then reconstructs the pointer after `str_modify_cat()` may detach or reallocate the receiver.

The check only covered the start of the source. When the source range extended beyond the receiver's visible bytes, detaching copied only the receiver's current length. Reconstructing the source pointer in the new buffer then read from uninitialized capacity and appended those bytes to the Ruby string. This could expose heap contents, including pointer-shaped data, to Ruby code.

The final copy also used `memcpy()` even though source and destination could overlap.

```ruby
a = "abcdefghij" * 12
b = a[21, 39]
c = a[22, 111]
b.concat(c)

b == a[21, 39] + a[22, 111] # master: false
```

Under AddressSanitizer, the simpler overlapping case aborted in `mrb_str_cat()`:

```ruby
a = "x" * 100
b = a[0, 50]
b << a
```

```text
ERROR: AddressSanitizer: memcpy-param-overlap
    #1 mrb_str_cat
    #2 mrb_str_cat_str
```

## Changes

- Reuse an offset only when the complete `[ptr, ptr + len)` range fits inside the receiver's visible bytes.
- Snapshot a source that starts inside the receiver but extends beyond it before `str_modify_cat()` can detach or reallocate the buffer.
- Use `memmove()` for the final append.
- Add a regression test using overlapping slices of one shared buffer.

## Behaviour

| Case | master | this PR |
| --- | --- | --- |
| source fully inside the receiver | appended through the reconstructed offset | unchanged |
| source starts inside and extends beyond the receiver | uninitialized heap bytes may be appended | original source bytes are appended |
| overlapping source and destination | AddressSanitizer abort / undefined behaviour | succeeds through `memmove()` |

## Testing

- Both reproductions above pass under AddressSanitizer, with byte-for-byte result checks.
- Default test suite: `Total: 2428`, `KO: 0`, `Crash: 0`.
- Default bintest suite: `Total: 128`, `KO: 0`, `Crash: 0`.
- `git diff --check` passes.

The full AddressSanitizer suite did not complete on this macOS host because the Prism parser stack-overflowed in the regexp parse-depth test. The targeted string reproductions and regression path completed with no sanitizer report.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed string concatenation when the appended source overlaps the destination and extends beyond its current contents.
  * Prevented corrupted or unexpected results when modifying strings with overlapping buffers.

* **Tests**
  * Added regression coverage to verify overlapping concatenation matches the result of using an independent copy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->