### PR TITLE
ci: add a build without Float and one without bigint

### DIFF
--- a/build_config/ci/gcc-clang.rb
+++ b/build_config/ci/gcc-clang.rb
@@ -106,3 +106,49 @@ MRuby::Build.new('ascii-ctype') do |conf|
 
   conf.enable_test
 end
+
+# The two builds below are left off an emulated runner for the accounting at
+# the top of this file, and neither is about an ABI: one takes Float out of
+# the numeric tower, the other stops Integer at mrb_int, so what they cover
+# reads the same wherever it is compiled. On a runner that executes its own
+# instructions the pair costs the second each of their suites takes, which is
+# why the native runners are the ones asked for them.
+if ENV['MRUBY_CI_EMULATED'].to_s.empty?
+MRuby::Build.new('no-float') do |conf|
+  conf.toolchain
+
+  # The one build here without Float. MRB_NO_FLOAT takes the type out of the
+  # numeric tower, and what is written for its absence compiles nowhere else
+  # in CI: the integer arms of Time, Rational and sleep, the %f that String#%
+  # refuses, and the codegen that reads a float literal as Integer 0 rather
+  # than a pool entry. The gems that refuse the define say so with #error and
+  # leave full-core here, Math, Complex and CMath; mruby-benchmark leaves it
+  # too, its Tms being fractional seconds its README documents as Float and
+  # its to_s formatting them with %f.
+  # Tests only, for the reason byte-string gives above.
+  conf.gembox 'full-core'
+  %w(mruby-math mruby-complex mruby-cmath mruby-benchmark).each do |g|
+    conf.gems.delete g
+  end
+  conf.compilers.each do |c|
+    c.defines << 'MRB_NO_FLOAT'
+  end
+
+  conf.enable_test
+end
+
+MRuby::Build.new('no-bigint') do |conf|
+  conf.toolchain
+
+  # The one build here whose Integer ends at mrb_int. Every other build in
+  # CI carries mruby-bigint, so the RangeError that arithmetic raises where
+  # mrb_int overflows, the literal the compiler refuses for the same reason,
+  # and the half of each width-dependent test written for the gem's absence
+  # run nowhere else; on the i686 runner that edge is 32 bits wide.
+  # Tests only, for the reason byte-string gives above.
+  conf.gembox 'full-core'
+  conf.gems.delete 'mruby-bigint'
+
+  conf.enable_test
+end
+end

--- a/mrbgems/mruby-env/test/env.rb
+++ b/mrbgems/mruby-env/test/env.rb
@@ -189,11 +189,20 @@ assert('ENV.reject') do
 end
 
 assert('ENV.replace') do
-  ENV["MRUBY_ENV_TEST_U1"] = "old1"
-  ENV.replace({"MRUBY_ENV_TEST_U2" => "new2"})
-  assert_nil ENV["MRUBY_ENV_TEST_U1"]
-  assert_equal "new2", ENV["MRUBY_ENV_TEST_U2"]
-  ENV.delete("MRUBY_ENV_TEST_U2")
+  # `replace` clears the environment first, and that environment is the
+  # process's own: what is taken away is gone for every test that runs after
+  # this one, in a run where the whole suite is one process. PATH is the
+  # entry that costs, since a later test may need it to name a command or to
+  # load a library, so the whole environment is put back before returning.
+  saved = ENV.to_h
+  begin
+    ENV["MRUBY_ENV_TEST_U1"] = "old1"
+    ENV.replace({"MRUBY_ENV_TEST_U2" => "new2"})
+    assert_nil ENV["MRUBY_ENV_TEST_U1"]
+    assert_equal "new2", ENV["MRUBY_ENV_TEST_U2"]
+  ensure
+    ENV.replace(saved)
+  end
 end
 
 assert('ENV.update/merge!') do

--- a/mrbgems/mruby-rational/src/rational.c
+++ b/mrbgems/mruby-rational/src/rational.c
@@ -551,17 +551,22 @@ nil_to_r(mrb_state *mrb, mrb_value self)
   return rational_new_i(mrb, 0, 1);
 }
 
