### PR TITLE
build: log where every define came from as a build starts

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -62,6 +62,7 @@ load "#{MRUBY_ROOT}/tasks/install.rake"
 load "#{MRUBY_ROOT}/tasks/amalgam.rake"
 load "#{MRUBY_ROOT}/tasks/compile_commands.rake"
 load "#{MRUBY_ROOT}/tasks/size.rake"
+load "#{MRUBY_ROOT}/tasks/define_log.rake"
 load "#{MRUBY_ROOT}/tasks/unicode.rake"
 load "#{MRUBY_ROOT}/tasks/difftest.rake"
 

--- a/doc/guides/compile.md
+++ b/doc/guides/compile.md
@@ -314,9 +314,9 @@ for it. The mechanical `MRBGEM_*_VERSION` defines are left out.
 When one name is held with two values, the losing rows are marked with what
 beats them: the last `-D` of a name on a compile line is the one in effect,
 and `conf.defines` comes after the compilers' lists. An unmarked row is what
-objects compile with; `[FOO=1 wins]` on a row says every object gets `FOO=1`
-instead, and `[FOO=1 wins for mruby-x cc]` says only that gem's objects do,
-the gem's own compiler having redefined a build-wide name.
+its objects compile with; `[FOO=1 wins]` on a row says `FOO=1` is in effect
+wherever that row would apply, and `[FOO=1 wins for mruby-x cc]` says the row
+loses only there, the gem's own compiler having redefined a build-wide name.
 
 `rake defines` prints the same tables without building anything, and
 `conf.disable_define_log` leaves a build out of the log.

--- a/doc/guides/compile.md
+++ b/doc/guides/compile.md
@@ -294,8 +294,8 @@ already carries every other define a gem writes.
 
 #### The define log
 
