### PR TITLE
mruby-regexp: give each lookbehind branch its own rewind

### DIFF
--- a/mrbgems/mruby-regexp/README.md
+++ b/mrbgems/mruby-regexp/README.md
@@ -33,8 +33,8 @@ simulation) with backtracking fallback.
 - `\g<n>`, `\g<-n>`, `\g<+n>` the same by number, `\g<0>` the whole pattern
 - `(?=...)` positive lookahead
 - `(?!...)` negative lookahead
-- `(?<=...)` positive lookbehind (fixed-length only)
-- `(?<!...)` negative lookbehind (fixed-length only)
+- `(?<=...)` positive lookbehind (fixed-length, per branch)
+- `(?<!...)` negative lookbehind (fixed-length, per branch)
 - `(?>...)` atomic group
 - `(?imx-imx)` options for the rest of the enclosing group
 - `(?imx-imx:...)` options for the group's own body
@@ -236,9 +236,19 @@ Every entry is a place this engine answers a pattern differently from CRuby.
   the build's `String` reads them. Without `MRB_UTF8_STRING` both are bytes:
   `/./` matches one byte, `/Ā/` is two atoms of one byte each, and `/i` folds
   ASCII only. A binary (`ASCII-8BIT`) subject reads by byte on either build.
-- **Fixed-length lookbehind only**: `(?<=...)` and `(?<!...)` take no `*`, `+`,
-  `?` or alternation, and at most 255 bytes. A call inside one must be
-  fixed-length too, recursion included, or `invalid pattern in look-behind`.
+- **Fixed-length lookbehind only**: `(?<=...)` and `(?<!...)` take no `*`, `+`
+  or `?` and hold no lookaround of their own, which is
+  `invalid pattern in look-behind` when they do, and are at most 255 bytes
+  wide, which is `lookbehind too long (max 255 bytes)`. The body's branches
+  are fixed per branch as in CRuby, so `(?<=ab|c)` looks back two characters
+  down one branch and one down the other, and the line either side of that
+  falls in two places CRuby puts it elsewhere. A call narrows the whole body
+  to one width, since a body holding one is measured after the calls are
+  wired and can no longer be given a rewind per branch: `(?<=\g<1>|zz)(a)`
+  raises where CRuby accepts it. An option construct between the lookbehind
+  and its alternation is nothing here and an enclosure in CRuby, so
+  `(?<=(?i:ab|b))x` and `(?<=(?i)ab|b)x` are accepted where CRuby raises
+  (`(?<=(?i:ab)|b)x`, the option inside a branch, is accepted by both).
 - **No Unicode properties**: `\p{Alpha}`, `\p{L}` raise `RegexpError`, inside a
   character class as much as outside one. A bare `\p`, and `\pL`, is the
   letter. `[[:alpha:]]` asks for a letter of any script.