-#if !defined(MRB_NO_FLOAT) || defined(RAT_BIGINT)
 static mrb_value
 rational_new(mrb_state *mrb, mrb_value a, mrb_value b)
 {
 #ifdef MRB_NO_FLOAT
-  /* The #if above admits this arm only when RAT_BIGINT is on, so a Bigint
-     operand is possible here and takes the same route as in the arm below:
+#ifdef RAT_BIGINT
+  /* A Bigint operand takes the same route as in the arm below:
      mrb_ensure_int_type() narrows a Bigint to an mrb_int, which is what
      rational_new_b() exists to avoid. */
   if (mrb_bigint_p(a) || mrb_bigint_p(b)) {
     return rational_new_b(mrb, mrb_as_bint(mrb, a), b);
+  }
+#endif
+  /* And a Rational operand the route the arm below gives it: the
+     integer coercion would truncate it through Rational#to_i. */
+  if (mrb_type(a) == MRB_TT_RATIONAL || mrb_type(b) == MRB_TT_RATIONAL) {
+    return mrb_rational_div(mrb, mrb_as_rational(mrb, a), b);
   }
   a = mrb_ensure_int_type(mrb, a);
   b = mrb_ensure_int_type(mrb, b);
@@ -609,29 +614,6 @@ rational_m(mrb_state *mrb, mrb_value self)
   mrb_get_args(mrb, "o|o", &a, &b);
   return rational_new(mrb, a, b);
 }
-
-#else
-
-/*
- * call-seq:
- *   Rational(numerator, denominator = 1) -> rational
- *
- * Creates a rational number from numerator and denominator.
- * The rational is automatically reduced to lowest terms.
- *
- *   Rational(1, 2)    #=> Rational(1, 2)
- *   Rational(6, 8)    #=> Rational(3, 4)
- *   Rational(5)       #=> Rational(5, 1)
- *   Rational(-2, 4)   #=> Rational(-1, 2)
- */
-static mrb_value
-rational_m(mrb_state *mrb, mrb_value self)
-{
-  mrb_int n, d = 1;
-  mrb_get_args(mrb, "i|i", &n, &d);
-  return rational_new_i(mrb, n, d);
-}
-#endif
 
 #ifdef RAT_BIGINT
 /* The bigint half of the union is what this reads, and rational_eq() reaches
@@ -1290,11 +1272,7 @@ rat_pow_int(mrb_state *mrb, mrb_value x, mrb_value e)
   if (inverse) {
     mrb_value t = a; a = b; b = t;   /* 0 in the numerator becomes 0 below */
   }
-#if !defined(MRB_NO_FLOAT) || defined(RAT_BIGINT)
   return rational_new(mrb, a, b);
-#else
-  return rational_new_i(mrb, mrb_integer(a), mrb_integer(b));
-#endif
 }
 
 /*

--- a/mrbgems/mruby-rational/src/rational.c
+++ b/mrbgems/mruby-rational/src/rational.c
@@ -554,7 +554,15 @@ nil_to_r(mrb_state *mrb, mrb_value self)
 static mrb_value
 rational_new(mrb_state *mrb, mrb_value a, mrb_value b)
 {
+  /* Rational(a, b) is a/b, and with a Rational among exact operands the
+     quotient is exact, so a Rational is asked about before anything that
+     would convert it: mrb_as_bint() below reaches a non-Bigint through
+     mrb_as_int(), and the integer coercion and the Float arm each lose it
+     the same way. */
 #ifdef MRB_NO_FLOAT
+  if (mrb_type(a) == MRB_TT_RATIONAL || mrb_type(b) == MRB_TT_RATIONAL) {
+    return mrb_rational_div(mrb, mrb_as_rational(mrb, a), b);
+  }
 #ifdef RAT_BIGINT
   /* A Bigint operand takes the same route as in the arm below:
      mrb_ensure_int_type() narrows a Bigint to an mrb_int, which is what
@@ -563,11 +571,6 @@ rational_new(mrb_state *mrb, mrb_value a, mrb_value b)
     return rational_new_b(mrb, mrb_as_bint(mrb, a), b);
   }
 #endif
-  /* And a Rational operand the route the arm below gives it: the
-     integer coercion would truncate it through Rational#to_i. */
-  if (mrb_type(a) == MRB_TT_RATIONAL || mrb_type(b) == MRB_TT_RATIONAL) {
-    return mrb_rational_div(mrb, mrb_as_rational(mrb, a), b);
-  }
   a = mrb_ensure_int_type(mrb, a);
   b = mrb_ensure_int_type(mrb, b);
   return rational_new_i(mrb, mrb_integer(a), mrb_integer(b));
