### PR TITLE
mruby-compiler: make Prism `#line` directives resolve from the tree

### DIFF
--- a/mrbgems/mruby-compiler/mrbgem.rake
+++ b/mrbgems/mruby-compiler/mrbgem.rake
@@ -84,9 +84,15 @@ MRuby::Gem::Specification.new('mruby-compiler') do |spec|
     # point at a file the editor cannot open, and ccache drops its direct mode
     # over the missing dependency. Rewrite the prefix to the gem's location in
     # the tree. When the gem sits outside the tree no name from the tree
-    # reaches it, so there is nothing to write.
-    prism_rel_dir = prism_dir.relative_path_from(MRUBY_ROOT)
-    unless prism_rel_dir.start_with?('..')
+    # reaches it, so there is nothing to write; on Windows a gem on another
+    # drive is outside with no relative path at all, which Pathname reports
+    # by raising instead of returning a ".."-prefixed path.
+    prism_rel_dir = begin
+      prism_dir.relative_path_from(MRUBY_ROOT)
+    rescue ArgumentError
+      nil
+    end
+    unless prism_rel_dir.nil? || prism_rel_dir.start_with?('..')
       prism_generated_files.each do |path|
         source = File.binread(path)
         rewritten = source.gsub(/^(#line \d+ ")prism\//) { "#{$1}#{prism_rel_dir}/" }

--- a/mrbgems/mruby-compiler/mrbgem.rake
+++ b/mrbgems/mruby-compiler/mrbgem.rake
@@ -72,10 +72,26 @@ MRuby::Gem::Specification.new('mruby-compiler') do |spec|
 
   task prism_templates: :prism_submodule do
     missing = prism_generated_files.reject { |path| File.exist?(path) }
-    next if missing.empty?
+    unless missing.empty?
+      FileUtils.cd prism_dir do
+        sh "#{RbConfig.ruby} templates/template.rb"
+      end
+    end
 
-    FileUtils.cd prism_dir do
-      sh "#{RbConfig.ruby} templates/template.rb"
+    # The templates write #line directives that name themselves against the
+    # root of the prism repository ("prism/templates/..."), a path that
+    # resolves to nothing from MRUBY_ROOT, where mruby compiles: diagnostics
+    # point at a file the editor cannot open, and ccache drops its direct mode
+    # over the missing dependency. Rewrite the prefix to the gem's location in
+    # the tree. When the gem sits outside the tree no name from the tree
+    # reaches it, so there is nothing to write.
+    prism_rel_dir = prism_dir.relative_path_from(MRUBY_ROOT)
+    unless prism_rel_dir.start_with?('..')
+      prism_generated_files.each do |path|
+        source = File.binread(path)
+        rewritten = source.gsub(/^(#line \d+ ")prism\//) { "#{$1}#{prism_rel_dir}/" }
+        File.binwrite(path, rewritten) unless rewritten == source
+      end
     end
   end
 


### PR DESCRIPTION
## Summary

The Prism templates write `#line` directives into the sources they generate, naming the template against the root of the prism repository:

```c
/* mrbgems/mruby-compiler/lib/prism/src/node.c:11 */
#line 2 "prism/templates/src/node.c.erb"
```

The template is real, at `mrbgems/mruby-compiler/lib/prism/templates/src/node.c.erb`, but the name is written against a root where `prism/` is the checkout. mruby compiles from `MRUBY_ROOT`, where that name resolves to nothing: a compiler diagnostic in these files points at a path the editor cannot open, and `ccache` gives up its direct mode over it:

```
Include file prism/templates/src/node.c.erb does not exist, disabling direct mode
```

The prefix is written into the template itself, so no option of `templates/template.rb` reaches it. This PR rewrites it right after generation, in the `prism_templates` task, the one place that knows both directories.

## Changes

| file | change |
| --- | --- |
| `mrbgems/mruby-compiler/mrbgem.rake` | rewrite the prefix of the `#line` directives in the generated sources to the gem's location relative to `MRUBY_ROOT` |

### Rewriting the prefix

After `templates/template.rb` runs, the task rewrites every `#line <n> "prism/..."` in the generated sources to `#line <n> "mrbgems/mruby-compiler/lib/prism/..."`. Of the generated files only `src/node.c` (153 directives) and `src/serialize.c` (1) carry any, and the one in `serialize.c` sits inside `#ifndef PRISM_EXCLUDE_SERIALIZATION`, so only configurations that compile serialization see it. The rewritten name resolves from `MRUBY_ROOT`, where the compiler runs.

- The task is also invoked from the file tasks that regenerate a source when its template changes, so the rewrite runs on every invocation and writes a file only when something changed: it is idempotent, and it repairs sources generated before this change without touching mtimes afterwards.
- When the gem sits outside the tree, its path relative to `MRUBY_ROOT` starts with `..` and the task writes nothing. No name from the tree resolves in such a checkout, so the directives stay as prism wrote them. On Windows a gem on another drive has no relative path at all; `Pathname` reports that by raising, and the task folds it into the same skip.
- The generated sources are not tracked by prism (`/src/node.c` and `/src/serialize.c` are in its `.gitignore`), so the rewrite leaves the submodule clean.
- The amalgam needs no change: `lib/mruby/amalgam.rb` drops every `#line` directive from the sources it takes in, whatever they name.

## Behaviour

No runtime behaviour changes. What changes is what the toolchain sees:

- A diagnostic, a debugger frame, or a line table entry in the generated regions names `mrbgems/mruby-compiler/lib/prism/templates/src/node.c.erb`, a file that exists.
- `ccache` keeps its direct mode on `src/node.c` and `src/serialize.c`. Before, every compile of them fell back to preprocessed mode; under `gcc` that mode also hashes a linemarker naming the working directory, which no `-ffile-prefix-map` rewrites, so with compile lines that are otherwise path independent (#7439) these two files were the ones still missing across checkouts of one commit. `clang` emits no such linemarker.

## Speed

`src/node.c` compiled twice into a cold cache, `ccache` 4.14 with `gcc` 13.3.0, from `MRUBY_ROOT`:

| directives | second compile | log |
| --- | --- | --- |
| as generated | hits only in preprocessed mode | `disabling direct mode`, once per compile |
| rewritten | direct hit | clean |

## Size

`.text` of `node.o` is byte identical before and after the rewrite, with `gcc` 13.3.0 and `clang` 23.1.0 at `-O3`. The one `assert` of `node.c` sits below a directive, so the `__FILE__` string it carries grows by the prefix: `.rodata` +27 bytes. `serialize.c` compiles to an empty `.text` in the default configuration.

## Testing

- `rake -m test` all green: 2568 assertions, 2505 OK, 0 KO, 0 crash, 63 skip (host build, clang).
- Idempotency: a second `rake` leaves the mtimes of the generated sources untouched, so nothing rebuilds.
- The `ccache` measurements above, with a control on the original directives reproducing the disabled direct mode.

## Environment

<details>

- Ubuntu 24.04.4, Linux 7.0.0-30-generic, x86_64
- ruby 4.0.6
- Homebrew clang 23.1.0 (build and test suite), gcc 13.3.0 (`ccache` and size measurements)
- ccache 4.14, no `base_dir`
- Measurement compile line, run from `MRUBY_ROOT`:

```
ccache /usr/bin/gcc -MMD -c -std=gnu99 -g -O3 -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -Iinclude -Imrbgems/mruby-compiler/include -Imrbgems/mruby-compiler/lib/prism/include -Ibuild/host/include -o node.o mrbgems/mruby-compiler/lib/prism/src/node.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Prism template generation by skipping unnecessary work when generated files are already up to date.
  * Automatically generates any missing template files.
  * Updated generated source references to use repository-relative paths where applicable.
  * Prevented generation failures when relative paths cannot be computed across different drives or environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
