### PR TITLE
mruby-process: freeze a `Process::Status` once it is built

### DIFF
--- a/mrbgems/mruby-process/README.md
+++ b/mrbgems/mruby-process/README.md
@@ -153,6 +153,13 @@ kept separate from adding this gem.
   will not do.
 - **`Process::Status.new(pid, raw_status)` stays public.** Making it private
   would break the `mruby-io` path it exists for.
+- **A `Process::Status` is frozen once built.** What a process did is over by
+  the time there is a status for it, and the pid and the raw status set at
+  construction are what every other question is read back from. Freezing says
+  so, and keeps the two from being rewritten under the answers. CRuby freezes
+  the status it leaves in `$?` for the same reason. An instance of a subclass
+  is left unfrozen: it is still being built when `#initialize` returns, and
+  every status this gem and `mruby-io` publish is a `Process::Status` itself.
 - **A wait flag no port stands for is refused before a port sees it.** The
   flags are mruby's own bits, and a port reads the ones it knows and can say
   nothing about the rest, so `MRB_PROCESS_WAIT_FLAGS` names every bit a wait

--- a/mrbgems/mruby-process/src/status.c
+++ b/mrbgems/mruby-process/src/status.c
@@ -73,6 +73,12 @@ status_flag(mrb_state *mrb, mrb_value self, unsigned int flag)
  * Wraps a platform wait status for the process +pid+.  +raw_status+ is the
  * value the platform reported the process with, as Process.waitpid passes
  * on and as Process::Status#to_i gives back.
+ *
+ * A Process::Status is frozen once built, as CRuby freezes the one it leaves
+ * in <code>$?</code>.  What a process did is over by the time there is a
+ * status for it, and every question a status answers is read back from the
+ * two integers set here.  An instance of a subclass is left unfrozen, since
+ * whatever else it is made of is set after this returns.
  */
 static mrb_value
 status_initialize(mrb_state *mrb, mrb_value self)
@@ -88,6 +94,20 @@ status_initialize(mrb_state *mrb, mrb_value self)
   mrb_process_int_arg(mrb, raw_status, "status");
   mrb_iv_set(mrb, self, MRB_IVSYM(pid), mrb_int_value(mrb, pid));
   mrb_iv_set(mrb, self, MRB_IVSYM(status), mrb_int_value(mrb, raw_status));
+  /* Last, since the two above are what there is to write.  A second
+     #initialize on the same object is refused from here on, which is what
+     freezing a value means and not a case this gem's own paths reach.
+
+     Only when the object is a Process::Status and nothing more.  A subclass
+     is still being built when this returns: its own #initialize called super
+     to have the two set and goes on to set whatever else it is made of, and
+     freezing here would turn that into a FrozenError.  Every status this gem
+     and mruby-io publish through `$?` is of this exact class, so the ones
+     that answer for a reaped process are the ones that are frozen.  CRuby's
+     Range does the same, freezing in #initialize only what is a Range. */
+  if (mrb_obj_class(mrb, self) == status_class(mrb)) {
+    mrb_obj_freeze(mrb, self);
+  }
   return self;
 }
 

--- a/mrbgems/mruby-process/test/process.rb
+++ b/mrbgems/mruby-process/test/process.rb
@@ -259,6 +259,44 @@ assert('Process::Status.new with a status too large for the platform') do
   assert_equal(-big, Process::Status.new(1234, -big).to_i)
 end
 
+assert('Process::Status is frozen once built') do
+  # What a process did is over by the time there is a status for it, and the
+  # pid and the raw status set at construction are what every other question
+  # is read back from.  Freezing says so, and keeps the two from being
+  # rewritten under the answers; CRuby freezes the status it leaves in $?.
+  st = Process::Status.new(1234, 0)
+  assert_true st.frozen?
+  # Written through the one door there is: #initialize is where the two are
+  # set, and a frozen receiver turns a second pass through it away.
+  assert_raise(FrozenError) { st.__send__(:initialize, 1234, 1) }
+  assert_equal 1234, st.pid
+  assert_equal 0, st.to_i
+end
+
+assert('Process::Status subclass is left to finish building itself') do
+  # A subclass calls super to have the two set and goes on to set whatever
+  # else it is made of, so it is still being built when #initialize returns
+  # and freezing there would turn the rest of its construction into a
+  # FrozenError.  What gets frozen is what is a status and nothing more.
+  cls = Class.new(Process::Status) do
+    def initialize(pid, raw_status, tag)
+      super(pid, raw_status)
+      @tag = tag
+    end
+
+    attr_reader :tag
+  end
+
+  st = cls.new(1234, 0, "reaped")
+  assert_false st.frozen?
+  assert_equal "reaped", st.tag
+  # Still a status, and still read as one.
+  assert_equal 1234, st.pid
+  assert_equal 0, st.to_i
+  assert_true st.exited?
+  assert_operator st, :==, Process::Status.new(1234, 0)
+end
+
 assert('Process::Status#==') do
   st = Process::Status.new(1234, 0)
   assert_operator st, :==, Process::Status.new(1234, 0)
