### PR TITLE
mruby-regexp: scan for first-byte candidates with memchr

### DIFF
--- a/mrbgems/mruby-regexp/include/re_internal.h
+++ b/mrbgems/mruby-regexp/include/re_internal.h
@@ -185,6 +185,11 @@ typedef struct mrb_regexp_pattern {
   uint8_t prefix_len;      /* length of prefix (0 = no prefix) */
   uint8_t first_bytes[16]; /* bitmap of possible first bytes (128-bit, ASCII) */
   mrb_bool has_first_bytes; /* true if first_bytes is usable for skipping */
+  uint8_t first_byte_count; /* how many bytes first_byte[] holds (1..3), or 0
+                               when the set is wider and only the bitmap
+                               serves; meaningful only under has_first_bytes */
+  uint8_t first_byte[3];   /* the whole first-byte set when it is this small,
+                              so the skip can memchr instead of walking */
   mrb_bool is_literal;     /* true if pattern is pure literal (no metacharacters) */
   uint8_t loop_depth;      /* deepest nesting of repetitions whose body can
                               match empty (see RE_MAX_PASS) */

--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -3862,6 +3862,19 @@ mrb_re_compile(mrb_state *mrb, mrb_regexp_pattern *pat,
     pat->has_first_bytes = compute_first_set(pat->code, code_len, pat->classes, bm);
     if (pat->has_first_bytes) {
       memcpy(pat->first_bytes, bm, 16);
+      /* A set of up to three bytes is also kept enumerated, so the skip can
+         ask memchr for each member instead of walking the subject a byte at
+         a time; see skip_to_first_byte(). Three covers the common shapes: an
+         alternation on one letter is one byte and a case-folded letter under
+         /i is two. */
+      int n = 0;
+      for (int b = 0; b < 128; b++) {
+        if (bm[b >> 3] & (1 << (b & 7))) {
+          if (n == 3) { n = 0; break; }
+          pat->first_byte[n++] = (uint8_t)b;
+        }
+      }
+      pat->first_byte_count = (uint8_t)n;
     }
   }
 

--- a/mrbgems/mruby-regexp/src/re_exec.c
+++ b/mrbgems/mruby-regexp/src/re_exec.c
@@ -38,6 +38,49 @@ skip_to_prefix(const mrb_regexp_pattern *pat, const char *sp, const char *str_en
 #define FIRST_BYTE_OK(pat, ch) \
   ((ch) >= 128 || ((pat)->first_bytes[(ch) >> 3] & (1 << ((ch) & 7))))
 
+/*
+ * Skip to the next position a match could start at, per the first-byte set.
+ * Returns NULL when no such position remains: the set never holds a byte the
+ * pattern can match empty at (first_set_walk() answers FALSE there), so a
+ * subject with none of it left holds no match either.
+ *
+ * A set of up to three bytes is scanned with one bounded memchr per member,
+ * each next call bounded by the nearest find so far, so every byte is read at
+ * most first_byte_count times and by memchr rather than one test at a time. A
+ * wider set walks the bitmap as before. The bitmap walk also stops at any
+ * byte above 127, which the memchr scan runs past: the set being usable at
+ * all means no match starts on a non-ASCII byte (see first_set_walk()), so
+ * those stops were never candidates, only where the walk gave up.
+ */
+static const char*
+skip_to_first_byte(const mrb_regexp_pattern *pat, const char *sp, const char *str_end)
+{
+  int n = pat->first_byte_count;
+  if (n == 0) {
+    while (sp < str_end && !FIRST_BYTE_OK(pat, (uint8_t)*sp)) sp++;
+    return sp < str_end ? sp : NULL;
+  }
+  if (sp >= str_end) return NULL;
+  /* The caller asks again after every failed attempt, and on a dense subject
+     the answer is usually the position it is already at: answer that with the
+     member tests alone, keeping the call per byte no dearer than the bitmap
+     test it replaces. */
+  uint8_t b = (uint8_t)*sp;
+  for (int i = 0; i < n; i++) {
+    if (b == pat->first_byte[i]) return sp;
+  }
+  const char *found = NULL;
+  size_t span = (size_t)(str_end - sp);
+  for (int i = 0; i < n; i++) {
+    const char *p = (const char*)memchr(sp, pat->first_byte[i], span);
+    if (p) {
+      found = p;
+      span = (size_t)(p - sp);
+    }
+  }
+  return found;
+}
+
 /* Check if the current input character matches a character class. ASCII
    (cp < 128) hits the bitmap; non-ASCII falls back to the inclusive (lo, hi)
    range list, then to the types the class holds by POSIX bracket, then to the
@@ -503,8 +546,9 @@ pike_vm(mrb_state *mrb, const mrb_regexp_pattern *pat,
           sp = skip;
         }
         else if (pat->has_first_bytes) {
-          while (sp < str_end && !FIRST_BYTE_OK(pat, (uint8_t)*sp)) sp++;
-          if (sp > str_end) break;
+          const char *skip = skip_to_first_byte(pat, sp, str_end);
+          if (!skip) break;
+          sp = skip;
         }
         if (sp > start_cap) break;
       }
@@ -1491,8 +1535,9 @@ backtrack_exec(mrb_state *mrb, const mrb_regexp_pattern *pat,
       sp = skip;
     }
     else if (pat->has_first_bytes) {
-      while (sp < str_end && !FIRST_BYTE_OK(pat, (uint8_t)*sp)) sp++;
-      if (sp > str_end) break;
+      const char *skip = skip_to_first_byte(pat, sp, str_end);
+      if (!skip) break;
+      sp = skip;
     }
     if (sp > start_cap) break;
     if (!binary && sp < str_end && mrb_re_char_interior_p(str, sp, str_end)) {


### PR DESCRIPTION
## Summary

A pattern with no literal prefix skips to its next candidate start by testing the first-byte bitmap one byte at a time. Most of those sets are tiny: an alternation whose branches share a first letter is a single byte, and a case pair under `/i` is two. This PR keeps a set of up to three bytes enumerated beside the bitmap and skips with one bounded `memchr` per member, so the scan runs at libc SIMD speed instead of one test per byte. Wider sets stay on the bitmap walk.

## Changes

| file | change |
|---|---|
| `include/re_internal.h` | `first_byte_count` / `first_byte[3]` on the compiled pattern |
| `src/re_compile.c` | enumerate the first-byte bitmap into `first_byte[]` when it holds at most three bytes |
| `src/re_exec.c` | `skip_to_first_byte()` used by both engines: a bounded `memchr` chain for a small set, the bitmap walk otherwise |

### Enumerating the set

After `compute_first_set()` fills the bitmap, its bits are counted once at compile time; three or fewer are kept in `first_byte[]`, and `first_byte_count` stays 0 for anything wider, which keeps the old path.

### The memchr chain

One `memchr` per member, each further call bounded by the nearest find so far, so every byte is read at most `first_byte_count` times. A membership test on the current byte answers first, so a dense subject pays one comparison per failed attempt, as the bitmap test did.

## Behaviour

No observable change. One internal difference: the bitmap walk stops at any byte above 127, while the `memchr` scan runs past them. That drops no candidate, because `first_set_walk()` refuses to publish a first-byte set whenever a match could start on a non-ASCII byte: `RE_BYTE`, a non-ASCII `RE_CHAR`, a class that is not ASCII-only, `RE_NCLASS` and `RE_ANY` all make it answer FALSE, and a class holding byte members is excluded through its ranges.

## Speed

callgrind Ir for `Regexp#match?` over a 10KB subject with no match, 2,000 calls, clang host build, master at d2e70b792. The control run was repeated and is bit-identical.

| case | pattern | subject | master | PR | Ir ratio |
|---|---|---|---|---|---|
| one byte, sparse | `/zebra\|zoo/` | lorem text, no `z` | 262,974,912 | 8,436,201 | 31.2x fewer |
| `/i` pair, sparse | `/qux/i` | lorem text, no `q` | 262,772,955 | 10,572,249 | 24.9x fewer |
| backtracking engine | `/(z\|w)a\1/` | lorem text | 244,124,617 | 10,543,911 | 23.2x fewer |
| dense candidates | `/ax\|ay/` | `"ab" * 5000` | 8,796,710,154 | 8,796,279,492 | 0.005% fewer |
| wide set (control) | `/[d-w]zzz/` | lorem text | 5,569,647,424 | 5,595,786,532 | +0.47% |

Wall clock for the first case at 200,000 calls: 1.17s to 0.02s.

The control keeps its wide set on the unchanged bitmap walk; its +0.47% is the added branch in the skip path, on a subject where three bytes in five are candidates.

## Size

`.text` sum of `libmruby.a`, `MRUBY_CONFIG=ci/gcc-clang` under clang, both revisions built from the same source path into empty build directories.

| build | master (d2e70b792) | PR | delta |
|---|---|---|---|
| ascii-ctype | 1,112,946 | 1,113,154 | +208 |
| bintest | 1,117,812 | 1,118,500 | +688 |
| byte-string | 1,091,916 | 1,092,684 | +768 |
| cxx_abi | 1,106,259 | 1,106,947 | +688 |
| full-debug | 1,928,759 | 1,929,095 | +336 |

## Testing

`rake -m test` on the default host config: 2510 OK, 0 KO, 0 crash, 63 skips (all pre-existing guards).

## Environment

<details>

- Linux x86_64, kernel 7.0.0, AMD Ryzen 9 5950X
- Homebrew clang 23.1.0, valgrind 3.27.1
- compile line (host, `re_exec.c`):

```
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK -MMD -c src/re_exec.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved regular expression matching by quickly skipping positions that cannot begin a match.
  * Optimized patterns with a small set of possible starting characters.
  * Improved scanning behavior when input contains non-ASCII characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->