-A build opens by printing every define it will compile with and the file and
-line that wrote it, one table per target:
+`rake defines` prints, one table per target, every define the build will
+compile with and the file and line that wrote it:
 
 ```console
 Defines of 'host':
@@ -318,8 +318,9 @@ its objects compile with; `[FOO=1 wins]` on a row says `FOO=1` is in effect
 wherever that row would apply, and `[FOO=1 wins for mruby-x cc]` says the row
 loses only there, the gem's own compiler having redefined a build-wide name.
 
-`rake defines` prints the same tables without building anything, and
-`conf.disable_define_log` leaves a build out of the log.
+A build says nothing of this by default, mruby being built from inside other
+projects' builds. A configuration that says `conf.define_log` opens its build
+output with the same tables.
 
 ### Linker
 

--- a/doc/guides/compile.md
+++ b/doc/guides/compile.md
@@ -292,6 +292,35 @@ defines a gem writes to its own `cc` into the generated `mruby.h`, so an
 amalgam carries the answers the build that generated it got, the way it
 already carries every other define a gem writes.
 
+#### The define log
+
+A build opens by printing every define it will compile with and the file and
+line that wrote it, one table per target:
+
+```console
+Defines of 'host':
+  HAVE_SYS_RESOURCE_H  mruby-process cc    mrbgems/mruby-process/mrbgem.rake:37
+  MRB_DEBUG            compilers internal  build_config/host-debug.rb:5 (via enable_debug)
+  MRB_USE_BIGINT       conf                mrbgems/mruby-bigint/mrbgem.rake:5
+```
+
+The middle column says who carries the define: `conf` is `conf.defines`, a
+compiler name is that compiler's own list (`compilers` when every compiler
+carries it, `internal` for what the build added from one of its own
+switches), and a gem name is the gem's own compiler. An add made through a
+switch such as `enable_debug` is charged to the configuration line that asked
+for it. The mechanical `MRBGEM_*_VERSION` defines are left out.
+
+When one name is held with two values, the losing rows are marked with what
+beats them: the last `-D` of a name on a compile line is the one in effect,
+and `conf.defines` comes after the compilers' lists. An unmarked row is what
+objects compile with; `[FOO=1 wins]` on a row says every object gets `FOO=1`
+instead, and `[FOO=1 wins for mruby-x cc]` says only that gem's objects do,
+the gem's own compiler having redefined a build-wide name.
+
+`rake defines` prints the same tables without building anything, and
+`conf.disable_define_log` leaves a build out of the log.
+
 ### Linker
 
 Configuration of the Linker binary, flags and library paths.

--- a/lib/mruby/build.rb
+++ b/lib/mruby/build.rb
@@ -583,13 +583,16 @@ EOS
       @defines = DefineList.assigned(list, @defines)
     end
 
-    # Leave this build out of the define log a build prints as it starts.
-    def disable_define_log
-      @define_log_disabled = true
+    # Have this build print the define log as it starts. `rake defines`
+    # prints it without this; a build says nothing by default, mruby being
+    # built from inside other projects' builds whose output is not its own
+    # to change.
+    def define_log
+      @define_log = true
     end
 
-    def define_log_disabled?
-      !!@define_log_disabled
+    def define_log?
+      !!@define_log
     end
 
     # Declare that every gem in the build has had its mrbgem.rake run, so the

--- a/lib/mruby/build.rb
+++ b/lib/mruby/build.rb
@@ -95,7 +95,8 @@ module MRuby
 
     include Rake::DSL
     include LoadGems
-    attr_accessor :name, :bins, :exts, :file_separator, :build_dir, :gem_clone_dir, :defines, :libdir_name
+    attr_accessor :name, :bins, :exts, :file_separator, :build_dir, :gem_clone_dir, :libdir_name
+    attr_reader :defines
     attr_reader :products, :libmruby_core_objs, :libmruby_objs, :gems, :toolchains, :presym, :mrbc_build, :gem_dir_to_repo_url
     attr_reader :build_root
     attr_reader :install_excludes, :port_names
@@ -146,7 +147,7 @@ module MRuby
         @libdir_name = (self.kind_of?(MRuby::CrossBuild) ? nil : ENV["MRUBY_SYSTEM_LIBDIR_NAME"]) || "lib"
         @install_prefix = nil
         @install_excludes = []
-        @defines = []
+        @defines = DefineList.new
         @defines_final = false
         @flags_change_reported = false
         @cc = Command::Compiler.new(self, %w(.c), label: "CC")
@@ -576,6 +577,19 @@ EOS
       COMPILERS.map do |c|
         instance_variable_get("@#{c}")
       end
+    end
+
+    def defines=(list)
+      @defines = DefineList.assigned(list, @defines)
+    end
+
+    # Leave this build out of the define log a build prints as it starts.
+    def disable_define_log
+      @define_log_disabled = true
+    end
+
+    def define_log_disabled?
+      !!@define_log_disabled
     end
 
     # Declare that every gem in the build has had its mrbgem.rake run, so the

--- a/lib/mruby/build/command.rb
+++ b/lib/mruby/build/command.rb
@@ -1,5 +1,6 @@
 require 'forwardable'
 require 'tmpdir'
+require 'mruby/build/define_list'
 
 module MRuby
   class Command
@@ -52,14 +53,23 @@ module MRuby
     # source it asked with.
     COMPILE_PROBES = {}
 
-    attr_accessor :label, :flags, :include_paths, :defines, :source_exts
+    attr_accessor :label, :flags, :include_paths, :source_exts
+    attr_reader :defines
     # Defines are held in two lists, split by who asked for them. `defines` is
     # what the build config and the gems write. `internal_defines` is what the
     # build adds on its own behalf, from its own switches (`enable_debug`,
     # `enable_cxx_abi`) or from a toolchain. Both reach the compiler as `-D`;
     # keeping them apart lets a toolchain set its own without overwriting what
     # the config already wrote, and lets a caller ask for one list alone.
-    attr_accessor :internal_defines
+    attr_reader :internal_defines
+
+    def defines=(list)
+      @defines = DefineList.assigned(list, @defines)
+    end
+
+    def internal_defines=(list)
+      @internal_defines = DefineList.assigned(list, @internal_defines)
+    end
     attr_accessor :compile_options, :option_define, :option_include_path, :out_ext
     # The directories the compiler writes another name for, as `from => to`,
     # and the option that spells that to it. They are kept out of `flags`
@@ -79,8 +89,8 @@ module MRuby
       @flags = [ENV['CFLAGS'] || []]
       @source_exts = source_exts
       @include_paths = ["#{MRUBY_ROOT}/include"]
-      @defines = []
-      @internal_defines = []
+      @defines = DefineList.new
+      @internal_defines = DefineList.new
       @option_include_path = %q[-I"%s"]
       @option_define = %q[-D"%s"]
       @file_prefix_maps = {}

--- a/lib/mruby/build/define_list.rb
+++ b/lib/mruby/build/define_list.rb
@@ -1,0 +1,116 @@
+module MRuby
+  # An Array of -D defines that remembers, for every entry it holds, the file
+  # and line that wrote it. The build and its compilers keep their define
+  # lists in one of these so the build can say where each define came from:
+  # a build_config line, a gem's mrbgem.rake, a toolchain file. An add made
+  # from inside lib/mruby (`enable_debug`) is charged to the first frame
+  # outside of it, the config line that asked, with the asking method named.
+  #
+  # Origins are plain strings so the list survives the Marshal deep clone
+  # `Command#clone` copies gem compilers with.
+  class DefineList < Array
+    LIB_DIR = File.expand_path("../..", __dir__)
+
+    attr_reader :origins
+
+    def initialize(*args)
+      super
+      @origins = {}
+    end
+
+    def initialize_copy(other)
+      super
+      @origins = {}
+      other.origins.each {|name, list| @origins[name] = list.dup}
+    end
+
+    def <<(value)
+      note(value)
+      super
+    end
+
+    def push(*values)
+      note(values)
+      super
+    end
+    alias append push
+
+    def unshift(*values)
+      note(values)
+      super
+    end
+    alias prepend unshift
+
+    def concat(*arrays)
+      note(arrays)
+      super
+    end
+
+    def insert(index, *values)
+      note(values)
+      super
+    end
+
+    # The writer's path, for `list = other` and `list += more` alike: an
+    # incoming DefineList (a `.dup` of another) keeps the origins it carries,
+    # anything else becomes one, entries the old list already knew keep their
+    # origins and the rest are charged to the assignment site.
+    def self.assigned(new_list, old_list)
+      return new_list if new_list.is_a?(DefineList)
+
+      origin = caller_origin
+      old_origins = old_list.is_a?(DefineList) ? old_list.origins : {}
+      list = DefineList.new
+      list.replace(Array(new_list))
+      list.flatten.each do |value|
+        define = value.to_s
+        if old_origins.key?(define)
+          list.origins[define] = old_origins[define].dup
+        elsif origin
+          (list.origins[define] ||= []) << origin
+        end
+      end
+      list
+    end
+
+    # A define may carry a value, as `FOO=1` does; the name is what one -D
+    # overrides another by.
+    def self.define_name(value)
+      value.to_s.split("=", 2).first
+    end
+
+    # The first frame outside lib/mruby, so that the reported line is the one
+    # a person wrote. When the frame right inside is not a writer method, its
+    # name says which switch did the writing (`via enable_debug`).
+    def self.caller_origin
+      locs = (caller_locations(1, 25) || []).reject do |loc|
+        File.expand_path(loc.path) == __FILE__
+      end
+      index = locs.index {|loc| !File.expand_path(loc.path).start_with?("#{LIB_DIR}/")}
+      return nil unless index
+
+      origin = "#{display_path(locs[index].path)}:#{locs[index].lineno}"
+      via = index > 0 ? locs[index - 1].base_label : nil
+      via = nil if via.nil? || via.end_with?("=")
+      via ? "#{origin} (via #{via})" : origin
+    end
+
+    def self.display_path(path)
+      path = File.expand_path(path)
+      root = "#{MRUBY_ROOT}/"
+      path.start_with?(root) ? path[root.size..] : path
+    end
+
+    private
+
+    # Keyed by the whole define, value and all, so that `FOO=0` and a `FOO=1`
+    # written elsewhere each answer with their own writer.
+    def note(values)
+      origin = DefineList.caller_origin
+      return unless origin
+      Array(values).flatten.each do |value|
+        (@origins[value.to_s] ||= []) << origin
+      end
+    end
+  end
+end

