### PR TITLE
mruby-benchmark: measure CPU time through `Process.times`

### DIFF
--- a/mrbgems/mruby-benchmark/README.md
+++ b/mrbgems/mruby-benchmark/README.md
@@ -88,8 +88,8 @@ Holds timing measurement results. Provides methods to access individual timing c
 
 - `utime` - User CPU time in seconds (Float)
 - `stime` - System CPU time in seconds (Float)
-- `cutime` - User CPU time of child processes (Float, usually 0 in mruby)
-- `cstime` - System CPU time of child processes (Float, usually 0 in mruby)
+- `cutime` - User CPU time of child processes reaped inside the block (Float)
+- `cstime` - System CPU time of child processes reaped inside the block (Float)
 - `real` - Real (wall-clock) time in seconds (Float)
 - `objects` - Number of objects allocated (Integer, when memory tracking enabled)
 - `memory` - Memory allocated in bytes (Integer, when memory tracking enabled)
@@ -98,7 +98,7 @@ Holds timing measurement results. Provides methods to access individual timing c
 
 ##### `total` → Float
 
-Returns the total CPU time (user + system).
+Returns the total CPU time (`utime` + `stime` + `cutime` + `cstime`).
 
 ```ruby
 result = Benchmark.measure { heavy_computation }
@@ -230,7 +230,7 @@ end
 
 ### Time Measurement
 
-mruby-benchmark uses `Process.clock_gettime` (via mruby-time) for high-resolution timing when available. User and system CPU times are measured using platform-specific APIs where available, otherwise both are set to 0.
+mruby-benchmark measures the way CRuby's `benchmark` does: real time is the difference of two `Process.clock_gettime(Process::CLOCK_MONOTONIC)` readings, so a wall clock stepped by NTP during the block does not show up in it, and the four CPU times are the difference of two `Process.times` readings. Both come from mruby-process, which reads them through its platform port; see that gem's README for what each platform can tell apart.
 
 ### Memory Tracking
 
@@ -238,14 +238,16 @@ Memory profiling uses `ObjectSpace.count_objects` (via mruby-objectspace) to tra
 
 ### Limitations
 
-- Child process timing (`cutime`, `cstime`) is not supported in most mruby environments and always returns 0
-- System CPU time may not be available on all platforms
+- `cutime` and `cstime` cover only children the block waited for, as `Process.times` does; on Windows they are always 0
+- CPU time has the granularity of the platform's clock: microseconds under getrusage(2), one tick under times(2) or Win32
+- Real time needs a host with `CLOCK_MONOTONIC`; the rare POSIX host without it gets `Errno::EINVAL` from `measure` and `realtime`, as CRuby's `benchmark` would
+- The gem needs a build with Float: `Process.times` and the `%f` in `Tms#to_s` both raise without one
 - Memory measurements are estimates and may not reflect actual heap usage
 - GC activity during benchmarking may affect timing results
 
 ## Dependencies
 
-- **mruby-time** - Required for timing measurements
+- **mruby-process** - Required for timing measurements
 - **mruby-objectspace** - Required for memory profiling
 
 ## License

--- a/mrbgems/mruby-benchmark/mrbgem.rake
+++ b/mrbgems/mruby-benchmark/mrbgem.rake
@@ -3,7 +3,10 @@ MRuby::Gem::Specification.new('mruby-benchmark') do |spec|
   spec.author  = 'mruby developers'
   spec.summary = 'benchmarking and profiling tools'
 
-  spec.add_dependency('mruby-time', :core => 'mruby-time')
+  # `Benchmark.measure` is built the way CRuby's is: CPU time from
+  # `Process.times`, real time from `Process.clock_gettime` on the
+  # monotonic clock.
+  spec.add_dependency('mruby-process', :core => 'mruby-process')
   spec.add_dependency('mruby-objectspace', :core => 'mruby-objectspace')
   spec.add_dependency('mruby-sprintf', :core => 'mruby-sprintf')
   spec.add_dependency('mruby-io', :core => 'mruby-io')

--- a/mrbgems/mruby-benchmark/mrblib/benchmark.rb
+++ b/mrbgems/mruby-benchmark/mrblib/benchmark.rb
@@ -70,7 +70,6 @@ module Benchmark
 
   # Measure execution time of a block
   def self.measure(memory: false)
-    start_time = Time.now
     start_objects = nil
     start_count = nil
 
@@ -81,10 +80,11 @@ module Benchmark
       end
     end
 
