### PR TITLE
mruby-process: work until the CPU time reading moves

### DIFF
--- a/mrbgems/mruby-process/test/process.rb
+++ b/mrbgems/mruby-process/test/process.rb
@@ -647,17 +647,30 @@ assert('Process.times counts CPU time this process spends') do
   # The CLOCK_MONOTONIC test below reads two clocks back to back with no
   # work forced between them, so it can only ask for a reading that is not
   # smaller. This one drives a busy loop between the two readings, so a
-  # strict increase is asked for: three million iterations burn far more CPU
-  # than even the coarsest clock this gem falls back to (a times(2) tick,
-  # usually 10ms) can fail to notice. A HAL bug that pins the reading at
-  # zero, or anywhere else it never moves from, has to fail this one where
-  # >= would have let it pass.
+  # strict increase is asked for: a HAL bug that pins the reading at zero,
+  # or anywhere else it never moves from, has to fail this one where >=
+  # would have let it pass.
+  #
+  # How much work that takes is not a number a test may fix. A CPU time
+  # total is accumulated rather than read: Win32 charges a process the clock
+  # interrupts it was found running at, 15.625ms of one at a time, so the
+  # reading steps rather than flows, and a whole round of this loop can sit
+  # inside one step. On a virtualised runner it can sit inside several,
+  # which is what made a fixed count of iterations fail here. So the loop is
+  # driven again until the reading moves, which is how CRuby's own spec for
+  # this property asks it (`1 until Process.times.utime > user`). The bound
+  # is what keeps a pinned reading a failure rather than a hung suite; a
+  # clock that moves leaves after the first round.
   skip "this build has no Float" unless ProcessTestUtil.float?
 
   before = Process.times
-  n = 0
-  n += 1 while n < 3_000_000
-  after = Process.times
+  after = before
+  20.times do
+    n = 0
+    n += 1 while n < 3_000_000
+    after = Process.times
+    break if after.utime + after.stime > before.utime + before.stime
+  end
 
   assert_operator after.utime + after.stime, :>, before.utime + before.stime
 end


### PR DESCRIPTION
## Summary

A test in `mruby-process` asked a CPU time reading to be strictly larger after a fixed three million iterations of a busy loop. Win32 does not report CPU time finely enough for a fixed amount of work to guarantee that, and the test failed on `windows-2022-mingw-gcc` with `Expected 0.4375 to be > 0.4375.`

## Changes

| File | What |
|---|---|
| `mrbgems/mruby-process/test/process.rb` | `Process.times counts CPU time this process spends` drives its busy loop again until the reading moves, up to 20 rounds |

### A fixed amount of work does not move a sampled clock

`GetProcessTimes()` charges a process the clock interrupts it was found running at, so its reading steps rather than flows. Driving the same three million iteration loop 30 times on a `windows-2022` runner and printing the step each round measures that step directly:

| Build | One round, wall clock | One round, `utime` step |
|---|---|---|
| `full-debug`, mingw gcc | 0.31s to 0.37s | 0.3125s to 0.375s, always a multiple of 15.625ms |
| `ci/msvc` | 0.108s | 0.109375s, which is 7 x 15.625ms |

The value the test failed on is of that shape too: 0.4375s is 28 x 15.625ms, read twice with the loop between the readings and unchanged across it. A step that a whole round can sit inside is a step a round can also fail to cross, and the test had no answer for that beyond running once.

The granularity is not something the reading can be asked about either, on this platform or on CRuby's. `Process.clock_getres(Process::CLOCK_PROCESS_CPUTIME_ID)` answers `1.0e-07` here, which is the FILETIME unit rather than the interval the reading moves by; CRuby answers 1ms on Windows for the same reason, its `rb_w32_times()` reporting `GetProcessTimes()` in `clock_t`. So the test cannot size its work from the resolution: it has to keep working until the reading moves.

### CRuby asks the same question the same way

`spec/ruby/core/process/times_spec.rb` fixes no amount of work either:

```ruby
it "returns current cpu times" do
  t = Process.times
  user = t.utime

  1 until Process.times.utime > user
  Process.times.utime.should > user
end
```

The bound this one adds is what keeps the property the test was written for: a reading pinned where it never moves has to fail, not spin, so the loop gives up after 20 rounds and lets the assertion report the two equal readings. A clock that moves leaves after the first round, which is what every platform in CI does.

## Testing

- `rake -m test` on the default build: Total 2593, OK 2528, KO 0, Crash 0, Skip 65
- `MRUBY_CONFIG=ci/gcc-clang rake -m test`, all five builds: KO 0, Crash 0 in every suite
  (`full-debug` 2834 with `MRB_GC_STRESS`, the other four 2753 to 2834, and the 147 bintest assertions)
- The measurement above ran the loop 30 times in `full-debug` on `windows-2022-mingw-gcc` and once more under `ci/msvc` on the same runner image, and the reading moved on every round

## Environment

<details>

| | |
|---|---|
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-30-generic x86_64 |
| CPU | AMD Ryzen 9 5950X, 16 cores / 32 threads |
| C compiler | Homebrew clang 23.1.0 (`x86_64-unknown-linux-gnu`) |
| binutils | GNU ld 2.47.20260726 |
| CRuby | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM |

Compile line for the default build, as `rake --verbose` prints it, with `-MMD -c`, `-I` and `-o` dropped:

```console
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration \
  -Wwrite-strings -Wzero-length-array -ffile-compilation-dir="." \
  -ffile-prefix-map="<build>=build" -DMRB_REVISION_HEADER \
  -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL \
  -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK
```

`ci/gcc-clang` builds the same sources with `-g3 -O0` in `full-debug` (`enable_debug()` appends it) and with `-g -O3` in `bintest`, `cxx_abi`, `byte-string` and `ascii-ctype`.

The Windows numbers come from GitHub hosted `windows-2022` runners, built by the same `.github/workflows/build.yml` matrix entry that reported the failure.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved the process CPU-time test to accommodate coarse or delayed CPU-time measurements across different environments.
  - Added a bounded retry mechanism to prevent the test from hanging when CPU-time readings remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->