--- a/lib/mruby/define_log.rb
+++ b/lib/mruby/define_log.rb
@@ -7,9 +7,10 @@ module MRuby
   module DefineLog
     COMPILERS = MRuby::Build::COMPILERS
 
-    def self.print
+    def self.print(all: false)
       MRuby.targets.each_value do |build|
-        next if build.internal? || build.define_log_disabled?
+        next if build.internal?
+        next unless all || build.define_log?
 
         rows = collect(build)
         next if rows.empty?

--- a/lib/mruby/define_log.rb
+++ b/lib/mruby/define_log.rb
@@ -1,0 +1,135 @@
+require "mruby/build/define_list"
+
+module MRuby
+  # The log a build opens with: every define each target compiles with, who
+  # carries it (the config, a compiler's list, a gem's own compiler) and the
+  # file and line that wrote it, read from the origins a DefineList records.
+  module DefineLog
+    COMPILERS = MRuby::Build::COMPILERS
+
+    def self.print
+      MRuby.targets.each_value do |build|
+        next if build.internal? || build.define_log_disabled?
+
+        rows = collect(build)
+        next if rows.empty?
+
+        puts "Defines of '#{build.name}':"
+        define_width = rows.keys.map(&:size).max
+        owner_width = rows.values.map {|row| row[:owners].join(", ").size}.max
+        rows.sort.each do |define, row|
+          line = format("  %-#{define_width}s  %-#{owner_width}s  %s",
+                        define, row[:owners].join(", "), row[:origins].join(", "))
+          line << "  #{row[:mark]}" if row[:mark]
+          puts line
+        end
+        puts
+      end
+    end
+
+    def self.collect(build)
+      rows = {}
+
+      note(rows, build.defines, build.defines, "conf")
+      COMPILERS.each do |name|
+        compiler = build.send(name)
+        note(rows, compiler.defines, compiler.defines, name)
+        note(rows, compiler.internal_defines, compiler.internal_defines,
+             "#{name} internal")
+      end
+      # A gem's compilers start as clones of the build's, so what the gem
+      # itself wrote is what its list holds beyond the build's.
+      build.gems.each do |gem|
+        COMPILERS.each do |name|
+          gem_list = gem.send(name).defines
+          extra = gem_list.flatten.map(&:to_s) -
+                  build.send(name).defines.flatten.map(&:to_s)
+          note(rows, extra, gem_list, "#{gem.name} #{name}") unless extra.empty?
+        end
+      end
+
+      mark_losses(build, rows)
+      rows.each_value {|row| row[:owners] = fold_compilers(row[:owners])}
+      rows
+    end
+
+    # When one name is held with two values, the rows alone do not say which
+    # one an object compiles with, so the losing rows are marked. A compile
+    # line is `[defines, internal_defines, build.defines]` of the compiler
+    # the object is built with (`Compiler#all_flags`), the build's own or a
+    # gem's copy, and the last -D of a name is the one in effect: the winner
+    # of a context is the last entry of the name there. A row that never wins
+    # is marked with what beats it; a row beaten only in some contexts, a gem
+    # redefining a build-wide name for its own objects, is marked with where.
+    def self.mark_losses(build, rows)
+      contested = rows.keys.group_by {|d| DefineList.define_name(d)}
+                      .select {|_, defines| defines.uniq.size > 1}
+      return if contested.empty?
+
+      present = Hash.new {|h, k| h[k] = []}  # define => context labels
+      winner = {}                            # [name, context label] => define
+      contexts(build).each do |label, compiler|
+        [compiler.defines, compiler.internal_defines, build.defines]
+          .flatten.each do |value|
+          define = value.to_s
+          name = DefineList.define_name(define)
+          next unless contested.key?(name)
+          present[define] |= [label]
+          winner[[name, label]] = define
+        end
+      end
+
+      contested.each do |name, defines|
+        defines.each do |define|
+          losses = present[define].reject {|label| winner[[name, label]] == define}
+          next if losses.empty?
+          rows[define][:mark] = format_losses(losses, present[define], name, winner)
+        end
+      end
+    end
+
+    # Every list an object's -D flags can be assembled from: the build's own
+    # compilers and each gem's copies of them.
+    def self.contexts(build)
+      contexts = {}
+      COMPILERS.each {|name| contexts[name] = build.send(name)}
+      build.gems.each do |gem|
+        COMPILERS.each {|name| contexts["#{gem.name} #{name}"] = gem.send(name)}
+      end
+      contexts
+    end
+
+    def self.format_losses(losses, presence, name, winner)
+      groups = losses.group_by {|label| winner[[name, label]]}
+      everywhere = losses.size == presence.size && groups.size == 1
+      marks = groups.map do |win, labels|
+        everywhere ? "#{win} wins" : "#{win} wins for #{fold_compilers(labels).join(', ')}"
+      end
+      "[#{marks.join('; ')}]"
+    end
+
+    def self.note(rows, values, list, owner)
+      origins = list.is_a?(DefineList) ? list.origins : {}
+      values.flatten.each do |value|
+        define = value.to_s
+        # One MRBGEM_*_VERSION per gem, written by the machinery
+        # (`GemList#check`), not by anything a person configured.
+        next if define.start_with?("MRBGEM_")
+        row = (rows[define] ||= {owners: [], origins: []})
+        row[:owners] |= [owner]
+        row[:origins] |= (origins[define] || ["(unknown)"])
+      end
+    end
+
+    # "cc, cxx, objc, asm" is every compiler; say so.
+    def self.fold_compilers(owners)
+      [nil, " internal"].each do |suffix|
+        set = COMPILERS.map {|name| "#{name}#{suffix}"}
+        if (set - owners).empty?
+          owners = (owners - set[1..]).map {|o| o == set[0] ? "compilers#{suffix}" : o}
+        end
+      end
+      owners
+    end
+  end
+end

