### PR TITLE
mruby-struct: take a recursive pair as equal in Struct#== and #eql?

### DIFF
--- a/mrbgems/mruby-struct/src/struct.c
+++ b/mrbgems/mruby-struct/src/struct.c
@@ -603,9 +603,10 @@ mrb_struct_equal(mrb_state *mrb, mrb_value s)
     return mrb_false_value();
   }
 
-  /* Check for recursion */
+  /* A pair already being compared is taken as equal, as in CRuby's
+     recursive_equal(), and the other members decide the outcome. */
   if (MRB_RECURSIVE_BINARY_FUNC_P(mrb, MRB_OPSYM(eq), s, s2)) {
-    return mrb_false_value();
+    return mrb_true_value();
   }
 
   mrb_int len = RSTRUCT_LEN(s);
@@ -650,9 +651,9 @@ mrb_struct_eql(mrb_state *mrb, mrb_value s)
     return mrb_false_value();
   }
 
-  /* Check for recursion */
+  /* see mrb_struct_equal(): the pair being compared is taken as equal */
   if (MRB_RECURSIVE_BINARY_FUNC_P(mrb, MRB_SYM_Q(eql), s, s2)) {
-    return mrb_false_value();
+    return mrb_true_value();
   }
 
   len = RSTRUCT_LEN(s);

--- a/mrbgems/mruby-struct/test/struct.rb
+++ b/mrbgems/mruby-struct/test/struct.rb
@@ -52,6 +52,21 @@ assert('Struct#== and #eql? with a member that replaces the storage') do
   end
 end
 
+assert('Struct#== and #eql? with recursive members') do
+  c = Struct.new(:m0, :m1, :m2, :m3)
+  a = c.new
+  b = c.new
+  d = c.new
+  a.initialize(a, 2, 3, 4)
+  b.initialize(b, 2, 3, 4)
+  d.initialize(d, 9, 3, 4)
+  [:==, :eql?].each do |op|
+    assert_true a.__send__(op, a)
+    assert_true a.__send__(op, b)
+    assert_false a.__send__(op, d)
+  end
+end
+
 assert('Struct#[]', '15.2.18.4.2') do
   c = Struct.new(:m1, :m2)
   cc = c.new(1,2)


### PR DESCRIPTION
## Summary
- A struct whose member references itself always compared unequal: the recursion guard in `mrb_struct_equal` / `mrb_struct_eql` answered false for the pair currently being compared
- Take that pair as equal, as in CRuby's `recursive_equal()`, and let the remaining members decide the outcome, so structs that differ only in their self reference are told apart
- Add a test covering `#==` and `#eql?` on self-referential structs

## Test plan
- [x] `make test` — all 2553 tests pass (2490 OK, 0 KO)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed equality checks for self-referential structs.
  * Recursive structs now correctly compare as equal when their contents match and unequal when members differ.
  * Updated both `==` and `eql?` behavior to align with standard Ruby semantics.

* **Tests**
  * Added coverage for reflexive and structural comparisons involving recursive structs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->