### PR TITLE
mruby-process: add Process.times and Process::Tms

### DIFF
--- a/build_config/ci/gcc-clang.rb
+++ b/build_config/ci/gcc-clang.rb
@@ -95,5 +95,14 @@ MRuby::Build.new('ascii-ctype') do |conf|
   # depth a pattern may nest is not what ASCII classification is about.
   conf.cc.defines << 'MRB_REGEXP_PARSE_DEPTH_LIMIT=512'
 
+  # mruby-process reads CPU time through getrusage(2) wherever the header
+  # probe finds <sys/resource.h>, which is every host this matrix runs on, so
+  # its times(2) fallback would otherwise compile nowhere in CI. Answering the
+  # probe no by hand is the override the port documents as standing on its
+  # own. It rides along here for the reason the depth limit above does: no
+  # extra pass, and CPU time accounting is not what ASCII classification is
+  # about.
+  conf.cc.defines << 'MRB_PROCESS_HAVE_GETRUSAGE=0'
+
   conf.enable_test
 end

--- a/mrbgems/mruby-process/README.md
+++ b/mrbgems/mruby-process/README.md
@@ -1,6 +1,6 @@
 # mruby-process
 
-`Process` module and `Process::Status` class for mruby.
+`Process` module and `Process::Status` / `Process::Tms` classes for mruby.
 
 ## Installation
 
@@ -11,7 +11,9 @@ Add the line below to your build configuration.
 ```
 
 It is part of the `stdlib-io` gembox, so `default.gembox` and `full-core.gembox`
-already include it.
+already include it. `mruby-signal` and `mruby-struct` come with it: the first
+owns the signal table `Process.kill` and `Process::Status#to_s` read names
+from, the second the `Struct` `Process::Tms` is one of.
 
 ## Implemented methods
 
@@ -24,6 +26,10 @@ already include it.
 | Process.waitpid                   | o             | sets `$?`; POSIX only, see below         |
 | Process.clock_gettime             | o             | seven units; symbolic clock ids          |
 | Process.clock_getres              | o             | takes `:hertz` too                       |
+| Process.times                     | o             | needs a build with Float, see below      |
+| Process::Tms                      | o             | a Struct, as in CRuby                    |
+| Process::Tms#utime, #stime        | o             |                                          |
+| Process::Tms#cutime, #cstime      | o             | reaped children only; 0 on Windows       |
 | Process::WNOHANG                  | o             | mruby's own value, not the platform's    |
 | Process::WUNTRACED                | o             | mruby's own value, not the platform's    |
 | Process::CLOCK_REALTIME           | o             | mruby's own value, not the platform's    |
@@ -63,6 +69,8 @@ other to provide its own feature set:
        v               v
    mruby-io       mruby-process ----> mruby-signal
        |               |                   |
+       |               +---> mruby-struct  |
+       |               |                   |
        v               v                   v
     io_hal         process_hal         signal_hal
        |               |                   |
@@ -75,9 +83,11 @@ other to provide its own feature set:
 `mrbgem.rake` names `mruby-io`, `mruby-errno` and `mruby-metaprog` as _test_
 dependencies only, for the reasons its comments give.
 
-`mruby-signal` is a real dependency: `Process.kill` takes a signal by name and
-`Process::Status#to_s` spells one out, and the signal table both need is
-`mruby-signal`'s, reached through `signal_hal.h`. Nothing runs the other way.
+`mruby-signal` and `mruby-struct` are the two real dependencies. `Process.kill`
+takes a signal by name and `Process::Status#to_s` spells one out, and the
+signal table both need is `mruby-signal`'s, reached through `signal_hal.h`;
+`Process.times` answers a `Process::Tms`, which is the `Struct` `mruby-struct`
+defines rather than a class written again here. Nothing runs the other way.
 `mruby-time` is not a dependency: the two gems ask the host the same question
 directly, so there is no table that could drift between them, and depending on
 it would pull a `Time` class into every build that only asked for I/O.
@@ -92,10 +102,11 @@ are dropped from the build.
 
 The HAL answers OS-level facts and performs OS-level operations, nothing more.
 No POSIX type or macro appears above it, and it knows nothing of `$?`, `$$`,
-blocks or `Process::Status`: everything Ruby promises lives in the common
-sources under `src/`, including which units a clock reading can be asked for
-in. What a signal is _called_ is `mruby-signal`'s to answer, and both callers
-reach its HAL directly.
+blocks, `Process::Status` or `Process::Tms`: everything Ruby promises lives in
+the common sources under `src/`, including which units a clock reading can be
+asked for in and the Floats a `Process::Tms` is built from. What a signal is
+_called_ is `mruby-signal`'s to answer, and both callers reach its HAL
+directly.
 
 ### Process::Status and mruby-io
 
@@ -144,6 +155,18 @@ constrains; this list is a map.
   `RangeError` in the common layer, where that can be said; `errno` has no
   spelling for it (`mrb_process_int_arg` in `src/process.c`,
   `status_initialize` in `src/status.c`).
+- `Process.times` crosses the HAL as four more clock readings, never as ticks
+  or a Float, and the conversion to Float happens once above it
+  (`mrb_process_times` in `include/process_hal.h`).
+- `Process.times` needs a build with Float, whole: it takes no unit argument
+  to name an Integer answer by, so `MRB_NO_FLOAT` raises `NotImplementedError`
+  rather than the method disappearing (`process_times` in `src/process.c`).
+- `Process::Tms` is the `Struct` CRuby's own is, with nothing left to decode
+  once built, so `Tms.new` stays public where `Process::Status.new` is
+  undefined (`mrb_mruby_process_gem_init` in `src/process.c`).
+- Whether `<sys/resource.h>` exists is asked of the compiler by `mrbgem.rake`
+  (`check_header`), not guessed inside the port; a target without it compiles
+  the `times(2)` fallback.
 
 ## Deviations from CRuby
 