--- a/lib/mruby/define_log.rb
+++ b/lib/mruby/define_log.rb
@@ -30,21 +30,34 @@ module MRuby
     def self.collect(build)
       rows = {}
 
-      note(rows, build.defines, build.defines, "conf")
+      note(rows, build.defines, origins_of(build.defines), "conf")
       COMPILERS.each do |name|
         compiler = build.send(name)
-        note(rows, compiler.defines, compiler.defines, name)
-        note(rows, compiler.internal_defines, compiler.internal_defines,
-             "#{name} internal")
+        note(rows, compiler.defines, origins_of(compiler.defines), name)
+        note(rows, compiler.internal_defines,
+             origins_of(compiler.internal_defines), "#{name} internal")
       end
       # A gem's compilers start as clones of the build's, so what the gem
-      # itself wrote is what its list holds beyond the build's.
+      # itself wrote is what its list holds beyond its clone's: entries the
+      # build's list does not have, and, for an entry both lists have, the
+      # origins beyond the ones the clone came with (a gem writing a define
+      # the build already carries is still one of its writers).
       build.gems.each do |gem|
         COMPILERS.each do |name|
           gem_list = gem.send(name).defines
-          extra = gem_list.flatten.map(&:to_s) -
-                  build.send(name).defines.flatten.map(&:to_s)
-          note(rows, extra, gem_list, "#{gem.name} #{name}") unless extra.empty?
+          base = build.send(name).defines
+          base_strings = base.flatten.map(&:to_s)
+          base_origins = origins_of(base)
+          gem_origins = origins_of(gem_list)
+          owner = "#{gem.name} #{name}"
+          gem_list.flatten.map(&:to_s).uniq.each do |define|
+            unless base_strings.include?(define)
+              note(rows, [define], gem_origins, owner)
+              next
+            end
+            own = (gem_origins[define] || []) - (base_origins[define] || [])
+            note(rows, [define], {define => own}, owner) unless own.empty?
+          end
         end
       end
 
