### PR TITLE
mruby-regexp: slice `MatchData#[]` with a start and length or a Range

### DIFF
--- a/mrbgems/mruby-regexp/README.md
+++ b/mrbgems/mruby-regexp/README.md
@@ -119,6 +119,8 @@ md[0]                             # => "user@host" (full match)
 md[1]                             # => "user"
 md[2]                             # => "host"
 md[:name]                         # named capture access
+md[0, 2]                          # => ["user@host", "user"]
+md[0..1]                          # => same as md[0, 2]
 md.captures                       # => ["user", "host"]
 md.values_at(1, 2)                # => ["user", "host"]
 md.to_a                           # => ["user@host", "user", "host"]

--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -1073,7 +1073,7 @@ matchdata_name_to_group(mrb_state *mrb, mrb_match_data *md, mrb_value arg)
 }
 
 /*
- * MatchData#[](n)
+ * MatchData#[](n) / #[](name) / #[](start, length) / #[](range)
  */
 
 /* Read the group at the absolute index `idx`, or nil when it names no group
@@ -1116,12 +1116,48 @@ md_aref(mrb_state *mrb, mrb_value self, mrb_value arg)
   return md_nth(mrb, md, idx);
 }
 
+/* The (start, length) and Range forms slice the groups the way Array#[]
+   slices to_a. They are told apart from the group forms the way CRuby's
+   match_aref() tells them apart: a second argument, unless it is nil, forces
+   both arguments through integer conversion, so a name or a Range in the
+   first position raises TypeError there; without one, only a Range slices,
+   and everything that is not a name converts to a single index. */
 static mrb_value
 matchdata_aref(mrb_state *mrb, mrb_value self)
 {
-  mrb_value arg;
-  mrb_get_args(mrb, "o", &arg);
-  return md_aref(mrb, self, arg);
+  mrb_value arg, len_v = mrb_nil_value();
+  mrb_int argc = mrb_get_args(mrb, "o|o", &arg, &len_v);
+
+  if ((argc < 2 || mrb_nil_p(len_v)) && !mrb_range_p(arg)) {
+    return md_aref(mrb, self, arg);
+  }
+
+  mrb_match_data *md = DATA_GET_PTR(mrb, self, &matchdata_type, mrb_match_data);
+  if (!md) return mrb_nil_value();
+
+  mrb_int beg, len;
+  if (argc == 2 && !mrb_nil_p(len_v)) {
+    beg = mrb_as_int(mrb, arg);
+    len = mrb_as_int(mrb, len_v);
+    if (len < 0) return mrb_nil_value();
+    if (beg < 0) {
+      beg += md->num_captures;
+      if (beg < 0) return mrb_nil_value();
+    }
+    else if (beg > md->num_captures) {
+      return mrb_nil_value();
+    }
+    if (len > md->num_captures - beg) len = md->num_captures - beg;
+  }
+  else if (mrb_range_beg_len(mrb, arg, &beg, &len, md->num_captures, TRUE) != MRB_RANGE_OK) {
+    return mrb_nil_value();
+  }
+
+  mrb_value ary = mrb_ary_new_capa(mrb, len);
+  for (mrb_int i = 0; i < len; i++) {
+    mrb_ary_push(mrb, ary, md_nth(mrb, md, beg + i));
+  }
+  return ary;
 }
 
 /* Build array of capture strings from group `from` to num_captures-1 */
@@ -3461,7 +3497,7 @@ mrb_mruby_regexp_gem_init(mrb_state *mrb)
   mrb_undef_class_method(mrb, md, "new");
   mrb_undef_class_method(mrb, md, "allocate");
 
-  mrb_define_method(mrb, md, "[]", matchdata_aref, MRB_ARGS_REQ(1));
+  mrb_define_method(mrb, md, "[]", matchdata_aref, MRB_ARGS_ARG(1, 1));
   mrb_define_method(mrb, md, "captures", matchdata_captures, MRB_ARGS_NONE());
   mrb_define_method(mrb, md, "to_a", matchdata_to_a, MRB_ARGS_NONE());
   mrb_define_method(mrb, md, "values_at", matchdata_values_at, MRB_ARGS_ANY());

