### PR TITLE
mruby-symbol-ext: slice a symbol's name from C rather than from a Ruby frame of its own

### DIFF
--- a/mrbgems/mruby-symbol-ext/mrblib/symbol.rb
+++ b/mrbgems/mruby-symbol-ext/mrblib/symbol.rb
@@ -69,10 +69,4 @@ class Symbol
     self.length == 0
   end
 
-  def slice *args
-    to_s.slice(*args)
-  end
-
-  alias [] slice
-
 end

--- a/mrbgems/mruby-symbol-ext/src/symbol.c
+++ b/mrbgems/mruby-symbol-ext/src/symbol.c
@@ -57,9 +57,42 @@ mrb_sym_length(mrb_state *mrb, mrb_value self)
   return mrb_fixnum_value(len);
 }
 
+/*
+ * call-seq:
+ *   sym.slice(index)          -> string or nil
+ *   sym.slice(start, length)  -> string or nil
+ *   sym.slice(range)          -> string or nil
+ *   sym[index]                -> string or nil
+ *
+ * Slices the symbol's name the way `String#slice` slices a string, and
+ * answers a String rather than a Symbol. The name comes from the symbol
+ * itself rather than through `to_s`, which is where CRuby's sym_aref() takes
+ * it from as well, so redefining `Symbol#to_s` does not move these two.
+ */
+static mrb_value
+mrb_sym_slice(mrb_state *mrb, mrb_value self)
+{
+  mrb_value *argv;
+  mrb_int argc;
+
+  mrb_get_args(mrb, "*", &argv, &argc);
+  /* The name is handed to `String#slice` rather than to the core function
+     that answers it, because mruby-regexp registers a `String#slice` of its
+     own to answer a Regexp index and this gem does not depend on it. Sending
+     is what keeps `sym[re]` answering wherever that gem is built in, which is
+     what the Ruby definition this replaces did, and it leaves the argument
+     checking in the one place that already spells it out. What comes back is
+     the answer, so nothing is read from it here and nothing is held across
+     the call. */
+  return mrb_funcall_argv(mrb, mrb_sym_str(mrb, mrb_symbol(self)),
+                          MRB_SYM(slice), argc, argv);
+}
+
 static const mrb_mt_entry symbol_ext_rom_entries[] = {
   MRB_MT_ENTRY(mrb_sym_length, MRB_SYM(length), MRB_ARGS_NONE()),
   MRB_MT_ENTRY(mrb_sym_length, MRB_SYM(size), MRB_ARGS_NONE()),
+  MRB_MT_ENTRY(mrb_sym_slice,  MRB_SYM(slice), MRB_ARGS_ANY()),
+  MRB_MT_ENTRY(mrb_sym_slice,  MRB_OPSYM(aref), MRB_ARGS_ANY()),
 };
 
 void

--- a/mrbgems/mruby-symbol-ext/test/symbol.rb
+++ b/mrbgems/mruby-symbol-ext/test/symbol.rb
@@ -58,10 +58,44 @@ assert('Symbol#slice') do
   assert_equal 'a', :abc.slice(0)
   assert_equal 'ab', :abc.slice(0, 2)
   assert_nil :abc.slice(4, 4)
+  assert_equal 'bc', :abc.slice(1..)
+  assert_equal 'b', :abc.slice("b")
+  assert_nil :abc.slice("z")
+
+  # the answer is a String of its own, not the name the symbol holds on to
+  s = :abc.slice(0, 3)
+  assert_equal 'abc', s
+  assert_false s.frozen?
+
+  # whatever slices the name is what checks the arguments
+  assert_raise(TypeError) { :abc.slice(:b) }
+  assert_raise(ArgumentError) { :abc.slice }
 end
 
 assert('Symbol#[]') do
   assert_equal 'a', :abc[0]
   assert_equal 'ab', :abc[0, 2]
   assert_nil :abc[4, 4]
+  assert_equal 'bc', :abc[1..]
+  assert_equal 'b', :abc["b"]
+end
+
+assert('Symbol#slice - the name comes from the symbol, not from #to_s') do
+  # CRuby's sym_aref() reads the name with rb_sym2str(), so a redefined
+  # Symbol#to_s moves `to_s` and leaves these two where they were.
+  class Symbol
+    alias __slice_test_to_s to_s
+    def to_s
+      "redefined"
+    end
+  end
+  begin
+    assert_equal 'redefined', :abc.to_s
+    assert_equal 'a', :abc.slice(0)
+    assert_equal 'abc', :abc[0, 3]
+  ensure
+    class Symbol
+      alias to_s __slice_test_to_s
+    end
+  end
 end


### PR DESCRIPTION
## Summary

`Symbol#slice`, and the `[]` aliased to it, have been `to_s.slice(*args)` in this gem's mrblib, so slicing a symbol runs inside a Ruby method frame of its own. CRuby answers both from C, in `sym_aref()`, which opens no Ruby frame at all.

Today that frame costs a send, an irep and an Array per call, because everything a match records lives in one global table: `$~` and its family answer the same wherever they are asked. It stops being only a cost the moment a match belongs to the scope that wrote it, the way CRuby's svar does, because the regexp form of `String#slice` then records its match into the frame that asked for the slice, which is the one this method opened rather than the one that wrote `sym[re]`.

Answers are unchanged apart from one that becomes CRuby's, under **Behaviour** below.

Measured on the branch of #7389, which is where a match starts belonging to a scope, with and without this commit on top:

```ruby
:hello.slice(/(l+)/)
$~  # => nil without this change; #<MatchData "ll" 1:"ll"> with it, as in CRuby
$1  # => nil without this change; "ll" with it, as in CRuby
```