@@ -108,16 +121,23 @@ module MRuby
       "[#{marks.join('; ')}]"
     end
 
-    def self.note(rows, values, list, owner)
-      origins = list.is_a?(DefineList) ? list.origins : {}
+    # One MRBGEM_<NAME>_VERSION per gem, written by the machinery
+    # (`GemList#check`), not by anything a person configured. Only that
+    # exact shape: a configured MRBGEM_* define of another name is listed.
+    MECHANICAL_VERSION = /\AMRBGEM_\w+_VERSION\z/
+
+    def self.origins_of(list)
+      list.is_a?(DefineList) ? list.origins : {}
+    end
+
+    def self.note(rows, values, origins, owner)
       values.flatten.each do |value|
         define = value.to_s
-        # One MRBGEM_*_VERSION per gem, written by the machinery
-        # (`GemList#check`), not by anything a person configured.
-        next if define.start_with?("MRBGEM_")
+        next if DefineList.define_name(define) =~ MECHANICAL_VERSION
         row = (rows[define] ||= {owners: [], origins: []})
         row[:owners] |= [owner]
-        row[:origins] |= (origins[define] || ["(unknown)"])
+        origin = origins[define]
+        row[:origins] |= (origin.nil? || origin.empty? ? ["(unknown)"] : origin)
       end
     end
 