@@ -575,18 +578,17 @@ rational_new(mrb_state *mrb, mrb_value a, mrb_value b)
   if (mrb_integer_p(a) && mrb_integer_p(b)) {
     return rational_new_i(mrb, mrb_integer(a), mrb_integer(b));
   }
+  /* A Float operand is not exact, so the pair goes to the Float arm below
+     even with a Rational beside it. */
+  else if ((mrb_type(a) == MRB_TT_RATIONAL || mrb_type(b) == MRB_TT_RATIONAL) &&
+           !mrb_float_p(a) && !mrb_float_p(b)) {
+    return mrb_rational_div(mrb, mrb_as_rational(mrb, a), b);
+  }
 #ifdef RAT_BIGINT
   else if (mrb_bigint_p(a) || mrb_bigint_p(b)) {
     return rational_new_b(mrb, mrb_as_bint(mrb, a), b);
   }
 #endif
-  else if ((mrb_type(a) == MRB_TT_RATIONAL || mrb_type(b) == MRB_TT_RATIONAL) &&
-           !mrb_float_p(a) && !mrb_float_p(b)) {
-    /* Rational(a, b) is a/b, and with a Rational among exact operands the
-       quotient is exact; the Float arm below would round it through a
-       division of two doubles. */
-    return mrb_rational_div(mrb, mrb_as_rational(mrb, a), b);
-  }
   else {
     mrb_float x = mrb_as_float(mrb, a);
     mrb_float y = mrb_as_float(mrb, b);

--- a/mrbgems/mruby-rational/test/rational.rb
+++ b/mrbgems/mruby-rational/test/rational.rb
@@ -636,3 +636,19 @@ assert 'Kernel#Rational with a Rational operand stays exact' do
   assert_equal Rational(3, 1), Rational(1, Rational(1, 3))
   assert_equal Rational(1, 6), Rational(Rational(1, 3), 2)
 end
+
+assert 'Kernel#Rational with a Rational and a Bigint operand stays exact' do
+  # The Bigint arm reaches a non-Bigint operand through mrb_as_int(), which
+  # truncates a Rational, so the Rational has to be asked about first. The
+  # shift count is a variable because a constant shift wider than mrb_int is
+  # folded at compile time, which fails the build instead of raising.
+  k = 70
+  begin
+    big = 1 << k
+  rescue RangeError
+    skip 'requires mruby-bigint'
+  end
+  assert_equal Rational(1, big * 2), Rational(Rational(1, 2), big)
+  assert_equal Rational(big * 2, 1), Rational(big, Rational(1, 2))
+  assert_equal Rational(1, big * 3), Rational(Rational(1, 3), big)
+end

--- a/mrbgems/mruby-task/src/task.c
+++ b/mrbgems/mruby-task/src/task.c
@@ -866,10 +866,27 @@ mrb_f_sleep(mrb_state *mrb, mrb_value self)
     mrb_raise(mrb, E_ARGUMENT_ERROR, "time interval must be positive");
   }
 
-  mrb_int ms = (mrb_int)(sec * 1000);
+  /* The wait reaches sleep_ms_impl() as milliseconds, is multiplied to
+     microseconds in a uint32_t there, and is then handed to the HAL as an
+     mrb_int, which a narrow one cannot hold past its own maximum and answers
+     by not sleeping at all. The smaller of those two is the longest wait
+     that can be named: some 71 minutes where mrb_int is 64 bits, some 35
+     where it is 32. A longer one is given that, which is also what keeps the
+     conversion below defined, `sec * 1000` being a signed multiplication
+     that overflows without Float and a product no mrb_int can hold with
+     one. */
+#if MRB_INT_MAX < UINT32_MAX
+  const mrb_int sec_max = MRB_INT_MAX / 1000000;
+#else
+  const mrb_int sec_max = (mrb_int)(UINT32_MAX / 1000000);
+#endif
+  mrb_int ms = sec > sec_max ? sec_max * 1000 : (mrb_int)(sec * 1000);
   sleep_ms_impl(mrb, (uint32_t)ms);
 
-  return mrb_fixnum_value((mrb_int)sec);
+  /* The seconds waited, which is what the cap leaves of the seconds asked
+     for; casting `sec` itself is the second value a Float too wide for an
+     mrb_int has nowhere to go. */
+  return mrb_fixnum_value(ms / 1000);
 }
 
 static mrb_value