@@ -165,6 +188,9 @@ constrains; this list is a map.
   and nothing more, so a status always reads as exited, and `Process.waitpid`
   fails for every process (`ENOSYS` for -1, `ECHILD` for a specific pid) until
   `Process.spawn` exists to make children; `ports/win/process_hal.c` says why.
+- On Windows `Process::Tms#cutime` and `#cstime` always read `0.0`: Win32
+  reports no reaped child's CPU time, and CRuby's Windows build answers the
+  same way.
 
 ## Adding a port
 

--- a/mrbgems/mruby-process/include/process_hal.h
+++ b/mrbgems/mruby-process/include/process_hal.h
@@ -9,15 +9,17 @@
 ** declared here.
 **
 ** The HAL answers OS-level facts and performs OS-level operations.  It knows
-** nothing about `Process::Status`, `$?`, `$$`, blocks or any other Ruby
-** notion: those belong to the common sources under src/.  In the other
-** direction, no platform type or macro (`pid_t`, `WIFEXITED`, `SIGTERM`,
-** `WNOHANG`, `CLOCK_MONOTONIC`, ...) crosses into the common layer: process
-** and signal numbers travel as `mrb_int`, wait options as the
-** MRB_PROCESS_WAIT_* bits below, a decoded wait status as
-** `mrb_process_status`, a clock as one of the `mrb_process_clock_id` values
-** and a time it reported as `mrb_process_clock_time`, whose two fields are
-** `int64_t` rather than `mrb_int` for the reason given where it is defined.
+** nothing about `Process::Status`, `Process::Tms`, `$?`, `$$`, blocks or any
+** other Ruby notion: those belong to the common sources under src/.  In the
+** other direction, no platform type or macro (`pid_t`, `WIFEXITED`,
+** `SIGTERM`, `WNOHANG`, `CLOCK_MONOTONIC`, `clock_t`, ...) crosses into the
+** common layer: process and signal numbers travel as `mrb_int`, wait options
+** as the MRB_PROCESS_WAIT_* bits below, a decoded wait status as
+** `mrb_process_status`, a clock as one of the `mrb_process_clock_id` values,
+** a time it reported as `mrb_process_clock_time`, whose two fields are
+** `int64_t` rather than `mrb_int` for the reason given where it is defined,
+** and the four CPU time totals behind `Process.times` as `mrb_process_times`,
+** four more `mrb_process_clock_time` readings rather than platform ticks.
 **
 ** What a signal is *called* is not asked here at all.  mruby-signal owns
 ** that table, and both `Process.kill` and `Process::Status#to_s` reach it
