### PR TITLE
mruby-process: add `Process.clock_gettime` and `Process.clock_getres`

### DIFF
--- a/mrbgems/mruby-process/README.md
+++ b/mrbgems/mruby-process/README.md
@@ -15,34 +15,40 @@ already include it.
 
 ## Implemented methods
 
-| method                     | mruby-process | memo                                     |
-| -------------------------- | ------------- | ---------------------------------------- |
-| Process.pid                | o             | also `$$`                                |
-| Process.ppid               | o             |                                          |
-| Process.kill               | o             | no negative-signal form yet, see below   |
-| Process.wait, .wait2       | o             | `.waitpid2` too; not `.waitall`          |
-| Process.waitpid            | o             | sets `$?`; POSIX only, see below         |
-| Process::WNOHANG           | o             | mruby's own value, not the platform's    |
-| Process::WUNTRACED         | o             | mruby's own value, not the platform's    |
-| Process::Status#pid        | o             |                                          |
-| Process::Status#to_i       | o             | no `#to_int`; mruby converts nothing     |
-| Process::Status#exited?    | o             |                                          |
-| Process::Status#exitstatus | o             |                                          |
-| Process::Status#signaled?  | o             |                                          |
-| Process::Status#termsig    | o             |                                          |
-| Process::Status#stopped?   | o             |                                          |
-| Process::Status#stopsig    | o             |                                          |
-| Process::Status#coredump?  | o             |                                          |
-| Process::Status#success?   | o             |                                          |
-| Process::Status#to_s       | o             |                                          |
-| Process::Status#inspect    | o             |                                          |
-| Process::Status#==         | o             | the raw status decides, not the pid      |
-| Process.fork               |               | inherently non-portable; separate change |
-| Process.spawn              |               | separate change                          |
-| Process.exec               |               | separate change                          |
-| Process.exit, .exit!       |               | see mruby-exit                           |
-| Process.uid, .gid, ...     |               | separate change                          |
-| Process.getpgrp, ...       |               | separate change                          |
+| method                            | mruby-process | memo                                     |
+| --------------------------------- | ------------- | ---------------------------------------- |
+| Process.pid                       | o             | also `$$`                                |
+| Process.ppid                      | o             |                                          |
+| Process.kill                      | o             | no negative-signal form yet, see below   |
+| Process.wait, .wait2              | o             | `.waitpid2` too; not `.waitall`          |
+| Process.waitpid                   | o             | sets `$?`; POSIX only, see below         |
+| Process.clock_gettime             | o             | seven units; symbolic clock ids          |
+| Process.clock_getres              | o             | takes `:hertz` too                       |
+| Process::WNOHANG                  | o             | mruby's own value, not the platform's    |
+| Process::WUNTRACED                | o             | mruby's own value, not the platform's    |
+| Process::CLOCK_REALTIME           | o             | mruby's own value, not the platform's    |
+| Process::CLOCK_MONOTONIC          | o             | mruby's own value, not the platform's    |
+| Process::CLOCK_PROCESS_CPUTIME_ID | o             | mruby's own value, not the platform's    |
+| Process::CLOCK_THREAD_CPUTIME_ID  | o             | mruby's own value, not the platform's    |
+| Process::Status#pid               | o             |                                          |
+| Process::Status#to_i              | o             | no `#to_int`; mruby converts nothing     |
+| Process::Status#exited?           | o             |                                          |
+| Process::Status#exitstatus        | o             |                                          |
+| Process::Status#signaled?         | o             |                                          |
+| Process::Status#termsig           | o             |                                          |
+| Process::Status#stopped?          | o             |                                          |
+| Process::Status#stopsig           | o             |                                          |
+| Process::Status#coredump?         | o             |                                          |
+| Process::Status#success?          | o             |                                          |
+| Process::Status#to_s              | o             |                                          |
+| Process::Status#inspect           | o             |                                          |
+| Process::Status#==                | o             | the raw status decides, not the pid      |
+| Process.fork                      |               | inherently non-portable; separate change |
+| Process.spawn                     |               | separate change                          |
+| Process.exec                      |               | separate change                          |
+| Process.exit, .exit!              |               | see mruby-exit                           |
+| Process.uid, .gid, ...            |               | separate change                          |
+| Process.getpgrp, ...              |               | separate change                          |
 
 ## Architecture
 
@@ -74,6 +80,19 @@ tests run in a state holding its dependency closure and nothing else, so
 naming an `Errno` class or asking an object for its `instance_variables` means
 asking for the gem that defines them.
 
+`mruby-time` is not a dependency either, although `Process.clock_gettime`
+and `Time.now` both end up asking the host what time it is. The two gems ask
+the same question of the same OS and get the same answer, so there is no
+table here that could drift out of step with one there — which is what makes
+the `mruby-signal` dependency below worth its edge and this one not. The
+dependency would also point the wrong way through the gemboxes: this gem is
+in `stdlib-io`, `mruby-time` is in `stdlib-ext`, and depending on it would
+pull a `Time` class into every build that only asked for I/O. Two of the four
+clocks are CPU time this process and this thread have spent, which is not
+something `Time` has an opinion about in any case. If `mruby-time` ever grows
+a HAL of its own, the wall clock is the one reading the two gems could come
+to share, and moving to it would be that gem's change to make.
+
 `mruby-signal` is a real dependency rather than a test one. `Process.kill`
 takes a signal by name and `Process::Status#to_s` spells one out, so both need
 the platform's signal table; that table is `mruby-signal`'s, and this gem
@@ -96,6 +115,14 @@ The HAL answers OS-level facts and performs OS-level operations:
 - `mrb_hal_process_kill()` — delivers a signal.
 - `mrb_hal_process_status_decode()` — reads a native wait status into
   `mrb_process_status`.
+- `mrb_hal_process_clock_gettime()`, `mrb_hal_process_clock_getres()` — read
+  one of the `mrb_process_clock_id` clocks, and say how finely it can be
+  read, both as whole seconds and nanoseconds.
+
+What a unit a reading is wanted in is not among them either. A port always
+reports the same two numbers and is asked nothing about `:float_second`,
+`:nanosecond` or what a build without `Float` should do about the first of
+them; see the design decisions below.
 
 What a signal is _called_ is not among them: `mruby-signal`'s
 `mrb_hal_signal_number()` and `mrb_hal_signal_name()` answer that, and both
@@ -178,6 +205,79 @@ kept separate from adding this gem.
   nothing about the rest, so `MRB_PROCESS_WAIT_FLAGS` names every bit a wait
   may carry and anything else is `EINVAL` in the common layer. Leaving the
   check to the ports would leave the answer to each of them.
+- **A clock is named by mruby's own number, as a wait flag is.**
+  `CLOCK_MONOTONIC` is 1 on Linux, 6 on macOS and 4 on FreeBSD, and Windows
+  has no `clockid_t` to give it a number at all, so borrowing the platform's
+  numbers would leave `Process::CLOCK_MONOTONIC` naming a different clock on
+  each port. The four ids are `mrb_process_clock_id`, every constant is
+  defined on every platform, and a number that names none of them is refused
+  in the common layer rather than by each port — with `Errno::EINVAL`, which
+  is what a platform's own call answers for a clock it does not have and what
+  CRuby raises here. A platform that has no such clock answers the same way,
+  so a program is told at the call site rather than finding the constant
+  missing.
+- **A reading crosses the HAL as seconds and nanoseconds, never as a Float.**
+  `MRB_NO_FLOAT` builds take `stdlib-io`, and a HAL typed in `mrb_float`
+  would not compile for one. A double holds 53 bits where a wall-clock
+  nanosecond needs about 61, so a port that divided would throw away what
+  `:nanosecond` was going to be asked for, and a single count of nanoseconds
+  runs out in 2262. Splitting the reading leaves every unit reachable from
+  the same two numbers, and leaves the unit itself entirely above the HAL.
+- **The two fields are `int64_t`, the one place in the HAL that is not an
+  `mrb_int`.** How large a reading is, is the platform's business; how much
+  of it this build's Integer can carry is mruby's, and is settled in the
+  common layer, where a bigint can be built and `RangeError` can be said.
+  With `mrb_int` there instead, a build with a 32-bit one would have every
+  port refusing the wall clock from 2038 on, and refusing it through `errno`,
+  which cannot say that the platform was fine and the Integer was not — the
+  same objection this gem raises to letting a port report an oversized pid.
+  It would also leave both ports narrowing a value the common layer narrows
+  again. `int64_t` is no more a platform type than `mrb_int` is: `time_t`,
+  `clockid_t` and `FILETIME` still stop at the port.
+- **What a build without `Float` does about a float unit is said at the call
+  site.** The three float units raise `NotImplementedError` there rather than
+  the methods disappearing or the default unit quietly becoming an integer
+  one; the four integer units are untouched, and `:nanosecond` says
+  everything `:float_second` would have. As in CRuby, `NotImplementedError`
+  is a `ScriptError` and not caught by a bare `rescue`. `mruby-time` makes
+  the other choice for `Time#to_f`, which is a method that could only ever
+  answer in a Float; a unit is an argument, and refusing one argument is not
+  a reason to withdraw a method that answers six others.
+- **A reading too large for the build's Integer becomes a bigint, or a
+  RangeError where there are none.** A 32-bit `mrb_int` carries a wall clock
+  in seconds and not in milliseconds, and an `int64_t` carries one in
+  nanoseconds only until 2262. Where the build has `mruby-bigint` the answer
+  is a bigint, which is the Integer CRuby answers with, and that holds for a
+  reading the `int64_t` sum itself cannot hold as much as for one only the
+  Integer cannot: where the arithmetic in between runs out is a fact about
+  that arithmetic, not about the reading or about the Integer being asked
+  for. Where the build has no bigints, what is wrong with the value is its
+  size, so `RangeError` says so, as it does for an oversized pid below. The
+  two ends are pinned by tests that hand the conversion readings no clock
+  reaches, rather than left to a clock to arrive at in 2262.
+- **`Process.clock_getres` arrives with `Process.clock_gettime`.** A reading
+  says little without it — a monotonic clock that moves every 15ms and one
+  that moves every 100ns are read the same way — and adding it later would
+  mean revising every port a second time for the same seam. It takes one
+  unit the reading does not, `:hertz`, which is one over what
+  `:float_second` says: a resolution can be given as a rate, and a moment
+  cannot, which is where CRuby draws the line too. It is a Float like the
+  other Float units, so a build without one answers it the same way.
+- **A resolution describes how the clock is read, not the clock.** Where a
+  platform states the interval a clock advances on, that is what
+  `Process.clock_getres` answers; where it does not, the answer is the
+  granularity of the call the reading came out of, which is the finest two
+  readings can differ by. So a resolution here is a bound on what a caller
+  can distinguish, and a clock may well move more coarsely than it. The
+  alternative would be for a port to refuse wherever a platform declines to
+  commit to a true period, which is nearly every clock on every platform:
+  POSIX's own `clock_getres(2)` is a statement of the same kind, with Linux
+  answering 1ns for clocks whose readings move in tens or hundreds of them,
+  and CRuby reports the granularity of whatever it emulated a clock out of —
+  a microsecond for its `gettimeofday(2)`-based wall clock, a tick for the
+  `times(2)`-based CPU one. Every clock a port can read therefore has a
+  resolution to answer with, and `Process.clock_getres` fails only where
+  `Process.clock_gettime` would.
 - **A pid, a signal or a raw status too large for the platform is refused in
   the common layer.** What is wrong with such a value is its size, and size is
   not something a port can report: the HAL answers with an `errno`, which has
@@ -206,6 +306,39 @@ kept separate from adding this gem.
   reach the platform as they are written, which on POSIX is `kill(2)`'s
   caller's process group, every process the caller may signal, and the group
   whose ID is `-pid`.