--- a/mrbgems/mruby-regexp/include/re_internal.h
+++ b/mrbgems/mruby-regexp/include/re_internal.h
@@ -60,12 +60,34 @@ enum re_opcode {
   RE_BACKREF,    /* backreference: a = group number, offset = 1 if case-insensitive */
   RE_LOOKAHEAD,  /* positive lookahead: offset = end of sub-pattern */
   RE_NEG_LOOKAHEAD, /* negative lookahead: offset = end of sub-pattern */
-  RE_LOOKBEHIND,     /* positive lookbehind: a = byte count, offset = end */
-  RE_NEG_LOOKBEHIND, /* negative lookbehind: a = byte count, offset = end */
-  RE_LB_WIDTH,       /* carrier after either lookbehind: a = character count.
-                        The executor rewinds by bytes against a binary subject
-                        and by characters otherwise, and the sub-pattern body
-                        starts past this instruction, at pc + 2. */
+  RE_LOOKBEHIND,     /* positive lookbehind: offset = end, a = 1 once the
+                        widths below are in place and 0 while the parse has
+                        left the measuring to measure_deferred_lookbehinds().
+                        It does not rewind: each branch of the sub-pattern
+                        rewinds by its own width, so the opener leaves the
+                        input where the lookbehind was entered and goes on at
+                        pc + 1. */
+  RE_NEG_LOOKBEHIND, /* negative lookbehind: as above */
+  RE_LB_WIDTH,       /* rewind by one fixed width, at the head of the branch
+                        that takes it: offset holds the byte count in its
+                        high 8 bits and the character count in its low 8
+                        bits, a fixed-width branch being at most 255 bytes
+                        wide so that both fit. The executor rewinds by bytes
+                        against a binary subject and by characters otherwise,
+                        which is why the two counts travel together; too
+                        little text before is this branch failing, and what
+                        the search tries next is the branch after it.
+
+                        A lookbehind whose top-level alternation takes
+                        different widths per branch, `(?<=ab|c)`, carries one
+                        of these at each branch's head, so the branches are
+                        tried in the order the alternation already gives them
+                        and each rewinds by its own measure; one whose body
+                        is a single fixed width carries one at the head of
+                        the body. RE_LOOK_END then asserts that the branch
+                        landed back where the lookbehind was entered, which
+                        is what keeps a branch of one width from matching
+                        from another's rewind. */
   RE_ATOMIC,         /* atomic group (?>...): offset = the group's number,
                         1 for the first one the pattern opens and no two the
                         same. The body follows and ends at the RE_ATOMIC_END
@@ -76,7 +98,8 @@ enum re_opcode {
                         the RE_ATOMIC it closes */
   RE_LOOK_END,       /* end of a lookaround's sub-pattern: offset = the
                         lookaround's number, from the same count as RE_ATOMIC;
-                        a = 1 for a negative one. The instruction after it is
+                        a holds RE_LOOK_NEGATED and RE_LOOK_LANDING. The
+                        instruction after it is
                         the text after the lookaround, which is where the
                         opener's `offset` points, so the opener finds its end
                         at offset - 1. */
@@ -103,6 +126,24 @@ enum re_opcode {
                         CRuby -- leaves a marker in the frame's place and
                         goes on where the frame says. */
 };
+
+/* RE_LOOK_END::a. The polarity says what a matched sub-pattern means. The
+   landing bit asks that the sub-pattern have ended where the lookaround was
+   entered, and stands only on a lookbehind whose branches take different
+   widths, the one shape that can miss: rewound by a branch two characters
+   wide, a branch one character wide matches and stops short. A lookahead
+   starts where the search stands and a lookbehind of one width is that wide
+   down every path, so neither can land anywhere else and neither pays for
+   the test. */
+#define RE_LOOK_NEGATED 1
+#define RE_LOOK_LANDING 2
+
+/* RE_LB_WIDTH::offset packs the two units one width is counted in. Both are
+   at most 255, the widest a lookbehind branch may be. */
+#define RE_LB_PACK(bytes, chars) \
+  ((uint16_t)((((bytes) & 0xff) << 8) | ((chars) & 0xff)))
+#define RE_LB_BYTES(offset) ((int)((offset) >> 8))
+#define RE_LB_CHARS(offset) ((int)((offset) & 0xff))
 
 /* Bytecode instruction (4 bytes each for alignment) */
 typedef struct {

--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -21,6 +21,9 @@
    silently alias different classes. */
 #define RE_MAX_CLASSES 256
 
+/* How many branches one alternation may hold. */
+#define RE_MAX_ALTS 64
+
 /* Compiler state.
 
    Everything the compile allocates and the finished pattern goes on owning
@@ -80,6 +83,23 @@ typedef struct {
   uint32_t depth;           /* nesting levels open at the parse point, one per
                                compile_alt() frame on the C stack; bounded by
                                MRB_REGEXP_PARSE_DEPTH_LIMIT */
+  /* The alternation that finished last, as the code index each of its
+     branches begins at, the span it covers, and how many branches it has.
+     The lookbehind arm reads it to tell a body that *is* an alternation
+     from one that merely holds one: only the first may give each branch a
+     rewind of its own, which is CRuby's line too. The record is cleared
+     when a lookbehind body begins, so what it holds is that body's own; the
+     alternation spanning the whole body is the last inside it to finish.
+
+     These are positions, so anything that moves or drops code ends the
+     record rather than adjusting it: insert_inst() clears it, and so does
+     every rollback in compile_quantified(). Without that, `(?:a|b){0}` would
+     leave the branch heads of an alternation whose code is gone, pointing at
+     whatever was emitted in its place. */
+  uint32_t alt_starts[RE_MAX_ALTS];
+  uint32_t alt_count;       /* 0 when no alternation has been compiled */
+  uint32_t alt_from;        /* code index of the alternation's first SPLIT */
+  uint32_t alt_to;          /* code index just past its last branch */
   mrb_bool has_call;        /* a \g call was emitted: resolve_calls() runs */
   mrb_value pending_calls;  /* the \g references the parse could not resolve,
                                as re_pending_call records in a String the GC
@@ -159,8 +179,8 @@ patch(re_compiler *c, uint32_t pos, uint16_t offset)
    each other and with the opcode set: both relocated the jumps alone, and a
    lookaround inside a quantified, repeated or alternated group kept an offset
    pointing at whatever the shift left in its place.
-   RE_LB_WIDTH is not here: it carries a character count in `a`, and RE_SAVE
-   and RE_BACKREF put a slot number and a case-fold flag in `offset` rather
+   RE_LB_WIDTH is not here: it carries a pair of widths in `offset`, and
+   RE_SAVE and RE_BACKREF put a slot number and a case-fold flag there rather
    than an index. RE_CALL is not here either, deliberately: while the parse
    runs, its `offset` is a pending-reference index that relocation would
    corrupt, and by the time resolve_calls() writes a code index into it, the
@@ -183,6 +203,12 @@ op_holds_code_index(uint8_t op)
 static void
 insert_inst(re_compiler *c, uint32_t pos, uint8_t op, uint8_t a, uint16_t offset)
 {
+  /* The alternation record is positions this does not adjust, so an insertion
+     is the end of it; see the record in re_compiler. The alternation that
+     writes one does so after its own insertions, and the lookbehind arm has
+     read the record into locals before it inserts anything, so nothing that
+     needs the record loses it here. */
+  c->alt_count = 0;
   emit(c, RE_JMP, 0, 0);  /* grow array */
   uint32_t len = c->code_len - 1 - pos;
   memmove(&c->pat->code[pos + 1], &c->pat->code[pos], sizeof(re_inst) * len);
@@ -1504,6 +1530,86 @@ compute_fixed_len(re_compiler *c, uint32_t start, uint32_t end, int *chars_out)
   return fixed_len_span(c, start, end, chars_out, 0);
 }
 
+/* One measured width, as the RE_LB_WIDTH that carries it. */
+static uint16_t
+lookbehind_width(re_compiler *c, uint32_t start, uint32_t end)
+{
+  int chars = 0;
+  int len = compute_fixed_len(c, start, end, &chars);
+  if (len < 0) compile_error(c, "invalid pattern in look-behind");
+  if (len > 255) compile_error(c, "lookbehind too long (max 255 bytes)");
+  /* The character count never exceeds the byte count, so it fits too. */
+  return RE_LB_PACK(len, chars);
+}
+
+/*
+ * Give the lookbehind at `lb_pos`, whose body is [sub_start, body_end), the
+ * rewinds it runs by, and refuse a body that has none.
+ *
+ * A body of a single fixed width carries one RE_LB_WIDTH at its head. A body
+ * that *is* an alternation carries one at the head of each branch, each
+ * measured on its own, which is how `(?<=ab|c)` looks back two characters
+ * down one branch and one down the other. CRuby draws its line in the same
+ * place, and by the same reading of the pattern: the branches of the body
+ * itself may differ, while an alternation anywhere else must come out one
+ * width or the body is refused, whether it stands under a capture,
+ * `(?<=(ab|b))`, or with anything beside it, `(?<=(?:a|bc)d)`. `(?:...)`
+ * around the whole body emits nothing, so `(?<=(?:ab|b))` is the first case
+ * there as it is here.
+ *
+ * The single width is tried first because the alternation may already be one:
+ * `(?<=ab|cd)` is two characters whichever branch runs, and one carrier for
+ * the whole body is one rewind rather than two identical ones.
+ */
+static void
+add_lookbehind_widths(re_compiler *c, uint32_t lb_pos, uint32_t sub_start,
+                      uint32_t body_end)
+{
+  uint16_t widths[RE_MAX_ALTS];
+  uint32_t heads[RE_MAX_ALTS];
+  uint32_t n;
+
+  int chars = 0;
+  int len = compute_fixed_len(c, sub_start, body_end, &chars);
+  if (len >= 0) {
+    if (len > 255) compile_error(c, "lookbehind too long (max 255 bytes)");
+    heads[0] = sub_start;
+    widths[0] = RE_LB_PACK(len, chars);
+    n = 1;
+  }
+  /* The alternation the body left behind is the body's own only when it
+     covers all of it: it starts where the body starts and ends at the
+     RE_LOOK_END, which stands at body_end - 1. */
+  else if (c->alt_count > 1 && c->alt_from == sub_start &&
+           c->alt_to == body_end - 1) {
+    n = c->alt_count;
+    for (uint32_t i = 0; i < n; i++) {
+      heads[i] = c->alt_starts[i];
+      widths[i] = lookbehind_width(c, heads[i], body_end);
+    }
+  }
+  else {
+    compile_error(c, "invalid pattern in look-behind");
+    return;  /* not reached */
+  }
+
+  /* With a rewind per branch, a branch can match from another's rewind and
+     stop short of where the lookbehind was entered, so the end has to check
+     where it landed. One width for the whole body is the width of every path
+     through it, and such a body cannot land anywhere else. */
+  if (n > 1) c->pat->code[body_end - 1].a |= RE_LOOK_LANDING;
+
+  /* Insert from the last head down, so that the heads still ahead of the
+     insertion keep the positions they were measured at. A branch's head is
+     what the alternation's SPLIT jumps to, and insert_inst() leaves such a
+     reference on the inserted instruction, so the branch now begins with its
+     rewind. */
+  c->pat->code[lb_pos].a = 1;  /* measured: measure_deferred skips it */
+  for (uint32_t i = n; i > 0; i--) {
+    insert_inst(c, heads[i - 1], RE_LB_WIDTH, 0, widths[i - 1]);
+  }
+}
+
 /* Parse the option letters of an inline (?...) group. The parser is
    positioned just past the '?'; it reads i, m, x and '-' in any order until
    the terminator (':' or ')'), a '-' switching the letters after it off.
@@ -1801,16 +1907,18 @@ add_pending_call(re_compiler *c, uint8_t kind, const char *at, uint32_t len,
 }
 
 /* Compile the sub-pattern of a lookaround, whose opener has just been
-   emitted, up to and including the RE_LOOK_END that closes it. The end
-   carries the lookaround's number, from the count the atomic groups use, so
-   that a cut aimed at this lookaround is told from one aimed at a group
-   around or inside it; see bt_match(). */
-static void
+   emitted, up to and including the RE_LOOK_END that closes it, and answer
+   where that end stands. The end carries the lookaround's number, from the
+   count the atomic groups use, so that a cut aimed at this lookaround is
+   told from one aimed at a group around or inside it; see bt_match(). The
+   landing bit is not set here: whether it is needed is known only once the
+   body is measured, and add_lookbehind_widths() sets it. */
+static uint32_t
 compile_look_body(re_compiler *c, mrb_bool negative)
 {
   uint16_t cut = (uint16_t)++c->num_cuts;
   compile_alt(c);
-  emit(c, RE_LOOK_END, negative, cut);
+  return emit(c, RE_LOOK_END, negative ? RE_LOOK_NEGATED : 0, cut);
 }
 
 /* Compile a single atom (character, class, group, etc.). Returns whether one
@@ -1870,37 +1978,29 @@ compile_atom(re_compiler *c)
           mrb_bool negative = (c->p[2] == '!');
           next_char(c); next_char(c); next_char(c);  /* skip ?<= or ?<! */
           uint32_t lb_pos = emit(c, negative ? RE_NEG_LOOKBEHIND : RE_LOOKBEHIND, 0, 0);
-          emit(c, RE_LB_WIDTH, 0, 0);
           uint32_t sub_start = c->code_len;
+          c->alt_count = 0;  /* the record is this body's own; see there */
           compile_look_body(c, negative);
-          c->pat->code[lb_pos].offset = (uint16_t)c->code_len;
+          uint32_t body_end = c->code_len;  /* the RE_LOOK_END is at body_end - 1 */
 
           /* A sub-pattern holding a \g call cannot be measured yet: where
              the call jumps is not decided until resolve_calls(), and the
-             body it runs may not be written yet. The RE_LB_WIDTH's spare
-             field marks the lookbehind for measure_deferred_lookbehinds(),
-             which runs the same walk once the calls are wired. */
+             body it runs may not be written yet. A width of its own per
+             branch is out of reach for one of those, the record above being
+             long gone by then, so it is left with the single carrier it can
+             be given here and measure_deferred_lookbehinds() fills that in
+             once the calls are wired. */
           mrb_bool deferred = FALSE;
-          for (uint32_t i = sub_start; i < c->code_len; i++) {
+          for (uint32_t i = sub_start; i < body_end; i++) {
             if (c->pat->code[i].op == RE_CALL) { deferred = TRUE; break; }
           }
           if (deferred) {
-            c->pat->code[lb_pos + 1].offset = 1;
+            insert_inst(c, sub_start, RE_LB_WIDTH, 0, 0);
           }
           else {
-            /* measure the sub-pattern for both rewind units */
-            int fixed_chars;
-            int fixed_len = compute_fixed_len(c, sub_start, c->code_len, &fixed_chars);
-            if (fixed_len < 0) {
-              compile_error(c, "invalid pattern in look-behind");
-            }
-            if (fixed_len > 255) {
-              compile_error(c, "lookbehind too long (max 255 bytes)");
-            }
-            c->pat->code[lb_pos].a = (uint8_t)fixed_len;
-            /* the character count never exceeds the byte count, so it fits */
-            c->pat->code[lb_pos + 1].a = (uint8_t)fixed_chars;
+            add_lookbehind_widths(c, lb_pos, sub_start, body_end);
           }
+          c->pat->code[lb_pos].offset = (uint16_t)c->code_len;
 
           if (peek(c) != ')') compile_error(c, "end pattern with unmatched parenthesis");
           next_char(c);
@@ -2713,6 +2813,7 @@ compile_quantified(re_compiler *c)
       if (assertion) {
         if (ch != '+') {
           c->code_len = start;
+        c->alt_count = 0;  /* the record's positions are gone with the code */
           skip_quantifiers(c);
           return;
         }
@@ -2765,6 +2866,7 @@ compile_quantified(re_compiler *c)
     if (assertion) {
       if (min == 0) {
         c->code_len = start;
+        c->alt_count = 0;  /* the record's positions are gone with the code */
         skip_quantifiers(c);
         return;
       }
@@ -2795,6 +2897,7 @@ compile_quantified(re_compiler *c)
       }
       else {
         c->code_len = start;
+        c->alt_count = 0;  /* the record's positions are gone with the code */
       }
     }
     else {
@@ -2882,7 +2985,7 @@ compile_alt_body(re_compiler *c)
 
   /* Collect all alternatives, then emit SPLIT chain at the end.
      This avoids insert_inst offset corruption for multi-way alternation. */
-  uint32_t alt_starts[64];  /* start positions of each alternative */
+  uint32_t alt_starts[RE_MAX_ALTS];  /* start positions of each alternative */
   int num_alts = 0;
   alt_starts[num_alts++] = alt_start;
 
@@ -2890,7 +2993,7 @@ compile_alt_body(re_compiler *c)
     next_char(c);
     emit(c, RE_JMP, 0, 0);  /* placeholder: jump to end */
     alt_starts[num_alts++] = c->code_len;
-    if (num_alts >= 64) compile_error(c, "too many alternatives");
+    if (num_alts >= RE_MAX_ALTS) compile_error(c, "too many alternatives");
     compile_seq(c);
   }
 
@@ -2929,6 +3032,15 @@ compile_alt_body(re_compiler *c)
     c->pat->code[jmp_pos].op = RE_JMP;
     c->pat->code[jmp_pos].offset = (uint16_t)end;
   }
+
+  /* Leave the branches where the lookbehind arm can find them; see the
+     record's declaration. Nothing moves this code between here and the arm's
+     look at it: a lookbehind body ends with the RE_LOOK_END emitted right
+     after this returns. */
+  for (int i = 0; i < num_alts; i++) c->alt_starts[i] = alt_starts[i];
+  c->alt_count = (uint32_t)num_alts;
+  c->alt_from = alt_starts[0] - split_count;
+  c->alt_to = end;
 }
 
 /* Bound the parser's own recursion. Every nesting level it descends into is
@@ -3593,6 +3705,7 @@ call_walk(const re_inst *code, uint32_t code_len, uint32_t start,
       case RE_WBOUND: case RE_NWBOUND:
       case RE_ATOMIC: case RE_ATOMIC_END:
       case RE_BACKREF: case RE_LOOK_END:
+      case RE_LB_WIDTH:  /* a rewind, which consumes nothing */
         pc++;
         continue;
       case RE_JMP:
