### PR TITLE
mruby-process: name nothing in the error `kill` and `waitpid` raise

### DIFF
--- a/mrbgems/mruby-process/src/process.c
+++ b/mrbgems/mruby-process/src/process.c
@@ -206,7 +206,12 @@ process_kill(mrb_state *mrb, mrb_value self)
   for (i = 0; i < argc; i++) {
     mrb_int pid = mrb_process_int_arg(mrb, mrb_as_int(mrb, pids[i]), "pid");
     if (mrb_hal_process_kill(mrb, pid, signo) != 0) {
-      mrb_sys_fail(mrb, "kill");
+      /* What a SystemCallError message carries after the error itself is the
+         object the call was working on, the way `File.open` names the path it
+         could not open.  Signalling a process works on no such object, and
+         CRuby names nothing here.  Passing the name of the call instead would
+         put a word in the message that CRuby never prints. */
+      mrb_sys_fail(mrb, NULL);
     }
   }
   return mrb_int_value(mrb, argc);
@@ -231,11 +236,12 @@ wait_for_child(mrb_state *mrb, mrb_value *statusp)
      every port refuses the same values. */
   if (flags < 0 || (flags & ~(mrb_int)MRB_PROCESS_WAIT_FLAGS) != 0) {
     errno = EINVAL;
-    mrb_sys_fail(mrb, "waitpid");
+    mrb_sys_fail(mrb, NULL);
   }
 
