### PR TITLE
mruby-regexp: collapse repeated capture-free assertions

### DIFF
--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -2407,6 +2407,36 @@ skip_quantifiers(re_compiler *c)
   }
 }
 
+/* TRUE for an assertion whose repeated evaluations at one position have no
+   observable difference. A capture write would make the repetitions visible,
+   and a call may write captures in a body outside this span. */
+static mrb_bool
+idempotent_assertion(const re_inst *code, uint32_t start, uint32_t end)
+{
+  if (end == start + 1) {
+    switch (code[start].op) {
+    case RE_BOL: case RE_EOL: case RE_BOT: case RE_EOT: case RE_EOTNL:
+    case RE_WBOUND: case RE_NWBOUND:
+      return TRUE;
+    default:
+      return FALSE;
+    }
+  }
+
+  switch (code[start].op) {
+  case RE_LOOKAHEAD: case RE_NEG_LOOKAHEAD:
+  case RE_LOOKBEHIND: case RE_NEG_LOOKBEHIND:
+    if (code[start].offset != end) return FALSE;
+    break;
+  default:
+    return FALSE;
+  }
+  for (uint32_t pc = start + 1; pc < end; pc++) {
+    if (code[pc].op == RE_SAVE || code[pc].op == RE_CALL) return FALSE;
+  }
+  return TRUE;
+}
+
 /* Compile atom with quantifiers (*, +, ?, {n,m}) */
 static void
 compile_quantified(re_compiler *c)
@@ -2432,6 +2462,7 @@ compile_quantified(re_compiler *c)
     if (atom) skip_quantifiers(c);
     return;
   }
+  mrb_bool assertion = idempotent_assertion(c->pat->code, start, c->code_len);
 
   /* Under /x the quantifier may stand apart from its atom, `a +` being `a+`.
      A `?` making it non-greedy is read right after it, though, as CRuby
@@ -2478,8 +2509,23 @@ compile_quantified(re_compiler *c)
       mrb_bool nongreedy = (peek(c) == '?');
       if (nongreedy) {
         next_char(c);
-        c->needs_backtrack = TRUE;
       }
+
+      /* Repeating a capture-free assertion at one position can only ask the
+         same question again. Zero repetitions therefore emit nothing, and a
+         positive minimum keeps the one copy already emitted. */
+      if (assertion) {
+        if (ch != '+') {
+          c->code_len = start;
+          skip_quantifiers(c);
+          return;
+        }
+        if (!nongreedy && peek(c) == '+') next_char(c);
+        greedy_rep = FALSE;
+        start = begin;
+        continue;
+      }
+      if (nongreedy) c->needs_backtrack = TRUE;
 
       if (ch == '*') {
         /* e* -> L: SPLIT(body, end); body; JMP L; end:
@@ -2519,8 +2565,18 @@ compile_quantified(re_compiler *c)
     mrb_bool nongreedy = (ranged && peek(c) == '?');
     if (nongreedy) {
       next_char(c);
-      c->needs_backtrack = TRUE;
     }
+    if (assertion) {
+      if (min == 0) {
+        c->code_len = start;
+        skip_quantifiers(c);
+        return;
+      }
+      greedy_rep = FALSE;
+      start = begin;
+      continue;
+    }
+    if (nongreedy) c->needs_backtrack = TRUE;
 
     /* For {n,m}: repeat atom min times, then optional (max-min) times */
     uint32_t atom_end = c->code_len;

--- a/mrbgems/mruby-regexp/test/string_regexp.rb
+++ b/mrbgems/mruby-regexp/test/string_regexp.rb
@@ -875,6 +875,15 @@ assert("String#gsub with a zero-width lookahead") do
   assert_equal [45, 195, 45, 169, 45, 120], bin.gsub(/(?=.)/) { "-" }.bytes
 end
 
+assert("String#gsub and #scan finish after repeated zero-width assertions") do
+  need_backtracking_stack
+  re = Regexp.new('(\\A{0,}${2}(?i:a)*(\\0*+|\\z??|\\s{,3}|(?!a){,3}){2}){,3}(?i:a)')
+  str = "AAayaB11Ab"
+
+  assert_equal "AAAyAB11Ab", str.gsub(re) { |match| match.upcase }
+  assert_equal [[nil, nil], [nil, nil], [nil, nil], [nil, nil], [nil, nil]], str.scan(re)
+end
+
 assert("String#gsub date reformat") do
   result = "2026-03-21".gsub(/(\d+)-(\d+)-(\d+)/) { "#{$~[3]}/#{$~[2]}/#{$~[1]}" }
   assert_equal "21/03/2026", result


### PR DESCRIPTION
## Summary

Repeated zero-width assertions could create redundant backtracking branches even though evaluating the same capture-free assertion again at the same input position cannot change its answer. A short `gsub` or `scan` could therefore exhaust `MRB_REGEXP_STEP_LIMIT` while retrying later start positions, even when a direct match succeeded.

```ruby
re = Regexp.new('(\\A{0,}${2}(?i:a)*(\\0*+|\\z??|\\s{,3}|(?!a){,3}){2}){,3}(?i:a)')
str = "AAayaB11Ab"

str.gsub(re) { |match| match.upcase }
str.scan(re)
```

The compiler now collapses a quantified, capture-free assertion to the only observable cases: no instruction when the minimum is zero, or one assertion when the minimum is positive. `MRB_REGEXP_STEP_LIMIT` itself is unchanged.

Assertions that write captures or call another subexpression are deliberately excluded. Their result may depend on backtracking state, so treating `(program counter, input position)` alone as a reusable match state would not be safe.

## Changes

| File | Change |
| --- | --- |
| `mrbgems/mruby-regexp/src/re_compile.c` | Recognize idempotent anchors, boundaries, and capture-free lookarounds, and remove redundant assertion repetitions while compiling their quantifiers |
| `mrbgems/mruby-regexp/test/string_regexp.rb` | Cover the reported pattern through both `String#gsub` and `String#scan` |

## Behaviour

| Expression | master | this PR |
| --- | --- | --- |
| `str.gsub(re) { \|match\| match.upcase }` | `RegexpError: step limit over (MRB_REGEXP_STEP_LIMIT)` | `"AAAyAB11Ab"` |
| `str.scan(re)` | `RegexpError: step limit over (MRB_REGEXP_STEP_LIMIT)` | `[[nil, nil], [nil, nil], [nil, nil], [nil, nil], [nil, nil]]` |

The results after the change agree with CRuby. Quantified assertions with capture writes retain their existing bytecode and capture behaviour.

## Testing

- `ruby minirake test`: core 2,429 total, 0 KO; bintest 128 total, 0 KO
- `MRUBY_CONFIG=build_config/clang-asan.rb ruby minirake test:build`, followed by the reported `gsub` and `scan` under the ASan/UBSan binary: no sanitizer diagnostics
- `MRUBY_CONFIG=build_config/ci/gcc-clang.rb ruby minirake test:build`: all five configurations built successfully (`full-debug`, `bintest`, `cxx_abi`, `byte-string`, and `ascii-ctype`)
- The reported `gsub` and `scan` produce the expected results under all five generated binaries
- Differential checks against CRuby for greedy, lazy, possessive, fixed, and ranged quantifiers over anchors and lookarounds, including capture-bearing lookarounds


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of repeated zero-width regular-expression assertions.
  * Prevented `String#gsub` and `String#scan` from hanging or behaving incorrectly with complex quantified assertions.
  * Preserved expected matching and capture results for affected patterns.

* **Tests**
  * Added coverage for nested quantifiers and zero-width constructs in substitution and scanning operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->