### PR TITLE
build: compile by the names the sources have from the tree

### DIFF
--- a/doc/guides/compile.md
+++ b/doc/guides/compile.md
@@ -473,21 +473,36 @@ When debugging mode is enabled
 
 ### File prefix map
 
-The compiler is given absolute paths, so where the mruby tree and the build
-directory sit would reach what it compiles: `__FILE__`, which is what
-`mrb_assert` reports through `assert`, and the debug information that the `-g`
-of the `gcc` and `clang` toolchains writes. Every build keeps them out of it on
-its own, compiling with `-ffile-prefix-map` for the two directories its sources
-come from: the mruby tree, written as `.`, and the build directory, written as
-`./build`. The build directory is written as the place it takes when nothing
-moves it, so that a build with `MRUBY_BUILD_DIR` pointing outside the tree
-compiles what a build inside the tree compiles.
+Where the mruby tree and the build directory sit would reach what a build
+compiles: `__FILE__`, which is what `mrb_assert` reports through `assert`, the
+debug information that the `-g` of the `gcc` and `clang` toolchains writes, and
+the file names `mrbc` records for the backtrace of an mruby script under
+`enable_debug`. Every build keeps them out of it on its own.
+
+It compiles the sources by the names they have from the tree, `src/vm.c` and
+not the path of the checkout, and names the two directories they come from for
+whatever a name cannot carry: the tree, written as `.`, and the build
+directory, written as `build`. The build directory is written as the place it
+takes when nothing moves it, so that a build with `MRUBY_BUILD_DIR` pointing
+anywhere else compiles what a build inside the tree compiles. The names are
+written with `-ffile-prefix-map`, except for the directory a compiler records
+as the one it compiled in, which `clang` is told by `-ffile-compilation-dir`.
+
+Two builds of the same commit in two checkouts therefore compile the same
+thing, and a compiler cache keyed on the command line, `ccache` or `sccache`,
+answers for one from what it learned of the other with nothing configured for
+it on the machine.
 
 To write the two names yourself:
 
 ```ruby
 conf.enable_file_prefix_map source: "mruby", build: "mruby/build"
 ```
+
+A name other than `.` for the tree is one no name from the tree carries, so
+such a build compiles with the paths as they are and writes the names through
+the map alone. A cache has nothing to carry from one checkout to another
+there, and a debugger looks for the sources under the name that was asked for.
 
 Any other directory is mapped one at a time, which is how the path of a
 toolchain or of a gem outside the tree is written:
@@ -503,23 +518,24 @@ conf.disable_file_prefix_map
 ```
 
 which is what a build to be debugged from outside the mruby tree wants: a
-debugger looks for the sources of a mapped build under the names they were
-mapped to, and finds them only from the directory those names are relative to.
-Either tell the debugger where they are (`set substitute-path . /path/to/mruby`
-in gdb) or take the map off this way.
+debugger looks for the sources under the names the build wrote, and finds them
+only from the tree they are named against. Either tell the debugger where they
+are (`set substitute-path . /path/to/mruby` in gdb), run it from the tree, or
+take the names off this way.
 
 Note that
 
-- A compiler that does not take `-ffile-prefix-map`, which `cl` and every
-  compiler older than GCC 8 or clang 10 are, is compiled with as it always was.
-  The build asks the compiler before it maps anything, and leaves the paths
-  alone where the answer is no.
-- The flags a build exports in `libmruby.flags.mak` carry no map: the
-  directories a map names are the ones of the machine that built the package,
-  and nothing compiled against the package from there sits under them.
-- The file names `mrbc` records under `enable_debug`, which the backtrace of an
-  mruby script reports, are written by `mrbc` and not by the compiler, so no
-  map reaches them.
+- A compiler that takes neither option, which `cl` and every compiler older
+  than GCC 8 or clang 10 are, still compiles by the names of the tree, and the
+  directory it records as the one it compiled in stays as it is. The build asks
+  the compiler before it writes either option and leaves it out where the
+  answer is no.
+- The flags a build exports in `libmruby.flags.mak` name every directory in
+  full: they are read where the package was installed, which is not where it
+  was built, and whoever compiles against it rewrites them.
+- A directory the build cannot name from the tree, a gem or a build directory
+  somewhere else, reaches the compiler as this machine spells it, and is
+  written through the map.
 
 ## Cross-Compilation
 

--- a/lib/mruby/build.rb
+++ b/lib/mruby/build.rb
@@ -122,7 +122,18 @@ module MRuby
           @exts = Exts.new('.o', '', '.a', '.pi')
         end
 
-        build_dir = build_dir || ENV['MRUBY_BUILD_DIR'] || "#{MRUBY_ROOT}/build"
+        # The directory is named against the one the build was started from,
+        # by the config or by `MRUBY_BUILD_DIR`, and is expanded here so that
+        # every path built from it is absolute whatever directory a later step
+        # runs in. The spelling a name was given, a trailing slash or a `..`
+        # among it, does not reach the paths the build compiles with.
+        #
+        # `MRUBY_BUILD_DIR` set to nothing names no directory, and is read as
+        # the unset it was meant to be: left as it is, the empty name would
+        # put the whole build under `/`.
+        env_build_dir = ENV['MRUBY_BUILD_DIR']
+        env_build_dir = nil if env_build_dir.nil? || env_build_dir.empty?
+        build_dir = File.expand_path(build_dir || env_build_dir || "#{MRUBY_ROOT}/build")
 
         @file_separator = '/'
         # The directory every target of this config builds under. `@build_dir`

--- a/lib/mruby/build.rb
+++ b/lib/mruby/build.rb
@@ -178,6 +178,7 @@ module MRuby
         @compile_commands_default = false
         @mrbcfile_external = false
         @file_prefix_map = nil
+        @file_prefix_map_source = nil
         @internal = internal
         @toolchains = []
         @port_names = nil
@@ -238,10 +239,15 @@ module MRuby
     # write the two names itself, and by calling it says that the build has
     # no say: the names a config writes are the only ones its output carries.
     #
-    # The build directory is written as `build` under the name of the tree,
-    # the place it takes when nothing moves it, so that a build with
-    # `MRUBY_BUILD_DIR` pointing outside the tree compiles what a build inside
-    # the tree compiles.
+    # The build directory is written as `build` beside the sources, the place
+    # it takes when nothing moves it, so that a build with `MRUBY_BUILD_DIR`
+    # pointing anywhere else compiles what a build inside the tree compiles.
+    #
+    # The tree is written as `.`, and under that name the build compiles the
+    # sources by the names they have from the tree, so that what it compiles
+    # is the same wherever the tree sits. A config that writes another name
+    # for the tree is asking for that name in the output, which no relative
+    # name carries, and its build compiles with the paths as they are.
     #
     # The two maps overlap where the build directory is inside the tree, and
     # both `gcc` and `clang` answer a path both cover with the longer prefix,
@@ -252,10 +258,11 @@ module MRuby
     # This says nothing of the paths `mrbc` writes: the file names it records
     # for a backtrace under `enable_debug` are the ones the build passes it,
     # and no compiler flag reaches them.
-    def enable_file_prefix_map(source: ".", build: "#{source}/build")
+    def enable_file_prefix_map(source: ".", build: source == "." ? "build" : "#{source}/build")
       file_prefix_map(MRUBY_ROOT, source)
       file_prefix_map(@build_root, build)
       @file_prefix_map = true
+      @file_prefix_map_source = source
     end
 
     # Compile with the paths of this build as they are, which a build that
@@ -264,6 +271,33 @@ module MRuby
     # them only from the directory they were mapped against.
     def disable_file_prefix_map
       @file_prefix_map = false
+      @file_prefix_map_source = nil
+    end
+
+    # Whether the compilers are handed the names the sources have from the
+    # tree, instead of the paths they have on this machine.
+    #
+    # This is the same question as whether the tree is written as `.`: a
+    # relative name is what a path under the tree looks like once the tree
+    # itself is dropped from it, so the build compiles under that name what
+    # the map would otherwise write. A build that keeps its paths, or that
+    # writes another name for the tree, has no such name to compile with.
+    def compile_relative?
+      @file_prefix_map_source == "."
+    end
+
+    # The name a compile is given for +path+: the one it has from the tree,
+    # where it sits under the tree and the build compiles by such names, and
+    # the path as it is anywhere else.
+    #
+    # A path this leaves alone is one no build of this tree can name the same
+    # way twice, an external gem or a build directory somewhere else, and it
+    # reaches the compiler as the machine spells it.
+    def compile_path(path)
+      return path unless compile_relative?
+      return "." if path == MRUBY_ROOT
+      prefix = "#{MRUBY_ROOT}/"
+      path.start_with?(prefix) ? path[prefix.length..-1] : path
     end
 
     # Set target port names for this build.

--- a/lib/mruby/build.rb
+++ b/lib/mruby/build.rb
@@ -255,9 +255,9 @@ module MRuby
     # either map gives; a caller that names the two apart is asking for the
     # longer one to win.
     #
-    # This says nothing of the paths `mrbc` writes: the file names it records
-    # for a backtrace under `enable_debug` are the ones the build passes it,
-    # and no compiler flag reaches them.
+    # No compiler flag reaches the file names `mrbc` records for a backtrace
+    # under `enable_debug`: those are the names the build passes it, and the
+    # build passes the names of the tree wherever it compiles by them.
     def enable_file_prefix_map(source: ".", build: source == "." ? "build" : "#{source}/build")
       file_prefix_map(MRUBY_ROOT, source)
       file_prefix_map(@build_root, build)
@@ -450,6 +450,21 @@ module MRuby
         obj = cxx_src.ext(@exts.object)
       end
 
+      # The generated source includes the file by its own name and the
+      # directory it sits in is searched for it, rather than the path being
+      # written into the file, so that what this generates says the same thing
+      # wherever the tree sits.
+      #
+      # The name the compiler then records is that directory and the name
+      # together, and the directory is the one the flags carry: the name the
+      # tree has for it where the build compiles by such names, and the path
+      # as it is otherwise. Written into the file instead, the name would be
+      # the one the search found it under, `./src/vm.c`, which `clang` keeps
+      # as it is or shortens depending on whether the build has any directory
+      # left to map, and two builds of the same tree would differ by it.
+      source_dir = File.dirname(File.absolute_path(src))
+      cxx.include_paths << source_dir unless cxx.include_paths.include?(source_dir)
+
       file cxx_src => [src, __FILE__] do |t|
         mkdir_p File.dirname t.name
         IO.write t.name, <<EOS
@@ -459,7 +474,7 @@ module MRuby
 #ifndef MRB_USE_CXX_ABI
 extern "C" {
 #endif
-#include "#{File.absolute_path src}"
+#include "#{File.basename(src)}"
 #ifndef MRB_USE_CXX_ABI
 }
 #endif
@@ -530,7 +545,10 @@ EOS
     end
 
     def mrbcfile=(path)
-      @mrbcfile = path
+      # Named against the directory the build was started from, like the
+      # build directory, and expanded here for the same reason: it is run
+      # from the tree.
+      @mrbcfile = File.expand_path(path)
       @mrbcfile_external = true
     end
 

--- a/lib/mruby/build/command.rb
+++ b/lib/mruby/build/command.rb
@@ -30,15 +30,23 @@ module MRuby
     end
 
     private
-    def _run(options, params={})
-      sh "#{build.filename(command)} #{options % params}"
+    # Run the command, from +chdir+ where one is given.
+    #
+    # A command handed the names its files have from the tree is run from the
+    # tree, and is given the directory rather than the build being left in it:
+    # `rake -m` runs the tasks of a build in threads of one process, which
+    # have one working directory between them, while a directory given here
+    # belongs to the one child it is given to.
+    def _run(options, params={}, chdir: nil)
+      cmd = "#{build.filename(command)} #{options % params}"
+      chdir ? sh(cmd, chdir: chdir) : sh(cmd)
     end
   end
 
   class Command::Compiler < Command
-    # The answers `file_prefix_map?` has had from the commands it asked,
-    # which are the same from one compiler to the next.
-    FILE_PREFIX_MAP_SUPPORT = {}
+    # The answers `option_support?` has had from the commands it asked, which
+    # are the same from one compiler to the next.
+    OPTION_SUPPORT = {}
 
     # The answers `try_compile` has had, keyed by the command line and the
     # source it asked with.
@@ -58,6 +66,9 @@ module MRuby
     # because they name directories of the machine the build runs on, which
     # the flags a package exports are asked not to carry.
     attr_accessor :file_prefix_maps, :option_file_prefix_map
+    # The option that tells the compiler which directory to record as the one
+    # it compiled in, for a compiler that takes such a thing.
+    attr_accessor :option_compilation_dir
     attr_accessor :cxx_compile_flag, :cxx_exception_flag, :cxx_invalid_flags
     attr_writer :preprocess_options
 
@@ -74,6 +85,7 @@ module MRuby
       @option_define = %q[-D"%s"]
       @file_prefix_maps = {}
       @option_file_prefix_map = %q[-ffile-prefix-map="%s=%s"]
+      @option_compilation_dir = %q[-ffile-compilation-dir="%s"]
       @compile_options = %q[%{flags} -o "%{outfile}" -c "%{infile}"]
       @cxx_invalid_flags = []
       @out_ext = build.exts.object
@@ -97,14 +109,41 @@ module MRuby
         .any? {|d| d.to_s.split('=', 2).first == name}
     end
 
-    # The flags that have this compiler write the names in `file_prefix_maps`
-    # in place of the directories they stand for, wherever it writes a path of
-    # its own: in `__FILE__`, and in the debug information. Empty where this
-    # compiler cannot map a path at all, and the paths it writes stand as they
-    # are.
+    # The flags that keep the directories of this machine out of what the
+    # compiler writes: the names in `file_prefix_maps` in place of the
+    # directories they stand for, wherever the compiler writes a path of its
+    # own, in `__FILE__` and in the debug information. A compiler that can
+    # neither map a path nor be told which directory it compiled in is left
+    # alone, and the paths it writes stand as they are.
+    #
+    # A build that compiles by the names its sources have from the tree hands
+    # those names to the map too, so a directory of the machine is named here
+    # only where the build could not name it any other way. Two of them then
+    # answer for themselves: the tree, which every name is already written
+    # against, and a build directory that is already spelled the way the map
+    # would write it.
+    #
+    # What no name of a source can carry is the directory the compiler records
+    # as the one it compiled in, which it takes from the machine whatever it
+    # is handed. A compiler that spells that directory on its own is asked for
+    # it, since that spelling names no path of this machine; the map is what
+    # answers for a compiler that does not.
     def file_prefix_map_flags
-      return [] if file_prefix_maps.empty? || !file_prefix_map?
-      file_prefix_maps.map {|from, to| option_file_prefix_map % [filename(from), to]}
+      relative = build.compile_relative?
+      flags = []
+      file_prefix_maps.each do |from, to|
+        if relative && from == MRUBY_ROOT
+          if compilation_dir?
+            flags << option_compilation_dir % to
+            next
+          end
+        elsif relative
+          from = build.compile_path(from)
+          next if from == to
+        end
+        flags << option_file_prefix_map % [filename(from), to] if file_prefix_map?
+      end
+      flags
     end
 
     # Whether this compiler can map a path, which is two questions: whether
@@ -114,17 +153,23 @@ module MRuby
     # in the older ones: `-ffile-prefix-map` arrived in GCC 8 and in clang
     # 10. A command that answers no is compiled with as it always was, so a
     # build that used to work is not broken by a map it never asked for.
-    #
-    # The answer is kept per command line, since a build has four compilers
-    # and a config has several builds, and they name few commands between
-    # them.
     def file_prefix_map?
       return false unless option_file_prefix_map
-      probe = "#{build.filename(command)} #{option_file_prefix_map % ['/mruby', '.']}"
-      FILE_PREFIX_MAP_SUPPORT.fetch(probe) do
-        `echo | #{probe} -E - 2>&1`
-        FILE_PREFIX_MAP_SUPPORT[probe] = $?.exitstatus == 0
-      end
+      option_support?(option_file_prefix_map % ['/mruby', '.'])
+    end
+
+    # Whether this compiler is told the directory it compiled in, rather than
+    # left to record the one it is run from. The option names no path of this
+    # machine, so a build that compiles by the names of the tree carries the
+    # same directory wherever the tree sits, and a cache keyed on the command
+    # line answers for one tree what it learned from another.
+    #
+    # Only `clang` spells it, and only from the version the spelling arrived
+    # in; `gcc` has nothing of the kind, and a build compiled by it says which
+    # directory it compiled in through the map instead.
+    def compilation_dir?
+      return false unless option_compilation_dir
+      option_support?(option_compilation_dir % '.')
     end
 
     # Whether this compiler compiles +source+, asked with the flags it will
