### PR TITLE
mruby-regexp: combine patterns with `Regexp.union`

### DIFF
--- a/mrbgems/mruby-regexp/README.md
+++ b/mrbgems/mruby-regexp/README.md
@@ -111,6 +111,9 @@ re.eql?(other)                    # => same as ==
 re.hash                           # => source and options hashed together
 Regexp.escape("a.b")              # => "a\\.b"
 Regexp.quote("a.b")               # => same as Regexp.escape
+Regexp.union("a+", /b/i)          # => /a\+|(?i-mx:b)/
+Regexp.union(["a", "b"])          # => /a|b/, one Array stands for its elements
+Regexp.union                      # => /(?!)/, which never matches
 Regexp.last_match(n)              # => nth capture from last match
 
 # MatchData

--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -1012,6 +1012,62 @@ regexp_escape(mrb_state *mrb, mrb_value self)
   return re_escape_str(mrb, str);
 }
 
+/*
+ * Regexp.union(*patterns) - a pattern matching any of the arguments
+ *
+ * A single Array argument stands for its elements, and a lone Regexp is
+ * answered as itself rather than recompiled. Everything else combines into
+ * one source the way interpolation would write it: a Regexp contributes its
+ * `to_s` form so its own flags travel inside the group, and a String is
+ * quoted so it stays literal. The answer is always a Regexp, whichever
+ * subclass the arguments or the receiver are, as CRuby answers.
+ *
+ * A Symbol is refused wherever it appears, where CRuby stringifies one in
+ * the single-argument path only: `Regexp.escape` here takes a String and
+ * nothing else, and the arguments a union quotes are read by the same rule
+ * however many there are.
+ */
+static mrb_value
+regexp_union(mrb_state *mrb, mrb_value self)
+{
+  const mrb_value *argv;
+  mrb_int argc;
+  mrb_get_args(mrb, "*", &argv, &argc);
+
+  struct RClass *re_class = mrb_class_get_id(mrb, MRB_SYM(Regexp));
+
+  if (argc == 1 && mrb_array_p(argv[0])) {
+    /* The element pointer stays valid across the allocations below: the
+       array itself is held by the VM stack and is never written to here. */
+    mrb_value ary = argv[0];
+    argv = RARRAY_PTR(ary);
+    argc = RARRAY_LEN(ary);
+  }
+  if (argc == 0) {
+    /* Nothing to match is a pattern that never matches. */
+    mrb_value src = mrb_str_new_lit(mrb, "(?!)");
+    return mrb_obj_new(mrb, re_class, 1, &src);
+  }
+  if (argc == 1 && mrb_obj_is_kind_of(mrb, argv[0], re_class)) {
+    return argv[0];
+  }
+
+  mrb_value src = mrb_str_new(mrb, NULL, 0);
+  int ai = mrb_gc_arena_save(mrb);
+  for (mrb_int i = 0; i < argc; i++) {
+    mrb_value e = argv[i];
+    if (i > 0) mrb_str_cat_lit(mrb, src, "|");
+    if (mrb_obj_is_kind_of(mrb, e, re_class)) {
+      mrb_str_cat_str(mrb, src, regexp_to_s(mrb, e));
+    }
+    else {
+      mrb_str_cat_str(mrb, src, re_escape_str(mrb, mrb_ensure_string_type(mrb, e)));
+    }
+    mrb_gc_arena_restore(mrb, ai);
+  }
+  return mrb_obj_new(mrb, re_class, 1, &src);
+}
+
 /* Answer the group a name refers to in the match the captures stand for, or
    -1 for a name the pattern gives to no group. A pattern may give one name
    to several groups, and CRuby's named accessors then read the last of them
@@ -3399,6 +3455,7 @@ mrb_mruby_regexp_gem_init(mrb_state *mrb)
   mrb_define_class_method(mrb, re, "escape", regexp_escape, MRB_ARGS_REQ(1));
   mrb_define_class_method(mrb, re, "quote", regexp_escape, MRB_ARGS_REQ(1));
   mrb_define_class_method(mrb, re, "last_match", regexp_s_last_match, MRB_ARGS_OPT(1));
+  mrb_define_class_method(mrb, re, "union", regexp_union, MRB_ARGS_ANY());
 
   /* Instance methods */
   mrb_define_method(mrb, re, "match", regexp_match, MRB_ARGS_ARG(1, 1)|MRB_ARGS_BLOCK());

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -198,6 +198,47 @@ assert("Regexp.escape") do
   assert_true Regexp.new(Regexp.escape("a # b"), Regexp::EXTENDED).match?("a # b")
 end
 