+- A clock can be named by the Symbol its constant is named with, as in
+  CRuby: `Process.clock_gettime(:CLOCK_MONOTONIC)` reads what
+  `Process::CLOCK_MONOTONIC` numbers. That is worth more here than there,
+  the numbers being mruby's own rather than the platform's. The names CRuby
+  knows beyond these four are not here: the platform-specific clocks, and
+  the ways it emulates one the host lacks
+  (`:GETTIMEOFDAY_BASED_CLOCK_REALTIME` and the rest), which a port that
+  either has a clock or says it has not gives nothing to pick out. Such a
+  name raises `Errno::EINVAL`, which is what CRuby raises for a name it does
+  not know.
+- The clocks are the four every platform can be expected to answer for. The
+  platform-specific ones CRuby also defines where it finds them —
+  `CLOCK_MONOTONIC_RAW`, `CLOCK_BOOTTIME` and the rest — are not here; each
+  would need a name of mruby's own and an answer from every port.
+- On Windows each clock is read by one Win32 call, and its resolution is the
+  granularity of that call. The wall clock is
+  `GetSystemTimePreciseAsFileTime()` where there is one and the coarse
+  `GetSystemTimeAsFileTime()` on Windows 7 and older, and which of the two
+  this Windows has decides both how the clock is read and how finely. The
+  precise call writes a `FILETIME`, so its resolution is one 100ns tick;
+  the coarse call does not interpolate between clock interrupts, so
+  there it is the interval between two of them, from
+  `NtQueryTimerResolution()` where that can be reached and from
+  `GetSystemTimeAdjustment()`'s `TimeIncrement` otherwise. The two CPU clocks
+  are `GetProcessTimes()` and `GetThreadTimes()`, both `FILETIME`s again, so
+  both answer one tick. Windows documents no rate at which any of these
+  clocks advances, and this port states none: a tick is how finely a reading
+  written as a `FILETIME` can be told from the next, which is what a
+  resolution is here.
+- On the rare POSIX host without `clock_gettime(2)`, the wall clock reads
+  through `gettimeofday(2)`, and its resolution is the microsecond that call
+  writes its answer in — the same number CRuby reports for its own
+  `gettimeofday(2)`-based clock.
 - On Windows a wait status is the child's exit code and nothing more, so a
   status there always reads as exited — even for a process this gem terminated.
 - On Windows, `Process.waitpid` fails for every process: `ENOSYS` for a pid of

--- a/mrbgems/mruby-process/include/process_hal.h
+++ b/mrbgems/mruby-process/include/process_hal.h
@@ -12,9 +12,12 @@
 ** nothing about `Process::Status`, `$?`, `$$`, blocks or any other Ruby
 ** notion: those belong to the common sources under src/.  In the other
 ** direction, no platform type or macro (`pid_t`, `WIFEXITED`, `SIGTERM`,
-** `WNOHANG`, ...) crosses into the common layer: process and signal
-** numbers travel as `mrb_int`, wait options as the MRB_PROCESS_WAIT_* bits
-** below, and a decoded wait status as `mrb_process_status`.
+** `WNOHANG`, `CLOCK_MONOTONIC`, ...) crosses into the common layer: process
+** and signal numbers travel as `mrb_int`, wait options as the
+** MRB_PROCESS_WAIT_* bits below, a decoded wait status as
+** `mrb_process_status`, a clock as one of the `mrb_process_clock_id` values
+** and a time it reported as `mrb_process_clock_time`, whose two fields are
+** `int64_t` rather than `mrb_int` for the reason given where it is defined.
 **
 ** What a signal is *called* is not asked here at all.  mruby-signal owns
 ** that table, and both `Process.kill` and `Process::Status#to_s` reach it
@@ -25,6 +28,7 @@
 #define MRUBY_PROCESS_HAL_H
 
 #include <mruby.h>
+#include <stdint.h>
 
 MRB_BEGIN_DECL
 
