### PR TITLE
mruby-regexp: state the README as the answers a reader comes for

### DIFF
--- a/mrbgems/mruby-regexp/README.md
+++ b/mrbgems/mruby-regexp/README.md
@@ -91,8 +91,10 @@ re = Regexp.new("pattern", Regexp::IGNORECASE)
 re = Regexp.compile("pattern")    # Regexp.new under its other name
 re = /pattern/i                   # literal syntax
 re.match("string")                # => MatchData or nil
+re.match("string", pos)           # => same, searching from pos
 re.match("string") { |md| ... }   # => block result, or nil if no match
 re.match?("string")               # => true/false
+re.match?("string", pos)          # => same, searching from pos
 re =~ "string"                    # => index or nil
 re === "string"                   # => true/false (for case/when)
 re.match(:symbol)                 # a Symbol is matched against its name
@@ -132,8 +134,10 @@ md.regexp                         # => the Regexp that matched
 
 # String methods
 str.match(re)                     # => MatchData or nil
+str.match(re, pos)                # => same, searching from pos
 str.match(re) { |md| ... }        # => block result, or nil if no match
 str.match?(re)                    # => true/false
+str.match?(re, pos)               # => same, searching from pos
 str =~ re                         # => index or nil
 str.sub(re, replacement)          # replace first occurrence
 str.sub(re) { |m| ... }           # replace with block
@@ -145,6 +149,8 @@ str.gsub!(re, replacement)        # => self, or nil if no match
 str.gsub!(re) { |m| ... }         # same, replacing with the block result
 str.scan(re)                      # => array of matches
 str.split(re)                     # => array of parts
+str.split(re, limit)              # => same, at most limit parts; a negative
+                                  #    limit keeps the trailing empty ones
 str[re]                           # => matched substring or nil
 str[re, capture]                  # => capture by index or name
 str.slice(re)                     # => same as str[re]
@@ -163,11 +169,14 @@ str.byterindex(re, pos)           # => same, at or before byte pos
 str.partition(re)                 # => [before, match, after]
 str.rpartition(re)                # => [before, last match, after]
 str.start_with?(re)               # => true/false (anchored at the start)
+str.start_with?(re, "s", ...)     # => true where any one of them does
 
 # Symbol methods (the String methods applied to the symbol's name)
 sym.match(re)                     # => MatchData or nil
+sym.match(re, pos)                # => same, searching from pos
 sym.match(re) { |md| ... }        # => block result, or nil if no match
 sym.match?(re)                    # => true/false
+sym.match?(re, pos)               # => same, searching from pos
 sym =~ re                         # => index or nil
 sym[re]                           # => matched substring or nil
                                   #    (Symbol#[] comes from mruby-symbol-ext)

--- a/mrbgems/mruby-regexp/README.md
+++ b/mrbgems/mruby-regexp/README.md
@@ -255,104 +255,64 @@ Every entry is a place this engine answers a pattern differently from CRuby.
 ## Configuration
 
 ```c
-/* Maximum step count for backtracking engine (ReDoS protection) */
+/* Steps one backtracking search may take (ReDoS protection) */
 #ifndef MRB_REGEXP_STEP_LIMIT
 #define MRB_REGEXP_STEP_LIMIT 1000000
 #endif
 
-/* Maximum height of the backtracking engine's stack (heap) */
+/* Entries on the backtracking engine's heap stack (1 to 16,777,216) */
 #ifndef MRB_REGEXP_STACK_LIMIT
 #define MRB_REGEXP_STACK_LIMIT 2048
 #endif
 
-/* How deep a pattern may nest (the parser's own C stack) */
+/* How deep a pattern may nest, the parser's own C stack (1 to 1,048,576) */
 #ifndef MRB_REGEXP_PARSE_DEPTH_LIMIT
 #define MRB_REGEXP_PARSE_DEPTH_LIMIT 4096
 #endif
 ```
 
-A search that reaches either limit raises `RegexpError`, `step limit over
-(MRB_REGEXP_STEP_LIMIT)` or `stack limit over (MRB_REGEXP_STACK_LIMIT)`,
-rather than answer with what it had found by then. The step limit bounds
-the work one search may do; the stack limit bounds the state it holds while
-doing it: the branches it has not taken yet and the writes it has not taken
-back, an entry each. A write of the value already in the slot leaves nothing
-to take back and is not counted. What a repetition spends per iteration is
-what it holds: one choice point where it captures nothing, and undo records
-on top of that for a capture (up to two writes to open a group and one to
-close it, an iteration that opens one the attempt has not closed yet paying
-for one of the two) and for the record of an iteration that may match empty.
-A run longer than the limit reaches it on a pattern that is not pathological;
-a build with the memory for it can set it higher, and one that wants a
-smaller ceiling can set it lower.
+A build that sets a limit outside its range fails to compile, and so does one
+still defining `MRB_REGEXP_RECURSION_LIMIT`, the name the stack limit had while
+it counted C frames. The values a build chose are `Regexp::STEP_LIMIT` and
+`Regexp::STACK_LIMIT`, for a program that has to size a subject or a pattern to
+the build it runs on; CRuby's counterpart is `Regexp.timeout`.
 
-The default is where the state moving off the C stack costs no pattern the
-subject it used to match, and no higher. The limit that preceded it counted
-C frames, and a frame is not an entry: a fork was one frame and is one
-choice point, while a capture was one frame and is up to three undo records.
-Of the shapes measured across that change the tightest is `(a)*?b`, which
-crossed 498 characters on the old 1,000 frames and crosses 682 on 2,048
-entries; a chain of atomic groups or of lookarounds, which spent two frames
-a link and now spends none once each has closed, is bounded by the pattern
-rather than by this limit either way.
+### The two search limits
 
-The limit stands between 1 and 16,777,216, and a build that sets it outside
-that fails to compile: at 0 no search could hold one entry, and above the
-ceiling the arithmetic that sizes the arrays stops holding on a 32-bit ABI.
-A low limit is a build's to choose, and what it buys is memory at the price
-of the patterns the engine will match: the gem's tests ask for 48, which is
-where every pattern they take for granted matches, and the assertions that
-reach the engine skip below it while the rest go on running. The two limits
-are set apart from one another as well: a build that turns this one up far
-enough puts it out of the step limit's reach, since filling the stack costs
-a handful of steps an entry, and the tests that pin the stack limit size
-their subjects from it are skipped there. The values a build chose are
-`Regexp::STACK_LIMIT` and `Regexp::STEP_LIMIT`, for a program that has to
-size a subject or a pattern to the build it runs on; CRuby has no
-counterpart, its guard being `Regexp.timeout`.
+A search that reaches one raises `RegexpError`, `step limit over
+(MRB_REGEXP_STEP_LIMIT)` or `stack limit over (MRB_REGEXP_STACK_LIMIT)`, rather
+than answer with what it had found by then. One whose stack the allocator
+refuses to grow raises `NoMemoryError` instead, that being a different thing to
+do something about.
 
-What the stack limit counts is live entries and not bytes. Two arrays hold
-them, one for the branches and one for the writes, and they grow
-geometrically and keep their capacity for the rest of the search, so a search
-that fills one, backtracks, and then fills the other holds both high-water
-marks at once. Neither is grown past the limit, so the memory one search may
-ask for is bounded by it: at most `MRB_REGEXP_STACK_LIMIT` entries in each
-array, an entry being 32 and 16 bytes respectively on a 64-bit ABI and 24 and
-8 on a 32-bit one, so 96 KiB together at the default on a 64-bit build and
-64 KiB on a 32-bit one. Halving the limit halves that ceiling. The capture
-slots and the per-instruction iteration records a search also holds are sized
-by the pattern rather than by this limit.
+The step limit bounds the work one search may do; the stack limit bounds the
+state it holds while doing it, the branches it has not taken yet and the writes
+it has not taken back, an entry each. A write of the value already in the slot
+leaves nothing to take back and is not counted.
 
