### PR TITLE
ci: add 32-bit x86 and Arm builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,15 +16,27 @@ jobs:
       max-parallel: 8
       matrix:
         include:
+          # x86-64 LP64 with signed plain `char`.
           - {os: ubuntu-24.04, cc: gcc, cxx: g++}
           - {os: ubuntu-24.04, cc: clang, cxx: clang++}
           - {os: ubuntu-22.04, cc: gcc, cxx: g++}
           - {os: ubuntu-22.04, cc: clang, cxx: clang++}
-          # The only runner where `char` is unsigned; the macOS runners are
-          # ARM64 too but Apple's ABI keeps `char` signed.
+          # AArch64 LP64 with unsigned plain `char`.
           - {os: ubuntu-24.04-arm, cc: gcc, cxx: g++}
+          # x86 ILP32 with signed plain `char`.
+          - os: ubuntu-24.04
+            cc: i686-linux-gnu-gcc
+            cxx: i686-linux-gnu-g++
+            altname: "i686-gcc"
+          # AArch32 ILP32 with unsigned plain `char`.
+          - os: ubuntu-24.04
+            cc: arm-linux-gnueabihf-gcc
+            cxx: arm-linux-gnueabihf-g++
+            altname: "armhf-gcc"
+          # AArch64 LP64 with signed plain `char`.
           - {os: macos-26, cc: clang, cxx: clang++}
           - {os: macos-15, cc: clang, cxx: clang++}
+          # x86-64 LLP64 with signed plain `char`.
           - {os: windows-2025, cc: gcc, cxx: g++, altname: "mingw-gcc"}
           - {os: windows-2022, cc: gcc, cxx: g++, altname: "mingw-gcc"}
     env:
@@ -37,6 +49,19 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      - name: Install i386 cross-build toolchain
+        if: matrix.altname == 'i686-gcc'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            crossbuild-essential-i386
+      - name: Install armhf cross-build toolchain
+        if: matrix.altname == 'armhf-gcc'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            crossbuild-essential-armhf binfmt-support qemu-user-static
+          echo 'QEMU_LD_PREFIX=/usr/arm-linux-gnueabihf' >> "$GITHUB_ENV"
       - name: Ruby version
         run: ruby -v
       - name: Compiler version

--- a/mrbgems/mruby-bin-mrbc/bintest/mrbc.rb
+++ b/mrbgems/mruby-bin-mrbc/bintest/mrbc.rb
@@ -149,7 +149,10 @@ assert('a directory as an input file is refused') do
   # of its own, so pin which message arrives, not merely that one did.
   Dir.mktmpdir do |dir|
     result, status = Open3.capture2e(*(cmd_list('mrbc') + ['-c', dir]))
-    assert_include result, 'compile.c: cannot read from program file.'
+    assert_true(
+      result.include?('compile.c: cannot read from program file.') ||
+      result.include?('compile.c: cannot get size of program file.') # AArch32/armhf
+    )
     assert_not_include result, 'compile.c: cannot read program file.'
     assert_equal 1, status.exitstatus
   end


### PR DESCRIPTION
## Summary

Add i686 and armhf cross-builds to CI to extend ABI coverage to ILP32, and fix the one bintest that assumed `ftell()` on a directory reports the same failure on every architecture.

## Changes

| File | What |
|---|---|
| `mrbgems/mruby-bin-mrbc/bintest/mrbc.rb` | Accept AArch32's alternate `ftell()`-on-a-directory failure message |
| `.github/workflows/build.yml` | Add `ubuntu-24.04-i686-gcc` and `ubuntu-24.04-armhf-gcc` cross-build jobs |

### `mruby-bin-mrbc` bintest: accept AArch32's directory-read message

The existing test feeds `mrbc` a directory as its input file and pins the
resulting error message. On ext4, `ftell()` on a directory stream answers
`LONG_MAX`, so the code passes the size check and fails later at `fread()`
with `"cannot read from program file."`. On AArch32/armhf, `ftell()`
answers `0` instead, so the code fails the size check itself with
`"cannot get size of program file."`. Both are legitimate outcomes of the
same directory-as-input-file guard; the test now accepts either.

### 32-bit x86 and Arm cross-builds

The existing matrix covers LP64/LLP64 with both signed and unsigned plain
`char`, but never ILP32. `ubuntu-24.04-i686-gcc` adds ILP32 with signed
plain `char`, and `ubuntu-24.04-armhf-gcc` adds ILP32 with unsigned plain
`char`, run under `qemu-user-static`.

## Testing

Local, on the host build (`rake -m all`, `rake -m test`, `rake -m test:bin`): all green.

CI on this branch, all 13 jobs green, including the two new ones:

```
ubuntu-24.04-i686-gcc   4m22s
ubuntu-24.04-armhf-gcc 10m17s
```

## Environment

<details>

| | |
|---|---|
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-30-generic x86_64 |
| Compiler | Homebrew clang version 23.1.0 |
| Binutils | GNU ld (GNU Binutils) 2.47.20260726 |
| CRuby | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded build coverage for x86-64, AArch64, x86 ILP32, and AArch32 ILP32 targets.
  * Added support for cross-building on i386 and armhf environments.

* **Bug Fixes**
  * Improved validation when a directory is supplied where a compiler input file is expected, ensuring consistent test behavior across supported architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->