### PR TITLE
mruby-process: keep pid and status out of `instance_variables`

### DIFF
--- a/mrbgems/mruby-process/README.md
+++ b/mrbgems/mruby-process/README.md
@@ -68,10 +68,11 @@ other to provide its own feature set:
 `mruby-io`'s own private spawn/wait primitives rather than by anything here.
 There is no dependency in either direction; `mrbgem.rake` names `mruby-io` only
 as a _test_ dependency, because waiting on a child process is only testable
-with a child, and `IO.popen` is how this build makes one. `mruby-errno` is a
-test dependency for the same kind of reason: a gem's tests run in a state
-holding its dependency closure and nothing else, so naming an `Errno` class in
-an assertion means asking for the gem that defines them.
+with a child, and `IO.popen` is how this build makes one. `mruby-errno` and
+`mruby-metaprog` are test dependencies for the same kind of reason: a gem's
+tests run in a state holding its dependency closure and nothing else, so
+naming an `Errno` class or asking an object for its `instance_variables` means
+asking for the gem that defines them.
 
 `mruby-signal` is a real dependency rather than a test one. `Process.kill`
 takes a signal by name and `Process::Status#to_s` spells one out, so both need

--- a/mrbgems/mruby-process/mrbgem.rake
+++ b/mrbgems/mruby-process/mrbgem.rake
@@ -18,4 +18,8 @@ MRuby::Gem::Specification.new('mruby-process') do |spec|
   # that defines them.  Without this the tests still pass, by taking the
   # branch that settles for any StandardError.
   spec.add_test_dependency 'mruby-errno', core: 'mruby-errno'
+
+  # Asking a Process::Status what instance_variables it hands out needs the
+  # gem that defines Object#instance_variables in the first place.
+  spec.add_test_dependency 'mruby-metaprog', core: 'mruby-metaprog'
 end

--- a/mrbgems/mruby-process/src/status.c
+++ b/mrbgems/mruby-process/src/status.c
@@ -53,8 +53,8 @@ status_class(mrb_state *mrb)
 static void
 status_decode(mrb_state *mrb, mrb_value self, mrb_process_status *st)
 {
-  mrb_int pid = status_ivar(mrb, self, MRB_IVSYM(pid));
-  mrb_int raw = status_ivar(mrb, self, MRB_IVSYM(status));
+  mrb_int pid = status_ivar(mrb, self, MRB_SYM(pid));
+  mrb_int raw = status_ivar(mrb, self, MRB_SYM(status));
 
   mrb_hal_process_status_decode(mrb, pid, raw, st);
 }
@@ -95,8 +95,8 @@ status_initialize(mrb_state *mrb, mrb_value self)
      read the low half of it.  The pid needs no such check, since it is
      carried and handed back whole rather than narrowed. */
   mrb_process_int_arg(mrb, raw_status, "status");
