### PR TITLE
mruby-regexp: show the groups in `MatchData#inspect`

### DIFF
--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -12,6 +12,7 @@
 #include <mruby/variable.h>
 #include <mruby/hash.h>
 #include <mruby/range.h>
+#include <mruby/numeric.h>
 #include <mruby/error.h>
 #include <mruby/internal.h>
 #include "re_internal.h"
@@ -1611,6 +1612,63 @@ matchdata_to_s(mrb_state *mrb, mrb_value self)
   int s = md->captures[0];
   int e = md->captures[1];
   return re_byte_substr(mrb, md->source, s, e - s);
+}
+
+/*
+ * MatchData#inspect - the groups by number or name, e.g.
+ * #<MatchData "ab" 1:"a" 2:"b">
+ */
+static mrb_value
+matchdata_inspect(mrb_state *mrb, mrb_value self)
+{
+  /* dup/clone leave the copy without match data. inspect answers rather than
+     raising, as it does on an uninitialized Regexp, and CRuby's answer for a
+     MatchData with no data is the bare class-and-address form. */
+  mrb_match_data *md = DATA_CHECK_GET_PTR(mrb, self, &matchdata_type, mrb_match_data);
+  if (!md) return mrb_any_to_s(mrb, self);
+
+  mrb_regexp_pattern *pat = NULL;
+  if (!mrb_nil_p(md->regexp)) {
+    pat = DATA_GET_PTR(mrb, md->regexp, &regexp_type, mrb_regexp_pattern);
+  }
+
+  mrb_value result = mrb_str_new_lit(mrb, "#<MatchData");
+  int ai = mrb_gc_arena_save(mrb);
+  for (int i = 0; i < md->num_captures; i++) {
+    mrb_str_cat_lit(mrb, result, " ");
+    if (i > 0) {
+      /* A group a name reaches is labeled with the name, not its number.
+         Each group carries at most one name, so the first entry that names
+         it is the whole answer; several groups of one name each show it. */
+      const re_named_capture *nc = NULL;
+      if (pat) {
+        for (uint16_t j = 0; j < pat->num_named; j++) {
+          if (pat->named_captures[j].group == i) {
+            nc = &pat->named_captures[j];
+            break;
+          }
+        }
+      }
+      if (nc) {
+        mrb_str_cat(mrb, result, nc->name, nc->name_len);
+      }
+      else {
+        mrb_str_cat_str(mrb, result, mrb_integer_to_str(mrb, mrb_int_value(mrb, i), 10));
+      }
+      mrb_str_cat_lit(mrb, result, ":");
+    }
+    int s = md->captures[i * 2];
+    if (s < 0) {
+      mrb_str_cat_lit(mrb, result, "nil");
+    }
+    else {
+      mrb_value grp = re_byte_substr(mrb, md->source, s, md->captures[i * 2 + 1] - s);
+      mrb_str_cat_str(mrb, result, mrb_str_inspect(mrb, grp));
+    }
+    mrb_gc_arena_restore(mrb, ai);
+  }
+  mrb_str_cat_lit(mrb, result, ">");
+  return result;
 }
 
 /* --- C-level gsub/sub/scan core --- */
@@ -3591,6 +3649,7 @@ mrb_mruby_regexp_gem_init(mrb_state *mrb)
   mrb_define_method(mrb, md, "string", matchdata_string, MRB_ARGS_NONE());
   mrb_define_method(mrb, md, "regexp", matchdata_regexp, MRB_ARGS_NONE());
   mrb_define_method(mrb, md, "to_s", matchdata_to_s, MRB_ARGS_NONE());
+  mrb_define_method(mrb, md, "inspect", matchdata_inspect, MRB_ARGS_NONE());
 }
 
 void

--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -468,7 +468,7 @@ re_check_exec_error(mrb_state *mrb, int n)
    Returns MatchData on match, nil on no match.
    Publishes the match as $~, and clears it on a miss. */
 static mrb_value
-exec_match(mrb_state *mrb, mrb_value self, mrb_value str, mrb_int pos)
+exec_match(mrb_state *mrb, mrb_value self, mrb_value str, mrb_int pos, mrb_bool literal)
 {
   mrb_regexp_pattern *pat = DATA_GET_PTR(mrb, self, &regexp_type, mrb_regexp_pattern);
   if (re_uninitialized_p(pat)) mrb_raise(mrb, E_ARGUMENT_ERROR, "uninitialized Regexp");
@@ -484,7 +484,10 @@ exec_match(mrb_state *mrb, mrb_value self, mrb_value str, mrb_int pos)
     clear_match_globals(mrb);
     return mrb_nil_value();
   }