@@ -222,10 +267,18 @@ module MRuby
       path && build.filename("#{path}/#{name}").sub(/^"(.*)"$/, '\1')
     end
 
-    def all_flags(_defines=[], _include_paths=[], _flags=[])
+    # The flags a caller compiles with, or that a package carries away.
+    #
+    # +compiled+ says which of the two is asking. A compile is run from the
+    # tree and names the directories it reads by the names they have from it,
+    # where they have one; a package is compiled from somewhere else entirely,
+    # and its flags name every directory in full, for whoever rewrites them
+    # into the directories the package was installed in.
+    def all_flags(_defines=[], _include_paths=[], _flags=[], compiled: false)
       define_flags = [defines, internal_defines, _defines, build.defines].flatten
                        .map{ |d| option_define % d }
       include_path_flags = [include_paths, _include_paths].flatten.map do |f|
+        f = build.compile_path(f) if compiled
         option_include_path % filename(f)
       end
       [flags, file_prefix_map_flags, define_flags, include_path_flags, _flags].flatten.join(' ')
@@ -242,7 +295,11 @@ module MRuby
         opts = preprocess_options
       end
       _pp label, infile.relative_path, outfile.relative_path
-      _run opts, flags: flags, infile: filename(infile), outfile: filename(outfile)
+      _run opts, {
+        flags: flags,
+        infile: filename(build.compile_path(infile)),
+        outfile: filename(build.compile_path(outfile)),
+      }, chdir: (MRUBY_ROOT if build.compile_relative?)
       # Recorded after the compile, so that a compile that failed leaves
       # nothing claiming a configuration its output was not built with.
       File.write(flags_file(outfile), flags_record(opts, flags))
