### PR TITLE
appveyor: fetch the queued commit instead of the branch tip

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,8 +11,8 @@ version: "{build}"
 # commit (or the pull request merge ref) by name transfers just as little and
 # always contains the tree to check out.
 clone_script:
-  - cmd: git clone -q --no-checkout --depth=1 https://github.com/%APPVEYOR_REPO_NAME%.git %APPVEYOR_BUILD_FOLDER%
-  - cmd: cd %APPVEYOR_BUILD_FOLDER%
+  - cmd: git clone -q --no-checkout --depth=1 https://github.com/%APPVEYOR_REPO_NAME%.git "%APPVEYOR_BUILD_FOLDER%"
+  - cmd: cd /d "%APPVEYOR_BUILD_FOLDER%"
   - cmd: if defined APPVEYOR_PULL_REQUEST_NUMBER (set "CLONE_REF=+refs/pull/%APPVEYOR_PULL_REQUEST_NUMBER%/merge") else (set "CLONE_REF=%APPVEYOR_REPO_COMMIT%")
   - cmd: git fetch -q --depth=1 origin %CLONE_REF%
   - cmd: git checkout -qf FETCH_HEAD

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,18 @@ version: "{build}"
 # Prism compiler submodule (mrbgems/mruby-compiler/lib/prism) cannot be checked
 # out and the build aborts on "git submodule update". A normal clone keeps .git
 # so the submodule can be initialized in install below.
-clone_depth: 1
+#
+# Clone by script instead of clone_depth: a depth-limited clone holds only the
+# newest commits of the branch, so a build that waited in the queue while the
+# branch moved on can no longer check out its commit. Fetching the queued
+# commit (or the pull request merge ref) by name transfers just as little and
+# always contains the tree to check out.
+clone_script:
+  - cmd: git clone -q --no-checkout --depth=1 https://github.com/%APPVEYOR_REPO_NAME%.git %APPVEYOR_BUILD_FOLDER%
+  - cmd: cd %APPVEYOR_BUILD_FOLDER%
+  - cmd: if defined APPVEYOR_PULL_REQUEST_NUMBER (set "CLONE_REF=+refs/pull/%APPVEYOR_PULL_REQUEST_NUMBER%/merge") else (set "CLONE_REF=%APPVEYOR_REPO_COMMIT%")
+  - cmd: git fetch -q --depth=1 origin %CLONE_REF%
+  - cmd: git checkout -qf FETCH_HEAD
 
 environment:
   matrix:


### PR DESCRIPTION
## Summary

AppVeyor builds regularly go red before any script runs:

```
git clone -q --depth=1 --branch=master https://github.com/mruby/mruby.git C:\projects\mruby
git checkout -qf 954e172c7744e163db73070eb2e3bce41a11d833
fatal: unable to read tree (954e172c7744e163db73070eb2e3bce41a11d833)
```

A clone limited by `clone_depth` holds only the newest commits of the branch, so a build that waited in the queue while master moved on can no longer check out the commit it was queued for. All three jobs clone independently, which is why sometimes only part of the matrix fails.

## Changes

Replace `clone_depth: 1` with a `clone_script` that clones with `--no-checkout --depth=1` and then fetches the exact ref the build is for at depth 1: the queued commit SHA for branch builds, `refs/pull/N/merge` for pull request builds. GitHub serves any commit it holds when asked by SHA, so the fetched tree is always present no matter how far the branch has moved.

## Behaviour

The checked out tree is the same one AppVeyor checks out today for both branch and pull request builds. The only difference is that a build whose commit is no longer the branch tip now succeeds instead of dying in checkout.

## Speed

The transfer stays as small as the current depth 1 clone: `.git` after clone plus fetch weighs 2.4M.

## Testing

The command sequence was exercised against github.com/mruby/mruby on all three paths:

- a commit already behind the branch tip (`954e172c7`, the failure quoted above) fetches and checks out
- a commit equal to the branch tip fetches and checks out
- a pull request merge ref (`refs/pull/7439/merge`) fetches and checks out

AppVeyor reads `appveyor.yml` out of band before cloning, so the AppVeyor run on this pull request itself exercises the new script on the pull request path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved build reliability by ensuring queued changes are checked out from the correct location and revision.
  - Builds now handle working directories consistently across environments, reducing failures caused by path or directory differences.
  - Changes continue to support efficient checkout operations while maintaining consistent results for each build.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->