-A search whose stack the allocator refuses to grow raises `NoMemoryError`
-rather than `RegexpError`. The two are worth telling apart: a limit names the
-knob to turn, where turning `MRB_REGEXP_STACK_LIMIT` up in answer to an
-allocator that had nothing left would only let the next search ask for more.
+The stack limit counts live entries and not bytes, and so bounds the memory one
+search may ask for: two arrays of at most `MRB_REGEXP_STACK_LIMIT` entries, an
+entry being 32 and 16 bytes on a 64-bit ABI and 24 and 8 on a 32-bit one, so 96
+KiB together at the default and 64 KiB respectively. Halving the limit halves
+that ceiling. Lowering it costs patterns as well as buying memory: the gem's
+tests ask for 48, which is where every pattern they take for granted still
+matches, and the assertions that reach the engine skip below it.
 
-The macro was called `MRB_REGEXP_RECURSION_LIMIT` while the engine recursed
-once per fork and the limit counted C frames. A build that still defines that
-name fails to compile: the two limits count different things, so an old value
-does not carry over and the build has to choose a new one.
+### The parse depth limit
 
-`MRB_REGEXP_PARSE_DEPTH_LIMIT` is the third limit and the odd one out: it
-bounds the compiler rather than a search, and what it guards is the C stack
-rather than memory or work. A pattern past it raises `RegexpError`, `parse
-depth limit over`, which is CRuby's message for the same refusal.
-
-Every construct that opens a level costs one: a group of any kind, a
+`MRB_REGEXP_PARSE_DEPTH_LIMIT` bounds the compiler rather than a search, and
+guards the C stack rather than memory or work. A pattern past it raises
+`RegexpError`, `parse depth limit over`, which is CRuby's message for the same
+refusal. Every construct that opens a level costs one: a group of any kind, a
 lookaround, an atomic group, and an inline option toggle, which encloses the
-rest of the group it stands in and so is a level of its own. A pattern of 4096
-nested `(?:` and one of 4096 nested `(?i)` are refused alike, at the same
-depth CRuby refuses them: the default is Onigmo's `ONIG_MAX_PARSE_DEPTH`.
+rest of the group it stands in. The default is Onigmo's
+`ONIG_MAX_PARSE_DEPTH`, so the refusal point is CRuby's.
 
 **A build on a stack smaller than about 3 MiB has to lower it.** The parser
-recurses once per level, so the ceiling is a property of the build's stack
-rather than of the engine, and the default is chosen for the refusal point
-rather than for the stack. A level costs about 600 bytes on a 64-bit build, so
-the deepest pattern the default accepts spends some 2.4 MiB, and so does a
-deeper one before being refused, since the count is reached at the bottom of
-the recursion. Where the stack cannot pay that, the crash the limit exists to
-prevent comes back. The compiler is not the only thing standing on that stack
-either, so a third of it is the share to size the limit from:
+recurses once per level at some 600 bytes a level on a 64-bit build, so the
+deepest pattern the default accepts spends about 2.4 MiB. The compiler is not
+the only thing standing on that stack, so a third of it is the share to size
+the limit from:
 
 | Stack   | A limit that fits           |
 | ------- | --------------------------- |
@@ -361,73 +321,50 @@ either, so a third of it is the share to size the limit from:
 | 256 KiB | 128                         |
 | 64 KiB  | 32                          |
 
-Divide the build's own figure, not this one: `-Os` and a 32-bit ABI both make
-a level cheaper, and `-fstack-usage` over `re_compile.c` names it, the frames
-of `compile_alt` and `compile_seq` summed and the rest inlining into them (560
-bytes on a 64-bit gcc `-O2` build, 528 at `-Os`, 592 on a clang `-O3` one).
+Divide the build's own figure, not this one: `-Os` and a 32-bit ABI both make a
+level cheaper, and `-fstack-usage` over `re_compile.c` names it, the frames of
+`compile_alt` and `compile_seq` summed. Lowering it costs little, since nesting
+this deep is not what a written pattern does: a build that sets 128 still takes
+every pattern anyone writes, and gives up only the CRuby-exact refusal point.
 
-Lowering it costs little. Nesting this deep is not what a written pattern
-does, a handful of levels being ordinary and dozens unusual, so a build that
-sets 128 still takes every pattern anyone writes, and gives up only the
-CRuby-exact refusal point. The limit stands between 1 and 1,048,576, and a
-build that sets it outside that fails to compile.
+### What the build decides
 
-Case folding beyond ASCII is not this gem's to configure. The table is
-core's, carried by any build that defines `MRB_UTF8_STRING` without
-`MRB_USE_ASCII_CTYPE`, and is what `String#downcase` and the four case methods
-beside it read; `/i` reads the two directions it needs over that same table.
-So `/i` folds what the build's own case conversion folds, and a build
-converting case by ASCII has nothing for it to fold beyond ASCII either,
-whether the conversion was narrowed there or the strings are read as bytes and
-hold no character to fold in the first place.
+Case folding beyond ASCII and what a POSIX bracket holds above it are not this
+gem's to configure. Both need a build that defines `MRB_UTF8_STRING` without
+`MRB_USE_ASCII_CTYPE`.
 
-Where the build converts case by Unicode, `/Ā/i` matches `"ā"`, `/Σ/i` matches
-`"σ"`, and `[^Ā]` under `/i` stops accepting `"ā"`.
-
-Where it converts by ASCII, those same patterns do not compile:
+`/i` reads the two directions it needs off core's case table, the one
+`String#downcase` and the four case methods beside it read, so it folds what
+the build's own case conversion folds. There `/Ā/i` matches `"ā"`, `/Σ/i`
+matches `"σ"`, and `[^Ā]` under `/i` stops accepting `"ā"`. Where the build
+converts case by ASCII those same patterns do not compile:
 
 ```ruby
 /Ā/i     # RegexpError: /i needs Unicode case folding for this character
 ```
 
-The test is whether a character has a case folding, not whether it is
-non-ASCII, so a script without case is unaffected and `/日本/i`, `/العربية/i`
-and `/😀/i` go on working. The codepoints that do have one are held as ranges
-rather than one by one, and those ranges are coarse: the uncased codepoints
-inside them are refused with the rest, `ƻ` (U+01BB) among them.
-Patterns like `/Ā/i` were answering wrongly rather than narrowly before this:
-`[Ā]` under `/i` missed `"ā"`, and `[^Ā]` accepted it. Reaching this error
-means the pattern wants a build that converts case by Unicode.
+The test is whether a character has a folding, not whether it is non-ASCII, so
+a script without case is unaffected and `/日本/i`, `/العربية/i` and `/😀/i` go
+on working. The codepoints that do have one are held as ranges, and those
+ranges are coarse: the uncased codepoints inside them are refused with the
+rest, `ƻ` (U+01BB) among them. A codepoint with no single counterpart to fold
+to (`ﬀ` to `ff`) is never folded by either build. `/k/i` matching `"K"`
+(U+212A) and `/s/i` matching `"ſ"` need no table and work on both, though a
+class holding the letter only through `\w`, `[:word:]` or `[:ascii:]` does not
+reach them, those being sets ASCII defines.
 
