### PR TITLE
kernel.c: answer `respond_to?` false for a method unimplemented here

### DIFF
--- a/include/mruby/proc.h
+++ b/include/mruby/proc.h
@@ -186,6 +186,13 @@ MRB_API mrb_value mrb_proc_cfunc_env_get(mrb_state *mrb, mrb_int idx);
 #define MRB_METHOD_PROC_P(m) (!MRB_METHOD_FUNC_P(m))
 #define MRB_METHOD_PROC(m) ((m).as.proc)
 #define MRB_METHOD_UNDEF_P(m) ((m).as.proc==NULL)
+/* A method whose body is `mrb_notimplement_m` stands for a feature the build
+   does not have (`IO#pread` where there is no pread(2), etc.). It is defined,
+   so it is listed and can be taken as a `Method`, but `respond_to?` answers
+   false for it, as CRuby does for a method defined with `rb_f_notimplement`.
+   The body is the mark: a table entry in ROM cannot be written at startup,
+   and no flag bit is spent. */
+#define MRB_METHOD_NOTIMPL_P(m) (MRB_METHOD_FUNC_P(m) && MRB_METHOD_FUNC(m)==mrb_notimplement_m)
 #define MRB_METHOD_VISIBILITY(m) ((m).flags & MRB_METHOD_VISIBILITY_MASK)
 #define MRB_SET_VISIBILITY_FLAGS(f,v) ((f)=(((f)&~MRB_METHOD_VISIBILITY_MASK)|(v)))
 #define MRB_METHOD_SET_VISIBILITY(m,v) MRB_SET_VISIBILITY_FLAGS((m).flags,(v))

--- a/mrbgems/mruby-metaprog/test/metaprog.rb
+++ b/mrbgems/mruby-metaprog/test/metaprog.rb
@@ -334,6 +334,13 @@ assert('Module#instance_methods', '15.2.2.4.33') do
   assert_true r.include?(:method2)
 end
 
+assert('Module#instance_methods lists a method that is unimplemented here') do
+  # `respond_to?` answers false for it, but it is a defined method and the
+  # listing says so; see "Kernel#respond_to? with an unimplemented method".
+  assert_true TestNotImplement.instance_methods(false).include?(:gone)
+  assert_false TestNotImplement.new.respond_to?(:gone)
+end
+
 assert 'Module#prepend #instance_methods(false)' do
   bug6660 = '[ruby-dev:45863]'
   assert_equal([:m1], Class.new{ prepend Module.new; def m1; end }.instance_methods(false), bug6660)

--- a/mrbgems/mruby-socket/src/socket.c
+++ b/mrbgems/mruby-socket/src/socket.c
@@ -601,14 +601,6 @@ socket_option_bool(mrb_state *mrb, mrb_value self)
   return mrb_bool_value((mrb_bool)i);
 }
 
-/* Helper to raise not implemented error for unimplemented Socket::Option methods */
-static mrb_value
-socket_option_notimp(mrb_state *mrb, mrb_value self)
-{
-  mrb_notimplement(mrb);
-  return mrb_nil_value();
-}
-
 /*
  * call-seq:
  *   socket_option.inspect -> string
@@ -1381,8 +1373,9 @@ static const mrb_mt_entry socket_option_rom_entries[] = {
   MRB_MT_ENTRY(socket_option_data,    MRB_SYM(data),    MRB_ARGS_REQ(0)),
   MRB_MT_ENTRY(socket_option_bool,    MRB_SYM(bool),    MRB_ARGS_REQ(0)),
   MRB_MT_ENTRY(socket_option_int,     MRB_SYM(int),     MRB_ARGS_REQ(0)),
-  MRB_MT_ENTRY(socket_option_notimp,  MRB_SYM(linger),  MRB_ARGS_REQ(0)),
-  MRB_MT_ENTRY(socket_option_notimp,  MRB_SYM(unpack), MRB_ARGS_REQ(1)),
+  /* unimplemented, and named as such so `respond_to?` can answer false */
+  MRB_MT_ENTRY(mrb_notimplement_m,    MRB_SYM(linger),  MRB_ARGS_REQ(0)),
+  MRB_MT_ENTRY(mrb_notimplement_m,    MRB_SYM(unpack), MRB_ARGS_REQ(1)),
 };
 
 void

--- a/mrbgems/mruby-test/driver.c
+++ b/mrbgems/mruby-test/driver.c
@@ -26,6 +26,7 @@ extern const uint8_t mrbtest_assert_irep[];
 
 void mrbgemtest_init(mrb_state* mrb);
 void mrb_init_test_vformat(mrb_state* mrb);
