### PR TITLE
mruby-regexp: add MatchData#values_at

### DIFF
--- a/mrbgems/mruby-regexp/README.md
+++ b/mrbgems/mruby-regexp/README.md
@@ -120,6 +120,7 @@ md[1]                             # => "user"
 md[2]                             # => "host"
 md[:name]                         # named capture access
 md.captures                       # => ["user", "host"]
+md.values_at(1, 2)                # => ["user", "host"]
 md.to_a                           # => ["user@host", "user", "host"]
 md.to_s                           # => "user@host" (same as md[0])
 md.size                           # => group count, group 0 included

--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -11,6 +11,7 @@
 #include <mruby/array.h>
 #include <mruby/variable.h>
 #include <mruby/hash.h>
+#include <mruby/range.h>
 #include <mruby/error.h>
 #include <mruby/internal.h>
 #include "re_internal.h"
@@ -1065,6 +1066,21 @@ matchdata_name_to_group(mrb_state *mrb, mrb_match_data *md, mrb_value arg)
 /*
  * MatchData#[](n)
  */
+
+/* Read the group at the absolute index `idx`, or nil when it names no group
+   of the match: out of 0...num_captures, or in range but the group did not
+   take part in the match. */
+static mrb_value
+md_nth(mrb_state *mrb, mrb_match_data *md, mrb_int idx)
+{
+  if (idx < 0 || idx >= md->num_captures) return mrb_nil_value();
+  int start = md->captures[idx * 2];
+  int end = md->captures[idx * 2 + 1];
+  if (start < 0) return mrb_nil_value();
+
+  return re_byte_substr(mrb, md->source, start, end - start);
+}
+
 static mrb_value
 md_aref(mrb_state *mrb, mrb_value self, mrb_value arg)
 {
@@ -1088,12 +1104,7 @@ md_aref(mrb_state *mrb, mrb_value self, mrb_value arg)
     }
   }
 
-  if (idx >= md->num_captures) return mrb_nil_value();
-  int start = md->captures[idx * 2];
-  int end = md->captures[idx * 2 + 1];
-  if (start < 0) return mrb_nil_value();
-
-  return re_byte_substr(mrb, md->source, start, end - start);
+  return md_nth(mrb, md, idx);
 }
 
 static mrb_value
