### PR TITLE
vm.c: gather the stack teardown's env closing into one walk

### DIFF
--- a/include/mruby/internal.h
+++ b/include/mruby/internal.h
@@ -165,6 +165,7 @@ struct RProc *mrb_closure_new(mrb_state*, const mrb_irep*);
 void mrb_proc_copy(mrb_state *mrb, struct RProc *a, const struct RProc *b);
 mrb_int mrb_proc_arity(const struct RProc *p);
 struct REnv *mrb_env_new(mrb_state *mrb, struct mrb_context *c, mrb_callinfo *ci, int nstacks, mrb_value *stack, struct RClass *tc);
+void mrb_env_detach_all(mrb_state *mrb, struct mrb_context *c);
 void mrb_proc_merge_lvar(mrb_state *mrb, mrb_irep *irep, struct REnv *env, int num, const mrb_sym *lv, const mrb_value *stack);
 mrb_value mrb_proc_local_variables(mrb_state *mrb, const struct RProc *proc);
 const struct RProc *mrb_proc_get_caller(mrb_state *mrb, struct REnv **env);

--- a/mrbgems/mruby-task/src/task.c
+++ b/mrbgems/mruby-task/src/task.c
@@ -11,10 +11,10 @@
 #include <mruby/error.h>
 #include <mruby/gc.h>
 #include <mruby/hash.h>
-#include <mruby/internal.h>
 #include <mruby/proc.h>
 #include <mruby/string.h>
 #include <mruby/variable.h>
+#include <mruby/internal.h>
 #include <string.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -39,7 +39,8 @@
  * An escaped closure keeps its REnv alive after the task is gone; if the
  * env still points into the freed stack, the next GC marks garbage and
  * crashes in mrb_gc_mark. mruby does the same for fibers in gc.c's
- * MRB_TT_FIBER free path.
+ * MRB_TT_FIBER free path; the walk both come through is
+ * mrb_env_detach_all() (vm.c).
  *
  * Only called while the VM is alive. A task stays GC-registered for its
  * whole life, so the GC frees one only while tearing the heap down, and