-  mrb_iv_set(mrb, self, MRB_IVSYM(pid), mrb_int_value(mrb, pid));
-  mrb_iv_set(mrb, self, MRB_IVSYM(status), mrb_int_value(mrb, raw_status));
+  mrb_iv_set(mrb, self, MRB_SYM(pid), mrb_int_value(mrb, pid));
+  mrb_iv_set(mrb, self, MRB_SYM(status), mrb_int_value(mrb, raw_status));
   /* Last, since the two above are what there is to write.  A second
      #initialize on the same object is refused from here on, which is what
      freezing a value means and not a case this gem's own paths reach.
@@ -123,7 +123,7 @@ status_initialize(mrb_state *mrb, mrb_value self)
 static mrb_value
 status_pid(mrb_state *mrb, mrb_value self)
 {
-  return mrb_int_value(mrb, status_ivar(mrb, self, MRB_IVSYM(pid)));
+  return mrb_int_value(mrb, status_ivar(mrb, self, MRB_SYM(pid)));
 }
 
 /*
@@ -136,7 +136,7 @@ status_pid(mrb_state *mrb, mrb_value self)
 static mrb_value
 status_to_i(mrb_state *mrb, mrb_value self)
 {
-  return mrb_int_value(mrb, status_ivar(mrb, self, MRB_IVSYM(status)));
+  return mrb_int_value(mrb, status_ivar(mrb, self, MRB_SYM(status)));
 }
 
 /*
@@ -248,7 +248,7 @@ status_coredump_p(mrb_state *mrb, mrb_value self)
 static mrb_value
 status_eq(mrb_state *mrb, mrb_value self)
 {
-  mrb_value raw = mrb_int_value(mrb, status_ivar(mrb, self, MRB_IVSYM(status)));
+  mrb_value raw = mrb_int_value(mrb, status_ivar(mrb, self, MRB_SYM(status)));
   mrb_value other;
 
   mrb_get_args(mrb, "o", &other);
@@ -260,7 +260,7 @@ status_eq(mrb_state *mrb, mrb_value self)
      one, and CRuby's way round reaches it through whichever #== the object
      carries. */
   if (mrb_obj_is_kind_of(mrb, other, status_class(mrb))) {
-    other = mrb_int_value(mrb, status_ivar(mrb, other, MRB_IVSYM(status)));
+    other = mrb_int_value(mrb, status_ivar(mrb, other, MRB_SYM(status)));
   }
   return mrb_bool_value(mrb_equal(mrb, raw, other));
 }

--- a/mrbgems/mruby-process/test/process.rb
+++ b/mrbgems/mruby-process/test/process.rb
@@ -264,6 +264,14 @@ assert('Process::Status') do
   assert_false st.coredump?
 end
 
+assert('Process::Status keeps its pid and raw status out of instance_variables') do
+  # The pid and raw status are internal state, not something a caller wrote or
+  # is meant to read back by name; CRuby answers the same empty array, since
+  # it keeps both in the object's own struct rather than in an ivar table.
+  st = ProcessTestUtil.status(1234, 0)
+  assert_equal [], st.instance_variables
+end
+
 assert('Process::Status with a status too large for the platform') do
   # A port reads a raw status as the `int` the platform reported it with, so a
   # value that does not fit one is refused where RangeError can be said rather


### PR DESCRIPTION
## Summary

`Process::Status` keeps the pid and raw wait status in `@pid` and `@status`, so `instance_variables` hands the internals out where CRuby answers `[]`:

```ruby
pid = spawn("true")
Process.waitpid(pid)
$?.instance_variables   # CRuby: [], mruby: [:@pid, :@status]
```

## Changes

Two commits, each buildable on its own:

| Commit | File | What |
|---|---|---|
| `mruby-process: run instance_variables tests where it is defined` | `mrbgem.rake`, `README.md` | names `mruby-metaprog` as a test dependency |
| `mruby-process: keep pid and status out of instance_variables` | `src/status.c`, `test/process.rb` | `MRB_IVSYM(pid)`/`MRB_IVSYM(status)` become `MRB_SYM(pid)`/`MRB_SYM(status)`; new test |

### A gem's tests run in a state holding only its own dependency closure

The regression test asks a `Process::Status` for `instance_variables`, which `mruby-metaprog` defines. `mrbgem.rake` did not name it, so the isolated interpreter each gem's tests run in (see `mruby-process: run the tests where the Errno classes are defined`, already in the tree for the same reason with `mruby-errno`) crashed the test with `NoMethodError: undefined method 'instance_variables'` rather than running it. Naming the dependency is its own commit, ahead of the test that needs it.

### The ivar spelling is the whole of the bug