@@ -133,6 +135,25 @@ typedef struct mrb_process_clock_time {
 #endif
 
 /*
+ * CPU time totals
+ *
+ * What Process.times reports: how much CPU time this process, and the
+ * children it has already reaped, have spent in user and kernel mode.  Each
+ * of the four travels the way a clock reading does, as an
+ * mrb_process_clock_time, for the reasons given above it, plus one of its
+ * own: mrb_float would not compile under MRB_NO_FLOAT.  Turning the four
+ * into a Ruby Float, and building the Process::Tms they are answered as, is
+ * Process.times's job once every port has answered the same shape; a port
+ * is asked for nothing beyond the four readings themselves.
+ */
+typedef struct mrb_process_times {
+  mrb_process_clock_time utime;   /* user CPU time this process has used */
+  mrb_process_clock_time stime;   /* system CPU time this process has used */
+  mrb_process_clock_time cutime;  /* user CPU time of reaped children */
+  mrb_process_clock_time cstime;  /* system CPU time of reaped children */
+} mrb_process_times;
+
+/*
  * HAL Interface Functions
  */
 
@@ -227,6 +248,21 @@ int mrb_hal_process_clock_gettime(mrb_state *mrb, mrb_int clock_id,
  */
 int mrb_hal_process_clock_getres(mrb_state *mrb, mrb_int clock_id,
                                  mrb_process_clock_time *t);
+
+/*
+ * Read the CPU time totals above.
+ *
+ * cutime and cstime cover only waited-for terminated children, whichever
+ * wait(2)/waitpid(2) call reaped them: Process.wait, Process.waitpid, or one
+ * this gem did not itself make (mruby-io's own reap on IO.popen(...).close,
+ * say). A child still running, or one never waited for, is not in them,
+ * which is what POSIX's times(2) reports too. A platform with no notion of
+ * a child's CPU time answers 0 for both.
+ *
+ * @param t  out: the four readings
+ * @return 0 on success, -1 on error (sets errno)
+ */
+int mrb_hal_process_times(mrb_state *mrb, mrb_process_times *t);
 
 /*
  * HAL Initialization/Finalization

--- a/mrbgems/mruby-process/mrbgem.rake
+++ b/mrbgems/mruby-process/mrbgem.rake
@@ -1,12 +1,17 @@
 MRuby::Gem::Specification.new('mruby-process') do |spec|
   spec.license = 'MIT'
   spec.authors = 'mruby developers'
-  spec.summary = 'Process module and Process::Status class'
+  spec.summary = 'Process module and Process::Status / Process::Tms classes'
 
   # `Process.kill(:TERM, pid)` takes a signal by name and `Process::Status#to_s`
   # spells one out, so both need the platform's signal table.  mruby-signal owns
   # it; this gem reaches it through signal_hal.h rather than keeping a copy.
   spec.add_dependency 'mruby-signal', core: 'mruby-signal'
+
+  # `Process.times` answers a `Process::Tms`, which is a Struct in CRuby and
+  # is one here too rather than a hand-written class that reimplements what a
+  # Struct already does: the members, `#to_a`, `#==` and `#inspect`.
+  spec.add_dependency 'mruby-struct', core: 'mruby-struct'
 
   # mruby-process needs no I/O of its own.  The tests do: waiting on a child
   # is only testable with a child, and IO.popen is how one is made.  The
@@ -22,4 +27,13 @@ MRuby::Gem::Specification.new('mruby-process') do |spec|
   # Asking a Process::Status what instance_variables it hands out needs the
   # gem that defines Object#instance_variables in the first place.
   spec.add_test_dependency 'mruby-metaprog', core: 'mruby-metaprog'
+
+  # `Process.times` reads CPU time through getrusage(2), whose <sys/resource.h>
+  # is an XSI extension rather than base POSIX.  Whether a target has it is a
+  # question the port cannot ask from inside a `#if`, since finding out means
+  # reading the header, so it is asked here and answered to the port as
+  # HAVE_SYS_RESOURCE_H.  A target without it falls back to times(2).
+  spec.build_settings do |spec|
+    spec.cc.defines << 'HAVE_SYS_RESOURCE_H' if spec.cc.check_header('sys/resource.h')
+  end
 end

--- a/mrbgems/mruby-process/ports/posix/process_hal.c
+++ b/mrbgems/mruby-process/ports/posix/process_hal.c
@@ -5,7 +5,9 @@
 **
 ** POSIX implementation of the process HAL using getpid(2), getppid(2),
 ** waitpid(2), kill(2), clock_gettime(2) and clock_getres(2), falling back to
-** gettimeofday(2) where the host has no POSIX clocks.
+** gettimeofday(2) where the host has no POSIX clocks, and getrusage(2) for
+** the CPU time totals behind Process.times, falling back to times(2) scaled
+** by sysconf(_SC_CLK_TCK) where the host has no getrusage(2).
 ** Supported platforms: Linux, macOS, BSD, Unix
 */
 
@@ -84,6 +86,35 @@
 # else
 #  define MRB_PROCESS_HAVE_WCOREDUMP 0
 # endif
+#endif
+
+/* Whether this host has getrusage(2), which is how Process.times reads CPU
+   time here: RUSAGE_SELF and RUSAGE_CHILDREN are both XSI extensions
+   (SUSv2), present on Linux, macOS and the BSDs but not guaranteed by base
+   POSIX.1, so a host missing either falls back to times(2).
+
+   <sys/resource.h> is part of that same XSI extension; whether it is there
+   is asked of the compiler by the gem's mrbgem.rake, for the reason given
+   there, and answered as HAVE_SYS_RESOURCE_H.
+   Overriding MRB_PROCESS_HAVE_GETRUSAGE to 1 asserts the call is there,
+   which it can only be where the header is, so HAVE_SYS_RESOURCE_H goes
+   with such an override; overriding it to 0 stands on its own. */
+#ifdef HAVE_SYS_RESOURCE_H
+# include <sys/resource.h>
+#endif
+#ifndef MRB_PROCESS_HAVE_GETRUSAGE
+# if defined(RUSAGE_SELF) && defined(RUSAGE_CHILDREN)
+#  define MRB_PROCESS_HAVE_GETRUSAGE 1
+# else
+#  define MRB_PROCESS_HAVE_GETRUSAGE 0
+# endif
+#endif
+
+/* times(2) is only reached where getrusage(2) is not, so <sys/times.h> is
+   only asked for there: a host that has the XSI call needs nothing from
+   this header, and is not made to have it. */
+#if !MRB_PROCESS_HAVE_GETRUSAGE
+# include <sys/times.h>
 #endif
 
 /* An mrb_int is wider than a pid_t where mrb_int is 64-bit, so a pid from
@@ -257,7 +288,7 @@ mrb_hal_process_clock_gettime(mrb_state *mrb, mrb_int clock_id,
   return 0;
 #else
   /* Without POSIX clocks the wall clock is the only one there is, and
-     gettimeofday(2) reads it to the microsecond. */
+     gettimeofday(2) answers it in microsecond units. */
   struct timeval tv;
   (void)mrb;
 
@@ -305,6 +336,92 @@ mrb_hal_process_clock_getres(mrb_state *mrb, mrb_int clock_id,
   return 0;
 #endif
 }
+
+/*
+ * CPU Time Totals
+ */
+
+#if MRB_PROCESS_HAVE_GETRUSAGE
+
+/* Convert a struct timeval, as getrusage(2) reports CPU time in, into an
+   mrb_process_clock_time.  tv_usec is always in [0, 1000000), so unlike the
+   FILETIME split on Windows there is nothing here to carry downwards. */
+static void
+timeval_to_clock_time(mrb_process_clock_time *t, const struct timeval *tv)
+{
+  t->sec = (int64_t)tv->tv_sec;
+  t->nsec = (int64_t)tv->tv_usec * 1000;
+}
+
+int
+mrb_hal_process_times(mrb_state *mrb, mrb_process_times *t)
+{
+  struct rusage self, children;
+  (void)mrb;
+
+  /* RUSAGE_SELF is this process, summed across every thread that has ever
+     run in it; RUSAGE_CHILDREN is every child this process has reaped via
+     wait(2)/waitpid(2), summed the same way, which is exactly the
+     utime/stime and cutime/cstime split Process.times reports. Both report
+     CPU time as a struct timeval with microsecond units, with no
+     sysconf(_SC_CLK_TCK) scale factor to look up. */
+  if (getrusage(RUSAGE_SELF, &self) != 0) return -1;
+  if (getrusage(RUSAGE_CHILDREN, &children) != 0) return -1;
+
+  timeval_to_clock_time(&t->utime,  &self.ru_utime);
+  timeval_to_clock_time(&t->stime,  &self.ru_stime);
+  timeval_to_clock_time(&t->cutime, &children.ru_utime);
+  timeval_to_clock_time(&t->cstime, &children.ru_stime);
+  return 0;
+}
+
+#else /* !MRB_PROCESS_HAVE_GETRUSAGE */
+
+/* Split a count of times(2) ticks into seconds and nanoseconds. */
+static void
+ticks_to_clock_time(mrb_process_clock_time *t, clock_t ticks, long clk_tck)
+{
+  int64_t v = (int64_t)ticks;
+
+  t->sec = v / (int64_t)clk_tck;
+  t->nsec = (v % (int64_t)clk_tck) * NSEC_PER_SEC / (int64_t)clk_tck;
+}
+
+int
+mrb_hal_process_times(mrb_state *mrb, mrb_process_times *t)
+{
+  struct tms tm;
+  long clk_tck;
+  (void)mrb;
+
+  /* Where getrusage(2) is unavailable, times(2) is the POSIX.1 baseline:
+     the same four totals, as clock_t ticks to be scaled by _SC_CLK_TCK.
+
+     Its return value is elapsed real time, not an error indicator: it
+     passes through (clock_t)-1 legitimately as that counter wraps, and
+     POSIX leaves errno after a successful call unspecified, so a failure
+     cannot be told from one portably. The tms fields are all this reading
+     needs, so the return value is ignored, as CRuby's fallback ignores it. */
+  (void)times(&tm);
+
+  /* Ticks per second. POSIX guarantees _SC_CLK_TCK an answer; a
+     non-positive one is a host declining to say. CLOCKS_PER_SEC is
+     clock(3)'s unit, not always times(2)'s, so declining is reported
+     rather than guessed past. */
+  clk_tck = sysconf(_SC_CLK_TCK);
+  if (clk_tck <= 0) {
+    errno = EINVAL;
+    return -1;
+  }
+
+  ticks_to_clock_time(&t->utime,  tm.tms_utime,  clk_tck);
+  ticks_to_clock_time(&t->stime,  tm.tms_stime,  clk_tck);
+  ticks_to_clock_time(&t->cutime, tm.tms_cutime, clk_tck);
+  ticks_to_clock_time(&t->cstime, tm.tms_cstime, clk_tck);
+  return 0;
+}
+
+#endif /* MRB_PROCESS_HAVE_GETRUSAGE */
 
 /*
  * HAL Initialization/Finalization

--- a/mrbgems/mruby-process/ports/win/process_hal.c
+++ b/mrbgems/mruby-process/ports/win/process_hal.c
@@ -21,11 +21,15 @@
 **     `IO.popen` already gives the `Process::Status` it builds on this
 **     platform, so a decoded status always reads as exited;
 **   - only `KILL` and `TERM` can be delivered, both as TerminateProcess(),
-**     and signal 0 asks whether the process can be opened at all.
+**     and signal 0 asks whether the process can be opened at all;
+**   - `Process.times`' cutime and cstime read 0, for the reason given at
+**     mrb_hal_process_times() below.
 **
 ** The clocks are the one part Win32 answers in full: the wall clock as a
 ** FILETIME, the monotonic one from the performance counter, and the two CPU
-** times from GetProcessTimes() and GetThreadTimes().
+** times from GetProcessTimes() and GetThreadTimes(); the same
+** GetProcessTimes() call also answers this process's own share of
+** Process.times.
 */
 
 #include <mruby.h>
@@ -444,10 +448,12 @@ monotonic_read(mrb_process_clock_time *t)
   return 0;
 }
 
-/* The CPU time a process or a thread has spent, as the sum of the kernel and
-   user halves Win32 reports it in. */
+/* The kernel and user FILETIMEs behind a process's or a thread's CPU time,
+   as raw FILETIME ticks: cpu_time() below sums the two into the one number
+   MRB_PROCESS_CLOCK_PROCESS_CPUTIME/THREAD_CPUTIME reports, and
+   mrb_hal_process_times() keeps them apart as utime and stime. */
 static int
-cpu_time(mrb_bool thread, mrb_process_clock_time *t)
+process_times_raw(mrb_bool thread, int64_t *kernel_ticks, int64_t *user_ticks)
 {
   FILETIME creation, exit, kernel, user;
   BOOL ok;
@@ -462,8 +468,20 @@ cpu_time(mrb_bool thread, mrb_process_clock_time *t)
     set_errno_from_win32(GetLastError());
     return -1;
   }
-  clock_time_from_ticks(t, (int64_t)(filetime_to_u64(&kernel) +
-                                     filetime_to_u64(&user)));
+  *kernel_ticks = (int64_t)filetime_to_u64(&kernel);
+  *user_ticks = (int64_t)filetime_to_u64(&user);
+  return 0;
+}
+
+/* The CPU time a process or a thread has spent, as the sum of the kernel and
+   user halves Win32 reports it in. */
+static int
+cpu_time(mrb_bool thread, mrb_process_clock_time *t)
+{
+  int64_t kernel_ticks, user_ticks;
+
+  if (process_times_raw(thread, &kernel_ticks, &user_ticks) != 0) return -1;
+  clock_time_from_ticks(t, kernel_ticks + user_ticks);
   return 0;
 }
 