@@ -48,22 +49,7 @@
 static void
 task_unshare_envs(mrb_state *mrb, struct mrb_context *c)
 {
-  mrb_callinfo *ci;
-
-  if (!c->cibase || !c->ci) return;
-  /* Stop AT cibase rather than decrementing past it: forming a pointer
-   * one element before the start of an array is undefined behavior. */
-  for (ci = c->ci; ; ci--) {
-    struct REnv *e = ci->u.env;
-    /* mrb_env_unshare() allocates and can therefore run a GC cycle. In
-     * teardown paths the task may already be unlinked, so an env that no
-     * other object refers to may be swept mid-walk; check liveness first. */
-    if (e && !mrb_object_dead_p(mrb, (struct RBasic*)e) &&
-        e->tt == MRB_TT_ENV && MRB_ENV_ONSTACK_P(e)) {
-      mrb_env_unshare(mrb, e, TRUE);
-    }
-    if (ci == c->cibase) break;
-  }
+  mrb_env_detach_all(mrb, c);
 }
 
 /*

--- a/src/gc.c
+++ b/src/gc.c
@@ -1179,17 +1179,7 @@ obj_free(mrb_state *mrb, struct RBasic *obj, mrb_bool end)
 
       if (c && c != mrb->root_c) {
         if (!end && c->status != MRB_FIBER_TERMINATED) {
-          mrb_callinfo *ci = c->ci;
-          mrb_callinfo *ce = c->cibase;
-
-          while (ce <= ci) {
-            struct REnv *e = ci->u.env;
-            if (e && heap_p(&mrb->gc, (struct RBasic*)e) && !is_dead(&mrb->gc, (struct RBasic*)e) &&
-                e->tt == MRB_TT_ENV && MRB_ENV_ONSTACK_P(e)) {
-              mrb_env_unshare(mrb, e, TRUE);
-            }
-            ci--;
-          }
+          mrb_env_detach_all(mrb, c);
         }
         mrb_free_context(mrb, c);
       }

--- a/src/vm.c
+++ b/src/vm.c
@@ -514,6 +514,33 @@ mrb_env_unshare(mrb_state *mrb, struct REnv *e, mrb_bool noraise)
   }
 }
 
+/* Detaches every live on-stack env of a context being torn down around it:
+ * the GC freeing a suspended fiber (gc.c) and mruby-task ending a task both
+ * come through here. An escaped closure keeps its REnv alive after the
+ * stack it stands on is gone, and an env still pointing into that freed
+ * stack makes the next marking chase whatever now sits there, so the
+ * locals move into a heap copy while the stack is still intact. */
+void
+mrb_env_detach_all(mrb_state *mrb, struct mrb_context *c)
+{
+  if (!c->cibase || !c->ci) return;
+
+  /* Stop AT cibase rather than decrementing past it: forming a pointer
+   * one element before the start of an array is undefined behavior. */
+  for (mrb_callinfo *ci = c->ci; ; ci--) {
+    struct REnv *e = ci->u.env;
+    /* mrb_env_unshare() allocates and can therefore run a GC cycle. In
+     * teardown paths the context may already be unlinked, so an env that
+     * no other object refers to may be swept before the walk reaches it;
+     * check liveness first. */
+    if (e && !mrb_object_dead_p(mrb, (struct RBasic*)e) &&
+        e->tt == MRB_TT_ENV && MRB_ENV_ONSTACK_P(e)) {
+      mrb_env_unshare(mrb, e, TRUE);
+    }
+    if (ci == c->cibase) break;
+  }
+}
+
 static inline mrb_callinfo*
 cipop(mrb_state *mrb)
 {


### PR DESCRIPTION
## Summary

Two paths tear a context down around its frames and close every env still standing on that stack: the GC freeing a suspended fiber, and mruby-task ending a task. An escaped closure keeps its `REnv` alive after the stack it stands on is gone, so an env still pointing into that freed stack makes the next marking chase whatever now sits there; both paths move the locals into a heap copy while the stack is still intact.

The two walks had drifted apart. This puts both onto one, `mrb_env_detach_all()` in vm.c, in the shape mruby-task already had.

Split out of #7389, where a teardown gains something to carry beyond the env. It needs nothing from that branch and is reviewable without it: the drift and the pointer one element before `cibase` are in master today.

## Changes

| commit | area | change |
|---|---|---|
| 1 | `src/vm.c`, `src/gc.c`, `include/mruby/internal.h`, `mrbgems/mruby-task` | the two teardown walks gathered into `mrb_env_detach_all()` |

### What the two spellings differed in

* the liveness test: gc.c spells it `heap_p() && !is_dead()` where mruby-task spells it `mrb_object_dead_p()`, which gc.c defines as exactly those two (`!heap_p() || is_dead()`). The two walks therefore already agreed on which envs they touch, and the gathered one keeps that answer
* the loop bound: gc.c runs `while (ce <= ci)` with the decrement at the bottom, so the pass that handles `cibase` decrements past it before the test ends the loop, forming a pointer one element before the start of an array. mruby-task stops at `cibase` instead, which is what the gathered walk keeps
* the null guard: mruby-task returns early on a context carrying no ci stack and gc.c has no such test. It comes along, for one pair of loads on a path that runs once per collected fiber

### Where it lives

What a frame carries out with its env is a policy of the language's scope machinery rather than of either caller, so the walk belongs in vm.c beside `mrb_env_unshare()`, the call it is a loop over. The declaration sits in internal.h beside `mrb_env_new()`, behind `MRUBY_PROC_H`, which is what mruby-task's include list takes internal.h after proc.h for.

Both callers keep their own comments on why they tear down when they do; what is stated once now is which envs a dying stack closes and in what order, so a teardown gaining anything later gains it in the one walk rather than in each caller.

## Behaviour

No change. The envs closed are the same ones, in the same order, by a liveness test that is the same test spelled differently, and the pointer one element before `cibase` that gc.c used to form was compared and never dereferenced.

## Speed

Neither caller is on a hot path: one runs per collected fiber, the other per task teardown. Inside the walk, gc.c's two inlined heap tests become the one `mrb_object_dead_p()` call mruby-task already paid, on an iteration that calls `mrb_env_unshare()` and may allocate.

## Size

`.text` of `bin/mruby`, `build_config/ci/gcc-clang.rb`, against master at the branch point (`156712079`), clean build directories, same tree path:

| build | master | PR | delta |
|---|---|---|---|
| bintest | 1,099,510 | 1,099,318 | -192 |
| ascii-ctype | 1,094,758 | 1,094,566 | -192 |
| byte-string | 1,074,454 | 1,074,262 | -192 |
| cxx_abi | 1,087,365 | 1,087,173 | -192 |
| full-debug (-O0) | 1,898,470 | 1,898,294 | -176 |

Attribution (bintest objects, `.text`): `vm.o` +304 for the walk, `gc.o` -192 and `task.o` -304 for the two loops it replaces, `task_unshare_envs()` reduced to the one call. At `-O0` the same three are +176, -224 and -128.

## Testing

* `build_config/ci/gcc-clang.rb`, all five builds including full-debug's `MRB_GC_STRESS` and cxx_abi's C++ compile, `rake -m test` green from a clean build directory, KO 0 and Crash 0 throughout. `full-core` globs mruby-task in, so the gem's own suite rides in all five, and the GC's fiber teardown runs under `MRB_GC_STRESS`
* `build_config/gctest.rb` (`MRB_INT64`, `MRB_NO_BOXING`, debug, scheduler compiled in), `rake -m test` green: 883 OK, KO 0, Crash 0
* the host build (clang, word boxing), `rake -m test` green: 2,383 OK, KO 0, Crash 0

## Environment

<details>

* Linux 7.0.0-30-generic x86_64, Ubuntu 24.04
* Homebrew clang 22.1.8, gcc (Ubuntu) 13.3.0

</details>