@@ -375,10 +432,25 @@ module MRuby
 
     private
 
+    # Whether the command this compiler names knows +option+, which is asked
+    # of the command itself: a toolchain stands for a family of compilers, and
+    # an option one of them takes is not in all of them.
+    #
+    # The answer is kept per command line, since a build has four compilers
+    # and a config has several builds, and they name few commands between
+    # them.
+    def option_support?(option)
+      probe = "#{build.filename(command)} #{option}"
+      OPTION_SUPPORT.fetch(probe) do
+        `echo | #{probe} -E - 2>&1`
+        OPTION_SUPPORT[probe] = $?.exitstatus == 0
+      end
+    end
+
     # Compile +source+ and answer whether it compiled.  The source and the
     # object are named inside a directory that is removed on the way out; the
-    # compiler is left in the working directory the build compiles from, which
-    # is what a relative path in the flags is written against.
+    # compiler is run from the directory a compile runs from, which is what a
+    # relative path in the flags is written against.
     def run_compile_probe(source)
       Dir.mktmpdir("mruby-probe") do |dir|
         infile = "#{dir}/probe#{source_exts.first || '.c'}"
@@ -387,10 +459,11 @@ module MRuby
         options = compile_options % {
           flags: all_flags, infile: filename(infile), outfile: filename(outfile)
         }
