### PR TITLE
build: ask the compiler whether a header is there

### DIFF
--- a/doc/guides/compile.md
+++ b/doc/guides/compile.md
@@ -221,6 +221,68 @@ def conf.cc.header_search_paths
 end
 ```
 
+The header searcher answers whether a file is there, which is not the same
+question as whether the compiler will accept it: it looks the name up in the
+search paths, and the flags this build compiles with are no part of that
+lookup. Where a build passes `-m32`, a `--sysroot`, or anything else that
+moves the compiler's idea of its target, ask the compiler instead.
+
+#### Asking the compiler
+
+`check_header` compiles `#include <name>` with the flags this build compiles
+with, and answers whether that compiled. It is how a build settles a question
+the preprocessor cannot answer on its own: finding out whether a header is
+there means reading it, so a `#if` guarding the `#include` runs too late to
+help.
+
+```ruby
+# `<sys/resource.h>` is an XSI extension, not part of base POSIX, so a host
+# either has it or does not and only the compiler knows which.
+spec.build_settings do |spec|
+  spec.cc.defines << 'HAVE_SYS_RESOURCE_H' if spec.cc.check_header('sys/resource.h')
+end
+```
+
+`check_func` asks whether a name is declared once a header is included, or is
+a macro spelled that way:
+
+```ruby
+spec.build_settings do |spec|
+  spec.cc.defines << 'HAVE_GETRUSAGE' if spec.cc.check_func('getrusage', header: 'sys/resource.h')
+end
+```
+
+A gem asks from a `spec.build_settings` block, as both of those do. It runs
+after every gem's `mrbgem.rake` body and before the rules are defined, which
+is what lets the defines an answer is turned into reach the compile.
+
+`try_compile` takes the source itself, for a question neither of the two
+spells. A build configuration asks its own compiler where it stands, having no
+gem lifecycle to wait on:
+
+```ruby
+conf.cc.defines << 'HAVE_BUILTIN_CLZ' if conf.cc.try_compile(<<~SOURCE)
+  int mrb_probe(void);
+  int mrb_probe(void) { return __builtin_clz(1u); }
+SOURCE
+```
+
+The three compile and never link, so a target with no library to link against
+still answers, and a `check_func` answer is about the declaration a compile
+can see rather than a symbol a link would resolve.
+
+Each answer is kept for the life of the `rake` process, keyed by everything
+that goes into the compile: the command, the option string and the source
+extension it is spelled with, the flags, and the source. The extension is what
+tells a compiler whether it is reading C or C++, and can be all that separates
+two of a build's compilers, a toolchain being free to give them one command
+and one set of flags.
+
+An answer holds for the compiler that gave it. `rake amalgam` embeds the
+defines a gem writes to its own `cc` into the generated `mruby.h`, so an
+amalgam carries the answers the build that generated it got, the way it
+already carries every other define a gem writes.
+
 ### Linker
 
 Configuration of the Linker binary, flags and library paths.

--- a/lib/mruby/build/command.rb
+++ b/lib/mruby/build/command.rb
@@ -1,4 +1,5 @@
 require 'forwardable'
+require 'tmpdir'
 
 module MRuby
   class Command
@@ -38,6 +39,10 @@ module MRuby
     # The answers `file_prefix_map?` has had from the commands it asked,
     # which are the same from one compiler to the next.
     FILE_PREFIX_MAP_SUPPORT = {}
+
+    # The answers `try_compile` has had, keyed by the command line and the
+    # source it asked with.
+    COMPILE_PROBES = {}
 
     attr_accessor :label, :flags, :include_paths, :defines, :source_exts
     # Defines are held in two lists, split by who asked for them. `defines` is
@@ -120,6 +125,90 @@ module MRuby
         `echo | #{probe} -E - 2>&1`
         FILE_PREFIX_MAP_SUPPORT[probe] = $?.exitstatus == 0
       end
