### PR TITLE
mruby-regexp: read the last participating group for a duplicate name

### DIFF
--- a/mrbgems/mruby-regexp/README.md
+++ b/mrbgems/mruby-regexp/README.md
@@ -120,6 +120,7 @@ md[1]                             # => "user"
 md[2]                             # => "host"
 md[:name]                         # named capture access
 md.captures                       # => ["user", "host"]
+md.values_at(1, 2)                # => ["user", "host"]
 md.to_a                           # => ["user@host", "user", "host"]
 md.to_s                           # => "user@host" (same as md[0])
 md.size                           # => group count, group 0 included

--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -11,6 +11,7 @@
 #include <mruby/array.h>
 #include <mruby/variable.h>
 #include <mruby/hash.h>
+#include <mruby/range.h>
 #include <mruby/error.h>
 #include <mruby/internal.h>
 #include "re_internal.h"
@@ -1065,6 +1066,21 @@ matchdata_name_to_group(mrb_state *mrb, mrb_match_data *md, mrb_value arg)
 /*
  * MatchData#[](n)
  */
+
+/* Read the group at the absolute index `idx`, or nil when it names no group
+   of the match: out of 0...num_captures, or in range but the group did not
+   take part in the match. */
+static mrb_value
+md_nth(mrb_state *mrb, mrb_match_data *md, mrb_int idx)
+{
+  if (idx < 0 || idx >= md->num_captures) return mrb_nil_value();
+  int start = md->captures[idx * 2];
+  int end = md->captures[idx * 2 + 1];
+  if (start < 0) return mrb_nil_value();
+
+  return re_byte_substr(mrb, md->source, start, end - start);
+}
+
 static mrb_value
 md_aref(mrb_state *mrb, mrb_value self, mrb_value arg)
 {
@@ -1088,12 +1104,7 @@ md_aref(mrb_state *mrb, mrb_value self, mrb_value arg)
     }
   }
 
-  if (idx >= md->num_captures) return mrb_nil_value();
-  int start = md->captures[idx * 2];
-  int end = md->captures[idx * 2 + 1];
-  if (start < 0) return mrb_nil_value();
-
-  return re_byte_substr(mrb, md->source, start, end - start);
+  return md_nth(mrb, md, idx);
 }
 
 static mrb_value
@@ -1135,6 +1146,65 @@ static mrb_value
 matchdata_to_a(mrb_state *mrb, mrb_value self)
 {
   return matchdata_to_ary(mrb, self, 0);
+}
+
+/*
+ * MatchData#values_at(*args)
+ */
+
+/* Read the arguments the way CRuby's rb_match_values_at() does. A String or
+   Symbol is the name of a named capture, looked up with the same rule as
+   MatchData#[], so a name the pattern does not carry raises and one that did
+   not take part in the match reads as nil. A Range reads the groups at its
+   positions, the way Array#values_at reads its indexes: a negative bound
+   counts back from the last group, so -num_captures reaches the whole match,
+    and the positions past the last group pad nil. A range that starts before
+    the match raises RangeError, the way an Array range index raises.
+    Everything else converts to an integer and reads the group as MatchData#[]
+    reads it, so a negative one never reaches the whole match and one out of
+    range reads as nil. */
+static mrb_value
+matchdata_values_at(mrb_state *mrb, mrb_value self)
+{
+  mrb_match_data *md = DATA_GET_PTR(mrb, self, &matchdata_type, mrb_match_data);
+  if (!md) return mrb_ary_new(mrb);
+
+  mrb_int argc = mrb_get_argc(mrb);
+  const mrb_value *argv = mrb_get_argv(mrb);
+  mrb_value ary = mrb_ary_new_capa(mrb, argc);
+  for (mrb_int i = 0; i < argc; i++) {
+    mrb_value v = argv[i];
+    if (mrb_string_p(v) || mrb_symbol_p(v)) {
+      mrb_ary_push(mrb, ary, md_nth(mrb, md, matchdata_name_to_group(mrb, md, v)));
+    }
+    else if (mrb_range_p(v)) {
+      mrb_int beg, len;
+      switch (mrb_range_beg_len(mrb, v, &beg, &len, md->num_captures, FALSE)) {
+      case MRB_RANGE_OK:
+        for (mrb_int j = 0; j < len; j++) {
+          mrb_ary_push(mrb, ary, md_nth(mrb, md, beg + j));
+        }
+        break;
+      case MRB_RANGE_OUT:
+        mrb_raisef(mrb, E_RANGE_ERROR, "%v out of range", v);
+        break;
+      default:
+        break;
+      }
+    }
+    else {
+      mrb_int idx = mrb_as_int(mrb, v);
+      if (idx < 0) {
+        idx += md->num_captures;
+        if (idx <= 0) {
+          mrb_ary_push(mrb, ary, mrb_nil_value());
+          continue;
+        }
+      }
+      mrb_ary_push(mrb, ary, md_nth(mrb, md, idx));
+    }
+  }
+  return ary;
 }
 
 /*
@@ -3360,6 +3430,7 @@ mrb_mruby_regexp_gem_init(mrb_state *mrb)
   mrb_define_method(mrb, md, "[]", matchdata_aref, MRB_ARGS_REQ(1));
   mrb_define_method(mrb, md, "captures", matchdata_captures, MRB_ARGS_NONE());
   mrb_define_method(mrb, md, "to_a", matchdata_to_a, MRB_ARGS_NONE());
+  mrb_define_method(mrb, md, "values_at", matchdata_values_at, MRB_ARGS_ANY());
   mrb_define_method(mrb, md, "length", matchdata_length, MRB_ARGS_NONE());
   mrb_define_method(mrb, md, "size", matchdata_length, MRB_ARGS_NONE());
   mrb_define_method(mrb, md, "begin", matchdata_begin, MRB_ARGS_REQ(1));

--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -1012,33 +1012,42 @@ regexp_escape(mrb_state *mrb, mrb_value self)
   return re_escape_str(mrb, str);
 }
 
-/* Answer the group a pattern gives a name to, or -1 for a name it gives to
-   no group. The name is compared as the bytes the pattern spelled it with.
-   A NULL pattern names nothing, which is the answer for a match made
+/* Answer the group a name refers to in the match the captures stand for, or
+   -1 for a name the pattern gives to no group. A pattern may give one name
+   to several groups, and CRuby's named accessors then read the last of them
+   that took part in the match, so the candidates are walked back to front
+   and the first one that participated is the answer; when none of them took
+   part the last of them stands in, a real group the caller reads as one that
+   did not match. The name is compared as the bytes the pattern spelled it
+   with. A NULL pattern names nothing, which is the answer for a match made
    without a pattern to compile: a literal String one. */
 static int