+assert("Regexp.union") do
+  assert_equal(/a|b/, Regexp.union("a", "b"))
+  assert_equal 1, Regexp.union("a", "b") =~ "xby"
+
+  # strings are quoted so they match literally
+  assert_equal(/a\+b|c/, Regexp.union("a+b", "c"))
+  assert_true Regexp.union("a+b", "c").match?("a+b")
+
+  # a Regexp contributes its to_s form, so its flags stay its own
+  assert_equal(/(?i-mx:a)|(?-mix:b)/, Regexp.union(/a/i, /b/))
+  assert_equal(/a|(?i-mx:b)/, Regexp.union("a", /b/i))
+  assert_true Regexp.union("a", /b/i).match?("B")
+  assert_false Regexp.union("a", /b/i).match?("A")
+  assert_equal 0, Regexp.union(/a/im, /b/).options
+
+  # non-ASCII bytes pass through the quoting untouched and match literally,
+  # on a UTF-8 build and a byte build alike
+  assert_equal(/あ|い/, Regexp.union("あ", "い"))
+  assert_true Regexp.union("あ", "い").match?("い")
+  assert_true Regexp.union("あ+い", "う").match?("あ+い")
+
+  # no pattern is a pattern that never matches
+  assert_equal(/(?!)/, Regexp.union)
+  assert_nil Regexp.union =~ ""
+
+  # one pattern: a Regexp is answered as itself, a String is quoted
+  re = /a/i
+  assert_true Regexp.union(re).equal?(re)
+  assert_equal(/a\+b/, Regexp.union("a+b"))
+
+  # a single Array argument stands for its elements
+  assert_equal(/a|b/, Regexp.union(["a", "b"]))
+  assert_equal(/(?!)/, Regexp.union([]))
+  assert_true Regexp.union([re]).equal?(re)
+
+  # everything else is refused, an Array among other arguments included
+  assert_raise(TypeError) { Regexp.union(nil) }
+  assert_raise(TypeError) { Regexp.union("a", :b) }
+  assert_raise(TypeError) { Regexp.union(["a"], "b") }
+end
+
 assert("Regexp#inspect") do
   re = Regexp.new("abc", Regexp::IGNORECASE)
   assert_equal "/abc/i", re.inspect


### PR DESCRIPTION
## Summary

`Regexp.union` was missing: CRuby builds one pattern that matches any of its arguments, and mruby answered the call with NoMethodError. This adds it in C beside `Regexp.escape`, with CRuby's reading for every argument form.

## Changes

| File | What |
|---|---|
| `mrbgems/mruby-regexp/src/regexp.c` | `regexp_union()` added, defined as `Regexp.union` |
| `mrbgems/mruby-regexp/test/regexp.rb` | assertions for every `Regexp.union` argument form |
| `mrbgems/mruby-regexp/README.md` | `Regexp.union` in the Ruby API listing |

### Sources combine the way interpolation writes them

A Regexp argument enters as its `to_s` form, so its flags stay inside their own group instead of leaking across the alternation, and a String is quoted the way `Regexp.escape` quotes one; the pieces join on `|`. A lone Regexp argument is answered as itself rather than recompiled, a single Array argument stands for its elements, and no arguments at all answer `/(?!)/`, a pattern that never matches. The answer is always a plain Regexp, whichever subclass the receiver or the arguments are. These are the readings of CRuby's `rb_reg_s_union()`, and the implementation reaches them through the C side it already shares a file with: the quoting is `re_escape_str()` and the group form is `regexp_to_s()`, called as functions rather than dispatched back into Ruby.