+    end
+
+    # Whether this compiler compiles +source+, asked with the flags it will
+    # compile the build with.  This is how a build settles a question about
+    # the target that the preprocessor cannot answer on its own: whether a
+    # header is there to be included is one such question, since finding out
+    # means reading the header, and a `#if` that guards the `#include` runs
+    # too late to help.
+    #
+    # The compiler is asked rather than guessed at from a table of platforms.
+    # It is the one that knows what its target has, and it is asked with the
+    # flags it will compile with, so a cross build answers about the target's
+    # headers and not the host's: the `--sysroot` that says which is which is
+    # among those flags.
+    #
+    # The source is compiled and never linked, so a target with no library to
+    # link against still answers.  Both it and the object go in a directory of
+    # their own, which is removed afterwards; the compiler still runs where
+    # the build runs, so that a relative path among the flags, an `-I` a
+    # configuration wrote without spelling out a root, names what it names
+    # during a compile.
+    #
+    # The answer is kept for the life of the rake process, since a build has
+    # four compilers and a config has several builds, and they name few
+    # commands between them.  It is keyed by everything that goes into the
+    # compile, the extension included: that is what tells a compiler whether
+    # it is reading C or C++, and it can be all that separates two compilers,
+    # a toolchain being free to give them one command and one set of flags.
+    # `visualcpp` does exactly that, naming `cl` for both and handing the C++
+    # one the C flags when `CFLAGS` is set and `CXXFLAGS` is not.
+    def try_compile(source)
+      key = [build.filename(command), compile_options, source_exts.first,
+             all_flags, source]
+      COMPILE_PROBES.fetch(key) { COMPILE_PROBES[key] = run_compile_probe(source) }
+    end
+
+    # Whether the header +name+ is there, as `#include <name>` asks for it.
+    #
+    # Unlike `search_header_path`, which looks through the paths this build
+    # adds with `-I` and answers about those alone, this asks the compiler,
+    # so it answers about the headers the compiler brings itself: those of
+    # the target's C library, where a header base POSIX does not guarantee
+    # (`<sys/resource.h>`, an XSI extension) either is or is not.
+    def check_header(name)
+      # A translation unit needs a declaration in it, and a header alone may
+      # leave one empty, so one is written that costs nothing.
+      try_compile("#include <#{name}>\nextern int mrb_probe;\n")
+    end
+
+    # Whether +name+ is declared once +header+ is included, or is a macro
+    # spelled that way.  A macro answers yes because a call written as
+    # `name(...)` compiles either way, which is what a caller is asking.
+    #
+    # The answer is about the declaration a compile can see, not about a
+    # symbol a link would resolve: this never links.  A host whose headers
+    # declare what its library does not define is not told apart here.
+    def check_func(name, header: nil)
+      source = header ? "#include <#{header}>\n" : ""
+      # The name is mentioned and never called, so an undeclared one is the
+      # error that answers no while a declared one asks nothing of a library.
+      # A macro is caught before that, since a macro is not an identifier the
+      # compiler would have anything to say about.
+      #
+      # A C++ compile is handed a different mention.  A C header read as C++
+      # may declare a name more than once, `pow` and `strchr` among them, and
+      # a cast to `void` cannot name a set: picking from one takes a target
+      # type, which that cast does not give, so the mention that answers for
+      # every other name would answer no for those.  A using-declaration asks
+      # for no target and so names them all.
+      source += <<~SOURCE
+        int mrb_probe(void);
+        int mrb_probe(void) {
+        #ifdef #{name}
+          return 0;
+        #elif defined(__cplusplus)
+          using ::#{name};
+          return 0;
+        #else
+          (void)#{name};
+          return 0;
+        #endif
+        }
+      SOURCE
+      try_compile(source)
     end
 
     def search_header_path(name)
@@ -277,6 +366,25 @@ module MRuby
     end
 
     private
+
+    # Compile +source+ and answer whether it compiled.  The source and the
+    # object are named inside a directory that is removed on the way out; the
+    # compiler is left in the working directory the build compiles from, which
+    # is what a relative path in the flags is written against.
+    def run_compile_probe(source)
+      Dir.mktmpdir("mruby-probe") do |dir|
+        infile = "#{dir}/probe#{source_exts.first || '.c'}"
+        outfile = "#{dir}/probe#{out_ext}"
+        File.write(infile, source)
+        options = compile_options % {
+          flags: all_flags, infile: filename(infile), outfile: filename(outfile)
+        }
+        # `system` answers nil where the command is not there to run at all,
+        # which is an answer of no like any other failure to compile.
+        !!system("#{build.filename(command)} #{options}",
+                 out: File::NULL, err: File::NULL)
+      end
+    end
 
     #
     # === Example of +.flags+ file


