### PR TITLE
mruby-struct: take a C fast path through `.new` for the default `initialize`

### DIFF
--- a/mrbgems/mruby-struct/mrblib/struct.rb
+++ b/mrbgems/mruby-struct/mrblib/struct.rb
@@ -66,4 +66,12 @@ class Struct
       n
     end
   end
+
+  # Bridge used by the C constructor when #initialize is overridden.
+  # mruby has no C API to send keyword arguments, so the arguments are
+  # re-sent to the (user-defined) #initialize here; kw is always a hash,
+  # possibly empty, matching what Class#new's forwarding would send.
+  private def __struct_init_fwd(args, kw, &blk)
+    initialize(*args, **kw, &blk)
+  end
 end

--- a/mrbgems/mruby-struct/src/struct.c
+++ b/mrbgems/mruby-struct/src/struct.c
@@ -426,8 +426,9 @@ mrb_struct_init_with_keywords(mrb_state *mrb, mrb_value hash, mrb_value self)
   return self;
 }
 
+/* Fill `self` from the constructor arguments of the current C frame. */
 static mrb_value
-mrb_struct_initialize(mrb_state *mrb, mrb_value self)
+struct_init_body(mrb_state *mrb, mrb_value self)
 {
   /* Read before mrb_get_args, which folds the kdict into argv and clears
      ci->kw. Class#new always forwards a kdict, so an empty one means the
@@ -458,6 +459,12 @@ mrb_struct_initialize(mrb_state *mrb, mrb_value self)
     return mrb_struct_init_with_keywords(mrb, argv[0], self);
   }
   return mrb_struct_init_with_args(mrb, argc, argv, self);
+}
+
+static mrb_value
+mrb_struct_initialize(mrb_state *mrb, mrb_value self)
+{
+  return struct_init_body(mrb, self);
 }
 
 /* 15.2.18.4.9  */

--- a/mrbgems/mruby-struct/src/struct.c
+++ b/mrbgems/mruby-struct/src/struct.c
@@ -212,6 +212,8 @@ make_struct_define_accessors(mrb_state *mrb, mrb_value members, struct RClass *c
   }
 }
 