--- a/mrbgems/mruby-regexp/test/match_data.rb
+++ b/mrbgems/mruby-regexp/test/match_data.rb
@@ -200,6 +200,17 @@ assert("Regexp.last_match") do
   assert_equal "123", Regexp.last_match(0)
 end
 
+assert("Regexp.last_match reads one group, never a slice") do
+  # the argument goes to the single-index read MatchData#[] keeps behind its
+  # slice forms, so a Range raises TypeError here where $~[0..1] answers an
+  # array, and there is no (start, length) form at all
+  "ab" =~ /(a)(b)/
+  assert_equal ["ab", "a"], $~[0..1]
+  assert_equal ["ab", "a"], $~[0, 2]
+  assert_raise(TypeError) { Regexp.last_match(0..1) }
+  assert_raise(ArgumentError) { Regexp.last_match(0, 2) }
+end
+
 assert("Regexp.last_match - an explicit nil is not an omitted argument") do
   "lm" =~ /lm/
   assert_equal "lm", Regexp.last_match[0]
@@ -246,6 +257,54 @@ assert("MatchData#[] - group name longer than a uint16 length") do
   md = /(?<abc>x)/.match("x")
   assert_raise(IndexError) { md["abc" + "A" * 65536] }
   assert_equal "x", md[:abc]
+end
+
+assert("MatchData#[] - start and length") do
+  md = /(a)(b)/.match("ab")
+  assert_equal ["ab", "a"], md[0, 2]
+  assert_equal [], md[0, 0]
+  # the slice reads like Array#[] on to_a: truncated at the last group, empty
+  # at the index one past it, nil beyond that or for a negative length
+  assert_equal ["ab", "a", "b"], md[0, 5]
+  assert_equal [], md[3, 1]
+  assert_nil md[4, 1]
+  assert_nil md[0, -1]
+  # a negative start counts back from the last group and, unlike a negative
+  # single index, does reach the whole match
+  assert_equal ["ab", "a"], md[-3, 2]
+  assert_nil md[-4, 2]
+  # a group that did not take part in the match reads nil in place
+  assert_equal ["a", nil, "a"], /(b)?(a)/.match("a")[0, 3]
+  # an explicit nil length selects the single-index form
+  assert_equal "ab", md[0, nil]
+end
+
+assert("MatchData#[] - Range") do
+  md = /(a)(b)/.match("ab")
+  assert_equal ["ab", "a"], md[0..1]
+  assert_equal ["ab", "a"], md[0...2]
+  assert_equal ["ab", "a", "b"], md[0..-1]
+  assert_equal ["a", "b"], md[1..]
+  assert_equal ["ab", "a"], md[..1]
+  assert_equal ["ab", "a", "b"], md[0..10]
+  # bounds read like Array#[]: starting at the index one past the last group
+  # is empty, further out is nil, and so is a start before -num_captures;
+  # a backwards range is empty
+  assert_equal [], md[3..4]
+  assert_nil md[4..5]
+  assert_nil md[-5..-4]
+  assert_equal [], md[2..1]
+  assert_equal ["a", nil, "a"], /(b)?(a)/.match("a")[0..2]
+end
+
+assert("MatchData#[] - a length argument forces integer conversion") do
+  md = /(?<x>a)(b)/.match("ab")
+  # with a length present, the first argument is an index, never a name or a
+  # Range, and the length is an integer, never a name
+  assert_raise(TypeError) { md["x", 2] }
+  assert_raise(TypeError) { md[:x, 2] }
+  assert_raise(TypeError) { md[0..1, 1] }
+  assert_raise(TypeError) { md[0, "2"] }
 end
 
 assert("MatchData#values_at") do

--- a/mrbgems/mruby-regexp/test/string_index.rb
+++ b/mrbgems/mruby-regexp/test/string_index.rb
@@ -33,6 +33,13 @@ assert("String#[] with regexp and capture") do
   # a failed match answers nil without ever looking at the capture argument
   assert_nil "hello"[/(z)/, 1]
   assert_nil "hello"[/(?<x>z)/, :zz]