--- a/tasks/define_log.rake
+++ b/tasks/define_log.rake
@@ -9,6 +9,12 @@ task :gensym do
   MRuby::DefineLog.print
 end
 
+# The Rakefile wires `:all => :gensym` but gives `:build` only the product
+# tasks, whose presym needs come through per-target proxies: a direct
+# `rake build` would compile without the log. This file loads before
+# `:build` gains those products, so `:gensym` sits in front of them.
+task :build => :gensym
+
 desc "print where every define of each build came from"
 task :defines do
   MRuby::DefineLog.print

--- a/tasks/define_log.rake
+++ b/tasks/define_log.rake
@@ -1,10 +1,12 @@
 require_relative '../lib/mruby/define_log'
 
-# The log says where every define of the configuration came from, so it is
-# printed where the build starts. Every build entry point runs `:gensym`
+# The log says where every define of the configuration came from. A build
+# opens with it only when its configuration asks (`conf.define_log`): mruby
+# is built from inside other projects' builds, whose output is not this
+# build's to change. For a build that asked, every entry point runs `:gensym`
 # first, its prerequisites (the presym scan) before this action and every
 # compile after it, so the log opens the compile output whatever task asked
-# for the build. `conf.disable_define_log` leaves a build out.
+# for the build.
 task :gensym do
   MRuby::DefineLog.print
 end
@@ -17,5 +19,5 @@ task :build => :gensym
 
 desc "print where every define of each build came from"
 task :defines do
-  MRuby::DefineLog.print
+  MRuby::DefineLog.print(all: true)
 end

--- a/tasks/define_log.rake
+++ b/tasks/define_log.rake
@@ -1,0 +1,15 @@
+require_relative '../lib/mruby/define_log'
+
+# The log says where every define of the configuration came from, so it is
+# printed where the build starts. Every build entry point runs `:gensym`
+# first, its prerequisites (the presym scan) before this action and every
+# compile after it, so the log opens the compile output whatever task asked
+# for the build. `conf.disable_define_log` leaves a build out.
+task :gensym do
+  MRuby::DefineLog.print
+end
+
+desc "print where every define of each build came from"
+task :defines do
+  MRuby::DefineLog.print
+end


### PR DESCRIPTION
## Summary

A build's defines gather from many hands: the build config, a gem's `mrbgem.rake`, a toolchain file, a switch such as `enable_debug`. By the time a compile line shows a `-D`, nothing says which hand wrote it, and when one name is written twice nothing says which write is in effect. `rake defines` now prints one table per target naming each define, who carries it, the file and line that wrote it, and, where one name is held with two values, which one wins. A build says nothing of this by default; a configuration that says `conf.define_log` opens its build output with the same tables.

## Changes

