### PR TITLE
mruby-regexp: add `MatchData#offset`

### DIFF
--- a/mrbgems/mruby-regexp/README.md
+++ b/mrbgems/mruby-regexp/README.md
@@ -127,6 +127,7 @@ md.size                           # => group count, group 0 included
 md.length                         # => same as size
 md.begin(0)                       # => match start position
 md.end(0)                         # => match end position
+md.offset(0)                      # => [begin, end] of the same group
 md.pre_match                      # => string before match
 md.post_match                     # => string after match
 md.named_captures                 # => {"name" => "value", ...}

--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -1267,6 +1267,31 @@ matchdata_end(mrb_state *mrb, mrb_value self)
   return mrb_int_value(mrb, re_byte_to_char(mrb, md->source, pos));
 }
 
+/*
+ * MatchData#offset(n)
+ */
+
+/* The two offsets `begin` and `end` report, read in one call. CRuby's
+   rb_match_offset() reads the argument the way begin and end read theirs, so
+   a name reaches its group and an argument that reaches none raises. A group
+   that took no part in the match has neither offset, and the pair is
+   [nil, nil] rather than nil: the method always answers an array of two. */
+static mrb_value
+matchdata_offset(mrb_state *mrb, mrb_value self)
+{
+  mrb_value arg;
+  mrb_get_args(mrb, "o", &arg);
+
+  mrb_match_data *md = DATA_GET_PTR(mrb, self, &matchdata_type, mrb_match_data);
+  if (!md) return mrb_nil_value();
+  mrb_int idx = matchdata_group_arg(mrb, md, arg);
+  int beg = md->captures[idx * 2];
+  if (beg < 0) return mrb_assoc_new(mrb, mrb_nil_value(), mrb_nil_value());
+  int end = md->captures[idx * 2 + 1];
+  return mrb_assoc_new(mrb, mrb_int_value(mrb, re_byte_to_char(mrb, md->source, beg)),
+                       mrb_int_value(mrb, re_byte_to_char(mrb, md->source, end)));
+}
+
 /* Whether `str` still reads as the subject `md` was made on. The block loops
    of `gsub` and `scan` end on a search from the offset their last match was
    found from, on the receiver as the block left it, the way CRuby's
@@ -3444,6 +3469,7 @@ mrb_mruby_regexp_gem_init(mrb_state *mrb)
   mrb_define_method(mrb, md, "size", matchdata_length, MRB_ARGS_NONE());
   mrb_define_method(mrb, md, "begin", matchdata_begin, MRB_ARGS_REQ(1));
   mrb_define_method(mrb, md, "end", matchdata_end, MRB_ARGS_REQ(1));
+  mrb_define_method(mrb, md, "offset", matchdata_offset, MRB_ARGS_REQ(1));
   mrb_define_method(mrb, md, "pre_match", matchdata_pre, MRB_ARGS_NONE());
   mrb_define_method(mrb, md, "post_match", matchdata_post, MRB_ARGS_NONE());
   mrb_define_method(mrb, md, "__pre_match", matchdata_pre, MRB_ARGS_NONE());

--- a/mrbgems/mruby-regexp/test/match_data.rb
+++ b/mrbgems/mruby-regexp/test/match_data.rb
@@ -154,6 +154,34 @@ assert("MatchData#begin / #end - index out of matches") do
   assert_nil md.end(2)
 end
 
+assert("MatchData#offset") do
+  md = /(a)(b)/.match("ab")
+  assert_equal [0, 2], md.offset(0)
+  assert_equal [0, 1], md.offset(1)
+  assert_equal [1, 2], md.offset(2)
+  # a name reaches its group, as it does in begin and end
+  md = /(?<x>b)(?<y>c)/.match("abcde")
+  assert_equal [1, 2], md.offset(:x)
+  assert_equal [2, 3], md.offset("y")
+end
+
+assert("MatchData#offset - a group that took no part in the match") do
+  # Neither offset exists, and the pair is [nil, nil]: an array of two comes
+  # back whatever the group did, where begin and end each answer nil.
+  assert_equal [nil, nil], /(a)|(b)/.match("a").offset(2)
+  assert_equal [nil, nil], /(?<y>a)(?<y>b)|c/.match("c").offset(:y)
+end
+
+assert("MatchData#offset - an argument that reaches no group") do
+  # The argument is read the way begin and end read theirs, so an index out of
+  # range raises rather than answering [nil, nil].
+  md = /(a)(b)/.match("ab")
+  assert_raise(IndexError) { md.offset(3) }
+  assert_raise(IndexError) { md.offset(-1) }
+  assert_raise(IndexError) { md.offset(:zz) }
+  assert_raise(IndexError) { /(a)/.match("a").offset(:zz) }
+end
+
 assert("$~ global variable") do
   /(\w+)@(\w+)/ =~ "user@host"
   assert_kind_of MatchData, $~

--- a/mrbgems/mruby-regexp/test/regexp_utf8.rb
+++ b/mrbgems/mruby-regexp/test/regexp_utf8.rb
@@ -391,6 +391,7 @@ assert("Regexp - a capture spans whole characters") do
   assert_equal [0xc4, 0x80], m[1].bytes
   assert_equal "x", m[2]
   assert_equal [0, 1, 1, 2], [m.begin(1), m.end(1), m.begin(2), m.end(2)]
+  assert_equal [[0, 1], [1, 2]], [m.offset(1), m.offset(2)]
   # Read as binary every byte stands alone, so a byte capture works there.
   if Object.const_defined?(:Encoding)
     bm = Regexp.new("(\xc4).").match("\xc4\x80x".b)


### PR DESCRIPTION
## Summary

- `MatchData#offset` was missing: `/(a)(b)/.match("ab").offset(1)` raised `NoMethodError` where CRuby answers `[0, 1]`
- Add `matchdata_offset()`, which reads its argument through the same helper `#begin` and `#end` use, so an index and a group name both reach the group and an argument that reaches none raises `IndexError`
- A group that took no part in the match answers `[nil, nil]`, so the method always hands back an array of two

## Changes

| File | What |
|---|---|
| `mrbgems/mruby-regexp/src/regexp.c` | `matchdata_offset()` beside `matchdata_begin()` and `matchdata_end()`, registered as `MatchData#offset` with `MRB_ARGS_REQ(1)` |
| `mrbgems/mruby-regexp/test/match_data.rb` | `MatchData#offset`, `MatchData#offset - a group that took no part in the match`, `MatchData#offset - an argument that reaches no group` |
| `mrbgems/mruby-regexp/test/regexp_utf8.rb` | one row pinning the pair against the `#begin` / `#end` pair already asserted there, on a build that indexes by character |
| `mrbgems/mruby-regexp/README.md` | `md.offset(0)` in the MatchData list |

### The fourth caller of the name-to-group helper

`#begin` and `#end` already share `matchdata_group_arg()`, which resolves a String or Symbol to the group it names and refuses an integer outside `0...num_captures`. CRuby's `rb_match_offset()` reads its argument exactly that way, so `#offset` calls the same helper and inherits both halves: `md.offset(:x)` reads the named group, `md.offset(3)` on a two-group match raises `IndexError: index 3 out of matches`, and a name the pattern does not carry raises `IndexError: undefined group name reference: zz`.

What differs is the answer for a group that exists but did not participate. `#begin` and `#end` each have a `nil` to give, and give it. `#offset` returns an array whatever happens, so the pair is `[nil, nil]`.

The offsets are the character positions `#begin` and `#end` report, taken through the same `re_byte_to_char()`, so on a build that indexes by byte they are byte positions in the same way.

## Behaviour

Rows measured against CRuby 4.0.6 (`03b6d3f889`) and against the branch binary:

| Expression | before | after | CRuby |
|---|---|---|---|
| `/(a)(b)/.match("ab").offset(0)` | `NoMethodError` | `[0, 2]` | `[0, 2]` |
| `/(a)(b)/.match("ab").offset(1)` | `NoMethodError` | `[0, 1]` | `[0, 1]` |
| `/(?<x>b)(?<y>c)/.match("abcde").offset(:x)` | `NoMethodError` | `[1, 2]` | `[1, 2]` |
| `/(?<x>b)(?<y>c)/.match("abcde").offset("y")` | `NoMethodError` | `[2, 3]` | `[2, 3]` |
| `/(a)\|(b)/.match("a").offset(2)` | `NoMethodError` | `[nil, nil]` | `[nil, nil]` |
| `/(?<y>a)(?<y>b)\|c/.match("c").offset(:y)` | `NoMethodError` | `[nil, nil]` | `[nil, nil]` |
| `/(あ)(い)/.match("xあいu").offset(0)` | `NoMethodError` | `[1, 3]` | `[1, 3]` |
| `md.offset(3)` on `/(a)(b)/` | `NoMethodError` | `IndexError` | `IndexError` |
| `md.offset(-1)` on `/(a)(b)/` | `NoMethodError` | `IndexError` | `IndexError` |
| `md.offset(:zz)` | `NoMethodError` | `IndexError` | `IndexError` |
| `md.offset` | `NoMethodError` | `ArgumentError` | `ArgumentError` |
| `md.offset(1, 2)` | `NoMethodError` | `ArgumentError` | `ArgumentError` |

The message texts agree too, `index 3 out of matches` and `undefined group name reference: zz` among them, because they come from the helper `#begin` and `#end` were already raising through.

One row stays apart: `md.offset(nil)` raises `TypeError` in both, worded `nil cannot be converted to Integer` here against CRuby's `no implicit conversion from nil to integer`. That wording is `mrb_as_int()`'s and is what `md.begin(nil)` already answers.

Nothing else moves: no existing path is touched, only a method added.

## Size

`.text` of `bin/mruby` for the five `build_config/ci/gcc-clang.rb` builds, `size -A`, master and this branch built at the same path from empty build directories:

| Build | master | this PR | delta |
|---|---|---|---|
| `bintest` | 1,110,406 | 1,110,806 | +400 |
| `ascii-ctype` | 1,105,526 | 1,105,926 | +400 |
| `byte-string` | 1,084,486 | 1,084,886 | +400 |
| `cxx_abi` | 1,097,565 | 1,097,965 | +400 |
| `full-debug` (-O0) | 1,913,622 | 1,914,006 | +384 |

The whole of it is the new function and its registration: `nm -S` puts `matchdata_offset` at 381 bytes in `bintest`, against 236 for each of `matchdata_begin` and `matchdata_end`, the difference being the second `re_byte_to_char()` call and the array it fills. `.rodata` is byte-identical in all five builds, because `offset` is already a presym (`MRB_SYM__offset` at the same index on both sides), so the symbol table gains nothing and no other section moves either.

## Testing

- `rake -m test` green with `build_config/ci/gcc-clang.rb`, all five builds (`bintest`, `cxx_abi`, `byte-string`, `ascii-ctype`, `full-debug`): 0 KO, 0 crashes
- `rake -m test` green with the default config: 2564 tests, 2501 OK, 0 KO, 0 crashes, 63 skipped, none of them new
- every row of the table above run on the branch binary and on CRuby 4.0.6, including the message texts
- the multibyte row runs only where the build indexes by character, so it sits in `regexp_utf8.rb` next to the `#begin` / `#end` assertions it mirrors; `match_data.rb` stays ASCII, as it was

## Environment

<details>

| | |
|---|---|
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-30-generic x86_64 |
| CPU | AMD Ryzen 9 5950X (16C/32T) |
| C compiler | Homebrew clang 23.1.0 |
| binutils | GNU ld 2.47.20260726 |
| CRuby | 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM |
| base | `3d13b7eb7` |

Compile lines for `mrbgems/mruby-regexp/src/regexp.c` as run, with `-MMD -c`, `-I`, `-o`, `-ffile-prefix-map` and `-DMRBGEM_MRUBY_REGEXP_VERSION` dropped:

```console
# bintest
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -DMRB_GC_FIXED_ARENA -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK

# ascii-ctype
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -DMRB_USE_ASCII_CTYPE -DMRB_REGEXP_PARSE_DEPTH_LIMIT=512 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# byte-string
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# cxx_abi
clang -g -O3 -Wall -Wundef -Wwrite-strings -Wzero-length-array -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# full-debug
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `MatchData#offset`, returning a capture group’s beginning and ending character positions together.
  * Supports numeric indexes and named capture groups.
  * Returns `[nil, nil]` when a group did not participate in the match.
  * Invalid or unavailable groups raise `IndexError`.

* **Documentation**
  * Added usage guidance for `MatchData#offset`.

* **Tests**
  * Added coverage for named, indexed, missing, invalid, and UTF-8 capture groups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->