### PR TITLE
string: copy a static string before checking its terminator

### DIFF
--- a/mrbgems/mruby-test/driver.c
+++ b/mrbgems/mruby-test/driver.c
@@ -222,6 +222,21 @@ m_str_match_p(mrb_state *mrb, mrb_value self)
   return mrb_bool_value(str_match_p(mrb, pat, pat_len, str, str_len, 0));
 }
 
+static mrb_value
+mrbtest_nofree_cstr(mrb_state *mrb, mrb_value self)
+{
+  mrb_int len = RSTRING_EMBED_LEN_MAX + 1;
+  char *buf = (char*)mrb_malloc(mrb, (size_t)len);
+  memset(buf, 'x', (size_t)len);
+
+  mrb_value str = mrb_str_new_static(mrb, buf, len);
+  const char *cstr = RSTRING_CSTR(mrb, str);
+  mrb_bool valid = cstr != buf &&
+    memcmp(cstr, buf, (size_t)len) == 0 && cstr[len] == '\0';
+  mrb_free(mrb, buf);
+  return mrb_bool_value(valid);
+}
+
 void
 mrb_init_test_driver(mrb_state *mrb, mrb_bool verbose)
 {
@@ -230,6 +245,7 @@ mrb_init_test_driver(mrb_state *mrb, mrb_bool verbose)
   mrb_define_method(mrb, krn, "_str_match?", m_str_match_p, MRB_ARGS_REQ(2));
 
   struct RClass *mrbtest = mrb_define_module(mrb, "Mrbtest");
+  mrb_define_module_function(mrb, mrbtest, "nofree_cstr?", mrbtest_nofree_cstr, MRB_ARGS_NONE());
 
 #ifndef MRB_NO_FLOAT
 #ifdef MRB_USE_FLOAT32

--- a/src/string.c
+++ b/src/string.c
@@ -3612,7 +3612,8 @@ mrb_string_value_cstr(mrb_state *mrb, mrb_value *ptr)
   p = RSTR_PTR(ps);
   len = RSTR_LEN(ps);
   if (p == NULL) return "";
-  if (p[len] == '\0') {
+  /* A NOFREE buffer only promises `len` readable bytes. */
+  if (!RSTR_NOFREE_P(ps) && p[len] == '\0') {
     return p;
   }
 

--- a/test/t/string.rb
+++ b/test/t/string.rb
@@ -8,6 +8,10 @@ assert('String', '15.2.10') do
   assert_equal Class, String.class
 end
 
+assert('RSTRING_CSTR with a non-terminated static string') do
+  assert_true Mrbtest.nofree_cstr?
+end
+
 assert('String#<=>', '15.2.10.5.1') do
   a = '' <=> ''
   b = '' <=> 'not empty'


### PR DESCRIPTION
## Summary

`mrb_string_value_cstr()` checks `p[len]` to determine whether a string is already NUL-terminated.

For a `NOFREE` string created by `mrb_str_new_static(mrb, buf, len)`, however, the external buffer only guarantees that the first `len` bytes are readable.
If `buf` is allocated with exactly `len` bytes, reading `p[len]` is a one-byte out-of-bounds read.

This PR checks `RSTR_NOFREE_P()` before reading `p[len]`. A `NOFREE` string now goes directly through the existing `str_unshare_buffer()` path, which copies the bytes into owned storage and appends the terminator safely.

## Changes

| File | Change |
| --- | --- |
| `src/string.c` | Avoid probing `p[len]` for `NOFREE` strings |
| `mrbgems/mruby-test/driver.c` | Add a C helper using an exactly sized static buffer |
| `test/t/string.rb` | Verify that `RSTRING_CSTR` copies and terminates the buffer |

## Behaviour

| Input | Before | After |
| --- | --- | --- |
| `NOFREE` buffer with exactly `len` readable bytes | Reads `p[len]` out of bounds | Copies `len` bytes and appends `'\0'` |
| Other string storage | Uses the existing terminator check | Unchanged |

A `NOFREE` buffer is copied even if its caller happens to have placed a terminator after `len`, because that extra byte is not part of the storage guarantee and cannot be inspected safely.

## Testing

- `ruby minirake test`
  - core: 2,429 total, 2,372 OK, 0 KO
  - bintest: 128 total, 127 OK, 0 KO
- A targeted clang AddressSanitizer/UndefinedBehaviorSanitizer harness using an exact-size `malloc(len)` buffer completed without sanitizer reports and verified that:
  - the returned pointer no longer aliases the external buffer;
  - all `len` bytes are preserved;
  - `cstr[len]` is `'\0'`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved string conversion for static strings that are not null-terminated.
  * Prevented potential out-of-bounds reads when creating C-compatible string copies.

* **Tests**
  * Added coverage verifying that non-terminated static strings are safely converted and remain valid after the original buffer is released.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->