### PR TITLE
numeric.c: round an Integer to a negative number of digits correctly

### DIFF
--- a/mrbgems/mruby-bigint/test/bigint.rb
+++ b/mrbgems/mruby-bigint/test/bigint.rb
@@ -495,3 +495,35 @@ assert('Bigint an mrb_int operand keeps every bit') do
   assert_equal 18446744069414584319, (1 << 64) - ((1 << 32) + 1)
   assert_equal 79228162514264337593543950336, (1 << 64) * (1 << 32)
 end
+
+assert('Bigint Integer#ceil keeps a value that is already a multiple') do
+  # A big integer that is already a multiple of 10**n is its own ceiling.
+  big = 10 ** 25
+  assert_equal big, big.ceil(-1)
+  assert_equal big, big.ceil(-2)
+  assert_equal big, big.ceil(-25)
+  assert_equal(-big, (-big).ceil(-1))
+  assert_equal(-big, (-big).ceil(-25))
+
+  assert_equal 10000000000000000000000010, (big + 5).ceil(-1)
+  assert_equal 10000000000000000000000010, (big + 4).ceil(-1)
+  assert_equal(-big, (-big - 5).ceil(-1))
+  assert_equal(-big, (-big - 4).ceil(-1))
+end
+
+assert('Bigint Integer#floor keeps a value that is already a multiple') do
+  big = 10 ** 25
+  assert_equal(-big, (-big).floor(-1))
+  assert_equal(-big, (-big).floor(-25))
+  assert_equal(-10000000000000000000000010, (-big - 5).floor(-1))
+end
+
+assert('Bigint Integer#round breaks a tie away from zero') do
+  big = 10 ** 25
+  assert_equal big, big.round(-1)
+  assert_equal 10000000000000000000000010, (big + 5).round(-1)
+  assert_equal big, (big + 4).round(-1)
+  assert_equal big, (big - 5).round(-1)
+  assert_equal(-10000000000000000000000010, (-big - 5).round(-1))
+  assert_equal(-big, (-big - 4).round(-1))
+end

