### PR TITLE
string.c: start the byte-at-a-time tail where the word loop stopped

### DIFF
--- a/src/string.c
+++ b/src/string.c
@@ -932,7 +932,10 @@ memsearch_swar(const char *xs, mrb_int m, const char *ys, mrb_int n)
   }
 
   if (i+m < n) {
-    const char *p = s0;
+    /* From where the loop above stopped, not from the start: the positions
+       before it have been answered, and re-reading them is the whole subject
+       walked a second time on every search that ends in no match. */
+    const char *p = s0 + i;
     const char *e = ys + n;
     while (p<e) {
       p = (const char*)memchr(p, *xs, e - p);

--- a/test/t/string.rb
+++ b/test/t/string.rb
@@ -800,6 +800,20 @@ assert('String#index', '15.2.10.5.22') do
   assert_raise(TypeError) { "hello".index(101) }
 end
 
+assert('String#index over a subject longer than one search word') do
+  # A needle of two bytes or more in a subject long enough to be read a word
+  # at a time is searched in two parts: whole words first, then the bytes past
+  # the last whole one, one at a time.  The cases above are all shorter than a
+  # word, so they only ever reach the second part; these place the same needle
+  # on either side of the seam, and past the seam at the last position it can
+  # start at.
+  head = 'x' * 100
+  assert_equal 100, (head + 'needle' + head).index('needle')
+  assert_equal 100, (head + 'needle' + 'x').index('needle')
+  assert_equal 100, (head + 'ne').index('ne')
+  assert_nil (head + head).index('needle')
+end
+
 assert('String#index(UTF-8)', '15.2.10.5.22') do
   assert_equal 0, '⓿➊➋➌➍➎'.index('⓿')
   assert_nil '⓿➊➋➌➍➎'.index('➓')


### PR DESCRIPTION
## Summary

`memsearch_swar()` answers positions a machine word at a time and then walks whatever is left one position at a time. The walk began at the head of the subject rather than at the first position the word loop had not reached, so a search that ends in no match read the whole subject twice: once by word, and then again with the `memchr` and `memcmp` that the word loop is there to replace.

`("a" * 65536).index("aaaaab")` spends 30 times the instructions it needs and 0.315s where 0.007s does.

Base: `33dbb48b9`.

## Changes

| commit | what |
| --- | --- |
| `beb576c7e` | resume the tail walk where the word loop stopped, and pin the seam between the two loops with tests |

### `src/string.c`

The tail starts at `s0 + i` instead of `s0`. Leaving the loop, `i` is the first position it has not answered, so the positions before it are already settled and reading them again is the whole subject walked a second time.

The two loops still cover the subject between them. The word loop answers `[0, i)` and the tail answers `[i, n-m]`. When the word loop does not run at all, `lim` is not positive, `i` is 0 and the tail reads what it read before. When it does run, `i` is a multiple of `sizeof(bitint)` in `[lim, lim+sizeof(bitint)-1]`, so `i+m < n` holds and the tail is never skipped.

### `test/t/string.rb`

Every existing `String#index` case is shorter than one word plus the needle, so they all reach `memsearch_swar()`'s tail without its word loop having run: the seam was not covered. The new cases put the same needle on either side of it, and past it at the last position a match can start at, plus a subject long enough for the word loop that holds no match at all.

## Behaviour

Nothing observable changes. A search that ends in a match returns from the word loop and never reaches the tail; a search that ends in no match answers the same, having read the positions once instead of twice.

## Speed

Callgrind Ir per call, taken as `Ir(2N) - Ir(N)` over `N` so that startup and parsing cancel:

| case | master | this PR | |
| --- | ---: | ---: | --- |
| `("a" * 65536).index("aaaaab")` | 4,539,211 | 149,997 | 30.3x |
| a 42 KiB log `.index("zzzzzz")` | 102,570 | 98,215 | 1.04x |
| the same log `.index("https")` | 98,161 | 98,161 | unchanged |

The third case ends in a match, returns from the word loop and never reaches the tail, so it comes back identical to the tenth of an instruction. Sixteen `mruby-regexp` cases and two unrelated controls are identical the same way.

Wall clock, minimum of 7 runs of `Benchmark.measure` on a pinned core:

| case | iterations | master | this PR | |
| --- | ---: | ---: | ---: | --- |
| `("a" * 65536).index("aaaaab")` | 1,000 | 0.3153s | 0.0072s | 43.8x |
| a 42 KiB log `.index("zzzzzz")` | 20,000 | 0.1011s | 0.0955s | 1.06x |
| the same log `.index("https")` | 20,000 | 0.0955s | 0.0956s | noise |

A case whose Ir is identical moved by up to 3% between runs on this host, which is the noise floor to read the last row against.

The commit message quotes the same three cases measured with clang rather than gcc; the tables here are the gcc build the section below describes.

## Size

`.text` of `bin/mruby` for the five `build_config/ci/gcc-clang.rb` builds, gcc, same worktree path, empty build directory, same `rake` target on both sides:

| build | master | this PR | delta |
| --- | ---: | ---: | ---: |
| bintest | 1,374,374 | 1,374,374 | 0 |
| ascii-ctype | 1,360,438 | 1,360,438 | 0 |
| byte-string | 1,337,494 | 1,337,494 | 0 |
| cxx_abi | 1,407,193 | 1,407,177 | -16 |
| full-debug (-O0) | 1,964,598 | 1,964,614 | +16 |

`string.o`'s `.text` is 53,984 on both sides, so the two builds that move are moving link padding rather than code.

## Testing

`MRUBY_CONFIG=ci/gcc-clang rake -m test` is green on all five builds, KO 0 and Crash 0. Each build's total rises by one over master, so the new assertion runs everywhere rather than being guarded out of some configuration.

## Environment

<details>

```
Ubuntu, Linux 7.0.0-30-generic x86_64, glibc 2.39
gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0
valgrind-3.27.1

gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration
    -Wwrite-strings -Wzero-length-array
    -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DMRB_UTF8_STRING -DMRB_USE_RATIONAL
    -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

The speed tables are taken with the full-core gembox at `-O3`. glibc's `memchr` dispatches to an AVX2 implementation here, which is what the tail costs when it runs.

</details>