+void mrb_init_test_notimplement(mrb_state* mrb);
 
 /* Print a short remark for the user */
 static void
@@ -262,6 +263,7 @@ mrb_init_test_driver(mrb_state *mrb, mrb_bool verbose)
 #endif
 
   mrb_init_test_vformat(mrb);
+  mrb_init_test_notimplement(mrb);
 
   if (verbose) {
     mrb_gv_set(mrb, mrb_intern_lit(mrb, "$mrbtest_verbose"), mrb_true_value());

--- a/mrbgems/mruby-test/notimplement.c
+++ b/mrbgems/mruby-test/notimplement.c
@@ -1,0 +1,20 @@
+/*
+** notimplement.c - methods standing for features a build does not have
+**
+** `mrb_notimplement_m` is what a gem installs when the platform lacks the
+** call behind a method (`IO#pread` without pread(2), and so on). Which of
+** those a build ends up with depends on the platform, so the tests for how
+** such a method behaves need one that is always there.
+*/
+
+#include <mruby.h>
+#include <mruby/class.h>
+
+void
+mrb_init_test_notimplement(mrb_state *mrb)
+{
+  struct RClass *c = mrb_define_class(mrb, "TestNotImplement", mrb->object_class);
+
+  mrb_define_method(mrb, c, "gone", mrb_notimplement_m, MRB_ARGS_NONE());
+  mrb_define_class_method(mrb, c, "gone", mrb_notimplement_m, MRB_ARGS_NONE());
+}

--- a/src/class.c
+++ b/src/class.c
@@ -3367,8 +3367,8 @@ mrb_obj_equal_m(mrb_state *mrb, mrb_value self)
  * @param c The `RClass*` representing the class of the object.
  * @param mid The symbol ID (`mrb_sym`) of the method name.
  * @return `TRUE` if an object of class `c` would respond to the method `mid`
- *         (i.e., the method is found and not undefined).
- *         `FALSE` otherwise.
+ *         (i.e., the method is found, not undefined, and not standing for a
+ *         feature this build does not have). `FALSE` otherwise.
  * @sideeffect May update the method cache if the method is found (due to the
  *             internal call to `mrb_method_search_vm`).
  */
@@ -3377,7 +3377,7 @@ mrb_obj_respond_to(mrb_state *mrb, struct RClass* c, mrb_sym mid)
 {
   mrb_method_t m = mrb_method_search_vm(mrb, &c, mid);
 
-  if (MRB_METHOD_UNDEF_P(m)) {
+  if (MRB_METHOD_UNDEF_P(m) || MRB_METHOD_NOTIMPL_P(m)) {
     return FALSE;
   }
   return TRUE;
@@ -3810,8 +3810,10 @@ undef_method(mrb_state *mrb, struct RClass *c, mrb_sym a)
  * @param c The class or module (`RClass*`) in which to undefine the method.
  * @param a The symbol ID (`mrb_sym`) of the method to undefine.
  * @return This function does not return a value.
- * @raise NameError if the method `a` is not defined in `c` or its ancestors
- *        (i.e., if `c` does not respond to `a` before undefinition).
+ * @raise NameError if the method `a` is not defined in `c` or its ancestors.
+ *        A method that is defined but unimplemented on this machine can be
+ *        undefined like any other, so the check here asks whether the method
+ *        exists, not whether `c` responds to it.
  * @sideeffect
  *   1. Modifies the method table of `c` by adding an entry that marks `a` as undefined.
  *   2. Triggers `method_undefined` (for regular classes/modules) or
@@ -3822,7 +3824,9 @@ undef_method(mrb_state *mrb, struct RClass *c, mrb_sym a)
 MRB_API void
 mrb_undef_method_id(mrb_state *mrb, struct RClass *c, mrb_sym a)
 {
-  if (!mrb_obj_respond_to(mrb, c, a)) {
+  struct RClass *found = c;
+  mrb_method_t m = mrb_method_search_vm(mrb, &found, a);
+  if (MRB_METHOD_UNDEF_P(m)) {
     mrb_name_error(mrb, a, "undefined method '%n' for class '%C'", a, c);
   }
   undef_method(mrb, c, a);

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -613,9 +613,9 @@ mrb_obj_remove_instance_variable(mrb_state *mrb, mrb_value self)
  *  method. Private methods are included in the search only if the
  *  optional second parameter evaluates to `true`.
  *
- *  If the method is not implemented,
- *  as Process.fork on Windows, File.lchmod on GNU/Linux, etc.,
- *  false is returned.
+ *  If the method is defined but unimplemented on this machine,
+ *  as IO#pread in a build without pread(2), false is returned
+ *  and `respond_to_missing?` is not consulted.
  *
  *  If the method is not defined, `respond_to_missing?`
  *  method is called and the result is returned.
@@ -624,18 +624,22 @@ static mrb_value
 obj_respond_to(mrb_state *mrb, mrb_value self)
 {
   mrb_sym id;
-  mrb_bool priv = FALSE, respond_to_p;
+  mrb_bool priv = FALSE;
 
   mrb_get_args(mrb, "n|b", &id, &priv);
-  respond_to_p = mrb_respond_to(mrb, self, id);
-  if (!respond_to_p) {
+  struct RClass *c = mrb_class(mrb, self);
+  mrb_method_t m = mrb_method_search_vm(mrb, &c, id);
+  if (MRB_METHOD_UNDEF_P(m)) {
     mrb_sym rtm_id = MRB_SYM_Q(respond_to_missing);
     if (!mrb_func_basic_p(mrb, self, rtm_id, mrb_false)) {
       mrb_value v = mrb_funcall_argv2(mrb, self, rtm_id, mrb_symbol_value(id), mrb_bool_value(priv));
       return mrb_bool_value(mrb_bool(v));
     }
+    return mrb_false_value();
   }
-  return mrb_bool_value(respond_to_p);
+  /* The method is there, so `respond_to_missing?` has nothing to add, and one
+     that is unimplemented on this machine answers a plain false. */
+  return mrb_bool_value(!MRB_METHOD_NOTIMPL_P(m));
 }
 
 static mrb_value

--- a/test/t/kernel.rb
+++ b/test/t/kernel.rb
@@ -406,6 +406,54 @@ assert('Kernel#respond_to?', '15.3.1.3.43') do
   assert_false Test4RespondTo.new.respond_to?(:test_method)
 end
 
+assert('Kernel#respond_to? with an unimplemented method') do
+  obj = TestNotImplement.new
+
+  assert_false obj.respond_to?(:gone)
+  assert_false obj.respond_to?(:gone, true)
+  assert_false TestNotImplement.respond_to?(:gone)
+  assert_false TestNotImplement.method_defined?(:gone)
+
+  # The method is defined all the same: calling it says why it is not there,
+  # rather than reporting no such method.
+  assert_raise(NotImplementedError) { obj.gone }
+  assert_raise(NotImplementedError) { TestNotImplement.gone }
+end
+
+assert('Kernel#respond_to? skips respond_to_missing? for an unimplemented method') do
+  cls = Class.new(TestNotImplement) do
+    def respond_to_missing?(name, priv = false)
+      true
+    end
+  end
+
+  # A method that exists leaves respond_to_missing? nothing to answer.
+  assert_false cls.new.respond_to?(:gone)
+  assert_true cls.new.respond_to?(:no_such_method)
+end
+
+assert('an unimplemented method can be overridden, aliased and undefined') do
+  overridden = Class.new(TestNotImplement) do
+    def gone
+      :here
+    end
+  end
+  assert_true overridden.new.respond_to?(:gone)
+  assert_equal :here, overridden.new.gone
+
+  aliased = Class.new(TestNotImplement) do
+    alias_method :also_gone, :gone
+  end
+  assert_false aliased.new.respond_to?(:also_gone)
+  assert_raise(NotImplementedError) { aliased.new.also_gone }
+
+  undefined = Class.new(TestNotImplement) do
+    undef_method :gone
+  end
+  assert_false undefined.new.respond_to?(:gone)
+  assert_raise(NoMethodError) { undefined.new.gone }
+end
+
 assert('Kernel#to_s', '15.3.1.3.46') do
   assert_equal to_s.class, String
 end


### PR DESCRIPTION
## Summary

A gem that cannot offer a method on this platform defines it as `mrb_notimplement_m`, so that calling it says why rather than reporting no such method. `respond_to?` never read that back. It asked only whether the method table held an entry, so it answered true for a method whose whole purpose is to refuse, and the two questions a caller can ask about such a method, "is it there" and "can I call it", had one answer between them.

The gap is visible inside mruby itself. `IO.popen` is written as

```ruby
def self.popen(command, mode = 'r', **opts, &block)
  if !self.respond_to?(:_popen)
    raise NotImplementedError, "popen is not supported on this platform"
  end
```

and `_popen` is `mrb_notimplement_m` in a build with `MRB_NO_IO_POPEN`. The guard never fired: the message it holds was unreachable, and the caller got `_popen() function is unimplemented on this machine` from one frame deeper. The gem had written down what it expected `respond_to?` to answer, and was answered otherwise.

CRuby decides this at the same place, comparing the function against `rb_f_notimplement` when a C method is defined, and has answered `respond_to?` false for such a method since 1.9.

## Changes

| file | what moves |
|---|---|
| `include/mruby/proc.h` | `MRB_METHOD_NOTIMPL_P()`: the body of the method is the mark |
| `src/class.c` | `mrb_obj_respond_to()` answers false for one; `mrb_undef_method_id()` looks the method up rather than asking it |
| `src/kernel.c` | `respond_to?` looks the method up itself, to tell a missing method from one that refuses |
| `mrbgems/mruby-socket/src/socket.c` | the gem's own copy of `mrb_notimplement_m` gives way to the shared one |
| `mrbgems/mruby-test/notimplement.c` | a method that is unimplemented in every build, for the tests to have one |
| `test/t/kernel.rb`, `mrbgems/mruby-metaprog/test/metaprog.rb` | what the answer is, and what stays as it was |

### The body is the mark, not a flag bit

`MRB_METHOD_NOTIMPL_P(m)` holds when the method is a C function and that function is `mrb_notimplement_m`. Two things make this the shape to use here rather than a flag on the table entry.

An entry can live in ROM, where nothing can write a flag into it at startup, and the entries that matter are already written that way:

```c
MRB_MT_ENTRY(io_pread, MRB_SYM(pread), MRB_ARGS_ANY()),
```

with `io_pread` defined as `mrb_notimplement_m` where there is no `pread(2)`. A flag would have to be spelled out a second time beside each such row, under the same `#ifdef` that chose the body.

And the flags word has no room to spare for something the body already says: its low 24 bits are the aspec, and bits 24 to 26 are `MRB_METHOD_FUNC_FL` and the visibility. Reading the body costs one comparison on a path that has already loaded the method, and asks nothing of the definition sites, so every existing `# define <name> mrb_notimplement_m` starts answering correctly with no edit.

### Two answers where there was one

"No such method" hands the question on to `respond_to_missing?`; "a method that refuses" is a plain false, since a method that exists leaves the fallback nothing to answer. `respond_to?` therefore does its own lookup and reads the `mrb_method_t` for both, which is also one call fewer than `mrb_respond_to()` plus `mrb_obj_respond_to()`. `mrb_obj_respond_to()` itself answers false for such a method, so `Module#method_defined?` follows it there, and so do the conversion checks in `object.c` and `array.c` that ask whether a `to_a` or a `to_str` can be called.

### What keeps the answer it had

The method is defined, and everything that asks that rather than "can I call it" still says so: `instance_methods` lists it, `method` and `instance_method` hand back a `Method`, `undef_method` removes it, and an alias of it is unimplemented in turn. The last falls out of `mrb_alias_method()` copying a cfunc entry as it is. `mrb_undef_method_id()` guarded itself with `mrb_obj_respond_to()` and so looks the method up directly now, since undefining a method that refuses is not an error in CRuby either.

## Behaviour

Against CRuby 4.0.6, using a method defined with `rb_f_notimplement` there and with `mrb_notimplement_m` here:

| | master | this PR | CRuby |
|---|---|---|---|
| `obj.respond_to?(:m)` | `true` | **`false`** | `false` |
| `obj.respond_to?(:m, true)` | `true` | **`false`** | `false` |
| `C.method_defined?(:m)` | `true` | **`false`** | `false` |
| `respond_to?` of an alias of `:m` | `true` | **`false`** | `false` |
| `respond_to_missing?` consulted | no | no | no |
| `C.instance_methods.include?(:m)` | `true` | `true` | `true` |
| `obj.method(:m)` | `Method` | `Method` | `Method` |
| `C.undef_method(:m)` | ok | ok | ok |
| `obj.m` | `NotImplementedError` | `NotImplementedError` | `NotImplementedError` |

What that means for the two gems in tree that have such methods, built with `MRB_NO_IO_POPEN`:

| | master | this PR |
|---|---|---|
| `IO.respond_to?(:_popen)` | `true` | **`false`** |
| `IO.popen("echo hi")` | `NotImplementedError: _popen() function is unimplemented on this machine` | **`NotImplementedError: popen is not supported on this platform`** |
| `Socket::Option#linger` → `respond_to?` | `true` | **`false`** |
| `Socket::Option.method_defined?(:linger)` | `true` | **`false`** |
| `Socket::Option#int` → `respond_to?` | `true` | `true` |

The `IO.popen` row is the guard quoted above reaching its own message. `IO.pipe` is written the same way, but where there is no `pipe(2)` its `_pipe` is left undefined rather than defined as unimplemented, so that guard was firing already. No other `respond_to?` in the tree asks about a method that can be `mrb_notimplement_m`.

## Speed

Ir per call, `bintest` build, 300,000 iterations, the empty loop subtracted (its two runs differ by 126 Ir over the whole program, 0.0004 per iteration):

| what `respond_to?` is asked | master | this PR | delta |
|---|---|---|---|
| a method that is there (`o.respond_to?(:to_s)`) | 523.02 | 524.02 | **+1** |
| a method that is not (`o.respond_to?(:no_such_method_at_all)`) | 1243.06 | 1237.06 | **-6** |

The comparison costs one instruction on the path that finds the method. The path that does not find one gets shorter, because the lookup is now made once by `respond_to?` rather than through `mrb_respond_to()` and `mrb_obj_respond_to()` in turn.

## Size

`.text` of `bin/mruby`, `build_config/ci/gcc-clang.rb`, clean build dirs, same rake target, base `9b05d103d`:

| build | master | this PR | delta |
|---|---|---|---|
| `bintest` | 1,099,222 | 1,099,510 | +288 |
| `ascii-ctype` | 1,094,470 | 1,094,758 | +288 |
| `byte-string` | 1,074,166 | 1,074,454 | +288 |
| `cxx_abi` | 1,087,349 | 1,087,637 | +288 |
| `full-debug` (-O0) | 1,898,422 | 1,898,470 | +48 |

Where it sits (`bintest`, `.text` per object):

| object | master | this PR | delta |
|---|---|---|---|
| `kernel.o` | 5,069 | 5,293 | +224 |
| `class.o` | 30,738 | 30,818 | +80 |
| `socket.o` | 13,514 | 13,494 | **-20** |

`kernel.o` holds the two answers `respond_to?` now tells apart, `class.o` the comparison in `mrb_obj_respond_to()` and the lookup in `mrb_undef_method_id()`, and `socket.o` shrinks by the helper this deletes. The optimized builds land on the same +288 because the added code is the same everywhere; `full-debug` is smaller rather than larger since at `-O0` nothing was inlined into the call sites to begin with.

## Testing

`test/t/kernel.rb`: three blocks, over a method `mruby-test` defines as `mrb_notimplement_m`. Which methods a real build has that are unimplemented depends on the platform (this Linux has `pread(2)` and `popen`, so `IO` has none of them), so the tests need one that is there in every build, defined the way `vformat.c` defines its helpers.

- what `respond_to?`, `respond_to?(name, true)` and `method_defined?` answer, and that calling it raises `NotImplementedError` rather than `NoMethodError`
- that a `respond_to_missing?` returning true for everything does not move the answer, while it still answers for a method that really is missing
- that overriding, aliasing and undefining behave as the table above says

`mrbgems/mruby-metaprog/test/metaprog.rb`: that `instance_methods` lists the method whose `respond_to?` is false. It lives there rather than beside the others because `instance_methods` is the gem's.

`MRUBY_CONFIG=ci/gcc-clang rake -m test` is green on all five builds, and so is the default config:

| build | total | OK | KO | skip |
|---|---|---|---|---|
| `full-debug` | 2681 | 2674 | 0 | 7 |
| `bintest` | 2681 | 2666 | 0 | 15 |
| `cxx_abi` | 2681 | 2666 | 0 | 15 |
| `byte-string` | 2600 | 2541 | 0 | 59 |
| `ascii-ctype` | 2672 | 2656 | 0 | 16 |
| default config | 2442 | 2383 | 0 | 59 |

A build with `MRB_NO_IO_POPEN` is green too (2442 total, 2365 OK, 0 KO, 77 skip), which is the configuration the `IO.popen` rows above were measured in.

## Environment

<details>

```
Linux 7.0.0-30-generic, x86_64
Homebrew clang version 22.1.8
valgrind-3.27.1
CRuby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM, for the behaviour table
```

The compile line the size figures were taken with (`bintest`, `kernel.c`):

```
clang -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration
  -Wwrite-strings -Wzero-length-array -ffile-prefix-map=...
  -DMRB_GC_FIXED_ARENA -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX
  -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL
  -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK
  -I... -o kernel.o kernel.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `respond_to?` and `method_defined?` now correctly return false for methods unavailable in the current build.
  * Unimplemented methods continue to raise `NotImplementedError` when called.
  * Unimplemented methods can still be overridden, aliased, or undefined as expected.

* **Bug Fixes**
  * Improved handling of missing-method fallbacks so they are not invoked for explicitly unimplemented methods.
  * Corrected method removal behavior for defined but unavailable methods.

* **Tests**
  * Added coverage for unimplemented methods across instances, classes, aliases, overrides, and method checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->