--- a/mrbgems/mruby-task/src/task.c
+++ b/mrbgems/mruby-task/src/task.c
@@ -832,8 +832,13 @@ sleep_ms_impl(mrb_state *mrb, uint32_t ms)
 static mrb_value
 mrb_f_sleep(mrb_state *mrb, mrb_value self)
 {
+#ifndef MRB_NO_FLOAT
   mrb_float sec = 0;
   mrb_int n = mrb_get_args(mrb, "|f", &sec);
+#else
+  mrb_int sec = 0;
+  mrb_int n = mrb_get_args(mrb, "|i", &sec);
+#endif
 
   if (n == 0) {
     /* No argument - suspend indefinitely */

--- a/mrbgems/mruby-task/test/queue.rb
+++ b/mrbgems/mruby-task/test/queue.rb
@@ -195,7 +195,8 @@ end
 
 assert("Task::Queue timeout validates arguments") do
   q = Task::Queue.new
-  assert_raise(TypeError) { q.pop(timeout_ms: 1.0) }
+  # a build without Float reads the literal as Integer 0, which is accepted
+  assert_raise(TypeError) { q.pop(timeout_ms: 1.0) } if Object.const_defined?(:Float)
   assert_raise(ArgumentError) { q.pop(timeout_ms: -1) }
   assert_raise(ArgumentError) { q.pop(true, timeout_ms: 1) }
 end


### PR DESCRIPTION
## Summary

Every build in CI carries Float and mruby-bigint, so what the tree writes for their absence compiles and runs nowhere. This PR gives `ci/gcc-clang` a build without each, and the three defects that turning them on found.

## Changes

| file | change |
|---|---|
| `mrbgems/mruby-task/src/task.c` | `mrb_f_sleep()` reads integer seconds where the build has no Float, and bounds the wait it converts |
| `mrbgems/mruby-task/test/queue.rb` | the `timeout_ms: 1.0` refusal is asked only where Float exists |
| `mrbgems/mruby-rational/src/rational.c` | one `rational_new()` for every build; both arms keep a Rational operand exact and ask about one before a Bigint |
| `mrbgems/mruby-rational/test/rational.rb` | a Rational paired with a Bigint |
| `mrbgems/mruby-env/test/env.rb` | the environment `ENV.replace` clears is put back in an `ensure` |
| `build_config/ci/gcc-clang.rb` | `no-float` and `no-bigint` builds, asked of the native runners |

### `sleep` had no integer arm (commit 1)

mruby-task's README says `sleep` "accepts integers or floats (when `MRB_NO_FLOAT` is not defined)", and the C side never had the integer half: `mrb_f_sleep()` reads its argument with `|f` into an `mrb_float`, a type a build without Float does not define, so the gem does not compile there at all. It takes the shape mruby-sleep's `f_sleep()` already has, `|i` into an `mrb_int`.

One test asks `Task::Queue#pop` to refuse `timeout_ms: 1.0` with a TypeError. Where there is no Float the compiler reads that literal as Integer 0, which the method accepts, so the assertion is asked only where Float exists, as the `sleep` tests beside it already are.

### `Kernel#Rational` lost a Rational operand (commit 2)

`eccb4b63c` routed a Rational operand through `mrb_rational_div()` so the quotient stays exact, but only in the arm a build with Float compiles. The other arm coerces both operands to Integer, which sends a Rational through `Rational#to_i`:

```ruby
Rational(Rational(1, 3), 1)
# CRuby: (1/3)
# mruby with MRB_NO_FLOAT: (0/1)
Rational(1, Rational(1, 3))
# CRuby: (3/1)
# mruby with MRB_NO_FLOAT: ZeroDivisionError: divided by 0 in rational
```

It takes the same route now. A build with neither Float nor mruby-bigint had a `rational_m()` of its own reading `i|i`, which truncates the same way, and `rat_pow_int()` reached past `rational_new()` for the same reason; one `rational_new()` serves every build, so both copies go.

### A test emptied the environment and left it that way (commit 3)

`ENV.replace` clears before it stores, and the environment it clears is the process's, which the whole suite shares. The test never put it back, so every test after it ran with no environment at all. On Windows that is what PATH is needed for, and the two things that ask for it answer:

```
'findstr' is not recognized as an internal or external command
getnameinfo: The requested service provider could not be loaded or initialized.
```

`cmd.exe` resolves a command name through PATH, which is how mruby-io's `popen` tests reach `findstr`, and Winsock loads its provider the first time a socket is made. Whether anything noticed came down to which tests ran after: in every build CI has today mruby-io comes before mruby-env and a socket is made before the environment goes, while a build whose gem list puts mruby-env first has both mruby-io and mruby-socket behind it. The `no-float` build below is such a build, and this is what it found. The test now takes the environment with `ENV.to_h` and restores it in an `ensure`.

### A build without Float, and one without bigint (commit 4)

Both start from `full-core`, so the rest of the box stays on the side being tested, and both are tests only, for the reason `byte-string` gives above.

`no-float` is what reaches the tree's `MRB_NO_FLOAT` arms: the integer halves of Time, Rational and `sleep`, the `%f` that `String#%` refuses, and the codegen that reads a float literal as Integer 0 rather than a pool entry. The gems that refuse the define say so with `#error` and leave the box here, Math, Complex and CMath; mruby-benchmark leaves it too, its `Tms` being fractional seconds its README documents as Float and its `to_s` formatting them with `%f`.

`no-bigint` is the build whose Integer ends at `mrb_int`. Every other build in CI carries the gem, so the RangeError that arithmetic raises with nothing wider to widen into, the literal the compiler refuses for the same reason, and the half of each width-dependent test written for the gem's absence run nowhere else. On the i686 runner it is also the `MRB_INT32` build with nothing beyond 32 bits, which the matrix has not had.

Both are asked of the native runners only, behind the guard the `full-debug` build already stands behind. Neither is about an ABI, so what they cover reads the same wherever it is compiled, and an emulated job's length is what decides whether that runner stays in the matrix at all. The emulated runner is left the four builds it has now, which is what the comment above the guard says of it.

### A Rational paired with a Bigint (commit 5)

Review found that the arm above is asked about too late: the Bigint arm comes first and converts through `mrb_as_bint()`, which sends a non-Bigint on through `mrb_as_int()`. Both arms carry that order, the Float one `eccb4b63c` wrote and the `MRB_NO_FLOAT` one commit 2 mirrored from it, so a build with Float answers the same way:

```ruby
big = 1 << 70
Rational(Rational(1, 2), big)
# CRuby: (1/2361183241434822606848)
# mruby, both builds: (0/1)
Rational(big, Rational(1, 2))
# CRuby: (2361183241434822606848/1)
# mruby, both builds: ZeroDivisionError: divided by 0 in rational
```

Both now ask about a Rational first, and the three rows are a test guarded on mruby-bigint. A Float operand is not exact and keeps its own arm, so `Rational(Rational(1, 2), 0.5)` still goes to the Float division.

### The wait `sleep` converts (commit 6)

Review also asked what bounds the conversion the integer arm does, and a `-fsanitize=undefined` build answers that nothing did, in either arm:

```
# without Float, sleep(1 << 62)
task.c:869:30: runtime error: signed integer overflow: 4611686018427387904 * 1000 cannot be represented in type 'mrb_int' (aka 'long')

# with Float, sleep(1e300)
task.c:870:16: runtime error: 1e+303 is outside the range of representable values of type 'long'
task.c:884:27: runtime error: 1e+300 is outside the range of representable values of type 'long'
```

`sleep_ms_impl()` takes milliseconds and multiplies them to microseconds in a `uint32_t`, and hands those to `mrb_hal_task_sleep_us()` as an `mrb_int`. Review named the second half of that: a 32-bit `mrb_int` cannot hold the microseconds a `uint32_t` can, and the POSIX, Windows and GLib ports each read the negative that conversion makes as nothing to wait for and return without sleeping. The bound is the smaller of the two, and every step holds what it is given at both widths:

| mrb_int | seconds | milliseconds | microseconds |
|---|---|---|---|
| 32 bits | 2,147 | 2,147,000 | 2,147,000,000 |
| 64 bits | 4,294 | 4,294,000 | 4,294,000,000 |

One bound serves both arms, and what comes back is now the seconds the cap leaves, the seconds actually waited, rather than a second cast of the argument. `sleep(0.25)` still answers 0 as CRuby does. No test reaches the bound: an argument large enough to convert wrongly sleeps for longer than a suite can wait.

## Behaviour

Only a build without Float sees the first two changes, and there was no such build to see them in:

```ruby
sleep 0                       # mruby-task: the gem did not compile at all
Rational(Rational(1, 3), 1)   # was (0/1), now (1/3)
Rational(1, Rational(1, 3))   # was ZeroDivisionError, now (3/1)
```

Commit 5 is the one every build sees, a Rational paired with a Bigint:

```ruby
big = 1 << 70
Rational(Rational(1, 2), big)   # was (0/1), now (1/2361183241434822606848)
Rational(big, Rational(1, 2))   # was ZeroDivisionError, now (2361183241434822606848/1)
```

Every reading was checked against CRuby 4.0.6.

## Speed

What the two builds cost a job, `rake -m test` over the whole config from an empty build directory, on a 32-thread machine:

| form | builds | master (bb6cd825e) | this PR | delta |
|---|---|---|---|---|
| native, clang | five to seven | 55.4 s | 66.3 s | +10.9 s |
| emulated, `arm-linux-gnueabihf-gcc` with `MRUBY_CI_EMULATED=1` | four, unchanged | 58.7 s, 57.0 s | 60.1 s, 56.9 s | none |

The emulated runner is asked for neither build, so what it compiles and runs is what it did before, and two readings of each side sit inside each other. A hosted native runner has fewer cores than this machine, so the compile share of that row grows there; the suites the two builds add are the cheap kind, one second each against the 33 to 47 the `MRB_GC_STRESS` build takes.

## Size

`.text` sum of `libmruby.a`, `MRUBY_CONFIG=ci/gcc-clang` under clang, both revisions built from the same source path into empty build directories.

| build | master (bb6cd825e) | this PR | delta |
|---|---|---|---|
| ascii-ctype | 1,115,707 | 1,115,775 | +68 |
| bintest | 1,120,623 | 1,120,691 | +68 |
| byte-string | 1,095,191 | 1,095,259 | +68 |
| cxx_abi | 1,109,017 | 1,109,085 | +68 |
| full-debug (-O0) | 1,933,188 | 1,933,252 | +64 |

The delta is the review commits, `rational.o` +36 and `task.o` +32 at `-O3`, and `task.o` +64 alone at `-O0`, where reordering the Rational test costs nothing. Commits 1 to 4 add none of it: the arms they touch sit inside `MRB_NO_FLOAT`, which a build with Float does not compile, and through commit 4 every one of these builds was byte for byte what master builds.

## Testing

- `rake -m test` on the default host config at each commit: 0 KO, 0 crash.
- `MRUBY_CONFIG=ci/gcc-clang rake -m test` under clang, gcc and `i686-linux-gnu-gcc`: all seven builds and bintest green.
- The same under `arm-linux-gnueabihf-gcc` with `MRUBY_CI_EMULATED=1`, the form the emulated job takes: the four builds it declared before this branch, and neither of the two new ones.
- The whole matrix on GitHub Actions, all thirteen jobs: https://github.com/takumin/mruby/actions/runs/33605783333. The armhf job there declares `ascii-ctype`, `bintest`, `byte-string` and `cxx_abi` and nothing else, which is the build set it had before this branch. The two MinGW runners are where commit 3 came from, and a run with the two builds declared first failed there the same way, which is what says the order inside the build is what decides it rather than the order of the builds.
- A scratch config for the pair the matrix still does not hold, `MRB_NO_FLOAT` with mruby-bigint also gone: 0 KO, 0 crash.
- Every `Kernel#Rational` reading above and the `sleep` argument were compared against CRuby 4.0.6, in a build with Float and in one without.
- A `-fsanitize=undefined` build of each side, with Float and without: `sleep(1 << 62)`, `sleep(1e300)` and `sleep(0.25)` report nothing after commit 6, and the three lines above before it.
- The narrow `mrb_int` half of commit 6 through the `i686-linux-gnu-gcc` run above, which is where a 32-bit one is.

## Environment

<details>

- Linux x86_64, kernel 7.0.0, AMD Ryzen 9 5950X
- Homebrew clang 23.1.0, gcc 13.3.0, i686-linux-gnu-gcc 13.3.0, arm-linux-gnueabihf-gcc 13.3.0
- GNU binutils 2.47, qemu-arm-static
- CRuby 4.0.6
- compile line, `no-float` (`src/vm.c`):

```
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -ffile-compilation-dir="." -DMRB_NO_FLOAT -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -MMD -c src/vm.c
```

- compile line, `no-bigint` (`src/vm.c`):

```
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -ffile-compilation-dir="." -DMRB_REVISION_HEADER -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -MMD -c src/vm.c
```

</details>