### PR DESCRIPTION
## Summary

Whether a header a target might not have is there is a question the preprocessor cannot answer on a build's behalf: finding out means reading the header, which is the very thing a `#if` around the `#include` would be deciding whether to do. This puts the question to the compiler instead, with the flags the build compiles with, and answers from what it did.

## Changes

| File                         | What                                                                                                                |
| ---------------------------- | ------------------------------------------------------------------------------------------------------------------- |
| `lib/mruby/build/command.rb` | adds `Command::Compiler#try_compile`, `#check_header` and `#check_func`, and `COMPILE_PROBES` to hold their answers |
| `doc/guides/compile.md`      | documents the three under **C Compiler**, and what separates them from the header searcher above them               |

### A header's absence is not a question a `#if` can reach

A port that wants to skip an `#include` on a target without that header has had nothing to test. `mruby-dir` shows what that leaves behind: `ports/posix/dir_hal.c` guards `<sys/param.h>` with `HAVE_SYS_PARAM_H`, a name nothing in this tree defines, so the header has not been read since the guard was written.

Putting a question to the compiler is not new here. `Command::Compiler#file_prefix_map?` already asks the command whether it takes `-ffile-prefix-map` and keeps the answer, because a toolchain stands for a family of compilers and only the one about to run knows what it accepts. A header is the same shape of question, and gets the same shape of answer.

### What the header searcher answers, and where that stops

`search_header_path` looks a name up in the search paths and reports the file it found. The gcc and clang toolchains widen those paths to the compiler's own, by asking it with `-Wp,-v`, but that ask carries none of the build's flags, so a build whose compiler has been pointed at another target is answered about the host. Under `cross-32bit`, whose `cc` carries `-m32`, on a host that has no 32-bit libc headers:

| header              | `search_header_path` | `check_header` | compiles? |
| ------------------- | -------------------- | -------------- | --------- |
| `stdio.h`           | found                | `false`        | no        |
| `sys/resource.h`    | found                | `false`        | no        |
| `sys/param.h`       | found                | `false`        | no        |
| `sys/nonexistent.h` | not found            | `false`        | no        |

The widening also lives in `tasks/toolchains/gcc.rake` alone, so under `visualcpp` the searcher sees `include_paths` and nothing else.

Both are kept. Where a caller wants a path, to put on `-I` or to read a file from, the searcher is still what returns one.

### Where a gem asks

`GemList#check` runs `setup_build`, which calls a gem's `build_settings` block, before `setup_compilers`, which defines the rules; by then every gem's `mrbgem.rake` body has run. A define written there reaches the compile:

```ruby
spec.build_settings do |spec|
  spec.cc.defines << 'HAVE_SYS_RESOURCE_H' if spec.cc.check_header('sys/resource.h')
end
```

The three compile and never link, so a target with no library to link against still answers, and a `check_func` answer is about the declaration a compile can see rather than a symbol a link would resolve. Each probe names its source and its object inside a directory that is removed afterwards, and runs the compiler where the build runs, so that a relative path among the flags, an `-I` a configuration wrote without spelling out a root, names during a probe what it names during a compile. Answers are held for the life of the `rake` process, keyed by everything that goes into the compile: the command, the option string and the source extension it is spelled with, the flags, and the source.

`rake amalgam` embeds the defines a gem writes to its own `cc` into the generated `mruby.h`, so an amalgam carries the answers the build that generated it got, the way it already carries every other define a gem writes. `doc/guides/compile.md` says so.

## Testing

Nothing in the tree calls the three yet, so no build compiles differently for this. A gem that reads CPU time through `getrusage(2)`, whose `<sys/resource.h>` is an XSI extension rather than base POSIX, is what asked for them and follows.

| what                                | result                                 |
| ----------------------------------- | -------------------------------------- |
| `rake -m test MRUBY_CONFIG=default` | 2561 total, 0 KO / 0 Crash / 0 Warning |
| `rake -m MRUBY_CONFIG=ci/gcc-clang` | all five builds link                   |