@@ -75,6 +79,53 @@ typedef struct mrb_process_status {
 #define MRB_PROCESS_WAIT_ANY ((mrb_int)-1)
 
 /*
+ * Clocks
+ *
+ * Which clocks there are is mruby's own list rather than the platform's, as
+ * the wait options above are: `CLOCK_MONOTONIC` is 1 on Linux, 6 on macOS
+ * and 4 on FreeBSD, and Windows has no `clockid_t` to give it a number at
+ * all, so a program that names a clock would otherwise be naming a different
+ * one on each port.  The common layer refuses an id outside this list before
+ * a port sees it, and a port whose platform has no such clock fails that
+ * one with EINVAL.
+ */
+typedef enum mrb_process_clock_id {
+  MRB_PROCESS_CLOCK_REALTIME = 0,     /* wall clock, counted from the epoch */
+  MRB_PROCESS_CLOCK_MONOTONIC,        /* never steps; unspecified origin */
+  MRB_PROCESS_CLOCK_PROCESS_CPUTIME,  /* CPU time this process has spent */
+  MRB_PROCESS_CLOCK_THREAD_CPUTIME,   /* CPU time this thread has spent */
+  MRB_PROCESS_CLOCK_COUNT             /* how many ids there are; not a clock */
+} mrb_process_clock_id;
+
+/*
+ * A time a clock reported, kept in two fields so that nothing is lost on the
+ * way up.
+ *
+ * A Float would hold 53 of the 61 bits a wall-clock nanosecond needs, which
+ * would leave `:nanosecond` unable to answer honestly however it was asked,
+ * and a single count of nanoseconds runs out in 2262.  A port therefore
+ * always reports the same two numbers and knows nothing of the unit a caller
+ * wanted: arriving at that unit is the common layer's.
+ *
+ * The fields are `int64_t` rather than `mrb_int`, which is what every other
+ * quantity crossing this interface travels as.  A reading is a fact about
+ * the platform and its size is the platform's, so a port reports what its
+ * clock said; how much of that this build's Integer can carry is a question
+ * about mruby, and is answered where RangeError can be said and a bigint
+ * can be built.  Were it `mrb_int`, a build with a 32-bit one would have
+ * every port refusing the wall clock from 2038 on, through `errno`, which
+ * has no way to say that the platform was fine and the Integer was not.
+ * `int64_t` is no more a platform type than `mrb_int` is: `time_t`,
+ * `clockid_t` and FILETIME still stop at the port.
+ *
+ * `nsec` is always in [0, 999999999], whatever the platform counts in.
+ */
+typedef struct mrb_process_clock_time {
+  int64_t sec;
+  int64_t nsec;
+} mrb_process_clock_time;
+
+/*
  * HAL Interface Functions
  */
 
@@ -119,6 +170,56 @@ int mrb_hal_process_kill(mrb_state *mrb, mrb_int pid, mrb_int signo);
  */
 void mrb_hal_process_status_decode(mrb_state *mrb, mrb_int pid, mrb_int raw_status,
                                    mrb_process_status *status);
+
+/*
+ * Read a clock.
+ *
+ * MRB_PROCESS_CLOCK_REALTIME is counted from the Unix epoch and may step,
+ * backwards included, when the host's idea of the time is corrected.  The
+ * other three are counted from an origin this interface does not name; a
+ * port must keep whichever it uses fixed for the life of the process, since
+ * subtracting two readings is the whole of what such a clock is for.
+ *
+ * @param clock_id  one of the mrb_process_clock_id values
+ * @param t         out: the reading, with nsec normalized to [0, 999999999]
+ * @return 0 on success, -1 on error, with errno set.  A clock the platform
+ *         does not have is EINVAL; a port that could read no clock at all
+ *         would answer ENOSYS, as an inexpressible wait pid does.
+ */
+int mrb_hal_process_clock_gettime(mrb_state *mrb, mrb_int clock_id,
+                                  mrb_process_clock_time *t);
+
+/*
+ * The granularity a clock is read at: how finely the mechanism a reading
+ * comes out of can tell two moments apart.  It describes the way the port
+ * reads the clock, not the clock itself: the interval a reading is driven
+ * by where the platform states one, and otherwise the unit a reading is
+ * written in, which is the finest two of them can differ by.  A caller gets
+ * a bound on what it can distinguish, never a period the clock is promised
+ * to advance on, and a port must not answer anything finer than the
+ * mechanism it used, since that promises a difference no two readings can
+ * show.
+ *
+ * A reading says little without it, since a monotonic clock that moves every
+ * 15ms and one that moves every 100ns are read the same way, so a clock a
+ * port can read is one it can answer this for: whatever a reading came out
+ * of has a granularity, even where the clock behind it does not state one.
+ *
+ * The looseness is the platforms', not this interface's.  POSIX's own
+ * clock_getres(2) is a statement of the same kind, Linux answering 1ns for
+ * clocks whose readings move in tens or hundreds of them, and CRuby reports
+ * the granularity of what it emulated a clock out of: a microsecond for the
+ * gettimeofday(2)-based wall clock, a tick for the times(2)-based CPU one.
+ * A port that refused to answer wherever a platform would not commit to a
+ * true period would refuse for nearly every clock on every platform.
+ *
+ * @param clock_id  one of the mrb_process_clock_id values
+ * @param t         out: the granularity, never zero (the common layer
+ *                  divides by it to answer `:hertz`), nsec in [0, 999999999]
+ * @return 0 on success, -1 on error, as for a reading
+ */
+int mrb_hal_process_clock_getres(mrb_state *mrb, mrb_int clock_id,
+                                 mrb_process_clock_time *t);
 
 /*
  * HAL Initialization/Finalization

--- a/mrbgems/mruby-process/include/process_internal.h
+++ b/mrbgems/mruby-process/include/process_internal.h
@@ -11,6 +11,7 @@
 #define MRUBY_PROCESS_INTERNAL_H
 
 #include <mruby.h>
+#include "process_hal.h"
 
 MRB_BEGIN_DECL
 
@@ -24,6 +25,16 @@ void mrb_process_status_init(mrb_state *mrb, struct RClass *process);
 /* Build a Process::Status for a pid and the platform status it was reaped
    with.  The status decodes itself through the HAL as it is asked questions. */
 mrb_value mrb_process_status_new(mrb_state *mrb, mrb_int pid, mrb_int raw_status);
+
+/* Answer the clock reading `t` in the unit `unit` names.  `resolution` says
+   whether `t` is a resolution rather than a moment, which is what makes
+   `:hertz` a unit it can be asked for.  Shared with the gem's tests, which
+   hand it readings no clock reports: the ends of an int64_t and of this
+   build's Integer are decided here, so that is where they can be asked
+   about. */
+mrb_value mrb_process_clock_result(mrb_state *mrb, mrb_value unit,
+                                   const mrb_process_clock_time *t,
+                                   mrb_bool resolution);
 
 MRB_END_DECL
 

--- a/mrbgems/mruby-process/ports/posix/process_hal.c
+++ b/mrbgems/mruby-process/ports/posix/process_hal.c
@@ -4,20 +4,87 @@
 ** See Copyright Notice in mruby.h
 **
 ** POSIX implementation of the process HAL using getpid(2), getppid(2),
-** waitpid(2) and kill(2).
+** waitpid(2), kill(2), clock_gettime(2) and clock_getres(2), falling back to
+** gettimeofday(2) where the host has no POSIX clocks.
 ** Supported platforms: Linux, macOS, BSD, Unix
 */
 
 #include <mruby.h>
 #include "process_hal.h"
 
+#include <sys/time.h>
 #include <sys/types.h>
 #include <sys/wait.h>
 
 #include <errno.h>
 #include <limits.h>
 #include <signal.h>
+#include <stdint.h>
+#include <time.h>
 #include <unistd.h>
+
+/*
+ * Feature Capabilities
+ *
+ * Each MRB_PROCESS_HAVE_* is always defined, to 0 or 1, so the rest of this
+ * file tests it with #if rather than #ifdef; the #ifndef guard around each
+ * one lets a build override the detection below where it gets a host wrong.
+ */
+
+/* Whether this host has POSIX clocks.  _POSIX_TIMERS is the feature-test
+   macro for POSIX's interval-timer option (timer_create(2) and friends),
+   not for clock_gettime(2) itself, and Apple's libc leaves it undefined
+   because it has never implemented that option, even though clock_gettime(2)
+   and CLOCK_REALTIME/CLOCK_MONOTONIC have been there since macOS 10.12.
+   Relying on _POSIX_TIMERS alone therefore misses a host that plainly has
+   the call, so Apple is also asked for directly. Where the answer is no,
+   the wall clock is still reachable through gettimeofday(2) and nothing
+   else is. */
+#ifndef MRB_PROCESS_HAVE_CLOCK_GETTIME
+# if (defined(_POSIX_TIMERS) && (_POSIX_TIMERS + 0) > 0 && defined(CLOCK_REALTIME)) || \
+     (defined(__APPLE__) && defined(CLOCK_REALTIME))
+#  define MRB_PROCESS_HAVE_CLOCK_GETTIME 1
+# else
+#  define MRB_PROCESS_HAVE_CLOCK_GETTIME 0
+# endif
+#endif
+
+/* CLOCK_MONOTONIC is absent on a few old hosts that still have
+   CLOCK_REALTIME. */
+#ifndef MRB_PROCESS_HAVE_CLOCK_MONOTONIC
+# ifdef CLOCK_MONOTONIC
+#  define MRB_PROCESS_HAVE_CLOCK_MONOTONIC 1
+# else
+#  define MRB_PROCESS_HAVE_CLOCK_MONOTONIC 0
+# endif
+#endif
+
+/* The CPU-time clocks are both optional POSIX extensions. */
+#ifndef MRB_PROCESS_HAVE_CLOCK_PROCESS_CPUTIME
+# ifdef CLOCK_PROCESS_CPUTIME_ID
+#  define MRB_PROCESS_HAVE_CLOCK_PROCESS_CPUTIME 1
+# else
+#  define MRB_PROCESS_HAVE_CLOCK_PROCESS_CPUTIME 0
+# endif
+#endif
+
+#ifndef MRB_PROCESS_HAVE_CLOCK_THREAD_CPUTIME
+# ifdef CLOCK_THREAD_CPUTIME_ID
+#  define MRB_PROCESS_HAVE_CLOCK_THREAD_CPUTIME 1
+# else
+#  define MRB_PROCESS_HAVE_CLOCK_THREAD_CPUTIME 0
+# endif
+#endif
+
+/* Whether WIFSIGNALED's status can also say the process dumped core; not
+   every host's <sys/wait.h> defines this. */
+#ifndef MRB_PROCESS_HAVE_WCOREDUMP
+# ifdef WCOREDUMP
+#  define MRB_PROCESS_HAVE_WCOREDUMP 1
+# else
+#  define MRB_PROCESS_HAVE_WCOREDUMP 0
+# endif
+#endif
 
 /* An mrb_int is wider than a pid_t where mrb_int is 64-bit, so a pid from
    Ruby is range-checked rather than truncated into one. */
@@ -127,12 +194,116 @@ mrb_hal_process_status_decode(mrb_state *mrb, mrb_int pid, mrb_int raw_status,
   else if (WIFSIGNALED(raw)) {
     status->flags |= MRB_PROCESS_STATUS_SIGNALED;
     status->termsig = (mrb_int)WTERMSIG(raw);
-#ifdef WCOREDUMP
+#if MRB_PROCESS_HAVE_WCOREDUMP
     if (WCOREDUMP(raw)) {
       status->flags |= MRB_PROCESS_STATUS_COREDUMP;
     }
 #endif
   }
+}
+
+/*
+ * Clocks
+ */
+
+#if MRB_PROCESS_HAVE_CLOCK_GETTIME
+/* Which clockid_t stands for one of mruby's clocks here.  A clock this host
+   does not have is left out, and the caller answers EINVAL for it. */
+static int
+posix_clock_id(mrb_int clock_id, clockid_t *out)
+{
+  switch (clock_id) {
+  case MRB_PROCESS_CLOCK_REALTIME:
+    *out = CLOCK_REALTIME;
+    return 0;
+#if MRB_PROCESS_HAVE_CLOCK_MONOTONIC
+  case MRB_PROCESS_CLOCK_MONOTONIC:
+    *out = CLOCK_MONOTONIC;
+    return 0;
+#endif
+#if MRB_PROCESS_HAVE_CLOCK_PROCESS_CPUTIME
+  case MRB_PROCESS_CLOCK_PROCESS_CPUTIME:
+    *out = CLOCK_PROCESS_CPUTIME_ID;
+    return 0;
+#endif
+#if MRB_PROCESS_HAVE_CLOCK_THREAD_CPUTIME
+  case MRB_PROCESS_CLOCK_THREAD_CPUTIME:
+    *out = CLOCK_THREAD_CPUTIME_ID;
+    return 0;
+#endif
+  default:
+    break;
+  }
+  return -1;
+}
+#endif /* MRB_PROCESS_HAVE_CLOCK_GETTIME */
+
+int
+mrb_hal_process_clock_gettime(mrb_state *mrb, mrb_int clock_id,
+                              mrb_process_clock_time *t)
+{
+#if MRB_PROCESS_HAVE_CLOCK_GETTIME
+  clockid_t c;
+  struct timespec ts;
+  (void)mrb;
+
+  if (posix_clock_id(clock_id, &c) != 0) {
+    errno = EINVAL;
+    return -1;
+  }
+  if (clock_gettime(c, &ts) != 0) return -1;
+  t->sec = (int64_t)ts.tv_sec;
+  t->nsec = (int64_t)ts.tv_nsec;
+  return 0;
+#else
+  /* Without POSIX clocks the wall clock is the only one there is, and
+     gettimeofday(2) reads it to the microsecond. */
+  struct timeval tv;
+  (void)mrb;
+
+  if (clock_id != MRB_PROCESS_CLOCK_REALTIME) {
+    errno = EINVAL;
+    return -1;
+  }
+  if (gettimeofday(&tv, NULL) != 0) return -1;
+  t->sec = (int64_t)tv.tv_sec;
+  t->nsec = (int64_t)tv.tv_usec * 1000;
+  return 0;
+#endif
+}
+
+int
+mrb_hal_process_clock_getres(mrb_state *mrb, mrb_int clock_id,
+                             mrb_process_clock_time *t)
+{
+#if MRB_PROCESS_HAVE_CLOCK_GETTIME
+  clockid_t c;
+  struct timespec ts;
+  (void)mrb;
+
+  if (posix_clock_id(clock_id, &c) != 0) {
+    errno = EINVAL;
+    return -1;
+  }
+  if (clock_getres(c, &ts) != 0) return -1;
+  t->sec = (int64_t)ts.tv_sec;
+  t->nsec = (int64_t)ts.tv_nsec;
+  return 0;
+#else
+  /* A microsecond, which is what gettimeofday(2) writes its answer in and so
+     how finely this port reads the wall clock where that is the only way to
+     read it.  CRuby reports the same number for its own gettimeofday(2)-based
+     clock. */
+  (void)mrb;
+
+  if (clock_id != MRB_PROCESS_CLOCK_REALTIME) {
+    errno = EINVAL;
+    return -1;
+  }
+  t->sec = 0;
+  t->nsec = 1000;
+  return 0;
+#endif
 }
 
 /*

--- a/mrbgems/mruby-process/ports/win/process_hal.c
+++ b/mrbgems/mruby-process/ports/win/process_hal.c
@@ -22,6 +22,10 @@
 **     platform, so a decoded status always reads as exited;
 **   - only `KILL` and `TERM` can be delivered, both as TerminateProcess(),
 **     and signal 0 asks whether the process can be opened at all.
+**
+** The clocks are the one part Win32 answers in full: the wall clock as a
+** FILETIME, the monotonic one from the performance counter, and the two CPU
+** times from GetProcessTimes() and GetThreadTimes().
 */
 
 #include <mruby.h>
@@ -234,6 +238,371 @@ mrb_hal_process_status_decode(mrb_state *mrb, mrb_int pid, mrb_int raw_status,
   status->termsig = 0;
   status->stopsig = 0;
   status->flags = MRB_PROCESS_STATUS_EXITED;
+}
+
+/*
+ * Clocks
+ *
+ * Four clocks, each read through the Win32 call that suits it, and for each
+ * way of reading one the granularity that way reads at.  The two travel
+ * together as one `win_clock`, so neither is chosen without the other.
+ */
+
+/* A FILETIME counts 100ns intervals.  The wall-clock one is counted from
+   1601-01-01 UTC, which is FILETIME_EPOCH_DELTA of them before the Unix
+   epoch.
+
+   That 100ns is what this port answers as the granularity of every reading
+   written as a FILETIME: two moments closer together than a tick have no
+   room to be written down apart, and Windows states no rate at which the
+   clocks behind those readings move. */
+#define FILETIME_TICKS_PER_SEC 10000000LL
+#define FILETIME_EPOCH_DELTA   116444736000000000LL
+#define NSEC_PER_FILETIME_TICK 100
+
+#define NSEC_PER_SEC           1000000000LL
+
+static uint64_t
+filetime_to_u64(const FILETIME *ft)
+{
+  return ((uint64_t)ft->dwHighDateTime << 32) | (uint64_t)ft->dwLowDateTime;
+}
+
+/* Split a count of FILETIME ticks into seconds and nanoseconds, normalizing
+   a negative count downwards so that the nanoseconds land in the
+   [0, 999999999] the HAL promises. */
+static void
+clock_time_from_ticks(mrb_process_clock_time *t, int64_t ticks)
+{
+  t->sec = ticks / FILETIME_TICKS_PER_SEC;
+  t->nsec = (ticks % FILETIME_TICKS_PER_SEC) * NSEC_PER_FILETIME_TICK;
+
+  if (t->nsec < 0) {
+    t->sec -= 1;
+    t->nsec += NSEC_PER_SEC;
+  }
+}
+
+/*
+ * A Win32 entry point this port resolves at run time.
+ *
+ * Looked up rather than linked, so that one binary runs both on the Windows
+ * that has the call and on the one that does not, and remembered rather than
+ * looked up per reading, since a clock is read in loops.
+ *
+ * `slot` holds NULL before anything has looked, PROC_ABSENT once a lookup
+ * has come back empty, and the entry point itself otherwise.  PROC_ABSENT is
+ * any value a lookup could not return; NULL cannot serve, being what the
+ * slot already says before anyone has looked.
+ *
+ * The slot is published and read back through interlocked operations.  Two
+ * threads reading a clock at once would otherwise be writing and reading a
+ * plain static without synchronization, which is a data race whether or not
+ * they arrive at the same answer, and a race is undefined rather than merely
+ * unlikely to matter.  InitOnceExecuteOnce() would say this more directly,
+ * but it is Vista and later, and binding to it would cost this port the
+ * older Windows that resolving at run time is here to keep working on; the
+ * interlocked calls have been there since XP.
+ */
+typedef struct win_proc {
+  PVOID volatile slot;
+  const wchar_t *dll;
+  const char *name;
+} win_proc;
+
+#define PROC_ABSENT ((PVOID)(INT_PTR)-1)
+
+static PVOID
+resolve_proc(win_proc *p)
+{
+  PVOID resolved = InterlockedCompareExchangePointer(&p->slot, NULL, NULL);
+
+  if (resolved == NULL) {
+    HMODULE dll = GetModuleHandleW(p->dll);
+    /* Through void*: a FARPROC is not the function's own type, and a direct
+       cast between the two is what -Wcast-function-type warns about. */
+    resolved = (dll == NULL) ? NULL
+             : (PVOID)(void*)GetProcAddress(dll, p->name);
+    if (resolved == NULL) resolved = PROC_ABSENT;
+    /* Every thread that looked found the same entry point, so a later
+       write only repeats what is already in the slot. */
+    InterlockedExchangePointer(&p->slot, resolved);
+  }
+  return (resolved == PROC_ABSENT) ? NULL : resolved;
+}
+
+/* GetSystemTimePreciseAsFileTime(), or NULL where this Windows is older than
+   8 and has only the coarse reading. */
+typedef VOID (WINAPI *precise_system_time_fn)(LPFILETIME);
+
+static win_proc precise_time_proc = {
+  NULL, L"kernel32.dll", "GetSystemTimePreciseAsFileTime"
+};
+
+static precise_system_time_fn
+precise_system_time(void)
+{
+  return (precise_system_time_fn)resolve_proc(&precise_time_proc);
+}
+
+/* NtQueryTimerResolution() answers a live "CurrentResolution": the interval
+   the clock interrupt is firing at right now, in the FILETIME's unit.  That
+   is what the coarse wall clock moves by, and it is the one number Windows
+   will state that follows a timeBeginPeriod() call in either direction, so a
+   caller reading a clock on a system that has raised the interrupt rate is
+   told the rate it is being read at rather than the one the system booted
+   with.
+
+   Undocumented, but read rather than guessed at: it is ntdll's half of the
+   same pair NtSetTimerResolution() is, has answered this since XP, and is
+   how the runtimes already shipping on every Windows this port supports
+   answer the same question.  Where it cannot be reached,
+   GetSystemTimeAdjustment()'s TimeIncrement stands in below, naming the
+   interrupt the system booted with rather than the one it is keeping now. */
+typedef LONG (NTAPI *nt_query_timer_resolution_fn)(PULONG, PULONG, PULONG);
+
+static win_proc timer_resolution_proc = {
+  NULL, L"ntdll.dll", "NtQueryTimerResolution"
+};
+
+static nt_query_timer_resolution_fn
+nt_query_timer_resolution(void)
+{
+  return (nt_query_timer_resolution_fn)resolve_proc(&timer_resolution_proc);
+}
+
+/* The performance counter and its frequency, which is what the monotonic
+   clock is read from.  Windows documents both calls as succeeding on every
+   version this port supports, so the failure arm below is only there to keep
+   an undocumented failure from being read as a time.  A frequency above
+   INT64_MAX / NSEC_PER_SEC, about 9.2GHz, is refused rather than wrapped:
+   `(counter % freq) * NSEC_PER_SEC` would overflow past it. */
+static int
+performance_counter(int64_t *counter, int64_t *freq)
+{
+  LARGE_INTEGER c, f;
+
+  if (!QueryPerformanceFrequency(&f) || !QueryPerformanceCounter(&c)) {
+    set_errno_from_win32(GetLastError());
+    return -1;
+  }
+  if (f.QuadPart <= 0 || f.QuadPart > INT64_MAX / NSEC_PER_SEC) {
+    errno = EINVAL;
+    return -1;
+  }
+  *counter = (int64_t)c.QuadPart;
+  *freq = (int64_t)f.QuadPart;
+  return 0;
+}
+
+/*
+ * Readings
+ */
+
+static void
+wall_clock_from_filetime(mrb_process_clock_time *t, const FILETIME *ft)
+{
+  clock_time_from_ticks(t, (int64_t)filetime_to_u64(ft) - FILETIME_EPOCH_DELTA);
+}
+
+/* The wall clock as GetSystemTimePreciseAsFileTime() interpolates it between
+   two clock interrupts.  win_clock_for() selects this pair only after the
+   lookup has answered, so the entry point here is never NULL. */
+static int
+precise_wall_read(mrb_process_clock_time *t)
+{
+  FILETIME ft;
+
+  precise_system_time()(&ft);
+  wall_clock_from_filetime(t, &ft);
+  return 0;
+}
+
+/* The wall clock as the clock interrupt leaves it, which is the only reading
+   of it a Windows older than 8 has. */
+static int
+coarse_wall_read(mrb_process_clock_time *t)
+{
+  FILETIME ft;
+
+  GetSystemTimeAsFileTime(&ft);
+  wall_clock_from_filetime(t, &ft);
+  return 0;
+}
+
+static int
+monotonic_read(mrb_process_clock_time *t)
+{
+  int64_t counter, freq;
+
+  /* The performance counter never steps, and Windows names no origin for it
+     beyond a point it fixes itself and holds while the system runs.  That is
+     all this clock is asked for: the origin stands for the life of the
+     process, so two readings can be subtracted, which is what a caller has
+     one of these for. */
+  if (performance_counter(&counter, &freq) != 0) return -1;
+  t->sec = counter / freq;
+  t->nsec = (counter % freq) * NSEC_PER_SEC / freq;
+  return 0;
+}
+
+/* The CPU time a process or a thread has spent, as the sum of the kernel and
+   user halves Win32 reports it in. */
+static int
+cpu_time(mrb_bool thread, mrb_process_clock_time *t)
+{
+  FILETIME creation, exit, kernel, user;
+  BOOL ok;
+
+  if (thread) {
+    ok = GetThreadTimes(GetCurrentThread(), &creation, &exit, &kernel, &user);
+  }
+  else {
+    ok = GetProcessTimes(GetCurrentProcess(), &creation, &exit, &kernel, &user);
+  }
+  if (!ok) {
+    set_errno_from_win32(GetLastError());
+    return -1;
+  }
+  clock_time_from_ticks(t, (int64_t)(filetime_to_u64(&kernel) +
+                                     filetime_to_u64(&user)));
+  return 0;
+}
+
+static int
+process_cpu_read(mrb_process_clock_time *t)
+{
+  return cpu_time(FALSE, t);
+}
+
+static int
+thread_cpu_read(mrb_process_clock_time *t)
+{
+  return cpu_time(TRUE, t);
+}
+
+/*
+ * Granularities
+ */
+
+/* One tick of a FILETIME: the precise wall clock and both CPU clocks are all
+   read as FILETIMEs, so this is the granularity of all three.  The FILETIME
+   macros above say why a tick is what this port can state about them. */
+static int
+filetime_tick_resolution(mrb_process_clock_time *t)
+{
+  t->sec = 0;
+  t->nsec = NSEC_PER_FILETIME_TICK;
+  return 0;
+}
+
+/* The interval between two clock interrupts as it stands now, which is what
+   the coarse wall clock moves by: that reading does not interpolate, so it
+   is no finer than the interrupt that updates it. */
+static int
+clock_interrupt_resolution(mrb_process_clock_time *t)
+{
+  nt_query_timer_resolution_fn query = nt_query_timer_resolution();
+  ULONG minimum, maximum, current;
+  DWORD adjustment, increment;
+  BOOL disabled;
+
+  t->sec = 0;
+  if (query != NULL && query(&minimum, &maximum, &current) == 0) {
+    t->nsec = (int64_t)current * NSEC_PER_FILETIME_TICK;
+    return 0;
+  }
+  if (!GetSystemTimeAdjustment(&adjustment, &increment, &disabled)) {
+    set_errno_from_win32(GetLastError());
+    return -1;
+  }
+  t->nsec = (int64_t)increment * NSEC_PER_FILETIME_TICK;
+  return 0;
+}
+
+/* A tick of the performance counter, rounded up.  A frequency that does not
+   divide a second into whole nanoseconds would otherwise be reported as
+   finer than it is, saying that two readings a tick apart can differ by less
+   than a tick; rounding up also keeps a frequency above 1GHz from flooring
+   to nothing, and a granularity of nothing is not one. */
+static int
+performance_counter_resolution(mrb_process_clock_time *t)
+{
+  int64_t counter, freq;
+
+  /* The counter is read and dropped: performance_counter() answers both, and
+     a granularity is the frequency alone. */
+  if (performance_counter(&counter, &freq) != 0) return -1;
+  t->sec = 0;
+  t->nsec = (NSEC_PER_SEC + freq - 1) / freq;
+  return 0;
+}
+
+/*
+ * A way of reading one clock, paired with the granularity that way of
+ * reading has; mrb_hal_process_clock_getres() in process_hal.h says what
+ * such a granularity is.  Keeping the two in one struct is what stops them
+ * drifting apart, and three pairs share filetime_tick_resolution() because
+ * three of the readings are FILETIMEs.
+ */
+typedef struct win_clock {
+  int (*read)(mrb_process_clock_time *t);
+  int (*resolution)(mrb_process_clock_time *t);
+} win_clock;
+
+static const win_clock precise_wall_clock =
+  { precise_wall_read, filetime_tick_resolution };
+static const win_clock coarse_wall_clock =
+  { coarse_wall_read, clock_interrupt_resolution };
+static const win_clock monotonic_clock =
+  { monotonic_read, performance_counter_resolution };
+static const win_clock process_cpu_clock =
+  { process_cpu_read, filetime_tick_resolution };
+static const win_clock thread_cpu_clock =
+  { thread_cpu_read, filetime_tick_resolution };
+
+static const win_clock *
+win_clock_for(mrb_int clock_id)
+{
+  switch (clock_id) {
+  case MRB_PROCESS_CLOCK_REALTIME:
+    /* Which wall clock this Windows has decides both how it is read and how
+       finely it is read, so it is asked once and answered as a pair. */
+    if (precise_system_time() != NULL) return &precise_wall_clock;
+    return &coarse_wall_clock;
+  case MRB_PROCESS_CLOCK_MONOTONIC:       return &monotonic_clock;
+  case MRB_PROCESS_CLOCK_PROCESS_CPUTIME: return &process_cpu_clock;
+  case MRB_PROCESS_CLOCK_THREAD_CPUTIME:  return &thread_cpu_clock;
+  default:                                return NULL;
+  }
+}
+
+int
+mrb_hal_process_clock_gettime(mrb_state *mrb, mrb_int clock_id,
+                              mrb_process_clock_time *t)
+{
+  const win_clock *c = win_clock_for(clock_id);
+  (void)mrb;
+
+  if (c == NULL) {
+    errno = EINVAL;
+    return -1;
+  }
+  return c->read(t);
+}
+
+int
+mrb_hal_process_clock_getres(mrb_state *mrb, mrb_int clock_id,
+                             mrb_process_clock_time *t)
+{
+  const win_clock *c = win_clock_for(clock_id);
+  (void)mrb;
+
+  if (c == NULL) {
+    errno = EINVAL;
+    return -1;
+  }
+  return c->resolution(t);
 }
 
 /*

--- a/mrbgems/mruby-process/src/process.c
+++ b/mrbgems/mruby-process/src/process.c
@@ -14,12 +14,16 @@
 #include <mruby/error.h>
 #include <mruby/string.h>
 #include <mruby/variable.h>
+#ifdef MRB_USE_BIGINT
+#include <mruby/internal.h>
+#endif
 #include "process_hal.h"
 #include "process_internal.h"
 #include "signal_hal.h"
 
 #include <errno.h>
 #include <limits.h>
+#include <stdint.h>
 #include <string.h>
 
 /* `$?` and `$$` are not word names, so MRB_GVSYM() cannot spell them and
@@ -304,6 +308,458 @@ process_waitpid2(mrb_state *mrb, mrb_value self)
   return mrb_assoc_new(mrb, pid, status);
 }
 
+/*
+ * Clocks
+ *
+ * A reading crosses the HAL as whole seconds and nanoseconds, and everything
+ * Ruby says about it is said here: which numbers name a clock, which unit
+ * names are understood, whether the answer is an Integer or a Float, and
+ * what happens where this build has no Float to answer with.  A port always
+ * reports the same two numbers and is asked nothing about any of that.
+ */
+
+#define NSEC_PER_SEC 1000000000
+
+/*
+ * Put `sec` seconds and `frac` `per_sec`-ths of one together, and say
+ * whether they fit an int64_t at all.
+ *
+ * int64_t's own ends are split into the same two parts as a reading, so that
+ * whole seconds are weighed against whole seconds and fractions against
+ * fractions, and no product is asked for that is itself past int64_t.  The
+ * second `INT64_MIN` falls in is one below what `INT64_MIN / per_sec` gives,
+ * C dividing towards zero rather than downwards, and its own product is off
+ * the end; a reading landing in that last second is counted up from
+ * `INT64_MIN` instead of multiplied.
+ *
+ * `frac` is at least zero and less than `per_sec`, a reading's nanoseconds
+ * being carried into its seconds before it is handed up, so the fraction
+ * only ever moves a value towards positive.
+ */
+static mrb_bool
+clock_int64_value(int64_t sec, int64_t frac, int64_t per_sec, int64_t *value)
+{
+  int64_t max_sec = INT64_MAX / per_sec, max_frac = INT64_MAX % per_sec;
+  int64_t min_sec = INT64_MIN / per_sec, min_frac = INT64_MIN % per_sec;
+
+  if (min_frac != 0) { /* min_sec is one above the second INT64_MIN falls in */
+    min_sec -= 1;
+    min_frac += per_sec;
+  }
+  if (sec > max_sec || (sec == max_sec && frac > max_frac)) return FALSE;
+  if (sec < min_sec || (sec == min_sec && frac < min_frac)) return FALSE;
+
+  *value = (sec == min_sec) ? INT64_MIN + (frac - min_frac) : sec * per_sec + frac;
+  return TRUE;
+}
+
+#ifdef MRB_USE_BIGINT
+/*
+ * The same sum built as a bigint, for a reading past what an int64_t holds.
+ *
+ * How large a reading is, is the platform's business, and the HAL carries it
+ * whole; how much of it an Integer can hold is mruby's, and a build with
+ * bigints can hold all of it however the reading is scaled.  Nothing about
+ * the answer is decided by the width of the arithmetic that would have been
+ * used: the sum comes back normalized, so one that turns out to fit is an
+ * ordinary Integer.
+ *
+ * That normalizing is not only the final sum's to do: `sec * per_sec` is
+ * itself a bigint multiply, and mrb_bint_mul() normalizes its own result the
+ * same way, so a product that turns out to fit is handed back as an ordinary
+ * Integer already, which happens whenever `sec` is small enough that only
+ * adding `frac` pushes the total past what fits.  mrb_as_bint() is the part
+ * that keeps the add after it correct either way: it takes a bigint back
+ * unchanged and widens an ordinary Integer rather than assuming the product
+ * stayed one.
+ */
+static mrb_value
+clock_bint_result(mrb_state *mrb, int64_t sec, int64_t frac, int64_t per_sec)
+{
+  mrb_value value = mrb_bint_mul(mrb, mrb_bint_new_int64(mrb, sec),
+                                 mrb_bint_new_int64(mrb, per_sec));
+  return mrb_bint_add(mrb, mrb_as_bint(mrb, value), mrb_bint_new_int64(mrb, frac));
+}
+#endif
+
+/*
+ * Read `t` as a whole number of `per_sec`-ths of a second.
+ *
+ * The nanoseconds contribute whatever the unit can hold of them and the rest
+ * is dropped, which is the truncation CRuby does: an integer unit answers
+ * with the reading as of the last tick of that unit, never with the one
+ * after it.
+ *
+ * A value the build's Integer cannot hold is answered as a bigint where the
+ * build has them, which is the Integer CRuby answers with, and refused with
+ * RangeError where it has not, the way an oversized pid is refused above.
+ * That is reachable rather than theoretical: a wall clock in nanoseconds is
+ * about 1.8e18, which fits a 64-bit mrb_int and no narrower one, and in
+ * milliseconds it is already past what 32 bits hold.  Past what an int64_t
+ * holds, a wall clock in nanoseconds from 2262 on, is answered the same way.
+ * This is the only place a reading meets mruby's Integer: a port hands up
+ * what its clock said, in int64_t, so a wall clock in seconds outgrowing a
+ * 32-bit mrb_int in 2038 arrives here like any other value too large to hand
+ * back.
+ */
+static mrb_value
+clock_int_result(mrb_state *mrb, mrb_sym unit, const mrb_process_clock_time *t,
+                 int64_t per_sec)
+{
+  int64_t frac = t->nsec / (NSEC_PER_SEC / per_sec);
+  int64_t value;
+
+#ifdef MRB_USE_BIGINT
+  (void)unit; /* nothing is refused for its size where there are bigints */
+#endif
+
+  if (!clock_int64_value(t->sec, frac, per_sec, &value)) {
+#ifdef MRB_USE_BIGINT
+    return clock_bint_result(mrb, t->sec, frac, per_sec);
+#else
+    goto too_large;
+#endif
+  }
+#if MRB_INT_MAX < INT64_MAX
+  if (value > MRB_INT_MAX || value < MRB_INT_MIN) {
+# ifdef MRB_USE_BIGINT
+    return mrb_bint_new_int64(mrb, value);
+# else
+    goto too_large;
+# endif
+  }
+#endif
+  return mrb_int_value(mrb, (mrb_int)value);
+
+#ifndef MRB_USE_BIGINT
+too_large:
+  mrb_raisef(mrb, E_RANGE_ERROR, "clock reading in %n does not fit an Integer", unit);
+  /* not reached */
+  return mrb_nil_value();
+#endif
+}
+
+#ifndef MRB_NO_FLOAT
+/*
+ * Read `t` as a fractional number of `per_sec`-ths of a second.
+ *
+ * The two fields are scaled apart rather than added first, so that the
+ * nanoseconds are not rounded away against a wall-clock second before they
+ * are used.  `NSEC_PER_SEC / per_sec` is exact for every unit here, being a
+ * power of ten small enough to be written whole in an mrb_float, a float32
+ * build included.
+ */
+static mrb_value
+clock_float_result(mrb_state *mrb, const mrb_process_clock_time *t, mrb_float per_sec)
+{
+  mrb_float value = (mrb_float)t->sec * per_sec +
+                    (mrb_float)t->nsec / ((mrb_float)NSEC_PER_SEC / per_sec);
+  return mrb_float_value(mrb, value);
+}
+
+/*
+ * Read a resolution as the number of times a second it can tell apart, which
+ * is one over what `:float_second` would say.
+ *
+ * Divided out of the nanoseconds rather than out of a fraction of a second,
+ * so that a resolution which is a whole number of them, which is every one a
+ * port can report, comes back as a whole number of hertz wherever one
+ * exists: 1ns is 1000000000.0 and 100ns is 10000000.0, where dividing 1.0 by
+ * a rounded fraction of a second would land beside them.
+ *
+ * The divisor is mrb_hal_process_clock_getres()'s promise that a
+ * granularity is never zero; no check stands behind it here.  The gem's
+ * tests are the one caller that could break it, and a zero there divides to
+ * infinity rather than trapping.
+ */
+static mrb_value
+clock_hertz_result(mrb_state *mrb, const mrb_process_clock_time *t)
+{
+  mrb_float nsec = (mrb_float)t->sec * (mrb_float)NSEC_PER_SEC + (mrb_float)t->nsec;
+  return mrb_float_value(mrb, (mrb_float)NSEC_PER_SEC / nsec);
+}
+#endif
+
+/*
+ * The unit a caller named, or the one leaving it out means.
+ *
+ * The unit is a Symbol, as it is in CRuby, which takes nothing else: a
+ * String naming the same thing is not a unit, and neither is a number.
+ * `nil` is the one value that is not a Symbol and not refused: naming no
+ * unit is what a caller who passes it means, which is what leaving the
+ * argument out means, and CRuby cannot tell the two apart at all: an
+ * omitted unit arrives there as `nil`.
+ *
+ * `resolution` says whether the answer being asked for is one, which
+ * decides `:hertz`: a resolution can be asked for as a rate, and a clock
+ * reading cannot, since there is no rate at which a moment happened.
+ * CRuby draws the line in the same place, and answers a reading asked for
+ * in hertz with the same "unexpected unit" this falls through to.
+ *
+ * Takes no reading as an argument: whether a unit is one this build knows
+ * is a mistake in the call, not a fact about what the platform's clock can
+ * do, and is settled before a port is ever asked for one.  Callers resolve
+ * the unit first and let the HAL call fail afterward, so a bad unit is
+ * reported as that rather than as whatever errno the HAL happened to fail
+ * with first.
+ */
+static mrb_sym
+clock_unit_resolve(mrb_state *mrb, mrb_value unit, mrb_bool resolution)
+{
+  mrb_sym u;
+
+  if (mrb_undef_p(unit) || mrb_nil_p(unit)) {
+    u = MRB_SYM(float_second);
+  }
+  else if (mrb_symbol_p(unit)) {
+    u = mrb_symbol(unit);
+  }
+  else {
+    mrb_raisef(mrb, E_ARGUMENT_ERROR, "unexpected unit: %!v", unit);
+    return 0; /* not reached */
+  }
+
+  if (u == MRB_SYM(second) || u == MRB_SYM(millisecond) ||
+      u == MRB_SYM(microsecond) || u == MRB_SYM(nanosecond)) {
+    return u;
+  }
+#ifndef MRB_NO_FLOAT
+  if (u == MRB_SYM(float_second) || u == MRB_SYM(float_millisecond) ||
+      u == MRB_SYM(float_microsecond)) {
+    return u;
+  }
+  if (resolution && u == MRB_SYM(hertz)) return u;
+#else
+  /* Without a Float there is nothing to hand back, and the method is not
+     made to disappear for it: a program written once is told at the call
+     site what this build will not do, as it is told what a platform will
+     not do.  The integer units above are untouched, and `:nanosecond` says
+     everything `:float_second` would have wherever this build's Integer can
+     carry it. */
+  if (u == MRB_SYM(float_second) || u == MRB_SYM(float_millisecond) ||
+      u == MRB_SYM(float_microsecond) || (resolution && u == MRB_SYM(hertz))) {
+    mrb_raisef(mrb, E_NOTIMP_ERROR, "%n needs a build with Float", u);
+  }
+#endif
+  mrb_raisef(mrb, E_ARGUMENT_ERROR, "unexpected unit: %n", u);
+  /* not reached */
+  return 0;
+}
+
+/* Answer a reading in the unit `u` already resolved to: a dispatch on the
+   unit alone, the ends of an int64_t and of this build's Integer being
+   clock_int_result's. */
+static mrb_value
+clock_unit_convert(mrb_state *mrb, mrb_sym u, const mrb_process_clock_time *t,
+                   mrb_bool resolution)
+{
+  if (u == MRB_SYM(second))      return clock_int_result(mrb, u, t, 1);
+  if (u == MRB_SYM(millisecond)) return clock_int_result(mrb, u, t, 1000);
+  if (u == MRB_SYM(microsecond)) return clock_int_result(mrb, u, t, 1000000);
+  if (u == MRB_SYM(nanosecond))  return clock_int_result(mrb, u, t, NSEC_PER_SEC);
+#ifndef MRB_NO_FLOAT
+  if (u == MRB_SYM(float_second))      return clock_float_result(mrb, t, 1.0);
+  if (u == MRB_SYM(float_millisecond)) return clock_float_result(mrb, t, 1.0e3);
+  if (u == MRB_SYM(float_microsecond)) return clock_float_result(mrb, t, 1.0e6);
+  if (resolution && u == MRB_SYM(hertz)) return clock_hertz_result(mrb, t);
+#endif
+  /* u is clock_unit_resolve's own return value, which never hands back
+     anything other than one of the symbols above. */
+  return mrb_nil_value(); /* not reached */
+}
+
+/* mrb_process_clock_result: clock_unit_resolve and clock_unit_convert in one
+   step.  process_internal.h says why the tests are handed this. */
+mrb_value
+mrb_process_clock_result(mrb_state *mrb, mrb_value unit,
+                         const mrb_process_clock_time *t, mrb_bool resolution)
+{
+  mrb_sym u = clock_unit_resolve(mrb, unit, resolution);
+  return clock_unit_convert(mrb, u, t, resolution);
+}
+
+/*
+ * The clock a Symbol names, or -1 for one that names none of them.
+ *
+ * A clock can be named as well as numbered, as it can in CRuby, and the name
+ * is the constant's: `Process.clock_gettime(:CLOCK_MONOTONIC)` reads what
+ * `Process::CLOCK_MONOTONIC` numbers.  That is worth more here than there,
+ * since the numbers are mruby's own, so a program that names its clock
+ * rather than numbering it reads the same on both.
+ *
+ * CRuby knows further names: the clocks only some platforms have, and the
+ * ways it emulates one the host lacks (`:GETTIMEOFDAY_BASED_CLOCK_REALTIME`
+ * and the rest).  A port here either has one of the four or says it has not,
+ * so there is nothing for such a name to pick out, and it names no clock the
+ * way an unknown name in CRuby names none.
+ */
+static mrb_int
+clock_id_for_sym(mrb_sym name)
+{
+  if (name == MRB_SYM(CLOCK_REALTIME))
+    return MRB_PROCESS_CLOCK_REALTIME;
+  if (name == MRB_SYM(CLOCK_MONOTONIC))
+    return MRB_PROCESS_CLOCK_MONOTONIC;
+  if (name == MRB_SYM(CLOCK_PROCESS_CPUTIME_ID))
+    return MRB_PROCESS_CLOCK_PROCESS_CPUTIME;
+  if (name == MRB_SYM(CLOCK_THREAD_CPUTIME_ID))
+    return MRB_PROCESS_CLOCK_THREAD_CPUTIME;
+  return -1;
+}
+
+/*
+ * Fail naming the call and the clock it was asked for, as CRuby names it:
+ * "clock_gettime(:NOPE)", not "clock_gettime".  What went wrong is the
+ * clock rather than the call, and a caller who named one is shown the name
+ * back rather than a number never written.
+ *
+ * The description is built before `errno` is handed on because building a
+ * String allocates, and an allocation can leave `errno` anywhere.
+ */
+static void
+clock_sys_fail(mrb_state *mrb, const char *what, mrb_value clock_id)
+{
+  int no = errno;
+  const char *at =
+    mrb_str_to_cstr(mrb, mrb_format(mrb, "%s(%!v)", what, clock_id));
+
+  errno = no;
+  mrb_sys_fail(mrb, at);
+}
+
+/*
+ * Read a clock argument into one of mruby's own clock numbers.
+ *
+ * An id outside the list is refused before a port sees it, as an unknown
+ * wait flag is; the list is mruby's own, for the reason process_hal.h
+ * gives.  It is refused with the errno a platform's own call answers for a
+ * clock it does not have, which is what CRuby raises here too, rather than
+ * with RangeError: nothing is wrong with the size of the number, it simply
+ * names no clock.  A name that picks out none of the four arrives at the
+ * same place, since it says the same thing.
+ */
+static mrb_int
+clock_id_arg(mrb_state *mrb, mrb_value clock_id, const char *what)
+{
+  mrb_int id;
+
+  if (mrb_symbol_p(clock_id)) {
+    id = clock_id_for_sym(mrb_symbol(clock_id));
+  }
+  else {
+    /* A String is not a name: it is refused for its type, as CRuby refuses
+       it, rather than read for a clock name it might spell. */
+    id = mrb_as_int(mrb, clock_id);
+  }
+  if (id < 0 || id >= MRB_PROCESS_CLOCK_COUNT) {
+    errno = EINVAL;
+    clock_sys_fail(mrb, what, clock_id);
+  }
+  return id;
+}
+
+/*
+ * call-seq:
+ *   Process.clock_gettime(clock_id, unit = :float_second) -> float or integer
+ *
+ * Reads the clock +clock_id+ names and returns what it says, in +unit+.
+ *
+ *   Process.clock_gettime(Process::CLOCK_MONOTONIC)               #=> 1234.5678
+ *   Process.clock_gettime(Process::CLOCK_MONOTONIC, :nanosecond)  #=> 1234567800000
+ *
+ * The clock is one of Process::CLOCK_REALTIME, which is the wall clock
+ * counted from the Unix epoch and may step when the host's idea of the time
+ * is corrected; Process::CLOCK_MONOTONIC, which never steps and is counted
+ * from an origin the platform chooses and this process keeps;
+ * Process::CLOCK_PROCESS_CPUTIME_ID, the CPU time this process has spent;
+ * and Process::CLOCK_THREAD_CPUTIME_ID, the CPU time this thread has spent.
+ * All four are defined everywhere, and one this platform does not have
+ * raises Errno::EINVAL, as a number naming no clock at all does.
+ *
+ * A clock can also be named by the Symbol its constant is named with, as in
+ * CRuby, so that a program need not depend on the number:
+ *
+ *   Process.clock_gettime(:CLOCK_MONOTONIC)  #=> 1234.5678
+ *
+ * A Symbol naming none of the four raises Errno::EINVAL too.
+ *
+ * The unit is +:float_second+, +:float_millisecond+, +:float_microsecond+,
+ * which answer with a Float, or +:second+, +:millisecond+, +:microsecond+,
+ * +:nanosecond+, which answer with an Integer, dropping what the unit cannot
+ * hold rather than rounding it.  Process.clock_getres takes +:hertz+ as
+ * well, and a reading asked for in it raises ArgumentError here.  Passing
+ * +nil+ names no unit, and answers in the default, as leaving the argument
+ * out does.  Any other unit raises ArgumentError, and in a build without
+ * Float the three Float units raise NotImplementedError.
+ * An answer too large for this build's Integer raises RangeError, unless the
+ * build has bigints for it to be answered in.
+ */
+static mrb_value
+process_clock_gettime(mrb_state *mrb, mrb_value self)
+{
+  mrb_value clock_id, unit = mrb_undef_value();
+  mrb_process_clock_time t;
+  mrb_int id;
+  mrb_sym u;
+
+  mrb_get_args(mrb, "o|o", &clock_id, &unit);
+  id = clock_id_arg(mrb, clock_id, "clock_gettime");
+  /* Resolved before the HAL is asked; see clock_unit_resolve(). */
+  u = clock_unit_resolve(mrb, unit, FALSE);
+
+  if (mrb_hal_process_clock_gettime(mrb, id, &t) != 0) {
+    clock_sys_fail(mrb, "clock_gettime", clock_id);
+  }
+  return clock_unit_convert(mrb, u, &t, FALSE);
+}
+
+/*
+ * call-seq:
+ *   Process.clock_getres(clock_id, unit = :float_second) -> float or integer
+ *
+ * How finely the clock +clock_id+ names is read: the smallest difference
+ * two readings of it can show, in +unit+.
+ *
+ *   Process.clock_getres(Process::CLOCK_MONOTONIC, :nanosecond)  #=> 1
+ *
+ * The clocks and the units are Process.clock_gettime's, and so are the
+ * errors.  A resolution finer than the unit asked for reads as 0 in an
+ * integer unit, since that is what is left of it after the truncation.
+ *
+ * This describes the way the platform is read rather than the clock behind
+ * it: where the platform states the interval a clock advances on, that is
+ * the answer, and where it does not, the answer is the granularity of the
+ * call the reading came out of.  A reading is never distinguishable more
+ * finely than this, and may well move more coarsely.  CRuby answers on the
+ * same terms.
+ *
+ * A resolution can also be asked for as +:hertz+, the number of times a
+ * second the clock can be told apart, which is one over what +:float_second+
+ * says and is a Float like the rest of the Float units.  A clock reading
+ * cannot be asked for in hertz, there being no rate at which a moment
+ * happened, which is where CRuby draws the line too.
+ *
+ *   Process.clock_getres(Process::CLOCK_MONOTONIC, :hertz)  #=> 1000000000.0
+ */
+static mrb_value
+process_clock_getres(mrb_state *mrb, mrb_value self)
+{
+  mrb_value clock_id, unit = mrb_undef_value();
+  mrb_process_clock_time t;
+  mrb_int id;
+  mrb_sym u;
+
+  mrb_get_args(mrb, "o|o", &clock_id, &unit);
+  id = clock_id_arg(mrb, clock_id, "clock_getres");
+  /* Resolved before the HAL is asked; see clock_unit_resolve(). */
+  u = clock_unit_resolve(mrb, unit, TRUE);
+
+  if (mrb_hal_process_clock_getres(mrb, id, &t) != 0) {
+    clock_sys_fail(mrb, "clock_getres", clock_id);
+  }
+  return clock_unit_convert(mrb, u, &t, TRUE);
+}
+
 void
 mrb_mruby_process_gem_init(mrb_state *mrb)
 {
@@ -321,6 +777,18 @@ mrb_mruby_process_gem_init(mrb_state *mrb)
   mrb_define_const_id(mrb, process, MRB_SYM(WUNTRACED),
                       mrb_fixnum_value(MRB_PROCESS_WAIT_UNTRACED));
 
+  /* The clock numbers are mruby's own too; see process_hal.h.  All four are
+     defined everywhere, so a program is told at the call site where a
+     platform has no such clock rather than finding the constant missing. */
+  mrb_define_const_id(mrb, process, MRB_SYM(CLOCK_REALTIME),
+                      mrb_fixnum_value(MRB_PROCESS_CLOCK_REALTIME));
+  mrb_define_const_id(mrb, process, MRB_SYM(CLOCK_MONOTONIC),
+                      mrb_fixnum_value(MRB_PROCESS_CLOCK_MONOTONIC));
+  mrb_define_const_id(mrb, process, MRB_SYM(CLOCK_PROCESS_CPUTIME_ID),
+                      mrb_fixnum_value(MRB_PROCESS_CLOCK_PROCESS_CPUTIME));
+  mrb_define_const_id(mrb, process, MRB_SYM(CLOCK_THREAD_CPUTIME_ID),
+                      mrb_fixnum_value(MRB_PROCESS_CLOCK_THREAD_CPUTIME));
+
   mrb_define_module_function_id(mrb, process, MRB_SYM(pid),     process_pid,     MRB_ARGS_NONE());
   mrb_define_module_function_id(mrb, process, MRB_SYM(ppid),    process_ppid,    MRB_ARGS_NONE());
   mrb_define_module_function_id(mrb, process, MRB_SYM(kill),    process_kill,    MRB_ARGS_REQ(2)|MRB_ARGS_REST());
@@ -328,6 +796,8 @@ mrb_mruby_process_gem_init(mrb_state *mrb)
   mrb_define_module_function_id(mrb, process, MRB_SYM(wait),     process_waitpid,  MRB_ARGS_OPT(2));
   mrb_define_module_function_id(mrb, process, MRB_SYM(waitpid2), process_waitpid2, MRB_ARGS_OPT(2));
   mrb_define_module_function_id(mrb, process, MRB_SYM(wait2),    process_waitpid2, MRB_ARGS_OPT(2));
+  mrb_define_module_function_id(mrb, process, MRB_SYM(clock_gettime), process_clock_gettime, MRB_ARGS_ARG(1, 1));
+  mrb_define_module_function_id(mrb, process, MRB_SYM(clock_getres),  process_clock_getres,  MRB_ARGS_ARG(1, 1));
 
   mrb_process_status_init(mrb, process);
 

--- a/mrbgems/mruby-process/test/process.c
+++ b/mrbgems/mruby-process/test/process.c
@@ -1,5 +1,10 @@
 #include <mruby.h>
 #include <mruby/class.h>
+#include "process_hal.h"
+#include "process_internal.h"
+
+#include <errno.h>
+#include <stdlib.h>
 
 /* ProcessStatusTest.build(pid, raw_status, klass) -> status
  *
@@ -23,10 +28,94 @@ test_status_build(mrb_state *mrb, mrb_value self)
   return mrb_obj_new(mrb, klass, 2, argv);
 }
 
+/* Nanoseconds in a second, which is the range a port promises `nsec` in. */
+#define TEST_NSEC_PER_SEC 1000000000
+
+/* Read a decimal into an int64_t, refusing anything the type cannot hold. */
+static int64_t
+test_clock_int64(mrb_state *mrb, const char *s, const char *what)
+{
+  char *end;
+  long long v;
+
+  errno = 0;
+  v = strtoll(s, &end, 10);
+  if (*s == '\0' || *end != '\0' || errno == ERANGE) {
+    mrb_raisef(mrb, E_ARGUMENT_ERROR, "%s is not a number an int64_t holds: %s", what, s);
+  }
+  return (int64_t)v;
+}
+
+/* ProcessClockTest.convert(sec, nsec, unit, resolution = false) -> number
+ *
+ * The reading of `sec` seconds and `nsec` nanoseconds, answered in `unit` by
+ * the very code a clock reading is answered by.  What a reading becomes at
+ * the ends of an int64_t and at the ends of this build's Integer is decided
+ * there, and no clock comes within centuries of either end, so the endings
+ * are handed to it rather than waited for.
+ *
+ * `sec` is a String because a build whose Integer is 32 bits cannot write
+ * the seconds this is about, and those are exactly the ones worth asking
+ * about.  `nsec` is nanoseconds within one second, which every build can
+ * write and which is what a port promises to report; a number outside that
+ * is refused here rather than passed on, a port that broke the promise being
+ * the bug in that case.
+ */
+static mrb_value
+test_clock_convert(mrb_state *mrb, mrb_value self)
+{
+  const char *sec;
+  mrb_int nsec;
+  mrb_value unit;
+  mrb_bool resolution = FALSE;
+  mrb_process_clock_time t;
+
+  mrb_get_args(mrb, "zio|b", &sec, &nsec, &unit, &resolution);
+  if (nsec < 0 || nsec >= TEST_NSEC_PER_SEC) {
+    mrb_raisef(mrb, E_ARGUMENT_ERROR, "nsec outside one second: %i", nsec);
+  }
+  t.sec = test_clock_int64(mrb, sec, "sec");
+  t.nsec = (int64_t)nsec;
+  return mrb_process_clock_result(mrb, unit, &t, resolution);
+}
+
+/* ProcessClockTest.fits?(decimal) -> true or false
+ *
+ * Whether an Integer in this build holds the number `decimal` spells, so
+ * that a test can say which of the two answers a reading is owed without
+ * knowing how wide an mrb_int is here or whether there are bigints.  It
+ * deliberately shares no line with the conversion it is used to check.
+ */
+static mrb_value
+test_clock_fits(mrb_state *mrb, mrb_value self)
+{
+  const char *decimal;
+
+  mrb_get_args(mrb, "z", &decimal);
+#ifdef MRB_USE_BIGINT
+  (void)decimal;
+  return mrb_true_value(); /* an Integer here is as wide as it needs to be */
+#else
+  {
+    char *end;
+    long long v;
+
+    errno = 0;
+    v = strtoll(decimal, &end, 10);
+    if (*decimal == '\0' || *end != '\0' || errno == ERANGE) return mrb_false_value();
+    return mrb_bool_value(v >= MRB_INT_MIN && v <= MRB_INT_MAX);
+  }
+#endif
+}
+
 void
 mrb_mruby_process_gem_test(mrb_state *mrb)
 {
   struct RClass *test = mrb_define_module(mrb, "ProcessStatusTest");
+  struct RClass *clock = mrb_define_module(mrb, "ProcessClockTest");
 
   mrb_define_module_function(mrb, test, "build", test_status_build, MRB_ARGS_REQ(3));
+  mrb_define_module_function(mrb, clock, "convert", test_clock_convert,
+                             MRB_ARGS_ARG(3, 1));
+  mrb_define_module_function(mrb, clock, "fits?", test_clock_fits, MRB_ARGS_REQ(1));
 }

--- a/mrbgems/mruby-process/test/process.rb
+++ b/mrbgems/mruby-process/test/process.rb
@@ -48,6 +48,52 @@ module ProcessTestUtil
     ProcessStatusTest.build(pid, raw, cls)
   end
 
+  # The four clocks Process names.  The ids are 0 to 3, so `clocks.size` is
+  # the first number that names none of them.
+  def self.clocks
+    [Process::CLOCK_REALTIME, Process::CLOCK_MONOTONIC,
+     Process::CLOCK_PROCESS_CPUTIME_ID, Process::CLOCK_THREAD_CPUTIME_ID]
+  end
+
+  # Whether this platform has the clock +id+ names.  Every constant is
+  # defined everywhere, and a port without the clock behind one refuses to
+  # read it, so a test that means to exercise a reading asks first.  Asked in
+  # seconds, which every build's Integer can carry.
+  def self.clock?(id)
+    Process.clock_gettime(id, :second)
+    true
+  rescue Errno::EINVAL
+    false
+  end
+
+  # Whether a reading of +id+ in +unit+ is one this build can answer with.
+  # An Integer of 32 bits carries a clock in seconds and little finer, and a
+  # build without bigints has nothing wider to put such a reading in, so a
+  # test that reads nanoseconds asks rather than pinning a build's width.
+  def self.fits?(id, unit)
+    Process.clock_gettime(id, unit)
+    true
+  rescue RangeError
+    false
+  end
+
+  # The reading of +sec+ seconds and +nsec+ nanoseconds answered in +unit+,
+  # as the decimal the Integer of it spells, or nil where this build's
+  # Integer is too narrow to hold it and the conversion says so.  Both the
+  # seconds handed in and the answer read back are decimal Strings: the
+  # values worth asking about here are the ones a build may have no way to
+  # write as a literal.
+  def self.convert(sec, nsec, unit)
+    ProcessClockTest.convert(sec, nsec, unit).to_s
+  rescue RangeError
+    nil
+  end
+
+  # Whether this build has a Float for the float units to answer in.
+  def self.float?
+    Object.const_defined?(:Float)
+  end
+
   # Start a child running +cmd+ through a shell, or return nil where this
   # build has no child to give.
   def self.spawn(cmd)
@@ -560,4 +606,317 @@ assert('$? after IO.popen') do
   assert_kind_of Process::Status, $?
   assert_equal pid, $?.pid
   assert_true $?.success?
+end
+
+
+assert('Process::CLOCK_REALTIME and the rest') do
+  # Four distinct ids, all defined on every platform, so that a program
+  # naming one is naming the same clock wherever it runs.
+  clocks = ProcessTestUtil.clocks
+  seen = {}
+  clocks.each do |id|
+    assert_kind_of Integer, id
+    seen[id] = true
+  end
+  assert_equal clocks.size, seen.size
+end
+
+assert('Process.clock_gettime') do
+  ProcessTestUtil.clocks.each do |id|
+    next unless ProcessTestUtil.clock?(id)
+
+    if ProcessTestUtil.float?
+      assert_kind_of Float, Process.clock_gettime(id)
+    end
+    assert_kind_of Integer, Process.clock_gettime(id, :second)
+    if ProcessTestUtil.fits?(id, :nanosecond)
+      assert_kind_of Integer, Process.clock_gettime(id, :nanosecond)
+    end
+  end
+end
+
+assert('Process.clock_gettime with CLOCK_MONOTONIC') do
+  # What a monotonic clock promises is that a later reading is not a smaller
+  # one.  Where its origin is, and so what any single reading says, is the
+  # platform's to choose and nothing to assert on.
+  skip "no monotonic clock on this platform" unless ProcessTestUtil.clock?(Process::CLOCK_MONOTONIC)
+  skip "no Integer for a reading in nanoseconds" unless ProcessTestUtil.fits?(Process::CLOCK_MONOTONIC, :nanosecond)
+
+  first = Process.clock_gettime(Process::CLOCK_MONOTONIC, :nanosecond)
+  second = Process.clock_gettime(Process::CLOCK_MONOTONIC, :nanosecond)
+  assert_operator second, :>=, first
+end
+
+assert('Process.clock_gettime in each unit') do
+  # The units are scalings of one reading, so a later reading in a smaller
+  # unit is worth at least what an earlier one in a bigger unit was, and the
+  # two are no further apart than the moment between them.  Read from the
+  # monotonic clock, which cannot step between the two readings.
+  skip "no monotonic clock on this platform" unless ProcessTestUtil.clock?(Process::CLOCK_MONOTONIC)
+  skip "no Integer for a reading in nanoseconds" unless ProcessTestUtil.fits?(Process::CLOCK_MONOTONIC, :nanosecond)
+
+  sec = Process.clock_gettime(Process::CLOCK_MONOTONIC, :second)
+  msec = Process.clock_gettime(Process::CLOCK_MONOTONIC, :millisecond)
+  usec = Process.clock_gettime(Process::CLOCK_MONOTONIC, :microsecond)
+  nsec = Process.clock_gettime(Process::CLOCK_MONOTONIC, :nanosecond)
+
+  [sec, msec, usec, nsec].each { |v| assert_kind_of Integer, v }
+  # A whole unit is what the reading had reached, never the one it was about
+  # to reach, so scaling a bigger unit up never overtakes a later reading.
+  assert_operator sec * 1000, :<=, msec
+  assert_operator msec * 1000, :<=, usec
+  assert_operator usec * 1000, :<=, nsec
+  # The four were read moments apart (a scheduler pause on a loaded CI runner
+  # costs seconds, not the minute asserted here), while a reading the HAL
+  # built wrong, the way a swapped field or the wrong clock would, is off by
+  # an amount this catches easily.
+  assert_operator nsec - sec * 1_000_000_000, :<, 60 * 1_000_000_000
+end
+
+assert('Process.clock_gettime in a float unit') do
+  skip "this build has no Float" unless ProcessTestUtil.float?
+  skip "no monotonic clock on this platform" unless ProcessTestUtil.clock?(Process::CLOCK_MONOTONIC)
+
+  sec = Process.clock_gettime(Process::CLOCK_MONOTONIC, :float_second)
+  msec = Process.clock_gettime(Process::CLOCK_MONOTONIC, :float_millisecond)
+  usec = Process.clock_gettime(Process::CLOCK_MONOTONIC, :float_microsecond)
+
+  [sec, msec, usec].each { |v| assert_kind_of Float, v }
+  # One reading in three scalings, taken in this order moments apart, so each
+  # is worth at least the one before it and the three say the same second.
+  # Every unit is scaled and rounded on its own, so comparing two of them
+  # rounds a second time, and that alone can read a live pair backwards once
+  # the clock's magnitude eats into the mantissa: hence the epsilon.  What a
+  # rounding costs is a share of the value rounded, not a fixed amount, so
+  # the epsilon is a share of the reading's magnitude too, the origin being
+  # the platform's to choose.  An absolute epsilon wide enough for a
+  # monotonic clock that has been running a while is either far too wide on
+  # a `double` or far too narrow on an `MRB_USE_FLOAT32` build, where the
+  # two roundings are worth two milliseconds after a day of uptime.  A
+  # millionth is many times the pair of them even there, and far short of
+  # what an ordering bug would show.  The minute is the same slack against a
+  # scheduler pause on a loaded CI runner that the integer test above uses.
+  epsilon = sec.abs * 1.0e-6
+  assert_operator msec / 1000, :>=, sec - epsilon
+  assert_operator usec / 1000000, :>=, msec / 1000 - epsilon
+  assert_operator usec / 1000000 - sec, :<, 60
+  # :float_second is what a caller who names no unit gets.
+  assert_operator Process.clock_gettime(Process::CLOCK_MONOTONIC), :>=, sec - epsilon
+end
+
+assert('Process.clock_gettime with a nil unit') do
+  # Naming no unit is what nil says, which is what leaving the argument out
+  # says: CRuby cannot tell the two apart at all, an omitted unit arriving
+  # there as nil, so neither is answered differently from the other here.
+  skip "this build has no Float" unless ProcessTestUtil.float?
+  skip "no monotonic clock on this platform" unless ProcessTestUtil.clock?(Process::CLOCK_MONOTONIC)
+
+  assert_kind_of Float, Process.clock_gettime(Process::CLOCK_MONOTONIC, nil)
+  assert_kind_of Float, Process.clock_getres(Process::CLOCK_MONOTONIC, nil)
+end
+
+assert('Process.clock_gettime in a float unit without a Float') do
+  # A build without Float cannot answer in one, and the method is not made
+  # to disappear over it: the integer units still answer, and asking for a
+  # float one is told so where it is asked.
+  skip "this build has a Float" if ProcessTestUtil.float?
+
+  assert_kind_of Integer, Process.clock_gettime(Process::CLOCK_REALTIME, :second)
+  [:float_second, :float_millisecond, :float_microsecond].each do |unit|
+    assert_raise(NotImplementedError) { Process.clock_gettime(Process::CLOCK_REALTIME, unit) }
+  end
+  # A resolution in hertz is a Float too, so it goes the same way, and it is
+  # still not a unit a reading has, which ArgumentError says first.
+  assert_raise(NotImplementedError) { Process.clock_getres(Process::CLOCK_REALTIME, :hertz) }
+  assert_raise(ArgumentError) { Process.clock_gettime(Process::CLOCK_REALTIME, :hertz) }
+  # Including the one a caller gets by not naming a unit at all, which is the
+  # one nil asks for as well.
+  assert_raise(NotImplementedError) { Process.clock_gettime(Process::CLOCK_REALTIME) }
+  assert_raise(NotImplementedError) { Process.clock_gettime(Process::CLOCK_REALTIME, nil) }
+  assert_raise(NotImplementedError) { Process.clock_getres(Process::CLOCK_REALTIME, nil) }
+end
+
+assert('Process.clock_gettime with a number naming no clock') do
+  # An id outside the list is refused before a port sees it, with the errno
+  # a platform's own call gives for a clock it does not have: nothing is
+  # wrong with the size of the number, it simply names nothing.
+  [-1, ProcessTestUtil.clocks.size, 99].each do |id|
+    assert_raise(Errno::EINVAL) { Process.clock_gettime(id) }
+    assert_raise(Errno::EINVAL) { Process.clock_getres(id) }
+  end
+end
+
+assert('Process.clock_gettime with a clock named by a Symbol') do
+  # A clock can be named as well as numbered, as it can in CRuby, and the
+  # name is the constant's, so a program need not depend on the number.
+  {
+    CLOCK_REALTIME: Process::CLOCK_REALTIME,
+    CLOCK_MONOTONIC: Process::CLOCK_MONOTONIC,
+    CLOCK_PROCESS_CPUTIME_ID: Process::CLOCK_PROCESS_CPUTIME_ID,
+    CLOCK_THREAD_CPUTIME_ID: Process::CLOCK_THREAD_CPUTIME_ID,
+  }.each do |name, id|
+    next unless ProcessTestUtil.clock?(id)
+
+    assert_kind_of Integer, Process.clock_gettime(name, :second)
+    assert_kind_of Integer, Process.clock_getres(name, :nanosecond)
+    assert_equal Process.clock_getres(id, :nanosecond),
+                 Process.clock_getres(name, :nanosecond)
+  end
+end
+
+assert('Process.clock_gettime with a clock_id that names nothing') do
+  # CRuby knows further names: the clocks only some platforms have, and the
+  # ways it emulates one the host lacks.  A port here either has one of the
+  # four or says it has not, so those pick nothing out, and are refused the
+  # way a number naming no clock is, which is also what CRuby answers for a
+  # name it does not know.
+  [:NOPE, :CLOCK_MONOTONIC_RAW, :GETTIMEOFDAY_BASED_CLOCK_REALTIME].each do |name|
+    assert_raise(Errno::EINVAL) { Process.clock_gettime(name, :second) }
+    assert_raise(Errno::EINVAL) { Process.clock_getres(name, :second) }
+  end
+  # A String is not a name: it is refused for its type, as CRuby refuses it,
+  # rather than read for a clock name it might spell.  nil is refused the
+  # same way: naming no clock is not the default a nil unit is.
+  assert_raise(TypeError) { Process.clock_gettime("CLOCK_MONOTONIC") }
+  assert_raise(TypeError) { Process.clock_gettime(nil) }
+end
+
+assert('Process.clock_gettime names the clock it failed on') do
+  # The failure says which call was made and which clock it was asked for,
+  # the way CRuby says it, so a caller who named a clock is shown the name
+  # back rather than a number never written.
+  begin
+    Process.clock_gettime(:NOPE, :second)
+    flunk "no error raised"
+  rescue Errno::EINVAL => e
+    assert_include e.message, "clock_gettime(:NOPE)"
+  end
+
+  begin
+    Process.clock_getres(99, :second)
+    flunk "no error raised"
+  rescue Errno::EINVAL => e
+    assert_include e.message, "clock_getres(99)"
+  end
+end
+
+assert('Process.clock_gettime with a unit it does not know') do
+  # A unit is a Symbol, as it is in CRuby, which takes nothing else: a String
+  # naming the same thing is not one of the units.
+  [:minute, :float_nanosecond, "second", 1].each do |unit|
+    assert_raise(ArgumentError) { Process.clock_gettime(Process::CLOCK_REALTIME, unit) }
+    assert_raise(ArgumentError) { Process.clock_getres(Process::CLOCK_REALTIME, unit) }
+  end
+  # :hertz is a resolution's unit alone: there is no rate at which a moment
+  # happened.  CRuby refuses it for a reading in the same words.
+  assert_raise(ArgumentError) { Process.clock_gettime(Process::CLOCK_REALTIME, :hertz) }
+end
+
+assert('Process.clock_gettime with a reading this build cannot carry') do
+  # A 32-bit Integer holds a wall clock in seconds and not in nanoseconds.
+  # What is wrong with such a reading is its size, so it is refused the way
+  # an oversized pid is, unless the build has bigints, which are what CRuby
+  # answers with here and are wide enough for any of these clocks.
+  skip "this build carries a wall clock in nanoseconds" if ProcessTestUtil.fits?(Process::CLOCK_REALTIME, :nanosecond)
+
+  assert_raise(RangeError) { Process.clock_gettime(Process::CLOCK_REALTIME, :nanosecond) }
+  # The same reading in seconds is untouched by it.
+  assert_kind_of Integer, Process.clock_gettime(Process::CLOCK_REALTIME, :second)
+end
+
+assert('Process.clock_gettime at the ends of what a reading fits in') do
+  # A reading becomes an Integer without a clock being read, so where that
+  # arithmetic ends can be asked about directly.  It has to be: the first of
+  # these is a wall clock in nanoseconds in 2262, and the ones below zero are
+  # centuries the other way.  The reading is handed over as a port hands one
+  # over, in whole seconds and nanoseconds within one, and the answer is read
+  # back as a decimal, these being numbers a build's own Integer may have no
+  # way to write.
+  #
+  # Where the build's Integer holds the answer it is that Integer, whether it
+  # took a bigint to hold it or not; where it does not, the reading is
+  # refused for its size, as an oversized pid is.
+  [
+    # int64_t's last value, and the nanosecond after it
+    ["9223372036", 854775807, :nanosecond, "9223372036854775807"],
+    ["9223372036", 854775808, :nanosecond, "9223372036854775808"],
+    # and its first, which falls in a second no whole product of seconds
+    # lands on, and the nanosecond before it
+    ["-9223372037", 145224192, :nanosecond, "-9223372036854775808"],
+    ["-9223372037", 145224191, :nanosecond, "-9223372036854775809"],
+    # a second int64_t holds, in a unit whose answer it does not: how far a
+    # reading reaches is the platform's business and how far an Integer
+    # reaches is mruby's, and the two are not the same question
+    ["9223372036854775807", 0, :second, "9223372036854775807"],
+    ["9223372036854775807", 0, :millisecond, "9223372036854775807000"],
+    ["10000000000", 123456789, :nanosecond, "10000000000123456789"],
+    # a reading before the epoch, whose nanoseconds count upwards from the
+    # second below it, as a port reports every reading
+    ["-2", 500000000, :second, "-2"],
+    ["-2", 500000000, :millisecond, "-1500"],
+    ["-2", 500000000, :nanosecond, "-1500000000"],
+  ].each do |sec, nsec, unit, expected|
+    if ProcessClockTest.fits?(expected)
+      assert_equal expected, ProcessTestUtil.convert(sec, nsec, unit)
+      assert_kind_of Integer, ProcessClockTest.convert(sec, nsec, unit)
+    else
+      assert_nil ProcessTestUtil.convert(sec, nsec, unit)
+      assert_raise(RangeError) { ProcessClockTest.convert(sec, nsec, unit) }
+    end
+  end
+end
+
+assert('Process.clock_getres in hertz') do
+  # How many times a second the clock can tell apart, which is one over what
+  # :float_second says.  Read back against the same resolution in
+  # nanoseconds: a hertz for every nanosecond of it is a second's worth,
+  # whatever the clock, and the two are computed apart from each other.
+  skip "this build has no Float" unless ProcessTestUtil.float?
+
+  ProcessTestUtil.clocks.each do |id|
+    next unless ProcessTestUtil.clock?(id)
+
+    hz = Process.clock_getres(id, :hertz)
+    res = Process.clock_getres(id, :nanosecond)
+    assert_kind_of Float, hz
+    assert_operator hz, :>, 0
+    assert_operator (hz * res - 1000000000).abs, :<, 1
+  end
+end
+
+assert('Process.clock_getres') do
+  ProcessTestUtil.clocks.each do |id|
+    next unless ProcessTestUtil.clock?(id)
+
+    # A clock a port can read is one it answers a granularity for, so
+    # nothing is skipped here for a port declining to say.
+    res = Process.clock_getres(id, :nanosecond)
+    assert_kind_of Integer, res
+    # A resolution is never zero, and no clock here is coarser than a whole
+    # second, so it is worth at least a nanosecond and at most one second.
+    assert_operator res, :>, 0
+    assert_operator res, :<=, 1000000000
+    # An integer unit truncates, so a resolution finer than one whole unit
+    # of it reads as 0; a clock coarser than a second is the only one that
+    # reads above it here.
+    assert_operator Process.clock_getres(id, :second), :>=, 0
+  end
+end
+
+assert('Process.clock_getres of a clock read as a FILETIME') do
+  # Windows accounts both CPU clocks in FILETIMEs, and a FILETIME is written
+  # in 100ns ticks, so that is how finely two of those readings can differ.
+  # The wall clock is left out, being read two different ways depending on
+  # the Windows; ports/win/process_hal.c pairs each way with its own
+  # granularity.
+  skip "not on Windows" unless ProcessTestUtil.windows?
+
+  # A tick is 100ns, so the resolution is asked for in nanoseconds; the
+  # reading beside it is asked in an integer unit too, the unit being
+  # resolved before the HAL is, so that a build without Float does not raise
+  # NotImplementedError before the port is reached at all.
+  [Process::CLOCK_PROCESS_CPUTIME_ID, Process::CLOCK_THREAD_CPUTIME_ID].each do |id|
+    assert_kind_of Integer, Process.clock_gettime(id, :nanosecond)
+    assert_equal 100, Process.clock_getres(id, :nanosecond)
+  end
 end


### PR DESCRIPTION
## Summary

Adds `Process.clock_gettime` and `Process.clock_getres` to `mruby-process`, based on CRuby's clock API.

## Behaviour

`Process.clock_gettime` and `Process.clock_getres` support the same seven units as CRuby, with `:hertz` additionally accepted by `clock_getres`.

The following behaviours intentionally differ from CRuby:

* The four clock constants use mruby-defined, platform-independent values and are defined on every platform. CRuby exposes platform-dependent clock constants and may leave unsupported constants undefined.
* Only `CLOCK_REALTIME`, `CLOCK_MONOTONIC`, `CLOCK_PROCESS_CPUTIME_ID`, and `CLOCK_THREAD_CPUTIME_ID` are supported. CRuby additionally exposes platform-specific and emulated clock IDs.
* On `MRB_NO_FLOAT` builds, the Float units and `:hertz` raise `NotImplementedError`; the Integer units remain available.
* When an Integer result does not fit `mrb_int`, it is returned as a bigint when `mruby-bigint` is available, and raises `RangeError` otherwise.

## Testing

* `rake test` on the host build
* `MRUBY_CONFIG=host-nofloat rake test`
* `MRB_INT32` builds with and without `mruby-bigint`
* 64-bit build without `mruby-bigint`
* MinGW cross-build and test suite under Wine
* `:hertz` results compared with CRuby 3.3.6


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `Process.clock_gettime` and `Process.clock_getres`.
  * Added realtime, monotonic, process CPU, and thread CPU clock constants.
  * Added integer, floating-point, and hertz unit support.
  * Added clock support across POSIX and Windows platforms, including fallbacks.

* **Bug Fixes**
  * Improved handling of unsupported clocks, unavailable features, and oversized results.

* **Documentation**
  * Documented clock behavior, supported platforms, units, and compatibility differences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->