### PR TITLE
mruby-process: read a `Process::Status` subclass as a status in `#==`

### DIFF
--- a/mrbgems/mruby-process/src/status.c
+++ b/mrbgems/mruby-process/src/status.c
@@ -38,6 +38,16 @@ status_ivar(mrb_state *mrb, mrb_value self, mrb_sym name)
   return mrb_integer(v);
 }
 
+/* Process::Status itself, which is not always an instance's own class: a
+   subclass of it is still one, and #== has to read one as such. */
+static struct RClass *
+status_class(mrb_state *mrb)
+{
+  struct RClass *process = mrb_module_get_id(mrb, MRB_SYM(Process));
+
+  return mrb_class_get_under_id(mrb, process, MRB_SYM(Status));
+}
+
 static void
 status_decode(mrb_state *mrb, mrb_value self, mrb_process_status *st)
 {
@@ -222,8 +232,11 @@ status_eq(mrb_state *mrb, mrb_value self)
   /* Ruby answers this question as `to_i == other`, and reaches a status on
      the right through Integer#== asking it back.  mrb_equal() answers false
      for anything that is not a number instead of asking, so a status is
-     unwrapped here rather than left to it. */
-  if (mrb_obj_class(mrb, self) == mrb_obj_class(mrb, other)) {
+     unwrapped here rather than left to it.  Being a status is what decides
+     that, not being of this exact class: a subclass of Process::Status is
+     one, and CRuby's way round reaches it through whichever #== the object
+     carries. */
+  if (mrb_obj_is_kind_of(mrb, other, status_class(mrb))) {
     other = mrb_int_value(mrb, status_ivar(mrb, other, MRB_IVSYM(status)));
   }
   return mrb_bool_value(mrb_equal(mrb, raw, other));
@@ -315,8 +328,7 @@ status_to_s(mrb_state *mrb, mrb_value self)
 mrb_value
 mrb_process_status_new(mrb_state *mrb, mrb_int pid, mrb_int raw_status)
 {
-  struct RClass *process = mrb_module_get_id(mrb, MRB_SYM(Process));
-  struct RClass *status = mrb_class_get_under_id(mrb, process, MRB_SYM(Status));
+  struct RClass *status = status_class(mrb);
   mrb_value argv[2];
 
   argv[0] = mrb_int_value(mrb, pid);

--- a/mrbgems/mruby-process/test/process.rb
+++ b/mrbgems/mruby-process/test/process.rb
@@ -270,6 +270,24 @@ assert('Process::Status#==') do
   assert_not_operator st, :==, "0"
 end
 
+assert('Process::Status#== reads a subclass as the status it is') do
+  # What decides is the raw status, and carrying one is not something a
+  # subclass stops doing.  CRuby never asks about the class here: its
+  # Integer#== hands a non-numeric right operand the question back, so the
+  # object on the right answers through whichever #== it inherits.  mruby's
+  # Integer#== does not hand back, so the unwrapping is this method's to do
+  # and it has to read a subclass as a status.
+  sub = Class.new(Process::Status)
+  st = Process::Status.new(1234, 0)
+
+  assert_operator st, :==, sub.new(1234, 0)
+  assert_operator sub.new(1234, 0), :==, st
+  # The pid takes no part here either.
+  assert_operator st, :==, sub.new(1235, 0)
+  assert_not_operator st, :==, sub.new(1234, 1)
+  assert_not_operator sub.new(1234, 1), :==, st
+end
+
 assert('Process::Status does not answer to_int') do
   # mruby has no implicit-conversion protocol, so nothing would ever call it,
   # and CRuby does not have the method either.


### PR DESCRIPTION
## Summary

`Process::Status#==` answers `to_i == other` and unwraps a status on the right itself, because `mrb_equal()` answers false for anything that is not a number rather than handing the question back. The unwrapping asked for the exact class, so a subclass of `Process::Status` was not read as a status: two objects carrying the same raw status compared unequal in both directions, while `#to_i` on the same two answered equal.

```ruby
sub = Class.new(Process::Status)
st = Process::Status.new(1234, 0)

st == sub.new(1234, 0)            #=> false, and false the other way round
st.to_i == sub.new(1234, 0).to_i  #=> true
```

## Changes

| File | What |
|---|---|
| `mrbgems/mruby-process/src/status.c` | `#==` asks `mrb_obj_is_kind_of()` about the object on the right; `Process::Status` is looked up by a `status_class()` helper that `mrb_process_status_new()` shares |
| `mrbgems/mruby-process/test/process.rb` | `Process::Status#==` through a subclass |

### Being a status is what decides, not being of this exact class

The raw status is the whole of what `#==` compares. Its documentation already says the pid takes no part, so two statuses holding the same platform value are equal whichever processes they came from, and a subclass changes neither half of that: it carries the same two instance variables, `#to_i` gives back the same number, and the only thing about it that is not the parent's is `mrb_obj_class()`, which is what the test was reading.

CRuby never asks that question. Its `#==` is `rb_equal(pst_to_i(st1), st2)`, and `Integer#==` hands a non-numeric right operand the question back, so the object on the right is reached through whichever `#==` it carries, a subclass through the inherited one. mruby's `Integer#==` answers false instead of handing back, which is why the unwrapping is written out here rather than left to `mrb_equal()`; doing it is mruby's to do, but narrowing it to a single class is not something CRuby's route does.

The case is only reachable in mruby. CRuby has no public `Process::Status.new`, so a subclass of it cannot be given a status there at all. This gem keeps that constructor working on purpose, as the file header records: mruby-io's `IO.popen` sets `$?` that way when the gem is present, and neither gem depends on the other.

`mrb_obj_is_kind_of()` is what the rest of the tree asks, `Regexp#==` in `mrbgems/mruby-regexp/src/regexp.c` among them. The two `mrb_obj_class()` results were compared in only one other place, `mruby-struct`'s `#==` and `#eql?`, and there it is right: a Struct subclass has its own members, so the class is part of what is being compared. A status has nothing but the raw value.

### `status_class()`

`mrb_process_status_new()` was already making the same two lookups, `Process` and then `Status` under it, so the helper is shared rather than added. `#==` now makes them per call where it made none before; it runs once per reaped process and per explicit comparison, so it is on no hot path, and there is nowhere for a gem to keep a class between calls without adding somewhere to keep it.

## Behaviour

With `st = Process::Status.new(1234, 0)` and `sub = Class.new(Process::Status)`, every row run on the master binary (`fdb2cca7d`) and this branch's:

| Expression | before | after |
|---|---|---|
| `st == sub.new(1234, 0)` | false | true |
| `sub.new(1234, 0) == st` | false | true |
| `st == sub.new(1235, 0)` | false | true |
| `st == sub.new(1234, 1)` | false | false |
| `sub.new(1234, 1) == st` | false | false |
| `st == Process::Status.new(1234, 0)` | true | true |
| `st == 0` | true | true |
| `st == "0"` | false | false |

The pid still takes no part, which is the third row: same raw status, different process, equal. A non-status on the right is answered by `mrb_equal()` exactly as before, and a receiver that never reached `#initialize` still raises `RuntimeError`.

## Size

`.text` of `bin/mruby` for the five `build_config/ci/gcc-clang.rb` builds, `size -A`, master and this branch built at the same path from empty build directories:

| Build | master | this PR | delta |
|---|---|---|---|
| `bintest` | 1,100,518 | 1,100,518 | ±0 |
| `ascii-ctype` | 1,095,814 | 1,095,814 | ±0 |
| `byte-string` | 1,075,894 | 1,075,894 | ±0 |
| `cxx_abi` | 1,088,629 | 1,088,645 | +16 |
| `full-debug` (-O0) | 1,897,126 | 1,897,158 | +32 |

Every byte of that is `mrbgems/mruby-process/src/status.o`, whose own `.text` moves by the same amount in each build: 2,215 unchanged in the three optimized C builds, 2,850 to 2,882 in `full-debug`. `status_class()` is `static` and has two call sites, and `nm` finds no symbol for it in either optimized build, so what the three that do not move pay for the lookups is what they stopped paying for the second `mrb_obj_class()`. `full-debug` compiles at `-O0`, where the helper stands as its own function.

## Testing

- `rake -m test` green with `build_config/ci/gcc-clang.rb` (`full-debug`, `bintest`, `cxx_abi`, `byte-string`, `ascii-ctype`) and with the default config, 2429 total and 0 KO there
- the new assertion fails on master's `status.c` with the rest of the tree unchanged (`KO: 1`, `Fail: Process::Status#== reads a subclass as the status it is`) and passes with the change, so it is the change it pins
- every row of the Behaviour table run on both binaries

## Environment

<details>

| | |
|---|---|
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-30-generic x86_64 |
| CPU | AMD Ryzen 9 5950X (16C/32T) |
| C compiler | Homebrew clang 22.1.8 |
| binutils | GNU ld 2.47.20260726 |
| base | `fdb2cca7d` |

Compile lines as run for `mrbgems/mruby-process/src/status.c`, with `-MMD -c`, `-I`, `-o` and `-ffile-prefix-map` dropped:

```console
# bintest
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_PROCESS_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK

# ascii-ctype
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -DMRB_USE_ASCII_CTYPE -DMRB_REGEXP_PARSE_DEPTH_LIMIT=512 -DMRBGEM_MRUBY_PROCESS_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# byte-string
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -DMRBGEM_MRUBY_PROCESS_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# cxx_abi
clang -g -O3 -Wall -Wundef -Wwrite-strings -Wzero-length-array -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_PROCESS_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# full-debug
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRBGEM_MRUBY_PROCESS_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved `Process::Status` equality comparisons to correctly support subclasses.
  - Status objects now compare based on their raw status value regardless of operand order; process IDs do not affect equality.

- **Tests**
  - Added coverage for comparisons involving `Process::Status` subclasses and reversed operands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->