-`/k/i` matching `"K"` (U+212A) and `/s/i` matching `"ſ"` need no table.
-Those two are the only foldings whose result is an ASCII letter, and both
-builds carry them, so that folding "ASCII only" covers the whole of the
-equivalence class an ASCII letter belongs to rather than the part of it that
-is ASCII. A class holding the letter only through `\w`, `[:word:]` or
-`[:ascii:]` does not reach them: those are sets ASCII defines, so `[\w]`
-under `/i` stays the ASCII word characters and `[^\w]` accepts `"K"` (U+212A),
-as in CRuby. A letter written out beside the shorthand (`[\ws]`) folds as usual.
-
-What a POSIX bracket holds above ASCII is this gem's table, `re_ctype.h`,
-carried on the same condition as the case table: a build that defines
-`MRB_UTF8_STRING` without `MRB_USE_ASCII_CTYPE`. There the brackets classify
-as CRuby's do, `[[:alpha:]]` holding `"あ"` and `[[:^alpha:]]` rejecting it,
-`[[:upper:]]` under `/i` reaching `"ā"` through `"Ā"`, and `[[:word:]]` every
-Unicode word character where `\w` stays ASCII. `\b` and `\B` read the
-bracket's set rather than the shorthand's, and so sit beside a character of
-any script; without the table they read as `[[:word:]]` does on such a build,
-which is the ASCII word characters and no more. The two are not two answers
-to one question: a class can be asked for another way, so the shorthand keeps
-the set CRuby gives it, while a boundary is the one thing a pattern cannot
-spell another way, and takes the set that is useful. The types are the ones the
-Unicode Character Database publishes: `alpha`, `upper` and `lower` are the
-derived properties Alphabetic, Uppercase and Lowercase, `space` is White_Space,
-and the rest are read off the general categories. Without the table a bracket
-holds its ASCII and no character above it, so `[[:alpha:]]` misses `"あ"` and
-`[[:^alpha:]]` takes it, and a build reading its strings by byte answers the
-same, having no character to classify. `[[:xdigit:]]` and `[[:ascii:]]` are
-sets ASCII defines and hold nothing above it on any build. The table is 13.9KB
-of read-only data; `MRB_USE_ASCII_CTYPE` is what leaves it out.
+The POSIX brackets read this gem's own table, `re_ctype.h`, 13.9KB of read-only
+data that `MRB_USE_ASCII_CTYPE` leaves out. With it the brackets classify as
+CRuby's do: `[[:alpha:]]` holds `"あ"` and `[[:^alpha:]]` rejects it,
+`[[:upper:]]` under `/i` reaches `"ā"` through `"Ā"`, and `[[:word:]]` holds
+every Unicode word character where `\w` stays ASCII. `\b` and `\B` read the
+bracket's set rather than the shorthand's, so a boundary sits beside a
+character of any script. The types are the ones the Unicode Character Database
+publishes: `alpha`, `upper` and `lower` are the derived properties Alphabetic,
+Uppercase and Lowercase, `space` is White_Space, and the rest are read off the
+general categories. Without the table a bracket holds its ASCII and no more, so
+`[[:alpha:]]` misses `"あ"`; `[[:xdigit:]]` and `[[:ascii:]]` are sets ASCII
+defines and hold nothing above it on any build.
 
 ## Checking against CRuby
 

--- a/mrbgems/mruby-regexp/README.md
+++ b/mrbgems/mruby-regexp/README.md
@@ -368,105 +368,46 @@ defines and hold nothing above it on any build.
 
 ## Checking against CRuby
 
-Everything under Limitations is a place this engine answers a pattern
-differently from CRuby, and the list is kept by hand. What keeps it honest is
-`tools/difftest`, which runs a corpus through both engines and reports where
-they disagree:
+The Limitations list is kept by hand. What keeps it honest is `tools/difftest`,
+which runs a corpus through both engines and reports where they disagree:
 
 ```console
 $ rake regexp:difftest
 5175 patterns, 101 known differences, no new ones
 ```
 
-The task asks the build the loaded config declares, so a working tree holding
-the builds of several configs still asks the one in hand. A config declaring
-more than one build with this gem in it leaves the choice to `MRUBY`, since a
-baseline describes one build.
+The task asks the build the loaded config declares, and leaves the choice to
+`MRUBY` where a config declares more than one build with this gem in it.
 
-`probe.rb` holds the corpus and runs under either engine. It asks along two
-axes, since a pattern and a character are worth asking about differently.
+`probe.rb` holds the corpus and runs under either engine, asking along two
+axes. The **pattern axis** prints a line per pattern: where a match starts in
+each of a fixed list of subjects, what it captured, and which class it raised,
+the class being part of the answer whether the pattern was refused at compile
+time or the search raised against a subject. The patterns are generated from
+the axes rather than listed, so an escape, a quantifier or a class form is
+covered in every context it can stand in, each asked under `//`, `/i`, `/m` and
+`/x`. The **character axis** turns that around: a line per character, a column
+per way of classifying one. The characters come out of the Unicode Character
+Database by the rule `tools/unicode/corpus_data.rb` states, one out of every
+class the engine's tables tell apart, where a class is the whole signature and
+not one property at a time, plus the whole of ASCII.
 
-The **pattern axis** prints a line per pattern: where a match starts in each of
-a fixed list of subjects, what it captured, and which class it raised. The
-class is part of the answer whether the pattern was refused at compile time or
-the search raised against a subject, since refusing with `RegexpError` and
-refusing with `ArgumentError` are different answers. The patterns are generated
-from the axes rather than listed, so an escape, a quantifier or a class form is
-covered in every context it can stand in — every printable ASCII character
-after a backslash, alone and beside a literal and inside a class and as an end
-of a range; every quantifier on every kind of atom; the groups, the anchors,
-the backreferences and the POSIX brackets. Each is asked under `//`, `/i`,
-`/m` and `/x`, one flag at a time rather than once per combination of them:
-asked once under all eight, no pattern differed under a combination that did
-not already differ under a single flag. The Unicode properties are four
-patterns rather than an axis, since this engine refuses `\p{...}` outright and
-asking it about every property would write the same refusal down once per
-property; what the four are for is the day it stops refusing, when the
-difference stops being one and the line goes GONE.
-
-The **character axis** turns that around: a line per character, a column per
-way of classifying one — the POSIX brackets and their complements, the
-shorthands, the boundaries, `.`, and a few of them under `i`. The characters
-come out of the Unicode Character Database, by the rule
-`tools/unicode/corpus_data.rb` states and written out as `corpus.rb` by `rake
-unicode:generate` with the tables, so a version bump moves the questions with
-the answers.
-
-What that rule takes is one character out of every class the engine's tables
-tell apart, where a class is a whole signature and not one property at a time:
-the general category, the script, which POSIX types hold the character, the
-shape its case folding takes, and the width the encoding spells it in. Taking a
-representative per category and another per script separately would leave the
-combinations of them unasked, and it is a combination that the tables can get
-wrong. Each is the lowest codepoint of its signature, which is the member that
-does not move as Unicode grows, and the whole of ASCII is taken as well.
-
-Picking by rule rather than by hand is what found the `\b` difference above. A
-list written by hand reaches for `Ā` and `ā` to stand for "a letter with a
-case", and those are U+0100 and U+0101 — one codepoint above the Latin-1 table
-where CRuby answers by other rules.
-
-`compare.rb` runs it in both and checks the disagreements against
-`baseline.txt`, which holds the ones that are meant: a construct this engine
-refuses rather than answers wrongly, a byte CRuby settles with the pattern's
-encoding, a boundary the two draw off different tables. Every line in it is one
-of the limitations above. A disagreement that is not in the baseline is what
-the tool is for, and it fails on one; a baseline line that has stopped
-disagreeing fails too, so that a fix prunes the list rather than leaving it to
+`compare.rb` checks the disagreements against `baseline.txt`, which holds the
+ones that are meant, every line in it being one of the limitations above. It
+fails on a disagreement the baseline does not hold and on a baseline line that
+has stopped disagreeing, so that a fix prunes the list rather than leaving it to
 describe an engine that has moved on. `rake regexp:difftest:update` takes a new