+        opts = {out: File::NULL, err: File::NULL}
+        opts[:chdir] = MRUBY_ROOT if build.compile_relative?
         # `system` answers nil where the command is not there to run at all,
         # which is an answer of no like any other failure to compile.
-        !!system("#{build.filename(command)} #{options}",
-                 out: File::NULL, err: File::NULL)
+        !!system("#{build.filename(command)} #{options}", **opts)
       end
     end
 
@@ -455,7 +528,7 @@ module MRuby
     # the presym scan is this compiler with one define more, so the define
     # belongs to the flags and to what is recorded of them.
     def compile_flags(outfile, _defines=[], _include_paths=[], _flags=[])
-      flags = all_flags(_defines, _include_paths, _flags)
+      flags = all_flags(_defines, _include_paths, _flags, compiled: true)
       flags += " -DMRB_PRESYM_SCANNING" unless object_ext?(outfile)
       flags
     end

--- a/lib/mruby/build/command.rb
+++ b/lib/mruby/build/command.rb
@@ -344,6 +344,14 @@ module MRuby
         #    []
         #    []
       end.flatten.uniq
+      # The names a +.d+ file carries are the ones the compile was given, so a
+      # compile that names its sources against the tree leaves relative names
+      # here. They are read against the directory the compile ran in, since
+      # everything below compares them with the names of the tasks, and those
+      # are absolute.
+      header_deps.map! do |dep|
+        Pathname.new(dep).absolute? ? dep : File.join(MRUBY_ROOT, dep)
+      end
       unless object_ext?(file)
         presym_dir = "#{build.presym.header_dir}/"
         header_deps.reject! {|dep| dep.start_with?(presym_dir) }

