### PR TITLE
mruby-socket: name the two methods that only refuse as unimplemented

### DIFF
--- a/mrbgems/mruby-socket/test/socket.rb
+++ b/mrbgems/mruby-socket/test/socket.rb
@@ -66,3 +66,23 @@ assert('BasicSocket#getpeereid') do
     s.close rescue nil
   end
 end
+
+# SocketTest.win? reads the same _WIN32 that guards the sysseek entry, so this
+# test runs everywhere and asks each platform for the answer it compiled.
+assert('BasicSocket#sysseek') do
+  s = Socket.new(Socket::AF_INET, Socket::SOCK_DGRAM, 0)
+  begin
+    if SocketTest.win?
+      # The entry is here to refuse, a socket having no position to seek to,
+      # and it shadows IO#sysseek for every socket.
+      assert_false s.respond_to?(:sysseek)
+      assert_raise(NotImplementedError) { s.sysseek(0) }
+    else
+      # Without that entry IO#sysseek is the nearest definition, and a socket
+      # answers with it.
+      assert_true s.respond_to?(:sysseek)
+    end
+  ensure
+    s.close rescue nil
+  end
+end

--- a/mrbgems/mruby-socket/test/socket.rb
+++ b/mrbgems/mruby-socket/test/socket.rb
@@ -35,20 +35,6 @@ assert('Socket#recvfrom') do
   end
 end
 
-assert('BasicSocket#getpeereid') do
-  s = Socket.new(Socket::AF_INET, Socket::SOCK_DGRAM, 0)
-  begin
-    # getpeereid(2) is compiled in only where HAVE_GETPEEREID is defined.
-    # Where it is not, the method is here to refuse, and that is what
-    # respond_to? has to report rather than promise an answer.
-    unless s.respond_to?(:getpeereid)
-      assert_raise(NotImplementedError) { s.getpeereid }
-    end
-  ensure
-    s.close rescue nil
-  end
-end
-
 end   # win?
 
 # Socket.ip_address_list works on both POSIX (getifaddrs) and Windows
@@ -62,5 +48,21 @@ assert('Socket.ip_address_list') do
     assert_kind_of Addrinfo, ai
     # Only AF_INET and AF_INET6 are returned.
     assert_true [Socket::AF_INET, Socket::AF_INET6].include?(ai.afamily)
+  end
+end
+
+# BasicSocket#getpeereid is defined on every platform, so this test runs
+# everywhere.
+assert('BasicSocket#getpeereid') do
+  s = Socket.new(Socket::AF_INET, Socket::SOCK_DGRAM, 0)
+  begin
+    # getpeereid(2) is compiled in only where HAVE_GETPEEREID is defined.
+    # Where it is not, the method is here to refuse, and that is what
+    # respond_to? has to report rather than promise an answer.
+    unless s.respond_to?(:getpeereid)
+      assert_raise(NotImplementedError) { s.getpeereid }
+    end
+  ensure
+    s.close rescue nil
   end
 end


### PR DESCRIPTION
## Summary

Two `BasicSocket` methods exist in order to refuse, and #7406 gave a method a
way to say that on its body, where `respond_to?` can read it. One of them was
refusing with the wrong exception class, in every build there is.

## Changes

| File | What |
|---|---|
| `mrbgems/mruby-socket/src/socket.c` | `mrb_basicsocket_getpeereid` is `mrb_notimplement_m` where `HAVE_GETPEEREID` is not defined; `mrb_win32_basicsocket_sysseek` is deleted and its table entry is `mrb_notimplement_m` |
| `mrbgems/mruby-socket/test/socket.rb` | adds a `BasicSocket#getpeereid` and a `BasicSocket#sysseek` test, both past the file's `unless SocketTest.win?` guard so that Windows runs them |

### `getpeereid` refuses in every build, and refused as a `RuntimeError`

`BasicSocket#getpeereid` compiles the call to getpeereid(2) only under
`HAVE_GETPEEREID`, and its other arm raised a bare `RuntimeError` saying the
call is not available on this system. Nothing in the tree defines that macro,
so that arm is where every build lands: the method is there in order to refuse.

The guard moves outside the function, the way `IO#pread` and
`IO#close_on_exec?` are written in `mrbgems/mruby-io/src/io.c`, so that where
the platform call is left out the method is `mrb_notimplement_m`. It raises
`NotImplementedError` now, which is the class the message always described,
and a caller can ask before calling.

### Windows `sysseek` is a table entry, not a function

The Windows entries override `IO`'s read and write pair with the socket calls
Winsock needs. `sysseek` joins them only to refuse, since a socket has no
position to seek to, and its whole body was the one raise that says so. Two
entries in the same table, `Socket::Option#linger` and `#unpack`, already
stand for a method that is not implemented, so this one is written the same
way and the function is gone.

