### PR TITLE
Change `mrb_callinfo::nk` to `kw`

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -172,8 +172,8 @@ typedef struct mrb_irep mrb_irep;
 #endif
 
 typedef struct {
-  uint8_t n:4;                  /* (15=*) c=n|nk<<4 */
-  uint8_t nk:4;                 /* (15=*) */
+  uint8_t n:4;                  /* number of positional arguments; 15 means packed arguments */
+  uint8_t kw:1;                 /* has keyword arguments (TRUE or FALSE) */
   uint8_t cci;                  /* called from C function */
   uint8_t vis;                  /* 4(ZERO):1(module_function):1(separate module):2(method visibility) */
                                 /* under 3-bit flags are copied to env, and after that, env takes precedence */

--- a/include/mruby/proc.h
+++ b/include/mruby/proc.h
@@ -34,10 +34,8 @@ struct REnv {
  * The bit above the block argument index says whether the heap stack of a
  * closed env carries the special-variable slot past its locals; it is an
  * implementation detail of the core, so its accessors live in
- * mruby/internal.h (MRB_ENV_SVAR_P) rather than here. The index below it
- * needs seven bits at most: it counts one for the receiver, at most 14
- * positional arguments (15 meaning a packed array, worth one) and at most
- * 28 for 14 keyword pairs (15 meaning a packed hash, worth one), so 43. */
+ * mruby/internal.h (MRB_ENV_SVAR_P) rather than here.
+ * The index range is 1..16. See also mrb_env_new(). */
 #define MRB_ENV_SET_LEN(e,len) ((e)->flags = (((e)->flags & ~0xff)|((unsigned int)(len) & 0xff)))
 #define MRB_ENV_LEN(e) ((mrb_int)((e)->flags & 0xff))
 #define MRB_ENV_CLOSE(e) ((e)->cxt = NULL)

--- a/mrbgems/mruby-data/src/data.c
+++ b/mrbgems/mruby-data/src/data.c
@@ -257,7 +257,7 @@ mrb_data_new(mrb_state *mrb, mrb_value self)
 
   /* default initialize: store the members directly (fast path) */
   mrb_value *vals;
-  if (mrb->c->ci->nk > 0) {
+  if (mrb->c->ci->kw) {
     mrb_value tmp = mrb_str_new(mrb, NULL, sizeof(mrb_sym)*n);
     mrb_sym *knames = (mrb_sym*)RSTRING_PTR(tmp);
     mrb_value m = mrb_ary_new_capa(mrb, n);
@@ -572,7 +572,7 @@ mrb_data_with(mrb_state *mrb, mrb_value self)
     mrb_argnum_error(mrb, argc, 0, 0);
   }
   /* no keyword arguments: nothing to update, return self (matches CRuby) */
-  if (mrb->c->ci->nk == 0) {
+  if (!mrb->c->ci->kw) {
     return self;
   }
 

--- a/mrbgems/mruby-eval/src/eval.c
+++ b/mrbgems/mruby-eval/src/eval.c
@@ -145,7 +145,7 @@ eval_irep(mrb_state *mrb, mrb_value self, struct RProc *proc)
 
   /* no argument passed from eval() */
   ci->n = 0;
-  ci->nk = 0;
+  ci->kw = FALSE;
   /* clear visibility */
   MRB_CI_SET_VISIBILITY_BREAK(ci);
   /* clear block */

--- a/mrbgems/mruby-method/src/method.c
+++ b/mrbgems/mruby-method/src/method.c
@@ -18,9 +18,8 @@ args_shift(mrb_state *mrb)
 
   if (ci->n < 15) {
     if (ci->n == 0) { goto argerr; }
-    mrb_assert(ci->nk == 0 || ci->nk == 15);
     mrb_value obj = argv[0];
-    int count = ci->n + (ci->nk == 0 ? 0 : 1) + 1 /* block */ - 1 /* first value */;
+    int count = ci->n + ci->kw + 1 /* block */ - 1 /* first value */;
     memmove(argv, argv + 1, count * sizeof(mrb_value));
     ci->n--;
     return obj;

--- a/src/class.c
+++ b/src/class.c
@@ -1312,7 +1312,7 @@ mrb_get_arg1(mrb_state *mrb)
     argc = ARY_LEN(a);
     array_argv = ARY_PTR(a);
   }
-  if (argc == 0 && ci->nk == 15) {
+  if (argc == 0 && ci->kw) {
     mrb_int n = ci->n;
     if (n == 15) n = 1;
     return ci->stack[n+1];      /* kwhash next to positional arguments */
@@ -1384,7 +1384,7 @@ get_args_fast(mrb_state *mrb, const char *format, void** ptr, va_list *ap)
   mrb_int i = 0;
 
   /* fast path only for non-packed, non-keyword args */
-  if (argc >= 15 || ci->nk > 0) return -1;
+  if (argc >= 15 || ci->kw) return -1;
   argv = ci->stack + 1;
 
   /* validate format and count args in one scan (table lookup, no switch) */
@@ -1552,8 +1552,7 @@ get_args_v(mrb_state *mrb, mrb_args_format format, void** ptr, va_list *ap)
   }
 
  check_exit:
-  if (!reqkarg && ci->nk > 0) {
-    mrb_assert(ci->nk == 15);
+  if (!reqkarg && ci->kw) {
     kdict = ci->stack[mrb_ci_bidx(ci)-1];
     if (mrb_hash_p(kdict) && mrb_hash_size(mrb, kdict) > 0) {
       if (argc < 14) {
@@ -1573,12 +1572,11 @@ get_args_v(mrb_state *mrb, mrb_args_format format, void** ptr, va_list *ap)
         }
         ci->stack[2] = ci->stack[mrb_ci_bidx(ci)];
       }
-      ci->nk = 0;
+      ci->kw = FALSE;
     }
   }
-  if (reqkarg && ci->nk > 0) {
+  if (reqkarg && ci->kw) {
     kdict = ci->stack[mrb_ci_bidx(ci)-1];
-    mrb_assert(ci->nk == 15);
     mrb_assert(mrb_hash_p(kdict));
   }
 

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -354,7 +354,7 @@ mrb_f_block_given_p_m(mrb_state *mrb, mrb_value self)
   }
   else {
     uint8_t n = ci->n == 15 ? 1 : ci->n;
-    uint8_t k = ci->nk == 15 ? 1 : ci->nk*2;
+    uint8_t k = ci->kw;
     bidx = n + k + 1;      /* self + args + kargs => bidx */
     bp = &ci->stack[bidx];
   }

--- a/src/proc.c
+++ b/src/proc.c
@@ -76,19 +76,16 @@ mrb_env_new(mrb_state *mrb, struct mrb_context *c, mrb_callinfo *ci, int nstacks
      Asked for here, where allocating is allowed. */
   mrb_svars_reserve(mrb, c);
   struct REnv *e;
-  mrb_int bidx = 1;
+  mrb_int bidx = 1; /* stack: [self, args..., keywords (if any), block] */
   int n = ci->n;
-  int nk = ci->nk;
+  int kw = ci->kw;
 
   e = (struct REnv*)mrb_obj_alloc_core(mrb, MRB_TT_ENV, NULL);
   e->c = tc;
   MRB_ENV_SET_LEN(e, nstacks);
   bidx += (n == 15) ? 1 : n;
-  bidx += (nk == 15) ? 1 : (2*nk);
-  /* This is the only index the VM computes, and the field holding it is
-     seven bits wide (proc.h), which the widest call fits in: one for the
-     receiver, 14 positional arguments and 28 for 14 keyword pairs. */
-  mrb_assert(bidx <= 43);
+  bidx += kw;
+  mrb_assert(bidx >= 1 && bidx <= 16);
   MRB_ENV_SET_BIDX(e, bidx);
   e->mid = ci->mid;
   e->stack = stack;

--- a/src/vm.c
+++ b/src/vm.c
@@ -863,7 +863,7 @@ cipush(mrb_state *mrb, mrb_int push_stacks, uint8_t cci, struct RClass *target_c
   ci->blk = blk;
   ci->stack = ci[-1].stack + push_stacks;
   ci->n = argc & 0xf;
-  ci->nk = (argc>>4) & 0xf;
+  ci->kw = (argc>>4) ? 1 : 0;
   ci->cci = cci;
   ci->vis = MRB_METHOD_PUBLIC_FL;
   if (c->svars) c->svars[ci - c->cibase] = NULL;
@@ -1329,7 +1329,7 @@ mrb_funcall_id(mrb_state *mrb, mrb_value self, mrb_sym mid, mrb_int argc, ...)
 static mrb_int
 mrb_ci_kidx(const mrb_callinfo *ci)
 {
-  if (ci->nk == 0) return -1;
+  if (!ci->kw) return -1;
   return (ci->n == CALL_MAXARGS) ? 2 : ci->n + 1;
 }
 
@@ -1345,7 +1345,10 @@ mrb_bidx(uint8_t n, uint8_t k)
 static inline mrb_int
 ci_bidx(mrb_callinfo *ci)
 {
-  return mrb_bidx(ci->n, ci->nk);
+  int n = ci->n;
+  if (n == CALL_MAXARGS) n = 1;
+  if (ci->kw) n++;
+  return n + 1; /* with self */
 }
 
 mrb_int
@@ -1406,12 +1409,11 @@ mrb_args_pack_positional(mrb_state *mrb)
        prepare_missing() makes the same room before writing the same ones. */
     stack_extend(mrb, 4);
     argv = ci->stack + 1;       /* maybe reallocated */
-    if (ci->nk == 0) {
+    if (ci->kw == FALSE) {
       mrb_value block = argv[argc];
       argv[1] = block;
     }
     else {
-      mrb_assert(ci->nk == CALL_MAXARGS);
       mrb_value keyword = argv[argc];
       mrb_value block = argv[argc + 1];
       argv[1] = keyword;
@@ -1431,7 +1433,7 @@ funcall_args_capture(mrb_state *mrb, int stoff, mrb_int argc, const mrb_value *a
     mrb_raisef(mrb, E_ARGUMENT_ERROR, "negative or too big argc for funcall (%i)", argc);
   }
 
-  ci->nk = 0;                   /* funcall does not support keyword arguments */
+  ci->kw = FALSE;               /* funcall does not support keyword arguments */
   if (argc < CALL_MAXARGS) {
     mrb_int extends = stoff + argc + 2 /* self + block */;
     stack_extend_adjust(mrb, extends, &argv);
@@ -1582,7 +1584,7 @@ check_argument_count(mrb_state *mrb, const mrb_callinfo *ci, mrb_aspec aspec)
     argc = RARRAY_LEN(ci->stack[1]);
   }
   /* keyword hash counts as positional if method doesn't accept keywords */
-  if (ci->nk > 0 && MRB_ASPEC_KEY(aspec) == 0 && !MRB_ASPEC_KDICT(aspec)) {
+  if (ci->kw && MRB_ASPEC_KEY(aspec) == 0 && !MRB_ASPEC_KDICT(aspec)) {
     mrb_value kdict = ci->stack[mrb_ci_kidx(ci)];
     if (mrb_hash_p(kdict) && !mrb_hash_empty_p(mrb, kdict)) {
       argc++;
@@ -1609,7 +1611,7 @@ exec_irep(mrb_state *mrb, mrb_value self, const struct RProc *p)
     if (caspec_bits != 0) {
       check_argument_count(mrb, ci, mrb_proc_decompress_caspec(caspec_bits));
     }
-    else if (MRB_PROC_NOARG_P(p) && (ci->n > 0 || ci->nk > 0)) {
+    else if (MRB_PROC_NOARG_P(p) && (ci->n > 0 || ci->kw)) {
       check_argument_count(mrb, ci, 0);
     }
     return MRB_PROC_CFUNC(p)(mrb, self);
@@ -1639,17 +1641,17 @@ mrb_exec_irep(mrb_state *mrb, mrb_value self, const struct RProc *p)
   else {
     mrb_value ret;
     if (MRB_PROC_CFUNC_P(p)) {
-      if (MRB_PROC_NOARG_P(p) && (ci->n > 0 || ci->nk > 0)) {
+      if (MRB_PROC_NOARG_P(p) && (ci->n > 0 || ci->kw)) {
         check_argument_count(mrb, ci, 0);
       }
-      ci = cipush(mrb, 0, CINFO_DIRECT, CI_TARGET_CLASS(ci), p, NULL, ci->mid, ci->n|(ci->nk<<4));
+      ci = cipush(mrb, 0, CINFO_DIRECT, CI_TARGET_CLASS(ci), p, NULL, ci->mid, ci->n|(ci->kw?15<<4:0));
       mrb->exc = NULL;
       ret = MRB_PROC_CFUNC(p)(mrb, self);
       cipop(mrb);
     }
     else {
       mrb_int keep = ci_bidx(ci) + 1; /* receiver + block */
-      ci = cipush(mrb, 0, CINFO_SKIP, CI_TARGET_CLASS(ci), p, NULL, ci->mid, ci->n|(ci->nk<<4));
+      ci = cipush(mrb, 0, CINFO_SKIP, CI_TARGET_CLASS(ci), p, NULL, ci->mid, ci->n|(ci->kw?15<<4:0));
       ret = mrb_vm_run(mrb, p, self, keep);
     }
     if (mrb->exc && mrb->jmp) {
@@ -1747,7 +1749,7 @@ send_method(mrb_state *mrb, mrb_value self, mrb_bool pub)
       regs[i] = regs[i+1];
     }
     regs[n] = regs[n+1];        /* copy kdict or block */
-    if (ci->nk > 0) {
+    if (ci->kw) {
       regs[n+1] = regs[n+2];    /* copy block */
     }
     ci->n--;
@@ -1765,7 +1767,7 @@ send_method(mrb_state *mrb, mrb_value self, mrb_bool pub)
     if (caspec_bits != 0) {
       check_argument_count(mrb, ci, mrb_proc_decompress_caspec(caspec_bits));
     }
-    else if (MRB_PROC_NOARG_P(p) && (ci->n > 0 || ci->nk > 0)) {
+    else if (MRB_PROC_NOARG_P(p) && (ci->n > 0 || ci->kw)) {
       check_argument_count(mrb, ci, 0);
     }
     return MRB_PROC_CFUNC(p)(mrb, self);
@@ -1840,7 +1842,7 @@ eval_under(mrb_state *mrb, mrb_value self, mrb_value blk, struct RClass *c)
   if (p->body.irep == NULL) return mrb_nil_value();
   CI_PROC_SET(ci, p);
   ci->n = 1;
-  ci->nk = 0;
+  ci->kw = FALSE;
   ci->mid = ci[-1].mid;
   MRB_CI_SET_VISIBILITY_BREAK(ci);
   if (MRB_PROC_CFUNC_P(p)) {
@@ -2050,7 +2052,7 @@ mrb_yield_cont(mrb_state *mrb, mrb_value b, mrb_value self, mrb_int argc, const 
   mrb->c->ci->stack[2] = mrb_nil_value();
   mrb->c->ci->stack[3] = mrb_nil_value();
   ci->n = 15;
-  ci->nk = 0;
+  ci->kw = FALSE;
   return exec_irep(mrb, self, p);
 }
 
@@ -2159,7 +2161,7 @@ argnum_error(mrb_state *mrb, mrb_int num)
       argc = RARRAY_LEN(args);
     }
   }
-  if (argc == 0 && mrb->c->ci->nk != 0 && !mrb_hash_empty_p(mrb, mrb->c->ci->stack[1])) {
+  if (argc == 0 && mrb->c->ci->kw && !mrb_hash_empty_p(mrb, mrb->c->ci->stack[1])) {
     argc++;
   }
   mrb_value str = mrb_format(mrb, "wrong number of arguments (given %i, expected %i)", argc, num);
@@ -2550,7 +2552,7 @@ vm_op_enter(mrb_state *mrb, uint32_t a)
 
   /* no other args */
   if ((a & ~0x7c0001) == 0 && argc < 15 && MRB_PROC_STRICT_P(ci->proc)) {
-    if (mrb_unlikely(argc+(ci->nk==15) != m1)) { /* count kdict too */
+    if (mrb_unlikely(argc+ci->kw != m1)) { /* count kdict too */
       argnum_error(mrb, m1);
       return VM_RAISE;
     }
@@ -2583,7 +2585,7 @@ vm_op_enter(mrb_state *mrb, uint32_t a)
   mrb_value kdict = mrb_nil_value();
 
   /* keyword arguments */
-  if (ci->nk == 15) {
+  if (ci->kw) {
     kdict = regs[mrb_ci_kidx(ci)];
   }
   if (!kd) {
@@ -2603,7 +2605,7 @@ vm_op_enter(mrb_state *mrb, uint32_t a)
       }
     }
     kdict = mrb_nil_value();
-    ci->nk = 0;
+    ci->kw = FALSE;
   }
   else if (!mrb_nil_p(kdict)) {
     mrb_gc_protect(mrb, kdict);
@@ -2688,7 +2690,7 @@ vm_op_enter(mrb_state *mrb, uint32_t a)
       kdict = mrb_hash_new_capa(mrb, 0);
     }
     regs[kw_pos] = kdict;             /* set kwhash */
-    ci->nk = 15;
+    ci->kw = TRUE;
   }
 
   /* format arguments for generated code */
@@ -3682,7 +3684,7 @@ RETRY_TRY_BLOCK:
         /* handle alias */
         MRB_PROC_RESOLVE_ALIAS(ci, p);
         CI_PROC_SET(ci, p);
-        if (MRB_PROC_CFUNC_P(p) && MRB_PROC_ENV_P(p) && !ci->blk && ci->nk == 0) {
+        if (MRB_PROC_CFUNC_P(p) && MRB_PROC_ENV_P(p) && !ci->blk && !ci->kw) {
           /* attr accessor fast path: access the ivar in place and pop the
              frame instead of doing a full cfunc call. Only for cases that
              cannot raise: reads never do; writes are limited to unfrozen
@@ -3716,7 +3718,7 @@ RETRY_TRY_BLOCK:
           JUMP;
         }
         else {
-          if (MRB_PROC_NOARG_P(p) && (ci->n > 0 || ci->nk > 0)) {
+          if (MRB_PROC_NOARG_P(p) && (ci->n > 0 || ci->kw)) {
             check_argument_count(mrb, ci, 0);
           }
           recv = MRB_PROC_CFUNC(p)(mrb, recv);


### PR DESCRIPTION
This means separating the semantic representation from the third operand of the OP_SEND* instruction.
Since its introduction, `mrb_callinfo::nk` has always had a value of either 0 or 15 (CALL_MAXARGS).
The reason for this is that when an OP_SEND* instruction is issued, the called method can only observe that either no keyword arguments exist or that packed keyword arguments exist.

This change also eliminates the need for related assertions.

Furthermore, it corrects errors in assertions and comments that assumed `ci->nk` to be in the range 1..14.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyword-argument handling throughout method calls, evaluation, blocks, and data operations.
  * Fixed argument parsing and block/environment indexing for calls that include keyword arguments.
  * Preserved packed-argument behavior while simplifying keyword-argument presence tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->