@@ -601,6 +619,31 @@ mrb_hal_process_clock_getres(mrb_state *mrb, mrb_int clock_id,
     return -1;
   }
   return c->resolution(t);
+}
+
+/*
+ * CPU Time Totals
+ */
+
+int
+mrb_hal_process_times(mrb_state *mrb, mrb_process_times *t)
+{
+  int64_t kernel_ticks, user_ticks;
+  (void)mrb;
+
+  if (process_times_raw(FALSE, &kernel_ticks, &user_ticks) != 0) return -1;
+  clock_time_from_ticks(&t->utime, user_ticks);
+  clock_time_from_ticks(&t->stime, kernel_ticks);
+
+  /* Win32 has no call that answers a reaped child's CPU time, and this port
+     creates no children yet in any case (Process.spawn is a separate
+     change), so there is nothing to add up.  0 says exactly that: nothing
+     has been added, not that nothing was asked. */
+  t->cutime.sec = 0;
+  t->cutime.nsec = 0;
+  t->cstime.sec = 0;
+  t->cstime.nsec = 0;
+  return 0;
 }
 
 /*

--- a/mrbgems/mruby-process/src/process.c
+++ b/mrbgems/mruby-process/src/process.c
@@ -11,7 +11,9 @@
 
 #include <mruby.h>
 #include <mruby/array.h>
+#include <mruby/class.h>
 #include <mruby/error.h>
+#include <mruby/proc.h>
 #include <mruby/string.h>
 #include <mruby/variable.h>
 #ifdef MRB_USE_BIGINT
@@ -758,6 +760,48 @@ process_clock_getres(mrb_state *mrb, mrb_value self)
   return clock_unit_convert(mrb, u, &t, TRUE);
 }
 
+/*
+ * call-seq:
+ *   Process.times -> a Process::Tms
+ *
+ * How much CPU time this process, and its waited-for terminated children,
+ * have used, as a Process::Tms holding four Float numbers of seconds;
+ * Process::Tms says what each of the four members covers.
+ *
+ * Answers only in Float, as CRuby does, there being no argument to name an
+ * Integer unit by the way Process.clock_gettime has one, so a build without
+ * Float raises NotImplementedError rather than answering something narrower.
+ */
+static mrb_value
+process_times(mrb_state *mrb, mrb_value self)
+{
+#ifndef MRB_NO_FLOAT
+  /* The class gem_init captured into this method's environment, not
+     whatever the Tms constant holds now: CRuby's Process.times builds on
+     rb_cProcessTms the same way, so reassigning Process::Tms does not
+     change what this answers. */
+  struct RClass *tms = mrb_class_ptr(mrb_proc_cfunc_env_get(mrb, 0));
+  mrb_process_times pt;
+  mrb_value argv[4];
+
+  if (mrb_hal_process_times(mrb, &pt) != 0) {
+    /* Names no object, as a wait or a kill does not either: nothing this
+       call was working on failed, the reading itself did. */
+    mrb_sys_fail(mrb, NULL);
+  }
+  argv[0] = clock_float_result(mrb, &pt.utime,  1.0);
+  argv[1] = clock_float_result(mrb, &pt.stime,  1.0);
+  argv[2] = clock_float_result(mrb, &pt.cutime, 1.0);
+  argv[3] = clock_float_result(mrb, &pt.cstime, 1.0);
+  /* The four members go to Struct's #initialize in the order gem_init gave
+     them to Struct.new. */
+  return mrb_obj_new(mrb, tms, 4, argv);
+#else
+  mrb_raise(mrb, E_NOTIMP_ERROR, "Process.times needs a build with Float");
+  return mrb_nil_value(); /* not reached */
+#endif
+}
+
 void
 mrb_mruby_process_gem_init(mrb_state *mrb)
 {
@@ -796,6 +840,43 @@ mrb_mruby_process_gem_init(mrb_state *mrb)
   mrb_define_module_function_id(mrb, process, MRB_SYM(wait2),    process_waitpid2, MRB_ARGS_OPT(2));
   mrb_define_module_function_id(mrb, process, MRB_SYM(clock_gettime), process_clock_gettime, MRB_ARGS_ARG(1, 1));
   mrb_define_module_function_id(mrb, process, MRB_SYM(clock_getres),  process_clock_getres,  MRB_ARGS_ARG(1, 1));
+
+  /* Process::Tms, what Process.times answers with: a Struct of the four
+     members, as CRuby's own Process::Tms is, so a Tms answers to everything
+     a Struct does.  #utime and #stime are this process's own user and
+     system CPU time, in seconds; #cutime and #cstime total the same over
+     every terminated child this process has waited for so far.
+
+     The class is made through the same Struct.new Ruby source would call,
+     but from here rather than from mrblib, so that the created class itself
+     can ride into Process.times as cfunc environment: Process.times then
+     keeps answering instances of this class even after the Tms constant is
+     reassigned, as CRuby's does by holding it in rb_cProcessTms.
+     mrb_const_set is what names the anonymous Struct class "Process::Tms";
+     mrb_define_const_id skips naming.  The two raw defines lay the method
+     the way mrb_define_module_function_id would: public on the module's
+     singleton class, private as an instance method. */
+  {
+    struct RClass *struct_cls = mrb_class_get_id(mrb, MRB_SYM(Struct));
+    mrb_value tms = mrb_funcall_id(mrb, mrb_obj_value(struct_cls), MRB_SYM(new), 4,
+                                   mrb_symbol_value(MRB_SYM(utime)),
+                                   mrb_symbol_value(MRB_SYM(stime)),
+                                   mrb_symbol_value(MRB_SYM(cutime)),
+                                   mrb_symbol_value(MRB_SYM(cstime)));
+    struct RProc *times_proc = mrb_proc_new_cfunc_with_env(mrb, process_times, 1, &tms);
+    mrb_method_t m;
+
+    /* mrb_define_module_function_id would carry MRB_ARGS_NONE() for us; a
+       raw proc method checks nothing until the aspec is set on the proc. */
+    mrb_proc_set_cfunc_aspec(times_proc, MRB_ARGS_NONE());
+
+    mrb_const_set(mrb, mrb_obj_value(process), MRB_SYM(Tms), tms);
+    MRB_METHOD_FROM_PROC(m, times_proc);
+    mrb_define_method_raw(mrb, mrb_class_ptr(mrb_singleton_class(mrb, mrb_obj_value(process))),
+                          MRB_SYM(times), m);
+    MRB_METHOD_SET_VISIBILITY(m, MRB_METHOD_PRIVATE_FL);
+    mrb_define_method_raw(mrb, process, MRB_SYM(times), m);
+  }
 
   mrb_process_status_init(mrb, process);
 

--- a/mrbgems/mruby-process/test/process.rb
+++ b/mrbgems/mruby-process/test/process.rb
@@ -89,7 +89,8 @@ module ProcessTestUtil
     nil
   end
 
-  # Whether this build has a Float for the float units to answer in.
+  # Whether this build has a Float for the float units and Process.times to
+  # answer in.
   def self.float?
     Object.const_defined?(:Float)
   end
@@ -608,6 +609,128 @@ assert('$? after IO.popen') do
   assert_true $?.success?
 end
 
+
+assert('Process.times') do
+  skip "this build has no Float" unless ProcessTestUtil.float?
+
+  t = Process.times
+  assert_kind_of Process::Tms, t
+  [t.utime, t.stime, t.cutime, t.cstime].each do |v|
+    assert_kind_of Float, v
+    assert_operator v, :>=, 0.0
+  end
+end
+
+assert('Process.times keeps the class Tms was created as') do
+  skip "this build has no Float" unless ProcessTestUtil.float?
+
+  original = Process::Tms
+  Process.__send__(:remove_const, :Tms)
+  Process::Tms = Struct.new(:other)
+  begin
+    t = Process.times
+    assert_true t.class.equal?(original)
+    assert_false t.class.equal?(Process::Tms)
+  ensure
+    Process.__send__(:remove_const, :Tms)
+    Process::Tms = original
+  end
+end
+
+assert('Process.times counts CPU time this process spends') do
+  # utime or stime, at least one of them, is worth more after genuine CPU
+  # work than before it; which of the two the work lands in is the
+  # scheduler's to say. A busy loop is read as user time on every platform
+  # this gem supports, so utime alone would do, but stime is read too in
+  # case a host charges some of it to system time.
+  #
+  # The CLOCK_MONOTONIC test below reads two clocks back to back with no
+  # work forced between them, so it can only ask for a reading that is not
+  # smaller. This one drives a busy loop between the two readings, so a
+  # strict increase is asked for: three million iterations burn far more CPU
+  # than even the coarsest clock this gem falls back to (a times(2) tick,
+  # usually 10ms) can fail to notice. A HAL bug that pins the reading at
+  # zero, or anywhere else it never moves from, has to fail this one where
+  # >= would have let it pass.
+  skip "this build has no Float" unless ProcessTestUtil.float?
+
+  before = Process.times
+  n = 0
+  n += 1 while n < 3_000_000
+  after = Process.times
+
+  assert_operator after.utime + after.stime, :>, before.utime + before.stime
+end
+
+assert('Process.times without a Float') do
+  skip "this build has a Float" if ProcessTestUtil.float?
+
+  assert_raise(NotImplementedError) { Process.times }
+end
+
+assert('Process.times takes no argument') do
+  # The count is checked by the VM before the C function runs, so this holds
+  # on every build: without a Float the bare call above raises
+  # NotImplementedError, but an argument still raises ArgumentError first.
+  assert_raise(ArgumentError) { Process.times(1) }
+  assert_raise(ArgumentError) { Process.times(1, 2) }
+end
+
+assert('Process.times is laid as a module function') do
+  # The method is defined by two raw defines from a proc rather than by
+  # mrb_define_module_function_id, so the shape that call would have given,
+  # public on the singleton and private as an instance method, is pinned
+  # here rather than assumed.
+  assert_true Process.respond_to?(:times)
+  assert_false Process.public_instance_methods.include?(:times)
+  assert_true Process.private_instance_methods.include?(:times)
+end
+
+assert('Process.times and reaped children') do
+  # cutime and cstime total the CPU time of children this process has
+  # reaped, and nothing else: a child still running, or one that has
+  # already exited but sits unwaited as a zombie, does not contribute yet.
+  # "exit 0" burns too little CPU to tell that apart from a HAL that always
+  # answers 0, so this spawns a child that spins for a measurable stretch,
+  # confirms it is not yet counted while unreaped, and that reaping it
+  # through waitpid makes cutime + cstime increase strictly.
+  skip "this build has no Float" unless ProcessTestUtil.float?
+  skip ProcessTestUtil.child_reason if ProcessTestUtil.child_reason
+
+  baseline = Process.times
+  io = ProcessTestUtil.spawn('i=0; while [ "$i" -lt 200000 ]; do i=$((i+1)); done; exit 0')
+  skip "IO.popen is not available" unless io
+
+  io.read
+  before = Process.times
+  assert_equal baseline.cutime, before.cutime
+  assert_equal baseline.cstime, before.cstime
+
+  Process.waitpid(io.pid)
+  io.close
+  after = Process.times
+
+  assert_kind_of Float, after.cutime
+  assert_kind_of Float, after.cstime
+  assert_operator after.cutime + after.cstime, :>, before.cutime + before.cstime
+end
+
+# Process::Tms is a Struct, so what a Struct answers (#==, #inspect,
+# #initialize's arity, and the rest) is mruby-struct's to test, and is not
+# repeated here. What is this gem's is that Process::Tms is that Struct, with
+# those four members in that order, under that name.
+assert('Process::Tms') do
+  t = Process::Tms.new(1, 2, 3, 4)
+  assert_kind_of Struct, t
+  assert_equal [:utime, :stime, :cutime, :cstime], Process::Tms.members
+  assert_equal [1, 2, 3, 4], [t.utime, t.stime, t.cutime, t.cstime]
+  assert_equal [1, 2, 3, 4], t.to_a
+  # Built with plain Integers rather than the Floats Process.times always
+  # gives it, on purpose: a Struct stores whatever it is given without asking
+  # whether it is a Float, which also makes this read the same under
+  # MRB_NO_FLOAT, where a Float literal is not one.
+  assert_equal "#<struct Process::Tms utime=1, stime=2, cutime=3, cstime=4>", t.inspect
+end
 
 assert('Process::CLOCK_REALTIME and the rest') do
   # Four distinct ids, all defined on every platform, so that a program


### PR DESCRIPTION
## Summary

`Process.times` answers the four CPU time totals a process has accumulated, as the `Process::Tms` CRuby answers it with. One HAL entry point asks a port for four readings and for nothing else; what unit they are answered in, and what a build without `Float` does instead, is settled above the boundary.

## Changes

| File                                              | What                                                                                           |
| ------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
| `mrbgems/mruby-process/include/process_hal.h`     | adds `mrb_process_times` and `mrb_hal_process_times()`                                         |
| `mrbgems/mruby-process/src/process.c`             | adds `Process.times`; creates `Process::Tms` at gem init                                       |
| `mrbgems/mruby-process/ports/posix/process_hal.c` | implements it over `getrusage(2)`, falling back to `times(2)` scaled by `sysconf(_SC_CLK_TCK)` |
| `mrbgems/mruby-process/ports/win/process_hal.c`   | implements it over `GetProcessTimes()`                                                         |
| `mrbgems/mruby-process/mrbgem.rake`               | depends on `mruby-struct`; asks the compiler for `<sys/resource.h>`                            |
| `mrbgems/mruby-process/test/process.rb`           | tests for both, including the `Float`-less paths and the class `Process.times` keeps           |
| `mrbgems/mruby-process/README.md`                 | records the decisions below and why each fell where it did                                     |
| `build_config/ci/gcc-clang.rb`                    | the `ascii-ctype` build answers the `getrusage(2)` probe no, keeping the fallback compiled     |

### The HAL reports readings, and nothing about units

`mrb_hal_process_times()` answers four `mrb_process_clock_time`, the same seconds-and-nanoseconds pair a clock reading already crosses the boundary as. No platform type crosses with them: a `struct timeval` from `getrusage(2)`, a `clock_t` from `times(2)` and a `FILETIME` from `GetProcessTimes()` all stop at the port, and so does the scale factor each needs.

That a port can read CPU time no finer than a microsecond, or than a clock tick, is not a reason to narrow what crosses; it only means the low bits of `nsec` are not always populated. Turning the four into the Floats CRuby answers with happens once, in `Process.times` itself, through the same conversion `Process.clock_gettime`'s `:float_second` already goes through.

POSIX reads `getrusage(RUSAGE_SELF)` for `utime` and `stime` and `getrusage(RUSAGE_CHILDREN)` for `cutime` and `cstime`. Windows answers `0` for the latter two: no Win32 call reports a reaped child's CPU time, and this port creates no children in any case, which is what CRuby's own Windows build answers there too.

### `Process::Tms` is a `Struct`

CRuby's `Process::Tms` is a `Struct`, and everything this one has to do, four members read back as given, `#to_a`, `#members`, `#==` between two of the same class, an `#inspect` that spells the members out, is what a `Struct` already does. Writing them again in C would be a second copy of `mruby-struct`'s, one that answers slightly less (`#[]`, `#each`, `#to_h`, the writers) and could drift from it.

The runtime dependency this buys costs nothing: no file under `build_config/` takes `mruby-process` without already carrying `mruby-struct` by way of `stdlib-ext`. The class is created at gem init through the same `Struct.new` call Ruby source would make, and assigning it to the constant with `mrb_const_set` is what names it, so `#<struct Process::Tms utime=...>` matches CRuby down to the spelling.

The created class also rides into `Process.times` as cfunc environment, rather than being read back from the `Tms` constant on each call: CRuby holds the class it created in `rb_cProcessTms` and builds on that directly, so reassigning `Process::Tms` changes what the constant answers and not what `Process.times` builds, and a test pins the same promise here. The method itself is laid the way `mrb_define_module_function_id` lays one, public on the module's singleton class and private as an instance method, just from a proc carrying the environment and the `MRB_ARGS_NONE()` aspec such a define would have set: a raw proc method checks no argument count until `mrb_proc_set_cfunc_aspec()` puts one on the proc, so without it `Process.times(1)` would have reached the C function instead of raising `ArgumentError`. A test pins the refusal, and runs on a `Float`-less build too, the VM checking the count before the C function decides it has no `Float` to answer with. The laying is pinned the same way: a test reads it back through `respond_to?` and `public_instance_methods` / `private_instance_methods`.

Unlike `Process::Status`, a `Tms` has nothing left to decode once built, which is what makes a class of its own have nothing to do here.

### Whether `<sys/resource.h>` is there is settled by the build

The header is an XSI extension rather than base POSIX, so a target either has it or does not, and a `#if` around the `#include` cannot tell which: finding out means reading the header, which is the very thing the guard would be deciding whether to do. Every other capability this port tests for is a macro that a header it can always include either defines or does not, and those stay in the port. This one leaves it, to `mrbgem.rake`, which asks the compiler and answers the port as `HAVE_SYS_RESOURCE_H`:

```ruby
spec.build_settings do |spec|
  spec.cc.defines << 'HAVE_SYS_RESOURCE_H' if spec.cc.check_header('sys/resource.h')
end
```

A target without it compiles the `times(2)` path, and is not asked for `<sys/times.h>` where it has the XSI call. The `ascii-ctype` build of `build_config/ci/gcc-clang.rb` answers the probe no by the override the port documents, so the fallback is a path CI compiles and runs rather than one only a host without the XSI header would reach.

### A build without `Float`

`Process.times` is the first reading here with no Integer unit to fall back to: CRuby answers it in Float seconds and takes no unit argument at all. `MRB_NO_FLOAT` raises `NotImplementedError`, as it already does for a float clock unit, rather than the method disappearing. `Process::Tms` itself needs no such guard, a `Struct` storing whatever it is given without asking whether it is a Float.

## Behaviour

```console
$ bin/mruby -e 'p Process.times'
#<struct Process::Tms utime=0.0, stime=0.00079, cutime=0.0, cstime=0.0>
```

`Process.times` keeps answering instances of the class the gem created, as CRuby's does through `rb_cProcessTms`:

```console
$ bin/mruby -e 'original = Process::Tms
Process.send(:remove_const, :Tms)
Process::Tms = Struct.new(:other)
p Process.times.class.equal?(original)'
true
```

Under `MRB_NO_FLOAT`, `Process.times` raises `NotImplementedError`; `Process::Tms` is still defined and still builds.

## Size

`.text` of `bin/mruby` across the five `build_config/ci/gcc-clang.rb` builds, base `167c8f084`:

| build              | master    | this PR   | delta  |
| ------------------ | --------- | --------- | ------ |
| bintest            | 1,112,774 | 1,113,398 | +624   |
| ascii-ctype        | 1,107,414 | 1,108,198 | +784   |
| byte-string        | 1,086,950 | 1,087,574 | +624   |
| cxx_abi            | 1,099,901 | 1,100,525 | +624   |
| full-debug (`-O0`) | 1,916,470 | 1,917,958 | +1,488 |

By object, in the `bintest` build: `src/process.o` `.text` +448 and `ports/posix/process_hal.o` `.text` +183, summing to +631 against the binary's +624, the difference being link-time padding. `gem_init.o` does not move: `Process::Tms` is created by the gem's C init, so no mrblib bytecode joins its `.rodata`. The `ascii-ctype` row is measured with each side's own config, so its wider delta is the `times(2)` fallback this PR turns on there: `process_hal.o` `.text` moves +341 instead of +183.

Every build above already carries `mruby-struct` by way of `stdlib-ext`, so those deltas price `Process.times` alone. A config taking `conf.gem core: 'mruby-process'` and nothing else pulls `mruby-struct` in through the new dependency, and pays for it once:

| build                                                      | master  | this PR | delta  |
| ---------------------------------------------------------- | ------- | ------- | ------ |
| minimal (`mruby-bin-mrbc`, `mruby-bin-mruby`, the gem) | 651,329 | 658,934 | +7,605 |

Of the +7,605, `mruby-struct` itself is 6,907 (`src/struct.o` 6,870 and its `gem_init.o` 37), this gem's own new code +647, the build's gem initializer table +48, and link-time padding the remaining +3. Same compiler and the same `-g -O3` as the five builds above.

## Testing

| what                                     | result                                          |
| ---------------------------------------- | ----------------------------------------------- |
| `rake -m test MRUBY_CONFIG=default`      | 2581 total, 0 KO / 0 Crash / 0 Warning          |
| `rake -m test MRUBY_CONFIG=host-nofloat` | 2216 total, 0 KO / 0 Crash / 0 Warning          |
| `rake -m test MRUBY_CONFIG=ci/gcc-clang` | all five builds green, 0 KO / 0 Crash / 0 Warning |
| `rake -m MRUBY_CONFIG=cross-mingw`       | the Windows port cross-compiles clean           |

The `ascii-ctype` build is the row that exercises the `times(2)` fallback, in the same pass as the other four; `Process.times` answers there too, to the granularity of a clock tick. `host-nofloat` exercises the `NotImplementedError` path and confirms `Process::Tms` itself needs no `Float`. The `cross-mingw` build is compiled and not run here, and mirrors the `GetProcessTimes()` and `FILETIME` handling already in `ports/win/process_hal.c` for the two CPU clocks.

## Environment

<details>

|                    |                                                                   |
| ------------------ | ----------------------------------------------------------------- |
| OS                 | Ubuntu 24.04.4 LTS                                                |
| Kernel             | Linux 7.0.0-30-generic x86_64                                     |
| CPU                | AMD Ryzen 9 5950X 16-Core Processor, 32 threads                   |
| C compiler         | Homebrew clang version 23.1.0                                     |
| C compiler (cross) | x86_64-w64-mingw32-gcc-posix (GCC) 13-posix                       |
| binutils           | GNU ld (GNU Binutils) 2.47.20260726                               |
| CRuby              | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |
| rake               | 13.3.1                                                            |

The compile of `src/string.c` in each of the five builds, as the build recorded it, with `-MMD -c`, the `-I` paths, the `-o` and the `-ffile-compilation-dir` taken off:

```console
# bintest
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -DMRB_GC_FIXED_ARENA -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK

# ascii-ctype
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -DMRB_USE_ASCII_CTYPE -DMRB_REGEXP_PARSE_DEPTH_LIMIT=512 -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# byte-string
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# cxx_abi
clang -g -O3 -Wall -Wundef -Wwrite-strings -Wzero-length-array -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# full-debug
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

</details>




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `Process.times`, returning user, system, and child CPU times.
  * Added the `Process::Tms` struct with `utime`, `stime`, `cutime`, and `cstime` fields.
  * Added support across POSIX and Windows platforms, including fallback timing behavior where needed.

* **Documentation**
  * Documented `Process.times`, `Process::Tms`, platform behavior, and configuration requirements.

* **Bug Fixes**
  * Improved compatibility on systems without `getrusage(2)` by using an alternative timing source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->