+
+  # the capture argument selects one group, never a slice: a Range raises
+  # TypeError here where MatchData#[] would build an array, as in CRuby
+  assert_raise(TypeError) { "hello"[/(l+)(o)/, 0..1] }
+  assert_raise(TypeError) { "hello".slice(/(l+)(o)/, 0..1) }
+  assert_raise(TypeError) { s = "hello"; s.slice!(/(l+)(o)/, 0..1) }
+  assert_raise(TypeError) { s = "hello"; s[/(l+)(o)/, 0..1] = "X" }
 end
 
 assert("String#[] with regexp sets the match globals") do


### PR DESCRIPTION
## Summary

- `MatchData#[]` knew only the single-index and name forms: `md[0, 2]` raised `ArgumentError` and `md[0..1]` raised `TypeError` where CRuby answers `["ab", "a"]` for both
- Both forms now slice the groups the way `Array#[]` reads `to_a`: truncated at the last group, `nil` outside the array bounds, a group that took no part in the match reading `nil` in place
- The forms are told apart the way CRuby's `match_aref()` tells them apart, so a name or a Range in front of a length raises the same `TypeError`, and an explicit `nil` length selects the single-index form

## Changes

| File | What |
|---|---|
| `mrbgems/mruby-regexp/src/regexp.c` | the two slice forms in `matchdata_aref()`, registered as `MRB_ARGS_ARG(1, 1)` |
| `mrbgems/mruby-regexp/test/match_data.rb` | `MatchData#[] - start and length`, `MatchData#[] - Range`, `MatchData#[] - a length argument forces integer conversion` |
| `mrbgems/mruby-regexp/README.md` | `md[0, 2]` and `md[0..1]` in the MatchData list |

### Telling a slice from a group

CRuby's `match_aref()` decides by the second argument first: present and not nil, both arguments go through integer conversion, so `md[:x, 2]` and `md[0..1, 1]` raise `TypeError` rather than reading the named group or slicing. Without one, a Range slices and everything that is not a String or Symbol converts to a single index. `matchdata_aref()` now decides in the same order and hands every single-index read to `md_aref()`, untouched.

That helper is shared with `String#[]` reading a capture selector and with `Regexp.last_match(n)`, so both keep refusing a Range with `TypeError`, as CRuby's do.

### The slice itself

Both forms read like `Array#[]` over `to_a`. The Range form goes through the `mrb_range_beg_len()` call `#values_at` already makes, but with `trunc` set, which is the whole of the Array behaviour: a backwards range is empty, a start one past the last group is empty, further out is `nil`, and so is a start before `-size`. The (start, length) form applies the same bounds by hand: a negative length is `nil`, and a negative start counts back from the last group and, unlike a negative single index, does reach the whole match.

## Behaviour

Rows measured on the base binary, the branch binary and CRuby 4.0.6 (`03b6d3f889`), with `m = /(a)(b)/.match("ab")` and `md` from `/(?<x>a)(b)/`:

| Expression | before | after | CRuby |
|---|---|---|---|
| `m[0, 2]` | `ArgumentError` | `["ab", "a"]` | `["ab", "a"]` |
| `m[0..1]` | `TypeError` | `["ab", "a"]` | `["ab", "a"]` |
| `m[0, 5]` | `ArgumentError` | `["ab", "a", "b"]` | `["ab", "a", "b"]` |
| `m[0, 0]` | `ArgumentError` | `[]` | `[]` |
| `m[3, 1]` | `ArgumentError` | `[]` | `[]` |
| `m[4, 1]` | `ArgumentError` | `nil` | `nil` |
| `m[0, -1]` | `ArgumentError` | `nil` | `nil` |
| `m[-3, 2]` | `ArgumentError` | `["ab", "a"]` | `["ab", "a"]` |
| `m[-4, 2]` | `ArgumentError` | `nil` | `nil` |
| `m[0..-1]` | `TypeError` | `["ab", "a", "b"]` | `["ab", "a", "b"]` |
| `m[1..]` | `TypeError` | `["a", "b"]` | `["a", "b"]` |
| `m[..1]` | `TypeError` | `["ab", "a"]` | `["ab", "a"]` |
| `m[2..1]` | `TypeError` | `[]` | `[]` |
| `m[4..5]` | `TypeError` | `nil` | `nil` |
| `m[-5..-4]` | `TypeError` | `nil` | `nil` |
| `/(b)?(a)/.match("a")[0..2]` | `TypeError` | `["a", nil, "a"]` | `["a", nil, "a"]` |
| `md[:x, 2]` | `ArgumentError` | `TypeError` | `TypeError` |
| `md["x", 2]` | `ArgumentError` | `TypeError` | `TypeError` |
| `m[0..1, 1]` | `ArgumentError` | `TypeError` | `TypeError` |
| `m[0, "2"]` | `ArgumentError` | `TypeError` | `TypeError` |
| `m[0, nil]` | `ArgumentError` | `"ab"` | `"ab"` |