This PR is that commit, on its own and against master.

## Changes

| file | what |
|---|---|
| `mrblib/symbol.rb` | the `slice` definition and the `alias [] slice` go |
| `src/symbol.c` | `mrb_sym_slice()` answers both, registered from the ROM table under each name |
| `test/symbol.rb` | the two existing tests grow the forms they did not cover, and a new one pins the `to_s` question |

### Both names, one implementation

Two ROM entries pointing at the same function is what the alias gave `[]` and `slice`: the same implementation under each name, and redefining one still leaves the other alone.

### The slicing stays a send

The name is handed to `String#slice` rather than to the core function that answers it, because mruby-regexp registers a `String#slice` of its own to answer a Regexp index and this gem does not depend on it. Sending is what keeps `sym[re]` answering wherever that gem is built in, which is what the Ruby definition did, and it leaves the argument checking in the one place that already spells it out. CRuby can reach `rb_str_aref_m()` directly because the regexp form is not in a separate library there.

The VM call is therefore the meaning of the method rather than a convenience: what comes back is the answer, so nothing is read from it here and nothing is held across the call, and an exception raised by the argument checking unwinds past this frame with no intermediate state left behind.

### The name is read off the symbol, not asked for with `to_s`

`mrb_sym_str()` is where CRuby's `sym_aref()` reads the name from as well, through `rb_sym2str()`. The Ruby definition asked `self` for it, so a program redefining `Symbol#to_s` moved these two methods along with it, which CRuby does not do. This is the one answer that changes, and it changes to CRuby's.

### The splat leaves with the Ruby definition

`*args` allocated an Array on every call to hand the arguments on. A C function forwards the ones it was given, which is most of what the numbers below are.

## Behaviour

One answer changes, and it becomes CRuby's:

```ruby
class Symbol
  def to_s = "redefined"
end
:abc.slice(0)  #=> "R" on master, "a" here, "a" in CRuby
:abc[0, 3]     #=> "RED" on master, "abc" here, "abc" in CRuby
:abc.to_s      #=> "redefined" everywhere
```

Two things a program can observe about the method itself change as well:

| shape | master | this PR | CRuby |
|---|---|---|---|
| `Symbol.instance_method(:slice).parameters` | `[[:rest, :args]]` | `[[:rest]]` | `[[:rest]]` |
| a backtrace through `:abc.slice(:b)` | one `slice` frame | two `slice` frames | one `Symbol#slice` frame |

`parameters` becomes CRuby's answer exactly. The backtrace gains a frame because this method and the `String#slice` it sends to are both called `slice`, and both are C frames now; that second frame is the send the section above keeps.

## Speed

Ir per iteration, `Ir(2N) - Ir(N)` over `N = 100,000` under callgrind, host build (clang, word boxing):

| case | master | this PR | delta |
|---|---|---|---|
| `:hello[0]` | 2,818.4 | 2,137.6 | -680.8 (-24.2%) |
| `:hello.slice(1, 3)` | 2,899.9 | 2,169.7 | -730.2 (-25.2%) |
| `:hello[/l+/]` | 7,292.4 | 6,577.7 | -714.7 (-9.8%) |
| `"hello"[0]`, control | 660.3 | 660.2 | -0.1 |

The saving is flat across the three, at roughly 700 Ir, because it is the frame and the Array rather than anything about the index: the regexp form pays the same and just has more to pay it against.

## Size

`.text` of `bin/mruby`, `build_config/ci/gcc-clang.rb`, this PR against master, clean build directories, same tree path:

| build | master | PR | delta |
|---|---|---|---|
| bintest | 1,100,518 | 1,100,614 | +96 |
| ascii-ctype | 1,095,814 | 1,095,910 | +96 |
| byte-string | 1,075,894 | 1,075,990 | +96 |
| cxx_abi | 1,088,629 | 1,088,725 | +96 |
| full-debug (-O0) | 1,897,126 | 1,897,222 | +96 |

All of it is the gem's `src/symbol.o`, whose `.text` goes 83 to 181. The irep the two definitions compiled to leaves in exchange: `mruby-symbol-ext/gem_init.o` `.rodata` goes 500 to 460, which `.text` does not count but the binary does, so a build carries 56 bytes more in total.

## Testing

* `build_config/ci/gcc-clang.rb`, all five builds, `rake -m test` green, KO 0 and Crash 0 throughout, bintest included (cxx_abi linked with `LDFLAGS=--gcc-install-dir=...`)
* host build (clang, word boxing): `rake -m test` green
* the two tests already pinned the integer forms. They now also pin the range and string forms, that the answer is a String of its own rather than the name the symbol holds on to, and that a `TypeError` and an `ArgumentError` still come from whatever slices the name. A third pins the `to_s` question from both sides: a redefined `Symbol#to_s` answers `to_s` and leaves `slice` and `[]` alone. All of them answer identically under CRuby 4.0.6
* `test/symbol_regexp.rb` in mruby-regexp pins the regexp form of `sym[re]`, including the two argument shape, and stays green

## Environment

<details>

* Linux 7.0.0-30-generic x86_64, Ubuntu 24.04
* Homebrew clang 22.1.8
* CRuby 4.0.6 for the comparisons

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `Symbol#slice` and `Symbol#[]` support for extracting portions of symbol names.
  * Supports ranges, substring arguments, and regular-expression indexing when available.
  * Returns an independent, mutable string containing the selected text.
* **Bug Fixes**
  * Symbol slicing now consistently uses the symbol’s original name, even when `to_s` is customized.
  * Added validation for missing or invalid slicing arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->