@@ -342,6 +380,7 @@ assert('Process.waitpid') do
 
   # waitpid publishes what it reaped through $?
   assert_kind_of Process::Status, $?
+  assert_true $?.frozen?
   assert_equal pid, $?.pid
   assert_true $?.exited?
   assert_equal 3, $?.exitstatus


### PR DESCRIPTION
## Summary

A `Process::Status` keeps only what the platform gave it, the pid and the raw wait status, and every question it answers (`#exited?`, `#termsig`, `#to_s`) is read back from those two integers through the HAL. That is the gem's stated design: nothing above the HAL keeps a decoded copy that could disagree with the platform.

Nothing was stopping the two from being rewritten under the answers, though, so a status could be made to describe a process it never came from:

```ruby
io = IO.popen("exit 0"); io.read; Process.waitpid(io.pid)
$?                                        #=> pid 141893 exit 0
$?.instance_variable_set(:@status, 999)
$?                                        #=> pid 141893 signal 103 (core dumped)
```

CRuby freezes the status it leaves in `$?`, where the same line raises `FrozenError`.

## Changes

| File | What |
|---|---|
| `mrbgems/mruby-process/src/status.c` | `#initialize` freezes the receiver after both writes, when the receiver is a `Process::Status` and nothing more |
| `mrbgems/mruby-process/README.md` | a design-decision row saying a status is frozen once built, and that a subclass instance is not |
| `mrbgems/mruby-process/test/process.rb` | `Process::Status is frozen once built`; `Process::Status subclass is left to finish building itself`; `Process.waitpid` asserts the status it publishes through `$?` is frozen |

### Freezing at the end of `#initialize`

What a process did is over by the time there is a status for it, so there is nothing a later write to those two integers could be reporting. Freezing says that, and `#initialize` is where the tree already says it: `range_initialize()` in `src/range.c` and `Data`'s `#initialize` in `mrbgems/mruby-data/src/data.c` both freeze the receiver as the last thing they do.

The freeze is after both `mrb_iv_set()` calls, so `Process::Status.new(pid, raw_status)` stays exactly the construction path it is today. That matters for `mruby-io`: `io_set_process_status()` in `mrbgems/mruby-io/src/io.c` reaches `Process::Status.new` by `mrb_funcall_argv2()` when the gem is present and puts the result straight into `$?`, writing nothing afterwards, and this gem's own `mrb_process_status_new()` goes through `mrb_obj_new()`, which is the same door. Neither is touched.

What is turned away is a second pass through `#initialize` on the same object, which now raises `FrozenError`. `#initialize` is where the pid and the raw status are set, so a second pass is a rewrite of a built status by definition, and no path in either gem takes one.

### Only what is a `Process::Status` and nothing more

A subclass is still being built when `#initialize` returns. Its own `#initialize` calls `super(pid, raw_status)` to have the two set and goes on to set whatever else it is made of, and freezing unconditionally would turn the rest of that into a `FrozenError`:

```ruby
class Reaped < Process::Status
  def initialize(pid, raw_status, tag)
    super(pid, raw_status)
    @tag = tag             # FrozenError, if #initialize froze unconditionally
  end
end
```

So the freeze asks `mrb_obj_class()` first. CRuby's `Range` draws the line in the same place, freezing in `#initialize` only what is a `Range` and leaving a subclass instance unfrozen; `Data` is the counter-example that freezes subclasses too, and `Process::Status` is on the `Range` side of that because a subclass of it is a status a user is building rather than a shape the gem defines.

The tree's own `Range` and `Data` do not decide it either way: both freeze unconditionally, but an `RRange` and a `Data` hold no instance variables at all, so a subclass of them cannot add state whether they freeze or not (`ArgumentError: cannot set instance variable`). A `Process::Status` is a plain object with an iv table, so here the guard is what keeps subclassing working.

Nothing is given up by it. Every status that answers for a reaped process is of the exact class: `mrb_process_status_new()` builds `Process::Status` itself, and `mruby-io` looks the constant up and calls `.new` on it. Subclasses stay what `#==` already reads them as, which #7399 settled two commits ago.

### The README row

The gem's README lists the decisions the implementation makes and why, `Process::Status.new` staying public among them. Freezing is one of those, so it goes beside the others, with the subclass line in the same row.

## Behaviour

`io = IO.popen("exit 3")`, `pid = io.pid` and then `Process.waitpid(pid)`, so `$?` is the status of a child that exited 3; `sub` is a `Class.new(Process::Status)` whose `#initialize` calls `super(pid, raw_status)` and then sets a `@tag` of its own. Every row run on the master binary (`2c680718a`) and this branch's, both the `bintest` build of `build_config/ci/gcc-clang.rb`, and on CRuby (ruby 4.0.6), where the same `$?` comes from `pid = spawn("/bin/sh", "-c", "exit 3")` and `Process.waitpid(pid)`:

