### PR TITLE
error.c: report the errno when SystemCallError is missing

### DIFF
--- a/mrbgems/mruby-socket/mrbgem.rake
+++ b/mrbgems/mruby-socket/mrbgem.rake
@@ -12,8 +12,8 @@ MRuby::Gem::Specification.new('mruby-socket') do |spec|
   # The tests need to tell one socket() failure from another - notably
   # EAFNOSUPPORT, which is what a host without IPv6 answers and is a
   # reason to skip a test rather than fail it. Without this gem
-  # mrb_sys_fail raises a bare RuntimeError whose message is just
-  # "socket", carrying no errno to match on. A test dependency rather
+  # mrb_sys_fail raises a RuntimeError that spells the errno as a bare
+  # number, leaving no class to match on. A test dependency rather
   # than a runtime one: the library itself works without Errno being
   # defined, only the tests need to name it.
   spec.add_test_dependency('mruby-errno', :core => 'mruby-errno')

--- a/mrbgems/mruby-socket/ports/win/socket_hal.c
+++ b/mrbgems/mruby-socket/ports/win/socket_hal.c
@@ -51,8 +51,10 @@ mrb_hal_socket_final(mrb_state *mrb)
 
 /* Map a Winsock error code to a POSIX errno value. Each case is guarded
  * with #ifdef so older MSVC CRTs that lack a particular Exxx still build;
- * unknown codes fall back to EIO so mrb_sys_fail still produces a non-zero
- * SystemCallError rather than reporting "success." */
+ * unknown codes fall back to EIO so that the errno mrb_sys_fail reports is
+ * still a failure rather than "success." Which exception carries it is the
+ * build's business: Errno::EIO where mruby-errno is present, a RuntimeError
+ * spelling the number where it is not. */
 static int
 wsa_to_errno(int wsa_err)
 {

--- a/mrbgems/mruby-socket/test/udpsocket.rb
+++ b/mrbgems/mruby-socket/test/udpsocket.rb
@@ -17,8 +17,8 @@ assert('UDPSocket.new(AF_INET6)') do
   # EAFNOSUPPORT specifically, not any failure: every other errno from
   # socket() is a real fault and should still fail the run. Naming it
   # needs Errno, which is why mrbgem.rake takes mruby-errno as a test
-  # dependency - without it this raises a bare RuntimeError("socket")
-  # and there is nothing to match on.
+  # dependency - without it this raises a RuntimeError that spells the
+  # errno as a bare number, and there is no class to match on.
   begin
     s = UDPSocket.new(Socket::AF_INET6)
   rescue Errno::EAFNOSUPPORT => e

--- a/mrbgems/mruby-test/driver.c
+++ b/mrbgems/mruby-test/driver.c
@@ -27,6 +27,7 @@ extern const uint8_t mrbtest_assert_irep[];
 void mrbgemtest_init(mrb_state* mrb);
 void mrb_init_test_vformat(mrb_state* mrb);
 void mrb_init_test_notimplement(mrb_state* mrb);
+void mrb_init_test_sysfail(mrb_state* mrb);
 
 /* Print a short remark for the user */
 static void
@@ -264,6 +265,7 @@ mrb_init_test_driver(mrb_state *mrb, mrb_bool verbose)
 
   mrb_init_test_vformat(mrb);
   mrb_init_test_notimplement(mrb);
+  mrb_init_test_sysfail(mrb);
 
   if (verbose) {
     mrb_gv_set(mrb, mrb_intern_lit(mrb, "$mrbtest_verbose"), mrb_true_value());

--- a/mrbgems/mruby-test/sysfail.c
+++ b/mrbgems/mruby-test/sysfail.c
@@ -1,0 +1,42 @@
+/*
+** sysfail.c - reach `mrb_sys_fail()` from Ruby
+**
+** `mrb_sys_fail()` reports the errno through SystemCallError when that class
+** is there, and mruby-errno is what defines it. A build without that gem
+** takes the other path, and the core test state is such a build: it holds
+** `mrb_open_core()` and nothing else. Nothing reachable from Ruby in that
+** state makes the call, and the errno it reads is a C one, so testing either
+** path needs a method that sets errno and calls it.
+*/
+
+#include <errno.h>
+#include <mruby.h>
+#include <mruby/class.h>
+#include <mruby/error.h>
+#include <mruby/string.h>
+
+static mrb_value
+sf_s_fail(mrb_state *mrb, mrb_value klass)
+{
+  mrb_int no;
+  mrb_value mesg = mrb_nil_value();
+
+  mrb_get_args(mrb, "i|S!", &no, &mesg);
+  errno = (int)no;
+  mrb_sys_fail(mrb, mrb_nil_p(mesg) ? NULL : RSTRING_CSTR(mrb, mesg));
+  /* not reached */
+  return mrb_nil_value();
+}
+
+void
+mrb_init_test_sysfail(mrb_state *mrb)
+{
+  struct RClass *c = mrb_define_class(mrb, "TestSysFail", mrb->object_class);
+
+  mrb_define_class_method(mrb, c, "fail", sf_s_fail, MRB_ARGS_ARG(1, 1));
+
+  /* Which path the tests can expect is decided by the state they run in, and
+  ** asking here keeps that answer next to the call it decides for. */
+  mrb_define_const(mrb, c, "SYSTEM_CALL_ERROR_DEFINED",
+                   mrb_bool_value(mrb_class_defined_id(mrb, MRB_SYM(SystemCallError))));
+}

--- a/src/error.c
+++ b/src/error.c
@@ -577,17 +577,16 @@ mrb_make_exception(mrb_state *mrb, mrb_value exc, mrb_value mesg)
  * its `_sys_fail` method with the current `errno` and an optional
  * message. This typically results in a SystemCallError being raised.
  *
- * If SystemCallError is not defined, or if the call to `_sys_fail`
- * itself fails (which shouldn't happen in normal circumstances but leads
- * to mrb_raise), it falls back to raising a RuntimeError with the
- * given message (or a default message if `mesg` is NULL, though the
- * current implementation would pass NULL to mrb_raise which might be
- * an issue).
+ * If SystemCallError is not defined, or if `_sys_fail` returns instead of
+ * raising, it falls back to raising a RuntimeError reading
+ * "errno: <number>", with " - <mesg>" appended when a message was given.
+ * Only the number is spelled out: naming the code takes a table of them,
+ * and that table is what mruby-errno is.
  *
  * mrb: The mruby state.
- * mesg: An optional C string message to append to the error. If NULL,
- *       a default message or no message might be used depending on the
- *       error path.
+ * mesg: An optional C string naming what the failed call was working on,
+ *       appended after the error itself the way CRuby appends a path.
+ *       Pass NULL when the call names nothing, as `kill(2)` does.
  */
 MRB_API mrb_noreturn void
 mrb_sys_fail(mrb_state *mrb, const char *mesg)
@@ -605,7 +604,18 @@ mrb_sys_fail(mrb_state *mrb, const char *mesg)
     }
   }
 