-baseline.
+baseline, and `rake regexp:difftest:selftest` puts those verdicts to
+`compare.rb` with answers made up rather than run. Both `probe.rb` and
+`corpus_data.rb` assert their shape rather than their size, so a corpus that has
+quietly shrunk stops the run instead of passing by not looking.
 
-Those three verdicts are the whole of what the tool reports, so
-`rake regexp:difftest:selftest` puts them to `compare.rb` with answers made up
-rather than run: a difference the baseline does not hold, one it holds
-differently, one it holds that has been fixed, and the two cases it has to stay
-quiet about. It runs at the start of every comparison as well, since a mistake
-there is a differential test that passes by not looking. So does the reading of
-the probe's own output, which is the same hazard a line further back: what
-`probe.rb` writes is a protocol, three tab separated fields per answer and one
-`#build` line, and a line of another shape, a label answered twice or a run
-that never said which build it is are each read as a probe to fix rather than
-taken for an answer.
-
-The same task asks the corpus whether it still holds what it says it does. A
-differential test goes quiet two ways, and the second one reads exactly like
-the first: fewer patterns, no disagreement, green. So `probe.rb` asserts its
-shape rather than its size, every escape in every context and every quantifier
-on every atom, with a case out of each axis that is not a product named
-besides; and `corpus_data.rb` reads the corpus back to check that every
-signature the database has really has a character standing for it. Both stop
-the run rather than the count going down unremarked.
-
-Two things bound what it can say, and `compare.rb` refuses rather than
-reporting either as a regression. The characters are chosen out of the Unicode
-release the tables are generated from, so a CRuby carrying an older one would
-call a character it has not heard of nothing at all; the check is `\p{Age=}`
-and CRuby 4.0 is the first that passes it. And a baseline describes the build
-it was taken against, since a build reading its strings as bytes or classifying
-them by ASCII answers differently wherever a table is read.
-
-Both are why this is a task to run rather than a job in the workflows, which
-use whatever CRuby a runner ships.
+Two things bound what the tool can say, and `compare.rb` refuses rather than
+reporting either as a regression: a CRuby carrying an older Unicode release than
+the tables were generated from (the check is `\p{Age=}`, and CRuby 4.0 is the
+first that passes it), and a baseline taken against a build that reads or
+classifies its strings differently. Both are why this is a task to run rather
+than a job in the workflows, which use whatever CRuby a runner ships.
 
 ## License
 

--- a/mrbgems/mruby-regexp/README.md
+++ b/mrbgems/mruby-regexp/README.md
@@ -9,7 +9,7 @@ simulation) with backtracking fallback.
 
 - `.` any character (except newline by default)
 - `*`, `+`, `?` greedy quantifiers
-- `*?`, `+?`, `??` non-greedy quantifiers
+- `*?`, `+?`, `??`, `{n,m}?` non-greedy quantifiers
 - `*+`, `++`, `?+` possessive quantifiers, `a*+` being `(?>a*)`
 - `{n}`, `{n,}`, `{n,m}` repetition counts
 - `[abc]`, `[a-z]`, `[^abc]` character classes
@@ -18,6 +18,7 @@ simulation) with backtracking fallback.
   `cntrl`, `print`, `graph`, `ascii`, `punct`
 - `\d`, `\w`, `\s` digit, word, whitespace shortcuts, ASCII as in CRuby
 - `\D`, `\W`, `\S` negated shortcuts
+- `\h`, `\H` hex digit and non-hex-digit shortcuts
 - `(...)` capture group
 - `(?:...)` non-capturing group
 - `(?#...)` comment group
@@ -53,6 +54,7 @@ Three rules settle what a spelling means:
 ### Character Escapes
 
 - `\n`, `\t`, `\r`, `\f`, `\v`, `\a`, `\e` control characters
+- `\b` backspace inside a character class, where the word boundary cannot stand
 - `\NNN` octal, one to three digits, where the digits spell no backreference
 - `\xHH` hex, one or two digits; `\x` with no digit raises `RegexpError`
 - `\cX`, `\C-X` control characters, `\c?` being DEL as it is in a String

--- a/mrbgems/mruby-regexp/README.md
+++ b/mrbgems/mruby-regexp/README.md
@@ -163,6 +163,27 @@ $&, $`, $', $+, $1, $2, ...       # read from $~ at the moment they are read
                                   #    (all nil while $~ is nil)
 ```
 
+### Named Captures
+
+As in CRuby, a named group anywhere in a pattern renumbers the whole of it: a
+plain `(...)` groups without capturing, and a numbered backreference raises
+`RegexpError` in every spelling (`\1`, `\k<1>`, `\k<-1>`). Refer to a group by
+name instead. A pattern with no named group numbers its groups as usual, and
+`\1`-`\9` work there.
+
+```ruby
+md = /(?<a>a)(b)/.match("ab")
+md.size                          # => 2
+md.captures                      # => ["a"]
+md[:a]                           # => "a"
+md[2]                            # => nil
+
+"aa".match(/(?<n>\w)\k<n>/)[0]   # => "aa"
+
+Regexp.new("(a)(?<b>b)\\1")
+# RegexpError: numbered backref/call is not allowed. (use name)
+```
+
 ## Engine Architecture
 
 The gem uses two execution engines:
@@ -291,29 +312,6 @@ pattern analysis.
   start and keep the last match that qualifies. The cost grows with the
   number of positions a match starts at, where CRuby hands the search to
   Onig.
-
-## Named Captures
-
-As in CRuby, declaring a named group anywhere in a pattern changes how the
-whole pattern is numbered: a plain `(...)` groups without capturing, and a
-numbered backreference is a `RegexpError` in every spelling (`\1`, `\k<1>`,
-`\k<-1>`). Refer to a group by name instead.
-
-```ruby
-md = /(?<a>a)(b)/.match("ab")
-md.size                          # => 2
-md.captures                      # => ["a"]
-md[:a]                           # => "a"
-md[2]                            # => nil
-
-"aa".match(/(?<n>\w)\k<n>/)[0]   # => "aa"
-
-Regexp.new("(a)(?<b>b)\\1")
-# RegexpError: numbered backref/call is not allowed. (use name)
-```
-
-A pattern with no named group numbers its groups as usual, and `\1`-`\9` work
-there.
 
 ## Configuration
 