The answers themselves, the same from `clang` and from `gcc`, with the C++ compiler asked for a C++ header:

| probe                                                                       | answer  |
| --------------------------------------------------------------------------- | ------- |
| `cc.check_header('stdio.h')`                                                | `true`  |
| `cc.check_header('sys/resource.h')`                                         | `true`  |
| `cc.check_header('sys/nonexistent-header.h')`                               | `false` |
| `cxx.check_header('vector')`                                                | `true`  |
| `cxx.check_header('no/such.hpp')`                                           | `false` |
| `cc.check_func('getrusage', header: 'sys/resource.h')`                      | `true`  |
| `cc.check_func('getrusage')`                                                | `false` |
| `cc.check_func('assert', header: 'assert.h')`                               | `true`  |
| `cc.check_func('no_such_function_here', header: 'stdio.h')`                 | `false` |
| `cc.try_compile('int f(void); int f(void) { return __builtin_clz(1u); }')`  | `true`  |
| `cc.try_compile('int f(void); int f(void) { return __builtin_nope(1u); }')` | `false` |

`assert` is a macro rather than a function, and answers yes because a call written that way compiles either way.

A cross build answers about its target rather than its host. `cross-mingw`, whose compiler is `x86_64-w64-mingw32-gcc-posix`:

| header           | answer  |
| ---------------- | ------- |
| `stdio.h`        | `true`  |
| `sys/resource.h` | `false` |
| `sys/times.h`    | `false` |

Two of a build's compilers can be given one command and one set of flags, which `visualcpp` does: it names `cl` for both, and hands the C++ one the C flags whenever `CFLAGS` is set and `CXXFLAGS` is not. The extension a probe is written under is then all that separates them, and it is part of the key:

| probe                        | answer  |
| ---------------------------- | ------- |
| `cc.check_header('vector')`  | `false` |
| `cxx.check_header('vector')` | `true`  |

100 repeats of an answered probe take 3.9ms, the compiler having been run once for it.

## Size

`.text` of `bin/mruby` across the five `build_config/ci/gcc-clang.rb` builds, base `3d13b7eb7`:

| build              | master    | this PR   | delta |
| ------------------ | --------- | --------- | ----- |
| bintest            | 1,110,406 | 1,110,406 | 0     |
| ascii-ctype        | 1,105,526 | 1,105,526 | 0     |
| byte-string        | 1,084,486 | 1,084,486 | 0     |
| cxx_abi            | 1,097,565 | 1,097,565 | 0     |
| full-debug (`-O0`) | 1,913,622 | 1,913,622 | 0     |

No C source changes: the compilers run on the same sources with the same flags.

## Environment

<details>

|                    |                                                                   |
| ------------------ | ----------------------------------------------------------------- |
| OS                 | Ubuntu 24.04.4 LTS                                                |
| Kernel             | Linux 7.0.0-30-generic x86_64                                     |
| CPU                | AMD Ryzen 9 5950X 16-Core Processor, 32 threads                   |
| C compiler         | Homebrew clang version 23.1.0                                     |
| C compiler (cross) | x86_64-w64-mingw32-gcc-posix (GCC) 13-posix                       |
| binutils           | GNU ld (GNU Binutils) 2.47.20260726                               |
| CRuby              | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |
| rake               | 13.3.1                                                            |

The compile of `src/string.c` in each of the five builds, as `rake --verbose` printed it, with `-MMD -c`, the `-I` paths, the `-o` and the two `-ffile-prefix-map` taken off:

```console
# bintest
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -DMRB_GC_FIXED_ARENA -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK

# ascii-ctype
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -DMRB_USE_ASCII_CTYPE -DMRB_REGEXP_PARSE_DEPTH_LIMIT=512 -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# byte-string
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# cxx_abi
clang -g -O3 -Wall -Wundef -Wwrite-strings -Wzero-length-array -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# full-debug
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added build-time compiler checks for headers, functions, macros, and custom source snippets.
  - Checks use the complete project build configuration and support both C and C++ compilation.
  - Results are cached during each build for faster repeated checks.
  - Probe results are preserved in amalgamated builds.

- **Documentation**
  - Added guidance and examples for using compiler checks in build settings.
  - Documented caching behavior, compilation flags, and supported probe methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->