### PR TITLE
mruby-process: undefine `Process::Status.new`, as CRuby does

### DIFF
--- a/mrbgems/mruby-io/src/io.c
+++ b/mrbgems/mruby-io/src/io.c
@@ -119,7 +119,15 @@ io_set_process_status(mrb_state *mrb, pid_t pid, int status)
     }
   }
   if (c_status != NULL) {
-    v = mrb_funcall_argv2(mrb, mrb_obj_value(c_status), MRB_SYM(new), mrb_fixnum_value(pid), mrb_fixnum_value(status));
+    /* What this needs is the status object, and asking the class for `new` is
+       not the way to it: mrb_obj_new() allocates one and hands #initialize the
+       pid and the raw status, which is the path mruby-process takes itself.
+       CRuby's Process::Status has no `new` to call. */
+    mrb_value argv[2];
+
+    argv[0] = mrb_fixnum_value(pid);
+    argv[1] = mrb_fixnum_value(status);
+    v = mrb_obj_new(mrb, c_status, 2, argv);
   }
   else {
     v = mrb_fixnum_value(WEXITSTATUS(status));

--- a/mrbgems/mruby-process/README.md
+++ b/mrbgems/mruby-process/README.md
@@ -111,13 +111,14 @@ blocks or `Process::Status`.
 
 ### Process::Status and mruby-io
 
-`mruby-io` sets `$?` after an `IO.popen` stream closes by calling
-`Process::Status.new(pid, raw_status)` when the class happens to be defined,
-and falling back to a plain Integer when it is not. That soft integration keeps
-working unchanged: `Process::Status.new(pid, raw_status)` is a supported way to
-build a status, and the status decodes itself through the same HAL that
-`Process.waitpid` uses, so a status `mruby-io` produced reads exactly like one
-this gem reaped.
+`mruby-io` sets `$?` after an `IO.popen` stream closes by building a status
+when the class happens to be defined, and falling back to a plain Integer when
+it is not. `Process::Status.new` is undefined, as it is in CRuby, so what it
+builds one with is `mrb_obj_new()`: the instance is allocated and handed to
+`#initialize`, which takes the pid and the raw platform status. That is the
+same path `Process.waitpid` takes here, and a status decodes itself through
+the same HAL whichever way it was built, so one `mruby-io` produced reads
+exactly like one this gem reaped.
 
 A `Process::Status` stores only the pid and the raw platform status, and asks
 the HAL afresh for every question about it. Nothing above the HAL ever holds a
@@ -151,8 +152,19 @@ kept separate from adding this gem.
   when `mruby-errno` is in the build. Methods are never conditionally absent,
   so a program can be written once and told at the call site what this platform
   will not do.
-- **`Process::Status.new(pid, raw_status)` stays public.** Making it private
-  would break the `mruby-io` path it exists for.
+- **`Process::Status.new` is undefined.** A status reports what happened to a
+  process, so one written by hand reports nothing, and CRuby says so by
+  undefining `new` on the class. What the
+  `mruby-io` seam needs is not a public constructor but a way to build the
+  object from C, and `mrb_obj_new()` allocates and initializes without asking
+  the class for `new`. That is also why `MRB_UNDEF_ALLOCATOR()` is not set
+  beside the undefinition, as `Data`, `Complex` and `Binding` set it:
+  `mrb_obj_new()` goes through the allocator, so marking it undefined would
+  close the seam along with the constructor. CRuby leaves its allocator alone
+  too, so `Process::Status.allocate` answers there with an uninitialized
+  status; here such an instance is answered with
+  `RuntimeError: uninitialized Process::Status` rather than read past, so
+  `allocate` gives nothing away that was not reachable before.
 - **A wait flag no port stands for is refused before a port sees it.** The
   flags are mruby's own bits, and a port reads the ones it knows and can say
   nothing about the rest, so `MRB_PROCESS_WAIT_FLAGS` names every bit a wait

--- a/mrbgems/mruby-process/ports/win/process_hal.c
+++ b/mrbgems/mruby-process/ports/win/process_hal.c
@@ -18,8 +18,8 @@
 **     when it creates them, so this is answerable once spawn exists and not
 **     before.  No process is ever reported as stopped either;
 **   - a raw status is the child's exit code, which is what mruby-io's
-**     `IO.popen` already hands to `Process::Status.new` on this platform, so
-**     a decoded status always reads as exited;
+**     `IO.popen` already gives the `Process::Status` it builds on this
+**     platform, so a decoded status always reads as exited;
 **   - only `KILL` and `TERM` can be delivered, both as TerminateProcess(),
 **     and signal 0 asks whether the process can be opened at all.
 */
@@ -223,11 +223,11 @@ mrb_hal_process_status_decode(mrb_state *mrb, mrb_int pid, mrb_int raw_status,
   /* A Windows raw status is an exit code and nothing else: a process killed
      with TerminateProcess() is indistinguishable from one that exited with
      the same code, so every status reads as exited.  Nothing in this port
-     produces one, since it performs no wait; a status reaching here came
-     from a caller of Process::Status.new, which is how mruby-io's IO.popen
-     reports a child on this platform.  An exit code such as 0xC0000005 does
-     not fit a 32-bit mrb_int unsigned and reads back negative, which is what
-     Process::Status#to_i then shows. */
+     produces one, since it performs no wait; a status reaching here was
+     built by a caller with a raw status of its own, which is how mruby-io's
+     IO.popen reports a child on this platform.  An exit code such as
+     0xC0000005 does not fit a 32-bit mrb_int unsigned and reads back
+     negative, which is what Process::Status#to_i then shows. */
   status->pid = pid;
   status->raw_status = raw_status;
   status->exitstatus = raw_status;

--- a/mrbgems/mruby-process/src/status.c
+++ b/mrbgems/mruby-process/src/status.c
@@ -9,10 +9,12 @@
 ** Ruby side never grows its own idea of what the bits mean and a status
 ** built elsewhere reads exactly as one this gem reaped.
 **
-** That "built elsewhere" is the point of keeping `Process::Status.new(pid,
-** raw_status)` a working construction path: mruby-io's `IO.popen` sets `$?`
-** that way when this gem happens to be present, and it must keep working
-** without either gem depending on the other.
+** That "built elsewhere" is mruby-io: its `IO.popen` sets `$?` with a status
+** it builds when this gem happens to be present, and that has to keep
+** working without either gem depending on the other.  `Process::Status.new`
+** is undefined here as it is in CRuby, so the seam is not a constructor but
+** the allocate-and-#initialize pair `mrb_obj_new()` performs, which is also
+** how Process.waitpid builds the status it publishes.
 */
 
 #include <mruby.h>
@@ -67,12 +69,13 @@ status_flag(mrb_state *mrb, mrb_value self, unsigned int flag)
 }
 
 /*
- * call-seq:
- *   Process::Status.new(pid, raw_status) -> status
- *
  * Wraps a platform wait status for the process +pid+.  +raw_status+ is the
  * value the platform reported the process with, as Process.waitpid passes
  * on and as Process::Status#to_i gives back.
+ *
+ * Reached by allocating an instance and initializing it rather than through
+ * `new`, which this class does not have.  Private, as mruby makes every
+ * #initialize.
  */
 static mrb_value
 status_initialize(mrb_state *mrb, mrb_value self)
@@ -355,4 +358,15 @@ mrb_process_status_init(mrb_state *mrb, struct RClass *process)
   mrb_define_method_id(mrb, status, MRB_SYM(stopsig),    status_stopsig,    MRB_ARGS_NONE());
   mrb_define_method_id(mrb, status, MRB_SYM_Q(coredump), status_coredump_p, MRB_ARGS_NONE());
   mrb_define_method_id(mrb, status, MRB_OPSYM(eq),       status_eq,         MRB_ARGS_REQ(1));
+
+  /* A status reports something that happened, so one written by hand reports
+     nothing: CRuby undefines `new` on the class for that reason, and the call
+     raises there as it now does here.  What is left is #initialize, which
+     mrb_obj_new() calls without asking for `new`: the path Process.waitpid
+     takes, and the one mruby-io takes to set `$?`.  MRB_UNDEF_ALLOCATOR() is
+     not set beside this, the way Data and Complex set it, because
+     mrb_obj_new() allocates through it and marking it undefined would close
+     that path too.  CRuby leaves its allocator alone as well; what it takes
+     away is the constructor. */
+  mrb_undef_class_method_id(mrb, status, MRB_SYM(new));
 }