-  mrb_exc_raise(mrb, mrb_exc_new_str(mrb, E_RUNTIME_ERROR, mesg ? mesg_str : mrb_str_new_lit(mrb, "")));
+  /* Reached where SystemCallError is not defined, and also where a
+     `_sys_fail` that does not raise returns here. Either way no class is
+     carrying the errno and nothing else will ever report it. Without it the
+     exception says only what the caller passed, which names the call that
+     failed but never why, and says nothing at all when the caller had
+     nothing to name. */
+  mrb_value str = mrb_format(mrb, "errno: %i", no);
+  if (mesg != NULL) {
+    mrb_str_cat_lit(mrb, str, " - ");
+    mrb_str_append(mrb, str, mesg_str);
+  }
+  mrb_exc_raise(mrb, mrb_exc_new_str(mrb, E_RUNTIME_ERROR, str));
 }
 
 /*

--- a/test/t/sysfail.rb
+++ b/test/t/sysfail.rb
@@ -1,0 +1,15 @@
+##
+# mrb_sys_fail with no SystemCallError
+
+assert('mrb_sys_fail without SystemCallError') do
+  # With mruby-errno the errno goes to SystemCallError and none of this
+  # applies. The core test state has no gems, so the tests below hold, but
+  # say what they depend on rather than assume it.
+  skip 'SystemCallError is defined' if TestSysFail::SYSTEM_CALL_ERROR_DEFINED
+
+  e = assert_raise(RuntimeError) { TestSysFail.fail(2) }
+  assert_equal 'errno: 2', e.message
+
+  e = assert_raise(RuntimeError) { TestSysFail.fail(2, 'wilma') }
+  assert_equal 'errno: 2 - wilma', e.message
+end


### PR DESCRIPTION
## Summary

`mrb_sys_fail()` reports the errno through `SystemCallError` where that class is defined, and falls back to a `RuntimeError` where it is not. The fallback was dropping the errno, so a build without mruby-errno learned which call had failed but never why, and learned nothing at all when the caller had no name to give.

## Changes

Three commits: the way for a test to reach the call, the change itself with the test that pins it, and the two comments the change leaves untrue.

| Commit | File | What |
|---|---|---|
| `mruby-test:` | `mrbgems/mruby-test/sysfail.c` | new; `TestSysFail.fail` reaches `mrb_sys_fail()` with a chosen errno |
| | `mrbgems/mruby-test/driver.c` | calls `mrb_init_test_sysfail()` |
| `error.c:` | `src/error.c` | `mrb_sys_fail()` writes the errno into the message it falls back to |
| | `test/t/sysfail.rb` | new; pins what the fallback message reads |
| `mruby-socket:` | `mrbgems/mruby-socket/mrbgem.rake` | comment follows the new message |
| | `mrbgems/mruby-socket/test/udpsocket.rb` | comment follows the new message |
| | `mrbgems/mruby-socket/ports/win/socket_hal.c` | comment stops naming `SystemCallError` as the only carrier |

### The fallback dropped the one thing the call exists to report

`mrb_sys_fail()` is how a C function reports an `errno`. Where `SystemCallError` is defined it does that through `_sys_fail`. Where it is not, the exception was built from the caller's string alone:

```c
mrb_exc_raise(mrb, mrb_exc_new_str(mrb, E_RUNTIME_ERROR, mesg ? mesg_str : mrb_str_new_lit(mrb, "")));
```

The callers in mruby-io, mruby-socket and mruby-process pass the name of the failing call, so such a build saw `RuntimeError: socket` and could not tell whether the address family was unsupported or the process was out of descriptors. A caller with nothing to name, which is the shape CRuby uses wherever the call works on no object, raised an exception with an empty message.

The errno now goes into the message, which reads `errno: <number>`, with ` - <mesg>` appended when a message was given. The word order follows what mruby-errno already builds in `mrb_sce_init()`: the error first, then after a dash the object the call was working on.

The comment over the function is rewritten with it. What it said about the fallback is that `SystemCallError` being undefined is one way to arrive there and a `_sys_fail` that returns instead of raising is the other, and both are still true: `mrb_funcall_argv()` propagates an exception rather than returning, so the second way needs a `SystemCallError` that came from somewhere other than mruby-errno. The rest of what it said was written as a guess about the code and is dropped.

### Only the number is spelled out

Naming the code rather than numbering it takes a table of them, and that table is what mruby-errno is. Reaching for `strerror()` in the core would link the platform's error table into every build, including every build that has mruby-errno and therefore never reaches this path. The number is what the core can say on its own, and it is enough to look up.

### Testing it needs a state with no gems

The core test state is `mrb_open_core()` and nothing else, so `SystemCallError` is not defined there and the fallback is reachable as it stands. What is not reachable from Ruby is the errno: it is a C one, which is why `mrbgems/mruby-test/sysfail.c` adds a method that sets it before calling. The same file publishes whether the state has `SystemCallError`, so the test says what it depends on rather than assuming it.

That file comes first, on its own, because the test in the second commit needs it to exist. It is the shape `vformat.c` and `notimplement.c` already have in this gem.

### The prose that describes this message is all in one gem

mruby-socket is the only place in the tree that says what `mrb_sys_fail()` raises where `SystemCallError` is not defined, and it says it three times. The last commit brings all three to the new message.

Two of them are the reason the gem takes mruby-errno as a test dependency: the tests need to tell `EAFNOSUPPORT` from any other `socket()` failure, and only that gem gives them a class to match on. Both were written against the message the path used to carry, so the reason to take the dependency is no longer that there is no errno to see but that there is still no class to rescue.

The third sits in the Windows port, over the table mapping a Winsock code to an errno, and named `SystemCallError` as what an unknown code arrives as. That was never the only answer, for the same reason the other two give: the dependency on mruby-errno here is a test one. What the fallback to `EIO` is for is the errno rather than the class carrying it, and now that the class is not the only thing that reports the number, the comment can say which build gives which. `ports/win` is not compiled on this host, so the Size table below is unaffected by it.

Nothing else in the tree makes a claim this changes. mruby-io, mruby-dir and mruby-process call `mrb_sys_fail()` without saying what it raises, `mruby-process/README.md` describes only the path a build with the gem takes, and mruby-errno's own documentation is about the class rather than its absence.

## Behaviour

Only builds with no `SystemCallError` change:

| Call | mruby-errno present | mruby-errno absent, before | mruby-errno absent, after |
|---|---|---|---|
| `File.open("/nonexistent-xyz")` | `Errno::ENOENT: No such file or directory - open /nonexistent-xyz` | `RuntimeError: open /nonexistent-xyz` | `RuntimeError: errno: 2 - open /nonexistent-xyz` |
| `Process.kill(:TERM, 4194303)` | `Errno::ESRCH: No such process - kill` | `RuntimeError: kill` | `RuntimeError: errno: 3 - kill` |
| `Process.waitpid(4194303)` | `Errno::ECHILD: No child processes - waitpid` | `RuntimeError: waitpid` | `RuntimeError: errno: 10 - waitpid` |

The first column is what CRuby is comparable against, and this PR does not touch it: CRuby always has `Errno`, so the path that changed is one no CRuby program has a counterpart for.

## Size

`bin/mruby` `.text`, from `size -A`, over the five builds in `build_config/ci/gcc-clang.rb`. Base is a312d657.

| Build | master | this PR | delta |
|---|---:|---:|---:|
| `bintest` | 1,099,430 | 1,099,494 | +64 |
| `ascii-ctype` | 1,094,678 | 1,094,742 | +64 |
| `byte-string` | 1,074,374 | 1,074,438 | +64 |
| `cxx_abi` | 1,087,285 | 1,087,349 | +64 |
| `full-debug` (-O0) | 1,898,438 | 1,898,486 | +48 |

The growth is the `mrb_format()` call and the append that follow it.

## Testing

- Every commit built and tested on its own with the default config: 2,445 assertions at the `mruby-test` commit, 2,446 at the other two, 0 KO and 0 crashes throughout.
- `MRUBY_CONFIG=ci/gcc-clang rake -m test` at the tip: all five builds green, 2,604 to 2,685 assertions each, 0 KO and 0 crashes throughout, plus the 145 of the bintest run. The new test is not among the skips in any of them.
- The new test was pinned by restoring master's `src/error.c` under it: it then reports `Fail: mrb_sys_fail without SystemCallError (core)` and the run ends 1 KO, so it is discriminating rather than passing by not running.
- The messages in the Behaviour table were read off three binaries: CRuby 4.0.6, an `mruby` from the default config, and one built from a gembox holding mruby-io and mruby-process but not mruby-errno.

## Environment

<details>
<summary>Host, toolchain, and the compile lines behind the Size table</summary>

| | |
|---|---|
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-30-generic x86_64 |
| CPU | AMD Ryzen 9 5950X 16-Core, 32 threads |
| C compiler | Homebrew clang 22.1.8, x86_64-unknown-linux-gnu |
| binutils | GNU ld and ar 2.47.20260726 |
| CRuby | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM |
| rake | 13.3.1 |

`cxx_abi` builds mruby as C++ through the same `clang` driver with `-x c++ -std=gnu++03`; `clang++` only links it.

Compile lines as `rake --verbose` printed them, with `-MMD -c`, `-I`, `-o` and `-ffile-prefix-map` dropped:

```console
# bintest
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -DMRB_GC_FIXED_ARENA -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK

# ascii-ctype
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -DMRB_USE_ASCII_CTYPE -DMRB_REGEXP_PARSE_DEPTH_LIMIT=512 -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# byte-string
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# cxx_abi
clang -g -O3 -Wall -Wundef -Wwrite-strings -Wzero-length-array -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# full-debug
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added test support for simulating system-call failures with configurable error numbers and messages.

* **Bug Fixes**
  * Improved fallback error messages to include the numeric error code, with optional descriptive text.
  * Clarified Windows socket error handling when standard system error classes are unavailable.

* **Tests**
  * Added coverage for system-call failures without `SystemCallError`, including formatted error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->