### PR TITLE
Use `mrb_args_pack_positional()` in `prepare_missing()`

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -1369,7 +1369,7 @@ mrb_ci_nregs(mrb_callinfo *ci)
 mrb_value mrb_obj_missing(mrb_state *mrb, mrb_value mod);
 
 static mrb_method_t
-prepare_missing(mrb_state *mrb, mrb_callinfo *ci, mrb_value recv, mrb_sym mid, mrb_value blk, mrb_bool super)
+prepare_missing(mrb_state *mrb, mrb_callinfo *ci, mrb_value recv, mrb_sym mid, mrb_bool super)
 {
   mrb_sym missing = MRB_SYM(method_missing);
   mrb_value args = mrb_args_pack_positional(mrb);
@@ -1523,7 +1523,7 @@ mrb_funcall_with_block(mrb_state *mrb, mrb_value self, mrb_sym mid, mrb_int argc
     ci->u.target_class = mrb_class(mrb, self);
     m = mrb_vm_find_method(mrb, ci->u.target_class, &ci->u.target_class, mid);
     if (MRB_METHOD_UNDEF_P(m)) {
-      m = prepare_missing(mrb, ci, self, mid, mrb_nil_value(), FALSE);
+      m = prepare_missing(mrb, ci, self, mid, FALSE);
     }
     else {
       ci->mid = mid;
@@ -3652,7 +3652,7 @@ RETRY_TRY_BLOCK:
       ci->u.target_class = (insn == OP_SUPER) ? CI_TARGET_CLASS(ci - 1)->super : mrb_class(mrb, recv);
       m = mrb_vm_find_method(mrb, ci->u.target_class, &ci->u.target_class, mid);
       if (mrb_unlikely(MRB_METHOD_UNDEF_P(m))) {
-        m = prepare_missing(mrb, ci, recv, mid, blk, (insn == OP_SUPER));
+        m = prepare_missing(mrb, ci, recv, mid, (insn == OP_SUPER));
       }
       else {
         ci->mid = mid;

--- a/src/vm.c
+++ b/src/vm.c
@@ -1372,13 +1372,8 @@ static mrb_method_t
 prepare_missing(mrb_state *mrb, mrb_callinfo *ci, mrb_value recv, mrb_sym mid, mrb_value blk, mrb_bool super)
 {
   mrb_sym missing = MRB_SYM(method_missing);
-  mrb_value *argv = &ci->stack[1];
-  mrb_value args;
+  mrb_value args = mrb_args_pack_positional(mrb);
   mrb_method_t m;
-
-  /* pack positional arguments */
-  if (ci->n == 15) args = argv[0];
-  else args = mrb_ary_new_from_values(mrb, ci->n, argv);
 
   if (mrb_func_basic_p(mrb, recv, missing, mrb_obj_missing)) {
   method_missing:
@@ -1391,22 +1386,7 @@ prepare_missing(mrb_state *mrb, mrb_callinfo *ci, mrb_value recv, mrb_sym mid, m
   }
   m = mrb_vm_find_method(mrb, ci->u.target_class, &ci->u.target_class, missing);
   if (MRB_METHOD_UNDEF_P(m)) goto method_missing; /* just in case */
-  stack_extend(mrb, 4);
 
-  argv = &ci->stack[1];         /* maybe reallocated */
-  if (ci->nk == 0) {
-    argv[1] = blk;
-  }
-  else {
-    mrb_assert(ci->nk == 15);
-    if (ci->n != CALL_MAXARGS) {
-      argv[1] = argv[ci->n];    /* keyword arguments */
-    }
-    argv[2] = blk;
-  }
-  argv[0] = args;               /* must be replaced after saving argv[0] as it may be a keyword argument */
-  ci->n = CALL_MAXARGS;
-  /* ci->nk is already set to zero or CALL_MAXARGS */
   mrb_ary_unshift(mrb, args, mrb_symbol_value(mid));
   ci->mid = missing;
   return m;

--- a/test/t/kernel.rb
+++ b/test/t/kernel.rb
@@ -315,6 +315,19 @@ assert('Kernel#method_missing', '15.3.1.3.30') do
   assert_raise_with_message(NoMethodError, msg) do
     a.no_method_named_this
   end
+
+  a = Object.new
+  def a.method_missing(mid, *args, **opts, &blk)
+    [mid, args, opts, blk&.call]
+  end
+  assert_equal [:foo, [], {}, nil], a.foo
+  assert_equal [:foo, [1, 2], {}, nil], a.foo(1, 2)
+  assert_equal [:foo, (1..15).to_a, {}, nil], a.foo(*(1..15).to_a)
+  assert_equal [:foo, [], { k: 1 }, nil], a.foo(k: 1)
+  assert_equal [:foo, [1], { k: 2 }, nil], a.foo(1, k: 2)
+  assert_equal [:foo, [1, 2], {}, 3], a.foo(1, 2) { 3 }
+  assert_equal [:foo, [1], { k: 2 }, 3], a.foo(1, k: 2) { 3 }
+  assert_equal [:foo, [], { k: 1 }, 2], a.foo(k: 1) { 2 }
 end
 
 assert('Kernel#nil?', '15.3.1.3.32') do


### PR DESCRIPTION
Also, removed the `blk` parameter, which is no longer used directly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `Kernel#method_missing` argument forwarding.
  * Positional, splatted, keyword, and block arguments are now correctly preserved when handling missing methods.

* **Tests**
  * Added coverage verifying that method names, arguments, keyword arguments, and block results are forwarded correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->