The single-argument rows all stand where they were: `m[0]`, `m[-1]`, `m[:x]`, the `IndexError` for an undefined name. The `TypeError` texts in the two-argument rows are `mrb_as_int()`'s wording (`Range cannot be converted to Integer` against CRuby's `no implicit conversion of Range into Integer`), the same the single-index form already answered for `m[nil]`.

## Size

`.text` of `bin/mruby` for the five `build_config/ci/gcc-clang.rb` builds, `size -A`, base and this branch built at the same path from empty build directories:

| Build | master | this PR | delta |
|---|---|---|---|
| `bintest` | 1,110,774 | 1,111,238 | +464 |
| `ascii-ctype` | 1,105,894 | 1,106,358 | +464 |
| `byte-string` | 1,084,854 | 1,085,318 | +464 |
| `cxx_abi` | 1,097,933 | 1,098,381 | +448 |
| `full-debug` (-O0) | 1,913,974 | 1,914,518 | +544 |

The growth is `matchdata_aref()` itself: `nm -S` puts it at 524 bytes in `bintest`, where it was a three-line wrapper around the shared `md_aref()`, which stands unchanged at 230.

## Testing

- `rake -m test` green with `build_config/ci/gcc-clang.rb`, all five builds (`bintest`, `cxx_abi`, `byte-string`, `ascii-ctype`, `full-debug`): 0 KO, 0 crashes, `bintest`'s binary tests included
- `rake -m test` green with the default config: 2567 tests, 2504 OK, 0 KO, 0 crashes, 63 skipped, none of them new
- every row of the table above run on the base binary (`07b315bbc`, `bintest`), the branch binary and CRuby 4.0.6

## Environment

<details>

| | |
|---|---|
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-30-generic x86_64 |
| CPU | AMD Ryzen 9 5950X (16C/32T) |
| C compiler | Homebrew clang 23.1.0 |
| binutils | GNU ld 2.47.20260726 |
| CRuby | 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM |
| base | `07b315bbc` |

Compile lines for `mrbgems/mruby-regexp/src/regexp.c` as run, with `-MMD -c`, `-I`, `-o`, `-ffile-prefix-map` and `-DMRBGEM_MRUBY_REGEXP_VERSION` dropped:

```console
# bintest
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -DMRB_GC_FIXED_ARENA -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK

# ascii-ctype
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -DMRB_USE_ASCII_CTYPE -DMRB_REGEXP_PARSE_DEPTH_LIMIT=512 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# byte-string
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# cxx_abi
clang -g -O3 -Wall -Wundef -Wwrite-strings -Wzero-length-array -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# full-debug
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced `MatchData#[]` to support start-and-length arguments and ranges for slicing capture groups, consistent with array behavior.
  * Supports negative and oversized bounds, omitted captures, and explicit `nil` lengths.

* **Bug Fixes**
  * Validates length-based slicing arguments and rejects invalid types.
  * Preserves single-capture behavior for regular-expression string indexing; range arguments are rejected.

* **Documentation**
  * Added examples demonstrating range and multi-element capture slicing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->