--- a/mrbgems/mruby-regexp/README.md
+++ b/mrbgems/mruby-regexp/README.md
@@ -88,6 +88,7 @@ and the one next to a `-` bounds the range, so `/[\u{61 62}-z]/` is `a` plus
 ```ruby
 # Regexp
 re = Regexp.new("pattern", Regexp::IGNORECASE)
+re = Regexp.compile("pattern")    # Regexp.new under its other name
 re = /pattern/i                   # literal syntax
 re.match("string")                # => MatchData or nil
 re.match("string") { |md| ... }   # => block result, or nil if no match
@@ -97,9 +98,16 @@ re === "string"                   # => true/false (for case/when)
 re.match(:symbol)                 # a Symbol is matched against its name
 re.source                         # => "pattern"
 re.options                        # => flags integer
+re.casefold?                      # => true where the pattern carries /i
 re.named_captures                 # => {"name" => [group_number], ...}
 re.names                          # => ["name", ...]
+re.to_s                           # => "(?i-mx:pattern)"
+re.inspect                        # => "/pattern/i"
+re == other                       # => true where source and options agree
+re.eql?(other)                    # => same as ==
+re.hash                           # => source and options hashed together
 Regexp.escape("a.b")              # => "a\\.b"
+Regexp.quote("a.b")               # => same as Regexp.escape
 Regexp.last_match(n)              # => nth capture from last match
 
 # MatchData
@@ -110,12 +118,17 @@ md[2]                             # => "host"
 md[:name]                         # named capture access
 md.captures                       # => ["user", "host"]
 md.to_a                           # => ["user@host", "user", "host"]
+md.to_s                           # => "user@host" (same as md[0])
+md.size                           # => group count, group 0 included
+md.length                         # => same as size
 md.begin(0)                       # => match start position
 md.end(0)                         # => match end position
 md.pre_match                      # => string before match
 md.post_match                     # => string after match
 md.named_captures                 # => {"name" => "value", ...}
 md.names                          # => ["name", ...]
+md.string                         # => the subject the match ran against
+md.regexp                         # => the Regexp that matched
 
 # String methods
 str.match(re)                     # => MatchData or nil

--- a/mrbgems/mruby-regexp/README.md
+++ b/mrbgems/mruby-regexp/README.md
@@ -45,8 +45,9 @@ Three rules settle what a spelling means:
   `a{2}{3}` is `(?:a{2}){3}`. `{n}` has no non-greedy form, so `a{3}?` matches
   empty where the lazy `a{3,3}?` does not.
 - `\N` is a backreference where its decimal value is at most 9 or at most the
-  number of groups opened before it, and an octal escape past both. A number no
-  group in the whole pattern carries raises `RegexpError`, so `\1(a)` is valid.
+  number of groups opened before it, and an octal escape past both. A number
+  matching no group anywhere in the pattern raises `RegexpError` at compile
+  time, so `\1(a)` is valid because group 1 appears later.
 - A recursion no input could end (`(?<a>\g<a>)`) raises `RegexpError` at
   compile time, as in CRuby. One that can end is bounded at match time by
   `MRB_REGEXP_STACK_LIMIT`.
@@ -233,18 +234,15 @@ Every entry is a place this engine answers a pattern differently from CRuby.
   fixed-length too, recursion included, or `invalid pattern in look-behind`.
 - **No Unicode properties**: `\p{Alpha}`, `\p{L}` raise `RegexpError`, inside a
   character class as much as outside one. A bare `\p`, and `\pL`, is the
-  letter, as in CRuby. `[[:alpha:]]` asks for a letter of any script.
-- **A set is not an end of a range**: `[a-\d]` and `[\d-z]` raise
-  `RegexpError`, as in CRuby. A `-` at either edge is still a member: `[\d-]`
-  holds the digits and the dash.
-- **No `\M-X` meta escape**: it raises `RegexpError`, as it does in CRuby for a
-  pattern that is not binary.
+  letter. `[[:alpha:]]` asks for a letter of any script.
+- **No `\M-X` meta escape**: it always raises `RegexpError`, where CRuby
+  refuses it only outside a binary pattern.
 - **A `[` inside a class opens something**: only a POSIX bracket is read there.
   A collating element (`[[.a.]]`), an equivalence class (`[[=a=]]`) and a
-  nested class (`[[a][b]]`) raise `RegexpError`. Write `[\[]`, as in CRuby.
+  nested class (`[[a][b]]`) raise `RegexpError`. Write `[\[]`.
 - **No `\G`, `\K`, `\R` or `\X`**: they raise `RegexpError` rather than
   standing for their own letter. Inside a character class each is the letter,
-  as in CRuby, and so is a bare `\g` either way.
+  and so is a bare `\g` either way.
 - **No nest level on a backreference**: `\k<name+n>` and `\k<name-n>` ask for a
   capture memory per call level where this engine keeps one flat slot per
   group, so they raise `RegexpError`. A plain `\k<name>` still works inside a
@@ -254,9 +252,7 @@ Every entry is a place this engine answers a pattern differently from CRuby.
   capture-tracking empty check that answers a few of them differently, among
   them `/((?<g1>|){2}b){2}\g<g1>{0}/` and `/(?<g1>)b\g<g1>{1,3}?/`.
 - **No character class intersection**: `[a&&b]` raises `RegexpError`. A lone
-  `&` is a member of the class, as it is in CRuby.
-- **No `\x{...}` hex escape**: the hex escape is `\xHH`, and `\x{...}` raises
-  `RegexpError` as CRuby does. Write `\u{...}` for a codepoint above `0xff`.
+  `&` is a member of the class.
 - **No encodings**: a byte that starts no whole character is that byte, inside
   a character class as much as outside one. `[\xB5]` and `\xB5` both hold the
   byte `0xB5` and neither matches `µ` (`C2 B5`), where CRuby raises
@@ -266,7 +262,7 @@ Every entry is a place this engine answers a pattern differently from CRuby.
   pattern holding a character that needs a Unicode folding raises
   `RegexpError`; see Configuration.
 - **Case-insensitive backreferences match a superset**: `\1` under `i` folds
-  each side and compares, so it matches across a width change (`k` and `K`)
+  each side and compares, so it matches across a width change (`k` and `K`)
   where CRuby declines to.
 - **`\b` reads `[[:word:]]` below U+0100 too**: CRuby draws a boundary beside
   `²`, `³`, `¹` and `½`, reading a character under 256 off a Latin-1 word table
@@ -373,7 +369,7 @@ a script without case is unaffected and `/日本/i`, `/العربية/i` and `/�
 on working. The codepoints that do have one are held as ranges, and those
 ranges are coarse: the uncased codepoints inside them are refused with the
 rest, `ƻ` (U+01BB) among them. A codepoint with no single counterpart to fold
-to (`ﬀ` to `ff`) is never folded by either build. `/k/i` matching `"K"`
+to (`ﬀ` to `ff`) is never folded by either build. `/k/i` matching `"K"`
 (U+212A) and `/s/i` matching `"ſ"` need no table and work on both, though a
 class holding the letter only through `\w`, `[:word:]` or `[:ascii:]` does not
 reach them, those being sets ASCII defines.

--- a/mrbgems/mruby-regexp/README.md
+++ b/mrbgems/mruby-regexp/README.md
@@ -12,15 +12,10 @@ simulation) with backtracking fallback.
 - `*?`, `+?`, `??` non-greedy quantifiers
 - `*+`, `++`, `?+` possessive quantifiers, `a*+` being `(?>a*)`
 - `{n}`, `{n,}`, `{n,m}` repetition counts
-- a quantifier after a quantifier repeats the repeat: `a**` is `(?:a*)*` and
-  `a{2}{3}` is `(?:a{2}){3}`. `{n}` has no non-greedy form, so its `?` is a
-  quantifier too and `a{3}?` matches empty where the lazy `a{3,3}?` does not
 - `[abc]`, `[a-z]`, `[^abc]` character classes
 - `[[:alpha:]]`, `[[:^alpha:]]` POSIX brackets inside a class: `alpha`,
   `digit`, `alnum`, `upper`, `lower`, `space`, `blank`, `xdigit`, `word`,
-  `cntrl`, `print`, `graph`, `ascii` and `punct`. Above ASCII each holds
-  what CRuby's does where the build classifies characters by Unicode, and
-  nothing where it does not; see Configuration
+  `cntrl`, `print`, `graph`, `ascii`, `punct`
 - `\d`, `\w`, `\s` digit, word, whitespace shortcuts, ASCII as in CRuby
 - `\D`, `\W`, `\S` negated shortcuts
 - `(...)` capture group
@@ -28,55 +23,46 @@ simulation) with backtracking fallback.
 - `(?#...)` comment group
 - `(?<name>...)`, `(?'name'...)` named capture group
 - `|` alternation
-- `\N` backreference: a digit run whose decimal value is at most 9 or at
-  most the number of groups opened before it; a run past both is an octal
-  escape (see below). A reference naming a group the pattern does not have
-  raises `RegexpError`, counting the groups of the whole pattern, so `\1(a)`
-  is valid
-- `\k<name>`, `\k'name'` named backreferences
-- `\k<n>`, `\k'n'` numbered backreferences
-- `\k<-n>`, `\k'-n'` relative backreferences
-- `\g<name>`, `\g'name'` subexpression calls: the group's sub-pattern runs
-  again where the call stands, recursively when the call stands inside it,
-  so `(?<p>\((?:[^()]|\g<p>)*\))` matches balanced parentheses. `\g<n>` is
-  absolute, `\g<-n>` counts back over the groups already opened, `\g<+n>`
-  counts forward, and `\g<0>` is the whole pattern. A recursion no input
-  could end (`(?<a>\g<a>)`, `(?<a>x\g<a>)`) raises `RegexpError` at compile
-  time, as in CRuby; one that can end is bounded at match time by
-  `MRB_REGEXP_STACK_LIMIT`, which counts the calls open or completed along
-  the current path -- a completed call's frame and return marker stay on
-  the backtracking stack until backtracking removes them -- so a long flat
-  repetition of a call reaches the limit as a deep recursion does
+- `\N` numbered backreference
+- `\k<name>`, `\k'name'` named backreference
+- `\k<n>`, `\k'n'` numbered backreference
+- `\k<-n>`, `\k'-n'` relative backreference
+- `\g<name>`, `\g'name'` subexpression call, recursive where the call stands
+  inside the group it names
+- `\g<n>`, `\g<-n>`, `\g<+n>` the same by number, `\g<0>` the whole pattern
 - `(?=...)` positive lookahead
 - `(?!...)` negative lookahead
 - `(?<=...)` positive lookbehind (fixed-length only)
 - `(?<!...)` negative lookbehind (fixed-length only)
 - `(?>...)` atomic group
-- `(?imx-imx)` options for the rest of the enclosing group,
-  `(?imx-imx:...)` options for the group's own body
+- `(?imx-imx)` options for the rest of the enclosing group
+- `(?imx-imx:...)` options for the group's own body
+
+Three rules settle what a spelling means:
+
+- A quantifier after a quantifier repeats the repeat: `a**` is `(?:a*)*` and
+  `a{2}{3}` is `(?:a{2}){3}`. `{n}` has no non-greedy form, so `a{3}?` matches
+  empty where the lazy `a{3,3}?` does not.
+- `\N` is a backreference where its decimal value is at most 9 or at most the
+  number of groups opened before it, and an octal escape past both. A number no
+  group in the whole pattern carries raises `RegexpError`, so `\1(a)` is valid.
+- A recursion no input could end (`(?<a>\g<a>)`) raises `RegexpError` at
+  compile time, as in CRuby. One that can end is bounded at match time by
+  `MRB_REGEXP_STACK_LIMIT`.
 
 ### Character Escapes
 
 - `\n`, `\t`, `\r`, `\f`, `\v`, `\a`, `\e` control characters
-- `\NNN` octal, one to three digits, when the digits spell no
-  backreference: `\101` is `A`, `\12` is a newline before twelve groups
-  and a backreference after them, `\0NN` is always octal; `\8` and `\9`
-  that spell no backreference are the digits themselves
+- `\NNN` octal, one to three digits, where the digits spell no backreference
 - `\xHH` hex, one or two digits; `\x` with no digit raises `RegexpError`
-- `\cX`, `\C-X` control characters, where a `\` in the X position opens an
-  escape of its own (`\c\n`). `\c?` is DEL, as it is in a String
+- `\cX`, `\C-X` control characters, `\c?` being DEL as it is in a String
 - `\uXXXX` Unicode codepoint, exactly four hex digits
-- `\u{...}` Unicode codepoints, one to six hex digits each, several of
-  them separated by spaces: `/\u{61 62}/` is `ab`
+- `\u{...}` Unicode codepoints, one to six hex digits each, space separated
 
-Outside a character class the list form is a sequence rather than one
-atom, so a quantifier after it repeats the last codepoint only:
-`/\u{61 62}+/` is `ab+`. Inside a class every codepoint is a member of
-its own, and the one next to a `-` still opens or closes a range: the
-last of the list before it and the first after it, so `/[\u{61 62}-z]/`
-is `a` plus `b-z` and `/[a-\u{63 7a}]/` is `a-c` plus `z`. A range
-written backwards, `[b-a]` or `[b-\u{61 63}]`, raises `RegexpError` as
-in CRuby.
+Outside a character class the list form is a sequence rather than one atom, so
+`/\u{61 62}+/` is `ab+`. Inside a class every codepoint is a member of its own
+and the one next to a `-` bounds the range, so `/[\u{61 62}-z]/` is `a` plus
+`b-z`. A range written backwards raises `RegexpError`, as in CRuby.
 
 ### Anchors
 
@@ -90,10 +76,10 @@ in CRuby.
 
 ### Flags
 
-- `i` (`Regexp::IGNORECASE`) case-insensitive matching (Unicode, or ASCII
-  where the build converts case by ASCII)
-- `m` (`Regexp::MULTILINE`) `.` matches newline; `^`/`$` match at line boundaries
-- `x` (`Regexp::EXTENDED`) free-spacing mode; unescaped whitespace ignored, `#` starts comments
+- `i` (`Regexp::IGNORECASE`) case-insensitive matching
+- `m` (`Regexp::MULTILINE`) `.` matches newline, `^`/`$` match at line
+  boundaries
+- `x` (`Regexp::EXTENDED`) free-spacing mode, `#` starts a comment
 
 ### Ruby API
 

--- a/mrbgems/mruby-regexp/README.md
+++ b/mrbgems/mruby-regexp/README.md
@@ -186,132 +186,71 @@ Regexp.new("(a)(?<b>b)\\1")
 
 ## Engine Architecture
 
-The gem uses two execution engines:
+Two engines, chosen automatically at compile time by pattern analysis.
 
-**Pike VM (NFA simulation)**: Used for patterns without
-backreferences, non-greedy quantifiers, lookaround, atomic groups or
-subexpression calls. Guarantees O(pattern x text) time complexity, making it
-immune to ReDoS attacks.
-
-**Backtracking engine**: Used when patterns contain `\1`-`\9`
-backreferences, non-greedy quantifiers (`*?`, `+?`, `??`),
-lookaround assertions (`(?=...)`, `(?!...)`, `(?<=...)`, `(?<!...)`),
-atomic groups (`(?>...)`) or subexpression calls (`\g<name>`), whose call
-frames the Pike VM's threads have no stack to hold -- a call declines the
-Pike path the way a backreference does. It backtracks on a stack of its own on the
-heap, so a search spends a constant amount of C stack however long the
-subject is. Bounded by a configurable step limit (`MRB_REGEXP_STEP_LIMIT`,
-default 1M) against excessive backtracking and by a stack limit
-(`MRB_REGEXP_STACK_LIMIT`, default 2048) on how tall that stack may
-stand. A search that reaches either raises `RegexpError` naming the limit,
-since what it had found by then is not the answer; one whose stack the
-allocator refuses to grow raises `NoMemoryError` instead, that being a
-different thing to do something about.
-
-The engine is selected automatically at compile time based on
-pattern analysis.
+- **Pike VM (NFA simulation)** for patterns without backreferences, non-greedy
+  quantifiers, lookaround, atomic groups or subexpression calls. O(pattern x
+  text), so it is immune to ReDoS.
+- **Backtracking engine** for the rest, whose state the Pike VM's threads have
+  no stack to hold. It backtracks on a stack of its own on the heap, so a
+  search spends a constant amount of C stack however long the subject is.
+  Bounded by `MRB_REGEXP_STEP_LIMIT` and `MRB_REGEXP_STACK_LIMIT`.
 
 ## Limitations
 
-- **UTF-8 only where the build reads it**: the engine reads a pattern and a
-  subject the way the build's `String` reads them, so everything below about
-  characters holds on a build that defines `MRB_UTF8_STRING` (mruby-encoding
-  is what defines it). Where it is not defined a string is bytes and so is the
-  engine: `/./` matches one byte, `/Ā/` is two atoms of one byte each, and
-  `/i` folds ASCII letters and nothing else. A binary (`ASCII-8BIT`) subject
-  reads by byte on either build.
-- **Fixed-length lookbehind only**: `(?<=...)` and `(?<!...)`
-  require a fixed-length pattern (no `*`, `+`, `?`, or alternation).
-  Maximum 255 bytes.
-- **No Unicode properties**: `\p{Alpha}`, `\p{L}`, etc. are not
-  supported and raise `RegexpError`, inside a character class as much as
-  outside one. It is the braces that name a property: a bare `\p`, and `\pL`
-  as well, is the letter, which is how CRuby reads them too. The POSIX
-  brackets read the same data where the build carries it, so `[[:alpha:]]` is
-  the way to ask for a letter of any script.
-- **A set is not an end of a range**: a shorthand (`\d`, `\w`, ...) and a
-  POSIX bracket each name a set rather than a character, so `[a-\d]` and
-  `[\d-z]` raise `RegexpError` as they do in CRuby. A `-` at either edge of
-  the class is still a member: `[\d-]` holds the digits and the dash.
-- **No `\M-X` meta escape**: it sets the high bit, making a byte that starts
-  no character, and there is no encoding here to read one against. It raises
-  `RegexpError`, as it does in CRuby for a pattern that is not binary.
-- **A `[` inside a class opens something**: as in CRuby it never stands for
-  itself, and what it opens is read here only when it is a POSIX bracket.
+Every entry is a place this engine answers a pattern differently from CRuby.
+
+- **UTF-8 only where the build reads it**: a pattern and a subject read the way
+  the build's `String` reads them. Without `MRB_UTF8_STRING` both are bytes:
+  `/./` matches one byte, `/Ā/` is two atoms of one byte each, and `/i` folds
+  ASCII only. A binary (`ASCII-8BIT`) subject reads by byte on either build.
+- **Fixed-length lookbehind only**: `(?<=...)` and `(?<!...)` take no `*`, `+`,
+  `?` or alternation, and at most 255 bytes. A call inside one must be
+  fixed-length too, recursion included, or `invalid pattern in look-behind`.
+- **No Unicode properties**: `\p{Alpha}`, `\p{L}` raise `RegexpError`, inside a
+  character class as much as outside one. A bare `\p`, and `\pL`, is the
+  letter, as in CRuby. `[[:alpha:]]` asks for a letter of any script.
+- **A set is not an end of a range**: `[a-\d]` and `[\d-z]` raise
+  `RegexpError`, as in CRuby. A `-` at either edge is still a member: `[\d-]`
+  holds the digits and the dash.
+- **No `\M-X` meta escape**: it raises `RegexpError`, as it does in CRuby for a
+  pattern that is not binary.
+- **A `[` inside a class opens something**: only a POSIX bracket is read there.
   A collating element (`[[.a.]]`), an equivalence class (`[[=a=]]`) and a
-  class nested in this one (`[[a][b]]`) each raise `RegexpError`. Write
-  `[\[]` for the bracket itself, which is the spelling CRuby wants too.
-- **No `\G`, `\K`, `\R` or `\X`**: the search-start anchor, the match-start
-  reset, the linebreak and the grapheme cluster all raise `RegexpError`
-  rather than standing for their own letter. Inside a character class CRuby
-  reads each as the letter, and so does this; a bare `\g`, which calls a
-  group only with a `<name>` or `'name'` after it, is the letter either way.
-- **No nest level on a backreference**: `\k<name+n>` and `\k<name-n>` read the
-  group as the enclosing recursion left it `n` levels up, which asks for a
+  nested class (`[[a][b]]`) raise `RegexpError`. Write `[\[]`, as in CRuby.
+- **No `\G`, `\K`, `\R` or `\X`**: they raise `RegexpError` rather than
+  standing for their own letter. Inside a character class each is the letter,
+  as in CRuby, and so is a bare `\g` either way.
+- **No nest level on a backreference**: `\k<name+n>` and `\k<name-n>` ask for a
   capture memory per call level where this engine keeps one flat slot per
   group, so they raise `RegexpError`. A plain `\k<name>` still works inside a
-  recursion: it reads the pair the innermost completed invocation left, and
-  reads the group as unmatched inside an invocation no inner one has
-  completed within, which are CRuby's answers for the same shapes. The level
-  starts at the first `+`
-  or `-` past the name's first byte, in CRuby as here, which leaves a group
-  whose name holds one out of a backreference's reach: `(?<a-1>x)` names a
-  group in both, and `\k<a-1>` reaches it in neither, though `\g<a-1>`, a
-  call taking no level, reaches it in both. The first byte is the relative
-  form's sign, so `\k<-1>` is still the group one back.
-- **A call in a lookbehind must still be fixed-length**: `(?<=\g<a>)` runs
-  where the group's body is fixed-length, and where it is not -- recursion
-  included -- raises `invalid pattern in look-behind`, which is CRuby's
-  message for the same refusal.
-- **An empty iteration ends a repeat around a call too**: an iteration that
-  matched empty ends the repetition and keeps what it captured, which is the
-  rule every inline repeat here follows, and a repeat whose body runs
-  through a called group follows it unchanged. Onigmo switches such repeats
-  to a capture-tracking empty check that can lose matches its own inline
-  rule finds: `/((?<g1>|){2}b){2}\g<g1>{0}/` answers nil in CRuby although
-  the dead call never runs, and `/(?<g1>)b\g<g1>{1,3}?/` answers nil where
-  its greedy spelling matches `"b"`. This engine answers every such pattern
-  as the call-free spelling does.
-- **No character class intersection**: `[a&&b]` narrows a class to what both
-  sides hold in CRuby, and raises `RegexpError` here. A lone `&` is a member
-  of the class, as it is in CRuby, and so is an escaped one: `[\&&]` holds
-  `&` twice rather than intersecting.
-- **No `\x{...}` hex escape**: the hex escape is `\xHH`, so it reaches
-  `0xff` at most, and `\x{...}` raises `RegexpError` as CRuby does, since
-  the brace is not a hex digit. Write `\u{...}` for a codepoint above that.
-- **No encodings**: a pattern is a byte string read the way the build reads a
-  String, and there is no encoding to consult about a byte that starts no
-  whole character. Such a byte is that byte, inside a character class as much
-  as outside one: `[\xB5]` and `\xB5` both hold the byte `0xB5`, and neither
-  matches `µ`, which is `C2 B5`. CRuby settles the same question with the
-  pattern's encoding and raises `RegexpError` for either spelling. A range
-  whose ends are a byte and a character (`[\x80-µ]`) names neither and raises
-  `RegexpError`.
-- **Case folding follows the build**: The `i` flag reads the Unicode
-  foldings that pair one codepoint with one other off core's case table,
-  which a build converting case by ASCII does not carry. There `i` folds
-  ASCII letters, and a pattern holding a character that needs one of those
-  foldings raises `RegexpError` rather than answering as if the character had
-  no case. What it refuses is held as ranges, which take in some uncased
-  characters as well; see Configuration. A codepoint with no single
-  counterpart to fold to (`ﬀ` to `ff`) is never folded by either build.
-- **Case-insensitive backreferences match a superset**: `\1` under `i`
-  folds each side and compares, so it matches where the capture and the
-  repeat hold the same characters in different widths (`k` and `K`).
-  CRuby declines to fold across a width change there.
-- **`\b` reads `[[:word:]]` below U+0100 too**: CRuby draws a word boundary
-  beside `²`, `³`, `¹` and `½`, which its own `[[:word:]]` does not hold; it
-  reads a character under 256 off a Latin-1 word table for the boundary and
-  off the Unicode tables for the bracket. Here the two are the same question
-  at every codepoint, so neither takes them. The difference is CRuby's own
-  rather than a rule Ruby states.
-- **Step limit on backtracking**: Patterns that require the
-  backtracking engine are subject to a step limit.
-- **Backward search walks forward**: the engine searches forward only,
-  so `rindex`, `byterindex` and `rpartition` walk the subject from the
-  start and keep the last match that qualifies. The cost grows with the
-  number of positions a match starts at, where CRuby hands the search to
-  Onig.
+  recursion, reading the pair the innermost completed invocation left.
+- **An empty iteration ends a repeat around a call too**, which is the rule
+  every inline repeat here follows. Onigmo switches such repeats to a
+  capture-tracking empty check that answers a few of them differently, among
+  them `/((?<g1>|){2}b){2}\g<g1>{0}/` and `/(?<g1>)b\g<g1>{1,3}?/`.
+- **No character class intersection**: `[a&&b]` raises `RegexpError`. A lone
+  `&` is a member of the class, as it is in CRuby.
+- **No `\x{...}` hex escape**: the hex escape is `\xHH`, and `\x{...}` raises
+  `RegexpError` as CRuby does. Write `\u{...}` for a codepoint above `0xff`.
+- **No encodings**: a byte that starts no whole character is that byte, inside
+  a character class as much as outside one. `[\xB5]` and `\xB5` both hold the
+  byte `0xB5` and neither matches `µ` (`C2 B5`), where CRuby raises
+  `RegexpError` for either spelling. A range whose ends are a byte and a
+  character (`[\x80-µ]`) raises `RegexpError`.
+- **Case folding follows the build**: where the build converts case by ASCII, a
+  pattern holding a character that needs a Unicode folding raises
+  `RegexpError`; see Configuration.
+- **Case-insensitive backreferences match a superset**: `\1` under `i` folds
+  each side and compares, so it matches across a width change (`k` and `K`)
+  where CRuby declines to.
+- **`\b` reads `[[:word:]]` below U+0100 too**: CRuby draws a boundary beside
+  `²`, `³`, `¹` and `½`, reading a character under 256 off a Latin-1 word table
+  for the boundary and off the Unicode tables for the bracket. Here the two are
+  the same question at every codepoint, so neither takes them.
+- **Backward search walks forward**: `rindex`, `byterindex` and `rpartition`
+  walk the subject from the start and keep the last match that qualifies, so
+  the cost grows with the number of positions a match starts at.
 
 ## Configuration
 

--- a/mrbgems/mruby-regexp/README.md
+++ b/mrbgems/mruby-regexp/README.md
@@ -297,9 +297,10 @@ Every entry is a place this engine answers a pattern differently from CRuby.
 
 A build that sets a limit outside its range fails to compile, and so does one
 still defining `MRB_REGEXP_RECURSION_LIMIT`, the name the stack limit had while
-it counted C frames. The values a build chose are `Regexp::STEP_LIMIT` and
-`Regexp::STACK_LIMIT`, for a program that has to size a subject or a pattern to
-the build it runs on; CRuby's counterpart is `Regexp.timeout`.
+it counted C frames. The values a build chose are `Regexp::STEP_LIMIT`,
+`Regexp::STACK_LIMIT` and `Regexp::PARSE_DEPTH_LIMIT`, for a program that has
+to size a subject or a pattern to the build it runs on; CRuby's counterpart to
+the two search limits is `Regexp.timeout`.
 
 ### The two search limits
 


### PR DESCRIPTION
## Summary

`mrbgems/mruby-regexp/README.md` had grown to 616 lines, and it had grown in one
direction: every rule was stated together with the reasoning that had chosen it,
the measurements that placed a default, and what an earlier spelling was called.
That reasoning is already written down, in the commit that made each change,
which is where a reader who wants it goes.

What the README is for is answering a question a reader arrives with, so this
states it as lists that carry the answer and nothing beside it, and fills the
gaps that reading it that way made visible: thirteen methods the gem defines
that no list named, three spellings the parser takes that no list named, and the
optional arguments the match methods take.

442 lines, and no rule is dropped.

## Changes

| Commit | What it does |
| --- | --- |
| `state each syntax entry on one line` | An entry is a spelling and what it stands for; what needs more goes below the list |
| `move the named capture rules in with the syntax` | Numbering is part of what a pattern means, so it sits with the syntax |
| `state each limitation as the answer it gives` | An entry names what a pattern raises here and how CRuby answers it |
| `split the configuration section by what it configures` | A heading each for the search limits, the parse depth limit and what the build decides |
| `say what the differential test asks, not why` | What the corpus covers, what the baseline holds, how to take a new one |
| `name the three spellings the syntax lists missed` | `\h` / `\H`, a `?` after `{n,m}`, `\b` as a backspace inside a class |
| `list the Regexp and MatchData methods the gem defines` | Thirteen methods, `Regexp`'s equality and both of its printings among them |
| `show the optional arguments the match methods take` | The start position, `split`'s limit, `start_with?`'s further patterns |
| `read the parse depth limit back beside the other two` | All three limits are constants, so the sentence naming them names three |

### The lists read as lists

The syntax and escape lists had grown paragraphs where an entry names a
spelling and what it stands for, so they had stopped reading as lists. Each
entry is a line again, and the three things that need more than a line are
stated below: how a quantifier after a quantifier reads, when a digit run is a
backreference and when it is octal, and which recursions are refused at compile
time.

Named captures move up beside the syntax, since how a named group renumbers the
whole pattern is part of what a pattern means, not something the engine
declines to do.

### Limitations answer, Configuration configures

A limitation entry now names what a pattern raises here and how CRuby answers
it, which is what a reader who has just hit one came for; the reasoning that
chose each refusal stays in the commit that made it. The step limit leaves the
list, because a limit a build sets is configuration rather than a difference
from CRuby, and Configuration already states it. So did the engine section,
which had spelled out both search limits a second time.

Configuration held the three limits, the case table and the ctype table under
one heading, and only the limits are a build's to set. Three headings now: the
two search limits, the parse depth limit, and what the build decides. A reader
looking for a knob stops before the two sections that have none.

### The gaps

Reading the file as answers made three absences visible, and each is filled
from the source and the test that covers it:

- Thirteen methods the gem defines stood in no list, among them the whole of
  `Regexp`'s equality (`==`, `eql?`, `hash`) and both of its printings (`to_s`,
  `inspect`). A reader asking whether the gem carries one had to read
  `regexp.c`.
- The parser takes `\h` and `\H`, a `?` after a `{n,m}` repeat, and `\b` as a
  backspace inside a character class. Each has a test of its own and none stood
  in the lists a reader goes to for the answer.
- Every spelling of `match` and `match?` takes a start position, `split` takes a
  limit and `start_with?` takes more than one pattern; the list showed each in
  its one-argument form only. The position is a character index, which is how
  the `index` entries beside them already read it; only the `byteindex` pair
  counts bytes.

## Testing

Documentation only: the change is confined to
`mrbgems/mruby-regexp/README.md`, and no source, test or build file is touched,
so there is nothing to build differently and no size or speed figure to report.

Every entry added was checked against the code that implements it and the test
that covers it: the method lists against the `mrb_define_method` calls in
`src/regexp.c`, the three spellings against `test/regexp_syntax.rb`, and the
optional arguments against the `mrb_get_args` format each method uses.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reorganized and condensed the mruby-regexp README for improved clarity.
  * Added documentation for hexadecimal character escapes and pattern interpretation rules.
  * Expanded examples covering regular expressions, match data, strings, and symbols.
  * Clarified engine architecture, named captures, limitations, configuration, search limits, and parse-depth settings.
  * Added guidance for comparing behavior with CRuby.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->