-  return create_matchdata(mrb, self, str, captures, cap_size);
+  /* `literal` says the caller quoted a String pattern into `self` to have
+     something to search with. Such a match carries no Regexp in CRuby until
+     MatchData#regexp builds one, so the quoted one is not recorded here. */
+  return create_matchdata(mrb, literal ? mrb_nil_value() : self, str, captures, cap_size);
 }
 
 /*
@@ -511,7 +514,7 @@ regexp_match(mrb_state *mrb, mrb_value self)
   }
 
   re_check_encoding(mrb, str);
-  md = exec_match(mrb, self, str, pos);
+  md = exec_match(mrb, self, str, pos, FALSE);
   if (!mrb_nil_p(md) && !mrb_nil_p(block)) {
     return mrb_yield(mrb, block, md);
   }
@@ -524,13 +527,13 @@ regexp_match(mrb_state *mrb, mrb_value self)
  * globals and answers nil, as `Regexp#match` does, which is what the
  * overrides use to report a miss.
  *
- * `checked` says the caller has settled the encoding question for the subject
- * and this search must not ask it again. `sub`, `sub!` and `gsub!` set it when
- * their pattern is a quoted String, which CRuby searches for without reading
- * the subject as UTF-8 at all.
+ * `literal` says the pattern arrived as a String and `re` is its quoting.
+ * `sub`, `sub!` and `gsub!` set it, and it carries what CRuby's literal
+ * search carries: the subject is not read as UTF-8 on the way, and the match
+ * records no Regexp (see exec_match()).
  */
 static mrb_value