@@ -1135,6 +1146,65 @@ static mrb_value
 matchdata_to_a(mrb_state *mrb, mrb_value self)
 {
   return matchdata_to_ary(mrb, self, 0);
+}
+
+/*
+ * MatchData#values_at(*args)
+ */
+
+/* Read the arguments the way CRuby's rb_match_values_at() does. A String or
+   Symbol is the name of a named capture, looked up with the same rule as
+   MatchData#[], so a name the pattern does not carry raises and one that did
+   not take part in the match reads as nil. A Range reads the groups at its
+   positions, the way Array#values_at reads its indexes: a negative bound
+   counts back from the last group, so -num_captures reaches the whole match,
+    and the positions past the last group pad nil. A range that starts before
+    the match raises RangeError, the way an Array range index raises.
+    Everything else converts to an integer and reads the group as MatchData#[]
+    reads it, so a negative one never reaches the whole match and one out of
+    range reads as nil. */
+static mrb_value
+matchdata_values_at(mrb_state *mrb, mrb_value self)
+{
+  mrb_match_data *md = DATA_GET_PTR(mrb, self, &matchdata_type, mrb_match_data);
+  if (!md) return mrb_ary_new(mrb);
+
+  mrb_int argc = mrb_get_argc(mrb);
+  const mrb_value *argv = mrb_get_argv(mrb);
+  mrb_value ary = mrb_ary_new_capa(mrb, argc);
+  for (mrb_int i = 0; i < argc; i++) {
+    mrb_value v = argv[i];
+    if (mrb_string_p(v) || mrb_symbol_p(v)) {
+      mrb_ary_push(mrb, ary, md_nth(mrb, md, matchdata_name_to_group(mrb, md, v)));
+    }
+    else if (mrb_range_p(v)) {
+      mrb_int beg, len;
+      switch (mrb_range_beg_len(mrb, v, &beg, &len, md->num_captures, FALSE)) {
+      case MRB_RANGE_OK:
+        for (mrb_int j = 0; j < len; j++) {
+          mrb_ary_push(mrb, ary, md_nth(mrb, md, beg + j));
+        }
+        break;
+      case MRB_RANGE_OUT:
+        mrb_raisef(mrb, E_RANGE_ERROR, "%v out of range", v);
+        break;
+      default:
+        break;
+      }
+    }
+    else {
+      mrb_int idx = mrb_as_int(mrb, v);
+      if (idx < 0) {
+        idx += md->num_captures;
+        if (idx <= 0) {
+          mrb_ary_push(mrb, ary, mrb_nil_value());
+          continue;
+        }
+      }
+      mrb_ary_push(mrb, ary, md_nth(mrb, md, idx));
+    }
+  }
+  return ary;
 }
 
 /*
@@ -3360,6 +3430,7 @@ mrb_mruby_regexp_gem_init(mrb_state *mrb)
   mrb_define_method(mrb, md, "[]", matchdata_aref, MRB_ARGS_REQ(1));
   mrb_define_method(mrb, md, "captures", matchdata_captures, MRB_ARGS_NONE());
   mrb_define_method(mrb, md, "to_a", matchdata_to_a, MRB_ARGS_NONE());
+  mrb_define_method(mrb, md, "values_at", matchdata_values_at, MRB_ARGS_ANY());
   mrb_define_method(mrb, md, "length", matchdata_length, MRB_ARGS_NONE());
   mrb_define_method(mrb, md, "size", matchdata_length, MRB_ARGS_NONE());
   mrb_define_method(mrb, md, "begin", matchdata_begin, MRB_ARGS_REQ(1));

--- a/mrbgems/mruby-regexp/test/match_data.rb
+++ b/mrbgems/mruby-regexp/test/match_data.rb
@@ -206,6 +206,80 @@ assert("MatchData#[] - group name longer than a uint16 length") do
   assert_equal "x", md[:abc]
 end
 
+assert("MatchData#values_at") do
+  md = /(a)(b)/.match("ab")
+  assert_equal [], md.values_at
+  assert_equal ["a", "b"], md.values_at(1, 2)
+  assert_equal ["ab"], md.values_at(0)
+  assert_equal ["ab", "a", "b"], md.values_at(0, 1, 2)
+  # an index out of range and a group that did not participate both read nil
+  assert_equal ["b", nil, nil], md.values_at(-1, 3, 5)
+  assert_equal ["a", nil], /(a)|(b)/.match("a").values_at(1, 2)
+  # a group that took part in the match with an empty string reads "", not
+  # the nil a group that did not take part reads
+  assert_equal ["b", ""], /(a?)b/.match("b").values_at(0, 1)
+  # a negative index counts back the way MatchData#[] does, never reaching
+  # the whole match
+  assert_equal ["a", nil, nil], md.values_at(-2, -3, -4)
+  # a Float reads the group its integer part names
+  if Object.const_defined?(:Float)
+    assert_equal ["a"], md.values_at(1.5)
+    assert_equal ["a", "ab"], md.values_at(1.5, 0)
+  end
+  # a pattern without capture groups carries only the whole match, so a
+  # negative index reads nil where a range still reaches the match
+  m = /a/.match("a")
+  assert_equal ["a"], m.values_at(0)
+  assert_equal [nil, nil], m.values_at(1, -1)
+  assert_equal ["a"], m.values_at(0..-1)
+  assert_raise(RangeError) { m.values_at(-2..-1) }
+end
+
+assert("MatchData#values_at - group name") do
+  md = /(?<x>a)(?<y>b)/.match("ab")
+  assert_equal ["a", "b"], md.values_at(:x, :y)
+  assert_equal ["b", "a"], md.values_at(:y, "x")
+  # a String is a group name, not a number
+  assert_raise(IndexError) { md.values_at("1") }
+  # a name the pattern does not carry raises, as in MatchData#[]
+  assert_raise(IndexError) { md.values_at(:zz) }
+  assert_raise(IndexError) { /(a)/.match("a").values_at(:zz) }
+  # a named group that did not take part in the match reads nil
+  assert_equal ["b", nil], /(?<x>a)|(?<y>b)/.match("b").values_at(:y, :x)
+end
+
+assert("MatchData#values_at - range") do
+  md = /(a)(b)/.match("ab")
+  assert_equal ["a", "b"], md.values_at(1..2)
+  # an exclusive end stops before its bound, negative or not
+  assert_equal ["a"], md.values_at(1...2)
+  assert_equal ["ab", "a"], md.values_at(-3...-1)
+  # positions past the last group pad nil, as Array#values_at does
+  assert_equal ["a", "b", nil, nil, nil], md.values_at(1..5)
+  assert_equal [nil, nil, nil], md.values_at(5..7)
+  assert_equal [], md.values_at(2..1)
+  assert_equal [], md.values_at(4..)
+  # a negative bound counts back the way an Array index does, so a range can
+  # reach the whole match where a negative index cannot
+  assert_equal ["ab", "a", "b"], md.values_at(-3..-1)
+  assert_equal ["ab", "a", "b"], md.values_at(0..-1)
+  assert_equal [], md.values_at(-2..0)
+  assert_equal ["b"], md.values_at(-1..)
+  assert_equal ["b", nil, nil, nil], md.values_at(-1..5)
+  assert_equal ["a"], md.values_at(-2..-2)
+  assert_equal ["a", nil], /(a)|(b)/.match("a").values_at(1..2)
+  # a range that starts before the match raises, as Array#[] does
+  assert_raise(RangeError) { md.values_at(-4..-1) }
+  assert_raise(RangeError) { md.values_at(-10..-3) }
+end
+
+assert("MatchData#values_at - a bad argument") do
+  md = /(a)(b)/.match("ab")
+  assert_raise(TypeError) { md.values_at(nil) }
+  assert_raise(TypeError) { md.values_at([1, 2]) }
+  assert_raise(TypeError) { md.values_at(true) }
+end
+
 assert("MatchData#begin / #end - group name longer than a stored name") do
   # begin/end share the name lookup with MatchData#[], so the bound that keeps
   # the memcmp() from being handed a length larger than what was measured


### PR DESCRIPTION
MatchData does not have #values_at, which CRuby has via rb_match_values_at().
This adds it to mruby-regexp with the same argument rules as CRuby:

- an Integer (or anything Integer-convertible, e.g. Float) reads the group
  at that index; negative indexes count back from the last group and never
  reach the whole match, out-of-range reads nil
- a String or Symbol is a named capture name, looked up as MatchData#[]
  does (unknown name raises IndexError, non-participating group reads nil)
- a Range reads the groups at its positions the way Array#values_at reads
  indexes: negative bounds count back from the last group (so a range can
  reach the whole match), positions past the last group pad nil, and a
  range starting before the match raises RangeError

Also refactors the index read shared by MatchData#[] and #values_at into
md_nth(), and updates the README with the new method.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `MatchData#values_at` for retrieving multiple regexp captures by index, name, symbol, or range.
  * Supports negative indexes, exclusive ranges, and `nil` padding for out-of-range captures.

* **Bug Fixes**
  * Improved consistency in capture extraction used by `MatchData#[]`.

* **Documentation**
  * Added an example demonstrating multiple capture retrieval.

* **Tests**
  * Added coverage for valid inputs, ranges, negative indexes, and invalid arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->