+    t0 = Process.times
+    r0 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     yield
-
-    end_time = Time.now
-    real = end_time - start_time
+    t1 = Process.times
+    r1 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
     objects_allocated = nil
     memory_allocated = nil
@@ -99,17 +99,16 @@ module Benchmark
       memory_allocated = objects_allocated * 40
     end
 
-    # mruby typically doesn't have per-process CPU time
-    # Set user/system times to 0
-    Tms.new(0.0, 0.0, 0.0, 0.0, real, nil, objects_allocated, memory_allocated)
+    Tms.new(t1.utime - t0.utime, t1.stime - t0.stime,
+            t1.cutime - t0.cutime, t1.cstime - t0.cstime,
+            r1 - r0, nil, objects_allocated, memory_allocated)
   end
 
   # Return only real time as a float
   def self.realtime
-    start_time = Time.now
+    r0 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     yield
-    end_time = Time.now
-    end_time - start_time
+    Process.clock_gettime(Process::CLOCK_MONOTONIC) - r0
   end
 
   # Formatted benchmark with labeled reports

--- a/mrbgems/mruby-benchmark/test/benchmark.rb
+++ b/mrbgems/mruby-benchmark/test/benchmark.rb
@@ -26,9 +26,10 @@ assert('Benchmark.measure') do
   assert_kind_of(Float, result.cstime)
   assert_kind_of(Float, result.real)
 
-  # For mruby, CPU times are typically 0
-  assert_equal(0.0, result.utime)
-  assert_equal(0.0, result.stime)
+  # The block spends CPU, but too little to promise the clock saw it
+  assert_true(result.utime >= 0)
+  assert_true(result.stime >= 0)
+  # cutime and cstime count children reaped inside the block, and there are none
   assert_equal(0.0, result.cutime)
   assert_equal(0.0, result.cstime)
 
@@ -45,6 +46,19 @@ assert('Benchmark.measure with actual delay') do
 
   # Real time should be measurable (greater than 0)
   assert_true(result.real > 0)
+end
+
+assert('Benchmark.measure counts CPU time') do
+  # Spin until Process.times itself has seen the CPU time, so the test
+  # asks nothing of a second clock and a tick-based Process.times
+  # (times(2), Win32) cannot have rounded the stretch to nothing
+  cpu = lambda { t = Process.times; t.utime + t.stime }
+  result = Benchmark.measure do
+    limit = cpu.call + 0.05
+    nil while cpu.call < limit
+  end
+
+  assert_true(result.utime + result.stime > 0)
 end
 
 assert('Benchmark.realtime') do


### PR DESCRIPTION
## Summary

`Benchmark.measure` answered 0.0 for every CPU time and took real time from the wall clock, while the README described a gem that read `Process.clock_gettime` and platform CPU clocks. With `Process.times` and `Process.clock_gettime` in mruby-process since #7421 and #7447, the gem can now do what the README said, the way CRuby's `benchmark` does.

## Changes

| File | What |
|---|---|
| `mrbgems/mruby-benchmark/mrbgem.rake` | depend on mruby-process instead of mruby-time |
| `mrbgems/mruby-benchmark/mrblib/benchmark.rb` | `measure` differences two `Process.times` and two monotonic clock readings; `realtime` uses the monotonic clock |
| `mrbgems/mruby-benchmark/test/benchmark.rb` | stop pinning `utime` / `stime` to 0.0; add a test that spins until `Process.times` has seen the CPU time |
| `mrbgems/mruby-benchmark/README.md` | describe the clocks actually used, what `cutime` / `cstime` cover, what `total` sums, and that a build with Float and a host with `CLOCK_MONOTONIC` are needed |

### CPU time was a constant

`measure` built its `Tms` from four literal `0.0`s, so `Benchmark.bm` printed a user and a system column that never said anything, and `Tms#total` was always 0.0. The test suite pinned that with four `assert_equal(0.0, ...)`. The rewrite is the shape of CRuby's `Benchmark.measure`: read `Process.times` and the monotonic clock before the block, read them again after, and hand `Tms.new` the four differences.

```ruby
t0 = Process.times
r0 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
yield
t1 = Process.times
r1 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
```

### Real time came from the wall clock

`Time.now` is gettimeofday(2), which steps when NTP corrects the clock, and the step landed in `real`. `CLOCK_MONOTONIC` never steps, and `realtime` moves to it too so the two answer from the same clock.

