### PR TITLE
mruby-dir: drop a guard that has never let its header in

### DIFF
--- a/mrbgems/mruby-dir/ports/posix/dir_hal.c
+++ b/mrbgems/mruby-dir/ports/posix/dir_hal.c
@@ -16,10 +16,6 @@
 #include <unistd.h>
 #include <errno.h>
 
-#ifdef HAVE_SYS_PARAM_H
-#include <sys/param.h>
-#endif
-
 /* On POSIX, mrb_dir_handle wraps DIR */
 struct mrb_dir_handle {
   DIR *dir;


### PR DESCRIPTION
## Summary

`mruby-dir`'s POSIX port asks for `<sys/param.h>` behind `#ifdef HAVE_SYS_PARAM_H`, a name nothing in this tree defines, so the header has not been read since the guard was written and the port needs nothing from it.

## Changes

| File                                      | What                                                           |
| ----------------------------------------- | -------------------------------------------------------------- |
| `mrbgems/mruby-dir/ports/posix/dir_hal.c` | drops the `HAVE_SYS_PARAM_H` guard and the `#include` it holds |

### The guard has no writer

```c
#ifdef HAVE_SYS_PARAM_H
#include <sys/param.h>
#endif
```

No `build_config/` file writes `HAVE_SYS_PARAM_H`, no `mrbgem.rake` writes it, and the build system has had nothing to work one out with. Every build has gone on compiling with the header unread, which is the answer to whether the port needs it.

### What the header used to carry

The include was unconditional before the HAL split, on the non-Windows arm of `src/dir.c`'s `_WIN32` test:

```c
#if defined(_WIN32)
  #define MAXPATHLEN 1024
  ...
#else
  #include <sys/param.h>
  #include <dirent.h>
  #include <unistd.h>
#endif
```

It kept its place through the move into `dir_hal.c` and gained the guard on the way, which is where it stopped being read. `MAXPATHLEN`, which the Windows arm defined by hand, is gone from the gem now along with `PATH_MAX`, and none of the other names `<sys/param.h>` carries appears in the port.

## Testing

Preprocessed as the build preprocesses it, with the line markers dropped, the file before and after this differ by the four blank lines the deletion leaves and by nothing else; `sys/param.h` is named zero times in either output. Compiled with the file names and the path map held equal, `.text` of `dir_hal.o` is byte for byte identical, the whole object differing only where the debug information records the line numbers that moved.

| what                                | result                                 |
| ----------------------------------- | -------------------------------------- |
| `rake -m test MRUBY_CONFIG=default` | 2561 total, 0 KO / 0 Crash / 0 Warning |
| `rake -m MRUBY_CONFIG=ci/gcc-clang` | all five builds link                   |

## Size

`.text` of `bin/mruby` across the five `build_config/ci/gcc-clang.rb` builds, base `3d13b7eb7`:

| build              | master    | this PR   | delta |
| ------------------ | --------- | --------- | ----- |
| bintest            | 1,110,406 | 1,110,406 | 0     |
| ascii-ctype        | 1,105,526 | 1,105,526 | 0     |
| byte-string        | 1,084,486 | 1,084,486 | 0     |
| cxx_abi            | 1,097,565 | 1,097,565 | 0     |
| full-debug (`-O0`) | 1,913,622 | 1,913,622 | 0     |

## Environment

<details>

|            |                                                                   |
| ---------- | ----------------------------------------------------------------- |
| OS         | Ubuntu 24.04.4 LTS                                                |
| Kernel     | Linux 7.0.0-30-generic x86_64                                     |
| CPU        | AMD Ryzen 9 5950X 16-Core Processor, 32 threads                   |
| C compiler | Homebrew clang version 23.1.0                                     |
| binutils   | GNU ld (GNU Binutils) 2.47.20260726                               |
| CRuby      | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |
| rake       | 13.3.1                                                            |

The compile of `src/string.c` in each of the five builds, as `rake --verbose` printed it, with `-MMD -c`, the `-I` paths, the `-o` and the two `-ffile-prefix-map` taken off:

```console
# bintest
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -DMRB_GC_FIXED_ARENA -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK

# ascii-ctype
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -DMRB_USE_ASCII_CTYPE -DMRB_REGEXP_PARSE_DEPTH_LIMIT=512 -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# byte-string
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# cxx_abi
clang -g -O3 -Wall -Wundef -Wwrite-strings -Wzero-length-array -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# full-debug
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified POSIX directory support without changing directory operations or end-user behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->