### PR TITLE
mruby-regexp: report every group of a duplicate name in `named_captures`

### DIFF
--- a/mrbgems/mruby-regexp/mrblib/regexp.rb
+++ b/mrbgems/mruby-regexp/mrblib/regexp.rb
@@ -4,14 +4,14 @@ class Regexp
   end
 
   # Return named captures hash: {"name" => [group_number, ...], ...}
-  # @named_captures holds the internal name -> group_number table, so a fresh
+  # @named_captures holds the internal name -> group list table, so a fresh
   # Hash is derived on every call and the caller cannot corrupt the table.
   def named_captures
     __check_initialized
     table = @named_captures
     return {} unless table
     result = {}
-    table.each { |name, group| result[name] = [group] }
+    table.each { |name, groups| result[name] = groups.dup }
     result
   end
 

--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -164,14 +164,25 @@ re_initialize(mrb_state *mrb, mrb_value self, mrb_value pattern, uint32_t flags)
   mrb_re_compile(mrb, pat, RSTRING_PTR(pattern), RSTRING_LEN(pattern), flags,
                  re_binary_string_p(pattern));
 
-  /* store named captures as hash */
+  /* Store named captures as a hash of name -> [group, ...]. A name may be
+     given to several groups, and each keeps its own number, so the table
+     carries them all; a name's slot in the hash is made by its first group
+     and later ones append to it, which is the order CRuby's named_captures
+     lists both the names and each name's groups in. */
   if (pat->num_named > 0) {
     mrb_value nc = mrb_hash_new_capa(mrb, pat->num_named);
+    mrb_iv_set(mrb, self, MRB_IVSYM(named_captures), nc);
+    int ai = mrb_gc_arena_save(mrb);
     for (uint16_t i = 0; i < pat->num_named; i++) {
       mrb_value name = mrb_str_new(mrb, pat->named_captures[i].name, pat->named_captures[i].name_len);
-      mrb_hash_set(mrb, nc, name, mrb_fixnum_value(pat->named_captures[i].group));
+      mrb_value groups = mrb_hash_get(mrb, nc, name);
+      if (mrb_nil_p(groups)) {
+        groups = mrb_ary_new_capa(mrb, 1);
+        mrb_hash_set(mrb, nc, name, groups);
+      }
+      mrb_ary_push(mrb, groups, mrb_fixnum_value(pat->named_captures[i].group));
+      mrb_gc_arena_restore(mrb, ai);
     }
-    mrb_iv_set(mrb, self, MRB_IVSYM(named_captures), nc);
   }
   else {
     /* The table belongs to the pattern compiled just above, so a pattern that

--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -1503,10 +1503,17 @@ matchdata_named_captures(mrb_state *mrb, mrb_value self)
   }
   if (!pat || pat->num_named == 0) return mrb_hash_new(mrb);
 
+  /* Each name gets the group re_name_to_group() picks for it, the same one
+     MatchData#[] reads, so a name given to several groups answers with the
+     one that took part in the match; walking the entries in order would
+     instead leave the value of whichever group the pattern spelled the name
+     on last. Duplicates re-resolve to the same group and overwrite with the
+     same value, and the first entry of each name fixes its key's position. */
   mrb_value result = mrb_hash_new_capa(mrb, pat->num_named);
   for (uint16_t i = 0; i < pat->num_named; i++) {
     mrb_value name = mrb_str_new(mrb, pat->named_captures[i].name, pat->named_captures[i].name_len);
-    int group = pat->named_captures[i].group;
+    int group = re_name_to_group(md->captures, md->num_captures, pat,
+                                 pat->named_captures[i].name, pat->named_captures[i].name_len);
     mrb_value val = mrb_nil_value();
     if (group >= 0 && group < md->num_captures) {
       int s = md->captures[group * 2];

--- a/mrbgems/mruby-regexp/test/match_data.rb
+++ b/mrbgems/mruby-regexp/test/match_data.rb
@@ -403,6 +403,16 @@ assert("MatchData#named_captures") do
   assert_equal "host", nc["b"]
 end
 
+assert("MatchData#named_captures - a name given to several groups") do
+  # The name appears once and reads the group MatchData#[] reads, the one
+  # that took part in the match, whichever side of the alternation it was
+  # spelled on; when none of the name's groups took part it reads nil.
+  re = /(?<a>x)|(?<a>b)/
+  assert_equal({"a" => "x"}, re.match("x").named_captures)
+  assert_equal({"a" => "b"}, re.match("b").named_captures)
+  assert_equal({"a" => nil}, /(?:(?<a>x)|(?<a>b))?c/.match("c").named_captures)
+end
+
 assert("MatchData#names") do
   assert_equal ["a", "b"], /(?<a>\w+)@(?<b>\w+)/.match("user@host").names
   assert_equal [], /\w+/.match("user").names

--- a/mrbgems/mruby-regexp/test/regexp_syntax.rb
+++ b/mrbgems/mruby-regexp/test/regexp_syntax.rb
@@ -1974,6 +1974,16 @@ assert("Regexp#named_captures") do
   re = /(?<a>x)/
   re.named_captures["a"] = 99
   assert_equal({"a" => [1]}, re.named_captures)
+
+  # a name given to several groups lists every group it was given to, and
+  # each group keeps its own number
+  assert_equal({"a" => [1, 2]}, /(?<a>x)|(?<a>b)/.named_captures)
+  assert_equal({"b" => [1], "a" => [2, 3]}, /(?<b>1)(?<a>x)|(?<a>b)/.named_captures)
+
+  # the group lists are copies too
+  re = /(?<a>x)|(?<a>b)/
+  re.named_captures["a"] << 99
+  assert_equal({"a" => [1, 2]}, re.named_captures)
 end
 
 assert("Regexp#names") do


### PR DESCRIPTION
## Summary

- A capture name the pattern gives to several groups kept only one of them: `Regexp#named_captures` reported the last group of the name, and `MatchData#named_captures` read whichever group the pattern spelled the name on last, `nil` when the match took another branch
- The name table now keeps every group of a name, so `Regexp#named_captures` answers `{"a" => [1, 2]}` for `(?<a>x)|(?<a>b)` as CRuby does
- `MatchData#named_captures` resolves each name through the lookup `MatchData#[]` uses, so the value is the last group of the name that took part in the match

## Changes

| File | What |
|---|---|
| `mrbgems/mruby-regexp/src/regexp.c` | the name table in `re_initialize()` keeps every group of a name; `matchdata_named_captures()` resolves each name through `re_name_to_group()` |
| `mrbgems/mruby-regexp/mrblib/regexp.rb` | `Regexp#named_captures` copies each group list instead of wrapping a single number |
| `mrbgems/mruby-regexp/test/regexp_syntax.rb` | duplicate-name rows in `Regexp#named_captures`, the group lists are copies |
| `mrbgems/mruby-regexp/test/match_data.rb` | `MatchData#named_captures - a name given to several groups` |

### The table keeps every group

`re_initialize()` stored the compiled pattern's name table as a hash of name to one group number, so registering a duplicate name overwrote the group before it. The hash now maps each name to the list of its groups in registration order, which is the order CRuby lists both the names and each name's groups in; a name's slot is made by its first group, so `Regexp#names` keeps reporting each name once, positioned as before. The table hash is rooted in the IV before the fill loop, and the loop restores the GC arena per iteration, since it now makes an array and a key copy beside each name string.

### The match reads the participating group

`MatchData#[]`, `#begin`, `#end`, `#values_at` and `\k<name>` in replacement strings already resolve a duplicated name to the last of its groups that took part in the match, through `re_name_to_group()` (d141e1c2b). `matchdata_named_captures()` was the one reader left walking the table entries in order and overwriting, so its answer for a duplicated name came from the pattern's spelling rather than from the match. It now resolves each entry's name through the same lookup; duplicates re-resolve to the same group and overwrite with the same value, and the first entry of a name fixes its key's position.

## Behaviour

Rows measured on the base binary, the branch binary and CRuby 4.0.6 (`03b6d3f889`), with `re = Regexp.new("(?<a>x)|(?<a>b)")`:

| Expression | before | after | CRuby |
|---|---|---|---|
| `re.named_captures` | `{"a" => [2]}` | `{"a" => [1, 2]}` | `{"a" => [1, 2]}` |
| `Regexp.new("(?<b>1)(?<a>x)\|(?<a>b)").named_captures` | `{"b" => [1], "a" => [3]}` | `{"b" => [1], "a" => [2, 3]}` | `{"b" => [1], "a" => [2, 3]}` |
| `re.names` | `["a"]` | `["a"]` | `["a"]` |
| `re.match("x").named_captures` | `{"a" => nil}` | `{"a" => "x"}` | `{"a" => "x"}` |
| `re.match("b").named_captures` | `{"a" => "b"}` | `{"a" => "b"}` | `{"a" => "b"}` |
| `Regexp.new("(?:(?<a>x)\|(?<a>b))?c").match("c").named_captures` | `{"a" => nil}` | `{"a" => nil}` | `{"a" => nil}` |
| `re.match("x")[:a]` | `"x"` | `"x"` | `"x"` |

The accessor rows stand where d141e1c2b put them. The `\k<name>` backreference side of the table is untouched: a reference to a duplicated name still compiles to the name's first group.

## Size

`.text` of `bin/mruby` for the five `build_config/ci/gcc-clang.rb` builds, `size -A`, base and this branch built at the same path from empty build directories:

| Build | master | this PR | delta |
|---|---|---|---|
| `bintest` | 1,112,774 | 1,113,094 | +320 |
| `ascii-ctype` | 1,107,414 | 1,107,734 | +320 |
| `byte-string` | 1,086,950 | 1,087,254 | +304 |
| `cxx_abi` | 1,099,901 | 1,100,221 | +320 |
| `full-debug` (-O0) | 1,916,470 | 1,916,646 | +176 |

The growth is the two rewritten functions: `nm -S` in `bintest` puts `re_initialize()` at 488 bytes where it was 380, and `matchdata_named_captures()` at 583 where it was 338, the participating-group lookup inlined into it.

## Testing

- `rake -m test` green with `build_config/ci/gcc-clang.rb`, all five builds (`bintest`, `cxx_abi`, `byte-string`, `ascii-ctype`, `full-debug`): 0 KO, 0 crashes, `bintest`'s binary tests included
- `rake -m test` green with the default config: 2574 tests, 2511 OK, 0 KO, 0 crashes, 63 skipped, none of them new
- both commits built and tested green on their own with the default config
- every row of the table above run on the base binary (`167c8f084`, `bintest`), the branch binary and CRuby 4.0.6

## Environment

<details>

| | |
|---|---|
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-30-generic x86_64 |
| CPU | AMD Ryzen 9 5950X (16C/32T) |
| C compiler | Homebrew clang 23.1.0 |
| binutils | GNU ld 2.47.20260726 |
| CRuby | 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM |
| base | `167c8f084` |

Compile lines for `mrbgems/mruby-regexp/src/regexp.c` as run, with `-MMD -c`, `-I`, `-o`, `-ffile-compilation-dir` and `-DMRBGEM_MRUBY_REGEXP_VERSION` dropped:

```console
# bintest
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -DMRB_GC_FIXED_ARENA -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK

# ascii-ctype
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -DMRB_USE_ASCII_CTYPE -DMRB_REGEXP_PARSE_DEPTH_LIMIT=512 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# byte-string
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# cxx_abi
clang -g -O3 -Wall -Wundef -Wwrite-strings -Wzero-length-array -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# full-debug
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Named captures can now be assigned to multiple groups, including across alternation branches.
  - Capture results correctly return the value from the participating group, or `nil` when none participate.
  - Named capture group lists are safely independent between calls.

- **Bug Fixes**
  - Improved handling of duplicate named groups in regular expression matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->