+  /* A wait names no object either, so both failures report the error alone. */
   if (mrb_hal_process_waitpid(mrb, pid, (unsigned int)flags, &result_pid, &raw_status) != 0) {
-    mrb_sys_fail(mrb, "waitpid");
+    mrb_sys_fail(mrb, NULL);
   }
   if (result_pid == 0) {
     /* MRB_PROCESS_WAIT_NOHANG and nothing had finished */

--- a/mrbgems/mruby-process/test/process.rb
+++ b/mrbgems/mruby-process/test/process.rb
@@ -91,6 +91,16 @@ assert('Process.waitpid with a flag it does not define') do
   end
 end
 
+assert('Process.waitpid reports the error by itself') do
+  # What a SystemCallError message carries after the error is the object the
+  # call was working on, the way `File.open` names the path it could not open.
+  # A wait has no such object and CRuby names nothing here.  Compared against
+  # the text this platform gives that errno rather than against a literal, so
+  # the wording itself is not pinned.
+  e = assert_raise(Errno::EINVAL) { Process.waitpid(-1, 4) }
+  assert_equal SystemCallError.new(e.errno).message, e.message
+end
+
 assert('Process.kill with signal 0') do
   # Signal 0 sends nothing; it only asks whether the process can be signalled.
   assert_equal 1, Process.kill(0, Process.pid)
@@ -438,6 +448,23 @@ assert('Process.waitpid with no child to wait for') do
   Process.waitpid(pid)
   assert_raise(Errno::ECHILD) { Process.waitpid(pid) }
   io.close
+end
+
+assert('Process.kill reports the error by itself') do
+  # Signalling names no object either, so its message is the error alone.  A
+  # reaped pid is one nothing answers to any more, which is how the failure is
+  # reached without naming a process that might belong to someone else.
+  skip ProcessTestUtil.child_reason if ProcessTestUtil.child_reason
+  io = ProcessTestUtil.spawn("exit 0")
+  skip "IO.popen is not available" unless io
+
+  io.read
+  pid = io.pid
+  Process.waitpid(pid)
+  io.close
+
+  e = assert_raise(Errno::ESRCH) { Process.kill(0, pid) }
+  assert_equal SystemCallError.new(e.errno).message, e.message
 end
 
 assert('Process.wait') do

--- a/mrbgems/mruby-socket/mrbgem.rake
+++ b/mrbgems/mruby-socket/mrbgem.rake
@@ -12,8 +12,8 @@ MRuby::Gem::Specification.new('mruby-socket') do |spec|
   # The tests need to tell one socket() failure from another - notably
   # EAFNOSUPPORT, which is what a host without IPv6 answers and is a
   # reason to skip a test rather than fail it. Without this gem
-  # mrb_sys_fail raises a bare RuntimeError whose message is just
-  # "socket", carrying no errno to match on. A test dependency rather
+  # mrb_sys_fail raises a RuntimeError that spells the errno as a bare
+  # number, leaving no class to match on. A test dependency rather
   # than a runtime one: the library itself works without Errno being
   # defined, only the tests need to name it.
   spec.add_test_dependency('mruby-errno', :core => 'mruby-errno')

--- a/mrbgems/mruby-socket/ports/win/socket_hal.c
+++ b/mrbgems/mruby-socket/ports/win/socket_hal.c
@@ -51,8 +51,10 @@ mrb_hal_socket_final(mrb_state *mrb)
 
 /* Map a Winsock error code to a POSIX errno value. Each case is guarded
  * with #ifdef so older MSVC CRTs that lack a particular Exxx still build;
- * unknown codes fall back to EIO so mrb_sys_fail still produces a non-zero
- * SystemCallError rather than reporting "success." */
+ * unknown codes fall back to EIO so that the errno mrb_sys_fail reports is
+ * still a failure rather than "success." Which exception carries it is the
+ * build's business: Errno::EIO where mruby-errno is present, a RuntimeError
+ * spelling the number where it is not. */
 static int
 wsa_to_errno(int wsa_err)
 {

--- a/mrbgems/mruby-socket/test/udpsocket.rb
+++ b/mrbgems/mruby-socket/test/udpsocket.rb
@@ -17,8 +17,8 @@ assert('UDPSocket.new(AF_INET6)') do
   # EAFNOSUPPORT specifically, not any failure: every other errno from
   # socket() is a real fault and should still fail the run. Naming it
   # needs Errno, which is why mrbgem.rake takes mruby-errno as a test
-  # dependency - without it this raises a bare RuntimeError("socket")
-  # and there is nothing to match on.
+  # dependency - without it this raises a RuntimeError that spells the
+  # errno as a bare number, and there is no class to match on.
   begin
     s = UDPSocket.new(Socket::AF_INET6)
   rescue Errno::EAFNOSUPPORT => e

--- a/mrbgems/mruby-test/driver.c
+++ b/mrbgems/mruby-test/driver.c
@@ -27,6 +27,7 @@ extern const uint8_t mrbtest_assert_irep[];
 void mrbgemtest_init(mrb_state* mrb);
 void mrb_init_test_vformat(mrb_state* mrb);
 void mrb_init_test_notimplement(mrb_state* mrb);
+void mrb_init_test_sysfail(mrb_state* mrb);
 
 /* Print a short remark for the user */
 static void
@@ -264,6 +265,7 @@ mrb_init_test_driver(mrb_state *mrb, mrb_bool verbose)
 
   mrb_init_test_vformat(mrb);
   mrb_init_test_notimplement(mrb);
+  mrb_init_test_sysfail(mrb);
 
   if (verbose) {
     mrb_gv_set(mrb, mrb_intern_lit(mrb, "$mrbtest_verbose"), mrb_true_value());

--- a/mrbgems/mruby-test/sysfail.c
+++ b/mrbgems/mruby-test/sysfail.c
@@ -1,0 +1,42 @@
+/*
+** sysfail.c - reach `mrb_sys_fail()` from Ruby
+**
+** `mrb_sys_fail()` reports the errno through SystemCallError when that class
+** is there, and mruby-errno is what defines it. A build without that gem
+** takes the other path, and the core test state is such a build: it holds
+** `mrb_open_core()` and nothing else. Nothing reachable from Ruby in that
+** state makes the call, and the errno it reads is a C one, so testing either
+** path needs a method that sets errno and calls it.
+*/
+
+#include <errno.h>
+#include <mruby.h>
+#include <mruby/class.h>
+#include <mruby/error.h>
+#include <mruby/string.h>
+
+static mrb_value
+sf_s_fail(mrb_state *mrb, mrb_value klass)
+{
+  mrb_int no;
+  mrb_value mesg = mrb_nil_value();
+
+  mrb_get_args(mrb, "i|S!", &no, &mesg);
+  errno = (int)no;
+  mrb_sys_fail(mrb, mrb_nil_p(mesg) ? NULL : RSTRING_CSTR(mrb, mesg));
+  /* not reached */
+  return mrb_nil_value();
+}
+
+void
+mrb_init_test_sysfail(mrb_state *mrb)
+{
+  struct RClass *c = mrb_define_class(mrb, "TestSysFail", mrb->object_class);
+
+  mrb_define_class_method(mrb, c, "fail", sf_s_fail, MRB_ARGS_ARG(1, 1));
+
+  /* Which path the tests can expect is decided by the state they run in, and
+  ** asking here keeps that answer next to the call it decides for. */
+  mrb_define_const(mrb, c, "SYSTEM_CALL_ERROR_DEFINED",
+                   mrb_bool_value(mrb_class_defined_id(mrb, MRB_SYM(SystemCallError))));
+}

--- a/src/error.c
+++ b/src/error.c
@@ -577,17 +577,16 @@ mrb_make_exception(mrb_state *mrb, mrb_value exc, mrb_value mesg)
  * its `_sys_fail` method with the current `errno` and an optional
  * message. This typically results in a SystemCallError being raised.
  *
- * If SystemCallError is not defined, or if the call to `_sys_fail`
- * itself fails (which shouldn't happen in normal circumstances but leads
- * to mrb_raise), it falls back to raising a RuntimeError with the
- * given message (or a default message if `mesg` is NULL, though the
- * current implementation would pass NULL to mrb_raise which might be
- * an issue).
+ * If SystemCallError is not defined, or if `_sys_fail` returns instead of
+ * raising, it falls back to raising a RuntimeError reading
+ * "errno: <number>", with " - <mesg>" appended when a message was given.
+ * Only the number is spelled out: naming the code takes a table of them,
+ * and that table is what mruby-errno is.
  *
  * mrb: The mruby state.
- * mesg: An optional C string message to append to the error. If NULL,
- *       a default message or no message might be used depending on the
- *       error path.
+ * mesg: An optional C string naming what the failed call was working on,
+ *       appended after the error itself the way CRuby appends a path.
+ *       Pass NULL when the call names nothing, as `kill(2)` does.
  */
 MRB_API mrb_noreturn void
 mrb_sys_fail(mrb_state *mrb, const char *mesg)
@@ -605,7 +604,18 @@ mrb_sys_fail(mrb_state *mrb, const char *mesg)
     }
   }
 
-  mrb_exc_raise(mrb, mrb_exc_new_str(mrb, E_RUNTIME_ERROR, mesg ? mesg_str : mrb_str_new_lit(mrb, "")));
+  /* Reached where SystemCallError is not defined, and also where a
+     `_sys_fail` that does not raise returns here. Either way no class is
+     carrying the errno and nothing else will ever report it. Without it the
+     exception says only what the caller passed, which names the call that
+     failed but never why, and says nothing at all when the caller had
+     nothing to name. */
+  mrb_value str = mrb_format(mrb, "errno: %i", no);
+  if (mesg != NULL) {
+    mrb_str_cat_lit(mrb, str, " - ");
+    mrb_str_append(mrb, str, mesg_str);
+  }
+  mrb_exc_raise(mrb, mrb_exc_new_str(mrb, E_RUNTIME_ERROR, str));
 }
 
 /*

--- a/test/t/sysfail.rb
+++ b/test/t/sysfail.rb
@@ -1,0 +1,15 @@
+##
+# mrb_sys_fail with no SystemCallError
+
+assert('mrb_sys_fail without SystemCallError') do
+  # With mruby-errno the errno goes to SystemCallError and none of this
+  # applies. The core test state has no gems, so the tests below hold, but
+  # say what they depend on rather than assume it.
+  skip 'SystemCallError is defined' if TestSysFail::SYSTEM_CALL_ERROR_DEFINED
+
+  e = assert_raise(RuntimeError) { TestSysFail.fail(2) }
+  assert_equal 'errno: 2', e.message
+
+  e = assert_raise(RuntimeError) { TestSysFail.fail(2, 'wilma') }
+  assert_equal 'errno: 2 - wilma', e.message
+end


### PR DESCRIPTION
Stacked on #7412, which is the first three of the four commits here. Only the last one belongs to this PR; it can be read on its own, and merging #7412 first leaves this diff at that commit alone.

## Summary

What a `SystemCallError` message carries after the error itself is the object the call was working on, the way `File.open` names the path it could not open. Signalling a process and waiting for one work on no such object, and CRuby names nothing in either message. Both were passing the name of the call, which put a word in the message that CRuby never prints.

## Changes

| File | What |
|---|---|
| `mrbgems/mruby-process/src/process.c` | `Process.kill` and the wait behind `Process.waitpid` name nothing in `mrb_sys_fail()` |
| `mrbgems/mruby-process/test/process.rb` | pins that the message is the error alone |

### The suffix carries the object, not the call

CRuby appends to a `SystemCallError` message wherever there is something for the message to name, and `kill(2)` has nothing:

```ruby
Process.kill(:TERM, 4194303)   #=> Errno::ESRCH: No such process
Process.waitpid(4194303)       #=> Errno::ECHILD: No child processes
Process.waitpid(-1, 999)       #=> Errno::EINVAL: Invalid argument
File.open("/nonexistent")      #=> Errno::ENOENT: No such file or directory @ rb_sysopen - /nonexistent
```

mruby was reading the suffix as the name of the failing C call instead:

```ruby
Process.kill(:TERM, 4194303)   #=> Errno::ESRCH: No such process - kill
Process.waitpid(4194303)       #=> Errno::ECHILD: No child processes - waitpid
```

The three call sites here are brought to what CRuby prints, and nothing else is. The rest of the tree is mixed: of the calls to `mrb_sys_fail()` in `src` and the gems, 39 pass the name of the call, 14 pass the path or pair of paths they were working on, and five pass `0`. Which of those CRuby would name and which it would not is a separate question per call, and the answer for `kill(2)` and `waitpid(2)` is the one read off CRuby above.

### The tests do not pin the wording

What the platform words an errno as is the platform's business, so the tests compare the message against the text this platform gives that same errno rather than against a literal:

```ruby
e = assert_raise(Errno::EINVAL) { Process.waitpid(-1, 4) }
assert_equal SystemCallError.new(e.errno).message, e.message
```

Equal means nothing was appended. The `Process.kill` case needs a pid that nothing answers to, and takes a reaped one rather than naming a number that might belong to another process.

`Process.pid` and `Process.ppid` keep the names they pass. `getpid(2)` and `getppid(2)` cannot fail, so CRuby has no message there to match and nothing says what those should read.

## Behaviour

| Call | Before | After | CRuby 4.0.6 |
|---|---|---|---|
| `Process.kill(:TERM, <unused pid>)` | `Errno::ESRCH: No such process - kill` | `Errno::ESRCH: No such process` | `Errno::ESRCH: No such process` |
| `Process.waitpid(<reaped pid>)` | `Errno::ECHILD: No child processes - waitpid` | `Errno::ECHILD: No child processes` | `Errno::ECHILD: No child processes` |
| `Process.waitpid(-1, 4)` | `Errno::EINVAL: Invalid argument - waitpid` | `Errno::EINVAL: Invalid argument` | `Errno::EINVAL: Invalid argument` |

The exception classes are unchanged.

## Size

`bin/mruby` `.text`, from `size -A`, over the five builds in `build_config/ci/gcc-clang.rb`. Base is 6d614d65, the tip of #7412, so the column shows this commit alone.

| Build | #7412 | this PR | delta |
|---|---:|---:|---:|
| `bintest` | 1,099,494 | 1,099,478 | -16 |
| `ascii-ctype` | 1,094,742 | 1,094,726 | -16 |
| `byte-string` | 1,074,438 | 1,074,422 | -16 |
| `cxx_abi` | 1,087,349 | 1,087,333 | -16 |
| `full-debug` (-O0) | 1,898,486 | 1,898,470 | -16 |

Three calls no longer set up a string argument.

## Testing

- `rake -m test` with the default config: 2,448 assertions, 0 KO, 0 crashes.
- `MRUBY_CONFIG=ci/gcc-clang rake -m test`: all five builds green, 2,606 to 2,687 assertions each, 0 KO and 0 crashes throughout, plus the 145 of the bintest run.
- Both new tests were pinned by restoring the old arguments to `mrb_sys_fail()`: they then report `Fail: Process.waitpid reports the error by itself` and `Fail: Process.kill reports the error by itself`.
- The CRuby column of the Behaviour table was read off ruby 4.0.6.

## Environment

<details>
<summary>Host, toolchain, and the compile lines behind the Size table</summary>

| | |
|---|---|
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-30-generic x86_64 |
| CPU | AMD Ryzen 9 5950X 16-Core, 32 threads |
| C compiler | Homebrew clang 22.1.8, x86_64-unknown-linux-gnu |
| binutils | GNU ld and ar 2.47.20260726 |
| CRuby | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM |
| rake | 13.3.1 |

`cxx_abi` builds mruby as C++ through the same `clang` driver with `-x c++ -std=gnu++03`; `clang++` only links it.

Compile lines as `rake --verbose` printed them, with `-MMD -c`, `-I`, `-o` and `-ffile-prefix-map` dropped:

```console
# bintest
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -DMRB_GC_FIXED_ARENA -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK

# ascii-ctype
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -DMRB_USE_ASCII_CTYPE -DMRB_REGEXP_PARSE_DEPTH_LIMIT=512 -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# byte-string
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# cxx_abi
clang -g -O3 -Wall -Wundef -Wwrite-strings -Wzero-length-array -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# full-debug
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved system error messages to report platform errno details consistently.
  - When specialized system-call errors are unavailable, fallback errors now include the errno number and optional operation context.
  - Standardized process error messages to omit misleading operation names.

- **Tests**
  - Added coverage for process failures, errno-only messages, and fallback error formatting across supported configurations.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->