--- a/mrbgems/mruby-process/test/process.c
+++ b/mrbgems/mruby-process/test/process.c
@@ -1,0 +1,32 @@
+#include <mruby.h>
+#include <mruby/class.h>
+
+/* ProcessStatusTest.build(pid, raw_status, klass) -> status
+ *
+ * `Process::Status.new` is undefined, as it is in CRuby, and the statuses a
+ * test can have a child report are the exited ones: signalled, stopped and
+ * core dumped statuses have to be written from a raw value to be examined at
+ * all.  This writes one the way the gem and mruby-io do, by allocating an
+ * instance and initializing it, so what the tests read is the construction
+ * path that is left rather than a door held open for them.
+ *
+ * Both numbers are passed on as they were written, so a value #initialize
+ * turns away by type or by size is turned away here just the same.
+ */
+static mrb_value
+test_status_build(mrb_state *mrb, mrb_value self)
+{
+  mrb_value argv[2];
+  struct RClass *klass;
+
+  mrb_get_args(mrb, "ooc", &argv[0], &argv[1], &klass);
+  return mrb_obj_new(mrb, klass, 2, argv);
+}
+
+void
+mrb_mruby_process_gem_test(mrb_state *mrb)
+{
+  struct RClass *test = mrb_define_module(mrb, "ProcessStatusTest");
+
+  mrb_define_module_function(mrb, test, "build", test_status_build, MRB_ARGS_REQ(3));
+}