`Hash`'s default (`MRB_SYM(ifnone)`) and `mruby-errno`'s `MRB_SYM(errno)` already keep internal per-object state under a symbol that is not an instance variable name, and get the hiding for free: `mrb_iv_get`/`mrb_iv_set` read and write the same table regardless of what the symbol looks like, only `instance_variables` (`src/variable.c`'s `iv_i()`) filters by the leading `@`. `status.c` used `MRB_IVSYM(pid)`/`MRB_IVSYM(status)` at its eight read/write sites; renaming them to `MRB_SYM(pid)`/`MRB_SYM(status)` leaves the table, its GC marking, the freeze in `#initialize`, and every method unchanged, and leaves `instance_variables` empty as it is in CRuby.

Nothing in the tree reads `@pid` or `@status` by name: no test names them, `mruby-io` builds a status through `mrb_obj_new()` and reads it back only through the methods, and the object is frozen at the end of `#initialize`.

## Behaviour

```ruby
pid = spawn("true")
Process.waitpid(pid)
$?.instance_variables   # before: [:@pid, :@status]  after: []
$?.pid                  # unchanged
$?.to_i                 # unchanged
```

## Size

`bin/mruby` `.text`, from `size -A`, over the five builds in `build_config/ci/gcc-clang.rb`. Base is 79b08d227.

| Build | master | this PR | delta |
|---|---:|---:|---:|
| `bintest` | 1,102,438 | 1,102,422 | -16 |
| `ascii-ctype` | 1,097,558 | 1,097,542 | -16 |
| `byte-string` | 1,076,598 | 1,076,566 | -32 |
| `cxx_abi` | 1,091,277 | 1,091,261 | -16 |
| `full-debug` (-O0) | 1,900,038 | 1,900,038 | 0 |

The shrink is `presym`'s generated symbol table losing the `@pid`/`@status` entries: nothing else in the tree names those two symbols, so they drop out once `status.c` stops using them. `MRB_SYM(pid)` and `MRB_SYM(status)` are not newly added; both were already compiled into `status.c` for the `#pid` and `#to_i` methods it defines. `full-debug` is unoptimized and does not move.

## Testing

- Every commit built and tested on its own with the default config: 2,449 assertions at the first commit, 2,450 at the second, 0 KO and 0 Crash throughout (`git rebase master --exec 'rake -m test'`).
- `MRUBY_CONFIG=ci/gcc-clang rake test` at the tip: all five builds green, 2,608 to 2,689 assertions each, 0 KO and 0 Crash throughout, plus the 145 of the bintest run. The new test is not among the skips in any of them.
- Checked by hand on the built binary: `Process::Status#instance_variables` answers `[]` right after construction, while `#pid`, `#to_i` and `#exited?` still read correctly.

## Environment

<details>
<summary>Host, toolchain, and the compile lines behind the Size table</summary>

| | |
|---|---|
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-30-generic x86_64 |
| CPU | AMD Ryzen 9 5950X 16-Core |
| C compiler | Homebrew clang 23.1.0, x86_64-unknown-linux-gnu |
| binutils | GNU ld and ar 2.47.20260726 |
| CRuby | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM |
| rake | 13.3.1 |

`cxx_abi` builds mruby as C++ through the same `clang` driver with `-x c++ -std=gnu++03`.

Compile lines for `mrbgems/mruby-process/src/status.c` as `rake --verbose` printed them, with `-MMD -c`, `-I`, `-o` and `-ffile-prefix-map` dropped:

```console
# bintest
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_PROCESS_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK

# ascii-ctype
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -DMRB_USE_ASCII_CTYPE -DMRB_REGEXP_PARSE_DEPTH_LIMIT=512 -DMRBGEM_MRUBY_PROCESS_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# byte-string
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -DMRBGEM_MRUBY_PROCESS_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# cxx_abi
clang -g -O3 -Wall -Wundef -Wwrite-strings -Wzero-length-array -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_PROCESS_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# full-debug
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRBGEM_MRUBY_PROCESS_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `Process::Status#instance_variables` no longer exposes internal `pid` and raw status values.
  * Process status objects now consistently keep these implementation details out of their publicly inspectable instance-variable list.

* **Tests**
  * Added coverage to verify that `Process::Status#instance_variables` returns an empty list for status objects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->