## Behaviour

```ruby
Regexp.union("a", "b")    # => /a|b/                   (was NoMethodError)
Regexp.union("a+b", "c")  # => /a\+b|c/
Regexp.union(/a/i, /b/)   # => /(?i-mx:a)|(?-mix:b)/
Regexp.union(["a", "b"])  # => /a|b/
Regexp.union              # => /(?!)/, which never matches

re = /a/i
Regexp.union(re).equal?(re)  # => true
```

One deliberate difference: a Symbol raises TypeError however many arguments there are, where CRuby stringifies one in its single-argument path alone and refuses it beside a second argument:

```ruby
Regexp.union(:a)      # CRuby: /a/, mruby: TypeError
Regexp.union(:a, :b)  # TypeError in both
```

`Regexp.escape` here takes a String and nothing else, and the arguments a union quotes are read by the same rule whatever their count.

## Size

`.text` of `bin/mruby`, measured with `size -A` on the `build_config/ci/gcc-clang.rb` builds, master at `5ce53afdb`:

| Build | master | this PR | delta |
|---|---:|---:|---:|
| bintest | 1,111,238 | 1,111,766 | +528 |
| ascii-ctype | 1,106,358 | 1,106,886 | +528 |
| byte-string | 1,085,318 | 1,085,846 | +528 |
| cxx_abi | 1,098,381 | 1,098,909 | +528 |
| full-debug (-O0) | 1,914,518 | 1,915,478 | +960 |

The whole delta is `regexp.o`: its `.text` grows by the same +528 (+960 under `-O0`) in every build, measured the same way.

## Testing

- `rake -m test` with the default config (a byte build): 2,569 tests, KO 0, Crash 0.
- `rake -m test` with `build_config/ci/gcc-clang.rb` (bintest / ascii-ctype / byte-string / cxx_abi / full-debug, the last under `MRB_GC_STRESS`): all five green, KO 0, Crash 0.
- Every expected value in the new assertions was checked against CRuby 4.0.6, the subclass and identity answers included.

## Environment

<details>
<summary>Machine, toolchain and compile lines</summary>

| | |
|---|---|
| OS | Ubuntu 24.04.4 LTS (kernel 7.0.0-30-generic) |
| CPU | AMD Ryzen 9 5950X |
| C compiler | Homebrew clang 23.1.0 |
| binutils | GNU Binutils 2.47.20260726 |
| CRuby | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |
| rake | 13.3.1 |

Compile lines for `regexp.c` as `rake --verbose` prints them, `-MMD -c`, the `-I` list and `-o` dropped:

```console
# bintest
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -ffile-prefix-map="<worktree>=." -ffile-prefix-map="<worktree>/build/size=./build" -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK
# ascii-ctype
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -ffile-prefix-map="<worktree>=." -ffile-prefix-map="<worktree>/build/size=./build" -DMRB_USE_ASCII_CTYPE -DMRB_REGEXP_PARSE_DEPTH_LIMIT=512 -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
# byte-string
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -ffile-prefix-map="<worktree>=." -ffile-prefix-map="<worktree>/build/size=./build" -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
# cxx_abi
clang -g -O3 -Wall -Wundef -Wwrite-strings -Wzero-length-array -x c++ -std=gnu++03 -ffile-prefix-map="<worktree>=." -ffile-prefix-map="<worktree>/build/size=./build" -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
# full-debug
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -g3 -O0 -ffile-prefix-map="<worktree>=." -ffile-prefix-map="<worktree>/build/size=./build" -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `Regexp.union` for combining strings, regular expressions, and arrays into a single pattern.
  - Supports literal string matching, single-pattern passthrough, and never-matching behavior with no arguments.

- **Documentation**
  - Documented the supported `Regexp.union` calling forms and behavior.

- **Tests**
  - Added coverage for argument types, quoting, arrays, flags, non-ASCII content, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->