### PR TITLE
mruby-regexp: scan only the positions an anchored pattern can start at

### DIFF
--- a/mrbgems/mruby-regexp/include/re_internal.h
+++ b/mrbgems/mruby-regexp/include/re_internal.h
@@ -191,6 +191,11 @@ typedef struct mrb_regexp_pattern {
   uint8_t first_byte[3];   /* the whole first-byte set when it is this small,
                               so the skip can memchr instead of walking */
   mrb_bool is_literal;     /* true if pattern is pure literal (no metacharacters) */
+  uint8_t anchor;          /* the anchor every branch asserts before consuming
+                              input (the weakest across branches), so the
+                              engines scan only positions it can pass: line
+                              starts under RE_ANCHOR_BOL, the string start
+                              alone under RE_ANCHOR_BOT */
   uint8_t loop_depth;      /* deepest nesting of repetitions whose body can
                               match empty (see RE_MAX_PASS) */
   /* Cached VM state for pike_vm (avoids malloc per mrb_re_exec call) */
@@ -199,6 +204,12 @@ typedef struct mrb_regexp_pattern {
   int cached_list_capa;         /* capacity of cached thread lists */
   mrb_bool cache_in_use;        /* re-entrancy guard */
 } mrb_regexp_pattern;
+
+/* mrb_regexp_pattern::anchor. Ordered by how much each restricts where a
+   match can start, so the weakest guarantee across branches is their min. */
+#define RE_ANCHOR_NONE 0
+#define RE_ANCHOR_BOL  1  /* every branch passes ^ first: line starts only */
+#define RE_ANCHOR_BOT  2  /* every branch passes \A first: string start only */
 
 /* Regexp flags */
 #define RE_FLAG_IGNORECASE  1

--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -3246,6 +3246,58 @@ first_set_walk(const re_inst *code, uint32_t code_len,
   return FALSE;
 }
 
+/*
+ * The anchor every path from pc asserts before consuming input, as the
+ * weakest guarantee: RE_ANCHOR_BOT when every path passes \A first,
+ * RE_ANCHOR_BOL when every path passes at least ^, RE_ANCHOR_NONE otherwise.
+ * The walk covers zero-width instructions only, so an anchor it finds holds
+ * at the position a match would start at; anything consuming, unknown, or an
+ * epsilon path to RE_MATCH answers NONE. A branch already seen answers BOT,
+ * the neutral value for the min: a path cut short there has no anchor of its
+ * own before the join (one before it would have been the walk's answer
+ * already), so its value is the join's, which the visit that explored the
+ * join contributed.
+ */
+static uint8_t
+anchor_walk(const re_inst *code, uint32_t code_len, uint32_t pc, uint8_t *seen)
+{
+  while (pc < code_len) {
+    if (seen[pc]) return RE_ANCHOR_BOT;
+    seen[pc] = 1;
+    switch (code[pc].op) {
+    case RE_BOT:
+      return RE_ANCHOR_BOT;
+    case RE_BOL:
+      return RE_ANCHOR_BOL;
+    case RE_SAVE:
+    case RE_EOL: case RE_EOT: case RE_EOTNL:
+    case RE_WBOUND: case RE_NWBOUND:
+    case RE_ATOMIC: case RE_ATOMIC_END:
+      pc++;
+      continue;
+    case RE_JMP:
+      pc = code[pc].offset;
+      continue;
+    case RE_CALL:
+      /* The body runs where the call stands, as in first_set_walk(); a body
+         that completes without consuming ends at its RE_RETURN, whose
+         default answers NONE. */
+      pc = code[pc].offset;
+      continue;
+    case RE_SPLIT:
+    case RE_SPLITNG: {
+      uint8_t other = anchor_walk(code, code_len, code[pc].offset, seen);
+      if (other == RE_ANCHOR_NONE) return RE_ANCHOR_NONE;
+      uint8_t mine = anchor_walk(code, code_len, pc + 1, seen);
+      return mine < other ? mine : other;
+    }
+    default:
+      return RE_ANCHOR_NONE;
+    }
+  }
+  return RE_ANCHOR_NONE;
+}
+
 /* TRUE when a path that need not consume runs from pc to goal, so the
    repetition that goal closes can complete an iteration without consuming.
    A lookaround is zero-width whatever its sub-pattern does, so the walk
@@ -3815,13 +3867,30 @@ mrb_re_compile(mrb_state *mrb, mrb_regexp_pattern *pat,
   pat->has_backref = c.has_backref;
   pat->needs_backtrack = c.needs_backtrack;
 
+  /* The anchor every branch asserts before consuming input, if any: the
+     engines then scan only the positions it can pass (line starts for ^, the
+     string start alone for \A) instead of proposing every position; see
+     skip_to_line_start(). Under \A the string is never scanned at all, which
+     is why a pattern carrying it leaves the prefix and the first-byte set
+     below unbuilt: they exist to move a scan along, and there is none. */
+  pat->anchor = RE_ANCHOR_NONE;
+  {
+    uint8_t seen[4096];
+    if (code_len < sizeof(seen)) {
+      memset(seen, 0, code_len + 1);
+      pat->anchor = anchor_walk(pat->code, code_len, 0, seen);
+    }
+  }
+
   /* Extract literal prefix for fast search skip.
      Walk bytecode from the start, skipping zero-width instructions,
      collecting RE_CHAR. A zero-width test consumes nothing, so the literal
      bytes after it still begin at the position a match would start at; the
      skip only proposes candidate positions, and the engine still runs the
      test there. */
-  {
+  pat->prefix = NULL;
+  pat->prefix_len = 0;
+  if (pat->anchor != RE_ANCHOR_BOT) {
     uint8_t pbuf[256];
     int plen = 0;
     for (uint32_t i = 0; i < code_len && plen < 255; i++) {
@@ -3841,10 +3910,6 @@ mrb_re_compile(mrb_state *mrb, mrb_regexp_pattern *pat,
       pat->prefix = (uint8_t*)mrb_malloc(mrb, plen);
       memcpy(pat->prefix, pbuf, plen);
       pat->prefix_len = (uint8_t)plen;
-    }
-    else {
-      pat->prefix = NULL;
-      pat->prefix_len = 0;
     }
   }
 
@@ -3866,7 +3931,8 @@ mrb_re_compile(mrb_state *mrb, mrb_regexp_pattern *pat,
 
   /* Compute first-byte bitmap: set of bytes that could start a match.
      Used when prefix is empty (e.g. alternation, character class patterns). */
-  {
+  pat->has_first_bytes = FALSE;
+  if (pat->anchor != RE_ANCHOR_BOT) {
     uint8_t bm[16];
     memset(bm, 0, sizeof(bm));
     pat->has_first_bytes = compute_first_set(pat->code, code_len, pat->classes, bm);

--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -3816,16 +3816,26 @@ mrb_re_compile(mrb_state *mrb, mrb_regexp_pattern *pat,
   pat->needs_backtrack = c.needs_backtrack;
 
   /* Extract literal prefix for fast search skip.
-     Walk bytecode from the start, skipping SAVE, collecting RE_CHAR. */
+     Walk bytecode from the start, skipping zero-width instructions,
+     collecting RE_CHAR. A zero-width test consumes nothing, so the literal
+     bytes after it still begin at the position a match would start at; the
+     skip only proposes candidate positions, and the engine still runs the
+     test there. */
   {
     uint8_t pbuf[256];
     int plen = 0;
     for (uint32_t i = 0; i < code_len && plen < 255; i++) {
-      if (pat->code[i].op == RE_SAVE) continue;
-      if (pat->code[i].op == RE_CHAR) {
-        pbuf[plen++] = pat->code[i].a;
+      uint8_t op = pat->code[i].op;
+      if (op == RE_SAVE ||
+          op == RE_BOL || op == RE_EOL || op == RE_BOT || op == RE_EOT ||
+          op == RE_EOTNL || op == RE_WBOUND || op == RE_NWBOUND) {
+        continue;
       }
-      else break;
+      if (op == RE_CHAR) {
+        pbuf[plen++] = pat->code[i].a;
+        continue;
+      }
+      break;
     }
     if (plen > 0) {
       pat->prefix = (uint8_t*)mrb_malloc(mrb, plen);

--- a/mrbgems/mruby-regexp/src/re_exec.c
+++ b/mrbgems/mruby-regexp/src/re_exec.c
@@ -81,6 +81,24 @@ skip_to_first_byte(const mrb_regexp_pattern *pat, const char *sp, const char *st
   return found;
 }
 
+/*
+ * Skip to the next position a line-anchored match could start at: the string
+ * start, or just after a \n. Everything between fails RE_BOL on its first
+ * step, so those positions are gone as candidates, found by memchr rather
+ * than proposed one at a time. The tests here are RE_BOL's own: the very end
+ * is no line start (a trailing \n opens no final line), except when the
+ * string is empty and the end is the start. Returns NULL when no candidate
+ * remains.
+ */
+static const char*
+skip_to_line_start(const char *str, const char *sp, const char *str_end)
+{
+  if (sp == str || (sp != str_end && sp[-1] == '\n')) return sp;
+  const char *nl = (const char*)memchr(sp, '\n', (size_t)(str_end - sp));
+  if (!nl || nl + 1 == str_end) return NULL;
+  return nl + 1;
+}
+
 /* Check if the current input character matches a character class. ASCII
    (cp < 128) hits the bitmap; non-ASCII falls back to the inclusive (lo, hi)
    range list, then to the types the class holds by POSIX bracket, then to the
@@ -444,6 +462,9 @@ pike_vm(mrb_state *mrb, const mrb_regexp_pattern *pat,
   const char *start_cap = str + start_limit;
   const char *sp = str + start;
   const char *str_end = str + len;
+  /* \A: no position past the string start can begin a match, which is what
+     start_cap already bounds, so the anchor costs the scan loop nothing. */
+  if (pat->anchor == RE_ANCHOR_BOT) start_cap = str;
   int ncap = pat->num_captures * 2;
   if (ncap == 0) ncap = 2;
 
@@ -540,6 +561,15 @@ pike_vm(mrb_state *mrb, const mrb_regexp_pattern *pat,
     if (!s.matched && sp <= start_cap) {
       /* Skip ahead when no active threads */
       if (curr.count == 0) {
+        /* ^: every branch asserts a line start first, so only those are
+           candidates. \A was folded into start_cap on entry; such a pattern
+           reaches here at the start alone, where the line-start answer is
+           the position unchanged. */
+        if (pat->anchor != RE_ANCHOR_NONE) {
+          const char *skip = skip_to_line_start(str, sp, str_end);
+          if (!skip) break;
+          sp = skip;
+        }
         if (pat->prefix_len > 0) {
           const char *skip = skip_to_prefix(pat, sp, str_end);
           if (!skip) break;
@@ -1488,6 +1518,8 @@ backtrack_exec(mrb_state *mrb, const mrb_regexp_pattern *pat,
 {
   const char *start_cap = str + start_limit;
   const char *str_end = str + len;
+  /* \A bounds the start positions the way pike_vm's clamp does. */
+  if (pat->anchor == RE_ANCHOR_BOT) start_cap = str;
   int ncap = pat->num_captures * 2;
   if (ncap == 0) ncap = 2;
 
@@ -1528,7 +1560,13 @@ backtrack_exec(mrb_state *mrb, const mrb_regexp_pattern *pat,
   memset(m.entered_in, 0, sizeof(int) * pat->code_len);
 
   for (const char *sp = str + start; sp <= str_end && sp <= start_cap; sp++) {
-    /* Skip ahead using literal prefix or first-byte bitmap */
+    /* Skip ahead using the anchor, the literal prefix or the first-byte
+       bitmap; the same composition as pike_vm's. */
+    if (pat->anchor != RE_ANCHOR_NONE) {
+      const char *skip = skip_to_line_start(str, sp, str_end);
+      if (!skip) break;
+      sp = skip;
+    }
     if (pat->prefix_len > 0) {
       const char *skip = skip_to_prefix(pat, sp, str_end);
       if (!skip) break;


### PR DESCRIPTION
## Summary

An anchored pattern can only start where its anchor holds: at a line start when every branch asserts `^` before consuming input, at the string start alone under `\A`. The search still proposed every position (or every occurrence of the first byte) and let the anchor kill each attempt one seed at a time. This PR records the anchor on the compiled pattern and lets both engines skip with it, and as a first step teaches the literal-prefix walk to step over zero-width tests, so `/\bfoo/` and `/^foo/` scan for `foo` rather than for every `f`.

## Changes

| file | change |
|---|---|
| `include/re_internal.h` | `anchor` on the compiled pattern, with `RE_ANCHOR_NONE` / `RE_ANCHOR_BOL` / `RE_ANCHOR_BOT` |
| `src/re_compile.c` | the prefix walk steps over zero-width instructions; `anchor_walk()` records the anchor; a `\A` pattern builds no prefix or first-byte set |
| `src/re_exec.c` | `skip_to_line_start()`; both engines clamp the start bound under `\A` and jump from line start to line start under `^` |

### Collecting the prefix past zero-width tests (commit 1)

The prefix walk stopped at the first instruction that was not `RE_SAVE` or `RE_CHAR`. A zero-width test consumes nothing, so the literal bytes after it still begin at the position a match would start at; the skip only proposes candidate positions, and the engine still runs the test there. The walk now steps over the eight zero-width instructions, the same set `first_set_walk()` already steps over.

### Recording the anchor (commit 2)

`anchor_walk()` walks the zero-width head of the bytecode the way `first_set_walk()` does: `RE_BOT` answers `RE_ANCHOR_BOT`, `RE_BOL` answers `RE_ANCHOR_BOL`, a split takes the weaker of its branches, and anything consuming, unknown, or an epsilon path to `RE_MATCH` answers `RE_ANCHOR_NONE`. Since the walk never crosses a consuming instruction, an anchor it finds holds at the position a match would start at.

### Skipping with it

`\A` needs no scanning at all: its one candidate is the string start, which is what the engines' existing bound on start positions (`start_cap`) already expresses, so the anchor clamps that bound on entry and costs the scan loop nothing. Such a pattern also skips building the prefix and the first-byte set, which exist to move a scan along when there is none. `^` skips by `skip_to_line_start()`: the current position when it is a line start, otherwise one past the next `\n` by memchr. The prefix and first-byte skips then compose behind it unchanged, cutting candidates down further within a line; a seed placed by one skip and refused by the other test dies on its first step and the loop converges without passing any position both accept.

## Behaviour

No observable change. `skip_to_line_start()` runs the same tests as `RE_BOL`: a line start is the string start or one past a `\n`, and the very end is no line start because a trailing `\n` opens no final line. The `\A` clamp mirrors `RE_BOT`, which compares against the string start regardless of the search offset, so `"foo".index(/\Afoo/, 1)` stays nil and `gsub` rescans stop as they did.

## Speed

callgrind Ir for `Regexp#match?` over a 10KB subject with no match, 2,000 calls, clang host build, master at 167c8f084. The lorem subject is 76-byte lines holding `f` words but no `foo`; the last row's subject is `"ax\n" * 3413`.

| case | pattern | master | commit 1 | PR | PR vs master |
|---|---|---|---|---|---|
| `\A` with prefix | `/\Afoo/` | 118,853,169 | 45,997,505 | 5,793,685 | 20.5x fewer |
| `^` with prefix | `/^foo/` | 120,474,192 | 45,998,528 | 46,018,615 | 2.6x fewer |
| `\b` with prefix | `/\bfoo/` | 144,775,266 | 45,999,602 | 46,009,700 | 3.1x fewer |
| `^` alone | `/^$/` | 3,476,636,987 | 3,476,637,016 | 75,819,099 | 45.9x fewer |
| backtracking engine | `/^(f)oo\1/` | 102,754,321 | 45,966,659 | 46,004,747 | 2.2x fewer |
| `^` over dense lines | `/^ab/` | 3,889,519,826 | 381,050,147 | 381,070,236 | 10.2x fewer |
| dense control | `/ax\|ay/` on `"ab" * 5000` | 8,795,319,201 | 8,795,319,203 | 8,935,329,328 | +1.59% |
| sparse control | `/zebra\|zoo/` | 7,539,067 | 7,539,069 | 7,557,195 | +0.24% |
| wide-set control | `/[d-w]zzz/` | 5,695,843,079 | 5,695,843,083 | 5,797,371,162 | +1.78% |

Commit 1 leaves unanchored patterns unchanged to the instruction (the 2 to 4 Ir on the control rows is run jitter). The controls' cost in the PR column is the branch the seeding loop gains, paid where every position is already a candidate and no skip can help; the structure was measured in four variants and this is the smallest.

Wall clock, `taskset` pinned, best of three: `/\Afoo/` at 200,000 calls 0.55s to 0.01s; `/^$/` at 20,000 calls 1.70s to 0.04s.

## Size

`.text` sum of `libmruby.a`, `MRUBY_CONFIG=ci/gcc-clang` under clang, both revisions built from the same source path into empty build directories.

| build | master (167c8f084) | PR | delta |
|---|---|---|---|
| ascii-ctype | 1,112,841 | 1,113,433 | +592 |
| bintest | 1,118,187 | 1,118,507 | +320 |
| byte-string | 1,092,371 | 1,093,075 | +704 |
| cxx_abi | 1,106,549 | 1,106,885 | +336 |
| full-debug | 1,929,095 | 1,929,975 | +880 |

In the bintest build the delta is `re_compile.o` +336 and `re_exec.o` -16.

## Testing

- `rake -m test` on the default host config: 2510 OK, 0 KO, 0 crash, 63 skips (all pre-existing guards), at each commit.
- `rake regexp:difftest` against CRuby 4.0.6: 5,175 patterns, 97 known differences, no new ones.
- A 40-case anchored-pattern sweep (`^` / `\A` / `\b` with `=~`, `index`, `rindex`, `scan`, `gsub`, `split`, offsets, empty subjects, trailing newlines) agrees with CRuby 4.0.6 line for line.

## Environment

<details>

- Linux x86_64, kernel 7.0.0, AMD Ryzen 9 5950X
- Homebrew clang 23.1.0, valgrind 3.27.1
- compile line (host, `re_exec.c`):

```
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK -MMD -c src/re_exec.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved regular expression matching by skipping impossible starting positions.
  * Patterns anchored to the beginning of the input now begin matching directly at the valid starting point.
  * Line-anchored patterns scan only valid line starts, improving search efficiency without changing matching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->