### PR TITLE
guard mrb_int overflow in String#slice!

### DIFF
--- a/mrbgems/mruby-string-ext/src/string.c
+++ b/mrbgems/mruby-string-ext/src/string.c
@@ -4,6 +4,7 @@
 #include <mruby/class.h>
 #include <mruby/string.h>
 #include <mruby/range.h>
+#include <mruby/numeric.h>
 #include <mruby/internal.h>
 
 #define ENC_ASCII_8BIT "ASCII-8BIT"
@@ -2346,7 +2347,8 @@ mrb_str_slice_bang(mrb_state *mrb, mrb_value self)
   }
 
   if (beg > str_len) return mrb_nil_value();
-  if (beg + len > str_len) {
+  mrb_int end;
+  if (mrb_int_add_overflow(beg, len, &end) || end > str_len) {
     len = str_len - beg;
   }
   if (len < 0) len = 0;
@@ -2354,7 +2356,9 @@ mrb_str_slice_bang(mrb_state *mrb, mrb_value self)
   mrb_int byte_beg = mrb_str_char_to_byte(mrb, self, 0, beg);
   mrb_int byte_len = mrb_str_char_to_byte(mrb, self, byte_beg, len);
 
-  if (byte_beg < 0 || byte_beg > RSTRING_LEN(self) || byte_beg + byte_len > RSTRING_LEN(self)) {
+  mrb_int byte_end;
+  if (byte_beg < 0 || byte_beg > RSTRING_LEN(self) ||
+      mrb_int_add_overflow(byte_beg, byte_len, &byte_end) || byte_end > RSTRING_LEN(self)) {
     return mrb_nil_value();
   }
 

--- a/mrbgems/mruby-string-ext/test/string.rb
+++ b/mrbgems/mruby-string-ext/test/string.rb
@@ -699,6 +699,20 @@ assert('String#slice! with a multibyte match') do
   assert_equal "あ", a
 end if UTF8STRING
 
+assert('String#slice! with a length near mrb_int max') do
+  # slice!(beg, len) clamps len to the string; beg + len must not overflow.
+  # The maximum is built at runtime because a folded out-of-range literal
+  # fails the build, and the case is skipped where mrb_int cannot hold it.
+  begin
+    int_max = (1 << 63) - 1
+  rescue RangeError
+    skip 'mrb_int is narrower than the value this test needs'
+  end
+  a = "abc"
+  assert_equal "bc", a.slice!(1, int_max)
+  assert_equal "a", a
+end
+
 assert('String#succ') do
   assert_equal "", "".succ
   assert_equal "1", "0".succ


### PR DESCRIPTION
UBSan, `"abc".slice!(1, 9223372036854775807)`:

    string.c:2349:11: runtime error: signed integer overflow: 1 + 9223372036854775807 cannot be represented in type 'mrb_int'
    string.c:2357:64: runtime error: signed integer overflow: 1 + 9223372036854775807 cannot be represented in type 'mrb_int'

`beg` and `len` come straight from `mrb_as_int`, so `beg + len` (and later `byte_beg + byte_len`) can wrap. The wrapped negative slips past the `> str_len` clamp, `len` stays at `MRB_INT_MAX`, and `mrb_str_new` is reached with it. On a 64-bit `mrb_int`, `str_check_length` rejects the length; on `MRB_INT32` the same input passes it and `memcpy` reads ~2GB past a small source.

Guard both adds with `mrb_int_add_overflow`, the same form `mrb_str_aset` and `str_bytesplice` already use in `src/string.c`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where using an extremely large length with `String#slice!` could cause integer overflow.
  * Large slice lengths are now safely clamped to the available string content.

* **Tests**
  * Added coverage for slicing with a length near the maximum supported integer value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->