| File | Change |
| --- | --- |
| `lib/mruby/build/define_list.rb` | new: an `Array` of defines that records, for every entry, the file and line that wrote it |
| `lib/mruby/define_log.rb` | new: collects a target's lists and prints the table |
| `tasks/define_log.rake` | new: `rake defines`, and the build-time print for a configuration that asks |
| `lib/mruby/build/command.rb` | a compiler's `defines` and `internal_defines` are `DefineList`s |
| `lib/mruby/build.rb` | `conf.defines` is a `DefineList`; `conf.define_log` |
| `Rakefile` | load the new task file |
| `doc/guides/compile.md` | a section on reading the log |

### Recording where a define was written

`MRuby::DefineList` is an `Array` that notes `caller_locations` whenever it is handed an entry, through `<<`, `push` and `concat`, and through assignment too: the `defines` writers re-wrap a plain array (which is what `conf.cc.defines += %w(...)` builds), keeping the origins of entries the old list already had and charging the rest to the assignment site. An add made from inside `lib/mruby` is charged to the first frame outside of it, so `enable_debug` reports the configuration line that asked for it, as `build_config/host-debug.rb:5 (via enable_debug)`.

Origins are kept as plain strings, so the lists survive the `Marshal` deep clone that `Command#clone` copies gem compilers with.

### Printing

`rake defines` prints the tables without building anything. A build prints them only when its configuration says `conf.define_log`: mruby is built from inside other projects' builds, whose output is not this build's to change. For a build that asked, the log is an action of `:gensym`, which every build entry point runs first, its prerequisites (the presym scan) before the action and every compile after it, so the tables open the compile output whatever task asked for the build; `rake clean` prints nothing.

### Marking the losing writes

When one name is held with two values, the rows alone do not say which one an object compiles with, so the losing rows are marked. The winner is settled the way `Compiler#all_flags` assembles a compile line: `[defines, internal_defines, build.defines]` of the compiler the object is built with, the build's own or a gem's copy, and the last `-D` of a name is the one in effect. A row that never wins is marked `[FOO=1 wins]`; a row beaten only for a gem whose own compiler redefined a build-wide name is marked `[FOO=1 wins for mruby-x cc]`. An unmarked row is what objects compile with.

The mechanical `MRBGEM_*_VERSION` defines are not listed: one per gem, written by `GemList#check` rather than by anything a person configured.

## Behaviour

Nothing of this is printed today; the first sight of a define is a `-D` in a compile line. With this change, `MRUBY_CONFIG=host-debug rake defines` prints:

```console
Defines of 'host':
  HAVE_MRUBY_ENCODING_GEM  conf                                  mrbgems/mruby-encoding/mrbgem.rake:5
  HAVE_MRUBY_IO_GEM        conf                                  mrbgems/mruby-io/mrbgem.rake:6
  HAVE_MRUBY_REGEXP_GEM    conf                                  mrbgems/mruby-regexp/mrbgem.rake:11
  HAVE_SYS_RESOURCE_H      mruby-process cc                      mrbgems/mruby-process/mrbgem.rake:37
  MRB_DEBUG                compilers internal                    build_config/host-debug.rb:5 (via enable_debug)
  MRB_NO_BOXING            cc                                    build_config/host-debug.rb:12
  MRB_REVISION_HEADER      compilers internal                    tasks/revision.rake:68
  MRB_USE_BIGINT           conf                                  mrbgems/mruby-bigint/mrbgem.rake:5
  MRB_USE_COMPLEX          conf                                  mrbgems/mruby-complex/mrbgem.rake:5
  MRB_USE_DEBUG_HOOK       conf, cc                              mrbgems/mruby-bin-debugger/mrbgem.rake:5, build_config/host-debug.rb:12
  MRB_USE_RATIONAL         conf                                  mrbgems/mruby-rational/mrbgem.rake:5
  MRB_USE_SET              conf                                  mrbgems/mruby-set/mrbgem.rake:5
  MRB_USE_TASK_SCHEDULER   conf                                  mrbgems/mruby-task/mrbgem.rake:7
  MRB_UTF8_STRING          conf                                  mrbgems/mruby-encoding/mrbgem.rake:6
  MRC_DEBUG                mruby-compiler cc                     mrbgems/mruby-compiler/mrbgem.rake:33
  MRC_DUMP_PRETTY          mruby-compiler cc                     mrbgems/mruby-compiler/mrbgem.rake:37
  MRC_TARGET_MRUBY         mruby-compiler cc, mruby-bin-mrbc cc  mrbgems/mruby-compiler/mrbgem.rake:31, mrbgems/mruby-bin-mrbc/mrbgem.rake:24
  PRISM_DEPTH_MAXIMUM=256  mruby-compiler cc                     mrbgems/mruby-compiler/mrbgem.rake:24
  PRISM_XALLOCATOR         mruby-compiler cc                     mrbgems/mruby-compiler/mrbgem.rake:14
```