--- a/mrbgems/mruby-process/test/process.rb
+++ b/mrbgems/mruby-process/test/process.rb
@@ -39,6 +39,15 @@ module ProcessTestUtil
     false
   end
 
+  # Write a status carrying +raw+ for +pid+.  Process::Status.new is
+  # undefined, here as in CRuby, so a status is built the way mruby-io builds
+  # the one it sets $? to: by allocating an instance and initializing it,
+  # which is what the C helper does.  +cls+ names the class to build, since a
+  # subclass has no `new` to reach either.
+  def self.status(pid, raw, cls = Process::Status)
+    ProcessStatusTest.build(pid, raw, cls)
+  end
+
   # Start a child running +cmd+ through a shell, or return nil where this
   # build has no child to give.
   def self.spawn(cmd)
@@ -221,10 +230,18 @@ assert('a pid or a signal number too large for the platform') do
   end
 end
 
-assert('Process::Status.new') do
+assert('Process::Status.new is undefined') do
+  # As in CRuby, which undefines it: a status reports what happened to a
+  # process, so one written by hand reports nothing.  A subclass inherits the
+  # absence rather than gaining a way round it.
+  assert_raise(NoMethodError) { Process::Status.new(1234, 0) }
+  assert_raise(NoMethodError) { Class.new(Process::Status).new(1234, 0) }
+end
+
+assert('Process::Status') do
   # A raw status of 0 means "exited with 0" on every port, which is what lets
   # this be asserted without knowing the platform's status layout.
-  st = Process::Status.new(1234, 0)
+  st = ProcessTestUtil.status(1234, 0)
   assert_equal 1234, st.pid
   assert_equal 0, st.to_i
   assert_true st.exited?
@@ -237,7 +254,7 @@ assert('Process::Status.new') do
   assert_false st.coredump?
 end
 
-assert('Process::Status.new with a status too large for the platform') do
+assert('Process::Status with a status too large for the platform') do
   # A port reads a raw status as the `int` the platform reported it with, so a
   # value that does not fit one is refused where RangeError can be said rather
   # than answered about from bits nobody wrote.  Nothing this gem produces can
@@ -251,20 +268,20 @@ assert('Process::Status.new with a status too large for the platform') do
   big = (2**31 rescue nil)
   skip "this build cannot name a number wider than an int" unless big
 
