### PR TITLE
mruby-socket: test the two methods that only refuse, Windows included

### DIFF
--- a/mrbgems/mruby-socket/test/socket.rb
+++ b/mrbgems/mruby-socket/test/socket.rb
@@ -66,3 +66,23 @@ assert('BasicSocket#getpeereid') do
     s.close rescue nil
   end
 end
+
+# SocketTest.win? reads the same _WIN32 that guards the sysseek entry, so this
+# test runs everywhere and asks each platform for the answer it compiled.
+assert('BasicSocket#sysseek') do
+  s = Socket.new(Socket::AF_INET, Socket::SOCK_DGRAM, 0)
+  begin
+    if SocketTest.win?
+      # The entry is here to refuse, a socket having no position to seek to,
+      # and it shadows IO#sysseek for every socket.
+      assert_false s.respond_to?(:sysseek)
+      assert_raise(NotImplementedError) { s.sysseek(0) }
+    else
+      # Without that entry IO#sysseek is the nearest definition, and a socket
+      # answers with it.
+      assert_true s.respond_to?(:sysseek)
+    end
+  ensure
+    s.close rescue nil
+  end
+end

--- a/mrbgems/mruby-socket/test/socket.rb
+++ b/mrbgems/mruby-socket/test/socket.rb
@@ -35,20 +35,6 @@ assert('Socket#recvfrom') do
   end
 end
 
-assert('BasicSocket#getpeereid') do
-  s = Socket.new(Socket::AF_INET, Socket::SOCK_DGRAM, 0)
-  begin
-    # getpeereid(2) is compiled in only where HAVE_GETPEEREID is defined.
-    # Where it is not, the method is here to refuse, and that is what
-    # respond_to? has to report rather than promise an answer.
-    unless s.respond_to?(:getpeereid)
-      assert_raise(NotImplementedError) { s.getpeereid }
-    end
-  ensure
-    s.close rescue nil
-  end
-end
-
 end   # win?
 
 # Socket.ip_address_list works on both POSIX (getifaddrs) and Windows
@@ -62,5 +48,21 @@ assert('Socket.ip_address_list') do
     assert_kind_of Addrinfo, ai
     # Only AF_INET and AF_INET6 are returned.
     assert_true [Socket::AF_INET, Socket::AF_INET6].include?(ai.afamily)
+  end
+end
+
+# BasicSocket#getpeereid is defined on every platform, so this test runs
+# everywhere.
+assert('BasicSocket#getpeereid') do
+  s = Socket.new(Socket::AF_INET, Socket::SOCK_DGRAM, 0)
+  begin
+    # getpeereid(2) is compiled in only where HAVE_GETPEEREID is defined.
+    # Where it is not, the method is here to refuse, and that is what
+    # respond_to? has to report rather than promise an answer.
+    unless s.respond_to?(:getpeereid)
+      assert_raise(NotImplementedError) { s.getpeereid }
+    end
+  ensure
+    s.close rescue nil
   end
 end


### PR DESCRIPTION
## Summary

`6bfa73ceb` (#7408) wrote `BasicSocket#getpeereid` and the Windows `BasicSocket#sysseek` as `mrb_notimplement_m`, so that `respond_to?` reads the refusal back. The tests that went with those two commits are not in the tree: the `getpeereid` test sits inside the file's POSIX guard, where the platform it has the most to say about never reaches it, and `sysseek` has no test at all. This is that half.

## Changes

| File | What |
|---|---|
| `mrbgems/mruby-socket/test/socket.rb` | Move the `BasicSocket#getpeereid` test past the `unless SocketTest.win?` guard, and add a `BasicSocket#sysseek` test |

### The `getpeereid` test asks for nothing POSIX

The `unless SocketTest.win?` guard at the top of the file fences off the tests that ask for POSIX behaviour, and the `getpeereid` test was written inside it.

That test asks for none. The method is one ROM entry, registered on every platform, and getpeereid(2) is compiled in only under `HAVE_GETPEEREID`, which nothing in the tree defines, so every build lands on the arm that refuses. The test asserts that pair rather than the platform: where the method does not answer `respond_to?`, calling it has to raise. Windows is one of the builds where the call is left out, so it is a platform the test has something to say about.

### `sysseek` was written but not tested

The Windows entries override `IO`'s read and write pair with the socket calls Winsock needs; `sysseek` joins them only to refuse, since a socket has no position to seek to, and the entry is `mrb_notimplement_m`. Neither the refusal nor what `respond_to?` now answers was covered.

The new test asks each platform for the answer it compiled, `SocketTest.win?` reading the same `_WIN32` that guards the entry. Where the entry is built, the method refuses and does not answer `respond_to?`; where it is not, `IO#sysseek` is the nearest definition and a socket answers with that.

## Size

No file that ships in `libmruby.a` is touched. Both tests are compiled into `mrbtest` alone.

## Testing

| Configuration | Result |
|---|---|
| host, `rake -m test` | mrbtest 2,446 (OK 2,387), bintest 128 (OK 127) |
| `MRUBY_CONFIG=ci/gcc-clang rake -m test` (`full-debug`, `bintest`, `cxx_abi`, `byte-string`, `ascii-ctype`) | mrbtest 2,604 to 2,685 across the five builds, bintest 145 (OK 144) |
| `MRUBY_CONFIG=build_config/cross-mingw-winetest.rb rake -m test` (mingw cross, run under wine) | mrbtest 2,668 (OK 2,628), bintest 98 (OK 90) |

KO 0, Crash 0 and Warning 0 everywhere. The first commit alone is green as well (host mrbtest 2,445, OK 2,386).

The wine run is the one that matters here: it is where the `SocketTest.win?` arm of the `sysseek` test and the new reach of the `getpeereid` test are actually executed. Neither shows up as a skip in that run.

## Environment

<details>

| | |
|---|---|
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-30-generic x86_64 |
| CPU | AMD Ryzen 9 5950X (16 cores) |
| C compiler | Homebrew clang 22.1.8 |
| Cross compiler | x86_64-w64-mingw32-gcc-posix (GCC) 13-posix, mingw-w64 11.0.1 |
| Wine | wine-11.0 |
| binutils | GNU ld 2.47.20260726 |
| CRuby | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |

The diff compiles no C, so there are no compile lines to quote; the commands are the three in the table above, each run in its own `MRUBY_BUILD_DIR`.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded socket test coverage across Windows and POSIX platforms.
  * Verified peer identity retrieval on all supported platforms.
  * Added platform-specific checks for `BasicSocket#sysseek`, including expected behavior when unsupported.
  * Reorganized related socket address tests for clearer coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->