### PR TITLE
io.c: read only WSAENOTSOCK as "not a socket" on Windows

### DIFF
--- a/mrbgems/mruby-io/src/io.c
+++ b/mrbgems/mruby-io/src/io.c
@@ -562,6 +562,14 @@ check_file_descriptor(mrb_state *mrb, mrb_int fd)
     if (getsockopt(fdi, SOL_SOCKET, SO_ERROR, (char*)&err, &len) == 0) {
       return;
     }
+    /* A Winsock handle is not a CRT file descriptor, so the probes below
+       cannot vouch for one and would call it bad. Only WSAENOTSOCK says
+       the value is not a socket; every other error is a socket that would
+       not answer this particular question, and treating that as "not a
+       socket" fails IO.new on a healthy one. */
+    if (WSAGetLastError() != WSAENOTSOCK) {
+      return;
+    }
   }
 
   if (fdi < 0 || fdi > _getmaxstdio()) {

--- a/mrbgems/mruby-socket/test/udpsocket.rb
+++ b/mrbgems/mruby-socket/test/udpsocket.rb
@@ -1,26 +1,3 @@
-# TEMPORARY diagnostic, to be removed before this branch is merged. The
-# 32-bit Windows job rejects UDPSocket.new(Socket::AF_INET6) with EBADF from
-# IO#initialize's descriptor check while the AF_INET case beside it passes,
-# and the descriptor Socket._socket hands over is the only thing that differs.
-# Print it.
-assert('DIAGNOSTIC descriptors') do
-  [["AF_INET", Socket::AF_INET], ["AF_INET6", Socket::AF_INET6]].each do |name, af|
-    begin
-      fd = Socket._socket(af, Socket::SOCK_DGRAM, 0)
-      puts "DIAG #{name}: af=#{af} fd=#{fd} (0x#{fd < 0 ? (fd + (1 << 32)).to_s(16) : fd.to_s(16)})"
-      begin
-        UDPSocket.for_fd(fd).close
-        puts "DIAG #{name}: wrapped and closed"
-      rescue Exception => e
-        puts "DIAG #{name}: wrap raised #{e.class}: #{e.message}"
-      end
-    rescue Exception => e
-      puts "DIAG #{name}: _socket raised #{e.class}: #{e.message}"
-    end
-  end
-  true
-end
-
 assert('UDPSocket.new') do
   s = UDPSocket.new
   assert_true(s.is_a? UDPSocket)

--- a/mrbgems/mruby-socket/test/udpsocket.rb
+++ b/mrbgems/mruby-socket/test/udpsocket.rb
@@ -1,3 +1,26 @@
+# TEMPORARY diagnostic, to be removed before this branch is merged. The
+# 32-bit Windows job rejects UDPSocket.new(Socket::AF_INET6) with EBADF from
+# IO#initialize's descriptor check while the AF_INET case beside it passes,
+# and the descriptor Socket._socket hands over is the only thing that differs.
+# Print it.
+assert('DIAGNOSTIC descriptors') do
+  [["AF_INET", Socket::AF_INET], ["AF_INET6", Socket::AF_INET6]].each do |name, af|
+    begin
+      fd = Socket._socket(af, Socket::SOCK_DGRAM, 0)
+      puts "DIAG #{name}: af=#{af} fd=#{fd} (0x#{fd < 0 ? (fd + (1 << 32)).to_s(16) : fd.to_s(16)})"
+      begin
+        UDPSocket.for_fd(fd).close
+        puts "DIAG #{name}: wrapped and closed"
+      rescue Exception => e
+        puts "DIAG #{name}: wrap raised #{e.class}: #{e.message}"
+      end
+    rescue Exception => e
+      puts "DIAG #{name}: _socket raised #{e.class}: #{e.message}"
+    end
+  end
+  true
+end
+
 assert('UDPSocket.new') do
   s = UDPSocket.new
   assert_true(s.is_a? UDPSocket)


### PR DESCRIPTION
The AppVeyor `Visual Studio 2019 32-bit` job has been failing since build
9150, intermittently, on one test:

```
Errno::EBADF: UDPSocket.new(AF_INET6) => Bad file descriptor - bad file descriptor
  Total: 2783
     OK: 2736
     KO: 0
  Crash: 1
```

The other two AppVeyor jobs and all 22 GitHub Actions checks stay green, so
this is specific to 32-bit Windows.

### Where it comes from

The message is `badfd_error()`'s, which `check_file_descriptor()` in
`mrbgems/mruby-io/src/io.c` raises. `UDPSocket#initialize` reaches it
because `BasicSocket#initialize` calls `super` (so `IO#initialize`, so the
descriptor check) before `self._is_socket = true`, leaving the check to
judge a raw Winsock handle.

That is why the check asks Winsock first: a Winsock handle is not a CRT
file descriptor, and the CRT probes after it would call a perfectly good
socket bad. But it read *any* `getsockopt` failure as the answer "not a
socket". `SO_ERROR` is refused on a socket that is not bound yet by some
stacks, so the socket fell through to the CRT fallback and was rejected as
`EBADF`.

Only `WSAENOTSOCK` reports that the value is not a socket. Every other
error is a socket declining that particular question, so this keeps it.

### Verification

I have no Windows machine, so the point of this PR is AppVeyor's
`Visual Studio 2019 32-bit` job. The change is inside `#ifdef _WIN32`;
`rake CONFIG=host-debug all test:run:serial` on Linux stays at
`KO: 0 / Crash: 0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows compatibility when working with valid Winsock socket handles.
  * Prevented healthy sockets from being incorrectly rejected during file descriptor checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->