-  assert_raise(RangeError) { Process::Status.new(1234, big) }
-  assert_raise(RangeError) { Process::Status.new(1234, -big - 1) }
+  assert_raise(RangeError) { ProcessTestUtil.status(1234, big) }
+  assert_raise(RangeError) { ProcessTestUtil.status(1234, -big - 1) }
 
   # The edges themselves are still statuses, being what an int can carry.
-  assert_equal big - 1, Process::Status.new(1234, big - 1).to_i
-  assert_equal(-big, Process::Status.new(1234, -big).to_i)
+  assert_equal big - 1, ProcessTestUtil.status(1234, big - 1).to_i
+  assert_equal(-big, ProcessTestUtil.status(1234, -big).to_i)
 end
 
 assert('Process::Status#==') do
-  st = Process::Status.new(1234, 0)
-  assert_operator st, :==, Process::Status.new(1234, 0)
+  st = ProcessTestUtil.status(1234, 0)
+  assert_operator st, :==, ProcessTestUtil.status(1234, 0)
   # The raw status alone decides, so the pid does not have to match.
-  assert_operator st, :==, Process::Status.new(1235, 0)
-  assert_not_operator st, :==, Process::Status.new(1234, 1)
+  assert_operator st, :==, ProcessTestUtil.status(1235, 0)
+  assert_not_operator st, :==, ProcessTestUtil.status(1234, 1)
   assert_operator st, :==, 0
   assert_not_operator st, :==, 1
   assert_not_operator st, :==, "0"
@@ -278,24 +295,24 @@ assert('Process::Status#== reads a subclass as the status it is') do
   # Integer#== does not hand back, so the unwrapping is this method's to do
   # and it has to read a subclass as a status.
   sub = Class.new(Process::Status)
-  st = Process::Status.new(1234, 0)
+  st = ProcessTestUtil.status(1234, 0)
 
-  assert_operator st, :==, sub.new(1234, 0)
-  assert_operator sub.new(1234, 0), :==, st
+  assert_operator st, :==, ProcessTestUtil.status(1234, 0, sub)
+  assert_operator ProcessTestUtil.status(1234, 0, sub), :==, st
   # The pid takes no part here either.
-  assert_operator st, :==, sub.new(1235, 0)
-  assert_not_operator st, :==, sub.new(1234, 1)
-  assert_not_operator sub.new(1234, 1), :==, st
+  assert_operator st, :==, ProcessTestUtil.status(1235, 0, sub)
+  assert_not_operator st, :==, ProcessTestUtil.status(1234, 1, sub)
+  assert_not_operator ProcessTestUtil.status(1234, 1, sub), :==, st
 end
 
 assert('Process::Status does not answer to_int') do
   # mruby has no implicit-conversion protocol, so nothing would ever call it,
   # and CRuby does not have the method either.
-  assert_false Process::Status.new(1234, 0).respond_to?(:to_int)
+  assert_false ProcessTestUtil.status(1234, 0).respond_to?(:to_int)
 end
 
 assert('Process::Status#to_s, #inspect') do
-  st = Process::Status.new(1234, 0)
+  st = ProcessTestUtil.status(1234, 0)
   assert_equal "pid 1234 exit 0", st.to_s
   assert_equal "#<Process::Status: pid 1234 exit 0>", st.inspect
 end
@@ -306,11 +323,11 @@ assert('Process::Status#to_s spells a signal out') do
   # checked through the decoding predicates first, so a platform that reads
   # one differently skips rather than fails on an encoding assumed here.
   kill = Signal.list["KILL"]
-  st = Process::Status.new(1234, kill)
+  st = ProcessTestUtil.status(1234, kill)
   skip "a raw status is not a POSIX wait status on this platform" unless st.signaled?
   assert_equal "pid 1234 SIGKILL (signal #{kill})", st.to_s
 
-  st = Process::Status.new(1234, kill | 0x80)
+  st = ProcessTestUtil.status(1234, kill | 0x80)
   assert_equal "pid 1234 SIGKILL (signal #{kill}) (core dumped)", st.to_s if st.coredump?
 
   # A raw stopped status can only be spelled where the platform has STOP to