--- a/src/numeric.c
+++ b/src/numeric.c
@@ -1624,7 +1624,7 @@ static mrb_value
 prepare_int_rounding(mrb_state *mrb, mrb_value x)
 {
   mrb_int nd = 0;
-  size_t bytes;
+  double bytes = (double)sizeof(mrb_int) - 0.125;
 
   mrb_get_args(mrb, "|i", &nd);
   if (nd >= 0) {
@@ -1632,12 +1632,10 @@ prepare_int_rounding(mrb_state *mrb, mrb_value x)
   }
 #ifdef MRB_USE_BIGINT
   if (mrb_bigint_p(x)) {
-    bytes = mrb_bint_memsize(x);
+    bytes = (double)mrb_bint_memsize(x) + 0.125;
   }
-  else
 #endif
-    bytes = sizeof(mrb_int);
-  if (-0.415241 * nd - 0.125 > bytes) {
+  if (-0.415241 * nd > bytes) {
     return mrb_undef_value();
   }
   return mrb_int_pow(mrb, mrb_fixnum_value(10), mrb_fixnum_value(-nd));
@@ -1662,13 +1660,16 @@ int_ceil(mrb_state *mrb, mrb_value x)
   if (mrb_nil_p(f)) return x;
 #ifdef MRB_USE_BIGINT
   if (mrb_bigint_p(x)) {
-    x = mrb_bint_add_n(mrb, x, f);
-    return mrb_bint_sub(mrb, x, mrb_bint_mod(mrb, x, f));
+    mrb_value m = mrb_bint_mod(mrb, x, f);
+    if (mrb_integer_p(m) && mrb_integer(m) == 0) return x;
+    x = mrb_bint_sub_n(mrb, x, m);
+    return mrb_bint_add(mrb, x, f);
   }
 #endif
   mrb_int a = mrb_integer(x);
   mrb_int b = mrb_integer(f);
   mrb_int c = a % b;
+  if (c == 0) return x;
   int neg = a < 0;
   a -= c;
   if (!neg) {
@@ -1710,6 +1711,7 @@ int_floor(mrb_state *mrb, mrb_value x)
   mrb_int a = mrb_integer(x);
   mrb_int b = mrb_integer(f);
   mrb_int c = a % b;
+  if (c == 0) return x;
   int neg = a < 0;
   a -= c;
   if (neg) {
@@ -1759,35 +1761,31 @@ int_round(mrb_state *mrb, mrb_value x)
   mrb_int a = mrb_integer(x);
   mrb_int b = mrb_integer(f);
   mrb_int c = a % b;
+  mrb_int half = b / 2;
   a -= c;
   if (c < 0) {
-    c = -c;
-    if (b/2 < c) {
-      if (mrb_int_sub_overflow(a, b, &c)) {
+    if (-c < half) return mrb_int_value(mrb, a);
+    if (mrb_int_sub_overflow(a, b, &c)) {
 #ifdef MRB_USE_BIGINT
-        x = mrb_bint_new_int(mrb, a);
-        return mrb_bint_sub(mrb, x, f);
+      x = mrb_bint_new_int(mrb, a);
+      return mrb_bint_sub(mrb, x, f);
 #else
-        mrb_int_overflow(mrb, "round");
+      mrb_int_overflow(mrb, "round");
 #endif
-      }
     }
-    a = c;
   }
   else {
-    if (b/2 < c) {
-      if (mrb_int_add_overflow(a, b, &c)) {
+    if (c < half) return mrb_int_value(mrb, a);
+    if (mrb_int_add_overflow(a, b, &c)) {
 #ifdef MRB_USE_BIGINT
-        x = mrb_bint_new_int(mrb, a);
-        return mrb_bint_add(mrb, x, f);
+      x = mrb_bint_new_int(mrb, a);
+      return mrb_bint_add(mrb, x, f);
 #else
-        mrb_int_overflow(mrb, "round");
+      mrb_int_overflow(mrb, "round");
 #endif
-      }
     }
-    a = c;
   }
-  return mrb_int_value(mrb, a);
+  return mrb_int_value(mrb, c);
 }
 
 /* 15.2.8.3.26 Integer#truncate */

--- a/test/t/integer.rb
+++ b/test/t/integer.rb
@@ -273,6 +273,19 @@ end
 
 assert('Integer#ceil', '15.2.8.3.14') do
   assert_equal 10, 10.ceil
+  assert_equal 10, 10.ceil(2)
+  assert_equal 1300, 1234.ceil(-2)
+  assert_equal(-1200, -1234.ceil(-2))
+  assert_equal 0, (-99).ceil(-2)
+end
+
+assert('Integer#ceil keeps a value that is already a multiple') do
+  assert_equal 0, 0.ceil(-1)
+  assert_equal 10, 10.ceil(-1)
+  assert_equal 100, 100.ceil(-2)
+  assert_equal 1200, 1200.ceil(-2)
+  assert_equal(-100, -100.ceil(-2))
+  assert_equal(-1200, -1200.ceil(-2))
 end
 
 assert('Integer#downto', '15.2.8.3.15') do
@@ -303,6 +316,19 @@ assert('Integer#floor', '15.2.8.3.17') do
   a = 1.floor
 
   assert_equal 1, a
+  assert_equal 1, 1.floor(2)
+  assert_equal 1200, 1234.floor(-2)
+  assert_equal(-1300, -1234.floor(-2))
+  assert_equal 0, 99.floor(-2)
+end
+
+assert('Integer#floor keeps a value that is already a multiple') do
+  assert_equal 0, 0.floor(-1)
+  assert_equal(-10, -10.floor(-1))
+  assert_equal(-100, -100.floor(-2))
+  assert_equal(-1200, -1200.floor(-2))
+  assert_equal 100, 100.floor(-2)
+  assert_equal 1200, 1200.floor(-2)
 end
 
 assert('Integer#next', '15.2.8.3.19') do
@@ -311,6 +337,34 @@ end
 
 assert('Integer#round', '15.2.8.3.20') do
   assert_equal 1, 1.round
+  assert_equal 1, 1.round(2)
+  assert_equal 12300, 12345.round(-2)
+  assert_equal 12350, 12345.round(-1)
+  assert_equal 12000, 12345.round(-3)
+  assert_equal(-12300, -12345.round(-2))
+  assert_equal 0, 4.round(-1)
+  assert_equal 100, 99.round(-2)
+  assert_equal 0, 0.round(-1)
+end
+
+assert('Integer#round keeps a value that is already a multiple') do
+  assert_equal 10, 10.round(-1)
+  assert_equal 100, 100.round(-2)
+  assert_equal 1200, 1200.round(-2)
+  assert_equal(-100, -100.round(-2))
+  assert_equal(-1200, -1200.round(-2))
+end
+
+assert('Integer#round breaks a tie away from zero') do
+  assert_equal 10, 5.round(-1)
+  assert_equal 20, 15.round(-1)
+  assert_equal 30, 25.round(-1)
+  assert_equal 200, 150.round(-2)
+  assert_equal 300, 250.round(-2)
+  assert_equal(-10, -5.round(-1))
+  assert_equal(-20, -15.round(-1))
+  assert_equal(-30, -25.round(-1))
+  assert_equal(-200, -150.round(-2))
 end
 
 assert('Integer#succ', '15.2.8.3.21') do
@@ -349,6 +403,23 @@ end
 
 assert('Integer#truncate', '15.2.8.3.26') do
   assert_equal 1, 1.truncate
+  assert_equal 1, 1.truncate(2)
+  assert_equal 1200, 1234.truncate(-2)
+  assert_equal(-1200, -1234.truncate(-2))
+  assert_equal 1200, 1200.truncate(-2)
+  assert_equal 0, 99.truncate(-2)
+end
+
+assert('Integer rounding to a power of ten wider than an mrb_int') do
+  # 10 ** 19 is wider than an mrb_int, so the four methods answer 0 rather than
+  # reaching for a power they cannot hold.
+  (19..25).each do |n|
+    assert_equal 0, 12345.round(-n)
+    assert_equal 0, (-12345).round(-n)
+    assert_equal 0, 12345.truncate(-n)
+    assert_equal 0, 12345.floor(-n)
+    assert_equal 0, (-12345).ceil(-n)
+  end
 end
 
 assert('Integer#upto', '15.2.8.3.27') do


### PR DESCRIPTION
`Integer#round`, `#ceil` and `#floor` with a negative `ndigits` can return a value that is not a multiple of `10 ** -ndigits`:

```ruby
12345.round(-2)   #=> 45     (want 12300)
15.round(-1)      #=> 5      (want 20)
100.ceil(-2)      #=> 200    (want 100)
-100.floor(-2)    #=> -200   (want -100)
1.round(-19)      #=> -8446744073709551616
```

Four separate things:

* `round` returns the scratch variable that still holds the remainder whenever no adjustment is needed, because `a = c` sits outside the `if` that computes the adjusted value.
* `round` breaks a tie toward zero. Ruby rounds half away from zero, so `15.round(-1)` is 20 and `-25.round(-1)` is -30.
* `ceil` adds a whole step to a value that is already a multiple, and `floor` subtracts one from a negative value that is already a multiple. Same defect on the mrb_int path and on the big integer path.
* `prepare_int_rounding` subtracts the sign bit from the width it needs instead of adding it, so `ndigits` of -19 gets past the guard and asks for `10 ** 19`. With mruby-bigint that comes back a bignum and the mrb_int path reads it with `mrb_integer()`; without it, `mrb_int_pow` raises RangeError out of `Integer#round`.

`truncate` was already right, and I left the big integer paths of `round` and `floor` alone since they were right too.

What this does not cover: `ceil` and `floor` still answer 0 when `10 ** -ndigits` is wider than the receiver, so `1.ceil(-20)` is 0 where CRuby gives `10 ** 20`. That shortcut predates this and is a precision question rather than an arithmetic one, so I left it. The -19 case now takes that same shortcut instead of producing garbage.

I found this by diffing mruby against CRuby 4.0.6 on generated snippets. 1104 combinations of receiver and ndigits over the four methods: `round` and `truncate` now agree with CRuby on every one, and the only remaining `ceil`/`floor` differences are the width shortcut above. Also checked a build without mruby-bigint and one with `MRB_INT32`, since the size guard depends on the width.

`rake test` passes (2459 tests). The 7 new tests all fail on master with only `src/numeric.c` reverted.

Used Claude Code to run the differential harness and draft the patch. I reviewed and tested it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved integer rounding with negative digit arguments for `ceil`, `floor`, and `round`.
  * Values already aligned to the rounding base are now preserved correctly.
  * Tie cases now round away from zero as expected for positive and negative integers.
  * Improved handling of rounding large integers to powers of ten beyond the native integer range.

* **Tests**
  * Added coverage for large integers, negative digits, exact multiples, tie cases, and truncation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->