### PR TITLE
mruby-process, mruby-task: one definition of NSEC_PER_SEC

### DIFF
--- a/mrbgems/mruby-process/include/process_hal.h
+++ b/mrbgems/mruby-process/include/process_hal.h
@@ -125,6 +125,13 @@ typedef struct mrb_process_clock_time {
   int64_t nsec;
 } mrb_process_clock_time;
 
+/* Nanoseconds in one second, the scale `nsec` above is a count in.  Darwin's
+   <mach/clock_types.h> spells the same name (as 1000000000ull), so a
+   definition already in scope is left standing. */
+#ifndef NSEC_PER_SEC
+#define NSEC_PER_SEC 1000000000LL
+#endif
+
 /*
  * HAL Interface Functions
  */

--- a/mrbgems/mruby-process/ports/win/process_hal.c
+++ b/mrbgems/mruby-process/ports/win/process_hal.c
@@ -260,8 +260,6 @@ mrb_hal_process_status_decode(mrb_state *mrb, mrb_int pid, mrb_int raw_status,
 #define FILETIME_EPOCH_DELTA   116444736000000000LL
 #define NSEC_PER_FILETIME_TICK 100
 
-#define NSEC_PER_SEC           1000000000LL
-
 static uint64_t
 filetime_to_u64(const FILETIME *ft)
 {

--- a/mrbgems/mruby-process/src/process.c
+++ b/mrbgems/mruby-process/src/process.c
@@ -318,8 +318,6 @@ process_waitpid2(mrb_state *mrb, mrb_value self)
  * reports the same two numbers and is asked nothing about any of that.
  */
 
-#define NSEC_PER_SEC 1000000000
-
 /*
  * Put `sec` seconds and `frac` `per_sec`-ths of one together, and say
  * whether they fit an int64_t at all.

--- a/mrbgems/mruby-process/test/process.c
+++ b/mrbgems/mruby-process/test/process.c
@@ -28,9 +28,6 @@ test_status_build(mrb_state *mrb, mrb_value self)
   return mrb_obj_new(mrb, klass, 2, argv);
 }
 
-/* Nanoseconds in a second, which is the range a port promises `nsec` in. */
-#define TEST_NSEC_PER_SEC 1000000000
-
 /* Read a decimal into an int64_t, refusing anything the type cannot hold. */
 static int64_t
 test_clock_int64(mrb_state *mrb, const char *s, const char *what)
@@ -71,7 +68,7 @@ test_clock_convert(mrb_state *mrb, mrb_value self)
   mrb_process_clock_time t;
 
   mrb_get_args(mrb, "zio|b", &sec, &nsec, &unit, &resolution);
-  if (nsec < 0 || nsec >= TEST_NSEC_PER_SEC) {
+  if (nsec < 0 || nsec >= NSEC_PER_SEC) {
     mrb_raisef(mrb, E_ARGUMENT_ERROR, "nsec outside one second: %i", nsec);
   }
   t.sec = test_clock_int64(mrb, sec, "sec");

--- a/mrbgems/mruby-task/ports/posix/task_hal.c
+++ b/mrbgems/mruby-task/ports/posix/task_hal.c
@@ -23,9 +23,13 @@
 #include <unistd.h>
 #include <stdint.h>
 
-/* Time conversion constants */
+/* Time conversion constants.  NSEC_PER_SEC is spelled exactly as
+   mruby-process's process_hal.h spells it, so an amalgamated build carrying
+   both gems sees identical definitions rather than a redefinition. */
 #define NSEC_PER_MSEC 1000000ULL
-#define NSEC_PER_SEC  1000000000ULL
+#ifndef NSEC_PER_SEC
+#define NSEC_PER_SEC 1000000000LL
+#endif
 #define USEC_PER_MSEC 1000ULL
 
 #ifndef __EMSCRIPTEN__


### PR DESCRIPTION
## Summary

`NSEC_PER_SEC` was defined in three places across two gems, spelled three ways: `1000000000` in mruby-process's `src/process.c`, `1000000000LL` in its win port and `1000000000ULL` in mruby-task's posix port, with the mruby-process test rig keeping a `TEST_NSEC_PER_SEC` of its own beside them. Separate translation units keep the copies apart; an amalgamated build does not, and meets them as macro redefinition warnings. This defines the constant once, in `process_hal.h`, and spells the one definition another gem keeps identically.

## Changes

| File                                              | What                                                          |
| ------------------------------------------------- | ------------------------------------------------------------- |
| `mrbgems/mruby-process/include/process_hal.h`     | defines `NSEC_PER_SEC`, beside the `nsec` range it is part of |
| `mrbgems/mruby-process/src/process.c`             | drops its copy                                                |
| `mrbgems/mruby-process/ports/win/process_hal.c`   | drops its copy                                                |
| `mrbgems/mruby-process/test/process.c`            | reads the header's, dropping `TEST_NSEC_PER_SEC`              |
| `mrbgems/mruby-task/ports/posix/task_hal.c`       | keeps its own definition, spelled as the header spells it     |

### Where the copies meet

An amalgamated `mruby.c` concatenates a gem's port and its common sources into one translation unit, and gems follow one another in that same unit. C allows a macro to be defined twice only when the token sequences are identical (C11 6.10.3p2), so two copies with different suffixes meeting there are a `-Wmacro-redefined` warning. Two pairs meet today:

- the win port's `1000000000LL` and then `src/process.c`'s `1000000000`, in any amalgamated Windows build of mruby-process;
- `src/process.c`'s `1000000000` and then the mruby-task posix port's `1000000000ULL`, in an amalgamated build carrying both gems.

The second pair, on an amalgam of the `default` gembox plus mruby-task:

```console
$ clang -std=gnu99 -O1 -Wall -c build/host/amalgam/mruby.c -Ibuild/host/amalgam
mruby.c:113963:9: warning: 'NSEC_PER_SEC' macro redefined [-Wmacro-redefined]
 113963 | #define NSEC_PER_SEC  1000000000ULL
mruby.c:99092:9: note: previous definition is here
  99092 | #define NSEC_PER_SEC 1000000000
```

With this change the same compile says nothing about `NSEC_PER_SEC`.

### The definition sits with the promise it is part of

`process_hal.h` is where `mrb_process_clock_time` promises `nsec` in [0, 999999999], and every mruby-process file that kept a copy already includes it. The definition is guarded: Darwin spells the same name in `<mach/clock_types.h>` (as `1000000000ull`), and a definition already in scope is left standing. mruby-task's port belongs to another gem and includes no mruby-process header, so it keeps a definition of its own, token-identical and guarded the same way, which is what makes the two lawful in one translation unit.

### `LL` rather than `ULL`

The win port adds the constant to a negative `nsec` when normalizing a FILETIME split downwards, which unsigned arithmetic would only get right by wrapping. Every mruby-task use combines it with a `uint64_t` operand, which converts either suffix the same way, so the signed spelling is the one that suits both gems.

## Behaviour

No Ruby-visible change: the constant's value is the same everywhere, and `.text` is byte-identical across every build measured below.

## Size

`.text` of `bin/mruby` across the five `build_config/ci/gcc-clang.rb` builds, base `07b315bbc`:

| build              | master    | this PR   | delta |
| ------------------ | --------- | --------- | ----- |
| bintest            | 1,110,774 | 1,110,774 | ±0    |
| ascii-ctype        | 1,105,894 | 1,105,894 | ±0    |
| byte-string        | 1,084,854 | 1,084,854 | ±0    |
| cxx_abi            | 1,097,933 | 1,097,933 | ±0    |
| full-debug (`-O0`) | 1,913,974 | 1,913,974 | ±0    |

## Testing

| what                                                    | result                                 |
| ------------------------------------------------------- | -------------------------------------- |
| `rake -m test MRUBY_CONFIG=default`                     | 2564 total, 0 KO / 0 Crash / 0 Warning |
| `rake -m test`, `default` gembox plus mruby-task        | 2639 total, 0 KO / 0 Crash / 0 Warning |
| `rake -m MRUBY_CONFIG=cross-mingw`                      | the win port cross-compiles clean      |
| `rake -m MRUBY_CONFIG=ci/gcc-clang`                     | all five builds link                   |
| `rake amalgam` for the task-plus-process config, master | 1 `-Wmacro-redefined` warning          |
| the same, this PR                                       | 0                                      |

The amalgamated translation unit in the last two rows compiles the mruby-task posix port and mruby-process's posix port and common sources together, which no separate-TU build can be made to do.

## Environment

<details>

|                    |                                                                   |
| ------------------ | ----------------------------------------------------------------- |
| OS                 | Ubuntu 24.04.4 LTS                                                |
| Kernel             | Linux 7.0.0-30-generic x86_64                                     |
| CPU                | AMD Ryzen 9 5950X 16-Core Processor, 32 threads                   |
| C compiler         | Homebrew clang version 23.1.0                                     |
| C compiler (cross) | x86_64-w64-mingw32-gcc-posix (GCC) 13-posix                       |
| binutils           | GNU ld (GNU Binutils) 2.47.20260726                               |
| CRuby              | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |
| rake               | 13.3.1                                                            |

The compile of `src/string.c` in each of the five builds, as the build recorded it, with `-MMD -c`, the `-I` paths, the `-o` and the two `-ffile-prefix-map` taken off:

```console
# bintest
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -DMRB_GC_FIXED_ARENA -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK

# ascii-ctype
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -DMRB_USE_ASCII_CTYPE -DMRB_REGEXP_PARSE_DEPTH_LIMIT=512 -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# byte-string
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# cxx_abi
clang -g -O3 -Wall -Wundef -Wwrite-strings -Wzero-length-array -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# full-debug
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency and portability of nanosecond-based time conversions across supported platforms.
  * Prevented duplicate constant definitions during combined builds.
  * Kept process clock conversion tests aligned with the shared timing constant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->