### PR TITLE
class.c: raise from `mrb_notimplement()` even with no method name

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -906,7 +906,7 @@ MRB_API struct RClass * mrb_module_get_under(mrb_state *mrb, struct RClass *oute
 MRB_API struct RClass * mrb_module_get_under_id(mrb_state *mrb, struct RClass *outer, mrb_sym name);
 
 /* a function to raise NotImplementedError with current method name */
-MRB_API void mrb_notimplement(mrb_state*);
+MRB_API mrb_noreturn void mrb_notimplement(mrb_state*);
 /* a function to be replacement of unimplemented method */
 MRB_API mrb_value mrb_notimplement_m(mrb_state*, mrb_value);
 /* just return it self */

--- a/mrbgems/mruby-test/notimplement.c
+++ b/mrbgems/mruby-test/notimplement.c
@@ -9,6 +9,16 @@
 
 #include <mruby.h>
 #include <mruby/class.h>
+#include <mruby/error.h>
+#include <mruby/variable.h>
+
+static mrb_value
+notimplement_here(mrb_state *mrb, void *userdata)
+{
+  mrb_notimplement(mrb);
+  /* not reached */
+  return mrb_nil_value();
+}
 
 void
 mrb_init_test_notimplement(mrb_state *mrb)
@@ -17,4 +27,13 @@ mrb_init_test_notimplement(mrb_state *mrb)
 
   mrb_define_method(mrb, c, "gone", mrb_notimplement_m, MRB_ARGS_NONE());
   mrb_define_class_method(mrb, c, "gone", mrb_notimplement_m, MRB_ARGS_NONE());
+
+  /* `mrb_notimplement()` names the method from the frame it is called on. A
+  ** gem init function is called by the embedder rather than by a method call,
+  ** so there is no name on this frame. Ruby cannot build such a frame, so make
+  ** the call from here and hand the outcome to the tests. */
+  mrb_bool error;
+  mrb_value result = mrb_protect_error(mrb, notimplement_here, NULL, &error);
+  mrb_define_const(mrb, c, "NAMELESS_RAISED", mrb_bool_value(error));
+  mrb_define_const(mrb, c, "NAMELESS_RESULT", result);
 }

--- a/src/class.c
+++ b/src/class.c
@@ -1191,8 +1191,10 @@ mrb_define_private_method(mrb_state *mrb, struct RClass *c, const char *name, mr
  *
  * @param mrb The mruby state.
  * @sideeffect Raises a NotImplementedError exception. This function does not return.
- *             If a method name is available from the callinfo, it's included
- *             in the error message (e.g., "foo() function is unimplemented on this machine").
+ *             The name comes from the callinfo of the frame the call is made on
+ *             (e.g., "foo() function is unimplemented on this machine"). A frame
+ *             that is not a method call has no name, and the message goes without
+ *             one.
  */
 MRB_API void
 mrb_notimplement(mrb_state *mrb)
@@ -1202,6 +1204,7 @@ mrb_notimplement(mrb_state *mrb)
   if (ci->mid) {
     mrb_raisef(mrb, E_NOTIMP_ERROR, "%n() function is unimplemented on this machine", ci->mid);
   }
+  mrb_raise(mrb, E_NOTIMP_ERROR, "function is unimplemented on this machine");
 }
 
 /*

--- a/src/class.c
+++ b/src/class.c
@@ -1196,7 +1196,7 @@ mrb_define_private_method(mrb_state *mrb, struct RClass *c, const char *name, mr
  *             that is not a method call has no name, and the message goes without
  *             one.
  */