| Expression | before | after | CRuby |
|---|---|---|---|
| `$?.frozen?` | false | true | true |
| `$?.pid == pid` | true | true | true |
| `$?.exitstatus` | 3 | 3 | 3 |
| `$?.__send__(:initialize, 1234, 1)` | returns | `FrozenError` | `ArgumentError` |
| `$?.to_i` after that attempt | 1 | 768 | 768 |
| `$?.to_s` after that attempt | `pid 1234 SIGHUP (signal 1)` | unchanged | unchanged |
| `$?.instance_variable_set(:@status, 999)` | writes | `FrozenError` | `FrozenError` |
| `$?.to_i` after that attempt | 999 | 768 | 768 |
| `$?.dup.frozen?` | false | false | false |
| `$?.clone.frozen?` | false | true | true |
| `$?.instance_variables` | `[:@pid, :@status]` | `[:@pid, :@status]` | `[]` |
| `Process::Status.respond_to?(:new)` | true | true | false |
| `Process::Status.new(1234, 0).frozen?` | false | true | `NoMethodError` |
| `sub.new(1234, 0, "reaped").tag` | `"reaped"` | `"reaped"` | `NoMethodError` |
| `sub.new(1234, 0, "reaped").frozen?` | false | false | `NoMethodError` |

A status still answers everything it answered, from the values it was built with. What changes is that those values are now the ones it keeps.

The CRuby column's `ArgumentError` is not a frozen check: CRuby's `Process::Status` has no `#initialize` of its own, so that call reaches `Object#initialize`, which takes no arguments. Its bottom four rows are why freezing is worth more here than the same word is worth there. CRuby holds the pid and the raw status in the object's own C struct, with no instance variable to reach and no public constructor to reach one through, so its freeze is a second lock on a door already shut, and a subclass of `Process::Status` cannot be given a status at all. This gem holds the two in instance variables and keeps `Process::Status.new` public on purpose, for the `mruby-io` path the README records, so here the freeze is the thing that shuts the door, and the subclass that CRuby cannot build is one this gem can.

## Size

`.text` of `bin/mruby` for the five `build_config/ci/gcc-clang.rb` builds, `size -A`, master and this branch built at the same path from empty build directories:

| Build | master | this PR | delta |
|---|---|---|---|
| `bintest` | 1,100,710 | 1,100,758 | +48 |
| `ascii-ctype` | 1,096,006 | 1,096,054 | +48 |
| `byte-string` | 1,076,086 | 1,076,134 | +48 |
| `cxx_abi` | 1,088,837 | 1,088,885 | +48 |
| `full-debug` (-O0) | 1,897,366 | 1,897,430 | +64 |

Every byte of that is `mrbgems/mruby-process/src/status.o`, whose own `.text` moves by the same amount in each build: 2,215 to 2,263 in the three optimized C builds, 2,231 to 2,279 in `cxx_abi`, 2,882 to 2,946 in `full-debug`. `status_initialize` itself goes 132 bytes to 191 in the four optimized builds and 174 to 229 in `full-debug`, the rest of the difference being the 16 byte function alignment padding the section was already carrying. `status_class()` is `static` and `nm` finds no symbol for it in any optimized build, so the class lookup is inlined into the two callers there and stands as its own function only at `-O0`.

The freeze runs once per status built, which is once per reaped process, so there is nothing to measure on the other side.

## Testing

- `rake -m test` green with `build_config/ci/gcc-clang.rb` (`full-debug`, `bintest`, `cxx_abi`, `byte-string`, `ascii-ctype`) and with the default config, 2432 total and 0 KO there
- on master's `status.c` with the rest of the tree unchanged, `Process::Status is frozen once built` and `Process.waitpid` fail (`KO: 2`), so those two pin the freezing
- with the freeze unguarded, `Process::Status subclass is left to finish building itself` raises (`Crash: 1`, `FrozenError: ... can't modify frozen`), so that one pins the guard
- every row of the Behaviour table run on both binaries, and the CRuby column on ruby 4.0.6

`instance_variable_set` is not in this gem's test dependency closure, so the test attempts the write through `__send__(:initialize, ...)`, which is core.

## Environment

<details>

| | |
|---|---|
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-30-generic x86_64 |
| CPU | AMD Ryzen 9 5950X (16C/32T) |
| C compiler | Homebrew clang 22.1.8 |
| binutils | GNU ld 2.47.20260726 |
| base | `2c680718a` |

Compile lines as run for `mrbgems/mruby-process/src/status.c`, with `-MMD -c`, `-I`, `-o` and `-ffile-prefix-map` dropped:

```console
# bintest
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_PROCESS_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK

# ascii-ctype
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -DMRB_USE_ASCII_CTYPE -DMRB_REGEXP_PARSE_DEPTH_LIMIT=512 -DMRBGEM_MRUBY_PROCESS_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# byte-string
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -DMRBGEM_MRUBY_PROCESS_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# cxx_abi
clang -g -O3 -Wall -Wundef -Wwrite-strings -Wzero-length-array -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_PROCESS_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# full-debug
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRBGEM_MRUBY_PROCESS_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `Process::Status` instances are now frozen after creation to preserve their process ID and raw status.
  * Subclasses remain mutable during initialization.
  * Status values published through `$?` are also frozen.

* **Documentation**
  * Added documentation explaining the freezing behavior and its rationale.

* **Tests**
  * Added coverage for frozen statuses, subclass behavior, and `$?` status immutability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->