@@ -319,14 +336,14 @@ assert('Process::Status#to_s spells a signal out') do
   # its own.
   stop = Signal.list["STOP"]
   if stop
-    st = Process::Status.new(1234, (stop << 8) | 0x7f)
+    st = ProcessTestUtil.status(1234, (stop << 8) | 0x7f)
     assert_equal "pid 1234 stopped SIGSTOP (signal #{stop})", st.to_s if st.stopped?
   end
 
   # A number this platform gives no name is written as the bare number.
   unnamed = (1..63).find { |signo| Signal.signame(signo).nil? }
   if unnamed
-    st = Process::Status.new(1234, unnamed)
+    st = ProcessTestUtil.status(1234, unnamed)
     assert_equal "pid 1234 signal #{unnamed}", st.to_s if st.signaled?
   end
 end
@@ -443,8 +460,9 @@ assert('Process.wait2 with Process::WNOHANG') do
 end
 
 assert('$? after IO.popen') do
-  # mruby-io sets $? through Process::Status.new(pid, raw_status) when this
-  # gem is present.  Neither gem depends on the other; this is the seam.
+  # mruby-io builds the status it sets $? to when this gem is present, by
+  # allocating one and initializing it with the pid and the raw status.
+  # Neither gem depends on the other; this is the seam.
   skip ProcessTestUtil.child_reason if ProcessTestUtil.child_reason
   io = ProcessTestUtil.spawn("exit 0")
   skip "IO.popen is not available" unless io


### PR DESCRIPTION
## Summary

`Process::Status.new(pid, raw_status)` is a public constructor here, and CRuby gives the class none: it undefines `new`, so the call raises `NoMethodError` there. A status reports what happened to a process, so one written by hand reports nothing. This undefines `new` here too, after moving the one caller that depended on it off it.

It touches the same README row and the same end of `mrb_process_status_init()` as #7402, which is open; whichever lands first, the other rebases onto it.

## Changes

| File | What |
|---|---|
| `mrbgems/mruby-io/src/io.c` | `io_set_process_status()` builds the status with `mrb_obj_new()` rather than by calling `Process::Status.new` |
| `mrbgems/mruby-process/src/status.c` | `mrb_undef_class_method_id(mrb, status, MRB_SYM(new))`; the file comment and the `#initialize` doc comment that named the constructor |
| `mrbgems/mruby-process/test/process.c` | new file: `ProcessStatusTest.build(pid, raw_status, klass)`, which builds a status the way `mruby-io` does |
| `mrbgems/mruby-process/test/process.rb` | statuses are written through `ProcessTestUtil.status()`; a new assertion covers the absence of `new` |
| `mrbgems/mruby-process/README.md` | the `Process::Status and mruby-io` section, and the design-decision row that said `new` had to stay public |
| `mrbgems/mruby-process/ports/win/process_hal.c` | two comments that named the constructor |

### The only caller was mruby-io

`mruby-io` sets `$?` when an `IO.popen` stream closes, and publishes a `Process::Status` rather than a plain Integer when `mruby-process` happens to be in the build. It built one with `mrb_funcall_argv2(..., MRB_SYM(new), pid, status)`, and that is the whole reason the constructor was public. The README recorded it as a decision: "**`Process::Status.new(pid, raw_status)` stays public.** Making it private would break the `mruby-io` path it exists for."

What that path needs is the object, and `new` is only one way to reach it. `mrb_obj_new()` allocates an instance and hands `#initialize` the same two arguments without asking the class for `new`, and it is already the path this gem takes itself: `mrb_process_status_new()` builds the status `Process.waitpid` publishes that way. Moving `mruby-io` onto it adds no dependency in either direction, the constant is still looked up and still optional, and the Integer fallback is untouched.

That move is the first commit, and with `new` still defined both spellings reach the same `#initialize` with the same two arguments. The one thing it does change is that a `new` someone else defined on `Process::Status` is no longer what `$?` is built with, which is the point: `$?` is this gem's own object either way.

