### PR TITLE
mruby-struct: add Struct.keyword_init? and follow CRuby keyword argument handling

### DIFF
--- a/mrbgems/mruby-struct/README.md
+++ b/mrbgems/mruby-struct/README.md
@@ -70,22 +70,34 @@ The `keyword_init` option supports three modes:
 
 1. **`keyword_init: true`** - Only keyword arguments are accepted
 2. **`keyword_init: false`** - Only positional arguments are accepted (hashes are treated as values)
-3. **`keyword_init: nil` (default)** - Flexible mode: accepts both positional arguments and keyword arguments (single hash)
+3. **`keyword_init: nil` (default)** - Flexible mode: accepts both positional arguments and keyword arguments
 
 ```ruby
 # Flexible mode (default behavior)
 FlexPoint = Struct.new(:x, :y)
 p1 = FlexPoint.new(1, 2)           # Positional arguments
-p2 = FlexPoint.new(x: 3, y: 4)     # Keyword arguments (single hash)
+p2 = FlexPoint.new(x: 3, y: 4)     # Keyword arguments
+p3 = FlexPoint.new({x: 3, y: 4})   # Hash passed positionally is a plain value: x={x: 3, y: 4}
 
 # Keyword-only mode
 KeywordPoint = Struct.new(:x, :y, keyword_init: true)
-p3 = KeywordPoint.new(x: 5, y: 6)  # Only keyword arguments allowed
+p4 = KeywordPoint.new(x: 5, y: 6)  # Only keyword arguments allowed
 
 # Positional-only mode
 PositionalPoint = Struct.new(:x, :y, keyword_init: false)
-p4 = PositionalPoint.new(7, 8)     # Only positional arguments
-p5 = PositionalPoint.new({x: 9, y: 10})  # Hash is treated as first value
+p5 = PositionalPoint.new(7, 8)     # Only positional arguments
+p6 = PositionalPoint.new({x: 9, y: 10})  # Hash is treated as first value
+```
+
+The generated class reports its mode through `keyword_init?`, which returns
+`true`, `false`, or `nil` accordingly. Subclasses inherit the mode from the
+struct class they derive from:
+
+```ruby
+KeywordPoint.keyword_init?     # => true
+PositionalPoint.keyword_init?  # => false
+FlexPoint.keyword_init?        # => nil
+Class.new(KeywordPoint).keyword_init?  # => true
 ```
 
 ## Available Methods

--- a/mrbgems/mruby-struct/src/struct.c
+++ b/mrbgems/mruby-struct/src/struct.c
@@ -429,9 +429,18 @@ mrb_struct_init_with_keywords(mrb_state *mrb, mrb_value hash, mrb_value self)
 static mrb_value
 mrb_struct_initialize(mrb_state *mrb, mrb_value self)
 {
+  /* Read before mrb_get_args, which folds the kdict into argv and clears
+     ci->kw. Class#new always forwards a kdict, so an empty one means the
+     caller wrote no keywords. */
+  mrb_callinfo *ci = mrb->c->ci;
+  mrb_bool kw_given = FALSE;
+  if (ci->kw) {
+    mrb_value kdict = ci->stack[mrb_ci_bidx(ci)-1];
+    kw_given = mrb_hash_p(kdict) && !mrb_hash_empty_p(mrb, kdict);
+  }
+
   const mrb_value *argv;
   mrb_int argc;
-
   mrb_get_args(mrb, "*", &argv, &argc);
 
   mrb_value keyword_init = struct_s_keyword_init(mrb, mrb_obj_class(mrb, self));
@@ -443,17 +452,12 @@ mrb_struct_initialize(mrb_state *mrb, mrb_value self)
     mrb_value hash = (argc == 1) ? argv[0] : mrb_hash_new(mrb);
     return mrb_struct_init_with_keywords(mrb, hash, self);
   }