@@ -3608,7 +3721,7 @@ call_walk(const re_inst *code, uint32_t code_len, uint32_t start,
         continue;
       case RE_LOOKBEHIND: case RE_NEG_LOOKBEHIND:
         if (look_forks) stack[top++] = in.offset;
-        pc += 2;  /* over the RE_LB_WIDTH carrier, into the sub-pattern */
+        pc++;  /* into the sub-pattern, whose head is a rewind */
         continue;
       case RE_CALL:
         if ((wall_mask >> in.a) & 1) break;
@@ -3737,26 +3850,20 @@ never_ending_check(re_compiler *c, uint32_t called, const uint32_t *entry)
 }
 
 /* Measure the lookbehinds whose sub-pattern holds a call, which the parse
-   marked and left; see the lookbehind arm in compile_atom(). The walk is the
-   parse's own, now able to follow a call. */
+   left unmeasured with an empty RE_LB_WIDTH at the head of the body; see the
+   lookbehind arm in compile_atom(). The walk is the parse's own, now able to
+   follow a call. Nothing may move code from here on, so the carrier that is
+   already there is the only one such a lookbehind gets: its body has to come
+   out one width, where a body without a call may take one per branch. */
 static void
 measure_deferred_lookbehinds(re_compiler *c)
 {
   for (uint32_t pc = 0; pc + 1 < c->code_len; pc++) {
     re_inst in = c->pat->code[pc];
     if (in.op != RE_LOOKBEHIND && in.op != RE_NEG_LOOKBEHIND) continue;
-    if (c->pat->code[pc + 1].offset != 1) continue;
-    int fixed_chars = 0;
-    int fixed_len = compute_fixed_len(c, pc + 2, in.offset, &fixed_chars);
-    if (fixed_len < 0) {
-      compile_error(c, "invalid pattern in look-behind");
-    }
-    if (fixed_len > 255) {
-      compile_error(c, "lookbehind too long (max 255 bytes)");
-    }
-    c->pat->code[pc].a = (uint8_t)fixed_len;
-    c->pat->code[pc + 1].a = (uint8_t)fixed_chars;
-    c->pat->code[pc + 1].offset = 0;
+    if (in.a != 0) continue;  /* measured during the parse */
+    c->pat->code[pc + 1].offset = lookbehind_width(c, pc + 2, in.offset);
+    c->pat->code[pc].a = 1;
   }
 }
 