-re_name_to_group(mrb_regexp_pattern *pat, const char *name, mrb_int name_len)
+re_name_to_group(const int *captures, int ncap, mrb_regexp_pattern *pat,
+                 const char *name, mrb_int name_len)
 {
   /* A stored name never exceeds RE_MAX_NAME_LEN, so a longer request can
      name no group. Rejecting it here keeps the cast in the loop lossless;
      without it the length test truncates while the memcmp() next to it does
      not. */
   if (!pat || !RE_NAME_LEN_FITS(name_len)) return -1;
-  for (uint16_t i = 0; i < pat->num_named; i++) {
+  int fallback = -1;
+  for (int i = pat->num_named - 1; i >= 0; i--) {
     if (pat->named_captures[i].name_len == (uint32_t)name_len &&
         memcmp(pat->named_captures[i].name, name, name_len) == 0) {
-      return pat->named_captures[i].group;
+      int group = pat->named_captures[i].group;
+      if (fallback < 0) fallback = group;
+      if (group < ncap && captures[group * 2] >= 0) return group;
     }
   }
-  return -1;
+  return fallback;
 }
 
 /* --- MatchData methods --- */
 
 /* Resolve a String or Symbol to the group it names. Shared by MatchData#[],
-   #begin and #end: the three disagree about what an out-of-range integer
-   means, but a name is looked up the same way for all of them. Does not
-   return when the name reaches no group. */
+   #begin, #end and #values_at: they disagree about what an out-of-range
+   integer means, but a name is looked up the same way for all of them. Does
+   not return when the name reaches no group. */
 static mrb_int
 matchdata_name_to_group(mrb_state *mrb, mrb_match_data *md, mrb_value arg)
 {
@@ -1055,7 +1064,7 @@ matchdata_name_to_group(mrb_state *mrb, mrb_match_data *md, mrb_value arg)
   if (!mrb_nil_p(md->regexp)) {
     pat = DATA_GET_PTR(mrb, md->regexp, &regexp_type, mrb_regexp_pattern);
   }
-  int group = re_name_to_group(pat, name, name_len);
+  int group = re_name_to_group(md->captures, md->num_captures, pat, name, name_len);
   if (group >= 0) return group;
   /* A name that resolves to no group is a mistake at the point of the call,
      not a failed match. CRuby raises here even when the pattern has no
@@ -1519,7 +1528,7 @@ apply_replacement(mrb_state *mrb, mrb_value result,
         /* What the name is asked of is the pattern, not the offsets, so a
            name no group carries raises where a group that took no part in
            the match would only have stood for nothing. */
-        g = re_name_to_group(pat, name, name_len);
+        g = re_name_to_group(captures, ncap, pat, name, name_len);
         if (g < 0) {
           mrb_raisef(mrb, E_INDEX_ERROR, "undefined group name reference: %l", name, (size_t)name_len);
         }

--- a/mrbgems/mruby-regexp/test/match_data.rb
+++ b/mrbgems/mruby-regexp/test/match_data.rb
@@ -132,6 +132,12 @@ assert("MatchData#begin / #end - group name") do
   assert_raise(IndexError) { md.end("zz") }
   # a pattern without any named group raises just the same
   assert_raise(IndexError) { /(a)/.match("a").begin(:zz) }
+  # a name the pattern gives to several groups reads the last one that took
+  # part in the match, nil when none of them did
+  assert_equal [0, 2], [/(?<y>ab)|(?<y>c)/.match("ab").begin(:y),
+                        /(?<y>ab)|(?<y>c)/.match("ab").end(:y)]
+  assert_equal 1, /(?<y>ab)|(?<y>c)/.match("c").end(:y)
+  assert_nil /(?<y>a)(?<y>b)|c/.match("c").begin(:y)
 end
 
 assert("MatchData#begin / #end - index out of matches") do
@@ -196,6 +202,14 @@ assert("MatchData#[] - undefined group name") do
   assert_raise(IndexError) { /(a)/.match("a")[:zz] }
 end
 
+assert("MatchData#[] - a name given to several groups") do
+  # a name the pattern gives to several groups reads the last one that took
+  # part in the match, nil when none of them did
+  assert_equal "b", /(?<x>a)|(?<x>b)/.match("b")[:x]
+  assert_equal "a", /(?<x>a)|(?<x>b)/.match("a")[:x]
+  assert_nil /(?<x>a)(?<y>b)|c/.match("c")[:x]
+end
+
 assert("MatchData#[] - group name longer than a uint16 length") do
   # Regression: the length test truncated the requested length to uint16_t
   # while the memcmp() next to it did not, so (uint16_t)65539 == 3 ==
@@ -246,6 +260,11 @@ assert("MatchData#values_at - group name") do
   assert_raise(IndexError) { /(a)/.match("a").values_at(:zz) }
   # a named group that did not take part in the match reads nil
   assert_equal ["b", nil], /(?<x>a)|(?<y>b)/.match("b").values_at(:y, :x)
+  # a name the pattern gives to several groups reads the last one that took
+  # part in the match, the way MatchData#[] does
+  assert_equal ["b"], /(?<x>a)|(?<x>b)/.match("b").values_at(:x)
+  assert_equal ["a"], /(?<x>a)|(?<x>b)/.match("a").values_at(:x)
+  assert_equal [nil], /(?<x>a)(?<y>b)|c/.match("c").values_at(:x)
 end
 
 assert("MatchData#values_at - range") do

--- a/mrbgems/mruby-regexp/test/match_data.rb
+++ b/mrbgems/mruby-regexp/test/match_data.rb
@@ -206,6 +206,80 @@ assert("MatchData#[] - group name longer than a uint16 length") do
   assert_equal "x", md[:abc]
 end
 
+assert("MatchData#values_at") do
+  md = /(a)(b)/.match("ab")
+  assert_equal [], md.values_at
+  assert_equal ["a", "b"], md.values_at(1, 2)
+  assert_equal ["ab"], md.values_at(0)
+  assert_equal ["ab", "a", "b"], md.values_at(0, 1, 2)
+  # an index out of range and a group that did not participate both read nil
+  assert_equal ["b", nil, nil], md.values_at(-1, 3, 5)
+  assert_equal ["a", nil], /(a)|(b)/.match("a").values_at(1, 2)
+  # a group that took part in the match with an empty string reads "", not
+  # the nil a group that did not take part reads
+  assert_equal ["b", ""], /(a?)b/.match("b").values_at(0, 1)
+  # a negative index counts back the way MatchData#[] does, never reaching
+  # the whole match
+  assert_equal ["a", nil, nil], md.values_at(-2, -3, -4)
+  # a Float reads the group its integer part names
+  if Object.const_defined?(:Float)
+    assert_equal ["a"], md.values_at(1.5)
+    assert_equal ["a", "ab"], md.values_at(1.5, 0)
+  end
+  # a pattern without capture groups carries only the whole match, so a
+  # negative index reads nil where a range still reaches the match
+  m = /a/.match("a")
+  assert_equal ["a"], m.values_at(0)
+  assert_equal [nil, nil], m.values_at(1, -1)
+  assert_equal ["a"], m.values_at(0..-1)
+  assert_raise(RangeError) { m.values_at(-2..-1) }
+end
+
+assert("MatchData#values_at - group name") do
+  md = /(?<x>a)(?<y>b)/.match("ab")
+  assert_equal ["a", "b"], md.values_at(:x, :y)
+  assert_equal ["b", "a"], md.values_at(:y, "x")
+  # a String is a group name, not a number
+  assert_raise(IndexError) { md.values_at("1") }
+  # a name the pattern does not carry raises, as in MatchData#[]
+  assert_raise(IndexError) { md.values_at(:zz) }
+  assert_raise(IndexError) { /(a)/.match("a").values_at(:zz) }
+  # a named group that did not take part in the match reads nil
+  assert_equal ["b", nil], /(?<x>a)|(?<y>b)/.match("b").values_at(:y, :x)
+end
+
+assert("MatchData#values_at - range") do
+  md = /(a)(b)/.match("ab")
+  assert_equal ["a", "b"], md.values_at(1..2)
+  # an exclusive end stops before its bound, negative or not
+  assert_equal ["a"], md.values_at(1...2)
+  assert_equal ["ab", "a"], md.values_at(-3...-1)
+  # positions past the last group pad nil, as Array#values_at does
+  assert_equal ["a", "b", nil, nil, nil], md.values_at(1..5)
+  assert_equal [nil, nil, nil], md.values_at(5..7)
+  assert_equal [], md.values_at(2..1)
+  assert_equal [], md.values_at(4..)
+  # a negative bound counts back the way an Array index does, so a range can
+  # reach the whole match where a negative index cannot
+  assert_equal ["ab", "a", "b"], md.values_at(-3..-1)
+  assert_equal ["ab", "a", "b"], md.values_at(0..-1)
+  assert_equal [], md.values_at(-2..0)
+  assert_equal ["b"], md.values_at(-1..)
+  assert_equal ["b", nil, nil, nil], md.values_at(-1..5)
+  assert_equal ["a"], md.values_at(-2..-2)
+  assert_equal ["a", nil], /(a)|(b)/.match("a").values_at(1..2)
+  # a range that starts before the match raises, as Array#[] does
+  assert_raise(RangeError) { md.values_at(-4..-1) }
+  assert_raise(RangeError) { md.values_at(-10..-3) }
+end
+
+assert("MatchData#values_at - a bad argument") do
+  md = /(a)(b)/.match("ab")
+  assert_raise(TypeError) { md.values_at(nil) }
+  assert_raise(TypeError) { md.values_at([1, 2]) }
+  assert_raise(TypeError) { md.values_at(true) }
+end
+
 assert("MatchData#begin / #end - group name longer than a stored name") do
   # begin/end share the name lookup with MatchData#[], so the bound that keeps
   # the memcmp() from being handed a length larger than what was measured

--- a/mrbgems/mruby-regexp/test/string_regexp.rb
+++ b/mrbgems/mruby-regexp/test/string_regexp.rb
@@ -759,6 +759,11 @@ assert("String#sub / #gsub expand \\k<name> in the replacement") do
   # A group that took no part in the match stands for nothing, the way a
   # numbered reference to one does.
   assert_equal "a[]", "ab".sub(/(?<x>c)?b/, '[\k<x>]')
+  # A name the pattern gives to several groups reaches the last one that took
+  # part in the match, nothing when none of them did.
+  assert_equal "a", "xa".sub(/x(?<y>a)|(?<y>b)/, '\k<y>')
+  assert_equal "xb", "xb".sub(/x(?<y>a)|(?<y>b)/, '\k<y>')
+  assert_equal "", "c".sub(/(?<y>a)(?<y>b)|c/, '\k<y>')
   # The name is the bytes between the angles, so a multibyte one reaches its
   # group without the replacement being read as characters.
   assert_equal "ab!", "ab".sub(/(?<あ>b)/, '\k<あ>!')


### PR DESCRIPTION
Stacked on #7427 (its commit is included in this branch).

When a pattern gives one name to several capture groups (e.g. the
alternatives in /(?<x>a)|(?<x>b)/), CRuby's named accessors read the last
group that took part in the match. re_name_to_group() returned the first
entry in the pattern's named-capture table instead, so
/(?<x>a)|(?<x>b)/.match("b")[:x] came back nil instead of "b".

Resolve the name against the match's captures in the shared lookup: the
candidates are walked back to front and the first one that participated
is the answer; when none of them took part the last of them stands in,
which the callers read as a non-participating group (nil or nothing).
Since the lookup is shared, this fixes every named accessor at once:

- MatchData#[] with a String/Symbol
- MatchData#begin and #end
- MatchData#values_at (added in #7427)
- \k<name> in replacement strings

Verified against CRuby.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `MatchData#values_at` for retrieving multiple captured values by index, name, or range.
  * Improved handling of duplicate named capture groups in match results and replacement strings.

* **Bug Fixes**
  * Corrected behavior when resolving named captures, including unmatched and repeated named groups.

* **Documentation**
  * Added usage documentation for `MatchData#values_at`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->