### PR TITLE
mruby-process: name the signal in a `kill` refusal past the lookup width

### DIFF
--- a/mrbgems/mruby-process/src/process.c
+++ b/mrbgems/mruby-process/src/process.c
@@ -117,7 +117,7 @@ signal_to_number(mrb_state *mrb, mrb_value sig)
     len -= 3;
   }
   if ((size_t)len >= sizeof(bare)) {
-    mrb_raise(mrb, E_ARGUMENT_ERROR, "bad signal name");
+    mrb_raisef(mrb, E_ARGUMENT_ERROR, "unsupported signal 'SIG%l'", name, (size_t)len);
   }
   /* The HAL takes a C string, and `name` is a slice of a longer one. */
   memcpy(bare, name, (size_t)len);

--- a/mrbgems/mruby-process/test/process.rb
+++ b/mrbgems/mruby-process/test/process.rb
@@ -137,6 +137,19 @@ assert('Process.kill with an unknown signal name') do
   end
 end
 
+assert('Process.kill with a signal name too long for any signal') do
+  # A name past the lookup buffer's width is still an unsupported signal, not
+  # a different kind of error; the name is reported in full rather than
+  # replaced by a generic message.
+  long_name = "A" * 40
+  assert_raise_with_message(ArgumentError, "unsupported signal 'SIG#{long_name}'") do
+    Process.kill(long_name, Process.pid)
+  end
+  assert_raise_with_message(ArgumentError, "unsupported signal 'SIG#{long_name}'") do
+    Process.kill(long_name.to_sym, Process.pid)
+  end
+end
+
 assert('Process.kill with a name that is nothing but the prefix') do
   # "SIG" loses the prefix like any longer name and leaves nothing behind, and
   # a name that was empty to begin with reaches the same place.  Neither is an


### PR DESCRIPTION
## Summary

A signal name at or past the 32-byte buffer `signal_to_number()` copies it into raised `ArgumentError: bad signal name`, a different message from every shorter unsupported name, which mruby (like CRuby) reports as `ArgumentError: unsupported signal 'SIG...'`. The buffer is only needed for the HAL lookup, not for the message: `mrb_raisef()` can name the refused signal from a pointer and a length, without copying it in first.

## Changes

| File | Change |
| --- | --- |
| `mrbgems/mruby-process/src/process.c` | `signal_to_number()` reports a name too wide for the lookup buffer as `unsupported signal 'SIG...'`, the shape every shorter unsupported name already gets |
| `mrbgems/mruby-process/test/process.rb` | pins the message for a 40-byte name, given as a String and as a Symbol |

### One refusal, two messages, no visible reason

`signal_to_number()` copies the bare name (the "SIG" prefix already stripped) into `char bare[32]` so `mrb_hal_signal_number()` can be asked in a C string. A name too wide for that buffer was refused before the copy (`process.c:119`):

```c
if ((size_t)len >= sizeof(bare)) {
  mrb_raise(mrb, E_ARGUMENT_ERROR, "bad signal name");
}
```

while a name that fits but names no signal is refused three lines further down, after the lookup itself fails (`process.c:126-127`):

```c
if (mrb_hal_signal_number(mrb, bare, &signo) != 0) {
  mrb_raisef(mrb, E_ARGUMENT_ERROR, "unsupported signal 'SIG%s'", bare);
}
```

Both are `ArgumentError` for the same reason: no signal by that name exists. CRuby answers both the same way, naming the signal it refuses. Only mruby's answer changed shape past 32 bytes, for no reason a caller can see; nothing about the class or the condition being reported differs.

### The buffer was never needed for the message

`mrb_raisef()` takes a string argument as a pointer and an explicit length through `%l` (`src/error.c:330-337`), so the too-wide branch can name `name` directly, before it is ever copied into `bare`:

```c
if ((size_t)len >= sizeof(bare)) {
  mrb_raisef(mrb, E_ARGUMENT_ERROR, "unsupported signal 'SIG%l'", name, (size_t)len);
}
```

`bare` still exists for the HAL call below it, which needs a NUL-terminated C string; only the message stops depending on it.

`signal_to_number()` also raises `bad signal name` at an earlier point (`process.c:95`), for a symbol whose name could not be read at all. That is a different condition, a name never obtained rather than one that names no signal, and is untouched here.

## Behaviour

```ruby
# CRuby 4.0.6, and mruby with this PR
Process.kill("A" * 40, pid)   # ArgumentError: unsupported signal 'SIGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
Process.kill(:NOSUCHSIG, pid) # ArgumentError: unsupported signal 'SIGNOSUCHSIG'  (unchanged)

# mruby before
Process.kill("A" * 40, pid)   # ArgumentError: bad signal name
```

Every name under 32 bytes already read as CRuby's does and is unchanged by this PR.

## Speed

Nothing to time: the change is confined to one refusal path that only a call already about to raise reaches.

## Size

`.text` of `bin/mruby`, from `size -A`, over the five builds in `build_config/ci/gcc-clang.rb`, compiled with clang. Master and this PR were measured at the same worktree path in clean build directories. Base is 79b08d22, the tip of `upstream/master` this PR sits on.

| Build | master | PR | delta |
|---|---:|---:|---:|
| `full-debug` (-O0) | 1,900,038 | 1,900,054 | +16 |
| `bintest` | 1,102,438 | 1,102,502 | +64 |
| `cxx_abi` | 1,091,277 | 1,091,341 | +64 |
| `byte-string` | 1,076,598 | 1,076,662 | +64 |
| `ascii-ctype` | 1,097,558 | 1,097,622 | +64 |

`mrb_raisef()`'s `%l` needs a wider format string and one more argument than the `mrb_raise()` it replaces; -O0 inlines less either way, which narrows the gap there.

## Testing

- `rake -m test` with the default config: 2,450 assertions, 0 KO, 0 crashes (59 skipped, unrelated to this change).
- `MRUBY_CONFIG=ci/gcc-clang rake -m test`: all five builds green, 2,608 to 2,689 assertions each, 0 KO and 0 crashes throughout, plus the 145 of the bintest run.
- Ran `Process.kill("A" * 40, $$)` and `Process.kill(:NOSUCHSIG, $$)` directly against `bin/mruby` to confirm the messages shown above.

## Environment

<details>
<summary>Host, toolchain, and the compile line behind the Size table</summary>

| | |
|---|---|
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-30-generic x86_64 |
| C compiler | Homebrew clang 23.1.0, x86_64-unknown-linux-gnu |
| binutils | GNU ld and ar 2.47.20260726 |
| CRuby | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM |
| rake | 13.3.1 |

Compile line as `rake --verbose` printed it for `mruby-process/src/process.o` in the `bintest` build, with `-MMD -c`, `-I`, `-o` and `-ffile-prefix-map` dropped:

```console
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_PROCESS_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error messages when an unsupported signal name is too long.
  - Error messages now include the complete signal name for clearer troubleshooting.
  - Consistent behavior is provided for both string and symbol signal formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->