### PR TITLE
mruby-bigint: initialize the mpz `mrb_bint_new_int64()` fills in

### DIFF
--- a/mrbgems/mruby-bigint/core/bigint.c
+++ b/mrbgems/mruby-bigint/core/bigint.c
@@ -5375,6 +5375,11 @@ mrb_bint_new_int64(mrb_state *mrb, int64_t n)
   mpz_t x;
   MPZ_CTX_INIT(mrb, ctx, pool);
 
+  /* mpz_set_int64() reallocates `x` to hold the value, which reads the size
+     and the limbs it already has, so it is given an initialized one rather
+     than whatever the stack held.  mrb_bint_new_uint64() below does the
+     same. */
+  mpz_init(ctx, &x);
   mpz_set_int64(ctx, &x, n);
   struct RBigint *b = bint_new(ctx, &x);
   return mrb_obj_value(b);


### PR DESCRIPTION
## Summary

`mrb_bint_new_int64()` declares an `mpz_t` on the stack and hands it straight to `mpz_set_int64()` without initializing it. `mrb_bint_new_uint64()`, right below it, initializes before the same call. This adds the missing `mpz_init()`.

## The bug

```c
mrb_value
mrb_bint_new_int64(mrb_state *mrb, int64_t n)
{
  mpz_t x;
  MPZ_CTX_INIT(mrb, ctx, pool);

  mpz_set_int64(ctx, &x, n);
```

`mpz_set_int64()` reaches `mpz_realloc()`, which reads the size and the limb pointer its target already holds in order to grow it. Given an uninitialized `mpz_t`, it resizes whatever the stack happened to contain and writes the value through a pointer that was never allocated. What that does depends on the garbage: a value of one limb often survives it, and one of two limbs was seen to abort in the allocator.

## Where it is reachable

Only where `mrb_bint_new_int64()` is a function rather than the `mrb_bint_new_int()` macro, which is every `MRB_INT32` build that has bigints: that is how a value too wide for an `mrb_int` is built there. `mruby-time` already takes this path for a `time_t` past what an `mrb_int` holds, so `Time#to_i` on a far enough date reaches it.

## Behaviour

On an `MRB_INT32` build with `mruby-bigint`, before:

```console
$ mruby -e 'p Time.at(4102444800).to_i'
free(): invalid size
Aborted (core dumped)
$ mruby -e 'p Time.at(1700000000000).to_i'
free(): invalid size
Aborted (core dumped)
```

After:

```console
$ mruby -e 'p Time.at(4102444800).to_i'
4102444800
$ mruby -e 'p Time.at(1700000000000).to_i'
1700000000000
```

CI does not build `MRB_INT32` together with bigints, so nothing here goes red either way.

## Testing

`rake -m test` on a `clang`, `enable_debug`, default gembox plus `mruby-bigint`, `MRB_INT32` build:

```
  Total: 2451
     OK: 2399
     KO: 0
  Crash: 0
Warning: 0
   Skip: 52
```

## Environment

<details>

```
Ubuntu, Linux 7.0.0-30-generic x86_64
Homebrew clang version 23.1.0
ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux]
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed bigint creation from signed 64-bit integers on 32-bit builds.
  * Prevented invalid memory reads that could cause incorrect results or runtime instability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->