Because that entry shadows `IO#sysseek`, `respond_to?(:sysseek)` on a socket
is false on Windows even though `IO` further up defines one. That is the
answer for the receiver at hand: the nearest definition is the one that would
run, and it refuses.

## Behaviour

| Expression | Before | After |
|---|---|---|
| `sock.respond_to?(:getpeereid)` | `true` | `false` |
| `sock.getpeereid` | `RuntimeError: getpeereid is not available on this system` | `NotImplementedError: getpeereid() function is unimplemented on this machine` |
| `sock.respond_to?(:sysseek)` (Windows) | `true` | `false` |
| `sock.sysseek(0)` (Windows) | `NotImplementedError: sysseek not implemented for windows sockets` | `NotImplementedError: sysseek() function is unimplemented on this machine` |

`Module#method_defined?` follows `respond_to?` in both rows, as it does since
#7406.

## Size

`.text` of `bin/mruby`, `build_config/ci/gcc-clang.rb`, base
`156712079`.

| Build | master | This PR | Delta |
|---|---|---|---|
| `bintest` | 1,099,510 | 1,099,478 | -32 |
| `ascii-ctype` | 1,094,758 | 1,094,726 | -32 |
| `byte-string` | 1,074,454 | 1,074,422 | -32 |
| `cxx_abi` | 1,087,365 | 1,087,333 | -32 |
| `full-debug` (-O0) | 1,898,470 | 1,898,406 | -64 |

All of it is `socket.o`, whose `.text` goes 13,494 to 13,462 in `bintest`: the
`getpeereid` arm that is compiled here loses a `mrb_raise` call and a return.
The Windows half of the PR compiles nowhere in this table.

## Testing

- `rake -m test` (`default` gembox): 2,444 tests, OK 2,385, KO 0, Crash 0
- `MRUBY_CONFIG=ci/gcc-clang rake -m test`: all five builds, KO 0, Crash 0, no
  compiler warnings
- `MRUBY_CONFIG=build_config/cross-mingw-winetest.rb rake -m test`, which is
  where the `_WIN32` arm compiles and runs: mrbtest 2,666 and bintest 98, KO 0,
  Crash 0. `BasicSocket.method_defined?(:sysseek)` reads `false` there
- the `getpeereid` test asserts the pair rather than the platform: where the
  method does not answer `respond_to?`, calling it has to raise. Nothing in the
  tree defines `HAVE_GETPEEREID`, so the compiled arm is the only one a build
  can be asked about
- the `sysseek` test asks the platform instead, `SocketTest.win?` reading the
  same `_WIN32` that guards the entry. Its other arm pins what a socket has to
  keep where the entry is not built: `IO#sysseek`, the nearest definition

## Environment

<details>

| | |
|---|---|
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-30-generic x86_64 |
| CPU | AMD Ryzen 9 5950X |
| C compiler | Homebrew clang 22.1.8 (x86_64-unknown-linux-gnu) |
| Cross compiler | x86_64-w64-mingw32-gcc-posix (GCC) 13-posix, wine 11.0 |
| binutils | GNU size (GNU Binutils) 2.47.20260726 |
| CRuby (rake) | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM |

Compile lines as recorded by the builds, with `-MMD -c`, `-I`, `-o` dropped
and the checkout path in the two `-ffile-prefix-map` arguments written as
`<src>`. `conf.toolchain` reads `CC`, which is `clang` here, so `cxx_abi`
compiles as `clang -x c++` rather than as gcc.

```console
# bintest
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -ffile-prefix-map="<src>=." -ffile-prefix-map="<src>/build=./build" -DMRB_GC_FIXED_ARENA -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK

# ascii-ctype
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -ffile-prefix-map="<src>=." -ffile-prefix-map="<src>/build=./build" -DMRB_USE_ASCII_CTYPE -DMRB_REGEXP_PARSE_DEPTH_LIMIT=512 -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# byte-string
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -ffile-prefix-map="<src>=." -ffile-prefix-map="<src>/build=./build" -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# cxx_abi
clang -g -O3 -Wall -Wundef -Wwrite-strings -Wzero-length-array -x c++ -std=gnu++03 -ffile-prefix-map="<src>=." -ffile-prefix-map="<src>/build=./build" -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# full-debug
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -g3 -O0 -ffile-prefix-map="<src>=." -ffile-prefix-map="<src>/build=./build" -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# default gembox, host
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -ffile-prefix-map="<src>=." -ffile-prefix-map="<src>/build=./build" -DMRB_REVISION_HEADER -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK

# cross-mingw-winetest
x86_64-w64-mingw32-gcc-posix -static -ffile-prefix-map="<src>=." -ffile-prefix-map="<src>/build=./build" -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved platform handling for unsupported socket methods.
  * Unsupported methods now consistently report as unavailable instead of raising runtime errors.
  * Windows socket seeking now uses the standard not-implemented behavior.
* **Tests**
  * Added coverage for `getpeereid` behavior on platforms where it is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