--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -1278,16 +1278,73 @@ parse_quantifier(re_compiler *c, int *min_out, int *max_out, mrb_bool *ranged)
   return TRUE;
 }
 
+/* What one pc's measure is once fixed_len_walk() has reached it, in the two
+   units a rewind may count (see RE_LB_WIDTH). `len` doubles as the state:
+   the two markers below stand where no measure does. A fork's arms are
+   measured to the same `end` and their measures compared, so what is
+   remembered per pc is the distance from it to `end`, the same question
+   whichever arm asks it, which is what makes one table serve them all. */
+typedef struct {
+  int32_t len;    /* bytes, or RE_FLEN_NEW / RE_FLEN_BUSY */
+  int32_t chars;
+} re_flen_memo;
+
+#define RE_FLEN_NEW  (-1)   /* not measured yet */
+#define RE_FLEN_BUSY (-2)   /* being measured: reaching it again is a cycle,
+                               and a cycle is a body of no fixed width */
+
+static int fixed_len_walk(re_compiler *c, uint32_t start, uint32_t end,
+                          int *chars_out, int depth,
+                          re_flen_memo *memo, uint32_t memo_base,
+                          uint32_t memo_len);
+static int fixed_len_span(re_compiler *c, uint32_t start, uint32_t end,
+                          int *chars_out, int depth);
+
+/* The measure from `pc` to `end`, remembered under the table when `pc` is one
+   the table covers. Without it a chain of forks is measured once per path
+   through it, both arms of every fork walking the whole tail, and `(?:a|b)`
+   thirty times over is 2^30 walks of a pattern a hundred bytes long. */
+static int
+fixed_len_at(re_compiler *c, uint32_t pc, uint32_t end, int *chars_out,
+             int depth, re_flen_memo *memo, uint32_t memo_base,
+             uint32_t memo_len)
+{
+  if (!memo || pc < memo_base || pc - memo_base >= memo_len) {
+    return fixed_len_walk(c, pc, end, chars_out, depth, memo, memo_base, memo_len);
+  }
+  re_flen_memo *slot = &memo[pc - memo_base];
+  if (slot->len == RE_FLEN_BUSY) return -1;
+  if (slot->len != RE_FLEN_NEW) {
+    *chars_out = slot->chars;
+    return slot->len;
+  }
+  slot->len = RE_FLEN_BUSY;
+  int chars = 0;
+  int len = fixed_len_walk(c, pc, end, &chars, depth, memo, memo_base, memo_len);
+  if (len < 0) {
+    /* Leave the slot BUSY: a body with one unmeasurable path has no fixed
+       width at all, so no later question about this pc has a different
+       answer, and the compile is about to be refused either way. */
+    return -1;
+  }
+  slot->len = len;
+  slot->chars = chars;
+  *chars_out = chars;
+  return len;
+}
+
 /*
  * Measure the bytecode in range [start, end) for a lookbehind, which must
  * know exactly how far back to rewind. Returns the byte count a binary
  * subject needs, one per consuming instruction since such a subject
  * advances one byte whatever the instruction is, and stores in *chars_out
  * the character count a UTF-8 subject needs. Returns -1 if the sub-pattern
- * has no fixed width (quantifiers, alternation, etc.).
+ * has no fixed width (a quantifier, or a fork whose arms disagree).
  */
 static int