A configuration that writes one name twice, and a gem that redefines a build-wide name:

```ruby
conf.cc.defines << 'MRB_TEST_KNOB=0'   # line 5
conf.defines << 'MRB_TEST_KNOB=1'      # line 6: build.defines is the last -D
conf.cc.defines << 'MRB_SAME_LIST=0'   # line 7
conf.cc.defines << 'MRB_SAME_LIST=1'   # line 8: later in the same list
conf.cc.defines << 'MRB_PART=0'        # line 9; a gem writes MRB_PART=1 to its own cc
```

```console
  MRB_PART=0       cc                    build_config/demo.rb:9   [MRB_PART=1 wins for mruby-x cc]
  MRB_PART=1       mruby-x cc            mrbgems/mruby-x/mrbgem.rake:6
  MRB_SAME_LIST=0  cc                    build_config/demo.rb:7   [MRB_SAME_LIST=1 wins]
  MRB_SAME_LIST=1  cc                    build_config/demo.rb:8
  MRB_TEST_KNOB=0  cc                    build_config/demo.rb:5   [MRB_TEST_KNOB=1 wins]
  MRB_TEST_KNOB=1  conf                  build_config/demo.rb:6
```

The marks were checked against the `-D` order the build records in the objects' `.flags` files: a core object compiles with `... MRB_PART=0 ... MRB_TEST_KNOB=1` and the gem's object with `... MRB_PART=0 ... MRB_PART=1 ... MRB_TEST_KNOB=1`, which is what the table says.

## Speed

The recording is a few dozen `caller_locations` calls while the configuration loads, and the printing is one table per target. A no-op `rake` of the default configuration, three runs each side:

| | run 1 | run 2 | run 3 |
| --- | --- | --- | --- |
| master | 0.69s | 0.67s | 0.67s |
| this branch | 0.70s | 0.67s | 0.66s |

## Size

No C source changes. Built from `git archive` trees of master and this branch with `.revision` removed from both (the baked `MRUBY_REVISION` is the one thing that separates the two sources' outputs), `libmruby.a`, `bin/mruby` and `bin/mrbc` of the default configuration are byte-identical. With the revision in place, the only differing object out of the whole build is `src/version.o`.

## Testing

- `rake -m test` (host, clang): 2593 assertions, OK 2528, KO 0, Crash 0, Skip 65.
- The tables were checked for `default`, `minimal`, `host-debug`, all five `ci/gcc-clang` targets, and a scratch configuration exercising `+=`, assignment, a valued define written twice in one list, in two lists, and a gem redefining a build-wide name. No row reads `(unknown)`, and no stock configuration gains a mark.
- A default build prints nothing; a `conf.define_log` build opens with the table, on a no-op rebuild too; `rake clean` prints nothing.

## Environment

<details>

- Linux x86_64 (kernel 7.0.0)
- Homebrew clang 23.1.0 (`CC=clang`)
- ruby 4.0.6, rake 13.3.1

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a define log showing compilation defines, their sources, and originating file and line.
  - Added `rake defines` to view define tables without building.
  - Added markers identifying overridden or context-dependent define values.
  - Builds can opt in to define-log output through configuration; output is disabled by default.

- **Documentation**
  - Documented define-log output, define precedence, winner markers, and configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->