### PR TITLE
mruby-struct: raise the ordinary arity error for a keyword_init struct

### DIFF
--- a/mrbgems/mruby-struct/README.md
+++ b/mrbgems/mruby-struct/README.md
@@ -61,7 +61,7 @@ person3 = Person.new
 puts person3.name  # Output: nil
 
 # Positional arguments will raise an error when keyword_init: true
-# Person.new("Charlie", 25)  # ArgumentError: wrong arguments, expected keyword arguments
+# Person.new("Charlie", 25)  # ArgumentError: wrong number of arguments (given 2, expected 0)
 ```
 
 ### Keyword Initialization Modes

--- a/mrbgems/mruby-struct/src/struct.c
+++ b/mrbgems/mruby-struct/src/struct.c
@@ -397,7 +397,7 @@ mrb_struct_initialize(mrb_state *mrb, mrb_value self)
 
   if (mrb_test(keyword_init)) { /* keyword_init: true or other truthy value */
     if (argc > 1 || (argc == 1 && !mrb_hash_p(argv[0]))) {
-      mrb_raise(mrb, E_ARGUMENT_ERROR, "wrong arguments, expected keyword arguments");
+      mrb_argnum_error(mrb, argc, 0, 0);
     }
     mrb_value hash = (argc == 1) ? argv[0] : mrb_hash_new(mrb);
     return mrb_struct_init_with_keywords(mrb, hash, self);

--- a/mrbgems/mruby-struct/test/struct.rb
+++ b/mrbgems/mruby-struct/test/struct.rb
@@ -320,11 +320,15 @@ assert "Struct initialize when :keyword_init is true" do
   assert_equal nil, o2.foo
   assert_equal nil, o2.bar
 
-  assert_raise(ArgumentError) do
+  assert_raise_with_message(ArgumentError, "wrong number of arguments (given 2, expected 0)") do
     c.new(1, 2)
   end
 
-  assert_raise(ArgumentError) do
+  assert_raise_with_message(ArgumentError, "wrong number of arguments (given 1, expected 0)") do
+    c.new(1)
+  end
+
+  assert_raise_with_message(ArgumentError, "wrong number of arguments (given 2, expected 0)") do
     c.new({foo: 1}, {bar: 2})
   end
 end
@@ -352,7 +356,7 @@ assert "Struct initialize when :keyword_init is non-boolean value (treat as true
   assert_equal 1, o.foo
   assert_equal 2, o.bar
 
-  assert_raise(ArgumentError) do
+  assert_raise_with_message(ArgumentError, "wrong number of arguments (given 2, expected 0)") do
     c.new(1, 2)
   end
 end


### PR DESCRIPTION
## Summary

A `Struct` built with `keyword_init: true` takes no positional arguments, so handing it one is an arity error. mruby announced it in wording of its own; this raises the sentence every other arity error in mruby uses, which is also the one CRuby prints.

## Changes

| File | What |
|---|---|
| `mrbgems/mruby-struct/src/struct.c` | `mrb_struct_initialize()` refuses through `mrb_argnum_error()` instead of a bespoke `mrb_raise()` |
| `mrbgems/mruby-struct/test/struct.rb` | the `keyword_init` refusals assert the message, and a single positional argument gets a case of its own |
| `mrbgems/mruby-struct/README.md` | the commented-out example shows the message that is now raised |

### The refusal is an arity error, so it says so

`mrb_struct_initialize()` takes `*` and decides for itself which argument lists it accepts. Under `keyword_init: true` the only accepted shape is a lone `Hash`, because at that point mruby cannot tell `c.new(foo: 1)` from `c.new({foo: 1})`. Everything else is a positional argument the method does not take, which is an arity error with `0` for both bounds. That is precisely what `mrb_argnum_error()` formats, and CRuby reaches the same conclusion through `rb_error_arity(argc, 0, 0)`.

## Behaviour

Which calls are refused does not change; only the message does. All eight shapes below now read the same in mruby and CRuby 4.0.6:

```ruby
c = Struct.new(:foo, :bar, keyword_init: true)

c.new                # => [nil, nil]
c.new({})            # => [nil, nil]
c.new(foo: 1)        # => [1, nil]
c.new(baz: 1)        # ArgumentError: unknown keywords: baz