-fixed_len_walk(re_compiler *c, uint32_t start, uint32_t end, int *chars_out, int depth)
+fixed_len_walk(re_compiler *c, uint32_t start, uint32_t end, int *chars_out,
+               int depth, re_flen_memo *memo, uint32_t memo_base,
+               uint32_t memo_len)
 {
   int len = 0;
   int chars = 0;
@@ -1348,12 +1405,28 @@ fixed_len_walk(re_compiler *c, uint32_t start, uint32_t end, int *chars_out, int
     case RE_JMP:
       pc = inst.offset;
       break;
-    case RE_SPLIT: {
-      /* alternation: both branches must have the same fixed length */
-      /* branch 1: pc+1 to next JMP before branch 2 */
-      /* branch 2: inst.offset to ... */
-      /* For simplicity, reject alternation in lookbehind */
-      return -1;
+    case RE_SPLIT:
+    case RE_SPLITNG: {
+      /* A fork the walk passes through is fixed only where both arms reach
+         `end` by the same measure: `(?<=(a|b)c)` is two characters whichever
+         arm runs, and `(?<=(a|bb)c)` is not two of anything. The arms are
+         measured to `end` rather than to the point they rejoin, which is
+         what makes what follows the fork part of each arm's measure and
+         leaves `(?:a|bc)d` unmeasured. CRuby refuses that body too, and
+         accepts a whole body of branches taking different widths only
+         through the per-branch rewind the lookbehind arm builds.
+
+         A loop closes with a backward fork, so this is also where a body
+         that repeats is refused: the memo marks the pc it is measuring and
+         reaching it again answers -1. */
+      int a_chars = 0, b_chars = 0;
+      int a = fixed_len_at(c, pc + 1, end, &a_chars, depth, memo, memo_base, memo_len);
+      if (a < 0) return -1;
+      int b = fixed_len_at(c, inst.offset, end, &b_chars, depth, memo, memo_base, memo_len);
+      if (b < 0) return -1;
+      if (a != b || a_chars != b_chars) return -1;
+      *chars_out = chars + a_chars;
+      return len + a;
     }
     case RE_LOOK_END:
       *chars_out = chars;
@@ -1374,7 +1447,9 @@ fixed_len_walk(re_compiler *c, uint32_t start, uint32_t end, int *chars_out, int
       }
       if (close >= c->code_len) return -1;
       int sub_chars = 0;
-      int sub_len = fixed_len_walk(c, body, close, &sub_chars, depth + 1);
+      /* The body is measured to its own end, so it gets a table of its own:
+         what a pc is worth is its distance to the end being asked about. */
+      int sub_len = fixed_len_span(c, body, close, &sub_chars, depth + 1);
       if (sub_len < 0) return -1;
       len += sub_len;
       chars += sub_chars;
@@ -1389,10 +1464,44 @@ fixed_len_walk(re_compiler *c, uint32_t start, uint32_t end, int *chars_out, int
   return len;
 }
 
+/* Measure [start, end) with whatever table the span needs. A span holding no
+   fork and no backward edge is a straight line the walk crosses once, and it
+   is measured with no table at all, which is every lookbehind that was
+   measurable before per-branch widths. A span holding either gets one, since
+   without it the walk would either repeat the tail of every fork or, on a
+   loop, not come back. */
+static int
+fixed_len_span(re_compiler *c, uint32_t start, uint32_t end, int *chars_out,
+               int depth)
+{
+  mrb_bool needs_memo = FALSE;
+  for (uint32_t pc = start; pc < end && pc < c->code_len; pc++) {
+    uint8_t op = c->pat->code[pc].op;
+    if (op == RE_SPLIT || op == RE_SPLITNG ||
+        (op == RE_JMP && c->pat->code[pc].offset <= pc)) {
+      needs_memo = TRUE;
+      break;
+    }
+  }
+  if (!needs_memo) return fixed_len_walk(c, start, end, chars_out, depth, NULL, 0, 0);
+
+  uint32_t span = end > start ? end - start : 0;
+  /* mrb_malloc_simple(), not mrb_malloc(): a raise here would longjmp past
+     the frees of the spans measuring around this one. A refusal is reported
+     as a body of no fixed width, which is what the caller does with every
+     other answer it cannot use. */
+  re_flen_memo *memo = (re_flen_memo*)mrb_malloc_simple(c->mrb, sizeof(re_flen_memo) * (span ? span : 1));
+  if (!memo) return -1;
+  for (uint32_t i = 0; i < span; i++) memo[i].len = RE_FLEN_NEW;
+  int len = fixed_len_walk(c, start, end, chars_out, depth, memo, start, span);
+  mrb_free(c->mrb, memo);
+  return len;
+}
+
 static int
 compute_fixed_len(re_compiler *c, uint32_t start, uint32_t end, int *chars_out)
 {
-  return fixed_len_walk(c, start, end, chars_out, 0);
+  return fixed_len_span(c, start, end, chars_out, 0);
 }
 
 /* Parse the option letters of an inline (?...) group. The parser is

--- a/mrbgems/mruby-regexp/src/re_exec.c
+++ b/mrbgems/mruby-regexp/src/re_exec.c
@@ -778,23 +778,22 @@ pike_vm(mrb_state *mrb, const mrb_regexp_pattern *pat,
 }
 
 /*
- * Where the lookbehind at pc starts matching from: sp rewound by the byte
- * count in the opcode for a binary subject, and otherwise by the character
- * count in the RE_LB_WIDTH that follows it. The backward walk steps over
+ * Where a lookbehind branch starts matching from: sp rewound by the byte
+ * count the RE_LB_WIDTH at its head carries for a binary subject, and
+ * otherwise by the character count beside it. The backward walk steps over
  * continuation bytes with mrb_re_char_interior_p(), which keeps it on the
  * boundaries the forward decode uses, broken input included. Returns NULL
  * when the text before sp runs out first.
  */
 static const char*
-lookbehind_start(const mrb_regexp_pattern *pat, const char *str,
-                 const char *str_end, const char *sp, uint32_t pc,
-                 mrb_bool binary)
+lookbehind_start(const char *str, const char *str_end, const char *sp,
+                 uint16_t width, mrb_bool binary)
 {
   if (binary) {
-    int lb_len = pat->code[pc].a;
+    int lb_len = RE_LB_BYTES(width);
     return (sp - str < lb_len) ? NULL : sp - lb_len;
   }
-  int nchars = pat->code[pc + 1].a;
+  int nchars = RE_LB_CHARS(width);
   while (nchars > 0) {
     if (sp <= str) return NULL;
     sp--;
@@ -1324,41 +1323,58 @@ bt_match(bt_state *m, const char *sp, uint32_t pc)
       break;
 
     case RE_LOOKAHEAD:
-    case RE_LOOKBEHIND:
     case RE_NEG_LOOKAHEAD:
+    case RE_LOOKBEHIND:
     case RE_NEG_LOOKBEHIND:
       {
         /* The lookaround is entered: a barrier stands where it began, and
-           the sub-pattern goes on from here, from sp for a lookahead, from
-           the rewound start for a lookbehind. What the barrier holds is
-           where the text after the lookaround goes on from and the pass to
-           go on in; for a negative one that is what taking the barrier
-           resumes, its sub-pattern running out of alternatives being the
-           assertion holding. The sub-pattern runs as a pass of its own, one
-           no run before it had, so the records of the loops inside it that
-           an earlier run may have left live are not taken for this run's
-           (see bt_state). */
+           the sub-pattern goes on from here. What the barrier holds is where
+           the text after the lookaround goes on from and the pass to go on
+           in; for a negative one that is what taking the barrier resumes,
+           its sub-pattern running out of alternatives being the assertion
+           holding. The sub-pattern runs as a pass of its own, one no run
+           before it had, so the records of the loops inside it that an
+           earlier run may have left live are not taken for this run's (see
+           bt_state).
+
+           A lookbehind is entered at the same position as a lookahead: the
+           rewind belongs to the branch, not to the opener, so that the
+           branches of a body whose widths differ each look back their own
+           way and are tried in the order the alternation gives them. The
+           RE_LB_WIDTH at the head of the branch does it (see there). */
         mrb_bool negated = (inst.op == RE_NEG_LOOKAHEAD || inst.op == RE_NEG_LOOKBEHIND);
-        const char *from = sp;
-        uint32_t body = pc + 1;
-        if (inst.op == RE_LOOKBEHIND || inst.op == RE_NEG_LOOKBEHIND) {
-          from = lookbehind_start(pat, str, str_end, sp, pc, binary);
-          if (!from) {
-            /* not enough text before: a positive lookbehind cannot hold and
-               a negative one holds without a sub-pattern to run */
-            if (!negated) goto fail;
-            pc = inst.offset;
-            break;
-          }
-          body = pc + 2;
-        }
         if ((r = bt_push(m, sp, inst.offset, negated ? RE_CP_NEG : RE_CP_BARRIER,
                          pat->code[inst.offset - 1].offset)) != BT_OK) {
           return r;
         }
         m->pass = ++m->pass_seq;
+        pc++;
+        /* A lookbehind whose body takes one width begins with that rewind,
+           and taking it here rather than through another turn of the loop is
+           what leaves such a lookbehind, every one this engine compiled
+           before a branch could have a width of its own, costing what it
+           did. A body whose branches differ begins with the fork that picks
+           between them, and each branch rewinds when it is reached.
+
+           The opcode alone tells the two apart for a lookahead as well: a
+           rewind stands at the head of a lookbehind branch and nowhere
+           else, so a lookahead's body never begins with one. */
+        if (pat->code[pc].op != RE_LB_WIDTH) break;
+        inst = pat->code[pc];
+      }
+      /* fall through */
+
+    case RE_LB_WIDTH:
+      {
+        /* The branch this heads looks back by the width it carries. Too
+           little text before is this branch failing and nothing more: what
+           the search tries next is the branch after it, and with none left
+           the barrier below answers, a positive lookbehind not holding and
+           a negative one holding with no sub-pattern having run. */
+        const char *from = lookbehind_start(str, str_end, sp, inst.offset, binary);
+        if (!from) goto fail;
         sp = from;
-        pc = body;
+        pc++;
       }
       break;
 
@@ -1379,12 +1395,22 @@ bt_match(bt_state *m, const char *sp, uint32_t pc)
         uint32_t idx;
         if (!bt_barrier_find(m, inst.offset, &idx)) goto fail;
         re_cpoint c = m->cp[idx];
-        /* No boundary test either: a sub-pattern reaches the same
+        /* Where the sub-pattern is one whose branches rewind by different
+           widths, it has to have landed back where the lookaround was
+           entered: `(?<=c|ab)` rewound the two characters `ab` asks for can
+           still match `c` and stop a character short, which is a match of
+           the text before the wrong position. The test comes before the cut
+           below, so that a branch that lands short leaves the search the
+           alternatives it has not tried, which are the branches after it,
+           each with its own rewind. Every other lookaround lands where it
+           must by construction and carries no such bit; see RE_LOOK_LANDING.
+           No boundary test either: a sub-pattern reaches the same
            positions as the rest of the search, so an assertion that used to
            hold on half a character has no half to hold on. */
+        if ((inst.a & RE_LOOK_LANDING) && sp != c.sp) goto fail;
         m->cp_top = idx;
         m->pass = c.pass;
-        if (inst.a) {
+        if (inst.a & RE_LOOK_NEGATED) {
           bt_undo_to(m, c.undo_top);
           goto fail;
         }

--- a/mrbgems/mruby-regexp/test/regexp_call.rb
+++ b/mrbgems/mruby-regexp/test/regexp_call.rb
@@ -190,6 +190,17 @@ assert("Regexp - a call in a lookbehind must measure fixed") do
   assert_raise_with_message(RegexpError, "#{msg}: /(?<p>\\(\\g<p>?\\))(?<=\\g<p>)/") do
     Regexp.new("(?<p>\\(\\g<p>?\\))(?<=\\g<p>)")
   end
+
+  # A body without a call is measured while the parse still holds its
+  # branches, so each may rewind its own way. One with a call is measured
+  # after the calls are wired, when nothing may move code any more and the
+  # branches are long forgotten, so it gets the one rewind that was put in
+  # place for it and the whole body has to come out that width. CRuby, which
+  # divides the branches before it compiles either, accepts the second.
+  assert_equal 1, ("ba" =~ Regexp.new("(?<=\\g<1>)(a|b)"))
+  assert_raise_with_message(RegexpError, "#{msg}: /(?<=\\g<1>|zz)(a)/") do
+    Regexp.new("(?<=\\g<1>|zz)(a)")
+  end
 end
 
 assert("Regexp - the group numbering calls use") do

--- a/mrbgems/mruby-regexp/test/regexp_syntax.rb
+++ b/mrbgems/mruby-regexp/test/regexp_syntax.rb
@@ -2477,6 +2477,98 @@ assert("Regexp - negative lookbehind at string start") do
   assert_equal "a", md[0]
 end
 
+assert("Regexp - each branch of a lookbehind looks back its own way") do
+  need_backtracking_stack
+  # The body of a lookbehind is measured so the match knows how far to rewind,
+  # and the branches of an alternation need not measure the same: `(?<=ab|c)`
+  # looks back two characters down one branch and one down the other. Each
+  # branch carries its own rewind, so the widths do not have to be reconciled
+  # and none of them is tried for a branch it does not belong to.
+  assert_equal 2, ("abx" =~ /(?<=ab|c)x/)
+  assert_equal 1, ("cx" =~ /(?<=ab|c)x/)
+  assert_nil ("bx" =~ /(?<=ab|c)x/)
+  # three of them, and the shorter branch written last
+  assert_equal 3, ("abcx" =~ /(?<=abc|q|zz)x/)
+  assert_equal 1, ("qx" =~ /(?<=abc|q|zz)x/)
+  assert_equal 2, ("zzx" =~ /(?<=abc|q|zz)x/)
+  # a branch may be empty, which looks back at nothing and always holds
+  assert_equal 1, ("zx" =~ /(?<=a|)x/)
+  assert_equal 1, ("zx" =~ /(?<=|a)x/)
+  # the negative form is every branch failing
+  assert_nil ("abx" =~ /(?<!ab|c)x/)
+  assert_nil ("cx" =~ /(?<!ab|c)x/)
+  assert_equal 1, ("bx" =~ /(?<!ab|c)x/)
+  # a branch too near the start of the subject fails alone: the branches
+  # after it are still tried
+  assert_equal 1, ("cx" =~ /(?<=abcd|c)x/)
+end
+
+assert("Regexp - a lookbehind branch has to land where it was entered") do
+  need_backtracking_stack
+  # With one width per branch, a branch can match from another branch's
+  # rewind and stop short: rewound the two characters `ab` asks for, `c`
+  # matches the `c` of "cax" and ends before the `x`. That is a match of the
+  # text before the wrong position, so the sub-pattern has to have come back
+  # to where the lookbehind was entered. CRuby answers nil for both.
+  assert_nil ("cax" =~ /(?<=c|ab)x/)
+  assert_nil ("cax" =~ /(?<=ab|c)x/)
+  # and the branch that does land is still found, whichever order they are
+  # written in
+  assert_equal 2, ("acx" =~ /(?<=c|ab)x/)
+  assert_equal 2, ("abx" =~ /(?<=c|ab)x/)
+end
+
+assert("Regexp - the branches of a lookbehind are tried in order") do
+  need_backtracking_stack
+  # Two branches can match at once, and which one the captures come from is
+  # the order they are written in, not the order their widths are tried in.
+  # Both `(b)` and `(cb)` match before the `x` of "cbx"; the leftmost wins.
+  assert_equal ["x", nil, "b", nil], "cbx".match(/(?<=(ab)|(b)|(cb))x/).to_a
+  assert_equal ["x", "cb", nil, nil], "cbx".match(/(?<=(cb)|(b)|(ab))x/).to_a
+  # a capture a branch did not run stays unset
+  assert_equal ["x", "a", nil], "abx".match(/(?<=(a)b|(c))x/).to_a
+  assert_equal ["x", nil, "c"], "cx".match(/(?<=(a)b|(c))x/).to_a
+end
+
+assert("Regexp - an alternation a lookbehind body only holds must measure one width") do
+  need_backtracking_stack
+  # A body that *is* an alternation gives each branch its own rewind. An
+  # alternation anywhere else has to come out one width, since what stands
+  # beside it is measured from wherever it ends. CRuby draws the line in the
+  # same place, and reads the pattern the same way: `(?:...)` around the whole
+  # body is nothing at all, so the body is the alternation; a capture group is
+  # something, so the alternation is inside it.
+  assert_equal 2, ("abx" =~ /(?<=(?:ab|b))x/)
+  assert_equal 1, ("bx" =~ /(?<=(a|b))x/)
+  assert_equal 2, ("bcx" =~ /(?<=(?:a|b)c)x/)
+  assert_equal 2, ("xby" =~ /(?<=x(a|b))y/)
+
+  msg = "invalid pattern in look-behind"
+  ["(?<=(ab|b))x", "(?<=(?:a|bc)d)x", "(?<=a|b*)x", "(?<=(?:a|b)*)x"].each do |src|
+    assert_raise_with_message(RegexpError, "#{msg}: /#{src}/", src) do
+      Regexp.new(src)
+    end
+  end
+
+  # Which branches the body has is read from what the alternation left behind
+  # when it was compiled, and `{0}` throws the code away and emits the rest
+  # over the top of it. The branch heads then point at instructions belonging
+  # to something else, and this body, which is the refused `(?<=a?bc)` with
+  # such a record beside it, was taken for an alternation of two branches.
+  ["(?<=(?:a|b){0}a?bc)x", "(?<=(?:ab|c){0}a?bcd)x"].each do |src|
+    assert_raise_with_message(RegexpError, "#{msg}: /#{src}/", src) do
+      Regexp.new(src)
+    end
+  end
+
+  # An option construct is where the two engines part: it emits nothing here,
+  # so the alternation under it is still the body, where CRuby keeps it as an
+  # enclosure and refuses the first two of these. README.md lists it.
+  assert_equal 2, ("abx" =~ /(?<=(?i:ab|b))x/)
+  assert_equal 2, ("abx" =~ /(?<=(?i)ab|b)x/)
+  assert_equal 2, ("abx" =~ /(?<=(?i:ab)|b)x/)  # accepted by CRuby too
+end
+
 assert("Regexp - a lookbehind body of many forks is measured once per fork") do
   need_backtracking_stack
   # Both arms of a fork are measured to the end of the body, so a chain of

--- a/mrbgems/mruby-regexp/test/regexp_syntax.rb
+++ b/mrbgems/mruby-regexp/test/regexp_syntax.rb
@@ -2477,6 +2477,18 @@ assert("Regexp - negative lookbehind at string start") do
   assert_equal "a", md[0]
 end
 
+assert("Regexp - a lookbehind body of many forks is measured once per fork") do
+  need_backtracking_stack
+  # Both arms of a fork are measured to the end of the body, so a chain of
+  # them has a path per combination: twenty forks are a million paths, and
+  # walking each one is a compile that does not finish. What each pc is worth
+  # is remembered instead, which makes the measure one walk per arm.
+  re = Regexp.new("(?<=" + "(?:a|b)" * 20 + ")x")
+  assert_equal 20, (("a" * 20 + "x") =~ re)
+  assert_equal 20, (("b" * 10 + "a" * 10 + "x") =~ re)
+  assert_nil (("c" + "a" * 19 + "x") =~ re)
+end
+
 assert("Regexp - a capture inside a lookaround is undone with the lookaround") do
   need_backtracking_stack
   # A lookaround's sub-pattern used to run in a call of its own, so once it

--- a/mrbgems/mruby-regexp/test/regexp_utf8.rb
+++ b/mrbgems/mruby-regexp/test/regexp_utf8.rb
@@ -405,6 +405,25 @@ assert("Regexp - a capture spans whole characters") do
   assert_equal [0x81], bm[2].bytes
 end
 
+assert("Regexp - a lookbehind branch counts its own width in both units") do
+  need_backtracking_stack
+  # A rewind is counted in characters against a subject read as characters and
+  # in bytes against one read as bytes, so a branch carries both counts. With
+  # one width per branch there is a pair per branch, and the two branches here
+  # disagree in each unit on its own: `ā` is one character and two bytes, `bc`
+  # two characters and two bytes, so a rewind that had only the byte count
+  # could not tell them apart.
+  skip unless __ENCODING__ == "UTF-8"
+  assert_equal 1, ("ābx" =~ /(?<=ā|bc)b/)
+  assert_equal 2, ("bcbx" =~ /(?<=ā|bc)b/)
+  assert_nil ("abx" =~ /(?<=ā|bc)b/)
+  # the same pattern against a byte-indexed subject rewinds by the bytes, so
+  # both branches step back two of them
+  bin = "ābx".b
+  assert_equal 2, (bin =~ /(?<=ā|bc)b/)
+  assert_nil ("abx".b =~ /(?<=ā|bc)b/)
+end
+
 assert("Regexp - a lookaround holds where its sub-pattern matches") do
   # A lookaround consumes nothing, so where its sub-pattern stopped was not the
   # end of a match and nothing held it to a character. It could therefore

--- a/mrbgems/mruby-regexp/tools/difftest/baseline.txt
+++ b/mrbgems/mruby-regexp/tools/difftest/baseline.txt
@@ -4,10 +4,6 @@
 # taken with ruby 4.0.6p0 x86_64-linux
 # against a build with chars=1 unicode=1
 010101010101010101011010010101010101101001| 010101010101010101011010010101010101011001| #char U+00B2
-...22................X...|;;;2-2;2-2;;;;;;;;;;;;;;;;;X:ArgumentError;;; E:RegexpError| (?<=ab|c)/
-...22................X...|;;;2-2;2-2;;;;;;;;;;;;;;;;;X:ArgumentError;;; E:RegexpError| (?<=ab|c)/i
-...22................X...|;;;2-2;2-2;;;;;;;;;;;;;;;;;X:ArgumentError;;; E:RegexpError| (?<=ab|c)/m
-...22................X...|;;;2-2;2-2;;;;;;;;;;;;;;;;;X:ArgumentError;;; E:RegexpError| (?<=ab|c)/x
 .....................X...|;;;;;;;;;;;;;;;;;;;;;X:ArgumentError;;; E:RegexpError| [&&a]/
 .....................X...|;;;;;;;;;;;;;;;;;;;;;X:ArgumentError;;; E:RegexpError| [&&a]/i
 .....................X...|;;;;;;;;;;;;;;;;;;;;;X:ArgumentError;;; E:RegexpError| [&&a]/m


### PR DESCRIPTION
## Summary

A lookbehind was rewound by one width measured over its whole body, so a body whose branches take different widths had no width and was refused. Each branch now carries the rewind it needs, which is how CRuby reads the same pattern.

## Changes

| File | What |
|---|---|
| `include/re_internal.h` | `RE_LB_WIDTH` moves into the body and packs both units in `offset`; adds `RE_LOOK_NEGATED`, `RE_LOOK_LANDING`, `RE_LB_PACK` |
| `src/re_compile.c` | adds `fixed_len_at()`, `fixed_len_span()`, `lookbehind_width()`, `add_lookbehind_widths()`; `fixed_len_walk()` measures forks; `compile_look_body()` answers where its end stands |
| `src/re_exec.c` | adds the `RE_LB_WIDTH` arm and the landing test; `lookbehind_start()` takes the packed width |
| `test/regexp_syntax.rb` | the branch widths, the try order, the landing, the fork chain |
| `test/regexp_utf8.rb` | a branch counts its width in both units |
| `test/regexp_call.rb` | what a body holding a `\g` call keeps |
| `README.md` | the limitation entry, which no longer says "no alternation" |
| `tools/difftest/baseline.txt` | four rows that are no longer differences |

### A fork inside a lookbehind body was refused whatever it was

`compute_fixed_len()` answered "no fixed width" at the first `RE_SPLIT` it met. A body whose alternation comes out the same width down every arm has a fixed width all the same, and CRuby measures it:

```ruby
"bx" =~ /(?<=(a|b))x/      # CRuby: 1, mruby: RegexpError
"bcx" =~ /(?<=(?:a|b)c)x/  # CRuby: 2, mruby: RegexpError
```

Both arms are now measured and compared. They are measured to the end of the body rather than to the point they rejoin, which keeps what follows a fork part of each arm's measure, so `(?<=(?:a|bc)d)` is refused here as it is in CRuby where `(?:a|bc)` alone would have measured.

What each pc is worth is remembered for the span being measured. Without that table both arms of every fork walk the whole tail after it, and a chain of twenty forks is a million walks of a pattern a hundred bytes long; the same table is what stops the backward fork closing a loop from walking for ever. A span holding neither a fork nor a backward edge, which is every lookbehind that measured before this change, is walked with no table at all.

### The rewind belongs to the branch, not to the lookbehind

`RE_LB_WIDTH` used to sit after the opener, carrying the character count beside the byte count in `RE_LOOKBEHIND.a`. It now carries both counts in one instruction and stands at the head of each top-level branch, or at the head of the body where the body is one width. The opener leaves the input where the lookbehind was entered and the branch looks back for itself.

The alternation that is already in the bytecode is therefore what tries the branches, in the order it gives them. Which branch a capture comes from is the source order, as in CRuby, and not the order the widths happen to fall in: `(b)` and `(cb)` both match before the `x` of `"cbx"`, and the leftmost wins.

```ruby
"cbx".match(/(?<=(ab)|(b)|(cb))x/).to_a   # ["x", nil, "b", nil]
"cbx".match(/(?<=(cb)|(b)|(ab))x/).to_a   # ["x", "cb", nil, nil]
```

### A branch has to land where the lookbehind was entered

With a rewind per branch, a branch can match from another branch's rewind and stop short. Rewound the two characters `ab` asks for, the `c` of `(?<=c|ab)` matches the `c` of `"cax"` and ends before the `x`, which is a match of the text before the wrong position. The end of such a body now asserts that the branch came back to where the lookaround was entered, and the test stands before the cut, so a branch that lands short leaves the branches after it to try.

Only a body whose branches differ carries the assertion. One width for the whole body is the width of every path through it, so no other lookaround can land anywhere else, and none of them pays for the test.

### Where the line stays CRuby's

The branches of the body itself may differ; an alternation anywhere else must still come out one width, whether it stands under a capture, `(?<=(ab|b))`, or with anything beside it, `(?<=(?:a|bc)d)`. `(?:...)` around the whole body emits nothing here, so `(?<=(?:ab|b))` is a body that is an alternation, which is how CRuby reads it too.

Two places are left where this engine draws the line elsewhere, and README.md's Limitations names both. A body holding a `\g` call is measured once the calls are wired, when nothing may move code any more, so it keeps the single rewind put in place for it during the parse and `(?<=\g<1>|zz)(a)` is refused where CRuby accepts it. An option construct standing between the lookbehind and its alternation emits nothing here and is an enclosure in CRuby, so `(?<=(?i:ab|b))x` and `(?<=(?i)ab|b)x` are accepted where CRuby raises.

## Behaviour

```ruby
"abx" =~ /(?<=ab|c)x/      # was RegexpError, now 2
"cx" =~ /(?<=ab|c)x/       # was RegexpError, now 1
"bx" =~ /(?<=ab|c)x/       # was RegexpError, now nil
"ābx" =~ /(?<=ā|bc)b/      # was RegexpError, now 1
"abx" =~ /(?<=(?:ab|b))x/  # was RegexpError, now 2
"bx" =~ /(?<=(a|b))x/      # was RegexpError, now 1
"cx" =~ /(?<!ab|c)x/       # was RegexpError, now nil
"abx".match(/(?<=(a)b|(c))x/).to_a  # was RegexpError, now ["x", "a", nil]
```

Every line above answers what CRuby 4.0.6 answers. What was refused before and is still refused keeps the message it had, `invalid pattern in look-behind`.

## Speed

The rewind moved out of the opener into an instruction of its own, so a lookbehind that takes one width would have paid a turn of the dispatch loop for it. It does not: the opener takes that rewind itself where the body begins with one, and only a body whose branches differ reaches the instruction through the loop. Measured on the `bintest` build:

```ruby
S = "ab" * 200
CASES = {
  "(?<=z)b  rewind, body fails" => [/(?<=z)b/, 4000],
  "(?<=a)b  rewind, body holds" => [/(?<=a)b/, 1000],
  "(?<!x)b  negative"           => [/(?<!x)b/, 2000],
  "(?=z)b   lookahead control"  => [/(?=z)b/,  4000],
}
CASES.each do |name, (re, n)|
  best = nil
  3.times do
    t = Benchmark.measure { n.times { S.scan(re) } }
    best = t.real if best.nil? || t.real < best
  end
  puts "%-32s %.4f" % [name, best]
end
```

| Case | master | this PR | ratio |
|---|---:|---:|---:|
| `(?<=z)b` rewind holds, body fails | 0.0203 | 0.0204 | 1.00x |
| `(?<=a)b` rewind holds, body matches | 0.0229 | 0.0230 | 1.00x |
| `(?<!x)b` negative | 0.0462 | 0.0456 | 0.99x |
| `(?=z)b` lookahead, control | 0.0180 | 0.0189 | 1.05x |

The wall clock moves less than the control does, so the same thing was measured with Callgrind, as the slope of `exec_range` between a workload and the same workload run twice over. That cancels the start-up and the layout the two binaries do not share:

| Workload | master | this PR | delta |
|---|---:|---:|---:|
| `(?<=z)b`, rewind holds and the body fails | 204,598,000 | 200,694,000 | -1.91% |
| `(?<=a)b`, rewind holds and the body matches | 77,749,500 | 77,073,500 | -0.87% |

## Size

`.text` of `bin/mruby`, from `size -A`, over the five builds of `build_config/ci/gcc-clang.rb`. Both sides built with gcc from the same worktree into an empty build directory with the same rake target.

| Build | master `33dbb48b9` | this PR | delta |
|---|---:|---:|---:|
| `bintest` | 1,374,374 | 1,375,654 | +1,280 |
| `ascii-ctype` | 1,360,438 | 1,361,670 | +1,232 |
| `byte-string` | 1,337,494 | 1,338,422 | +928 |
| `cxx_abi` | 1,407,193 | 1,407,481 | +288 |
| `full-debug` (-O0) | 1,964,598 | 1,966,166 | +1,568 |

All of it is the measuring, which is compile time; the matcher is unchanged in size to within the noise of one build.

| Object `.text` | `bintest` | `ascii-ctype` | `byte-string` | `cxx_abi` | `full-debug` |
|---|---:|---:|---:|---:|---:|
| `re_compile.o` | +752 | +752 | +1,136 | +608 | +1,595 |
| `re_exec.o` | +528 | +480 | -208 | -320 | -29 |
| `regexp.o` | 0 | 0 | 0 | 0 | 0 |

## Testing

`MRUBY_CONFIG=ci/gcc-clang rake -m test` is green on all five builds and on the bintests, with gcc and with clang: 2,840 assertions on `bintest`, `cxx_abi` and `full-debug`, 2,831 on `ascii-ctype`, 2,759 on `byte-string`, 147 bintests, and no KO and no crash anywhere. Every commit in the series is green on its own, checked by running the suite of a `full-core` build under `git rebase 33dbb48b9 --exec`.

`rake regexp:difftest`, which runs the gem's pattern corpus through the host CRuby and through this build, reports no new difference over 5,175 patterns. Four rows left the baseline: `(?<=ab|c)` under each of the four flag sets, which is the construct this PR implements.

Beyond the suite, every lookbehind body that can be spelled as two or three branches over a small alphabet of literals, classes and captures, 1,573 patterns against ten subjects, was compared against CRuby 4.0.6 answer by answer, captures included. The rows that differ are all one construct this PR does not touch, a capture group inside a negative lookbehind, which CRuby refuses and this engine has always accepted.

## Environment

<details>

| | |
|---|---|
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-30-generic x86_64 |
| CPU | AMD Ryzen 9 5950X |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0 |
| C++ compiler | `gcc -x c++ -std=gnu++03` for `cxx_abi`; g++ 13.3.0 links it |
| binutils | GNU Binutils 2.47.20260726 |
| CRuby | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |

The compile line of each build, as `rake --verbose` prints it, with `-MMD -c`, the `-I` paths and the `-o` path dropped and the two `-ffile-prefix-map` paths written as `<srcdir>` and `<builddir>`:

```console
# bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="<srcdir>=." -ffile-prefix-map="<builddir>=build" -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK

# ascii-ctype
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="<srcdir>=." -ffile-prefix-map="<builddir>=build" -DMRB_USE_ASCII_CTYPE -DMRB_REGEXP_PARSE_DEPTH_LIMIT=512 -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="<srcdir>=." -ffile-prefix-map="<builddir>=build" -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -ffile-prefix-map="<srcdir>=." -ffile-prefix-map="<builddir>=build" -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# full-debug
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -ffile-prefix-map="<srcdir>=." -ffile-prefix-map="<builddir>=build" -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Lookbehind expressions now support alternation when each branch has a fixed length.
  * Branches may have different character and byte widths.
  * Callable groups can be used in fixed-length lookbehind expressions.

* **Bug Fixes**
  * Improved lookbehind matching, branch ordering, capture handling, and UTF-8 behavior.
  * Reduced differences from CRuby for supported lookbehind patterns.

* **Documentation**
  * Expanded documentation covering branch widths, limits, options, and subexpression calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->