+static mrb_value mrb_struct_new(mrb_state *mrb, mrb_value klass);
+
 static mrb_value
 make_struct(mrb_state *mrb, mrb_value name, mrb_value members, struct RClass *klass)
 {
@@ -241,13 +243,12 @@ make_struct(mrb_state *mrb, mrb_value name, mrb_value members, struct RClass *kl
   mrb_iv_set(mrb, nstr, MRB_SYM(__members__), members);
 
   /* Shadow the class-creating Struct.new inherited through the metaclass
-     with the ordinary Class#new; unlike a C trampoline, its forwarding keeps
-     keyword arguments keywords all the way into #initialize */
-  struct RClass *cls = mrb->class_class;
-  mrb_method_t nm = mrb_method_search_vm(mrb, &cls, MRB_SYM(new));
-  struct RClass *sc = mrb_class_ptr(mrb_singleton_class(mrb, nstr));
-  mrb_define_method_raw(mrb, sc, MRB_SYM(new), nm);
-  mrb_define_method_raw(mrb, sc, MRB_OPSYM(aref), nm);
+     with a C constructor: while #initialize is not overridden it fills the
+     members from its own frame, and otherwise re-sends the arguments
+     through a Ruby bridge, which keeps keyword arguments keywords (a C
+     funcall cannot). */
+  mrb_define_class_method_id(mrb, c, MRB_SYM(new), mrb_struct_new, MRB_ARGS_ANY());
+  mrb_define_class_method_id(mrb, c, MRB_OPSYM(aref), mrb_struct_new, MRB_ARGS_ANY());
   mrb_define_class_method_id(mrb, c, MRB_SYM(members), mrb_struct_s_members_m, MRB_ARGS_NONE());
   mrb_define_class_method_id(mrb, c, MRB_SYM_Q(keyword_init), mrb_struct_s_keyword_init_p, MRB_ARGS_NONE());
   /* RSTRUCT(nstr)->basic.c->super = c->c; */
@@ -431,8 +432,9 @@ static mrb_value
 struct_init_body(mrb_state *mrb, mrb_value self)
 {
   /* Read before mrb_get_args, which folds the kdict into argv and clears
-     ci->kw. Class#new always forwards a kdict, so an empty one means the
-     caller wrote no keywords. */
+     ci->kw. In #initialize's frame, Class#new and the Ruby bridge always
+     forward a kdict, so an empty one means the caller wrote no keywords;
+     in the C constructor's frame the flag is the caller's own. */
   mrb_callinfo *ci = mrb->c->ci;
   mrb_bool kw_given = FALSE;
   if (ci->kw) {
@@ -465,6 +467,47 @@ static mrb_value
 mrb_struct_initialize(mrb_state *mrb, mrb_value self)
 {
   return struct_init_body(mrb, self);
+}
+
+/*
+ *  call-seq:
+ *     StructClass.new(arg, ...)  -> obj
+ *     StructClass[arg, ...]      -> obj
+ *
+ *  Creates a new instance of the generated struct class.
+ */
+static mrb_value
+mrb_struct_new(mrb_state *mrb, mrb_value klass)
+{
+  struct RArray *p = MRB_OBJ_ALLOC(mrb, MRB_TT_STRUCT, mrb_class_ptr(klass));
+  mrb_value obj = mrb_obj_value(p);
+
+  if (!mrb_func_basic_p(mrb, obj, MRB_SYM(initialize), mrb_struct_initialize)) {
+    /* overridden initialize */
+    if (mrb->c->ci->kw) {
+      /* only the VM can pass keyword arguments, so re-send positional
+         arguments, keywords, and block through the Ruby bridge (see mrblib) */
+      const mrb_value *argv;
+      mrb_int argc;
+      mrb_value kwrest, blk;
+      const mrb_kwargs kw = {0, 0, NULL, NULL, &kwrest};
+      mrb_get_args(mrb, "*:&", &argv, &argc, &kw, &blk);
+      mrb_value fargs[2];
+      fargs[0] = mrb_ary_new_from_values(mrb, argc, argv);
+      fargs[1] = kwrest;
+      mrb_funcall_with_block(mrb, obj, MRB_SYM(__struct_init_fwd), 2, fargs, blk);
+    }
+    else {
+      const mrb_value *argv;
+      mrb_int argc;
+      mrb_value blk;
+      mrb_get_args(mrb, "*&", &argv, &argc, &blk);
+      mrb_funcall_with_block(mrb, obj, MRB_SYM(initialize), argc, argv, blk);
+    }
+    return obj;
+  }
+
+  return struct_init_body(mrb, obj);
 }
 
 /* 15.2.18.4.9  */

--- a/mrbgems/mruby-struct/test/struct.rb
+++ b/mrbgems/mruby-struct/test/struct.rb
@@ -349,6 +349,77 @@ assert "Struct.new dispatches an overridden initialize" do
   assert_equal 3, kw.new(foo: 3).foo
 end
 
+assert "StructClass.[] dispatches an overridden initialize" do
+  c = Class.new(Struct.new(:foo)) do
+    def initialize(x)
+      super(x * 2)
+    end
+  end
+  assert_equal 4, c[2].foo
+
+  kw = Class.new(Struct.new(:foo)) do
+    def initialize(foo: 0)
+      super(foo: foo + 1)
+    end
+  end
+  assert_equal 8, kw[foo: 7].foo
+end
+
+assert "Struct.new forwards a block to an overridden initialize" do
+  c = Class.new(Struct.new(:foo)) do
+    def initialize(&blk)
+      super(blk.call)
+    end
+  end
+  assert_equal 42, c.new { 42 }.foo
+end
+
+assert "Struct.new passes a positional hash to an overridden initialize as one value" do
+  c = Class.new(Struct.new(:foo)) do
+    def initialize(h)
+      super(h)
+    end
+  end
+  assert_equal({a: 1}, c.new({a: 1}).foo)
+end
+
+assert "Struct.new with a splatted empty hash makes a blank struct" do
+  c = Struct.new(:foo)
+  assert_nil c.new(**{}).foo
+
+  o = Class.new(c) do
+    def initialize(*a)
+      super(a.size)
+    end
+  end
+  assert_equal 0, o.new(**{}).foo
+end
+
+assert "Struct.new keeps the direct path on a class whose subclass overrides initialize" do
+  c = Struct.new(:foo)
+  plain = Class.new(c)
+  assert_equal 1, plain.new(1).foo
+  doubled = Class.new(plain) do
+    def initialize(x)
+      super(x * 2)
+    end
+  end
+  assert_equal 2, doubled.new(1).foo
+  assert_equal 1, plain.new(1).foo
+end
+
+assert "overridden initialize forwards keywords through super under keyword_init" do
+  c = Struct.new(:foo, :bar, keyword_init: true)
+  sub = Class.new(c) do
+    def initialize(**h)
+      super(foo: h[:foo], bar: 2)
+    end
+  end
+  s = sub.new(foo: 1)
+  assert_equal 1, s.foo
+  assert_equal 2, s.bar
+end
+
 assert "Struct initialize when :keyword_init is true" do
   c = Struct.new(:foo, :bar, keyword_init: true)
 


### PR DESCRIPTION
### Summary

`StructClass.new` currently dispatches through `Class#new`, whose bytecode packs `*args` and `**kw` and crosses two extra method frames on every instantiation. This PR replaces the binding on the generated classes with a C constructor modeled on `mruby-data`'s: it asks `mrb_func_basic_p` per call, and while `#initialize` is untouched it fills the members straight from its own frame, without ever re-entering the VM. An overridden `#initialize` still receives its arguments from the VM: directly when the caller wrote no keywords, and through a small Ruby bridge when it did, since only the VM can pass keywords onward from C.

### Changes

| commit | file | what |
| --- | --- | --- |
| 1 | `src/struct.c` | split the frame-reading body of `#initialize` into `struct_init_body` |
| 2 | `src/struct.c` | C constructor `mrb_struct_new` bound as `.new` / `.[]` on generated classes |
| 2 | `mrblib/struct.rb` | `__struct_init_fwd` bridge for the overridden-with-keywords case |
| 2 | `test/struct.rb` | block forwarding, `[]` dispatch, positional hash, `**{}`, sibling classes, `keyword_init` + `super` |

#### The fast path

`struct_init_body` reads keyword presence and arguments from the current C frame. Called from `#initialize` that frame is the one `Class#new`'s forwarding built; called from the C constructor it is the caller's own, so the keyword detection sees the caller's actual `ci->kw` instead of inferring it from a forwarded kdict. The `keyword_init` handling (true / false / nil) is the same code on both routes.

#### The overridden route

`mrb_func_basic_p` is asked on every call, so an `initialize` defined after the class (or on a subclass) is honored, and sibling classes keep the fast path. Without keywords the constructor re-sends `argv` and the block to `#initialize` directly. With keywords it packs them for the `__struct_init_fwd` bridge, which re-splats them in Ruby, keeping keywords keywords all the way in, as `Class#new`'s bytecode did.

### Behaviour

No observable change intended. The new tests' expectations were cross-checked against CRuby 4.0.6 (block forwarding, `[]` with an overridden initialize, a positional hash staying one value, `new(**{})`, `keyword_init` with `super(**h)`): all match. The existing keyword matrix tests (positional, keywords, positional hash, mixed, `keyword_init` true/false/nil, overridden initialize with `super`) pass unchanged.

### Speed

callgrind Ir per instantiation, two-point subtraction ((Ir(300k) − Ir(100k)) / 200k) on the default host build, base `167c8f084`:

| case | master | PR | delta |
| --- | ---: | ---: | ---: |
| `S.new(1, 2)` (default initialize) | 3,654 | 2,520 | −31% |
| `S.new(a: 1, b: 2)` (default initialize) | 6,903 | 5,978 | −13% |
| `Sub.new(1)` (overridden, positional) | 4,585 | 4,125 | −10% |
| `Sub.new(a: 1, b: 2)` (overridden, keywords) | 8,796 | 10,607 | +21% |

The last row pays for the bridge hop; it is the combination of a user-defined `initialize` and a keyword call, and `mruby-data`'s constructor takes the same route there.

### Size

`.text` of `libmruby.a` (`size -t`), `build_config/ci/gcc-clang.rb`, clang, same path and empty build dir on both sides:

| build | master | PR | delta |
| --- | ---: | ---: | ---: |
| ascii-ctype | 1,535,271 | 1,535,706 | +435 |
| bintest | 1,567,223 | 1,567,658 | +435 |
| byte-string | 1,511,998 | 1,512,417 | +419 |
| cxx_abi | 1,557,281 | 1,557,716 | +435 |
| full-debug | 2,459,547 | 2,460,097 | +550 |

### Testing

- `rake -m test` (default config, clang): 2579 tests, 0 failures, 0 crashes
- full suite on an `MRB_GC_STRESS` debug build: 0 failures, 0 crashes
- new-test expectations verified against CRuby 4.0.6

### Environment

<details>

- Linux x86_64, Homebrew clang 23.1.0 (via ccache)
- compile line (host build, recorded `.flags`):
  `clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -ffile-compilation-dir="." -DMRBGEM_MRUBY_STRUCT_VERSION=0.0.0 -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK -I"include" -I"build/host/include"`
- valgrind/callgrind for the Ir table; `size -t` for the `.text` table

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `Struct` subclass construction so overridden initializers receive positional arguments, keyword arguments, and blocks correctly.
  * Preserved expected handling of positional hashes, empty keyword arguments, and `super` calls.
  * Ensured both `Struct.new` and bracket-style construction follow consistent initialization behavior.
* **Tests**
  * Added coverage for subclass initialization and argument forwarding scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->