### The allocator stays, as it does in CRuby

The tree's usual shape for a class Ruby cannot build is a pair, `MRB_UNDEF_ALLOCATOR()` beside `mrb_undef_class_method_id(c, MRB_SYM(new))`: `mruby-data`, `mruby-complex`, `mruby-rational`, `mruby-method`, `mruby-binding` and `mruby-struct` all set both, and so do core's `Integer`, `Float` and `Proc`.

Only the second half is used here. `mrb_obj_new()` allocates through `mrb_instance_alloc()`, which raises `TypeError: allocator undefined for Process::Status` once the flag is set, so setting it would close the `mruby-io` seam along with the constructor.

CRuby draws the line in the same place. `Process::Status.new` raises `NoMethodError` there, but the allocator is left alone, so `Process::Status.allocate` still answers, with an uninitialized status. Here an instance that never reached `#initialize` holds neither integer, and `status_ivar()` already answered it with `RuntimeError: uninitialized Process::Status` rather than reading past, so `allocate` gives away nothing that was not reachable before.

A subclass inherits the absence rather than gaining a way round it: `Class.new(Process::Status).new(1234, 0)` raises `NoMethodError`, there as here.

The `#initialize` definition is unchanged. mruby makes every `#initialize` private wherever it is defined, so nothing has to be said for it to be so, and it stays the two-argument method the C path calls.

### What the tests were building statuses for

The statuses a test can have a child report are the exited ones. A signalled, stopped or core dumped status has to be written from a raw value to be examined at all, which is why the tests were the heaviest user of the constructor.

`test/process.c` is a new test-only file with one module function, `ProcessStatusTest.build(pid, raw_status, klass)`, which does what `mruby-io` does: `mrb_obj_new()` on the class it is handed, with the two arguments passed on untouched, so a value `#initialize` turns away by type or by size is turned away here just the same. The Ruby tests go through `ProcessTestUtil.status(pid, raw, cls = Process::Status)`, the `cls` argument being for the subclass cases, which have no `new` to reach either.

What the tests read is therefore the construction path that is left, rather than a door held open for them.

## Behaviour

`io = IO.popen("exit 3")`, `io.read` and `io.close`, so `$?` is the status `mruby-io` published for a child that exited 3. Every row was run on the master binary (`2c680718a`) and on this branch's, both the `bintest` build of `build_config/ci/gcc-clang.rb`, and on CRuby (ruby 4.0.6), where the same `$?` comes from `pid = spawn("/bin/sh", "-c", "exit 3")` and `Process.waitpid(pid)`. The last row waits on a second child, one that exited 5.

| Expression | before | after | CRuby |
|---|---|---|---|
| `Process::Status.respond_to?(:new)` | true | false | false |
| `Process::Status.new(1234, 0)` | a status | `NoMethodError` | `NoMethodError` |
| `Class.new(Process::Status).new(1234, 0)` | a status | `NoMethodError` | `NoMethodError` |
| `Process::Status.allocate.class` | `Process::Status` | `Process::Status` | `Process::Status` |
| `Process::Status.allocate.pid` | `RuntimeError` | `RuntimeError` | 0 |
| `Process::Status.allocate.initialize(1234, 0)` | `NoMethodError` (private) | `NoMethodError` (private) | `NoMethodError` (private) |
| `$?.class` | `Process::Status` | `Process::Status` | `Process::Status` |
| `$?.pid == io.pid` | true | true | true |
| `$?.exitstatus` | 3 | 3 | 3 |
| `$?.to_s` | `"pid <pid> exit 3"` | `"pid <pid> exit 3"` | `"pid <pid> exit 3"` |
| `Process.wait2(pid)[1].exitstatus` | 5 | 5 | 5 |

Everything a status answers, it answers the same way. What is gone is the way to write one by hand.

The two `allocate` rows are the ones the columns do not line up on, and neither is new. CRuby holds the pid and the raw status in the object's own C struct, so an uninitialized status there reads back as zeros; this gem holds them in instance variables, so there is nothing to read and `status_ivar()` says so. That was already true before this change, `allocate` being a method of `Class`.

## Size

