### PR TITLE
amalgam: leave out the port an external HAL provider replaced

### DIFF
--- a/lib/mruby/amalgam.rb
+++ b/lib/mruby/amalgam.rb
@@ -724,10 +724,13 @@ module MRuby
       source_dirs = ["#{gem.dir}/src", "#{gem.dir}/core"].select { |d| File.directory?(d) }
       @build.effective_ports.each do |port|
         port_dir = "#{gem.dir}/ports/#{port}"
-        if File.directory?(port_dir)
-          source_dirs << port_dir
-          break
-        end
+        next unless File.directory?(port_dir)
+        # An external HAL provider supplies these entry points instead, and
+        # List#resolve_external_hal! has already dropped the port's objs from
+        # the build.  The sources have to go with them, or the amalgam ends up
+        # with both definitions.
+        source_dirs << port_dir unless (gem.port_objs & gem.objs).empty?
+        break
       end
       sources = source_dirs.flat_map { |d| Dir.glob("#{d}/**/*.c") }.sort
         .map { |s| File.expand_path(s) }


### PR DESCRIPTION
# Summary

A gem named `hal-<short>-<conf>` is the external HAL provider for the gem whose name ends in `<short>`, and `MRuby::Gem::List#resolve_external_hal!` drops the target gem's `ports/<name>/` objects from the build so that only the provider's implementation is compiled.

`MRuby::Amalgam#gem_source_files` never saw that. It resolved the port directory on its own, from `Build#effective_ports` plus a directory listing, so the amalgam emitted the in-gem port and the provider side by side and every HAL entry point was defined twice. The ordinary build of the same config links and runs; only the amalgam it generates is broken.

# Changes

| File | What changed |
| --- | --- |
| `lib/mruby/amalgam.rb` | `gem_source_files` emits a gem's port sources only while the port's objects are still in the gem's object list |

### The port sources follow the port objects

`resolve_external_hal!` records its decision in one place: it removes the port's objects from `Gem::Specification#objs`, leaving `#port_objs` intact. Asking whether the two still intersect is therefore the same question the linker answers, and it is asked at the point where the sources are collected:

```ruby
source_dirs << port_dir unless (gem.port_objs & gem.objs).empty?
```

A gem with no `ports/` tree has an empty `port_objs` and is untouched. A gem whose port survived intersects and is emitted as before.

# Behaviour

With `mruby-task` and a `hal-task-*` provider in the same build, before this change:

```
$ clang -I. -c mruby.c
mruby.c: error: redefinition of 'mrb_hal_task_init'
mruby.c: error: redefinition of 'mrb_hal_task_final'
mruby.c: error: redefinition of 'mrb_task_enable_irq'
mruby.c: error: redefinition of 'mrb_task_disable_irq'
mruby.c: error: redefinition of 'mrb_hal_task_idle_cpu'
mruby.c: error: redefinition of 'mrb_hal_task_sleep_us'
```

After, `mruby.c` compiles, links and runs, and carries one definition of each. The ordinary build of that config was already correct both times: `libmruby.a` holds `hal_task_dummy.o` and no `task_hal.o`.

Ports of gems that have no provider are unaffected. The same amalgam still carries `mruby-io`, `mruby-socket`, `mruby-dir`, `mruby-signal` and `mruby-process` from `ports/posix/`.

# Testing

A build with no external HAL provider generates a byte for byte identical amalgam. `mruby.c`, `mruby.h` and `mruby_compiler.c` from the default gembox plus `mruby-task`, compared between `master` and this branch:

```
$ cmp plain-master/host/amalgam/mruby.c plain-after/host/amalgam/mruby.c
$ cmp plain-master/host/amalgam/mruby.h plain-after/host/amalgam/mruby.h
$ cmp plain-master/host/amalgam/mruby_compiler.c plain-after/host/amalgam/mruby_compiler.c
```

The reproduction uses a stand-in provider gem `hal-task-dummy` that defines the six HAL entry points and nothing else, loaded next to `mruby-task` with `conf.ports :posix`.

`rake -m test` on the default config: 2445 assertions and 128 bintests, 0 failures, 0 crashes.

# Environment

<details>

```
Linux 7.0.0-30-generic x86_64
Homebrew clang version 22.1.8 (Target: x86_64-unknown-linux-gnu)
GNU ld (GNU Binutils) 2.47.20260726
ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux]
```

The amalgam was compiled and linked with

```
clang -I<amalgam dir> -c <amalgam dir>/mruby.c -o mruby.o
clang -I<amalgam dir> -c <amalgam dir>/mruby_compiler.c -o mruby_compiler.o
clang -I<amalgam dir> main.c mruby.o mruby_compiler.o -lm -o amalgam
```

where `main.c` opens an `mrb_state`, runs `puts` through `mrb_load_string` and closes it.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate port entry points when an external provider supplies them.
  * Improved source handling so only necessary port files are included in builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->