-  else if (mrb_equal(mrb, keyword_init, mrb_false_value())) { /* keyword_init: false */
-    return mrb_struct_init_with_args(mrb, argc, argv, self);
+  if (mrb_nil_p(keyword_init) && kw_given && argc == 1 && mrb_hash_p(argv[0])) {
+    /* keyword_init: nil (default): keyword arguments initialize by member
+       name, while a hash passed positionally stays a plain member value */
+    return mrb_struct_init_with_keywords(mrb, argv[0], self);
   }
-  else { /* keyword_init: nil (default) */
-    if (argc == 1 && mrb_hash_p(argv[0])) {
-      return mrb_struct_init_with_keywords(mrb, argv[0], self);
-    }
-    else {
-      return mrb_struct_init_with_args(mrb, argc, argv, self);
-    }
-  }
+  return mrb_struct_init_with_args(mrb, argc, argv, self);
 }
 
 /* 15.2.18.4.9  */

--- a/mrbgems/mruby-struct/src/struct.c
+++ b/mrbgems/mruby-struct/src/struct.c
@@ -54,6 +54,38 @@ struct_s_members(mrb_state *mrb, struct RClass *c)
 }
 
 static mrb_value
+struct_s_keyword_init(mrb_state *mrb, struct RClass *c)
+{
+  struct RClass *sclass = struct_class(mrb);
+
+  while (c && c != sclass) {
+    mrb_value ki = mrb_iv_get(mrb, mrb_obj_value(c), MRB_IVSYM(__keyword_init__));
+    if (!mrb_nil_p(ki)) return ki;
+    c = c->super;
+  }
+  return mrb_nil_value();
+}
+
+/*
+ *  call-seq:
+ *     StructClass.keyword_init?    -> true or false or nil
+ *
+ *  Returns the value of the `keyword_init` option given to
+ *  `Struct.new`: `true` (only keyword arguments), `false` (only
+ *  positional arguments), or `nil` (either). Subclasses inherit
+ *  the value from the struct class they derive from.
+ *
+ *     Struct.new(:a).keyword_init?                      #=> nil
+ *     Struct.new(:a, keyword_init: true).keyword_init?  #=> true
+ *     Struct.new(:a, keyword_init: false).keyword_init? #=> false
+ */
+static mrb_value
+mrb_struct_s_keyword_init_p(mrb_state *mrb, mrb_value klass)
+{
+  return struct_s_keyword_init(mrb, mrb_class_ptr(klass));
+}
+
+static mrb_value
 struct_members(mrb_state *mrb, mrb_value s)
 {
   if (!mrb_struct_p(s)) {
@@ -211,6 +243,7 @@ make_struct(mrb_state *mrb, mrb_value name, mrb_value members, struct RClass *kl
   mrb_define_class_method_id(mrb, c, MRB_SYM(new), mrb_instance_new, MRB_ARGS_ANY());
   mrb_define_class_method_id(mrb, c, MRB_OPSYM(aref), mrb_instance_new, MRB_ARGS_ANY());
   mrb_define_class_method_id(mrb, c, MRB_SYM(members), mrb_struct_s_members_m, MRB_ARGS_NONE());
+  mrb_define_class_method_id(mrb, c, MRB_SYM_Q(keyword_init), mrb_struct_s_keyword_init_p, MRB_ARGS_NONE());
   /* RSTRUCT(nstr)->basic.c->super = c->c; */
   make_struct_define_accessors(mrb, members, c);
   return nstr;
@@ -280,6 +313,9 @@ mrb_struct_s_def(mrb_state *mrb, mrb_value klass)
 
     if (mrb_hash_key_p(mrb, options, keyword_init_sym)) {
       keyword_init_val = mrb_hash_get(mrb, options, keyword_init_sym);
+      if (!mrb_nil_p(keyword_init_val)) {
+        keyword_init_val = mrb_bool_value(mrb_test(keyword_init_val));
+      }
       argc--; /* Don't treat the options hash as a member name */
     }
   }
@@ -395,7 +431,7 @@ mrb_struct_initialize(mrb_state *mrb, mrb_value self)
   mrb_value klass = mrb_obj_value(mrb_obj_class(mrb, self));
   mrb_value keyword_init = mrb_iv_get(mrb, klass, MRB_IVSYM(__keyword_init__));
 
-  if (mrb_test(keyword_init)) { /* keyword_init: true or other truthy value */
+  if (mrb_test(keyword_init)) { /* keyword_init: true */
     if (argc > 1 || (argc == 1 && !mrb_hash_p(argv[0]))) {
       mrb_argnum_error(mrb, argc, 0, 0);
     }

--- a/mrbgems/mruby-struct/src/struct.c
+++ b/mrbgems/mruby-struct/src/struct.c
@@ -428,8 +428,7 @@ mrb_struct_initialize(mrb_state *mrb, mrb_value self)
 
   mrb_get_args(mrb, "*", &argv, &argc);
 
-  mrb_value klass = mrb_obj_value(mrb_obj_class(mrb, self));
-  mrb_value keyword_init = mrb_iv_get(mrb, klass, MRB_IVSYM(__keyword_init__));
+  mrb_value keyword_init = struct_s_keyword_init(mrb, mrb_obj_class(mrb, self));
 
   if (mrb_test(keyword_init)) { /* keyword_init: true */
     if (argc > 1 || (argc == 1 && !mrb_hash_p(argv[0]))) {

--- a/mrbgems/mruby-struct/src/struct.c
+++ b/mrbgems/mruby-struct/src/struct.c
@@ -240,8 +240,14 @@ make_struct(mrb_state *mrb, mrb_value name, mrb_value members, struct RClass *kl
   mrb_value nstr = mrb_obj_value(c);
   mrb_iv_set(mrb, nstr, MRB_SYM(__members__), members);
 
-  mrb_define_class_method_id(mrb, c, MRB_SYM(new), mrb_instance_new, MRB_ARGS_ANY());
-  mrb_define_class_method_id(mrb, c, MRB_OPSYM(aref), mrb_instance_new, MRB_ARGS_ANY());
+  /* Shadow the class-creating Struct.new inherited through the metaclass
+     with the ordinary Class#new; unlike a C trampoline, its forwarding keeps
+     keyword arguments keywords all the way into #initialize */
+  struct RClass *cls = mrb->class_class;
+  mrb_method_t nm = mrb_method_search_vm(mrb, &cls, MRB_SYM(new));
+  struct RClass *sc = mrb_class_ptr(mrb_singleton_class(mrb, nstr));
+  mrb_define_method_raw(mrb, sc, MRB_SYM(new), nm);
+  mrb_define_method_raw(mrb, sc, MRB_OPSYM(aref), nm);
   mrb_define_class_method_id(mrb, c, MRB_SYM(members), mrb_struct_s_members_m, MRB_ARGS_NONE());
   mrb_define_class_method_id(mrb, c, MRB_SYM_Q(keyword_init), mrb_struct_s_keyword_init_p, MRB_ARGS_NONE());
   /* RSTRUCT(nstr)->basic.c->super = c->c; */

--- a/mrbgems/mruby-struct/test/struct.rb
+++ b/mrbgems/mruby-struct/test/struct.rb
@@ -360,3 +360,13 @@ assert "Struct initialize when :keyword_init is non-boolean value (treat as true
     c.new(1, 2)
   end
 end
+
+assert "Struct.keyword_init?" do
+  assert_true Struct.new(:foo, keyword_init: true).keyword_init?
+  assert_false Struct.new(:foo, keyword_init: false).keyword_init?
+  assert_nil Struct.new(:foo).keyword_init?
+  assert_nil Struct.new(:foo, keyword_init: nil).keyword_init?
+  assert_true Struct.new(:foo, keyword_init: 12).keyword_init?
+  assert_false Struct.respond_to?(:keyword_init?)
+  assert_false Struct.new(:foo).new(1).respond_to?(:keyword_init?)
+end

--- a/mrbgems/mruby-struct/test/struct.rb
+++ b/mrbgems/mruby-struct/test/struct.rb
@@ -309,6 +309,29 @@ assert "Struct initialize with keyword arguments" do
   end
 end
 
+assert "Struct initialize takes a positional hash as a plain value" do
+  c = Struct.new(:foo, :bar)
+
+  o = c.new({foo: 1, bar: 2})
+  assert_equal({foo: 1, bar: 2}, o.foo)
+  assert_nil o.bar
+
+  o2 = c.new({baz: 1})
+  assert_equal({baz: 1}, o2.foo)
+
+  o3 = c.new(1, bar: 2)
+  assert_equal 1, o3.foo
+  assert_equal({bar: 2}, o3.bar)
+
+  h = {foo: 1}
+  o4 = c.new(**h)
+  assert_equal 1, o4.foo
+
+  o5 = c[{foo: 1}]
+  assert_equal({foo: 1}, o5.foo)
+  assert_equal 1, c[foo: 1].foo
+end
+
 assert "Struct.new dispatches an overridden initialize" do
   c = Struct.new(:foo)
   sub = Class.new(c) do

--- a/mrbgems/mruby-struct/test/struct.rb
+++ b/mrbgems/mruby-struct/test/struct.rb
@@ -370,3 +370,24 @@ assert "Struct.keyword_init?" do
   assert_false Struct.respond_to?(:keyword_init?)
   assert_false Struct.new(:foo).new(1).respond_to?(:keyword_init?)
 end
+
+assert "Struct subclass inherits :keyword_init" do
+  c = Struct.new(:foo, :bar, keyword_init: true)
+  sub = Class.new(c)
+
+  assert_true sub.keyword_init?
+
+  o = sub.new(foo: 1, bar: 2)
+  assert_equal 1, o.foo
+  assert_equal 2, o.bar
+
+  assert_raise_with_message(ArgumentError, "wrong number of arguments (given 2, expected 0)") do
+    sub.new(1, 2)
+  end
+
+  fsub = Class.new(Struct.new(:foo, keyword_init: false))
+  assert_false fsub.keyword_init?
+  assert_equal({foo: 1}, fsub.new(foo: 1).foo)
+
+  assert_nil Class.new(Struct.new(:foo)).keyword_init?
+end

--- a/mrbgems/mruby-struct/test/struct.rb
+++ b/mrbgems/mruby-struct/test/struct.rb
@@ -309,6 +309,23 @@ assert "Struct initialize with keyword arguments" do
   end
 end
 
+assert "Struct.new dispatches an overridden initialize" do
+  c = Struct.new(:foo)
+  sub = Class.new(c) do
+    def initialize(x)
+      super(x * 2)
+    end
+  end
+  assert_equal 2, sub.new(1).foo
+
+  kw = Class.new(c) do
+    def initialize(**h)
+      super(**h)
+    end
+  end
+  assert_equal 3, kw.new(foo: 3).foo
+end
+
 assert "Struct initialize when :keyword_init is true" do
   c = Struct.new(:foo, :bar, keyword_init: true)
 


### PR DESCRIPTION
## Summary

This PR adds `Struct.keyword_init?` (CRuby 3.1) and brings the three `keyword_init` modes to the semantics CRuby 3.2 settled on in [Feature #16806](https://bugs.ruby-lang.org/issues/16806): with no option given, only real keyword arguments initialize members by name, and a hash passed positionally is a plain member value. Along the way, a plain subclass now inherits its parent's `keyword_init`, and an overridden `initialize(**opts)` receives its keywords as keywords instead of one positional hash.

## Changes

| commit | change |
|---|---|
| `mruby-struct: add Struct.keyword_init?` | the predicate, plus normalization of truthy values to `true` |
| `mruby-struct: let a subclass inherit keyword_init` | `#initialize` resolves the option through the superclass chain |
| `mruby-struct: dispatch .new through Class#new` | keyword arguments survive into `#initialize` |
| `mruby-struct: keep a positional hash positional in the default mode` | the Feature #16806 semantics |
| `mruby-struct: document keyword_init? and the default mode` | README |

### `Struct.keyword_init?`

Registered per generated class next to `new` and `members`, since CRuby's `Struct` itself does not respond to it. The stored option is looked up through the superclass chain the way `__members__` already is, and any truthy value is normalized to `true` at `Struct.new` time, both as CRuby does.

### Subclass inheritance

`#initialize` read `__keyword_init__` from the instance's own class, so a plain subclass of a `keyword_init: true` struct class silently fell back to the flexible mode. It now resolves the option through the same superclass walk as the predicate.

### `.new` dispatch

The generated classes shadowed the class-creating `Struct.new` with `mrb_instance_new`, which reaches `#initialize` via `mrb_funcall_with_block`, and funcall carries no keyword arguments. The singleton `new` and `[]` now borrow the method of the ordinary `Class#new`, whose forwarding keeps keywords keywords, so a struct class constructs instances exactly like every other class.

### The default mode

`#initialize` keyed the keyword decision on the argument's type alone, so `Post.new(id: 1)` and `Post.new({id: 1})` were indistinguishable. It now reads the caller's keyword flag before `mrb_get_args` folds the kdict into the positional arguments, counting an empty kdict as no keywords since `Class#new` always forwards one.

## Behaviour

All rows measured against CRuby 4.0.6; a 21-call side-by-side run of the two interpreters now prints identical output.

```ruby
Post = Struct.new(:id, :name)
Post.new(id: 1)     # id=1              (unchanged)
Post.new({id: 1})   # id={id: 1}        (was: id=1)
Post.new({foo: 1})  # id={foo: 1}       (was: ArgumentError)
Post.new(1, id: 2)  # id=1, name={id: 2} (unchanged)

Post.keyword_init?                                  # => nil   (was: NoMethodError)
Struct.new(:a, keyword_init: 12).keyword_init?      # => true

A = Struct.new(:a, keyword_init: true)
Class.new(A).keyword_init?  # => true          (was: NoMethodError)
Class.new(A).new(1)         # ArgumentError    (was: a=1)

B = Class.new(Post) { def initialize(**h) = super(**h) }
B.new(id: 1)  # id=1  (was: ArgumentError, keywords arrived as one positional hash)
```

## Speed

Constructing an instance now runs `Class#new`'s bytecode instead of a C trampoline, which costs one VM frame plus the rest array and kdict that frame builds. 1,000,000 constructions of a two-member struct, `bintest` build, median of 3 runs:

| case | master | PR | delta per call |
|---|---|---|---|
| `c.new(1, 2)` | 175 ms | 219 ms | +44 ns |
| `c.new(a: 1, b: 2)`, default mode | 381 ms | 435 ms | +54 ns |
| `k.new(a: 1, b: 2)`, `keyword_init: true` | 372 ms | 418 ms | +46 ns |

## Size

`.text` of `libmruby.a` (`size -t`), `build_config/ci/gcc-clang.rb`, clang, master `07b315bbc` and this branch built in the same tree into an emptied build directory:

| build | master | PR | delta |
|---|---|---|---|
| full-debug | 2,464,998 | 2,465,764 | +766 |
| bintest | 1,565,053 | 1,565,407 | +354 |
| cxx_abi | 1,555,143 | 1,555,481 | +338 |
| byte-string | 1,509,716 | 1,510,102 | +386 |
| ascii-ctype | 1,533,581 | 1,533,935 | +354 |

## Testing

- `rake -m test`, default host config: 2,568 assertions, 0 failures, 0 crashes.
- `rake -m test` with `build_config/ci/gcc-clang.rb`, all 5 builds including full-debug's `MRB_GC_STRESS`: green (2,726 / 2,807 / 2,807 / 2,798 / 2,807 assertions, 0 failures, 0 crashes, plus 147 binary tests).
- Every commit verified green individually with `git rebase master --exec 'rake -m test'`.
- The Behaviour section's calls run side by side against CRuby 4.0.6 with identical output.

## Environment

<details>

- Linux 7.0.0-30-generic x86_64
- Homebrew clang version 23.1.0
- CRuby for comparison: ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux]
- base: `07b315bbc`
- compile line (bintest, from `struct.o.flags`):

```
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -ffile-prefix-map="<worktree>=." -ffile-prefix-map="<build>=./build" -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_STRUCT_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `keyword_init?` to report whether a struct uses keyword, positional, or flexible initialization.
  - Struct subclasses inherit the configured initialization mode.
  - Standard and bracket-based construction now consistently support positional values and keyword arguments.

- **Bug Fixes**
  - Corrected handling of hashes passed positionally versus as keyword arguments.
  - Improved behavior for all supported initialization modes, including flexible mode.

- **Documentation**
  - Expanded examples and documented `keyword_init?`, inheritance, and initialization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->