CRuby's `benchmark` names `CLOCK_MONOTONIC` unconditionally and so does this one. The rare POSIX host without it gets `Errno::EINVAL` from `measure` and `realtime`, which the README now says; falling back to the wall clock there would bring back the step this change removes.

### The dependency moves from mruby-time to mruby-process

Nothing in the gem reads `Time` any more. mruby-process is in `stdlib-io.gembox` alongside mruby-io, which this gem already needs for `$stdout`.

## Behaviour

Before, on any platform:

```ruby
Benchmark.measure { 300_000.times { |i| i * 2 } }.utime  #=> 0.0
```

After, on Linux (getrusage(2)):

```
              user     system      total        real
spin:     0.015549   0.000000   0.015549 (  0.015566)
sleep:    0.000115   0.000000   0.000115 (  0.050063)
child:    0.001525   0.000000   0.369121 (  0.368212)
```

`child:` is a block that runs a shell loop through `IO.popen` and waits for it; its CPU time arrives through `cutime` and `cstime`, which count children reaped inside the block, as `Process.times` does. A block that reaps none still gets 0.0 for both, and the test keeps pinning that.

`Benchmark::Tms`, `Benchmark::Report`, `Benchmark.bm` and the `memory:` option are untouched. `Tms#total` has always summed all four CPU times; the README said user plus system, and now says what the method does.

A build without Float gets NotImplementedError from the first `measure` or `realtime`, where it used to get 0 and then ArgumentError from the `%f` in `Tms#to_s`. The gem has needed Float since it was written; the README now says so.

## Size

`.text` of `bin/mruby` is unchanged in all five `ci/gcc-clang` builds. The mrblib bytecode grows by 112 bytes in the `.rodata` of `mruby-benchmark/gem_init.o`, which shows in `bin/mruby` as:

| Build | master `.rodata` | this PR | delta |
|---|---:|---:|---:|
| `bintest` | 285,792 | 285,888 | +96 |
| `ascii-ctype` | 259,800 | 259,896 | +96 |
| `byte-string` | 258,712 | 258,808 | +96 |
| `cxx_abi` | 285,696 | 285,792 | +96 |
| `full-debug` (-O0) | 345,792 | 345,920 | +128 |

master is bb6cd825e. Both sides were built from the same worktree path into an emptied build directory with the same `rake` target.

## Testing

`MRUBY_CONFIG=ci/gcc-clang rake -m test` passes on all five builds (KO 0, Crash 0). The `ascii-ctype` build compiles mruby-process with `MRB_PROCESS_HAVE_GETRUSAGE=0`, so the new CPU time test has been through the times(2) fallback as well as getrusage(2). The test spins until `Process.times` has seen the CPU time, so it needs no clock beyond the one `measure` reads. The `full-debug` build runs it under `MRB_GC_STRESS`.

## Environment

<details>
<summary>Host and compile lines</summary>

| | |
|---|---|
| OS | Ubuntu 24.04.4 LTS, Linux 7.0.0-30-generic x86_64 |
| CPU | AMD Ryzen 9 5950X |
| Compiler | Homebrew clang 23.1.0 |
| binutils | GNU Binutils 2.47.20260726 |
| rake | 13.3.1 |
| CRuby | 4.0.6 |

Compile lines as `rake --verbose` printed them for `src/string.c`, with `-I`, `-MMD -c` and `-o` dropped:

```console
# full-debug
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -g3 -O0 -ffile-compilation-dir="." -ffile-prefix-map="<build>=build" -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
# bintest
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -ffile-compilation-dir="." -ffile-prefix-map="<build>=build" -DMRB_GC_FIXED_ARENA -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK src/string.c
# cxx_abi
clang -g -O3 -Wall -Wundef -Wwrite-strings -Wzero-length-array -x c++ -std=gnu++03 -ffile-compilation-dir="." -ffile-prefix-map="<build>=build" -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
# byte-string
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -ffile-compilation-dir="." -ffile-prefix-map="<build>=build" -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
# ascii-ctype
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -ffile-compilation-dir="." -ffile-prefix-map="<build>=build" -DMRB_USE_ASCII_CTYPE -DMRB_REGEXP_PARSE_DEPTH_LIMIT=512 -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Benchmark measurements now report user, system, and child-process CPU time.
  * Real-time measurements use a monotonic clock for improved reliability.
  * Total benchmark time reflects the combined CPU-time components.

* **Documentation**
  * Clarified timing behavior, child-process measurement limitations, platform considerations, and implementation details.

* **Tests**
  * Added coverage confirming that CPU time is recorded during measurable workloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->