c.new(nil)           # before: wrong arguments, expected keyword arguments
                     # after:  wrong number of arguments (given 1, expected 0)
c.new(1)             # before: wrong arguments, expected keyword arguments
                     # after:  wrong number of arguments (given 1, expected 0)
c.new(1, 2)          # before: wrong arguments, expected keyword arguments
                     # after:  wrong number of arguments (given 2, expected 0)
c.new({foo: 1}, {})  # before: wrong arguments, expected keyword arguments
                     # after:  wrong number of arguments (given 2, expected 0)
```

## Size

`.text` of `bin/mruby`, `build_config/ci/gcc-clang.rb`, base `3d13b7eb7`.

| Build | master | This PR | Delta |
| --- | ---: | ---: | ---: |
| `bintest` | 1,110,406 | 1,110,374 | -32 |
| `ascii-ctype` | 1,105,526 | 1,105,494 | -32 |
| `byte-string` | 1,084,486 | 1,084,454 | -32 |
| `cxx_abi` | 1,097,565 | 1,097,533 | -32 |
| `full-debug` (-O0) | 1,913,622 | 1,913,590 | -32 |

The whole delta is `struct.o`, whose `.text` goes 6,594 to 6,562 on `bintest`. `.rodata` of `bin/mruby` drops 48 bytes in all five builds, the retired string literal.

## Testing

`MRUBY_CONFIG=ci/gcc-clang rake -m test`, then each `mrbtest` run on its own so the counts attribute:

| Build | Total | OK | KO | Crash | Skip |
| --- | ---: | ---: | ---: | ---: | ---: |
| `bintest` | 2800 | 2781 | 0 | 0 | 19 |
| `ascii-ctype` | 2791 | 2771 | 0 | 0 | 20 |
| `byte-string` | 2719 | 2656 | 0 | 0 | 63 |
| `cxx_abi` | 2800 | 2781 | 0 | 0 | 19 |
| `full-debug` (-O0) | 2800 | 2790 | 0 | 0 | 10 |

The shell-level bintests carried by the `bintest` build pass in the same run. `rake -m test` on the default configuration is green as well: 2561 total, 2498 OK, 0 KO, 0 Crash, 63 skip.

## Environment

<details>

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-30-generic x86_64 |
| CPU | AMD Ryzen 9 5950X 16-Core |
| C compiler | Homebrew clang 23.1.0 |
| C++ compiler | `clang -x c++ -std=gnu++03` for `cxx_abi`, `clang++` links |
| binutils | GNU Binutils 2.47.20260726 (`size`, `ld`) |
| CRuby | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |
| rake | 13.3.1 |

Compile lines as the builds actually issue them, taken from `rake --verbose` after touching `mrbgems/mruby-struct/src/struct.c`, with `-MMD -c`, `-I`, `-o` and the source path dropped. `<root>` stands for the checkout directory in the two `-ffile-prefix-map` arguments:

```console
$ # bintest
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -ffile-prefix-map="<root>=." -ffile-prefix-map="<root>/build/citest=./build" -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_STRUCT_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK

$ # ascii-ctype
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -ffile-prefix-map="<root>=." -ffile-prefix-map="<root>/build/citest=./build" -DMRB_USE_ASCII_CTYPE -DMRB_REGEXP_PARSE_DEPTH_LIMIT=512 -DMRBGEM_MRUBY_STRUCT_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

$ # byte-string
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -ffile-prefix-map="<root>=." -ffile-prefix-map="<root>/build/citest=./build" -DMRBGEM_MRUBY_STRUCT_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

$ # cxx_abi
clang -g -O3 -Wall -Wundef -Wwrite-strings -Wzero-length-array -x c++ -std=gnu++03 -ffile-prefix-map="<root>=." -ffile-prefix-map="<root>/build/citest=./build" -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_STRUCT_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

$ # full-debug
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -g3 -O0 -ffile-prefix-map="<root>=." -ffile-prefix-map="<root>/build/citest=./build" -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRBGEM_MRUBY_STRUCT_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated `Struct` keyword initialization to report the standard argument-count error when positional arguments are provided.
  * Error messages now clearly indicate the number of arguments received and expected.

* **Tests**
  * Added and updated coverage for invalid arguments with truthy `keyword_init` settings.

* **Documentation**
  * Updated the documented error message to match the current behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->