-MRB_API void
+MRB_API mrb_noreturn void
 mrb_notimplement(mrb_state *mrb)
 {
   mrb_callinfo *ci = mrb->c->ci;

--- a/test/t/kernel.rb
+++ b/test/t/kernel.rb
@@ -454,6 +454,23 @@ assert('an unimplemented method can be overridden, aliased and undefined') do
   assert_raise(NoMethodError) { undefined.new.gone }
 end
 
+assert('an unimplemented method reports itself by name') do
+  assert_raise_with_message(NotImplementedError,
+                            'gone() function is unimplemented on this machine') do
+    TestNotImplement.new.gone
+  end
+end
+
+assert('mrb_notimplement() raises where there is no method name to report') do
+  # The name comes from the frame the call is made on, and a call that does not
+  # come from a method has none. Ruby cannot build such a frame; TestNotImplement
+  # makes the call from its own init function and records what came back.
+  assert_true TestNotImplement::NAMELESS_RAISED
+  assert_kind_of NotImplementedError, TestNotImplement::NAMELESS_RESULT
+  assert_equal 'function is unimplemented on this machine',
+               TestNotImplement::NAMELESS_RESULT.message
+end
+
 assert('Kernel#to_s', '15.3.1.3.46') do
   assert_equal to_s.class, String
 end


### PR DESCRIPTION
## Summary

`mrb_notimplement()` is declared `void` and `mrb_notimplement_m()` writes `/* not reached */` over the line after the call, but the function returns without raising when the frame it is called on carries no method name. Raise there as well, with the name left out of the message.

## Changes

| File | What |
|---|---|
| `src/class.c` | `mrb_notimplement()` raises a nameless `NotImplementedError` instead of returning, and is defined `mrb_noreturn` |
| `include/mruby.h` | `mrb_notimplement()` declared `mrb_noreturn` |
| `mrbgems/mruby-test/notimplement.c` | `TestNotImplement::NAMELESS_RAISED` and `NAMELESS_RESULT`, recorded by making the call from the gem init function |
| `test/t/kernel.rb` | two `assert` blocks: the message with a name, and the one without |

### The guard is what is left of the shape the function had in 2014

`mrb_notimplement()` arrived in `9a06cfa9d` returning `mrb_value`, as the body of a method:

```c
MRB_API mrb_value
mrb_notimplement(mrb_state *mrb, mrb_value self)
{
  mrb_callinfo *ci = mrb->c->ci;

  if (ci->mid) {
    ...
    mrb_raisef(mrb, E_NOTIMP_ERROR, ...);
  }
  return mrb_nil_value();
}
```

Answering `nil` was a legal outcome of that function. Two days later `5c6d6309b` split it into `mrb_notimplement()` and `mrb_notimplement_m()`, gave the first one `void`, gave the second the comment `/* not reached */`, and carried the guard across untouched. Since then the arm has had no way to report itself: a `void` function cannot hand the condition back, and the declaration in `mruby.h` reads `a function to raise NotImplementedError with current method name`.

### Which frames have no name

The name is read off `mrb->c->ci`, so it is there for a method call and missing for a frame that C code reaches on its own: an embedder calling into mruby, or a gem init function. Ruby cannot build such a frame, which is why no method in the tree is affected today. Every in-tree use of `mrb_notimplement_m()` is a method body, and every one of those has a name; the `void` form has no in-tree caller at all, so what it does is what an embedder and an out-of-tree gem see.

What such a caller gets is the whole of the problem. `mrb_notimplement()` comes back, the code written under `/* not reached */` runs, and `mrb_notimplement_m()` hands `nil` to Ruby, so a method standing for a feature the build does not have answers as if it had succeeded.

### CRuby raises from such a frame

`rb_notimplement()` reads the name the same way and raises either way; only the message degrades, because `rb_id2str(0)` is `false`. Measured on ruby 4.0.6 with a C extension that calls it from `Init_notimp()` and from a method body:

```ruby
NotImplementedError: false() function is unimplemented on this machine  # from Init_notimp()
NotImplementedError: named() function is unimplemented on this machine  # from a method body
```

mruby leaves the name out instead of printing what the symbol table answers for 0.

## Behaviour

| Caller | Before | After |
|---|---|---|
| C function running as a method body | `NotImplementedError: foo() function is unimplemented on this machine` | unchanged |
| C code on a frame with no method name | returns; `mrb_notimplement_m()` answers `nil` | `NotImplementedError: function is unimplemented on this machine` |

Nothing changes for Ruby: the second row cannot be reached from Ruby.

## Size

`.text` of `bin/mruby`, `build_config/ci/gcc-clang.rb`, measured with `size -A`.

| Build | master | This PR | Delta |
|---|---:|---:|---:|
| `bintest` | 1,099,510 | 1,099,462 | -48 |
| `ascii-ctype` | 1,094,758 | 1,094,710 | -48 |
| `byte-string` | 1,074,454 | 1,074,406 | -48 |
| `cxx_abi` | 1,087,365 | 1,087,317 | -48 |
| `full-debug` (-O0) | 1,898,470 | 1,898,502 | +32 |

All of it is `src/class.o`, whose `.text` moves by the same -48 and +32.

The two commits pull in opposite directions. The raise alone costs +112 on the optimized builds and +48 on `full-debug`; `mrb_noreturn` then takes 160 and 16 back, because a call that cannot return needs no code after it.

## Testing

`rake -m test` on the host build, and `MRUBY_CONFIG=ci/gcc-clang rake -m test` for the five builds plus the bintest pass. No KO, no crash, no compiler warning.

| Suite | Total | OK | KO | Crash | Skip |
|---|---:|---:|---:|---:|---:|
| host | 2,444 | 2,385 | 0 | 0 | 59 |
| `full-debug` | 2,683 | 2,676 | 0 | 0 | 7 |
| `bintest` (mrbtest) | 2,683 | 2,668 | 0 | 0 | 15 |
| `bintest` (bintest) | 145 | 144 | 0 | 0 | 1 |
| `cxx_abi` | 2,683 | 2,668 | 0 | 0 | 15 |
| `byte-string` | 2,602 | 2,543 | 0 | 0 | 59 |
| `ascii-ctype` | 2,674 | 2,658 | 0 | 0 | 16 |

The new `assert` block is discriminating: with the added `mrb_raise()` taken back out and everything else kept, the host suite reports `mrb_notimplement() raises where there is no method name to report` as a failure, since `NAMELESS_RESULT` is then `nil`.

## Environment

<details>

| | |
|---|---|
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-30-generic x86_64 |
| CPU | AMD Ryzen 9 5950X |
| C compiler | Homebrew clang 22.1.8 (`CC=clang CXX=clang++ LD=clang`) |
| binutils | GNU Binutils 2.47.20260726 |
| CRuby | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM |

Compile lines, taken from `rake --verbose` after `touch src/string.c`, with `-MMD -c`, the `-I` flags and `-o` dropped. `<srcdir>` and `<builddir>` stand for the two absolute paths in `-ffile-prefix-map`.

```console
# full-debug
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -g3 -O0 -ffile-prefix-map="<srcdir>=." -ffile-prefix-map="<builddir>=./build" -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# bintest
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -ffile-prefix-map="<srcdir>=." -ffile-prefix-map="<builddir>=./build" -DMRB_GC_FIXED_ARENA -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK

# cxx_abi (compiled as C++ by the C driver; g++/clang++ links)
clang -g -O3 -Wall -Wundef -Wwrite-strings -Wzero-length-array -x c++ -std=gnu++03 -ffile-prefix-map="<srcdir>=." -ffile-prefix-map="<builddir>=./build" -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# byte-string
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -ffile-prefix-map="<srcdir>=." -ffile-prefix-map="<builddir>=./build" -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ascii-ctype
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -ffile-prefix-map="<srcdir>=." -ffile-prefix-map="<builddir>=./build" -DMRB_USE_ASCII_CTYPE -DMRB_REGEXP_PARSE_DEPTH_LIMIT=512 -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Unimplemented functions now consistently raise `NotImplementedError`, including cases where no method name is available.
  - Error messages are provided consistently for both named and unnamed unimplemented functions.

- **Tests**
  - Added coverage confirming exception types, messages, and behavior for unimplemented methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->