### PR TITLE
mruby-regexp: read a mutual recursion from the body that ends

### DIFF
--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -3251,8 +3251,9 @@ compute_first_set(const re_inst *code, uint32_t code_len,
    - consuming_stops off, look_forks off, wall_mask set: whether an
      invocation can complete without recursing. A lookaround is walked
      through its sub-pattern alone, since the text after it is reached only
-     once the sub-pattern has run; a call into the recursion under test is a
-     wall, and reaching the body's own RE_RETURN is the escape.
+     once the sub-pattern has run; a call no invocation is yet known to
+     return from is a wall, and reaching the body's own RE_RETURN is the
+     escape.
 
    A RE_RETURN ends every path: the walk has no call stack, and what follows
    one belongs to whoever called. seen[] is marked with `mark` so one buffer
@@ -3346,19 +3347,20 @@ call_closure(uint32_t *adj)
    - a call cycle a walk reaches with nothing consumed on the way, wherever
      the calls stand: `(?<a>\g<a>?x)` and `(?<a>x|\g<a>)` alike, since an
      engine that takes them re-enters the body at the position it left.
-   - a group no invocation can complete without re-entering its own
-     recursion: `(?<a>x\g<a>)` must recurse to match at all, and so must
-     `x(?=\g<0>)`, whose lookahead is not an alternative but a requirement.
+   - a group no invocation can complete: `(?<a>x\g<a>)` must recurse to match
+     at all, and so must `x(?=\g<0>)`, whose lookahead is not an alternative
+     but a requirement.
 
    What escapes both is a call every path can decline: `(?<a>x\g<a>?)` and
-   the balanced-parentheses pattern this feature exists for. */
+   the balanced-parentheses pattern this feature exists for. A body may also
+   decline through a call it can step through, which is how the mutual
+   recursion in `(?<a>\g<b>)(?<b>x\g<a>?)` compiles. */
 static void
 never_ending_check(re_compiler *c, uint32_t called, const uint32_t *entry)
 {
   uint32_t code_len = c->code_len;
   const re_inst *code = c->pat->code;
   uint32_t eps[RE_MAX_CAPTURES];   /* calls reached consuming nothing */
-  uint32_t any[RE_MAX_CAPTURES];   /* calls reached at all */
   uint32_t mark = 0;
   mrb_bool bad = FALSE;
 
@@ -3388,32 +3390,39 @@ never_ending_check(re_compiler *c, uint32_t called, const uint32_t *entry)
   }
 
   memset(eps, 0, sizeof(eps));
-  memset(any, 0, sizeof(any));
   for (int k = 0; k < RE_MAX_CAPTURES; k++) {
     if (!((called >> k) & 1)) continue;
     eps[k] = call_walk(code, code_len, entry[k], seen, ++mark, stack,
                        TRUE, TRUE, 0, eps_done, (uint16_t)k, NULL);
-    any[k] = call_walk(code, code_len, entry[k], seen, ++mark, stack,
-                       FALSE, TRUE, 0, ~(uint32_t)0, (uint16_t)k, NULL);
   }
   call_closure(eps);
-  call_closure(any);
 
   for (int k = 0; !bad && k < RE_MAX_CAPTURES; k++) {
     if (((called >> k) & 1) && ((eps[k] >> k) & 1)) bad = TRUE;
   }
-  for (int k = 0; !bad && k < RE_MAX_CAPTURES; k++) {
-    if (!((called >> k) & 1)) continue;
-    /* The walls are this group and everything a call chain leads back from:
-       a path that reaches one has re-entered the recursion under test. */
-    uint32_t wall = (uint32_t)1 << k;
-    for (int m = 0; m < RE_MAX_CAPTURES; m++) {
-      if ((any[m] >> k) & 1) wall |= (uint32_t)1 << m;
+
+  /* Which called bodies an invocation can complete, to fixpoint: a body
+     completes by declining every call it cannot step through, and it can
+     step through only a call some invocation is already known to complete,
+     its own excluded. The set starts empty and grows, so a mutual recursion
+     is admitted from whichever body stands on its own first:
+     `(?<a>\g<b>)(?<b>x\g<a>?)` compiles because b's body can stop at its
+     `x`, which is then what a's one call steps through. A body left out
+     when the set holds is one no input could end. */
+  if (!bad) {
+    uint32_t ends = 0;
+    for (;;) {
+      uint32_t before = ends;
+      for (int k = 0; k < RE_MAX_CAPTURES; k++) {
+        if (!((called >> k) & 1) || ((ends >> k) & 1)) continue;
+        mrb_bool escapes;
+        call_walk(code, code_len, entry[k], seen, ++mark, stack,
+                  FALSE, FALSE, ~ends, ~(uint32_t)0, (uint16_t)k, &escapes);
+        if (escapes) ends |= (uint32_t)1 << k;
+      }
+      if (ends == before) break;
     }
-    mrb_bool escapes;
-    call_walk(code, code_len, entry[k], seen, ++mark, stack,
-              FALSE, FALSE, wall, ~(uint32_t)0, (uint16_t)k, &escapes);
-    if (!escapes) bad = TRUE;
+    if (called & ~ends) bad = TRUE;
   }
 
   mrb_free(c->mrb, buf);

--- a/mrbgems/mruby-regexp/test/regexp_call.rb
+++ b/mrbgems/mruby-regexp/test/regexp_call.rb
@@ -316,6 +316,18 @@ assert("Regexp - the recursions an input can end compile") do
   assert_equal "xy", "xy".match(Regexp.new("(?<a>x(?:(?=\\g<a>)|y))"))[0]
   assert_equal "xx", "xx".match(Regexp.new("(?<a>(?>x)\\g<a>?)"))[0]
 
+  # mutual recursion is admitted from whichever body stands on its own: b's
+  # can stop at its `x`, and that is what a's one call steps through, where
+  # walling off every group a call chain leads back from would have left a's
+  # body with nowhere to go
+  assert_equal "xx", "xx".match(Regexp.new("(?<a>\\g<b>)(?<b>x\\g<a>?)"))[0]
+  assert_equal "xxx",
+               "xxx".match(Regexp.new("(?<a>\\g<b>){0}(?<b>x(?:\\g<a>)?){0}\\g<a>"))[0]
+  assert_equal "xxx",
+               "xxx".match(Regexp.new("(?<a>\\g<b>){0}(?<b>\\g<c>){0}(?<c>x\\g<a>?){0}\\g<a>"))[0]
+  assert_equal "yx",
+               "yxyx".match(Regexp.new("(?<a>\\g<b>x){0}(?<b>y\\g<a>?){0}\\g<a>"))[0]
+
   # a call on the way to a recursion prices in its body's minimum, so a call
   # to a group that always consumes keeps what follows off the head:
   # \g<0> here stands behind a's `b` and compiles, where a call to an


### PR DESCRIPTION
## Summary

`never_ending_check()` refused every mutual recursion between subexpression calls, including the ones an input can end and CRuby compiles. The wall its second walk stands on is now grown to a fixpoint rather than assumed, and the walk that built the old wall is gone with it.

## Changes

| File | What |
|---|---|
| `mrbgems/mruby-regexp/src/re_compile.c` | `never_ending_check()` grows the set of groups an invocation is known to return from and walls off its complement; the per-group `any[]` walk and the `call_closure()` over it are removed |
| `mrbgems/mruby-regexp/test/regexp_call.rb` | four mutual recursions added to the "recursions an input can end compile" block |

### The wall the second walk stood on

`never_ending_check()` runs two walks over the finished code. The first asks which calls a body reaches with nothing consumed on the way, and refuses a cycle among them. The second asks whether an invocation of a group can complete without recursing, and it is this one that read the call graph too coarsely: its walls were the group under test together with every group a call chain leads back from. In a mutual recursion that set is the whole cycle, so the walk left the body at its first call with nowhere to go, and the pattern was refused whatever its shape.

The wall is now the complement of a set that is grown rather than assumed: the groups no invocation is yet known to return from. The set starts empty, and each round admits a body that reaches its own `RE_RETURN` while declining every call it cannot step through, a call being one it can step through only when the set already holds that call's group, its own excluded. In `(?<a>\g<b>)(?<b>x\g<a>?)`, `b`'s body stands on its own at its `x` and enters the set first; `a`'s one call then steps through `b`, so `a` follows. A group still outside the set when the fixpoint holds is one no input could end, which is the answer the walk was always after.

The per-group `any[]` walk and the `call_closure()` over it existed only to build the old wall, so both are gone. `call_closure()` itself stays, the zero-width check being its other caller.

### What the change does not move

The zero-width cycle check is untouched, and still carries the shapes that terminate for the wrong reason: `(?<a>\g<b>x)(?<b>\g<a>?)` is refused there, `b`'s body completing at zero width, as CRuby refuses it. A self-recursion is unaffected, its own bit never entering the set while it is under test, so `(?<a>x\g<a>)` and `x(?=\g<0>)` are still refused, as are `(?<a>\g<a>?x)` and `(?<a>x|\g<a>)` in the first walk.

## Behaviour

Mutual recursions an input can end now compile and match what CRuby matches. Nothing that compiled before this change is refused after it.

```ruby
# CRuby 4.0.6 compiles all four
# mruby before this change: RegexpError, never ending recursion
Regexp.new("(?<a>\\g<b>)(?<b>x\\g<a>?)").match("xx")[0]                              # => "xx"
Regexp.new("(?<a>\\g<b>){0}(?<b>x(?:\\g<a>)?){0}\\g<a>").match("xxx")[0]             # => "xxx"
Regexp.new("(?<a>\\g<b>){0}(?<b>\\g<c>){0}(?<c>x\\g<a>?){0}\\g<a>").match("xxx")[0]  # => "xxx"
Regexp.new("(?<a>\\g<b>x){0}(?<b>y\\g<a>?){0}\\g<a>").match("yxyx")[0]               # => "yx"
```

## Size

`.text` of `bin/mruby`, `build_config/ci/gcc-clang.rb`, this PR against master (2c680718a), clean build directories, same tree path:

| build | master | PR | delta |
|---|---|---|---|
| bintest | 1,100,710 | 1,098,598 | -2,112 |
| ascii-ctype | 1,096,006 | 1,093,894 | -2,112 |
| byte-string | 1,076,086 | 1,073,894 | -2,192 |
| cxx_abi | 1,088,837 | 1,086,725 | -2,112 |
| full-debug (-O0) | 1,897,366 | 1,897,190 | -176 |

Attribution (bintest objects): the whole delta is `re_compile.o`, whose `.text` goes from 28,982 bytes to 26,870. Every other object is byte-identical but `version.o`, which carries the revision string and is the same size on both sides.

## Testing

* `build_config/ci/gcc-clang.rb`, all five builds including full-debug's `MRB_GC_STRESS` and cxx_abi's C++ compile, `rake -m test` green on clean build directories (cxx_abi linked with `LDFLAGS=--gcc-install-dir=...`)
* host build (clang, word boxing, full-core gembox): `rake -m test` green, and `rake regexp:difftest` reports the corpus's 97 known differences with no new ones and none gone
* a corpus of 617 patterns over two and three named groups, whose bodies are drawn from calls to each other, calls to themselves, literals and the quantifiers that admit zero, each written both as a body that runs where it stands and as a `{0}` declaration the pattern calls into. Compile verdicts and match results were diffed against the host CRuby: master refuses 278 of them where CRuby refuses 180, and after this change the gem refuses those same 180 and answers every one of the other 437 exactly as CRuby answers it. The 98 patterns that changed verdict all terminate.
* two wider differential runs against the host CRuby, as a check that nothing else moved: 20,000 random patterns drawn over every syntax the gem carries, and a systematic 21,222-pattern corpus of every reference a pattern may make, compared by refusal message. Master and this branch write byte-identical output on both, so the divergences from CRuby that remain in each are the ones that were already there.

## Environment

<details>

* Linux 7.0.0-30-generic x86_64, Ubuntu 24.04.4 LTS
* Homebrew clang 22.1.8, gcc (Ubuntu) 13.3.0, GNU ld (GNU Binutils) 2.47.20260726
* CRuby 4.0.6 for the differential runs
* compile line for `re_compile.c` in the bintest build, as recorded by the build (`-ffile-prefix-map`, `-I` and `-o` elided):

```console
clang -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved regular expression compilation for patterns containing mutually recursive groups.
  * Patterns can now compile and match correctly when recursive groups include valid terminating paths.
  * Improved handling of recursive calls combined with optional or zero-length group occurrences.
  * Preserved detection of recursive patterns that can loop indefinitely without consuming input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->