-re_search(mrb_state *mrb, mrb_value re, mrb_value str, mrb_int pos, mrb_bool checked)
+re_search(mrb_state *mrb, mrb_value re, mrb_value str, mrb_int pos, mrb_bool literal)
 {
   if (mrb_nil_p(str)) {
     clear_match_globals(mrb);
@@ -542,8 +545,8 @@ re_search(mrb_state *mrb, mrb_value re, mrb_value str, mrb_int pos, mrb_bool che
     clear_match_globals(mrb);
     return mrb_nil_value();
   }
-  if (!checked) re_check_encoding(mrb, str);
-  return exec_match(mrb, re, str, pos);
+  if (!literal) re_check_encoding(mrb, str);
+  return exec_match(mrb, re, str, pos, literal);
 }
 
 /*
@@ -630,7 +633,7 @@ regexp_match_op(mrb_state *mrb, mrb_value self)
   str = match_operand(mrb, str);
   re_check_encoding(mrb, str);
 
-  mrb_value md = exec_match(mrb, self, str, 0);
+  mrb_value md = exec_match(mrb, self, str, 0, FALSE);
   if (mrb_nil_p(md)) return mrb_nil_value();
 
   mrb_match_data *m = DATA_GET_PTR(mrb, md, &matchdata_type, mrb_match_data);
@@ -654,7 +657,7 @@ regexp_case_match(mrb_state *mrb, mrb_value self)
   if (re_uninitialized_p(pat)) return mrb_false_value();
   re_check_encoding(mrb, str);
 
-  md = exec_match(mrb, self, str, 0);
+  md = exec_match(mrb, self, str, 0, FALSE);
   return mrb_bool_value(!mrb_nil_p(md));
 }
 
@@ -1576,11 +1579,13 @@ re_quoted_regexp(mrb_state *mrb, mrb_value lit)
  * MatchData#regexp - the Regexp used
  *
  * A literal String pattern leaves none behind: `__sub_lit` and `__gsub_lit`
- * search for its bytes without compiling anything to search with, so the
- * Regexp it names is built here, out of the bytes the match reports, the first
- * time something asks for one. That is what CRuby does with a match against a
- * String pattern, down to the memo the answer is kept in. A call that never
- * asks pays for no compile at all.
+ * search for its bytes without compiling anything to search with, and the
+ * paths that do quote one to search with withhold it from the match (see
+ * exec_match()). So the Regexp named here is built here, out of the bytes
+ * the match reports, the first time something asks for one; group 0 of a
+ * literal match spans the pattern itself, whichever path made it. That is
+ * what CRuby does with a match against a String pattern, down to the memo
+ * the answer is kept in. A call that never asks pays for no compile at all.
  */
 static mrb_value
 matchdata_regexp(mrb_state *mrb, mrb_value self)
@@ -1627,10 +1632,20 @@ matchdata_inspect(mrb_state *mrb, mrb_value self)
   mrb_match_data *md = DATA_CHECK_GET_PTR(mrb, self, &matchdata_type, mrb_match_data);
   if (!md) return mrb_any_to_s(mrb, self);
 
-  mrb_regexp_pattern *pat = NULL;
-  if (!mrb_nil_p(md->regexp)) {
-    pat = DATA_GET_PTR(mrb, md->regexp, &regexp_type, mrb_regexp_pattern);
+  /* A match a literal String pattern made carries no Regexp until
+     MatchData#regexp builds one. CRuby renders such a match as
+     "#<MatchData: ab>", the whole match raw, and switches to the group
+     listing once the memo is filled; the memo is mirrored here, so the
+     switch comes with it. */
+  if (mrb_nil_p(md->regexp)) {
+    mrb_value result = mrb_str_new_lit(mrb, "#<MatchData: ");
+    mrb_str_cat_str(mrb, result, re_byte_substr(mrb, md->source, md->captures[0],
+                                                md->captures[1] - md->captures[0]));
+    mrb_str_cat_lit(mrb, result, ">");
+    return result;
   }
+
+  mrb_regexp_pattern *pat = DATA_GET_PTR(mrb, md->regexp, &regexp_type, mrb_regexp_pattern);
 
   mrb_value result = mrb_str_new_lit(mrb, "#<MatchData");
   int ai = mrb_gc_arena_save(mrb);
@@ -1641,12 +1656,10 @@ matchdata_inspect(mrb_state *mrb, mrb_value self)
          Each group carries at most one name, so the first entry that names
          it is the whole answer; several groups of one name each show it. */
       const re_named_capture *nc = NULL;
-      if (pat) {
-        for (uint16_t j = 0; j < pat->num_named; j++) {
-          if (pat->named_captures[j].group == i) {
-            nc = &pat->named_captures[j];
-            break;
-          }
+      for (uint16_t j = 0; j < pat->num_named; j++) {
+        if (pat->named_captures[j].group == i) {
+          nc = &pat->named_captures[j];
+          break;
         }
       }
       if (nc) {
@@ -2172,12 +2185,12 @@ sub_piece(mrb_state *mrb, mrb_value block, mrb_value hash, mrb_value matched)
  * the lookup form walks under the same answers.
  */
 static mrb_value
-re_gsub_walk(mrb_state *mrb, mrb_value re, mrb_value str, mrb_bool checked,
+re_gsub_walk(mrb_state *mrb, mrb_value re, mrb_value str, mrb_bool literal,
              mrb_value block, mrb_value hash)
 {
   mrb_regexp_pattern *pat = DATA_GET_PTR(mrb, re, &regexp_type, mrb_regexp_pattern);
   if (re_uninitialized_p(pat)) mrb_raise(mrb, E_ARGUMENT_ERROR, "uninitialized Regexp");
-  if (!checked) re_check_encoding(mrb, str);
+  if (!literal) re_check_encoding(mrb, str);
 
   mrb_bool binary = re_binary_string_p(str);
   int cap_size = pat->num_captures * 2;
@@ -2203,7 +2216,7 @@ re_gsub_walk(mrb_state *mrb, mrb_value re, mrb_value str, mrb_bool checked,
     mrb_int beg = captures[0], end = captures[1];
 
     mrb_value matched = re_byte_substr(mrb, str, beg, end - beg);
-    last_md = create_matchdata(mrb, re, str, captures, cap_size);
+    last_md = create_matchdata(mrb, literal ? mrb_nil_value() : re, str, captures, cap_size);
     last = pos;
     mrb_value piece = sub_piece(mrb, block, hash, matched);
     /* What the block did to the receiver while it had it. A change of length
@@ -2215,7 +2228,7 @@ re_gsub_walk(mrb_state *mrb, mrb_value re, mrb_value str, mrb_bool checked,
     if (RSTRING_LEN(str) != slen) {
       mrb_raise(mrb, E_RUNTIME_ERROR, "string modified");
     }
-    if (!checked) re_check_encoding(mrb, str);
+    if (!literal) re_check_encoding(mrb, str);
     s = RSTRING_PTR(str);
     binary = re_binary_string_p(str);
 
@@ -2263,7 +2276,7 @@ re_gsub_walk(mrb_state *mrb, mrb_value re, mrb_value str, mrb_bool checked,
   else {
     /* The closing search of `str_gsub`, on the receiver as the block left it,
        which publishes what it finds or clears the globals for a miss. */
-    exec_match(mrb, re, str, last);
+    exec_match(mrb, re, str, last, literal);
   }
   return result;
 }
@@ -2272,7 +2285,7 @@ re_gsub_walk(mrb_state *mrb, mrb_value re, mrb_value str, mrb_bool checked,
  * scan core without a block: every match collected into the answered array.
  */
 static mrb_value
-re_scan_ary(mrb_state *mrb, mrb_value re, mrb_value str)
+re_scan_ary(mrb_state *mrb, mrb_value re, mrb_value str, mrb_bool literal)
 {
   mrb_regexp_pattern *pat = DATA_GET_PTR(mrb, re, &regexp_type, mrb_regexp_pattern);
   if (re_uninitialized_p(pat)) mrb_raise(mrb, E_ARGUMENT_ERROR, "uninitialized Regexp");
@@ -2337,7 +2350,7 @@ re_scan_ary(mrb_state *mrb, mrb_value re, mrb_value str)
   }
 
   if (last_ncap > 0) {
-    create_matchdata(mrb, re, str, last_captures, last_ncap);
+    create_matchdata(mrb, literal ? mrb_nil_value() : re, str, last_captures, last_ncap);
   }
   else {
     clear_match_globals(mrb);
@@ -2917,8 +2930,9 @@ str_scan_m(mrb_state *mrb, mrb_value self)
 
   mrb_get_args(mrb, "o&", &pattern, &block);
   pattern = check_pattern(mrb, pattern);
-  if (mrb_string_p(pattern)) pattern = quote_to_regexp(mrb, pattern);
-  if (mrb_nil_p(block)) return re_scan_ary(mrb, pattern, self);
+  mrb_bool literal = mrb_string_p(pattern);
+  if (literal) pattern = quote_to_regexp(mrb, pattern);
+  if (mrb_nil_p(block)) return re_scan_ary(mrb, pattern, self, literal);
 
   /* A block reads the match globals of the match it was handed, so the block
      form walks the subject itself and lets each search publish as it goes:
@@ -2951,7 +2965,7 @@ str_scan_m(mrb_state *mrb, mrb_value self)
       mrb_raise(mrb, E_RUNTIME_ERROR, "string modified");
     }
     re_check_encoding(mrb, self);
-    mrb_value md = exec_match(mrb, pattern, self, pos);
+    mrb_value md = exec_match(mrb, pattern, self, pos, literal);
     if (mrb_nil_p(md)) break;
     last = pos;
     last_md = md;
@@ -2977,7 +2991,7 @@ str_scan_m(mrb_state *mrb, mrb_value self)
         mrb_raise(mrb, E_RUNTIME_ERROR, "string modified");
       }
       re_check_encoding(mrb, self);
-      exec_match(mrb, pattern, self, last);
+      exec_match(mrb, pattern, self, last, literal);
     }
   }
   return self;
@@ -3040,7 +3054,7 @@ str_split_m(mrb_state *mrb, mrb_value self)
       return result;
     }
     re_check_encoding(mrb, self);
-    mrb_value md = exec_match(mrb, pattern, self, search_pos);
+    mrb_value md = exec_match(mrb, pattern, self, search_pos, FALSE);
     if (mrb_nil_p(md)) break;
     mrb_match_data *m = DATA_GET_PTR(mrb, md, &matchdata_type, mrb_match_data);
     mrb_int ms = m->captures[0], me = m->captures[1];
@@ -3280,7 +3294,7 @@ str_byteindex_m(mrb_state *mrb, mrb_value self)
      miss rather than becoming an error. */
   mrb_str_check_byte_pos(mrb, self, pos);
   re_check_encoding(mrb, self);
-  mrb_value md = exec_match(mrb, pattern, self, pos);
+  mrb_value md = exec_match(mrb, pattern, self, pos, FALSE);
   if (mrb_nil_p(md)) return mrb_nil_value();
   mrb_match_data *m = DATA_GET_PTR(mrb, md, &matchdata_type, mrb_match_data);
   return mrb_int_value(mrb, m->captures[0]);

--- a/mrbgems/mruby-regexp/test/match_data.rb
+++ b/mrbgems/mruby-regexp/test/match_data.rb
@@ -133,6 +133,31 @@ assert("MatchData#inspect - named groups") do
   assert_equal '#<MatchData "c" a:nil a:nil>', /(?:(?<a>x)|(?<a>b))?c/.match("c").inspect
 end
 
+assert("MatchData#inspect - a match a literal String pattern made") do
+  # such a match carries no Regexp until MatchData#regexp builds one, and
+  # CRuby renders it as the whole match raw, switching to the group listing
+  # once the memo is filled
+  "a\tb x".sub("a\tb", "z")
+  md = $~
+  assert_equal "#<MatchData: a\tb>", md.inspect
+  md.regexp
+  assert_equal '#<MatchData "a\tb">', md.inspect
+
+  # every literal search leaves the same regexp-less match behind, the block
+  # and Hash walks and scan included, though those quote a Regexp to search
+  # with; a Regexp pattern is recorded as itself
+  "ab x".sub("ab") { "z" }
+  assert_equal "#<MatchData: ab>", $~.inspect
+  "ab ab".gsub("ab", "ab" => "z")
+  assert_equal "#<MatchData: ab>", $~.inspect
+  "ab ab".scan("ab")
+  assert_equal "#<MatchData: ab>", $~.inspect
+  "ab ab".scan("ab") { }
+  assert_equal "#<MatchData: ab>", $~.inspect
+  "ab x".sub(/ab/) { "z" }
+  assert_equal '#<MatchData "ab">', $~.inspect
+end
+
 assert("MatchData#inspect - a copy without match data") do
   # dup does not carry the match over, and inspect answers about the object
   # it has rather than raising as the other readers do

--- a/mrbgems/mruby-regexp/test/match_data.rb
+++ b/mrbgems/mruby-regexp/test/match_data.rb
@@ -115,6 +115,30 @@ assert("MatchData#to_s") do
   assert_equal "bc", md.to_s
 end
 
+assert("MatchData#inspect") do
+  assert_equal '#<MatchData "ab">', /ab/.match("ab").inspect
+  assert_equal '#<MatchData "ab" 1:"a" 2:"b">', /(a)(b)/.match("ab").inspect
+  # a group that took no part in the match shows nil
+  assert_equal '#<MatchData "a" 1:"a" 2:nil>', /(a)(z)?/.match("a").inspect
+  # the values go through String#inspect, so a quote in one is escaped
+  assert_equal '#<MatchData "a\"b" 1:"a\"b" 2:"\"b">',
+               /(a("b))/.match('a"b').inspect
+end
+
+assert("MatchData#inspect - named groups") do
+  # a group a name reaches is labeled with the name instead of its number
+  assert_equal '#<MatchData "ab" x:"a" y:"b">', /(?<x>a)(?<y>b)/.match("ab").inspect
+  # several groups of one name each show it, matched or not
+  assert_equal '#<MatchData "b" a:nil a:"b">', /(?<a>x)|(?<a>b)/.match("b").inspect
+  assert_equal '#<MatchData "c" a:nil a:nil>', /(?:(?<a>x)|(?<a>b))?c/.match("c").inspect
+end
+
+assert("MatchData#inspect - a copy without match data") do
+  # dup does not carry the match over, and inspect answers about the object
+  # it has rather than raising as the other readers do
+  assert_true /a/.match("a").dup.inspect.start_with?("#<MatchData:")
+end
+
 assert("MatchData#begin / #end") do
   re = Regexp.new("bc")
   md = re.match("abcde")

--- a/mrbgems/mruby-regexp/test/regexp_utf8.rb
+++ b/mrbgems/mruby-regexp/test/regexp_utf8.rb
@@ -472,6 +472,13 @@ assert("Regexp - multibyte (UTF-8) match extraction") do
   assert_false /い/.match?("あいあ", 2)
 end
 
+assert("MatchData#inspect spells the groups by string mode") do
+  # The values go through String#inspect, which keeps a UTF-8 character
+  # whole only on a build that reads them
+  skip unless __ENCODING__ == "UTF-8"
+  assert_equal %(#<MatchData "あ" 1:"あ" 2:nil>), /(あ)(x)?/.match("あ").inspect
+end
+
 assert("Regexp - UTF-8 codepoints in character class") do
   assert_equal 0, ("β" =~ /[α-ω]/)
   assert_nil ("Z" =~ /[α-ω]/)


### PR DESCRIPTION
## Summary

`MatchData` defined no `inspect` of its own, so a match rendered itself as `#<MatchData:0x5704651e9d18>`. This PR gives it CRuby's rendering, the groups by number or name, and with it the form CRuby reserves for a match a literal String pattern made, which asks such a match not to record the Regexp that was quoted to search with.

## Changes

| file | change |
|---|---|
| `src/regexp.c` | `matchdata_inspect()`; `exec_match()`, `re_search()`, `re_gsub_walk()` and `re_scan_ary()` take a `literal` flag and withhold the quoted Regexp from the match |
| `test/match_data.rb` | `MatchData#inspect` cases: numbered and named groups, the literal forms, a copy without match data |
| `test/regexp_utf8.rb` | the values keep UTF-8 characters whole on a build that reads them |

### The group listing (commit 1)

The groups are written the way CRuby's `match_inspect()` writes them: the whole match first, then each group as `number:value`, or `name:value` where a name reaches the group, `nil` for a group that took no part in the match, every value through `String#inspect`.

```ruby
/(a)(z)?/.match("a").inspect
# => "#<MatchData \"a\" 1:\"a\" 2:nil>"
/(?<a>x)|(?<a>b)/.match("b").inspect
# => "#<MatchData \"b\" a:nil a:\"b\">"
```

Names come from the compiled pattern's table, so the groups of a duplicate name each show it, as above. A copy `dup` leaves without match data answers with the bare class-and-address form rather than raising, which is the answer CRuby has for a `MatchData` with no data, and the line `inspect` already holds on an uninitialized `Regexp`.

### The literal form (commit 2)

CRuby renders the match of a literal String pattern as `#<MatchData: ab>`, the whole match raw, for as long as the `regexp` field is empty, and switches to the group listing once `MatchData#regexp` fills it. The field mirrors CRuby's here, and the replacement forms of `sub` and `gsub` already leave it empty, but the block and Hash walks and both forms of `scan` quote a Regexp to have something to search with, and recorded it. The quoted Regexp is now withheld from the match. Group 0 of a literal match spans the pattern itself, so the Regexp that `MatchData#regexp` builds on demand reads the same as the one the search quoted.

## Behaviour

```ruby
"ab x".sub("ab") { "z" }
$~.inspect  # => "#<MatchData: ab>"
$~.regexp   # => /ab/
$~.inspect  # => "#<MatchData \"ab\">"
```

Beyond `inspect` itself, the one observable change is that `$~` of a literal-pattern `sub` / `gsub` block or Hash walk and of `scan` no longer holds an eagerly recorded Regexp: `MatchData#regexp` still answers the same source and flags, built on the first ask the way the replacement forms already build theirs. Every output above was checked against CRuby 4.0.6, the memo-driven switch included.

## Size

`.text` sum of `libmruby.a`, `MRUBY_CONFIG=ci/gcc-clang` under clang, both revisions built from the same source path into empty build directories.

| build | master (f38ef473b) | PR | delta |
|---|---|---|---|
| ascii-ctype | 1,113,161 | 1,114,041 | +880 |
| bintest | 1,118,507 | 1,119,387 | +880 |
| byte-string | 1,092,675 | 1,093,555 | +880 |
| cxx_abi | 1,106,869 | 1,107,765 | +896 |
| full-debug (-O0) | 1,929,271 | 1,930,439 | +1,168 |

The delta is `regexp.o` alone (bintest: +880).

## Testing

- `rake -m test` on the default host config at each commit: 0 KO, 0 crash (2,578 and 2,579 assertions).
- `MRUBY_CONFIG=ci/gcc-clang rake -m test`: all five builds and bintest green, the `MRB_GC_STRESS` suite of `full-debug` included.
- The differential tool against CRuby 4.0.6, on the PR's bintest build: 5,175 patterns, 97 known differences, no new ones.
- The rendering was probed against CRuby 4.0.6 directly: numbered, named and duplicate-named groups, unmatched groups, values needing escapes, UTF-8 values, no-group patterns, and all seven literal-search paths (`sub` / `sub!` / `gsub` / `gsub!` with a block and with a Hash, `scan` with and without one) answer byte for byte alike.

## Environment

<details>

- Linux x86_64, kernel 7.0.0, AMD Ryzen 9 5950X
- Homebrew clang 23.1.0
- CRuby 4.0.6
- compile line (host, `regexp.c`):

```
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -ffile-compilation-dir="." -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK -MMD -c src/regexp.c
```

</details>
