### PR TITLE
mruby-struct: let a bare Struct.new answer a memberless struct

### DIFF
--- a/mrbgems/mruby-struct/src/struct.c
+++ b/mrbgems/mruby-struct/src/struct.c
@@ -272,9 +272,6 @@ mrb_struct_s_def(mrb_state *mrb, mrb_value klass)
   mrb_value keyword_init_val = mrb_nil_value();
 
   mrb_get_args(mrb, "*&", &argv, &argc, &b);
-  if (argc == 0) {
-    mrb_raise(mrb, E_ARGUMENT_ERROR, "wrong number of arguments (given 0, expected 1+)");
-  }
 
   /* Check for keyword_init option in arguments */
   if (argc > 0 && mrb_hash_p(argv[argc-1])) {

--- a/mrbgems/mruby-struct/test/struct.rb
+++ b/mrbgems/mruby-struct/test/struct.rb
@@ -11,6 +11,15 @@ assert('Struct.new', '15.2.18.3.1') do
   assert_equal [:m1, :m2], c.members
 end
 
+assert('Struct.new with no arguments', '15.2.18.3.1') do
+  c = Struct.new
+  assert_equal Struct, c.superclass
+  assert_equal [], c.members
+  o = c.new
+  assert_equal [], o.members
+  assert_equal 0, o.size
+end
+
 assert('Struct#==', '15.2.18.4.1') do
   c = Struct.new(:m1, :m2)
   cc1 = c.new(1,2)


### PR DESCRIPTION
## Summary

- `Struct.new` with no arguments raised `ArgumentError: wrong number of arguments (given 0, expected 1+)`, where CRuby answers a memberless struct
- Drop the arity check in `mrb_struct_s_def()` so a bare `Struct.new` yields a class with no members, as in CRuby
- Add a test pinning the memberless `Struct.new` and the size-0 object it builds

## Changes

| File | Change |
| --- | --- |
| `mrbgems/mruby-struct/src/struct.c` | `mrb_struct_s_def()` no longer refuses a zero-argument call; the empty member list flows through the unchanged duplicate scan and accessor definition, which both no-op at length zero |
| `mrbgems/mruby-struct/test/struct.rb` | pins `Struct.new` with no arguments: superclass `Struct`, `members` `[]`, a `new` of size 0 |

## Behaviour

```ruby
# CRuby 4.0.6, and mruby with this PR
c = Struct.new
c.superclass    # => Struct
c.members       # => []
c.new.size      # => 0
c.new.members   # => []

# mruby before
Struct.new      # => ArgumentError: wrong number of arguments (given 0, expected 1+)
```

A call that names one or more members is untouched: the member list is read exactly as before.

## Testing

- [x] `rake test` — all 2561 tests pass (2498 OK, 0 KO, 0 crashes; 63 skipped, unrelated to this change)
- [x] Ran a bare `Struct.new` directly against `bin/mruby` to confirm the memberless struct above


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `Struct.new` now works without arguments, creating an anonymous struct with no members.
  * Instances of empty structs correctly report zero members and a size of zero.

* **Tests**
  * Added coverage for creating and using empty structs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->