--- a/lib/mruby/build/command.rb
+++ b/lib/mruby/build/command.rb
@@ -738,9 +738,16 @@ module MRuby
       # leak into the captured stdout and corrupt the generated C file.
       tmpout = "#{out.path}.#{funcname}.mrbcout"
       opt = opt.sub(/\s-o-(?=\s|\z)/, %Q[ -o "#{filename tmpout}"])
-      cmd = %["#{filename @command}" #{opt} #{filename(infiles).map{|f| %["#{f}"]}.join(' ')}]
+      # The names given here are the ones `mrbc` records for a backtrace, so
+      # they are the names the sources have from the tree wherever the build
+      # compiles by those, and `mrbc` is run from the tree to read them. This
+      # is what the compilers are told through their own options, which reach
+      # nothing `mrbc` writes.
+      sources = infiles.map {|f| build.compile_path(f) }
+      cmd = %["#{filename @command}" #{opt} #{filename(sources).map{|f| %["#{f}"]}.join(' ')}]
       puts cmd if Rake.verbose
-      unless system(cmd)
+      opts = build.compile_relative? ? {chdir: MRUBY_ROOT} : {}
+      unless system(cmd, **opts)
         rm_f tmpout
         rm_f out.path
         fail "Command failed with status (#{$?.exitstatus}): [#{cmd[0,42]}...]"

--- a/lib/mruby/compile_commands.rb
+++ b/lib/mruby/compile_commands.rb
@@ -181,11 +181,19 @@ module MRuby
       record = read_record("#{outfile}.flags")
       return nil unless record
       infile = source_of(outfile)
-      return nil unless infile && File.exist?(infile)
+      return nil unless infile
+      # The record and the dependency file name the source the way the compile
+      # was given it, which is the name it has from the tree where the build
+      # compiles by those names. The command keeps that name, since it is the
+      # command that was run and `directory` says what it was written against,
+      # while `file` is answered in full: it is what a tool matches the file it
+      # has open against, and it has that one by its path.
+      path = File.absolute_path(infile, MRUBY_ROOT)
+      return nil unless File.exist?(path)
 
       {
         "directory" => MRUBY_ROOT,
-        "file" => infile,
+        "file" => path,
         "command" => command_line(record, infile, outfile),
         "output" => outfile,
       }
@@ -199,7 +207,7 @@ module MRuby
       params = {
         :flags => record["flags"],
         :infile => @build.filename(infile),
-        :outfile => @build.filename(outfile),
+        :outfile => @build.filename(@build.compile_path(outfile)),
       }
       "#{record["command"]} #{record["options"] % params}"
     end

--- a/tasks/toolchains/visualcpp.rake
+++ b/tasks/toolchains/visualcpp.rake
@@ -13,8 +13,10 @@ MRuby::Toolchain.new(:visualcpp) do |conf, _params|
     compiler.option_include_path = %q[/I"%s"]
     compiler.option_define = '/D%s'
     # `cl` has no counterpart of `-ffile-prefix-map`: it writes the path it
-    # is given, and `/d1trimfile` only takes a prefix off `__FILE__`.
+    # is given, and `/d1trimfile` only takes a prefix off `__FILE__`. Nor has
+    # it one for the directory it records as the one it compiled in.
     compiler.option_file_prefix_map = nil
+    compiler.option_compilation_dir = nil
     compiler.compile_options = %Q[/Zi /c /Fo"%{outfile}" %{flags} "%{infile}"]
     compiler.preprocess_options = %Q[/EP %{flags} "%{infile}" > "%{outfile}"]
     compiler.cxx_compile_flag = '/TP'


### PR DESCRIPTION
## Summary

A build hands its compilers the paths of this machine: the sources they read,
the directories they search, the outputs they write. Two checkouts of the same
commit therefore compile two different command lines, and a compiler cache
keyed on the command line answers for neither from the other. The file names
`mrbc` records for a backtrace are those paths too, so a build with
`enable_debug` is not reproducible at all: `bin/mruby` carries 43 paths of the
machine that built it, and two checkouts produce different binaries.

A build already says that its output carries no path of this machine, by
mapping the tree to `.` (#7374). It compiles by those names now, run from the
tree, and the map is left with what such a name cannot carry.

## Changes

| Commit | What it does |
|---|---|
| build: expand the build directory where it is read | `MRUBY_BUILD_DIR`, and a directory a config names, are expanded once where they are read |
| build: read the names in a `.d` file against the tree | dependency records are read against the directory a compile runs in |
| build: compile by the names the sources have from the tree | the sources, the include directories and the outputs are named as the tree names them |
| build: name the sources of a `mrbc` run as the tree names them | the names a backtrace reports, and the include in the generated C++ wrapper |
| build: name the source in full in `compile_commands.json` | `file` answers by path, the command keeps the names it ran with |
| doc: say that a build compiles by the names of the tree | the guide follows |

### The build directory

`MRUBY_BUILD_DIR`, and the directory a config names, are written against the
directory the build was started from and were kept as they were spelled. A
relative name meant one directory to Rake and another to any step that runs
somewhere else. They are expanded where they are read, so the spelling a name
was given reaches nothing else.

An empty `MRUBY_BUILD_DIR` was a name like any other, an empty string being
true in Ruby, and put every target under `/`: the `host` build looked for
`/host/presym` and stopped there. It is read as the unset it was meant to be,
as `MRUBY_CONFIG` already is.

### The names a compile is given

The sources and the include directories are named as the tree names them,
`src/vm.c` and not the path of the checkout, and the compile is run from the
tree. The working directory is given to the child rather than set on the
process, since `rake -m` runs the tasks of a build in threads that have one
working directory between them.

The flags a package carries away in `libmruby.flags.mak` still name every
directory in full: they are read where the package was installed, and whoever
compiles against it rewrites them.

A `.d` file carries the names the compile was given, and every reader of it
compares them with the names of the tasks, which are absolute. They are read
against the directory a compile runs in, so that the dependency on a generated
header survives.

### The directory the compiler records

What no name of a source can carry is the directory the compiler records as
the one it compiled in. `clang` is told it by `-ffile-compilation-dir`, an
option that names no path of this machine, so nothing absolute is left on its
command line; `gcc` has no counterpart and keeps `-ffile-prefix-map`. The
build asks the compiler which it takes, as it already does for the map.

A build directory the tree cannot name, one `MRUBY_BUILD_DIR` puts elsewhere,
is written through the map as before, and still reads `build`.

### `mrbc` and the generated C++ wrapper

The names `mrbc` records are the ones it is handed, and no compiler flag
reaches them. It is handed the names of the tree now and run from the tree.

The source generated to wrap a core file for a C++ compile named the file it
includes in full. It includes it by its own name now, and the directory it
sits in is searched for it, so the name the compiler records is the one the
flags carry rather than the one the search wrote.

### The compile database

`file` names the source in full, and whether the source is still there is
asked about that same path rather than from whichever directory the database
was generated in. The command keeps the names the compile ran with, which
`directory` already answers for.

## Behaviour

- The names recorded in the output lose the `./` the map wrote and read
  `src/vm.c`. This is what `__FILE__` gives `mrb_assert`, what the debug
  information carries, and what a backtrace reports under `enable_debug`.
- A debug build is reproducible: two checkouts of one commit produce the same
  `libmruby.a` and `bin/mruby`, whatever the build directory is called and
  wherever it sits, and nothing in `bin/mruby` names the directory it was
  built in.
- A config that writes another name for the tree, `enable_file_prefix_map
  source: "mruby"`, is asking for a name no relative name carries, so its
  build compiles with the paths as they are, as it does today.
  `disable_file_prefix_map` is unchanged.
- A debugger looks for the sources under the names the build wrote and finds
  them from the tree: run it there, or `set substitute-path . /path/to/mruby`.
- A compiler that takes neither option, `cl` and anything older than GCC 8 or
  clang 10, still compiles by the names of the tree, and the directory it
  records stays as it is.

## Speed

What a compiler cache can answer for a second checkout of the same commit,
with nothing configured for it on the machine, 216 compiles per build:

| | before | after |
|---|---|---|
| `ccache`, default config | 0 | 216 |
| `ccache`, `enable_debug` + `enable_cxx_exception` | 0 | 216 |
| `sccache`, default config | 0 | 216 |
| `sccache`, `enable_debug` + `enable_cxx_exception` | 0 | 216 |

The table is `clang`. `ccache` answered 185 of 216 for the debug build with
`base_dir` set on the machine, and nothing for either build without it.
`sccache` has no such setting.

`gcc` with `ccache` answers 214 of 216, and 212 of 216 for the debug build.
What falls out is the generated sources of prism, `src/node.c` and, in the
debug build, `src/serialize.c`, each compiled once for the `mrbc` a build
makes for itself and once for the build. Their `#line` directives name a
template under `prism/templates` that a checkout does not carry, so `ccache`
turns off its direct mode for them and hashes the preprocessed output instead,
and `gcc` writes the working directory into that output in a linemarker of its
own that no map rewrites. Nothing on the command line decides that one;
#7441 rewrites the directives to a name the tree carries and gives `ccache`
its direct mode back on these files.

No claim is made about wall clock here. 161 of the 377 compiler invocations a
build makes are the `-E -P` presym preprocess, which neither tool caches, and
what is left varies too much on this machine to measure honestly.

`gcc` with `-g` is the one case a cache cannot answer for: `sccache` hashes
the working directory whenever `gcc` writes debug information, whatever the
command line says, and `gcc` has no option that names the recorded directory
without naming a path. A build compiled by `clang`, or by `gcc` without `-g`,
is answered for.

## Size

`.text` of `bin/mruby`, `ci/gcc-clang`, clang, against `07b315bb`:

| build | base | PR | delta |
|---|---|---|---|
| full-debug | 1,913,974 | 1,913,974 | +0 |
| bintest | 1,110,774 | 1,110,774 | +0 |
| cxx_abi | 1,097,933 | 1,097,933 | +0 |
| byte-string | 1,084,854 | 1,084,854 | +0 |
| ascii-ctype | 1,105,894 | 1,105,894 | +0 |

The recorded names are data, so what moves is `.rodata`, and only where the
build carries them: full-debug is 4,032 bytes smaller, from the `./` the
names of `mrb_assert` and of the backtrace no longer carry. The other four
builds are unchanged.

## Testing

- `rake -m test` on each commit of the series: 2,501 OK, 0 KO, 0 crash.
- `MRUBY_CONFIG=ci/gcc-clang rake -m all test` with `gcc` and with `clang`:
  0 KO, 0 crash.
- Two checkouts at different depths, default config and `enable_debug` with
  `enable_cxx_exception`, `gcc` and `clang`: `libmruby.a` and `bin/mruby`
  identical, and identical again between a build directory inside the tree and
  one outside it.
- `MRUBY_BUILD_DIR` unset, relative, relative with a trailing slash, relative
  through `..`, and absolute outside the tree: all build, and all five produce
  the same `libmruby.a`.
- `MRUBY_CFLAGS` in `libmruby.flags.mak` still reads
  `-I"$(MRUBY_PACKAGE_DIR)/include"`.
- `compile_commands.json`: every entry names a file that exists.

## Environment

<details>

```
Ubuntu 24.04.4 LTS, Linux 7.0.0-30-generic, x86_64
ruby 4.0.6
Homebrew clang version 23.1.0
gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0
ccache 4.14
sccache 0.17.0
```

A compile line before and after, `host` build, `clang`:

```
-std=gnu99 -g -O3 -Wall ... -ffile-prefix-map="/home/.../mruby=."
  -ffile-prefix-map="/home/.../mruby/build=./build"
  -I"/home/.../mruby/include" -I"/home/.../mruby/build/host/include"
  -o "/home/.../mruby/build/host/src/array.o" -c "/home/.../mruby/src/array.c"

-std=gnu99 -g -O3 -Wall ... -ffile-compilation-dir="."
  -I"include" -I"build/host/include"
  -o "build/host/src/array.o" -c "src/array.c"
```

and with `gcc`, which keeps the map for the directory it records:

```
-std=gnu99 -g -O3 -Wall ... -ffile-prefix-map="/home/.../mruby=."
  -I"include" -I"build/bintest/include"
```

</details>