`.text` of `bin/mruby` for the five `build_config/ci/gcc-clang.rb` builds, `size -A`, master and this branch built at the same path from empty build directories:

| Build | master | this PR | delta |
|---|---|---|---|
| `bintest` | 1,100,710 | 1,100,726 | +16 |
| `ascii-ctype` | 1,096,006 | 1,096,022 | +16 |
| `byte-string` | 1,076,086 | 1,076,102 | +16 |
| `cxx_abi` | 1,088,837 | 1,088,853 | +16 |
| `full-debug` (-O0) | 1,897,366 | 1,897,270 | -96 |

Two objects account for all of it. `mrbgems/mruby-process/src/status.o` grows by 16 bytes in every build (2,215 to 2,231 in the three optimized C builds, 2,231 to 2,247 in `cxx_abi`, 2,882 to 2,898 in `full-debug`), which is the one added `mrb_undef_class_method_id()` call. `mrbgems/mruby-io/src/io.o` is unchanged in the four optimized builds (17,360, 17,152 and 17,392 on both sides) and 112 bytes smaller at `-O0`, 25,941 to 25,829: writing two `mrb_value`s into a local array and calling `mrb_obj_new()` is less code unoptimized than handing the same two to `mrb_funcall_argv2()`, and the optimizer erases the difference everywhere else.

## Testing

- `rake -m test` green with `build_config/ci/gcc-clang.rb` (`full-debug`, `bintest`, `cxx_abi`, `byte-string`, `ascii-ctype`): `KO: 0` and `Crash: 0` in all five, and no `mruby-process` assertion skipped in any of them
- `rake -m test` green with the default config: Total 2431, OK 2374, KO 0, Crash 0, Skip 57, all of the skips pre-existing environment ones
- `rake -m test` green cross-compiled for Windows and run under Wine (`build_config/cross-mingw-winetest.rb`): Total 2653, OK 2613, KO 0, Crash 0, Skip 40, the skips being the port's existing ones. `test/process.c` compiles for that target too, and `Process::Status.new is undefined` runs there rather than skipping
- with master's `src/status.c` put back and the rest of the tree left alone, exactly one assertion fails, `Process::Status.new is undefined` (`KO: 1`), so that one pins the undefinition
- the first commit on its own is green (default config, Total 2430, KO 0, Crash 0), the one fewer assertion being the one the second commit adds
- every row of the Behaviour table run on both binaries, and the CRuby column on ruby 4.0.6

## Environment

<details>

| | |
|---|---|
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-30-generic x86_64 |
| CPU | AMD Ryzen 9 5950X (16C/32T) |
| C compiler | Homebrew clang 22.1.8 |
| binutils | GNU ld 2.47.20260726 |
| CRuby | ruby 4.0.6 |
| base | `2c680718a` |

Compile lines as run for `mrbgems/mruby-process/src/status.c`, with `-MMD -c`, `-I`, `-o` and `-ffile-prefix-map` dropped. `mrbgems/mruby-io/src/io.c` is compiled with the same lines, `-DMRBGEM_MRUBY_IO_VERSION=0.0.0` standing where `-DMRBGEM_MRUBY_PROCESS_VERSION=0.0.0` does here:

```console
# bintest
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_PROCESS_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK

# ascii-ctype
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -DMRB_USE_ASCII_CTYPE -DMRB_REGEXP_PARSE_DEPTH_LIMIT=512 -DMRBGEM_MRUBY_PROCESS_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# byte-string
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -DMRBGEM_MRUBY_PROCESS_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# cxx_abi
clang -g -O3 -Wall -Wundef -Wwrite-strings -Wzero-length-array -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_PROCESS_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# full-debug
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRBGEM_MRUBY_PROCESS_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated `Process::Status` construction to align with CRuby behavior.
  * `Process::Status.new` is no longer available and now raises `NoMethodError`.
  * Process status objects returned by process and I/O operations continue to be created correctly.

* **Tests**
  * Added coverage for the updated construction behavior, including subclasses and invalid arguments.

* **Documentation**
  * Updated process status and Windows integration documentation to reflect the revised behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->