### PR TITLE
kernel.c: negate `=~` from C rather than from a Ruby frame of its own

### DIFF
--- a/mrblib/kernel.rb
+++ b/mrblib/kernel.rb
@@ -34,11 +34,6 @@ module Kernel
     e.result
   end
 
-  # 11.4.4 Step c)
-  def !~(y)
-    !(self =~ y)
-  end
-
   def to_enum(*a)
     raise NotImplementedError.new("fiber required for enumerator")
   end

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -138,6 +138,33 @@ mrb_eqq_m(mrb_state *mrb, mrb_value self)
   return mrb_bool_value(mrb_equal(mrb, self, arg));
 }
 
+/* 11.4.4 Step c) */
+/*
+ *  call-seq:
+ *     obj !~ other  -> true or false
+ *
+ *  Returns true when *obj* does not match *other*, which is what `=~`
+ *  answering a false value means.  Overriding `=~` is what gives a class a
+ *  meaning for both operators; overriding this one separately is what makes
+ *  the two disagree, as it does in CRuby.
+ */
+static mrb_value
+mrb_obj_not_match(mrb_state *mrb, mrb_value self)
+{
+  mrb_value arg = mrb_get_arg1(mrb);
+
+  /* Dispatching `=~` is the meaning of this method rather than a convenience,
+     so the VM call belongs here.  What comes back is read as a truth value and
+     then dropped, so nothing has to survive the arena restore, and an exception
+     raised by `=~` unwinds past this frame with nothing left behind to clean
+     up.  Answering from C is also what keeps `=~` writing `$~` into the scope
+     that wrote `!~`, the way CRuby's `rb_obj_not_match()` does. */
+  int ai = mrb_gc_arena_save(mrb);
+  mrb_bool matched = mrb_test(mrb_funcall_argv(mrb, self, MRB_OPSYM(match), 1, &arg));
+  mrb_gc_arena_restore(mrb, ai);
+  return mrb_bool_value(!matched);
+}
+
 static mrb_value
 mrb_cmp_m(mrb_state *mrb, mrb_value self)
 {
@@ -788,6 +815,7 @@ static const mrb_mt_entry kernel_rom_entries[] = {
   MRB_MT_ENTRY(mrb_f_defined_cvar,   MRB_SYM_Q(__defined_cvar),   MRB_ARGS_REQ(1) | MRB_MT_PRIVATE),
   MRB_MT_ENTRY(mrb_f_defined_super,  MRB_SYM_Q(__defined_super),  MRB_ARGS_NONE() | MRB_MT_PRIVATE),
   MRB_MT_ENTRY(mrb_eqq_m,                        MRB_OPSYM(eqq),        MRB_ARGS_REQ(1)),  /* 15.3.1.3.2  */
+  MRB_MT_ENTRY(mrb_obj_not_match,                MRB_OPSYM(nmatch),      MRB_ARGS_REQ(1)),  /* 11.4.4 c) */
   MRB_MT_ENTRY(mrb_cmp_m,                        MRB_OPSYM(cmp),         MRB_ARGS_REQ(1)),
   MRB_MT_ENTRY(mrb_f_block_given_p_m,    MRB_SYM_Q(block_given),                           MRB_ARGS_NONE() | MRB_MT_PRIVATE),  /* 15.3.1.3.6  */
   MRB_MT_ENTRY(mrb_obj_class_m,                  MRB_SYM(class),                     MRB_ARGS_NONE()),  /* 15.3.1.3.7  */

--- a/test/t/kernel.rb
+++ b/test/t/kernel.rb
@@ -439,6 +439,35 @@ assert('Kernel#!~') do
   assert_false y !~ "y"
   assert_false y !~ "z"
   assert_true  y !~ "not y"
+
+  # the answer is a truth value read off what `=~` returned, not that value
+  z = "z"
+  def z.=~(other)
+    other == "z" ? 0 : nil
+  end
+  assert_false z !~ "z"
+  assert_true  z !~ "not z"
+
+  # an exception raised by `=~` is the answer to `!~`
+  e = "e"
+  def e.=~(other)
+    raise ArgumentError, "no match for you"
+  end
+  assert_raise(ArgumentError) { e !~ "e" }
+
+  # `=~` may ask another object the same question while answering
+  class Test4NotMatchPeer
+    def =~(other)
+      other == "b"
+    end
+  end
+  class Test4NotMatch
+    def =~(other)
+      Test4NotMatchPeer.new !~ other
+    end
+  end
+  assert_true  Test4NotMatch.new !~ "b"
+  assert_false Test4NotMatch.new !~ "c"
 end
 
 assert('Kernel#respond_to_missing?') do


### PR DESCRIPTION
## Summary

`Kernel#!~` is `=~` negated, and mruby answers it from `mrblib/kernel.rb`, where `!(self =~ y)` runs inside a Ruby method frame of its own. CRuby answers the same method from C, in `rb_obj_not_match()`, which opens no Ruby frame at all.

Today that frame costs a send and an irep and nothing else, because everything a match records lives in one global table: `$~` and its family answer the same wherever they are asked. It stops being free the moment a match belongs to the scope that wrote it, the way CRuby's svar does, because the scope `=~` writes into is then the frame `!~` opened rather than the frame that called `!~`. The write the caller was meant to see dies with the frame.

Measured on the branch of #7389, which is where a match starts belonging to a scope, with and without this commit on top:

```ruby
"abc" !~ /(b)/
$~  # => nil without this change; #<MatchData "b" 1:"b"> with it, as in CRuby
$1  # => nil without this change; "b" with it, as in CRuby
```

This PR is that commit, on its own and against master, where it changes no answer.

## Changes

| file | what |
|---|---|
| `mrblib/kernel.rb` | the `!~` definition goes |
| `src/kernel.c` | `mrb_obj_not_match()` answers it, registered on `Kernel` from the ROM table with `MRB_ARGS_REQ(1)` |
| `test/t/kernel.rb` | three cases join the existing `Kernel#!~` test |

### The dispatch stays a dispatch

`=~` is sent, not inlined into a type test, so a class that defines `=~` keeps deciding what a match means for it, and a class that redefines `!~` on its own keeps disagreeing with its own `=~`. Both are what CRuby does, and the existing test already pinned both.

What the C side does with the result is read it as a truth value: `!~` answers `true` or `false`, never what `=~` returned. That is also what `!(self =~ y)` answered, so a `=~` answering `0` still makes `!~` answer `false`.

### Why the VM call belongs on the C side

Dispatching `=~` is the meaning of this method rather than a convenience, so the call into the VM is not one that can be pushed back to mrblib without bringing the frame back with it. What the call has to satisfy:

* the result is read and dropped, so nothing has to survive the arena restore that brackets the call, and the arena does not grow across repeated `!~`
* an exception raised by `=~` unwinds past this frame with no intermediate state left behind to clean up
* nothing is held across the call: the argument is read from the stack before it and never touched after

## Behaviour

No answer changes on master. Two things a program can observe about the method itself do:

| shape | master | this PR | CRuby |
|---|---|---|---|
| a backtrace through `!~` | no `!~` frame | a `!~` frame | a `Kernel#!~` frame |
| `Kernel.instance_method(:!~).parameters` | `[[:req, :y]]` | `[[:opt]]` | `[[:req]]` |

The backtrace moves toward CRuby. `parameters` moves toward every other C method in mruby: `Kernel#eql?`, `Kernel#===`, `Kernel#instance_of?`, `String#+` and `Array#at` all answer `[[:opt]]` today, since a C method carries no `aspec` to describe. `arity` stays `1` on both sides.

## Speed

Ir per iteration, `Ir(2N) - Ir(N)` over `N = 100,000` under callgrind, host build (clang, word boxing):

| case | master | this PR | delta |
|---|---|---|---|
| `"abc" !~ /(b)/` | 4,904.9 | 4,616.4 | -288.5 (-5.9%) |
| `obj !~ 2`, `=~` defined in Ruby | 1,347.0 | 1,248.0 | -99.0 (-7.3%) |
| `"abc" =~ /(b)/`, control | 4,319.5 | 4,316.0 | -3.5 |
| `obj.plain(2)`, control | 754.0 | 754.0 | 0 |

The saving is the Ruby frame: one send, its irep, and the `!` that followed it.

The `=~` control is not bit identical, and the 3.5 Ir is GC scheduling rather than the match path. Running the same loop behind `GC.disable` makes both sides answer 4,687.8 exactly, so what moved is where the incremental collector's steps fall, which the smaller startup footprint below shifts. The send control, which allocates nothing, is bit identical either way.

## Size

`.text` of `bin/mruby`, `build_config/ci/gcc-clang.rb`, this PR against master, clean build directories, same tree path:

| build | master | PR | delta |
|---|---|---|---|
| bintest | 1,100,518 | 1,100,614 | +96 |
| ascii-ctype | 1,095,814 | 1,095,910 | +96 |
| byte-string | 1,075,894 | 1,075,990 | +96 |
| cxx_abi | 1,088,629 | 1,088,725 | +96 |
| full-debug (-O0) | 1,897,126 | 1,897,238 | +112 |

All of it is `src/kernel.o`, whose `.text` goes 4,973 to 5,069. The irep the definition compiled to leaves in exchange: `mrblib/mrblib.o` `.rodata` goes 10,084 to 10,036, which `.text` does not count but the binary does, so a build carries 48 bytes more in total.

## Testing

* `build_config/ci/gcc-clang.rb`, all five builds, `rake -m test` green, KO 0 and Crash 0 throughout, bintest included (cxx_abi linked with `LDFLAGS=--gcc-install-dir=...`)
* host build (clang, word boxing): `rake -m test` green
* the three new cases pin that the answer is a truth value read off what `=~` returned rather than that value, that an exception raised by `=~` is what `!~` answers, and that `=~` may ask another object the same question while answering. All three, and the two the test already had, answer identically under CRuby 4.0.6

## Environment

<details>

* Linux 7.0.0-30-generic x86_64, Ubuntu 24.04
* Homebrew clang 22.1.8
* CRuby 4.0.6 for the comparisons

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored support for the `!~` operator.
  * `!~` now correctly returns the boolean negation of `=~`, including matches that return `0` or `nil`.
  * Errors raised during pattern matching are now propagated correctly.
  * Matching behavior supports delegation to another object’s `!~` implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->